### PR TITLE
Running code-format for alca

### DIFF
--- a/Alignment/APEEstimation/interface/EventVariables.h
+++ b/Alignment/APEEstimation/interface/EventVariables.h
@@ -3,49 +3,73 @@
 
 #include <vector>
 
-struct TrackStruct{
-  
-  TrackStruct(){}
-  
-  enum HitState{notInTracker, notAssignedToSectors, invalid, negativeError, ok};
-  
-  struct HitParameterStruct{
-    
-    HitParameterStruct(): hitState(ok),
-                 isPixelHit(false),
-		 goodXMeasurement(false),
-		 goodYMeasurement(false),
-		 widthX(0),
-		 baryStripX(-999.F),
-		 widthY(0),
-		 baryStripY(-999.F),
-		 chargePixel(-999.F),
-		 clusterProbabilityXY(-999.F), clusterProbabilityQ(-999.F),
-		 clusterProbabilityXYQ(-999.F), logClusterProbability(-999.F),
-		 isOnEdge(false), hasBadPixels(false), spansTwoRoc(false),
-		 qBin(-1),
-		 isModuleUsable(true),
-		 chargeStrip(0),
-		 maxStrip(0), maxStripInv(0), maxCharge(0), maxIndex(0),
-		 chargeOnEdges(-999.F), chargeAsymmetry(-999.F), 
-		 chargeLRplus(-999.F), chargeLRminus(-999.F),
-		 sOverN(-999.F),
-		 projWidth(-999.F),
-		 resX(-999.F), norResX(-999.F), xHit(-999.F), xTrk(-999.F),
-                 errXHit(-999.F), errXTrk(-999.F), errX(-999.F), errX2(-999.F),
-		 errXHitWoApe(-999.F), errXWoApe(-999.F),
-		 probX(-999.F),
-		 resY(-999.F), norResY(-999.F), yHit(-999.F), yTrk(-999.F),
-                 errYHit(-999.F), errYTrk(-999.F), errY(-999.F), errY2(-999.F),
-		 errYHitWoApe(-999.F), errYWoApe(-999.F),
-		 probY(-999.F),
-		 phiSens(-999.F), phiSensX(-999.F), phiSensY(-999.F){}
-    
+struct TrackStruct {
+  TrackStruct() {}
+
+  enum HitState { notInTracker, notAssignedToSectors, invalid, negativeError, ok };
+
+  struct HitParameterStruct {
+    HitParameterStruct()
+        : hitState(ok),
+          isPixelHit(false),
+          goodXMeasurement(false),
+          goodYMeasurement(false),
+          widthX(0),
+          baryStripX(-999.F),
+          widthY(0),
+          baryStripY(-999.F),
+          chargePixel(-999.F),
+          clusterProbabilityXY(-999.F),
+          clusterProbabilityQ(-999.F),
+          clusterProbabilityXYQ(-999.F),
+          logClusterProbability(-999.F),
+          isOnEdge(false),
+          hasBadPixels(false),
+          spansTwoRoc(false),
+          qBin(-1),
+          isModuleUsable(true),
+          chargeStrip(0),
+          maxStrip(0),
+          maxStripInv(0),
+          maxCharge(0),
+          maxIndex(0),
+          chargeOnEdges(-999.F),
+          chargeAsymmetry(-999.F),
+          chargeLRplus(-999.F),
+          chargeLRminus(-999.F),
+          sOverN(-999.F),
+          projWidth(-999.F),
+          resX(-999.F),
+          norResX(-999.F),
+          xHit(-999.F),
+          xTrk(-999.F),
+          errXHit(-999.F),
+          errXTrk(-999.F),
+          errX(-999.F),
+          errX2(-999.F),
+          errXHitWoApe(-999.F),
+          errXWoApe(-999.F),
+          probX(-999.F),
+          resY(-999.F),
+          norResY(-999.F),
+          yHit(-999.F),
+          yTrk(-999.F),
+          errYHit(-999.F),
+          errYTrk(-999.F),
+          errY(-999.F),
+          errY2(-999.F),
+          errYHitWoApe(-999.F),
+          errYWoApe(-999.F),
+          probY(-999.F),
+          phiSens(-999.F),
+          phiSensX(-999.F),
+          phiSensY(-999.F) {}
+
     HitState hitState;
     bool isPixelHit;
     bool goodXMeasurement, goodYMeasurement;
     std::vector<unsigned int> v_sector;
-    
+
     // Cluster parameters
     // pixel+strip
     unsigned int widthX;
@@ -54,58 +78,58 @@ struct TrackStruct{
     unsigned int widthY;
     float baryStripY;
     float chargePixel;
-    float clusterProbabilityXY, clusterProbabilityQ,
-          clusterProbabilityXYQ, logClusterProbability;
+    float clusterProbabilityXY, clusterProbabilityQ, clusterProbabilityXYQ, logClusterProbability;
     bool isOnEdge, hasBadPixels, spansTwoRoc;
     int qBin;
     // strip only
     bool isModuleUsable;
     unsigned int chargeStrip;
     unsigned int maxStrip, maxStripInv, maxCharge, maxIndex;
-    float chargeOnEdges, chargeAsymmetry,
-          chargeLRplus, chargeLRminus;
+    float chargeOnEdges, chargeAsymmetry, chargeLRplus, chargeLRminus;
     float sOverN;
     float projWidth;
-    
+
     // trackFit results
-    float resX, norResX, xHit, xTrk,
-          errXHit, errXTrk, errX, errX2,
-	  errXHitWoApe, errXWoApe,
-	  probX;
-    float resY, norResY, yHit, yTrk,
-          errYHit, errYTrk, errY, errY2,
-	  errYHitWoApe, errYWoApe,
-	  probY;
+    float resX, norResX, xHit, xTrk, errXHit, errXTrk, errX, errX2, errXHitWoApe, errXWoApe, probX;
+    float resY, norResY, yHit, yTrk, errYHit, errYTrk, errY, errY2, errYHitWoApe, errYWoApe, probY;
     float phiSens, phiSensX, phiSensY;
   };
-  
-  struct TrackParameterStruct{
-    
-    TrackParameterStruct(): hitsSize(-999), hitsValid(-999), hitsInvalid(-999),
-		   hits2D(-999), layersMissed(-999),
-		   hitsPixel(-999), hitsStrip(-999),
-		   charge(-999),
-		   chi2(-999.F), ndof(-999.F), norChi2(-999.F), prob(-999.F),
-                   eta(-999.F), etaErr(-999.F), theta(-999.F),
-		   phi(-999.F), phiErr(-999.F),
-		   d0(-999.F), d0Beamspot(-999.F), d0BeamspotErr(-999.F),
-		   dz(-999.F), dzErr(-999.F), dzBeamspot(-999.F),
-                   p(-999.F), pt(-999.F), ptErr(-999.F),
-		   meanPhiSensToNorm(-999.F){}
-    
-    int hitsSize, hitsValid, hitsInvalid,
-        hits2D, layersMissed,
-	hitsPixel, hitsStrip,
-	charge;
-    float chi2, ndof, norChi2, prob,
-          eta, etaErr, theta,
-	  phi, phiErr,
-	  d0, d0Beamspot, d0BeamspotErr,
-	  dz, dzErr, dzBeamspot,
-	  p, pt, ptErr,
-	  meanPhiSensToNorm;
+
+  struct TrackParameterStruct {
+    TrackParameterStruct()
+        : hitsSize(-999),
+          hitsValid(-999),
+          hitsInvalid(-999),
+          hits2D(-999),
+          layersMissed(-999),
+          hitsPixel(-999),
+          hitsStrip(-999),
+          charge(-999),
+          chi2(-999.F),
+          ndof(-999.F),
+          norChi2(-999.F),
+          prob(-999.F),
+          eta(-999.F),
+          etaErr(-999.F),
+          theta(-999.F),
+          phi(-999.F),
+          phiErr(-999.F),
+          d0(-999.F),
+          d0Beamspot(-999.F),
+          d0BeamspotErr(-999.F),
+          dz(-999.F),
+          dzErr(-999.F),
+          dzBeamspot(-999.F),
+          p(-999.F),
+          pt(-999.F),
+          ptErr(-999.F),
+          meanPhiSensToNorm(-999.F) {}
+
+    int hitsSize, hitsValid, hitsInvalid, hits2D, layersMissed, hitsPixel, hitsStrip, charge;
+    float chi2, ndof, norChi2, prob, eta, etaErr, theta, phi, phiErr, d0, d0Beamspot, d0BeamspotErr, dz, dzErr,
+        dzBeamspot, p, pt, ptErr, meanPhiSensToNorm;
   };
-  
+
   TrackParameterStruct trkParams;
   std::vector<HitParameterStruct> v_hitParams;
 };

--- a/Alignment/APEEstimation/interface/ReducedTrackerTreeVariables.h
+++ b/Alignment/APEEstimation/interface/ReducedTrackerTreeVariables.h
@@ -1,28 +1,21 @@
 #ifndef ReducedTrackerTreeVariables_h
 #define ReducedTrackerTreeVariables_h
 
-
 // For ROOT types with '_t':
 #include <Rtypes.h>
 
-
-
 // container to hold those static module parameters needed for correct xPrime-Residual calculation (and others), determined with ideal geometry
-struct ReducedTrackerTreeVariables{
-  
-  ReducedTrackerTreeVariables(){this->clear();}
-  
-  void clear(){
+struct ReducedTrackerTreeVariables {
+  ReducedTrackerTreeVariables() { this->clear(); }
+
+  void clear() {
     subdetId = 0;
     nStrips = 0;
     uDirection = vDirection = wDirection = 0;
   }
-  
-  UInt_t subdetId,
-         nStrips;
+
+  UInt_t subdetId, nStrips;
   Int_t uDirection, vDirection, wDirection;
 };
-
-
 
 #endif

--- a/Alignment/APEEstimation/interface/TrackerDetectorStruct.h
+++ b/Alignment/APEEstimation/interface/TrackerDetectorStruct.h
@@ -1,57 +1,71 @@
 #ifndef Alignment_APEEstimation_TrackerDetectorStruct_h
 #define Alignment_APEEstimation_TrackerDetectorStruct_h
 
-
 #include "TH1.h"
 #include "TH2.h"
 #include "TProfile.h"
 
-struct TrackerDetectorStruct{
-  
-  TrackerDetectorStruct(): TrkSize(nullptr), TrkSizeGood(nullptr),
-                           HitsSize(nullptr), HitsValid(nullptr), HitsInvalid(nullptr), Hits2D(nullptr),
-			   HitsGood(nullptr), LayersMissed(nullptr),
-			   HitsPixel(nullptr), HitsStrip(nullptr),
-			   Charge(nullptr),
-			   Chi2(nullptr), Ndof(nullptr), NorChi2(nullptr), Prob(nullptr),
-			   Eta(nullptr), EtaErr(nullptr), EtaSig(nullptr), Theta(nullptr),
-			   Phi(nullptr), PhiErr(nullptr), PhiSig(nullptr),
-			   D0Beamspot(nullptr), D0BeamspotErr(nullptr), D0BeamspotSig(nullptr),
-			   Dz(nullptr), DzErr(nullptr), DzSig(nullptr),
-			   P(nullptr), Pt(nullptr), PtErr(nullptr), PtSig(nullptr),
-			   MeanAngle(nullptr),
-			   HitsGoodVsHitsValid(nullptr), MeanAngleVsHits(nullptr),
-			   HitsPixelVsEta(nullptr), HitsPixelVsTheta(nullptr),
-			   HitsStripVsEta(nullptr), HitsStripVsTheta(nullptr),
-			   PtVsEta(nullptr), PtVsTheta(nullptr),
-			   PHitsGoodVsHitsValid(nullptr), PMeanAngleVsHits(nullptr),
-			   PHitsPixelVsEta(nullptr), PHitsPixelVsTheta(nullptr),
-			   PHitsStripVsEta(nullptr), PHitsStripVsTheta(nullptr),
-			   PPtVsEta(nullptr), PPtVsTheta(nullptr){}
-  
-  TH1 *TrkSize, *TrkSizeGood,
-      *HitsSize, *HitsValid, *HitsInvalid, *Hits2D,
-      *HitsGood, *LayersMissed,
-      *HitsPixel, *HitsStrip,
-      *Charge,
-      *Chi2, *Ndof, *NorChi2, *Prob,
-      *Eta, *EtaErr, *EtaSig, *Theta,
-      *Phi,*PhiErr, *PhiSig,
-      *D0Beamspot, *D0BeamspotErr, *D0BeamspotSig,
-      *Dz, *DzErr, *DzSig,
-      *P, *Pt, *PtErr, *PtSig,
-      *MeanAngle;
-  
-  TH2 *HitsGoodVsHitsValid, *MeanAngleVsHits,
-      *HitsPixelVsEta, *HitsPixelVsTheta,
-      *HitsStripVsEta, *HitsStripVsTheta,
+struct TrackerDetectorStruct {
+  TrackerDetectorStruct()
+      : TrkSize(nullptr),
+        TrkSizeGood(nullptr),
+        HitsSize(nullptr),
+        HitsValid(nullptr),
+        HitsInvalid(nullptr),
+        Hits2D(nullptr),
+        HitsGood(nullptr),
+        LayersMissed(nullptr),
+        HitsPixel(nullptr),
+        HitsStrip(nullptr),
+        Charge(nullptr),
+        Chi2(nullptr),
+        Ndof(nullptr),
+        NorChi2(nullptr),
+        Prob(nullptr),
+        Eta(nullptr),
+        EtaErr(nullptr),
+        EtaSig(nullptr),
+        Theta(nullptr),
+        Phi(nullptr),
+        PhiErr(nullptr),
+        PhiSig(nullptr),
+        D0Beamspot(nullptr),
+        D0BeamspotErr(nullptr),
+        D0BeamspotSig(nullptr),
+        Dz(nullptr),
+        DzErr(nullptr),
+        DzSig(nullptr),
+        P(nullptr),
+        Pt(nullptr),
+        PtErr(nullptr),
+        PtSig(nullptr),
+        MeanAngle(nullptr),
+        HitsGoodVsHitsValid(nullptr),
+        MeanAngleVsHits(nullptr),
+        HitsPixelVsEta(nullptr),
+        HitsPixelVsTheta(nullptr),
+        HitsStripVsEta(nullptr),
+        HitsStripVsTheta(nullptr),
+        PtVsEta(nullptr),
+        PtVsTheta(nullptr),
+        PHitsGoodVsHitsValid(nullptr),
+        PMeanAngleVsHits(nullptr),
+        PHitsPixelVsEta(nullptr),
+        PHitsPixelVsTheta(nullptr),
+        PHitsStripVsEta(nullptr),
+        PHitsStripVsTheta(nullptr),
+        PPtVsEta(nullptr),
+        PPtVsTheta(nullptr) {}
+
+  TH1 *TrkSize, *TrkSizeGood, *HitsSize, *HitsValid, *HitsInvalid, *Hits2D, *HitsGood, *LayersMissed, *HitsPixel,
+      *HitsStrip, *Charge, *Chi2, *Ndof, *NorChi2, *Prob, *Eta, *EtaErr, *EtaSig, *Theta, *Phi, *PhiErr, *PhiSig,
+      *D0Beamspot, *D0BeamspotErr, *D0BeamspotSig, *Dz, *DzErr, *DzSig, *P, *Pt, *PtErr, *PtSig, *MeanAngle;
+
+  TH2 *HitsGoodVsHitsValid, *MeanAngleVsHits, *HitsPixelVsEta, *HitsPixelVsTheta, *HitsStripVsEta, *HitsStripVsTheta,
       *PtVsEta, *PtVsTheta;
-  
-  TProfile *PHitsGoodVsHitsValid, *PMeanAngleVsHits,
-           *PHitsPixelVsEta, *PHitsPixelVsTheta,
-           *PHitsStripVsEta, *PHitsStripVsTheta,
-           *PPtVsEta, *PPtVsTheta;
-  
+
+  TProfile *PHitsGoodVsHitsValid, *PMeanAngleVsHits, *PHitsPixelVsEta, *PHitsPixelVsTheta, *PHitsStripVsEta,
+      *PHitsStripVsTheta, *PPtVsEta, *PPtVsTheta;
 };
 
 #endif

--- a/Alignment/APEEstimation/interface/TrackerSectorStruct.h
+++ b/Alignment/APEEstimation/interface/TrackerSectorStruct.h
@@ -1,7 +1,6 @@
 #ifndef Alignment_APEEstimation_TrackerSectorStruct_h
 #define Alignment_APEEstimation_TrackerSectorStruct_h
 
-
 #include <vector>
 #include <map>
 #include "TH1F.h"
@@ -11,7 +10,6 @@
 #include "CommonTools/Utils/interface/TFileDirectory.h"
 
 #include "Alignment/APEEstimation/interface/EventVariables.h"
-
 
 #include "TH1.h"
 #include "TH2.h"
@@ -24,323 +22,492 @@
 //class TString;
 //class TFileDirectory;
 
-
-
-
-
-
-
-
-
-class TrackerSectorStruct{
-  public:
-  
+class TrackerSectorStruct {
+public:
   inline TrackerSectorStruct();
-  
+
   inline ~TrackerSectorStruct();
-  
-  
-  
-  struct CorrelationHists{
-    CorrelationHists():Variable(nullptr),
-                       NorResXVsVar(nullptr), ProbXVsVar(nullptr),
-	               SigmaXHitVsVar(nullptr), SigmaXTrkVsVar(nullptr), SigmaXVsVar(nullptr),
-		       PNorResXVsVar(nullptr), PProbXVsVar(nullptr),
-		       PSigmaXHitVsVar(nullptr), PSigmaXTrkVsVar(nullptr), PSigmaXVsVar(nullptr){};
-    
-    inline void fillCorrHists(const TString, const TrackStruct::HitParameterStruct& hitParameterStruct, double variable);
-    inline void fillCorrHistsX(const TrackStruct::HitParameterStruct& hitParameterStruct, double variable);
-    inline void fillCorrHistsY(const TrackStruct::HitParameterStruct& hitParameterStruct, double variable);
-    
+
+  struct CorrelationHists {
+    CorrelationHists()
+        : Variable(nullptr),
+          NorResXVsVar(nullptr),
+          ProbXVsVar(nullptr),
+          SigmaXHitVsVar(nullptr),
+          SigmaXTrkVsVar(nullptr),
+          SigmaXVsVar(nullptr),
+          PNorResXVsVar(nullptr),
+          PProbXVsVar(nullptr),
+          PSigmaXHitVsVar(nullptr),
+          PSigmaXTrkVsVar(nullptr),
+          PSigmaXVsVar(nullptr){};
+
+    inline void fillCorrHists(const TString,
+                              const TrackStruct::HitParameterStruct &hitParameterStruct,
+                              double variable);
+    inline void fillCorrHistsX(const TrackStruct::HitParameterStruct &hitParameterStruct, double variable);
+    inline void fillCorrHistsY(const TrackStruct::HitParameterStruct &hitParameterStruct, double variable);
+
     TH1F *Variable;
-    TH2F *NorResXVsVar, *ProbXVsVar,
-         *SigmaXHitVsVar, *SigmaXTrkVsVar, *SigmaXVsVar;
-    TProfile *PNorResXVsVar, *PProbXVsVar,
-             *PSigmaXHitVsVar, *PSigmaXTrkVsVar, *PSigmaXVsVar;
+    TH2F *NorResXVsVar, *ProbXVsVar, *SigmaXHitVsVar, *SigmaXTrkVsVar, *SigmaXVsVar;
+    TProfile *PNorResXVsVar, *PProbXVsVar, *PSigmaXHitVsVar, *PSigmaXTrkVsVar, *PSigmaXVsVar;
   };
-  
-  
-  inline void setCorrHistParams(TFileDirectory*, double, double, double);
-  inline CorrelationHists bookCorrHists(TString, TString, TString, TString, TString, int, int, double, double, std::string ="nphtr");
-  inline CorrelationHists bookCorrHistsX(TString, TString, TString, TString, int, int, double, double, std::string ="nphtr");
-  inline CorrelationHists bookCorrHistsY(TString, TString, TString, TString, int, int, double, double, std::string ="nphtr");
-  /// same, but without booking 1D histo 
-  inline CorrelationHists bookCorrHists(TString, TString ,TString ,TString, int, double, double, std::string ="nphtr");
-  inline CorrelationHists bookCorrHistsX(TString ,TString ,TString, int, double, double, std::string ="nphtr");
-  inline CorrelationHists bookCorrHistsY(TString ,TString ,TString, int, double, double, std::string ="nphtr");
-  
-  
-  
-  
+
+  inline void setCorrHistParams(TFileDirectory *, double, double, double);
+  inline CorrelationHists bookCorrHists(
+      TString, TString, TString, TString, TString, int, int, double, double, std::string = "nphtr");
+  inline CorrelationHists bookCorrHistsX(
+      TString, TString, TString, TString, int, int, double, double, std::string = "nphtr");
+  inline CorrelationHists bookCorrHistsY(
+      TString, TString, TString, TString, int, int, double, double, std::string = "nphtr");
+  /// same, but without booking 1D histo
+  inline CorrelationHists bookCorrHists(TString, TString, TString, TString, int, double, double, std::string = "nphtr");
+  inline CorrelationHists bookCorrHistsX(TString, TString, TString, int, double, double, std::string = "nphtr");
+  inline CorrelationHists bookCorrHistsY(TString, TString, TString, int, double, double, std::string = "nphtr");
+
   TFileDirectory *directory_;
-  double norResXMax_, sigmaXHitMax_, sigmaXMax_;   // Used for x and y
-  std::map<std::string,CorrelationHists> m_correlationHistsX;
-  std::map<std::string,CorrelationHists> m_correlationHistsY;
-  
-  
+  double norResXMax_, sigmaXHitMax_, sigmaXMax_;  // Used for x and y
+  std::map<std::string, CorrelationHists> m_correlationHistsX;
+  std::map<std::string, CorrelationHists> m_correlationHistsY;
+
   // Name of sector as string and as title of a histogram
   std::string name;
   TH1 *Name;
-  
+
   // Module IDs of modules in sector
   std::vector<unsigned int> v_rawId;
-  
-  
-  TH1 *ResX, *NorResX, *XHit, *XTrk,
-      *SigmaX2, *ProbX;
-  TH2 *WidthVsPhiSensX, *WidthVsWidthProjected, *WidthDiffVsMaxStrip, *WidthDiffVsSigmaXHit,
-      *PhiSensXVsBarycentreX;
+
+  TH1 *ResX, *NorResX, *XHit, *XTrk, *SigmaX2, *ProbX;
+  TH2 *WidthVsPhiSensX, *WidthVsWidthProjected, *WidthDiffVsMaxStrip, *WidthDiffVsSigmaXHit, *PhiSensXVsBarycentreX;
   TProfile *PWidthVsPhiSensX, *PWidthVsWidthProjected, *PWidthDiffVsMaxStrip, *PWidthDiffVsSigmaXHit,
       *PPhiSensXVsBarycentreX;
-  std::map<std::string,std::vector<TH1*> > m_sigmaX;
-  
-  TH1 *ResY, *NorResY, *YHit, *YTrk,
-      *SigmaY2, *ProbY;
+  std::map<std::string, std::vector<TH1 *> > m_sigmaX;
+
+  TH1 *ResY, *NorResY, *YHit, *YTrk, *SigmaY2, *ProbY;
   TH2 *PhiSensYVsBarycentreY;
-  TProfile *PPhiSensYVsBarycentreY; 
-  std::map<std::string,std::vector<TH1*> > m_sigmaY;
-  
-  
+  TProfile *PPhiSensYVsBarycentreY;
+  std::map<std::string, std::vector<TH1 *> > m_sigmaY;
+
   //for every bin in sigmaX or sigmaY the needful histos to calculate the APE
-  std::map<unsigned int, std::map<std::string,TH1*> > m_binnedHists;
-  
-  
+  std::map<unsigned int, std::map<std::string, TH1 *> > m_binnedHists;
+
   //for presenting results
   TTree *RawId;
   TH1 *EntriesX;
-  TH1 *WeightX, *MeanX, *RmsX, *FitMeanX1, *ResidualWidthX1, *CorrectionX1,
-      *FitMeanX2, *ResidualWidthX2, *CorrectionX2;
+  TH1 *WeightX, *MeanX, *RmsX, *FitMeanX1, *ResidualWidthX1, *CorrectionX1, *FitMeanX2, *ResidualWidthX2, *CorrectionX2;
   TH1 *EntriesY;
-  TH1 *WeightY, *MeanY, *RmsY, *FitMeanY1, *ResidualWidthY1, *CorrectionY1,
-      *FitMeanY2, *ResidualWidthY2, *CorrectionY2;
-  
+  TH1 *WeightY, *MeanY, *RmsY, *FitMeanY1, *ResidualWidthY1, *CorrectionY1, *FitMeanY2, *ResidualWidthY2, *CorrectionY2;
+
   // To book pixel-specific or strip-specific histos only
   bool isPixel;
 };
 
+TrackerSectorStruct::TrackerSectorStruct()
+    : directory_(nullptr),
+      norResXMax_(999.),
+      sigmaXHitMax_(999.),
+      sigmaXMax_(999.),
+      name("default"),
+      Name(nullptr),
+      ResX(nullptr),
+      NorResX(nullptr),
+      XHit(nullptr),
+      XTrk(nullptr),
+      SigmaX2(nullptr),
+      ProbX(nullptr),
+      WidthVsPhiSensX(nullptr),
+      WidthVsWidthProjected(nullptr),
+      WidthDiffVsMaxStrip(nullptr),
+      WidthDiffVsSigmaXHit(nullptr),
+      PhiSensXVsBarycentreX(nullptr),
+      PWidthVsPhiSensX(nullptr),
+      PWidthVsWidthProjected(nullptr),
+      PWidthDiffVsMaxStrip(nullptr),
+      PWidthDiffVsSigmaXHit(nullptr),
+      PPhiSensXVsBarycentreX(nullptr),
+      ResY(nullptr),
+      NorResY(nullptr),
+      YHit(nullptr),
+      YTrk(nullptr),
+      SigmaY2(nullptr),
+      ProbY(nullptr),
+      PhiSensYVsBarycentreY(nullptr),
+      PPhiSensYVsBarycentreY(nullptr),
+      RawId(nullptr),
+      EntriesX(nullptr),
+      MeanX(nullptr),
+      RmsX(nullptr),
+      FitMeanX1(nullptr),
+      ResidualWidthX1(nullptr),
+      CorrectionX1(nullptr),
+      FitMeanX2(nullptr),
+      ResidualWidthX2(nullptr),
+      CorrectionX2(nullptr),
+      EntriesY(nullptr),
+      MeanY(nullptr),
+      RmsY(nullptr),
+      FitMeanY1(nullptr),
+      ResidualWidthY1(nullptr),
+      CorrectionY1(nullptr),
+      FitMeanY2(nullptr),
+      ResidualWidthY2(nullptr),
+      CorrectionY2(nullptr),
+      isPixel(false) {}
 
+TrackerSectorStruct::~TrackerSectorStruct() {}
 
-
-
-
-
-
-
-TrackerSectorStruct::TrackerSectorStruct(): directory_(nullptr),
-                         norResXMax_(999.), sigmaXHitMax_(999.), sigmaXMax_(999.),
-			 name("default"), Name(nullptr),
-			 ResX(nullptr), NorResX(nullptr), XHit(nullptr), XTrk(nullptr),
-			 SigmaX2(nullptr), ProbX(nullptr),
-			 WidthVsPhiSensX(nullptr), WidthVsWidthProjected(nullptr), WidthDiffVsMaxStrip(nullptr), WidthDiffVsSigmaXHit(nullptr),
-			 PhiSensXVsBarycentreX(nullptr),
-			 PWidthVsPhiSensX(nullptr), PWidthVsWidthProjected(nullptr), PWidthDiffVsMaxStrip(nullptr), PWidthDiffVsSigmaXHit(nullptr),
-			 PPhiSensXVsBarycentreX(nullptr),
-			 ResY(nullptr), NorResY(nullptr), YHit(nullptr), YTrk(nullptr),
-			 SigmaY2(nullptr), ProbY(nullptr),
-			 PhiSensYVsBarycentreY(nullptr),
-			 PPhiSensYVsBarycentreY(nullptr),
-			 RawId(nullptr),
-			 EntriesX(nullptr),
-			 MeanX(nullptr), RmsX(nullptr), FitMeanX1(nullptr), ResidualWidthX1(nullptr), CorrectionX1(nullptr),
-			 FitMeanX2(nullptr), ResidualWidthX2(nullptr), CorrectionX2(nullptr),
-			 EntriesY(nullptr),
-			 MeanY(nullptr), RmsY(nullptr), FitMeanY1(nullptr), ResidualWidthY1(nullptr), CorrectionY1(nullptr),
-			 FitMeanY2(nullptr), ResidualWidthY2(nullptr), CorrectionY2(nullptr),
-			 isPixel(false){}
-
-
-
-TrackerSectorStruct::~TrackerSectorStruct(){}
-
-
-
-void
-TrackerSectorStruct::setCorrHistParams(TFileDirectory *directory, double norResXMax, double sigmaXHitMax, double sigmaXMax){
+void TrackerSectorStruct::setCorrHistParams(TFileDirectory *directory,
+                                            double norResXMax,
+                                            double sigmaXHitMax,
+                                            double sigmaXMax) {
   directory_ = directory;
   norResXMax_ = norResXMax;
   sigmaXHitMax_ = sigmaXHitMax;
   sigmaXMax_ = sigmaXMax;
 }
 
-
-
-TrackerSectorStruct::CorrelationHists
-TrackerSectorStruct::bookCorrHistsX(TString varName,TString varTitle,TString labelX,TString unitX,int nBinX1D,int nBinX2D,double minBinX,double maxBinX,std::string options){
+TrackerSectorStruct::CorrelationHists TrackerSectorStruct::bookCorrHistsX(TString varName,
+                                                                          TString varTitle,
+                                                                          TString labelX,
+                                                                          TString unitX,
+                                                                          int nBinX1D,
+                                                                          int nBinX2D,
+                                                                          double minBinX,
+                                                                          double maxBinX,
+                                                                          std::string options) {
   return bookCorrHists("X", varName, varTitle, labelX, unitX, nBinX1D, nBinX2D, minBinX, maxBinX, options);
 }
-TrackerSectorStruct::CorrelationHists
-TrackerSectorStruct::bookCorrHistsY(TString varName,TString varTitle,TString labelX,TString unitX,int nBinX1D,int nBinX2D,double minBinX,double maxBinX,std::string options){
+TrackerSectorStruct::CorrelationHists TrackerSectorStruct::bookCorrHistsY(TString varName,
+                                                                          TString varTitle,
+                                                                          TString labelX,
+                                                                          TString unitX,
+                                                                          int nBinX1D,
+                                                                          int nBinX2D,
+                                                                          double minBinX,
+                                                                          double maxBinX,
+                                                                          std::string options) {
   return bookCorrHists("Y", varName, varTitle, labelX, unitX, nBinX1D, nBinX2D, minBinX, maxBinX, options);
 }
-TrackerSectorStruct::CorrelationHists
-TrackerSectorStruct::bookCorrHists(TString xY,TString varName,TString varTitle,TString labelX,TString unitX,int nBinX1D,int nBinX2D,double minBinX,double maxBinX,std::string options){
+TrackerSectorStruct::CorrelationHists TrackerSectorStruct::bookCorrHists(TString xY,
+                                                                         TString varName,
+                                                                         TString varTitle,
+                                                                         TString labelX,
+                                                                         TString unitX,
+                                                                         int nBinX1D,
+                                                                         int nBinX2D,
+                                                                         double minBinX,
+                                                                         double maxBinX,
+                                                                         std::string options) {
   TString xy;
   TString suffix;
-  if(xY=="X"){
+  if (xY == "X") {
     xy = "x";
     suffix = "";
   }
-  if(xY=="Y"){
+  if (xY == "Y") {
     xy = "y";
     suffix = "_y";
   }
-  
-  const std::string& o(options);
+
+  const std::string &o(options);
   CorrelationHists correlationHists;
-  
-  if(!(o.find("n") != std::string::npos || o.find("p") != std::string::npos || o.find("h") != std::string::npos || 
-       o.find("t") != std::string::npos || o.find("r") != std::string::npos))return correlationHists;
-  
+
+  if (!(o.find("n") != std::string::npos || o.find("p") != std::string::npos || o.find("h") != std::string::npos ||
+        o.find("t") != std::string::npos || o.find("r") != std::string::npos))
+    return correlationHists;
+
   TFileDirectory *directory(directory_);
   double norResXMax(norResXMax_), sigmaXHitMax(sigmaXHitMax_), sigmaXMax(sigmaXMax_);
-  
-  if(!directory)return correlationHists;
-  
-  
-  correlationHists.Variable = directory->make<TH1F>("h_"+varName+suffix,varTitle+" "+labelX+";"+labelX+"  "+unitX+";# hits",nBinX1D,minBinX,maxBinX);
-  
-  if(options.find("n") != std::string::npos)
-  correlationHists.NorResXVsVar = directory->make<TH2F>("h2_norRes"+xY+"Vs"+varName,"r_{"+xy+"}/#sigma_{r,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";("+xy+"_{trk}-"+xy+"_{hit})/#sigma_{r,"+xy+"}",nBinX2D,minBinX,maxBinX,25,-norResXMax,norResXMax);
-  if(options.find("p") != std::string::npos)
-  correlationHists.ProbXVsVar = directory->make<TH2F>("h2_prob"+xY+"Vs"+varName,"prob_{"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";prob_{"+xy+"}",nBinX2D,minBinX,maxBinX,60,-0.1,1.1);
-  if(options.find("h") != std::string::npos)
-  correlationHists.SigmaXHitVsVar = directory->make<TH2F>("h2_sigma"+xY+"HitVs"+varName,"#sigma_{hit,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{hit,"+xy+"}  [#mum]",nBinX2D,minBinX,maxBinX,50,0*10000.,sigmaXHitMax*10000.);
-  if(options.find("t") != std::string::npos)
-  correlationHists.SigmaXTrkVsVar = directory->make<TH2F>("h2_sigma"+xY+"TrkVs"+varName,"#sigma_{trk,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{trk,"+xy+"}  [#mum]",nBinX2D,minBinX,maxBinX,50,0*10000.,sigmaXMax*10000.);
-  if(options.find("r") != std::string::npos)
-  correlationHists.SigmaXVsVar = directory->make<TH2F>("h2_sigma"+xY+"Vs"+varName,"#sigma_{r,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{r,"+xy+"}  [#mum]",nBinX2D,minBinX,maxBinX,50,0*10000.,sigmaXMax*10000.);
-    
-  if(options.find("n") != std::string::npos)
-  correlationHists.PNorResXVsVar = directory->make<TProfile>("p_norRes"+xY+"Vs"+varName,"r_{"+xy+"}/#sigma_{r,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";("+xy+"_{trk}-"+xy+"_{hit})/#sigma_{r,"+xy+"}",nBinX2D,minBinX,maxBinX,"s");
-  if(options.find("p") != std::string::npos)
-  correlationHists.PProbXVsVar = directory->make<TProfile>("p_prob"+xY+"Vs"+varName,"prob_{"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";prob_{"+xy+"}",nBinX2D,minBinX,maxBinX,"s");
-  if(options.find("h") != std::string::npos)
-  correlationHists.PSigmaXHitVsVar = directory->make<TProfile>("p_sigma"+xY+"HitVs"+varName,"#sigma_{hit,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{hit,"+xy+"}  [#mum]",nBinX2D,minBinX,maxBinX);
-  if(options.find("t") != std::string::npos)
-  correlationHists.PSigmaXTrkVsVar = directory->make<TProfile>("p_sigma"+xY+"TrkVs"+varName,"#sigma_{trk,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{trk,"+xy+"}  [#mum]",nBinX2D,minBinX,maxBinX);
-  if(options.find("r") != std::string::npos)
-  correlationHists.PSigmaXVsVar = directory->make<TProfile>("p_sigma"+xY+"Vs"+varName,"#sigma_{r,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{r,"+xy+"}  [#mum]",nBinX2D,minBinX,maxBinX);
-  
+
+  if (!directory)
+    return correlationHists;
+
+  correlationHists.Variable = directory->make<TH1F>("h_" + varName + suffix,
+                                                    varTitle + " " + labelX + ";" + labelX + "  " + unitX + ";# hits",
+                                                    nBinX1D,
+                                                    minBinX,
+                                                    maxBinX);
+
+  if (options.find("n") != std::string::npos)
+    correlationHists.NorResXVsVar =
+        directory->make<TH2F>("h2_norRes" + xY + "Vs" + varName,
+                              "r_{" + xy + "}/#sigma_{r," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX +
+                                  ";(" + xy + "_{trk}-" + xy + "_{hit})/#sigma_{r," + xy + "}",
+                              nBinX2D,
+                              minBinX,
+                              maxBinX,
+                              25,
+                              -norResXMax,
+                              norResXMax);
+  if (options.find("p") != std::string::npos)
+    correlationHists.ProbXVsVar =
+        directory->make<TH2F>("h2_prob" + xY + "Vs" + varName,
+                              "prob_{" + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";prob_{" + xy + "}",
+                              nBinX2D,
+                              minBinX,
+                              maxBinX,
+                              60,
+                              -0.1,
+                              1.1);
+  if (options.find("h") != std::string::npos)
+    correlationHists.SigmaXHitVsVar = directory->make<TH2F>(
+        "h2_sigma" + xY + "HitVs" + varName,
+        "#sigma_{hit," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{hit," + xy + "}  [#mum]",
+        nBinX2D,
+        minBinX,
+        maxBinX,
+        50,
+        0 * 10000.,
+        sigmaXHitMax * 10000.);
+  if (options.find("t") != std::string::npos)
+    correlationHists.SigmaXTrkVsVar = directory->make<TH2F>(
+        "h2_sigma" + xY + "TrkVs" + varName,
+        "#sigma_{trk," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{trk," + xy + "}  [#mum]",
+        nBinX2D,
+        minBinX,
+        maxBinX,
+        50,
+        0 * 10000.,
+        sigmaXMax * 10000.);
+  if (options.find("r") != std::string::npos)
+    correlationHists.SigmaXVsVar = directory->make<TH2F>(
+        "h2_sigma" + xY + "Vs" + varName,
+        "#sigma_{r," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{r," + xy + "}  [#mum]",
+        nBinX2D,
+        minBinX,
+        maxBinX,
+        50,
+        0 * 10000.,
+        sigmaXMax * 10000.);
+
+  if (options.find("n") != std::string::npos)
+    correlationHists.PNorResXVsVar =
+        directory->make<TProfile>("p_norRes" + xY + "Vs" + varName,
+                                  "r_{" + xy + "}/#sigma_{r," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX +
+                                      ";(" + xy + "_{trk}-" + xy + "_{hit})/#sigma_{r," + xy + "}",
+                                  nBinX2D,
+                                  minBinX,
+                                  maxBinX,
+                                  "s");
+  if (options.find("p") != std::string::npos)
+    correlationHists.PProbXVsVar = directory->make<TProfile>(
+        "p_prob" + xY + "Vs" + varName,
+        "prob_{" + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";prob_{" + xy + "}",
+        nBinX2D,
+        minBinX,
+        maxBinX,
+        "s");
+  if (options.find("h") != std::string::npos)
+    correlationHists.PSigmaXHitVsVar = directory->make<TProfile>(
+        "p_sigma" + xY + "HitVs" + varName,
+        "#sigma_{hit," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{hit," + xy + "}  [#mum]",
+        nBinX2D,
+        minBinX,
+        maxBinX);
+  if (options.find("t") != std::string::npos)
+    correlationHists.PSigmaXTrkVsVar = directory->make<TProfile>(
+        "p_sigma" + xY + "TrkVs" + varName,
+        "#sigma_{trk," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{trk," + xy + "}  [#mum]",
+        nBinX2D,
+        minBinX,
+        maxBinX);
+  if (options.find("r") != std::string::npos)
+    correlationHists.PSigmaXVsVar = directory->make<TProfile>(
+        "p_sigma" + xY + "Vs" + varName,
+        "#sigma_{r," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{r," + xy + "}  [#mum]",
+        nBinX2D,
+        minBinX,
+        maxBinX);
+
   return correlationHists;
 }
 
-
-
-TrackerSectorStruct::CorrelationHists
-TrackerSectorStruct::bookCorrHistsX(TString varName,TString labelX,TString unitX,int nBinX,double minBinX,double maxBinX,std::string options){
+TrackerSectorStruct::CorrelationHists TrackerSectorStruct::bookCorrHistsX(
+    TString varName, TString labelX, TString unitX, int nBinX, double minBinX, double maxBinX, std::string options) {
   return bookCorrHists("X", varName, labelX, unitX, nBinX, minBinX, maxBinX, options);
 }
-TrackerSectorStruct::CorrelationHists
-TrackerSectorStruct::bookCorrHistsY(TString varName,TString labelX,TString unitX,int nBinX,double minBinX,double maxBinX,std::string options){
+TrackerSectorStruct::CorrelationHists TrackerSectorStruct::bookCorrHistsY(
+    TString varName, TString labelX, TString unitX, int nBinX, double minBinX, double maxBinX, std::string options) {
   return bookCorrHists("Y", varName, labelX, unitX, nBinX, minBinX, maxBinX, options);
 }
-TrackerSectorStruct::CorrelationHists
-TrackerSectorStruct::bookCorrHists(TString xY,TString varName,TString labelX,TString unitX,int nBinX,double minBinX,double maxBinX,std::string options){
+TrackerSectorStruct::CorrelationHists TrackerSectorStruct::bookCorrHists(TString xY,
+                                                                         TString varName,
+                                                                         TString labelX,
+                                                                         TString unitX,
+                                                                         int nBinX,
+                                                                         double minBinX,
+                                                                         double maxBinX,
+                                                                         std::string options) {
   TString xy;
-  if(xY=="X"){
+  if (xY == "X") {
     xy = "x";
   }
-  if(xY=="Y"){
+  if (xY == "Y") {
     xy = "y";
   }
-  
-  const std::string& o(options);
+
+  const std::string &o(options);
   CorrelationHists correlationHists;
-  
-  if(!(o.find("n") != std::string::npos || o.find("p") != std::string::npos || o.find("h") != std::string::npos || 
-       o.find("t") != std::string::npos || o.find("r") != std::string::npos))return correlationHists;
-  
+
+  if (!(o.find("n") != std::string::npos || o.find("p") != std::string::npos || o.find("h") != std::string::npos ||
+        o.find("t") != std::string::npos || o.find("r") != std::string::npos))
+    return correlationHists;
+
   TFileDirectory *directory(directory_);
   double norResXMax(norResXMax_), sigmaXHitMax(sigmaXHitMax_), sigmaXMax(sigmaXMax_);
-  
-  if(!directory)return correlationHists;
-  
-  
-  if(options.find("n") != std::string::npos)
-  correlationHists.NorResXVsVar = directory->make<TH2F>("h2_norRes"+xY+"Vs"+varName,"r_{"+xy+"}/#sigma_{r,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";("+xy+"_{trk}-"+xy+"_{hit})/#sigma_{r,"+xy+"}",nBinX,minBinX,maxBinX,25,-norResXMax,norResXMax);
-  if(options.find("p") != std::string::npos)
-  correlationHists.ProbXVsVar = directory->make<TH2F>("h2_prob"+xY+"Vs"+varName,"prob_{"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";prob_{"+xy+"}",nBinX,minBinX,maxBinX,60,-0.1,1.1);
-  if(options.find("h") != std::string::npos)
-  correlationHists.SigmaXHitVsVar = directory->make<TH2F>("h2_sigma"+xY+"HitVs"+varName,"#sigma_{hit,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{hit,"+xy+"}  [#mum]",nBinX,minBinX,maxBinX,50,0*10000.,sigmaXHitMax*10000.);
-  if(options.find("t") != std::string::npos)
-  correlationHists.SigmaXTrkVsVar = directory->make<TH2F>("h2_sigma"+xY+"TrkVs"+varName,"#sigma_{trk,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{trk,"+xy+"}  [#mum]",nBinX,minBinX,maxBinX,50,0*10000.,sigmaXMax*10000.);
-  if(options.find("r") != std::string::npos)
-  correlationHists.SigmaXVsVar = directory->make<TH2F>("h2_sigma"+xY+"Vs"+varName,"#sigma_{r,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{r,"+xy+"}  [#mum]",nBinX,minBinX,maxBinX,50,0*10000.,sigmaXMax*10000.);
-    
-  if(options.find("n") != std::string::npos)
-  correlationHists.PNorResXVsVar = directory->make<TProfile>("p_norRes"+xY+"Vs"+varName,"r_{"+xy+"}/#sigma_{r,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";("+xy+"_{trk}-"+xy+"_{hit})/#sigma_{r,"+xy+"}",nBinX,minBinX,maxBinX,"s");
-  if(options.find("p") != std::string::npos)
-  correlationHists.PProbXVsVar = directory->make<TProfile>("p_prob"+xY+"Vs"+varName,"prob_{"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";prob_{"+xy+"}",nBinX,minBinX,maxBinX,"s");
-  if(options.find("h") != std::string::npos)
-  correlationHists.PSigmaXHitVsVar = directory->make<TProfile>("p_sigma"+xY+"HitVs"+varName,"#sigma_{hit,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{hit,"+xy+"}  [#mum]",nBinX,minBinX,maxBinX);
-  if(options.find("t") != std::string::npos)
-  correlationHists.PSigmaXTrkVsVar = directory->make<TProfile>("p_sigma"+xY+"TrkVs"+varName,"#sigma_{trk,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{trk,"+xy+"}  [#mum]",nBinX,minBinX,maxBinX);
-  if(options.find("r") != std::string::npos)
-  correlationHists.PSigmaXVsVar = directory->make<TProfile>("p_sigma"+xY+"Vs"+varName,"#sigma_{r,"+xy+"} vs. "+labelX+";"+labelX+"  "+unitX+";#sigma_{r,"+xy+"}  [#mum]",nBinX,minBinX,maxBinX);
-  
+
+  if (!directory)
+    return correlationHists;
+
+  if (options.find("n") != std::string::npos)
+    correlationHists.NorResXVsVar =
+        directory->make<TH2F>("h2_norRes" + xY + "Vs" + varName,
+                              "r_{" + xy + "}/#sigma_{r," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX +
+                                  ";(" + xy + "_{trk}-" + xy + "_{hit})/#sigma_{r," + xy + "}",
+                              nBinX,
+                              minBinX,
+                              maxBinX,
+                              25,
+                              -norResXMax,
+                              norResXMax);
+  if (options.find("p") != std::string::npos)
+    correlationHists.ProbXVsVar =
+        directory->make<TH2F>("h2_prob" + xY + "Vs" + varName,
+                              "prob_{" + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";prob_{" + xy + "}",
+                              nBinX,
+                              minBinX,
+                              maxBinX,
+                              60,
+                              -0.1,
+                              1.1);
+  if (options.find("h") != std::string::npos)
+    correlationHists.SigmaXHitVsVar = directory->make<TH2F>(
+        "h2_sigma" + xY + "HitVs" + varName,
+        "#sigma_{hit," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{hit," + xy + "}  [#mum]",
+        nBinX,
+        minBinX,
+        maxBinX,
+        50,
+        0 * 10000.,
+        sigmaXHitMax * 10000.);
+  if (options.find("t") != std::string::npos)
+    correlationHists.SigmaXTrkVsVar = directory->make<TH2F>(
+        "h2_sigma" + xY + "TrkVs" + varName,
+        "#sigma_{trk," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{trk," + xy + "}  [#mum]",
+        nBinX,
+        minBinX,
+        maxBinX,
+        50,
+        0 * 10000.,
+        sigmaXMax * 10000.);
+  if (options.find("r") != std::string::npos)
+    correlationHists.SigmaXVsVar = directory->make<TH2F>(
+        "h2_sigma" + xY + "Vs" + varName,
+        "#sigma_{r," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{r," + xy + "}  [#mum]",
+        nBinX,
+        minBinX,
+        maxBinX,
+        50,
+        0 * 10000.,
+        sigmaXMax * 10000.);
+
+  if (options.find("n") != std::string::npos)
+    correlationHists.PNorResXVsVar =
+        directory->make<TProfile>("p_norRes" + xY + "Vs" + varName,
+                                  "r_{" + xy + "}/#sigma_{r," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX +
+                                      ";(" + xy + "_{trk}-" + xy + "_{hit})/#sigma_{r," + xy + "}",
+                                  nBinX,
+                                  minBinX,
+                                  maxBinX,
+                                  "s");
+  if (options.find("p") != std::string::npos)
+    correlationHists.PProbXVsVar = directory->make<TProfile>(
+        "p_prob" + xY + "Vs" + varName,
+        "prob_{" + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";prob_{" + xy + "}",
+        nBinX,
+        minBinX,
+        maxBinX,
+        "s");
+  if (options.find("h") != std::string::npos)
+    correlationHists.PSigmaXHitVsVar = directory->make<TProfile>(
+        "p_sigma" + xY + "HitVs" + varName,
+        "#sigma_{hit," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{hit," + xy + "}  [#mum]",
+        nBinX,
+        minBinX,
+        maxBinX);
+  if (options.find("t") != std::string::npos)
+    correlationHists.PSigmaXTrkVsVar = directory->make<TProfile>(
+        "p_sigma" + xY + "TrkVs" + varName,
+        "#sigma_{trk," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{trk," + xy + "}  [#mum]",
+        nBinX,
+        minBinX,
+        maxBinX);
+  if (options.find("r") != std::string::npos)
+    correlationHists.PSigmaXVsVar = directory->make<TProfile>(
+        "p_sigma" + xY + "Vs" + varName,
+        "#sigma_{r," + xy + "} vs. " + labelX + ";" + labelX + "  " + unitX + ";#sigma_{r," + xy + "}  [#mum]",
+        nBinX,
+        minBinX,
+        maxBinX);
+
   return correlationHists;
 }
 
-
-
-
-void
-TrackerSectorStruct::CorrelationHists::fillCorrHistsX(const TrackStruct::HitParameterStruct& hitParameterStruct, double variable){
+void TrackerSectorStruct::CorrelationHists::fillCorrHistsX(const TrackStruct::HitParameterStruct &hitParameterStruct,
+                                                           double variable) {
   return fillCorrHists("X", hitParameterStruct, variable);
 }
-void
-TrackerSectorStruct::CorrelationHists::fillCorrHistsY(const TrackStruct::HitParameterStruct& hitParameterStruct, double variable){
+void TrackerSectorStruct::CorrelationHists::fillCorrHistsY(const TrackStruct::HitParameterStruct &hitParameterStruct,
+                                                           double variable) {
   return fillCorrHists("Y", hitParameterStruct, variable);
 }
-void
-TrackerSectorStruct::CorrelationHists::fillCorrHists(const TString xY, const TrackStruct::HitParameterStruct& hitParameterStruct, double variable){
+void TrackerSectorStruct::CorrelationHists::fillCorrHists(const TString xY,
+                                                          const TrackStruct::HitParameterStruct &hitParameterStruct,
+                                                          double variable) {
   float norRes(999.);
   float prob(999.);
   float errHit(999.);
   float errTrk(999.);
   float err(999.);
-  if(xY=="X"){
+  if (xY == "X") {
     norRes = hitParameterStruct.norResX;
     prob = hitParameterStruct.probX;
     errHit = hitParameterStruct.errXHit;
     errTrk = hitParameterStruct.errXTrk;
     err = hitParameterStruct.errX;
   }
-  if(xY=="Y"){
+  if (xY == "Y") {
     norRes = hitParameterStruct.norResY;
     prob = hitParameterStruct.probY;
     errHit = hitParameterStruct.errYHit;
     errTrk = hitParameterStruct.errYTrk;
     err = hitParameterStruct.errY;
   }
-  
-  if(Variable){Variable->Fill(variable);}
-  
-  if(NorResXVsVar){
-    NorResXVsVar->Fill(variable,norRes);
-    PNorResXVsVar->Fill(variable,norRes);
+
+  if (Variable) {
+    Variable->Fill(variable);
   }
-  if(ProbXVsVar){
-    ProbXVsVar->Fill(variable,prob);
-    PProbXVsVar->Fill(variable,prob);
+
+  if (NorResXVsVar) {
+    NorResXVsVar->Fill(variable, norRes);
+    PNorResXVsVar->Fill(variable, norRes);
   }
-  if(SigmaXHitVsVar){
-    SigmaXHitVsVar->Fill(variable,errHit*10000.);
-    PSigmaXHitVsVar->Fill(variable,errHit*10000.);
+  if (ProbXVsVar) {
+    ProbXVsVar->Fill(variable, prob);
+    PProbXVsVar->Fill(variable, prob);
   }
-  if(SigmaXTrkVsVar){
-    SigmaXTrkVsVar->Fill(variable,errTrk*10000.);
-    PSigmaXTrkVsVar->Fill(variable,errTrk*10000.);
+  if (SigmaXHitVsVar) {
+    SigmaXHitVsVar->Fill(variable, errHit * 10000.);
+    PSigmaXHitVsVar->Fill(variable, errHit * 10000.);
   }
-  if(SigmaXVsVar){
-    SigmaXVsVar->Fill(variable,err*10000.);
-    PSigmaXVsVar->Fill(variable,err*10000.);
+  if (SigmaXTrkVsVar) {
+    SigmaXTrkVsVar->Fill(variable, errTrk * 10000.);
+    PSigmaXTrkVsVar->Fill(variable, errTrk * 10000.);
   }
-  
+  if (SigmaXVsVar) {
+    SigmaXVsVar->Fill(variable, err * 10000.);
+    PSigmaXVsVar->Fill(variable, err * 10000.);
+  }
 }
-
-
-
-
 
 #endif

--- a/Alignment/APEEstimation/plugins/ApeEstimator.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimator.cc
@@ -2,7 +2,7 @@
 //
 // Package:    ApeEstimator
 // Class:      ApeEstimator
-// 
+//
 /**\class ApeEstimator ApeEstimator.cc Alignment/APEEstimation/src/ApeEstimator.cc
 
  Description: <one line class summary>
@@ -17,7 +17,6 @@
 // $Id: ApeEstimator.cc,v 1.27 2012/06/26 09:42:33 hauk Exp $
 //
 //
-
 
 // system include files
 #include <memory>
@@ -92,7 +91,6 @@
 #include "Alignment/APEEstimation/interface/EventVariables.h"
 #include "Alignment/APEEstimation/interface/ReducedTrackerTreeVariables.h"
 
-
 #include "TH1.h"
 #include "TH2.h"
 #include "TProfile.h"
@@ -101,7 +99,6 @@
 #include "TF1.h"
 #include "TString.h"
 #include "TMath.h"
-
 
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
@@ -127,89 +124,86 @@
 //
 
 class ApeEstimator : public edm::one::EDAnalyzer<> {
-   public:
-      explicit ApeEstimator(const edm::ParameterSet&);
-      ~ApeEstimator() override;
+public:
+  explicit ApeEstimator(const edm::ParameterSet&);
+  ~ApeEstimator() override;
 
+private:
+  struct PositionAndError2 {
+    PositionAndError2() : posX(-999.F), posY(-999.F), errX2(-999.F), errY2(-999.F){};
+    PositionAndError2(float x, float y, float eX, float eY) : posX(x), posY(y), errX2(eX), errY2(eY){};
+    float posX;
+    float posY;
+    float errX2;
+    float errY2;
+  };
+  typedef std::pair<TrackStruct::HitState, PositionAndError2> StatePositionAndError2;
 
-   private:
-      struct PositionAndError2{
-        PositionAndError2(): posX(-999.F), posY(-999.F), errX2(-999.F), errY2(-999.F) {};
-        PositionAndError2(float x, float y, float eX, float eY): posX(x), posY(y), errX2(eX), errY2(eY) {};
-        float posX;
-        float posY;
-        float errX2;
-        float errY2;
-      };
-      typedef std::pair<TrackStruct::HitState,PositionAndError2> StatePositionAndError2;
-      
-      void beginJob() override ;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
-      
-      bool isHit2D(const TrackingRecHit&)const;
-      
-      void sectorBuilder();
-      bool checkIntervalsForSectors(const unsigned int sectorCounter, const std::vector<double>&)const;
-      bool checkModuleIds(const unsigned int, const std::vector<unsigned int>&)const;
-      bool checkModuleBools(const bool, const std::vector<unsigned int>&)const;
-      bool checkModuleDirections(const int, const std::vector<int>&)const;
-      bool checkModulePositions(const float, const std::vector<double>&)const;
-      void statistics(const TrackerSectorStruct&, const int)const;
-      
-      void residualErrorBinning();
-      
-      void bookSectorHistsForAnalyzerMode();
-      void bookSectorHistsForApeCalculation();
-      void bookTrackHists();
-      
-      TrackStruct::TrackParameterStruct fillTrackVariables(const reco::Track&, const Trajectory&, const reco::BeamSpot&);
-      TrackStruct::HitParameterStruct fillHitVariables(const TrajectoryMeasurement&, const edm::EventSetup&);
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-      StatePositionAndError2 positionAndError2(const LocalPoint&, const LocalError&, const TransientTrackingRecHit&);
-      PositionAndError2 rectangularPositionAndError2(const LocalPoint&, const LocalError&);
-      PositionAndError2 radialPositionAndError2(const LocalPoint&, const LocalError&, const RadialStripTopology&);
-      
-      void hitSelection();
-      void setHitSelectionMap(const std::string&);
-      void setHitSelectionMapUInt(const std::string&);
-      bool hitSelected(TrackStruct::HitParameterStruct&)const;
-      bool inDoubleInterval(const std::vector<double>&, const float)const;
-      bool inUintInterval(const std::vector<unsigned int>&, const unsigned int, const unsigned int =999)const;
-      
-      void fillHistsForAnalyzerMode(const TrackStruct&);
-      void fillHitHistsXForAnalyzerMode(const TrackStruct::HitParameterStruct&, TrackerSectorStruct&);
-      void fillHitHistsYForAnalyzerMode(const TrackStruct::HitParameterStruct&, TrackerSectorStruct&);
-      void fillHistsForApeCalculation(const TrackStruct&);
-      
-      void calculateAPE();
-      
-      // ----------member data ---------------------------
-      const edm::ParameterSet parameterSet_;
-      std::map<unsigned int, TrackerSectorStruct> m_tkSector_;
-      TrackerDetectorStruct tkDetector_;
-      
-      edm::EDGetTokenT<TrajTrackAssociationCollection> tjTagToken_;
-      edm::EDGetTokenT<reco::BeamSpot> offlinebeamSpot_;
-      
-      
-      std::map<unsigned int, std::pair<double,double> > m_resErrBins_;
-      std::map<unsigned int, ReducedTrackerTreeVariables> m_tkTreeVar_;
-      
-      std::map<std::string,std::vector<double> > m_hitSelection_;
-      std::map<std::string,std::vector<unsigned int> > m_hitSelectionUInt_;
-      
-      bool trackCut_;
-      
-      const unsigned int maxTracksPerEvent_;
-      const unsigned int minGoodHitsPerTrack_;
-      
-      const bool analyzerMode_;
-      
-      const bool calculateApe_;
-      
-      unsigned int counter1, counter2, counter3, counter4, counter5, counter6;
- 
+  bool isHit2D(const TrackingRecHit&) const;
+
+  void sectorBuilder();
+  bool checkIntervalsForSectors(const unsigned int sectorCounter, const std::vector<double>&) const;
+  bool checkModuleIds(const unsigned int, const std::vector<unsigned int>&) const;
+  bool checkModuleBools(const bool, const std::vector<unsigned int>&) const;
+  bool checkModuleDirections(const int, const std::vector<int>&) const;
+  bool checkModulePositions(const float, const std::vector<double>&) const;
+  void statistics(const TrackerSectorStruct&, const int) const;
+
+  void residualErrorBinning();
+
+  void bookSectorHistsForAnalyzerMode();
+  void bookSectorHistsForApeCalculation();
+  void bookTrackHists();
+
+  TrackStruct::TrackParameterStruct fillTrackVariables(const reco::Track&, const Trajectory&, const reco::BeamSpot&);
+  TrackStruct::HitParameterStruct fillHitVariables(const TrajectoryMeasurement&, const edm::EventSetup&);
+
+  StatePositionAndError2 positionAndError2(const LocalPoint&, const LocalError&, const TransientTrackingRecHit&);
+  PositionAndError2 rectangularPositionAndError2(const LocalPoint&, const LocalError&);
+  PositionAndError2 radialPositionAndError2(const LocalPoint&, const LocalError&, const RadialStripTopology&);
+
+  void hitSelection();
+  void setHitSelectionMap(const std::string&);
+  void setHitSelectionMapUInt(const std::string&);
+  bool hitSelected(TrackStruct::HitParameterStruct&) const;
+  bool inDoubleInterval(const std::vector<double>&, const float) const;
+  bool inUintInterval(const std::vector<unsigned int>&, const unsigned int, const unsigned int = 999) const;
+
+  void fillHistsForAnalyzerMode(const TrackStruct&);
+  void fillHitHistsXForAnalyzerMode(const TrackStruct::HitParameterStruct&, TrackerSectorStruct&);
+  void fillHitHistsYForAnalyzerMode(const TrackStruct::HitParameterStruct&, TrackerSectorStruct&);
+  void fillHistsForApeCalculation(const TrackStruct&);
+
+  void calculateAPE();
+
+  // ----------member data ---------------------------
+  const edm::ParameterSet parameterSet_;
+  std::map<unsigned int, TrackerSectorStruct> m_tkSector_;
+  TrackerDetectorStruct tkDetector_;
+
+  edm::EDGetTokenT<TrajTrackAssociationCollection> tjTagToken_;
+  edm::EDGetTokenT<reco::BeamSpot> offlinebeamSpot_;
+
+  std::map<unsigned int, std::pair<double, double> > m_resErrBins_;
+  std::map<unsigned int, ReducedTrackerTreeVariables> m_tkTreeVar_;
+
+  std::map<std::string, std::vector<double> > m_hitSelection_;
+  std::map<std::string, std::vector<unsigned int> > m_hitSelectionUInt_;
+
+  bool trackCut_;
+
+  const unsigned int maxTracksPerEvent_;
+  const unsigned int minGoodHitsPerTrack_;
+
+  const bool analyzerMode_;
+
+  const bool calculateApe_;
+
+  unsigned int counter1, counter2, counter3, counter4, counter5, counter6;
 };
 
 //
@@ -223,23 +217,20 @@ class ApeEstimator : public edm::one::EDAnalyzer<> {
 //
 // constructors and destructor
 //
-ApeEstimator::ApeEstimator(const edm::ParameterSet& iConfig):
-  parameterSet_(iConfig),
-  tjTagToken_(consumes<TrajTrackAssociationCollection>(parameterSet_.getParameter<edm::InputTag>("tjTkAssociationMapTag"))),
-  offlinebeamSpot_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
-  trackCut_(false), maxTracksPerEvent_(parameterSet_.getParameter<unsigned int>("maxTracksPerEvent")),
-  minGoodHitsPerTrack_(parameterSet_.getParameter<unsigned int>("minGoodHitsPerTrack")),
-  analyzerMode_(parameterSet_.getParameter<bool>("analyzerMode")),
-  calculateApe_(parameterSet_.getParameter<bool>("calculateApe"))
-{
-   counter1 = counter2 = counter3 = counter4 = counter5 = counter6 = 0;
+ApeEstimator::ApeEstimator(const edm::ParameterSet& iConfig)
+    : parameterSet_(iConfig),
+      tjTagToken_(
+          consumes<TrajTrackAssociationCollection>(parameterSet_.getParameter<edm::InputTag>("tjTkAssociationMapTag"))),
+      offlinebeamSpot_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
+      trackCut_(false),
+      maxTracksPerEvent_(parameterSet_.getParameter<unsigned int>("maxTracksPerEvent")),
+      minGoodHitsPerTrack_(parameterSet_.getParameter<unsigned int>("minGoodHitsPerTrack")),
+      analyzerMode_(parameterSet_.getParameter<bool>("analyzerMode")),
+      calculateApe_(parameterSet_.getParameter<bool>("calculateApe")) {
+  counter1 = counter2 = counter3 = counter4 = counter5 = counter6 = 0;
 }
 
-
-ApeEstimator::~ApeEstimator()
-{
-}
-
+ApeEstimator::~ApeEstimator() {}
 
 //
 // member functions
@@ -247,30 +238,28 @@ ApeEstimator::~ApeEstimator()
 
 // -----------------------------------------------------------------------------------------------------------
 
-void
-ApeEstimator::sectorBuilder(){
-  
+void ApeEstimator::sectorBuilder() {
   TFile* tkTreeFile(TFile::Open((parameterSet_.getParameter<std::string>("TrackerTreeFile")).c_str()));
-  if(tkTreeFile){
-      edm::LogInfo("SectorBuilder")<<"TrackerTreeFile OK";
-  }else{
-      edm::LogError("SectorBuilder")<<"TrackerTreeFile not found";
-      return;
+  if (tkTreeFile) {
+    edm::LogInfo("SectorBuilder") << "TrackerTreeFile OK";
+  } else {
+    edm::LogError("SectorBuilder") << "TrackerTreeFile not found";
+    return;
   }
   TTree* tkTree(nullptr);
-  tkTreeFile->GetObject("TrackerTreeGenerator/TrackerTree/TrackerTree",tkTree);
-  if(tkTree){
-      edm::LogInfo("SectorBuilder")<<"TrackerTree OK";
-  }else{
-      edm::LogError("SectorBuilder")<<"TrackerTree not found in file";
-      return;
+  tkTreeFile->GetObject("TrackerTreeGenerator/TrackerTree/TrackerTree", tkTree);
+  if (tkTree) {
+    edm::LogInfo("SectorBuilder") << "TrackerTree OK";
+  } else {
+    edm::LogError("SectorBuilder") << "TrackerTree not found in file";
+    return;
   }
-  unsigned int rawId(999), subdetId(999), layer(999), side(999), half(999), rod(999), ring(999), petal(999),
-         blade(999), panel(999), outerInner(999), module(999), nStrips(999);
+  unsigned int rawId(999), subdetId(999), layer(999), side(999), half(999), rod(999), ring(999), petal(999), blade(999),
+      panel(999), outerInner(999), module(999), nStrips(999);
   bool isDoubleSide(false), isRPhi(false), isStereo(false);
   int uDirection(999), vDirection(999), wDirection(999);
-  float posR(999.F), posPhi(999.F), posEta(999.F), posX(999.F), posY(999.F), posZ(999.F); 
-  
+  float posR(999.F), posPhi(999.F), posEta(999.F), posX(999.F), posY(999.F), posZ(999.F);
+
   tkTree->SetBranchAddress("RawId", &rawId);
   tkTree->SetBranchAddress("SubdetId", &subdetId);
   tkTree->SetBranchAddress("Layer", &layer);
@@ -296,265 +285,296 @@ ApeEstimator::sectorBuilder(){
   tkTree->SetBranchAddress("PosX", &posX);
   tkTree->SetBranchAddress("PosY", &posY);
   tkTree->SetBranchAddress("PosZ", &posZ);
-  
+
   int nModules(tkTree->GetEntries());
   TrackerSectorStruct allSectors;
-  
+
   //Loop over all Sectors
   unsigned int sectorCounter(0);
   std::vector<edm::ParameterSet> v_sectorDef(parameterSet_.getParameter<std::vector<edm::ParameterSet> >("Sectors"));
-  edm::LogInfo("SectorBuilder")<<"There are "<<v_sectorDef.size()<<" Sectors definded";
-  for(auto const & parSet : v_sectorDef){
-      ++sectorCounter;
-      const std::string& sectorName(parSet.getParameter<std::string>("name"));
-      std::vector<unsigned int> v_rawId(parSet.getParameter<std::vector<unsigned int> >("rawId")),
-                                v_subdetId(parSet.getParameter<std::vector<unsigned int> >("subdetId")),
-                                v_layer(parSet.getParameter<std::vector<unsigned int> >("layer")),
-                                v_side(parSet.getParameter<std::vector<unsigned int> >("side")),
-                                v_half(parSet.getParameter<std::vector<unsigned int> >("half")),
-                                v_rod(parSet.getParameter<std::vector<unsigned int> >("rod")),
-                                v_ring(parSet.getParameter<std::vector<unsigned int> >("ring")),
-                                v_petal(parSet.getParameter<std::vector<unsigned int> >("petal")),
-                                v_blade(parSet.getParameter<std::vector<unsigned int> >("blade")),
-                                v_panel(parSet.getParameter<std::vector<unsigned int> >("panel")),
-                                v_outerInner(parSet.getParameter<std::vector<unsigned int> >("outerInner")),
-                                v_module(parSet.getParameter<std::vector<unsigned int> >("module")),
-                                v_nStrips(parSet.getParameter<std::vector<unsigned int> >("nStrips")),
-                                v_isDoubleSide(parSet.getParameter<std::vector<unsigned int> >("isDoubleSide")),
-                                v_isRPhi(parSet.getParameter<std::vector<unsigned int> >("isRPhi")),
-                                v_isStereo(parSet.getParameter<std::vector<unsigned int> >("isStereo"));
-      std::vector<int>  v_uDirection(parSet.getParameter<std::vector<int> >("uDirection")),
-                        v_vDirection(parSet.getParameter<std::vector<int> >("vDirection")),
-                        v_wDirection(parSet.getParameter<std::vector<int> >("wDirection"));
-      std::vector<double> v_posR(parSet.getParameter<std::vector<double> >("posR")),
-                          v_posPhi(parSet.getParameter<std::vector<double> >("posPhi")),
-                          v_posEta(parSet.getParameter<std::vector<double> >("posEta")),
-                          v_posX(parSet.getParameter<std::vector<double> >("posX")),
-                          v_posY(parSet.getParameter<std::vector<double> >("posY")),
-                          v_posZ(parSet.getParameter<std::vector<double> >("posZ"));
-    
-      if(!this->checkIntervalsForSectors(sectorCounter,v_posR) || !this->checkIntervalsForSectors(sectorCounter,v_posPhi) ||
-        !this->checkIntervalsForSectors(sectorCounter,v_posEta) || !this->checkIntervalsForSectors(sectorCounter,v_posX) ||
-        !this->checkIntervalsForSectors(sectorCounter,v_posY)   || !this->checkIntervalsForSectors(sectorCounter,v_posZ))continue;
-    
-    
-      TrackerSectorStruct tkSector;
-      tkSector.name = sectorName;
-      
-      ReducedTrackerTreeVariables tkTreeVar;
-    
-      //Loop over all Modules
-      for(int module = 0; module < nModules; ++module){
-          tkTree->GetEntry(module);
-          
-          if(sectorCounter==1){
-            tkTreeVar.subdetId = subdetId;
-            tkTreeVar.nStrips = nStrips;
-            tkTreeVar.uDirection = uDirection;
-            tkTreeVar.vDirection = vDirection;
-            tkTreeVar.wDirection = wDirection;
-            m_tkTreeVar_[rawId] = tkTreeVar;
-          }
-      
-          if(!this->checkModuleIds(rawId,v_rawId))continue;
-          if(!this->checkModuleIds(subdetId,v_subdetId))continue;
-          if(!this->checkModuleIds(layer,v_layer))continue;
-          if(!this->checkModuleIds(side,v_side))continue;
-          if(!this->checkModuleIds(half,v_half))continue;
-          if(!this->checkModuleIds(rod,v_rod))continue;
-          if(!this->checkModuleIds(ring,v_ring))continue;
-          if(!this->checkModuleIds(petal,v_petal))continue;
-          if(!this->checkModuleIds(blade,v_blade))continue;
-          if(!this->checkModuleIds(panel,v_panel))continue;
-          if(!this->checkModuleIds(outerInner,v_outerInner))continue;
-          if(!this->checkModuleIds(module,v_module))continue;
-          if(!this->checkModuleIds(nStrips,v_nStrips))continue;
-          if(!this->checkModuleBools(isDoubleSide,v_isDoubleSide))continue;
-          if(!this->checkModuleBools(isRPhi,v_isRPhi))continue;
-          if(!this->checkModuleBools(isStereo,v_isStereo))continue;
-          if(!this->checkModuleDirections(uDirection,v_uDirection))continue;
-          if(!this->checkModuleDirections(vDirection,v_vDirection))continue;
-          if(!this->checkModuleDirections(wDirection,v_wDirection))continue;
-          if(!this->checkModulePositions(posR,v_posR))continue;
-          if(!this->checkModulePositions(posPhi,v_posPhi))continue;
-          if(!this->checkModulePositions(posEta,v_posEta))continue;
-          if(!this->checkModulePositions(posX,v_posX))continue;
-          if(!this->checkModulePositions(posY,v_posY))continue;
-          if(!this->checkModulePositions(posZ,v_posZ))continue;
-          
-          tkSector.v_rawId.push_back(rawId);
-          bool moduleSelected(false);
-          for(auto const & i_rawId : allSectors.v_rawId){
-            if(rawId == i_rawId)moduleSelected = true;
-          }
-          if(!moduleSelected)allSectors.v_rawId.push_back(rawId);
-      }
-    
-      bool isPixel(false);
-      bool isStrip(false);
-      for(auto const & i_rawId : tkSector.v_rawId){
-        switch (m_tkTreeVar_[i_rawId].subdetId) {
-          case PixelSubdetector::PixelBarrel:
-          case PixelSubdetector::PixelEndcap:
-            isPixel = true;
-            break;
-          case StripSubdetector::TIB:
-          case StripSubdetector::TOB:
-          case StripSubdetector::TID:
-          case StripSubdetector::TEC:
-            isStrip = true;
-            break;
-        }
+  edm::LogInfo("SectorBuilder") << "There are " << v_sectorDef.size() << " Sectors definded";
+  for (auto const& parSet : v_sectorDef) {
+    ++sectorCounter;
+    const std::string& sectorName(parSet.getParameter<std::string>("name"));
+    std::vector<unsigned int> v_rawId(parSet.getParameter<std::vector<unsigned int> >("rawId")),
+        v_subdetId(parSet.getParameter<std::vector<unsigned int> >("subdetId")),
+        v_layer(parSet.getParameter<std::vector<unsigned int> >("layer")),
+        v_side(parSet.getParameter<std::vector<unsigned int> >("side")),
+        v_half(parSet.getParameter<std::vector<unsigned int> >("half")),
+        v_rod(parSet.getParameter<std::vector<unsigned int> >("rod")),
+        v_ring(parSet.getParameter<std::vector<unsigned int> >("ring")),
+        v_petal(parSet.getParameter<std::vector<unsigned int> >("petal")),
+        v_blade(parSet.getParameter<std::vector<unsigned int> >("blade")),
+        v_panel(parSet.getParameter<std::vector<unsigned int> >("panel")),
+        v_outerInner(parSet.getParameter<std::vector<unsigned int> >("outerInner")),
+        v_module(parSet.getParameter<std::vector<unsigned int> >("module")),
+        v_nStrips(parSet.getParameter<std::vector<unsigned int> >("nStrips")),
+        v_isDoubleSide(parSet.getParameter<std::vector<unsigned int> >("isDoubleSide")),
+        v_isRPhi(parSet.getParameter<std::vector<unsigned int> >("isRPhi")),
+        v_isStereo(parSet.getParameter<std::vector<unsigned int> >("isStereo"));
+    std::vector<int> v_uDirection(parSet.getParameter<std::vector<int> >("uDirection")),
+        v_vDirection(parSet.getParameter<std::vector<int> >("vDirection")),
+        v_wDirection(parSet.getParameter<std::vector<int> >("wDirection"));
+    std::vector<double> v_posR(parSet.getParameter<std::vector<double> >("posR")),
+        v_posPhi(parSet.getParameter<std::vector<double> >("posPhi")),
+        v_posEta(parSet.getParameter<std::vector<double> >("posEta")),
+        v_posX(parSet.getParameter<std::vector<double> >("posX")),
+        v_posY(parSet.getParameter<std::vector<double> >("posY")),
+        v_posZ(parSet.getParameter<std::vector<double> >("posZ"));
+
+    if (!this->checkIntervalsForSectors(sectorCounter, v_posR) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posPhi) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posEta) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posX) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posY) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posZ))
+      continue;
+
+    TrackerSectorStruct tkSector;
+    tkSector.name = sectorName;
+
+    ReducedTrackerTreeVariables tkTreeVar;
+
+    //Loop over all Modules
+    for (int module = 0; module < nModules; ++module) {
+      tkTree->GetEntry(module);
+
+      if (sectorCounter == 1) {
+        tkTreeVar.subdetId = subdetId;
+        tkTreeVar.nStrips = nStrips;
+        tkTreeVar.uDirection = uDirection;
+        tkTreeVar.vDirection = vDirection;
+        tkTreeVar.wDirection = wDirection;
+        m_tkTreeVar_[rawId] = tkTreeVar;
       }
 
-      if(isPixel && isStrip){
-        edm::LogError("SectorBuilder")<<"Incorrect Sector Definition: there are pixel and strip modules within one sector"
-                                     <<"\n... sector selection is not applied, sector "<<sectorCounter<<" is not built";
+      if (!this->checkModuleIds(rawId, v_rawId))
         continue;
+      if (!this->checkModuleIds(subdetId, v_subdetId))
+        continue;
+      if (!this->checkModuleIds(layer, v_layer))
+        continue;
+      if (!this->checkModuleIds(side, v_side))
+        continue;
+      if (!this->checkModuleIds(half, v_half))
+        continue;
+      if (!this->checkModuleIds(rod, v_rod))
+        continue;
+      if (!this->checkModuleIds(ring, v_ring))
+        continue;
+      if (!this->checkModuleIds(petal, v_petal))
+        continue;
+      if (!this->checkModuleIds(blade, v_blade))
+        continue;
+      if (!this->checkModuleIds(panel, v_panel))
+        continue;
+      if (!this->checkModuleIds(outerInner, v_outerInner))
+        continue;
+      if (!this->checkModuleIds(module, v_module))
+        continue;
+      if (!this->checkModuleIds(nStrips, v_nStrips))
+        continue;
+      if (!this->checkModuleBools(isDoubleSide, v_isDoubleSide))
+        continue;
+      if (!this->checkModuleBools(isRPhi, v_isRPhi))
+        continue;
+      if (!this->checkModuleBools(isStereo, v_isStereo))
+        continue;
+      if (!this->checkModuleDirections(uDirection, v_uDirection))
+        continue;
+      if (!this->checkModuleDirections(vDirection, v_vDirection))
+        continue;
+      if (!this->checkModuleDirections(wDirection, v_wDirection))
+        continue;
+      if (!this->checkModulePositions(posR, v_posR))
+        continue;
+      if (!this->checkModulePositions(posPhi, v_posPhi))
+        continue;
+      if (!this->checkModulePositions(posEta, v_posEta))
+        continue;
+      if (!this->checkModulePositions(posX, v_posX))
+        continue;
+      if (!this->checkModulePositions(posY, v_posY))
+        continue;
+      if (!this->checkModulePositions(posZ, v_posZ))
+        continue;
+
+      tkSector.v_rawId.push_back(rawId);
+      bool moduleSelected(false);
+      for (auto const& i_rawId : allSectors.v_rawId) {
+        if (rawId == i_rawId)
+          moduleSelected = true;
       }
-      tkSector.isPixel = isPixel;
-    
-      m_tkSector_[sectorCounter] = tkSector;
-      edm::LogInfo("SectorBuilder")<<"There are "<<tkSector.v_rawId.size()<<" Modules in Sector "<<sectorCounter;
+      if (!moduleSelected)
+        allSectors.v_rawId.push_back(rawId);
+    }
+
+    bool isPixel(false);
+    bool isStrip(false);
+    for (auto const& i_rawId : tkSector.v_rawId) {
+      switch (m_tkTreeVar_[i_rawId].subdetId) {
+        case PixelSubdetector::PixelBarrel:
+        case PixelSubdetector::PixelEndcap:
+          isPixel = true;
+          break;
+        case StripSubdetector::TIB:
+        case StripSubdetector::TOB:
+        case StripSubdetector::TID:
+        case StripSubdetector::TEC:
+          isStrip = true;
+          break;
+      }
+    }
+
+    if (isPixel && isStrip) {
+      edm::LogError("SectorBuilder")
+          << "Incorrect Sector Definition: there are pixel and strip modules within one sector"
+          << "\n... sector selection is not applied, sector " << sectorCounter << " is not built";
+      continue;
+    }
+    tkSector.isPixel = isPixel;
+
+    m_tkSector_[sectorCounter] = tkSector;
+    edm::LogInfo("SectorBuilder") << "There are " << tkSector.v_rawId.size() << " Modules in Sector " << sectorCounter;
   }
   this->statistics(allSectors, nModules);
   return;
 }
 
-
-
 // -----------------------------------------------------------------------------------------------------------
 
-
-bool
-ApeEstimator::checkIntervalsForSectors(const unsigned int sectorCounter, const std::vector<double>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  if(v_id.size()%2==1){
-    edm::LogError("SectorBuilder")<<"Incorrect Sector Definition: Position Vectors need even number of arguments (Intervals)"
-                                     <<"\n... sector selection is not applied, sector "<<sectorCounter<<" is not built";
+bool ApeEstimator::checkIntervalsForSectors(const unsigned int sectorCounter, const std::vector<double>& v_id) const {
+  if (v_id.empty())
+    return true;
+  if (v_id.size() % 2 == 1) {
+    edm::LogError("SectorBuilder")
+        << "Incorrect Sector Definition: Position Vectors need even number of arguments (Intervals)"
+        << "\n... sector selection is not applied, sector " << sectorCounter << " is not built";
     return false;
   }
-  int entry(0); double intervalBegin(999.);
-  for(auto const & i_id : v_id){
+  int entry(0);
+  double intervalBegin(999.);
+  for (auto const& i_id : v_id) {
     ++entry;
-    if(entry%2==1) intervalBegin = i_id;
-    if(entry%2==0 && intervalBegin > i_id){
-      edm::LogError("SectorBuilder")<<"Incorrect Sector Definition (Position Vector Intervals): \t"
-                                    <<intervalBegin<<" is bigger than "<<i_id<<" but is expected to be smaller"
-                                    <<"\n... sector selection is not applied, sector "<<sectorCounter<<" is not built";
+    if (entry % 2 == 1)
+      intervalBegin = i_id;
+    if (entry % 2 == 0 && intervalBegin > i_id) {
+      edm::LogError("SectorBuilder") << "Incorrect Sector Definition (Position Vector Intervals): \t" << intervalBegin
+                                     << " is bigger than " << i_id << " but is expected to be smaller"
+                                     << "\n... sector selection is not applied, sector " << sectorCounter
+                                     << " is not built";
       return false;
     }
   }
   return true;
 }
 
-bool
-ApeEstimator::checkModuleIds(const unsigned int id, const std::vector<unsigned int>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  for(auto const & i_id : v_id){
-    if(id==i_id)return true;
+bool ApeEstimator::checkModuleIds(const unsigned int id, const std::vector<unsigned int>& v_id) const {
+  if (v_id.empty())
+    return true;
+  for (auto const& i_id : v_id) {
+    if (id == i_id)
+      return true;
   }
   return false;
 }
 
-bool
-ApeEstimator::checkModuleBools(const bool id, const std::vector<unsigned int>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  for(auto const & i_id : v_id){
-    if(1==i_id && id)return true;
-    if(2==i_id && !id)return true;
+bool ApeEstimator::checkModuleBools(const bool id, const std::vector<unsigned int>& v_id) const {
+  if (v_id.empty())
+    return true;
+  for (auto const& i_id : v_id) {
+    if (1 == i_id && id)
+      return true;
+    if (2 == i_id && !id)
+      return true;
   }
   return false;
 }
 
-bool
-ApeEstimator::checkModuleDirections(const int id, const std::vector<int>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  for(auto const & i_id : v_id){
-    if(id==i_id)return true;
+bool ApeEstimator::checkModuleDirections(const int id, const std::vector<int>& v_id) const {
+  if (v_id.empty())
+    return true;
+  for (auto const& i_id : v_id) {
+    if (id == i_id)
+      return true;
   }
   return false;
 }
 
-bool
-ApeEstimator::checkModulePositions(const float id, const std::vector<double>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  int entry(0); double intervalBegin(999.);
-  for(auto const & i_id : v_id){
+bool ApeEstimator::checkModulePositions(const float id, const std::vector<double>& v_id) const {
+  if (v_id.empty())
+    return true;
+  int entry(0);
+  double intervalBegin(999.);
+  for (auto const& i_id : v_id) {
     ++entry;
-    if(entry%2==1)intervalBegin = i_id;
-    if(entry%2==0 && id>=intervalBegin && id<i_id)return true;
+    if (entry % 2 == 1)
+      intervalBegin = i_id;
+    if (entry % 2 == 0 && id >= intervalBegin && id < i_id)
+      return true;
   }
   return false;
 }
 
-void
-ApeEstimator::statistics(const TrackerSectorStruct& allSectors, const int nModules)const{
+void ApeEstimator::statistics(const TrackerSectorStruct& allSectors, const int nModules) const {
   bool commonModules(false);
-  for(std::map<unsigned int,TrackerSectorStruct>::const_iterator i_sector = m_tkSector_.begin(); i_sector != m_tkSector_.end(); ++i_sector){
-    std::map<unsigned int,TrackerSectorStruct>::const_iterator i_sector2(i_sector);
-    for(++i_sector2; i_sector2 != m_tkSector_.end(); ++i_sector2){
+  for (std::map<unsigned int, TrackerSectorStruct>::const_iterator i_sector = m_tkSector_.begin();
+       i_sector != m_tkSector_.end();
+       ++i_sector) {
+    std::map<unsigned int, TrackerSectorStruct>::const_iterator i_sector2(i_sector);
+    for (++i_sector2; i_sector2 != m_tkSector_.end(); ++i_sector2) {
       unsigned int nCommonModules(0);
-      for(auto const & i_module : (*i_sector).second.v_rawId){
-        for(auto const & i_module2 : (*i_sector2).second.v_rawId){
-          if(i_module2 == i_module) ++nCommonModules;
+      for (auto const& i_module : (*i_sector).second.v_rawId) {
+        for (auto const& i_module2 : (*i_sector2).second.v_rawId) {
+          if (i_module2 == i_module)
+            ++nCommonModules;
         }
       }
-      if(nCommonModules==0)
-        ;//edm::LogInfo("SectorBuilder")<<"Sector "<<(*i_sector).first<<" and Sector "<<(*i_sector2).first<< " have ZERO Modules in common";
-      else{
-        edm::LogError("SectorBuilder")<<"Sector "<<(*i_sector).first<<" and Sector "<<(*i_sector2).first<< " have "<<nCommonModules<<" Modules in common";
+      if (nCommonModules == 0)
+        ;  //edm::LogInfo("SectorBuilder")<<"Sector "<<(*i_sector).first<<" and Sector "<<(*i_sector2).first<< " have ZERO Modules in common";
+      else {
+        edm::LogError("SectorBuilder") << "Sector " << (*i_sector).first << " and Sector " << (*i_sector2).first
+                                       << " have " << nCommonModules << " Modules in common";
         commonModules = true;
       }
     }
   }
-  if(static_cast<int>(allSectors.v_rawId.size())==nModules)
-    edm::LogInfo("SectorBuilder")<<"ALL Tracker Modules are contained in the Sectors";
+  if (static_cast<int>(allSectors.v_rawId.size()) == nModules)
+    edm::LogInfo("SectorBuilder") << "ALL Tracker Modules are contained in the Sectors";
   else
-    edm::LogWarning("SectorBuilder")<<"There are "<<allSectors.v_rawId.size()<<" Modules in all Sectors"
-                               <<" out of "<<nModules<<" Tracker Modules";
-  if(!commonModules)
-    edm::LogInfo("SectorBuilder")<<"There are ZERO modules associated to different sectors, no ambiguities exist";
+    edm::LogWarning("SectorBuilder") << "There are " << allSectors.v_rawId.size() << " Modules in all Sectors"
+                                     << " out of " << nModules << " Tracker Modules";
+  if (!commonModules)
+    edm::LogInfo("SectorBuilder") << "There are ZERO modules associated to different sectors, no ambiguities exist";
   else
-  edm::LogError("SectorBuilder")<<"There are modules associated to different sectors, APE value cannot be assigned reasonably";
+    edm::LogError("SectorBuilder")
+        << "There are modules associated to different sectors, APE value cannot be assigned reasonably";
 }
-
 
 // -----------------------------------------------------------------------------------------------------------
 
-
-void
-ApeEstimator::residualErrorBinning(){
+void ApeEstimator::residualErrorBinning() {
   std::vector<double> v_residualErrorBinning(parameterSet_.getParameter<std::vector<double> >("residualErrorBinning"));
-  if(v_residualErrorBinning.size()==1){
-    edm::LogError("ResidualErrorBinning")<<"Incorrect selection of Residual Error Bins (used for APE calculation): \t"
-                                        <<"Only one argument passed, so no interval is specified"
-          <<"\n... delete whole bin selection";    //m_resErrBins_ remains empty
+  if (v_residualErrorBinning.size() == 1) {
+    edm::LogError("ResidualErrorBinning") << "Incorrect selection of Residual Error Bins (used for APE calculation): \t"
+                                          << "Only one argument passed, so no interval is specified"
+                                          << "\n... delete whole bin selection";  //m_resErrBins_ remains empty
     return;
   }
   double xMin(0.), xMax(0.);
   unsigned int binCounter(-1);
-  for(auto const & i_binning : v_residualErrorBinning){
+  for (auto const& i_binning : v_residualErrorBinning) {
     ++binCounter;
-    if(binCounter == 0){
-        xMin = i_binning;
-        continue;
+    if (binCounter == 0) {
+      xMin = i_binning;
+      continue;
     }
     xMax = i_binning;
-    if(xMax<=xMin){
-      edm::LogError("ResidualErrorBinning")<<"Incorrect selection of Residual Error Bins (used for APE calculation): \t"
-                                            <<xMin<<" is bigger than "<<xMax<<" but is expected to be smaller"
-              <<"\n... delete whole bin selection";
+    if (xMax <= xMin) {
+      edm::LogError("ResidualErrorBinning")
+          << "Incorrect selection of Residual Error Bins (used for APE calculation): \t" << xMin << " is bigger than "
+          << xMax << " but is expected to be smaller"
+          << "\n... delete whole bin selection";
       m_resErrBins_.clear();
       return;
     }
@@ -562,576 +582,880 @@ ApeEstimator::residualErrorBinning(){
     m_resErrBins_[binCounter].second = xMax;
     xMin = xMax;
   }
-  edm::LogInfo("ResidualErrorBinning")<<m_resErrBins_.size()<<" Intervals of residual errors used for separate APE calculation sucessfully set";
+  edm::LogInfo("ResidualErrorBinning")
+      << m_resErrBins_.size() << " Intervals of residual errors used for separate APE calculation sucessfully set";
 }
-
-
 
 // -----------------------------------------------------------------------------------------------------------
 
-
-
-void
-ApeEstimator::bookSectorHistsForAnalyzerMode(){
+void ApeEstimator::bookSectorHistsForAnalyzerMode() {
   std::vector<unsigned int> v_errHists(parameterSet_.getParameter<std::vector<unsigned int> >("vErrHists"));
-  for(std::vector<unsigned int>::iterator i_errHists = v_errHists.begin(); i_errHists != v_errHists.end(); ++i_errHists){
-    for(std::vector<unsigned int>::iterator i_errHists2 = i_errHists; i_errHists2 != v_errHists.end();){
+  for (std::vector<unsigned int>::iterator i_errHists = v_errHists.begin(); i_errHists != v_errHists.end();
+       ++i_errHists) {
+    for (std::vector<unsigned int>::iterator i_errHists2 = i_errHists; i_errHists2 != v_errHists.end();) {
       ++i_errHists2;
-      if(*i_errHists==*i_errHists2){
-        edm::LogError("BookSectorHists")<<"Value of vErrHists in config exists twice: "<<*i_errHists<<"\n... delete one of both";
+      if (*i_errHists == *i_errHists2) {
+        edm::LogError("BookSectorHists") << "Value of vErrHists in config exists twice: " << *i_errHists
+                                         << "\n... delete one of both";
         v_errHists.erase(i_errHists2);
       }
     }
   }
-  
-  
-  for(auto & i_sector : m_tkSector_){
+
+  for (auto& i_sector : m_tkSector_) {
     bool zoomHists(parameterSet_.getParameter<bool>("zoomHists"));
-    
+
     double widthMax = zoomHists ? 20. : 200.;
     double chargePixelMax = zoomHists ? 200000. : 2000000.;
     double chargeStripMax = zoomHists ? 1000. : 10000.;
     double sOverNMax = zoomHists ? 200. : 2000.;
     double logClusterProbMin = zoomHists ? -5. : -15.;
-    
+
     double resXAbsMax = zoomHists ? 0.5 : 5.;
     double norResXAbsMax = zoomHists ? 10. : 50.;
-    double probXMin = zoomHists ? -0.01 :  -0.1;
-    double probXMax = zoomHists ? 0.11 :  1.1;
+    double probXMin = zoomHists ? -0.01 : -0.1;
+    double probXMax = zoomHists ? 0.11 : 1.1;
     double sigmaXMin = zoomHists ? 0. : -0.05;
     double sigmaXMax = zoomHists ? 0.02 : 1.;
-    double sigmaX2Max = sigmaXMax*sigmaXMax;
+    double sigmaX2Max = sigmaXMax * sigmaXMax;
     double sigmaXHitMax = zoomHists ? 0.02 : 1.;
     double phiSensXMax = zoomHists ? 31. : 93.;
-    
+
     double norChi2Max = zoomHists ? 5. : 1000.;
     double d0Max = zoomHists ? 0.02 : 40.;  // cosmics: 100.|100.
     double dzMax = zoomHists ? 15. : 100.;  // cosmics: 200.|600.
     double pMax = zoomHists ? 200. : 2000.;
-    double invPMax = zoomHists ? 0.05 : 10.;   //begins at 20GeV, 0.1GeV
-    
-    
+    double invPMax = zoomHists ? 0.05 : 10.;  //begins at 20GeV, 0.1GeV
+
     edm::Service<TFileService> fileService;
-    if(!fileService){
-      throw edm::Exception( edm::errors::Configuration,
-                            "TFileService is not registered in cfg file" );
+    if (!fileService) {
+      throw edm::Exception(edm::errors::Configuration, "TFileService is not registered in cfg file");
     }
-    
-    std::stringstream sector; sector << "Sector_" << i_sector.first;
+
+    std::stringstream sector;
+    sector << "Sector_" << i_sector.first;
     TFileDirectory secDir = fileService->mkdir(sector.str());
-    
+
     // Dummy histo containing the sector name as title
-    i_sector.second.Name = secDir.make<TH1F>("z_name",i_sector.second.name.c_str(),1,0,1);
-    
+    i_sector.second.Name = secDir.make<TH1F>("z_name", i_sector.second.name.c_str(), 1, 0, 1);
+
     // Do not book histos for empty sectors
-    if(i_sector.second.v_rawId.empty()){
+    if (i_sector.second.v_rawId.empty()) {
       continue;
     }
     // Set parameters for correlationHists
-    i_sector.second.setCorrHistParams(&secDir,norResXAbsMax,sigmaXHitMax,sigmaXMax);
-    
-    
+    i_sector.second.setCorrHistParams(&secDir, norResXAbsMax, sigmaXHitMax, sigmaXMax);
+
     // Book pixel or strip specific hists
     const bool pixelSector(i_sector.second.isPixel);
-    
-    
+
     // Cluster Parameters
-    i_sector.second.m_correlationHistsX["WidthX"] = i_sector.second.bookCorrHistsX("WidthX","cluster width","w_{cl,x}","[# channels]",static_cast<int>(widthMax),static_cast<int>(widthMax),0.,widthMax,"nph");
-    i_sector.second.m_correlationHistsX["BaryStripX"] = i_sector.second.bookCorrHistsX("BaryStripX","barycenter of cluster charge","b_{cl,x}","[# channels]",800,100,-10.,790.,"nph");
-    
-    if(pixelSector){
-      i_sector.second.m_correlationHistsY["WidthY"] = i_sector.second.bookCorrHistsY("WidthY","cluster width","w_{cl,y}","[# channels]",static_cast<int>(widthMax),static_cast<int>(widthMax),0.,widthMax,"nph");
-      i_sector.second.m_correlationHistsY["BaryStripY"] = i_sector.second.bookCorrHistsY("BaryStripY","barycenter of cluster charge","b_{cl,y}","[# channels]",800,100,-10.,790.,"nph");
-      
-      i_sector.second.m_correlationHistsX["ChargePixel"] = i_sector.second.bookCorrHistsX("ChargePixel","cluster charge","c_{cl}","[e]",100,50,0.,chargePixelMax,"nph");
-      i_sector.second.m_correlationHistsX["ClusterProbXY"] = i_sector.second.bookCorrHistsX("ClusterProbXY","cluster probability xy","prob_{cl,xy}","",100,50,0.,1.,"nph");
-      i_sector.second.m_correlationHistsX["ClusterProbQ"] = i_sector.second.bookCorrHistsX("ClusterProbQ","cluster probability q","prob_{cl,q}","",100,50,0.,1.,"nph");
-      i_sector.second.m_correlationHistsX["ClusterProbXYQ"] = i_sector.second.bookCorrHistsX("ClusterProbXYQ","cluster probability xyq","prob_{cl,xyq}","",100,50,0.,1.,"nph");
-      i_sector.second.m_correlationHistsX["LogClusterProb"] = i_sector.second.bookCorrHistsX("LogClusterProb","cluster probability xy","log(prob_{cl,xy})","",60,30,logClusterProbMin,0.,"nph");
-      i_sector.second.m_correlationHistsX["IsOnEdge"] = i_sector.second.bookCorrHistsX("IsOnEdge","IsOnEdge","isOnEdge","",2,2,0,2,"nph");
-      i_sector.second.m_correlationHistsX["HasBadPixels"] = i_sector.second.bookCorrHistsX("HasBadPixels","HasBadPixels","hasBadPixels","",2,2,0,2,"nph");
-      i_sector.second.m_correlationHistsX["SpansTwoRoc"] = i_sector.second.bookCorrHistsX("SpansTwoRoc","SpansTwoRoc","spansTwoRoc","",2,2,0,2,"nph");
-      i_sector.second.m_correlationHistsX["QBin"] = i_sector.second.bookCorrHistsX("QBin","q bin","q bin","",8,8,0,8,"nph");
-      
-      i_sector.second.m_correlationHistsY["ChargePixel"] = i_sector.second.bookCorrHistsY("ChargePixel","cluster charge","c_{cl}","[e]",100,50,0.,chargePixelMax,"nph");
-      i_sector.second.m_correlationHistsY["ClusterProbXY"] = i_sector.second.bookCorrHistsY("ClusterProbXY","cluster probability xy","prob_{cl,xy}","",100,50,0.,1.,"nph");
-      i_sector.second.m_correlationHistsY["ClusterProbQ"] = i_sector.second.bookCorrHistsY("ClusterProbQ","cluster probability q","prob_{cl,q}","",100,50,0.,1.,"nph");
-      i_sector.second.m_correlationHistsY["ClusterProbXYQ"] = i_sector.second.bookCorrHistsY("ClusterProbXYQ","cluster probability xyq","prob_{cl,xyq}","",100,50,0.,1.,"nph");
-      i_sector.second.m_correlationHistsY["LogClusterProb"] = i_sector.second.bookCorrHistsY("LogClusterProb","cluster probability xy","log(prob_{cl,xy})","",60,30,logClusterProbMin,0.,"nph");
-      i_sector.second.m_correlationHistsY["IsOnEdge"] = i_sector.second.bookCorrHistsY("IsOnEdge","IsOnEdge","isOnEdge","",2,2,0,2,"nph");
-      i_sector.second.m_correlationHistsY["HasBadPixels"] = i_sector.second.bookCorrHistsY("HasBadPixels","HasBadPixels","hasBadPixels","",2,2,0,2,"nph");
-      i_sector.second.m_correlationHistsY["SpansTwoRoc"] = i_sector.second.bookCorrHistsY("SpansTwoRoc","SpansTwoRoc","spansTwoRoc","",2,2,0,2,"nph");
-      i_sector.second.m_correlationHistsY["QBin"] = i_sector.second.bookCorrHistsY("QBin","q bin","q bin","",8,8,0,8,"nph");
+    i_sector.second.m_correlationHistsX["WidthX"] = i_sector.second.bookCorrHistsX("WidthX",
+                                                                                   "cluster width",
+                                                                                   "w_{cl,x}",
+                                                                                   "[# channels]",
+                                                                                   static_cast<int>(widthMax),
+                                                                                   static_cast<int>(widthMax),
+                                                                                   0.,
+                                                                                   widthMax,
+                                                                                   "nph");
+    i_sector.second.m_correlationHistsX["BaryStripX"] = i_sector.second.bookCorrHistsX(
+        "BaryStripX", "barycenter of cluster charge", "b_{cl,x}", "[# channels]", 800, 100, -10., 790., "nph");
+
+    if (pixelSector) {
+      i_sector.second.m_correlationHistsY["WidthY"] = i_sector.second.bookCorrHistsY("WidthY",
+                                                                                     "cluster width",
+                                                                                     "w_{cl,y}",
+                                                                                     "[# channels]",
+                                                                                     static_cast<int>(widthMax),
+                                                                                     static_cast<int>(widthMax),
+                                                                                     0.,
+                                                                                     widthMax,
+                                                                                     "nph");
+      i_sector.second.m_correlationHistsY["BaryStripY"] = i_sector.second.bookCorrHistsY(
+          "BaryStripY", "barycenter of cluster charge", "b_{cl,y}", "[# channels]", 800, 100, -10., 790., "nph");
+
+      i_sector.second.m_correlationHistsX["ChargePixel"] = i_sector.second.bookCorrHistsX(
+          "ChargePixel", "cluster charge", "c_{cl}", "[e]", 100, 50, 0., chargePixelMax, "nph");
+      i_sector.second.m_correlationHistsX["ClusterProbXY"] = i_sector.second.bookCorrHistsX(
+          "ClusterProbXY", "cluster probability xy", "prob_{cl,xy}", "", 100, 50, 0., 1., "nph");
+      i_sector.second.m_correlationHistsX["ClusterProbQ"] = i_sector.second.bookCorrHistsX(
+          "ClusterProbQ", "cluster probability q", "prob_{cl,q}", "", 100, 50, 0., 1., "nph");
+      i_sector.second.m_correlationHistsX["ClusterProbXYQ"] = i_sector.second.bookCorrHistsX(
+          "ClusterProbXYQ", "cluster probability xyq", "prob_{cl,xyq}", "", 100, 50, 0., 1., "nph");
+      i_sector.second.m_correlationHistsX["LogClusterProb"] = i_sector.second.bookCorrHistsX(
+          "LogClusterProb", "cluster probability xy", "log(prob_{cl,xy})", "", 60, 30, logClusterProbMin, 0., "nph");
+      i_sector.second.m_correlationHistsX["IsOnEdge"] =
+          i_sector.second.bookCorrHistsX("IsOnEdge", "IsOnEdge", "isOnEdge", "", 2, 2, 0, 2, "nph");
+      i_sector.second.m_correlationHistsX["HasBadPixels"] =
+          i_sector.second.bookCorrHistsX("HasBadPixels", "HasBadPixels", "hasBadPixels", "", 2, 2, 0, 2, "nph");
+      i_sector.second.m_correlationHistsX["SpansTwoRoc"] =
+          i_sector.second.bookCorrHistsX("SpansTwoRoc", "SpansTwoRoc", "spansTwoRoc", "", 2, 2, 0, 2, "nph");
+      i_sector.second.m_correlationHistsX["QBin"] =
+          i_sector.second.bookCorrHistsX("QBin", "q bin", "q bin", "", 8, 8, 0, 8, "nph");
+
+      i_sector.second.m_correlationHistsY["ChargePixel"] = i_sector.second.bookCorrHistsY(
+          "ChargePixel", "cluster charge", "c_{cl}", "[e]", 100, 50, 0., chargePixelMax, "nph");
+      i_sector.second.m_correlationHistsY["ClusterProbXY"] = i_sector.second.bookCorrHistsY(
+          "ClusterProbXY", "cluster probability xy", "prob_{cl,xy}", "", 100, 50, 0., 1., "nph");
+      i_sector.second.m_correlationHistsY["ClusterProbQ"] = i_sector.second.bookCorrHistsY(
+          "ClusterProbQ", "cluster probability q", "prob_{cl,q}", "", 100, 50, 0., 1., "nph");
+      i_sector.second.m_correlationHistsY["ClusterProbXYQ"] = i_sector.second.bookCorrHistsY(
+          "ClusterProbXYQ", "cluster probability xyq", "prob_{cl,xyq}", "", 100, 50, 0., 1., "nph");
+      i_sector.second.m_correlationHistsY["LogClusterProb"] = i_sector.second.bookCorrHistsY(
+          "LogClusterProb", "cluster probability xy", "log(prob_{cl,xy})", "", 60, 30, logClusterProbMin, 0., "nph");
+      i_sector.second.m_correlationHistsY["IsOnEdge"] =
+          i_sector.second.bookCorrHistsY("IsOnEdge", "IsOnEdge", "isOnEdge", "", 2, 2, 0, 2, "nph");
+      i_sector.second.m_correlationHistsY["HasBadPixels"] =
+          i_sector.second.bookCorrHistsY("HasBadPixels", "HasBadPixels", "hasBadPixels", "", 2, 2, 0, 2, "nph");
+      i_sector.second.m_correlationHistsY["SpansTwoRoc"] =
+          i_sector.second.bookCorrHistsY("SpansTwoRoc", "SpansTwoRoc", "spansTwoRoc", "", 2, 2, 0, 2, "nph");
+      i_sector.second.m_correlationHistsY["QBin"] =
+          i_sector.second.bookCorrHistsY("QBin", "q bin", "q bin", "", 8, 8, 0, 8, "nph");
     }
-    
-    else{
-      i_sector.second.m_correlationHistsX["ChargeStrip"] = i_sector.second.bookCorrHistsX("ChargeStrip","cluster charge","c_{cl}","[APV counts]",100,50,0.,chargeStripMax,"nph");
-      i_sector.second.m_correlationHistsX["MaxStrip"] = i_sector.second.bookCorrHistsX("MaxStrip","strip with max. charge","n_{cl,max}","[# strips]",800,800,-10.,790.,"npht");
-      i_sector.second.m_correlationHistsX["MaxCharge"] = i_sector.second.bookCorrHistsX("MaxCharge","charge of strip with max. charge","c_{cl,max}","[APV counts]",300,75,-10.,290.,"nph");
-      i_sector.second.m_correlationHistsX["MaxIndex"] = i_sector.second.bookCorrHistsX("MaxIndex","cluster-index of strip with max. charge","i_{cl,max}","[# strips]",10,10,0.,10.,"nph");
-      i_sector.second.m_correlationHistsX["ChargeOnEdges"] = i_sector.second.bookCorrHistsX("ChargeOnEdges","fraction of charge on edge strips","(c_{st,L}+c_{st,R})/c_{cl}","",60,60,-0.1,1.1,"nph");
-      i_sector.second.m_correlationHistsX["ChargeAsymmetry"] = i_sector.second.bookCorrHistsX("ChargeAsymmetry","asymmetry of charge on edge strips","(c_{st,L}-c_{st,R})/c_{cl}","",110,55,-1.1,1.1,"nph");
-      i_sector.second.m_correlationHistsX["ChargeLRplus"] = i_sector.second.bookCorrHistsX("ChargeLRplus","fraction of charge not on maxStrip","(c_{cl,L}+c_{cl,R})/c_{cl}","",60,60,-0.1,1.1,"nph");
-      i_sector.second.m_correlationHistsX["ChargeLRminus"] = i_sector.second.bookCorrHistsX("ChargeLRminus","asymmetry of charge L and R of maxStrip","(c_{cl,L}-c_{cl,R})/c_{cl}","",110,55,-1.1,1.1,"nph");
-      i_sector.second.m_correlationHistsX["SOverN"] = i_sector.second.bookCorrHistsX("SOverN","signal over noise","s/N","",100,50,0,sOverNMax,"nph");
-      i_sector.second.m_correlationHistsX["WidthProj"] = i_sector.second.bookCorrHistsX("WidthProj","projected width","w_{p}","[# strips]",200,20,0.,widthMax,"nph");
-      i_sector.second.m_correlationHistsX["WidthDiff"] = i_sector.second.bookCorrHistsX("WidthDiff","width difference","w_{p} - w_{cl}","[# strips]",200,20,-widthMax/2.,widthMax/2.,"nph");
-      
-      i_sector.second.WidthVsWidthProjected = secDir.make<TH2F>("h2_widthVsWidthProj","w_{cl} vs. w_{p};w_{p}  [# strips];w_{cl}  [# strips]",static_cast<int>(widthMax),0,widthMax,static_cast<int>(widthMax),0,widthMax);
-      i_sector.second.PWidthVsWidthProjected = secDir.make<TProfile>("p_widthVsWidthProj","w_{cl} vs. w_{p};w_{p}  [# strips];w_{cl}  [# strips]",static_cast<int>(widthMax),0,widthMax);
-      
-      i_sector.second.WidthDiffVsMaxStrip = secDir.make<TH2F>("h2_widthDiffVsMaxStrip","(w_{p} - w_{cl}) vs. n_{cl,max};n_{cl,max};w_{p} - w_{cl}  [# strips]",800,-10.,790.,static_cast<int>(widthMax),-widthMax/2.,widthMax/2.);
-      i_sector.second.PWidthDiffVsMaxStrip = secDir.make<TProfile>("p_widthDiffVsMaxStrip","(w_{p} - w_{cl}) vs. n_{cl,max};n_{cl,max};w_{p} - w_{cl}  [# strips]",800,-10.,790.);
-      
-      i_sector.second.WidthDiffVsSigmaXHit = secDir.make<TH2F>("h2_widthDiffVsSigmaXHit","(w_{p} - w_{cl}) vs. #sigma_{hit,x};#sigma_{hit,x}  [cm];w_{p} - w_{cl}  [# strips]",100,0.,sigmaXMax,100,-10.,10.);
-      i_sector.second.PWidthDiffVsSigmaXHit = secDir.make<TProfile>("p_widthDiffVsSigmaXHit","(w_{p} - w_{cl}) vs. #sigma_{hit,x};#sigma_{hit,x}  [cm];w_{p} - w_{cl}  [# strips]",100,0.,sigmaXMax);
-      
-      i_sector.second.WidthVsPhiSensX = secDir.make<TH2F>("h2_widthVsPhiSensX","w_{cl} vs. #phi_{module,x};#phi_{module,x}  [ ^{o}];w_{cl}  [# strips]",93,-93,93,static_cast<int>(widthMax),0,widthMax);
-      i_sector.second.PWidthVsPhiSensX = secDir.make<TProfile>("p_widthVsPhiSensX","w_{cl} vs. #phi_{module,x};#phi_{module,x}  [ ^{o}];w_{cl}  [# strips]",93,-93,93);
+
+    else {
+      i_sector.second.m_correlationHistsX["ChargeStrip"] = i_sector.second.bookCorrHistsX(
+          "ChargeStrip", "cluster charge", "c_{cl}", "[APV counts]", 100, 50, 0., chargeStripMax, "nph");
+      i_sector.second.m_correlationHistsX["MaxStrip"] = i_sector.second.bookCorrHistsX(
+          "MaxStrip", "strip with max. charge", "n_{cl,max}", "[# strips]", 800, 800, -10., 790., "npht");
+      i_sector.second.m_correlationHistsX["MaxCharge"] = i_sector.second.bookCorrHistsX(
+          "MaxCharge", "charge of strip with max. charge", "c_{cl,max}", "[APV counts]", 300, 75, -10., 290., "nph");
+      i_sector.second.m_correlationHistsX["MaxIndex"] = i_sector.second.bookCorrHistsX(
+          "MaxIndex", "cluster-index of strip with max. charge", "i_{cl,max}", "[# strips]", 10, 10, 0., 10., "nph");
+      i_sector.second.m_correlationHistsX["ChargeOnEdges"] =
+          i_sector.second.bookCorrHistsX("ChargeOnEdges",
+                                         "fraction of charge on edge strips",
+                                         "(c_{st,L}+c_{st,R})/c_{cl}",
+                                         "",
+                                         60,
+                                         60,
+                                         -0.1,
+                                         1.1,
+                                         "nph");
+      i_sector.second.m_correlationHistsX["ChargeAsymmetry"] =
+          i_sector.second.bookCorrHistsX("ChargeAsymmetry",
+                                         "asymmetry of charge on edge strips",
+                                         "(c_{st,L}-c_{st,R})/c_{cl}",
+                                         "",
+                                         110,
+                                         55,
+                                         -1.1,
+                                         1.1,
+                                         "nph");
+      i_sector.second.m_correlationHistsX["ChargeLRplus"] =
+          i_sector.second.bookCorrHistsX("ChargeLRplus",
+                                         "fraction of charge not on maxStrip",
+                                         "(c_{cl,L}+c_{cl,R})/c_{cl}",
+                                         "",
+                                         60,
+                                         60,
+                                         -0.1,
+                                         1.1,
+                                         "nph");
+      i_sector.second.m_correlationHistsX["ChargeLRminus"] =
+          i_sector.second.bookCorrHistsX("ChargeLRminus",
+                                         "asymmetry of charge L and R of maxStrip",
+                                         "(c_{cl,L}-c_{cl,R})/c_{cl}",
+                                         "",
+                                         110,
+                                         55,
+                                         -1.1,
+                                         1.1,
+                                         "nph");
+      i_sector.second.m_correlationHistsX["SOverN"] =
+          i_sector.second.bookCorrHistsX("SOverN", "signal over noise", "s/N", "", 100, 50, 0, sOverNMax, "nph");
+      i_sector.second.m_correlationHistsX["WidthProj"] = i_sector.second.bookCorrHistsX(
+          "WidthProj", "projected width", "w_{p}", "[# strips]", 200, 20, 0., widthMax, "nph");
+      i_sector.second.m_correlationHistsX["WidthDiff"] = i_sector.second.bookCorrHistsX("WidthDiff",
+                                                                                        "width difference",
+                                                                                        "w_{p} - w_{cl}",
+                                                                                        "[# strips]",
+                                                                                        200,
+                                                                                        20,
+                                                                                        -widthMax / 2.,
+                                                                                        widthMax / 2.,
+                                                                                        "nph");
+
+      i_sector.second.WidthVsWidthProjected = secDir.make<TH2F>("h2_widthVsWidthProj",
+                                                                "w_{cl} vs. w_{p};w_{p}  [# strips];w_{cl}  [# strips]",
+                                                                static_cast<int>(widthMax),
+                                                                0,
+                                                                widthMax,
+                                                                static_cast<int>(widthMax),
+                                                                0,
+                                                                widthMax);
+      i_sector.second.PWidthVsWidthProjected =
+          secDir.make<TProfile>("p_widthVsWidthProj",
+                                "w_{cl} vs. w_{p};w_{p}  [# strips];w_{cl}  [# strips]",
+                                static_cast<int>(widthMax),
+                                0,
+                                widthMax);
+
+      i_sector.second.WidthDiffVsMaxStrip =
+          secDir.make<TH2F>("h2_widthDiffVsMaxStrip",
+                            "(w_{p} - w_{cl}) vs. n_{cl,max};n_{cl,max};w_{p} - w_{cl}  [# strips]",
+                            800,
+                            -10.,
+                            790.,
+                            static_cast<int>(widthMax),
+                            -widthMax / 2.,
+                            widthMax / 2.);
+      i_sector.second.PWidthDiffVsMaxStrip =
+          secDir.make<TProfile>("p_widthDiffVsMaxStrip",
+                                "(w_{p} - w_{cl}) vs. n_{cl,max};n_{cl,max};w_{p} - w_{cl}  [# strips]",
+                                800,
+                                -10.,
+                                790.);
+
+      i_sector.second.WidthDiffVsSigmaXHit =
+          secDir.make<TH2F>("h2_widthDiffVsSigmaXHit",
+                            "(w_{p} - w_{cl}) vs. #sigma_{hit,x};#sigma_{hit,x}  [cm];w_{p} - w_{cl}  [# strips]",
+                            100,
+                            0.,
+                            sigmaXMax,
+                            100,
+                            -10.,
+                            10.);
+      i_sector.second.PWidthDiffVsSigmaXHit =
+          secDir.make<TProfile>("p_widthDiffVsSigmaXHit",
+                                "(w_{p} - w_{cl}) vs. #sigma_{hit,x};#sigma_{hit,x}  [cm];w_{p} - w_{cl}  [# strips]",
+                                100,
+                                0.,
+                                sigmaXMax);
+
+      i_sector.second.WidthVsPhiSensX =
+          secDir.make<TH2F>("h2_widthVsPhiSensX",
+                            "w_{cl} vs. #phi_{module,x};#phi_{module,x}  [ ^{o}];w_{cl}  [# strips]",
+                            93,
+                            -93,
+                            93,
+                            static_cast<int>(widthMax),
+                            0,
+                            widthMax);
+      i_sector.second.PWidthVsPhiSensX = secDir.make<TProfile>(
+          "p_widthVsPhiSensX", "w_{cl} vs. #phi_{module,x};#phi_{module,x}  [ ^{o}];w_{cl}  [# strips]", 93, -93, 93);
     }
-    
-    
+
     // Hit Parameters (transform errors and residuals from [cm] in [mum])
-    i_sector.second.m_correlationHistsX["SigmaXHit"] = i_sector.second.bookCorrHistsX("SigmaXHit","hit error","#sigma_{hit,x}","[#mum]",105,20,sigmaXMin*10000.,sigmaXMax*10000.,"np");
-    i_sector.second.m_correlationHistsX["SigmaXTrk"] = i_sector.second.bookCorrHistsX("SigmaXTrk","track error","#sigma_{trk,x}","[#mum]",105,20,sigmaXMin*10000.,sigmaXMax*10000.,"np");
-    i_sector.second.m_correlationHistsX["SigmaX"]    = i_sector.second.bookCorrHistsX("SigmaX","residual error","#sigma_{r,x}","[#mum]",105,20,sigmaXMin*10000.,sigmaXMax*10000.,"np");
-    i_sector.second.m_correlationHistsX["PhiSens"]   = i_sector.second.bookCorrHistsX("PhiSens","track angle on sensor","#phi_{module}","[ ^{o}]",96,48,-3,93,"nphtr");
-    i_sector.second.m_correlationHistsX["PhiSensX"]  = i_sector.second.bookCorrHistsX("PhiSensX","track angle on sensor","#phi_{module,x}","[ ^{o}]",186,93,-phiSensXMax,phiSensXMax,"nphtr");
-    i_sector.second.m_correlationHistsX["PhiSensY"]  = i_sector.second.bookCorrHistsX("PhiSensY","track angle on sensor","#phi_{module,y}","[ ^{o}]",186,93,-93,93,"nphtr");
-    
-    i_sector.second.XHit    = secDir.make<TH1F>("h_XHit"," hit measurement x_{hit};x_{hit}  [cm];# hits",100,-20,20);
-    i_sector.second.XTrk    = secDir.make<TH1F>("h_XTrk","track prediction x_{trk};x_{trk}  [cm];# hits",100,-20,20);
-    i_sector.second.SigmaX2 = secDir.make<TH1F>("h_SigmaX2","squared residual error #sigma_{r,x}^{2};#sigma_{r,x}^{2}  [#mum^{2}];# hits",105,sigmaXMin*10000.,sigmaX2Max*10000.*10000.); //no mistake !
-    i_sector.second.ResX    = secDir.make<TH1F>("h_ResX","residual r_{x};x_{trk}-x_{hit}  [#mum];# hits",100,-resXAbsMax*10000.,resXAbsMax*10000.);
-    i_sector.second.NorResX = secDir.make<TH1F>("h_NorResX","normalized residual r_{x}/#sigma_{r,x};(x_{trk}-x_{hit})/#sigma_{r,x};# hits",100,-norResXAbsMax,norResXAbsMax);
-    i_sector.second.ProbX   = secDir.make<TH1F>("h_ProbX","residual probability;prob(r_{x}^{2}/#sigma_{r,x}^{2},1);# hits",60,probXMin,probXMax);
-    
-    i_sector.second.PhiSensXVsBarycentreX = secDir.make<TH2F>("h2_phiSensXVsBarycentreX","#phi_{module,x} vs. b_{cl,x};b_{cl,x}  [# channels];#phi_{module,x}  [ ^{o}]",200,-10.,790.,93,-93,93);
-    i_sector.second.PPhiSensXVsBarycentreX = secDir.make<TProfile>("p_phiSensXVsBarycentreX","#phi_{module,x} vs. b_{cl,x};b_{cl,x}  [# channels];#phi_{module,x}  [ ^{o}]",200,-10.,790.);
-    
-    if(pixelSector){
-      i_sector.second.m_correlationHistsY["SigmaYHit"] = i_sector.second.bookCorrHistsY("SigmaYHit","hit error","#sigma_{hit,y}","[#mum]",105,20,sigmaXMin*10000.,sigmaXMax*10000.,"np");
-      i_sector.second.m_correlationHistsY["SigmaYTrk"] = i_sector.second.bookCorrHistsY("SigmaYTrk","track error","#sigma_{trk,y}","[#mum]",105,20,sigmaXMin*10000.,sigmaXMax*10000.,"np");
-      i_sector.second.m_correlationHistsY["SigmaY"]    = i_sector.second.bookCorrHistsY("SigmaY","residual error","#sigma_{r,y}","[#mum]",105,20,sigmaXMin*10000.,sigmaXMax*10000.,"np");
-      i_sector.second.m_correlationHistsY["PhiSens"]   = i_sector.second.bookCorrHistsY("PhiSens","track angle on sensor","#phi_{module}","[ ^{o}]",96,48,-3,93,"nphtr");
-      i_sector.second.m_correlationHistsY["PhiSensX"]  = i_sector.second.bookCorrHistsY("PhiSensX","track angle on sensor","#phi_{module,x}","[ ^{o}]",186,93,-phiSensXMax,phiSensXMax,"nphtr");
-      i_sector.second.m_correlationHistsY["PhiSensY"]  = i_sector.second.bookCorrHistsY("PhiSensY","track angle on sensor","#phi_{module,y}","[ ^{o}]",186,93,-93,93,"nphtr");
-      
-      i_sector.second.YHit    = secDir.make<TH1F>("h_YHit"," hit measurement y_{hit};y_{hit}  [cm];# hits",100,-20,20);
-      i_sector.second.YTrk    = secDir.make<TH1F>("h_YTrk","track prediction y_{trk};y_{trk}  [cm];# hits",100,-20,20);
-      i_sector.second.SigmaY2 = secDir.make<TH1F>("h_SigmaY2","squared residual error #sigma_{r,y}^{2};#sigma_{r,y}^{2}  [#mum^{2}];# hits",105,sigmaXMin*10000.,sigmaX2Max*10000.*10000.); //no mistake !
-      i_sector.second.ResY    = secDir.make<TH1F>("h_ResY","residual r_{y};y_{trk}-y_{hit}  [#mum];# hits",100,-resXAbsMax*10000.,resXAbsMax*10000.);
-      i_sector.second.NorResY = secDir.make<TH1F>("h_NorResY","normalized residual r_{y}/#sigma_{r,y};(y_{trk}-y_{hit})/#sigma_{r,y};# hits",100,-norResXAbsMax,norResXAbsMax);
-      i_sector.second.ProbY   = secDir.make<TH1F>("h_ProbY","residual probability;prob(r_{y}^{2}/#sigma_{r,y}^{2},1);# hits",60,probXMin,probXMax);
-      
-      i_sector.second.PhiSensYVsBarycentreY = secDir.make<TH2F>("h2_phiSensYVsBarycentreY","#phi_{module,y} vs. b_{cl,y};b_{cl,y}  [# channels];#phi_{module,y}  [ ^{o}]",200,-10.,790.,93,-93,93);
-      i_sector.second.PPhiSensYVsBarycentreY = secDir.make<TProfile>("p_phiSensYVsBarycentreY","#phi_{module,y} vs. b_{cl,y};b_{cl,y}  [# channels];#phi_{module,y}  [ ^{o}]",200,-10.,790.);
+    i_sector.second.m_correlationHistsX["SigmaXHit"] = i_sector.second.bookCorrHistsX(
+        "SigmaXHit", "hit error", "#sigma_{hit,x}", "[#mum]", 105, 20, sigmaXMin * 10000., sigmaXMax * 10000., "np");
+    i_sector.second.m_correlationHistsX["SigmaXTrk"] = i_sector.second.bookCorrHistsX(
+        "SigmaXTrk", "track error", "#sigma_{trk,x}", "[#mum]", 105, 20, sigmaXMin * 10000., sigmaXMax * 10000., "np");
+    i_sector.second.m_correlationHistsX["SigmaX"] = i_sector.second.bookCorrHistsX(
+        "SigmaX", "residual error", "#sigma_{r,x}", "[#mum]", 105, 20, sigmaXMin * 10000., sigmaXMax * 10000., "np");
+    i_sector.second.m_correlationHistsX["PhiSens"] = i_sector.second.bookCorrHistsX(
+        "PhiSens", "track angle on sensor", "#phi_{module}", "[ ^{o}]", 96, 48, -3, 93, "nphtr");
+    i_sector.second.m_correlationHistsX["PhiSensX"] = i_sector.second.bookCorrHistsX(
+        "PhiSensX", "track angle on sensor", "#phi_{module,x}", "[ ^{o}]", 186, 93, -phiSensXMax, phiSensXMax, "nphtr");
+    i_sector.second.m_correlationHistsX["PhiSensY"] = i_sector.second.bookCorrHistsX(
+        "PhiSensY", "track angle on sensor", "#phi_{module,y}", "[ ^{o}]", 186, 93, -93, 93, "nphtr");
+
+    i_sector.second.XHit = secDir.make<TH1F>("h_XHit", " hit measurement x_{hit};x_{hit}  [cm];# hits", 100, -20, 20);
+    i_sector.second.XTrk = secDir.make<TH1F>("h_XTrk", "track prediction x_{trk};x_{trk}  [cm];# hits", 100, -20, 20);
+    i_sector.second.SigmaX2 =
+        secDir.make<TH1F>("h_SigmaX2",
+                          "squared residual error #sigma_{r,x}^{2};#sigma_{r,x}^{2}  [#mum^{2}];# hits",
+                          105,
+                          sigmaXMin * 10000.,
+                          sigmaX2Max * 10000. * 10000.);  //no mistake !
+    i_sector.second.ResX = secDir.make<TH1F>(
+        "h_ResX", "residual r_{x};x_{trk}-x_{hit}  [#mum];# hits", 100, -resXAbsMax * 10000., resXAbsMax * 10000.);
+    i_sector.second.NorResX =
+        secDir.make<TH1F>("h_NorResX",
+                          "normalized residual r_{x}/#sigma_{r,x};(x_{trk}-x_{hit})/#sigma_{r,x};# hits",
+                          100,
+                          -norResXAbsMax,
+                          norResXAbsMax);
+    i_sector.second.ProbX = secDir.make<TH1F>(
+        "h_ProbX", "residual probability;prob(r_{x}^{2}/#sigma_{r,x}^{2},1);# hits", 60, probXMin, probXMax);
+
+    i_sector.second.PhiSensXVsBarycentreX =
+        secDir.make<TH2F>("h2_phiSensXVsBarycentreX",
+                          "#phi_{module,x} vs. b_{cl,x};b_{cl,x}  [# channels];#phi_{module,x}  [ ^{o}]",
+                          200,
+                          -10.,
+                          790.,
+                          93,
+                          -93,
+                          93);
+    i_sector.second.PPhiSensXVsBarycentreX =
+        secDir.make<TProfile>("p_phiSensXVsBarycentreX",
+                              "#phi_{module,x} vs. b_{cl,x};b_{cl,x}  [# channels];#phi_{module,x}  [ ^{o}]",
+                              200,
+                              -10.,
+                              790.);
+
+    if (pixelSector) {
+      i_sector.second.m_correlationHistsY["SigmaYHit"] = i_sector.second.bookCorrHistsY(
+          "SigmaYHit", "hit error", "#sigma_{hit,y}", "[#mum]", 105, 20, sigmaXMin * 10000., sigmaXMax * 10000., "np");
+      i_sector.second.m_correlationHistsY["SigmaYTrk"] = i_sector.second.bookCorrHistsY(
+          "SigmaYTrk", "track error", "#sigma_{trk,y}", "[#mum]", 105, 20, sigmaXMin * 10000., sigmaXMax * 10000., "np");
+      i_sector.second.m_correlationHistsY["SigmaY"] = i_sector.second.bookCorrHistsY(
+          "SigmaY", "residual error", "#sigma_{r,y}", "[#mum]", 105, 20, sigmaXMin * 10000., sigmaXMax * 10000., "np");
+      i_sector.second.m_correlationHistsY["PhiSens"] = i_sector.second.bookCorrHistsY(
+          "PhiSens", "track angle on sensor", "#phi_{module}", "[ ^{o}]", 96, 48, -3, 93, "nphtr");
+      i_sector.second.m_correlationHistsY["PhiSensX"] = i_sector.second.bookCorrHistsY("PhiSensX",
+                                                                                       "track angle on sensor",
+                                                                                       "#phi_{module,x}",
+                                                                                       "[ ^{o}]",
+                                                                                       186,
+                                                                                       93,
+                                                                                       -phiSensXMax,
+                                                                                       phiSensXMax,
+                                                                                       "nphtr");
+      i_sector.second.m_correlationHistsY["PhiSensY"] = i_sector.second.bookCorrHistsY(
+          "PhiSensY", "track angle on sensor", "#phi_{module,y}", "[ ^{o}]", 186, 93, -93, 93, "nphtr");
+
+      i_sector.second.YHit = secDir.make<TH1F>("h_YHit", " hit measurement y_{hit};y_{hit}  [cm];# hits", 100, -20, 20);
+      i_sector.second.YTrk = secDir.make<TH1F>("h_YTrk", "track prediction y_{trk};y_{trk}  [cm];# hits", 100, -20, 20);
+      i_sector.second.SigmaY2 =
+          secDir.make<TH1F>("h_SigmaY2",
+                            "squared residual error #sigma_{r,y}^{2};#sigma_{r,y}^{2}  [#mum^{2}];# hits",
+                            105,
+                            sigmaXMin * 10000.,
+                            sigmaX2Max * 10000. * 10000.);  //no mistake !
+      i_sector.second.ResY = secDir.make<TH1F>(
+          "h_ResY", "residual r_{y};y_{trk}-y_{hit}  [#mum];# hits", 100, -resXAbsMax * 10000., resXAbsMax * 10000.);
+      i_sector.second.NorResY =
+          secDir.make<TH1F>("h_NorResY",
+                            "normalized residual r_{y}/#sigma_{r,y};(y_{trk}-y_{hit})/#sigma_{r,y};# hits",
+                            100,
+                            -norResXAbsMax,
+                            norResXAbsMax);
+      i_sector.second.ProbY = secDir.make<TH1F>(
+          "h_ProbY", "residual probability;prob(r_{y}^{2}/#sigma_{r,y}^{2},1);# hits", 60, probXMin, probXMax);
+
+      i_sector.second.PhiSensYVsBarycentreY =
+          secDir.make<TH2F>("h2_phiSensYVsBarycentreY",
+                            "#phi_{module,y} vs. b_{cl,y};b_{cl,y}  [# channels];#phi_{module,y}  [ ^{o}]",
+                            200,
+                            -10.,
+                            790.,
+                            93,
+                            -93,
+                            93);
+      i_sector.second.PPhiSensYVsBarycentreY =
+          secDir.make<TProfile>("p_phiSensYVsBarycentreY",
+                                "#phi_{module,y} vs. b_{cl,y};b_{cl,y}  [# channels];#phi_{module,y}  [ ^{o}]",
+                                200,
+                                -10.,
+                                790.);
     }
-    
-    
+
     // Track Parameters
-    i_sector.second.m_correlationHistsX["HitsValid"] = i_sector.second.bookCorrHistsX("HitsValid","# hits","[valid]",50,0,50,"npt");
-    i_sector.second.m_correlationHistsX["HitsInvalid"] = i_sector.second.bookCorrHistsX("HitsInvalid","# hits","[invalid]",20,0,20,"npt");
-    i_sector.second.m_correlationHistsX["Hits2D"] = i_sector.second.bookCorrHistsX("Hits2D","# hits","[2D]",20,0,20,"npt");
-    i_sector.second.m_correlationHistsX["LayersMissed"] = i_sector.second.bookCorrHistsX("LayersMissed","# layers","[missed]",10,0,10,"npt");
-    i_sector.second.m_correlationHistsX["HitsPixel"] = i_sector.second.bookCorrHistsX("HitsPixel","# hits","[pixel]",10,0,10,"npt");
-    i_sector.second.m_correlationHistsX["HitsStrip"] = i_sector.second.bookCorrHistsX("HitsStrip","# hits","[strip]",40,0,40,"npt");
-    i_sector.second.m_correlationHistsX["HitsGood"] = i_sector.second.bookCorrHistsX("HitsGood","# hits","[good]",50,0,50,"npt");
-    i_sector.second.m_correlationHistsX["NorChi2"] = i_sector.second.bookCorrHistsX("NorChi2","#chi^{2}/f","",50,0,norChi2Max,"npr");
-    i_sector.second.m_correlationHistsX["Theta"] = i_sector.second.bookCorrHistsX("Theta","#theta","[ ^{o}]",40,-10,190,"npt");
-    i_sector.second.m_correlationHistsX["Phi"] = i_sector.second.bookCorrHistsX("Phi","#phi","[ ^{o}]",76,-190,190,"npt");
-    i_sector.second.m_correlationHistsX["D0Beamspot"] = i_sector.second.bookCorrHistsX("D0Beamspot","d_{0, BS}","[cm]",40,-d0Max,d0Max,"npt");
-    i_sector.second.m_correlationHistsX["Dz"] = i_sector.second.bookCorrHistsX("Dz","d_{z}","[cm]",40,-dzMax,dzMax,"npt");
-    i_sector.second.m_correlationHistsX["Pt"] = i_sector.second.bookCorrHistsX("Pt","p_{t}","[GeV]",50,0,pMax,"npt");
-    i_sector.second.m_correlationHistsX["P"] = i_sector.second.bookCorrHistsX("P","|p|","[GeV]",50,0,pMax,"npt");
-    i_sector.second.m_correlationHistsX["InvP"] = i_sector.second.bookCorrHistsX("InvP","1/|p|","[GeV^{-1}]",25,0,invPMax,"t");
-    i_sector.second.m_correlationHistsX["MeanAngle"] = i_sector.second.bookCorrHistsX("MeanAngle","<#phi_{module}>","[ ^{o}]",25,-5,95,"npt");
+    i_sector.second.m_correlationHistsX["HitsValid"] =
+        i_sector.second.bookCorrHistsX("HitsValid", "# hits", "[valid]", 50, 0, 50, "npt");
+    i_sector.second.m_correlationHistsX["HitsInvalid"] =
+        i_sector.second.bookCorrHistsX("HitsInvalid", "# hits", "[invalid]", 20, 0, 20, "npt");
+    i_sector.second.m_correlationHistsX["Hits2D"] =
+        i_sector.second.bookCorrHistsX("Hits2D", "# hits", "[2D]", 20, 0, 20, "npt");
+    i_sector.second.m_correlationHistsX["LayersMissed"] =
+        i_sector.second.bookCorrHistsX("LayersMissed", "# layers", "[missed]", 10, 0, 10, "npt");
+    i_sector.second.m_correlationHistsX["HitsPixel"] =
+        i_sector.second.bookCorrHistsX("HitsPixel", "# hits", "[pixel]", 10, 0, 10, "npt");
+    i_sector.second.m_correlationHistsX["HitsStrip"] =
+        i_sector.second.bookCorrHistsX("HitsStrip", "# hits", "[strip]", 40, 0, 40, "npt");
+    i_sector.second.m_correlationHistsX["HitsGood"] =
+        i_sector.second.bookCorrHistsX("HitsGood", "# hits", "[good]", 50, 0, 50, "npt");
+    i_sector.second.m_correlationHistsX["NorChi2"] =
+        i_sector.second.bookCorrHistsX("NorChi2", "#chi^{2}/f", "", 50, 0, norChi2Max, "npr");
+    i_sector.second.m_correlationHistsX["Theta"] =
+        i_sector.second.bookCorrHistsX("Theta", "#theta", "[ ^{o}]", 40, -10, 190, "npt");
+    i_sector.second.m_correlationHistsX["Phi"] =
+        i_sector.second.bookCorrHistsX("Phi", "#phi", "[ ^{o}]", 76, -190, 190, "npt");
+    i_sector.second.m_correlationHistsX["D0Beamspot"] =
+        i_sector.second.bookCorrHistsX("D0Beamspot", "d_{0, BS}", "[cm]", 40, -d0Max, d0Max, "npt");
+    i_sector.second.m_correlationHistsX["Dz"] =
+        i_sector.second.bookCorrHistsX("Dz", "d_{z}", "[cm]", 40, -dzMax, dzMax, "npt");
+    i_sector.second.m_correlationHistsX["Pt"] =
+        i_sector.second.bookCorrHistsX("Pt", "p_{t}", "[GeV]", 50, 0, pMax, "npt");
+    i_sector.second.m_correlationHistsX["P"] = i_sector.second.bookCorrHistsX("P", "|p|", "[GeV]", 50, 0, pMax, "npt");
+    i_sector.second.m_correlationHistsX["InvP"] =
+        i_sector.second.bookCorrHistsX("InvP", "1/|p|", "[GeV^{-1}]", 25, 0, invPMax, "t");
+    i_sector.second.m_correlationHistsX["MeanAngle"] =
+        i_sector.second.bookCorrHistsX("MeanAngle", "<#phi_{module}>", "[ ^{o}]", 25, -5, 95, "npt");
     //i_sector.second.m_correlationHistsX[""] = i_sector.second.bookCorrHistsX("","","",,,,"nphtr");
-    
-    if(pixelSector){
-      i_sector.second.m_correlationHistsY["HitsValid"] = i_sector.second.bookCorrHistsY("HitsValid","# hits","[valid]",50,0,50,"npt");
-      i_sector.second.m_correlationHistsY["HitsInvalid"] = i_sector.second.bookCorrHistsY("HitsInvalid","# hits","[invalid]",20,0,20,"npt");
-      i_sector.second.m_correlationHistsY["Hits2D"] = i_sector.second.bookCorrHistsY("Hits2D","# hits","[2D]",20,0,20,"npt");
-      i_sector.second.m_correlationHistsY["LayersMissed"] = i_sector.second.bookCorrHistsY("LayersMissed","# layers","[missed]",10,0,10,"npt");
-      i_sector.second.m_correlationHistsY["HitsPixel"] = i_sector.second.bookCorrHistsY("HitsPixel","# hits","[pixel]",10,0,10,"npt");
-      i_sector.second.m_correlationHistsY["HitsStrip"] = i_sector.second.bookCorrHistsY("HitsStrip","# hits","[strip]",40,0,40,"npt");
-      i_sector.second.m_correlationHistsY["HitsGood"] = i_sector.second.bookCorrHistsY("HitsGood","# hits","[good]",50,0,50,"npt");
-      i_sector.second.m_correlationHistsY["NorChi2"] = i_sector.second.bookCorrHistsY("NorChi2","#chi^{2}/f","",50,0,norChi2Max,"npr");
-      i_sector.second.m_correlationHistsY["Theta"] = i_sector.second.bookCorrHistsY("Theta","#theta","[ ^{o}]",40,-10,190,"npt");
-      i_sector.second.m_correlationHistsY["Phi"] = i_sector.second.bookCorrHistsY("Phi","#phi","[ ^{o}]",76,-190,190,"npt");
-      i_sector.second.m_correlationHistsY["D0Beamspot"] = i_sector.second.bookCorrHistsY("D0Beamspot","d_{0, BS}","[cm]",40,-d0Max,d0Max,"npt");
-      i_sector.second.m_correlationHistsY["Dz"] = i_sector.second.bookCorrHistsY("Dz","d_{z}","[cm]",40,-dzMax,dzMax,"npt");
-      i_sector.second.m_correlationHistsY["Pt"] = i_sector.second.bookCorrHistsY("Pt","p_{t}","[GeV]",50,0,pMax,"npt");
-      i_sector.second.m_correlationHistsY["P"] = i_sector.second.bookCorrHistsY("P","|p|","[GeV]",50,0,pMax,"npt");
-      i_sector.second.m_correlationHistsY["InvP"] = i_sector.second.bookCorrHistsY("InvP","1/|p|","[GeV^{-1}]",25,0,invPMax,"t");
-      i_sector.second.m_correlationHistsY["MeanAngle"] = i_sector.second.bookCorrHistsY("MeanAngle","<#phi_{module}>","[ ^{o}]",25,-5,95,"npt");
+
+    if (pixelSector) {
+      i_sector.second.m_correlationHistsY["HitsValid"] =
+          i_sector.second.bookCorrHistsY("HitsValid", "# hits", "[valid]", 50, 0, 50, "npt");
+      i_sector.second.m_correlationHistsY["HitsInvalid"] =
+          i_sector.second.bookCorrHistsY("HitsInvalid", "# hits", "[invalid]", 20, 0, 20, "npt");
+      i_sector.second.m_correlationHistsY["Hits2D"] =
+          i_sector.second.bookCorrHistsY("Hits2D", "# hits", "[2D]", 20, 0, 20, "npt");
+      i_sector.second.m_correlationHistsY["LayersMissed"] =
+          i_sector.second.bookCorrHistsY("LayersMissed", "# layers", "[missed]", 10, 0, 10, "npt");
+      i_sector.second.m_correlationHistsY["HitsPixel"] =
+          i_sector.second.bookCorrHistsY("HitsPixel", "# hits", "[pixel]", 10, 0, 10, "npt");
+      i_sector.second.m_correlationHistsY["HitsStrip"] =
+          i_sector.second.bookCorrHistsY("HitsStrip", "# hits", "[strip]", 40, 0, 40, "npt");
+      i_sector.second.m_correlationHistsY["HitsGood"] =
+          i_sector.second.bookCorrHistsY("HitsGood", "# hits", "[good]", 50, 0, 50, "npt");
+      i_sector.second.m_correlationHistsY["NorChi2"] =
+          i_sector.second.bookCorrHistsY("NorChi2", "#chi^{2}/f", "", 50, 0, norChi2Max, "npr");
+      i_sector.second.m_correlationHistsY["Theta"] =
+          i_sector.second.bookCorrHistsY("Theta", "#theta", "[ ^{o}]", 40, -10, 190, "npt");
+      i_sector.second.m_correlationHistsY["Phi"] =
+          i_sector.second.bookCorrHistsY("Phi", "#phi", "[ ^{o}]", 76, -190, 190, "npt");
+      i_sector.second.m_correlationHistsY["D0Beamspot"] =
+          i_sector.second.bookCorrHistsY("D0Beamspot", "d_{0, BS}", "[cm]", 40, -d0Max, d0Max, "npt");
+      i_sector.second.m_correlationHistsY["Dz"] =
+          i_sector.second.bookCorrHistsY("Dz", "d_{z}", "[cm]", 40, -dzMax, dzMax, "npt");
+      i_sector.second.m_correlationHistsY["Pt"] =
+          i_sector.second.bookCorrHistsY("Pt", "p_{t}", "[GeV]", 50, 0, pMax, "npt");
+      i_sector.second.m_correlationHistsY["P"] =
+          i_sector.second.bookCorrHistsY("P", "|p|", "[GeV]", 50, 0, pMax, "npt");
+      i_sector.second.m_correlationHistsY["InvP"] =
+          i_sector.second.bookCorrHistsY("InvP", "1/|p|", "[GeV^{-1}]", 25, 0, invPMax, "t");
+      i_sector.second.m_correlationHistsY["MeanAngle"] =
+          i_sector.second.bookCorrHistsY("MeanAngle", "<#phi_{module}>", "[ ^{o}]", 25, -5, 95, "npt");
     }
-    
-    
+
     // (transform errors and residuals from [cm] in [mum])
-    for(auto const & i_errHists : v_errHists){
-      double xMin(0.01*(i_errHists-1)), xMax(0.01*(i_errHists));
+    for (auto const& i_errHists : v_errHists) {
+      double xMin(0.01 * (i_errHists - 1)), xMax(0.01 * (i_errHists));
       std::stringstream sigmaXHit, sigmaXTrk, sigmaX;
       sigmaXHit << "h_sigmaXHit_" << i_errHists;
       sigmaXTrk << "h_sigmaXTrk_" << i_errHists;
-      sigmaX    << "h_sigmaX_"    << i_errHists;
-      i_sector.second.m_sigmaX["sigmaXHit"].push_back(secDir.make<TH1F>(sigmaXHit.str().c_str(),"hit error #sigma_{hit,x};#sigma_{hit,x}  [#mum];# hits",100,xMin*10000.,xMax*10000.));
-      i_sector.second.m_sigmaX["sigmaXTrk"].push_back(secDir.make<TH1F>(sigmaXTrk.str().c_str(),"track error #sigma_{trk,x};#sigma_{trk,x}  [#mum];# hits",100,xMin*10000.,xMax*10000.));
-      i_sector.second.m_sigmaX["sigmaX"   ].push_back(secDir.make<TH1F>(sigmaX.str().c_str(),"residual error #sigma_{r,x};#sigma_{r,x}  [#mum];# hits",100,xMin*10000.,xMax*10000.));
-      if(pixelSector){
+      sigmaX << "h_sigmaX_" << i_errHists;
+      i_sector.second.m_sigmaX["sigmaXHit"].push_back(
+          secDir.make<TH1F>(sigmaXHit.str().c_str(),
+                            "hit error #sigma_{hit,x};#sigma_{hit,x}  [#mum];# hits",
+                            100,
+                            xMin * 10000.,
+                            xMax * 10000.));
+      i_sector.second.m_sigmaX["sigmaXTrk"].push_back(
+          secDir.make<TH1F>(sigmaXTrk.str().c_str(),
+                            "track error #sigma_{trk,x};#sigma_{trk,x}  [#mum];# hits",
+                            100,
+                            xMin * 10000.,
+                            xMax * 10000.));
+      i_sector.second.m_sigmaX["sigmaX"].push_back(
+          secDir.make<TH1F>(sigmaX.str().c_str(),
+                            "residual error #sigma_{r,x};#sigma_{r,x}  [#mum];# hits",
+                            100,
+                            xMin * 10000.,
+                            xMax * 10000.));
+      if (pixelSector) {
         std::stringstream sigmaYHit, sigmaYTrk, sigmaY;
         sigmaYHit << "h_sigmaYHit_" << i_errHists;
         sigmaYTrk << "h_sigmaYTrk_" << i_errHists;
-        sigmaY    << "h_sigmaY_"    << i_errHists;
-        i_sector.second.m_sigmaY["sigmaYHit"].push_back(secDir.make<TH1F>(sigmaYHit.str().c_str(),"hit error #sigma_{hit,y};#sigma_{hit,y}  [#mum];# hits",100,xMin*10000.,xMax*10000.));
-        i_sector.second.m_sigmaY["sigmaYTrk"].push_back(secDir.make<TH1F>(sigmaYTrk.str().c_str(),"track error #sigma_{trk,y};#sigma_{trk,y}  [#mum];# hits",100,xMin*10000.,xMax*10000.));
-        i_sector.second.m_sigmaY["sigmaY"   ].push_back(secDir.make<TH1F>(sigmaY.str().c_str(),"residual error #sigma_{r,y};#sigma_{r,y}  [#mum];# hits",100,xMin*10000.,xMax*10000.));
+        sigmaY << "h_sigmaY_" << i_errHists;
+        i_sector.second.m_sigmaY["sigmaYHit"].push_back(
+            secDir.make<TH1F>(sigmaYHit.str().c_str(),
+                              "hit error #sigma_{hit,y};#sigma_{hit,y}  [#mum];# hits",
+                              100,
+                              xMin * 10000.,
+                              xMax * 10000.));
+        i_sector.second.m_sigmaY["sigmaYTrk"].push_back(
+            secDir.make<TH1F>(sigmaYTrk.str().c_str(),
+                              "track error #sigma_{trk,y};#sigma_{trk,y}  [#mum];# hits",
+                              100,
+                              xMin * 10000.,
+                              xMax * 10000.));
+        i_sector.second.m_sigmaY["sigmaY"].push_back(
+            secDir.make<TH1F>(sigmaY.str().c_str(),
+                              "residual error #sigma_{r,y};#sigma_{r,y}  [#mum];# hits",
+                              100,
+                              xMin * 10000.,
+                              xMax * 10000.));
       }
     }
-    
   }
 }
 
-
-
-void
-ApeEstimator::bookSectorHistsForApeCalculation(){
+void ApeEstimator::bookSectorHistsForApeCalculation() {
   std::vector<unsigned int> v_errHists(parameterSet_.getParameter<std::vector<unsigned int> >("vErrHists"));
-  for(std::vector<unsigned int>::iterator i_errHists = v_errHists.begin(); i_errHists != v_errHists.end(); ++i_errHists){
-    for(std::vector<unsigned int>::iterator i_errHists2 = i_errHists; i_errHists2 != v_errHists.end();){
+  for (std::vector<unsigned int>::iterator i_errHists = v_errHists.begin(); i_errHists != v_errHists.end();
+       ++i_errHists) {
+    for (std::vector<unsigned int>::iterator i_errHists2 = i_errHists; i_errHists2 != v_errHists.end();) {
       ++i_errHists2;
-      if(*i_errHists==*i_errHists2){
-        edm::LogError("BookSectorHists")<<"Value of vErrHists in config exists twice: "<<*i_errHists<<"\n... delete one of both";
+      if (*i_errHists == *i_errHists2) {
+        edm::LogError("BookSectorHists") << "Value of vErrHists in config exists twice: " << *i_errHists
+                                         << "\n... delete one of both";
         v_errHists.erase(i_errHists2);
       }
     }
   }
-  
-  for(auto &i_sector : m_tkSector_){
+
+  for (auto& i_sector : m_tkSector_) {
     edm::Service<TFileService> fileService;
-    if(!fileService){
-      throw edm::Exception( edm::errors::Configuration,
-                            "TFileService is not registered in cfg file" );
+    if (!fileService) {
+      throw edm::Exception(edm::errors::Configuration, "TFileService is not registered in cfg file");
     }
-    
-    std::stringstream sector; sector << "Sector_" << i_sector.first;
+
+    std::stringstream sector;
+    sector << "Sector_" << i_sector.first;
     TFileDirectory secDir = fileService->mkdir(sector.str());
-    
+
     // Dummy histo containing the sector name as title
-    i_sector.second.Name = secDir.make<TH1F>("z_name",i_sector.second.name.c_str(),1,0,1);
-    
+    i_sector.second.Name = secDir.make<TH1F>("z_name", i_sector.second.name.c_str(), 1, 0, 1);
+
     // Do not book histos for empty sectors
-    if(i_sector.second.v_rawId.empty()){
+    if (i_sector.second.v_rawId.empty()) {
       continue;
     }
-    
-    
+
     // Distributions in each interval (stay in [cm], to have all calculations in [cm])
-    if(m_resErrBins_.empty()){ // default if no selection taken into account: calculate APE with one bin with residual error 0-100um
+    if (m_resErrBins_
+            .empty()) {  // default if no selection taken into account: calculate APE with one bin with residual error 0-100um
       m_resErrBins_[1].first = 0.;
       m_resErrBins_[1].second = 0.01;
-    } 
-    for(auto const & i_errBins : m_resErrBins_){
-      std::stringstream interval; interval << "Interval_" << i_errBins.first;
+    }
+    for (auto const& i_errBins : m_resErrBins_) {
+      std::stringstream interval;
+      interval << "Interval_" << i_errBins.first;
       TFileDirectory intDir = secDir.mkdir(interval.str());
-      i_sector.second.m_binnedHists[i_errBins.first]["sigmaX"]  = intDir.make<TH1F>("h_sigmaX","residual resolution #sigma_{x};#sigma_{x}  [cm];# hits",100,0.,0.01);
-      i_sector.second.m_binnedHists[i_errBins.first]["norResX"] = intDir.make<TH1F>("h_norResX","normalized residual r_{x}/#sigma_{r,x};(x_{trk}-x_{hit})/#sigma_{r,x};# hits",100,-10,10);
-      if(i_sector.second.isPixel){
-        i_sector.second.m_binnedHists[i_errBins.first]["sigmaY"]  = intDir.make<TH1F>("h_sigmaY","residual resolution #sigma_{y};#sigma_{y}  [cm];# hits",100,0.,0.01);
-        i_sector.second.m_binnedHists[i_errBins.first]["norResY"] = intDir.make<TH1F>("h_norResY","normalized residual r_{y}/#sigma_{r,y};(y_{trk}-y_{hit})/#sigma_{r,y};# hits",100,-10,10);
+      i_sector.second.m_binnedHists[i_errBins.first]["sigmaX"] =
+          intDir.make<TH1F>("h_sigmaX", "residual resolution #sigma_{x};#sigma_{x}  [cm];# hits", 100, 0., 0.01);
+      i_sector.second.m_binnedHists[i_errBins.first]["norResX"] = intDir.make<TH1F>(
+          "h_norResX", "normalized residual r_{x}/#sigma_{r,x};(x_{trk}-x_{hit})/#sigma_{r,x};# hits", 100, -10, 10);
+      if (i_sector.second.isPixel) {
+        i_sector.second.m_binnedHists[i_errBins.first]["sigmaY"] =
+            intDir.make<TH1F>("h_sigmaY", "residual resolution #sigma_{y};#sigma_{y}  [cm];# hits", 100, 0., 0.01);
+        i_sector.second.m_binnedHists[i_errBins.first]["norResY"] = intDir.make<TH1F>(
+            "h_norResY", "normalized residual r_{y}/#sigma_{r,y};(y_{trk}-y_{hit})/#sigma_{r,y};# hits", 100, -10, 10);
       }
     }
-    
-    
+
     TFileDirectory resDir = secDir.mkdir("Results");
-    
+
     // TTree containing rawIds of all modules in sector
     unsigned int rawId(0);
-    i_sector.second.RawId = resDir.make<TTree>("rawIdTree","Tree containing rawIds of all modules in sector");
+    i_sector.second.RawId = resDir.make<TTree>("rawIdTree", "Tree containing rawIds of all modules in sector");
     i_sector.second.RawId->Branch("RawId", &rawId, "RawId/i");
-    for(auto const & i_rawId : i_sector.second.v_rawId){
+    for (auto const& i_rawId : i_sector.second.v_rawId) {
       rawId = i_rawId;
       i_sector.second.RawId->Fill();
     }
-    
+
     // Result plots (one hist per sector containing one bin per interval)
     // (transform errors and residuals from [cm] in [mum])
     std::vector<double> v_binX(parameterSet_.getParameter<std::vector<double> >("residualErrorBinning"));
-    for(auto & i_binX : v_binX){
+    for (auto& i_binX : v_binX) {
       i_binX *= 10000.;
     }
-    i_sector.second.EntriesX = resDir.make<TH1F>("h_entriesX","# hits used;#sigma_{x}  [#mum];# hits",v_binX.size()-1,&(v_binX[0]));
-    if(i_sector.second.isPixel){
-      i_sector.second.EntriesY = resDir.make<TH1F>("h_entriesY","# hits used;#sigma_{y}  [#mum];# hits",v_binX.size()-1,&(v_binX[0]));
+    i_sector.second.EntriesX =
+        resDir.make<TH1F>("h_entriesX", "# hits used;#sigma_{x}  [#mum];# hits", v_binX.size() - 1, &(v_binX[0]));
+    if (i_sector.second.isPixel) {
+      i_sector.second.EntriesY =
+          resDir.make<TH1F>("h_entriesY", "# hits used;#sigma_{y}  [#mum];# hits", v_binX.size() - 1, &(v_binX[0]));
     }
-    
+
     // In fact these are un-needed Analyzer plots, but I want to have them always for every sector visible
     // (transform errors and residuals from [cm] in [mum])
-    i_sector.second.ResX    = resDir.make<TH1F>("h_ResX","residual r_{x};x_{trk}-x_{hit}  [#mum];# hits",100,-0.03*10000.,0.03*10000.);
-    i_sector.second.NorResX = resDir.make<TH1F>("h_NorResX","normalized residual r_{x}/#sigma_{r,x};(x_{trk}-x_{hit})/#sigma_{r,x};# hits",100,-5.,5.);
-    if(i_sector.second.isPixel){
-      i_sector.second.ResY    = resDir.make<TH1F>("h_ResY","residual r_{y};y_{trk}-y_{hit}  [#mum];# hits",100,-0.03*10000.,0.03*10000.);
-      i_sector.second.NorResY = resDir.make<TH1F>("h_NorResY","normalized residual r_{y}/#sigma_{r,y};(y_{trk}-y_{hit})/#sigma_{r,y};# hits",100,-5.,5.);
+    i_sector.second.ResX = resDir.make<TH1F>(
+        "h_ResX", "residual r_{x};x_{trk}-x_{hit}  [#mum];# hits", 100, -0.03 * 10000., 0.03 * 10000.);
+    i_sector.second.NorResX = resDir.make<TH1F>(
+        "h_NorResX", "normalized residual r_{x}/#sigma_{r,x};(x_{trk}-x_{hit})/#sigma_{r,x};# hits", 100, -5., 5.);
+    if (i_sector.second.isPixel) {
+      i_sector.second.ResY = resDir.make<TH1F>(
+          "h_ResY", "residual r_{y};y_{trk}-y_{hit}  [#mum];# hits", 100, -0.03 * 10000., 0.03 * 10000.);
+      i_sector.second.NorResY = resDir.make<TH1F>(
+          "h_NorResY", "normalized residual r_{y}/#sigma_{r,y};(y_{trk}-y_{hit})/#sigma_{r,y};# hits", 100, -5., 5.);
     }
   }
 }
 
-
 // -----------------------------------------------------------------------------------------------------------
 
-void
-ApeEstimator::bookTrackHists(){
+void ApeEstimator::bookTrackHists() {
   bool zoomHists(parameterSet_.getParameter<bool>("zoomHists"));
-  
+
   int trackSizeBins = zoomHists ? 6 : 201;
-  double trackSizeMax = trackSizeBins -1;
-  
+  double trackSizeMax = trackSizeBins - 1;
+
   double chi2Max = zoomHists ? 100. : 2000.;
   double norChi2Max = zoomHists ? 5. : 1000.;
   double d0max = zoomHists ? 0.02 : 40.;  // cosmics: 100.|100.
   double dzmax = zoomHists ? 15. : 100.;  // cosmics: 200.|600.
   double pMax = zoomHists ? 200. : 2000.;
-  
+
   edm::Service<TFileService> fileService;
   TFileDirectory evtDir = fileService->mkdir("EventVariables");
-  tkDetector_.TrkSize     = evtDir.make<TH1F>("h_trackSize","# tracks  [all];# tracks;# events",trackSizeBins,-1,trackSizeMax);
-  tkDetector_.TrkSizeGood = evtDir.make<TH1F>("h_trackSizeGood","# tracks  [good];# tracks;# events",trackSizeBins,-1,trackSizeMax);
+  tkDetector_.TrkSize =
+      evtDir.make<TH1F>("h_trackSize", "# tracks  [all];# tracks;# events", trackSizeBins, -1, trackSizeMax);
+  tkDetector_.TrkSizeGood =
+      evtDir.make<TH1F>("h_trackSizeGood", "# tracks  [good];# tracks;# events", trackSizeBins, -1, trackSizeMax);
   TFileDirectory trkDir = fileService->mkdir("TrackVariables");
-  tkDetector_.HitsSize      = trkDir.make<TH1F>("h_hitsSize","# hits;# hits;# tracks",51,-1,50);
-  tkDetector_.HitsValid     = trkDir.make<TH1F>("h_hitsValid","# hits  [valid];# hits  [valid];# tracks",51,-1,50);
-  tkDetector_.HitsInvalid   = trkDir.make<TH1F>("h_hitsInvalid","# hits  [invalid];# hits  [invalid];# tracks",21,-1,20);
-  tkDetector_.Hits2D        = trkDir.make<TH1F>("h_hits2D","# hits  [2D];# hits  [2D];# tracks",21,-1,20);
-  tkDetector_.LayersMissed  = trkDir.make<TH1F>("h_layersMissed","# layers  [missed];# layers  [missed];# tracks",11,-1,10);
-  tkDetector_.HitsPixel     = trkDir.make<TH1F>("h_hitsPixel","# hits  [pixel];# hits  [pixel];# tracks",11,-1,10);
-  tkDetector_.HitsStrip     = trkDir.make<TH1F>("h_hitsStrip","# hits  [strip];# hits  [strip];# tracks",41,-1,40);
-  tkDetector_.Charge        = trkDir.make<TH1F>("h_charge","charge q;q  [e];# tracks",5,-2,3);
-  tkDetector_.Chi2          = trkDir.make<TH1F>("h_chi2"," #chi^{2};#chi^{2};# tracks",100,0,chi2Max);
-  tkDetector_.Ndof          = trkDir.make<TH1F>("h_ndof","# degrees of freedom f;f;# tracks",101,-1,100);
-  tkDetector_.NorChi2       = trkDir.make<TH1F>("h_norChi2","normalized #chi^{2};#chi^{2}/f;# tracks",200,0,norChi2Max);
-  tkDetector_.Prob          = trkDir.make<TH1F>("h_prob"," #chi^{2} probability;prob(#chi^{2},f);# tracks",50,0,1);
-  tkDetector_.Eta           = trkDir.make<TH1F>("h_eta","pseudorapidity #eta;#eta;# tracks",100,-5,5);
-  tkDetector_.EtaErr        = trkDir.make<TH1F>("h_etaErr","Error of #eta;#sigma(#eta);# tracks",100,0,0.001);
-  tkDetector_.EtaSig        = trkDir.make<TH1F>("h_etaSig","Significance of #eta;#eta/#sigma(#eta);# tracks",100,-20000,20000);
-  tkDetector_.Theta         = trkDir.make<TH1F>("h_theta","polar angle #theta;#theta  [ ^{o}];# tracks",100,-10,190);
-  tkDetector_.Phi           = trkDir.make<TH1F>("h_phi","azimuth angle #phi;#phi  [ ^{o}];# tracks",190,-190,190);
-  tkDetector_.PhiErr        = trkDir.make<TH1F>("h_phiErr","Error of #phi;#sigma(#phi)  [ ^{o}];# tracks",100,0,0.04);
-  tkDetector_.PhiSig        = trkDir.make<TH1F>("h_phiSig","Significance of #phi;#phi/#sigma(#phi)  [ ^{o}];# tracks",100,-50000,50000);
-  tkDetector_.D0Beamspot    = trkDir.make<TH1F>("h_d0Beamspot","Closest approach d_{0} wrt. beamspot;d_{0, BS}  [cm];# tracks",200,-d0max,d0max);
-  tkDetector_.D0BeamspotErr = trkDir.make<TH1F>("h_d0BeamspotErr","Error of d_{0, BS};#sigma(d_{0, BS})  [cm];# tracks",200,0,0.01);
-  tkDetector_.D0BeamspotSig = trkDir.make<TH1F>("h_d0BeamspotSig","Significance of d_{0, BS};d_{0, BS}/#sigma(d_{0, BS});# tracks",100,-5,5);
-  tkDetector_.Dz            = trkDir.make<TH1F>("h_dz","Closest approach d_{z};d_{z}  [cm];# tracks",200,-dzmax,dzmax);
-  tkDetector_.DzErr         = trkDir.make<TH1F>("h_dzErr","Error of d_{z};#sigma(d_{z})  [cm];# tracks",200,0,0.01);
-  tkDetector_.DzSig         = trkDir.make<TH1F>("h_dzSig","Significance of d_{z};d_{z}/#sigma(d_{z});# tracks",100,-10000,10000);
-  tkDetector_.Pt      = trkDir.make<TH1F>("h_pt","transverse momentum p_{t};p_{t}  [GeV];# tracks",100,0,pMax);
-  tkDetector_.PtErr         = trkDir.make<TH1F>("h_ptErr","Error of p_{t};#sigma(p_{t})  [GeV];# tracks",100,0,1.6);
-  tkDetector_.PtSig         = trkDir.make<TH1F>("h_ptSig","Significance of p_{t};p_{t}/#sigma(p_{t});# tracks",100,0,200);
-  tkDetector_.P             = trkDir.make<TH1F>("h_p","momentum magnitude |p|;|p|  [GeV];# tracks",100,0,pMax);
-  tkDetector_.MeanAngle     = trkDir.make<TH1F>("h_meanAngle","mean angle on module <#phi_{module}>;<#phi_{module}>  [ ^{o}];# tracks",100,-5,95);
-  tkDetector_.HitsGood      = trkDir.make<TH1F>("h_hitsGood","# hits  [good];# hits  [good];# tracks",51,-1,50);
-  
-  tkDetector_.MeanAngleVsHits     = trkDir.make<TH2F>("h2_meanAngleVsHits","<#phi_{module}> vs. # hits;# hits;<#phi_{module}>  [ ^{o}]",51,-1,50,50,-5,95);
-  tkDetector_.HitsGoodVsHitsValid = trkDir.make<TH2F>("h2_hitsGoodVsHitsValid","# hits  [good] vs. # hits  [valid];# hits  [valid];# hits  [good]",51,-1,50,51,-1,50);
-  tkDetector_.HitsPixelVsEta      = trkDir.make<TH2F>("h2_hitsPixelVsEta","# hits  [pixel] vs. #eta;#eta;# hits  [pixel]",60,-3,3,11,-1,10);
-  tkDetector_.HitsPixelVsTheta    = trkDir.make<TH2F>("h2_hitsPixelVsTheta","# hits  [pixel] vs. #theta;#theta;# hits  [pixel]",100,-10,190,11,-1,10);
-  tkDetector_.HitsStripVsEta      = trkDir.make<TH2F>("h2_hitsStripVsEta","# hits  [strip] vs. #eta;#eta;# hits  [strip]",60,-3,3,31,-1,40);
-  tkDetector_.HitsStripVsTheta    = trkDir.make<TH2F>("h2_hitsStripVsTheta","# hits  [strip] vs. #theta;#theta;# hits  [strip]",100,-10,190,31,-1,40);
-  tkDetector_.PtVsEta             = trkDir.make<TH2F>("h2_ptVsEta","p_{t} vs. #eta;#eta;p_{t}  [GeV]",60,-3,3,100,0,pMax);
-  tkDetector_.PtVsTheta           = trkDir.make<TH2F>("h2_ptVsTheta","p_{t} vs. #theta;#theta;p_{t}  [GeV]",100,-10,190,100,0,pMax);
-  
-  tkDetector_.PMeanAngleVsHits     = trkDir.make<TProfile>("p_meanAngleVsHits","<#phi_{module}> vs. # hits;# hits;<#phi_{module}>  [ ^{o}]",51,-1,50);
-  tkDetector_.PHitsGoodVsHitsValid = trkDir.make<TProfile>("p_hitsGoodVsHitsValid","# hits  [good] vs. # hits  [valid];# hits  [valid];# hits  [good]",51,-1,50);
-  tkDetector_.PHitsPixelVsEta      = trkDir.make<TProfile>("p_hitsPixelVsEta","# hits  [pixel] vs. #eta;#eta;# hits  [pixel]",60,-3,3);
-  tkDetector_.PHitsPixelVsTheta    = trkDir.make<TProfile>("p_hitsPixelVsTheta","# hits  [pixel] vs. #theta;#theta;# hits  [pixel]",100,-10,190);
-  tkDetector_.PHitsStripVsEta      = trkDir.make<TProfile>("p_hitsStripVsEta","# hits  [strip] vs. #eta;#eta;# hits  [strip]",60,-3,3);
-  tkDetector_.PHitsStripVsTheta    = trkDir.make<TProfile>("p_hitsStripVsTheta","# hits  [strip] vs. #theta;#theta;# hits  [strip]",100,-10,190);
-  tkDetector_.PPtVsEta             = trkDir.make<TProfile>("p_ptVsEta","p_{t} vs. #eta;#eta;p_{t}  [GeV]",60,-3,3);
-  tkDetector_.PPtVsTheta           = trkDir.make<TProfile>("p_ptVsTheta","p_{t} vs. #theta;#theta;p_{t}  [GeV]",100,-10,190);
+  tkDetector_.HitsSize = trkDir.make<TH1F>("h_hitsSize", "# hits;# hits;# tracks", 51, -1, 50);
+  tkDetector_.HitsValid = trkDir.make<TH1F>("h_hitsValid", "# hits  [valid];# hits  [valid];# tracks", 51, -1, 50);
+  tkDetector_.HitsInvalid =
+      trkDir.make<TH1F>("h_hitsInvalid", "# hits  [invalid];# hits  [invalid];# tracks", 21, -1, 20);
+  tkDetector_.Hits2D = trkDir.make<TH1F>("h_hits2D", "# hits  [2D];# hits  [2D];# tracks", 21, -1, 20);
+  tkDetector_.LayersMissed =
+      trkDir.make<TH1F>("h_layersMissed", "# layers  [missed];# layers  [missed];# tracks", 11, -1, 10);
+  tkDetector_.HitsPixel = trkDir.make<TH1F>("h_hitsPixel", "# hits  [pixel];# hits  [pixel];# tracks", 11, -1, 10);
+  tkDetector_.HitsStrip = trkDir.make<TH1F>("h_hitsStrip", "# hits  [strip];# hits  [strip];# tracks", 41, -1, 40);
+  tkDetector_.Charge = trkDir.make<TH1F>("h_charge", "charge q;q  [e];# tracks", 5, -2, 3);
+  tkDetector_.Chi2 = trkDir.make<TH1F>("h_chi2", " #chi^{2};#chi^{2};# tracks", 100, 0, chi2Max);
+  tkDetector_.Ndof = trkDir.make<TH1F>("h_ndof", "# degrees of freedom f;f;# tracks", 101, -1, 100);
+  tkDetector_.NorChi2 = trkDir.make<TH1F>("h_norChi2", "normalized #chi^{2};#chi^{2}/f;# tracks", 200, 0, norChi2Max);
+  tkDetector_.Prob = trkDir.make<TH1F>("h_prob", " #chi^{2} probability;prob(#chi^{2},f);# tracks", 50, 0, 1);
+  tkDetector_.Eta = trkDir.make<TH1F>("h_eta", "pseudorapidity #eta;#eta;# tracks", 100, -5, 5);
+  tkDetector_.EtaErr = trkDir.make<TH1F>("h_etaErr", "Error of #eta;#sigma(#eta);# tracks", 100, 0, 0.001);
+  tkDetector_.EtaSig =
+      trkDir.make<TH1F>("h_etaSig", "Significance of #eta;#eta/#sigma(#eta);# tracks", 100, -20000, 20000);
+  tkDetector_.Theta = trkDir.make<TH1F>("h_theta", "polar angle #theta;#theta  [ ^{o}];# tracks", 100, -10, 190);
+  tkDetector_.Phi = trkDir.make<TH1F>("h_phi", "azimuth angle #phi;#phi  [ ^{o}];# tracks", 190, -190, 190);
+  tkDetector_.PhiErr = trkDir.make<TH1F>("h_phiErr", "Error of #phi;#sigma(#phi)  [ ^{o}];# tracks", 100, 0, 0.04);
+  tkDetector_.PhiSig =
+      trkDir.make<TH1F>("h_phiSig", "Significance of #phi;#phi/#sigma(#phi)  [ ^{o}];# tracks", 100, -50000, 50000);
+  tkDetector_.D0Beamspot = trkDir.make<TH1F>(
+      "h_d0Beamspot", "Closest approach d_{0} wrt. beamspot;d_{0, BS}  [cm];# tracks", 200, -d0max, d0max);
+  tkDetector_.D0BeamspotErr =
+      trkDir.make<TH1F>("h_d0BeamspotErr", "Error of d_{0, BS};#sigma(d_{0, BS})  [cm];# tracks", 200, 0, 0.01);
+  tkDetector_.D0BeamspotSig = trkDir.make<TH1F>(
+      "h_d0BeamspotSig", "Significance of d_{0, BS};d_{0, BS}/#sigma(d_{0, BS});# tracks", 100, -5, 5);
+  tkDetector_.Dz = trkDir.make<TH1F>("h_dz", "Closest approach d_{z};d_{z}  [cm];# tracks", 200, -dzmax, dzmax);
+  tkDetector_.DzErr = trkDir.make<TH1F>("h_dzErr", "Error of d_{z};#sigma(d_{z})  [cm];# tracks", 200, 0, 0.01);
+  tkDetector_.DzSig =
+      trkDir.make<TH1F>("h_dzSig", "Significance of d_{z};d_{z}/#sigma(d_{z});# tracks", 100, -10000, 10000);
+  tkDetector_.Pt = trkDir.make<TH1F>("h_pt", "transverse momentum p_{t};p_{t}  [GeV];# tracks", 100, 0, pMax);
+  tkDetector_.PtErr = trkDir.make<TH1F>("h_ptErr", "Error of p_{t};#sigma(p_{t})  [GeV];# tracks", 100, 0, 1.6);
+  tkDetector_.PtSig = trkDir.make<TH1F>("h_ptSig", "Significance of p_{t};p_{t}/#sigma(p_{t});# tracks", 100, 0, 200);
+  tkDetector_.P = trkDir.make<TH1F>("h_p", "momentum magnitude |p|;|p|  [GeV];# tracks", 100, 0, pMax);
+  tkDetector_.MeanAngle = trkDir.make<TH1F>(
+      "h_meanAngle", "mean angle on module <#phi_{module}>;<#phi_{module}>  [ ^{o}];# tracks", 100, -5, 95);
+  tkDetector_.HitsGood = trkDir.make<TH1F>("h_hitsGood", "# hits  [good];# hits  [good];# tracks", 51, -1, 50);
+
+  tkDetector_.MeanAngleVsHits = trkDir.make<TH2F>(
+      "h2_meanAngleVsHits", "<#phi_{module}> vs. # hits;# hits;<#phi_{module}>  [ ^{o}]", 51, -1, 50, 50, -5, 95);
+  tkDetector_.HitsGoodVsHitsValid =
+      trkDir.make<TH2F>("h2_hitsGoodVsHitsValid",
+                        "# hits  [good] vs. # hits  [valid];# hits  [valid];# hits  [good]",
+                        51,
+                        -1,
+                        50,
+                        51,
+                        -1,
+                        50);
+  tkDetector_.HitsPixelVsEta =
+      trkDir.make<TH2F>("h2_hitsPixelVsEta", "# hits  [pixel] vs. #eta;#eta;# hits  [pixel]", 60, -3, 3, 11, -1, 10);
+  tkDetector_.HitsPixelVsTheta = trkDir.make<TH2F>(
+      "h2_hitsPixelVsTheta", "# hits  [pixel] vs. #theta;#theta;# hits  [pixel]", 100, -10, 190, 11, -1, 10);
+  tkDetector_.HitsStripVsEta =
+      trkDir.make<TH2F>("h2_hitsStripVsEta", "# hits  [strip] vs. #eta;#eta;# hits  [strip]", 60, -3, 3, 31, -1, 40);
+  tkDetector_.HitsStripVsTheta = trkDir.make<TH2F>(
+      "h2_hitsStripVsTheta", "# hits  [strip] vs. #theta;#theta;# hits  [strip]", 100, -10, 190, 31, -1, 40);
+  tkDetector_.PtVsEta = trkDir.make<TH2F>("h2_ptVsEta", "p_{t} vs. #eta;#eta;p_{t}  [GeV]", 60, -3, 3, 100, 0, pMax);
+  tkDetector_.PtVsTheta =
+      trkDir.make<TH2F>("h2_ptVsTheta", "p_{t} vs. #theta;#theta;p_{t}  [GeV]", 100, -10, 190, 100, 0, pMax);
+
+  tkDetector_.PMeanAngleVsHits = trkDir.make<TProfile>(
+      "p_meanAngleVsHits", "<#phi_{module}> vs. # hits;# hits;<#phi_{module}>  [ ^{o}]", 51, -1, 50);
+  tkDetector_.PHitsGoodVsHitsValid = trkDir.make<TProfile>(
+      "p_hitsGoodVsHitsValid", "# hits  [good] vs. # hits  [valid];# hits  [valid];# hits  [good]", 51, -1, 50);
+  tkDetector_.PHitsPixelVsEta =
+      trkDir.make<TProfile>("p_hitsPixelVsEta", "# hits  [pixel] vs. #eta;#eta;# hits  [pixel]", 60, -3, 3);
+  tkDetector_.PHitsPixelVsTheta =
+      trkDir.make<TProfile>("p_hitsPixelVsTheta", "# hits  [pixel] vs. #theta;#theta;# hits  [pixel]", 100, -10, 190);
+  tkDetector_.PHitsStripVsEta =
+      trkDir.make<TProfile>("p_hitsStripVsEta", "# hits  [strip] vs. #eta;#eta;# hits  [strip]", 60, -3, 3);
+  tkDetector_.PHitsStripVsTheta =
+      trkDir.make<TProfile>("p_hitsStripVsTheta", "# hits  [strip] vs. #theta;#theta;# hits  [strip]", 100, -10, 190);
+  tkDetector_.PPtVsEta = trkDir.make<TProfile>("p_ptVsEta", "p_{t} vs. #eta;#eta;p_{t}  [GeV]", 60, -3, 3);
+  tkDetector_.PPtVsTheta = trkDir.make<TProfile>("p_ptVsTheta", "p_{t} vs. #theta;#theta;p_{t}  [GeV]", 100, -10, 190);
 }
-
-
 
 // -----------------------------------------------------------------------------------------------------------
 
+TrackStruct::TrackParameterStruct ApeEstimator::fillTrackVariables(const reco::Track& track,
+                                                                   const Trajectory& traj,
+                                                                   const reco::BeamSpot& beamSpot) {
+  const math::XYZPoint beamPoint(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
+  double d0BeamspotErr =
+      std::sqrt(track.d0Error() * track.d0Error() + 0.5 * beamSpot.BeamWidthX() * beamSpot.BeamWidthX() +
+                0.5 * beamSpot.BeamWidthY() * beamSpot.BeamWidthY());
 
-TrackStruct::TrackParameterStruct
-ApeEstimator::fillTrackVariables(const reco::Track& track, const Trajectory& traj, const reco::BeamSpot& beamSpot){
-  const math::XYZPoint beamPoint(beamSpot.x0(),beamSpot.y0(), beamSpot.z0());
-  double d0BeamspotErr = std::sqrt( track.d0Error()*track.d0Error() + 0.5*beamSpot.BeamWidthX()*beamSpot.BeamWidthX() + 0.5*beamSpot.BeamWidthY()*beamSpot.BeamWidthY() );
-  
   const static TrajectoryStateCombiner tsoscomb;
-  
+
   const reco::HitPattern& hitPattern(track.hitPattern());
-  
+
   TrackStruct::TrackParameterStruct trkParams;
-  
-  trkParams.hitsSize      = track.recHitsSize();
-  trkParams.hitsValid     = track.found(); // invalid is every hit from every single module that expects a hit
-  trkParams.hitsInvalid   = trkParams.hitsSize-trkParams.hitsValid;
-  trkParams.layersMissed  = track.lost();  // lost hit means, that a crossed layer doesn't contain a hit (can be more than one invalid hit)
-  trkParams.hitsPixel     = hitPattern.numberOfValidPixelHits();
-  trkParams.hitsStrip     = hitPattern.numberOfValidStripHits();
-  trkParams.charge        = track.charge();
-  trkParams.chi2          = track.chi2();
-  trkParams.ndof          = track.ndof();
-  trkParams.norChi2       = trkParams.chi2/trkParams.ndof;
-  trkParams.prob          = TMath::Prob(trkParams.chi2,trkParams.ndof);
-  trkParams.eta           = track.eta();
-  trkParams.etaErr        = track.etaError();
-  trkParams.theta         = track.theta();
-  trkParams.phi           = track.phi();
-  trkParams.phiErr        = track.phiError();
-  trkParams.d0            = track.d0();
-  trkParams.d0Beamspot    = -1.*track.dxy(beamPoint);
+
+  trkParams.hitsSize = track.recHitsSize();
+  trkParams.hitsValid = track.found();  // invalid is every hit from every single module that expects a hit
+  trkParams.hitsInvalid = trkParams.hitsSize - trkParams.hitsValid;
+  trkParams.layersMissed =
+      track.lost();  // lost hit means, that a crossed layer doesn't contain a hit (can be more than one invalid hit)
+  trkParams.hitsPixel = hitPattern.numberOfValidPixelHits();
+  trkParams.hitsStrip = hitPattern.numberOfValidStripHits();
+  trkParams.charge = track.charge();
+  trkParams.chi2 = track.chi2();
+  trkParams.ndof = track.ndof();
+  trkParams.norChi2 = trkParams.chi2 / trkParams.ndof;
+  trkParams.prob = TMath::Prob(trkParams.chi2, trkParams.ndof);
+  trkParams.eta = track.eta();
+  trkParams.etaErr = track.etaError();
+  trkParams.theta = track.theta();
+  trkParams.phi = track.phi();
+  trkParams.phiErr = track.phiError();
+  trkParams.d0 = track.d0();
+  trkParams.d0Beamspot = -1. * track.dxy(beamPoint);
   trkParams.d0BeamspotErr = d0BeamspotErr;
-  trkParams.dz            = track.dz();
-  trkParams.dzErr         = track.dzError();
-  trkParams.dzBeamspot    = track.dz(beamPoint);
-  trkParams.p             = track.p();
-  trkParams.pt            = track.pt();
-  trkParams.ptErr         = track.ptError();
-  
+  trkParams.dz = track.dz();
+  trkParams.dzErr = track.dzError();
+  trkParams.dzBeamspot = track.dz(beamPoint);
+  trkParams.p = track.p();
+  trkParams.pt = track.pt();
+  trkParams.ptErr = track.ptError();
+
   const std::vector<TrajectoryMeasurement>& v_meas = traj.measurements();
-     
-  int count2D(0); float meanPhiSensToNorm(0.F);
-  for(auto const & i_meas : v_meas){     
+
+  int count2D(0);
+  float meanPhiSensToNorm(0.F);
+  for (auto const& i_meas : v_meas) {
     const TrajectoryMeasurement& meas = i_meas;
     const TransientTrackingRecHit& hit = *meas.recHit();
     const TrackingRecHit& recHit = *hit.hit();
-    if(this->isHit2D(recHit)) ++count2D;
-    
-    TrajectoryStateOnSurface tsos = tsoscomb(meas.forwardPredictedState(),meas.backwardPredictedState());
+    if (this->isHit2D(recHit))
+      ++count2D;
+
+    TrajectoryStateOnSurface tsos = tsoscomb(meas.forwardPredictedState(), meas.backwardPredictedState());
     const align::LocalVector mom(tsos.localDirection());
-    meanPhiSensToNorm += atan(fabs(sqrt(mom.x()*mom.x()+mom.y()*mom.y())/mom.z()));
+    meanPhiSensToNorm += atan(fabs(sqrt(mom.x() * mom.x() + mom.y() * mom.y()) / mom.z()));
   }
-  meanPhiSensToNorm *= (1./static_cast<float>(trkParams.hitsSize));
-  
-  trkParams.hits2D            = count2D;
+  meanPhiSensToNorm *= (1. / static_cast<float>(trkParams.hitsSize));
+
+  trkParams.hits2D = count2D;
   trkParams.meanPhiSensToNorm = meanPhiSensToNorm;
-  
-  if(parameterSet_.getParameter<bool>("applyTrackCuts")){
+
+  if (parameterSet_.getParameter<bool>("applyTrackCuts")) {
     trackCut_ = false;
-    if(trkParams.hitsStrip<11 || trkParams.hits2D<2 || trkParams.hitsPixel<2 || //trkParams.hitsInvalid>2 ||
-       trkParams.hitsStrip>35 || trkParams.hitsPixel>7 ||
-       trkParams.norChi2>5. ||
-       trkParams.pt<25. || trkParams.pt>150. || 
-       std::abs(trkParams.d0Beamspot)>0.02 || std::abs(trkParams.dz)>15.)trackCut_ = true;
-  }
-  else{
+    if (trkParams.hitsStrip < 11 || trkParams.hits2D < 2 || trkParams.hitsPixel < 2 ||  //trkParams.hitsInvalid>2 ||
+        trkParams.hitsStrip > 35 || trkParams.hitsPixel > 7 || trkParams.norChi2 > 5. || trkParams.pt < 25. ||
+        trkParams.pt > 150. || std::abs(trkParams.d0Beamspot) > 0.02 || std::abs(trkParams.dz) > 15.)
+      trackCut_ = true;
+  } else {
     trackCut_ = false;
   }
-  
+
   return trkParams;
 }
 
-
-
-TrackStruct::HitParameterStruct
-ApeEstimator::fillHitVariables(const TrajectoryMeasurement& i_meas, const edm::EventSetup& iSetup){
+TrackStruct::HitParameterStruct ApeEstimator::fillHitVariables(const TrajectoryMeasurement& i_meas,
+                                                               const edm::EventSetup& iSetup) {
   TrackStruct::HitParameterStruct hitParams;
-  
+
   const static TrajectoryStateCombiner tsoscomb;
-  
+
   const TrajectoryMeasurement& meas = i_meas;
   const TransientTrackingRecHit& hit = *meas.recHit();
   const TrackingRecHit& recHit = *hit.hit();
-  const TrajectoryStateOnSurface& tsos = tsoscomb(meas.forwardPredictedState(),meas.backwardPredictedState());
-  
+  const TrajectoryStateOnSurface& tsos = tsoscomb(meas.forwardPredictedState(), meas.backwardPredictedState());
+
   const DetId& detId(hit.geographicalId());
-  const DetId::Detector& detector = detId.det(); if(detector != DetId::Tracker){hitParams.hitState = TrackStruct::notInTracker; return hitParams;}
-  const uint32_t rawId(detId.rawId());
-  
-  for(auto & i_sector : m_tkSector_){
-    for(auto const & i_rawId : i_sector.second.v_rawId){
-      if(rawId==i_rawId){hitParams.v_sector.push_back(i_sector.first); break;}
-    }
-  }
- 
-  const align::LocalVector& mom(tsos.localDirection());
-  int xMomentum(0), yMomentum(0), zMomentum(0);
-  xMomentum = mom.x()>0. ? 1 : -1;
-  yMomentum = mom.y()>0. ? 1 : -1;
-  zMomentum = mom.z()>0. ? 1 : -1;
-  float phiSensX = std::atan(std::fabs(mom.x()/mom.z()))*static_cast<float>(m_tkTreeVar_[rawId].vDirection);  // check for orientation of E- and B- Field (thoughts for barrel)
-  float phiSensY = std::atan(std::fabs(mom.y()/mom.z()))*static_cast<float>(m_tkTreeVar_[rawId].vDirection);
-  hitParams.phiSens  = std::atan(std::fabs(std::sqrt(mom.x()*mom.x()+mom.y()*mom.y())/mom.z()));
-  hitParams.phiSensX = (xMomentum==zMomentum ? phiSensX : -phiSensX );
-  hitParams.phiSensY = (yMomentum==zMomentum ? phiSensY : -phiSensY );
-  
-  if(!hit.isValid()){
-    hitParams.hitState = TrackStruct::invalid; 
+  const DetId::Detector& detector = detId.det();
+  if (detector != DetId::Tracker) {
+    hitParams.hitState = TrackStruct::notInTracker;
     return hitParams;
   }
-  
+  const uint32_t rawId(detId.rawId());
+
+  for (auto& i_sector : m_tkSector_) {
+    for (auto const& i_rawId : i_sector.second.v_rawId) {
+      if (rawId == i_rawId) {
+        hitParams.v_sector.push_back(i_sector.first);
+        break;
+      }
+    }
+  }
+
+  const align::LocalVector& mom(tsos.localDirection());
+  int xMomentum(0), yMomentum(0), zMomentum(0);
+  xMomentum = mom.x() > 0. ? 1 : -1;
+  yMomentum = mom.y() > 0. ? 1 : -1;
+  zMomentum = mom.z() > 0. ? 1 : -1;
+  float phiSensX =
+      std::atan(std::fabs(mom.x() / mom.z())) *
+      static_cast<float>(
+          m_tkTreeVar_[rawId].vDirection);  // check for orientation of E- and B- Field (thoughts for barrel)
+  float phiSensY = std::atan(std::fabs(mom.y() / mom.z())) * static_cast<float>(m_tkTreeVar_[rawId].vDirection);
+  hitParams.phiSens = std::atan(std::fabs(std::sqrt(mom.x() * mom.x() + mom.y() * mom.y()) / mom.z()));
+  hitParams.phiSensX = (xMomentum == zMomentum ? phiSensX : -phiSensX);
+  hitParams.phiSensY = (yMomentum == zMomentum ? phiSensY : -phiSensY);
+
+  if (!hit.isValid()) {
+    hitParams.hitState = TrackStruct::invalid;
+    return hitParams;
+  }
+
   // Get local positions and errors of hit and track
   const LocalPoint& lPHit = hit.localPosition();
   const LocalPoint& lPTrk = tsos.localPosition();
-  
+
   // use APE also for the hit error, while APE is automatically included in tsos error
   //
   //  no need to add  APE to hitError anymore by Ajay 27 Oct 2014
   const LocalError& errHitApe = hit.localPositionError();  // now sum of CPE+APE as said by MARCO?
   LocalError errorWithoutAPE;
-  
+
   bool Pixel(false);
   bool Strip(false);
 
-  if(       m_tkTreeVar_[rawId].subdetId==PixelSubdetector::PixelBarrel || m_tkTreeVar_[rawId].subdetId==PixelSubdetector::PixelEndcap){
+  if (m_tkTreeVar_[rawId].subdetId == PixelSubdetector::PixelBarrel ||
+      m_tkTreeVar_[rawId].subdetId == PixelSubdetector::PixelEndcap) {
     Pixel = true;
-  }else if( m_tkTreeVar_[rawId].subdetId==StripSubdetector::TIB || m_tkTreeVar_[rawId].subdetId==StripSubdetector::TOB ||
-            m_tkTreeVar_[rawId].subdetId==StripSubdetector::TID || m_tkTreeVar_[rawId].subdetId==StripSubdetector::TEC){
+  } else if (m_tkTreeVar_[rawId].subdetId == StripSubdetector::TIB ||
+             m_tkTreeVar_[rawId].subdetId == StripSubdetector::TOB ||
+             m_tkTreeVar_[rawId].subdetId == StripSubdetector::TID ||
+             m_tkTreeVar_[rawId].subdetId == StripSubdetector::TEC) {
     Strip = true;
-  }else{ 
-    edm::LogWarning("FillHitVariables")<<"cant identify wether hit is from pixel or strip";
-    hitParams.hitState = TrackStruct::invalid; return hitParams;
+  } else {
+    edm::LogWarning("FillHitVariables") << "cant identify wether hit is from pixel or strip";
+    hitParams.hitState = TrackStruct::invalid;
+    return hitParams;
   }
 
-  if(!hit.detUnit()){
-    hitParams.hitState = TrackStruct::invalid; 
+  if (!hit.detUnit()) {
+    hitParams.hitState = TrackStruct::invalid;
     return hitParams;
-  } // is it a single physical module?
+  }  // is it a single physical module?
   const GeomDetUnit& detUnit = *hit.detUnit();
 
-  if(Pixel){
-    if(!dynamic_cast<const PixelTopology*>(&detUnit.type().topology())){
-      hitParams.hitState = TrackStruct::invalid; 
+  if (Pixel) {
+    if (!dynamic_cast<const PixelTopology*>(&detUnit.type().topology())) {
+      hitParams.hitState = TrackStruct::invalid;
       return hitParams;
     }
-    const PixelGeomDetUnit * pixelDet = (const PixelGeomDetUnit*)(&detUnit);
+    const PixelGeomDetUnit* pixelDet = (const PixelGeomDetUnit*)(&detUnit);
     const LocalError& lape = pixelDet->localAlignmentError();
-    if (lape.valid()){ 
-      errorWithoutAPE = LocalError(errHitApe.xx() -lape.xx(), errHitApe.xy()- lape.xy(), errHitApe.yy()-lape.yy());
+    if (lape.valid()) {
+      errorWithoutAPE = LocalError(errHitApe.xx() - lape.xx(), errHitApe.xy() - lape.xy(), errHitApe.yy() - lape.yy());
     }
   }
-  if(Strip){
-    if(!dynamic_cast<const StripTopology*>(&detUnit.type().topology())){
-      hitParams.hitState = TrackStruct::invalid; 
+  if (Strip) {
+    if (!dynamic_cast<const StripTopology*>(&detUnit.type().topology())) {
+      hitParams.hitState = TrackStruct::invalid;
       return hitParams;
     }
-    const StripGeomDetUnit * stripDet = (const StripGeomDetUnit*)(&detUnit);
+    const StripGeomDetUnit* stripDet = (const StripGeomDetUnit*)(&detUnit);
     const LocalError& lape = stripDet->localAlignmentError();
-    if (lape.valid())
-              { errorWithoutAPE = LocalError(errHitApe.xx() -lape.xx(), errHitApe.xy()- lape.xy(), errHitApe.yy()-lape.yy());
+    if (lape.valid()) {
+      errorWithoutAPE = LocalError(errHitApe.xx() - lape.xx(), errHitApe.xy() - lape.xy(), errHitApe.yy() - lape.yy());
     }
   }
-
 
   const LocalError& errHitWoApe = errorWithoutAPE;
   const LocalError& errTrk = tsos.localError().positionError();
-  
+
   const StatePositionAndError2 positionAndError2Hit = this->positionAndError2(lPHit, errHitApe, hit);
   const StatePositionAndError2 positionAndError2HitWoApe = this->positionAndError2(lPHit, errHitWoApe, hit);
-  edm::LogInfo("CalculateAPE")<<"errHitWoApe  "<<errHitWoApe<<"errHitApe  "<<errHitApe;
+  edm::LogInfo("CalculateAPE") << "errHitWoApe  " << errHitWoApe << "errHitApe  " << errHitApe;
 
   const StatePositionAndError2 positionAndError2Trk = this->positionAndError2(lPTrk, errTrk, hit);
-  
+
   const TrackStruct::HitState& stateHit(positionAndError2Hit.first);
   const TrackStruct::HitState& stateHitWoApe(positionAndError2HitWoApe.first);
   const TrackStruct::HitState& stateTrk(positionAndError2Trk.first);
-  
-  if(stateHit==TrackStruct::invalid || stateHitWoApe==TrackStruct::invalid || stateTrk==TrackStruct::invalid){
+
+  if (stateHit == TrackStruct::invalid || stateHitWoApe == TrackStruct::invalid || stateTrk == TrackStruct::invalid) {
     hitParams.hitState = TrackStruct::invalid;
     return hitParams;
-  }else if(stateHit==TrackStruct::negativeError || stateHitWoApe==TrackStruct::negativeError || stateTrk==TrackStruct::negativeError){
+  } else if (stateHit == TrackStruct::negativeError || stateHitWoApe == TrackStruct::negativeError ||
+             stateTrk == TrackStruct::negativeError) {
     ++counter1;
     // Do not print error message by default
     //std::stringstream ss_error;
@@ -1143,265 +1467,271 @@ ApeEstimator::fillHitVariables(const TrajectoryMeasurement& i_meas, const edm::E
     hitParams.hitState = TrackStruct::negativeError;
     return hitParams;
   }
-  
-  
+
   // Calculate residuals
-  
+
   const float xHit = positionAndError2Hit.second.posX;
   const float xTrk = positionAndError2Trk.second.posX;
   const float yHit = positionAndError2Hit.second.posY;
   const float yTrk = positionAndError2Trk.second.posY;
-  
+
   const float errXHit2(positionAndError2Hit.second.errX2);
   const float errXHitWoApe2(positionAndError2HitWoApe.second.errX2);
   const float errXTrk2(positionAndError2Trk.second.errX2);
   const float errYHit2(positionAndError2Hit.second.errY2);
   const float errYHitWoApe2(positionAndError2HitWoApe.second.errY2);
   const float errYTrk2(positionAndError2Trk.second.errY2);
-  
+
   const float errXHit = std::sqrt(positionAndError2Hit.second.errX2);
   const float errXHitWoApe = std::sqrt(positionAndError2HitWoApe.second.errX2);
   const float errXTrk = std::sqrt(positionAndError2Trk.second.errX2);
   const float errYHit = std::sqrt(positionAndError2Hit.second.errY2);
   const float errYHitWoApe = std::sqrt(positionAndError2HitWoApe.second.errY2);
   const float errYTrk = std::sqrt(positionAndError2Trk.second.errY2);
-  
+
   const float resX = xTrk - xHit;
   const float resY = yTrk - yHit;
-  
+
   const float errX = std::sqrt(errXHit2 + errXTrk2);
   const float errXWoApe2 = errXHitWoApe2 + errXTrk2;
   const float errXWoApe = std::sqrt(errXWoApe2);
   const float errY = std::sqrt(errYHit2 + errYTrk2);
   const float errYWoApe2 = errYHitWoApe2 + errYTrk2;
   const float errYWoApe = std::sqrt(errYWoApe2);
-  
-  const float norResX = resX/errX;
-  const float norResY = resY/errY;
-  
-    
+
+  const float norResX = resX / errX;
+  const float norResY = resY / errY;
+
   // Take global orientation into account for residuals (sign is not important for errors)
-  
+
   float resXprime(999.F), resYprime(999.F), norResXprime(999.F), norResYprime(999.F);
-  if(m_tkTreeVar_[rawId].uDirection == 1){
-    resXprime = resX; 
+  if (m_tkTreeVar_[rawId].uDirection == 1) {
+    resXprime = resX;
     norResXprime = norResX;
-  }else if(m_tkTreeVar_[rawId].uDirection == -1){
-    resXprime = -resX; 
+  } else if (m_tkTreeVar_[rawId].uDirection == -1) {
+    resXprime = -resX;
     norResXprime = -norResX;
-  }else{
-    edm::LogError("FillHitVariables")<<"Incorrect value of uDirection, which gives global module orientation"; 
-    hitParams.hitState = TrackStruct::invalid; 
+  } else {
+    edm::LogError("FillHitVariables") << "Incorrect value of uDirection, which gives global module orientation";
+    hitParams.hitState = TrackStruct::invalid;
     return hitParams;
   }
-  if(m_tkTreeVar_[rawId].vDirection == 1){
-    resYprime = resY; 
+  if (m_tkTreeVar_[rawId].vDirection == 1) {
+    resYprime = resY;
     norResYprime = norResY;
-  }else if(m_tkTreeVar_[rawId].vDirection == -1){
-    resYprime = -resY; 
+  } else if (m_tkTreeVar_[rawId].vDirection == -1) {
+    resYprime = -resY;
     norResYprime = -norResY;
-  }else{
-    edm::LogError("FillHitVariables")<<"Incorrect value of vDirection, which gives global module orientation"; 
-    hitParams.hitState = TrackStruct::invalid; 
+  } else {
+    edm::LogError("FillHitVariables") << "Incorrect value of vDirection, which gives global module orientation";
+    hitParams.hitState = TrackStruct::invalid;
     return hitParams;
   }
-  
+
   hitParams.xHit = xHit;
   hitParams.xTrk = xTrk;
-  
+
   hitParams.errXHit = errXHit;
   hitParams.errXHitWoApe = errXHitWoApe;
   hitParams.errXTrk = errXTrk;
-  
-  hitParams.errX2 = errX*errX;
+
+  hitParams.errX2 = errX * errX;
   hitParams.errX = errX;
   hitParams.errXWoApe = errXWoApe;
 
   hitParams.resX = resXprime;
   hitParams.norResX = norResXprime;
-  
-  const float norResX2(norResXprime*norResXprime);
-  hitParams.probX = TMath::Prob(norResX2,1);
-  
-  
+
+  const float norResX2(norResXprime * norResXprime);
+  hitParams.probX = TMath::Prob(norResX2, 1);
+
   hitParams.yHit = yHit;
   hitParams.yTrk = yTrk;
-  
+
   hitParams.errYHit = errYHit;
   hitParams.errYHitWoApe = errYHitWoApe;
   hitParams.errYTrk = errYTrk;
-  
-  hitParams.errY2 = errY*errY;
+
+  hitParams.errY2 = errY * errY;
   hitParams.errY = errY;
   hitParams.errYWoApe = errYWoApe;
 
   hitParams.resY = resYprime;
   hitParams.norResY = norResYprime;
-  
-  const float norResY2(norResYprime*norResYprime);
-  hitParams.probY = TMath::Prob(norResY2,1);
-  
-  
+
+  const float norResY2(norResYprime * norResYprime);
+  hitParams.probY = TMath::Prob(norResY2, 1);
+
   // Cluster parameters
-  
-  if(m_tkTreeVar_[rawId].subdetId==PixelSubdetector::PixelBarrel || m_tkTreeVar_[rawId].subdetId==PixelSubdetector::PixelEndcap){
+
+  if (m_tkTreeVar_[rawId].subdetId == PixelSubdetector::PixelBarrel ||
+      m_tkTreeVar_[rawId].subdetId == PixelSubdetector::PixelEndcap) {
     const SiPixelRecHit& pixelHit = dynamic_cast<const SiPixelRecHit&>(recHit);
     const SiPixelCluster& pixelCluster = *pixelHit.cluster();
-    
+
     hitParams.chargePixel = pixelCluster.charge();
     hitParams.widthX = pixelCluster.sizeX();
     hitParams.baryStripX = pixelCluster.x();
     hitParams.widthY = pixelCluster.sizeY();
     hitParams.baryStripY = pixelCluster.y();
-    
+
     hitParams.clusterProbabilityXY = pixelHit.clusterProbability(0);
     hitParams.clusterProbabilityQ = pixelHit.clusterProbability(2);
     hitParams.clusterProbabilityXYQ = pixelHit.clusterProbability(1);
     hitParams.logClusterProbability = std::log10(hitParams.clusterProbabilityXY);
-    
+
     hitParams.isOnEdge = pixelHit.isOnEdge();
     hitParams.hasBadPixels = pixelHit.hasBadPixels();
     hitParams.spansTwoRoc = pixelHit.spansTwoROCs();
     hitParams.qBin = pixelHit.qBin();
-    
+
     hitParams.isPixelHit = true;
-  }else if( m_tkTreeVar_[rawId].subdetId==StripSubdetector::TIB || m_tkTreeVar_[rawId].subdetId==StripSubdetector::TOB ||
-            m_tkTreeVar_[rawId].subdetId==StripSubdetector::TID || m_tkTreeVar_[rawId].subdetId==StripSubdetector::TEC){
-    if(!(dynamic_cast<const SiStripRecHit2D*>(&recHit) || dynamic_cast<const SiStripRecHit1D*>(&recHit))){
-      edm::LogError("FillHitVariables")<<"RecHit in Strip is 'Matched' or 'Projected', but here all should be monohits per module";
-      hitParams.hitState = TrackStruct::invalid; return hitParams;
+  } else if (m_tkTreeVar_[rawId].subdetId == StripSubdetector::TIB ||
+             m_tkTreeVar_[rawId].subdetId == StripSubdetector::TOB ||
+             m_tkTreeVar_[rawId].subdetId == StripSubdetector::TID ||
+             m_tkTreeVar_[rawId].subdetId == StripSubdetector::TEC) {
+    if (!(dynamic_cast<const SiStripRecHit2D*>(&recHit) || dynamic_cast<const SiStripRecHit1D*>(&recHit))) {
+      edm::LogError("FillHitVariables")
+          << "RecHit in Strip is 'Matched' or 'Projected', but here all should be monohits per module";
+      hitParams.hitState = TrackStruct::invalid;
+      return hitParams;
     }
     const SiStripCluster* clusterPtr(nullptr);
-    if( m_tkTreeVar_[rawId].subdetId==StripSubdetector::TIB || m_tkTreeVar_[rawId].subdetId==StripSubdetector::TOB){
-      if(dynamic_cast<const SiStripRecHit1D*>(&recHit)){
+    if (m_tkTreeVar_[rawId].subdetId == StripSubdetector::TIB ||
+        m_tkTreeVar_[rawId].subdetId == StripSubdetector::TOB) {
+      if (dynamic_cast<const SiStripRecHit1D*>(&recHit)) {
         const SiStripRecHit1D& stripHit = dynamic_cast<const SiStripRecHit1D&>(recHit);
         clusterPtr = &(*stripHit.cluster());
-      }else if(dynamic_cast<const SiStripRecHit2D*>(&recHit)){
-        edm::LogWarning("FillHitVariables")<<"Data has TIB/TOB hits as SiStripRecHit2D and not 1D. Probably data is processed with CMSSW<34X. Nevertheless everything should work fine";
+      } else if (dynamic_cast<const SiStripRecHit2D*>(&recHit)) {
+        edm::LogWarning("FillHitVariables") << "Data has TIB/TOB hits as SiStripRecHit2D and not 1D. Probably data is "
+                                               "processed with CMSSW<34X. Nevertheless everything should work fine";
         const SiStripRecHit2D& stripHit = dynamic_cast<const SiStripRecHit2D&>(recHit);
         clusterPtr = &(*stripHit.cluster());
       }
-    }else if( m_tkTreeVar_[rawId].subdetId==StripSubdetector::TID || m_tkTreeVar_[rawId].subdetId==StripSubdetector::TEC){
-       const SiStripRecHit2D& stripHit = dynamic_cast<const SiStripRecHit2D&>(recHit);
-       clusterPtr = &(*stripHit.cluster());
+    } else if (m_tkTreeVar_[rawId].subdetId == StripSubdetector::TID ||
+               m_tkTreeVar_[rawId].subdetId == StripSubdetector::TEC) {
+      const SiStripRecHit2D& stripHit = dynamic_cast<const SiStripRecHit2D&>(recHit);
+      clusterPtr = &(*stripHit.cluster());
     }
-    if(!clusterPtr){
-      edm::LogError("FillHitVariables")<<"Pointer to cluster not valid!!! This should never happen...";
-      hitParams.hitState = TrackStruct::invalid; return hitParams;
+    if (!clusterPtr) {
+      edm::LogError("FillHitVariables") << "Pointer to cluster not valid!!! This should never happen...";
+      hitParams.hitState = TrackStruct::invalid;
+      return hitParams;
     }
     const SiStripCluster& stripCluster(*clusterPtr);
-    
-    const SiStripClusterInfo clusterInfo =SiStripClusterInfo(stripCluster,iSetup,rawId,std::string(""));
+
+    const SiStripClusterInfo clusterInfo = SiStripClusterInfo(stripCluster, iSetup, rawId, std::string(""));
 
     const std::vector<uint8_t>::const_iterator stripChargeL(clusterInfo.stripCharges().begin());
     const std::vector<uint8_t>::const_iterator stripChargeR(--(clusterInfo.stripCharges().end()));
-    const std::pair<uint16_t, uint16_t> stripChargeLR = std::make_pair(*stripChargeL,*stripChargeR);
-    
-    hitParams.chargeStrip      = clusterInfo.charge();
-    hitParams.widthX           = clusterInfo.width();
-    hitParams.baryStripX       = clusterInfo.baryStrip() +1.;
-    hitParams.isModuleUsable   = clusterInfo.IsModuleUsable();
-    hitParams.maxStrip         = clusterInfo.maxStrip() +1;
-    hitParams.maxStripInv      = m_tkTreeVar_[rawId].nStrips - hitParams.maxStrip +1;
-    hitParams.maxCharge        = clusterInfo.maxCharge();
-    hitParams.maxIndex         = clusterInfo.maxIndex();
-    hitParams.chargeOnEdges    = static_cast<float>(stripChargeLR.first + stripChargeLR.second)/static_cast<float>(hitParams.chargeStrip);
-    hitParams.chargeAsymmetry  = static_cast<float>(stripChargeLR.first - stripChargeLR.second)/static_cast<float>(stripChargeLR.first + stripChargeLR.second);
-    hitParams.chargeLRplus     = static_cast<float>(clusterInfo.chargeLR().first + clusterInfo.chargeLR().second)/static_cast<float>(hitParams.chargeStrip);
-    hitParams.chargeLRminus    = static_cast<float>(clusterInfo.chargeLR().first - clusterInfo.chargeLR().second)/static_cast<float>(hitParams.chargeStrip);
-    hitParams.sOverN          = clusterInfo.signalOverNoise();
+    const std::pair<uint16_t, uint16_t> stripChargeLR = std::make_pair(*stripChargeL, *stripChargeR);
 
+    hitParams.chargeStrip = clusterInfo.charge();
+    hitParams.widthX = clusterInfo.width();
+    hitParams.baryStripX = clusterInfo.baryStrip() + 1.;
+    hitParams.isModuleUsable = clusterInfo.IsModuleUsable();
+    hitParams.maxStrip = clusterInfo.maxStrip() + 1;
+    hitParams.maxStripInv = m_tkTreeVar_[rawId].nStrips - hitParams.maxStrip + 1;
+    hitParams.maxCharge = clusterInfo.maxCharge();
+    hitParams.maxIndex = clusterInfo.maxIndex();
+    hitParams.chargeOnEdges =
+        static_cast<float>(stripChargeLR.first + stripChargeLR.second) / static_cast<float>(hitParams.chargeStrip);
+    hitParams.chargeAsymmetry = static_cast<float>(stripChargeLR.first - stripChargeLR.second) /
+                                static_cast<float>(stripChargeLR.first + stripChargeLR.second);
+    hitParams.chargeLRplus = static_cast<float>(clusterInfo.chargeLR().first + clusterInfo.chargeLR().second) /
+                             static_cast<float>(hitParams.chargeStrip);
+    hitParams.chargeLRminus = static_cast<float>(clusterInfo.chargeLR().first - clusterInfo.chargeLR().second) /
+                              static_cast<float>(hitParams.chargeStrip);
+    hitParams.sOverN = clusterInfo.signalOverNoise();
 
     // Calculate projection length corrected by drift
-    if(!hit.detUnit()){
-      hitParams.hitState = TrackStruct::invalid; 
+    if (!hit.detUnit()) {
+      hitParams.hitState = TrackStruct::invalid;
       return hitParams;
-    } // is it a single physical module?
+    }  // is it a single physical module?
     const GeomDetUnit& detUnit = *hit.detUnit();
-    if(!dynamic_cast<const StripTopology*>(&detUnit.type().topology())){
-      hitParams.hitState = TrackStruct::invalid; 
+    if (!dynamic_cast<const StripTopology*>(&detUnit.type().topology())) {
+      hitParams.hitState = TrackStruct::invalid;
       return hitParams;
     }
-    
-    
+
     edm::ESHandle<MagneticField> magFieldHandle;
     iSetup.get<IdealMagneticFieldRecord>().get(magFieldHandle);
-   
+
     edm::ESHandle<SiStripLorentzAngle> lorentzAngleHandle;
     iSetup.get<SiStripLorentzAngleDepRcd>().get(lorentzAngleHandle);  //MODIFIED BY LOIC QUERTENMONT
 
-
-    const StripGeomDetUnit * stripDet = (const StripGeomDetUnit*)(&detUnit);
-    const MagneticField * magField(magFieldHandle.product());
+    const StripGeomDetUnit* stripDet = (const StripGeomDetUnit*)(&detUnit);
+    const MagneticField* magField(magFieldHandle.product());
     LocalVector bField = (stripDet->surface()).toLocal(magField->inTesla(stripDet->surface().position()));
-    const SiStripLorentzAngle * lorentzAngle(lorentzAngleHandle.product());
+    const SiStripLorentzAngle* lorentzAngle(lorentzAngleHandle.product());
     float tanLorentzAnglePerTesla = lorentzAngle->getLorentzAngle(stripDet->geographicalId().rawId());
 
     float dirX = -tanLorentzAnglePerTesla * bField.y();
     float dirY = tanLorentzAnglePerTesla * bField.x();
-    float dirZ = 1.; // E field always in z direction
-    LocalVector driftDirection(dirX,dirY,dirZ);
-    
-    
+    float dirZ = 1.;  // E field always in z direction
+    LocalVector driftDirection(dirX, dirY, dirZ);
+
     const Bounds& bounds = stripDet->specificSurface().bounds();
-    float maxLength = std::sqrt(std::pow(bounds.length(),2)+std::pow(bounds.width(),2));
+    float maxLength = std::sqrt(std::pow(bounds.length(), 2) + std::pow(bounds.width(), 2));
     float thickness = bounds.thickness();
-    
-    
-    
+
     const StripTopology& topol = dynamic_cast<const StripTopology&>(detUnit.type().topology());
     LocalVector momentumDir(tsos.localDirection());
     LocalPoint momentumPos(tsos.localPosition());
     LocalVector scaledMomentumDir(momentumDir);
-    if(momentumDir.z() > 0.)scaledMomentumDir *= std::fabs(thickness/momentumDir.z());
-    else if(momentumDir.z() < 0.)scaledMomentumDir *= -std::fabs(thickness/momentumDir.z());
-    else scaledMomentumDir *= maxLength/momentumDir.mag();
-    
-    float projEdge1 = topol.measurementPosition(momentumPos - 0.5*scaledMomentumDir).x();
-    if(projEdge1 < 0.)projEdge1 = 0.;
-    else if(projEdge1 > m_tkTreeVar_[rawId].nStrips)projEdge1 = m_tkTreeVar_[rawId].nStrips;
-    float projEdge2 = topol.measurementPosition(momentumPos + 0.5*scaledMomentumDir).x();
-    if(projEdge2 < 0.)projEdge1 = 0.;
-    else if(projEdge2 > m_tkTreeVar_[rawId].nStrips)projEdge1 = m_tkTreeVar_[rawId].nStrips;
-    
-    
+    if (momentumDir.z() > 0.)
+      scaledMomentumDir *= std::fabs(thickness / momentumDir.z());
+    else if (momentumDir.z() < 0.)
+      scaledMomentumDir *= -std::fabs(thickness / momentumDir.z());
+    else
+      scaledMomentumDir *= maxLength / momentumDir.mag();
+
+    float projEdge1 = topol.measurementPosition(momentumPos - 0.5 * scaledMomentumDir).x();
+    if (projEdge1 < 0.)
+      projEdge1 = 0.;
+    else if (projEdge1 > m_tkTreeVar_[rawId].nStrips)
+      projEdge1 = m_tkTreeVar_[rawId].nStrips;
+    float projEdge2 = topol.measurementPosition(momentumPos + 0.5 * scaledMomentumDir).x();
+    if (projEdge2 < 0.)
+      projEdge1 = 0.;
+    else if (projEdge2 > m_tkTreeVar_[rawId].nStrips)
+      projEdge1 = m_tkTreeVar_[rawId].nStrips;
+
     float coveredStrips = std::fabs(projEdge2 - projEdge1);
-    
+
     hitParams.projWidth = coveredStrips;
-      
-    
-  }
-  else{
-    edm::LogError("FillHitVariables")<<"Incorrect subdetector ID, hit not associated to tracker";
-    hitParams.hitState = TrackStruct::notInTracker; return hitParams;
-  }
-  
-  
-  if(!hitParams.isModuleUsable){
-    hitParams.hitState = TrackStruct::invalid; 
+
+  } else {
+    edm::LogError("FillHitVariables") << "Incorrect subdetector ID, hit not associated to tracker";
+    hitParams.hitState = TrackStruct::notInTracker;
     return hitParams;
   }
-  
-  if(hitParams.v_sector.empty()){
-    hitParams.hitState = TrackStruct::notAssignedToSectors; 
+
+  if (!hitParams.isModuleUsable) {
+    hitParams.hitState = TrackStruct::invalid;
     return hitParams;
   }
-  
+
+  if (hitParams.v_sector.empty()) {
+    hitParams.hitState = TrackStruct::notAssignedToSectors;
+    return hitParams;
+  }
+
   return hitParams;
-//}  
+  //}
 }
 
+ApeEstimator::StatePositionAndError2 ApeEstimator::positionAndError2(const LocalPoint& localPoint,
+                                                                     const LocalError& localError,
+                                                                     const TransientTrackingRecHit& hit) {
+  StatePositionAndError2 vPE2 = std::make_pair(TrackStruct::invalid, PositionAndError2());
 
-
-ApeEstimator::StatePositionAndError2
-ApeEstimator::positionAndError2(const LocalPoint& localPoint, const LocalError& localError, const TransientTrackingRecHit& hit){
-  StatePositionAndError2 vPE2 = std::make_pair(TrackStruct::invalid,PositionAndError2());
-  
   const DetId& detId(hit.geographicalId());
   const uint32_t& rawId(detId.rawId());
   const unsigned int& subdetId(m_tkTreeVar_[rawId].subdetId);
-  
-  if(localError.xx()<0. || localError.yy()<0.){
+
+  if (localError.xx() < 0. || localError.yy() < 0.) {
     // Do not print error message by default
     //edm::LogError("Negative error Value")<<"@SUB=ApeEstimator::fillHitVariables"
     //                                     <<"One of the squared error methods gives negative result\n"
@@ -1410,22 +1740,23 @@ ApeEstimator::positionAndError2(const LocalPoint& localPoint, const LocalError& 
     vPE2.first = TrackStruct::negativeError;
     return vPE2;
   }
-  
-  if(subdetId==PixelSubdetector::PixelBarrel || subdetId==PixelSubdetector::PixelEndcap ||
-     subdetId==StripSubdetector::TIB || subdetId==StripSubdetector::TOB){
+
+  if (subdetId == PixelSubdetector::PixelBarrel || subdetId == PixelSubdetector::PixelEndcap ||
+      subdetId == StripSubdetector::TIB || subdetId == StripSubdetector::TOB) {
     // Cartesian coordinates
     vPE2 = std::make_pair(TrackStruct::ok, this->rectangularPositionAndError2(localPoint, localError));
-  }
-  else if(subdetId==StripSubdetector::TID || subdetId==StripSubdetector::TEC){
+  } else if (subdetId == StripSubdetector::TID || subdetId == StripSubdetector::TEC) {
     // Local x in radial coordinates
-    if(!hit.detUnit())return vPE2; // is it a single physical module?
+    if (!hit.detUnit())
+      return vPE2;  // is it a single physical module?
     const GeomDetUnit& detUnit = *hit.detUnit();
-    
-    if(!dynamic_cast<const RadialStripTopology*>(&detUnit.type().topology()))return vPE2;
+
+    if (!dynamic_cast<const RadialStripTopology*>(&detUnit.type().topology()))
+      return vPE2;
     const RadialStripTopology& topol = dynamic_cast<const RadialStripTopology&>(detUnit.type().topology());
-    
-    MeasurementError measError = topol.measurementError(localPoint,localError);
-    if(measError.uu()<0. || measError.vv()<0.){
+
+    MeasurementError measError = topol.measurementError(localPoint, localError);
+    if (measError.uu() < 0. || measError.vv() < 0.) {
       // Do not print error message by default
       //edm::LogError("Negative error Value")<<"@SUB=ApeEstimator::fillHitVariables"
       //                                     <<"One of the squared error methods gives negative result\n"
@@ -1439,67 +1770,58 @@ ApeEstimator::positionAndError2(const LocalPoint& localPoint, const LocalError& 
       return vPE2;
     }
     vPE2 = std::make_pair(TrackStruct::ok, this->radialPositionAndError2(localPoint, localError, topol));
-  }else{
-    edm::LogError("FillHitVariables")<<"Incorrect subdetector ID, hit not associated to tracker";
+  } else {
+    edm::LogError("FillHitVariables") << "Incorrect subdetector ID, hit not associated to tracker";
   }
-  
+
   return vPE2;
 }
 
-
-
-ApeEstimator::PositionAndError2
-ApeEstimator::rectangularPositionAndError2(const LocalPoint& lP, const LocalError& lE){
+ApeEstimator::PositionAndError2 ApeEstimator::rectangularPositionAndError2(const LocalPoint& lP, const LocalError& lE) {
   const float x(lP.x());
   const float y(lP.y());
   const float errX2(lE.xx());
   const float errY2(lE.yy());
-  
+
   return PositionAndError2(x, y, errX2, errY2);
 }
 
-
-
-ApeEstimator::PositionAndError2
-ApeEstimator::radialPositionAndError2(const LocalPoint& lP, const LocalError& lE, const RadialStripTopology& topol){
+ApeEstimator::PositionAndError2 ApeEstimator::radialPositionAndError2(const LocalPoint& lP,
+                                                                      const LocalError& lE,
+                                                                      const RadialStripTopology& topol) {
   MeasurementPoint measPos = topol.measurementPosition(lP);
-  MeasurementError measErr = topol.measurementError(lP,lE);
-  
+  MeasurementError measErr = topol.measurementError(lP, lE);
+
   const float r_0 = topol.originToIntersection();
   const float stripLength = topol.localStripLength(lP);
   const float phi = topol.stripAngle(measPos.x());
-  
+
   float x(-999.F);
   float y(-999.F);
   float errX2(-999.F);
   float errY2(-999.F);
-  
-  x = phi*r_0;
+
+  x = phi * r_0;
   // Radial y (not symmetric around 0; radial distance with minimum at middle strip at lower edge [0, yMax])
-  const float l_0 = r_0 - topol.detHeight()/2;
+  const float l_0 = r_0 - topol.detHeight() / 2;
   const float cosPhi(std::cos(phi));
-  y = measPos.y()*stripLength - 0.5*stripLength + l_0*(1./cosPhi - 1.);
-  
-  const float angularWidth2(topol.angularWidth()*topol.angularWidth());
-  const float errPhi2(measErr.uu()*angularWidth2);
-  
-  errX2 = errPhi2*r_0*r_0;
+  y = measPos.y() * stripLength - 0.5 * stripLength + l_0 * (1. / cosPhi - 1.);
+
+  const float angularWidth2(topol.angularWidth() * topol.angularWidth());
+  const float errPhi2(measErr.uu() * angularWidth2);
+
+  errX2 = errPhi2 * r_0 * r_0;
   // Radial y (not symmetric around 0, real radial distance from intersection point)
-  const float cosPhi4(std::pow(cosPhi,4)), sinPhi2(std::sin(phi)*std::sin(phi));
-  const float helpSummand = l_0*l_0*(sinPhi2/cosPhi4*errPhi2);
-  errY2 = measErr.vv()*stripLength*stripLength + helpSummand;
+  const float cosPhi4(std::pow(cosPhi, 4)), sinPhi2(std::sin(phi) * std::sin(phi));
+  const float helpSummand = l_0 * l_0 * (sinPhi2 / cosPhi4 * errPhi2);
+  errY2 = measErr.vv() * stripLength * stripLength + helpSummand;
 
   return PositionAndError2(x, y, errX2, errY2);
 }
 
-
-
-
-
 // -----------------------------------------------------------------------------------------------------------
 
-void
-ApeEstimator::hitSelection(){
+void ApeEstimator::hitSelection() {
   this->setHitSelectionMapUInt("width");
   this->setHitSelectionMap("widthProj");
   this->setHitSelectionMap("widthDiff");
@@ -1512,11 +1834,11 @@ ApeEstimator::hitSelection(){
   this->setHitSelectionMap("chargeLRplus");
   this->setHitSelectionMap("chargeLRminus");
   this->setHitSelectionMap("sOverN");
-  
+
   this->setHitSelectionMap("chargePixel");
   this->setHitSelectionMapUInt("widthX");
   this->setHitSelectionMapUInt("widthY");
-  
+
   this->setHitSelectionMap("baryStripX");
   this->setHitSelectionMap("baryStripY");
   this->setHitSelectionMap("clusterProbabilityXY");
@@ -1527,7 +1849,7 @@ ApeEstimator::hitSelection(){
   this->setHitSelectionMapUInt("hasBadPixels");
   this->setHitSelectionMapUInt("spansTwoRoc");
   this->setHitSelectionMapUInt("qBin");
-  
+
   this->setHitSelectionMap("phiSens");
   this->setHitSelectionMap("phiSensX");
   this->setHitSelectionMap("phiSensY");
@@ -1538,7 +1860,7 @@ ApeEstimator::hitSelection(){
   this->setHitSelectionMap("errXTrk");
   this->setHitSelectionMap("errX");
   this->setHitSelectionMap("errX2");
-  
+
   this->setHitSelectionMap("resY");
   this->setHitSelectionMap("norResY");
   this->setHitSelectionMap("probY");
@@ -1546,71 +1868,83 @@ ApeEstimator::hitSelection(){
   this->setHitSelectionMap("errYTrk");
   this->setHitSelectionMap("errY");
   this->setHitSelectionMap("errY2");
-  
-  edm::LogInfo("HitSelector")<<"applying hit cuts ...";
+
+  edm::LogInfo("HitSelector") << "applying hit cuts ...";
   bool emptyMap(true);
-  for(auto & i_hitSelection : m_hitSelection_){
-    if(!i_hitSelection.second.empty()){
-      int entry(1); double intervalBegin(999.);
-      for(std::vector<double>::iterator i_hitInterval = i_hitSelection.second.begin(); i_hitInterval != i_hitSelection.second.end(); ++entry){
-        if(entry%2==1){
-          intervalBegin = *i_hitInterval; ++i_hitInterval;
-        }else{
-          if(intervalBegin > *i_hitInterval){
-            edm::LogError("HitSelector")<<"INVALID Interval selected for  "<<i_hitSelection.first<<":\t"<<intervalBegin<<" > "<<(*i_hitInterval)
-                                  <<"\n ... delete Selection for "<<i_hitSelection.first;
-            i_hitSelection.second.clear(); i_hitInterval = i_hitSelection.second.begin(); //emptyMap = true; i_hitSelection = m_hitSelection_.begin();
-          }else{
-            edm::LogInfo("HitSelector")<<"Interval selected for  "<<i_hitSelection.first<<":\t"<<intervalBegin<<", "<<(*i_hitInterval);
-            ++i_hitInterval;
-          }
-        }
-      }
-      if(!i_hitSelection.second.empty())emptyMap = false;
-    }
-  }
-  
-  
-  bool emptyMapUInt(true);
-  for(auto & i_hitSelection : m_hitSelectionUInt_){
-    if(!i_hitSelection.second.empty()){
-      int entry(1); unsigned int intervalBegin(999);
-      for(std::vector<unsigned int>::iterator i_hitInterval = i_hitSelection.second.begin(); i_hitInterval != i_hitSelection.second.end(); ++entry){
-        if(entry%2==1){
-          intervalBegin = *i_hitInterval; 
+  for (auto& i_hitSelection : m_hitSelection_) {
+    if (!i_hitSelection.second.empty()) {
+      int entry(1);
+      double intervalBegin(999.);
+      for (std::vector<double>::iterator i_hitInterval = i_hitSelection.second.begin();
+           i_hitInterval != i_hitSelection.second.end();
+           ++entry) {
+        if (entry % 2 == 1) {
+          intervalBegin = *i_hitInterval;
           ++i_hitInterval;
-        }else{
-          if(intervalBegin > *i_hitInterval){
-            edm::LogError("HitSelector")<<"INVALID Interval selected for  "<<i_hitSelection.first<<":\t"<<intervalBegin<<" > "<<(*i_hitInterval)
-                                  <<"\n ... delete Selection for "<<i_hitSelection.first;
-            i_hitSelection.second.clear(); i_hitInterval = i_hitSelection.second.begin(); //emptyMap = true; i_hitSelection = m_hitSelection_.begin();
-          }else{
-            edm::LogInfo("HitSelector")<<"Interval selected for  "<<i_hitSelection.first<<":\t"<<intervalBegin<<", "<<(*i_hitInterval);
+        } else {
+          if (intervalBegin > *i_hitInterval) {
+            edm::LogError("HitSelector") << "INVALID Interval selected for  " << i_hitSelection.first << ":\t"
+                                         << intervalBegin << " > " << (*i_hitInterval) << "\n ... delete Selection for "
+                                         << i_hitSelection.first;
+            i_hitSelection.second.clear();
+            i_hitInterval = i_hitSelection.second.begin();  //emptyMap = true; i_hitSelection = m_hitSelection_.begin();
+          } else {
+            edm::LogInfo("HitSelector") << "Interval selected for  " << i_hitSelection.first << ":\t" << intervalBegin
+                                        << ", " << (*i_hitInterval);
             ++i_hitInterval;
           }
         }
       }
-      if(!i_hitSelection.second.empty())emptyMapUInt = false;
+      if (!i_hitSelection.second.empty())
+        emptyMap = false;
     }
   }
-  
-  if(emptyMap && emptyMapUInt){
+
+  bool emptyMapUInt(true);
+  for (auto& i_hitSelection : m_hitSelectionUInt_) {
+    if (!i_hitSelection.second.empty()) {
+      int entry(1);
+      unsigned int intervalBegin(999);
+      for (std::vector<unsigned int>::iterator i_hitInterval = i_hitSelection.second.begin();
+           i_hitInterval != i_hitSelection.second.end();
+           ++entry) {
+        if (entry % 2 == 1) {
+          intervalBegin = *i_hitInterval;
+          ++i_hitInterval;
+        } else {
+          if (intervalBegin > *i_hitInterval) {
+            edm::LogError("HitSelector") << "INVALID Interval selected for  " << i_hitSelection.first << ":\t"
+                                         << intervalBegin << " > " << (*i_hitInterval) << "\n ... delete Selection for "
+                                         << i_hitSelection.first;
+            i_hitSelection.second.clear();
+            i_hitInterval = i_hitSelection.second.begin();  //emptyMap = true; i_hitSelection = m_hitSelection_.begin();
+          } else {
+            edm::LogInfo("HitSelector") << "Interval selected for  " << i_hitSelection.first << ":\t" << intervalBegin
+                                        << ", " << (*i_hitInterval);
+            ++i_hitInterval;
+          }
+        }
+      }
+      if (!i_hitSelection.second.empty())
+        emptyMapUInt = false;
+    }
+  }
+
+  if (emptyMap && emptyMapUInt) {
     m_hitSelection_.clear();
     m_hitSelectionUInt_.clear();
-    edm::LogInfo("HitSelector")<<"NO hit cuts applied";
+    edm::LogInfo("HitSelector") << "NO hit cuts applied";
   }
   return;
 }
 
-
-
-void
-ApeEstimator::setHitSelectionMap(const std::string& cutVariable){
+void ApeEstimator::setHitSelectionMap(const std::string& cutVariable) {
   edm::ParameterSet parSet(parameterSet_.getParameter<edm::ParameterSet>("HitSelector"));
   std::vector<double> v_cutVariable(parSet.getParameter<std::vector<double> >(cutVariable));
-  if(v_cutVariable.size()%2==1){
-    edm::LogError("HitSelector")<<"Invalid Hit Selection for "<<cutVariable<<": need even number of arguments (intervals)"
-                                <<"\n ... delete Selection for "<<cutVariable;
+  if (v_cutVariable.size() % 2 == 1) {
+    edm::LogError("HitSelector") << "Invalid Hit Selection for " << cutVariable
+                                 << ": need even number of arguments (intervals)"
+                                 << "\n ... delete Selection for " << cutVariable;
     v_cutVariable.clear();
     m_hitSelection_[cutVariable] = v_cutVariable;
     return;
@@ -1619,14 +1953,13 @@ ApeEstimator::setHitSelectionMap(const std::string& cutVariable){
   return;
 }
 
-
-void
-ApeEstimator::setHitSelectionMapUInt(const std::string& cutVariable){
+void ApeEstimator::setHitSelectionMapUInt(const std::string& cutVariable) {
   edm::ParameterSet parSet(parameterSet_.getParameter<edm::ParameterSet>("HitSelector"));
   std::vector<unsigned int> v_cutVariable(parSet.getParameter<std::vector<unsigned int> >(cutVariable));
-  if(v_cutVariable.size()%2==1){
-    edm::LogError("HitSelector")<<"Invalid Hit Selection for "<<cutVariable<<": need even number of arguments (intervals)"
-                                <<"\n ... delete Selection for "<<cutVariable;
+  if (v_cutVariable.size() % 2 == 1) {
+    edm::LogError("HitSelector") << "Invalid Hit Selection for " << cutVariable
+                                 << ": need even number of arguments (intervals)"
+                                 << "\n ... delete Selection for " << cutVariable;
     v_cutVariable.clear();
     m_hitSelectionUInt_[cutVariable] = v_cutVariable;
     return;
@@ -1635,294 +1968,396 @@ ApeEstimator::setHitSelectionMapUInt(const std::string& cutVariable){
   return;
 }
 
-
-
 // -----------------------------------------------------------------------------------------------------------
 
-bool
-ApeEstimator::hitSelected(TrackStruct::HitParameterStruct& hitParams)const{
-  if(hitParams.hitState == TrackStruct::notInTracker)return false;
-  if(hitParams.hitState == TrackStruct::invalid || hitParams.hitState == TrackStruct::negativeError)return false;
-  
+bool ApeEstimator::hitSelected(TrackStruct::HitParameterStruct& hitParams) const {
+  if (hitParams.hitState == TrackStruct::notInTracker)
+    return false;
+  if (hitParams.hitState == TrackStruct::invalid || hitParams.hitState == TrackStruct::negativeError)
+    return false;
+
   bool isGoodHit(true);
   bool isGoodHitX(true);
   bool isGoodHitY(true);
-  
-  for(auto & i_hitSelection : m_hitSelection_){
+
+  for (auto& i_hitSelection : m_hitSelection_) {
     const std::string& hitSelection(i_hitSelection.first);
     const std::vector<double>& v_hitSelection(i_hitSelection.second);
-    if(v_hitSelection.empty())continue;
-    
+    if (v_hitSelection.empty())
+      continue;
+
     // For pixel and strip sectors in common
-    if     (hitSelection == "phiSens")        {if(!this->inDoubleInterval(v_hitSelection, hitParams.phiSens))isGoodHit = false;}
-    else if(hitSelection == "phiSensX")       {if(!this->inDoubleInterval(v_hitSelection, hitParams.phiSensX))isGoodHit = false;}
-    else if(hitSelection == "phiSensY")       {if(!this->inDoubleInterval(v_hitSelection, hitParams.phiSensY))isGoodHit = false;}
-    
-    else if(hitSelection == "resX")           {if(!this->inDoubleInterval(v_hitSelection, hitParams.resX))isGoodHitX = false;}
-    else if(hitSelection == "norResX")        {if(!this->inDoubleInterval(v_hitSelection, hitParams.norResX))isGoodHitX = false;}
-    else if(hitSelection == "probX")          {if(!this->inDoubleInterval(v_hitSelection, hitParams.probX))isGoodHitX = false;}
-    else if(hitSelection == "errXHit")        {if(!this->inDoubleInterval(v_hitSelection, hitParams.errXHit))isGoodHitX = false;}
-    else if(hitSelection == "errXTrk")        {if(!this->inDoubleInterval(v_hitSelection, hitParams.errXTrk))isGoodHitX = false;}
-    else if(hitSelection == "errX")           {if(!this->inDoubleInterval(v_hitSelection, hitParams.errX))isGoodHitX = false;}
-    else if(hitSelection == "errX2")          {if(!this->inDoubleInterval(v_hitSelection, hitParams.errX2))isGoodHitX = false;}
-    
+    if (hitSelection == "phiSens") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.phiSens))
+        isGoodHit = false;
+    } else if (hitSelection == "phiSensX") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.phiSensX))
+        isGoodHit = false;
+    } else if (hitSelection == "phiSensY") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.phiSensY))
+        isGoodHit = false;
+    }
+
+    else if (hitSelection == "resX") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.resX))
+        isGoodHitX = false;
+    } else if (hitSelection == "norResX") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.norResX))
+        isGoodHitX = false;
+    } else if (hitSelection == "probX") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.probX))
+        isGoodHitX = false;
+    } else if (hitSelection == "errXHit") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.errXHit))
+        isGoodHitX = false;
+    } else if (hitSelection == "errXTrk") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.errXTrk))
+        isGoodHitX = false;
+    } else if (hitSelection == "errX") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.errX))
+        isGoodHitX = false;
+    } else if (hitSelection == "errX2") {
+      if (!this->inDoubleInterval(v_hitSelection, hitParams.errX2))
+        isGoodHitX = false;
+    }
+
     // For pixel only
-    if(hitParams.isPixelHit){
-      if     (hitSelection == "chargePixel")          {if(!this->inDoubleInterval(v_hitSelection, hitParams.chargePixel))isGoodHit = false;}
-      else if(hitSelection == "clusterProbabilityXY") {if(!this->inDoubleInterval(v_hitSelection, hitParams.clusterProbabilityXY))isGoodHit = false;}
-      else if(hitSelection == "clusterProbabilityQ")  {if(!this->inDoubleInterval(v_hitSelection, hitParams.clusterProbabilityQ))isGoodHit = false;}
-      else if(hitSelection == "clusterProbabilityXYQ"){if(!this->inDoubleInterval(v_hitSelection, hitParams.clusterProbabilityXYQ))isGoodHit = false;}
-      else if(hitSelection == "logClusterProbability"){if(!this->inDoubleInterval(v_hitSelection, hitParams.logClusterProbability))isGoodHit = false;}
-      
-      else if(hitSelection == "baryStripX")           {if(!this->inDoubleInterval(v_hitSelection, hitParams.baryStripX))isGoodHitX = false;}
-      else if(hitSelection == "baryStripY")           {if(!this->inDoubleInterval(v_hitSelection, hitParams.baryStripY))isGoodHitY = false;}
-      
-      
-      
-      else if(hitSelection == "resY")           {if(!this->inDoubleInterval(v_hitSelection, hitParams.resY))isGoodHitY = false;}
-      else if(hitSelection == "norResY")        {if(!this->inDoubleInterval(v_hitSelection, hitParams.norResY))isGoodHitY = false;}
-      else if(hitSelection == "probY")          {if(!this->inDoubleInterval(v_hitSelection, hitParams.probY))isGoodHitY = false;}
-      else if(hitSelection == "errYHit")        {if(!this->inDoubleInterval(v_hitSelection, hitParams.errYHit))isGoodHitY = false;}
-      else if(hitSelection == "errYTrk")        {if(!this->inDoubleInterval(v_hitSelection, hitParams.errYTrk))isGoodHitY = false;}
-      else if(hitSelection == "errY")           {if(!this->inDoubleInterval(v_hitSelection, hitParams.errY))isGoodHitY = false;}
-      else if(hitSelection == "errY2")          {if(!this->inDoubleInterval(v_hitSelection, hitParams.errY2))isGoodHitY = false;}
-    }else{ // For strip only
-      if     (hitSelection == "widthProj")      {if(!this->inDoubleInterval(v_hitSelection, hitParams.projWidth))isGoodHit = false;}
-      else if(hitSelection == "widthDiff")      {if(!this->inDoubleInterval(v_hitSelection, hitParams.projWidth-static_cast<float>(hitParams.widthX)))isGoodHit = false;}
-      else if(hitSelection == "charge")         {if(!this->inDoubleInterval(v_hitSelection, hitParams.chargeStrip))isGoodHit = false;}
-      else if(hitSelection == "maxCharge")      {if(!this->inDoubleInterval(v_hitSelection, hitParams.maxCharge))isGoodHit = false;}
-      else if(hitSelection == "chargeOnEdges")  {if(!this->inDoubleInterval(v_hitSelection, hitParams.chargeOnEdges))isGoodHit = false;}
-      else if(hitSelection == "chargeAsymmetry"){if(!this->inDoubleInterval(v_hitSelection, hitParams.chargeAsymmetry))isGoodHit = false;}
-      else if(hitSelection == "chargeLRplus")   {if(!this->inDoubleInterval(v_hitSelection, hitParams.chargeLRplus))isGoodHit = false;}
-      else if(hitSelection == "chargeLRminus")  {if(!this->inDoubleInterval(v_hitSelection, hitParams.chargeLRminus))isGoodHit = false;}
-      else if(hitSelection == "sOverN")         {if(!this->inDoubleInterval(v_hitSelection, hitParams.sOverN))isGoodHit = false;}
+    if (hitParams.isPixelHit) {
+      if (hitSelection == "chargePixel") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.chargePixel))
+          isGoodHit = false;
+      } else if (hitSelection == "clusterProbabilityXY") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.clusterProbabilityXY))
+          isGoodHit = false;
+      } else if (hitSelection == "clusterProbabilityQ") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.clusterProbabilityQ))
+          isGoodHit = false;
+      } else if (hitSelection == "clusterProbabilityXYQ") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.clusterProbabilityXYQ))
+          isGoodHit = false;
+      } else if (hitSelection == "logClusterProbability") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.logClusterProbability))
+          isGoodHit = false;
+      }
+
+      else if (hitSelection == "baryStripX") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.baryStripX))
+          isGoodHitX = false;
+      } else if (hitSelection == "baryStripY") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.baryStripY))
+          isGoodHitY = false;
+      }
+
+      else if (hitSelection == "resY") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.resY))
+          isGoodHitY = false;
+      } else if (hitSelection == "norResY") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.norResY))
+          isGoodHitY = false;
+      } else if (hitSelection == "probY") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.probY))
+          isGoodHitY = false;
+      } else if (hitSelection == "errYHit") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.errYHit))
+          isGoodHitY = false;
+      } else if (hitSelection == "errYTrk") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.errYTrk))
+          isGoodHitY = false;
+      } else if (hitSelection == "errY") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.errY))
+          isGoodHitY = false;
+      } else if (hitSelection == "errY2") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.errY2))
+          isGoodHitY = false;
+      }
+    } else {  // For strip only
+      if (hitSelection == "widthProj") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.projWidth))
+          isGoodHit = false;
+      } else if (hitSelection == "widthDiff") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.projWidth - static_cast<float>(hitParams.widthX)))
+          isGoodHit = false;
+      } else if (hitSelection == "charge") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.chargeStrip))
+          isGoodHit = false;
+      } else if (hitSelection == "maxCharge") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.maxCharge))
+          isGoodHit = false;
+      } else if (hitSelection == "chargeOnEdges") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.chargeOnEdges))
+          isGoodHit = false;
+      } else if (hitSelection == "chargeAsymmetry") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.chargeAsymmetry))
+          isGoodHit = false;
+      } else if (hitSelection == "chargeLRplus") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.chargeLRplus))
+          isGoodHit = false;
+      } else if (hitSelection == "chargeLRminus") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.chargeLRminus))
+          isGoodHit = false;
+      } else if (hitSelection == "sOverN") {
+        if (!this->inDoubleInterval(v_hitSelection, hitParams.sOverN))
+          isGoodHit = false;
+      }
     }
   }
-  
-  for(auto & i_hitSelection : m_hitSelectionUInt_){
+
+  for (auto& i_hitSelection : m_hitSelectionUInt_) {
     const std::string& hitSelection(i_hitSelection.first);
     const std::vector<unsigned int>& v_hitSelection(i_hitSelection.second);
-    if(v_hitSelection.empty())continue;
-    
+    if (v_hitSelection.empty())
+      continue;
+
     // For pixel and strip sectors in common
-    
+
     // For pixel only
-    if(hitParams.isPixelHit){
-      if(hitSelection == "isOnEdge")          {if(!this->inUintInterval(v_hitSelection, hitParams.isOnEdge))isGoodHit = false;}
-      else if(hitSelection == "hasBadPixels") {if(!this->inUintInterval(v_hitSelection, hitParams.hasBadPixels))isGoodHit = false;}
-      else if(hitSelection == "spansTwoRoc")  {if(!this->inUintInterval(v_hitSelection, hitParams.spansTwoRoc))isGoodHit = false;}
-      else if(hitSelection == "qBin")         {if(!this->inUintInterval(v_hitSelection, hitParams.qBin))isGoodHit = false;}
-      
-      else if(hitSelection == "widthX")       {if(!this->inUintInterval(v_hitSelection, hitParams.widthX))isGoodHitX = false;}
-      else if(hitSelection == "widthY")       {if(!this->inUintInterval(v_hitSelection, hitParams.widthY))isGoodHitY = false;}
-    }else{ // For strip only
-      if     (hitSelection == "width")     {if(!this->inUintInterval(v_hitSelection, hitParams.widthX))isGoodHit = false;}
-      else if(hitSelection == "edgeStrips"){if(!this->inUintInterval(v_hitSelection, hitParams.maxStrip, hitParams.maxStripInv))isGoodHit = false;}
-      else if(hitSelection == "maxIndex")  {if(!this->inUintInterval(v_hitSelection, hitParams.maxIndex))isGoodHit = false;}
+    if (hitParams.isPixelHit) {
+      if (hitSelection == "isOnEdge") {
+        if (!this->inUintInterval(v_hitSelection, hitParams.isOnEdge))
+          isGoodHit = false;
+      } else if (hitSelection == "hasBadPixels") {
+        if (!this->inUintInterval(v_hitSelection, hitParams.hasBadPixels))
+          isGoodHit = false;
+      } else if (hitSelection == "spansTwoRoc") {
+        if (!this->inUintInterval(v_hitSelection, hitParams.spansTwoRoc))
+          isGoodHit = false;
+      } else if (hitSelection == "qBin") {
+        if (!this->inUintInterval(v_hitSelection, hitParams.qBin))
+          isGoodHit = false;
+      }
+
+      else if (hitSelection == "widthX") {
+        if (!this->inUintInterval(v_hitSelection, hitParams.widthX))
+          isGoodHitX = false;
+      } else if (hitSelection == "widthY") {
+        if (!this->inUintInterval(v_hitSelection, hitParams.widthY))
+          isGoodHitY = false;
+      }
+    } else {  // For strip only
+      if (hitSelection == "width") {
+        if (!this->inUintInterval(v_hitSelection, hitParams.widthX))
+          isGoodHit = false;
+      } else if (hitSelection == "edgeStrips") {
+        if (!this->inUintInterval(v_hitSelection, hitParams.maxStrip, hitParams.maxStripInv))
+          isGoodHit = false;
+      } else if (hitSelection == "maxIndex") {
+        if (!this->inUintInterval(v_hitSelection, hitParams.maxIndex))
+          isGoodHit = false;
+      }
     }
   }
-  
-  if(hitParams.isPixelHit){
+
+  if (hitParams.isPixelHit) {
     hitParams.goodXMeasurement = isGoodHit && isGoodHitX;
     hitParams.goodYMeasurement = isGoodHit && isGoodHitY;
-  }else{
+  } else {
     hitParams.goodXMeasurement = isGoodHit && isGoodHitX;
     hitParams.goodYMeasurement = false;
   }
-  
-  if(!hitParams.goodXMeasurement && !hitParams.goodYMeasurement)return false;
-  else return true;
+
+  if (!hitParams.goodXMeasurement && !hitParams.goodYMeasurement)
+    return false;
+  else
+    return true;
 }
 
-
-bool
-ApeEstimator::inDoubleInterval(const std::vector<double>& v_hitSelection, const float variable)const{
-  int entry(0); double intervalBegin(999.);
+bool ApeEstimator::inDoubleInterval(const std::vector<double>& v_hitSelection, const float variable) const {
+  int entry(0);
+  double intervalBegin(999.);
   bool isSelected(false);
-  for(auto const & i_hitInterval : v_hitSelection){
+  for (auto const& i_hitInterval : v_hitSelection) {
     ++entry;
-    if(entry%2==1)intervalBegin = i_hitInterval;
-    else if(variable>=intervalBegin && variable<i_hitInterval)isSelected = true;
+    if (entry % 2 == 1)
+      intervalBegin = i_hitInterval;
+    else if (variable >= intervalBegin && variable < i_hitInterval)
+      isSelected = true;
   }
   return isSelected;
 }
 
-
-bool
-ApeEstimator::inUintInterval(const std::vector<unsigned int>& v_hitSelection, const unsigned int variable, const unsigned int variable2)const{
-  int entry(0); unsigned int intervalBegin(999);
+bool ApeEstimator::inUintInterval(const std::vector<unsigned int>& v_hitSelection,
+                                  const unsigned int variable,
+                                  const unsigned int variable2) const {
+  int entry(0);
+  unsigned int intervalBegin(999);
   bool isSelected(false);
-  for(auto i_hitInterval : v_hitSelection ){
+  for (auto i_hitInterval : v_hitSelection) {
     ++entry;
-    if(entry%2==1)intervalBegin = i_hitInterval;
-    else if(variable>=intervalBegin && variable<=i_hitInterval){
-      if(variable2==999 || (variable2>=intervalBegin && variable2<=i_hitInterval))isSelected = true;
+    if (entry % 2 == 1)
+      intervalBegin = i_hitInterval;
+    else if (variable >= intervalBegin && variable <= i_hitInterval) {
+      if (variable2 == 999 || (variable2 >= intervalBegin && variable2 <= i_hitInterval))
+        isSelected = true;
     }
   }
   return isSelected;
 }
-
-
 
 // -----------------------------------------------------------------------------------------------------------
 
-
-void
-ApeEstimator::fillHistsForAnalyzerMode(const TrackStruct& trackStruct){ 
+void ApeEstimator::fillHistsForAnalyzerMode(const TrackStruct& trackStruct) {
   unsigned int goodHitsPerTrack(trackStruct.v_hitParams.size());
   tkDetector_.HitsGood->Fill(goodHitsPerTrack);
-  tkDetector_.HitsGoodVsHitsValid->Fill(trackStruct.trkParams.hitsValid,goodHitsPerTrack);
-  tkDetector_.PHitsGoodVsHitsValid->Fill(trackStruct.trkParams.hitsValid,goodHitsPerTrack);
-  
-  if(parameterSet_.getParameter<bool>("applyTrackCuts")){
+  tkDetector_.HitsGoodVsHitsValid->Fill(trackStruct.trkParams.hitsValid, goodHitsPerTrack);
+  tkDetector_.PHitsGoodVsHitsValid->Fill(trackStruct.trkParams.hitsValid, goodHitsPerTrack);
+
+  if (parameterSet_.getParameter<bool>("applyTrackCuts")) {
     // which tracks to take? need min. nr. of selected hits?
-    if(goodHitsPerTrack < minGoodHitsPerTrack_)return;
+    if (goodHitsPerTrack < minGoodHitsPerTrack_)
+      return;
   }
-  
-  tkDetector_.HitsSize     ->Fill(trackStruct.trkParams.hitsSize);
-  tkDetector_.HitsValid    ->Fill(trackStruct.trkParams.hitsValid);
-  tkDetector_.HitsInvalid  ->Fill(trackStruct.trkParams.hitsInvalid);
-  tkDetector_.Hits2D       ->Fill(trackStruct.trkParams.hits2D);
-  tkDetector_.LayersMissed ->Fill(trackStruct.trkParams.layersMissed);
-  tkDetector_.HitsPixel    ->Fill(trackStruct.trkParams.hitsPixel);
-  tkDetector_.HitsStrip    ->Fill(trackStruct.trkParams.hitsStrip);
-  tkDetector_.Charge       ->Fill(trackStruct.trkParams.charge);
-  tkDetector_.Chi2         ->Fill(trackStruct.trkParams.chi2);
-  tkDetector_.Ndof         ->Fill(trackStruct.trkParams.ndof);
-  tkDetector_.NorChi2      ->Fill(trackStruct.trkParams.norChi2);
-  tkDetector_.Prob         ->Fill(trackStruct.trkParams.prob);
-  tkDetector_.Eta          ->Fill(trackStruct.trkParams.eta);
-  tkDetector_.EtaErr       ->Fill(trackStruct.trkParams.etaErr);
-  tkDetector_.EtaSig       ->Fill(trackStruct.trkParams.eta/trackStruct.trkParams.etaErr);
-  tkDetector_.Theta        ->Fill(trackStruct.trkParams.theta*180./M_PI);
-  tkDetector_.Phi          ->Fill(trackStruct.trkParams.phi*180./M_PI);
-  tkDetector_.PhiErr       ->Fill(trackStruct.trkParams.phiErr*180./M_PI);
-  tkDetector_.PhiSig       ->Fill(trackStruct.trkParams.phi/trackStruct.trkParams.phiErr);
-  tkDetector_.D0Beamspot   ->Fill(trackStruct.trkParams.d0Beamspot);
+
+  tkDetector_.HitsSize->Fill(trackStruct.trkParams.hitsSize);
+  tkDetector_.HitsValid->Fill(trackStruct.trkParams.hitsValid);
+  tkDetector_.HitsInvalid->Fill(trackStruct.trkParams.hitsInvalid);
+  tkDetector_.Hits2D->Fill(trackStruct.trkParams.hits2D);
+  tkDetector_.LayersMissed->Fill(trackStruct.trkParams.layersMissed);
+  tkDetector_.HitsPixel->Fill(trackStruct.trkParams.hitsPixel);
+  tkDetector_.HitsStrip->Fill(trackStruct.trkParams.hitsStrip);
+  tkDetector_.Charge->Fill(trackStruct.trkParams.charge);
+  tkDetector_.Chi2->Fill(trackStruct.trkParams.chi2);
+  tkDetector_.Ndof->Fill(trackStruct.trkParams.ndof);
+  tkDetector_.NorChi2->Fill(trackStruct.trkParams.norChi2);
+  tkDetector_.Prob->Fill(trackStruct.trkParams.prob);
+  tkDetector_.Eta->Fill(trackStruct.trkParams.eta);
+  tkDetector_.EtaErr->Fill(trackStruct.trkParams.etaErr);
+  tkDetector_.EtaSig->Fill(trackStruct.trkParams.eta / trackStruct.trkParams.etaErr);
+  tkDetector_.Theta->Fill(trackStruct.trkParams.theta * 180. / M_PI);
+  tkDetector_.Phi->Fill(trackStruct.trkParams.phi * 180. / M_PI);
+  tkDetector_.PhiErr->Fill(trackStruct.trkParams.phiErr * 180. / M_PI);
+  tkDetector_.PhiSig->Fill(trackStruct.trkParams.phi / trackStruct.trkParams.phiErr);
+  tkDetector_.D0Beamspot->Fill(trackStruct.trkParams.d0Beamspot);
   tkDetector_.D0BeamspotErr->Fill(trackStruct.trkParams.d0BeamspotErr);
-  tkDetector_.D0BeamspotSig->Fill(trackStruct.trkParams.d0Beamspot/trackStruct.trkParams.d0BeamspotErr);
-  tkDetector_.Dz           ->Fill(trackStruct.trkParams.dz);
-  tkDetector_.DzErr        ->Fill(trackStruct.trkParams.dzErr);
-  tkDetector_.DzSig        ->Fill(trackStruct.trkParams.dz/trackStruct.trkParams.dzErr);
-  tkDetector_.P            ->Fill(trackStruct.trkParams.p);
-  tkDetector_.Pt           ->Fill(trackStruct.trkParams.pt);
-  tkDetector_.PtErr        ->Fill(trackStruct.trkParams.ptErr);
-  tkDetector_.PtSig        ->Fill(trackStruct.trkParams.pt/trackStruct.trkParams.ptErr);
-  tkDetector_.MeanAngle    ->Fill(trackStruct.trkParams.meanPhiSensToNorm*180./M_PI);
-  
-  tkDetector_.MeanAngleVsHits ->Fill(trackStruct.trkParams.hitsSize,trackStruct.trkParams.meanPhiSensToNorm*180./M_PI);
-  tkDetector_.HitsPixelVsEta  ->Fill(trackStruct.trkParams.eta,trackStruct.trkParams.hitsPixel);
-  tkDetector_.HitsPixelVsTheta->Fill(trackStruct.trkParams.theta*180./M_PI,trackStruct.trkParams.hitsPixel);
-  tkDetector_.HitsStripVsEta  ->Fill(trackStruct.trkParams.eta,trackStruct.trkParams.hitsStrip);
-  tkDetector_.HitsStripVsTheta->Fill(trackStruct.trkParams.theta*180./M_PI,trackStruct.trkParams.hitsStrip);
-  tkDetector_.PtVsEta       ->Fill(trackStruct.trkParams.eta,trackStruct.trkParams.pt);
-  tkDetector_.PtVsTheta       ->Fill(trackStruct.trkParams.theta*180./M_PI,trackStruct.trkParams.pt);
-  
-  tkDetector_.PMeanAngleVsHits ->Fill(trackStruct.trkParams.hitsSize,trackStruct.trkParams.meanPhiSensToNorm*180./M_PI);
-  tkDetector_.PHitsPixelVsEta  ->Fill(trackStruct.trkParams.eta,trackStruct.trkParams.hitsPixel);
-  tkDetector_.PHitsPixelVsTheta->Fill(trackStruct.trkParams.theta*180./M_PI,trackStruct.trkParams.hitsPixel);
-  tkDetector_.PHitsStripVsEta  ->Fill(trackStruct.trkParams.eta,trackStruct.trkParams.hitsStrip);
-  tkDetector_.PHitsStripVsTheta->Fill(trackStruct.trkParams.theta*180./M_PI,trackStruct.trkParams.hitsStrip);
-  tkDetector_.PPtVsEta         ->Fill(trackStruct.trkParams.eta,trackStruct.trkParams.pt);
-  tkDetector_.PPtVsTheta       ->Fill(trackStruct.trkParams.theta*180./M_PI,trackStruct.trkParams.pt);
-  
-  
-  for(auto & i_hit : trackStruct.v_hitParams){
+  tkDetector_.D0BeamspotSig->Fill(trackStruct.trkParams.d0Beamspot / trackStruct.trkParams.d0BeamspotErr);
+  tkDetector_.Dz->Fill(trackStruct.trkParams.dz);
+  tkDetector_.DzErr->Fill(trackStruct.trkParams.dzErr);
+  tkDetector_.DzSig->Fill(trackStruct.trkParams.dz / trackStruct.trkParams.dzErr);
+  tkDetector_.P->Fill(trackStruct.trkParams.p);
+  tkDetector_.Pt->Fill(trackStruct.trkParams.pt);
+  tkDetector_.PtErr->Fill(trackStruct.trkParams.ptErr);
+  tkDetector_.PtSig->Fill(trackStruct.trkParams.pt / trackStruct.trkParams.ptErr);
+  tkDetector_.MeanAngle->Fill(trackStruct.trkParams.meanPhiSensToNorm * 180. / M_PI);
+
+  tkDetector_.MeanAngleVsHits->Fill(trackStruct.trkParams.hitsSize,
+                                    trackStruct.trkParams.meanPhiSensToNorm * 180. / M_PI);
+  tkDetector_.HitsPixelVsEta->Fill(trackStruct.trkParams.eta, trackStruct.trkParams.hitsPixel);
+  tkDetector_.HitsPixelVsTheta->Fill(trackStruct.trkParams.theta * 180. / M_PI, trackStruct.trkParams.hitsPixel);
+  tkDetector_.HitsStripVsEta->Fill(trackStruct.trkParams.eta, trackStruct.trkParams.hitsStrip);
+  tkDetector_.HitsStripVsTheta->Fill(trackStruct.trkParams.theta * 180. / M_PI, trackStruct.trkParams.hitsStrip);
+  tkDetector_.PtVsEta->Fill(trackStruct.trkParams.eta, trackStruct.trkParams.pt);
+  tkDetector_.PtVsTheta->Fill(trackStruct.trkParams.theta * 180. / M_PI, trackStruct.trkParams.pt);
+
+  tkDetector_.PMeanAngleVsHits->Fill(trackStruct.trkParams.hitsSize,
+                                     trackStruct.trkParams.meanPhiSensToNorm * 180. / M_PI);
+  tkDetector_.PHitsPixelVsEta->Fill(trackStruct.trkParams.eta, trackStruct.trkParams.hitsPixel);
+  tkDetector_.PHitsPixelVsTheta->Fill(trackStruct.trkParams.theta * 180. / M_PI, trackStruct.trkParams.hitsPixel);
+  tkDetector_.PHitsStripVsEta->Fill(trackStruct.trkParams.eta, trackStruct.trkParams.hitsStrip);
+  tkDetector_.PHitsStripVsTheta->Fill(trackStruct.trkParams.theta * 180. / M_PI, trackStruct.trkParams.hitsStrip);
+  tkDetector_.PPtVsEta->Fill(trackStruct.trkParams.eta, trackStruct.trkParams.pt);
+  tkDetector_.PPtVsTheta->Fill(trackStruct.trkParams.theta * 180. / M_PI, trackStruct.trkParams.pt);
+
+  for (auto& i_hit : trackStruct.v_hitParams) {
     const TrackStruct::HitParameterStruct& hit(i_hit);
     //Put here from earlier method
-    if(hit.hitState == TrackStruct::notAssignedToSectors)continue;
-    
-    for(auto & i_sector : m_tkSector_){
+    if (hit.hitState == TrackStruct::notAssignedToSectors)
+      continue;
+
+    for (auto& i_sector : m_tkSector_) {
       bool moduleInSector(false);
-      for(auto const & i_hitSector : hit.v_sector){
-        if(i_sector.first == i_hitSector){
-          moduleInSector = true; 
+      for (auto const& i_hitSector : hit.v_sector) {
+        if (i_sector.first == i_hitSector) {
+          moduleInSector = true;
           break;
         }
       }
-      if(!moduleInSector)continue;
+      if (!moduleInSector)
+        continue;
       TrackerSectorStruct& sector(i_sector.second);
-      
-      if(hit.goodXMeasurement){
-        std::map<std::string,TrackerSectorStruct::CorrelationHists>& m_corrHists(sector.m_correlationHistsX);
-  
+
+      if (hit.goodXMeasurement) {
+        std::map<std::string, TrackerSectorStruct::CorrelationHists>& m_corrHists(sector.m_correlationHistsX);
+
         // Cluster and Hit Parameters
         this->fillHitHistsXForAnalyzerMode(hit, sector);
-        
+
         // Track Parameters
-        m_corrHists["HitsValid"].fillCorrHistsX(hit,trackStruct.trkParams.hitsValid);
-        m_corrHists["HitsGood"].fillCorrHistsX(hit,goodHitsPerTrack);
-        m_corrHists["HitsInvalid"].fillCorrHistsX(hit,trackStruct.trkParams.hitsInvalid);
-        m_corrHists["Hits2D"].fillCorrHistsX(hit,trackStruct.trkParams.hits2D);
-        m_corrHists["LayersMissed"].fillCorrHistsX(hit,trackStruct.trkParams.layersMissed);
-        m_corrHists["HitsPixel"].fillCorrHistsX(hit,trackStruct.trkParams.hitsPixel);
-        m_corrHists["HitsStrip"].fillCorrHistsX(hit,trackStruct.trkParams.hitsStrip);
-        m_corrHists["NorChi2"].fillCorrHistsX(hit,trackStruct.trkParams.norChi2);
-        m_corrHists["Theta"].fillCorrHistsX(hit,trackStruct.trkParams.theta*180./M_PI);
-        m_corrHists["Phi"].fillCorrHistsX(hit,trackStruct.trkParams.phi*180./M_PI);
-        m_corrHists["D0Beamspot"].fillCorrHistsX(hit,trackStruct.trkParams.d0Beamspot);
-        m_corrHists["Dz"].fillCorrHistsX(hit,trackStruct.trkParams.dz);
-        m_corrHists["Pt"].fillCorrHistsX(hit,trackStruct.trkParams.pt);
-        m_corrHists["P"].fillCorrHistsX(hit,trackStruct.trkParams.p);
-        m_corrHists["InvP"].fillCorrHistsX(hit,1./trackStruct.trkParams.p);
-        m_corrHists["MeanAngle"].fillCorrHistsX(hit,trackStruct.trkParams.meanPhiSensToNorm*180./M_PI);
+        m_corrHists["HitsValid"].fillCorrHistsX(hit, trackStruct.trkParams.hitsValid);
+        m_corrHists["HitsGood"].fillCorrHistsX(hit, goodHitsPerTrack);
+        m_corrHists["HitsInvalid"].fillCorrHistsX(hit, trackStruct.trkParams.hitsInvalid);
+        m_corrHists["Hits2D"].fillCorrHistsX(hit, trackStruct.trkParams.hits2D);
+        m_corrHists["LayersMissed"].fillCorrHistsX(hit, trackStruct.trkParams.layersMissed);
+        m_corrHists["HitsPixel"].fillCorrHistsX(hit, trackStruct.trkParams.hitsPixel);
+        m_corrHists["HitsStrip"].fillCorrHistsX(hit, trackStruct.trkParams.hitsStrip);
+        m_corrHists["NorChi2"].fillCorrHistsX(hit, trackStruct.trkParams.norChi2);
+        m_corrHists["Theta"].fillCorrHistsX(hit, trackStruct.trkParams.theta * 180. / M_PI);
+        m_corrHists["Phi"].fillCorrHistsX(hit, trackStruct.trkParams.phi * 180. / M_PI);
+        m_corrHists["D0Beamspot"].fillCorrHistsX(hit, trackStruct.trkParams.d0Beamspot);
+        m_corrHists["Dz"].fillCorrHistsX(hit, trackStruct.trkParams.dz);
+        m_corrHists["Pt"].fillCorrHistsX(hit, trackStruct.trkParams.pt);
+        m_corrHists["P"].fillCorrHistsX(hit, trackStruct.trkParams.p);
+        m_corrHists["InvP"].fillCorrHistsX(hit, 1. / trackStruct.trkParams.p);
+        m_corrHists["MeanAngle"].fillCorrHistsX(hit, trackStruct.trkParams.meanPhiSensToNorm * 180. / M_PI);
       }
-            
-      if(hit.goodYMeasurement){
-        std::map<std::string,TrackerSectorStruct::CorrelationHists>& m_corrHists(sector.m_correlationHistsY);
-  
+
+      if (hit.goodYMeasurement) {
+        std::map<std::string, TrackerSectorStruct::CorrelationHists>& m_corrHists(sector.m_correlationHistsY);
+
         // Cluster and Hit Parameters
         this->fillHitHistsYForAnalyzerMode(hit, sector);
-  
+
         // Track Parameters
-        m_corrHists["HitsValid"].fillCorrHistsY(hit,trackStruct.trkParams.hitsValid);
-        m_corrHists["HitsGood"].fillCorrHistsY(hit,goodHitsPerTrack);
-        m_corrHists["HitsInvalid"].fillCorrHistsY(hit,trackStruct.trkParams.hitsInvalid);
-        m_corrHists["Hits2D"].fillCorrHistsY(hit,trackStruct.trkParams.hits2D);
-        m_corrHists["LayersMissed"].fillCorrHistsY(hit,trackStruct.trkParams.layersMissed);
-        m_corrHists["HitsPixel"].fillCorrHistsY(hit,trackStruct.trkParams.hitsPixel);
-        m_corrHists["HitsStrip"].fillCorrHistsY(hit,trackStruct.trkParams.hitsStrip);
-        m_corrHists["NorChi2"].fillCorrHistsY(hit,trackStruct.trkParams.norChi2);
-        m_corrHists["Theta"].fillCorrHistsY(hit,trackStruct.trkParams.theta*180./M_PI);
-        m_corrHists["Phi"].fillCorrHistsY(hit,trackStruct.trkParams.phi*180./M_PI);
-        m_corrHists["D0Beamspot"].fillCorrHistsY(hit,trackStruct.trkParams.d0Beamspot);
-        m_corrHists["Dz"].fillCorrHistsY(hit,trackStruct.trkParams.dz);
-        m_corrHists["Pt"].fillCorrHistsY(hit,trackStruct.trkParams.pt);
-        m_corrHists["P"].fillCorrHistsY(hit,trackStruct.trkParams.p);
-        m_corrHists["InvP"].fillCorrHistsY(hit,1./trackStruct.trkParams.p);
-        m_corrHists["MeanAngle"].fillCorrHistsY(hit,trackStruct.trkParams.meanPhiSensToNorm*180./M_PI);
+        m_corrHists["HitsValid"].fillCorrHistsY(hit, trackStruct.trkParams.hitsValid);
+        m_corrHists["HitsGood"].fillCorrHistsY(hit, goodHitsPerTrack);
+        m_corrHists["HitsInvalid"].fillCorrHistsY(hit, trackStruct.trkParams.hitsInvalid);
+        m_corrHists["Hits2D"].fillCorrHistsY(hit, trackStruct.trkParams.hits2D);
+        m_corrHists["LayersMissed"].fillCorrHistsY(hit, trackStruct.trkParams.layersMissed);
+        m_corrHists["HitsPixel"].fillCorrHistsY(hit, trackStruct.trkParams.hitsPixel);
+        m_corrHists["HitsStrip"].fillCorrHistsY(hit, trackStruct.trkParams.hitsStrip);
+        m_corrHists["NorChi2"].fillCorrHistsY(hit, trackStruct.trkParams.norChi2);
+        m_corrHists["Theta"].fillCorrHistsY(hit, trackStruct.trkParams.theta * 180. / M_PI);
+        m_corrHists["Phi"].fillCorrHistsY(hit, trackStruct.trkParams.phi * 180. / M_PI);
+        m_corrHists["D0Beamspot"].fillCorrHistsY(hit, trackStruct.trkParams.d0Beamspot);
+        m_corrHists["Dz"].fillCorrHistsY(hit, trackStruct.trkParams.dz);
+        m_corrHists["Pt"].fillCorrHistsY(hit, trackStruct.trkParams.pt);
+        m_corrHists["P"].fillCorrHistsY(hit, trackStruct.trkParams.p);
+        m_corrHists["InvP"].fillCorrHistsY(hit, 1. / trackStruct.trkParams.p);
+        m_corrHists["MeanAngle"].fillCorrHistsY(hit, trackStruct.trkParams.meanPhiSensToNorm * 180. / M_PI);
       }
-      
-      // Special Histograms 
-      for(auto & i_sigmaX : sector.m_sigmaX){
-        for(auto & iHist : i_sigmaX.second){
-          if     (i_sigmaX.first=="sigmaXHit") iHist->Fill(hit.errXHit*10000.);
-          else if(i_sigmaX.first=="sigmaXTrk") iHist->Fill(hit.errXTrk*10000.);
-          else if(i_sigmaX.first=="sigmaX")    iHist->Fill(hit.errX*10000.);
+
+      // Special Histograms
+      for (auto& i_sigmaX : sector.m_sigmaX) {
+        for (auto& iHist : i_sigmaX.second) {
+          if (i_sigmaX.first == "sigmaXHit")
+            iHist->Fill(hit.errXHit * 10000.);
+          else if (i_sigmaX.first == "sigmaXTrk")
+            iHist->Fill(hit.errXTrk * 10000.);
+          else if (i_sigmaX.first == "sigmaX")
+            iHist->Fill(hit.errX * 10000.);
         }
       }
-      for(auto & i_sigmaY : sector.m_sigmaY){
-        for(auto & iHist : i_sigmaY.second){
-          if     (i_sigmaY.first=="sigmaYHit") iHist->Fill(hit.errYHit*10000.);
-          else if(i_sigmaY.first=="sigmaYTrk") iHist->Fill(hit.errYTrk*10000.);
-          else if(i_sigmaY.first=="sigmaY")    iHist->Fill(hit.errY*10000.);
+      for (auto& i_sigmaY : sector.m_sigmaY) {
+        for (auto& iHist : i_sigmaY.second) {
+          if (i_sigmaY.first == "sigmaYHit")
+            iHist->Fill(hit.errYHit * 10000.);
+          else if (i_sigmaY.first == "sigmaYTrk")
+            iHist->Fill(hit.errYTrk * 10000.);
+          else if (i_sigmaY.first == "sigmaY")
+            iHist->Fill(hit.errY * 10000.);
         }
       }
     }
   }
 }
 
-
-
-void
-ApeEstimator::fillHitHistsXForAnalyzerMode(const TrackStruct::HitParameterStruct& hit, TrackerSectorStruct& sector){
+void ApeEstimator::fillHitHistsXForAnalyzerMode(const TrackStruct::HitParameterStruct& hit,
+                                                TrackerSectorStruct& sector) {
   std::map<std::string, TrackerSectorStruct::CorrelationHists>& m_corrHists(sector.m_correlationHistsX);
-  
+
   // Cluster Parameters
   m_corrHists["WidthX"].fillCorrHistsX(hit, hit.widthX);
   m_corrHists["BaryStripX"].fillCorrHistsX(hit, hit.baryStripX);
-  
-  if(hit.isPixelHit){
+
+  if (hit.isPixelHit) {
     m_corrHists["ChargePixel"].fillCorrHistsX(hit, hit.chargePixel);
     m_corrHists["ClusterProbXY"].fillCorrHistsX(hit, hit.clusterProbabilityXY);
     m_corrHists["ClusterProbQ"].fillCorrHistsX(hit, hit.clusterProbabilityQ);
@@ -1932,8 +2367,8 @@ ApeEstimator::fillHitHistsXForAnalyzerMode(const TrackStruct::HitParameterStruct
     m_corrHists["HasBadPixels"].fillCorrHistsX(hit, hit.hasBadPixels);
     m_corrHists["SpansTwoRoc"].fillCorrHistsX(hit, hit.spansTwoRoc);
     m_corrHists["QBin"].fillCorrHistsX(hit, hit.qBin);
-    
-  }else{
+
+  } else {
     m_corrHists["ChargeStrip"].fillCorrHistsX(hit, hit.chargeStrip);
     m_corrHists["MaxStrip"].fillCorrHistsX(hit, hit.maxStrip);
     m_corrHists["MaxCharge"].fillCorrHistsX(hit, hit.maxCharge);
@@ -1944,55 +2379,54 @@ ApeEstimator::fillHitHistsXForAnalyzerMode(const TrackStruct::HitParameterStruct
     m_corrHists["ChargeLRminus"].fillCorrHistsX(hit, hit.chargeLRminus);
     m_corrHists["SOverN"].fillCorrHistsX(hit, hit.sOverN);
     m_corrHists["WidthProj"].fillCorrHistsX(hit, hit.projWidth);
-    m_corrHists["WidthDiff"].fillCorrHistsX(hit, hit.projWidth-static_cast<float>( hit.widthX));
-    
-    sector.WidthVsWidthProjected->Fill( hit.projWidth, hit.widthX);
-    sector.PWidthVsWidthProjected->Fill( hit.projWidth, hit.widthX);
-    
-    sector.WidthDiffVsMaxStrip->Fill( hit.maxStrip, hit.projWidth-static_cast<float>( hit.widthX));
-    sector.PWidthDiffVsMaxStrip->Fill( hit.maxStrip, hit.projWidth-static_cast<float>( hit.widthX));
-    
-    sector.WidthDiffVsSigmaXHit->Fill( hit.errXHit, hit.projWidth-static_cast<float>( hit.widthX));
-    sector.PWidthDiffVsSigmaXHit->Fill( hit.errXHit, hit.projWidth-static_cast<float>( hit.widthX));
-    
-    sector.WidthVsPhiSensX->Fill( hit.phiSensX*180./M_PI, hit.widthX);
-    sector.PWidthVsPhiSensX->Fill( hit.phiSensX*180./M_PI, hit.widthX);
+    m_corrHists["WidthDiff"].fillCorrHistsX(hit, hit.projWidth - static_cast<float>(hit.widthX));
+
+    sector.WidthVsWidthProjected->Fill(hit.projWidth, hit.widthX);
+    sector.PWidthVsWidthProjected->Fill(hit.projWidth, hit.widthX);
+
+    sector.WidthDiffVsMaxStrip->Fill(hit.maxStrip, hit.projWidth - static_cast<float>(hit.widthX));
+    sector.PWidthDiffVsMaxStrip->Fill(hit.maxStrip, hit.projWidth - static_cast<float>(hit.widthX));
+
+    sector.WidthDiffVsSigmaXHit->Fill(hit.errXHit, hit.projWidth - static_cast<float>(hit.widthX));
+    sector.PWidthDiffVsSigmaXHit->Fill(hit.errXHit, hit.projWidth - static_cast<float>(hit.widthX));
+
+    sector.WidthVsPhiSensX->Fill(hit.phiSensX * 180. / M_PI, hit.widthX);
+    sector.PWidthVsPhiSensX->Fill(hit.phiSensX * 180. / M_PI, hit.widthX);
   }
-  
+
   // Hit Parameters
-  m_corrHists["SigmaXHit"].fillCorrHistsX(hit, hit.errXHit*10000.);
-  m_corrHists["SigmaXTrk"].fillCorrHistsX(hit, hit.errXTrk*10000.);
-  m_corrHists["SigmaX"].fillCorrHistsX(hit, hit.errX*10000.);
-  
-  m_corrHists["PhiSens"].fillCorrHistsX(hit, hit.phiSens*180./M_PI);
-  m_corrHists["PhiSensX"].fillCorrHistsX(hit, hit.phiSensX*180./M_PI);
-  m_corrHists["PhiSensY"].fillCorrHistsX(hit, hit.phiSensY*180./M_PI);
-  
-  sector.XHit ->Fill(hit.xHit);
-  sector.XTrk ->Fill(hit.xTrk);
-  sector.SigmaX2->Fill(hit.errX2*10000.*10000.);
-  
-  sector.ResX ->Fill(hit.resX*10000.);
+  m_corrHists["SigmaXHit"].fillCorrHistsX(hit, hit.errXHit * 10000.);
+  m_corrHists["SigmaXTrk"].fillCorrHistsX(hit, hit.errXTrk * 10000.);
+  m_corrHists["SigmaX"].fillCorrHistsX(hit, hit.errX * 10000.);
+
+  m_corrHists["PhiSens"].fillCorrHistsX(hit, hit.phiSens * 180. / M_PI);
+  m_corrHists["PhiSensX"].fillCorrHistsX(hit, hit.phiSensX * 180. / M_PI);
+  m_corrHists["PhiSensY"].fillCorrHistsX(hit, hit.phiSensY * 180. / M_PI);
+
+  sector.XHit->Fill(hit.xHit);
+  sector.XTrk->Fill(hit.xTrk);
+  sector.SigmaX2->Fill(hit.errX2 * 10000. * 10000.);
+
+  sector.ResX->Fill(hit.resX * 10000.);
   sector.NorResX->Fill(hit.norResX);
-  
+
   sector.ProbX->Fill(hit.probX);
-  
-  sector.PhiSensXVsBarycentreX->Fill(hit.baryStripX, hit.phiSensX*180./M_PI);
-  sector.PPhiSensXVsBarycentreX->Fill(hit.baryStripX, hit.phiSensX*180./M_PI);
+
+  sector.PhiSensXVsBarycentreX->Fill(hit.baryStripX, hit.phiSensX * 180. / M_PI);
+  sector.PPhiSensXVsBarycentreX->Fill(hit.baryStripX, hit.phiSensX * 180. / M_PI);
 }
 
-
-
-void
-ApeEstimator::fillHitHistsYForAnalyzerMode(const TrackStruct::HitParameterStruct& hit, TrackerSectorStruct& sector){
+void ApeEstimator::fillHitHistsYForAnalyzerMode(const TrackStruct::HitParameterStruct& hit,
+                                                TrackerSectorStruct& sector) {
   std::map<std::string, TrackerSectorStruct::CorrelationHists>& m_corrHists(sector.m_correlationHistsY);
   // Do not fill anything for strip
-  if(!hit.isPixelHit)return;
-  
+  if (!hit.isPixelHit)
+    return;
+
   // Cluster Parameters
-  m_corrHists["WidthY"].fillCorrHistsY(hit,hit.widthY);
-  m_corrHists["BaryStripY"].fillCorrHistsY(hit,hit.baryStripY);
-  
+  m_corrHists["WidthY"].fillCorrHistsY(hit, hit.widthY);
+  m_corrHists["BaryStripY"].fillCorrHistsY(hit, hit.baryStripY);
+
   m_corrHists["ChargePixel"].fillCorrHistsY(hit, hit.chargePixel);
   m_corrHists["ClusterProbXY"].fillCorrHistsY(hit, hit.clusterProbabilityXY);
   m_corrHists["ClusterProbQ"].fillCorrHistsY(hit, hit.clusterProbabilityQ);
@@ -2002,113 +2436,106 @@ ApeEstimator::fillHitHistsYForAnalyzerMode(const TrackStruct::HitParameterStruct
   m_corrHists["HasBadPixels"].fillCorrHistsY(hit, hit.hasBadPixels);
   m_corrHists["SpansTwoRoc"].fillCorrHistsY(hit, hit.spansTwoRoc);
   m_corrHists["QBin"].fillCorrHistsY(hit, hit.qBin);
-  
+
   // Hit Parameters
-  m_corrHists["SigmaYHit"].fillCorrHistsY(hit, hit.errYHit*10000.);
-  m_corrHists["SigmaYTrk"].fillCorrHistsY(hit, hit.errYTrk*10000.);
-  m_corrHists["SigmaY"].fillCorrHistsY(hit, hit.errY*10000.);
-  
-  m_corrHists["PhiSens"].fillCorrHistsY(hit, hit.phiSens*180./M_PI);
-  m_corrHists["PhiSensX"].fillCorrHistsY(hit, hit.phiSensX*180./M_PI);
-  m_corrHists["PhiSensY"].fillCorrHistsY(hit, hit.phiSensY*180./M_PI);
-  
-  sector.YHit ->Fill(hit.yHit);
-  sector.YTrk ->Fill(hit.yTrk);
-  sector.SigmaY2->Fill(hit.errY2*10000.*10000.);
-  
-  sector.ResY ->Fill(hit.resY*10000.);
+  m_corrHists["SigmaYHit"].fillCorrHistsY(hit, hit.errYHit * 10000.);
+  m_corrHists["SigmaYTrk"].fillCorrHistsY(hit, hit.errYTrk * 10000.);
+  m_corrHists["SigmaY"].fillCorrHistsY(hit, hit.errY * 10000.);
+
+  m_corrHists["PhiSens"].fillCorrHistsY(hit, hit.phiSens * 180. / M_PI);
+  m_corrHists["PhiSensX"].fillCorrHistsY(hit, hit.phiSensX * 180. / M_PI);
+  m_corrHists["PhiSensY"].fillCorrHistsY(hit, hit.phiSensY * 180. / M_PI);
+
+  sector.YHit->Fill(hit.yHit);
+  sector.YTrk->Fill(hit.yTrk);
+  sector.SigmaY2->Fill(hit.errY2 * 10000. * 10000.);
+
+  sector.ResY->Fill(hit.resY * 10000.);
   sector.NorResY->Fill(hit.norResY);
-  
+
   sector.ProbY->Fill(hit.probY);
-  
-  sector.PhiSensYVsBarycentreY->Fill(hit.baryStripY, hit.phiSensY*180./M_PI);
-  sector.PPhiSensYVsBarycentreY->Fill(hit.baryStripY, hit.phiSensY*180./M_PI);
+
+  sector.PhiSensYVsBarycentreY->Fill(hit.baryStripY, hit.phiSensY * 180. / M_PI);
+  sector.PPhiSensYVsBarycentreY->Fill(hit.baryStripY, hit.phiSensY * 180. / M_PI);
 }
 
-
-
-void
-ApeEstimator::fillHistsForApeCalculation(const TrackStruct& trackStruct){
+void ApeEstimator::fillHistsForApeCalculation(const TrackStruct& trackStruct) {
   unsigned int goodHitsPerTrack(trackStruct.v_hitParams.size());
-  
-  if(parameterSet_.getParameter<bool>("applyTrackCuts")){
+
+  if (parameterSet_.getParameter<bool>("applyTrackCuts")) {
     // which tracks to take? need min. nr. of selected hits?
-    if(goodHitsPerTrack < minGoodHitsPerTrack_)return;
+    if (goodHitsPerTrack < minGoodHitsPerTrack_)
+      return;
   }
-  
-  for(auto const & i_hit : trackStruct.v_hitParams){
+
+  for (auto const& i_hit : trackStruct.v_hitParams) {
     // Put here from earlier method
-    if(i_hit.hitState == TrackStruct::notAssignedToSectors)continue;
-    
-    for(auto & i_sector : m_tkSector_){
-      
+    if (i_hit.hitState == TrackStruct::notAssignedToSectors)
+      continue;
+
+    for (auto& i_sector : m_tkSector_) {
       bool moduleInSector(false);
-      for(auto const & i_hitSector : i_hit.v_sector){
-        if(i_sector.first == i_hitSector){
-          moduleInSector = true; 
+      for (auto const& i_hitSector : i_hit.v_sector) {
+        if (i_sector.first == i_hitSector) {
+          moduleInSector = true;
           break;
         }
       }
-      if(!moduleInSector)continue;      
-      
-      if(!calculateApe_)continue;
-      
-      if(i_hit.goodXMeasurement){
-        for(auto const & i_errBins : m_resErrBins_){
+      if (!moduleInSector)
+        continue;
+
+      if (!calculateApe_)
+        continue;
+
+      if (i_hit.goodXMeasurement) {
+        for (auto const& i_errBins : m_resErrBins_) {
           // Separate the bins for residual resolution w/o APE, to be consistent within iterations where APE will change (have same hit always in same bin)
           // So also fill this value in the histogram sigmaX
           // But of course use the normalized residual regarding the APE to have its influence in its width
-          if(i_hit.errXWoApe < i_errBins.second.first || i_hit.errXWoApe >= i_errBins.second.second){
+          if (i_hit.errXWoApe < i_errBins.second.first || i_hit.errXWoApe >= i_errBins.second.second) {
             continue;
           }
-          i_sector.second.m_binnedHists[i_errBins.first]["sigmaX"] ->Fill(i_hit.errXWoApe);
+          i_sector.second.m_binnedHists[i_errBins.first]["sigmaX"]->Fill(i_hit.errXWoApe);
           i_sector.second.m_binnedHists[i_errBins.first]["norResX"]->Fill(i_hit.norResX);
           break;
         }
-        i_sector.second.ResX->Fill(i_hit.resX*10000.);
+        i_sector.second.ResX->Fill(i_hit.resX * 10000.);
         i_sector.second.NorResX->Fill(i_hit.norResX);
       }
-      
-      if(i_hit.goodYMeasurement){
-        for(auto const & i_errBins : m_resErrBins_){
-            // Separate the bins for residual resolution w/o APE, to be consistent within iterations where APE will change (have same hit always in same bin)
-            // So also fill this value in the histogram sigmaY
-            // But of course use the normalized residual regarding the APE to have its influence in its width
-            if(i_hit.errYWoApe < i_errBins.second.first || i_hit.errYWoApe >= i_errBins.second.second){
-              continue;
-            }
-            i_sector.second.m_binnedHists[i_errBins.first]["sigmaY"] ->Fill(i_hit.errYWoApe);
-            i_sector.second.m_binnedHists[i_errBins.first]["norResY"]->Fill(i_hit.norResY);
-            break;
+
+      if (i_hit.goodYMeasurement) {
+        for (auto const& i_errBins : m_resErrBins_) {
+          // Separate the bins for residual resolution w/o APE, to be consistent within iterations where APE will change (have same hit always in same bin)
+          // So also fill this value in the histogram sigmaY
+          // But of course use the normalized residual regarding the APE to have its influence in its width
+          if (i_hit.errYWoApe < i_errBins.second.first || i_hit.errYWoApe >= i_errBins.second.second) {
+            continue;
+          }
+          i_sector.second.m_binnedHists[i_errBins.first]["sigmaY"]->Fill(i_hit.errYWoApe);
+          i_sector.second.m_binnedHists[i_errBins.first]["norResY"]->Fill(i_hit.norResY);
+          break;
         }
-        i_sector.second.ResY->Fill(i_hit.resY*10000.);
+        i_sector.second.ResY->Fill(i_hit.resY * 10000.);
         i_sector.second.NorResY->Fill(i_hit.norResY);
       }
     }
   }
 }
 
-
-
-
 // -----------------------------------------------------------------------------------------------------------
 
-
-
-void
-ApeEstimator::calculateAPE(){
+void ApeEstimator::calculateAPE() {
   // Loop over sectors for calculating APE
-  for(auto & i_sector : m_tkSector_){    
-     
-     // Loop over residual error bins to calculate APE for every bin
-    for(auto const & i_errBins : i_sector.second.m_binnedHists){
-      std::map<std::string,TH1*> m_Hists = i_errBins.second;
-       
-       // Fitting Parameters
+  for (auto& i_sector : m_tkSector_) {
+    // Loop over residual error bins to calculate APE for every bin
+    for (auto const& i_errBins : i_sector.second.m_binnedHists) {
+      std::map<std::string, TH1*> m_Hists = i_errBins.second;
+
+      // Fitting Parameters
       double integralX = m_Hists["norResX"]->Integral();
       i_sector.second.EntriesX->SetBinContent(i_errBins.first, integralX);
-      
-      if(i_sector.second.isPixel){
+
+      if (i_sector.second.isPixel) {
         double integralY = m_Hists["norResY"]->Integral();
         i_sector.second.EntriesY->SetBinContent(i_errBins.first, integralY);
       }
@@ -2116,142 +2543,140 @@ ApeEstimator::calculateAPE(){
   }
 }
 
-
-
-
 // -----------------------------------------------------------------------------------------------------------
 
-
-bool
-ApeEstimator::isHit2D(const TrackingRecHit &hit) const
-{
+bool ApeEstimator::isHit2D(const TrackingRecHit& hit) const {
   // we count SiStrip stereo modules as 2D if selected via countStereoHitAs2D_
   // (since they provide theta information)
   // --- NO, here it is always set to true ---
-  if(!hit.isValid() || (hit.dimension() < 2 && !dynamic_cast<const SiStripRecHit1D*>(&hit))){
-    return false; // real RecHit1D - but SiStripRecHit1D depends on countStereoHitAs2D_
-  }else{
+  if (!hit.isValid() || (hit.dimension() < 2 && !dynamic_cast<const SiStripRecHit1D*>(&hit))) {
+    return false;  // real RecHit1D - but SiStripRecHit1D depends on countStereoHitAs2D_
+  } else {
     const DetId detId(hit.geographicalId());
-    if(detId.det() == DetId::Tracker) {
-      if(detId.subdetId() == PixelSubdetector::PixelBarrel || detId.subdetId() == PixelSubdetector::PixelEndcap) {
-        return true; // pixel is always 2D
-      }else{ // should be SiStrip now
+    if (detId.det() == DetId::Tracker) {
+      if (detId.subdetId() == PixelSubdetector::PixelBarrel || detId.subdetId() == PixelSubdetector::PixelEndcap) {
+        return true;  // pixel is always 2D
+      } else {        // should be SiStrip now
         const SiStripDetId stripId(detId);
-        if (stripId.stereo()) return true; // stereo modules
-        else if (dynamic_cast<const SiStripRecHit1D*>(&hit) || dynamic_cast<const SiStripRecHit2D*>(&hit)) return false; // rphi modules hit
-        //the following two are not used any more since ages... 
-        else if (dynamic_cast<const SiStripMatchedRecHit2D*>(&hit)) return true; // matched is 2D
+        if (stripId.stereo())
+          return true;  // stereo modules
+        else if (dynamic_cast<const SiStripRecHit1D*>(&hit) || dynamic_cast<const SiStripRecHit2D*>(&hit))
+          return false;  // rphi modules hit
+        //the following two are not used any more since ages...
+        else if (dynamic_cast<const SiStripMatchedRecHit2D*>(&hit))
+          return true;  // matched is 2D
         else if (dynamic_cast<const ProjectedSiStripRecHit2D*>(&hit)) {
           const ProjectedSiStripRecHit2D* pH = static_cast<const ProjectedSiStripRecHit2D*>(&hit);
-          return (this->isHit2D(pH->originalHit())); // depends on original...
-        }else{
+          return (this->isHit2D(pH->originalHit()));  // depends on original...
+        } else {
           edm::LogError("UnkownType") << "@SUB=AlignmentTrackSelector::isHit2D"
                                       << "Tracker hit not in pixel, neither SiStripRecHit[12]D nor "
                                       << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
           return false;
         }
       }
-    }else{ // not tracker??
+    } else {  // not tracker??
       edm::LogWarning("DetectorMismatch") << "@SUB=AlignmentTrackSelector::isHit2D"
                                           << "Hit not in tracker with 'official' dimension >=2.";
-      return true; // dimension() >= 2 so accept that...
+      return true;  // dimension() >= 2 so accept that...
     }
   }
   // never reached...
 }
 
-
-
 // -----------------------------------------------------------------------------------------------------------
 
 // ------------ method called to for each event  ------------
-void
-ApeEstimator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   reco::BeamSpot beamSpot;
-   edm::Handle<reco::BeamSpot> beamSpotHandle;
-   iEvent.getByToken(offlinebeamSpot_, beamSpotHandle);
-   
-   if (beamSpotHandle.isValid()){
-     beamSpot = *beamSpotHandle;
-   }else{
-     edm::LogError("ApeEstimator")<<"No beam spot available from EventSetup"
-                                  <<"\n...skip event";
-     return;
-   }
-      
-   edm::Handle<TrajTrackAssociationCollection> m_TrajTracksMap;
-   iEvent.getByToken(tjTagToken_, m_TrajTracksMap);
-   
-   if(analyzerMode_)tkDetector_.TrkSize->Fill(m_TrajTracksMap->size());
-   
-   if(maxTracksPerEvent_!=0 && m_TrajTracksMap->size()>maxTracksPerEvent_)return;
-   
-   //Creation of (traj,track)
-   typedef std::pair<const Trajectory*, const reco::Track*> ConstTrajTrackPair;
-   typedef std::vector<ConstTrajTrackPair> ConstTrajTrackPairCollection;
-   ConstTrajTrackPairCollection trajTracks;
-   
-   TrajTrackAssociationCollection::const_iterator i_trajTrack;
-   for(i_trajTrack = m_TrajTracksMap->begin();i_trajTrack != m_TrajTracksMap->end();++i_trajTrack){
-     trajTracks.push_back(ConstTrajTrackPair(&(*(*i_trajTrack).key), &(*(*i_trajTrack).val)));
-   }
-   
-   
-   //Loop over Tracks & Hits
-   unsigned int trackSizeGood(0);
-   ConstTrajTrackPairCollection::const_iterator iTrack;
-   for(iTrack = trajTracks.begin(); iTrack != trajTracks.end();++iTrack){
-     
-     const Trajectory *traj = (*iTrack).first;
-     const reco::Track *track = (*iTrack).second;
-     
-     TrackStruct trackStruct;
-     trackStruct.trkParams = this->fillTrackVariables(*track, *traj, beamSpot);
-     
-     if(trackCut_)continue;
-     
-     const std::vector<TrajectoryMeasurement> v_meas = (*traj).measurements();
-     
-     //Loop over Hits
-     for(std::vector<TrajectoryMeasurement>::const_iterator i_meas = v_meas.begin(); i_meas != v_meas.end(); ++i_meas){
-       TrackStruct::HitParameterStruct hitParams = this->fillHitVariables(*i_meas, iSetup);
-       if(this->hitSelected(hitParams))trackStruct.v_hitParams.push_back(hitParams);
-     }
-     
-     if(analyzerMode_)this->fillHistsForAnalyzerMode(trackStruct);
-     if(calculateApe_)this->fillHistsForApeCalculation(trackStruct);
-     
-     if(!trackStruct.v_hitParams.empty())++trackSizeGood;
-   }
-   if(analyzerMode_ && trackSizeGood>0)tkDetector_.TrkSizeGood->Fill(trackSizeGood);
+void ApeEstimator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  reco::BeamSpot beamSpot;
+  edm::Handle<reco::BeamSpot> beamSpotHandle;
+  iEvent.getByToken(offlinebeamSpot_, beamSpotHandle);
+
+  if (beamSpotHandle.isValid()) {
+    beamSpot = *beamSpotHandle;
+  } else {
+    edm::LogError("ApeEstimator") << "No beam spot available from EventSetup"
+                                  << "\n...skip event";
+    return;
+  }
+
+  edm::Handle<TrajTrackAssociationCollection> m_TrajTracksMap;
+  iEvent.getByToken(tjTagToken_, m_TrajTracksMap);
+
+  if (analyzerMode_)
+    tkDetector_.TrkSize->Fill(m_TrajTracksMap->size());
+
+  if (maxTracksPerEvent_ != 0 && m_TrajTracksMap->size() > maxTracksPerEvent_)
+    return;
+
+  //Creation of (traj,track)
+  typedef std::pair<const Trajectory*, const reco::Track*> ConstTrajTrackPair;
+  typedef std::vector<ConstTrajTrackPair> ConstTrajTrackPairCollection;
+  ConstTrajTrackPairCollection trajTracks;
+
+  TrajTrackAssociationCollection::const_iterator i_trajTrack;
+  for (i_trajTrack = m_TrajTracksMap->begin(); i_trajTrack != m_TrajTracksMap->end(); ++i_trajTrack) {
+    trajTracks.push_back(ConstTrajTrackPair(&(*(*i_trajTrack).key), &(*(*i_trajTrack).val)));
+  }
+
+  //Loop over Tracks & Hits
+  unsigned int trackSizeGood(0);
+  ConstTrajTrackPairCollection::const_iterator iTrack;
+  for (iTrack = trajTracks.begin(); iTrack != trajTracks.end(); ++iTrack) {
+    const Trajectory* traj = (*iTrack).first;
+    const reco::Track* track = (*iTrack).second;
+
+    TrackStruct trackStruct;
+    trackStruct.trkParams = this->fillTrackVariables(*track, *traj, beamSpot);
+
+    if (trackCut_)
+      continue;
+
+    const std::vector<TrajectoryMeasurement> v_meas = (*traj).measurements();
+
+    //Loop over Hits
+    for (std::vector<TrajectoryMeasurement>::const_iterator i_meas = v_meas.begin(); i_meas != v_meas.end(); ++i_meas) {
+      TrackStruct::HitParameterStruct hitParams = this->fillHitVariables(*i_meas, iSetup);
+      if (this->hitSelected(hitParams))
+        trackStruct.v_hitParams.push_back(hitParams);
+    }
+
+    if (analyzerMode_)
+      this->fillHistsForAnalyzerMode(trackStruct);
+    if (calculateApe_)
+      this->fillHistsForApeCalculation(trackStruct);
+
+    if (!trackStruct.v_hitParams.empty())
+      ++trackSizeGood;
+  }
+  if (analyzerMode_ && trackSizeGood > 0)
+    tkDetector_.TrkSizeGood->Fill(trackSizeGood);
 }
 
-
 // ------------ method called once each job just before starting event loop  ------------
-void 
-ApeEstimator::beginJob(){
-   this->hitSelection();
-   
-   this->sectorBuilder();
-   
-   this->residualErrorBinning();
-   
-   if(analyzerMode_)this->bookSectorHistsForAnalyzerMode();
-   
-   if(calculateApe_)this->bookSectorHistsForApeCalculation();
-   
-   if(analyzerMode_)this->bookTrackHists();
-   
-   
+void ApeEstimator::beginJob() {
+  this->hitSelection();
+
+  this->sectorBuilder();
+
+  this->residualErrorBinning();
+
+  if (analyzerMode_)
+    this->bookSectorHistsForAnalyzerMode();
+
+  if (calculateApe_)
+    this->bookSectorHistsForApeCalculation();
+
+  if (analyzerMode_)
+    this->bookTrackHists();
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-ApeEstimator::endJob() {
-   if(calculateApe_)this->calculateAPE();
-   
-   edm::LogInfo("HitSelector")<<"\nThere are "<<counter1<< " negative Errors calculated\n";
+void ApeEstimator::endJob() {
+  if (calculateApe_)
+    this->calculateAPE();
+
+  edm::LogInfo("HitSelector") << "\nThere are " << counter1 << " negative Errors calculated\n";
 }
 
 //define this as a plug-in

--- a/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc
@@ -2,7 +2,7 @@
 //
 // Package:    ApeEstimatorSummary
 // Class:      ApeEstimatorSummary
-// 
+//
 /**\class ApeEstimatorSummary ApeEstimatorSummary.cc Alignment/APEEstimation/src/ApeEstimatorSummary.cc
 
  Description: [one line class summary]
@@ -17,7 +17,6 @@
 // $Id: ApeEstimatorSummary.cc,v 1.14 2012/01/26 00:06:33 hauk Exp $
 //
 //
-
 
 // system include files
 #include <memory>
@@ -39,14 +38,12 @@
 
 #include "CLHEP/Matrix/SymMatrix.h"
 
-
 //#include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
 
 //...............
 #include "Alignment/APEEstimation/interface/TrackerSectorStruct.h"
-
 
 #include "TH1.h"
 #include "TString.h"
@@ -60,36 +57,34 @@
 //
 
 class ApeEstimatorSummary : public edm::one::EDAnalyzer<> {
-   public:
-      explicit ApeEstimatorSummary(const edm::ParameterSet&);
-      ~ApeEstimatorSummary() override;
+public:
+  explicit ApeEstimatorSummary(const edm::ParameterSet&);
+  ~ApeEstimatorSummary() override;
 
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-   private:
-      void beginJob() override ;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
-      
-      void openInputFile();
-      void getTrackerSectorStructs();
-      void bookHists();
-      std::vector<double> residualErrorBinning();
-      void writeHists();
-      
-      void calculateApe();
-      
-      enum ApeWeight{wInvalid, wUnity, wEntries, wEntriesOverSigmaX2};
-      
-      // ----------member data ---------------------------
-      const edm::ParameterSet parameterSet_;
-      
-      bool firstEvent=true;
-      
-      
-      TFile* inputFile_;
-      
-      std::map<unsigned int, TrackerSectorStruct> m_tkSector_;
-      unsigned int noSectors_;
+  void openInputFile();
+  void getTrackerSectorStructs();
+  void bookHists();
+  std::vector<double> residualErrorBinning();
+  void writeHists();
+
+  void calculateApe();
+
+  enum ApeWeight { wInvalid, wUnity, wEntries, wEntriesOverSigmaX2 };
+
+  // ----------member data ---------------------------
+  const edm::ParameterSet parameterSet_;
+
+  bool firstEvent = true;
+
+  TFile* inputFile_;
+
+  std::map<unsigned int, TrackerSectorStruct> m_tkSector_;
+  unsigned int noSectors_;
 };
 
 //
@@ -103,192 +98,220 @@ class ApeEstimatorSummary : public edm::one::EDAnalyzer<> {
 //
 // constructors and destructor
 //
-ApeEstimatorSummary::ApeEstimatorSummary(const edm::ParameterSet& iConfig):
-  parameterSet_(iConfig),
-  inputFile_(nullptr)
-{
-}
+ApeEstimatorSummary::ApeEstimatorSummary(const edm::ParameterSet& iConfig)
+    : parameterSet_(iConfig), inputFile_(nullptr) {}
 
-
-ApeEstimatorSummary::~ApeEstimatorSummary()
-{
-}
-
+ApeEstimatorSummary::~ApeEstimatorSummary() {}
 
 //
 // member functions
 //
 
-
-void
-ApeEstimatorSummary::openInputFile(){
+void ApeEstimatorSummary::openInputFile() {
   const std::string inputFileName(parameterSet_.getParameter<std::string>("InputFile"));
   std::ifstream inputFileStream;
   // Check if baseline file exists
   inputFileStream.open(inputFileName.c_str());
-  if(inputFileStream.is_open()){
-    inputFile_ = new TFile(inputFileName.c_str(),"READ");
+  if (inputFileStream.is_open()) {
+    inputFile_ = new TFile(inputFileName.c_str(), "READ");
   }
-  if(inputFile_){
-    edm::LogInfo("CalculateAPE")<<"Input file from loop over tracks and corresponding hits sucessfully opened";
-  }
-  else{
-    edm::LogError("CalculateAPE")<<"There is NO input file\n"
-       <<"...APE calculation stopped. Please check path of input file name in config:\n"
-       <<"\t"<<inputFileName;
-    throw edm::Exception( edm::errors::Configuration, "Bad input file name");
+  if (inputFile_) {
+    edm::LogInfo("CalculateAPE") << "Input file from loop over tracks and corresponding hits sucessfully opened";
+  } else {
+    edm::LogError("CalculateAPE") << "There is NO input file\n"
+                                  << "...APE calculation stopped. Please check path of input file name in config:\n"
+                                  << "\t" << inputFileName;
+    throw edm::Exception(edm::errors::Configuration, "Bad input file name");
   }
 }
 
-
-
-void
-ApeEstimatorSummary::getTrackerSectorStructs(){
+void ApeEstimatorSummary::getTrackerSectorStructs() {
   // At present first of the plugins registered in TFileService needs to be the one containing the normalized residual histos per sector per error bin
   TString pluginName(inputFile_->GetListOfKeys()->At(0)->GetName());
-  
+
   pluginName += "/";
   TDirectory *sectorDir(nullptr), *intervalDir(nullptr);
   bool sectorBool(true);
   unsigned int iSector(1);
-  for(;sectorBool;++iSector){
+  for (; sectorBool; ++iSector) {
     std::stringstream sectorName, fullSectorName;
     sectorName << "Sector_" << iSector << "/";
     fullSectorName << pluginName << sectorName.str();
     TString fullName(fullSectorName.str().c_str());
     inputFile_->cd();
     sectorDir = (TDirectory*)inputFile_->TDirectory::GetDirectory(fullName);
-    if(sectorDir){
+    if (sectorDir) {
       TrackerSectorStruct tkSector;
       sectorDir->GetObject("z_name;1", tkSector.Name);
       tkSector.name = tkSector.Name->GetTitle();
       bool intervalBool(true);
-      for(unsigned int iInterval(1);intervalBool;++iInterval){
+      for (unsigned int iInterval(1); intervalBool; ++iInterval) {
         std::stringstream intervalName, fullIntervalName;
-        intervalName << "Interval_" << iInterval <<"/";
+        intervalName << "Interval_" << iInterval << "/";
         fullIntervalName << fullSectorName.str() << intervalName.str();
         fullName = fullIntervalName.str().c_str();
         intervalDir = (TDirectory*)inputFile_->TDirectory::GetDirectory(fullName);
-        if(intervalDir){
+        if (intervalDir) {
           intervalDir->GetObject("h_sigmaX;1", tkSector.m_binnedHists[iInterval]["sigmaX"]);
           intervalDir->GetObject("h_norResX;1", tkSector.m_binnedHists[iInterval]["norResX"]);
           intervalDir->GetObject("h_sigmaY;1", tkSector.m_binnedHists[iInterval]["sigmaY"]);
           intervalDir->GetObject("h_norResY;1", tkSector.m_binnedHists[iInterval]["norResY"]);
-          if(tkSector.m_binnedHists[iInterval]["sigmaY"] && tkSector.m_binnedHists[iInterval]["norResY"]){
+          if (tkSector.m_binnedHists[iInterval]["sigmaY"] && tkSector.m_binnedHists[iInterval]["norResY"]) {
             tkSector.isPixel = true;
           }
-        }else{
+        } else {
           intervalBool = false;
-          if(iSector==1)edm::LogInfo("CalculateAPE")<<"There are "<<iInterval-1<<" intervals per sector defined in input file";
+          if (iSector == 1)
+            edm::LogInfo("CalculateAPE") << "There are " << iInterval - 1
+                                         << " intervals per sector defined in input file";
         }
       }
-      TDirectory *resultsDir(nullptr);
+      TDirectory* resultsDir(nullptr);
       std::stringstream fullResultName;
       fullResultName << fullSectorName.str() << "Results/";
       fullName = fullResultName.str().c_str();
       resultsDir = (TDirectory*)inputFile_->TDirectory::GetDirectory(fullName);
-      if(resultsDir){
+      if (resultsDir) {
         resultsDir->GetObject("h_entriesX;1", tkSector.EntriesX);
-        if(tkSector.isPixel)resultsDir->GetObject("h_entriesY;1", tkSector.EntriesY);
+        if (tkSector.isPixel)
+          resultsDir->GetObject("h_entriesY;1", tkSector.EntriesY);
         TTree* rawIdTree(nullptr);
         resultsDir->GetObject("rawIdTree", rawIdTree);
         unsigned int rawId(0);
         rawIdTree->SetBranchAddress("RawId", &rawId);
-        for(int entry=0; entry<rawIdTree->GetEntries(); ++entry){
+        for (int entry = 0; entry < rawIdTree->GetEntries(); ++entry) {
           rawIdTree->GetEntry(entry);
           // command "hadd" adds entries in TTree, so rawId are existing as often as number of files are added
           bool alreadyAdded(false);
-          for(auto const & i_rawId : tkSector.v_rawId){
-            if(rawId==i_rawId)alreadyAdded = true;
+          for (auto const& i_rawId : tkSector.v_rawId) {
+            if (rawId == i_rawId)
+              alreadyAdded = true;
           }
-          if(alreadyAdded)break;
+          if (alreadyAdded)
+            break;
           tkSector.v_rawId.push_back(rawId);
         }
       }
       m_tkSector_[iSector] = tkSector;
-    }else{
+    } else {
       sectorBool = false;
-      edm::LogInfo("CalculateAPE")<<"There are "<<iSector-1<<" sectors defined in input file";
+      edm::LogInfo("CalculateAPE") << "There are " << iSector - 1 << " sectors defined in input file";
     }
   }
-  noSectors_ = iSector+1;
-  
-  
+  noSectors_ = iSector + 1;
 }
 
-
-
-void
-ApeEstimatorSummary::bookHists(){
+void ApeEstimatorSummary::bookHists() {
   const std::vector<double> v_binX(this->residualErrorBinning());
-  for(auto & i_sector : m_tkSector_){
-    i_sector.second.WeightX         = new TH1F("h_weightX","relative weight w_{x}/w_{tot,x};#sigma_{x}  [#mum];w_{x}/w_{tot,x}",v_binX.size()-1,&(v_binX[0]));
-    i_sector.second.MeanX           = new TH1F("h_meanX","residual mean <r_{x}/#sigma_{r,x}>;#sigma_{x}  [#mum];<r_{x}/#sigma_{r,x}>",v_binX.size()-1,&(v_binX[0]));
-    i_sector.second.RmsX            = new TH1F("h_rmsX","residual rms RMS(r_{x}/#sigma_{r,x});#sigma_{x}  [#mum];RMS(r_{x}/#sigma_{r,x})",v_binX.size()-1,&(v_binX[0]));
-    i_sector.second.FitMeanX1       = new TH1F("h_fitMeanX1","fitted residual mean #mu_{x};#sigma_{x}  [#mum];#mu_{x}",v_binX.size()-1,&(v_binX[0]));
-    i_sector.second.ResidualWidthX1 = new TH1F("h_residualWidthX1","residual width #Delta_{x};#sigma_{x}  [#mum];#Delta_{x}",v_binX.size()-1,&(v_binX[0]));
-    i_sector.second.CorrectionX1    = new TH1F("h_correctionX1","correction to APE_{x};#sigma_{x}  [#mum];#Delta#sigma_{align,x}  [#mum]",v_binX.size()-1,&(v_binX[0]));
-    i_sector.second.FitMeanX2       = new TH1F("h_fitMeanX2","fitted residual mean #mu_{x};#sigma_{x}  [#mum];#mu_{x}",v_binX.size()-1,&(v_binX[0]));
-    i_sector.second.ResidualWidthX2 = new TH1F("h_residualWidthX2","residual width #Delta_{x};#sigma_{x}  [#mum];#Delta_{x}",v_binX.size()-1,&(v_binX[0]));
-    i_sector.second.CorrectionX2    = new TH1F("h_correctionX2","correction to APE_{x};#sigma_{x}  [#mum];#Delta#sigma_{align,x}  [#mum]",v_binX.size()-1,&(v_binX[0]));
-  
-    if(i_sector.second.isPixel){
-      i_sector.second.WeightY         = new TH1F("h_weightY","relative weight w_{y}/w_{tot,y};#sigma_{y}  [#mum];w_{y}/w_{tot,y}",v_binX.size()-1,&(v_binX[0]));
-      i_sector.second.MeanY           = new TH1F("h_meanY","residual mean <r_{y}/#sigma_{r,y}>;#sigma_{y}  [#mum];<r_{y}/#sigma_{r,y}>",v_binX.size()-1,&(v_binX[0]));
-      i_sector.second.RmsY            = new TH1F("h_rmsY","residual rms RMS(r_{y}/#sigma_{r,y});#sigma_{y}  [#mum];RMS(r_{y}/#sigma_{r,y})",v_binX.size()-1,&(v_binX[0]));
-      i_sector.second.FitMeanY1       = new TH1F("h_fitMeanY1","fitted residual mean #mu_{y};#sigma_{y}  [#mum];#mu_{y}",v_binX.size()-1,&(v_binX[0]));
-      i_sector.second.ResidualWidthY1 = new TH1F("h_residualWidthY1","residual width #Delta_{y};#sigma_{y}  [#mum];#Delta_{y}",v_binX.size()-1,&(v_binX[0]));
-      i_sector.second.CorrectionY1    = new TH1F("h_correctionY1","correction to APE_{y};#sigma_{y}  [#mum];#Delta#sigma_{align,y}  [#mum]",v_binX.size()-1,&(v_binX[0]));
-      i_sector.second.FitMeanY2       = new TH1F("h_fitMeanY2","fitted residual mean #mu_{y};#sigma_{y}  [#mum];#mu_{y}",v_binX.size()-1,&(v_binX[0]));
-      i_sector.second.ResidualWidthY2 = new TH1F("h_residualWidthY2","residual width #Delta_{y};#sigma_{y}  [#mum];#Delta_{y}",v_binX.size()-1,&(v_binX[0]));
-      i_sector.second.CorrectionY2    = new TH1F("h_correctionY2","correction to APE_{y};#sigma_{y}  [#mum];#Delta#sigma_{align,y}  [#mum]",v_binX.size()-1,&(v_binX[0]));
+  for (auto& i_sector : m_tkSector_) {
+    i_sector.second.WeightX = new TH1F("h_weightX",
+                                       "relative weight w_{x}/w_{tot,x};#sigma_{x}  [#mum];w_{x}/w_{tot,x}",
+                                       v_binX.size() - 1,
+                                       &(v_binX[0]));
+    i_sector.second.MeanX = new TH1F("h_meanX",
+                                     "residual mean <r_{x}/#sigma_{r,x}>;#sigma_{x}  [#mum];<r_{x}/#sigma_{r,x}>",
+                                     v_binX.size() - 1,
+                                     &(v_binX[0]));
+    i_sector.second.RmsX = new TH1F("h_rmsX",
+                                    "residual rms RMS(r_{x}/#sigma_{r,x});#sigma_{x}  [#mum];RMS(r_{x}/#sigma_{r,x})",
+                                    v_binX.size() - 1,
+                                    &(v_binX[0]));
+    i_sector.second.FitMeanX1 = new TH1F(
+        "h_fitMeanX1", "fitted residual mean #mu_{x};#sigma_{x}  [#mum];#mu_{x}", v_binX.size() - 1, &(v_binX[0]));
+    i_sector.second.ResidualWidthX1 = new TH1F("h_residualWidthX1",
+                                               "residual width #Delta_{x};#sigma_{x}  [#mum];#Delta_{x}",
+                                               v_binX.size() - 1,
+                                               &(v_binX[0]));
+    i_sector.second.CorrectionX1 = new TH1F("h_correctionX1",
+                                            "correction to APE_{x};#sigma_{x}  [#mum];#Delta#sigma_{align,x}  [#mum]",
+                                            v_binX.size() - 1,
+                                            &(v_binX[0]));
+    i_sector.second.FitMeanX2 = new TH1F(
+        "h_fitMeanX2", "fitted residual mean #mu_{x};#sigma_{x}  [#mum];#mu_{x}", v_binX.size() - 1, &(v_binX[0]));
+    i_sector.second.ResidualWidthX2 = new TH1F("h_residualWidthX2",
+                                               "residual width #Delta_{x};#sigma_{x}  [#mum];#Delta_{x}",
+                                               v_binX.size() - 1,
+                                               &(v_binX[0]));
+    i_sector.second.CorrectionX2 = new TH1F("h_correctionX2",
+                                            "correction to APE_{x};#sigma_{x}  [#mum];#Delta#sigma_{align,x}  [#mum]",
+                                            v_binX.size() - 1,
+                                            &(v_binX[0]));
+
+    if (i_sector.second.isPixel) {
+      i_sector.second.WeightY = new TH1F("h_weightY",
+                                         "relative weight w_{y}/w_{tot,y};#sigma_{y}  [#mum];w_{y}/w_{tot,y}",
+                                         v_binX.size() - 1,
+                                         &(v_binX[0]));
+      i_sector.second.MeanY = new TH1F("h_meanY",
+                                       "residual mean <r_{y}/#sigma_{r,y}>;#sigma_{y}  [#mum];<r_{y}/#sigma_{r,y}>",
+                                       v_binX.size() - 1,
+                                       &(v_binX[0]));
+      i_sector.second.RmsY = new TH1F("h_rmsY",
+                                      "residual rms RMS(r_{y}/#sigma_{r,y});#sigma_{y}  [#mum];RMS(r_{y}/#sigma_{r,y})",
+                                      v_binX.size() - 1,
+                                      &(v_binX[0]));
+      i_sector.second.FitMeanY1 = new TH1F(
+          "h_fitMeanY1", "fitted residual mean #mu_{y};#sigma_{y}  [#mum];#mu_{y}", v_binX.size() - 1, &(v_binX[0]));
+      i_sector.second.ResidualWidthY1 = new TH1F("h_residualWidthY1",
+                                                 "residual width #Delta_{y};#sigma_{y}  [#mum];#Delta_{y}",
+                                                 v_binX.size() - 1,
+                                                 &(v_binX[0]));
+      i_sector.second.CorrectionY1 = new TH1F("h_correctionY1",
+                                              "correction to APE_{y};#sigma_{y}  [#mum];#Delta#sigma_{align,y}  [#mum]",
+                                              v_binX.size() - 1,
+                                              &(v_binX[0]));
+      i_sector.second.FitMeanY2 = new TH1F(
+          "h_fitMeanY2", "fitted residual mean #mu_{y};#sigma_{y}  [#mum];#mu_{y}", v_binX.size() - 1, &(v_binX[0]));
+      i_sector.second.ResidualWidthY2 = new TH1F("h_residualWidthY2",
+                                                 "residual width #Delta_{y};#sigma_{y}  [#mum];#Delta_{y}",
+                                                 v_binX.size() - 1,
+                                                 &(v_binX[0]));
+      i_sector.second.CorrectionY2 = new TH1F("h_correctionY2",
+                                              "correction to APE_{y};#sigma_{y}  [#mum];#Delta#sigma_{align,y}  [#mum]",
+                                              v_binX.size() - 1,
+                                              &(v_binX[0]));
     }
   }
 }
 
-
-
-std::vector<double>
-ApeEstimatorSummary::residualErrorBinning(){
+std::vector<double> ApeEstimatorSummary::residualErrorBinning() {
   std::vector<double> v_binX;
   TH1* EntriesX(m_tkSector_[1].EntriesX);
-  for(int iBin=1; iBin<=EntriesX->GetNbinsX()+1; ++iBin){
+  for (int iBin = 1; iBin <= EntriesX->GetNbinsX() + 1; ++iBin) {
     v_binX.push_back(EntriesX->GetBinLowEdge(iBin));
   }
   return v_binX;
 }
 
-
-void
-ApeEstimatorSummary::writeHists(){
+void ApeEstimatorSummary::writeHists() {
   TFile* resultsFile = new TFile(parameterSet_.getParameter<std::string>("ResultsFile").c_str(), "RECREATE");
   TDirectory* baseDir = resultsFile->mkdir("ApeEstimatorSummary");
-  for(auto const & i_sector : m_tkSector_){
+  for (auto const& i_sector : m_tkSector_) {
     std::stringstream dirName;
-    dirName<<"Sector_" << i_sector.first;
+    dirName << "Sector_" << i_sector.first;
     TDirectory* dir = baseDir->mkdir(dirName.str().c_str());
     dir->cd();
-    
+
     i_sector.second.Name->Write();
-    
+
     i_sector.second.WeightX->Write();
     i_sector.second.MeanX->Write();
-    i_sector.second.RmsX->Write();        
-    i_sector.second.FitMeanX1->Write();          
-    i_sector.second.ResidualWidthX1 ->Write();
-    i_sector.second.CorrectionX1->Write();   
-    i_sector.second.FitMeanX2->Write();          
+    i_sector.second.RmsX->Write();
+    i_sector.second.FitMeanX1->Write();
+    i_sector.second.ResidualWidthX1->Write();
+    i_sector.second.CorrectionX1->Write();
+    i_sector.second.FitMeanX2->Write();
     i_sector.second.ResidualWidthX2->Write();
     i_sector.second.CorrectionX2->Write();
-    
-    if(i_sector.second.isPixel){
+
+    if (i_sector.second.isPixel) {
       i_sector.second.WeightY->Write();
       i_sector.second.MeanY->Write();
-      i_sector.second.RmsY->Write();      
-      i_sector.second.FitMeanY1->Write();        
-      i_sector.second.ResidualWidthY1 ->Write();
-      i_sector.second.CorrectionY1->Write();   
-      i_sector.second.FitMeanY2->Write();        
+      i_sector.second.RmsY->Write();
+      i_sector.second.FitMeanY1->Write();
+      i_sector.second.ResidualWidthY1->Write();
+      i_sector.second.CorrectionY1->Write();
+      i_sector.second.FitMeanY2->Write();
       i_sector.second.ResidualWidthY2->Write();
       i_sector.second.CorrectionY2->Write();
     }
@@ -296,13 +319,10 @@ ApeEstimatorSummary::writeHists(){
   resultsFile->Close();
 }
 
-
-
-void
-ApeEstimatorSummary::calculateApe(){
+void ApeEstimatorSummary::calculateApe() {
   // Set baseline or calculate APE value?
   const bool setBaseline(parameterSet_.getParameter<bool>("setBaseline"));
-      
+
   // Read in baseline file for calculation of APE value (if not setting baseline)
   // Has same format as iterationFile
   const std::string baselineFileName(parameterSet_.getParameter<std::string>("BaselineFile"));
@@ -310,164 +330,170 @@ ApeEstimatorSummary::calculateApe(){
   TTree* baselineTreeX(nullptr);
   TTree* baselineTreeY(nullptr);
   TTree* sectorNameBaselineTree(nullptr);
-  if(!setBaseline){
+  if (!setBaseline) {
     std::ifstream baselineFileStream;
     // Check if baseline file exists
     baselineFileStream.open(baselineFileName.c_str());
-    if(baselineFileStream.is_open()){
+    if (baselineFileStream.is_open()) {
       baselineFileStream.close();
-      baselineFile = new TFile(baselineFileName.c_str(),"READ");
+      baselineFile = new TFile(baselineFileName.c_str(), "READ");
     }
-    if(baselineFile){
-      edm::LogInfo("CalculateAPE")<<"Baseline file for APE values sucessfully opened";
-      baselineFile->GetObject("iterTreeX;1",baselineTreeX);
-      baselineFile->GetObject("iterTreeY;1",baselineTreeY);
-      baselineFile->GetObject("nameTree;1",sectorNameBaselineTree);
-    }else{
-      edm::LogWarning("CalculateAPE")<<"There is NO baseline file for APE values, so normalized residual width =1 for ideal conditions is assumed";
+    if (baselineFile) {
+      edm::LogInfo("CalculateAPE") << "Baseline file for APE values sucessfully opened";
+      baselineFile->GetObject("iterTreeX;1", baselineTreeX);
+      baselineFile->GetObject("iterTreeY;1", baselineTreeY);
+      baselineFile->GetObject("nameTree;1", sectorNameBaselineTree);
+    } else {
+      edm::LogWarning("CalculateAPE") << "There is NO baseline file for APE values, so normalized residual width =1 "
+                                         "for ideal conditions is assumed";
     }
   }
-   
+
   // Set up root file for iterations on APE value (or for setting baseline in setBaseline mode)
-  const std::string iterationFileName(setBaseline ? baselineFileName : parameterSet_.getParameter<std::string>("IterationFile"));
+  const std::string iterationFileName(setBaseline ? baselineFileName
+                                                  : parameterSet_.getParameter<std::string>("IterationFile"));
   // For iterations, updates are needed to not overwrite the iterations before
-  TFile* iterationFile = new TFile(iterationFileName.c_str(),setBaseline ? "RECREATE" : "UPDATE");
-   
-   
+  TFile* iterationFile = new TFile(iterationFileName.c_str(), setBaseline ? "RECREATE" : "UPDATE");
+
   // Set up TTree for iterative APE values on first pass (first iteration) or read from file (further iterations)
   TTree* iterationTreeX(nullptr);
   TTree* iterationTreeY(nullptr);
-  iterationFile->GetObject("iterTreeX;1",iterationTreeX);
-  iterationFile->GetObject("iterTreeY;1",iterationTreeY);
+  iterationFile->GetObject("iterTreeX;1", iterationTreeX);
+  iterationFile->GetObject("iterTreeY;1", iterationTreeY);
   // The same for TTree containing the names of the sectors (no additional check, since always handled exactly as iterationTree)
   TTree* sectorNameTree(nullptr);
-  iterationFile->GetObject("nameTree;1",sectorNameTree);
-   
+  iterationFile->GetObject("nameTree;1", sectorNameTree);
+
   bool firstIter(false);
-  if(!iterationTreeX){ // should be always true in setBaseline mode, since file is recreated
+  if (!iterationTreeX) {  // should be always true in setBaseline mode, since file is recreated
     firstIter = true;
-    if(!setBaseline){
-      iterationTreeX = new TTree("iterTreeX","Tree for APE x values of all iterations");
-      iterationTreeY = new TTree("iterTreeY","Tree for APE y values of all iterations");
-      edm::LogInfo("CalculateAPE")<<"First APE iteration (number 0.), create iteration file with TTree";
-      sectorNameTree = new TTree("nameTree","Tree with names of sectors");
-    }else{
-      iterationTreeX = new TTree("iterTreeX","Tree for baseline x values of normalized residual width");
-      iterationTreeY = new TTree("iterTreeY","Tree for baseline y values of normalized residual width");
-      edm::LogInfo("CalculateAPE")<<"Set baseline, create baseline file with TTree";
-      sectorNameTree = new TTree("nameTree","Tree with names of sectors");
+    if (!setBaseline) {
+      iterationTreeX = new TTree("iterTreeX", "Tree for APE x values of all iterations");
+      iterationTreeY = new TTree("iterTreeY", "Tree for APE y values of all iterations");
+      edm::LogInfo("CalculateAPE") << "First APE iteration (number 0.), create iteration file with TTree";
+      sectorNameTree = new TTree("nameTree", "Tree with names of sectors");
+    } else {
+      iterationTreeX = new TTree("iterTreeX", "Tree for baseline x values of normalized residual width");
+      iterationTreeY = new TTree("iterTreeY", "Tree for baseline y values of normalized residual width");
+      edm::LogInfo("CalculateAPE") << "Set baseline, create baseline file with TTree";
+      sectorNameTree = new TTree("nameTree", "Tree with names of sectors");
     }
-  }else{
+  } else {
     const unsigned int iteration(iterationTreeX->GetEntries());
-    edm::LogWarning("CalculateAPE")<<"NOT the first APE iteration (number 0.) but the "<<iteration<<". one, is this wanted or forgot to delete old iteration file with TTree?";
+    edm::LogWarning("CalculateAPE") << "NOT the first APE iteration (number 0.) but the " << iteration
+                                    << ". one, is this wanted or forgot to delete old iteration file with TTree?";
   }
-   
-   
+
   // Assign the information stored in the trees to arrays
   double a_apeSectorX[noSectors_];
   double a_apeSectorY[noSectors_];
   double a_baselineSectorX[noSectors_];
   double a_baselineSectorY[noSectors_];
-  
+
   std::string* a_sectorName[noSectors_];
   std::string* a_sectorBaselineName[noSectors_];
-  for(auto const & i_sector : m_tkSector_){
+  for (auto const& i_sector : m_tkSector_) {
     const unsigned int iSector(i_sector.first);
     const bool pixelSector(i_sector.second.isPixel);
     a_apeSectorX[iSector] = 99.;
     a_apeSectorY[iSector] = 99.;
     a_baselineSectorX[iSector] = -99.;
     a_baselineSectorY[iSector] = -99.;
-    
+
     a_sectorName[iSector] = nullptr;
     a_sectorBaselineName[iSector] = nullptr;
     std::stringstream ss_sector, ss_sectorSuffixed;
     ss_sector << "Ape_Sector_" << iSector;
-    if(!setBaseline && baselineTreeX){
+    if (!setBaseline && baselineTreeX) {
       baselineTreeX->SetBranchAddress(ss_sector.str().c_str(), &a_baselineSectorX[iSector]);
       baselineTreeX->GetEntry(0);
-      if(pixelSector){
+      if (pixelSector) {
         baselineTreeY->SetBranchAddress(ss_sector.str().c_str(), &a_baselineSectorY[iSector]);
         baselineTreeY->GetEntry(0);
       }
       sectorNameBaselineTree->SetBranchAddress(ss_sector.str().c_str(), &a_sectorBaselineName[iSector]);
       sectorNameBaselineTree->GetEntry(0);
-    }else{
+    } else {
       // Set default ideal normalized residual width to 1
       a_baselineSectorX[iSector] = 1.;
       a_baselineSectorY[iSector] = 1.;
     }
-    if(firstIter){ // should be always true in setBaseline mode, since file is recreated  
+    if (firstIter) {  // should be always true in setBaseline mode, since file is recreated
       ss_sectorSuffixed << ss_sector.str() << "/D";
       iterationTreeX->Branch(ss_sector.str().c_str(), &a_apeSectorX[iSector], ss_sectorSuffixed.str().c_str());
-      if(pixelSector){
+      if (pixelSector) {
         iterationTreeY->Branch(ss_sector.str().c_str(), &a_apeSectorY[iSector], ss_sectorSuffixed.str().c_str());
       }
       sectorNameTree->Branch(ss_sector.str().c_str(), &a_sectorName[iSector], 32000, 00);
-    }else{
+    } else {
       iterationTreeX->SetBranchAddress(ss_sector.str().c_str(), &a_apeSectorX[iSector]);
-      iterationTreeX->GetEntry(iterationTreeX->GetEntries()-1);
-      if(pixelSector){
+      iterationTreeX->GetEntry(iterationTreeX->GetEntries() - 1);
+      if (pixelSector) {
         iterationTreeY->SetBranchAddress(ss_sector.str().c_str(), &a_apeSectorY[iSector]);
-        iterationTreeY->GetEntry(iterationTreeY->GetEntries()-1);
+        iterationTreeY->GetEntry(iterationTreeY->GetEntries() - 1);
       }
       sectorNameTree->SetBranchAddress(ss_sector.str().c_str(), &a_sectorName[iSector]);
       sectorNameTree->GetEntry(0);
     }
   }
-   
-   
+
   // Check whether sector definitions are identical with the ones of previous iterations and with the ones in baseline file
-  for(auto & i_sector : m_tkSector_){
+  for (auto& i_sector : m_tkSector_) {
     const std::string& name(i_sector.second.name);
-    if(!firstIter){
+    if (!firstIter) {
       const std::string& nameLastIter(*a_sectorName[i_sector.first]);
-      if(name!=nameLastIter){
-        edm::LogError("CalculateAPE")<<"Inconsistent sector definition in iterationFile for sector "<<i_sector.first<<",\n"
-                                    <<"Recent iteration has name \""<<name<<"\", while previous had \""<<nameLastIter<<"\"\n"
-                                <<"...APE calculation stopped. Please check sector definitions in config!\n";
+      if (name != nameLastIter) {
+        edm::LogError("CalculateAPE") << "Inconsistent sector definition in iterationFile for sector " << i_sector.first
+                                      << ",\n"
+                                      << "Recent iteration has name \"" << name << "\", while previous had \""
+                                      << nameLastIter << "\"\n"
+                                      << "...APE calculation stopped. Please check sector definitions in config!\n";
         return;
       }
-    }else{ 
+    } else {
       a_sectorName[i_sector.first] = new std::string(name);
     }
-    if(!setBaseline && baselineFile){
+    if (!setBaseline && baselineFile) {
       const std::string& nameBaseline(*a_sectorBaselineName[i_sector.first]);
-      if(name!=nameBaseline){
-        edm::LogError("CalculateAPE")<<"Inconsistent sector definition in baselineFile for sector "<<i_sector.first<<",\n"
-                                    <<"Recent iteration has name \""<<name<<"\", while baseline had \""<<nameBaseline<<"\"\n"
-                                <<"...APE calculation stopped. Please check sector definitions in config!\n";
+      if (name != nameBaseline) {
+        edm::LogError("CalculateAPE") << "Inconsistent sector definition in baselineFile for sector " << i_sector.first
+                                      << ",\n"
+                                      << "Recent iteration has name \"" << name << "\", while baseline had \""
+                                      << nameBaseline << "\"\n"
+                                      << "...APE calculation stopped. Please check sector definitions in config!\n";
         return;
       }
     }
   }
-   
-   
+
   // Set up text file for writing out APE values per module
   std::ofstream apeOutputFile;
-  if(!setBaseline){
+  if (!setBaseline) {
     const std::string apeOutputFileName(parameterSet_.getParameter<std::string>("ApeOutputFile"));
     apeOutputFile.open(apeOutputFileName.c_str());
-    if(apeOutputFile.is_open()){
-      edm::LogInfo("CalculateAPE")<<"Text file for writing APE values successfully opened";
-    }else{
-      edm::LogError("CalculateAPE")<<"Text file for writing APE values NOT opened,\n"
-                                  <<"...APE calculation stopped. Please check path of text file name in config:\n"
-                                  <<"\t"<<apeOutputFileName;
+    if (apeOutputFile.is_open()) {
+      edm::LogInfo("CalculateAPE") << "Text file for writing APE values successfully opened";
+    } else {
+      edm::LogError("CalculateAPE") << "Text file for writing APE values NOT opened,\n"
+                                    << "...APE calculation stopped. Please check path of text file name in config:\n"
+                                    << "\t" << apeOutputFileName;
       return;
     }
   }
-   
+
   // Loop over sectors for calculating APE
   const std::string apeWeightName(parameterSet_.getParameter<std::string>("apeWeight"));
   ApeWeight apeWeight(wInvalid);
-  if(apeWeightName=="unity") apeWeight = wUnity;
-  else if(apeWeightName=="entries")apeWeight = wEntries;
-  else if(apeWeightName=="entriesOverSigmaX2")apeWeight = wEntriesOverSigmaX2;
-  if(apeWeight==wInvalid){
-    edm::LogError("CalculateAPE")<<"Invalid parameter 'apeWeight' in cfg file: \""<<apeWeightName
-                                <<"\"\nimplemented apeWeights are \"unity\", \"entries\", \"entriesOverSigmaX2\""
-                            <<"\n...APE calculation stopped.";
+  if (apeWeightName == "unity")
+    apeWeight = wUnity;
+  else if (apeWeightName == "entries")
+    apeWeight = wEntries;
+  else if (apeWeightName == "entriesOverSigmaX2")
+    apeWeight = wEntriesOverSigmaX2;
+  if (apeWeight == wInvalid) {
+    edm::LogError("CalculateAPE") << "Invalid parameter 'apeWeight' in cfg file: \"" << apeWeightName
+                                  << "\"\nimplemented apeWeights are \"unity\", \"entries\", \"entriesOverSigmaX2\""
+                                  << "\n...APE calculation stopped.";
     return;
   }
   const double minHitsPerInterval(parameterSet_.getParameter<double>("minHitsPerInterval"));
@@ -475,78 +501,81 @@ ApeEstimatorSummary::calculateApe(){
   const double correctionScaling(parameterSet_.getParameter<double>("correctionScaling"));
   const bool smoothIteration(parameterSet_.getParameter<bool>("smoothIteration"));
   const double smoothFraction(parameterSet_.getParameter<double>("smoothFraction"));
-  if(smoothFraction<=0. || smoothFraction>1.){
-    edm::LogError("CalculateAPE")<<"Incorrect parameter in cfg file,"
-                                <<"\nsmoothFraction has to be in [0,1], but is "<<smoothFraction
-                            <<"\n...APE calculation stopped.";
+  if (smoothFraction <= 0. || smoothFraction > 1.) {
+    edm::LogError("CalculateAPE") << "Incorrect parameter in cfg file,"
+                                  << "\nsmoothFraction has to be in [0,1], but is " << smoothFraction
+                                  << "\n...APE calculation stopped.";
     return;
   }
-  for(auto & i_sector : m_tkSector_){
-    typedef std::pair<double,double> Error2AndResidualWidth2PerBin;
-    typedef std::pair<double,Error2AndResidualWidth2PerBin> WeightAndResultsPerBin;
+  for (auto& i_sector : m_tkSector_) {
+    typedef std::pair<double, double> Error2AndResidualWidth2PerBin;
+    typedef std::pair<double, Error2AndResidualWidth2PerBin> WeightAndResultsPerBin;
     std::vector<WeightAndResultsPerBin> v_weightAndResultsPerBinX;
     std::vector<WeightAndResultsPerBin> v_weightAndResultsPerBinY;
-    
+
     double baselineWidthX2(a_baselineSectorX[i_sector.first]);
     double baselineWidthY2(a_baselineSectorY[i_sector.first]);
-    
+
     // Loop over residual error bins to calculate APE for every bin
-    for(auto const & i_errBins : i_sector.second.m_binnedHists){
-      std::map<std::string,TH1*> mHists = i_errBins.second;
-      
+    for (auto const& i_errBins : i_sector.second.m_binnedHists) {
+      std::map<std::string, TH1*> mHists = i_errBins.second;
+
       double entriesX = mHists["sigmaX"]->GetEntries();
-      double meanSigmaX = mHists["sigmaX"]->GetMean(); 
-      
+      double meanSigmaX = mHists["sigmaX"]->GetMean();
+
       // Fitting Parameters
-      double xMin      = mHists["norResX"]->GetXaxis()->GetXmin();
-      double xMax      = mHists["norResX"]->GetXaxis()->GetXmax();
+      double xMin = mHists["norResX"]->GetXaxis()->GetXmin();
+      double xMax = mHists["norResX"]->GetXaxis()->GetXmax();
       double integralX = mHists["norResX"]->Integral();
-      double meanX     = mHists["norResX"]->GetMean();
-      double rmsX      = mHists["norResX"]->GetRMS();
-      double maximumX  = mHists["norResX"]->GetBinContent(mHists["norResX"]->GetMaximumBin());
-      
+      double meanX = mHists["norResX"]->GetMean();
+      double rmsX = mHists["norResX"]->GetRMS();
+      double maximumX = mHists["norResX"]->GetBinContent(mHists["norResX"]->GetMaximumBin());
+
       // First Gaus Fit
       TF1 funcX_1("mygausX", "gaus", xMin, xMax);
       funcX_1.SetParameters(maximumX, meanX, rmsX);
-      TString fitOpt("ILERQ"); //TString fitOpt("IMR"); ("IRLL"); ("IRQ");
-      if(integralX>minHitsPerInterval){
-        if(mHists["norResX"]->Fit(&funcX_1, fitOpt)){
-          edm::LogWarning("CalculateAPE")<<"Fit1 did not work: "<<mHists["norResX"]->Fit(&funcX_1, fitOpt);
+      TString fitOpt("ILERQ");  //TString fitOpt("IMR"); ("IRLL"); ("IRQ");
+      if (integralX > minHitsPerInterval) {
+        if (mHists["norResX"]->Fit(&funcX_1, fitOpt)) {
+          edm::LogWarning("CalculateAPE") << "Fit1 did not work: " << mHists["norResX"]->Fit(&funcX_1, fitOpt);
           continue;
         }
-        LogDebug("CalculateAPE")<<"FitResultX1\t"<<mHists["norResX"]->Fit(&funcX_1, fitOpt)<<"\n";
+        LogDebug("CalculateAPE") << "FitResultX1\t" << mHists["norResX"]->Fit(&funcX_1, fitOpt) << "\n";
       }
-      double meanX_1  = funcX_1.GetParameter(1);
+      double meanX_1 = funcX_1.GetParameter(1);
       double sigmaX_1 = funcX_1.GetParameter(2);
-      
+
       // Second gaus fit
-      TF1 funcX_2("mygausX2","gaus",meanX_1 - sigmaFactorFit*TMath::Abs(sigmaX_1), meanX_1 + sigmaFactorFit*TMath::Abs(sigmaX_1));
-      funcX_2.SetParameters(funcX_1.GetParameter(0),meanX_1,sigmaX_1);
-      if(integralX>minHitsPerInterval){
-        if(mHists["norResX"]->Fit(&funcX_2, fitOpt)){
-          edm::LogWarning("CalculateAPE")<<"Fit2 did not work for x : "<<mHists["norResX"]->Fit(&funcX_2, fitOpt);
+      TF1 funcX_2("mygausX2",
+                  "gaus",
+                  meanX_1 - sigmaFactorFit * TMath::Abs(sigmaX_1),
+                  meanX_1 + sigmaFactorFit * TMath::Abs(sigmaX_1));
+      funcX_2.SetParameters(funcX_1.GetParameter(0), meanX_1, sigmaX_1);
+      if (integralX > minHitsPerInterval) {
+        if (mHists["norResX"]->Fit(&funcX_2, fitOpt)) {
+          edm::LogWarning("CalculateAPE") << "Fit2 did not work for x : " << mHists["norResX"]->Fit(&funcX_2, fitOpt);
           continue;
         }
-        LogDebug("CalculateAPE")<<"FitResultX2\t"<<mHists["norResX"]->Fit(&funcX_2, fitOpt)<<"\n";
+        LogDebug("CalculateAPE") << "FitResultX2\t" << mHists["norResX"]->Fit(&funcX_2, fitOpt) << "\n";
       }
-      double meanX_2  = funcX_2.GetParameter(1);
+      double meanX_2 = funcX_2.GetParameter(1);
       double sigmaX_2 = funcX_2.GetParameter(2);
-  
+
       // Now the same for y coordinate
       double entriesY(0.);
       double meanSigmaY(0.);
-      if(i_sector.second.isPixel){
+      if (i_sector.second.isPixel) {
         entriesY = mHists["sigmaY"]->GetEntries();
         meanSigmaY = mHists["sigmaY"]->GetMean();
       }
-      
+
       double meanY_1(0.);
       double sigmaY_1(0.);
       double meanY_2(0.);
       double sigmaY_2(0.);
       double meanY(0.);
       double rmsY(0.);
-      if(i_sector.second.isPixel){
+      if (i_sector.second.isPixel) {
         // Fitting Parameters
         double yMin = mHists["norResY"]->GetXaxis()->GetXmin();
         double yMax = mHists["norResY"]->GetXaxis()->GetXmax();
@@ -554,375 +583,400 @@ ApeEstimatorSummary::calculateApe(){
         meanY = mHists["norResY"]->GetMean();
         rmsY = mHists["norResY"]->GetRMS();
         double maximumY = mHists["norResY"]->GetBinContent(mHists["norResY"]->GetMaximumBin());
-      
+
         // First Gaus Fit
         TF1 funcY_1("mygausY", "gaus", yMin, yMax);
         funcY_1.SetParameters(maximumY, meanY, rmsY);
-        if(integralY>minHitsPerInterval){
-          if(mHists["norResY"]->Fit(&funcY_1, fitOpt)){
-            edm::LogWarning("CalculateAPE")<<"Fit1 did not work: "<<mHists["norResY"]->Fit(&funcY_1, fitOpt);
+        if (integralY > minHitsPerInterval) {
+          if (mHists["norResY"]->Fit(&funcY_1, fitOpt)) {
+            edm::LogWarning("CalculateAPE") << "Fit1 did not work: " << mHists["norResY"]->Fit(&funcY_1, fitOpt);
             continue;
           }
-          LogDebug("CalculateAPE")<<"FitResultY1\t"<<mHists["norResY"]->Fit(&funcY_1, fitOpt)<<"\n";
+          LogDebug("CalculateAPE") << "FitResultY1\t" << mHists["norResY"]->Fit(&funcY_1, fitOpt) << "\n";
         }
-        meanY_1  = funcY_1.GetParameter(1);
+        meanY_1 = funcY_1.GetParameter(1);
         sigmaY_1 = funcY_1.GetParameter(2);
-      
+
         // Second gaus fit
-        TF1 funcY_2("mygausY2","gaus",meanY_1 - sigmaFactorFit*TMath::Abs(sigmaY_1), meanY_1 + sigmaFactorFit*TMath::Abs(sigmaY_1));
-        funcY_2.SetParameters(funcY_1.GetParameter(0),meanY_1,sigmaY_1);
-        if(integralY>minHitsPerInterval){
-          if(mHists["norResY"]->Fit(&funcY_2, fitOpt)){
-            edm::LogWarning("CalculateAPE")<<"Fit2 did not work for y : "<<mHists["norResY"]->Fit(&funcY_2, fitOpt);
+        TF1 funcY_2("mygausY2",
+                    "gaus",
+                    meanY_1 - sigmaFactorFit * TMath::Abs(sigmaY_1),
+                    meanY_1 + sigmaFactorFit * TMath::Abs(sigmaY_1));
+        funcY_2.SetParameters(funcY_1.GetParameter(0), meanY_1, sigmaY_1);
+        if (integralY > minHitsPerInterval) {
+          if (mHists["norResY"]->Fit(&funcY_2, fitOpt)) {
+            edm::LogWarning("CalculateAPE") << "Fit2 did not work for y : " << mHists["norResY"]->Fit(&funcY_2, fitOpt);
             continue;
           }
-          LogDebug("CalculateAPE")<<"FitResultY2\t"<<mHists["norResY"]->Fit(&funcY_2, fitOpt)<<"\n";
+          LogDebug("CalculateAPE") << "FitResultY2\t" << mHists["norResY"]->Fit(&funcY_2, fitOpt) << "\n";
         }
-        meanY_2  = funcY_2.GetParameter(1);
+        meanY_2 = funcY_2.GetParameter(1);
         sigmaY_2 = funcY_2.GetParameter(2);
       }
-      
+
       // Fill histograms
       double fitMeanX_1(meanX_1), fitMeanX_2(meanX_2);
       double residualWidthX_1(sigmaX_1), residualWidthX_2(sigmaX_2);
       double fitMeanY_1(meanY_1), fitMeanY_2(meanY_2);
       double residualWidthY_1(sigmaY_1), residualWidthY_2(sigmaY_2);
-      
+
       double correctionX2_1(-0.0010), correctionX2_2(-0.0010);
       double correctionY2_1(-0.0010), correctionY2_2(-0.0010);
-      correctionX2_1 = meanSigmaX*meanSigmaX*(residualWidthX_1*residualWidthX_1 -baselineWidthX2);
-      correctionX2_2 = meanSigmaX*meanSigmaX*(residualWidthX_2*residualWidthX_2 -baselineWidthX2);
-      if(i_sector.second.isPixel){
-        correctionY2_1 = meanSigmaY*meanSigmaY*(residualWidthY_1*residualWidthY_1 -baselineWidthY2);
-        correctionY2_2 = meanSigmaY*meanSigmaY*(residualWidthY_2*residualWidthY_2 -baselineWidthY2);
+      correctionX2_1 = meanSigmaX * meanSigmaX * (residualWidthX_1 * residualWidthX_1 - baselineWidthX2);
+      correctionX2_2 = meanSigmaX * meanSigmaX * (residualWidthX_2 * residualWidthX_2 - baselineWidthX2);
+      if (i_sector.second.isPixel) {
+        correctionY2_1 = meanSigmaY * meanSigmaY * (residualWidthY_1 * residualWidthY_1 - baselineWidthY2);
+        correctionY2_2 = meanSigmaY * meanSigmaY * (residualWidthY_2 * residualWidthY_2 - baselineWidthY2);
       }
-      
-      double correctionX_1 = correctionX2_1>=0. ? std::sqrt(correctionX2_1) : -std::sqrt(-correctionX2_1);
-      double correctionX_2 = correctionX2_2>=0. ? std::sqrt(correctionX2_2) : -std::sqrt(-correctionX2_2);
-      double correctionY_1 = correctionY2_1>=0. ? std::sqrt(correctionY2_1) : -std::sqrt(-correctionY2_1);
-      double correctionY_2 = correctionY2_2>=0. ? std::sqrt(correctionY2_2) : -std::sqrt(-correctionY2_2);
+
+      double correctionX_1 = correctionX2_1 >= 0. ? std::sqrt(correctionX2_1) : -std::sqrt(-correctionX2_1);
+      double correctionX_2 = correctionX2_2 >= 0. ? std::sqrt(correctionX2_2) : -std::sqrt(-correctionX2_2);
+      double correctionY_1 = correctionY2_1 >= 0. ? std::sqrt(correctionY2_1) : -std::sqrt(-correctionY2_1);
+      double correctionY_2 = correctionY2_2 >= 0. ? std::sqrt(correctionY2_2) : -std::sqrt(-correctionY2_2);
       // Meanwhile, this got very bad default values, or? (negative corrections allowed)
-      if(isnan(correctionX_1))correctionX_1 = -0.0010;
-      if(isnan(correctionX_2))correctionX_2 = -0.0010;
-      if(isnan(correctionY_1))correctionY_1 = -0.0010;
-      if(isnan(correctionY_2))correctionY_2 = -0.0010;
-      
-      if(entriesX<minHitsPerInterval){
-        meanX = 0.; rmsX = -0.0010;
-        fitMeanX_1 = 0.; correctionX_1 = residualWidthX_1 = -0.0010;
-        fitMeanX_2 = 0.; correctionX_2 = residualWidthX_2 = -0.0010;
+      if (isnan(correctionX_1))
+        correctionX_1 = -0.0010;
+      if (isnan(correctionX_2))
+        correctionX_2 = -0.0010;
+      if (isnan(correctionY_1))
+        correctionY_1 = -0.0010;
+      if (isnan(correctionY_2))
+        correctionY_2 = -0.0010;
+
+      if (entriesX < minHitsPerInterval) {
+        meanX = 0.;
+        rmsX = -0.0010;
+        fitMeanX_1 = 0.;
+        correctionX_1 = residualWidthX_1 = -0.0010;
+        fitMeanX_2 = 0.;
+        correctionX_2 = residualWidthX_2 = -0.0010;
       }
-      
-      if(entriesY<minHitsPerInterval){
-        meanY = 0.; rmsY = -0.0010;
-        fitMeanY_1 = 0.; correctionY_1 = residualWidthY_1 = -0.0010;
-        fitMeanY_2 = 0.; correctionY_2 = residualWidthY_2 = -0.0010;
+
+      if (entriesY < minHitsPerInterval) {
+        meanY = 0.;
+        rmsY = -0.0010;
+        fitMeanY_1 = 0.;
+        correctionY_1 = residualWidthY_1 = -0.0010;
+        fitMeanY_2 = 0.;
+        correctionY_2 = residualWidthY_2 = -0.0010;
       }
-      
-      i_sector.second.MeanX         ->SetBinContent(i_errBins.first,meanX);
-      i_sector.second.RmsX          ->SetBinContent(i_errBins.first,rmsX);
-      
-      i_sector.second.FitMeanX1      ->SetBinContent(i_errBins.first,fitMeanX_1);
-      i_sector.second.ResidualWidthX1->SetBinContent(i_errBins.first,residualWidthX_1);
-      i_sector.second.CorrectionX1   ->SetBinContent(i_errBins.first,correctionX_1*10000.);
-      
-      i_sector.second.FitMeanX2      ->SetBinContent(i_errBins.first,fitMeanX_2);
-      i_sector.second.ResidualWidthX2->SetBinContent(i_errBins.first,residualWidthX_2);
-      i_sector.second.CorrectionX2   ->SetBinContent(i_errBins.first,correctionX_2*10000.);
-      
-      if(i_sector.second.isPixel){
-        i_sector.second.MeanY         ->SetBinContent(i_errBins.first,meanY);
-        i_sector.second.RmsY          ->SetBinContent(i_errBins.first,rmsY);
-        
-        i_sector.second.FitMeanY1      ->SetBinContent(i_errBins.first,fitMeanY_1);
-        i_sector.second.ResidualWidthY1->SetBinContent(i_errBins.first,residualWidthY_1);
-        i_sector.second.CorrectionY1   ->SetBinContent(i_errBins.first,correctionY_1*10000.);
-        
-        i_sector.second.FitMeanY2      ->SetBinContent(i_errBins.first,fitMeanY_2);
-        i_sector.second.ResidualWidthY2->SetBinContent(i_errBins.first,residualWidthY_2);
-        i_sector.second.CorrectionY2   ->SetBinContent(i_errBins.first,correctionY_2*10000.);
+
+      i_sector.second.MeanX->SetBinContent(i_errBins.first, meanX);
+      i_sector.second.RmsX->SetBinContent(i_errBins.first, rmsX);
+
+      i_sector.second.FitMeanX1->SetBinContent(i_errBins.first, fitMeanX_1);
+      i_sector.second.ResidualWidthX1->SetBinContent(i_errBins.first, residualWidthX_1);
+      i_sector.second.CorrectionX1->SetBinContent(i_errBins.first, correctionX_1 * 10000.);
+
+      i_sector.second.FitMeanX2->SetBinContent(i_errBins.first, fitMeanX_2);
+      i_sector.second.ResidualWidthX2->SetBinContent(i_errBins.first, residualWidthX_2);
+      i_sector.second.CorrectionX2->SetBinContent(i_errBins.first, correctionX_2 * 10000.);
+
+      if (i_sector.second.isPixel) {
+        i_sector.second.MeanY->SetBinContent(i_errBins.first, meanY);
+        i_sector.second.RmsY->SetBinContent(i_errBins.first, rmsY);
+
+        i_sector.second.FitMeanY1->SetBinContent(i_errBins.first, fitMeanY_1);
+        i_sector.second.ResidualWidthY1->SetBinContent(i_errBins.first, residualWidthY_1);
+        i_sector.second.CorrectionY1->SetBinContent(i_errBins.first, correctionY_1 * 10000.);
+
+        i_sector.second.FitMeanY2->SetBinContent(i_errBins.first, fitMeanY_2);
+        i_sector.second.ResidualWidthY2->SetBinContent(i_errBins.first, residualWidthY_2);
+        i_sector.second.CorrectionY2->SetBinContent(i_errBins.first, correctionY_2 * 10000.);
       }
-      
-      
+
       // Use result for bin only when entries>=minHitsPerInterval
-      if(entriesX<minHitsPerInterval && entriesY<minHitsPerInterval)continue;
-      
+      if (entriesX < minHitsPerInterval && entriesY < minHitsPerInterval)
+        continue;
+
       double weightX(0.);
       double weightY(0.);
-      if(apeWeight==wUnity){
+      if (apeWeight == wUnity) {
         weightX = 1.;
         weightY = 1.;
-      }else if(apeWeight==wEntries){
+      } else if (apeWeight == wEntries) {
         weightX = entriesX;
         weightY = entriesY;
-      }else if(apeWeight==wEntriesOverSigmaX2){
-        weightX = entriesX/(meanSigmaX*meanSigmaX);
-        weightY = entriesY/(meanSigmaY*meanSigmaY);
+      } else if (apeWeight == wEntriesOverSigmaX2) {
+        weightX = entriesX / (meanSigmaX * meanSigmaX);
+        weightY = entriesY / (meanSigmaY * meanSigmaY);
       }
-      
-      const Error2AndResidualWidth2PerBin error2AndResidualWidth2PerBinX(meanSigmaX*meanSigmaX, residualWidthX_1*residualWidthX_1);
+
+      const Error2AndResidualWidth2PerBin error2AndResidualWidth2PerBinX(meanSigmaX * meanSigmaX,
+                                                                         residualWidthX_1 * residualWidthX_1);
       const WeightAndResultsPerBin weightAndResultsPerBinX(weightX, error2AndResidualWidth2PerBinX);
-      if(!(entriesX<minHitsPerInterval)){
+      if (!(entriesX < minHitsPerInterval)) {
         //Fill absolute weights
-        i_sector.second.WeightX->SetBinContent(i_errBins.first,weightX);
+        i_sector.second.WeightX->SetBinContent(i_errBins.first, weightX);
         v_weightAndResultsPerBinX.push_back(weightAndResultsPerBinX);
       }
-      
-      const Error2AndResidualWidth2PerBin error2AndResidualWidth2PerBinY(meanSigmaY*meanSigmaY, residualWidthY_1*residualWidthY_1);
+
+      const Error2AndResidualWidth2PerBin error2AndResidualWidth2PerBinY(meanSigmaY * meanSigmaY,
+                                                                         residualWidthY_1 * residualWidthY_1);
       const WeightAndResultsPerBin weightAndResultsPerBinY(weightY, error2AndResidualWidth2PerBinY);
-      if(!(entriesY<minHitsPerInterval)){
+      if (!(entriesY < minHitsPerInterval)) {
         //Fill absolute weights
-        i_sector.second.WeightY->SetBinContent(i_errBins.first,weightY);
+        i_sector.second.WeightY->SetBinContent(i_errBins.first, weightY);
         v_weightAndResultsPerBinY.push_back(weightAndResultsPerBinY);
       }
     }
-    
-    
+
     // Do the final calculations
-    
-    if(v_weightAndResultsPerBinX.empty()){
-      edm::LogError("CalculateAPE")<<"NO error interval of sector "<<i_sector.first<<" has a valid x APE calculated,\n...so cannot set APE";
+
+    if (v_weightAndResultsPerBinX.empty()) {
+      edm::LogError("CalculateAPE") << "NO error interval of sector " << i_sector.first
+                                    << " has a valid x APE calculated,\n...so cannot set APE";
       continue;
     }
-    
-    if(i_sector.second.isPixel && v_weightAndResultsPerBinY.empty()){
-      edm::LogError("CalculateAPE")<<"NO error interval of sector "<<i_sector.first<<" has a valid y APE calculated,\n...so cannot set APE";
+
+    if (i_sector.second.isPixel && v_weightAndResultsPerBinY.empty()) {
+      edm::LogError("CalculateAPE") << "NO error interval of sector " << i_sector.first
+                                    << " has a valid y APE calculated,\n...so cannot set APE";
       continue;
     }
-    
+
     double correctionX2(999.);
     double correctionY2(999.);
-    
+
     // Get sum of all weights
     double weightSumX(0.);
-    for(auto const & i_apeBin : v_weightAndResultsPerBinX){
+    for (auto const& i_apeBin : v_weightAndResultsPerBinX) {
       weightSumX += i_apeBin.first;
     }
-    i_sector.second.WeightX->Scale(1/weightSumX);
+    i_sector.second.WeightX->Scale(1 / weightSumX);
     double weightSumY(0.);
-    if(i_sector.second.isPixel){
-      for(auto const & i_apeBin : v_weightAndResultsPerBinY){
+    if (i_sector.second.isPixel) {
+      for (auto const& i_apeBin : v_weightAndResultsPerBinY) {
         weightSumY += i_apeBin.first;
       }
-      i_sector.second.WeightY->Scale(1/weightSumY);
+      i_sector.second.WeightY->Scale(1 / weightSumY);
     }
-    
-    if(!setBaseline){
+
+    if (!setBaseline) {
       // Calculate weighted mean
       bool firstIntervalX(true);
-      for(auto const & i_apeBin : v_weightAndResultsPerBinX){
-        if(firstIntervalX){
-          correctionX2 = i_apeBin.first*i_apeBin.second.first*(i_apeBin.second.second - baselineWidthX2);
+      for (auto const& i_apeBin : v_weightAndResultsPerBinX) {
+        if (firstIntervalX) {
+          correctionX2 = i_apeBin.first * i_apeBin.second.first * (i_apeBin.second.second - baselineWidthX2);
           firstIntervalX = false;
-        }else{
-          correctionX2 += i_apeBin.first*i_apeBin.second.first*(i_apeBin.second.second - baselineWidthX2);
+        } else {
+          correctionX2 += i_apeBin.first * i_apeBin.second.first * (i_apeBin.second.second - baselineWidthX2);
         }
       }
-      correctionX2 = correctionX2/weightSumX;
-    }else{
+      correctionX2 = correctionX2 / weightSumX;
+    } else {
       double numeratorX(0.), denominatorX(0.);
-      for(auto const & i_apeBin : v_weightAndResultsPerBinX){
-        numeratorX += i_apeBin.first*i_apeBin.second.first*i_apeBin.second.second;
-        denominatorX += i_apeBin.first*i_apeBin.second.first;
+      for (auto const& i_apeBin : v_weightAndResultsPerBinX) {
+        numeratorX += i_apeBin.first * i_apeBin.second.first * i_apeBin.second.second;
+        denominatorX += i_apeBin.first * i_apeBin.second.first;
       }
-      correctionX2 = numeratorX/denominatorX;
+      correctionX2 = numeratorX / denominatorX;
     }
-    
-    if(i_sector.second.isPixel){
-      if(!setBaseline){
+
+    if (i_sector.second.isPixel) {
+      if (!setBaseline) {
         // Calculate weighted mean
         bool firstIntervalY(true);
-        for(auto const & i_apeBin : v_weightAndResultsPerBinY){
-          if(firstIntervalY){
-            correctionY2 = i_apeBin.first*i_apeBin.second.first*(i_apeBin.second.second - baselineWidthY2);
+        for (auto const& i_apeBin : v_weightAndResultsPerBinY) {
+          if (firstIntervalY) {
+            correctionY2 = i_apeBin.first * i_apeBin.second.first * (i_apeBin.second.second - baselineWidthY2);
             firstIntervalY = false;
-          }else{
-            correctionY2 += i_apeBin.first*i_apeBin.second.first*(i_apeBin.second.second - baselineWidthY2);
+          } else {
+            correctionY2 += i_apeBin.first * i_apeBin.second.first * (i_apeBin.second.second - baselineWidthY2);
           }
         }
-        correctionY2 = correctionY2/weightSumY;
-      }else{
+        correctionY2 = correctionY2 / weightSumY;
+      } else {
         double numeratorY(0.), denominatorY(0.);
-        for(auto const & i_apeBin : v_weightAndResultsPerBinY){
-          numeratorY += i_apeBin.first*i_apeBin.second.first*i_apeBin.second.second;
-          denominatorY += i_apeBin.first*i_apeBin.second.first;
+        for (auto const& i_apeBin : v_weightAndResultsPerBinY) {
+          numeratorY += i_apeBin.first * i_apeBin.second.first * i_apeBin.second.second;
+          denominatorY += i_apeBin.first * i_apeBin.second.first;
         }
-        correctionY2 = numeratorY/denominatorY;
+        correctionY2 = numeratorY / denominatorY;
       }
     }
-    
-    if(!setBaseline){
+
+    if (!setBaseline) {
       // Calculate updated squared APE of current iteration
       double apeX2(999.);
       double apeY2(999.);
-      
+
       // old APE value from last iteration
-      if(firstIter){
+      if (firstIter) {
         apeX2 = 0.;
         apeY2 = 0.;
-      }
-      else{
+      } else {
         apeX2 = a_apeSectorX[i_sector.first];
         apeY2 = a_apeSectorY[i_sector.first];
       }
       const double apeX2old = apeX2;
       const double apeY2old = apeY2;
-      
+
       // scale APE Correction with value given in cfg (not if smoothed iteration is used)
-      edm::LogInfo("CalculateAPE")<<"Unscaled correction x for sector "<<i_sector.first<<" is "<<(correctionX2>0. ? +1. : -1.)*std::sqrt(std::fabs(correctionX2));
-      if(!smoothIteration || firstIter)correctionX2 = correctionX2*correctionScaling*correctionScaling;
-      if(i_sector.second.isPixel){
-        edm::LogInfo("CalculateAPE")<<"Unscaled correction y for sector "<<i_sector.first<<" is "<<(correctionY2>0. ? +1. : -1.)*std::sqrt(std::fabs(correctionY2));
-        if(!smoothIteration || firstIter)correctionY2 = correctionY2*correctionScaling*correctionScaling;
+      edm::LogInfo("CalculateAPE") << "Unscaled correction x for sector " << i_sector.first << " is "
+                                   << (correctionX2 > 0. ? +1. : -1.) * std::sqrt(std::fabs(correctionX2));
+      if (!smoothIteration || firstIter)
+        correctionX2 = correctionX2 * correctionScaling * correctionScaling;
+      if (i_sector.second.isPixel) {
+        edm::LogInfo("CalculateAPE") << "Unscaled correction y for sector " << i_sector.first << " is "
+                                     << (correctionY2 > 0. ? +1. : -1.) * std::sqrt(std::fabs(correctionY2));
+        if (!smoothIteration || firstIter)
+          correctionY2 = correctionY2 * correctionScaling * correctionScaling;
       }
-      
+
       // new APE value
       // smooth iteration or not?
-      if(apeX2 + correctionX2 < 0.) correctionX2 = -apeX2;
-      if(apeY2 + correctionY2 < 0.) correctionY2 = -apeY2;
+      if (apeX2 + correctionX2 < 0.)
+        correctionX2 = -apeX2;
+      if (apeY2 + correctionY2 < 0.)
+        correctionY2 = -apeY2;
       const double apeX2new(apeX2old + correctionX2);
       const double apeY2new(apeY2old + correctionY2);
-      if(!smoothIteration || firstIter){
+      if (!smoothIteration || firstIter) {
         apeX2 = apeX2new;
         apeY2 = apeY2new;
-      }else{
-        const double apeXtmp = smoothFraction*std::sqrt(apeX2new) + (1-smoothFraction)*std::sqrt(apeX2old);
-        const double apeYtmp = smoothFraction*std::sqrt(apeY2new) + (1-smoothFraction)*std::sqrt(apeY2old);
-        apeX2 = apeXtmp*apeXtmp;
-        apeY2 = apeYtmp*apeYtmp;
+      } else {
+        const double apeXtmp = smoothFraction * std::sqrt(apeX2new) + (1 - smoothFraction) * std::sqrt(apeX2old);
+        const double apeYtmp = smoothFraction * std::sqrt(apeY2new) + (1 - smoothFraction) * std::sqrt(apeY2old);
+        apeX2 = apeXtmp * apeXtmp;
+        apeY2 = apeYtmp * apeYtmp;
       }
-      if(apeX2<0. || apeY2<0.)edm::LogError("CalculateAPE")<<"\n\n\tBad APE, but why???\n\n\n";
+      if (apeX2 < 0. || apeY2 < 0.)
+        edm::LogError("CalculateAPE") << "\n\n\tBad APE, but why???\n\n\n";
       a_apeSectorX[i_sector.first] = apeX2;
       a_apeSectorY[i_sector.first] = apeY2;
-      
+
       // Set the calculated APE spherical for all modules of strip sectors
       const double apeX(std::sqrt(apeX2));
       const double apeY(std::sqrt(apeY2));
-      const double apeZ(std::sqrt(0.5*(apeX2+apeY2)));
-      for(auto const & i_rawId : i_sector.second.v_rawId){
-        if(i_sector.second.isPixel){
-          apeOutputFile<<i_rawId<<" "<<std::fixed<<std::setprecision(5)<<apeX<<" "<<apeY<<" "<<apeZ<<"\n";
-        }else{
-          apeOutputFile<<i_rawId<<" "<<std::fixed<<std::setprecision(5)<<apeX<<" "<<apeX<<" "<<apeX<<"\n";
+      const double apeZ(std::sqrt(0.5 * (apeX2 + apeY2)));
+      for (auto const& i_rawId : i_sector.second.v_rawId) {
+        if (i_sector.second.isPixel) {
+          apeOutputFile << i_rawId << " " << std::fixed << std::setprecision(5) << apeX << " " << apeY << " " << apeZ
+                        << "\n";
+        } else {
+          apeOutputFile << i_rawId << " " << std::fixed << std::setprecision(5) << apeX << " " << apeX << " " << apeX
+                        << "\n";
         }
       }
-    }else{ // In setBaseline mode, just fill estimated mean value of residual width
+    } else {  // In setBaseline mode, just fill estimated mean value of residual width
       a_apeSectorX[i_sector.first] = correctionX2;
       a_apeSectorY[i_sector.first] = correctionY2;
     }
   }
-  if(!setBaseline)apeOutputFile.close();
-   
+  if (!setBaseline)
+    apeOutputFile.close();
+
   iterationTreeX->Fill();
-  iterationTreeX->Write("iterTreeX", TObject::kOverwrite);  // TObject::kOverwrite needed to not produce another iterTreeX;2
+  iterationTreeX->Write("iterTreeX",
+                        TObject::kOverwrite);  // TObject::kOverwrite needed to not produce another iterTreeX;2
   iterationTreeY->Fill();
-  iterationTreeY->Write("iterTreeY", TObject::kOverwrite);  // TObject::kOverwrite needed to not produce another iterTreeY;2
-  if(firstIter){
+  iterationTreeY->Write("iterTreeY",
+                        TObject::kOverwrite);  // TObject::kOverwrite needed to not produce another iterTreeY;2
+  if (firstIter) {
     sectorNameTree->Fill();
     sectorNameTree->Write("nameTree");
   }
   iterationFile->Close();
   delete iterationFile;
-  
-  if(baselineFile){
+
+  if (baselineFile) {
     baselineFile->Close();
     delete baselineFile;
-  }  
+  }
 }
 
-
-
 // ------------ method called to for each event  ------------
-void
-ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Load APEs from the GT and write them to root files similar to the ones from calculateAPE()
-  
-  if(firstEvent){
+
+  if (firstEvent) {
     // Set baseline or calculate APE value?
     const bool setBaseline(parameterSet_.getParameter<bool>("setBaseline"));
-    
+
     edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
     iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
-    
+
     // Read in baseline file for calculation of APE value (if not setting baseline)
     // Has same format as iterationFile
     const std::string baselineFileName(parameterSet_.getParameter<std::string>("BaselineFile"));
     TFile* baselineFile(nullptr);
     TTree* sectorNameBaselineTree(nullptr);
-    if(!setBaseline){
+    if (!setBaseline) {
       std::ifstream baselineFileStream;
       // Check if baseline file exists
       baselineFileStream.open(baselineFileName.c_str());
-      if(baselineFileStream.is_open()){
+      if (baselineFileStream.is_open()) {
         baselineFileStream.close();
-        baselineFile = new TFile(baselineFileName.c_str(),"READ");
+        baselineFile = new TFile(baselineFileName.c_str(), "READ");
       }
-      if(baselineFile){
-        edm::LogInfo("CalculateAPE")<<"Baseline file for APE values sucessfully opened";
-        baselineFile->GetObject("nameTree;1",sectorNameBaselineTree);
-      }else{
-        edm::LogWarning("CalculateAPE")<<"There is NO baseline file for APE values, so normalized residual width =1 for ideal conditions is assumed";
+      if (baselineFile) {
+        edm::LogInfo("CalculateAPE") << "Baseline file for APE values sucessfully opened";
+        baselineFile->GetObject("nameTree;1", sectorNameBaselineTree);
+      } else {
+        edm::LogWarning("CalculateAPE") << "There is NO baseline file for APE values, so normalized residual width =1 "
+                                           "for ideal conditions is assumed";
       }
     }
-    
+
     // Set up root file for default APE values
     const std::string defaultFileName(parameterSet_.getParameter<std::string>("DefaultFile"));
-    TFile* defaultFile = new TFile(defaultFileName.c_str(),"RECREATE");
-    
+    TFile* defaultFile = new TFile(defaultFileName.c_str(), "RECREATE");
+
     // Naming in the root files has to be iterTreeX to be consistent for the plotting tool
     TTree* defaultTreeX(nullptr);
     TTree* defaultTreeY(nullptr);
-    defaultFile->GetObject("iterTreeX;1",defaultTreeX);
-    defaultFile->GetObject("iterTreeY;1",defaultTreeY);
+    defaultFile->GetObject("iterTreeX;1", defaultTreeX);
+    defaultFile->GetObject("iterTreeY;1", defaultTreeY);
     // The same for TTree containing the names of the sectors (no additional check, since always handled exactly as defaultTree)
     TTree* sectorNameTree(nullptr);
-    defaultFile->GetObject("nameTree;1",sectorNameTree);
-    
+    defaultFile->GetObject("nameTree;1", sectorNameTree);
+
     bool firstIter(false);
-    if(!defaultTreeX){ // should be always true in setBaseline mode, since file is recreated
+    if (!defaultTreeX) {  // should be always true in setBaseline mode, since file is recreated
       firstIter = true;
-      defaultTreeX = new TTree("iterTreeX","Tree for default APE x values from GT");
-      defaultTreeY = new TTree("iterTreeY","Tree for default APE y values from GT");
-      edm::LogInfo("CalculateAPE")<<"First APE iteration (number 0.), create default file with TTree";
-      sectorNameTree = new TTree("nameTree","Tree with names of sectors");
-    }else{
-      edm::LogWarning("CalculateAPE")<<"NOT the first APE iteration (number 0.), is this wanted or forgot to delete old iteration file with TTree?";
+      defaultTreeX = new TTree("iterTreeX", "Tree for default APE x values from GT");
+      defaultTreeY = new TTree("iterTreeY", "Tree for default APE y values from GT");
+      edm::LogInfo("CalculateAPE") << "First APE iteration (number 0.), create default file with TTree";
+      sectorNameTree = new TTree("nameTree", "Tree with names of sectors");
+    } else {
+      edm::LogWarning("CalculateAPE") << "NOT the first APE iteration (number 0.), is this wanted or forgot to delete "
+                                         "old iteration file with TTree?";
     }
-      
+
     // Assign the information stored in the trees to arrays
     double a_defaultSectorX[noSectors_];
     double a_defaultSectorY[noSectors_];
-    
+
     std::string* a_sectorName[noSectors_];
     std::string* a_sectorBaselineName[noSectors_];
-    for(auto const & i_sector : m_tkSector_){
+    for (auto const& i_sector : m_tkSector_) {
       const unsigned int iSector(i_sector.first);
       const bool pixelSector(i_sector.second.isPixel);
-      
+
       a_defaultSectorX[iSector] = -99.;
       a_defaultSectorY[iSector] = -99.;
-      
+
       a_sectorName[iSector] = nullptr;
       a_sectorBaselineName[iSector] = nullptr;
       std::stringstream ss_sector, ss_sectorSuffixed;
       ss_sector << "Ape_Sector_" << iSector;
-      if(!setBaseline && sectorNameBaselineTree){
+      if (!setBaseline && sectorNameBaselineTree) {
         sectorNameBaselineTree->SetBranchAddress(ss_sector.str().c_str(), &a_sectorBaselineName[iSector]);
         sectorNameBaselineTree->GetEntry(0);
       }
-    
-      if(firstIter){ // should be always true in setBaseline mode, since file is recreated  
+
+      if (firstIter) {  // should be always true in setBaseline mode, since file is recreated
         ss_sectorSuffixed << ss_sector.str() << "/D";
         defaultTreeX->Branch(ss_sector.str().c_str(), &a_defaultSectorX[iSector], ss_sectorSuffixed.str().c_str());
-        if(pixelSector){
+        if (pixelSector) {
           defaultTreeY->Branch(ss_sector.str().c_str(), &a_defaultSectorY[iSector], ss_sectorSuffixed.str().c_str());
         }
         sectorNameTree->Branch(ss_sector.str().c_str(), &a_sectorName[iSector], 32000, 00);
-      }else{
+      } else {
         defaultTreeX->SetBranchAddress(ss_sector.str().c_str(), &a_defaultSectorX[iSector]);
         defaultTreeX->GetEntry(0);
-        if(pixelSector){
+        if (pixelSector) {
           defaultTreeY->SetBranchAddress(ss_sector.str().c_str(), &a_defaultSectorY[iSector]);
           defaultTreeY->GetEntry(0);
         }
@@ -930,41 +984,46 @@ ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
         sectorNameTree->GetEntry(0);
       }
     }
-    
-    
+
     // Check whether sector definitions are identical with the ones of previous iterations and with the ones in baseline file
-    for(auto & i_sector : m_tkSector_){
+    for (auto& i_sector : m_tkSector_) {
       const std::string& name(i_sector.second.name);
-      if(!firstIter){
+      if (!firstIter) {
         const std::string& nameLastIter(*a_sectorName[i_sector.first]);
-        if(name!=nameLastIter){
-          edm::LogError("CalculateAPE")<<"Inconsistent sector definition in iterationFile for sector "<<i_sector.first<<",\n"
-                                        <<"Recent iteration has name \""<<name<<"\", while previous had \""<<nameLastIter<<"\"\n"
-                                    <<"...APE calculation stopped. Please check sector definitions in config!\n";
+        if (name != nameLastIter) {
+          edm::LogError("CalculateAPE") << "Inconsistent sector definition in iterationFile for sector "
+                                        << i_sector.first << ",\n"
+                                        << "Recent iteration has name \"" << name << "\", while previous had \""
+                                        << nameLastIter << "\"\n"
+                                        << "...APE calculation stopped. Please check sector definitions in config!\n";
           return;
         }
-      }
-      else a_sectorName[i_sector.first] = new std::string(name);
-      if(!setBaseline && baselineFile){
+      } else
+        a_sectorName[i_sector.first] = new std::string(name);
+      if (!setBaseline && baselineFile) {
         const std::string& nameBaseline(*a_sectorBaselineName[i_sector.first]);
-        if(name!=nameBaseline){
-          edm::LogError("CalculateAPE")<<"Inconsistent sector definition in baselineFile for sector "<<i_sector.first<<",\n"
-                                        <<"Recent iteration has name \""<<name<<"\", while baseline had \""<<nameBaseline<<"\"\n"
-                                    <<"...APE calculation stopped. Please check sector definitions in config!\n";
+        if (name != nameBaseline) {
+          edm::LogError("CalculateAPE") << "Inconsistent sector definition in baselineFile for sector "
+                                        << i_sector.first << ",\n"
+                                        << "Recent iteration has name \"" << name << "\", while baseline had \""
+                                        << nameBaseline << "\"\n"
+                                        << "...APE calculation stopped. Please check sector definitions in config!\n";
           return;
         }
       }
     }
-    
+
     // Loop over sectors for calculating getting default APE
-    for(auto & i_sector : m_tkSector_){
+    for (auto& i_sector : m_tkSector_) {
       double defaultApeX(0.);
       double defaultApeY(0.);
       unsigned int nModules(0);
-      for(auto const & i_rawId : i_sector.second.v_rawId){
+      for (auto const& i_rawId : i_sector.second.v_rawId) {
         std::vector<AlignTransformErrorExtended> alignErrors = alignmentErrors->m_alignError;
-        for(std::vector<AlignTransformErrorExtended>::const_iterator i_alignError = alignErrors.begin(); i_alignError != alignErrors.end(); ++i_alignError){
-          if(i_rawId ==  i_alignError->rawId()){
+        for (std::vector<AlignTransformErrorExtended>::const_iterator i_alignError = alignErrors.begin();
+             i_alignError != alignErrors.end();
+             ++i_alignError) {
+          if (i_rawId == i_alignError->rawId()) {
             CLHEP::HepSymMatrix errMatrix = i_alignError->matrix();
             defaultApeX += errMatrix[0][0];
             defaultApeY += errMatrix[1][1];
@@ -972,8 +1031,8 @@ ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
           }
         }
       }
-      a_defaultSectorX[i_sector.first] = defaultApeX/nModules;
-      a_defaultSectorY[i_sector.first] = defaultApeY/nModules;
+      a_defaultSectorX[i_sector.first] = defaultApeX / nModules;
+      a_defaultSectorY[i_sector.first] = defaultApeY / nModules;
     }
     sectorNameTree->Fill();
     sectorNameTree->Write("nameTree");
@@ -981,40 +1040,33 @@ ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     defaultTreeX->Write("iterTreeX");
     defaultTreeY->Fill();
     defaultTreeY->Write("iterTreeY");
-    
+
     defaultFile->Close();
     delete defaultFile;
-    
-    if(baselineFile){
+
+    if (baselineFile) {
       baselineFile->Close();
       delete baselineFile;
     }
-    
-    firstEvent = false;   
+
+    firstEvent = false;
   }
 }
 
-
 // ------------ method called once each job just before starting event loop  ------------
-void 
-ApeEstimatorSummary::beginJob()
-{
+void ApeEstimatorSummary::beginJob() {
   this->openInputFile();
-  
+
   this->getTrackerSectorStructs();
-  
+
   this->bookHists();
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-ApeEstimatorSummary::endJob() {
-  
+void ApeEstimatorSummary::endJob() {
   this->calculateApe();
-  
+
   this->writeHists();
-  
-  
 }
 
 //define this as a plug-in

--- a/Alignment/APEEstimation/plugins/ApeTreeCreateDefault.cc
+++ b/Alignment/APEEstimation/plugins/ApeTreeCreateDefault.cc
@@ -3,7 +3,7 @@
 //
 // Package:    DefaultApeTree
 // Class:      DefaultApeTree
-// 
+//
 /**\class ApeTreeCreateDefault ApeTreeCreateDefault.cc Alignment/APEEstimation/src/ApeTreeCreateDefault.cc
 
  Description: [one line class summary]
@@ -17,7 +17,6 @@
 //         Created:  Tue Nov 14 11:43 CET 2017
 //
 //
-
 
 // system include files
 #include <fstream>
@@ -53,7 +52,6 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 
-
 #include "TString.h"
 #include "TFile.h"
 #include "TDirectory.h"
@@ -64,33 +62,33 @@
 //
 
 class ApeTreeCreateDefault : public edm::one::EDAnalyzer<> {
-  public:
-    explicit ApeTreeCreateDefault(const edm::ParameterSet&);
-    ~ApeTreeCreateDefault() override;
-    
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  
-  private:
-    void beginJob() override ;
-    void analyze(const edm::Event&, const edm::EventSetup&) override;
-    void endJob() override ;
-    
-    void sectorBuilder();
-    bool checkIntervalsForSectors(const unsigned int sectorCounter, const std::vector<double>&)const;
-    bool checkModuleIds(const unsigned int, const std::vector<unsigned int>&)const;
-    bool checkModuleBools(const bool, const std::vector<unsigned int>&)const;
-    bool checkModuleDirections(const int, const std::vector<int>&)const;
-    bool checkModulePositions(const float, const std::vector<double>&)const;
-    
-    // ----------member data ---------------------------
-    const std::string resultFile_;
-    const std::string trackerTreeFile_;
-    const std::vector<edm::ParameterSet> sectors_;
-    
-    std::map<unsigned int, TrackerSectorStruct> m_tkSector_;
-    std::map<unsigned int, ReducedTrackerTreeVariables> m_tkTreeVar_;
-    unsigned int noSectors;
-};              
+public:
+  explicit ApeTreeCreateDefault(const edm::ParameterSet&);
+  ~ApeTreeCreateDefault() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  void sectorBuilder();
+  bool checkIntervalsForSectors(const unsigned int sectorCounter, const std::vector<double>&) const;
+  bool checkModuleIds(const unsigned int, const std::vector<unsigned int>&) const;
+  bool checkModuleBools(const bool, const std::vector<unsigned int>&) const;
+  bool checkModuleDirections(const int, const std::vector<int>&) const;
+  bool checkModulePositions(const float, const std::vector<double>&) const;
+
+  // ----------member data ---------------------------
+  const std::string resultFile_;
+  const std::string trackerTreeFile_;
+  const std::vector<edm::ParameterSet> sectors_;
+
+  std::map<unsigned int, TrackerSectorStruct> m_tkSector_;
+  std::map<unsigned int, ReducedTrackerTreeVariables> m_tkTreeVar_;
+  unsigned int noSectors;
+};
 
 //
 // constants, enums and typedefs
@@ -103,48 +101,40 @@ class ApeTreeCreateDefault : public edm::one::EDAnalyzer<> {
 //
 // constructors and destructor
 //
-ApeTreeCreateDefault::ApeTreeCreateDefault(const edm::ParameterSet& iConfig):
-  resultFile_(iConfig.getParameter<std::string>("resultFile")),
-  trackerTreeFile_(iConfig.getParameter<std::string>("trackerTreeFile")),
-  sectors_(iConfig.getParameter<std::vector<edm::ParameterSet> >("sectors"))
-{
-}
+ApeTreeCreateDefault::ApeTreeCreateDefault(const edm::ParameterSet& iConfig)
+    : resultFile_(iConfig.getParameter<std::string>("resultFile")),
+      trackerTreeFile_(iConfig.getParameter<std::string>("trackerTreeFile")),
+      sectors_(iConfig.getParameter<std::vector<edm::ParameterSet>>("sectors")) {}
 
-
-ApeTreeCreateDefault::~ApeTreeCreateDefault()
-{
-}
-
+ApeTreeCreateDefault::~ApeTreeCreateDefault() {}
 
 //
 // member functions
 //
-void
-ApeTreeCreateDefault::sectorBuilder()
-{
+void ApeTreeCreateDefault::sectorBuilder() {
   // Same procedure as in ApeEstimator.cc
   TFile* tkTreeFile(TFile::Open(trackerTreeFile_.c_str()));
-  if(tkTreeFile){
-    edm::LogInfo("SectorBuilder")<<"TrackerTreeFile OK";
-  }else{
-    edm::LogError("SectorBuilder")<<"TrackerTreeFile not found";
+  if (tkTreeFile) {
+    edm::LogInfo("SectorBuilder") << "TrackerTreeFile OK";
+  } else {
+    edm::LogError("SectorBuilder") << "TrackerTreeFile not found";
     return;
   }
   TTree* tkTree(nullptr);
-  tkTreeFile->GetObject("TrackerTreeGenerator/TrackerTree/TrackerTree",tkTree);
-  if(tkTree){
-    edm::LogInfo("SectorBuilder")<<"TrackerTree OK";
-  }else{
-    edm::LogError("SectorBuilder")<<"TrackerTree not found in file";
+  tkTreeFile->GetObject("TrackerTreeGenerator/TrackerTree/TrackerTree", tkTree);
+  if (tkTree) {
+    edm::LogInfo("SectorBuilder") << "TrackerTree OK";
+  } else {
+    edm::LogError("SectorBuilder") << "TrackerTree not found in file";
     return;
   }
-  
-  unsigned int rawId(999), subdetId(999), layer(999), side(999), half(999), rod(999), ring(999), petal(999),
-         blade(999), panel(999), outerInner(999), module(999), nStrips(999);
+
+  unsigned int rawId(999), subdetId(999), layer(999), side(999), half(999), rod(999), ring(999), petal(999), blade(999),
+      panel(999), outerInner(999), module(999), nStrips(999);
   bool isDoubleSide(false), isRPhi(false), isStereo(false);
   int uDirection(999), vDirection(999), wDirection(999);
-  float posR(999.F), posPhi(999.F), posEta(999.F), posX(999.F), posY(999.F), posZ(999.F); 
-  
+  float posR(999.F), posPhi(999.F), posEta(999.F), posX(999.F), posY(999.F), posZ(999.F);
+
   tkTree->SetBranchAddress("RawId", &rawId);
   tkTree->SetBranchAddress("SubdetId", &subdetId);
   tkTree->SetBranchAddress("Layer", &layer);
@@ -170,60 +160,63 @@ ApeTreeCreateDefault::sectorBuilder()
   tkTree->SetBranchAddress("PosX", &posX);
   tkTree->SetBranchAddress("PosY", &posY);
   tkTree->SetBranchAddress("PosZ", &posZ);
-  
+
   int nModules(tkTree->GetEntries());
   TrackerSectorStruct allSectors;
-  
+
   //Loop over all Sectors
   unsigned int sectorCounter(0);
   std::vector<edm::ParameterSet> v_sectorDef(sectors_);
-  edm::LogInfo("SectorBuilder")<<"There are "<<v_sectorDef.size()<<" Sectors defined";
+  edm::LogInfo("SectorBuilder") << "There are " << v_sectorDef.size() << " Sectors defined";
 
-  for(auto const & parSet : v_sectorDef){
+  for (auto const& parSet : v_sectorDef) {
     ++sectorCounter;
     const std::string& sectorName(parSet.getParameter<std::string>("name"));
-    std::vector<unsigned int> v_rawId(parSet.getParameter<std::vector<unsigned int> >("rawId")),
-                              v_subdetId(parSet.getParameter<std::vector<unsigned int> >("subdetId")),
-                              v_layer(parSet.getParameter<std::vector<unsigned int> >("layer")),
-                              v_side(parSet.getParameter<std::vector<unsigned int> >("side")),
-                              v_half(parSet.getParameter<std::vector<unsigned int> >("half")),
-                              v_rod(parSet.getParameter<std::vector<unsigned int> >("rod")),
-                              v_ring(parSet.getParameter<std::vector<unsigned int> >("ring")),
-                              v_petal(parSet.getParameter<std::vector<unsigned int> >("petal")),
-                              v_blade(parSet.getParameter<std::vector<unsigned int> >("blade")),
-                              v_panel(parSet.getParameter<std::vector<unsigned int> >("panel")),
-                              v_outerInner(parSet.getParameter<std::vector<unsigned int> >("outerInner")),
-                              v_module(parSet.getParameter<std::vector<unsigned int> >("module")),
-                              v_nStrips(parSet.getParameter<std::vector<unsigned int> >("nStrips")),
-                              v_isDoubleSide(parSet.getParameter<std::vector<unsigned int> >("isDoubleSide")),
-                              v_isRPhi(parSet.getParameter<std::vector<unsigned int> >("isRPhi")),
-                              v_isStereo(parSet.getParameter<std::vector<unsigned int> >("isStereo"));
-    std::vector<int>  v_uDirection(parSet.getParameter<std::vector<int> >("uDirection")),
-                      v_vDirection(parSet.getParameter<std::vector<int> >("vDirection")),
-                      v_wDirection(parSet.getParameter<std::vector<int> >("wDirection"));
-    std::vector<double> v_posR(parSet.getParameter<std::vector<double> >("posR")),
-                        v_posPhi(parSet.getParameter<std::vector<double> >("posPhi")),
-                        v_posEta(parSet.getParameter<std::vector<double> >("posEta")),
-                        v_posX(parSet.getParameter<std::vector<double> >("posX")),
-                        v_posY(parSet.getParameter<std::vector<double> >("posY")),
-                        v_posZ(parSet.getParameter<std::vector<double> >("posZ"));
-    
-    if(!this->checkIntervalsForSectors(sectorCounter,v_posR) || !this->checkIntervalsForSectors(sectorCounter,v_posPhi) ||
-       !this->checkIntervalsForSectors(sectorCounter,v_posEta) || !this->checkIntervalsForSectors(sectorCounter,v_posX) ||
-       !this->checkIntervalsForSectors(sectorCounter,v_posY)   || !this->checkIntervalsForSectors(sectorCounter,v_posZ)){
+    std::vector<unsigned int> v_rawId(parSet.getParameter<std::vector<unsigned int>>("rawId")),
+        v_subdetId(parSet.getParameter<std::vector<unsigned int>>("subdetId")),
+        v_layer(parSet.getParameter<std::vector<unsigned int>>("layer")),
+        v_side(parSet.getParameter<std::vector<unsigned int>>("side")),
+        v_half(parSet.getParameter<std::vector<unsigned int>>("half")),
+        v_rod(parSet.getParameter<std::vector<unsigned int>>("rod")),
+        v_ring(parSet.getParameter<std::vector<unsigned int>>("ring")),
+        v_petal(parSet.getParameter<std::vector<unsigned int>>("petal")),
+        v_blade(parSet.getParameter<std::vector<unsigned int>>("blade")),
+        v_panel(parSet.getParameter<std::vector<unsigned int>>("panel")),
+        v_outerInner(parSet.getParameter<std::vector<unsigned int>>("outerInner")),
+        v_module(parSet.getParameter<std::vector<unsigned int>>("module")),
+        v_nStrips(parSet.getParameter<std::vector<unsigned int>>("nStrips")),
+        v_isDoubleSide(parSet.getParameter<std::vector<unsigned int>>("isDoubleSide")),
+        v_isRPhi(parSet.getParameter<std::vector<unsigned int>>("isRPhi")),
+        v_isStereo(parSet.getParameter<std::vector<unsigned int>>("isStereo"));
+    std::vector<int> v_uDirection(parSet.getParameter<std::vector<int>>("uDirection")),
+        v_vDirection(parSet.getParameter<std::vector<int>>("vDirection")),
+        v_wDirection(parSet.getParameter<std::vector<int>>("wDirection"));
+    std::vector<double> v_posR(parSet.getParameter<std::vector<double>>("posR")),
+        v_posPhi(parSet.getParameter<std::vector<double>>("posPhi")),
+        v_posEta(parSet.getParameter<std::vector<double>>("posEta")),
+        v_posX(parSet.getParameter<std::vector<double>>("posX")),
+        v_posY(parSet.getParameter<std::vector<double>>("posY")),
+        v_posZ(parSet.getParameter<std::vector<double>>("posZ"));
+
+    if (!this->checkIntervalsForSectors(sectorCounter, v_posR) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posPhi) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posEta) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posX) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posY) ||
+        !this->checkIntervalsForSectors(sectorCounter, v_posZ)) {
       continue;
     }
-    
+
     TrackerSectorStruct tkSector;
     tkSector.name = sectorName;
-    
+
     ReducedTrackerTreeVariables tkTreeVar;
-    
+
     //Loop over all Modules
-    for(int module = 0; module < nModules; ++module){
+    for (int module = 0; module < nModules; ++module) {
       tkTree->GetEntry(module);
-      
-      if(sectorCounter==1){
+
+      if (sectorCounter == 1) {
         tkTreeVar.subdetId = subdetId;
         tkTreeVar.nStrips = nStrips;
         tkTreeVar.uDirection = uDirection;
@@ -232,44 +225,71 @@ ApeTreeCreateDefault::sectorBuilder()
         m_tkTreeVar_[rawId] = tkTreeVar;
       }
       //Check if modules from Sector builder equal those from TrackerTree
-      if(!this->checkModuleIds(rawId,v_rawId))continue;
-      if(!this->checkModuleIds(subdetId,v_subdetId))continue;
-      if(!this->checkModuleIds(layer,v_layer))continue;
-      if(!this->checkModuleIds(side,v_side))continue;
-      if(!this->checkModuleIds(half,v_half))continue;
-      if(!this->checkModuleIds(rod,v_rod))continue;
-      if(!this->checkModuleIds(ring,v_ring))continue;
-      if(!this->checkModuleIds(petal,v_petal))continue;
-      if(!this->checkModuleIds(blade,v_blade))continue;
-      if(!this->checkModuleIds(panel,v_panel))continue;
-      if(!this->checkModuleIds(outerInner,v_outerInner))continue;
-      if(!this->checkModuleIds(module,v_module))continue;
-      if(!this->checkModuleIds(nStrips,v_nStrips))continue;
-      if(!this->checkModuleBools(isDoubleSide,v_isDoubleSide))continue;
-      if(!this->checkModuleBools(isRPhi,v_isRPhi))continue;
-      if(!this->checkModuleBools(isStereo,v_isStereo))continue;
-      if(!this->checkModuleDirections(uDirection,v_uDirection))continue;
-      if(!this->checkModuleDirections(vDirection,v_vDirection))continue;
-      if(!this->checkModuleDirections(wDirection,v_wDirection))continue;
-      if(!this->checkModulePositions(posR,v_posR))continue;
-      if(!this->checkModulePositions(posPhi,v_posPhi))continue;
-      if(!this->checkModulePositions(posEta,v_posEta))continue;
-      if(!this->checkModulePositions(posX,v_posX))continue;
-      if(!this->checkModulePositions(posY,v_posY))continue;
-      if(!this->checkModulePositions(posZ,v_posZ))continue;
-      
+      if (!this->checkModuleIds(rawId, v_rawId))
+        continue;
+      if (!this->checkModuleIds(subdetId, v_subdetId))
+        continue;
+      if (!this->checkModuleIds(layer, v_layer))
+        continue;
+      if (!this->checkModuleIds(side, v_side))
+        continue;
+      if (!this->checkModuleIds(half, v_half))
+        continue;
+      if (!this->checkModuleIds(rod, v_rod))
+        continue;
+      if (!this->checkModuleIds(ring, v_ring))
+        continue;
+      if (!this->checkModuleIds(petal, v_petal))
+        continue;
+      if (!this->checkModuleIds(blade, v_blade))
+        continue;
+      if (!this->checkModuleIds(panel, v_panel))
+        continue;
+      if (!this->checkModuleIds(outerInner, v_outerInner))
+        continue;
+      if (!this->checkModuleIds(module, v_module))
+        continue;
+      if (!this->checkModuleIds(nStrips, v_nStrips))
+        continue;
+      if (!this->checkModuleBools(isDoubleSide, v_isDoubleSide))
+        continue;
+      if (!this->checkModuleBools(isRPhi, v_isRPhi))
+        continue;
+      if (!this->checkModuleBools(isStereo, v_isStereo))
+        continue;
+      if (!this->checkModuleDirections(uDirection, v_uDirection))
+        continue;
+      if (!this->checkModuleDirections(vDirection, v_vDirection))
+        continue;
+      if (!this->checkModuleDirections(wDirection, v_wDirection))
+        continue;
+      if (!this->checkModulePositions(posR, v_posR))
+        continue;
+      if (!this->checkModulePositions(posPhi, v_posPhi))
+        continue;
+      if (!this->checkModulePositions(posEta, v_posEta))
+        continue;
+      if (!this->checkModulePositions(posX, v_posX))
+        continue;
+      if (!this->checkModulePositions(posY, v_posY))
+        continue;
+      if (!this->checkModulePositions(posZ, v_posZ))
+        continue;
+
       tkSector.v_rawId.push_back(rawId);
       bool moduleSelected(false);
-      for(auto const & i_rawId : allSectors.v_rawId){
-        if(rawId == i_rawId)moduleSelected = true;
+      for (auto const& i_rawId : allSectors.v_rawId) {
+        if (rawId == i_rawId)
+          moduleSelected = true;
       }
-      if(!moduleSelected)allSectors.v_rawId.push_back(rawId);
+      if (!moduleSelected)
+        allSectors.v_rawId.push_back(rawId);
     }
-    
+
     // Stops you from combining pixel and strip detector into one sector
     bool isPixel(false);
     bool isStrip(false);
-    for(auto const & i_rawId : tkSector.v_rawId){
+    for (auto const& i_rawId : tkSector.v_rawId) {
       switch (m_tkTreeVar_[i_rawId].subdetId) {
         case PixelSubdetector::PixelBarrel:
         case PixelSubdetector::PixelEndcap:
@@ -284,213 +304,195 @@ ApeTreeCreateDefault::sectorBuilder()
       }
     }
 
-    if(isPixel && isStrip){
-      edm::LogError("SectorBuilder")<<"Incorrect Sector Definition: there are pixel and strip modules within one sector"
-                                     <<"\n... sector selection is not applied, sector "<<sectorCounter<<" is not built";
+    if (isPixel && isStrip) {
+      edm::LogError("SectorBuilder")
+          << "Incorrect Sector Definition: there are pixel and strip modules within one sector"
+          << "\n... sector selection is not applied, sector " << sectorCounter << " is not built";
       continue;
     }
     tkSector.isPixel = isPixel;
-    
+
     m_tkSector_[sectorCounter] = tkSector;
-    edm::LogInfo("SectorBuilder")<<"There are "<<tkSector.v_rawId.size()<<" Modules in Sector "<<sectorCounter;
+    edm::LogInfo("SectorBuilder") << "There are " << tkSector.v_rawId.size() << " Modules in Sector " << sectorCounter;
   }
   noSectors = sectorCounter;
   return;
 }
 
-
 // Checking methods copied from ApeEstimator.cc
-bool
-ApeTreeCreateDefault::checkIntervalsForSectors(const unsigned int sectorCounter, const std::vector<double>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  if(v_id.size()%2==1){
-    edm::LogError("SectorBuilder")<<"Incorrect Sector Definition: Position Vectors need even number of arguments (Intervals)"
-                                     <<"\n... sector selection is not applied, sector "<<sectorCounter<<" is not built";
+bool ApeTreeCreateDefault::checkIntervalsForSectors(const unsigned int sectorCounter,
+                                                    const std::vector<double>& v_id) const {
+  if (v_id.empty())
+    return true;
+  if (v_id.size() % 2 == 1) {
+    edm::LogError("SectorBuilder")
+        << "Incorrect Sector Definition: Position Vectors need even number of arguments (Intervals)"
+        << "\n... sector selection is not applied, sector " << sectorCounter << " is not built";
     return false;
   }
-  int entry(0); double intervalBegin(999.);
-  for(auto const & i_id : v_id){
+  int entry(0);
+  double intervalBegin(999.);
+  for (auto const& i_id : v_id) {
     ++entry;
-    if(entry%2==1) intervalBegin = i_id;
-    if(entry%2==0 && intervalBegin > i_id){
-      edm::LogError("SectorBuilder")<<"Incorrect Sector Definition (Position Vector Intervals): \t"
-                                    <<intervalBegin<<" is bigger than "<<i_id<<" but is expected to be smaller"
-                                    <<"\n... sector selection is not applied, sector "<<sectorCounter<<" is not built";
+    if (entry % 2 == 1)
+      intervalBegin = i_id;
+    if (entry % 2 == 0 && intervalBegin > i_id) {
+      edm::LogError("SectorBuilder") << "Incorrect Sector Definition (Position Vector Intervals): \t" << intervalBegin
+                                     << " is bigger than " << i_id << " but is expected to be smaller"
+                                     << "\n... sector selection is not applied, sector " << sectorCounter
+                                     << " is not built";
       return false;
     }
   }
   return true;
 }
 
-bool
-ApeTreeCreateDefault::checkModuleIds(const unsigned int id, const std::vector<unsigned int>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  for(auto const & i_id : v_id){
-    if(id==i_id)return true;
+bool ApeTreeCreateDefault::checkModuleIds(const unsigned int id, const std::vector<unsigned int>& v_id) const {
+  if (v_id.empty())
+    return true;
+  for (auto const& i_id : v_id) {
+    if (id == i_id)
+      return true;
   }
   return false;
 }
 
-bool
-ApeTreeCreateDefault::checkModuleBools(const bool id, const std::vector<unsigned int>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  for(auto const & i_id : v_id){
-    if(1==i_id && id)return true;
-    if(2==i_id && !id)return true;
+bool ApeTreeCreateDefault::checkModuleBools(const bool id, const std::vector<unsigned int>& v_id) const {
+  if (v_id.empty())
+    return true;
+  for (auto const& i_id : v_id) {
+    if (1 == i_id && id)
+      return true;
+    if (2 == i_id && !id)
+      return true;
   }
   return false;
 }
 
-bool
-ApeTreeCreateDefault::checkModuleDirections(const int id, const std::vector<int>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  for(auto const & i_id : v_id){
-    if(id==i_id)return true;
+bool ApeTreeCreateDefault::checkModuleDirections(const int id, const std::vector<int>& v_id) const {
+  if (v_id.empty())
+    return true;
+  for (auto const& i_id : v_id) {
+    if (id == i_id)
+      return true;
   }
   return false;
 }
 
-bool
-ApeTreeCreateDefault::checkModulePositions(const float id, const std::vector<double>& v_id)const
-{
-    
-  if(v_id.empty())return true;
-  int entry(0); double intervalBegin(999.);
-  for(auto const & i_id : v_id){
+bool ApeTreeCreateDefault::checkModulePositions(const float id, const std::vector<double>& v_id) const {
+  if (v_id.empty())
+    return true;
+  int entry(0);
+  double intervalBegin(999.);
+  for (auto const& i_id : v_id) {
     ++entry;
-    if(entry%2==1)intervalBegin = i_id;
-    if(entry%2==0 && id>=intervalBegin && id<i_id)return true;
+    if (entry % 2 == 1)
+      intervalBegin = i_id;
+    if (entry % 2 == 0 && id >= intervalBegin && id < i_id)
+      return true;
   }
   return false;
 }
-
-
 
 // ------------ method called to for each event  ------------
-void
-ApeTreeCreateDefault::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void ApeTreeCreateDefault::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Same procedure as in ApeEstimatorSummary.cc minus reading of baseline tree
-  
+
   // Load APEs from the GT and write them to root files similar to the ones from calculateAPE()
   edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);  
-  
+  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
+
   // Set up root file for default APE values
   const std::string defaultFileName(resultFile_);
-  TFile* defaultFile = new TFile(defaultFileName.c_str(),"RECREATE");
-  
+  TFile* defaultFile = new TFile(defaultFileName.c_str(), "RECREATE");
+
   // Naming in the root files has to be iterTreeX to be consistent for the plotting tool
   TTree* defaultTreeX(nullptr);
   TTree* defaultTreeY(nullptr);
-  defaultFile->GetObject("iterTreeX;1",defaultTreeX);
-  defaultFile->GetObject("iterTreeY;1",defaultTreeY);
+  defaultFile->GetObject("iterTreeX;1", defaultTreeX);
+  defaultFile->GetObject("iterTreeY;1", defaultTreeY);
   // The same for TTree containing the names of the sectors (no additional check, since always handled exactly as defaultTree)
   TTree* sectorNameTree(nullptr);
-  defaultFile->GetObject("nameTree;1",sectorNameTree);
-  
-  edm::LogInfo("DefaultAPETree")<<"APE Tree is being created";
-  defaultTreeX = new TTree("iterTreeX","Tree for default APE x values from GT");
-  defaultTreeY = new TTree("iterTreeY","Tree for default APE y values from GT");     
-  sectorNameTree = new TTree("nameTree","Tree with names of sectors");
-  
-    
+  defaultFile->GetObject("nameTree;1", sectorNameTree);
+
+  edm::LogInfo("DefaultAPETree") << "APE Tree is being created";
+  defaultTreeX = new TTree("iterTreeX", "Tree for default APE x values from GT");
+  defaultTreeY = new TTree("iterTreeY", "Tree for default APE y values from GT");
+  sectorNameTree = new TTree("nameTree", "Tree with names of sectors");
+
   // Assign the information stored in the trees to arrays
   std::vector<double*> a_defaultSectorX;
   std::vector<double*> a_defaultSectorY;
-  
+
   std::vector<std::string*> a_sectorName;
-  for(auto const & i_sector : m_tkSector_){
+  for (auto const& i_sector : m_tkSector_) {
     const unsigned int iSector(i_sector.first);
     const bool pixelSector(i_sector.second.isPixel);
-    
+
     a_defaultSectorX.push_back(new double(-99.));
     a_defaultSectorY.push_back(new double(-99.));
     a_sectorName.push_back(new std::string(i_sector.second.name));
-    
+
     std::stringstream ss_sector;
     std::stringstream ss_sectorSuffixed;
     ss_sector << "Ape_Sector_" << iSector;
-  
+
     ss_sectorSuffixed << ss_sector.str() << "/D";
-    defaultTreeX->Branch(ss_sector.str().c_str(), &(*a_defaultSectorX[iSector-1]), ss_sectorSuffixed.str().c_str());
-    
-    if(pixelSector){
-      defaultTreeY->Branch(ss_sector.str().c_str(), &(*a_defaultSectorY[iSector-1]), ss_sectorSuffixed.str().c_str());
+    defaultTreeX->Branch(ss_sector.str().c_str(), &(*a_defaultSectorX[iSector - 1]), ss_sectorSuffixed.str().c_str());
+
+    if (pixelSector) {
+      defaultTreeY->Branch(ss_sector.str().c_str(), &(*a_defaultSectorY[iSector - 1]), ss_sectorSuffixed.str().c_str());
     }
-    sectorNameTree->Branch(ss_sector.str().c_str(), &(*a_sectorName[iSector-1]), 32000, 00);  
+    sectorNameTree->Branch(ss_sector.str().c_str(), &(*a_sectorName[iSector - 1]), 32000, 00);
   }
 
-  
   // Loop over sectors for getting default APE
-  
-  for(auto & i_sector : m_tkSector_){
-    
+
+  for (auto& i_sector : m_tkSector_) {
     double defaultApeX(0.);
     double defaultApeY(0.);
     unsigned int nModules(0);
-    for(auto const & i_rawId : i_sector.second.v_rawId){
+    for (auto const& i_rawId : i_sector.second.v_rawId) {
       std::vector<AlignTransformErrorExtended> alignErrors = alignmentErrors->m_alignError;
-      for(auto const & i_alignError : alignErrors){
-        if(i_rawId ==  i_alignError.rawId()){
+      for (auto const& i_alignError : alignErrors) {
+        if (i_rawId == i_alignError.rawId()) {
           CLHEP::HepSymMatrix errMatrix = i_alignError.matrix();
           defaultApeX += errMatrix[0][0];
           defaultApeY += errMatrix[1][1];
           nModules++;
         }
       }
+    }
+    *a_defaultSectorX[i_sector.first - 1] = defaultApeX / nModules;
+    *a_defaultSectorY[i_sector.first - 1] = defaultApeY / nModules;
   }
-  *a_defaultSectorX[i_sector.first-1] = defaultApeX/nModules;
-  *a_defaultSectorY[i_sector.first-1] = defaultApeY/nModules;
-  }
-  
-  
+
   sectorNameTree->Fill();
   sectorNameTree->Write("nameTree");
   defaultTreeX->Fill();
   defaultTreeX->Write("iterTreeX");
   defaultTreeY->Fill();
   defaultTreeY->Write("iterTreeY");
-  
-  defaultFile->Close(); 
+
+  defaultFile->Close();
   delete defaultFile;
-  for(unsigned int i = 0; i < a_defaultSectorX.size(); i++){
+  for (unsigned int i = 0; i < a_defaultSectorX.size(); i++) {
     delete a_defaultSectorX[i];
     delete a_defaultSectorY[i];
     delete a_sectorName[i];
   }
 }
-  
-
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-ApeTreeCreateDefault::beginJob()
-{  
-  this->sectorBuilder();
-}
+void ApeTreeCreateDefault::beginJob() { this->sectorBuilder(); }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-ApeTreeCreateDefault::endJob() 
-{   
-}
+void ApeTreeCreateDefault::endJob() {}
 
-void
-ApeTreeCreateDefault::fillDescriptions(edm::ConfigurationDescriptions & descriptions)
-{
+void ApeTreeCreateDefault::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   edm::ParameterSetDescription sector;
-  
+
   std::vector<unsigned> emptyUnsignedIntVector;
   std::vector<int> emptyIntVector;
   std::vector<double> emptyDoubleVector;
@@ -524,7 +526,7 @@ ApeTreeCreateDefault::fillDescriptions(edm::ConfigurationDescriptions & descript
   desc.add<std::string>("resultFile", "defaultAPE.root");
   desc.add<std::string>("trackerTreeFile");
   desc.addVPSet("sectors", sector);
- 
+
   descriptions.add("apeTreeCreateDefault", desc);
 }
 

--- a/Alignment/CocoaApplication/bin/cocoa.cpp
+++ b/Alignment/CocoaApplication/bin/cocoa.cpp
@@ -1,23 +1,23 @@
 
-#include "Alignment/CocoaUtilities/interface/ALIUtils.h"
-#include <assert.h>
-#include "Alignment/CocoaModel/interface/Model.h"
 #include "Alignment/CocoaFit/interface/Fit.h"
+#include "Alignment/CocoaModel/interface/Model.h"
 #include "Alignment/CocoaUtilities/interface/ALIFileOut.h"
+#include "Alignment/CocoaUtilities/interface/ALIUtils.h"
+#include <cassert>
 //#include "Analysis/FittedEntriesRoot/interface/FERootDump.h"
 #include "Alignment/CocoaToDDL/interface/CocoaToDDLMgr.h"
 #include "Alignment/CocoaUtilities/interface/GlobalOptionMgr.h"
 
-#include <time.h>
+#include <ctime>
 
 int main( int argc, char** argv ) 
 {
   char* nam = getenv("COCOA_SDF_FILENAME"); 
-  if(nam != 0) Model::setSDFName( nam );
+  if(nam != nullptr) Model::setSDFName( nam );
   nam = getenv("COCOA_REPORT_FILENAME"); 
-  if(nam != 0) Model::setReportFName( nam );
+  if(nam != nullptr) Model::setReportFName( nam );
   nam = getenv("COCOA_MATRICES_FILENAME"); 
-  if(nam != 0) Model::setMatricesFName( nam );
+  if(nam != nullptr) Model::setMatricesFName( nam );
 
   ALIstring COCOA_ver = "COCOA_3_2_4";
   //---------- Read the input arguments to set file names

--- a/Alignment/CocoaApplication/bin/cocoa.cpp
+++ b/Alignment/CocoaApplication/bin/cocoa.cpp
@@ -10,34 +10,39 @@
 
 #include <ctime>
 
-int main( int argc, char** argv ) 
-{
-  char* nam = getenv("COCOA_SDF_FILENAME"); 
-  if(nam != nullptr) Model::setSDFName( nam );
-  nam = getenv("COCOA_REPORT_FILENAME"); 
-  if(nam != nullptr) Model::setReportFName( nam );
-  nam = getenv("COCOA_MATRICES_FILENAME"); 
-  if(nam != nullptr) Model::setMatricesFName( nam );
+int main(int argc, char** argv) {
+  char* nam = getenv("COCOA_SDF_FILENAME");
+  if (nam != nullptr)
+    Model::setSDFName(nam);
+  nam = getenv("COCOA_REPORT_FILENAME");
+  if (nam != nullptr)
+    Model::setReportFName(nam);
+  nam = getenv("COCOA_MATRICES_FILENAME");
+  if (nam != nullptr)
+    Model::setMatricesFName(nam);
 
   ALIstring COCOA_ver = "COCOA_3_2_4";
   //---------- Read the input arguments to set file names
-  switch( argc ){
-  case 1:
-    break;
-  case 4:
-    if( ALIstring(argv[3]) != "!" ) Model::setMatricesFName( argv[3] );
-  case 3:
-    if( ALIstring(argv[2]) != "!" ) Model::setReportFName( argv[2] );
-  case 2:
-    if( ALIstring(argv[1]) != "!" ) Model::setSDFName( argv[1] );
-    if( ALIstring(argv[1]) == "-v" ) {
-      std::cerr << "COCOA version = " << COCOA_ver << std::endl;
-      exit(0);
-    }
-    break;
-  default:
-    std::cerr << "WARNING: more than two arguments, from third on will not be taken into account " << std::endl;
-    break;
+  switch (argc) {
+    case 1:
+      break;
+    case 4:
+      if (ALIstring(argv[3]) != "!")
+        Model::setMatricesFName(argv[3]);
+    case 3:
+      if (ALIstring(argv[2]) != "!")
+        Model::setReportFName(argv[2]);
+    case 2:
+      if (ALIstring(argv[1]) != "!")
+        Model::setSDFName(argv[1]);
+      if (ALIstring(argv[1]) == "-v") {
+        std::cerr << "COCOA version = " << COCOA_ver << std::endl;
+        exit(0);
+      }
+      break;
+    default:
+      std::cerr << "WARNING: more than two arguments, from third on will not be taken into account " << std::endl;
+      break;
   }
 
   //---------- Build the Model out of the system description text file
@@ -48,22 +53,26 @@ int main( int argc, char** argv )
   time_t now, time_start;
   now = clock();
   time_start = now;
-  if(ALIUtils::debug >= 0) std::cout << "TIME:START_READING  : " << now << " " << difftime(now, ALIUtils::time_now())/1.E6  << "   " << ALIUtils::debug <<std::endl;
-  ALIUtils::set_time_now(now); 
+  if (ALIUtils::debug >= 0)
+    std::cout << "TIME:START_READING  : " << now << " " << difftime(now, ALIUtils::time_now()) / 1.E6 << "   "
+              << ALIUtils::debug << std::endl;
+  ALIUtils::set_time_now(now);
 
   Model::readSystemDescription();
   now = clock();
-  if(ALIUtils::debug >= 0) std::cout << "TIME:ENDED_READING  : " << now << " " << difftime(now, ALIUtils::time_now())/1.E6  << "   " << ALIUtils::debug << std::endl;
-  ALIUtils::set_time_now(now); 
+  if (ALIUtils::debug >= 0)
+    std::cout << "TIME:ENDED_READING  : " << now << " " << difftime(now, ALIUtils::time_now()) / 1.E6 << "   "
+              << ALIUtils::debug << std::endl;
+  ALIUtils::set_time_now(now);
 
   ALIdouble go;
   GlobalOptionMgr* gomgr = GlobalOptionMgr::getInstance();
-  gomgr->getGlobalOptionValue("writeXML", go );
+  gomgr->getGlobalOptionValue("writeXML", go);
 
-  if( ALIint(go) == 1 ){
+  if (ALIint(go) == 1) {
     ALIstring xmlfname = Model::SDFName();
     xmlfname += ALIstring(".xml");
-    CocoaToDDLMgr::getInstance()->writeDDDFile( xmlfname );
+    CocoaToDDLMgr::getInstance()->writeDDDFile(xmlfname);
   }
 
   Fit::getInstance();
@@ -76,18 +85,21 @@ int main( int argc, char** argv )
 
   //analysis code
 
-//  FERootDump fehistos;
-//  std::cout << " call  fehistos.MakeHistos " << std::endl;
-//  fehistos.MakeHistos();
+  //  FERootDump fehistos;
+  //  std::cout << " call  fehistos.MakeHistos " << std::endl;
+  //  fehistos.MakeHistos();
 
-  if(ALIUtils::debug >= 0) std::cout << "............ program ended OK" << std::endl;
-  if( ALIUtils::report >=1 ) {
-    ALIFileOut& fileout = ALIFileOut::getInstance( Model::ReportFName() );
+  if (ALIUtils::debug >= 0)
+    std::cout << "............ program ended OK" << std::endl;
+  if (ALIUtils::report >= 1) {
+    ALIFileOut& fileout = ALIFileOut::getInstance(Model::ReportFName());
     fileout << "............ program ended OK" << std::endl;
   }
   now = clock();
-  if(ALIUtils::debug >= 0) std::cout << "TIME:PROGRAM ENDED  : "<< now << " " << difftime(now, ALIUtils::time_now())/1.E6  << std::endl;
-  if(ALIUtils::debug >= 0) std::cout << "TIME:TOTAL PROGRAM  : "<< now << " " << difftime(now, time_start)/1.E6  << std::endl;
+  if (ALIUtils::debug >= 0)
+    std::cout << "TIME:PROGRAM ENDED  : " << now << " " << difftime(now, ALIUtils::time_now()) / 1.E6 << std::endl;
+  if (ALIUtils::debug >= 0)
+    std::cout << "TIME:TOTAL PROGRAM  : " << now << " " << difftime(now, time_start) / 1.E6 << std::endl;
 
   exit(0);
 }

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentCSCBeamHaloSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentCSCBeamHaloSelector.h
@@ -6,28 +6,28 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 namespace edm {
-   class Event;
-   class ParameterSet;
-}
+  class Event;
+  class ParameterSet;
+}  // namespace edm
 
 class TrackingRecHit;
 
 class AlignmentCSCBeamHaloSelector {
-   public:
-      typedef std::vector<const reco::Track*> Tracks;
+public:
+  typedef std::vector<const reco::Track *> Tracks;
 
-      /// constructor
-      AlignmentCSCBeamHaloSelector(const edm::ParameterSet &iConfig, edm::ConsumesCollector & iC);
+  /// constructor
+  AlignmentCSCBeamHaloSelector(const edm::ParameterSet &iConfig, edm::ConsumesCollector &iC);
 
-      /// destructor
-      ~AlignmentCSCBeamHaloSelector();
+  /// destructor
+  ~AlignmentCSCBeamHaloSelector();
 
-      /// select tracks
-      Tracks select(const Tracks &tracks, const edm::Event &iEvent) const;
+  /// select tracks
+  Tracks select(const Tracks &tracks, const edm::Event &iEvent) const;
 
-   private:
-      unsigned int m_minStations;
-      unsigned int m_minHitsPerStation;
+private:
+  unsigned int m_minStations;
+  unsigned int m_minHitsPerStation;
 };
 
 #endif

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentCSCOverlapSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentCSCOverlapSelector.h
@@ -5,28 +5,28 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 namespace edm {
-   class Event;
-   class ParameterSet;
-}
+  class Event;
+  class ParameterSet;
+}  // namespace edm
 
 class TrackingRecHit;
 
 class AlignmentCSCOverlapSelector {
-   public:
-      typedef std::vector<const reco::Track*> Tracks; 
+public:
+  typedef std::vector<const reco::Track *> Tracks;
 
-      /// constructor
-      AlignmentCSCOverlapSelector(const edm::ParameterSet &iConfig);
+  /// constructor
+  AlignmentCSCOverlapSelector(const edm::ParameterSet &iConfig);
 
-      /// destructor
-      ~AlignmentCSCOverlapSelector();
+  /// destructor
+  ~AlignmentCSCOverlapSelector();
 
-      /// select tracks
-      Tracks select(const Tracks &tracks, const edm::Event &iEvent) const;
+  /// select tracks
+  Tracks select(const Tracks &tracks, const edm::Event &iEvent) const;
 
-   private:
-      int m_station;
-      unsigned int m_minHitsPerChamber;
+private:
+  int m_station;
+  unsigned int m_minHitsPerChamber;
 };
 
 #endif

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentCSCTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentCSCTrackSelector.h
@@ -8,19 +8,16 @@
 namespace edm {
   class Event;
   class ParameterSet;
-}
+}  // namespace edm
 
 class TrackingRecHit;
 
-class AlignmentCSCTrackSelector
-{
-
- public:
-
-  typedef std::vector<const reco::Track*> Tracks; 
+class AlignmentCSCTrackSelector {
+public:
+  typedef std::vector<const reco::Track*> Tracks;
 
   /// constructor
-  AlignmentCSCTrackSelector(const edm::ParameterSet & cfg);
+  AlignmentCSCTrackSelector(const edm::ParameterSet& cfg);
 
   /// destructor
   ~AlignmentCSCTrackSelector();
@@ -28,12 +25,9 @@ class AlignmentCSCTrackSelector
   /// select tracks
   Tracks select(const Tracks& tracks, const edm::Event& evt) const;
 
- private:
-
+private:
   edm::InputTag m_src;
   int m_stationA, m_stationB, m_minHitsDT, m_minHitsPerStation, m_maxHitsPerStation;
-
 };
 
 #endif
-

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
@@ -11,18 +11,20 @@
 //STL
 #include <vector>
 
-namespace reco {class Track;}
-namespace edm {class Event; class EventSetup;}
+namespace reco {
+  class Track;
+}
+namespace edm {
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
-class AlignmentGlobalTrackSelector
-{
-
- public:
-
-  typedef std::vector<const reco::Track*> Tracks; 
+class AlignmentGlobalTrackSelector {
+public:
+  typedef std::vector<const reco::Track*> Tracks;
 
   /// constructor
-  AlignmentGlobalTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
+  AlignmentGlobalTrackSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
   /// destructor
   ~AlignmentGlobalTrackSelector();
@@ -31,15 +33,14 @@ class AlignmentGlobalTrackSelector
   Tracks select(const Tracks& tracks, const edm::Event& iEvent, const edm::EventSetup& eSetup);
   ///returns if any of the Filters is used.
   bool useThisFilter();
- 
- private:
-  
+
+private:
   ///returns [tracks] if there are less than theMaxCount Jets with theMinJetPt and an empty set if not
-  Tracks checkJetCount(const Tracks& cands,const edm::Event& iEvent)const;
+  Tracks checkJetCount(const Tracks& cands, const edm::Event& iEvent) const;
   ///returns only isolated tracks in [cands]
-  Tracks checkIsolation(const Tracks& cands,const edm::Event& iEvent)const;
+  Tracks checkIsolation(const Tracks& cands, const edm::Event& iEvent) const;
   ///filter for Tracks that match the Track of a global Muon
-  Tracks findMuons(const Tracks& tracks,const edm::Event& iEvent)const;
+  Tracks findMuons(const Tracks& tracks, const edm::Event& iEvent) const;
 
   /// private data members
   edm::ParameterSet theConf;
@@ -75,4 +76,3 @@ class AlignmentGlobalTrackSelector
 };
 
 #endif
-

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentMuonSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentMuonSelector.h
@@ -19,17 +19,16 @@
 #include "CommonTools/RecoAlgos/interface/MuonSelector.h"
 #include <vector>
 
-namespace edm { class Event; }
+namespace edm {
+  class Event;
+}
 
-class AlignmentMuonSelector 
-{
-
- public:
-
-  typedef std::vector<const reco::Muon*> Muons; 
+class AlignmentMuonSelector {
+public:
+  typedef std::vector<const reco::Muon*> Muons;
 
   /// constructor
-  AlignmentMuonSelector(const edm::ParameterSet & cfg);
+  AlignmentMuonSelector(const edm::ParameterSet& cfg);
 
   /// destructor
   ~AlignmentMuonSelector();
@@ -37,35 +36,30 @@ class AlignmentMuonSelector
   /// select muons
   Muons select(const Muons& muons, const edm::Event& evt) const;
 
- private:
-
+private:
   /// apply basic cuts on pt,eta,phi,nhit
   Muons basicCuts(const Muons& muons) const;
 
   /// filter the n highest pt muons
   Muons theNHighestPtMuons(const Muons& muons) const;
-  
+
   /// filter only those muons giving best mass pair combination
   Muons theBestMassPairCombinationMuons(const Muons& muons) const;
-  
+
   /// compare two muons in pt (used by theNHighestPtMuons)
   struct ComparePt {
-    bool operator()( const reco::Muon* t1, const reco::Muon* t2 ) const {
-      return t1->pt()> t2->pt();
-    }
+    bool operator()(const reco::Muon* t1, const reco::Muon* t2) const { return t1->pt() > t2->pt(); }
   };
   ComparePt ptComparator;
 
   /// private data members
-  bool applyBasicCuts,applyNHighestPt,applyMultiplicityFilter,applyMassPairFilter;
-  int nHighestPt,minMultiplicity;
-  double pMin,pMax,ptMin,ptMax,etaMin,etaMax,phiMin,phiMax;
-  double nHitMinSA,nHitMaxSA,chi2nMaxSA;
-  double nHitMinGB,nHitMaxGB,chi2nMaxGB;
-  double nHitMinTO,nHitMaxTO,chi2nMaxTO;
-  double minMassPair,maxMassPair;
-
+  bool applyBasicCuts, applyNHighestPt, applyMultiplicityFilter, applyMassPairFilter;
+  int nHighestPt, minMultiplicity;
+  double pMin, pMax, ptMin, ptMax, etaMin, etaMax, phiMin, phiMax;
+  double nHitMinSA, nHitMaxSA, chi2nMaxSA;
+  double nHitMinGB, nHitMaxGB, chi2nMaxGB;
+  double nHitMinTO, nHitMaxTO, chi2nMaxTO;
+  double minMassPair, maxMassPair;
 };
 
 #endif
-

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -57,7 +57,6 @@
 
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
-
 class AlignTransform;
 class Alignments;
 class AlignmentErrorsExtended;
@@ -67,9 +66,7 @@ struct SurveyErrors;
 class TrackerTopology;
 class TrackerDigiGeometryRecord;
 
-
-class AlignmentProducerBase
-{
+class AlignmentProducerBase {
 protected:
   AlignmentProducerBase(const edm::ParameterSet&);
 
@@ -108,15 +105,11 @@ protected:
   /// @alignmentAlgo_
   bool finish();
 
-  virtual bool getTrajTrackAssociationCollection(const edm::Event&,
-                                                 edm::Handle<TrajTrackAssociationCollection>&) = 0;
+  virtual bool getTrajTrackAssociationCollection(const edm::Event&, edm::Handle<TrajTrackAssociationCollection>&) = 0;
   virtual bool getBeamSpot(const edm::Event&, edm::Handle<reco::BeamSpot>&) = 0;
-  virtual bool getTkFittedLasBeamCollection(const edm::Run&,
-                                            edm::Handle<TkFittedLasBeamCollection>&) = 0;
-  virtual bool getTsosVectorCollection(const edm::Run&,
-                                       edm::Handle<TsosVectorCollection>&) = 0;
-  virtual bool getAliClusterValueMap(const edm::Event&,
-                                     edm::Handle<AliClusterValueMap>&) = 0;
+  virtual bool getTkFittedLasBeamCollection(const edm::Run&, edm::Handle<TkFittedLasBeamCollection>&) = 0;
+  virtual bool getTsosVectorCollection(const edm::Run&, edm::Handle<TsosVectorCollection>&) = 0;
+  virtual bool getAliClusterValueMap(const edm::Event&, edm::Handle<AliClusterValueMap>&) = 0;
 
   std::shared_ptr<TrackerGeometry> trackerGeometry_;
   std::shared_ptr<DTGeometry> muonDTGeometry_;
@@ -136,7 +129,6 @@ protected:
   const edm::InputTag clusterValueMapTag_;
 
 private:
-
   /// Creates the choosen alignment algorithm
   void createAlignmentAlgorithm();
 
@@ -170,8 +162,7 @@ private:
   void applyMisalignment();
 
   /// Applies misalignment scenario to @alignableTracker_
-  void simpleMisalignment(const align::Alignables&, const std::string&,
-                          float, float, bool);
+  void simpleMisalignment(const align::Alignables&, const std::string&, float, float, bool);
 
   /// Applies Alignments, AlignmentErrors and SurfaceDeformations to
   /// @trackerGeometry_
@@ -179,11 +170,11 @@ private:
 
   /// Applies DB constants belonging to (Err)Rcd to Geometry, taking into
   /// account 'globalPosition' correction.
-  template<class G, class Rcd, class ErrRcd>
+  template <class G, class Rcd, class ErrRcd>
   void applyDB(G*, const edm::EventSetup&, const AlignTransform&) const;
 
   /// Applies DB constants for SurfaceDeformations
-  template<class G, class DeformationRcd>
+  template <class G, class DeformationRcd>
   void applyDB(G*, const edm::EventSetup&) const;
 
   /// Reads in survey records
@@ -202,18 +193,19 @@ private:
   /// Writes Alignments and/or AlignmentErrors to DB for record names
   /// (removes *globalCoordinates before writing if non-null...).
   /// Takes over ownership of Alignments and AlignmentErrors.
-  void writeDB(Alignments*, const std::string&, AlignmentErrorsExtended*,
-               const std::string&, const AlignTransform*, cond::Time_t) const;
+  void writeDB(Alignments*,
+               const std::string&,
+               AlignmentErrorsExtended*,
+               const std::string&,
+               const AlignTransform*,
+               cond::Time_t) const;
 
   /// Writes SurfaceDeformations (bows & kinks) to DB for given record name
   /// Takes over ownership of AlignmentSurfaceDeformations.
-  void writeDB(AlignmentSurfaceDeformations*,
-               const std::string&, cond::Time_t) const;
+  void writeDB(AlignmentSurfaceDeformations*, const std::string&, cond::Time_t) const;
 
-  template<typename T>
+  template <typename T>
   bool hasParameter(const edm::ParameterSet&, const std::string& name);
-
-
 
   //========================== PRIVATE DATA ====================================
   //============================================================================
@@ -237,7 +229,6 @@ private:
   int nevent_{0};
   bool runAtPCL_{false};
 
-
   /*** Parameters from config-file ***/
 
   edm::ParameterSet config_;
@@ -250,7 +241,6 @@ private:
   const bool useSurvey_;
   const bool enableAlignableUpdates_;
 
-
   /*** ESWatcher ***/
 
   edm::ESWatcher<IdealGeometryRecord> watchIdealGeometryRcd_;
@@ -261,7 +251,7 @@ private:
   edm::ESWatcher<TrackerSurfaceDeformationRcd> watchTrackerSurDeRcd_;
 
   edm::ESWatcher<DTAlignmentRcd> watchDTAlRcd_;
-  edm::ESWatcher<DTAlignmentErrorExtendedRcd>  watchDTAlErrExtRcd_;
+  edm::ESWatcher<DTAlignmentErrorExtendedRcd> watchDTAlErrExtRcd_;
   edm::ESWatcher<CSCAlignmentRcd> watchCSCAlRcd_;
   edm::ESWatcher<CSCAlignmentErrorExtendedRcd> watchCSCAlErrExtRcd_;
 
@@ -272,49 +262,39 @@ private:
   edm::ESWatcher<CSCSurveyRcd> watchCSCSurveyRcd_;
   edm::ESWatcher<CSCSurveyErrorExtendedRcd> watchCSCSurveyErrExtRcd_;
 
-
   /*** Survey stuff ***/
 
   size_t surveyIndex_{0};
   const Alignments* surveyValues_{nullptr};
   const SurveyErrors* surveyErrors_{nullptr};
 
-
   /*** Status flags ***/
   bool isAlgoInitialized_{false};
-  bool isDuringLoop_{false};    // -> needed to ensure correct behaviour in
-                                //    both, EDLooper and standard framework
-                                //    modules
+  bool isDuringLoop_{false};  // -> needed to ensure correct behaviour in
+                              //    both, EDLooper and standard framework
+                              //    modules
   cond::Time_t firstRun_{cond::timeTypeSpecs[cond::runnumber].endValue};
-
 };
 
-
-
-template<class G, class Rcd, class ErrRcd>
-void
-AlignmentProducerBase::applyDB(G* geometry, const edm::EventSetup& iSetup,
-                               const AlignTransform& globalCoordinates) const
-{
+template <class G, class Rcd, class ErrRcd>
+void AlignmentProducerBase::applyDB(G* geometry,
+                                    const edm::EventSetup& iSetup,
+                                    const AlignTransform& globalCoordinates) const {
   // 'G' is the geometry class for that DB should be applied,
   // 'Rcd' is the record class for its Alignments
   // 'ErrRcd' is the record class for its AlignmentErrorsExtended
   // 'globalCoordinates' are global transformation for this geometry
 
-  const Rcd & record = iSetup.get<Rcd>();
+  const Rcd& record = iSetup.get<Rcd>();
   if (checkDbAlignmentValidity_) {
-    const edm::ValidityInterval & validity = record.validityInterval();
+    const edm::ValidityInterval& validity = record.validityInterval();
     const edm::IOVSyncValue first = validity.first();
     const edm::IOVSyncValue last = validity.last();
-    if (first!=edm::IOVSyncValue::beginOfTime() ||
-        last!=edm::IOVSyncValue::endOfTime()) {
+    if (first != edm::IOVSyncValue::beginOfTime() || last != edm::IOVSyncValue::endOfTime()) {
       throw cms::Exception("DatabaseError")
-        << "@SUB=AlignmentProducerBase::applyDB"
-        << "\nTrying to apply "
-        << record.key().name()
-        << " with multiple IOVs in tag.\n"
-        << "Validity range is "
-        << first.eventID().run() << " - " << last.eventID().run();
+          << "@SUB=AlignmentProducerBase::applyDB"
+          << "\nTrying to apply " << record.key().name() << " with multiple IOVs in tag.\n"
+          << "Validity range is " << first.eventID().run() << " - " << last.eventID().run();
     }
   }
 
@@ -325,32 +305,24 @@ AlignmentProducerBase::applyDB(G* geometry, const edm::EventSetup& iSetup,
   iSetup.get<ErrRcd>().get(alignmentErrors);
 
   GeometryAligner aligner;
-  aligner.applyAlignments<G>(geometry, &(*alignments), &(*alignmentErrors),
-                             globalCoordinates);
+  aligner.applyAlignments<G>(geometry, &(*alignments), &(*alignmentErrors), globalCoordinates);
 }
 
-
-template<class G, class DeformationRcd>
-void
-AlignmentProducerBase::applyDB(G* geometry, const edm::EventSetup& iSetup) const
-{
+template <class G, class DeformationRcd>
+void AlignmentProducerBase::applyDB(G* geometry, const edm::EventSetup& iSetup) const {
   // 'G' is the geometry class for that DB should be applied,
   // 'DeformationRcd' is the record class for its surface deformations
 
-  const DeformationRcd & record = iSetup.get<DeformationRcd>();
+  const DeformationRcd& record = iSetup.get<DeformationRcd>();
   if (checkDbAlignmentValidity_) {
-    const edm::ValidityInterval & validity = record.validityInterval();
+    const edm::ValidityInterval& validity = record.validityInterval();
     const edm::IOVSyncValue first = validity.first();
     const edm::IOVSyncValue last = validity.last();
-    if (first!=edm::IOVSyncValue::beginOfTime() ||
-        last!=edm::IOVSyncValue::endOfTime()) {
+    if (first != edm::IOVSyncValue::beginOfTime() || last != edm::IOVSyncValue::endOfTime()) {
       throw cms::Exception("DatabaseError")
-        << "@SUB=AlignmentProducerBase::applyDB"
-        << "\nTrying to apply "
-        << record.key().name()
-        << " with multiple IOVs in tag.\n"
-        << "Validity range is "
-        << first.eventID().run() << " - " << last.eventID().run();
+          << "@SUB=AlignmentProducerBase::applyDB"
+          << "\nTrying to apply " << record.key().name() << " with multiple IOVs in tag.\n"
+          << "Validity range is " << first.eventID().run() << " - " << last.eventID().run();
     }
   }
   edm::ESHandle<AlignmentSurfaceDeformations> surfaceDeformations;
@@ -359,6 +331,5 @@ AlignmentProducerBase::applyDB(G* geometry, const edm::EventSetup& iSetup) const
   GeometryAligner aligner;
   aligner.attachSurfaceDeformations<G>(geometry, &(*surfaceDeformations));
 }
-
 
 #endif /* Alignment_CommonAlignmentProducer_AlignmentProducerBase_h */

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentSeedSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentSeedSelector.h
@@ -5,17 +5,16 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 #include <vector>
 
-namespace edm { class Event; }
+namespace edm {
+  class Event;
+}
 
-class AlignmentSeedSelector
-{
-
- public:
-
-  typedef std::vector<const TrajectorySeed*> Seeds; 
+class AlignmentSeedSelector {
+public:
+  typedef std::vector<const TrajectorySeed*> Seeds;
 
   /// constructor
-  AlignmentSeedSelector(const edm::ParameterSet & cfg);
+  AlignmentSeedSelector(const edm::ParameterSet& cfg);
 
   /// destructor
   ~AlignmentSeedSelector();
@@ -23,13 +22,10 @@ class AlignmentSeedSelector
   /// select tracks
   Seeds select(const Seeds& seeds, const edm::Event& evt) const;
 
- private:
- 
+private:
   /// private data members
   bool applySeedNumber;
-  int minNSeeds,maxNSeeds;
-
+  int minNSeeds, maxNSeeds;
 };
 
 #endif
-

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTrackSelector.h
@@ -14,21 +14,18 @@ namespace edm {
   class Event;
   class EventSetup;
   class ParameterSet;
-}
+}  // namespace edm
 
 class TrackingRecHit;
 class SiStripRecHit1D;
 class SiStripRecHit2D;
 
-class AlignmentTrackSelector
-{
-
- public:
-
-  typedef std::vector<const reco::Track*> Tracks; 
+class AlignmentTrackSelector {
+public:
+  typedef std::vector<const reco::Track*> Tracks;
 
   /// constructor
-  AlignmentTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
+  AlignmentTrackSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
   /// destructor
   ~AlignmentTrackSelector();
@@ -38,18 +35,16 @@ class AlignmentTrackSelector
   ///returns if any of the Filters is used.
   bool useThisFilter();
 
-
- private:
-
+private:
   /// apply basic cuts on pt,eta,phi,nhit
   Tracks basicCuts(const Tracks& tracks, const edm::Event& evt, const edm::EventSetup& eSetup) const;
   /// checking hit requirements beyond simple number of valid hits
   bool detailedHitsCheck(const reco::Track* track, const edm::Event& evt, const edm::EventSetup& eSetup) const;
-  bool isHit2D(const TrackingRecHit &hit) const;
-  /// if valid, check for minimum charge (currently only in strip), if invalid give true 
+  bool isHit2D(const TrackingRecHit& hit) const;
+  /// if valid, check for minimum charge (currently only in strip), if invalid give true
   bool isOkCharge(const TrackingRecHit* therechit) const;
-  bool isOkChargeStripHit(const SiStripRecHit1D &siStripRecHit1D) const;
-  bool isOkChargeStripHit(const SiStripRecHit2D &siStripRecHit2D) const;
+  bool isOkChargeStripHit(const SiStripRecHit1D& siStripRecHit1D) const;
+  bool isOkChargeStripHit(const SiStripRecHit2D& siStripRecHit2D) const;
   bool isIsolated(const TrackingRecHit* therechit, const edm::Event& evt) const;
   bool isOkTrkQuality(const reco::Track* track) const;
 
@@ -61,9 +56,7 @@ class AlignmentTrackSelector
 
   /// compare two tracks in pt (used by theNHighestPtTracks)
   struct ComparePt {
-    bool operator()( const reco::Track* t1, const reco::Track* t2 ) const {
-      return t1->pt()> t2->pt();
-    }
+    bool operator()(const reco::Track* t1, const reco::Track* t2) const { return t1->pt() > t2->pt(); }
   };
   ComparePt ptComparator;
 
@@ -71,14 +64,14 @@ class AlignmentTrackSelector
   const int seedOnlyFromAbove_;
   const bool applyIsolation_, chargeCheck_;
   const int nHighestPt_, minMultiplicity_, maxMultiplicity_;
-  const bool multiplicityOnInput_; /// if true, cut min/maxMultiplicity on input instead of on final result
-  const double ptMin_,ptMax_,pMin_,pMax_,etaMin_,etaMax_,phiMin_,phiMax_;
-  const double nHitMin_,nHitMax_,chi2nMax_, d0Min_,d0Max_,dzMin_,dzMax_;
+  const bool multiplicityOnInput_;  /// if true, cut min/maxMultiplicity on input instead of on final result
+  const double ptMin_, ptMax_, pMin_, pMax_, etaMin_, etaMax_, phiMin_, phiMax_;
+  const double nHitMin_, nHitMax_, chi2nMax_, d0Min_, d0Max_, dzMin_, dzMax_;
   const int theCharge_;
   const double minHitChargeStrip_, minHitIsolation_;
   edm::EDGetTokenT<SiStripRecHit2DCollection> rphirecHitsToken_;
   edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> matchedrecHitsToken_;
-  const bool countStereoHitAs2D_; // count hits on stereo components of GluedDet for nHitMin2D_?
+  const bool countStereoHitAs2D_;  // count hits on stereo components of GluedDet for nHitMin2D_?
   const unsigned int nHitMin2D_;
   const int minHitsinTIB_, minHitsinTOB_, minHitsinTID_, minHitsinTEC_;
   const int minHitsinBPIX_, minHitsinFPIX_, minHitsinPIX_;
@@ -92,7 +85,7 @@ class AlignmentTrackSelector
   std::vector<double> RorZofLastHitMin_;
   std::vector<double> RorZofLastHitMax_;
 
-  const edm::InputTag clusterValueMapTag_;  // ValueMap containing association cluster - flag
+  const edm::InputTag clusterValueMapTag_;                     // ValueMap containing association cluster - flag
   edm::EDGetTokenT<AliClusterValueMap> clusterValueMapToken_;  // ValueMap containing association cluster - flag
   const int minPrescaledHits_;
   const bool applyPrescaledHitsFilter_;
@@ -105,4 +98,3 @@ class AlignmentTrackSelector
 };
 
 #endif
-

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTwoBodyDecayTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTwoBodyDecayTrackSelector.h
@@ -12,16 +12,17 @@
 #include <DataFormats/TrackReco/interface/TrackFwd.h>
 #include <DataFormats/METReco/interface/CaloMETFwd.h>
 
-namespace edm { class Event; class EventSetup; }
+namespace edm {
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
-class AlignmentTwoBodyDecayTrackSelector
-{
- public:
-
-  typedef std::vector<const reco::Track*> Tracks; 
+class AlignmentTwoBodyDecayTrackSelector {
+public:
+  typedef std::vector<const reco::Track*> Tracks;
 
   /// constructor
-  AlignmentTwoBodyDecayTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
+  AlignmentTwoBodyDecayTrackSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
   /// destructor
   ~AlignmentTwoBodyDecayTrackSelector();
@@ -30,17 +31,18 @@ class AlignmentTwoBodyDecayTrackSelector
   Tracks select(const Tracks& tracks, const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
   bool useThisFilter();
- private:
+
+private:
   ///checks if the mass of the mother is in the mass region
-  Tracks checkMass(const Tracks& cands)const;
+  Tracks checkMass(const Tracks& cands) const;
   ///checks if the mass of the mother is in the mass region adding missing E_T
-  Tracks checkMETMass(const Tracks& cands,const edm::Event& iEvent)const;
+  Tracks checkMETMass(const Tracks& cands, const edm::Event& iEvent) const;
   ///checks if the mother has charge = [theCharge]
-  bool checkCharge(const reco::Track* trk1,const reco::Track* trk2 = nullptr)const;
+  bool checkCharge(const reco::Track* trk1, const reco::Track* trk2 = nullptr) const;
   ///checks if the [cands] are acoplanar (returns empty set if not)
-  bool checkAcoplanarity(const reco::Track* trk1,const reco::Track* trk2)const;
+  bool checkAcoplanarity(const reco::Track* trk1, const reco::Track* trk2) const;
   ///checks if [cands] contains a acoplanar track w.r.t missing ET (returns empty set if not)
-  bool checkMETAcoplanarity(const reco::Track* trk,const reco::CaloMET* met)const; 
+  bool checkMETAcoplanarity(const reco::Track* trk, const reco::CaloMET* met) const;
 
   /// private data members
 
@@ -55,8 +57,8 @@ class AlignmentTwoBodyDecayTrackSelector
   double theDaughterMass;
   unsigned int theCandNumber;
   bool secThrBool;
-  double thesecThr ;
-   //charge filter
+  double thesecThr;
+  //charge filter
   int theCharge;
   bool theUnsignedSwitch;
   //missing ET Filter
@@ -69,4 +71,3 @@ class AlignmentTwoBodyDecayTrackSelector
 };
 
 #endif
-

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCBeamHaloSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCBeamHaloSelectorModule.cc
@@ -11,37 +11,32 @@
 #include "CommonTools/RecoAlgos/interface/TrackSelector.h"
 
 struct CSCBeamHaloConfigSelector {
-
-  typedef std::vector<const reco::Track*> container;
+  typedef std::vector<const reco::Track *> container;
   typedef container::const_iterator const_iterator;
   typedef reco::TrackCollection collection;
 
-  CSCBeamHaloConfigSelector( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-    CSCBeamHaloConfigSelector(cfg, iC) {}
-  CSCBeamHaloConfigSelector( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) :
-    theSelector(cfg, iC) {}
+  CSCBeamHaloConfigSelector(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC)
+      : CSCBeamHaloConfigSelector(cfg, iC) {}
+  CSCBeamHaloConfigSelector(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC) : theSelector(cfg, iC) {}
 
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
   size_t size() const { return selected_.size(); }
 
-  void select( const edm::Handle<reco::TrackCollection> & c,  const edm::Event & evt,
-               const edm::EventSetup &/*dummy*/)
-  {
+  void select(const edm::Handle<reco::TrackCollection> &c, const edm::Event &evt, const edm::EventSetup & /*dummy*/) {
     all_.clear();
     selected_.clear();
-    for (collection::const_iterator i = c.product()->begin(), iE = c.product()->end();
-         i != iE; ++i){
-      all_.push_back(& * i );
+    for (collection::const_iterator i = c.product()->begin(), iE = c.product()->end(); i != iE; ++i) {
+      all_.push_back(&*i);
     }
-    selected_ = theSelector.select(all_, evt); // might add dummy...
+    selected_ = theSelector.select(all_, evt);  // might add dummy...
   }
 
 private:
-  container all_,selected_;
+  container all_, selected_;
   AlignmentCSCBeamHaloSelector theSelector;
 };
 
-typedef ObjectSelectorStream<CSCBeamHaloConfigSelector>  AlignmentCSCBeamHaloSelectorModule;
+typedef ObjectSelectorStream<CSCBeamHaloConfigSelector> AlignmentCSCBeamHaloSelectorModule;
 
-DEFINE_FWK_MODULE( AlignmentCSCBeamHaloSelectorModule );
+DEFINE_FWK_MODULE(AlignmentCSCBeamHaloSelectorModule);

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCOverlapSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCOverlapSelectorModule.cc
@@ -11,35 +11,30 @@
 #include "CommonTools/RecoAlgos/interface/TrackSelector.h"
 
 struct CSCOverlapConfigSelector {
-
-  typedef std::vector<const reco::Track*> container;
+  typedef std::vector<const reco::Track *> container;
   typedef container::const_iterator const_iterator;
   typedef reco::TrackCollection collection;
 
-  CSCOverlapConfigSelector( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-    theSelector(cfg) {}
+  CSCOverlapConfigSelector(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC) : theSelector(cfg) {}
 
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
   size_t size() const { return selected_.size(); }
 
-  void select( const edm::Handle<reco::TrackCollection> & c,  const edm::Event & evt,
-               const edm::EventSetup &/*dummy*/)
-  {
+  void select(const edm::Handle<reco::TrackCollection> &c, const edm::Event &evt, const edm::EventSetup & /*dummy*/) {
     all_.clear();
     selected_.clear();
-    for (collection::const_iterator i = c.product()->begin(), iE = c.product()->end();
-         i != iE; ++i){
-      all_.push_back(& * i );
+    for (collection::const_iterator i = c.product()->begin(), iE = c.product()->end(); i != iE; ++i) {
+      all_.push_back(&*i);
     }
-    selected_ = theSelector.select(all_, evt); // might add dummy...
+    selected_ = theSelector.select(all_, evt);  // might add dummy...
   }
 
 private:
-  container all_,selected_;
+  container all_, selected_;
   AlignmentCSCOverlapSelector theSelector;
 };
 
-typedef ObjectSelectorStream<CSCOverlapConfigSelector>  AlignmentCSCOverlapSelectorModule;
+typedef ObjectSelectorStream<CSCOverlapConfigSelector> AlignmentCSCOverlapSelectorModule;
 
-DEFINE_FWK_MODULE( AlignmentCSCOverlapSelectorModule );
+DEFINE_FWK_MODULE(AlignmentCSCOverlapSelectorModule);

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCTrackSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCTrackSelectorModule.cc
@@ -15,32 +15,30 @@
 #include "CommonTools/RecoAlgos/interface/TrackSelector.h"
 
 struct CSCTrackConfigSelector {
+  typedef std::vector<const reco::Track *> container;
+  typedef container::const_iterator const_iterator;
+  typedef reco::TrackCollection collection;
 
-      typedef std::vector<const reco::Track*> container;
-      typedef container::const_iterator const_iterator;
-      typedef reco::TrackCollection collection;
+  CSCTrackConfigSelector(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC) : theBaseSelector(cfg) {}
 
-      CSCTrackConfigSelector( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) : theBaseSelector(cfg) {}
+  const_iterator begin() const { return theSelectedTracks.begin(); }
+  const_iterator end() const { return theSelectedTracks.end(); }
+  size_t size() const { return theSelectedTracks.size(); }
 
-      const_iterator begin() const { return theSelectedTracks.begin(); }
-      const_iterator end() const { return theSelectedTracks.end(); }
-      size_t size() const { return theSelectedTracks.size(); }
+  void select(const edm::Handle<reco::TrackCollection> &c, const edm::Event &evt, const edm::EventSetup & /*dummy*/) {
+    container all;
+    for (reco::TrackCollection::const_iterator i = c.product()->begin(); i != c.product()->end(); ++i) {
+      all.push_back(&*i);
+    }
+    theSelectedTracks = theBaseSelector.select(all, evt);  // might add dummy
+  }
 
-      void select( const edm::Handle<reco::TrackCollection> & c,  const edm::Event & evt, const edm::EventSetup &/*dummy*/)
-      {
-	 container all;
-	 for( reco::TrackCollection::const_iterator i=c.product()->begin();i!=c.product()->end();++i){
-	    all.push_back(& * i );
-	 }
-	 theSelectedTracks = theBaseSelector.select(all, evt); // might add dummy
-      }
+private:
+  container theSelectedTracks;
 
-   private:
-      container theSelectedTracks;
-
-      AlignmentCSCTrackSelector theBaseSelector;
+  AlignmentCSCTrackSelector theBaseSelector;
 };
 
-typedef ObjectSelectorStream<CSCTrackConfigSelector>  AlignmentCSCTrackSelectorModule;
+typedef ObjectSelectorStream<CSCTrackConfigSelector> AlignmentCSCTrackSelectorModule;
 
-DEFINE_FWK_MODULE( AlignmentCSCTrackSelectorModule );
+DEFINE_FWK_MODULE(AlignmentCSCTrackSelectorModule);

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentMuonHIPTrajectorySelector.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentMuonHIPTrajectorySelector.cc
@@ -2,7 +2,7 @@
 //
 // Package:    AlignmentMuonHIPTrajectorySelector
 // Class:      AlignmentMuonHIPTrajectorySelector
-// 
+//
 /**\class AlignmentMuonHIPTrajectorySelector AlignmentMuonHIPTrajectorySelector.cc Alignment/CommonAlignmentProducer/plugins/AlignmentMuonHIPTrajectorySelector.cc
 
  Description: <one line class summary>
@@ -16,7 +16,6 @@
 // $Id: AlignmentMuonHIPTrajectorySelector.cc,v 1.4 2010/01/06 15:26:10 mussgill Exp $
 //
 //
-
 
 // system include files
 #include <memory>
@@ -53,29 +52,28 @@
 //
 
 class AlignmentMuonHIPTrajectorySelector : public edm::EDProducer {
-   public:
-      explicit AlignmentMuonHIPTrajectorySelector(const edm::ParameterSet&);
-      ~AlignmentMuonHIPTrajectorySelector() override;
+public:
+  explicit AlignmentMuonHIPTrajectorySelector(const edm::ParameterSet&);
+  ~AlignmentMuonHIPTrajectorySelector() override;
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      
-      // ---------- member data --------------------------------
-      edm::InputTag m_input;
-      double m_minPt;
-      double m_maxTrackerForwardRedChi2;
-      int m_minTrackerDOF;
-      double m_maxMuonResidual;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      bool m_hists;
-      TH1F *m_pt, *m_tracker_forwardredchi2, *m_tracker_dof;
-      TH1F *m_resid_before, *m_resid_after;
+  // ---------- member data --------------------------------
+  edm::InputTag m_input;
+  double m_minPt;
+  double m_maxTrackerForwardRedChi2;
+  int m_minTrackerDOF;
+  double m_maxMuonResidual;
+
+  bool m_hists;
+  TH1F *m_pt, *m_tracker_forwardredchi2, *m_tracker_dof;
+  TH1F *m_resid_before, *m_resid_after;
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -85,125 +83,133 @@ class AlignmentMuonHIPTrajectorySelector : public edm::EDProducer {
 // constructors and destructor
 //
 AlignmentMuonHIPTrajectorySelector::AlignmentMuonHIPTrajectorySelector(const edm::ParameterSet& iConfig)
-   : m_input(iConfig.getParameter<edm::InputTag>("input"))
-   , m_minPt(iConfig.getParameter<double>("minPt"))
-   , m_maxTrackerForwardRedChi2(iConfig.getParameter<double>("maxTrackerForwardRedChi2"))
-   , m_minTrackerDOF(iConfig.getParameter<int>("minTrackerDOF"))
-   , m_maxMuonResidual(iConfig.getParameter<double>("maxMuonResidual"))
-   , m_hists(iConfig.getParameter<bool>("hists"))
-   , m_pt(nullptr), m_tracker_forwardredchi2(nullptr), m_tracker_dof(nullptr)
-{
-   produces<TrajTrackAssociationCollection>();
+    : m_input(iConfig.getParameter<edm::InputTag>("input")),
+      m_minPt(iConfig.getParameter<double>("minPt")),
+      m_maxTrackerForwardRedChi2(iConfig.getParameter<double>("maxTrackerForwardRedChi2")),
+      m_minTrackerDOF(iConfig.getParameter<int>("minTrackerDOF")),
+      m_maxMuonResidual(iConfig.getParameter<double>("maxMuonResidual")),
+      m_hists(iConfig.getParameter<bool>("hists")),
+      m_pt(nullptr),
+      m_tracker_forwardredchi2(nullptr),
+      m_tracker_dof(nullptr) {
+  produces<TrajTrackAssociationCollection>();
 
-   if (m_hists) {
-      edm::Service<TFileService> fs;
-      m_pt = fs->make<TH1F>("pt", "Transverse momentum (GeV)", 100, 0., 100.);
-      m_tracker_forwardredchi2 = fs->make<TH1F>("trackerForwardRedChi2", "forward-biased reduced chi2 in tracker", 100, 0., 5.);
-      m_tracker_dof = fs->make<TH1F>("trackerDOF", "DOF in tracker", 61, -0.5, 60.5);
-      m_resid_before = fs->make<TH1F>("residBefore", "muon residuals before cut (cm)", 100, -20, 20);
-      m_resid_after = fs->make<TH1F>("residAfter", "muon residuals after cut (cm)", 100, -20, 20);
-   }
+  if (m_hists) {
+    edm::Service<TFileService> fs;
+    m_pt = fs->make<TH1F>("pt", "Transverse momentum (GeV)", 100, 0., 100.);
+    m_tracker_forwardredchi2 =
+        fs->make<TH1F>("trackerForwardRedChi2", "forward-biased reduced chi2 in tracker", 100, 0., 5.);
+    m_tracker_dof = fs->make<TH1F>("trackerDOF", "DOF in tracker", 61, -0.5, 60.5);
+    m_resid_before = fs->make<TH1F>("residBefore", "muon residuals before cut (cm)", 100, -20, 20);
+    m_resid_after = fs->make<TH1F>("residAfter", "muon residuals after cut (cm)", 100, -20, 20);
+  }
 }
 
-
 AlignmentMuonHIPTrajectorySelector::~AlignmentMuonHIPTrajectorySelector() {}
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-AlignmentMuonHIPTrajectorySelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   // input
-   edm::Handle<TrajTrackAssociationCollection> originalTrajTrackMap;
-   iEvent.getByLabel(m_input, originalTrajTrackMap);
+void AlignmentMuonHIPTrajectorySelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // input
+  edm::Handle<TrajTrackAssociationCollection> originalTrajTrackMap;
+  iEvent.getByLabel(m_input, originalTrajTrackMap);
 
-   // output
-   auto newTrajTrackMap = std::make_unique<TrajTrackAssociationCollection>();
+  // output
+  auto newTrajTrackMap = std::make_unique<TrajTrackAssociationCollection>();
 
-   TrajectoryStateCombiner tsoscomb;
+  TrajectoryStateCombiner tsoscomb;
 
-   for (TrajTrackAssociationCollection::const_iterator iPair = originalTrajTrackMap->begin();  iPair != originalTrajTrackMap->end();  ++iPair) {
-      if (m_hists) {
-	 m_pt->Fill((*(*iPair).val).pt());
+  for (TrajTrackAssociationCollection::const_iterator iPair = originalTrajTrackMap->begin();
+       iPair != originalTrajTrackMap->end();
+       ++iPair) {
+    if (m_hists) {
+      m_pt->Fill((*(*iPair).val).pt());
+    }
+
+    if ((*(*iPair).val).pt() > m_minPt) {
+      std::vector<TrajectoryMeasurement> measurements = (*(*iPair).key).measurements();
+
+      bool has_bad_residual = false;
+
+      double tracker_forwardchi2 = 0.;
+      double tracker_dof = 0.;
+      for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin(); im != measurements.end();
+           ++im) {
+        const TrajectoryMeasurement meas = *im;
+        auto hit = &(*meas.recHit());
+        const DetId id = hit->geographicalId();
+
+        if (hit->isValid() && id.det() == DetId::Tracker) {
+          if (hit->dimension() == 1) {
+            double residual = meas.forwardPredictedState().localPosition().x() - hit->localPosition().x();
+            double error2 =
+                meas.forwardPredictedState().localError().positionError().xx() + hit->localPositionError().xx();
+
+            tracker_forwardchi2 += residual * residual / error2;
+            tracker_dof += 1.;
+          } else if (hit->dimension() == 2) {
+            double residualx = meas.forwardPredictedState().localPosition().x() - hit->localPosition().x();
+            double residualy = meas.forwardPredictedState().localPosition().y() - hit->localPosition().y();
+            double errorxx2 =
+                meas.forwardPredictedState().localError().positionError().xx() + hit->localPositionError().xx();
+            double errorxy2 =
+                meas.forwardPredictedState().localError().positionError().xy() + hit->localPositionError().xy();
+            double erroryy2 =
+                meas.forwardPredictedState().localError().positionError().yy() + hit->localPositionError().yy();
+
+            tracker_forwardchi2 +=
+                (residualx * residualx + residualy * residualy) / (errorxx2 + 2. * errorxy2 + erroryy2);
+            tracker_dof += 2.;
+          }
+        }  // end if a tracker hit
+
+        if (hit->isValid() && id.det() == DetId::Muon &&
+            (id.subdetId() == MuonSubdetId::DT || id.subdetId() == MuonSubdetId::CSC)) {
+          TrajectoryStateOnSurface tsosc =
+              tsoscomb.combine(meas.forwardPredictedState(), meas.backwardPredictedState());
+          double residual = tsosc.localPosition().x() - hit->localPosition().x();
+          m_resid_before->Fill(residual);
+          if (fabs(residual) > m_maxMuonResidual) {
+            has_bad_residual = true;
+          }
+        }  // end if a muon hit
       }
+      tracker_dof -= 5.;
+      double tracker_forwardredchi2 = tracker_forwardchi2 / tracker_dof;
 
-      if ((*(*iPair).val).pt() > m_minPt) {
+      if (m_hists) {
+        m_tracker_forwardredchi2->Fill(tracker_forwardredchi2);
+        m_tracker_dof->Fill(tracker_dof);
 
-	 std::vector<TrajectoryMeasurement> measurements = (*(*iPair).key).measurements();
+        for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin(); im != measurements.end();
+             ++im) {
+          const TrajectoryMeasurement meas = *im;
+          auto hit = &(*meas.recHit());
+          const DetId id = hit->geographicalId();
 
-	 bool has_bad_residual = false;
+          if (!has_bad_residual) {
+            if (hit->isValid() && id.det() == DetId::Muon &&
+                (id.subdetId() == MuonSubdetId::DT || id.subdetId() == MuonSubdetId::CSC)) {
+              TrajectoryStateOnSurface tsosc =
+                  tsoscomb.combine(meas.forwardPredictedState(), meas.backwardPredictedState());
+              double residual = tsosc.localPosition().x() - hit->localPosition().x();
+              m_resid_after->Fill(residual);
+            }
+          }  // end if residuals pass cut
+        }    // end second loop over hits
+      }      // end if filling histograms
 
-	 double tracker_forwardchi2 = 0.;
-	 double tracker_dof = 0.;
-	 for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin();  im != measurements.end();  ++im) {
-	    const TrajectoryMeasurement meas = *im;
-	    auto hit = &(*meas.recHit());
-	    const DetId id = hit->geographicalId();
+      if (tracker_forwardredchi2 < m_maxTrackerForwardRedChi2 && tracker_dof >= m_minTrackerDOF && !has_bad_residual) {
+        newTrajTrackMap->insert((*iPair).key, (*iPair).val);
+      }  // end if passes tracker cuts
+    }    // end if passes pT cut
+  }      // end loop over original trajTrackMap
 
-	    if (hit->isValid()  &&  id.det() == DetId::Tracker) {
-	       if (hit->dimension() == 1) {
-		  double residual = meas.forwardPredictedState().localPosition().x() - hit->localPosition().x();
-		  double error2 = meas.forwardPredictedState().localError().positionError().xx() + hit->localPositionError().xx();
-
-		  tracker_forwardchi2 += residual * residual / error2;
-		  tracker_dof += 1.;
-	       }
-	       else if (hit->dimension() == 2) {
-		  double residualx = meas.forwardPredictedState().localPosition().x() - hit->localPosition().x();
-		  double residualy = meas.forwardPredictedState().localPosition().y() - hit->localPosition().y();
-		  double errorxx2 = meas.forwardPredictedState().localError().positionError().xx() + hit->localPositionError().xx();
-		  double errorxy2 = meas.forwardPredictedState().localError().positionError().xy() + hit->localPositionError().xy();
-		  double erroryy2 = meas.forwardPredictedState().localError().positionError().yy() + hit->localPositionError().yy();
-
-		  tracker_forwardchi2 += (residualx * residualx + residualy * residualy) / (errorxx2 + 2.*errorxy2 + erroryy2);
-		  tracker_dof += 2.;
-	       }
-	    } // end if a tracker hit
-
-	    if (hit->isValid()  &&  id.det() == DetId::Muon  &&  (id.subdetId() == MuonSubdetId::DT  ||  id.subdetId() == MuonSubdetId::CSC)) {
-	       TrajectoryStateOnSurface tsosc = tsoscomb.combine(meas.forwardPredictedState(), meas.backwardPredictedState());
-	       double residual = tsosc.localPosition().x() - hit->localPosition().x();
-	       m_resid_before->Fill(residual);
-	       if (fabs(residual) > m_maxMuonResidual) {
-		  has_bad_residual = true;
-	       }
-	    } // end if a muon hit
-
-	 }
-	 tracker_dof -= 5.;
-	 double tracker_forwardredchi2 = tracker_forwardchi2 / tracker_dof;
-
-	 if (m_hists) {
-	    m_tracker_forwardredchi2->Fill(tracker_forwardredchi2);
-	    m_tracker_dof->Fill(tracker_dof);
-
-	    for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin();  im != measurements.end();  ++im) {
-	       const TrajectoryMeasurement meas = *im;
-	       auto hit = &(*meas.recHit());
-	       const DetId id = hit->geographicalId();
-
-	       if (!has_bad_residual) {
-		  if (hit->isValid()  &&  id.det() == DetId::Muon  &&  (id.subdetId() == MuonSubdetId::DT  ||  id.subdetId() == MuonSubdetId::CSC)) {
-		     TrajectoryStateOnSurface tsosc = tsoscomb.combine(meas.forwardPredictedState(), meas.backwardPredictedState());
-		     double residual = tsosc.localPosition().x() - hit->localPosition().x();
-		     m_resid_after->Fill(residual);
-		  }
-	       } // end if residuals pass cut
-	    } // end second loop over hits
-	 } // end if filling histograms
-
-	 if (tracker_forwardredchi2 < m_maxTrackerForwardRedChi2  &&  tracker_dof >= m_minTrackerDOF  &&  !has_bad_residual) {
-	    newTrajTrackMap->insert((*iPair).key, (*iPair).val);
-	 } // end if passes tracker cuts
-      } // end if passes pT cut
-   } // end loop over original trajTrackMap
-
-   // put it in the Event
-   iEvent.put(std::move(newTrajTrackMap));
+  // put it in the Event
+  iEvent.put(std::move(newTrajTrackMap));
 }
 
 //define this as a plug-in

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentMuonSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentMuonSelectorModule.cc
@@ -24,35 +24,30 @@
 // tracks have only the recoMuons branch!
 
 struct MuonConfigSelector {
-
-  typedef std::vector<const reco::Muon*> container;
+  typedef std::vector<const reco::Muon *> container;
   typedef container::const_iterator const_iterator;
   typedef reco::MuonCollection collection;
 
-  MuonConfigSelector( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-    theSelector(cfg) {}
+  MuonConfigSelector(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC) : theSelector(cfg) {}
 
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
   size_t size() const { return selected_.size(); }
 
-  void select( const edm::Handle<reco::MuonCollection> & c,  const edm::Event & evt, const edm::EventSetup &/* dummy*/)
-  {
+  void select(const edm::Handle<reco::MuonCollection> &c, const edm::Event &evt, const edm::EventSetup & /* dummy*/) {
     all_.clear();
     selected_.clear();
-    for (collection::const_iterator i = c.product()->begin(), iE = c.product()->end();
-         i != iE; ++i){
-      all_.push_back(& * i );
+    for (collection::const_iterator i = c.product()->begin(), iE = c.product()->end(); i != iE; ++i) {
+      all_.push_back(&*i);
     }
-    selected_ = theSelector.select(all_, evt); // might add dummy
+    selected_ = theSelector.select(all_, evt);  // might add dummy
   }
 
 private:
-  container all_,selected_;
+  container all_, selected_;
   AlignmentMuonSelector theSelector;
 };
 
-typedef ObjectSelector<MuonConfigSelector>  AlignmentMuonSelectorModule;
+typedef ObjectSelector<MuonConfigSelector> AlignmentMuonSelectorModule;
 
-DEFINE_FWK_MODULE( AlignmentMuonSelectorModule );
-
+DEFINE_FWK_MODULE(AlignmentMuonSelectorModule);

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.cc
@@ -2,7 +2,6 @@
 ///
 ///  \author    : Frederic Ronga
 
-
 #include "AlignmentProducer.h"
 
 #include "FWCore/Framework/interface/LooperFactory.h"
@@ -10,12 +9,9 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
-
 //------------------------------------------------------------------------------
-AlignmentProducer::AlignmentProducer(const edm::ParameterSet& config) :
-  AlignmentProducerBase{config},
-  maxLoops_{config.getUntrackedParameter<unsigned int>("maxLoops")}
-{
+AlignmentProducer::AlignmentProducer(const edm::ParameterSet &config)
+    : AlignmentProducerBase{config}, maxLoops_{config.getUntrackedParameter<unsigned int>("maxLoops")} {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::AlignmentProducer";
 
   // Tell the framework what data is being produced
@@ -28,130 +24,93 @@ AlignmentProducer::AlignmentProducer(const edm::ParameterSet& config) :
   }
 }
 
-
 //------------------------------------------------------------------------------
-std::shared_ptr<TrackerGeometry>
-AlignmentProducer::produceTracker(const TrackerDigiGeometryRecord&)
-{
+std::shared_ptr<TrackerGeometry> AlignmentProducer::produceTracker(const TrackerDigiGeometryRecord &) {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::produceTracker";
   return trackerGeometry_;
 }
 
-
 //------------------------------------------------------------------------------
-std::shared_ptr<DTGeometry>
-AlignmentProducer::produceDT(const MuonGeometryRecord&)
-{
+std::shared_ptr<DTGeometry> AlignmentProducer::produceDT(const MuonGeometryRecord &) {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::produceDT";
   return muonDTGeometry_;
 }
 
-
 //------------------------------------------------------------------------------
-std::shared_ptr<CSCGeometry>
-AlignmentProducer::produceCSC(const MuonGeometryRecord&)
-{
+std::shared_ptr<CSCGeometry> AlignmentProducer::produceCSC(const MuonGeometryRecord &) {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::produceCSC";
   return muonCSCGeometry_;
 }
 
-
 //------------------------------------------------------------------------------
-void AlignmentProducer::beginOfJob(const edm::EventSetup& iSetup)
-{
+void AlignmentProducer::beginOfJob(const edm::EventSetup &iSetup) {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::beginOfJob";
   initAlignmentAlgorithm(iSetup);
 }
 
-
 //------------------------------------------------------------------------------
-void AlignmentProducer::endOfJob()
-{
+void AlignmentProducer::endOfJob() {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::endOfJob";
 
   if (!finish()) {
-    edm::LogError("Alignment")
-      << "@SUB=AlignmentProducer::endOfJob"
-      << "Did not process any events in last loop, do not dare to store to DB.";
+    edm::LogError("Alignment") << "@SUB=AlignmentProducer::endOfJob"
+                               << "Did not process any events in last loop, do not dare to store to DB.";
   }
 }
 
-
 //------------------------------------------------------------------------------
-void AlignmentProducer::startingNewLoop(unsigned int iLoop)
-{
+void AlignmentProducer::startingNewLoop(unsigned int iLoop) {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::startingNewLoop"
                             << "Starting loop number " << iLoop;
   startProcessing();
 }
 
-
 //------------------------------------------------------------------------------
-edm::EDLooper::Status
-AlignmentProducer::endOfLoop(const edm::EventSetup& iSetup, unsigned int iLoop)
-{
-
+edm::EDLooper::Status AlignmentProducer::endOfLoop(const edm::EventSetup &iSetup, unsigned int iLoop) {
   if (0 == nEvent()) {
     // beginOfJob is usually called by the framework in the first event of the first loop
     // (a hack: beginOfJob needs the EventSetup that is not well defined without an event)
     // and the algorithms rely on the initialisations done in beginOfJob. We cannot call
     // this->beginOfJob(iSetup); here either since that will access the EventSetup to get
     // some geometry information that is not defined either without having seen an event.
-    edm::LogError("Alignment")
-      << "@SUB=AlignmentProducer::endOfLoop"
-      << "Did not process any events in loop " << iLoop
-      << ", stop processing without terminating algorithm.";
+    edm::LogError("Alignment") << "@SUB=AlignmentProducer::endOfLoop"
+                               << "Did not process any events in loop " << iLoop
+                               << ", stop processing without terminating algorithm.";
     return kStop;
   }
 
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducer::endOfLoop"
-    << "Ending loop " << iLoop << ", terminating algorithm.";
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducer::endOfLoop"
+                            << "Ending loop " << iLoop << ", terminating algorithm.";
   terminateProcessing(&iSetup);
 
-  if ( iLoop == maxLoops_-1 || iLoop >= maxLoops_ ) return kStop;
-  else return kContinue;
+  if (iLoop == maxLoops_ - 1 || iLoop >= maxLoops_)
+    return kStop;
+  else
+    return kContinue;
 }
 
-
 //------------------------------------------------------------------------------
-edm::EDLooper::Status
-AlignmentProducer::duringLoop(const edm::Event& event,
-                              const edm::EventSetup& setup)
-{
-  if (processEvent(event, setup)) return kContinue;
-  else return kStop;
+edm::EDLooper::Status AlignmentProducer::duringLoop(const edm::Event &event, const edm::EventSetup &setup) {
+  if (processEvent(event, setup))
+    return kContinue;
+  else
+    return kStop;
 }
 
+//------------------------------------------------------------------------------
+void AlignmentProducer::beginRun(const edm::Run &run, const edm::EventSetup &setup) { beginRunImpl(run, setup); }
 
 //------------------------------------------------------------------------------
-void AlignmentProducer::beginRun(const edm::Run &run, const edm::EventSetup &setup)
-{
-  beginRunImpl(run, setup);
-}
-
+void AlignmentProducer::endRun(const edm::Run &run, const edm::EventSetup &setup) { endRunImpl(run, setup); }
 
 //------------------------------------------------------------------------------
-void AlignmentProducer::endRun(const edm::Run &run, const edm::EventSetup &setup)
-{
-  endRunImpl(run, setup);
-}
-
-
-//------------------------------------------------------------------------------
-void AlignmentProducer::beginLuminosityBlock(const edm::LuminosityBlock &lumiBlock,
-                                             const edm::EventSetup &setup)
-{
+void AlignmentProducer::beginLuminosityBlock(const edm::LuminosityBlock &lumiBlock, const edm::EventSetup &setup) {
   beginLuminosityBlockImpl(lumiBlock, setup);
 }
 
-
 //------------------------------------------------------------------------------
-void AlignmentProducer::endLuminosityBlock(const edm::LuminosityBlock &lumiBlock,
-                                           const edm::EventSetup &setup)
-{
+void AlignmentProducer::endLuminosityBlock(const edm::LuminosityBlock &lumiBlock, const edm::EventSetup &setup) {
   endLuminosityBlockImpl(lumiBlock, setup);
 }
-
 
 DEFINE_FWK_LOOPER(AlignmentProducer);

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducer.h
@@ -8,17 +8,12 @@
 ///
 ///  \author    : Frederic Ronga
 
-
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h"
 #include "FWCore/Framework/interface/ESProducerLooper.h"
 #include "FWCore/Framework/interface/Run.h"
 
-
-class AlignmentProducer : public AlignmentProducerBase, public edm::ESProducerLooper
-{
-
+class AlignmentProducer : public AlignmentProducerBase, public edm::ESProducerLooper {
 public:
-
   /// Constructor
   AlignmentProducer(const edm::ParameterSet&);
 
@@ -53,73 +48,48 @@ public:
   void endRun(const edm::Run&, const edm::EventSetup&) override;
 
   /// Called at lumi block start, calling algorithm's beginLuminosityBlock
-  void beginLuminosityBlock(const edm::LuminosityBlock&,
-                                    const edm::EventSetup&) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
   /// Called at lumi block end, calling algorithm's endLuminosityBlock
-  void endLuminosityBlock(const edm::LuminosityBlock&,
-                                  const edm::EventSetup&) override;
+  void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
   /// Called at each event
   Status duringLoop(const edm::Event&, const edm::EventSetup&) override;
 
 private:
-  bool getTrajTrackAssociationCollection(const edm::Event&,
-                                                 edm::Handle<TrajTrackAssociationCollection>&) override;
+  bool getTrajTrackAssociationCollection(const edm::Event&, edm::Handle<TrajTrackAssociationCollection>&) override;
   bool getBeamSpot(const edm::Event&, edm::Handle<reco::BeamSpot>&) override;
-  bool getTkFittedLasBeamCollection(const edm::Run&,
-                                            edm::Handle<TkFittedLasBeamCollection>&) override;
-  bool getTsosVectorCollection(const edm::Run&,
-                                       edm::Handle<TsosVectorCollection>&) override;
-  bool getAliClusterValueMap(const edm::Event&,
-                                     edm::Handle<AliClusterValueMap>&) override;
+  bool getTkFittedLasBeamCollection(const edm::Run&, edm::Handle<TkFittedLasBeamCollection>&) override;
+  bool getTsosVectorCollection(const edm::Run&, edm::Handle<TsosVectorCollection>&) override;
+  bool getAliClusterValueMap(const edm::Event&, edm::Handle<AliClusterValueMap>&) override;
 
-  const unsigned int maxLoops_;     /// Number of loops to loop
-
+  const unsigned int maxLoops_;  /// Number of loops to loop
 };
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducer::getTrajTrackAssociationCollection(const edm::Event& event,
-                                                     edm::Handle<TrajTrackAssociationCollection>& result) {
+inline bool AlignmentProducer::getTrajTrackAssociationCollection(const edm::Event& event,
+                                                                 edm::Handle<TrajTrackAssociationCollection>& result) {
   return event.getByLabel(tjTkAssociationMapTag_, result);
 }
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducer::getBeamSpot(const edm::Event& event,
-                               edm::Handle<reco::BeamSpot>& result) {
+inline bool AlignmentProducer::getBeamSpot(const edm::Event& event, edm::Handle<reco::BeamSpot>& result) {
   return event.getByLabel(beamSpotTag_, result);
 }
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducer::getTkFittedLasBeamCollection(const edm::Run& run,
-                                                edm::Handle<TkFittedLasBeamCollection>& result) {
+inline bool AlignmentProducer::getTkFittedLasBeamCollection(const edm::Run& run,
+                                                            edm::Handle<TkFittedLasBeamCollection>& result) {
   return run.getByLabel(tkLasBeamTag_, result);
 }
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducer::getTsosVectorCollection(const edm::Run& run,
-                                           edm::Handle<TsosVectorCollection>& result) {
+inline bool AlignmentProducer::getTsosVectorCollection(const edm::Run& run, edm::Handle<TsosVectorCollection>& result) {
   return run.getByLabel(tkLasBeamTag_, result);
 }
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducer::getAliClusterValueMap(const edm::Event& event,
-                                         edm::Handle<AliClusterValueMap>& result) {
+inline bool AlignmentProducer::getAliClusterValueMap(const edm::Event& event, edm::Handle<AliClusterValueMap>& result) {
   return event.getByLabel(clusterValueMapTag_, result);
 }
 

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducerAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducerAsAnalyzer.cc
@@ -6,20 +6,15 @@
  * @date      2015/07/16
  */
 
-
-
 /*** Header file ***/
 #include "AlignmentProducerAsAnalyzer.h"
 
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
-
 //------------------------------------------------------------------------------
-AlignmentProducerAsAnalyzer::AlignmentProducerAsAnalyzer(const edm::ParameterSet& config) :
-  AlignmentProducerBase{config}
-{
+AlignmentProducerAsAnalyzer::AlignmentProducerAsAnalyzer(const edm::ParameterSet& config)
+    : AlignmentProducerBase{config} {
   usesResource(TFileService::kSharedResource);
 
   tjTkAssociationMapToken_ = consumes<TrajTrackAssociationCollection>(tjTkAssociationMapTag_);
@@ -29,72 +24,45 @@ AlignmentProducerAsAnalyzer::AlignmentProducerAsAnalyzer(const edm::ParameterSet
   clusterValueMapToken_ = consumes<AliClusterValueMap>(clusterValueMapTag_);
 }
 
+//------------------------------------------------------------------------------
+void AlignmentProducerAsAnalyzer::beginJob() {}
 
 //------------------------------------------------------------------------------
-void
-AlignmentProducerAsAnalyzer::beginJob()
-{
-}
-
-
-//------------------------------------------------------------------------------
-void
-AlignmentProducerAsAnalyzer::endJob()
-{
+void AlignmentProducerAsAnalyzer::endJob() {
   terminateProcessing();
   if (!finish()) {
-    edm::LogError("Alignment")
-      << "@SUB=AlignmentProducerAsAnalyzer::endJob"
-      << "Did not process any events, do not dare to store to DB.";
+    edm::LogError("Alignment") << "@SUB=AlignmentProducerAsAnalyzer::endJob"
+                               << "Did not process any events, do not dare to store to DB.";
   }
 
   // message is used by the MillePede log parser to check the end of the job
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerAsAnalyzer::endJob"
-    << "Finished alignment producer job.";
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerAsAnalyzer::endJob"
+                            << "Finished alignment producer job.";
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerAsAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& setup)
-{
+void AlignmentProducerAsAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
   beginRunImpl(run, setup);
 }
 
+//------------------------------------------------------------------------------
+void AlignmentProducerAsAnalyzer::endRun(const edm::Run& run, const edm::EventSetup& setup) { endRunImpl(run, setup); }
 
 //------------------------------------------------------------------------------
-void
-AlignmentProducerAsAnalyzer::endRun(const edm::Run& run, const edm::EventSetup& setup)
-{
-  endRunImpl(run, setup);
-}
-
-
-//------------------------------------------------------------------------------
-void
-AlignmentProducerAsAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock,
-                                           const edm::EventSetup& setup)
-{
+void AlignmentProducerAsAnalyzer::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock,
+                                                       const edm::EventSetup& setup) {
   beginLuminosityBlockImpl(lumiBlock, setup);
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerAsAnalyzer::endLuminosityBlock(const edm::LuminosityBlock& lumiBlock,
-                                         const edm::EventSetup& setup)
-{
+void AlignmentProducerAsAnalyzer::endLuminosityBlock(const edm::LuminosityBlock& lumiBlock,
+                                                     const edm::EventSetup& setup) {
   endLuminosityBlockImpl(lumiBlock, setup);
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerAsAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
+void AlignmentProducerAsAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   processEvent(event, setup);
 }
-
 
 DEFINE_FWK_MODULE(AlignmentProducerAsAnalyzer);

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentProducerAsAnalyzer.h
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentProducerAsAnalyzer.h
@@ -19,21 +19,15 @@
  *
  */
 
-
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Run.h"
 
-
-class AlignmentProducerAsAnalyzer :
-  public AlignmentProducerBase,
-  public edm::one::EDAnalyzer<edm::one::WatchRuns,
-                              edm::one::WatchLuminosityBlocks,
-                              edm::one::SharedResources>
-{
+class AlignmentProducerAsAnalyzer
+    : public AlignmentProducerBase,
+      public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks, edm::one::SharedResources> {
   //========================== PUBLIC METHODS ==================================
-public: //====================================================================
-
+public:  //====================================================================
   /// Constructor
   AlignmentProducerAsAnalyzer(const edm::ParameterSet&);
 
@@ -49,74 +43,51 @@ public: //====================================================================
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void endRun(const edm::Run&, const edm::EventSetup&) override;
 
-  void beginLuminosityBlock(const edm::LuminosityBlock&,
-                                    const edm::EventSetup&) override;
-  void endLuminosityBlock(const edm::LuminosityBlock&,
-                                  const edm::EventSetup&) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
-  bool getTrajTrackAssociationCollection(const edm::Event&,
-                                                 edm::Handle<TrajTrackAssociationCollection>&) override;
+  bool getTrajTrackAssociationCollection(const edm::Event&, edm::Handle<TrajTrackAssociationCollection>&) override;
   bool getBeamSpot(const edm::Event&, edm::Handle<reco::BeamSpot>&) override;
-  bool getTkFittedLasBeamCollection(const edm::Run&,
-                                            edm::Handle<TkFittedLasBeamCollection>&) override;
-  bool getTsosVectorCollection(const edm::Run&,
-                                       edm::Handle<TsosVectorCollection>&) override;
-  bool getAliClusterValueMap(const edm::Event&,
-                                     edm::Handle<AliClusterValueMap>&) override;
+  bool getTkFittedLasBeamCollection(const edm::Run&, edm::Handle<TkFittedLasBeamCollection>&) override;
+  bool getTsosVectorCollection(const edm::Run&, edm::Handle<TsosVectorCollection>&) override;
+  bool getAliClusterValueMap(const edm::Event&, edm::Handle<AliClusterValueMap>&) override;
 
   edm::EDGetTokenT<TrajTrackAssociationCollection> tjTkAssociationMapToken_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
   edm::EDGetTokenT<TkFittedLasBeamCollection> tkLasBeamToken_;
   edm::EDGetTokenT<TsosVectorCollection> tsosVectorToken_;
   edm::EDGetTokenT<AliClusterValueMap> clusterValueMapToken_;
-
 };
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducerAsAnalyzer::getTrajTrackAssociationCollection(const edm::Event& event,
-                                                               edm::Handle<TrajTrackAssociationCollection>& result) {
+inline bool AlignmentProducerAsAnalyzer::getTrajTrackAssociationCollection(
+    const edm::Event& event, edm::Handle<TrajTrackAssociationCollection>& result) {
   return event.getByToken(tjTkAssociationMapToken_, result);
 }
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducerAsAnalyzer::getBeamSpot(const edm::Event& event,
-                                         edm::Handle<reco::BeamSpot>& result) {
+inline bool AlignmentProducerAsAnalyzer::getBeamSpot(const edm::Event& event, edm::Handle<reco::BeamSpot>& result) {
   return event.getByToken(beamSpotToken_, result);
 }
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducerAsAnalyzer::getTkFittedLasBeamCollection(const edm::Run& run,
-                                                          edm::Handle<TkFittedLasBeamCollection>& result) {
+inline bool AlignmentProducerAsAnalyzer::getTkFittedLasBeamCollection(const edm::Run& run,
+                                                                      edm::Handle<TkFittedLasBeamCollection>& result) {
   return run.getByToken(tkLasBeamToken_, result);
 }
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducerAsAnalyzer::getTsosVectorCollection(const edm::Run& run,
-                                                     edm::Handle<TsosVectorCollection>& result) {
+inline bool AlignmentProducerAsAnalyzer::getTsosVectorCollection(const edm::Run& run,
+                                                                 edm::Handle<TsosVectorCollection>& result) {
   return run.getByToken(tsosVectorToken_, result);
 }
 
-
 //------------------------------------------------------------------------------
-inline
-bool
-AlignmentProducerAsAnalyzer::getAliClusterValueMap(const edm::Event& event,
-                                                   edm::Handle<AliClusterValueMap>& result) {
+inline bool AlignmentProducerAsAnalyzer::getAliClusterValueMap(const edm::Event& event,
+                                                               edm::Handle<AliClusterValueMap>& result) {
   return event.getByToken(clusterValueMapToken_, result);
 }
 

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentSeedSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentSeedSelectorModule.cc
@@ -6,35 +6,30 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 struct SeedConfigSelector {
-
-  typedef std::vector<const TrajectorySeed*> container;
+  typedef std::vector<const TrajectorySeed *> container;
   typedef container::const_iterator const_iterator;
   typedef TrajectorySeedCollection collection;
 
-  SeedConfigSelector( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-    theSelector(cfg) {}
+  SeedConfigSelector(const edm::ParameterSet &cfg, edm::ConsumesCollector &&iC) : theSelector(cfg) {}
 
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
   size_t size() const { return selected_.size(); }
 
-  void select( const edm::Handle<TrajectorySeedCollection> c,  const edm::Event & evt,
-               const edm::EventSetup &/*dummy*/)
-  {
+  void select(const edm::Handle<TrajectorySeedCollection> c, const edm::Event &evt, const edm::EventSetup & /*dummy*/) {
     all_.clear();
     selected_.clear();
-    for (collection::const_iterator i = c.product()->begin(), iE = c.product()->end();
-         i != iE; ++i) {
-      all_.push_back( & * i );
+    for (collection::const_iterator i = c.product()->begin(), iE = c.product()->end(); i != iE; ++i) {
+      all_.push_back(&*i);
     }
-    selected_ = theSelector.select(all_, evt); // might add dummy...
+    selected_ = theSelector.select(all_, evt);  // might add dummy...
   }
 
 private:
-  container all_,selected_;
+  container all_, selected_;
   AlignmentSeedSelector theSelector;
 };
 
-typedef ObjectSelector<SeedConfigSelector>  AlignmentSeedSelectorModule;
+typedef ObjectSelector<SeedConfigSelector> AlignmentSeedSelectorModule;
 
-DEFINE_FWK_MODULE( AlignmentSeedSelectorModule );
+DEFINE_FWK_MODULE(AlignmentSeedSelectorModule);

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentTrackSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentTrackSelectorModule.cc
@@ -17,20 +17,18 @@
 #include "CommonTools/RecoAlgos/interface/TrackSelector.h"
 
 struct TrackConfigSelector {
-
   typedef std::vector<const reco::Track*> container;
   typedef container::const_iterator const_iterator;
   typedef reco::TrackCollection collection;
 
- TrackConfigSelector( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-   theBaseSelector(cfg, iC),
-   theGlobalSelector(cfg.getParameter<edm::ParameterSet>("GlobalSelector"), iC),
-   theTwoBodyDecaySelector(cfg.getParameter<edm::ParameterSet>("TwoBodyDecaySelector"), iC)
-  {
+  TrackConfigSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : theBaseSelector(cfg, iC),
+        theGlobalSelector(cfg.getParameter<edm::ParameterSet>("GlobalSelector"), iC),
+        theTwoBodyDecaySelector(cfg.getParameter<edm::ParameterSet>("TwoBodyDecaySelector"), iC) {
     //TODO Wrap the BaseSelector into its own PSet
     theBaseSwitch = theBaseSelector.useThisFilter();
 
-    theGlobalSwitch =  theGlobalSelector.useThisFilter();
+    theGlobalSwitch = theGlobalSelector.useThisFilter();
 
     theTwoBodyDecaySwitch = theTwoBodyDecaySelector.useThisFilter();
   }
@@ -39,20 +37,18 @@ struct TrackConfigSelector {
   const_iterator end() const { return theSelectedTracks.end(); }
   size_t size() const { return theSelectedTracks.size(); }
 
-  void select( const edm::Handle<reco::TrackCollection> & c,  const edm::Event & evt,
-               const edm::EventSetup& eSetup)
-  {
+  void select(const edm::Handle<reco::TrackCollection>& c, const edm::Event& evt, const edm::EventSetup& eSetup) {
     theSelectedTracks.clear();
-    for( reco::TrackCollection::const_iterator i=c.product()->begin();i!=c.product()->end();++i){
-      theSelectedTracks.push_back(& * i );
+    for (reco::TrackCollection::const_iterator i = c.product()->begin(); i != c.product()->end(); ++i) {
+      theSelectedTracks.push_back(&*i);
     }
     // might add EvetSetup to the select(...) method of the Selectors
-    if(theBaseSwitch)
-      theSelectedTracks=theBaseSelector.select(theSelectedTracks,evt,eSetup);
-    if(theGlobalSwitch)
-      theSelectedTracks=theGlobalSelector.select(theSelectedTracks,evt,eSetup);
-    if(theTwoBodyDecaySwitch)
-      theSelectedTracks=theTwoBodyDecaySelector.select(theSelectedTracks,evt,eSetup);
+    if (theBaseSwitch)
+      theSelectedTracks = theBaseSelector.select(theSelectedTracks, evt, eSetup);
+    if (theGlobalSwitch)
+      theSelectedTracks = theGlobalSelector.select(theSelectedTracks, evt, eSetup);
+    if (theTwoBodyDecaySwitch)
+      theSelectedTracks = theTwoBodyDecaySelector.select(theSelectedTracks, evt, eSetup);
   }
 
 private:
@@ -62,9 +58,8 @@ private:
   AlignmentTrackSelector theBaseSelector;
   AlignmentGlobalTrackSelector theGlobalSelector;
   AlignmentTwoBodyDecayTrackSelector theTwoBodyDecaySelector;
-
 };
 
-typedef ObjectSelectorStream<TrackConfigSelector>  AlignmentTrackSelectorModule;
+typedef ObjectSelectorStream<TrackConfigSelector> AlignmentTrackSelectorModule;
 
-DEFINE_FWK_MODULE( AlignmentTrackSelectorModule );
+DEFINE_FWK_MODULE(AlignmentTrackSelectorModule);

--- a/Alignment/CommonAlignmentProducer/plugins/FakeAlignmentProducer.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/FakeAlignmentProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    FakeAlignmentProducer
 // Class:      FakeAlignmentProducer
-// 
+//
 /**\class FakeAlignmentProducer FakeAlignmentProducer.h Alignment/FakeAlignmentProducer/interface/FakeAlignmentProducer.h
 
 Description: Producer of fake alignment data for all geometries (currently: Tracker, DT and CSC)
@@ -19,7 +19,6 @@ reconstruction Geometry should notice that and not pass to GeometryAligner.
 //
 //
 
-
 // System
 #include <memory>
 
@@ -27,8 +26,6 @@ reconstruction Geometry should notice that and not pass to GeometryAligner.
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-
 
 // Alignment
 #include "CondFormats/Alignment/interface/Alignments.h"
@@ -46,14 +43,10 @@ public:
   FakeAlignmentProducer(const edm::ParameterSet&);
   ~FakeAlignmentProducer() override {}
 
-  std::unique_ptr<Alignments>
-  produceTkAli(const TrackerAlignmentRcd&) { return std::make_unique<Alignments>();}
-  std::unique_ptr<Alignments> 
-  produceDTAli(const DTAlignmentRcd&) { return std::make_unique<Alignments>();}
-  std::unique_ptr<Alignments>
-  produceCSCAli(const CSCAlignmentRcd&)  { return std::make_unique<Alignments>();}
-  std::unique_ptr<Alignments>
-  produceGlobals(const GlobalPositionRcd&) {return std::make_unique<Alignments>();}
+  std::unique_ptr<Alignments> produceTkAli(const TrackerAlignmentRcd&) { return std::make_unique<Alignments>(); }
+  std::unique_ptr<Alignments> produceDTAli(const DTAlignmentRcd&) { return std::make_unique<Alignments>(); }
+  std::unique_ptr<Alignments> produceCSCAli(const CSCAlignmentRcd&) { return std::make_unique<Alignments>(); }
+  std::unique_ptr<Alignments> produceGlobals(const GlobalPositionRcd&) { return std::make_unique<Alignments>(); }
 
   std::unique_ptr<AlignmentErrorsExtended> produceTkAliErr(const TrackerAlignmentErrorExtendedRcd&) {
     return std::make_unique<AlignmentErrorsExtended>();
@@ -64,28 +57,24 @@ public:
   std::unique_ptr<AlignmentErrorsExtended> produceCSCAliErr(const CSCAlignmentErrorExtendedRcd&) {
     return std::make_unique<AlignmentErrorsExtended>();
   }
-
 };
 
-FakeAlignmentProducer::FakeAlignmentProducer(const edm::ParameterSet& iConfig) 
-{
+FakeAlignmentProducer::FakeAlignmentProducer(const edm::ParameterSet& iConfig) {
   // This 'appendToDataLabel' is used by the framework to distinguish providers
   // with different settings and to request a special one by e.g.
   // iSetup.get<TrackerDigiGeometryRecord>().get("theLabel", tkGeomHandle);
-  edm::LogInfo("Alignments") 
-    << "@SUB=FakeAlignmentProducer" << "Providing data with label '" 
-    << iConfig.getParameter<std::string>("appendToDataLabel") << "'.";
+  edm::LogInfo("Alignments") << "@SUB=FakeAlignmentProducer"
+                             << "Providing data with label '" << iConfig.getParameter<std::string>("appendToDataLabel")
+                             << "'.";
 
-  setWhatProduced( this, &FakeAlignmentProducer::produceTkAli );
-  setWhatProduced( this, &FakeAlignmentProducer::produceTkAliErr );
-  setWhatProduced( this, &FakeAlignmentProducer::produceDTAli );
-  setWhatProduced( this, &FakeAlignmentProducer::produceDTAliErr );
-  setWhatProduced( this, &FakeAlignmentProducer::produceCSCAli );
-  setWhatProduced( this, &FakeAlignmentProducer::produceCSCAliErr );
-  setWhatProduced( this, &FakeAlignmentProducer::produceGlobals );
-
+  setWhatProduced(this, &FakeAlignmentProducer::produceTkAli);
+  setWhatProduced(this, &FakeAlignmentProducer::produceTkAliErr);
+  setWhatProduced(this, &FakeAlignmentProducer::produceDTAli);
+  setWhatProduced(this, &FakeAlignmentProducer::produceDTAliErr);
+  setWhatProduced(this, &FakeAlignmentProducer::produceCSCAli);
+  setWhatProduced(this, &FakeAlignmentProducer::produceCSCAliErr);
+  setWhatProduced(this, &FakeAlignmentProducer::produceGlobals);
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(FakeAlignmentProducer);

--- a/Alignment/CommonAlignmentProducer/plugins/FakeAlignmentSource.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/FakeAlignmentSource.cc
@@ -2,7 +2,7 @@
 //
 // Package:    FakeAlignmentSource
 // Class:      FakeAlignmentSource
-// 
+//
 /**\class FakeAlignmentSource FakeAlignmentSource.cc Alignment/FakeAlignmentProducer/plugins/FakeAlignmentSource.cc
 
 Description: Producer of fake alignment data for all geometries (currently: Tracker, DT and CSC)
@@ -18,7 +18,6 @@ reconstruction Geometry should notice that and not pass to GeometryAligner.
 // $Id: FakeAlignmentSource.cc,v 1.2 2008/06/26 17:52:29 flucke Exp $
 //
 //
-
 
 // System
 #include <memory>
@@ -44,53 +43,44 @@ reconstruction Geometry should notice that and not pass to GeometryAligner.
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerSurfaceDeformationRcd.h"
 
-class FakeAlignmentSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
+class FakeAlignmentSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
   FakeAlignmentSource(const edm::ParameterSet&);
   ~FakeAlignmentSource() override {}
 
   /// Tracker and its APE
-  std::unique_ptr<Alignments> produceTkAli(const TrackerAlignmentRcd&) {
-    return std::make_unique<Alignments>();
-  }
-  std::unique_ptr<AlignmentErrorsExtended> produceTkAliErr(const TrackerAlignmentErrorExtendedRcd&) { 
+  std::unique_ptr<Alignments> produceTkAli(const TrackerAlignmentRcd&) { return std::make_unique<Alignments>(); }
+  std::unique_ptr<AlignmentErrorsExtended> produceTkAliErr(const TrackerAlignmentErrorExtendedRcd&) {
     return std::make_unique<AlignmentErrorsExtended>();
   }
 
   /// DT and its APE
-  std::unique_ptr<Alignments> produceDTAli(const DTAlignmentRcd&) {
-    return std::make_unique<Alignments>();
-  }
+  std::unique_ptr<Alignments> produceDTAli(const DTAlignmentRcd&) { return std::make_unique<Alignments>(); }
   std::unique_ptr<AlignmentErrorsExtended> produceDTAliErr(const DTAlignmentErrorExtendedRcd&) {
     return std::make_unique<AlignmentErrorsExtended>();
   }
 
   /// CSC and its APE
-  std::unique_ptr<Alignments> produceCSCAli(const CSCAlignmentRcd&) {
-    return std::make_unique<Alignments>();
-  }
+  std::unique_ptr<Alignments> produceCSCAli(const CSCAlignmentRcd&) { return std::make_unique<Alignments>(); }
   std::unique_ptr<AlignmentErrorsExtended> produceCSCAliErr(const CSCAlignmentErrorExtendedRcd&) {
     return std::make_unique<AlignmentErrorsExtended>();
   }
 
   /// GlobalPositions
-  std::unique_ptr<Alignments> produceGlobals(const GlobalPositionRcd&) {
-    return std::make_unique<Alignments>();
-  }
+  std::unique_ptr<Alignments> produceGlobals(const GlobalPositionRcd&) { return std::make_unique<Alignments>(); }
 
   /// Tracker surface deformations
-  std::unique_ptr<AlignmentSurfaceDeformations>
-  produceTrackerSurfaceDeformation(const TrackerSurfaceDeformationRcd&) {
+  std::unique_ptr<AlignmentSurfaceDeformations> produceTrackerSurfaceDeformation(const TrackerSurfaceDeformationRcd&) {
     return std::make_unique<AlignmentSurfaceDeformations>();
   }
 
- protected:
+protected:
   /// provide (dummy) IOV
-  void setIntervalFor( const edm::eventsetup::EventSetupRecordKey& /*dummy*/,
-			       const edm::IOVSyncValue& ioSyncVal, edm::ValidityInterval& iov) override;
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey& /*dummy*/,
+                      const edm::IOVSyncValue& ioSyncVal,
+                      edm::ValidityInterval& iov) override;
 
- private:
-
+private:
   bool produceTracker_;
   bool produceDT_;
   bool produceCSC_;
@@ -103,20 +93,19 @@ public:
 //________________________________________________________________________________________
 
 FakeAlignmentSource::FakeAlignmentSource(const edm::ParameterSet& iConfig)
-  :produceTracker_(iConfig.getParameter<bool>("produceTracker")),
-   produceDT_(iConfig.getParameter<bool>("produceDT")),
-   produceCSC_(iConfig.getParameter<bool>("produceCSC")),
-   produceGlobalPosition_(iConfig.getParameter<bool>("produceGlobalPosition")),
-   produceTrackerSurfaceDeformation_(iConfig.getParameter<bool>("produceTrackerSurfaceDeformation"))
-{
+    : produceTracker_(iConfig.getParameter<bool>("produceTracker")),
+      produceDT_(iConfig.getParameter<bool>("produceDT")),
+      produceCSC_(iConfig.getParameter<bool>("produceCSC")),
+      produceGlobalPosition_(iConfig.getParameter<bool>("produceGlobalPosition")),
+      produceTrackerSurfaceDeformation_(iConfig.getParameter<bool>("produceTrackerSurfaceDeformation")) {
   // This 'appendToDataLabel' is used by the framework to distinguish providers
   // with different settings and to request a special one by e.g.
   // iSetup.get<TrackerDigiGeometryRecord>().get("theLabel", tkGeomHandle);
-  
-  edm::LogInfo("Alignments") 
-    << "@SUB=FakeAlignmentSource" << "Providing data with label '" 
-    << iConfig.getParameter<std::string>("appendToDataLabel") << "'.";
-  
+
+  edm::LogInfo("Alignments") << "@SUB=FakeAlignmentSource"
+                             << "Providing data with label '" << iConfig.getParameter<std::string>("appendToDataLabel")
+                             << "'.";
+
   // Tell framework what data is produced by which method:
   if (produceTracker_) {
     this->setWhatProduced(this, &FakeAlignmentSource::produceTkAli);
@@ -158,10 +147,9 @@ FakeAlignmentSource::FakeAlignmentSource(const edm::ParameterSet& iConfig)
   }
 }
 
-void FakeAlignmentSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey& /*dummy*/, 
-					    const edm::IOVSyncValue& ioSyncVal, 
-					    edm::ValidityInterval& outValidity )
-{
+void FakeAlignmentSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& /*dummy*/,
+                                         const edm::IOVSyncValue& ioSyncVal,
+                                         edm::ValidityInterval& outValidity) {
   // Implementation copied from SiStripGainFakeESSource: unlimited IOV
   outValidity = edm::ValidityInterval(ioSyncVal.beginOfTime(), ioSyncVal.endOfTime());
 }

--- a/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
@@ -2,7 +2,7 @@
 //
 // Package:    GlobalTrackerMuonAlignment
 // Class:      GlobalTrackerMuonAlignment
-// 
+//
 /**\class GlobalTrackerMuonAlignment GlobalTrackerMuonAlignment.cc Alignment/GlobalTrackerMuonAlignment/src/GlobalTrackerMuonAlignment.cc
 
  Description: Producer of relative tracker and muon system alignment
@@ -63,7 +63,7 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/GeomPropagators/interface/SmartPropagator.h"
-#include "TrackingTools/GeomPropagators/interface/PropagationDirectionChooser.h" 
+#include "TrackingTools/GeomPropagators/interface/PropagationDirectionChooser.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackPropagation/RungeKutta/interface/defaultRKPropagator.h"
@@ -92,13 +92,13 @@
 #include <TH2.h>
 #include <TFile.h>
 
-#include<iostream>
-#include<cmath>
-#include<cassert>
-#include<fstream>
-#include<iomanip>
+#include <iostream>
+#include <cmath>
+#include <cassert>
+#include <fstream>
+#include <iomanip>
 
-using namespace edm; 
+using namespace edm;
 using namespace std;
 using namespace reco;
 
@@ -107,7 +107,7 @@ using namespace reco;
 //
 
 class GlobalTrackerMuonAlignment : public edm::EDAnalyzer {
- public:
+public:
   explicit GlobalTrackerMuonAlignment(const edm::ParameterSet&);
   ~GlobalTrackerMuonAlignment() override;
 
@@ -115,57 +115,62 @@ class GlobalTrackerMuonAlignment : public edm::EDAnalyzer {
   void analyzeTrackTrajectory(const edm::Event&, const edm::EventSetup&);
   void bookHist();
   void fitHist();
-  void trackFitter(reco::TrackRef, reco::TransientTrack&, PropagationDirection, 
-		  TrajectoryStateOnSurface&);
-  void muonFitter(reco::TrackRef, reco::TransientTrack&, PropagationDirection, 
-		  TrajectoryStateOnSurface&);
+  void trackFitter(reco::TrackRef, reco::TransientTrack&, PropagationDirection, TrajectoryStateOnSurface&);
+  void muonFitter(reco::TrackRef, reco::TransientTrack&, PropagationDirection, TrajectoryStateOnSurface&);
   void debugTrackHit(const std::string, reco::TrackRef);
   void debugTrackHit(const std::string, reco::TransientTrack&);
   void debugTrajectorySOS(const std::string, TrajectoryStateOnSurface&);
   void debugTrajectorySOSv(const std::string, TrajectoryStateOnSurface);
   void debugTrajectory(const std::string, Trajectory&);
 
-  void gradientGlobal(GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&, 
-		      GlobalVector&, AlgebraicSymMatrix66&);
-  void gradientLocal(GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&, 
-		     GlobalVector&, CLHEP::HepSymMatrix&, CLHEP::HepMatrix&, 
-		     CLHEP::HepVector&, AlgebraicVector4&);
-  void gradientGlobalAlg(GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&,  
-  			 AlgebraicSymMatrix66&);
-  void misalignMuon(GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&, 
-		    GlobalVector&, GlobalVector&);
-  void misalignMuonL(GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&, 
-		     GlobalVector&, GlobalVector&, AlgebraicVector4&, 
-		     TrajectoryStateOnSurface&, TrajectoryStateOnSurface&);
-  void writeGlPosRcd(CLHEP::HepVector& d3); 
-  inline double CLHEP_dot(const CLHEP::HepVector& a, const CLHEP::HepVector& b)
-  {
-    return a(1)*b(1)+a(2)*b(2)+a(3)*b(3);
+  void gradientGlobal(GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&, AlgebraicSymMatrix66&);
+  void gradientLocal(GlobalVector&,
+                     GlobalVector&,
+                     GlobalVector&,
+                     GlobalVector&,
+                     GlobalVector&,
+                     CLHEP::HepSymMatrix&,
+                     CLHEP::HepMatrix&,
+                     CLHEP::HepVector&,
+                     AlgebraicVector4&);
+  void gradientGlobalAlg(GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&, AlgebraicSymMatrix66&);
+  void misalignMuon(GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&, GlobalVector&);
+  void misalignMuonL(GlobalVector&,
+                     GlobalVector&,
+                     GlobalVector&,
+                     GlobalVector&,
+                     GlobalVector&,
+                     GlobalVector&,
+                     AlgebraicVector4&,
+                     TrajectoryStateOnSurface&,
+                     TrajectoryStateOnSurface&);
+  void writeGlPosRcd(CLHEP::HepVector& d3);
+  inline double CLHEP_dot(const CLHEP::HepVector& a, const CLHEP::HepVector& b) {
+    return a(1) * b(1) + a(2) * b(2) + a(3) * b(3);
   }
 
- private:
-
-  void beginJob() override ;
+private:
+  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
-  
+  void endJob() override;
+
   // ----------member data ---------------------------
 
-  edm::InputTag trackTags_;     // used to select what tracks to read from configuration file
-  edm::InputTag muonTags_;      // used to select what standalone muons
-  edm::InputTag gmuonTags_;     // used to select what global muons
-  edm::InputTag smuonTags_;     // used to select what selected muons
-  string propagator_;           // name of the propagator
-  bool cosmicMuonMode_;   
+  edm::InputTag trackTags_;  // used to select what tracks to read from configuration file
+  edm::InputTag muonTags_;   // used to select what standalone muons
+  edm::InputTag gmuonTags_;  // used to select what global muons
+  edm::InputTag smuonTags_;  // used to select what selected muons
+  string propagator_;        // name of the propagator
+  bool cosmicMuonMode_;
   bool isolatedMuonMode_;
-  bool collectionCosmic;        // if true, read muon collection expected for CosmicMu
-  bool collectionIsolated;      //                                            IsolateMu
-  bool refitMuon_;              // if true, refit stand alone muon track
-  bool refitTrack_;             //                tracker track
+  bool collectionCosmic;    // if true, read muon collection expected for CosmicMu
+  bool collectionIsolated;  //                                            IsolateMu
+  bool refitMuon_;          // if true, refit stand alone muon track
+  bool refitTrack_;         //                tracker track
   string rootOutFile_;
   string txtOutFile_;
-  bool writeDB_;                // write results to DB
-  bool debug_;                  // run in debugging mode
+  bool writeDB_;  // write results to DB
+  bool debug_;    // run in debugging mode
 
   edm::ESWatcher<GlobalTrackingGeometryRecord> watchTrackingGeometry_;
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
@@ -187,79 +192,75 @@ class GlobalTrackerMuonAlignment : public edm::EDAnalyzer {
   MuonTransientTrackingRecHitBuilder* MuRHBuilder;
   const TransientTrackingRecHitBuilder* TTRHBuilder;
 
-  //                            // LSF for global d(3):    Inf * d = Gfr 
-  AlgebraicVector3 Gfr;         // free terms 
-  AlgebraicSymMatrix33 Inf;     // information matrix 
-  //                            // LSF for global d(6):    Hess * d = Grad 
-  CLHEP::HepVector Grad;        // gradient of the objective function in global parameters
-  CLHEP::HepMatrix Hess;        // Hessian                  -- // ---     
+  //                            // LSF for global d(3):    Inf * d = Gfr
+  AlgebraicVector3 Gfr;      // free terms
+  AlgebraicSymMatrix33 Inf;  // information matrix
+  //                            // LSF for global d(6):    Hess * d = Grad
+  CLHEP::HepVector Grad;  // gradient of the objective function in global parameters
+  CLHEP::HepMatrix Hess;  // Hessian                  -- // ---
 
-  CLHEP::HepVector GradL;       // gradient of the objective function in local parameters
-  CLHEP::HepMatrix HessL;       // Hessian                  -- // ---     
+  CLHEP::HepVector GradL;  // gradient of the objective function in local parameters
+  CLHEP::HepMatrix HessL;  // Hessian                  -- // ---
 
-  int N_event;                  // processed events
-  int N_track;                  // selected tracks
+  int N_event;  // processed events
+  int N_track;  // selected tracks
 
-  std::vector<AlignTransform>::const_iterator 
-  iteratorTrackerRcd;           // location of Tracker in container globalPositionRcd_->m_aligm
-  std::vector<AlignTransform>::const_iterator 
-  iteratorMuonRcd;              //              Muon
   std::vector<AlignTransform>::const_iterator
-  iteratorEcalRcd;              //              Ecal
-  std::vector<AlignTransform>::const_iterator
-  iteratorHcalRcd;              //              Hcal
+      iteratorTrackerRcd;  // location of Tracker in container globalPositionRcd_->m_aligm
+  std::vector<AlignTransform>::const_iterator iteratorMuonRcd;  //              Muon
+  std::vector<AlignTransform>::const_iterator iteratorEcalRcd;  //              Ecal
+  std::vector<AlignTransform>::const_iterator iteratorHcalRcd;  //              Hcal
 
-  CLHEP::HepVector MuGlShift;   // evaluated global muon shifts  
-  CLHEP::HepVector MuGlAngle;   // evaluated global muon angles  
+  CLHEP::HepVector MuGlShift;  // evaluated global muon shifts
+  CLHEP::HepVector MuGlAngle;  // evaluated global muon angles
 
-  std::string MuSelect;         // what part of muon system is selected for 1st hit 
+  std::string MuSelect;  // what part of muon system is selected for 1st hit
 
-  ofstream OutGlobalTxt;        // output the vector of global alignment as text     
+  ofstream OutGlobalTxt;  // output the vector of global alignment as text
 
-  TFile * file;
-  TH1F * histo;
-  TH1F * histo2; // outerP
-  TH1F * histo3; // outerLambda = PI/2-outerTheta
-  TH1F * histo4; // phi
-  TH1F * histo5; // outerR
-  TH1F * histo6; // outerZ
-  TH1F * histo7; // s
-  TH1F * histo8; // chi^2 of muon-track
+  TFile* file;
+  TH1F* histo;
+  TH1F* histo2;  // outerP
+  TH1F* histo3;  // outerLambda = PI/2-outerTheta
+  TH1F* histo4;  // phi
+  TH1F* histo5;  // outerR
+  TH1F* histo6;  // outerZ
+  TH1F* histo7;  // s
+  TH1F* histo8;  // chi^2 of muon-track
 
-  TH1F * histo11; // |Rm-Rt| 
-  TH1F * histo12; // Xm-Xt 
-  TH1F * histo13; // Ym-Yt 
-  TH1F * histo14; // Zm-Zt 
-  TH1F * histo15; // Nxm-Nxt 
-  TH1F * histo16; // Nym-Nyt 
-  TH1F * histo17; // Nzm-Nzt 
-  TH1F * histo18; // Error X of inner track  
-  TH1F * histo19; // Error X of muon 
-  TH1F * histo20; // Error of Xm-Xt 
-  TH1F * histo21; // pull(Xm-Xt) 
-  TH1F * histo22; // pull(Ym-Yt) 
-  TH1F * histo23; // pull(Zm-Zt) 
-  TH1F * histo24; // pull(PXm-PXt) 
-  TH1F * histo25; // pull(PYm-Pyt) 
-  TH1F * histo26; // pull(PZm-PZt) 
-  TH1F * histo27; // Nx of tangent plane  
-  TH1F * histo28; // Ny of tangent plane  
-  TH1F * histo29; // lenght of inner track  
-  TH1F * histo30; // lenght of muon track  
-  TH1F * histo31; // chi2 local  
-  TH1F * histo32; // pull(Pxm/Pzm - Pxt/Pzt) local  
-  TH1F * histo33; // pull(Pym/Pzm - Pyt/Pzt) local
-  TH1F * histo34; // pull(Xm - Xt) local
-  TH1F * histo35; // pull(Ym - Yt) local
+  TH1F* histo11;  // |Rm-Rt|
+  TH1F* histo12;  // Xm-Xt
+  TH1F* histo13;  // Ym-Yt
+  TH1F* histo14;  // Zm-Zt
+  TH1F* histo15;  // Nxm-Nxt
+  TH1F* histo16;  // Nym-Nyt
+  TH1F* histo17;  // Nzm-Nzt
+  TH1F* histo18;  // Error X of inner track
+  TH1F* histo19;  // Error X of muon
+  TH1F* histo20;  // Error of Xm-Xt
+  TH1F* histo21;  // pull(Xm-Xt)
+  TH1F* histo22;  // pull(Ym-Yt)
+  TH1F* histo23;  // pull(Zm-Zt)
+  TH1F* histo24;  // pull(PXm-PXt)
+  TH1F* histo25;  // pull(PYm-Pyt)
+  TH1F* histo26;  // pull(PZm-PZt)
+  TH1F* histo27;  // Nx of tangent plane
+  TH1F* histo28;  // Ny of tangent plane
+  TH1F* histo29;  // lenght of inner track
+  TH1F* histo30;  // lenght of muon track
+  TH1F* histo31;  // chi2 local
+  TH1F* histo32;  // pull(Pxm/Pzm - Pxt/Pzt) local
+  TH1F* histo33;  // pull(Pym/Pzm - Pyt/Pzt) local
+  TH1F* histo34;  // pull(Xm - Xt) local
+  TH1F* histo35;  // pull(Ym - Yt) local
 
-  TH2F * histo101; // Rtrack/muon vs Ztrack/muon
-  TH2F * histo102; // Ytrack/muon vs Xtrack/muon
+  TH2F* histo101;  // Rtrack/muon vs Ztrack/muon
+  TH2F* histo102;  // Ytrack/muon vs Xtrack/muon
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -269,42 +270,38 @@ class GlobalTrackerMuonAlignment : public edm::EDAnalyzer {
 // constructors and destructor
 //
 GlobalTrackerMuonAlignment::GlobalTrackerMuonAlignment(const edm::ParameterSet& iConfig)
-  :trackTags_(iConfig.getParameter<edm::InputTag>("tracks")),
-   muonTags_(iConfig.getParameter<edm::InputTag>("muons")),
-   gmuonTags_(iConfig.getParameter<edm::InputTag>("gmuons")),
-   smuonTags_(iConfig.getParameter<edm::InputTag>("smuons")),
-   propagator_(iConfig.getParameter<string>("Propagator")),
+    : trackTags_(iConfig.getParameter<edm::InputTag>("tracks")),
+      muonTags_(iConfig.getParameter<edm::InputTag>("muons")),
+      gmuonTags_(iConfig.getParameter<edm::InputTag>("gmuons")),
+      smuonTags_(iConfig.getParameter<edm::InputTag>("smuons")),
+      propagator_(iConfig.getParameter<string>("Propagator")),
 
-   cosmicMuonMode_(iConfig.getParameter<bool>("cosmics")),
-   isolatedMuonMode_(iConfig.getParameter<bool>("isolated")),
+      cosmicMuonMode_(iConfig.getParameter<bool>("cosmics")),
+      isolatedMuonMode_(iConfig.getParameter<bool>("isolated")),
 
-   refitMuon_(iConfig.getParameter<bool>("refitmuon")),
-   refitTrack_(iConfig.getParameter<bool>("refittrack")),
+      refitMuon_(iConfig.getParameter<bool>("refitmuon")),
+      refitTrack_(iConfig.getParameter<bool>("refittrack")),
 
-   rootOutFile_(iConfig.getUntrackedParameter<string>("rootOutFile")),
-   txtOutFile_(iConfig.getUntrackedParameter<string>("txtOutFile")),
-   writeDB_(iConfig.getUntrackedParameter<bool>("writeDB")),
-   debug_(iConfig.getUntrackedParameter<bool>("debug")),
-   defineFitter(true)
-{
-#ifdef NO_FALSE_FALSE_MODE 
-  if (cosmicMuonMode_==false && isolatedMuonMode_==false) {
+      rootOutFile_(iConfig.getUntrackedParameter<string>("rootOutFile")),
+      txtOutFile_(iConfig.getUntrackedParameter<string>("txtOutFile")),
+      writeDB_(iConfig.getUntrackedParameter<bool>("writeDB")),
+      debug_(iConfig.getUntrackedParameter<bool>("debug")),
+      defineFitter(true) {
+#ifdef NO_FALSE_FALSE_MODE
+  if (cosmicMuonMode_ == false && isolatedMuonMode_ == false) {
     throw cms::Exception("BadConfig") << "Muon collection not set! "
-				      << "Use from GlobalTrackerMuonAlignment_test_cfg.py.";
+                                      << "Use from GlobalTrackerMuonAlignment_test_cfg.py.";
   }
-#endif  
-  if (cosmicMuonMode_==true && isolatedMuonMode_==true) {
+#endif
+  if (cosmicMuonMode_ == true && isolatedMuonMode_ == true) {
     throw cms::Exception("BadConfig") << "Muon collection can be either cosmic or isolated! "
-				      << "Please set only one to true.";
+                                      << "Please set only one to true.";
   }
 }
 
-GlobalTrackerMuonAlignment::~GlobalTrackerMuonAlignment()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+GlobalTrackerMuonAlignment::~GlobalTrackerMuonAlignment() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -312,43 +309,45 @@ GlobalTrackerMuonAlignment::~GlobalTrackerMuonAlignment()
 //
 
 // ------------ method called to for each event  ------------
-void
-GlobalTrackerMuonAlignment::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{  
-  //GlobalTrackerMuonAlignment::analyzeTrackTrack(iEvent, iSetup);  
-  GlobalTrackerMuonAlignment::analyzeTrackTrajectory(iEvent, iSetup);  
+void GlobalTrackerMuonAlignment::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  //GlobalTrackerMuonAlignment::analyzeTrackTrack(iEvent, iSetup);
+  GlobalTrackerMuonAlignment::analyzeTrackTrajectory(iEvent, iSetup);
 }
 
 // ------------ method called once for job just before starting event loop  ------------
-void GlobalTrackerMuonAlignment::beginJob()
-{
+void GlobalTrackerMuonAlignment::beginJob() {
   N_event = 0;
   N_track = 0;
-  
-  if (cosmicMuonMode_==true && isolatedMuonMode_==false) {
-    collectionCosmic = true; collectionIsolated = false;}
-  else if (cosmicMuonMode_==false && isolatedMuonMode_==true) {
-    collectionCosmic = false; collectionIsolated = true;}
-  else {
-    collectionCosmic = false; collectionIsolated = false;}
 
-  for(int i=0; i<=2; i++){
+  if (cosmicMuonMode_ == true && isolatedMuonMode_ == false) {
+    collectionCosmic = true;
+    collectionIsolated = false;
+  } else if (cosmicMuonMode_ == false && isolatedMuonMode_ == true) {
+    collectionCosmic = false;
+    collectionIsolated = true;
+  } else {
+    collectionCosmic = false;
+    collectionIsolated = false;
+  }
+
+  for (int i = 0; i <= 2; i++) {
     Gfr(i) = 0.;
-    for(int j=0; j<=2; j++){
-      Inf(i,j) = 0.;
-    }}
+    for (int j = 0; j <= 2; j++) {
+      Inf(i, j) = 0.;
+    }
+  }
 
-  Grad =  CLHEP::HepVector(6,0);
-  Hess =  CLHEP::HepSymMatrix(6,0);
+  Grad = CLHEP::HepVector(6, 0);
+  Hess = CLHEP::HepSymMatrix(6, 0);
 
-  GradL =  CLHEP::HepVector(6,0);
-  HessL =  CLHEP::HepSymMatrix(6,0);
+  GradL = CLHEP::HepVector(6, 0);
+  HessL = CLHEP::HepSymMatrix(6, 0);
 
   // histograms
-  TDirectory * dirsave = gDirectory;
+  TDirectory* dirsave = gDirectory;
 
-  file = new TFile(rootOutFile_.c_str(), "recreate"); 
-  const bool oldAddDir = TH1::AddDirectoryStatus(); 
+  file = new TFile(rootOutFile_.c_str(), "recreate");
+  const bool oldAddDir = TH1::AddDirectoryStatus();
 
   TH1::AddDirectory(true);
 
@@ -364,225 +363,235 @@ void GlobalTrackerMuonAlignment::endJob() {
 
   this->fitHist();
 
-  AlgebraicVector3 d(0., 0., 0.);   // ------------  alignmnet  Global Algebraic
+  AlgebraicVector3 d(0., 0., 0.);  // ------------  alignmnet  Global Algebraic
 
-  AlgebraicSymMatrix33 InfI;   // inverse it   
-  for(int i=0; i<=2; i++) 
-    for(int j=0; j<=2; j++){
-      if(j < i) continue;
-      InfI(i,j) += Inf(i,j);}
+  AlgebraicSymMatrix33 InfI;  // inverse it
+  for (int i = 0; i <= 2; i++)
+    for (int j = 0; j <= 2; j++) {
+      if (j < i)
+        continue;
+      InfI(i, j) += Inf(i, j);
+    }
   bool ierr = !InfI.Invert();
-  if( ierr ) { if(alarm)
-      std::cout<<" Error inverse  Inf matrix !!!!!!!!!!!"<<std::endl;}
-  
-  for(int i=0; i<=2; i++) 
-    for(int k=0; k<=2; k++) d(i) -= InfI(i,k)*Gfr(k);
+  if (ierr) {
+    if (alarm)
+      std::cout << " Error inverse  Inf matrix !!!!!!!!!!!" << std::endl;
+  }
+
+  for (int i = 0; i <= 2; i++)
+    for (int k = 0; k <= 2; k++)
+      d(i) -= InfI(i, k) * Gfr(k);
   // end of Global Algebraic
-        
+
   //                                ---------------  alignment Global CLHEP
   CLHEP::HepVector d3 = CLHEP::solve(Hess, -Grad);
   int iEr3;
   CLHEP::HepMatrix Errd3 = Hess.inverse(iEr3);
-  if( iEr3 != 0) { if(alarm)
-    std::cout<<" endJob Error inverse Hess matrix !!!!!!!!!!!"<<std::endl;
+  if (iEr3 != 0) {
+    if (alarm)
+      std::cout << " endJob Error inverse Hess matrix !!!!!!!!!!!" << std::endl;
   }
   // end of Global CLHEP
-  
+
   //                                ----------------- alignment Local CLHEP
   CLHEP::HepVector dLI = CLHEP::solve(HessL, -GradL);
   int iErI;
   CLHEP::HepMatrix ErrdLI = HessL.inverse(iErI);
-  if( iErI != 0) { if(alarm)
-      std::cout<<" endJob Error inverse HessL matrix !!!!!!!!!!!"<<std::endl;
+  if (iErI != 0) {
+    if (alarm)
+      std::cout << " endJob Error inverse HessL matrix !!!!!!!!!!!" << std::endl;
   }
   // end of Local CLHEP
 
   // printout of final parameters
-  std::cout<<" ---- "<<N_event<<" event "<<N_track<<" tracks "
-	   <<MuSelect<<" ---- "<<std::endl;
-  if (collectionIsolated) std::cout<<" ALCARECOMuAlCalIsolatedMu "<<std::endl;
-  else if (collectionCosmic) std::cout<<"  ALCARECOMuAlGlobalCosmics "<<std::endl; 
-  else std::cout<<smuonTags_<<std::endl;
-  std::cout<<" Similated shifts[cm] "
-	   <<MuGlShift(1)<<" "<<MuGlShift(2)<<" "<<MuGlShift(3)<<" "
-	   <<" angles[rad] "<<MuGlAngle(1)<<" "<<MuGlAngle(2)<<" "<<MuGlAngle(3)<<" "
-	   <<std::endl;
-  std::cout<<" d    "<<-d<<std::endl;;
-  std::cout<<" +-   "<<sqrt(InfI(0,0))<<" "<<sqrt(InfI(1,1))<<" "<<sqrt(InfI(2,2))
-	   <<std::endl;
-  std::cout<<" dG   "<<d3(1)<<" "<<d3(2)<<" "<<d3(3)<<" "<<d3(4)<<" "
-	   <<d3(5)<<" "<<d3(6)<<std::endl;;
-  std::cout<<" +-   "<<sqrt(Errd3(1,1))<<" "<<sqrt(Errd3(2,2))<<" "<<sqrt(Errd3(3,3))
-	   <<" "<<sqrt(Errd3(4,4))<<" "<<sqrt(Errd3(5,5))<<" "<<sqrt(Errd3(6,6))
-	   <<std::endl;
-  std::cout<<" dL   "<<dLI(1)<<" "<<dLI(2)<<" "<<dLI(3)<<" "<<dLI(4)<<" "
-	   <<dLI(5)<<" "<<dLI(6)<<std::endl;;
-  std::cout<<" +-   "<<sqrt(ErrdLI(1,1))<<" "<<sqrt(ErrdLI(2,2))<<" "<<sqrt(ErrdLI(3,3))
-	   <<" "<<sqrt(ErrdLI(4,4))<<" "<<sqrt(ErrdLI(5,5))<<" "<<sqrt(ErrdLI(6,6))
-	   <<std::endl;
+  std::cout << " ---- " << N_event << " event " << N_track << " tracks " << MuSelect << " ---- " << std::endl;
+  if (collectionIsolated)
+    std::cout << " ALCARECOMuAlCalIsolatedMu " << std::endl;
+  else if (collectionCosmic)
+    std::cout << "  ALCARECOMuAlGlobalCosmics " << std::endl;
+  else
+    std::cout << smuonTags_ << std::endl;
+  std::cout << " Similated shifts[cm] " << MuGlShift(1) << " " << MuGlShift(2) << " " << MuGlShift(3) << " "
+            << " angles[rad] " << MuGlAngle(1) << " " << MuGlAngle(2) << " " << MuGlAngle(3) << " " << std::endl;
+  std::cout << " d    " << -d << std::endl;
+  ;
+  std::cout << " +-   " << sqrt(InfI(0, 0)) << " " << sqrt(InfI(1, 1)) << " " << sqrt(InfI(2, 2)) << std::endl;
+  std::cout << " dG   " << d3(1) << " " << d3(2) << " " << d3(3) << " " << d3(4) << " " << d3(5) << " " << d3(6)
+            << std::endl;
+  ;
+  std::cout << " +-   " << sqrt(Errd3(1, 1)) << " " << sqrt(Errd3(2, 2)) << " " << sqrt(Errd3(3, 3)) << " "
+            << sqrt(Errd3(4, 4)) << " " << sqrt(Errd3(5, 5)) << " " << sqrt(Errd3(6, 6)) << std::endl;
+  std::cout << " dL   " << dLI(1) << " " << dLI(2) << " " << dLI(3) << " " << dLI(4) << " " << dLI(5) << " " << dLI(6)
+            << std::endl;
+  ;
+  std::cout << " +-   " << sqrt(ErrdLI(1, 1)) << " " << sqrt(ErrdLI(2, 2)) << " " << sqrt(ErrdLI(3, 3)) << " "
+            << sqrt(ErrdLI(4, 4)) << " " << sqrt(ErrdLI(5, 5)) << " " << sqrt(ErrdLI(6, 6)) << std::endl;
 
   // what do we write to DB
-  CLHEP::HepVector vectorToDb(6,0), vectorErrToDb(6,0);
+  CLHEP::HepVector vectorToDb(6, 0), vectorErrToDb(6, 0);
   //vectorToDb = d3;
   //for(unsigned int i=1; i<=6; i++) vectorErrToDb(i) = sqrt(Errd3(i,i));
   vectorToDb = -dLI;
-  for(unsigned int i=1; i<=6; i++) vectorErrToDb(i) = sqrt(ErrdLI(i,i));
+  for (unsigned int i = 1; i <= 6; i++)
+    vectorErrToDb(i) = sqrt(ErrdLI(i, i));
 
   // write histograms to root file
-  file->Write(); 
-  file->Close(); 
+  file->Write();
+  file->Close();
 
-  // write global parameters to text file 
+  // write global parameters to text file
   OutGlobalTxt.open(txtOutFile_.c_str(), ios::out);
-  if(!OutGlobalTxt.is_open()) std::cout<<" outglobal.txt is not open !!!!!"<<std::endl;
-  else{
-    OutGlobalTxt<<vectorToDb(1)<<" "<<vectorToDb(2)<<" "<<vectorToDb(3)<<" "<<vectorToDb(4)<<" "
-		<<vectorToDb(5)<<" "<<vectorToDb(6)<<" muon Global.\n";
-    OutGlobalTxt<<vectorErrToDb(1)<<" "<<vectorErrToDb(1)<<" "<<vectorErrToDb(1)<<" "
-		<<vectorErrToDb(1)<<" "<<vectorErrToDb(1)<<" "<<vectorErrToDb(1)<<" errors.\n";
-    OutGlobalTxt<<N_event<<" events are processed.\n";
+  if (!OutGlobalTxt.is_open())
+    std::cout << " outglobal.txt is not open !!!!!" << std::endl;
+  else {
+    OutGlobalTxt << vectorToDb(1) << " " << vectorToDb(2) << " " << vectorToDb(3) << " " << vectorToDb(4) << " "
+                 << vectorToDb(5) << " " << vectorToDb(6) << " muon Global.\n";
+    OutGlobalTxt << vectorErrToDb(1) << " " << vectorErrToDb(1) << " " << vectorErrToDb(1) << " " << vectorErrToDb(1)
+                 << " " << vectorErrToDb(1) << " " << vectorErrToDb(1) << " errors.\n";
+    OutGlobalTxt << N_event << " events are processed.\n";
 
-    if (collectionIsolated) OutGlobalTxt<<"ALCARECOMuAlCalIsolatedMu.\n";
-    else if (collectionCosmic) OutGlobalTxt<<"  ALCARECOMuAlGlobalCosmics.\n"; 
-    else OutGlobalTxt<<smuonTags_<<".\n";
+    if (collectionIsolated)
+      OutGlobalTxt << "ALCARECOMuAlCalIsolatedMu.\n";
+    else if (collectionCosmic)
+      OutGlobalTxt << "  ALCARECOMuAlGlobalCosmics.\n";
+    else
+      OutGlobalTxt << smuonTags_ << ".\n";
     OutGlobalTxt.close();
-    std::cout<<" Write to the file outglobal.txt done  "<<std::endl;
+    std::cout << " Write to the file outglobal.txt done  " << std::endl;
   }
 
   // write new GlobalPositionRcd to DB
-  if(debug_)
-    std::cout<<" writeBD_ "<<writeDB_<<std::endl;
-  if (writeDB_) 
+  if (debug_)
+    std::cout << " writeBD_ " << writeDB_ << std::endl;
+  if (writeDB_)
     GlobalTrackerMuonAlignment::writeGlPosRcd(vectorToDb);
 }
 
 // ------------ book histogram  ------------
-void GlobalTrackerMuonAlignment::bookHist()
-{
+void GlobalTrackerMuonAlignment::bookHist() {
   double PI = 3.1415927;
-  histo = new TH1F("Pt","pt",1000,0,100); 
-  histo2 = new TH1F("P","P [GeV/c]",400,0.,400.);       
+  histo = new TH1F("Pt", "pt", 1000, 0, 100);
+  histo2 = new TH1F("P", "P [GeV/c]", 400, 0., 400.);
   histo2->GetXaxis()->SetTitle("momentum [GeV/c]");
-  histo3 = new TH1F("outerLambda","#lambda outer",100,-PI/2.,PI/2.);    
+  histo3 = new TH1F("outerLambda", "#lambda outer", 100, -PI / 2., PI / 2.);
   histo3->GetXaxis()->SetTitle("#lambda outer");
-  histo4 = new TH1F("phi","#phi [rad]",100,-PI,PI);       
+  histo4 = new TH1F("phi", "#phi [rad]", 100, -PI, PI);
   histo4->GetXaxis()->SetTitle("#phi [rad]");
-  histo5 = new TH1F("Rmuon","inner muon hit R [cm]",100,0.,800.);       
+  histo5 = new TH1F("Rmuon", "inner muon hit R [cm]", 100, 0., 800.);
   histo5->GetXaxis()->SetTitle("R of muon [cm]");
-  histo6 = new TH1F("Zmuon","inner muon hit Z[cm]",100,-1000.,1000.);       
+  histo6 = new TH1F("Zmuon", "inner muon hit Z[cm]", 100, -1000., 1000.);
   histo6->GetXaxis()->SetTitle("Z of muon [cm]");
-  histo7 = new TH1F("(Pm-Pt)/Pt"," (Pmuon-Ptrack)/Ptrack", 100,-2.,2.);       
+  histo7 = new TH1F("(Pm-Pt)/Pt", " (Pmuon-Ptrack)/Ptrack", 100, -2., 2.);
   histo7->GetXaxis()->SetTitle("(Pmuon-Ptrack)/Ptrack");
-  histo8 = new TH1F("chi muon-track","#chi^{2}(muon-track)", 1000,0.,1000.);       
+  histo8 = new TH1F("chi muon-track", "#chi^{2}(muon-track)", 1000, 0., 1000.);
   histo8->GetXaxis()->SetTitle("#chi^{2} of muon w.r.t. propagated track");
-  histo11 = new TH1F("distance muon-track","distance muon w.r.t track [cm]",100,0.,30.);
+  histo11 = new TH1F("distance muon-track", "distance muon w.r.t track [cm]", 100, 0., 30.);
   histo11->GetXaxis()->SetTitle("distance of muon w.r.t. track [cm]");
-  histo12 = new TH1F("Xmuon-Xtrack","Xmuon-Xtrack [cm]",200,-20.,20.);
-  histo12->GetXaxis()->SetTitle("Xmuon - Xtrack [cm]"); 
-  histo13 = new TH1F("Ymuon-Ytrack","Ymuon-Ytrack [cm]",200,-20.,20.);
+  histo12 = new TH1F("Xmuon-Xtrack", "Xmuon-Xtrack [cm]", 200, -20., 20.);
+  histo12->GetXaxis()->SetTitle("Xmuon - Xtrack [cm]");
+  histo13 = new TH1F("Ymuon-Ytrack", "Ymuon-Ytrack [cm]", 200, -20., 20.);
   histo13->GetXaxis()->SetTitle("Ymuon - Ytrack [cm]");
-  histo14 = new TH1F("Zmuon-Ztrack","Zmuon-Ztrack [cm]",200,-20.,20.);       
+  histo14 = new TH1F("Zmuon-Ztrack", "Zmuon-Ztrack [cm]", 200, -20., 20.);
   histo14->GetXaxis()->SetTitle("Zmuon-Ztrack [cm]");
-  histo15 = new TH1F("NXmuon-NXtrack","NXmuon-NXtrack [rad]",200,-.1,.1);       
+  histo15 = new TH1F("NXmuon-NXtrack", "NXmuon-NXtrack [rad]", 200, -.1, .1);
   histo15->GetXaxis()->SetTitle("N_{X}(muon)-N_{X}(track) [rad]");
-  histo16 = new TH1F("NYmuon-NYtrack","NYmuon-NYtrack [rad]",200,-.1,.1);       
+  histo16 = new TH1F("NYmuon-NYtrack", "NYmuon-NYtrack [rad]", 200, -.1, .1);
   histo16->GetXaxis()->SetTitle("N_{Y}(muon)-N_{Y}(track) [rad]");
-  histo17 = new TH1F("NZmuon-NZtrack","NZmuon-NZtrack [rad]",200,-.1,.1);       
+  histo17 = new TH1F("NZmuon-NZtrack", "NZmuon-NZtrack [rad]", 200, -.1, .1);
   histo17->GetXaxis()->SetTitle("N_{Z}(muon)-N_{Z}(track) [rad]");
-  histo18 = new TH1F("expected error of Xinner","outer hit of inner tracker",100,0,.01);
+  histo18 = new TH1F("expected error of Xinner", "outer hit of inner tracker", 100, 0, .01);
   histo18->GetXaxis()->SetTitle("expected error of Xinner [cm]");
-  histo19 = new TH1F("expected error of Xmuon","inner hit of muon",100,0,.1);       
+  histo19 = new TH1F("expected error of Xmuon", "inner hit of muon", 100, 0, .1);
   histo19->GetXaxis()->SetTitle("expected error of Xmuon [cm]");
-  histo20 = new TH1F("expected error of Xmuon-Xtrack","muon w.r.t. propagated track",100,0.,10.);
+  histo20 = new TH1F("expected error of Xmuon-Xtrack", "muon w.r.t. propagated track", 100, 0., 10.);
   histo20->GetXaxis()->SetTitle("expected error of Xmuon-Xtrack [cm]");
-  histo21 = new TH1F("pull of Xmuon-Xtrack","pull of Xmuon-Xtrack",100,-10.,10.);
+  histo21 = new TH1F("pull of Xmuon-Xtrack", "pull of Xmuon-Xtrack", 100, -10., 10.);
   histo21->GetXaxis()->SetTitle("(Xmuon-Xtrack)/expected error");
-  histo22 = new TH1F("pull of Ymuon-Ytrack","pull of Ymuon-Ytrack",100,-10.,10.);       
+  histo22 = new TH1F("pull of Ymuon-Ytrack", "pull of Ymuon-Ytrack", 100, -10., 10.);
   histo22->GetXaxis()->SetTitle("(Ymuon-Ytrack)/expected error");
-  histo23 = new TH1F("pull of Zmuon-Ztrack","pull of Zmuon-Ztrack",100,-10.,10.);       
+  histo23 = new TH1F("pull of Zmuon-Ztrack", "pull of Zmuon-Ztrack", 100, -10., 10.);
   histo23->GetXaxis()->SetTitle("(Zmuon-Ztrack)/expected error");
-  histo24 = new TH1F("pull of PXmuon-PXtrack","pull of PXmuon-PXtrack",100,-10.,10.);       
+  histo24 = new TH1F("pull of PXmuon-PXtrack", "pull of PXmuon-PXtrack", 100, -10., 10.);
   histo24->GetXaxis()->SetTitle("(P_{X}(muon)-P_{X}(track))/expected error");
-  histo25 = new TH1F("pull of PYmuon-PYtrack","pull of PYmuon-PYtrack",100,-10.,10.);       
+  histo25 = new TH1F("pull of PYmuon-PYtrack", "pull of PYmuon-PYtrack", 100, -10., 10.);
   histo25->GetXaxis()->SetTitle("(P_{Y}(muon)-P_{Y}(track))/expected error");
-  histo26 = new TH1F("pull of PZmuon-PZtrack","pull of PZmuon-PZtrack",100,-10.,10.);       
+  histo26 = new TH1F("pull of PZmuon-PZtrack", "pull of PZmuon-PZtrack", 100, -10., 10.);
   histo26->GetXaxis()->SetTitle("(P_{Z}(muon)-P_{Z}(track))/expected error");
-  histo27 = new TH1F("N_x","Nx of tangent plane",120,-1.1,1.1); 
+  histo27 = new TH1F("N_x", "Nx of tangent plane", 120, -1.1, 1.1);
   histo27->GetXaxis()->SetTitle("normal vector projection N_{X}");
-  histo28 = new TH1F("N_y","Ny of tangent plane",120,-1.1,1.1); 
+  histo28 = new TH1F("N_y", "Ny of tangent plane", 120, -1.1, 1.1);
   histo28->GetXaxis()->SetTitle("normal vector projection N_{Y}");
-  histo29 = new TH1F("lenght of track","lenght of track",200,0.,400); 
+  histo29 = new TH1F("lenght of track", "lenght of track", 200, 0., 400);
   histo29->GetXaxis()->SetTitle("lenght of track [cm]");
-  histo30 = new TH1F("lenght of muon","lenght of muon",200,0.,800); 
+  histo30 = new TH1F("lenght of muon", "lenght of muon", 200, 0., 800);
   histo30->GetXaxis()->SetTitle("lenght of muon [cm]");
 
-  histo31 = new TH1F("local chi muon-track","#local chi^{2}(muon-track)", 1000,0.,1000.);       
+  histo31 = new TH1F("local chi muon-track", "#local chi^{2}(muon-track)", 1000, 0., 1000.);
   histo31->GetXaxis()->SetTitle("#local chi^{2} of muon w.r.t. propagated track");
-  histo32 = new TH1F("pull of Px/Pz local","pull of Px/Pz local",100,-10.,10.);
+  histo32 = new TH1F("pull of Px/Pz local", "pull of Px/Pz local", 100, -10., 10.);
   histo32->GetXaxis()->SetTitle("local (Px/Pz(muon) - Px/Pz(track))/expected error");
-  histo33 = new TH1F("pull of Py/Pz local","pull of Py/Pz local",100,-10.,10.);
+  histo33 = new TH1F("pull of Py/Pz local", "pull of Py/Pz local", 100, -10., 10.);
   histo33->GetXaxis()->SetTitle("local (Py/Pz(muon) - Py/Pz(track))/expected error");
-  histo34 = new TH1F("pull of X local","pull of X local",100,-10.,10.);
+  histo34 = new TH1F("pull of X local", "pull of X local", 100, -10., 10.);
   histo34->GetXaxis()->SetTitle("local (Xmuon - Xtrack)/expected error");
-  histo35 = new TH1F("pull of Y local","pull of Y local",100,-10.,10.);
+  histo35 = new TH1F("pull of Y local", "pull of Y local", 100, -10., 10.);
   histo35->GetXaxis()->SetTitle("local (Ymuon - Ytrack)/expected error");
 
-  histo101 = new TH2F("Rtr/mu vs Ztr/mu","hit of track/muon",100,-800.,800.,100,0.,600.);
+  histo101 = new TH2F("Rtr/mu vs Ztr/mu", "hit of track/muon", 100, -800., 800., 100, 0., 600.);
   histo101->GetXaxis()->SetTitle("Z of track/muon [cm]");
   histo101->GetYaxis()->SetTitle("R of track/muon [cm]");
-  histo102 = new TH2F("Ytr/mu vs Xtr/mu","hit of track/muon",100,-600.,600.,100,-600.,600.);
+  histo102 = new TH2F("Ytr/mu vs Xtr/mu", "hit of track/muon", 100, -600., 600., 100, -600., 600.);
   histo102->GetXaxis()->SetTitle("X of track/muon [cm]");
   histo102->GetYaxis()->SetTitle("Y of track/muon [cm]");
 }
 
 // ------------ fit histogram  ------------
 void GlobalTrackerMuonAlignment::fitHist() {
+  histo7->Fit("gaus", "Q");
 
-  histo7->Fit("gaus","Q");
+  histo12->Fit("gaus", "Q");
+  histo13->Fit("gaus", "Q");
+  histo14->Fit("gaus", "Q");
+  histo15->Fit("gaus", "Q");
+  histo16->Fit("gaus", "Q");
+  histo17->Fit("gaus", "Q");
 
-  histo12->Fit("gaus","Q");
-  histo13->Fit("gaus","Q");
-  histo14->Fit("gaus","Q");
-  histo15->Fit("gaus","Q");
-  histo16->Fit("gaus","Q");
-  histo17->Fit("gaus","Q");
+  histo21->Fit("gaus", "Q");
+  histo22->Fit("gaus", "Q");
+  histo23->Fit("gaus", "Q");
+  histo24->Fit("gaus", "Q");
+  histo25->Fit("gaus", "Q");
+  histo26->Fit("gaus", "Q");
 
-  histo21->Fit("gaus","Q");
-  histo22->Fit("gaus","Q");
-  histo23->Fit("gaus","Q");
-  histo24->Fit("gaus","Q");
-  histo25->Fit("gaus","Q");
-  histo26->Fit("gaus","Q");
-
-  histo32->Fit("gaus","Q");
-  histo33->Fit("gaus","Q");
-  histo34->Fit("gaus","Q");
-  histo35->Fit("gaus","Q");
+  histo32->Fit("gaus", "Q");
+  histo33->Fit("gaus", "Q");
+  histo34->Fit("gaus", "Q");
+  histo35->Fit("gaus", "Q");
 }
 
 // ------------ method to analyze recoTrack & recoMuon of Global Muon  ------------
-void GlobalTrackerMuonAlignment::analyzeTrackTrack
-(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void GlobalTrackerMuonAlignment::analyzeTrackTrack(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
-  using namespace reco;  
+  using namespace reco;
   //debug_ = true;
   bool info = false;
   bool alarm = false;
   //bool alarm = true;
   double PI = 3.1415927;
- 
-  cosmicMuonMode_ = true; // true: both Cosmic and IsolatedMuon are treated with 1,2 tracks
-  isolatedMuonMode_ = !cosmicMuonMode_; //true: only IsolatedMuon are treated with 1 track
- 
+
+  cosmicMuonMode_ = true;                // true: both Cosmic and IsolatedMuon are treated with 1,2 tracks
+  isolatedMuonMode_ = !cosmicMuonMode_;  //true: only IsolatedMuon are treated with 1 track
+
   //if(N_event == 1)
   //GlobalPositionRcdRead1::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
   N_event++;
   if (info || debug_) {
-    std::cout << "----- event " << N_event << " -- tracks "<<N_track<<" ---";
-    if (cosmicMuonMode_) std::cout << " treated as CosmicMu ";
-    if (isolatedMuonMode_) std::cout <<" treated as IsolatedMu ";
+    std::cout << "----- event " << N_event << " -- tracks " << N_track << " ---";
+    if (cosmicMuonMode_)
+      std::cout << " treated as CosmicMu ";
+    if (isolatedMuonMode_)
+      std::cout << " treated as IsolatedMu ";
     std::cout << std::endl;
   }
 
@@ -591,52 +600,55 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
   Handle<reco::TrackCollection> gmuons;
   Handle<reco::MuonCollection> smuons;
 
-  if (collectionIsolated){
-    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "TrackerOnly",  tracks);
-    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "StandAlone",  muons);
-    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "GlobalMuon",  gmuons);
-    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "SelectedMuons",  smuons);
+  if (collectionIsolated) {
+    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "TrackerOnly", tracks);
+    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "StandAlone", muons);
+    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "GlobalMuon", gmuons);
+    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "SelectedMuons", smuons);
+  } else if (collectionCosmic) {
+    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "TrackerOnly", tracks);
+    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "StandAlone", muons);
+    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "GlobalMuon", gmuons);
+    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "SelectedMuons", smuons);
+  } else {
+    iEvent.getByLabel(trackTags_, tracks);
+    iEvent.getByLabel(muonTags_, muons);
+    iEvent.getByLabel(gmuonTags_, gmuons);
+    iEvent.getByLabel(smuonTags_, smuons);
   }
-  else if (collectionCosmic){
-    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "TrackerOnly",  tracks);
-    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "StandAlone",  muons);
-    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "GlobalMuon",  gmuons);
-    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "SelectedMuons",  smuons);
-  }
-  else{
-    iEvent.getByLabel(trackTags_,tracks);
-    iEvent.getByLabel(muonTags_,muons);
-    iEvent.getByLabel(gmuonTags_,gmuons);
-    iEvent.getByLabel(smuonTags_,smuons);
-  }  
 
   if (debug_) {
-    std::cout << " ievBunch " << iEvent.bunchCrossing()
-	      << " runN " << (int)iEvent.run() <<std::endl;
-    std::cout << " N tracks s/amu gmu selmu "<<tracks->size() << " " <<muons->size()
-              << " "<<gmuons->size() << " " << smuons->size() << std::endl;
-    for (MuonCollection::const_iterator itMuon = smuons->begin();
-	itMuon != smuons->end();
-	 ++itMuon) {
-      std::cout << " is isolatValid Matches " << itMuon->isIsolationValid()
-		<< " " <<itMuon->isMatchesValid() << std::endl;
+    std::cout << " ievBunch " << iEvent.bunchCrossing() << " runN " << (int)iEvent.run() << std::endl;
+    std::cout << " N tracks s/amu gmu selmu " << tracks->size() << " " << muons->size() << " " << gmuons->size() << " "
+              << smuons->size() << std::endl;
+    for (MuonCollection::const_iterator itMuon = smuons->begin(); itMuon != smuons->end(); ++itMuon) {
+      std::cout << " is isolatValid Matches " << itMuon->isIsolationValid() << " " << itMuon->isMatchesValid()
+                << std::endl;
     }
   }
 
-  if (isolatedMuonMode_) {                // ---- Only 1 Isolated Muon --------
-    if (tracks->size() != 1) return;  
-    if (muons->size()  != 1) return;  
-    if (gmuons->size() != 1) return; 
-    if (smuons->size() != 1) return; 
+  if (isolatedMuonMode_) {  // ---- Only 1 Isolated Muon --------
+    if (tracks->size() != 1)
+      return;
+    if (muons->size() != 1)
+      return;
+    if (gmuons->size() != 1)
+      return;
+    if (smuons->size() != 1)
+      return;
   }
-  
-  if (cosmicMuonMode_){                // ---- 1,2 Cosmic Muon --------
-    if (smuons->size() > 2) return; 
-    if (tracks->size() != smuons->size()) return;  
-    if (muons->size() != smuons->size()) return;  
-    if (gmuons->size() != smuons->size()) return;  
+
+  if (cosmicMuonMode_) {  // ---- 1,2 Cosmic Muon --------
+    if (smuons->size() > 2)
+      return;
+    if (tracks->size() != smuons->size())
+      return;
+    if (muons->size() != smuons->size())
+      return;
+    if (gmuons->size() != smuons->size())
+      return;
   }
-  
+
   // ok mc_isolated_mu
   //edm::ESHandle<TrackerGeometry> trackerGeometry;
   //iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
@@ -646,13 +658,13 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
   // don't work
   //edm::ESHandle<CSCGeometry> cscGeometry;
   //iSetup.get<MuonGeometryRecord>().get(cscGeometry);
-  
+
   if (watchTrackingGeometry_.check(iSetup) || !trackingGeometry_) {
     edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
     iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
     trackingGeometry_ = &*trackingGeometry;
   }
-  
+
   if (watchMagneticFieldRecord_.check(iSetup) || !magneticField_) {
     edm::ESHandle<MagneticField> magneticField;
     iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
@@ -663,92 +675,95 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
     edm::ESHandle<Alignments> globalPositionRcd;
     iSetup.get<GlobalPositionRcd>().get(globalPositionRcd);
     globalPositionRcd_ = &*globalPositionRcd;
-    for (std::vector<AlignTransform>::const_iterator i 
-	   = globalPositionRcd_->m_align.begin();
-	 i != globalPositionRcd_->m_align.end();  ++i){
-      if(DetId(DetId::Tracker).rawId() == i->rawId()) iteratorTrackerRcd = i;
-      if(DetId(DetId::Muon).rawId() == i->rawId()) iteratorMuonRcd = i;
-      if(DetId(DetId::Ecal).rawId() == i->rawId()) iteratorEcalRcd = i;
-      if(DetId(DetId::Hcal).rawId() == i->rawId()) iteratorHcalRcd = i;
+    for (std::vector<AlignTransform>::const_iterator i = globalPositionRcd_->m_align.begin();
+         i != globalPositionRcd_->m_align.end();
+         ++i) {
+      if (DetId(DetId::Tracker).rawId() == i->rawId())
+        iteratorTrackerRcd = i;
+      if (DetId(DetId::Muon).rawId() == i->rawId())
+        iteratorMuonRcd = i;
+      if (DetId(DetId::Ecal).rawId() == i->rawId())
+        iteratorEcalRcd = i;
+      if (DetId(DetId::Hcal).rawId() == i->rawId())
+        iteratorHcalRcd = i;
     }
-    if(true || debug_){
-      std::cout << "=== iteratorMuonRcd " << iteratorMuonRcd->rawId()<<" ====\n" 
-		<< " translation " << iteratorMuonRcd->translation()<<"\n" 
-		<< " angles " << iteratorMuonRcd->rotation().eulerAngles() << std::endl;
+    if (true || debug_) {
+      std::cout << "=== iteratorMuonRcd " << iteratorMuonRcd->rawId() << " ====\n"
+                << " translation " << iteratorMuonRcd->translation() << "\n"
+                << " angles " << iteratorMuonRcd->rotation().eulerAngles() << std::endl;
       std::cout << iteratorMuonRcd->rotation() << std::endl;
-    }   
-  } // end of GlobalPositionRcd
-  
+    }
+  }  // end of GlobalPositionRcd
+
   ESHandle<Propagator> propagator;
   iSetup.get<TrackingComponentsRecord>().get(propagator_, propagator);
-  
-  SteppingHelixPropagator alongStHePr = 
-    SteppingHelixPropagator(magneticField_, alongMomentum);  
-  SteppingHelixPropagator oppositeStHePr = 
-    SteppingHelixPropagator(magneticField_, oppositeToMomentum);  
+
+  SteppingHelixPropagator alongStHePr = SteppingHelixPropagator(magneticField_, alongMomentum);
+  SteppingHelixPropagator oppositeStHePr = SteppingHelixPropagator(magneticField_, oppositeToMomentum);
 
   //double tolerance = 5.e-5;
-  defaultRKPropagator::Product  aprod( magneticField_, alongMomentum, 5.e-5); auto & alongRKPr = aprod.propagator;
-  defaultRKPropagator::Product  oprod( magneticField_, oppositeToMomentum, 5.e-5); auto & oppositeRKPr = oprod.propagator;
+  defaultRKPropagator::Product aprod(magneticField_, alongMomentum, 5.e-5);
+  auto& alongRKPr = aprod.propagator;
+  defaultRKPropagator::Product oprod(magneticField_, oppositeToMomentum, 5.e-5);
+  auto& oppositeRKPr = oprod.propagator;
 
   float epsilon = 5.;
-  SmartPropagator alongSmPr = 
-    SmartPropagator(alongRKPr, alongStHePr, magneticField_, alongMomentum, epsilon);
-  SmartPropagator oppositeSmPr = 
-    SmartPropagator(oppositeRKPr, oppositeStHePr, magneticField_, oppositeToMomentum, epsilon);
-  
+  SmartPropagator alongSmPr = SmartPropagator(alongRKPr, alongStHePr, magneticField_, alongMomentum, epsilon);
+  SmartPropagator oppositeSmPr =
+      SmartPropagator(oppositeRKPr, oppositeStHePr, magneticField_, oppositeToMomentum, epsilon);
+
   // ................................................ selected/global muon
-  //itMuon -->  Jim's globalMuon  
-  for(MuonCollection::const_iterator itMuon = smuons->begin();
-      itMuon != smuons->end(); ++itMuon) {
-    
-    if(debug_){
-      std::cout<<" mu gM is GM Mu SaM tM "<<itMuon->isGlobalMuon()<<" "
-	       <<itMuon->isMuon()<<" "<<itMuon->isStandAloneMuon()
-	       <<" "<<itMuon->isTrackerMuon()<<" "
-	       <<std::endl;
+  //itMuon -->  Jim's globalMuon
+  for (MuonCollection::const_iterator itMuon = smuons->begin(); itMuon != smuons->end(); ++itMuon) {
+    if (debug_) {
+      std::cout << " mu gM is GM Mu SaM tM " << itMuon->isGlobalMuon() << " " << itMuon->isMuon() << " "
+                << itMuon->isStandAloneMuon() << " " << itMuon->isTrackerMuon() << " " << std::endl;
     }
-    
+
     // get information about the innermost muon hit -------------------------
     TransientTrack muTT(itMuon->outerTrack(), magneticField_, trackingGeometry_);
     TrajectoryStateOnSurface innerMuTSOS = muTT.innermostMeasurementState();
     TrajectoryStateOnSurface outerMuTSOS = muTT.outermostMeasurementState();
-    
+
     // get information about the outermost tracker hit -----------------------
     TransientTrack trackTT(itMuon->track(), magneticField_, trackingGeometry_);
     TrajectoryStateOnSurface outerTrackTSOS = trackTT.outermostMeasurementState();
     TrajectoryStateOnSurface innerTrackTSOS = trackTT.innermostMeasurementState();
-    
-    GlobalPoint pointTrackIn  = innerTrackTSOS.globalPosition();
+
+    GlobalPoint pointTrackIn = innerTrackTSOS.globalPosition();
     GlobalPoint pointTrackOut = outerTrackTSOS.globalPosition();
-    float lenghtTrack = (pointTrackOut-pointTrackIn).mag();
-    GlobalPoint pointMuonIn  = innerMuTSOS.globalPosition();
+    float lenghtTrack = (pointTrackOut - pointTrackIn).mag();
+    GlobalPoint pointMuonIn = innerMuTSOS.globalPosition();
     GlobalPoint pointMuonOut = outerMuTSOS.globalPosition();
     float lenghtMuon = (pointMuonOut - pointMuonIn).mag();
     GlobalVector momentumTrackOut = outerTrackTSOS.globalMomentum();
     GlobalVector momentumTrackIn = innerTrackTSOS.globalMomentum();
-    float distanceInIn   = (pointTrackIn  - pointMuonIn).mag();
-    float distanceInOut  = (pointTrackIn  - pointMuonOut).mag();
-    float distanceOutIn  = (pointTrackOut - pointMuonIn).mag();
+    float distanceInIn = (pointTrackIn - pointMuonIn).mag();
+    float distanceInOut = (pointTrackIn - pointMuonOut).mag();
+    float distanceOutIn = (pointTrackOut - pointMuonIn).mag();
     float distanceOutOut = (pointTrackOut - pointMuonOut).mag();
 
-    if(debug_){
-      std::cout<<" pointTrackIn "<<pointTrackIn<<std::endl;
-      std::cout<<"          Out "<<pointTrackOut<<" lenght "<<lenghtTrack<<std::endl;
-      std::cout<<" point MuonIn "<<pointMuonIn<<std::endl;
-      std::cout<<"          Out "<<pointMuonOut<<" lenght "<<lenghtMuon<<std::endl;
-      std::cout<<" momeTrackIn Out "<<momentumTrackIn<<" "<<momentumTrackOut<<std::endl;
-      std::cout<<" doi io ii oo "<<distanceOutIn<<" "<<distanceInOut<<" "
-	       <<distanceInIn<<" "<<distanceOutOut<<std::endl; 
-  }   
+    if (debug_) {
+      std::cout << " pointTrackIn " << pointTrackIn << std::endl;
+      std::cout << "          Out " << pointTrackOut << " lenght " << lenghtTrack << std::endl;
+      std::cout << " point MuonIn " << pointMuonIn << std::endl;
+      std::cout << "          Out " << pointMuonOut << " lenght " << lenghtMuon << std::endl;
+      std::cout << " momeTrackIn Out " << momentumTrackIn << " " << momentumTrackOut << std::endl;
+      std::cout << " doi io ii oo " << distanceOutIn << " " << distanceInOut << " " << distanceInIn << " "
+                << distanceOutOut << std::endl;
+    }
 
-    if(lenghtTrack < 90.) continue;
-    if(lenghtMuon < 300.) continue;
-    if(momentumTrackIn.mag() < 15. || momentumTrackOut.mag() < 15.) continue;
-    if(trackTT.charge() != muTT.charge()) continue;
+    if (lenghtTrack < 90.)
+      continue;
+    if (lenghtMuon < 300.)
+      continue;
+    if (momentumTrackIn.mag() < 15. || momentumTrackOut.mag() < 15.)
+      continue;
+    if (trackTT.charge() != muTT.charge())
+      continue;
 
-    if(debug_)
-      std::cout<<" passed lenght momentum cuts"<<std::endl;
+    if (debug_)
+      std::cout << " passed lenght momentum cuts" << std::endl;
 
     GlobalVector GRm, GPm, Nl, Rm, Pm, Rt, Pt, Rt0;
     AlgebraicSymMatrix66 Cm, C0, Ce, C1;
@@ -756,297 +771,289 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
     TrajectoryStateOnSurface extrapolationT;
     int tsosMuonIf = 0;
 
-    if( isolatedMuonMode_ ){      //------------------------------- Isolated Muon -----
-      const Surface& refSurface = innerMuTSOS.surface(); 
-      ConstReferenceCountingPointer<TangentPlane> 
-	tpMuLocal(refSurface.tangentPlane(innerMuTSOS.localPosition()));
+    if (isolatedMuonMode_) {  //------------------------------- Isolated Muon -----
+      const Surface& refSurface = innerMuTSOS.surface();
+      ConstReferenceCountingPointer<TangentPlane> tpMuLocal(refSurface.tangentPlane(innerMuTSOS.localPosition()));
       Nl = tpMuLocal->normalVector();
-      ConstReferenceCountingPointer<TangentPlane> 
-      tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
+      ConstReferenceCountingPointer<TangentPlane> tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
       GlobalVector Ng = tpMuGlobal->normalVector();
       Surface* surf = (Surface*)&refSurface;
-      const Plane* refPlane = dynamic_cast<Plane*>(surf); 
+      const Plane* refPlane = dynamic_cast<Plane*>(surf);
       GlobalVector Nlp = refPlane->normalVector();
-      
-      if(debug_){
-	std::cout<<" Nlocal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-	 <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	std::cout<<"  global "<<Ng.x()<<" "<<Ng.y()<<" "<<Ng.z()<<std::endl;
-	std::cout<<"      lp "<<Nlp.x()<<" "<<Nlp.y()<<" "<<Nlp.z()<<std::endl;
-	//std::cout<<" Nlocal Nglobal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-	// <<Ng.x()<<" "<<Ng.y()<<" "<<Ng.z()
-	//<<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
+
+      if (debug_) {
+        std::cout << " Nlocal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                  << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+        std::cout << "  global " << Ng.x() << " " << Ng.y() << " " << Ng.z() << std::endl;
+        std::cout << "      lp " << Nlp.x() << " " << Nlp.y() << " " << Nlp.z() << std::endl;
+        //std::cout<<" Nlocal Nglobal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
+        // <<Ng.x()<<" "<<Ng.y()<<" "<<Ng.z()
+        //<<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
       }
 
-      //                          extrapolation to innermost muon hit     
+      //                          extrapolation to innermost muon hit
       extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
       //extrapolationT = propagator->propagate(outerTrackTSOS, refSurface);
-      
-      if(!extrapolationT.isValid()){
-	if(false & alarm)
-	  std::cout<<" !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
-	    //<<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
-		   <<std::endl;
-	continue;
+
+      if (!extrapolationT.isValid()) {
+        if (false & alarm)
+          std::cout << " !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
+                    //<<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
+                    << std::endl;
+        continue;
       }
       tsosMuonIf = 1;
       Rt = GlobalVector((extrapolationT.globalPosition()).x(),
-			(extrapolationT.globalPosition()).y(),
-			(extrapolationT.globalPosition()).z());
-      
+                        (extrapolationT.globalPosition()).y(),
+                        (extrapolationT.globalPosition()).z());
+
       Pt = extrapolationT.globalMomentum();
       //                          global parameters of muon
-      GRm = GlobalVector((innerMuTSOS.globalPosition()).x(),
-			 (innerMuTSOS.globalPosition()).y(),
-			 (innerMuTSOS.globalPosition()).z());
+      GRm = GlobalVector(
+          (innerMuTSOS.globalPosition()).x(), (innerMuTSOS.globalPosition()).y(), (innerMuTSOS.globalPosition()).z());
       GPm = innerMuTSOS.globalMomentum();
       Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
-			 (outerTrackTSOS.globalPosition()).y(),
-			 (outerTrackTSOS.globalPosition()).z());
-      Cm = AlgebraicSymMatrix66 (extrapolationT.cartesianError().matrix() + 
-				 innerMuTSOS.cartesianError().matrix());
-      C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix()); 		   
-      Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix()); 
+                         (outerTrackTSOS.globalPosition()).y(),
+                         (outerTrackTSOS.globalPosition()).z());
+      Cm = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix() + innerMuTSOS.cartesianError().matrix());
+      C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix());
+      Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix());
       C1 = AlgebraicSymMatrix66(innerMuTSOS.cartesianError().matrix());
-     
+
     }  //                    -------------------------------   end Isolated Muon -----
-    
-    
-    if( cosmicMuonMode_ ){      //------------------------------- Cosmic Muon -----
 
-      if((distanceOutIn <= distanceInOut) & (distanceOutIn <= distanceInIn) & 
-	 (distanceOutIn <= distanceOutOut)){             // ----- Out - In ------    
-	if(debug_) std::cout<<" -----    Out - In -----"<<std::endl;
+    if (cosmicMuonMode_) {  //------------------------------- Cosmic Muon -----
 
-        const Surface& refSurface = innerMuTSOS.surface(); 
-	ConstReferenceCountingPointer<TangentPlane> 
-	  tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
-	Nl = tpMuGlobal->normalVector();
+      if ((distanceOutIn <= distanceInOut) & (distanceOutIn <= distanceInIn) &
+          (distanceOutIn <= distanceOutOut)) {  // ----- Out - In ------
+        if (debug_)
+          std::cout << " -----    Out - In -----" << std::endl;
 
-	//                          extrapolation to innermost muon hit     
-	extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
-	//extrapolationT = propagator->propagate(outerTrackTSOS, refSurface);
+        const Surface& refSurface = innerMuTSOS.surface();
+        ConstReferenceCountingPointer<TangentPlane> tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
+        Nl = tpMuGlobal->normalVector();
 
-	if(!extrapolationT.isValid()){
-	  if(false & alarm)
-	    std::cout<<" !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
-	      //<<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
-		     <<std::endl;
-	  continue;
-	}
-	if(debug_)
-	  std::cout<<" extrapolationT.isValid "<<extrapolationT.isValid()<<std::endl; 
+        //                          extrapolation to innermost muon hit
+        extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
+        //extrapolationT = propagator->propagate(outerTrackTSOS, refSurface);
 
-	tsosMuonIf = 1;
-	Rt = GlobalVector((extrapolationT.globalPosition()).x(),
-			  (extrapolationT.globalPosition()).y(),
-			  (extrapolationT.globalPosition()).z());
-	
-	Pt = extrapolationT.globalMomentum();
-	//                          global parameters of muon
-	GRm = GlobalVector((innerMuTSOS.globalPosition()).x(),
-			   (innerMuTSOS.globalPosition()).y(),
-			   (innerMuTSOS.globalPosition()).z());
-	GPm = innerMuTSOS.globalMomentum();
-	Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
-			   (outerTrackTSOS.globalPosition()).y(),
-			   (outerTrackTSOS.globalPosition()).z());
-	Cm = AlgebraicSymMatrix66 (extrapolationT.cartesianError().matrix() + 
-				   innerMuTSOS.cartesianError().matrix());
-	C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix()); 		   
-	Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix()); 
-	C1 = AlgebraicSymMatrix66(innerMuTSOS.cartesianError().matrix());
-	
-	if(false & debug_){
-	  //std::cout<<" ->propDir "<<propagator->propagationDirection()<<std::endl;
-	  PropagationDirectionChooser Chooser;
-	  std::cout<<" propDirCh "
-		   <<Chooser.operator()(*outerTrackTSOS.freeState(), refSurface)
-		   <<" Ch == along "<<(alongMomentum == 
-				       Chooser.operator()(*outerTrackTSOS.freeState(), refSurface))
-		   <<std::endl;
-	  std::cout<<" --- Nlocal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-		   <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	}
-      }           //                                       enf of ---- Out - In -----
-      
+        if (!extrapolationT.isValid()) {
+          if (false & alarm)
+            std::cout << " !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
+                      //<<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
+                      << std::endl;
+          continue;
+        }
+        if (debug_)
+          std::cout << " extrapolationT.isValid " << extrapolationT.isValid() << std::endl;
 
-      else if((distanceInOut <= distanceInIn) & (distanceInOut <= distanceOutIn) & 
-	      (distanceInOut <= distanceOutOut)){            // ----- In - Out ------    
-	if(debug_) std::cout<<" -----    In - Out -----"<<std::endl;
+        tsosMuonIf = 1;
+        Rt = GlobalVector((extrapolationT.globalPosition()).x(),
+                          (extrapolationT.globalPosition()).y(),
+                          (extrapolationT.globalPosition()).z());
 
-	const Surface& refSurface = outerMuTSOS.surface(); 
-	ConstReferenceCountingPointer<TangentPlane> 
-	  tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
-	Nl = tpMuGlobal->normalVector();
-		
-	//                          extrapolation to outermost muon hit     
-	extrapolationT = oppositeSmPr.propagate(innerTrackTSOS, refSurface);
+        Pt = extrapolationT.globalMomentum();
+        //                          global parameters of muon
+        GRm = GlobalVector(
+            (innerMuTSOS.globalPosition()).x(), (innerMuTSOS.globalPosition()).y(), (innerMuTSOS.globalPosition()).z());
+        GPm = innerMuTSOS.globalMomentum();
+        Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
+                           (outerTrackTSOS.globalPosition()).y(),
+                           (outerTrackTSOS.globalPosition()).z());
+        Cm = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix() + innerMuTSOS.cartesianError().matrix());
+        C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix());
+        Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix());
+        C1 = AlgebraicSymMatrix66(innerMuTSOS.cartesianError().matrix());
 
-	if(!extrapolationT.isValid()){
-	  if(false & alarm)
-	    std::cout<<" !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
-	      <<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
-		     <<std::endl;
-	  continue;
-	}
-	if(debug_)
-	  std::cout<<" extrapolationT.isValid "<<extrapolationT.isValid()<<std::endl; 
-	
-	tsosMuonIf = 2;
-	Rt = GlobalVector((extrapolationT.globalPosition()).x(),
-			  (extrapolationT.globalPosition()).y(),
-			  (extrapolationT.globalPosition()).z());
-	
-	Pt = extrapolationT.globalMomentum();
-	//                          global parameters of muon
-	GRm = GlobalVector((outerMuTSOS.globalPosition()).x(),
-			   (outerMuTSOS.globalPosition()).y(),
-			   (outerMuTSOS.globalPosition()).z());
-	GPm = outerMuTSOS.globalMomentum();
-	Rt0 = GlobalVector((innerTrackTSOS.globalPosition()).x(),
-			   (innerTrackTSOS.globalPosition()).y(),
-			   (innerTrackTSOS.globalPosition()).z());
-	Cm = AlgebraicSymMatrix66 (extrapolationT.cartesianError().matrix() + 
-				   outerMuTSOS.cartesianError().matrix());
-	C0 = AlgebraicSymMatrix66(innerTrackTSOS.cartesianError().matrix()); 		   
-	Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix()); 
-	C1 = AlgebraicSymMatrix66(outerMuTSOS.cartesianError().matrix());
-	
-	if(false & debug_){
-	  //std::cout<<" ->propDir "<<propagator->propagationDirection()<<std::endl;
-	  PropagationDirectionChooser Chooser;
-	  std::cout<<" propDirCh "
-		   <<Chooser.operator()(*innerTrackTSOS.freeState(), refSurface)
-		   <<" Ch == oppisite "<<(oppositeToMomentum == 
-					  Chooser.operator()(*innerTrackTSOS.freeState(), refSurface))
-		   <<std::endl;
-	  std::cout<<" --- Nlocal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-		   <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	}
-      }           //                                        enf of ---- In - Out -----
+        if (false & debug_) {
+          //std::cout<<" ->propDir "<<propagator->propagationDirection()<<std::endl;
+          PropagationDirectionChooser Chooser;
+          std::cout << " propDirCh " << Chooser.operator()(*outerTrackTSOS.freeState(), refSurface) << " Ch == along "
+                    << (alongMomentum == Chooser.operator()(*outerTrackTSOS.freeState(), refSurface)) << std::endl;
+          std::cout << " --- Nlocal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                    << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+        }
+      }  //                                       enf of ---- Out - In -----
 
-      else if((distanceOutOut <= distanceInOut) & (distanceOutOut <= distanceInIn) & 
-	      (distanceOutOut <= distanceOutIn)){          // ----- Out - Out ------    
-	if(debug_) std::cout<<" -----    Out - Out -----"<<std::endl;
+      else if ((distanceInOut <= distanceInIn) & (distanceInOut <= distanceOutIn) &
+               (distanceInOut <= distanceOutOut)) {  // ----- In - Out ------
+        if (debug_)
+          std::cout << " -----    In - Out -----" << std::endl;
 
-	// reject: momentum of track has opposite direction to muon track
-	continue;
+        const Surface& refSurface = outerMuTSOS.surface();
+        ConstReferenceCountingPointer<TangentPlane> tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
+        Nl = tpMuGlobal->normalVector();
 
-	const Surface& refSurface = outerMuTSOS.surface(); 
-	ConstReferenceCountingPointer<TangentPlane> 
-	  tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
-	Nl = tpMuGlobal->normalVector();
-		
-	//                          extrapolation to outermost muon hit     
-	extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
+        //                          extrapolation to outermost muon hit
+        extrapolationT = oppositeSmPr.propagate(innerTrackTSOS, refSurface);
 
-	if(!extrapolationT.isValid()){
-	  if(alarm)
-	    std::cout<<" !!!!!!!!! Catastrophe Out-Out extrapolationT.isValid "
-		     <<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
-		     <<std::endl;
-	  continue;
-	}
-	if(debug_)
-	  std::cout<<" extrapolationT.isValid "<<extrapolationT.isValid()<<std::endl; 
+        if (!extrapolationT.isValid()) {
+          if (false & alarm)
+            std::cout << " !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
+                      << "\a\a\a\a\a\a\a\a" << extrapolationT.isValid() << std::endl;
+          continue;
+        }
+        if (debug_)
+          std::cout << " extrapolationT.isValid " << extrapolationT.isValid() << std::endl;
 
-	tsosMuonIf = 2;
-	Rt = GlobalVector((extrapolationT.globalPosition()).x(),
-			  (extrapolationT.globalPosition()).y(),
-			  (extrapolationT.globalPosition()).z());
-	
-	Pt = extrapolationT.globalMomentum();
-	//                          global parameters of muon
-	GRm = GlobalVector((outerMuTSOS.globalPosition()).x(),
-			   (outerMuTSOS.globalPosition()).y(),
-			   (outerMuTSOS.globalPosition()).z());
-	GPm = outerMuTSOS.globalMomentum();
-	Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
-			   (outerTrackTSOS.globalPosition()).y(),
-			   (outerTrackTSOS.globalPosition()).z());
-	Cm = AlgebraicSymMatrix66 (extrapolationT.cartesianError().matrix() + 
-				   outerMuTSOS.cartesianError().matrix());
-	C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix()); 		   
-	Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix()); 
-	C1 = AlgebraicSymMatrix66(outerMuTSOS.cartesianError().matrix());
-	
-	if(debug_){
-	  PropagationDirectionChooser Chooser;
-	  std::cout<<" propDirCh "
-		   <<Chooser.operator()(*outerTrackTSOS.freeState(), refSurface)
-		   <<" Ch == along "<<(alongMomentum == 
-				       Chooser.operator()(*outerTrackTSOS.freeState(), refSurface))
-		   <<std::endl;
-	  std::cout<<" --- Nlocal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-		   <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	  std::cout<<"     Nornal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-		   <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	}
-      }           //                                       enf of ---- Out - Out -----
-      else{
-	if(alarm)
-	  std::cout<<" ------- !!!!!!!!!!!!!!! No proper Out - In \a\a\a\a\a\a\a"<<std::endl; 
-	continue;
+        tsosMuonIf = 2;
+        Rt = GlobalVector((extrapolationT.globalPosition()).x(),
+                          (extrapolationT.globalPosition()).y(),
+                          (extrapolationT.globalPosition()).z());
+
+        Pt = extrapolationT.globalMomentum();
+        //                          global parameters of muon
+        GRm = GlobalVector(
+            (outerMuTSOS.globalPosition()).x(), (outerMuTSOS.globalPosition()).y(), (outerMuTSOS.globalPosition()).z());
+        GPm = outerMuTSOS.globalMomentum();
+        Rt0 = GlobalVector((innerTrackTSOS.globalPosition()).x(),
+                           (innerTrackTSOS.globalPosition()).y(),
+                           (innerTrackTSOS.globalPosition()).z());
+        Cm = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix() + outerMuTSOS.cartesianError().matrix());
+        C0 = AlgebraicSymMatrix66(innerTrackTSOS.cartesianError().matrix());
+        Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix());
+        C1 = AlgebraicSymMatrix66(outerMuTSOS.cartesianError().matrix());
+
+        if (false & debug_) {
+          //std::cout<<" ->propDir "<<propagator->propagationDirection()<<std::endl;
+          PropagationDirectionChooser Chooser;
+          std::cout << " propDirCh " << Chooser.operator()(*innerTrackTSOS.freeState(), refSurface)
+                    << " Ch == oppisite "
+                    << (oppositeToMomentum == Chooser.operator()(*innerTrackTSOS.freeState(), refSurface)) << std::endl;
+          std::cout << " --- Nlocal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                    << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+        }
+      }  //                                        enf of ---- In - Out -----
+
+      else if ((distanceOutOut <= distanceInOut) & (distanceOutOut <= distanceInIn) &
+               (distanceOutOut <= distanceOutIn)) {  // ----- Out - Out ------
+        if (debug_)
+          std::cout << " -----    Out - Out -----" << std::endl;
+
+        // reject: momentum of track has opposite direction to muon track
+        continue;
+
+        const Surface& refSurface = outerMuTSOS.surface();
+        ConstReferenceCountingPointer<TangentPlane> tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
+        Nl = tpMuGlobal->normalVector();
+
+        //                          extrapolation to outermost muon hit
+        extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
+
+        if (!extrapolationT.isValid()) {
+          if (alarm)
+            std::cout << " !!!!!!!!! Catastrophe Out-Out extrapolationT.isValid "
+                      << "\a\a\a\a\a\a\a\a" << extrapolationT.isValid() << std::endl;
+          continue;
+        }
+        if (debug_)
+          std::cout << " extrapolationT.isValid " << extrapolationT.isValid() << std::endl;
+
+        tsosMuonIf = 2;
+        Rt = GlobalVector((extrapolationT.globalPosition()).x(),
+                          (extrapolationT.globalPosition()).y(),
+                          (extrapolationT.globalPosition()).z());
+
+        Pt = extrapolationT.globalMomentum();
+        //                          global parameters of muon
+        GRm = GlobalVector(
+            (outerMuTSOS.globalPosition()).x(), (outerMuTSOS.globalPosition()).y(), (outerMuTSOS.globalPosition()).z());
+        GPm = outerMuTSOS.globalMomentum();
+        Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
+                           (outerTrackTSOS.globalPosition()).y(),
+                           (outerTrackTSOS.globalPosition()).z());
+        Cm = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix() + outerMuTSOS.cartesianError().matrix());
+        C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix());
+        Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix());
+        C1 = AlgebraicSymMatrix66(outerMuTSOS.cartesianError().matrix());
+
+        if (debug_) {
+          PropagationDirectionChooser Chooser;
+          std::cout << " propDirCh " << Chooser.operator()(*outerTrackTSOS.freeState(), refSurface) << " Ch == along "
+                    << (alongMomentum == Chooser.operator()(*outerTrackTSOS.freeState(), refSurface)) << std::endl;
+          std::cout << " --- Nlocal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                    << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+          std::cout << "     Nornal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                    << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+        }
+      }  //                                       enf of ---- Out - Out -----
+      else {
+        if (alarm)
+          std::cout << " ------- !!!!!!!!!!!!!!! No proper Out - In \a\a\a\a\a\a\a" << std::endl;
+        continue;
       }
-      
+
     }  //                     -------------------------------   end Cosmic Muon -----
-    
-    if(tsosMuonIf == 0) {if(info) {std::cout<<"No tsosMuon !!!!!!"<<std::endl; continue;}}
+
+    if (tsosMuonIf == 0) {
+      if (info) {
+        std::cout << "No tsosMuon !!!!!!" << std::endl;
+        continue;
+      }
+    }
     TrajectoryStateOnSurface tsosMuon;
-    if(tsosMuonIf == 1) tsosMuon = muTT.innermostMeasurementState();
-    else tsosMuon = muTT.outermostMeasurementState();
+    if (tsosMuonIf == 1)
+      tsosMuon = muTT.innermostMeasurementState();
+    else
+      tsosMuon = muTT.outermostMeasurementState();
 
     //GlobalTrackerMuonAlignment::misalignMuon(GRm, GPm, Nl, Rt, Rm, Pm);
     AlgebraicVector4 LPRm;  // muon local (dx/dz, dy/dz, x, y)
-    GlobalTrackerMuonAlignment::misalignMuonL
-    (GRm, GPm, Nl, Rt, Rm, Pm, LPRm, extrapolationT, tsosMuon);
+    GlobalTrackerMuonAlignment::misalignMuonL(GRm, GPm, Nl, Rt, Rm, Pm, LPRm, extrapolationT, tsosMuon);
 
     GlobalVector resR = Rm - Rt;
     GlobalVector resP0 = Pm - Pt;
     GlobalVector resP = Pm / Pm.mag() - Pt / Pt.mag();
-    float RelMomResidual = (Pm.mag() - Pt.mag()) / (Pt.mag() + 1.e-6);;
+    float RelMomResidual = (Pm.mag() - Pt.mag()) / (Pt.mag() + 1.e-6);
+    ;
 
     AlgebraicVector6 Vm;
-    Vm(0) = resR.x();  Vm(1) = resR.y();  Vm(2) = resR.z(); 
-    Vm(3) = resP0.x();  Vm(4) = resP0.y();  Vm(5) = resP0.z(); 
+    Vm(0) = resR.x();
+    Vm(1) = resR.y();
+    Vm(2) = resR.z();
+    Vm(3) = resP0.x();
+    Vm(4) = resP0.y();
+    Vm(5) = resP0.z();
     float Rmuon = Rm.perp();
     float Zmuon = Rm.z();
-    float alfa_x = atan2(Nl.x(),Nl.y())*57.29578;
-    
-    if(debug_){
-      std::cout<<" Nx Ny Nz alfa_x "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "<<alfa_x<<std::endl;
+    float alfa_x = atan2(Nl.x(), Nl.y()) * 57.29578;
+
+    if (debug_) {
+      std::cout << " Nx Ny Nz alfa_x " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " " << alfa_x << std::endl;
       //std::cout<<" Rm "<<Rm<<std::endl<<" Rt "<<Rt<<std::endl<<" resR "<<resR<<std::endl
       //       <<" resP "<<resP<<" dp/p "<<RelMomResidual<<std::endl;
     }
 
     double chi_d = 0;
-    for(int i=0; i<=5; i++) chi_d += Vm(i)*Vm(i)/Cm(i,i);
-        
-    AlgebraicVector5 Vml(tsosMuon.localParameters().vector() 
-		       - extrapolationT.localParameters().vector());
+    for (int i = 0; i <= 5; i++)
+      chi_d += Vm(i) * Vm(i) / Cm(i, i);
+
+    AlgebraicVector5 Vml(tsosMuon.localParameters().vector() - extrapolationT.localParameters().vector());
     AlgebraicSymMatrix55 m(tsosMuon.localError().matrix() + extrapolationT.localError().matrix());
     AlgebraicSymMatrix55 Cml(tsosMuon.localError().matrix() + extrapolationT.localError().matrix());
     bool ierrLoc = !m.Invert();
-    if (ierrLoc && debug_ && info) { 
-      std::cout<< " ==== Error inverting Local covariance matrix ==== "<<std::endl;
-      continue;}
-    double chi_Loc = ROOT::Math::Similarity(Vml,m);
-    if(debug_)
-      std::cout<<" chi_Loc px/pz/err "<<chi_Loc<<" "<<Vml(1)/sqrt(Cml(1,1))<<std::endl;
+    if (ierrLoc && debug_ && info) {
+      std::cout << " ==== Error inverting Local covariance matrix ==== " << std::endl;
+      continue;
+    }
+    double chi_Loc = ROOT::Math::Similarity(Vml, m);
+    if (debug_)
+      std::cout << " chi_Loc px/pz/err " << chi_Loc << " " << Vml(1) / sqrt(Cml(1, 1)) << std::endl;
 
-    if(Pt.mag() < 15.) continue;
-    if(Pm.mag() <  5.) continue;
- 
+    if (Pt.mag() < 15.)
+      continue;
+    if (Pm.mag() < 5.)
+      continue;
+
     //if(Pt.mag() < 30.) continue;          // momenum cut  < 30GeV
     //if(Pt.mag() < 60.) continue;          // momenum cut  < 30GeV
     //if(Pt.mag() > 50.) continue;          //  momenum cut > 50GeV
     //if(Pt.mag() > 100.) continue;          //  momenum cut > 100GeV
     //if(trackTT.charge() < 0) continue;    // select positive charge
     //if(trackTT.charge() > 0) continue;    // select negative charge
-    
-    //if(fabs(resR.x()) > 5.) continue;     // strong cut  X 
-    //if(fabs(resR.y()) > 5.) continue;     //             Y 
+
+    //if(fabs(resR.x()) > 5.) continue;     // strong cut  X
+    //if(fabs(resR.y()) > 5.) continue;     //             Y
     //if(fabs(resR.z()) > 5.) continue;     //             Z
     //if(fabs(resR.mag()) > 7.5) continue;   //            dR
 
@@ -1062,8 +1069,8 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
     if(chi_d > 40.) continue;
     */
 
-    //                                            select Barrel 
-    //if(Rmuon < 400. || Rmuon > 450.) continue; 
+    //                                            select Barrel
+    //if(Rmuon < 400. || Rmuon > 450.) continue;
     //if(Zmuon < -600. || Zmuon > 600.) continue;
     //if(fabs(Nl.z()) > 0.95) continue;
     //MuSelect = " Barrel";
@@ -1071,51 +1078,51 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
     //if(Rmuon < 120. || Rmuon > 450.) continue;
     //if(Zmuon < -720.) continue;
     //if(Zmuon > -580.) continue;
-    //if(fabs(Nl.z()) < 0.95) continue;  
+    //if(fabs(Nl.z()) < 0.95) continue;
     //MuSelect = " EndCap1";
     //                                                  EndCap2
     //if(Rmuon < 120. || Rmuon > 450.) continue;
     //if(Zmuon >  720.) continue;
     //if(Zmuon <  580.) continue;
-    //if(fabs(Nl.z()) < 0.95) continue;  
+    //if(fabs(Nl.z()) < 0.95) continue;
     //MuSelect = " EndCap2";
     //                                                 select All
-    if(Rmuon < 120. || Rmuon > 450.) continue;  
-    if(Zmuon < -720. || Zmuon > 720.) continue;
+    if (Rmuon < 120. || Rmuon > 450.)
+      continue;
+    if (Zmuon < -720. || Zmuon > 720.)
+      continue;
     MuSelect = " Barrel+EndCaps";
 
-    
-    if(debug_)
-      std::cout<<" .............. passed all cuts"<<std::endl;
-        
+    if (debug_)
+      std::cout << " .............. passed all cuts" << std::endl;
+
     N_track++;
     //                     gradient and Hessian for each track
-    
-    GlobalTrackerMuonAlignment::gradientGlobalAlg(Rt, Pt, Rm, Nl, Cm);
-    GlobalTrackerMuonAlignment::gradientGlobal(Rt, Pt, Rm, Pm, Nl, Cm); 
 
-    CLHEP::HepSymMatrix covLoc(4,0);
-    for(int i=1; i<=4; i++)
-      for(int j=1; j<=i; j++){
-	covLoc(i,j) = (tsosMuon.localError().matrix()
-		       + extrapolationT.localError().matrix())(i,j);
-	//if(i != j) Cov(i,j) = 0.;
+    GlobalTrackerMuonAlignment::gradientGlobalAlg(Rt, Pt, Rm, Nl, Cm);
+    GlobalTrackerMuonAlignment::gradientGlobal(Rt, Pt, Rm, Pm, Nl, Cm);
+
+    CLHEP::HepSymMatrix covLoc(4, 0);
+    for (int i = 1; i <= 4; i++)
+      for (int j = 1; j <= i; j++) {
+        covLoc(i, j) = (tsosMuon.localError().matrix() + extrapolationT.localError().matrix())(i, j);
+        //if(i != j) Cov(i,j) = 0.;
       }
 
-    const Surface& refSurface = tsosMuon.surface(); 
-    CLHEP::HepMatrix rotLoc (3,3,0);
-    rotLoc(1,1) = refSurface.rotation().xx();
-    rotLoc(1,2) = refSurface.rotation().xy();
-    rotLoc(1,3) = refSurface.rotation().xz();
-    
-    rotLoc(2,1) = refSurface.rotation().yx();
-    rotLoc(2,2) = refSurface.rotation().yy();
-    rotLoc(2,3) = refSurface.rotation().yz();
-    
-    rotLoc(3,1) = refSurface.rotation().zx();
-    rotLoc(3,2) = refSurface.rotation().zy();
-    rotLoc(3,3) = refSurface.rotation().zz();
-    
+    const Surface& refSurface = tsosMuon.surface();
+    CLHEP::HepMatrix rotLoc(3, 3, 0);
+    rotLoc(1, 1) = refSurface.rotation().xx();
+    rotLoc(1, 2) = refSurface.rotation().xy();
+    rotLoc(1, 3) = refSurface.rotation().xz();
+
+    rotLoc(2, 1) = refSurface.rotation().yx();
+    rotLoc(2, 2) = refSurface.rotation().yy();
+    rotLoc(2, 3) = refSurface.rotation().yz();
+
+    rotLoc(3, 1) = refSurface.rotation().zx();
+    rotLoc(3, 2) = refSurface.rotation().zy();
+    rotLoc(3, 3) = refSurface.rotation().zz();
+
     CLHEP::HepVector posLoc(3);
     posLoc(1) = refSurface.position().x();
     posLoc(2) = refSurface.position().y();
@@ -1123,143 +1130,147 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
 
     GlobalTrackerMuonAlignment::gradientLocal(Rt, Pt, Rm, Pm, Nl, covLoc, rotLoc, posLoc, LPRm);
 
-    if(debug_){
-      std::cout<<" Norm   "<<Nl<<std::endl;
-      std::cout<<" posLoc "<<posLoc.T()<<std::endl;
-      std::cout<<" rotLoc "<<rotLoc<<std::endl;
+    if (debug_) {
+      std::cout << " Norm   " << Nl << std::endl;
+      std::cout << " posLoc " << posLoc.T() << std::endl;
+      std::cout << " rotLoc " << rotLoc << std::endl;
     }
 
-    // -----------------------------------------------------  fill histogram 
-    histo->Fill(itMuon->track()->pt()); 
-    
-    //histo2->Fill(itMuon->track()->outerP()); 
-    histo2->Fill(Pt.mag()); 
-    histo3->Fill((PI/2.-itMuon->track()->outerTheta())); 
-    histo4->Fill(itMuon->track()->phi()); 
-    histo5->Fill(Rmuon); 
-    histo6->Fill(Zmuon); 
-    histo7->Fill(RelMomResidual); 
-    //histo8->Fill(chi); 
-    histo8->Fill(chi_d); 
-    
-    histo101->Fill(Zmuon, Rmuon); 
-    histo101->Fill(Rt0.z(), Rt0.perp()); 
-    histo102->Fill(Rt0.x(), Rt0.y()); 
-    histo102->Fill(Rm.x(), Rm.y()); 
-    
-    histo11->Fill(resR.mag()); 
-    if(fabs(Nl.x()) < 0.98) histo12->Fill(resR.x()); 
-    if(fabs(Nl.y()) < 0.98) histo13->Fill(resR.y()); 
-    if(fabs(Nl.z()) < 0.98) histo14->Fill(resR.z()); 
-    histo15->Fill(resP.x()); 
-    histo16->Fill(resP.y()); 
-    histo17->Fill(resP.z()); 
-    
-    if((fabs(Nl.x()) < 0.98) && (fabs(Nl.y()) < 0.98) &&(fabs(Nl.z()) < 0.98))
-      { 
-	histo18->Fill(sqrt(C0(0,0))); 
-	histo19->Fill(sqrt(C1(0,0))); 
-	histo20->Fill(sqrt(C1(0,0)+Ce(0,0))); 		   
-      }
-    if(fabs(Nl.x()) < 0.98) histo21->Fill(Vm(0)/sqrt(Cm(0,0))); 
-    if(fabs(Nl.y()) < 0.98) histo22->Fill(Vm(1)/sqrt(Cm(1,1))); 
-    if(fabs(Nl.z()) < 0.98) histo23->Fill(Vm(2)/sqrt(Cm(2,2))); 
-    histo24->Fill(Vm(3)/sqrt(C1(3,3)+Ce(3,3))); 
-    histo25->Fill(Vm(4)/sqrt(C1(4,4)+Ce(4,4))); 
-    histo26->Fill(Vm(5)/sqrt(C1(5,5)+Ce(5,5))); 
-    histo27->Fill(Nl.x()); 
-    histo28->Fill(Nl.y()); 
-    histo29->Fill(lenghtTrack); 
-    histo30->Fill(lenghtMuon);     
-    histo31->Fill(chi_Loc);
-    histo32->Fill(Vml(1)/sqrt(Cml(1,1))); 
-    histo33->Fill(Vml(2)/sqrt(Cml(2,2))); 
-    histo34->Fill(Vml(3)/sqrt(Cml(3,3))); 
-    histo35->Fill(Vml(4)/sqrt(Cml(4,4))); 
+    // -----------------------------------------------------  fill histogram
+    histo->Fill(itMuon->track()->pt());
 
-    if (debug_) {   //--------------------------------- debug print ----------
-      
-      std::cout<<" diag 0[ "<<C0(0,0)<<" "<<C0(1,1)<<" "<<C0(2,2)<<" "<<C0(3,3)<<" "
-	       <<C0(4,4)<<" "<<C0(5,5)<<" ]"<<std::endl;
-      std::cout<<" diag e[ "<<Ce(0,0)<<" "<<Ce(1,1)<<" "<<Ce(2,2)<<" "<<Ce(3,3)<<" "
-	       <<Ce(4,4)<<" "<<Ce(5,5)<<" ]"<<std::endl;
-      std::cout<<" diag 1[ "<<C1(0,0)<<" "<<C1(1,1)<<" "<<C1(2,2)<<" "<<C1(3,3)<<" "
-	       <<C1(4,4)<<" "<<C1(5,5)<<" ]"<<std::endl;
-      std::cout<<" Rm   "<<Rm.x()<<" "<<Rm.y()<<" "<<Rm.z()
-	       <<" Pm   "<<Pm.x()<<" "<<Pm.y()<<" "<<Pm.z()<<std::endl;
-      std::cout<<" Rt   "<<Rt.x()<<" "<<Rt.y()<<" "<<Rt.z()
-	       <<" Pt   "<<Pt.x()<<" "<<Pt.y()<<" "<<Pt.z()<<std::endl;
-      std::cout<<" Nl*(Rm-Rt) "<<Nl.dot(Rm-Rt)<<std::endl;
-      std::cout<<" resR "<<resR.x()<<" "<<resR.y()<<" "<<resR.z()
-	       <<" resP "<<resP.x()<<" "<<resP.y()<<" "<<resP.z()<<std::endl;       
-      std::cout<<" Rm-t "<<(Rm-Rt).x()<<" "<<(Rm-Rt).y()<<" "<<(Rm-Rt).z()
-	       <<" Pm-t "<<(Pm-Pt).x()<<" "<<(Pm-Pt).y()<<" "<<(Pm-Pt).z()<<std::endl;       
-      std::cout<<" Vm   "<<Vm<<std::endl;
-      std::cout<<" +-   "<<sqrt(Cm(0,0))<<" "<<sqrt(Cm(1,1))<<" "<<sqrt(Cm(2,2))<<" "
-	       <<sqrt(Cm(3,3))<<" "<<sqrt(Cm(4,4))<<" "<<sqrt(Cm(5,5))<<std::endl;
-      std::cout<<" Pmuon Ptrack dP/Ptrack "<<itMuon->outerTrack()->p()<<" "
-	       <<itMuon->track()->outerP()<<" "
-	       <<(itMuon->outerTrack()->p() - 
-		  itMuon->track()->outerP())/itMuon->track()->outerP()<<std::endl;
-      std::cout<<" cov matrix "<<std::endl;
-      std::cout<<Cm<<std::endl;
-      std::cout<<" diag [ "<<Cm(0,0)<<" "<<Cm(1,1)<<" "<<Cm(2,2)<<" "<<Cm(3,3)<<" "
-	       <<Cm(4,4)<<" "<<Cm(5,5)<<" ]"<<std::endl;
-      
+    //histo2->Fill(itMuon->track()->outerP());
+    histo2->Fill(Pt.mag());
+    histo3->Fill((PI / 2. - itMuon->track()->outerTheta()));
+    histo4->Fill(itMuon->track()->phi());
+    histo5->Fill(Rmuon);
+    histo6->Fill(Zmuon);
+    histo7->Fill(RelMomResidual);
+    //histo8->Fill(chi);
+    histo8->Fill(chi_d);
+
+    histo101->Fill(Zmuon, Rmuon);
+    histo101->Fill(Rt0.z(), Rt0.perp());
+    histo102->Fill(Rt0.x(), Rt0.y());
+    histo102->Fill(Rm.x(), Rm.y());
+
+    histo11->Fill(resR.mag());
+    if (fabs(Nl.x()) < 0.98)
+      histo12->Fill(resR.x());
+    if (fabs(Nl.y()) < 0.98)
+      histo13->Fill(resR.y());
+    if (fabs(Nl.z()) < 0.98)
+      histo14->Fill(resR.z());
+    histo15->Fill(resP.x());
+    histo16->Fill(resP.y());
+    histo17->Fill(resP.z());
+
+    if ((fabs(Nl.x()) < 0.98) && (fabs(Nl.y()) < 0.98) && (fabs(Nl.z()) < 0.98)) {
+      histo18->Fill(sqrt(C0(0, 0)));
+      histo19->Fill(sqrt(C1(0, 0)));
+      histo20->Fill(sqrt(C1(0, 0) + Ce(0, 0)));
+    }
+    if (fabs(Nl.x()) < 0.98)
+      histo21->Fill(Vm(0) / sqrt(Cm(0, 0)));
+    if (fabs(Nl.y()) < 0.98)
+      histo22->Fill(Vm(1) / sqrt(Cm(1, 1)));
+    if (fabs(Nl.z()) < 0.98)
+      histo23->Fill(Vm(2) / sqrt(Cm(2, 2)));
+    histo24->Fill(Vm(3) / sqrt(C1(3, 3) + Ce(3, 3)));
+    histo25->Fill(Vm(4) / sqrt(C1(4, 4) + Ce(4, 4)));
+    histo26->Fill(Vm(5) / sqrt(C1(5, 5) + Ce(5, 5)));
+    histo27->Fill(Nl.x());
+    histo28->Fill(Nl.y());
+    histo29->Fill(lenghtTrack);
+    histo30->Fill(lenghtMuon);
+    histo31->Fill(chi_Loc);
+    histo32->Fill(Vml(1) / sqrt(Cml(1, 1)));
+    histo33->Fill(Vml(2) / sqrt(Cml(2, 2)));
+    histo34->Fill(Vml(3) / sqrt(Cml(3, 3)));
+    histo35->Fill(Vml(4) / sqrt(Cml(4, 4)));
+
+    if (debug_) {  //--------------------------------- debug print ----------
+
+      std::cout << " diag 0[ " << C0(0, 0) << " " << C0(1, 1) << " " << C0(2, 2) << " " << C0(3, 3) << " " << C0(4, 4)
+                << " " << C0(5, 5) << " ]" << std::endl;
+      std::cout << " diag e[ " << Ce(0, 0) << " " << Ce(1, 1) << " " << Ce(2, 2) << " " << Ce(3, 3) << " " << Ce(4, 4)
+                << " " << Ce(5, 5) << " ]" << std::endl;
+      std::cout << " diag 1[ " << C1(0, 0) << " " << C1(1, 1) << " " << C1(2, 2) << " " << C1(3, 3) << " " << C1(4, 4)
+                << " " << C1(5, 5) << " ]" << std::endl;
+      std::cout << " Rm   " << Rm.x() << " " << Rm.y() << " " << Rm.z() << " Pm   " << Pm.x() << " " << Pm.y() << " "
+                << Pm.z() << std::endl;
+      std::cout << " Rt   " << Rt.x() << " " << Rt.y() << " " << Rt.z() << " Pt   " << Pt.x() << " " << Pt.y() << " "
+                << Pt.z() << std::endl;
+      std::cout << " Nl*(Rm-Rt) " << Nl.dot(Rm - Rt) << std::endl;
+      std::cout << " resR " << resR.x() << " " << resR.y() << " " << resR.z() << " resP " << resP.x() << " " << resP.y()
+                << " " << resP.z() << std::endl;
+      std::cout << " Rm-t " << (Rm - Rt).x() << " " << (Rm - Rt).y() << " " << (Rm - Rt).z() << " Pm-t "
+                << (Pm - Pt).x() << " " << (Pm - Pt).y() << " " << (Pm - Pt).z() << std::endl;
+      std::cout << " Vm   " << Vm << std::endl;
+      std::cout << " +-   " << sqrt(Cm(0, 0)) << " " << sqrt(Cm(1, 1)) << " " << sqrt(Cm(2, 2)) << " " << sqrt(Cm(3, 3))
+                << " " << sqrt(Cm(4, 4)) << " " << sqrt(Cm(5, 5)) << std::endl;
+      std::cout << " Pmuon Ptrack dP/Ptrack " << itMuon->outerTrack()->p() << " " << itMuon->track()->outerP() << " "
+                << (itMuon->outerTrack()->p() - itMuon->track()->outerP()) / itMuon->track()->outerP() << std::endl;
+      std::cout << " cov matrix " << std::endl;
+      std::cout << Cm << std::endl;
+      std::cout << " diag [ " << Cm(0, 0) << " " << Cm(1, 1) << " " << Cm(2, 2) << " " << Cm(3, 3) << " " << Cm(4, 4)
+                << " " << Cm(5, 5) << " ]" << std::endl;
+
       AlgebraicSymMatrix66 Ro;
       double Diag[6];
-      for(int i=0; i<=5; i++) Diag[i] = sqrt(Cm(i,i));
-      for(int i=0; i<=5; i++)
-	for(int j=0; j<=5; j++)
-	  Ro(i,j) = Cm(i,j)/Diag[i]/Diag[j];
-      std::cout<<" correlation matrix "<<std::endl;
-      std::cout<<Ro<<std::endl;
-      
+      for (int i = 0; i <= 5; i++)
+        Diag[i] = sqrt(Cm(i, i));
+      for (int i = 0; i <= 5; i++)
+        for (int j = 0; j <= 5; j++)
+          Ro(i, j) = Cm(i, j) / Diag[i] / Diag[j];
+      std::cout << " correlation matrix " << std::endl;
+      std::cout << Ro << std::endl;
+
       AlgebraicSymMatrix66 CmI;
-      for(int i=0; i<=5; i++)
-	for(int j=0; j<=5; j++)
-	  CmI(i,j) = Cm(i,j);
-      
+      for (int i = 0; i <= 5; i++)
+        for (int j = 0; j <= 5; j++)
+          CmI(i, j) = Cm(i, j);
+
       bool ierr = !CmI.Invert();
-      if( ierr ) { if(alarm || debug_)
-	  std::cout<<" Error inverse covariance matrix !!!!!!!!!!!"<<std::endl;
-	continue;
-      }       
-      std::cout<<" inverse cov matrix "<<std::endl;
-      std::cout<<Cm<<std::endl;
-      
+      if (ierr) {
+        if (alarm || debug_)
+          std::cout << " Error inverse covariance matrix !!!!!!!!!!!" << std::endl;
+        continue;
+      }
+      std::cout << " inverse cov matrix " << std::endl;
+      std::cout << Cm << std::endl;
+
       double chi = ROOT::Math::Similarity(Vm, CmI);
-      std::cout<<" chi chi_d "<<chi<<" "<<chi_d<<std::endl;
+      std::cout << " chi chi_d " << chi << " " << chi_d << std::endl;
     }  // end of debug_ printout  --------------------------------------------
-    
-  } // end loop on selected muons, i.e. Jim's globalMuon
 
-} //end of analyzeTrackTrack
+  }  // end loop on selected muons, i.e. Jim's globalMuon
 
+}  //end of analyzeTrackTrack
 
 // ------- method to analyze recoTrack & trajectoryMuon of Global Muon ------
-void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
-(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void GlobalTrackerMuonAlignment::analyzeTrackTrajectory(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
-  using namespace reco;  
+  using namespace reco;
   //debug_ = true;
   bool info = false;
   bool alarm = false;
   //bool alarm = true;
   double PI = 3.1415927;
- 
+
   //-*-*-*-*-*-*-
-  cosmicMuonMode_ = true; // true: both Cosmic and IsolatedMuon are treated with 1,2 tracks
+  cosmicMuonMode_ = true;  // true: both Cosmic and IsolatedMuon are treated with 1,2 tracks
   //cosmicMuonMode_ = false; // true: both Cosmic and IsolatedMuon are treated with 1,2 tracks
   //-*-*-*-*-*-*-
-  isolatedMuonMode_ = !cosmicMuonMode_; //true: only IsolatedMuon are treated with 1 track
- 
+  isolatedMuonMode_ = !cosmicMuonMode_;  //true: only IsolatedMuon are treated with 1 track
+
   N_event++;
   if (info || debug_) {
-    std::cout << "----- event " << N_event << " -- tracks "<<N_track<<" ---";
-    if (cosmicMuonMode_) std::cout << " treated as CosmicMu ";
-    if (isolatedMuonMode_) std::cout <<" treated as IsolatedMu ";
+    std::cout << "----- event " << N_event << " -- tracks " << N_track << " ---";
+    if (cosmicMuonMode_)
+      std::cout << " treated as CosmicMu ";
+    if (isolatedMuonMode_)
+      std::cout << " treated as IsolatedMu ";
     std::cout << std::endl;
   }
 
@@ -1268,52 +1279,55 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
   Handle<reco::TrackCollection> gmuons;
   Handle<reco::MuonCollection> smuons;
 
-  if (collectionIsolated){
-    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "TrackerOnly",  tracks);
-    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "StandAlone",  muons);
-    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "GlobalMuon",  gmuons);
-    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "SelectedMuons",  smuons);
+  if (collectionIsolated) {
+    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "TrackerOnly", tracks);
+    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "StandAlone", muons);
+    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "GlobalMuon", gmuons);
+    iEvent.getByLabel("ALCARECOMuAlCalIsolatedMu", "SelectedMuons", smuons);
+  } else if (collectionCosmic) {
+    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "TrackerOnly", tracks);
+    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "StandAlone", muons);
+    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "GlobalMuon", gmuons);
+    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "SelectedMuons", smuons);
+  } else {
+    iEvent.getByLabel(trackTags_, tracks);
+    iEvent.getByLabel(muonTags_, muons);
+    iEvent.getByLabel(gmuonTags_, gmuons);
+    iEvent.getByLabel(smuonTags_, smuons);
   }
-  else if (collectionCosmic){
-    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "TrackerOnly",  tracks);
-    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "StandAlone",  muons);
-    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "GlobalMuon",  gmuons);
-    iEvent.getByLabel("ALCARECOMuAlGlobalCosmics", "SelectedMuons",  smuons);
-  }
-  else{
-    iEvent.getByLabel(trackTags_,tracks);
-    iEvent.getByLabel(muonTags_,muons);
-    iEvent.getByLabel(gmuonTags_,gmuons);
-    iEvent.getByLabel(smuonTags_,smuons);
-  }  
 
   if (debug_) {
-    std::cout << " ievBunch " << iEvent.bunchCrossing()
-	      << " runN " << (int)iEvent.run() <<std::endl;
-    std::cout << " N tracks s/amu gmu selmu "<<tracks->size() << " " <<muons->size()
-              << " "<<gmuons->size() << " " << smuons->size() << std::endl;
-    for (MuonCollection::const_iterator itMuon = smuons->begin();
-	itMuon != smuons->end();
-	 ++itMuon) {
-      std::cout << " is isolatValid Matches " << itMuon->isIsolationValid()
-		<< " " <<itMuon->isMatchesValid() << std::endl;
+    std::cout << " ievBunch " << iEvent.bunchCrossing() << " runN " << (int)iEvent.run() << std::endl;
+    std::cout << " N tracks s/amu gmu selmu " << tracks->size() << " " << muons->size() << " " << gmuons->size() << " "
+              << smuons->size() << std::endl;
+    for (MuonCollection::const_iterator itMuon = smuons->begin(); itMuon != smuons->end(); ++itMuon) {
+      std::cout << " is isolatValid Matches " << itMuon->isIsolationValid() << " " << itMuon->isMatchesValid()
+                << std::endl;
     }
   }
 
-  if (isolatedMuonMode_) {                // ---- Only 1 Isolated Muon --------
-    if (tracks->size() != 1) return;  
-    if (muons->size()  != 1) return;  
-    if (gmuons->size() != 1) return; 
-    if (smuons->size() != 1) return; 
+  if (isolatedMuonMode_) {  // ---- Only 1 Isolated Muon --------
+    if (tracks->size() != 1)
+      return;
+    if (muons->size() != 1)
+      return;
+    if (gmuons->size() != 1)
+      return;
+    if (smuons->size() != 1)
+      return;
   }
-  
-  if (cosmicMuonMode_){                // ---- 1,2 Cosmic Muon --------
-    if (smuons->size() > 2) return; 
-    if (tracks->size() != smuons->size()) return;  
-    if (muons->size() != smuons->size()) return;  
-    if (gmuons->size() != smuons->size()) return;  
+
+  if (cosmicMuonMode_) {  // ---- 1,2 Cosmic Muon --------
+    if (smuons->size() > 2)
+      return;
+    if (tracks->size() != smuons->size())
+      return;
+    if (muons->size() != smuons->size())
+      return;
+    if (gmuons->size() != smuons->size())
+      return;
   }
-  
+
   // ok mc_isolated_mu
   //edm::ESHandle<TrackerGeometry> trackerGeometry;
   //iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
@@ -1323,14 +1337,14 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
   // don't work
   //edm::ESHandle<CSCGeometry> cscGeometry;
   //iSetup.get<MuonGeometryRecord>().get(cscGeometry);
-  
+
   if (watchTrackingGeometry_.check(iSetup) || !trackingGeometry_) {
     edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
     iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
     trackingGeometry_ = &*trackingGeometry;
     theTrackingGeometry = trackingGeometry;
   }
-  
+
   if (watchMagneticFieldRecord_.check(iSetup) || !magneticField_) {
     edm::ESHandle<MagneticField> magneticField;
     iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
@@ -1341,128 +1355,126 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
     edm::ESHandle<Alignments> globalPositionRcd;
     iSetup.get<GlobalPositionRcd>().get(globalPositionRcd);
     globalPositionRcd_ = &*globalPositionRcd;
-    for (std::vector<AlignTransform>::const_iterator i 
-	   = globalPositionRcd_->m_align.begin();
-	 i != globalPositionRcd_->m_align.end();  ++i){
-      if(DetId(DetId::Tracker).rawId() == i->rawId()) iteratorTrackerRcd = i;
-      if(DetId(DetId::Muon).rawId() == i->rawId()) iteratorMuonRcd = i;
-      if(DetId(DetId::Ecal).rawId() == i->rawId()) iteratorEcalRcd = i;
-      if(DetId(DetId::Hcal).rawId() == i->rawId()) iteratorHcalRcd = i;
+    for (std::vector<AlignTransform>::const_iterator i = globalPositionRcd_->m_align.begin();
+         i != globalPositionRcd_->m_align.end();
+         ++i) {
+      if (DetId(DetId::Tracker).rawId() == i->rawId())
+        iteratorTrackerRcd = i;
+      if (DetId(DetId::Muon).rawId() == i->rawId())
+        iteratorMuonRcd = i;
+      if (DetId(DetId::Ecal).rawId() == i->rawId())
+        iteratorEcalRcd = i;
+      if (DetId(DetId::Hcal).rawId() == i->rawId())
+        iteratorHcalRcd = i;
     }
-    if(debug_){
-      std::cout << "=== iteratorTrackerRcd " << iteratorTrackerRcd->rawId()<<" ====\n" 
-		<< " translation " << iteratorTrackerRcd->translation()<<"\n" 
-		<< " angles " << iteratorTrackerRcd->rotation().eulerAngles() << std::endl;
+    if (debug_) {
+      std::cout << "=== iteratorTrackerRcd " << iteratorTrackerRcd->rawId() << " ====\n"
+                << " translation " << iteratorTrackerRcd->translation() << "\n"
+                << " angles " << iteratorTrackerRcd->rotation().eulerAngles() << std::endl;
       std::cout << iteratorTrackerRcd->rotation() << std::endl;
-      std::cout << "=== iteratorMuonRcd " << iteratorMuonRcd->rawId()<<" ====\n" 
-		<< " translation " << iteratorMuonRcd->translation()<<"\n" 
-		<< " angles " << iteratorMuonRcd->rotation().eulerAngles() << std::endl;
+      std::cout << "=== iteratorMuonRcd " << iteratorMuonRcd->rawId() << " ====\n"
+                << " translation " << iteratorMuonRcd->translation() << "\n"
+                << " angles " << iteratorMuonRcd->rotation().eulerAngles() << std::endl;
       std::cout << iteratorMuonRcd->rotation() << std::endl;
-    }   
-  } // end of GlobalPositionRcd
-  
+    }
+  }  // end of GlobalPositionRcd
+
   ESHandle<Propagator> propagator;
   iSetup.get<TrackingComponentsRecord>().get(propagator_, propagator);
 
-  SteppingHelixPropagator alongStHePr = 
-    SteppingHelixPropagator(magneticField_, alongMomentum);  
-  SteppingHelixPropagator oppositeStHePr = 
-    SteppingHelixPropagator(magneticField_, oppositeToMomentum);  
+  SteppingHelixPropagator alongStHePr = SteppingHelixPropagator(magneticField_, alongMomentum);
+  SteppingHelixPropagator oppositeStHePr = SteppingHelixPropagator(magneticField_, oppositeToMomentum);
 
   //double tolerance = 5.e-5;
-  defaultRKPropagator::Product  aprod( magneticField_, alongMomentum, 5.e-5); auto & alongRKPr = aprod.propagator;
-  defaultRKPropagator::Product  oprod( magneticField_, oppositeToMomentum, 5.e-5); auto & oppositeRKPr = oprod.propagator;
+  defaultRKPropagator::Product aprod(magneticField_, alongMomentum, 5.e-5);
+  auto& alongRKPr = aprod.propagator;
+  defaultRKPropagator::Product oprod(magneticField_, oppositeToMomentum, 5.e-5);
+  auto& oppositeRKPr = oprod.propagator;
 
   float epsilon = 5.;
-  SmartPropagator alongSmPr = 
-    SmartPropagator(alongRKPr, alongStHePr, magneticField_, alongMomentum, epsilon);
-  SmartPropagator oppositeSmPr = 
-    SmartPropagator(oppositeRKPr, oppositeStHePr, magneticField_, oppositeToMomentum, epsilon);
+  SmartPropagator alongSmPr = SmartPropagator(alongRKPr, alongStHePr, magneticField_, alongMomentum, epsilon);
+  SmartPropagator oppositeSmPr =
+      SmartPropagator(oppositeRKPr, oppositeStHePr, magneticField_, oppositeToMomentum, epsilon);
 
-  if(defineFitter){
-    if(debug_)
-      std::cout<<" ............... DEFINE FITTER ..................."<<std::endl;
+  if (defineFitter) {
+    if (debug_)
+      std::cout << " ............... DEFINE FITTER ..................." << std::endl;
     KFUpdator* theUpdator = new KFUpdator();
     //Chi2MeasurementEstimator* theEstimator = new Chi2MeasurementEstimator(30);
-    Chi2MeasurementEstimator* theEstimator = new Chi2MeasurementEstimator(100000,100000);
-    theFitter = new KFTrajectoryFitter(alongSmPr, 
-				       *theUpdator, 
-				       *theEstimator);
-    theSmoother = new KFTrajectorySmoother(alongSmPr,
-					   *theUpdator,     
-					   *theEstimator);
-    theFitterOp = new KFTrajectoryFitter(oppositeSmPr, 
-					 *theUpdator, 
-					 *theEstimator);
-    theSmootherOp = new KFTrajectorySmoother(oppositeSmPr,
-					     *theUpdator,     
-					     *theEstimator);
-    
+    Chi2MeasurementEstimator* theEstimator = new Chi2MeasurementEstimator(100000, 100000);
+    theFitter = new KFTrajectoryFitter(alongSmPr, *theUpdator, *theEstimator);
+    theSmoother = new KFTrajectorySmoother(alongSmPr, *theUpdator, *theEstimator);
+    theFitterOp = new KFTrajectoryFitter(oppositeSmPr, *theUpdator, *theEstimator);
+    theSmootherOp = new KFTrajectorySmoother(oppositeSmPr, *theUpdator, *theEstimator);
+
     edm::ESHandle<TransientTrackingRecHitBuilder> builder;
-    iSetup.get<TransientRecHitRecord>().get("WithTrackAngle",builder);
+    iSetup.get<TransientRecHitRecord>().get("WithTrackAngle", builder);
     this->TTRHBuilder = &(*builder);
     this->MuRHBuilder = new MuonTransientTrackingRecHitBuilder(theTrackingGeometry);
-    if(debug_){
-      std::cout<<" theTrackingGeometry.isValid() "<<theTrackingGeometry.isValid()<<std::endl;
-      std::cout<< "get also the MuonTransientTrackingRecHitBuilder" << "\n";
-      std::cout<< "get also the TransientTrackingRecHitBuilder" << "\n";
+    if (debug_) {
+      std::cout << " theTrackingGeometry.isValid() " << theTrackingGeometry.isValid() << std::endl;
+      std::cout << "get also the MuonTransientTrackingRecHitBuilder"
+                << "\n";
+      std::cout << "get also the TransientTrackingRecHitBuilder"
+                << "\n";
     }
     defineFitter = false;
   }
 
   // ................................................ selected/global muon
-  //itMuon -->  Jim's globalMuon  
-  for(MuonCollection::const_iterator itMuon = smuons->begin();
-      itMuon != smuons->end(); ++itMuon) {
-    
-    if(debug_){
-      std::cout<<" mu gM is GM Mu SaM tM "<<itMuon->isGlobalMuon()<<" "
-	       <<itMuon->isMuon()<<" "<<itMuon->isStandAloneMuon()
-	       <<" "<<itMuon->isTrackerMuon()<<" "
-	       <<std::endl;
+  //itMuon -->  Jim's globalMuon
+  for (MuonCollection::const_iterator itMuon = smuons->begin(); itMuon != smuons->end(); ++itMuon) {
+    if (debug_) {
+      std::cout << " mu gM is GM Mu SaM tM " << itMuon->isGlobalMuon() << " " << itMuon->isMuon() << " "
+                << itMuon->isStandAloneMuon() << " " << itMuon->isTrackerMuon() << " " << std::endl;
     }
-    
+
     // get information about the innermost muon hit -------------------------
     TransientTrack muTT(itMuon->outerTrack(), magneticField_, trackingGeometry_);
     TrajectoryStateOnSurface innerMuTSOS = muTT.innermostMeasurementState();
     TrajectoryStateOnSurface outerMuTSOS = muTT.outermostMeasurementState();
-    
+
     // get information about the outermost tracker hit -----------------------
     TransientTrack trackTT(itMuon->track(), magneticField_, trackingGeometry_);
     TrajectoryStateOnSurface outerTrackTSOS = trackTT.outermostMeasurementState();
     TrajectoryStateOnSurface innerTrackTSOS = trackTT.innermostMeasurementState();
-    
-    GlobalPoint pointTrackIn  = innerTrackTSOS.globalPosition();
+
+    GlobalPoint pointTrackIn = innerTrackTSOS.globalPosition();
     GlobalPoint pointTrackOut = outerTrackTSOS.globalPosition();
-    float lenghtTrack = (pointTrackOut-pointTrackIn).mag();
-    GlobalPoint pointMuonIn  = innerMuTSOS.globalPosition();
+    float lenghtTrack = (pointTrackOut - pointTrackIn).mag();
+    GlobalPoint pointMuonIn = innerMuTSOS.globalPosition();
     GlobalPoint pointMuonOut = outerMuTSOS.globalPosition();
     float lenghtMuon = (pointMuonOut - pointMuonIn).mag();
     GlobalVector momentumTrackOut = outerTrackTSOS.globalMomentum();
     GlobalVector momentumTrackIn = innerTrackTSOS.globalMomentum();
-    float distanceInIn   = (pointTrackIn  - pointMuonIn).mag();
-    float distanceInOut  = (pointTrackIn  - pointMuonOut).mag();
-    float distanceOutIn  = (pointTrackOut - pointMuonIn).mag();
+    float distanceInIn = (pointTrackIn - pointMuonIn).mag();
+    float distanceInOut = (pointTrackIn - pointMuonOut).mag();
+    float distanceOutIn = (pointTrackOut - pointMuonIn).mag();
     float distanceOutOut = (pointTrackOut - pointMuonOut).mag();
 
-    if(debug_){
-      std::cout<<" pointTrackIn "<<pointTrackIn<<std::endl;
-      std::cout<<"          Out "<<pointTrackOut<<" lenght "<<lenghtTrack<<std::endl;
-      std::cout<<" point MuonIn "<<pointMuonIn<<std::endl;
-      std::cout<<"          Out "<<pointMuonOut<<" lenght "<<lenghtMuon<<std::endl;
-      std::cout<<" momeTrackIn Out "<<momentumTrackIn<<" "<<momentumTrackOut<<std::endl;
-      std::cout<<" doi io ii oo "<<distanceOutIn<<" "<<distanceInOut<<" "
-	       <<distanceInIn<<" "<<distanceOutOut<<std::endl; 
-  }   
+    if (debug_) {
+      std::cout << " pointTrackIn " << pointTrackIn << std::endl;
+      std::cout << "          Out " << pointTrackOut << " lenght " << lenghtTrack << std::endl;
+      std::cout << " point MuonIn " << pointMuonIn << std::endl;
+      std::cout << "          Out " << pointMuonOut << " lenght " << lenghtMuon << std::endl;
+      std::cout << " momeTrackIn Out " << momentumTrackIn << " " << momentumTrackOut << std::endl;
+      std::cout << " doi io ii oo " << distanceOutIn << " " << distanceInOut << " " << distanceInIn << " "
+                << distanceOutOut << std::endl;
+    }
 
-    if(lenghtTrack < 90.) continue;
-    if(lenghtMuon < 300.) continue;
-    if(innerMuTSOS.globalMomentum().mag() < 5. || outerMuTSOS.globalMomentum().mag() < 5.) continue;
-    if(momentumTrackIn.mag() < 15. || momentumTrackOut.mag() < 15.) continue;
-    if(trackTT.charge() != muTT.charge()) continue;
+    if (lenghtTrack < 90.)
+      continue;
+    if (lenghtMuon < 300.)
+      continue;
+    if (innerMuTSOS.globalMomentum().mag() < 5. || outerMuTSOS.globalMomentum().mag() < 5.)
+      continue;
+    if (momentumTrackIn.mag() < 15. || momentumTrackOut.mag() < 15.)
+      continue;
+    if (trackTT.charge() != muTT.charge())
+      continue;
 
-    if(debug_)
-      std::cout<<" passed lenght momentum cuts"<<std::endl;
+    if (debug_)
+      std::cout << " passed lenght momentum cuts" << std::endl;
 
     GlobalVector GRm, GPm, Nl, Rm, Pm, Rt, Pt, Rt0;
     AlgebraicSymMatrix66 Cm, C0, Ce, C1;
@@ -1474,418 +1486,423 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
     TrajectoryStateOnSurface muonFittedTSOS;
     TrajectoryStateOnSurface trackFittedTSOS;
 
-    if( isolatedMuonMode_ ){      //------------------------------- Isolated Muon --- Out-In --
-      if(debug_) std::cout<<" ------ Isolated (out-in) ----- "<<std::endl;
-      const Surface& refSurface = innerMuTSOS.surface(); 
-      ConstReferenceCountingPointer<TangentPlane> 
-	tpMuLocal(refSurface.tangentPlane(innerMuTSOS.localPosition()));
+    if (isolatedMuonMode_) {  //------------------------------- Isolated Muon --- Out-In --
+      if (debug_)
+        std::cout << " ------ Isolated (out-in) ----- " << std::endl;
+      const Surface& refSurface = innerMuTSOS.surface();
+      ConstReferenceCountingPointer<TangentPlane> tpMuLocal(refSurface.tangentPlane(innerMuTSOS.localPosition()));
       Nl = tpMuLocal->normalVector();
-      ConstReferenceCountingPointer<TangentPlane> 
-      tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
+      ConstReferenceCountingPointer<TangentPlane> tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
       GlobalVector Ng = tpMuGlobal->normalVector();
       Surface* surf = (Surface*)&refSurface;
-      const Plane* refPlane = dynamic_cast<Plane*>(surf); 
+      const Plane* refPlane = dynamic_cast<Plane*>(surf);
       GlobalVector Nlp = refPlane->normalVector();
-      
-      if(debug_){
-	std::cout<<" Nlocal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-	 <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	std::cout<<"  global "<<Ng.x()<<" "<<Ng.y()<<" "<<Ng.z()<<std::endl;
-	std::cout<<"      lp "<<Nlp.x()<<" "<<Nlp.y()<<" "<<Nlp.z()<<std::endl;
-	//std::cout<<" Nlocal Nglobal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-	// <<Ng.x()<<" "<<Ng.y()<<" "<<Ng.z()
-	//<<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
+
+      if (debug_) {
+        std::cout << " Nlocal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                  << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+        std::cout << "  global " << Ng.x() << " " << Ng.y() << " " << Ng.z() << std::endl;
+        std::cout << "      lp " << Nlp.x() << " " << Nlp.y() << " " << Nlp.z() << std::endl;
+        //std::cout<<" Nlocal Nglobal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
+        // <<Ng.x()<<" "<<Ng.y()<<" "<<Ng.z()
+        //<<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
       }
 
-      //                          extrapolation to innermost muon hit     
+      //                          extrapolation to innermost muon hit
 
       //extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
-      if(!refitTrack_)
-	extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
-      else{
-	GlobalTrackerMuonAlignment::trackFitter(itMuon->track(),
-						trackTT,alongMomentum,trackFittedTSOS);
-	if(trackFittedTSOS.isValid())
-	  extrapolationT = alongSmPr.propagate(trackFittedTSOS, refSurface);	   
-      }   
-      
-      if(!extrapolationT.isValid()){
-	if(false & alarm)
-	  std::cout<<" !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
-	    //<<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
-		   <<std::endl;
-	continue;
+      if (!refitTrack_)
+        extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
+      else {
+        GlobalTrackerMuonAlignment::trackFitter(itMuon->track(), trackTT, alongMomentum, trackFittedTSOS);
+        if (trackFittedTSOS.isValid())
+          extrapolationT = alongSmPr.propagate(trackFittedTSOS, refSurface);
+      }
+
+      if (!extrapolationT.isValid()) {
+        if (false & alarm)
+          std::cout << " !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
+                    //<<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
+                    << std::endl;
+        continue;
       }
       tsosMuonIf = 1;
       Rt = GlobalVector((extrapolationT.globalPosition()).x(),
-			(extrapolationT.globalPosition()).y(),
-			(extrapolationT.globalPosition()).z());
-      
+                        (extrapolationT.globalPosition()).y(),
+                        (extrapolationT.globalPosition()).z());
+
       Pt = extrapolationT.globalMomentum();
       //                          global parameters of muon
-      GRm = GlobalVector((innerMuTSOS.globalPosition()).x(),
-			 (innerMuTSOS.globalPosition()).y(),
-			 (innerMuTSOS.globalPosition()).z());
+      GRm = GlobalVector(
+          (innerMuTSOS.globalPosition()).x(), (innerMuTSOS.globalPosition()).y(), (innerMuTSOS.globalPosition()).z());
       GPm = innerMuTSOS.globalMomentum();
-      
+
       Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
-			 (outerTrackTSOS.globalPosition()).y(),
-			 (outerTrackTSOS.globalPosition()).z());
-      Cm = AlgebraicSymMatrix66 (extrapolationT.cartesianError().matrix() + 
-				 innerMuTSOS.cartesianError().matrix());
-      C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix()); 		   
-      Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix()); 
+                         (outerTrackTSOS.globalPosition()).y(),
+                         (outerTrackTSOS.globalPosition()).z());
+      Cm = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix() + innerMuTSOS.cartesianError().matrix());
+      C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix());
+      Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix());
       C1 = AlgebraicSymMatrix66(innerMuTSOS.cartesianError().matrix());
 
-      if(refitMuon_)
-	GlobalTrackerMuonAlignment::muonFitter(itMuon->outerTrack(),muTT,oppositeToMomentum,muonFittedTSOS);
+      if (refitMuon_)
+        GlobalTrackerMuonAlignment::muonFitter(itMuon->outerTrack(), muTT, oppositeToMomentum, muonFittedTSOS);
 
     }  //                    -------------------------------   end Isolated Muon -- Out - In  ---
-    
-    
-    if( cosmicMuonMode_ ){      //------------------------------- Cosmic Muon -----
-      
-      if((distanceOutIn <= distanceInOut) & (distanceOutIn <= distanceInIn) & 
-	 (distanceOutIn <= distanceOutOut)){             // ----- Out - In ------    
-	if(debug_) std::cout<<" -----    Out - In -----"<<std::endl;
 
-        const Surface& refSurface = innerMuTSOS.surface(); 
-	ConstReferenceCountingPointer<TangentPlane> 
-	  tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
-	Nl = tpMuGlobal->normalVector();
+    if (cosmicMuonMode_) {  //------------------------------- Cosmic Muon -----
 
-	//                          extrapolation to innermost muon hit     
-	//extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
-	if(!refitTrack_)
-	  extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
-	else{
-	  GlobalTrackerMuonAlignment::trackFitter(itMuon->track(),
-						  trackTT,alongMomentum,trackFittedTSOS);
-	  if(trackFittedTSOS.isValid())
-	    extrapolationT = alongSmPr.propagate(trackFittedTSOS, refSurface);	   
-	}  
+      if ((distanceOutIn <= distanceInOut) & (distanceOutIn <= distanceInIn) &
+          (distanceOutIn <= distanceOutOut)) {  // ----- Out - In ------
+        if (debug_)
+          std::cout << " -----    Out - In -----" << std::endl;
 
-	if(!extrapolationT.isValid()){
-	  if(false & alarm)
-	    std::cout<<" !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
-	      //<<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
-		     <<std::endl;
-	  continue;
-	}
-	if(debug_)
-	  std::cout<<" extrapolationT.isValid "<<extrapolationT.isValid()<<std::endl; 
+        const Surface& refSurface = innerMuTSOS.surface();
+        ConstReferenceCountingPointer<TangentPlane> tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
+        Nl = tpMuGlobal->normalVector();
 
-	tsosMuonIf = 1;
-	Rt = GlobalVector((extrapolationT.globalPosition()).x(),
-			  (extrapolationT.globalPosition()).y(),
-			  (extrapolationT.globalPosition()).z());
-	
-	Pt = extrapolationT.globalMomentum();
-	//                          global parameters of muon
-	GRm = GlobalVector((innerMuTSOS.globalPosition()).x(),
-			   (innerMuTSOS.globalPosition()).y(),
-			   (innerMuTSOS.globalPosition()).z());
-	GPm = innerMuTSOS.globalMomentum();
-	Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
-			   (outerTrackTSOS.globalPosition()).y(),
-			   (outerTrackTSOS.globalPosition()).z());
-	Cm = AlgebraicSymMatrix66 (extrapolationT.cartesianError().matrix() + 
-				   innerMuTSOS.cartesianError().matrix());
-	C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix()); 		   
-	Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix()); 
-	C1 = AlgebraicSymMatrix66(innerMuTSOS.cartesianError().matrix());
-	
-	if(refitMuon_)
-	  GlobalTrackerMuonAlignment::muonFitter(itMuon->outerTrack(),muTT,oppositeToMomentum,muonFittedTSOS);
+        //                          extrapolation to innermost muon hit
+        //extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
+        if (!refitTrack_)
+          extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
+        else {
+          GlobalTrackerMuonAlignment::trackFitter(itMuon->track(), trackTT, alongMomentum, trackFittedTSOS);
+          if (trackFittedTSOS.isValid())
+            extrapolationT = alongSmPr.propagate(trackFittedTSOS, refSurface);
+        }
 
-	if(false & debug_){
-	  //std::cout<<" ->propDir "<<propagator->propagationDirection()<<std::endl;
-	  PropagationDirectionChooser Chooser;
-	  std::cout<<" propDirCh "
-		   <<Chooser.operator()(*outerTrackTSOS.freeState(), refSurface)
-		   <<" Ch == along "<<(alongMomentum == 
-				       Chooser.operator()(*outerTrackTSOS.freeState(), refSurface))
-		   <<std::endl;
-	  std::cout<<" --- Nlocal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-		   <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	}
-      }           //                                       enf of ---- Out - In -----
-      
+        if (!extrapolationT.isValid()) {
+          if (false & alarm)
+            std::cout << " !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
+                      //<<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
+                      << std::endl;
+          continue;
+        }
+        if (debug_)
+          std::cout << " extrapolationT.isValid " << extrapolationT.isValid() << std::endl;
 
-      else if((distanceInOut <= distanceInIn) & (distanceInOut <= distanceOutIn) & 
-	      (distanceInOut <= distanceOutOut)){            // ----- In - Out ------    
-	if(debug_) std::cout<<" -----    In - Out -----"<<std::endl;
+        tsosMuonIf = 1;
+        Rt = GlobalVector((extrapolationT.globalPosition()).x(),
+                          (extrapolationT.globalPosition()).y(),
+                          (extrapolationT.globalPosition()).z());
 
-	const Surface& refSurface = outerMuTSOS.surface(); 
-	ConstReferenceCountingPointer<TangentPlane> 
-	  tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
-	Nl = tpMuGlobal->normalVector();
-		
-	//                          extrapolation to outermost muon hit     
-	//extrapolationT = oppositeSmPr.propagate(innerTrackTSOS, refSurface);
-	if(!refitTrack_)
-	  extrapolationT = oppositeSmPr.propagate(innerTrackTSOS, refSurface);
-	else{
-	  GlobalTrackerMuonAlignment::trackFitter(itMuon->track(),
-						trackTT,oppositeToMomentum,trackFittedTSOS);
-	if(trackFittedTSOS.isValid())
-	  extrapolationT = oppositeSmPr.propagate(trackFittedTSOS, refSurface);	   
-      }   
+        Pt = extrapolationT.globalMomentum();
+        //                          global parameters of muon
+        GRm = GlobalVector(
+            (innerMuTSOS.globalPosition()).x(), (innerMuTSOS.globalPosition()).y(), (innerMuTSOS.globalPosition()).z());
+        GPm = innerMuTSOS.globalMomentum();
+        Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
+                           (outerTrackTSOS.globalPosition()).y(),
+                           (outerTrackTSOS.globalPosition()).z());
+        Cm = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix() + innerMuTSOS.cartesianError().matrix());
+        C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix());
+        Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix());
+        C1 = AlgebraicSymMatrix66(innerMuTSOS.cartesianError().matrix());
 
-	if(!extrapolationT.isValid()){
-	  if(false & alarm)
-	    std::cout<<" !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
-	      <<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
-		     <<std::endl;
-	  continue;
-	}
-	if(debug_)
-	  std::cout<<" extrapolationT.isValid "<<extrapolationT.isValid()<<std::endl; 
-	
-	tsosMuonIf = 2;
-	Rt = GlobalVector((extrapolationT.globalPosition()).x(),
-			  (extrapolationT.globalPosition()).y(),
-			  (extrapolationT.globalPosition()).z());
-	
-	Pt = extrapolationT.globalMomentum();
-	//                          global parameters of muon
-	GRm = GlobalVector((outerMuTSOS.globalPosition()).x(),
-			   (outerMuTSOS.globalPosition()).y(),
-			   (outerMuTSOS.globalPosition()).z());
-	GPm = outerMuTSOS.globalMomentum();
-	Rt0 = GlobalVector((innerTrackTSOS.globalPosition()).x(),
-			   (innerTrackTSOS.globalPosition()).y(),
-			   (innerTrackTSOS.globalPosition()).z());
-	Cm = AlgebraicSymMatrix66 (extrapolationT.cartesianError().matrix() + 
-				   outerMuTSOS.cartesianError().matrix());
-	C0 = AlgebraicSymMatrix66(innerTrackTSOS.cartesianError().matrix()); 		   
-	Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix()); 
-	C1 = AlgebraicSymMatrix66(outerMuTSOS.cartesianError().matrix());
-	
-	if(refitMuon_)
-	  GlobalTrackerMuonAlignment::muonFitter(itMuon->outerTrack(),muTT,alongMomentum,muonFittedTSOS);
+        if (refitMuon_)
+          GlobalTrackerMuonAlignment::muonFitter(itMuon->outerTrack(), muTT, oppositeToMomentum, muonFittedTSOS);
 
-	if(false & debug_){
-	  //std::cout<<" ->propDir "<<propagator->propagationDirection()<<std::endl;
-	  PropagationDirectionChooser Chooser;
-	  std::cout<<" propDirCh "
-		   <<Chooser.operator()(*innerTrackTSOS.freeState(), refSurface)
-		   <<" Ch == oppisite "<<(oppositeToMomentum == 
-					  Chooser.operator()(*innerTrackTSOS.freeState(), refSurface))
-		   <<std::endl;
-	  std::cout<<" --- Nlocal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-		   <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	}
-      }           //                                        enf of ---- In - Out -----
+        if (false & debug_) {
+          //std::cout<<" ->propDir "<<propagator->propagationDirection()<<std::endl;
+          PropagationDirectionChooser Chooser;
+          std::cout << " propDirCh " << Chooser.operator()(*outerTrackTSOS.freeState(), refSurface) << " Ch == along "
+                    << (alongMomentum == Chooser.operator()(*outerTrackTSOS.freeState(), refSurface)) << std::endl;
+          std::cout << " --- Nlocal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                    << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+        }
+      }  //                                       enf of ---- Out - In -----
 
-      else if((distanceOutOut <= distanceInOut) & (distanceOutOut <= distanceInIn) & 
-	      (distanceOutOut <= distanceOutIn)){          // ----- Out - Out ------    
-	if(debug_) std::cout<<" -----    Out - Out -----"<<std::endl;
+      else if ((distanceInOut <= distanceInIn) & (distanceInOut <= distanceOutIn) &
+               (distanceInOut <= distanceOutOut)) {  // ----- In - Out ------
+        if (debug_)
+          std::cout << " -----    In - Out -----" << std::endl;
 
-	// reject: momentum of track has opposite direction to muon track
-	continue;
+        const Surface& refSurface = outerMuTSOS.surface();
+        ConstReferenceCountingPointer<TangentPlane> tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
+        Nl = tpMuGlobal->normalVector();
 
-	const Surface& refSurface = outerMuTSOS.surface(); 
-	ConstReferenceCountingPointer<TangentPlane> 
-	  tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
-	Nl = tpMuGlobal->normalVector();
-		
-	//                          extrapolation to outermost muon hit     
-	extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
+        //                          extrapolation to outermost muon hit
+        //extrapolationT = oppositeSmPr.propagate(innerTrackTSOS, refSurface);
+        if (!refitTrack_)
+          extrapolationT = oppositeSmPr.propagate(innerTrackTSOS, refSurface);
+        else {
+          GlobalTrackerMuonAlignment::trackFitter(itMuon->track(), trackTT, oppositeToMomentum, trackFittedTSOS);
+          if (trackFittedTSOS.isValid())
+            extrapolationT = oppositeSmPr.propagate(trackFittedTSOS, refSurface);
+        }
 
-	if(!extrapolationT.isValid()){
-	  if(alarm)
-	    std::cout<<" !!!!!!!!! Catastrophe Out-Out extrapolationT.isValid "
-		     <<"\a\a\a\a\a\a\a\a"<<extrapolationT.isValid()
-		     <<std::endl;
-	  continue;
-	}
-	if(debug_)
-	  std::cout<<" extrapolationT.isValid "<<extrapolationT.isValid()<<std::endl; 
+        if (!extrapolationT.isValid()) {
+          if (false & alarm)
+            std::cout << " !!!!!!!!! Catastrophe Out-In extrapolationT.isValid "
+                      << "\a\a\a\a\a\a\a\a" << extrapolationT.isValid() << std::endl;
+          continue;
+        }
+        if (debug_)
+          std::cout << " extrapolationT.isValid " << extrapolationT.isValid() << std::endl;
 
-	tsosMuonIf = 2;
-	Rt = GlobalVector((extrapolationT.globalPosition()).x(),
-			  (extrapolationT.globalPosition()).y(),
-			  (extrapolationT.globalPosition()).z());
-	
-	Pt = extrapolationT.globalMomentum();
-	//                          global parameters of muon
-	GRm = GlobalVector((outerMuTSOS.globalPosition()).x(),
-			   (outerMuTSOS.globalPosition()).y(),
-			   (outerMuTSOS.globalPosition()).z());
-	GPm = outerMuTSOS.globalMomentum();
-	Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
-			   (outerTrackTSOS.globalPosition()).y(),
-			   (outerTrackTSOS.globalPosition()).z());
-	Cm = AlgebraicSymMatrix66 (extrapolationT.cartesianError().matrix() + 
-				   outerMuTSOS.cartesianError().matrix());
-	C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix()); 		   
-	Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix()); 
-	C1 = AlgebraicSymMatrix66(outerMuTSOS.cartesianError().matrix());
-	
-	if(debug_){
-	  PropagationDirectionChooser Chooser;
-	  std::cout<<" propDirCh "
-		   <<Chooser.operator()(*outerTrackTSOS.freeState(), refSurface)
-		   <<" Ch == along "<<(alongMomentum == 
-				       Chooser.operator()(*outerTrackTSOS.freeState(), refSurface))
-		   <<std::endl;
-	  std::cout<<" --- Nlocal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-		   <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	  std::cout<<"     Nornal "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "
-		   <<" alfa "<<int(asin(Nl.x())*57.29578)<<std::endl;
-	}
-      }           //                                       enf of ---- Out - Out -----
-      else{
-	if(alarm)
-	  std::cout<<" ------- !!!!!!!!!!!!!!! No proper Out - In \a\a\a\a\a\a\a"<<std::endl; 
-	continue;
+        tsosMuonIf = 2;
+        Rt = GlobalVector((extrapolationT.globalPosition()).x(),
+                          (extrapolationT.globalPosition()).y(),
+                          (extrapolationT.globalPosition()).z());
+
+        Pt = extrapolationT.globalMomentum();
+        //                          global parameters of muon
+        GRm = GlobalVector(
+            (outerMuTSOS.globalPosition()).x(), (outerMuTSOS.globalPosition()).y(), (outerMuTSOS.globalPosition()).z());
+        GPm = outerMuTSOS.globalMomentum();
+        Rt0 = GlobalVector((innerTrackTSOS.globalPosition()).x(),
+                           (innerTrackTSOS.globalPosition()).y(),
+                           (innerTrackTSOS.globalPosition()).z());
+        Cm = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix() + outerMuTSOS.cartesianError().matrix());
+        C0 = AlgebraicSymMatrix66(innerTrackTSOS.cartesianError().matrix());
+        Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix());
+        C1 = AlgebraicSymMatrix66(outerMuTSOS.cartesianError().matrix());
+
+        if (refitMuon_)
+          GlobalTrackerMuonAlignment::muonFitter(itMuon->outerTrack(), muTT, alongMomentum, muonFittedTSOS);
+
+        if (false & debug_) {
+          //std::cout<<" ->propDir "<<propagator->propagationDirection()<<std::endl;
+          PropagationDirectionChooser Chooser;
+          std::cout << " propDirCh " << Chooser.operator()(*innerTrackTSOS.freeState(), refSurface)
+                    << " Ch == oppisite "
+                    << (oppositeToMomentum == Chooser.operator()(*innerTrackTSOS.freeState(), refSurface)) << std::endl;
+          std::cout << " --- Nlocal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                    << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+        }
+      }  //                                        enf of ---- In - Out -----
+
+      else if ((distanceOutOut <= distanceInOut) & (distanceOutOut <= distanceInIn) &
+               (distanceOutOut <= distanceOutIn)) {  // ----- Out - Out ------
+        if (debug_)
+          std::cout << " -----    Out - Out -----" << std::endl;
+
+        // reject: momentum of track has opposite direction to muon track
+        continue;
+
+        const Surface& refSurface = outerMuTSOS.surface();
+        ConstReferenceCountingPointer<TangentPlane> tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
+        Nl = tpMuGlobal->normalVector();
+
+        //                          extrapolation to outermost muon hit
+        extrapolationT = alongSmPr.propagate(outerTrackTSOS, refSurface);
+
+        if (!extrapolationT.isValid()) {
+          if (alarm)
+            std::cout << " !!!!!!!!! Catastrophe Out-Out extrapolationT.isValid "
+                      << "\a\a\a\a\a\a\a\a" << extrapolationT.isValid() << std::endl;
+          continue;
+        }
+        if (debug_)
+          std::cout << " extrapolationT.isValid " << extrapolationT.isValid() << std::endl;
+
+        tsosMuonIf = 2;
+        Rt = GlobalVector((extrapolationT.globalPosition()).x(),
+                          (extrapolationT.globalPosition()).y(),
+                          (extrapolationT.globalPosition()).z());
+
+        Pt = extrapolationT.globalMomentum();
+        //                          global parameters of muon
+        GRm = GlobalVector(
+            (outerMuTSOS.globalPosition()).x(), (outerMuTSOS.globalPosition()).y(), (outerMuTSOS.globalPosition()).z());
+        GPm = outerMuTSOS.globalMomentum();
+        Rt0 = GlobalVector((outerTrackTSOS.globalPosition()).x(),
+                           (outerTrackTSOS.globalPosition()).y(),
+                           (outerTrackTSOS.globalPosition()).z());
+        Cm = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix() + outerMuTSOS.cartesianError().matrix());
+        C0 = AlgebraicSymMatrix66(outerTrackTSOS.cartesianError().matrix());
+        Ce = AlgebraicSymMatrix66(extrapolationT.cartesianError().matrix());
+        C1 = AlgebraicSymMatrix66(outerMuTSOS.cartesianError().matrix());
+
+        if (debug_) {
+          PropagationDirectionChooser Chooser;
+          std::cout << " propDirCh " << Chooser.operator()(*outerTrackTSOS.freeState(), refSurface) << " Ch == along "
+                    << (alongMomentum == Chooser.operator()(*outerTrackTSOS.freeState(), refSurface)) << std::endl;
+          std::cout << " --- Nlocal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                    << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+          std::cout << "     Nornal " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " "
+                    << " alfa " << int(asin(Nl.x()) * 57.29578) << std::endl;
+        }
+      }  //                                       enf of ---- Out - Out -----
+      else {
+        if (alarm)
+          std::cout << " ------- !!!!!!!!!!!!!!! No proper Out - In \a\a\a\a\a\a\a" << std::endl;
+        continue;
       }
-      
+
     }  //                     -------------------------------   end Cosmic Muon -----
-    
-    if(tsosMuonIf == 0) {if(info) {std::cout<<"No tsosMuon !!!!!!"<<std::endl; continue;}}
+
+    if (tsosMuonIf == 0) {
+      if (info) {
+        std::cout << "No tsosMuon !!!!!!" << std::endl;
+        continue;
+      }
+    }
     TrajectoryStateOnSurface tsosMuon;
-    if(tsosMuonIf == 1) tsosMuon = muTT.innermostMeasurementState();
-    else tsosMuon = muTT.outermostMeasurementState();
+    if (tsosMuonIf == 1)
+      tsosMuon = muTT.innermostMeasurementState();
+    else
+      tsosMuon = muTT.outermostMeasurementState();
 
     //GlobalTrackerMuonAlignment::misalignMuon(GRm, GPm, Nl, Rt, Rm, Pm);
     AlgebraicVector4 LPRm;  // muon local (dx/dz, dy/dz, x, y)
-    GlobalTrackerMuonAlignment::misalignMuonL
-    (GRm, GPm, Nl, Rt, Rm, Pm, LPRm, extrapolationT, tsosMuon);
+    GlobalTrackerMuonAlignment::misalignMuonL(GRm, GPm, Nl, Rt, Rm, Pm, LPRm, extrapolationT, tsosMuon);
 
-    if(refitTrack_){
-      if(!trackFittedTSOS.isValid()){ 
-	if(info) std::cout<<" =================  trackFittedTSOS notValid !!!!!!!! "<<std::endl;
-	continue;}
-      if(debug_) this->debugTrajectorySOS(" trackFittedTSOS ", trackFittedTSOS);
+    if (refitTrack_) {
+      if (!trackFittedTSOS.isValid()) {
+        if (info)
+          std::cout << " =================  trackFittedTSOS notValid !!!!!!!! " << std::endl;
+        continue;
+      }
+      if (debug_)
+        this->debugTrajectorySOS(" trackFittedTSOS ", trackFittedTSOS);
     }
 
-    if(refitMuon_){
-      if(!muonFittedTSOS.isValid()){ 
-	if(info) std::cout<<" =================  muonFittedTSOS notValid !!!!!!!! "<<std::endl;
-	continue;}
-      if(debug_) this->debugTrajectorySOS(" muonFittedTSOS ", muonFittedTSOS);
+    if (refitMuon_) {
+      if (!muonFittedTSOS.isValid()) {
+        if (info)
+          std::cout << " =================  muonFittedTSOS notValid !!!!!!!! " << std::endl;
+        continue;
+      }
+      if (debug_)
+        this->debugTrajectorySOS(" muonFittedTSOS ", muonFittedTSOS);
       Rm = GlobalVector((muonFittedTSOS.globalPosition()).x(),
-			(muonFittedTSOS.globalPosition()).y(),
-			(muonFittedTSOS.globalPosition()).z());
+                        (muonFittedTSOS.globalPosition()).y(),
+                        (muonFittedTSOS.globalPosition()).z());
       Pm = muonFittedTSOS.globalMomentum();
       LPRm = AlgebraicVector4(muonFittedTSOS.localParameters().vector()(1),
-			      muonFittedTSOS.localParameters().vector()(2),
-			      muonFittedTSOS.localParameters().vector()(3),
-			      muonFittedTSOS.localParameters().vector()(4)); 
+                              muonFittedTSOS.localParameters().vector()(2),
+                              muonFittedTSOS.localParameters().vector()(3),
+                              muonFittedTSOS.localParameters().vector()(4));
     }
     GlobalVector resR = Rm - Rt;
     GlobalVector resP0 = Pm - Pt;
     GlobalVector resP = Pm / Pm.mag() - Pt / Pt.mag();
-    float RelMomResidual = (Pm.mag() - Pt.mag()) / (Pt.mag() + 1.e-6);;
+    float RelMomResidual = (Pm.mag() - Pt.mag()) / (Pt.mag() + 1.e-6);
+    ;
 
     AlgebraicVector6 Vm;
-    Vm(0) = resR.x();  Vm(1) = resR.y();  Vm(2) = resR.z(); 
-    Vm(3) = resP0.x();  Vm(4) = resP0.y();  Vm(5) = resP0.z(); 
+    Vm(0) = resR.x();
+    Vm(1) = resR.y();
+    Vm(2) = resR.z();
+    Vm(3) = resP0.x();
+    Vm(4) = resP0.y();
+    Vm(5) = resP0.z();
     float Rmuon = Rm.perp();
     float Zmuon = Rm.z();
-    float alfa_x = atan2(Nl.x(),Nl.y())*57.29578;
-    
-    if(debug_){
-      std::cout<<" Nx Ny Nz alfa_x "<<Nl.x()<<" "<<Nl.y()<<" "<<Nl.z()<<" "<<alfa_x<<std::endl;
+    float alfa_x = atan2(Nl.x(), Nl.y()) * 57.29578;
+
+    if (debug_) {
+      std::cout << " Nx Ny Nz alfa_x " << Nl.x() << " " << Nl.y() << " " << Nl.z() << " " << alfa_x << std::endl;
       //std::cout<<" Rm "<<Rm<<std::endl<<" Rt "<<Rt<<std::endl<<" resR "<<resR<<std::endl
       //       <<" resP "<<resP<<" dp/p "<<RelMomResidual<<std::endl;
     }
 
     double chi_d = 0;
-    for(int i=0; i<=5; i++) chi_d += Vm(i)*Vm(i)/Cm(i,i);
-        
-    AlgebraicVector5 Vml(tsosMuon.localParameters().vector() 
-		       - extrapolationT.localParameters().vector());
+    for (int i = 0; i <= 5; i++)
+      chi_d += Vm(i) * Vm(i) / Cm(i, i);
+
+    AlgebraicVector5 Vml(tsosMuon.localParameters().vector() - extrapolationT.localParameters().vector());
     AlgebraicSymMatrix55 m(tsosMuon.localError().matrix() + extrapolationT.localError().matrix());
     AlgebraicSymMatrix55 Cml(tsosMuon.localError().matrix() + extrapolationT.localError().matrix());
     bool ierrLoc = !m.Invert();
-    if (ierrLoc && debug_ && info) { 
-      std::cout<< " ==== Error inverting Local covariance matrix ==== "<<std::endl;
-      continue;}
-    double chi_Loc = ROOT::Math::Similarity(Vml,m);
-    if(debug_)
-      std::cout<<" chi_Loc px/pz/err "<<chi_Loc<<" "<<Vml(1)/sqrt(Cml(1,1))<<std::endl;
+    if (ierrLoc && debug_ && info) {
+      std::cout << " ==== Error inverting Local covariance matrix ==== " << std::endl;
+      continue;
+    }
+    double chi_Loc = ROOT::Math::Similarity(Vml, m);
+    if (debug_)
+      std::cout << " chi_Loc px/pz/err " << chi_Loc << " " << Vml(1) / sqrt(Cml(1, 1)) << std::endl;
 
-    if(Pt.mag() < 15.) continue;
-    if(Pm.mag() <  5.) continue;
- 
+    if (Pt.mag() < 15.)
+      continue;
+    if (Pm.mag() < 5.)
+      continue;
+
     //if(Pt.mag() < 30.) continue;          // momenum cut  < 30GeV
     //if(Pt.mag() < 60.) continue;          // momenum cut  < 30GeV
     //if(Pt.mag() > 50.) continue;          //  momenum cut > 50GeV
     //if(Pt.mag() > 100.) continue;          //  momenum cut > 100GeV
     //if(trackTT.charge() < 0) continue;    // select positive charge
     //if(trackTT.charge() > 0) continue;    // select negative charge
-    
-    //if(fabs(resR.x()) > 5.) continue;     // strong cut  X 
-    //if(fabs(resR.y()) > 5.) continue;     //             Y 
+
+    //if(fabs(resR.x()) > 5.) continue;     // strong cut  X
+    //if(fabs(resR.y()) > 5.) continue;     //             Y
     //if(fabs(resR.z()) > 5.) continue;     //             Z
     //if(fabs(resR.mag()) > 7.5) continue;   //            dR
 
     //if(fabs(RelMomResidual) > 0.5) continue;
-    if(fabs(resR.x()) > 20.) continue;
-    if(fabs(resR.y()) > 20.) continue;
-    if(fabs(resR.z()) > 20.) continue;
-    if(fabs(resR.mag()) > 30.) continue;
-    if(fabs(resP.x()) > 0.06) continue;
-    if(fabs(resP.y()) > 0.06) continue;
-    if(fabs(resP.z()) > 0.06) continue;
-    if(chi_d > 40.) continue;
+    if (fabs(resR.x()) > 20.)
+      continue;
+    if (fabs(resR.y()) > 20.)
+      continue;
+    if (fabs(resR.z()) > 20.)
+      continue;
+    if (fabs(resR.mag()) > 30.)
+      continue;
+    if (fabs(resP.x()) > 0.06)
+      continue;
+    if (fabs(resP.y()) > 0.06)
+      continue;
+    if (fabs(resP.z()) > 0.06)
+      continue;
+    if (chi_d > 40.)
+      continue;
 
-    //                                            select Barrel 
-    //if(Rmuon < 400. || Rmuon > 450.) continue; 
+    //                                            select Barrel
+    //if(Rmuon < 400. || Rmuon > 450.) continue;
     //if(Zmuon < -600. || Zmuon > 600.) continue;
-    //if(fabs(Nl.z()) > 0.95) continue;  
+    //if(fabs(Nl.z()) > 0.95) continue;
     //MuSelect = " Barrel";
     //                                                  EndCap1
     //if(Rmuon < 120. || Rmuon > 450.) continue;
     //if(Zmuon < -720.) continue;
     //if(Zmuon > -580.) continue;
-    //if(fabs(Nl.z()) < 0.95) continue;  
+    //if(fabs(Nl.z()) < 0.95) continue;
     //MuSelect = " EndCap1";
     //                                                  EndCap2
     //if(Rmuon < 120. || Rmuon > 450.) continue;
     //if(Zmuon >  720.) continue;
     //if(Zmuon <  580.) continue;
-    //if(fabs(Nl.z()) < 0.95) continue;  
+    //if(fabs(Nl.z()) < 0.95) continue;
     //MuSelect = " EndCap2";
     //                                                 select All
-    if(Rmuon < 120. || Rmuon > 450.) continue;  
-    if(Zmuon < -720. || Zmuon > 720.) continue;
+    if (Rmuon < 120. || Rmuon > 450.)
+      continue;
+    if (Zmuon < -720. || Zmuon > 720.)
+      continue;
     MuSelect = " Barrel+EndCaps";
 
-    if(debug_)
-      std::cout<<" .............. passed all cuts"<<std::endl;
-        
+    if (debug_)
+      std::cout << " .............. passed all cuts" << std::endl;
+
     N_track++;
     //                     gradient and Hessian for each track
-    
-    GlobalTrackerMuonAlignment::gradientGlobalAlg(Rt, Pt, Rm, Nl, Cm);
-    GlobalTrackerMuonAlignment::gradientGlobal(Rt, Pt, Rm, Pm, Nl, Cm); 
 
-    CLHEP::HepSymMatrix covLoc(4,0);
-    for(int i=1; i<=4; i++)
-      for(int j=1; j<=i; j++){
-	covLoc(i,j) = (tsosMuon.localError().matrix()
-		       + extrapolationT.localError().matrix())(i,j);
-	//if(i != j) Cov(i,j) = 0.;
+    GlobalTrackerMuonAlignment::gradientGlobalAlg(Rt, Pt, Rm, Nl, Cm);
+    GlobalTrackerMuonAlignment::gradientGlobal(Rt, Pt, Rm, Pm, Nl, Cm);
+
+    CLHEP::HepSymMatrix covLoc(4, 0);
+    for (int i = 1; i <= 4; i++)
+      for (int j = 1; j <= i; j++) {
+        covLoc(i, j) = (tsosMuon.localError().matrix() + extrapolationT.localError().matrix())(i, j);
+        //if(i != j) Cov(i,j) = 0.;
       }
 
-    const Surface& refSurface = tsosMuon.surface(); 
-    CLHEP::HepMatrix rotLoc (3,3,0);
-    rotLoc(1,1) = refSurface.rotation().xx();
-    rotLoc(1,2) = refSurface.rotation().xy();
-    rotLoc(1,3) = refSurface.rotation().xz();
-    
-    rotLoc(2,1) = refSurface.rotation().yx();
-    rotLoc(2,2) = refSurface.rotation().yy();
-    rotLoc(2,3) = refSurface.rotation().yz();
-    
-    rotLoc(3,1) = refSurface.rotation().zx();
-    rotLoc(3,2) = refSurface.rotation().zy();
-    rotLoc(3,3) = refSurface.rotation().zz();
-    
+    const Surface& refSurface = tsosMuon.surface();
+    CLHEP::HepMatrix rotLoc(3, 3, 0);
+    rotLoc(1, 1) = refSurface.rotation().xx();
+    rotLoc(1, 2) = refSurface.rotation().xy();
+    rotLoc(1, 3) = refSurface.rotation().xz();
+
+    rotLoc(2, 1) = refSurface.rotation().yx();
+    rotLoc(2, 2) = refSurface.rotation().yy();
+    rotLoc(2, 3) = refSurface.rotation().yz();
+
+    rotLoc(3, 1) = refSurface.rotation().zx();
+    rotLoc(3, 2) = refSurface.rotation().zy();
+    rotLoc(3, 3) = refSurface.rotation().zz();
+
     CLHEP::HepVector posLoc(3);
     posLoc(1) = refSurface.position().x();
     posLoc(2) = refSurface.position().y();
@@ -1893,292 +1910,324 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
 
     GlobalTrackerMuonAlignment::gradientLocal(Rt, Pt, Rm, Pm, Nl, covLoc, rotLoc, posLoc, LPRm);
 
-    if(debug_){
-      std::cout<<" Norm   "<<Nl<<std::endl;
-      std::cout<<" posLoc "<<posLoc.T()<<std::endl;
-      std::cout<<" rotLoc "<<rotLoc<<std::endl;
+    if (debug_) {
+      std::cout << " Norm   " << Nl << std::endl;
+      std::cout << " posLoc " << posLoc.T() << std::endl;
+      std::cout << " rotLoc " << rotLoc << std::endl;
     }
 
-    // -----------------------------------------------------  fill histogram 
-    histo->Fill(itMuon->track()->pt()); 
-    
-    //histo2->Fill(itMuon->track()->outerP()); 
-    histo2->Fill(Pt.mag()); 
-    histo3->Fill((PI/2.-itMuon->track()->outerTheta())); 
-    histo4->Fill(itMuon->track()->phi()); 
-    histo5->Fill(Rmuon); 
-    histo6->Fill(Zmuon); 
-    histo7->Fill(RelMomResidual); 
-    //histo8->Fill(chi); 
-    histo8->Fill(chi_d); 
-    
-    histo101->Fill(Zmuon, Rmuon); 
-    histo101->Fill(Rt0.z(), Rt0.perp()); 
-    histo102->Fill(Rt0.x(), Rt0.y()); 
-    histo102->Fill(Rm.x(), Rm.y()); 
-    
-    histo11->Fill(resR.mag()); 
-    if(fabs(Nl.x()) < 0.98) histo12->Fill(resR.x()); 
-    if(fabs(Nl.y()) < 0.98) histo13->Fill(resR.y()); 
-    if(fabs(Nl.z()) < 0.98) histo14->Fill(resR.z()); 
-    histo15->Fill(resP.x()); 
-    histo16->Fill(resP.y()); 
-    histo17->Fill(resP.z()); 
-    
-    if((fabs(Nl.x()) < 0.98) && (fabs(Nl.y()) < 0.98) &&(fabs(Nl.z()) < 0.98))
-      { 
-	histo18->Fill(sqrt(C0(0,0))); 
-	histo19->Fill(sqrt(C1(0,0))); 
-	histo20->Fill(sqrt(C1(0,0)+Ce(0,0))); 		   
-      }
-    if(fabs(Nl.x()) < 0.98) histo21->Fill(Vm(0)/sqrt(Cm(0,0))); 
-    if(fabs(Nl.y()) < 0.98) histo22->Fill(Vm(1)/sqrt(Cm(1,1))); 
-    if(fabs(Nl.z()) < 0.98) histo23->Fill(Vm(2)/sqrt(Cm(2,2))); 
-    histo24->Fill(Vm(3)/sqrt(C1(3,3)+Ce(3,3))); 
-    histo25->Fill(Vm(4)/sqrt(C1(4,4)+Ce(4,4))); 
-    histo26->Fill(Vm(5)/sqrt(C1(5,5)+Ce(5,5))); 
-    histo27->Fill(Nl.x()); 
-    histo28->Fill(Nl.y()); 
-    histo29->Fill(lenghtTrack); 
-    histo30->Fill(lenghtMuon);     
-    histo31->Fill(chi_Loc);
-    histo32->Fill(Vml(1)/sqrt(Cml(1,1))); 
-    histo33->Fill(Vml(2)/sqrt(Cml(2,2))); 
-    histo34->Fill(Vml(3)/sqrt(Cml(3,3))); 
-    histo35->Fill(Vml(4)/sqrt(Cml(4,4))); 
+    // -----------------------------------------------------  fill histogram
+    histo->Fill(itMuon->track()->pt());
 
-    if (debug_) {   //--------------------------------- debug print ----------
-      
-      std::cout<<" diag 0[ "<<C0(0,0)<<" "<<C0(1,1)<<" "<<C0(2,2)<<" "<<C0(3,3)<<" "
-	       <<C0(4,4)<<" "<<C0(5,5)<<" ]"<<std::endl;
-      std::cout<<" diag e[ "<<Ce(0,0)<<" "<<Ce(1,1)<<" "<<Ce(2,2)<<" "<<Ce(3,3)<<" "
-	       <<Ce(4,4)<<" "<<Ce(5,5)<<" ]"<<std::endl;
-      std::cout<<" diag 1[ "<<C1(0,0)<<" "<<C1(1,1)<<" "<<C1(2,2)<<" "<<C1(3,3)<<" "
-	       <<C1(4,4)<<" "<<C1(5,5)<<" ]"<<std::endl;
-      std::cout<<" Rm   "<<Rm.x()<<" "<<Rm.y()<<" "<<Rm.z()
-	       <<" Pm   "<<Pm.x()<<" "<<Pm.y()<<" "<<Pm.z()<<std::endl;
-      std::cout<<" Rt   "<<Rt.x()<<" "<<Rt.y()<<" "<<Rt.z()
-	       <<" Pt   "<<Pt.x()<<" "<<Pt.y()<<" "<<Pt.z()<<std::endl;
-      std::cout<<" Nl*(Rm-Rt) "<<Nl.dot(Rm-Rt)<<std::endl;
-      std::cout<<" resR "<<resR.x()<<" "<<resR.y()<<" "<<resR.z()
-	       <<" resP "<<resP.x()<<" "<<resP.y()<<" "<<resP.z()<<std::endl;       
-      std::cout<<" Rm-t "<<(Rm-Rt).x()<<" "<<(Rm-Rt).y()<<" "<<(Rm-Rt).z()
-	       <<" Pm-t "<<(Pm-Pt).x()<<" "<<(Pm-Pt).y()<<" "<<(Pm-Pt).z()<<std::endl;       
-      std::cout<<" Vm   "<<Vm<<std::endl;
-      std::cout<<" +-   "<<sqrt(Cm(0,0))<<" "<<sqrt(Cm(1,1))<<" "<<sqrt(Cm(2,2))<<" "
-	       <<sqrt(Cm(3,3))<<" "<<sqrt(Cm(4,4))<<" "<<sqrt(Cm(5,5))<<std::endl;
-      std::cout<<" Pmuon Ptrack dP/Ptrack "<<itMuon->outerTrack()->p()<<" "
-	       <<itMuon->track()->outerP()<<" "
-	       <<(itMuon->outerTrack()->p() - 
-		  itMuon->track()->outerP())/itMuon->track()->outerP()<<std::endl;
-      std::cout<<" cov matrix "<<std::endl;
-      std::cout<<Cm<<std::endl;
-      std::cout<<" diag [ "<<Cm(0,0)<<" "<<Cm(1,1)<<" "<<Cm(2,2)<<" "<<Cm(3,3)<<" "
-	       <<Cm(4,4)<<" "<<Cm(5,5)<<" ]"<<std::endl;
-      
+    //histo2->Fill(itMuon->track()->outerP());
+    histo2->Fill(Pt.mag());
+    histo3->Fill((PI / 2. - itMuon->track()->outerTheta()));
+    histo4->Fill(itMuon->track()->phi());
+    histo5->Fill(Rmuon);
+    histo6->Fill(Zmuon);
+    histo7->Fill(RelMomResidual);
+    //histo8->Fill(chi);
+    histo8->Fill(chi_d);
+
+    histo101->Fill(Zmuon, Rmuon);
+    histo101->Fill(Rt0.z(), Rt0.perp());
+    histo102->Fill(Rt0.x(), Rt0.y());
+    histo102->Fill(Rm.x(), Rm.y());
+
+    histo11->Fill(resR.mag());
+    if (fabs(Nl.x()) < 0.98)
+      histo12->Fill(resR.x());
+    if (fabs(Nl.y()) < 0.98)
+      histo13->Fill(resR.y());
+    if (fabs(Nl.z()) < 0.98)
+      histo14->Fill(resR.z());
+    histo15->Fill(resP.x());
+    histo16->Fill(resP.y());
+    histo17->Fill(resP.z());
+
+    if ((fabs(Nl.x()) < 0.98) && (fabs(Nl.y()) < 0.98) && (fabs(Nl.z()) < 0.98)) {
+      histo18->Fill(sqrt(C0(0, 0)));
+      histo19->Fill(sqrt(C1(0, 0)));
+      histo20->Fill(sqrt(C1(0, 0) + Ce(0, 0)));
+    }
+    if (fabs(Nl.x()) < 0.98)
+      histo21->Fill(Vm(0) / sqrt(Cm(0, 0)));
+    if (fabs(Nl.y()) < 0.98)
+      histo22->Fill(Vm(1) / sqrt(Cm(1, 1)));
+    if (fabs(Nl.z()) < 0.98)
+      histo23->Fill(Vm(2) / sqrt(Cm(2, 2)));
+    histo24->Fill(Vm(3) / sqrt(C1(3, 3) + Ce(3, 3)));
+    histo25->Fill(Vm(4) / sqrt(C1(4, 4) + Ce(4, 4)));
+    histo26->Fill(Vm(5) / sqrt(C1(5, 5) + Ce(5, 5)));
+    histo27->Fill(Nl.x());
+    histo28->Fill(Nl.y());
+    histo29->Fill(lenghtTrack);
+    histo30->Fill(lenghtMuon);
+    histo31->Fill(chi_Loc);
+    histo32->Fill(Vml(1) / sqrt(Cml(1, 1)));
+    histo33->Fill(Vml(2) / sqrt(Cml(2, 2)));
+    histo34->Fill(Vml(3) / sqrt(Cml(3, 3)));
+    histo35->Fill(Vml(4) / sqrt(Cml(4, 4)));
+
+    if (debug_) {  //--------------------------------- debug print ----------
+
+      std::cout << " diag 0[ " << C0(0, 0) << " " << C0(1, 1) << " " << C0(2, 2) << " " << C0(3, 3) << " " << C0(4, 4)
+                << " " << C0(5, 5) << " ]" << std::endl;
+      std::cout << " diag e[ " << Ce(0, 0) << " " << Ce(1, 1) << " " << Ce(2, 2) << " " << Ce(3, 3) << " " << Ce(4, 4)
+                << " " << Ce(5, 5) << " ]" << std::endl;
+      std::cout << " diag 1[ " << C1(0, 0) << " " << C1(1, 1) << " " << C1(2, 2) << " " << C1(3, 3) << " " << C1(4, 4)
+                << " " << C1(5, 5) << " ]" << std::endl;
+      std::cout << " Rm   " << Rm.x() << " " << Rm.y() << " " << Rm.z() << " Pm   " << Pm.x() << " " << Pm.y() << " "
+                << Pm.z() << std::endl;
+      std::cout << " Rt   " << Rt.x() << " " << Rt.y() << " " << Rt.z() << " Pt   " << Pt.x() << " " << Pt.y() << " "
+                << Pt.z() << std::endl;
+      std::cout << " Nl*(Rm-Rt) " << Nl.dot(Rm - Rt) << std::endl;
+      std::cout << " resR " << resR.x() << " " << resR.y() << " " << resR.z() << " resP " << resP.x() << " " << resP.y()
+                << " " << resP.z() << std::endl;
+      std::cout << " Rm-t " << (Rm - Rt).x() << " " << (Rm - Rt).y() << " " << (Rm - Rt).z() << " Pm-t "
+                << (Pm - Pt).x() << " " << (Pm - Pt).y() << " " << (Pm - Pt).z() << std::endl;
+      std::cout << " Vm   " << Vm << std::endl;
+      std::cout << " +-   " << sqrt(Cm(0, 0)) << " " << sqrt(Cm(1, 1)) << " " << sqrt(Cm(2, 2)) << " " << sqrt(Cm(3, 3))
+                << " " << sqrt(Cm(4, 4)) << " " << sqrt(Cm(5, 5)) << std::endl;
+      std::cout << " Pmuon Ptrack dP/Ptrack " << itMuon->outerTrack()->p() << " " << itMuon->track()->outerP() << " "
+                << (itMuon->outerTrack()->p() - itMuon->track()->outerP()) / itMuon->track()->outerP() << std::endl;
+      std::cout << " cov matrix " << std::endl;
+      std::cout << Cm << std::endl;
+      std::cout << " diag [ " << Cm(0, 0) << " " << Cm(1, 1) << " " << Cm(2, 2) << " " << Cm(3, 3) << " " << Cm(4, 4)
+                << " " << Cm(5, 5) << " ]" << std::endl;
+
       AlgebraicSymMatrix66 Ro;
       double Diag[6];
-      for(int i=0; i<=5; i++) Diag[i] = sqrt(Cm(i,i));
-      for(int i=0; i<=5; i++)
-	for(int j=0; j<=5; j++)
-	  Ro(i,j) = Cm(i,j)/Diag[i]/Diag[j];
-      std::cout<<" correlation matrix "<<std::endl;
-      std::cout<<Ro<<std::endl;
-      
+      for (int i = 0; i <= 5; i++)
+        Diag[i] = sqrt(Cm(i, i));
+      for (int i = 0; i <= 5; i++)
+        for (int j = 0; j <= 5; j++)
+          Ro(i, j) = Cm(i, j) / Diag[i] / Diag[j];
+      std::cout << " correlation matrix " << std::endl;
+      std::cout << Ro << std::endl;
+
       AlgebraicSymMatrix66 CmI;
-      for(int i=0; i<=5; i++)
-	for(int j=0; j<=5; j++)
-	  CmI(i,j) = Cm(i,j);
-      
+      for (int i = 0; i <= 5; i++)
+        for (int j = 0; j <= 5; j++)
+          CmI(i, j) = Cm(i, j);
+
       bool ierr = !CmI.Invert();
-      if( ierr ) { if(alarm || debug_)
-	  std::cout<<" Error inverse covariance matrix !!!!!!!!!!!"<<std::endl;
-	continue;
-      }       
-      std::cout<<" inverse cov matrix "<<std::endl;
-      std::cout<<Cm<<std::endl;
-      
+      if (ierr) {
+        if (alarm || debug_)
+          std::cout << " Error inverse covariance matrix !!!!!!!!!!!" << std::endl;
+        continue;
+      }
+      std::cout << " inverse cov matrix " << std::endl;
+      std::cout << Cm << std::endl;
+
       double chi = ROOT::Math::Similarity(Vm, CmI);
-      std::cout<<" chi chi_d "<<chi<<" "<<chi_d<<std::endl;
+      std::cout << " chi chi_d " << chi << " " << chi_d << std::endl;
     }  // end of debug_ printout  --------------------------------------------
-    
-  } // end loop on selected muons, i.e. Jim's globalMuon
 
-} //end of analyzeTrackTrajectory
+  }  // end loop on selected muons, i.e. Jim's globalMuon
 
+}  //end of analyzeTrackTrajectory
 
 // ----  calculate gradient and Hessian matrix (algebraic) to search global shifts ------
-void 
-GlobalTrackerMuonAlignment::gradientGlobalAlg(GlobalVector& Rt, GlobalVector& Pt, 
-				     GlobalVector& Rm, GlobalVector& Nl, 
-				     AlgebraicSymMatrix66& Cm)
-{
+void GlobalTrackerMuonAlignment::gradientGlobalAlg(
+    GlobalVector& Rt, GlobalVector& Pt, GlobalVector& Rm, GlobalVector& Nl, AlgebraicSymMatrix66& Cm) {
   // ---------------------------- Calculate Information matrix and Gfree vector
   // Information == Hessian , Gfree == gradient of the objective function
-  
-  AlgebraicMatrix33 Jac; 
-  AlgebraicVector3 Wi, R_m, R_t, P_t, Norm, dR;   
-  
-  R_m(0)  = Rm.x();  R_m(1)  = Rm.y();  R_m(2)  = Rm.z(); 
-  R_t(0)  = Rt.x();  R_t(1)  = Rt.y();  R_t(2)  = Rt.z(); 
-  P_t(0)  = Pt.x();  P_t(1)  = Pt.y();  P_t(2)  = Pt.z(); 
-  Norm(0) = Nl.x();  Norm(1) = Nl.y();  Norm(2) = Nl.z(); 
-  
-  for(int i=0; i<=2; i++){
-    if(Cm(i,i) > 1.e-20)
-      Wi(i) = 1./Cm(i,i);
-    else Wi(i) = 1.e-10;
+
+  AlgebraicMatrix33 Jac;
+  AlgebraicVector3 Wi, R_m, R_t, P_t, Norm, dR;
+
+  R_m(0) = Rm.x();
+  R_m(1) = Rm.y();
+  R_m(2) = Rm.z();
+  R_t(0) = Rt.x();
+  R_t(1) = Rt.y();
+  R_t(2) = Rt.z();
+  P_t(0) = Pt.x();
+  P_t(1) = Pt.y();
+  P_t(2) = Pt.z();
+  Norm(0) = Nl.x();
+  Norm(1) = Nl.y();
+  Norm(2) = Nl.z();
+
+  for (int i = 0; i <= 2; i++) {
+    if (Cm(i, i) > 1.e-20)
+      Wi(i) = 1. / Cm(i, i);
+    else
+      Wi(i) = 1.e-10;
     dR(i) = R_m(i) - R_t(i);
   }
-  
-  float PtN = P_t(0)*Norm(0) + P_t(1)*Norm(1) + P_t(2)*Norm(2);
-  
-  Jac(0,0) = 1. - P_t(0)*Norm(0)/PtN;
-  Jac(0,1) =    - P_t(0)*Norm(1)/PtN;
-  Jac(0,2) =    - P_t(0)*Norm(2)/PtN;
-  
-  Jac(1,0) =    - P_t(1)*Norm(0)/PtN;
-  Jac(1,1) = 1. - P_t(1)*Norm(1)/PtN;
-  Jac(1,2) =    - P_t(1)*Norm(2)/PtN;
-  
-  Jac(2,0) =    - P_t(2)*Norm(0)/PtN;
-  Jac(2,1) =    - P_t(2)*Norm(1)/PtN;
-  Jac(2,2) = 1. - P_t(2)*Norm(2)/PtN;
-  
-  AlgebraicSymMatrix33 Itr;
-  
-  for(int i=0; i<=2; i++) 
-    for(int j=0; j<=2; j++){
-      if(j < i) continue;
-      Itr(i,j) = 0.;
-      //std::cout<<" ij "<<i<<" "<<j<<std::endl;	 
-      for(int k=0; k<=2; k++){
-	Itr(i,j) += Jac(k,i)*Wi(k)*Jac(k,j);}}
-  
-  for(int i=0; i<=2; i++) 
-    for(int j=0; j<=2; j++){
-      if(j < i) continue;
-      Inf(i,j) += Itr(i,j);}
-  
-  AlgebraicVector3 Gtr(0., 0., 0.);
-  for(int i=0; i<=2; i++)
-    for(int k=0; k<=2; k++) Gtr(i) += dR(k)*Wi(k)*Jac(k,i);
-  for(int i=0; i<=2; i++) Gfr(i) += Gtr(i); 
 
-  if(debug_){
-   std::cout<<" Wi  "<<Wi<<std::endl;     
-   std::cout<<" N   "<<Norm<<std::endl;
-   std::cout<<" P_t "<<P_t<<std::endl;
-   std::cout<<" (Pt*N) "<<PtN<<std::endl;  
-   std::cout<<" dR  "<<dR<<std::endl;
-   std::cout<<" +/- "<<1./sqrt(Wi(0))<<" "<<1./sqrt(Wi(1))<<" "<<1./sqrt(Wi(2))
-         <<" "<<std::endl;
-   std::cout<<" Jacobian dr/ddx "<<std::endl;
-   std::cout<<Jac<<std::endl;
-   std::cout<<" G-- "<<Gtr<<std::endl;
-   std::cout<<" Itrack "<<std::endl;
-   std::cout<<Itr<<std::endl;
-   std::cout<<" Gfr "<<Gfr<<std::endl;
-   std::cout<<" -- Inf --"<<std::endl;
-   std::cout<<Inf<<std::endl;
+  float PtN = P_t(0) * Norm(0) + P_t(1) * Norm(1) + P_t(2) * Norm(2);
+
+  Jac(0, 0) = 1. - P_t(0) * Norm(0) / PtN;
+  Jac(0, 1) = -P_t(0) * Norm(1) / PtN;
+  Jac(0, 2) = -P_t(0) * Norm(2) / PtN;
+
+  Jac(1, 0) = -P_t(1) * Norm(0) / PtN;
+  Jac(1, 1) = 1. - P_t(1) * Norm(1) / PtN;
+  Jac(1, 2) = -P_t(1) * Norm(2) / PtN;
+
+  Jac(2, 0) = -P_t(2) * Norm(0) / PtN;
+  Jac(2, 1) = -P_t(2) * Norm(1) / PtN;
+  Jac(2, 2) = 1. - P_t(2) * Norm(2) / PtN;
+
+  AlgebraicSymMatrix33 Itr;
+
+  for (int i = 0; i <= 2; i++)
+    for (int j = 0; j <= 2; j++) {
+      if (j < i)
+        continue;
+      Itr(i, j) = 0.;
+      //std::cout<<" ij "<<i<<" "<<j<<std::endl;
+      for (int k = 0; k <= 2; k++) {
+        Itr(i, j) += Jac(k, i) * Wi(k) * Jac(k, j);
+      }
+    }
+
+  for (int i = 0; i <= 2; i++)
+    for (int j = 0; j <= 2; j++) {
+      if (j < i)
+        continue;
+      Inf(i, j) += Itr(i, j);
+    }
+
+  AlgebraicVector3 Gtr(0., 0., 0.);
+  for (int i = 0; i <= 2; i++)
+    for (int k = 0; k <= 2; k++)
+      Gtr(i) += dR(k) * Wi(k) * Jac(k, i);
+  for (int i = 0; i <= 2; i++)
+    Gfr(i) += Gtr(i);
+
+  if (debug_) {
+    std::cout << " Wi  " << Wi << std::endl;
+    std::cout << " N   " << Norm << std::endl;
+    std::cout << " P_t " << P_t << std::endl;
+    std::cout << " (Pt*N) " << PtN << std::endl;
+    std::cout << " dR  " << dR << std::endl;
+    std::cout << " +/- " << 1. / sqrt(Wi(0)) << " " << 1. / sqrt(Wi(1)) << " " << 1. / sqrt(Wi(2)) << " " << std::endl;
+    std::cout << " Jacobian dr/ddx " << std::endl;
+    std::cout << Jac << std::endl;
+    std::cout << " G-- " << Gtr << std::endl;
+    std::cout << " Itrack " << std::endl;
+    std::cout << Itr << std::endl;
+    std::cout << " Gfr " << Gfr << std::endl;
+    std::cout << " -- Inf --" << std::endl;
+    std::cout << Inf << std::endl;
   }
 
   return;
 }
 
 // ----  calculate gradient and Hessian matrix in global parameters ------
-void 
-GlobalTrackerMuonAlignment::gradientGlobal(GlobalVector& GRt, GlobalVector& GPt, 
-				  GlobalVector& GRm, GlobalVector& GPm, 
-				  GlobalVector& GNorm, AlgebraicSymMatrix66 & GCov)
-{
+void GlobalTrackerMuonAlignment::gradientGlobal(GlobalVector& GRt,
+                                                GlobalVector& GPt,
+                                                GlobalVector& GRm,
+                                                GlobalVector& GPm,
+                                                GlobalVector& GNorm,
+                                                AlgebraicSymMatrix66& GCov) {
   // we search for 6D global correction vector (d, a), where
-  //                        3D vector of shihts d 
-  //               3D vector of rotation angles    a   
+  //                        3D vector of shihts d
+  //               3D vector of rotation angles    a
 
   //bool alarm = true;
   bool alarm = false;
   bool info = false;
 
-  int Nd = 6;     // dimension of vector of alignment pararmeters, d 
-  
+  int Nd = 6;  // dimension of vector of alignment pararmeters, d
+
   //double PtMom = GPt.mag();
-  CLHEP::HepSymMatrix w(Nd,0);
-  for (int i=1; i <= Nd; i++)
-    for (int j=1; j <= Nd; j++){
-      if(j <= i ) w(i,j) = GCov(i-1, j-1);
+  CLHEP::HepSymMatrix w(Nd, 0);
+  for (int i = 1; i <= Nd; i++)
+    for (int j = 1; j <= Nd; j++) {
+      if (j <= i)
+        w(i, j) = GCov(i - 1, j - 1);
       //if(i >= 3) w(i,j) /= PtMom;
       //if(j >= 3) w(i,j) /= PtMom;
-      if((i == j) && (i<=3) && (GCov(i-1, j-1) < 1.e-20))  w(i,j) = 1.e20; // w=0  
-      if(i != j) w(i,j) = 0.;                // use diaginal elements    
+      if ((i == j) && (i <= 3) && (GCov(i - 1, j - 1) < 1.e-20))
+        w(i, j) = 1.e20;  // w=0
+      if (i != j)
+        w(i, j) = 0.;  // use diaginal elements
     }
 
   //GPt /= GPt.mag();
   //GPm /= GPm.mag();   // end of transform
 
   CLHEP::HepVector V(Nd), Rt(3), Pt(3), Rm(3), Pm(3), Norm(3);
-  Rt(1) = GRt.x(); Rt(2) = GRt.y();  Rt(3) = GRt.z();
-  Pt(1) = GPt.x(); Pt(2) = GPt.y();  Pt(3) = GPt.z();
-  Rm(1) = GRm.x(); Rm(2) = GRm.y();  Rm(3) = GRm.z();
-  Pm(1) = GPm.x(); Pm(2) = GPm.y();  Pm(3) = GPm.z();
-   Norm(1) = GNorm.x(); Norm(2) = GNorm.y(); Norm(3) = GNorm.z(); 
+  Rt(1) = GRt.x();
+  Rt(2) = GRt.y();
+  Rt(3) = GRt.z();
+  Pt(1) = GPt.x();
+  Pt(2) = GPt.y();
+  Pt(3) = GPt.z();
+  Rm(1) = GRm.x();
+  Rm(2) = GRm.y();
+  Rm(3) = GRm.z();
+  Pm(1) = GPm.x();
+  Pm(2) = GPm.y();
+  Pm(3) = GPm.z();
+  Norm(1) = GNorm.x();
+  Norm(2) = GNorm.y();
+  Norm(3) = GNorm.z();
 
-  V = dsum(Rm - Rt, Pm - Pt) ;   //std::cout<<" V "<<V.T()<<std::endl;
-  
+  V = dsum(Rm - Rt, Pm - Pt);  //std::cout<<" V "<<V.T()<<std::endl;
+
   //double PmN = CLHEP::dot(Pm, Norm);
   double PmN = CLHEP_dot(Pm, Norm);
 
-  CLHEP::HepMatrix Jac(Nd,Nd,0);
-  for (int i=1; i <= 3; i++)
-    for (int j=1; j <= 3; j++){
-      Jac(i,j) =  Pm(i)*Norm(j) / PmN;
-      if(i == j ) Jac(i,j) -= 1.;
-    } 
+  CLHEP::HepMatrix Jac(Nd, Nd, 0);
+  for (int i = 1; i <= 3; i++)
+    for (int j = 1; j <= 3; j++) {
+      Jac(i, j) = Pm(i) * Norm(j) / PmN;
+      if (i == j)
+        Jac(i, j) -= 1.;
+    }
 
-  //                                            dp/da                   
-  Jac(4,4) =     0.;   // dpx/dax
-  Jac(5,4) = -Pm(3);   // dpy/dax
-  Jac(6,4) =  Pm(2);   // dpz/dax
-  Jac(4,5) =  Pm(3);   // dpx/day
-  Jac(5,5) =     0.;   // dpy/day
-  Jac(6,5) = -Pm(1);   // dpz/day
-  Jac(4,6) = -Pm(2);   // dpx/daz
-  Jac(5,6) =  Pm(1);   // dpy/daz
-  Jac(6,6) =     0.;   // dpz/daz
+  //                                            dp/da
+  Jac(4, 4) = 0.;      // dpx/dax
+  Jac(5, 4) = -Pm(3);  // dpy/dax
+  Jac(6, 4) = Pm(2);   // dpz/dax
+  Jac(4, 5) = Pm(3);   // dpx/day
+  Jac(5, 5) = 0.;      // dpy/day
+  Jac(6, 5) = -Pm(1);  // dpz/day
+  Jac(4, 6) = -Pm(2);  // dpx/daz
+  Jac(5, 6) = Pm(1);   // dpy/daz
+  Jac(6, 6) = 0.;      // dpz/daz
 
   CLHEP::HepVector dsda(3);
-  dsda(1) = (Norm(2)*Rm(3) - Norm(3)*Rm(2)) / PmN;
-  dsda(2) = (Norm(3)*Rm(1) - Norm(1)*Rm(3)) / PmN;
-  dsda(3) = (Norm(1)*Rm(2) - Norm(2)*Rm(1)) / PmN;
+  dsda(1) = (Norm(2) * Rm(3) - Norm(3) * Rm(2)) / PmN;
+  dsda(2) = (Norm(3) * Rm(1) - Norm(1) * Rm(3)) / PmN;
+  dsda(3) = (Norm(1) * Rm(2) - Norm(2) * Rm(1)) / PmN;
 
-  //                                             dr/da  
-  Jac(1,4) =          Pm(1)*dsda(1);  // drx/dax
-  Jac(2,4) = -Rm(3) + Pm(2)*dsda(1);  // dry/dax
-  Jac(3,4) =  Rm(2) + Pm(3)*dsda(1);  // drz/dax
+  //                                             dr/da
+  Jac(1, 4) = Pm(1) * dsda(1);           // drx/dax
+  Jac(2, 4) = -Rm(3) + Pm(2) * dsda(1);  // dry/dax
+  Jac(3, 4) = Rm(2) + Pm(3) * dsda(1);   // drz/dax
 
-  Jac(1,5) =  Rm(3) + Pm(1)*dsda(2);  // drx/day
-  Jac(2,5) =          Pm(2)*dsda(2);  // dry/day
-  Jac(3,5) = -Rm(1) + Pm(3)*dsda(2);  // drz/day
+  Jac(1, 5) = Rm(3) + Pm(1) * dsda(2);   // drx/day
+  Jac(2, 5) = Pm(2) * dsda(2);           // dry/day
+  Jac(3, 5) = -Rm(1) + Pm(3) * dsda(2);  // drz/day
 
-  Jac(1,6) = -Rm(2) + Pm(1)*dsda(3);  // drx/daz
-  Jac(2,6) =  Rm(1) + Pm(2)*dsda(3);  // dry/daz
-  Jac(3,6) =          Pm(3)*dsda(3);  // drz/daz
+  Jac(1, 6) = -Rm(2) + Pm(1) * dsda(3);  // drx/daz
+  Jac(2, 6) = Rm(1) + Pm(2) * dsda(3);   // dry/daz
+  Jac(3, 6) = Pm(3) * dsda(3);           // drz/daz
 
-  CLHEP::HepSymMatrix W(Nd,0);
+  CLHEP::HepSymMatrix W(Nd, 0);
   int ierr;
   W = w.inverse(ierr);
-  if(ierr != 0) { if(alarm)
-      std::cout<<" gradientGlobal: inversion of matrix w fail "<<std::endl;
+  if (ierr != 0) {
+    if (alarm)
+      std::cout << " gradientGlobal: inversion of matrix w fail " << std::endl;
     return;
   }
 
-  CLHEP::HepMatrix W_Jac(Nd,Nd,0);
+  CLHEP::HepMatrix W_Jac(Nd, Nd, 0);
   W_Jac = Jac.T() * W;
-  
+
   CLHEP::HepVector grad3(Nd);
   grad3 = W_Jac * V;
 
-  CLHEP::HepMatrix hess3(Nd,Nd);
+  CLHEP::HepMatrix hess3(Nd, Nd);
   hess3 = Jac.T() * W * Jac;
   //hess3(4,4) = 1.e-10;  hess3(5,5) = 1.e-10;  hess3(6,6) = 1.e-10; //????????????????
 
@@ -2188,97 +2237,93 @@ GlobalTrackerMuonAlignment::gradientGlobal(GlobalVector& GRt, GlobalVector& GPt,
   CLHEP::HepVector d3I = CLHEP::solve(Hess, -Grad);
   int iEr3I;
   CLHEP::HepMatrix Errd3I = Hess.inverse(iEr3I);
-  if( iEr3I != 0) { if(alarm)
-      std::cout<<" gradientGlobal error inverse  Hess matrix !!!!!!!!!!!"<<std::endl;
+  if (iEr3I != 0) {
+    if (alarm)
+      std::cout << " gradientGlobal error inverse  Hess matrix !!!!!!!!!!!" << std::endl;
   }
 
-  if(info || debug_){
-    std::cout<<" dG   "<<d3I(1)<<" "<<d3I(2)<<" "<<d3I(3)<<" "<<d3I(4)<<" "
-	     <<d3I(5)<<" "<<d3I(6)<<std::endl;;
-    std::cout<<" +-   "<<sqrt(Errd3I(1,1))<<" "<<sqrt(Errd3I(2,2))<<" "<<sqrt(Errd3I(3,3))
-	     <<" "<<sqrt(Errd3I(4,4))<<" "<<sqrt(Errd3I(5,5))<<" "<<sqrt(Errd3I(6,6))
-	     <<std::endl;
+  if (info || debug_) {
+    std::cout << " dG   " << d3I(1) << " " << d3I(2) << " " << d3I(3) << " " << d3I(4) << " " << d3I(5) << " " << d3I(6)
+              << std::endl;
+    ;
+    std::cout << " +-   " << sqrt(Errd3I(1, 1)) << " " << sqrt(Errd3I(2, 2)) << " " << sqrt(Errd3I(3, 3)) << " "
+              << sqrt(Errd3I(4, 4)) << " " << sqrt(Errd3I(5, 5)) << " " << sqrt(Errd3I(6, 6)) << std::endl;
   }
 
 #ifdef CHECK_OF_DERIVATIVES
   //              --------------------    check of derivatives
-  
-  CLHEP::HepVector d(3,0), a(3,0); 
-  CLHEP::HepMatrix T(3,3,1);
+
+  CLHEP::HepVector d(3, 0), a(3, 0);
+  CLHEP::HepMatrix T(3, 3, 1);
 
   CLHEP::HepMatrix Ti = T.T();
   //double A = CLHEP::dot(Ti*Pm, Norm);
   //double B = CLHEP::dot((Rt -Ti*Rm + Ti*d), Norm);
-  double A = CLHEP_dot(Ti*Pm, Norm);
-  double B = CLHEP_dot((Rt -Ti*Rm + Ti*d), Norm);
+  double A = CLHEP_dot(Ti * Pm, Norm);
+  double B = CLHEP_dot((Rt - Ti * Rm + Ti * d), Norm);
   double s0 = B / A;
 
-  CLHEP::HepVector r0(3,0), p0(3,0);
-  r0 = Ti*Rm - Ti*d + s0*(Ti*Pm) - Rt;
-  p0 = Ti*Pm - Pt;
+  CLHEP::HepVector r0(3, 0), p0(3, 0);
+  r0 = Ti * Rm - Ti * d + s0 * (Ti * Pm) - Rt;
+  p0 = Ti * Pm - Pt;
 
   double delta = 0.0001;
 
-  int ii = 3; d(ii) += delta; // d
+  int ii = 3;
+  d(ii) += delta;  // d
   //T(2,3) += delta;   T(3,2) -= delta;  int ii = 1; // a1
   //T(3,1) += delta;   T(1,3) -= delta;   int ii = 2; // a2
   //T(1,2) += delta;   T(2,1) -= delta;   int ii = 3; // a2
   Ti = T.T();
   //A = CLHEP::dot(Ti*Pm, Norm);
   //B = CLHEP::dot((Rt -Ti*Rm + Ti*d), Norm);
-  A = CLHEP_dot(Ti*Pm, Norm);
-  B = CLHEP_dot((Rt -Ti*Rm + Ti*d), Norm);
+  A = CLHEP_dot(Ti * Pm, Norm);
+  B = CLHEP_dot((Rt - Ti * Rm + Ti * d), Norm);
   double s = B / A;
 
-  CLHEP::HepVector r(3,0), p(3,0);
-  r = Ti*Rm - Ti*d + s*(Ti*Pm) - Rt;
-  p = Ti*Pm - Pt;
+  CLHEP::HepVector r(3, 0), p(3, 0);
+  r = Ti * Rm - Ti * d + s * (Ti * Pm) - Rt;
+  p = Ti * Pm - Pt;
 
-  std::cout<<" s0 s num dsda("<<ii<<") "<<s0<<" "<<s<<" "
-  	   <<(s-s0)/delta<<" "<<dsda(ii)<<endl;
+  std::cout << " s0 s num dsda(" << ii << ") " << s0 << " " << s << " " << (s - s0) / delta << " " << dsda(ii) << endl;
   // d(r,p) / d shift
-  std::cout<<" -- An d(r,p)/d("<<ii<<") "<<Jac(1,ii)<<" "<<Jac(2,ii)<<" "
-     <<Jac(3,ii)<<" "<<Jac(4,ii)<<" "<<Jac(5,ii)<<" "
-     <<Jac(6,ii)<<std::endl;
-  std::cout<<"    Nu d(r,p)/d("<<ii<<") "<<(r(1)-r0(1))/delta<<" "
-     <<(r(2)-r0(2))/delta<<" "<<(r(3)-r0(3))/delta<<" "
-     <<(p(1)-p0(1))/delta<<" "<<(p(2)-p0(2))/delta<<" "
-     <<(p(3)-p0(3))/delta<<std::endl;
+  std::cout << " -- An d(r,p)/d(" << ii << ") " << Jac(1, ii) << " " << Jac(2, ii) << " " << Jac(3, ii) << " "
+            << Jac(4, ii) << " " << Jac(5, ii) << " " << Jac(6, ii) << std::endl;
+  std::cout << "    Nu d(r,p)/d(" << ii << ") " << (r(1) - r0(1)) / delta << " " << (r(2) - r0(2)) / delta << " "
+            << (r(3) - r0(3)) / delta << " " << (p(1) - p0(1)) / delta << " " << (p(2) - p0(2)) / delta << " "
+            << (p(3) - p0(3)) / delta << std::endl;
   // d(r,p) / d angle
-  std::cout<<" -- An d(r,p)/a("<<ii<<") "<<Jac(1,ii+3)<<" "<<Jac(2,ii+3)<<" "
-	   <<Jac(3,ii+3)<<" "<<Jac(4,ii+3)<<" "<<Jac(5,ii+3)<<" "
-	   <<Jac(6,ii+3)<<std::endl;
-  std::cout<<"    Nu d(r,p)/a("<<ii<<") "<<(r(1)-r0(1))/delta<<" "
-	   <<(r(2)-r0(2))/delta<<" "<<(r(3)-r0(3))/delta<<" "
-	   <<(p(1)-p0(1))/delta<<" "<<(p(2)-p0(2))/delta<<" "
-	   <<(p(3)-p0(3))/delta<<std::endl;
+  std::cout << " -- An d(r,p)/a(" << ii << ") " << Jac(1, ii + 3) << " " << Jac(2, ii + 3) << " " << Jac(3, ii + 3)
+            << " " << Jac(4, ii + 3) << " " << Jac(5, ii + 3) << " " << Jac(6, ii + 3) << std::endl;
+  std::cout << "    Nu d(r,p)/a(" << ii << ") " << (r(1) - r0(1)) / delta << " " << (r(2) - r0(2)) / delta << " "
+            << (r(3) - r0(3)) / delta << " " << (p(1) - p0(1)) / delta << " " << (p(2) - p0(2)) / delta << " "
+            << (p(3) - p0(3)) / delta << std::endl;
   //               -----------------------------  end of check
 #endif
 
   return;
-} // end gradientGlobal
-
+}  // end gradientGlobal
 
 // ----  calculate gradient and Hessian matrix in local parameters ------
-void 
-GlobalTrackerMuonAlignment::gradientLocal(GlobalVector& GRt, GlobalVector& GPt, 
-					  GlobalVector& GRm, GlobalVector& GPm, 
-					  GlobalVector& GNorm, 
-					  CLHEP::HepSymMatrix& covLoc,
-					  CLHEP::HepMatrix& rotLoc,
-					  CLHEP::HepVector& R0,
-					  AlgebraicVector4& LPRm) 
-{
+void GlobalTrackerMuonAlignment::gradientLocal(GlobalVector& GRt,
+                                               GlobalVector& GPt,
+                                               GlobalVector& GRm,
+                                               GlobalVector& GPm,
+                                               GlobalVector& GNorm,
+                                               CLHEP::HepSymMatrix& covLoc,
+                                               CLHEP::HepMatrix& rotLoc,
+                                               CLHEP::HepVector& R0,
+                                               AlgebraicVector4& LPRm) {
   // we search for 6D global correction vector (d, a), where
-  //                        3D vector of shihts d 
-  //               3D vector of rotation angles    a   
+  //                        3D vector of shihts d
+  //               3D vector of rotation angles    a
 
   bool alarm = true;
   //bool alarm = false;
   bool info = false;
 
-  if(debug_)
-    std::cout<<" gradientLocal "<<std::endl; 
+  if (debug_)
+    std::cout << " gradientLocal " << std::endl;
 
   /*
   const Surface& refSurface = tsosMuon.surface();
@@ -2295,14 +2340,24 @@ GlobalTrackerMuonAlignment::gradientLocal(GlobalVector& GRt, GlobalVector& GPt,
   rotLoc(3,1) = refSurface.rotation().zx();
   rotLoc(3,2) = refSurface.rotation().zy();
   rotLoc(3,3) = refSurface.rotation().zz();
-  */  
+  */
 
   CLHEP::HepVector Rt(3), Pt(3), Rm(3), Pm(3), Norm(3);
-  Rt(1) = GRt.x(); Rt(2) = GRt.y();  Rt(3) = GRt.z();
-  Pt(1) = GPt.x(); Pt(2) = GPt.y();  Pt(3) = GPt.z();
-  Rm(1) = GRm.x(); Rm(2) = GRm.y();  Rm(3) = GRm.z();
-  Pm(1) = GPm.x(); Pm(2) = GPm.y();  Pm(3) = GPm.z();
-  Norm(1) = GNorm.x(); Norm(2) = GNorm.y(); Norm(3) = GNorm.z(); 
+  Rt(1) = GRt.x();
+  Rt(2) = GRt.y();
+  Rt(3) = GRt.z();
+  Pt(1) = GPt.x();
+  Pt(2) = GPt.y();
+  Pt(3) = GPt.z();
+  Rm(1) = GRm.x();
+  Rm(2) = GRm.y();
+  Rm(3) = GRm.z();
+  Pm(1) = GPm.x();
+  Pm(2) = GPm.y();
+  Pm(3) = GPm.z();
+  Norm(1) = GNorm.x();
+  Norm(2) = GNorm.y();
+  Norm(3) = GNorm.z();
 
   CLHEP::HepVector V(4), Rml(3), Pml(3), Rtl(3), Ptl(3);
 
@@ -2310,17 +2365,17 @@ GlobalTrackerMuonAlignment::gradientLocal(GlobalVector& GRt, GlobalVector& GPt,
   R0(1) = refSurface.position().x();
   R0(2) = refSurface.position().y();
   R0(3) = refSurface.position().z();
-  */ 
+  */
 
   Rml = rotLoc * (Rm - R0);
   Rtl = rotLoc * (Rt - R0);
   Pml = rotLoc * Pm;
   Ptl = rotLoc * Pt;
-  
-  V(1) = LPRm(0) - Ptl(1)/Ptl(3); 
-  V(2) = LPRm(1) - Ptl(2)/Ptl(3);   
-  V(3) = LPRm(2) - Rtl(1);   
-  V(4) = LPRm(3) - Rtl(2); 
+
+  V(1) = LPRm(0) - Ptl(1) / Ptl(3);
+  V(2) = LPRm(1) - Ptl(2) / Ptl(3);
+  V(3) = LPRm(2) - Rtl(1);
+  V(4) = LPRm(3) - Rtl(2);
 
   /*
   CLHEP::HepSymMatrix Cov(4,0), W(4,0);
@@ -2339,78 +2394,80 @@ GlobalTrackerMuonAlignment::gradientLocal(GlobalVector& GRt, GlobalVector& GPt,
 
   int ierr;
   W.invert(ierr);
-  if(ierr != 0) { if(alarm)
-      std::cout<<" gradientLocal: inversion of matrix W fail "<<std::endl;
+  if (ierr != 0) {
+    if (alarm)
+      std::cout << " gradientLocal: inversion of matrix W fail " << std::endl;
     return;
   }
-  
+
   //                               JacobianCartesianToLocal
- 
-  //AlgebraicMatrix56 jacobian   // differ from calculation above 
-  //= JacobianCartesianToLocal::JacobianCartesianToLocal 
-  //(refSurface, tsosTrack.localParameters()).jacobian();  
+
+  //AlgebraicMatrix56 jacobian   // differ from calculation above
+  //= JacobianCartesianToLocal::JacobianCartesianToLocal
+  //(refSurface, tsosTrack.localParameters()).jacobian();
   //for(int i=1; i<=4; i++) for(int j=1; j<=6; j++){
   //int j1 = j - 1; JacToLoc(i,j) = jacobian(i, j1);}
-  
-  CLHEP::HepMatrix JacToLoc(4,6,0);
-  for(int i=1; i<=2; i++)
-    for(int j=1; j<=3; j++){
-      JacToLoc(i,j+3) = (rotLoc(i,j) - rotLoc(3,j)*Pml(i)/Pml(3))/Pml(3); 
-      JacToLoc(i+2,j) = rotLoc(i,j);
+
+  CLHEP::HepMatrix JacToLoc(4, 6, 0);
+  for (int i = 1; i <= 2; i++)
+    for (int j = 1; j <= 3; j++) {
+      JacToLoc(i, j + 3) = (rotLoc(i, j) - rotLoc(3, j) * Pml(i) / Pml(3)) / Pml(3);
+      JacToLoc(i + 2, j) = rotLoc(i, j);
     }
 
   //                                    JacobianCorrectionsToCartesian
   //double PmN = CLHEP::dot(Pm, Norm);
   double PmN = CLHEP_dot(Pm, Norm);
 
-  CLHEP::HepMatrix Jac(6,6,0);
-  for (int i=1; i <= 3; i++)
-    for (int j=1; j <= 3; j++){
-      Jac(i,j) =  Pm(i)*Norm(j) / PmN;
-      if(i == j ) Jac(i,j) -= 1.;
-    }  
+  CLHEP::HepMatrix Jac(6, 6, 0);
+  for (int i = 1; i <= 3; i++)
+    for (int j = 1; j <= 3; j++) {
+      Jac(i, j) = Pm(i) * Norm(j) / PmN;
+      if (i == j)
+        Jac(i, j) -= 1.;
+    }
 
-  //                                            dp/da                   
-  Jac(4,4) =     0.;   // dpx/dax
-  Jac(5,4) = -Pm(3);   // dpy/dax
-  Jac(6,4) =  Pm(2);   // dpz/dax
-  Jac(4,5) =  Pm(3);   // dpx/day
-  Jac(5,5) =     0.;   // dpy/day
-  Jac(6,5) = -Pm(1);   // dpz/day
-  Jac(4,6) = -Pm(2);   // dpx/daz
-  Jac(5,6) =  Pm(1);   // dpy/daz
-  Jac(6,6) =     0.;   // dpz/daz
+  //                                            dp/da
+  Jac(4, 4) = 0.;      // dpx/dax
+  Jac(5, 4) = -Pm(3);  // dpy/dax
+  Jac(6, 4) = Pm(2);   // dpz/dax
+  Jac(4, 5) = Pm(3);   // dpx/day
+  Jac(5, 5) = 0.;      // dpy/day
+  Jac(6, 5) = -Pm(1);  // dpz/day
+  Jac(4, 6) = -Pm(2);  // dpx/daz
+  Jac(5, 6) = Pm(1);   // dpy/daz
+  Jac(6, 6) = 0.;      // dpz/daz
 
   CLHEP::HepVector dsda(3);
-  dsda(1) = (Norm(2)*Rm(3) - Norm(3)*Rm(2)) / PmN;
-  dsda(2) = (Norm(3)*Rm(1) - Norm(1)*Rm(3)) / PmN;
-  dsda(3) = (Norm(1)*Rm(2) - Norm(2)*Rm(1)) / PmN;
+  dsda(1) = (Norm(2) * Rm(3) - Norm(3) * Rm(2)) / PmN;
+  dsda(2) = (Norm(3) * Rm(1) - Norm(1) * Rm(3)) / PmN;
+  dsda(3) = (Norm(1) * Rm(2) - Norm(2) * Rm(1)) / PmN;
 
-  //                                             dr/da  
-  Jac(1,4) =          Pm(1)*dsda(1);  // drx/dax
-  Jac(2,4) = -Rm(3) + Pm(2)*dsda(1);  // dry/dax
-  Jac(3,4) =  Rm(2) + Pm(3)*dsda(1);  // drz/dax
+  //                                             dr/da
+  Jac(1, 4) = Pm(1) * dsda(1);           // drx/dax
+  Jac(2, 4) = -Rm(3) + Pm(2) * dsda(1);  // dry/dax
+  Jac(3, 4) = Rm(2) + Pm(3) * dsda(1);   // drz/dax
 
-  Jac(1,5) =  Rm(3) + Pm(1)*dsda(2);  // drx/day
-  Jac(2,5) =          Pm(2)*dsda(2);  // dry/day
-  Jac(3,5) = -Rm(1) + Pm(3)*dsda(2);  // drz/day
+  Jac(1, 5) = Rm(3) + Pm(1) * dsda(2);   // drx/day
+  Jac(2, 5) = Pm(2) * dsda(2);           // dry/day
+  Jac(3, 5) = -Rm(1) + Pm(3) * dsda(2);  // drz/day
 
-  Jac(1,6) = -Rm(2) + Pm(1)*dsda(3);  // drx/daz
-  Jac(2,6) =  Rm(1) + Pm(2)*dsda(3);  // dry/daz
-  Jac(3,6) =          Pm(3)*dsda(3);  // drz/daz
+  Jac(1, 6) = -Rm(2) + Pm(1) * dsda(3);  // drx/daz
+  Jac(2, 6) = Rm(1) + Pm(2) * dsda(3);   // dry/daz
+  Jac(3, 6) = Pm(3) * dsda(3);           // drz/daz
 
   //                                   JacobianCorrectionToLocal
-  CLHEP::HepMatrix JacCorLoc(4,6,0);
+  CLHEP::HepMatrix JacCorLoc(4, 6, 0);
   JacCorLoc = JacToLoc * Jac;
 
-  //                                   gradient and Hessian 
-  CLHEP::HepMatrix W_Jac(6,4,0);
+  //                                   gradient and Hessian
+  CLHEP::HepMatrix W_Jac(6, 4, 0);
   W_Jac = JacCorLoc.T() * W;
-  
+
   CLHEP::HepVector gradL(6);
   gradL = W_Jac * V;
 
-  CLHEP::HepMatrix hessL(6,6);
+  CLHEP::HepMatrix hessL(6, 6);
   hessL = JacCorLoc.T() * W * JacCorLoc;
 
   GradL += gradL;
@@ -2419,19 +2476,20 @@ GlobalTrackerMuonAlignment::gradientLocal(GlobalVector& GRt, GlobalVector& GPt,
   CLHEP::HepVector dLI = CLHEP::solve(HessL, -GradL);
   int iErI;
   CLHEP::HepMatrix ErrdLI = HessL.inverse(iErI);
-  if( iErI != 0) { if(alarm)
-      std::cout<<" gradLocal Error inverse  Hess matrix !!!!!!!!!!!"<<std::endl;
+  if (iErI != 0) {
+    if (alarm)
+      std::cout << " gradLocal Error inverse  Hess matrix !!!!!!!!!!!" << std::endl;
   }
 
-  if(info || debug_){
-    std::cout<<" dL   "<<dLI(1)<<" "<<dLI(2)<<" "<<dLI(3)<<" "<<dLI(4)<<" "
-	     <<dLI(5)<<" "<<dLI(6)<<std::endl;;
-    std::cout<<" +-   "<<sqrt(ErrdLI(1,1))<<" "<<sqrt(ErrdLI(2,2))<<" "<<sqrt(ErrdLI(3,3))
-	     <<" "<<sqrt(ErrdLI(4,4))<<" "<<sqrt(ErrdLI(5,5))<<" "<<sqrt(ErrdLI(6,6))
-	     <<std::endl;
+  if (info || debug_) {
+    std::cout << " dL   " << dLI(1) << " " << dLI(2) << " " << dLI(3) << " " << dLI(4) << " " << dLI(5) << " " << dLI(6)
+              << std::endl;
+    ;
+    std::cout << " +-   " << sqrt(ErrdLI(1, 1)) << " " << sqrt(ErrdLI(2, 2)) << " " << sqrt(ErrdLI(3, 3)) << " "
+              << sqrt(ErrdLI(4, 4)) << " " << sqrt(ErrdLI(5, 5)) << " " << sqrt(ErrdLI(6, 6)) << std::endl;
   }
- 
-  if(debug_){
+
+  if (debug_) {
     //std::cout<<" dV(da3) {"<<-JacCorLoc(1,6)*0.002<<" "<<-JacCorLoc(2,6)*0.002<<" "
     //   <<-JacCorLoc(3,6)*0.002<<" "<<-JacCorLoc(4,6)*0.002<<"}"<<std::endl;
     //std::cout<<" JacCLo {"<<JacCorLoc(1,6)<<" "<<JacCorLoc(2,6)<<" "
@@ -2440,176 +2498,193 @@ GlobalTrackerMuonAlignment::gradientLocal(GlobalVector& GRt, GlobalVector& GPt,
     //   <<Jac(1,6)<<" "<<Jac(2,6)<<"}"<<std::endl;
     //std::cout<<"Jac(,a3){"<<Jac(1,6)<<" "<<Jac(2,6)<<" "<<Jac(3,6)<<" "<<Jac(4,6)<<" "
     //   <<Jac(5,6)<<" "<<Jac(6,6)<<std::endl;
-    int i=5;  
-    if(GNorm.z() > 0.95)
-      std::cout<<" Ecap1   N "<<GNorm<<std::endl; 
-    else if(GNorm.z() < -0.95)
-      std::cout<<" Ecap2   N "<<GNorm<<std::endl; 
+    int i = 5;
+    if (GNorm.z() > 0.95)
+      std::cout << " Ecap1   N " << GNorm << std::endl;
+    else if (GNorm.z() < -0.95)
+      std::cout << " Ecap2   N " << GNorm << std::endl;
     else
-      std::cout<<" Barrel  N "<<GNorm<<std::endl; 
-    std::cout<<" JacCLo(i,"<<i<<") = {"<<JacCorLoc(1,i)<<" "<<JacCorLoc(2,i)<<" "
-     <<JacCorLoc(3,i)<<" "<<JacCorLoc(4,i)<<"}"<<std::endl;
-    std::cout<<"   rotLoc "<<rotLoc<<std::endl;
-    std::cout<<" position "<<R0<<std::endl;
-    std::cout<<" Pm,l "<<Pm.T()<<" "<<Pml(1)/Pml(3)<<" "<<Pml(2)/Pml(3)<<std::endl;
-    std::cout<<" Pt,l "<<Pt.T()<<" "<<Ptl(1)/Ptl(3)<<" "<<Ptl(2)/Ptl(3)<<std::endl;
-    std::cout<<" V  "<<V.T()<<std::endl;  
-    std::cout<<" Cov \n"<<covLoc<<std::endl;
-    std::cout<<" W*Cov "<<W*covLoc<<std::endl;
+      std::cout << " Barrel  N " << GNorm << std::endl;
+    std::cout << " JacCLo(i," << i << ") = {" << JacCorLoc(1, i) << " " << JacCorLoc(2, i) << " " << JacCorLoc(3, i)
+              << " " << JacCorLoc(4, i) << "}" << std::endl;
+    std::cout << "   rotLoc " << rotLoc << std::endl;
+    std::cout << " position " << R0 << std::endl;
+    std::cout << " Pm,l " << Pm.T() << " " << Pml(1) / Pml(3) << " " << Pml(2) / Pml(3) << std::endl;
+    std::cout << " Pt,l " << Pt.T() << " " << Ptl(1) / Ptl(3) << " " << Ptl(2) / Ptl(3) << std::endl;
+    std::cout << " V  " << V.T() << std::endl;
+    std::cout << " Cov \n" << covLoc << std::endl;
+    std::cout << " W*Cov " << W * covLoc << std::endl;
     //std::cout<<" JacCarToLoc = drldrc \n"<<
     //JacobianCartesianToLocal::JacobianCartesianToLocal
     //(refSurface, tsosTrack.localParameters()).jacobian()<<std::endl;
-    std::cout<<" JacToLoc "<<JacToLoc<<std::endl;
-    
+    std::cout << " JacToLoc " << JacToLoc << std::endl;
   }
 
 #ifdef CHECK_OF_JACOBIAN_CARTESIAN_TO_LOCAL
   //---------------------- check of derivatives
-  CLHEP::HepVector V0(4,0);
-  V0(1) = Pml(1)/Pml(3) - Ptl(1)/Ptl(3); 
-  V0(2) = Pml(2)/Pml(3) - Ptl(2)/Ptl(3);   
-  V0(3) = Rml(1) - Rtl(1);   
-  V0(4) = Rml(2) - Rtl(2); 
-  int ii = 3; float delta = 0.01;
-  CLHEP::HepVector V1(4,0);
-  if(ii <= 3) {Rm(ii) += delta; Rml = rotLoc * (Rm - R0);}
-  else {Pm(ii-3) += delta; Pml = rotLoc * Pm;}
+  CLHEP::HepVector V0(4, 0);
+  V0(1) = Pml(1) / Pml(3) - Ptl(1) / Ptl(3);
+  V0(2) = Pml(2) / Pml(3) - Ptl(2) / Ptl(3);
+  V0(3) = Rml(1) - Rtl(1);
+  V0(4) = Rml(2) - Rtl(2);
+  int ii = 3;
+  float delta = 0.01;
+  CLHEP::HepVector V1(4, 0);
+  if (ii <= 3) {
+    Rm(ii) += delta;
+    Rml = rotLoc * (Rm - R0);
+  } else {
+    Pm(ii - 3) += delta;
+    Pml = rotLoc * Pm;
+  }
   //if(ii <= 3) {Rt(ii) += delta; Rtl = rotLoc * (Rt - R0);}
   //else {Pt(ii-3) += delta; Ptl = rotLoc * Pt;}
-  V1(1) = Pml(1)/Pml(3) - Ptl(1)/Ptl(3); 
-  V1(2) = Pml(2)/Pml(3) - Ptl(2)/Ptl(3);   
-  V1(3) = Rml(1) - Rtl(1);   
-  V1(4) = Rml(2) - Rtl(2); 
+  V1(1) = Pml(1) / Pml(3) - Ptl(1) / Ptl(3);
+  V1(2) = Pml(2) / Pml(3) - Ptl(2) / Ptl(3);
+  V1(3) = Rml(1) - Rtl(1);
+  V1(4) = Rml(2) - Rtl(2);
 
-  if(GNorm.z() > 0.95)
-    std::cout<<" Ecap1   N "<<GNorm<<std::endl; 
-  else if(GNorm.z() < -0.95)
-    std::cout<<" Ecap2   N "<<GNorm<<std::endl; 
+  if (GNorm.z() > 0.95)
+    std::cout << " Ecap1   N " << GNorm << std::endl;
+  else if (GNorm.z() < -0.95)
+    std::cout << " Ecap2   N " << GNorm << std::endl;
   else
-    std::cout<<" Barrel  N "<<GNorm<<std::endl; 
-  std::cout<<" dldc Num (i,"<<ii<<") "<<(V1(1)-V0(1))/delta<<" "<<(V1(2)-V0(2))/delta<<" "
-	   <<(V1(3)-V0(3))/delta<<" "<<(V1(4)-V0(4))/delta<<std::endl;
-  std::cout<<" dldc Ana (i,"<<ii<<") "<<JacToLoc(1,ii)<<" "<<JacToLoc(2,ii)<<" "
-	   <<JacToLoc(3,ii)<<" "<<JacToLoc(4,ii)<<std::endl;
+    std::cout << " Barrel  N " << GNorm << std::endl;
+  std::cout << " dldc Num (i," << ii << ") " << (V1(1) - V0(1)) / delta << " " << (V1(2) - V0(2)) / delta << " "
+            << (V1(3) - V0(3)) / delta << " " << (V1(4) - V0(4)) / delta << std::endl;
+  std::cout << " dldc Ana (i," << ii << ") " << JacToLoc(1, ii) << " " << JacToLoc(2, ii) << " " << JacToLoc(3, ii)
+            << " " << JacToLoc(4, ii) << std::endl;
   //float dtxdpx = (rotLoc(1,1) - rotLoc(3,1)*Pml(1)/Pml(3))/Pml(3);
   //float dtydpx = (rotLoc(2,1) - rotLoc(3,2)*Pml(2)/Pml(3))/Pml(3);
   //std::cout<<" dtx/dpx dty/ "<<dtxdpx<<" "<<dtydpx<<std::endl;
-#endif						  
+#endif
 
   return;
-} // end gradientLocal
-
+}  // end gradientLocal
 
 // ----  simulate a misalignment of muon system   ------
-void 
-GlobalTrackerMuonAlignment::misalignMuon(GlobalVector& GRm, GlobalVector& GPm, GlobalVector& Nl, 
-				GlobalVector& Rt, GlobalVector& Rm, GlobalVector& Pm)
-{
-  CLHEP::HepVector d(3,0), a(3,0), Norm(3), Rm0(3), Pm0(3), Rm1(3), Pm1(3), 
-    Rmi(3), Pmi(3) ; 
-  
-  d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0000; // zero     
+void GlobalTrackerMuonAlignment::misalignMuon(
+    GlobalVector& GRm, GlobalVector& GPm, GlobalVector& Nl, GlobalVector& Rt, GlobalVector& Rm, GlobalVector& Pm) {
+  CLHEP::HepVector d(3, 0), a(3, 0), Norm(3), Rm0(3), Pm0(3), Rm1(3), Pm1(3), Rmi(3), Pmi(3);
+
+  d(1) = 0.0;
+  d(2) = 0.0;
+  d(3) = 0.0;
+  a(1) = 0.0000;
+  a(2) = 0.0000;
+  a(3) = 0.0000;  // zero
   //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0020; a(2)=0.0000; a(3)=0.0000; // a1=.002
   //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0020; a(3)=0.0000; // a2=.002
-  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0020; // a3=.002    
-  //d(1)=1.0; d(2)=2.0; d(3)=3.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0000; // 12300     
-  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0020; // a3=0.002    
-  //d(1)=10.; d(2)=20.; d(3)=30.; a(1)=0.0100; a(2)=0.0200; a(3)=0.0300; // huge      
-  //d(1)=10.; d(2)=20.; d(3)=30.; a(1)=0.2000; a(2)=0.2500; a(3)=0.3000; // huge angles      
+  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0020; // a3=.002
+  //d(1)=1.0; d(2)=2.0; d(3)=3.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0000; // 12300
+  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0020; // a3=0.002
+  //d(1)=10.; d(2)=20.; d(3)=30.; a(1)=0.0100; a(2)=0.0200; a(3)=0.0300; // huge
+  //d(1)=10.; d(2)=20.; d(3)=30.; a(1)=0.2000; a(2)=0.2500; a(3)=0.3000; // huge angles
   //d(1)=0.3; d(2)=0.4; d(3)=0.5; a(1)=0.0005; a(2)=0.0006; a(3)=0.0007; // 0345 0567
   //d(1)=0.3; d(2)=0.4; d(3)=0.5; a(1)=0.0001; a(2)=0.0002; a(3)=0.0003; // 0345 0123
   //d(1)=0.2; d(2)=0.2; d(3)=0.2; a(1)=0.0002; a(2)=0.0002; a(3)=0.0002; // 0111 0111
 
-  MuGlShift = d; MuGlAngle = a;
+  MuGlShift = d;
+  MuGlAngle = a;
 
-  if((d(1) == 0.) & (d(2) == 0.) & (d(3) == 0.) & 
-     (a(1) == 0.) & (a(2) == 0.) & (a(3) == 0.)){
+  if ((d(1) == 0.) & (d(2) == 0.) & (d(3) == 0.) & (a(1) == 0.) & (a(2) == 0.) & (a(3) == 0.)) {
     Rm = GRm;
     Pm = GPm;
-    if(debug_)
-      std::cout<<" ......   without misalignment "<<std::endl;
+    if (debug_)
+      std::cout << " ......   without misalignment " << std::endl;
     return;
   }
-  
-  Rm0(1) = GRm.x(); Rm0(2) = GRm.y(); Rm0(3) = GRm.z();
-  Pm0(1) = GPm.x(); Pm0(2) = GPm.y(); Pm0(3) = GPm.z();  
-  Norm(1) = Nl.x(); Norm(2) = Nl.y(); Norm(3) = Nl.z();     
-  
-  CLHEP::HepMatrix T(3,3,1);
- 
+
+  Rm0(1) = GRm.x();
+  Rm0(2) = GRm.y();
+  Rm0(3) = GRm.z();
+  Pm0(1) = GPm.x();
+  Pm0(2) = GPm.y();
+  Pm0(3) = GPm.z();
+  Norm(1) = Nl.x();
+  Norm(2) = Nl.y();
+  Norm(3) = Nl.z();
+
+  CLHEP::HepMatrix T(3, 3, 1);
+
   //T(1,2) =  a(3); T(1,3) = -a(2);
   //T(2,1) = -a(3); T(2,3) =  a(1);
   //T(3,1) =  a(2); T(3,2) = -a(1);
-  
+
   double s1 = std::sin(a(1)), c1 = std::cos(a(1));
   double s2 = std::sin(a(2)), c2 = std::cos(a(2));
-  double s3 = std::sin(a(3)), c3 = std::cos(a(3));     
-  T(1,1) =  c2 * c3;  
-  T(1,2) =  c1 * s3 + s1 * s2 * c3;
-  T(1,3) =  s1 * s3 - c1 * s2 * c3;
-  T(2,1) = -c2 * s3; 
-  T(2,2) =  c1 * c3 - s1 * s2 * s3;
-  T(2,3) =  s1 * c3 + c1 * s2 * s3;
-  T(3,1) =  s2;
-  T(3,2) = -s1 * c2;
-  T(3,3) =  c1 * c2;
-  
+  double s3 = std::sin(a(3)), c3 = std::cos(a(3));
+  T(1, 1) = c2 * c3;
+  T(1, 2) = c1 * s3 + s1 * s2 * c3;
+  T(1, 3) = s1 * s3 - c1 * s2 * c3;
+  T(2, 1) = -c2 * s3;
+  T(2, 2) = c1 * c3 - s1 * s2 * s3;
+  T(2, 3) = s1 * c3 + c1 * s2 * s3;
+  T(3, 1) = s2;
+  T(3, 2) = -s1 * c2;
+  T(3, 3) = c1 * c2;
+
   //int terr;
   //CLHEP::HepMatrix Ti = T.inverse(terr);
   CLHEP::HepMatrix Ti = T.T();
   CLHEP::HepVector di = -Ti * d;
-  
-  CLHEP::HepVector ex0(3,0), ey0(3,0), ez0(3,0), ex(3,0), ey(3,0), ez(3,0);
-  ex0(1) = 1.; ey0(2) = 1.;  ez0(3) = 1.;
-  ex = Ti*ex0; ey = Ti*ey0; ez = Ti*ez0;
-  
-  CLHEP::HepVector TiN = Ti * Norm; 
-  //double si = CLHEP::dot((Ti*Rm0 - Rm0 + di), TiN) / CLHEP::dot(Pm0, TiN); 
+
+  CLHEP::HepVector ex0(3, 0), ey0(3, 0), ez0(3, 0), ex(3, 0), ey(3, 0), ez(3, 0);
+  ex0(1) = 1.;
+  ey0(2) = 1.;
+  ez0(3) = 1.;
+  ex = Ti * ex0;
+  ey = Ti * ey0;
+  ez = Ti * ez0;
+
+  CLHEP::HepVector TiN = Ti * Norm;
+  //double si = CLHEP::dot((Ti*Rm0 - Rm0 + di), TiN) / CLHEP::dot(Pm0, TiN);
   //Rm1(1) = CLHEP::dot(ex, Rm0 + si*Pm0 - di);
   //Rm1(2) = CLHEP::dot(ey, Rm0 + si*Pm0 - di);
   //Rm1(3) = CLHEP::dot(ez, Rm0 + si*Pm0 - di);
-  double si = CLHEP_dot((Ti*Rm0 - Rm0 + di), TiN) / CLHEP_dot(Pm0, TiN); 
-  Rm1(1) = CLHEP_dot(ex, Rm0 + si*Pm0 - di);
-  Rm1(2) = CLHEP_dot(ey, Rm0 + si*Pm0 - di);
-  Rm1(3) = CLHEP_dot(ez, Rm0 + si*Pm0 - di);
+  double si = CLHEP_dot((Ti * Rm0 - Rm0 + di), TiN) / CLHEP_dot(Pm0, TiN);
+  Rm1(1) = CLHEP_dot(ex, Rm0 + si * Pm0 - di);
+  Rm1(2) = CLHEP_dot(ey, Rm0 + si * Pm0 - di);
+  Rm1(3) = CLHEP_dot(ez, Rm0 + si * Pm0 - di);
   Pm1 = T * Pm0;
-  
-  Rm = GlobalVector(Rm1(1), Rm1(2), Rm1(3));  
-  //Pm = GlobalVector(CLHEP::dot(Pm0,ex), CLHEP::dot(Pm0, ey), CLHEP::dot(Pm0,ez));// =T*Pm0 
-  Pm = GlobalVector(CLHEP_dot(Pm0,ex), CLHEP_dot(Pm0, ey), CLHEP_dot(Pm0,ez));// =T*Pm0 
-  
-  if(debug_){    //    -------------  debug tranformation 
-    
-    std::cout<<" ----- Pm "<<Pm<<std::endl;
-    std::cout<<"    T*Pm0 "<<Pm1.T()<<std::endl;
+
+  Rm = GlobalVector(Rm1(1), Rm1(2), Rm1(3));
+  //Pm = GlobalVector(CLHEP::dot(Pm0,ex), CLHEP::dot(Pm0, ey), CLHEP::dot(Pm0,ez));// =T*Pm0
+  Pm = GlobalVector(CLHEP_dot(Pm0, ex), CLHEP_dot(Pm0, ey), CLHEP_dot(Pm0, ez));  // =T*Pm0
+
+  if (debug_) {  //    -------------  debug tranformation
+
+    std::cout << " ----- Pm " << Pm << std::endl;
+    std::cout << "    T*Pm0 " << Pm1.T() << std::endl;
     //std::cout<<" Ti*T*Pm0 "<<(Ti*(T*Pm0)).T()<<std::endl;
-    
+
     //CLHEP::HepVector Rml = (Rm0 + si*Pm0 - di) + di;
-    CLHEP::HepVector Rml = Rm1(1)*ex + Rm1(2)*ey + Rm1(3)*ez + di;
-    
-    CLHEP::HepVector Rt0(3); 
-    Rt0(1)=Rt.x();  Rt0(2)=Rt.y();  Rt0(3)=Rt.z();      
-    
-    //double sl = CLHEP::dot(T*(Rt0 - Rml), T*Norm) / CLHEP::dot(Ti * Pm1, Norm);     
-    double sl = CLHEP_dot(T*(Rt0 - Rml), T*Norm) / CLHEP_dot(Ti * Pm1, Norm);     
-    CLHEP::HepVector Rl = Rml + sl*(Ti*Pm1);
-    
+    CLHEP::HepVector Rml = Rm1(1) * ex + Rm1(2) * ey + Rm1(3) * ez + di;
+
+    CLHEP::HepVector Rt0(3);
+    Rt0(1) = Rt.x();
+    Rt0(2) = Rt.y();
+    Rt0(3) = Rt.z();
+
+    //double sl = CLHEP::dot(T*(Rt0 - Rml), T*Norm) / CLHEP::dot(Ti * Pm1, Norm);
+    double sl = CLHEP_dot(T * (Rt0 - Rml), T * Norm) / CLHEP_dot(Ti * Pm1, Norm);
+    CLHEP::HepVector Rl = Rml + sl * (Ti * Pm1);
+
     //double A = CLHEP::dot(Ti*Pm1, Norm);
-    //double B = CLHEP::dot(Rt0, Norm) - CLHEP::dot(Ti*Rm1, Norm) 
-    //+ CLHEP::dot(Ti*d, Norm); 
-    double A = CLHEP_dot(Ti*Pm1, Norm);
-    double B = CLHEP_dot(Rt0, Norm) - CLHEP_dot(Ti*Rm1, Norm) 
-      + CLHEP_dot(Ti*d, Norm); 
-    double s = B/A;
-    CLHEP::HepVector Dr = Ti*Rm1 - Ti*d  + s*(Ti*Pm1) - Rm0;
-    CLHEP::HepVector Dp = Ti*Pm1 - Pm0;
+    //double B = CLHEP::dot(Rt0, Norm) - CLHEP::dot(Ti*Rm1, Norm)
+    //+ CLHEP::dot(Ti*d, Norm);
+    double A = CLHEP_dot(Ti * Pm1, Norm);
+    double B = CLHEP_dot(Rt0, Norm) - CLHEP_dot(Ti * Rm1, Norm) + CLHEP_dot(Ti * d, Norm);
+    double s = B / A;
+    CLHEP::HepVector Dr = Ti * Rm1 - Ti * d + s * (Ti * Pm1) - Rm0;
+    CLHEP::HepVector Dp = Ti * Pm1 - Pm0;
 
     CLHEP::HepVector TiR = Ti * Rm0 + di;
     CLHEP::HepVector Ri = T * TiR + d;
-    
-    std::cout<<" --TTi-0 "<<(Ri-Rm0).T()<<std::endl;
-    std::cout<<" --  Dr  "<<Dr.T()<<endl;
-    std::cout<<" --  Dp  "<<Dp.T()<<endl;
+
+    std::cout << " --TTi-0 " << (Ri - Rm0).T() << std::endl;
+    std::cout << " --  Dr  " << Dr.T() << endl;
+    std::cout << " --  Dp  " << Dp.T() << endl;
     //std::cout<<" ex "<<ex.T()<<endl;
     //std::cout<<" ey "<<ey.T()<<endl;
     //std::cout<<" ez "<<ez.T()<<endl;
@@ -2617,10 +2692,10 @@ GlobalTrackerMuonAlignment::misalignMuon(GlobalVector& GRm, GlobalVector& GPm, G
     //std::cout<<" ---- Ti ---- "<<Ti<<std::endl;
     //std::cout<<" ---- d  ---- "<<d.T()<<std::endl;
     //std::cout<<" ---- di ---- "<<di.T()<<std::endl;
-    std::cout<<" -- si sl s "<<si<<" "<<sl<<" "<<s<<std::endl;
+    std::cout << " -- si sl s " << si << " " << sl << " " << s << std::endl;
     //std::cout<<" -- si sl "<<si<<" "<<sl<<endl;
     //std::cout<<" -- si s "<<si<<" "<<s<<endl;
-    std::cout<<" -- Rml-(Rm0+si*Pm0) "<<(Rml - Rm0 - si*Pm0).T()<<std::endl;
+    std::cout << " -- Rml-(Rm0+si*Pm0) " << (Rml - Rm0 - si * Pm0).T() << std::endl;
     //std::cout<<" -- Rm0 "<<Rm0.T()<<std::endl;
     //std::cout<<" -- Rm1 "<<Rm1.T()<<std::endl;
     //std::cout<<" -- Rmi "<<Rmi.T()<<std::endl;
@@ -2628,121 +2703,137 @@ GlobalTrackerMuonAlignment::misalignMuon(GlobalVector& GRm, GlobalVector& GPm, G
     //std::cout<<" --s2Pm "<<(s2*(T * Pm1)).T()<<std::endl;
     //std::cout<<" --R1-0 "<<(Rm1-Rm0).T()<<std::endl;
     //std::cout<<" --Ri-0 "<<(Rmi-Rm0).T()<<std::endl;
-    std::cout<<" --Rl-0 "<<(Rl-Rm0).T()<<std::endl;
+    std::cout << " --Rl-0 " << (Rl - Rm0).T() << std::endl;
     //std::cout<<" --Pi-0 "<<(Pmi-Pm0).T()<<std::endl;
-  }      //                                --------   end of debug
-  
+  }  //                                --------   end of debug
+
   return;
 
-} // end of misalignMuon
+}  // end of misalignMuon
 
 // ----  simulate a misalignment of muon system with Local  ------
-void 
-GlobalTrackerMuonAlignment::misalignMuonL(GlobalVector& GRm, GlobalVector& GPm, GlobalVector& Nl, 
-					  GlobalVector& Rt, GlobalVector& Rm, GlobalVector& Pm,
-					  AlgebraicVector4& Vm, 
-					  TrajectoryStateOnSurface& tsosTrack,
-					  TrajectoryStateOnSurface& tsosMuon)
-{
-  CLHEP::HepVector d(3,0), a(3,0), Norm(3), Rm0(3), Pm0(3), Rm1(3), Pm1(3), 
-    Rmi(3), Pmi(3); 
-  
-  d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0000; // zero     
+void GlobalTrackerMuonAlignment::misalignMuonL(GlobalVector& GRm,
+                                               GlobalVector& GPm,
+                                               GlobalVector& Nl,
+                                               GlobalVector& Rt,
+                                               GlobalVector& Rm,
+                                               GlobalVector& Pm,
+                                               AlgebraicVector4& Vm,
+                                               TrajectoryStateOnSurface& tsosTrack,
+                                               TrajectoryStateOnSurface& tsosMuon) {
+  CLHEP::HepVector d(3, 0), a(3, 0), Norm(3), Rm0(3), Pm0(3), Rm1(3), Pm1(3), Rmi(3), Pmi(3);
+
+  d(1) = 0.0;
+  d(2) = 0.0;
+  d(3) = 0.0;
+  a(1) = 0.0000;
+  a(2) = 0.0000;
+  a(3) = 0.0000;  // zero
   //d(1)=0.0000001; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0000; // nonzero
   //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0020; a(2)=0.0000; a(3)=0.0000; // a1=.002
   //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0020; a(3)=0.0000; // a2=.002
-  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0020; // a3=.002    
-  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0200; // a3=.020    
-  //d(1)=1.0; d(2)=2.0; d(3)=3.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0000; // 12300     
-  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0020; // a3=0.002    
-  //d(1)=10.; d(2)=20.; d(3)=30.; a(1)=0.0100; a(2)=0.0200; a(3)=0.0300; // huge      
-  //d(1)=10.; d(2)=20.; d(3)=30.; a(1)=0.2000; a(2)=0.2500; a(3)=0.3000; // huge angles      
+  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0020; // a3=.002
+  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0200; // a3=.020
+  //d(1)=1.0; d(2)=2.0; d(3)=3.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0000; // 12300
+  //d(1)=0.0; d(2)=0.0; d(3)=0.0; a(1)=0.0000; a(2)=0.0000; a(3)=0.0020; // a3=0.002
+  //d(1)=10.; d(2)=20.; d(3)=30.; a(1)=0.0100; a(2)=0.0200; a(3)=0.0300; // huge
+  //d(1)=10.; d(2)=20.; d(3)=30.; a(1)=0.2000; a(2)=0.2500; a(3)=0.3000; // huge angles
   //d(1)=0.3; d(2)=0.4; d(3)=0.5; a(1)=0.0005; a(2)=0.0006; a(3)=0.0007; // 0345 0567
   //d(1)=0.3; d(2)=0.4; d(3)=0.5; a(1)=0.0001; a(2)=0.0002; a(3)=0.0003; // 0345 0123
   //d(1)=0.1; d(2)=0.2; d(3)=0.3; a(1)=0.0003; a(2)=0.0004; a(3)=0.0005; // 0123 0345
 
-  MuGlShift = d; MuGlAngle = a;
+  MuGlShift = d;
+  MuGlAngle = a;
 
-  if((d(1) == 0.) & (d(2) == 0.) & (d(3) == 0.) & 
-     (a(1) == 0.) & (a(2) == 0.) & (a(3) == 0.)){
+  if ((d(1) == 0.) & (d(2) == 0.) & (d(3) == 0.) & (a(1) == 0.) & (a(2) == 0.) & (a(3) == 0.)) {
     Rm = GRm;
     Pm = GPm;
     AlgebraicVector4 Vm0;
     Vm = AlgebraicVector4(tsosMuon.localParameters().vector()(1),
-			  tsosMuon.localParameters().vector()(2),
-			  tsosMuon.localParameters().vector()(3),
-			  tsosMuon.localParameters().vector()(4)); 
-    if(debug_)
-      std::cout<<" ......   without misalignment "<<std::endl;
+                          tsosMuon.localParameters().vector()(2),
+                          tsosMuon.localParameters().vector()(3),
+                          tsosMuon.localParameters().vector()(4));
+    if (debug_)
+      std::cout << " ......   without misalignment " << std::endl;
     return;
   }
-  
-  Rm0(1) = GRm.x(); Rm0(2) = GRm.y(); Rm0(3) = GRm.z();
-  Pm0(1) = GPm.x(); Pm0(2) = GPm.y(); Pm0(3) = GPm.z();  
-  Norm(1) = Nl.x(); Norm(2) = Nl.y(); Norm(3) = Nl.z();     
-  
-  CLHEP::HepMatrix T(3,3,1);
- 
+
+  Rm0(1) = GRm.x();
+  Rm0(2) = GRm.y();
+  Rm0(3) = GRm.z();
+  Pm0(1) = GPm.x();
+  Pm0(2) = GPm.y();
+  Pm0(3) = GPm.z();
+  Norm(1) = Nl.x();
+  Norm(2) = Nl.y();
+  Norm(3) = Nl.z();
+
+  CLHEP::HepMatrix T(3, 3, 1);
+
   //T(1,2) =  a(3); T(1,3) = -a(2);
   //T(2,1) = -a(3); T(2,3) =  a(1);
   //T(3,1) =  a(2); T(3,2) = -a(1);
-  
+
   double s1 = std::sin(a(1)), c1 = std::cos(a(1));
   double s2 = std::sin(a(2)), c2 = std::cos(a(2));
-  double s3 = std::sin(a(3)), c3 = std::cos(a(3));     
-  T(1,1) =  c2 * c3;  
-  T(1,2) =  c1 * s3 + s1 * s2 * c3;
-  T(1,3) =  s1 * s3 - c1 * s2 * c3;
-  T(2,1) = -c2 * s3; 
-  T(2,2) =  c1 * c3 - s1 * s2 * s3;
-  T(2,3) =  s1 * c3 + c1 * s2 * s3;
-  T(3,1) =  s2;
-  T(3,2) = -s1 * c2;
-  T(3,3) =  c1 * c2;
+  double s3 = std::sin(a(3)), c3 = std::cos(a(3));
+  T(1, 1) = c2 * c3;
+  T(1, 2) = c1 * s3 + s1 * s2 * c3;
+  T(1, 3) = s1 * s3 - c1 * s2 * c3;
+  T(2, 1) = -c2 * s3;
+  T(2, 2) = c1 * c3 - s1 * s2 * s3;
+  T(2, 3) = s1 * c3 + c1 * s2 * s3;
+  T(3, 1) = s2;
+  T(3, 2) = -s1 * c2;
+  T(3, 3) = c1 * c2;
 
-  //                    Ti, di what we have to apply for misalignment  
+  //                    Ti, di what we have to apply for misalignment
   //int terr;
   //CLHEP::HepMatrix Ti = T.inverse(terr);
   CLHEP::HepMatrix Ti = T.T();
   CLHEP::HepVector di = -Ti * d;
-  
-  CLHEP::HepVector ex0(3,0), ey0(3,0), ez0(3,0), ex(3,0), ey(3,0), ez(3,0);
-  ex0(1) = 1.; ey0(2) = 1.;  ez0(3) = 1.;
-  ex = Ti*ex0; ey = Ti*ey0; ez = Ti*ez0;
 
-  CLHEP::HepVector TiN = Ti * Norm; 
-  //double si = CLHEP::dot((Ti*Rm0 - Rm0 + di), TiN) / CLHEP::dot(Pm0, TiN); 
+  CLHEP::HepVector ex0(3, 0), ey0(3, 0), ez0(3, 0), ex(3, 0), ey(3, 0), ez(3, 0);
+  ex0(1) = 1.;
+  ey0(2) = 1.;
+  ez0(3) = 1.;
+  ex = Ti * ex0;
+  ey = Ti * ey0;
+  ez = Ti * ez0;
+
+  CLHEP::HepVector TiN = Ti * Norm;
+  //double si = CLHEP::dot((Ti*Rm0 - Rm0 + di), TiN) / CLHEP::dot(Pm0, TiN);
   //Rm1(1) = CLHEP::dot(ex, Rm0 + si*Pm0 - di);
   //Rm1(2) = CLHEP::dot(ey, Rm0 + si*Pm0 - di);
   //Rm1(3) = CLHEP::dot(ez, Rm0 + si*Pm0 - di);
-  double si = CLHEP_dot((Ti*Rm0 - Rm0 + di), TiN) / CLHEP_dot(Pm0, TiN); 
-  Rm1(1) = CLHEP_dot(ex, Rm0 + si*Pm0 - di);
-  Rm1(2) = CLHEP_dot(ey, Rm0 + si*Pm0 - di);
-  Rm1(3) = CLHEP_dot(ez, Rm0 + si*Pm0 - di);
+  double si = CLHEP_dot((Ti * Rm0 - Rm0 + di), TiN) / CLHEP_dot(Pm0, TiN);
+  Rm1(1) = CLHEP_dot(ex, Rm0 + si * Pm0 - di);
+  Rm1(2) = CLHEP_dot(ey, Rm0 + si * Pm0 - di);
+  Rm1(3) = CLHEP_dot(ez, Rm0 + si * Pm0 - di);
   Pm1 = T * Pm0;
-    
+
   // Global muon parameters after misalignment
-  Rm = GlobalVector(Rm1(1), Rm1(2), Rm1(3));  
-  //Pm = GlobalVector(CLHEP::dot(Pm0,ex), CLHEP::dot(Pm0, ey), CLHEP::dot(Pm0,ez));// =T*Pm0 
-  Pm = GlobalVector(CLHEP_dot(Pm0,ex), CLHEP_dot(Pm0, ey), CLHEP_dot(Pm0,ez));// =T*Pm0 
+  Rm = GlobalVector(Rm1(1), Rm1(2), Rm1(3));
+  //Pm = GlobalVector(CLHEP::dot(Pm0,ex), CLHEP::dot(Pm0, ey), CLHEP::dot(Pm0,ez));// =T*Pm0
+  Pm = GlobalVector(CLHEP_dot(Pm0, ex), CLHEP_dot(Pm0, ey), CLHEP_dot(Pm0, ez));  // =T*Pm0
 
   // Local muon parameters after misalignment
   const Surface& refSurface = tsosMuon.surface();
-  CLHEP::HepMatrix Tl(3,3,0);
+  CLHEP::HepMatrix Tl(3, 3, 0);
 
-  Tl(1,1) = refSurface.rotation().xx();
-  Tl(1,2) = refSurface.rotation().xy();
-  Tl(1,3) = refSurface.rotation().xz();
-  
-  Tl(2,1) = refSurface.rotation().yx();
-  Tl(2,2) = refSurface.rotation().yy();
-  Tl(2,3) = refSurface.rotation().yz();
-  
-  Tl(3,1) = refSurface.rotation().zx();
-  Tl(3,2) = refSurface.rotation().zy();
-  Tl(3,3) = refSurface.rotation().zz();
+  Tl(1, 1) = refSurface.rotation().xx();
+  Tl(1, 2) = refSurface.rotation().xy();
+  Tl(1, 3) = refSurface.rotation().xz();
 
-  CLHEP::HepVector R0(3,0), newR0(3,0), newRl(3,0), newPl(3,0);
+  Tl(2, 1) = refSurface.rotation().yx();
+  Tl(2, 2) = refSurface.rotation().yy();
+  Tl(2, 3) = refSurface.rotation().yz();
+
+  Tl(3, 1) = refSurface.rotation().zx();
+  Tl(3, 2) = refSurface.rotation().zy();
+  Tl(3, 3) = refSurface.rotation().zz();
+
+  CLHEP::HepVector R0(3, 0), newR0(3, 0), newRl(3, 0), newPl(3, 0);
   R0(1) = refSurface.position().x();
   R0(2) = refSurface.position().y();
   R0(3) = refSurface.position().z();
@@ -2750,129 +2841,132 @@ GlobalTrackerMuonAlignment::misalignMuonL(GlobalVector& GRm, GlobalVector& GPm, 
   newRl = Tl * (Rm1 - R0);
   newPl = Tl * Pm1;
 
-  Vm(0) = newPl(1)/newPl(3);
-  Vm(1) = newPl(2)/newPl(3);
+  Vm(0) = newPl(1) / newPl(3);
+  Vm(1) = newPl(2) / newPl(3);
   Vm(2) = newRl(1);
   Vm(3) = newRl(2);
-  
+
 #ifdef CHECK_DERIVATIVES_LOCAL_VS_ANGLES
   float del = 0.0001;
   //int ii = 1; T(3,2) +=del; T(2,3) -=del;
-  int ii = 2; T(3,1) -=del; T(1,3) +=del;
+  int ii = 2;
+  T(3, 1) -= del;
+  T(1, 3) += del;
   //int ii = 3; T(1,2) -=del; T(2,1) +=del;
   AlgebraicVector4 Vm0 = Vm;
-  CLHEP::HepVector Rm10 = Rm1, Pm10 = Pm1;;
-  CLHEP::HepMatrix newTl = Tl*T;
+  CLHEP::HepVector Rm10 = Rm1, Pm10 = Pm1;
+  ;
+  CLHEP::HepMatrix newTl = Tl * T;
   Ti = T.T();
-  di = -Ti * d;  
-  ex = Ti*ex0; ey = Ti*ey0; ez = Ti*ez0;
-  TiN = Ti * Norm; 
-  si = CLHEP_dot((Ti*Rm0 - Rm0 + di), TiN) / CLHEP_dot(Pm0, TiN); 
-  Rm1(1) = CLHEP_dot(ex, Rm0 + si*Pm0 - di);
-  Rm1(2) = CLHEP_dot(ey, Rm0 + si*Pm0 - di);
-  Rm1(3) = CLHEP_dot(ez, Rm0 + si*Pm0 - di);
+  di = -Ti * d;
+  ex = Ti * ex0;
+  ey = Ti * ey0;
+  ez = Ti * ez0;
+  TiN = Ti * Norm;
+  si = CLHEP_dot((Ti * Rm0 - Rm0 + di), TiN) / CLHEP_dot(Pm0, TiN);
+  Rm1(1) = CLHEP_dot(ex, Rm0 + si * Pm0 - di);
+  Rm1(2) = CLHEP_dot(ey, Rm0 + si * Pm0 - di);
+  Rm1(3) = CLHEP_dot(ez, Rm0 + si * Pm0 - di);
   Pm1 = T * Pm0;
 
   newRl = Tl * (Rm1 - R0);
   newPl = Tl * Pm1;
 
-  Vm(0) = newPl(1)/newPl(3);
-  Vm(1) = newPl(2)/newPl(3);
+  Vm(0) = newPl(1) / newPl(3);
+  Vm(1) = newPl(2) / newPl(3);
   Vm(2) = newRl(1);
   Vm(3) = newRl(2);
-  std::cout<<" ========= dVm/da"<<ii<<" "<<(Vm-Vm0)*(1./del)<<std::endl;
-#endif 
+  std::cout << " ========= dVm/da" << ii << " " << (Vm - Vm0) * (1. / del) << std::endl;
+#endif
 
-  if(debug_){
-  //std::cout<<" dRm/da3 "<<((Rm1-Rm10)*(1./del)).T()<<" "<<((Pm1-Pm10)*(1./del)).T()<<std::endl; 
-  //std::cout<<"             Norm "<<Norm.T()<<std::endl;
-  std::cout<<"             ex  "<<(Tl.T()*ex0).T()<<std::endl;
-  std::cout<<"             ey  "<<(Tl.T()*ey0).T()<<std::endl;
-  std::cout<<"             ez  "<<(Tl.T()*ez0).T()<<std::endl;
-  //std::cpot<<" 
+  if (debug_) {
+    //std::cout<<" dRm/da3 "<<((Rm1-Rm10)*(1./del)).T()<<" "<<((Pm1-Pm10)*(1./del)).T()<<std::endl;
+    //std::cout<<"             Norm "<<Norm.T()<<std::endl;
+    std::cout << "             ex  " << (Tl.T() * ex0).T() << std::endl;
+    std::cout << "             ey  " << (Tl.T() * ey0).T() << std::endl;
+    std::cout << "             ez  " << (Tl.T() * ez0).T() << std::endl;
+    //std::cpot<<"
 
-  std::cout<<"    pxyz/p gl 0 "<<(Pm0/Pm0.norm()).T()<<std::endl;
-  std::cout<<"    pxyz/p loc0 "<<(Tl*Pm0/(Tl*Pm0).norm()).T()<<std::endl;
-  std::cout<<"    pxyz/p glob  "<<(Pm1/Pm1.norm()).T()<<std::endl;
-  std::cout<<"    pxyz/p  loc  "<<(newPl/newPl.norm()).T()<<std::endl;
+    std::cout << "    pxyz/p gl 0 " << (Pm0 / Pm0.norm()).T() << std::endl;
+    std::cout << "    pxyz/p loc0 " << (Tl * Pm0 / (Tl * Pm0).norm()).T() << std::endl;
+    std::cout << "    pxyz/p glob  " << (Pm1 / Pm1.norm()).T() << std::endl;
+    std::cout << "    pxyz/p  loc  " << (newPl / newPl.norm()).T() << std::endl;
 
-  //std::cout<<"             Rot   "<<refSurface.rotation()<<endl;
-  //std::cout<<"             Tl   "<<Tl<<endl;
-  std::cout<<" ---- phi g0 g1 l0 l1  "
-	   <<atan2(Pm0(2),Pm0(1))<<" "<<atan2(Pm1(2),Pm1(1))<<" "
-	   <<atan2((Tl*Pm0)(2),(Tl*Pm0)(1))<<" "
-	   <<atan2(newPl(2),newPl(1))<<std::endl;
-  std::cout<<" ---- angl Gl Loc "<<atan2(Pm1(2),Pm1(1))-atan2(Pm0(2),Pm0(1))<<" "
-	   <<atan2(newPl(2),newPl(1))-atan2((Tl*Pm0)(2),(Tl*Pm0)(1))<<" "
-	   <<atan2(newPl(3),newPl(2))-atan2((Tl*Pm0)(3),(Tl*Pm0)(2))<<" "
-	   <<atan2(newPl(1),newPl(3))-atan2((Tl*Pm0)(1),(Tl*Pm0)(3))<<" "<<std::endl;
+    //std::cout<<"             Rot   "<<refSurface.rotation()<<endl;
+    //std::cout<<"             Tl   "<<Tl<<endl;
+    std::cout << " ---- phi g0 g1 l0 l1  " << atan2(Pm0(2), Pm0(1)) << " " << atan2(Pm1(2), Pm1(1)) << " "
+              << atan2((Tl * Pm0)(2), (Tl * Pm0)(1)) << " " << atan2(newPl(2), newPl(1)) << std::endl;
+    std::cout << " ---- angl Gl Loc " << atan2(Pm1(2), Pm1(1)) - atan2(Pm0(2), Pm0(1)) << " "
+              << atan2(newPl(2), newPl(1)) - atan2((Tl * Pm0)(2), (Tl * Pm0)(1)) << " "
+              << atan2(newPl(3), newPl(2)) - atan2((Tl * Pm0)(3), (Tl * Pm0)(2)) << " "
+              << atan2(newPl(1), newPl(3)) - atan2((Tl * Pm0)(1), (Tl * Pm0)(3)) << " " << std::endl;
   }
 
-  if(debug_){
-    CLHEP::HepMatrix newTl(3,3,0);
-    CLHEP::HepVector R0(3,0), newRl(3,0), newPl(3,0);
+  if (debug_) {
+    CLHEP::HepMatrix newTl(3, 3, 0);
+    CLHEP::HepVector R0(3, 0), newRl(3, 0), newPl(3, 0);
     newTl = Tl * Ti.T();
     newR0 = Ti * R0 + di;
 
-    std::cout<<" N "<<Norm.T()<<std::endl;
-    std::cout<<" dtxl yl "<<Vm(0)-tsosMuon.localParameters().vector()(1)<<" "
-	     <<Vm(1)-tsosMuon.localParameters().vector()(2)<<std::endl;
-    std::cout<<" dXl dYl "<<Vm(2)-tsosMuon.localParameters().vector()(3)<<" "
-	     <<Vm(3)-tsosMuon.localParameters().vector()(4)<<std::endl;
-    std::cout<<" localM    "<<tsosMuon.localParameters().vector()<<std::endl;  
-    std::cout<<"       Vm  "<<Vm<<std::endl;
-    
-    
-    CLHEP::HepVector Rvc(3,0), Pvc(3,0), Rvg(3,0), Pvg(3,0);
-    Rvc(1) = Vm(2); Rvc(2) = Vm(3);
-    Pvc(3) = tsosMuon.localParameters().pzSign() * Pm0.norm() /
-      sqrt(1 + Vm(0)*Vm(0) + Vm(1)*Vm(1));
+    std::cout << " N " << Norm.T() << std::endl;
+    std::cout << " dtxl yl " << Vm(0) - tsosMuon.localParameters().vector()(1) << " "
+              << Vm(1) - tsosMuon.localParameters().vector()(2) << std::endl;
+    std::cout << " dXl dYl " << Vm(2) - tsosMuon.localParameters().vector()(3) << " "
+              << Vm(3) - tsosMuon.localParameters().vector()(4) << std::endl;
+    std::cout << " localM    " << tsosMuon.localParameters().vector() << std::endl;
+    std::cout << "       Vm  " << Vm << std::endl;
+
+    CLHEP::HepVector Rvc(3, 0), Pvc(3, 0), Rvg(3, 0), Pvg(3, 0);
+    Rvc(1) = Vm(2);
+    Rvc(2) = Vm(3);
+    Pvc(3) = tsosMuon.localParameters().pzSign() * Pm0.norm() / sqrt(1 + Vm(0) * Vm(0) + Vm(1) * Vm(1));
     Pvc(1) = Pvc(3) * Vm(0);
     Pvc(2) = Pvc(3) * Vm(1);
-    
+
     Rvg = newTl.T() * Rvc + newR0;
     Pvg = newTl.T() * Pvc;
-    
-    std::cout<<" newPl     "<<newPl.T()<<std::endl;
-    std::cout<<"    Pvc    "<<Pvc.T()<<std::endl;
-    std::cout<<"    Rvg    "<<Rvg.T()<<std::endl;
-    std::cout<<"    Rm1    "<<Rm1.T()<<std::endl;
-    std::cout<<"    Pvg    "<<Pvg.T()<<std::endl;
-    std::cout<<"    Pm1    "<<Pm1.T()<<std::endl;
+
+    std::cout << " newPl     " << newPl.T() << std::endl;
+    std::cout << "    Pvc    " << Pvc.T() << std::endl;
+    std::cout << "    Rvg    " << Rvg.T() << std::endl;
+    std::cout << "    Rm1    " << Rm1.T() << std::endl;
+    std::cout << "    Pvg    " << Pvg.T() << std::endl;
+    std::cout << "    Pm1    " << Pm1.T() << std::endl;
   }
-  
-  if(debug_){    //    ----------  how to transform cartesian from shifted to correct 
-    
-    std::cout<<" ----- Pm "<<Pm<<std::endl;
-    std::cout<<"    T*Pm0 "<<Pm1.T()<<std::endl;
+
+  if (debug_) {  //    ----------  how to transform cartesian from shifted to correct
+
+    std::cout << " ----- Pm " << Pm << std::endl;
+    std::cout << "    T*Pm0 " << Pm1.T() << std::endl;
     //std::cout<<" Ti*T*Pm0 "<<(Ti*(T*Pm0)).T()<<std::endl;
-    
+
     //CLHEP::HepVector Rml = (Rm0 + si*Pm0 - di) + di;
-    CLHEP::HepVector Rml = Rm1(1)*ex + Rm1(2)*ey + Rm1(3)*ez + di;
-    
-    CLHEP::HepVector Rt0(3); 
-    Rt0(1)=Rt.x();  Rt0(2)=Rt.y();  Rt0(3)=Rt.z();      
-    
-    //double sl = CLHEP::dot(T*(Rt0 - Rml), T*Norm) / CLHEP::dot(Ti * Pm1, Norm);     
-    double sl = CLHEP_dot(T*(Rt0 - Rml), T*Norm) / CLHEP_dot(Ti * Pm1, Norm);     
-    CLHEP::HepVector Rl = Rml + sl*(Ti*Pm1);
-    
+    CLHEP::HepVector Rml = Rm1(1) * ex + Rm1(2) * ey + Rm1(3) * ez + di;
+
+    CLHEP::HepVector Rt0(3);
+    Rt0(1) = Rt.x();
+    Rt0(2) = Rt.y();
+    Rt0(3) = Rt.z();
+
+    //double sl = CLHEP::dot(T*(Rt0 - Rml), T*Norm) / CLHEP::dot(Ti * Pm1, Norm);
+    double sl = CLHEP_dot(T * (Rt0 - Rml), T * Norm) / CLHEP_dot(Ti * Pm1, Norm);
+    CLHEP::HepVector Rl = Rml + sl * (Ti * Pm1);
+
     //double A = CLHEP::dot(Ti*Pm1, Norm);
-    //double B = CLHEP::dot(Rt0, Norm) - CLHEP::dot(Ti*Rm1, Norm) 
-    //+ CLHEP::dot(Ti*d, Norm); 
-    double A = CLHEP_dot(Ti*Pm1, Norm);
-    double B = CLHEP_dot(Rt0, Norm) - CLHEP_dot(Ti*Rm1, Norm) 
-      + CLHEP_dot(Ti*d, Norm); 
-    double s = B/A;
-    CLHEP::HepVector Dr = Ti*Rm1 - Ti*d  + s*(Ti*Pm1) - Rm0;
-    CLHEP::HepVector Dp = Ti*Pm1 - Pm0;
+    //double B = CLHEP::dot(Rt0, Norm) - CLHEP::dot(Ti*Rm1, Norm)
+    //+ CLHEP::dot(Ti*d, Norm);
+    double A = CLHEP_dot(Ti * Pm1, Norm);
+    double B = CLHEP_dot(Rt0, Norm) - CLHEP_dot(Ti * Rm1, Norm) + CLHEP_dot(Ti * d, Norm);
+    double s = B / A;
+    CLHEP::HepVector Dr = Ti * Rm1 - Ti * d + s * (Ti * Pm1) - Rm0;
+    CLHEP::HepVector Dp = Ti * Pm1 - Pm0;
 
     CLHEP::HepVector TiR = Ti * Rm0 + di;
     CLHEP::HepVector Ri = T * TiR + d;
-    
-    std::cout<<" --TTi-0 "<<(Ri-Rm0).T()<<std::endl;
-    std::cout<<" --  Dr  "<<Dr.T()<<endl;
-    std::cout<<" --  Dp  "<<Dp.T()<<endl;
+
+    std::cout << " --TTi-0 " << (Ri - Rm0).T() << std::endl;
+    std::cout << " --  Dr  " << Dr.T() << endl;
+    std::cout << " --  Dp  " << Dp.T() << endl;
     //std::cout<<" ex "<<ex.T()<<endl;
     //std::cout<<" ey "<<ey.T()<<endl;
     //std::cout<<" ez "<<ez.T()<<endl;
@@ -2880,10 +2974,10 @@ GlobalTrackerMuonAlignment::misalignMuonL(GlobalVector& GRm, GlobalVector& GPm, 
     //std::cout<<" ---- Ti ---- "<<Ti<<std::endl;
     //std::cout<<" ---- d  ---- "<<d.T()<<std::endl;
     //std::cout<<" ---- di ---- "<<di.T()<<std::endl;
-    std::cout<<" -- si sl s "<<si<<" "<<sl<<" "<<s<<std::endl;
+    std::cout << " -- si sl s " << si << " " << sl << " " << s << std::endl;
     //std::cout<<" -- si sl "<<si<<" "<<sl<<endl;
     //std::cout<<" -- si s "<<si<<" "<<s<<endl;
-    std::cout<<" -- Rml-(Rm0+si*Pm0) "<<(Rml - Rm0 - si*Pm0).T()<<std::endl;
+    std::cout << " -- Rml-(Rm0+si*Pm0) " << (Rml - Rm0 - si * Pm0).T() << std::endl;
     //std::cout<<" -- Rm0 "<<Rm0.T()<<std::endl;
     //std::cout<<" -- Rm1 "<<Rm1.T()<<std::endl;
     //std::cout<<" -- Rmi "<<Rmi.T()<<std::endl;
@@ -2891,330 +2985,341 @@ GlobalTrackerMuonAlignment::misalignMuonL(GlobalVector& GRm, GlobalVector& GPm, 
     //std::cout<<" --s2Pm "<<(s2*(T * Pm1)).T()<<std::endl;
     //std::cout<<" --R1-0 "<<(Rm1-Rm0).T()<<std::endl;
     //std::cout<<" --Ri-0 "<<(Rmi-Rm0).T()<<std::endl;
-    std::cout<<" --Rl-0 "<<(Rl-Rm0).T()<<std::endl;
+    std::cout << " --Rl-0 " << (Rl - Rm0).T() << std::endl;
     //std::cout<<" --Pi-0 "<<(Pmi-Pm0).T()<<std::endl;
-  }      //                                --------   end of debug
-  
+  }  //                                --------   end of debug
+
   return;
 
 }  // end misalignMuonL
 
-
 // ----  refit any direction of transient track ------
-void 
-GlobalTrackerMuonAlignment::trackFitter(reco::TrackRef alongTr, reco::TransientTrack& alongTTr,
-				       PropagationDirection direction,
-				       TrajectoryStateOnSurface& trackFittedTSOS)
-{
+void GlobalTrackerMuonAlignment::trackFitter(reco::TrackRef alongTr,
+                                             reco::TransientTrack& alongTTr,
+                                             PropagationDirection direction,
+                                             TrajectoryStateOnSurface& trackFittedTSOS) {
   bool info = false;
   bool smooth = false;
-  
-  if(info)
-    std::cout<<" ......... start of trackFitter ......... "<<std::endl;  
-  if(false && info){ 
-    this->debugTrackHit(" Tracker track hits ", alongTr); 
-    this->debugTrackHit(" Tracker TransientTrack hits ", alongTTr); 
+
+  if (info)
+    std::cout << " ......... start of trackFitter ......... " << std::endl;
+  if (false && info) {
+    this->debugTrackHit(" Tracker track hits ", alongTr);
+    this->debugTrackHit(" Tracker TransientTrack hits ", alongTTr);
   }
 
   edm::OwnVector<TrackingRecHit> recHit;
   DetId trackDetId = DetId(alongTr->innerDetId());
-  for(auto const& hit : alongTr->recHits()) recHit.push_back(hit->clone());
-  if(direction != alongMomentum)
-    {
-      edm::OwnVector<TrackingRecHit> recHitAlong = recHit;
-      recHit.clear();
-      for(unsigned int ihit = recHitAlong.size()-1; ihit+1>0; ihit--){
-	recHit.push_back(recHitAlong[ihit]);
-      }
-      recHitAlong.clear();
+  for (auto const& hit : alongTr->recHits())
+    recHit.push_back(hit->clone());
+  if (direction != alongMomentum) {
+    edm::OwnVector<TrackingRecHit> recHitAlong = recHit;
+    recHit.clear();
+    for (unsigned int ihit = recHitAlong.size() - 1; ihit + 1 > 0; ihit--) {
+      recHit.push_back(recHitAlong[ihit]);
     }
-  if(info)
-    std::cout<<" ... Own recHit.size() "<<recHit.size()<<" "<<trackDetId.rawId()<<std::endl;
+    recHitAlong.clear();
+  }
+  if (info)
+    std::cout << " ... Own recHit.size() " << recHit.size() << " " << trackDetId.rawId() << std::endl;
 
   //MuonTransientTrackingRecHitBuilder::ConstRecHitContainer recHitTrack;
   TransientTrackingRecHit::RecHitContainer recHitTrack;
-  for(auto const& hit : alongTr->recHits()) recHitTrack.push_back(TTRHBuilder->build(hit));
-  
-  if(info)
-    std::cout<<" ... recHitTrack.size() "<<recHit.size()<<" "<<trackDetId.rawId()
-	     <<" ======> recHitMu "<<std::endl;
+  for (auto const& hit : alongTr->recHits())
+    recHitTrack.push_back(TTRHBuilder->build(hit));
+
+  if (info)
+    std::cout << " ... recHitTrack.size() " << recHit.size() << " " << trackDetId.rawId() << " ======> recHitMu "
+              << std::endl;
 
   MuonTransientTrackingRecHitBuilder::ConstRecHitContainer recHitMu = recHitTrack;
   /*
     MuonTransientTrackingRecHitBuilder::ConstRecHitContainer recHitMu =
     MuRHBuilder->build(alongTTr.recHits().begin(), alongTTr.recHits().end());
   */
-  if(info)
-    std::cout<<" ...along.... recHitMu.size() "<<recHitMu.size()<<std::endl;
-  if(direction != alongMomentum){
+  if (info)
+    std::cout << " ...along.... recHitMu.size() " << recHitMu.size() << std::endl;
+  if (direction != alongMomentum) {
     MuonTransientTrackingRecHitBuilder::ConstRecHitContainer recHitMuAlong = recHitMu;
     recHitMu.clear();
-    for(unsigned int ihit = recHitMuAlong.size()-1; ihit+1>0; ihit--){
+    for (unsigned int ihit = recHitMuAlong.size() - 1; ihit + 1 > 0; ihit--) {
       recHitMu.push_back(recHitMuAlong[ihit]);
     }
     recHitMuAlong.clear();
   }
-  if(info)
-    std::cout<<" ...opposite... recHitMu.size() "<<recHitMu.size()<<std::endl;
+  if (info)
+    std::cout << " ...opposite... recHitMu.size() " << recHitMu.size() << std::endl;
 
   TrajectoryStateOnSurface firstTSOS;
-  if(direction == alongMomentum) firstTSOS = alongTTr.innermostMeasurementState();
-  else                           firstTSOS = alongTTr.outermostMeasurementState();
+  if (direction == alongMomentum)
+    firstTSOS = alongTTr.innermostMeasurementState();
+  else
+    firstTSOS = alongTTr.outermostMeasurementState();
 
   AlgebraicSymMatrix55 CovLoc;
-  CovLoc(0,0) = 1.   * firstTSOS.localError().matrix()(0,0);
-  CovLoc(1,1) = 10.  * firstTSOS.localError().matrix()(1,1);
-  CovLoc(2,2) = 10.  * firstTSOS.localError().matrix()(2,2);
-  CovLoc(3,3) = 100. * firstTSOS.localError().matrix()(3,3);
-  CovLoc(4,4) = 100. * firstTSOS.localError().matrix()(4,4);
-  TrajectoryStateOnSurface initialTSOS(firstTSOS.localParameters(), LocalTrajectoryError(CovLoc),
-				       firstTSOS.surface(), &*magneticField_);
-  
-  PTrajectoryStateOnDet  PTraj = 
-    trajectoryStateTransform::persistentState(initialTSOS, trackDetId.rawId());
-  //const TrajectorySeed seedT(*PTraj, recHit, alongMomentum);  
-  const TrajectorySeed seedT(PTraj, recHit, direction);  
+  CovLoc(0, 0) = 1. * firstTSOS.localError().matrix()(0, 0);
+  CovLoc(1, 1) = 10. * firstTSOS.localError().matrix()(1, 1);
+  CovLoc(2, 2) = 10. * firstTSOS.localError().matrix()(2, 2);
+  CovLoc(3, 3) = 100. * firstTSOS.localError().matrix()(3, 3);
+  CovLoc(4, 4) = 100. * firstTSOS.localError().matrix()(4, 4);
+  TrajectoryStateOnSurface initialTSOS(
+      firstTSOS.localParameters(), LocalTrajectoryError(CovLoc), firstTSOS.surface(), &*magneticField_);
+
+  PTrajectoryStateOnDet PTraj = trajectoryStateTransform::persistentState(initialTSOS, trackDetId.rawId());
+  //const TrajectorySeed seedT(*PTraj, recHit, alongMomentum);
+  const TrajectorySeed seedT(PTraj, recHit, direction);
 
   std::vector<Trajectory> trajVec;
-  if(direction == alongMomentum) trajVec = theFitter->fit(seedT, recHitMu, initialTSOS);
-  else                           trajVec = theFitterOp->fit(seedT, recHitMu, initialTSOS);
-  
-  if(info){
-    this->debugTrajectorySOSv(" innermostTSOS of TransientTrack", 
-			     alongTTr.innermostMeasurementState());
-    this->debugTrajectorySOSv(" outermostTSOS of TransientTrack", 
-			     alongTTr.outermostMeasurementState());
+  if (direction == alongMomentum)
+    trajVec = theFitter->fit(seedT, recHitMu, initialTSOS);
+  else
+    trajVec = theFitterOp->fit(seedT, recHitMu, initialTSOS);
+
+  if (info) {
+    this->debugTrajectorySOSv(" innermostTSOS of TransientTrack", alongTTr.innermostMeasurementState());
+    this->debugTrajectorySOSv(" outermostTSOS of TransientTrack", alongTTr.outermostMeasurementState());
     this->debugTrajectorySOS(" initialTSOS for theFitter ", initialTSOS);
-    std::cout<<" . . . . . trajVec.size() "<<trajVec.size()<<std::endl;
-    if(!trajVec.empty()) this->debugTrajectory(" theFitter trajectory ", trajVec[0]);
+    std::cout << " . . . . . trajVec.size() " << trajVec.size() << std::endl;
+    if (!trajVec.empty())
+      this->debugTrajectory(" theFitter trajectory ", trajVec[0]);
   }
 
-  if(!smooth){
-    if(!trajVec.empty()) trackFittedTSOS = trajVec[0].lastMeasurement().updatedState();}
-  else{
+  if (!smooth) {
+    if (!trajVec.empty())
+      trackFittedTSOS = trajVec[0].lastMeasurement().updatedState();
+  } else {
     std::vector<Trajectory> trajSVec;
-    if (!trajVec.empty()){
-      if(direction == alongMomentum) trajSVec = theSmoother->trajectories(*(trajVec.begin()));
-      else                           trajSVec = theSmootherOp->trajectories(*(trajVec.begin()));
+    if (!trajVec.empty()) {
+      if (direction == alongMomentum)
+        trajSVec = theSmoother->trajectories(*(trajVec.begin()));
+      else
+        trajSVec = theSmootherOp->trajectories(*(trajVec.begin()));
     }
-    if(info) std::cout<<" . . . . trajSVec.size() "<<trajSVec.size()<<std::endl;
-    if(!trajSVec.empty()) this->debugTrajectorySOSv("smoothed geom InnermostState",
-						  trajSVec[0].geometricalInnermostState());
-    if(!trajSVec.empty()) trackFittedTSOS = trajSVec[0].geometricalInnermostState();
+    if (info)
+      std::cout << " . . . . trajSVec.size() " << trajSVec.size() << std::endl;
+    if (!trajSVec.empty())
+      this->debugTrajectorySOSv("smoothed geom InnermostState", trajSVec[0].geometricalInnermostState());
+    if (!trajSVec.empty())
+      trackFittedTSOS = trajSVec[0].geometricalInnermostState();
   }
 
-  if(info) this->debugTrajectorySOSv(" trackFittedTSOS ", trackFittedTSOS);
+  if (info)
+    this->debugTrajectorySOSv(" trackFittedTSOS ", trackFittedTSOS);
 
-} // end of trackFitter
+}  // end of trackFitter
 
 // ----  refit any direction of muon transient track ------
-void 
-GlobalTrackerMuonAlignment::muonFitter(reco::TrackRef alongTr, reco::TransientTrack& alongTTr,
-				       PropagationDirection direction,
-				       TrajectoryStateOnSurface& trackFittedTSOS)
-{  
+void GlobalTrackerMuonAlignment::muonFitter(reco::TrackRef alongTr,
+                                            reco::TransientTrack& alongTTr,
+                                            PropagationDirection direction,
+                                            TrajectoryStateOnSurface& trackFittedTSOS) {
   bool info = false;
   bool smooth = false;
-  
-  if(info)  std::cout<<" ......... start of muonFitter ........"<<std::endl;  
-  if(false && info){  
-    this->debugTrackHit(" Muon track hits ", alongTr); 
-    this->debugTrackHit(" Muon TransientTrack hits ", alongTTr); 
+
+  if (info)
+    std::cout << " ......... start of muonFitter ........" << std::endl;
+  if (false && info) {
+    this->debugTrackHit(" Muon track hits ", alongTr);
+    this->debugTrackHit(" Muon TransientTrack hits ", alongTTr);
   }
 
   edm::OwnVector<TrackingRecHit> recHit;
   DetId trackDetId = DetId(alongTr->innerDetId());
-  for(auto const& hit : alongTr->recHits()) recHit.push_back(hit->clone());
-  if(direction != alongMomentum)
-    {
-      edm::OwnVector<TrackingRecHit> recHitAlong = recHit;
-      recHit.clear();
-      for(unsigned int ihit = recHitAlong.size()-1; ihit+1>0; ihit--){
-	recHit.push_back(recHitAlong[ihit]);
-      }
-      recHitAlong.clear();
+  for (auto const& hit : alongTr->recHits())
+    recHit.push_back(hit->clone());
+  if (direction != alongMomentum) {
+    edm::OwnVector<TrackingRecHit> recHitAlong = recHit;
+    recHit.clear();
+    for (unsigned int ihit = recHitAlong.size() - 1; ihit + 1 > 0; ihit--) {
+      recHit.push_back(recHitAlong[ihit]);
     }
-  if(info)
-    std::cout<<" ... Own recHit.size() DetId==Muon "<<recHit.size()<<" "<<trackDetId.rawId()<<std::endl;
+    recHitAlong.clear();
+  }
+  if (info)
+    std::cout << " ... Own recHit.size() DetId==Muon " << recHit.size() << " " << trackDetId.rawId() << std::endl;
 
   MuonTransientTrackingRecHitBuilder::ConstRecHitContainer recHitMu =
-    MuRHBuilder->build(alongTTr.recHitsBegin(), alongTTr.recHitsEnd());
-  if(info)
-    std::cout<<" ...along.... recHitMu.size() "<<recHitMu.size()<<std::endl;
-  if(direction != alongMomentum){
+      MuRHBuilder->build(alongTTr.recHitsBegin(), alongTTr.recHitsEnd());
+  if (info)
+    std::cout << " ...along.... recHitMu.size() " << recHitMu.size() << std::endl;
+  if (direction != alongMomentum) {
     MuonTransientTrackingRecHitBuilder::ConstRecHitContainer recHitMuAlong = recHitMu;
     recHitMu.clear();
-    for(unsigned int ihit = recHitMuAlong.size()-1; ihit+1>0; ihit--){
+    for (unsigned int ihit = recHitMuAlong.size() - 1; ihit + 1 > 0; ihit--) {
       recHitMu.push_back(recHitMuAlong[ihit]);
     }
     recHitMuAlong.clear();
   }
-  if(info)
-    std::cout<<" ...opposite... recHitMu.size() "<<recHitMu.size()<<std::endl;
+  if (info)
+    std::cout << " ...opposite... recHitMu.size() " << recHitMu.size() << std::endl;
 
   TrajectoryStateOnSurface firstTSOS;
-  if(direction == alongMomentum) firstTSOS = alongTTr.innermostMeasurementState();
-  else                           firstTSOS = alongTTr.outermostMeasurementState();
+  if (direction == alongMomentum)
+    firstTSOS = alongTTr.innermostMeasurementState();
+  else
+    firstTSOS = alongTTr.outermostMeasurementState();
 
   AlgebraicSymMatrix55 CovLoc;
-  CovLoc(0,0) = 1.   * firstTSOS.localError().matrix()(0,0);
-  CovLoc(1,1) = 10.  * firstTSOS.localError().matrix()(1,1);
-  CovLoc(2,2) = 10.  * firstTSOS.localError().matrix()(2,2);
-  CovLoc(3,3) = 100. * firstTSOS.localError().matrix()(3,3);
-  CovLoc(4,4) = 100. * firstTSOS.localError().matrix()(4,4);
-  TrajectoryStateOnSurface initialTSOS(firstTSOS.localParameters(), LocalTrajectoryError(CovLoc),
-				       firstTSOS.surface(), &*magneticField_);
-  
-  PTrajectoryStateOnDet PTraj = 
-    trajectoryStateTransform::persistentState(initialTSOS, trackDetId.rawId());
-  //const TrajectorySeed seedT(*PTraj, recHit, alongMomentum);  
-  const TrajectorySeed seedT(PTraj, recHit, direction);  
+  CovLoc(0, 0) = 1. * firstTSOS.localError().matrix()(0, 0);
+  CovLoc(1, 1) = 10. * firstTSOS.localError().matrix()(1, 1);
+  CovLoc(2, 2) = 10. * firstTSOS.localError().matrix()(2, 2);
+  CovLoc(3, 3) = 100. * firstTSOS.localError().matrix()(3, 3);
+  CovLoc(4, 4) = 100. * firstTSOS.localError().matrix()(4, 4);
+  TrajectoryStateOnSurface initialTSOS(
+      firstTSOS.localParameters(), LocalTrajectoryError(CovLoc), firstTSOS.surface(), &*magneticField_);
+
+  PTrajectoryStateOnDet PTraj = trajectoryStateTransform::persistentState(initialTSOS, trackDetId.rawId());
+  //const TrajectorySeed seedT(*PTraj, recHit, alongMomentum);
+  const TrajectorySeed seedT(PTraj, recHit, direction);
 
   std::vector<Trajectory> trajVec;
-  if(direction == alongMomentum) trajVec = theFitter->fit(seedT, recHitMu, initialTSOS);
-  else                           trajVec = theFitterOp->fit(seedT, recHitMu, initialTSOS);
-  
-  if(info){
-    this->debugTrajectorySOSv(" innermostTSOS of TransientTrack", 
-			     alongTTr.innermostMeasurementState());
-    this->debugTrajectorySOSv(" outermostTSOS of TransientTrack", 
-			     alongTTr.outermostMeasurementState());
+  if (direction == alongMomentum)
+    trajVec = theFitter->fit(seedT, recHitMu, initialTSOS);
+  else
+    trajVec = theFitterOp->fit(seedT, recHitMu, initialTSOS);
+
+  if (info) {
+    this->debugTrajectorySOSv(" innermostTSOS of TransientTrack", alongTTr.innermostMeasurementState());
+    this->debugTrajectorySOSv(" outermostTSOS of TransientTrack", alongTTr.outermostMeasurementState());
     this->debugTrajectorySOS(" initialTSOS for theFitter ", initialTSOS);
-    std::cout<<" . . . . . trajVec.size() "<<trajVec.size()<<std::endl;
-    if(!trajVec.empty()) this->debugTrajectory(" theFitter trajectory ", trajVec[0]);
+    std::cout << " . . . . . trajVec.size() " << trajVec.size() << std::endl;
+    if (!trajVec.empty())
+      this->debugTrajectory(" theFitter trajectory ", trajVec[0]);
   }
 
-  if(!smooth){
-    if(!trajVec.empty()) trackFittedTSOS = trajVec[0].lastMeasurement().updatedState();}
-  else{
+  if (!smooth) {
+    if (!trajVec.empty())
+      trackFittedTSOS = trajVec[0].lastMeasurement().updatedState();
+  } else {
     std::vector<Trajectory> trajSVec;
-    if (!trajVec.empty()){
-      if(direction == alongMomentum) trajSVec = theSmoother->trajectories(*(trajVec.begin()));
-      else                           trajSVec = theSmootherOp->trajectories(*(trajVec.begin()));
+    if (!trajVec.empty()) {
+      if (direction == alongMomentum)
+        trajSVec = theSmoother->trajectories(*(trajVec.begin()));
+      else
+        trajSVec = theSmootherOp->trajectories(*(trajVec.begin()));
     }
-    if(info) std::cout<<" . . . . trajSVec.size() "<<trajSVec.size()<<std::endl;
-    if(!trajSVec.empty()) this->debugTrajectorySOSv("smoothed geom InnermostState",
-						  trajSVec[0].geometricalInnermostState());
-    if(!trajSVec.empty()) trackFittedTSOS = trajSVec[0].geometricalInnermostState();
+    if (info)
+      std::cout << " . . . . trajSVec.size() " << trajSVec.size() << std::endl;
+    if (!trajSVec.empty())
+      this->debugTrajectorySOSv("smoothed geom InnermostState", trajSVec[0].geometricalInnermostState());
+    if (!trajSVec.empty())
+      trackFittedTSOS = trajSVec[0].geometricalInnermostState();
   }
 
-} // end of muonFitter
-
+}  // end of muonFitter
 
 // ----  debug printout of hits from TransientTrack  ------
-void GlobalTrackerMuonAlignment::debugTrackHit(const std::string title, TransientTrack& alongTr) 
-{
-  std::cout<<" ------- "<<title<<" --------"<<std::endl;
+void GlobalTrackerMuonAlignment::debugTrackHit(const std::string title, TransientTrack& alongTr) {
+  std::cout << " ------- " << title << " --------" << std::endl;
   int nHit = 1;
-  for (trackingRecHit_iterator i=alongTr.recHitsBegin();i!=alongTr.recHitsEnd(); i++) {
-    std::cout<<" Hit "<<nHit++<<" DetId "<< (*i)->geographicalId().det();
-    if( (*i)->geographicalId().det() == DetId::Tracker ) std::cout<<" Tracker ";
-    else if ( (*i)->geographicalId().det() == DetId::Muon ) std::cout<<" Muon "; 
-    else std::cout<<" Unknown ";
-    if(!(*i)->isValid()) std::cout<<" not valid "<<std::endl;  
-    else std::cout<<std::endl;
+  for (trackingRecHit_iterator i = alongTr.recHitsBegin(); i != alongTr.recHitsEnd(); i++) {
+    std::cout << " Hit " << nHit++ << " DetId " << (*i)->geographicalId().det();
+    if ((*i)->geographicalId().det() == DetId::Tracker)
+      std::cout << " Tracker ";
+    else if ((*i)->geographicalId().det() == DetId::Muon)
+      std::cout << " Muon ";
+    else
+      std::cout << " Unknown ";
+    if (!(*i)->isValid())
+      std::cout << " not valid " << std::endl;
+    else
+      std::cout << std::endl;
   }
 }
-
 
 // ----  debug printout of hits from TrackRef   ------
-void GlobalTrackerMuonAlignment::debugTrackHit(const std::string title, reco::TrackRef alongTr) 
-{
-  std::cout<<" ------- "<<title<<" --------"<<std::endl;
+void GlobalTrackerMuonAlignment::debugTrackHit(const std::string title, reco::TrackRef alongTr) {
+  std::cout << " ------- " << title << " --------" << std::endl;
   int nHit = 1;
-  for(auto const& hit : alongTr->recHits()) {
-    std::cout<<" Hit "<<nHit++<<" DetId "<< hit->geographicalId().det();
-    if( hit->geographicalId().det() == DetId::Tracker ) std::cout<<" Tracker ";
-    else if ( hit->geographicalId().det() == DetId::Muon ) std::cout<<" Muon "; 
-    else std::cout<<" Unknown ";
-    if(!hit->isValid()) std::cout<<" not valid "<<std::endl;  
-    else std::cout<<std::endl;
+  for (auto const& hit : alongTr->recHits()) {
+    std::cout << " Hit " << nHit++ << " DetId " << hit->geographicalId().det();
+    if (hit->geographicalId().det() == DetId::Tracker)
+      std::cout << " Tracker ";
+    else if (hit->geographicalId().det() == DetId::Muon)
+      std::cout << " Muon ";
+    else
+      std::cout << " Unknown ";
+    if (!hit->isValid())
+      std::cout << " not valid " << std::endl;
+    else
+      std::cout << std::endl;
   }
 }
 
 // ----  debug printout TrajectoryStateOnSurface  ------
-void GlobalTrackerMuonAlignment::debugTrajectorySOS(const std::string title, 
-						     TrajectoryStateOnSurface& trajSOS) 
-{
-  std::cout<<"    --- "<<title<<" --- "<<std::endl;
-  if(!trajSOS.isValid()) {std::cout<<"      Not valid !!!! "<<std::endl; return;}
-  std::cout<<" R |p| "<<trajSOS.globalPosition().perp()<<" "
-	   <<trajSOS.globalMomentum().mag()<<" charge "<<trajSOS.charge()<<std::endl; 
-  std::cout<<" x p  "<<trajSOS.globalParameters().vector()(0)<<" "
-	   <<trajSOS.globalParameters().vector()(1)<<" "
-	   <<trajSOS.globalParameters().vector()(2)<<" "
-	   <<trajSOS.globalParameters().vector()(3)<<" "
-	   <<trajSOS.globalParameters().vector()(4)<<" "
-	   <<trajSOS.globalParameters().vector()(5)<<std::endl;
-  std::cout<<" +/- "<<sqrt(trajSOS.cartesianError().matrix()(0,0))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(1,1))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(2,2))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(3,3))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(4,4))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(5,5))<<std::endl;
-  std::cout<<" q/p dxy/dz xy "<<trajSOS.localParameters().vector()(0)<<" "
-	   <<trajSOS.localParameters().vector()(1)<<" "
-	   <<trajSOS.localParameters().vector()(2)<<" "
-	   <<trajSOS.localParameters().vector()(3)<<" "
-	   <<trajSOS.localParameters().vector()(4)<<std::endl;
-  std::cout<<"   +/- error  "<<sqrt(trajSOS.localError().matrix()(0,0))<<" "
-	   <<sqrt(trajSOS.localError().matrix()(1,1))<<" "
-	   <<sqrt(trajSOS.localError().matrix()(2,2))<<" "
-	   <<sqrt(trajSOS.localError().matrix()(3,3))<<" "
-	   <<sqrt(trajSOS.localError().matrix()(4,4))<<" "<<std::endl;
+void GlobalTrackerMuonAlignment::debugTrajectorySOS(const std::string title, TrajectoryStateOnSurface& trajSOS) {
+  std::cout << "    --- " << title << " --- " << std::endl;
+  if (!trajSOS.isValid()) {
+    std::cout << "      Not valid !!!! " << std::endl;
+    return;
+  }
+  std::cout << " R |p| " << trajSOS.globalPosition().perp() << " " << trajSOS.globalMomentum().mag() << " charge "
+            << trajSOS.charge() << std::endl;
+  std::cout << " x p  " << trajSOS.globalParameters().vector()(0) << " " << trajSOS.globalParameters().vector()(1)
+            << " " << trajSOS.globalParameters().vector()(2) << " " << trajSOS.globalParameters().vector()(3) << " "
+            << trajSOS.globalParameters().vector()(4) << " " << trajSOS.globalParameters().vector()(5) << std::endl;
+  std::cout << " +/- " << sqrt(trajSOS.cartesianError().matrix()(0, 0)) << " "
+            << sqrt(trajSOS.cartesianError().matrix()(1, 1)) << " " << sqrt(trajSOS.cartesianError().matrix()(2, 2))
+            << " " << sqrt(trajSOS.cartesianError().matrix()(3, 3)) << " "
+            << sqrt(trajSOS.cartesianError().matrix()(4, 4)) << " " << sqrt(trajSOS.cartesianError().matrix()(5, 5))
+            << std::endl;
+  std::cout << " q/p dxy/dz xy " << trajSOS.localParameters().vector()(0) << " "
+            << trajSOS.localParameters().vector()(1) << " " << trajSOS.localParameters().vector()(2) << " "
+            << trajSOS.localParameters().vector()(3) << " " << trajSOS.localParameters().vector()(4) << std::endl;
+  std::cout << "   +/- error  " << sqrt(trajSOS.localError().matrix()(0, 0)) << " "
+            << sqrt(trajSOS.localError().matrix()(1, 1)) << " " << sqrt(trajSOS.localError().matrix()(2, 2)) << " "
+            << sqrt(trajSOS.localError().matrix()(3, 3)) << " " << sqrt(trajSOS.localError().matrix()(4, 4)) << " "
+            << std::endl;
 }
 
 // ----  debug printout TrajectoryStateOnSurface  ------
-void GlobalTrackerMuonAlignment::debugTrajectorySOSv(const std::string title, 
-						     TrajectoryStateOnSurface trajSOS) 
-{
-  std::cout<<"    --- "<<title<<" --- "<<std::endl;
-  if(!trajSOS.isValid()) {std::cout<<"      Not valid !!!! "<<std::endl; return;}
-  std::cout<<" R |p| "<<trajSOS.globalPosition().perp()<<" "
-	   <<trajSOS.globalMomentum().mag()<<" charge "<<trajSOS.charge()<<std::endl; 
-  std::cout<<" x p  "<<trajSOS.globalParameters().vector()(0)<<" "
-	   <<trajSOS.globalParameters().vector()(1)<<" "
-	   <<trajSOS.globalParameters().vector()(2)<<" "
-	   <<trajSOS.globalParameters().vector()(3)<<" "
-	   <<trajSOS.globalParameters().vector()(4)<<" "
-	   <<trajSOS.globalParameters().vector()(5)<<std::endl;
-  std::cout<<" +/- "<<sqrt(trajSOS.cartesianError().matrix()(0,0))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(1,1))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(2,2))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(3,3))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(4,4))<<" "
-	   <<sqrt(trajSOS.cartesianError().matrix()(5,5))<<std::endl;
-  std::cout<<" q/p dxy/dz xy "<<trajSOS.localParameters().vector()(0)<<" "
-	   <<trajSOS.localParameters().vector()(1)<<" "
-	   <<trajSOS.localParameters().vector()(2)<<" "
-	   <<trajSOS.localParameters().vector()(3)<<" "
-	   <<trajSOS.localParameters().vector()(4)<<std::endl;
-  std::cout<<"   +/- error  "<<sqrt(trajSOS.localError().matrix()(0,0))<<" "
-	   <<sqrt(trajSOS.localError().matrix()(1,1))<<" "
-	   <<sqrt(trajSOS.localError().matrix()(2,2))<<" "
-	   <<sqrt(trajSOS.localError().matrix()(3,3))<<" "
-	   <<sqrt(trajSOS.localError().matrix()(4,4))<<" "<<std::endl;
+void GlobalTrackerMuonAlignment::debugTrajectorySOSv(const std::string title, TrajectoryStateOnSurface trajSOS) {
+  std::cout << "    --- " << title << " --- " << std::endl;
+  if (!trajSOS.isValid()) {
+    std::cout << "      Not valid !!!! " << std::endl;
+    return;
+  }
+  std::cout << " R |p| " << trajSOS.globalPosition().perp() << " " << trajSOS.globalMomentum().mag() << " charge "
+            << trajSOS.charge() << std::endl;
+  std::cout << " x p  " << trajSOS.globalParameters().vector()(0) << " " << trajSOS.globalParameters().vector()(1)
+            << " " << trajSOS.globalParameters().vector()(2) << " " << trajSOS.globalParameters().vector()(3) << " "
+            << trajSOS.globalParameters().vector()(4) << " " << trajSOS.globalParameters().vector()(5) << std::endl;
+  std::cout << " +/- " << sqrt(trajSOS.cartesianError().matrix()(0, 0)) << " "
+            << sqrt(trajSOS.cartesianError().matrix()(1, 1)) << " " << sqrt(trajSOS.cartesianError().matrix()(2, 2))
+            << " " << sqrt(trajSOS.cartesianError().matrix()(3, 3)) << " "
+            << sqrt(trajSOS.cartesianError().matrix()(4, 4)) << " " << sqrt(trajSOS.cartesianError().matrix()(5, 5))
+            << std::endl;
+  std::cout << " q/p dxy/dz xy " << trajSOS.localParameters().vector()(0) << " "
+            << trajSOS.localParameters().vector()(1) << " " << trajSOS.localParameters().vector()(2) << " "
+            << trajSOS.localParameters().vector()(3) << " " << trajSOS.localParameters().vector()(4) << std::endl;
+  std::cout << "   +/- error  " << sqrt(trajSOS.localError().matrix()(0, 0)) << " "
+            << sqrt(trajSOS.localError().matrix()(1, 1)) << " " << sqrt(trajSOS.localError().matrix()(2, 2)) << " "
+            << sqrt(trajSOS.localError().matrix()(3, 3)) << " " << sqrt(trajSOS.localError().matrix()(4, 4)) << " "
+            << std::endl;
 }
 
 // ----  debug printout Trajectory   ------
-void GlobalTrackerMuonAlignment::debugTrajectory(const std::string title, Trajectory& traj) 
-{
-  std::cout<<"\n"<<"    ...... "<<title<<" ...... "<<std::endl;
-  if(!traj.isValid()) {std::cout<<"          Not valid !!!!!!!!  "<<std::endl; return;}
-  std::cout<<" chi2/Nhit "<<traj.chiSquared()<<" / "<<traj.foundHits();
-  if(traj.direction() == alongMomentum) std::cout<<" alongMomentum  >>>>"<<std::endl;
-  else                                  std::cout<<" oppositeToMomentum  <<<<"<<std::endl;
-  this->debugTrajectorySOSv(" firstMeasurementTSOS ",traj.firstMeasurement().updatedState());
+void GlobalTrackerMuonAlignment::debugTrajectory(const std::string title, Trajectory& traj) {
+  std::cout << "\n"
+            << "    ...... " << title << " ...... " << std::endl;
+  if (!traj.isValid()) {
+    std::cout << "          Not valid !!!!!!!!  " << std::endl;
+    return;
+  }
+  std::cout << " chi2/Nhit " << traj.chiSquared() << " / " << traj.foundHits();
+  if (traj.direction() == alongMomentum)
+    std::cout << " alongMomentum  >>>>" << std::endl;
+  else
+    std::cout << " oppositeToMomentum  <<<<" << std::endl;
+  this->debugTrajectorySOSv(" firstMeasurementTSOS ", traj.firstMeasurement().updatedState());
   //this->debugTrajectorySOSv(" firstMeasurementTSOS ",traj.firstMeasurement().predictedState());
-  this->debugTrajectorySOSv(" lastMeasurementTSOS ",traj.lastMeasurement().updatedState());
+  this->debugTrajectorySOSv(" lastMeasurementTSOS ", traj.lastMeasurement().updatedState());
   //this->debugTrajectorySOSv(" geom InnermostState", traj.geometricalInnermostState());
-  std::cout<<"    . . . . . . . . . . . . . . . . . . . . . . . . . . . . \n"<<std::endl;
+  std::cout << "    . . . . . . . . . . . . . . . . . . . . . . . . . . . . \n" << std::endl;
 }
 
-
 // ----  write GlobalPositionRcd   ------
-void GlobalTrackerMuonAlignment::writeGlPosRcd(CLHEP::HepVector& paramVec) 
-{
+void GlobalTrackerMuonAlignment::writeGlPosRcd(CLHEP::HepVector& paramVec) {
   //paramVec(1) = 0.1; paramVec(2) = 0.2; paramVec(3) = 0.3;         //0123
   //paramVec(4) = 0.0001; paramVec(5) = 0.0002; paramVec(6) = 0.0003;
   //paramVec(1) = 0.3; paramVec(2) = 0.4; paramVec(3) = 0.5;         //03450123
@@ -3226,141 +3331,121 @@ void GlobalTrackerMuonAlignment::writeGlPosRcd(CLHEP::HepVector& paramVec)
   //paramVec(1) = 0.; paramVec(2) = 0.; paramVec(3) = 1.;               //1z
   //paramVec(4) = 0.0000; paramVec(5) = 0.0000; paramVec(6) = 0.0000;
 
-  std::cout<<" paramVector "<<paramVec.T()<<std::endl;
-  
+  std::cout << " paramVector " << paramVec.T() << std::endl;
+
   CLHEP::Hep3Vector colX, colY, colZ;
 
-#ifdef NOT_EXACT_ROTATION_MATRIX     
-  colX = CLHEP::Hep3Vector(          1.,  -paramVec(6),  paramVec(5));
-  colY = CLHEP::Hep3Vector( paramVec(6),            1., -paramVec(4));
-  colZ = CLHEP::Hep3Vector(-paramVec(5),   paramVec(4),           1.);
-#else 
+#ifdef NOT_EXACT_ROTATION_MATRIX
+  colX = CLHEP::Hep3Vector(1., -paramVec(6), paramVec(5));
+  colY = CLHEP::Hep3Vector(paramVec(6), 1., -paramVec(4));
+  colZ = CLHEP::Hep3Vector(-paramVec(5), paramVec(4), 1.);
+#else
   double s1 = std::sin(paramVec(4)), c1 = std::cos(paramVec(4));
   double s2 = std::sin(paramVec(5)), c2 = std::cos(paramVec(5));
   double s3 = std::sin(paramVec(6)), c3 = std::cos(paramVec(6));
-  colX = CLHEP::Hep3Vector(               c2 * c3,               -c2 * s3,       s2);
+  colX = CLHEP::Hep3Vector(c2 * c3, -c2 * s3, s2);
   colY = CLHEP::Hep3Vector(c1 * s3 + s1 * s2 * c3, c1 * c3 - s1 * s2 * s3, -s1 * c2);
-  colZ = CLHEP::Hep3Vector(s1 * s3 - c1 * s2 * c3, s1 * c3 + c1 * s2 * s3,  c1 * c2);
+  colZ = CLHEP::Hep3Vector(s1 * s3 - c1 * s2 * c3, s1 * c3 + c1 * s2 * s3, c1 * c2);
 #endif
 
-  CLHEP::HepVector  param0(6,0);
+  CLHEP::HepVector param0(6, 0);
 
-  Alignments* globalPositions = new Alignments();  
+  Alignments* globalPositions = new Alignments();
 
   //Tracker
-  AlignTransform tracker(iteratorTrackerRcd->translation(),
-			 iteratorTrackerRcd->rotation(),
-			 DetId(DetId::Tracker).rawId());
+  AlignTransform tracker(
+      iteratorTrackerRcd->translation(), iteratorTrackerRcd->rotation(), DetId(DetId::Tracker).rawId());
   // Muon
   CLHEP::Hep3Vector posMuGlRcd = iteratorMuonRcd->translation();
   CLHEP::HepRotation rotMuGlRcd = iteratorMuonRcd->rotation();
   CLHEP::HepEulerAngles angMuGlRcd = iteratorMuonRcd->rotation().eulerAngles();
-  if(debug_)
-    std::cout<<" Old muon Rcd Euler angles "<<angMuGlRcd.phi()<<" "<<angMuGlRcd.theta()
-	     <<" "<<angMuGlRcd.psi()<<std::endl;
+  if (debug_)
+    std::cout << " Old muon Rcd Euler angles " << angMuGlRcd.phi() << " " << angMuGlRcd.theta() << " "
+              << angMuGlRcd.psi() << std::endl;
   AlignTransform muon;
-  if((angMuGlRcd.phi() == 0.) && (angMuGlRcd.theta() == 0.) && (angMuGlRcd.psi() == 0.) &&
-     (posMuGlRcd.x() == 0.) && (posMuGlRcd.y() == 0.) && (posMuGlRcd.z() == 0.)){
-    std::cout<<" New muon parameters are stored in Rcd"<<std::endl; 
+  if ((angMuGlRcd.phi() == 0.) && (angMuGlRcd.theta() == 0.) && (angMuGlRcd.psi() == 0.) && (posMuGlRcd.x() == 0.) &&
+      (posMuGlRcd.y() == 0.) && (posMuGlRcd.z() == 0.)) {
+    std::cout << " New muon parameters are stored in Rcd" << std::endl;
 
-    AlignTransform muonNew(AlignTransform::Translation(paramVec(1),
-						       paramVec(2),
-						       paramVec(3)),
-			   AlignTransform::Rotation   (colX,
-						       colY,
-						       colZ),
-			   DetId(DetId::Muon).rawId());
+    AlignTransform muonNew(AlignTransform::Translation(paramVec(1), paramVec(2), paramVec(3)),
+                           AlignTransform::Rotation(colX, colY, colZ),
+                           DetId(DetId::Muon).rawId());
     muon = muonNew;
-  }
-  else if((paramVec(1) == 0.) && (paramVec(2) == 0.) && (paramVec(3) == 0.) && 
-	  (paramVec(4) == 0.) && (paramVec(5) == 0.) && (paramVec(6) == 0.)){
-    std::cout<<" Old muon parameters are stored in Rcd"<<std::endl; 
-    
-    AlignTransform muonNew(iteratorMuonRcd->translation(),
-			   iteratorMuonRcd->rotation(),
-			   DetId(DetId::Muon).rawId());
-    muon = muonNew;  
-  }
-  else{
-    std::cout<<" New + Old muon parameters are stored in Rcd"<<std::endl; 
-    CLHEP::Hep3Vector posMuGlRcdThis = CLHEP::Hep3Vector(paramVec(1), paramVec(2), paramVec(3));   
-    CLHEP::HepRotation rotMuGlRcdThis = CLHEP::HepRotation(colX, colY, colZ);   
+  } else if ((paramVec(1) == 0.) && (paramVec(2) == 0.) && (paramVec(3) == 0.) && (paramVec(4) == 0.) &&
+             (paramVec(5) == 0.) && (paramVec(6) == 0.)) {
+    std::cout << " Old muon parameters are stored in Rcd" << std::endl;
+
+    AlignTransform muonNew(iteratorMuonRcd->translation(), iteratorMuonRcd->rotation(), DetId(DetId::Muon).rawId());
+    muon = muonNew;
+  } else {
+    std::cout << " New + Old muon parameters are stored in Rcd" << std::endl;
+    CLHEP::Hep3Vector posMuGlRcdThis = CLHEP::Hep3Vector(paramVec(1), paramVec(2), paramVec(3));
+    CLHEP::HepRotation rotMuGlRcdThis = CLHEP::HepRotation(colX, colY, colZ);
     CLHEP::Hep3Vector posMuGlRcdNew = rotMuGlRcdThis * posMuGlRcd + posMuGlRcdThis;
     CLHEP::HepRotation rotMuGlRcdNew = rotMuGlRcdThis * rotMuGlRcd;
 
-    AlignTransform muonNew(posMuGlRcdNew,
-			   rotMuGlRcdNew, 
-			   DetId(DetId::Muon).rawId());
+    AlignTransform muonNew(posMuGlRcdNew, rotMuGlRcdNew, DetId(DetId::Muon).rawId());
     muon = muonNew;
   }
 
   // Ecal
-  AlignTransform ecal(iteratorEcalRcd->translation(),
-			 iteratorEcalRcd->rotation(),
-			 DetId(DetId::Ecal).rawId());
+  AlignTransform ecal(iteratorEcalRcd->translation(), iteratorEcalRcd->rotation(), DetId(DetId::Ecal).rawId());
   // Hcal
-  AlignTransform hcal(iteratorHcalRcd->translation(),
-			 iteratorHcalRcd->rotation(),
-			 DetId(DetId::Hcal).rawId());
+  AlignTransform hcal(iteratorHcalRcd->translation(), iteratorHcalRcd->rotation(), DetId(DetId::Hcal).rawId());
   // Calo
-  AlignTransform calo(AlignTransform::Translation(param0(1),
-						  param0(2),
-						  param0(3)),
-		      AlignTransform::EulerAngles(param0(4),
-						  param0(5),
-						  param0(6)),
-		      DetId(DetId::Calo).rawId());
+  AlignTransform calo(AlignTransform::Translation(param0(1), param0(2), param0(3)),
+                      AlignTransform::EulerAngles(param0(4), param0(5), param0(6)),
+                      DetId(DetId::Calo).rawId());
 
-  std::cout << "Tracker (" << tracker.rawId() << ") at " << tracker.translation() 
-	    << " " << tracker.rotation().eulerAngles() << std::endl;
+  std::cout << "Tracker (" << tracker.rawId() << ") at " << tracker.translation() << " "
+            << tracker.rotation().eulerAngles() << std::endl;
   std::cout << tracker.rotation() << std::endl;
-  
-  std::cout << "Muon (" << muon.rawId() << ") at " << muon.translation() 
-    	    << " " << muon.rotation().eulerAngles() << std::endl;
+
+  std::cout << "Muon (" << muon.rawId() << ") at " << muon.translation() << " " << muon.rotation().eulerAngles()
+            << std::endl;
   std::cout << "          rotations angles around x,y,z "
-	    << " ( " << -muon.rotation().zy() << " " << muon.rotation().zx() 
-	    << " " << -muon.rotation().yx() << " )" << std::endl;
-   std::cout << muon.rotation() << std::endl;
-   
-   std::cout << "Ecal (" << ecal.rawId() << ") at " << ecal.translation() 
-	     << " " << ecal.rotation().eulerAngles() << std::endl;
-   std::cout << ecal.rotation() << std::endl;
-   
-   std::cout << "Hcal (" << hcal.rawId() << ") at " << hcal.translation()
-	     << " " << hcal.rotation().eulerAngles() << std::endl;
-   std::cout << hcal.rotation() << std::endl;
-   
-   std::cout << "Calo (" << calo.rawId() << ") at " << calo.translation()
-	     << " " << calo.rotation().eulerAngles() << std::endl;
-   std::cout << calo.rotation() << std::endl;
+            << " ( " << -muon.rotation().zy() << " " << muon.rotation().zx() << " " << -muon.rotation().yx() << " )"
+            << std::endl;
+  std::cout << muon.rotation() << std::endl;
 
-   globalPositions->m_align.push_back(tracker);
-   globalPositions->m_align.push_back(muon);
-   globalPositions->m_align.push_back(ecal);
-   globalPositions->m_align.push_back(hcal);
-   globalPositions->m_align.push_back(calo);
+  std::cout << "Ecal (" << ecal.rawId() << ") at " << ecal.translation() << " " << ecal.rotation().eulerAngles()
+            << std::endl;
+  std::cout << ecal.rotation() << std::endl;
 
-   std::cout << "Uploading to the database..." << std::endl;
+  std::cout << "Hcal (" << hcal.rawId() << ") at " << hcal.translation() << " " << hcal.rotation().eulerAngles()
+            << std::endl;
+  std::cout << hcal.rotation() << std::endl;
 
-   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-   
-   if (!poolDbService.isAvailable())
-     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
-                  
-   //    if (poolDbService->isNewTagRequest("GlobalPositionRcd")) {
-//       poolDbService->createNewIOV<Alignments>(&(*globalPositions), poolDbService->endOfTime(), "GlobalPositionRcd");
-//    } else {
-//       poolDbService->appendSinceTime<Alignments>(&(*globalPositions), poolDbService->currentTime(), "GlobalPositionRcd");
-//    }
-   poolDbService->writeOne<Alignments>(&(*globalPositions), 
-				       poolDbService->currentTime(),
-				       //poolDbService->beginOfTime(),
-                                       "GlobalPositionRcd");
-   std::cout << "done!" << std::endl;
-   
-   return;
+  std::cout << "Calo (" << calo.rawId() << ") at " << calo.translation() << " " << calo.rotation().eulerAngles()
+            << std::endl;
+  std::cout << calo.rotation() << std::endl;
+
+  globalPositions->m_align.push_back(tracker);
+  globalPositions->m_align.push_back(muon);
+  globalPositions->m_align.push_back(ecal);
+  globalPositions->m_align.push_back(hcal);
+  globalPositions->m_align.push_back(calo);
+
+  std::cout << "Uploading to the database..." << std::endl;
+
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+
+  if (!poolDbService.isAvailable())
+    throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
+
+  //    if (poolDbService->isNewTagRequest("GlobalPositionRcd")) {
+  //       poolDbService->createNewIOV<Alignments>(&(*globalPositions), poolDbService->endOfTime(), "GlobalPositionRcd");
+  //    } else {
+  //       poolDbService->appendSinceTime<Alignments>(&(*globalPositions), poolDbService->currentTime(), "GlobalPositionRcd");
+  //    }
+  poolDbService->writeOne<Alignments>(&(*globalPositions),
+                                      poolDbService->currentTime(),
+                                      //poolDbService->beginOfTime(),
+                                      "GlobalPositionRcd");
+  std::cout << "done!" << std::endl;
+
+  return;
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(GlobalTrackerMuonAlignment);

--- a/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
@@ -10,13 +10,9 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
-
 //
 // class declaration
 //
-
-
 
 class LSNumberFilter : public edm::EDFilter {
 public:
@@ -24,53 +20,38 @@ public:
   ~LSNumberFilter() override;
 
 private:
-
-  void beginJob() override ;
+  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
+  void endJob() override;
 
   unsigned int minLS;
 };
 
+LSNumberFilter::LSNumberFilter(const edm::ParameterSet& iConfig)
+    : minLS(iConfig.getUntrackedParameter<unsigned>("minLS", 21)) {}
 
-
-LSNumberFilter::LSNumberFilter(const edm::ParameterSet& iConfig):
-  minLS(iConfig.getUntrackedParameter<unsigned>("minLS",21))
-{}
-
-
-LSNumberFilter::~LSNumberFilter()
-{
-
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+LSNumberFilter::~LSNumberFilter() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool LSNumberFilter::filter(edm::Event& iEvent,
-			    const edm::EventSetup& iSetup) {
+bool LSNumberFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  if (iEvent.luminosityBlock() < minLS)
+    return false;
 
-  if(iEvent.luminosityBlock() < minLS) return false;
-  
   return true;
-
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void
-LSNumberFilter::beginJob()
-{}
+void LSNumberFilter::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-LSNumberFilter::endJob() {
-}
+void LSNumberFilter::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(LSNumberFilter);

--- a/Alignment/CommonAlignmentProducer/src/AlignmentCSCBeamHaloSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentCSCBeamHaloSelector.cc
@@ -11,12 +11,12 @@
 
 // constructor ----------------------------------------------------------------
 
-AlignmentCSCBeamHaloSelector::AlignmentCSCBeamHaloSelector(const edm::ParameterSet &iConfig, edm::ConsumesCollector & iC)
-   : m_minStations(iConfig.getParameter<unsigned int>("minStations"))
-   , m_minHitsPerStation(iConfig.getParameter<unsigned int>("minHitsPerStation"))
-{
-   edm::LogInfo("AlignmentCSCBeamHaloSelector")
-      << "Acceptable tracks must have at least " << m_minHitsPerStation << " hits in " << m_minStations << " different CSC stations." << std::endl;
+AlignmentCSCBeamHaloSelector::AlignmentCSCBeamHaloSelector(const edm::ParameterSet &iConfig, edm::ConsumesCollector &iC)
+    : m_minStations(iConfig.getParameter<unsigned int>("minStations")),
+      m_minHitsPerStation(iConfig.getParameter<unsigned int>("minHitsPerStation")) {
+  edm::LogInfo("AlignmentCSCBeamHaloSelector")
+      << "Acceptable tracks must have at least " << m_minHitsPerStation << " hits in " << m_minStations
+      << " different CSC stations." << std::endl;
 }
 
 // destructor -----------------------------------------------------------------
@@ -25,35 +25,38 @@ AlignmentCSCBeamHaloSelector::~AlignmentCSCBeamHaloSelector() {}
 
 // do selection ---------------------------------------------------------------
 
-AlignmentCSCBeamHaloSelector::Tracks
-AlignmentCSCBeamHaloSelector::select(const Tracks &tracks, const edm::Event &iEvent) const {
-   Tracks result;
+AlignmentCSCBeamHaloSelector::Tracks AlignmentCSCBeamHaloSelector::select(const Tracks &tracks,
+                                                                          const edm::Event &iEvent) const {
+  Tracks result;
 
-   for(auto const& track : tracks) {
-      std::map<int, unsigned int> station_map;
+  for (auto const &track : tracks) {
+    std::map<int, unsigned int> station_map;
 
-      for(auto const& hit : track->recHits()) {
-	 DetId id = hit->geographicalId();
-	 if (id.det() == DetId::Muon  &&  id.subdetId() == MuonSubdetId::CSC) {
-	    CSCDetId cscid(id.rawId());
-	    int station = (cscid.endcap() == 1 ? 1 : -1) * cscid.station();
+    for (auto const &hit : track->recHits()) {
+      DetId id = hit->geographicalId();
+      if (id.det() == DetId::Muon && id.subdetId() == MuonSubdetId::CSC) {
+        CSCDetId cscid(id.rawId());
+        int station = (cscid.endcap() == 1 ? 1 : -1) * cscid.station();
 
-	    std::map<int, unsigned int>::const_iterator station_iter = station_map.find(station);
-	    if (station_iter == station_map.end()) {
-	       station_map[station] = 0;
-	    }
-	    station_map[station]++;
-	 } // end if it's a CSC hit
-      } // end loop over hits
+        std::map<int, unsigned int>::const_iterator station_iter = station_map.find(station);
+        if (station_iter == station_map.end()) {
+          station_map[station] = 0;
+        }
+        station_map[station]++;
+      }  // end if it's a CSC hit
+    }    // end loop over hits
 
-      unsigned int stations = 0;
-      for (std::map<int, unsigned int>::const_iterator station_iter = station_map.begin();  station_iter != station_map.end();  ++station_iter) {
-	 if (station_iter->second > m_minHitsPerStation) stations++;
-      }
-      if (stations >= m_minStations) {
-	 result.push_back(track);
-      }
-   } // end loop over tracks
+    unsigned int stations = 0;
+    for (std::map<int, unsigned int>::const_iterator station_iter = station_map.begin();
+         station_iter != station_map.end();
+         ++station_iter) {
+      if (station_iter->second > m_minHitsPerStation)
+        stations++;
+    }
+    if (stations >= m_minStations) {
+      result.push_back(track);
+    }
+  }  // end loop over tracks
 
-   return result;
+  return result;
 }

--- a/Alignment/CommonAlignmentProducer/src/AlignmentCSCOverlapSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentCSCOverlapSelector.cc
@@ -12,17 +12,15 @@
 // constructor ----------------------------------------------------------------
 
 AlignmentCSCOverlapSelector::AlignmentCSCOverlapSelector(const edm::ParameterSet &iConfig)
-   : m_station(iConfig.getParameter<int>("station"))
-   , m_minHitsPerChamber(iConfig.getParameter<unsigned int>("minHitsPerChamber"))
-{
-   if (m_station == 0) {
-      edm::LogInfo("AlignmentCSCOverlapSelector") 
-	 << "Acceptable tracks must have " << m_minHitsPerChamber << " in two chambers on all stations." << std::endl;
-   }
-   else {
-      edm::LogInfo("AlignmentCSCOverlapSelector") 
-	 << "Acceptable tracks must have " << m_minHitsPerChamber << " in two chambers on station " << m_station << "." << std::endl;
-   }
+    : m_station(iConfig.getParameter<int>("station")),
+      m_minHitsPerChamber(iConfig.getParameter<unsigned int>("minHitsPerChamber")) {
+  if (m_station == 0) {
+    edm::LogInfo("AlignmentCSCOverlapSelector")
+        << "Acceptable tracks must have " << m_minHitsPerChamber << " in two chambers on all stations." << std::endl;
+  } else {
+    edm::LogInfo("AlignmentCSCOverlapSelector") << "Acceptable tracks must have " << m_minHitsPerChamber
+                                                << " in two chambers on station " << m_station << "." << std::endl;
+  }
 }
 
 // destructor -----------------------------------------------------------------
@@ -31,97 +29,115 @@ AlignmentCSCOverlapSelector::~AlignmentCSCOverlapSelector() {}
 
 // do selection ---------------------------------------------------------------
 
-AlignmentCSCOverlapSelector::Tracks 
-AlignmentCSCOverlapSelector::select(const Tracks &tracks, const edm::Event &iEvent) const {
-   Tracks result;
+AlignmentCSCOverlapSelector::Tracks AlignmentCSCOverlapSelector::select(const Tracks &tracks,
+                                                                        const edm::Event &iEvent) const {
+  Tracks result;
 
-   for(auto const& track : tracks) {
-      unsigned int MEminus4_even = 0;
-      unsigned int MEminus4_odd = 0;
-      unsigned int MEminus3_even = 0;
-      unsigned int MEminus3_odd = 0;
-      unsigned int MEminus2_even = 0;
-      unsigned int MEminus2_odd = 0;
-      unsigned int MEminus1_even = 0;
-      unsigned int MEminus1_odd = 0;
+  for (auto const &track : tracks) {
+    unsigned int MEminus4_even = 0;
+    unsigned int MEminus4_odd = 0;
+    unsigned int MEminus3_even = 0;
+    unsigned int MEminus3_odd = 0;
+    unsigned int MEminus2_even = 0;
+    unsigned int MEminus2_odd = 0;
+    unsigned int MEminus1_even = 0;
+    unsigned int MEminus1_odd = 0;
 
-      unsigned int MEplus1_even = 0;
-      unsigned int MEplus1_odd = 0;
-      unsigned int MEplus2_even = 0;
-      unsigned int MEplus2_odd = 0;
-      unsigned int MEplus3_even = 0;
-      unsigned int MEplus3_odd = 0;
-      unsigned int MEplus4_even = 0;
-      unsigned int MEplus4_odd = 0;
+    unsigned int MEplus1_even = 0;
+    unsigned int MEplus1_odd = 0;
+    unsigned int MEplus2_even = 0;
+    unsigned int MEplus2_odd = 0;
+    unsigned int MEplus3_even = 0;
+    unsigned int MEplus3_odd = 0;
+    unsigned int MEplus4_even = 0;
+    unsigned int MEplus4_odd = 0;
 
-      for(auto const& hit : track->recHits()) {
-	 DetId id = hit->geographicalId();
-	 if (id.det() == DetId::Muon  &&  id.subdetId() == MuonSubdetId::CSC) {
-	    CSCDetId cscid(id.rawId());
-	    int station = (cscid.endcap() == 1 ? 1 : -1) * cscid.station();
+    for (auto const &hit : track->recHits()) {
+      DetId id = hit->geographicalId();
+      if (id.det() == DetId::Muon && id.subdetId() == MuonSubdetId::CSC) {
+        CSCDetId cscid(id.rawId());
+        int station = (cscid.endcap() == 1 ? 1 : -1) * cscid.station();
 
-	    if (station == -4) {
-	       if (cscid.chamber() % 2 == 0) MEminus4_even++;
-	       else MEminus4_odd++;
-	    }
-	    else if (station == -3) {
-	       if (cscid.chamber() % 2 == 0) MEminus3_even++;
-	       else MEminus3_odd++;
-	    }
-	    else if (station == -2) {
-	       if (cscid.chamber() % 2 == 0) MEminus2_even++;
-	       else MEminus2_odd++;
-	    }
-	    else if (station == -1) {
-	       if (cscid.chamber() % 2 == 0) MEminus1_even++;
-	       else MEminus1_odd++;
-	    }
+        if (station == -4) {
+          if (cscid.chamber() % 2 == 0)
+            MEminus4_even++;
+          else
+            MEminus4_odd++;
+        } else if (station == -3) {
+          if (cscid.chamber() % 2 == 0)
+            MEminus3_even++;
+          else
+            MEminus3_odd++;
+        } else if (station == -2) {
+          if (cscid.chamber() % 2 == 0)
+            MEminus2_even++;
+          else
+            MEminus2_odd++;
+        } else if (station == -1) {
+          if (cscid.chamber() % 2 == 0)
+            MEminus1_even++;
+          else
+            MEminus1_odd++;
+        }
 
-	    else if (station == 1) {
-	       if (cscid.chamber() % 2 == 0) MEplus1_even++;
-	       else MEplus1_odd++;
-	    }
-	    else if (station == 2) {
-	       if (cscid.chamber() % 2 == 0) MEplus2_even++;
-	       else MEplus2_odd++;
-	    }
-	    else if (station == 3) {
-	       if (cscid.chamber() % 2 == 0) MEplus3_even++;
-	       else MEplus3_odd++;
-	    }
-	    else if (station == 4) {
-	       if (cscid.chamber() % 2 == 0) MEplus4_even++;
-	       else MEplus4_odd++;
-	    }
+        else if (station == 1) {
+          if (cscid.chamber() % 2 == 0)
+            MEplus1_even++;
+          else
+            MEplus1_odd++;
+        } else if (station == 2) {
+          if (cscid.chamber() % 2 == 0)
+            MEplus2_even++;
+          else
+            MEplus2_odd++;
+        } else if (station == 3) {
+          if (cscid.chamber() % 2 == 0)
+            MEplus3_even++;
+          else
+            MEplus3_odd++;
+        } else if (station == 4) {
+          if (cscid.chamber() % 2 == 0)
+            MEplus4_even++;
+          else
+            MEplus4_odd++;
+        }
 
-	 } // end if it's a CSC hit
-      } // end loop over hits
+      }  // end if it's a CSC hit
+    }    // end loop over hits
 
-      if ((m_station == 0  ||  m_station == -4)  &&
-	  (MEminus4_even >= m_minHitsPerChamber)  &&  (MEminus4_odd >= m_minHitsPerChamber)) result.push_back(track);
+    if ((m_station == 0 || m_station == -4) && (MEminus4_even >= m_minHitsPerChamber) &&
+        (MEminus4_odd >= m_minHitsPerChamber))
+      result.push_back(track);
 
-      else if ((m_station == 0  ||  m_station == -3)  &&
-	       (MEminus3_even >= m_minHitsPerChamber)  &&  (MEminus3_odd >= m_minHitsPerChamber)) result.push_back(track);
+    else if ((m_station == 0 || m_station == -3) && (MEminus3_even >= m_minHitsPerChamber) &&
+             (MEminus3_odd >= m_minHitsPerChamber))
+      result.push_back(track);
 
-      else if ((m_station == 0  ||  m_station == -2)  &&
-	       (MEminus2_even >= m_minHitsPerChamber)  &&  (MEminus2_odd >= m_minHitsPerChamber)) result.push_back(track);
+    else if ((m_station == 0 || m_station == -2) && (MEminus2_even >= m_minHitsPerChamber) &&
+             (MEminus2_odd >= m_minHitsPerChamber))
+      result.push_back(track);
 
-      else if ((m_station == 0  ||  m_station == -1)  &&
-	       (MEminus1_even >= m_minHitsPerChamber)  &&  (MEminus1_odd >= m_minHitsPerChamber)) result.push_back(track);
+    else if ((m_station == 0 || m_station == -1) && (MEminus1_even >= m_minHitsPerChamber) &&
+             (MEminus1_odd >= m_minHitsPerChamber))
+      result.push_back(track);
 
-      else if ((m_station == 0  ||  m_station == 1)  &&
-	       (MEplus1_even >= m_minHitsPerChamber)  &&  (MEplus1_odd >= m_minHitsPerChamber)) result.push_back(track);
+    else if ((m_station == 0 || m_station == 1) && (MEplus1_even >= m_minHitsPerChamber) &&
+             (MEplus1_odd >= m_minHitsPerChamber))
+      result.push_back(track);
 
-      else if ((m_station == 0  ||  m_station == 2)  &&
-	       (MEplus2_even >= m_minHitsPerChamber)  &&  (MEplus2_odd >= m_minHitsPerChamber)) result.push_back(track);
+    else if ((m_station == 0 || m_station == 2) && (MEplus2_even >= m_minHitsPerChamber) &&
+             (MEplus2_odd >= m_minHitsPerChamber))
+      result.push_back(track);
 
-      else if ((m_station == 0  ||  m_station == 3)  &&
-	       (MEplus3_even >= m_minHitsPerChamber)  &&  (MEplus3_odd >= m_minHitsPerChamber)) result.push_back(track);
+    else if ((m_station == 0 || m_station == 3) && (MEplus3_even >= m_minHitsPerChamber) &&
+             (MEplus3_odd >= m_minHitsPerChamber))
+      result.push_back(track);
 
-      else if ((m_station == 0  ||  m_station == 4)  &&
-	       (MEplus4_even >= m_minHitsPerChamber)  &&  (MEplus4_odd >= m_minHitsPerChamber)) result.push_back(track);
+    else if ((m_station == 0 || m_station == 4) && (MEplus4_even >= m_minHitsPerChamber) &&
+             (MEplus4_odd >= m_minHitsPerChamber))
+      result.push_back(track);
 
-   } // end loop over tracks
-  
-   return result;
+  }  // end loop over tracks
+
+  return result;
 }

--- a/Alignment/CommonAlignmentProducer/src/AlignmentCSCTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentCSCTrackSelector.cc
@@ -10,65 +10,65 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
-
 // constructor ----------------------------------------------------------------
 
-AlignmentCSCTrackSelector::AlignmentCSCTrackSelector(const edm::ParameterSet & cfg)
-   : m_src(cfg.getParameter<edm::InputTag>("src"))
-   , m_stationA(cfg.getParameter<int>("stationA"))
-   , m_stationB(cfg.getParameter<int>("stationB"))
-   , m_minHitsDT(cfg.getParameter<int>("minHitsDT"))
-   , m_minHitsPerStation(cfg.getParameter<int>("minHitsPerStation"))
-   , m_maxHitsPerStation(cfg.getParameter<int>("maxHitsPerStation"))
-{}
+AlignmentCSCTrackSelector::AlignmentCSCTrackSelector(const edm::ParameterSet& cfg)
+    : m_src(cfg.getParameter<edm::InputTag>("src")),
+      m_stationA(cfg.getParameter<int>("stationA")),
+      m_stationB(cfg.getParameter<int>("stationB")),
+      m_minHitsDT(cfg.getParameter<int>("minHitsDT")),
+      m_minHitsPerStation(cfg.getParameter<int>("minHitsPerStation")),
+      m_maxHitsPerStation(cfg.getParameter<int>("maxHitsPerStation")) {}
 
 // destructor -----------------------------------------------------------------
 
-AlignmentCSCTrackSelector::~AlignmentCSCTrackSelector()
-{}
-
+AlignmentCSCTrackSelector::~AlignmentCSCTrackSelector() {}
 
 // do selection ---------------------------------------------------------------
 
-AlignmentCSCTrackSelector::Tracks 
-AlignmentCSCTrackSelector::select(const Tracks& tracks, const edm::Event& evt) const 
-{
-   Tracks result;
+AlignmentCSCTrackSelector::Tracks AlignmentCSCTrackSelector::select(const Tracks& tracks, const edm::Event& evt) const {
+  Tracks result;
 
-   for(auto const& track : tracks) {
-      int hitsOnStationA = 0;
-      int hitsOnStationB = 0;
+  for (auto const& track : tracks) {
+    int hitsOnStationA = 0;
+    int hitsOnStationB = 0;
 
-      for(auto const& hit : track->recHits()) {
-	 DetId id = hit->geographicalId();
+    for (auto const& hit : track->recHits()) {
+      DetId id = hit->geographicalId();
 
-	 if (id.det() == DetId::Muon  &&  id.subdetId() == MuonSubdetId::DT) {
-	    if (m_stationA == 0) hitsOnStationA++;
-	    if (m_stationB == 0) hitsOnStationB++;
-	 }
-	 else if (id.det() == DetId::Muon  &&  id.subdetId() == MuonSubdetId::CSC) {
-	    CSCDetId cscid(id.rawId());
-	    int station = (cscid.endcap() == 1 ? 1 : -1) * cscid.station();
+      if (id.det() == DetId::Muon && id.subdetId() == MuonSubdetId::DT) {
+        if (m_stationA == 0)
+          hitsOnStationA++;
+        if (m_stationB == 0)
+          hitsOnStationB++;
+      } else if (id.det() == DetId::Muon && id.subdetId() == MuonSubdetId::CSC) {
+        CSCDetId cscid(id.rawId());
+        int station = (cscid.endcap() == 1 ? 1 : -1) * cscid.station();
 
-	    if (station == m_stationA) hitsOnStationA++;
-	    if (station == m_stationB) hitsOnStationB++;
+        if (station == m_stationA)
+          hitsOnStationA++;
+        if (station == m_stationB)
+          hitsOnStationB++;
 
-	 } // end if CSC
-      } // end loop over hits
+      }  // end if CSC
+    }    // end loop over hits
 
-      bool stationAokay;
-      if (m_stationA == 0) stationAokay = (m_minHitsDT <= hitsOnStationA);
-      else stationAokay = (m_minHitsPerStation <= hitsOnStationA  &&  hitsOnStationA <= m_maxHitsPerStation);
+    bool stationAokay;
+    if (m_stationA == 0)
+      stationAokay = (m_minHitsDT <= hitsOnStationA);
+    else
+      stationAokay = (m_minHitsPerStation <= hitsOnStationA && hitsOnStationA <= m_maxHitsPerStation);
 
-      bool stationBokay;
-      if (m_stationB == 0) stationBokay = (m_minHitsDT <= hitsOnStationB);
-      else stationBokay = (m_minHitsPerStation <= hitsOnStationB  &&  hitsOnStationB <= m_maxHitsPerStation);
+    bool stationBokay;
+    if (m_stationB == 0)
+      stationBokay = (m_minHitsDT <= hitsOnStationB);
+    else
+      stationBokay = (m_minHitsPerStation <= hitsOnStationB && hitsOnStationB <= m_maxHitsPerStation);
 
-      if (stationAokay  &&  stationBokay) {
-	 result.push_back(track);
-      }
-   } // end loop over tracks
-  
-   return result;
+    if (stationAokay && stationBokay) {
+      result.push_back(track);
+    }
+  }  // end loop over tracks
+
+  return result;
 }
-

--- a/Alignment/CommonAlignmentProducer/src/AlignmentGlobalTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentGlobalTrackSelector.cc
@@ -12,7 +12,7 @@
 
 #include <DataFormats/MuonReco/interface/Muon.h>
 
-#include <DataFormats/RecoCandidate/interface/RecoCandidate.h> //for the get<TrackRef>() Call
+#include <DataFormats/RecoCandidate/interface/RecoCandidate.h>  //for the get<TrackRef>() Call
 
 #include <DataFormats/Math/interface/deltaR.h>
 
@@ -21,85 +21,76 @@
 
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h"
 
-
 using namespace std;
-using namespace edm;   
+using namespace edm;
 
 // constructor ----------------------------------------------------------------
-AlignmentGlobalTrackSelector::AlignmentGlobalTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC) :
-  theGMFilterSwitch(cfg.getParameter<bool>("applyGlobalMuonFilter")),
-  theIsoFilterSwitch(cfg.getParameter<bool>("applyIsolationtest")),
-  theJetCountFilterSwitch(cfg.getParameter<bool>("applyJetCountFilter"))
-{
+AlignmentGlobalTrackSelector::AlignmentGlobalTrackSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
+    : theGMFilterSwitch(cfg.getParameter<bool>("applyGlobalMuonFilter")),
+      theIsoFilterSwitch(cfg.getParameter<bool>("applyIsolationtest")),
+      theJetCountFilterSwitch(cfg.getParameter<bool>("applyJetCountFilter")) {
   if (theGMFilterSwitch || theIsoFilterSwitch || theJetCountFilterSwitch)
     LogDebug("Alignment") << "> applying global Trackfilter ...";
 
   if (theGMFilterSwitch) {
     edm::InputTag theMuonSource = cfg.getParameter<InputTag>("muonSource");
     theMuonToken = iC.consumes<reco::MuonCollection>(theMuonSource);
-    theMaxTrackDeltaR =cfg.getParameter<double>("maxTrackDeltaR");
+    theMaxTrackDeltaR = cfg.getParameter<double>("maxTrackDeltaR");
     theMinGlobalMuonCount = cfg.getParameter<int>("minGlobalMuonCount");
-    LogDebug("Alignment") << ">  GlobalMuonFilter : source, maxTrackDeltaR, min. Count       : "
-			  << theMuonSource << " , "
-			  << theMaxTrackDeltaR << " , "
-			  << theMinIsolatedCount;
+    LogDebug("Alignment") << ">  GlobalMuonFilter : source, maxTrackDeltaR, min. Count       : " << theMuonSource
+                          << " , " << theMaxTrackDeltaR << " , " << theMinIsolatedCount;
   }
-  
+
   if (theIsoFilterSwitch) {
     edm::InputTag theJetIsoSource = cfg.getParameter<InputTag>("jetIsoSource");
     theJetIsoToken = iC.consumes<reco::CaloJetCollection>(theJetIsoSource);
     theMaxJetPt = cfg.getParameter<double>("maxJetPt");
     theMinJetDeltaR = cfg.getParameter<double>("minJetDeltaR");
     theMinIsolatedCount = cfg.getParameter<int>("minIsolatedCount");
-    LogDebug("Alignment") << ">  Isolationtest    : source, maxJetPt, minJetDeltaR, min. Count: "
-			  << theJetIsoSource << " , "
-			  << theMaxJetPt << " ,"
-			  << theMinJetDeltaR << " ,"
-			  << theMinGlobalMuonCount;
+    LogDebug("Alignment") << ">  Isolationtest    : source, maxJetPt, minJetDeltaR, min. Count: " << theJetIsoSource
+                          << " , " << theMaxJetPt << " ," << theMinJetDeltaR << " ," << theMinGlobalMuonCount;
   }
-  
+
   if (theJetCountFilterSwitch) {
     edm::InputTag theJetCountSource = cfg.getParameter<InputTag>("jetCountSource");
     theJetCountToken = iC.consumes<reco::CaloJetCollection>(theJetCountSource);
     theMinJetPt = cfg.getParameter<double>("minJetPt");
     theMaxJetCount = cfg.getParameter<int>("maxJetCount");
-    LogDebug("Alignment") << ">  JetCountFilter   : source, minJetPt, maxJetCount             : "
-			  << theJetCountSource << " , "
-			  << theMinJetPt << " ,"
-			  << theMaxJetCount;  
+    LogDebug("Alignment") << ">  JetCountFilter   : source, minJetPt, maxJetCount             : " << theJetCountSource
+                          << " , " << theMinJetPt << " ," << theMaxJetCount;
   }
 }
 
 // destructor -----------------------------------------------------------------
-AlignmentGlobalTrackSelector::~AlignmentGlobalTrackSelector()
-{}
+AlignmentGlobalTrackSelector::~AlignmentGlobalTrackSelector() {}
 
 ///returns if any of the Filters is used.
-bool AlignmentGlobalTrackSelector::useThisFilter()
-{
-  return theGMFilterSwitch || theIsoFilterSwitch|| theJetCountFilterSwitch;
+bool AlignmentGlobalTrackSelector::useThisFilter() {
+  return theGMFilterSwitch || theIsoFilterSwitch || theJetCountFilterSwitch;
 }
 
 // do selection ---------------------------------------------------------------
-AlignmentGlobalTrackSelector::Tracks 
-AlignmentGlobalTrackSelector::select(const Tracks& tracks, const edm::Event& iEvent, const edm::EventSetup& iSetup) 
-{
+AlignmentGlobalTrackSelector::Tracks AlignmentGlobalTrackSelector::select(const Tracks& tracks,
+                                                                          const edm::Event& iEvent,
+                                                                          const edm::EventSetup& iSetup) {
   Tracks result = tracks;
 
-  if (theGMFilterSwitch) result = findMuons(result, iEvent);
-  if (theIsoFilterSwitch) result = checkIsolation(result, iEvent);
-  if (theJetCountFilterSwitch) result = checkJetCount(result, iEvent);
+  if (theGMFilterSwitch)
+    result = findMuons(result, iEvent);
+  if (theIsoFilterSwitch)
+    result = checkIsolation(result, iEvent);
+  if (theJetCountFilterSwitch)
+    result = checkJetCount(result, iEvent);
   LogDebug("Alignment") << ">  Global: tracks all, kept: " << tracks.size() << ", " << result.size();
-//  LogDebug("Alignment")<<">  o kept:";
-//  printTracks(result);
-  
+  //  LogDebug("Alignment")<<">  o kept:";
+  //  printTracks(result);
+
   return result;
 }
 
 ///filter for Tracks that match the Track of a global Muon
-AlignmentGlobalTrackSelector::Tracks 
-AlignmentGlobalTrackSelector::findMuons(const Tracks& tracks, const edm::Event& iEvent) const
-{
+AlignmentGlobalTrackSelector::Tracks AlignmentGlobalTrackSelector::findMuons(const Tracks& tracks,
+                                                                             const edm::Event& iEvent) const {
   Tracks result;
   Tracks globalMuons;
 
@@ -108,78 +99,72 @@ AlignmentGlobalTrackSelector::findMuons(const Tracks& tracks, const edm::Event& 
   iEvent.getByToken(theMuonToken, muons);
 
   if (muons.isValid()) {
-    for (reco::MuonCollection::const_iterator itMuon = muons->begin(); 
-	 itMuon != muons->end();
-	 ++itMuon) {
+    for (reco::MuonCollection::const_iterator itMuon = muons->begin(); itMuon != muons->end(); ++itMuon) {
       const reco::Track* muonTrack = (*itMuon).get<reco::TrackRef>().get();
       if (!muonTrack) {
-	LogDebug("Alignment") << "@SUB=AlignmentGlobalTrackSelector::findMuons"
-			      << "Found muon without track: Standalone Muon!";
+        LogDebug("Alignment") << "@SUB=AlignmentGlobalTrackSelector::findMuons"
+                              << "Found muon without track: Standalone Muon!";
       } else {
-	globalMuons.push_back(muonTrack);
+        globalMuons.push_back(muonTrack);
       }
     }
   } else {
     LogError("Alignment") << "@SUB=AlignmentGlobalTrackSelector::findMuons"
-			  <<">  could not optain mounCollection!";
+                          << ">  could not optain mounCollection!";
   }
 
   result = this->matchTracks(tracks, globalMuons);
-  
-  if (static_cast<int>(result.size()) < theMinGlobalMuonCount) result.clear();
+
+  if (static_cast<int>(result.size()) < theMinGlobalMuonCount)
+    result.clear();
 
   return result;
 }
 
 ///returns only isolated tracks in [cands]
-AlignmentGlobalTrackSelector::Tracks 
-AlignmentGlobalTrackSelector::checkIsolation(const Tracks& cands,const edm::Event& iEvent) const
-{
-  Tracks result; result.clear();
+AlignmentGlobalTrackSelector::Tracks AlignmentGlobalTrackSelector::checkIsolation(const Tracks& cands,
+                                                                                  const edm::Event& iEvent) const {
+  Tracks result;
+  result.clear();
 
   Handle<reco::CaloJetCollection> jets;
   iEvent.getByToken(theJetIsoToken, jets);
 
   if (jets.isValid()) {
-    for (Tracks::const_iterator it = cands.begin();
-	 it!=cands.end();
-	 ++it) {
+    for (Tracks::const_iterator it = cands.begin(); it != cands.end(); ++it) {
       bool isolated = true;
-      for (reco::CaloJetCollection::const_iterator itJet = jets->begin();
-	   itJet!=jets->end();
-	   ++itJet) 
-	isolated &= !((*itJet).pt() > theMaxJetPt && deltaR(*(*it),(*itJet)) < theMinJetDeltaR);
-      
-      if (isolated)
-	result.push_back(*it);
-    }
-    //    LogDebug("Alignment") << "D  Found "<<result.size()<<" isolated of "<< cands.size()<<" Tracks!";   
-    
-  } else
-    LogError("Alignment")<< "@SUB=AlignmentGlobalTrackSelector::checkIsolation"
-			 << "> could not optain jetCollection!";
+      for (reco::CaloJetCollection::const_iterator itJet = jets->begin(); itJet != jets->end(); ++itJet)
+        isolated &= !((*itJet).pt() > theMaxJetPt && deltaR(*(*it), (*itJet)) < theMinJetDeltaR);
 
-  if (static_cast<int>(result.size()) < theMinIsolatedCount) result.clear();
+      if (isolated)
+        result.push_back(*it);
+    }
+    //    LogDebug("Alignment") << "D  Found "<<result.size()<<" isolated of "<< cands.size()<<" Tracks!";
+
+  } else
+    LogError("Alignment") << "@SUB=AlignmentGlobalTrackSelector::checkIsolation"
+                          << "> could not optain jetCollection!";
+
+  if (static_cast<int>(result.size()) < theMinIsolatedCount)
+    result.clear();
 
   return result;
 }
 
 ///returns [tracks] if there are less than theMaxCount Jets with theMinJetPt and an empty set if not
-AlignmentGlobalTrackSelector::Tracks 
-AlignmentGlobalTrackSelector::checkJetCount(const Tracks& tracks, const edm::Event& iEvent) const
-{
-  Tracks result; result.clear();
+AlignmentGlobalTrackSelector::Tracks AlignmentGlobalTrackSelector::checkJetCount(const Tracks& tracks,
+                                                                                 const edm::Event& iEvent) const {
+  Tracks result;
+  result.clear();
 
   Handle<reco::CaloJetCollection> jets;
   iEvent.getByToken(theJetCountToken, jets);
 
   if (jets.isValid()) {
     int jetCount = 0;
-    for (reco::CaloJetCollection::const_iterator itJet = jets->begin();
-	 itJet!=jets->end();
-	 ++itJet) {
+    for (reco::CaloJetCollection::const_iterator itJet = jets->begin(); itJet != jets->end(); ++itJet) {
       if ((*itJet).pt() > theMinJetPt)
-	jetCount++;
+        jetCount++;
     }
 
     if (jetCount <= theMaxJetCount)
@@ -188,7 +173,7 @@ AlignmentGlobalTrackSelector::checkJetCount(const Tracks& tracks, const edm::Eve
     LogDebug("Alignment") << "> found " << jetCount << " Jets";
   } else
     LogError("Alignment") << "@SUB=AlignmentGlobalTrackSelector::checkJetCount"
-			  << ">  could not optain jetCollection!";
+                          << ">  could not optain jetCollection!";
 
   return result;
 }
@@ -196,45 +181,34 @@ AlignmentGlobalTrackSelector::checkJetCount(const Tracks& tracks, const edm::Eve
 //===================HELPERS===================
 
 ///matches [src] with [comp] returns collection with matching Tracks coming from [src]
-AlignmentGlobalTrackSelector::Tracks
-AlignmentGlobalTrackSelector::matchTracks(const Tracks& src, const Tracks& comp) const
-{
+AlignmentGlobalTrackSelector::Tracks AlignmentGlobalTrackSelector::matchTracks(const Tracks& src,
+                                                                               const Tracks& comp) const {
   Tracks result;
-  for (Tracks::const_iterator itComp = comp.begin();
-       itComp!=comp.end();
-       ++itComp) {
+  for (Tracks::const_iterator itComp = comp.begin(); itComp != comp.end(); ++itComp) {
     int match = -1;
     double min = theMaxTrackDeltaR;
-    for (unsigned int i=0;i<src.size();i++) {
+    for (unsigned int i = 0; i < src.size(); i++) {
       // LogDebug("Alignment") << "> Trackmatch dist: "<<deltaR(src.at(i),*itComp);
-      if(min > deltaR(*(src.at(i)),*(*itComp))){
-	min = deltaR(*(src.at(i)),*(*itComp));
-	match = static_cast<int>(i);
+      if (min > deltaR(*(src.at(i)), *(*itComp))) {
+        min = deltaR(*(src.at(i)), *(*itComp));
+        match = static_cast<int>(i);
       }
     }
     if (match > -1)
-      result.push_back(src.at(match)); 
+      result.push_back(src.at(match));
   }
   return result;
 }
 
 ///print Information on Track-Collection
-void AlignmentGlobalTrackSelector::printTracks(const Tracks& col) const
-{
+void AlignmentGlobalTrackSelector::printTracks(const Tracks& col) const {
   int count = 0;
   LogDebug("Alignment") << ">......................................";
-  for (Tracks::const_iterator it = col.begin();
-       it < col.end();
-       ++it,++count) {
-    LogDebug("Alignment") 
-      << ">  Track No. " << count << ": p = (" 
-      << (*it)->px() << "," 
-      << (*it)->py() << ","
-      << (*it)->pz() << ")\n"
-      << ">                        pT = "
-      << (*it)->pt() << " eta = "
-      << (*it)->eta() << " charge = "
-      << (*it)->charge();    
+  for (Tracks::const_iterator it = col.begin(); it < col.end(); ++it, ++count) {
+    LogDebug("Alignment") << ">  Track No. " << count << ": p = (" << (*it)->px() << "," << (*it)->py() << ","
+                          << (*it)->pz() << ")\n"
+                          << ">                        pT = " << (*it)->pt() << " eta = " << (*it)->eta()
+                          << " charge = " << (*it)->charge();
   }
   LogDebug("Alignment") << ">......................................";
 }

--- a/Alignment/CommonAlignmentProducer/src/AlignmentMuonSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentMuonSelector.cc
@@ -1,147 +1,132 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentMuonSelector.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h" 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "TLorentzVector.h"
 
 // constructor ----------------------------------------------------------------
 
-AlignmentMuonSelector::AlignmentMuonSelector(const edm::ParameterSet & cfg) :
-  applyBasicCuts( cfg.getParameter<bool>( "applyBasicCuts" ) ),
-  applyNHighestPt( cfg.getParameter<bool>( "applyNHighestPt" ) ),
-  applyMultiplicityFilter( cfg.getParameter<bool>( "applyMultiplicityFilter" ) ),
-  applyMassPairFilter( cfg.getParameter<bool>( "applyMassPairFilter" ) ),
-  nHighestPt( cfg.getParameter<int>( "nHighestPt" ) ),
-  minMultiplicity ( cfg.getParameter<int>( "minMultiplicity" ) ),
-  pMin( cfg.getParameter<double>( "pMin" ) ),
-  pMax( cfg.getParameter<double>( "pMax" ) ),
-  ptMin( cfg.getParameter<double>( "ptMin" ) ),
-  ptMax( cfg.getParameter<double>( "ptMax" ) ),
-  etaMin( cfg.getParameter<double>( "etaMin" ) ),
-  etaMax( cfg.getParameter<double>( "etaMax" ) ),
-  phiMin( cfg.getParameter<double>( "phiMin" ) ),
-  phiMax( cfg.getParameter<double>( "phiMax" ) ),
-  nHitMinSA( cfg.getParameter<double>( "nHitMinSA" ) ),
-  nHitMaxSA( cfg.getParameter<double>( "nHitMaxSA" ) ),
-  chi2nMaxSA( cfg.getParameter<double>( "chi2nMaxSA") ),
-  nHitMinGB( cfg.getParameter<double>( "nHitMinGB" ) ),
-  nHitMaxGB( cfg.getParameter<double>( "nHitMaxGB" ) ),
-  chi2nMaxGB( cfg.getParameter<double>( "chi2nMaxGB") ),
-  nHitMinTO( cfg.getParameter<double>( "nHitMinTO" ) ),
-  nHitMaxTO( cfg.getParameter<double>( "nHitMaxTO" ) ),
-  chi2nMaxTO( cfg.getParameter<double>( "chi2nMaxTO" ) ),
-  minMassPair( cfg.getParameter<double>( "minMassPair" ) ),
-  maxMassPair( cfg.getParameter<double>( "maxMassPair" ) )
-{
-
+AlignmentMuonSelector::AlignmentMuonSelector(const edm::ParameterSet& cfg)
+    : applyBasicCuts(cfg.getParameter<bool>("applyBasicCuts")),
+      applyNHighestPt(cfg.getParameter<bool>("applyNHighestPt")),
+      applyMultiplicityFilter(cfg.getParameter<bool>("applyMultiplicityFilter")),
+      applyMassPairFilter(cfg.getParameter<bool>("applyMassPairFilter")),
+      nHighestPt(cfg.getParameter<int>("nHighestPt")),
+      minMultiplicity(cfg.getParameter<int>("minMultiplicity")),
+      pMin(cfg.getParameter<double>("pMin")),
+      pMax(cfg.getParameter<double>("pMax")),
+      ptMin(cfg.getParameter<double>("ptMin")),
+      ptMax(cfg.getParameter<double>("ptMax")),
+      etaMin(cfg.getParameter<double>("etaMin")),
+      etaMax(cfg.getParameter<double>("etaMax")),
+      phiMin(cfg.getParameter<double>("phiMin")),
+      phiMax(cfg.getParameter<double>("phiMax")),
+      nHitMinSA(cfg.getParameter<double>("nHitMinSA")),
+      nHitMaxSA(cfg.getParameter<double>("nHitMaxSA")),
+      chi2nMaxSA(cfg.getParameter<double>("chi2nMaxSA")),
+      nHitMinGB(cfg.getParameter<double>("nHitMinGB")),
+      nHitMaxGB(cfg.getParameter<double>("nHitMaxGB")),
+      chi2nMaxGB(cfg.getParameter<double>("chi2nMaxGB")),
+      nHitMinTO(cfg.getParameter<double>("nHitMinTO")),
+      nHitMaxTO(cfg.getParameter<double>("nHitMaxTO")),
+      chi2nMaxTO(cfg.getParameter<double>("chi2nMaxTO")),
+      minMassPair(cfg.getParameter<double>("minMassPair")),
+      maxMassPair(cfg.getParameter<double>("maxMassPair")) {
   if (applyBasicCuts)
-	edm::LogInfo("AlignmentMuonSelector") 
-	  << "applying basic muon cuts ..."
-          << "\npmin,pmax:           " << pMin   << "," << pMax
-	  << "\nptmin,ptmax:         " << ptMin   << "," << ptMax 
-	  << "\netamin,etamax:       " << etaMin  << "," << etaMax
-	  << "\nphimin,phimax:       " << phiMin  << "," << phiMax
-	  << "\nnhitminSA,nhitmaxSA: " << nHitMinSA << "," << nHitMaxSA
-	  << "\nchi2nmaxSA:          " << chi2nMaxSA<< ","
-	  << "\nnhitminGB,nhitmaxGB: " << nHitMinGB << "," << nHitMaxGB
-	  << "\nchi2nmaxGB:          " << chi2nMaxGB<< ","
-	  << "\nnhitminTO,nhitmaxTO: " << nHitMinTO << "," << nHitMaxTO
-	  << "\nchi2nmaxTO:          " << chi2nMaxTO;
+    edm::LogInfo("AlignmentMuonSelector")
+        << "applying basic muon cuts ..."
+        << "\npmin,pmax:           " << pMin << "," << pMax << "\nptmin,ptmax:         " << ptMin << "," << ptMax
+        << "\netamin,etamax:       " << etaMin << "," << etaMax << "\nphimin,phimax:       " << phiMin << "," << phiMax
+        << "\nnhitminSA,nhitmaxSA: " << nHitMinSA << "," << nHitMaxSA << "\nchi2nmaxSA:          " << chi2nMaxSA << ","
+        << "\nnhitminGB,nhitmaxGB: " << nHitMinGB << "," << nHitMaxGB << "\nchi2nmaxGB:          " << chi2nMaxGB << ","
+        << "\nnhitminTO,nhitmaxTO: " << nHitMinTO << "," << nHitMaxTO << "\nchi2nmaxTO:          " << chi2nMaxTO;
 
   if (applyNHighestPt)
-	edm::LogInfo("AlignmentMuonSelector") 
-	  << "filter N muons with highest Pt N=" << nHighestPt;
+    edm::LogInfo("AlignmentMuonSelector") << "filter N muons with highest Pt N=" << nHighestPt;
 
   if (applyMultiplicityFilter)
-	edm::LogInfo("AlignmentMuonSelector") 
-	  << "apply multiplicity filter N>=" << minMultiplicity;
+    edm::LogInfo("AlignmentMuonSelector") << "apply multiplicity filter N>=" << minMultiplicity;
 
   if (applyMassPairFilter)
-	edm::LogInfo("AlignmentMuonSelector") 
-	  << "apply Mass Pair filter minMassPair=" << minMassPair << " maxMassPair=" << maxMassPair;
-
+    edm::LogInfo("AlignmentMuonSelector")
+        << "apply Mass Pair filter minMassPair=" << minMassPair << " maxMassPair=" << maxMassPair;
 }
 
 // destructor -----------------------------------------------------------------
 
-AlignmentMuonSelector::~AlignmentMuonSelector()
-{}
-
+AlignmentMuonSelector::~AlignmentMuonSelector() {}
 
 // do selection ---------------------------------------------------------------
 
-AlignmentMuonSelector::Muons 
-AlignmentMuonSelector::select(const Muons& muons, const edm::Event& evt) const 
-{
-  Muons result=muons;
+AlignmentMuonSelector::Muons AlignmentMuonSelector::select(const Muons& muons, const edm::Event& evt) const {
+  Muons result = muons;
 
   // apply basic muon cuts (if selected)
-  if (applyBasicCuts)  result= this->basicCuts(result);
+  if (applyBasicCuts)
+    result = this->basicCuts(result);
 
   // filter N muons with highest Pt (if selected)
-  if (applyNHighestPt) result= this->theNHighestPtMuons(result);
+  if (applyNHighestPt)
+    result = this->theNHighestPtMuons(result);
 
   // apply minimum multiplicity requirement (if selected)
   if (applyMultiplicityFilter) {
-    if (result.size()<(unsigned int)minMultiplicity) result.clear();
+    if (result.size() < (unsigned int)minMultiplicity)
+      result.clear();
   }
 
   // apply mass pair requirement (if selected)
   if (applyMassPairFilter) {
-    if (result.size()<2) result.clear();  // at least 2 muons are require for a mass pair...
-    else result = this->theBestMassPairCombinationMuons(result);
+    if (result.size() < 2)
+      result.clear();  // at least 2 muons are require for a mass pair...
+    else
+      result = this->theBestMassPairCombinationMuons(result);
   }
 
   edm::LogInfo("AlignmentMuonSelector") << "muons all,kept: " << muons.size() << "," << result.size();
 
   return result;
-
 }
 
 // make basic cuts ------------------------------------------------------------
 
-AlignmentMuonSelector::Muons 
-AlignmentMuonSelector::basicCuts(const Muons& muons) const 
-{
+AlignmentMuonSelector::Muons AlignmentMuonSelector::basicCuts(const Muons& muons) const {
   Muons result;
 
-  for(Muons::const_iterator it=muons.begin();
-      it!=muons.end();++it) {
-    const reco::Muon* muonp=*it;
-    float p=muonp->p();
-    float pt=muonp->pt();
-    float eta=muonp->eta();
-    float phi=muonp->phi();
+  for (Muons::const_iterator it = muons.begin(); it != muons.end(); ++it) {
+    const reco::Muon* muonp = *it;
+    float p = muonp->p();
+    float pt = muonp->pt();
+    float eta = muonp->eta();
+    float phi = muonp->phi();
 
-    int nhitSA=0;float chi2nSA=9999.;
-    if(muonp->isStandAloneMuon()){
-    nhitSA = muonp->standAloneMuon()->numberOfValidHits();// standAlone Muon
-    chi2nSA = muonp->standAloneMuon()->normalizedChi2();  // standAlone Muon
+    int nhitSA = 0;
+    float chi2nSA = 9999.;
+    if (muonp->isStandAloneMuon()) {
+      nhitSA = muonp->standAloneMuon()->numberOfValidHits();  // standAlone Muon
+      chi2nSA = muonp->standAloneMuon()->normalizedChi2();    // standAlone Muon
     }
-    int nhitGB=0;float chi2nGB=9999.;
-    if(muonp->isGlobalMuon()){
-    nhitGB = muonp->combinedMuon()->numberOfValidHits();// global Muon
-    chi2nGB = muonp->combinedMuon()->normalizedChi2();	// global Muon
+    int nhitGB = 0;
+    float chi2nGB = 9999.;
+    if (muonp->isGlobalMuon()) {
+      nhitGB = muonp->combinedMuon()->numberOfValidHits();  // global Muon
+      chi2nGB = muonp->combinedMuon()->normalizedChi2();    // global Muon
     }
-	int nhitTO=0;float chi2nTO=9999.;
-    if(muonp->isTrackerMuon()){
-    nhitTO = muonp->track()->numberOfValidHits(); 	// Tracker Only
-    chi2nTO = muonp->track()->normalizedChi2();		// Tracker Only
+    int nhitTO = 0;
+    float chi2nTO = 9999.;
+    if (muonp->isTrackerMuon()) {
+      nhitTO = muonp->track()->numberOfValidHits();  // Tracker Only
+      chi2nTO = muonp->track()->normalizedChi2();    // Tracker Only
     }
-    edm::LogInfo("AlignmentMuonSelector") << " pt,eta,phi,nhitSA,chi2nSA,nhitGB,chi2nGB,nhitTO,chi2nTO: "
-      <<pt<<","<<eta<<","<<phi<<","<<nhitSA<< ","<<chi2nSA<<","<<nhitGB<< ","<<chi2nGB<<","<<nhitTO<< ","<<chi2nTO;
+    edm::LogInfo("AlignmentMuonSelector")
+        << " pt,eta,phi,nhitSA,chi2nSA,nhitGB,chi2nGB,nhitTO,chi2nTO: " << pt << "," << eta << "," << phi << ","
+        << nhitSA << "," << chi2nSA << "," << nhitGB << "," << chi2nGB << "," << nhitTO << "," << chi2nTO;
 
-    if (p>pMin && p<pMax
-       && pt>ptMin && pt<ptMax 
-       && eta>etaMin && eta<etaMax 
-       && phi>phiMin && phi<phiMax 
-       && nhitSA>=nHitMinSA && nhitSA<=nHitMaxSA
-       && chi2nSA<chi2nMaxSA 
-       && nhitGB>=nHitMinGB && nhitGB<=nHitMaxGB
-       && chi2nGB<chi2nMaxGB 
-       && nhitTO>=nHitMinTO && nhitTO<=nHitMaxTO
-       && chi2nTO<chi2nMaxTO) {
+    if (p > pMin && p < pMax && pt > ptMin && pt < ptMax && eta > etaMin && eta < etaMax && phi > phiMin &&
+        phi < phiMax && nhitSA >= nHitMinSA && nhitSA <= nHitMaxSA && chi2nSA < chi2nMaxSA && nhitGB >= nHitMinGB &&
+        nhitGB <= nHitMaxGB && chi2nGB < chi2nMaxGB && nhitTO >= nHitMinTO && nhitTO <= nHitMaxTO &&
+        chi2nTO < chi2nMaxTO) {
       result.push_back(muonp);
     }
   }
@@ -151,20 +136,20 @@ AlignmentMuonSelector::basicCuts(const Muons& muons) const
 
 //-----------------------------------------------------------------------------
 
-AlignmentMuonSelector::Muons 
-AlignmentMuonSelector::theNHighestPtMuons(const Muons& muons) const
-{
-  Muons sortedMuons=muons;
+AlignmentMuonSelector::Muons AlignmentMuonSelector::theNHighestPtMuons(const Muons& muons) const {
+  Muons sortedMuons = muons;
   Muons result;
 
   // sort in pt
-  std::sort(sortedMuons.begin(),sortedMuons.end(),ptComparator);
+  std::sort(sortedMuons.begin(), sortedMuons.end(), ptComparator);
 
   // copy theMuonMult highest pt muons to result vector
-  int n=0;
-  for (Muons::const_iterator it=sortedMuons.begin();
-	   it!=sortedMuons.end(); ++it) {
-	if (n<nHighestPt) { result.push_back(*it); n++; }
+  int n = 0;
+  for (Muons::const_iterator it = sortedMuons.begin(); it != sortedMuons.end(); ++it) {
+    if (n < nHighestPt) {
+      result.push_back(*it);
+      n++;
+    }
   }
 
   return result;
@@ -172,39 +157,42 @@ AlignmentMuonSelector::theNHighestPtMuons(const Muons& muons) const
 
 //-----------------------------------------------------------------------------
 
-AlignmentMuonSelector::Muons 
-AlignmentMuonSelector::theBestMassPairCombinationMuons(const Muons& muons) const
-{
-  Muons sortedMuons=muons;
+AlignmentMuonSelector::Muons AlignmentMuonSelector::theBestMassPairCombinationMuons(const Muons& muons) const {
+  Muons sortedMuons = muons;
   Muons result;
-  TLorentzVector mu1,mu2,pair;
-  double mass=0, minDiff=999999.;
+  TLorentzVector mu1, mu2, pair;
+  double mass = 0, minDiff = 999999.;
 
   // sort in pt
-  std::sort(sortedMuons.begin(),sortedMuons.end(),ptComparator);
+  std::sort(sortedMuons.begin(), sortedMuons.end(), ptComparator);
 
   // copy best mass pair combination muons to result vector
-  // Criteria: 
+  // Criteria:
   // a) maxMassPair !=    minMassPair: the two highest pt muons with mass pair inside the given mass window
   // b) maxMassPair ==    minMassPair: the muon pair with massPair closest to given mass value
-   for (Muons::const_iterator it1=sortedMuons.begin();
-	   it1!=sortedMuons.end(); ++it1) {
-	   for (Muons::const_iterator it2=it1+1;
-	   it2!=sortedMuons.end(); ++it2) {
-	   mu1 = TLorentzVector((*it1)->momentum().x(),(*it1)->momentum().y(),(*it1)->momentum().z(),(*it1)->p());
-	   mu2 = TLorentzVector((*it2)->momentum().x(),(*it2)->momentum().y(),(*it2)->momentum().z(),(*it2)->p());
-	   pair=mu1+mu2;
-	   mass = pair.M();
-	   
-	if(	maxMassPair !=    minMassPair){
-	   if(mass<maxMassPair && mass>minMassPair) { result.push_back(*it1); result.push_back(*it2); break;}
-	}
-	else{
-	   if(fabs(mass-maxMassPair)< minDiff) { minDiff=fabs(mass-maxMassPair); result.clear(); result.push_back(*it1); result.push_back(*it2);}
-	}
-	}
+  for (Muons::const_iterator it1 = sortedMuons.begin(); it1 != sortedMuons.end(); ++it1) {
+    for (Muons::const_iterator it2 = it1 + 1; it2 != sortedMuons.end(); ++it2) {
+      mu1 = TLorentzVector((*it1)->momentum().x(), (*it1)->momentum().y(), (*it1)->momentum().z(), (*it1)->p());
+      mu2 = TLorentzVector((*it2)->momentum().x(), (*it2)->momentum().y(), (*it2)->momentum().z(), (*it2)->p());
+      pair = mu1 + mu2;
+      mass = pair.M();
+
+      if (maxMassPair != minMassPair) {
+        if (mass < maxMassPair && mass > minMassPair) {
+          result.push_back(*it1);
+          result.push_back(*it2);
+          break;
+        }
+      } else {
+        if (fabs(mass - maxMassPair) < minDiff) {
+          minDiff = fabs(mass - maxMassPair);
+          result.clear();
+          result.push_back(*it1);
+          result.push_back(*it2);
+        }
+      }
+    }
   }
 
   return result;
 }
-

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -30,32 +30,29 @@
 #include "Geometry/Records/interface/MuonNumberingRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-
 //------------------------------------------------------------------------------
-AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config) :
-  doTracker_{config.getUntrackedParameter<bool>("doTracker")},
-  doMuon_{config.getUntrackedParameter<bool>("doMuon")},
-  useExtras_{config.getUntrackedParameter<bool>("useExtras")},
-  tjTkAssociationMapTag_{config.getParameter<edm::InputTag>("tjTkAssociationMapTag")},
-  beamSpotTag_{config.getParameter<edm::InputTag>("beamSpotTag")},
-  tkLasBeamTag_{config.getParameter<edm::InputTag>("tkLasBeamTag")},
-  clusterValueMapTag_{config.getParameter<edm::InputTag>("hitPrescaleMapTag")},
-  uniqueRunRanges_
-  {align::makeUniqueRunRanges(config.getParameter<edm::VParameterSet>("RunRangeSelection"),
-                              cond::timeTypeSpecs[cond::runnumber].beginValue)},
-  config_{config},
-  stNFixAlignables_{config.getParameter<int>("nFixAlignables")},
-  stRandomShift_{config.getParameter<double>("randomShift")},
-  stRandomRotation_{config.getParameter<double>("randomRotation")},
-  applyDbAlignment_{config.getUntrackedParameter<bool>("applyDbAlignment")},
-  checkDbAlignmentValidity_{config.getUntrackedParameter<bool>("checkDbAlignmentValidity")},
-  doMisalignmentScenario_{config.getParameter<bool>("doMisalignmentScenario")},
-  saveToDB_{config.getParameter<bool>("saveToDB")},
-  saveApeToDB_{config.getParameter<bool>("saveApeToDB")},
-  saveDeformationsToDB_{config.getParameter<bool>("saveDeformationsToDB")},
-  useSurvey_{config.getParameter<bool>("useSurvey")},
-  enableAlignableUpdates_{config.getParameter<bool>("enableAlignableUpdates")}
-{
+AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config)
+    : doTracker_{config.getUntrackedParameter<bool>("doTracker")},
+      doMuon_{config.getUntrackedParameter<bool>("doMuon")},
+      useExtras_{config.getUntrackedParameter<bool>("useExtras")},
+      tjTkAssociationMapTag_{config.getParameter<edm::InputTag>("tjTkAssociationMapTag")},
+      beamSpotTag_{config.getParameter<edm::InputTag>("beamSpotTag")},
+      tkLasBeamTag_{config.getParameter<edm::InputTag>("tkLasBeamTag")},
+      clusterValueMapTag_{config.getParameter<edm::InputTag>("hitPrescaleMapTag")},
+      uniqueRunRanges_{align::makeUniqueRunRanges(config.getParameter<edm::VParameterSet>("RunRangeSelection"),
+                                                  cond::timeTypeSpecs[cond::runnumber].beginValue)},
+      config_{config},
+      stNFixAlignables_{config.getParameter<int>("nFixAlignables")},
+      stRandomShift_{config.getParameter<double>("randomShift")},
+      stRandomRotation_{config.getParameter<double>("randomRotation")},
+      applyDbAlignment_{config.getUntrackedParameter<bool>("applyDbAlignment")},
+      checkDbAlignmentValidity_{config.getUntrackedParameter<bool>("checkDbAlignmentValidity")},
+      doMisalignmentScenario_{config.getParameter<bool>("doMisalignmentScenario")},
+      saveToDB_{config.getParameter<bool>("saveToDB")},
+      saveApeToDB_{config.getParameter<bool>("saveApeToDB")},
+      saveDeformationsToDB_{config.getParameter<bool>("saveDeformationsToDB")},
+      useSurvey_{config.getParameter<bool>("useSurvey")},
+      enableAlignableUpdates_{config.getParameter<bool>("enableAlignableUpdates")} {
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::AlignmentProducerBase";
 
   const auto& algoConfig = config_.getParameterSet("algoConfig");
@@ -63,11 +60,9 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config) :
     // configured in main config?
     runAtPCL_ = config_.getParameter<bool>("runAtPCL");
 
-    if (hasParameter<bool>(algoConfig, "runAtPCL") &&
-        (runAtPCL_ != algoConfig.getParameter<bool>("runAtPCL"))) {
-      throw cms::Exception("BadConfig")
-        << "Inconsistent settings for 'runAtPCL' in configuration of the "
-        << "alignment producer and the alignment algorithm.";
+    if (hasParameter<bool>(algoConfig, "runAtPCL") && (runAtPCL_ != algoConfig.getParameter<bool>("runAtPCL"))) {
+      throw cms::Exception("BadConfig") << "Inconsistent settings for 'runAtPCL' in configuration of the "
+                                        << "alignment producer and the alignment algorithm.";
     }
 
   } else if (hasParameter<bool>(algoConfig, "runAtPCL")) {
@@ -84,12 +79,10 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config) :
   createCalibrations();
 }
 
-
-
 //------------------------------------------------------------------------------
-AlignmentProducerBase::~AlignmentProducerBase() noexcept(false)
-{
-  for (auto& iCal: calibrations_) delete iCal;
+AlignmentProducerBase::~AlignmentProducerBase() noexcept(false) {
+  for (auto& iCal : calibrations_)
+    delete iCal;
 
   delete alignmentParameterStore_;
   delete alignableExtras_;
@@ -97,22 +90,18 @@ AlignmentProducerBase::~AlignmentProducerBase() noexcept(false)
   delete alignableMuon_;
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::startProcessing()
-{
-  if (isDuringLoop_) return;
+void AlignmentProducerBase::startProcessing() {
+  if (isDuringLoop_)
+    return;
 
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::startProcessing"
-    << "Begin";
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::startProcessing"
+                            << "Begin";
 
   if (!isAlgoInitialized_) {
-    throw cms::Exception("LogicError")
-      << "@SUB=AlignmentProducerBase::startProcessing\n"
-      << "Trying to start event processing before initializing the alignment "
-      << "algorithm.";
+    throw cms::Exception("LogicError") << "@SUB=AlignmentProducerBase::startProcessing\n"
+                                       << "Trying to start event processing before initializing the alignment "
+                                       << "algorithm.";
   }
 
   nevent_ = 0;
@@ -120,23 +109,22 @@ AlignmentProducerBase::startProcessing()
   alignmentAlgo_->startNewLoop();
 
   // FIXME: Should this be done in algorithm::startNewLoop()??
-  for (const auto& iCal: calibrations_) iCal->startNewLoop();
-  for (const auto& monitor: monitors_) monitor->startingNewLoop();
+  for (const auto& iCal : calibrations_)
+    iCal->startNewLoop();
+  for (const auto& monitor : monitors_)
+    monitor->startingNewLoop();
 
   applyAlignmentsToGeometry();
   isDuringLoop_ = true;
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::terminateProcessing(const edm::EventSetup* setup)
-{
-  if (!isDuringLoop_) return;
+void AlignmentProducerBase::terminateProcessing(const edm::EventSetup* setup) {
+  if (!isDuringLoop_)
+    return;
 
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::terminateProcessing"
-    << "Terminating algorithm.";
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::terminateProcessing"
+                            << "Terminating algorithm.";
   if (setup) {
     alignmentAlgo_->terminate(*setup);
   } else {
@@ -144,22 +132,19 @@ AlignmentProducerBase::terminateProcessing(const edm::EventSetup* setup)
   }
 
   // FIXME: Should this be done in algorithm::terminate()??
-  for (const auto& iCal:calibrations_) iCal->endOfLoop();
-  for (const auto& monitor: monitors_) monitor->endOfLoop();
+  for (const auto& iCal : calibrations_)
+    iCal->endOfLoop();
+  for (const auto& monitor : monitors_)
+    monitor->endOfLoop();
 
   isDuringLoop_ = false;
 }
 
-
 //------------------------------------------------------------------------------
-bool
-AlignmentProducerBase::processEvent(const edm::Event& event,
-                                    const edm::EventSetup& setup)
-{
+bool AlignmentProducerBase::processEvent(const edm::Event& event, const edm::EventSetup& setup) {
   if (setupChanged(setup)) {
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::processEvent"
-      << "EventSetup-Record changed.";
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::processEvent"
+                              << "EventSetup-Record changed.";
 
     // updatable alignables are currently not used at PCL, but event setup
     // changes require a complete re-initialization
@@ -170,16 +155,15 @@ AlignmentProducerBase::processEvent(const edm::Event& event,
     }
   }
 
-  initBeamSpot(event); // must happen every event and before incrementing 'nevent_'
+  initBeamSpot(event);  // must happen every event and before incrementing 'nevent_'
 
   ++nevent_;  // must happen before the check below;
               // otherwise subsequent checks fail for "EmptySource"
 
   if (!alignmentAlgo_->processesEvents()) {
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::processEvent"
-      << "Skipping event. The current configuration of the alignment algorithm "
-      << "does not need to process any events.";
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::processEvent"
+                              << "Skipping event. The current configuration of the alignment algorithm "
+                              << "does not need to process any events.";
     return false;
   }
 
@@ -187,11 +171,10 @@ AlignmentProducerBase::processEvent(const edm::Event& event,
   readInSurveyRcds(setup);
 
   // Printout event number
-  for ( int i=10; i<10000000; i*=10 ) {
-    if ( nevent_<10*i && (nevent_%i)==0 ) {
-      edm::LogInfo("Alignment")
-        << "@SUB=AlignmentProducerBase::processEvent"
-        << "Events processed: " << nevent_;
+  for (int i = 10; i < 10000000; i *= 10) {
+    if (nevent_ < 10 * i && (nevent_ % i) == 0) {
+      edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::processEvent"
+                                << "Events processed: " << nevent_;
     }
   }
 
@@ -200,12 +183,9 @@ AlignmentProducerBase::processEvent(const edm::Event& event,
   edm::Handle<TrajTrackAssociationCollection> handleTrajTracksCollection;
 
   if (getTrajTrackAssociationCollection(event, handleTrajTracksCollection)) {
-
     // Form pairs of trajectories and tracks
     ConstTrajTrackPairs trajTracks;
-    for (auto iter  = handleTrajTracksCollection->begin();
-              iter != handleTrajTracksCollection->end();
-            ++iter) {
+    for (auto iter = handleTrajTracksCollection->begin(); iter != handleTrajTracksCollection->end(); ++iter) {
       trajTracks.push_back(ConstTrajTrackPair(&(*(*iter).key), &(*(*iter).val)));
     }
 
@@ -217,36 +197,26 @@ AlignmentProducerBase::processEvent(const edm::Event& event,
       clusterValueMapPtr = &(*clusterValueMap);
     }
 
-
-    const AlignmentAlgorithmBase::EventInfo eventInfo{event.id(),
-                                                      trajTracks,
-                                                      *beamSpot_,
-                                                      clusterValueMapPtr};
+    const AlignmentAlgorithmBase::EventInfo eventInfo{event.id(), trajTracks, *beamSpot_, clusterValueMapPtr};
     alignmentAlgo_->run(setup, eventInfo);
 
-
-    for (const auto& monitor: monitors_) {
-      monitor->duringLoop(event, setup, trajTracks); // forward eventInfo?
+    for (const auto& monitor : monitors_) {
+      monitor->duringLoop(event, setup, trajTracks);  // forward eventInfo?
     }
   } else {
-    edm::LogError("Alignment")
-      << "@SUB=AlignmentProducerBase::processEvent"
-      << "No track collection found: skipping event";
+    edm::LogError("Alignment") << "@SUB=AlignmentProducerBase::processEvent"
+                               << "No track collection found: skipping event";
   }
 
   return true;
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::beginRunImpl(const edm::Run& run, const edm::EventSetup& setup)
-{
+void AlignmentProducerBase::beginRunImpl(const edm::Run& run, const edm::EventSetup& setup) {
   const bool changed{setupChanged(setup)};
   if (changed) {
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::beginRunImpl"
-      << "EventSetup-Record changed.";
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::beginRunImpl"
+                              << "EventSetup-Record changed.";
 
     // updatable alignables are currently not used at PCL, but event setup
     // changes require a complete re-initialization
@@ -257,10 +227,10 @@ AlignmentProducerBase::beginRunImpl(const edm::Run& run, const edm::EventSetup& 
     }
   }
 
-  alignmentAlgo_->beginRun(run, setup,
-                           changed && (runAtPCL_ || enableAlignableUpdates_));
+  alignmentAlgo_->beginRun(run, setup, changed && (runAtPCL_ || enableAlignableUpdates_));
 
-  for (const auto& iCal:calibrations_) iCal->beginRun(run, setup);
+  for (const auto& iCal : calibrations_)
+    iCal->beginRun(run, setup);
 
   //store the first run analyzed to be used for setting the IOV (for PCL)
   if (firstRun_ > static_cast<cond::Time_t>(run.id().run())) {
@@ -268,11 +238,8 @@ AlignmentProducerBase::beginRunImpl(const edm::Run& run, const edm::EventSetup& 
   }
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::endRunImpl(const edm::Run& run, const edm::EventSetup& setup)
-{
+void AlignmentProducerBase::endRunImpl(const edm::Run& run, const edm::EventSetup& setup) {
   if (!tkLasBeamTag_.encode().empty()) {
     edm::Handle<TkFittedLasBeamCollection> lasBeams;
     edm::Handle<TsosVectorCollection> tsoses;
@@ -281,71 +248,47 @@ AlignmentProducerBase::endRunImpl(const edm::Run& run, const edm::EventSetup& se
 
     alignmentAlgo_->endRun(EndRunInfo(run.id(), &(*lasBeams), &(*tsoses)), setup);
   } else {
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::endRunImpl"
-      << "No Tk LAS beams to forward to algorithm.";
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::endRunImpl"
+                              << "No Tk LAS beams to forward to algorithm.";
     alignmentAlgo_->endRun(EndRunInfo(run.id(), nullptr, nullptr), setup);
   }
-
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::beginLuminosityBlockImpl(const edm::LuminosityBlock&,
-                                                const edm::EventSetup& setup)
-{
+void AlignmentProducerBase::beginLuminosityBlockImpl(const edm::LuminosityBlock&, const edm::EventSetup& setup) {
   // Do not forward edm::LuminosityBlock
   alignmentAlgo_->beginLuminosityBlock(setup);
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::endLuminosityBlockImpl(const edm::LuminosityBlock&,
-                                              const edm::EventSetup& setup)
-{
+void AlignmentProducerBase::endLuminosityBlockImpl(const edm::LuminosityBlock&, const edm::EventSetup& setup) {
   // Do not forward edm::LuminosityBlock
   alignmentAlgo_->endLuminosityBlock(setup);
 }
 
-
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::createAlignmentAlgorithm()
-{
+void AlignmentProducerBase::createAlignmentAlgorithm() {
   auto algoConfig = config_.getParameter<edm::ParameterSet>("algoConfig");
-  algoConfig.addUntrackedParameter("RunRangeSelection",
-                                   config_.getParameter<edm::VParameterSet>("RunRangeSelection"));
-  algoConfig.addUntrackedParameter<align::RunNumber>("firstIOV",
-                                                     runAtPCL_ ?
-                                                     1 :
-                                                     uniqueRunRanges_.front().first);
-  algoConfig.addUntrackedParameter("enableAlignableUpdates",
-                                   enableAlignableUpdates_);
+  algoConfig.addUntrackedParameter("RunRangeSelection", config_.getParameter<edm::VParameterSet>("RunRangeSelection"));
+  algoConfig.addUntrackedParameter<align::RunNumber>("firstIOV", runAtPCL_ ? 1 : uniqueRunRanges_.front().first);
+  algoConfig.addUntrackedParameter("enableAlignableUpdates", enableAlignableUpdates_);
 
   const auto& algoName = algoConfig.getParameter<std::string>("algoName");
-  alignmentAlgo_ = std::unique_ptr<AlignmentAlgorithmBase>
-    {AlignmentAlgorithmPluginFactory::get()->create(algoName, algoConfig)};
+  alignmentAlgo_ =
+      std::unique_ptr<AlignmentAlgorithmBase>{AlignmentAlgorithmPluginFactory::get()->create(algoName, algoConfig)};
 
   if (!alignmentAlgo_) {
-    throw cms::Exception("BadConfig")
-      << "Couldn't find the called alignment algorithm: " << algoName;
+    throw cms::Exception("BadConfig") << "Couldn't find the called alignment algorithm: " << algoName;
   }
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::createMonitors()
-{
+void AlignmentProducerBase::createMonitors() {
   const auto& monitorConfig = config_.getParameter<edm::ParameterSet>("monitorConfig");
   auto monitors = monitorConfig.getUntrackedParameter<std::vector<std::string> >("monitors");
-  for (const auto& miter: monitors) {
-    std::unique_ptr<AlignmentMonitorBase> newMonitor
-      {AlignmentMonitorPluginFactory::get()
-       ->create(miter, monitorConfig.getUntrackedParameterSet(miter))};
+  for (const auto& miter : monitors) {
+    std::unique_ptr<AlignmentMonitorBase> newMonitor{
+        AlignmentMonitorPluginFactory::get()->create(miter, monitorConfig.getUntrackedParameterSet(miter))};
 
     if (!newMonitor) {
       throw cms::Exception("BadConfig") << "Couldn't find monitor named " << miter;
@@ -354,24 +297,17 @@ AlignmentProducerBase::createMonitors()
   }
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::createCalibrations()
-{
+void AlignmentProducerBase::createCalibrations() {
   const auto& calibrations = config_.getParameter<edm::VParameterSet>("calibrations");
-  for (const auto& iCalib: calibrations) {
-    calibrations_.push_back(IntegratedCalibrationPluginFactory::get()
-                            ->create(iCalib.getParameter<std::string>("calibrationName"),
-                                     iCalib));
+  for (const auto& iCalib : calibrations) {
+    calibrations_.push_back(
+        IntegratedCalibrationPluginFactory::get()->create(iCalib.getParameter<std::string>("calibrationName"), iCalib));
   }
 }
 
-
 //------------------------------------------------------------------------------
-bool
-AlignmentProducerBase::setupChanged(const edm::EventSetup& setup)
-{
+bool AlignmentProducerBase::setupChanged(const edm::EventSetup& setup) {
   bool changed{false};
 
   if (watchIdealGeometryRcd_.check(setup)) {
@@ -422,15 +358,10 @@ AlignmentProducerBase::setupChanged(const edm::EventSetup& setup)
   return changed;
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::initAlignmentAlgorithm(const edm::EventSetup& setup,
-                                              bool update)
-{
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::initAlignmentAlgorithm"
-    << "Begin";
+void AlignmentProducerBase::initAlignmentAlgorithm(const edm::EventSetup& setup, bool update) {
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::initAlignmentAlgorithm"
+                            << "Begin";
 
   auto isTrueUpdate = update && isAlgoInitialized_;
 
@@ -449,14 +380,9 @@ AlignmentProducerBase::initAlignmentAlgorithm(const edm::EventSetup& setup,
 
   // Initialize alignment algorithm and integrated calibration and pass the
   // latter to algorithm
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::initAlignmentAlgorithm"
-    << "Initializing alignment algorithm.";
-  alignmentAlgo_->initialize(setup,
-                             alignableTracker_,
-                             alignableMuon_,
-                             alignableExtras_,
-                             alignmentParameterStore_);
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::initAlignmentAlgorithm"
+                            << "Initializing alignment algorithm.";
+  alignmentAlgo_->initialize(setup, alignableTracker_, alignableMuon_, alignableExtras_, alignmentParameterStore_);
 
   // Not all algorithms support calibrations - so do not pass empty vector
   // and throw if non-empty and not supported:
@@ -464,10 +390,9 @@ AlignmentProducerBase::initAlignmentAlgorithm(const edm::EventSetup& setup,
     if (alignmentAlgo_->supportsCalibrations()) {
       alignmentAlgo_->addCalibrations(calibrations_);
     } else {
-      throw cms::Exception("BadConfig")
-        << "@SUB=AlignmentProducerBase::createCalibrations\n"
-        << "Configured " << calibrations_.size() << " calibration(s) "
-        << "for algorithm not supporting it.";
+      throw cms::Exception("BadConfig") << "@SUB=AlignmentProducerBase::createCalibrations\n"
+                                        << "Configured " << calibrations_.size() << " calibration(s) "
+                                        << "for algorithm not supporting it.";
     }
   }
 
@@ -475,48 +400,36 @@ AlignmentProducerBase::initAlignmentAlgorithm(const edm::EventSetup& setup,
 
   applyAlignmentsToGeometry();
 
-  if (!isTrueUpdate) {                // only needed the first time
-    for (const auto& iCal: calibrations_) {
+  if (!isTrueUpdate) {  // only needed the first time
+    for (const auto& iCal : calibrations_) {
       iCal->beginOfJob(alignableTracker_, alignableMuon_, alignableExtras_);
     }
-    for (const auto& monitor: monitors_) {
-     monitor->beginOfJob(alignableTracker_, alignableMuon_, alignmentParameterStore_);
+    for (const auto& monitor : monitors_) {
+      monitor->beginOfJob(alignableTracker_, alignableMuon_, alignmentParameterStore_);
     }
   }
-  startProcessing();            // needed if derived class is non-EDLooper-based
-                                // has no effect, if called during loop
+  startProcessing();  // needed if derived class is non-EDLooper-based
+                      // has no effect, if called during loop
 
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::initAlignmentAlgorithm"
-    << "End";
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::initAlignmentAlgorithm"
+                            << "End";
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::initBeamSpot(const edm::Event& event)
-{
+void AlignmentProducerBase::initBeamSpot(const edm::Event& event) {
   getBeamSpot(event, beamSpot_);
 
-  if (nevent_== 0 && alignableExtras_) {
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::initBeamSpot"
-      << "Initializing AlignableBeamSpot";
+  if (nevent_ == 0 && alignableExtras_) {
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::initBeamSpot"
+                              << "Initializing AlignableBeamSpot";
 
-    alignableExtras_->initializeBeamSpot(beamSpot_->x0(),
-                                         beamSpot_->y0(),
-                                         beamSpot_->z0(),
-                                         beamSpot_->dxdz(),
-                                         beamSpot_->dydz());
+    alignableExtras_->initializeBeamSpot(
+        beamSpot_->x0(), beamSpot_->y0(), beamSpot_->z0(), beamSpot_->dxdz(), beamSpot_->dydz());
   }
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::createGeometries(const edm::EventSetup& iSetup,
-                                        const TrackerTopology* tTopo)
-{
+void AlignmentProducerBase::createGeometries(const edm::EventSetup& iSetup, const TrackerTopology* tTopo) {
   if (doTracker_) {
     edm::ESHandle<GeometricDet> geometricDet;
     iSetup.get<IdealGeometryRecord>().get(geometricDet);
@@ -526,8 +439,7 @@ AlignmentProducerBase::createGeometries(const edm::EventSetup& iSetup,
 
     TrackerGeomBuilderFromGeometricDet trackerBuilder;
 
-    trackerGeometry_ = std::shared_ptr<TrackerGeometry>
-      (trackerBuilder.build(&(*geometricDet), *ptp, tTopo));
+    trackerGeometry_ = std::shared_ptr<TrackerGeometry>(trackerBuilder.build(&(*geometricDet), *ptp, tTopo));
   }
 
   if (doMuon_) {
@@ -540,15 +452,12 @@ AlignmentProducerBase::createGeometries(const edm::EventSetup& iSetup,
     muonDTGeometry_ = std::make_shared<DTGeometry>();
     DTGeometryBuilder.build(*muonDTGeometry_, &(*cpv), *mdc);
     muonCSCGeometry_ = std::make_shared<CSCGeometry>();
-    CSCGeometryBuilder.build(*muonCSCGeometry_, &(*cpv), *mdc );
+    CSCGeometryBuilder.build(*muonCSCGeometry_, &(*cpv), *mdc);
   }
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::applyAlignmentsToDB(const edm::EventSetup& setup)
-{
+void AlignmentProducerBase::applyAlignmentsToDB(const edm::EventSetup& setup) {
   // Retrieve and apply alignments, if requested (requires z setup)
   if (applyDbAlignment_) {
     // we need GlobalPositionRcd - and have to keep track for later removal
@@ -559,40 +468,24 @@ AlignmentProducerBase::applyAlignmentsToDB(const edm::EventSetup& setup)
     globalPositions_ = std::make_unique<Alignments>(*globalAlignments);
 
     if (doTracker_) {
-      applyDB<TrackerGeometry,
-              TrackerAlignmentRcd,
-              TrackerAlignmentErrorExtendedRcd>
-        (trackerGeometry_.get(), setup,
-         align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Tracker))
-         );
+      applyDB<TrackerGeometry, TrackerAlignmentRcd, TrackerAlignmentErrorExtendedRcd>(
+          trackerGeometry_.get(), setup, align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Tracker)));
 
-      applyDB<TrackerGeometry,
-              TrackerSurfaceDeformationRcd>(trackerGeometry_.get(), setup);
+      applyDB<TrackerGeometry, TrackerSurfaceDeformationRcd>(trackerGeometry_.get(), setup);
     }
 
     if (doMuon_) {
-      applyDB<DTGeometry,
-              DTAlignmentRcd,
-              DTAlignmentErrorExtendedRcd>
-        (muonDTGeometry_.get(), setup,
-         align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon))
-         );
+      applyDB<DTGeometry, DTAlignmentRcd, DTAlignmentErrorExtendedRcd>(
+          muonDTGeometry_.get(), setup, align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon)));
 
-      applyDB<CSCGeometry,
-              CSCAlignmentRcd,
-              CSCAlignmentErrorExtendedRcd>
-        (muonCSCGeometry_.get(), setup,
-         align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon))
-         );
+      applyDB<CSCGeometry, CSCAlignmentRcd, CSCAlignmentErrorExtendedRcd>(
+          muonCSCGeometry_.get(), setup, align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon)));
     }
   }
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::createAlignables(const TrackerTopology* tTopo, bool update)
-{
+void AlignmentProducerBase::createAlignables(const TrackerTopology* tTopo, bool update) {
   if (doTracker_) {
     if (update) {
       alignableTracker_->update(trackerGeometry_.get(), tTopo);
@@ -618,25 +511,17 @@ AlignmentProducerBase::createAlignables(const TrackerTopology* tTopo, bool updat
   }
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::buildParameterStore()
-{
+void AlignmentProducerBase::buildParameterStore() {
   // Create alignment parameter builder
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::buildParameterStore"
-    << "Creating AlignmentParameterBuilder";
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::buildParameterStore"
+                            << "Creating AlignmentParameterBuilder";
 
-  const auto& alParamBuildCfg =
-    config_.getParameter<edm::ParameterSet>("ParameterBuilder");
-  const auto& alParamStoreCfg =
-    config_.getParameter<edm::ParameterSet>("ParameterStore");
+  const auto& alParamBuildCfg = config_.getParameter<edm::ParameterSet>("ParameterBuilder");
+  const auto& alParamStoreCfg = config_.getParameter<edm::ParameterSet>("ParameterStore");
 
-  AlignmentParameterBuilder alignmentParameterBuilder{alignableTracker_,
-                                                      alignableMuon_,
-                                                      alignableExtras_,
-                                                      alParamBuildCfg};
+  AlignmentParameterBuilder alignmentParameterBuilder{
+      alignableTracker_, alignableMuon_, alignableExtras_, alParamBuildCfg};
 
   // Fix alignables if requested
   if (stNFixAlignables_ > 0) {
@@ -645,32 +530,24 @@ AlignmentProducerBase::buildParameterStore()
 
   // Get list of alignables
   const auto& alignables = alignmentParameterBuilder.alignables();
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::buildParameterStore"
-    << "got " << alignables.size() << " alignables";
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::buildParameterStore"
+                            << "got " << alignables.size() << " alignables";
 
   // Create AlignmentParameterStore
-  alignmentParameterStore_ =
-    new AlignmentParameterStore(alignables, alParamStoreCfg);
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::buildParameterStore"
-    << "AlignmentParameterStore created!";
+  alignmentParameterStore_ = new AlignmentParameterStore(alignables, alParamStoreCfg);
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::buildParameterStore"
+                            << "AlignmentParameterStore created!";
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::applyMisalignment()
-{
+void AlignmentProducerBase::applyMisalignment() {
   // Apply misalignment scenario to alignable tracker and muon if requested
   // WARNING: this assumes scenarioConfig can be passed to both muon and tracker
 
   if (doMisalignmentScenario_ && (doTracker_ || doMuon_)) {
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::applyMisalignment"
-      << "Applying misalignment scenario to "
-      << (doTracker_ ? "tracker" : "")
-      << (doMuon_    ? (doTracker_ ? " and muon" : "muon") : ".");
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::applyMisalignment"
+                              << "Applying misalignment scenario to " << (doTracker_ ? "tracker" : "")
+                              << (doMuon_ ? (doTracker_ ? " and muon" : "muon") : ".");
 
     const auto& scenarioConfig = config_.getParameterSet("MisalignmentScenario");
 
@@ -684,155 +561,137 @@ AlignmentProducerBase::applyMisalignment()
     }
 
   } else {
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::applyMisalignment"
-      << "NOT applying misalignment scenario!";
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::applyMisalignment"
+                              << "NOT applying misalignment scenario!";
   }
 
   // Apply simple misalignment
-  const auto& sParSel =
-    config_.getParameter<std::string>("parameterSelectorSimple");
-  simpleMisalignment(alignmentParameterStore_->alignables(), sParSel,
-                     stRandomShift_, stRandomRotation_, true);
+  const auto& sParSel = config_.getParameter<std::string>("parameterSelectorSimple");
+  simpleMisalignment(alignmentParameterStore_->alignables(), sParSel, stRandomShift_, stRandomRotation_, true);
 }
 
-
 // ----------------------------------------------------------------------------
-void
-AlignmentProducerBase::simpleMisalignment(const align::Alignables &alivec,
-                                          const std::string &selection,
-                                          float shift, float rot, bool local)
-{
-
-  std::ostringstream output; // collecting output
+void AlignmentProducerBase::simpleMisalignment(
+    const align::Alignables& alivec, const std::string& selection, float shift, float rot, bool local) {
+  std::ostringstream output;  // collecting output
 
   if (shift > 0. || rot > 0.) {
-    output << "Adding random flat shift of max size " << shift
-           << " and adding random flat rotation of max size " << rot <<" to ";
+    output << "Adding random flat shift of max size " << shift << " and adding random flat rotation of max size " << rot
+           << " to ";
 
     std::vector<bool> commSel(0);
     if (selection != "-1") {
-      AlignmentParameterSelector aSelector(nullptr,nullptr); // no alignable needed here...
+      AlignmentParameterSelector aSelector(nullptr, nullptr);  // no alignable needed here...
       const std::vector<char> cSel(aSelector.convertParamSel(selection));
       if (cSel.size() < RigidBodyAlignmentParameters::N_PARAM) {
         throw cms::Exception("BadConfig")
-          << "[AlignmentProducerBase::simpleMisalignment_]\n"
-          << "Expect selection string '" << selection << "' to be at least of length "
-          << RigidBodyAlignmentParameters::N_PARAM << " or to be '-1'.\n"
-          << "(Most probably you have to adjust the parameter 'parameterSelectorSimple'.)";
+            << "[AlignmentProducerBase::simpleMisalignment_]\n"
+            << "Expect selection string '" << selection << "' to be at least of length "
+            << RigidBodyAlignmentParameters::N_PARAM << " or to be '-1'.\n"
+            << "(Most probably you have to adjust the parameter 'parameterSelectorSimple'.)";
       }
-      for (const auto& cIter: cSel) {
+      for (const auto& cIter : cSel) {
         commSel.push_back(cIter == '0' ? false : true);
       }
-      output << "parameters defined by (" << selection
-             << "), representing (x,y,z,alpha,beta,gamma),";
+      output << "parameters defined by (" << selection << "), representing (x,y,z,alpha,beta,gamma),";
     } else {
       output << "the active parameters of each alignable,";
     }
     output << " in " << (local ? "local" : "global") << " frame.";
 
-    for (const auto& ali: alivec) {
+    for (const auto& ali : alivec) {
       std::vector<bool> mysel(commSel.empty() ? ali->alignmentParameters()->selector() : commSel);
 
-      if (std::abs(shift)>0.00001) {
+      if (std::abs(shift) > 0.00001) {
         double s0 = 0., s1 = 0., s2 = 0.;
-        if (mysel[RigidBodyAlignmentParameters::dx]) s0 = shift * double(random()%1000-500)/500.;
-        if (mysel[RigidBodyAlignmentParameters::dy]) s1 = shift * double(random()%1000-500)/500.;
-        if (mysel[RigidBodyAlignmentParameters::dz]) s2 = shift * double(random()%1000-500)/500.;
+        if (mysel[RigidBodyAlignmentParameters::dx])
+          s0 = shift * double(random() % 1000 - 500) / 500.;
+        if (mysel[RigidBodyAlignmentParameters::dy])
+          s1 = shift * double(random() % 1000 - 500) / 500.;
+        if (mysel[RigidBodyAlignmentParameters::dz])
+          s2 = shift * double(random() % 1000 - 500) / 500.;
 
-        if (local) ali->move(ali->surface().toGlobal(align::LocalVector(s0,s1,s2)));
-        else       ali->move(align::GlobalVector(s0,s1,s2));
+        if (local)
+          ali->move(ali->surface().toGlobal(align::LocalVector(s0, s1, s2)));
+        else
+          ali->move(align::GlobalVector(s0, s1, s2));
 
         //AlignmentPositionError ape(dx,dy,dz);
         //ali->addAlignmentPositionError(ape);
       }
 
-      if (std::abs(rot)>0.00001) {
+      if (std::abs(rot) > 0.00001) {
         align::EulerAngles r(3);
-        if (mysel[RigidBodyAlignmentParameters::dalpha]) r(1)=rot*double(random()%1000-500)/500.;
-        if (mysel[RigidBodyAlignmentParameters::dbeta])  r(2)=rot*double(random()%1000-500)/500.;
-        if (mysel[RigidBodyAlignmentParameters::dgamma]) r(3)=rot*double(random()%1000-500)/500.;
+        if (mysel[RigidBodyAlignmentParameters::dalpha])
+          r(1) = rot * double(random() % 1000 - 500) / 500.;
+        if (mysel[RigidBodyAlignmentParameters::dbeta])
+          r(2) = rot * double(random() % 1000 - 500) / 500.;
+        if (mysel[RigidBodyAlignmentParameters::dgamma])
+          r(3) = rot * double(random() % 1000 - 500) / 500.;
 
         const align::RotationType mrot = align::toMatrix(r);
-        if (local) ali->rotateInLocalFrame(mrot);
-        else       ali->rotateInGlobalFrame(mrot);
+        if (local)
+          ali->rotateInLocalFrame(mrot);
+        else
+          ali->rotateInGlobalFrame(mrot);
 
         //ali->addAlignmentPositionErrorFromRotation(mrot);
       }
-    } // end loop on alignables
+    }  // end loop on alignables
   } else {
     output << "No simple misalignment added!";
   }
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::simpleMisalignment" << output.str();
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::simpleMisalignment" << output.str();
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::applyAlignmentsToGeometry()
-{
-  edm::LogInfo("Alignment")
-    << "@SUB=AlignmentProducerBase::applyAlignmentsToGeometry"
-    << "Now physically apply alignments to  geometry...";
+void AlignmentProducerBase::applyAlignmentsToGeometry() {
+  edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::applyAlignmentsToGeometry"
+                            << "Now physically apply alignments to  geometry...";
 
   // Propagate changes to reconstruction geometry (from initialisation or iteration)
   GeometryAligner aligner;
 
   if (doTracker_) {
     if (!alignableTracker_) {
-      throw cms::Exception("LogicError")
-        << "@SUB=AlignmentProducerBase::applyAlignmentsToGeometry\n"
-        << "Trying to apply tracker alignment before creating it.";
+      throw cms::Exception("LogicError") << "@SUB=AlignmentProducerBase::applyAlignmentsToGeometry\n"
+                                         << "Trying to apply tracker alignment before creating it.";
     }
 
     std::unique_ptr<Alignments> alignments{alignableTracker_->alignments()};
-    std::unique_ptr<AlignmentErrorsExtended>
-      alignmentErrExt{alignableTracker_->alignmentErrors()};
-    std::unique_ptr<AlignmentSurfaceDeformations>
-      aliDeforms{alignableTracker_->surfaceDeformations()};
+    std::unique_ptr<AlignmentErrorsExtended> alignmentErrExt{alignableTracker_->alignmentErrors()};
+    std::unique_ptr<AlignmentSurfaceDeformations> aliDeforms{alignableTracker_->surfaceDeformations()};
 
-    aligner.applyAlignments(trackerGeometry_.get(), alignments.get(),
-                            alignmentErrExt.get(), AlignTransform());
+    aligner.applyAlignments(trackerGeometry_.get(), alignments.get(), alignmentErrExt.get(), AlignTransform());
     aligner.attachSurfaceDeformations(trackerGeometry_.get(), aliDeforms.get());
   }
 
   if (doMuon_) {
     if (!alignableMuon_) {
-      throw cms::Exception("LogicError")
-        << "@SUB=AlignmentProducerBase::applyAlignmentsToGeometry\n"
-        << "Trying to apply muon alignment before creating it.";
+      throw cms::Exception("LogicError") << "@SUB=AlignmentProducerBase::applyAlignmentsToGeometry\n"
+                                         << "Trying to apply muon alignment before creating it.";
     }
 
     std::unique_ptr<Alignments> dtAlignments{alignableMuon_->dtAlignments()};
     std::unique_ptr<Alignments> cscAlignments{alignableMuon_->cscAlignments()};
 
-    std::unique_ptr<AlignmentErrorsExtended>
-      dtAlignmentErrExt{alignableMuon_->dtAlignmentErrorsExtended()};
-    std::unique_ptr<AlignmentErrorsExtended>
-      cscAlignmentErrExt{alignableMuon_->cscAlignmentErrorsExtended()};
+    std::unique_ptr<AlignmentErrorsExtended> dtAlignmentErrExt{alignableMuon_->dtAlignmentErrorsExtended()};
+    std::unique_ptr<AlignmentErrorsExtended> cscAlignmentErrExt{alignableMuon_->cscAlignmentErrorsExtended()};
 
-    aligner.applyAlignments(muonDTGeometry_.get(), dtAlignments.get(),
-                            dtAlignmentErrExt.get(), AlignTransform());
-    aligner.applyAlignments(muonCSCGeometry_.get(), cscAlignments.get(),
-                            cscAlignmentErrExt.get(), AlignTransform());
+    aligner.applyAlignments(muonDTGeometry_.get(), dtAlignments.get(), dtAlignmentErrExt.get(), AlignTransform());
+    aligner.applyAlignments(muonCSCGeometry_.get(), cscAlignments.get(), cscAlignmentErrExt.get(), AlignTransform());
   }
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::readInSurveyRcds(const edm::EventSetup& iSetup)
-{
-
+void AlignmentProducerBase::readInSurveyRcds(const edm::EventSetup& iSetup) {
   // Get Survey Rcds and add Survey Info
-  if ( doTracker_ && useSurvey_ ){
+  if (doTracker_ && useSurvey_) {
     bool tkSurveyBool = watchTkSurveyRcd_.check(iSetup);
     bool tkSurveyErrBool = watchTkSurveyErrExtRcd_.check(iSetup);
     edm::LogInfo("Alignment") << "watcher tksurveyrcd: " << tkSurveyBool;
     edm::LogInfo("Alignment") << "watcher tksurveyerrrcd: " << tkSurveyErrBool;
-    if ( tkSurveyBool || tkSurveyErrBool){
-
+    if (tkSurveyBool || tkSurveyErrBool) {
       edm::LogInfo("Alignment") << "ADDING THE SURVEY INFORMATION";
       edm::ESHandle<Alignments> surveys;
       edm::ESHandle<SurveyErrors> surveyErrors;
@@ -840,20 +699,20 @@ AlignmentProducerBase::readInSurveyRcds(const edm::EventSetup& iSetup)
       iSetup.get<TrackerSurveyRcd>().get(surveys);
       iSetup.get<TrackerSurveyErrorExtendedRcd>().get(surveyErrors);
 
-      surveyIndex_  = 0;
+      surveyIndex_ = 0;
       surveyValues_ = &*surveys;
       surveyErrors_ = &*surveyErrors;
       addSurveyInfo(alignableTracker_);
     }
   }
 
-  if ( doMuon_ && useSurvey_) {
+  if (doMuon_ && useSurvey_) {
     bool DTSurveyBool = watchTkSurveyRcd_.check(iSetup);
     bool DTSurveyErrBool = watchTkSurveyErrExtRcd_.check(iSetup);
     bool CSCSurveyBool = watchTkSurveyRcd_.check(iSetup);
     bool CSCSurveyErrBool = watchTkSurveyErrExtRcd_.check(iSetup);
 
-    if ( DTSurveyBool || DTSurveyErrBool || CSCSurveyBool || CSCSurveyErrBool ){
+    if (DTSurveyBool || DTSurveyErrBool || CSCSurveyBool || CSCSurveyErrBool) {
       edm::ESHandle<Alignments> dtSurveys;
       edm::ESHandle<SurveyErrors> dtSurveyErrors;
       edm::ESHandle<Alignments> cscSurveys;
@@ -864,48 +723,42 @@ AlignmentProducerBase::readInSurveyRcds(const edm::EventSetup& iSetup)
       iSetup.get<CSCSurveyRcd>().get(cscSurveys);
       iSetup.get<CSCSurveyErrorExtendedRcd>().get(cscSurveyErrors);
 
-      surveyIndex_  = 0;
+      surveyIndex_ = 0;
       surveyValues_ = &*dtSurveys;
       surveyErrors_ = &*dtSurveyErrors;
       const auto& barrels = alignableMuon_->DTBarrel();
-      for (const auto& barrel: barrels) addSurveyInfo(barrel);
+      for (const auto& barrel : barrels)
+        addSurveyInfo(barrel);
 
-      surveyIndex_  = 0;
+      surveyIndex_ = 0;
       surveyValues_ = &*cscSurveys;
       surveyErrors_ = &*cscSurveyErrors;
       const auto& endcaps = alignableMuon_->CSCEndcaps();
-      for (const auto& endcap: endcaps) addSurveyInfo(endcap);
-
+      for (const auto& endcap : endcaps)
+        addSurveyInfo(endcap);
     }
   }
-
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::addSurveyInfo(Alignable* ali)
-{
+void AlignmentProducerBase::addSurveyInfo(Alignable* ali) {
   const auto& comps = ali->components();
 
-  for (const auto& comp: comps) addSurveyInfo(comp);
+  for (const auto& comp : comps)
+    addSurveyInfo(comp);
 
   const SurveyError& error = surveyErrors_->m_surveyErrors[surveyIndex_];
 
-  if ( ali->id() != error.rawId() ||
-       ali->alignableObjectId() != error.structureType() )
-    {
-      throw cms::Exception("DatabaseError")
-        << "Error reading survey info from DB. Mismatched id!";
-    }
+  if (ali->id() != error.rawId() || ali->alignableObjectId() != error.structureType()) {
+    throw cms::Exception("DatabaseError") << "Error reading survey info from DB. Mismatched id!";
+  }
 
   const auto& pos = surveyValues_->m_align[surveyIndex_].translation();
   const auto& rot = surveyValues_->m_align[surveyIndex_].rotation();
 
-  AlignableSurface surf(align::PositionType(pos.x(), pos.y(), pos.z()),
-                        align::RotationType(rot.xx(), rot.xy(), rot.xz(),
-                                            rot.yx(), rot.yy(), rot.yz(),
-                                            rot.zx(), rot.zy(), rot.zz()));
+  AlignableSurface surf(
+      align::PositionType(pos.x(), pos.y(), pos.z()),
+      align::RotationType(rot.xx(), rot.xy(), rot.xz(), rot.yx(), rot.yy(), rot.yz(), rot.zx(), rot.zy(), rot.zz()));
 
   surf.setWidth(ali->surface().width());
   surf.setLength(ali->surface().length());
@@ -915,51 +768,42 @@ AlignmentProducerBase::addSurveyInfo(Alignable* ali)
   ++surveyIndex_;
 }
 
-
 //------------------------------------------------------------------------------
-bool
-AlignmentProducerBase::finish()
-{
-
-  for (const auto& monitor: monitors_) monitor->endOfJob();
+bool AlignmentProducerBase::finish() {
+  for (const auto& monitor : monitors_)
+    monitor->endOfJob();
 
   if (alignmentAlgo_->processesEvents() && nevent_ == 0) {
     return false;
   }
 
   if (saveToDB_ || saveApeToDB_ || saveDeformationsToDB_) {
-    if (alignmentAlgo_->storeAlignments()) storeAlignmentsToDB();
+    if (alignmentAlgo_->storeAlignments())
+      storeAlignmentsToDB();
   } else {
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::finish"
-      << "No payload to be stored!";
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::finish"
+                              << "No payload to be stored!";
   }
 
   // takes care of storing output of calibrations, but needs to be called only
   // after 'storeAlignmentsToDB()'
-  for (const auto& iCal:calibrations_) iCal->endOfJob();
+  for (const auto& iCal : calibrations_)
+    iCal->endOfJob();
 
   return true;
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::storeAlignmentsToDB()
-{
-  const auto runRangeSelectionVPSet =
-    config_.getParameterSetVector("RunRangeSelection");
+void AlignmentProducerBase::storeAlignmentsToDB() {
+  const auto runRangeSelectionVPSet = config_.getParameterSetVector("RunRangeSelection");
 
   // handle PCL use case
   const auto& uniqueRunRanges =
-    (runAtPCL_ ?
-     align::makeUniqueRunRanges(runRangeSelectionVPSet, firstRun_) :
-     uniqueRunRanges_);
+      (runAtPCL_ ? align::makeUniqueRunRanges(runRangeSelectionVPSet, firstRun_) : uniqueRunRanges_);
 
   std::vector<AlgebraicVector> beamSpotParameters;
 
-  for (const auto& iRunRange: uniqueRunRanges) {
-
+  for (const auto& iRunRange : uniqueRunRanges) {
     alignmentAlgo_->setParametersForRunRange(iRunRange);
 
     // Save alignments to database
@@ -971,13 +815,11 @@ AlignmentProducerBase::storeAlignmentsToDB()
     if (alignableExtras_) {
       auto& alis = alignableExtras_->beamSpot();
       if (!alis.empty()) {
-        auto beamSpotAliPars =
-          dynamic_cast<BeamSpotAlignmentParameters*>(alis[0]->alignmentParameters());
+        auto beamSpotAliPars = dynamic_cast<BeamSpotAlignmentParameters*>(alis[0]->alignmentParameters());
         if (!beamSpotAliPars) {
-          throw cms::Exception("LogicError")
-            << "@SUB=AlignmentProducerBase::storeAlignmentsToDB\n"
-            << "First alignable of alignableExtras_ does not have "
-            << "'BeamSpotAlignmentParameters', while it should have.";
+          throw cms::Exception("LogicError") << "@SUB=AlignmentProducerBase::storeAlignmentsToDB\n"
+                                             << "First alignable of alignableExtras_ does not have "
+                                             << "'BeamSpotAlignmentParameters', while it should have.";
         }
 
         beamSpotParameters.push_back(beamSpotAliPars->parameters());
@@ -989,37 +831,30 @@ AlignmentProducerBase::storeAlignmentsToDB()
     std::ostringstream bsOutput;
 
     auto itPar = beamSpotParameters.cbegin();
-    for (auto iRunRange = uniqueRunRanges.cbegin();
-         iRunRange != uniqueRunRanges.cend();
-         ++iRunRange, ++itPar) {
+    for (auto iRunRange = uniqueRunRanges.cbegin(); iRunRange != uniqueRunRanges.cend(); ++iRunRange, ++itPar) {
       bsOutput << "Run range: " << (*iRunRange).first << " - " << (*iRunRange).second << "\n";
       bsOutput << "  Displacement: x=" << (*itPar)[0] << ", y=" << (*itPar)[1] << "\n";
       bsOutput << "  Slope: dx/dz=" << (*itPar)[2] << ", dy/dz=" << (*itPar)[3] << "\n";
     }
 
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::storeAlignmentsToDB"
-      << "Parameters for alignable beamspot:\n" << bsOutput.str();
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::storeAlignmentsToDB"
+                              << "Parameters for alignable beamspot:\n"
+                              << bsOutput.str();
   }
 }
 
-
 //------------------------------------------------------------------------------
-void
-AlignmentProducerBase::writeForRunRange(cond::Time_t time)
-{
-  if (doTracker_) { // first tracker
-    const AlignTransform* trackerGlobal{nullptr}; // will be 'removed' from constants
-    if (globalPositions_) { // i.e. applied before in applyDB
-      trackerGlobal = &align::DetectorGlobalPosition(*globalPositions_,
-                                                     DetId(DetId::Tracker));
+void AlignmentProducerBase::writeForRunRange(cond::Time_t time) {
+  if (doTracker_) {                                // first tracker
+    const AlignTransform* trackerGlobal{nullptr};  // will be 'removed' from constants
+    if (globalPositions_) {                        // i.e. applied before in applyDB
+      trackerGlobal = &align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Tracker));
     }
 
     auto alignments = alignableTracker_->alignments();
     auto alignmentErrors = alignableTracker_->alignmentErrors();
-    this->writeDB(alignments, "TrackerAlignmentRcd",
-                  alignmentErrors, "TrackerAlignmentErrorExtendedRcd", trackerGlobal,
-                  time);
+    this->writeDB(
+        alignments, "TrackerAlignmentRcd", alignmentErrors, "TrackerAlignmentErrorExtendedRcd", trackerGlobal, time);
 
     // Save surface deformations to database
     if (saveDeformationsToDB_) {
@@ -1028,28 +863,22 @@ AlignmentProducerBase::writeForRunRange(cond::Time_t time)
     }
   }
 
-  if (doMuon_) { // now muon
-    const AlignTransform* muonGlobal{nullptr}; // will be 'removed' from constants
-    if (globalPositions_) { // i.e. applied before in applyDB
-      muonGlobal = &align::DetectorGlobalPosition(*globalPositions_,
-                                                  DetId(DetId::Muon));
+  if (doMuon_) {                                // now muon
+    const AlignTransform* muonGlobal{nullptr};  // will be 'removed' from constants
+    if (globalPositions_) {                     // i.e. applied before in applyDB
+      muonGlobal = &align::DetectorGlobalPosition(*globalPositions_, DetId(DetId::Muon));
     }
     // Get alignments+errors, first DT - ownership taken over by writeDB(..), so no delete
     auto alignments = alignableMuon_->dtAlignments();
     auto alignmentErrors = alignableMuon_->dtAlignmentErrorsExtended();
-    this->writeDB(alignments, "DTAlignmentRcd",
-                  alignmentErrors, "DTAlignmentErrorExtendedRcd", muonGlobal,
-                  time);
+    this->writeDB(alignments, "DTAlignmentRcd", alignmentErrors, "DTAlignmentErrorExtendedRcd", muonGlobal, time);
 
     // Get alignments+errors, now CSC - ownership taken over by writeDB(..), so no delete
     alignments = alignableMuon_->cscAlignments();
     alignmentErrors = alignableMuon_->cscAlignmentErrorsExtended();
-    this->writeDB(alignments, "CSCAlignmentRcd",
-                  alignmentErrors, "CSCAlignmentErrorExtendedRcd", muonGlobal,
-                  time);
+    this->writeDB(alignments, "CSCAlignmentRcd", alignmentErrors, "CSCAlignmentErrorExtendedRcd", muonGlobal, time);
   }
 }
-
 
 //------------------------------------------------------------------------------
 void AlignmentProducerBase::writeDB(Alignments* alignments,
@@ -1057,86 +886,73 @@ void AlignmentProducerBase::writeDB(Alignments* alignments,
                                     AlignmentErrorsExtended* alignmentErrors,
                                     const std::string& errRcd,
                                     const AlignTransform* globalCoordinates,
-                                    cond::Time_t time) const
-{
+                                    cond::Time_t time) const {
   Alignments* tempAlignments = alignments;
   AlignmentErrorsExtended* tempAlignmentErrorsExtended = alignmentErrors;
 
   // Call service
   edm::Service<cond::service::PoolDBOutputService> poolDb;
-  if (!poolDb.isAvailable()) { // Die if not available
-    delete tempAlignments;      // promised to take over ownership...
-    delete tempAlignmentErrorsExtended; // dito
+  if (!poolDb.isAvailable()) {           // Die if not available
+    delete tempAlignments;               // promised to take over ownership...
+    delete tempAlignmentErrorsExtended;  // dito
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
   }
 
   if (globalCoordinates  // happens only if (applyDbAlignment_ == true)
       && globalCoordinates->transform() != AlignTransform::Transform::Identity) {
-
-    tempAlignments = new Alignments();            // temporary storage for
+    tempAlignments = new Alignments();                            // temporary storage for
     tempAlignmentErrorsExtended = new AlignmentErrorsExtended();  // final alignments and errors
 
     GeometryAligner aligner;
-    aligner.removeGlobalTransform(alignments, alignmentErrors,
-                                  *globalCoordinates,
-                                  tempAlignments, tempAlignmentErrorsExtended);
+    aligner.removeGlobalTransform(
+        alignments, alignmentErrors, *globalCoordinates, tempAlignments, tempAlignmentErrorsExtended);
 
     delete alignments;       // have to delete original alignments
     delete alignmentErrors;  // same thing for the errors
 
-    edm::LogInfo("Alignment")
-      << "@SUB=AlignmentProducerBase::writeDB"
-      << "globalCoordinates removed from alignments (" << alignRcd
-      << ") and errors (" << alignRcd << ").";
+    edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::writeDB"
+                              << "globalCoordinates removed from alignments (" << alignRcd << ") and errors ("
+                              << alignRcd << ").";
   }
 
   if (saveToDB_) {
-    edm::LogInfo("Alignment") << "Writing Alignments for run " << time
-                              << " to " << alignRcd << ".";
+    edm::LogInfo("Alignment") << "Writing Alignments for run " << time << " to " << alignRcd << ".";
     poolDb->writeOne<Alignments>(tempAlignments, time, alignRcd);
-  } else { // poolDb->writeOne(..) takes over 'alignments' ownership,...
-    delete tempAlignments; // ...otherwise we have to delete, as promised!
+  } else {                  // poolDb->writeOne(..) takes over 'alignments' ownership,...
+    delete tempAlignments;  // ...otherwise we have to delete, as promised!
   }
 
   if (saveApeToDB_) {
-    edm::LogInfo("Alignment") << "Writing AlignmentErrorsExtended for run " << time
-                              << " to " << errRcd << ".";
+    edm::LogInfo("Alignment") << "Writing AlignmentErrorsExtended for run " << time << " to " << errRcd << ".";
     poolDb->writeOne<AlignmentErrorsExtended>(tempAlignmentErrorsExtended, time, errRcd);
-  } else { // poolDb->writeOne(..) takes over 'alignmentErrors' ownership,...
-    delete tempAlignmentErrorsExtended; // ...otherwise we have to delete, as promised!
+  } else {                               // poolDb->writeOne(..) takes over 'alignmentErrors' ownership,...
+    delete tempAlignmentErrorsExtended;  // ...otherwise we have to delete, as promised!
   }
 }
-
 
 //------------------------------------------------------------------------------
 void AlignmentProducerBase::writeDB(AlignmentSurfaceDeformations* alignmentSurfaceDeformations,
                                     const std::string& surfaceDeformationRcd,
-                                    cond::Time_t time) const
-{
+                                    cond::Time_t time) const {
   // Call service
   edm::Service<cond::service::PoolDBOutputService> poolDb;
-  if (!poolDb.isAvailable()) { // Die if not available
-    delete alignmentSurfaceDeformations; // promised to take over ownership...
+  if (!poolDb.isAvailable()) {            // Die if not available
+    delete alignmentSurfaceDeformations;  // promised to take over ownership...
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
   }
 
   if (saveDeformationsToDB_) {
-    edm::LogInfo("Alignment") << "Writing AlignmentSurfaceDeformations for run " << time
-                              << " to " << surfaceDeformationRcd  << ".";
-    poolDb->writeOne<AlignmentSurfaceDeformations>(alignmentSurfaceDeformations, time,
-                                                   surfaceDeformationRcd);
-  } else { // poolDb->writeOne(..) takes over 'surfaceDeformation' ownership,...
-    delete alignmentSurfaceDeformations; // ...otherwise we have to delete, as promised!
+    edm::LogInfo("Alignment") << "Writing AlignmentSurfaceDeformations for run " << time << " to "
+                              << surfaceDeformationRcd << ".";
+    poolDb->writeOne<AlignmentSurfaceDeformations>(alignmentSurfaceDeformations, time, surfaceDeformationRcd);
+  } else {                                // poolDb->writeOne(..) takes over 'surfaceDeformation' ownership,...
+    delete alignmentSurfaceDeformations;  // ...otherwise we have to delete, as promised!
   }
 }
 
-
 //------------------------------------------------------------------------------
-template<typename T>
-bool
-AlignmentProducerBase::hasParameter(const edm::ParameterSet& config,
-                                    const std::string& name)
-{
+template <typename T>
+bool AlignmentProducerBase::hasParameter(const edm::ParameterSet& config, const std::string& name) {
   try {
     config.getParameter<T>(name);
   } catch (const edm::Exception& e) {

--- a/Alignment/CommonAlignmentProducer/src/AlignmentSeedSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentSeedSelector.cc
@@ -4,38 +4,30 @@
 
 // constructor ----------------------------------------------------------------
 
-AlignmentSeedSelector::AlignmentSeedSelector(const edm::ParameterSet & cfg) :
-  applySeedNumber( cfg.getParameter<bool>( "applySeedNumber" ) ),
-  minNSeeds ( cfg.getParameter<int>( "minNSeeds" ) ),
-  maxNSeeds ( cfg.getParameter<int>( "maxNSeeds" ) )
-{
-
+AlignmentSeedSelector::AlignmentSeedSelector(const edm::ParameterSet& cfg)
+    : applySeedNumber(cfg.getParameter<bool>("applySeedNumber")),
+      minNSeeds(cfg.getParameter<int>("minNSeeds")),
+      maxNSeeds(cfg.getParameter<int>("maxNSeeds")) {
   if (applySeedNumber)
-	edm::LogInfo("AlignmentSeedSelector") 
-	  << "apply seedNumber N<=" << minNSeeds;
-
+    edm::LogInfo("AlignmentSeedSelector") << "apply seedNumber N<=" << minNSeeds;
 }
 
 // destructor -----------------------------------------------------------------
 
-AlignmentSeedSelector::~AlignmentSeedSelector()
-{}
-
+AlignmentSeedSelector::~AlignmentSeedSelector() {}
 
 // do selection ---------------------------------------------------------------
 
-AlignmentSeedSelector::Seeds 
-AlignmentSeedSelector::select(const Seeds& seeds, const edm::Event& evt) const 
-{
+AlignmentSeedSelector::Seeds AlignmentSeedSelector::select(const Seeds& seeds, const edm::Event& evt) const {
   Seeds result = seeds;
 
   // apply minimum/maximum multiplicity requirement (if selected)
   if (applySeedNumber) {
-    if (result.size()<(unsigned int)minNSeeds || result.size()>(unsigned int)maxNSeeds ) result.clear();
+    if (result.size() < (unsigned int)minNSeeds || result.size() > (unsigned int)maxNSeeds)
+      result.clear();
   }
 
   return result;
-
 }
 
 // make basic cuts ------------------------------------------------------------

--- a/Alignment/CommonAlignmentProducer/src/AlignmentTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentTrackSelector.cc
@@ -30,298 +30,285 @@ const int kFPIX = PixelSubdetector::PixelEndcap;
 
 // constructor ----------------------------------------------------------------
 
-AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC) :
-  applyBasicCuts_( cfg.getParameter<bool>( "applyBasicCuts" ) ),
-  applyNHighestPt_( cfg.getParameter<bool>( "applyNHighestPt" ) ),
-  applyMultiplicityFilter_( cfg.getParameter<bool>( "applyMultiplicityFilter" ) ),
-  seedOnlyFromAbove_( cfg.getParameter<int>( "seedOnlyFrom" ) ),
-  applyIsolation_( cfg.getParameter<bool>( "applyIsolationCut" ) ),
-  chargeCheck_( cfg.getParameter<bool>( "applyChargeCheck" ) ),
-  nHighestPt_( cfg.getParameter<int>( "nHighestPt" ) ),
-  minMultiplicity_ ( cfg.getParameter<int>( "minMultiplicity" ) ),
-  maxMultiplicity_ ( cfg.getParameter<int>( "maxMultiplicity" ) ),
-  multiplicityOnInput_ ( cfg.getParameter<bool>( "multiplicityOnInput" ) ),
-  ptMin_( cfg.getParameter<double>( "ptMin" ) ),
-  ptMax_( cfg.getParameter<double>( "ptMax" ) ),
-  pMin_( cfg.getParameter<double>( "pMin" ) ),
-  pMax_( cfg.getParameter<double>( "pMax" ) ),
-  etaMin_( cfg.getParameter<double>( "etaMin" ) ),
-  etaMax_( cfg.getParameter<double>( "etaMax" ) ),
-  phiMin_( cfg.getParameter<double>( "phiMin" ) ),
-  phiMax_( cfg.getParameter<double>( "phiMax" ) ),
-  nHitMin_( cfg.getParameter<double>( "nHitMin" ) ),
-  nHitMax_( cfg.getParameter<double>( "nHitMax" ) ),
-  chi2nMax_( cfg.getParameter<double>( "chi2nMax" ) ),
-  d0Min_(  cfg.getParameter<double>( "d0Min" ) ),
-  d0Max_(  cfg.getParameter<double>( "d0Max" ) ),
-  dzMin_(  cfg.getParameter<double>( "dzMin" ) ),
-  dzMax_(  cfg.getParameter<double>( "dzMax" ) ),
-  theCharge_( cfg.getParameter<int>( "theCharge" ) ),
-  minHitChargeStrip_( cfg.getParameter<double>( "minHitChargeStrip" ) ),
-  minHitIsolation_( cfg.getParameter<double>( "minHitIsolation" ) ),
-  countStereoHitAs2D_( cfg.getParameter<bool>( "countStereoHitAs2D" ) ),
-  nHitMin2D_( cfg.getParameter<unsigned int>( "nHitMin2D" ) ),
-  // Ugly to use the same getParameter n times, but this allows const cut variables...
-  minHitsinTIB_(cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inTIB" ) ),
-  minHitsinTOB_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inTOB" ) ),
-  minHitsinTID_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inTID" ) ),
-  minHitsinTEC_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inTEC" ) ),
-  minHitsinBPIX_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inBPIX" ) ),
-  minHitsinFPIX_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inFPIX" ) ),
-  minHitsinPIX_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inPIXEL" ) ),
-  minHitsinTIDplus_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inTIDplus" ) ),
-  minHitsinTIDminus_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inTIDminus" ) ),
-  minHitsinTECplus_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inTECplus" ) ),
-  minHitsinTECminus_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inTECminus" ) ),
-  minHitsinFPIXplus_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inFPIXplus" ) ),
-  minHitsinFPIXminus_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inFPIXminus" ) ),
-  minHitsinENDCAP_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inENDCAP" ) ),
-  minHitsinENDCAPplus_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inENDCAPplus" ) ),
-  minHitsinENDCAPminus_ (cfg.getParameter<edm::ParameterSet>( "minHitsPerSubDet" ).getParameter<int>( "inENDCAPminus" ) ),
-  maxHitDiffEndcaps_( cfg.getParameter<double>( "maxHitDiffEndcaps" ) ),
-  nLostHitMax_( cfg.getParameter<double>( "nLostHitMax" ) ),
-  RorZofFirstHitMin_( cfg.getParameter<std::vector<double> >( "RorZofFirstHitMin" ) ),
-  RorZofFirstHitMax_( cfg.getParameter<std::vector<double> >( "RorZofFirstHitMax" ) ),
-  RorZofLastHitMin_( cfg.getParameter<std::vector<double> >( "RorZofLastHitMin" ) ),
-  RorZofLastHitMax_( cfg.getParameter<std::vector<double> >( "RorZofLastHitMax" ) ),
-  clusterValueMapTag_(cfg.getParameter<edm::InputTag>("hitPrescaleMapTag")),
-  minPrescaledHits_( cfg.getParameter<int>("minPrescaledHits")),
-  applyPrescaledHitsFilter_(!clusterValueMapTag_.encode().empty() && minPrescaledHits_ > 0)
-{
-  if(applyIsolation_) {
+AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
+    : applyBasicCuts_(cfg.getParameter<bool>("applyBasicCuts")),
+      applyNHighestPt_(cfg.getParameter<bool>("applyNHighestPt")),
+      applyMultiplicityFilter_(cfg.getParameter<bool>("applyMultiplicityFilter")),
+      seedOnlyFromAbove_(cfg.getParameter<int>("seedOnlyFrom")),
+      applyIsolation_(cfg.getParameter<bool>("applyIsolationCut")),
+      chargeCheck_(cfg.getParameter<bool>("applyChargeCheck")),
+      nHighestPt_(cfg.getParameter<int>("nHighestPt")),
+      minMultiplicity_(cfg.getParameter<int>("minMultiplicity")),
+      maxMultiplicity_(cfg.getParameter<int>("maxMultiplicity")),
+      multiplicityOnInput_(cfg.getParameter<bool>("multiplicityOnInput")),
+      ptMin_(cfg.getParameter<double>("ptMin")),
+      ptMax_(cfg.getParameter<double>("ptMax")),
+      pMin_(cfg.getParameter<double>("pMin")),
+      pMax_(cfg.getParameter<double>("pMax")),
+      etaMin_(cfg.getParameter<double>("etaMin")),
+      etaMax_(cfg.getParameter<double>("etaMax")),
+      phiMin_(cfg.getParameter<double>("phiMin")),
+      phiMax_(cfg.getParameter<double>("phiMax")),
+      nHitMin_(cfg.getParameter<double>("nHitMin")),
+      nHitMax_(cfg.getParameter<double>("nHitMax")),
+      chi2nMax_(cfg.getParameter<double>("chi2nMax")),
+      d0Min_(cfg.getParameter<double>("d0Min")),
+      d0Max_(cfg.getParameter<double>("d0Max")),
+      dzMin_(cfg.getParameter<double>("dzMin")),
+      dzMax_(cfg.getParameter<double>("dzMax")),
+      theCharge_(cfg.getParameter<int>("theCharge")),
+      minHitChargeStrip_(cfg.getParameter<double>("minHitChargeStrip")),
+      minHitIsolation_(cfg.getParameter<double>("minHitIsolation")),
+      countStereoHitAs2D_(cfg.getParameter<bool>("countStereoHitAs2D")),
+      nHitMin2D_(cfg.getParameter<unsigned int>("nHitMin2D")),
+      // Ugly to use the same getParameter n times, but this allows const cut variables...
+      minHitsinTIB_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTIB")),
+      minHitsinTOB_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTOB")),
+      minHitsinTID_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTID")),
+      minHitsinTEC_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTEC")),
+      minHitsinBPIX_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inBPIX")),
+      minHitsinFPIX_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inFPIX")),
+      minHitsinPIX_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inPIXEL")),
+      minHitsinTIDplus_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTIDplus")),
+      minHitsinTIDminus_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTIDminus")),
+      minHitsinTECplus_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTECplus")),
+      minHitsinTECminus_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inTECminus")),
+      minHitsinFPIXplus_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inFPIXplus")),
+      minHitsinFPIXminus_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inFPIXminus")),
+      minHitsinENDCAP_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inENDCAP")),
+      minHitsinENDCAPplus_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inENDCAPplus")),
+      minHitsinENDCAPminus_(cfg.getParameter<edm::ParameterSet>("minHitsPerSubDet").getParameter<int>("inENDCAPminus")),
+      maxHitDiffEndcaps_(cfg.getParameter<double>("maxHitDiffEndcaps")),
+      nLostHitMax_(cfg.getParameter<double>("nLostHitMax")),
+      RorZofFirstHitMin_(cfg.getParameter<std::vector<double> >("RorZofFirstHitMin")),
+      RorZofFirstHitMax_(cfg.getParameter<std::vector<double> >("RorZofFirstHitMax")),
+      RorZofLastHitMin_(cfg.getParameter<std::vector<double> >("RorZofLastHitMin")),
+      RorZofLastHitMax_(cfg.getParameter<std::vector<double> >("RorZofLastHitMax")),
+      clusterValueMapTag_(cfg.getParameter<edm::InputTag>("hitPrescaleMapTag")),
+      minPrescaledHits_(cfg.getParameter<int>("minPrescaledHits")),
+      applyPrescaledHitsFilter_(!clusterValueMapTag_.encode().empty() && minPrescaledHits_ > 0) {
+  if (applyIsolation_) {
     rphirecHitsToken_ = iC.consumes<SiStripRecHit2DCollection>(cfg.getParameter<edm::InputTag>("rphirecHits"));
-    matchedrecHitsToken_ = iC.consumes<SiStripMatchedRecHit2DCollection>(cfg.getParameter<edm::InputTag>("matchedrecHits"));
+    matchedrecHitsToken_ =
+        iC.consumes<SiStripMatchedRecHit2DCollection>(cfg.getParameter<edm::InputTag>("matchedrecHits"));
   }
 
-  if(applyPrescaledHitsFilter_) {
+  if (applyPrescaledHitsFilter_) {
     clusterValueMapToken_ = iC.consumes<AliClusterValueMap>(clusterValueMapTag_);
   }
 
   //convert track quality from string to enum
   std::vector<std::string> trkQualityStrings(cfg.getParameter<std::vector<std::string> >("trackQualities"));
   std::string qualities;
-  if(!trkQualityStrings.empty()){
-    applyTrkQualityCheck_=true;
+  if (!trkQualityStrings.empty()) {
+    applyTrkQualityCheck_ = true;
     for (unsigned int i = 0; i < trkQualityStrings.size(); ++i) {
       (qualities += trkQualityStrings[i]) += ", ";
       trkQualities_.push_back(reco::TrackBase::qualityByName(trkQualityStrings[i]));
     }
-  }
-  else applyTrkQualityCheck_=false;
+  } else
+    applyTrkQualityCheck_ = false;
 
   std::vector<std::string> trkIterStrings(cfg.getParameter<std::vector<std::string> >("iterativeTrackingSteps"));
-  if(!trkIterStrings.empty()){
-    applyIterStepCheck_=true;
+  if (!trkIterStrings.empty()) {
+    applyIterStepCheck_ = true;
     std::string tracksteps;
     for (unsigned int i = 0; i < trkIterStrings.size(); ++i) {
       (tracksteps += trkIterStrings[i]) += ", ";
       trkSteps_.push_back(reco::TrackBase::algoByName(trkIterStrings[i]));
     }
+  } else
+    applyIterStepCheck_ = false;
+
+  if (applyBasicCuts_) {
+    edm::LogInfo("AlignmentTrackSelector")
+        << "applying basic track cuts ..."
+        << "\nptmin,ptmax:     " << ptMin_ << "," << ptMax_ << "\npmin,pmax:       " << pMin_ << "," << pMax_
+        << "\netamin,etamax:   " << etaMin_ << "," << etaMax_ << "\nphimin,phimax:   " << phiMin_ << "," << phiMax_
+        << "\nnhitmin,nhitmax: " << nHitMin_ << "," << nHitMax_ << "\nnlosthitmax:     " << nLostHitMax_
+        << "\nnhitmin2D:       " << nHitMin2D_ << (countStereoHitAs2D_ ? "," : ", not")
+        << " counting hits on SiStrip stereo modules as 2D"
+        << "\nchi2nmax:        " << chi2nMax_;
+
+    if (applyIsolation_)
+      edm::LogInfo("AlignmentTrackSelector")
+          << "only retain tracks isolated at least by " << minHitIsolation_ << " cm from other rechits";
+
+    if (chargeCheck_)
+      edm::LogInfo("AlignmentTrackSelector")
+          << "only retain hits with at least " << minHitChargeStrip_ << " ADC counts of total cluster charge";
+
+    edm::LogInfo("AlignmentTrackSelector")
+        << "Minimum number of hits in TIB/TID/TOB/TEC/BPIX/FPIX/PIXEL = " << minHitsinTIB_ << "/" << minHitsinTID_
+        << "/" << minHitsinTOB_ << "/" << minHitsinTEC_ << "/" << minHitsinBPIX_ << "/" << minHitsinFPIX_ << "/"
+        << minHitsinPIX_;
+
+    edm::LogInfo("AlignmentTrackSelector")
+        << "Minimum number of hits in TID+/TID-/TEC+/TEC-/FPIX+/FPIX- = " << minHitsinTIDplus_ << "/"
+        << minHitsinTIDminus_ << "/" << minHitsinTECplus_ << "/" << minHitsinTECminus_ << "/" << minHitsinFPIXplus_
+        << "/" << minHitsinFPIXminus_;
+
+    edm::LogInfo("AlignmentTrackSelector")
+        << "Minimum number of hits in EndCap (TID+TEC)/EndCap+/EndCap- = " << minHitsinENDCAP_ << "/"
+        << minHitsinENDCAPplus_ << "/" << minHitsinENDCAPminus_;
+
+    edm::LogInfo("AlignmentTrackSelector")
+        << "Max value of |nHitsinENDCAPplus - nHitsinENDCAPminus| = " << maxHitDiffEndcaps_;
+
+    if (!trkQualityStrings.empty()) {
+      edm::LogInfo("AlignmentTrackSelector") << "Select tracks with these qualities: " << qualities;
+    }
   }
-  else   applyIterStepCheck_=false;
 
-  if (applyBasicCuts_){
-      edm::LogInfo("AlignmentTrackSelector") 
-	<< "applying basic track cuts ..."
-	<< "\nptmin,ptmax:     " << ptMin_   << "," << ptMax_ 
-	<< "\npmin,pmax:       " << pMin_    << "," << pMax_ 
-	<< "\netamin,etamax:   " << etaMin_  << "," << etaMax_
-	<< "\nphimin,phimax:   " << phiMin_  << "," << phiMax_
-	<< "\nnhitmin,nhitmax: " << nHitMin_ << "," << nHitMax_
-	<< "\nnlosthitmax:     " << nLostHitMax_
-	<< "\nnhitmin2D:       " << nHitMin2D_
-        << (countStereoHitAs2D_ ? "," : ", not") << " counting hits on SiStrip stereo modules as 2D" 
-	<< "\nchi2nmax:        " << chi2nMax_;
-
-      if (applyIsolation_)
-	edm::LogInfo("AlignmentTrackSelector") 
-	  << "only retain tracks isolated at least by " << minHitIsolation_ << 
-	  " cm from other rechits"; 
-      
-      if (chargeCheck_)
-	edm::LogInfo("AlignmentTrackSelector") 
-	  << "only retain hits with at least " << minHitChargeStrip_ <<  
-	  " ADC counts of total cluster charge"; 
-   
-      edm::LogInfo("AlignmentTrackSelector") 
-	<< "Minimum number of hits in TIB/TID/TOB/TEC/BPIX/FPIX/PIXEL = " 
-	<< minHitsinTIB_ << "/" << minHitsinTID_ << "/" << minHitsinTOB_
-        << "/" << minHitsinTEC_ << "/" << minHitsinBPIX_ << "/" << minHitsinFPIX_ << "/" << minHitsinPIX_;
-
-      edm::LogInfo("AlignmentTrackSelector")
-        << "Minimum number of hits in TID+/TID-/TEC+/TEC-/FPIX+/FPIX- = "
-        << minHitsinTIDplus_ << "/" << minHitsinTIDminus_
-        << "/" << minHitsinTECplus_ << "/" << minHitsinTECminus_
-        << "/" << minHitsinFPIXplus_ << "/" << minHitsinFPIXminus_;
-
-      edm::LogInfo("AlignmentTrackSelector")
-        << "Minimum number of hits in EndCap (TID+TEC)/EndCap+/EndCap- = "
-        << minHitsinENDCAP_ << "/" << minHitsinENDCAPplus_ << "/" << minHitsinENDCAPminus_;
-
-      edm::LogInfo("AlignmentTrackSelector")
-	<< "Max value of |nHitsinENDCAPplus - nHitsinENDCAPminus| = "
-	<< maxHitDiffEndcaps_;
-
-      if (!trkQualityStrings.empty()) {
-	edm::LogInfo("AlignmentTrackSelector")
-	  << "Select tracks with these qualities: " << qualities;
-      }    
-  }
-  
   if (applyNHighestPt_)
-	edm::LogInfo("AlignmentTrackSelector") 
-	  << "filter N tracks with highest Pt N=" << nHighestPt_;
+    edm::LogInfo("AlignmentTrackSelector") << "filter N tracks with highest Pt N=" << nHighestPt_;
 
   if (applyMultiplicityFilter_)
-	edm::LogInfo("AlignmentTrackSelector") 
-	  << "apply multiplicity filter N>= " << minMultiplicity_ << "and N<= " << maxMultiplicity_
-          << " on " << (multiplicityOnInput_ ? "input" : "output");
+    edm::LogInfo("AlignmentTrackSelector")
+        << "apply multiplicity filter N>= " << minMultiplicity_ << "and N<= " << maxMultiplicity_ << " on "
+        << (multiplicityOnInput_ ? "input" : "output");
 
   if (applyPrescaledHitsFilter_) {
-    edm::LogInfo("AlignmentTrackSelector") 
-      << "apply cut on number of prescaled hits N>= " << minPrescaledHits_
-      << " (prescale info from " << clusterValueMapTag_ << ")";
-    
+    edm::LogInfo("AlignmentTrackSelector") << "apply cut on number of prescaled hits N>= " << minPrescaledHits_
+                                           << " (prescale info from " << clusterValueMapTag_ << ")";
   }
 
   // Checking whether cuts on positions of first and last track hits are defined properly
-  if(RorZofFirstHitMin_.size() != 2){
-      throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector" 
-	  << "Wrong configuration of 'RorZofFirstHitMin'."
-	  << " Must have exactly 2 values instead of configured " << RorZofFirstHitMin_.size() << ")";
+  if (RorZofFirstHitMin_.size() != 2) {
+    throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector"
+                                      << "Wrong configuration of 'RorZofFirstHitMin'."
+                                      << " Must have exactly 2 values instead of configured "
+                                      << RorZofFirstHitMin_.size() << ")";
   } else {
-    RorZofFirstHitMin_.at(0)=std::fabs(RorZofFirstHitMin_.at(0));
-    RorZofFirstHitMin_.at(1)=std::fabs(RorZofFirstHitMin_.at(1));
+    RorZofFirstHitMin_.at(0) = std::fabs(RorZofFirstHitMin_.at(0));
+    RorZofFirstHitMin_.at(1) = std::fabs(RorZofFirstHitMin_.at(1));
   }
-  if(RorZofFirstHitMax_.size() != 2){
-      throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector" 
-	  << "Wrong configuration of 'RorZofFirstHitMax'."
-	  << " Must have exactly 2 values instead of configured " << RorZofFirstHitMax_.size() << ")";
+  if (RorZofFirstHitMax_.size() != 2) {
+    throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector"
+                                      << "Wrong configuration of 'RorZofFirstHitMax'."
+                                      << " Must have exactly 2 values instead of configured "
+                                      << RorZofFirstHitMax_.size() << ")";
   } else {
     RorZofFirstHitMax_.at(0) = std::fabs(RorZofFirstHitMax_.at(0));
     RorZofFirstHitMax_.at(1) = std::fabs(RorZofFirstHitMax_.at(1));
   }
-  if(RorZofLastHitMin_.size() != 2){
-      throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector" 
-	  << "Wrong configuration of 'RorZofLastHitMin'."
-	  << " Must have exactly 2 values instead of configured " << RorZofLastHitMin_.size() << ")";
+  if (RorZofLastHitMin_.size() != 2) {
+    throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector"
+                                      << "Wrong configuration of 'RorZofLastHitMin'."
+                                      << " Must have exactly 2 values instead of configured "
+                                      << RorZofLastHitMin_.size() << ")";
   } else {
     RorZofLastHitMin_.at(0) = std::fabs(RorZofLastHitMin_.at(0));
     RorZofLastHitMin_.at(1) = std::fabs(RorZofLastHitMin_.at(1));
   }
-  if(RorZofLastHitMax_.size() != 2){
-      throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector" 
-	  << "Wrong configuration of 'RorZofLastHitMax'."
-	  << " Must have exactly 2 values instead of configured " << RorZofLastHitMax_.size() << ")";
+  if (RorZofLastHitMax_.size() != 2) {
+    throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector"
+                                      << "Wrong configuration of 'RorZofLastHitMax'."
+                                      << " Must have exactly 2 values instead of configured "
+                                      << RorZofLastHitMax_.size() << ")";
   } else {
     RorZofLastHitMax_.at(0) = std::fabs(RorZofLastHitMax_.at(0));
     RorZofLastHitMax_.at(1) = std::fabs(RorZofLastHitMax_.at(1));
   }
   // If first hit set to be at larger distance then the last hit
-  if(RorZofFirstHitMin_.at(0) > RorZofLastHitMax_.at(0) && RorZofFirstHitMin_.at(1) > RorZofLastHitMax_.at(1)){
-      throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector" 
-	  << "Position of the first hit is set to larger distance than the last hit:."
-	  << " First hit(min): [" << RorZofFirstHitMin_.at(0) << ", " << RorZofFirstHitMin_.at(1) << "]; Last hit(max): [" 
-	  << RorZofLastHitMax_.at(0) << ", " << RorZofLastHitMax_.at(1) << "];";
+  if (RorZofFirstHitMin_.at(0) > RorZofLastHitMax_.at(0) && RorZofFirstHitMin_.at(1) > RorZofLastHitMax_.at(1)) {
+    throw cms::Exception("BadConfig") << "@SUB=AlignmentTrackSelector::AlignmentTrackSelector"
+                                      << "Position of the first hit is set to larger distance than the last hit:."
+                                      << " First hit(min): [" << RorZofFirstHitMin_.at(0) << ", "
+                                      << RorZofFirstHitMin_.at(1) << "]; Last hit(max): [" << RorZofLastHitMax_.at(0)
+                                      << ", " << RorZofLastHitMax_.at(1) << "];";
   }
-
 }
 
 // destructor -----------------------------------------------------------------
 
-AlignmentTrackSelector::~AlignmentTrackSelector()
-{}
-
+AlignmentTrackSelector::~AlignmentTrackSelector() {}
 
 // do selection ---------------------------------------------------------------
 
-AlignmentTrackSelector::Tracks 
-AlignmentTrackSelector::select(const Tracks& tracks, const edm::Event& evt, const edm::EventSetup& eSetup) const 
-{
-  
-  if (applyMultiplicityFilter_ && multiplicityOnInput_ && 
-      (tracks.size() < static_cast<unsigned int>(minMultiplicity_) 
-       || tracks.size() > static_cast<unsigned int>(maxMultiplicity_))) {
-    return Tracks(); // empty collection
+AlignmentTrackSelector::Tracks AlignmentTrackSelector::select(const Tracks& tracks,
+                                                              const edm::Event& evt,
+                                                              const edm::EventSetup& eSetup) const {
+  if (applyMultiplicityFilter_ && multiplicityOnInput_ &&
+      (tracks.size() < static_cast<unsigned int>(minMultiplicity_) ||
+       tracks.size() > static_cast<unsigned int>(maxMultiplicity_))) {
+    return Tracks();  // empty collection
   }
 
   Tracks result = tracks;
   // apply basic track cuts (if selected)
-  if (applyBasicCuts_) result= this->basicCuts(result, evt, eSetup);
-  
+  if (applyBasicCuts_)
+    result = this->basicCuts(result, evt, eSetup);
+
   // filter N tracks with highest Pt (if selected)
-  if (applyNHighestPt_) result = this->theNHighestPtTracks(result);
-  
+  if (applyNHighestPt_)
+    result = this->theNHighestPtTracks(result);
+
   // apply minimum multiplicity requirement (if selected)
   if (applyMultiplicityFilter_ && !multiplicityOnInput_) {
-    if (result.size() < static_cast<unsigned int>(minMultiplicity_) 
-        || result.size() > static_cast<unsigned int>(maxMultiplicity_) ) {
-
+    if (result.size() < static_cast<unsigned int>(minMultiplicity_) ||
+        result.size() > static_cast<unsigned int>(maxMultiplicity_)) {
       result.clear();
     }
   }
 
-  if(applyPrescaledHitsFilter_){
+  if (applyPrescaledHitsFilter_) {
     result = this->checkPrescaledHits(result, evt);
   }
 
   return result;
 }
 
- ///returns if any of the Filters is used.
-bool AlignmentTrackSelector::useThisFilter()
-{
+///returns if any of the Filters is used.
+bool AlignmentTrackSelector::useThisFilter() {
   return applyMultiplicityFilter_ || applyBasicCuts_ || applyNHighestPt_ || applyPrescaledHitsFilter_;
-
 }
-
 
 // make basic cuts ------------------------------------------------------------
 
-AlignmentTrackSelector::Tracks 
-AlignmentTrackSelector::basicCuts(const Tracks& tracks, const edm::Event& evt, const edm::EventSetup& eSetup) const 
-{
+AlignmentTrackSelector::Tracks AlignmentTrackSelector::basicCuts(const Tracks& tracks,
+                                                                 const edm::Event& evt,
+                                                                 const edm::EventSetup& eSetup) const {
   Tracks result;
 
-  for (Tracks::const_iterator it=tracks.begin(); it != tracks.end(); ++it) {
-    const reco::Track* trackp=*it;
-    float pt=trackp->pt();
-    float p=trackp->p();
-    float eta=trackp->eta();
-    float phi=trackp->phi();
-    int nhit = trackp->numberOfValidHits(); 
-    int nlosthit = trackp->numberOfLostHits(); 
+  for (Tracks::const_iterator it = tracks.begin(); it != tracks.end(); ++it) {
+    const reco::Track* trackp = *it;
+    float pt = trackp->pt();
+    float p = trackp->p();
+    float eta = trackp->eta();
+    float phi = trackp->phi();
+    int nhit = trackp->numberOfValidHits();
+    int nlosthit = trackp->numberOfLostHits();
     float chi2n = trackp->normalizedChi2();
 
     int q = trackp->charge();
     bool isChargeOk = false;
-    if(theCharge_==-1 && q<0)         isChargeOk = true; 
-    else if (theCharge_==1 && q>0)    isChargeOk = true; 
-    else if (theCharge_==0)           isChargeOk = true; 
+    if (theCharge_ == -1 && q < 0)
+      isChargeOk = true;
+    else if (theCharge_ == 1 && q > 0)
+      isChargeOk = true;
+    else if (theCharge_ == 0)
+      isChargeOk = true;
 
-    float d0    = trackp->d0();
-    float dz    = trackp->dz();
+    float d0 = trackp->d0();
+    float dz = trackp->dz();
 
     // edm::LogDebug("AlignmentTrackSelector") << " pt,eta,phi,nhit: "
     //  <<pt<<","<<eta<<","<<phi<<","<<nhit;
 
-    if (pt>ptMin_ && pt<ptMax_ 
-       && p>pMin_ && p<pMax_ 
-       && eta>etaMin_ && eta<etaMax_ 
-       && phi>phiMin_ && phi<phiMax_ 
-       && nhit>=nHitMin_ && nhit<=nHitMax_
-       && nlosthit<=nLostHitMax_
-       && chi2n<chi2nMax_
-       && isChargeOk
-       && d0>=d0Min_ && d0<=d0Max_
-       && dz>=dzMin_ && dz<=dzMax_) {
-      bool trkQualityOk=false ;
-      if (!applyTrkQualityCheck_ &&!applyIterStepCheck_)trkQualityOk=true ; // nothing required
-      else trkQualityOk = this->isOkTrkQuality(trackp);
+    if (pt > ptMin_ && pt < ptMax_ && p > pMin_ && p < pMax_ && eta > etaMin_ && eta < etaMax_ && phi > phiMin_ &&
+        phi < phiMax_ && nhit >= nHitMin_ && nhit <= nHitMax_ && nlosthit <= nLostHitMax_ && chi2n < chi2nMax_ &&
+        isChargeOk && d0 >= d0Min_ && d0 <= d0Max_ && dz >= dzMin_ && dz <= dzMax_) {
+      bool trkQualityOk = false;
+      if (!applyTrkQualityCheck_ && !applyIterStepCheck_)
+        trkQualityOk = true;  // nothing required
+      else
+        trkQualityOk = this->isOkTrkQuality(trackp);
 
-      bool hitsCheckOk=this->detailedHitsCheck(trackp, evt, eSetup);
- 
-      if (trkQualityOk && hitsCheckOk )  result.push_back(trackp);
+      bool hitsCheckOk = this->detailedHitsCheck(trackp, evt, eSetup);
+
+      if (trkQualityOk && hitsCheckOk)
+        result.push_back(trackp);
     }
   }
 
@@ -330,9 +317,9 @@ AlignmentTrackSelector::basicCuts(const Tracks& tracks, const edm::Event& evt, c
 
 //-----------------------------------------------------------------------------
 
-bool AlignmentTrackSelector::detailedHitsCheck(const reco::Track *trackp, const edm::Event& evt, const edm::EventSetup& eSetup) const
-{
-
+bool AlignmentTrackSelector::detailedHitsCheck(const reco::Track* trackp,
+                                               const edm::Event& evt,
+                                               const edm::EventSetup& eSetup) const {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   eSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
@@ -340,18 +327,16 @@ bool AlignmentTrackSelector::detailedHitsCheck(const reco::Track *trackp, const 
 
   // checking hit requirements beyond simple number of valid hits
 
-  if (minHitsinTIB_ || minHitsinTOB_ || minHitsinTID_ || minHitsinTEC_
-      || minHitsinENDCAP_ || minHitsinENDCAPplus_ || minHitsinENDCAPminus_ || (maxHitDiffEndcaps_ < 999)
-      || minHitsinTIDplus_ || minHitsinTIDminus_
-      || minHitsinFPIXplus_ || minHitsinFPIXminus_
-      || minHitsinTECplus_ || minHitsinTECminus_
-      || minHitsinFPIX_ || minHitsinBPIX_ || minHitsinPIX_ ||nHitMin2D_ || chargeCheck_
-      || applyIsolation_ || (seedOnlyFromAbove_ == 1 || seedOnlyFromAbove_ == 2)
-      || !RorZofFirstHitMin_.empty() || !RorZofFirstHitMax_.empty() || !RorZofLastHitMin_.empty() || !RorZofLastHitMax_.empty() ) {
+  if (minHitsinTIB_ || minHitsinTOB_ || minHitsinTID_ || minHitsinTEC_ || minHitsinENDCAP_ || minHitsinENDCAPplus_ ||
+      minHitsinENDCAPminus_ || (maxHitDiffEndcaps_ < 999) || minHitsinTIDplus_ || minHitsinTIDminus_ ||
+      minHitsinFPIXplus_ || minHitsinFPIXminus_ || minHitsinTECplus_ || minHitsinTECminus_ || minHitsinFPIX_ ||
+      minHitsinBPIX_ || minHitsinPIX_ || nHitMin2D_ || chargeCheck_ || applyIsolation_ ||
+      (seedOnlyFromAbove_ == 1 || seedOnlyFromAbove_ == 2) || !RorZofFirstHitMin_.empty() ||
+      !RorZofFirstHitMax_.empty() || !RorZofLastHitMin_.empty() || !RorZofLastHitMax_.empty()) {
     // any detailed hit cut is active, so have to check
-    
+
     int nhitinTIB = 0, nhitinTOB = 0, nhitinTID = 0;
-    int nhitinTEC = 0, nhitinBPIX = 0, nhitinFPIX = 0, nhitinPIXEL=0;
+    int nhitinTEC = 0, nhitinBPIX = 0, nhitinFPIX = 0, nhitinPIXEL = 0;
     int nhitinENDCAP = 0, nhitinENDCAPplus = 0, nhitinENDCAPminus = 0;
     int nhitinTIDplus = 0, nhitinTIDminus = 0;
     int nhitinFPIXplus = 0, nhitinFPIXminus = 0;
@@ -359,157 +344,164 @@ bool AlignmentTrackSelector::detailedHitsCheck(const reco::Track *trackp, const 
     unsigned int nHit2D = 0;
     unsigned int thishit = 0;
 
-    for(auto const& hit : trackp->recHits()) {
+    for (auto const& hit : trackp->recHits()) {
       thishit++;
       const DetId detId(hit->geographicalId());
-      const int subdetId = detId.subdetId(); 
+      const int subdetId = detId.subdetId();
 
-      // *** thishit == 1 means last hit in CTF *** 
+      // *** thishit == 1 means last hit in CTF ***
       // (FIXME: assumption might change or not be valid for all tracking algorthms)
       // ==> for cosmics
       // seedOnlyFrom = 1 is TIB-TOB-TEC tracks only
-      // seedOnlyFrom = 2 is TOB-TEC tracks only 
-      if (seedOnlyFromAbove_ == 1 && thishit == 1 
-          && (subdetId == int(SiStripDetId::TOB) || subdetId == int(SiStripDetId::TEC))){
-        return false; 
+      // seedOnlyFrom = 2 is TOB-TEC tracks only
+      if (seedOnlyFromAbove_ == 1 && thishit == 1 &&
+          (subdetId == int(SiStripDetId::TOB) || subdetId == int(SiStripDetId::TEC))) {
+        return false;
       }
       if (seedOnlyFromAbove_ == 2 && thishit == 1 && subdetId == int(SiStripDetId::TIB)) {
         return false;
       }
 
-      if (!hit->isValid()) continue; // only real hits count as in trackp->numberOfValidHits()
+      if (!hit->isValid())
+        continue;  // only real hits count as in trackp->numberOfValidHits()
       if (detId.det() != DetId::Tracker) {
-        edm::LogError("DetectorMismatch") << "@SUB=AlignmentTrackSelector::detailedHitsCheck"
-                                          << "DetId.det() != DetId::Tracker (=" << DetId::Tracker
-                                          << "), but " << detId.det() << ".";
+        edm::LogError("DetectorMismatch")
+            << "@SUB=AlignmentTrackSelector::detailedHitsCheck"
+            << "DetId.det() != DetId::Tracker (=" << DetId::Tracker << "), but " << detId.det() << ".";
       }
-      if (chargeCheck_ && !(this->isOkCharge(hit))) return false;
-      if (applyIsolation_ && (!this->isIsolated(hit, evt))) return false;
-      if      (SiStripDetId::TIB == subdetId) ++nhitinTIB;
-      else if (SiStripDetId::TOB == subdetId) ++nhitinTOB;
+      if (chargeCheck_ && !(this->isOkCharge(hit)))
+        return false;
+      if (applyIsolation_ && (!this->isIsolated(hit, evt)))
+        return false;
+      if (SiStripDetId::TIB == subdetId)
+        ++nhitinTIB;
+      else if (SiStripDetId::TOB == subdetId)
+        ++nhitinTOB;
       else if (SiStripDetId::TID == subdetId) {
         ++nhitinTID;
         ++nhitinENDCAP;
-        
+
         if (tTopo->tidIsZMinusSide(detId)) {
           ++nhitinTIDminus;
           ++nhitinENDCAPminus;
-	}
-        else if (tTopo->tidIsZPlusSide(detId)) {
+        } else if (tTopo->tidIsZPlusSide(detId)) {
           ++nhitinTIDplus;
           ++nhitinENDCAPplus;
-	}
-      }
-      else if (SiStripDetId::TEC == subdetId) {
+        }
+      } else if (SiStripDetId::TEC == subdetId) {
         ++nhitinTEC;
         ++nhitinENDCAP;
-        
+
         if (tTopo->tecIsZMinusSide(detId)) {
           ++nhitinTECminus;
           ++nhitinENDCAPminus;
-	}
-        else if (tTopo->tecIsZPlusSide(detId)) {
+        } else if (tTopo->tecIsZPlusSide(detId)) {
           ++nhitinTECplus;
           ++nhitinENDCAPplus;
-	}
-      }
-      else if (            kBPIX == subdetId) {++nhitinBPIX;++nhitinPIXEL;}
-      else if (            kFPIX == subdetId) {
+        }
+      } else if (kBPIX == subdetId) {
+        ++nhitinBPIX;
+        ++nhitinPIXEL;
+      } else if (kFPIX == subdetId) {
         ++nhitinFPIX;
         ++nhitinPIXEL;
-	
-        if (tTopo->pxfSide(detId)==1) ++nhitinFPIXminus;
-        else if (tTopo->pxfSide(detId)==2) ++nhitinFPIXplus;
+
+        if (tTopo->pxfSide(detId) == 1)
+          ++nhitinFPIXminus;
+        else if (tTopo->pxfSide(detId) == 2)
+          ++nhitinFPIXplus;
       }
       // Do not call isHit2D(..) if already enough 2D hits for performance reason:
-      if (nHit2D < nHitMin2D_ && this->isHit2D(*hit)) ++nHit2D;
-    } // end loop on hits
-
+      if (nHit2D < nHitMin2D_ && this->isHit2D(*hit))
+        ++nHit2D;
+    }  // end loop on hits
 
     // Checking whether the track satisfies requirement of the first and last hit positions
     bool passedLastHitPositionR = true;
     bool passedLastHitPositionZ = true;
     bool passedFirstHitPositionR = true;
     bool passedFirstHitPositionZ = true;
-    
-    if( RorZofFirstHitMin_.at(0) != 0.0 || RorZofFirstHitMin_.at(1) != 0.0 
-      || RorZofFirstHitMax_.at(0) != 999.0 || RorZofFirstHitMax_.at(1) != 999.0 ) {
 
+    if (RorZofFirstHitMin_.at(0) != 0.0 || RorZofFirstHitMin_.at(1) != 0.0 || RorZofFirstHitMax_.at(0) != 999.0 ||
+        RorZofFirstHitMax_.at(1) != 999.0) {
       const reco::TrackBase::Point& firstPoint(trackp->innerPosition());
 
-      if( (std::fabs(firstPoint.R()) < RorZofFirstHitMin_.at(0) )) passedFirstHitPositionR = false;
-      if( (std::fabs(firstPoint.R()) > RorZofFirstHitMax_.at(0) )) passedFirstHitPositionR = false;
-      if( (std::fabs(firstPoint.Z()) < RorZofFirstHitMin_.at(1) )) passedFirstHitPositionZ = false;
-      if( (std::fabs(firstPoint.Z()) > RorZofFirstHitMax_.at(1) )) passedFirstHitPositionZ = false;
+      if ((std::fabs(firstPoint.R()) < RorZofFirstHitMin_.at(0)))
+        passedFirstHitPositionR = false;
+      if ((std::fabs(firstPoint.R()) > RorZofFirstHitMax_.at(0)))
+        passedFirstHitPositionR = false;
+      if ((std::fabs(firstPoint.Z()) < RorZofFirstHitMin_.at(1)))
+        passedFirstHitPositionZ = false;
+      if ((std::fabs(firstPoint.Z()) > RorZofFirstHitMax_.at(1)))
+        passedFirstHitPositionZ = false;
     }
-    
-    if( RorZofLastHitMin_.at(0) != 0.0 || RorZofLastHitMin_.at(1) != 0.0 
-      || RorZofLastHitMax_.at(0) != 999.0 || RorZofLastHitMax_.at(1) != 999.0 ) {
 
+    if (RorZofLastHitMin_.at(0) != 0.0 || RorZofLastHitMin_.at(1) != 0.0 || RorZofLastHitMax_.at(0) != 999.0 ||
+        RorZofLastHitMax_.at(1) != 999.0) {
       const reco::TrackBase::Point& lastPoint(trackp->outerPosition());
 
-      if( (std::fabs(lastPoint.R()) < RorZofLastHitMin_.at(0) )) passedLastHitPositionR = false;
-      if( (std::fabs(lastPoint.R()) > RorZofLastHitMax_.at(0) )) passedLastHitPositionR = false;
-      if( (std::fabs(lastPoint.Z()) < RorZofLastHitMin_.at(1) )) passedLastHitPositionZ = false;
-      if( (std::fabs(lastPoint.Z()) > RorZofLastHitMax_.at(1) )) passedLastHitPositionZ = false;
+      if ((std::fabs(lastPoint.R()) < RorZofLastHitMin_.at(0)))
+        passedLastHitPositionR = false;
+      if ((std::fabs(lastPoint.R()) > RorZofLastHitMax_.at(0)))
+        passedLastHitPositionR = false;
+      if ((std::fabs(lastPoint.Z()) < RorZofLastHitMin_.at(1)))
+        passedLastHitPositionZ = false;
+      if ((std::fabs(lastPoint.Z()) > RorZofLastHitMax_.at(1)))
+        passedLastHitPositionZ = false;
     }
 
     bool passedFirstHitPosition = passedFirstHitPositionR || passedFirstHitPositionZ;
     bool passedLastHitPosition = passedLastHitPositionR || passedLastHitPositionZ;
 
-
-  
-    return (nhitinTIB >= minHitsinTIB_ && nhitinTOB >= minHitsinTOB_ 
-            && nhitinTID >= minHitsinTID_ && nhitinTEC >= minHitsinTEC_ 
-            && nhitinENDCAP >= minHitsinENDCAP_ && nhitinENDCAPplus >= minHitsinENDCAPplus_ && nhitinENDCAPminus >= minHitsinENDCAPminus_
-	    && std::abs(nhitinENDCAPplus-nhitinENDCAPminus) <= maxHitDiffEndcaps_
-            && nhitinTIDplus >= minHitsinTIDplus_ && nhitinTIDminus >= minHitsinTIDminus_
-            && nhitinFPIXplus >= minHitsinFPIXplus_ && nhitinFPIXminus >= minHitsinFPIXminus_
-            && nhitinTECplus >= minHitsinTECplus_ && nhitinTECminus >= minHitsinTECminus_
-            && nhitinBPIX >= minHitsinBPIX_ 
-	    && nhitinFPIX >= minHitsinFPIX_ && nhitinPIXEL>=minHitsinPIX_ 
-            && nHit2D >= nHitMin2D_ && passedFirstHitPosition && passedLastHitPosition);
-  } else { // no cuts set, so we are just fine and can avoid loop on hits
+    return (nhitinTIB >= minHitsinTIB_ && nhitinTOB >= minHitsinTOB_ && nhitinTID >= minHitsinTID_ &&
+            nhitinTEC >= minHitsinTEC_ && nhitinENDCAP >= minHitsinENDCAP_ &&
+            nhitinENDCAPplus >= minHitsinENDCAPplus_ && nhitinENDCAPminus >= minHitsinENDCAPminus_ &&
+            std::abs(nhitinENDCAPplus - nhitinENDCAPminus) <= maxHitDiffEndcaps_ &&
+            nhitinTIDplus >= minHitsinTIDplus_ && nhitinTIDminus >= minHitsinTIDminus_ &&
+            nhitinFPIXplus >= minHitsinFPIXplus_ && nhitinFPIXminus >= minHitsinFPIXminus_ &&
+            nhitinTECplus >= minHitsinTECplus_ && nhitinTECminus >= minHitsinTECminus_ &&
+            nhitinBPIX >= minHitsinBPIX_ && nhitinFPIX >= minHitsinFPIX_ && nhitinPIXEL >= minHitsinPIX_ &&
+            nHit2D >= nHitMin2D_ && passedFirstHitPosition && passedLastHitPosition);
+  } else {  // no cuts set, so we are just fine and can avoid loop on hits
     return true;
   }
-  
 }
 
 //-----------------------------------------------------------------------------
 
-bool AlignmentTrackSelector::isHit2D(const TrackingRecHit &hit) const
-{
+bool AlignmentTrackSelector::isHit2D(const TrackingRecHit& hit) const {
   // we count SiStrip stereo modules as 2D if selected via countStereoHitAs2D_
   // (since they provide theta information)
-  if (!hit.isValid() ||
-      (hit.dimension() < 2 && !countStereoHitAs2D_ && !dynamic_cast<const SiStripRecHit1D*>(&hit))){
-    return false; // real RecHit1D - but SiStripRecHit1D depends on countStereoHitAs2D_
+  if (!hit.isValid() || (hit.dimension() < 2 && !countStereoHitAs2D_ && !dynamic_cast<const SiStripRecHit1D*>(&hit))) {
+    return false;  // real RecHit1D - but SiStripRecHit1D depends on countStereoHitAs2D_
   } else {
     const DetId detId(hit.geographicalId());
     if (detId.det() == DetId::Tracker) {
       if (detId.subdetId() == kBPIX || detId.subdetId() == kFPIX) {
-        return true; // pixel is always 2D
-      } else { // should be SiStrip now
-	const SiStripDetId stripId(detId);
-	if (stripId.stereo()) return countStereoHitAs2D_; // stereo modules
-        else if (dynamic_cast<const SiStripRecHit1D*>(&hit)
-		 || dynamic_cast<const SiStripRecHit2D*>(&hit)) return false; // rphi modules hit
-	//the following two are not used any more since ages... 
-        else if (dynamic_cast<const SiStripMatchedRecHit2D*>(&hit)) return true; // matched is 2D
+        return true;  // pixel is always 2D
+      } else {        // should be SiStrip now
+        const SiStripDetId stripId(detId);
+        if (stripId.stereo())
+          return countStereoHitAs2D_;  // stereo modules
+        else if (dynamic_cast<const SiStripRecHit1D*>(&hit) || dynamic_cast<const SiStripRecHit2D*>(&hit))
+          return false;  // rphi modules hit
+                         //the following two are not used any more since ages...
+        else if (dynamic_cast<const SiStripMatchedRecHit2D*>(&hit))
+          return true;  // matched is 2D
         else if (dynamic_cast<const ProjectedSiStripRecHit2D*>(&hit)) {
-	  const ProjectedSiStripRecHit2D* pH = static_cast<const ProjectedSiStripRecHit2D*>(&hit);
-	  return (countStereoHitAs2D_ && this->isHit2D(pH->originalHit())); // depends on original...
-	} else {
+          const ProjectedSiStripRecHit2D* pH = static_cast<const ProjectedSiStripRecHit2D*>(&hit);
+          return (countStereoHitAs2D_ && this->isHit2D(pH->originalHit()));  // depends on original...
+        } else {
           edm::LogError("UnkownType") << "@SUB=AlignmentTrackSelector::isHit2D"
                                       << "Tracker hit not in pixel, neither SiStripRecHit[12]D nor "
                                       << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
           return false;
         }
       }
-    } else { // not tracker??
+    } else {  // not tracker??
       edm::LogWarning("DetectorMismatch") << "@SUB=AlignmentTrackSelector::isHit2D"
                                           << "Hit not in tracker with 'official' dimension >=2.";
-      return true; // dimension() >= 2 so accept that...
+      return true;  // dimension() >= 2 so accept that...
     }
   }
   // never reached...
@@ -517,78 +509,72 @@ bool AlignmentTrackSelector::isHit2D(const TrackingRecHit &hit) const
 
 //-----------------------------------------------------------------------------
 
-bool AlignmentTrackSelector::isOkCharge(const TrackingRecHit* hit) const
-{
-  if (!hit || !hit->isValid()) return true; 
+bool AlignmentTrackSelector::isOkCharge(const TrackingRecHit* hit) const {
+  if (!hit || !hit->isValid())
+    return true;
 
   // check det and subdet
   const DetId id(hit->geographicalId());
   if (id.det() != DetId::Tracker) {
-    edm::LogWarning("DetectorMismatch") << "@SUB=isOkCharge" << "Hit not in tracker!";
+    edm::LogWarning("DetectorMismatch") << "@SUB=isOkCharge"
+                                        << "Hit not in tracker!";
     return true;
   }
   if (id.subdetId() == kFPIX || id.subdetId() == kBPIX) {
-    return true; // might add some requirement...
+    return true;  // might add some requirement...
   }
 
   // We are in SiStrip now, so test normal hit:
-  const std::type_info &type = typeid(*hit);
-  
+  const std::type_info& type = typeid(*hit);
 
   if (type == typeid(SiStripRecHit2D)) {
-    const SiStripRecHit2D *stripHit2D = dynamic_cast<const SiStripRecHit2D*>(hit);
+    const SiStripRecHit2D* stripHit2D = dynamic_cast<const SiStripRecHit2D*>(hit);
     if (stripHit2D) {
       return this->isOkChargeStripHit(*stripHit2D);
     }
-  }
-  else if(type == typeid(SiStripRecHit1D)){
-    const SiStripRecHit1D *stripHit1D = dynamic_cast<const SiStripRecHit1D*>(hit);
+  } else if (type == typeid(SiStripRecHit1D)) {
+    const SiStripRecHit1D* stripHit1D = dynamic_cast<const SiStripRecHit1D*>(hit);
     if (stripHit1D) {
       return this->isOkChargeStripHit(*stripHit1D);
-    } 
-  }
-
-  else if(type == typeid(SiStripMatchedRecHit2D)){  // or matched (should not occur anymore due to hit splitting since 20X)
-    const SiStripMatchedRecHit2D *matchedHit = dynamic_cast<const SiStripMatchedRecHit2D*>(hit);
-    if (matchedHit) {  
-      return (this->isOkChargeStripHit(matchedHit->monoHit())
-	      && this->isOkChargeStripHit(matchedHit->stereoHit()));
     }
   }
-  else if(type == typeid(ProjectedSiStripRecHit2D)){ 
+
+  else if (type ==
+           typeid(SiStripMatchedRecHit2D)) {  // or matched (should not occur anymore due to hit splitting since 20X)
+    const SiStripMatchedRecHit2D* matchedHit = dynamic_cast<const SiStripMatchedRecHit2D*>(hit);
+    if (matchedHit) {
+      return (this->isOkChargeStripHit(matchedHit->monoHit()) && this->isOkChargeStripHit(matchedHit->stereoHit()));
+    }
+  } else if (type == typeid(ProjectedSiStripRecHit2D)) {
     // or projected (should not occur anymore due to hit splitting since 20X):
-    const ProjectedSiStripRecHit2D *projHit = dynamic_cast<const ProjectedSiStripRecHit2D*>(hit);
+    const ProjectedSiStripRecHit2D* projHit = dynamic_cast<const ProjectedSiStripRecHit2D*>(hit);
     if (projHit) {
       return this->isOkChargeStripHit(projHit->originalHit());
     }
-  }
-  else{
-    edm::LogError("AlignmentTrackSelector")<< "@SUB=isOkCharge" <<"Unknown type of a valid tracker hit in Strips "
-                                           << " SubDet = "<<id.subdetId();
+  } else {
+    edm::LogError("AlignmentTrackSelector") << "@SUB=isOkCharge"
+                                            << "Unknown type of a valid tracker hit in Strips "
+                                            << " SubDet = " << id.subdetId();
     return false;
   }
-  
-
 
   // and now? SiTrackerMultiRecHit? Not here I guess!
   // Should we throw instead?
-  edm::LogError("AlignmentTrackSelector") 
-    << "@SUB=isOkCharge" << "Unknown valid tracker hit not in pixel, subdet " << id.subdetId()
-    << ", SiTrackerMultiRecHit " << dynamic_cast<const SiTrackerMultiRecHit*>(hit)
-    << ", BaseTrackerRecHit " << dynamic_cast<const BaseTrackerRecHit*>(hit); 
-  
-  return true;
-} 
+  edm::LogError("AlignmentTrackSelector") << "@SUB=isOkCharge"
+                                          << "Unknown valid tracker hit not in pixel, subdet " << id.subdetId()
+                                          << ", SiTrackerMultiRecHit " << dynamic_cast<const SiTrackerMultiRecHit*>(hit)
+                                          << ", BaseTrackerRecHit " << dynamic_cast<const BaseTrackerRecHit*>(hit);
 
+  return true;
+}
 
 //-----------------------------------------------------------------------------
 
-bool AlignmentTrackSelector::isOkChargeStripHit(const SiStripRecHit2D & siStripRecHit2D) const
-{
+bool AlignmentTrackSelector::isOkChargeStripHit(const SiStripRecHit2D& siStripRecHit2D) const {
   double charge = 0.;
 
   SiStripRecHit2D::ClusterRef cluster(siStripRecHit2D.cluster());
-  const auto &amplitudes = cluster->amplitudes();
+  const auto& amplitudes = cluster->amplitudes();
 
   for (size_t ia = 0; ia < amplitudes.size(); ++ia) {
     charge += amplitudes[ia];
@@ -599,12 +585,11 @@ bool AlignmentTrackSelector::isOkChargeStripHit(const SiStripRecHit2D & siStripR
 
 //-----------------------------------------------------------------------------
 
-bool AlignmentTrackSelector::isOkChargeStripHit(const SiStripRecHit1D & siStripRecHit1D) const
-{
+bool AlignmentTrackSelector::isOkChargeStripHit(const SiStripRecHit1D& siStripRecHit1D) const {
   double charge = 0.;
 
   SiStripRecHit1D::ClusterRef cluster(siStripRecHit1D.cluster());
-  const auto &amplitudes = cluster->amplitudes();
+  const auto& amplitudes = cluster->amplitudes();
 
   for (size_t ia = 0; ia < amplitudes.size(); ++ia) {
     charge += amplitudes[ia];
@@ -615,8 +600,7 @@ bool AlignmentTrackSelector::isOkChargeStripHit(const SiStripRecHit1D & siStripR
 
 //-----------------------------------------------------------------------------
 
-bool AlignmentTrackSelector::isIsolated(const TrackingRecHit* hit, const edm::Event& evt) const
-{
+bool AlignmentTrackSelector::isIsolated(const TrackingRecHit* hit, const edm::Event& evt) const {
   // FIXME:
   // adapt to changes after introduction of SiStripRecHit1D...
   //
@@ -624,56 +608,60 @@ bool AlignmentTrackSelector::isIsolated(const TrackingRecHit* hit, const edm::Ev
   edm::Handle<SiStripRecHit2DCollection> rphirecHits;
   edm::Handle<SiStripMatchedRecHit2DCollection> matchedrecHits;
   // es.get<TrackerDigiGeometryRecord>().get(tracker);
-  evt.getByToken( rphirecHitsToken_, rphirecHits );
-  evt.getByToken( matchedrecHitsToken_, matchedrecHits );
+  evt.getByToken(rphirecHitsToken_, rphirecHits);
+  evt.getByToken(matchedrecHitsToken_, matchedrecHits);
 
-  SiStripRecHit2DCollection::DataContainer::const_iterator istripSt; 
-  SiStripMatchedRecHit2DCollection::DataContainer::const_iterator istripStm; 
+  SiStripRecHit2DCollection::DataContainer::const_iterator istripSt;
+  SiStripMatchedRecHit2DCollection::DataContainer::const_iterator istripStm;
   const SiStripRecHit2DCollection::DataContainer& stripcollSt = rphirecHits->data();
   const SiStripMatchedRecHit2DCollection::DataContainer& stripcollStm = matchedrecHits->data();
-  
-  DetId idet = hit->geographicalId(); 
-  
-  // FIXME: instead of looping the full hit collection, we should explore the features of 
+
+  DetId idet = hit->geographicalId();
+
+  // FIXME: instead of looping the full hit collection, we should explore the features of
   // SiStripRecHit2DCollection::rangeRphi = rphirecHits.get(idet) and loop
   // only from rangeRphi.first until rangeRphi.second
-  for( istripSt=stripcollSt.begin(); istripSt!=stripcollSt.end(); ++istripSt ) {
-    const SiStripRecHit2D *aHit = &*(istripSt);
-    DetId mydet1 = aHit->geographicalId(); 
-    if (idet.rawId() != mydet1.rawId()) continue; 
-    float theDistance = ( hit->localPosition() - aHit->localPosition() ).mag();
-    // std::cout << "theDistance1 = " << theDistance << "\n";
-    if (theDistance > 0.001 && theDistance < minHitIsolation_) return false;
-  }
-  
-  // FIXME: see above
-  for( istripStm=stripcollStm.begin(); istripStm!=stripcollStm.end(); ++istripStm ) {
-    const SiStripMatchedRecHit2D *aHit = &*(istripStm);
-    DetId mydet2 = aHit->geographicalId(); 
-    if (idet.rawId() != mydet2.rawId()) continue;
+  for (istripSt = stripcollSt.begin(); istripSt != stripcollSt.end(); ++istripSt) {
+    const SiStripRecHit2D* aHit = &*(istripSt);
+    DetId mydet1 = aHit->geographicalId();
+    if (idet.rawId() != mydet1.rawId())
+      continue;
     float theDistance = (hit->localPosition() - aHit->localPosition()).mag();
     // std::cout << "theDistance1 = " << theDistance << "\n";
-    if (theDistance > 0.001 && theDistance < minHitIsolation_) return false;
+    if (theDistance > 0.001 && theDistance < minHitIsolation_)
+      return false;
+  }
+
+  // FIXME: see above
+  for (istripStm = stripcollStm.begin(); istripStm != stripcollStm.end(); ++istripStm) {
+    const SiStripMatchedRecHit2D* aHit = &*(istripStm);
+    DetId mydet2 = aHit->geographicalId();
+    if (idet.rawId() != mydet2.rawId())
+      continue;
+    float theDistance = (hit->localPosition() - aHit->localPosition()).mag();
+    // std::cout << "theDistance1 = " << theDistance << "\n";
+    if (theDistance > 0.001 && theDistance < minHitIsolation_)
+      return false;
   }
   return true;
 }
 
 //-----------------------------------------------------------------------------
 
-AlignmentTrackSelector::Tracks 
-AlignmentTrackSelector::theNHighestPtTracks(const Tracks& tracks) const
-{
-  Tracks sortedTracks=tracks;
+AlignmentTrackSelector::Tracks AlignmentTrackSelector::theNHighestPtTracks(const Tracks& tracks) const {
+  Tracks sortedTracks = tracks;
   Tracks result;
 
   // sort in pt
-  std::sort(sortedTracks.begin(),sortedTracks.end(),ptComparator);
+  std::sort(sortedTracks.begin(), sortedTracks.end(), ptComparator);
 
   // copy theTrackMult highest pt tracks to result vector
-  int n=0;
-  for (Tracks::const_iterator it=sortedTracks.begin();
-	   it!=sortedTracks.end(); ++it) {
-	if (n<nHighestPt_) { result.push_back(*it); n++; }
+  int n = 0;
+  for (Tracks::const_iterator it = sortedTracks.begin(); it != sortedTracks.end(); ++it) {
+    if (n < nHighestPt_) {
+      result.push_back(*it);
+      n++;
+    }
   }
 
   return result;
@@ -681,101 +669,99 @@ AlignmentTrackSelector::theNHighestPtTracks(const Tracks& tracks) const
 
 //---------
 
-AlignmentTrackSelector::Tracks 
-AlignmentTrackSelector::checkPrescaledHits(const Tracks& tracks, const edm::Event& evt) const 
-{
+AlignmentTrackSelector::Tracks AlignmentTrackSelector::checkPrescaledHits(const Tracks& tracks,
+                                                                          const edm::Event& evt) const {
   Tracks result;
 
   //take Cluster-Flag Assomap
   edm::Handle<AliClusterValueMap> fMap;
-  evt.getByToken( clusterValueMapToken_, fMap);
-  const AliClusterValueMap &flagMap=*fMap;
+  evt.getByToken(clusterValueMapToken_, fMap);
+  const AliClusterValueMap& flagMap = *fMap;
 
   //for each track loop on hits and count the number of taken hits
-  for(auto const& trackp : tracks) {
-    int ntakenhits=0;
+  for (auto const& trackp : tracks) {
+    int ntakenhits = 0;
     //    float pt=trackp->pt();
 
-    for(auto const& hit : trackp->recHits()) {
-      if(! hit->isValid())continue;
+    for (auto const& hit : trackp->recHits()) {
+      if (!hit->isValid())
+        continue;
       DetId detid = hit->geographicalId();
       int subDet = detid.subdetId();
       AlignmentClusterFlag flag;
 
-      bool isPixelHit=(subDet == kFPIX || subDet == kBPIX);
+      bool isPixelHit = (subDet == kFPIX || subDet == kBPIX);
 
-      if (!isPixelHit){
-	const std::type_info &type = typeid(*hit);
+      if (!isPixelHit) {
+        const std::type_info& type = typeid(*hit);
 
-	if (type == typeid(SiStripRecHit2D)) {	
-	  const SiStripRecHit2D* striphit=dynamic_cast<const  SiStripRecHit2D*>(hit); 
-	  if(striphit!=nullptr){
-	    SiStripRecHit2D::ClusterRef stripclust(striphit->cluster());
-	    flag = flagMap[stripclust];
-	  }
-	}
-	else if(type == typeid(SiStripRecHit1D)){
-	  const SiStripRecHit1D* striphit = dynamic_cast<const SiStripRecHit1D*>(hit);
-	  if(striphit!=nullptr){
-	    SiStripRecHit1D::ClusterRef stripclust(striphit->cluster());
-	    flag = flagMap[stripclust];
-	  }
-	} 
-	else{
-	   edm::LogError("AlignmentTrackSelector")<<"ERROR in <AlignmentTrackSelector::checkPrescaledHits>: Dynamic cast of Strip RecHit failed!"
-						  <<" Skipping this hit.";
-	   continue;
-	}
+        if (type == typeid(SiStripRecHit2D)) {
+          const SiStripRecHit2D* striphit = dynamic_cast<const SiStripRecHit2D*>(hit);
+          if (striphit != nullptr) {
+            SiStripRecHit2D::ClusterRef stripclust(striphit->cluster());
+            flag = flagMap[stripclust];
+          }
+        } else if (type == typeid(SiStripRecHit1D)) {
+          const SiStripRecHit1D* striphit = dynamic_cast<const SiStripRecHit1D*>(hit);
+          if (striphit != nullptr) {
+            SiStripRecHit1D::ClusterRef stripclust(striphit->cluster());
+            flag = flagMap[stripclust];
+          }
+        } else {
+          edm::LogError("AlignmentTrackSelector")
+              << "ERROR in <AlignmentTrackSelector::checkPrescaledHits>: Dynamic cast of Strip RecHit failed!"
+              << " Skipping this hit.";
+          continue;
+        }
 
-	  
+      }       //end if hit in Strips
+      else {  // test explicitely BPIX/FPIX
+        const SiPixelRecHit* pixelhit = dynamic_cast<const SiPixelRecHit*>(hit);
+        if (pixelhit != nullptr) {
+          SiPixelRecHit::ClusterRef pixclust(pixelhit->cluster());
+          flag = flagMap[pixclust];
+        } else {
+          edm::LogError("AlignmentTrackSelector")
+              << "ERROR in <AlignmentTrackSelector::checkPrescaledHits>: Dynamic cast of Pixel RecHit failed!  ";
+        }
+      }  //end else hit is in Pixel
 
-      }//end if hit in Strips
-      else{ // test explicitely BPIX/FPIX
-	const SiPixelRecHit* pixelhit= dynamic_cast<const SiPixelRecHit*>(hit);
-	if(pixelhit!=nullptr){
-	  SiPixelRecHit::ClusterRef pixclust(pixelhit->cluster());
-	  flag = flagMap[pixclust];
-	}
-	else{
-	    edm::LogError("AlignmentTrackSelector")<<"ERROR in <AlignmentTrackSelector::checkPrescaledHits>: Dynamic cast of Pixel RecHit failed!  ";
-	}
-      }//end else hit is in Pixel
-      
-      if(flag.isTaken())ntakenhits++;
+      if (flag.isTaken())
+        ntakenhits++;
 
-    }//end loop on hits
-    if(ntakenhits >= minPrescaledHits_)result.push_back(trackp);
-  }//end loop on tracks
+    }  //end loop on hits
+    if (ntakenhits >= minPrescaledHits_)
+      result.push_back(trackp);
+  }  //end loop on tracks
 
   return result;
-}//end checkPrescaledHits
+}  //end checkPrescaledHits
 
 //-----------------------------------------------------------------
 
-bool AlignmentTrackSelector::isOkTrkQuality(const reco::Track* track) const
-{
-  bool qualityOk=false;
-  bool iterStepOk=false;
+bool AlignmentTrackSelector::isOkTrkQuality(const reco::Track* track) const {
+  bool qualityOk = false;
+  bool iterStepOk = false;
 
   //check iterative step
-  if(applyIterStepCheck_){
+  if (applyIterStepCheck_) {
     for (unsigned int i = 0; i < trkSteps_.size(); ++i) {
-      if (track->algo()==(trkSteps_[i])) {
-	iterStepOk=true;
+      if (track->algo() == (trkSteps_[i])) {
+        iterStepOk = true;
       }
     }
-  }
-  else iterStepOk=true;
+  } else
+    iterStepOk = true;
 
   //check track quality
-  if(applyTrkQualityCheck_){
+  if (applyTrkQualityCheck_) {
     for (unsigned int i = 0; i < trkQualities_.size(); ++i) {
       if (track->quality(trkQualities_[i])) {
-	qualityOk=true;
+        qualityOk = true;
       }
     }
-  }
-  else 	qualityOk=true;
+  } else
+    qualityOk = true;
 
-  return qualityOk&&iterStepOk;
-}//end check on track quality
+  return qualityOk && iterStepOk;
+}  //end check on track quality

--- a/Alignment/CommonAlignmentProducer/src/AlignmentTwoBoyDecayTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentTwoBoyDecayTrackSelector.cc
@@ -18,77 +18,73 @@
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentTwoBodyDecayTrackSelector.h"
 //TODO put those namespaces into functions?
 using namespace std;
-using namespace edm; 
+using namespace edm;
 // constructor ----------------------------------------------------------------
 
-AlignmentTwoBodyDecayTrackSelector::AlignmentTwoBodyDecayTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC)
-{
- LogDebug("Alignment")   << "> applying two body decay Trackfilter ...";
-  theMassrangeSwitch = cfg.getParameter<bool>( "applyMassrangeFilter" );
-  if (theMassrangeSwitch){
-    theMinMass = cfg.getParameter<double>( "minXMass" );
-    theMaxMass = cfg.getParameter<double>( "maxXMass" );
-    theDaughterMass = cfg.getParameter<double>( "daughterMass" );
-    theCandNumber = cfg.getParameter<unsigned int>( "numberOfCandidates" );//Number of candidates to keep
-    secThrBool = cfg.getParameter<bool> ( "applySecThreshold" );
-    thesecThr = cfg.getParameter<double>( "secondThreshold" );
-    LogDebug("Alignment") << ">  Massrange min,max         :   " << theMinMass   << "," << theMaxMass 
-			 << "\n>  Mass of daughter Particle :   " << theDaughterMass;
+AlignmentTwoBodyDecayTrackSelector::AlignmentTwoBodyDecayTrackSelector(const edm::ParameterSet& cfg,
+                                                                       edm::ConsumesCollector& iC) {
+  LogDebug("Alignment") << "> applying two body decay Trackfilter ...";
+  theMassrangeSwitch = cfg.getParameter<bool>("applyMassrangeFilter");
+  if (theMassrangeSwitch) {
+    theMinMass = cfg.getParameter<double>("minXMass");
+    theMaxMass = cfg.getParameter<double>("maxXMass");
+    theDaughterMass = cfg.getParameter<double>("daughterMass");
+    theCandNumber = cfg.getParameter<unsigned int>("numberOfCandidates");  //Number of candidates to keep
+    secThrBool = cfg.getParameter<bool>("applySecThreshold");
+    thesecThr = cfg.getParameter<double>("secondThreshold");
+    LogDebug("Alignment") << ">  Massrange min,max         :   " << theMinMass << "," << theMaxMass
+                          << "\n>  Mass of daughter Particle :   " << theDaughterMass;
 
-  }else{
+  } else {
     theMinMass = 0;
     theMaxMass = 0;
     theDaughterMass = 0;
   }
-  theChargeSwitch = cfg.getParameter<bool>( "applyChargeFilter" );
-  if(theChargeSwitch){
-    theCharge = cfg.getParameter<int>( "charge" );
-    theUnsignedSwitch = cfg.getParameter<bool>( "useUnsignedCharge" );
-    if(theUnsignedSwitch) 
-      theCharge=std::abs(theCharge);
-    LogDebug("Alignment") << ">  Desired Charge, unsigned: "<<theCharge<<" , "<<theUnsignedSwitch;
-  }else{
-    theCharge =0;
+  theChargeSwitch = cfg.getParameter<bool>("applyChargeFilter");
+  if (theChargeSwitch) {
+    theCharge = cfg.getParameter<int>("charge");
+    theUnsignedSwitch = cfg.getParameter<bool>("useUnsignedCharge");
+    if (theUnsignedSwitch)
+      theCharge = std::abs(theCharge);
+    LogDebug("Alignment") << ">  Desired Charge, unsigned: " << theCharge << " , " << theUnsignedSwitch;
+  } else {
+    theCharge = 0;
     theUnsignedSwitch = true;
   }
-  theMissingETSwitch = cfg.getParameter<bool>( "applyMissingETFilter" );
-  if(theMissingETSwitch){
-    edm::InputTag theMissingETSource = cfg.getParameter<InputTag>( "missingETSource" );
+  theMissingETSwitch = cfg.getParameter<bool>("applyMissingETFilter");
+  if (theMissingETSwitch) {
+    edm::InputTag theMissingETSource = cfg.getParameter<InputTag>("missingETSource");
     theMissingETToken = iC.consumes<reco::CaloMETCollection>(theMissingETSource);
-    LogDebug("Alignment") << ">  missing Et Source: "<< theMissingETSource;
+    LogDebug("Alignment") << ">  missing Et Source: " << theMissingETSource;
   }
-  theAcoplanarityFilterSwitch = cfg.getParameter<bool>( "applyAcoplanarityFilter" );
-  if(theAcoplanarityFilterSwitch){
-    theAcoplanarDistance = cfg.getParameter<double>( "acoplanarDistance" );
-    LogDebug("Alignment") << ">  Acoplanar Distance: "<<theAcoplanarDistance;
+  theAcoplanarityFilterSwitch = cfg.getParameter<bool>("applyAcoplanarityFilter");
+  if (theAcoplanarityFilterSwitch) {
+    theAcoplanarDistance = cfg.getParameter<double>("acoplanarDistance");
+    LogDebug("Alignment") << ">  Acoplanar Distance: " << theAcoplanarDistance;
   }
-  
 }
 
 // destructor -----------------------------------------------------------------
 
-AlignmentTwoBodyDecayTrackSelector::~AlignmentTwoBodyDecayTrackSelector()
-{}
-
+AlignmentTwoBodyDecayTrackSelector::~AlignmentTwoBodyDecayTrackSelector() {}
 
 ///returns if any of the Filters is used.
-bool AlignmentTwoBodyDecayTrackSelector::useThisFilter()
-{
+bool AlignmentTwoBodyDecayTrackSelector::useThisFilter() {
   return theMassrangeSwitch || theChargeSwitch || theAcoplanarityFilterSwitch;
 }
 
 // do selection ---------------------------------------------------------------
 
-AlignmentTwoBodyDecayTrackSelector::Tracks 
-AlignmentTwoBodyDecayTrackSelector::select(const Tracks& tracks, const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+AlignmentTwoBodyDecayTrackSelector::Tracks AlignmentTwoBodyDecayTrackSelector::select(const Tracks& tracks,
+                                                                                      const edm::Event& iEvent,
+                                                                                      const edm::EventSetup& iSetup) {
   Tracks result = tracks;
 
-  if (theMassrangeSwitch) {  
+  if (theMassrangeSwitch) {
     if (theMissingETSwitch)
-      result = checkMETMass(result,iEvent); 
+      result = checkMETMass(result, iEvent);
     else
-      result = checkMass(result); 
+      result = checkMass(result);
   }
 
   LogDebug("Alignment") << ">  TwoBodyDecay tracks all,kept: " << tracks.size() << "," << result.size();
@@ -96,76 +92,71 @@ AlignmentTwoBodyDecayTrackSelector::select(const Tracks& tracks, const edm::Even
 }
 
 ///checks if the mass of the X is in the mass region
-AlignmentTwoBodyDecayTrackSelector::Tracks 
-AlignmentTwoBodyDecayTrackSelector::checkMass(const Tracks& cands) const
-{
+AlignmentTwoBodyDecayTrackSelector::Tracks AlignmentTwoBodyDecayTrackSelector::checkMass(const Tracks& cands) const {
   Tracks result;
-  
-  LogDebug("Alignment") <<">  cands size : "<< cands.size();
-  
-  if (cands.size()<2) return result;
+
+  LogDebug("Alignment") << ">  cands size : " << cands.size();
+
+  if (cands.size() < 2)
+    return result;
 
   TLorentzVector track0;
   TLorentzVector track1;
   TLorentzVector mother;
-  typedef pair<const reco::Track*,const reco::Track*> constTrackPair;
-  typedef pair<double,constTrackPair> candCollectionItem;
+  typedef pair<const reco::Track*, const reco::Track*> constTrackPair;
+  typedef pair<double, constTrackPair> candCollectionItem;
   vector<candCollectionItem> candCollection;
-  
-  for (unsigned int iCand = 0; iCand < cands.size(); iCand++) {
-    
-    track0.SetXYZT(cands.at(iCand)->px(),
-		   cands.at(iCand)->py(),
-		   cands.at(iCand)->pz(),
-		   sqrt( cands.at(iCand)->p()*cands.at(iCand)->p() + theDaughterMass*theDaughterMass ));
-    
-    for (unsigned int jCand = iCand+1; jCand < cands.size(); jCand++) {
 
+  for (unsigned int iCand = 0; iCand < cands.size(); iCand++) {
+    track0.SetXYZT(cands.at(iCand)->px(),
+                   cands.at(iCand)->py(),
+                   cands.at(iCand)->pz(),
+                   sqrt(cands.at(iCand)->p() * cands.at(iCand)->p() + theDaughterMass * theDaughterMass));
+
+    for (unsigned int jCand = iCand + 1; jCand < cands.size(); jCand++) {
       track1.SetXYZT(cands.at(jCand)->px(),
-		     cands.at(jCand)->py(),
-		     cands.at(jCand)->pz(),
-		     sqrt( cands.at(jCand)->p()*cands.at(jCand)->p() + theDaughterMass*theDaughterMass ));
-      if (secThrBool==true && track1.Pt() < thesecThr && track0.Pt()< thesecThr) continue;          
+                     cands.at(jCand)->py(),
+                     cands.at(jCand)->pz(),
+                     sqrt(cands.at(jCand)->p() * cands.at(jCand)->p() + theDaughterMass * theDaughterMass));
+      if (secThrBool == true && track1.Pt() < thesecThr && track0.Pt() < thesecThr)
+        continue;
       mother = track0 + track1;
-      
-      const reco::Track *trk1 = cands.at(iCand);
-      const reco::Track *trk2 = cands.at(jCand);
+
+      const reco::Track* trk1 = cands.at(iCand);
+      const reco::Track* trk2 = cands.at(jCand);
 
       bool correctCharge = true;
-      if (theChargeSwitch) correctCharge = this->checkCharge(trk1, trk2);
+      if (theChargeSwitch)
+        correctCharge = this->checkCharge(trk1, trk2);
 
       bool acoplanarTracks = true;
-      if (theAcoplanarityFilterSwitch) acoplanarTracks = this->checkAcoplanarity(trk1, trk2);
+      if (theAcoplanarityFilterSwitch)
+        acoplanarTracks = this->checkAcoplanarity(trk1, trk2);
 
-      if (mother.M() > theMinMass &&
-	  mother.M() < theMaxMass &&
-	  correctCharge &&
-	  acoplanarTracks) {
-	candCollection.push_back(candCollectionItem(mother.Pt(),
-						    constTrackPair(trk1, trk2)));
+      if (mother.M() > theMinMass && mother.M() < theMaxMass && correctCharge && acoplanarTracks) {
+        candCollection.push_back(candCollectionItem(mother.Pt(), constTrackPair(trk1, trk2)));
       }
     }
   }
 
-  if (candCollection.empty()) return result;
+  if (candCollection.empty())
+    return result;
 
-  sort(candCollection.begin(), candCollection.end(), [](auto& a, auto& b){return a.first > b.first ;});
+  sort(candCollection.begin(), candCollection.end(), [](auto& a, auto& b) { return a.first > b.first; });
 
-  std::map<const reco::Track*,unsigned int> uniqueTrackIndex;
-  std::map<const reco::Track*,unsigned int>::iterator it;
-  for (unsigned int i=0;
-       i<candCollection.size() && i<theCandNumber;
-       i++) {
-    constTrackPair & trackPair = candCollection[i].second;
-    
+  std::map<const reco::Track*, unsigned int> uniqueTrackIndex;
+  std::map<const reco::Track*, unsigned int>::iterator it;
+  for (unsigned int i = 0; i < candCollection.size() && i < theCandNumber; i++) {
+    constTrackPair& trackPair = candCollection[i].second;
+
     it = uniqueTrackIndex.find(trackPair.first);
-    if (it==uniqueTrackIndex.end()) {
+    if (it == uniqueTrackIndex.end()) {
       result.push_back(trackPair.first);
       uniqueTrackIndex[trackPair.first] = i;
     }
-    
+
     it = uniqueTrackIndex.find(trackPair.second);
-    if (it==uniqueTrackIndex.end()) {
+    if (it == uniqueTrackIndex.end()) {
       result.push_back(trackPair.second);
       uniqueTrackIndex[trackPair.second] = i;
     }
@@ -175,77 +166,68 @@ AlignmentTwoBodyDecayTrackSelector::checkMass(const Tracks& cands) const
 }
 
 ///checks if the mass of the X is in the mass region adding missing E_T
-AlignmentTwoBodyDecayTrackSelector::Tracks 
-AlignmentTwoBodyDecayTrackSelector::checkMETMass(const Tracks& cands,const edm::Event& iEvent) const
-{
+AlignmentTwoBodyDecayTrackSelector::Tracks AlignmentTwoBodyDecayTrackSelector::checkMETMass(
+    const Tracks& cands, const edm::Event& iEvent) const {
   Tracks result;
-  
-  LogDebug("Alignment") <<">  cands size : "<< cands.size();
-  
-  if (cands.empty()) return result;
+
+  LogDebug("Alignment") << ">  cands size : " << cands.size();
+
+  if (cands.empty())
+    return result;
 
   TLorentzVector track;
   TLorentzVector met4;
   TLorentzVector mother;
 
   Handle<reco::CaloMETCollection> missingET;
-  iEvent.getByToken(theMissingETToken ,missingET);
+  iEvent.getByToken(theMissingETToken, missingET);
   if (!missingET.isValid()) {
-    LogError("Alignment")<< "@SUB=AlignmentTwoBodyDecayTrackSelector::checkMETMass"
-			 << ">  could not optain missingET Collection!";
+    LogError("Alignment") << "@SUB=AlignmentTwoBodyDecayTrackSelector::checkMETMass"
+                          << ">  could not optain missingET Collection!";
     return result;
   }
 
-  typedef pair<double,const reco::Track*> candCollectionItem;
+  typedef pair<double, const reco::Track*> candCollectionItem;
   vector<candCollectionItem> candCollection;
 
-  for (reco::CaloMETCollection::const_iterator itMET = missingET->begin();
-       itMET != missingET->end();
-       ++itMET) {
-    
-    met4.SetXYZT((*itMET).px(),
-		 (*itMET).py(),
-		 (*itMET).pz(),
-		 (*itMET).p());
-  
+  for (reco::CaloMETCollection::const_iterator itMET = missingET->begin(); itMET != missingET->end(); ++itMET) {
+    met4.SetXYZT((*itMET).px(), (*itMET).py(), (*itMET).pz(), (*itMET).p());
+
     for (unsigned int iCand = 0; iCand < cands.size(); iCand++) {
-    
       track.SetXYZT(cands.at(iCand)->px(),
-		    cands.at(iCand)->py(),
-		    cands.at(iCand)->pz(),
-		    sqrt( cands.at(iCand)->p()*cands.at(iCand)->p() + theDaughterMass*theDaughterMass ));
-      
+                    cands.at(iCand)->py(),
+                    cands.at(iCand)->pz(),
+                    sqrt(cands.at(iCand)->p() * cands.at(iCand)->p() + theDaughterMass * theDaughterMass));
+
       mother = track + met4;
-      
-      const reco::Track *trk = cands.at(iCand);
-      const reco::CaloMET *met = &(*itMET);
+
+      const reco::Track* trk = cands.at(iCand);
+      const reco::CaloMET* met = &(*itMET);
 
       bool correctCharge = true;
-      if (theChargeSwitch) correctCharge = this->checkCharge(trk);
+      if (theChargeSwitch)
+        correctCharge = this->checkCharge(trk);
 
       bool acoplanarTracks = true;
-      if (theAcoplanarityFilterSwitch) acoplanarTracks = this->checkMETAcoplanarity(trk, met);
+      if (theAcoplanarityFilterSwitch)
+        acoplanarTracks = this->checkMETAcoplanarity(trk, met);
 
-      if (mother.M() > theMinMass &&
-	  mother.M() < theMaxMass &&
-	  correctCharge &&
-	  acoplanarTracks) {
-	candCollection.push_back(candCollectionItem(mother.Pt(), trk));
+      if (mother.M() > theMinMass && mother.M() < theMaxMass && correctCharge && acoplanarTracks) {
+        candCollection.push_back(candCollectionItem(mother.Pt(), trk));
       }
     }
   }
 
-  if (candCollection.empty()) return result;
+  if (candCollection.empty())
+    return result;
 
-  sort(candCollection.begin(), candCollection.end(), [](auto& a, auto& b){return a.first > b.first ;});
-  
-  std::map<const reco::Track*,unsigned int> uniqueTrackIndex;
-  std::map<const reco::Track*,unsigned int>::iterator it;
-  for (unsigned int i=0;
-       i<candCollection.size() && i<theCandNumber;
-       i++) {
+  sort(candCollection.begin(), candCollection.end(), [](auto& a, auto& b) { return a.first > b.first; });
+
+  std::map<const reco::Track*, unsigned int> uniqueTrackIndex;
+  std::map<const reco::Track*, unsigned int>::iterator it;
+  for (unsigned int i = 0; i < candCollection.size() && i < theCandNumber; i++) {
     it = uniqueTrackIndex.find(candCollection[i].second);
-    if (it==uniqueTrackIndex.end()) {
+    if (it == uniqueTrackIndex.end()) {
       result.push_back(candCollection[i].second);
       uniqueTrackIndex[candCollection[i].second] = i;
     }
@@ -255,45 +237,42 @@ AlignmentTwoBodyDecayTrackSelector::checkMETMass(const Tracks& cands,const edm::
 }
 
 ///checks if the mother has charge = [theCharge]
-bool
-AlignmentTwoBodyDecayTrackSelector::checkCharge(const reco::Track* trk1, const reco::Track* trk2)const
-{
+bool AlignmentTwoBodyDecayTrackSelector::checkCharge(const reco::Track* trk1, const reco::Track* trk2) const {
   int sumCharge = trk1->charge();
-  if (trk2) sumCharge += trk2->charge();
-  if (theUnsignedSwitch) sumCharge = std::abs(sumCharge);
-  if (sumCharge == theCharge) return true;
+  if (trk2)
+    sumCharge += trk2->charge();
+  if (theUnsignedSwitch)
+    sumCharge = std::abs(sumCharge);
+  if (sumCharge == theCharge)
+    return true;
   return false;
 }
 
 ///checks if the [cands] are acoplanar (returns empty set if not)
-bool
-AlignmentTwoBodyDecayTrackSelector::checkAcoplanarity(const reco::Track* trk1, const reco::Track* trk2)const
-{
-  if (fabs(deltaPhi(trk1->phi(),trk2->phi()-M_PI)) < theAcoplanarDistance) return true;
+bool AlignmentTwoBodyDecayTrackSelector::checkAcoplanarity(const reco::Track* trk1, const reco::Track* trk2) const {
+  if (fabs(deltaPhi(trk1->phi(), trk2->phi() - M_PI)) < theAcoplanarDistance)
+    return true;
   return false;
 }
 
 ///checks if the [cands] are acoplanar (returns empty set if not)
-bool
-AlignmentTwoBodyDecayTrackSelector::checkMETAcoplanarity(const reco::Track* trk1, const reco::CaloMET* met)const
-{
-  if (fabs(deltaPhi(trk1->phi(),met->phi()-M_PI)) < theAcoplanarDistance) return true;
+bool AlignmentTwoBodyDecayTrackSelector::checkMETAcoplanarity(const reco::Track* trk1, const reco::CaloMET* met) const {
+  if (fabs(deltaPhi(trk1->phi(), met->phi() - M_PI)) < theAcoplanarDistance)
+    return true;
   return false;
 }
 
 //===================HELPERS===================
 
 ///print Information on Track-Collection
-void AlignmentTwoBodyDecayTrackSelector::printTracks(const Tracks& col) const
-{
+void AlignmentTwoBodyDecayTrackSelector::printTracks(const Tracks& col) const {
   int count = 0;
   LogDebug("Alignment") << ">......................................";
-  for(Tracks::const_iterator it = col.begin();it < col.end();++it,++count){
-    LogDebug("Alignment") 
-      <<">  Track No. "<< count <<": p = ("<<(*it)->px()<<","<<(*it)->py()<<","<<(*it)->pz()<<")\n"
-      <<">                        pT = "<<(*it)->pt()<<" eta = "<<(*it)->eta()<<" charge = "<<(*it)->charge();    
+  for (Tracks::const_iterator it = col.begin(); it < col.end(); ++it, ++count) {
+    LogDebug("Alignment") << ">  Track No. " << count << ": p = (" << (*it)->px() << "," << (*it)->py() << ","
+                          << (*it)->pz() << ")\n"
+                          << ">                        pT = " << (*it)->pt() << " eta = " << (*it)->eta()
+                          << " charge = " << (*it)->charge();
   }
   LogDebug("Alignment") << ">......................................";
 }
-
-

--- a/Alignment/CommonAlignmentProducer/test/GlobalPositionRcdRead.cpp
+++ b/Alignment/CommonAlignmentProducer/test/GlobalPositionRcdRead.cpp
@@ -11,48 +11,40 @@
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-class  GlobalPositionRcdRead : public edm::EDAnalyzer
-{
+class GlobalPositionRcdRead : public edm::EDAnalyzer {
 public:
-  explicit GlobalPositionRcdRead( const edm::ParameterSet& iConfig )
-    : nEventCalls_(0)
-  {}
+  explicit GlobalPositionRcdRead(const edm::ParameterSet& iConfig) : nEventCalls_(0) {}
   ~GlobalPositionRcdRead() {}
-  virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup); 
-  
-private:
+  virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup);
 
+private:
   unsigned int nEventCalls_;
 };
 
-void GlobalPositionRcdRead::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup)
-{
-  if (nEventCalls_>0) {
+void GlobalPositionRcdRead::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
+  if (nEventCalls_ > 0) {
     std::cout << "Reading from DB to be done only once, "
-	      << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'." << std::endl;
- 
+              << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'." << std::endl;
+
     return;
   }
 
   std::cout << "Reading from database in GlobalPositionRcdRead::analyze..." << std::endl;
-  
+
   edm::ESHandle<Alignments> globalPositionRcd;
   evtSetup.get<GlobalPositionRcd>().get(globalPositionRcd);
-  
-  std::cout << "Expecting entries in " 
-	    << DetId(DetId::Tracker).rawId() << " " 
-	    << DetId(DetId::Muon).rawId() << " " 
-	    << DetId(DetId::Ecal).rawId() << " " 
-	    << DetId(DetId::Hcal).rawId() << " " 
-	    << DetId(DetId::Calo).rawId() << std::endl;
+
+  std::cout << "Expecting entries in " << DetId(DetId::Tracker).rawId() << " " << DetId(DetId::Muon).rawId() << " "
+            << DetId(DetId::Ecal).rawId() << " " << DetId(DetId::Hcal).rawId() << " " << DetId(DetId::Calo).rawId()
+            << std::endl;
   for (std::vector<AlignTransform>::const_iterator i = globalPositionRcd->m_align.begin();
-       i != globalPositionRcd->m_align.end();  ++i) {
-    std::cout << "entry " << i->rawId() 
-	      << " translation " << i->translation() 
-	      << " angles " << i->rotation().eulerAngles() << std::endl;
+       i != globalPositionRcd->m_align.end();
+       ++i) {
+    std::cout << "entry " << i->rawId() << " translation " << i->translation() << " angles "
+              << i->rotation().eulerAngles() << std::endl;
     std::cout << i->rotation() << std::endl;
   }
-  
+
   std::cout << "done!" << std::endl;
   nEventCalls_++;
 }

--- a/Alignment/CommonAlignmentProducer/test/GlobalPositionRcdScan.cpp
+++ b/Alignment/CommonAlignmentProducer/test/GlobalPositionRcdScan.cpp
@@ -16,17 +16,15 @@
 
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 
-class  GlobalPositionRcdScan : public edm::EDAnalyzer
-{
+class GlobalPositionRcdScan : public edm::EDAnalyzer {
 public:
   explicit GlobalPositionRcdScan(const edm::ParameterSet& iConfig);
 
   virtual ~GlobalPositionRcdScan() {}
-  virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup); 
+  virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup);
   virtual void endJob();
 
 private:
-
   edm::ESWatcher<GlobalPositionRcd> watcher_;
 
   bool eulerAngles_;
@@ -37,88 +35,84 @@ private:
 };
 
 GlobalPositionRcdScan::GlobalPositionRcdScan(const edm::ParameterSet& iConfig)
-  : eulerAngles_(false), alignAngles_(false), matrix_(false),
-    firstRun_(0), lastRun_(0)
-{
-
+    : eulerAngles_(false), alignAngles_(false), matrix_(false), firstRun_(0), lastRun_(0) {
   const std::string howRot(iConfig.getParameter<std::string>("rotation"));
-  
-  if (howRot == "euler"  || howRot == "all") eulerAngles_ = true;
-  if (howRot == "align"  || howRot == "all") alignAngles_ = true;
-  if (howRot == "matrix" || howRot == "all") matrix_      = true;
+
+  if (howRot == "euler" || howRot == "all")
+    eulerAngles_ = true;
+  if (howRot == "align" || howRot == "all")
+    alignAngles_ = true;
+  if (howRot == "matrix" || howRot == "all")
+    matrix_ = true;
 
   if (!eulerAngles_ && !alignAngles_ && !matrix_) {
     edm::LogError("BadConfig") << "@SUB=GlobalPositionRcdScan"
-			       << "Parameter 'rotation' should be 'euler', 'align',"
-			       << "'matrix' or 'all', but is '" << howRot
-			       << "'. Treat as 'all'.";
+                               << "Parameter 'rotation' should be 'euler', 'align',"
+                               << "'matrix' or 'all', but is '" << howRot << "'. Treat as 'all'.";
     eulerAngles_ = alignAngles_ = matrix_ = true;
   }
-
 }
 
-void GlobalPositionRcdScan::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup)
-{
+void GlobalPositionRcdScan::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
   lastRun_ = evt.run();
-  if (0 == firstRun_) firstRun_ = lastRun_;
+  if (0 == firstRun_)
+    firstRun_ = lastRun_;
 
   if (watcher_.check(evtSetup)) {
-  
     edm::ESHandle<Alignments> globalPositionRcd;
     evtSetup.get<GlobalPositionRcd>().get(globalPositionRcd);
 
-    std::cout << "=====================================================\n" 
-	      << "GlobalPositionRcd content starting from run " << evt.run() << ":" << std::endl;
-  
+    std::cout << "=====================================================\n"
+              << "GlobalPositionRcd content starting from run " << evt.run() << ":" << std::endl;
+
     for (std::vector<AlignTransform>::const_iterator i = globalPositionRcd->m_align.begin();
-	 i != globalPositionRcd->m_align.end();  ++i) {
+         i != globalPositionRcd->m_align.end();
+         ++i) {
       std::cout << "  Component ";
       if (i->rawId() == DetId(DetId::Tracker).rawId()) {
-	std::cout << "Tracker";
+        std::cout << "Tracker";
+      } else if (i->rawId() == DetId(DetId::Muon).rawId()) {
+        std::cout << "Muon   ";
+      } else if (i->rawId() == DetId(DetId::Ecal).rawId()) {
+        std::cout << "Ecal   ";
+      } else if (i->rawId() == DetId(DetId::Hcal).rawId()) {
+        std::cout << "Hcal   ";
+      } else if (i->rawId() == DetId(DetId::Calo).rawId()) {
+        std::cout << "Calo   ";
+      } else {
+        std::cout << "Unknown";
       }
-      else if (i->rawId() == DetId(DetId::Muon).rawId()) {
-	std::cout << "Muon   ";
-      }
-      else if (i->rawId() == DetId(DetId::Ecal).rawId()) {
-	std::cout << "Ecal   ";
-      }
-      else if (i->rawId() == DetId(DetId::Hcal).rawId()) {
-	std::cout << "Hcal   ";
-      }
-      else if (i->rawId() == DetId(DetId::Calo).rawId()) {
-	std::cout << "Calo   ";
-      }
-      else {
-	std::cout << "Unknown";
-      }
-      std::cout << " entry " << i->rawId() 
-		<< "\n     translation " << i->translation() << "\n";
+      std::cout << " entry " << i->rawId() << "\n     translation " << i->translation() << "\n";
       const AlignTransform::Rotation hepRot(i->rotation());
       if (eulerAngles_) {
-	std::cout << "     euler angles " << hepRot.eulerAngles() << std::endl;
+        std::cout << "     euler angles " << hepRot.eulerAngles() << std::endl;
       }
       if (alignAngles_) {
-	const align::RotationType matrix(hepRot.xx(), hepRot.xy(), hepRot.xz(),
-					 hepRot.yx(), hepRot.yy(), hepRot.yz(),
-					 hepRot.zx(), hepRot.zy(), hepRot.zz());
-	const AlgebraicVector angles(align::toAngles(matrix));
-	std::cout << "     alpha, beta, gamma (" << angles[0] << ", " << angles[1] << ", "
-		  << angles[2] << ')' << std::endl;
+        const align::RotationType matrix(hepRot.xx(),
+                                         hepRot.xy(),
+                                         hepRot.xz(),
+                                         hepRot.yx(),
+                                         hepRot.yy(),
+                                         hepRot.yz(),
+                                         hepRot.zx(),
+                                         hepRot.zy(),
+                                         hepRot.zz());
+        const AlgebraicVector angles(align::toAngles(matrix));
+        std::cout << "     alpha, beta, gamma (" << angles[0] << ", " << angles[1] << ", " << angles[2] << ')'
+                  << std::endl;
       }
       if (matrix_) {
-	std::cout << "     rotation matrix " << hepRot << std::endl;
+        std::cout << "     rotation matrix " << hepRot << std::endl;
       }
     }
   }
 }
 
-void GlobalPositionRcdScan::endJob()
-{
-  std::cout << "\n=====================================================\n" 
-	    << "=====================================================\n" 
-	    << "Checked run range " << firstRun_ << " to " << lastRun_ << "." << std::endl;
+void GlobalPositionRcdScan::endJob() {
+  std::cout << "\n=====================================================\n"
+            << "=====================================================\n"
+            << "Checked run range " << firstRun_ << " to " << lastRun_ << "." << std::endl;
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(GlobalPositionRcdScan);

--- a/Alignment/CommonAlignmentProducer/test/GlobalPositionRcdWrite.cpp
+++ b/Alignment/CommonAlignmentProducer/test/GlobalPositionRcdWrite.cpp
@@ -21,22 +21,20 @@
 #include "CondFormats/Alignment/interface/AlignTransform.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 
-class  GlobalPositionRcdWrite : public edm::EDAnalyzer {
-   public:
-      explicit  GlobalPositionRcdWrite(const edm::ParameterSet& iConfig)
-	 : m_useEulerAngles(iConfig.getParameter<bool>("useEulerAngles"))
-	 , m_tracker(iConfig.getParameter<edm::ParameterSet>("tracker"))
-         , m_muon(iConfig.getParameter<edm::ParameterSet>("muon"))
-         , m_ecal(iConfig.getParameter<edm::ParameterSet>("ecal"))
-         , m_hcal(iConfig.getParameter<edm::ParameterSet>("hcal"))
-         , m_calo(iConfig.getParameter<edm::ParameterSet>("calo"))
-	 , nEventCalls_(0)
-      {};
-      ~GlobalPositionRcdWrite() {}
+class GlobalPositionRcdWrite : public edm::EDAnalyzer {
+public:
+  explicit GlobalPositionRcdWrite(const edm::ParameterSet& iConfig)
+      : m_useEulerAngles(iConfig.getParameter<bool>("useEulerAngles")),
+        m_tracker(iConfig.getParameter<edm::ParameterSet>("tracker")),
+        m_muon(iConfig.getParameter<edm::ParameterSet>("muon")),
+        m_ecal(iConfig.getParameter<edm::ParameterSet>("ecal")),
+        m_hcal(iConfig.getParameter<edm::ParameterSet>("hcal")),
+        m_calo(iConfig.getParameter<edm::ParameterSet>("calo")),
+        nEventCalls_(0){};
+  ~GlobalPositionRcdWrite() {}
   virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup);
 
 private:
-  
   AlignTransform::Rotation toMatrix(double alpha, double beta, double gamma);
 
   bool m_useEulerAngles;
@@ -44,147 +42,140 @@ private:
   unsigned int nEventCalls_;
 };
 
-AlignTransform::Rotation GlobalPositionRcdWrite::toMatrix(double alpha, double beta, double gamma)
-{
+AlignTransform::Rotation GlobalPositionRcdWrite::toMatrix(double alpha, double beta, double gamma) {
   align::EulerAngles angles(3);
   angles(1) = alpha;
   angles(2) = beta;
   angles(3) = gamma;
-  
+
   align::RotationType alignRotation = align::toMatrix(angles);
 
-  return AlignTransform::Rotation(CLHEP::HepRep3x3(alignRotation.xx(), alignRotation.xy(), alignRotation.xz(),
-						   alignRotation.yx(), alignRotation.yy(), alignRotation.yz(),
-						   alignRotation.zx(), alignRotation.zy(), alignRotation.zz()));
+  return AlignTransform::Rotation(CLHEP::HepRep3x3(alignRotation.xx(),
+                                                   alignRotation.xy(),
+                                                   alignRotation.xz(),
+                                                   alignRotation.yx(),
+                                                   alignRotation.yy(),
+                                                   alignRotation.yz(),
+                                                   alignRotation.zx(),
+                                                   alignRotation.zy(),
+                                                   alignRotation.zz()));
 }
 
-void GlobalPositionRcdWrite::analyze(const edm::Event& evt, const edm::EventSetup& iSetup)
-{
-   if (nEventCalls_ > 0) {
-     std::cout << "Writing to DB to be done only once, "
-	       << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
-	       << "(Your writing should be fine.)" << std::endl;
-     return;
-   }
-   
-   Alignments* globalPositions = new Alignments();
+void GlobalPositionRcdWrite::analyze(const edm::Event& evt, const edm::EventSetup& iSetup) {
+  if (nEventCalls_ > 0) {
+    std::cout << "Writing to DB to be done only once, "
+              << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
+              << "(Your writing should be fine.)" << std::endl;
+    return;
+  }
 
-   AlignTransform tracker(AlignTransform::Translation(m_tracker.getParameter<double>("x"),
-						      m_tracker.getParameter<double>("y"),
-						      m_tracker.getParameter<double>("z")),
-			  (m_useEulerAngles != true) ?
-			    this->toMatrix(m_tracker.getParameter<double>("alpha"),
-					   m_tracker.getParameter<double>("beta"),
-					   m_tracker.getParameter<double>("gamma"))
-			  :
-			    AlignTransform::EulerAngles(m_tracker.getParameter<double>("alpha"),
-							m_tracker.getParameter<double>("beta"),
-							m_tracker.getParameter<double>("gamma")),
-			  DetId(DetId::Tracker).rawId());
-   
-   AlignTransform muon(AlignTransform::Translation(m_muon.getParameter<double>("x"),
-						   m_muon.getParameter<double>("y"),
-						   m_muon.getParameter<double>("z")),
-		       (m_useEulerAngles != true) ?
-		         this->toMatrix(m_muon.getParameter<double>("alpha"),
-					m_muon.getParameter<double>("beta"),
-					m_muon.getParameter<double>("gamma"))
-		       :
-		         AlignTransform::EulerAngles(m_muon.getParameter<double>("alpha"),
-						     m_muon.getParameter<double>("beta"),
-						     m_muon.getParameter<double>("gamma")),
-		       DetId(DetId::Muon).rawId());
-   
-   AlignTransform ecal(AlignTransform::Translation(m_ecal.getParameter<double>("x"),
-						   m_ecal.getParameter<double>("y"),
-						   m_ecal.getParameter<double>("z")),
-		       (m_useEulerAngles != true) ?
-		         this->toMatrix(m_ecal.getParameter<double>("alpha"),
-					m_ecal.getParameter<double>("beta"),
-					m_ecal.getParameter<double>("gamma"))
-		       :
-		         AlignTransform::EulerAngles(m_ecal.getParameter<double>("alpha"),
-						     m_ecal.getParameter<double>("beta"),
-						     m_ecal.getParameter<double>("gamma")),
-		       DetId(DetId::Ecal).rawId());
+  Alignments* globalPositions = new Alignments();
 
-   AlignTransform hcal(AlignTransform::Translation(m_hcal.getParameter<double>("x"),
-						   m_hcal.getParameter<double>("y"),
-						   m_hcal.getParameter<double>("z")),
-		       (m_useEulerAngles != true) ?
-		         this->toMatrix(m_hcal.getParameter<double>("alpha"),
-					m_hcal.getParameter<double>("beta"),
-					m_hcal.getParameter<double>("gamma"))
-		       :
-		         AlignTransform::EulerAngles(m_hcal.getParameter<double>("alpha"),
-						     m_hcal.getParameter<double>("beta"),
-						     m_hcal.getParameter<double>("gamma")),
-		       DetId(DetId::Hcal).rawId());
+  AlignTransform tracker(AlignTransform::Translation(m_tracker.getParameter<double>("x"),
+                                                     m_tracker.getParameter<double>("y"),
+                                                     m_tracker.getParameter<double>("z")),
+                         (m_useEulerAngles != true)
+                             ? this->toMatrix(m_tracker.getParameter<double>("alpha"),
+                                              m_tracker.getParameter<double>("beta"),
+                                              m_tracker.getParameter<double>("gamma"))
+                             : AlignTransform::EulerAngles(m_tracker.getParameter<double>("alpha"),
+                                                           m_tracker.getParameter<double>("beta"),
+                                                           m_tracker.getParameter<double>("gamma")),
+                         DetId(DetId::Tracker).rawId());
 
-   AlignTransform calo(AlignTransform::Translation(m_calo.getParameter<double>("x"),
-						   m_calo.getParameter<double>("y"),
-						   m_calo.getParameter<double>("z")),
-		       (m_useEulerAngles != true) ?
-		         this->toMatrix(m_calo.getParameter<double>("alpha"),
-					m_calo.getParameter<double>("beta"),
-					m_calo.getParameter<double>("gamma"))
-		       :
-		         AlignTransform::EulerAngles(m_calo.getParameter<double>("alpha"),
-						     m_calo.getParameter<double>("beta"),
-						     m_calo.getParameter<double>("gamma")),
-		       DetId(DetId::Calo).rawId());
+  AlignTransform muon(
+      AlignTransform::Translation(
+          m_muon.getParameter<double>("x"), m_muon.getParameter<double>("y"), m_muon.getParameter<double>("z")),
+      (m_useEulerAngles != true) ? this->toMatrix(m_muon.getParameter<double>("alpha"),
+                                                  m_muon.getParameter<double>("beta"),
+                                                  m_muon.getParameter<double>("gamma"))
+                                 : AlignTransform::EulerAngles(m_muon.getParameter<double>("alpha"),
+                                                               m_muon.getParameter<double>("beta"),
+                                                               m_muon.getParameter<double>("gamma")),
+      DetId(DetId::Muon).rawId());
 
-   std::cout << "\nProvided rotation angles are interpreted as "
-	     << ((m_useEulerAngles != true) ? "rotations around X, Y and Z" : "Euler angles")
-	     << ".\n" << std::endl;
-   
-   std::cout << "Tracker (" << tracker.rawId() << ") at " << tracker.translation() 
-	     << " " << tracker.rotation().eulerAngles() << std::endl;
-   std::cout << tracker.rotation() << std::endl;
+  AlignTransform ecal(
+      AlignTransform::Translation(
+          m_ecal.getParameter<double>("x"), m_ecal.getParameter<double>("y"), m_ecal.getParameter<double>("z")),
+      (m_useEulerAngles != true) ? this->toMatrix(m_ecal.getParameter<double>("alpha"),
+                                                  m_ecal.getParameter<double>("beta"),
+                                                  m_ecal.getParameter<double>("gamma"))
+                                 : AlignTransform::EulerAngles(m_ecal.getParameter<double>("alpha"),
+                                                               m_ecal.getParameter<double>("beta"),
+                                                               m_ecal.getParameter<double>("gamma")),
+      DetId(DetId::Ecal).rawId());
 
-   std::cout << "Muon (" << muon.rawId() << ") at " << muon.translation() 
-	     << " " << muon.rotation().eulerAngles() << std::endl;
-   std::cout << muon.rotation() << std::endl;
+  AlignTransform hcal(
+      AlignTransform::Translation(
+          m_hcal.getParameter<double>("x"), m_hcal.getParameter<double>("y"), m_hcal.getParameter<double>("z")),
+      (m_useEulerAngles != true) ? this->toMatrix(m_hcal.getParameter<double>("alpha"),
+                                                  m_hcal.getParameter<double>("beta"),
+                                                  m_hcal.getParameter<double>("gamma"))
+                                 : AlignTransform::EulerAngles(m_hcal.getParameter<double>("alpha"),
+                                                               m_hcal.getParameter<double>("beta"),
+                                                               m_hcal.getParameter<double>("gamma")),
+      DetId(DetId::Hcal).rawId());
 
-   std::cout << "Ecal (" << ecal.rawId() << ") at " << ecal.translation() 
-	     << " " << ecal.rotation().eulerAngles() << std::endl;
-   std::cout << ecal.rotation() << std::endl;
+  AlignTransform calo(
+      AlignTransform::Translation(
+          m_calo.getParameter<double>("x"), m_calo.getParameter<double>("y"), m_calo.getParameter<double>("z")),
+      (m_useEulerAngles != true) ? this->toMatrix(m_calo.getParameter<double>("alpha"),
+                                                  m_calo.getParameter<double>("beta"),
+                                                  m_calo.getParameter<double>("gamma"))
+                                 : AlignTransform::EulerAngles(m_calo.getParameter<double>("alpha"),
+                                                               m_calo.getParameter<double>("beta"),
+                                                               m_calo.getParameter<double>("gamma")),
+      DetId(DetId::Calo).rawId());
 
-   std::cout << "Hcal (" << hcal.rawId() << ") at " << hcal.translation()
-	     << " " << hcal.rotation().eulerAngles() << std::endl;
-   std::cout << hcal.rotation() << std::endl;
+  std::cout << "\nProvided rotation angles are interpreted as "
+            << ((m_useEulerAngles != true) ? "rotations around X, Y and Z" : "Euler angles") << ".\n"
+            << std::endl;
 
-   std::cout << "Calo (" << calo.rawId() << ") at " << calo.translation()
-	     << " " << calo.rotation().eulerAngles() << std::endl;
-   std::cout << calo.rotation() << std::endl;
+  std::cout << "Tracker (" << tracker.rawId() << ") at " << tracker.translation() << " "
+            << tracker.rotation().eulerAngles() << std::endl;
+  std::cout << tracker.rotation() << std::endl;
 
-   globalPositions->m_align.push_back(tracker);
-   globalPositions->m_align.push_back(muon);
-   globalPositions->m_align.push_back(ecal);
-   globalPositions->m_align.push_back(hcal);
-   globalPositions->m_align.push_back(calo);
+  std::cout << "Muon (" << muon.rawId() << ") at " << muon.translation() << " " << muon.rotation().eulerAngles()
+            << std::endl;
+  std::cout << muon.rotation() << std::endl;
 
-   std::cout << "Uploading to the database..." << std::endl;
+  std::cout << "Ecal (" << ecal.rawId() << ") at " << ecal.translation() << " " << ecal.rotation().eulerAngles()
+            << std::endl;
+  std::cout << ecal.rotation() << std::endl;
 
-   edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  std::cout << "Hcal (" << hcal.rawId() << ") at " << hcal.translation() << " " << hcal.rotation().eulerAngles()
+            << std::endl;
+  std::cout << hcal.rotation() << std::endl;
 
-   if (!poolDbService.isAvailable())
-      throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
-                  
-//    if (poolDbService->isNewTagRequest("GlobalPositionRcd")) {
-//       poolDbService->createNewIOV<Alignments>(&(*globalPositions), poolDbService->endOfTime(), "GlobalPositionRcd");
-//    } else {
-//       poolDbService->appendSinceTime<Alignments>(&(*globalPositions), poolDbService->currentTime(), "GlobalPositionRcd");
-//    }
-   poolDbService->writeOne<Alignments>(&(*globalPositions), 
-				       poolDbService->currentTime(),
-				       //poolDbService->beginOfTime(),
-                                       "GlobalPositionRcd");
+  std::cout << "Calo (" << calo.rawId() << ") at " << calo.translation() << " " << calo.rotation().eulerAngles()
+            << std::endl;
+  std::cout << calo.rotation() << std::endl;
 
+  globalPositions->m_align.push_back(tracker);
+  globalPositions->m_align.push_back(muon);
+  globalPositions->m_align.push_back(ecal);
+  globalPositions->m_align.push_back(hcal);
+  globalPositions->m_align.push_back(calo);
 
+  std::cout << "Uploading to the database..." << std::endl;
 
-   std::cout << "done!" << std::endl;
-   nEventCalls_++;
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+
+  if (!poolDbService.isAvailable())
+    throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
+
+  //    if (poolDbService->isNewTagRequest("GlobalPositionRcd")) {
+  //       poolDbService->createNewIOV<Alignments>(&(*globalPositions), poolDbService->endOfTime(), "GlobalPositionRcd");
+  //    } else {
+  //       poolDbService->appendSinceTime<Alignments>(&(*globalPositions), poolDbService->currentTime(), "GlobalPositionRcd");
+  //    }
+  poolDbService->writeOne<Alignments>(&(*globalPositions),
+                                      poolDbService->currentTime(),
+                                      //poolDbService->beginOfTime(),
+                                      "GlobalPositionRcd");
+
+  std::cout << "done!" << std::endl;
+  nEventCalls_++;
 }
 
 //define this as a plug-in

--- a/Alignment/CommonAlignmentProducer/test/TestAccessGeom.cc
+++ b/Alignment/CommonAlignmentProducer/test/TestAccessGeom.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TestAccessGeom
 // Class:      TestAccessGeom
-// 
+//
 /**\class TestAccessGeom Alignment/CommonAlignmentProducer/test/TestAccessGeom.cc
 
  Description: <one line class summary>
@@ -17,7 +17,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -31,9 +30,9 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"  
-#include "Geometry/DTGeometry/interface/DTGeometry.h"  
-#include "Geometry/CSCGeometry/interface/CSCGeometry.h"  
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -49,19 +48,18 @@
 //
 
 class TestAccessGeom : public edm::EDAnalyzer {
-   public:
-      explicit TestAccessGeom(const edm::ParameterSet&);
-      ~TestAccessGeom();
+public:
+  explicit TestAccessGeom(const edm::ParameterSet&);
+  ~TestAccessGeom();
 
+private:
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-   private:
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  // ----------member data ---------------------------
 
-      // ----------member data ---------------------------
-
-      const std::vector<std::string> tkGeomLabels_;
-      const std::vector<std::string> dtGeomLabels_;
-      const std::vector<std::string> cscGeomLabels_;
+  const std::vector<std::string> tkGeomLabels_;
+  const std::vector<std::string> dtGeomLabels_;
+  const std::vector<std::string> cscGeomLabels_;
 };
 
 //
@@ -76,73 +74,63 @@ class TestAccessGeom : public edm::EDAnalyzer {
 // constructors and destructor
 //
 TestAccessGeom::TestAccessGeom(const edm::ParameterSet& iConfig)
-  : tkGeomLabels_(iConfig.getParameter<std::vector<std::string> >("TrackerGeomLabels")),
-    dtGeomLabels_(iConfig.getParameter<std::vector<std::string> >("DTGeomLabels")),
-    cscGeomLabels_(iConfig.getParameter<std::vector<std::string> >("CSCGeomLabels"))
-{
-   //now do what ever initialization is needed
-
+    : tkGeomLabels_(iConfig.getParameter<std::vector<std::string> >("TrackerGeomLabels")),
+      dtGeomLabels_(iConfig.getParameter<std::vector<std::string> >("DTGeomLabels")),
+      cscGeomLabels_(iConfig.getParameter<std::vector<std::string> >("CSCGeomLabels")) {
+  //now do what ever initialization is needed
 }
 
-
-TestAccessGeom::~TestAccessGeom()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+TestAccessGeom::~TestAccessGeom() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-TestAccessGeom::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  using std::vector;
+void TestAccessGeom::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using std::string;
+  using std::vector;
 
-  edm::LogInfo("Test") << "@SUB=analyze" << "Try to  access " << tkGeomLabels_.size() 
-		       << " Tracker-, " << dtGeomLabels_.size() << " DT- and "
-		       << cscGeomLabels_.size() << " CSC-geometries.";
+  edm::LogInfo("Test") << "@SUB=analyze"
+                       << "Try to  access " << tkGeomLabels_.size() << " Tracker-, " << dtGeomLabels_.size()
+                       << " DT- and " << cscGeomLabels_.size() << " CSC-geometries.";
 
-  for (vector<string>::const_iterator iL = tkGeomLabels_.begin(), iE = tkGeomLabels_.end();
-       iL != iE; ++iL) {
-    TString label(iL->c_str()); label.ReplaceAll(" ", ""); // fix for buggy framework
+  for (vector<string>::const_iterator iL = tkGeomLabels_.begin(), iE = tkGeomLabels_.end(); iL != iE; ++iL) {
+    TString label(iL->c_str());
+    label.ReplaceAll(" ", "");  // fix for buggy framework
     edm::LogInfo("Test") << "Try access to tracker geometry with label '" << label << "'.";
     //*iL << "'.";
     edm::ESHandle<TrackerGeometry> tkGeomHandle;
-    iSetup.get<TrackerDigiGeometryRecord>().get(label, tkGeomHandle);// *iL, tkGeomHandle);
+    iSetup.get<TrackerDigiGeometryRecord>().get(label, tkGeomHandle);  // *iL, tkGeomHandle);
     edm::LogInfo("Test") << "TrackerGeometry pointer: " << tkGeomHandle.product();
   }
 
-  for (vector<string>::const_iterator iL = dtGeomLabels_.begin(), iE = dtGeomLabels_.end();
-       iL != iE; ++iL) {
-    TString label(iL->c_str()); label.ReplaceAll(" ", ""); // fix for buggy framework
+  for (vector<string>::const_iterator iL = dtGeomLabels_.begin(), iE = dtGeomLabels_.end(); iL != iE; ++iL) {
+    TString label(iL->c_str());
+    label.ReplaceAll(" ", "");  // fix for buggy framework
     edm::LogInfo("Test") << "Try access to DT geometry with label '" << label << "'.";
     //*iL << "'.";
     edm::ESHandle<DTGeometry> dtGeomHandle;
-    iSetup.get<MuonGeometryRecord>().get(label, dtGeomHandle);//*iL, dtGeomHandle);
+    iSetup.get<MuonGeometryRecord>().get(label, dtGeomHandle);  //*iL, dtGeomHandle);
     edm::LogInfo("Test") << "DTGeometry pointer: " << dtGeomHandle.product();
   }
 
-  for (vector<string>::const_iterator iL = cscGeomLabels_.begin(), iE = cscGeomLabels_.end();
-       iL != iE; ++iL) {
-    TString label(iL->c_str()); label.ReplaceAll(" ", ""); // fix for buggy framework
+  for (vector<string>::const_iterator iL = cscGeomLabels_.begin(), iE = cscGeomLabels_.end(); iL != iE; ++iL) {
+    TString label(iL->c_str());
+    label.ReplaceAll(" ", "");  // fix for buggy framework
     edm::LogInfo("Test") << "Try access to CSC geometry with label '" << label << "'.";
     //*iL << "'.";
     edm::ESHandle<CSCGeometry> cscGeomHandle;
-    iSetup.get<MuonGeometryRecord>().get(label, cscGeomHandle); //*iL, cscGeomHandle);
+    iSetup.get<MuonGeometryRecord>().get(label, cscGeomHandle);  //*iL, cscGeomHandle);
     edm::LogInfo("Test") << "CSCGeometry pointer: " << cscGeomHandle.product();
   }
 
-
-  edm::LogInfo("Test") << "@SUB=analyze" << "Succesfully accessed " << tkGeomLabels_.size() 
-                       << " Tracker-, " << dtGeomLabels_.size() << " DT- and "
-                       << cscGeomLabels_.size() << " CSC-geometries.";
+  edm::LogInfo("Test") << "@SUB=analyze"
+                       << "Succesfully accessed " << tkGeomLabels_.size() << " Tracker-, " << dtGeomLabels_.size()
+                       << " DT- and " << cscGeomLabels_.size() << " CSC-geometries.";
 }
 
 //define this as a plug-in

--- a/Alignment/SurveyAnalysis/interface/Chi2.h
+++ b/Alignment/SurveyAnalysis/interface/Chi2.h
@@ -7,33 +7,28 @@
  *  \author Pablo Martinez Ruiz del Arbol
  */
 
-
 #ifndef Alignment_SurveyAnalysis_Chi2_H
 #define Alignment_SurveyAnalysis_Chi2_H
 
 #include "TMatrixD.h"
 
-
 class Chi2 {
-
- public:
+public:
   Chi2(TMatrixD &, TMatrixD &, TMatrixD &);
   ~Chi2();
-  
-  TMatrixD & getCovariance();
-  TMatrixD & getSolution();
+
+  TMatrixD &getCovariance();
+  TMatrixD &getSolution();
   double getChi2();
   int getDOF();
-  
- private:
-  
+
+private:
   double myChi2;
   int dof;
   TMatrixD covariance;
   TMatrixD leftMatrix;
   TMatrixD rightMatrix;
   TMatrixD solution;
-
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/interface/DTSurvey.h
+++ b/Alignment/SurveyAnalysis/interface/DTSurvey.h
@@ -9,8 +9,6 @@
  *  \author Pablo Martinez Ruiz del Arbol
  */
 
-
-
 #ifndef Alignment_SurveyAnalysis_DTSurvey_H
 #define Alignment_SurveyAnalysis_DTSurvey_H
 
@@ -19,40 +17,39 @@
 class DTGeometry;
 class DTSurveyChamber;
 
-namespace edm { template<class> class ESHandle; }
+namespace edm {
+  template <class>
+  class ESHandle;
+}
 
 class DTSurvey {
-
-  
- public:
-  DTSurvey(const std::string&, const std::string&, int);
+public:
+  DTSurvey(const std::string &, const std::string &, int);
   ~DTSurvey();
- 
+
   void ReadChambers(edm::ESHandle<DTGeometry>);
   void CalculateChambers();
 
-  const DTSurveyChamber * getChamber(int, int) const;
+  const DTSurveyChamber *getChamber(int, int) const;
 
   int getId() const { return id; }
 
   //void ToDB(MuonAlignment *);
- 
-  private:
+
+private:
   void FillWheelInfo();
 
   std::string nameOfWheelInfoFile, nameOfChamberInfoFile;
-  int id; 
-  
+  int id;
+
   //This is the displacement (vector) and rotation (matrix) for the wheel
   float OffsetZ;
   TMatrixD delta;
-  TMatrixD Rot; 
+  TMatrixD Rot;
 
   DTSurveyChamber ***chambers;
-  
 };
 
-
-std::ostream &operator<<(std::ostream &, const DTSurvey&);
+std::ostream &operator<<(std::ostream &, const DTSurvey &);
 
 #endif

--- a/Alignment/SurveyAnalysis/interface/DTSurveyChamber.h
+++ b/Alignment/SurveyAnalysis/interface/DTSurveyChamber.h
@@ -8,77 +8,65 @@
  *  \author Pablo Martinez Ruiz del Arbol
  */
 
-
 #ifndef Alignment_SurveyAnalysis_DTSurveyChamber_H
 #define Alignment_SurveyAnalysis_DTSurveyChamber_H
 
 #include <vector>
 
 #include "TMath.h"
-#include "TMatrixD.h" 
+#include "TMatrixD.h"
 
 class DTSurveyChamber {
-  
-  
- public:
-
+public:
   DTSurveyChamber(int, int, int, long);
-  
 
   //Add a point to the Chamber
-  void addPoint(int, const TMatrixD&, const TMatrixD&, const TMatrixD&);
-  
+  void addPoint(int, const TMatrixD &, const TMatrixD &, const TMatrixD &);
+
   //Begin the chi2 computation
   int getNumberPoints() const { return pointNumber; }
   void compute();
-  void printChamberInfo(); 
-  long getId() const {return rawId;}
-  float getDeltaX() const {return Solution(0,0);}
-  float getDeltaY() const {return Solution(1,0);}
-  float getDeltaZ() const {return Solution(2,0);}
-  //My definition of the matrix rotation is not the same as the used in CMSSW  
-  float getAlpha() const {return Solution(5,0);}
-  float getBeta() const {return -1.0*Solution(4,0);}
-  float getGamma() const {return Solution(3,0);}
-  float getDeltaXError() const {return TMath::Sqrt(Covariance(0,0));}
-  float getDeltaYError() const {return TMath::Sqrt(Covariance(1,1));}
-  float getDeltaZError() const {return TMath::Sqrt(Covariance(2,2));}
-  float getAlphaError() const {return TMath::Sqrt(Covariance(5,5));}
-  float getBetaError() const {return TMath::Sqrt(Covariance(4,4));}
-  float getGammaError() const {return TMath::Sqrt(Covariance(3,3));}
+  void printChamberInfo();
+  long getId() const { return rawId; }
+  float getDeltaX() const { return Solution(0, 0); }
+  float getDeltaY() const { return Solution(1, 0); }
+  float getDeltaZ() const { return Solution(2, 0); }
+  //My definition of the matrix rotation is not the same as the used in CMSSW
+  float getAlpha() const { return Solution(5, 0); }
+  float getBeta() const { return -1.0 * Solution(4, 0); }
+  float getGamma() const { return Solution(3, 0); }
+  float getDeltaXError() const { return TMath::Sqrt(Covariance(0, 0)); }
+  float getDeltaYError() const { return TMath::Sqrt(Covariance(1, 1)); }
+  float getDeltaZError() const { return TMath::Sqrt(Covariance(2, 2)); }
+  float getAlphaError() const { return TMath::Sqrt(Covariance(5, 5)); }
+  float getBetaError() const { return TMath::Sqrt(Covariance(4, 4)); }
+  float getGammaError() const { return TMath::Sqrt(Covariance(3, 3)); }
 
- 
- private:
+private:
+  //   static const unsigned int MAX_PUNTOS = 16;
 
-//   static const unsigned int MAX_PUNTOS = 16;
+  TMatrixD &makeMatrix();
+  TMatrixD &makeErrors();
+  TMatrixD &makeVector();
 
-  TMatrixD & makeMatrix();
-  TMatrixD & makeErrors();
-  TMatrixD & makeVector();
-
-  
   //Identifiers
   int wheel, station, sector;
-  
-  long rawId;
 
+  long rawId;
 
   //Points data
   std::vector<TMatrixD> points;
   std::vector<TMatrixD> pointsDiff;
   std::vector<TMatrixD> pointsError;
   std::vector<TMatrixD> pointsTheoretical;
-  
+
   TMatrixD Solution;
   TMatrixD Covariance;
-   
+
   //Number of points
   int pointNumber;
-  
 };
 
-std::ostream & operator<<(std::ostream &, const DTSurveyChamber&);
-
-
+std::ostream &operator<<(std::ostream &, const DTSurveyChamber &);
 
 #endif

--- a/Alignment/SurveyAnalysis/interface/SurveyAlignment.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyAlignment.h
@@ -13,33 +13,24 @@
 #include "Alignment/CommonAlignment/interface/StructureType.h"
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 
-class SurveyAlignment
-{
-  protected:
-
-  public:
-
+class SurveyAlignment {
+protected:
+public:
   /// Constructor to set the sensors and residual levels.
-  SurveyAlignment(
-		  const align::Alignables& sensors,
-		  const std::vector<align::StructureType>& levels
-		  );
+  SurveyAlignment(const align::Alignables& sensors, const std::vector<align::StructureType>& levels);
 
   virtual ~SurveyAlignment() {}
 
   /// Run the iteration: find residuals, write to output, shift sensors.
-  void iterate(
-	       unsigned int nIteration,     // number of iterations
-	       const std::string& fileName, // name of output file
-	       bool bias = false            // true for biased residuals
-	       );
+  void iterate(unsigned int nIteration,      // number of iterations
+               const std::string& fileName,  // name of output file
+               bool bias = false             // true for biased residuals
+  );
 
-  protected:
-
+protected:
   /// Find the alignment parameters for all sensors.
-  virtual void findAlignPars(
-			     bool bias = false // true for biased residuals
-			     ) = 0;
+  virtual void findAlignPars(bool bias = false  // true for biased residuals
+                             ) = 0;
 
   /// Apply the alignment parameters to all sensors.
   virtual void shiftSensors();

--- a/Alignment/SurveyAnalysis/interface/SurveyAlignmentPoints.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyAlignmentPoints.h
@@ -15,23 +15,15 @@
 
 #include "Alignment/SurveyAnalysis/interface/SurveyAlignment.h"
 
-class SurveyAlignmentPoints:
-  public SurveyAlignment
-{
-  public:
-
+class SurveyAlignmentPoints : public SurveyAlignment {
+public:
   /// Constructor to set the sensors and residual levels in base class.
-  SurveyAlignmentPoints(
-			const align::Alignables& sensors,
-			const std::vector<align::StructureType>& levels
-			);
+  SurveyAlignmentPoints(const align::Alignables& sensors, const std::vector<align::StructureType>& levels);
 
-  protected:
-
+protected:
   /// Find the alignment parameters for all sensors.
-  void findAlignPars(
-			     bool bias = false // true for biased residuals
-			     ) override;
+  void findAlignPars(bool bias = false  // true for biased residuals
+                     ) override;
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/interface/SurveyAlignmentSensor.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyAlignmentSensor.h
@@ -15,23 +15,15 @@
 
 #include "Alignment/SurveyAnalysis/interface/SurveyAlignment.h"
 
-class SurveyAlignmentSensor:
-  public SurveyAlignment
-{
-  public:
-
+class SurveyAlignmentSensor : public SurveyAlignment {
+public:
   /// Constructor to set the sensors and residual levels in base class.
-  SurveyAlignmentSensor(
-			const align::Alignables& sensors,
-			const std::vector<align::StructureType>& levels
-			);
+  SurveyAlignmentSensor(const align::Alignables& sensors, const std::vector<align::StructureType>& levels);
 
-  protected:
-
+protected:
   /// Find the alignment parameters for all sensors.
-  void findAlignPars(
-			     bool bias = false // true for biased residuals
-			     ) override;
+  void findAlignPars(bool bias = false  // true for biased residuals
+                     ) override;
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/interface/SurveyDataReader.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyDataReader.h
@@ -12,29 +12,24 @@
 
 class TrackerTopology;
 
-class SurveyDataReader
-{
-
+class SurveyDataReader {
 public:
+  typedef std::map<align::ID, align::Scalars> MapType;
+  typedef std::pair<align::ID, align::Scalars> PairType;
+  typedef std::map<std::vector<int>, align::Scalars> MapTypeOr;
+  typedef std::pair<std::vector<int>, align::Scalars> PairTypeOr;
 
-  typedef std::map<align::ID, align::Scalars >  MapType;
-  typedef std::pair<align::ID,align::Scalars > PairType;
-  typedef std::map< std::vector<int>, align::Scalars > MapTypeOr;
-  typedef std::pair< std::vector<int>, align::Scalars > PairTypeOr;
-  
   /// Read given text file
-  void readFile( const std::string& textFileName, const std::string& fileType, const TrackerTopology* tTopo);
-  align::Scalars convertToAlignableCoord( const align::Scalars& align_params );
+  void readFile(const std::string& textFileName, const std::string& fileType, const TrackerTopology* tTopo);
+  align::Scalars convertToAlignableCoord(const align::Scalars& align_params);
 
   // Returns the Map
   const MapType& detIdMap() const { return theMap; }
   const MapTypeOr& surveyMap() const { return theOriginalMap; }
 
 private:
-
   MapType theMap;
   MapTypeOr theOriginalMap;
-
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/interface/SurveyInputBase.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyInputBase.h
@@ -14,43 +14,30 @@
 
 class Alignable;
 
-class SurveyInputBase:
-  public edm::EDAnalyzer
-{
-  public:
-
+class SurveyInputBase : public edm::EDAnalyzer {
+public:
   ~SurveyInputBase() override;
 
   /// Read data from input.
   void beginJob() override { theFirstEvent = true; }
 
   /// Do nothing for each event.
-  void analyze(
-		       const edm::Event&,
-		       const edm::EventSetup&
-		       ) override = 0;
+  void analyze(const edm::Event&, const edm::EventSetup&) override = 0;
 
   /// Get alignable detector as read from input.
   inline static Alignable* detector();
 
   /// Add a component or sub-system to the detector.
   /// Class will own component (takes care of deleting the pointer).
-  static void addComponent(
-			   Alignable*
-			   );
+  static void addComponent(Alignable*);
 
-  protected:
-
+protected:
   bool theFirstEvent;
 
-  private:
-
-  static Alignable* theDetector; // only one detector
+private:
+  static Alignable* theDetector;  // only one detector
 };
 
-Alignable* SurveyInputBase::detector()
-{
-  return theDetector;
-}
+Alignable* SurveyInputBase::detector() { return theDetector; }
 
 #endif

--- a/Alignment/SurveyAnalysis/interface/SurveyInputTextReader.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyInputTextReader.h
@@ -15,27 +15,23 @@
 #include "Alignment/CommonAlignment/interface/StructureType.h"
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 
-class SurveyInputTextReader
-{
+class SurveyInputTextReader {
 public:
-
   typedef std::pair<align::ID, align::StructureType> UniqueId;
 
   typedef std::map<UniqueId, align::Scalars> MapType;
   typedef std::pair<UniqueId, align::Scalars> PairType;
 
   /// Read given text file
-  void readFile( const std::string& textFileName );
+  void readFile(const std::string& textFileName);
 
   // Returns the Map
   const MapType& UniqueIdMap() const { return theMap; }
 
 private:
-	
   MapType theMap;
 
-  static const int NINPUTS = 27; // Not including DetId
-	
+  static const int NINPUTS = 27;  // Not including DetId
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/interface/SurveyOutput.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyOutput.h
@@ -18,21 +18,15 @@
 
 class Alignable;
 
-class SurveyOutput
-{
-  public:
-
-  SurveyOutput(const align::Alignables&,
-	       const std::string& fileName
-	       );
+class SurveyOutput {
+public:
+  SurveyOutput(const align::Alignables&, const std::string& fileName);
 
   /// write out variables
-  void write(
-	     unsigned int iter // iteration number
-	     );
+  void write(unsigned int iter  // iteration number
+  );
 
-  private:
-
+private:
   const align::Alignables& theAlignables;
 
   TFile theFile;

--- a/Alignment/SurveyAnalysis/interface/SurveyParameters.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyParameters.h
@@ -14,47 +14,27 @@
 
 #include "Alignment/CommonAlignment/interface/AlignmentParameters.h"
 
-class SurveyParameters:
-  public AlignmentParameters
-{
-  public:
-
+class SurveyParameters : public AlignmentParameters {
+public:
   /// Set the alignable, parameters, covariance in base class.
   /// No user variables, default is all parameters are selected and valid.
-  SurveyParameters(
-		   Alignable*,
-		   const AlgebraicVector& par,
-		   const AlgebraicSymMatrix& cov
-		   );
+  SurveyParameters(Alignable*, const AlgebraicVector& par, const AlgebraicSymMatrix& cov);
 
   /// apply not implemented
   void apply() override;
   int type() const override;
 
   /// Cloning not implemented.
-  AlignmentParameters* clone(
-				     const AlgebraicVector&,
-                                     const AlgebraicSymMatrix&
-				     ) const override;
+  AlignmentParameters* clone(const AlgebraicVector&, const AlgebraicSymMatrix&) const override;
 
   /// Cloning not implemented.
-  AlignmentParameters* cloneFromSelected(
-						 const AlgebraicVector&,
-                                                 const AlgebraicSymMatrix&
-						 ) const override;
+  AlignmentParameters* cloneFromSelected(const AlgebraicVector&, const AlgebraicSymMatrix&) const override;
 
   /// Derivatives not implemented.
-  AlgebraicMatrix derivatives(
-				      const TrajectoryStateOnSurface&,
-				      const AlignableDetOrUnitPtr&
-				      ) const override;
+  AlgebraicMatrix derivatives(const TrajectoryStateOnSurface&, const AlignableDetOrUnitPtr&) const override;
 
   /// Derivatives not implemented.
-  AlgebraicMatrix selectedDerivatives(
-					      const TrajectoryStateOnSurface&,
-					      const AlignableDetOrUnitPtr&
-					      ) const override;
-
+  AlgebraicMatrix selectedDerivatives(const TrajectoryStateOnSurface&, const AlignableDetOrUnitPtr&) const override;
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/interface/SurveyPxbDicer.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyPxbDicer.h
@@ -18,61 +18,59 @@
 
 //! Class to dice a picture from a given set of fiducial points
 //! This class has its use for toy MC simulations to validate the PXB survey
-class SurveyPxbDicer
-{
+class SurveyPxbDicer {
 public:
-	typedef SurveyPxbImage::coord_t coord_t;
-	typedef double value_t;
-	typedef std::vector<coord_t> fidpoint_t;
-	typedef unsigned int count_t;
-	typedef SurveyPxbImage::id_t id_t;
-	typedef std::pair<id_t,id_t> idPair_t;
+  typedef SurveyPxbImage::coord_t coord_t;
+  typedef double value_t;
+  typedef std::vector<coord_t> fidpoint_t;
+  typedef unsigned int count_t;
+  typedef SurveyPxbImage::id_t id_t;
+  typedef std::pair<id_t, id_t> idPair_t;
 
-	// Constructors
-	SurveyPxbDicer() {};
-	// Constructor from VPSet
-	SurveyPxbDicer(const std::vector<edm::ParameterSet>& pars, unsigned int seed);
+  // Constructors
+  SurveyPxbDicer(){};
+  // Constructor from VPSet
+  SurveyPxbDicer(const std::vector<edm::ParameterSet> &pars, unsigned int seed);
 
-	//! Invoke the dicer
-	//! \param fidpointvec vector with fiducial points where values need to be diced for and transformed to the photo fram
-	//! \param idPair pair of the id values
-	std::string doDice(const fidpoint_t &fidpointvec, const idPair_t &id, const bool rotate=false);
-	void doDice(const fidpoint_t &fidpointvec, const idPair_t &id, std::ofstream &outfile, const bool rotate=false);
+  //! Invoke the dicer
+  //! \param fidpointvec vector with fiducial points where values need to be diced for and transformed to the photo fram
+  //! \param idPair pair of the id values
+  std::string doDice(const fidpoint_t &fidpointvec, const idPair_t &id, const bool rotate = false);
+  void doDice(const fidpoint_t &fidpointvec, const idPair_t &id, std::ofstream &outfile, const bool rotate = false);
 
 private:
-	//! invoke the RNG to geat a gaussian smeared value
-	//! \param mean mean value
-	//! \param sigma 
-	value_t ranGauss(value_t mean, value_t sigma) {return CLHEP::RandGauss::shoot(mean,sigma);};
+  //! invoke the RNG to geat a gaussian smeared value
+  //! \param mean mean value
+  //! \param sigma
+  value_t ranGauss(value_t mean, value_t sigma) { return CLHEP::RandGauss::shoot(mean, sigma); };
 
-	value_t mean_a0, sigma_a0;
-	value_t mean_a1, sigma_a1;
-	value_t mean_scale, sigma_scale;
-	value_t mean_phi, sigma_phi;
-	value_t mean_x, sigma_x;
-	value_t mean_y, sigma_y;
+  value_t mean_a0, sigma_a0;
+  value_t mean_a1, sigma_a1;
+  value_t mean_scale, sigma_scale;
+  value_t mean_phi, sigma_phi;
+  value_t mean_x, sigma_x;
+  value_t mean_y, sigma_y;
 
-	//! Gets parameter by name from the VPSet
-	//! \param name name of the parameter to be searched for in field 'name' of the VPSet
-	//! \param par selects the value, i.e. mean or sigma
-	//! \param pars reference to VPSet
-	value_t getParByName(const std::string &name, const std::string &par, const std::vector<edm::ParameterSet>& pars);
+  //! Gets parameter by name from the VPSet
+  //! \param name name of the parameter to be searched for in field 'name' of the VPSet
+  //! \param par selects the value, i.e. mean or sigma
+  //! \param pars reference to VPSet
+  value_t getParByName(const std::string &name, const std::string &par, const std::vector<edm::ParameterSet> &pars);
 
-	//! Transform the diced values to the frame of a toy photograph
-	//! \param x coordinate to be transformed from local frame to photo frame
-	//! \param a0 Transformation parameter, shift in x
-	//! \param a1 Transformation parameter, shift in y
-	//! \param a2 Transformation parameter, scale*cos(phi)
-	//! \param a3 Transformation parameter, scale*sin(phi)
-	coord_t transform(const coord_t &x, const value_t &a0, const value_t &a1, const value_t &a2, const value_t &a3);
+  //! Transform the diced values to the frame of a toy photograph
+  //! \param x coordinate to be transformed from local frame to photo frame
+  //! \param a0 Transformation parameter, shift in x
+  //! \param a1 Transformation parameter, shift in y
+  //! \param a2 Transformation parameter, scale*cos(phi)
+  //! \param a3 Transformation parameter, scale*sin(phi)
+  coord_t transform(const coord_t &x, const value_t &a0, const value_t &a1, const value_t &a2, const value_t &a3);
 
-	//! Function object for searching for a parameter in the VPSet
-	struct findParByName {
-		bool operator () ( const std::string &name, const edm::ParameterSet &parset )
-			const {	return (parset.getParameter<std::string>("name") == name);}
-	};
-
+  //! Function object for searching for a parameter in the VPSet
+  struct findParByName {
+    bool operator()(const std::string &name, const edm::ParameterSet &parset) const {
+      return (parset.getParameter<std::string>("name") == name);
+    }
+  };
 };
 
 #endif
-

--- a/Alignment/SurveyAnalysis/interface/SurveyPxbImage.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyPxbImage.h
@@ -9,26 +9,25 @@
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
 
 //! Class to hold one picture of the BPix survey
-class SurveyPxbImage
-{
-    public:
-	typedef unsigned int count_t;
-	typedef unsigned int id_t;
-	typedef double value_t;
-	typedef Point3DBase<value_t, LocalTag> coord_t;
-	typedef std::pair<id_t,id_t> idPair_t;
+class SurveyPxbImage {
+public:
+  typedef unsigned int count_t;
+  typedef unsigned int id_t;
+  typedef double value_t;
+  typedef Point3DBase<value_t, LocalTag> coord_t;
+  typedef std::pair<id_t, id_t> idPair_t;
 
-	//! \p enum to help access specific locations on a picture
-	enum location{
-	    ll, // lower left mark   (0)
-	    ul, // upper left mark   (1)
-	    lr, // lower right mark  (2)
-	    ur  // upper right mark  (3)
-	};
+  //! \p enum to help access specific locations on a picture
+  enum location {
+    ll,  // lower left mark   (0)
+    ul,  // upper left mark   (1)
+    lr,  // lower right mark  (2)
+    ur   // upper right mark  (3)
+  };
 
-	// Constructors
-	SurveyPxbImage();
-	/*! Constructor from a string stream.\n
+  // Constructors
+  SurveyPxbImage();
+  /*! Constructor from a string stream.\n
 	  Observe the ordering:
 	  A line needs to be of the form <tt>rawID1 y_1_1 x_1_1 y_2_1 x_2_1 rawId2 y_1_2 x_1_2 y_2_2 x_2_2 sigma_y sigma_x</tt>\n
 	  <tt>x_i_1</tt> denoting the left, <tt>x_i_2</tt> the right module. The data is then mapped to
@@ -49,53 +48,47 @@ class SurveyPxbImage
 	  - <tt>y_2_2, x_2_2 -> (3)</tt>
 	  The sigmas denote the Gaussian error of the measurement in the u and v coordinate
 	  */
-	SurveyPxbImage(std::istringstream &iss) : isValidFlag_(false)
-	{
-		fill(iss);
-	};
+  SurveyPxbImage(std::istringstream &iss) : isValidFlag_(false) { fill(iss); };
 
-	void fill(std::istringstream &iss);
+  void fill(std::istringstream &iss);
 
-	//! Get \p Id of first module
-	id_t getIdFirst() { return idPair_.first; };
-	//! Get \p Id of second module
-	id_t getIdSecond() { return idPair_.second; };
-	//! Get \p Id pair
-	const idPair_t getIdPair() { return idPair_; };
+  //! Get \p Id of first module
+  id_t getIdFirst() { return idPair_.first; };
+  //! Get \p Id of second module
+  id_t getIdSecond() { return idPair_.second; };
+  //! Get \p Id pair
+  const idPair_t getIdPair() { return idPair_; };
 
-	/*! Get coordinate of a measurement
+  /*! Get coordinate of a measurement
 	  \param m number of mark
 	 */
-        const coord_t getCoord(count_t m);	
+  const coord_t getCoord(count_t m);
 
-	//! Get Gaussian error in u direction
-        value_t getSigmaX() { return sigma_x_; }
+  //! Get Gaussian error in u direction
+  value_t getSigmaX() { return sigma_x_; }
 
-	//! Get Gaussian error in u direction
-	value_t getSigmaY() { return sigma_y_; }
+  //! Get Gaussian error in u direction
+  value_t getSigmaY() { return sigma_y_; }
 
-	//! returns validity flag
-	bool isValid() { return isValidFlag_; };
-	
+  //! returns validity flag
+  bool isValid() { return isValidFlag_; };
 
-    protected:
-	//! Vector to hold four measurements
-	std::vector<coord_t> measurementVec_;
+protected:
+  //! Vector to hold four measurements
+  std::vector<coord_t> measurementVec_;
 
-	//! Gaussian errors
-	value_t sigma_x_, sigma_y_;
+  //! Gaussian errors
+  value_t sigma_x_, sigma_y_;
 
-	//! Flag if the image was rotated or not
-	bool isRotated_;
+  //! Flag if the image was rotated or not
+  bool isRotated_;
 
-	//! Validity Flag
-	bool isValidFlag_;
-	
-	//! Pair to hold the Id's of the involved modules
-	//! first: module with lower Id
-	idPair_t idPair_;
-	
+  //! Validity Flag
+  bool isValidFlag_;
+
+  //! Pair to hold the Id's of the involved modules
+  //! first: module with lower Id
+  idPair_t idPair_;
 };
 
 #endif
-

--- a/Alignment/SurveyAnalysis/interface/SurveyPxbImageLocalFit.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyPxbImageLocalFit.h
@@ -11,108 +11,101 @@
 #include <iostream>
 
 //! Class to hold one picture of the BPix survey and the local fit
-class SurveyPxbImageLocalFit : public SurveyPxbImage
-{
+class SurveyPxbImageLocalFit : public SurveyPxbImage {
 public:
-	typedef std::vector<value_t> localpars_t;
-	typedef std::vector<coord_t> fidpoint_t;
-	typedef unsigned int count_t;
-	static const count_t nGlD = 3; // no of global derivs
-	static const count_t nLcD = 4; // no of local derivs
-	static const count_t nMsrmts = 8; // no of measurements per image
-	static const count_t nLcPars = 4; // no of local parameters
-	static const count_t nFidpoints = 4; // no of fiducial points
-	// Typedefs for pede
-	typedef int pede_label_t;
-	typedef float pede_deriv_t;
+  typedef std::vector<value_t> localpars_t;
+  typedef std::vector<coord_t> fidpoint_t;
+  typedef unsigned int count_t;
+  static const count_t nGlD = 3;        // no of global derivs
+  static const count_t nLcD = 4;        // no of local derivs
+  static const count_t nMsrmts = 8;     // no of measurements per image
+  static const count_t nLcPars = 4;     // no of local parameters
+  static const count_t nFidpoints = 4;  // no of fiducial points
+  // Typedefs for pede
+  typedef int pede_label_t;
+  typedef float pede_deriv_t;
 
-	// Constructors
-	SurveyPxbImageLocalFit(): 
-		SurveyPxbImage(), a_(nLcPars,0), fidpoints_(nFidpoints), fitValidFlag_(false), derivsValidFlag_(false)
-	{
-		initFidPoints();
-	};
+  // Constructors
+  SurveyPxbImageLocalFit()
+      : SurveyPxbImage(), a_(nLcPars, 0), fidpoints_(nFidpoints), fitValidFlag_(false), derivsValidFlag_(false) {
+    initFidPoints();
+  };
 
-	//! Constructor from istringstream
-	SurveyPxbImageLocalFit(std::istringstream &iss): 
-	    SurveyPxbImage(iss), a_(nLcPars,0), fidpoints_(nFidpoints), fitValidFlag_(false), derivsValidFlag_(false)
-	{
-		initFidPoints();
-	};
+  //! Constructor from istringstream
+  SurveyPxbImageLocalFit(std::istringstream& iss)
+      : SurveyPxbImage(iss), a_(nLcPars, 0), fidpoints_(nFidpoints), fitValidFlag_(false), derivsValidFlag_(false) {
+    initFidPoints();
+  };
 
-	//! Invoke the fit
-	void doFit(const fidpoint_t &fidpointvec);
-	void doFit(const fidpoint_t &fidpointvec, const pede_label_t &label1, const pede_label_t &label2);
-	void doFit(value_t x1, value_t y1, value_t g1, value_t x2, value_t y2, value_t g2);
+  //! Invoke the fit
+  void doFit(const fidpoint_t& fidpointvec);
+  void doFit(const fidpoint_t& fidpointvec, const pede_label_t& label1, const pede_label_t& label2);
+  void doFit(value_t x1, value_t y1, value_t g1, value_t x2, value_t y2, value_t g2);
 
-	//! returns validity flag
-	bool isFitValid() { return fitValidFlag_; };
+  //! returns validity flag
+  bool isFitValid() { return fitValidFlag_; };
 
-	//! returns local parameters after fit
-	localpars_t getLocalParameters();
+  //! returns local parameters after fit
+  localpars_t getLocalParameters();
 
-	//! returns the chi^2 of the fit
-	value_t getChi2();
+  //! returns the chi^2 of the fit
+  value_t getChi2();
 
-	pede_label_t getLocalDerivsSize()                      {return nLcD; };
-	pede_label_t getGlobalDerivsSize()                     {return nGlD; };
-	const pede_deriv_t* getLocalDerivsPtr(count_t i)       {return localDerivsMatrix_.Array()+i*nLcD; };
-	const pede_deriv_t* getGlobalDerivsPtr(count_t i)      {return globalDerivsMatrix_.Array()+i*nGlD;};
-	const pede_label_t* getGlobalDerivsLabelPtr(count_t i) {return i<4 ? &labelVec1_[0] : &labelVec2_[0];};
-	pede_deriv_t getResiduum(count_t i) { return (pede_deriv_t) r(i); };
-	pede_deriv_t getSigma(count_t i) { return i%2 ? sigma_x_ : sigma_y_ ; };
+  pede_label_t getLocalDerivsSize() { return nLcD; };
+  pede_label_t getGlobalDerivsSize() { return nGlD; };
+  const pede_deriv_t* getLocalDerivsPtr(count_t i) { return localDerivsMatrix_.Array() + i * nLcD; };
+  const pede_deriv_t* getGlobalDerivsPtr(count_t i) { return globalDerivsMatrix_.Array() + i * nGlD; };
+  const pede_label_t* getGlobalDerivsLabelPtr(count_t i) { return i < 4 ? &labelVec1_[0] : &labelVec2_[0]; };
+  pede_deriv_t getResiduum(count_t i) { return (pede_deriv_t)r(i); };
+  pede_deriv_t getSigma(count_t i) { return i % 2 ? sigma_x_ : sigma_y_; };
 
-	void setLocalDerivsToZero(count_t i);
-	void setGlobalDerivsToZero(count_t i);
+  void setLocalDerivsToZero(count_t i);
+  void setGlobalDerivsToZero(count_t i);
 
 private:
-	//! Local parameters
-	localpars_t a_;
-	
-	//! Vector of residuals
-	ROOT::Math::SVector<value_t, nMsrmts> r;
+  //! Local parameters
+  localpars_t a_;
 
-	//! Matrix with global derivs
-	//std::vector<localDerivs_t> globalDerivsVec_;
-	ROOT::Math::SMatrix<pede_deriv_t,nMsrmts,nGlD> globalDerivsMatrix_;
+  //! Vector of residuals
+  ROOT::Math::SVector<value_t, nMsrmts> r;
 
-	//! Matrix with local derivs
-	//std::vector<globalDerivs_t> localDerivsVec_;
-	ROOT::Math::SMatrix<pede_deriv_t,nMsrmts,nLcD> localDerivsMatrix_;
+  //! Matrix with global derivs
+  //std::vector<localDerivs_t> globalDerivsVec_;
+  ROOT::Math::SMatrix<pede_deriv_t, nMsrmts, nGlD> globalDerivsMatrix_;
 
-	//! Vector with labels to global derivs
-	std::vector<pede_label_t> labelVec1_, labelVec2_;
+  //! Matrix with local derivs
+  //std::vector<globalDerivs_t> localDerivsVec_;
+  ROOT::Math::SMatrix<pede_deriv_t, nMsrmts, nLcD> localDerivsMatrix_;
 
-	//! True position of the fiducial points on a sensor wrt. local frame (u,v)
-	std::vector<coord_t> fidpoints_;
+  //! Vector with labels to global derivs
+  std::vector<pede_label_t> labelVec1_, labelVec2_;
 
-	//! chi2 of the local fit
-	value_t chi2_;
+  //! True position of the fiducial points on a sensor wrt. local frame (u,v)
+  std::vector<coord_t> fidpoints_;
 
-	//! Validity Flag
-	bool fitValidFlag_;
+  //! chi2 of the local fit
+  value_t chi2_;
 
-	//! 
-	bool derivsValidFlag_;
+  //! Validity Flag
+  bool fitValidFlag_;
 
-	//! Initialise the fiducial points
-	void initFidPoints()
-	{
-		fidpoints_[0] = coord_t(-0.91,-3.30);
-		fidpoints_[1] = coord_t(+0.91,-3.30);
-		fidpoints_[2] = coord_t(-0.91,+3.30);
-		fidpoints_[3] = coord_t(+0.91,+3.30);
-	}
+  //!
+  bool derivsValidFlag_;
 
-	//! Distance
-	value_t dist(const coord_t& p1, const coord_t& p2)
-	{
-	    value_t dx = p1.x()-p2.x();
-	    value_t dy = p1.y()-p2.y();
-	    return sqrt(dx*dx+dy*dy);
-	}
-	
+  //! Initialise the fiducial points
+  void initFidPoints() {
+    fidpoints_[0] = coord_t(-0.91, -3.30);
+    fidpoints_[1] = coord_t(+0.91, -3.30);
+    fidpoints_[2] = coord_t(-0.91, +3.30);
+    fidpoints_[3] = coord_t(+0.91, +3.30);
+  }
+
+  //! Distance
+  value_t dist(const coord_t& p1, const coord_t& p2) {
+    value_t dx = p1.x() - p2.x();
+    value_t dy = p1.y() - p2.y();
+    return sqrt(dx * dx + dy * dy);
+  }
 };
 
 #endif
-

--- a/Alignment/SurveyAnalysis/interface/SurveyPxbImageReader.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyPxbImageReader.h
@@ -11,70 +11,62 @@
 #include <string>
 
 //! Class to hold one picture of the BPix survey
-template <class T> class SurveyPxbImageReader
-{
-    public:
-		typedef std::vector<T> measurements_t;
+template <class T>
+class SurveyPxbImageReader {
+public:
+  typedef std::vector<T> measurements_t;
 
-	// Constructors
-	//! Empty default constructor
-	SurveyPxbImageReader() {};
-	//! Constructor with ifstream and destination vector
-	SurveyPxbImageReader(std::ifstream &infile, measurements_t &measurements, SurveyPxbImage::count_t reserve = 800)
-	{
-		read(infile, measurements, reserve);
-	};
+  // Constructors
+  //! Empty default constructor
+  SurveyPxbImageReader(){};
+  //! Constructor with ifstream and destination vector
+  SurveyPxbImageReader(std::ifstream &infile, measurements_t &measurements, SurveyPxbImage::count_t reserve = 800) {
+    read(infile, measurements, reserve);
+  };
 
-	//! Constructor with filename and destination vector
-	SurveyPxbImageReader(std::string filename, measurements_t &measurements, SurveyPxbImage::count_t reserve = 800)
-	{ 
-		std::ifstream infile(filename.c_str());
-		if (!infile)
-		{
-			std::cerr << "Cannot open file " << filename
-			     << " - operation aborted." << std::endl;
-		}
-		read(infile, measurements, reserve);
-   	};
-	
-	//! Reads a file, parses its content and fills the data vector
-	//! All data after a hash sign (#) is treated as a comment and not read
-	//! \param filename Filename of the file to be read
-	//! \param measurements Vector containing the measurements, previous content will be deleted
-	//! \param reserve Initial size of the vector, set with vector::reserve()
-	//! \return number of succesfully read entries
-	SurveyPxbImage::count_t read(std::ifstream &infile, measurements_t &measurements, SurveyPxbImage::count_t reserve = 830)
-	{
+  //! Constructor with filename and destination vector
+  SurveyPxbImageReader(std::string filename, measurements_t &measurements, SurveyPxbImage::count_t reserve = 800) {
+    std::ifstream infile(filename.c_str());
+    if (!infile) {
+      std::cerr << "Cannot open file " << filename << " - operation aborted." << std::endl;
+    }
+    read(infile, measurements, reserve);
+  };
 
-		// prepare the measurements vector
-		measurements.clear();
-		measurements.reserve(reserve);
+  //! Reads a file, parses its content and fills the data vector
+  //! All data after a hash sign (#) is treated as a comment and not read
+  //! \param filename Filename of the file to be read
+  //! \param measurements Vector containing the measurements, previous content will be deleted
+  //! \param reserve Initial size of the vector, set with vector::reserve()
+  //! \return number of succesfully read entries
+  SurveyPxbImage::count_t read(std::ifstream &infile,
+                               measurements_t &measurements,
+                               SurveyPxbImage::count_t reserve = 830) {
+    // prepare the measurements vector
+    measurements.clear();
+    measurements.reserve(reserve);
 
-		// container for the current line
-		std::string aLine;
+    // container for the current line
+    std::string aLine;
 
-	    // loop over lines of input file
-	    while (std::getline(infile,aLine))
-	    {
-	        // strip off everything after a hash
-	        std::string stripped = "";
-	        std::string::iterator iter = std::find(aLine.begin(), aLine.end(), '#');
-	        std::copy(aLine.begin(), iter, std::back_inserter(stripped));
-	        // read one measurment and add to vector if successfull
-	        std::istringstream iss(stripped, std::istringstream::in);
-	        T curMeas(iss);
-	        if (curMeas.isValid())
-	        {
-	             measurements.push_back(curMeas);
-	        }
-	    }
+    // loop over lines of input file
+    while (std::getline(infile, aLine)) {
+      // strip off everything after a hash
+      std::string stripped = "";
+      std::string::iterator iter = std::find(aLine.begin(), aLine.end(), '#');
+      std::copy(aLine.begin(), iter, std::back_inserter(stripped));
+      // read one measurment and add to vector if successfull
+      std::istringstream iss(stripped, std::istringstream::in);
+      T curMeas(iss);
+      if (curMeas.isValid()) {
+        measurements.push_back(curMeas);
+      }
+    }
 
-		return measurements.size();
-	}
+    return measurements.size();
+  }
 
-    protected:
-
+protected:
 };
 
 #endif
-

--- a/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.cc
+++ b/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.cc
@@ -28,509 +28,991 @@
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-CreateSurveyRcds::CreateSurveyRcds(const edm::ParameterSet& cfg)
-{
-	m_inputGeom = cfg.getUntrackedParameter< std::string > ("inputGeom");
-	m_inputSimpleMis = cfg.getUntrackedParameter< double > ("simpleMis");
-	m_generatedRandom = cfg.getUntrackedParameter< bool > ("generatedRandom");
-	m_generatedSimple = cfg.getUntrackedParameter< bool > ("generatedSimple");
+CreateSurveyRcds::CreateSurveyRcds(const edm::ParameterSet& cfg) {
+  m_inputGeom = cfg.getUntrackedParameter<std::string>("inputGeom");
+  m_inputSimpleMis = cfg.getUntrackedParameter<double>("simpleMis");
+  m_generatedRandom = cfg.getUntrackedParameter<bool>("generatedRandom");
+  m_generatedSimple = cfg.getUntrackedParameter<bool>("generatedSimple");
 }
 
-void CreateSurveyRcds::analyze(const edm::Event& event, const edm::EventSetup& setup){
+void CreateSurveyRcds::analyze(const edm::Event& event, const edm::EventSetup& setup) {
+  //Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHandle;
+  setup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  const TrackerTopology* const tTopo = tTopoHandle.product();
 
-	//Retrieve tracker topology from geometry
-	edm::ESHandle<TrackerTopology> tTopoHandle;
-	setup.get<TrackerTopologyRcd>().get(tTopoHandle);
-	const TrackerTopology* const tTopo = tTopoHandle.product();
-	
-	edm::ESHandle<GeometricDet>  geom;
-	setup.get<IdealGeometryRecord>().get(geom);	 
-	edm::ESHandle<PTrackerParameters> ptp;
-	setup.get<PTrackerParametersRcd>().get( ptp );
-	TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(&*geom, *ptp, tTopo);
-	
-	//take geometry from DB or randomly generate geometry
-	if (m_inputGeom == "sqlite"){
-		//build the tracker
-        edm::ESHandle<Alignments> alignments;
-        edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-        
-        setup.get<TrackerAlignmentRcd>().get(alignments);
-        setup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
-        
-        //apply the latest alignments
-        GeometryAligner aligner;
-        aligner.applyAlignments<TrackerGeometry>( &(*tracker), &(*alignments), &(*alignmentErrors), AlignTransform() );
-		
-	}
-	
-	
-	addComponent(new AlignableTracker( tracker, tTopo ) );
-	
-	Alignable* ali = detector();
-	if(m_inputGeom == "generated"){
-		setGeometry( ali );
-	}
-	
-	setSurveyErrors( ali ); 
-	
+  edm::ESHandle<GeometricDet> geom;
+  setup.get<IdealGeometryRecord>().get(geom);
+  edm::ESHandle<PTrackerParameters> ptp;
+  setup.get<PTrackerParametersRcd>().get(ptp);
+  TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(&*geom, *ptp, tTopo);
+
+  //take geometry from DB or randomly generate geometry
+  if (m_inputGeom == "sqlite") {
+    //build the tracker
+    edm::ESHandle<Alignments> alignments;
+    edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
+
+    setup.get<TrackerAlignmentRcd>().get(alignments);
+    setup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
+
+    //apply the latest alignments
+    GeometryAligner aligner;
+    aligner.applyAlignments<TrackerGeometry>(&(*tracker), &(*alignments), &(*alignmentErrors), AlignTransform());
+  }
+
+  addComponent(new AlignableTracker(tracker, tTopo));
+
+  Alignable* ali = detector();
+  if (m_inputGeom == "generated") {
+    setGeometry(ali);
+  }
+
+  setSurveyErrors(ali);
 }
 
-void CreateSurveyRcds::setGeometry(Alignable* ali)
-{
-	
-	const align::Alignables& comp = ali->components();
-	unsigned int nComp = comp.size();
-	//move then do for lower level object
-	//for issue of det vs detunit
-	bool usecomps = true;
-	if ((ali->alignableObjectId()==2)&&(nComp>=1)) usecomps = false;
-	for (unsigned int i = 0; i < nComp; ++i){
-		if (usecomps) setGeometry(comp[i]);
-	}
-	DetId id( ali->id() );
-	int subdetlevel = id.subdetId();
-	int level = ali->alignableObjectId();
-		
-	//for random misalignment
-	if (m_generatedRandom){
-		if (subdetlevel > 0){
-			AlgebraicVector value = getStructureErrors(level, subdetlevel);
+void CreateSurveyRcds::setGeometry(Alignable* ali) {
+  const align::Alignables& comp = ali->components();
+  unsigned int nComp = comp.size();
+  //move then do for lower level object
+  //for issue of det vs detunit
+  bool usecomps = true;
+  if ((ali->alignableObjectId() == 2) && (nComp >= 1))
+    usecomps = false;
+  for (unsigned int i = 0; i < nComp; ++i) {
+    if (usecomps)
+      setGeometry(comp[i]);
+  }
+  DetId id(ali->id());
+  int subdetlevel = id.subdetId();
+  int level = ali->alignableObjectId();
 
-			double value0 = CLHEP::RandGauss::shoot(0,value[0]);
-			double value1 = CLHEP::RandGauss::shoot(0,value[1]);
-			double value2 = CLHEP::RandGauss::shoot(0,value[2]);
-			double value3 = CLHEP::RandGauss::shoot(0,value[3]);
-			double value4 = CLHEP::RandGauss::shoot(0,value[4]);
-			double value5 = CLHEP::RandGauss::shoot(0,value[5]);
-			
-			//move/rotate the surface
-			align::LocalVector diffR(value0,value1,value2);
-			align::Scalar diffWx = value3;
-			align::Scalar diffWy = value4;
-			align::Scalar diffWz = value5;
-			ali->move(ali->surface().toGlobal(diffR));
-			ali->rotateAroundLocalX(diffWx);
-			ali->rotateAroundLocalY(diffWy);
-			ali->rotateAroundLocalZ(diffWz);
-		}
-	}
-	
-	// for simple misalignments
-	if (m_generatedSimple){
-		if ((level == 2)||((level == 1)&&(ali->mother()->alignableObjectId() != 2))){
-			
-			const double constMis = m_inputSimpleMis;
-			const double dAngle = constMis/ali->surface().length();
-			//std::cout << "Shift: " << constMis << ", Rot: " << dAngle << std::endl;
-			double value0 = CLHEP::RandGauss::shoot(0, constMis);
-			double value1 = CLHEP::RandGauss::shoot(0, constMis);
-			double value2 = CLHEP::RandGauss::shoot(0, constMis);
-			double value3 = CLHEP::RandGauss::shoot(0, dAngle);
-			double value4 = CLHEP::RandGauss::shoot(0, dAngle);
-			double value5 = CLHEP::RandGauss::shoot(0, dAngle);
-			
-			align::LocalVector diffR(value0,value1,value2);
-			ali->move(ali->surface().toGlobal(diffR));
-			align::Scalar diffWx = value3;
-			align::Scalar diffWy = value4;
-			align::Scalar diffWz = value5;
-			ali->rotateAroundLocalX(diffWx);
-			ali->rotateAroundLocalY(diffWy);
-			ali->rotateAroundLocalZ(diffWz);
-		}
-	}
-	
+  //for random misalignment
+  if (m_generatedRandom) {
+    if (subdetlevel > 0) {
+      AlgebraicVector value = getStructureErrors(level, subdetlevel);
+
+      double value0 = CLHEP::RandGauss::shoot(0, value[0]);
+      double value1 = CLHEP::RandGauss::shoot(0, value[1]);
+      double value2 = CLHEP::RandGauss::shoot(0, value[2]);
+      double value3 = CLHEP::RandGauss::shoot(0, value[3]);
+      double value4 = CLHEP::RandGauss::shoot(0, value[4]);
+      double value5 = CLHEP::RandGauss::shoot(0, value[5]);
+
+      //move/rotate the surface
+      align::LocalVector diffR(value0, value1, value2);
+      align::Scalar diffWx = value3;
+      align::Scalar diffWy = value4;
+      align::Scalar diffWz = value5;
+      ali->move(ali->surface().toGlobal(diffR));
+      ali->rotateAroundLocalX(diffWx);
+      ali->rotateAroundLocalY(diffWy);
+      ali->rotateAroundLocalZ(diffWz);
+    }
+  }
+
+  // for simple misalignments
+  if (m_generatedSimple) {
+    if ((level == 2) || ((level == 1) && (ali->mother()->alignableObjectId() != 2))) {
+      const double constMis = m_inputSimpleMis;
+      const double dAngle = constMis / ali->surface().length();
+      //std::cout << "Shift: " << constMis << ", Rot: " << dAngle << std::endl;
+      double value0 = CLHEP::RandGauss::shoot(0, constMis);
+      double value1 = CLHEP::RandGauss::shoot(0, constMis);
+      double value2 = CLHEP::RandGauss::shoot(0, constMis);
+      double value3 = CLHEP::RandGauss::shoot(0, dAngle);
+      double value4 = CLHEP::RandGauss::shoot(0, dAngle);
+      double value5 = CLHEP::RandGauss::shoot(0, dAngle);
+
+      align::LocalVector diffR(value0, value1, value2);
+      ali->move(ali->surface().toGlobal(diffR));
+      align::Scalar diffWx = value3;
+      align::Scalar diffWy = value4;
+      align::Scalar diffWz = value5;
+      ali->rotateAroundLocalX(diffWx);
+      ali->rotateAroundLocalY(diffWy);
+      ali->rotateAroundLocalZ(diffWz);
+    }
+  }
 }
 
-void CreateSurveyRcds::setSurveyErrors( Alignable* ali ){
-	
-	const align::Alignables& comp = ali->components();
-	unsigned int nComp = comp.size();
-	//move then do for lower level object
-	//for issue of det vs detunit
-	for (unsigned int i = 0; i < nComp; ++i){
-		setSurveyErrors(comp[i]);
-	}
-	
-	DetId id( ali->id() );
-	int subdetlevel = id.subdetId();
-	int level = ali->alignableObjectId();
-	
-	AlgebraicVector error = getStructureErrors(level, subdetlevel);
-	
-	double error0 = error[0];
-	double error1 = error[1];
-	double error2 = error[2];
-	double error3 = error[3];
-	double error4 = error[4];
-	double error5 = error[5];
+void CreateSurveyRcds::setSurveyErrors(Alignable* ali) {
+  const align::Alignables& comp = ali->components();
+  unsigned int nComp = comp.size();
+  //move then do for lower level object
+  //for issue of det vs detunit
+  for (unsigned int i = 0; i < nComp; ++i) {
+    setSurveyErrors(comp[i]);
+  }
 
-	// ----------------INFLATING ERRORS----------------------
-	// inflating sensitive coordinates in each subdetector
-	// tib
-	if ((level <= 2)&&(subdetlevel == 3)){
-		error0 = 0.01; error5 = 0.001;
-		if ((level==2)&&(nComp == 2)){
-			error1 = 0.01;
-		}
-	}
-	// tid
-	if ((level <= 2)&&(subdetlevel == 4)){ 
-		error0=0.01; error1=0.01; error2=0.01; error3=0.001; error4=0.001; error5=0.001;
-		//error0=0.01; error1=0.002; error2=0.002; error3=0.0002; error4=0.0002; error5=0.001;
-		//if ((level == 2)&&(nComp == 2)){
-		//	error1 = 0.01;
-		//}
-	}
-	if ((level == 23)&&(subdetlevel == 4)){ //Ring is a Disk
-		error0=0.02; error1=0.02; error2=0.03; error3=0.0002; error4=0.0002; error5=0.0002;
-	}
-	if ((level == 22)&&(subdetlevel == 4)){ //Side of a Ring
-		error0=0.01; error1=0.01; error2=0.01; error3=0.0002; error4=0.0002; error5=0.0002;
-	}
-	// tob
-	if ((level <= 2)&&(subdetlevel == 5)){
-		//error0 = 0.015; error1 = 0.015; error2 = 0.05; error3 = 0.001; error4 = 0.001; error5 = 0.001;
-		error0 = 0.015; error1 = 0.003; error2 = 0.003; error3 = 0.0002; error4 = 0.0002; error5 = 0.001;
-		if ((level == 2)&&(nComp == 2)){
-			error1 = 0.015;
-		}
-	}
-	if ((level == 27)&&(subdetlevel == 5)){ //Rod in a Layer
-		error0=0.02; error1=0.02; error2=0.03; error3=0.001; error4=0.001; error5=0.001;
-	}	
-	// tec
-	if ((level <= 2)&&(subdetlevel == 6)){
-		error0 = 0.02; error5 = 0.0005; 
-		if ((level==2)&&(nComp == 2)){
-			error1 = 0.02;
-		}
-	}
-	if ((level == 34)&&(subdetlevel == 6)){ //Side on a Disk
-		error0=0.01; error1=0.01; error2=0.02; error3=0.00005; error4=0.00005; error5=0.00005;
-	}
-	if ((level == 33)&&(subdetlevel == 6)){ //Petal on a Side of a Disk
-		error0=0.01; error1=0.01; error2=0.02; error3=0.0001; error4=0.0001; error5=0.0001;
-	}
-	if ((level == 32)&&(subdetlevel == 6)){ //Ring on a Petal
-		error0=0.007; error1=0.007; error2=0.015; error3=0.00015; error4=0.00015; error5=0.00015;
-	}
-	// ----------------INFLATING ERRORS----------------------
-	
-	//create the error matrix
-	align::ErrorMatrix error_Matrix;
-	double * errorData = error_Matrix.Array();
-	errorData[0] = error0*error0; errorData[2] = error1*error1; errorData[5] = error2*error2;
-	errorData[9] = error3*error3; errorData[14] = error4*error4; errorData[20] = error5*error5;
-	errorData[1] = 0.0; 
-	errorData[3] = 0.0; errorData[4] = 0.0; 
-	errorData[6] = 0.0; errorData[7] = 0.0; errorData[8] = 0.0;
-	errorData[10] = 0.0; errorData[11] = 0.0; errorData[12] = 0.0; errorData[13] = 0.0;
-	errorData[15] = 0.0; errorData[16] = 0.0; errorData[17] = 0.0; errorData[18] = 0.0; errorData[19] = 0.0;
-	
-	
-	ali->setSurvey( new SurveyDet(ali->surface(), error_Matrix ) );
-	
+  DetId id(ali->id());
+  int subdetlevel = id.subdetId();
+  int level = ali->alignableObjectId();
+
+  AlgebraicVector error = getStructureErrors(level, subdetlevel);
+
+  double error0 = error[0];
+  double error1 = error[1];
+  double error2 = error[2];
+  double error3 = error[3];
+  double error4 = error[4];
+  double error5 = error[5];
+
+  // ----------------INFLATING ERRORS----------------------
+  // inflating sensitive coordinates in each subdetector
+  // tib
+  if ((level <= 2) && (subdetlevel == 3)) {
+    error0 = 0.01;
+    error5 = 0.001;
+    if ((level == 2) && (nComp == 2)) {
+      error1 = 0.01;
+    }
+  }
+  // tid
+  if ((level <= 2) && (subdetlevel == 4)) {
+    error0 = 0.01;
+    error1 = 0.01;
+    error2 = 0.01;
+    error3 = 0.001;
+    error4 = 0.001;
+    error5 = 0.001;
+    //error0=0.01; error1=0.002; error2=0.002; error3=0.0002; error4=0.0002; error5=0.001;
+    //if ((level == 2)&&(nComp == 2)){
+    //	error1 = 0.01;
+    //}
+  }
+  if ((level == 23) && (subdetlevel == 4)) {  //Ring is a Disk
+    error0 = 0.02;
+    error1 = 0.02;
+    error2 = 0.03;
+    error3 = 0.0002;
+    error4 = 0.0002;
+    error5 = 0.0002;
+  }
+  if ((level == 22) && (subdetlevel == 4)) {  //Side of a Ring
+    error0 = 0.01;
+    error1 = 0.01;
+    error2 = 0.01;
+    error3 = 0.0002;
+    error4 = 0.0002;
+    error5 = 0.0002;
+  }
+  // tob
+  if ((level <= 2) && (subdetlevel == 5)) {
+    //error0 = 0.015; error1 = 0.015; error2 = 0.05; error3 = 0.001; error4 = 0.001; error5 = 0.001;
+    error0 = 0.015;
+    error1 = 0.003;
+    error2 = 0.003;
+    error3 = 0.0002;
+    error4 = 0.0002;
+    error5 = 0.001;
+    if ((level == 2) && (nComp == 2)) {
+      error1 = 0.015;
+    }
+  }
+  if ((level == 27) && (subdetlevel == 5)) {  //Rod in a Layer
+    error0 = 0.02;
+    error1 = 0.02;
+    error2 = 0.03;
+    error3 = 0.001;
+    error4 = 0.001;
+    error5 = 0.001;
+  }
+  // tec
+  if ((level <= 2) && (subdetlevel == 6)) {
+    error0 = 0.02;
+    error5 = 0.0005;
+    if ((level == 2) && (nComp == 2)) {
+      error1 = 0.02;
+    }
+  }
+  if ((level == 34) && (subdetlevel == 6)) {  //Side on a Disk
+    error0 = 0.01;
+    error1 = 0.01;
+    error2 = 0.02;
+    error3 = 0.00005;
+    error4 = 0.00005;
+    error5 = 0.00005;
+  }
+  if ((level == 33) && (subdetlevel == 6)) {  //Petal on a Side of a Disk
+    error0 = 0.01;
+    error1 = 0.01;
+    error2 = 0.02;
+    error3 = 0.0001;
+    error4 = 0.0001;
+    error5 = 0.0001;
+  }
+  if ((level == 32) && (subdetlevel == 6)) {  //Ring on a Petal
+    error0 = 0.007;
+    error1 = 0.007;
+    error2 = 0.015;
+    error3 = 0.00015;
+    error4 = 0.00015;
+    error5 = 0.00015;
+  }
+  // ----------------INFLATING ERRORS----------------------
+
+  //create the error matrix
+  align::ErrorMatrix error_Matrix;
+  double* errorData = error_Matrix.Array();
+  errorData[0] = error0 * error0;
+  errorData[2] = error1 * error1;
+  errorData[5] = error2 * error2;
+  errorData[9] = error3 * error3;
+  errorData[14] = error4 * error4;
+  errorData[20] = error5 * error5;
+  errorData[1] = 0.0;
+  errorData[3] = 0.0;
+  errorData[4] = 0.0;
+  errorData[6] = 0.0;
+  errorData[7] = 0.0;
+  errorData[8] = 0.0;
+  errorData[10] = 0.0;
+  errorData[11] = 0.0;
+  errorData[12] = 0.0;
+  errorData[13] = 0.0;
+  errorData[15] = 0.0;
+  errorData[16] = 0.0;
+  errorData[17] = 0.0;
+  errorData[18] = 0.0;
+  errorData[19] = 0.0;
+
+  ali->setSurvey(new SurveyDet(ali->surface(), error_Matrix));
 }
 
 //-------------------------------------------------------
 // DEFAULT VALUES FOR THE ASSEMBLY PRECISION
 //-------------------------------------------------------
-AlgebraicVector CreateSurveyRcds::getStructurePlacements(int level, int subdetlevel)
-{
-	AlgebraicVector deltaRW(6);
-	deltaRW(1)=0.0; deltaRW(2)=0.0; deltaRW(3)=0.0; deltaRW(4)=0.0; deltaRW(5)=0.0; deltaRW(6)=0.0;
-	//PIXEL
-	if ((level == 37)&&(subdetlevel == 1)){
-		deltaRW(1)=0.3; deltaRW(2)=0.3; deltaRW(3)=0.3; deltaRW(4)=0.0017; deltaRW(5)=0.0017; deltaRW(6)=0.0017;
-	}
-	//STRIP
-	if ((level == 38)&&(subdetlevel == 3)){
-		deltaRW(1)=0.3; deltaRW(2)=0.3; deltaRW(3)=0.3; deltaRW(4)=0.0004; deltaRW(5)=0.0004; deltaRW(6)=0.0004;
-	}
-	//TRACKER
-	if ((level == 39)&&(subdetlevel == 1)){
-		deltaRW(1)=0.0; deltaRW(2)=0.0; deltaRW(3)=0.0; deltaRW(4)=0.0; deltaRW(5)=0.0; deltaRW(6)=0.0;
-	}
-	//TPB
-	if ((level == 7)&&(subdetlevel == 1)){
-		deltaRW(1)=0.2; deltaRW(2)=0.2; deltaRW(3)=0.2; deltaRW(4)=0.003; deltaRW(5)=0.003; deltaRW(6)=0.003;
-	}
-	if ((level == 6)&&(subdetlevel == 1)){
-		deltaRW(1)=0.05; deltaRW(2)=0.05; deltaRW(3)=0.05; deltaRW(4)=0.0008; deltaRW(5)=0.0008; deltaRW(6)=0.0008;
-	}
-	if ((level == 5)&&(subdetlevel == 1)){
-		deltaRW(1)=0.02; deltaRW(2)=0.02; deltaRW(3)=0.02; deltaRW(4)=0.0004; deltaRW(5)=0.0004; deltaRW(6)=0.0004;
-	}
-	if ((level == 4)&&(subdetlevel == 1)){
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.005; deltaRW(4)=0.0002; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	if ((level == 2)&&(subdetlevel == 1)){
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.003; deltaRW(4)=0.001; deltaRW(5)=0.001; deltaRW(6)=0.001;
-	}
-	if ((level == 1)&&(subdetlevel == 1)){
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.003; deltaRW(4)=0.001; deltaRW(5)=0.001; deltaRW(6)=0.001;
-	}
-	//TPE
-	if ((level == 13)&&(subdetlevel == 2)){
-		deltaRW(1)=0.2; deltaRW(2)=0.2; deltaRW(3)=0.2; deltaRW(4)=0.0017; deltaRW(5)=0.0017; deltaRW(6)=0.0017;
-	}
-	if ((level == 12)&&(subdetlevel == 2)){
-		deltaRW(1)=0.05; deltaRW(2)=0.05; deltaRW(3)=0.05; deltaRW(4)=0.0004; deltaRW(5)=0.0004; deltaRW(6)=0.0004;
-	}
-	if ((level == 11)&&(subdetlevel == 2)){
-		deltaRW(1)=0.02; deltaRW(2)=0.02; deltaRW(3)=0.02; deltaRW(4)=0.001; deltaRW(5)=0.001; deltaRW(6)=0.001;
-	}
-	if ((level == 10)&&(subdetlevel == 2)){
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.01; deltaRW(4)=0.001; deltaRW(5)=0.001; deltaRW(6)=0.001;
-	}
-	if ((level == 9)&&(subdetlevel == 2)){
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.005; deltaRW(4)=0.002; deltaRW(5)=0.002; deltaRW(6)=0.002;
-	}
-	if ((level == 2)&&(subdetlevel == 2)){
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.003; deltaRW(4)=0.001; deltaRW(5)=0.001; deltaRW(6)=0.001;
-	}
-	if ((level == 1)&&(subdetlevel == 2)){
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.003; deltaRW(4)=0.001; deltaRW(5)=0.001; deltaRW(6)=0.001;
-	}
-	//TIB
-	if ((level == 20)&&(subdetlevel == 3)){
-		deltaRW(1)=0.2; deltaRW(2)=0.2; deltaRW(3)=0.2; deltaRW(4)=0.0017; deltaRW(5)=0.0017; deltaRW(6)=0.0017;
-	}
-	if ((level == 19)&&(subdetlevel == 3)){
-		deltaRW(1)=0.1; deltaRW(2)=0.1; deltaRW(3)=0.1; deltaRW(4)=0.0008; deltaRW(5)=0.0008; deltaRW(6)=0.0008;
-	}
-	if ((level == 18)&&(subdetlevel == 3)){
-		deltaRW(1)=0.04; deltaRW(2)=0.04; deltaRW(3)=0.02; deltaRW(4)=0.0006; deltaRW(5)=0.0006; deltaRW(6)=0.0006;
-	}
-	if ((level == 17)&&(subdetlevel == 3)){
-		deltaRW(1)=0.03; deltaRW(2)=0.03; deltaRW(3)=0.015; deltaRW(4)=0.0004; deltaRW(5)=0.0004; deltaRW(6)=0.0004;
-	}
-	if ((level == 16)&&(subdetlevel == 3)){
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.01; deltaRW(4)=0.0004; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	if ((level == 15)&&(subdetlevel == 3)){
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.01; deltaRW(4)=0.0004; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	if ((level == 2)&&(subdetlevel == 3)){
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.005; deltaRW(4)=0.001; deltaRW(5)=0.0005; deltaRW(6)=0.0005;
-	}
-	if ((level == 1)&&(subdetlevel == 3)){
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.005; deltaRW(4)=0.001; deltaRW(5)=0.0005; deltaRW(6)=0.0005;
-	}
-	//TID
-	if ((level == 25)&&(subdetlevel == 4)){
-		deltaRW(1)=0.2; deltaRW(2)=0.2; deltaRW(3)=0.2; deltaRW(4)=0.0013; deltaRW(5)=0.0013; deltaRW(6)=0.0013;
-	}
-	if ((level == 24)&&(subdetlevel == 4)){
-		deltaRW(1)=0.05; deltaRW(2)=0.05; deltaRW(3)=0.05; deltaRW(4)=0.0004; deltaRW(5)=0.0004; deltaRW(6)=0.0004;
-	}
-	if ((level == 23)&&(subdetlevel == 4)){
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.01; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 22)&&(subdetlevel == 4)){
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.005; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 2)&&(subdetlevel == 4)){
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.005; deltaRW(4)=0.0005; deltaRW(5)=0.0005; deltaRW(6)=0.0005;
-	}
-	if ((level == 1)&&(subdetlevel == 4)){
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.005; deltaRW(4)=0.0005; deltaRW(5)=0.0005; deltaRW(6)=0.0005;
-	}
-	//TOB
-	if ((level == 30)&&(subdetlevel == 5)){
-		deltaRW(1)=0.2; deltaRW(2)=0.2; deltaRW(3)=0.2; deltaRW(4)=0.0008; deltaRW(5)=0.0008; deltaRW(6)=0.0008;
-	}
-	if ((level == 29)&&(subdetlevel == 5)){
-		deltaRW(1)=0.014; deltaRW(2)=0.014; deltaRW(3)=0.05; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 28)&&(subdetlevel == 5)){
-		deltaRW(1)=0.02; deltaRW(2)=0.02; deltaRW(3)=0.02; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 27)&&(subdetlevel == 5)){
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.02; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 2)&&(subdetlevel == 5)){
-		deltaRW(1)=0.003; deltaRW(2)=0.003; deltaRW(3)=0.01; deltaRW(4)=0.0002; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	if ((level == 1)&&(subdetlevel == 5)){
-		deltaRW(1)=0.003; deltaRW(2)=0.003; deltaRW(3)=0.01; deltaRW(4)=0.0002; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	//TEC
-	if ((level == 36)&&(subdetlevel == 6)){
-		deltaRW(1)=0.2; deltaRW(2)=0.2; deltaRW(3)=0.2; deltaRW(4)=0.0008; deltaRW(5)=0.0008; deltaRW(6)=0.0008;
-	}
-	if ((level == 35)&&(subdetlevel == 6)){
-		deltaRW(1)=0.05; deltaRW(2)=0.05; deltaRW(3)=0.05; deltaRW(4)=0.0003; deltaRW(5)=0.0003; deltaRW(6)=0.0003;
-	}
-	if ((level == 34)&&(subdetlevel == 6)){
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.02; deltaRW(4)=0.00005; deltaRW(5)=0.00005; deltaRW(6)=0.00005;
-	}
-	if ((level == 33)&&(subdetlevel == 6)){
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.02; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 32)&&(subdetlevel == 6)){
-		deltaRW(1)=0.007; deltaRW(2)=0.007; deltaRW(3)=0.015; deltaRW(4)=0.00015; deltaRW(5)=0.00015; deltaRW(6)=0.00015;
-	}
-	if ((level == 2)&&(subdetlevel == 6)){
-		deltaRW(1)=0.002; deltaRW(2)=0.002; deltaRW(3)=0.005; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 1)&&(subdetlevel == 6)){
-		deltaRW(1)=0.002; deltaRW(2)=0.002; deltaRW(3)=0.005; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	
-	return deltaRW;
+AlgebraicVector CreateSurveyRcds::getStructurePlacements(int level, int subdetlevel) {
+  AlgebraicVector deltaRW(6);
+  deltaRW(1) = 0.0;
+  deltaRW(2) = 0.0;
+  deltaRW(3) = 0.0;
+  deltaRW(4) = 0.0;
+  deltaRW(5) = 0.0;
+  deltaRW(6) = 0.0;
+  //PIXEL
+  if ((level == 37) && (subdetlevel == 1)) {
+    deltaRW(1) = 0.3;
+    deltaRW(2) = 0.3;
+    deltaRW(3) = 0.3;
+    deltaRW(4) = 0.0017;
+    deltaRW(5) = 0.0017;
+    deltaRW(6) = 0.0017;
+  }
+  //STRIP
+  if ((level == 38) && (subdetlevel == 3)) {
+    deltaRW(1) = 0.3;
+    deltaRW(2) = 0.3;
+    deltaRW(3) = 0.3;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0004;
+    deltaRW(6) = 0.0004;
+  }
+  //TRACKER
+  if ((level == 39) && (subdetlevel == 1)) {
+    deltaRW(1) = 0.0;
+    deltaRW(2) = 0.0;
+    deltaRW(3) = 0.0;
+    deltaRW(4) = 0.0;
+    deltaRW(5) = 0.0;
+    deltaRW(6) = 0.0;
+  }
+  //TPB
+  if ((level == 7) && (subdetlevel == 1)) {
+    deltaRW(1) = 0.2;
+    deltaRW(2) = 0.2;
+    deltaRW(3) = 0.2;
+    deltaRW(4) = 0.003;
+    deltaRW(5) = 0.003;
+    deltaRW(6) = 0.003;
+  }
+  if ((level == 6) && (subdetlevel == 1)) {
+    deltaRW(1) = 0.05;
+    deltaRW(2) = 0.05;
+    deltaRW(3) = 0.05;
+    deltaRW(4) = 0.0008;
+    deltaRW(5) = 0.0008;
+    deltaRW(6) = 0.0008;
+  }
+  if ((level == 5) && (subdetlevel == 1)) {
+    deltaRW(1) = 0.02;
+    deltaRW(2) = 0.02;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0004;
+    deltaRW(6) = 0.0004;
+  }
+  if ((level == 4) && (subdetlevel == 1)) {
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  if ((level == 2) && (subdetlevel == 1)) {
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.003;
+    deltaRW(4) = 0.001;
+    deltaRW(5) = 0.001;
+    deltaRW(6) = 0.001;
+  }
+  if ((level == 1) && (subdetlevel == 1)) {
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.003;
+    deltaRW(4) = 0.001;
+    deltaRW(5) = 0.001;
+    deltaRW(6) = 0.001;
+  }
+  //TPE
+  if ((level == 13) && (subdetlevel == 2)) {
+    deltaRW(1) = 0.2;
+    deltaRW(2) = 0.2;
+    deltaRW(3) = 0.2;
+    deltaRW(4) = 0.0017;
+    deltaRW(5) = 0.0017;
+    deltaRW(6) = 0.0017;
+  }
+  if ((level == 12) && (subdetlevel == 2)) {
+    deltaRW(1) = 0.05;
+    deltaRW(2) = 0.05;
+    deltaRW(3) = 0.05;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0004;
+    deltaRW(6) = 0.0004;
+  }
+  if ((level == 11) && (subdetlevel == 2)) {
+    deltaRW(1) = 0.02;
+    deltaRW(2) = 0.02;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.001;
+    deltaRW(5) = 0.001;
+    deltaRW(6) = 0.001;
+  }
+  if ((level == 10) && (subdetlevel == 2)) {
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.001;
+    deltaRW(5) = 0.001;
+    deltaRW(6) = 0.001;
+  }
+  if ((level == 9) && (subdetlevel == 2)) {
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.002;
+    deltaRW(5) = 0.002;
+    deltaRW(6) = 0.002;
+  }
+  if ((level == 2) && (subdetlevel == 2)) {
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.003;
+    deltaRW(4) = 0.001;
+    deltaRW(5) = 0.001;
+    deltaRW(6) = 0.001;
+  }
+  if ((level == 1) && (subdetlevel == 2)) {
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.003;
+    deltaRW(4) = 0.001;
+    deltaRW(5) = 0.001;
+    deltaRW(6) = 0.001;
+  }
+  //TIB
+  if ((level == 20) && (subdetlevel == 3)) {
+    deltaRW(1) = 0.2;
+    deltaRW(2) = 0.2;
+    deltaRW(3) = 0.2;
+    deltaRW(4) = 0.0017;
+    deltaRW(5) = 0.0017;
+    deltaRW(6) = 0.0017;
+  }
+  if ((level == 19) && (subdetlevel == 3)) {
+    deltaRW(1) = 0.1;
+    deltaRW(2) = 0.1;
+    deltaRW(3) = 0.1;
+    deltaRW(4) = 0.0008;
+    deltaRW(5) = 0.0008;
+    deltaRW(6) = 0.0008;
+  }
+  if ((level == 18) && (subdetlevel == 3)) {
+    deltaRW(1) = 0.04;
+    deltaRW(2) = 0.04;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0006;
+    deltaRW(5) = 0.0006;
+    deltaRW(6) = 0.0006;
+  }
+  if ((level == 17) && (subdetlevel == 3)) {
+    deltaRW(1) = 0.03;
+    deltaRW(2) = 0.03;
+    deltaRW(3) = 0.015;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0004;
+    deltaRW(6) = 0.0004;
+  }
+  if ((level == 16) && (subdetlevel == 3)) {
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  if ((level == 15) && (subdetlevel == 3)) {
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  if ((level == 2) && (subdetlevel == 3)) {
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.001;
+    deltaRW(5) = 0.0005;
+    deltaRW(6) = 0.0005;
+  }
+  if ((level == 1) && (subdetlevel == 3)) {
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.001;
+    deltaRW(5) = 0.0005;
+    deltaRW(6) = 0.0005;
+  }
+  //TID
+  if ((level == 25) && (subdetlevel == 4)) {
+    deltaRW(1) = 0.2;
+    deltaRW(2) = 0.2;
+    deltaRW(3) = 0.2;
+    deltaRW(4) = 0.0013;
+    deltaRW(5) = 0.0013;
+    deltaRW(6) = 0.0013;
+  }
+  if ((level == 24) && (subdetlevel == 4)) {
+    deltaRW(1) = 0.05;
+    deltaRW(2) = 0.05;
+    deltaRW(3) = 0.05;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0004;
+    deltaRW(6) = 0.0004;
+  }
+  if ((level == 23) && (subdetlevel == 4)) {
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 22) && (subdetlevel == 4)) {
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 2) && (subdetlevel == 4)) {
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.0005;
+    deltaRW(5) = 0.0005;
+    deltaRW(6) = 0.0005;
+  }
+  if ((level == 1) && (subdetlevel == 4)) {
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.0005;
+    deltaRW(5) = 0.0005;
+    deltaRW(6) = 0.0005;
+  }
+  //TOB
+  if ((level == 30) && (subdetlevel == 5)) {
+    deltaRW(1) = 0.2;
+    deltaRW(2) = 0.2;
+    deltaRW(3) = 0.2;
+    deltaRW(4) = 0.0008;
+    deltaRW(5) = 0.0008;
+    deltaRW(6) = 0.0008;
+  }
+  if ((level == 29) && (subdetlevel == 5)) {
+    deltaRW(1) = 0.014;
+    deltaRW(2) = 0.014;
+    deltaRW(3) = 0.05;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 28) && (subdetlevel == 5)) {
+    deltaRW(1) = 0.02;
+    deltaRW(2) = 0.02;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 27) && (subdetlevel == 5)) {
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 2) && (subdetlevel == 5)) {
+    deltaRW(1) = 0.003;
+    deltaRW(2) = 0.003;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  if ((level == 1) && (subdetlevel == 5)) {
+    deltaRW(1) = 0.003;
+    deltaRW(2) = 0.003;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  //TEC
+  if ((level == 36) && (subdetlevel == 6)) {
+    deltaRW(1) = 0.2;
+    deltaRW(2) = 0.2;
+    deltaRW(3) = 0.2;
+    deltaRW(4) = 0.0008;
+    deltaRW(5) = 0.0008;
+    deltaRW(6) = 0.0008;
+  }
+  if ((level == 35) && (subdetlevel == 6)) {
+    deltaRW(1) = 0.05;
+    deltaRW(2) = 0.05;
+    deltaRW(3) = 0.05;
+    deltaRW(4) = 0.0003;
+    deltaRW(5) = 0.0003;
+    deltaRW(6) = 0.0003;
+  }
+  if ((level == 34) && (subdetlevel == 6)) {
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.00005;
+    deltaRW(5) = 0.00005;
+    deltaRW(6) = 0.00005;
+  }
+  if ((level == 33) && (subdetlevel == 6)) {
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 32) && (subdetlevel == 6)) {
+    deltaRW(1) = 0.007;
+    deltaRW(2) = 0.007;
+    deltaRW(3) = 0.015;
+    deltaRW(4) = 0.00015;
+    deltaRW(5) = 0.00015;
+    deltaRW(6) = 0.00015;
+  }
+  if ((level == 2) && (subdetlevel == 6)) {
+    deltaRW(1) = 0.002;
+    deltaRW(2) = 0.002;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 1) && (subdetlevel == 6)) {
+    deltaRW(1) = 0.002;
+    deltaRW(2) = 0.002;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+
+  return deltaRW;
 }
 //-------------------------------------------------------
 // DEFAULT VALUES FOR THE PRECISION OF THE SURVEY
 //-------------------------------------------------------
-AlgebraicVector CreateSurveyRcds::getStructureErrors(int level, int subdetlevel)
-{
-	AlgebraicVector deltaRW(6);
-	deltaRW(1)=0.0; deltaRW(2)=0.0; deltaRW(3)=0.0; deltaRW(4)=0.0; deltaRW(5)=0.0; deltaRW(6)=0.0;
-	//PIXEL
-	if ((level == 37)&&(subdetlevel == 1)){ //Pixel Detector in Tracker
-		deltaRW(1)=0.2; deltaRW(2)=0.2; deltaRW(3)=0.2; deltaRW(4)=0.0017; deltaRW(5)=0.0017; deltaRW(6)=0.0017;
-	}
-	//STRIP
-	if ((level == 38)&&(subdetlevel == 3)){ //Strip Tracker in Tracker
-		deltaRW(1)=0.2; deltaRW(2)=0.2; deltaRW(3)=0.2; deltaRW(4)=0.0004; deltaRW(5)=0.0004; deltaRW(6)=0.0004;
-	}
-	//TRACKER
-	if ((level == 39)&&(subdetlevel == 1)){ //Tracker
-		deltaRW(1)=0.0; deltaRW(2)=0.0; deltaRW(3)=0.0; deltaRW(4)=0.0; deltaRW(5)=0.0; deltaRW(6)=0.0;
-	}
-	//TPB
-	if ((level == 7)&&(subdetlevel == 1)){ //Barrel Pixel in Pixel
-		deltaRW(1)=0.05; deltaRW(2)=0.05; deltaRW(3)=0.1; deltaRW(4)=0.0008; deltaRW(5)=0.0008; deltaRW(6)=0.0008;
-	}
-	if ((level == 6)&&(subdetlevel == 1)){ //HalfBarrel in Barrel Pixel
-		deltaRW(1)=0.015; deltaRW(2)=0.015; deltaRW(3)=0.03; deltaRW(4)=0.0003; deltaRW(5)=0.0003; deltaRW(6)=0.0003;
-	}
-	if ((level == 5)&&(subdetlevel == 1)){ //HalfShell in HalfBarrel
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.01; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 4)&&(subdetlevel == 1)){ //Ladder in HalfShell
-		deltaRW(1)=0.001; deltaRW(2)=0.001; deltaRW(3)=0.002; deltaRW(4)=0.00005; deltaRW(5)=0.00005; deltaRW(6)=0.00005;
-	}
-	if ((level == 2)&&(subdetlevel == 1)){ //Det in Ladder
-		deltaRW(1)=0.0005; deltaRW(2)=0.001; deltaRW(3)=0.001; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 1)&&(subdetlevel == 1)){ //DetUnit in Ladder
-		deltaRW(1)=0.0005; deltaRW(2)=0.001; deltaRW(3)=0.001; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	//TPE
-	if ((level == 13)&&(subdetlevel == 2)){ //Forward Pixel in Pixel
-		deltaRW(1)=0.05; deltaRW(2)=0.05; deltaRW(3)=0.1; deltaRW(4)=0.0004; deltaRW(5)=0.0004; deltaRW(6)=0.0004;
-	}
-	if ((level == 12)&&(subdetlevel == 2)){ //HalfCylinder in Forward Pixel
-		deltaRW(1)=0.015; deltaRW(2)=0.015; deltaRW(3)=0.03; deltaRW(4)=0.00015; deltaRW(5)=0.00015; deltaRW(6)=0.00015;
-	}
-	if ((level == 11)&&(subdetlevel == 2)){ //HalfDisk in HalfCylinder
-		deltaRW(1)=0.005; deltaRW(2)=0.005; deltaRW(3)=0.01; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 10)&&(subdetlevel == 2)){ //Blade in HalfDisk
-		deltaRW(1)=0.001; deltaRW(2)=0.001; deltaRW(3)=0.002; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 9)&&(subdetlevel == 2)){ //Panel in Blade
-		deltaRW(1)=0.001; deltaRW(2)=0.0008; deltaRW(3)=0.0006; deltaRW(4)=0.0002; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	if ((level == 2)&&(subdetlevel == 2)){ //Det in Panel
-		deltaRW(1)=0.0005; deltaRW(2)=0.0004; deltaRW(3)=0.0006; deltaRW(4)=0.0001; deltaRW(5)=0.0003; deltaRW(6)=0.0001;
-	}
-	if ((level == 1)&&(subdetlevel == 2)){ //DetUnit in Panel
-		deltaRW(1)=0.0005; deltaRW(2)=0.0004; deltaRW(3)=0.0006; deltaRW(4)=0.0001; deltaRW(5)=0.0003; deltaRW(6)=0.0001;
-	}
-	//TIB
-	if ((level == 20)&&(subdetlevel == 3)){ //TIB in Strip Tracker
-		deltaRW(1)=0.08; deltaRW(2)=0.08; deltaRW(3)=0.04; deltaRW(4)=0.0017; deltaRW(5)=0.0017; deltaRW(6)=0.0017;
-	}
-	if ((level == 19)&&(subdetlevel == 3)){ //HalfBarrel in TIB
-		deltaRW(1)=0.04; deltaRW(2)=0.04; deltaRW(3)=0.02; deltaRW(4)=0.0003; deltaRW(5)=0.0003; deltaRW(6)=0.0003;
-	}
-	if ((level == 18)&&(subdetlevel == 3)){ //Layer in HalfBarrel
-		deltaRW(1)=0.02; deltaRW(2)=0.02; deltaRW(3)=0.01; deltaRW(4)=0.0006; deltaRW(5)=0.0006; deltaRW(6)=0.0006;
-	}
-	if ((level == 17)&&(subdetlevel == 3)){ //HalfShell in Layer
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.005; deltaRW(4)=0.0002; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	if ((level == 16)&&(subdetlevel == 3)){ //Surface in a HalfShell
-		deltaRW(1)=0.004; deltaRW(2)=0.004; deltaRW(3)=0.008; deltaRW(4)=0.0002; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 15)&&(subdetlevel == 3)){ //String in a Surface
-		deltaRW(1)=0.004; deltaRW(2)=0.004; deltaRW(3)=0.008; deltaRW(4)=0.0002; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 2)&&(subdetlevel == 3)){ //Det in a String
-		deltaRW(1)=0.002; deltaRW(2)=0.002; deltaRW(3)=0.004; deltaRW(4)=0.0004; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	if ((level == 1)&&(subdetlevel == 3)){ //DetUnit in a String
-		deltaRW(1)=0.002; deltaRW(2)=0.002; deltaRW(3)=0.004; deltaRW(4)=0.0004; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	//TID
-	if ((level == 25)&&(subdetlevel == 4)){ //TID in Strip Tracker
-		deltaRW(1)=0.05; deltaRW(2)=0.05; deltaRW(3)=0.1; deltaRW(4)=0.0003; deltaRW(5)=0.0003; deltaRW(6)=0.0003;
-	}
-	if ((level == 24)&&(subdetlevel == 4)){ //Disk in a TID
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.02; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 23)&&(subdetlevel == 4)){ //Ring is a Disk
-		deltaRW(1)=0.004; deltaRW(2)=0.004; deltaRW(3)=0.005; deltaRW(4)=0.00004; deltaRW(5)=0.00004; deltaRW(6)=0.00004;
-	}
-	if ((level == 22)&&(subdetlevel == 4)){ //Side of a Ring
-		deltaRW(1)=0.002; deltaRW(2)=0.002; deltaRW(3)=0.002; deltaRW(4)=0.00004; deltaRW(5)=0.00004; deltaRW(6)=0.00004;
-	}
-	if ((level == 2)&&(subdetlevel == 4)){ //Det in a Side
-		deltaRW(1)=0.002; deltaRW(2)=0.002; deltaRW(3)=0.002; deltaRW(4)=0.0002; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	if ((level == 1)&&(subdetlevel == 4)){ //DetUnit is a Side
-		deltaRW(1)=0.002; deltaRW(2)=0.002; deltaRW(3)=0.002; deltaRW(4)=0.0002; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	//TOB
-	if ((level == 30)&&(subdetlevel == 5)){ // TOB in Strip Tracker
-		deltaRW(1)=0.06; deltaRW(2)=0.06; deltaRW(3)=0.06; deltaRW(4)=0.00025; deltaRW(5)=0.00025; deltaRW(6)=0.00025;
-	}
-	if ((level == 29)&&(subdetlevel == 5)){ //HalfBarrel in the TOB
-		deltaRW(1)=0.014; deltaRW(2)=0.014; deltaRW(3)=0.05; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 28)&&(subdetlevel == 5)){ //Layer in a HalfBarrel
-		deltaRW(1)=0.02; deltaRW(2)=0.02; deltaRW(3)=0.02; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 27)&&(subdetlevel == 5)){ //Rod in a Layer
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.02; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 2)&&(subdetlevel == 5)){ //Det in a Rod
-		deltaRW(1)=0.003; deltaRW(2)=0.003; deltaRW(3)=0.01; deltaRW(4)=0.0002; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	if ((level == 1)&&(subdetlevel == 5)){ //DetUnit in a Rod
-		deltaRW(1)=0.003; deltaRW(2)=0.003; deltaRW(3)=0.01; deltaRW(4)=0.0002; deltaRW(5)=0.0002; deltaRW(6)=0.0002;
-	}
-	//TEC
-	if ((level == 36)&&(subdetlevel == 6)){ //TEC in the Strip Tracker
-		deltaRW(1)=0.06; deltaRW(2)=0.06; deltaRW(3)=0.1; deltaRW(4)=0.0003; deltaRW(5)=0.0003; deltaRW(6)=0.0003;
-	}
-	if ((level == 35)&&(subdetlevel == 6)){ //Disk in the TEC 
-		deltaRW(1)=0.015; deltaRW(2)=0.015; deltaRW(3)=0.03; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 34)&&(subdetlevel == 6)){ //Side on a Disk
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.02; deltaRW(4)=0.00005; deltaRW(5)=0.00005; deltaRW(6)=0.00005;
-	}
-	if ((level == 33)&&(subdetlevel == 6)){ //Petal on a Side of a Disk
-		deltaRW(1)=0.01; deltaRW(2)=0.01; deltaRW(3)=0.02; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 32)&&(subdetlevel == 6)){ //Ring on a Petal
-		deltaRW(1)=0.007; deltaRW(2)=0.007; deltaRW(3)=0.015; deltaRW(4)=0.00015; deltaRW(5)=0.00015; deltaRW(6)=0.00015;
-	}
-	if ((level == 2)&&(subdetlevel == 6)){ //Det on a Ring
-		deltaRW(1)=0.002; deltaRW(2)=0.002; deltaRW(3)=0.005; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	if ((level == 1)&&(subdetlevel == 6)){ // DetUnit on a Ring
-		deltaRW(1)=0.002; deltaRW(2)=0.002; deltaRW(3)=0.005; deltaRW(4)=0.0001; deltaRW(5)=0.0001; deltaRW(6)=0.0001;
-	}
-	
-	return deltaRW;
-	
+AlgebraicVector CreateSurveyRcds::getStructureErrors(int level, int subdetlevel) {
+  AlgebraicVector deltaRW(6);
+  deltaRW(1) = 0.0;
+  deltaRW(2) = 0.0;
+  deltaRW(3) = 0.0;
+  deltaRW(4) = 0.0;
+  deltaRW(5) = 0.0;
+  deltaRW(6) = 0.0;
+  //PIXEL
+  if ((level == 37) && (subdetlevel == 1)) {  //Pixel Detector in Tracker
+    deltaRW(1) = 0.2;
+    deltaRW(2) = 0.2;
+    deltaRW(3) = 0.2;
+    deltaRW(4) = 0.0017;
+    deltaRW(5) = 0.0017;
+    deltaRW(6) = 0.0017;
+  }
+  //STRIP
+  if ((level == 38) && (subdetlevel == 3)) {  //Strip Tracker in Tracker
+    deltaRW(1) = 0.2;
+    deltaRW(2) = 0.2;
+    deltaRW(3) = 0.2;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0004;
+    deltaRW(6) = 0.0004;
+  }
+  //TRACKER
+  if ((level == 39) && (subdetlevel == 1)) {  //Tracker
+    deltaRW(1) = 0.0;
+    deltaRW(2) = 0.0;
+    deltaRW(3) = 0.0;
+    deltaRW(4) = 0.0;
+    deltaRW(5) = 0.0;
+    deltaRW(6) = 0.0;
+  }
+  //TPB
+  if ((level == 7) && (subdetlevel == 1)) {  //Barrel Pixel in Pixel
+    deltaRW(1) = 0.05;
+    deltaRW(2) = 0.05;
+    deltaRW(3) = 0.1;
+    deltaRW(4) = 0.0008;
+    deltaRW(5) = 0.0008;
+    deltaRW(6) = 0.0008;
+  }
+  if ((level == 6) && (subdetlevel == 1)) {  //HalfBarrel in Barrel Pixel
+    deltaRW(1) = 0.015;
+    deltaRW(2) = 0.015;
+    deltaRW(3) = 0.03;
+    deltaRW(4) = 0.0003;
+    deltaRW(5) = 0.0003;
+    deltaRW(6) = 0.0003;
+  }
+  if ((level == 5) && (subdetlevel == 1)) {  //HalfShell in HalfBarrel
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 4) && (subdetlevel == 1)) {  //Ladder in HalfShell
+    deltaRW(1) = 0.001;
+    deltaRW(2) = 0.001;
+    deltaRW(3) = 0.002;
+    deltaRW(4) = 0.00005;
+    deltaRW(5) = 0.00005;
+    deltaRW(6) = 0.00005;
+  }
+  if ((level == 2) && (subdetlevel == 1)) {  //Det in Ladder
+    deltaRW(1) = 0.0005;
+    deltaRW(2) = 0.001;
+    deltaRW(3) = 0.001;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 1) && (subdetlevel == 1)) {  //DetUnit in Ladder
+    deltaRW(1) = 0.0005;
+    deltaRW(2) = 0.001;
+    deltaRW(3) = 0.001;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  //TPE
+  if ((level == 13) && (subdetlevel == 2)) {  //Forward Pixel in Pixel
+    deltaRW(1) = 0.05;
+    deltaRW(2) = 0.05;
+    deltaRW(3) = 0.1;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0004;
+    deltaRW(6) = 0.0004;
+  }
+  if ((level == 12) && (subdetlevel == 2)) {  //HalfCylinder in Forward Pixel
+    deltaRW(1) = 0.015;
+    deltaRW(2) = 0.015;
+    deltaRW(3) = 0.03;
+    deltaRW(4) = 0.00015;
+    deltaRW(5) = 0.00015;
+    deltaRW(6) = 0.00015;
+  }
+  if ((level == 11) && (subdetlevel == 2)) {  //HalfDisk in HalfCylinder
+    deltaRW(1) = 0.005;
+    deltaRW(2) = 0.005;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 10) && (subdetlevel == 2)) {  //Blade in HalfDisk
+    deltaRW(1) = 0.001;
+    deltaRW(2) = 0.001;
+    deltaRW(3) = 0.002;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 9) && (subdetlevel == 2)) {  //Panel in Blade
+    deltaRW(1) = 0.001;
+    deltaRW(2) = 0.0008;
+    deltaRW(3) = 0.0006;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  if ((level == 2) && (subdetlevel == 2)) {  //Det in Panel
+    deltaRW(1) = 0.0005;
+    deltaRW(2) = 0.0004;
+    deltaRW(3) = 0.0006;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0003;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 1) && (subdetlevel == 2)) {  //DetUnit in Panel
+    deltaRW(1) = 0.0005;
+    deltaRW(2) = 0.0004;
+    deltaRW(3) = 0.0006;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0003;
+    deltaRW(6) = 0.0001;
+  }
+  //TIB
+  if ((level == 20) && (subdetlevel == 3)) {  //TIB in Strip Tracker
+    deltaRW(1) = 0.08;
+    deltaRW(2) = 0.08;
+    deltaRW(3) = 0.04;
+    deltaRW(4) = 0.0017;
+    deltaRW(5) = 0.0017;
+    deltaRW(6) = 0.0017;
+  }
+  if ((level == 19) && (subdetlevel == 3)) {  //HalfBarrel in TIB
+    deltaRW(1) = 0.04;
+    deltaRW(2) = 0.04;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0003;
+    deltaRW(5) = 0.0003;
+    deltaRW(6) = 0.0003;
+  }
+  if ((level == 18) && (subdetlevel == 3)) {  //Layer in HalfBarrel
+    deltaRW(1) = 0.02;
+    deltaRW(2) = 0.02;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0006;
+    deltaRW(5) = 0.0006;
+    deltaRW(6) = 0.0006;
+  }
+  if ((level == 17) && (subdetlevel == 3)) {  //HalfShell in Layer
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  if ((level == 16) && (subdetlevel == 3)) {  //Surface in a HalfShell
+    deltaRW(1) = 0.004;
+    deltaRW(2) = 0.004;
+    deltaRW(3) = 0.008;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 15) && (subdetlevel == 3)) {  //String in a Surface
+    deltaRW(1) = 0.004;
+    deltaRW(2) = 0.004;
+    deltaRW(3) = 0.008;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 2) && (subdetlevel == 3)) {  //Det in a String
+    deltaRW(1) = 0.002;
+    deltaRW(2) = 0.002;
+    deltaRW(3) = 0.004;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  if ((level == 1) && (subdetlevel == 3)) {  //DetUnit in a String
+    deltaRW(1) = 0.002;
+    deltaRW(2) = 0.002;
+    deltaRW(3) = 0.004;
+    deltaRW(4) = 0.0004;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  //TID
+  if ((level == 25) && (subdetlevel == 4)) {  //TID in Strip Tracker
+    deltaRW(1) = 0.05;
+    deltaRW(2) = 0.05;
+    deltaRW(3) = 0.1;
+    deltaRW(4) = 0.0003;
+    deltaRW(5) = 0.0003;
+    deltaRW(6) = 0.0003;
+  }
+  if ((level == 24) && (subdetlevel == 4)) {  //Disk in a TID
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 23) && (subdetlevel == 4)) {  //Ring is a Disk
+    deltaRW(1) = 0.004;
+    deltaRW(2) = 0.004;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.00004;
+    deltaRW(5) = 0.00004;
+    deltaRW(6) = 0.00004;
+  }
+  if ((level == 22) && (subdetlevel == 4)) {  //Side of a Ring
+    deltaRW(1) = 0.002;
+    deltaRW(2) = 0.002;
+    deltaRW(3) = 0.002;
+    deltaRW(4) = 0.00004;
+    deltaRW(5) = 0.00004;
+    deltaRW(6) = 0.00004;
+  }
+  if ((level == 2) && (subdetlevel == 4)) {  //Det in a Side
+    deltaRW(1) = 0.002;
+    deltaRW(2) = 0.002;
+    deltaRW(3) = 0.002;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  if ((level == 1) && (subdetlevel == 4)) {  //DetUnit is a Side
+    deltaRW(1) = 0.002;
+    deltaRW(2) = 0.002;
+    deltaRW(3) = 0.002;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  //TOB
+  if ((level == 30) && (subdetlevel == 5)) {  // TOB in Strip Tracker
+    deltaRW(1) = 0.06;
+    deltaRW(2) = 0.06;
+    deltaRW(3) = 0.06;
+    deltaRW(4) = 0.00025;
+    deltaRW(5) = 0.00025;
+    deltaRW(6) = 0.00025;
+  }
+  if ((level == 29) && (subdetlevel == 5)) {  //HalfBarrel in the TOB
+    deltaRW(1) = 0.014;
+    deltaRW(2) = 0.014;
+    deltaRW(3) = 0.05;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 28) && (subdetlevel == 5)) {  //Layer in a HalfBarrel
+    deltaRW(1) = 0.02;
+    deltaRW(2) = 0.02;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 27) && (subdetlevel == 5)) {  //Rod in a Layer
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 2) && (subdetlevel == 5)) {  //Det in a Rod
+    deltaRW(1) = 0.003;
+    deltaRW(2) = 0.003;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  if ((level == 1) && (subdetlevel == 5)) {  //DetUnit in a Rod
+    deltaRW(1) = 0.003;
+    deltaRW(2) = 0.003;
+    deltaRW(3) = 0.01;
+    deltaRW(4) = 0.0002;
+    deltaRW(5) = 0.0002;
+    deltaRW(6) = 0.0002;
+  }
+  //TEC
+  if ((level == 36) && (subdetlevel == 6)) {  //TEC in the Strip Tracker
+    deltaRW(1) = 0.06;
+    deltaRW(2) = 0.06;
+    deltaRW(3) = 0.1;
+    deltaRW(4) = 0.0003;
+    deltaRW(5) = 0.0003;
+    deltaRW(6) = 0.0003;
+  }
+  if ((level == 35) && (subdetlevel == 6)) {  //Disk in the TEC
+    deltaRW(1) = 0.015;
+    deltaRW(2) = 0.015;
+    deltaRW(3) = 0.03;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 34) && (subdetlevel == 6)) {  //Side on a Disk
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.00005;
+    deltaRW(5) = 0.00005;
+    deltaRW(6) = 0.00005;
+  }
+  if ((level == 33) && (subdetlevel == 6)) {  //Petal on a Side of a Disk
+    deltaRW(1) = 0.01;
+    deltaRW(2) = 0.01;
+    deltaRW(3) = 0.02;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 32) && (subdetlevel == 6)) {  //Ring on a Petal
+    deltaRW(1) = 0.007;
+    deltaRW(2) = 0.007;
+    deltaRW(3) = 0.015;
+    deltaRW(4) = 0.00015;
+    deltaRW(5) = 0.00015;
+    deltaRW(6) = 0.00015;
+  }
+  if ((level == 2) && (subdetlevel == 6)) {  //Det on a Ring
+    deltaRW(1) = 0.002;
+    deltaRW(2) = 0.002;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
+  if ((level == 1) && (subdetlevel == 6)) {  // DetUnit on a Ring
+    deltaRW(1) = 0.002;
+    deltaRW(2) = 0.002;
+    deltaRW(3) = 0.005;
+    deltaRW(4) = 0.0001;
+    deltaRW(5) = 0.0001;
+    deltaRW(6) = 0.0001;
+  }
 
+  return deltaRW;
 }
 
 // Plug in to framework

--- a/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.h
+++ b/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.h
@@ -18,46 +18,34 @@
 class AlignableSurface;
 class Alignments;
 
-class CreateSurveyRcds:
-	public SurveyInputBase
-	{
-	public:
-		
-		CreateSurveyRcds(
-				 const edm::ParameterSet&
-				 );
-		
-		void analyze(
-				     const edm::Event&, 
-				     const edm::EventSetup&
-				     ) override;
-		
-	private:
-		
-		/// module which modifies the geometry
-		void setGeometry(Alignable* );
-		/// module which creates/inserts the survey errors
-		void setSurveyErrors( Alignable* );
-		
-		/// default values for assembly precision
-		AlgebraicVector getStructurePlacements(int ,int );
-		
-		/// default values for survey uncertainty
-		AlgebraicVector getStructureErrors(int ,int );
-		
-		
-		
-		std::string m_inputGeom;
-		double m_inputSimpleMis;
-		bool m_generatedRandom;
-		bool m_generatedSimple;
-		
-		
-		SurveyInputTextReader::MapType uIdMap;
-		
-		std::string textFileName;
-		
-		edm::ESHandle<Alignments> alignments;
-	};
+class CreateSurveyRcds : public SurveyInputBase {
+public:
+  CreateSurveyRcds(const edm::ParameterSet&);
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  /// module which modifies the geometry
+  void setGeometry(Alignable*);
+  /// module which creates/inserts the survey errors
+  void setSurveyErrors(Alignable*);
+
+  /// default values for assembly precision
+  AlgebraicVector getStructurePlacements(int, int);
+
+  /// default values for survey uncertainty
+  AlgebraicVector getStructureErrors(int, int);
+
+  std::string m_inputGeom;
+  double m_inputSimpleMis;
+  bool m_generatedRandom;
+  bool m_generatedSimple;
+
+  SurveyInputTextReader::MapType uIdMap;
+
+  std::string textFileName;
+
+  edm::ESHandle<Alignments> alignments;
+};
 
 #endif

--- a/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.cc
+++ b/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.cc
@@ -11,89 +11,85 @@
 
 #include "Alignment/SurveyAnalysis/plugins/DTSurveyConvert.h"
 
-DTSurveyConvert::DTSurveyConvert(const edm::ParameterSet& iConfig)
-{
-   //now do what ever initialization is needed
-   nameWheel_m2 = iConfig.getUntrackedParameter<std::string>("nameWheel_m2");
-   nameWheel_m1 = iConfig.getUntrackedParameter<std::string>("nameWheel_m1");
-   nameWheel_0 = iConfig.getUntrackedParameter<std::string>("nameWheel_0");
-   nameWheel_p1 = iConfig.getUntrackedParameter<std::string>("nameWheel_p1");
-   nameWheel_p2 = iConfig.getUntrackedParameter<std::string>("nameWheel_p2");
-   
-   nameChambers_m2 = iConfig.getUntrackedParameter<std::string>("nameChambers_m2");
-   nameChambers_m1 = iConfig.getUntrackedParameter<std::string>("nameChambers_m1");
-   nameChambers_0 = iConfig.getUntrackedParameter<std::string>("nameChambers_0");
-   nameChambers_p1 = iConfig.getUntrackedParameter<std::string>("nameChambers_p1");
-   nameChambers_p2 = iConfig.getUntrackedParameter<std::string>("nameChambers_p2");
+DTSurveyConvert::DTSurveyConvert(const edm::ParameterSet &iConfig) {
+  //now do what ever initialization is needed
+  nameWheel_m2 = iConfig.getUntrackedParameter<std::string>("nameWheel_m2");
+  nameWheel_m1 = iConfig.getUntrackedParameter<std::string>("nameWheel_m1");
+  nameWheel_0 = iConfig.getUntrackedParameter<std::string>("nameWheel_0");
+  nameWheel_p1 = iConfig.getUntrackedParameter<std::string>("nameWheel_p1");
+  nameWheel_p2 = iConfig.getUntrackedParameter<std::string>("nameWheel_p2");
 
-   wheel_m2 = iConfig.getUntrackedParameter<bool>("wheel_m2");
-   wheel_m1 = iConfig.getUntrackedParameter<bool>("wheel_m1");
-   wheel_0 = iConfig.getUntrackedParameter<bool>("wheel_0");
-   wheel_p1 = iConfig.getUntrackedParameter<bool>("wheel_p1");
-   wheel_p2 = iConfig.getUntrackedParameter<bool>("wheel_p2");
+  nameChambers_m2 = iConfig.getUntrackedParameter<std::string>("nameChambers_m2");
+  nameChambers_m1 = iConfig.getUntrackedParameter<std::string>("nameChambers_m1");
+  nameChambers_0 = iConfig.getUntrackedParameter<std::string>("nameChambers_0");
+  nameChambers_p1 = iConfig.getUntrackedParameter<std::string>("nameChambers_p1");
+  nameChambers_p2 = iConfig.getUntrackedParameter<std::string>("nameChambers_p2");
 
-   outputFileName = iConfig.getUntrackedParameter<std::string>("OutputTextFile");
-   WriteToDB = iConfig.getUntrackedParameter<bool>("writeToDB");
-  
+  wheel_m2 = iConfig.getUntrackedParameter<bool>("wheel_m2");
+  wheel_m1 = iConfig.getUntrackedParameter<bool>("wheel_m1");
+  wheel_0 = iConfig.getUntrackedParameter<bool>("wheel_0");
+  wheel_p1 = iConfig.getUntrackedParameter<bool>("wheel_p1");
+  wheel_p2 = iConfig.getUntrackedParameter<bool>("wheel_p2");
+
+  outputFileName = iConfig.getUntrackedParameter<std::string>("OutputTextFile");
+  WriteToDB = iConfig.getUntrackedParameter<bool>("writeToDB");
 }
 
 // ------------ method called to for each event  ------------
-void
-DTSurveyConvert::analyze(const edm::Event&, const edm::EventSetup& iSetup)
-{
-
+void DTSurveyConvert::analyze(const edm::Event &, const edm::EventSetup &iSetup) {
   edm::ESHandle<DTGeometry> pDD;
-  iSetup.get<MuonGeometryRecord>().get( pDD );
- 
+  iSetup.get<MuonGeometryRecord>().get(pDD);
+
   std::ofstream outFile(outputFileName.c_str());
-  
+
   if (wheel_m2 == true) {
     DTSurvey *wheel = new DTSurvey(nameWheel_m2, nameChambers_m2, -2);
     wheel->ReadChambers(pDD);
     wheel->CalculateChambers();
-    outFile << *wheel; 
+    outFile << *wheel;
     wheelList.push_back(wheel);
-  } 
+  }
   if (wheel_m1 == true) {
     DTSurvey *wheel = new DTSurvey(nameWheel_m1, nameChambers_m1, -1);
     wheel->ReadChambers(pDD);
     wheel->CalculateChambers();
-    outFile << *wheel; 
+    outFile << *wheel;
     wheelList.push_back(wheel);
-  } 
+  }
   if (wheel_0 == true) {
     DTSurvey *wheel = new DTSurvey(nameWheel_0, nameChambers_0, 0);
     wheel->ReadChambers(pDD);
     wheel->CalculateChambers();
-    outFile << *wheel; 
+    outFile << *wheel;
     wheelList.push_back(wheel);
-  } 
+  }
   if (wheel_p1 == true) {
     DTSurvey *wheel = new DTSurvey(nameWheel_p1, nameChambers_p1, 1);
     wheel->ReadChambers(pDD);
     wheel->CalculateChambers();
-    outFile << *wheel; 
+    outFile << *wheel;
     wheelList.push_back(wheel);
-  } 
-  if(wheel_p2 == true) {
+  }
+  if (wheel_p2 == true) {
     DTSurvey *wheel = new DTSurvey(nameWheel_p2, nameChambers_p2, 2);
     wheel->ReadChambers(pDD);
     wheel->CalculateChambers();
-    outFile << *wheel; 
+    outFile << *wheel;
     wheelList.push_back(wheel);
   }
   outFile.close();
 
-  if(WriteToDB == true) {
+  if (WriteToDB == true) {
     // Instantiate the helper class
     MuonAlignment align(iSetup);
     std::ifstream inFile(outputFileName.c_str());
-    while(!inFile.eof()) {
+    while (!inFile.eof()) {
       float dx, dy, dz, sigma_dx, sigma_dy, sigma_dz;
       float alpha, beta, gamma, sigma_alpha, sigma_beta, sigma_gamma;
-      inFile >> dx >> sigma_dx >> dy >> sigma_dy >> dz >> sigma_dz
-             >> alpha >> sigma_alpha >> beta >> sigma_beta >> gamma >> sigma_gamma; 
-      if(inFile.eof()) break;
+      inFile >> dx >> sigma_dx >> dy >> sigma_dy >> dz >> sigma_dz >> alpha >> sigma_alpha >> beta >> sigma_beta >>
+          gamma >> sigma_gamma;
+      if (inFile.eof())
+        break;
       std::vector<float> displacement;
       displacement.push_back(dx);
       displacement.push_back(dy);

--- a/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.h
+++ b/Alignment/SurveyAnalysis/plugins/DTSurveyConvert.h
@@ -5,7 +5,7 @@
 //
 // Package:    DTSurveyConvert
 // Class:      DTSurveyConvert
-// 
+//
 /**\class DTSurveyConvert DTSurveyConvert.cc Alignment/DTSurveyConvert/src/DTSurveyConvert.cc
 
  Description: Reads survey information, process it and outputs a text file with results
@@ -23,32 +23,30 @@
 
 class DTSurvey;
 
-class DTSurveyConvert : public edm::EDAnalyzer
-{
-   public:
-      explicit DTSurveyConvert(const edm::ParameterSet&);
+class DTSurveyConvert : public edm::EDAnalyzer {
+public:
+  explicit DTSurveyConvert(const edm::ParameterSet &);
 
-   private:
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      std::vector<DTSurvey *> wheelList;
-      std::string nameWheel_m2; 
-      std::string nameWheel_m1; 
-      std::string nameWheel_0; 
-      std::string nameWheel_p1; 
-      std::string nameWheel_p2;
-      std::string nameChambers_m2;
-      std::string nameChambers_m1;
-      std::string nameChambers_0;
-      std::string nameChambers_p1;
-      std::string nameChambers_p2;
-      std::string outputFileName;
-      bool wheel_m2;
-      bool wheel_m1;
-      bool wheel_0;
-      bool wheel_p1;
-      bool wheel_p2;
-      bool WriteToDB;
+private:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  std::vector<DTSurvey *> wheelList;
+  std::string nameWheel_m2;
+  std::string nameWheel_m1;
+  std::string nameWheel_0;
+  std::string nameWheel_p1;
+  std::string nameWheel_p2;
+  std::string nameChambers_m2;
+  std::string nameChambers_m1;
+  std::string nameChambers_0;
+  std::string nameChambers_p1;
+  std::string nameChambers_p2;
+  std::string outputFileName;
+  bool wheel_m2;
+  bool wheel_m1;
+  bool wheel_0;
+  bool wheel_p1;
+  bool wheel_p2;
+  bool WriteToDB;
 };
 
 #endif
-

--- a/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.cc
@@ -5,28 +5,21 @@
 
 #include "Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.h"
 
-SurveyAlignmentAlgorithm::SurveyAlignmentAlgorithm(const edm::ParameterSet& cfg):
-  AlignmentAlgorithmBase(cfg),
-  theOutfile(cfg.getParameter<std::string>("outfile")),
-  theIterations(cfg.getParameter<unsigned int>("nIteration")),
-  theLevels(cfg.getParameter< std::vector<std::string> >("levels"))
-{
-}
+SurveyAlignmentAlgorithm::SurveyAlignmentAlgorithm(const edm::ParameterSet& cfg)
+    : AlignmentAlgorithmBase(cfg),
+      theOutfile(cfg.getParameter<std::string>("outfile")),
+      theIterations(cfg.getParameter<unsigned int>("nIteration")),
+      theLevels(cfg.getParameter<std::vector<std::string> >("levels")) {}
 
-void SurveyAlignmentAlgorithm::initialize(const edm::EventSetup&,
-					  AlignableTracker*,
-					  AlignableMuon*,
-					  AlignableExtras*,
-					  AlignmentParameterStore* store)
-{
+void SurveyAlignmentAlgorithm::initialize(
+    const edm::EventSetup&, AlignableTracker*, AlignableMuon*, AlignableExtras*, AlignmentParameterStore* store) {
   std::vector<align::StructureType> levels;
 
   // FIXME: - currently defaulting to RunI as this was the previous behaviour
   //        - check this, when resurrecting this code in the future
   AlignableObjectId alignableObjectId{AlignableObjectId::Geometry::General};
 
-  for (unsigned int l = 0; l < theLevels.size(); ++l)
-  {
+  for (unsigned int l = 0; l < theLevels.size(); ++l) {
     levels.push_back(alignableObjectId.stringToId(theLevels[l].c_str()));
   }
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyAlignmentAlgorithm.h
@@ -12,42 +12,31 @@
 
 #include "Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h"
 
-namespace edm { class ParameterSet; class EventSetup; }
+namespace edm {
+  class ParameterSet;
+  class EventSetup;
+}  // namespace edm
 
 class AlignmentParameterStore;
 class AlignableMuon;
 class AlignableTracker;
 class AlignableExtras;
 
-class SurveyAlignmentAlgorithm : public AlignmentAlgorithmBase
-{
-  public:
-
-  SurveyAlignmentAlgorithm(
-			   const edm::ParameterSet&
-			   );
+class SurveyAlignmentAlgorithm : public AlignmentAlgorithmBase {
+public:
+  SurveyAlignmentAlgorithm(const edm::ParameterSet&);
 
   /// call at start of job
   void initialize(
-			  const edm::EventSetup&,
-			  AlignableTracker*,
-			  AlignableMuon*,
-			  AlignableExtras*,
-			  AlignmentParameterStore*
-			  ) override;
+      const edm::EventSetup&, AlignableTracker*, AlignableMuon*, AlignableExtras*, AlignmentParameterStore*) override;
 
   /// call at end of job
   void terminate(const edm::EventSetup& iSetup) override {}
 
   /// run for every event
-  void run(
-		   const edm::EventSetup&,
-		   const AlignmentAlgorithmBase::EventInfo &
-		   ) override {}
+  void run(const edm::EventSetup&, const AlignmentAlgorithmBase::EventInfo&) override {}
 
-
-  private:
-
+private:
   std::string theOutfile;
 
   unsigned int theIterations;

--- a/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDBUploader.h
@@ -24,39 +24,28 @@ class Alignments;
 class AlignTransform;
 struct SurveyErrors;
 
-class SurveyDBUploader:
-  public edm::EDAnalyzer
-{
+class SurveyDBUploader : public edm::EDAnalyzer {
   typedef AlignTransform SurveyValue;
-  typedef Alignments     SurveyValues;
+  typedef Alignments SurveyValues;
 
-  public:
-
+public:
   /// Set value & error tag names for survey records.
-  SurveyDBUploader(
-		   const edm::ParameterSet&
-		   );
+  SurveyDBUploader(const edm::ParameterSet&);
 
-  void analyze(
-		       const edm::Event&,
-		       const edm::EventSetup&
-		       ) override {}
+  void analyze(const edm::Event&, const edm::EventSetup&) override {}
 
   /// Upload to DB
   void endJob() override;
 
-  private:
-
+private:
   /// Get survey info of an alignable in the detector.
-  void getSurveyInfo(
-		     const Alignable*
-		     );
+  void getSurveyInfo(const Alignable*);
 
-  std::string theValueRcd; // tag name of survey values record in DB
-  std::string theErrorExtendedRcd; // tag name of survey errors record in DB
+  std::string theValueRcd;          // tag name of survey values record in DB
+  std::string theErrorExtendedRcd;  // tag name of survey errors record in DB
 
-  SurveyValues* theValues; // survey values for all alignables in detector
-  SurveyErrors* theErrors; // survey errors for all alignables in detector
+  SurveyValues* theValues;  // survey values for all alignables in detector
+  SurveyErrors* theErrors;  // survey errors for all alignables in detector
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.cc
@@ -7,7 +7,7 @@
 #include "Alignment/CommonAlignment/interface/AlignableModifier.h"
 #include "Alignment/TrackerAlignment/interface/TrackerAlignment.h"
 #include "Alignment/TrackerAlignment/interface/TrackerScenarioBuilder.h"
-#include "Alignment/CommonAlignment/interface/Alignable.h" 
+#include "Alignment/CommonAlignment/interface/Alignable.h"
 
 #include "Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h"
 
@@ -15,75 +15,84 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 //__________________________________________________________________________________________________
-SurveyDataConverter::SurveyDataConverter(const edm::ParameterSet& iConfig) :
-  theParameterSet( iConfig )
-{  
-}
+SurveyDataConverter::SurveyDataConverter(const edm::ParameterSet& iConfig) : theParameterSet(iConfig) {}
 
 //__________________________________________________________________________________________________
-void SurveyDataConverter::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void SurveyDataConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
-  
+
   edm::LogInfo("SurveyDataConverter") << "Analyzer called";
   applyfineinfo = theParameterSet.getParameter<bool>("applyFineInfo");
   applycoarseinfo = theParameterSet.getParameter<bool>("applyCoarseInfo");
   adderrors = theParameterSet.getParameter<bool>("applyErrors");
 
   // Read in the information from the text files
-  edm::ParameterSet textFiles = theParameterSet.getParameter<edm::ParameterSet>( "textFileNames" );
+  edm::ParameterSet textFiles = theParameterSet.getParameter<edm::ParameterSet>("textFileNames");
 
-  std::string textFileNames[NFILES]; 
-  std::string fileType[NFILES];    
-  textFileNames[0] = textFiles.getUntrackedParameter<std::string>("forTIB","NONE");  
+  std::string textFileNames[NFILES];
+  std::string fileType[NFILES];
+  textFileNames[0] = textFiles.getUntrackedParameter<std::string>("forTIB", "NONE");
   fileType[0] = "TIB";
-  textFileNames[1] = textFiles.getUntrackedParameter<std::string>("forTID","NONE");
+  textFileNames[1] = textFiles.getUntrackedParameter<std::string>("forTID", "NONE");
   fileType[1] = "TID";
 
   SurveyDataReader dataReader;
-  for (int ii=0 ; ii<NFILES ;ii++) {
-    if ( textFileNames[ii] == "NONE" )
+  for (int ii = 0; ii < NFILES; ii++) {
+    if (textFileNames[ii] == "NONE")
       throw cms::Exception("BadConfig") << fileType[ii] << " input file not found in configuration";
-    dataReader.readFile( textFileNames[ii], fileType[ii], tTopo );
+    dataReader.readFile(textFileNames[ii], fileType[ii], tTopo);
   }
 
   // Get info and map
   const MapType& mapIdToInfo = dataReader.detIdMap();
   std::cout << "DATA HAS BEEN READ INTO THE MAP" << std::endl;
-  std::cout << "DATA HAS BEEN CONVERTED IN ALIGNABLE COORDINATES" << std::endl;  
+  std::cout << "DATA HAS BEEN CONVERTED IN ALIGNABLE COORDINATES" << std::endl;
 
-  TrackerAlignment tr_align( iSetup );
-  if (applycoarseinfo) this->applyCoarseSurveyInfo(tr_align); 
-  if (applyfineinfo) this->applyFineSurveyInfo(tr_align, mapIdToInfo);
-  if (adderrors) this->applyAPEs(tr_align);
+  TrackerAlignment tr_align(iSetup);
+  if (applycoarseinfo)
+    this->applyCoarseSurveyInfo(tr_align);
+  if (applyfineinfo)
+    this->applyFineSurveyInfo(tr_align, mapIdToInfo);
+  if (adderrors)
+    this->applyAPEs(tr_align);
   tr_align.saveToDB();
 }
 
 //___________________________________
 //
-void SurveyDataConverter::applyFineSurveyInfo( TrackerAlignment& tr_align, const MapType& map ){
-
+void SurveyDataConverter::applyFineSurveyInfo(TrackerAlignment& tr_align, const MapType& map) {
   std::cout << "Apply fine info: " << std::endl;
-	
-  for ( MapType::const_iterator it = map.begin(); it != map.end(); it++){
 
-    const align::Scalars& align_params = (it)->second; 
-      
-    align::Scalars translations; 
-    translations.push_back(align_params[0]);  
-    translations.push_back(align_params[1]);  
-    translations.push_back(align_params[2]); 
+  for (MapType::const_iterator it = map.begin(); it != map.end(); it++) {
+    const align::Scalars& align_params = (it)->second;
 
-    align::RotationType bRotation(align_params[6], align_params[9], align_params[3],
-                                  align_params[7], align_params[10], align_params[4],
-                                  align_params[8], align_params[11], align_params[5]);
+    align::Scalars translations;
+    translations.push_back(align_params[0]);
+    translations.push_back(align_params[1]);
+    translations.push_back(align_params[2]);
 
-    align::RotationType fRotation(align_params[15], align_params[18], align_params[12],
-                                  align_params[16], align_params[19], align_params[13],
-                                  align_params[17], align_params[20], align_params[14]);
+    align::RotationType bRotation(align_params[6],
+                                  align_params[9],
+                                  align_params[3],
+                                  align_params[7],
+                                  align_params[10],
+                                  align_params[4],
+                                  align_params[8],
+                                  align_params[11],
+                                  align_params[5]);
+
+    align::RotationType fRotation(align_params[15],
+                                  align_params[18],
+                                  align_params[12],
+                                  align_params[16],
+                                  align_params[19],
+                                  align_params[13],
+                                  align_params[17],
+                                  align_params[20],
+                                  align_params[14]);
 
     // Use "false" for debugging only
     tr_align.moveAlignableTIBTIDs((it)->first, translations, bRotation, fRotation, true);
@@ -92,101 +101,97 @@ void SurveyDataConverter::applyFineSurveyInfo( TrackerAlignment& tr_align, const
 
 //___________________________________
 //
-void SurveyDataConverter::applyCoarseSurveyInfo( TrackerAlignment& tr_align ){
-        
+void SurveyDataConverter::applyCoarseSurveyInfo(TrackerAlignment& tr_align) {
   std::cout << "Apply coarse info: " << std::endl;
-  MisalignScenario = theParameterSet.getParameter<edm::ParameterSet>( "MisalignmentScenario" );
+  MisalignScenario = theParameterSet.getParameter<edm::ParameterSet>("MisalignmentScenario");
 
-  TrackerScenarioBuilder scenarioBuilder( tr_align.getAlignableTracker() );
-  scenarioBuilder.applyScenario( MisalignScenario );
-  
+  TrackerScenarioBuilder scenarioBuilder(tr_align.getAlignableTracker());
+  scenarioBuilder.applyScenario(MisalignScenario);
 }
 
 //___________________________________
 //
-void SurveyDataConverter::applyAPEs( TrackerAlignment& tr_align ) {
-        
+void SurveyDataConverter::applyAPEs(TrackerAlignment& tr_align) {
   std::cout << "Apply APEs: " << std::endl;
   // Neglect sensor-on-module mounting precision (10 um)
   // Irrelevant given other sizes ..
-  std::vector<double> TIBerrors = theParameterSet.getParameter< std::vector<double> >("TIBerrors");
-  std::vector<double> TOBerrors = theParameterSet.getParameter< std::vector<double> >("TOBerrors");
-  std::vector<double> TIDerrors = theParameterSet.getParameter< std::vector<double> >("TIDerrors"); 
-  std::vector<double> TECerrors = theParameterSet.getParameter< std::vector<double> >("TECerrors"); 
-        
+  std::vector<double> TIBerrors = theParameterSet.getParameter<std::vector<double> >("TIBerrors");
+  std::vector<double> TOBerrors = theParameterSet.getParameter<std::vector<double> >("TOBerrors");
+  std::vector<double> TIDerrors = theParameterSet.getParameter<std::vector<double> >("TIDerrors");
+  std::vector<double> TECerrors = theParameterSet.getParameter<std::vector<double> >("TECerrors");
+
   if (TIBerrors.size() < 3 || TOBerrors.size() < 4 || TIDerrors.size() < 4 || TECerrors.size() < 4) {
     std::cout << "APE info not valid : please check test/run-converter.cfg" << std::endl;
     return;
   }
-         
+
   AlignableModifier theModifier{};
-  AlignableTracker* theAlignableTracker = tr_align.getAlignableTracker() ; 
+  AlignableTracker* theAlignableTracker = tr_align.getAlignableTracker();
   align::Alignables::const_iterator iter;
 
   // TIB
   const align::Alignables& theTIBhb = theAlignableTracker->innerHalfBarrels();
-  for (iter = theTIBhb.begin(); iter != theTIBhb.end(); ++iter ) 
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TIBerrors.at(0),
-                                                  TIBerrors.at(0), TIBerrors.at(0) ); }
+  for (iter = theTIBhb.begin(); iter != theTIBhb.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TIBerrors.at(0), TIBerrors.at(0), TIBerrors.at(0));
+  }
   const align::Alignables& theTIBlayers = theAlignableTracker->innerBarrelLayers();
-  for (iter = theTIBlayers.begin(); iter != theTIBlayers.end(); ++iter)
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TIBerrors.at(1),
-                                                  TIBerrors.at(1), TIBerrors.at(1) ); }
+  for (iter = theTIBlayers.begin(); iter != theTIBlayers.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TIBerrors.at(1), TIBerrors.at(1), TIBerrors.at(1));
+  }
   const align::Alignables& theTIBgd = theAlignableTracker->innerBarrelGeomDets();
-  for (iter = theTIBgd.begin(); iter != theTIBgd.end(); ++iter ) 
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TIBerrors.at(2),
-                                                  TIBerrors.at(2), TIBerrors.at(2) ); }
+  for (iter = theTIBgd.begin(); iter != theTIBgd.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TIBerrors.at(2), TIBerrors.at(2), TIBerrors.at(2));
+  }
 
   // TOB
   const align::Alignables& theTOBhb = theAlignableTracker->outerHalfBarrels();
-  for (iter = theTOBhb.begin(); iter != theTOBhb.end(); ++iter )
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TOBerrors.at(0),
-                                                  TOBerrors.at(0), TOBerrors.at(1) ); }
+  for (iter = theTOBhb.begin(); iter != theTOBhb.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TOBerrors.at(0), TOBerrors.at(0), TOBerrors.at(1));
+  }
   const align::Alignables& theTOBrods = theAlignableTracker->outerBarrelRods();
-  for (iter = theTOBrods.begin(); iter != theTOBrods.end(); ++iter ) 
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TOBerrors.at(2),
-                                                  TOBerrors.at(2), TOBerrors.at(2) ); }
+  for (iter = theTOBrods.begin(); iter != theTOBrods.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TOBerrors.at(2), TOBerrors.at(2), TOBerrors.at(2));
+  }
   const align::Alignables& theTOBgd = theAlignableTracker->outerBarrelGeomDets();
-  for (iter = theTOBgd.begin(); iter != theTOBgd.end(); ++iter )
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TOBerrors.at(3),
-                                                  TOBerrors.at(3), TOBerrors.at(3) ); }
+  for (iter = theTOBgd.begin(); iter != theTOBgd.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TOBerrors.at(3), TOBerrors.at(3), TOBerrors.at(3));
+  }
 
   // TID
   const align::Alignables& theTIDs = theAlignableTracker->TIDs();
-  for (iter = theTIDs.begin(); iter != theTIDs.end(); ++iter ) 
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TIDerrors.at(0),
-                                                  TIDerrors.at(0), TIDerrors.at(0) ); }
+  for (iter = theTIDs.begin(); iter != theTIDs.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TIDerrors.at(0), TIDerrors.at(0), TIDerrors.at(0));
+  }
   const align::Alignables& theTIDdiscs = theAlignableTracker->TIDLayers();
-  for (iter = theTIDdiscs.begin(); iter != theTIDdiscs.end(); ++iter )
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TIDerrors.at(1),
-                                                  TIDerrors.at(1), TIDerrors.at(1) ); }
+  for (iter = theTIDdiscs.begin(); iter != theTIDdiscs.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TIDerrors.at(1), TIDerrors.at(1), TIDerrors.at(1));
+  }
   const align::Alignables& theTIDrings = theAlignableTracker->TIDRings();
-  for (iter = theTIDrings.begin(); iter != theTIDrings.end(); ++iter )
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TIDerrors.at(2),
-                                                  TIDerrors.at(2), TIDerrors.at(2) ); } 
+  for (iter = theTIDrings.begin(); iter != theTIDrings.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TIDerrors.at(2), TIDerrors.at(2), TIDerrors.at(2));
+  }
   const align::Alignables& theTIDgd = theAlignableTracker->TIDGeomDets();
-  for (iter = theTIDgd.begin(); iter != theTIDgd.end(); ++iter )
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TIDerrors.at(3),
-                                                  TIDerrors.at(3), TIDerrors.at(3) ); } 
+  for (iter = theTIDgd.begin(); iter != theTIDgd.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TIDerrors.at(3), TIDerrors.at(3), TIDerrors.at(3));
+  }
 
   // TEC
   const align::Alignables& theTECs = theAlignableTracker->endCaps();
-  for (iter = theTECs.begin(); iter != theTECs.end(); ++iter ) 
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TECerrors.at(0),
-                                                  TECerrors.at(0), TECerrors.at(0) ); } 
+  for (iter = theTECs.begin(); iter != theTECs.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TECerrors.at(0), TECerrors.at(0), TECerrors.at(0));
+  }
   const align::Alignables& theTECdiscs = theAlignableTracker->endcapLayers();
-  for (iter = theTECdiscs.begin(); iter != theTECdiscs.end(); ++iter )
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TECerrors.at(1),
-                                                  TECerrors.at(1), TECerrors.at(1) ); } 
+  for (iter = theTECdiscs.begin(); iter != theTECdiscs.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TECerrors.at(1), TECerrors.at(1), TECerrors.at(1));
+  }
   const align::Alignables& theTECpetals = theAlignableTracker->endcapPetals();
-  for (iter = theTECpetals.begin(); iter != theTECpetals.end(); ++iter ) 
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TECerrors.at(2),
-                                                  TECerrors.at(2), TECerrors.at(2) ); }   
+  for (iter = theTECpetals.begin(); iter != theTECpetals.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TECerrors.at(2), TECerrors.at(2), TECerrors.at(2));
+  }
   const align::Alignables& theTECgd = theAlignableTracker->endcapGeomDets();
-  for (iter = theTECgd.begin(); iter != theTECgd.end(); ++iter )
-    { theModifier.addAlignmentPositionErrorLocal( *iter, TECerrors.at(3),
-                                                  TECerrors.at(3), TECerrors.at(3) ); }   
+  for (iter = theTECgd.begin(); iter != theTECgd.end(); ++iter) {
+    theModifier.addAlignmentPositionErrorLocal(*iter, TECerrors.at(3), TECerrors.at(3), TECerrors.at(3));
+  }
 }
 
 DEFINE_FWK_MODULE(SurveyDataConverter);
-

--- a/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyDataConverter.h
@@ -3,7 +3,7 @@
 
 // Package:    SurveyDataConverter
 // Class:      SurveyDataConverter
-// 
+//
 /**\class SurveyDataConverter SurveyDataConverter.h Alignment/SurveyDataConverter/interface/SurveyDataConverter.h
 
  Description: Reads survey corrections and applies them to the geometry.
@@ -23,40 +23,36 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Alignment/TrackerAlignment/interface/TrackerAlignment.h"
 
-class SurveyDataConverter : public edm::EDAnalyzer
-{
-
-  typedef SurveyDataReader::MapType    MapType;
-  typedef SurveyDataReader::PairType   PairType;
-  typedef SurveyDataReader::MapTypeOr  MapTypeOr;
+class SurveyDataConverter : public edm::EDAnalyzer {
+  typedef SurveyDataReader::MapType MapType;
+  typedef SurveyDataReader::PairType PairType;
+  typedef SurveyDataReader::MapTypeOr MapTypeOr;
   typedef SurveyDataReader::PairTypeOr PairTypeOr;
-	
+
 public:
   explicit SurveyDataConverter(const edm::ParameterSet& iConfig);
-	
-  void analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  void endJob() override {};
+
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void endJob() override{};
 
 private:
-
   static const int NFILES = 2;
-  
+
   // void applyAllSurveyInfo( align::Alignables alignables,
   //			   const MapType map );
-  
+
   void applyCoarseSurveyInfo(TrackerAlignment& tr_align);
-  
+
   void applyFineSurveyInfo(TrackerAlignment& tr_align, const MapType& map);
-  
-  void applyAPEs( TrackerAlignment& tr_align );
-  
+
+  void applyAPEs(TrackerAlignment& tr_align);
+
   edm::ParameterSet theParameterSet;
   edm::ParameterSet MisalignScenario;
-  
+
   //private data members
   // AlignableTracker* theAlignableTracker;
   bool applyfineinfo, applycoarseinfo, adderrors;
-
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.cc
@@ -3,7 +3,7 @@
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Alignment/MuonAlignment/interface/AlignableMuon.h"
-#include "FWCore/Framework/interface/ESHandle.h" 
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "Alignment/CommonAlignment/interface/AlignableNavigator.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
@@ -20,332 +20,350 @@
 
 #include "SurveyInputCSCfromPins.h"
 
-#define SQR(x) ((x)*(x))
+#define SQR(x) ((x) * (x))
 
-SurveyInputCSCfromPins::SurveyInputCSCfromPins(const edm::ParameterSet& cfg)
-  : m_pinPositions(cfg.getParameter<std::string>("pinPositions"))
-  , m_rootFile(cfg.getParameter<std::string>("rootFile"))
-  , m_verbose(cfg.getParameter<bool>("verbose"))
-  , m_errorX(cfg.getParameter<double>("errorX"))
-  , m_errorY(cfg.getParameter<double>("errorY"))
-  , m_errorZ(cfg.getParameter<double>("errorZ"))
-  , m_missingErrorTranslation(cfg.getParameter<double>("missingErrorTranslation"))
-  , m_missingErrorAngle(cfg.getParameter<double>("missingErrorAngle"))
-  , m_stationErrorX(cfg.getParameter<double>("stationErrorX"))
-  , m_stationErrorY(cfg.getParameter<double>("stationErrorY"))
-  , m_stationErrorZ(cfg.getParameter<double>("stationErrorZ"))
-  , m_stationErrorPhiX(cfg.getParameter<double>("stationErrorPhiX"))
-  , m_stationErrorPhiY(cfg.getParameter<double>("stationErrorPhiY"))
-  , m_stationErrorPhiZ(cfg.getParameter<double>("stationErrorPhiZ"))
-{}
+SurveyInputCSCfromPins::SurveyInputCSCfromPins(const edm::ParameterSet &cfg)
+    : m_pinPositions(cfg.getParameter<std::string>("pinPositions")),
+      m_rootFile(cfg.getParameter<std::string>("rootFile")),
+      m_verbose(cfg.getParameter<bool>("verbose")),
+      m_errorX(cfg.getParameter<double>("errorX")),
+      m_errorY(cfg.getParameter<double>("errorY")),
+      m_errorZ(cfg.getParameter<double>("errorZ")),
+      m_missingErrorTranslation(cfg.getParameter<double>("missingErrorTranslation")),
+      m_missingErrorAngle(cfg.getParameter<double>("missingErrorAngle")),
+      m_stationErrorX(cfg.getParameter<double>("stationErrorX")),
+      m_stationErrorY(cfg.getParameter<double>("stationErrorY")),
+      m_stationErrorZ(cfg.getParameter<double>("stationErrorZ")),
+      m_stationErrorPhiX(cfg.getParameter<double>("stationErrorPhiX")),
+      m_stationErrorPhiY(cfg.getParameter<double>("stationErrorPhiY")),
+      m_stationErrorPhiZ(cfg.getParameter<double>("stationErrorPhiZ")) {}
 
-void SurveyInputCSCfromPins::orient(align::LocalVector LC1, align::LocalVector LC2, double a, double b, double &T, double &dx, double &dy, double &dz, double &PhX, double &PhZ) {
-   double cosPhX, sinPhX, cosPhZ, sinPhZ;
+void SurveyInputCSCfromPins::orient(align::LocalVector LC1,
+                                    align::LocalVector LC2,
+                                    double a,
+                                    double b,
+                                    double &T,
+                                    double &dx,
+                                    double &dy,
+                                    double &dz,
+                                    double &PhX,
+                                    double &PhZ) {
+  double cosPhX, sinPhX, cosPhZ, sinPhZ;
 
-   LocalPoint LP1(LC1.x(), LC1.y() + a, LC1.z() + b);
-   LocalPoint LP2(LC2.x(), LC2.y() - a, LC2.z() + b);
-  
-   LocalPoint P((LP1.x() - LP2.x())/(2.*a), (LP1.y() - LP2.y())/(2.*a), (LP1.z() - LP2.z())/(2.*a));
-   LocalPoint Pp((LP1.x() + LP2.x())/(2.), (LP1.y() + LP2.y())/(2.), (LP1.z() + LP2.z())/(2.));
-    
-   T=P.mag();
-	
-   sinPhX=P.z()/T;
-   cosPhX=sqrt(1-SQR(sinPhX));
-   cosPhZ=P.y()/(T*cosPhX);
-   sinPhZ=-P.x()/(T*cosPhZ);
-	 	
-   PhX=atan2(sinPhX,cosPhX);
-	
-   PhZ=atan2(sinPhZ,cosPhZ);
-	
-   dx=Pp.x()-sinPhZ*sinPhX*b;
-   dy=Pp.y()+cosPhZ*sinPhX*b;
-   dz=Pp.z()-cosPhX*b;
+  LocalPoint LP1(LC1.x(), LC1.y() + a, LC1.z() + b);
+  LocalPoint LP2(LC2.x(), LC2.y() - a, LC2.z() + b);
+
+  LocalPoint P((LP1.x() - LP2.x()) / (2. * a), (LP1.y() - LP2.y()) / (2. * a), (LP1.z() - LP2.z()) / (2. * a));
+  LocalPoint Pp((LP1.x() + LP2.x()) / (2.), (LP1.y() + LP2.y()) / (2.), (LP1.z() + LP2.z()) / (2.));
+
+  T = P.mag();
+
+  sinPhX = P.z() / T;
+  cosPhX = sqrt(1 - SQR(sinPhX));
+  cosPhZ = P.y() / (T * cosPhX);
+  sinPhZ = -P.x() / (T * cosPhZ);
+
+  PhX = atan2(sinPhX, cosPhX);
+
+  PhZ = atan2(sinPhZ, cosPhZ);
+
+  dx = Pp.x() - sinPhZ * sinPhX * b;
+  dy = Pp.y() + cosPhZ * sinPhX * b;
+  dz = Pp.z() - cosPhX * b;
 }
 
-void SurveyInputCSCfromPins::errors(double a, double b, bool missing1, bool missing2, double &dx_dx, double &dy_dy, double &dz_dz, double &phix_phix, double &phiz_phiz, double &dy_phix) {
-   dx_dx = 0.;
-   dy_dy = 0.;
-   dz_dz = 0.;
-   phix_phix = 0.;
-   phiz_phiz = 0.;
-   dy_phix = 0.;
+void SurveyInputCSCfromPins::errors(double a,
+                                    double b,
+                                    bool missing1,
+                                    bool missing2,
+                                    double &dx_dx,
+                                    double &dy_dy,
+                                    double &dz_dz,
+                                    double &phix_phix,
+                                    double &phiz_phiz,
+                                    double &dy_phix) {
+  dx_dx = 0.;
+  dy_dy = 0.;
+  dz_dz = 0.;
+  phix_phix = 0.;
+  phiz_phiz = 0.;
+  dy_phix = 0.;
 
-   const double trials = 10000.;  // two significant digits
+  const double trials = 10000.;  // two significant digits
 
-   for (int i = 0;  i < trials;  i++) {
-      LocalVector LC1, LC2;
-      if (missing1) {
-	 LC1 = LocalVector(gRandom->Gaus(0., m_missingErrorTranslation), gRandom->Gaus(0., m_missingErrorTranslation), gRandom->Gaus(0., m_missingErrorTranslation));
-      }
-      else {
-      	 LC1 = LocalVector(gRandom->Gaus(0., m_errorX), gRandom->Gaus(0., m_errorY), gRandom->Gaus(0., m_errorZ));
+  for (int i = 0; i < trials; i++) {
+    LocalVector LC1, LC2;
+    if (missing1) {
+      LC1 = LocalVector(gRandom->Gaus(0., m_missingErrorTranslation),
+                        gRandom->Gaus(0., m_missingErrorTranslation),
+                        gRandom->Gaus(0., m_missingErrorTranslation));
+    } else {
+      LC1 = LocalVector(gRandom->Gaus(0., m_errorX), gRandom->Gaus(0., m_errorY), gRandom->Gaus(0., m_errorZ));
+    }
+
+    if (missing2) {
+      LC2 = LocalVector(gRandom->Gaus(0., m_missingErrorTranslation),
+                        gRandom->Gaus(0., m_missingErrorTranslation),
+                        gRandom->Gaus(0., m_missingErrorTranslation));
+    } else {
+      LC2 = LocalVector(gRandom->Gaus(0., m_errorX), gRandom->Gaus(0., m_errorY), gRandom->Gaus(0., m_errorZ));
+    }
+
+    double dx, dy, dz, PhX, PhZ, T;
+    orient(LC1, LC2, a, b, T, dx, dy, dz, PhX, PhZ);
+
+    dx_dx += dx * dx;
+    dy_dy += dy * dy;
+    dz_dz += dz * dz;
+    phix_phix += PhX * PhX;
+    phiz_phiz += PhZ * PhZ;
+    dy_phix += dy * PhX;  // the only non-zero off-diagonal element
+  }
+
+  dx_dx /= trials;
+  dy_dy /= trials;
+  dz_dz /= trials;
+  phix_phix /= trials;
+  phiz_phiz /= trials;
+  dy_phix /= trials;
+}
+
+void SurveyInputCSCfromPins::analyze(const edm::Event &, const edm::EventSetup &iSetup) {
+  if (theFirstEvent) {
+    edm::LogInfo("SurveyInputCSCfromPins") << "***************ENTERING INITIALIZATION******************"
+                                           << "  \n";
+
+    std::ifstream in;
+    in.open(m_pinPositions.c_str());
+
+    Double_t x1, y1, z1, x2, y2, z2, a, b, tot = 0.0, maxErr = 0.0, h, s1, dx, dy, dz, PhX, PhZ, T;
+
+    int ID1, ID2, ID3, ID4, ID5, i = 1, ii = 0;
+
+    TFile *file1 = new TFile(m_rootFile.c_str(), "recreate");
+    TTree *tree1 = new TTree("tree1", "alignment pins");
+
+    if (m_verbose) {
+      tree1->Branch("displacement_x_pin1_cm", &x1, "x1/D");
+      tree1->Branch("displacement_y_pin1_cm", &y1, "y1/D");
+      tree1->Branch("displacement_z_pin1_cm", &z1, "z1/D");
+      tree1->Branch("displacement_x_pin2_cm", &x2, "x2/D");
+      tree1->Branch("displacement_y_pin2_cm", &y2, "y2/D");
+      tree1->Branch("displacement_z_pin2_cm", &z2, "z2/D");
+      tree1->Branch("error_vector_length_cm", &h, "h/D");
+      tree1->Branch("stretch_diff_cm", &s1, "s1/D");
+      tree1->Branch("stretch_factor", &T, "T/D");
+      tree1->Branch("chamber_displacement_x_cm", &dx, "dx/D");
+      tree1->Branch("chamber_displacement_y_cm", &dy, "dy/D");
+      tree1->Branch("chamber_displacement_z_cm", &dz, "dz/D");
+      tree1->Branch("chamber_rotation_x_rad", &PhX, "PhX/D");
+      tree1->Branch("chamber_rotation_z_rad", &PhZ, "PhZ/D");
+    }
+
+    edm::ESHandle<DTGeometry> dtGeometry;
+    edm::ESHandle<CSCGeometry> cscGeometry;
+    iSetup.get<MuonGeometryRecord>().get(dtGeometry);
+    iSetup.get<MuonGeometryRecord>().get(cscGeometry);
+
+    AlignableMuon *theAlignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
+    AlignableNavigator *theAlignableNavigator = new AlignableNavigator(theAlignableMuon);
+
+    const auto &theEndcaps = theAlignableMuon->CSCEndcaps();
+
+    for (const auto &aliiter : theEndcaps) {
+      addComponent(aliiter);
+    }
+
+    while (in.good()) {
+      bool missing1 = false;
+      bool missing2 = false;
+
+      in >> ID1 >> ID2 >> ID3 >> ID4 >> ID5 >> x1 >> y1 >> z1 >> x2 >> y2 >> z2 >> a >> b;
+
+      if (fabs(x1 - 1000.) < 1e5 && fabs(y1 - 1000.) < 1e5 && fabs(z1 - 1000.) < 1e5) {
+        missing1 = true;
+        x1 = x2;
+        y1 = y2;
+        z1 = z2;
       }
 
-      if (missing2) {
-	 LC2 = LocalVector(gRandom->Gaus(0., m_missingErrorTranslation), gRandom->Gaus(0., m_missingErrorTranslation), gRandom->Gaus(0., m_missingErrorTranslation));
-      }
-      else {
-	 LC2 = LocalVector(gRandom->Gaus(0., m_errorX), gRandom->Gaus(0., m_errorY), gRandom->Gaus(0., m_errorZ));
+      if (fabs(x2 - 1000.) < 1e5 && fabs(y2 - 1000.) < 1e5 && fabs(z2 - 1000.) < 1e5) {
+        missing2 = true;
+        x2 = x1;
+        y2 = y1;
+        z2 = z1;
       }
 
-      double dx, dy, dz, PhX, PhZ, T;
+      x1 = x1 / 10.0;
+      y1 = y1 / 10.0;
+      z1 = z1 / 10.0;
+      x2 = x2 / 10.0;
+      y2 = y2 / 10.0;
+      z2 = z2 / 10.0;
+
+      CSCDetId layerID(ID1, ID2, ID3, ID4, 1);
+
+      // We cannot use chamber ID (when ID5=0), because AlignableNavigator gives the error (aliDet and aliDetUnit are undefined for chambers)
+
+      Alignable *theAlignable1 = theAlignableNavigator->alignableFromDetId(layerID);
+      Alignable *chamberAli = theAlignable1->mother();
+
+      LocalVector LC1 = chamberAli->surface().toLocal(GlobalVector(x1, y1, z1));
+      LocalVector LC2 = chamberAli->surface().toLocal(GlobalVector(x2, y2, z2));
+
       orient(LC1, LC2, a, b, T, dx, dy, dz, PhX, PhZ);
 
-      dx_dx += dx * dx;
-      dy_dy += dy * dy;
-      dz_dz += dz * dz;
-      phix_phix += PhX * PhX;
-      phiz_phiz += PhZ * PhZ;
-      dy_phix += dy * PhX;      // the only non-zero off-diagonal element
-   }
+      GlobalPoint PG1 = chamberAli->surface().toGlobal(LocalPoint(LC1.x(), LC1.y() + a, LC1.z() + b));
+      chamberAli->surface().toGlobal(LocalPoint(LC2.x(), LC2.y() - a, LC2.z() + b));
 
-   dx_dx /= trials;
-   dy_dy /= trials;
-   dz_dz /= trials;
-   phix_phix /= trials;
-   phiz_phiz /= trials;
-   dy_phix /= trials;
-}
+      LocalVector lvector(dx, dy, dz);
+      GlobalVector gvector = (chamberAli->surface()).toGlobal(lvector);
+      chamberAli->move(gvector);
 
-void SurveyInputCSCfromPins::analyze(const edm::Event&, const edm::EventSetup& iSetup)
-{
-  if (theFirstEvent) {
+      chamberAli->rotateAroundLocalX(PhX);
+      chamberAli->rotateAroundLocalZ(PhZ);
 
-	edm::LogInfo("SurveyInputCSCfromPins") << "***************ENTERING INITIALIZATION******************" << "  \n";
-	
-	std::ifstream in;
-  	in.open(m_pinPositions.c_str());
-  
-	Double_t x1, y1, z1, x2, y2, z2, a, b, tot=0.0, maxErr=0.0, h, s1, dx, dy, dz, PhX, PhZ, T;
-   
-	int ID1, ID2, ID3, ID4, ID5, i=1, ii=0;
-	
-	TFile *file1 = new TFile(m_rootFile.c_str(),"recreate");
-	TTree *tree1 = new TTree("tree1","alignment pins");
-      
-   	if (m_verbose) {
-   
-   		tree1->Branch("displacement_x_pin1_cm", &x1, "x1/D");
-   		tree1->Branch("displacement_y_pin1_cm", &y1, "y1/D");
-	   	tree1->Branch("displacement_z_pin1_cm", &z1, "z1/D");
-	   	tree1->Branch("displacement_x_pin2_cm", &x2, "x2/D");
-   		tree1->Branch("displacement_y_pin2_cm", &y2, "y2/D");
-   		tree1->Branch("displacement_z_pin2_cm", &z2, "z2/D");     
-	   	tree1->Branch("error_vector_length_cm",&h, "h/D"); 
-   		tree1->Branch("stretch_diff_cm",&s1, "s1/D");
-	   	tree1->Branch("stretch_factor",&T, "T/D");
-   		tree1->Branch("chamber_displacement_x_cm",&dx, "dx/D");
-	   	tree1->Branch("chamber_displacement_y_cm",&dy, "dy/D");
-   		tree1->Branch("chamber_displacement_z_cm",&dz, "dz/D");
-	   	tree1->Branch("chamber_rotation_x_rad",&PhX, "PhX/D");
-   		tree1->Branch("chamber_rotation_z_rad",&PhZ, "PhZ/D");
-  	}
-  
-	edm::ESHandle<DTGeometry> dtGeometry;
-	edm::ESHandle<CSCGeometry> cscGeometry;
- 	iSetup.get<MuonGeometryRecord>().get( dtGeometry );     
- 	iSetup.get<MuonGeometryRecord>().get( cscGeometry );
- 
- 	AlignableMuon* theAlignableMuon = new AlignableMuon( &(*dtGeometry) , &(*cscGeometry) );
- 	AlignableNavigator* theAlignableNavigator = new AlignableNavigator( theAlignableMuon );
+      double dx_dx, dy_dy, dz_dz, phix_phix, phiz_phiz, dy_phix;
+      errors(a, b, missing1, missing2, dx_dx, dy_dy, dz_dz, phix_phix, phiz_phiz, dy_phix);
+      align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
+      error(0, 0) = dx_dx;
+      error(1, 1) = dy_dy;
+      error(2, 2) = dz_dz;
+      error(3, 3) = phix_phix;
+      error(4, 4) = m_missingErrorAngle;
+      error(5, 5) = phiz_phiz;
+      error(1, 3) = dy_phix;
+      error(3, 1) = dy_phix;  // just in case
 
-        const auto& theEndcaps = theAlignableMuon->CSCEndcaps();
+      chamberAli->setSurvey(new SurveyDet(chamberAli->surface(), error));
 
-        for (const auto& aliiter: theEndcaps) {
-                addComponent(aliiter);
-        }
-    
-	
-	while (in.good())
-  	{
-	   bool missing1 = false;
-	   bool missing2 = false;
-    
-    		in >> ID1 >> ID2 >> ID3 >> ID4 >> ID5 >> x1 >> y1 >> z1 >> x2 >> y2 >> z2 >> a >> b;
+      if (m_verbose) {
+        edm::LogInfo("SurveyInputCSCfromPins") << " survey information = " << chamberAli->survey() << "  \n";
 
-		if (fabs(x1 - 1000.) < 1e5  &&  fabs(y1 - 1000.) < 1e5  &&  fabs(z1 - 1000.) < 1e5) {
-		   missing1 = true;
-		   x1 = x2;
-		   y1 = y2;
-		   z1 = z2;
-		}
+        LocalPoint LP1n = chamberAli->surface().toLocal(PG1);
 
-		if (fabs(x2 - 1000.) < 1e5  &&  fabs(y2 - 1000.) < 1e5  &&  fabs(z2 - 1000.) < 1e5) {
-		   missing2 = true;
-		   x2 = x1;
-		   y2 = y1;
-		   z2 = z1;
-		}
+        LocalPoint hiP(LP1n.x(), LP1n.y() - a * T, LP1n.z() - b);
 
-		x1=x1/10.0;
-		y1=y1/10.0;
-		z1=z1/10.0;
-		x2=x2/10.0;
-		y2=y2/10.0;
-		z2=z2/10.0;
-   
- 		CSCDetId layerID(ID1, ID2, ID3, ID4, 1);
-		
-		// We cannot use chamber ID (when ID5=0), because AlignableNavigator gives the error (aliDet and aliDetUnit are undefined for chambers)
-		
-		
-		Alignable* theAlignable1 = theAlignableNavigator->alignableFromDetId( layerID ); 
- 		Alignable* chamberAli=theAlignable1->mother();
+        h = hiP.mag();
+        s1 = LP1n.y() - a;
 
-  		LocalVector LC1 = chamberAli->surface().toLocal(GlobalVector(x1,y1,z1));
-  		LocalVector LC2 = chamberAli->surface().toLocal(GlobalVector(x2,y2,z2));
-  
-		orient(LC1, LC2, a, b, T, dx, dy, dz, PhX, PhZ);	
-   
- 		GlobalPoint PG1 = chamberAli->surface().toGlobal(LocalPoint(LC1.x(), LC1.y() + a, LC1.z() + b));
- 		chamberAli->surface().toGlobal(LocalPoint(LC2.x(), LC2.y() - a, LC2.z() + b));
- 
-	
- 		LocalVector lvector( dx, dy, dz);
- 		GlobalVector gvector = ( chamberAli->surface()).toGlobal( lvector );
- 		chamberAli->move( gvector );
-  
-  		chamberAli->rotateAroundLocalX( PhX );
-  		chamberAli->rotateAroundLocalZ( PhZ );
-		
-		double dx_dx, dy_dy, dz_dz, phix_phix, phiz_phiz, dy_phix;
-		errors(a, b, missing1, missing2, dx_dx, dy_dy, dz_dz, phix_phix, phiz_phiz, dy_phix);
-  		align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
-		error(0,0) = dx_dx;
-		error(1,1) = dy_dy;
-		error(2,2) = dz_dz;
-		error(3,3) = phix_phix;
-		error(4,4) = m_missingErrorAngle;
-		error(5,5) = phiz_phiz;
-		error(1,3) = dy_phix;
-		error(3,1) = dy_phix;  // just in case
+        if (h > maxErr) {
+          maxErr = h;
 
-  		chamberAli->setSurvey( new SurveyDet(chamberAli->surface(), error) );
-    
-    		if (m_verbose) {
-    			
-			edm::LogInfo("SurveyInputCSCfromPins") << " survey information = " << chamberAli->survey() << "  \n";
-			
-  			LocalPoint LP1n = chamberAli->surface().toLocal(PG1);
-	
-			LocalPoint hiP(LP1n.x(), LP1n.y() - a*T, LP1n.z() - b);
-
-			h=hiP.mag();
-			s1=LP1n.y() - a;
-
-			if (h>maxErr) { maxErr=h; 
-			
-				ii=i;
-	 		}
-	
-			edm::LogInfo("SurveyInputCSCfromPins") << "  \n" 
-			 << "i " << i++ << " " << ID1 << " " << ID2 << " " << ID3 << " " << ID4 << " " << ID5 << " error  " << h  << " \n"	
-			 <<" x1 " << x1 << " y1 " << y1 << " z1 " << z1 << " x2 " << x2 << " y2 " << y2 << " z2 " << z2  << " \n"
-			 << " error " << h <<  " S1 " << s1 << " \n"
-			 <<" dx " << dx << " dy " << dy << " dz " << dz << " PhX " << PhX << " PhZ " << PhZ  << " \n";
-
-			tot+=h;
-	
-			tree1->Fill();
-			}
-   	
-   	} 
- 
-	in.close();
-
-	if (m_verbose) {
-	
-   		file1->Write();
-		edm::LogInfo("SurveyInputCSCfromPins") << " Total error  " << tot << "  Max Error " << maxErr << " N " << ii << "  \n";
-   	}
-
-	file1->Close();
-   
-        for (const auto& aliiter: theEndcaps) {
-                fillAllRecords(aliiter);
+          ii = i;
         }
 
-	delete theAlignableMuon;
-	delete theAlignableNavigator;
+        edm::LogInfo("SurveyInputCSCfromPins")
+            << "  \n"
+            << "i " << i++ << " " << ID1 << " " << ID2 << " " << ID3 << " " << ID4 << " " << ID5 << " error  " << h
+            << " \n"
+            << " x1 " << x1 << " y1 " << y1 << " z1 " << z1 << " x2 " << x2 << " y2 " << y2 << " z2 " << z2 << " \n"
+            << " error " << h << " S1 " << s1 << " \n"
+            << " dx " << dx << " dy " << dy << " dz " << dz << " PhX " << PhX << " PhZ " << PhZ << " \n";
 
-	edm::LogInfo("SurveyInputCSCfromPins") << "*************END INITIALIZATION***************" << "  \n";
+        tot += h;
 
-	theFirstEvent = false;
+        tree1->Fill();
+      }
+    }
+
+    in.close();
+
+    if (m_verbose) {
+      file1->Write();
+      edm::LogInfo("SurveyInputCSCfromPins")
+          << " Total error  " << tot << "  Max Error " << maxErr << " N " << ii << "  \n";
+    }
+
+    file1->Close();
+
+    for (const auto &aliiter : theEndcaps) {
+      fillAllRecords(aliiter);
+    }
+
+    delete theAlignableMuon;
+    delete theAlignableNavigator;
+
+    edm::LogInfo("SurveyInputCSCfromPins") << "*************END INITIALIZATION***************"
+                                           << "  \n";
+
+    theFirstEvent = false;
   }
 }
 
-
 void SurveyInputCSCfromPins::fillAllRecords(Alignable *ali) {
-   	if (ali->survey() == nullptr) {
+  if (ali->survey() == nullptr) {
+    AlignableCSCChamber *ali_AlignableCSCChamber = dynamic_cast<AlignableCSCChamber *>(ali);
+    AlignableCSCStation *ali_AlignableCSCStation = dynamic_cast<AlignableCSCStation *>(ali);
 
-	   AlignableCSCChamber *ali_AlignableCSCChamber = dynamic_cast<AlignableCSCChamber*>(ali);
-	   AlignableCSCStation *ali_AlignableCSCStation = dynamic_cast<AlignableCSCStation*>(ali);
+    if (ali_AlignableCSCChamber != nullptr) {
+      CSCDetId detid(ali->geomDetId());
+      if (abs(detid.station()) == 1 && (detid.ring() == 1 || detid.ring() == 4)) {
+        align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
+        error(0, 0) = m_missingErrorTranslation;
+        error(1, 1) = m_missingErrorTranslation;
+        error(2, 2) = m_missingErrorTranslation;
+        error(3, 3) = m_missingErrorAngle;
+        error(4, 4) = m_missingErrorAngle;
+        error(5, 5) = m_missingErrorAngle;
 
-	   if (ali_AlignableCSCChamber != nullptr) {
-	      CSCDetId detid(ali->geomDetId());
-	      if (abs(detid.station()) == 1  &&  (detid.ring() == 1  ||  detid.ring() == 4)) {
-		 align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
-		 error(0,0) = m_missingErrorTranslation;
-		 error(1,1) = m_missingErrorTranslation;
-		 error(2,2) = m_missingErrorTranslation;
-		 error(3,3) = m_missingErrorAngle;
-		 error(4,4) = m_missingErrorAngle;
-		 error(5,5) = m_missingErrorAngle;
+        ali->setSurvey(new SurveyDet(ali->surface(), error));
+      } else {
+        double a = 100.;
+        double b = -9.4034;
+        if (abs(detid.station()) == 1 && detid.ring() == 2)
+          a = -90.260;
+        else if (abs(detid.station()) == 1 && detid.ring() == 3)
+          a = -85.205;
+        else if (abs(detid.station()) == 2 && detid.ring() == 1)
+          a = -97.855;
+        else if (abs(detid.station()) == 2 && detid.ring() == 2)
+          a = -164.555;
+        else if (abs(detid.station()) == 3 && detid.ring() == 1)
+          a = -87.870;
+        else if (abs(detid.station()) == 3 && detid.ring() == 2)
+          a = -164.555;
+        else if (abs(detid.station()) == 4 && detid.ring() == 1)
+          a = -77.890;
 
-		 ali->setSurvey(new SurveyDet(ali->surface(), error));
-	      }
-	      else {
-		 double a = 100.;
-		 double b = -9.4034;
-		 if      (abs(detid.station()) == 1  &&  detid.ring() == 2) a = -90.260;
-		 else if (abs(detid.station()) == 1  &&  detid.ring() == 3) a = -85.205;
-		 else if (abs(detid.station()) == 2  &&  detid.ring() == 1) a = -97.855;
-		 else if (abs(detid.station()) == 2  &&  detid.ring() == 2) a = -164.555;
-		 else if (abs(detid.station()) == 3  &&  detid.ring() == 1) a = -87.870;
-		 else if (abs(detid.station()) == 3  &&  detid.ring() == 2) a = -164.555;
-		 else if (abs(detid.station()) == 4  &&  detid.ring() == 1) a = -77.890;
+        double dx_dx, dy_dy, dz_dz, phix_phix, phiz_phiz, dy_phix;
+        errors(a, b, true, true, dx_dx, dy_dy, dz_dz, phix_phix, phiz_phiz, dy_phix);
+        align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
+        error(0, 0) = dx_dx;
+        error(1, 1) = dy_dy;
+        error(2, 2) = dz_dz;
+        error(3, 3) = phix_phix;
+        error(4, 4) = m_missingErrorAngle;
+        error(5, 5) = phiz_phiz;
+        error(1, 3) = dy_phix;
+        error(3, 1) = dy_phix;  // just in case
 
-		double dx_dx, dy_dy, dz_dz, phix_phix, phiz_phiz, dy_phix;
-		errors(a, b, true, true, dx_dx, dy_dy, dz_dz, phix_phix, phiz_phiz, dy_phix);
-  		align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
-		error(0,0) = dx_dx;
-		error(1,1) = dy_dy;
-		error(2,2) = dz_dz;
-		error(3,3) = phix_phix;
-		error(4,4) = m_missingErrorAngle;
-		error(5,5) = phiz_phiz;
-		error(1,3) = dy_phix;
-		error(3,1) = dy_phix;  // just in case
+        ali->setSurvey(new SurveyDet(ali->surface(), error));
+      }
+    }
 
-		ali->setSurvey(new SurveyDet(ali->surface(), error));
-	      }
-	   }
+    else if (ali_AlignableCSCStation != nullptr) {
+      align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
+      error(0, 0) = m_stationErrorX;
+      error(1, 1) = m_stationErrorY;
+      error(2, 2) = m_stationErrorZ;
+      error(3, 3) = m_stationErrorPhiX;
+      error(4, 4) = m_stationErrorPhiY;
+      error(5, 5) = m_stationErrorPhiZ;
 
-	   else if (ali_AlignableCSCStation != nullptr) {
-	      align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
-	      error(0,0) = m_stationErrorX;
-	      error(1,1) = m_stationErrorY;
-	      error(2,2) = m_stationErrorZ;
-	      error(3,3) = m_stationErrorPhiX;
-	      error(4,4) = m_stationErrorPhiY;
-	      error(5,5) = m_stationErrorPhiZ;
+      ali->setSurvey(new SurveyDet(ali->surface(), error));
+    }
 
-	      ali->setSurvey(new SurveyDet(ali->surface(), error));
-	   }
+    else {
+      align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
+      ali->setSurvey(new SurveyDet(ali->surface(), error * (1e-10)));
+    }
+  }
 
-	   else {
-	      align::ErrorMatrix error = ROOT::Math::SMatrixIdentity();
-	      ali->setSurvey(new SurveyDet(ali->surface(), error*(1e-10)));
-	   }
-   	}
-
-        for (const auto& iter: ali->components()) {
-                fillAllRecords(iter);
-        }
+  for (const auto &iter : ali->components()) {
+    fillAllRecords(iter);
+  }
 }
-
 
 // Plug in to framework
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.h
@@ -13,20 +13,34 @@
 #include "Alignment/SurveyAnalysis/interface/SurveyInputBase.h"
 #include "CondFormats/Alignment/interface/Definitions.h"
 
-class SurveyInputCSCfromPins:
-  public SurveyInputBase
-{
+class SurveyInputCSCfromPins : public SurveyInputBase {
 public:
-	
-  SurveyInputCSCfromPins(const edm::ParameterSet&);
-	
+  SurveyInputCSCfromPins(const edm::ParameterSet &);
+
   /// Read ideal tracker geometry from DB
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
-
-  void orient(align::LocalVector LC1, align::LocalVector LC2, double a, double b, double &T, double &dx, double &dy, double &dz, double &PhX, double &PhZ);
-  void errors(double a, double b, bool missing1, bool missing2, double &dx_dx, double &dy_dy, double &dz_dz, double &phix_phix, double &phiz_phiz, double &dy_phix);
+  void orient(align::LocalVector LC1,
+              align::LocalVector LC2,
+              double a,
+              double b,
+              double &T,
+              double &dx,
+              double &dy,
+              double &dz,
+              double &PhX,
+              double &PhZ);
+  void errors(double a,
+              double b,
+              bool missing1,
+              bool missing2,
+              double &dx_dx,
+              double &dy_dy,
+              double &dz_dz,
+              double &phix_phix,
+              double &phiz_phiz,
+              double &dy_phix);
 
   void fillAllRecords(Alignable *ali);
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.cc
@@ -17,98 +17,91 @@
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
 
-
 #include "Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.h"
 
 SurveyInputTrackerFromDB::SurveyInputTrackerFromDB(const edm::ParameterSet& cfg)
-  : textFileName( cfg.getParameter<std::string>("textFileName") )
-{}
+    : textFileName(cfg.getParameter<std::string>("textFileName")) {}
 
-void SurveyInputTrackerFromDB::analyze(const edm::Event&, const edm::EventSetup& setup)
-{
-
+void SurveyInputTrackerFromDB::analyze(const edm::Event&, const edm::EventSetup& setup) {
   if (theFirstEvent) {
+    //  std::cout << "***************ENTERING INITIALIZATION******************" << std::endl;
 
-	//  std::cout << "***************ENTERING INITIALIZATION******************" << std::endl;
-	
-	//Retrieve tracker topology from geometry
-	edm::ESHandle<TrackerTopology> tTopoHandle;
-	setup.get<TrackerTopologyRcd>().get(tTopoHandle);
-	const TrackerTopology* const tTopo = tTopoHandle.product();
+    //Retrieve tracker topology from geometry
+    edm::ESHandle<TrackerTopology> tTopoHandle;
+    setup.get<TrackerTopologyRcd>().get(tTopoHandle);
+    const TrackerTopology* const tTopo = tTopoHandle.product();
 
-	//Get map from textreader
-	SurveyInputTextReader dataReader;
-	dataReader.readFile( textFileName );
-	uIdMap = dataReader.UniqueIdMap();
-	
-	edm::ESHandle<GeometricDet>  geom;
-	setup.get<IdealGeometryRecord>().get(geom); 
-	edm::ESHandle<PTrackerParameters> ptp;
-	setup.get<PTrackerParametersRcd>().get( ptp );
-	TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(&*geom, *ptp, tTopo );
-	
-	addComponent( new AlignableTracker( tracker, tTopo ) );
-	addSurveyInfo( detector() );
-	
-	//write out to a DB ...
-	Alignments* myAlignments = detector()->alignments();
-	AlignmentErrorsExtended* myAlignmentErrorsExtended = detector()->alignmentErrors();
-	
-	// 2. Store alignment[Error]s to DB
-	edm::Service<cond::service::PoolDBOutputService> poolDbService;
-	// Call service
-	
-	if( !poolDbService.isAvailable() ) // Die if not available
-		throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
-	
-	poolDbService->writeOne<Alignments>( myAlignments, poolDbService->beginOfTime(), "TrackerAlignmentRcd" );
-	poolDbService->writeOne<AlignmentErrorsExtended>( myAlignmentErrorsExtended, poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd" );
-	
-	theFirstEvent = false;
+    //Get map from textreader
+    SurveyInputTextReader dataReader;
+    dataReader.readFile(textFileName);
+    uIdMap = dataReader.UniqueIdMap();
+
+    edm::ESHandle<GeometricDet> geom;
+    setup.get<IdealGeometryRecord>().get(geom);
+    edm::ESHandle<PTrackerParameters> ptp;
+    setup.get<PTrackerParametersRcd>().get(ptp);
+    TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(&*geom, *ptp, tTopo);
+
+    addComponent(new AlignableTracker(tracker, tTopo));
+    addSurveyInfo(detector());
+
+    //write out to a DB ...
+    Alignments* myAlignments = detector()->alignments();
+    AlignmentErrorsExtended* myAlignmentErrorsExtended = detector()->alignmentErrors();
+
+    // 2. Store alignment[Error]s to DB
+    edm::Service<cond::service::PoolDBOutputService> poolDbService;
+    // Call service
+
+    if (!poolDbService.isAvailable())  // Die if not available
+      throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
+
+    poolDbService->writeOne<Alignments>(myAlignments, poolDbService->beginOfTime(), "TrackerAlignmentRcd");
+    poolDbService->writeOne<AlignmentErrorsExtended>(
+        myAlignmentErrorsExtended, poolDbService->beginOfTime(), "TrackerAlignmentErrorExtendedRcd");
+
+    theFirstEvent = false;
   }
 }
 
-void SurveyInputTrackerFromDB::addSurveyInfo(Alignable* ali)
-{
-	const align::Alignables& comp = ali->components();
-	unsigned int nComp = comp.size();
-	
-	for (unsigned int i = 0; i < nComp; ++i) addSurveyInfo(comp[i]);
-	
-	align::ErrorMatrix error;
+void SurveyInputTrackerFromDB::addSurveyInfo(Alignable* ali) {
+  const align::Alignables& comp = ali->components();
+  unsigned int nComp = comp.size();
 
-	SurveyInputTextReader::MapType::const_iterator it
-	  = uIdMap.find(std::make_pair(ali->id(), ali->alignableObjectId()));
+  for (unsigned int i = 0; i < nComp; ++i)
+    addSurveyInfo(comp[i]);
 
-	if (it != uIdMap.end()){
-		
-		const align::Scalars& parameters = (it)->second;
-		
-		//move the surface
-		//displacement
-		align::LocalVector lvector (parameters[0], parameters[1], parameters[2]);
-		align::GlobalVector gvector = ali->surface().toGlobal(lvector);
-		ali->move(gvector);
-		//rotation
-		Basic3DVector<align::Scalar> rot_aa(parameters[3], parameters[4], parameters[5]);
-		align::RotationType rotation(rot_aa, rot_aa.mag());
-		ali->rotateInLocalFrame(rotation);
-		
-		//sets the errors for the hierarchy level
-		double* errorData = error.Array();
-		for (unsigned int i = 0; i < 21; ++i){errorData[i] = parameters[i+6];}
-		
-		ali->setSurvey( new SurveyDet(ali->surface(), error*(1e-6)) );
-	}
-	else {
-		error = ROOT::Math::SMatrixIdentity();
-		ali->setSurvey( new SurveyDet(ali->surface(), error * 1e-6) );
-	}
-	
+  align::ErrorMatrix error;
+
+  SurveyInputTextReader::MapType::const_iterator it = uIdMap.find(std::make_pair(ali->id(), ali->alignableObjectId()));
+
+  if (it != uIdMap.end()) {
+    const align::Scalars& parameters = (it)->second;
+
+    //move the surface
+    //displacement
+    align::LocalVector lvector(parameters[0], parameters[1], parameters[2]);
+    align::GlobalVector gvector = ali->surface().toGlobal(lvector);
+    ali->move(gvector);
+    //rotation
+    Basic3DVector<align::Scalar> rot_aa(parameters[3], parameters[4], parameters[5]);
+    align::RotationType rotation(rot_aa, rot_aa.mag());
+    ali->rotateInLocalFrame(rotation);
+
+    //sets the errors for the hierarchy level
+    double* errorData = error.Array();
+    for (unsigned int i = 0; i < 21; ++i) {
+      errorData[i] = parameters[i + 6];
+    }
+
+    ali->setSurvey(new SurveyDet(ali->surface(), error * (1e-6)));
+  } else {
+    error = ROOT::Math::SMatrixIdentity();
+    ali->setSurvey(new SurveyDet(ali->surface(), error * 1e-6));
+  }
 }
 // Plug in to framework
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 
 DEFINE_FWK_MODULE(SurveyInputTrackerFromDB);

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.h
@@ -17,31 +17,20 @@ namespace edm {
   class ParameterSet;
 }
 
-class SurveyInputTrackerFromDB:
-  public SurveyInputBase
-{
+class SurveyInputTrackerFromDB : public SurveyInputBase {
 public:
-	
-  SurveyInputTrackerFromDB(
-			   const edm::ParameterSet&
-			   );
-	
+  SurveyInputTrackerFromDB(const edm::ParameterSet&);
+
   /// Read ideal tracker geometry from DB
-  void analyze(
-		       const edm::Event&,
-		       const edm::EventSetup&
-		       ) override;
-	
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
 private:
-	
   SurveyInputTextReader::MapType uIdMap;
 
   std::string textFileName;
-	
+
   /// Add survey info to an alignable
-  void addSurveyInfo(
-		     Alignable*
-		     );
+  void addSurveyInfo(Alignable*);
 };
 
 #endif

--- a/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.cc
@@ -16,12 +16,10 @@
 
 #include "Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.h"
 
-SurveyMisalignmentInput::SurveyMisalignmentInput(const edm::ParameterSet& cfg):
-  textFileName( cfg.getParameter<std::string>("textFileName") )
-{}
+SurveyMisalignmentInput::SurveyMisalignmentInput(const edm::ParameterSet& cfg)
+    : textFileName(cfg.getParameter<std::string>("textFileName")) {}
 
-void SurveyMisalignmentInput::analyze(const edm::Event&, const edm::EventSetup& setup)
-{
+void SurveyMisalignmentInput::analyze(const edm::Event&, const edm::EventSetup& setup) {
   if (theFirstEvent) {
     //Retrieve tracker topology from geometry
     edm::ESHandle<TrackerTopology> tTopoHandle;
@@ -29,85 +27,77 @@ void SurveyMisalignmentInput::analyze(const edm::Event&, const edm::EventSetup& 
     const TrackerTopology* const tTopo = tTopoHandle.product();
 
     edm::ESHandle<GeometricDet> geom;
-    setup.get<IdealGeometryRecord>().get(geom);	 
+    setup.get<IdealGeometryRecord>().get(geom);
 
     edm::ESHandle<PTrackerParameters> ptp;
-    setup.get<PTrackerParametersRcd>().get( ptp );
-    TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(&*geom, *ptp, tTopo );
-    
-    addComponent(new AlignableTracker( tracker, tTopo ));
+    setup.get<PTrackerParametersRcd>().get(ptp);
+    TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(&*geom, *ptp, tTopo);
+
+    addComponent(new AlignableTracker(tracker, tTopo));
 
     edm::LogInfo("SurveyMisalignmentInput") << "Starting!";
     // Retrieve alignment[Error]s from DBase
-    setup.get<TrackerAlignmentRcd>().get( alignments );
-    
+    setup.get<TrackerAlignmentRcd>().get(alignments);
+
     //Get map from textreader
     SurveyInputTextReader dataReader;
-    dataReader.readFile( textFileName );
+    dataReader.readFile(textFileName);
     uIdMap = dataReader.UniqueIdMap();
-    
-    addSurveyInfo( detector() );
+
+    addSurveyInfo(detector());
 
     theFirstEvent = false;
   }
 }
 
-
-void SurveyMisalignmentInput::addSurveyInfo(Alignable* ali)
-{
-
+void SurveyMisalignmentInput::addSurveyInfo(Alignable* ali) {
   const align::Alignables& comp = ali->components();
   unsigned int nComp = comp.size();
-  for (unsigned int i = 0; i < nComp; ++i) addSurveyInfo(comp[i]);
-	
-  SurveyInputTextReader::MapType::const_iterator it
-    = uIdMap.find(std::make_pair(ali->id(), ali->alignableObjectId()));
+  for (unsigned int i = 0; i < nComp; ++i)
+    addSurveyInfo(comp[i]);
+
+  SurveyInputTextReader::MapType::const_iterator it = uIdMap.find(std::make_pair(ali->id(), ali->alignableObjectId()));
 
   align::ErrorMatrix error;
 
-  if (it != uIdMap.end()){
+  if (it != uIdMap.end()) {
     //survey error values
     const align::Scalars& parameters = (it)->second;
     //sets the errors for the hierarchy level
     double* errorData = error.Array();
-    for (unsigned int i = 0; i < 21; ++i){errorData[i] = parameters[i+6];}
-		
+    for (unsigned int i = 0; i < 21; ++i) {
+      errorData[i] = parameters[i + 6];
+    }
+
     //because record only needs global value of modules
-    if (ali->alignableObjectId() == align::AlignableDetUnit){
+    if (ali->alignableObjectId() == align::AlignableDetUnit) {
       // fill survey values
-      ali->setSurvey( new SurveyDet(getAlignableSurface(ali->id()), error) );
+      ali->setSurvey(new SurveyDet(getAlignableSurface(ali->id()), error));
+    } else {
+      ali->setSurvey(new SurveyDet(ali->surface(), error));
     }
-    else{
-      ali->setSurvey( new SurveyDet(ali->surface(), error) );
-    }
-  }
-  else{
+  } else {
     //fill
     error = ROOT::Math::SMatrixIdentity();
-    ali->setSurvey( new SurveyDet(ali->surface(), error*(1e-6)) );
+    ali->setSurvey(new SurveyDet(ali->surface(), error * (1e-6)));
   }
   //std::cout << "UniqueId: " << id.first << ", " << id.second << std::endl;
   //std::cout << error << std::endl;
-	
 }
 
-AlignableSurface SurveyMisalignmentInput::getAlignableSurface(align::ID id)
-{
+AlignableSurface SurveyMisalignmentInput::getAlignableSurface(align::ID id) {
   std::vector<AlignTransform>::const_iterator it;
 
-  for (it = alignments->m_align.begin(); it != alignments->m_align.end(); ++it)
-  {
-    if (id == (*it).rawId())
-    {
-      align::PositionType position( (*it).translation().x(), (*it).translation().y(), (*it).translation().z() );
-      CLHEP::HepRotation rot( (*it).rotation() );
-      align::RotationType rotation( rot.xx(), rot.xy(), rot.xz(),
-				    rot.yx(), rot.yy(), rot.yz(),
-				    rot.zx(), rot.zy(), rot.zz() );
-      return AlignableSurface(position,rotation);
+  for (it = alignments->m_align.begin(); it != alignments->m_align.end(); ++it) {
+    if (id == (*it).rawId()) {
+      align::PositionType position((*it).translation().x(), (*it).translation().y(), (*it).translation().z());
+      CLHEP::HepRotation rot((*it).rotation());
+      align::RotationType rotation(
+          rot.xx(), rot.xy(), rot.xz(), rot.yx(), rot.yy(), rot.yz(), rot.zx(), rot.zy(), rot.zz());
+      return AlignableSurface(position, rotation);
     }
   }
-	
+
   return AlignableSurface();
 }
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.h
@@ -18,29 +18,20 @@
 class AlignableSurface;
 class Alignments;
 
-class SurveyMisalignmentInput:
-  public SurveyInputBase
-{
+class SurveyMisalignmentInput : public SurveyInputBase {
 public:
-	
-  SurveyMisalignmentInput(
-			  const edm::ParameterSet&
-			  );
-	
+  SurveyMisalignmentInput(const edm::ParameterSet&);
+
   /// Read ideal tracker geometry from DB
-  void analyze(
-		       const edm::Event&,
-		       const edm::EventSetup&
-		       ) override;
-	
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
 private:
-	
   SurveyInputTextReader::MapType uIdMap;
 
   std::string textFileName;
 
   edm::ESHandle<Alignments> alignments;
-	
+
   /// Add survey info to an alignable
   void addSurveyInfo(Alignable*);
 

--- a/Alignment/SurveyAnalysis/src/Chi2.cc
+++ b/Alignment/SurveyAnalysis/src/Chi2.cc
@@ -1,34 +1,29 @@
 #include "Alignment/SurveyAnalysis/interface/Chi2.h"
 
 Chi2::Chi2(TMatrixD &m, TMatrixD &ym, TMatrixD &merrors) {
-  
   TMatrixD mt = m;
   mt.T();
   TMatrixD yt = ym;
   yt.T();
-  TMatrixD m_leftMatrix(mt*merrors*m);
-  TMatrixD m_rightMatrix(mt*merrors*ym);
+  TMatrixD m_leftMatrix(mt * merrors * m);
+  TMatrixD m_rightMatrix(mt * merrors * ym);
   leftMatrix.ResizeTo(m_leftMatrix.GetNrows(), m_leftMatrix.GetNcols());
   rightMatrix.ResizeTo(m_rightMatrix.GetNrows(), m_rightMatrix.GetNcols());
   covariance.ResizeTo(m_leftMatrix.GetNrows(), m_leftMatrix.GetNrows());
   rightMatrix = m_rightMatrix;
   leftMatrix = m_leftMatrix;
   covariance = m_leftMatrix.Invert();
-  TMatrixD m_solution(covariance*m_rightMatrix);
+  TMatrixD m_solution(covariance * m_rightMatrix);
   solution.ResizeTo(m_solution.GetNrows(), m_solution.GetNcols());
   solution = m_solution;
-  TMatrixD m_Chi2((yt-m_solution.T()*mt)*merrors*(ym-m*solution));
-  myChi2 = m_Chi2(0,0);
-  dof = ym.GetNrows()-solution.GetNrows();
-
-
+  TMatrixD m_Chi2((yt - m_solution.T() * mt) * merrors * (ym - m * solution));
+  myChi2 = m_Chi2(0, 0);
+  dof = ym.GetNrows() - solution.GetNrows();
 }
 
-Chi2::~Chi2(){}
+Chi2::~Chi2() {}
 
-TMatrixD & Chi2::getCovariance() {return covariance;}
-TMatrixD & Chi2::getSolution() {return solution;}
-double Chi2::getChi2() {return myChi2;}
-int Chi2::getDOF() {return dof;}
-
-  
+TMatrixD &Chi2::getCovariance() { return covariance; }
+TMatrixD &Chi2::getSolution() { return solution; }
+double Chi2::getChi2() { return myChi2; }
+int Chi2::getDOF() { return dof; }

--- a/Alignment/SurveyAnalysis/src/DTSurvey.cc
+++ b/Alignment/SurveyAnalysis/src/DTSurvey.cc
@@ -1,86 +1,95 @@
 #include <fstream>
 
 #include "Alignment/SurveyAnalysis/interface/DTSurveyChamber.h"
-#include "DataFormats/MuonDetId/interface/DTChamberId.h" 
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
-#include "Geometry/DTGeometry/interface/DTChamber.h" 
+#include "Geometry/DTGeometry/interface/DTChamber.h"
 
 #include "Alignment/SurveyAnalysis/interface/DTSurvey.h"
 #include <iostream>
 
-DTSurvey::DTSurvey(const std::string& Wheel, const std::string& Chambers, int n)
-  : chambers(nullptr) {
-  
+DTSurvey::DTSurvey(const std::string &Wheel, const std::string &Chambers, int n) : chambers(nullptr) {
   nameOfWheelInfoFile = Wheel;
   nameOfChamberInfoFile = Chambers;
-  id = n;   
-  
+  id = n;
+
   FillWheelInfo();
 }
 
-
-DTSurvey::~DTSurvey() {
-  delete [] chambers;
-}
-
+DTSurvey::~DTSurvey() { delete[] chambers; }
 
 void DTSurvey::CalculateChambers() {
-  for(int stationCounter = 0; stationCounter < 4; stationCounter++) {
-    for(int sectorCounter = 0; sectorCounter < 14; sectorCounter++) {
-      if(chambers[stationCounter][sectorCounter]->getNumberPoints() > 2) {
+  for (int stationCounter = 0; stationCounter < 4; stationCounter++) {
+    for (int sectorCounter = 0; sectorCounter < 14; sectorCounter++) {
+      if (chambers[stationCounter][sectorCounter]->getNumberPoints() > 2) {
         chambers[stationCounter][sectorCounter]->compute();
       }
     }
   }
 }
 
-
-const DTSurveyChamber * DTSurvey::getChamber(int station, int sector) const {return chambers[station][sector];}
+const DTSurveyChamber *DTSurvey::getChamber(int station, int sector) const { return chambers[station][sector]; }
 
 void DTSurvey::ReadChambers(edm::ESHandle<DTGeometry> pDD) {
-  
   //Create the chambers
-  chambers = new DTSurveyChamber ** [4];
+  chambers = new DTSurveyChamber **[4];
   for (int cont_stat = 0; cont_stat < 4; cont_stat++) {
-    chambers[cont_stat] = new DTSurveyChamber * [14];
-    for(int cont_sect = 0; cont_sect < 14; cont_sect++) {
-      DTChamberId mId(id, cont_stat+1, cont_sect+1);
-      chambers[cont_stat][cont_sect] = new DTSurveyChamber(id, cont_stat+1, cont_sect+1, mId.rawId());
+    chambers[cont_stat] = new DTSurveyChamber *[14];
+    for (int cont_sect = 0; cont_sect < 14; cont_sect++) {
+      DTChamberId mId(id, cont_stat + 1, cont_sect + 1);
+      chambers[cont_stat][cont_sect] = new DTSurveyChamber(id, cont_stat + 1, cont_sect + 1, mId.rawId());
     }
   }
 
   std::cout << nameOfChamberInfoFile << std::endl;
   std::ifstream file(nameOfChamberInfoFile.c_str());
-  while(!file.eof()) {
+  while (!file.eof()) {
     int code, station, sector;
     double x, y, z, rms, dx, dy, dz;
     file >> code >> x >> y >> z >> rms >> dx >> dy >> dz;
-    if(file.eof()) break;
-    x = x/10.0; y=y/10.0; z=z/10.0; dx=dx/10.0; dy=dy/10.0; dz=dz/10.0;rms=rms/10.0; 
-    station = code/10000 - 1;
-    sector = (code-(station+1)*10000)/100 - 1;
+    if (file.eof())
+      break;
+    x = x / 10.0;
+    y = y / 10.0;
+    z = z / 10.0;
+    dx = dx / 10.0;
+    dy = dy / 10.0;
+    dz = dz / 10.0;
+    rms = rms / 10.0;
+    station = code / 10000 - 1;
+    sector = (code - (station + 1) * 10000) / 100 - 1;
     //De momento vamos a actuar como si no hubiera otra forma de resolver esto
-    TMatrixD r(3,1);
-    r(0,0) = x; r(1,0) = y;r(2,0) = z+OffsetZ;
-    TMatrixD disp(3,1);
-    disp(0,0) = dx; disp(1,0) = dy; disp(2,0) = dz;
-    TMatrixD rp = Rot*r-delta;
-    disp = disp-r+rp;
-    
-    GlobalPoint rg(r(0,0), r(1,0), r(2,0));
-    GlobalPoint rt(r(0,0)-disp(0,0), r(1,0)-disp(1,0), r(2,0)-disp(2,0));
-    DTChamberId mId(id, station+1, sector+1);
+    TMatrixD r(3, 1);
+    r(0, 0) = x;
+    r(1, 0) = y;
+    r(2, 0) = z + OffsetZ;
+    TMatrixD disp(3, 1);
+    disp(0, 0) = dx;
+    disp(1, 0) = dy;
+    disp(2, 0) = dz;
+    TMatrixD rp = Rot * r - delta;
+    disp = disp - r + rp;
+
+    GlobalPoint rg(r(0, 0), r(1, 0), r(2, 0));
+    GlobalPoint rt(r(0, 0) - disp(0, 0), r(1, 0) - disp(1, 0), r(2, 0) - disp(2, 0));
+    DTChamberId mId(id, station + 1, sector + 1);
     const DTChamber *mChamber = static_cast<const DTChamber *>(pDD->idToDet(mId));
     LocalPoint rl = mChamber->toLocal(rg);
     LocalPoint rtl = mChamber->toLocal(rt);
-    TMatrixD rLocal(3,1);
-    rLocal(0,0) = rl.x(); rLocal(1,0) = rl.y(); rLocal(2,0) = rl.z();
-    TMatrixD rTeo(3,1);
-    rTeo(0,0) = rtl.x(); rTeo(1,0) = rtl.y(); rTeo(2,0) = rtl.z();
-    TMatrixD diff = rLocal-rTeo;
-    TMatrixD errors(3,1);
-    errors(0,0) = rms; errors(1,0) = rms; errors(2,0) = rms;
+    TMatrixD rLocal(3, 1);
+    rLocal(0, 0) = rl.x();
+    rLocal(1, 0) = rl.y();
+    rLocal(2, 0) = rl.z();
+    TMatrixD rTeo(3, 1);
+    rTeo(0, 0) = rtl.x();
+    rTeo(1, 0) = rtl.y();
+    rTeo(2, 0) = rtl.z();
+    TMatrixD diff = rLocal - rTeo;
+    TMatrixD errors(3, 1);
+    errors(0, 0) = rms;
+    errors(1, 0) = rms;
+    errors(2, 0) = rms;
     chambers[station][sector]->addPoint(code, rLocal, diff, errors);
   }
   file.close();
@@ -109,57 +118,54 @@ void DTSurvey::ToDB(MuonAlignment *myMuonAlignment) {
 */
 
 void DTSurvey::FillWheelInfo() {
-
   std::ifstream wheeltowheel(nameOfWheelInfoFile.c_str());
   float zOffset, deltax, deltay, deltaz, alpha, beta, gamma;
   wheeltowheel >> zOffset >> deltax >> deltay >> deltaz >> alpha >> beta >> gamma;
   wheeltowheel.close();
-  
+
   OffsetZ = zOffset;
 
   //Build displacement vector
-  delta.ResizeTo(3,1);
-  delta(0,0) = deltax/10.0;
-  delta(1,0) = deltay/10.0;
-  delta(2,0) = deltaz/10.0;
-  
+  delta.ResizeTo(3, 1);
+  delta(0, 0) = deltax / 10.0;
+  delta(1, 0) = deltay / 10.0;
+  delta(2, 0) = deltaz / 10.0;
+
   //Build rotation matrix
-  Rot.ResizeTo(3,3);
-  TMatrixD alpha_m(3,3);
-  TMatrixD beta_m(3,3);
-  TMatrixD gamma_m(3,3);
+  Rot.ResizeTo(3, 3);
+  TMatrixD alpha_m(3, 3);
+  TMatrixD beta_m(3, 3);
+  TMatrixD gamma_m(3, 3);
   alpha_m.Zero();
   beta_m.Zero();
   gamma_m.Zero();
-  for(int k = 0; k < 3; k++) {
-    alpha_m(k,k) = 1.0;
-    beta_m(k,k) = 1.0;
-    gamma_m(k,k) = 1.0;
+  for (int k = 0; k < 3; k++) {
+    alpha_m(k, k) = 1.0;
+    beta_m(k, k) = 1.0;
+    gamma_m(k, k) = 1.0;
   }
-  alpha /= 1000.0; //New scale: angles in radians
+  alpha /= 1000.0;  //New scale: angles in radians
   beta /= 1000.0;
   gamma /= 1000.0;
-  alpha_m(1,1) = cos(alpha);
-  alpha_m(1,2) = sin(alpha);
-  alpha_m(2,1) = -sin(alpha);
-  alpha_m(2,2) = cos(alpha);
-  beta_m(0,0) = cos(beta);
-  beta_m(0,2) = -sin(beta);
-  beta_m(2,0) = sin(beta);
-  beta_m(2,2) = cos(beta);
-  gamma_m(0,0) = cos(gamma);
-  gamma_m(0,1) = sin(gamma);
-  gamma_m(1,0) = -sin(gamma);
-  gamma_m(1,1) = cos(gamma);
-  Rot = alpha_m*beta_m*gamma_m;
+  alpha_m(1, 1) = cos(alpha);
+  alpha_m(1, 2) = sin(alpha);
+  alpha_m(2, 1) = -sin(alpha);
+  alpha_m(2, 2) = cos(alpha);
+  beta_m(0, 0) = cos(beta);
+  beta_m(0, 2) = -sin(beta);
+  beta_m(2, 0) = sin(beta);
+  beta_m(2, 2) = cos(beta);
+  gamma_m(0, 0) = cos(gamma);
+  gamma_m(0, 1) = sin(gamma);
+  gamma_m(1, 0) = -sin(gamma);
+  gamma_m(1, 1) = cos(gamma);
+  Rot = alpha_m * beta_m * gamma_m;
 }
 
-
-std::ostream &operator<<(std::ostream & flux, const DTSurvey& obj) {
-
-  for(int stationCounter = 0; stationCounter < 4; stationCounter++) {
-    for(int sectorCounter = 0; sectorCounter < 14; sectorCounter++) {
-      if(obj.getChamber(stationCounter,sectorCounter)->getNumberPoints() > 2) {
+std::ostream &operator<<(std::ostream &flux, const DTSurvey &obj) {
+  for (int stationCounter = 0; stationCounter < 4; stationCounter++) {
+    for (int sectorCounter = 0; sectorCounter < 14; sectorCounter++) {
+      if (obj.getChamber(stationCounter, sectorCounter)->getNumberPoints() > 2) {
         const DTSurveyChamber *m_chamber = obj.getChamber(stationCounter, sectorCounter);
         flux << *m_chamber;
       }

--- a/Alignment/SurveyAnalysis/src/DTSurveyChamber.cc
+++ b/Alignment/SurveyAnalysis/src/DTSurveyChamber.cc
@@ -1,113 +1,89 @@
 #include <iostream>
 
 #include "Alignment/SurveyAnalysis/interface/DTSurveyChamber.h"
-#include "Alignment/SurveyAnalysis/interface/Chi2.h" 
-
+#include "Alignment/SurveyAnalysis/interface/Chi2.h"
 
 DTSurveyChamber::DTSurveyChamber(int m_wheel, int m_station, int m_sector, long m_rawId) {
-  
   //Coordinates of the chamber
   wheel = m_wheel;
   station = m_station;
   sector = m_sector;
   pointNumber = 0;
-  rawId = m_rawId;  
-   
+  rawId = m_rawId;
 }
 
-
 void DTSurveyChamber::compute() {
-  
   TMatrixD leftMatrix = makeMatrix();
   TMatrixD rightMatrix = makeVector();
   TMatrixD errors = makeErrors();
-  
-  Chi2 myChi2(leftMatrix, rightMatrix, errors);
-  
-  Solution.ResizeTo(6,1);
-  Solution = myChi2.getSolution();
-  Covariance.ResizeTo(6,6);
-  Covariance = myChi2.getCovariance();
 
+  Chi2 myChi2(leftMatrix, rightMatrix, errors);
+
+  Solution.ResizeTo(6, 1);
+  Solution = myChi2.getSolution();
+  Covariance.ResizeTo(6, 6);
+  Covariance = myChi2.getCovariance();
 }
 
-
-void DTSurveyChamber::addPoint(int code, const TMatrixD& r, const TMatrixD& disp, const TMatrixD& err) {
-  
-  
+void DTSurveyChamber::addPoint(int code, const TMatrixD &r, const TMatrixD &disp, const TMatrixD &err) {
   ++pointNumber;
 
   points.push_back(r);
   pointsDiff.push_back(disp);
   pointsError.push_back(err);
-  pointsTheoretical.push_back(r-disp);
-
+  pointsTheoretical.push_back(r - disp);
 }
-  
 
-
-TMatrixD & DTSurveyChamber::makeVector() {
-
-  TMatrixD *result = new TMatrixD(3*getNumberPoints(),1);
+TMatrixD &DTSurveyChamber::makeVector() {
+  TMatrixD *result = new TMatrixD(3 * getNumberPoints(), 1);
   result->Zero();
   int real = 0;
-  for(std::vector<TMatrixD >::iterator p = pointsDiff.begin(); p != pointsDiff.end(); ++p) {  
-    (*result)(real*3,0) = (*p)(0,0);
-    (*result)(real*3+1,0) = (*p)(1,0);
-    (*result)(real*3+2,0) = (*p)(2,0);
+  for (std::vector<TMatrixD>::iterator p = pointsDiff.begin(); p != pointsDiff.end(); ++p) {
+    (*result)(real * 3, 0) = (*p)(0, 0);
+    (*result)(real * 3 + 1, 0) = (*p)(1, 0);
+    (*result)(real * 3 + 2, 0) = (*p)(2, 0);
     ++real;
   }
   return *result;
 }
 
-
-
-TMatrixD & DTSurveyChamber::makeErrors() {
-  
-  TMatrixD *result = new TMatrixD(3*getNumberPoints(),3*getNumberPoints());
+TMatrixD &DTSurveyChamber::makeErrors() {
+  TMatrixD *result = new TMatrixD(3 * getNumberPoints(), 3 * getNumberPoints());
   result->Zero();
   int real = 0;
-  for(std::vector<TMatrixD >::iterator p = pointsError.begin(); p != pointsError.end(); ++p) {
-    double rmsn = 1.0/((*p)(0,0)*(*p)(0,0));
-    (*result)(real*3,real*3) = rmsn;
-    (*result)(real*3+1,real*3+1) = rmsn;
-    (*result)(real*3+2,real*3+2) = rmsn;
+  for (std::vector<TMatrixD>::iterator p = pointsError.begin(); p != pointsError.end(); ++p) {
+    double rmsn = 1.0 / ((*p)(0, 0) * (*p)(0, 0));
+    (*result)(real * 3, real * 3) = rmsn;
+    (*result)(real * 3 + 1, real * 3 + 1) = rmsn;
+    (*result)(real * 3 + 2, real * 3 + 2) = rmsn;
     real++;
   }
   return *result;
 }
 
-
-TMatrixD & DTSurveyChamber::makeMatrix() {
-
-  TMatrixD *result = new TMatrixD(3*getNumberPoints(), 6);
+TMatrixD &DTSurveyChamber::makeMatrix() {
+  TMatrixD *result = new TMatrixD(3 * getNumberPoints(), 6);
   result->Zero();
   int real = 0;
-  for(std::vector<TMatrixD >::iterator p = pointsTheoretical.begin(); p != pointsTheoretical.end(); p++) {
-    (*result)(real*3,0)= 1.0;
-    (*result)(real*3,3) = (*p)(1,0);
-    (*result)(real*3,4) = (*p)(2,0);
-    (*result)(real*3+1,1) = 1.0;
-    (*result)(real*3+1,3) = -(*p)(0,0);
-    (*result)(real*3+1,5) = (*p)(2,0);
-    (*result)(real*3+2,2) = 1.0;
-    (*result)(real*3+2,4) = -(*p)(0,0);
-    (*result)(real*3+2,5) = -(*p)(1,0);
+  for (std::vector<TMatrixD>::iterator p = pointsTheoretical.begin(); p != pointsTheoretical.end(); p++) {
+    (*result)(real * 3, 0) = 1.0;
+    (*result)(real * 3, 3) = (*p)(1, 0);
+    (*result)(real * 3, 4) = (*p)(2, 0);
+    (*result)(real * 3 + 1, 1) = 1.0;
+    (*result)(real * 3 + 1, 3) = -(*p)(0, 0);
+    (*result)(real * 3 + 1, 5) = (*p)(2, 0);
+    (*result)(real * 3 + 2, 2) = 1.0;
+    (*result)(real * 3 + 2, 4) = -(*p)(0, 0);
+    (*result)(real * 3 + 2, 5) = -(*p)(1, 0);
     real++;
   }
   return *result;
 }
 
-
-std::ostream &operator<<(std::ostream &flujo, const DTSurveyChamber& obj) {
-
-  flujo << obj.getId() << " "
-        << obj.getDeltaX() << " " << obj.getDeltaXError() << " "
-        << obj.getDeltaY() << " " << obj.getDeltaYError() << " "
-        << obj.getDeltaZ() << " " << obj.getDeltaZError() << " "
-        << obj.getAlpha() << " " << obj.getAlphaError() << " "
-        << obj.getBeta() << " " << obj.getBetaError() << " "
-        << obj.getGamma() << " " << obj.getGammaError() << std::endl;
+std::ostream &operator<<(std::ostream &flujo, const DTSurveyChamber &obj) {
+  flujo << obj.getId() << " " << obj.getDeltaX() << " " << obj.getDeltaXError() << " " << obj.getDeltaY() << " "
+        << obj.getDeltaYError() << " " << obj.getDeltaZ() << " " << obj.getDeltaZError() << " " << obj.getAlpha() << " "
+        << obj.getAlphaError() << " " << obj.getBeta() << " " << obj.getBetaError() << " " << obj.getGamma() << " "
+        << obj.getGammaError() << std::endl;
   return flujo;
-
 }

--- a/Alignment/SurveyAnalysis/src/SurveyAlignment.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyAlignment.cc
@@ -6,65 +6,56 @@
 
 using namespace align;
 
-SurveyAlignment::SurveyAlignment(const Alignables& sensors,
-				 const std::vector<StructureType>& levels):
-  theSensors(sensors),
-  theLevels(levels)
-{
-}
+SurveyAlignment::SurveyAlignment(const Alignables& sensors, const std::vector<StructureType>& levels)
+    : theSensors(sensors), theLevels(levels) {}
 
-void SurveyAlignment::shiftSensors()
-{
+void SurveyAlignment::shiftSensors() {
   unsigned int nSensor = theSensors.size();
 
-  for (unsigned int i = 0; i < nSensor; ++i)
-  {
+  for (unsigned int i = 0; i < nSensor; ++i) {
     Alignable* ali = theSensors[i];
 
     const AlignableSurface& surf = ali->surface();
-    const AlgebraicVector&  pars = ali->alignmentParameters()->parameters();
+    const AlgebraicVector& pars = ali->alignmentParameters()->parameters();
 
     EulerAngles angles(3);
 
-    angles(1) = pars[3]; angles(2) = pars[4]; angles(3) = pars[5];
+    angles(1) = pars[3];
+    angles(2) = pars[4];
+    angles(3) = pars[5];
 
-    RotationType rot = surf.toGlobal( toMatrix(angles) );
+    RotationType rot = surf.toGlobal(toMatrix(angles));
 
-    rectify(rot); // correct for rounding errors
+    rectify(rot);  // correct for rounding errors
 
-    ali->move( surf.toGlobal( align::LocalVector(pars[0], pars[1], pars[2]) ) );
+    ali->move(surf.toGlobal(align::LocalVector(pars[0], pars[1], pars[2])));
     ali->rotateInGlobalFrame(rot);
   }
 }
 
-void SurveyAlignment::iterate(unsigned int nIteration,
-			      const std::string& fileName,
-			      bool bias)
-{
-  static const double tolerance = 1e-4; // convergence criteria
+void SurveyAlignment::iterate(unsigned int nIteration, const std::string& fileName, bool bias) {
+  static const double tolerance = 1e-4;  // convergence criteria
 
   SurveyOutput out(theSensors, fileName);
 
   out.write(0);
 
-  for (unsigned int i = 1; i <= nIteration; ++i)
-  {
+  for (unsigned int i = 1; i <= nIteration; ++i) {
     std::cout << "***** Iteration " << i << " *****\n";
     findAlignPars(bias);
     shiftSensors();
     out.write(i);
 
-  // Check convergence
+    // Check convergence
 
     double parChi2 = 0.;
 
     unsigned int nSensor = theSensors.size();
 
-    for (unsigned int j = 0; j < nSensor; ++j)
-    {
+    for (unsigned int j = 0; j < nSensor; ++j) {
       AlignmentParameters* alignPar = theSensors[j]->alignmentParameters();
 
-      const AlgebraicVector&    par = alignPar->parameters();
+      const AlgebraicVector& par = alignPar->parameters();
       const AlgebraicSymMatrix& cov = alignPar->covariance();
 
       int dummy;
@@ -74,6 +65,7 @@ void SurveyAlignment::iterate(unsigned int nIteration,
 
     parChi2 /= static_cast<double>(nSensor);
     std::cout << "chi2 = " << parChi2 << std::endl;
-    if (parChi2 < tolerance) break; // converges, so exit loop
+    if (parChi2 < tolerance)
+      break;  // converges, so exit loop
   }
 }

--- a/Alignment/SurveyAnalysis/src/SurveyAlignmentPoints.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyAlignmentPoints.cc
@@ -6,51 +6,48 @@
 #include "Alignment/SurveyAnalysis/interface/SurveyAlignmentPoints.h"
 
 SurveyAlignmentPoints::SurveyAlignmentPoints(const align::Alignables& sensors,
-					     const std::vector<align::StructureType>& levels):
-  SurveyAlignment(sensors, levels)
-{
-}
+                                             const std::vector<align::StructureType>& levels)
+    : SurveyAlignment(sensors, levels) {}
 
-void SurveyAlignmentPoints::findAlignPars(bool bias)
-{
+void SurveyAlignmentPoints::findAlignPars(bool bias) {
   unsigned int nSensor = theSensors.size();
 
-  for (unsigned int i = 0; i < nSensor; ++i)
-  {
+  for (unsigned int i = 0; i < nSensor; ++i) {
     Alignable* ali = theSensors[i];
 
-    AlgebraicSymMatrix sumJVJT(6, 0); // 6 by 6 symmetric matrix init to 0
-    AlgebraicVector    sumJVe(6, 0);  // init to 0
+    AlgebraicSymMatrix sumJVJT(6, 0);  // 6 by 6 symmetric matrix init to 0
+    AlgebraicVector sumJVe(6, 0);      // init to 0
 
-    for (unsigned int l = 0; l < theLevels.size(); ++l)
-    {
+    for (unsigned int l = 0; l < theLevels.size(); ++l) {
       SurveyResidual res(*ali, theLevels[l], bias);
 
-      if ( !res.valid() ) continue;
+      if (!res.valid())
+        continue;
 
       align::LocalVectors residuals = res.pointsResidual();
 
       unsigned int nPoints = residuals.size();
 
-      for (unsigned int j = 0; j < nPoints; ++j)
-      {
-	AlgebraicMatrix J = ali->survey()->derivatives(j);
-	AlgebraicSymMatrix V(3, 1); // identity for now
-	AlgebraicVector e(3); // local residual
+      for (unsigned int j = 0; j < nPoints; ++j) {
+        AlgebraicMatrix J = ali->survey()->derivatives(j);
+        AlgebraicSymMatrix V(3, 1);  // identity for now
+        AlgebraicVector e(3);        // local residual
 
-	const align::LocalVector& lr = residuals[j];
+        const align::LocalVector& lr = residuals[j];
 
-	e(1) = lr.x(); e(2) = lr.y(); e(3) = lr.z();
-	V /= 1e-4 * 1e-4;
-	sumJVe  += J * (V * e);
-	sumJVJT += V.similarity(J);
+        e(1) = lr.x();
+        e(2) = lr.y();
+        e(3) = lr.z();
+        V /= 1e-4 * 1e-4;
+        sumJVe += J * (V * e);
+        sumJVJT += V.similarity(J);
       }
     }
 
     int dummy;
-    sumJVJT.invert(dummy); // sumJVJT = sumJVJT^-1
+    sumJVJT.invert(dummy);  // sumJVJT = sumJVJT^-1
     sumJVe = -sumJVJT * sumJVe;
 
-    ali->setAlignmentParameters( new SurveyParameters(ali, sumJVe, sumJVJT) );
+    ali->setAlignmentParameters(new SurveyParameters(ali, sumJVe, sumJVJT));
   }
 }

--- a/Alignment/SurveyAnalysis/src/SurveyAlignmentSensor.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyAlignmentSensor.cc
@@ -5,27 +5,23 @@
 #include "Alignment/SurveyAnalysis/interface/SurveyAlignmentSensor.h"
 
 SurveyAlignmentSensor::SurveyAlignmentSensor(const align::Alignables& sensors,
-					     const std::vector<align::StructureType>& levels):
-  SurveyAlignment(sensors, levels)
-{
-}
+                                             const std::vector<align::StructureType>& levels)
+    : SurveyAlignment(sensors, levels) {}
 
-void SurveyAlignmentSensor::findAlignPars(bool bias)
-{
+void SurveyAlignmentSensor::findAlignPars(bool bias) {
   unsigned int nSensor = theSensors.size();
 
-  for (unsigned int i = 0; i < nSensor; ++i)
-  {
+  for (unsigned int i = 0; i < nSensor; ++i) {
     Alignable* ali = theSensors[i];
 
     AlgebraicVector par(6, 0);
     AlgebraicSymMatrix cov(6, 0);
 
-    for (unsigned int l = 0; l < theLevels.size(); ++l)
-    {
+    for (unsigned int l = 0; l < theLevels.size(); ++l) {
       SurveyResidual res(*ali, theLevels[l], bias);
 
-      if ( !res.valid() ) continue;
+      if (!res.valid())
+        continue;
 
       AlgebraicSymMatrix invCov = res.inverseCovariance();
 
@@ -34,9 +30,9 @@ void SurveyAlignmentSensor::findAlignPars(bool bias)
     }
 
     int dummy;
-    cov.invert(dummy); // cov = cov^-1
+    cov.invert(dummy);  // cov = cov^-1
     par = -cov * par;
 
-    ali->setAlignmentParameters( new SurveyParameters(ali, par, cov) );
+    ali->setAlignmentParameters(new SurveyParameters(ali, par, cov));
   }
 }

--- a/Alignment/SurveyAnalysis/src/SurveyDataReader.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyDataReader.cc
@@ -14,109 +14,102 @@ using namespace std;
 using namespace edm;
 
 //__________________________________________________________________________________________________
-void SurveyDataReader::readFile( const std::string& textFileName, const std::string& fileType, const TrackerTopology* tTopo) {
-  
-  std::ifstream myfile( textFileName.c_str() );
-  if ( !myfile.is_open() ) 
+void SurveyDataReader::readFile(const std::string& textFileName,
+                                const std::string& fileType,
+                                const TrackerTopology* tTopo) {
+  std::ifstream myfile(textFileName.c_str());
+  if (!myfile.is_open())
     throw cms::Exception("FileAccess") << "Unable to open input text file for " << fileType.c_str();
 
   int nErrors = 0;
   align::ID m_detId = 0;
   int NINPUTS_align = 30;
   int NINPUTS_detId = 6;
-  if (fileType == "TID") NINPUTS_detId++;
+  if (fileType == "TID")
+    NINPUTS_detId++;
 
   std::vector<int> d_inputs;
   align::Scalars a_inputs;
   align::Scalars a_outputs;
   int itmpInput;
-  float tmpInput; 
+  float tmpInput;
 
-  while ( !myfile.eof() && myfile.good() )
-	{
-	  d_inputs.clear();
-          a_inputs.clear();
-          a_outputs.clear();
+  while (!myfile.eof() && myfile.good()) {
+    d_inputs.clear();
+    a_inputs.clear();
+    a_outputs.clear();
 
-          if (fileType == "TIB") {
-	    itmpInput = int(StripSubdetector::TIB) ; 
-	  } else {
-	    itmpInput = int(StripSubdetector::TID) ;
-	  }
+    if (fileType == "TIB") {
+      itmpInput = int(StripSubdetector::TIB);
+    } else {
+      itmpInput = int(StripSubdetector::TID);
+    }
 
-          d_inputs.push_back( itmpInput );
+    d_inputs.push_back(itmpInput);
 
-	  for ( int i=0; i<NINPUTS_detId; i++ )
-		{
-		  myfile >> itmpInput;
-		  d_inputs.push_back( itmpInput );
-		}
-            
-          // Calculate DetId(s)
-          int ster = 0;  // if module is single-sided, take the module
-                         // if double-sided get the glued module
+    for (int i = 0; i < NINPUTS_detId; i++) {
+      myfile >> itmpInput;
+      d_inputs.push_back(itmpInput);
+    }
 
-	  if (fileType == "TID") {
-	    
-	    m_detId = tTopo->tidDetId(d_inputs[2], d_inputs[3], d_inputs[4], d_inputs[5], d_inputs[6], ster);
-	  }
-	  else if (fileType == "TIB") {
-	     
-	    m_detId = tTopo->tibDetId(d_inputs[2], d_inputs[3], d_inputs[4], d_inputs[5], d_inputs[6], ster);
-	  }
+    // Calculate DetId(s)
+    int ster = 0;  // if module is single-sided, take the module
+                   // if double-sided get the glued module
 
-          if (abs(int(m_detId) - int(d_inputs[1])) > 2) {  // Check DetId calculation ...
-            std::cout << "ERROR : DetId - detector position mismatch! Found " << nErrors << std::endl;
-            nErrors++;
-	  }
+    if (fileType == "TID") {
+      m_detId = tTopo->tidDetId(d_inputs[2], d_inputs[3], d_inputs[4], d_inputs[5], d_inputs[6], ster);
+    } else if (fileType == "TIB") {
+      m_detId = tTopo->tibDetId(d_inputs[2], d_inputs[3], d_inputs[4], d_inputs[5], d_inputs[6], ster);
+    }
 
-          // std::cout << m_detId << " " << d_inputs[1] << std::endl;
-	  // m_detId = d_inputs[1];
-	  for ( int j=0; j<NINPUTS_align; j++ )
-		{
-		  myfile >> tmpInput;
-		  a_inputs.push_back( tmpInput );
-		}
+    if (abs(int(m_detId) - int(d_inputs[1])) > 2) {  // Check DetId calculation ...
+      std::cout << "ERROR : DetId - detector position mismatch! Found " << nErrors << std::endl;
+      nErrors++;
+    }
 
-	  // Check if read succeeded (otherwise, we are at eof)
-	  if ( myfile.fail() ) break;
+    // std::cout << m_detId << " " << d_inputs[1] << std::endl;
+    // m_detId = d_inputs[1];
+    for (int j = 0; j < NINPUTS_align; j++) {
+      myfile >> tmpInput;
+      a_inputs.push_back(tmpInput);
+    }
 
-          a_outputs = convertToAlignableCoord( a_inputs );
+    // Check if read succeeded (otherwise, we are at eof)
+    if (myfile.fail())
+      break;
 
-	  theOriginalMap.insert( PairTypeOr( d_inputs, a_inputs ));
-	  theMap.insert( PairType( m_detId, a_outputs ));
-	 
-	}
+    a_outputs = convertToAlignableCoord(a_inputs);
 
+    theOriginalMap.insert(PairTypeOr(d_inputs, a_inputs));
+    theMap.insert(PairType(m_detId, a_outputs));
+  }
 }
 //__________________________________________________________________________________________________
-align::Scalars 
-SurveyDataReader::convertToAlignableCoord( const align::Scalars& align_params ) 
-{
-      align::Scalars align_outputs;
+align::Scalars SurveyDataReader::convertToAlignableCoord(const align::Scalars& align_params) {
+  align::Scalars align_outputs;
 
-      // Convert to coordinates that TrackerAlignment can read in
-     
-      // Center of sensor 
-      AlgebraicVector geomCent(3);
-      AlgebraicVector surCent(3);
-      for (int ii = 0; ii < 3; ii++) {
-	geomCent[ii] = align_params[ii];
-	surCent[ii] = align_params[ii+15];
-      }
-      surCent -= geomCent;
-                 
-      align_outputs.push_back( surCent[0] ); 
-      align_outputs.push_back( surCent[1] );   
-      align_outputs.push_back( surCent[2] );   
-      
-      // Rotation matrices
-      for (int ii = 3; ii < 12; ii++) { 
-	  align_outputs.push_back( align_params[ii] );
-      }
-      for (int ii = 18; ii < 27; ii++) { 
-	  align_outputs.push_back( align_params[ii] );
-      } 
-           
-      return align_outputs; 
+  // Convert to coordinates that TrackerAlignment can read in
+
+  // Center of sensor
+  AlgebraicVector geomCent(3);
+  AlgebraicVector surCent(3);
+  for (int ii = 0; ii < 3; ii++) {
+    geomCent[ii] = align_params[ii];
+    surCent[ii] = align_params[ii + 15];
+  }
+  surCent -= geomCent;
+
+  align_outputs.push_back(surCent[0]);
+  align_outputs.push_back(surCent[1]);
+  align_outputs.push_back(surCent[2]);
+
+  // Rotation matrices
+  for (int ii = 3; ii < 12; ii++) {
+    align_outputs.push_back(align_params[ii]);
+  }
+  for (int ii = 18; ii < 27; ii++) {
+    align_outputs.push_back(align_params[ii]);
+  }
+
+  return align_outputs;
 }

--- a/Alignment/SurveyAnalysis/src/SurveyInputBase.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyInputBase.cc
@@ -4,15 +4,13 @@
 
 Alignable* SurveyInputBase::theDetector(nullptr);
 
-SurveyInputBase::~SurveyInputBase()
-{
+SurveyInputBase::~SurveyInputBase() {
   delete theDetector;
 
   theDetector = nullptr;
 }
 
-void SurveyInputBase::addComponent(Alignable* comp)
-{
+void SurveyInputBase::addComponent(Alignable* comp) {
   if (nullptr == theDetector)
     theDetector = comp;
   else

--- a/Alignment/SurveyAnalysis/src/SurveyInputTextReader.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyInputTextReader.cc
@@ -8,54 +8,47 @@
 #include "Alignment/SurveyAnalysis/interface/SurveyInputTextReader.h"
 
 //__________________________________________________________________________________________________
-void SurveyInputTextReader::readFile( const std::string& textFileName )
-{
-
-  std::ifstream myfile( textFileName.c_str() );
-  if ( !myfile.is_open() )
-        throw cms::Exception("FileAccess") << "Unable to open input text file";
+void SurveyInputTextReader::readFile(const std::string& textFileName) {
+  std::ifstream myfile(textFileName.c_str());
+  if (!myfile.is_open())
+    throw cms::Exception("FileAccess") << "Unable to open input text file";
 
   // FIXME: - currently defaulting to RunI as this was the previous behaviour
   //        - check this, when resurrecting this code in the future
   AlignableObjectId alignableObjectId{AlignableObjectId::Geometry::General};
 
-  while ( !myfile.eof() && myfile.good() )
-    {
-      align::Scalars m_inputs;
-		
-      UniqueId  m_uId;
-      char firstchar;
-      firstchar = myfile.peek();
+  while (!myfile.eof() && myfile.good()) {
+    align::Scalars m_inputs;
 
-      if(firstchar == '#'){
-	std::string line;
-	getline(myfile,line);
-      }
-      else if (firstchar == '!'){
-	std::string firststring;
-	std::string structure; 
-	myfile >> firststring >> structure;
-	std::string endofline;
-	getline(myfile,endofline);
-	m_uId.second = alignableObjectId.stringToId(structure.c_str());
-      }
-      else{
-	myfile >> m_uId.first;
+    UniqueId m_uId;
+    char firstchar;
+    firstchar = myfile.peek();
 
-	for ( int i=0; i<NINPUTS; i++ )
-	  {
-	    float tmpInput;
-	    myfile >> tmpInput;
-	    m_inputs.push_back( tmpInput );
-	  }
-	std::string endofline;
-	getline(myfile,endofline);
-	theMap.insert( PairType( m_uId, m_inputs));			
-			
-	// Check if read succeeded (otherwise, we are at eof)
-	if ( myfile.fail() ) break;
-			
+    if (firstchar == '#') {
+      std::string line;
+      getline(myfile, line);
+    } else if (firstchar == '!') {
+      std::string firststring;
+      std::string structure;
+      myfile >> firststring >> structure;
+      std::string endofline;
+      getline(myfile, endofline);
+      m_uId.second = alignableObjectId.stringToId(structure.c_str());
+    } else {
+      myfile >> m_uId.first;
 
+      for (int i = 0; i < NINPUTS; i++) {
+        float tmpInput;
+        myfile >> tmpInput;
+        m_inputs.push_back(tmpInput);
       }
+      std::string endofline;
+      getline(myfile, endofline);
+      theMap.insert(PairType(m_uId, m_inputs));
+
+      // Check if read succeeded (otherwise, we are at eof)
+      if (myfile.fail())
+        break;
     }
+  }
 }

--- a/Alignment/SurveyAnalysis/src/SurveyOutput.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyOutput.cc
@@ -7,15 +7,10 @@
 
 #include "Alignment/SurveyAnalysis/interface/SurveyOutput.h"
 
-SurveyOutput::SurveyOutput(const align::Alignables& alignables,
-			   const std::string& fileName):
-  theAlignables(alignables),
-  theFile(fileName.c_str(), "RECREATE")
-{
-}
+SurveyOutput::SurveyOutput(const align::Alignables& alignables, const std::string& fileName)
+    : theAlignables(alignables), theFile(fileName.c_str(), "RECREATE") {}
 
-void SurveyOutput::write(unsigned int iter)
-{
+void SurveyOutput::write(unsigned int iter) {
   std::ostringstream o;
 
   o << 't' << iter;
@@ -24,19 +19,17 @@ void SurveyOutput::write(unsigned int iter)
 
   unsigned int N = theAlignables.size();
 
-  for (unsigned int i = 0; i < N; ++i)
-  {
+  for (unsigned int i = 0; i < N; ++i) {
     const Alignable* ali = theAlignables[i];
 
-    align::GlobalVector shifts = ali->displacement() * 1e4; // cm to um
+    align::GlobalVector shifts = ali->displacement() * 1e4;  // cm to um
 
-    align::EulerAngles angles = align::toAngles( ali->rotation() ) * 1e3; // to mrad
+    align::EulerAngles angles = align::toAngles(ali->rotation()) * 1e3;  // to mrad
 
-    nt->Fill( shifts.x(), shifts.y(), shifts.z(),
-	      angles(1), angles(2), angles(3) );
-//     const AlgebraicVector& pars = ali->alignmentParameters()->parameters();
+    nt->Fill(shifts.x(), shifts.y(), shifts.z(), angles(1), angles(2), angles(3));
+    //     const AlgebraicVector& pars = ali->alignmentParameters()->parameters();
 
-//     nt->Fill(pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
+    //     nt->Fill(pars[0], pars[1], pars[2], pars[3], pars[4], pars[5]);
   }
 
   theFile.Write();

--- a/Alignment/SurveyAnalysis/src/SurveyParameters.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyParameters.cc
@@ -2,55 +2,35 @@
 #include "Alignment/CommonAlignmentParametrization/interface/AlignmentParametersFactory.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-SurveyParameters::SurveyParameters(Alignable* object,
-				   const AlgebraicVector& par,
-				   const AlgebraicSymMatrix& cov):
-  AlignmentParameters(object, par, cov)
-{
+SurveyParameters::SurveyParameters(Alignable* object, const AlgebraicVector& par, const AlgebraicSymMatrix& cov)
+    : AlignmentParameters(object, par, cov) {}
+
+void SurveyParameters::apply() {
+  throw cms::Exception("BadInheritance") << "SurveyParameters::apply(): Not implemented.";
 }
 
-void SurveyParameters::apply()
-{
-  throw cms::Exception("BadInheritance") 
-      << "SurveyParameters::apply(): Not implemented.";
-}
+int SurveyParameters::type() const { return AlignmentParametersFactory::kSurvey; }
 
-int SurveyParameters::type() const
-{
-  return AlignmentParametersFactory::kSurvey;
-}
-
-AlignmentParameters* SurveyParameters::clone(const AlgebraicVector&,
-					     const AlgebraicSymMatrix&) const
-{
-  throw cms::Exception("BadInheritance") 
-      << "SurveyParameters::clone(): Not implemented.";
+AlignmentParameters* SurveyParameters::clone(const AlgebraicVector&, const AlgebraicSymMatrix&) const {
+  throw cms::Exception("BadInheritance") << "SurveyParameters::clone(): Not implemented.";
   return nullptr;
 }
 
-AlignmentParameters* SurveyParameters::cloneFromSelected(const AlgebraicVector&,
-							 const AlgebraicSymMatrix&) const
-{
-  throw cms::Exception("BadInheritance") 
-      << "SurveyParameters::cloneFromSelected(): Not implemented.";
+AlignmentParameters* SurveyParameters::cloneFromSelected(const AlgebraicVector&, const AlgebraicSymMatrix&) const {
+  throw cms::Exception("BadInheritance") << "SurveyParameters::cloneFromSelected(): Not implemented.";
 
   return nullptr;
 }
 
-AlgebraicMatrix SurveyParameters::derivatives(const TrajectoryStateOnSurface&,
-					      const AlignableDetOrUnitPtr& ) const
-{
-  throw cms::Exception("BadInheritance") 
-      << "SurveyParameters::derivatives(): Not implemented.";
+AlgebraicMatrix SurveyParameters::derivatives(const TrajectoryStateOnSurface&, const AlignableDetOrUnitPtr&) const {
+  throw cms::Exception("BadInheritance") << "SurveyParameters::derivatives(): Not implemented.";
 
   return AlgebraicMatrix();
 }
 
 AlgebraicMatrix SurveyParameters::selectedDerivatives(const TrajectoryStateOnSurface&,
-						      const AlignableDetOrUnitPtr& ) const
-{
-  throw cms::Exception("BadInheritance") 
-      << "SurveyParameters::selectedDerivatives(): Not implemented.";
+                                                      const AlignableDetOrUnitPtr&) const {
+  throw cms::Exception("BadInheritance") << "SurveyParameters::selectedDerivatives(): Not implemented.";
 
   return AlgebraicMatrix();
 }

--- a/Alignment/SurveyAnalysis/src/SurveyPxbDicer.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyPxbDicer.cc
@@ -18,73 +18,67 @@
 
 #include <iostream>
 
-SurveyPxbDicer::SurveyPxbDicer(const std::vector<edm::ParameterSet>& pars, unsigned int seed)
-{
-	CLHEP::HepRandom::setTheSeed( seed );
-	mean_a0 = getParByName("a0", "mean", pars);
-	sigma_a0 = getParByName("a0", "sigma", pars);
-	mean_a1 = getParByName("a1", "mean", pars);
-	sigma_a1 = getParByName("a1", "sigma", pars);
-	mean_scale = getParByName("scale", "mean", pars);
-	sigma_scale = getParByName("scale", "sigma", pars);
-	mean_phi = getParByName("phi", "mean", pars);
-	sigma_phi = getParByName("phi", "sigma", pars);
-	mean_x = getParByName("x", "mean", pars);
-	sigma_x = getParByName("x", "sigma", pars);
-	mean_y = getParByName("y", "mean", pars);
-	sigma_y = getParByName("y", "sigma", pars);
+SurveyPxbDicer::SurveyPxbDicer(const std::vector<edm::ParameterSet> &pars, unsigned int seed) {
+  CLHEP::HepRandom::setTheSeed(seed);
+  mean_a0 = getParByName("a0", "mean", pars);
+  sigma_a0 = getParByName("a0", "sigma", pars);
+  mean_a1 = getParByName("a1", "mean", pars);
+  sigma_a1 = getParByName("a1", "sigma", pars);
+  mean_scale = getParByName("scale", "mean", pars);
+  sigma_scale = getParByName("scale", "sigma", pars);
+  mean_phi = getParByName("phi", "mean", pars);
+  sigma_phi = getParByName("phi", "sigma", pars);
+  mean_x = getParByName("x", "mean", pars);
+  sigma_x = getParByName("x", "sigma", pars);
+  mean_y = getParByName("y", "mean", pars);
+  sigma_y = getParByName("y", "sigma", pars);
 }
 
-std::string SurveyPxbDicer::doDice(const fidpoint_t &fidpointvec, const idPair_t &id, const bool rotate)
-{
-	// Dice the local parameters
-	const value_t a0 = ranGauss(mean_a0, sigma_a0);
-	const value_t a1 = ranGauss(mean_a1, sigma_a1);
-	const value_t scale = ranGauss(mean_scale, sigma_scale);
-	const value_t phi = ranGauss(mean_phi, sigma_phi);
-	const value_t a2 = scale * cos(phi);
-	const value_t a3 = scale * sin(phi);
-	const coord_t p0 = transform(fidpointvec[0],a0,a1,a2,a3);
-	const coord_t p1 = transform(fidpointvec[1],a0,a1,a2,a3);
-	const coord_t p2 = transform(fidpointvec[2],a0,a1,a2,a3);
-	const coord_t p3 = transform(fidpointvec[3],a0,a1,a2,a3);
-	const value_t sign = rotate ? -1 : 1;
-	std::ostringstream oss;
-	oss << id.first << " " 
-		 << sign*ranGauss(p0.x(),sigma_x) << " " << -sign*ranGauss(p0.y(),sigma_y) << " "
-		 << sign*ranGauss(p1.x(),sigma_x) << " " << -sign*ranGauss(p1.y(),sigma_y) << " "
-		 << id.second << " "
-		 << sign*ranGauss(p2.x(),sigma_x) << " " << -sign*ranGauss(p2.y(),sigma_y) << " "
-		 << sign*ranGauss(p3.x(),sigma_x) << " " << -sign*ranGauss(p3.y(),sigma_y) << " "
-		 << sigma_x << " " << sigma_y << " "
-		 << rotate
-		 << " # MC-truth:"
-		 << " a0-a3: " << a0 << " " << a1 << " " << a2 << " " << a3
-		 << " S: " << scale
-		 << " phi: " << phi
-		 << " x0: " << fidpointvec[0].x() << " " << fidpointvec[0].y()
-		 << " x1: " << fidpointvec[1].x() << " " << fidpointvec[1].y()
-		 << " x2: " << fidpointvec[2].x() << " " << fidpointvec[2].y()
-		 << " x3: " << fidpointvec[3].x() << " " << fidpointvec[3].y()
-		 << std::endl;
-	return oss.str();
+std::string SurveyPxbDicer::doDice(const fidpoint_t &fidpointvec, const idPair_t &id, const bool rotate) {
+  // Dice the local parameters
+  const value_t a0 = ranGauss(mean_a0, sigma_a0);
+  const value_t a1 = ranGauss(mean_a1, sigma_a1);
+  const value_t scale = ranGauss(mean_scale, sigma_scale);
+  const value_t phi = ranGauss(mean_phi, sigma_phi);
+  const value_t a2 = scale * cos(phi);
+  const value_t a3 = scale * sin(phi);
+  const coord_t p0 = transform(fidpointvec[0], a0, a1, a2, a3);
+  const coord_t p1 = transform(fidpointvec[1], a0, a1, a2, a3);
+  const coord_t p2 = transform(fidpointvec[2], a0, a1, a2, a3);
+  const coord_t p3 = transform(fidpointvec[3], a0, a1, a2, a3);
+  const value_t sign = rotate ? -1 : 1;
+  std::ostringstream oss;
+  oss << id.first << " " << sign * ranGauss(p0.x(), sigma_x) << " " << -sign * ranGauss(p0.y(), sigma_y) << " "
+      << sign * ranGauss(p1.x(), sigma_x) << " " << -sign * ranGauss(p1.y(), sigma_y) << " " << id.second << " "
+      << sign * ranGauss(p2.x(), sigma_x) << " " << -sign * ranGauss(p2.y(), sigma_y) << " "
+      << sign * ranGauss(p3.x(), sigma_x) << " " << -sign * ranGauss(p3.y(), sigma_y) << " " << sigma_x << " "
+      << sigma_y << " " << rotate << " # MC-truth:"
+      << " a0-a3: " << a0 << " " << a1 << " " << a2 << " " << a3 << " S: " << scale << " phi: " << phi
+      << " x0: " << fidpointvec[0].x() << " " << fidpointvec[0].y() << " x1: " << fidpointvec[1].x() << " "
+      << fidpointvec[1].y() << " x2: " << fidpointvec[2].x() << " " << fidpointvec[2].y()
+      << " x3: " << fidpointvec[3].x() << " " << fidpointvec[3].y() << std::endl;
+  return oss.str();
 }
 
-void SurveyPxbDicer::doDice(const fidpoint_t &fidpointvec, const idPair_t &id, std::ofstream &outfile, const bool rotate)
-{
-	outfile << doDice(fidpointvec, id, rotate);
+void SurveyPxbDicer::doDice(const fidpoint_t &fidpointvec,
+                            const idPair_t &id,
+                            std::ofstream &outfile,
+                            const bool rotate) {
+  outfile << doDice(fidpointvec, id, rotate);
 }
 
-SurveyPxbDicer::coord_t SurveyPxbDicer::transform(const coord_t &x, const value_t &a0, const value_t &a1, const value_t &a2, const value_t &a3)
-{
-	return coord_t(a0+a2*x.x()+a3*x.y(), a1-a3*x.x()+a2*x.y());
+SurveyPxbDicer::coord_t SurveyPxbDicer::transform(
+    const coord_t &x, const value_t &a0, const value_t &a1, const value_t &a2, const value_t &a3) {
+  return coord_t(a0 + a2 * x.x() + a3 * x.y(), a1 - a3 * x.x() + a2 * x.y());
 }
 
-SurveyPxbDicer::value_t SurveyPxbDicer::getParByName(const std::string &name, const std::string &par, const std::vector<edm::ParameterSet>& pars)
-{
-	std::vector<edm::ParameterSet>::const_iterator it;
-	it = std::find_if(pars.begin(), pars.end(), [&name] (auto const& c){return findParByName()(name,c);});
-	if (it == pars.end()) { throw std::runtime_error("Parameter not found in SurveyPxbDicer::getParByName"); }
-	return (*it).getParameter<value_t>(par);
+SurveyPxbDicer::value_t SurveyPxbDicer::getParByName(const std::string &name,
+                                                     const std::string &par,
+                                                     const std::vector<edm::ParameterSet> &pars) {
+  std::vector<edm::ParameterSet>::const_iterator it;
+  it = std::find_if(pars.begin(), pars.end(), [&name](auto const &c) { return findParByName()(name, c); });
+  if (it == pars.end()) {
+    throw std::runtime_error("Parameter not found in SurveyPxbDicer::getParByName");
+  }
+  return (*it).getParameter<value_t>(par);
 }
-

--- a/Alignment/SurveyAnalysis/src/SurveyPxbImage.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyPxbImage.cc
@@ -6,8 +6,7 @@
 #include <vector>
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 
-void SurveyPxbImage::fill(std::istringstream &iss)
-{
+void SurveyPxbImage::fill(std::istringstream &iss) {
   id_t id1, id2;
   value_t x0, y0;
   value_t x1, y1;
@@ -15,40 +14,31 @@ void SurveyPxbImage::fill(std::istringstream &iss)
   value_t x3, y3;
   value_t sx, sy;
   bool rotflag;
-  if(! (iss >> id1 >> x0 >> y0 >> x1 >> y1
-            >> id2 >> x2 >> y2 >> x3 >> y3
-            >> sy >> sx >> rotflag).fail())
-    {
-      idPair_.first = id1;
-      idPair_.second = id2;
-      if (!rotflag)
-      {
-	  measurementVec_.push_back(coord_t(x0,-y0));
-	  measurementVec_.push_back(coord_t(x1,-y1));
-	  measurementVec_.push_back(coord_t(x2,-y2));
-	  measurementVec_.push_back(coord_t(x3,-y3));
-      }
-      else
-      {
-	  measurementVec_.push_back(coord_t(-x0,y0));
-	  measurementVec_.push_back(coord_t(-x1,y1));
-	  measurementVec_.push_back(coord_t(-x2,y2));
-	  measurementVec_.push_back(coord_t(-x3,y3));
-      }
-      sigma_x_ = sx;
-      sigma_y_ = sy;
-      isRotated_ = rotflag;
-      isValidFlag_ = true;
+  if (!(iss >> id1 >> x0 >> y0 >> x1 >> y1 >> id2 >> x2 >> y2 >> x3 >> y3 >> sy >> sx >> rotflag).fail()) {
+    idPair_.first = id1;
+    idPair_.second = id2;
+    if (!rotflag) {
+      measurementVec_.push_back(coord_t(x0, -y0));
+      measurementVec_.push_back(coord_t(x1, -y1));
+      measurementVec_.push_back(coord_t(x2, -y2));
+      measurementVec_.push_back(coord_t(x3, -y3));
+    } else {
+      measurementVec_.push_back(coord_t(-x0, y0));
+      measurementVec_.push_back(coord_t(-x1, y1));
+      measurementVec_.push_back(coord_t(-x2, y2));
+      measurementVec_.push_back(coord_t(-x3, y3));
     }
-  else
+    sigma_x_ = sx;
+    sigma_y_ = sy;
+    isRotated_ = rotflag;
+    isValidFlag_ = true;
+  } else
     isValidFlag_ = false;
 }
 
-const SurveyPxbImage::coord_t SurveyPxbImage::getCoord(count_t m)
-{
-  if (m>0 && m<5)
-    return measurementVec_[m-1];
+const SurveyPxbImage::coord_t SurveyPxbImage::getCoord(count_t m) {
+  if (m > 0 && m < 5)
+    return measurementVec_[m - 1];
   else
     throw std::out_of_range("Attempt to access an inexistent measurement");
 }
-

--- a/Alignment/SurveyAnalysis/src/SurveyPxbImageLocalFit.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyPxbImageLocalFit.cc
@@ -12,263 +12,314 @@
 
 #include <iostream>
 
-void SurveyPxbImageLocalFit::doFit(const fidpoint_t &fidpointvec, const pede_label_t &label1, const pede_label_t &label2)
-{
-	labelVec1_.clear();
-	labelVec1_.push_back(label1+0);
-	labelVec1_.push_back(label1+1);
-	labelVec1_.push_back(label1+5);
-	labelVec2_.clear();
-	labelVec2_.push_back(label2+0);
-	labelVec2_.push_back(label2+1);
-	labelVec2_.push_back(label2+5);
-	doFit(fidpointvec);
+void SurveyPxbImageLocalFit::doFit(const fidpoint_t &fidpointvec,
+                                   const pede_label_t &label1,
+                                   const pede_label_t &label2) {
+  labelVec1_.clear();
+  labelVec1_.push_back(label1 + 0);
+  labelVec1_.push_back(label1 + 1);
+  labelVec1_.push_back(label1 + 5);
+  labelVec2_.clear();
+  labelVec2_.push_back(label2 + 0);
+  labelVec2_.push_back(label2 + 1);
+  labelVec2_.push_back(label2 + 5);
+  doFit(fidpointvec);
 }
 
-void SurveyPxbImageLocalFit::doFit(const fidpoint_t &fidpointvec)
-{
-	fitValidFlag_ = false;
+void SurveyPxbImageLocalFit::doFit(const fidpoint_t &fidpointvec) {
+  fitValidFlag_ = false;
 
-	// Calculate gamma of right module w.r.t left modules' fram
-	const value_t dxr = fidpointvec[3].x()-fidpointvec[2].x();
-	const value_t dyr = fidpointvec[3].y()-fidpointvec[2].y();
-	const value_t gammar = atan(dyr/dxr);
-	const value_t dxl = fidpointvec[1].x()-fidpointvec[0].x();
-	const value_t dyl = fidpointvec[1].y()-fidpointvec[0].y();
-	const value_t gammal = atan(dyl/dxl);
-	const value_t gamma = gammar-gammal;
-	//const value_t gamma = 0.; // Testhalber
-	const value_t sing = sin(gamma);
-	const value_t cosg = cos(gamma);
+  // Calculate gamma of right module w.r.t left modules' fram
+  const value_t dxr = fidpointvec[3].x() - fidpointvec[2].x();
+  const value_t dyr = fidpointvec[3].y() - fidpointvec[2].y();
+  const value_t gammar = atan(dyr / dxr);
+  const value_t dxl = fidpointvec[1].x() - fidpointvec[0].x();
+  const value_t dyl = fidpointvec[1].y() - fidpointvec[0].y();
+  const value_t gammal = atan(dyl / dxl);
+  const value_t gamma = gammar - gammal;
+  //const value_t gamma = 0.; // Testhalber
+  const value_t sing = sin(gamma);
+  const value_t cosg = cos(gamma);
 #ifdef DEBUG
-	std::cout << "gamma: " << gamma << " gamma left: " << gammal << " gamma right: " << gammar << std::endl;
+  std::cout << "gamma: " << gamma << " gamma left: " << gammal << " gamma right: " << gammar << std::endl;
 #endif
 
-
 #ifdef DEBUG
-	std::cout << "&fidpointvec: " << std::endl;
-	for (count_t i=0; i!=fidpointvec.size(); i++)
-	    std::cout << i << ": " << fidpointvec[i] << std::endl;
-	std::cout << "&fidpoints_: " << std::endl;
-	for (count_t i=0; i!=fidpoints_.size(); i++)
-	    std::cout << i << ": " << fidpoints_[i] << std::endl;
+  std::cout << "&fidpointvec: " << std::endl;
+  for (count_t i = 0; i != fidpointvec.size(); i++)
+    std::cout << i << ": " << fidpointvec[i] << std::endl;
+  std::cout << "&fidpoints_: " << std::endl;
+  for (count_t i = 0; i != fidpoints_.size(); i++)
+    std::cout << i << ": " << fidpoints_[i] << std::endl;
 #endif
 
-	// Matrix of the local derivatives
-	ROOT::Math::SMatrix<value_t,nMsrmts,nLcD> A; // 8x4
-	A(0,0)=1.; A(0,1)=0; A(0,2)=+fidpointvec[0].x(); A(0,3)=+fidpointvec[0].y();
-	A(1,0)=0.; A(1,1)=1; A(1,2)=+fidpointvec[0].y(); A(1,3)=-fidpointvec[0].x();
-	A(2,0)=1.; A(2,1)=0; A(2,2)=+fidpointvec[1].x(); A(2,3)=+fidpointvec[1].y();
-	A(3,0)=0.; A(3,1)=1; A(3,2)=+fidpointvec[1].y(); A(3,3)=-fidpointvec[1].x();
-	A(4,0)=1.; A(4,1)=0; A(4,2)=+fidpointvec[2].x(); A(4,3)=+fidpointvec[2].y();
-	A(5,0)=0.; A(5,1)=1; A(5,2)=+fidpointvec[2].y(); A(5,3)=-fidpointvec[2].x();
-	A(6,0)=1.; A(6,1)=0; A(6,2)=+fidpointvec[3].x(); A(6,3)=+fidpointvec[3].y();
-	A(7,0)=0.; A(7,1)=1; A(7,2)=+fidpointvec[3].y(); A(7,3)=-fidpointvec[3].x();
+  // Matrix of the local derivatives
+  ROOT::Math::SMatrix<value_t, nMsrmts, nLcD> A;  // 8x4
+  A(0, 0) = 1.;
+  A(0, 1) = 0;
+  A(0, 2) = +fidpointvec[0].x();
+  A(0, 3) = +fidpointvec[0].y();
+  A(1, 0) = 0.;
+  A(1, 1) = 1;
+  A(1, 2) = +fidpointvec[0].y();
+  A(1, 3) = -fidpointvec[0].x();
+  A(2, 0) = 1.;
+  A(2, 1) = 0;
+  A(2, 2) = +fidpointvec[1].x();
+  A(2, 3) = +fidpointvec[1].y();
+  A(3, 0) = 0.;
+  A(3, 1) = 1;
+  A(3, 2) = +fidpointvec[1].y();
+  A(3, 3) = -fidpointvec[1].x();
+  A(4, 0) = 1.;
+  A(4, 1) = 0;
+  A(4, 2) = +fidpointvec[2].x();
+  A(4, 3) = +fidpointvec[2].y();
+  A(5, 0) = 0.;
+  A(5, 1) = 1;
+  A(5, 2) = +fidpointvec[2].y();
+  A(5, 3) = -fidpointvec[2].x();
+  A(6, 0) = 1.;
+  A(6, 1) = 0;
+  A(6, 2) = +fidpointvec[3].x();
+  A(6, 3) = +fidpointvec[3].y();
+  A(7, 0) = 0.;
+  A(7, 1) = 1;
+  A(7, 2) = +fidpointvec[3].y();
+  A(7, 3) = -fidpointvec[3].x();
 #ifdef DEBUG
-	std::cout << "A: \n" << A << std::endl;
+  std::cout << "A: \n" << A << std::endl;
 #endif
 
-	// Covariance matrix
-	ROOT::Math::SMatrix<value_t,nMsrmts,nMsrmts> W; // 8x8
-	//ROOT::Math::MatRepSym<value_t,8> W;
-	const value_t sigma_x2inv = 1./(sigma_x_*sigma_x_);
-	const value_t sigma_y2inv = 1./(sigma_y_*sigma_y_);
-	W(0,0) = sigma_x2inv;
-	W(1,1) = sigma_y2inv;
-	W(2,2) = sigma_x2inv;
-	W(3,3) = sigma_y2inv;
-	W(4,4) = sigma_x2inv;
-	W(5,5) = sigma_y2inv;
-	W(6,6) = sigma_x2inv;
-	W(7,7) = sigma_y2inv;
+  // Covariance matrix
+  ROOT::Math::SMatrix<value_t, nMsrmts, nMsrmts> W;  // 8x8
+  //ROOT::Math::MatRepSym<value_t,8> W;
+  const value_t sigma_x2inv = 1. / (sigma_x_ * sigma_x_);
+  const value_t sigma_y2inv = 1. / (sigma_y_ * sigma_y_);
+  W(0, 0) = sigma_x2inv;
+  W(1, 1) = sigma_y2inv;
+  W(2, 2) = sigma_x2inv;
+  W(3, 3) = sigma_y2inv;
+  W(4, 4) = sigma_x2inv;
+  W(5, 5) = sigma_y2inv;
+  W(6, 6) = sigma_x2inv;
+  W(7, 7) = sigma_y2inv;
 #ifdef DEBUG
-	std::cout << "W: \n" << W << std::endl;
+  std::cout << "W: \n" << W << std::endl;
 #endif
 
-	// Prepare for the fit
-	ROOT::Math::SMatrix<value_t,nLcD,nLcD> ATWA; // 4x4
-	ATWA = ROOT::Math::Transpose(A) * W * A;
-	//ATWA = ROOT::Math::SimilarityT(A,W); // W muss symmterisch sein -> aendern.
-	//std::cout << "ATWA: \n" << ATWA << std::endl;
-	ROOT::Math::SMatrix<value_t,nLcD,nLcD> ATWAi; // 4x4
-	int ifail = 0;
-	ATWAi = ATWA.Inverse(ifail);
-	if (ifail != 0)
-	{ // TODO: ifail Pruefung auf message logger ausgeben statt cout
-		std::cout << "Problem singular - fit impossible." << std::endl;
-		fitValidFlag_ = false;
-		return;
-	}
+  // Prepare for the fit
+  ROOT::Math::SMatrix<value_t, nLcD, nLcD> ATWA;  // 4x4
+  ATWA = ROOT::Math::Transpose(A) * W * A;
+  //ATWA = ROOT::Math::SimilarityT(A,W); // W muss symmterisch sein -> aendern.
+  //std::cout << "ATWA: \n" << ATWA << std::endl;
+  ROOT::Math::SMatrix<value_t, nLcD, nLcD> ATWAi;  // 4x4
+  int ifail = 0;
+  ATWAi = ATWA.Inverse(ifail);
+  if (ifail != 0) {  // TODO: ifail Pruefung auf message logger ausgeben statt cout
+    std::cout << "Problem singular - fit impossible." << std::endl;
+    fitValidFlag_ = false;
+    return;
+  }
 #ifdef DEBUG
-	std::cout << "ATWA-1: \n" << ATWAi << ifail << std::endl;
+  std::cout << "ATWA-1: \n" << ATWAi << ifail << std::endl;
 #endif
 
-	// Measurements
-	ROOT::Math::SVector<value_t,nMsrmts> y; // 8
-	y(0) = measurementVec_[0].x();
-	y(1) = measurementVec_[0].y();
-	y(2) = measurementVec_[1].x();
-	y(3) = measurementVec_[1].y();
-	y(4) = measurementVec_[2].x();
-	y(5) = measurementVec_[2].y();
-	y(6) = measurementVec_[3].x();
-	y(7) = measurementVec_[3].y();
+  // Measurements
+  ROOT::Math::SVector<value_t, nMsrmts> y;  // 8
+  y(0) = measurementVec_[0].x();
+  y(1) = measurementVec_[0].y();
+  y(2) = measurementVec_[1].x();
+  y(3) = measurementVec_[1].y();
+  y(4) = measurementVec_[2].x();
+  y(5) = measurementVec_[2].y();
+  y(6) = measurementVec_[3].x();
+  y(7) = measurementVec_[3].y();
 #ifdef DEBUG
-	std::cout << "y: " << y << std::endl;
+  std::cout << "y: " << y << std::endl;
 #endif
 
-	// do the fit
-	ROOT::Math::SVector<value_t,nLcD> a; // 4
-	a = ATWAi * ROOT::Math::Transpose(A) * W * y;
-	chi2_ = ROOT::Math::Dot(y,W*y)-ROOT::Math::Dot(a,ROOT::Math::Transpose(A)*W*y);
+  // do the fit
+  ROOT::Math::SVector<value_t, nLcD> a;  // 4
+  a = ATWAi * ROOT::Math::Transpose(A) * W * y;
+  chi2_ = ROOT::Math::Dot(y, W * y) - ROOT::Math::Dot(a, ROOT::Math::Transpose(A) * W * y);
 #ifdef DEBUG
-	std::cout << "a: " << a 
-		<< " S= " << sqrt(a[2]*a[2]+a[3]*a[3]) 
-		<< " phi= " << atan(a[3]/a[2]) 
-		<< " chi2= " << chi2_ << std::endl;
-	std::cout << "A*a: " << A*a << std::endl;
+  std::cout << "a: " << a << " S= " << sqrt(a[2] * a[2] + a[3] * a[3]) << " phi= " << atan(a[3] / a[2])
+            << " chi2= " << chi2_ << std::endl;
+  std::cout << "A*a: " << A * a << std::endl;
 #endif
-	a_.assign(a.begin(),a.end());
+  a_.assign(a.begin(), a.end());
 
-	// Calculate vector of residuals
-	r = y - A*a;
+  // Calculate vector of residuals
+  r = y - A * a;
 #ifdef DEBUG
-	std::cout << "r: " << r << std::endl;
+  std::cout << "r: " << r << std::endl;
 #endif
 
-	// Fill matrix for global fit with local derivatives
-	localDerivsMatrix_(0,0)=1.; localDerivsMatrix_(0,1)=0; 
-	localDerivsMatrix_(1,0)=0.; localDerivsMatrix_(1,1)=1; 
-	localDerivsMatrix_(2,0)=1.; localDerivsMatrix_(2,1)=0; 
-	localDerivsMatrix_(3,0)=0.; localDerivsMatrix_(3,1)=1; 
-	localDerivsMatrix_(4,0)=1.; localDerivsMatrix_(4,1)=0; 
-	localDerivsMatrix_(5,0)=0.; localDerivsMatrix_(5,1)=1; 
-	localDerivsMatrix_(6,0)=1.; localDerivsMatrix_(6,1)=0; 
-	localDerivsMatrix_(7,0)=0.; localDerivsMatrix_(7,1)=1; 
-	localDerivsMatrix_(0,2)=+fidpointvec[0].x()+cosg*fidpoints_[0].x()-sing*fidpoints_[0].y();
-	localDerivsMatrix_(0,3)=+fidpointvec[0].y()+cosg*fidpoints_[0].y()+sing*fidpoints_[0].x();
-	localDerivsMatrix_(1,2)=+fidpointvec[0].y()+cosg*fidpoints_[0].y()+sing*fidpoints_[0].x();
-	localDerivsMatrix_(1,3)=-fidpointvec[0].x()-cosg*fidpoints_[0].x()+sing*fidpoints_[0].y();
-	localDerivsMatrix_(2,2)=+fidpointvec[1].x()+cosg*fidpoints_[1].x()-sing*fidpoints_[1].y();
-	localDerivsMatrix_(2,3)=+fidpointvec[1].y()+cosg*fidpoints_[1].y()+sing*fidpoints_[1].x();
-	localDerivsMatrix_(3,2)=+fidpointvec[1].y()+cosg*fidpoints_[1].y()+sing*fidpoints_[1].x();
-	localDerivsMatrix_(3,3)=-fidpointvec[1].x()-cosg*fidpoints_[1].x()+sing*fidpoints_[1].y();
-	localDerivsMatrix_(4,2)=+fidpointvec[2].x()+cosg*fidpoints_[2].x()-sing*fidpoints_[2].y();
-	localDerivsMatrix_(4,3)=+fidpointvec[2].y()+cosg*fidpoints_[2].y()+sing*fidpoints_[2].x();
-	localDerivsMatrix_(5,2)=+fidpointvec[2].y()+cosg*fidpoints_[2].y()+sing*fidpoints_[2].x();
-	localDerivsMatrix_(5,3)=-fidpointvec[2].x()-cosg*fidpoints_[2].x()+sing*fidpoints_[2].y();
-	localDerivsMatrix_(6,2)=+fidpointvec[3].x()+cosg*fidpoints_[3].x()-sing*fidpoints_[3].y();
-	localDerivsMatrix_(6,3)=+fidpointvec[3].y()+cosg*fidpoints_[3].y()+sing*fidpoints_[3].x();
-	localDerivsMatrix_(7,2)=+fidpointvec[3].y()+cosg*fidpoints_[3].y()+sing*fidpoints_[3].x();
-	localDerivsMatrix_(7,3)=-fidpointvec[3].x()-cosg*fidpoints_[3].x()+sing*fidpoints_[3].y();
+  // Fill matrix for global fit with local derivatives
+  localDerivsMatrix_(0, 0) = 1.;
+  localDerivsMatrix_(0, 1) = 0;
+  localDerivsMatrix_(1, 0) = 0.;
+  localDerivsMatrix_(1, 1) = 1;
+  localDerivsMatrix_(2, 0) = 1.;
+  localDerivsMatrix_(2, 1) = 0;
+  localDerivsMatrix_(3, 0) = 0.;
+  localDerivsMatrix_(3, 1) = 1;
+  localDerivsMatrix_(4, 0) = 1.;
+  localDerivsMatrix_(4, 1) = 0;
+  localDerivsMatrix_(5, 0) = 0.;
+  localDerivsMatrix_(5, 1) = 1;
+  localDerivsMatrix_(6, 0) = 1.;
+  localDerivsMatrix_(6, 1) = 0;
+  localDerivsMatrix_(7, 0) = 0.;
+  localDerivsMatrix_(7, 1) = 1;
+  localDerivsMatrix_(0, 2) = +fidpointvec[0].x() + cosg * fidpoints_[0].x() - sing * fidpoints_[0].y();
+  localDerivsMatrix_(0, 3) = +fidpointvec[0].y() + cosg * fidpoints_[0].y() + sing * fidpoints_[0].x();
+  localDerivsMatrix_(1, 2) = +fidpointvec[0].y() + cosg * fidpoints_[0].y() + sing * fidpoints_[0].x();
+  localDerivsMatrix_(1, 3) = -fidpointvec[0].x() - cosg * fidpoints_[0].x() + sing * fidpoints_[0].y();
+  localDerivsMatrix_(2, 2) = +fidpointvec[1].x() + cosg * fidpoints_[1].x() - sing * fidpoints_[1].y();
+  localDerivsMatrix_(2, 3) = +fidpointvec[1].y() + cosg * fidpoints_[1].y() + sing * fidpoints_[1].x();
+  localDerivsMatrix_(3, 2) = +fidpointvec[1].y() + cosg * fidpoints_[1].y() + sing * fidpoints_[1].x();
+  localDerivsMatrix_(3, 3) = -fidpointvec[1].x() - cosg * fidpoints_[1].x() + sing * fidpoints_[1].y();
+  localDerivsMatrix_(4, 2) = +fidpointvec[2].x() + cosg * fidpoints_[2].x() - sing * fidpoints_[2].y();
+  localDerivsMatrix_(4, 3) = +fidpointvec[2].y() + cosg * fidpoints_[2].y() + sing * fidpoints_[2].x();
+  localDerivsMatrix_(5, 2) = +fidpointvec[2].y() + cosg * fidpoints_[2].y() + sing * fidpoints_[2].x();
+  localDerivsMatrix_(5, 3) = -fidpointvec[2].x() - cosg * fidpoints_[2].x() + sing * fidpoints_[2].y();
+  localDerivsMatrix_(6, 2) = +fidpointvec[3].x() + cosg * fidpoints_[3].x() - sing * fidpoints_[3].y();
+  localDerivsMatrix_(6, 3) = +fidpointvec[3].y() + cosg * fidpoints_[3].y() + sing * fidpoints_[3].x();
+  localDerivsMatrix_(7, 2) = +fidpointvec[3].y() + cosg * fidpoints_[3].y() + sing * fidpoints_[3].x();
+  localDerivsMatrix_(7, 3) = -fidpointvec[3].x() - cosg * fidpoints_[3].x() + sing * fidpoints_[3].y();
 
-	// Fill vector with global derivatives and labels (8x3)
-	globalDerivsMatrix_(0,0) = +a(2);
-	globalDerivsMatrix_(0,1) = +a(3);
-	globalDerivsMatrix_(0,2) = +cosg*(a(3)*fidpoints_[0].x()-a(2)*fidpoints_[0].y())
-				   -sing*(a(2)*fidpoints_[0].x()+a(3)*fidpoints_[0].y());
-	globalDerivsMatrix_(1,0) = -a(3);
-	globalDerivsMatrix_(1,1) = +a(2);
-	globalDerivsMatrix_(1,2) = +cosg*(a(2)*fidpoints_[0].x()+a(3)*fidpoints_[0].y())
-				   -sing*(a(2)*fidpoints_[0].y()-a(3)*fidpoints_[0].x());
-	globalDerivsMatrix_(2,0) = +a(2);
-	globalDerivsMatrix_(2,1) = +a(3);
-	globalDerivsMatrix_(2,2) = +cosg*(a(3)*fidpoints_[1].x()-a(2)*fidpoints_[1].y())
-				   -sing*(a(2)*fidpoints_[1].x()+a(3)*fidpoints_[1].y());
-	globalDerivsMatrix_(3,0) = -a(3);
-	globalDerivsMatrix_(3,1) = +a(2);
-	globalDerivsMatrix_(3,2) = +cosg*(a(2)*fidpoints_[1].x()+a(3)*fidpoints_[1].y())
-				   -sing*(a(2)*fidpoints_[1].y()-a(3)*fidpoints_[1].x());
+  // Fill vector with global derivatives and labels (8x3)
+  globalDerivsMatrix_(0, 0) = +a(2);
+  globalDerivsMatrix_(0, 1) = +a(3);
+  globalDerivsMatrix_(0, 2) = +cosg * (a(3) * fidpoints_[0].x() - a(2) * fidpoints_[0].y()) -
+                              sing * (a(2) * fidpoints_[0].x() + a(3) * fidpoints_[0].y());
+  globalDerivsMatrix_(1, 0) = -a(3);
+  globalDerivsMatrix_(1, 1) = +a(2);
+  globalDerivsMatrix_(1, 2) = +cosg * (a(2) * fidpoints_[0].x() + a(3) * fidpoints_[0].y()) -
+                              sing * (a(2) * fidpoints_[0].y() - a(3) * fidpoints_[0].x());
+  globalDerivsMatrix_(2, 0) = +a(2);
+  globalDerivsMatrix_(2, 1) = +a(3);
+  globalDerivsMatrix_(2, 2) = +cosg * (a(3) * fidpoints_[1].x() - a(2) * fidpoints_[1].y()) -
+                              sing * (a(2) * fidpoints_[1].x() + a(3) * fidpoints_[1].y());
+  globalDerivsMatrix_(3, 0) = -a(3);
+  globalDerivsMatrix_(3, 1) = +a(2);
+  globalDerivsMatrix_(3, 2) = +cosg * (a(2) * fidpoints_[1].x() + a(3) * fidpoints_[1].y()) -
+                              sing * (a(2) * fidpoints_[1].y() - a(3) * fidpoints_[1].x());
 
-	globalDerivsMatrix_(4,0) = +a(2);
-	globalDerivsMatrix_(4,1) = +a(3);
-	globalDerivsMatrix_(4,2) = +cosg*(a(3)*fidpoints_[2].x()-a(2)*fidpoints_[2].y())
-				   -sing*(a(2)*fidpoints_[2].x()+a(3)*fidpoints_[2].y());
-	globalDerivsMatrix_(5,0) = -a(3);
-	globalDerivsMatrix_(5,1) = +a(2);
-	globalDerivsMatrix_(5,2) = +cosg*(a(2)*fidpoints_[2].x()+a(3)*fidpoints_[2].y())
-				   -sing*(a(2)*fidpoints_[2].y()-a(3)*fidpoints_[2].x());
-	globalDerivsMatrix_(6,0) = +a(2);
-	globalDerivsMatrix_(6,1) = +a(3);
-	globalDerivsMatrix_(6,2) = +cosg*(a(3)*fidpoints_[3].x()-a(2)*fidpoints_[3].y())
-				   -sing*(a(2)*fidpoints_[3].x()+a(3)*fidpoints_[3].y());
-	globalDerivsMatrix_(7,0) = -a(3);
-	globalDerivsMatrix_(7,1) = +a(2);
-	globalDerivsMatrix_(7,2) = +cosg*(a(2)*fidpoints_[3].x()+a(3)*fidpoints_[3].y())
-				   -sing*(a(2)*fidpoints_[3].y()-a(3)*fidpoints_[3].x());
+  globalDerivsMatrix_(4, 0) = +a(2);
+  globalDerivsMatrix_(4, 1) = +a(3);
+  globalDerivsMatrix_(4, 2) = +cosg * (a(3) * fidpoints_[2].x() - a(2) * fidpoints_[2].y()) -
+                              sing * (a(2) * fidpoints_[2].x() + a(3) * fidpoints_[2].y());
+  globalDerivsMatrix_(5, 0) = -a(3);
+  globalDerivsMatrix_(5, 1) = +a(2);
+  globalDerivsMatrix_(5, 2) = +cosg * (a(2) * fidpoints_[2].x() + a(3) * fidpoints_[2].y()) -
+                              sing * (a(2) * fidpoints_[2].y() - a(3) * fidpoints_[2].x());
+  globalDerivsMatrix_(6, 0) = +a(2);
+  globalDerivsMatrix_(6, 1) = +a(3);
+  globalDerivsMatrix_(6, 2) = +cosg * (a(3) * fidpoints_[3].x() - a(2) * fidpoints_[3].y()) -
+                              sing * (a(2) * fidpoints_[3].x() + a(3) * fidpoints_[3].y());
+  globalDerivsMatrix_(7, 0) = -a(3);
+  globalDerivsMatrix_(7, 1) = +a(2);
+  globalDerivsMatrix_(7, 2) = +cosg * (a(2) * fidpoints_[3].x() + a(3) * fidpoints_[3].y()) -
+                              sing * (a(2) * fidpoints_[3].y() - a(3) * fidpoints_[3].x());
 
-	fitValidFlag_ = true;
+  fitValidFlag_ = true;
 }
 
+void SurveyPxbImageLocalFit::doFit(value_t u1, value_t v1, value_t g1, value_t u2, value_t v2, value_t g2) {
+  // Creating vectors with the global parameters of the two modules
+  ROOT::Math::SVector<value_t, 4> mod1, mod2;
+  mod1(0) = u1;
+  mod1(1) = v1;
+  mod1(2) = cos(g1);
+  mod1(3) = sin(g1);
+  mod2(0) = u2;
+  mod2(1) = v2;
+  mod2(2) = cos(g2);
+  mod2(3) = sin(g2);
+  //std::cout << "mod1: " << mod1 << std::endl;
+  //std::cout << "mod2: " << mod2 << std::endl;
 
-void SurveyPxbImageLocalFit::doFit(value_t u1, value_t v1, value_t g1, value_t u2, value_t v2, value_t g2)
-{
-	// Creating vectors with the global parameters of the two modules
-	ROOT::Math::SVector<value_t,4> mod1, mod2;
-	mod1(0)=u1;
-	mod1(1)=v1;
-	mod1(2)=cos(g1);
-	mod1(3)=sin(g1);
-	mod2(0)=u2;
-	mod2(1)=v2;
-	mod2(2)=cos(g2);
-	mod2(3)=sin(g2);
-	//std::cout << "mod1: " << mod1 << std::endl;
-	//std::cout << "mod2: " << mod2 << std::endl;
+  // Create a matrix for the transformed position of the fidpoints
+  ROOT::Math::SMatrix<value_t, 4, 4> M1, M2;
+  M1(0, 0) = 1.;
+  M1(0, 1) = 0.;
+  M1(0, 2) = +fidpoints_[0].x();
+  M1(0, 3) = -fidpoints_[0].y();
+  M1(1, 0) = 0.;
+  M1(1, 1) = 1.;
+  M1(1, 2) = +fidpoints_[0].y();
+  M1(1, 3) = +fidpoints_[0].x();
+  M1(2, 0) = 1.;
+  M1(2, 1) = 0.;
+  M1(2, 2) = +fidpoints_[1].x();
+  M1(2, 3) = -fidpoints_[1].y();
+  M1(3, 0) = 0.;
+  M1(3, 1) = 1.;
+  M1(3, 2) = +fidpoints_[1].y();
+  M1(3, 3) = +fidpoints_[1].x();
+  M2(0, 0) = 1.;
+  M2(0, 1) = 0.;
+  M2(0, 2) = +fidpoints_[2].x();
+  M2(0, 3) = -fidpoints_[2].y();
+  M2(1, 0) = 0.;
+  M2(1, 1) = 1.;
+  M2(1, 2) = +fidpoints_[2].y();
+  M2(1, 3) = +fidpoints_[2].x();
+  M2(2, 0) = 1.;
+  M2(2, 1) = 0.;
+  M2(2, 2) = +fidpoints_[3].x();
+  M2(2, 3) = -fidpoints_[3].y();
+  M2(3, 0) = 0.;
+  M2(3, 1) = 1.;
+  M2(3, 2) = +fidpoints_[3].y();
+  M2(3, 3) = +fidpoints_[3].x();
 
-	// Create a matrix for the transformed position of the fidpoints
-	ROOT::Math::SMatrix<value_t,4,4> M1, M2;
-	M1(0,0)=1.; M1(0,1)=0.; M1(0,2)=+fidpoints_[0].x(); M1(0,3)=-fidpoints_[0].y();
-	M1(1,0)=0.; M1(1,1)=1.; M1(1,2)=+fidpoints_[0].y(); M1(1,3)=+fidpoints_[0].x();
-	M1(2,0)=1.; M1(2,1)=0.; M1(2,2)=+fidpoints_[1].x(); M1(2,3)=-fidpoints_[1].y();
-	M1(3,0)=0.; M1(3,1)=1.; M1(3,2)=+fidpoints_[1].y(); M1(3,3)=+fidpoints_[1].x();
-	M2(0,0)=1.; M2(0,1)=0.; M2(0,2)=+fidpoints_[2].x(); M2(0,3)=-fidpoints_[2].y();
-	M2(1,0)=0.; M2(1,1)=1.; M2(1,2)=+fidpoints_[2].y(); M2(1,3)=+fidpoints_[2].x();
-	M2(2,0)=1.; M2(2,1)=0.; M2(2,2)=+fidpoints_[3].x(); M2(2,3)=-fidpoints_[3].y();
-	M2(3,0)=0.; M2(3,1)=1.; M2(3,2)=+fidpoints_[3].y(); M2(3,3)=+fidpoints_[3].x();
+  //std::cout << "M1:\n" << M1 << std::endl;
+  //std::cout << "M2:\n" << M2 << std::endl;
 
-	//std::cout << "M1:\n" << M1 << std::endl;
-	//std::cout << "M2:\n" << M2 << std::endl;
+  ROOT::Math::SVector<value_t, 4> mod_tr1, mod_tr2;
+  mod_tr1 = M1 * mod2;
+  mod_tr2 = M2 * mod1;
+  //std::cout << "mod_tr1: " << mod_tr1 << std::endl;
+  //std::cout << "mod_tr2: " << mod_tr2 << std::endl;
 
-	ROOT::Math::SVector<value_t,4> mod_tr1, mod_tr2;
-	mod_tr1 = M1*mod2;
-	mod_tr2 = M2*mod1;
-	//std::cout << "mod_tr1: " << mod_tr1 << std::endl;
-	//std::cout << "mod_tr2: " << mod_tr2 << std::endl;
+  fidpoint_t fidpointvec;
+  fidpointvec.push_back(coord_t(mod_tr1(0), mod_tr1(1)));
+  fidpointvec.push_back(coord_t(mod_tr1(2), mod_tr1(3)));
+  fidpointvec.push_back(coord_t(mod_tr2(0), mod_tr2(1)));
+  fidpointvec.push_back(coord_t(mod_tr2(2), mod_tr2(3)));
 
-	fidpoint_t fidpointvec;
-	fidpointvec.push_back(coord_t(mod_tr1(0),mod_tr1(1)));
-	fidpointvec.push_back(coord_t(mod_tr1(2),mod_tr1(3)));
-	fidpointvec.push_back(coord_t(mod_tr2(0),mod_tr2(1)));
-	fidpointvec.push_back(coord_t(mod_tr2(2),mod_tr2(3)));
-
-	doFit(fidpointvec);
+  doFit(fidpointvec);
 }
 
-SurveyPxbImageLocalFit::localpars_t SurveyPxbImageLocalFit::getLocalParameters()
-{
-	if (!fitValidFlag_) throw std::logic_error("SurveyPxbImageLocalFit::getLocalParameters(): Fit is not valid. Call doFit(...) before calling this function.");
-	return a_;
+SurveyPxbImageLocalFit::localpars_t SurveyPxbImageLocalFit::getLocalParameters() {
+  if (!fitValidFlag_)
+    throw std::logic_error(
+        "SurveyPxbImageLocalFit::getLocalParameters(): Fit is not valid. Call doFit(...) before calling this "
+        "function.");
+  return a_;
 }
 
-SurveyPxbImageLocalFit::value_t SurveyPxbImageLocalFit::getChi2()
-{
-	if (!fitValidFlag_) throw std::logic_error("SurveyPxbImageLocalFit::getChi2(): Fit is not valid. Call doFit(...) before calling this function.");
-	return chi2_;
+SurveyPxbImageLocalFit::value_t SurveyPxbImageLocalFit::getChi2() {
+  if (!fitValidFlag_)
+    throw std::logic_error(
+        "SurveyPxbImageLocalFit::getChi2(): Fit is not valid. Call doFit(...) before calling this function.");
+  return chi2_;
 }
 
-void SurveyPxbImageLocalFit::setLocalDerivsToZero(count_t j)
-{
-    if (!(j < nLcD)) throw std::range_error("SurveyPxbImageLocalFit::setLocalDerivsToZero(j): j out of range.");
-    for(count_t i=0; i!=nMsrmts; i++)
-	localDerivsMatrix_(i,j)=0;
+void SurveyPxbImageLocalFit::setLocalDerivsToZero(count_t j) {
+  if (!(j < nLcD))
+    throw std::range_error("SurveyPxbImageLocalFit::setLocalDerivsToZero(j): j out of range.");
+  for (count_t i = 0; i != nMsrmts; i++)
+    localDerivsMatrix_(i, j) = 0;
 }
 
-void SurveyPxbImageLocalFit::setGlobalDerivsToZero(count_t j)
-{
-    if (!(j < nGlD)) throw std::range_error("SurveyPxbImageLocalFit::setLocalDerivsToZero(j): j out of range.");
-    for(count_t i=0; i!=nMsrmts; i++)
-	globalDerivsMatrix_(i,j)=0;
+void SurveyPxbImageLocalFit::setGlobalDerivsToZero(count_t j) {
+  if (!(j < nGlD))
+    throw std::range_error("SurveyPxbImageLocalFit::setLocalDerivsToZero(j): j out of range.");
+  for (count_t i = 0; i != nMsrmts; i++)
+    globalDerivsMatrix_(i, j) = 0;
 }
-
-

--- a/Alignment/SurveyAnalysis/test/SurveyDBReader.cc
+++ b/Alignment/SurveyAnalysis/test/SurveyDBReader.cc
@@ -13,79 +13,70 @@
 
 #include "Alignment/SurveyAnalysis/test/SurveyDBReader.h"
 
-SurveyDBReader::SurveyDBReader(const edm::ParameterSet& cfg):
-  theFileName( cfg.getParameter<std::string>("fileName") ),
-  theFirstEvent(true)
-{
-}
+SurveyDBReader::SurveyDBReader(const edm::ParameterSet& cfg)
+    : theFileName(cfg.getParameter<std::string>("fileName")), theFirstEvent(true) {}
 
-void SurveyDBReader::analyze(const edm::Event&, const edm::EventSetup& setup)
-{
+void SurveyDBReader::analyze(const edm::Event&, const edm::EventSetup& setup) {
   typedef AlignTransform SurveyValue;
-  typedef Alignments     SurveyValues;
+  typedef Alignments SurveyValues;
 
   if (theFirstEvent) {
-
     edm::ESHandle<SurveyValues> valuesHandle;
     edm::ESHandle<SurveyErrors> errorsHandle;
-    
+
     setup.get<TrackerSurveyRcd>().get(valuesHandle);
     setup.get<TrackerSurveyErrorExtendedRcd>().get(errorsHandle);
-    
+
     const std::vector<SurveyValue>& values = valuesHandle->m_align;
     const std::vector<SurveyError>& errors = errorsHandle->m_surveyErrors;
-    
+
     unsigned int size = values.size();
-    
-    if ( errors.size() != size )
-      {
-	edm::LogError("SurveyDBReader")
-	  << "Value and error records have different sizes. Abort!";
-	
-	return;
-      }
-    
-    uint8_t  type = 0;
-    uint32_t id   = 0;
-    
-    ROOT::Math::Cartesian3D<double>* pos(0); // pointer required by ROOT
-    ROOT::Math::EulerAngles* rot(0); // pointer required by ROOT
-    const align::ErrorMatrix* cov(0); // pointer required by ROOT
-    
+
+    if (errors.size() != size) {
+      edm::LogError("SurveyDBReader") << "Value and error records have different sizes. Abort!";
+
+      return;
+    }
+
+    uint8_t type = 0;
+    uint32_t id = 0;
+
+    ROOT::Math::Cartesian3D<double>* pos(0);  // pointer required by ROOT
+    ROOT::Math::EulerAngles* rot(0);          // pointer required by ROOT
+    const align::ErrorMatrix* cov(0);         // pointer required by ROOT
+
     TFile fout(theFileName.c_str(), "RECREATE");
     TTree tree("survey", "");
-    
-    tree.Branch("type", &type, "type/b");
-    tree.Branch("id",   &id,   "id/i");
-    tree.Branch("pos", "ROOT::Math::Cartesian3D<double>",    &pos);
-    tree.Branch("rot", "ROOT::Math::EulerAngles",   &rot);
-    tree.Branch("cov", "align::ErrorMatrix", &cov);
-    
-    for (unsigned int i = 0; i < size; ++i)
-      {
-	const SurveyValue& value = values[i];
-	const SurveyError& error = errors[i];
-	
-	const CLHEP::Hep3Vector&  transl = value.translation();
-	const CLHEP::HepRotation& orient = value.rotation();
-	const align::ErrorMatrix& matrix = error.matrix();
 
-	ROOT::Math::Cartesian3D<double> coords( transl.x(),transl.y(),transl.z() );
-	ROOT::Math::EulerAngles angles( orient.phi(), orient.theta(), orient.psi() );
-	
-	type = error.structureType();
-	id   = error.rawId();
-	pos  = &coords;
-	rot  = &angles;
-	cov  = &matrix;
-	
-	tree.Fill();
-      }
-    
+    tree.Branch("type", &type, "type/b");
+    tree.Branch("id", &id, "id/i");
+    tree.Branch("pos", "ROOT::Math::Cartesian3D<double>", &pos);
+    tree.Branch("rot", "ROOT::Math::EulerAngles", &rot);
+    tree.Branch("cov", "align::ErrorMatrix", &cov);
+
+    for (unsigned int i = 0; i < size; ++i) {
+      const SurveyValue& value = values[i];
+      const SurveyError& error = errors[i];
+
+      const CLHEP::Hep3Vector& transl = value.translation();
+      const CLHEP::HepRotation& orient = value.rotation();
+      const align::ErrorMatrix& matrix = error.matrix();
+
+      ROOT::Math::Cartesian3D<double> coords(transl.x(), transl.y(), transl.z());
+      ROOT::Math::EulerAngles angles(orient.phi(), orient.theta(), orient.psi());
+
+      type = error.structureType();
+      id = error.rawId();
+      pos = &coords;
+      rot = &angles;
+      cov = &matrix;
+
+      tree.Fill();
+    }
+
     fout.Write();
 
-    edm::LogInfo("SurveyDBReader")
-      << "Number of alignables read " << size << std::endl;
+    edm::LogInfo("SurveyDBReader") << "Number of alignables read " << size << std::endl;
 
     theFirstEvent = false;
   }

--- a/Alignment/SurveyAnalysis/test/SurveyDBReader.h
+++ b/Alignment/SurveyAnalysis/test/SurveyDBReader.h
@@ -18,26 +18,17 @@
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 
-class SurveyDBReader:
-  public edm::EDAnalyzer
-{
-  public:
-
+class SurveyDBReader : public edm::EDAnalyzer {
+public:
   /// Set file name
-  SurveyDBReader(
-		 const edm::ParameterSet&
-		 );
+  SurveyDBReader(const edm::ParameterSet&);
 
   /// Read from DB and print survey info.
   virtual void beginJob() { theFirstEvent = true; }
 
-  virtual void analyze(
-		       const edm::Event&,
-		       const edm::EventSetup&
-		       );
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-  private:
-
+private:
   std::string theFileName;
 
   bool theFirstEvent;

--- a/Alignment/SurveyAnalysis/test/SurveyInputDummy.cc
+++ b/Alignment/SurveyAnalysis/test/SurveyInputDummy.cc
@@ -11,11 +11,10 @@
 
 #include "Alignment/SurveyAnalysis/test/SurveyInputDummy.h"
 
-SurveyInputDummy::SurveyInputDummy(const edm::ParameterSet& cfg):
-  theRandomizeValue( cfg.getParameter<bool>("randomizeValue") )
-{
+SurveyInputDummy::SurveyInputDummy(const edm::ParameterSet& cfg)
+    : theRandomizeValue(cfg.getParameter<bool>("randomizeValue")) {
   typedef std::vector<edm::ParameterSet> ParameterSets;
- 
+
   const ParameterSets& errors = cfg.getParameter<ParameterSets>("errors");
 
   unsigned int nError = errors.size();
@@ -24,17 +23,15 @@ SurveyInputDummy::SurveyInputDummy(const edm::ParameterSet& cfg):
   //        - check this, when resurrecting this code in the future
   AlignableObjectId alignableObjectId{AlignableObjectId::Geometry::General};
 
-  for (unsigned int i = 0; i < nError; ++i)
-  {
+  for (unsigned int i = 0; i < nError; ++i) {
     const edm::ParameterSet& error = errors[i];
 
-    theErrors[alignableObjectId.stringToId( error.getParameter<std::string>("level") )]
-      = error.getParameter<double>("value");
+    theErrors[alignableObjectId.stringToId(error.getParameter<std::string>("level"))] =
+        error.getParameter<double>("value");
   }
 }
 
-void SurveyInputDummy::analyze(const edm::Event&, const edm::EventSetup& setup)
-{
+void SurveyInputDummy::analyze(const edm::Event&, const edm::EventSetup& setup) {
   if (theFirstEvent) {
     //Retrieve tracker topology from geometry
     edm::ESHandle<TrackerTopology> tTopoHandle;
@@ -42,10 +39,10 @@ void SurveyInputDummy::analyze(const edm::Event&, const edm::EventSetup& setup)
     const TrackerTopology* const tTopo = tTopoHandle.product();
 
     edm::ESHandle<TrackerGeometry> tracker;
-    setup.get<TrackerDigiGeometryRecord>().get( tracker );
-    
-    Alignable* ali = new AlignableTracker( &*tracker, tTopo );
-    
+    setup.get<TrackerDigiGeometryRecord>().get(tracker);
+
+    Alignable* ali = new AlignableTracker(&*tracker, tTopo);
+
     addSurveyInfo(ali);
     addComponent(ali);
 
@@ -53,26 +50,24 @@ void SurveyInputDummy::analyze(const edm::Event&, const edm::EventSetup& setup)
   }
 }
 
-void SurveyInputDummy::addSurveyInfo(Alignable* ali)
-{
+void SurveyInputDummy::addSurveyInfo(Alignable* ali) {
   static TRandom3 rand;
 
   const align::Alignables& comp = ali->components();
 
   unsigned int nComp = comp.size();
 
-  for (unsigned int i = 0; i < nComp; ++i) addSurveyInfo(comp[i]);
+  for (unsigned int i = 0; i < nComp; ++i)
+    addSurveyInfo(comp[i]);
 
-  align::ErrorMatrix cov; // default 0
+  align::ErrorMatrix cov;  // default 0
 
-  std::map<align::StructureType, double>::const_iterator e = theErrors.find( ali->alignableObjectId() );
+  std::map<align::StructureType, double>::const_iterator e = theErrors.find(ali->alignableObjectId());
 
-  if (theErrors.end() != e)
-  {
+  if (theErrors.end() != e) {
     double error = e->second;
 
-    if (theRandomizeValue)
-    {
+    if (theRandomizeValue) {
       double x = rand.Gaus(0., error);
       double y = rand.Gaus(0., error);
       double z = rand.Gaus(0., error);
@@ -82,15 +77,17 @@ void SurveyInputDummy::addSurveyInfo(Alignable* ali)
 
       align::EulerAngles angles(3);
 
-      angles(1) = a; angles(2) = b; angles(3) = g;
+      angles(1) = a;
+      angles(2) = b;
+      angles(3) = g;
 
-      ali->move( ali->surface().toGlobal( align::LocalVector(x, y, z) ) );
-      ali->rotateInLocalFrame( align::toMatrix(angles) );
+      ali->move(ali->surface().toGlobal(align::LocalVector(x, y, z)));
+      ali->rotateInLocalFrame(align::toMatrix(angles));
     }
 
     cov = ROOT::Math::SMatrixIdentity();
     cov *= error * error;
   }
 
-  ali->setSurvey( new SurveyDet(ali->surface(), cov) );
+  ali->setSurvey(new SurveyDet(ali->surface(), cov));
 }

--- a/Alignment/SurveyAnalysis/test/SurveyInputDummy.h
+++ b/Alignment/SurveyAnalysis/test/SurveyInputDummy.h
@@ -32,29 +32,18 @@
 
 #include <map>
 
-class SurveyInputDummy:
-  public SurveyInputBase
-{
-  public:
-
-  SurveyInputDummy(
-		   const edm::ParameterSet&
-		   );
+class SurveyInputDummy : public SurveyInputBase {
+public:
+  SurveyInputDummy(const edm::ParameterSet&);
 
   /// Read ideal tracker geometry from DB
-  virtual void analyze(
-		       const edm::Event&,
-		       const edm::EventSetup&
-		       );
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-  private:
-
+private:
   /// Add survey info to an alignable
-  void addSurveyInfo(
-		     Alignable*
-		     );
+  void addSurveyInfo(Alignable*);
 
-  bool theRandomizeValue; // randomize survey values if true
+  bool theRandomizeValue;  // randomize survey values if true
 
   std::map<align::StructureType, double> theErrors;
 };

--- a/Alignment/SurveyAnalysis/test/SurveyInputTest.cc
+++ b/Alignment/SurveyAnalysis/test/SurveyInputTest.cc
@@ -6,19 +6,12 @@
 
 using namespace align;
 
-SurveyInputTest::SurveyInputTest(const edm::ParameterSet& cfg):
-  theConfig(cfg)
-{
-}
+SurveyInputTest::SurveyInputTest(const edm::ParameterSet& cfg) : theConfig(cfg) {}
 
-void SurveyInputTest::beginJob()
-{
-  addComponent( create( theConfig.getParameter<std::string>("detector") ) );
-}
+void SurveyInputTest::beginJob() { addComponent(create(theConfig.getParameter<std::string>("detector"))); }
 
-Alignable* SurveyInputTest::create(const std::string& parName)
-{
-  typedef std::vector<double>      Doubles;
+Alignable* SurveyInputTest::create(const std::string& parName) {
+  typedef std::vector<double> Doubles;
   typedef std::vector<std::string> Strings;
 
   static const Doubles zero3Vector(3, 0.);
@@ -34,42 +27,43 @@ Alignable* SurveyInputTest::create(const std::string& parName)
 
   ErrorMatrix cov;
 
-  for (unsigned int i = 0; i < 6; ++i) cov(i, i) = errors[i];
+  for (unsigned int i = 0; i < 6; ++i)
+    cov(i, i) = errors[i];
 
   PositionType pos(center[0], center[1], center[2]);
   EulerAngles ang(3);
 
-  ang(1) = angles[0], ang(2) = angles[1]; ang(3) = angles[2];
+  ang(1) = angles[0], ang(2) = angles[1];
+  ang(3) = angles[2];
 
-  AlignableSurface surf( pos, toMatrix(ang) );
+  AlignableSurface surf(pos, toMatrix(ang));
 
-  surf.setWidth ( pars.getUntrackedParameter<double>("width" , 0.) );
-  surf.setLength( pars.getUntrackedParameter<double>("length", 0.) );
+  surf.setWidth(pars.getUntrackedParameter<double>("width", 0.));
+  surf.setLength(pars.getUntrackedParameter<double>("length", 0.));
 
-          int type = pars.getParameter<int>        ("typeId");
+  int type = pars.getParameter<int>("typeId");
   std::string name = pars.getParameter<std::string>("object");
 
   // FIXME: - currently defaulting to RunI as this was the previous behaviour
   //        - check this, when resurrecting this code in the future
   AlignableObjectId alignableObjectId{AlignableObjectId::Geometry::General};
 
-  Alignable* ali = new AlignableComposite( type, alignableObjectId.stringToId(name),
-					   surf.rotation() );
+  Alignable* ali = new AlignableComposite(type, alignableObjectId.stringToId(name), surf.rotation());
 
   Strings comp = pars.getUntrackedParameter<Strings>("compon", emptyString);
 
   unsigned int nComp = comp.size();
 
-  for (unsigned int i = 0; i < nComp; ++i)
-  {
-    ali->addComponent( create(comp[i]) );
+  for (unsigned int i = 0; i < nComp; ++i) {
+    ali->addComponent(create(comp[i]));
   }
 
-  ang(1) = shifts[3], ang(2) = shifts[4]; ang(3) = shifts[5];
+  ang(1) = shifts[3], ang(2) = shifts[4];
+  ang(3) = shifts[5];
 
-  ali->setSurvey( new SurveyDet(surf, cov) );
-  ali->move( surf.toGlobal( align::LocalVector(shifts[0], shifts[1], shifts[2]) ) );
-  ali->rotateInLocalFrame( toMatrix(ang) );
+  ali->setSurvey(new SurveyDet(surf, cov));
+  ali->move(surf.toGlobal(align::LocalVector(shifts[0], shifts[1], shifts[2])));
+  ali->rotateInLocalFrame(toMatrix(ang));
 
   return ali;
 }

--- a/Alignment/SurveyAnalysis/test/SurveyInputTest.h
+++ b/Alignment/SurveyAnalysis/test/SurveyInputTest.h
@@ -13,28 +13,18 @@
 #include "Alignment/SurveyAnalysis/interface/SurveyInputBase.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class SurveyInputTest:
-  public SurveyInputBase
-{
-  public:
-
-  SurveyInputTest(
-		  const edm::ParameterSet&
-		  );
+class SurveyInputTest : public SurveyInputBase {
+public:
+  SurveyInputTest(const edm::ParameterSet&);
 
   /// Read data from cfg file
   virtual void beginJob();
-  
-  virtual void analyze(
-		       const edm::Event&,
-		       const edm::EventSetup&
-		       ) {}
 
-  private:
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) {}
 
-  Alignable* create(
-		    const std::string& parName // name of alignable
-		    );
+private:
+  Alignable* create(const std::string& parName  // name of alignable
+  );
 
   edm::ParameterSet theConfig;
 };

--- a/Alignment/SurveyAnalysis/test/SurveyTest.cc
+++ b/Alignment/SurveyAnalysis/test/SurveyTest.cc
@@ -8,12 +8,11 @@
 
 #include "Alignment/SurveyAnalysis/test/SurveyTest.h"
 
-SurveyTest::SurveyTest(const edm::ParameterSet& cfg):
-  theBiasFlag( cfg.getUntrackedParameter<bool>("bias", false) ),
-  theIterations( cfg.getParameter<unsigned int>("iterator") ),
-  theAlgorithm ( cfg.getParameter<std::string>("algorith") ),
-  theOutputFile( cfg.getParameter<std::string>("fileName") )
-{
+SurveyTest::SurveyTest(const edm::ParameterSet& cfg)
+    : theBiasFlag(cfg.getUntrackedParameter<bool>("bias", false)),
+      theIterations(cfg.getParameter<unsigned int>("iterator")),
+      theAlgorithm(cfg.getParameter<std::string>("algorith")),
+      theOutputFile(cfg.getParameter<std::string>("fileName")) {
   typedef std::vector<std::string> Strings;
 
   const Strings& hierarchy = cfg.getParameter<Strings>("hierarch");
@@ -22,14 +21,12 @@ SurveyTest::SurveyTest(const edm::ParameterSet& cfg):
   //        - check this, when resurrecting this code in the future
   AlignableObjectId alignableObjectId{AlignableObjectId::Geometry::General};
 
-  for (unsigned int l = 0; l < hierarchy.size(); ++l)
-  {
-    theHierarchy.push_back(alignableObjectId.stringToId(hierarchy[l]) );
+  for (unsigned int l = 0; l < hierarchy.size(); ++l) {
+    theHierarchy.push_back(alignableObjectId.stringToId(hierarchy[l]));
   }
 }
 
-void SurveyTest::beginJob()
-{
+void SurveyTest::beginJob() {
   Alignable* det = SurveyInputBase::detector();
 
   align::Alignables sensors;
@@ -43,20 +40,17 @@ void SurveyTest::beginJob()
 
   algos[theAlgorithm]->iterate(theIterations, theOutputFile, theBiasFlag);
 
-  for (std::map<std::string, SurveyAlignment*>::iterator i = algos.begin();
-       i != algos.end(); ++i) delete i->second;
+  for (std::map<std::string, SurveyAlignment*>::iterator i = algos.begin(); i != algos.end(); ++i)
+    delete i->second;
 }
 
-void SurveyTest::getTerminals(align::Alignables& terminals,
-			      Alignable* ali)
-{
+void SurveyTest::getTerminals(align::Alignables& terminals, Alignable* ali) {
   const auto& comp = ali->components();
 
   unsigned int nComp = comp.size();
 
   if (nComp > 0)
-    for (unsigned int i = 0; i < nComp; ++i)
-    {
+    for (unsigned int i = 0; i < nComp; ++i) {
       getTerminals(terminals, comp[i]);
     }
   else

--- a/Alignment/SurveyAnalysis/test/SurveyTest.h
+++ b/Alignment/SurveyAnalysis/test/SurveyTest.h
@@ -14,27 +14,23 @@
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 
-class SurveyTest:
-  public edm::EDAnalyzer
-{
-  public:
-
+class SurveyTest : public edm::EDAnalyzer {
+public:
   SurveyTest(const edm::ParameterSet&);
 
   virtual void beginJob();
 
   virtual void analyze(const edm::Event&, const edm::EventSetup&) {}
 
-  private:
-
+private:
   void getTerminals(align::Alignables& terminals, Alignable* ali);
 
-  bool theBiasFlag; // true for biased residuals
+  bool theBiasFlag;  // true for biased residuals
 
-  unsigned int theIterations; // number of iterations
+  unsigned int theIterations;  // number of iterations
 
-  std::string theAlgorithm;  // points or sensor residual
-  std::string theOutputFile; // name of output file
+  std::string theAlgorithm;   // points or sensor residual
+  std::string theOutputFile;  // name of output file
 
   std::vector<align::StructureType> theHierarchy;
 };

--- a/Alignment/SurveyAnalysis/test/TestConverter.cpp
+++ b/Alignment/SurveyAnalysis/test/TestConverter.cpp
@@ -2,7 +2,7 @@
 //
 // Package:    TestConverter
 // Class:      TestConverter
-// 
+//
 //
 // Description: Module to test the SurveyConverter software
 //
@@ -10,7 +10,6 @@
 // Original Author:  Roberto Covarelli
 //         Created:  March 16, 2006
 //
-
 
 // system include files
 #include <string>
@@ -28,9 +27,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "CondFormats/Alignment/interface/Alignments.h"
-#include <boost/cstdint.hpp> 
+#include <boost/cstdint.hpp>
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
-#include "CLHEP/Vector/RotationInterfaces.h" 
+#include "CLHEP/Vector/RotationInterfaces.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
 
@@ -44,27 +43,27 @@
 //
 
 class TestConverter : public edm::EDAnalyzer {
-
-  typedef SurveyDataReader::MapType    MapType;
-  typedef SurveyDataReader::PairType   PairType;
-  typedef SurveyDataReader::MapTypeOr  MapTypeOr;
+  typedef SurveyDataReader::MapType MapType;
+  typedef SurveyDataReader::PairType PairType;
+  typedef SurveyDataReader::MapTypeOr MapTypeOr;
   typedef SurveyDataReader::PairTypeOr PairTypeOr;
 
 public:
-  explicit TestConverter( const edm::ParameterSet& );
+  explicit TestConverter(const edm::ParameterSet&);
   ~TestConverter();
-  
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
 private:
   // ----------member data ---------------------------
   TTree* theTree;
   TFile* theFile;
   edm::ParameterSet theParameterSet;
-  float dx_,dy_,dz_;
-  float dtx_,dty_,dtz_;
-  float dkx_,dky_,dkz_;
-  float dnx_,dny_,dnz_;
-  float errx_,erry_,errz_; 
+  float dx_, dy_, dz_;
+  float dtx_, dty_, dtz_;
+  float dkx_, dky_, dkz_;
+  float dnx_, dny_, dnz_;
+  float errx_, erry_, errz_;
   int Id_;
   // TRotMatrix* rot_;
 
@@ -74,46 +73,36 @@ private:
 //
 // constructors and destructor
 //
-TestConverter::TestConverter( const edm::ParameterSet& iConfig ) :
-  theParameterSet( iConfig )
-{ 
-  
+TestConverter::TestConverter(const edm::ParameterSet& iConfig) : theParameterSet(iConfig) {
   // Open root file and define tree
-  std::string fileName = theParameterSet.getUntrackedParameter<std::string>("fileName","test.root");
-  theFile = new TFile( fileName.c_str(), "RECREATE" );
-  theTree = new TTree( "theTree", "Detector units positions" );
-  
-  theTree->Branch("Id",     &Id_,     "Id/I"     );
-  theTree->Branch("dx",     &dx_,     "dx/F"     );
-  theTree->Branch("dy",     &dy_,     "dy/F"     );
-  theTree->Branch("dz",     &dz_,     "dz/F"     );
-  theTree->Branch("dtx",    &dtx_,    "dtx/F"    );
-  theTree->Branch("dty",    &dty_,    "dty/F"    );
-  theTree->Branch("dtz",    &dtz_,    "dtz/F"    );
-  theTree->Branch("dkx",    &dkx_,    "dkx/F"    );
-  theTree->Branch("dky",    &dky_,    "dky/F"    );
-  theTree->Branch("dkz",    &dkz_,    "dkz/F"    );
-  theTree->Branch("dnx",    &dnx_,    "dnx/F"    );
-  theTree->Branch("dny",    &dny_,    "dny/F"    );
-  theTree->Branch("dnz",    &dnz_,    "dnz/F"    ); 
-  theTree->Branch("errx",   &errx_,   "errx/F"   );
-  theTree->Branch("erry",   &erry_,   "erry/F"   );
-  theTree->Branch("errz",   &errz_,   "errz/F"   );
+  std::string fileName = theParameterSet.getUntrackedParameter<std::string>("fileName", "test.root");
+  theFile = new TFile(fileName.c_str(), "RECREATE");
+  theTree = new TTree("theTree", "Detector units positions");
+
+  theTree->Branch("Id", &Id_, "Id/I");
+  theTree->Branch("dx", &dx_, "dx/F");
+  theTree->Branch("dy", &dy_, "dy/F");
+  theTree->Branch("dz", &dz_, "dz/F");
+  theTree->Branch("dtx", &dtx_, "dtx/F");
+  theTree->Branch("dty", &dty_, "dty/F");
+  theTree->Branch("dtz", &dtz_, "dtz/F");
+  theTree->Branch("dkx", &dkx_, "dkx/F");
+  theTree->Branch("dky", &dky_, "dky/F");
+  theTree->Branch("dkz", &dkz_, "dkz/F");
+  theTree->Branch("dnx", &dnx_, "dnx/F");
+  theTree->Branch("dny", &dny_, "dny/F");
+  theTree->Branch("dnz", &dnz_, "dnz/F");
+  theTree->Branch("errx", &errx_, "errx/F");
+  theTree->Branch("erry", &erry_, "erry/F");
+  theTree->Branch("errz", &errz_, "errz/F");
 }
 
-
-TestConverter::~TestConverter()
-{ 
-  
+TestConverter::~TestConverter() {
   theTree->Write();
   theFile->Close();
-  
 }
 
-
-void
-TestConverter::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void TestConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::LogInfo("TrackerAlignment") << "Starting!";
 
   //Retrieve tracker topology from geometry
@@ -123,21 +112,21 @@ TestConverter::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
 
   //
   // Read in the survey information from the text files
-  // 
-  edm::ParameterSet textFiles = theParameterSet.getParameter<edm::ParameterSet>( "textFileNames" );
-  std::string textFileNames[NFILES]; 
-  std::string fileType[NFILES];    
-  textFileNames[0] = textFiles.getUntrackedParameter<std::string>("forTIB","NONE");  
+  //
+  edm::ParameterSet textFiles = theParameterSet.getParameter<edm::ParameterSet>("textFileNames");
+  std::string textFileNames[NFILES];
+  std::string fileType[NFILES];
+  textFileNames[0] = textFiles.getUntrackedParameter<std::string>("forTIB", "NONE");
   fileType[0] = "TIB";
-  textFileNames[1] = textFiles.getUntrackedParameter<std::string>("forTID","NONE");
+  textFileNames[1] = textFiles.getUntrackedParameter<std::string>("forTID", "NONE");
   fileType[1] = "TID";
 
   SurveyDataReader dataReader;
-  for (int ii=0 ; ii<NFILES ;ii++) {
-    if ( textFileNames[ii] == "NONE" )
+  for (int ii = 0; ii < NFILES; ii++) {
+    if (textFileNames[ii] == "NONE")
       throw cms::Exception("BadConfig") << fileType[ii] << " input file not found in configuration";
-    dataReader.readFile( textFileNames[ii], fileType[ii], tTopo );
-  } 
+    dataReader.readFile(textFileNames[ii], fileType[ii], tTopo);
+  }
 
   edm::LogInfo("TrackerAlignment") << "Files read";
 
@@ -153,20 +142,19 @@ TestConverter::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
 
   // Retrieve alignment[Error]s from DBase
   edm::ESHandle<Alignments> alignments;
-  iSetup.get<TrackerAlignmentRcd>().get( alignments );
+  iSetup.get<TrackerAlignmentRcd>().get(alignments);
   edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get( alignmentErrors );
-  
+  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
+
   std::vector<AlignTransformErrorExtended> alignErrors = alignmentErrors->m_alignError;
   // int countDet = 0;
 
   // Now loop on detector units, and store difference position and orientation w.r.t. survey
-  
-   for ( std::vector<AlignTransform>::const_iterator iGeomDet = alignments->m_align.begin();
-		iGeomDet != alignments->m_align.end(); iGeomDet++ )
-	{
-          
-          /* if (countDet == 0) countDet = countDet + 3;
+
+  for (std::vector<AlignTransform>::const_iterator iGeomDet = alignments->m_align.begin();
+       iGeomDet != alignments->m_align.end();
+       iGeomDet++) {
+    /* if (countDet == 0) countDet = countDet + 3;
 	  unsigned int comparisonVect[6] = {0,0,0,0,0,0};
 	  
 	  DetId * thisId = new DetId( (*iGeomDet).rawId() );
@@ -197,75 +185,92 @@ TestConverter::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup 
 	  if (countDet == 0) { // Store only r-phi for double-sided modules
           */
 
-	  for ( MapTypeOr::const_iterator it = theSurveyMap.begin(); it != theSurveyMap.end(); it++ ) {
-	      const std::vector<int>& locPos = (it)->first;
-	      const align::Scalars& align_params = (it)->second;
-	      
-	      /* if (locPos[0] == int(comparisonVect[0]) &&
+    for (MapTypeOr::const_iterator it = theSurveyMap.begin(); it != theSurveyMap.end(); it++) {
+      const std::vector<int>& locPos = (it)->first;
+      const align::Scalars& align_params = (it)->second;
+
+      /* if (locPos[0] == int(comparisonVect[0]) &&
 		  locPos[2] == int(comparisonVect[1]) &&
 		  locPos[3] == int(comparisonVect[2]) &&
 		  locPos[4] == int(comparisonVect[3]) &&
 		  locPos[5] == int(comparisonVect[4]) &&
 		  locPos[6] == int(comparisonVect[5]) ) { */
-                
-              int thecomparison = (int)locPos[1] - (int)(*iGeomDet).rawId();
-	      if (thecomparison == 0) {
-                
-		for ( std::vector<AlignTransformErrorExtended>::const_iterator it = alignErrors.begin();
-		      it != alignErrors.end(); it++ ) {
-		  
-		  if ((*it).rawId() == (*iGeomDet).rawId()) {
-		  
-		    CLHEP::HepRotation fromAngles = (*iGeomDet).rotation() ;
-		    align::RotationType rotation( fromAngles.xx(), fromAngles.xy(), fromAngles.xz(),
-						  fromAngles.yx(), fromAngles.yy(), fromAngles.yz(),
-						  fromAngles.zx(), fromAngles.zy(), fromAngles.zz() );
-		    
-		    Id_     = (*iGeomDet).rawId();    
-		    dx_      = (*iGeomDet).translation().x() - align_params[15]; 
-		    dy_      = (*iGeomDet).translation().y() - align_params[16];
-		    dz_      = (*iGeomDet).translation().z() - align_params[17];
-		    dtx_     = rotation.xx() - align_params[21];
-		    dty_     = rotation.xy() - align_params[22];
-		    dtz_     = rotation.xz() - align_params[23];
-		    dkx_     = rotation.yx() - align_params[24];
-		    dky_     = rotation.yy() - align_params[25];
-		    dkz_     = rotation.yz() - align_params[26];
-		    dnx_     = rotation.zx() - align_params[18];
-		    dny_     = rotation.zy() - align_params[19];
-		    dnz_     = rotation.zz() - align_params[20];
-                    CLHEP::HepSymMatrix errMat = (*it).matrix();
-                    errx_    = sqrt(errMat[0][0]); 
-		    erry_    = sqrt(errMat[1][1]);
-		    errz_    = sqrt(errMat[2][2]); 
-		    
-		    theTree->Fill();
-		    
-		    // if (dkx_ > 0.04) {
-		    edm::LogInfo("TrackerAlignment") << "DetId = " << Id_ << "\n"
-		     << "DetId decodified = " << locPos[0] << " " << locPos[2] << " " << locPos[3] << " " << locPos[4] << " " << locPos[5] << " " << locPos[6] << "\n"
-		     << "X pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().x() << " / SURVEY RICCARDO = " << align_params[15] << "\n"
-		     << "Y pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().y() << " / SURVEY RICCARDO = " << align_params[16] << "\n"
-		     << "Z pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().z() << " / SURVEY RICCARDO = " << align_params[17] << "\n"
-		     << "SPATIAL DISTANCE = " << std::fixed << std::setprecision(3) << sqrt(pow(dx_,2)+pow(dy_,2)+pow(dz_,2)) << "\n"
-		     << "Trans vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xx() << " / SURVEY RICCARDO = " << align_params[21] << "\n"
-		     << "Trans vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xy() << " / SURVEY RICCARDO = " << align_params[22] << "\n"
-		     << "Trans vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xz() << " / SURVEY RICCARDO = " << align_params[23] << "\n" 
-		     << "Long vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yx() << " / SURVEY RICCARDO = " << align_params[24] << "\n"	
-		     << "Long vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yy() << " / SURVEY RICCARDO = " << align_params[25] << "\n"  
-		     << "Long vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yz() << " / SURVEY RICCARDO = " << align_params[26] << "\n"
-		     << "Norm vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zx() << " / SURVEY RICCARDO = " << align_params[18] << "\n"
-		     << "Norm vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zy() << " / SURVEY RICCARDO = " << align_params[19] << "\n" 
-		     << "Norm vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zz() << " / SURVEY RICCARDO = " << align_params[20]; 
-		      // }
-		  }
-		}
-	      }
-	    }	  
-	  } 
-   //}
-  edm::LogInfo("TrackerAlignment") << "Done!";
 
+      int thecomparison = (int)locPos[1] - (int)(*iGeomDet).rawId();
+      if (thecomparison == 0) {
+        for (std::vector<AlignTransformErrorExtended>::const_iterator it = alignErrors.begin(); it != alignErrors.end();
+             it++) {
+          if ((*it).rawId() == (*iGeomDet).rawId()) {
+            CLHEP::HepRotation fromAngles = (*iGeomDet).rotation();
+            align::RotationType rotation(fromAngles.xx(),
+                                         fromAngles.xy(),
+                                         fromAngles.xz(),
+                                         fromAngles.yx(),
+                                         fromAngles.yy(),
+                                         fromAngles.yz(),
+                                         fromAngles.zx(),
+                                         fromAngles.zy(),
+                                         fromAngles.zz());
+
+            Id_ = (*iGeomDet).rawId();
+            dx_ = (*iGeomDet).translation().x() - align_params[15];
+            dy_ = (*iGeomDet).translation().y() - align_params[16];
+            dz_ = (*iGeomDet).translation().z() - align_params[17];
+            dtx_ = rotation.xx() - align_params[21];
+            dty_ = rotation.xy() - align_params[22];
+            dtz_ = rotation.xz() - align_params[23];
+            dkx_ = rotation.yx() - align_params[24];
+            dky_ = rotation.yy() - align_params[25];
+            dkz_ = rotation.yz() - align_params[26];
+            dnx_ = rotation.zx() - align_params[18];
+            dny_ = rotation.zy() - align_params[19];
+            dnz_ = rotation.zz() - align_params[20];
+            CLHEP::HepSymMatrix errMat = (*it).matrix();
+            errx_ = sqrt(errMat[0][0]);
+            erry_ = sqrt(errMat[1][1]);
+            errz_ = sqrt(errMat[2][2]);
+
+            theTree->Fill();
+
+            // if (dkx_ > 0.04) {
+            edm::LogInfo("TrackerAlignment")
+                << "DetId = " << Id_ << "\n"
+                << "DetId decodified = " << locPos[0] << " " << locPos[2] << " " << locPos[3] << " " << locPos[4] << " "
+                << locPos[5] << " " << locPos[6] << "\n"
+                << "X pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().x()
+                << " / SURVEY RICCARDO = " << align_params[15] << "\n"
+                << "Y pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().y()
+                << " / SURVEY RICCARDO = " << align_params[16] << "\n"
+                << "Z pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().z()
+                << " / SURVEY RICCARDO = " << align_params[17] << "\n"
+                << "SPATIAL DISTANCE = " << std::fixed << std::setprecision(3)
+                << sqrt(pow(dx_, 2) + pow(dy_, 2) + pow(dz_, 2)) << "\n"
+                << "Trans vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xx()
+                << " / SURVEY RICCARDO = " << align_params[21] << "\n"
+                << "Trans vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xy()
+                << " / SURVEY RICCARDO = " << align_params[22] << "\n"
+                << "Trans vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xz()
+                << " / SURVEY RICCARDO = " << align_params[23] << "\n"
+                << "Long vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yx()
+                << " / SURVEY RICCARDO = " << align_params[24] << "\n"
+                << "Long vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yy()
+                << " / SURVEY RICCARDO = " << align_params[25] << "\n"
+                << "Long vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yz()
+                << " / SURVEY RICCARDO = " << align_params[26] << "\n"
+                << "Norm vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zx()
+                << " / SURVEY RICCARDO = " << align_params[18] << "\n"
+                << "Norm vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zy()
+                << " / SURVEY RICCARDO = " << align_params[19] << "\n"
+                << "Norm vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zz()
+                << " / SURVEY RICCARDO = " << align_params[20];
+            // }
+          }
+        }
+      }
+    }
+  }
+  //}
+  edm::LogInfo("TrackerAlignment") << "Done!";
 }
 
 //define this as a plug-in

--- a/Alignment/SurveyAnalysis/test/TestConverter2.cpp
+++ b/Alignment/SurveyAnalysis/test/TestConverter2.cpp
@@ -2,7 +2,7 @@
 //
 // Package:    TestConverter2
 // Class:      TestConverter2
-// 
+//
 //
 // Description: Module to test the SurveyConverter software
 //
@@ -10,7 +10,6 @@
 // Original Author:  Roberto Covarelli
 //         Created:  March 16, 2006
 //
-
 
 // system include files
 #include <string>
@@ -32,9 +31,9 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "CondFormats/Alignment/interface/Alignments.h"
-#include <boost/cstdint.hpp> 
+#include <boost/cstdint.hpp>
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
-#include "CLHEP/Vector/RotationInterfaces.h" 
+#include "CLHEP/Vector/RotationInterfaces.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
 
@@ -48,215 +47,208 @@
 using namespace std;
 
 class TestConverter2 : public edm::EDAnalyzer {
-
 public:
-  explicit TestConverter2( const edm::ParameterSet& );
+  explicit TestConverter2(const edm::ParameterSet&);
   ~TestConverter2();
-  
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
 private:
   // ----------member data ---------------------------
   TTree* theTree;
   TFile* theFile;
   edm::ParameterSet theParameterSet;
-  float dx_,dy_,dz_;
-  float dtx_,dty_,dtz_;
-  float dkx_,dky_,dkz_;
-  float dnx_,dny_,dnz_;
-  float errx_,erry_,errz_; 
+  float dx_, dy_, dz_;
+  float dtx_, dty_, dtz_;
+  float dkx_, dky_, dkz_;
+  float dnx_, dny_, dnz_;
+  float errx_, erry_, errz_;
   int subdid_, fwbw_, layerdisk_, frontback_, stringrod_, petal_, module_;
   // TRotMatrix* rot_;
-
 };
 
 //
 // constructors and destructor
 //
-TestConverter2::TestConverter2( const edm::ParameterSet& iConfig ) :
-  theParameterSet( iConfig )
-{ 
-  
+TestConverter2::TestConverter2(const edm::ParameterSet& iConfig) : theParameterSet(iConfig) {
   // Open root file and define tree
-  std::string fileName = theParameterSet.getUntrackedParameter<std::string>("fileName","test.root");
-  theFile = new TFile( fileName.c_str(), "RECREATE" );
-  theTree = new TTree( "theTree", "Detector units positions" );
-  
-  theTree->Branch("subDetId",     &subdid_,     "subDetId/I"     );
-  theTree->Branch("Fw_Bw",        &fwbw_,       "Fw_Bw/I"        );
-  theTree->Branch("FrBa_InEx",    &frontback_,  "FrBa_inEx/I"    );
-  theTree->Branch("LayerDisk",    &layerdisk_,  "LayerDisk/I"    );
-  theTree->Branch("Petal",        &petal_,      "Petal/I"        );
-  theTree->Branch("StRingRod",    &stringrod_,  "StRingRod/I"    );
-  theTree->Branch("Module",       &module_,     "Module/I"       );
-  theTree->Branch("dx",     &dx_,     "dx/F"     );
-  theTree->Branch("dy",     &dy_,     "dy/F"     );
-  theTree->Branch("dz",     &dz_,     "dz/F"     );
-  theTree->Branch("dtx",    &dtx_,    "dtx/F"    );
-  theTree->Branch("dty",    &dty_,    "dty/F"    );
-  theTree->Branch("dtz",    &dtz_,    "dtz/F"    );
-  theTree->Branch("dkx",    &dkx_,    "dkx/F"    );
-  theTree->Branch("dky",    &dky_,    "dky/F"    );
-  theTree->Branch("dkz",    &dkz_,    "dkz/F"    );
-  theTree->Branch("dnx",    &dnx_,    "dnx/F"    );
-  theTree->Branch("dny",    &dny_,    "dny/F"    );
-  theTree->Branch("dnz",    &dnz_,    "dnz/F"    ); 
-  theTree->Branch("errx",   &errx_,   "errx/F"   );
-  theTree->Branch("erry",   &erry_,   "erry/F"   );
-  theTree->Branch("errz",   &errz_,   "errz/F"   );
+  std::string fileName = theParameterSet.getUntrackedParameter<std::string>("fileName", "test.root");
+  theFile = new TFile(fileName.c_str(), "RECREATE");
+  theTree = new TTree("theTree", "Detector units positions");
+
+  theTree->Branch("subDetId", &subdid_, "subDetId/I");
+  theTree->Branch("Fw_Bw", &fwbw_, "Fw_Bw/I");
+  theTree->Branch("FrBa_InEx", &frontback_, "FrBa_inEx/I");
+  theTree->Branch("LayerDisk", &layerdisk_, "LayerDisk/I");
+  theTree->Branch("Petal", &petal_, "Petal/I");
+  theTree->Branch("StRingRod", &stringrod_, "StRingRod/I");
+  theTree->Branch("Module", &module_, "Module/I");
+  theTree->Branch("dx", &dx_, "dx/F");
+  theTree->Branch("dy", &dy_, "dy/F");
+  theTree->Branch("dz", &dz_, "dz/F");
+  theTree->Branch("dtx", &dtx_, "dtx/F");
+  theTree->Branch("dty", &dty_, "dty/F");
+  theTree->Branch("dtz", &dtz_, "dtz/F");
+  theTree->Branch("dkx", &dkx_, "dkx/F");
+  theTree->Branch("dky", &dky_, "dky/F");
+  theTree->Branch("dkz", &dkz_, "dkz/F");
+  theTree->Branch("dnx", &dnx_, "dnx/F");
+  theTree->Branch("dny", &dny_, "dny/F");
+  theTree->Branch("dnz", &dnz_, "dnz/F");
+  theTree->Branch("errx", &errx_, "errx/F");
+  theTree->Branch("erry", &erry_, "erry/F");
+  theTree->Branch("errz", &errz_, "errz/F");
 }
 
-
-TestConverter2::~TestConverter2()
-{ 
-  
+TestConverter2::~TestConverter2() {
   theTree->Write();
   theFile->Close();
-  
 }
 
-
-void
-TestConverter2::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void TestConverter2::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
-
-   
   edm::LogInfo("TrackerAlignment") << "Starting!";
 
   //
   // Retrieve tracker geometry from event setup
   edm::ESHandle<TrackerGeometry> trackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get( trackerGeometry );
+  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
 
   // Retrieve alignment[Error]s from DBase
   edm::ESHandle<Alignments> alignments;
-  iSetup.get<TrackerAlignmentRcd>().get( alignments );
+  iSetup.get<TrackerAlignmentRcd>().get(alignments);
   edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get( alignmentErrors );
-  
+  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
+
   auto alignErrors = alignmentErrors->m_alignError;
 
   // Now loop on detector units, and store difference position and orientation w.r.t. survey
-  
-   for ( auto iGeomDet = alignments->m_align.begin();
-		iGeomDet != alignments->m_align.end(); iGeomDet++ )
-	{
-	  
-	  for ( auto iDet = trackerGeometry->dets().begin();
-		iDet != trackerGeometry->dets().end(); iDet++ )
-	    {
-              
-	      // std::cout << (*iDet)->geographicalId().rawId() << " " << (*iGeomDet).rawId() << std::endl;
-              if ((*iDet)->geographicalId().rawId() == (*iGeomDet).rawId()) {
-                
-		for ( auto it = alignErrors.begin();
-		      it != alignErrors.end(); it++ ) {
-		  
-		  if ((*it).rawId() == (*iGeomDet).rawId()) {
-		  
-		    DetId thisId((*iGeomDet).rawId());
-		    
-		    if (thisId.subdetId() == int(StripSubdetector::TIB) ) {
-		      
-		      subdid_ = 3;
-		      layerdisk_ = tTopo->tibLayer(thisId); 
-		      std::vector<unsigned int> theString = tTopo->tibStringInfo(thisId);
-		      fwbw_ = theString[0];
-		      frontback_ = theString[1];
-		      stringrod_ = theString[2];
-		      petal_ = 0;
-		      module_ = tTopo->tibModule(thisId);
 
-		    } else if (thisId.subdetId() == int(StripSubdetector::TID) ) {
-		      
-		      subdid_ = 4;
-		      layerdisk_ = tTopo->tidWheel(thisId); 
-		      std::vector<unsigned int> theModule = tTopo->tidModuleInfo(thisId);
-		      frontback_ = theModule[0];
-		      module_ = theModule[1];
-		      petal_ = 0;
-		      fwbw_ = tTopo->tidSide(thisId);
-		      stringrod_ = tTopo->tidRing(thisId);
-		     
-		    } else if (thisId.subdetId() == int(StripSubdetector::TOB) ) {
-		      
-		      subdid_ = 5;
-		      layerdisk_ = tTopo->tobLayer(thisId); 
-		      std::vector<unsigned int> theRod = tTopo->tobRodInfo(thisId);
-		      fwbw_ = theRod[0];
-		      stringrod_ = theRod[1];
-		      petal_ = 0;
-		      frontback_ = 0;
-		      module_ = tTopo->tobModule(thisId);
-		      
-		    } else if (thisId.subdetId() == int(StripSubdetector::TEC) ) {
-		      
-		      subdid_ = 6;
-		      layerdisk_ = tTopo->tecWheel(thisId); 
-		      std::vector<unsigned int> thePetal = tTopo->tecPetalInfo(thisId);
-		      frontback_ = thePetal[0];
-		      petal_ = thePetal[1];
-		      fwbw_ = tTopo->tecSide(thisId);
-		      stringrod_ = tTopo->tecRing(thisId);
-		      module_ = tTopo->tecModule(thisId);
-		         
-		    } else {
-		      std::cout << "WARNING!!! this DetId (" << thisId.rawId() << ") does not belong to SiStrip tracker" << std::endl;
-		      break;
-		    }
+  for (auto iGeomDet = alignments->m_align.begin(); iGeomDet != alignments->m_align.end(); iGeomDet++) {
+    for (auto iDet = trackerGeometry->dets().begin(); iDet != trackerGeometry->dets().end(); iDet++) {
+      // std::cout << (*iDet)->geographicalId().rawId() << " " << (*iGeomDet).rawId() << std::endl;
+      if ((*iDet)->geographicalId().rawId() == (*iGeomDet).rawId()) {
+        for (auto it = alignErrors.begin(); it != alignErrors.end(); it++) {
+          if ((*it).rawId() == (*iGeomDet).rawId()) {
+            DetId thisId((*iGeomDet).rawId());
 
-		    // CLHEP::HepRotation fromAngles( (*iGeomDet).eulerAngles()  );
-                    CLHEP::HepRotation fromAngles( (*iGeomDet).rotation()  );
-		    align::RotationType rotation( fromAngles.xx(), fromAngles.xy(), fromAngles.xz(),
-						    fromAngles.yx(), fromAngles.yy(), fromAngles.yz(),
-						    fromAngles.zx(), fromAngles.zy(), fromAngles.zz() );
-		    
-		    dx_      = (*iGeomDet).translation().x() - (*iDet)->position().x(); 
-		    dy_      = (*iGeomDet).translation().y() - (*iDet)->position().y();
-		    dz_      = (*iGeomDet).translation().z() - (*iDet)->position().z();
-		    dtx_     = rotation.xx() - (*iDet)->rotation().xx();
-		    dty_     = rotation.xy() - (*iDet)->rotation().xy();
-		    dtz_     = rotation.xz() - (*iDet)->rotation().xz();
-		    dkx_     = rotation.yx() - (*iDet)->rotation().yx();
-		    dky_     = rotation.yy() - (*iDet)->rotation().yy();
-		    dkz_     = rotation.yz() - (*iDet)->rotation().yz();
-		    dnx_     = rotation.zx() - (*iDet)->rotation().zx();
-		    dny_     = rotation.zy() - (*iDet)->rotation().zy();
-		    dnz_     = rotation.zz() - (*iDet)->rotation().zz();
-                    CLHEP::HepSymMatrix errMat = (*it).matrix();
-                    errx_    = sqrt(errMat[0][0]); 
-		    erry_    = sqrt(errMat[1][1]);
-		    errz_    = sqrt(errMat[2][2]); 
-		    
-		    theTree->Fill();
-		    
-		    cout << "DetId = " << (*iGeomDet).rawId() << " " << endl;
-		    cout << "DetId decodified = " << subdid_ << " " << fwbw_ << " " << frontback_ << " " << layerdisk_ << " " << stringrod_ << " " << petal_ << " " << module_ << endl;
-		    cout << "X pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().x() << " / TRACKER_ORIGINAL = " << (*iDet)->position().x() << endl;
-		    cout << "Y pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().y() << " / TRACKER_ORIGINAL = " << (*iDet)->position().y() << endl;
-		    cout << "Z pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().z() << " / TRACKER_ORIGINAL = " << (*iDet)->position().z() << endl;
-		    cout << "SPATIAL DISTANCE = " << std::fixed << std::setprecision(3) << sqrt(pow(dx_,2)+pow(dy_,2)+pow(dz_,2)) << endl;
-		    cout << "Trans vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xx() << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().xx() << endl;
-		    cout << "Trans vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xy() << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().xy() << endl;
-		    cout << "Trans vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xz() << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().xz() << endl; 
-		    cout << "Long vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yx() << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().yx() << endl;	
-		    cout << "Long vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yy() << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().yy() << endl;  
-		    cout << "Long vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yz() << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().yz() << endl;
-		    cout << "Norm vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zx() << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().zx() << endl;
-		    cout << "Norm vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zy() << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().zy() << endl; 
-		    cout << "Norm vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zz() << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().zz() << endl; 
-		  }
-		}
-	      }
-	    }
-	}	   
-   
+            if (thisId.subdetId() == int(StripSubdetector::TIB)) {
+              subdid_ = 3;
+              layerdisk_ = tTopo->tibLayer(thisId);
+              std::vector<unsigned int> theString = tTopo->tibStringInfo(thisId);
+              fwbw_ = theString[0];
+              frontback_ = theString[1];
+              stringrod_ = theString[2];
+              petal_ = 0;
+              module_ = tTopo->tibModule(thisId);
+
+            } else if (thisId.subdetId() == int(StripSubdetector::TID)) {
+              subdid_ = 4;
+              layerdisk_ = tTopo->tidWheel(thisId);
+              std::vector<unsigned int> theModule = tTopo->tidModuleInfo(thisId);
+              frontback_ = theModule[0];
+              module_ = theModule[1];
+              petal_ = 0;
+              fwbw_ = tTopo->tidSide(thisId);
+              stringrod_ = tTopo->tidRing(thisId);
+
+            } else if (thisId.subdetId() == int(StripSubdetector::TOB)) {
+              subdid_ = 5;
+              layerdisk_ = tTopo->tobLayer(thisId);
+              std::vector<unsigned int> theRod = tTopo->tobRodInfo(thisId);
+              fwbw_ = theRod[0];
+              stringrod_ = theRod[1];
+              petal_ = 0;
+              frontback_ = 0;
+              module_ = tTopo->tobModule(thisId);
+
+            } else if (thisId.subdetId() == int(StripSubdetector::TEC)) {
+              subdid_ = 6;
+              layerdisk_ = tTopo->tecWheel(thisId);
+              std::vector<unsigned int> thePetal = tTopo->tecPetalInfo(thisId);
+              frontback_ = thePetal[0];
+              petal_ = thePetal[1];
+              fwbw_ = tTopo->tecSide(thisId);
+              stringrod_ = tTopo->tecRing(thisId);
+              module_ = tTopo->tecModule(thisId);
+
+            } else {
+              std::cout << "WARNING!!! this DetId (" << thisId.rawId() << ") does not belong to SiStrip tracker"
+                        << std::endl;
+              break;
+            }
+
+            // CLHEP::HepRotation fromAngles( (*iGeomDet).eulerAngles()  );
+            CLHEP::HepRotation fromAngles((*iGeomDet).rotation());
+            align::RotationType rotation(fromAngles.xx(),
+                                         fromAngles.xy(),
+                                         fromAngles.xz(),
+                                         fromAngles.yx(),
+                                         fromAngles.yy(),
+                                         fromAngles.yz(),
+                                         fromAngles.zx(),
+                                         fromAngles.zy(),
+                                         fromAngles.zz());
+
+            dx_ = (*iGeomDet).translation().x() - (*iDet)->position().x();
+            dy_ = (*iGeomDet).translation().y() - (*iDet)->position().y();
+            dz_ = (*iGeomDet).translation().z() - (*iDet)->position().z();
+            dtx_ = rotation.xx() - (*iDet)->rotation().xx();
+            dty_ = rotation.xy() - (*iDet)->rotation().xy();
+            dtz_ = rotation.xz() - (*iDet)->rotation().xz();
+            dkx_ = rotation.yx() - (*iDet)->rotation().yx();
+            dky_ = rotation.yy() - (*iDet)->rotation().yy();
+            dkz_ = rotation.yz() - (*iDet)->rotation().yz();
+            dnx_ = rotation.zx() - (*iDet)->rotation().zx();
+            dny_ = rotation.zy() - (*iDet)->rotation().zy();
+            dnz_ = rotation.zz() - (*iDet)->rotation().zz();
+            CLHEP::HepSymMatrix errMat = (*it).matrix();
+            errx_ = sqrt(errMat[0][0]);
+            erry_ = sqrt(errMat[1][1]);
+            errz_ = sqrt(errMat[2][2]);
+
+            theTree->Fill();
+
+            cout << "DetId = " << (*iGeomDet).rawId() << " " << endl;
+            cout << "DetId decodified = " << subdid_ << " " << fwbw_ << " " << frontback_ << " " << layerdisk_ << " "
+                 << stringrod_ << " " << petal_ << " " << module_ << endl;
+            cout << "X pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().x()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->position().x() << endl;
+            cout << "Y pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().y()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->position().y() << endl;
+            cout << "Z pos : TRACKER_MOVED = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().z()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->position().z() << endl;
+            cout << "SPATIAL DISTANCE = " << std::fixed << std::setprecision(3)
+                 << sqrt(pow(dx_, 2) + pow(dy_, 2) + pow(dz_, 2)) << endl;
+            cout << "Trans vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xx()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().xx() << endl;
+            cout << "Trans vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xy()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().xy() << endl;
+            cout << "Trans vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.xz()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().xz() << endl;
+            cout << "Long vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yx()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().yx() << endl;
+            cout << "Long vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yy()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().yy() << endl;
+            cout << "Long vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.yz()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().yz() << endl;
+            cout << "Norm vect X : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zx()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().zx() << endl;
+            cout << "Norm vect Y : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zy()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().zy() << endl;
+            cout << "Norm vect Z : TRACKER_MOVED = " << std::fixed << std::setprecision(5) << rotation.zz()
+                 << " / TRACKER_ORIGINAL = " << (*iDet)->rotation().zz() << endl;
+          }
+        }
+      }
+    }
+  }
+
   edm::LogInfo("TrackerAlignment") << "Done!";
-
 }
 
 //define this as a plug-in

--- a/Alignment/SurveyAnalysis/test/TestIdealGeometry.cpp
+++ b/Alignment/SurveyAnalysis/test/TestIdealGeometry.cpp
@@ -2,7 +2,7 @@
 //
 // Package:    TestIdealGeometry
 // Class:      TestIdealGeometry
-// 
+//
 //
 // Description: Module to test the SurveyConverter software
 //
@@ -10,7 +10,6 @@
 // Original Author:  Roberto Covarelli
 //         Created:  March 16, 2006
 //
-
 
 // system include files
 #include "TTree.h"
@@ -47,26 +46,26 @@
 using namespace std;
 
 class TestIdealGeometry : public edm::EDAnalyzer {
-
-  typedef SurveyDataReader::MapType    MapType;
-  typedef SurveyDataReader::PairType   PairType;
-  typedef SurveyDataReader::MapTypeOr  MapTypeOr;
+  typedef SurveyDataReader::MapType MapType;
+  typedef SurveyDataReader::PairType PairType;
+  typedef SurveyDataReader::MapTypeOr MapTypeOr;
   typedef SurveyDataReader::PairTypeOr PairTypeOr;
 
 public:
-  explicit TestIdealGeometry( const edm::ParameterSet& );
+  explicit TestIdealGeometry(const edm::ParameterSet&);
   ~TestIdealGeometry();
-  
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
 private:
   // ----------member data ---------------------------
   TTree* theTree;
   TFile* theFile;
   edm::ParameterSet theParameterSet;
-  float dx_,dy_,dz_;
-  float dtx_,dty_,dtz_;
-  float dkx_,dky_,dkz_;
-  float dnx_,dny_,dnz_;
+  float dx_, dy_, dz_;
+  float dtx_, dty_, dtz_;
+  float dkx_, dky_, dkz_;
+  float dnx_, dny_, dnz_;
   int Id_;
   // TRotMatrix* rot_;
   static const int NFILES = 2;
@@ -75,43 +74,33 @@ private:
 //
 // constructors and destructor
 //
-TestIdealGeometry::TestIdealGeometry( const edm::ParameterSet& iConfig ) :
-  theParameterSet( iConfig )
-{ 
-  
+TestIdealGeometry::TestIdealGeometry(const edm::ParameterSet& iConfig) : theParameterSet(iConfig) {
   // Open root file and define tree
-  std::string fileName = theParameterSet.getUntrackedParameter<std::string>("fileName","testideal.root");
-  theFile = new TFile( fileName.c_str(), "RECREATE" );
-  theTree = new TTree( "theTree", "Detector units positions" );
-  
-  theTree->Branch("Id",     &Id_,     "Id/I"     );
-  theTree->Branch("dx",     &dx_,     "dx/F"     );
-  theTree->Branch("dy",     &dy_,     "dy/F"     );
-  theTree->Branch("dz",     &dz_,     "dz/F"     );
-  theTree->Branch("dtx",    &dtx_,    "dtx/F"    );
-  theTree->Branch("dty",    &dty_,    "dty/F"    );
-  theTree->Branch("dtz",    &dtz_,    "dtz/F"    );
-  theTree->Branch("dkx",    &dkx_,    "dkx/F"    );
-  theTree->Branch("dky",    &dky_,    "dky/F"    );
-  theTree->Branch("dkz",    &dkz_,    "dkz/F"    );
-  theTree->Branch("dnx",    &dnx_,    "dnx/F"    );
-  theTree->Branch("dny",    &dny_,    "dny/F"    );
-  theTree->Branch("dnz",    &dnz_,    "dnz/F"    ); 
+  std::string fileName = theParameterSet.getUntrackedParameter<std::string>("fileName", "testideal.root");
+  theFile = new TFile(fileName.c_str(), "RECREATE");
+  theTree = new TTree("theTree", "Detector units positions");
+
+  theTree->Branch("Id", &Id_, "Id/I");
+  theTree->Branch("dx", &dx_, "dx/F");
+  theTree->Branch("dy", &dy_, "dy/F");
+  theTree->Branch("dz", &dz_, "dz/F");
+  theTree->Branch("dtx", &dtx_, "dtx/F");
+  theTree->Branch("dty", &dty_, "dty/F");
+  theTree->Branch("dtz", &dtz_, "dtz/F");
+  theTree->Branch("dkx", &dkx_, "dkx/F");
+  theTree->Branch("dky", &dky_, "dky/F");
+  theTree->Branch("dkz", &dkz_, "dkz/F");
+  theTree->Branch("dnx", &dnx_, "dnx/F");
+  theTree->Branch("dny", &dny_, "dny/F");
+  theTree->Branch("dnz", &dnz_, "dnz/F");
 }
 
-
-TestIdealGeometry::~TestIdealGeometry()
-{ 
-  
+TestIdealGeometry::~TestIdealGeometry() {
   theTree->Write();
   theFile->Close();
-  
 }
 
-
-void
-TestIdealGeometry::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void TestIdealGeometry::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
@@ -121,21 +110,21 @@ TestIdealGeometry::analyze( const edm::Event& iEvent, const edm::EventSetup& iSe
 
   //
   // Read in the survey information from the text files
-  // 
-  edm::ParameterSet textFiles = theParameterSet.getParameter<edm::ParameterSet>( "textFileNames" );
-  std::string textFileNames[NFILES]; 
-  std::string fileType[NFILES];    
-  textFileNames[0] = textFiles.getUntrackedParameter<std::string>("forTIB","NONE");  
+  //
+  edm::ParameterSet textFiles = theParameterSet.getParameter<edm::ParameterSet>("textFileNames");
+  std::string textFileNames[NFILES];
+  std::string fileType[NFILES];
+  textFileNames[0] = textFiles.getUntrackedParameter<std::string>("forTIB", "NONE");
   fileType[0] = "TIB";
-  textFileNames[1] = textFiles.getUntrackedParameter<std::string>("forTID","NONE");
+  textFileNames[1] = textFiles.getUntrackedParameter<std::string>("forTID", "NONE");
   fileType[1] = "TID";
 
   SurveyDataReader dataReader;
-  for (int ii=0 ; ii<NFILES ;ii++) {
-    if ( textFileNames[ii] == "NONE" )
+  for (int ii = 0; ii < NFILES; ii++) {
+    if (textFileNames[ii] == "NONE")
       throw cms::Exception("BadConfig") << fileType[ii] << " input file not found in configuration";
-    dataReader.readFile( textFileNames[ii], fileType[ii], tTopo );
-  } 
+    dataReader.readFile(textFileNames[ii], fileType[ii], tTopo);
+  }
 
   edm::LogInfo("TrackerAlignment") << "Files read";
 
@@ -147,7 +136,7 @@ TestIdealGeometry::analyze( const edm::Event& iEvent, const edm::EventSetup& iSe
   // Retrieve tracker geometry from event setup
   //
   edm::ESHandle<TrackerGeometry> trackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get( trackerGeometry );
+  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
 
   // Retrieve alignment[Error]s from DBase
   // edm::ESHandle<Alignments> alignments;
@@ -155,93 +144,98 @@ TestIdealGeometry::analyze( const edm::Event& iEvent, const edm::EventSetup& iSe
   // edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
   // iSetup.get<TrackerAlignmentErrorExtendedRcd>().get( alignmentErrors );
 
-  int countDet = 0; 
+  int countDet = 0;
 
   // Now loop on detector units, and store difference position and orientation w.r.t. survey
-  for ( auto iGeomDet = trackerGeometry->dets().begin();
-  		iGeomDet != trackerGeometry->dets().end(); iGeomDet++ )
-    // for (auto iGeomDet = alignments->m_align.begin();
-    //	iGeomDet != alignments->m_align.end(); iGeomDet++ )
-	{
-          
-	  if (countDet == 0) {  // Enter only once for double-sided dets
+  for (auto iGeomDet = trackerGeometry->dets().begin(); iGeomDet != trackerGeometry->dets().end(); iGeomDet++)
+  // for (auto iGeomDet = alignments->m_align.begin();
+  //	iGeomDet != alignments->m_align.end(); iGeomDet++ )
+  {
+    if (countDet == 0) {  // Enter only once for double-sided dets
 
-            countDet++;
-	    unsigned int comparisonVect[6] = {0,0,0,0,0,0};
-	    
-	    if (((*iGeomDet)->geographicalId()).subdetId() == int(StripSubdetector::TIB)) {
-	      
-	      comparisonVect[0] = int(StripSubdetector::TIB);
-	      
-	      comparisonVect[1] = tTopo->tibLayer((*iGeomDet)->geographicalId());
-              if (comparisonVect[1] < 3) countDet = countDet + 2;  
-	      std::vector<unsigned int> theString = tTopo->tibStringInfo((*iGeomDet)->geographicalId());
-	      comparisonVect[2] = theString[0];
-	      comparisonVect[3] = theString[1];
-	      comparisonVect[4] = theString[2];
-	      comparisonVect[5] = tTopo->tibModule((*iGeomDet)->geographicalId());
-	      
-	    } else if (((*iGeomDet)->geographicalId()).subdetId() == int(StripSubdetector::TID)) {
-	      
-	      comparisonVect[0] = int(StripSubdetector::TID);
-	      
-	      comparisonVect[1] = tTopo->tidSide((*iGeomDet)->geographicalId());
-	      comparisonVect[2] = tTopo->tidWheel((*iGeomDet)->geographicalId());
-	      comparisonVect[3] = tTopo->tidRing((*iGeomDet)->geographicalId());
-              if (comparisonVect[3] < 3) countDet = countDet + 2; 
-	      std::vector<unsigned int> theModule = tTopo->tidModuleInfo((*iGeomDet)->geographicalId());
-	      comparisonVect[4] = theModule[0];
-	      comparisonVect[5] = theModule[1];
-	      
-	    }
+      countDet++;
+      unsigned int comparisonVect[6] = {0, 0, 0, 0, 0, 0};
 
-	    for ( MapTypeOr::const_iterator it = theSurveyMap.begin(); it != theSurveyMap.end(); it++ ) {
-	      std::vector<int> locPos = (it)->first;
-	      align::Scalars align_params = (it)->second;
-	      
-	      if (locPos[0] == int(comparisonVect[0]) &&
-		  locPos[1] == int(comparisonVect[1]) &&
-		  locPos[2] == int(comparisonVect[2]) &&
-		  locPos[3] == int(comparisonVect[3]) &&
-		  locPos[4] == int(comparisonVect[4]) &&
-		  locPos[5] == int(comparisonVect[5]) ) {
-		
-		Id_     = (*iGeomDet)->geographicalId().rawId();
-		cout << "DetId = " << Id_ << " " << endl;
-		cout << "DetId decodified = " << comparisonVect[0] << " " << comparisonVect[1] << " " << comparisonVect[2] << " " << comparisonVect[3] << " " << comparisonVect[4] << " " << comparisonVect[5] << endl;	      
-		dx_      = (*iGeomDet)->position().x() - align_params[0];
-		cout << "X pos : TRACKER_GEOM = " << std::fixed << std::setprecision(2) << (*iGeomDet)->position().x() << " / IDEAL RICCARDO = " << align_params[0] << endl; 
-		dy_      = (*iGeomDet)->position().y() - align_params[1];
-		cout << "Y pos : TRACKER_GEOM = " << std::fixed << std::setprecision(2) << (*iGeomDet)->position().y() << " / IDEAL RICCARDO = " << align_params[1] << endl;
-		dz_      = (*iGeomDet)->position().z() - align_params[2];
-		cout << "Z pos : TRACKER_GEOM = " << std::fixed << std::setprecision(2) << (*iGeomDet)->position().z() << " / IDEAL RICCARDO = " << align_params[2] << endl;
-		dtx_     = (*iGeomDet)->rotation().xx() - align_params[6];
-		cout << "Trans vect X : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().xx() << " / IDEAL RICCARDO = " << align_params[6] << endl;
-		dty_     = (*iGeomDet)->rotation().xy() - align_params[7];
-		cout << "Trans vect Y : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().xy() << " / IDEAL RICCARDO = " << align_params[7] << endl;
-		dtz_     = (*iGeomDet)->rotation().xz() - align_params[8];
-		cout << "Trans vect Z : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().xz() << " / IDEAL RICCARDO = " << align_params[8] << endl; 	
-		dkx_     = (*iGeomDet)->rotation().yx() - align_params[9];
-		cout << "Long vect X : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().yx() << " / IDEAL RICCARDO = " << align_params[9] << endl;
-		dky_     = (*iGeomDet)->rotation().yy() - align_params[10];
-		cout << "Long vect Y : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().yy() << " / IDEAL RICCARDO = " << align_params[10] << endl;
-		dkz_     = (*iGeomDet)->rotation().yz() - align_params[11];
-		cout << "Long vect Z : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().yz() << " / IDEAL RICCARDO = " << align_params[11] << endl;
-		dnx_     = (*iGeomDet)->rotation().zx() - align_params[3];
-		cout << "Norm vect X : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().zx() << " / IDEAL RICCARDO = " << align_params[3] << endl;
-		dny_     = (*iGeomDet)->rotation().zy() - align_params[4];
-		cout << "Norm vect Y : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().zy() << " / IDEAL RICCARDO = " << align_params[4] << endl;
-		dnz_     = (*iGeomDet)->rotation().zz() - align_params[5];
-		cout << "Norm vect Z : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().zz() << " / IDEAL RICCARDO = " << align_params[5] << endl; 
-		theTree->Fill();
-	      }
-	    }	  
-	  } 
-	  countDet--;
-	}
-  
+      if (((*iGeomDet)->geographicalId()).subdetId() == int(StripSubdetector::TIB)) {
+        comparisonVect[0] = int(StripSubdetector::TIB);
+
+        comparisonVect[1] = tTopo->tibLayer((*iGeomDet)->geographicalId());
+        if (comparisonVect[1] < 3)
+          countDet = countDet + 2;
+        std::vector<unsigned int> theString = tTopo->tibStringInfo((*iGeomDet)->geographicalId());
+        comparisonVect[2] = theString[0];
+        comparisonVect[3] = theString[1];
+        comparisonVect[4] = theString[2];
+        comparisonVect[5] = tTopo->tibModule((*iGeomDet)->geographicalId());
+
+      } else if (((*iGeomDet)->geographicalId()).subdetId() == int(StripSubdetector::TID)) {
+        comparisonVect[0] = int(StripSubdetector::TID);
+
+        comparisonVect[1] = tTopo->tidSide((*iGeomDet)->geographicalId());
+        comparisonVect[2] = tTopo->tidWheel((*iGeomDet)->geographicalId());
+        comparisonVect[3] = tTopo->tidRing((*iGeomDet)->geographicalId());
+        if (comparisonVect[3] < 3)
+          countDet = countDet + 2;
+        std::vector<unsigned int> theModule = tTopo->tidModuleInfo((*iGeomDet)->geographicalId());
+        comparisonVect[4] = theModule[0];
+        comparisonVect[5] = theModule[1];
+      }
+
+      for (MapTypeOr::const_iterator it = theSurveyMap.begin(); it != theSurveyMap.end(); it++) {
+        std::vector<int> locPos = (it)->first;
+        align::Scalars align_params = (it)->second;
+
+        if (locPos[0] == int(comparisonVect[0]) && locPos[1] == int(comparisonVect[1]) &&
+            locPos[2] == int(comparisonVect[2]) && locPos[3] == int(comparisonVect[3]) &&
+            locPos[4] == int(comparisonVect[4]) && locPos[5] == int(comparisonVect[5])) {
+          Id_ = (*iGeomDet)->geographicalId().rawId();
+          cout << "DetId = " << Id_ << " " << endl;
+          cout << "DetId decodified = " << comparisonVect[0] << " " << comparisonVect[1] << " " << comparisonVect[2]
+               << " " << comparisonVect[3] << " " << comparisonVect[4] << " " << comparisonVect[5] << endl;
+          dx_ = (*iGeomDet)->position().x() - align_params[0];
+          cout << "X pos : TRACKER_GEOM = " << std::fixed << std::setprecision(2) << (*iGeomDet)->position().x()
+               << " / IDEAL RICCARDO = " << align_params[0] << endl;
+          dy_ = (*iGeomDet)->position().y() - align_params[1];
+          cout << "Y pos : TRACKER_GEOM = " << std::fixed << std::setprecision(2) << (*iGeomDet)->position().y()
+               << " / IDEAL RICCARDO = " << align_params[1] << endl;
+          dz_ = (*iGeomDet)->position().z() - align_params[2];
+          cout << "Z pos : TRACKER_GEOM = " << std::fixed << std::setprecision(2) << (*iGeomDet)->position().z()
+               << " / IDEAL RICCARDO = " << align_params[2] << endl;
+          dtx_ = (*iGeomDet)->rotation().xx() - align_params[6];
+          cout << "Trans vect X : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().xx()
+               << " / IDEAL RICCARDO = " << align_params[6] << endl;
+          dty_ = (*iGeomDet)->rotation().xy() - align_params[7];
+          cout << "Trans vect Y : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().xy()
+               << " / IDEAL RICCARDO = " << align_params[7] << endl;
+          dtz_ = (*iGeomDet)->rotation().xz() - align_params[8];
+          cout << "Trans vect Z : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().xz()
+               << " / IDEAL RICCARDO = " << align_params[8] << endl;
+          dkx_ = (*iGeomDet)->rotation().yx() - align_params[9];
+          cout << "Long vect X : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().yx()
+               << " / IDEAL RICCARDO = " << align_params[9] << endl;
+          dky_ = (*iGeomDet)->rotation().yy() - align_params[10];
+          cout << "Long vect Y : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().yy()
+               << " / IDEAL RICCARDO = " << align_params[10] << endl;
+          dkz_ = (*iGeomDet)->rotation().yz() - align_params[11];
+          cout << "Long vect Z : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().yz()
+               << " / IDEAL RICCARDO = " << align_params[11] << endl;
+          dnx_ = (*iGeomDet)->rotation().zx() - align_params[3];
+          cout << "Norm vect X : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().zx()
+               << " / IDEAL RICCARDO = " << align_params[3] << endl;
+          dny_ = (*iGeomDet)->rotation().zy() - align_params[4];
+          cout << "Norm vect Y : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().zy()
+               << " / IDEAL RICCARDO = " << align_params[4] << endl;
+          dnz_ = (*iGeomDet)->rotation().zz() - align_params[5];
+          cout << "Norm vect Z : TRACKER_GEOM = " << std::fixed << std::setprecision(3) << (*iGeomDet)->rotation().zz()
+               << " / IDEAL RICCARDO = " << align_params[5] << endl;
+          theTree->Fill();
+        }
+      }
+    }
+    countDet--;
+  }
+
   edm::LogInfo("TrackerAlignment") << "Done!";
-
 }
 
 //define this as a plug-in

--- a/Alignment/SurveyAnalysis/test/TestIdealGeometry2.cpp
+++ b/Alignment/SurveyAnalysis/test/TestIdealGeometry2.cpp
@@ -2,7 +2,7 @@
 //
 // Package:    TestIdealGeometry2
 // Class:      TestIdealGeometry2
-// 
+//
 //
 // Description: Module to test the SurveyConverter software
 //
@@ -10,7 +10,6 @@
 // Original Author:  Roberto Covarelli
 //         Created:  March 16, 2006
 //
-
 
 // system include files
 #include <string>
@@ -43,26 +42,26 @@
 //
 
 class TestIdealGeometry2 : public edm::EDAnalyzer {
-
-  typedef SurveyDataReader::MapType    MapType;
-  typedef SurveyDataReader::PairType   PairType;
-  typedef SurveyDataReader::MapTypeOr  MapTypeOr;
+  typedef SurveyDataReader::MapType MapType;
+  typedef SurveyDataReader::PairType PairType;
+  typedef SurveyDataReader::MapTypeOr MapTypeOr;
   typedef SurveyDataReader::PairTypeOr PairTypeOr;
 
 public:
-  explicit TestIdealGeometry2( const edm::ParameterSet& );
+  explicit TestIdealGeometry2(const edm::ParameterSet&);
   ~TestIdealGeometry2();
-  
-  virtual void analyze( const edm::Event&, const edm::EventSetup& );
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
 private:
   // ----------member data ---------------------------
   TTree* theTree;
   TFile* theFile;
   edm::ParameterSet theParameterSet;
-  float dx_,dy_,dz_;
-  float dtx_,dty_,dtz_;
-  float dkx_,dky_,dkz_;
-  float dnx_,dny_,dnz_;
+  float dx_, dy_, dz_;
+  float dtx_, dty_, dtz_;
+  float dkx_, dky_, dkz_;
+  float dnx_, dny_, dnz_;
   int Id_;
   // TRotMatrix* rot_;
 
@@ -72,43 +71,33 @@ private:
 //
 // constructors and destructor
 //
-TestIdealGeometry2::TestIdealGeometry2( const edm::ParameterSet& iConfig ) :
-  theParameterSet( iConfig )
-{ 
-  
+TestIdealGeometry2::TestIdealGeometry2(const edm::ParameterSet& iConfig) : theParameterSet(iConfig) {
   // Open root file and define tree
-  std::string fileName = theParameterSet.getUntrackedParameter<std::string>("fileName","testideal.root");
-  theFile = new TFile( fileName.c_str(), "RECREATE" );
-  theTree = new TTree( "theTree", "Detector units positions" );
-  
-  theTree->Branch("Id",     &Id_,     "Id/I"     );
-  theTree->Branch("dx",     &dx_,     "dx/F"     );
-  theTree->Branch("dy",     &dy_,     "dy/F"     );
-  theTree->Branch("dz",     &dz_,     "dz/F"     );
-  theTree->Branch("dtx",    &dtx_,    "dtx/F"    );
-  theTree->Branch("dty",    &dty_,    "dty/F"    );
-  theTree->Branch("dtz",    &dtz_,    "dtz/F"    );
-  theTree->Branch("dkx",    &dkx_,    "dkx/F"    );
-  theTree->Branch("dky",    &dky_,    "dky/F"    );
-  theTree->Branch("dkz",    &dkz_,    "dkz/F"    );
-  theTree->Branch("dnx",    &dnx_,    "dnx/F"    );
-  theTree->Branch("dny",    &dny_,    "dny/F"    );
-  theTree->Branch("dnz",    &dnz_,    "dnz/F"    ); 
+  std::string fileName = theParameterSet.getUntrackedParameter<std::string>("fileName", "testideal.root");
+  theFile = new TFile(fileName.c_str(), "RECREATE");
+  theTree = new TTree("theTree", "Detector units positions");
+
+  theTree->Branch("Id", &Id_, "Id/I");
+  theTree->Branch("dx", &dx_, "dx/F");
+  theTree->Branch("dy", &dy_, "dy/F");
+  theTree->Branch("dz", &dz_, "dz/F");
+  theTree->Branch("dtx", &dtx_, "dtx/F");
+  theTree->Branch("dty", &dty_, "dty/F");
+  theTree->Branch("dtz", &dtz_, "dtz/F");
+  theTree->Branch("dkx", &dkx_, "dkx/F");
+  theTree->Branch("dky", &dky_, "dky/F");
+  theTree->Branch("dkz", &dkz_, "dkz/F");
+  theTree->Branch("dnx", &dnx_, "dnx/F");
+  theTree->Branch("dny", &dny_, "dny/F");
+  theTree->Branch("dnz", &dnz_, "dnz/F");
 }
 
-
-TestIdealGeometry2::~TestIdealGeometry2()
-{ 
-  
+TestIdealGeometry2::~TestIdealGeometry2() {
   theTree->Write();
   theFile->Close();
-  
 }
 
-
-void
-TestIdealGeometry2::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void TestIdealGeometry2::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
@@ -118,21 +107,21 @@ TestIdealGeometry2::analyze( const edm::Event& iEvent, const edm::EventSetup& iS
 
   //
   // Read in the survey information from the text files
-  // 
-  edm::ParameterSet textFiles = theParameterSet.getParameter<edm::ParameterSet>( "textFileNames" );
-  std::string textFileNames[NFILES]; 
-  std::string fileType[NFILES];    
-  textFileNames[0] = textFiles.getUntrackedParameter<std::string>("forTIB","NONE");  
+  //
+  edm::ParameterSet textFiles = theParameterSet.getParameter<edm::ParameterSet>("textFileNames");
+  std::string textFileNames[NFILES];
+  std::string fileType[NFILES];
+  textFileNames[0] = textFiles.getUntrackedParameter<std::string>("forTIB", "NONE");
   fileType[0] = "TIB";
-  textFileNames[1] = textFiles.getUntrackedParameter<std::string>("forTID","NONE");
+  textFileNames[1] = textFiles.getUntrackedParameter<std::string>("forTID", "NONE");
   fileType[1] = "TID";
 
   SurveyDataReader dataReader;
-  for (int ii=0 ; ii<NFILES ;ii++) {
-    if ( textFileNames[ii] == "NONE" )
+  for (int ii = 0; ii < NFILES; ii++) {
+    if (textFileNames[ii] == "NONE")
       throw cms::Exception("BadConfig") << fileType[ii] << " input file not found in configuration";
-    dataReader.readFile( textFileNames[ii], fileType[ii], tTopo );
-  } 
+    dataReader.readFile(textFileNames[ii], fileType[ii], tTopo);
+  }
 
   edm::LogInfo("TrackerAlignment") << "Files read";
 
@@ -148,101 +137,100 @@ TestIdealGeometry2::analyze( const edm::Event& iEvent, const edm::EventSetup& iS
 
   // Retrieve alignment[Error]s from DBase
   edm::ESHandle<Alignments> alignments;
-  iSetup.get<TrackerAlignmentRcd>().get( alignments );
+  iSetup.get<TrackerAlignmentRcd>().get(alignments);
   edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get( alignmentErrors );
+  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
   int countDet = 0;
 
   // Now loop on detector units, and store difference position and orientation w.r.t. survey
-  
-   for ( std::vector<AlignTransform>::const_iterator iGeomDet = alignments->m_align.begin();
-		iGeomDet != alignments->m_align.end(); iGeomDet++ )
-	{
-          
-          if (countDet == 0) countDet = countDet + 3;
-	  unsigned int comparisonVect[6] = {0,0,0,0,0,0};
-	  
-	  DetId thisId( (*iGeomDet).rawId() );
-	  if (thisId.subdetId() == int(StripSubdetector::TIB)) {
-	    
-	    comparisonVect[0] = int(StripSubdetector::TIB);
-	    
-	    comparisonVect[1] = tTopo->tibLayer(thisId);  
-            if (comparisonVect[1] < 3) {countDet--;} else {countDet = countDet - 3;}
-	    std::vector<unsigned int> theString = tTopo->tibStringInfo(thisId);
-	    comparisonVect[2] = theString[0];
-	    comparisonVect[3] = theString[1];
-	    comparisonVect[4] = theString[2];
-	    comparisonVect[5] = tTopo->tibModule(thisId);
-	    
-	  } else if (thisId.subdetId() == int(StripSubdetector::TID)) {
-	    
-	    comparisonVect[0] = int(StripSubdetector::TID);
-	    
-	    comparisonVect[1] = tTopo->tidSide(thisId);
-	    comparisonVect[2] = tTopo->tidWheel(thisId);
-	    comparisonVect[3] = tTopo->tidRing(thisId); 
-            if (comparisonVect[3] < 3) {countDet--;} else {countDet = countDet - 3;}
-	    std::vector<unsigned int> theModule = tTopo->tidModuleInfo(thisId);
-	    comparisonVect[4] = theModule[0];
-	    comparisonVect[5] = theModule[1];
-	    
-	  }
-	  
-	  if (countDet == 0) { // Store only r-phi for double-sided modules
 
-	    for ( MapTypeOr::const_iterator it = theSurveyMap.begin(); it != theSurveyMap.end(); it++ ) {
-	      const std::vector<int>& locPos = (it)->first;
-	      const align::Scalars& align_params = (it)->second;
-	      
-	      if (locPos[0] == int(comparisonVect[0]) &&
-		  locPos[1] == int(comparisonVect[1]) &&
-		  locPos[2] == int(comparisonVect[2]) &&
-		  locPos[3] == int(comparisonVect[3]) &&
-		  locPos[4] == int(comparisonVect[4]) &&
-		  locPos[5] == int(comparisonVect[5]) ) {
-	      
-		const CLHEP::HepRotation& rot = (*iGeomDet).rotation();
-		align::RotationType rotation( rot.xx(), rot.xy(), rot.xz(),
-					      rot.yx(), rot.yy(), rot.yz(),
-					      rot.zx(), rot.zy(), rot.zz() );
-		
-		Id_     = (*iGeomDet).rawId();
-		// cout << "DetId = " << Id_ << " " << endl;
-		// cout << "DetId decodified = " << comparisonVect[0] << " " << comparisonVect[1] << " " << comparisonVect[2] << " " << comparisonVect[3] << " " << comparisonVect[4] << " " << comparisonVect[5] << endl;	      
-		dx_      = (*iGeomDet).translation().x() - align_params[0];
-		// cout << "X pos : TRACKER_ALIGN = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().x() << " / IDEAL RICCARDO = " << align_params[0] << endl; 
-		dy_      = (*iGeomDet).translation().y() - align_params[1];
-		// cout << "Y pos : TRACKER_ALIGN = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().y() << " / IDEAL RICCARDO = " << align_params[1] << endl;
-		dz_      = (*iGeomDet).translation().z() - align_params[2];
-		// cout << "Z pos : TRACKER_ALIGN = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().z() << " / IDEAL RICCARDO = " << align_params[2] << endl;
-		// cout << "SPATIAL DISTANCE = " << std::fixed << std::setprecision(3) << sqrt(pow(dx_,2)+pow(dy_,2)+pow(dz_,2)) << endl;
-		dtx_     = rotation.xx() - align_params[6];
-		// cout << "Trans vect X : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.xx() << " / IDEAL RICCARDO = " << align_params[6] << endl;
-		dty_     = rotation.xy() - align_params[7];
-		// cout << "Trans vect Y : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.xy() << " / IDEAL RICCARDO = " << align_params[7] << endl;
-		dtz_     = rotation.xz() - align_params[8];
-		// cout << "Trans vect Z : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.xz() << " / IDEAL RICCARDO = " << align_params[8] << endl; 	
-		dkx_     = rotation.yx() - align_params[9];
-		// cout << "Long vect X : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.yx() << " / IDEAL RICCARDO = " << align_params[9] << endl;
-		dky_     = rotation.yy() - align_params[10];
-		// cout << "Long vect Y : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.yy() << " / IDEAL RICCARDO = " << align_params[10] << endl;
-		dkz_     = rotation.yz() - align_params[11];
-		// cout << "Long vect Z : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.yz() << " / IDEAL RICCARDO = " << align_params[11] << endl;
-		dnx_     = rotation.zx() - align_params[3];
-		// cout << "Norm vect X : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.zx() << " / IDEAL RICCARDO = " << align_params[3] << endl;
-		dny_     = rotation.zy() - align_params[4];
-		// cout << "Norm vect Y : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.zy() << " / IDEAL RICCARDO = " << align_params[4] << endl;
-		dnz_     = rotation.zz() - align_params[5];
-		// cout << "Norm vect Z : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.zz() << " / IDEAL RICCARDO = " << align_params[5] << endl; 
-		theTree->Fill();
-	      }
-	    }
-	  }	  
-	} 
-   
+  for (std::vector<AlignTransform>::const_iterator iGeomDet = alignments->m_align.begin();
+       iGeomDet != alignments->m_align.end();
+       iGeomDet++) {
+    if (countDet == 0)
+      countDet = countDet + 3;
+    unsigned int comparisonVect[6] = {0, 0, 0, 0, 0, 0};
+
+    DetId thisId((*iGeomDet).rawId());
+    if (thisId.subdetId() == int(StripSubdetector::TIB)) {
+      comparisonVect[0] = int(StripSubdetector::TIB);
+
+      comparisonVect[1] = tTopo->tibLayer(thisId);
+      if (comparisonVect[1] < 3) {
+        countDet--;
+      } else {
+        countDet = countDet - 3;
+      }
+      std::vector<unsigned int> theString = tTopo->tibStringInfo(thisId);
+      comparisonVect[2] = theString[0];
+      comparisonVect[3] = theString[1];
+      comparisonVect[4] = theString[2];
+      comparisonVect[5] = tTopo->tibModule(thisId);
+
+    } else if (thisId.subdetId() == int(StripSubdetector::TID)) {
+      comparisonVect[0] = int(StripSubdetector::TID);
+
+      comparisonVect[1] = tTopo->tidSide(thisId);
+      comparisonVect[2] = tTopo->tidWheel(thisId);
+      comparisonVect[3] = tTopo->tidRing(thisId);
+      if (comparisonVect[3] < 3) {
+        countDet--;
+      } else {
+        countDet = countDet - 3;
+      }
+      std::vector<unsigned int> theModule = tTopo->tidModuleInfo(thisId);
+      comparisonVect[4] = theModule[0];
+      comparisonVect[5] = theModule[1];
+    }
+
+    if (countDet == 0) {  // Store only r-phi for double-sided modules
+
+      for (MapTypeOr::const_iterator it = theSurveyMap.begin(); it != theSurveyMap.end(); it++) {
+        const std::vector<int>& locPos = (it)->first;
+        const align::Scalars& align_params = (it)->second;
+
+        if (locPos[0] == int(comparisonVect[0]) && locPos[1] == int(comparisonVect[1]) &&
+            locPos[2] == int(comparisonVect[2]) && locPos[3] == int(comparisonVect[3]) &&
+            locPos[4] == int(comparisonVect[4]) && locPos[5] == int(comparisonVect[5])) {
+          const CLHEP::HepRotation& rot = (*iGeomDet).rotation();
+          align::RotationType rotation(
+              rot.xx(), rot.xy(), rot.xz(), rot.yx(), rot.yy(), rot.yz(), rot.zx(), rot.zy(), rot.zz());
+
+          Id_ = (*iGeomDet).rawId();
+          // cout << "DetId = " << Id_ << " " << endl;
+          // cout << "DetId decodified = " << comparisonVect[0] << " " << comparisonVect[1] << " " << comparisonVect[2] << " " << comparisonVect[3] << " " << comparisonVect[4] << " " << comparisonVect[5] << endl;
+          dx_ = (*iGeomDet).translation().x() - align_params[0];
+          // cout << "X pos : TRACKER_ALIGN = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().x() << " / IDEAL RICCARDO = " << align_params[0] << endl;
+          dy_ = (*iGeomDet).translation().y() - align_params[1];
+          // cout << "Y pos : TRACKER_ALIGN = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().y() << " / IDEAL RICCARDO = " << align_params[1] << endl;
+          dz_ = (*iGeomDet).translation().z() - align_params[2];
+          // cout << "Z pos : TRACKER_ALIGN = " << std::fixed << std::setprecision(2) << (*iGeomDet).translation().z() << " / IDEAL RICCARDO = " << align_params[2] << endl;
+          // cout << "SPATIAL DISTANCE = " << std::fixed << std::setprecision(3) << sqrt(pow(dx_,2)+pow(dy_,2)+pow(dz_,2)) << endl;
+          dtx_ = rotation.xx() - align_params[6];
+          // cout << "Trans vect X : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.xx() << " / IDEAL RICCARDO = " << align_params[6] << endl;
+          dty_ = rotation.xy() - align_params[7];
+          // cout << "Trans vect Y : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.xy() << " / IDEAL RICCARDO = " << align_params[7] << endl;
+          dtz_ = rotation.xz() - align_params[8];
+          // cout << "Trans vect Z : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.xz() << " / IDEAL RICCARDO = " << align_params[8] << endl;
+          dkx_ = rotation.yx() - align_params[9];
+          // cout << "Long vect X : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.yx() << " / IDEAL RICCARDO = " << align_params[9] << endl;
+          dky_ = rotation.yy() - align_params[10];
+          // cout << "Long vect Y : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.yy() << " / IDEAL RICCARDO = " << align_params[10] << endl;
+          dkz_ = rotation.yz() - align_params[11];
+          // cout << "Long vect Z : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.yz() << " / IDEAL RICCARDO = " << align_params[11] << endl;
+          dnx_ = rotation.zx() - align_params[3];
+          // cout << "Norm vect X : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.zx() << " / IDEAL RICCARDO = " << align_params[3] << endl;
+          dny_ = rotation.zy() - align_params[4];
+          // cout << "Norm vect Y : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.zy() << " / IDEAL RICCARDO = " << align_params[4] << endl;
+          dnz_ = rotation.zz() - align_params[5];
+          // cout << "Norm vect Z : TRACKER_ALIGN = " << std::fixed << std::setprecision(3) << rotation.zz() << " / IDEAL RICCARDO = " << align_params[5] << endl;
+          theTree->Fill();
+        }
+      }
+    }
+  }
+
   edm::LogInfo("TrackerAlignment") << "Done!";
-
 }
 
 //define this as a plug-in

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMap.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMap.h
@@ -5,18 +5,13 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include <map>
 
-class CaloMiscalibMap{
+class CaloMiscalibMap {
+public:
+  CaloMiscalibMap() {}
+  virtual ~CaloMiscalibMap() {}
 
 public:
-CaloMiscalibMap(){}
-virtual ~CaloMiscalibMap(){}
-
-public:
-
-
-virtual void addCell(const DetId &cell, float scaling_factor)=0;
-
+  virtual void addCell(const DetId &cell, float scaling_factor) = 0;
 };
-
 
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapEcal.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapEcal.h
@@ -13,109 +13,85 @@
 #include <map>
 #include <vector>
 
-
-
-class CaloMiscalibMapEcal: public CaloMiscalibMap {
+class CaloMiscalibMapEcal : public CaloMiscalibMap {
 public:
-CaloMiscalibMapEcal(){ 
-}
+  CaloMiscalibMapEcal() {}
 
-void prefillMap(){
-  
+  void prefillMap() {
+    for (int iEta = -EBDetId::MAX_IETA; iEta <= EBDetId::MAX_IETA; ++iEta) {
+      if (iEta == 0)
+        continue;
+      for (int iPhi = EBDetId::MIN_IPHI; iPhi <= EBDetId::MAX_IPHI; ++iPhi) {
+        try {
+          EBDetId ebdetid(iEta, iPhi);
+          map_.setValue(ebdetid.rawId(), 1.0);
+        } catch (...) {
+        }
+      }
+    }
 
-   for(int iEta=-EBDetId::MAX_IETA; iEta<=EBDetId::MAX_IETA ;++iEta) {
-     if(iEta==0) continue;
-     for(int iPhi=EBDetId::MIN_IPHI; iPhi<=EBDetId::MAX_IPHI; ++iPhi) {
+    for (int iX = EEDetId::IX_MIN; iX <= EEDetId::IX_MAX; ++iX) {
+      for (int iY = EEDetId::IY_MIN; iY <= EEDetId::IY_MAX; ++iY) {
+        try {
+          EEDetId eedetidpos(iX, iY, 1);
+          map_.setValue(eedetidpos.rawId(), 1.0);
+          EEDetId eedetidneg(iX, iY, -1);
+          map_.setValue(eedetidneg.rawId(), 1.0);
+        } catch (...) {
+        }
+      }
+    }
+  }
 
-       try 
-	 {
-	   EBDetId ebdetid(iEta,iPhi);
-	   map_.setValue(ebdetid.rawId(),1.0);
-	 }
-       catch (...)
-	 {
-	 }
-     }
-   }
-   
-   for(int iX=EEDetId::IX_MIN; iX<=EEDetId::IX_MAX ;++iX) {
-     for(int iY=EEDetId::IY_MIN; iY<=EEDetId::IY_MAX; ++iY) {
-       try 
-	 {
- 	   EEDetId eedetidpos(iX,iY,1);
-	   map_.setValue(eedetidpos.rawId(),1.0);
-	   EEDetId eedetidneg(iX,iY,-1);
-	   map_.setValue(eedetidneg.rawId(),1.0);
-	 }
-       catch (...)
-	 {
-	 }
-     }
-   }
+  void addCell(const DetId &cell, float scaling_factor) override { map_.setValue(cell.rawId(), scaling_factor); }
 
+  void print() {
+    int icount = 0;
+    for (int iEta = -EBDetId::MAX_IETA; iEta <= EBDetId::MAX_IETA; ++iEta) {
+      if (iEta == 0)
+        continue;
+      for (int iPhi = EBDetId::MIN_IPHI; iPhi <= EBDetId::MAX_IPHI; ++iPhi) {
+        if (EBDetId::validDetId(iEta, iPhi)) {
+          EBDetId ebdetid(iEta, iPhi);
+          EcalIntercalibConstantMap::const_iterator icalit = map_.find(ebdetid.rawId());
+          EcalIntercalibConstant icalconst;
+          icalconst = (*icalit);
 
-}
+          icount++;
+          if (icount % 230 == 0) {
+            std::cout << "here is value for chan eta/phi " << iEta << "/" << iPhi << "=" << icalconst << std::endl;
+          }
+        }
+      }
+    }
+    for (int iX = EEDetId::IX_MIN; iX <= EEDetId::IX_MAX; ++iX) {
+      for (int iY = EEDetId::IY_MIN; iY <= EEDetId::IY_MAX; ++iY) {
+        if (EEDetId::validDetId(iX, iY, 1)) {
+          EEDetId eedetidpos(iX, iY, 1);
+          EcalIntercalibConstantMap::const_iterator icalit = map_.find(eedetidpos.rawId());
+          EcalIntercalibConstant icalconst;
+          icalconst = (*icalit);
 
+          EEDetId eedetidneg(iX, iY, -1);
+          EcalIntercalibConstantMap::const_iterator icalit2 = map_.find(eedetidneg.rawId());
+          EcalIntercalibConstant icalconst2;
+          icalconst2 = (*icalit2);
 
-void addCell(const DetId &cell, float scaling_factor) override
-{
-map_.setValue(cell.rawId(),scaling_factor);
-}
+          icount++;
+          if (icount % 230 == 0) {
+            std::cout << "here is value for chan x/y " << iX << "/" << iY << " pos side is =" << icalconst
+                      << " and neg side is= " << icalconst2 << std::endl;
+          }
+        }
+      }
+    }
+  }
 
-void print()
- {
-
-   int icount=0;
-   for(int iEta=-EBDetId::MAX_IETA; iEta<=EBDetId::MAX_IETA ;++iEta) {
-     if(iEta==0) continue;
-     for(int iPhi=EBDetId::MIN_IPHI; iPhi<=EBDetId::MAX_IPHI; ++iPhi) {
-       if (EBDetId::validDetId(iEta,iPhi))
-	 {
-	   EBDetId ebdetid(iEta,iPhi);
-	   EcalIntercalibConstantMap::const_iterator icalit= map_.find(ebdetid.rawId());
-	   EcalIntercalibConstant icalconst;
-	   icalconst = (*icalit);
-	   
-	   icount++;
-	   if(icount%230==0){
-	     std::cout<< "here is value for chan eta/phi "<<iEta<<"/"<<iPhi<<"="<<icalconst<<std::endl;}
-	 }
-     }
-   }
-   for(int iX=EEDetId::IX_MIN; iX<=EEDetId::IX_MAX ;++iX) {
-     for(int iY=EEDetId::IY_MIN; iY<=EEDetId::IY_MAX; ++iY) {
-       if (EEDetId::validDetId(iX,iY,1))
-	 {
-	   EEDetId eedetidpos(iX,iY,1);
-	   EcalIntercalibConstantMap::const_iterator icalit= map_.find(eedetidpos.rawId());
-           EcalIntercalibConstant icalconst;
-           icalconst = (*icalit);
-
-	   EEDetId eedetidneg(iX,iY,-1);
-	   EcalIntercalibConstantMap::const_iterator icalit2= map_.find(eedetidneg.rawId());
-           EcalIntercalibConstant icalconst2;
-           icalconst2 = (*icalit2);
-
-
-	   icount++;
-	   if(icount%230==0){
-
-	     std::cout<< "here is value for chan x/y "<<iX<<"/"<<iY<<" pos side is ="<<icalconst<< " and neg side is= "<< icalconst2<<std::endl;}
-
-	 }
-     }
-   }
- 
-}
-
-const EcalIntercalibConstants & get(){
-return map_;
-}
+  const EcalIntercalibConstants &get() { return map_; }
 
 private:
-
-EcalIntercalibConstants map_;
-const CaloSubdetectorGeometry *geometry;
+  EcalIntercalibConstants map_;
+  const CaloSubdetectorGeometry *geometry;
 };
 
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapHcal.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapHcal.h
@@ -14,62 +14,50 @@
 #include <map>
 #include <vector>
 
-class CaloMiscalibMapHcal: public CaloMiscalibMap {
+class CaloMiscalibMapHcal : public CaloMiscalibMap {
 public:
-    CaloMiscalibMapHcal(){
-    }
+  CaloMiscalibMapHcal() {}
 
-void prefillMap(const HcalTopology & topology){
+  void prefillMap(const HcalTopology &topology) {
+    for (int det = 1; det <= HcalForward; det++) {
+      for (int eta = -HcalDetId::kHcalEtaMask2; eta <= (int)(HcalDetId::kHcalEtaMask2); eta++) {
+        for (unsigned int phi = 1; phi <= HcalDetId::kHcalPhiMask2; phi++) {
+          for (unsigned int depth = 1; depth <= HcalDetId::kHcalDepthMask2; depth++) {
+            try {
+              HcalDetId hcaldetid((HcalSubdetector)det, eta, phi, depth);
+              if (topology.valid(hcaldetid)) {
+                mapHcal_[hcaldetid.rawId()] = 1.0;
+                //	      std::cout << "Valid cell found: " << det << " " << eta << " " << phi << " " << depth << std::endl;
+              }
 
-  for (int det = 1; det <= HcalForward; det++) {
-    for (int eta = -HcalDetId::kHcalEtaMask2; eta <= (int)(HcalDetId::kHcalEtaMask2); eta++) {
-      for (unsigned int phi = 1; phi <= HcalDetId::kHcalPhiMask2; phi++) {
-	for (unsigned int depth = 1; depth <= HcalDetId::kHcalDepthMask2; depth++) {
-
-	  try {
-	    HcalDetId hcaldetid ((HcalSubdetector) det, eta, phi, depth);
-	    if (topology.valid(hcaldetid)) {
-	      mapHcal_[hcaldetid.rawId()]=1.0; 
-	      //	      std::cout << "Valid cell found: " << det << " " << eta << " " << phi << " " << depth << std::endl;
-	    }
-		
-	  }
-	  catch (...) {
-	  }
-	}
+            } catch (...) {
+            }
+          }
+        }
       }
     }
   }
-}
 
+  void addCell(const DetId &cell, float scaling_factor) override {
+    //mapHcal_.setValue(cell.rawId(),scaling_factor);
+    mapHcal_[cell.rawId()] = scaling_factor;
+  }
 
-void addCell(const DetId &cell, float scaling_factor) override
-{
-  //mapHcal_.setValue(cell.rawId(),scaling_factor);
-  mapHcal_[cell.rawId()]=scaling_factor;
-}
+  void print() {
+    std::map<uint32_t, float>::const_iterator it;
 
-void print()
- {
- 
- std::map<uint32_t,float>::const_iterator it;
- 
- //   for(it=mapHcal_.getMap().begin();it!=mapHcal_.getMap().end();it++){
- //   }
-   for(it=mapHcal_.begin();it!=mapHcal_.end();it++){
-   }
- 
-}
+    //   for(it=mapHcal_.getMap().begin();it!=mapHcal_.getMap().end();it++){
+    //   }
+    for (it = mapHcal_.begin(); it != mapHcal_.end(); it++) {
+    }
+  }
 
-const std::map<uint32_t, float> & get(){
-return mapHcal_;
-}
+  const std::map<uint32_t, float> &get() { return mapHcal_; }
 
 private:
-
-   std::map<uint32_t, float> mapHcal_;
-   // EcalIntercalibConstants map_;
-   // const CaloSubdetectorGeometry *geometry;
+  std::map<uint32_t, float> mapHcal_;
+  // EcalIntercalibConstants map_;
+  // const CaloSubdetectorGeometry *geometry;
 };
 
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h
@@ -5,7 +5,7 @@
 //
 // Package:    CaloMiscalibTools
 // Class:      CaloMiscalibTools
-// 
+//
 /**\class CaloMiscalibTools CaloMiscalibTools.cc CalibCalorimetry/CaloMiscalibTools/src/CaloMiscalibTools.cc
 
  Description: Definition of CaloMiscalibTools
@@ -17,10 +17,9 @@
 // Original Author:  Lorenzo AGOSTINO
 //         Created:  Mon Jul 17 18:07:01 CEST 2006
 //
-// Modified       : Luca Malgeri 
-// Date:          : 11/09/2006 
+// Modified       : Luca Malgeri
+// Date:          : 11/09/2006
 // Reason         : split class definition (.h) from source code (.cc)
- 
 
 // system include files
 #include <memory>
@@ -47,23 +46,25 @@
 // class decleration
 //
 
-class CaloMiscalibTools : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-   public:
-      CaloMiscalibTools(const edm::ParameterSet&);
-      ~CaloMiscalibTools() override;
+class CaloMiscalibTools : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
+  CaloMiscalibTools(const edm::ParameterSet &);
+  ~CaloMiscalibTools() override;
 
-      typedef std::unique_ptr<EcalIntercalibConstants> ReturnType;
+  typedef std::unique_ptr<EcalIntercalibConstants> ReturnType;
 
-      ReturnType produce(const EcalIntercalibConstantsRcd&);
-   private:
-      // ----------member data ---------------------------
-    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
-    
-    std::string barrelfile_; 
-    std::string endcapfile_; 
-    std::string barrelfileinpath_; 
-    std::string endcapfileinpath_; 
+  ReturnType produce(const EcalIntercalibConstantsRcd &);
 
+private:
+  // ----------member data ---------------------------
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+  std::string barrelfile_;
+  std::string endcapfile_;
+  std::string barrelfileinpath_;
+  std::string endcapfileinpath_;
 };
 
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibToolsMC.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibToolsMC.h
@@ -5,7 +5,7 @@
 //
 // Package:    CaloMiscalibToolsMC
 // Class:      CaloMiscalibToolsMC
-// 
+//
 /**\class CaloMiscalibToolsMC CaloMiscalibToolsMC.cc CalibCalorimetry/CaloMiscalibToolsMC/src/CaloMiscalibToolsMC.cc
 
  Description: Definition of CaloMiscalibToolsMC
@@ -17,10 +17,9 @@
 // Original Author:  Lorenzo AGOSTINO
 //         Created:  Mon Jul 17 18:07:01 CEST 2006
 //
-// Modified       : Luca Malgeri 
-// Date:          : 11/09/2006 
+// Modified       : Luca Malgeri
+// Date:          : 11/09/2006
 // Reason         : split class definition (.h) from source code (.cc)
- 
 
 // system include files
 #include <memory>
@@ -47,23 +46,25 @@
 // class decleration
 //
 
-class CaloMiscalibToolsMC : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder  {
-   public:
-      CaloMiscalibToolsMC(const edm::ParameterSet&);
-      ~CaloMiscalibToolsMC() override;
+class CaloMiscalibToolsMC : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
+  CaloMiscalibToolsMC(const edm::ParameterSet &);
+  ~CaloMiscalibToolsMC() override;
 
-      typedef std::unique_ptr<EcalIntercalibConstantsMC> ReturnType;
+  typedef std::unique_ptr<EcalIntercalibConstantsMC> ReturnType;
 
-      ReturnType produce(const EcalIntercalibConstantsMCRcd&);
-   private:
-      // ----------member data ---------------------------
-    void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&, edm::ValidityInterval & ) override;
-    
-    std::string barrelfile_; 
-    std::string endcapfile_; 
-    std::string barrelfileinpath_; 
-    std::string endcapfileinpath_; 
+  ReturnType produce(const EcalIntercalibConstantsMCRcd &);
 
+private:
+  // ----------member data ---------------------------
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey &,
+                      const edm::IOVSyncValue &,
+                      edm::ValidityInterval &) override;
+
+  std::string barrelfile_;
+  std::string endcapfile_;
+  std::string barrelfileinpath_;
+  std::string endcapfileinpath_;
 };
 
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/EcalRecHitRecalib.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/EcalRecHitRecalib.h
@@ -1,11 +1,11 @@
-#ifndef  _ECALRECHITRECALIB_H
-#define  _ECALRECHITRECALIB_H
+#ifndef _ECALRECHITRECALIB_H
+#define _ECALRECHITRECALIB_H
 
 // -*- C++ -*-
 //
 // Package:    EcalRecHitRecalib
 // Class:      EcalRecHitRecalib
-// 
+//
 /**\class EcalRecHitRecalib EcalRecHitRecalib.cc CalibCalorimetry/CaloMiscalibTools.src/EcalRecHitRecalib.cc
 
  Description: Producer to miscalibrate (calibrated) Ecal RecHit 
@@ -17,7 +17,6 @@
 // Original Author:  Luca Malgeri
 //
 //
-
 
 // system include files
 #include <memory>
@@ -36,23 +35,22 @@
 //
 
 class EcalRecHitRecalib : public edm::EDProducer {
-   public:
-      explicit EcalRecHitRecalib(const edm::ParameterSet&);
-      ~EcalRecHitRecalib() override;
+public:
+  explicit EcalRecHitRecalib(const edm::ParameterSet &);
+  ~EcalRecHitRecalib() override;
 
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-      void produce(edm::Event &, const edm::EventSetup&) override;
-   private:
-      // ----------member data ---------------------------
+private:
+  // ----------member data ---------------------------
 
- std::string ecalHitsProducer_;
- std::string barrelHits_;
- std::string endcapHits_;
- std::string RecalibBarrelHits_;
- std::string RecalibEndcapHits_;
- double refactor_;
- double refactor_mean_;
-
+  std::string ecalHitsProducer_;
+  std::string barrelHits_;
+  std::string endcapHits_;
+  std::string RecalibBarrelHits_;
+  std::string RecalibEndcapHits_;
+  double refactor_;
+  double refactor_mean_;
 };
 
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/HcalRecHitRecalib.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/HcalRecHitRecalib.h
@@ -5,7 +5,7 @@
 //
 // Package:    HcalRecHitRecalib
 // Class:      HcalRecHitRecalib
-// 
+//
 /**\class HcalRecHitRecalib HcalRecHitRecalib.cc CalibCalorimetry/CaloRecalibTools.src/HcalRecHitRecalib.cc
 
  Description: Producer to miscalibrate (calibrated) Hcal RecHit 
@@ -17,7 +17,6 @@
 // Original Author:  Luca Malgeri
 //
 //
-
 
 // system include files
 #include <memory>
@@ -34,28 +33,27 @@
 #include "CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapHcal.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 
-class HcalRecHitRecalib : public edm::EDProducer
-{
+class HcalRecHitRecalib : public edm::EDProducer {
 public:
-    explicit HcalRecHitRecalib(const edm::ParameterSet&);
-    ~HcalRecHitRecalib() override;
+  explicit HcalRecHitRecalib(const edm::ParameterSet &);
+  ~HcalRecHitRecalib() override;
 
-    void beginRun(const edm::Run&, const edm::EventSetup&) override;
-    void produce(edm::Event &, const edm::EventSetup&) override;
+  void beginRun(const edm::Run &, const edm::EventSetup &) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
 private:
-    edm::EDGetTokenT<HBHERecHitCollection> tok_hbhe_;
-    edm::EDGetTokenT<HORecHitCollection> tok_ho_;
-    edm::EDGetTokenT<HFRecHitCollection> tok_hf_;
-    std::string RecalibHBHEHits_;
-    std::string RecalibHFHits_;
-    std::string RecalibHOHits_;
+  edm::EDGetTokenT<HBHERecHitCollection> tok_hbhe_;
+  edm::EDGetTokenT<HORecHitCollection> tok_ho_;
+  edm::EDGetTokenT<HFRecHitCollection> tok_hf_;
+  std::string RecalibHBHEHits_;
+  std::string RecalibHFHits_;
+  std::string RecalibHOHits_;
 
-    std::string hcalfile_;
-    std::string hcalfileinpath_;
+  std::string hcalfile_;
+  std::string hcalfileinpath_;
 
-    CaloMiscalibMapHcal mapHcal_;
-    double refactor_;
-    double refactor_mean_;
+  CaloMiscalibMapHcal mapHcal_;
+  double refactor_;
+  double refactor_mean_;
 };
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXML.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXML.h
@@ -17,30 +17,27 @@
 #include <xercesc/util/XMLUni.hpp>
 #include <xercesc/util/XMLURL.hpp>
 #include "CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMap.h"
-          
 
-#include<iostream>
-#include<string>
-#include<vector>
-#include<map>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
 
-
-class MiscalibReaderFromXML{
-
+class MiscalibReaderFromXML {
 public:
-MiscalibReaderFromXML(CaloMiscalibMap &);
-virtual ~MiscalibReaderFromXML(){}
+  MiscalibReaderFromXML(CaloMiscalibMap &);
+  virtual ~MiscalibReaderFromXML() {}
 
-bool parseXMLMiscalibFile(std::string configFile);
+  bool parseXMLMiscalibFile(std::string configFile);
 
-virtual DetId parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute)=0;
-int    getIntAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute, const std::string &attribute_name);
-double getScalingFactor(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute);
-double getFloatAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute, const std::string &attribute_name);
+  virtual DetId parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute) = 0;
+  int getIntAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute, const std::string &attribute_name);
+  double getScalingFactor(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute);
+  double getFloatAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute, const std::string &attribute_name);
 
 private:
-static int s_numberOfInstances;
-CaloMiscalibMap & caloMap_;
+  static int s_numberOfInstances;
+  CaloMiscalibMap &caloMap_;
 };
 
 #endif

--- a/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLDomUtils.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLDomUtils.h
@@ -9,19 +9,22 @@
 #include <xercesc/dom/DOMNode.hpp>
 
 /** a collection of some XML reading utilities */
-class MiscalibReaderFromXMLDomUtils
-{
+class MiscalibReaderFromXMLDomUtils {
 public:
   inline static std::string toString(const XMLCh *str);
 
-  inline static int getIntAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes, std::string attr_name, bool &well_formed_string);
-  
-  inline static double getFloatAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes, std::string attr_name, bool &well_formed_string);
+  inline static int getIntAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes,
+                                    std::string attr_name,
+                                    bool &well_formed_string);
 
-  inline static std::string getStringAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes, std::string attr_name);
+  inline static double getFloatAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes,
+                                         std::string attr_name,
+                                         bool &well_formed_string);
+
+  inline static std::string getStringAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes,
+                                               std::string attr_name);
 
   inline static bool hasAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes, std::string attr_name);
-  
 };
 
 #include <CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLDomUtils.icc>

--- a/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLDomUtils.icc
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLDomUtils.icc
@@ -1,55 +1,51 @@
-// -*- c++ -*- 
+// -*- c++ -*-
 #ifndef _MISCALIB_READER_FROM_XML_DOM_UTILS_ICC
 #define _MISCALIB_READER_FROM_XML_DOM_UTILS_ICC
 
 //----------------------------------------------------------------------
 
-inline std::string 
-MiscalibReaderFromXMLDomUtils::toString(const XMLCh *str)
-{
+inline std::string MiscalibReaderFromXMLDomUtils::toString(const XMLCh *str) {
   char *name = XERCES_CPP_NAMESPACE::XMLString::transcode(str);
   std::string retval(name);
-  delete [] name;
+  delete[] name;
   return retval;
 }
 
 //----------------------------------------------------------------------
 
-inline int 
-MiscalibReaderFromXMLDomUtils::getIntAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes, std::string attr_name, bool &well_formed_string)
-{
+inline int MiscalibReaderFromXMLDomUtils::getIntAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes,
+                                                          std::string attr_name,
+                                                          bool &well_formed_string) {
   XMLCh *buffer = XERCES_CPP_NAMESPACE::XMLString::transcode(attr_name.c_str());
 
   // we could also use XMLString::parseInt(...) here..
   char *endptr = nullptr;
-  int retval = strtol(toString(attributes->getNamedItem(buffer)->getNodeValue()).c_str(),
-                      &endptr,0);
+  int retval = strtol(toString(attributes->getNamedItem(buffer)->getNodeValue()).c_str(), &endptr, 0);
   if (*endptr != '\0')
     well_formed_string = false;
   else
     well_formed_string = true;
 
-  delete [] buffer;
+  delete[] buffer;
   // std::cout << "retval=" << retval << std::endl;
   return retval;
 }
 
 //----------------------------------------------------------------------
 
-inline double 
-MiscalibReaderFromXMLDomUtils::getFloatAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes, std::string attr_name, bool &well_formed_string)
-{
+inline double MiscalibReaderFromXMLDomUtils::getFloatAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes,
+                                                               std::string attr_name,
+                                                               bool &well_formed_string) {
   XMLCh *buffer = XERCES_CPP_NAMESPACE::XMLString::transcode(attr_name.c_str());
 
   char *endptr = nullptr;
-  double retval = strtod(toString(attributes->getNamedItem(buffer)->getNodeValue()).c_str(),
-                         &endptr);
+  double retval = strtod(toString(attributes->getNamedItem(buffer)->getNodeValue()).c_str(), &endptr);
   if (*endptr != '\0')
     well_formed_string = false;
   else
     well_formed_string = true;
-  
-  delete [] buffer;
+
+  delete[] buffer;
   // std::cout << "retval=" << retval << std::endl;
   return retval;
 
@@ -58,29 +54,26 @@ MiscalibReaderFromXMLDomUtils::getFloatAttribute(XERCES_CPP_NAMESPACE::DOMNamedN
 
 //----------------------------------------------------------------------
 
-inline std::string 
-MiscalibReaderFromXMLDomUtils::getStringAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes, std::string attr_name)
-{
+inline std::string MiscalibReaderFromXMLDomUtils::getStringAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes,
+                                                                     std::string attr_name) {
   XMLCh *buffer = XERCES_CPP_NAMESPACE::XMLString::transcode(attr_name.c_str());
   std::string retval = toString(attributes->getNamedItem(buffer)->getNodeValue());
 
-  delete [] buffer;
+  delete[] buffer;
   // std::cout << "retval=" << retval << std::endl;
   return retval;
 }
 
 //----------------------------------------------------------------------
 
-inline bool 
-MiscalibReaderFromXMLDomUtils::hasAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes, std::string attr_name)
-{
+inline bool MiscalibReaderFromXMLDomUtils::hasAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attributes,
+                                                        std::string attr_name) {
   bool retval;
   XMLCh *buffer = XERCES_CPP_NAMESPACE::XMLString::transcode(attr_name.c_str());
   retval = attributes->getNamedItem(buffer) != nullptr;
-  delete [] buffer;
-    
+  delete[] buffer;
+
   return retval;
-    
 }
 
 //----------------------------------------------------------------------

--- a/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLDomUtils.icc
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLDomUtils.icc
@@ -21,7 +21,7 @@ MiscalibReaderFromXMLDomUtils::getIntAttribute(XERCES_CPP_NAMESPACE::DOMNamedNod
   XMLCh *buffer = XERCES_CPP_NAMESPACE::XMLString::transcode(attr_name.c_str());
 
   // we could also use XMLString::parseInt(...) here..
-  char *endptr = NULL;
+  char *endptr = nullptr;
   int retval = strtol(toString(attributes->getNamedItem(buffer)->getNodeValue()).c_str(),
                       &endptr,0);
   if (*endptr != '\0')
@@ -41,7 +41,7 @@ MiscalibReaderFromXMLDomUtils::getFloatAttribute(XERCES_CPP_NAMESPACE::DOMNamedN
 {
   XMLCh *buffer = XERCES_CPP_NAMESPACE::XMLString::transcode(attr_name.c_str());
 
-  char *endptr = NULL;
+  char *endptr = nullptr;
   double retval = strtod(toString(attributes->getNamedItem(buffer)->getNodeValue()).c_str(),
                          &endptr);
   if (*endptr != '\0')
@@ -76,7 +76,7 @@ MiscalibReaderFromXMLDomUtils::hasAttribute(XERCES_CPP_NAMESPACE::DOMNamedNodeMa
 {
   bool retval;
   XMLCh *buffer = XERCES_CPP_NAMESPACE::XMLString::transcode(attr_name.c_str());
-  retval = attributes->getNamedItem(buffer) != NULL;
+  retval = attributes->getNamedItem(buffer) != nullptr;
   delete [] buffer;
     
   return retval;

--- a/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalBarrel.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalBarrel.h
@@ -5,19 +5,13 @@
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXML.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapEcal.h"
 
-
-
-class MiscalibReaderFromXMLEcalBarrel : public MiscalibReaderFromXML
-{
- public:
-  MiscalibReaderFromXMLEcalBarrel(CaloMiscalibMapEcal & map):MiscalibReaderFromXML(map){};
-
+class MiscalibReaderFromXMLEcalBarrel : public MiscalibReaderFromXML {
+public:
+  MiscalibReaderFromXMLEcalBarrel(CaloMiscalibMapEcal &map) : MiscalibReaderFromXML(map){};
 
   DetId parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute) override;
 
   EBDetId getCellFromAttributes(int ieta, int iphi);
-
 };
 
 #endif
-

--- a/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalEndcap.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalEndcap.h
@@ -5,18 +5,13 @@
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXML.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapEcal.h"
 
-
-
-class MiscalibReaderFromXMLEcalEndcap : public MiscalibReaderFromXML
-{
- public:
-  MiscalibReaderFromXMLEcalEndcap(CaloMiscalibMapEcal & map):MiscalibReaderFromXML(map){};
+class MiscalibReaderFromXMLEcalEndcap : public MiscalibReaderFromXML {
+public:
+  MiscalibReaderFromXMLEcalEndcap(CaloMiscalibMapEcal &map) : MiscalibReaderFromXML(map){};
 
   DetId parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute) override;
 
   EEDetId getCellFromAttributes(int ix, int iy, int iz);
-
 };
 
 #endif
-

--- a/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLHcal.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLHcal.h
@@ -5,19 +5,13 @@
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXML.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibMapHcal.h"
 
-
-
-class MiscalibReaderFromXMLHcal : public MiscalibReaderFromXML
-{
- public:
-  MiscalibReaderFromXMLHcal(CaloMiscalibMapHcal & map):MiscalibReaderFromXML(map){};
-
+class MiscalibReaderFromXMLHcal : public MiscalibReaderFromXML {
+public:
+  MiscalibReaderFromXMLHcal(CaloMiscalibMapHcal &map) : MiscalibReaderFromXML(map){};
 
   DetId parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute) override;
 
   HcalDetId getCellFromAttributes(int idet, int ieta, int iphi, int idepth);
-
 };
 
 #endif
-

--- a/CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstants.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstants.h
@@ -6,7 +6,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -23,16 +22,15 @@
 //
 
 class WriteEcalMiscalibConstants : public edm::EDAnalyzer {
- public:
+public:
   explicit WriteEcalMiscalibConstants(const edm::ParameterSet&);
   ~WriteEcalMiscalibConstants() override;
-  
-  
- private:
-      void beginJob() override ;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
-      
-      // ----------member data ---------------------------
-      std::string newTagRequest_;
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  // ----------member data ---------------------------
+  std::string newTagRequest_;
 };

--- a/CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstantsMC.h
+++ b/CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstantsMC.h
@@ -6,7 +6,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -23,16 +22,15 @@
 //
 
 class WriteEcalMiscalibConstantsMC : public edm::EDAnalyzer {
- public:
+public:
   explicit WriteEcalMiscalibConstantsMC(const edm::ParameterSet&);
   ~WriteEcalMiscalibConstantsMC() override;
-  
-  
- private:
-      void beginJob() override ;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
-      
-      // ----------member data ---------------------------
-      std::string newTagRequest_;
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  // ----------member data ---------------------------
+  std::string newTagRequest_;
 };

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibTools.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CaloMiscalibTools
 // Class:      CaloMiscalibTools
-// 
+//
 /**\class CaloMiscalibTools CaloMiscalibTools.h CalibCalorimetry/CaloMiscalibTools/interface/CaloMiscalibTools.h
 
  Description: <one line class summary>
@@ -14,12 +14,11 @@
 // Original Author:  Lorenzo AGOSTINO
 //         Created:  Wed May 31 10:37:45 CEST 2006
 //
-// Modified       : Luca Malgeri 
-// Date:          : 11/09/2006 
+// Modified       : Luca Malgeri
+// Date:          : 11/09/2006
 // Reason         : split class definition (.h) from source code (.cc)
 //
 //
-
 
 // system include files
 
@@ -33,67 +32,57 @@
 //
 // constructors and destructor
 //
-CaloMiscalibTools::CaloMiscalibTools(const edm::ParameterSet& iConfig)
-{
-   //the following line is needed to tell the framework what
-   // data is being produced
+CaloMiscalibTools::CaloMiscalibTools(const edm::ParameterSet& iConfig) {
+  //the following line is needed to tell the framework what
+  // data is being produced
 
-  barrelfileinpath_=iConfig.getUntrackedParameter<std::string> ("fileNameBarrel","");
-  endcapfileinpath_=iConfig.getUntrackedParameter<std::string> ("fileNameEndcap","");
+  barrelfileinpath_ = iConfig.getUntrackedParameter<std::string>("fileNameBarrel", "");
+  endcapfileinpath_ = iConfig.getUntrackedParameter<std::string>("fileNameEndcap", "");
 
-  edm::FileInPath barrelfiletmp("CalibCalorimetry/CaloMiscalibTools/data/"+barrelfileinpath_);
-  edm::FileInPath endcapfiletmp("CalibCalorimetry/CaloMiscalibTools/data/"+endcapfileinpath_);
-  
-  
-  barrelfile_=barrelfiletmp.fullPath();
-  endcapfile_=endcapfiletmp.fullPath();
+  edm::FileInPath barrelfiletmp("CalibCalorimetry/CaloMiscalibTools/data/" + barrelfileinpath_);
+  edm::FileInPath endcapfiletmp("CalibCalorimetry/CaloMiscalibTools/data/" + endcapfileinpath_);
 
-  std::cout <<"Barrel file is:"<< barrelfile_<<std::endl;
-  std::cout <<"endcap file is:"<< endcapfile_<<std::endl;
+  barrelfile_ = barrelfiletmp.fullPath();
+  endcapfile_ = endcapfiletmp.fullPath();
 
+  std::cout << "Barrel file is:" << barrelfile_ << std::endl;
+  std::cout << "endcap file is:" << endcapfile_ << std::endl;
 
-   // added by Zhen (changed since 1_2_0)
-   setWhatProduced(this,&CaloMiscalibTools::produce);
-   findingRecord<EcalIntercalibConstantsRcd>();
-   //now do what ever other initialization is needed
+  // added by Zhen (changed since 1_2_0)
+  setWhatProduced(this, &CaloMiscalibTools::produce);
+  findingRecord<EcalIntercalibConstantsRcd>();
+  //now do what ever other initialization is needed
 }
 
-
-CaloMiscalibTools::~CaloMiscalibTools()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+CaloMiscalibTools::~CaloMiscalibTools() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-CaloMiscalibTools::ReturnType
-CaloMiscalibTools::produce(const EcalIntercalibConstantsRcd& iRecord)
-{
-    CaloMiscalibMapEcal map;
-    map.prefillMap();
-    MiscalibReaderFromXMLEcalBarrel barrelreader_(map);
-    MiscalibReaderFromXMLEcalEndcap endcapreader_(map);
-    if(!barrelfile_.empty()) barrelreader_.parseXMLMiscalibFile(barrelfile_);
-    if(!endcapfile_.empty())endcapreader_.parseXMLMiscalibFile(endcapfile_);
-    map.print();
-    // Added by Zhen, need a new object so to not be deleted at exit
-    //    std::cout<<"about to copy"<<std::endl;
-    CaloMiscalibTools::ReturnType mydata = std::make_unique<EcalIntercalibConstants>(map.get());
-    //    std::cout<<"mydata "<<mydata<<std::endl;
-    return mydata;
+CaloMiscalibTools::ReturnType CaloMiscalibTools::produce(const EcalIntercalibConstantsRcd& iRecord) {
+  CaloMiscalibMapEcal map;
+  map.prefillMap();
+  MiscalibReaderFromXMLEcalBarrel barrelreader_(map);
+  MiscalibReaderFromXMLEcalEndcap endcapreader_(map);
+  if (!barrelfile_.empty())
+    barrelreader_.parseXMLMiscalibFile(barrelfile_);
+  if (!endcapfile_.empty())
+    endcapreader_.parseXMLMiscalibFile(endcapfile_);
+  map.print();
+  // Added by Zhen, need a new object so to not be deleted at exit
+  //    std::cout<<"about to copy"<<std::endl;
+  CaloMiscalibTools::ReturnType mydata = std::make_unique<EcalIntercalibConstants>(map.get());
+  //    std::cout<<"mydata "<<mydata<<std::endl;
+  return mydata;
 }
 
- void CaloMiscalibTools::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&,
- edm::ValidityInterval & oValidity)
- {
- oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),edm::IOVSyncValue::endOfTime());
- 
- }
-
+void CaloMiscalibTools::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                       const edm::IOVSyncValue&,
+                                       edm::ValidityInterval& oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
+}

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/CaloMiscalibToolsMC.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CaloMiscalibToolsMC
 // Class:      CaloMiscalibToolsMC
-// 
+//
 /**\class CaloMiscalibToolsMC CaloMiscalibToolsMC.h CalibCalorimetry/CaloMiscalibToolsMC/interface/CaloMiscalibToolsMC.h
 
  Description: <one line class summary>
@@ -14,12 +14,11 @@
 // Original Author:  Lorenzo AGOSTINO
 //         Created:  Wed May 31 10:37:45 CEST 2006
 //
-// Modified       : Luca Malgeri 
-// Date:          : 11/09/2006 
+// Modified       : Luca Malgeri
+// Date:          : 11/09/2006
 // Reason         : split class definition (.h) from source code (.cc)
 //
 //
-
 
 // system include files
 
@@ -33,67 +32,57 @@
 //
 // constructors and destructor
 //
-CaloMiscalibToolsMC::CaloMiscalibToolsMC(const edm::ParameterSet& iConfig)
-{
-   //the following line is needed to tell the framework what
-   // data is being produced
+CaloMiscalibToolsMC::CaloMiscalibToolsMC(const edm::ParameterSet& iConfig) {
+  //the following line is needed to tell the framework what
+  // data is being produced
 
-  barrelfileinpath_=iConfig.getUntrackedParameter<std::string> ("fileNameBarrel","");
-  endcapfileinpath_=iConfig.getUntrackedParameter<std::string> ("fileNameEndcap","");
+  barrelfileinpath_ = iConfig.getUntrackedParameter<std::string>("fileNameBarrel", "");
+  endcapfileinpath_ = iConfig.getUntrackedParameter<std::string>("fileNameEndcap", "");
 
-  edm::FileInPath barrelfiletmp("CalibCalorimetry/CaloMiscalibTools/data/"+barrelfileinpath_);
-  edm::FileInPath endcapfiletmp("CalibCalorimetry/CaloMiscalibTools/data/"+endcapfileinpath_);
-  
-  
-  barrelfile_=barrelfiletmp.fullPath();
-  endcapfile_=endcapfiletmp.fullPath();
+  edm::FileInPath barrelfiletmp("CalibCalorimetry/CaloMiscalibTools/data/" + barrelfileinpath_);
+  edm::FileInPath endcapfiletmp("CalibCalorimetry/CaloMiscalibTools/data/" + endcapfileinpath_);
 
-  std::cout <<"Barrel file is:"<< barrelfile_<<std::endl;
-  std::cout <<"endcap file is:"<< endcapfile_<<std::endl;
+  barrelfile_ = barrelfiletmp.fullPath();
+  endcapfile_ = endcapfiletmp.fullPath();
 
+  std::cout << "Barrel file is:" << barrelfile_ << std::endl;
+  std::cout << "endcap file is:" << endcapfile_ << std::endl;
 
-   // added by Zhen (changed since 1_2_0)
-   setWhatProduced(this,&CaloMiscalibToolsMC::produce);
-   findingRecord<EcalIntercalibConstantsMCRcd>();
-   //now do what ever other initialization is needed
+  // added by Zhen (changed since 1_2_0)
+  setWhatProduced(this, &CaloMiscalibToolsMC::produce);
+  findingRecord<EcalIntercalibConstantsMCRcd>();
+  //now do what ever other initialization is needed
 }
 
-
-CaloMiscalibToolsMC::~CaloMiscalibToolsMC()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+CaloMiscalibToolsMC::~CaloMiscalibToolsMC() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-CaloMiscalibToolsMC::ReturnType
-CaloMiscalibToolsMC::produce(const EcalIntercalibConstantsMCRcd& iRecord)
-{
-    CaloMiscalibMapEcal map;
-    map.prefillMap();
-    MiscalibReaderFromXMLEcalBarrel barrelreader_(map);
-    MiscalibReaderFromXMLEcalEndcap endcapreader_(map);
-    if(!barrelfile_.empty()) barrelreader_.parseXMLMiscalibFile(barrelfile_);
-    if(!endcapfile_.empty())endcapreader_.parseXMLMiscalibFile(endcapfile_);
-    map.print();
-    // Added by Zhen, need a new object so to not be deleted at exit
-    //    std::cout<<"about to copy"<<std::endl;
-    CaloMiscalibToolsMC::ReturnType mydata = std::make_unique<EcalIntercalibConstantsMC>(map.get());
-    //    std::cout<<"mydata "<<mydata<<std::endl;
-    return mydata;
+CaloMiscalibToolsMC::ReturnType CaloMiscalibToolsMC::produce(const EcalIntercalibConstantsMCRcd& iRecord) {
+  CaloMiscalibMapEcal map;
+  map.prefillMap();
+  MiscalibReaderFromXMLEcalBarrel barrelreader_(map);
+  MiscalibReaderFromXMLEcalEndcap endcapreader_(map);
+  if (!barrelfile_.empty())
+    barrelreader_.parseXMLMiscalibFile(barrelfile_);
+  if (!endcapfile_.empty())
+    endcapreader_.parseXMLMiscalibFile(endcapfile_);
+  map.print();
+  // Added by Zhen, need a new object so to not be deleted at exit
+  //    std::cout<<"about to copy"<<std::endl;
+  CaloMiscalibToolsMC::ReturnType mydata = std::make_unique<EcalIntercalibConstantsMC>(map.get());
+  //    std::cout<<"mydata "<<mydata<<std::endl;
+  return mydata;
 }
 
- void CaloMiscalibToolsMC::setIntervalFor(const edm::eventsetup::EventSetupRecordKey &, const edm::IOVSyncValue&,
- edm::ValidityInterval & oValidity)
- {
- oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(),edm::IOVSyncValue::endOfTime());
- 
- }
-
+void CaloMiscalibToolsMC::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                         const edm::IOVSyncValue&,
+                                         edm::ValidityInterval& oValidity) {
+  oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
+}

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/EcalRecHitRecalib.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/EcalRecHitRecalib.cc
@@ -12,126 +12,109 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-EcalRecHitRecalib::EcalRecHitRecalib(const edm::ParameterSet& iConfig)
-{
-  ecalHitsProducer_ = iConfig.getParameter< std::string > ("ecalRecHitsProducer");
-  barrelHits_ = iConfig.getParameter< std::string > ("barrelHitCollection");
-  endcapHits_ = iConfig.getParameter< std::string > ("endcapHitCollection");
-  RecalibBarrelHits_ = iConfig.getParameter< std::string > ("RecalibBarrelHitCollection");
-  RecalibEndcapHits_ = iConfig.getParameter< std::string > ("RecalibEndcapHitCollection");
-  refactor_ = iConfig.getUntrackedParameter<double> ("Refactor",(double)1);
-  refactor_mean_ = iConfig.getUntrackedParameter<double> ("Refactor_mean",(double)1);
+EcalRecHitRecalib::EcalRecHitRecalib(const edm::ParameterSet& iConfig) {
+  ecalHitsProducer_ = iConfig.getParameter<std::string>("ecalRecHitsProducer");
+  barrelHits_ = iConfig.getParameter<std::string>("barrelHitCollection");
+  endcapHits_ = iConfig.getParameter<std::string>("endcapHitCollection");
+  RecalibBarrelHits_ = iConfig.getParameter<std::string>("RecalibBarrelHitCollection");
+  RecalibEndcapHits_ = iConfig.getParameter<std::string>("RecalibEndcapHitCollection");
+  refactor_ = iConfig.getUntrackedParameter<double>("Refactor", (double)1);
+  refactor_mean_ = iConfig.getUntrackedParameter<double>("Refactor_mean", (double)1);
 
   //register your products
-  produces< EBRecHitCollection >(RecalibBarrelHits_);
-  produces< EERecHitCollection >(RecalibEndcapHits_);
+  produces<EBRecHitCollection>(RecalibBarrelHits_);
+  produces<EERecHitCollection>(RecalibEndcapHits_);
 }
 
-
-EcalRecHitRecalib::~EcalRecHitRecalib()
-{
- 
-
-}
-
+EcalRecHitRecalib::~EcalRecHitRecalib() {}
 
 // ------------ method called to produce the data  ------------
-void
-EcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void EcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   using namespace std;
 
   Handle<EBRecHitCollection> barrelRecHitsHandle;
   Handle<EERecHitCollection> endcapRecHitsHandle;
 
-  const EBRecHitCollection*  EBRecHits = nullptr;
-  const EERecHitCollection*  EERecHits = nullptr; 
- 
-  iEvent.getByLabel(ecalHitsProducer_,barrelHits_,barrelRecHitsHandle);
+  const EBRecHitCollection* EBRecHits = nullptr;
+  const EERecHitCollection* EERecHits = nullptr;
+
+  iEvent.getByLabel(ecalHitsProducer_, barrelHits_, barrelRecHitsHandle);
   if (!barrelRecHitsHandle.isValid()) {
     LogDebug("") << "EcalREcHitMiscalib: Error! can't get product!" << std::endl;
   } else {
-    EBRecHits = barrelRecHitsHandle.product(); // get a ptr to the product
+    EBRecHits = barrelRecHitsHandle.product();  // get a ptr to the product
   }
 
-  iEvent.getByLabel(ecalHitsProducer_,endcapHits_,endcapRecHitsHandle);
+  iEvent.getByLabel(ecalHitsProducer_, endcapHits_, endcapRecHitsHandle);
   if (!endcapRecHitsHandle.isValid()) {
     LogDebug("") << "EcalREcHitMiscalib: Error! can't get product!" << std::endl;
   } else {
-    EERecHits = endcapRecHitsHandle.product(); // get a ptr to the product
+    EERecHits = endcapRecHitsHandle.product();  // get a ptr to the product
   }
 
   //Create empty output collections
   auto RecalibEBRecHitCollection = std::make_unique<EBRecHitCollection>();
   auto RecalibEERecHitCollection = std::make_unique<EERecHitCollection>();
 
-
   // Intercalib constants
   edm::ESHandle<EcalIntercalibConstants> pIcal;
   iSetup.get<EcalIntercalibConstantsRcd>().get(pIcal);
   const EcalIntercalibConstants* ical = pIcal.product();
 
-  if(EBRecHits)
-    {
+  if (EBRecHits) {
+    //loop on all EcalRecHits (barrel)
+    EBRecHitCollection::const_iterator itb;
+    for (itb = EBRecHits->begin(); itb != EBRecHits->end(); ++itb) {
+      // find intercalib constant for this xtal
+      EcalIntercalibConstantMap::const_iterator icalit = ical->getMap().find(itb->id().rawId());
+      EcalIntercalibConstant icalconst = -1;
 
-       //loop on all EcalRecHits (barrel)
-      EBRecHitCollection::const_iterator itb;
-      for (itb=EBRecHits->begin(); itb!=EBRecHits->end(); ++itb) {
-	
-	// find intercalib constant for this xtal
-	EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
-	EcalIntercalibConstant icalconst = -1;
+      if (icalit != ical->getMap().end()) {
+        icalconst = (*icalit);
+        // edm::LogDebug("EcalRecHitRecalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
 
-	if( icalit!=ical->getMap().end() ){
-	  icalconst = (*icalit);
-	  // edm::LogDebug("EcalRecHitRecalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
-
-	} else {
-	  edm::LogError("EcalRecHitRecalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
-              ;
-          }
-          
-          // make the rechit with rescaled energy and put in the output collection
-	icalconst=refactor_mean_+(icalconst-refactor_mean_)*refactor_; //apply additional scaling factor (works if gaussian)
-	EcalRecHit aHit(itb->id(),itb->energy()*icalconst,itb->time());
-	  
-	RecalibEBRecHitCollection->push_back( aHit);
+      } else {
+        edm::LogError("EcalRecHitRecalib") << "No intercalib const found for xtal " << EBDetId(itb->id())
+                                           << "! something wrong with EcalIntercalibConstants in your DB? ";
       }
+
+      // make the rechit with rescaled energy and put in the output collection
+      icalconst = refactor_mean_ +
+                  (icalconst - refactor_mean_) * refactor_;  //apply additional scaling factor (works if gaussian)
+      EcalRecHit aHit(itb->id(), itb->energy() * icalconst, itb->time());
+
+      RecalibEBRecHitCollection->push_back(aHit);
     }
+  }
 
-  if(EERecHits)
-    {
+  if (EERecHits) {
+    //loop on all EcalRecHits (barrel)
+    EERecHitCollection::const_iterator ite;
+    for (ite = EERecHits->begin(); ite != EERecHits->end(); ++ite) {
+      // find intercalib constant for this xtal
+      EcalIntercalibConstantMap::const_iterator icalit = ical->getMap().find(ite->id().rawId());
+      EcalIntercalibConstant icalconst = -1;
 
-       //loop on all EcalRecHits (barrel)
-      EERecHitCollection::const_iterator ite;
-      for (ite=EERecHits->begin(); ite!=EERecHits->end(); ++ite) {
-	
-	// find intercalib constant for this xtal
-	EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(ite->id().rawId());
-	EcalIntercalibConstant icalconst = -1;
-
-	if( icalit!=ical->getMap().end() ){
-	  icalconst = (*icalit);
-	  // edm:: LogDebug("EcalRecHitRecalib") << "Found intercalib for xtal " << EEDetId(ite->id()) << " " << icalconst ;
-          } else {
-            edm::LogError("EcalRecHitRecalib") << "No intercalib const found for xtal " << EEDetId(ite->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
-              ;
-          }
-          
-          // make the rechit with rescaled energy and put in the output collection
-	
-	icalconst=refactor_mean_+(icalconst-refactor_mean_)*refactor_; //apply additional scaling factor (works if gaussian)
-	EcalRecHit aHit(ite->id(),ite->energy()*icalconst,ite->time());
-	
-	RecalibEERecHitCollection->push_back( aHit);
+      if (icalit != ical->getMap().end()) {
+        icalconst = (*icalit);
+        // edm:: LogDebug("EcalRecHitRecalib") << "Found intercalib for xtal " << EEDetId(ite->id()) << " " << icalconst ;
+      } else {
+        edm::LogError("EcalRecHitRecalib") << "No intercalib const found for xtal " << EEDetId(ite->id())
+                                           << "! something wrong with EcalIntercalibConstants in your DB? ";
       }
-    }
 
+      // make the rechit with rescaled energy and put in the output collection
+
+      icalconst = refactor_mean_ +
+                  (icalconst - refactor_mean_) * refactor_;  //apply additional scaling factor (works if gaussian)
+      EcalRecHit aHit(ite->id(), ite->energy() * icalconst, ite->time());
+
+      RecalibEERecHitCollection->push_back(aHit);
+    }
+  }
 
   //Put Recalibrated rechit in the event
   iEvent.put(std::move(RecalibEBRecHitCollection), RecalibBarrelHits_);
   iEvent.put(std::move(RecalibEERecHitCollection), RecalibEndcapHits_);
-  
 }
-

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/HcalRecHitRecalib.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/HcalRecHitRecalib.cc
@@ -9,64 +9,54 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLHcal.h"
 
-HcalRecHitRecalib::HcalRecHitRecalib(const edm::ParameterSet& iConfig)
-{
-
+HcalRecHitRecalib::HcalRecHitRecalib(const edm::ParameterSet& iConfig) {
   tok_hbhe_ = consumes<HBHERecHitCollection>(iConfig.getParameter<edm::InputTag>("hbheInput"));
   tok_ho_ = consumes<HORecHitCollection>(iConfig.getParameter<edm::InputTag>("hoInput"));
   tok_hf_ = consumes<HFRecHitCollection>(iConfig.getParameter<edm::InputTag>("hfInput"));
 
-//   HBHEHitsProducer_ = iConfig.getParameter< std::string > ("HBHERecHitsProducer");
-//   HOHitsProducer_ = iConfig.getParameter< std::string > ("HERecHitsProducer");
-//   HFHitsProducer_ = iConfig.getParameter< std::string > ("HERecHitsProducer");
-//   HBHEHits_ = iConfig.getParameter< std::string > ("HBHEHitCollection");
-//   HFHits_ = iConfig.getParameter< std::string > ("HFHitCollection");
-//   HOHits_ = iConfig.getParameter< std::string > ("HOHitCollection");
+  //   HBHEHitsProducer_ = iConfig.getParameter< std::string > ("HBHERecHitsProducer");
+  //   HOHitsProducer_ = iConfig.getParameter< std::string > ("HERecHitsProducer");
+  //   HFHitsProducer_ = iConfig.getParameter< std::string > ("HERecHitsProducer");
+  //   HBHEHits_ = iConfig.getParameter< std::string > ("HBHEHitCollection");
+  //   HFHits_ = iConfig.getParameter< std::string > ("HFHitCollection");
+  //   HOHits_ = iConfig.getParameter< std::string > ("HOHitCollection");
 
-  RecalibHBHEHits_ = iConfig.getParameter< std::string > ("RecalibHBHEHitCollection");
-  RecalibHFHits_ = iConfig.getParameter< std::string > ("RecalibHFHitCollection");
-  RecalibHOHits_ = iConfig.getParameter< std::string > ("RecalibHOHitCollection");
+  RecalibHBHEHits_ = iConfig.getParameter<std::string>("RecalibHBHEHitCollection");
+  RecalibHFHits_ = iConfig.getParameter<std::string>("RecalibHFHitCollection");
+  RecalibHOHits_ = iConfig.getParameter<std::string>("RecalibHOHitCollection");
 
-  refactor_ = iConfig.getUntrackedParameter<double> ("Refactor",(double)1);
-  refactor_mean_ = iConfig.getUntrackedParameter<double> ("Refactor_mean",(double)1);
+  refactor_ = iConfig.getUntrackedParameter<double>("Refactor", (double)1);
+  refactor_mean_ = iConfig.getUntrackedParameter<double>("Refactor_mean", (double)1);
 
   //register your products
-  produces< HBHERecHitCollection >(RecalibHBHEHits_);
-  produces< HFRecHitCollection >(RecalibHFHits_);
-  produces< HORecHitCollection >(RecalibHOHits_);
+  produces<HBHERecHitCollection>(RecalibHBHEHits_);
+  produces<HFRecHitCollection>(RecalibHFHits_);
+  produces<HORecHitCollection>(RecalibHOHits_);
 
   // here read them from xml (particular to HCAL)
 
-  hcalfileinpath_=iConfig.getUntrackedParameter<std::string> ("fileNameHcal","");
-  edm::FileInPath hcalfiletmp("CalibCalorimetry/CaloMiscalibTools/data/"+hcalfileinpath_);
+  hcalfileinpath_ = iConfig.getUntrackedParameter<std::string>("fileNameHcal", "");
+  edm::FileInPath hcalfiletmp("CalibCalorimetry/CaloMiscalibTools/data/" + hcalfileinpath_);
 
-  hcalfile_=hcalfiletmp.fullPath();
+  hcalfile_ = hcalfiletmp.fullPath();
 }
 
+HcalRecHitRecalib::~HcalRecHitRecalib() {}
 
-HcalRecHitRecalib::~HcalRecHitRecalib()
-{
- 
-
-}
-
-void
-HcalRecHitRecalib::beginRun(const edm::Run&, const edm::EventSetup& iSetup)
-{
+void HcalRecHitRecalib::beginRun(const edm::Run&, const edm::EventSetup& iSetup) {
   edm::ESHandle<HcalTopology> topology;
-  iSetup.get<HcalRecNumberingRecord>().get( topology );
-  
+  iSetup.get<HcalRecNumberingRecord>().get(topology);
+
   mapHcal_.prefillMap(*topology);
 
   MiscalibReaderFromXMLHcal hcalreader_(mapHcal_);
-  if(!hcalfile_.empty()) hcalreader_.parseXMLMiscalibFile(hcalfile_);
+  if (!hcalfile_.empty())
+    hcalreader_.parseXMLMiscalibFile(hcalfile_);
   mapHcal_.print();
 }
 
 // ------------ method called to produce the data  ------------
-void
-HcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void HcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   using namespace std;
 
@@ -74,41 +64,39 @@ HcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   Handle<HFRecHitCollection> HFRecHitsHandle;
   Handle<HORecHitCollection> HORecHitsHandle;
 
-  const HBHERecHitCollection*  HBHERecHits = nullptr;
-  const HFRecHitCollection*  HFRecHits = nullptr;
-  const HORecHitCollection*  HORecHits = nullptr;
+  const HBHERecHitCollection* HBHERecHits = nullptr;
+  const HFRecHitCollection* HFRecHits = nullptr;
+  const HORecHitCollection* HORecHits = nullptr;
 
-  iEvent.getByToken(tok_hbhe_,HBHERecHitsHandle);
+  iEvent.getByToken(tok_hbhe_, HBHERecHitsHandle);
   if (!HBHERecHitsHandle.isValid()) {
     LogDebug("") << "HcalREcHitRecalib: Error! can't get product!" << std::endl;
   } else {
-    HBHERecHits = HBHERecHitsHandle.product(); // get a ptr to the product
+    HBHERecHits = HBHERecHitsHandle.product();  // get a ptr to the product
   }
 
-  iEvent.getByToken(tok_ho_,HORecHitsHandle);
+  iEvent.getByToken(tok_ho_, HORecHitsHandle);
   if (!HORecHitsHandle.isValid()) {
     LogDebug("") << "HcalREcHitRecalib: Error! can't get product!" << std::endl;
   } else {
-    HORecHits = HORecHitsHandle.product(); // get a ptr to the product
+    HORecHits = HORecHitsHandle.product();  // get a ptr to the product
   }
 
-  iEvent.getByToken(tok_hf_,HFRecHitsHandle);
+  iEvent.getByToken(tok_hf_, HFRecHitsHandle);
   if (!HFRecHitsHandle.isValid()) {
     LogDebug("") << "HcalREcHitRecalib: Error! can't get product!" << std::endl;
   } else {
-    HFRecHits = HFRecHitsHandle.product(); // get a ptr to the product
+    HFRecHits = HFRecHitsHandle.product();  // get a ptr to the product
   }
 
+  //     iEvent.getByLabel(HBHEHitsProducer_,HBHEHits_,HBHERecHitsHandle);
+  //     HBHERecHits = HBHERecHitsHandle.product(); // get a ptr to the product
 
-//     iEvent.getByLabel(HBHEHitsProducer_,HBHEHits_,HBHERecHitsHandle);
-//     HBHERecHits = HBHERecHitsHandle.product(); // get a ptr to the product
+  //     iEvent.getByLabel(HFHitsProducer_,HFHits_,HFRecHitsHandle);
+  //     HFRecHits = HFRecHitsHandle.product(); // get a ptr to the product
 
-//     iEvent.getByLabel(HFHitsProducer_,HFHits_,HFRecHitsHandle);
-//     HFRecHits = HFRecHitsHandle.product(); // get a ptr to the product
-
-//     iEvent.getByLabel(HOHitsProducer_,HOHits_,HORecHitsHandle);
-//     HORecHits = HORecHitsHandle.product(); // get a ptr to the product
-
+  //     iEvent.getByLabel(HOHitsProducer_,HOHits_,HORecHitsHandle);
+  //     HORecHits = HORecHitsHandle.product(); // get a ptr to the product
 
   //Create empty output collections
   auto RecalibHBHERecHitCollection = std::make_unique<HBHERecHitCollection>();
@@ -120,103 +108,95 @@ HcalRecHitRecalib::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   //  iSetup.get<EcalIntercalibConstantsRcd>().get(pIcal);
   //  const EcalIntercalibConstants* ical = pIcal.product();
 
-  if(HBHERecHits)
-    {
+  if (HBHERecHits) {
+    //loop on all EcalRecHits (barrel)
+    HBHERecHitCollection::const_iterator itHBHE;
+    for (itHBHE = HBHERecHits->begin(); itHBHE != HBHERecHits->end(); ++itHBHE) {
+      // find intercalib constant for this cell
 
-       //loop on all EcalRecHits (barrel)
-      HBHERecHitCollection::const_iterator itHBHE;
-      for (itHBHE=HBHERecHits->begin(); itHBHE!=HBHERecHits->end(); ++itHBHE) {
-	
-	// find intercalib constant for this cell
+      //	EcalIntercalibConstants::EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
+      //	EcalIntercalibConstants::EcalIntercalibConstant icalconst;
 
-	//	EcalIntercalibConstants::EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
-	//	EcalIntercalibConstants::EcalIntercalibConstant icalconst;
+      //	if( icalit!=ical->getMap().end() ){
+      //	  icalconst = icalit->second;
+      // edm::LogDebug("EcalRecHitMiscalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
 
-	//	if( icalit!=ical->getMap().end() ){
-	//	  icalconst = icalit->second;
-	  // edm::LogDebug("EcalRecHitMiscalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
+      //	} else {
+      //	  edm::LogError("EcalRecHitMiscalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
+      //              ;
+      //          }
 
-	//	} else {
-	//	  edm::LogError("EcalRecHitMiscalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
-	//              ;
-	//          }
-          
-	float icalconst=(mapHcal_.get().find(itHBHE->id().rawId()))->second;
-          // make the rechit with rescaled energy and put in the output collection
+      float icalconst = (mapHcal_.get().find(itHBHE->id().rawId()))->second;
+      // make the rechit with rescaled energy and put in the output collection
 
-	icalconst=refactor_mean_+(icalconst-refactor_mean_)*refactor_; //apply additional scaling factor (works if gaussian)	
-	HBHERecHit aHit(itHBHE->id(),itHBHE->energy()*icalconst,itHBHE->time());
-	
-	RecalibHBHERecHitCollection->push_back( aHit);
-      }
+      icalconst = refactor_mean_ +
+                  (icalconst - refactor_mean_) * refactor_;  //apply additional scaling factor (works if gaussian)
+      HBHERecHit aHit(itHBHE->id(), itHBHE->energy() * icalconst, itHBHE->time());
+
+      RecalibHBHERecHitCollection->push_back(aHit);
     }
+  }
 
-  if(HFRecHits)
-    {
+  if (HFRecHits) {
+    //loop on all EcalRecHits (barrel)
+    HFRecHitCollection::const_iterator itHF;
+    for (itHF = HFRecHits->begin(); itHF != HFRecHits->end(); ++itHF) {
+      // find intercalib constant for this cell
 
-       //loop on all EcalRecHits (barrel)
-      HFRecHitCollection::const_iterator itHF;
-      for (itHF=HFRecHits->begin(); itHF!=HFRecHits->end(); ++itHF) {
-	
-	// find intercalib constant for this cell
+      //	EcalIntercalibConstants::EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
+      //	EcalIntercalibConstants::EcalIntercalibConstant icalconst;
 
-	//	EcalIntercalibConstants::EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
-	//	EcalIntercalibConstants::EcalIntercalibConstant icalconst;
+      //	if( icalit!=ical->getMap().end() ){
+      //	  icalconst = icalit->second;
+      // edm::LogDebug("EcalRecHitMiscalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
 
-	//	if( icalit!=ical->getMap().end() ){
-	//	  icalconst = icalit->second;
-	  // edm::LogDebug("EcalRecHitMiscalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
+      //	} else {
+      //	  edm::LogError("EcalRecHitMiscalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
+      //              ;
+      //          }
 
-	//	} else {
-	//	  edm::LogError("EcalRecHitMiscalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
-	//              ;
-	//          }
-          
-          // make the rechit with rescaled energy and put in the output collection
-	
-	float icalconst=(mapHcal_.get().find(itHF->id().rawId()))->second;
-	icalconst=refactor_mean_+(icalconst-refactor_mean_)*refactor_; //apply additional scaling factor (works if gaussian)	
-	HFRecHit aHit(itHF->id(),itHF->energy()*icalconst,itHF->time());
-	
-	RecalibHFRecHitCollection->push_back( aHit);
-      }
+      // make the rechit with rescaled energy and put in the output collection
+
+      float icalconst = (mapHcal_.get().find(itHF->id().rawId()))->second;
+      icalconst = refactor_mean_ +
+                  (icalconst - refactor_mean_) * refactor_;  //apply additional scaling factor (works if gaussian)
+      HFRecHit aHit(itHF->id(), itHF->energy() * icalconst, itHF->time());
+
+      RecalibHFRecHitCollection->push_back(aHit);
     }
+  }
 
-  if(HORecHits)
-    {
+  if (HORecHits) {
+    //loop on all EcalRecHits (barrel)
+    HORecHitCollection::const_iterator itHO;
+    for (itHO = HORecHits->begin(); itHO != HORecHits->end(); ++itHO) {
+      // find intercalib constant for this cell
 
-       //loop on all EcalRecHits (barrel)
-      HORecHitCollection::const_iterator itHO;
-      for (itHO=HORecHits->begin(); itHO!=HORecHits->end(); ++itHO) {
-	
-	// find intercalib constant for this cell
+      //	EcalIntercalibConstants::EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
+      //	EcalIntercalibConstants::EcalIntercalibConstant icalconst;
 
-	//	EcalIntercalibConstants::EcalIntercalibConstantMap::const_iterator icalit=ical->getMap().find(itb->id().rawId());
-	//	EcalIntercalibConstants::EcalIntercalibConstant icalconst;
+      //	if( icalit!=ical->getMap().end() ){
+      //	  icalconst = icalit->second;
+      // edm::LogDebug("EcalRecHitMiscalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
 
-	//	if( icalit!=ical->getMap().end() ){
-	//	  icalconst = icalit->second;
-	  // edm::LogDebug("EcalRecHitMiscalib") << "Found intercalib for xtal " << EBDetId(itb->id()) << " " << icalconst ;
+      //	} else {
+      //	  edm::LogError("EcalRecHitMiscalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
+      //              ;
+      //          }
 
-	//	} else {
-	//	  edm::LogError("EcalRecHitMiscalib") << "No intercalib const found for xtal " << EBDetId(itb->id()) << "! something wrong with EcalIntercalibConstants in your DB? "
-	//              ;
-	//          }
-          
-          // make the rechit with rescaled energy and put in the output collection
+      // make the rechit with rescaled energy and put in the output collection
 
-	float icalconst=(mapHcal_.get().find(itHO->id().rawId()))->second;
-	icalconst=refactor_mean_+(icalconst-refactor_mean_)*refactor_; //apply additional scaling factor (works if gaussian)	
-	HORecHit aHit(itHO->id(),itHO->energy()*icalconst,itHO->time());
-	  
-	  RecalibHORecHitCollection->push_back( aHit);
-      }
+      float icalconst = (mapHcal_.get().find(itHO->id().rawId()))->second;
+      icalconst = refactor_mean_ +
+                  (icalconst - refactor_mean_) * refactor_;  //apply additional scaling factor (works if gaussian)
+      HORecHit aHit(itHO->id(), itHO->energy() * icalconst, itHO->time());
+
+      RecalibHORecHitCollection->push_back(aHit);
     }
-
+  }
 
   //Put Recalibrated rechit in the event
   iEvent.put(std::move(RecalibHBHERecHitCollection), RecalibHBHEHits_);
   iEvent.put(std::move(RecalibHFRecHitCollection), RecalibHFHits_);
   iEvent.put(std::move(RecalibHORecHitCollection), RecalibHOHits_);
 }
-

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/SealModule.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/SealModule.cc
@@ -8,11 +8,9 @@
 #include "CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstants.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/WriteEcalMiscalibConstantsMC.h"
 
-
 DEFINE_FWK_EVENTSETUP_SOURCE(CaloMiscalibTools);
 DEFINE_FWK_EVENTSETUP_SOURCE(CaloMiscalibToolsMC);
 DEFINE_FWK_MODULE(EcalRecHitRecalib);
 DEFINE_FWK_MODULE(HcalRecHitRecalib);
 DEFINE_FWK_MODULE(WriteEcalMiscalibConstants);
 DEFINE_FWK_MODULE(WriteEcalMiscalibConstantsMC);
-

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
@@ -2,7 +2,7 @@
 //
 // Package:    WriteEcalMiscalibConstants
 // Class:      WriteEcalMiscalibConstants
-// 
+//
 /**\class WriteEcalMiscalibConstants WriteEcalMiscalibConstants.cc CalibCalorimetry/WriteEcalMiscalibConstants/src/WriteEcalMiscalibConstants.cc
 
  Description: <one line class summary>
@@ -16,14 +16,10 @@
 //
 //
 
-
 // system include files
 #include <iostream>
 
 // user include files
-
-
-
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -47,62 +43,48 @@
 //
 // constructors and destructor
 //
-WriteEcalMiscalibConstants::WriteEcalMiscalibConstants(const edm::ParameterSet& iConfig)
-{
-   //now do what ever initialization is needed
-  newTagRequest_ = iConfig.getParameter< std::string > ("NewTagRequest");
-
-
+WriteEcalMiscalibConstants::WriteEcalMiscalibConstants(const edm::ParameterSet& iConfig) {
+  //now do what ever initialization is needed
+  newTagRequest_ = iConfig.getParameter<std::string>("NewTagRequest");
 }
 
-
-WriteEcalMiscalibConstants::~WriteEcalMiscalibConstants()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+WriteEcalMiscalibConstants::~WriteEcalMiscalibConstants() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-WriteEcalMiscalibConstants::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void WriteEcalMiscalibConstants::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
   // Intercalib constants
-   edm::ESHandle<EcalIntercalibConstants> pIcal;
-   iSetup.get<EcalIntercalibConstantsRcd>().get(pIcal);
-   const EcalIntercalibConstants* Mcal = pIcal.product();
+  edm::ESHandle<EcalIntercalibConstants> pIcal;
+  iSetup.get<EcalIntercalibConstantsRcd>().get(pIcal);
+  const EcalIntercalibConstants* Mcal = pIcal.product();
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( poolDbService.isAvailable() ){
-    if ( poolDbService->isNewTagRequest(newTagRequest_) ){
-      std::cout<<" Creating a  new one "<<std::endl;
-      poolDbService->createNewIOV<const EcalIntercalibConstants>( Mcal, poolDbService->beginOfTime(), poolDbService->endOfTime(),newTagRequest_);
-      std::cout<<"Done" << std::endl;
-    }else{
-      std::cout<<"Old One "<<std::endl;
-       poolDbService->appendSinceTime<const EcalIntercalibConstants>( Mcal, poolDbService->currentTime(),newTagRequest_);
+  if (poolDbService.isAvailable()) {
+    if (poolDbService->isNewTagRequest(newTagRequest_)) {
+      std::cout << " Creating a  new one " << std::endl;
+      poolDbService->createNewIOV<const EcalIntercalibConstants>(
+          Mcal, poolDbService->beginOfTime(), poolDbService->endOfTime(), newTagRequest_);
+      std::cout << "Done" << std::endl;
+    } else {
+      std::cout << "Old One " << std::endl;
+      poolDbService->appendSinceTime<const EcalIntercalibConstants>(Mcal, poolDbService->currentTime(), newTagRequest_);
     }
-  }  
+  }
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-WriteEcalMiscalibConstants::beginJob()
-{
-}
+void WriteEcalMiscalibConstants::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void 
 
 WriteEcalMiscalibConstants::endJob() {
-  std::cout << "Here is the end" << std::endl; 
+  std::cout << "Here is the end" << std::endl;
 }
-

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
@@ -2,7 +2,7 @@
 //
 // Package:    WriteEcalMiscalibConstantsMC
 // Class:      WriteEcalMiscalibConstantsMC
-// 
+//
 /**\class WriteEcalMiscalibConstantsMC WriteEcalMiscalibConstantsMC.cc CalibCalorimetry/WriteEcalMiscalibConstantsMC/src/WriteEcalMiscalibConstantsMC.cc
 
  Description: <one line class summary>
@@ -16,14 +16,10 @@
 //
 //
 
-
 // system include files
 #include <iostream>
 
 // user include files
-
-
-
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -47,62 +43,49 @@
 //
 // constructors and destructor
 //
-WriteEcalMiscalibConstantsMC::WriteEcalMiscalibConstantsMC(const edm::ParameterSet& iConfig)
-{
-   //now do what ever initialization is needed
-  newTagRequest_ = iConfig.getParameter< std::string > ("NewTagRequest");
-
-
+WriteEcalMiscalibConstantsMC::WriteEcalMiscalibConstantsMC(const edm::ParameterSet& iConfig) {
+  //now do what ever initialization is needed
+  newTagRequest_ = iConfig.getParameter<std::string>("NewTagRequest");
 }
 
-
-WriteEcalMiscalibConstantsMC::~WriteEcalMiscalibConstantsMC()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+WriteEcalMiscalibConstantsMC::~WriteEcalMiscalibConstantsMC() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-WriteEcalMiscalibConstantsMC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void WriteEcalMiscalibConstantsMC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
   // Intercalib constants
-   edm::ESHandle<EcalIntercalibConstantsMC> pIcal;
-   iSetup.get<EcalIntercalibConstantsMCRcd>().get(pIcal);
-   const EcalIntercalibConstantsMC* Mcal = pIcal.product();
+  edm::ESHandle<EcalIntercalibConstantsMC> pIcal;
+  iSetup.get<EcalIntercalibConstantsMCRcd>().get(pIcal);
+  const EcalIntercalibConstantsMC* Mcal = pIcal.product();
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( poolDbService.isAvailable() ){
-    if ( poolDbService->isNewTagRequest(newTagRequest_) ){
-      std::cout<<" Creating a  new one "<<std::endl;
-      poolDbService->createNewIOV<const EcalIntercalibConstantsMC>( Mcal, poolDbService->beginOfTime(), poolDbService->endOfTime(),newTagRequest_);
-      std::cout<<"Done" << std::endl;
-    }else{
-      std::cout<<"Old One "<<std::endl;
-       poolDbService->appendSinceTime<const EcalIntercalibConstantsMC>( Mcal, poolDbService->currentTime(),newTagRequest_);
+  if (poolDbService.isAvailable()) {
+    if (poolDbService->isNewTagRequest(newTagRequest_)) {
+      std::cout << " Creating a  new one " << std::endl;
+      poolDbService->createNewIOV<const EcalIntercalibConstantsMC>(
+          Mcal, poolDbService->beginOfTime(), poolDbService->endOfTime(), newTagRequest_);
+      std::cout << "Done" << std::endl;
+    } else {
+      std::cout << "Old One " << std::endl;
+      poolDbService->appendSinceTime<const EcalIntercalibConstantsMC>(
+          Mcal, poolDbService->currentTime(), newTagRequest_);
     }
-  }  
+  }
 }
-
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-WriteEcalMiscalibConstantsMC::beginJob()
-{
-}
+void WriteEcalMiscalibConstantsMC::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void 
 
 WriteEcalMiscalibConstantsMC::endJob() {
-  std::cout << "Here is the end" << std::endl; 
+  std::cout << "Here is the end" << std::endl;
 }
-

--- a/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXML.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXML.cc
@@ -9,127 +9,106 @@
 
 using namespace xercesc;
 
-int MiscalibReaderFromXML::s_numberOfInstances = 0; //to check that there is only 1 instance
+int MiscalibReaderFromXML::s_numberOfInstances = 0;  //to check that there is only 1 instance
 
-inline std::string _toString(const XMLCh *toTranscode){
-	std::string tmp(XMLString::transcode(toTranscode));
-	return tmp;
+inline std::string _toString(const XMLCh* toTranscode) {
+  std::string tmp(XMLString::transcode(toTranscode));
+  return tmp;
 }
 
-inline XMLCh*  _toDOMS( std::string temp ){
-	XMLCh* buff = XMLString::transcode(temp.c_str());    
-	return  buff;
+inline XMLCh* _toDOMS(std::string temp) {
+  XMLCh* buff = XMLString::transcode(temp.c_str());
+  return buff;
 }
 
+MiscalibReaderFromXML::MiscalibReaderFromXML(CaloMiscalibMap& caloMap) : caloMap_(caloMap) {
+  try {
+    //std::cout << "Xerces-c initialization Number "
+    //<< s_numberOfInstances<<std::endl;
+    if (s_numberOfInstances == 0)
+      cms::concurrency::xercesInitialize();
+  } catch (const XMLException& e) {
+    std::cout << "Xerces-c error in initialization \n"
+              << "Exception message is:  \n"
+              << _toString(e.getMessage()) << std::endl;
+    // throw an exception here
+  }
 
-
-MiscalibReaderFromXML::MiscalibReaderFromXML(CaloMiscalibMap & caloMap):caloMap_(caloMap){
-      
-	     
-	try { 
-		//std::cout << "Xerces-c initialization Number "
-		//<< s_numberOfInstances<<std::endl;
-		if (s_numberOfInstances==0) 
-		cms::concurrency::xercesInitialize();  
-	}
-	catch (const XMLException& e) {
-		std::cout << "Xerces-c error in initialization \n"
-		<< "Exception message is:  \n"
-		<< _toString(e.getMessage()) <<std::endl;
-		// throw an exception here
-	}
- 
-	++s_numberOfInstances;
-	
-	
-	
-	
+  ++s_numberOfInstances;
 }
 //////////////////////////////////////////////////////////////////////////////////
 
-
-int MiscalibReaderFromXML::getIntAttribute(DOMNamedNodeMap * attribute, const std::string & attribute_name)
-{
-bool well_formed_string;
-int retval = MiscalibReaderFromXMLDomUtils::getIntAttribute(attribute,attribute_name,well_formed_string);
-if(!well_formed_string) std::cout << "MiscalibReaderFromXML::getIntAttribute PROBLEMS ...!!!" << std::endl;
+int MiscalibReaderFromXML::getIntAttribute(DOMNamedNodeMap* attribute, const std::string& attribute_name) {
+  bool well_formed_string;
+  int retval = MiscalibReaderFromXMLDomUtils::getIntAttribute(attribute, attribute_name, well_formed_string);
+  if (!well_formed_string)
+    std::cout << "MiscalibReaderFromXML::getIntAttribute PROBLEMS ...!!!" << std::endl;
 
   return retval;
 }
 
 //////////////////////////////////////////////////////////////////////////////////
 
-double MiscalibReaderFromXML::getScalingFactor(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute)
-{
-return MiscalibReaderFromXML::getFloatAttribute(attribute,"scale_factor");
+double MiscalibReaderFromXML::getScalingFactor(XERCES_CPP_NAMESPACE::DOMNamedNodeMap* attribute) {
+  return MiscalibReaderFromXML::getFloatAttribute(attribute, "scale_factor");
 }
 
 //////////////////////////////////////////////////////////////////////////////////
 
-double MiscalibReaderFromXML::getFloatAttribute(DOMNamedNodeMap * attribute, const std::string & attribute_name)
-{
-bool well_formed_string;
-double retval = MiscalibReaderFromXMLDomUtils::getFloatAttribute(attribute,attribute_name,well_formed_string);
-if(!well_formed_string) std::cout << "MiscalibReaderFromXML::getFloatAttribute PROBLEMS ...!!!" << std::endl;
-  
+double MiscalibReaderFromXML::getFloatAttribute(DOMNamedNodeMap* attribute, const std::string& attribute_name) {
+  bool well_formed_string;
+  double retval = MiscalibReaderFromXMLDomUtils::getFloatAttribute(attribute, attribute_name, well_formed_string);
+  if (!well_formed_string)
+    std::cout << "MiscalibReaderFromXML::getFloatAttribute PROBLEMS ...!!!" << std::endl;
+
   return retval;
 }
 
 //////////////////////////////////////////////////////////////////////////////////
 
-bool MiscalibReaderFromXML::parseXMLMiscalibFile(std::string configFile){
+bool MiscalibReaderFromXML::parseXMLMiscalibFile(std::string configFile) {
+  XercesDOMParser* parser = new XercesDOMParser;
+  parser->setValidationScheme(XercesDOMParser::Val_Auto);
+  parser->setDoNamespaces(false);
+  parser->parse(configFile.c_str());
+  DOMDocument* doc = parser->getDocument();
+  assert(doc);
 
-	XercesDOMParser* parser = new XercesDOMParser;     
-	parser->setValidationScheme(XercesDOMParser::Val_Auto);
-	parser->setDoNamespaces(false);
-	parser->parse(configFile.c_str()); 
-	DOMDocument* doc = parser->getDocument();
-	assert(doc);
+  unsigned int linkTagsNum = doc->getElementsByTagName(_toDOMS("Cell"))->getLength();
+  // The following should be on LogInfo
+  //std::cout << "Read number of Cells = " << linkTagsNum << std::endl;
 
-        unsigned int linkTagsNum = doc->getElementsByTagName(_toDOMS("Cell"))->getLength();
-        // The following should be on LogInfo
-        //std::cout << "Read number of Cells = " << linkTagsNum << std::endl;
+  if (linkTagsNum == 0)
+    std::cout << "Number of Cells in file is 0 - probably bad file format" << std::endl;
 
-        if(linkTagsNum==0) std::cout <<"Number of Cells in file is 0 - probably bad file format"<<std::endl;
+  int count = 0;
+  for (unsigned int i = 0; i < linkTagsNum; i++) {
+    DOMNode* linkNode = doc->getElementsByTagName(_toDOMS("Cell"))->item(i);
+    ///Get ME name
+    if (!linkNode) {
+      std::cout << "Node LINK does not exist, i=" << i << std::endl;
+      return true;
+    }
+    DOMElement* linkElement = static_cast<DOMElement*>(linkNode);
+    if (!linkElement) {
+      std::cout << "Element LINK does not exist, i=" << i << std::endl;
+      return true;
+    }
 
-        int count=0;	
-	for (unsigned int i=0; i<linkTagsNum; i++){
-			
-		
-		DOMNode* linkNode = doc->getElementsByTagName(_toDOMS("Cell"))->item(i);
-		///Get ME name
-		if (! linkNode){
-			std::cout<<"Node LINK does not exist, i="<<i<<std::endl;
-			return true;
-		}
-		DOMElement* linkElement = static_cast<DOMElement *>(linkNode);          
-		if (! linkElement){
-			std::cout<<"Element LINK does not exist, i="<<i<<std::endl;
-			return true;		 
-		}
+    DOMNamedNodeMap* attributes = linkNode->getAttributes();
+    double scalingfactor = getScalingFactor(attributes);
 
+    DetId cell = parseCellEntry(attributes);
 
-                DOMNamedNodeMap *attributes = linkNode->getAttributes();
-		double scalingfactor= getScalingFactor(attributes);
-		
-		
-		
-		DetId cell = parseCellEntry(attributes);
-		
-		if(cell!= DetId(0)) 
-		{ 
-		count++;
-		caloMap_.addCell(cell,scalingfactor);
-		} else  
-		{
-		  //		std::cout << "Null received" << std::endl;
-		}
-		
-	}
- 
-        // The following should be on LogInfo
-        // std::cout << "Number of good Cells = " << count << std::endl;
-	return false;
+    if (cell != DetId(0)) {
+      count++;
+      caloMap_.addCell(cell, scalingfactor);
+    } else {
+      //		std::cout << "Null received" << std::endl;
+    }
+  }
 
+  // The following should be on LogInfo
+  // std::cout << "Number of good Cells = " << count << std::endl;
+  return false;
 }
-

--- a/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXMLEcalBarrel.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXMLEcalBarrel.cc
@@ -1,21 +1,13 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalBarrel.h"
 
-
-
-DetId MiscalibReaderFromXMLEcalBarrel::parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute)
-{
-
-EBDetId cell= MiscalibReaderFromXMLEcalBarrel::getCellFromAttributes(
-                                            getIntAttribute(attribute,"eta_index"),
-                                            getIntAttribute(attribute,"phi_index")
-                                            );
-return cell;
+DetId MiscalibReaderFromXMLEcalBarrel::parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute) {
+  EBDetId cell = MiscalibReaderFromXMLEcalBarrel::getCellFromAttributes(getIntAttribute(attribute, "eta_index"),
+                                                                        getIntAttribute(attribute, "phi_index"));
+  return cell;
 }
 
-EBDetId MiscalibReaderFromXMLEcalBarrel::getCellFromAttributes(int ieta, int iphi)
-{
-EBDetId cell(ieta,iphi);
-return cell;
+EBDetId MiscalibReaderFromXMLEcalBarrel::getCellFromAttributes(int ieta, int iphi) {
+  EBDetId cell(ieta, iphi);
+  return cell;
 }
-

--- a/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXMLEcalEndcap.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXMLEcalEndcap.cc
@@ -1,38 +1,27 @@
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLEcalEndcap.h"
 
-
-DetId MiscalibReaderFromXMLEcalEndcap::parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute)
-{
-
-EEDetId cell= MiscalibReaderFromXMLEcalEndcap::getCellFromAttributes(
-                                            getIntAttribute(attribute,"x_index"),
-                                            getIntAttribute(attribute,"y_index"),
-                                            getIntAttribute(attribute,"z_index")
-                                            );
-return cell;
+DetId MiscalibReaderFromXMLEcalEndcap::parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute) {
+  EEDetId cell = MiscalibReaderFromXMLEcalEndcap::getCellFromAttributes(getIntAttribute(attribute, "x_index"),
+                                                                        getIntAttribute(attribute, "y_index"),
+                                                                        getIntAttribute(attribute, "z_index"));
+  return cell;
 }
 
-EEDetId MiscalibReaderFromXMLEcalEndcap::getCellFromAttributes(int ix, int iy, int iz)
-{
+EEDetId MiscalibReaderFromXMLEcalEndcap::getCellFromAttributes(int ix, int iy, int iz) {
+  try {
+    if (EEDetId::validDetId(ix, iy, iz)) {
+      EEDetId cell(ix, iy, iz);
+      return cell;
+    } else {
+      return EEDetId(0);
+    }
+  }
 
-       try 
-         {
-	   if (EEDetId::validDetId(ix, iy, iz)) {
-	     EEDetId cell(ix,iy,iz);
-	     return cell;
-	   } else {
-	     return EEDetId(0);
-	   }
-         }
-    
-           catch (...)
-	  
-        {
-          std::cout << "Null coordinates = "<< ix << "," << iy << "," << iz << std::endl;
-	  return EEDetId(0);
-        }
-	    
-	    
+  catch (...)
+
+  {
+    std::cout << "Null coordinates = " << ix << "," << iy << "," << iz << std::endl;
+    return EEDetId(0);
+  }
 }
-

--- a/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXMLHcal.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXMLHcal.cc
@@ -1,31 +1,20 @@
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "CalibCalorimetry/CaloMiscalibTools/interface/MiscalibReaderFromXMLHcal.h"
 
-
-
-DetId MiscalibReaderFromXMLHcal::parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute)
-{
-
-HcalDetId cell= MiscalibReaderFromXMLHcal::getCellFromAttributes(
-                                            getIntAttribute(attribute,"det_index"),
-                                            getIntAttribute(attribute,"eta_index"),
-                                            getIntAttribute(attribute,"phi_index"),
-                                            getIntAttribute(attribute,"depth_index")
-                                            );
-return cell;
+DetId MiscalibReaderFromXMLHcal::parseCellEntry(XERCES_CPP_NAMESPACE::DOMNamedNodeMap *attribute) {
+  HcalDetId cell = MiscalibReaderFromXMLHcal::getCellFromAttributes(getIntAttribute(attribute, "det_index"),
+                                                                    getIntAttribute(attribute, "eta_index"),
+                                                                    getIntAttribute(attribute, "phi_index"),
+                                                                    getIntAttribute(attribute, "depth_index"));
+  return cell;
 }
 
-HcalDetId MiscalibReaderFromXMLHcal::getCellFromAttributes(int idet, int ieta, int iphi, int idepth)
-{
-  try
-    {
-      HcalDetId cell((HcalSubdetector) idet, ieta, iphi, idepth);
-      return cell;
-    }
-  catch (...)
-    {
-      std::cout << "Null coordinates = "<< idet << "," << ieta << "," << iphi << "," << idepth << std::endl;
-      return HcalDetId(0);
-    }
+HcalDetId MiscalibReaderFromXMLHcal::getCellFromAttributes(int idet, int ieta, int iphi, int idepth) {
+  try {
+    HcalDetId cell((HcalSubdetector)idet, ieta, iphi, idepth);
+    return cell;
+  } catch (...) {
+    std::cout << "Null coordinates = " << idet << "," << ieta << "," << iphi << "," << idepth << std::endl;
+    return HcalDetId(0);
+  }
 }
-

--- a/CalibCalorimetry/CastorCalib/interface/CastorAlgoUtils.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorAlgoUtils.h
@@ -7,15 +7,12 @@
 namespace reco {
   namespace castor {
 
-    void getLinearizedADC(const CastorQIEShape& shape,
-		      const CastorQIECoder* coder,
-		      int bins,int capid,
-		      float& lo,
-		      float& hi);
+    void getLinearizedADC(
+        const CastorQIEShape& shape, const CastorQIECoder* coder, int bins, int capid, float& lo, float& hi);
 
     float maxDiff(float one, float two, float three, float four);
 
-  }
-}
+  }  // namespace castor
+}  // namespace reco
 
 #endif

--- a/CalibCalorimetry/CastorCalib/interface/CastorDbASCIIIO.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorDbASCIIIO.h
@@ -35,27 +35,27 @@ Text file formats for different data types is as following:
   
 */
 namespace CastorDbASCIIIO {
-  bool getObject (std::istream& fInput, CastorPedestals& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorPedestals& fObject);
-  bool getObject (std::istream& fInput, CastorPedestalWidths& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorPedestalWidths& fObject);
-  bool getObject (std::istream& fInput, CastorGains& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorGains& fObject);
-  bool getObject (std::istream& fInput, CastorGainWidths& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorGainWidths& fObject);
-  bool getObject (std::istream& fInput, CastorQIEData& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorQIEData& fObject);
-  bool getObject (std::istream& fInput, CastorCalibrationQIEData& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorCalibrationQIEData& fObject);
-  bool getObject (std::istream& fInput, CastorElectronicsMap& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorElectronicsMap& fObject);
-  bool getObject (std::istream& fInput, CastorChannelQuality& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorChannelQuality& fObject);
-  bool getObject (std::istream& fInput, CastorRecoParams& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorRecoParams& fObject);
-  bool getObject (std::istream& fInput, CastorSaturationCorrs& fObject);
-  bool dumpObject (std::ostream& fOutput, const CastorSaturationCorrs& fObject);
-  DetId getId (const std::vector <std::string> & items);
-  void dumpId (std::ostream& fOutput, DetId id);
-} 
+  bool getObject(std::istream& fInput, CastorPedestals& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorPedestals& fObject);
+  bool getObject(std::istream& fInput, CastorPedestalWidths& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorPedestalWidths& fObject);
+  bool getObject(std::istream& fInput, CastorGains& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorGains& fObject);
+  bool getObject(std::istream& fInput, CastorGainWidths& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorGainWidths& fObject);
+  bool getObject(std::istream& fInput, CastorQIEData& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorQIEData& fObject);
+  bool getObject(std::istream& fInput, CastorCalibrationQIEData& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorCalibrationQIEData& fObject);
+  bool getObject(std::istream& fInput, CastorElectronicsMap& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorElectronicsMap& fObject);
+  bool getObject(std::istream& fInput, CastorChannelQuality& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorChannelQuality& fObject);
+  bool getObject(std::istream& fInput, CastorRecoParams& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorRecoParams& fObject);
+  bool getObject(std::istream& fInput, CastorSaturationCorrs& fObject);
+  bool dumpObject(std::ostream& fOutput, const CastorSaturationCorrs& fObject);
+  DetId getId(const std::vector<std::string>& items);
+  void dumpId(std::ostream& fOutput, DetId id);
+}  // namespace CastorDbASCIIIO
 #endif

--- a/CalibCalorimetry/CastorCalib/interface/CastorDbHardcode.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorDbHardcode.h
@@ -16,15 +16,15 @@
 #include "CondFormats/CastorObjects/interface/CastorSaturationCorr.h"
 
 namespace CastorDbHardcode {
-  CastorPedestal makePedestal (HcalGenericDetId fId, bool fSmear = false);
-  CastorPedestalWidth makePedestalWidth (HcalGenericDetId fId);
-  CastorGain makeGain (HcalGenericDetId fId, bool fSmear = false);
-  CastorGainWidth makeGainWidth (HcalGenericDetId fId);
-  CastorQIECoder makeQIECoder (HcalGenericDetId fId);
-  CastorCalibrationQIECoder makeCalibrationQIECoder (HcalGenericDetId fId);
-  CastorQIEShape makeQIEShape ();
-  CastorRecoParam makeRecoParam (HcalGenericDetId fId);
-  CastorSaturationCorr makeSaturationCorr (HcalGenericDetId fId);
+  CastorPedestal makePedestal(HcalGenericDetId fId, bool fSmear = false);
+  CastorPedestalWidth makePedestalWidth(HcalGenericDetId fId);
+  CastorGain makeGain(HcalGenericDetId fId, bool fSmear = false);
+  CastorGainWidth makeGainWidth(HcalGenericDetId fId);
+  CastorQIECoder makeQIECoder(HcalGenericDetId fId);
+  CastorCalibrationQIECoder makeCalibrationQIECoder(HcalGenericDetId fId);
+  CastorQIEShape makeQIEShape();
+  CastorRecoParam makeRecoParam(HcalGenericDetId fId);
+  CastorSaturationCorr makeSaturationCorr(HcalGenericDetId fId);
   void makeHardcodeMap(CastorElectronicsMap& emap);
-}
+}  // namespace CastorDbHardcode
 #endif

--- a/CalibCalorimetry/CastorCalib/interface/CastorDbXml.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorDbXml.h
@@ -11,32 +11,80 @@
    \brief IO for XML instances of Hcal/Castor Calibrations
 */
 namespace CastorDbXml {
-  bool dumpObject (std::ostream& fOutput, 
-		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion, 
-		   const CastorPedestals& fObject, const CastorPedestalWidths& fError);
-  bool dumpObject (std::ostream& fOutput, 
-		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion,
-		   const CastorPedestals& fObject);
-  bool dumpObject (std::ostream& fOutput, 
-		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion,
-		   const CastorPedestalWidths& fObject) {return false;}
-  bool dumpObject (std::ostream& fOutput, 
-		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion, 
-		   const CastorGains& fObject, const CastorGainWidths& fError);
-  bool dumpObject (std::ostream& fOutput, 
-		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion, 
-		   const CastorGains& fObject);
-  bool dumpObject (std::ostream& fOutput, 
-		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion, 
-		   const CastorGainWidths& fObject) {return false;}
-  bool dumpObject (std::ostream& fOutput, 
-		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion, 
-		   const CastorElectronicsMap& fObject) {return false;}
-  bool dumpObject (std::ostream& fOutput, 
-		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion, 
-		   const CastorQIEData& fObject) {return false;}
-  bool dumpObject (std::ostream& fOutput, 
-		   unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion, 
-		   const CastorCalibrationQIEData& fObject) {return false;}
-} 
+  bool dumpObject(std::ostream& fOutput,
+                  unsigned fRun,
+                  unsigned long fGMTIOVBegin,
+                  unsigned long fGMTIOVEnd,
+                  const std::string& fTag,
+                  unsigned fVersion,
+                  const CastorPedestals& fObject,
+                  const CastorPedestalWidths& fError);
+  bool dumpObject(std::ostream& fOutput,
+                  unsigned fRun,
+                  unsigned long fGMTIOVBegin,
+                  unsigned long fGMTIOVEnd,
+                  const std::string& fTag,
+                  unsigned fVersion,
+                  const CastorPedestals& fObject);
+  bool dumpObject(std::ostream& fOutput,
+                  unsigned fRun,
+                  unsigned long fGMTIOVBegin,
+                  unsigned long fGMTIOVEnd,
+                  const std::string& fTag,
+                  unsigned fVersion,
+                  const CastorPedestalWidths& fObject) {
+    return false;
+  }
+  bool dumpObject(std::ostream& fOutput,
+                  unsigned fRun,
+                  unsigned long fGMTIOVBegin,
+                  unsigned long fGMTIOVEnd,
+                  const std::string& fTag,
+                  unsigned fVersion,
+                  const CastorGains& fObject,
+                  const CastorGainWidths& fError);
+  bool dumpObject(std::ostream& fOutput,
+                  unsigned fRun,
+                  unsigned long fGMTIOVBegin,
+                  unsigned long fGMTIOVEnd,
+                  const std::string& fTag,
+                  unsigned fVersion,
+                  const CastorGains& fObject);
+  bool dumpObject(std::ostream& fOutput,
+                  unsigned fRun,
+                  unsigned long fGMTIOVBegin,
+                  unsigned long fGMTIOVEnd,
+                  const std::string& fTag,
+                  unsigned fVersion,
+                  const CastorGainWidths& fObject) {
+    return false;
+  }
+  bool dumpObject(std::ostream& fOutput,
+                  unsigned fRun,
+                  unsigned long fGMTIOVBegin,
+                  unsigned long fGMTIOVEnd,
+                  const std::string& fTag,
+                  unsigned fVersion,
+                  const CastorElectronicsMap& fObject) {
+    return false;
+  }
+  bool dumpObject(std::ostream& fOutput,
+                  unsigned fRun,
+                  unsigned long fGMTIOVBegin,
+                  unsigned long fGMTIOVEnd,
+                  const std::string& fTag,
+                  unsigned fVersion,
+                  const CastorQIEData& fObject) {
+    return false;
+  }
+  bool dumpObject(std::ostream& fOutput,
+                  unsigned fRun,
+                  unsigned long fGMTIOVBegin,
+                  unsigned long fGMTIOVEnd,
+                  const std::string& fTag,
+                  unsigned fVersion,
+                  const CastorCalibrationQIEData& fObject) {
+    return false;
+  }
+}  // namespace CastorDbXml
 #endif

--- a/CalibCalorimetry/CastorCalib/interface/CastorLedAnalysis.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorLedAnalysis.h
@@ -1,7 +1,6 @@
 #ifndef CastorLedAnalysis_H
 #define CastorLedAnalysis_H
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -12,11 +11,9 @@
 
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 
-
 #include "TH1F.h"
 #include "TF1.h"
 #include "TProfile.h"
-
 
 #include <memory>
 //#include <iostream>
@@ -30,96 +27,93 @@ class CastorQIEShape;
 class CastorQIECoder;
 class TFile;
 
-class CastorLedAnalysis{
-  
+class CastorLedAnalysis {
 public:
-  
   /// Constructor
-  CastorLedAnalysis(const edm::ParameterSet& ps);  
+  CastorLedAnalysis(const edm::ParameterSet& ps);
   /// Destructor
   ~CastorLedAnalysis();
   void LedSetup(const std::string& m_outputFileROOT);
   //void doPeds(const CastorPedestals* fInputPedestals);
   void LedSampleAnalysis();
   void LedDone();
-  void processLedEvent(const CastorDigiCollection& castor,
-		    const CastorDbService& cond);
+  void processLedEvent(const CastorDigiCollection& castor, const CastorDbService& cond);
 
 protected:
-  
-  
 private:
   //###
   //#  LEDBUNCH is used in map<HcalDetId,map<int, LEDBUNCH > > LEDTRENDS;
   //#  For each HcalDetId (channel) a map<int, LEDBUNCH> is associated;
   //#  int was originally cap-id and now is just dummy;
-  //#  LEDBUNCH is a pair - first element is the main 
+  //#  LEDBUNCH is a pair - first element is the main
   //#  histo with the ADC values and second one is another pair;
   //#  this pair contains map<int, std::vector<double> > as a first element;
   //#  vector contains some useful variables;
   //#  the second element is a vector of histos (pointers);
-  //#  for the "trend" analysis the main histo (with ADC values) is reset every 
+  //#  for the "trend" analysis the main histo (with ADC values) is reset every
   //#  m_nevtsample events and info is put in the other part of the LEDBUNCH;
   //#  so at the end we have the trends for the variables in concern
-  //#  which are written in THE vector<TH1F*>; 
-  //###  
-  typedef std::pair<TH1F*,std::pair<std::map<int, std::vector<double> >,std::vector<TH1F*> > > LEDBUNCH;
-  typedef struct{
+  //#  which are written in THE vector<TH1F*>;
+  //###
+  typedef std::pair<TH1F*, std::pair<std::map<int, std::vector<double> >, std::vector<TH1F*> > > LEDBUNCH;
+  typedef struct {
     TProfile* avePulse[3];
     TH1F* thisPulse[3];
     TH1F* integPulse[3];
   } CALIBBUNCH;
   TFile* m_file;
-  void LedCastorHists(const HcalDetId& detid, const CastorDataFrame& ledDigi, std::map<HcalDetId, std::map<int,LEDBUNCH> > &toolT, const CastorDbService& cond);
-  void SetupLEDHists(int id, const HcalDetId detid, std::map<HcalDetId, std::map<int,LEDBUNCH> > &toolT);
-  void GetLedConst(std::map<HcalDetId,std::map<int, LEDBUNCH > > &toolT);
-  void LedTrendings(std::map<HcalDetId,std::map<int, LEDBUNCH > > &toolT);
+  void LedCastorHists(const HcalDetId& detid,
+                      const CastorDataFrame& ledDigi,
+                      std::map<HcalDetId, std::map<int, LEDBUNCH> >& toolT,
+                      const CastorDbService& cond);
+  void SetupLEDHists(int id, const HcalDetId detid, std::map<HcalDetId, std::map<int, LEDBUNCH> >& toolT);
+  void GetLedConst(std::map<HcalDetId, std::map<int, LEDBUNCH> >& toolT);
+  void LedTrendings(std::map<HcalDetId, std::map<int, LEDBUNCH> >& toolT);
   float BinsizeCorr(float time);
-  
+
   std::string m_outputFileROOT;
   std::string m_outputFileText;
   std::string m_outputFileX;
   std::ofstream m_outFile;
   std::ofstream m_logFile;
   std::ofstream m_outputFileXML;
- 
+
   int m_startTS;
   int m_endTS;
   int m_nevtsample;
   int m_hiSaveflag;
   bool m_usecalib;
-// analysis flag:
-//  m_fitflag = 0  - take mean TS value of averaged pulse shape
-//              1  - take peak from landau fit to averaged pulse shape
-//              2  - take average of mean TS values per event
-//                     (preferred for laser & HF LED)
-//              3  - take average of peaks from landau fits per event
-//                     (preferred for LED)
-//              4  - 0+1+2+3 REMOVED in 1_6
+  // analysis flag:
+  //  m_fitflag = 0  - take mean TS value of averaged pulse shape
+  //              1  - take peak from landau fit to averaged pulse shape
+  //              2  - take average of mean TS values per event
+  //                     (preferred for laser & HF LED)
+  //              3  - take average of peaks from landau fits per event
+  //                     (preferred for LED)
+  //              4  - 0+1+2+3 REMOVED in 1_6
   int m_fitflag;
-  
+
   const CastorQIEShape* m_shape;
   const CastorQIECoder* m_coder;
   const CastorPedestal* m_ped;
-  struct{
-    std::map<HcalDetId,std::map<int, LEDBUNCH > > LEDTRENDS;
+  struct {
+    std::map<HcalDetId, std::map<int, LEDBUNCH> > LEDTRENDS;
     TH1F* ALLLEDS;
     TH1F* LEDRMS;
     TH1F* LEDMEAN;
     TH1F* CHI2;
   } castorHists;
-  std::map<HcalDetId,std::map<int, LEDBUNCH > >::iterator _meol;
-  std::map<HcalDetId,std::map<int,float> > m_AllPedVals;
-  std::map<HcalDetId,std::map<int,float> >::iterator _meee;
+  std::map<HcalDetId, std::map<int, LEDBUNCH> >::iterator _meol;
+  std::map<HcalDetId, std::map<int, float> > m_AllPedVals;
+  std::map<HcalDetId, std::map<int, float> >::iterator _meee;
 
-  std::map<HcalCalibDetId,CALIBBUNCH>::iterator _meca;
+  std::map<HcalCalibDetId, CALIBBUNCH>::iterator _meca;
 
   //const CastorPedestal* pedCan;
   int evt;
   int sample;
   int evt_curr;
   std::vector<bool> state;
-
 };
 
 #endif

--- a/CalibCalorimetry/CastorCalib/interface/CastorPedestalAnalysis.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorPedestalAnalysis.h
@@ -12,7 +12,6 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 
-
 #include "TH1F.h"
 #include "TF1.h"
 
@@ -36,12 +35,10 @@ class CastorDbService;
 class CastorQIEShape;
 class CastorQIECoder;
 class TFile;
-class CastorPedestalAnalysis{
-  
+class CastorPedestalAnalysis {
 public:
-  
   /// Constructor
-  CastorPedestalAnalysis(const edm::ParameterSet& ps);  
+  CastorPedestalAnalysis(const edm::ParameterSet& ps);
   /// Destructor
   ~CastorPedestalAnalysis();
 
@@ -49,52 +46,63 @@ public:
 
   void SampleAnalysis();
 
-  int done(const CastorPedestals* fInputPedestals, 
-	    const CastorPedestalWidths* fInputWidths,
-	    CastorPedestals* fOutputPedestals, 
-	    CastorPedestalWidths* fOutputWidths);
+  int done(const CastorPedestals* fInputPedestals,
+           const CastorPedestalWidths* fInputWidths,
+           CastorPedestals* fOutputPedestals,
+           CastorPedestalWidths* fOutputWidths);
 
-  void processEvent(const CastorDigiCollection& castor,
-		    const CastorDbService& cond);
+  void processEvent(const CastorDigiCollection& castor, const CastorDbService& cond);
 
-// pedestal validation: CastorPedVal=-1 means not validated,
-//                                  0 everything OK,
-//                                  N>0 : mod(N,100000) drifts + width changes
-//                                        int(N/100000) missing channels
-  static int CastorPedVal(int nstat[4], const CastorPedestals* fRefPedestals,
-            const CastorPedestalWidths* fRefPedestalWidths,
-            CastorPedestals* fRawPedestals,
-            CastorPedestalWidths* fRawPedestalWidths,
-            CastorPedestals* fValPedestals,
-            CastorPedestalWidths* fValPedestalWidths);
+  // pedestal validation: CastorPedVal=-1 means not validated,
+  //                                  0 everything OK,
+  //                                  N>0 : mod(N,100000) drifts + width changes
+  //                                        int(N/100000) missing channels
+  static int CastorPedVal(int nstat[4],
+                          const CastorPedestals* fRefPedestals,
+                          const CastorPedestalWidths* fRefPedestalWidths,
+                          CastorPedestals* fRawPedestals,
+                          CastorPedestalWidths* fRawPedestalWidths,
+                          CastorPedestals* fValPedestals,
+                          CastorPedestalWidths* fValPedestalWidths);
 
 protected:
-  
-  
 private:
   //###
   //#  PEDBUNCH is used in map<HcalDetId,map<int, PEDBUNCH > > PEDTRENDS;
   //#  For each HcalDetId (channel) a map<int, PEDBUNCH> is associated;
   //#  int is cap-id (1-4);
-  //#  PEDBUNCH is a pair - first element is the main 
+  //#  PEDBUNCH is a pair - first element is the main
   //#  histo with the pedestal distribution and second one is another pair;
   //#  this pair contains map<int, std::vector<double> > as a first element;
   //#  int is cap-id, and vector contains some useful variables;
   //#  the second element is a vector of histos (pointers);
-  //#  for the "trend" analysis the main histo (with pedestals) is reset every 
+  //#  for the "trend" analysis the main histo (with pedestals) is reset every
   //#  nevt_ped events and info is put in the other part of the PEDBUNCH;
   //#  so at the end we have the trends for the variables in concern
-  //#  which are written in THE vector<TH1F*>; 
-  //###  
-  typedef std::pair<TH1F*,std::pair<std::map<int, std::vector<double> >,std::vector<TH1F*> > > PEDBUNCH;
+  //#  which are written in THE vector<TH1F*>;
+  //###
+  typedef std::pair<TH1F*, std::pair<std::map<int, std::vector<double> >, std::vector<TH1F*> > > PEDBUNCH;
 
-  void per2CapsHists(int flag, int id, const HcalDetId detid, const HcalQIESample& qie1, const HcalQIESample& qie2, std::map<HcalDetId, std::map<int,PEDBUNCH> > &toolT,const CastorDbService& cond);
+  void per2CapsHists(int flag,
+                     int id,
+                     const HcalDetId detid,
+                     const HcalQIESample& qie1,
+                     const HcalQIESample& qie2,
+                     std::map<HcalDetId, std::map<int, PEDBUNCH> >& toolT,
+                     const CastorDbService& cond);
 
-  void GetPedConst(std::map<HcalDetId,std::map<int, PEDBUNCH > > &toolT, TH1F* PedMeans, TH1F* PedWidths);
+  void GetPedConst(std::map<HcalDetId, std::map<int, PEDBUNCH> >& toolT, TH1F* PedMeans, TH1F* PedWidths);
 
-  void Trendings(std::map<HcalDetId,std::map<int, PEDBUNCH > > &toolT, TH1F* Chi2, TH1F* CapidAverage, TH1F* CapidChi2);
+  void Trendings(std::map<HcalDetId, std::map<int, PEDBUNCH> >& toolT, TH1F* Chi2, TH1F* CapidAverage, TH1F* CapidChi2);
 
-  void AllChanHists(const HcalDetId detid, const HcalQIESample& qie0, const HcalQIESample& qie1, const HcalQIESample& qie2, const HcalQIESample& qie3, const HcalQIESample& qie4, const HcalQIESample& qie5, std::map<HcalDetId, std::map<int,PEDBUNCH> > &toolT);
+  void AllChanHists(const HcalDetId detid,
+                    const HcalQIESample& qie0,
+                    const HcalQIESample& qie1,
+                    const HcalQIESample& qie2,
+                    const HcalQIESample& qie3,
+                    const HcalQIESample& qie4,
+                    const HcalQIESample& qie5,
+                    std::map<HcalDetId, std::map<int, PEDBUNCH> >& toolT);
 
   TFile* m_file;
 
@@ -109,11 +117,11 @@ private:
   int m_hiSaveflag;
   int m_pedValflag;
   int m_AllPedsOK;
-  
+
   const CastorQIEShape* m_shape;
   const CastorQIECoder* m_coder;
-  struct{
-    std::map<HcalDetId,std::map<int, PEDBUNCH > > PEDTRENDS;
+  struct {
+    std::map<HcalDetId, std::map<int, PEDBUNCH> > PEDTRENDS;
     TH1F* ALLPEDS;
     TH1F* PEDRMS;
     TH1F* PEDMEAN;
@@ -121,7 +129,7 @@ private:
     TH1F* CAPID_AVERAGE;
     TH1F* CAPID_CHI2;
   } castorHists;
-  std::map<HcalDetId,std::map<int, PEDBUNCH > >::iterator _meot;
+  std::map<HcalDetId, std::map<int, PEDBUNCH> >::iterator _meot;
   const CastorPedestals* fRefPedestals;
   const CastorPedestalWidths* fRefPedestalWidths;
   CastorPedestals* fRawPedestals;
@@ -134,8 +142,8 @@ private:
   float m_stat[4];
   std::vector<bool> state;
 
-// flag to make gaussian fits to charge dists
-  static const int fitflag=0;
+  // flag to make gaussian fits to charge dists
+  static const int fitflag = 0;
 };
 
 #endif

--- a/CalibCalorimetry/CastorCalib/interface/CastorPedestalsAnalysis.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorPedestalsAnalysis.h
@@ -55,60 +55,57 @@ namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
-   struct NewPedBunch
-   {
-      HcalCastorDetId detid;
-      bool usedflag;
-      float cap[4];
-      float capfc[4];
-      float sig[4][4];
-      float sigfc[4][4];
-      float prod[4][4];
-      float prodfc[4][4];
-      int num[4][4];
-   };
+struct NewPedBunch {
+  HcalCastorDetId detid;
+  bool usedflag;
+  float cap[4];
+  float capfc[4];
+  float sig[4][4];
+  float sigfc[4][4];
+  float prod[4][4];
+  float prodfc[4][4];
+  int num[4][4];
+};
 
-class CastorPedestalsAnalysis : public edm::EDAnalyzer
-{
-   public:
-   //Constructor
-   CastorPedestalsAnalysis(const edm::ParameterSet& ps);
-   //Destructor
-   ~CastorPedestalsAnalysis() override;
-   //Analysis
-   void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+class CastorPedestalsAnalysis : public edm::EDAnalyzer {
+public:
+  //Constructor
+  CastorPedestalsAnalysis(const edm::ParameterSet &ps);
+  //Destructor
+  ~CastorPedestalsAnalysis() override;
+  //Analysis
+  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
-   private:
-   //Container for data, 1 per channel
-   std::vector<NewPedBunch> Bunches;
-   //Flag for saving histos
-   bool hiSaveFlag;
-   bool dumpXML;
-   bool verboseflag;
-   int runnum;
-   int firstTS;
-   int lastTS;
-   std::string ROOTfilename;
-   std::string pedsADCfilename;
-   std::string pedsfCfilename;
-   std::string widthsADCfilename;
-   std::string widthsfCfilename;
-   std::string XMLfilename;
-   std::string XMLtag;
-   std::string ZSfilename;
+private:
+  //Container for data, 1 per channel
+  std::vector<NewPedBunch> Bunches;
+  //Flag for saving histos
+  bool hiSaveFlag;
+  bool dumpXML;
+  bool verboseflag;
+  int runnum;
+  int firstTS;
+  int lastTS;
+  std::string ROOTfilename;
+  std::string pedsADCfilename;
+  std::string pedsfCfilename;
+  std::string widthsADCfilename;
+  std::string widthsfCfilename;
+  std::string XMLfilename;
+  std::string XMLtag;
+  std::string ZSfilename;
 
-   TH1F *CASTORMeans;
-   TH1F *CASTORWidths;
+  TH1F *CASTORMeans;
+  TH1F *CASTORWidths;
 
-   // TH2F *dephist[4];
-   TH2F *dephist;
+  // TH2F *dephist[4];
+  TH2F *dephist;
 
-   TFile *theFile;
-   bool firsttime;
+  TFile *theFile;
+  bool firsttime;
 
-   edm::InputTag castorDigiCollectionTag;
+  edm::InputTag castorDigiCollectionTag;
 };
 #endif
-

--- a/CalibCalorimetry/CastorCalib/interface/CastorPulseContainmentCorrection.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorPulseContainmentCorrection.h
@@ -11,15 +11,13 @@
 
 class CastorPulseContainmentCorrection {
 public:
-  CastorPulseContainmentCorrection(int num_samples,
-                                 float fixedphase_ns,
-                                 float max_fracerror);
+  CastorPulseContainmentCorrection(int num_samples, float fixedphase_ns, float max_fracerror);
 
   double getCorrection(double fc_ampl) const;
-  double fractionContained(double fc_ampl) const { return 1.0/this->getCorrection(fc_ampl); }
+  double fractionContained(double fc_ampl) const { return 1.0 / this->getCorrection(fc_ampl); }
 
 private:
-  std::map<double,double> mCorFactors_;
+  std::map<double, double> mCorFactors_;
 };
 
 #endif

--- a/CalibCalorimetry/CastorCalib/interface/CastorPulseShapes.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorPulseShapes.h
@@ -20,6 +20,7 @@ public:
     float operator()(double time) const;
     float at(double time) const;
     float integrate(double tmin, double tmax) const;
+
   private:
     std::vector<float> shape_;
     int nbin_;

--- a/CalibCalorimetry/CastorCalib/interface/CastorTimeSlew.h
+++ b/CalibCalorimetry/CastorCalib/interface/CastorTimeSlew.h
@@ -1,7 +1,6 @@
 #ifndef CALIBCALORIMETRY_CASTORCALIB_CASTORTIMESLEW_H
 #define CALIBCALORIMETRY_CASTORCALIB_CASTORTIMESLEW_H 1
 
-
 /** \class CastorTimeSlew
   * 
   * copy from HCAL (author: J. Mans)
@@ -17,12 +16,12 @@
   */
 class CastorTimeSlew {
 public:
-  enum BiasSetting { Slow=0, Medium=1, Fast=2 };
+  enum BiasSetting { Slow = 0, Medium = 1, Fast = 2 };
 
   /** \brief Returns the amount (ns) by which a pulse of the given
    number of fC will be delayed by the timeslew effect, for the
    specified bias setting. */
-  static double delay(double fC, BiasSetting bias=Medium);
+  static double delay(double fC, BiasSetting bias = Medium);
 };
 
 #endif

--- a/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.cc
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CastorDbProducer
 // Class:      CastorDbProducer
-// 
+//
 /**\class CastorDbProducer CastorDbProducer.h CalibFormats/CastorDbProducer/interface/CastorDbProducer.h
 
  Description: <one line class summary>
@@ -17,7 +17,6 @@
 //
 //
 
-
 // system include files
 #include <iostream>
 #include <fstream>
@@ -28,90 +27,67 @@
 #include "CalibFormats/CastorObjects/interface/CastorDbService.h"
 #include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
 
-
 #include "CondFormats/CastorObjects/interface/AllObjects.h"
 
 #include "CastorDbProducer.h"
 
-CastorDbProducer::CastorDbProducer( const edm::ParameterSet& fConfig)
-  : ESProducer(),
-    mDumpRequest (),
-    mDumpStream(nullptr)
-{
+CastorDbProducer::CastorDbProducer(const edm::ParameterSet& fConfig)
+    : ESProducer(), mDumpRequest(), mDumpStream(nullptr) {
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this);
 
   //now do what ever other initialization is needed
 
-  mDumpRequest = fConfig.getUntrackedParameter <std::vector <std::string> > ("dump", std::vector<std::string>());
+  mDumpRequest = fConfig.getUntrackedParameter<std::vector<std::string> >("dump", std::vector<std::string>());
   if (!mDumpRequest.empty()) {
-    std::string otputFile = fConfig.getUntrackedParameter <std::string> ("file", "");
-    mDumpStream = otputFile.empty () ? &std::cout : new std::ofstream (otputFile.c_str());
+    std::string otputFile = fConfig.getUntrackedParameter<std::string>("file", "");
+    mDumpStream = otputFile.empty() ? &std::cout : new std::ofstream(otputFile.c_str());
   }
 }
 
-
-CastorDbProducer::~CastorDbProducer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-  if (mDumpStream != &std::cout) delete mDumpStream;
+CastorDbProducer::~CastorDbProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  if (mDumpStream != &std::cout)
+    delete mDumpStream;
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-std::shared_ptr<CastorDbService> CastorDbProducer::produce( const CastorDbRecord& record)
-{
-  auto host = holder_.makeOrGet([]() {
-    return new HostType;
-  });
+std::shared_ptr<CastorDbService> CastorDbProducer::produce(const CastorDbRecord& record) {
+  auto host = holder_.makeOrGet([]() { return new HostType; });
 
   bool needBuildCalibrations = false;
   bool needBuildCalibWidths = false;
 
-  host->ifRecordChanges<CastorElectronicsMapRcd>(record,
-                                                 [this, h=host.get()](auto const& rec) {
-    setupElectronicsMap(rec, h);
-  });
-  host->ifRecordChanges<CastorChannelQualityRcd>(record,
-                                                 [this, h=host.get()](auto const& rec) {
-    setupChannelQuality(rec, h);
-  });
-  host->ifRecordChanges<CastorGainWidthsRcd>(record,
-                                             [this, h=host.get(),
-                                              &needBuildCalibWidths](auto const& rec) {
+  host->ifRecordChanges<CastorElectronicsMapRcd>(
+      record, [this, h = host.get()](auto const& rec) { setupElectronicsMap(rec, h); });
+  host->ifRecordChanges<CastorChannelQualityRcd>(
+      record, [this, h = host.get()](auto const& rec) { setupChannelQuality(rec, h); });
+  host->ifRecordChanges<CastorGainWidthsRcd>(record, [this, h = host.get(), &needBuildCalibWidths](auto const& rec) {
     setupGainWidths(rec, h);
     needBuildCalibWidths = true;
   });
-  host->ifRecordChanges<CastorQIEDataRcd>(record,
-                                          [this, h=host.get(),
-                                           &needBuildCalibrations,
-                                           &needBuildCalibWidths](auto const& rec) {
-    setupQIEData(rec, h);
-    needBuildCalibrations = true;
-    needBuildCalibWidths = true;
-  });
+  host->ifRecordChanges<CastorQIEDataRcd>(
+      record, [this, h = host.get(), &needBuildCalibrations, &needBuildCalibWidths](auto const& rec) {
+        setupQIEData(rec, h);
+        needBuildCalibrations = true;
+        needBuildCalibWidths = true;
+      });
   host->ifRecordChanges<CastorPedestalWidthsRcd>(record,
-                                                 [this, h=host.get(),
-                                                  &needBuildCalibWidths](auto const& rec) {
-    setupPedestalWidths(rec, h);
-    needBuildCalibWidths = true;
-  });
-  host->ifRecordChanges<CastorGainsRcd>(record,
-                                        [this, h=host.get(),
-                                         &needBuildCalibrations](auto const& rec) {
+                                                 [this, h = host.get(), &needBuildCalibWidths](auto const& rec) {
+                                                   setupPedestalWidths(rec, h);
+                                                   needBuildCalibWidths = true;
+                                                 });
+  host->ifRecordChanges<CastorGainsRcd>(record, [this, h = host.get(), &needBuildCalibrations](auto const& rec) {
     setupGains(rec, h);
     needBuildCalibrations = true;
   });
-  host->ifRecordChanges<CastorPedestalsRcd>(record,
-                                            [this, h=host.get(),
-                                             &needBuildCalibrations](auto const& rec) {
+  host->ifRecordChanges<CastorPedestalsRcd>(record, [this, h = host.get(), &needBuildCalibrations](auto const& rec) {
     setupPedestals(rec, h);
     needBuildCalibrations = true;
   });
@@ -124,86 +100,76 @@ std::shared_ptr<CastorDbService> CastorDbProducer::produce( const CastorDbRecord
     host->buildCalibrations();
   }
 
-  return host; // automatically converts to std::shared_ptr<CastorDbService>
+  return host;  // automatically converts to std::shared_ptr<CastorDbService>
 }
 
-void CastorDbProducer::setupPedestals(const CastorPedestalsRcd& fRecord,
-                                      CastorDbService* service) {
-
-  edm::ESHandle <CastorPedestals> item;
-  fRecord.get (item);
+void CastorDbProducer::setupPedestals(const CastorPedestalsRcd& fRecord, CastorDbService* service) {
+  edm::ESHandle<CastorPedestals> item;
+  fRecord.get(item);
 
   service->setData(item.product());
-  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("Pedestals")) != mDumpRequest.end()) {
+  if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("Pedestals")) != mDumpRequest.end()) {
     *mDumpStream << "New HCAL/CASTOR Pedestals set" << std::endl;
-    CastorDbASCIIIO::dumpObject (*mDumpStream, *(item.product ()));
+    CastorDbASCIIIO::dumpObject(*mDumpStream, *(item.product()));
   }
 }
 
-void CastorDbProducer::setupPedestalWidths(const CastorPedestalWidthsRcd& fRecord,
-                                           CastorDbService* service) {
-  edm::ESHandle <CastorPedestalWidths> item;
-  fRecord.get (item);
+void CastorDbProducer::setupPedestalWidths(const CastorPedestalWidthsRcd& fRecord, CastorDbService* service) {
+  edm::ESHandle<CastorPedestalWidths> item;
+  fRecord.get(item);
   service->setData(item.product());
-  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("PedestalWidths")) != mDumpRequest.end()) {
+  if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("PedestalWidths")) != mDumpRequest.end()) {
     *mDumpStream << "New HCAL/CASTOR Pedestals set" << std::endl;
-    CastorDbASCIIIO::dumpObject (*mDumpStream, *(item.product ()));
+    CastorDbASCIIIO::dumpObject(*mDumpStream, *(item.product()));
   }
 }
 
-
-void CastorDbProducer::setupGains(const CastorGainsRcd& fRecord,
-                                  CastorDbService* service) {
-  edm::ESHandle <CastorGains> item;
-  fRecord.get (item);
+void CastorDbProducer::setupGains(const CastorGainsRcd& fRecord, CastorDbService* service) {
+  edm::ESHandle<CastorGains> item;
+  fRecord.get(item);
   service->setData(item.product());
-  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("Gains")) != mDumpRequest.end()) {
+  if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("Gains")) != mDumpRequest.end()) {
     *mDumpStream << "New HCAL/CASTOR Gains set" << std::endl;
-    CastorDbASCIIIO::dumpObject (*mDumpStream, *(item.product ()));
+    CastorDbASCIIIO::dumpObject(*mDumpStream, *(item.product()));
   }
 }
 
-
-void CastorDbProducer::setupGainWidths(const CastorGainWidthsRcd& fRecord,
-                                       CastorDbService* service) {
-  edm::ESHandle <CastorGainWidths> item;
-  fRecord.get (item);
+void CastorDbProducer::setupGainWidths(const CastorGainWidthsRcd& fRecord, CastorDbService* service) {
+  edm::ESHandle<CastorGainWidths> item;
+  fRecord.get(item);
   service->setData(item.product());
-  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("GainWidths")) != mDumpRequest.end()) {
+  if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("GainWidths")) != mDumpRequest.end()) {
     *mDumpStream << "New HCAL/CASTOR GainWidths set" << std::endl;
-    CastorDbASCIIIO::dumpObject (*mDumpStream, *(item.product ()));
+    CastorDbASCIIIO::dumpObject(*mDumpStream, *(item.product()));
   }
 }
 
-void CastorDbProducer::setupQIEData(const CastorQIEDataRcd& fRecord,
-                                    CastorDbService* service) {
-  edm::ESHandle <CastorQIEData> item;
-  fRecord.get (item);
+void CastorDbProducer::setupQIEData(const CastorQIEDataRcd& fRecord, CastorDbService* service) {
+  edm::ESHandle<CastorQIEData> item;
+  fRecord.get(item);
   service->setData(item.product());
-  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("QIEData")) != mDumpRequest.end()) {
+  if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("QIEData")) != mDumpRequest.end()) {
     *mDumpStream << "New HCAL/CASTOR QIEData set" << std::endl;
-    CastorDbASCIIIO::dumpObject (*mDumpStream, *(item.product ()));
+    CastorDbASCIIIO::dumpObject(*mDumpStream, *(item.product()));
   }
 }
 
-void CastorDbProducer::setupChannelQuality(const CastorChannelQualityRcd& fRecord,
-                                           CastorDbService* service) {
-  edm::ESHandle <CastorChannelQuality> item;
-  fRecord.get (item);
+void CastorDbProducer::setupChannelQuality(const CastorChannelQualityRcd& fRecord, CastorDbService* service) {
+  edm::ESHandle<CastorChannelQuality> item;
+  fRecord.get(item);
   service->setData(item.product());
-  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("ChannelQuality")) != mDumpRequest.end()) {
+  if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("ChannelQuality")) != mDumpRequest.end()) {
     *mDumpStream << "New HCAL/CASTOR ChannelQuality set" << std::endl;
-    CastorDbASCIIIO::dumpObject (*mDumpStream, *(item.product ()));
+    CastorDbASCIIIO::dumpObject(*mDumpStream, *(item.product()));
   }
 }
 
-void CastorDbProducer::setupElectronicsMap(const CastorElectronicsMapRcd& fRecord,
-                                           CastorDbService* service) {
-  edm::ESHandle <CastorElectronicsMap> item;
-  fRecord.get (item);
+void CastorDbProducer::setupElectronicsMap(const CastorElectronicsMapRcd& fRecord, CastorDbService* service) {
+  edm::ESHandle<CastorElectronicsMap> item;
+  fRecord.get(item);
   service->setData(item.product());
-  if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("ElectronicsMap")) != mDumpRequest.end()) {
+  if (std::find(mDumpRequest.begin(), mDumpRequest.end(), std::string("ElectronicsMap")) != mDumpRequest.end()) {
     *mDumpStream << "New HCAL/CASTOR Electronics Map set" << std::endl;
-    CastorDbASCIIIO::dumpObject (*mDumpStream, *(item.product ()));
+    CastorDbASCIIIO::dumpObject(*mDumpStream, *(item.product()));
   }
 }

--- a/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.h
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.h
@@ -11,19 +11,19 @@ class CastorDbService;
 class CastorDbRecord;
 
 #include "CondFormats/DataRecord/interface/CastorChannelQualityRcd.h"
-#include "CondFormats/DataRecord/interface/CastorElectronicsMapRcd.h"  	 
+#include "CondFormats/DataRecord/interface/CastorElectronicsMapRcd.h"
 #include "CondFormats/DataRecord/interface/CastorGainWidthsRcd.h"
 #include "CondFormats/DataRecord/interface/CastorGainsRcd.h"
 #include "CondFormats/DataRecord/interface/CastorPedestalWidthsRcd.h"
-#include "CondFormats/DataRecord/interface/CastorPedestalsRcd.h" 
+#include "CondFormats/DataRecord/interface/CastorPedestalsRcd.h"
 #include "CondFormats/DataRecord/interface/CastorQIEDataRcd.h"
 
 class CastorDbProducer : public edm::ESProducer {
 public:
-  CastorDbProducer( const edm::ParameterSet& );
+  CastorDbProducer(const edm::ParameterSet&);
   ~CastorDbProducer() override;
-  
-  std::shared_ptr<CastorDbService> produce( const CastorDbRecord& );
+
+  std::shared_ptr<CastorDbService> produce(const CastorDbRecord&);
 
 private:
   // ----------member data ---------------------------

--- a/CalibCalorimetry/CastorCalib/plugins/CastorHardcodeCalibrations.cc
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorHardcodeCalibrations.cc
@@ -35,170 +35,171 @@ using namespace cms;
 
 namespace {
 
-std::vector<HcalGenericDetId> allCells (bool h2_mode) {
-  static std::vector<HcalGenericDetId> result;
-  if (result.empty()) {
+  std::vector<HcalGenericDetId> allCells(bool h2_mode) {
+    static std::vector<HcalGenericDetId> result;
+    if (result.empty()) {
+      CastorTopology castortopology;
+      HcalCastorDetId cell;
+      HcalCastorDetId::Section section = HcalCastorDetId::EM;
 
-    CastorTopology castortopology;
-    HcalCastorDetId cell;
-    HcalCastorDetId::Section section  = HcalCastorDetId::EM;
+      for (int sector = 1; sector < 17; sector++) {
+        for (int module = 1; module < 3; module++) {
+          cell = HcalCastorDetId(section, true, sector, module);
+          if (castortopology.valid(cell))
+            result.push_back(cell);
+          cell = HcalCastorDetId(section, false, sector, module);
+          if (castortopology.valid(cell))
+            result.push_back(cell);
+        }
+      }
 
-    for(int sector=1; sector<17; sector++) {
-      for(int module=1; module<3; module++) {
-	cell = HcalCastorDetId(section, true, sector, module);
-    if (castortopology.valid(cell)) result.push_back(cell);
-    cell = HcalCastorDetId(section, false, sector, module);
-    if (castortopology.valid(cell)) result.push_back(cell);
+      section = HcalCastorDetId::HAD;
+      for (int sector = 1; sector < 17; sector++) {
+        for (int module = 3; module < 15; module++) {
+          cell = HcalCastorDetId(section, true, sector, module);
+          if (castortopology.valid(cell))
+            result.push_back(cell);
+          cell = HcalCastorDetId(section, false, sector, module);
+          if (castortopology.valid(cell))
+            result.push_back(cell);
+        }
+      }
     }
-   }
+    return result;
+  }
+}  // namespace
 
-   section = HcalCastorDetId::HAD;
-    for(int sector= 1; sector < 17; sector++){
-     for(int module=3; module<15; module++) {
-      cell = HcalCastorDetId(section, true, sector, module);
-      if(castortopology.valid(cell)) result.push_back(cell);
-      cell = HcalCastorDetId(section, false, sector, module);
-      if(castortopology.valid(cell)) result.push_back(cell);
-     }
-   }
+CastorHardcodeCalibrations::CastorHardcodeCalibrations(const edm::ParameterSet& iConfig)
 
-}
-  return result;
-
- }
-}
-
-CastorHardcodeCalibrations::CastorHardcodeCalibrations ( const edm::ParameterSet& iConfig ) 
-  
 {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::CastorHardcodeCalibrations->...";
   //parsing record parameters
-  h2mode_=iConfig.getUntrackedParameter<bool>("H2Mode",false);
-  std::vector <std::string> toGet = iConfig.getUntrackedParameter <std::vector <std::string> > ("toGet");
-  for(std::vector <std::string>::iterator objectName = toGet.begin(); objectName != toGet.end(); ++objectName ) {
+  h2mode_ = iConfig.getUntrackedParameter<bool>("H2Mode", false);
+  std::vector<std::string> toGet = iConfig.getUntrackedParameter<std::vector<std::string> >("toGet");
+  for (std::vector<std::string>::iterator objectName = toGet.begin(); objectName != toGet.end(); ++objectName) {
     bool all = *objectName == "all";
     if ((*objectName == "Pedestals") || all) {
-      setWhatProduced (this, &CastorHardcodeCalibrations::producePedestals);
-      findingRecord <CastorPedestalsRcd> ();
+      setWhatProduced(this, &CastorHardcodeCalibrations::producePedestals);
+      findingRecord<CastorPedestalsRcd>();
     }
     if ((*objectName == "PedestalWidths") || all) {
-      setWhatProduced (this, &CastorHardcodeCalibrations::producePedestalWidths);
-      findingRecord <CastorPedestalWidthsRcd> ();
+      setWhatProduced(this, &CastorHardcodeCalibrations::producePedestalWidths);
+      findingRecord<CastorPedestalWidthsRcd>();
     }
     if ((*objectName == "Gains") || all) {
-      setWhatProduced (this, &CastorHardcodeCalibrations::produceGains);
-      findingRecord <CastorGainsRcd> ();
+      setWhatProduced(this, &CastorHardcodeCalibrations::produceGains);
+      findingRecord<CastorGainsRcd>();
     }
     if ((*objectName == "GainWidths") || all) {
-      setWhatProduced (this, &CastorHardcodeCalibrations::produceGainWidths);
-      findingRecord <CastorGainWidthsRcd> ();
+      setWhatProduced(this, &CastorHardcodeCalibrations::produceGainWidths);
+      findingRecord<CastorGainWidthsRcd>();
     }
     if ((*objectName == "QIEData") || all) {
-      setWhatProduced (this, &CastorHardcodeCalibrations::produceQIEData);
-      findingRecord <CastorQIEDataRcd> ();
+      setWhatProduced(this, &CastorHardcodeCalibrations::produceQIEData);
+      findingRecord<CastorQIEDataRcd>();
     }
     if ((*objectName == "ChannelQuality") || (*objectName == "channelQuality") || all) {
-      setWhatProduced (this, &CastorHardcodeCalibrations::produceChannelQuality);
-      findingRecord <CastorChannelQualityRcd> ();
+      setWhatProduced(this, &CastorHardcodeCalibrations::produceChannelQuality);
+      findingRecord<CastorChannelQualityRcd>();
     }
     if ((*objectName == "ElectronicsMap") || (*objectName == "electronicsMap") || all) {
-      setWhatProduced (this, &CastorHardcodeCalibrations::produceElectronicsMap);
-      findingRecord <CastorElectronicsMapRcd> ();
+      setWhatProduced(this, &CastorHardcodeCalibrations::produceElectronicsMap);
+      findingRecord<CastorElectronicsMapRcd>();
     }
     if ((*objectName == "RecoParams") || all) {
-      setWhatProduced (this, &CastorHardcodeCalibrations::produceRecoParams);
-      findingRecord <CastorRecoParamsRcd> ();
+      setWhatProduced(this, &CastorHardcodeCalibrations::produceRecoParams);
+      findingRecord<CastorRecoParamsRcd>();
     }
     if ((*objectName == "SaturationCorrs") || all) {
-      setWhatProduced (this, &CastorHardcodeCalibrations::produceSaturationCorrs);
-      findingRecord <CastorSaturationCorrsRcd> ();
+      setWhatProduced(this, &CastorHardcodeCalibrations::produceSaturationCorrs);
+      findingRecord<CastorSaturationCorrsRcd>();
     }
   }
 }
 
-
-CastorHardcodeCalibrations::~CastorHardcodeCalibrations()
-{
-}
-
+CastorHardcodeCalibrations::~CastorHardcodeCalibrations() {}
 
 //
 // member functions
 //
-void 
-CastorHardcodeCalibrations::setIntervalFor( const edm::eventsetup::EventSetupRecordKey& iKey, const edm::IOVSyncValue& iTime, edm::ValidityInterval& oInterval ) {
-  std::string record = iKey.name ();
-  edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::setIntervalFor-> key: " << record << " time: " << iTime.eventID() << '/' << iTime.time ().value ();
-  oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime()); //infinite
+void CastorHardcodeCalibrations::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey,
+                                                const edm::IOVSyncValue& iTime,
+                                                edm::ValidityInterval& oInterval) {
+  std::string record = iKey.name();
+  edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::setIntervalFor-> key: " << record << " time: " << iTime.eventID()
+                       << '/' << iTime.time().value();
+  oInterval = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());  //infinite
 }
 
-std::unique_ptr<CastorPedestals> CastorHardcodeCalibrations::producePedestals (const CastorPedestalsRcd&) {
+std::unique_ptr<CastorPedestals> CastorHardcodeCalibrations::producePedestals(const CastorPedestalsRcd&) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::producePedestals-> ...";
   auto result = std::make_unique<CastorPedestals>(false);
-  std::vector <HcalGenericDetId> cells = allCells(h2mode_);
-  for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-    CastorPedestal item = CastorDbHardcode::makePedestal (*cell);
+  std::vector<HcalGenericDetId> cells = allCells(h2mode_);
+  for (std::vector<HcalGenericDetId>::const_iterator cell = cells.begin(); cell != cells.end(); ++cell) {
+    CastorPedestal item = CastorDbHardcode::makePedestal(*cell);
     result->addValues(item);
   }
   return result;
 }
 
-std::unique_ptr<CastorPedestalWidths> CastorHardcodeCalibrations::producePedestalWidths (const CastorPedestalWidthsRcd&) {
+std::unique_ptr<CastorPedestalWidths> CastorHardcodeCalibrations::producePedestalWidths(const CastorPedestalWidthsRcd&) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::producePedestalWidths-> ...";
   auto result = std::make_unique<CastorPedestalWidths>(false);
-  std::vector <HcalGenericDetId> cells = allCells(h2mode_);
-  for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-    CastorPedestalWidth item = CastorDbHardcode::makePedestalWidth (*cell);
+  std::vector<HcalGenericDetId> cells = allCells(h2mode_);
+  for (std::vector<HcalGenericDetId>::const_iterator cell = cells.begin(); cell != cells.end(); ++cell) {
+    CastorPedestalWidth item = CastorDbHardcode::makePedestalWidth(*cell);
     result->addValues(item);
   }
   return result;
 }
 
-std::unique_ptr<CastorGains> CastorHardcodeCalibrations::produceGains (const CastorGainsRcd&) {
+std::unique_ptr<CastorGains> CastorHardcodeCalibrations::produceGains(const CastorGainsRcd&) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceGains-> ...";
   auto result = std::make_unique<CastorGains>();
-  std::vector <HcalGenericDetId> cells = allCells(h2mode_);
-  for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-    CastorGain item = CastorDbHardcode::makeGain (*cell);
+  std::vector<HcalGenericDetId> cells = allCells(h2mode_);
+  for (std::vector<HcalGenericDetId>::const_iterator cell = cells.begin(); cell != cells.end(); ++cell) {
+    CastorGain item = CastorDbHardcode::makeGain(*cell);
     result->addValues(item);
   }
   return result;
 }
 
-std::unique_ptr<CastorGainWidths> CastorHardcodeCalibrations::produceGainWidths (const CastorGainWidthsRcd&) {
+std::unique_ptr<CastorGainWidths> CastorHardcodeCalibrations::produceGainWidths(const CastorGainWidthsRcd&) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceGainWidths-> ...";
   auto result = std::make_unique<CastorGainWidths>();
-  std::vector <HcalGenericDetId> cells = allCells(h2mode_);
-  for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-    CastorGainWidth item = CastorDbHardcode::makeGainWidth (*cell);
+  std::vector<HcalGenericDetId> cells = allCells(h2mode_);
+  for (std::vector<HcalGenericDetId>::const_iterator cell = cells.begin(); cell != cells.end(); ++cell) {
+    CastorGainWidth item = CastorDbHardcode::makeGainWidth(*cell);
     result->addValues(item);
   }
   return result;
 }
 
-std::unique_ptr<CastorQIEData> CastorHardcodeCalibrations::produceQIEData (const CastorQIEDataRcd& rcd) {
+std::unique_ptr<CastorQIEData> CastorHardcodeCalibrations::produceQIEData(const CastorQIEDataRcd& rcd) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceQIEData-> ...";
   auto result = std::make_unique<CastorQIEData>();
-  std::vector <HcalGenericDetId> cells = allCells(h2mode_);
-  for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-    CastorQIECoder coder = CastorDbHardcode::makeQIECoder (*cell);
+  std::vector<HcalGenericDetId> cells = allCells(h2mode_);
+  for (std::vector<HcalGenericDetId>::const_iterator cell = cells.begin(); cell != cells.end(); ++cell) {
+    CastorQIECoder coder = CastorDbHardcode::makeQIECoder(*cell);
     result->addCoder(coder);
   }
   return result;
 }
 
-std::unique_ptr<CastorChannelQuality> CastorHardcodeCalibrations::produceChannelQuality (const CastorChannelQualityRcd& rcd) {
+std::unique_ptr<CastorChannelQuality> CastorHardcodeCalibrations::produceChannelQuality(
+    const CastorChannelQualityRcd& rcd) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceChannelQuality-> ...";
   auto result = std::make_unique<CastorChannelQuality>();
-  std::vector <HcalGenericDetId> cells = allCells(h2mode_);
-  for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-    CastorChannelStatus item(cell->rawId(),CastorChannelStatus::GOOD);
+  std::vector<HcalGenericDetId> cells = allCells(h2mode_);
+  for (std::vector<HcalGenericDetId>::const_iterator cell = cells.begin(); cell != cells.end(); ++cell) {
+    CastorChannelStatus item(cell->rawId(), CastorChannelStatus::GOOD);
     result->addValues(item);
   }
   return result;
 }
 
-std::unique_ptr<CastorElectronicsMap> CastorHardcodeCalibrations::produceElectronicsMap (const CastorElectronicsMapRcd& rcd) {
+std::unique_ptr<CastorElectronicsMap> CastorHardcodeCalibrations::produceElectronicsMap(
+    const CastorElectronicsMapRcd& rcd) {
   edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceElectronicsMap-> ...";
 
   auto result = std::make_unique<CastorElectronicsMap>();
@@ -206,24 +207,25 @@ std::unique_ptr<CastorElectronicsMap> CastorHardcodeCalibrations::produceElectro
   return result;
 }
 
-std::unique_ptr<CastorRecoParams> CastorHardcodeCalibrations::produceRecoParams (const CastorRecoParamsRcd& rcd) {
-	edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceRecoParams-> ...";
-        auto result = std::make_unique<CastorRecoParams>();
-	std::vector <HcalGenericDetId> cells = allCells(h2mode_);
-	for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-		CastorRecoParam item = CastorDbHardcode::makeRecoParam (*cell);
-		result->addValues(item);
-	}
-	return result;
+std::unique_ptr<CastorRecoParams> CastorHardcodeCalibrations::produceRecoParams(const CastorRecoParamsRcd& rcd) {
+  edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceRecoParams-> ...";
+  auto result = std::make_unique<CastorRecoParams>();
+  std::vector<HcalGenericDetId> cells = allCells(h2mode_);
+  for (std::vector<HcalGenericDetId>::const_iterator cell = cells.begin(); cell != cells.end(); ++cell) {
+    CastorRecoParam item = CastorDbHardcode::makeRecoParam(*cell);
+    result->addValues(item);
+  }
+  return result;
 }
 
-std::unique_ptr<CastorSaturationCorrs> CastorHardcodeCalibrations::produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd) {
-	edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceSaturationCorrs-> ...";
-        auto result = std::make_unique<CastorSaturationCorrs>();
-	std::vector <HcalGenericDetId> cells = allCells(h2mode_);
-	for (std::vector <HcalGenericDetId>::const_iterator cell = cells.begin (); cell != cells.end (); ++cell) {
-		CastorSaturationCorr item = CastorDbHardcode::makeSaturationCorr (*cell);
-		result->addValues(item);
-	}
-	return result;
+std::unique_ptr<CastorSaturationCorrs> CastorHardcodeCalibrations::produceSaturationCorrs(
+    const CastorSaturationCorrsRcd& rcd) {
+  edm::LogInfo("HCAL") << "CastorHardcodeCalibrations::produceSaturationCorrs-> ...";
+  auto result = std::make_unique<CastorSaturationCorrs>();
+  std::vector<HcalGenericDetId> cells = allCells(h2mode_);
+  for (std::vector<HcalGenericDetId>::const_iterator cell = cells.begin(); cell != cells.end(); ++cell) {
+    CastorSaturationCorr item = CastorDbHardcode::makeSaturationCorr(*cell);
+    result->addValues(item);
+  }
+  return result;
 }

--- a/CalibCalorimetry/CastorCalib/plugins/CastorHardcodeCalibrations.h
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorHardcodeCalibrations.h
@@ -1,4 +1,4 @@
-// ESSource to generate default HCAL/CASTOR calibration objects 
+// ESSource to generate default HCAL/CASTOR calibration objects
 //
 #include <map>
 #include <string>
@@ -20,29 +20,26 @@ class CastorElectronicsMapRcd;
 class CastorRecoParamsRcd;
 class CastorSaturationCorrsRcd;
 
-class CastorHardcodeCalibrations : public edm::ESProducer,
-		       public edm::EventSetupRecordIntervalFinder
-{
+class CastorHardcodeCalibrations : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
-  CastorHardcodeCalibrations (const edm::ParameterSet& );
-  ~CastorHardcodeCalibrations () override;
+  CastorHardcodeCalibrations(const edm::ParameterSet&);
+  ~CastorHardcodeCalibrations() override;
 
-  void produce () {};
-  
+  void produce(){};
+
 protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-			      const edm::IOVSyncValue& , 
-			      edm::ValidityInterval&) override ;
+                      const edm::IOVSyncValue&,
+                      edm::ValidityInterval&) override;
 
-  std::unique_ptr<CastorPedestals> producePedestals (const CastorPedestalsRcd& rcd);
-  std::unique_ptr<CastorPedestalWidths> producePedestalWidths (const CastorPedestalWidthsRcd& rcd);
-  std::unique_ptr<CastorGains> produceGains (const CastorGainsRcd& rcd);
-  std::unique_ptr<CastorGainWidths> produceGainWidths (const CastorGainWidthsRcd& rcd);
-  std::unique_ptr<CastorQIEData> produceQIEData (const CastorQIEDataRcd& rcd);
-  std::unique_ptr<CastorChannelQuality> produceChannelQuality (const CastorChannelQualityRcd& rcd);
-  std::unique_ptr<CastorElectronicsMap> produceElectronicsMap (const CastorElectronicsMapRcd& rcd);
-  std::unique_ptr<CastorRecoParams> produceRecoParams (const CastorRecoParamsRcd& rcd);
-  std::unique_ptr<CastorSaturationCorrs> produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd);
+  std::unique_ptr<CastorPedestals> producePedestals(const CastorPedestalsRcd& rcd);
+  std::unique_ptr<CastorPedestalWidths> producePedestalWidths(const CastorPedestalWidthsRcd& rcd);
+  std::unique_ptr<CastorGains> produceGains(const CastorGainsRcd& rcd);
+  std::unique_ptr<CastorGainWidths> produceGainWidths(const CastorGainWidthsRcd& rcd);
+  std::unique_ptr<CastorQIEData> produceQIEData(const CastorQIEDataRcd& rcd);
+  std::unique_ptr<CastorChannelQuality> produceChannelQuality(const CastorChannelQualityRcd& rcd);
+  std::unique_ptr<CastorElectronicsMap> produceElectronicsMap(const CastorElectronicsMapRcd& rcd);
+  std::unique_ptr<CastorRecoParams> produceRecoParams(const CastorRecoParamsRcd& rcd);
+  std::unique_ptr<CastorSaturationCorrs> produceSaturationCorrs(const CastorSaturationCorrsRcd& rcd);
   bool h2mode_;
 };
-

--- a/CalibCalorimetry/CastorCalib/plugins/CastorPedestalsAnalysis.cc
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorPedestalsAnalysis.cc
@@ -1,42 +1,37 @@
 // Original Author:  Steven Won
 // Original Author:  Alan Campbell for castor
 //         Created:  Fri May  2 15:34:43 CEST 2008
-// Written to replace the combination of HcalPedestalAnalyzer and HcalPedestalAnalysis 
+// Written to replace the combination of HcalPedestalAnalyzer and HcalPedestalAnalysis
 // This code runs 1000x faster and produces all outputs from a single run
 // (ADC, fC in .txt plus an .xml file)
 //
 #include <memory>
 #include "CalibCalorimetry/CastorCalib/interface/CastorPedestalsAnalysis.h"
 
-CastorPedestalsAnalysis::CastorPedestalsAnalysis(const edm::ParameterSet& ps) :
-   castorDigiCollectionTag(ps.getParameter<edm::InputTag>("castorDigiCollectionTag"))
-{
-   hiSaveFlag = ps.getUntrackedParameter<bool>("hiSaveFlag", false);
-   dumpXML = ps.getUntrackedParameter<bool>("dumpXML", false);
-   verboseflag = ps.getUntrackedParameter<bool>("verbose", false);
-   firstTS = ps.getUntrackedParameter<int>("firstTS", 0);
-   lastTS = ps.getUntrackedParameter<int>("lastTS", 9);   
-   firsttime = true;
+CastorPedestalsAnalysis::CastorPedestalsAnalysis(const edm::ParameterSet& ps)
+    : castorDigiCollectionTag(ps.getParameter<edm::InputTag>("castorDigiCollectionTag")) {
+  hiSaveFlag = ps.getUntrackedParameter<bool>("hiSaveFlag", false);
+  dumpXML = ps.getUntrackedParameter<bool>("dumpXML", false);
+  verboseflag = ps.getUntrackedParameter<bool>("verbose", false);
+  firstTS = ps.getUntrackedParameter<int>("firstTS", 0);
+  lastTS = ps.getUntrackedParameter<int>("lastTS", 9);
+  firsttime = true;
 }
 
+CastorPedestalsAnalysis::~CastorPedestalsAnalysis() {
+  CastorPedestals* rawPedsItem = new CastorPedestals(true);
+  CastorPedestalWidths* rawWidthsItem = new CastorPedestalWidths(true);
+  CastorPedestals* rawPedsItemfc = new CastorPedestals(false);
+  CastorPedestalWidths* rawWidthsItemfc = new CastorPedestalWidths(false);
 
-CastorPedestalsAnalysis::~CastorPedestalsAnalysis()
-{
-   CastorPedestals* rawPedsItem = new CastorPedestals(true);
-   CastorPedestalWidths* rawWidthsItem = new CastorPedestalWidths(true);
-   CastorPedestals* rawPedsItemfc = new CastorPedestals(false);
-   CastorPedestalWidths* rawWidthsItemfc = new CastorPedestalWidths(false);
-
-   //Calculate pedestal constants
-   std::cout << "Calculating Pedestal constants...\n";
-   std::vector<NewPedBunch>::iterator bunch_it;
-   for(bunch_it=Bunches.begin(); bunch_it != Bunches.end(); ++bunch_it)
-   {
-      if(bunch_it->usedflag){
-
-      if(verboseflag) std::cout << "Analyzing channel sector= " << bunch_it->detid.sector() 
-        << " module = " << bunch_it->detid.module() 
-        << std::endl;
+  //Calculate pedestal constants
+  std::cout << "Calculating Pedestal constants...\n";
+  std::vector<NewPedBunch>::iterator bunch_it;
+  for (bunch_it = Bunches.begin(); bunch_it != Bunches.end(); ++bunch_it) {
+    if (bunch_it->usedflag) {
+      if (verboseflag)
+        std::cout << "Analyzing channel sector= " << bunch_it->detid.sector()
+                  << " module = " << bunch_it->detid.module() << std::endl;
       //pedestal constant is the mean
       bunch_it->cap[0] /= bunch_it->num[0][0];
       bunch_it->cap[1] /= bunch_it->num[1][1];
@@ -47,155 +42,182 @@ CastorPedestalsAnalysis::~CastorPedestalsAnalysis()
       bunch_it->capfc[2] /= bunch_it->num[2][2];
       bunch_it->capfc[3] /= bunch_it->num[3][3];
       //widths are the covariance matrix--assumed symmetric
-      bunch_it->sig[0][0] = (bunch_it->prod[0][0]/bunch_it->num[0][0])-(bunch_it->cap[0]*bunch_it->cap[0]);
-      bunch_it->sig[0][1] = (bunch_it->prod[0][1]/bunch_it->num[0][1])-(bunch_it->cap[0]*bunch_it->cap[1]);
-      bunch_it->sig[0][2] = (bunch_it->prod[0][2]/bunch_it->num[0][2])-(bunch_it->cap[0]*bunch_it->cap[2]);
-      bunch_it->sig[0][3] = (bunch_it->prod[0][3]/bunch_it->num[0][3])-(bunch_it->cap[0]*bunch_it->cap[3]);
-      bunch_it->sig[1][0] = (bunch_it->prod[1][0]/bunch_it->num[1][0])-(bunch_it->cap[1]*bunch_it->cap[0]);
-      bunch_it->sig[1][1] = (bunch_it->prod[1][1]/bunch_it->num[1][1])-(bunch_it->cap[1]*bunch_it->cap[1]);
-      bunch_it->sig[1][2] = (bunch_it->prod[1][2]/bunch_it->num[1][2])-(bunch_it->cap[1]*bunch_it->cap[2]);
-      bunch_it->sig[1][3] = (bunch_it->prod[1][3]/bunch_it->num[1][3])-(bunch_it->cap[1]*bunch_it->cap[3]);
-      bunch_it->sig[2][0] = (bunch_it->prod[2][0]/bunch_it->num[2][0])-(bunch_it->cap[2]*bunch_it->cap[0]);
-      bunch_it->sig[2][1] = (bunch_it->prod[2][1]/bunch_it->num[2][1])-(bunch_it->cap[2]*bunch_it->cap[1]);
-      bunch_it->sig[2][2] = (bunch_it->prod[2][2]/bunch_it->num[2][2])-(bunch_it->cap[2]*bunch_it->cap[2]);
-      bunch_it->sig[2][3] = (bunch_it->prod[2][3]/bunch_it->num[2][3])-(bunch_it->cap[2]*bunch_it->cap[3]);
-      bunch_it->sig[3][0] = (bunch_it->prod[3][0]/bunch_it->num[3][0])-(bunch_it->cap[3]*bunch_it->cap[0]);
-      bunch_it->sig[3][1] = (bunch_it->prod[3][1]/bunch_it->num[3][1])-(bunch_it->cap[3]*bunch_it->cap[1]);
-      bunch_it->sig[3][2] = (bunch_it->prod[3][2]/bunch_it->num[3][2])-(bunch_it->cap[3]*bunch_it->cap[2]);
-      bunch_it->sig[3][3] = (bunch_it->prod[3][3]/bunch_it->num[3][3])-(bunch_it->cap[3]*bunch_it->cap[3]);
+      bunch_it->sig[0][0] = (bunch_it->prod[0][0] / bunch_it->num[0][0]) - (bunch_it->cap[0] * bunch_it->cap[0]);
+      bunch_it->sig[0][1] = (bunch_it->prod[0][1] / bunch_it->num[0][1]) - (bunch_it->cap[0] * bunch_it->cap[1]);
+      bunch_it->sig[0][2] = (bunch_it->prod[0][2] / bunch_it->num[0][2]) - (bunch_it->cap[0] * bunch_it->cap[2]);
+      bunch_it->sig[0][3] = (bunch_it->prod[0][3] / bunch_it->num[0][3]) - (bunch_it->cap[0] * bunch_it->cap[3]);
+      bunch_it->sig[1][0] = (bunch_it->prod[1][0] / bunch_it->num[1][0]) - (bunch_it->cap[1] * bunch_it->cap[0]);
+      bunch_it->sig[1][1] = (bunch_it->prod[1][1] / bunch_it->num[1][1]) - (bunch_it->cap[1] * bunch_it->cap[1]);
+      bunch_it->sig[1][2] = (bunch_it->prod[1][2] / bunch_it->num[1][2]) - (bunch_it->cap[1] * bunch_it->cap[2]);
+      bunch_it->sig[1][3] = (bunch_it->prod[1][3] / bunch_it->num[1][3]) - (bunch_it->cap[1] * bunch_it->cap[3]);
+      bunch_it->sig[2][0] = (bunch_it->prod[2][0] / bunch_it->num[2][0]) - (bunch_it->cap[2] * bunch_it->cap[0]);
+      bunch_it->sig[2][1] = (bunch_it->prod[2][1] / bunch_it->num[2][1]) - (bunch_it->cap[2] * bunch_it->cap[1]);
+      bunch_it->sig[2][2] = (bunch_it->prod[2][2] / bunch_it->num[2][2]) - (bunch_it->cap[2] * bunch_it->cap[2]);
+      bunch_it->sig[2][3] = (bunch_it->prod[2][3] / bunch_it->num[2][3]) - (bunch_it->cap[2] * bunch_it->cap[3]);
+      bunch_it->sig[3][0] = (bunch_it->prod[3][0] / bunch_it->num[3][0]) - (bunch_it->cap[3] * bunch_it->cap[0]);
+      bunch_it->sig[3][1] = (bunch_it->prod[3][1] / bunch_it->num[3][1]) - (bunch_it->cap[3] * bunch_it->cap[1]);
+      bunch_it->sig[3][2] = (bunch_it->prod[3][2] / bunch_it->num[3][2]) - (bunch_it->cap[3] * bunch_it->cap[2]);
+      bunch_it->sig[3][3] = (bunch_it->prod[3][3] / bunch_it->num[3][3]) - (bunch_it->cap[3] * bunch_it->cap[3]);
 
-      bunch_it->sigfc[0][0] = (bunch_it->prodfc[0][0]/bunch_it->num[0][0])-(bunch_it->capfc[0]*bunch_it->capfc[0]);
-      bunch_it->sigfc[0][1] = (bunch_it->prodfc[0][1]/bunch_it->num[0][1])-(bunch_it->capfc[0]*bunch_it->capfc[1]);
-      bunch_it->sigfc[0][2] = (bunch_it->prodfc[0][2]/bunch_it->num[0][2])-(bunch_it->capfc[0]*bunch_it->capfc[2]);
-      bunch_it->sigfc[0][3] = (bunch_it->prodfc[0][3]/bunch_it->num[0][3])-(bunch_it->capfc[0]*bunch_it->capfc[3]);
-      bunch_it->sigfc[1][0] = (bunch_it->prodfc[1][0]/bunch_it->num[1][0])-(bunch_it->capfc[1]*bunch_it->capfc[0]);
-      bunch_it->sigfc[1][1] = (bunch_it->prodfc[1][1]/bunch_it->num[1][1])-(bunch_it->capfc[1]*bunch_it->capfc[1]);
-      bunch_it->sigfc[1][2] = (bunch_it->prodfc[1][2]/bunch_it->num[1][2])-(bunch_it->capfc[1]*bunch_it->capfc[2]);
-      bunch_it->sigfc[1][3] = (bunch_it->prodfc[1][3]/bunch_it->num[1][3])-(bunch_it->capfc[1]*bunch_it->capfc[3]);
-      bunch_it->sigfc[2][0] = (bunch_it->prodfc[2][0]/bunch_it->num[2][0])-(bunch_it->capfc[2]*bunch_it->capfc[0]);
-      bunch_it->sigfc[2][1] = (bunch_it->prodfc[2][1]/bunch_it->num[2][1])-(bunch_it->capfc[2]*bunch_it->capfc[1]);
-      bunch_it->sigfc[2][2] = (bunch_it->prodfc[2][2]/bunch_it->num[2][2])-(bunch_it->capfc[2]*bunch_it->capfc[2]);
-      bunch_it->sigfc[2][3] = (bunch_it->prodfc[2][3]/bunch_it->num[2][3])-(bunch_it->capfc[2]*bunch_it->capfc[3]);
-      bunch_it->sigfc[3][0] = (bunch_it->prodfc[3][0]/bunch_it->num[3][0])-(bunch_it->capfc[3]*bunch_it->capfc[0]);
-      bunch_it->sigfc[3][1] = (bunch_it->prodfc[3][1]/bunch_it->num[3][1])-(bunch_it->capfc[3]*bunch_it->capfc[1]);
-      bunch_it->sigfc[3][2] = (bunch_it->prodfc[3][2]/bunch_it->num[3][2])-(bunch_it->capfc[3]*bunch_it->capfc[2]);
-      bunch_it->sigfc[3][3] = (bunch_it->prodfc[3][3]/bunch_it->num[3][3])-(bunch_it->capfc[3]*bunch_it->capfc[3]);
+      bunch_it->sigfc[0][0] =
+          (bunch_it->prodfc[0][0] / bunch_it->num[0][0]) - (bunch_it->capfc[0] * bunch_it->capfc[0]);
+      bunch_it->sigfc[0][1] =
+          (bunch_it->prodfc[0][1] / bunch_it->num[0][1]) - (bunch_it->capfc[0] * bunch_it->capfc[1]);
+      bunch_it->sigfc[0][2] =
+          (bunch_it->prodfc[0][2] / bunch_it->num[0][2]) - (bunch_it->capfc[0] * bunch_it->capfc[2]);
+      bunch_it->sigfc[0][3] =
+          (bunch_it->prodfc[0][3] / bunch_it->num[0][3]) - (bunch_it->capfc[0] * bunch_it->capfc[3]);
+      bunch_it->sigfc[1][0] =
+          (bunch_it->prodfc[1][0] / bunch_it->num[1][0]) - (bunch_it->capfc[1] * bunch_it->capfc[0]);
+      bunch_it->sigfc[1][1] =
+          (bunch_it->prodfc[1][1] / bunch_it->num[1][1]) - (bunch_it->capfc[1] * bunch_it->capfc[1]);
+      bunch_it->sigfc[1][2] =
+          (bunch_it->prodfc[1][2] / bunch_it->num[1][2]) - (bunch_it->capfc[1] * bunch_it->capfc[2]);
+      bunch_it->sigfc[1][3] =
+          (bunch_it->prodfc[1][3] / bunch_it->num[1][3]) - (bunch_it->capfc[1] * bunch_it->capfc[3]);
+      bunch_it->sigfc[2][0] =
+          (bunch_it->prodfc[2][0] / bunch_it->num[2][0]) - (bunch_it->capfc[2] * bunch_it->capfc[0]);
+      bunch_it->sigfc[2][1] =
+          (bunch_it->prodfc[2][1] / bunch_it->num[2][1]) - (bunch_it->capfc[2] * bunch_it->capfc[1]);
+      bunch_it->sigfc[2][2] =
+          (bunch_it->prodfc[2][2] / bunch_it->num[2][2]) - (bunch_it->capfc[2] * bunch_it->capfc[2]);
+      bunch_it->sigfc[2][3] =
+          (bunch_it->prodfc[2][3] / bunch_it->num[2][3]) - (bunch_it->capfc[2] * bunch_it->capfc[3]);
+      bunch_it->sigfc[3][0] =
+          (bunch_it->prodfc[3][0] / bunch_it->num[3][0]) - (bunch_it->capfc[3] * bunch_it->capfc[0]);
+      bunch_it->sigfc[3][1] =
+          (bunch_it->prodfc[3][1] / bunch_it->num[3][1]) - (bunch_it->capfc[3] * bunch_it->capfc[1]);
+      bunch_it->sigfc[3][2] =
+          (bunch_it->prodfc[3][2] / bunch_it->num[3][2]) - (bunch_it->capfc[3] * bunch_it->capfc[2]);
+      bunch_it->sigfc[3][3] =
+          (bunch_it->prodfc[3][3] / bunch_it->num[3][3]) - (bunch_it->capfc[3] * bunch_it->capfc[3]);
 
-        for(int i = 0; i != 3; i++){
-            CASTORMeans->Fill(bunch_it->cap[i]);
-            CASTORWidths->Fill(bunch_it->sig[i][i]);
-         }
+      for (int i = 0; i != 3; i++) {
+        CASTORMeans->Fill(bunch_it->cap[i]);
+        CASTORWidths->Fill(bunch_it->sig[i][i]);
+      }
 
       //if(bunch_it->detid.subdet() == 1){
- 
-
 
       int fillphi = bunch_it->detid.sector();
       //if (bunch_it->detid.depth()==4) fillphi++;
 
-  //    dephist[bunch_it->detid.module()-1]->Fill(bunch_it->detid.ieta(),fillphi,
-   //             (bunch_it->cap[0]+bunch_it->cap[1]+bunch_it->cap[2]+bunch_it->cap[3])/4);
-      dephist->Fill( bunch_it->detid.module(),fillphi,
-                (bunch_it->cap[0]+bunch_it->cap[1]+bunch_it->cap[2]+bunch_it->cap[3])/4);
+      //    dephist[bunch_it->detid.module()-1]->Fill(bunch_it->detid.ieta(),fillphi,
+      //             (bunch_it->cap[0]+bunch_it->cap[1]+bunch_it->cap[2]+bunch_it->cap[3])/4);
+      dephist->Fill(bunch_it->detid.module(),
+                    fillphi,
+                    (bunch_it->cap[0] + bunch_it->cap[1] + bunch_it->cap[2] + bunch_it->cap[3]) / 4);
 
-      const CastorPedestal item(bunch_it->detid, bunch_it->cap[0], bunch_it->cap[1], bunch_it->cap[2], bunch_it->cap[3],
-                              bunch_it->sig[0][0], bunch_it->sig[1][1], bunch_it->sig[2][2], bunch_it->sig[3][3]);
+      const CastorPedestal item(bunch_it->detid,
+                                bunch_it->cap[0],
+                                bunch_it->cap[1],
+                                bunch_it->cap[2],
+                                bunch_it->cap[3],
+                                bunch_it->sig[0][0],
+                                bunch_it->sig[1][1],
+                                bunch_it->sig[2][2],
+                                bunch_it->sig[3][3]);
       rawPedsItem->addValues(item);
       CastorPedestalWidth widthsp(bunch_it->detid);
-      widthsp.setSigma(0,0,bunch_it->sig[0][0]);
-      widthsp.setSigma(0,1,bunch_it->sig[0][1]);
-      widthsp.setSigma(0,2,bunch_it->sig[0][2]);
-      widthsp.setSigma(0,3,bunch_it->sig[0][3]);
-      widthsp.setSigma(1,0,bunch_it->sig[1][0]);
-      widthsp.setSigma(1,1,bunch_it->sig[1][1]);
-      widthsp.setSigma(1,2,bunch_it->sig[1][2]);
-      widthsp.setSigma(1,3,bunch_it->sig[1][3]);
-      widthsp.setSigma(2,0,bunch_it->sig[2][0]);
-      widthsp.setSigma(2,1,bunch_it->sig[2][1]);
-      widthsp.setSigma(2,2,bunch_it->sig[2][2]);
-      widthsp.setSigma(2,3,bunch_it->sig[2][3]);
-      widthsp.setSigma(3,0,bunch_it->sig[3][0]);
-      widthsp.setSigma(3,1,bunch_it->sig[3][1]);
-      widthsp.setSigma(3,2,bunch_it->sig[3][2]);
-      widthsp.setSigma(3,3,bunch_it->sig[3][3]);
+      widthsp.setSigma(0, 0, bunch_it->sig[0][0]);
+      widthsp.setSigma(0, 1, bunch_it->sig[0][1]);
+      widthsp.setSigma(0, 2, bunch_it->sig[0][2]);
+      widthsp.setSigma(0, 3, bunch_it->sig[0][3]);
+      widthsp.setSigma(1, 0, bunch_it->sig[1][0]);
+      widthsp.setSigma(1, 1, bunch_it->sig[1][1]);
+      widthsp.setSigma(1, 2, bunch_it->sig[1][2]);
+      widthsp.setSigma(1, 3, bunch_it->sig[1][3]);
+      widthsp.setSigma(2, 0, bunch_it->sig[2][0]);
+      widthsp.setSigma(2, 1, bunch_it->sig[2][1]);
+      widthsp.setSigma(2, 2, bunch_it->sig[2][2]);
+      widthsp.setSigma(2, 3, bunch_it->sig[2][3]);
+      widthsp.setSigma(3, 0, bunch_it->sig[3][0]);
+      widthsp.setSigma(3, 1, bunch_it->sig[3][1]);
+      widthsp.setSigma(3, 2, bunch_it->sig[3][2]);
+      widthsp.setSigma(3, 3, bunch_it->sig[3][3]);
       rawWidthsItem->addValues(widthsp);
 
-      const CastorPedestal itemfc(bunch_it->detid, bunch_it->capfc[0], bunch_it->capfc[1], bunch_it->capfc[2], bunch_it->capfc[3],
-                              bunch_it->sigfc[0][0], bunch_it->sigfc[1][1], bunch_it->sigfc[2][2], bunch_it->sigfc[3][3]);
+      const CastorPedestal itemfc(bunch_it->detid,
+                                  bunch_it->capfc[0],
+                                  bunch_it->capfc[1],
+                                  bunch_it->capfc[2],
+                                  bunch_it->capfc[3],
+                                  bunch_it->sigfc[0][0],
+                                  bunch_it->sigfc[1][1],
+                                  bunch_it->sigfc[2][2],
+                                  bunch_it->sigfc[3][3]);
       rawPedsItemfc->addValues(itemfc);
       CastorPedestalWidth widthspfc(bunch_it->detid);
-      widthspfc.setSigma(0,0,bunch_it->sigfc[0][0]);
-      widthspfc.setSigma(0,1,bunch_it->sigfc[0][1]);
-      widthspfc.setSigma(0,2,bunch_it->sigfc[0][2]);
-      widthspfc.setSigma(0,3,bunch_it->sigfc[0][3]);
-      widthspfc.setSigma(1,0,bunch_it->sigfc[1][0]);      
-      widthspfc.setSigma(1,1,bunch_it->sigfc[1][1]);
-      widthspfc.setSigma(1,2,bunch_it->sigfc[1][2]);
-      widthspfc.setSigma(1,3,bunch_it->sigfc[1][3]);
-      widthspfc.setSigma(2,0,bunch_it->sigfc[2][0]);
-      widthspfc.setSigma(2,1,bunch_it->sigfc[2][1]);
-      widthspfc.setSigma(2,2,bunch_it->sigfc[2][2]);
-      widthspfc.setSigma(2,3,bunch_it->sigfc[2][3]);
-      widthspfc.setSigma(3,0,bunch_it->sigfc[3][0]);
-      widthspfc.setSigma(3,1,bunch_it->sigfc[3][1]);
-      widthspfc.setSigma(3,2,bunch_it->sigfc[3][2]);
-      widthspfc.setSigma(3,3,bunch_it->sigfc[3][3]);
+      widthspfc.setSigma(0, 0, bunch_it->sigfc[0][0]);
+      widthspfc.setSigma(0, 1, bunch_it->sigfc[0][1]);
+      widthspfc.setSigma(0, 2, bunch_it->sigfc[0][2]);
+      widthspfc.setSigma(0, 3, bunch_it->sigfc[0][3]);
+      widthspfc.setSigma(1, 0, bunch_it->sigfc[1][0]);
+      widthspfc.setSigma(1, 1, bunch_it->sigfc[1][1]);
+      widthspfc.setSigma(1, 2, bunch_it->sigfc[1][2]);
+      widthspfc.setSigma(1, 3, bunch_it->sigfc[1][3]);
+      widthspfc.setSigma(2, 0, bunch_it->sigfc[2][0]);
+      widthspfc.setSigma(2, 1, bunch_it->sigfc[2][1]);
+      widthspfc.setSigma(2, 2, bunch_it->sigfc[2][2]);
+      widthspfc.setSigma(2, 3, bunch_it->sigfc[2][3]);
+      widthspfc.setSigma(3, 0, bunch_it->sigfc[3][0]);
+      widthspfc.setSigma(3, 1, bunch_it->sigfc[3][1]);
+      widthspfc.setSigma(3, 2, bunch_it->sigfc[3][2]);
+      widthspfc.setSigma(3, 3, bunch_it->sigfc[3][3]);
       rawWidthsItemfc->addValues(widthspfc);
-
-      }
-   }
-
-    // dump the resulting list of pedestals into a file
-    std::ofstream outStream1(pedsADCfilename.c_str());
-    CastorDbASCIIIO::dumpObject (outStream1, (*rawPedsItem) );
-    std::ofstream outStream2(widthsADCfilename.c_str());
-    CastorDbASCIIIO::dumpObject (outStream2, (*rawWidthsItem) );
-
-    std::ofstream outStream3(pedsfCfilename.c_str());
-    CastorDbASCIIIO::dumpObject (outStream3, (*rawPedsItemfc) );
-    std::ofstream outStream4(widthsfCfilename.c_str());
-    CastorDbASCIIIO::dumpObject (outStream4, (*rawWidthsItemfc) );
-
-    if(dumpXML){
-       std::ofstream outStream5(XMLfilename.c_str());
-     //  CastorCondXML::dumpObject (outStream5, runnum, runnum, runnum, XMLtag, 1, (*rawPedsItem), (*rawWidthsItem)); 
     }
+  }
 
-    if(hiSaveFlag){
-       theFile->Write();
-    }else{
-       theFile->cd();
-       theFile->cd("CASTOR");
-       CASTORMeans->Write();
-       CASTORWidths->Write();
- 
-    }
+  // dump the resulting list of pedestals into a file
+  std::ofstream outStream1(pedsADCfilename.c_str());
+  CastorDbASCIIIO::dumpObject(outStream1, (*rawPedsItem));
+  std::ofstream outStream2(widthsADCfilename.c_str());
+  CastorDbASCIIIO::dumpObject(outStream2, (*rawWidthsItem));
+
+  std::ofstream outStream3(pedsfCfilename.c_str());
+  CastorDbASCIIIO::dumpObject(outStream3, (*rawPedsItemfc));
+  std::ofstream outStream4(widthsfCfilename.c_str());
+  CastorDbASCIIIO::dumpObject(outStream4, (*rawWidthsItemfc));
+
+  if (dumpXML) {
+    std::ofstream outStream5(XMLfilename.c_str());
+    //  CastorCondXML::dumpObject (outStream5, runnum, runnum, runnum, XMLtag, 1, (*rawPedsItem), (*rawWidthsItem));
+  }
+
+  if (hiSaveFlag) {
+    theFile->Write();
+  } else {
     theFile->cd();
-        dephist->Write();
-        dephist->SetDrawOption("colz");
-        dephist->GetXaxis()->SetTitle("module");
-        dephist->GetYaxis()->SetTitle("sector");
-    
-    //for (int n=0; n!= 4; n++) 
-    //{
-         //dephist[n]->Write();
-         //dephist[n]->SetDrawOption("colz");
-         //dephist[n]->GetXaxis()->SetTitle("i#eta");
-         //dephist[n]->GetYaxis()->SetTitle("i#phi");
-    //}
+    theFile->cd("CASTOR");
+    CASTORMeans->Write();
+    CASTORWidths->Write();
+  }
+  theFile->cd();
+  dephist->Write();
+  dephist->SetDrawOption("colz");
+  dephist->GetXaxis()->SetTitle("module");
+  dephist->GetYaxis()->SetTitle("sector");
 
-    std::stringstream tempstringout;
-    tempstringout << runnum;
-    std::string name1 = tempstringout.str() + "_pedplots_1d.png";
-    std::string name2 = tempstringout.str() + "_pedplots_2d.png";
+  //for (int n=0; n!= 4; n++)
+  //{
+  //dephist[n]->Write();
+  //dephist[n]->SetDrawOption("colz");
+  //dephist[n]->GetXaxis()->SetTitle("i#eta");
+  //dephist[n]->GetYaxis()->SetTitle("i#phi");
+  //}
 
-    TStyle *theStyle = new TStyle("style","null");
-    theStyle->SetPalette(1,nullptr);
-    theStyle->SetCanvasDefH(1200); //Height of canvas
-    theStyle->SetCanvasDefW(1600); //Width of canvas
+  std::stringstream tempstringout;
+  tempstringout << runnum;
+  std::string name1 = tempstringout.str() + "_pedplots_1d.png";
+  std::string name2 = tempstringout.str() + "_pedplots_2d.png";
 
-    gStyle = theStyle;
-/*
+  TStyle* theStyle = new TStyle("style", "null");
+  theStyle->SetPalette(1, nullptr);
+  theStyle->SetCanvasDefH(1200);  //Height of canvas
+  theStyle->SetCanvasDefW(1600);  //Width of canvas
+
+  gStyle = theStyle;
+  /*
     TCanvas * c1 = new TCanvas("c1","graph",1);
     c1->Divide(2,2);
     c1->cd(1);
@@ -221,130 +243,125 @@ CastorPedestalsAnalysis::~CastorPedestalsAnalysis()
     //dephist[3]->SetDrawOption("colz");
     c2->SaveAs(name2.c_str());
 */
-    std::cout << "Writing ROOT file... ";
-    theFile->Close();
-    std::cout << "ROOT file closed.\n";
+  std::cout << "Writing ROOT file... ";
+  theFile->Close();
+  std::cout << "ROOT file closed.\n";
 }
 
 // ------------ method called to for each event  ------------
-void
-CastorPedestalsAnalysis::analyze(const edm::Event& e, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   using namespace std;
+void CastorPedestalsAnalysis::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-   edm::Handle<CastorDigiCollection> castor;
-   e.getByLabel(castorDigiCollectionTag, castor);
+  edm::Handle<CastorDigiCollection> castor;
+  e.getByLabel(castorDigiCollectionTag, castor);
 
-   edm::ESHandle<CastorDbService> conditions;
-   iSetup.get<CastorDbRecord>().get(conditions);
+  edm::ESHandle<CastorDbService> conditions;
+  iSetup.get<CastorDbRecord>().get(conditions);
 
-   const CastorQIEShape* shape = conditions->getCastorShape();
+  const CastorQIEShape* shape = conditions->getCastorShape();
 
-   if(firsttime)
-   {
-      runnum = e.id().run();
-      std::string runnum_string;
-      std::stringstream tempstringout;
-      tempstringout << runnum;
-      runnum_string = tempstringout.str();
-      ROOTfilename = runnum_string + "-peds_ADC.root";
-      pedsADCfilename = runnum_string + "-peds_ADC.txt";
-      pedsfCfilename = runnum_string + "-peds_fC.txt";
-      widthsADCfilename = runnum_string + "-widths_ADC.txt";
-      widthsfCfilename = runnum_string + "-widths_fC.txt";
-      XMLfilename = runnum_string + "-peds_ADC_complete.xml"; 
-      XMLtag = "Castor_pedestals_" + runnum_string;
+  if (firsttime) {
+    runnum = e.id().run();
+    std::string runnum_string;
+    std::stringstream tempstringout;
+    tempstringout << runnum;
+    runnum_string = tempstringout.str();
+    ROOTfilename = runnum_string + "-peds_ADC.root";
+    pedsADCfilename = runnum_string + "-peds_ADC.txt";
+    pedsfCfilename = runnum_string + "-peds_fC.txt";
+    widthsADCfilename = runnum_string + "-widths_ADC.txt";
+    widthsfCfilename = runnum_string + "-widths_fC.txt";
+    XMLfilename = runnum_string + "-peds_ADC_complete.xml";
+    XMLtag = "Castor_pedestals_" + runnum_string;
 
-      theFile = new TFile(ROOTfilename.c_str(), "RECREATE");
-      theFile->cd();
-      // Create sub-directories
-      theFile->mkdir("CASTOR"); 
-      theFile->cd();
+    theFile = new TFile(ROOTfilename.c_str(), "RECREATE");
+    theFile->cd();
+    // Create sub-directories
+    theFile->mkdir("CASTOR");
+    theFile->cd();
 
-      CASTORMeans = new TH1F("All Ped Means CASTOR","All Ped Means CASTOR", 100, 0, 9);
-      CASTORWidths = new TH1F("All Ped Widths CASTOR","All Ped Widths CASTOR", 100, 0, 3);
+    CASTORMeans = new TH1F("All Ped Means CASTOR", "All Ped Means CASTOR", 100, 0, 9);
+    CASTORWidths = new TH1F("All Ped Widths CASTOR", "All Ped Widths CASTOR", 100, 0, 3);
 
-      dephist = new TH2F("Pedestals (ADC)","All Castor",14, 0., 14.5, 16, .5, 16.5);
-     // dephist[0] = new TH2F("Pedestals (ADC)","Depth 1",89, -44, 44, 72, .5, 72.5);
-     // dephist[1] = new TH2F("Pedestals (ADC)","Depth 2",89, -44, 44, 72, .5, 72.5);
-     // dephist[2] = new TH2F("Pedestals (ADC)","Depth 3",89, -44, 44, 72, .5, 72.5);
-     // dephist[3] = new TH2F("Pedestals (ADC)","Depth 4",89, -44, 44, 72, .5, 72.5);
+    dephist = new TH2F("Pedestals (ADC)", "All Castor", 14, 0., 14.5, 16, .5, 16.5);
+    // dephist[0] = new TH2F("Pedestals (ADC)","Depth 1",89, -44, 44, 72, .5, 72.5);
+    // dephist[1] = new TH2F("Pedestals (ADC)","Depth 2",89, -44, 44, 72, .5, 72.5);
+    // dephist[2] = new TH2F("Pedestals (ADC)","Depth 3",89, -44, 44, 72, .5, 72.5);
+    // dephist[3] = new TH2F("Pedestals (ADC)","Depth 4",89, -44, 44, 72, .5, 72.5);
 
-      edm::ESHandle<CastorElectronicsMap> refEMap;
-      iSetup.get<CastorElectronicsMapRcd>().get(refEMap);
-      const CastorElectronicsMap* myRefEMap = refEMap.product();
-      std::vector<HcalGenericDetId> listEMap = myRefEMap->allPrecisionId();
-      for (std::vector<HcalGenericDetId>::const_iterator it = listEMap.begin(); it != listEMap.end(); ++it)
-      {     
-         HcalGenericDetId mygenid(it->rawId());
-         if(mygenid.isHcalCastorDetId())
-         {
-            NewPedBunch a;
-            HcalCastorDetId chanid(mygenid.rawId());
-            a.detid = chanid;
-            a.usedflag = false;
-            string type;
-			type = "CASTOR";
-            for(int i = 0; i != 4; i++)
-            {
-               a.cap[i] = 0;
-               a.capfc[i] = 0;
-               for(int j = 0; j != 4; j++)
-               {
-                  a.sig[i][j] = 0;
-                  a.sigfc[i][j] = 0;
-                  a.prod[i][j] = 0;
-                  a.prodfc[i][j] = 0;
-                  a.num[i][j] = 0;
-               }
-            }
-            Bunches.push_back(a);
-         }
+    edm::ESHandle<CastorElectronicsMap> refEMap;
+    iSetup.get<CastorElectronicsMapRcd>().get(refEMap);
+    const CastorElectronicsMap* myRefEMap = refEMap.product();
+    std::vector<HcalGenericDetId> listEMap = myRefEMap->allPrecisionId();
+    for (std::vector<HcalGenericDetId>::const_iterator it = listEMap.begin(); it != listEMap.end(); ++it) {
+      HcalGenericDetId mygenid(it->rawId());
+      if (mygenid.isHcalCastorDetId()) {
+        NewPedBunch a;
+        HcalCastorDetId chanid(mygenid.rawId());
+        a.detid = chanid;
+        a.usedflag = false;
+        string type;
+        type = "CASTOR";
+        for (int i = 0; i != 4; i++) {
+          a.cap[i] = 0;
+          a.capfc[i] = 0;
+          for (int j = 0; j != 4; j++) {
+            a.sig[i][j] = 0;
+            a.sigfc[i][j] = 0;
+            a.prod[i][j] = 0;
+            a.prodfc[i][j] = 0;
+            a.num[i][j] = 0;
+          }
+        }
+        Bunches.push_back(a);
       }
-      firsttime = false;
-   }
+    }
+    firsttime = false;
+  }
 
-   std::vector<NewPedBunch>::iterator bunch_it;
+  std::vector<NewPedBunch>::iterator bunch_it;
 
-   for(CastorDigiCollection::const_iterator j = castor->begin(); j != castor->end(); ++j)
-   {
-      const CastorDataFrame digi = (const CastorDataFrame)(*j);
-      for(bunch_it = Bunches.begin(); bunch_it != Bunches.end(); ++bunch_it)
-         if(bunch_it->detid.rawId() == digi.id().rawId()) break;
-      bunch_it->usedflag = true;
-      for(int ts = firstTS; ts != lastTS+1; ts++)
-      {
-         const CastorQIECoder* coder = conditions->getCastorCoder(digi.id().rawId());
-         bunch_it->num[digi.sample(ts).capid()][digi.sample(ts).capid()] += 1;
-         bunch_it->cap[digi.sample(ts).capid()] += digi.sample(ts).adc();
-         double charge1 = coder->charge(*shape, digi.sample(ts).adc(), digi.sample(ts).capid());
-         bunch_it->capfc[digi.sample(ts).capid()] += charge1;
-         bunch_it->prod[digi.sample(ts).capid()][digi.sample(ts).capid()] += (digi.sample(ts).adc() * digi.sample(ts).adc());
-         bunch_it->prodfc[digi.sample(ts).capid()][digi.sample(ts).capid()] += charge1 * charge1;
-         if((ts+1 < digi.size()) && (ts+1 < lastTS)){
-            bunch_it->prod[digi.sample(ts).capid()][digi.sample(ts+1).capid()] += digi.sample(ts).adc()*digi.sample(ts+1).adc();
-            double charge2 = coder->charge(*shape, digi.sample(ts+1).adc(), digi.sample(ts+1).capid());
-            bunch_it->prodfc[digi.sample(ts).capid()][digi.sample(ts+1).capid()] += charge1*charge2;
-            bunch_it->num[digi.sample(ts).capid()][digi.sample(ts+1).capid()] += 1;
-         }
-         if((ts+2 < digi.size()) && (ts+2 < lastTS)){
-            bunch_it->prod[digi.sample(ts).capid()][digi.sample(ts+2).capid()] += digi.sample(ts).adc()*digi.sample(ts+2).adc();
-            double charge2 = coder->charge(*shape, digi.sample(ts+2).adc(), digi.sample(ts+2).capid());
-            bunch_it->prodfc[digi.sample(ts).capid()][digi.sample(ts+2).capid()] += charge1*charge2;
-            bunch_it->num[digi.sample(ts).capid()][digi.sample(ts+2).capid()] += 1;
-         }
-         if((ts+3 < digi.size()) && (ts+3 < lastTS)){
-            bunch_it->prod[digi.sample(ts).capid()][digi.sample(ts+3).capid()] += digi.sample(ts).adc()*digi.sample(ts+3).adc();
-            double charge2 = coder->charge(*shape, digi.sample(ts+3).adc(), digi.sample(ts+3).capid());
-            bunch_it->prodfc[digi.sample(ts).capid()][digi.sample(ts+3).capid()] += charge1*charge2;
-            bunch_it->num[digi.sample(ts).capid()][digi.sample(ts+3).capid()] += 1;
-         }
+  for (CastorDigiCollection::const_iterator j = castor->begin(); j != castor->end(); ++j) {
+    const CastorDataFrame digi = (const CastorDataFrame)(*j);
+    for (bunch_it = Bunches.begin(); bunch_it != Bunches.end(); ++bunch_it)
+      if (bunch_it->detid.rawId() == digi.id().rawId())
+        break;
+    bunch_it->usedflag = true;
+    for (int ts = firstTS; ts != lastTS + 1; ts++) {
+      const CastorQIECoder* coder = conditions->getCastorCoder(digi.id().rawId());
+      bunch_it->num[digi.sample(ts).capid()][digi.sample(ts).capid()] += 1;
+      bunch_it->cap[digi.sample(ts).capid()] += digi.sample(ts).adc();
+      double charge1 = coder->charge(*shape, digi.sample(ts).adc(), digi.sample(ts).capid());
+      bunch_it->capfc[digi.sample(ts).capid()] += charge1;
+      bunch_it->prod[digi.sample(ts).capid()][digi.sample(ts).capid()] +=
+          (digi.sample(ts).adc() * digi.sample(ts).adc());
+      bunch_it->prodfc[digi.sample(ts).capid()][digi.sample(ts).capid()] += charge1 * charge1;
+      if ((ts + 1 < digi.size()) && (ts + 1 < lastTS)) {
+        bunch_it->prod[digi.sample(ts).capid()][digi.sample(ts + 1).capid()] +=
+            digi.sample(ts).adc() * digi.sample(ts + 1).adc();
+        double charge2 = coder->charge(*shape, digi.sample(ts + 1).adc(), digi.sample(ts + 1).capid());
+        bunch_it->prodfc[digi.sample(ts).capid()][digi.sample(ts + 1).capid()] += charge1 * charge2;
+        bunch_it->num[digi.sample(ts).capid()][digi.sample(ts + 1).capid()] += 1;
       }
-   }
+      if ((ts + 2 < digi.size()) && (ts + 2 < lastTS)) {
+        bunch_it->prod[digi.sample(ts).capid()][digi.sample(ts + 2).capid()] +=
+            digi.sample(ts).adc() * digi.sample(ts + 2).adc();
+        double charge2 = coder->charge(*shape, digi.sample(ts + 2).adc(), digi.sample(ts + 2).capid());
+        bunch_it->prodfc[digi.sample(ts).capid()][digi.sample(ts + 2).capid()] += charge1 * charge2;
+        bunch_it->num[digi.sample(ts).capid()][digi.sample(ts + 2).capid()] += 1;
+      }
+      if ((ts + 3 < digi.size()) && (ts + 3 < lastTS)) {
+        bunch_it->prod[digi.sample(ts).capid()][digi.sample(ts + 3).capid()] +=
+            digi.sample(ts).adc() * digi.sample(ts + 3).adc();
+        double charge2 = coder->charge(*shape, digi.sample(ts + 3).adc(), digi.sample(ts + 3).capid());
+        bunch_it->prodfc[digi.sample(ts).capid()][digi.sample(ts + 3).capid()] += charge1 * charge2;
+        bunch_it->num[digi.sample(ts).capid()][digi.sample(ts + 3).capid()] += 1;
+      }
+    }
+  }
 
-
-//this is the last brace
+  //this is the last brace
 }
 
 //define this as a plug-in

--- a/CalibCalorimetry/CastorCalib/plugins/CastorTextCalibrations.cc
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorTextCalibrations.cc
@@ -34,125 +34,113 @@
 
 using namespace cms;
 
-CastorTextCalibrations::CastorTextCalibrations ( const edm::ParameterSet& iConfig ) 
-  
+CastorTextCalibrations::CastorTextCalibrations(const edm::ParameterSet& iConfig)
+
 {
   //parsing parameters
   std::vector<edm::ParameterSet> data = iConfig.getParameter<std::vector<edm::ParameterSet> >("input");
-  std::vector<edm::ParameterSet>::iterator request = data.begin ();
-  for (; request != data.end (); ++request) {
-    std::string objectName = request->getParameter<std::string> ("object");
+  std::vector<edm::ParameterSet>::iterator request = data.begin();
+  for (; request != data.end(); ++request) {
+    std::string objectName = request->getParameter<std::string>("object");
     edm::FileInPath fp = request->getParameter<edm::FileInPath>("file");
-    mInputs [objectName] = fp.fullPath();
+    mInputs[objectName] = fp.fullPath();
     if (objectName == "Pedestals") {
-      setWhatProduced (this, &CastorTextCalibrations::producePedestals);
-      findingRecord <CastorPedestalsRcd> ();
-    }
-    else if (objectName == "PedestalWidths") {
-      setWhatProduced (this, &CastorTextCalibrations::producePedestalWidths);
-      findingRecord <CastorPedestalWidthsRcd> ();
-    }
-    else if (objectName == "Gains") {
-      setWhatProduced (this, &CastorTextCalibrations::produceGains);
-      findingRecord <CastorGainsRcd> ();
-    }
-    else if (objectName == "GainWidths") {
-      setWhatProduced (this, &CastorTextCalibrations::produceGainWidths);
-      findingRecord <CastorGainWidthsRcd> ();
-    }
-    else if (objectName == "QIEData") {
-      setWhatProduced (this, &CastorTextCalibrations::produceQIEData);
-      findingRecord <CastorQIEDataRcd> ();
-    }
-    else if (objectName == "ChannelQuality") {
-      setWhatProduced (this, &CastorTextCalibrations::produceChannelQuality);
-      findingRecord <CastorChannelQualityRcd> ();
-    }
-    else if (objectName == "ElectronicsMap") {
-      setWhatProduced (this, &CastorTextCalibrations::produceElectronicsMap);
-      findingRecord <CastorElectronicsMapRcd> ();
-    }
-    else if (objectName == "RecoParams") {
-      setWhatProduced (this, &CastorTextCalibrations::produceRecoParams);
-      findingRecord <CastorRecoParamsRcd> ();
-    }
-    else if (objectName == "SaturationCorrs") {
-      setWhatProduced (this, &CastorTextCalibrations::produceSaturationCorrs);
-      findingRecord <CastorSaturationCorrsRcd> ();
-    }
-    else {
-      std::cerr << "CastorTextCalibrations-> Unknown object name '" << objectName 
-		<< "', known names are: "
-		<< "Pedestals PedestalWidths Gains GainWidths QIEData ChannelQuality ElectronicsMap RecoParams SaturationCorrs"
-		<< std::endl;
+      setWhatProduced(this, &CastorTextCalibrations::producePedestals);
+      findingRecord<CastorPedestalsRcd>();
+    } else if (objectName == "PedestalWidths") {
+      setWhatProduced(this, &CastorTextCalibrations::producePedestalWidths);
+      findingRecord<CastorPedestalWidthsRcd>();
+    } else if (objectName == "Gains") {
+      setWhatProduced(this, &CastorTextCalibrations::produceGains);
+      findingRecord<CastorGainsRcd>();
+    } else if (objectName == "GainWidths") {
+      setWhatProduced(this, &CastorTextCalibrations::produceGainWidths);
+      findingRecord<CastorGainWidthsRcd>();
+    } else if (objectName == "QIEData") {
+      setWhatProduced(this, &CastorTextCalibrations::produceQIEData);
+      findingRecord<CastorQIEDataRcd>();
+    } else if (objectName == "ChannelQuality") {
+      setWhatProduced(this, &CastorTextCalibrations::produceChannelQuality);
+      findingRecord<CastorChannelQualityRcd>();
+    } else if (objectName == "ElectronicsMap") {
+      setWhatProduced(this, &CastorTextCalibrations::produceElectronicsMap);
+      findingRecord<CastorElectronicsMapRcd>();
+    } else if (objectName == "RecoParams") {
+      setWhatProduced(this, &CastorTextCalibrations::produceRecoParams);
+      findingRecord<CastorRecoParamsRcd>();
+    } else if (objectName == "SaturationCorrs") {
+      setWhatProduced(this, &CastorTextCalibrations::produceSaturationCorrs);
+      findingRecord<CastorSaturationCorrsRcd>();
+    } else {
+      std::cerr << "CastorTextCalibrations-> Unknown object name '" << objectName << "', known names are: "
+                << "Pedestals PedestalWidths Gains GainWidths QIEData ChannelQuality ElectronicsMap RecoParams "
+                   "SaturationCorrs"
+                << std::endl;
     }
   }
   //  setWhatProduced(this);
 }
 
-
-CastorTextCalibrations::~CastorTextCalibrations()
-{
-}
-
+CastorTextCalibrations::~CastorTextCalibrations() {}
 
 //
 // member functions
 //
-void 
-CastorTextCalibrations::setIntervalFor( const edm::eventsetup::EventSetupRecordKey& iKey, const edm::IOVSyncValue& iTime, edm::ValidityInterval& oInterval ) {
-  std::string record = iKey.name ();
-  oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime()); //infinite
+void CastorTextCalibrations::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey,
+                                            const edm::IOVSyncValue& iTime,
+                                            edm::ValidityInterval& oInterval) {
+  std::string record = iKey.name();
+  oInterval = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());  //infinite
 }
 
 template <class T>
-std::unique_ptr<T> produce_impl (const std::string& fFile) {
-  std::unique_ptr<T> result (new T ());
-  std::ifstream inStream (fFile.c_str ());
-  if (!inStream.good ()) {
+std::unique_ptr<T> produce_impl(const std::string& fFile) {
+  std::unique_ptr<T> result(new T());
+  std::ifstream inStream(fFile.c_str());
+  if (!inStream.good()) {
     std::cerr << "CastorTextCalibrations-> Unable to open file '" << fFile << "'" << std::endl;
     throw cms::Exception("FileNotFound") << "Unable to open '" << fFile << "'" << std::endl;
   }
-  if (!CastorDbASCIIIO::getObject (inStream, *result)) {
+  if (!CastorDbASCIIIO::getObject(inStream, *result)) {
     std::cerr << "CastorTextCalibrations-> Can not read object from file '" << fFile << "'" << std::endl;
     throw cms::Exception("ReadError") << "Can not read object from file '" << fFile << "'" << std::endl;
   }
   return result;
 }
 
-
-std::unique_ptr<CastorPedestals> CastorTextCalibrations::producePedestals (const CastorPedestalsRcd&) {
-  return produce_impl<CastorPedestals> (mInputs ["Pedestals"]);
+std::unique_ptr<CastorPedestals> CastorTextCalibrations::producePedestals(const CastorPedestalsRcd&) {
+  return produce_impl<CastorPedestals>(mInputs["Pedestals"]);
 }
 
-std::unique_ptr<CastorPedestalWidths> CastorTextCalibrations::producePedestalWidths (const CastorPedestalWidthsRcd&) {
-  return produce_impl<CastorPedestalWidths> (mInputs ["PedestalWidths"]);
+std::unique_ptr<CastorPedestalWidths> CastorTextCalibrations::producePedestalWidths(const CastorPedestalWidthsRcd&) {
+  return produce_impl<CastorPedestalWidths>(mInputs["PedestalWidths"]);
 }
 
-std::unique_ptr<CastorGains> CastorTextCalibrations::produceGains (const CastorGainsRcd&) {
-  return produce_impl<CastorGains> (mInputs ["Gains"]);
+std::unique_ptr<CastorGains> CastorTextCalibrations::produceGains(const CastorGainsRcd&) {
+  return produce_impl<CastorGains>(mInputs["Gains"]);
 }
 
-std::unique_ptr<CastorGainWidths> CastorTextCalibrations::produceGainWidths (const CastorGainWidthsRcd&) {
-  return produce_impl<CastorGainWidths> (mInputs ["GainWidths"]);
+std::unique_ptr<CastorGainWidths> CastorTextCalibrations::produceGainWidths(const CastorGainWidthsRcd&) {
+  return produce_impl<CastorGainWidths>(mInputs["GainWidths"]);
 }
 
-std::unique_ptr<CastorQIEData> CastorTextCalibrations::produceQIEData (const CastorQIEDataRcd& rcd) {
-  return produce_impl<CastorQIEData> (mInputs ["QIEData"]);
+std::unique_ptr<CastorQIEData> CastorTextCalibrations::produceQIEData(const CastorQIEDataRcd& rcd) {
+  return produce_impl<CastorQIEData>(mInputs["QIEData"]);
 }
 
-std::unique_ptr<CastorChannelQuality> CastorTextCalibrations::produceChannelQuality (const CastorChannelQualityRcd& rcd) {
-  return produce_impl<CastorChannelQuality> (mInputs ["ChannelQuality"]);
+std::unique_ptr<CastorChannelQuality> CastorTextCalibrations::produceChannelQuality(const CastorChannelQualityRcd& rcd) {
+  return produce_impl<CastorChannelQuality>(mInputs["ChannelQuality"]);
 }
 
-std::unique_ptr<CastorElectronicsMap> CastorTextCalibrations::produceElectronicsMap (const CastorElectronicsMapRcd& rcd) {
-  return produce_impl<CastorElectronicsMap> (mInputs ["ElectronicsMap"]);
+std::unique_ptr<CastorElectronicsMap> CastorTextCalibrations::produceElectronicsMap(const CastorElectronicsMapRcd& rcd) {
+  return produce_impl<CastorElectronicsMap>(mInputs["ElectronicsMap"]);
 }
 
-std::unique_ptr<CastorRecoParams> CastorTextCalibrations::produceRecoParams (const CastorRecoParamsRcd& rcd) {
-  return produce_impl<CastorRecoParams> (mInputs ["RecoParams"]);
+std::unique_ptr<CastorRecoParams> CastorTextCalibrations::produceRecoParams(const CastorRecoParamsRcd& rcd) {
+  return produce_impl<CastorRecoParams>(mInputs["RecoParams"]);
 }
 
-std::unique_ptr<CastorSaturationCorrs> CastorTextCalibrations::produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd) {
-  return produce_impl<CastorSaturationCorrs> (mInputs ["SaturationCorrs"]);
+std::unique_ptr<CastorSaturationCorrs> CastorTextCalibrations::produceSaturationCorrs(
+    const CastorSaturationCorrsRcd& rcd) {
+  return produce_impl<CastorSaturationCorrs>(mInputs["SaturationCorrs"]);
 }

--- a/CalibCalorimetry/CastorCalib/plugins/CastorTextCalibrations.h
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorTextCalibrations.h
@@ -30,31 +30,28 @@ class CastorChannelQuality;
 class CastorRecoParams;
 class CastorSaturationCorrs;
 
-class CastorTextCalibrations : public edm::ESProducer,
-		       public edm::EventSetupRecordIntervalFinder
-{
+class CastorTextCalibrations : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:
-  CastorTextCalibrations (const edm::ParameterSet& );
-  ~CastorTextCalibrations () override;
+  CastorTextCalibrations(const edm::ParameterSet&);
+  ~CastorTextCalibrations() override;
 
-  void produce () {};
-  
+  void produce(){};
+
 protected:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-			      const edm::IOVSyncValue& , 
-			      edm::ValidityInterval&) override ;
+                      const edm::IOVSyncValue&,
+                      edm::ValidityInterval&) override;
 
-  std::unique_ptr<CastorPedestals> producePedestals (const CastorPedestalsRcd& rcd);
-  std::unique_ptr<CastorPedestalWidths> producePedestalWidths (const CastorPedestalWidthsRcd& rcd);
-  std::unique_ptr<CastorGains> produceGains (const CastorGainsRcd& rcd);
-  std::unique_ptr<CastorGainWidths> produceGainWidths (const CastorGainWidthsRcd& rcd);
-  std::unique_ptr<CastorQIEData> produceQIEData (const CastorQIEDataRcd& rcd);
-  std::unique_ptr<CastorChannelQuality> produceChannelQuality (const CastorChannelQualityRcd& rcd);
-  std::unique_ptr<CastorElectronicsMap> produceElectronicsMap (const CastorElectronicsMapRcd& rcd);
-  std::unique_ptr<CastorRecoParams> produceRecoParams (const CastorRecoParamsRcd& rcd);
-  std::unique_ptr<CastorSaturationCorrs> produceSaturationCorrs (const CastorSaturationCorrsRcd& rcd);
+  std::unique_ptr<CastorPedestals> producePedestals(const CastorPedestalsRcd& rcd);
+  std::unique_ptr<CastorPedestalWidths> producePedestalWidths(const CastorPedestalWidthsRcd& rcd);
+  std::unique_ptr<CastorGains> produceGains(const CastorGainsRcd& rcd);
+  std::unique_ptr<CastorGainWidths> produceGainWidths(const CastorGainWidthsRcd& rcd);
+  std::unique_ptr<CastorQIEData> produceQIEData(const CastorQIEDataRcd& rcd);
+  std::unique_ptr<CastorChannelQuality> produceChannelQuality(const CastorChannelQualityRcd& rcd);
+  std::unique_ptr<CastorElectronicsMap> produceElectronicsMap(const CastorElectronicsMapRcd& rcd);
+  std::unique_ptr<CastorRecoParams> produceRecoParams(const CastorRecoParamsRcd& rcd);
+  std::unique_ptr<CastorSaturationCorrs> produceSaturationCorrs(const CastorSaturationCorrsRcd& rcd);
 
- private:
-  std::map <std::string, std::string> mInputs;
+private:
+  std::map<std::string, std::string> mInputs;
 };
-

--- a/CalibCalorimetry/CastorCalib/plugins/SealModule.cc
+++ b/CalibCalorimetry/CastorCalib/plugins/SealModule.cc
@@ -5,7 +5,6 @@
 #include "CastorHardcodeCalibrations.h"
 #include "CastorTextCalibrations.h"
 
-
 DEFINE_FWK_EVENTSETUP_MODULE(CastorDbProducer);
 DEFINE_FWK_EVENTSETUP_SOURCE(CastorHardcodeCalibrations);
 DEFINE_FWK_EVENTSETUP_SOURCE(CastorTextCalibrations);

--- a/CalibCalorimetry/CastorCalib/src/CastorAlgoUtils.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorAlgoUtils.cc
@@ -4,32 +4,39 @@
 namespace reco {
   namespace castor {
 
-    void getLinearizedADC(const CastorQIEShape& shape,
-		      const CastorQIECoder* coder,
-		      int bins,int capid,
-		      float& lo,
-		      float& hi){
-  
-      float low = coder->charge(shape,0,capid); 
-      float high = coder->charge(shape,bins-1,capid);
-      float step = (high-low)/(bins-1);
-      low -= step/2.0; high += step/2.0;
-      lo = low; hi = high;
+    void getLinearizedADC(
+        const CastorQIEShape& shape, const CastorQIECoder* coder, int bins, int capid, float& lo, float& hi) {
+      float low = coder->charge(shape, 0, capid);
+      float high = coder->charge(shape, bins - 1, capid);
+      float step = (high - low) / (bins - 1);
+      low -= step / 2.0;
+      high += step / 2.0;
+      lo = low;
+      hi = high;
       return;
     }
 
-    float maxDiff(float one, float two, float three, float four){
-      float max=-1000; float min = 1000;
-      if(one>max) max = one;
-      if(one<min) min = one;
-      if(two>max) max = two;
-      if(two<min) min = two;
-      if(three>max) max = three;
-      if(three<min) min = three;
-      if(four>max) max = four;
-      if(four<min) min = four;
-      return fabs(max-min);
+    float maxDiff(float one, float two, float three, float four) {
+      float max = -1000;
+      float min = 1000;
+      if (one > max)
+        max = one;
+      if (one < min)
+        min = one;
+      if (two > max)
+        max = two;
+      if (two < min)
+        min = two;
+      if (three > max)
+        max = three;
+      if (three < min)
+        min = three;
+      if (four > max)
+        max = four;
+      if (four < min)
+        min = four;
+      return fabs(max - min);
     }
 
-  }
-}
+  }  // namespace castor
+}  // namespace reco

--- a/CalibCalorimetry/CastorCalib/src/CastorDbASCIIIO.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorDbASCIIIO.cc
@@ -16,779 +16,931 @@
 namespace CastorDbASCIIIO {
   class DetIdLess {
   public:
-    bool operator () (DetId fFirst, DetId fSecond) const {
-      HcalGenericDetId first (fFirst);
-      HcalGenericDetId second (fSecond);
-      if (first.genericSubdet () != second.genericSubdet ()) return first.genericSubdet () < second.genericSubdet ();
-      if (first.isHcalDetId ()) {
-	HcalDetId f1 (first);
-	HcalDetId s1 (second);
-	return	f1.zside () != s1.zside () ? f1.zside () < s1.zside () :
-	  f1.iphi () != s1.iphi () ? f1.iphi () < s1.iphi () :
-	  f1.ietaAbs () != s1.ietaAbs () ? f1.ietaAbs () < s1.ietaAbs () :
-	  f1.depth () < s1.depth ();
-      }
-      else {
-	return first.rawId() < second.rawId();
+    bool operator()(DetId fFirst, DetId fSecond) const {
+      HcalGenericDetId first(fFirst);
+      HcalGenericDetId second(fSecond);
+      if (first.genericSubdet() != second.genericSubdet())
+        return first.genericSubdet() < second.genericSubdet();
+      if (first.isHcalDetId()) {
+        HcalDetId f1(first);
+        HcalDetId s1(second);
+        return f1.zside() != s1.zside()
+                   ? f1.zside() < s1.zside()
+                   : f1.iphi() != s1.iphi()
+                         ? f1.iphi() < s1.iphi()
+                         : f1.ietaAbs() != s1.ietaAbs() ? f1.ietaAbs() < s1.ietaAbs() : f1.depth() < s1.depth();
+      } else {
+        return first.rawId() < second.rawId();
       }
     }
   };
   class CastorElectronicsIdLess {
   public:
-    bool operator () (CastorElectronicsId first, CastorElectronicsId second) const {
-      return
-	first.readoutVMECrateId () != second.readoutVMECrateId () ? first.readoutVMECrateId () < second.readoutVMECrateId () :
-	first.htrSlot () != second.htrSlot () ? first.htrSlot () < second.htrSlot () :
-	first.htrTopBottom () != second.htrTopBottom () ? first.htrTopBottom () < second.htrTopBottom () :
-	first.fiberIndex () != second.fiberIndex () ? first.fiberIndex () < second.fiberIndex () :
-	first.fiberChanId () < second.fiberChanId ();
+    bool operator()(CastorElectronicsId first, CastorElectronicsId second) const {
+      return first.readoutVMECrateId() != second.readoutVMECrateId()
+                 ? first.readoutVMECrateId() < second.readoutVMECrateId()
+                 : first.htrSlot() != second.htrSlot()
+                       ? first.htrSlot() < second.htrSlot()
+                       : first.htrTopBottom() != second.htrTopBottom()
+                             ? first.htrTopBottom() < second.htrTopBottom()
+                             : first.fiberIndex() != second.fiberIndex() ? first.fiberIndex() < second.fiberIndex()
+                                                                         : first.fiberChanId() < second.fiberChanId();
     }
   };
 
-std::vector <std::string> splitString (const std::string& fLine) {
-  std::vector <std::string> result;
-  int start = 0;
-  bool empty = true;
-  for (unsigned i = 0; i <= fLine.size (); i++) {
-    if (fLine [i] == ' ' || i == fLine.size ()) {
-      if (!empty) {
-	std::string item (fLine, start, i-start);
-	result.push_back (item);
-	empty = true;
+  std::vector<std::string> splitString(const std::string& fLine) {
+    std::vector<std::string> result;
+    int start = 0;
+    bool empty = true;
+    for (unsigned i = 0; i <= fLine.size(); i++) {
+      if (fLine[i] == ' ' || i == fLine.size()) {
+        if (!empty) {
+          std::string item(fLine, start, i - start);
+          result.push_back(item);
+          empty = true;
+        }
+        start = i + 1;
+      } else {
+        if (empty)
+          empty = false;
       }
-      start = i+1;
     }
-    else {
-      if (empty) empty = false;
-    }
-  }
-  return result;
-}
-
-DetId getId (const std::vector <std::string> & items) {
-  CastorText2DetIdConverter converter (items [3], items [0], items [1], items [2]);
-  return converter.getId ();
-}
-
-void dumpId (std::ostream& fOutput, DetId id) {
-  CastorText2DetIdConverter converter (id);
-  char buffer [1024];
-  sprintf (buffer, "  %15s %15s %15s %15s",
-	   converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str (),converter.getFlavor ().c_str ());  
-  fOutput << buffer;
-}
-
-template <class S,class T> 
-bool getCastorObject (std::istream& fInput, T& fObject) {
-  char buffer [1024];
-  while (fInput.getline(buffer, 1024)) {
-    if (buffer [0] == '#') continue; //ignore comment
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.empty()) continue; // blank line
-    if (items.size () < 8) {
-      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 8 items: eta, phi, depth, subdet, 4x values" << std::endl;
-      continue;
-    }
-    DetId id = getId (items);
-    
-//    if (fObject->exists(id) )
-//      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
-//    else
-//      {
-    S fCondObject(id, atof (items [4].c_str()), atof (items [5].c_str()), atof (items [6].c_str()), atof (items [7].c_str()));
-    fObject.addValues(fCondObject);
-	//      }
+    return result;
   }
 
-  return true;
-}
-
-template <class T>
-bool dumpCastorObject (std::ostream& fOutput, const T& fObject) {
-  char buffer [1024];
-  sprintf (buffer, "# %15s %15s %15s %15s %8s %8s %8s %8s %10s\n", "eta", "phi", "dep", "det", "cap0", "cap1", "cap2", "cap3", "DetId");
-  fOutput << buffer;
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  //std::sort (channels.begin(), channels.end(), DetIdLess ());
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
-    const float* values = fObject.getValues (*channel)->getValues ();
-    if (values) {
-      dumpId (fOutput, *channel);
-      sprintf (buffer, " %8.5f %8.5f %8.5f %8.5f %10X\n",
-	       values[0], values[1], values[2], values[3], channel->rawId ());
-      fOutput << buffer;
-    }
+  DetId getId(const std::vector<std::string>& items) {
+    CastorText2DetIdConverter converter(items[3], items[0], items[1], items[2]);
+    return converter.getId();
   }
-  return true;
-}
 
-template <class S,class T> 
-bool getCastorSingleFloatObject (std::istream& fInput, T& fObject) {
-  char buffer [1024];
-  while (fInput.getline(buffer, 1024)) {
-    if (buffer [0] == '#') continue; //ignore comment
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.empty()) continue; // blank line
-    if (items.size () < 5) {
-      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 5 items: eta, phi, depth, subdet, value" << std::endl;
-      continue;
-    }
-    DetId id = getId (items);
-    
-//    if (fObject->exists(id) )
-//      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
-//    else
-//      {
-    S fCondObject(id, atof (items [4].c_str()) );
-    fObject.addValues(fCondObject);
-    //      }
-  }
-  return true;
-}
-
-template <class T>
-bool dumpCastorSingleFloatObject (std::ostream& fOutput, const T& fObject) {
-  char buffer [1024];
-  sprintf (buffer, "# %15s %15s %15s %15s %8s %10s\n", "eta", "phi", "dep", "det", "value", "DetId");
-  fOutput << buffer;
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  std::sort (channels.begin(), channels.end(), DetIdLess ());
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
-    const float value = fObject.getValues (*channel)->getValue ();
-    dumpId (fOutput, *channel);
-    sprintf (buffer, " %8.5f %10X\n",
-	     value, channel->rawId ());
+  void dumpId(std::ostream& fOutput, DetId id) {
+    CastorText2DetIdConverter converter(id);
+    char buffer[1024];
+    sprintf(buffer,
+            "  %15s %15s %15s %15s",
+            converter.getField1().c_str(),
+            converter.getField2().c_str(),
+            converter.getField3().c_str(),
+            converter.getFlavor().c_str());
     fOutput << buffer;
   }
-  return true;
-}
 
-template <class S,class T> 
-bool getCastorSingleIntObject (std::istream& fInput, T& fObject, S* fCondObject) {
-  char buffer [1024];
-  while (fInput.getline(buffer, 1024)) {
-    if (buffer [0] == '#') continue; //ignore comment
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.empty()) continue; // blank line
-    if (items.size () < 5) {
-      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 5 items: eta, phi, depth, subdet, value" << std::endl;
-      continue;
-    }
-    DetId id = getId (items);
-    
-//    if (fObject->exists(id) )
-//      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
-//    else
-//      {
-	fCondObject = new S(id, atoi (items [4].c_str()) );
-	fObject.addValues(*fCondObject);
-	delete fCondObject;
-	//      }
-  }
-  return true;
-}
-
-template <class T>
-bool dumpCastorSingleIntObject (std::ostream& fOutput, const T& fObject) {
-  char buffer [1024];
-  sprintf (buffer, "# %15s %15s %15s %15s %8s %10s\n", "eta", "phi", "dep", "det", "value", "DetId");
-  fOutput << buffer;
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  std::sort (channels.begin(), channels.end(), DetIdLess ());
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
-    const int value = fObject.getValues (*channel)->getValue ();
-    dumpId (fOutput, *channel);
-    sprintf (buffer, " %15d %10X\n",
-	     value, channel->rawId ());
-    fOutput << buffer;
-  }
-  return true;
-}
-
-
-bool getObject (std::istream& fInput, CastorGains& fObject) {return getCastorObject<CastorGain> (fInput, fObject);}
-bool dumpObject (std::ostream& fOutput, const CastorGains& fObject) {return dumpCastorObject (fOutput, fObject);}
-bool getObject (std::istream& fInput, CastorGainWidths& fObject) {return getCastorObject<CastorGainWidth> (fInput, fObject);}
-bool dumpObject (std::ostream& fOutput, const CastorGainWidths& fObject) {return dumpCastorObject (fOutput, fObject);}
-
-bool getObject (std::istream& fInput, CastorSaturationCorrs& fObject) {return getCastorSingleFloatObject<CastorSaturationCorr> (fInput, fObject);}
-bool dumpObject (std::ostream& fOutput, const CastorSaturationCorrs& fObject) {return dumpCastorSingleFloatObject (fOutput, fObject);}
-
-
-
-// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool getObject (std::istream& fInput, CastorPedestals& fObject) {
-  char buffer [1024];
-
-  while (fInput.getline(buffer, 1024)) {
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.empty()) continue; // blank line
-    else {
-      if (items[0] == "#U")
-	{
-	  if (items[1] == (std::string)"ADC") fObject.setUnitADC(true);
-	    else if (items[1] == (std::string)"fC") fObject.setUnitADC(false);
-	  else 
-	    {
-	      edm::LogWarning("Pedestal Unit Error") << "Unrecognized unit for pedestals. Assuming fC." << std::endl;
-	      fObject.setUnitADC(false);
-	    }
-	  break;
-	}
-      else
-	{
-	  edm::LogWarning("Pedestal Unit Missing") << "The unit for the pedestals is missing in the txt file." << std::endl;
-	  return false;
-	}
-    }
-  }
-  while (fInput.getline(buffer, 1024)) {
-    if (buffer [0] == '#') continue;
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.empty()) continue; // blank line
-    if (items.size () < 8) {
-      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 8 items: eta, phi, depth, subdet, 4x values" 
-				      << " or 12 items: eta, phi, depth, subdet, 4x values for mean, 4x values for width"
-				      << std::endl;
-      continue;
-    }
-    DetId id = getId (items);
-    
-//    if (fObject.exists(id) )
-//      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
-//    else
-//      {
-
-    if (items.size() < 12) // old format without widths
-      {
-	CastorPedestal fCondObject(id, atof (items [4].c_str()), atof (items [5].c_str()), 
-                                   atof (items [6].c_str()), atof (items [7].c_str()), 
-                                   0., 0., 0., 0. );
-	fObject.addValues(fCondObject);
+  template <class S, class T>
+  bool getCastorObject(std::istream& fInput, T& fObject) {
+    char buffer[1024];
+    while (fInput.getline(buffer, 1024)) {
+      if (buffer[0] == '#')
+        continue;  //ignore comment
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;  // blank line
+      if (items.size() < 8) {
+        edm::LogWarning("Format Error") << "Bad line: " << buffer
+                                        << "\n line must contain 8 items: eta, phi, depth, subdet, 4x values"
+                                        << std::endl;
+        continue;
       }
-    else // new format with widths
-      {
-	CastorPedestal fCondObject(id, atof (items [4].c_str()), atof (items [5].c_str()), 
-                                   atof (items [6].c_str()), atof (items [7].c_str()), 
-                                   atof (items [8].c_str()), atof (items [9].c_str()),
-                                   atof (items [10].c_str()), atof (items [11].c_str()) );
-	fObject.addValues(fCondObject);
-      }
+      DetId id = getId(items);
 
-	//      }
-  }
-  return true;
-}
-
-
-bool dumpObject (std::ostream& fOutput, const CastorPedestals& fObject) {
-  char buffer [1024];
-  if (fObject.isADC() ) sprintf (buffer, "#U ADC  << this is the unit \n");
-  else  sprintf (buffer, "#U fC  << this is the unit \n");
-  fOutput << buffer;
-
-  sprintf (buffer, "# %15s %15s %15s %15s %8s %8s %8s %8s %8s %8s %8s %8s %10s\n", "eta", "phi", "dep", "det", "cap0", "cap1", "cap2", "cap3", "widthcap0", "widthcap1", "widthcap2", "widthcap3", "DetId");
-  fOutput << buffer;
-
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  std::sort (channels.begin(), channels.end(), DetIdLess ());
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
-    const float* values = fObject.getValues (*channel)->getValues ();
-    if (values) {
-      dumpId (fOutput, *channel);
-      sprintf (buffer, " %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %10X\n",
-	       values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7], channel->rawId ());
-      fOutput << buffer;
-    }
-  }
-  return true;
-}
-
-
-// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool getObject (std::istream& fInput, CastorChannelQuality& fObject) 
-{
-  char buffer [1024];
-  while (fInput.getline(buffer, 1024)) {
-    if (buffer [0] == '#') continue; //ignore comment
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.empty()) continue; // blank line
-    if (items.size () < 5) {
-      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 5 items: eta, phi, depth, subdet, GOOD/BAD/HOT/DEAD" << std::endl;
-      continue;
-    }
-    DetId id = getId (items);
-    
-    if (fObject.exists(id) ) {
-      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
-      continue;
-    }
-//    else
-//      {
-    uint32_t mystatus;
-    std::unique_ptr<CastorChannelStatus> fCondObject;
-    if (items[4].substr(0,2)=="0x") {
-       sscanf(items[4].c_str(),"%X", &mystatus);
-       fCondObject = std::make_unique<CastorChannelStatus>(id,mystatus);
-    }
-    else if (isalpha(items[4].c_str()[0])) {
-       fCondObject = std::make_unique<CastorChannelStatus>(id, items[4]);
-    }
-    else {
-       sscanf(items[4].c_str(),"%u", &mystatus);
-       fCondObject = std::make_unique<CastorChannelStatus>(id,mystatus);
-    }
-    fObject.addValues(*fCondObject);
-	//      }
-  }
-  return true;
-}
-
-
-bool dumpObject (std::ostream& fOutput, const CastorChannelQuality& fObject) {
-  char buffer [1024];
-  sprintf (buffer, "# %15s %15s %15s %15s %15s %10s\n", "eta", "phi", "dep", "det", "value", "DetId");
-  fOutput << buffer;
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  std::sort (channels.begin(), channels.end(), DetIdLess ());
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
-    const int value = fObject.getValues (*channel)->getValue ();
-    dumpId (fOutput, *channel);
-    sprintf (buffer, " %15X %10X\n",
-	     value, channel->rawId ());
-    fOutput << buffer;
-  }
-  return true;
-}
-
-
-// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool getObject (std::istream& fInput, CastorPedestalWidths& fObject) {
-  char buffer [1024];
-  int linecounter = 0;
-
-  while (fInput.getline(buffer, 1024)) {
-    linecounter++;
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.empty()) continue; // blank line
-    else {
-      if (items[0] == (std::string)"#U")
-	{
-	  if (items[1] == (std::string)"ADC") fObject.setUnitADC(true); 
-	  else if (items[1] == (std::string)"fC") fObject.setUnitADC(false);
-	  else 
-	    {
-	      edm::LogWarning("Pedestal Width Unit Error") << "Unrecognized unit for pedestal widths. Assuming fC." << std::endl;
-	      fObject.setUnitADC(false);
-	    }
-	  break;
-	}
-      else
-	{
-	  edm::LogWarning("Pedestal Width Unit Missing") << "The unit for the pedestal widths is missing in the txt file." << std::endl;
-	  return false;
-	}
-    }
-  }
-
-  while (fInput.getline(buffer, 1024)) {
-    linecounter++;
-    if (buffer [0] == '#') continue; //ignore comment
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.empty()) continue; // blank line
-    if (items.size () < 14) {
-      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line number: " << linecounter << "\n line must contain 14 items: eta, phi, depth, subdet, 10x correlations" 
-				      << " or 20 items: eta, phi, depth, subdet, 16x correlations" 
-				      << std::endl;
-      continue;
-    }
-    DetId id = getId (items);
-
-//    if (fObject.exists(id) )
-//      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
-//    else
-//      {
-
-    if (items.size() < 20) //old format
-      {
-	CastorPedestalWidth values(id);
-	values.setSigma (0, 0, atof (items [4].c_str()));
-	values.setSigma (1, 0, atof (items [5].c_str()));
-	values.setSigma (1, 1, atof (items [6].c_str()));
-	values.setSigma (2, 0, atof (items [7].c_str()));
-	values.setSigma (2, 1, atof (items [8].c_str()));
-	values.setSigma (2, 2, atof (items [9].c_str()));
-	values.setSigma (3, 0, atof (items [10].c_str()));
-	values.setSigma (3, 1, atof (items [11].c_str()));
-	values.setSigma (3, 2, atof (items [12].c_str()));
-	values.setSigma (3, 3, atof (items [13].c_str()));
-	values.setSigma (0, 1, 0.);
-	values.setSigma (0, 2, 0.);
-	values.setSigma (0, 3, 0.);
-	values.setSigma (1, 2, 0.);
-	values.setSigma (1, 3, 0.);
-	values.setSigma (2, 3, 0.);
-	fObject.addValues(values);	
-      }
-    else // new format
-      {
-	CastorPedestalWidth values(id);
-	values.setSigma (0, 0, atof (items [4].c_str()) );
-	values.setSigma (0, 1, atof (items [5].c_str()) );
-	values.setSigma (0, 2, atof (items [6].c_str()) );
-	values.setSigma (0, 3, atof (items [7].c_str()) );
-	values.setSigma (1, 0, atof (items [8].c_str()) );
-	values.setSigma (1, 1, atof (items [9].c_str()) );
-	values.setSigma (1, 2, atof (items [10].c_str()) );
-	values.setSigma (1, 3, atof (items [11].c_str()) );
-	values.setSigma (2, 0, atof (items [12].c_str()) );
-	values.setSigma (2, 1, atof (items [13].c_str()) );
-	values.setSigma (2, 2, atof (items [14].c_str()) );
-	values.setSigma (2, 3, atof (items [15].c_str()) );
-	values.setSigma (3, 0, atof (items [16].c_str()) );
-	values.setSigma (3, 1, atof (items [17].c_str()) );
-	values.setSigma (3, 2, atof (items [18].c_str()) );
-	values.setSigma (3, 3, atof (items [19].c_str()) );
-	fObject.addValues(values);	
-      }
-
-	//      }
-  }
-  return true;
-}
-
-bool dumpObject (std::ostream& fOutput, const CastorPedestalWidths& fObject) {
-  char buffer [1024];
-  if (fObject.isADC() ) sprintf (buffer, "#U ADC  << this is the unit \n");
-  else  sprintf (buffer, "#U fC  << this is the unit \n");
-  fOutput << buffer;
-
-  sprintf (buffer, "# %15s %15s %15s %15s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %10s\n", 
-	   "eta", "phi", "dep", "det", 
-	   "cov_0_0", "cov_0_1", "cov_0_2", "cov_0_3", "cov_1_0", "cov_1_1", "cov_1_2", "cov_1_3", "cov_2_0", "cov_2_1", "cov_2_2", "cov_2_3", "cov_3_0", "cov_3_1", "cov_3_2", "cov_3_3", 
-	   "DetId");
-  fOutput << buffer;
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  std::sort (channels.begin(), channels.end(), DetIdLess ());
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
-    const CastorPedestalWidth* item = fObject.getValues (*channel);
-    if (item) {
-      dumpId (fOutput, *channel);
-      sprintf (buffer, " %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %10X\n",
-	       item->getSigma (0,0), item->getSigma (0,1), item->getSigma (0,2), item->getSigma (0,3), 
-	       item->getSigma (1,0), item->getSigma (1,1), item->getSigma (1,2), item->getSigma (1,3),
-	       item->getSigma (2,0), item->getSigma (2,1), item->getSigma (2,2), item->getSigma (2,3),
-	       item->getSigma (3,0), item->getSigma (3,1), item->getSigma (3,2), item->getSigma (3,3), channel->rawId ());
-      fOutput << buffer;
-    }
-  }
-  return true;
-}
-
-
-// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool getObject (std::istream& fInput, CastorQIEData& fObject) {
-  char buffer [1024];
-  while (fInput.getline(buffer, 1024)) {
-    if (buffer [0] == '#') continue; //ignore comment
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.empty()) continue;
-    if (items [0] == "SHAPE") { // basic shape
-      if (items.size () < 33) {
-	edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 33 items: SHAPE  32 x low QIE edges for first 32 bins" << std::endl;
-	continue;
-      }
-      //float lowEdges [32];
-      //int i = 32;
-      //while (--i >= 0) lowEdges [i] = atof (items [i+1].c_str ());
-      //      fObject.setShape (lowEdges);
-    }
-    else { // QIE parameters
-      if (items.size () < 36) {
-	edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 36 items: eta, phi, depth, subdet, 4 capId x 4 Ranges x offsets, 4 capId x 4 Ranges x slopes" << std::endl;
-	continue;
-      }
-      DetId id = getId (items);
-      fObject.sort ();
-      //      try {
-      //      fObject.getCoder (id);
+      //    if (fObject->exists(id) )
       //      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
-	//      }
-//      catch (cms::Exception& e) {
-	CastorQIECoder coder (id.rawId ());
-	int index = 4;
-	for (unsigned capid = 0; capid < 4; capid++) {
-	  for (unsigned range = 0; range < 4; range++) {
-	    coder.setOffset (capid, range, atof (items [index++].c_str ()));
-	  }
-	}
-	for (unsigned capid = 0; capid < 4; capid++) {
-	  for (unsigned range = 0; range < 4; range++) {
-	    coder.setSlope (capid, range, atof (items [index++].c_str ()));
-	  }
-	}
-	fObject.addCoder (coder);
-//      }
+      //    else
+      //      {
+      S fCondObject(id, atof(items[4].c_str()), atof(items[5].c_str()), atof(items[6].c_str()), atof(items[7].c_str()));
+      fObject.addValues(fCondObject);
+      //      }
     }
-  }
-  fObject.sort ();
-  return true;
-}
 
-bool dumpObject (std::ostream& fOutput, const CastorQIEData& fObject) {
-  char buffer [1024];
-  fOutput << "# QIE basic shape: SHAPE 32 x low edge values for first 32 channels" << std::endl;
-  sprintf (buffer, "SHAPE ");
-  fOutput << buffer;
-  for (unsigned bin = 0; bin < 32; bin++) {
-    sprintf (buffer, " %8.5f", fObject.getShape ().lowEdge (bin));
+    return true;
+  }
+
+  template <class T>
+  bool dumpCastorObject(std::ostream& fOutput, const T& fObject) {
+    char buffer[1024];
+    sprintf(buffer,
+            "# %15s %15s %15s %15s %8s %8s %8s %8s %10s\n",
+            "eta",
+            "phi",
+            "dep",
+            "det",
+            "cap0",
+            "cap1",
+            "cap2",
+            "cap3",
+            "DetId");
     fOutput << buffer;
-  }
-  fOutput << std::endl;
-
-  fOutput << "# QIE data" << std::endl;
-  sprintf (buffer, "# %15s %15s %15s %15s %36s %36s %36s %36s %36s %36s %36s %36s\n", 
-	   "eta", "phi", "dep", "det", 
-	   "4 x offsets cap0", "4 x offsets cap1", "4 x offsets cap2", "4 x offsets cap3",
-	   "4 x slopes cap0", "4 x slopes cap1", "4 x slopes cap2", "4 x slopes cap3");
-  fOutput << buffer;
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  std::sort (channels.begin(), channels.end(), DetIdLess ());
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
-    const CastorQIECoder* coder = fObject.getCoder (*channel);
-    dumpId (fOutput, *channel);
-    for (unsigned capid = 0; capid < 4; capid++) {
-      for (unsigned range = 0; range < 4; range++) {
-	sprintf (buffer, " %8.5f", coder->offset (capid, range));
-	fOutput << buffer;
+    std::vector<DetId> channels = fObject.getAllChannels();
+    //std::sort (channels.begin(), channels.end(), DetIdLess ());
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+      const float* values = fObject.getValues(*channel)->getValues();
+      if (values) {
+        dumpId(fOutput, *channel);
+        sprintf(
+            buffer, " %8.5f %8.5f %8.5f %8.5f %10X\n", values[0], values[1], values[2], values[3], channel->rawId());
+        fOutput << buffer;
       }
     }
-    for (unsigned capid = 0; capid < 4; capid++) {
-      for (unsigned range = 0; range < 4; range++) {
-	sprintf (buffer, " %8.5f", coder->slope (capid, range));
-	fOutput << buffer;
+    return true;
+  }
+
+  template <class S, class T>
+  bool getCastorSingleFloatObject(std::istream& fInput, T& fObject) {
+    char buffer[1024];
+    while (fInput.getline(buffer, 1024)) {
+      if (buffer[0] == '#')
+        continue;  //ignore comment
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;  // blank line
+      if (items.size() < 5) {
+        edm::LogWarning("Format Error") << "Bad line: " << buffer
+                                        << "\n line must contain 5 items: eta, phi, depth, subdet, value" << std::endl;
+        continue;
       }
+      DetId id = getId(items);
+
+      //    if (fObject->exists(id) )
+      //      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
+      //    else
+      //      {
+      S fCondObject(id, atof(items[4].c_str()));
+      fObject.addValues(fCondObject);
+      //      }
+    }
+    return true;
+  }
+
+  template <class T>
+  bool dumpCastorSingleFloatObject(std::ostream& fOutput, const T& fObject) {
+    char buffer[1024];
+    sprintf(buffer, "# %15s %15s %15s %15s %8s %10s\n", "eta", "phi", "dep", "det", "value", "DetId");
+    fOutput << buffer;
+    std::vector<DetId> channels = fObject.getAllChannels();
+    std::sort(channels.begin(), channels.end(), DetIdLess());
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+      const float value = fObject.getValues(*channel)->getValue();
+      dumpId(fOutput, *channel);
+      sprintf(buffer, " %8.5f %10X\n", value, channel->rawId());
+      fOutput << buffer;
+    }
+    return true;
+  }
+
+  template <class S, class T>
+  bool getCastorSingleIntObject(std::istream& fInput, T& fObject, S* fCondObject) {
+    char buffer[1024];
+    while (fInput.getline(buffer, 1024)) {
+      if (buffer[0] == '#')
+        continue;  //ignore comment
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;  // blank line
+      if (items.size() < 5) {
+        edm::LogWarning("Format Error") << "Bad line: " << buffer
+                                        << "\n line must contain 5 items: eta, phi, depth, subdet, value" << std::endl;
+        continue;
+      }
+      DetId id = getId(items);
+
+      //    if (fObject->exists(id) )
+      //      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
+      //    else
+      //      {
+      fCondObject = new S(id, atoi(items[4].c_str()));
+      fObject.addValues(*fCondObject);
+      delete fCondObject;
+      //      }
+    }
+    return true;
+  }
+
+  template <class T>
+  bool dumpCastorSingleIntObject(std::ostream& fOutput, const T& fObject) {
+    char buffer[1024];
+    sprintf(buffer, "# %15s %15s %15s %15s %8s %10s\n", "eta", "phi", "dep", "det", "value", "DetId");
+    fOutput << buffer;
+    std::vector<DetId> channels = fObject.getAllChannels();
+    std::sort(channels.begin(), channels.end(), DetIdLess());
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+      const int value = fObject.getValues(*channel)->getValue();
+      dumpId(fOutput, *channel);
+      sprintf(buffer, " %15d %10X\n", value, channel->rawId());
+      fOutput << buffer;
+    }
+    return true;
+  }
+
+  bool getObject(std::istream& fInput, CastorGains& fObject) { return getCastorObject<CastorGain>(fInput, fObject); }
+  bool dumpObject(std::ostream& fOutput, const CastorGains& fObject) { return dumpCastorObject(fOutput, fObject); }
+  bool getObject(std::istream& fInput, CastorGainWidths& fObject) {
+    return getCastorObject<CastorGainWidth>(fInput, fObject);
+  }
+  bool dumpObject(std::ostream& fOutput, const CastorGainWidths& fObject) { return dumpCastorObject(fOutput, fObject); }
+
+  bool getObject(std::istream& fInput, CastorSaturationCorrs& fObject) {
+    return getCastorSingleFloatObject<CastorSaturationCorr>(fInput, fObject);
+  }
+  bool dumpObject(std::ostream& fOutput, const CastorSaturationCorrs& fObject) {
+    return dumpCastorSingleFloatObject(fOutput, fObject);
+  }
+
+  // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  bool getObject(std::istream& fInput, CastorPedestals& fObject) {
+    char buffer[1024];
+
+    while (fInput.getline(buffer, 1024)) {
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;  // blank line
+      else {
+        if (items[0] == "#U") {
+          if (items[1] == (std::string) "ADC")
+            fObject.setUnitADC(true);
+          else if (items[1] == (std::string) "fC")
+            fObject.setUnitADC(false);
+          else {
+            edm::LogWarning("Pedestal Unit Error") << "Unrecognized unit for pedestals. Assuming fC." << std::endl;
+            fObject.setUnitADC(false);
+          }
+          break;
+        } else {
+          edm::LogWarning("Pedestal Unit Missing")
+              << "The unit for the pedestals is missing in the txt file." << std::endl;
+          return false;
+        }
+      }
+    }
+    while (fInput.getline(buffer, 1024)) {
+      if (buffer[0] == '#')
+        continue;
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;  // blank line
+      if (items.size() < 8) {
+        edm::LogWarning("Format Error")
+            << "Bad line: " << buffer << "\n line must contain 8 items: eta, phi, depth, subdet, 4x values"
+            << " or 12 items: eta, phi, depth, subdet, 4x values for mean, 4x values for width" << std::endl;
+        continue;
+      }
+      DetId id = getId(items);
+
+      //    if (fObject.exists(id) )
+      //      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
+      //    else
+      //      {
+
+      if (items.size() < 12)  // old format without widths
+      {
+        CastorPedestal fCondObject(id,
+                                   atof(items[4].c_str()),
+                                   atof(items[5].c_str()),
+                                   atof(items[6].c_str()),
+                                   atof(items[7].c_str()),
+                                   0.,
+                                   0.,
+                                   0.,
+                                   0.);
+        fObject.addValues(fCondObject);
+      } else  // new format with widths
+      {
+        CastorPedestal fCondObject(id,
+                                   atof(items[4].c_str()),
+                                   atof(items[5].c_str()),
+                                   atof(items[6].c_str()),
+                                   atof(items[7].c_str()),
+                                   atof(items[8].c_str()),
+                                   atof(items[9].c_str()),
+                                   atof(items[10].c_str()),
+                                   atof(items[11].c_str()));
+        fObject.addValues(fCondObject);
+      }
+
+      //      }
+    }
+    return true;
+  }
+
+  bool dumpObject(std::ostream& fOutput, const CastorPedestals& fObject) {
+    char buffer[1024];
+    if (fObject.isADC())
+      sprintf(buffer, "#U ADC  << this is the unit \n");
+    else
+      sprintf(buffer, "#U fC  << this is the unit \n");
+    fOutput << buffer;
+
+    sprintf(buffer,
+            "# %15s %15s %15s %15s %8s %8s %8s %8s %8s %8s %8s %8s %10s\n",
+            "eta",
+            "phi",
+            "dep",
+            "det",
+            "cap0",
+            "cap1",
+            "cap2",
+            "cap3",
+            "widthcap0",
+            "widthcap1",
+            "widthcap2",
+            "widthcap3",
+            "DetId");
+    fOutput << buffer;
+
+    std::vector<DetId> channels = fObject.getAllChannels();
+    std::sort(channels.begin(), channels.end(), DetIdLess());
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+      const float* values = fObject.getValues(*channel)->getValues();
+      if (values) {
+        dumpId(fOutput, *channel);
+        sprintf(buffer,
+                " %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %10X\n",
+                values[0],
+                values[1],
+                values[2],
+                values[3],
+                values[4],
+                values[5],
+                values[6],
+                values[7],
+                channel->rawId());
+        fOutput << buffer;
+      }
+    }
+    return true;
+  }
+
+  // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  bool getObject(std::istream& fInput, CastorChannelQuality& fObject) {
+    char buffer[1024];
+    while (fInput.getline(buffer, 1024)) {
+      if (buffer[0] == '#')
+        continue;  //ignore comment
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;  // blank line
+      if (items.size() < 5) {
+        edm::LogWarning("Format Error") << "Bad line: " << buffer
+                                        << "\n line must contain 5 items: eta, phi, depth, subdet, GOOD/BAD/HOT/DEAD"
+                                        << std::endl;
+        continue;
+      }
+      DetId id = getId(items);
+
+      if (fObject.exists(id)) {
+        edm::LogWarning("Redefining Channel")
+            << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
+        continue;
+      }
+      //    else
+      //      {
+      uint32_t mystatus;
+      std::unique_ptr<CastorChannelStatus> fCondObject;
+      if (items[4].substr(0, 2) == "0x") {
+        sscanf(items[4].c_str(), "%X", &mystatus);
+        fCondObject = std::make_unique<CastorChannelStatus>(id, mystatus);
+      } else if (isalpha(items[4].c_str()[0])) {
+        fCondObject = std::make_unique<CastorChannelStatus>(id, items[4]);
+      } else {
+        sscanf(items[4].c_str(), "%u", &mystatus);
+        fCondObject = std::make_unique<CastorChannelStatus>(id, mystatus);
+      }
+      fObject.addValues(*fCondObject);
+      //      }
+    }
+    return true;
+  }
+
+  bool dumpObject(std::ostream& fOutput, const CastorChannelQuality& fObject) {
+    char buffer[1024];
+    sprintf(buffer, "# %15s %15s %15s %15s %15s %10s\n", "eta", "phi", "dep", "det", "value", "DetId");
+    fOutput << buffer;
+    std::vector<DetId> channels = fObject.getAllChannels();
+    std::sort(channels.begin(), channels.end(), DetIdLess());
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+      const int value = fObject.getValues(*channel)->getValue();
+      dumpId(fOutput, *channel);
+      sprintf(buffer, " %15X %10X\n", value, channel->rawId());
+      fOutput << buffer;
+    }
+    return true;
+  }
+
+  // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  bool getObject(std::istream& fInput, CastorPedestalWidths& fObject) {
+    char buffer[1024];
+    int linecounter = 0;
+
+    while (fInput.getline(buffer, 1024)) {
+      linecounter++;
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;  // blank line
+      else {
+        if (items[0] == (std::string) "#U") {
+          if (items[1] == (std::string) "ADC")
+            fObject.setUnitADC(true);
+          else if (items[1] == (std::string) "fC")
+            fObject.setUnitADC(false);
+          else {
+            edm::LogWarning("Pedestal Width Unit Error")
+                << "Unrecognized unit for pedestal widths. Assuming fC." << std::endl;
+            fObject.setUnitADC(false);
+          }
+          break;
+        } else {
+          edm::LogWarning("Pedestal Width Unit Missing")
+              << "The unit for the pedestal widths is missing in the txt file." << std::endl;
+          return false;
+        }
+      }
+    }
+
+    while (fInput.getline(buffer, 1024)) {
+      linecounter++;
+      if (buffer[0] == '#')
+        continue;  //ignore comment
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;  // blank line
+      if (items.size() < 14) {
+        edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line number: " << linecounter
+                                        << "\n line must contain 14 items: eta, phi, depth, subdet, 10x correlations"
+                                        << " or 20 items: eta, phi, depth, subdet, 16x correlations" << std::endl;
+        continue;
+      }
+      DetId id = getId(items);
+
+      //    if (fObject.exists(id) )
+      //      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
+      //    else
+      //      {
+
+      if (items.size() < 20)  //old format
+      {
+        CastorPedestalWidth values(id);
+        values.setSigma(0, 0, atof(items[4].c_str()));
+        values.setSigma(1, 0, atof(items[5].c_str()));
+        values.setSigma(1, 1, atof(items[6].c_str()));
+        values.setSigma(2, 0, atof(items[7].c_str()));
+        values.setSigma(2, 1, atof(items[8].c_str()));
+        values.setSigma(2, 2, atof(items[9].c_str()));
+        values.setSigma(3, 0, atof(items[10].c_str()));
+        values.setSigma(3, 1, atof(items[11].c_str()));
+        values.setSigma(3, 2, atof(items[12].c_str()));
+        values.setSigma(3, 3, atof(items[13].c_str()));
+        values.setSigma(0, 1, 0.);
+        values.setSigma(0, 2, 0.);
+        values.setSigma(0, 3, 0.);
+        values.setSigma(1, 2, 0.);
+        values.setSigma(1, 3, 0.);
+        values.setSigma(2, 3, 0.);
+        fObject.addValues(values);
+      } else  // new format
+      {
+        CastorPedestalWidth values(id);
+        values.setSigma(0, 0, atof(items[4].c_str()));
+        values.setSigma(0, 1, atof(items[5].c_str()));
+        values.setSigma(0, 2, atof(items[6].c_str()));
+        values.setSigma(0, 3, atof(items[7].c_str()));
+        values.setSigma(1, 0, atof(items[8].c_str()));
+        values.setSigma(1, 1, atof(items[9].c_str()));
+        values.setSigma(1, 2, atof(items[10].c_str()));
+        values.setSigma(1, 3, atof(items[11].c_str()));
+        values.setSigma(2, 0, atof(items[12].c_str()));
+        values.setSigma(2, 1, atof(items[13].c_str()));
+        values.setSigma(2, 2, atof(items[14].c_str()));
+        values.setSigma(2, 3, atof(items[15].c_str()));
+        values.setSigma(3, 0, atof(items[16].c_str()));
+        values.setSigma(3, 1, atof(items[17].c_str()));
+        values.setSigma(3, 2, atof(items[18].c_str()));
+        values.setSigma(3, 3, atof(items[19].c_str()));
+        fObject.addValues(values);
+      }
+
+      //      }
+    }
+    return true;
+  }
+
+  bool dumpObject(std::ostream& fOutput, const CastorPedestalWidths& fObject) {
+    char buffer[1024];
+    if (fObject.isADC())
+      sprintf(buffer, "#U ADC  << this is the unit \n");
+    else
+      sprintf(buffer, "#U fC  << this is the unit \n");
+    fOutput << buffer;
+
+    sprintf(buffer,
+            "# %15s %15s %15s %15s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %8s %10s\n",
+            "eta",
+            "phi",
+            "dep",
+            "det",
+            "cov_0_0",
+            "cov_0_1",
+            "cov_0_2",
+            "cov_0_3",
+            "cov_1_0",
+            "cov_1_1",
+            "cov_1_2",
+            "cov_1_3",
+            "cov_2_0",
+            "cov_2_1",
+            "cov_2_2",
+            "cov_2_3",
+            "cov_3_0",
+            "cov_3_1",
+            "cov_3_2",
+            "cov_3_3",
+            "DetId");
+    fOutput << buffer;
+    std::vector<DetId> channels = fObject.getAllChannels();
+    std::sort(channels.begin(), channels.end(), DetIdLess());
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+      const CastorPedestalWidth* item = fObject.getValues(*channel);
+      if (item) {
+        dumpId(fOutput, *channel);
+        sprintf(
+            buffer,
+            " %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %8.5f %10X\n",
+            item->getSigma(0, 0),
+            item->getSigma(0, 1),
+            item->getSigma(0, 2),
+            item->getSigma(0, 3),
+            item->getSigma(1, 0),
+            item->getSigma(1, 1),
+            item->getSigma(1, 2),
+            item->getSigma(1, 3),
+            item->getSigma(2, 0),
+            item->getSigma(2, 1),
+            item->getSigma(2, 2),
+            item->getSigma(2, 3),
+            item->getSigma(3, 0),
+            item->getSigma(3, 1),
+            item->getSigma(3, 2),
+            item->getSigma(3, 3),
+            channel->rawId());
+        fOutput << buffer;
+      }
+    }
+    return true;
+  }
+
+  // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  bool getObject(std::istream& fInput, CastorQIEData& fObject) {
+    char buffer[1024];
+    while (fInput.getline(buffer, 1024)) {
+      if (buffer[0] == '#')
+        continue;  //ignore comment
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;
+      if (items[0] == "SHAPE") {  // basic shape
+        if (items.size() < 33) {
+          edm::LogWarning("Format Error")
+              << "Bad line: " << buffer << "\n line must contain 33 items: SHAPE  32 x low QIE edges for first 32 bins"
+              << std::endl;
+          continue;
+        }
+        //float lowEdges [32];
+        //int i = 32;
+        //while (--i >= 0) lowEdges [i] = atof (items [i+1].c_str ());
+        //      fObject.setShape (lowEdges);
+      } else {  // QIE parameters
+        if (items.size() < 36) {
+          edm::LogWarning("Format Error") << "Bad line: " << buffer
+                                          << "\n line must contain 36 items: eta, phi, depth, subdet, 4 capId x 4 "
+                                             "Ranges x offsets, 4 capId x 4 Ranges x slopes"
+                                          << std::endl;
+          continue;
+        }
+        DetId id = getId(items);
+        fObject.sort();
+        //      try {
+        //      fObject.getCoder (id);
+        //      edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
+        //      }
+        //      catch (cms::Exception& e) {
+        CastorQIECoder coder(id.rawId());
+        int index = 4;
+        for (unsigned capid = 0; capid < 4; capid++) {
+          for (unsigned range = 0; range < 4; range++) {
+            coder.setOffset(capid, range, atof(items[index++].c_str()));
+          }
+        }
+        for (unsigned capid = 0; capid < 4; capid++) {
+          for (unsigned range = 0; range < 4; range++) {
+            coder.setSlope(capid, range, atof(items[index++].c_str()));
+          }
+        }
+        fObject.addCoder(coder);
+        //      }
+      }
+    }
+    fObject.sort();
+    return true;
+  }
+
+  bool dumpObject(std::ostream& fOutput, const CastorQIEData& fObject) {
+    char buffer[1024];
+    fOutput << "# QIE basic shape: SHAPE 32 x low edge values for first 32 channels" << std::endl;
+    sprintf(buffer, "SHAPE ");
+    fOutput << buffer;
+    for (unsigned bin = 0; bin < 32; bin++) {
+      sprintf(buffer, " %8.5f", fObject.getShape().lowEdge(bin));
+      fOutput << buffer;
     }
     fOutput << std::endl;
-  }
-  return true;
-}
 
-// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool getObject (std::istream& fInput, CastorCalibrationQIEData& fObject) {
-  char buffer [1024];
-  while (fInput.getline(buffer, 1024)) {
-    if (buffer [0] == '#') continue; //ignore comment
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.size () < 36) {
-      edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 36 items: eta, phi, depth, subdet, 32 bin values" << std::endl;
-      continue;
-    }
-    DetId id = getId (items);
-    fObject.sort ();
-    //    try {
-    //    fObject.getCoder (id);
-    //    edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
-      //    }
-//    catch (cms::Exception& e) {
-      CastorCalibrationQIECoder coder (id.rawId ());
-      int index = 4;
-      float values [32];
-      for (unsigned bin = 0; bin < 32; bin++) {
-	values[bin] = atof (items [index++].c_str ());
+    fOutput << "# QIE data" << std::endl;
+    sprintf(buffer,
+            "# %15s %15s %15s %15s %36s %36s %36s %36s %36s %36s %36s %36s\n",
+            "eta",
+            "phi",
+            "dep",
+            "det",
+            "4 x offsets cap0",
+            "4 x offsets cap1",
+            "4 x offsets cap2",
+            "4 x offsets cap3",
+            "4 x slopes cap0",
+            "4 x slopes cap1",
+            "4 x slopes cap2",
+            "4 x slopes cap3");
+    fOutput << buffer;
+    std::vector<DetId> channels = fObject.getAllChannels();
+    std::sort(channels.begin(), channels.end(), DetIdLess());
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+      const CastorQIECoder* coder = fObject.getCoder(*channel);
+      dumpId(fOutput, *channel);
+      for (unsigned capid = 0; capid < 4; capid++) {
+        for (unsigned range = 0; range < 4; range++) {
+          sprintf(buffer, " %8.5f", coder->offset(capid, range));
+          fOutput << buffer;
+        }
       }
-      coder.setMinCharges (values);
-      fObject.addCoder (coder);
-//    }
-  }
-  fObject.sort ();
-  return true;
-}
-
-bool dumpObject (std::ostream& fOutput, const CastorCalibrationQIEData& fObject) {
-  char buffer [1024];
-  fOutput << "# QIE data in calibration mode" << std::endl;
-  sprintf (buffer, "# %15s %15s %15s %15s %288s\n", 
-	   "eta", "phi", "dep", "det", "32 x charges");
-  fOutput << buffer;
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  std::sort (channels.begin(), channels.end(), DetIdLess ());
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
-    const CastorCalibrationQIECoder* coder = fObject.getCoder (*channel);
-    if (coder) {
-      dumpId (fOutput, *channel);
-      const float* lowEdge = coder->minCharges ();
-      for (unsigned bin = 0; bin < 32; bin++) {
-	sprintf (buffer, " %8.5f", lowEdge [bin]);
-	fOutput << buffer;
+      for (unsigned capid = 0; capid < 4; capid++) {
+        for (unsigned range = 0; range < 4; range++) {
+          sprintf(buffer, " %8.5f", coder->slope(capid, range));
+          fOutput << buffer;
+        }
       }
       fOutput << std::endl;
     }
+    return true;
   }
-  return true;
-}
 
-
-// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-bool getObject (std::istream& fInput, CastorElectronicsMap& fObject) {
-  char buffer [1024];
-  while (fInput.getline(buffer, 1024)) {
-    if (buffer [0] == '#') continue; //ignore comment
-    std::vector <std::string> items = splitString (std::string (buffer));
-    if (items.size () < 12) {
-      if (items.empty()) continue; // no warning here
-      if (items.size()<9) {
-	edm::LogError("MapFormat") << "CastorElectronicsMap-> line too short: " << buffer;
-	continue;
+  // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  bool getObject(std::istream& fInput, CastorCalibrationQIEData& fObject) {
+    char buffer[1024];
+    while (fInput.getline(buffer, 1024)) {
+      if (buffer[0] == '#')
+        continue;  //ignore comment
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.size() < 36) {
+        edm::LogWarning("Format Error") << "Bad line: " << buffer
+                                        << "\n line must contain 36 items: eta, phi, depth, subdet, 32 bin values"
+                                        << std::endl;
+        continue;
       }
-      if (items[8]=="NA" || items[8]=="NT") {
-	while (items.size()<12) items.push_back(""); // don't worry here
-      } else if (items[8]=="HT") {
-	if (items.size()==11) items.push_back("");
-	else {
-	  edm::LogError("MapFormat") << "CastorElectronicsMap-> Bad line: " << buffer 
-				     << "\n HT line must contain at least 11 items: i  cr sl tb dcc spigot fiber fiberchan subdet=HT ieta iphi";
-	  continue;
-	}
+      DetId id = getId(items);
+      fObject.sort();
+      //    try {
+      //    fObject.getCoder (id);
+      //    edm::LogWarning("Redefining Channel") << "line: " << buffer << "\n attempts to redefine data. Ignored" << std::endl;
+      //    }
+      //    catch (cms::Exception& e) {
+      CastorCalibrationQIECoder coder(id.rawId());
+      int index = 4;
+      float values[32];
+      for (unsigned bin = 0; bin < 32; bin++) {
+        values[bin] = atof(items[index++].c_str());
+      }
+      coder.setMinCharges(values);
+      fObject.addCoder(coder);
+      //    }
+    }
+    fObject.sort();
+    return true;
+  }
+
+  bool dumpObject(std::ostream& fOutput, const CastorCalibrationQIEData& fObject) {
+    char buffer[1024];
+    fOutput << "# QIE data in calibration mode" << std::endl;
+    sprintf(buffer, "# %15s %15s %15s %15s %288s\n", "eta", "phi", "dep", "det", "32 x charges");
+    fOutput << buffer;
+    std::vector<DetId> channels = fObject.getAllChannels();
+    std::sort(channels.begin(), channels.end(), DetIdLess());
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+      const CastorCalibrationQIECoder* coder = fObject.getCoder(*channel);
+      if (coder) {
+        dumpId(fOutput, *channel);
+        const float* lowEdge = coder->minCharges();
+        for (unsigned bin = 0; bin < 32; bin++) {
+          sprintf(buffer, " %8.5f", lowEdge[bin]);
+          fOutput << buffer;
+        }
+        fOutput << std::endl;
+      }
+    }
+    return true;
+  }
+
+  // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  bool getObject(std::istream& fInput, CastorElectronicsMap& fObject) {
+    char buffer[1024];
+    while (fInput.getline(buffer, 1024)) {
+      if (buffer[0] == '#')
+        continue;  //ignore comment
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.size() < 12) {
+        if (items.empty())
+          continue;  // no warning here
+        if (items.size() < 9) {
+          edm::LogError("MapFormat") << "CastorElectronicsMap-> line too short: " << buffer;
+          continue;
+        }
+        if (items[8] == "NA" || items[8] == "NT") {
+          while (items.size() < 12)
+            items.push_back("");  // don't worry here
+        } else if (items[8] == "HT") {
+          if (items.size() == 11)
+            items.push_back("");
+          else {
+            edm::LogError("MapFormat") << "CastorElectronicsMap-> Bad line: " << buffer
+                                       << "\n HT line must contain at least 11 items: i  cr sl tb dcc spigot fiber "
+                                          "fiberchan subdet=HT ieta iphi";
+            continue;
+          }
+        } else {
+          edm::LogError("MapFormat")
+              << "CastorElectronicsMap-> Bad line: " << buffer
+              << "\n line must contain 12 items: i  cr sl tb dcc spigot fiber fiberchan subdet ieta iphi depth";
+          continue;
+        }
+      }
+      //    std::cout << "CastorElectronicsMap-> processing line: " << buffer << std::endl;
+      int crate = atoi(items[1].c_str());
+      int slot = atoi(items[2].c_str());
+      int top = 1;
+      if (items[3] == "b")
+        top = 0;
+      int dcc = atoi(items[4].c_str());
+      int spigot = atoi(items[5].c_str());
+      CastorElectronicsId elId;
+      if (items[8] == "HT" || items[8] == "NT") {
+        int slb = atoi(items[6].c_str());
+        int slbCh = atoi(items[7].c_str());
+        elId = CastorElectronicsId(slbCh, slb, spigot, dcc, crate, slot, top);
       } else {
-	edm::LogError("MapFormat") << "CastorElectronicsMap-> Bad line: " << buffer 
-				   << "\n line must contain 12 items: i  cr sl tb dcc spigot fiber fiberchan subdet ieta iphi depth";
-	continue;
-      }
-    }
-    //    std::cout << "CastorElectronicsMap-> processing line: " << buffer << std::endl;
-    int crate = atoi (items [1].c_str());
-    int slot = atoi (items [2].c_str());
-    int top = 1;
-    if (items [3] == "b") top = 0;
-    int dcc = atoi (items [4].c_str());
-    int spigot = atoi (items [5].c_str());
-    CastorElectronicsId elId;
-    if (items[8] == "HT" || items[8] == "NT") {
-      int slb = atoi (items [6].c_str());
-      int slbCh = atoi (items [7].c_str());
-      elId=CastorElectronicsId(slbCh, slb, spigot, dcc,crate,slot,top);
-    } else {
-      int fiber = atoi (items [6].c_str());
-      int fiberCh = atoi (items [7].c_str());
+        int fiber = atoi(items[6].c_str());
+        int fiberCh = atoi(items[7].c_str());
 
-      elId=CastorElectronicsId(fiberCh, fiber, spigot, dcc);
-      elId.setHTR (crate, slot, top);
-    }
+        elId = CastorElectronicsId(fiberCh, fiber, spigot, dcc);
+        elId.setHTR(crate, slot, top);
+      }
 
-    // first, handle undefined cases
-    if (items [8] == "NA") { // undefined channel
-      fObject.mapEId2chId (elId, DetId (HcalDetId::Undefined));
-    } else if (items [8] == "NT") { // undefined trigger channel
-      fObject.mapEId2tId (elId, DetId (HcalTrigTowerDetId::Undefined));
-    } else {
-      CastorText2DetIdConverter converter (items [8], items [9], items [10], items [11]);
-      if (converter.isHcalCastorDetId ()) { 
-	fObject.mapEId2chId (elId, converter.getId ());
-      }
-      else {
-	edm::LogWarning("Format Error") << "CastorElectronicsMap-> Unknown subdetector: " 
-		  << items [8] << '/' << items [9] << '/' << items [10] << '/' << items [11] << std::endl; 
+      // first, handle undefined cases
+      if (items[8] == "NA") {  // undefined channel
+        fObject.mapEId2chId(elId, DetId(HcalDetId::Undefined));
+      } else if (items[8] == "NT") {  // undefined trigger channel
+        fObject.mapEId2tId(elId, DetId(HcalTrigTowerDetId::Undefined));
+      } else {
+        CastorText2DetIdConverter converter(items[8], items[9], items[10], items[11]);
+        if (converter.isHcalCastorDetId()) {
+          fObject.mapEId2chId(elId, converter.getId());
+        } else {
+          edm::LogWarning("Format Error") << "CastorElectronicsMap-> Unknown subdetector: " << items[8] << '/'
+                                          << items[9] << '/' << items[10] << '/' << items[11] << std::endl;
+        }
       }
     }
+    fObject.sort();
+    return true;
   }
-  fObject.sort ();
-  return true;
-}
 
-bool dumpObject (std::ostream& fOutput, const CastorElectronicsMap& fObject) {
-  std::vector<CastorElectronicsId> eids = fObject.allElectronicsId ();
-  char buf [1024];
-  // changes by Jared, 6.03.09/(included 25.03.09)
-  //  sprintf (buf, "#%10s %6s %6s %6s %6s %6s %6s %6s %15s %15s %15s %15s",
-  sprintf (buf, "# %7s %3s %3s %3s %4s %7s %10s %14s %7s %5s %5s %6s",
-	   "i", "cr", "sl", "tb", "dcc", "spigot", "fiber/slb", "fibcha/slbcha", "subdet", "ieta", "iphi", "depth");
-  fOutput << buf << std::endl;
+  bool dumpObject(std::ostream& fOutput, const CastorElectronicsMap& fObject) {
+    std::vector<CastorElectronicsId> eids = fObject.allElectronicsId();
+    char buf[1024];
+    // changes by Jared, 6.03.09/(included 25.03.09)
+    //  sprintf (buf, "#%10s %6s %6s %6s %6s %6s %6s %6s %15s %15s %15s %15s",
+    sprintf(buf,
+            "# %7s %3s %3s %3s %4s %7s %10s %14s %7s %5s %5s %6s",
+            "i",
+            "cr",
+            "sl",
+            "tb",
+            "dcc",
+            "spigot",
+            "fiber/slb",
+            "fibcha/slbcha",
+            "subdet",
+            "ieta",
+            "iphi",
+            "depth");
+    fOutput << buf << std::endl;
 
-  for (unsigned i = 0; i < eids.size (); i++) {
-    CastorElectronicsId eid = eids[i];
-    if (eid.isTriggerChainId()) {
-      DetId trigger = fObject.lookupTrigger (eid);
-      if (trigger.rawId ()) {
-	CastorText2DetIdConverter converter (trigger);
-	// changes by Jared, 6.03.09/(included 25.03.09)
-	//	sprintf (buf, " %10X %6d %6d %6c %6d %6d %6d %6d %15s %15s %15s %15s",
-	sprintf (buf, " %7X %3d %3d %3c %4d %7d %10d %14d %7s %5s %5s %6s",
-		 //		 i,
-		 converter.getId().rawId(),
-		 // changes by Jared, 6.03.09/(included 25.03.09)
-		 //		 eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.fiberIndex(), eid.fiberChanId(),
-		 eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.slbSiteNumber(), eid.slbChannelIndex(),
-		 converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
-		 );
-	fOutput << buf << std::endl;
-      }
-    } else {
-      DetId channel = fObject.lookup (eid);
-      if (channel.rawId()) {
-	CastorText2DetIdConverter converter (channel);
-	// changes by Jared, 6.03.09/(included 25.03.09)
-	//	sprintf (buf, " %10X %6d %6d %6c %6d %6d %6d %6d %15s %15s %15s %15s",
-	sprintf (buf, " %7X %3d %3d %3c %4d %7d %10d %14d %7s %5s %5s %6s",
-		 //		 i,
-		 converter.getId().rawId(),
-		 eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.fiberIndex(), eid.fiberChanId(),
-		 converter.getFlavor ().c_str (), converter.getField1 ().c_str (), converter.getField2 ().c_str (), converter.getField3 ().c_str ()
-	       );
-	fOutput << buf << std::endl;
+    for (unsigned i = 0; i < eids.size(); i++) {
+      CastorElectronicsId eid = eids[i];
+      if (eid.isTriggerChainId()) {
+        DetId trigger = fObject.lookupTrigger(eid);
+        if (trigger.rawId()) {
+          CastorText2DetIdConverter converter(trigger);
+          // changes by Jared, 6.03.09/(included 25.03.09)
+          //	sprintf (buf, " %10X %6d %6d %6c %6d %6d %6d %6d %15s %15s %15s %15s",
+          sprintf(
+              buf,
+              " %7X %3d %3d %3c %4d %7d %10d %14d %7s %5s %5s %6s",
+              //		 i,
+              converter.getId().rawId(),
+              // changes by Jared, 6.03.09/(included 25.03.09)
+              //		 eid.readoutVMECrateId(), eid.htrSlot(), eid.htrTopBottom()>0?'t':'b', eid.dccid(), eid.spigot(), eid.fiberIndex(), eid.fiberChanId(),
+              eid.readoutVMECrateId(),
+              eid.htrSlot(),
+              eid.htrTopBottom() > 0 ? 't' : 'b',
+              eid.dccid(),
+              eid.spigot(),
+              eid.slbSiteNumber(),
+              eid.slbChannelIndex(),
+              converter.getFlavor().c_str(),
+              converter.getField1().c_str(),
+              converter.getField2().c_str(),
+              converter.getField3().c_str());
+          fOutput << buf << std::endl;
+        }
+      } else {
+        DetId channel = fObject.lookup(eid);
+        if (channel.rawId()) {
+          CastorText2DetIdConverter converter(channel);
+          // changes by Jared, 6.03.09/(included 25.03.09)
+          //	sprintf (buf, " %10X %6d %6d %6c %6d %6d %6d %6d %15s %15s %15s %15s",
+          sprintf(buf,
+                  " %7X %3d %3d %3c %4d %7d %10d %14d %7s %5s %5s %6s",
+                  //		 i,
+                  converter.getId().rawId(),
+                  eid.readoutVMECrateId(),
+                  eid.htrSlot(),
+                  eid.htrTopBottom() > 0 ? 't' : 'b',
+                  eid.dccid(),
+                  eid.spigot(),
+                  eid.fiberIndex(),
+                  eid.fiberChanId(),
+                  converter.getFlavor().c_str(),
+                  converter.getField1().c_str(),
+                  converter.getField2().c_str(),
+                  converter.getField3().c_str());
+          fOutput << buf << std::endl;
+        }
       }
     }
+    return true;
   }
-  return true;
-}
 
-bool getObject (std::istream& fInput, CastorRecoParams& fObject) {
-	char buffer [1024];
-	while (fInput.getline(buffer, 1024)) {
-		if (buffer [0] == '#') continue; //ignore comment
-		std::vector <std::string> items = splitString (std::string (buffer));
-		if (items.empty()) continue; // blank line
-		if (items.size () < 6) {
-			edm::LogWarning("Format Error") << "Bad line: " << buffer << "\n line must contain 6 items: eta, phi, depth, subdet, firstSample, samplesToAdd" << std::endl;
-		    	continue;
-		}
-		DetId id = getId (items);
-	      
-		CastorRecoParam fCondObject(id, atoi (items [4].c_str()), atoi (items [5].c_str()) );
-		fObject.addValues(fCondObject);
-	}
-	return true;
-}
+  bool getObject(std::istream& fInput, CastorRecoParams& fObject) {
+    char buffer[1024];
+    while (fInput.getline(buffer, 1024)) {
+      if (buffer[0] == '#')
+        continue;  //ignore comment
+      std::vector<std::string> items = splitString(std::string(buffer));
+      if (items.empty())
+        continue;  // blank line
+      if (items.size() < 6) {
+        edm::LogWarning("Format Error")
+            << "Bad line: " << buffer
+            << "\n line must contain 6 items: eta, phi, depth, subdet, firstSample, samplesToAdd" << std::endl;
+        continue;
+      }
+      DetId id = getId(items);
 
-bool dumpObject (std::ostream& fOutput, const CastorRecoParams& fObject) {
-	char buffer [1024];
-	sprintf (buffer, "# %15s %15s %15s %15s %18s %15s %10s\n", "eta", "phi", "dep", "det", "firstSample", "samplesToAdd", "DetId");
-	fOutput << buffer;
-	std::vector<DetId> channels = fObject.getAllChannels ();
-	std::sort (channels.begin(), channels.end(), DetIdLess ());
-	for (std::vector<DetId>::iterator channel = channels.begin();channel != channels.end();++channel) {
-		dumpId (fOutput, *channel);
-		sprintf (buffer, " %15d %15d %16X\n",
-		fObject.getValues (*channel)->firstSample(), fObject.getValues (*channel)->samplesToAdd(), channel->rawId ());
-		fOutput << buffer;
-	}
-	return true;
-}
+      CastorRecoParam fCondObject(id, atoi(items[4].c_str()), atoi(items[5].c_str()));
+      fObject.addValues(fCondObject);
+    }
+    return true;
+  }
 
-}
+  bool dumpObject(std::ostream& fOutput, const CastorRecoParams& fObject) {
+    char buffer[1024];
+    sprintf(buffer,
+            "# %15s %15s %15s %15s %18s %15s %10s\n",
+            "eta",
+            "phi",
+            "dep",
+            "det",
+            "firstSample",
+            "samplesToAdd",
+            "DetId");
+    fOutput << buffer;
+    std::vector<DetId> channels = fObject.getAllChannels();
+    std::sort(channels.begin(), channels.end(), DetIdLess());
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+      dumpId(fOutput, *channel);
+      sprintf(buffer,
+              " %15d %15d %16X\n",
+              fObject.getValues(*channel)->firstSample(),
+              fObject.getValues(*channel)->samplesToAdd(),
+              channel->rawId());
+      fOutput << buffer;
+    }
+    return true;
+  }
+
+}  // namespace CastorDbASCIIIO

--- a/CalibCalorimetry/CastorCalib/src/CastorDbHardcode.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorDbHardcode.cc
@@ -9,24 +9,23 @@
 #include "CondFormats/CastorObjects/interface/CastorElectronicsMap.h"
 #include "CalibCalorimetry/CastorCalib/interface/CastorDbHardcode.h"
 
-
-CastorPedestal CastorDbHardcode::makePedestal (HcalGenericDetId fId, bool fSmear) {
-  CastorPedestalWidth width = makePedestalWidth (fId);
+CastorPedestal CastorDbHardcode::makePedestal(HcalGenericDetId fId, bool fSmear) {
+  CastorPedestalWidth width = makePedestalWidth(fId);
   float value0 = fId.genericSubdet() == HcalGenericDetId::HcalGenForward ? 11. : 4.;  // fC
-  float value [4] = {value0, value0, value0, value0};
+  float value[4] = {value0, value0, value0, value0};
   if (fSmear) {
     for (int i = 0; i < 4; i++) {
-      value [i] = CLHEP::RandGauss::shoot (value0, width.getWidth (i) / 100.); // ignore correlations, assume 10K pedestal run 
-      while (value [i] <= 0) value [i] = CLHEP::RandGauss::shoot (value0, width.getWidth (i));
+      value[i] =
+          CLHEP::RandGauss::shoot(value0, width.getWidth(i) / 100.);  // ignore correlations, assume 10K pedestal run
+      while (value[i] <= 0)
+        value[i] = CLHEP::RandGauss::shoot(value0, width.getWidth(i));
     }
   }
-  CastorPedestal result (fId.rawId (), 
-		       value[0], value[1], value[2], value[3]
-		       );
+  CastorPedestal result(fId.rawId(), value[0], value[1], value[2], value[3]);
   return result;
 }
 
-CastorPedestalWidth CastorDbHardcode::makePedestalWidth (HcalGenericDetId fId) {
+CastorPedestalWidth CastorDbHardcode::makePedestalWidth(HcalGenericDetId fId) {
   float value = 0;
   /*
   if (fId.genericSubdet() == HcalGenericDetId::HcalGenBarrel || 
@@ -35,69 +34,73 @@ CastorPedestalWidth CastorDbHardcode::makePedestalWidth (HcalGenericDetId fId) {
   else if (fId.genericSubdet() == HcalGenericDetId::HcalGenForward) value = 2.5;
   */
   // everything in fC
-  CastorPedestalWidth result (fId.rawId ());
+  CastorPedestalWidth result(fId.rawId());
   for (int i = 0; i < 4; i++) {
     double width = value;
     for (int j = 0; j < 4; j++) {
-      result.setSigma (i, j, i == j ? width * width : 0);
+      result.setSigma(i, j, i == j ? width * width : 0);
     }
-  } 
-  return result;
-}
-
-CastorGain CastorDbHardcode::makeGain (HcalGenericDetId fId, bool fSmear) {
-  CastorGainWidth width = makeGainWidth (fId);
-  float value0 = 0;
-  if (fId.genericSubdet() != HcalGenericDetId::HcalGenForward) value0 = 0.177;  // GeV/fC
-  else {
-    if (HcalDetId(fId).depth() == 1) value0 = 0.2146;
-    else if (HcalDetId(fId).depth() == 2) value0 = 0.3375;
   }
-  float value [4] = {value0, value0, value0, value0};
-  if (fSmear) for (int i = 0; i < 4; i++) value [i] = CLHEP::RandGauss::shoot (value0, width.getValue (i)); 
-  CastorGain result (fId.rawId (), value[0], value[1], value[2], value[3]);
   return result;
 }
 
-CastorGainWidth CastorDbHardcode::makeGainWidth (HcalGenericDetId fId) {
+CastorGain CastorDbHardcode::makeGain(HcalGenericDetId fId, bool fSmear) {
+  CastorGainWidth width = makeGainWidth(fId);
+  float value0 = 0;
+  if (fId.genericSubdet() != HcalGenericDetId::HcalGenForward)
+    value0 = 0.177;  // GeV/fC
+  else {
+    if (HcalDetId(fId).depth() == 1)
+      value0 = 0.2146;
+    else if (HcalDetId(fId).depth() == 2)
+      value0 = 0.3375;
+  }
+  float value[4] = {value0, value0, value0, value0};
+  if (fSmear)
+    for (int i = 0; i < 4; i++)
+      value[i] = CLHEP::RandGauss::shoot(value0, width.getValue(i));
+  CastorGain result(fId.rawId(), value[0], value[1], value[2], value[3]);
+  return result;
+}
+
+CastorGainWidth CastorDbHardcode::makeGainWidth(HcalGenericDetId fId) {
   float value = 0;
-  CastorGainWidth result (fId.rawId (), value, value, value, value);
+  CastorGainWidth result(fId.rawId(), value, value, value, value);
   return result;
 }
 
-CastorQIECoder CastorDbHardcode::makeQIECoder (HcalGenericDetId fId) {
-  CastorQIECoder result (fId.rawId ());
+CastorQIECoder CastorDbHardcode::makeQIECoder(HcalGenericDetId fId) {
+  CastorQIECoder result(fId.rawId());
   float offset = 0;
-  float slope = fId.genericSubdet () == HcalGenericDetId::HcalGenForward ? 0.36 : 0.92;  // ADC/fC
+  float slope = fId.genericSubdet() == HcalGenericDetId::HcalGenForward ? 0.36 : 0.92;  // ADC/fC
   for (unsigned range = 0; range < 4; range++) {
     for (unsigned capid = 0; capid < 4; capid++) {
-      result.setOffset (capid, range, offset);
-      result.setSlope (capid, range, slope);
+      result.setOffset(capid, range, offset);
+      result.setSlope(capid, range, slope);
     }
   }
   return result;
 }
 
-CastorCalibrationQIECoder CastorDbHardcode::makeCalibrationQIECoder (HcalGenericDetId fId) {
-  CastorCalibrationQIECoder result (fId.rawId ());
-  float lowEdges [32];
-  for (int i = 0; i < 32; i++) lowEdges[i] = -1.5 + i*0.35;
-  result.setMinCharges (lowEdges);
+CastorCalibrationQIECoder CastorDbHardcode::makeCalibrationQIECoder(HcalGenericDetId fId) {
+  CastorCalibrationQIECoder result(fId.rawId());
+  float lowEdges[32];
+  for (int i = 0; i < 32; i++)
+    lowEdges[i] = -1.5 + i * 0.35;
+  result.setMinCharges(lowEdges);
   return result;
 }
 
-CastorQIEShape CastorDbHardcode::makeQIEShape () {
-  return CastorQIEShape ();
+CastorQIEShape CastorDbHardcode::makeQIEShape() { return CastorQIEShape(); }
+
+CastorRecoParam CastorDbHardcode::makeRecoParam(HcalGenericDetId fId) {
+  CastorRecoParam result(fId.rawId(), 4, 2);
+  return result;
 }
 
-CastorRecoParam CastorDbHardcode::makeRecoParam (HcalGenericDetId fId) {
-	CastorRecoParam result(fId.rawId(), 4, 2);
-	return result;
-}
-
-CastorSaturationCorr CastorDbHardcode::makeSaturationCorr (HcalGenericDetId fId) {
-	CastorSaturationCorr result(fId.rawId(), 1);
-	return result;
+CastorSaturationCorr CastorDbHardcode::makeSaturationCorr(HcalGenericDetId fId) {
+  CastorSaturationCorr result(fId.rawId(), 1);
+  return result;
 }
 
 #define EMAP_NHBHECR 9
@@ -112,279 +115,288 @@ CastorSaturationCorr CastorDbHardcode::makeSaturationCorr (HcalGenericDetId fId)
 #define EMAP_NHSETSHO 3
 
 void CastorDbHardcode::makeHardcodeMap(CastorElectronicsMap& emap) {
-
   /* HBHE crate numbering */
-  int hbhecrate[EMAP_NHBHECR]={0,1,4,5,10,11,14,15,17};
+  int hbhecrate[EMAP_NHBHECR] = {0, 1, 4, 5, 10, 11, 14, 15, 17};
   /* HF crate numbering */
-  int hfcrate[EMAP_NHFCR]={2,9,12};
+  int hfcrate[EMAP_NHFCR] = {2, 9, 12};
   /* HO crate numbering */
-  int hocrate[EMAP_NHOCR]={3,7,6,13};
+  int hocrate[EMAP_NHOCR] = {3, 7, 6, 13};
   /* HBHE FED numbering of DCCs */
-  int fedhbhenum[EMAP_NHBHECR][2]={{702,703},{704,705},{700,701},
-				   {706,707},{716,717},{708,709},
-				   {714,715},{710,711},{712,713}};
+  int fedhbhenum[EMAP_NHBHECR][2] = {
+      {702, 703}, {704, 705}, {700, 701}, {706, 707}, {716, 717}, {708, 709}, {714, 715}, {710, 711}, {712, 713}};
   /* HF FED numbering of DCCs */
-  int fedhfnum[EMAP_NHFCR][2]={{718,719},{720,721},{722,723}};
+  int fedhfnum[EMAP_NHFCR][2] = {{718, 719}, {720, 721}, {722, 723}};
   /* HO FED numbering of DCCs */
-  int fedhonum[EMAP_NHOCR][2]={{724,725},{726,727},{728,729},{730,731}};
+  int fedhonum[EMAP_NHOCR][2] = {{724, 725}, {726, 727}, {728, 729}, {730, 731}};
   /* HBHE/HF htr slot offsets for set of three htrs */
-  int ihslot[EMAP_NHSETS]={2,5,13,16};
+  int ihslot[EMAP_NHSETS] = {2, 5, 13, 16};
   /* HO htr slot offsets for three sets of four htrs */
-  int ihslotho[EMAP_NHSETSHO][EMAP_NHTRSHO]={{2,3,4,5},{6,7,13,14},{15,16,17,18}};
+  int ihslotho[EMAP_NHSETSHO][EMAP_NHTRSHO] = {{2, 3, 4, 5}, {6, 7, 13, 14}, {15, 16, 17, 18}};
   /* iphi (lower) starting index for each HBHE crate */
-  int ihbhephis[EMAP_NHBHECR]={11,19,3,27,67,35,59,43,51};
+  int ihbhephis[EMAP_NHBHECR] = {11, 19, 3, 27, 67, 35, 59, 43, 51};
   /* iphi (lower) starting index for each HF crate */
-  int ihfphis[EMAP_NHFCR]={3,27,51};
+  int ihfphis[EMAP_NHFCR] = {3, 27, 51};
   /* iphi (lower) starting index for each HO crate */
-  int ihophis[EMAP_NHOCR]={71,17,35,53};
+  int ihophis[EMAP_NHOCR] = {71, 17, 35, 53};
   /* ihbheetadepth - unique HBHE {eta,depth} assignments per fiber and fiber channel */
-  int ihbheetadepth[EMAP_NHTRS][EMAP_NTOPBOT][EMAP_NFBR][EMAP_NFCH][2]={
-    {{{{11,1},{ 7,1},{ 3,1}},  /* htr 0 (HB) -bot(+top) */
-      {{ 5,1},{ 1,1},{ 9,1}},
-      {{11,1},{ 7,1},{ 3,1}},
-      {{ 5,1},{ 1,1},{ 9,1}},
-      {{10,1},{ 6,1},{ 2,1}},
-      {{ 8,1},{ 4,1},{12,1}},
-      {{10,1},{ 6,1},{ 2,1}},
-      {{ 8,1},{ 4,1},{12,1}}},
-     {{{11,1},{ 7,1},{ 3,1}},  /* htr 0 (HB) +bot(-top) */
-      {{ 5,1},{ 1,1},{ 9,1}},
-      {{11,1},{ 7,1},{ 3,1}},
-      {{ 5,1},{ 1,1},{ 9,1}},
-      {{10,1},{ 6,1},{ 2,1}},
-      {{ 8,1},{ 4,1},{12,1}},
-      {{10,1},{ 6,1},{ 2,1}},
-      {{ 8,1},{ 4,1},{12,1}}}},
-    {{{{16,2},{15,2},{14,1}},  /* htr 1 (HBHE) -bot(+top) */
-      {{15,1},{13,1},{16,1}},
-      {{16,2},{15,2},{14,1}},
-      {{15,1},{13,1},{16,1}},
-      {{17,1},{16,3},{26,1}},
-      {{18,1},{18,2},{26,2}},
-      {{17,1},{16,3},{25,1}},
-      {{18,1},{18,2},{25,2}}},
-     {{{16,2},{15,2},{14,1}},  /* htr 1 (HBHE) +bot(-top) */
-      {{15,1},{13,1},{16,1}},
-      {{16,2},{15,2},{14,1}},
-      {{15,1},{13,1},{16,1}},
-      {{17,1},{16,3},{25,1}},
-      {{18,1},{18,2},{25,2}},
-      {{17,1},{16,3},{26,1}},
-      {{18,1},{18,2},{26,2}}}},
-    {{{{28,1},{28,2},{29,1}},  /* htr 2 (HE) -bot(+top) */
-      {{28,3},{24,2},{24,1}},
-      {{27,1},{27,2},{29,2}},
-      {{27,3},{23,2},{23,1}},
-      {{19,2},{20,1},{22,2}},
-      {{19,1},{20,2},{22,1}},
-      {{19,2},{20,1},{21,2}},
-      {{19,1},{20,2},{21,1}}},
-     {{{27,1},{27,2},{29,2}},  /* htr 2 (HE) +bot(-top) */
-      {{27,3},{23,2},{23,1}},
-      {{28,1},{28,2},{29,1}},
-      {{28,3},{24,2},{24,1}},
-      {{19,2},{20,1},{21,2}},
-      {{19,1},{20,2},{21,1}},
-      {{19,2},{20,1},{22,2}},
-      {{19,1},{20,2},{22,1}}}}
-  };
+  int ihbheetadepth[EMAP_NHTRS][EMAP_NTOPBOT][EMAP_NFBR][EMAP_NFCH][2] = {
+      {{{{11, 1}, {7, 1}, {3, 1}}, /* htr 0 (HB) -bot(+top) */
+        {{5, 1}, {1, 1}, {9, 1}},
+        {{11, 1}, {7, 1}, {3, 1}},
+        {{5, 1}, {1, 1}, {9, 1}},
+        {{10, 1}, {6, 1}, {2, 1}},
+        {{8, 1}, {4, 1}, {12, 1}},
+        {{10, 1}, {6, 1}, {2, 1}},
+        {{8, 1}, {4, 1}, {12, 1}}},
+       {{{11, 1}, {7, 1}, {3, 1}}, /* htr 0 (HB) +bot(-top) */
+        {{5, 1}, {1, 1}, {9, 1}},
+        {{11, 1}, {7, 1}, {3, 1}},
+        {{5, 1}, {1, 1}, {9, 1}},
+        {{10, 1}, {6, 1}, {2, 1}},
+        {{8, 1}, {4, 1}, {12, 1}},
+        {{10, 1}, {6, 1}, {2, 1}},
+        {{8, 1}, {4, 1}, {12, 1}}}},
+      {{{{16, 2}, {15, 2}, {14, 1}}, /* htr 1 (HBHE) -bot(+top) */
+        {{15, 1}, {13, 1}, {16, 1}},
+        {{16, 2}, {15, 2}, {14, 1}},
+        {{15, 1}, {13, 1}, {16, 1}},
+        {{17, 1}, {16, 3}, {26, 1}},
+        {{18, 1}, {18, 2}, {26, 2}},
+        {{17, 1}, {16, 3}, {25, 1}},
+        {{18, 1}, {18, 2}, {25, 2}}},
+       {{{16, 2}, {15, 2}, {14, 1}}, /* htr 1 (HBHE) +bot(-top) */
+        {{15, 1}, {13, 1}, {16, 1}},
+        {{16, 2}, {15, 2}, {14, 1}},
+        {{15, 1}, {13, 1}, {16, 1}},
+        {{17, 1}, {16, 3}, {25, 1}},
+        {{18, 1}, {18, 2}, {25, 2}},
+        {{17, 1}, {16, 3}, {26, 1}},
+        {{18, 1}, {18, 2}, {26, 2}}}},
+      {{{{28, 1}, {28, 2}, {29, 1}}, /* htr 2 (HE) -bot(+top) */
+        {{28, 3}, {24, 2}, {24, 1}},
+        {{27, 1}, {27, 2}, {29, 2}},
+        {{27, 3}, {23, 2}, {23, 1}},
+        {{19, 2}, {20, 1}, {22, 2}},
+        {{19, 1}, {20, 2}, {22, 1}},
+        {{19, 2}, {20, 1}, {21, 2}},
+        {{19, 1}, {20, 2}, {21, 1}}},
+       {{{27, 1}, {27, 2}, {29, 2}}, /* htr 2 (HE) +bot(-top) */
+        {{27, 3}, {23, 2}, {23, 1}},
+        {{28, 1}, {28, 2}, {29, 1}},
+        {{28, 3}, {24, 2}, {24, 1}},
+        {{19, 2}, {20, 1}, {21, 2}},
+        {{19, 1}, {20, 2}, {21, 1}},
+        {{19, 2}, {20, 1}, {22, 2}},
+        {{19, 1}, {20, 2}, {22, 1}}}}};
   /* ihfetadepth - unique HF {eta,depth} assignments per fiber and fiber channel */
-  int ihfetadepth[EMAP_NTOPBOT][EMAP_NFBR][EMAP_NFCH][2]={
-    {{{33,1},{31,1},{29,1}},  /* top */
-     {{32,1},{30,1},{34,1}},
-     {{33,2},{31,2},{29,2}},
-     {{32,2},{30,2},{34,2}},
-     {{34,2},{32,2},{30,2}},
-     {{31,2},{29,2},{33,2}},
-     {{34,1},{32,1},{30,1}},
-     {{31,1},{29,1},{33,1}}},
-    {{{41,1},{37,1},{35,1}},  /* bot */
-     {{38,1},{36,1},{39,1}},
-     {{41,2},{37,2},{35,2}},
-     {{38,2},{36,2},{39,2}},
-     {{40,2},{38,2},{36,2}},
-     {{37,2},{35,2},{39,2}},
-     {{40,1},{38,1},{36,1}},
-     {{37,1},{35,1},{39,1}}}
-  };
+  int ihfetadepth[EMAP_NTOPBOT][EMAP_NFBR][EMAP_NFCH][2] = {{{{33, 1}, {31, 1}, {29, 1}}, /* top */
+                                                             {{32, 1}, {30, 1}, {34, 1}},
+                                                             {{33, 2}, {31, 2}, {29, 2}},
+                                                             {{32, 2}, {30, 2}, {34, 2}},
+                                                             {{34, 2}, {32, 2}, {30, 2}},
+                                                             {{31, 2}, {29, 2}, {33, 2}},
+                                                             {{34, 1}, {32, 1}, {30, 1}},
+                                                             {{31, 1}, {29, 1}, {33, 1}}},
+                                                            {{{41, 1}, {37, 1}, {35, 1}}, /* bot */
+                                                             {{38, 1}, {36, 1}, {39, 1}},
+                                                             {{41, 2}, {37, 2}, {35, 2}},
+                                                             {{38, 2}, {36, 2}, {39, 2}},
+                                                             {{40, 2}, {38, 2}, {36, 2}},
+                                                             {{37, 2}, {35, 2}, {39, 2}},
+                                                             {{40, 1}, {38, 1}, {36, 1}},
+                                                             {{37, 1}, {35, 1}, {39, 1}}}};
   /* ihoetasidephi - unique HO {eta,side,phi} assignments per fiber and fiber channel */
-  int ihoetasidephi[EMAP_NHTRSHO][EMAP_NTOPBOT][EMAP_NFBR][EMAP_NFCH][3]={
-    {{{{ 1,-1,0},{ 2,-1,0},{ 3,-1,0}},  /* htr 0 (HO) top */
-      {{ 1,-1,1},{ 2,-1,1},{ 3,-1,1}},
-      {{ 1,-1,2},{ 2,-1,2},{ 3,-1,2}},
-      {{ 1,-1,3},{ 2,-1,3},{ 3,-1,3}},
-      {{ 1,-1,4},{ 2,-1,4},{ 3,-1,4}},
-      {{ 1,-1,5},{ 2,-1,5},{ 3,-1,5}},
-      {{14, 1,0},{14, 1,1},{14, 1,2}},
-      {{14, 1,3},{14, 1,4},{14, 1,5}}},
-     {{{ 1, 1,0},{ 2, 1,0},{ 3, 1,0}},  /* htr 0 (HO) bot */
-      {{ 1, 1,1},{ 2, 1,1},{ 3, 1,1}},
-      {{ 1, 1,2},{ 2, 1,2},{ 3, 1,2}},
-      {{ 1, 1,3},{ 2, 1,3},{ 3, 1,3}},
-      {{ 1, 1,4},{ 2, 1,4},{ 3, 1,4}},
-      {{ 1, 1,5},{ 2, 1,5},{ 3, 1,5}},
-      {{15, 1,0},{15, 1,1},{15, 1,2}},
-      {{15, 1,3},{15, 1,4},{15, 1,5}}}},
-    {{{{ 6, 1,0},{ 6, 1,1},{ 6, 1,2}},  /* htr 1 (HO) top */
-      {{ 6, 1,3},{ 6, 1,4},{ 6, 1,5}},
-      {{ 7, 1,0},{ 7, 1,1},{ 7, 1,2}},
-      {{ 7, 1,3},{ 7, 1,4},{ 7, 1,5}},
-      {{ 8, 1,0},{ 8, 1,1},{ 8, 1,2}},
-      {{ 8, 1,3},{ 8, 1,4},{ 8, 1,5}},
-      {{ 9, 1,0},{ 9, 1,1},{ 9, 1,2}},
-      {{ 9, 1,3},{ 9, 1,4},{ 9, 1,5}}},
-     {{{10, 1,0},{10, 1,1},{10, 1,2}},  /* htr 1 (HO) bot */
-      {{10, 1,3},{10, 1,4},{10, 1,5}},
-      {{11, 1,0},{11, 1,1},{11, 1,2}},
-      {{11, 1,3},{11, 1,4},{11, 1,5}},
-      {{12, 1,0},{12, 1,1},{12, 1,2}},
-      {{12, 1,3},{12, 1,4},{12, 1,5}},
-      {{13, 1,0},{13, 1,1},{13, 1,2}},
-      {{13, 1,3},{13, 1,4},{13, 1,5}}}},
-    {{{{ 4,-1,0},{ 4,-1,1},{ 0, 0,0}},  /* htr 2 (HO) top */
-      {{ 4,-1,2},{ 4,-1,3},{ 0, 0,0}},
-      {{ 4,-1,4},{ 4,-1,5},{ 0, 0,0}},
-      {{ 0, 0,0},{ 0, 0,0},{ 0, 0,0}},
-      {{ 5,-1,0},{ 5,-1,1},{ 5,-1,2}},
-      {{ 5,-1,3},{ 5,-1,4},{ 5,-1,5}},
-      {{14,-1,0},{14,-1,1},{14,-1,2}},
-      {{14,-1,3},{14,-1,4},{14,-1,5}}},
-     {{{ 4, 1,0},{ 4, 1,1},{ 0, 0,0}},  /* htr 2 (HO) bot */
-      {{ 4, 1,2},{ 4, 1,3},{ 0, 0,0}},
-      {{ 4, 1,4},{ 4, 1,5},{ 0, 0,0}},
-      {{ 0, 0,0},{ 0, 0,0},{ 0, 0,0}},
-      {{ 5, 1,0},{ 5, 1,1},{ 5, 1,2}},
-      {{ 5, 1,3},{ 5, 1,4},{ 5, 1,5}},
-      {{15,-1,0},{15,-1,1},{15,-1,2}},
-      {{15,-1,3},{15,-1,4},{15,-1,5}}}},
-    {{{{ 6,-1,0},{ 6,-1,1},{ 6,-1,2}},  /* htr 3 (HO) top */
-      {{ 6,-1,3},{ 6,-1,4},{ 6,-1,5}},
-      {{ 7,-1,0},{ 7,-1,1},{ 7,-1,2}},
-      {{ 7,-1,3},{ 7,-1,4},{ 7,-1,5}},
-      {{ 8,-1,0},{ 8,-1,1},{ 8,-1,2}},
-      {{ 8,-1,3},{ 8,-1,4},{ 8,-1,5}},
-      {{ 9,-1,0},{ 9,-1,1},{ 9,-1,2}},
-      {{ 9,-1,3},{ 9,-1,4},{ 9,-1,5}}},
-     {{{10,-1,0},{10,-1,1},{10,-1,2}},  /* htr 3 (HO) bot */
-      {{10,-1,3},{10,-1,4},{10,-1,5}},
-      {{11,-1,0},{11,-1,1},{11,-1,2}},
-      {{11,-1,3},{11,-1,4},{11,-1,5}},
-      {{12,-1,0},{12,-1,1},{12,-1,2}},
-      {{12,-1,3},{12,-1,4},{12,-1,5}},
-      {{13,-1,0},{13,-1,1},{13,-1,2}},
-      {{13,-1,3},{13,-1,4},{13,-1,5}}}} 
-  };
-  int ic,is,ih,itb,ifb,ifc,ifwtb,iphi_loc;
-  int iside,ieta,iphi,idepth,icrate,ihtr,ihtr_fi,ifi_ch,ispigot,idcc,/*idcc_sl,*/ifed;
+  int ihoetasidephi[EMAP_NHTRSHO][EMAP_NTOPBOT][EMAP_NFBR][EMAP_NFCH][3] = {
+      {{{{1, -1, 0}, {2, -1, 0}, {3, -1, 0}}, /* htr 0 (HO) top */
+        {{1, -1, 1}, {2, -1, 1}, {3, -1, 1}},
+        {{1, -1, 2}, {2, -1, 2}, {3, -1, 2}},
+        {{1, -1, 3}, {2, -1, 3}, {3, -1, 3}},
+        {{1, -1, 4}, {2, -1, 4}, {3, -1, 4}},
+        {{1, -1, 5}, {2, -1, 5}, {3, -1, 5}},
+        {{14, 1, 0}, {14, 1, 1}, {14, 1, 2}},
+        {{14, 1, 3}, {14, 1, 4}, {14, 1, 5}}},
+       {{{1, 1, 0}, {2, 1, 0}, {3, 1, 0}}, /* htr 0 (HO) bot */
+        {{1, 1, 1}, {2, 1, 1}, {3, 1, 1}},
+        {{1, 1, 2}, {2, 1, 2}, {3, 1, 2}},
+        {{1, 1, 3}, {2, 1, 3}, {3, 1, 3}},
+        {{1, 1, 4}, {2, 1, 4}, {3, 1, 4}},
+        {{1, 1, 5}, {2, 1, 5}, {3, 1, 5}},
+        {{15, 1, 0}, {15, 1, 1}, {15, 1, 2}},
+        {{15, 1, 3}, {15, 1, 4}, {15, 1, 5}}}},
+      {{{{6, 1, 0}, {6, 1, 1}, {6, 1, 2}}, /* htr 1 (HO) top */
+        {{6, 1, 3}, {6, 1, 4}, {6, 1, 5}},
+        {{7, 1, 0}, {7, 1, 1}, {7, 1, 2}},
+        {{7, 1, 3}, {7, 1, 4}, {7, 1, 5}},
+        {{8, 1, 0}, {8, 1, 1}, {8, 1, 2}},
+        {{8, 1, 3}, {8, 1, 4}, {8, 1, 5}},
+        {{9, 1, 0}, {9, 1, 1}, {9, 1, 2}},
+        {{9, 1, 3}, {9, 1, 4}, {9, 1, 5}}},
+       {{{10, 1, 0}, {10, 1, 1}, {10, 1, 2}}, /* htr 1 (HO) bot */
+        {{10, 1, 3}, {10, 1, 4}, {10, 1, 5}},
+        {{11, 1, 0}, {11, 1, 1}, {11, 1, 2}},
+        {{11, 1, 3}, {11, 1, 4}, {11, 1, 5}},
+        {{12, 1, 0}, {12, 1, 1}, {12, 1, 2}},
+        {{12, 1, 3}, {12, 1, 4}, {12, 1, 5}},
+        {{13, 1, 0}, {13, 1, 1}, {13, 1, 2}},
+        {{13, 1, 3}, {13, 1, 4}, {13, 1, 5}}}},
+      {{{{4, -1, 0}, {4, -1, 1}, {0, 0, 0}}, /* htr 2 (HO) top */
+        {{4, -1, 2}, {4, -1, 3}, {0, 0, 0}},
+        {{4, -1, 4}, {4, -1, 5}, {0, 0, 0}},
+        {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+        {{5, -1, 0}, {5, -1, 1}, {5, -1, 2}},
+        {{5, -1, 3}, {5, -1, 4}, {5, -1, 5}},
+        {{14, -1, 0}, {14, -1, 1}, {14, -1, 2}},
+        {{14, -1, 3}, {14, -1, 4}, {14, -1, 5}}},
+       {{{4, 1, 0}, {4, 1, 1}, {0, 0, 0}}, /* htr 2 (HO) bot */
+        {{4, 1, 2}, {4, 1, 3}, {0, 0, 0}},
+        {{4, 1, 4}, {4, 1, 5}, {0, 0, 0}},
+        {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+        {{5, 1, 0}, {5, 1, 1}, {5, 1, 2}},
+        {{5, 1, 3}, {5, 1, 4}, {5, 1, 5}},
+        {{15, -1, 0}, {15, -1, 1}, {15, -1, 2}},
+        {{15, -1, 3}, {15, -1, 4}, {15, -1, 5}}}},
+      {{{{6, -1, 0}, {6, -1, 1}, {6, -1, 2}}, /* htr 3 (HO) top */
+        {{6, -1, 3}, {6, -1, 4}, {6, -1, 5}},
+        {{7, -1, 0}, {7, -1, 1}, {7, -1, 2}},
+        {{7, -1, 3}, {7, -1, 4}, {7, -1, 5}},
+        {{8, -1, 0}, {8, -1, 1}, {8, -1, 2}},
+        {{8, -1, 3}, {8, -1, 4}, {8, -1, 5}},
+        {{9, -1, 0}, {9, -1, 1}, {9, -1, 2}},
+        {{9, -1, 3}, {9, -1, 4}, {9, -1, 5}}},
+       {{{10, -1, 0}, {10, -1, 1}, {10, -1, 2}}, /* htr 3 (HO) bot */
+        {{10, -1, 3}, {10, -1, 4}, {10, -1, 5}},
+        {{11, -1, 0}, {11, -1, 1}, {11, -1, 2}},
+        {{11, -1, 3}, {11, -1, 4}, {11, -1, 5}},
+        {{12, -1, 0}, {12, -1, 1}, {12, -1, 2}},
+        {{12, -1, 3}, {12, -1, 4}, {12, -1, 5}},
+        {{13, -1, 0}, {13, -1, 1}, {13, -1, 2}},
+        {{13, -1, 3}, {13, -1, 4}, {13, -1, 5}}}}};
+  int ic, is, ih, itb, ifb, ifc, ifwtb, iphi_loc;
+  int iside, ieta, iphi, idepth, icrate, ihtr, ihtr_fi, ifi_ch, ispigot, idcc, /*idcc_sl,*/ ifed;
   std::string det;
   std::string fpga;
   // printf("      side       eta       phi     depth       det     crate       htr      fpga    htr_fi     fi_ch     spigo       dcc    dcc_sl     fedid\n");
   /* all HBHE crates */
-  for(ic=0; ic<EMAP_NHBHECR; ic++){
+  for (ic = 0; ic < EMAP_NHBHECR; ic++) {
     /* four sets of three htrs per crate */
-    for(is=0; is<EMAP_NHSETS; is++){
+    for (is = 0; is < EMAP_NHSETS; is++) {
       /* three htrs per set */
-      for(ih=0; ih<EMAP_NHTRS; ih++){
-	/* top and bottom */
-	for(itb=0; itb<EMAP_NTOPBOT; itb++){
-	  /* eight fibers per HTR FPGA */
-	  for(ifb=0; ifb<EMAP_NFBR; ifb++){
-	    /* three channels per fiber */
-	    for(ifc=0; ifc<EMAP_NFCH; ifc++){
-	      icrate=hbhecrate[ic];
-	      iside=is<EMAP_NHSETS/2?-1:1;
-	      ifwtb=(is/2+itb+1)%2;
-	      ieta=ihbheetadepth[ih][ifwtb][ifb][ifc][0];
-	      idepth=ihbheetadepth[ih][ifwtb][ifb][ifc][1];
-	      ihtr=ihslot[is]+ih;
-	      det=((ieta>16||idepth>2)?("HE"):("HB"));
-	      fpga=((itb%2)==1)?("bot"):("top");
-	      ihtr_fi=ifb+1;
-	      ifi_ch=ifc;
-	      iphi=(ieta>20)?(ihbhephis[ic]+(is%2)*4+itb*2-1)%72+1:(ihbhephis[ic]+(is%2)*4+itb*2+(ifb/2+is/2+1)%2-1)%72+1;
-	      ispigot=(is%2)*6+ih*2+itb;
-	      idcc=is<EMAP_NHSETS/2?1:2;
-	      //idcc_sl=idcc==1?9:19;
-	      ifed=fedhbhenum[ic][idcc-1];
-	      /// load map
-	      CastorElectronicsId elId(ifi_ch, ihtr_fi, ispigot, ifed-700);
-	      elId.setHTR(icrate, ihtr, (fpga=="top")?(1):(0));
-	      HcalDetId hId((det=="HB")?(HcalBarrel):(HcalEndcap),ieta*iside,iphi,idepth);
-	      emap.mapEId2chId(elId,hId);
-	      
-	      //	      printf(" %9d %9d %9d %9d %9s %9d %9d %9s %9d %9d %9d %9d %9d %9d\n",iside,ieta,iphi,idepth,&det,icrate,ihtr,&fpga,ihtr_fi,ifi_ch,ispigot,idcc,idcc_sl,ifed);
-	    }}}}}}
+      for (ih = 0; ih < EMAP_NHTRS; ih++) {
+        /* top and bottom */
+        for (itb = 0; itb < EMAP_NTOPBOT; itb++) {
+          /* eight fibers per HTR FPGA */
+          for (ifb = 0; ifb < EMAP_NFBR; ifb++) {
+            /* three channels per fiber */
+            for (ifc = 0; ifc < EMAP_NFCH; ifc++) {
+              icrate = hbhecrate[ic];
+              iside = is < EMAP_NHSETS / 2 ? -1 : 1;
+              ifwtb = (is / 2 + itb + 1) % 2;
+              ieta = ihbheetadepth[ih][ifwtb][ifb][ifc][0];
+              idepth = ihbheetadepth[ih][ifwtb][ifb][ifc][1];
+              ihtr = ihslot[is] + ih;
+              det = ((ieta > 16 || idepth > 2) ? ("HE") : ("HB"));
+              fpga = ((itb % 2) == 1) ? ("bot") : ("top");
+              ihtr_fi = ifb + 1;
+              ifi_ch = ifc;
+              iphi = (ieta > 20) ? (ihbhephis[ic] + (is % 2) * 4 + itb * 2 - 1) % 72 + 1
+                                 : (ihbhephis[ic] + (is % 2) * 4 + itb * 2 + (ifb / 2 + is / 2 + 1) % 2 - 1) % 72 + 1;
+              ispigot = (is % 2) * 6 + ih * 2 + itb;
+              idcc = is < EMAP_NHSETS / 2 ? 1 : 2;
+              //idcc_sl=idcc==1?9:19;
+              ifed = fedhbhenum[ic][idcc - 1];
+              /// load map
+              CastorElectronicsId elId(ifi_ch, ihtr_fi, ispigot, ifed - 700);
+              elId.setHTR(icrate, ihtr, (fpga == "top") ? (1) : (0));
+              HcalDetId hId((det == "HB") ? (HcalBarrel) : (HcalEndcap), ieta * iside, iphi, idepth);
+              emap.mapEId2chId(elId, hId);
+
+              //	      printf(" %9d %9d %9d %9d %9s %9d %9d %9s %9d %9d %9d %9d %9d %9d\n",iside,ieta,iphi,idepth,&det,icrate,ihtr,&fpga,ihtr_fi,ifi_ch,ispigot,idcc,idcc_sl,ifed);
+            }
+          }
+        }
+      }
+    }
+  }
   /* all HF crates */
-  for(ic=0; ic<EMAP_NHFCR; ic++){
+  for (ic = 0; ic < EMAP_NHFCR; ic++) {
     /* four sets of three htrs per crate */
-    for(is=0; is<EMAP_NHSETS; is++){
+    for (is = 0; is < EMAP_NHSETS; is++) {
       /* three htrs per set */
-      for(ih=0; ih<EMAP_NHTRS; ih++){
-	/* top and bottom */
-	for(itb=0; itb<EMAP_NTOPBOT; itb++){
-	  /* eight fibers per HTR FPGA */
-	  for(ifb=0; ifb<EMAP_NFBR; ifb++){
-	    /* three channels per fiber */
-	    for(ifc=0; ifc<EMAP_NFCH; ifc++){
-	      icrate=hfcrate[ic];
-	      iside=is<EMAP_NHSETS/2?-1:1;
-	      ieta=ihfetadepth[itb][ifb][ifc][0];
-	      idepth=ihfetadepth[itb][ifb][ifc][1];
-	      ihtr=ihslot[is]+ih;
-	      det="HF";
-	      fpga=((itb%2)==1)?("bot"):("top");
-	      ihtr_fi=ifb+1;
-	      ifi_ch=ifc;
-	      iphi=(ieta>39)?(ihfphis[ic]+(is%2)*12+ih*4-3)%72+1:(ihfphis[ic]+(is%2)*12+ih*4+(ifb/4)*2-1)%72+1;
-	      ispigot=(is%2)*6+ih*2+itb;
-	      idcc=is<EMAP_NHSETS/2?1:2;
-	      //idcc_sl=idcc==1?9:19;
-	      ifed=fedhfnum[ic][idcc-1];
-	      CastorElectronicsId elId(ifi_ch, ihtr_fi, ispigot, ifed-700);
-	      elId.setHTR(icrate, ihtr, (fpga=="top")?(1):(0));
-	      HcalDetId hId(HcalForward,ieta*iside,iphi,idepth);
-	      emap.mapEId2chId(elId,hId);
-	      // printf(" %9d %9d %9d %9d %9s %9d %9d %9s %9d %9d %9d %9d %9d %9d\n",iside,ieta,iphi,idepth,&det,icrate,ihtr,&fpga,ihtr_fi,ifi_ch,ispigot,idcc,idcc_sl,ifed);
-	    }}}}}}
+      for (ih = 0; ih < EMAP_NHTRS; ih++) {
+        /* top and bottom */
+        for (itb = 0; itb < EMAP_NTOPBOT; itb++) {
+          /* eight fibers per HTR FPGA */
+          for (ifb = 0; ifb < EMAP_NFBR; ifb++) {
+            /* three channels per fiber */
+            for (ifc = 0; ifc < EMAP_NFCH; ifc++) {
+              icrate = hfcrate[ic];
+              iside = is < EMAP_NHSETS / 2 ? -1 : 1;
+              ieta = ihfetadepth[itb][ifb][ifc][0];
+              idepth = ihfetadepth[itb][ifb][ifc][1];
+              ihtr = ihslot[is] + ih;
+              det = "HF";
+              fpga = ((itb % 2) == 1) ? ("bot") : ("top");
+              ihtr_fi = ifb + 1;
+              ifi_ch = ifc;
+              iphi = (ieta > 39) ? (ihfphis[ic] + (is % 2) * 12 + ih * 4 - 3) % 72 + 1
+                                 : (ihfphis[ic] + (is % 2) * 12 + ih * 4 + (ifb / 4) * 2 - 1) % 72 + 1;
+              ispigot = (is % 2) * 6 + ih * 2 + itb;
+              idcc = is < EMAP_NHSETS / 2 ? 1 : 2;
+              //idcc_sl=idcc==1?9:19;
+              ifed = fedhfnum[ic][idcc - 1];
+              CastorElectronicsId elId(ifi_ch, ihtr_fi, ispigot, ifed - 700);
+              elId.setHTR(icrate, ihtr, (fpga == "top") ? (1) : (0));
+              HcalDetId hId(HcalForward, ieta * iside, iphi, idepth);
+              emap.mapEId2chId(elId, hId);
+              // printf(" %9d %9d %9d %9d %9s %9d %9d %9s %9d %9d %9d %9d %9d %9d\n",iside,ieta,iphi,idepth,&det,icrate,ihtr,&fpga,ihtr_fi,ifi_ch,ispigot,idcc,idcc_sl,ifed);
+            }
+          }
+        }
+      }
+    }
+  }
   /* all HO crates */
-  for(ic=0; ic<EMAP_NHOCR; ic++){
+  for (ic = 0; ic < EMAP_NHOCR; ic++) {
     /* three sets of four htrs per crate */
-    for(is=0; is<EMAP_NHSETSHO; is++){
+    for (is = 0; is < EMAP_NHSETSHO; is++) {
       /* four htrs per set */
-      for(ih=0; ih<EMAP_NHTRSHO; ih++){
-	/* top and bottom */
-	for(itb=0; itb<EMAP_NTOPBOT; itb++){
-	  /* eight fibers per HTR FPGA */
-	  for(ifb=0; ifb<EMAP_NFBR; ifb++){
-	    /* three channels per fiber */
-	    for(ifc=0; ifc<EMAP_NFCH; ifc++){
-	      icrate=hocrate[ic];
-	      idepth=1;
-	      ieta=ihoetasidephi[ih][itb][ifb][ifc][0];
-	      iside=ihoetasidephi[ih][itb][ifb][ifc][1];
-	      iphi_loc=ihoetasidephi[ih][itb][ifb][ifc][2];
-	      ihtr=ihslotho[is][ih];
-	      det="HO";
-	      fpga=((itb%2)==1)?("bot"):("top");
-	      ihtr_fi=ifb+1;
-	      ifi_ch=ifc;
-	      iphi=(ihophis[ic]+is*6+iphi_loc-1)%72+1;
-	      ispigot=ihtr<9?(ihtr-2)*2+itb:(ihtr-13)*2+itb;
-	      idcc=ihtr<9?1:2;
-	      //idcc_sl=idcc==1?9:19;
-	      ifed=fedhonum[ic][idcc-1];
-	      CastorElectronicsId elId(ifi_ch, ihtr_fi, ispigot, ifed-700);
-	      elId.setHTR(icrate, ihtr, (fpga=="top")?(1):(0));
-	      if (ieta==0) { // unmapped 
-		emap.mapEId2chId(elId,DetId(HcalDetId::Undefined));
-	      } else {
-		HcalDetId hId(HcalOuter,ieta*iside,iphi,4); // HO is officially "depth=4"
-		emap.mapEId2chId(elId,hId);
-	      }
-	      // printf(" %9d %9d %9d %9d %9s %9d %9d %9s %9d %9d %9d %9d %9d %9d\n",iside,ieta,iphi,idepth,&det,icrate,ihtr,&fpga,ihtr_fi,ifi_ch,ispigot,idcc,idcc_sl,ifed);
-	    }}}}}}
-  
+      for (ih = 0; ih < EMAP_NHTRSHO; ih++) {
+        /* top and bottom */
+        for (itb = 0; itb < EMAP_NTOPBOT; itb++) {
+          /* eight fibers per HTR FPGA */
+          for (ifb = 0; ifb < EMAP_NFBR; ifb++) {
+            /* three channels per fiber */
+            for (ifc = 0; ifc < EMAP_NFCH; ifc++) {
+              icrate = hocrate[ic];
+              idepth = 1;
+              ieta = ihoetasidephi[ih][itb][ifb][ifc][0];
+              iside = ihoetasidephi[ih][itb][ifb][ifc][1];
+              iphi_loc = ihoetasidephi[ih][itb][ifb][ifc][2];
+              ihtr = ihslotho[is][ih];
+              det = "HO";
+              fpga = ((itb % 2) == 1) ? ("bot") : ("top");
+              ihtr_fi = ifb + 1;
+              ifi_ch = ifc;
+              iphi = (ihophis[ic] + is * 6 + iphi_loc - 1) % 72 + 1;
+              ispigot = ihtr < 9 ? (ihtr - 2) * 2 + itb : (ihtr - 13) * 2 + itb;
+              idcc = ihtr < 9 ? 1 : 2;
+              //idcc_sl=idcc==1?9:19;
+              ifed = fedhonum[ic][idcc - 1];
+              CastorElectronicsId elId(ifi_ch, ihtr_fi, ispigot, ifed - 700);
+              elId.setHTR(icrate, ihtr, (fpga == "top") ? (1) : (0));
+              if (ieta == 0) {  // unmapped
+                emap.mapEId2chId(elId, DetId(HcalDetId::Undefined));
+              } else {
+                HcalDetId hId(HcalOuter, ieta * iside, iphi, 4);  // HO is officially "depth=4"
+                emap.mapEId2chId(elId, hId);
+              }
+              // printf(" %9d %9d %9d %9d %9s %9d %9d %9s %9d %9d %9d %9d %9d %9d\n",iside,ieta,iphi,idepth,&det,icrate,ihtr,&fpga,ihtr_fi,ifi_ch,ispigot,idcc,idcc_sl,ifed);
+            }
+          }
+        }
+      }
+    }
+  }
 
   emap.sort();
-
 }

--- a/CalibCalorimetry/CastorCalib/src/CastorDbXml.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorDbXml.cc
@@ -4,124 +4,129 @@
 #include <vector>
 #include <string>
 
-
 #include "CalibFormats/CastorObjects/interface/CastorText2DetIdConverter.h"
 
 #include "CondFormats/CastorObjects/interface/AllObjects.h"
 #include "CalibCalorimetry/CastorCalib/interface/CastorDbXml.h"
 
 namespace {
-  void dumpProlog (std::ostream& fOutput) {
+  void dumpProlog(std::ostream& fOutput) {
     fOutput << "<?xml version='1.0' encoding='UTF-8'?>" << std::endl;
     fOutput << "<!DOCTYPE root []>" << std::endl;
     fOutput << "<ROOT>" << std::endl;
   }
 
-  void dumpRun (std::ostream& fOutput, unsigned fRun) {
-    fOutput << "<RUN>"<< std::endl;
-    fOutput << "   <RUN_TYPE>" << "CastorDbXml" << "</RUN_TYPE>"<< std::endl;
-    fOutput << "   <RUN_NUMBER>" << fRun << "</RUN_NUMBER>"<< std::endl;
+  void dumpRun(std::ostream& fOutput, unsigned fRun) {
+    fOutput << "<RUN>" << std::endl;
+    fOutput << "   <RUN_TYPE>"
+            << "CastorDbXml"
+            << "</RUN_TYPE>" << std::endl;
+    fOutput << "   <RUN_NUMBER>" << fRun << "</RUN_NUMBER>" << std::endl;
     fOutput << "</RUN>" << std::endl;
   }
 
-  void dumpHeader (std::ostream& fOutput, unsigned fRun, const std::string& fTableName, const std::string& fTypeName) {
+  void dumpHeader(std::ostream& fOutput, unsigned fRun, const std::string& fTableName, const std::string& fTypeName) {
     fOutput << "  <HEADER>" << std::endl;
     fOutput << "    <TYPE>" << std::endl;
     fOutput << "      <EXTENSION_TABLE_NAME>" << fTableName << "</EXTENSION_TABLE_NAME>" << std::endl;
     fOutput << "      <NAME>" << fTypeName << "</NAME>" << std::endl;
     fOutput << "    </TYPE>" << std::endl;
-    dumpRun (fOutput, fRun);
+    dumpRun(fOutput, fRun);
     fOutput << "  </HEADER>" << std::endl;
   }
 
-  void dumpFooter (std::ostream& fOutput) {
-    fOutput << "</ROOT>" << std::endl;
-  }
+  void dumpFooter(std::ostream& fOutput) { fOutput << "</ROOT>" << std::endl; }
 
-  void dumpChannelId (std::ostream& fOutput, DetId fChannel) {
-    CastorText2DetIdConverter converter (fChannel);
-    fOutput << "<CHANNEL> "<< std::endl;
-    fOutput << "   <EXTENSION_TABLE_NAME>HCAL_CHANNELS</EXTENSION_TABLE_NAME> "<< std::endl;
-    fOutput << "   <ETA>" << abs (converter.getField (1)) << "</ETA>"<< std::endl;
-    fOutput << "   <PHI>" << converter.getField (2) << "</PHI> "<< std::endl;
-    fOutput << "   <DEPTH>" << converter.getField (3) << "</DEPTH> "<< std::endl;
-    fOutput << "   <Z>" << (converter.getField (1) > 0 ? "1" : "-1") << "</Z> "<< std::endl;
-    fOutput << "   <DETECTOR_NAME>" << converter.getFlavor () << "</DETECTOR_NAME> "<< std::endl;
-    fOutput << "   <HCAL_CHANNEL_ID>" << converter.getId().rawId () << "</HCAL_CHANNEL_ID> "<< std::endl;
-    fOutput << "</CHANNEL>"<< std::endl;
+  void dumpChannelId(std::ostream& fOutput, DetId fChannel) {
+    CastorText2DetIdConverter converter(fChannel);
+    fOutput << "<CHANNEL> " << std::endl;
+    fOutput << "   <EXTENSION_TABLE_NAME>HCAL_CHANNELS</EXTENSION_TABLE_NAME> " << std::endl;
+    fOutput << "   <ETA>" << abs(converter.getField(1)) << "</ETA>" << std::endl;
+    fOutput << "   <PHI>" << converter.getField(2) << "</PHI> " << std::endl;
+    fOutput << "   <DEPTH>" << converter.getField(3) << "</DEPTH> " << std::endl;
+    fOutput << "   <Z>" << (converter.getField(1) > 0 ? "1" : "-1") << "</Z> " << std::endl;
+    fOutput << "   <DETECTOR_NAME>" << converter.getFlavor() << "</DETECTOR_NAME> " << std::endl;
+    fOutput << "   <HCAL_CHANNEL_ID>" << converter.getId().rawId() << "</HCAL_CHANNEL_ID> " << std::endl;
+    fOutput << "</CHANNEL>" << std::endl;
     fOutput << std::endl;
   }
 
-  void dumpData (std::ostream& fOutput, const float* fValues, const CastorPedestalWidth& fErrors) {
-    fOutput << "<DATA> "<< std::endl;
-    fOutput << "   <CAPACITOR_0_VALUE>" << fValues [0] << "</CAPACITOR_0_VALUE> "<< std::endl;
-    fOutput << "   <CAPACITOR_1_VALUE>" << fValues [1] << "</CAPACITOR_1_VALUE> "<< std::endl;
-    fOutput << "   <CAPACITOR_2_VALUE>" << fValues [2] << "</CAPACITOR_2_VALUE> "<< std::endl;	
-    fOutput << "   <CAPACITOR_3_VALUE>" << fValues [3] << "</CAPACITOR_3_VALUE> "<< std::endl;
-    fOutput << "   <SIGMA_0_0>" << fErrors.getSigma (0,0) << "</SIGMA_0_0> "<< std::endl;	
-    fOutput << "   <SIGMA_1_1>" << fErrors.getSigma (1,1) << "</SIGMA_1_1> "<< std::endl;	
-    fOutput << "   <SIGMA_2_2>" << fErrors.getSigma (2,2) << "</SIGMA_2_2> "<< std::endl;	
-    fOutput << "   <SIGMA_3_3>" << fErrors.getSigma (3,3) << "</SIGMA_3_3> "<< std::endl;	
-    fOutput << "   <SIGMA_0_1>" << fErrors.getSigma (1,0) << "</SIGMA_0_1> "<< std::endl;	
-    fOutput << "   <SIGMA_0_2>" << fErrors.getSigma (2,0) << "</SIGMA_0_2> "<< std::endl;	
-    fOutput << "   <SIGMA_0_3>" << fErrors.getSigma (3,0) << "</SIGMA_0_3> "<< std::endl;	
-    fOutput << "   <SIGMA_1_2>" << fErrors.getSigma (2,1) << "</SIGMA_1_2> "<< std::endl;	
-    fOutput << "   <SIGMA_1_3>" << fErrors.getSigma (3,1) << "</SIGMA_1_3> "<< std::endl;	
-    fOutput << "   <SIGMA_2_3>" << fErrors.getSigma (3,2) << "</SIGMA_2_3> "<< std::endl;	
+  void dumpData(std::ostream& fOutput, const float* fValues, const CastorPedestalWidth& fErrors) {
+    fOutput << "<DATA> " << std::endl;
+    fOutput << "   <CAPACITOR_0_VALUE>" << fValues[0] << "</CAPACITOR_0_VALUE> " << std::endl;
+    fOutput << "   <CAPACITOR_1_VALUE>" << fValues[1] << "</CAPACITOR_1_VALUE> " << std::endl;
+    fOutput << "   <CAPACITOR_2_VALUE>" << fValues[2] << "</CAPACITOR_2_VALUE> " << std::endl;
+    fOutput << "   <CAPACITOR_3_VALUE>" << fValues[3] << "</CAPACITOR_3_VALUE> " << std::endl;
+    fOutput << "   <SIGMA_0_0>" << fErrors.getSigma(0, 0) << "</SIGMA_0_0> " << std::endl;
+    fOutput << "   <SIGMA_1_1>" << fErrors.getSigma(1, 1) << "</SIGMA_1_1> " << std::endl;
+    fOutput << "   <SIGMA_2_2>" << fErrors.getSigma(2, 2) << "</SIGMA_2_2> " << std::endl;
+    fOutput << "   <SIGMA_3_3>" << fErrors.getSigma(3, 3) << "</SIGMA_3_3> " << std::endl;
+    fOutput << "   <SIGMA_0_1>" << fErrors.getSigma(1, 0) << "</SIGMA_0_1> " << std::endl;
+    fOutput << "   <SIGMA_0_2>" << fErrors.getSigma(2, 0) << "</SIGMA_0_2> " << std::endl;
+    fOutput << "   <SIGMA_0_3>" << fErrors.getSigma(3, 0) << "</SIGMA_0_3> " << std::endl;
+    fOutput << "   <SIGMA_1_2>" << fErrors.getSigma(2, 1) << "</SIGMA_1_2> " << std::endl;
+    fOutput << "   <SIGMA_1_3>" << fErrors.getSigma(3, 1) << "</SIGMA_1_3> " << std::endl;
+    fOutput << "   <SIGMA_2_3>" << fErrors.getSigma(3, 2) << "</SIGMA_2_3> " << std::endl;
     fOutput << "</DATA> " << std::endl;
   }
 
-  void dumpData (std::ostream& fOutput, const float* fValues, const float* fErrors) {
-    fOutput << "<DATA> "<< std::endl;
-    fOutput << "   <CAPACITOR_0_VALUE>" << fValues [0] << "</CAPACITOR_0_VALUE> "<< std::endl;
-    fOutput << "   <CAPACITOR_1_VALUE>" << fValues [1] << "</CAPACITOR_1_VALUE> "<< std::endl;
-    fOutput << "   <CAPACITOR_2_VALUE>" << fValues [2] << "</CAPACITOR_2_VALUE> "<< std::endl;
-    fOutput << "   <CAPACITOR_3_VALUE>" << fValues [3] << "</CAPACITOR_3_VALUE> "<< std::endl;
-    fOutput << "   <CAPACITOR_0_ERROR>" << fErrors [0] << "</CAPACITOR_0_ERROR> "<< std::endl;
-    fOutput << "   <CAPACITOR_1_ERROR>" << fErrors [1] << "</CAPACITOR_1_ERROR> "<< std::endl;
-    fOutput << "   <CAPACITOR_2_ERROR>" << fErrors [2] << "</CAPACITOR_2_ERROR> "<< std::endl;
-    fOutput << "   <CAPACITOR_3_ERROR>" << fErrors [3] << "</CAPACITOR_3_ERROR> "<< std::endl;
+  void dumpData(std::ostream& fOutput, const float* fValues, const float* fErrors) {
+    fOutput << "<DATA> " << std::endl;
+    fOutput << "   <CAPACITOR_0_VALUE>" << fValues[0] << "</CAPACITOR_0_VALUE> " << std::endl;
+    fOutput << "   <CAPACITOR_1_VALUE>" << fValues[1] << "</CAPACITOR_1_VALUE> " << std::endl;
+    fOutput << "   <CAPACITOR_2_VALUE>" << fValues[2] << "</CAPACITOR_2_VALUE> " << std::endl;
+    fOutput << "   <CAPACITOR_3_VALUE>" << fValues[3] << "</CAPACITOR_3_VALUE> " << std::endl;
+    fOutput << "   <CAPACITOR_0_ERROR>" << fErrors[0] << "</CAPACITOR_0_ERROR> " << std::endl;
+    fOutput << "   <CAPACITOR_1_ERROR>" << fErrors[1] << "</CAPACITOR_1_ERROR> " << std::endl;
+    fOutput << "   <CAPACITOR_2_ERROR>" << fErrors[2] << "</CAPACITOR_2_ERROR> " << std::endl;
+    fOutput << "   <CAPACITOR_3_ERROR>" << fErrors[3] << "</CAPACITOR_3_ERROR> " << std::endl;
     fOutput << "</DATA> " << std::endl;
   }
 
-  void dumpDataset (std::ostream& fOutput, unsigned fVersion = 0, const std::string& fFileName = "", const std::string& fDescription = "") {
+  void dumpDataset(std::ostream& fOutput,
+                   unsigned fVersion = 0,
+                   const std::string& fFileName = "",
+                   const std::string& fDescription = "") {
     fOutput << "<DATA_SET>" << std::endl;
     fOutput << "   <VERSION>" << fVersion << "</VERSION>" << std::endl;
-    if (!fFileName.empty ()) 
+    if (!fFileName.empty())
       fOutput << "      <DATA_FILE_NAME>" << fFileName << "</DATA_FILE_NAME>" << std::endl;
-    if (!fDescription.empty ())
+    if (!fDescription.empty())
       fOutput << "      <COMMENT_DESCRIPTION>" << fDescription << "</COMMENT_DESCRIPTION>" << std::endl;
   }
 
-  void endDataset (std::ostream& fOutput) {
-    fOutput << "</DATA_SET>" << std::endl;
-  }
+  void endDataset(std::ostream& fOutput) { fOutput << "</DATA_SET>" << std::endl; }
 
-  void dumpMapping (std::ostream& fOutput, unsigned fRun, const std::string& fKind, 
-		    unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, 
-		    const std::string& fTag, unsigned fVersion, const std::vector<DetId>& fChannels) {
+  void dumpMapping(std::ostream& fOutput,
+                   unsigned fRun,
+                   const std::string& fKind,
+                   unsigned long fGMTIOVBegin,
+                   unsigned long fGMTIOVEnd,
+                   const std::string& fTag,
+                   unsigned fVersion,
+                   const std::vector<DetId>& fChannels) {
     const std::string IOV_ID = "IOV_ID";
     const std::string TAG_ID = "TAG_ID";
     fOutput << "<ELEMENTS>" << std::endl;
     // set channels affected
-    int i = fChannels.size ();
+    int i = fChannels.size();
     while (--i >= 0) {
       fOutput << "<DATA_SET id=\"" << i << "\">" << std::endl;
-      dumpRun (fOutput, fRun);
+      dumpRun(fOutput, fRun);
       fOutput << "<KIND_OF_CONDITION><NAME>" << fKind << "</NAME></KIND_OF_CONDITION>" << std::endl;
-      dumpChannelId (fOutput, fChannels[i]);
+      dumpChannelId(fOutput, fChannels[i]);
       fOutput << "<VERSION>" << fVersion << "</VERSION>" << std::endl;
       fOutput << "</DATA_SET>" << std::endl;
     }
     // set IOV
     fOutput << "<IOV id=\"" << IOV_ID << "\">";
-    fOutput << "   <INTERVAL_OF_VALIDITY_BEGIN>" << fGMTIOVBegin << "</INTERVAL_OF_VALIDITY_BEGIN>"<< std::endl;
-    fOutput << "   <INTERVAL_OF_VALIDITY_END>" << fGMTIOVEnd << "</INTERVAL_OF_VALIDITY_END>"<< std::endl;
+    fOutput << "   <INTERVAL_OF_VALIDITY_BEGIN>" << fGMTIOVBegin << "</INTERVAL_OF_VALIDITY_BEGIN>" << std::endl;
+    fOutput << "   <INTERVAL_OF_VALIDITY_END>" << fGMTIOVEnd << "</INTERVAL_OF_VALIDITY_END>" << std::endl;
     fOutput << "</IOV>" << std::endl;
     // set TAG
-    fOutput << "<TAG id=\"" << TAG_ID << "\" mode=\"create\">"<< std::endl;
-    fOutput << "   <TAG_NAME>" << fTag << "</TAG_NAME>"<< std::endl;
-    fOutput << "   <DETECTOR_NAME>HCAL</DETECTOR_NAME>"<< std::endl;
+    fOutput << "<TAG id=\"" << TAG_ID << "\" mode=\"create\">" << std::endl;
+    fOutput << "   <TAG_NAME>" << fTag << "</TAG_NAME>" << std::endl;
+    fOutput << "   <DETECTOR_NAME>HCAL</DETECTOR_NAME>" << std::endl;
     fOutput << "   <COMMENT_DESCRIPTION>Automatically created by CastorDbXml</COMMENT_DESCRIPTION>" << std::endl;
     fOutput << "</TAG>" << std::endl;
 
@@ -131,7 +136,7 @@ namespace {
     fOutput << "<MAPS>" << std::endl;
     fOutput << "<TAG idref=\"" << TAG_ID << "\">" << std::endl;
     fOutput << "<IOV idref=\"" << IOV_ID << "\">" << std::endl;
-    i = fChannels.size ();
+    i = fChannels.size();
     while (--i >= 0) {
       fOutput << "<DATA_SET idref=\"" << i << "\"/>" << std::endl;
     }
@@ -139,113 +144,124 @@ namespace {
     fOutput << "</TAG>" << std::endl;
     fOutput << "</MAPS>" << std::endl;
   }
-}
+}  // namespace
 
-
-
-bool CastorDbXml::dumpObject (std::ostream& fOutput, 
-			    unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion, 
-			    const CastorPedestals& fObject) {
+bool CastorDbXml::dumpObject(std::ostream& fOutput,
+                             unsigned fRun,
+                             unsigned long fGMTIOVBegin,
+                             unsigned long fGMTIOVEnd,
+                             const std::string& fTag,
+                             unsigned fVersion,
+                             const CastorPedestals& fObject) {
   float dummyError = 0.0001;
   std::cout << "CastorDbXml::dumpObject-> set default errors: 0.0001, 0.0001, 0.0001, 0.0001" << std::endl;
-  CastorPedestalWidths widths(fObject.isADC() );
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
-
+  CastorPedestalWidths widths(fObject.isADC());
+  std::vector<DetId> channels = fObject.getAllChannels();
+  for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
     CastorPedestalWidth item(*channel);
     for (int iCapId = 1; iCapId <= 4; iCapId++) {
-      item.setSigma (iCapId, iCapId, dummyError*dummyError);
+      item.setSigma(iCapId, iCapId, dummyError * dummyError);
     }
     widths.addValues(item);
-
   }
-  return dumpObject (fOutput, fRun, fGMTIOVBegin, fGMTIOVEnd, fTag, fVersion, fObject, widths);
+  return dumpObject(fOutput, fRun, fGMTIOVBegin, fGMTIOVEnd, fTag, fVersion, fObject, widths);
 }
 
-bool CastorDbXml::dumpObject (std::ostream& fOutput, 
-			    unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion, 
-			    const CastorPedestals& fObject, const CastorPedestalWidths& fError) {
+bool CastorDbXml::dumpObject(std::ostream& fOutput,
+                             unsigned fRun,
+                             unsigned long fGMTIOVBegin,
+                             unsigned long fGMTIOVEnd,
+                             const std::string& fTag,
+                             unsigned fVersion,
+                             const CastorPedestals& fObject,
+                             const CastorPedestalWidths& fError) {
   const std::string KIND = "HCAL_PEDESTALS_V2";
 
-  dumpProlog (fOutput);
-  dumpHeader (fOutput, fRun, KIND, KIND);
+  dumpProlog(fOutput);
+  dumpHeader(fOutput, fRun, KIND, KIND);
 
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
+  std::vector<DetId> channels = fObject.getAllChannels();
+  for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
     DetId chId = *channel;
-    const float* values = fObject.getValues (chId)->getValues ();
-    const CastorPedestalWidth* errors = fError.getValues (chId);
+    const float* values = fObject.getValues(chId)->getValues();
+    const CastorPedestalWidth* errors = fError.getValues(chId);
     if (!values) {
-      std::cerr << "CastorDbXml::dumpObject-> Can not get data for channel " << CastorText2DetIdConverter(chId).toString () << std::endl;
+      std::cerr << "CastorDbXml::dumpObject-> Can not get data for channel "
+                << CastorText2DetIdConverter(chId).toString() << std::endl;
       continue;
     }
     if (!errors) {
-      std::cerr << "CastorDbXml::dumpObject-> Can not get errors for channel " << CastorText2DetIdConverter(chId).toString () <<  ". Use defaults" << std::endl;
+      std::cerr << "CastorDbXml::dumpObject-> Can not get errors for channel "
+                << CastorText2DetIdConverter(chId).toString() << ". Use defaults" << std::endl;
       continue;
     }
-    dumpDataset (fOutput, fVersion, "", "");
-    dumpChannelId (fOutput,chId); 
-    dumpData (fOutput, values, *errors);
-    endDataset (fOutput);
+    dumpDataset(fOutput, fVersion, "", "");
+    dumpChannelId(fOutput, chId);
+    dumpData(fOutput, values, *errors);
+    endDataset(fOutput);
   }
-  dumpMapping (fOutput, fRun, KIND, fGMTIOVBegin, fGMTIOVEnd, fTag, fVersion, channels);
+  dumpMapping(fOutput, fRun, KIND, fGMTIOVBegin, fGMTIOVEnd, fTag, fVersion, channels);
 
-  dumpFooter (fOutput);
+  dumpFooter(fOutput);
   return true;
 }
 
-bool CastorDbXml::dumpObject (std::ostream& fOutput, 
-			    unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion,
-			    const CastorGains& fObject) {
-  float dummyErrors [4] = {0., 0., 0., 0.};
+bool CastorDbXml::dumpObject(std::ostream& fOutput,
+                             unsigned fRun,
+                             unsigned long fGMTIOVBegin,
+                             unsigned long fGMTIOVEnd,
+                             const std::string& fTag,
+                             unsigned fVersion,
+                             const CastorGains& fObject) {
+  float dummyErrors[4] = {0., 0., 0., 0.};
   std::cout << "CastorDbXml::dumpObject-> set default errors: 4 x 0.0" << std::endl;
 
   CastorGainWidths widths;
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  for (std::vector<DetId>::iterator channel = channels.begin (); channel !=  channels.end (); ++channel) 
-    {
-      CastorGainWidth item(*channel,dummyErrors[0],dummyErrors[1],dummyErrors[2],dummyErrors[3]);
-      widths.addValues(item);
-    }
+  std::vector<DetId> channels = fObject.getAllChannels();
+  for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
+    CastorGainWidth item(*channel, dummyErrors[0], dummyErrors[1], dummyErrors[2], dummyErrors[3]);
+    widths.addValues(item);
+  }
 
-  return dumpObject (fOutput, fRun, fGMTIOVBegin, fGMTIOVEnd, fTag, fVersion, fObject, widths);
+  return dumpObject(fOutput, fRun, fGMTIOVBegin, fGMTIOVEnd, fTag, fVersion, fObject, widths);
 }
 
-bool CastorDbXml::dumpObject (std::ostream& fOutput, 
-			    unsigned fRun, unsigned long fGMTIOVBegin, unsigned long fGMTIOVEnd, const std::string& fTag, unsigned fVersion,
-			    const CastorGains& fObject, const CastorGainWidths& fError) {
+bool CastorDbXml::dumpObject(std::ostream& fOutput,
+                             unsigned fRun,
+                             unsigned long fGMTIOVBegin,
+                             unsigned long fGMTIOVEnd,
+                             const std::string& fTag,
+                             unsigned fVersion,
+                             const CastorGains& fObject,
+                             const CastorGainWidths& fError) {
   const std::string KIND = "HCAL Gains";
   const std::string TABLE = "HCAL_GAIN_PEDSTL_CALIBRATIONS";
 
-  dumpProlog (fOutput);
-  dumpHeader (fOutput, fRun, TABLE, KIND);
+  dumpProlog(fOutput);
+  dumpHeader(fOutput, fRun, TABLE, KIND);
 
-  std::vector<DetId> channels = fObject.getAllChannels ();
-  for (std::vector<DetId>::iterator channel = channels.begin ();
-       channel !=  channels.end ();
-       ++channel) {
+  std::vector<DetId> channels = fObject.getAllChannels();
+  for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); ++channel) {
     DetId chId = *channel;
-    const float* values = fObject.getValues (chId)->getValues ();
-    const float* errors = fError.getValues (chId)->getValues ();
+    const float* values = fObject.getValues(chId)->getValues();
+    const float* errors = fError.getValues(chId)->getValues();
     if (!values) {
-      std::cerr << "CastorDbXml::dumpObject-> Can not get data for channel " << CastorText2DetIdConverter(chId).toString () << std::endl;
+      std::cerr << "CastorDbXml::dumpObject-> Can not get data for channel "
+                << CastorText2DetIdConverter(chId).toString() << std::endl;
       continue;
     }
     if (!errors) {
-      std::cerr << "CastorDbXml::dumpObject-> Can not get errors for channel " << CastorText2DetIdConverter(chId).toString () <<  ". Use defaults" << std::endl;
+      std::cerr << "CastorDbXml::dumpObject-> Can not get errors for channel "
+                << CastorText2DetIdConverter(chId).toString() << ". Use defaults" << std::endl;
       continue;
     }
-    dumpDataset (fOutput, fVersion, "", "");
-    dumpChannelId (fOutput,chId); 
-    dumpData (fOutput, values, errors);
-    endDataset (fOutput);
+    dumpDataset(fOutput, fVersion, "", "");
+    dumpChannelId(fOutput, chId);
+    dumpData(fOutput, values, errors);
+    endDataset(fOutput);
   }
-  dumpMapping (fOutput, fRun, KIND, fGMTIOVBegin, fGMTIOVEnd, fTag, fVersion, channels);
+  dumpMapping(fOutput, fRun, KIND, fGMTIOVBegin, fGMTIOVEnd, fTag, fVersion, channels);
 
-  dumpFooter (fOutput);
+  dumpFooter(fOutput);
   return true;
 }

--- a/CalibCalorimetry/CastorCalib/src/CastorLedAnalysis.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorLedAnalysis.cc
@@ -13,48 +13,53 @@
 
 using namespace std;
 
-
-CastorLedAnalysis::CastorLedAnalysis(const edm::ParameterSet& ps)
-{
+CastorLedAnalysis::CastorLedAnalysis(const edm::ParameterSet& ps) {
   // init
-  evt=0;
-  sample=0;
-  m_file=nullptr;
+  evt = 0;
+  sample = 0;
+  m_file = nullptr;
   char output[100]{0};
   // output files
-  for(int k=0;k<4;k++) state.push_back(true); // 4 cap-ids (do we care?)
+  for (int k = 0; k < 4; k++)
+    state.push_back(true);  // 4 cap-ids (do we care?)
   m_outputFileText = ps.getUntrackedParameter<string>("outputFileText", "");
-  m_outputFileX = ps.getUntrackedParameter<string>("outputFileXML","");
-  if ( !m_outputFileText.empty() ) {
+  m_outputFileX = ps.getUntrackedParameter<string>("outputFileXML", "");
+  if (!m_outputFileText.empty()) {
     cout << "Castor LED results will be saved to " << m_outputFileText.c_str() << endl;
     m_outFile.open(m_outputFileText.c_str());
-  } 
+  }
   m_outputFileROOT = ps.getUntrackedParameter<string>("outputFileHist", "");
-  if ( !m_outputFileROOT.empty() ) {
+  if (!m_outputFileROOT.empty()) {
     cout << "Castor LED histograms will be saved to " << m_outputFileROOT.c_str() << endl;
   }
 
-  m_nevtsample = ps.getUntrackedParameter<int>("nevtsample",9999999);
-  if(m_nevtsample<1)m_nevtsample=9999999;
-  m_hiSaveflag = ps.getUntrackedParameter<int>("hiSaveflag",0);
-  if(m_hiSaveflag<0)m_hiSaveflag=0;
-  if(m_hiSaveflag>0)m_hiSaveflag=1;
-  m_fitflag = ps.getUntrackedParameter<int>("analysisflag",2);
-  if(m_fitflag<0)m_fitflag=0;
-  if(m_fitflag>4)m_fitflag=4;
+  m_nevtsample = ps.getUntrackedParameter<int>("nevtsample", 9999999);
+  if (m_nevtsample < 1)
+    m_nevtsample = 9999999;
+  m_hiSaveflag = ps.getUntrackedParameter<int>("hiSaveflag", 0);
+  if (m_hiSaveflag < 0)
+    m_hiSaveflag = 0;
+  if (m_hiSaveflag > 0)
+    m_hiSaveflag = 1;
+  m_fitflag = ps.getUntrackedParameter<int>("analysisflag", 2);
+  if (m_fitflag < 0)
+    m_fitflag = 0;
+  if (m_fitflag > 4)
+    m_fitflag = 4;
   m_startTS = ps.getUntrackedParameter<int>("firstTS", 0);
-  if(m_startTS<0) m_startTS=0;
+  if (m_startTS < 0)
+    m_startTS = 0;
   m_endTS = ps.getUntrackedParameter<int>("lastTS", 9);
-  m_usecalib = ps.getUntrackedParameter<bool>("usecalib",false);
+  m_usecalib = ps.getUntrackedParameter<bool>("usecalib", false);
   m_logFile.open("CastorLedAnalysis.log");
 
-  int runNum = ps.getUntrackedParameter<int>("runNumber",999999);
+  int runNum = ps.getUntrackedParameter<int>("runNumber", 999999);
 
   // histogram booking
-  castorHists.ALLLEDS = new TH1F("Castor All LEDs","HF All Leds",10,0,9);
-  castorHists.LEDRMS= new TH1F("Castor All LED RMS","HF All LED RMS",100,0,3);
-  castorHists.LEDMEAN= new TH1F("Castor All LED Means","HF All LED Means",100,0,9);
-  castorHists.CHI2= new TH1F("Castor Chi2 by ndf for Landau fit","HF Chi2/ndf Landau",200,0.,50.);
+  castorHists.ALLLEDS = new TH1F("Castor All LEDs", "HF All Leds", 10, 0, 9);
+  castorHists.LEDRMS = new TH1F("Castor All LED RMS", "HF All LED RMS", 100, 0, 3);
+  castorHists.LEDMEAN = new TH1F("Castor All LED Means", "HF All LED Means", 100, 0, 9);
+  castorHists.CHI2 = new TH1F("Castor Chi2 by ndf for Landau fit", "HF Chi2/ndf Landau", 200, 0., 50.);
 
   //XML file header
   m_outputFileXML.open(m_outputFileX.c_str());
@@ -126,16 +131,15 @@ CastorLedAnalysis::CastorLedAnalysis(const edm::ParameterSet& ps)
   m_outputFileXML << output << endl;
   snprintf(output, sizeof output, "  </MAPS>");
   m_outputFileXML << output << endl;
-
-
 }
 
 //-----------------------------------------------------------------------------
-CastorLedAnalysis::~CastorLedAnalysis(){
+CastorLedAnalysis::~CastorLedAnalysis() {
   ///All done, clean up!!
 
-  for(_meol=castorHists.LEDTRENDS.begin(); _meol!=castorHists.LEDTRENDS.end(); _meol++){
-    for(int i=0; i<15; i++) _meol->second[i].first->Delete();
+  for (_meol = castorHists.LEDTRENDS.begin(); _meol != castorHists.LEDTRENDS.end(); _meol++) {
+    for (int i = 0; i < 15; i++)
+      _meol->second[i].first->Delete();
   }
 
   castorHists.ALLLEDS->Delete();
@@ -147,87 +151,102 @@ CastorLedAnalysis::~CastorLedAnalysis(){
 //-----------------------------------------------------------------------------
 void CastorLedAnalysis::LedSetup(const std::string& m_outputFileROOT) {
   // open the histogram file, create directories within
-  m_file=new TFile(m_outputFileROOT.c_str(),"RECREATE");
+  m_file = new TFile(m_outputFileROOT.c_str(), "RECREATE");
   m_file->mkdir("Castor");
   m_file->cd();
 }
 
 //-----------------------------------------------------------------------------
-void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
-  double time2=0; double time1=0; double time3=0; double time4=0;
-  double dtime2=0; double dtime1=0; double dtime3=0; double dtime4=0;
+void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int, LEDBUNCH> >& toolT) {
+  double time2 = 0;
+  double time1 = 0;
+  double time3 = 0;
+  double time4 = 0;
+  double dtime2 = 0;
+  double dtime1 = 0;
+  double dtime3 = 0;
+  double dtime4 = 0;
   char output[100]{0};
 
-  if (!m_outputFileText.empty()){
-    if(m_fitflag==0 || m_fitflag==2) m_outFile<<"Det Eta,Phi,D   Mean    Error"<<std::endl;
-    else if(m_fitflag==1 || m_fitflag==3) m_outFile<<"Det Eta,Phi,D   Peak    Error"<<std::endl;
-    else if(m_fitflag==4) m_outFile<<"Det Eta,Phi,D   Mean    Error      Peak    Error       MeanEv  Error       PeakEv  Error"<<std::endl;
+  if (!m_outputFileText.empty()) {
+    if (m_fitflag == 0 || m_fitflag == 2)
+      m_outFile << "Det Eta,Phi,D   Mean    Error" << std::endl;
+    else if (m_fitflag == 1 || m_fitflag == 3)
+      m_outFile << "Det Eta,Phi,D   Peak    Error" << std::endl;
+    else if (m_fitflag == 4)
+      m_outFile << "Det Eta,Phi,D   Mean    Error      Peak    Error       MeanEv  Error       PeakEv  Error"
+                << std::endl;
   }
-  for(_meol=toolT.begin(); _meol!=toolT.end(); _meol++){
-// scale the LED pulse to 1 event
-    _meol->second[10].first->Scale(1./evt_curr);
-    if(m_fitflag==0 || m_fitflag==4){
+  for (_meol = toolT.begin(); _meol != toolT.end(); _meol++) {
+    // scale the LED pulse to 1 event
+    _meol->second[10].first->Scale(1. / evt_curr);
+    if (m_fitflag == 0 || m_fitflag == 4) {
       time1 = _meol->second[10].first->GetMean();
-      dtime1 = _meol->second[10].first->GetRMS()/sqrt((float)evt_curr*(m_endTS-m_startTS+1));
+      dtime1 = _meol->second[10].first->GetRMS() / sqrt((float)evt_curr * (m_endTS - m_startTS + 1));
     }
-    if(m_fitflag==1 || m_fitflag==4){
-// put proper errors
-      for(int j=0; j<10; j++) _meol->second[10].first->SetBinError(j+1,_meol->second[j].first->GetRMS()/sqrt((float)evt_curr));
+    if (m_fitflag == 1 || m_fitflag == 4) {
+      // put proper errors
+      for (int j = 0; j < 10; j++)
+        _meol->second[10].first->SetBinError(j + 1, _meol->second[j].first->GetRMS() / sqrt((float)evt_curr));
     }
-    if(m_fitflag==1 || m_fitflag==3 || m_fitflag==4){
-      _meol->second[10].first->Fit("landau","Q");
-//      _meol->second[10].first->Fit("gaus","Q");
-      TF1 *fit = _meol->second[10].first->GetFunction("landau");
-//      TF1 *fit = _meol->second[10].first->GetFunction("gaus");
-      time2=fit->GetParameter(1);
-      dtime2=fit->GetParError(1);
+    if (m_fitflag == 1 || m_fitflag == 3 || m_fitflag == 4) {
+      _meol->second[10].first->Fit("landau", "Q");
+      //      _meol->second[10].first->Fit("gaus","Q");
+      TF1* fit = _meol->second[10].first->GetFunction("landau");
+      //      TF1 *fit = _meol->second[10].first->GetFunction("gaus");
+      time2 = fit->GetParameter(1);
+      dtime2 = fit->GetParError(1);
     }
-    if(m_fitflag==2 || m_fitflag==4){
+    if (m_fitflag == 2 || m_fitflag == 4) {
       time3 = _meol->second[12].first->GetMean();
-      dtime3 = _meol->second[12].first->GetRMS()/sqrt((float)_meol->second[12].first->GetEntries());
+      dtime3 = _meol->second[12].first->GetRMS() / sqrt((float)_meol->second[12].first->GetEntries());
     }
-    if(m_fitflag==3 || m_fitflag==4){
+    if (m_fitflag == 3 || m_fitflag == 4) {
       time4 = _meol->second[13].first->GetMean();
-      dtime4 = _meol->second[13].first->GetRMS()/sqrt((float)_meol->second[13].first->GetEntries());
+      dtime4 = _meol->second[13].first->GetRMS() / sqrt((float)_meol->second[13].first->GetEntries());
     }
-    for (int i=0; i<10; i++){
+    for (int i = 0; i < 10; i++) {
       _meol->second[i].first->GetXaxis()->SetTitle("Pulse height (fC)");
       _meol->second[i].first->GetYaxis()->SetTitle("Counts");
-//      if(m_hiSaveflag>0)_meol->second[i].first->Write();
+      //      if(m_hiSaveflag>0)_meol->second[i].first->Write();
     }
     _meol->second[10].first->GetXaxis()->SetTitle("Time slice");
     _meol->second[10].first->GetYaxis()->SetTitle("Averaged pulse (fC)");
-    if(m_hiSaveflag>0)_meol->second[10].first->Write();
+    if (m_hiSaveflag > 0)
+      _meol->second[10].first->Write();
     _meol->second[10].second.first[0].push_back(time1);
     _meol->second[10].second.first[1].push_back(dtime1);
     _meol->second[11].second.first[0].push_back(time2);
     _meol->second[11].second.first[1].push_back(dtime2);
     _meol->second[12].first->GetXaxis()->SetTitle("Mean TS");
     _meol->second[12].first->GetYaxis()->SetTitle("Counts");
-    if(m_fitflag==2 && m_hiSaveflag>0)_meol->second[12].first->Write();
+    if (m_fitflag == 2 && m_hiSaveflag > 0)
+      _meol->second[12].first->Write();
     _meol->second[12].second.first[0].push_back(time3);
     _meol->second[12].second.first[1].push_back(dtime3);
     _meol->second[13].first->GetXaxis()->SetTitle("Peak TS");
     _meol->second[13].first->GetYaxis()->SetTitle("Counts");
-    if(m_fitflag>2 && m_hiSaveflag>0)_meol->second[13].first->Write();
+    if (m_fitflag > 2 && m_hiSaveflag > 0)
+      _meol->second[13].first->Write();
     _meol->second[13].second.first[0].push_back(time4);
     _meol->second[13].second.first[1].push_back(dtime4);
     _meol->second[14].first->GetXaxis()->SetTitle("Peak TS error");
     _meol->second[14].first->GetYaxis()->SetTitle("Counts");
-    if(m_fitflag>2 && m_hiSaveflag>0)_meol->second[14].first->Write();
+    if (m_fitflag > 2 && m_hiSaveflag > 0)
+      _meol->second[14].first->Write();
     _meol->second[15].first->GetXaxis()->SetTitle("Chi2/NDF");
     _meol->second[15].first->GetYaxis()->SetTitle("Counts");
-    if(m_fitflag>2 && m_hiSaveflag>0)_meol->second[15].first->Write();
+    if (m_fitflag > 2 && m_hiSaveflag > 0)
+      _meol->second[15].first->Write();
     _meol->second[16].first->GetXaxis()->SetTitle("Integrated Signal");
     _meol->second[16].first->Write();
 
-
-// Ascii printout (need to modify to include new info)
+    // Ascii printout (need to modify to include new info)
     HcalDetId detid = _meol->first;
 
-    if (!m_outputFileText.empty()){
-      if(m_fitflag==0) {
-	m_outFile<<detid<<"   "<<time1<<" "<<dtime1<<std::endl;
+    if (!m_outputFileText.empty()) {
+      if (m_fitflag == 0) {
+        m_outFile << detid << "   " << time1 << " " << dtime1 << std::endl;
         snprintf(output, sizeof output, "  <DATA_SET>");
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "    <VERSION>version:1</VERSION>");
@@ -236,20 +255,24 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <EXTENSION_TABLE_NAME>HCAL_CHANNELS</EXTENSION_TABLE_NAME>");
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <ETA>%2i</ETA>", detid.ietaAbs() );
+        snprintf(output, sizeof output, "      <ETA>%2i</ETA>", detid.ietaAbs());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <PHI>%2i</PHI>", detid.iphi() );
+        snprintf(output, sizeof output, "      <PHI>%2i</PHI>", detid.iphi());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <DEPTH>%2i</DEPTH>", detid.depth() );
+        snprintf(output, sizeof output, "      <DEPTH>%2i</DEPTH>", detid.depth());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <Z>%2i</Z>", detid.zside() );
+        snprintf(output, sizeof output, "      <Z>%2i</Z>", detid.zside());
         m_outputFileXML << output << endl;
-        if(detid.subdet() == 1) snprintf(output, sizeof output, "      <DETECTOR_NAME>HB</DETECTOR_NAME>");
-        if(detid.subdet() == 2) snprintf(output, sizeof output, "      <DETECTOR_NAME>HE</DETECTOR_NAME>");
-        if(detid.subdet() == 3) snprintf(output, sizeof output, "      <DETECTOR_NAME>HO</DETECTOR_NAME>");
-        if(detid.subdet() == 4) snprintf(output, sizeof output, "      <DETECTOR_NAME>HF</DETECTOR_NAME>");
+        if (detid.subdet() == 1)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HB</DETECTOR_NAME>");
+        if (detid.subdet() == 2)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HE</DETECTOR_NAME>");
+        if (detid.subdet() == 3)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HO</DETECTOR_NAME>");
+        if (detid.subdet() == 4)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HF</DETECTOR_NAME>");
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <HCAL_CHANNEL_ID>%10i</HCAL_CHANNEL_ID>", detid.rawId() );
+        snprintf(output, sizeof output, "      <HCAL_CHANNEL_ID>%10i</HCAL_CHANNEL_ID>", detid.rawId());
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "    </CHANNEL>");
         m_outputFileXML << output << endl;
@@ -261,7 +284,7 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <ERROR_STAT>%7f</ERROR_STAT>", dtime1);
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <ANALYSIS_FLAG>%2i</ANALYSIS_FLAG>", m_fitflag+1);
+        snprintf(output, sizeof output, "      <ANALYSIS_FLAG>%2i</ANALYSIS_FLAG>", m_fitflag + 1);
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <STATUS_WORD>  0</STATUS_WORD>");
         m_outputFileXML << output << endl;
@@ -270,9 +293,8 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         snprintf(output, sizeof output, "  </DATA_SET>");
         m_outputFileXML << output << endl;
 
-	}
-      else if(m_fitflag==1){
-	m_outFile<<detid<<"   "<<time2<<" "<<dtime2<<std::endl;
+      } else if (m_fitflag == 1) {
+        m_outFile << detid << "   " << time2 << " " << dtime2 << std::endl;
         snprintf(output, sizeof output, "  <DATA_SET>");
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "    <VERSION>version:1</VERSION>");
@@ -281,20 +303,24 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <EXTENSION_TABLE_NAME>HCAL_CHANNELS</EXTENSION_TABLE_NAME>");
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <ETA>%2i</ETA>", detid.ietaAbs() );
+        snprintf(output, sizeof output, "      <ETA>%2i</ETA>", detid.ietaAbs());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <PHI>%2i</PHI>", detid.iphi() );
+        snprintf(output, sizeof output, "      <PHI>%2i</PHI>", detid.iphi());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <DEPTH>%2i</DEPTH>", detid.depth() );
+        snprintf(output, sizeof output, "      <DEPTH>%2i</DEPTH>", detid.depth());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <Z>%2i</Z>", detid.zside() );
+        snprintf(output, sizeof output, "      <Z>%2i</Z>", detid.zside());
         m_outputFileXML << output << endl;
-        if(detid.subdet() == 1) snprintf(output, sizeof output, "      <DETECTOR_NAME>HB</DETECTOR_NAME>");
-        if(detid.subdet() == 2) snprintf(output, sizeof output, "      <DETECTOR_NAME>HE</DETECTOR_NAME>");
-        if(detid.subdet() == 3) snprintf(output, sizeof output, "      <DETECTOR_NAME>HO</DETECTOR_NAME>");
-        if(detid.subdet() == 4) snprintf(output, sizeof output, "      <DETECTOR_NAME>HF</DETECTOR_NAME>");
+        if (detid.subdet() == 1)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HB</DETECTOR_NAME>");
+        if (detid.subdet() == 2)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HE</DETECTOR_NAME>");
+        if (detid.subdet() == 3)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HO</DETECTOR_NAME>");
+        if (detid.subdet() == 4)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HF</DETECTOR_NAME>");
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <HCAL_CHANNEL_ID>%10i</HCAL_CHANNEL_ID>", detid.rawId() );
+        snprintf(output, sizeof output, "      <HCAL_CHANNEL_ID>%10i</HCAL_CHANNEL_ID>", detid.rawId());
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "    </CHANNEL>");
         m_outputFileXML << output << endl;
@@ -306,7 +332,7 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <ERROR_STAT>%7f</ERROR_STAT>", dtime2);
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <ANALYSIS_FLAG>%2i</ANALYSIS_FLAG>", m_fitflag+1);
+        snprintf(output, sizeof output, "      <ANALYSIS_FLAG>%2i</ANALYSIS_FLAG>", m_fitflag + 1);
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <STATUS_WORD>  0</STATUS_WORD>");
         m_outputFileXML << output << endl;
@@ -314,10 +340,10 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "  </DATA_SET>");
         m_outputFileXML << output << endl;
-        }
+      }
 
-      else if(m_fitflag==2){
-	m_outFile<<detid<<"   "<<time3<<" "<<dtime3<<std::endl;
+      else if (m_fitflag == 2) {
+        m_outFile << detid << "   " << time3 << " " << dtime3 << std::endl;
         snprintf(output, sizeof output, "  <DATA_SET>");
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "    <VERSION>version:1</VERSION>");
@@ -326,20 +352,24 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <EXTENSION_TABLE_NAME>HCAL_CHANNELS</EXTENSION_TABLE_NAME>");
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <ETA>%2i</ETA>", detid.ietaAbs() );
+        snprintf(output, sizeof output, "      <ETA>%2i</ETA>", detid.ietaAbs());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <PHI>%2i</PHI>", detid.iphi() );
+        snprintf(output, sizeof output, "      <PHI>%2i</PHI>", detid.iphi());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <DEPTH>%2i</DEPTH>", detid.depth() );
+        snprintf(output, sizeof output, "      <DEPTH>%2i</DEPTH>", detid.depth());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <Z>%2i</Z>", detid.zside() );
+        snprintf(output, sizeof output, "      <Z>%2i</Z>", detid.zside());
         m_outputFileXML << output << endl;
-	if(detid.subdet() == 1) snprintf(output, sizeof output, "      <DETECTOR_NAME>HB</DETECTOR_NAME>");
-        if(detid.subdet() == 2) snprintf(output, sizeof output, "      <DETECTOR_NAME>HE</DETECTOR_NAME>");
-        if(detid.subdet() == 3) snprintf(output, sizeof output, "      <DETECTOR_NAME>HO</DETECTOR_NAME>");
-        if(detid.subdet() == 4) snprintf(output, sizeof output, "      <DETECTOR_NAME>HF</DETECTOR_NAME>");
+        if (detid.subdet() == 1)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HB</DETECTOR_NAME>");
+        if (detid.subdet() == 2)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HE</DETECTOR_NAME>");
+        if (detid.subdet() == 3)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HO</DETECTOR_NAME>");
+        if (detid.subdet() == 4)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HF</DETECTOR_NAME>");
         m_outputFileXML << output << endl;
-	snprintf(output, sizeof output, "      <HCAL_CHANNEL_ID>%10i</HCAL_CHANNEL_ID>", detid.rawId() );
+        snprintf(output, sizeof output, "      <HCAL_CHANNEL_ID>%10i</HCAL_CHANNEL_ID>", detid.rawId());
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "    </CHANNEL>");
         m_outputFileXML << output << endl;
@@ -351,17 +381,16 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <ERROR_STAT>%7f</ERROR_STAT>", dtime3);
         m_outputFileXML << output << endl;
-	snprintf(output, sizeof output, "      <ANALYSIS_FLAG>%2i</ANALYSIS_FLAG>", m_fitflag+1);
-	m_outputFileXML << output << endl;
-  	snprintf(output, sizeof output, "      <STATUS_WORD>  0</STATUS_WORD>");
-  	m_outputFileXML << output << endl;
+        snprintf(output, sizeof output, "      <ANALYSIS_FLAG>%2i</ANALYSIS_FLAG>", m_fitflag + 1);
+        m_outputFileXML << output << endl;
+        snprintf(output, sizeof output, "      <STATUS_WORD>  0</STATUS_WORD>");
+        m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "    </DATA>");
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "  </DATA_SET>");
         m_outputFileXML << output << endl;
-        }
-      else if(m_fitflag==3){
-	m_outFile<<detid<<"   "<<time4<<" "<<dtime4<<std::endl;
+      } else if (m_fitflag == 3) {
+        m_outFile << detid << "   " << time4 << " " << dtime4 << std::endl;
         snprintf(output, sizeof output, "  <DATA_SET>");
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "    <VERSION>version:1</VERSION>");
@@ -370,20 +399,24 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <EXTENSION_TABLE_NAME>HCAL_CHANNELS</EXTENSION_TABLE_NAME>");
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <ETA>%2i</ETA>", detid.ietaAbs() );
+        snprintf(output, sizeof output, "      <ETA>%2i</ETA>", detid.ietaAbs());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <PHI>%2i</PHI>", detid.iphi() );
+        snprintf(output, sizeof output, "      <PHI>%2i</PHI>", detid.iphi());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <DEPTH>%2i</DEPTH>", detid.depth() );
+        snprintf(output, sizeof output, "      <DEPTH>%2i</DEPTH>", detid.depth());
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <Z>%2i</Z>", detid.zside() );
+        snprintf(output, sizeof output, "      <Z>%2i</Z>", detid.zside());
         m_outputFileXML << output << endl;
-        if(detid.subdet() == 1) snprintf(output, sizeof output, "      <DETECTOR_NAME>HB</DETECTOR_NAME>");
-        if(detid.subdet() == 2) snprintf(output, sizeof output, "      <DETECTOR_NAME>HE</DETECTOR_NAME>");
-        if(detid.subdet() == 3) snprintf(output, sizeof output, "      <DETECTOR_NAME>HO</DETECTOR_NAME>");
-        if(detid.subdet() == 4) snprintf(output, sizeof output, "      <DETECTOR_NAME>HF</DETECTOR_NAME>");
+        if (detid.subdet() == 1)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HB</DETECTOR_NAME>");
+        if (detid.subdet() == 2)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HE</DETECTOR_NAME>");
+        if (detid.subdet() == 3)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HO</DETECTOR_NAME>");
+        if (detid.subdet() == 4)
+          snprintf(output, sizeof output, "      <DETECTOR_NAME>HF</DETECTOR_NAME>");
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <HCAL_CHANNEL_ID>%10i</HCAL_CHANNEL_ID>", detid.rawId() );
+        snprintf(output, sizeof output, "      <HCAL_CHANNEL_ID>%10i</HCAL_CHANNEL_ID>", detid.rawId());
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "    </CHANNEL>");
         m_outputFileXML << output << endl;
@@ -395,7 +428,7 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <ERROR_STAT>%7f</ERROR_STAT>", dtime4);
         m_outputFileXML << output << endl;
-        snprintf(output, sizeof output, "      <ANALYSIS_FLAG>%2i</ANALYSIS_FLAG>", m_fitflag+1);
+        snprintf(output, sizeof output, "      <ANALYSIS_FLAG>%2i</ANALYSIS_FLAG>", m_fitflag + 1);
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "      <STATUS_WORD>  0</STATUS_WORD>");
         m_outputFileXML << output << endl;
@@ -403,70 +436,70 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
         m_outputFileXML << output << endl;
         snprintf(output, sizeof output, "  </DATA_SET>");
         m_outputFileXML << output << endl;
-        }
+      }
 
-      else if(m_fitflag==4){
-	m_outFile<<detid<<"   "<<time1<<" "<<dtime1<<"   "<<time2<<" "<<dtime2<<"   "<<time3<<" "<<dtime3<<"   "<<time4<<" "<<dtime4<<std::endl;
-	}
+      else if (m_fitflag == 4) {
+        m_outFile << detid << "   " << time1 << " " << dtime1 << "   " << time2 << " " << dtime2 << "   " << time3
+                  << " " << dtime3 << "   " << time4 << " " << dtime4 << std::endl;
+      }
     }
   }
 }
 
 //-----------------------------------------------------------------------------
-void CastorLedAnalysis::LedSampleAnalysis(){
+void CastorLedAnalysis::LedSampleAnalysis() {
   // it is called every m_nevtsample events (a sample) and the end of run
   char LedSampleNum[20];
 
-  sprintf(LedSampleNum,"LedSample_%d",sample);
+  sprintf(LedSampleNum, "LedSample_%d", sample);
   m_file->cd();
   m_file->mkdir(LedSampleNum);
   m_file->cd(LedSampleNum);
 
-// Compute LED constants
+  // Compute LED constants
   GetLedConst(castorHists.LEDTRENDS);
 }
 
 //-----------------------------------------------------------------------------
-void CastorLedAnalysis::LedTrendings(map<HcalDetId, map<int,LEDBUNCH> > &toolT)
-{
-
-  for(_meol=toolT.begin(); _meol!=toolT.end(); _meol++){
+void CastorLedAnalysis::LedTrendings(map<HcalDetId, map<int, LEDBUNCH> >& toolT) {
+  for (_meol = toolT.begin(); _meol != toolT.end(); _meol++) {
     char name[1024];
     HcalDetId detid = _meol->first;
-    sprintf(name,"LED timing trend, eta=%d phi=%d depth=%d",detid.ieta(),detid.iphi(),detid.depth());
-    int bins = _meol->second[10+m_fitflag].second.first[0].size();
-    float lo =0.5;
-    float hi = (float)bins+0.5;
-    _meol->second[10+m_fitflag].second.second.push_back(new TH1F(name,name,bins,lo,hi));
+    sprintf(name, "LED timing trend, eta=%d phi=%d depth=%d", detid.ieta(), detid.iphi(), detid.depth());
+    int bins = _meol->second[10 + m_fitflag].second.first[0].size();
+    float lo = 0.5;
+    float hi = (float)bins + 0.5;
+    _meol->second[10 + m_fitflag].second.second.push_back(new TH1F(name, name, bins, lo, hi));
 
     std::vector<double>::iterator sample_it;
-// LED timing - put content and errors
-    int j=0;
-    for(sample_it=_meol->second[10+m_fitflag].second.first[0].begin();
-        sample_it!=_meol->second[10+m_fitflag].second.first[0].end();++sample_it){
-      _meol->second[10+m_fitflag].second.second[0]->SetBinContent(++j,*sample_it);
+    // LED timing - put content and errors
+    int j = 0;
+    for (sample_it = _meol->second[10 + m_fitflag].second.first[0].begin();
+         sample_it != _meol->second[10 + m_fitflag].second.first[0].end();
+         ++sample_it) {
+      _meol->second[10 + m_fitflag].second.second[0]->SetBinContent(++j, *sample_it);
     }
-    j=0;
-    for(sample_it=_meol->second[10+m_fitflag].second.first[1].begin();
-        sample_it!=_meol->second[10+m_fitflag].second.first[1].end();++sample_it){
-      _meol->second[10+m_fitflag].second.second[0]->SetBinError(++j,*sample_it);
+    j = 0;
+    for (sample_it = _meol->second[10 + m_fitflag].second.first[1].begin();
+         sample_it != _meol->second[10 + m_fitflag].second.first[1].end();
+         ++sample_it) {
+      _meol->second[10 + m_fitflag].second.second[0]->SetBinError(++j, *sample_it);
     }
-    sprintf(name,"Sample (%d events)",m_nevtsample);
-    _meol->second[10+m_fitflag].second.second[0]->GetXaxis()->SetTitle(name);
-    _meol->second[10+m_fitflag].second.second[0]->GetYaxis()->SetTitle("Peak position");
-    _meol->second[10+m_fitflag].second.second[0]->Write();
+    sprintf(name, "Sample (%d events)", m_nevtsample);
+    _meol->second[10 + m_fitflag].second.second[0]->GetXaxis()->SetTitle(name);
+    _meol->second[10 + m_fitflag].second.second[0]->GetYaxis()->SetTitle("Peak position");
+    _meol->second[10 + m_fitflag].second.second[0]->Write();
   }
 }
 
 //-----------------------------------------------------------------------------
-void CastorLedAnalysis::LedDone() 
-{
+void CastorLedAnalysis::LedDone() {
+  // First process the last sample (remaining events).
+  if (evt % m_nevtsample != 0)
+    LedSampleAnalysis();
 
-// First process the last sample (remaining events).
-  if(evt%m_nevtsample!=0) LedSampleAnalysis();
-
-// Now do the end of run analysis: trending histos
-  if(sample>1 && m_fitflag!=4){
+  // Now do the end of run analysis: trending histos
+  if (sample > 1 && m_fitflag != 4) {
     m_file->cd();
     m_file->cd("Castor");
     LedTrendings(castorHists.LEDTRENDS);
@@ -480,84 +513,95 @@ void CastorLedAnalysis::LedDone()
   castorHists.LEDMEAN->Write();
 
   // Write the histo file and close it
-//  m_file->Write();
+  //  m_file->Write();
   m_file->Close();
   cout << "Castor histograms written to " << m_outputFileROOT.c_str() << endl;
 }
 
 //-----------------------------------------------------------------------------
-void CastorLedAnalysis::processLedEvent(const CastorDigiCollection& castor,
-					const CastorDbService& cond)
-{
+void CastorLedAnalysis::processLedEvent(const CastorDigiCollection& castor, const CastorDbService& cond) {
   evt++;
-  sample = (evt-1)/m_nevtsample +1;
-  evt_curr = evt%m_nevtsample;
-  if(evt_curr==0)evt_curr=m_nevtsample;
+  sample = (evt - 1) / m_nevtsample + 1;
+  evt_curr = evt % m_nevtsample;
+  if (evt_curr == 0)
+    evt_curr = m_nevtsample;
 
   // HF/Castor
-  try{
-    if(castor.empty()) throw (int)castor.size();
-    for (CastorDigiCollection::const_iterator j=castor.begin(); j!=castor.end(); ++j){
+  try {
+    if (castor.empty())
+      throw(int) castor.size();
+    for (CastorDigiCollection::const_iterator j = castor.begin(); j != castor.end(); ++j) {
       const CastorDataFrame digi = (const CastorDataFrame)(*j);
       _meol = castorHists.LEDTRENDS.find(digi.id());
-      if (_meol==castorHists.LEDTRENDS.end()){
-        SetupLEDHists(2,digi.id(),castorHists.LEDTRENDS);
+      if (_meol == castorHists.LEDTRENDS.end()) {
+        SetupLEDHists(2, digi.id(), castorHists.LEDTRENDS);
       }
-      LedCastorHists(digi.id(),digi,castorHists.LEDTRENDS,cond);
+      LedCastorHists(digi.id(), digi, castorHists.LEDTRENDS, cond);
     }
-  } 
-  catch (int i ) {
-//    m_logFile << "Event with " << i<<" Castor Digis passed." << std::endl;
-  } 
+  } catch (int i) {
+    //    m_logFile << "Event with " << i<<" Castor Digis passed." << std::endl;
+  }
 
   // Call the function every m_nevtsample events
-  if(evt%m_nevtsample==0) LedSampleAnalysis();
-
+  if (evt % m_nevtsample == 0)
+    LedSampleAnalysis();
 }
 //----------------------------------------------------------------------------
-void CastorLedAnalysis::SetupLEDHists(int id, const HcalDetId detid, map<HcalDetId, map<int,LEDBUNCH> > &toolT) {
-
+void CastorLedAnalysis::SetupLEDHists(int id, const HcalDetId detid, map<HcalDetId, map<int, LEDBUNCH> >& toolT) {
   string type = "HBHE";
-  if(id==1) type = "HO";
-  if(id==2) type = "HF";
+  if (id == 1)
+    type = "HO";
+  if (id == 2)
+    type = "HF";
 
   _meol = toolT.find(detid);
-  if (_meol==toolT.end()){
-// if histos for this channel do not exist, create them
-    map<int,LEDBUNCH> insert;
+  if (_meol == toolT.end()) {
+    // if histos for this channel do not exist, create them
+    map<int, LEDBUNCH> insert;
     char name[1024];
-    for(int i=0; i<10; i++){
-      sprintf(name,"%s Pulse height, eta=%d phi=%d depth=%d TS=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth(),i);
-      insert[i].first =  new TH1F(name,name,200,0.,2000.);
+    for (int i = 0; i < 10; i++) {
+      sprintf(name,
+              "%s Pulse height, eta=%d phi=%d depth=%d TS=%d",
+              type.c_str(),
+              detid.ieta(),
+              detid.iphi(),
+              detid.depth(),
+              i);
+      insert[i].first = new TH1F(name, name, 200, 0., 2000.);
     }
-    sprintf(name,"%s LED Mean pulse, eta=%d phi=%d depth=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());
-    insert[10].first =  new TH1F(name,name,10,-0.5,9.5);
-    sprintf(name,"%s LED Pulse, eta=%d phi=%d depth=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());
-    insert[11].first =  new TH1F(name,name,10,-0.5,9.5);
-    sprintf(name,"%s Mean TS, eta=%d phi=%d depth=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());
-    insert[12].first =  new TH1F(name,name,200,0.,10.);
-    sprintf(name,"%s Peak TS, eta=%d phi=%d depth=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());
-    insert[13].first =  new TH1F(name,name,200,0.,10.);
-    sprintf(name,"%s Peak TS error, eta=%d phi=%d depth=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());
-    insert[14].first =  new TH1F(name,name,200,0.,0.05);
-    sprintf(name,"%s Fit chi2, eta=%d phi=%d depth=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());
-    insert[15].first =  new TH1F(name,name,100,0.,50.);
-    sprintf(name,"%s Integrated Signal, eta=%d phi=%d depth=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());
-    insert[16].first =  new TH1F(name,name,500,0.,5000.);
+    sprintf(name, "%s LED Mean pulse, eta=%d phi=%d depth=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth());
+    insert[10].first = new TH1F(name, name, 10, -0.5, 9.5);
+    sprintf(name, "%s LED Pulse, eta=%d phi=%d depth=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth());
+    insert[11].first = new TH1F(name, name, 10, -0.5, 9.5);
+    sprintf(name, "%s Mean TS, eta=%d phi=%d depth=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth());
+    insert[12].first = new TH1F(name, name, 200, 0., 10.);
+    sprintf(name, "%s Peak TS, eta=%d phi=%d depth=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth());
+    insert[13].first = new TH1F(name, name, 200, 0., 10.);
+    sprintf(name, "%s Peak TS error, eta=%d phi=%d depth=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth());
+    insert[14].first = new TH1F(name, name, 200, 0., 0.05);
+    sprintf(name, "%s Fit chi2, eta=%d phi=%d depth=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth());
+    insert[15].first = new TH1F(name, name, 100, 0., 50.);
+    sprintf(
+        name, "%s Integrated Signal, eta=%d phi=%d depth=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth());
+    insert[16].first = new TH1F(name, name, 500, 0., 5000.);
 
     toolT[detid] = insert;
   }
 }
 //-----------------------------------------------------------------------------
-void CastorLedAnalysis::LedCastorHists(const HcalDetId& detid, const CastorDataFrame& ledDigi, map<HcalDetId, map<int,LEDBUNCH> > &toolT, const CastorDbService& cond) {
-
-  map<int,LEDBUNCH> _mei;
+void CastorLedAnalysis::LedCastorHists(const HcalDetId& detid,
+                                       const CastorDataFrame& ledDigi,
+                                       map<HcalDetId, map<int, LEDBUNCH> >& toolT,
+                                       const CastorDbService& cond) {
+  map<int, LEDBUNCH> _mei;
   _meol = toolT.find(detid);
   _mei = _meol->second;
   // Rest the histos if we're at the end of a 'bunch'
-  if((evt-1)%m_nevtsample==0 && state[0]){
-    for(int k=0; k<(int)state.size();k++) state[k]=false;
-    for(int i=0; i<16; i++) _mei[i].first->Reset();
+  if ((evt - 1) % m_nevtsample == 0 && state[0]) {
+    for (int k = 0; k < (int)state.size(); k++)
+      state[k] = false;
+    for (int i = 0; i < 16; i++)
+      _mei[i].first->Reset();
   }
 
   // now we have the signal in fC, let's get rid of that darn pedestal
@@ -569,25 +613,28 @@ void CastorLedAnalysis::LedCastorHists(const HcalDetId& detid, const CastorDataF
   m_ped = cond.getPedestal(detid);
   m_shape = cond.getCastorShape();
   //cout << "New Digi!!!!!!!!!!!!!!!!!!!!!!" << endl;
-  for (int TS = m_startTS; TS < m_endTS && TS < ledDigi.size(); TS++){
+  for (int TS = m_startTS; TS < m_endTS && TS < ledDigi.size(); TS++) {
     int capid = ledDigi[TS].capid();
     // BE CAREFUL: this is assuming peds are stored in ADCs
     int adc = (int)(ledDigi[TS].adc() - m_ped->getValue(capid));
-    if (adc < 0){ adc = 0; }  // to prevent negative adcs after ped subtraction, which should really only happen
-                              // if you're using the wrong peds.
-    double fC = m_coder->charge(*m_shape,adc,capid);
+    if (adc < 0) {
+      adc = 0;
+    }  // to prevent negative adcs after ped subtraction, which should really only happen
+       // if you're using the wrong peds.
+    double fC = m_coder->charge(*m_shape, adc, capid);
     //ta = (fC - m_ped->getValue(capid));
     ta = fC;
     //cout << "DetID: " << detid << "  CapID: " << capid << "  ADC: " << adc << "  Ped: " << m_ped->getValue(capid) << "  fC: " << fC << endl;
     _mei[TS].first->Fill(ta);
-    _mei[10].first->AddBinContent(TS+1,ta);  // This is average pulse, could probably do better (Profile?)
-    if(m_fitflag>1){
-      if(TS==m_startTS)_mei[11].first->Reset();
-      _mei[11].first->SetBinContent(TS+1,ta);
+    _mei[10].first->AddBinContent(TS + 1, ta);  // This is average pulse, could probably do better (Profile?)
+    if (m_fitflag > 1) {
+      if (TS == m_startTS)
+        _mei[11].first->Reset();
+      _mei[11].first->SetBinContent(TS + 1, ta);
     }
 
     // keep track of max TS and max amplitude (in fC)
-    if (ta > max_fC){
+    if (ta > max_fC) {
       max_fC = ta;
     }
   }
@@ -597,68 +644,66 @@ void CastorLedAnalysis::LedCastorHists(const HcalDetId& detid, const CastorDataF
   // we now want to use Phil's timing correction.  This is not necessary
   // if we are performing a Landau fit (m_fitflag = 3)
 
-  float sum=0.;
-  for(int i=0; i<10; i++)sum=sum+_mei[11].first->GetBinContent(i+1);
-  if(sum>100){
-    if(m_fitflag==2 || m_fitflag==4){
-      float timmean=_mei[11].first->GetMean();  // let's use Phil's way instead
-      float timmeancorr=BinsizeCorr(timmean);
+  float sum = 0.;
+  for (int i = 0; i < 10; i++)
+    sum = sum + _mei[11].first->GetBinContent(i + 1);
+  if (sum > 100) {
+    if (m_fitflag == 2 || m_fitflag == 4) {
+      float timmean = _mei[11].first->GetMean();  // let's use Phil's way instead
+      float timmeancorr = BinsizeCorr(timmean);
       _mei[12].first->Fill(timmeancorr);
     }
-    _mei[16].first->Fill(_mei[11].first->Integral()); // Integrated charge (may be more usfull to convert to Energy first?)
-    if(m_fitflag==3 || m_fitflag==4){
-      _mei[11].first->Fit("landau","Q");
-      TF1 *fit = _mei[11].first->GetFunction("landau");
+    _mei[16].first->Fill(
+        _mei[11].first->Integral());  // Integrated charge (may be more usfull to convert to Energy first?)
+    if (m_fitflag == 3 || m_fitflag == 4) {
+      _mei[11].first->Fit("landau", "Q");
+      TF1* fit = _mei[11].first->GetFunction("landau");
       _mei[13].first->Fill(fit->GetParameter(1));
       _mei[14].first->Fill(fit->GetParError(1));
-      _mei[15].first->Fill(fit->GetChisquare()/fit->GetNDF());
+      _mei[15].first->Fill(fit->GetChisquare() / fit->GetNDF());
     }
   }
-
-
-
 }
-
 
 //-----------------------------------------------------------------------------
 float CastorLedAnalysis::BinsizeCorr(float time) {
+  // this is the bin size correction to be applied for laser data (from Andy),
+  // it comes from a pulse shape measured from TB04 data (from Jordan)
+  // This should eventually be replaced with the more thorough treatment from Phil
 
-// this is the bin size correction to be applied for laser data (from Andy),
-// it comes from a pulse shape measured from TB04 data (from Jordan)
-// This should eventually be replaced with the more thorough treatment from Phil
+  float corrtime = 0.;
+  static const float tstrue[32] = {0.003, 0.03425, 0.06548, 0.09675, 0.128, 0.15925, 0.1905, 0.22175,
+                                   0.253, 0.28425, 0.3155,  0.34675, 0.378, 0.40925, 0.4405, 0.47175,
+                                   0.503, 0.53425, 0.5655,  0.59675, 0.628, 0.65925, 0.6905, 0.72175,
+                                   0.753, 0.78425, 0.8155,  0.84675, 0.878, 0.90925, 0.9405, 0.97175};
+  static const float tsreco[32] = {-0.00422, 0.01815, 0.04409, 0.07346, 0.09799, 0.12192, 0.15072, 0.18158,
+                                   0.21397,  0.24865, 0.28448, 0.31973, 0.35449, 0.39208, 0.43282, 0.47244,
+                                   0.5105,   0.55008, 0.58827, 0.62828, 0.6717,  0.70966, 0.74086, 0.77496,
+                                   0.80843,  0.83472, 0.86044, 0.8843,  0.90674, 0.92982, 0.95072, 0.9726};
 
-  float corrtime=0.;
-  static const float tstrue[32]={0.003, 0.03425, 0.06548, 0.09675, 0.128,
- 0.15925, 0.1905, 0.22175, 0.253, 0.28425, 0.3155, 0.34675, 0.378, 0.40925,
- 0.4405, 0.47175, 0.503, 0.53425, 0.5655, 0.59675, 0.628, 0.65925, 0.6905,
- 0.72175, 0.753, 0.78425, 0.8155, 0.84675, 0.878, 0.90925, 0.9405, 0.97175};
-  static const float tsreco[32]={-0.00422, 0.01815, 0.04409, 0.07346, 0.09799,
- 0.12192, 0.15072, 0.18158, 0.21397, 0.24865, 0.28448, 0.31973, 0.35449,
- 0.39208, 0.43282, 0.47244, 0.5105, 0.55008, 0.58827, 0.62828, 0.6717, 0.70966,
- 0.74086, 0.77496, 0.80843, 0.83472, 0.86044, 0.8843, 0.90674, 0.92982,
- 0.95072, 0.9726};
-
- int inttime=(int)time;
- float restime=time-inttime;
- for(int i=0; i<=32; i++) {
-   float lolim=0.; float uplim=1.; float tsdown; float tsup;
-   if(i>0){
-     lolim=tsreco[i-1];
-     tsdown=tstrue[i-1];
-   }
-   else tsdown=tstrue[31]-1.;
-   if(i<32){
-     uplim=tsreco[i];
-     tsup=tstrue[i];
-   }
-   else tsup=tstrue[0]+1.;
-   if(restime>=lolim && restime<uplim){
-      corrtime=(tsdown*(uplim-restime)+tsup*(restime-lolim)) / (uplim-lolim);
+  int inttime = (int)time;
+  float restime = time - inttime;
+  for (int i = 0; i <= 32; i++) {
+    float lolim = 0.;
+    float uplim = 1.;
+    float tsdown;
+    float tsup;
+    if (i > 0) {
+      lolim = tsreco[i - 1];
+      tsdown = tstrue[i - 1];
+    } else
+      tsdown = tstrue[31] - 1.;
+    if (i < 32) {
+      uplim = tsreco[i];
+      tsup = tstrue[i];
+    } else
+      tsup = tstrue[0] + 1.;
+    if (restime >= lolim && restime < uplim) {
+      corrtime = (tsdown * (uplim - restime) + tsup * (restime - lolim)) / (uplim - lolim);
     }
   }
-  corrtime+=inttime;
+  corrtime += inttime;
 
- return corrtime;
+  return corrtime;
 }
 //-----------------------------------------------------------------------------
-

--- a/CalibCalorimetry/CastorCalib/src/CastorLedAnalysis.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorLedAnalysis.cc
@@ -158,7 +158,7 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
   double dtime2=0; double dtime1=0; double dtime3=0; double dtime4=0;
   char output[100]{0};
 
-  if (m_outputFileText!=""){
+  if (!m_outputFileText.empty()){
     if(m_fitflag==0 || m_fitflag==2) m_outFile<<"Det Eta,Phi,D   Mean    Error"<<std::endl;
     else if(m_fitflag==1 || m_fitflag==3) m_outFile<<"Det Eta,Phi,D   Peak    Error"<<std::endl;
     else if(m_fitflag==4) m_outFile<<"Det Eta,Phi,D   Mean    Error      Peak    Error       MeanEv  Error       PeakEv  Error"<<std::endl;
@@ -225,7 +225,7 @@ void CastorLedAnalysis::GetLedConst(map<HcalDetId, map<int,LEDBUNCH> > &toolT){
 // Ascii printout (need to modify to include new info)
     HcalDetId detid = _meol->first;
 
-    if (m_outputFileText!=""){
+    if (!m_outputFileText.empty()){
       if(m_fitflag==0) {
 	m_outFile<<detid<<"   "<<time1<<" "<<dtime1<<std::endl;
         snprintf(output, sizeof output, "  <DATA_SET>");

--- a/CalibCalorimetry/CastorCalib/src/CastorPedestalAnalysis.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorPedestalAnalysis.cc
@@ -13,63 +13,69 @@
 using namespace std;
 
 CastorPedestalAnalysis::CastorPedestalAnalysis(const edm::ParameterSet& ps)
-  : fRefPedestals (nullptr),
-    fRefPedestalWidths (nullptr),
-    fRawPedestals (nullptr),
-    fRawPedestalWidths (nullptr),
-    fValPedestals (nullptr),
-    fValPedestalWidths (nullptr)
-{
-  evt=0;
-  sample=0;
-  m_file=nullptr;
-  m_AllPedsOK=0;
-  for(int i=0; i<4; i++) m_stat[i]=0;
-  for(int k=0;k<4;k++) state.push_back(true);
+    : fRefPedestals(nullptr),
+      fRefPedestalWidths(nullptr),
+      fRawPedestals(nullptr),
+      fRawPedestalWidths(nullptr),
+      fValPedestals(nullptr),
+      fValPedestalWidths(nullptr) {
+  evt = 0;
+  sample = 0;
+  m_file = nullptr;
+  m_AllPedsOK = 0;
+  for (int i = 0; i < 4; i++)
+    m_stat[i] = 0;
+  for (int k = 0; k < 4; k++)
+    state.push_back(true);
 
-// user cfg parameters
+  // user cfg parameters
   m_outputFileMean = ps.getUntrackedParameter<string>("outputFileMeans", "");
-  if ( !m_outputFileMean.empty() ) {
+  if (!m_outputFileMean.empty()) {
     cout << "Castor pedestal means will be saved to " << m_outputFileMean.c_str() << endl;
-  } 
-  m_outputFileWidth = ps.getUntrackedParameter<string>("outputFileWidths", "");
-  if ( !m_outputFileWidth.empty() ) {
-    cout << "Castor pedestal widths will be saved to " << m_outputFileWidth.c_str() << endl;
-  } 
-  m_outputFileROOT = ps.getUntrackedParameter<string>("outputFileHist", "");
-  if ( !m_outputFileROOT.empty() ) {
-    cout << "Castor pedestal histograms will be saved to " << m_outputFileROOT.c_str() << endl;
-  } 
-  m_nevtsample = ps.getUntrackedParameter<int>("nevtsample",0);
-// for compatibility with previous versions
-  if(m_nevtsample==9999999) m_nevtsample=0;
-  m_pedsinADC = ps.getUntrackedParameter<int>("pedsinADC",0);
-  m_hiSaveflag = ps.getUntrackedParameter<int>("hiSaveflag",0);
-  m_pedValflag = ps.getUntrackedParameter<int>("pedValflag",0);
-  if(m_pedValflag<0) m_pedValflag=0;
-  if (m_nevtsample>0 && m_pedValflag>0) {
-    cout<<"WARNING - incompatible cfg options: nevtsample = "<<m_nevtsample<<", pedValflag = "<<m_pedValflag<<endl;
-    cout<<"Setting pedValflag = 0"<<endl;
-    m_pedValflag=0;
   }
-  if(m_pedValflag>1) m_pedValflag=1;
+  m_outputFileWidth = ps.getUntrackedParameter<string>("outputFileWidths", "");
+  if (!m_outputFileWidth.empty()) {
+    cout << "Castor pedestal widths will be saved to " << m_outputFileWidth.c_str() << endl;
+  }
+  m_outputFileROOT = ps.getUntrackedParameter<string>("outputFileHist", "");
+  if (!m_outputFileROOT.empty()) {
+    cout << "Castor pedestal histograms will be saved to " << m_outputFileROOT.c_str() << endl;
+  }
+  m_nevtsample = ps.getUntrackedParameter<int>("nevtsample", 0);
+  // for compatibility with previous versions
+  if (m_nevtsample == 9999999)
+    m_nevtsample = 0;
+  m_pedsinADC = ps.getUntrackedParameter<int>("pedsinADC", 0);
+  m_hiSaveflag = ps.getUntrackedParameter<int>("hiSaveflag", 0);
+  m_pedValflag = ps.getUntrackedParameter<int>("pedValflag", 0);
+  if (m_pedValflag < 0)
+    m_pedValflag = 0;
+  if (m_nevtsample > 0 && m_pedValflag > 0) {
+    cout << "WARNING - incompatible cfg options: nevtsample = " << m_nevtsample << ", pedValflag = " << m_pedValflag
+         << endl;
+    cout << "Setting pedValflag = 0" << endl;
+    m_pedValflag = 0;
+  }
+  if (m_pedValflag > 1)
+    m_pedValflag = 1;
   m_startTS = ps.getUntrackedParameter<int>("firstTS", 0);
-  if(m_startTS<0) m_startTS=0;
+  if (m_startTS < 0)
+    m_startTS = 0;
   m_endTS = ps.getUntrackedParameter<int>("lastTS", 9);
 
-//  m_logFile.open("CastorPedestalAnalysis.log");
+  //  m_logFile.open("CastorPedestalAnalysis.log");
 
-  castorHists.ALLPEDS = new TH1F("Castor All Pedestals","HF All Peds",10,0,9);
-  castorHists.PEDRMS= new TH1F("Castor All Pedestal Widths","HF All Pedestal RMS",100,0,3);
-  castorHists.PEDMEAN= new TH1F("Castor All Pedestal Means","HF All Pedestal Means",100,0,9);
-  castorHists.CHI2= new TH1F("Castor Chi2/ndf for whole range Gauss fit","HF Chi2/ndf Gauss",200,0.,50.);
+  castorHists.ALLPEDS = new TH1F("Castor All Pedestals", "HF All Peds", 10, 0, 9);
+  castorHists.PEDRMS = new TH1F("Castor All Pedestal Widths", "HF All Pedestal RMS", 100, 0, 3);
+  castorHists.PEDMEAN = new TH1F("Castor All Pedestal Means", "HF All Pedestal Means", 100, 0, 9);
+  castorHists.CHI2 = new TH1F("Castor Chi2/ndf for whole range Gauss fit", "HF Chi2/ndf Gauss", 200, 0., 50.);
 }
 
 //-----------------------------------------------------------------------------
-CastorPedestalAnalysis::~CastorPedestalAnalysis(){
-
-  for(_meot=castorHists.PEDTRENDS.begin(); _meot!=castorHists.PEDTRENDS.end(); _meot++){
-    for(int i=0; i<16; i++) _meot->second[i].first->Delete();
+CastorPedestalAnalysis::~CastorPedestalAnalysis() {
+  for (_meot = castorHists.PEDTRENDS.begin(); _meot != castorHists.PEDTRENDS.end(); _meot++) {
+    for (int i = 0; i < 16; i++)
+      _meot->second[i].first->Delete();
   }
 
   castorHists.ALLPEDS->Delete();
@@ -81,63 +87,76 @@ CastorPedestalAnalysis::~CastorPedestalAnalysis(){
 //-----------------------------------------------------------------------------
 void CastorPedestalAnalysis::setup(const std::string& m_outputFileROOT) {
   // open the histogram file, create directories within
-  m_file=new TFile(m_outputFileROOT.c_str(),"RECREATE");
+  m_file = new TFile(m_outputFileROOT.c_str(), "RECREATE");
   m_file->mkdir("Castor");
   m_file->cd();
 }
 
 //-----------------------------------------------------------------------------
-void CastorPedestalAnalysis::processEvent(const CastorDigiCollection& castor,
-					const CastorDbService& cond)
-{
+void CastorPedestalAnalysis::processEvent(const CastorDigiCollection& castor, const CastorDbService& cond) {
   evt++;
-  sample=1;
-  evt_curr=evt;
-  if(m_nevtsample>0) {
-    sample = (evt-1)/m_nevtsample +1;
-    evt_curr = evt%m_nevtsample;
-    if(evt_curr==0)evt_curr=m_nevtsample;
+  sample = 1;
+  evt_curr = evt;
+  if (m_nevtsample > 0) {
+    sample = (evt - 1) / m_nevtsample + 1;
+    evt_curr = evt % m_nevtsample;
+    if (evt_curr == 0)
+      evt_curr = m_nevtsample;
   }
 
   m_shape = cond.getCastorShape();
   // HF
-  try{
-    if(castor.empty()) throw (int)castor.size();
-    for (CastorDigiCollection::const_iterator j=castor.begin(); j!=castor.end(); ++j){
+  try {
+    if (castor.empty())
+      throw(int) castor.size();
+    for (CastorDigiCollection::const_iterator j = castor.begin(); j != castor.end(); ++j) {
       const CastorDataFrame digi = (const CastorDataFrame)(*j);
       m_coder = cond.getCastorCoder(digi.id());
-      for (int i=m_startTS; i<digi.size() && i<=m_endTS; i++) {
-        for(int flag=0; flag<4; flag++){
-          if(i+flag<digi.size() && i+flag<=m_endTS){
-            per2CapsHists(flag,2,digi.id(),digi.sample(i),digi.sample(i+flag),castorHists.PEDTRENDS,cond);
+      for (int i = m_startTS; i < digi.size() && i <= m_endTS; i++) {
+        for (int flag = 0; flag < 4; flag++) {
+          if (i + flag < digi.size() && i + flag <= m_endTS) {
+            per2CapsHists(flag, 2, digi.id(), digi.sample(i), digi.sample(i + flag), castorHists.PEDTRENDS, cond);
           }
         }
       }
-      if(m_startTS==0 && m_endTS>4){
-        AllChanHists(digi.id(),digi.sample(0),digi.sample(1),digi.sample(2),digi.sample(3),digi.sample(4),digi.sample(5),castorHists.PEDTRENDS);
+      if (m_startTS == 0 && m_endTS > 4) {
+        AllChanHists(digi.id(),
+                     digi.sample(0),
+                     digi.sample(1),
+                     digi.sample(2),
+                     digi.sample(3),
+                     digi.sample(4),
+                     digi.sample(5),
+                     castorHists.PEDTRENDS);
       }
     }
-  } 
-  catch (int i ) {
-//    m_logFile << "Event with " << i<<" Castor Digis passed." << std::endl;
-  } 
+  } catch (int i) {
+    //    m_logFile << "Event with " << i<<" Castor Digis passed." << std::endl;
+  }
   // Call the function every m_nevtsample events
-  if(m_nevtsample>0) {
-    if(evt%m_nevtsample==0) SampleAnalysis();
+  if (m_nevtsample > 0) {
+    if (evt % m_nevtsample == 0)
+      SampleAnalysis();
   }
 }
 
 //-----------------------------------------------------------------------------
-void CastorPedestalAnalysis::per2CapsHists(int flag, int id, const HcalDetId detid, const HcalQIESample& qie1, const HcalQIESample& qie2, map<HcalDetId, map<int,PEDBUNCH> > &toolT, const CastorDbService& cond) {
+void CastorPedestalAnalysis::per2CapsHists(int flag,
+                                           int id,
+                                           const HcalDetId detid,
+                                           const HcalQIESample& qie1,
+                                           const HcalQIESample& qie2,
+                                           map<HcalDetId, map<int, PEDBUNCH> >& toolT,
+                                           const CastorDbService& cond) {
+  // this function is due to be called for every time slice, it fills either a charge
+  // histo for a single capID (flag=0) or a product histo for two capIDs (flag>0)
 
-// this function is due to be called for every time slice, it fills either a charge
-// histo for a single capID (flag=0) or a product histo for two capIDs (flag>0)
-
-  static const int bins=10;
-  static const int bins2=100;
-  float lo=-0.5; float hi=9.5;
-  map<int,PEDBUNCH> _mei;
-  static map<HcalDetId, map<int,float> > QieCalibMap;
+  static const int bins = 10;
+  static const int bins2 = 100;
+  float lo = -0.5;
+  float hi = 9.5;
+  map<int, PEDBUNCH> _mei;
+  static map<HcalDetId, map<int, float> > QieCalibMap;
   string type = "Castor";
 
   /*
@@ -155,79 +174,109 @@ void CastorPedestalAnalysis::per2CapsHists(int flag, int id, const HcalDetId det
 
   _meot = toolT.find(detid);
 
-// if histos for the current channel do not exist, first create them,
-  if (_meot==toolT.end()){
-    map<int,PEDBUNCH> insert;
-    map<int,float> qiecalib;
+  // if histos for the current channel do not exist, first create them,
+  if (_meot == toolT.end()) {
+    map<int, PEDBUNCH> insert;
+    map<int, float> qiecalib;
     char name[1024];
-    for(int i=0; i<4; i++){
-      lo=-0.5;
+    for (int i = 0; i < 4; i++) {
+      lo = -0.5;
       // fix from Andy: if you convert to fC and then bin in units of 1, you may 'skip' a bin while
       // filling, since the ADCs are quantized
-      if (m_pedsinADC) hi=9.5;
-      else hi = 11.5;
-      sprintf(name,"%s Pedestal, eta=%d phi=%d d=%d cap=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth(),i);  
-      insert[i].first =  new TH1F(name,name,bins,lo,hi);
-      sprintf(name,"%s Product, eta=%d phi=%d d=%d caps=%d*%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth(),i,(i+1)%4);  
-      insert[4+i].first = new TH1F(name,name,bins2,0.,100.);
-      sprintf(name,"%s Product, eta=%d phi=%d d=%d caps=%d*%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth(),i,(i+2)%4);  
-      insert[8+i].first = new TH1F(name,name,bins2,0.,100.);
-      sprintf(name,"%s Product, eta=%d phi=%d d=%d caps=%d*%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth(),i,(i+3)%4);  
-      insert[12+i].first = new TH1F(name,name,bins2,0.,100.);
+      if (m_pedsinADC)
+        hi = 9.5;
+      else
+        hi = 11.5;
+      sprintf(
+          name, "%s Pedestal, eta=%d phi=%d d=%d cap=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth(), i);
+      insert[i].first = new TH1F(name, name, bins, lo, hi);
+      sprintf(name,
+              "%s Product, eta=%d phi=%d d=%d caps=%d*%d",
+              type.c_str(),
+              detid.ieta(),
+              detid.iphi(),
+              detid.depth(),
+              i,
+              (i + 1) % 4);
+      insert[4 + i].first = new TH1F(name, name, bins2, 0., 100.);
+      sprintf(name,
+              "%s Product, eta=%d phi=%d d=%d caps=%d*%d",
+              type.c_str(),
+              detid.ieta(),
+              detid.iphi(),
+              detid.depth(),
+              i,
+              (i + 2) % 4);
+      insert[8 + i].first = new TH1F(name, name, bins2, 0., 100.);
+      sprintf(name,
+              "%s Product, eta=%d phi=%d d=%d caps=%d*%d",
+              type.c_str(),
+              detid.ieta(),
+              detid.iphi(),
+              detid.depth(),
+              i,
+              (i + 3) % 4);
+      insert[12 + i].first = new TH1F(name, name, bins2, 0., 100.);
     }
-    sprintf(name,"%s Signal in TS 4+5, eta=%d phi=%d d=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());  
-    insert[16].first = new TH1F(name,name,21,-0.5,20.5);
-    sprintf(name,"%s Signal in TS 4+5-2-3, eta=%d phi=%d d=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());  
-    insert[17].first = new TH1F(name,name,21,-10.5,10.5);
-    sprintf(name,"%s Signal in TS 4+5-(0+1+2+3)/2., eta=%d phi=%d d=%d",type.c_str(),detid.ieta(),detid.iphi(),detid.depth());  
-    insert[18].first = new TH1F(name,name,21,-10.5,10.5);
+    sprintf(name, "%s Signal in TS 4+5, eta=%d phi=%d d=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth());
+    insert[16].first = new TH1F(name, name, 21, -0.5, 20.5);
+    sprintf(
+        name, "%s Signal in TS 4+5-2-3, eta=%d phi=%d d=%d", type.c_str(), detid.ieta(), detid.iphi(), detid.depth());
+    insert[17].first = new TH1F(name, name, 21, -10.5, 10.5);
+    sprintf(name,
+            "%s Signal in TS 4+5-(0+1+2+3)/2., eta=%d phi=%d d=%d",
+            type.c_str(),
+            detid.ieta(),
+            detid.iphi(),
+            detid.depth());
+    insert[18].first = new TH1F(name, name, 21, -10.5, 10.5);
     toolT[detid] = insert;
     _meot = toolT.find(detid);
-// store QIE calibrations in a map for later reuse
-    QieCalibMap[detid]=qiecalib;
+    // store QIE calibrations in a map for later reuse
+    QieCalibMap[detid] = qiecalib;
   }
 
   _mei = _meot->second;
 
   const CastorQIECoder* coder = cond.getCastorCoder(detid);
   const CastorQIEShape* shape = cond.getCastorShape();
-  float charge1 = coder->charge(*shape,qie1.adc(),qie1.capid());
-  float charge2 = coder->charge(*shape,qie2.adc(),qie2.capid());
+  float charge1 = coder->charge(*shape, qie1.adc(), qie1.capid());
+  float charge2 = coder->charge(*shape, qie2.adc(), qie2.capid());
 
-// fill single capID histo
-  if(flag==0){
-    if(m_nevtsample>0) {
-      if((evt-1)%m_nevtsample==0 && state[qie1.capid()]){
-        state[qie1.capid()]=false; 
+  // fill single capID histo
+  if (flag == 0) {
+    if (m_nevtsample > 0) {
+      if ((evt - 1) % m_nevtsample == 0 && state[qie1.capid()]) {
+        state[qie1.capid()] = false;
         _mei[qie1.capid()].first->Reset();
-        _mei[qie1.capid()+4].first->Reset();
-        _mei[qie1.capid()+8].first->Reset();
-        _mei[qie1.capid()+12].first->Reset();
+        _mei[qie1.capid() + 4].first->Reset();
+        _mei[qie1.capid() + 8].first->Reset();
+        _mei[qie1.capid() + 12].first->Reset();
       }
     }
-    if (qie1.adc()<bins){
-      if (m_pedsinADC) _mei[qie1.capid()].first->Fill(qie1.adc());
-      else _mei[qie1.capid()].first->Fill(charge1); 
-    }
-    else if(qie1.adc()>=bins){
-      _mei[qie1.capid()].first->AddBinContent(bins+1,1);
+    if (qie1.adc() < bins) {
+      if (m_pedsinADC)
+        _mei[qie1.capid()].first->Fill(qie1.adc());
+      else
+        _mei[qie1.capid()].first->Fill(charge1);
+    } else if (qie1.adc() >= bins) {
+      _mei[qie1.capid()].first->AddBinContent(bins + 1, 1);
     }
   }
 
-// fill 2 capID histo
-  if(flag>0){
-    map<int,float> qiecalib = QieCalibMap[detid];
+  // fill 2 capID histo
+  if (flag > 0) {
+    map<int, float> qiecalib = QieCalibMap[detid];
     //float charge1=(qie1.adc()-qiecalib[qie1.capid()+4])/qiecalib[qie1.capid()];
     //float charge2=(qie2.adc()-qiecalib[qie2.capid()+4])/qiecalib[qie2.capid()];
-    if (charge1*charge2<bins2){
-      _mei[qie1.capid()+4*flag].first->Fill(charge1*charge2);
-    }
-    else{
-      _mei[qie1.capid()+4*flag].first->Fill(bins2);
+    if (charge1 * charge2 < bins2) {
+      _mei[qie1.capid() + 4 * flag].first->Fill(charge1 * charge2);
+    } else {
+      _mei[qie1.capid() + 4 * flag].first->Fill(bins2);
     }
   }
 
-  if(flag==0){
+  if (flag == 0) {
     //    if(id==0) hbHists.ALLPEDS->Fill(qie1.adc());
     //   else if(id==1) hoHists.ALLPEDS->Fill(qie1.adc());
     //   else if(id==2) castorHists.ALLPEDS->Fill(qie1.adc());
@@ -236,77 +285,87 @@ void CastorPedestalAnalysis::per2CapsHists(int flag, int id, const HcalDetId det
 }
 
 //-----------------------------------------------------------------------------
-void CastorPedestalAnalysis::AllChanHists(const HcalDetId detid, const HcalQIESample& qie0, const HcalQIESample& qie1, const HcalQIESample& qie2, const HcalQIESample& qie3, const HcalQIESample& qie4, const HcalQIESample& qie5, map<HcalDetId, map<int,PEDBUNCH> > &toolT) { 
-
-// this function is due to be called for every channel
+void CastorPedestalAnalysis::AllChanHists(const HcalDetId detid,
+                                          const HcalQIESample& qie0,
+                                          const HcalQIESample& qie1,
+                                          const HcalQIESample& qie2,
+                                          const HcalQIESample& qie3,
+                                          const HcalQIESample& qie4,
+                                          const HcalQIESample& qie5,
+                                          map<HcalDetId, map<int, PEDBUNCH> >& toolT) {
+  // this function is due to be called for every channel
 
   _meot = toolT.find(detid);
-  map<int,PEDBUNCH> _mei = _meot->second;
-  _mei[16].first->Fill(qie4.adc()+qie5.adc()-1.);
-  _mei[17].first->Fill(qie4.adc()+qie5.adc()-qie2.adc()-qie3.adc());
-  _mei[18].first->Fill(qie4.adc()+qie5.adc()-(qie0.adc()+qie1.adc()+qie2.adc()+qie3.adc())/2.);
+  map<int, PEDBUNCH> _mei = _meot->second;
+  _mei[16].first->Fill(qie4.adc() + qie5.adc() - 1.);
+  _mei[17].first->Fill(qie4.adc() + qie5.adc() - qie2.adc() - qie3.adc());
+  _mei[18].first->Fill(qie4.adc() + qie5.adc() - (qie0.adc() + qie1.adc() + qie2.adc() + qie3.adc()) / 2.);
 }
 
 //-----------------------------------------------------------------------------
-void CastorPedestalAnalysis::SampleAnalysis(){
+void CastorPedestalAnalysis::SampleAnalysis() {
   // it is called every m_nevtsample events (a sample) and the end of run
   char PedSampleNum[20];
 
-// Compute pedestal constants for each HBHE, HO, HF
-  sprintf(PedSampleNum,"Castor_Sample%d",sample);
+  // Compute pedestal constants for each HBHE, HO, HF
+  sprintf(PedSampleNum, "Castor_Sample%d", sample);
   m_file->cd();
   m_file->mkdir(PedSampleNum);
   m_file->cd(PedSampleNum);
-  GetPedConst(castorHists.PEDTRENDS,castorHists.PEDMEAN,castorHists.PEDRMS);
+  GetPedConst(castorHists.PEDTRENDS, castorHists.PEDMEAN, castorHists.PEDRMS);
 }
 
 //-----------------------------------------------------------------------------
-void CastorPedestalAnalysis::GetPedConst(map<HcalDetId, map<int,PEDBUNCH> > &toolT, TH1F* PedMeans, TH1F* PedWidths)
-{
-// Completely rewritten version oct 2006
-// Compute pedestal constants and fill into CastorPedestals and CastorPedestalWidths objects
-  float cap[4]; float sig[4][4]; float dcap[4]; float dsig[4][4]; float chi2[4];
+void CastorPedestalAnalysis::GetPedConst(map<HcalDetId, map<int, PEDBUNCH> >& toolT, TH1F* PedMeans, TH1F* PedWidths) {
+  // Completely rewritten version oct 2006
+  // Compute pedestal constants and fill into CastorPedestals and CastorPedestalWidths objects
+  float cap[4];
+  float sig[4][4];
+  float dcap[4];
+  float dsig[4][4];
+  float chi2[4];
 
-  for(_meot=toolT.begin(); _meot!=toolT.end(); _meot++){
+  for (_meot = toolT.begin(); _meot != toolT.end(); _meot++) {
     HcalDetId detid = _meot->first;
 
-// take mean and width from a Gaussian fit or directly from the histo
-    if(fitflag>0){
-      for (int i=0; i<4; i++) {
-        TF1 *fit = _meot->second[i].first->GetFunction("gaus");
-        chi2[i]=0;
-        if(fit->GetNDF()!=0) chi2[i]=fit->GetChisquare()/fit->GetNDF();
-        cap[i]=fit->GetParameter(1);
-        sig[i][i]=fit->GetParameter(2);
-        dcap[i]=fit->GetParError(1);
-        dsig[i][i]=fit->GetParError(2);
+    // take mean and width from a Gaussian fit or directly from the histo
+    if (fitflag > 0) {
+      for (int i = 0; i < 4; i++) {
+        TF1* fit = _meot->second[i].first->GetFunction("gaus");
+        chi2[i] = 0;
+        if (fit->GetNDF() != 0)
+          chi2[i] = fit->GetChisquare() / fit->GetNDF();
+        cap[i] = fit->GetParameter(1);
+        sig[i][i] = fit->GetParameter(2);
+        dcap[i] = fit->GetParError(1);
+        dsig[i][i] = fit->GetParError(2);
       }
-    }
-    else{
-      for (int i=0; i<4; i++) {
-        cap[i]=_meot->second[i].first->GetMean();
-        sig[i][i]=_meot->second[i].first->GetRMS();
-        m_stat[i]=0;
+    } else {
+      for (int i = 0; i < 4; i++) {
+        cap[i] = _meot->second[i].first->GetMean();
+        sig[i][i] = _meot->second[i].first->GetRMS();
+        m_stat[i] = 0;
 
-        for(int j=m_startTS; j<m_endTS+1; j++){
-          m_stat[i]+=_meot->second[i].first->GetBinContent(j+1);
+        for (int j = m_startTS; j < m_endTS + 1; j++) {
+          m_stat[i] += _meot->second[i].first->GetBinContent(j + 1);
         }
-        dcap[i] = sig[i][i]/sqrt(m_stat[i]);
-//        dsig[i][i] = dcap[i]*sig[i][i]/cap[i];
-        dsig[i][i] = sig[i][i]/sqrt(2.*m_stat[i]);
-        chi2[i]=0.;
+        dcap[i] = sig[i][i] / sqrt(m_stat[i]);
+        //        dsig[i][i] = dcap[i]*sig[i][i]/cap[i];
+        dsig[i][i] = sig[i][i] / sqrt(2. * m_stat[i]);
+        chi2[i] = 0.;
       }
     }
 
-    for (int i=0; i<4; i++) {
-      if(m_hiSaveflag>0) {
+    for (int i = 0; i < 4; i++) {
+      if (m_hiSaveflag > 0) {
         if (m_pedsinADC)
-        _meot->second[i].first->GetXaxis()->SetTitle("ADC");
-        else _meot->second[i].first->GetXaxis()->SetTitle("Charge, fC");
+          _meot->second[i].first->GetXaxis()->SetTitle("ADC");
+        else
+          _meot->second[i].first->GetXaxis()->SetTitle("Charge, fC");
         _meot->second[i].first->GetYaxis()->SetTitle("CapID samplings");
         _meot->second[i].first->Write();
       }
-      if(m_nevtsample>0) {
+      if (m_nevtsample > 0) {
         _meot->second[i].second.first[0].push_back(cap[i]);
         _meot->second[i].second.first[1].push_back(dcap[i]);
         _meot->second[i].second.first[2].push_back(sig[i][i]);
@@ -317,93 +376,97 @@ void CastorPedestalAnalysis::GetPedConst(map<HcalDetId, map<int,PEDBUNCH> > &too
       PedWidths->Fill(sig[i][i]);
     }
 
-// special histos for Shuichi
-    if(m_hiSaveflag==-100){
-      for(int i=16; i<19; i++){
+    // special histos for Shuichi
+    if (m_hiSaveflag == -100) {
+      for (int i = 16; i < 19; i++) {
         if (m_pedsinADC)
-        _meot->second[i].first->GetXaxis()->SetTitle("ADC");
-        else _meot->second[i].first->GetXaxis()->SetTitle("Charge, fC");
+          _meot->second[i].first->GetXaxis()->SetTitle("ADC");
+        else
+          _meot->second[i].first->GetXaxis()->SetTitle("Charge, fC");
         _meot->second[i].first->GetYaxis()->SetTitle("Events");
         _meot->second[i].first->Write();
       }
     }
 
-// diagonal sigma is width squared
-    sig[0][0]=sig[0][0]*sig[0][0];
-    sig[1][1]=sig[1][1]*sig[1][1];
-    sig[2][2]=sig[2][2]*sig[2][2];
-    sig[3][3]=sig[3][3]*sig[3][3];
+    // diagonal sigma is width squared
+    sig[0][0] = sig[0][0] * sig[0][0];
+    sig[1][1] = sig[1][1] * sig[1][1];
+    sig[2][2] = sig[2][2] * sig[2][2];
+    sig[3][3] = sig[3][3] * sig[3][3];
 
-// off diagonal sigmas (correlations) are computed from 3 histograms
-// here we still have all 4*3=12 combinations
-    sig[0][1]= _meot->second[4].first->GetMean()-cap[0]*cap[1];
-    sig[0][2]= _meot->second[8].first->GetMean()-cap[0]*cap[2];
-    sig[1][2]= _meot->second[5].first->GetMean()-cap[1]*cap[2];
-    sig[1][3]= _meot->second[9].first->GetMean()-cap[1]*cap[3];
-    sig[2][3]= _meot->second[6].first->GetMean()-cap[2]*cap[3];
-    sig[0][3]= _meot->second[12].first->GetMean()-cap[0]*cap[3];
-    sig[1][0]= _meot->second[13].first->GetMean()-cap[1]*cap[0];
-    sig[2][0]= _meot->second[10].first->GetMean()-cap[2]*cap[0];
-    sig[2][1]= _meot->second[14].first->GetMean()-cap[2]*cap[1];
-    sig[3][1]= _meot->second[11].first->GetMean()-cap[3]*cap[1];
-    sig[3][2]= _meot->second[15].first->GetMean()-cap[3]*cap[2];
-    sig[3][0]= _meot->second[7].first->GetMean()-cap[3]*cap[0];
+    // off diagonal sigmas (correlations) are computed from 3 histograms
+    // here we still have all 4*3=12 combinations
+    sig[0][1] = _meot->second[4].first->GetMean() - cap[0] * cap[1];
+    sig[0][2] = _meot->second[8].first->GetMean() - cap[0] * cap[2];
+    sig[1][2] = _meot->second[5].first->GetMean() - cap[1] * cap[2];
+    sig[1][3] = _meot->second[9].first->GetMean() - cap[1] * cap[3];
+    sig[2][3] = _meot->second[6].first->GetMean() - cap[2] * cap[3];
+    sig[0][3] = _meot->second[12].first->GetMean() - cap[0] * cap[3];
+    sig[1][0] = _meot->second[13].first->GetMean() - cap[1] * cap[0];
+    sig[2][0] = _meot->second[10].first->GetMean() - cap[2] * cap[0];
+    sig[2][1] = _meot->second[14].first->GetMean() - cap[2] * cap[1];
+    sig[3][1] = _meot->second[11].first->GetMean() - cap[3] * cap[1];
+    sig[3][2] = _meot->second[15].first->GetMean() - cap[3] * cap[2];
+    sig[3][0] = _meot->second[7].first->GetMean() - cap[3] * cap[0];
 
-// there is no proper error calculation for the correlation coefficients
-    for(int i=0; i<4; i++){
-      if(m_nevtsample>0) {
-        _meot->second[i].second.first[5].push_back(sig[i][(i+1)%4]);
-        _meot->second[i].second.first[6].push_back(2*sig[i][i]*dsig[i][i]);
-        _meot->second[i].second.first[7].push_back(sig[i][(i+2)%4]);
-        _meot->second[i].second.first[8].push_back(2*sig[i][i]*dsig[i][i]);
-        _meot->second[i].second.first[9].push_back(sig[i][(i+3)%4]);
-        _meot->second[i].second.first[10].push_back(2*sig[i][i]*dsig[i][i]);
+    // there is no proper error calculation for the correlation coefficients
+    for (int i = 0; i < 4; i++) {
+      if (m_nevtsample > 0) {
+        _meot->second[i].second.first[5].push_back(sig[i][(i + 1) % 4]);
+        _meot->second[i].second.first[6].push_back(2 * sig[i][i] * dsig[i][i]);
+        _meot->second[i].second.first[7].push_back(sig[i][(i + 2) % 4]);
+        _meot->second[i].second.first[8].push_back(2 * sig[i][i] * dsig[i][i]);
+        _meot->second[i].second.first[9].push_back(sig[i][(i + 3) % 4]);
+        _meot->second[i].second.first[10].push_back(2 * sig[i][i] * dsig[i][i]);
       }
-// save product histos if desired
-      if(m_hiSaveflag>10) {
+      // save product histos if desired
+      if (m_hiSaveflag > 10) {
         if (m_pedsinADC)
-        _meot->second[i+4].first->GetXaxis()->SetTitle("ADC^2");
-        else _meot->second[i+4].first->GetXaxis()->SetTitle("Charge^2, fC^2");
-        _meot->second[i+4].first->GetYaxis()->SetTitle("2-CapID samplings");
-        _meot->second[i+4].first->Write();
+          _meot->second[i + 4].first->GetXaxis()->SetTitle("ADC^2");
+        else
+          _meot->second[i + 4].first->GetXaxis()->SetTitle("Charge^2, fC^2");
+        _meot->second[i + 4].first->GetYaxis()->SetTitle("2-CapID samplings");
+        _meot->second[i + 4].first->Write();
         if (m_pedsinADC)
-        _meot->second[i+8].first->GetXaxis()->SetTitle("ADC^2");
-        else _meot->second[i+8].first->GetXaxis()->SetTitle("Charge^2, fC^2");
-        _meot->second[i+8].first->GetYaxis()->SetTitle("2-CapID samplings");
-        _meot->second[i+8].first->Write();
+          _meot->second[i + 8].first->GetXaxis()->SetTitle("ADC^2");
+        else
+          _meot->second[i + 8].first->GetXaxis()->SetTitle("Charge^2, fC^2");
+        _meot->second[i + 8].first->GetYaxis()->SetTitle("2-CapID samplings");
+        _meot->second[i + 8].first->Write();
         if (m_pedsinADC)
-        _meot->second[i+12].first->GetXaxis()->SetTitle("ADC^2");
-        else _meot->second[i+12].first->GetXaxis()->SetTitle("Charge^2, fC^2");
-        _meot->second[i+12].first->GetYaxis()->SetTitle("2-CapID samplings");
-        _meot->second[i+12].first->Write();
+          _meot->second[i + 12].first->GetXaxis()->SetTitle("ADC^2");
+        else
+          _meot->second[i + 12].first->GetXaxis()->SetTitle("Charge^2, fC^2");
+        _meot->second[i + 12].first->GetYaxis()->SetTitle("2-CapID samplings");
+        _meot->second[i + 12].first->Write();
       }
     }
 
-// fill the objects - at this point only close and medium correlations are stored
-// and the matrix is assumed symmetric
-    if (m_nevtsample<1) {
-      sig[1][0]=sig[0][1];
-      sig[2][0]=sig[0][2];
-      sig[2][1]=sig[1][2];
-      sig[3][1]=sig[1][3];
-      sig[3][2]=sig[2][3];
-      sig[0][3]=sig[3][0];
+    // fill the objects - at this point only close and medium correlations are stored
+    // and the matrix is assumed symmetric
+    if (m_nevtsample < 1) {
+      sig[1][0] = sig[0][1];
+      sig[2][0] = sig[0][2];
+      sig[2][1] = sig[1][2];
+      sig[3][1] = sig[1][3];
+      sig[3][2] = sig[2][3];
+      sig[0][3] = sig[3][0];
       if (fRawPedestals) {
-	  CastorPedestal item(detid,cap[0],cap[1],cap[2],cap[3]);
-          fRawPedestals->addValues(item);
+        CastorPedestal item(detid, cap[0], cap[1], cap[2], cap[3]);
+        fRawPedestals->addValues(item);
       }
       if (fRawPedestalWidths) {
         CastorPedestalWidth widthsp(detid);
-        widthsp.setSigma(0,0,sig[0][0]);
-        widthsp.setSigma(0,1,sig[0][1]);
-        widthsp.setSigma(0,2,sig[0][2]);
-        widthsp.setSigma(1,1,sig[1][1]);
-        widthsp.setSigma(1,2,sig[1][2]);
-        widthsp.setSigma(1,3,sig[1][3]);
-        widthsp.setSigma(2,2,sig[2][2]);
-        widthsp.setSigma(2,3,sig[2][3]);
-        widthsp.setSigma(3,3,sig[3][3]);
-        widthsp.setSigma(3,0,sig[0][3]);
+        widthsp.setSigma(0, 0, sig[0][0]);
+        widthsp.setSigma(0, 1, sig[0][1]);
+        widthsp.setSigma(0, 2, sig[0][2]);
+        widthsp.setSigma(1, 1, sig[1][1]);
+        widthsp.setSigma(1, 2, sig[1][2]);
+        widthsp.setSigma(1, 3, sig[1][3]);
+        widthsp.setSigma(2, 2, sig[2][2]);
+        widthsp.setSigma(2, 3, sig[2][3]);
+        widthsp.setSigma(3, 3, sig[3][3]);
+        widthsp.setSigma(3, 0, sig[0][3]);
         fRawPedestalWidths->addValues(widthsp);
       }
     }
@@ -411,64 +474,67 @@ void CastorPedestalAnalysis::GetPedConst(map<HcalDetId, map<int,PEDBUNCH> > &too
 }
 
 //-----------------------------------------------------------------------------
-int CastorPedestalAnalysis::done(const CastorPedestals* fInputPedestals, 
-				const CastorPedestalWidths* fInputPedestalWidths,
-				CastorPedestals* fOutputPedestals, 
-				CastorPedestalWidths* fOutputPedestalWidths)
-{
-   int nstat[4];
+int CastorPedestalAnalysis::done(const CastorPedestals* fInputPedestals,
+                                 const CastorPedestalWidths* fInputPedestalWidths,
+                                 CastorPedestals* fOutputPedestals,
+                                 CastorPedestalWidths* fOutputPedestalWidths) {
+  int nstat[4];
 
-// Pedestal objects
+  // Pedestal objects
   // inputs...
   fRefPedestals = fInputPedestals;
   fRefPedestalWidths = fInputPedestalWidths;
-  
+
   // outputs...
-  if(m_pedValflag>0) {
+  if (m_pedValflag > 0) {
     fValPedestals = fOutputPedestals;
     fValPedestalWidths = fOutputPedestalWidths;
     fRawPedestals = new CastorPedestals();
     fRawPedestalWidths = new CastorPedestalWidths();
-  }
-  else {
+  } else {
     fRawPedestals = fOutputPedestals;
     fRawPedestalWidths = fOutputPedestalWidths;
     fValPedestals = new CastorPedestals();
     fValPedestalWidths = new CastorPedestalWidths();
   }
 
-// compute pedestal constants
-  if(m_nevtsample<1) SampleAnalysis();
-  if(m_nevtsample>0) {
-    if(evt%m_nevtsample!=0) SampleAnalysis();
+  // compute pedestal constants
+  if (m_nevtsample < 1)
+    SampleAnalysis();
+  if (m_nevtsample > 0) {
+    if (evt % m_nevtsample != 0)
+      SampleAnalysis();
   }
 
-// trending histos
-  if(m_nevtsample>0){
+  // trending histos
+  if (m_nevtsample > 0) {
     m_file->cd();
     m_file->cd("Castor");
-    Trendings(castorHists.PEDTRENDS,castorHists.CHI2,castorHists.CAPID_AVERAGE,castorHists.CAPID_CHI2);
+    Trendings(castorHists.PEDTRENDS, castorHists.CHI2, castorHists.CAPID_AVERAGE, castorHists.CAPID_CHI2);
   }
 
-  if (m_nevtsample<1) {
-
-// pedestal validation: m_AllPedsOK=-1 means not validated,
-//                                   0 everything OK,
-//                                   N>0 : mod(N,100000) drifts + width changes
-//                                         int(N/100000) missing channels
-    m_AllPedsOK=-1;
-    if(m_pedValflag>0) {
-      for (int i=0; i<4; i++) nstat[i]=(int)m_stat[i];
-      int NPedErrors=CastorPedVal(nstat,fRefPedestals,fRefPedestalWidths,
-                            fRawPedestals,fRawPedestalWidths,
-                            fValPedestals,fValPedestalWidths);
-      m_AllPedsOK=NPedErrors;
+  if (m_nevtsample < 1) {
+    // pedestal validation: m_AllPedsOK=-1 means not validated,
+    //                                   0 everything OK,
+    //                                   N>0 : mod(N,100000) drifts + width changes
+    //                                         int(N/100000) missing channels
+    m_AllPedsOK = -1;
+    if (m_pedValflag > 0) {
+      for (int i = 0; i < 4; i++)
+        nstat[i] = (int)m_stat[i];
+      int NPedErrors = CastorPedVal(nstat,
+                                    fRefPedestals,
+                                    fRefPedestalWidths,
+                                    fRawPedestals,
+                                    fRawPedestalWidths,
+                                    fValPedestals,
+                                    fValPedestalWidths);
+      m_AllPedsOK = NPedErrors;
     }
-// setting m_AllPedsOK=-2 will inhibit writing pedestals out
-//    if(m_pedValflag==1){
-//      if(evt<100)m_AllPedsOK=-2;
-//    }
-
+    // setting m_AllPedsOK=-2 will inhibit writing pedestals out
+    //    if(m_pedValflag==1){
+    //      if(evt<100)m_AllPedsOK=-2;
+    //    }
   }
 
   // Write other histograms.
@@ -486,30 +552,38 @@ int CastorPedestalAnalysis::done(const CastorPedestals* fInputPedestals,
 }
 
 //-----------------------------------------------------------------------------
-void CastorPedestalAnalysis::Trendings(map<HcalDetId, map<int,PEDBUNCH> > &toolT, TH1F* Chi2, TH1F* CapidAverage, TH1F* CapidChi2){
-
-// check stability of pedestal constants in a single long run
+void CastorPedestalAnalysis::Trendings(map<HcalDetId, map<int, PEDBUNCH> >& toolT,
+                                       TH1F* Chi2,
+                                       TH1F* CapidAverage,
+                                       TH1F* CapidChi2) {
+  // check stability of pedestal constants in a single long run
 
   map<int, std::vector<double> > AverageValues;
 
-  for(_meot=toolT.begin(); _meot!=toolT.end(); _meot++){
-    for(int i=0; i<4; i++){
+  for (_meot = toolT.begin(); _meot != toolT.end(); _meot++) {
+    for (int i = 0; i < 4; i++) {
       char name[1024];
       HcalDetId detid = _meot->first;
-      sprintf(name,"Pedestal trend, eta=%d phi=%d d=%d cap=%d",detid.ieta(),detid.iphi(),detid.depth(),i);
+      sprintf(name, "Pedestal trend, eta=%d phi=%d d=%d cap=%d", detid.ieta(), detid.iphi(), detid.depth(), i);
       int bins = _meot->second[i].second.first[0].size();
-      float lo =0.5;
-      float hi = (float)bins+0.5;
-      _meot->second[i].second.second.push_back(new TH1F(name,name,bins,lo,hi));
-      sprintf(name,"Width trend, eta=%d phi=%d d=%d cap=%d",detid.ieta(),detid.iphi(),detid.depth(),i);
+      float lo = 0.5;
+      float hi = (float)bins + 0.5;
+      _meot->second[i].second.second.push_back(new TH1F(name, name, bins, lo, hi));
+      sprintf(name, "Width trend, eta=%d phi=%d d=%d cap=%d", detid.ieta(), detid.iphi(), detid.depth(), i);
       bins = _meot->second[i].second.first[2].size();
-      hi = (float)bins+0.5;
-      _meot->second[i].second.second.push_back(new TH1F(name,name,bins,lo,hi));
-      sprintf(name,"Correlation trend, eta=%d phi=%d d=%d caps=%d*%d",detid.ieta(),detid.iphi(),detid.depth(),i,(i+1)%4);
+      hi = (float)bins + 0.5;
+      _meot->second[i].second.second.push_back(new TH1F(name, name, bins, lo, hi));
+      sprintf(name,
+              "Correlation trend, eta=%d phi=%d d=%d caps=%d*%d",
+              detid.ieta(),
+              detid.iphi(),
+              detid.depth(),
+              i,
+              (i + 1) % 4);
       bins = _meot->second[i].second.first[5].size();
-      hi = (float)bins+0.5;
-      _meot->second[i].second.second.push_back(new TH1F(name,name,bins,lo,hi));
-/*      sprintf(name,"Correlation trend, eta=%d phi=%d d=%d caps=%d*%d",detid.ieta(),detid.iphi(),detid.depth(),i,(i+2)%4);
+      hi = (float)bins + 0.5;
+      _meot->second[i].second.second.push_back(new TH1F(name, name, bins, lo, hi));
+      /*      sprintf(name,"Correlation trend, eta=%d phi=%d d=%d caps=%d*%d",detid.ieta(),detid.iphi(),detid.depth(),i,(i+2)%4);
       bins = _meot->second[i].second.first[7].size();
       hi = (float)bins+0.5;
       _meot->second[i].second.second.push_back(new TH1F(name,name,bins,lo,hi));
@@ -520,58 +594,58 @@ void CastorPedestalAnalysis::Trendings(map<HcalDetId, map<int,PEDBUNCH> > &toolT
 
       std::vector<double>::iterator sample_it;
       // Pedestal mean - put content and errors
-      int j=0;
-      for(sample_it=_meot->second[i].second.first[0].begin();
-          sample_it!=_meot->second[i].second.first[0].end();++sample_it){
-        _meot->second[i].second.second[0]->SetBinContent(++j,*sample_it);
+      int j = 0;
+      for (sample_it = _meot->second[i].second.first[0].begin(); sample_it != _meot->second[i].second.first[0].end();
+           ++sample_it) {
+        _meot->second[i].second.second[0]->SetBinContent(++j, *sample_it);
       }
-      j=0;
-      for(sample_it=_meot->second[i].second.first[1].begin();
-          sample_it!=_meot->second[i].second.first[1].end();++sample_it){
-        _meot->second[i].second.second[0]->SetBinError(++j,*sample_it);
+      j = 0;
+      for (sample_it = _meot->second[i].second.first[1].begin(); sample_it != _meot->second[i].second.first[1].end();
+           ++sample_it) {
+        _meot->second[i].second.second[0]->SetBinError(++j, *sample_it);
       }
       // fit with a constant - extract parameters
-      _meot->second[i].second.second[0]->Fit("pol0","Q");
-      TF1 *fit = _meot->second[i].second.second[0]->GetFunction("pol0");
+      _meot->second[i].second.second[0]->Fit("pol0", "Q");
+      TF1* fit = _meot->second[i].second.second[0]->GetFunction("pol0");
       AverageValues[0].push_back(fit->GetParameter(0));
       AverageValues[1].push_back(fit->GetParError(0));
-      if(sample>1)
-      AverageValues[2].push_back(fit->GetChisquare()/fit->GetNDF());
+      if (sample > 1)
+        AverageValues[2].push_back(fit->GetChisquare() / fit->GetNDF());
       else
-      AverageValues[2].push_back(fit->GetChisquare());
-      sprintf(name,"Sample (%d events)",m_nevtsample);
+        AverageValues[2].push_back(fit->GetChisquare());
+      sprintf(name, "Sample (%d events)", m_nevtsample);
       _meot->second[i].second.second[0]->GetXaxis()->SetTitle(name);
       _meot->second[i].second.second[0]->GetYaxis()->SetTitle("Pedestal value");
       _meot->second[i].second.second[0]->Write();
       // Pedestal width - put content and errors
-      j=0;
-      for(sample_it=_meot->second[i].second.first[2].begin();
-          sample_it!=_meot->second[i].second.first[2].end();++sample_it){
-        _meot->second[i].second.second[1]->SetBinContent(++j,*sample_it);
+      j = 0;
+      for (sample_it = _meot->second[i].second.first[2].begin(); sample_it != _meot->second[i].second.first[2].end();
+           ++sample_it) {
+        _meot->second[i].second.second[1]->SetBinContent(++j, *sample_it);
       }
-      j=0;
-      for(sample_it=_meot->second[i].second.first[3].begin();
-          sample_it!=_meot->second[i].second.first[3].end();++sample_it){
-        _meot->second[i].second.second[1]->SetBinError(++j,*sample_it);
+      j = 0;
+      for (sample_it = _meot->second[i].second.first[3].begin(); sample_it != _meot->second[i].second.first[3].end();
+           ++sample_it) {
+        _meot->second[i].second.second[1]->SetBinError(++j, *sample_it);
       }
       _meot->second[i].second.second[1]->GetXaxis()->SetTitle(name);
       _meot->second[i].second.second[1]->GetYaxis()->SetTitle("Pedestal width");
       _meot->second[i].second.second[1]->Write();
       // Correlation coeffs - put contents and errors
-      j=0;
-      for(sample_it=_meot->second[i].second.first[5].begin();
-          sample_it!=_meot->second[i].second.first[5].end();++sample_it){
-        _meot->second[i].second.second[2]->SetBinContent(++j,*sample_it);
+      j = 0;
+      for (sample_it = _meot->second[i].second.first[5].begin(); sample_it != _meot->second[i].second.first[5].end();
+           ++sample_it) {
+        _meot->second[i].second.second[2]->SetBinContent(++j, *sample_it);
       }
-      j=0;
-      for(sample_it=_meot->second[i].second.first[6].begin();
-          sample_it!=_meot->second[i].second.first[6].end();++sample_it){
-        _meot->second[i].second.second[2]->SetBinError(++j,*sample_it);
+      j = 0;
+      for (sample_it = _meot->second[i].second.first[6].begin(); sample_it != _meot->second[i].second.first[6].end();
+           ++sample_it) {
+        _meot->second[i].second.second[2]->SetBinError(++j, *sample_it);
       }
       _meot->second[i].second.second[2]->GetXaxis()->SetTitle(name);
       _meot->second[i].second.second[2]->GetYaxis()->SetTitle("Close correlation");
       _meot->second[i].second.second[2]->Write();
- /*     j=0;
+      /*     j=0;
       for(sample_it=_meot->second[i].second.first[7].begin();
           sample_it!=_meot->second[i].second.first[7].end();sample_it++){
         _meot->second[i].second.second[3]->SetBinContent(++j,*sample_it);
@@ -598,34 +672,32 @@ void CastorPedestalAnalysis::Trendings(map<HcalDetId, map<int,PEDBUNCH> > &toolT
       _meot->second[i].second.second[4]->GetYaxis()->SetTitle("Distant correlation");
       _meot->second[i].second.second[4]->Write(); */
       // chi2
-      j=0;
-      for(sample_it=_meot->second[i].second.first[4].begin();
-          sample_it!=_meot->second[i].second.first[4].end();++sample_it){
+      j = 0;
+      for (sample_it = _meot->second[i].second.first[4].begin(); sample_it != _meot->second[i].second.first[4].end();
+           ++sample_it) {
         Chi2->Fill(*sample_it);
       }
     }
   }
-  CapidAverage= new TH1F("Constant fit: Pedestal Values",
-                         "Constant fit: Pedestal Values",
-                         AverageValues[0].size(),0.,AverageValues[0].size());
+  CapidAverage = new TH1F("Constant fit: Pedestal Values",
+                          "Constant fit: Pedestal Values",
+                          AverageValues[0].size(),
+                          0.,
+                          AverageValues[0].size());
   std::vector<double>::iterator sample_it;
-  int j=0;
-  for(sample_it=AverageValues[0].begin();
-      sample_it!=AverageValues[0].end();++sample_it){
-    CapidAverage->SetBinContent(++j,*sample_it);
+  int j = 0;
+  for (sample_it = AverageValues[0].begin(); sample_it != AverageValues[0].end(); ++sample_it) {
+    CapidAverage->SetBinContent(++j, *sample_it);
   }
-  j=0;
-  for(sample_it=AverageValues[1].begin();
-      sample_it!=AverageValues[1].end();++sample_it){
-    CapidAverage->SetBinError(++j,*sample_it);
+  j = 0;
+  for (sample_it = AverageValues[1].begin(); sample_it != AverageValues[1].end(); ++sample_it) {
+    CapidAverage->SetBinError(++j, *sample_it);
   }
-  CapidChi2= new TH1F("Constant fit: Chi2/ndf",
-                      "Constant fit: Chi2/ndf",
-                      AverageValues[2].size(),0.,AverageValues[2].size());
-  j=0;
-  for(sample_it=AverageValues[2].begin();
-      sample_it!=AverageValues[2].end();++sample_it){
-    CapidChi2->SetBinContent(++j,*sample_it);
+  CapidChi2 = new TH1F(
+      "Constant fit: Chi2/ndf", "Constant fit: Chi2/ndf", AverageValues[2].size(), 0., AverageValues[2].size());
+  j = 0;
+  for (sample_it = AverageValues[2].begin(); sample_it != AverageValues[2].end(); ++sample_it) {
+    CapidChi2->SetBinContent(++j, *sample_it);
     //CapidChi2->SetBinError(++j,0);
   }
   Chi2->GetXaxis()->SetTitle("Chi2/ndf");
@@ -637,170 +709,184 @@ void CastorPedestalAnalysis::Trendings(map<HcalDetId, map<int,PEDBUNCH> > &toolT
   CapidChi2->GetYaxis()->SetTitle("Chi2/ndf");
   CapidChi2->GetXaxis()->SetTitle("(16+2) x 4 x 4 `events`");
   CapidChi2->Write();
-
 }
 
 //-----------------------------------------------------------------------------
-int CastorPedestalAnalysis::CastorPedVal(int nstat[4], const CastorPedestals* fRefPedestals, 
-				const CastorPedestalWidths* fRefPedestalWidths,
-                                CastorPedestals* fRawPedestals,
-                                CastorPedestalWidths* fRawPedestalWidths,
-				CastorPedestals* fValPedestals, 
-				CastorPedestalWidths* fValPedestalWidths)
-{
-// new version of pedestal validation - it is designed to be as independent of
-// all the rest as possible - you only need to provide valid pedestal objects
-// and a vector of statistics per capID to use this as standalone code
+int CastorPedestalAnalysis::CastorPedVal(int nstat[4],
+                                         const CastorPedestals* fRefPedestals,
+                                         const CastorPedestalWidths* fRefPedestalWidths,
+                                         CastorPedestals* fRawPedestals,
+                                         CastorPedestalWidths* fRawPedestalWidths,
+                                         CastorPedestals* fValPedestals,
+                                         CastorPedestalWidths* fValPedestalWidths) {
+  // new version of pedestal validation - it is designed to be as independent of
+  // all the rest as possible - you only need to provide valid pedestal objects
+  // and a vector of statistics per capID to use this as standalone code
   HcalDetId detid;
-  float RefPedVals[4]; float RefPedSigs[4][4];
-  float RawPedVals[4]; float RawPedSigs[4][4];
-  map<HcalDetId,bool> isinRaw;
-  map<HcalDetId,bool> isinRef;
-  std::vector<DetId> RefChanns=fRefPedestals->getAllChannels();
-  std::vector<DetId> RawChanns=fRawPedestals->getAllChannels();
+  float RefPedVals[4];
+  float RefPedSigs[4][4];
+  float RawPedVals[4];
+  float RawPedSigs[4][4];
+  map<HcalDetId, bool> isinRaw;
+  map<HcalDetId, bool> isinRef;
+  std::vector<DetId> RefChanns = fRefPedestals->getAllChannels();
+  std::vector<DetId> RawChanns = fRawPedestals->getAllChannels();
   std::ofstream PedValLog;
   PedValLog.open("CastorPedVal.log");
 
-  if(nstat[0]+nstat[1]+nstat[2]+nstat[3]<2500) PedValLog<<"CastorPedVal: warning - low statistics"<<std::endl;
-// find complete list of channels in current data and reference
-  for (int i=0; i<(int)RawChanns.size(); i++){
-    isinRef[HcalDetId(RawChanns[i])]=false;
+  if (nstat[0] + nstat[1] + nstat[2] + nstat[3] < 2500)
+    PedValLog << "CastorPedVal: warning - low statistics" << std::endl;
+  // find complete list of channels in current data and reference
+  for (int i = 0; i < (int)RawChanns.size(); i++) {
+    isinRef[HcalDetId(RawChanns[i])] = false;
   }
-  for (int i=0; i<(int)RefChanns.size(); i++){
-    detid=HcalDetId(RefChanns[i]);
-    isinRaw[detid]=false;
-    isinRef[detid]=true;
+  for (int i = 0; i < (int)RefChanns.size(); i++) {
+    detid = HcalDetId(RefChanns[i]);
+    isinRaw[detid] = false;
+    isinRef[detid] = true;
   }
-  for (int i=0; i<(int)RawChanns.size(); i++){
-    detid=HcalDetId(RawChanns[i]);
-    isinRaw[detid]=true;
-    if (isinRef[detid]==false) {
-      PedValLog<<"CastorPedVal: channel "<<detid<<" not found in reference set"<<std::endl;
-      std::cerr<<"CastorPedVal: channel "<<detid<<" not found in reference set"<<std::endl;
+  for (int i = 0; i < (int)RawChanns.size(); i++) {
+    detid = HcalDetId(RawChanns[i]);
+    isinRaw[detid] = true;
+    if (isinRef[detid] == false) {
+      PedValLog << "CastorPedVal: channel " << detid << " not found in reference set" << std::endl;
+      std::cerr << "CastorPedVal: channel " << detid << " not found in reference set" << std::endl;
     }
   }
 
-// main loop over channels
-  int erflag=0;
-  for (int i=0; i<(int)RefChanns.size(); i++){
-    detid=HcalDetId(RefChanns[i]);
-    for (int icap=0; icap<4; icap++) {
-      RefPedVals[icap]=fRefPedestals->getValues(detid)->getValue(icap);
-      for (int icap2=icap; icap2<4; icap2++) {
-        RefPedSigs[icap][icap2]=fRefPedestalWidths->getValues(detid)->getSigma(icap,icap2);
-        if(icap2!=icap)RefPedSigs[icap2][icap]=RefPedSigs[icap][icap2];
+  // main loop over channels
+  int erflag = 0;
+  for (int i = 0; i < (int)RefChanns.size(); i++) {
+    detid = HcalDetId(RefChanns[i]);
+    for (int icap = 0; icap < 4; icap++) {
+      RefPedVals[icap] = fRefPedestals->getValues(detid)->getValue(icap);
+      for (int icap2 = icap; icap2 < 4; icap2++) {
+        RefPedSigs[icap][icap2] = fRefPedestalWidths->getValues(detid)->getSigma(icap, icap2);
+        if (icap2 != icap)
+          RefPedSigs[icap2][icap] = RefPedSigs[icap][icap2];
       }
     }
 
-// read new raw values
-    if(isinRaw[detid]) {
-      for (int icap=0; icap<4; icap++) {
-        RawPedVals[icap]=fRawPedestals->getValues(detid)->getValue(icap);
-        for (int icap2=icap; icap2<4; icap2++) {
-          RawPedSigs[icap][icap2]=fRawPedestalWidths->getValues(detid)->getSigma(icap,icap2);
-          if(icap2!=icap)RawPedSigs[icap2][icap]=RawPedSigs[icap][icap2];
+    // read new raw values
+    if (isinRaw[detid]) {
+      for (int icap = 0; icap < 4; icap++) {
+        RawPedVals[icap] = fRawPedestals->getValues(detid)->getValue(icap);
+        for (int icap2 = icap; icap2 < 4; icap2++) {
+          RawPedSigs[icap][icap2] = fRawPedestalWidths->getValues(detid)->getSigma(icap, icap2);
+          if (icap2 != icap)
+            RawPedSigs[icap2][icap] = RawPedSigs[icap][icap2];
         }
       }
 
-// first quick check if raw values make sense: if not, the channel is treated like absent
-      for (int icap=0; icap<4; icap++) {
-        if(RawPedVals[icap]<1. || RawPedSigs[icap][icap]<0.01) isinRaw[detid]=false;
-        for (int icap2=icap; icap2<4; icap2++){
-          if(fabs(RawPedSigs[icap][icap2]/sqrt(RawPedSigs[icap][icap]*RawPedSigs[icap2][icap2]))>1.) isinRaw[detid]=false;
-        }
-      }
-    }
-
-// check raw values against reference
-    if(isinRaw[detid]) {
-      for (int icap=0; icap<4; icap++) {
-        int icap2=(icap+1)%4;
-        float width=sqrt(RawPedSigs[icap][icap]);
-        float erof1=width/sqrt((float)nstat[icap]);
-        float erof2=sqrt(erof1*erof1+RawPedSigs[icap][icap]/(float)nstat[icap]);
-        float erofwidth=width/sqrt(2.*nstat[icap]);
-        float diffof1=RawPedVals[icap]-RefPedVals[icap];
-        float diffof2=RawPedVals[icap]+RawPedVals[icap2]-RefPedVals[icap]-RefPedVals[icap2];
-        float diffofw=width-sqrt(RefPedSigs[icap][icap]);
-
-// validation in 2 TS for HB, HE, HO, in 1 TS for HF
-        int nTS=2;
-        if(detid.subdet()==HcalForward) nTS=1;
-        if(nTS==1 && fabs(diffof1)>0.5+erof1) { 
-          erflag+=1;
-          PedValLog<<"HcalPedVal: drift in channel "<<detid<<" cap "<<icap<<": "<<RawPedVals[icap]<<" - "<<RefPedVals[icap]<<" = "<<diffof1<<std::endl;
-        }
-        if(nTS==2 && fabs(diffof2)>0.5+erof2) { 
-          erflag+=1;
-          PedValLog<<"HcalPedVal: drift in channel "<<detid<<" caps "<<icap<<"+"<<icap2<<": "<<RawPedVals[icap]<<"+"<<RawPedVals[icap2]<<" - "<<RefPedVals[icap]<<"+"<<RefPedVals[icap2]<<" = "<<diffof2<<std::endl;
-        }
-        if(fabs(diffofw)>0.15*width+erofwidth) {
-          erflag+=1;
-          PedValLog<<"HcalPedVal: width changed in channel "<<detid<<" cap "<<icap<<": "<<width<<" - "<<sqrt(RefPedSigs[icap][icap])<<" = "<<diffofw<<std::endl;
+      // first quick check if raw values make sense: if not, the channel is treated like absent
+      for (int icap = 0; icap < 4; icap++) {
+        if (RawPedVals[icap] < 1. || RawPedSigs[icap][icap] < 0.01)
+          isinRaw[detid] = false;
+        for (int icap2 = icap; icap2 < 4; icap2++) {
+          if (fabs(RawPedSigs[icap][icap2] / sqrt(RawPedSigs[icap][icap] * RawPedSigs[icap2][icap2])) > 1.)
+            isinRaw[detid] = false;
         }
       }
     }
 
-// for disconnected/bad channels restore reference values
+    // check raw values against reference
+    if (isinRaw[detid]) {
+      for (int icap = 0; icap < 4; icap++) {
+        int icap2 = (icap + 1) % 4;
+        float width = sqrt(RawPedSigs[icap][icap]);
+        float erof1 = width / sqrt((float)nstat[icap]);
+        float erof2 = sqrt(erof1 * erof1 + RawPedSigs[icap][icap] / (float)nstat[icap]);
+        float erofwidth = width / sqrt(2. * nstat[icap]);
+        float diffof1 = RawPedVals[icap] - RefPedVals[icap];
+        float diffof2 = RawPedVals[icap] + RawPedVals[icap2] - RefPedVals[icap] - RefPedVals[icap2];
+        float diffofw = width - sqrt(RefPedSigs[icap][icap]);
+
+        // validation in 2 TS for HB, HE, HO, in 1 TS for HF
+        int nTS = 2;
+        if (detid.subdet() == HcalForward)
+          nTS = 1;
+        if (nTS == 1 && fabs(diffof1) > 0.5 + erof1) {
+          erflag += 1;
+          PedValLog << "HcalPedVal: drift in channel " << detid << " cap " << icap << ": " << RawPedVals[icap] << " - "
+                    << RefPedVals[icap] << " = " << diffof1 << std::endl;
+        }
+        if (nTS == 2 && fabs(diffof2) > 0.5 + erof2) {
+          erflag += 1;
+          PedValLog << "HcalPedVal: drift in channel " << detid << " caps " << icap << "+" << icap2 << ": "
+                    << RawPedVals[icap] << "+" << RawPedVals[icap2] << " - " << RefPedVals[icap] << "+"
+                    << RefPedVals[icap2] << " = " << diffof2 << std::endl;
+        }
+        if (fabs(diffofw) > 0.15 * width + erofwidth) {
+          erflag += 1;
+          PedValLog << "HcalPedVal: width changed in channel " << detid << " cap " << icap << ": " << width << " - "
+                    << sqrt(RefPedSigs[icap][icap]) << " = " << diffofw << std::endl;
+        }
+      }
+    }
+
+    // for disconnected/bad channels restore reference values
     else {
-      PedValLog<<"HcalPedVal: no valid data from channel "<<detid<<std::endl;
-      erflag+=100000;
-      CastorPedestal item(detid,RefPedVals[0],RefPedVals[1],RefPedVals[2],RefPedVals[3]);
+      PedValLog << "HcalPedVal: no valid data from channel " << detid << std::endl;
+      erflag += 100000;
+      CastorPedestal item(detid, RefPedVals[0], RefPedVals[1], RefPedVals[2], RefPedVals[3]);
       fValPedestals->addValues(item);
       CastorPedestalWidth widthsp(detid);
-      for (int icap=0; icap<4; icap++) {
-        for (int icap2=icap; icap2<4; icap2++) widthsp.setSigma(icap2,icap,RefPedSigs[icap2][icap]);
+      for (int icap = 0; icap < 4; icap++) {
+        for (int icap2 = icap; icap2 < 4; icap2++)
+          widthsp.setSigma(icap2, icap, RefPedSigs[icap2][icap]);
       }
       fValPedestalWidths->addValues(widthsp);
     }
 
-// end of channel loop
+    // end of channel loop
   }
 
-  if(erflag==0) PedValLog<<"HcalPedVal: all pedestals checked OK"<<std::endl;
+  if (erflag == 0)
+    PedValLog << "HcalPedVal: all pedestals checked OK" << std::endl;
 
-// now construct the remaining part of the validated objects
-// if nothing changed outside tolerance, validated set = reference set
-  if(erflag%100000 == 0) {
-    for (int i=0; i<(int)RefChanns.size(); i++){
-      detid=HcalDetId(RefChanns[i]);
+  // now construct the remaining part of the validated objects
+  // if nothing changed outside tolerance, validated set = reference set
+  if (erflag % 100000 == 0) {
+    for (int i = 0; i < (int)RefChanns.size(); i++) {
+      detid = HcalDetId(RefChanns[i]);
       if (isinRaw[detid]) {
         CastorPedestalWidth widthsp(detid);
-        for (int icap=0; icap<4; icap++) {
-          RefPedVals[icap]=fRefPedestals->getValues(detid)->getValue(icap);
-          for (int icap2=icap; icap2<4; icap2++) {
-            RefPedSigs[icap][icap2]=fRefPedestalWidths->getValues(detid)->getSigma(icap,icap2);
-            if(icap2!=icap)RefPedSigs[icap2][icap]=RefPedSigs[icap][icap2];
-            widthsp.setSigma(icap2,icap,RefPedSigs[icap2][icap]);
+        for (int icap = 0; icap < 4; icap++) {
+          RefPedVals[icap] = fRefPedestals->getValues(detid)->getValue(icap);
+          for (int icap2 = icap; icap2 < 4; icap2++) {
+            RefPedSigs[icap][icap2] = fRefPedestalWidths->getValues(detid)->getSigma(icap, icap2);
+            if (icap2 != icap)
+              RefPedSigs[icap2][icap] = RefPedSigs[icap][icap2];
+            widthsp.setSigma(icap2, icap, RefPedSigs[icap2][icap]);
           }
         }
-	fValPedestalWidths->addValues(widthsp);
-	CastorPedestal item(detid,RefPedVals[0],RefPedVals[1],RefPedVals[2],RefPedVals[3]);
+        fValPedestalWidths->addValues(widthsp);
+        CastorPedestal item(detid, RefPedVals[0], RefPedVals[1], RefPedVals[2], RefPedVals[3]);
         fValPedestals->addValues(item);
       }
     }
   }
 
-// if anything changed, validated set = raw set + reference for missing/bad channels
+  // if anything changed, validated set = raw set + reference for missing/bad channels
   else {
-    for (int i=0; i<(int)RawChanns.size(); i++){
-      detid=HcalDetId(RawChanns[i]);
+    for (int i = 0; i < (int)RawChanns.size(); i++) {
+      detid = HcalDetId(RawChanns[i]);
       if (isinRaw[detid]) {
         CastorPedestalWidth widthsp(detid);
-        for (int icap=0; icap<4; icap++) {
-          RawPedVals[icap]=fRawPedestals->getValues(detid)->getValue(icap);
-          for (int icap2=icap; icap2<4; icap2++) {
-            RawPedSigs[icap][icap2]=fRawPedestalWidths->getValues(detid)->getSigma(icap,icap2);
-            if(icap2!=icap)RawPedSigs[icap2][icap]=RawPedSigs[icap][icap2];
-            widthsp.setSigma(icap2,icap,RawPedSigs[icap2][icap]);
+        for (int icap = 0; icap < 4; icap++) {
+          RawPedVals[icap] = fRawPedestals->getValues(detid)->getValue(icap);
+          for (int icap2 = icap; icap2 < 4; icap2++) {
+            RawPedSigs[icap][icap2] = fRawPedestalWidths->getValues(detid)->getSigma(icap, icap2);
+            if (icap2 != icap)
+              RawPedSigs[icap2][icap] = RawPedSigs[icap][icap2];
+            widthsp.setSigma(icap2, icap, RawPedSigs[icap2][icap]);
           }
         }
-	fValPedestalWidths->addValues(widthsp);
-	CastorPedestal item(detid,RawPedVals[0],RawPedVals[1],RawPedVals[2],RawPedVals[3]);
+        fValPedestalWidths->addValues(widthsp);
+        CastorPedestal item(detid, RawPedVals[0], RawPedVals[1], RawPedVals[2], RawPedVals[3]);
         fValPedestals->addValues(item);
       }
     }
   }
   return erflag;
 }
-

--- a/CalibCalorimetry/CastorCalib/src/CastorPulseContainmentCorrection.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorPulseContainmentCorrection.cc
@@ -2,37 +2,34 @@
 #include "CalibCalorimetry/CastorCalib/interface/CastorTimeSlew.h"
 #include "CalibCalorimetry/CastorCalib/interface/CastorPulseShapes.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <algorithm> // for "max","min"
+#include <algorithm>  // for "max","min"
 #include <cmath>
 #include <iostream>
 
 #include "CalibCalorimetry/HcalAlgos/interface/genlkupmap.h"
 
-
-template<>
-RecoFCcorFactorAlgo<CastorPulseShapes::Shape>::RecoFCcorFactorAlgo(int num_samples, double fixedphase_ns)
-{
+template <>
+RecoFCcorFactorAlgo<CastorPulseShapes::Shape>::RecoFCcorFactorAlgo(int num_samples, double fixedphase_ns) {
   fixedphasens_ = fixedphase_ns;
   CastorPulseShapes shapes;
-  shape_=shapes.castorShape();
+  shape_ = shapes.castorShape();
   const int binsize_ns = 25;
 
   // First set up controlling parameters for calculating the correction factor:
   // Integration window size...
   //
-  integrationwindowns_ = (double)(binsize_ns*num_samples);
+  integrationwindowns_ = (double)(binsize_ns * num_samples);
 
   // First find the point at which time bin "1" exceeds time bin "0",
   // and call that point "time 0".
   //
-  for (int shift_ns=0; shift_ns<binsize_ns; shift_ns++) {
-
+  for (int shift_ns = 0; shift_ns < binsize_ns; shift_ns++) {
     // Digitize by integrating to find all time sample
     // bin values for this shift.
     //
-    double tmin    = -(double)shift_ns;
-    double bin0val = (double)shape_.integrate(tmin, tmin+binsize_ns);
-    double bin1val = (double)shape_.integrate(tmin+binsize_ns, tmin+2*binsize_ns);
+    double tmin = -(double)shift_ns;
+    double bin0val = (double)shape_.integrate(tmin, tmin + binsize_ns);
+    double bin1val = (double)shape_.integrate(tmin + binsize_ns, tmin + 2 * binsize_ns);
 
 #if 0
     char s[80];
@@ -52,18 +49,16 @@ RecoFCcorFactorAlgo<CastorPulseShapes::Shape>::RecoFCcorFactorAlgo(int num_sampl
 }
 
 template <>
-std::pair<double,double> RecoFCcorFactorAlgo<CastorPulseShapes::Shape>::calcpair(double truefc)
-{
-  double timeslew_ns = CastorTimeSlew::delay(std::max(0.0,(double)truefc),
-                                           CastorTimeSlew::Medium);
-  double shift_ns  = fixedphasens_ - time0shiftns_ + timeslew_ns;
+std::pair<double, double> RecoFCcorFactorAlgo<CastorPulseShapes::Shape>::calcpair(double truefc) {
+  double timeslew_ns = CastorTimeSlew::delay(std::max(0.0, (double)truefc), CastorTimeSlew::Medium);
+  double shift_ns = fixedphasens_ - time0shiftns_ + timeslew_ns;
 
-  double tmin      = -shift_ns;
-  double tmax      = tmin+integrationwindowns_;
+  double tmin = -shift_ns;
+  double tmax = tmin + integrationwindowns_;
 
-  double integral  = shape_.integrate( tmin, tmax );
-  double corfactor = 1.0/integral;
-  double recofc    = (double)truefc * integral;
+  double integral = shape_.integrate(tmin, tmax);
+  double corfactor = 1.0 / integral;
+  double recofc = (double)truefc * integral;
 
 #if 0
   char s[80];
@@ -72,34 +67,32 @@ std::pair<double,double> RecoFCcorFactorAlgo<CastorPulseShapes::Shape>::calcpair
   cout << s;
 #endif
 
-  std::pair<double,double> thepair(recofc,corfactor);
+  std::pair<double, double> thepair(recofc, corfactor);
   return thepair;
 }
 
 ///Generate energy correction factors based on a predetermined phase of the hit + time slew
 //
 CastorPulseContainmentCorrection::CastorPulseContainmentCorrection(int num_samples,
-                                                               float fixedphase_ns,
-                                                               float max_fracerror)
-{
+                                                                   float fixedphase_ns,
+                                                                   float max_fracerror) {
   RecoFCcorFactorAlgo<CastorPulseShapes::Shape> corFalgo(num_samples, (double)fixedphase_ns);
 
   // Generate lookup map for the correction function, never exceeding
   // a maximum fractional error for lookups.
   //
-  genlkupmap< RecoFCcorFactorAlgo<CastorPulseShapes::Shape> > (1.0, 5000.0f,  // generation domain
-                                     max_fracerror,     // maximum fractional error
-                                     1.0,   // min_xstep = minimum true fC increment
-                                     corFalgo,
-                                     mCorFactors_);     // return lookup map
+  genlkupmap<RecoFCcorFactorAlgo<CastorPulseShapes::Shape> >(1.0,
+                                                             5000.0f,        // generation domain
+                                                             max_fracerror,  // maximum fractional error
+                                                             1.0,            // min_xstep = minimum true fC increment
+                                                             corFalgo,
+                                                             mCorFactors_);  // return lookup map
 }
 
-
-double CastorPulseContainmentCorrection::getCorrection(double fc_ampl) const
-{
+double CastorPulseContainmentCorrection::getCorrection(double fc_ampl) const {
   double correction;
 
-  std::map<double,double>::const_iterator fcupper,fclower;
+  std::map<double, double>::const_iterator fcupper, fclower;
 
   fcupper = mCorFactors_.upper_bound(fc_ampl);
   fclower = fcupper;
@@ -107,13 +100,10 @@ double CastorPulseContainmentCorrection::getCorrection(double fc_ampl) const
 
   if (fcupper == mCorFactors_.end()) {
     correction = fclower->second;
-  }
-  else if (fcupper == mCorFactors_.begin()) {
+  } else if (fcupper == mCorFactors_.begin()) {
     correction = fcupper->second;
-  }
-  else {
-    if (fabs(fclower->first - fc_ampl) <
-	fabs(fcupper->first - fc_ampl) )
+  } else {
+    if (fabs(fclower->first - fc_ampl) < fabs(fcupper->first - fc_ampl))
       correction = fclower->second;
     else
       correction = fcupper->second;

--- a/CalibCalorimetry/CastorCalib/src/CastorPulseShapes.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorPulseShapes.cc
@@ -6,74 +6,75 @@ CastorPulseShapes::CastorPulseShapes() {
   computeCastorShape(castorShape_);
 }
 
-
 void CastorPulseShapes::computeCastorShape(CastorPulseShapes::Shape& sh) {
-
   //  cout << endl << " ===== computeShapeHF  !!! " << endl << endl;
 
-  const float ts = 3.0;           // time constant in   t * exp(-(t/ts)**2)
+  const float ts = 3.0;  // time constant in   t * exp(-(t/ts)**2)
 
   // first create pulse shape over a range of time 0 ns to 255 ns in 1 ns steps
   int nbin = 256;
   sh.setNBin(nbin);
-  std::vector<float> ntmp(nbin,0.0);  // 
+  std::vector<float> ntmp(nbin, 0.0);  //
 
   int j;
   float norm;
 
   // CASTOR SHAPE
   norm = 0.0;
-  for( j = 0; j < 3 * ts && j < nbin; j++){
-    ntmp[j] = ((float)j)*exp(-((float)(j*j))/(ts*ts));
+  for (j = 0; j < 3 * ts && j < nbin; j++) {
+    ntmp[j] = ((float)j) * exp(-((float)(j * j)) / (ts * ts));
     norm += ntmp[j];
   }
   // normalize pulse area to 1.0
-  for( j = 0; j < 3 * ts && j < nbin; j++){
+  for (j = 0; j < 3 * ts && j < nbin; j++) {
     ntmp[j] /= norm;
 
     //    cout << " nt [" << j << "] = " <<  ntmp[j] << endl;
-    sh.setShapeBin(j,ntmp[j]);
+    sh.setShapeBin(j, ntmp[j]);
   }
 }
 
 CastorPulseShapes::Shape::Shape() {
-  nbin_=0;
-  tpeak_=0;
+  nbin_ = 0;
+  tpeak_ = 0;
 }
 
 void CastorPulseShapes::Shape::setNBin(int n) {
-  nbin_=n;
-  shape_=std::vector<float>(n,0.0f);
+  nbin_ = n;
+  shape_ = std::vector<float>(n, 0.0f);
 }
 
 void CastorPulseShapes::Shape::setShapeBin(int i, float f) {
-  if (i>=0 && i<nbin_) shape_[i]=f;
+  if (i >= 0 && i < nbin_)
+    shape_[i] = f;
 }
 
 float CastorPulseShapes::Shape::operator()(double t) const {
   // shape is in 1 ns steps
-  int i=(int)(t+0.5);
-  float rv=0;
-  if (i>=0 && i<nbin_) rv=shape_[i];
+  int i = (int)(t + 0.5);
+  float rv = 0;
+  if (i >= 0 && i < nbin_)
+    rv = shape_[i];
   return rv;
 }
 
 float CastorPulseShapes::Shape::at(double t) const {
   // shape is in 1 ns steps
-  int i=(int)(t+0.5);
-  float rv=0;
-  if (i>=0 && i<nbin_) rv=shape_[i];
+  int i = (int)(t + 0.5);
+  float rv = 0;
+  if (i >= 0 && i < nbin_)
+    rv = shape_[i];
   return rv;
 }
 
 float CastorPulseShapes::Shape::integrate(double t1, double t2) const {
-  static const float int_delta_ns = 0.05f; 
+  static const float int_delta_ns = 0.05f;
   double intval = 0.0;
 
-  for (double t = t1; t < t2; t+= int_delta_ns) {
+  for (double t = t1; t < t2; t += int_delta_ns) {
     float loedge = at(t);
-    float hiedge = at(t+int_delta_ns);
-    intval += (loedge+hiedge)*int_delta_ns/2.0;
+    float hiedge = at(t + int_delta_ns);
+    intval += (loedge + hiedge) * int_delta_ns / 2.0;
   }
 
   return (float)intval;

--- a/CalibCalorimetry/CastorCalib/src/CastorTimeSlew.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorTimeSlew.cc
@@ -1,12 +1,12 @@
 #include "CalibCalorimetry/CastorCalib/interface/CastorTimeSlew.h"
 #include <cmath>
 
-// NOTE check these numbers 
-static const double tzero[3]= {23.960177, 13.307784, 9.109694};
-static const double slope[3] = {-3.178648,  -1.556668, -1.075824 };
-static const double tmax[3] = {16.00, 10.00, 6.25 };
+// NOTE check these numbers
+static const double tzero[3] = {23.960177, 13.307784, 9.109694};
+static const double slope[3] = {-3.178648, -1.556668, -1.075824};
+static const double tmax[3] = {16.00, 10.00, 6.25};
 
 double CastorTimeSlew::delay(double fC, BiasSetting bias) {
-  double rawDelay=tzero[bias]+slope[bias]*log(fC);
-  return (rawDelay<0)?(0):((rawDelay>tmax[bias])?(tmax[bias]):(rawDelay));			   
+  double rawDelay = tzero[bias] + slope[bias] * log(fC);
+  return (rawDelay < 0) ? (0) : ((rawDelay > tmax[bias]) ? (tmax[bias]) : (rawDelay));
 }

--- a/CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h
+++ b/CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h
@@ -16,7 +16,6 @@ namespace edm {
   class EventSetup;
 }
 
-
 class DTTTrigBaseSync {
 public:
   /// Constructor
@@ -30,20 +29,15 @@ public:
   /// Pass the Event Setup to the synchronization module at each event
   virtual void setES(const edm::EventSetup& setup) = 0;
 
-
-
   /// Time (ns) to be subtracted to the digi time.
   /// Parameters are the layer and the wireId to which the
   /// digi is referred and the estimation of
-  /// the 3D hit position (globPos) 
-  double offset(const DTLayer* layer,
-		const DTWireId& wireId,
-		const GlobalPoint& globalPos) const;
+  /// the 3D hit position (globPos)
+  double offset(const DTLayer* layer, const DTWireId& wireId, const GlobalPoint& globalPos) const;
 
   /// Time (ns) to be subtracted to the digi time.
   /// It does not take into account TOF and signal propagation along the wire
-  virtual double offset(const DTWireId& wireId) const = 0 ;
-
+  virtual double offset(const DTWireId& wireId) const = 0;
 
   /// Time to be subtracted to the digi time,
   /// Parameters are the layer and the wireId to which the
@@ -54,12 +48,11 @@ public:
   ///     - wirePropCorr is the delay for signal propagation along the wire
   ///     - tofCorr is the correction due to the particle TOF
   virtual double offset(const DTLayer* layer,
-			const DTWireId& wireId,
-			const GlobalPoint& globalPos,
-			double &tTrig,
-			double& wirePropCorr,
-			double& tofCorr) const = 0;
-
+                        const DTWireId& wireId,
+                        const GlobalPoint& globalPos,
+                        double& tTrig,
+                        double& wirePropCorr,
+                        double& tofCorr) const = 0;
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
   /// It does not take into account TOF and signal propagation along the wire
@@ -70,11 +63,6 @@ public:
   /// It also returns the different contributions separately:
   ///     - tTrig is the offset (t_trig)
   ///     - t0cell is the t0 from pulses
-  virtual double emulatorOffset(const DTWireId& wireId,
-				double &tTrig,
-				double &t0cell) const = 0;
-  
-
+  virtual double emulatorOffset(const DTWireId& wireId, double& tTrig, double& t0cell) const = 0;
 };
 #endif
-

--- a/CalibMuon/DTDigiSync/interface/DTTTrigSyncFactory.h
+++ b/CalibMuon/DTDigiSync/interface/DTTTrigSyncFactory.h
@@ -16,4 +16,3 @@ class DTTTrigBaseSync;
 
 typedef edmplugin::PluginFactory<DTTTrigBaseSync *(const edm::ParameterSet &)> DTTTrigSyncFactory;
 #endif
-

--- a/CalibMuon/DTDigiSync/src/DTTTrigBaseSync.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigBaseSync.cc
@@ -6,28 +6,18 @@
 
 #include "CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h"
 
+DTTTrigBaseSync::DTTTrigBaseSync() {}
 
-DTTTrigBaseSync::DTTTrigBaseSync(){}
+DTTTrigBaseSync::~DTTTrigBaseSync() {}
 
-
-
-DTTTrigBaseSync::~DTTTrigBaseSync(){}
-
-
-
-double DTTTrigBaseSync::offset(const DTLayer* layer,
-			       const DTWireId& wireId,
-			       const GlobalPoint& globalPos) const {
+double DTTTrigBaseSync::offset(const DTLayer* layer, const DTWireId& wireId, const GlobalPoint& globalPos) const {
   double tTrig = 0;
   double wireProp = 0;
   double tof = 0;
   return offset(layer, wireId, globalPos, tTrig, wireProp, tof);
 }
 
-
-
 double DTTTrigBaseSync::emulatorOffset(const DTWireId& wireId) const {
-
   double tTrig = 0.;
   double t0cell = 0.;
   return emulatorOffset(wireId, tTrig, t0cell);

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFactory.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFactory.cc
@@ -7,5 +7,4 @@
 
 #include "CalibMuon/DTDigiSync/interface/DTTTrigSyncFactory.h"
 
-EDM_REGISTER_PLUGINFACTORY(DTTTrigSyncFactory,"DTTTrigSyncFactory");
-
+EDM_REGISTER_PLUGINFACTORY(DTTTrigSyncFactory, "DTTTrigSyncFactory");

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
@@ -6,7 +6,6 @@
 
 #include "DTTTrigSyncFromDB.h"
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -23,59 +22,50 @@
 using namespace std;
 using namespace edm;
 
-
 DTTTrigSyncFromDB::DTTTrigSyncFromDB(const ParameterSet& config)
-:  debug(config.getUntrackedParameter<bool>("debug")),
-  // The velocity of signal propagation along the wire (cm/ns)
-  theVPropWire(config.getParameter<double>("vPropWire")),
-  // Switch on/off the T0 correction from pulses
-  doT0Correction(config.getParameter<bool>("doT0Correction")),
-  // Switch on/off the TOF correction for particles from IP
-  doTOFCorrection(config.getParameter<bool>("doTOFCorrection")),
-  theTOFCorrType(config.getParameter<int>("tofCorrType")),
-  // Switch on/off the correction for the signal propagation along the wire
-  doWirePropCorrection(config.getParameter<bool>("doWirePropCorrection")),
-  theWirePropCorrType(config.getParameter<int>("wirePropCorrType")),
-  // spacing of BX in ns
-  theBXspace(config.getUntrackedParameter<double>("bxSpace", 25.)),
-  thetTrigLabel(config.getParameter<string>("tTrigLabel"))
-{
-}
+    : debug(config.getUntrackedParameter<bool>("debug")),
+      // The velocity of signal propagation along the wire (cm/ns)
+      theVPropWire(config.getParameter<double>("vPropWire")),
+      // Switch on/off the T0 correction from pulses
+      doT0Correction(config.getParameter<bool>("doT0Correction")),
+      // Switch on/off the TOF correction for particles from IP
+      doTOFCorrection(config.getParameter<bool>("doTOFCorrection")),
+      theTOFCorrType(config.getParameter<int>("tofCorrType")),
+      // Switch on/off the correction for the signal propagation along the wire
+      doWirePropCorrection(config.getParameter<bool>("doWirePropCorrection")),
+      theWirePropCorrType(config.getParameter<int>("wirePropCorrType")),
+      // spacing of BX in ns
+      theBXspace(config.getUntrackedParameter<double>("bxSpace", 25.)),
+      thetTrigLabel(config.getParameter<string>("tTrigLabel")) {}
 
-
-
-DTTTrigSyncFromDB::~DTTTrigSyncFromDB(){}
-
-
+DTTTrigSyncFromDB::~DTTTrigSyncFromDB() {}
 
 void DTTTrigSyncFromDB::setES(const EventSetup& setup) {
-  if(doT0Correction)
-    {
-      // Get the map of t0 from pulses from the Setup
-      ESHandle<DTT0> t0Handle;
-      setup.get<DTT0Rcd>().get(t0Handle);
-      tZeroMap = &*t0Handle;
-      if(debug) {
-	cout << "[DTTTrigSyncFromDB] t0 version: " << tZeroMap->version()<<endl;
-	  }
+  if (doT0Correction) {
+    // Get the map of t0 from pulses from the Setup
+    ESHandle<DTT0> t0Handle;
+    setup.get<DTT0Rcd>().get(t0Handle);
+    tZeroMap = &*t0Handle;
+    if (debug) {
+      cout << "[DTTTrigSyncFromDB] t0 version: " << tZeroMap->version() << endl;
     }
+  }
 
   // Get the map of ttrig from the Setup
   ESHandle<DTTtrig> ttrigHandle;
-  setup.get<DTTtrigRcd>().get(thetTrigLabel,ttrigHandle);
+  setup.get<DTTtrigRcd>().get(thetTrigLabel, ttrigHandle);
   tTrigMap = &*ttrigHandle;
-    if(debug) {
-      cout << "[DTTTrigSyncFromDB] ttrig version: " << tTrigMap->version() << endl;
+  if (debug) {
+    cout << "[DTTTrigSyncFromDB] ttrig version: " << tTrigMap->version() << endl;
   }
 }
 
-
 double DTTTrigSyncFromDB::offset(const DTLayer* layer,
-				  const DTWireId& wireId,
-				  const GlobalPoint& globPos,
-				  double& tTrig,
-				  double& wirePropCorr,
-				  double& tofCorr) const {
+                                 const DTWireId& wireId,
+                                 const GlobalPoint& globPos,
+                                 double& tTrig,
+                                 double& wirePropCorr,
+                                 double& tofCorr) const {
   // Correction for the float to int conversion while writeing the ttrig in ns into an int variable
   // (half a bin on average)
   // FIXME: this should disappear as soon as the ttrig object will become a float
@@ -84,151 +74,126 @@ double DTTTrigSyncFromDB::offset(const DTLayer* layer,
   tTrig = offset(wireId);
 
   // Compute the time spent in signal propagation along wire.
-   // NOTE: the FE is always at y>0
+  // NOTE: the FE is always at y>0
   wirePropCorr = 0;
-  if(doWirePropCorrection) {
-    switch(theWirePropCorrType){
-      // The ttrig computed from the timebox accounts on average for the signal propagation time
-      // from the center of the wire to the frontend. Here we just have to correct for
-      // the distance of the hit from the wire center.
-    case 0: {
-      float wireCoord = layer->toLocal(globPos).y();
-      wirePropCorr = -wireCoord/theVPropWire;
-      break;
-      // FIXME: What if hits used for the time box are not distributed uniformly along the wire?
-    }
-    //On simulated data you need to subtract the total propagation time 
-    case 1: {
-      float halfL     = layer->specificTopology().cellLenght()/2;
-      float wireCoord = layer->toLocal(globPos).y();
-      float propgL    = halfL - wireCoord;
-      wirePropCorr = propgL/theVPropWire;
-      break;
-    }
-    default: {
-    throw
-      cms::Exception("[DTTTrigSyncFromDB]") << " Invalid parameter: wirePropCorrType = "
-					     << theWirePropCorrType 
-					     << std::endl;
-    break;
-    }
+  if (doWirePropCorrection) {
+    switch (theWirePropCorrType) {
+        // The ttrig computed from the timebox accounts on average for the signal propagation time
+        // from the center of the wire to the frontend. Here we just have to correct for
+        // the distance of the hit from the wire center.
+      case 0: {
+        float wireCoord = layer->toLocal(globPos).y();
+        wirePropCorr = -wireCoord / theVPropWire;
+        break;
+        // FIXME: What if hits used for the time box are not distributed uniformly along the wire?
+      }
+      //On simulated data you need to subtract the total propagation time
+      case 1: {
+        float halfL = layer->specificTopology().cellLenght() / 2;
+        float wireCoord = layer->toLocal(globPos).y();
+        float propgL = halfL - wireCoord;
+        wirePropCorr = propgL / theVPropWire;
+        break;
+      }
+      default: {
+        throw cms::Exception("[DTTTrigSyncFromDB]")
+            << " Invalid parameter: wirePropCorrType = " << theWirePropCorrType << std::endl;
+        break;
+      }
     }
   }
 
   // Compute TOF correction:
   tofCorr = 0.;
   // TOF Correction can be switched off with appropriate parameter
-  if(doTOFCorrection) {
+  if (doTOFCorrection) {
     float flightToHit = globPos.mag();
-    static const float cSpeed = 29.9792458; // cm/ns
-    switch(theTOFCorrType) {
-    case 0: {
-      // The ttrig computed from the real data accounts on average for the TOF correction 
-      // Depending on the granularity used for the ttrig computation we just have to correct for the
-      // TOF from the center of the chamber, SL, layer or wire to the hit position.
-      // At the moment only SL granularity is considered
-      // Correction for TOF from the center of the SL to hit position
-      const DTSuperLayer *sl = layer->superLayer();
-      double flightToSL = sl->surface().position().mag();
-      tofCorr = (flightToSL-flightToHit)/cSpeed;
-      break;
-    }
-    case 1: {
-      // On simulated data you need to consider only the TOF from 3D center of the wire to hit position 
-      // (because the TOF from the IP to the wire has been already subtracted in the digitization: 
-      // SimMuon/DTDigitizer/DTDigiSyncTOFCorr.cc corrType=2)
-      float flightToWire =
-	layer->toGlobal(LocalPoint(layer->specificTopology().wirePosition(wireId.wire()), 0., 0.)).mag();
-      tofCorr = (flightToWire-flightToHit)/cSpeed;
-      break;
-    }
-    default: {
-      throw
-	cms::Exception("[DTTTrigSyncFromDB]") << " Invalid parameter: tofCorrType = "
-					      << theTOFCorrType 
-					      << std::endl;
-      break;
-    }
+    static const float cSpeed = 29.9792458;  // cm/ns
+    switch (theTOFCorrType) {
+      case 0: {
+        // The ttrig computed from the real data accounts on average for the TOF correction
+        // Depending on the granularity used for the ttrig computation we just have to correct for the
+        // TOF from the center of the chamber, SL, layer or wire to the hit position.
+        // At the moment only SL granularity is considered
+        // Correction for TOF from the center of the SL to hit position
+        const DTSuperLayer* sl = layer->superLayer();
+        double flightToSL = sl->surface().position().mag();
+        tofCorr = (flightToSL - flightToHit) / cSpeed;
+        break;
+      }
+      case 1: {
+        // On simulated data you need to consider only the TOF from 3D center of the wire to hit position
+        // (because the TOF from the IP to the wire has been already subtracted in the digitization:
+        // SimMuon/DTDigitizer/DTDigiSyncTOFCorr.cc corrType=2)
+        float flightToWire =
+            layer->toGlobal(LocalPoint(layer->specificTopology().wirePosition(wireId.wire()), 0., 0.)).mag();
+        tofCorr = (flightToWire - flightToHit) / cSpeed;
+        break;
+      }
+      default: {
+        throw cms::Exception("[DTTTrigSyncFromDB]")
+            << " Invalid parameter: tofCorrType = " << theTOFCorrType << std::endl;
+        break;
+      }
     }
   }
 
-
-  if(debug) {
+  if (debug) {
     cout << "[DTTTrigSyncFromDB] Channel: " << wireId << endl
-	 << "      Offset (ns): " << tTrig + wirePropCorr - tofCorr << endl
-	 << "      various contributions are: " << endl
-	 << "      tTrig + t0 (ns):   " << tTrig << endl
-	 //<< "      tZero (ns):   " << t0 << endl
-	 << "      Propagation along wire delay (ns): " <<  wirePropCorr << endl
-	 << "      TOF correction (ns): " << tofCorr << endl
-	 << endl;
+         << "      Offset (ns): " << tTrig + wirePropCorr - tofCorr << endl
+         << "      various contributions are: " << endl
+         << "      tTrig + t0 (ns):   " << tTrig
+         << endl
+         //<< "      tZero (ns):   " << t0 << endl
+         << "      Propagation along wire delay (ns): " << wirePropCorr << endl
+         << "      TOF correction (ns): " << tofCorr << endl
+         << endl;
   }
   //The global offset is the sum of various contributions
-    return tTrig + wirePropCorr - tofCorr;
+  return tTrig + wirePropCorr - tofCorr;
 }
 
 double DTTTrigSyncFromDB::offset(const DTWireId& wireId) const {
   float t0 = 0;
   float t0rms = 0;
-  if(doT0Correction)
-    {
-      // Read the t0 from pulses for this wire (ns)
-       tZeroMap->get(wireId,
-		     t0,
-		     t0rms,
-	             DTTimeUnits::ns);
-
-    }
+  if (doT0Correction) {
+    // Read the t0 from pulses for this wire (ns)
+    tZeroMap->get(wireId, t0, t0rms, DTTimeUnits::ns);
+  }
 
   // Read the ttrig for this wire
   float ttrigMean = 0;
   float ttrigSigma = 0;
   float kFactor = 0;
   // FIXME: should check the return value of the DTTtrigRcd::get(..) method
-  if(tTrigMap->get(wireId.superlayerId(),
-		   ttrigMean,
-		   ttrigSigma,
-		   kFactor,
-		   DTTimeUnits::ns) != 0) {
+  if (tTrigMap->get(wireId.superlayerId(), ttrigMean, ttrigSigma, kFactor, DTTimeUnits::ns) != 0) {
     cout << "[DTTTrigSyncFromDB]*Error: ttrig not found for SL: " << wireId.superlayerId() << endl;
-//     FIXME: LogError.....
+    //     FIXME: LogError.....
   }
-  
-  return t0 + ttrigMean + kFactor * ttrigSigma;
 
+  return t0 + ttrigMean + kFactor * ttrigSigma;
 }
 
-double DTTTrigSyncFromDB::emulatorOffset(const DTWireId& wireId,
-					 double &tTrig,
-					 double &t0cell) const {
+double DTTTrigSyncFromDB::emulatorOffset(const DTWireId& wireId, double& tTrig, double& t0cell) const {
   float t0 = 0;
   float t0rms = 0;
-  if(doT0Correction)
-    {
-      // Read the t0 from pulses for this wire (ns)
-       tZeroMap->get(wireId,
-		     t0,
-		     t0rms,
-	             DTTimeUnits::ns);
-
-    }
+  if (doT0Correction) {
+    // Read the t0 from pulses for this wire (ns)
+    tZeroMap->get(wireId, t0, t0rms, DTTimeUnits::ns);
+  }
 
   // Read the ttrig for this wire
   float ttrigMean = 0;
   float ttrigSigma = 0;
   float kFactor = 0;
   // FIXME: should check the return value of the DTTtrigRcd::get(..) method
-  if(tTrigMap->get(wireId.superlayerId(),
-		   ttrigMean,
-		   ttrigSigma,
-		   kFactor,
-		   DTTimeUnits::ns) != 0) {
+  if (tTrigMap->get(wireId.superlayerId(), ttrigMean, ttrigSigma, kFactor, DTTimeUnits::ns) != 0) {
     cout << "[DTTTrigSyncFromDB]*Error: ttrig not found for SL: " << wireId.superlayerId() << endl;
-//     FIXME: LogError.....
+    //     FIXME: LogError.....
   }
-  
+
   tTrig = ttrigMean + kFactor * ttrigSigma;
   t0cell = t0;
 
-  return int(tTrig/theBXspace)*theBXspace + t0cell;
+  return int(tTrig / theBXspace) * theBXspace + t0cell;
 }

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.h
@@ -40,12 +40,10 @@
 
 #include "CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h"
 
-
 class DTLayer;
 class DTWireId;
 class DTT0;
 class DTTtrig;
-
 
 namespace edm {
   class ParameterSet;
@@ -64,37 +62,31 @@ public:
   /// Pass the Event Setup to the algo at each event
   void setES(const edm::EventSetup& setup) override;
 
-
   /// Time (ns) to be subtracted to the digi time,
   /// Parameters are the layer and the wireId to which the
   /// digi is referred and the estimation of
   /// the 3D hit position (globPos)
   double offset(const DTLayer* layer,
-			const DTWireId& wireId,
-			const GlobalPoint& globPos,
-			double& tTrig,
-			double& wirePropCorr,
-			double& tofCorr) const override;
+                const DTWireId& wireId,
+                const GlobalPoint& globPos,
+                double& tTrig,
+                double& wirePropCorr,
+                double& tofCorr) const override;
 
   /// Time (ns) to be subtracted to the digi time.
   /// It does not take into account TOF and signal propagation along the wire
   double offset(const DTWireId& wireId) const override;
-
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
   /// It does not take into account TOF and signal propagation along the wire
   /// It also returns the different contributions separately:
   ///     - tTrig is the offset (t_trig)
   ///     - t0cell is the t0 from pulses
-  double emulatorOffset(const DTWireId& wireId,
-				double &tTrig,
-				double &t0cell) const override;
+  double emulatorOffset(const DTWireId& wireId, double& tTrig, double& t0cell) const override;
 
-
- private:
-  
-  const DTT0 *tZeroMap;
-  const DTTtrig *tTrigMap;
+private:
+  const DTT0* tZeroMap;
+  const DTTtrig* tTrigMap;
   // Set the verbosity level
   const bool debug;
   // The velocity of signal propagation along the wire (cm/ns)
@@ -111,7 +103,5 @@ public:
   double theBXspace;
 
   std::string thetTrigLabel;
-
 };
 #endif
-

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.cc
@@ -6,7 +6,6 @@
 
 #include "DTTTrigSyncT0Only.h"
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -19,48 +18,38 @@
 using namespace std;
 using namespace edm;
 
+DTTTrigSyncT0Only::DTTTrigSyncT0Only(const ParameterSet& config) : debug(config.getUntrackedParameter<bool>("debug")) {}
 
-DTTTrigSyncT0Only::DTTTrigSyncT0Only(const ParameterSet& config)
- :debug(config.getUntrackedParameter<bool>("debug"))
-{
-}
-
-
-
-DTTTrigSyncT0Only::~DTTTrigSyncT0Only(){}
-
-
+DTTTrigSyncT0Only::~DTTTrigSyncT0Only() {}
 
 void DTTTrigSyncT0Only::setES(const EventSetup& setup) {
   ESHandle<DTT0> t0;
   setup.get<DTT0Rcd>().get(t0);
   tZeroMap = &*t0;
-  
-  if(debug) {
+
+  if (debug) {
     cout << "[DTTTrigSyncT0Only] T0 version: " << t0->version() << endl;
   }
 }
 
-
-
-
 double DTTTrigSyncT0Only::offset(const DTLayer* layer,
-				  const DTWireId& wireId,
-				  const GlobalPoint& globPos,
-				  double& tTrig,
-				  double& wirePropCorr,
-				  double& tofCorr) const {
+                                 const DTWireId& wireId,
+                                 const GlobalPoint& globPos,
+                                 double& tTrig,
+                                 double& wirePropCorr,
+                                 double& tofCorr) const {
   tTrig = offset(wireId);
   wirePropCorr = 0;
   tofCorr = 0;
 
-  if(debug) {
+  if (debug) {
     cout << "[DTTTrigSyncT0Only] Offset (ns): " << tTrig + wirePropCorr - tofCorr << endl
-	 << "      various contributions are: " << endl
-	 //<< "      tZero (ns):   " << t0 << endl
-	 << "      Propagation along wire delay (ns): " <<  wirePropCorr << endl
-	 << "      TOF correction (ns): " << tofCorr << endl
-	 << endl;
+         << "      various contributions are: "
+         << endl
+         //<< "      tZero (ns):   " << t0 << endl
+         << "      Propagation along wire delay (ns): " << wirePropCorr << endl
+         << "      TOF correction (ns): " << tofCorr << endl
+         << endl;
   }
   //The global offset is the sum of various contributions
   return tTrig + wirePropCorr - tofCorr;
@@ -69,18 +58,12 @@ double DTTTrigSyncT0Only::offset(const DTLayer* layer,
 double DTTTrigSyncT0Only::offset(const DTWireId& wireId) const {
   float t0 = 0;
   float t0rms = 0;
-  tZeroMap->get(wireId,
-                t0,
-                t0rms,
-                DTTimeUnits::ns);
+  tZeroMap->get(wireId, t0, t0rms, DTTimeUnits::ns);
 
   return t0;
 }
 
-
-double DTTTrigSyncT0Only::emulatorOffset(const DTWireId& wireId,
-					 double &tTrig,
-					 double &t0cell) const {
+double DTTTrigSyncT0Only::emulatorOffset(const DTWireId& wireId, double& tTrig, double& t0cell) const {
   tTrig = 0.;
   t0cell = 0.;
   return 0.;

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncT0Only.h
@@ -11,8 +11,6 @@
 
 #include "CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h"
 
-
-
 class DTLayer;
 class DTWireId;
 class DTT0;
@@ -34,33 +32,27 @@ public:
   /// Pass the Event Setup to the algo at each event
   void setES(const edm::EventSetup& setup) override;
 
-
   /// Time (ns) to be subtracted to the digi time,
   /// Parameters are the layer and the wireId to which the
   /// digi is referred and the estimation of
   /// the 3D hit position (globPos)
   double offset(const DTLayer* layer,
-			const DTWireId& wireId,
-			const GlobalPoint& globPos,
-			double& tTrig,
-			double& wirePropCorr,
-			double& tofCorr) const override;
+                const DTWireId& wireId,
+                const GlobalPoint& globPos,
+                double& tTrig,
+                double& wirePropCorr,
+                double& tofCorr) const override;
 
   double offset(const DTWireId& wireId) const override;
 
   /// Time (ns) to be subtracted to the digi time for emulation purposes
   /// Returns just 0 in this implementation of the plugin
-  double emulatorOffset(const DTWireId& wireId,
-				double &tTrig,
-				double &t0cell) const override;
+  double emulatorOffset(const DTWireId& wireId, double& tTrig, double& t0cell) const override;
 
-
- private:
-  
-  const DTT0 *tZeroMap;
+private:
+  const DTT0* tZeroMap;
 
   // Set the verbosity level
   const bool debug;
 };
 #endif
-

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.cc
@@ -16,90 +16,81 @@
 using namespace std;
 
 DTTTrigSyncTOFCorr::DTTTrigSyncTOFCorr(const edm::ParameterSet& config)
-: 
-  // The fixed t0 (or t_trig) to be subtracted to digi time (ns)
-  theTTrig(config.getParameter<double>("tTrig")),           // FIXME: Default was 500 ns
-  // Velocity of signal propagation along the wire (cm/ns)
-  theVPropWire(config.getParameter<double>("vPropWire")),   // FIXME: Default was 24.4 cm/ns
-  // Select the mode for TOF correction:
-  //     0: tofCorr = TOF from IP to 3D Hit position (globPos)
-  //     1: tofCorr = TOF correction for distance difference
-  //                  between 3D center of the chamber and hit position
-  //                  (default)
-  //     2: tofCorr = TOF correction for distance difference
-  //                  between 3D center of the wire and hit position
-  //                  (This mode in available for backward compatibility)
-  theTOFCorrType(config.getParameter<int>("tofCorrType")), // FIXME: Default was 1
-  debug(config.getUntrackedParameter<bool>("debug")),
-  theBXspace(config.getUntrackedParameter<double>("bxSpace", 25.)) // spacing of BX in ns
-{
-}
+    :                                                  // The fixed t0 (or t_trig) to be subtracted to digi time (ns)
+      theTTrig(config.getParameter<double>("tTrig")),  // FIXME: Default was 500 ns
+      // Velocity of signal propagation along the wire (cm/ns)
+      theVPropWire(config.getParameter<double>("vPropWire")),  // FIXME: Default was 24.4 cm/ns
+      // Select the mode for TOF correction:
+      //     0: tofCorr = TOF from IP to 3D Hit position (globPos)
+      //     1: tofCorr = TOF correction for distance difference
+      //                  between 3D center of the chamber and hit position
+      //                  (default)
+      //     2: tofCorr = TOF correction for distance difference
+      //                  between 3D center of the wire and hit position
+      //                  (This mode in available for backward compatibility)
+      theTOFCorrType(config.getParameter<int>("tofCorrType")),  // FIXME: Default was 1
+      debug(config.getUntrackedParameter<bool>("debug")),
+      theBXspace(config.getUntrackedParameter<double>("bxSpace", 25.))  // spacing of BX in ns
+{}
 
-
-
-DTTTrigSyncTOFCorr::~DTTTrigSyncTOFCorr(){}
-
-
+DTTTrigSyncTOFCorr::~DTTTrigSyncTOFCorr() {}
 
 double DTTTrigSyncTOFCorr::offset(const DTLayer* layer,
-				  const DTWireId& wireId,
-				  const GlobalPoint& globPos,
-				  double& tTrig,
-				  double& wirePropCorr,
-				  double& tofCorr) const {
+                                  const DTWireId& wireId,
+                                  const GlobalPoint& globPos,
+                                  double& tTrig,
+                                  double& wirePropCorr,
+                                  double& tofCorr) const {
   tTrig = offset(wireId);
 
   //Compute the time spent in signal propagation along wire.
   // NOTE: the FE is always at y>0
-  float halfL     = layer->specificTopology().cellLenght()/2;
+  float halfL = layer->specificTopology().cellLenght() / 2;
   float wireCoord = layer->toLocal(globPos).y();
-  float propgL    = halfL - wireCoord;
-  wirePropCorr = propgL/theVPropWire;
-
+  float propgL = halfL - wireCoord;
+  wirePropCorr = propgL / theVPropWire;
 
   // Compute TOF correction treating it accordingly to
   // the tofCorrType card
   float flightToHit = globPos.mag();
-  static const float cSpeed = 29.9792458; // cm/ns
+  static const float cSpeed = 29.9792458;  // cm/ns
   tofCorr = 0.;
-  switch(theTOFCorrType) {
-  case 0: {
-    // In this mode the subtraction of the TOF from IP to
-    // estimate 3D hit digi position is done here
-    // (No correction is needed anymore)
-    tofCorr = -flightToHit/cSpeed;
-    break;
-  }
-  case 1: {
-    // Correction for TOF from the center of the chamber to hit position
-    const DTChamber * chamber = layer->chamber();
-    double flightToChamber = chamber->surface().position().mag();
-    tofCorr = (flightToChamber-flightToHit)/cSpeed;
-    break;
-  }
-  case 2: {
-    // TOF from 3D center of the wire to hit position
-    float flightToWire =
-      layer->toGlobal(LocalPoint(layer->specificTopology().wirePosition(wireId.wire()), 0., 0.)).mag();
-    tofCorr = (flightToWire-flightToHit)/cSpeed;
-    break;
-  }
-  default: {
-    throw
-      cms::Exception("[DTTTrigSyncTOFCorr]") << " Invalid parameter: tofCorrType = "
-					     << theTOFCorrType 
-					     << std::endl;
-    break;
-  }
+  switch (theTOFCorrType) {
+    case 0: {
+      // In this mode the subtraction of the TOF from IP to
+      // estimate 3D hit digi position is done here
+      // (No correction is needed anymore)
+      tofCorr = -flightToHit / cSpeed;
+      break;
+    }
+    case 1: {
+      // Correction for TOF from the center of the chamber to hit position
+      const DTChamber* chamber = layer->chamber();
+      double flightToChamber = chamber->surface().position().mag();
+      tofCorr = (flightToChamber - flightToHit) / cSpeed;
+      break;
+    }
+    case 2: {
+      // TOF from 3D center of the wire to hit position
+      float flightToWire =
+          layer->toGlobal(LocalPoint(layer->specificTopology().wirePosition(wireId.wire()), 0., 0.)).mag();
+      tofCorr = (flightToWire - flightToHit) / cSpeed;
+      break;
+    }
+    default: {
+      throw cms::Exception("[DTTTrigSyncTOFCorr]")
+          << " Invalid parameter: tofCorrType = " << theTOFCorrType << std::endl;
+      break;
+    }
   }
 
-  if(debug) {
+  if (debug) {
     cout << "[DTTTrigSyncTOFCorr] Offset (ns): " << tTrig + wirePropCorr - tofCorr << endl
-	 << "      various contributions are: " << endl
-	 << "      tTrig (ns):   " << tTrig << endl
-	 << "      Propagation along wire delay (ns): " <<  wirePropCorr << endl
-	 << "      TOF correction (ns): " << tofCorr << endl
-	 << endl;
+         << "      various contributions are: " << endl
+         << "      tTrig (ns):   " << tTrig << endl
+         << "      Propagation along wire delay (ns): " << wirePropCorr << endl
+         << "      TOF correction (ns): " << tofCorr << endl
+         << endl;
   }
   //The global offset is the sum of various contributions
   return tTrig + wirePropCorr - tofCorr;
@@ -108,21 +99,16 @@ double DTTTrigSyncTOFCorr::offset(const DTLayer* layer,
 double DTTTrigSyncTOFCorr::offset(const DTWireId& wireId) const {
   // Correction for the float to int conversion
   // (half a bin on average) in DTDigi constructor
-  static const float f2i_convCorr = (25./64.); // ns
+  static const float f2i_convCorr = (25. / 64.);  // ns
   //FIXME: This should be considered only if the Digi is constructed from a float....
-
 
   // The tTrig is taken from a parameter
   return theTTrig - f2i_convCorr;
 }
 
-
-double DTTTrigSyncTOFCorr::emulatorOffset(const DTWireId& wireId,
-					 double &tTrig,
-					 double &t0cell) const {
+double DTTTrigSyncTOFCorr::emulatorOffset(const DTWireId& wireId, double& tTrig, double& t0cell) const {
   tTrig = theTTrig;
   t0cell = 0.;
 
-  return int(tTrig/theBXspace)*theBXspace;
+  return int(tTrig / theBXspace) * theBXspace;
 }
-

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncTOFCorr.h
@@ -38,8 +38,6 @@
 
 #include "CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h"
 
-
-
 class DTLayer;
 class DTWireId;
 
@@ -60,7 +58,6 @@ public:
   /// Pass the Event Setup to the algo at each event
   void setES(const edm::EventSetup& setup) override {}
 
-
   /// Time (ns) to be subtracted to the digi time,
   /// Parameters are the layer and the wireId to which the
   /// digi is referred and the estimation of
@@ -68,13 +65,13 @@ public:
   /// It also returns the different contributions separately:
   ///     - tTrig is the offset (t_trig)
   ///     - wirePropCorr is the delay for signal propagation along the wire
-  ///     - tofCorr is the correction due to the particle TOF 
+  ///     - tofCorr is the correction due to the particle TOF
   double offset(const DTLayer* layer,
-			const DTWireId& wireId,
-			const GlobalPoint& globPos,
-			double& tTrig,
-			double& wirePropCorr,
-			double& tofCorr) const override;
+                const DTWireId& wireId,
+                const GlobalPoint& globPos,
+                double& tTrig,
+                double& wirePropCorr,
+                double& tofCorr) const override;
 
   double offset(const DTWireId& wireId) const override;
 
@@ -83,11 +80,9 @@ public:
   /// It also returns the different contributions separately:
   ///     - tTrig is the offset (t_trig)
   ///     - t0cell is the t0 from pulses (always 0 in this case)
-  double emulatorOffset(const DTWireId& wireId,
-				double &tTrig,
-				double &t0cell) const override;
+  double emulatorOffset(const DTWireId& wireId, double& tTrig, double& t0cell) const override;
 
- private:
+private:
   // The fixed t_trig to be subtracted to digi time (ns)
   const double theTTrig;
   // Velocity of signal propagation along the wire (cm/ns)
@@ -95,7 +90,7 @@ public:
   // cfr. CMS-IN 2000-021:   (2.56+-0.17)x1e8 m/s
   //      CMS NOTE 2003-17:  (0.244)  m/ns = 24.4 cm/ns
   const double theVPropWire;
-  
+
   // Select the mode for TOF correction:
   //     0: tofCorr = TOF from IP to 3D Hit position (globPos)
   //     1: tofCorr = TOF correction for distance difference
@@ -110,4 +105,3 @@ public:
   double theBXspace;
 };
 #endif
-

--- a/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
+++ b/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
@@ -28,18 +28,18 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h" 
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 //--- for SimHit association
-#include "SimDataFormats/TrackingHit/interface/PSimHit.h"  
-#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h" 
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDet.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -58,67 +58,57 @@
 #include <TProfile.h>
 
 class TTree;
-class TFile; 
+class TFile;
 
-class SiPixelErrorEstimation : public edm::EDAnalyzer 
-{
- public:
-  
+class SiPixelErrorEstimation : public edm::EDAnalyzer {
+public:
   explicit SiPixelErrorEstimation(const edm::ParameterSet&);
   ~SiPixelErrorEstimation() override;
-    
-  void beginJob() override ;
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
 
-  void computeAnglesFromDetPosition( const SiPixelCluster & cl, 
-				     const GeomDetUnit    & det, 
-				     float& alpha, float& beta );
-    
- private: 
-  
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  void computeAnglesFromDetPosition(const SiPixelCluster& cl, const GeomDetUnit& det, float& alpha, float& beta);
+
+private:
   edm::ParameterSet conf_;
   edm::EDGetTokenT<std::vector<Trajectory>> tTrajectory;
   edm::EDGetTokenT<SiPixelRecHitCollection> tPixRecHitCollection;
-  edm::EDGetTokenT <edm::SimTrackContainer> tSimTrackContainer;
-  edm::EDGetTokenT <reco::TrackCollection> tTrackCollection; 
+  edm::EDGetTokenT<edm::SimTrackContainer> tSimTrackContainer;
+  edm::EDGetTokenT<reco::TrackCollection> tTrackCollection;
   std::string outputFile_;
   std::string src_;
-  bool checkType_; // do we check that the simHit associated with recHit is of the expected particle type ?
-  int genType_; // the type of particle that the simHit associated with recHits should be
-  bool include_trk_hits_; // if set to false, take only hits directly from detector modules (don't ntuplize hits from tracks)
+  bool checkType_;         // do we check that the simHit associated with recHit is of the expected particle type ?
+  int genType_;            // the type of particle that the simHit associated with recHits should be
+  bool include_trk_hits_;  // if set to false, take only hits directly from detector modules (don't ntuplize hits from tracks)
 
   // variables that go in the output ttree_track_hits_
-  float rechitx; // x position of hit 
-  float rechity; // y position of hit
-  float rechitz; // z position of hit
-  float rechiterrx; // x position error of hit (error not squared)
-  float rechiterry; // y position error of hit (error not squared)
-  float rechitresx; // difference between reconstructed hit x position and 'true' x position
-  float rechitresy; // difference between reconstructed hit y position and 'true' y position
-  float rechitpullx; // x residual divideded by error
-  float rechitpully; // y residual divideded by error
+  float rechitx;      // x position of hit
+  float rechity;      // y position of hit
+  float rechitz;      // z position of hit
+  float rechiterrx;   // x position error of hit (error not squared)
+  float rechiterry;   // y position error of hit (error not squared)
+  float rechitresx;   // difference between reconstructed hit x position and 'true' x position
+  float rechitresy;   // difference between reconstructed hit y position and 'true' y position
+  float rechitpullx;  // x residual divideded by error
+  float rechitpully;  // y residual divideded by error
 
+  float strip_rechitx;     // x position of hit
+  float strip_rechity;     // y position of hit
+  float strip_rechitz;     // z position of hit
+  float strip_rechiterrx;  // x position error of hit (error not squared)
+  float strip_rechiterry;  // y position error of hit (error not squared)
+  float strip_rechitresx;  // difference between reconstructed hit x position and 'true' x position
 
-
-
-
-  float strip_rechitx; // x position of hit 
-  float strip_rechity; // y position of hit
-  float strip_rechitz; // z position of hit
-  float strip_rechiterrx; // x position error of hit (error not squared)
-  float strip_rechiterry; // y position error of hit (error not squared)
-  float strip_rechitresx; // difference between reconstructed hit x position and 'true' x position
-  
-  
   float strip_rechitresx2;
 
-  float strip_rechitresy; // difference between reconstructed hit y position and 'true' y position
-  float strip_rechitpullx; // x residual divideded by error
-  float strip_rechitpully; // y residual divideded by error
+  float strip_rechitresy;   // difference between reconstructed hit y position and 'true' y position
+  float strip_rechitpullx;  // x residual divideded by error
+  float strip_rechitpully;  // y residual divideded by error
   int strip_is_stereo;
-  int strip_hit_type; // matched=0, 1D=1 or 2D=2
-  int detector_type; //IB1=1, IB2=2, OB1=3, OB2=4
+  int strip_hit_type;  // matched=0, 1D=1 or 2D=2
+  int detector_type;   //IB1=1, IB2=2, OB1=3, OB2=4
 
   float strip_trk_pt;
   float strip_cotalpha;
@@ -129,52 +119,52 @@ class SiPixelErrorEstimation : public edm::EDAnalyzer
   float strip_charge;
   int strip_size;
   int strip_edge;
-  int strip_nsimhit; // number of simhits associated with a rechit
-  int strip_pidhit; // PID of the particle that produced the simHit associated with the recHit
-  int strip_simproc; // procces type
+  int strip_nsimhit;  // number of simhits associated with a rechit
+  int strip_pidhit;   // PID of the particle that produced the simHit associated with the recHit
+  int strip_simproc;  // procces type
 
-  int strip_subdet_id; // enum SubDetector { UNKNOWN=0, TIB=3, TID=4, TOB=5, TEC=6 };
- 
-  int strip_tib_layer             ;
-  int strip_tib_module            ;
-  int strip_tib_order             ;
-  int strip_tib_side              ;
-  int strip_tib_is_double_side    ;
-  int strip_tib_is_z_plus_side    ;
-  int strip_tib_is_z_minus_side   ;
-  int strip_tib_layer_number      ;
-  int strip_tib_string_number     ;
-  int strip_tib_module_number     ;
+  int strip_subdet_id;  // enum SubDetector { UNKNOWN=0, TIB=3, TID=4, TOB=5, TEC=6 };
+
+  int strip_tib_layer;
+  int strip_tib_module;
+  int strip_tib_order;
+  int strip_tib_side;
+  int strip_tib_is_double_side;
+  int strip_tib_is_z_plus_side;
+  int strip_tib_is_z_minus_side;
+  int strip_tib_layer_number;
+  int strip_tib_string_number;
+  int strip_tib_module_number;
   int strip_tib_is_internal_string;
   int strip_tib_is_external_string;
-  int strip_tib_is_rphi           ;
-  int strip_tib_is_stereo         ;          
-  
-  int strip_tob_layer             ;
-  int strip_tob_module            ;
-  //int strip_tob_order             ;
-  int strip_tob_side              ;
-  int strip_tob_is_double_side    ;
-  int strip_tob_is_z_plus_side    ;
-  int strip_tob_is_z_minus_side   ;
-  int strip_tob_layer_number      ;
-  int strip_tob_rod_number     ;
-  int strip_tob_module_number     ;
+  int strip_tib_is_rphi;
+  int strip_tib_is_stereo;
 
-  int strip_tob_is_rphi           ;
-  int strip_tob_is_stereo         ;     
+  int strip_tob_layer;
+  int strip_tob_module;
+  //int strip_tob_order             ;
+  int strip_tob_side;
+  int strip_tob_is_double_side;
+  int strip_tob_is_z_plus_side;
+  int strip_tob_is_z_minus_side;
+  int strip_tob_layer_number;
+  int strip_tob_rod_number;
+  int strip_tob_module_number;
+
+  int strip_tob_is_rphi;
+  int strip_tob_is_stereo;
 
   float strip_prob;
-  int   strip_qbin;
-  
-  int   strip_nprm;
+  int strip_qbin;
+
+  int strip_nprm;
 
   int strip_pidhit1;
   int strip_simproc1;
-  
+
   int strip_pidhit2;
   int strip_simproc2;
-  
+
   int strip_pidhit3;
   int strip_simproc3;
 
@@ -188,45 +178,45 @@ class SiPixelErrorEstimation : public edm::EDAnalyzer
   float strip_clst_err_x;
   float strip_clst_err_y;
 
-  int npix; // number of pixel in the cluster
-  int nxpix; // size of cluster (number of pixels) along x direction
-  int nypix; // size of cluster (number of pixels) along y direction
-  float charge; // total charge in cluster
+  int npix;      // number of pixel in the cluster
+  int nxpix;     // size of cluster (number of pixels) along x direction
+  int nypix;     // size of cluster (number of pixels) along y direction
+  float charge;  // total charge in cluster
 
-  int edgex; // edgex = 1 if the cluster is at the x edge of the module  
-  int edgey; // edgey = 1 if the cluster is at the y edge of the module 
+  int edgex;  // edgex = 1 if the cluster is at the x edge of the module
+  int edgey;  // edgey = 1 if the cluster is at the y edge of the module
 
-  int bigx; // bigx = 1 if the cluster contains at least one big pixel in x
-  int bigy; // bigy = 1 if the cluster contains at least one big pixel in y
+  int bigx;  // bigx = 1 if the cluster contains at least one big pixel in x
+  int bigy;  // bigy = 1 if the cluster contains at least one big pixel in y
 
-  float alpha; // track angle in the xz plane of the module local coordinate system  
-  float beta;  // track angle in the yz plane of the module local coordinate system  
+  float alpha;  // track angle in the xz plane of the module local coordinate system
+  float beta;   // track angle in the yz plane of the module local coordinate system
 
-  float trk_alpha; // reconstructed track angle in the xz plane of the module local coordinate system  
-  float trk_beta;  // reconstructed track angle in the yz plane of the module local coordinate system  
+  float trk_alpha;  // reconstructed track angle in the xz plane of the module local coordinate system
+  float trk_beta;   // reconstructed track angle in the yz plane of the module local coordinate system
 
-  float phi;   // polar track angle
-  float eta;   // pseudo-rapidity (function of theta, the azimuthal angle)
+  float phi;  // polar track angle
+  float eta;  // pseudo-rapidity (function of theta, the azimuthal angle)
 
   int subdetId;
-  int layer;  
-  int ladder; 
-  int mod;    
-  int side;    
-  int disk;   
-  int blade;  
-  int panel;  
-  int plaq;   
- 
-  int half; // half = 1 if the barrel module is half size and 0 if it is full size (only defined for barrel) 
-  int flipped; // flipped = 1 if the module is flipped and 0 if non-flipped (only defined for barrel) 
+  int layer;
+  int ladder;
+  int mod;
+  int side;
+  int disk;
+  int blade;
+  int panel;
+  int plaq;
 
-  int nsimhit; // number of simhits associated with a rechit
-  int pidhit; // PID of the particle that produced the simHit associated with the recHit
-  int simproc; // procces tye
+  int half;     // half = 1 if the barrel module is half size and 0 if it is full size (only defined for barrel)
+  int flipped;  // flipped = 1 if the module is flipped and 0 if non-flipped (only defined for barrel)
 
-  float simhitx; // true x position of hit 
-  float simhity; // true y position of hit
+  int nsimhit;  // number of simhits associated with a rechit
+  int pidhit;   // PID of the particle that produced the simHit associated with the recHit
+  int simproc;  // procces tye
+
+  float simhitx;  // true x position of hit
+  float simhity;  // true y position of hit
 
   int evt;
   int run;
@@ -242,9 +232,8 @@ class SiPixelErrorEstimation : public edm::EDAnalyzer
   float pixel_clst_err_x;
   float pixel_clst_err_y;
 
+  // variables that go in the output ttree_sll_hits_
 
-   // variables that go in the output ttree_sll_hits_
-  
   int all_subdetid;
 
   int all_layer;
@@ -256,7 +245,7 @@ class SiPixelErrorEstimation : public edm::EDAnalyzer
   int all_blade;
   int all_panel;
   int all_plaq;
-  
+
   int all_half;
   int all_flipped;
 
@@ -360,7 +349,7 @@ class SiPixelErrorEstimation : public edm::EDAnalyzer
   float all_pixgx[maxpix];
   float all_pixgy[maxpix];
   float all_pixgz[maxpix];
-    
+
   float all_hit_probx;
   float all_hit_proby;
   float all_hit_cprob0;
@@ -371,15 +360,14 @@ class SiPixelErrorEstimation : public edm::EDAnalyzer
   float all_pixel_clst_err_x;
   float all_pixel_clst_err_y;
 
-
   // ----------------------------------
 
-  TFile * tfile_;
-  TTree * ttree_all_hits_;
-  TTree * ttree_track_hits_;
+  TFile* tfile_;
+  TTree* ttree_all_hits_;
+  TTree* ttree_track_hits_;
 
-  TTree * ttree_track_hits_strip_;
-  
+  TTree* ttree_track_hits_strip_;
+
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 };
 

--- a/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
+++ b/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
@@ -10,7 +10,7 @@
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/DetId/interface/DetId.h" 
+#include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
@@ -32,260 +32,263 @@
 using namespace std;
 using namespace edm;
 
-SiPixelErrorEstimation::SiPixelErrorEstimation(const edm::ParameterSet& ps):tfile_(nullptr), ttree_all_hits_(nullptr), 
-									    ttree_track_hits_(nullptr), ttree_track_hits_strip_(nullptr),
-									    trackerHitAssociatorConfig_(consumesCollector())
-{
+SiPixelErrorEstimation::SiPixelErrorEstimation(const edm::ParameterSet& ps)
+    : tfile_(nullptr),
+      ttree_all_hits_(nullptr),
+      ttree_track_hits_(nullptr),
+      ttree_track_hits_strip_(nullptr),
+      trackerHitAssociatorConfig_(consumesCollector()) {
   //Read config file
-  outputFile_ = ps.getUntrackedParameter<string>( "outputFile", "SiPixelErrorEstimation_Ntuple.root" );
-  
+  outputFile_ = ps.getUntrackedParameter<string>("outputFile", "SiPixelErrorEstimation_Ntuple.root");
+
   // Replace  "ctfWithMaterialTracks" with "generalTracks"
   //src_ = ps.getUntrackedParameter<std::string>( "src", "ctfWithMaterialTracks" );
-  src_ = ps.getUntrackedParameter<std::string>( "src", "generalTracks" );
+  src_ = ps.getUntrackedParameter<std::string>("src", "generalTracks");
 
-  checkType_ = ps.getParameter<bool>( "checkType" );
-  genType_ = ps.getParameter<int>( "genType" );
-  include_trk_hits_ = ps.getParameter<bool>( "include_trk_hits" );
+  checkType_ = ps.getParameter<bool>("checkType");
+  genType_ = ps.getParameter<int>("genType");
+  include_trk_hits_ = ps.getParameter<bool>("include_trk_hits");
 
-  tTrajectory = consumes<std::vector<Trajectory>> (src_);
-  tPixRecHitCollection = consumes<SiPixelRecHitCollection>(edm::InputTag( "siPixelRecHits"));
-  tSimTrackContainer = consumes <edm::SimTrackContainer>(edm::InputTag("g4SimHits"));
+  tTrajectory = consumes<std::vector<Trajectory>>(src_);
+  tPixRecHitCollection = consumes<SiPixelRecHitCollection>(edm::InputTag("siPixelRecHits"));
+  tSimTrackContainer = consumes<edm::SimTrackContainer>(edm::InputTag("g4SimHits"));
   tTrackCollection = consumes<reco::TrackCollection>(src_);
-
 }
 
-SiPixelErrorEstimation::~SiPixelErrorEstimation()
-{}
+SiPixelErrorEstimation::~SiPixelErrorEstimation() {}
 
-void SiPixelErrorEstimation::beginJob()
-{
-   int bufsize = 64000;
+void SiPixelErrorEstimation::beginJob() {
+  int bufsize = 64000;
 
+  tfile_ = new TFile(outputFile_.c_str(), "RECREATE");
 
-  tfile_ = new TFile ( outputFile_.c_str() , "RECREATE");
-
-  
   ttree_track_hits_strip_ = new TTree("TrackHitNtupleStrip", "TrackHitNtupleStrip");
-  
-  ttree_track_hits_strip_->Branch("strip_rechitx", &strip_rechitx, "strip_rechitx/F"    , bufsize);
-  ttree_track_hits_strip_->Branch("strip_rechity", &strip_rechity, "strip_rechity/F"    , bufsize);
-  ttree_track_hits_strip_->Branch("strip_rechitz", &strip_rechitz, "strip_rechitz/F"    , bufsize);
-  
-  ttree_track_hits_strip_->Branch("strip_rechiterrx", &strip_rechiterrx, "strip_rechiterrx/F" , bufsize);
-  ttree_track_hits_strip_->Branch("strip_rechiterry", &strip_rechiterry, "strip_rechiterry/F" , bufsize);
 
-  ttree_track_hits_strip_->Branch("strip_rechitresx", &strip_rechitresx, "strip_rechitresx/F" , bufsize);
-  
-  ttree_track_hits_strip_->Branch("strip_rechitresx2", &strip_rechitresx2, "strip_rechitresx2/F" , bufsize);
+  ttree_track_hits_strip_->Branch("strip_rechitx", &strip_rechitx, "strip_rechitx/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_rechity", &strip_rechity, "strip_rechity/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_rechitz", &strip_rechitz, "strip_rechitz/F", bufsize);
 
+  ttree_track_hits_strip_->Branch("strip_rechiterrx", &strip_rechiterrx, "strip_rechiterrx/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_rechiterry", &strip_rechiterry, "strip_rechiterry/F", bufsize);
 
-  ttree_track_hits_strip_->Branch("strip_rechitresy", &strip_rechitresy, "strip_rechitresy/F" , bufsize);
-  
+  ttree_track_hits_strip_->Branch("strip_rechitresx", &strip_rechitresx, "strip_rechitresx/F", bufsize);
+
+  ttree_track_hits_strip_->Branch("strip_rechitresx2", &strip_rechitresx2, "strip_rechitresx2/F", bufsize);
+
+  ttree_track_hits_strip_->Branch("strip_rechitresy", &strip_rechitresy, "strip_rechitresy/F", bufsize);
+
   ttree_track_hits_strip_->Branch("strip_rechitpullx", &strip_rechitpullx, "strip_rechitpullx/F", bufsize);
   ttree_track_hits_strip_->Branch("strip_rechitpully", &strip_rechitpully, "strip_rechitpully/F", bufsize);
 
   ttree_track_hits_strip_->Branch("strip_is_stereo", &strip_is_stereo, "strip_is_stereo/I", bufsize);
-  ttree_track_hits_strip_->Branch("strip_hit_type" , &strip_hit_type , "strip_hit_type/I" , bufsize);
-  ttree_track_hits_strip_->Branch("detector_type"  , &detector_type  , "detector_type/I"  , bufsize);
+  ttree_track_hits_strip_->Branch("strip_hit_type", &strip_hit_type, "strip_hit_type/I", bufsize);
+  ttree_track_hits_strip_->Branch("detector_type", &detector_type, "detector_type/I", bufsize);
 
-  ttree_track_hits_strip_->Branch("strip_trk_pt"   , &strip_trk_pt   , "strip_trk_pt/F"   , bufsize);
-  ttree_track_hits_strip_->Branch("strip_cotalpha" , &strip_cotalpha , "strip_cotalpha/F" , bufsize);
-  ttree_track_hits_strip_->Branch("strip_cotbeta"  , &strip_cotbeta  , "strip_cotbeta/F"  , bufsize);
-  ttree_track_hits_strip_->Branch("strip_locbx"    , &strip_locbx    , "strip_locbx/F"    , bufsize);
-  ttree_track_hits_strip_->Branch("strip_locby"    , &strip_locby    , "strip_locby/F"    , bufsize);
-  ttree_track_hits_strip_->Branch("strip_locbz"    , &strip_locbz    , "strip_locbz/F"    , bufsize);
-  ttree_track_hits_strip_->Branch("strip_charge"   , &strip_charge   , "strip_charge/F"   , bufsize);
-  ttree_track_hits_strip_->Branch("strip_size"     , &strip_size     , "strip_size/I"     , bufsize);
+  ttree_track_hits_strip_->Branch("strip_trk_pt", &strip_trk_pt, "strip_trk_pt/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_cotalpha", &strip_cotalpha, "strip_cotalpha/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_cotbeta", &strip_cotbeta, "strip_cotbeta/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_locbx", &strip_locbx, "strip_locbx/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_locby", &strip_locby, "strip_locby/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_locbz", &strip_locbz, "strip_locbz/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_charge", &strip_charge, "strip_charge/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_size", &strip_size, "strip_size/I", bufsize);
 
-  
-  ttree_track_hits_strip_->Branch("strip_edge"   , &strip_edge   , "strip_edge/I"    , bufsize);
-  ttree_track_hits_strip_->Branch("strip_nsimhit", &strip_nsimhit, "strip_nsimhit/I" , bufsize);
-  ttree_track_hits_strip_->Branch("strip_pidhit" , &strip_pidhit , "strip_pidhit/I"  , bufsize);
-  ttree_track_hits_strip_->Branch("strip_simproc", &strip_simproc, "strip_simproc/I" , bufsize);
+  ttree_track_hits_strip_->Branch("strip_edge", &strip_edge, "strip_edge/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_nsimhit", &strip_nsimhit, "strip_nsimhit/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_pidhit", &strip_pidhit, "strip_pidhit/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_simproc", &strip_simproc, "strip_simproc/I", bufsize);
 
+  ttree_track_hits_strip_->Branch("strip_subdet_id", &strip_subdet_id, "strip_subdet_id/I", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_subdet_id"             , &strip_subdet_id             , "strip_subdet_id/I"            , bufsize);
- 
-ttree_track_hits_strip_->Branch("strip_tib_layer"             , &strip_tib_layer             , "strip_tib_layer/I"            , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_module"            , &strip_tib_module            , "strip_tib_module/I"           , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_order"             , &strip_tib_order             , "strip_tib_order/I"            , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_side"              , &strip_tib_side              , "strip_tib_side/I"             , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_is_double_side"    , &strip_tib_is_double_side    , "strip_tib_is_double_side/I"   , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_is_z_plus_side"    , &strip_tib_is_z_plus_side    , "strip_tib_is_z_plus_side/I"   , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_is_z_minus_side"   , &strip_tib_is_z_minus_side   , "strip_tib_is_z_minus_side/I"  , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_layer_number"      , &strip_tib_layer_number      , "strip_tib_layer_number/I"     , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_string_number"     , &strip_tib_string_number     , "strip_tib_string_number/I"    , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_module_number"     , &strip_tib_module_number     ,"strip_tib_module_number/I"     , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_is_internal_string", &strip_tib_is_internal_string,"strip_tib_is_internal_string/I", bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_is_external_string", &strip_tib_is_external_string,"strip_tib_is_external_string/I", bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_is_rphi"           , &strip_tib_is_rphi           , "strip_tib_is_rphi/I"          , bufsize);
-ttree_track_hits_strip_->Branch("strip_tib_is_stereo"         , &strip_tib_is_stereo         , "strip_tib_is_stereo/I"        , bufsize);
-ttree_track_hits_strip_->Branch("strip_tob_layer"             , &strip_tob_layer             , "strip_tob_layer/I"            , bufsize);
-ttree_track_hits_strip_->Branch("strip_tob_module"            , &strip_tob_module            , "strip_tob_module/I"           , bufsize);
-ttree_track_hits_strip_->Branch("strip_tob_side"              , &strip_tob_side              , "strip_tob_side/I"             , bufsize);
-ttree_track_hits_strip_->Branch("strip_tob_is_double_side"    , &strip_tob_is_double_side    , "strip_tob_is_double_side/I"   , bufsize);
-ttree_track_hits_strip_->Branch("strip_tob_is_z_plus_side"    , &strip_tob_is_z_plus_side    , "strip_tob_is_z_plus_side/I"   , bufsize);
-ttree_track_hits_strip_->Branch("strip_tob_is_z_minus_side"   , &strip_tob_is_z_minus_side   , "strip_tob_is_z_minus_side/I"  , bufsize);
-ttree_track_hits_strip_->Branch("strip_tob_layer_number"      , &strip_tob_layer_number      , "strip_tob_layer_number/I"     , bufsize);
-ttree_track_hits_strip_->Branch("strip_tob_rod_number"        , &strip_tob_rod_number        , "strip_tob_rod_number/I"       , bufsize);
-ttree_track_hits_strip_->Branch("strip_tob_module_number"     , &strip_tob_module_number     , "strip_tob_module_number/I"    , bufsize);
+  ttree_track_hits_strip_->Branch("strip_tib_layer", &strip_tib_layer, "strip_tib_layer/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_tib_module", &strip_tib_module, "strip_tib_module/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_tib_order", &strip_tib_order, "strip_tib_order/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_tib_side", &strip_tib_side, "strip_tib_side/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tib_is_double_side", &strip_tib_is_double_side, "strip_tib_is_double_side/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tib_is_z_plus_side", &strip_tib_is_z_plus_side, "strip_tib_is_z_plus_side/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tib_is_z_minus_side", &strip_tib_is_z_minus_side, "strip_tib_is_z_minus_side/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tib_layer_number", &strip_tib_layer_number, "strip_tib_layer_number/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tib_string_number", &strip_tib_string_number, "strip_tib_string_number/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tib_module_number", &strip_tib_module_number, "strip_tib_module_number/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tib_is_internal_string", &strip_tib_is_internal_string, "strip_tib_is_internal_string/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tib_is_external_string", &strip_tib_is_external_string, "strip_tib_is_external_string/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_tib_is_rphi", &strip_tib_is_rphi, "strip_tib_is_rphi/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_tib_is_stereo", &strip_tib_is_stereo, "strip_tib_is_stereo/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_tob_layer", &strip_tob_layer, "strip_tob_layer/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_tob_module", &strip_tob_module, "strip_tob_module/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_tob_side", &strip_tob_side, "strip_tob_side/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tob_is_double_side", &strip_tob_is_double_side, "strip_tob_is_double_side/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tob_is_z_plus_side", &strip_tob_is_z_plus_side, "strip_tob_is_z_plus_side/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tob_is_z_minus_side", &strip_tob_is_z_minus_side, "strip_tob_is_z_minus_side/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tob_layer_number", &strip_tob_layer_number, "strip_tob_layer_number/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_tob_rod_number", &strip_tob_rod_number, "strip_tob_rod_number/I", bufsize);
+  ttree_track_hits_strip_->Branch(
+      "strip_tob_module_number", &strip_tob_module_number, "strip_tob_module_number/I", bufsize);
 
+  ttree_track_hits_strip_->Branch("strip_prob", &strip_prob, "strip_prob/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_qbin", &strip_qbin, "strip_qbin/I", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_prob", &strip_prob, "strip_prob/F"   , bufsize);
-ttree_track_hits_strip_->Branch("strip_qbin", &strip_qbin, "strip_qbin/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_nprm", &strip_nprm, "strip_nprm/I", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_nprm", &strip_nprm, "strip_nprm/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_pidhit1", &strip_pidhit1, "strip_pidhit1/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_simproc1", &strip_simproc1, "strip_simproc1/I", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_pidhit1" , &strip_pidhit1 , "strip_pidhit1/I"  , bufsize);
-ttree_track_hits_strip_->Branch("strip_simproc1", &strip_simproc1, "strip_simproc1/I" , bufsize);
+  ttree_track_hits_strip_->Branch("strip_pidhit2", &strip_pidhit2, "strip_pidhit2/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_simproc2", &strip_simproc2, "strip_simproc2/I", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_pidhit2" , &strip_pidhit2 , "strip_pidhit2/I"  , bufsize);
-ttree_track_hits_strip_->Branch("strip_simproc2", &strip_simproc2, "strip_simproc2/I" , bufsize);
+  ttree_track_hits_strip_->Branch("strip_pidhit3", &strip_pidhit3, "strip_pidhit3/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_simproc3", &strip_simproc3, "strip_simproc3/I", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_pidhit3" , &strip_pidhit3 , "strip_pidhit3/I"  , bufsize);
-ttree_track_hits_strip_->Branch("strip_simproc3", &strip_simproc3, "strip_simproc3/I" , bufsize);
+  ttree_track_hits_strip_->Branch("strip_pidhit4", &strip_pidhit4, "strip_pidhit4/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_simproc4", &strip_simproc4, "strip_simproc4/I", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_pidhit4" , &strip_pidhit4 , "strip_pidhit4/I"  , bufsize);
-ttree_track_hits_strip_->Branch("strip_simproc4", &strip_simproc4, "strip_simproc4/I" , bufsize);
+  ttree_track_hits_strip_->Branch("strip_pidhit5", &strip_pidhit5, "strip_pidhit5/I", bufsize);
+  ttree_track_hits_strip_->Branch("strip_simproc5", &strip_simproc5, "strip_simproc5/I", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_pidhit5" , &strip_pidhit5 , "strip_pidhit5/I"  , bufsize);
-ttree_track_hits_strip_->Branch("strip_simproc5", &strip_simproc5, "strip_simproc5/I" , bufsize);
+  ttree_track_hits_strip_->Branch("strip_split", &strip_split, "strip_split/I", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_split", &strip_split, "strip_split/I" , bufsize);
+  ttree_track_hits_strip_->Branch("strip_clst_err_x", &strip_clst_err_x, "strip_clst_err_x/F", bufsize);
+  ttree_track_hits_strip_->Branch("strip_clst_err_y", &strip_clst_err_y, "strip_clst_err_y/F", bufsize);
 
-ttree_track_hits_strip_->Branch("strip_clst_err_x", &strip_clst_err_x, "strip_clst_err_x/F"   , bufsize);
-ttree_track_hits_strip_->Branch("strip_clst_err_y", &strip_clst_err_y, "strip_clst_err_y/F"   , bufsize);
+  if (include_trk_hits_) {
+    //tfile_ = new TFile ("SiPixelErrorEstimation_Ntuple.root" , "RECREATE");
+    //const char* tmp_name = outputFile_.c_str();
 
- if ( include_trk_hits_ )
-   {
-     //tfile_ = new TFile ("SiPixelErrorEstimation_Ntuple.root" , "RECREATE");
-     //const char* tmp_name = outputFile_.c_str();
-     
-     
-     ttree_track_hits_ = new TTree("TrackHitNtuple", "TrackHitNtuple");
-     
-      ttree_track_hits_->Branch("evt", &evt, "evt/I", bufsize);
-      ttree_track_hits_->Branch("run", &run, "run/I", bufsize);
-      
-      ttree_track_hits_->Branch("subdetId", &subdetId, "subdetId/I", bufsize);
-      
-      ttree_track_hits_->Branch("layer" , &layer , "layer/I" , bufsize);
-      ttree_track_hits_->Branch("ladder", &ladder, "ladder/I", bufsize);
-      ttree_track_hits_->Branch("mod"   , &mod   , "mod/I"   , bufsize);
-      
-      ttree_track_hits_->Branch("side"  , &side  , "side/I"  , bufsize);
-      ttree_track_hits_->Branch("disk"  , &disk  , "disk/I"  , bufsize);
-      ttree_track_hits_->Branch("blade" , &blade , "blade/I" , bufsize);
-      ttree_track_hits_->Branch("panel" , &panel , "panel/I" , bufsize);
-      ttree_track_hits_->Branch("plaq"  , &plaq  , "plaq/I"  , bufsize);
-      
-      ttree_track_hits_->Branch("half"   , &half   , "half/I"   , bufsize);
-      ttree_track_hits_->Branch("flipped", &flipped, "flipped/I", bufsize);
-      
-      ttree_track_hits_->Branch("rechitx", &rechitx, "rechitx/F"    , bufsize);
-      ttree_track_hits_->Branch("rechity", &rechity, "rechity/F"    , bufsize);
-      ttree_track_hits_->Branch("rechitz", &rechitz, "rechitz/F"    , bufsize);
-      
-      ttree_track_hits_->Branch("rechiterrx", &rechiterrx, "rechiterrx/F" , bufsize);
-      ttree_track_hits_->Branch("rechiterry", &rechiterry, "rechiterry/F" , bufsize);
-      
-      ttree_track_hits_->Branch("rechitresx", &rechitresx, "rechitresx/F" , bufsize);
-      ttree_track_hits_->Branch("rechitresy", &rechitresy, "rechitresy/F" , bufsize);
-      
-      ttree_track_hits_->Branch("rechitpullx", &rechitpullx, "rechitpullx/F", bufsize);
-      ttree_track_hits_->Branch("rechitpully", &rechitpully, "rechitpully/F", bufsize);
+    ttree_track_hits_ = new TTree("TrackHitNtuple", "TrackHitNtuple");
 
-      
-      ttree_track_hits_->Branch("npix"  , &npix  , "npix/I"  , bufsize);
-      ttree_track_hits_->Branch("nxpix" , &nxpix , "nxpix/I" , bufsize);
-      ttree_track_hits_->Branch("nypix" , &nypix , "nypix/I" , bufsize);
-      ttree_track_hits_->Branch("charge", &charge, "charge/F", bufsize);
-      
-      ttree_track_hits_->Branch("edgex", &edgex, "edgex/I", bufsize);
-      ttree_track_hits_->Branch("edgey", &edgey, "edgey/I", bufsize);
-      
-      ttree_track_hits_->Branch("bigx", &bigx, "bigx/I", bufsize);
-      ttree_track_hits_->Branch("bigy", &bigy, "bigy/I", bufsize);
-      
-      ttree_track_hits_->Branch("alpha", &alpha, "alpha/F", bufsize);
-      ttree_track_hits_->Branch("beta" , &beta , "beta/F" , bufsize);
-      
-      ttree_track_hits_->Branch("trk_alpha", &trk_alpha, "trk_alpha/F", bufsize);
-      ttree_track_hits_->Branch("trk_beta" , &trk_beta , "trk_beta/F" , bufsize);
+    ttree_track_hits_->Branch("evt", &evt, "evt/I", bufsize);
+    ttree_track_hits_->Branch("run", &run, "run/I", bufsize);
 
-      ttree_track_hits_->Branch("phi", &phi, "phi/F", bufsize);
-      ttree_track_hits_->Branch("eta", &eta, "eta/F", bufsize);
-      
-      ttree_track_hits_->Branch("simhitx", &simhitx, "simhitx/F", bufsize);
-      ttree_track_hits_->Branch("simhity", &simhity, "simhity/F", bufsize);
-      
-      ttree_track_hits_->Branch("nsimhit", &nsimhit, "nsimhit/I", bufsize);
-      ttree_track_hits_->Branch("pidhit" , &pidhit , "pidhit/I" , bufsize);
-      ttree_track_hits_->Branch("simproc", &simproc, "simproc/I", bufsize);
-      
-      ttree_track_hits_->Branch("pixel_split", &pixel_split, "pixel_split/I", bufsize);
+    ttree_track_hits_->Branch("subdetId", &subdetId, "subdetId/I", bufsize);
 
-      ttree_track_hits_->Branch("pixel_clst_err_x", &pixel_clst_err_x, "pixel_clst_err_x/F"   , bufsize);
-      ttree_track_hits_->Branch("pixel_clst_err_y", &pixel_clst_err_y, "pixel_clst_err_y/F"   , bufsize);
+    ttree_track_hits_->Branch("layer", &layer, "layer/I", bufsize);
+    ttree_track_hits_->Branch("ladder", &ladder, "ladder/I", bufsize);
+    ttree_track_hits_->Branch("mod", &mod, "mod/I", bufsize);
 
-    } // if ( include_trk_hits_ )
+    ttree_track_hits_->Branch("side", &side, "side/I", bufsize);
+    ttree_track_hits_->Branch("disk", &disk, "disk/I", bufsize);
+    ttree_track_hits_->Branch("blade", &blade, "blade/I", bufsize);
+    ttree_track_hits_->Branch("panel", &panel, "panel/I", bufsize);
+    ttree_track_hits_->Branch("plaq", &plaq, "plaq/I", bufsize);
+
+    ttree_track_hits_->Branch("half", &half, "half/I", bufsize);
+    ttree_track_hits_->Branch("flipped", &flipped, "flipped/I", bufsize);
+
+    ttree_track_hits_->Branch("rechitx", &rechitx, "rechitx/F", bufsize);
+    ttree_track_hits_->Branch("rechity", &rechity, "rechity/F", bufsize);
+    ttree_track_hits_->Branch("rechitz", &rechitz, "rechitz/F", bufsize);
+
+    ttree_track_hits_->Branch("rechiterrx", &rechiterrx, "rechiterrx/F", bufsize);
+    ttree_track_hits_->Branch("rechiterry", &rechiterry, "rechiterry/F", bufsize);
+
+    ttree_track_hits_->Branch("rechitresx", &rechitresx, "rechitresx/F", bufsize);
+    ttree_track_hits_->Branch("rechitresy", &rechitresy, "rechitresy/F", bufsize);
+
+    ttree_track_hits_->Branch("rechitpullx", &rechitpullx, "rechitpullx/F", bufsize);
+    ttree_track_hits_->Branch("rechitpully", &rechitpully, "rechitpully/F", bufsize);
+
+    ttree_track_hits_->Branch("npix", &npix, "npix/I", bufsize);
+    ttree_track_hits_->Branch("nxpix", &nxpix, "nxpix/I", bufsize);
+    ttree_track_hits_->Branch("nypix", &nypix, "nypix/I", bufsize);
+    ttree_track_hits_->Branch("charge", &charge, "charge/F", bufsize);
+
+    ttree_track_hits_->Branch("edgex", &edgex, "edgex/I", bufsize);
+    ttree_track_hits_->Branch("edgey", &edgey, "edgey/I", bufsize);
+
+    ttree_track_hits_->Branch("bigx", &bigx, "bigx/I", bufsize);
+    ttree_track_hits_->Branch("bigy", &bigy, "bigy/I", bufsize);
+
+    ttree_track_hits_->Branch("alpha", &alpha, "alpha/F", bufsize);
+    ttree_track_hits_->Branch("beta", &beta, "beta/F", bufsize);
+
+    ttree_track_hits_->Branch("trk_alpha", &trk_alpha, "trk_alpha/F", bufsize);
+    ttree_track_hits_->Branch("trk_beta", &trk_beta, "trk_beta/F", bufsize);
+
+    ttree_track_hits_->Branch("phi", &phi, "phi/F", bufsize);
+    ttree_track_hits_->Branch("eta", &eta, "eta/F", bufsize);
+
+    ttree_track_hits_->Branch("simhitx", &simhitx, "simhitx/F", bufsize);
+    ttree_track_hits_->Branch("simhity", &simhity, "simhity/F", bufsize);
+
+    ttree_track_hits_->Branch("nsimhit", &nsimhit, "nsimhit/I", bufsize);
+    ttree_track_hits_->Branch("pidhit", &pidhit, "pidhit/I", bufsize);
+    ttree_track_hits_->Branch("simproc", &simproc, "simproc/I", bufsize);
+
+    ttree_track_hits_->Branch("pixel_split", &pixel_split, "pixel_split/I", bufsize);
+
+    ttree_track_hits_->Branch("pixel_clst_err_x", &pixel_clst_err_x, "pixel_clst_err_x/F", bufsize);
+    ttree_track_hits_->Branch("pixel_clst_err_y", &pixel_clst_err_y, "pixel_clst_err_y/F", bufsize);
+
+  }  // if ( include_trk_hits_ )
 
   // ----------------------------------------------------------------------
-  
+
   ttree_all_hits_ = new TTree("AllHitNtuple", "AllHitNtuple");
 
   ttree_all_hits_->Branch("evt", &evt, "evt/I", bufsize);
   ttree_all_hits_->Branch("run", &run, "run/I", bufsize);
 
   ttree_all_hits_->Branch("subdetid", &all_subdetid, "subdetid/I", bufsize);
-  
-  ttree_all_hits_->Branch("layer" , &all_layer , "layer/I" , bufsize);
-  ttree_all_hits_->Branch("ladder", &all_ladder, "ladder/I", bufsize);
-  ttree_all_hits_->Branch("mod"   , &all_mod   , "mod/I"   , bufsize);
-  
-  ttree_all_hits_->Branch("side"  , &all_side  , "side/I"  , bufsize);
-  ttree_all_hits_->Branch("disk"  , &all_disk  , "disk/I"  , bufsize);
-  ttree_all_hits_->Branch("blade" , &all_blade , "blade/I" , bufsize);
-  ttree_all_hits_->Branch("panel" , &all_panel , "panel/I" , bufsize);
-  ttree_all_hits_->Branch("plaq"  , &all_plaq  , "plaq/I"  , bufsize);
 
-  ttree_all_hits_->Branch("half"   , &all_half   , "half/I"   , bufsize);
+  ttree_all_hits_->Branch("layer", &all_layer, "layer/I", bufsize);
+  ttree_all_hits_->Branch("ladder", &all_ladder, "ladder/I", bufsize);
+  ttree_all_hits_->Branch("mod", &all_mod, "mod/I", bufsize);
+
+  ttree_all_hits_->Branch("side", &all_side, "side/I", bufsize);
+  ttree_all_hits_->Branch("disk", &all_disk, "disk/I", bufsize);
+  ttree_all_hits_->Branch("blade", &all_blade, "blade/I", bufsize);
+  ttree_all_hits_->Branch("panel", &all_panel, "panel/I", bufsize);
+  ttree_all_hits_->Branch("plaq", &all_plaq, "plaq/I", bufsize);
+
+  ttree_all_hits_->Branch("half", &all_half, "half/I", bufsize);
   ttree_all_hits_->Branch("flipped", &all_flipped, "flipped/I", bufsize);
 
   ttree_all_hits_->Branch("cols", &all_cols, "cols/I", bufsize);
   ttree_all_hits_->Branch("rows", &all_rows, "rows/I", bufsize);
 
-  ttree_all_hits_->Branch("rechitx"    , &all_rechitx    , "rechitx/F"    , bufsize);
-  ttree_all_hits_->Branch("rechity"    , &all_rechity    , "rechity/F"    , bufsize);
-  ttree_all_hits_->Branch("rechitz"    , &all_rechitz    , "rechitz/F"    , bufsize);
- 
-  ttree_all_hits_->Branch("rechiterrx" , &all_rechiterrx , "rechiterrx/F" , bufsize);
-  ttree_all_hits_->Branch("rechiterry" , &all_rechiterry , "rechiterry/F" , bufsize);
-  
-  ttree_all_hits_->Branch("rechitresx" , &all_rechitresx , "rechitresx/F" , bufsize);
-  ttree_all_hits_->Branch("rechitresy" , &all_rechitresy , "rechitresy/F" , bufsize);
-  
+  ttree_all_hits_->Branch("rechitx", &all_rechitx, "rechitx/F", bufsize);
+  ttree_all_hits_->Branch("rechity", &all_rechity, "rechity/F", bufsize);
+  ttree_all_hits_->Branch("rechitz", &all_rechitz, "rechitz/F", bufsize);
+
+  ttree_all_hits_->Branch("rechiterrx", &all_rechiterrx, "rechiterrx/F", bufsize);
+  ttree_all_hits_->Branch("rechiterry", &all_rechiterry, "rechiterry/F", bufsize);
+
+  ttree_all_hits_->Branch("rechitresx", &all_rechitresx, "rechitresx/F", bufsize);
+  ttree_all_hits_->Branch("rechitresy", &all_rechitresy, "rechitresy/F", bufsize);
+
   ttree_all_hits_->Branch("rechitpullx", &all_rechitpullx, "rechitpullx/F", bufsize);
   ttree_all_hits_->Branch("rechitpully", &all_rechitpully, "rechitpully/F", bufsize);
 
-  ttree_all_hits_->Branch("npix"  , &all_npix  , "npix/I"  , bufsize);
-  ttree_all_hits_->Branch("nxpix" , &all_nxpix , "nxpix/I" , bufsize);
-  ttree_all_hits_->Branch("nypix" , &all_nypix , "nypix/I" , bufsize);
+  ttree_all_hits_->Branch("npix", &all_npix, "npix/I", bufsize);
+  ttree_all_hits_->Branch("nxpix", &all_nxpix, "nxpix/I", bufsize);
+  ttree_all_hits_->Branch("nypix", &all_nypix, "nypix/I", bufsize);
 
   ttree_all_hits_->Branch("edgex", &all_edgex, "edgex/I", bufsize);
   ttree_all_hits_->Branch("edgey", &all_edgey, "edgey/I", bufsize);
- 
+
   ttree_all_hits_->Branch("bigx", &all_bigx, "bigx/I", bufsize);
   ttree_all_hits_->Branch("bigy", &all_bigy, "bigy/I", bufsize);
-  
+
   ttree_all_hits_->Branch("alpha", &all_alpha, "alpha/F", bufsize);
-  ttree_all_hits_->Branch("beta" , &all_beta , "beta/F" , bufsize);
+  ttree_all_hits_->Branch("beta", &all_beta, "beta/F", bufsize);
 
   ttree_all_hits_->Branch("simhitx", &all_simhitx, "simhitx/F", bufsize);
   ttree_all_hits_->Branch("simhity", &all_simhity, "simhity/F", bufsize);
 
   ttree_all_hits_->Branch("nsimhit", &all_nsimhit, "nsimhit/I", bufsize);
-  ttree_all_hits_->Branch("pidhit" , &all_pidhit , "pidhit/I" , bufsize);
+  ttree_all_hits_->Branch("pidhit", &all_pidhit, "pidhit/I", bufsize);
   ttree_all_hits_->Branch("simproc", &all_simproc, "simproc/I", bufsize);
 
   ttree_all_hits_->Branch("vtxr", &all_vtxr, "vtxr/F", bufsize);
@@ -296,12 +299,12 @@ ttree_track_hits_strip_->Branch("strip_clst_err_y", &strip_clst_err_y, "strip_cl
   ttree_all_hits_->Branch("simpz", &all_simpz, "simpz/F", bufsize);
 
   ttree_all_hits_->Branch("eloss", &all_eloss, "eloss/F", bufsize);
-  
+
   ttree_all_hits_->Branch("simphi", &all_simphi, "simphi/F", bufsize);
   ttree_all_hits_->Branch("simtheta", &all_simtheta, "simtheta/F", bufsize);
-  
+
   ttree_all_hits_->Branch("trkid", &all_trkid, "trkid/I", bufsize);
-  
+
   ttree_all_hits_->Branch("x1", &all_x1, "x1/F", bufsize);
   ttree_all_hits_->Branch("x2", &all_x2, "x2/F", bufsize);
   ttree_all_hits_->Branch("y1", &all_x1, "y1/F", bufsize);
@@ -320,13 +323,13 @@ ttree_track_hits_strip_->Branch("strip_clst_err_y", &strip_clst_err_y, "strip_cl
   ttree_all_hits_->Branch("gy2", &all_gx2, "gy2/F", bufsize);
   ttree_all_hits_->Branch("gz1", &all_gx1, "gz1/F", bufsize);
   ttree_all_hits_->Branch("gz2", &all_gx2, "gz2/F", bufsize);
-  
+
   ttree_all_hits_->Branch("simtrketa", &all_simtrketa, "simtrketa/F", bufsize);
   ttree_all_hits_->Branch("simtrkphi", &all_simtrkphi, "simtrkphi/F", bufsize);
 
   ttree_all_hits_->Branch("clust_row", &all_clust_row, "clust_row/F", bufsize);
   ttree_all_hits_->Branch("clust_col", &all_clust_col, "clust_col/F", bufsize);
-  
+
   ttree_all_hits_->Branch("clust_x", &all_clust_x, "clust_x/F", bufsize);
   ttree_all_hits_->Branch("clust_y", &all_clust_y, "clust_y/F", bufsize);
 
@@ -336,11 +339,11 @@ ttree_track_hits_strip_->Branch("strip_clst_err_y", &strip_clst_err_y, "strip_cl
   ttree_all_hits_->Branch("clust_maxpixrow", &all_clust_maxpixrow, "clust_maxpixrow/I", bufsize);
   ttree_all_hits_->Branch("clust_minpixcol", &all_clust_minpixcol, "clust_minpixcol/I", bufsize);
   ttree_all_hits_->Branch("clust_minpixrow", &all_clust_minpixrow, "clust_minpixrow/I", bufsize);
-  
+
   ttree_all_hits_->Branch("clust_geoid", &all_clust_geoid, "clust_geoid/I", bufsize);
-  
+
   ttree_all_hits_->Branch("clust_alpha", &all_clust_alpha, "clust_alpha/F", bufsize);
-  ttree_all_hits_->Branch("clust_beta" , &all_clust_beta , "clust_beta/F" , bufsize);
+  ttree_all_hits_->Branch("clust_beta", &all_clust_beta, "clust_beta/F", bufsize);
 
   ttree_all_hits_->Branch("rowpix", all_pixrow, "row[npix]/F", bufsize);
   ttree_all_hits_->Branch("colpix", all_pixcol, "col[npix]/F", bufsize);
@@ -350,42 +353,38 @@ ttree_track_hits_strip_->Branch("strip_clst_err_y", &strip_clst_err_y, "strip_cl
   ttree_all_hits_->Branch("gxpix", all_pixgx, "gx[npix]/F", bufsize);
   ttree_all_hits_->Branch("gypix", all_pixgy, "gy[npix]/F", bufsize);
   ttree_all_hits_->Branch("gzpix", all_pixgz, "gz[npix]/F", bufsize);
-  
-  ttree_all_hits_->Branch("hit_probx", &all_hit_probx, "hit_probx/F" , bufsize);
-  ttree_all_hits_->Branch("hit_proby", &all_hit_proby, "hit_proby/F" , bufsize);
 
-  ttree_all_hits_->Branch("all_pixel_split", &all_pixel_split, "all_pixel_split/I" , bufsize);
+  ttree_all_hits_->Branch("hit_probx", &all_hit_probx, "hit_probx/F", bufsize);
+  ttree_all_hits_->Branch("hit_proby", &all_hit_proby, "hit_proby/F", bufsize);
 
-  ttree_all_hits_->Branch("all_pixel_clst_err_x", &all_pixel_clst_err_x, "all_pixel_clst_err_x/F"   , bufsize);
-  ttree_all_hits_->Branch("all_pixel_clst_err_y", &all_pixel_clst_err_y, "all_pixel_clst_err_y/F"   , bufsize);
+  ttree_all_hits_->Branch("all_pixel_split", &all_pixel_split, "all_pixel_split/I", bufsize);
 
+  ttree_all_hits_->Branch("all_pixel_clst_err_x", &all_pixel_clst_err_x, "all_pixel_clst_err_x/F", bufsize);
+  ttree_all_hits_->Branch("all_pixel_clst_err_y", &all_pixel_clst_err_y, "all_pixel_clst_err_y/F", bufsize);
 }
 
-void SiPixelErrorEstimation::endJob() 
-{
+void SiPixelErrorEstimation::endJob() {
   tfile_->Write();
   tfile_->Close();
 }
 
-void
-SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
-{
+void SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   es.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
   using namespace edm;
-  
+
   run = e.id().run();
   evt = e.id().event();
-  
-  if ( evt%1000 == 0 ) 
+
+  if (evt % 1000 == 0)
     cout << "evt = " << evt << endl;
 
   float math_pi = 3.14159265;
   float radtodeg = 180.0 / math_pi;
-    
+
   LocalPoint position;
   LocalError error;
   float mindist = 999999.9;
@@ -394,409 +393,354 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
   TrackerHitAssociator associate(e, trackerHitAssociatorConfig_);
 
   edm::ESHandle<TrackerGeometry> pDD;
-  es.get<TrackerDigiGeometryRecord> ().get (pDD);
-  const TrackerGeometry* tracker = &(* pDD);
-  
+  es.get<TrackerDigiGeometryRecord>().get(pDD);
+  const TrackerGeometry* tracker = &(*pDD);
 
   //cout << "...1..." << endl;
 
-
   edm::ESHandle<MagneticField> magneticField;
-  es.get<IdealMagneticFieldRecord>().get( magneticField );
+  es.get<IdealMagneticFieldRecord>().get(magneticField);
   //const MagneticField* magField_ = magFieldHandle.product();
 
   edm::FileInPath FileInPath_;
-    
-
 
   // Strip hits ==============================================================================================================
 
+  edm::Handle<vector<Trajectory>> trajCollectionHandle;
 
-  edm::Handle<vector<Trajectory> > trajCollectionHandle;
-  
-  e.getByToken( tTrajectory, trajCollectionHandle);
+  e.getByToken(tTrajectory, trajCollectionHandle);
   //e.getByLabel( "generalTracks", trajCollectionHandle);
 
-  for ( vector<Trajectory>::const_iterator it = trajCollectionHandle->begin(); it!=trajCollectionHandle->end(); ++it )
-    {
-      
-      vector<TrajectoryMeasurement> tmColl = it->measurements();
-      for ( vector<TrajectoryMeasurement>::const_iterator itTraj = tmColl.begin(); itTraj!=tmColl.end(); ++itTraj )
-	{
-	  
-	  if ( !itTraj->updatedState().isValid() ) 
-	    continue;
-       
-	  strip_rechitx     = -9999999.9;
-	  strip_rechity     = -9999999.9;
-	  strip_rechitz     = -9999999.9;
-	  strip_rechiterrx  = -9999999.9;
-	  strip_rechiterry  = -9999999.9;
-	  strip_rechitresx  = -9999999.9;
-	  strip_rechitresx2  = -9999999.9;
-	  
+  for (vector<Trajectory>::const_iterator it = trajCollectionHandle->begin(); it != trajCollectionHandle->end(); ++it) {
+    vector<TrajectoryMeasurement> tmColl = it->measurements();
+    for (vector<TrajectoryMeasurement>::const_iterator itTraj = tmColl.begin(); itTraj != tmColl.end(); ++itTraj) {
+      if (!itTraj->updatedState().isValid())
+        continue;
 
-	  strip_rechitresy  = -9999999.9;
-	  strip_rechitpullx = -9999999.9;
-	  strip_rechitpully = -9999999.9;
-	  strip_is_stereo   = -9999999  ;
-	  strip_hit_type    = -9999999  ;
-	  detector_type     = -9999999  ;
-	  
-	  strip_trk_pt    = -9999999.9;
-	  strip_cotalpha  = -9999999.9;
-	  strip_cotbeta   = -9999999.9;
-	  strip_locbx     = -9999999.9;
-	  strip_locby     = -9999999.9;
-	  strip_locbz     = -9999999.9;
-	  strip_charge    = -9999999.9;
-	  strip_size        = -9999999  ;
+      strip_rechitx = -9999999.9;
+      strip_rechity = -9999999.9;
+      strip_rechitz = -9999999.9;
+      strip_rechiterrx = -9999999.9;
+      strip_rechiterry = -9999999.9;
+      strip_rechitresx = -9999999.9;
+      strip_rechitresx2 = -9999999.9;
 
-	  strip_edge        = -9999999  ;
-	  strip_nsimhit     = -9999999  ;
-	  strip_pidhit      = -9999999  ;
-	  strip_simproc     = -9999999  ;
+      strip_rechitresy = -9999999.9;
+      strip_rechitpullx = -9999999.9;
+      strip_rechitpully = -9999999.9;
+      strip_is_stereo = -9999999;
+      strip_hit_type = -9999999;
+      detector_type = -9999999;
 
+      strip_trk_pt = -9999999.9;
+      strip_cotalpha = -9999999.9;
+      strip_cotbeta = -9999999.9;
+      strip_locbx = -9999999.9;
+      strip_locby = -9999999.9;
+      strip_locbz = -9999999.9;
+      strip_charge = -9999999.9;
+      strip_size = -9999999;
 
-	  strip_subdet_id = -9999999;
- 
-	  strip_tib_layer             = -9999999;
-	  strip_tib_module            = -9999999;
-	  strip_tib_order             = -9999999;
-	  strip_tib_side              = -9999999;
-	  strip_tib_is_double_side    = -9999999;
-	  strip_tib_is_z_plus_side    = -9999999;
-	  strip_tib_is_z_minus_side   = -9999999;
-	  strip_tib_layer_number      = -9999999;
-	  strip_tib_string_number     = -9999999;
-	  strip_tib_module_number     = -9999999;
-	  strip_tib_is_internal_string= -9999999;
-	  strip_tib_is_external_string= -9999999;
-	  strip_tib_is_rphi           = -9999999;
-	  strip_tib_is_stereo         = -9999999;          
-	  
-	  strip_tob_layer             = -9999999;
-	  strip_tob_module            = -9999999;
-	  strip_tob_side              = -9999999;
-	  strip_tob_is_double_side    = -9999999;
-	  strip_tob_is_z_plus_side    = -9999999;
-	  strip_tob_is_z_minus_side   = -9999999;
-	  strip_tob_layer_number      = -9999999;
-	  strip_tob_rod_number        = -9999999;
-	  strip_tob_module_number     = -9999999;
-	  	  
-	  strip_tob_is_rphi           = -9999999;
-	  strip_tob_is_stereo         = -9999999;     
+      strip_edge = -9999999;
+      strip_nsimhit = -9999999;
+      strip_pidhit = -9999999;
+      strip_simproc = -9999999;
 
-	  strip_prob                  = -9999999.9;
-	  strip_qbin                  = -9999999;
+      strip_subdet_id = -9999999;
 
-	  strip_nprm                  = -9999999;
-	  
-	  strip_pidhit1      = -9999999  ;
-	  strip_simproc1     = -9999999  ;
-	  
-	  strip_pidhit2      = -9999999  ;
-	  strip_simproc2     = -9999999  ;
-	  
-	  strip_pidhit3      = -9999999  ;
-	  strip_simproc3     = -9999999  ;
-	  
-	  strip_pidhit4      = -9999999  ;
-	  strip_simproc4     = -9999999  ;
+      strip_tib_layer = -9999999;
+      strip_tib_module = -9999999;
+      strip_tib_order = -9999999;
+      strip_tib_side = -9999999;
+      strip_tib_is_double_side = -9999999;
+      strip_tib_is_z_plus_side = -9999999;
+      strip_tib_is_z_minus_side = -9999999;
+      strip_tib_layer_number = -9999999;
+      strip_tib_string_number = -9999999;
+      strip_tib_module_number = -9999999;
+      strip_tib_is_internal_string = -9999999;
+      strip_tib_is_external_string = -9999999;
+      strip_tib_is_rphi = -9999999;
+      strip_tib_is_stereo = -9999999;
 
-	  strip_pidhit5      = -9999999  ;
-	  strip_simproc5     = -9999999  ;
+      strip_tob_layer = -9999999;
+      strip_tob_module = -9999999;
+      strip_tob_side = -9999999;
+      strip_tob_is_double_side = -9999999;
+      strip_tob_is_z_plus_side = -9999999;
+      strip_tob_is_z_minus_side = -9999999;
+      strip_tob_layer_number = -9999999;
+      strip_tob_rod_number = -9999999;
+      strip_tob_module_number = -9999999;
 
-	  strip_split        = -9999999;   
-	  strip_clst_err_x   = -9999999.9;
-	  strip_clst_err_y   = -9999999.9;
+      strip_tob_is_rphi = -9999999;
+      strip_tob_is_stereo = -9999999;
 
-	  const TransientTrackingRecHit::ConstRecHitPointer trans_trk_rec_hit_point = itTraj->recHit();
-	 
-	  if ( trans_trk_rec_hit_point == nullptr )
-	    continue;
+      strip_prob = -9999999.9;
+      strip_qbin = -9999999;
 
-	  const TrackingRecHit *trk_rec_hit = (*trans_trk_rec_hit_point).hit();
+      strip_nprm = -9999999;
 
-	  if ( trk_rec_hit == nullptr )
-	    continue;
+      strip_pidhit1 = -9999999;
+      strip_simproc1 = -9999999;
 
-	  DetId detid = (trk_rec_hit)->geographicalId();
+      strip_pidhit2 = -9999999;
+      strip_simproc2 = -9999999;
 
-	  strip_subdet_id = (int)detid.subdetId();
-	  
-	  if ( (int)detid.subdetId() != (int)(StripSubdetector::TIB) && (int)detid.subdetId() != (int)(StripSubdetector::TOB) )
-	    continue;
+      strip_pidhit3 = -9999999;
+      strip_simproc3 = -9999999;
 
-	  const SiStripMatchedRecHit2D* matchedhit = dynamic_cast<const SiStripMatchedRecHit2D*>( (*trans_trk_rec_hit_point).hit() );
-	  const SiStripRecHit2D       * hit2d      = dynamic_cast<const SiStripRecHit2D       *>( (*trans_trk_rec_hit_point).hit() );
-	  const SiStripRecHit1D       * hit1d      = dynamic_cast<const SiStripRecHit1D       *>( (*trans_trk_rec_hit_point).hit() );
-	  
-	  if ( !matchedhit && !hit2d && !hit1d )
-	    continue;
-	  
-	  position = (trk_rec_hit)->localPosition(); 
-	  error = (trk_rec_hit)->localPositionError();
-	  
-	  strip_rechitx = position.x();
-	  strip_rechity = position.y();
-	  strip_rechitz = position.z();
-	  strip_rechiterrx = sqrt( error.xx() );
-	  strip_rechiterry = sqrt( error.yy() );
-	  
-	  
-	  //cout << "strip_rechitx = " << strip_rechitx << endl;	      
-	  //cout << "strip_rechity = " << strip_rechity << endl;
-	  //cout << "strip_rechitz = " << strip_rechitz << endl;
-	  
-	  //cout << "strip_rechiterrx = " << strip_rechiterrx << endl;
-	  //cout << "strip_rechiterry = " << strip_rechiterry << endl;
-	  
-	  TrajectoryStateOnSurface tsos = itTraj->updatedState(); 
-	  
-	  strip_trk_pt = tsos.globalMomentum().perp();
-	  
-	  LocalTrajectoryParameters ltp = tsos.localParameters();
-	  
-	  LocalVector localDir = ltp.momentum()/ltp.momentum().mag();
-	  
-	  float locx = localDir.x();
-	  float locy = localDir.y();
-	  float locz = localDir.z();
-	  
-	  //alpha_ = atan2( locz, locx );
-	  //beta_  = atan2( locz, locy );
-	  
-	  strip_cotalpha = locx/locz;
-	  strip_cotbeta  = locy/locz;
-	      
+      strip_pidhit4 = -9999999;
+      strip_simproc4 = -9999999;
 
-	  StripSubdetector StripSubdet = (StripSubdetector)detid;
+      strip_pidhit5 = -9999999;
+      strip_simproc5 = -9999999;
 
-	  if ( StripSubdet.stereo() == 0 )
-	    strip_is_stereo = 0;
-	  else
-	    strip_is_stereo = 1;
+      strip_split = -9999999;
+      strip_clst_err_x = -9999999.9;
+      strip_clst_err_y = -9999999.9;
 
+      const TransientTrackingRecHit::ConstRecHitPointer trans_trk_rec_hit_point = itTraj->recHit();
 
-	  SiStripDetId si_strip_det_id = SiStripDetId( detid );
-	  
-	  //const StripGeomDetUnit* strip_geom_det_unit = dynamic_cast<const StripGeomDetUnit*> ( tracker->idToDet( detid ) );
-	  const StripGeomDetUnit* strip_geom_det_unit = (const StripGeomDetUnit*)tracker->idToDetUnit( detid );
-	  
-	  if ( strip_geom_det_unit != nullptr )
-	    {
-	      LocalVector lbfield 
-		= (strip_geom_det_unit->surface()).toLocal( (*magneticField).inTesla( strip_geom_det_unit->surface().position() ) ); 
-	      
-	      strip_locbx = lbfield.x();
-	      strip_locby = lbfield.y();
-	      strip_locbz = lbfield.z();
-	    }
-	  
+      if (trans_trk_rec_hit_point == nullptr)
+        continue;
 
-	  //enum ModuleGeometry {UNKNOWNGEOMETRY, IB1, IB2, OB1, OB2, W1A, W2A, W3A, W1B, W2B, W3B, W4, W5, W6, W7};
-	  
-	  if ( si_strip_det_id.moduleGeometry() == 1 )
-	    {
-	      detector_type = 1;
-	      //cout << "si_strip_det_id.moduleGeometry() = IB1" << endl;
-	      //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
-	    }
-	  else if ( si_strip_det_id.moduleGeometry() == 2 )
-	    {
-	      detector_type = 2;
-	      //cout << "si_strip_det_id.moduleGeometry() = IB2" << endl;
-	      //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
-	    }
-	  else if ( si_strip_det_id.moduleGeometry() == 3 )
-	    {
-	      detector_type = 3;
-	      //cout << "si_strip_det_id.moduleGeometry() = OB1" << endl;
-	      //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
-	    }
-	  else if ( si_strip_det_id.moduleGeometry() == 4 )
-	    {
-	      detector_type = 4;
-	      //cout << "si_strip_det_id.moduleGeometry() = OB2" << endl;
-	      //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
-	    }
-	  
+      const TrackingRecHit* trk_rec_hit = (*trans_trk_rec_hit_point).hit();
 
-	  // Store ntuple variables 
-	  
-	  if ( (int)detid.subdetId() == int(StripSubdetector::TIB) )
-	    {
-	      
-	      
-	      
-	      strip_tib_layer              = (int)tTopo->tibLayer( detid );
-	      strip_tib_module             = (int)tTopo->tibModule( detid ); 
-	      strip_tib_order              = (int)tTopo->tibOrder( detid );
-	      strip_tib_side               = (int)tTopo->tibSide( detid );
-	      strip_tib_is_double_side     = (int)tTopo->tibIsDoubleSide( detid );
-	      strip_tib_is_z_plus_side     = (int)tTopo->tibIsZPlusSide( detid );
-	      strip_tib_is_z_minus_side    = (int)tTopo->tibIsZMinusSide( detid );
-	      strip_tib_layer_number       = (int)tTopo->tibLayer( detid );
-	      strip_tib_string_number      = (int)tTopo->tibString( detid ) ;
-	      strip_tib_module_number      = (int)tTopo->tibModule( detid );
-	      strip_tib_is_internal_string = (int)tTopo->tibIsInternalString( detid );
-	      strip_tib_is_external_string = (int)tTopo->tibIsExternalString( detid );
-	      strip_tib_is_rphi            = (int)tTopo->tibIsRPhi( detid );
-	      strip_tib_is_stereo          = (int)tTopo->tibIsStereo( detid );
-	    }
-	  
-	  
-	  if ( (int)detid.subdetId() == int(StripSubdetector::TOB) )
-	    {
-	      
-	      
-	      
-	      strip_tob_layer              = (int)tTopo->tobLayer( detid );
-	      strip_tob_module             = (int)tTopo->tobModule( detid );
-	      
-	      strip_tob_side               = (int)tTopo->tobSide( detid );
-	      strip_tob_is_double_side     = (int)tTopo->tobIsDoubleSide( detid );
-	      strip_tob_is_z_plus_side     = (int)tTopo->tobIsZPlusSide( detid );
-	      strip_tob_is_z_minus_side    = (int)tTopo->tobIsZMinusSide( detid );
-	      strip_tob_layer_number       = (int)tTopo->tobLayer( detid );
-	      strip_tob_rod_number         = (int)tTopo->tobRod( detid );
-	      strip_tob_module_number      = (int)tTopo->tobModule( detid );
-	      
-	      
-	      strip_tob_is_rphi            = (int)tTopo->tobIsRPhi( detid );
-	      strip_tob_is_stereo          = (int)tTopo->tobIsStereo( detid );
-	          
-	    }
-	 
-	 
-	  if ( matchedhit ) 
-	    {
-	      //cout << endl << endl << endl;
-	      //cout << "Found a SiStripMatchedRecHit2D !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! " << endl;
-	      //cout << endl << endl << endl;
-	      strip_hit_type = 0;
+      if (trk_rec_hit == nullptr)
+        continue;
 
-	    } //  if ( matchedhit )
+      DetId detid = (trk_rec_hit)->geographicalId();
 
-   
-	  if ( hit1d )
-	    {
-	      strip_hit_type = 1;
+      strip_subdet_id = (int)detid.subdetId();
 
-	      const SiStripRecHit1D::ClusterRef & cluster = hit1d->cluster();
+      if ((int)detid.subdetId() != (int)(StripSubdetector::TIB) &&
+          (int)detid.subdetId() != (int)(StripSubdetector::TOB))
+        continue;
 
-	      if ( cluster->getSplitClusterError()  > 0.0 )
-		strip_split = 1;
-	      else 
-		strip_split = 0;
-	      
-	      strip_clst_err_x = cluster->getSplitClusterError();
-	      //strip_clst_err_y = ... 
+      const SiStripMatchedRecHit2D* matchedhit =
+          dynamic_cast<const SiStripMatchedRecHit2D*>((*trans_trk_rec_hit_point).hit());
+      const SiStripRecHit2D* hit2d = dynamic_cast<const SiStripRecHit2D*>((*trans_trk_rec_hit_point).hit());
+      const SiStripRecHit1D* hit1d = dynamic_cast<const SiStripRecHit1D*>((*trans_trk_rec_hit_point).hit());
 
-	      // Get cluster total charge
-	      const auto & stripCharges = cluster->amplitudes();
-	      uint16_t charge = 0;
-	      for (unsigned int i = 0; i < stripCharges.size(); ++i) 
-		{
-		  charge += stripCharges[i];
-		}
-	      
-	      strip_charge = (float)charge;
-	      strip_size = (int)( (cluster->amplitudes()).size() );
+      if (!matchedhit && !hit2d && !hit1d)
+        continue;
 
+      position = (trk_rec_hit)->localPosition();
+      error = (trk_rec_hit)->localPositionError();
 
-	      // Association of the rechit to the simhit
-	      float mindist = 999999.9;
-	      matched.clear();  
-	      
-	      matched = associate.associateHit(*hit1d);
+      strip_rechitx = position.x();
+      strip_rechity = position.y();
+      strip_rechitz = position.z();
+      strip_rechiterrx = sqrt(error.xx());
+      strip_rechiterry = sqrt(error.yy());
 
-	      strip_nsimhit = (int)matched.size();
-	      
-	      if ( !matched.empty()) 
-		{
-		  PSimHit closest;
-		  
-		  // Get the closest simhit
-		  
-		  int strip_nprimaries = 0; 
-		  int current_index = 0;
-		 
-		  for ( vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); ++m)
-		    {
-		      ++current_index;
-		      
-		      if ( (*m).processType() == 2 )
-			++strip_nprimaries;
+      //cout << "strip_rechitx = " << strip_rechitx << endl;
+      //cout << "strip_rechity = " << strip_rechity << endl;
+      //cout << "strip_rechitz = " << strip_rechitz << endl;
 
-		      if ( current_index == 1 )
-			{
-			  strip_pidhit1 = (*m).particleType();
-			  strip_simproc1 = (*m).processType();
-			}
-		      else if ( current_index == 2 )
-			{
-			  strip_pidhit2 = (*m).particleType();
-			  strip_simproc2 = (*m).processType();
-			}
-		      else if ( current_index == 3 )
-			{
-			  strip_pidhit3 = (*m).particleType();
-			  strip_simproc3 = (*m).processType();
-			}
-		      else if ( current_index == 4 )
-			{
-			  strip_pidhit4 = (*m).particleType();
-			  strip_simproc4 = (*m).processType();
-			}
-		      else if ( current_index == 5 )
-			{
-			  strip_pidhit5 = (*m).particleType();
-			  strip_simproc5 = (*m).processType();
-			}
+      //cout << "strip_rechiterrx = " << strip_rechiterrx << endl;
+      //cout << "strip_rechiterry = " << strip_rechiterry << endl;
 
+      TrajectoryStateOnSurface tsos = itTraj->updatedState();
 
-		      float dist = abs( (hit1d)->localPosition().x() - (*m).localPosition().x() );
-		      
-		      if ( dist<mindist )
-			{
-			  mindist = dist;
-			  closest = (*m);
-			}
-		    
-		    } // for ( vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); ++m)
-		  
-		  strip_nprm = strip_nprimaries;
+      strip_trk_pt = tsos.globalMomentum().perp();
 
-		  strip_rechitresx = strip_rechitx - closest.localPosition().x();
-		  strip_rechitresy = strip_rechity - closest.localPosition().y();
- 
-		  strip_rechitresx2 = strip_rechitx - matched[0].localPosition().x();
+      LocalTrajectoryParameters ltp = tsos.localParameters();
 
-		  strip_rechitpullx = strip_rechitresx / strip_rechiterrx;
-		  strip_rechitpully = strip_rechitresy / strip_rechiterry;
+      LocalVector localDir = ltp.momentum() / ltp.momentum().mag();
 
-		  strip_pidhit = closest.particleType();
-		  strip_simproc = closest.processType();
+      float locx = localDir.x();
+      float locy = localDir.y();
+      float locz = localDir.z();
 
-		  
-		} //   if( !matched.empty()) 
-		  
+      //alpha_ = atan2( locz, locx );
+      //beta_  = atan2( locz, locy );
 
-	      //strip_prob = (hit1d)->getTemplProb();
-	      //strip_qbin = (hit1d)->getTemplQbin();
+      strip_cotalpha = locx / locz;
+      strip_cotbeta = locy / locz;
 
-	      //cout << endl;
-	      //cout << "SiPixelErrorEstimation 1d hit: " << endl;
-	      //cout << "prob 1d = " << strip_prob << endl;
-	      //cout << "qbin 1d = " << strip_qbin << endl;
-	      //cout << endl;
+      StripSubdetector StripSubdet = (StripSubdetector)detid;
 
-	      
-	      // Is the cluster on edge ?
-	      /*
+      if (StripSubdet.stereo() == 0)
+        strip_is_stereo = 0;
+      else
+        strip_is_stereo = 1;
+
+      SiStripDetId si_strip_det_id = SiStripDetId(detid);
+
+      //const StripGeomDetUnit* strip_geom_det_unit = dynamic_cast<const StripGeomDetUnit*> ( tracker->idToDet( detid ) );
+      const StripGeomDetUnit* strip_geom_det_unit = (const StripGeomDetUnit*)tracker->idToDetUnit(detid);
+
+      if (strip_geom_det_unit != nullptr) {
+        LocalVector lbfield = (strip_geom_det_unit->surface())
+                                  .toLocal((*magneticField).inTesla(strip_geom_det_unit->surface().position()));
+
+        strip_locbx = lbfield.x();
+        strip_locby = lbfield.y();
+        strip_locbz = lbfield.z();
+      }
+
+      //enum ModuleGeometry {UNKNOWNGEOMETRY, IB1, IB2, OB1, OB2, W1A, W2A, W3A, W1B, W2B, W3B, W4, W5, W6, W7};
+
+      if (si_strip_det_id.moduleGeometry() == 1) {
+        detector_type = 1;
+        //cout << "si_strip_det_id.moduleGeometry() = IB1" << endl;
+        //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
+      } else if (si_strip_det_id.moduleGeometry() == 2) {
+        detector_type = 2;
+        //cout << "si_strip_det_id.moduleGeometry() = IB2" << endl;
+        //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
+      } else if (si_strip_det_id.moduleGeometry() == 3) {
+        detector_type = 3;
+        //cout << "si_strip_det_id.moduleGeometry() = OB1" << endl;
+        //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
+      } else if (si_strip_det_id.moduleGeometry() == 4) {
+        detector_type = 4;
+        //cout << "si_strip_det_id.moduleGeometry() = OB2" << endl;
+        //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
+      }
+
+      // Store ntuple variables
+
+      if ((int)detid.subdetId() == int(StripSubdetector::TIB)) {
+        strip_tib_layer = (int)tTopo->tibLayer(detid);
+        strip_tib_module = (int)tTopo->tibModule(detid);
+        strip_tib_order = (int)tTopo->tibOrder(detid);
+        strip_tib_side = (int)tTopo->tibSide(detid);
+        strip_tib_is_double_side = (int)tTopo->tibIsDoubleSide(detid);
+        strip_tib_is_z_plus_side = (int)tTopo->tibIsZPlusSide(detid);
+        strip_tib_is_z_minus_side = (int)tTopo->tibIsZMinusSide(detid);
+        strip_tib_layer_number = (int)tTopo->tibLayer(detid);
+        strip_tib_string_number = (int)tTopo->tibString(detid);
+        strip_tib_module_number = (int)tTopo->tibModule(detid);
+        strip_tib_is_internal_string = (int)tTopo->tibIsInternalString(detid);
+        strip_tib_is_external_string = (int)tTopo->tibIsExternalString(detid);
+        strip_tib_is_rphi = (int)tTopo->tibIsRPhi(detid);
+        strip_tib_is_stereo = (int)tTopo->tibIsStereo(detid);
+      }
+
+      if ((int)detid.subdetId() == int(StripSubdetector::TOB)) {
+        strip_tob_layer = (int)tTopo->tobLayer(detid);
+        strip_tob_module = (int)tTopo->tobModule(detid);
+
+        strip_tob_side = (int)tTopo->tobSide(detid);
+        strip_tob_is_double_side = (int)tTopo->tobIsDoubleSide(detid);
+        strip_tob_is_z_plus_side = (int)tTopo->tobIsZPlusSide(detid);
+        strip_tob_is_z_minus_side = (int)tTopo->tobIsZMinusSide(detid);
+        strip_tob_layer_number = (int)tTopo->tobLayer(detid);
+        strip_tob_rod_number = (int)tTopo->tobRod(detid);
+        strip_tob_module_number = (int)tTopo->tobModule(detid);
+
+        strip_tob_is_rphi = (int)tTopo->tobIsRPhi(detid);
+        strip_tob_is_stereo = (int)tTopo->tobIsStereo(detid);
+      }
+
+      if (matchedhit) {
+        //cout << endl << endl << endl;
+        //cout << "Found a SiStripMatchedRecHit2D !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! " << endl;
+        //cout << endl << endl << endl;
+        strip_hit_type = 0;
+
+      }  //  if ( matchedhit )
+
+      if (hit1d) {
+        strip_hit_type = 1;
+
+        const SiStripRecHit1D::ClusterRef& cluster = hit1d->cluster();
+
+        if (cluster->getSplitClusterError() > 0.0)
+          strip_split = 1;
+        else
+          strip_split = 0;
+
+        strip_clst_err_x = cluster->getSplitClusterError();
+        //strip_clst_err_y = ...
+
+        // Get cluster total charge
+        const auto& stripCharges = cluster->amplitudes();
+        uint16_t charge = 0;
+        for (unsigned int i = 0; i < stripCharges.size(); ++i) {
+          charge += stripCharges[i];
+        }
+
+        strip_charge = (float)charge;
+        strip_size = (int)((cluster->amplitudes()).size());
+
+        // Association of the rechit to the simhit
+        float mindist = 999999.9;
+        matched.clear();
+
+        matched = associate.associateHit(*hit1d);
+
+        strip_nsimhit = (int)matched.size();
+
+        if (!matched.empty()) {
+          PSimHit closest;
+
+          // Get the closest simhit
+
+          int strip_nprimaries = 0;
+          int current_index = 0;
+
+          for (vector<PSimHit>::const_iterator m = matched.begin(); m < matched.end(); ++m) {
+            ++current_index;
+
+            if ((*m).processType() == 2)
+              ++strip_nprimaries;
+
+            if (current_index == 1) {
+              strip_pidhit1 = (*m).particleType();
+              strip_simproc1 = (*m).processType();
+            } else if (current_index == 2) {
+              strip_pidhit2 = (*m).particleType();
+              strip_simproc2 = (*m).processType();
+            } else if (current_index == 3) {
+              strip_pidhit3 = (*m).particleType();
+              strip_simproc3 = (*m).processType();
+            } else if (current_index == 4) {
+              strip_pidhit4 = (*m).particleType();
+              strip_simproc4 = (*m).processType();
+            } else if (current_index == 5) {
+              strip_pidhit5 = (*m).particleType();
+              strip_simproc5 = (*m).processType();
+            }
+
+            float dist = abs((hit1d)->localPosition().x() - (*m).localPosition().x());
+
+            if (dist < mindist) {
+              mindist = dist;
+              closest = (*m);
+            }
+
+          }  // for ( vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); ++m)
+
+          strip_nprm = strip_nprimaries;
+
+          strip_rechitresx = strip_rechitx - closest.localPosition().x();
+          strip_rechitresy = strip_rechity - closest.localPosition().y();
+
+          strip_rechitresx2 = strip_rechitx - matched[0].localPosition().x();
+
+          strip_rechitpullx = strip_rechitresx / strip_rechiterrx;
+          strip_rechitpully = strip_rechitresy / strip_rechiterry;
+
+          strip_pidhit = closest.particleType();
+          strip_simproc = closest.processType();
+
+        }  //   if( !matched.empty())
+
+        //strip_prob = (hit1d)->getTemplProb();
+        //strip_qbin = (hit1d)->getTemplQbin();
+
+        //cout << endl;
+        //cout << "SiPixelErrorEstimation 1d hit: " << endl;
+        //cout << "prob 1d = " << strip_prob << endl;
+        //cout << "qbin 1d = " << strip_qbin << endl;
+        //cout << endl;
+
+        // Is the cluster on edge ?
+        /*
 		SiStripDetInfoFileReader* reader;
 		
 		FileInPath_("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
@@ -814,105 +758,82 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
 		strip_edge = 0;
 	      */
 
-	    } // if ( hit1d )
+      }  // if ( hit1d )
 
+      if (hit2d) {
+        strip_hit_type = 2;
 
-	  if ( hit2d )
-	    {
-	      strip_hit_type = 2;
-	      
-	      const SiStripRecHit1D::ClusterRef & cluster = hit2d->cluster();
-	      
-	      //if ( cluster->getSplitClusterError()  > 0.0 )
-	      //strip_split = 1;
-	      //else 
-	      //strip_split = 0;
+        const SiStripRecHit1D::ClusterRef& cluster = hit2d->cluster();
 
-	      //strip_clst_err_x = cluster->getSplitClusterError();
-	      //strip_clst_err_y = ... 
+        //if ( cluster->getSplitClusterError()  > 0.0 )
+        //strip_split = 1;
+        //else
+        //strip_split = 0;
 
-	      // Get cluster total charge
-	      auto & stripCharges = cluster->amplitudes();
-	      uint16_t charge = 0;
-	      for (unsigned int i = 0; i < stripCharges.size(); ++i) 
-		{
-		  charge += stripCharges[i];
-		}
-	      
-	      strip_charge = (float)charge;
-	      strip_size = (int)( (cluster->amplitudes()).size() );
-	     
-	      // Association of the rechit to the simhit
-	      float mindist = 999999.9;
-	      matched.clear();  
-	      
-	      matched = associate.associateHit(*hit2d);
+        //strip_clst_err_x = cluster->getSplitClusterError();
+        //strip_clst_err_y = ...
 
-	      strip_nsimhit = (int)matched.size();
-	      
-	      if ( !matched.empty()) 
-		{
-		  PSimHit closest;
-		  
-		  // Get the closest simhit
-		  
-		  for ( vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); ++m)
-		    {
-		      float dist = abs( (hit2d)->localPosition().x() - (*m).localPosition().x() );
-		      
-		      if ( dist<mindist )
-			{
-			  mindist = dist;
-			  closest = (*m);
-			}
-		    }
-		  
-		  strip_rechitresx = strip_rechitx - closest.localPosition().x();
-		  strip_rechitresy = strip_rechity - closest.localPosition().y();
- 
-		  strip_rechitpullx = strip_rechitresx / strip_rechiterrx;
-		  strip_rechitpully = strip_rechitresy / strip_rechiterry;
+        // Get cluster total charge
+        auto& stripCharges = cluster->amplitudes();
+        uint16_t charge = 0;
+        for (unsigned int i = 0; i < stripCharges.size(); ++i) {
+          charge += stripCharges[i];
+        }
 
-		  strip_pidhit = closest.particleType();
-		  strip_simproc = closest.processType();
+        strip_charge = (float)charge;
+        strip_size = (int)((cluster->amplitudes()).size());
 
-		  
-		} //   if( !matched.empty()) 
-		  
+        // Association of the rechit to the simhit
+        float mindist = 999999.9;
+        matched.clear();
 
-	      //strip_prob = (hit2d)->getTemplProb();
-	      //strip_qbin = (hit2d)->getTemplQbin();
+        matched = associate.associateHit(*hit2d);
 
-	      //cout << endl;
-	      //cout << "SiPixelErrorEstimation 2d hit: " << endl;
-	      //cout << "prob 2d = " << strip_prob << endl;
-	      //cout << "qbin 2d = " << strip_qbin << endl;
-	      //cout << endl;
-		  
-	      
-	    } // if ( hit2d )
+        strip_nsimhit = (int)matched.size();
 
+        if (!matched.empty()) {
+          PSimHit closest;
 
-	  ttree_track_hits_strip_->Fill();
+          // Get the closest simhit
 
+          for (vector<PSimHit>::const_iterator m = matched.begin(); m < matched.end(); ++m) {
+            float dist = abs((hit2d)->localPosition().x() - (*m).localPosition().x());
 
-	} // for ( vector<TrajectoryMeasurement>::const_iterator itTraj = tmColl.begin(); itTraj!=tmColl.end(); ++itTraj )
+            if (dist < mindist) {
+              mindist = dist;
+              closest = (*m);
+            }
+          }
 
-    } // for( vector<Trajectory>::const_iterator it = trajCollectionHandle->begin(); it!=trajCollectionHandle->end(); ++it)
+          strip_rechitresx = strip_rechitx - closest.localPosition().x();
+          strip_rechitresy = strip_rechity - closest.localPosition().y();
 
+          strip_rechitpullx = strip_rechitresx / strip_rechiterrx;
+          strip_rechitpully = strip_rechitresy / strip_rechiterry;
 
+          strip_pidhit = closest.particleType();
+          strip_simproc = closest.processType();
 
+        }  //   if( !matched.empty())
 
+        //strip_prob = (hit2d)->getTemplProb();
+        //strip_qbin = (hit2d)->getTemplQbin();
 
+        //cout << endl;
+        //cout << "SiPixelErrorEstimation 2d hit: " << endl;
+        //cout << "prob 2d = " << strip_prob << endl;
+        //cout << "qbin 2d = " << strip_qbin << endl;
+        //cout << endl;
 
+      }  // if ( hit2d )
 
+      ttree_track_hits_strip_->Fill();
+
+    }  // for ( vector<TrajectoryMeasurement>::const_iterator itTraj = tmColl.begin(); itTraj!=tmColl.end(); ++itTraj )
+
+  }  // for( vector<Trajectory>::const_iterator it = trajCollectionHandle->begin(); it!=trajCollectionHandle->end(); ++it)
 
   //cout << "...2..." << endl;
-
-
-
-
-
 
   // --------------------------------------- all hits -----------------------------------------------------------
   edm::Handle<SiPixelRecHitCollection> recHitColl;
@@ -922,142 +843,139 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
   e.getByToken(tSimTrackContainer, simtracks);
 
   //-----Iterate over detunits
-  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++) 
-    {
-      DetId detId = ((*it)->geographicalId());
-      
-      SiPixelRecHitCollection::const_iterator dsmatch = recHitColl->find(detId);
-      if (dsmatch == recHitColl->end()) continue;
+  for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++) {
+    DetId detId = ((*it)->geographicalId());
 
-      SiPixelRecHitCollection::DetSet pixelrechitRange = *dsmatch;
-      SiPixelRecHitCollection::DetSet::const_iterator pixelrechitRangeIteratorBegin = pixelrechitRange.begin();
-      SiPixelRecHitCollection::DetSet::const_iterator pixelrechitRangeIteratorEnd = pixelrechitRange.end();
-      SiPixelRecHitCollection::DetSet::const_iterator pixeliter = pixelrechitRangeIteratorBegin;
-      std::vector<PSimHit> matched;
-      
-      //----Loop over rechits for this detId
-      for ( ; pixeliter != pixelrechitRangeIteratorEnd; ++pixeliter) 
-	{
-	  matched.clear();
-	  matched = associate.associateHit(*pixeliter);
-	  // only consider rechits that have associated simhit
-	  // otherwise cannot determine residiual
-	  if ( matched.empty() )
-	    {
-	      cout << "SiPixelErrorEstimation::analyze: rechits without associated simhit !!!!!!!" 
-		   << endl;
-	      continue;
-	    }
-		
-	  all_subdetid = -9999;
-	  
-	  all_layer = -9999;
-	  all_ladder = -9999;
-	  all_mod = -9999;
-	  
-	  all_side = -9999;
-	  all_disk = -9999;
-	  all_blade = -9999;
-	  all_panel = -9999;
-	  all_plaq = -9999;
-	  
-	  all_half = -9999;
-	  all_flipped = -9999;
-	  
-	  all_cols = -9999;
-	  all_rows = -9999;
-	  
-	  all_rechitx = -9999;
-	  all_rechity = -9999;
-	  all_rechitz = -9999;
-	  
-	  all_simhitx = -9999;
-	  all_simhity = -9999;
+    SiPixelRecHitCollection::const_iterator dsmatch = recHitColl->find(detId);
+    if (dsmatch == recHitColl->end())
+      continue;
 
-	  all_rechiterrx = -9999;
-	  all_rechiterry = -9999;
-	  
-	  all_rechitresx = -9999;
-	  all_rechitresy = -9999;
-	  
-	  all_rechitpullx = -9999;
-	  all_rechitpully = -9999;
-	  
-	  all_npix = -9999;
-	  all_nxpix = -9999;
-	  all_nypix = -9999;
-	 	  
-	  all_edgex = -9999;
-	  all_edgey = -9999;
-	  
-	  all_bigx = -9999;
-	  all_bigy = -9999;
-	  
-	  all_alpha = -9999;
-	  all_beta = -9999;
-	  
-	  all_simphi = -9999;
-	  all_simtheta = -9999;
-	  
-	  all_simhitx = -9999;
-	  all_simhity = -9999;
-	  
-	  all_nsimhit = -9999;
-	  all_pidhit = -9999;
-	  all_simproc = -9999;
-	  
-	  all_vtxr = -9999;
-	  all_vtxz = -9999;
-	  
-	  all_simpx = -9999;
-	  all_simpy = -9999;
-	  all_simpz = -9999;
-	  
-	  all_eloss = -9999;
-	  	  
-	  all_trkid = -9999;
-	  
-	  all_x1 = -9999;
-	  all_x2 = -9999;
-	  all_y1 = -9999;
-	  all_y2 = -9999;
-	  all_z1 = -9999;
-	  all_z2 = -9999;
-	  
-	  all_row1 = -9999;
-	  all_row2 = -9999;
-	  all_col1 = -9999;
-	  all_col2 = -9999;
-	  
-	  all_gx1 = -9999;
-	  all_gx2 = -9999;
-	  all_gy1 = -9999;
-	  all_gy2 = -9999;
-	  all_gz1 = -9999;
-	  all_gz2 = -9999;
-	  
-	  all_simtrketa = -9999;
-	  all_simtrkphi = -9999;
-	  
-	  all_clust_row = -9999;
-	  all_clust_col = -9999;
-	  
-	  all_clust_x = -9999;
-	  all_clust_y = -9999;
-	  
-	  all_clust_q = -9999;
-	  
-	  all_clust_maxpixcol = -9999;
-	  all_clust_maxpixrow = -9999;
-	  all_clust_minpixcol = -9999;
-	  all_clust_minpixrow = -9999;
-	  
-	  all_clust_geoid = -9999;
-	  
-	  all_clust_alpha = -9999;
-	  all_clust_beta = -9999;
-	  
-	  /*
+    SiPixelRecHitCollection::DetSet pixelrechitRange = *dsmatch;
+    SiPixelRecHitCollection::DetSet::const_iterator pixelrechitRangeIteratorBegin = pixelrechitRange.begin();
+    SiPixelRecHitCollection::DetSet::const_iterator pixelrechitRangeIteratorEnd = pixelrechitRange.end();
+    SiPixelRecHitCollection::DetSet::const_iterator pixeliter = pixelrechitRangeIteratorBegin;
+    std::vector<PSimHit> matched;
+
+    //----Loop over rechits for this detId
+    for (; pixeliter != pixelrechitRangeIteratorEnd; ++pixeliter) {
+      matched.clear();
+      matched = associate.associateHit(*pixeliter);
+      // only consider rechits that have associated simhit
+      // otherwise cannot determine residiual
+      if (matched.empty()) {
+        cout << "SiPixelErrorEstimation::analyze: rechits without associated simhit !!!!!!!" << endl;
+        continue;
+      }
+
+      all_subdetid = -9999;
+
+      all_layer = -9999;
+      all_ladder = -9999;
+      all_mod = -9999;
+
+      all_side = -9999;
+      all_disk = -9999;
+      all_blade = -9999;
+      all_panel = -9999;
+      all_plaq = -9999;
+
+      all_half = -9999;
+      all_flipped = -9999;
+
+      all_cols = -9999;
+      all_rows = -9999;
+
+      all_rechitx = -9999;
+      all_rechity = -9999;
+      all_rechitz = -9999;
+
+      all_simhitx = -9999;
+      all_simhity = -9999;
+
+      all_rechiterrx = -9999;
+      all_rechiterry = -9999;
+
+      all_rechitresx = -9999;
+      all_rechitresy = -9999;
+
+      all_rechitpullx = -9999;
+      all_rechitpully = -9999;
+
+      all_npix = -9999;
+      all_nxpix = -9999;
+      all_nypix = -9999;
+
+      all_edgex = -9999;
+      all_edgey = -9999;
+
+      all_bigx = -9999;
+      all_bigy = -9999;
+
+      all_alpha = -9999;
+      all_beta = -9999;
+
+      all_simphi = -9999;
+      all_simtheta = -9999;
+
+      all_simhitx = -9999;
+      all_simhity = -9999;
+
+      all_nsimhit = -9999;
+      all_pidhit = -9999;
+      all_simproc = -9999;
+
+      all_vtxr = -9999;
+      all_vtxz = -9999;
+
+      all_simpx = -9999;
+      all_simpy = -9999;
+      all_simpz = -9999;
+
+      all_eloss = -9999;
+
+      all_trkid = -9999;
+
+      all_x1 = -9999;
+      all_x2 = -9999;
+      all_y1 = -9999;
+      all_y2 = -9999;
+      all_z1 = -9999;
+      all_z2 = -9999;
+
+      all_row1 = -9999;
+      all_row2 = -9999;
+      all_col1 = -9999;
+      all_col2 = -9999;
+
+      all_gx1 = -9999;
+      all_gx2 = -9999;
+      all_gy1 = -9999;
+      all_gy2 = -9999;
+      all_gz1 = -9999;
+      all_gz2 = -9999;
+
+      all_simtrketa = -9999;
+      all_simtrkphi = -9999;
+
+      all_clust_row = -9999;
+      all_clust_col = -9999;
+
+      all_clust_x = -9999;
+      all_clust_y = -9999;
+
+      all_clust_q = -9999;
+
+      all_clust_maxpixcol = -9999;
+      all_clust_maxpixrow = -9999;
+      all_clust_minpixcol = -9999;
+      all_clust_minpixrow = -9999;
+
+      all_clust_geoid = -9999;
+
+      all_clust_alpha = -9999;
+      all_clust_beta = -9999;
+
+      /*
 	    for (int i=0; i<all_npix; ++i)
 	    {
 	    all_pixrow[i] = -9999;
@@ -1071,635 +989,580 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
 	    }
 	  */
 
-	  all_hit_probx = -9999;
-	  all_hit_proby = -9999;
-	  all_hit_cprob0 = -9999;
-	  all_hit_cprob1 = -9999;
-	  all_hit_cprob2 = -9999;
+      all_hit_probx = -9999;
+      all_hit_proby = -9999;
+      all_hit_cprob0 = -9999;
+      all_hit_cprob1 = -9999;
+      all_hit_cprob2 = -9999;
 
-	  all_pixel_split = -9999;
-	  all_pixel_clst_err_x = -9999.9;
-	  all_pixel_clst_err_y = -9999.9;
+      all_pixel_split = -9999;
+      all_pixel_clst_err_x = -9999.9;
+      all_pixel_clst_err_y = -9999.9;
 
-	  all_nsimhit = (int)matched.size();
-	  
-	  all_subdetid = (int)detId.subdetId();
-	  // only consider rechits in pixel barrel and pixel forward 
-	  if ( !(all_subdetid==1 || all_subdetid==2) )
-	    {
-	      cout << "SiPixelErrorEstimation::analyze: Not in a pixel detector !!!!!" << endl; 
-	      continue;
-	    }
+      all_nsimhit = (int)matched.size();
 
-	  const PixelGeomDetUnit* theGeomDet 
-	    = dynamic_cast<const PixelGeomDetUnit*> ( tracker->idToDet(detId) );
-	  
-	  const PixelTopology* topol = &(theGeomDet->specificTopology());
+      all_subdetid = (int)detId.subdetId();
+      // only consider rechits in pixel barrel and pixel forward
+      if (!(all_subdetid == 1 || all_subdetid == 2)) {
+        cout << "SiPixelErrorEstimation::analyze: Not in a pixel detector !!!!!" << endl;
+        continue;
+      }
 
-	  if ( pixeliter->cluster()->getSplitClusterErrorX()  > 0.0 && 
-	       pixeliter->cluster()->getSplitClusterErrorY()  > 0.0 )
-	    {
-	      all_pixel_split = 1;
-	    }
-	  else
-	    {
-	      all_pixel_split = 0;
-	    }
-	
-	  all_pixel_clst_err_x = pixeliter->cluster()->getSplitClusterErrorX();
-	  all_pixel_clst_err_y = pixeliter->cluster()->getSplitClusterErrorY();
+      const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*>(tracker->idToDet(detId));
 
+      const PixelTopology* topol = &(theGeomDet->specificTopology());
 
-	  const int maxPixelCol = pixeliter->cluster()->maxPixelCol();
-	  const int maxPixelRow = pixeliter->cluster()->maxPixelRow();
-	  const int minPixelCol = pixeliter->cluster()->minPixelCol();
-	  const int minPixelRow = pixeliter->cluster()->minPixelRow();
-	  
-	  //all_hit_probx  = (float)pixeliter->probabilityX();
-	  //all_hit_proby  = (float)pixeliter->probabilityY();
-	  all_hit_cprob0 = (float)pixeliter->clusterProbability(0);
-	  all_hit_cprob1 = (float)pixeliter->clusterProbability(1);
-	  all_hit_cprob2 = (float)pixeliter->clusterProbability(2);
-	  
-	  // check whether the cluster is at the module edge 
-	  if ( topol->isItEdgePixelInX( minPixelRow ) || 
-	       topol->isItEdgePixelInX( maxPixelRow ) )
-	    all_edgex = 1;
-	  else 
-	    all_edgex = 0;
-	  
-	  if ( topol->isItEdgePixelInY( minPixelCol ) || 
-	       topol->isItEdgePixelInY( maxPixelCol ) )
-	    all_edgey = 1;
-	  else 
-	    all_edgey = 0;
-	  
-	  // check whether this rechit contains big pixels
-	  if ( topol->containsBigPixelInX(minPixelRow, maxPixelRow) )
-	    all_bigx = 1;
-	  else 
-	    all_bigx = 0;
-	  
-	  if ( topol->containsBigPixelInY(minPixelCol, maxPixelCol) )
-	    all_bigy = 1;
-	  else 
-	    all_bigy = 0;
-	  
-	  if ( (int)detId.subdetId() == (int)PixelSubdetector::PixelBarrel ) 
-	    {
-	      
-	      all_layer = tTopo->pxbLayer(detId);
-	      all_ladder = tTopo->pxbLadder(detId);
-	      all_mod = tTopo->pxbModule(detId);
-	      
-	      int tmp_nrows = theGeomDet->specificTopology().nrows();
-	      if ( tmp_nrows == 80 ) 
-		all_half = 1;
-	      else if ( tmp_nrows == 160 ) 
-		all_half = 0;
-	      else 
-		cout << "-------------------------------------------------- Wrong module size !!!" << endl;
-	      
-	      float tmp1 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,0.)).perp();
-	      float tmp2 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,1.)).perp();
-	      
-	      if ( tmp2<tmp1 ) 
-		all_flipped = 1;
-	      else 
-		all_flipped = 0;
-	    }
-	  else if ( (int)detId.subdetId() == (int)PixelSubdetector::PixelEndcap )
-	    {
-	      
-	      all_side  = tTopo->pxfSide(detId);
-	      all_disk  = tTopo->pxfDisk(detId);
-	      all_blade = tTopo->pxfBlade(detId);
-	      all_panel = tTopo->pxfPanel(detId);
-	      all_plaq  = tTopo->pxfModule(detId); // also known as plaquette
-	      
-	    } // else if ( detId.subdetId()==PixelSubdetector::PixelEndcap )
-	  else std::cout << "We are not in the pixel detector" << (int)detId.subdetId() << endl;
-	  
-	  all_cols = theGeomDet->specificTopology().ncolumns();
-	  all_rows = theGeomDet->specificTopology().nrows();
-	  	  
-	  LocalPoint lp = pixeliter->localPosition();
-	  // gavril: change this name
-	  all_rechitx = lp.x();
-	  all_rechity = lp.y();
-	  all_rechitz = lp.z();
-	  
-	  LocalError le = pixeliter->localPositionError();
-	  all_rechiterrx = sqrt( le.xx() );
-	  all_rechiterry = sqrt( le.yy() );
+      if (pixeliter->cluster()->getSplitClusterErrorX() > 0.0 && pixeliter->cluster()->getSplitClusterErrorY() > 0.0) {
+        all_pixel_split = 1;
+      } else {
+        all_pixel_split = 0;
+      }
 
-	  bool found_hit_from_generated_particle = false;
-	  
-	  //---Loop over sim hits, fill closest
-	  float closest_dist = 99999.9;
-	  std::vector<PSimHit>::const_iterator closest_simhit = matched.begin();
-	  
-	  for (std::vector<PSimHit>::const_iterator m = matched.begin(); m < matched.end(); m++) 
-	    {
-	      if ( checkType_ )
-		{
-		  int pid = (*m).particleType();
-		  if ( abs(pid) != genType_ )
-		    continue;
-		} 
-	      
-	      float simhitx = 0.5 * ( (*m).entryPoint().x() + (*m).exitPoint().x() );
-	      float simhity = 0.5 * ( (*m).entryPoint().y() + (*m).exitPoint().y() );
-	      
-	      float x_res = simhitx - rechitx;
-	      float y_res = simhity - rechity;
-		  
-	      float dist = sqrt( x_res*x_res + y_res*y_res );		  
-	      
-	      if ( dist < closest_dist ) 
-		{
-		  closest_dist = dist;
-		  closest_simhit = m;
-		  found_hit_from_generated_particle = true;
-		} 
-	    } // end sim hit loop
-	  
-	  // If this recHit does not have any simHit with the same particleType as the particles generated
-	  // ignore it as most probably comes from delta rays.
-	  if ( checkType_ && !found_hit_from_generated_particle )
-	    continue; 
+      all_pixel_clst_err_x = pixeliter->cluster()->getSplitClusterErrorX();
+      all_pixel_clst_err_y = pixeliter->cluster()->getSplitClusterErrorY();
 
-	  all_x1 = (*closest_simhit).entryPoint().x(); // width (row index, in col direction)
-	  all_y1 = (*closest_simhit).entryPoint().y(); // length (col index, in row direction) 
-	  all_z1 = (*closest_simhit).entryPoint().z(); 
-	  all_x2 = (*closest_simhit).exitPoint().x();
-	  all_y2 = (*closest_simhit).exitPoint().y();
-	  all_z2 = (*closest_simhit).exitPoint().z();
-	  GlobalPoint GP1 = 
-	    theGeomDet->surface().toGlobal( Local3DPoint( (*closest_simhit).entryPoint().x(),
-							  (*closest_simhit).entryPoint().y(),
-							  (*closest_simhit).entryPoint().z() ) );
-	  GlobalPoint GP2 = 
-	    theGeomDet->surface().toGlobal (Local3DPoint( (*closest_simhit).exitPoint().x(),
-							  (*closest_simhit).exitPoint().y(),
-							  (*closest_simhit).exitPoint().z() ) );
-	  all_gx1 = GP1.x();
-	  all_gx2 = GP2.x();
-	  all_gy1 = GP1.y();
-	  all_gy2 = GP2.y();
-	  all_gz1 = GP1.z();
-	  all_gz2 = GP2.z();
-	  
-	  MeasurementPoint mp1 =
-	    topol->measurementPosition( LocalPoint( (*closest_simhit).entryPoint().x(),
-						    (*closest_simhit).entryPoint().y(),
-						    (*closest_simhit).entryPoint().z() ) );
-	  MeasurementPoint mp2 =
-	    topol->measurementPosition( LocalPoint( (*closest_simhit).exitPoint().x(),
-						    (*closest_simhit).exitPoint().y(), 
-						    (*closest_simhit).exitPoint().z() ) );
-	  all_row1 = mp1.x();
-	  all_col1 = mp1.y();
-	  all_row2 = mp2.x();
-	  all_col2 = mp2.y();
-	  
-	  all_simhitx = 0.5*(all_x1+all_x2);  
-	  all_simhity = 0.5*(all_y1+all_y2);  
-	  
-	  all_rechitresx = all_rechitx - all_simhitx;
-	  all_rechitresy = all_rechity - all_simhity;
+      const int maxPixelCol = pixeliter->cluster()->maxPixelCol();
+      const int maxPixelRow = pixeliter->cluster()->maxPixelRow();
+      const int minPixelCol = pixeliter->cluster()->minPixelCol();
+      const int minPixelRow = pixeliter->cluster()->minPixelRow();
 
-	  all_rechitpullx = all_rechitresx / all_rechiterrx;
-	  all_rechitpully = all_rechitresy / all_rechiterry;
-	  
-	  SiPixelRecHit::ClusterRef const& clust = pixeliter->cluster();
-	  
-	  all_npix = clust->size();
-	  all_nxpix = clust->sizeX();
-	  all_nypix = clust->sizeY();
+      //all_hit_probx  = (float)pixeliter->probabilityX();
+      //all_hit_proby  = (float)pixeliter->probabilityY();
+      all_hit_cprob0 = (float)pixeliter->clusterProbability(0);
+      all_hit_cprob1 = (float)pixeliter->clusterProbability(1);
+      all_hit_cprob2 = (float)pixeliter->clusterProbability(2);
 
-	  all_clust_row = clust->x();
-	  all_clust_col = clust->y();
-	  
-	  LocalPoint lp2 = topol->localPosition( MeasurementPoint( all_clust_row, all_clust_col ) );
-	  all_clust_x = lp2.x();
-	  all_clust_y = lp2.y();
+      // check whether the cluster is at the module edge
+      if (topol->isItEdgePixelInX(minPixelRow) || topol->isItEdgePixelInX(maxPixelRow))
+        all_edgex = 1;
+      else
+        all_edgex = 0;
 
-	  all_clust_q = clust->charge();
+      if (topol->isItEdgePixelInY(minPixelCol) || topol->isItEdgePixelInY(maxPixelCol))
+        all_edgey = 1;
+      else
+        all_edgey = 0;
 
-	  all_clust_maxpixcol = clust->maxPixelCol();
-	  all_clust_maxpixrow = clust->maxPixelRow();
-	  all_clust_minpixcol = clust->minPixelCol();
-	  all_clust_minpixrow = clust->minPixelRow();
-	  
-	  all_clust_geoid = 0;  // never set!
-  
-	  all_simpx  = (*closest_simhit).momentumAtEntry().x();
-	  all_simpy  = (*closest_simhit).momentumAtEntry().y();
-	  all_simpz  = (*closest_simhit).momentumAtEntry().z();
-	  all_eloss = (*closest_simhit).energyLoss();
-	  all_simphi   = (*closest_simhit).phiAtEntry();
-	  all_simtheta = (*closest_simhit).thetaAtEntry();
-	  all_pidhit = (*closest_simhit).particleType();
-	  all_trkid = (*closest_simhit).trackId();
-	  
-	  //--- Fill alpha and beta -- more useful for exploring the residuals...
-	  all_beta  = atan2(all_simpz, all_simpy);
-	  all_alpha = atan2(all_simpz, all_simpx);
-	  
-	  all_simproc = (int)closest_simhit->processType();
-	  
-	  const edm::SimTrackContainer& trks = *(simtracks.product());
-	  SimTrackContainer::const_iterator trksiter;
-	  for (trksiter = trks.begin(); trksiter != trks.end(); trksiter++) 
-	    if ( (int)trksiter->trackId() == all_trkid ) 
-	      {
-		all_simtrketa = trksiter->momentum().eta();
-		all_simtrkphi = trksiter->momentum().phi();
-	      }
-	  
-	  all_vtxz = theGeomDet->surface().position().z();
-	  all_vtxr = theGeomDet->surface().position().perp();
-	  
-	  //computeAnglesFromDetPosition(clust, 
-	  //		       theGeomDet, 
-	  //		       all_clust_alpha, all_clust_beta )
+      // check whether this rechit contains big pixels
+      if (topol->containsBigPixelInX(minPixelRow, maxPixelRow))
+        all_bigx = 1;
+      else
+        all_bigx = 0;
 
-	  const std::vector<SiPixelCluster::Pixel>& pixvector = clust->pixels();
-	  for ( int i=0;  i<(int)pixvector.size(); ++i)
-	    {
-	      SiPixelCluster::Pixel holdpix = pixvector[i];
-	      all_pixrow[i] = holdpix.x;
-	      all_pixcol[i] = holdpix.y;
-	      all_pixadc[i] = holdpix.adc;
-	      LocalPoint lp = topol->localPosition(MeasurementPoint(holdpix.x, holdpix.y));
-	      all_pixx[i] = lp.x();
-	      all_pixy[i]= lp.y();
-	      GlobalPoint GP =  theGeomDet->surface().toGlobal(Local3DPoint(lp.x(),lp.y(),lp.z()));
-	      all_pixgx[i] = GP.x();	
-	      all_pixgy[i]= GP.y();
-	      all_pixgz[i]= GP.z();
-	    }
+      if (topol->containsBigPixelInY(minPixelCol, maxPixelCol))
+        all_bigy = 1;
+      else
+        all_bigy = 0;
 
-	  ttree_all_hits_->Fill();
-	  
-	} // for ( ; pixeliter != pixelrechitRangeIteratorEnd; ++pixeliter)
+      if ((int)detId.subdetId() == (int)PixelSubdetector::PixelBarrel) {
+        all_layer = tTopo->pxbLayer(detId);
+        all_ladder = tTopo->pxbLadder(detId);
+        all_mod = tTopo->pxbModule(detId);
 
-    } // for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++) 
- 
+        int tmp_nrows = theGeomDet->specificTopology().nrows();
+        if (tmp_nrows == 80)
+          all_half = 1;
+        else if (tmp_nrows == 160)
+          all_half = 0;
+        else
+          cout << "-------------------------------------------------- Wrong module size !!!" << endl;
+
+        float tmp1 = theGeomDet->surface().toGlobal(Local3DPoint(0., 0., 0.)).perp();
+        float tmp2 = theGeomDet->surface().toGlobal(Local3DPoint(0., 0., 1.)).perp();
+
+        if (tmp2 < tmp1)
+          all_flipped = 1;
+        else
+          all_flipped = 0;
+      } else if ((int)detId.subdetId() == (int)PixelSubdetector::PixelEndcap) {
+        all_side = tTopo->pxfSide(detId);
+        all_disk = tTopo->pxfDisk(detId);
+        all_blade = tTopo->pxfBlade(detId);
+        all_panel = tTopo->pxfPanel(detId);
+        all_plaq = tTopo->pxfModule(detId);  // also known as plaquette
+
+      }  // else if ( detId.subdetId()==PixelSubdetector::PixelEndcap )
+      else
+        std::cout << "We are not in the pixel detector" << (int)detId.subdetId() << endl;
+
+      all_cols = theGeomDet->specificTopology().ncolumns();
+      all_rows = theGeomDet->specificTopology().nrows();
+
+      LocalPoint lp = pixeliter->localPosition();
+      // gavril: change this name
+      all_rechitx = lp.x();
+      all_rechity = lp.y();
+      all_rechitz = lp.z();
+
+      LocalError le = pixeliter->localPositionError();
+      all_rechiterrx = sqrt(le.xx());
+      all_rechiterry = sqrt(le.yy());
+
+      bool found_hit_from_generated_particle = false;
+
+      //---Loop over sim hits, fill closest
+      float closest_dist = 99999.9;
+      std::vector<PSimHit>::const_iterator closest_simhit = matched.begin();
+
+      for (std::vector<PSimHit>::const_iterator m = matched.begin(); m < matched.end(); m++) {
+        if (checkType_) {
+          int pid = (*m).particleType();
+          if (abs(pid) != genType_)
+            continue;
+        }
+
+        float simhitx = 0.5 * ((*m).entryPoint().x() + (*m).exitPoint().x());
+        float simhity = 0.5 * ((*m).entryPoint().y() + (*m).exitPoint().y());
+
+        float x_res = simhitx - rechitx;
+        float y_res = simhity - rechity;
+
+        float dist = sqrt(x_res * x_res + y_res * y_res);
+
+        if (dist < closest_dist) {
+          closest_dist = dist;
+          closest_simhit = m;
+          found_hit_from_generated_particle = true;
+        }
+      }  // end sim hit loop
+
+      // If this recHit does not have any simHit with the same particleType as the particles generated
+      // ignore it as most probably comes from delta rays.
+      if (checkType_ && !found_hit_from_generated_particle)
+        continue;
+
+      all_x1 = (*closest_simhit).entryPoint().x();  // width (row index, in col direction)
+      all_y1 = (*closest_simhit).entryPoint().y();  // length (col index, in row direction)
+      all_z1 = (*closest_simhit).entryPoint().z();
+      all_x2 = (*closest_simhit).exitPoint().x();
+      all_y2 = (*closest_simhit).exitPoint().y();
+      all_z2 = (*closest_simhit).exitPoint().z();
+      GlobalPoint GP1 = theGeomDet->surface().toGlobal(Local3DPoint(
+          (*closest_simhit).entryPoint().x(), (*closest_simhit).entryPoint().y(), (*closest_simhit).entryPoint().z()));
+      GlobalPoint GP2 = theGeomDet->surface().toGlobal(Local3DPoint(
+          (*closest_simhit).exitPoint().x(), (*closest_simhit).exitPoint().y(), (*closest_simhit).exitPoint().z()));
+      all_gx1 = GP1.x();
+      all_gx2 = GP2.x();
+      all_gy1 = GP1.y();
+      all_gy2 = GP2.y();
+      all_gz1 = GP1.z();
+      all_gz2 = GP2.z();
+
+      MeasurementPoint mp1 = topol->measurementPosition(LocalPoint(
+          (*closest_simhit).entryPoint().x(), (*closest_simhit).entryPoint().y(), (*closest_simhit).entryPoint().z()));
+      MeasurementPoint mp2 = topol->measurementPosition(LocalPoint(
+          (*closest_simhit).exitPoint().x(), (*closest_simhit).exitPoint().y(), (*closest_simhit).exitPoint().z()));
+      all_row1 = mp1.x();
+      all_col1 = mp1.y();
+      all_row2 = mp2.x();
+      all_col2 = mp2.y();
+
+      all_simhitx = 0.5 * (all_x1 + all_x2);
+      all_simhity = 0.5 * (all_y1 + all_y2);
+
+      all_rechitresx = all_rechitx - all_simhitx;
+      all_rechitresy = all_rechity - all_simhity;
+
+      all_rechitpullx = all_rechitresx / all_rechiterrx;
+      all_rechitpully = all_rechitresy / all_rechiterry;
+
+      SiPixelRecHit::ClusterRef const& clust = pixeliter->cluster();
+
+      all_npix = clust->size();
+      all_nxpix = clust->sizeX();
+      all_nypix = clust->sizeY();
+
+      all_clust_row = clust->x();
+      all_clust_col = clust->y();
+
+      LocalPoint lp2 = topol->localPosition(MeasurementPoint(all_clust_row, all_clust_col));
+      all_clust_x = lp2.x();
+      all_clust_y = lp2.y();
+
+      all_clust_q = clust->charge();
+
+      all_clust_maxpixcol = clust->maxPixelCol();
+      all_clust_maxpixrow = clust->maxPixelRow();
+      all_clust_minpixcol = clust->minPixelCol();
+      all_clust_minpixrow = clust->minPixelRow();
+
+      all_clust_geoid = 0;  // never set!
+
+      all_simpx = (*closest_simhit).momentumAtEntry().x();
+      all_simpy = (*closest_simhit).momentumAtEntry().y();
+      all_simpz = (*closest_simhit).momentumAtEntry().z();
+      all_eloss = (*closest_simhit).energyLoss();
+      all_simphi = (*closest_simhit).phiAtEntry();
+      all_simtheta = (*closest_simhit).thetaAtEntry();
+      all_pidhit = (*closest_simhit).particleType();
+      all_trkid = (*closest_simhit).trackId();
+
+      //--- Fill alpha and beta -- more useful for exploring the residuals...
+      all_beta = atan2(all_simpz, all_simpy);
+      all_alpha = atan2(all_simpz, all_simpx);
+
+      all_simproc = (int)closest_simhit->processType();
+
+      const edm::SimTrackContainer& trks = *(simtracks.product());
+      SimTrackContainer::const_iterator trksiter;
+      for (trksiter = trks.begin(); trksiter != trks.end(); trksiter++)
+        if ((int)trksiter->trackId() == all_trkid) {
+          all_simtrketa = trksiter->momentum().eta();
+          all_simtrkphi = trksiter->momentum().phi();
+        }
+
+      all_vtxz = theGeomDet->surface().position().z();
+      all_vtxr = theGeomDet->surface().position().perp();
+
+      //computeAnglesFromDetPosition(clust,
+      //		       theGeomDet,
+      //		       all_clust_alpha, all_clust_beta )
+
+      const std::vector<SiPixelCluster::Pixel>& pixvector = clust->pixels();
+      for (int i = 0; i < (int)pixvector.size(); ++i) {
+        SiPixelCluster::Pixel holdpix = pixvector[i];
+        all_pixrow[i] = holdpix.x;
+        all_pixcol[i] = holdpix.y;
+        all_pixadc[i] = holdpix.adc;
+        LocalPoint lp = topol->localPosition(MeasurementPoint(holdpix.x, holdpix.y));
+        all_pixx[i] = lp.x();
+        all_pixy[i] = lp.y();
+        GlobalPoint GP = theGeomDet->surface().toGlobal(Local3DPoint(lp.x(), lp.y(), lp.z()));
+        all_pixgx[i] = GP.x();
+        all_pixgy[i] = GP.y();
+        all_pixgz[i] = GP.z();
+      }
+
+      ttree_all_hits_->Fill();
+
+    }  // for ( ; pixeliter != pixelrechitRangeIteratorEnd; ++pixeliter)
+
+  }  // for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++)
+
   // ------------------------------------------------ all hits ---------------------------------------------------------------
-
 
   //cout << "...3..." << endl;
 
+  // ------------------------------------------------ track hits only --------------------------------------------------------
 
-  // ------------------------------------------------ track hits only -------------------------------------------------------- 
+  if (include_trk_hits_) {
+    // Get tracks
+    edm::Handle<reco::TrackCollection> trackCollection;
+    e.getByToken(tTrackCollection, trackCollection);
+    const reco::TrackCollection* tracks = trackCollection.product();
+    reco::TrackCollection::const_iterator tciter;
 
-  
-  
-  if ( include_trk_hits_ )
-    {
-      // Get tracks
-      edm::Handle<reco::TrackCollection> trackCollection;
-      e.getByToken(tTrackCollection, trackCollection);
-      const reco::TrackCollection *tracks = trackCollection.product();
-      reco::TrackCollection::const_iterator tciter;
-      
-      if ( !tracks->empty() )
-	{
-	  // Loop on tracks
-	  for ( tciter=tracks->begin(); tciter!=tracks->end(); ++tciter)
-	    {
-	      // First loop on hits: find matched hits
-          for(auto const hit : tciter->recHits())
-		{
-		  // Is it a matched hit?
-		  const SiPixelRecHit* matchedhit = dynamic_cast<const SiPixelRecHit*>(hit);
-		  
-		  if ( matchedhit ) 
-		    {
-		      rechitx = -9999.9;
-		      rechity = -9999.9;
-		      rechitz = -9999.9;
-		      rechiterrx = -9999.9;
-		      rechiterry = -9999.9;		      
-		      rechitresx = -9999.9;
-		      rechitresy = -9999.9;
-		      rechitpullx = -9999.9;
-		      rechitpully = -9999.9;
-		      
-		      npix = -9999;
-		      nxpix = -9999;
-		      nypix = -9999;
-		      charge = -9999.9;
-		      
-		      edgex = -9999;
-		      edgey = -9999;
-		      
-		      bigx = -9999;
-		      bigy = -9999;
-		      
-		      alpha = -9999.9;
-		      beta  = -9999.9;
-		      
-		      phi = -9999.9;
-		      eta = -9999.9;
-		      
-		      subdetId = -9999;
-		      
-		      layer  = -9999; 
-		      ladder = -9999; 
-		      mod    = -9999; 
-		      side   = -9999;  
-		      disk   = -9999;  
-		      blade  = -9999; 
-		      panel  = -9999; 
-		      plaq   = -9999; 
-		      
-		      half = -9999;
-		      flipped = -9999;
-		      
-		      nsimhit = -9999;
-		      pidhit  = -9999;
-		      simproc = -9999;
-		      
-		      simhitx = -9999.9;
-		      simhity = -9999.9;
+    if (!tracks->empty()) {
+      // Loop on tracks
+      for (tciter = tracks->begin(); tciter != tracks->end(); ++tciter) {
+        // First loop on hits: find matched hits
+        for (auto const hit : tciter->recHits()) {
+          // Is it a matched hit?
+          const SiPixelRecHit* matchedhit = dynamic_cast<const SiPixelRecHit*>(hit);
 
-		      hit_probx = -9999.9;
-		      hit_proby = -9999.9;
-		      hit_cprob0 = -9999.9;
-		      hit_cprob1 = -9999.9;
-		      hit_cprob2 = -9999.9;
-  
-		      pixel_split = -9999;
+          if (matchedhit) {
+            rechitx = -9999.9;
+            rechity = -9999.9;
+            rechitz = -9999.9;
+            rechiterrx = -9999.9;
+            rechiterry = -9999.9;
+            rechitresx = -9999.9;
+            rechitresy = -9999.9;
+            rechitpullx = -9999.9;
+            rechitpully = -9999.9;
 
-		      pixel_clst_err_x = -9999.9;
-		      pixel_clst_err_y = -9999.9;
-		      
-		      position = hit->localPosition();
-		      error = hit->localPositionError();
-		      
-		      rechitx = position.x();
-		      rechity = position.y();
-		      rechitz = position.z();
-		      rechiterrx = sqrt(error.xx());
-		      rechiterry = sqrt(error.yy());
-		      
-		      npix = matchedhit->cluster()->size();
-		      nxpix = matchedhit->cluster()->sizeX();
-		      nypix = matchedhit->cluster()->sizeY();
-		      charge = matchedhit->cluster()->charge();
+            npix = -9999;
+            nxpix = -9999;
+            nypix = -9999;
+            charge = -9999.9;
 
-		      if ( matchedhit->cluster()->getSplitClusterErrorX() > 0.0 && 
-			   matchedhit->cluster()->getSplitClusterErrorY() > 0.0 )
-			pixel_split = 1;
-		      else
-			pixel_split = 0;
-		      
-		      pixel_clst_err_x = matchedhit->cluster()->getSplitClusterErrorX();
-		      pixel_clst_err_y = matchedhit->cluster()->getSplitClusterErrorY();
+            edgex = -9999;
+            edgey = -9999;
 
-		      //hit_probx  = (float)matchedhit->probabilityX();
-		      //hit_proby  = (float)matchedhit->probabilityY();
-		      hit_cprob0 = (float)matchedhit->clusterProbability(0);
-		      hit_cprob1 = (float)matchedhit->clusterProbability(1);
-		      hit_cprob2 = (float)matchedhit->clusterProbability(2);
-		      
-		      
-		      //Association of the rechit to the simhit
-		      matched.clear();
-		      matched = associate.associateHit(*matchedhit);
-		      
-		      nsimhit = (int)matched.size();
-		      
-		      if ( !matched.empty() ) 
-			{
-			  mindist = 999999.9;
-			  float distx, disty, dist;
-			  bool found_hit_from_generated_particle = false;
-			  
-			  int n_assoc_muon = 0;
-			  
-			  vector<PSimHit>::const_iterator closestit = matched.begin();
-			  for (vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); ++m)
-			    {
-			      if ( checkType_ )
-				{ // only consider associated simhits with the generated pid (muons)
-				  int pid = (*m).particleType();
-				  if ( abs(pid) != genType_ )
-				    continue;
-				}
-			      
-			      float simhitx = 0.5 * ( (*m).entryPoint().x() + (*m).exitPoint().x() );
-			      float simhity = 0.5 * ( (*m).entryPoint().y() + (*m).exitPoint().y() );
-			      
-			      distx = fabs(rechitx - simhitx);
-			      disty = fabs(rechity - simhity);
-			      dist = sqrt( distx*distx + disty*disty );
-			      
-			      if ( dist < mindist )
-				{
-				  n_assoc_muon++;
-				  
-				  mindist = dist;
-				  closestit = m;
-				  found_hit_from_generated_particle = true;
-				}
-			    } // for (vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++)
-			  
-			  // This recHit does not have any simHit with the same particleType as the particles generated
-			  // Ignore it as most probably come from delta rays.
-			  if ( checkType_ && !found_hit_from_generated_particle )
-			    continue; 
-			  
-			  //if ( n_assoc_muon > 1 )
-			  //{
-			  //  // cout << " ----- This is not good: n_assoc_muon = " << n_assoc_muon << endl;
-			  //  // cout << "evt = " << evt << endl;
-			  //}
-			  
-			  DetId detId = hit->geographicalId();
+            bigx = -9999;
+            bigy = -9999;
 
-			  const PixelGeomDetUnit* theGeomDet =
-			    dynamic_cast<const PixelGeomDetUnit*> ((*tracker).idToDet(detId) );
-			  
-			  const PixelTopology* theTopol = &(theGeomDet->specificTopology());
+            alpha = -9999.9;
+            beta = -9999.9;
 
-			  pidhit = (*closestit).particleType();
-			  simproc = (int)(*closestit).processType();
-			  
-			  simhitx = 0.5*( (*closestit).entryPoint().x() + (*closestit).exitPoint().x() );
-			  simhity = 0.5*( (*closestit).entryPoint().y() + (*closestit).exitPoint().y() );
-			  
-			  rechitresx = rechitx - simhitx;
-			  rechitresy = rechity - simhity;
-			  rechitpullx = ( rechitx - simhitx ) / sqrt(error.xx());
-			  rechitpully = ( rechity - simhity ) / sqrt(error.yy());
-			  
-			  float simhitpx = (*closestit).momentumAtEntry().x();
-			  float simhitpy = (*closestit).momentumAtEntry().y();
-			  float simhitpz = (*closestit).momentumAtEntry().z();
-			  
-			  beta = atan2(simhitpz, simhitpy) * radtodeg;
-			  alpha = atan2(simhitpz, simhitpx) * radtodeg;
-			  
-			  //beta  = fabs(atan2(simhitpz, simhitpy)) * radtodeg;
-			  //alpha = fabs(atan2(simhitpz, simhitpx)) * radtodeg;
+            phi = -9999.9;
+            eta = -9999.9;
 
-			  // calculate alpha and beta exactly as in PixelCPEBase.cc
-			  float locx = simhitpx;
-			  float locy = simhitpy;
-			  float locz = simhitpz;
-			  
-			  bool isFlipped = false;
-			  float tmp1 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,0.)).perp();
-			  float tmp2 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,1.)).perp();
-			  if ( tmp2<tmp1 ) 
-			    isFlipped = true;
-			  else 
-			    isFlipped = false;    
+            subdetId = -9999;
 
-			  trk_alpha = acos(locx/sqrt(locx*locx+locz*locz)) * radtodeg;
-			  if ( isFlipped )                    // &&& check for FPIX !!!
-			    trk_alpha = 180.0 - trk_alpha ;
-			  
-			  trk_beta = acos(locy/sqrt(locy*locy+locz*locz)) * radtodeg;
-			  
+            layer = -9999;
+            ladder = -9999;
+            mod = -9999;
+            side = -9999;
+            disk = -9999;
+            blade = -9999;
+            panel = -9999;
+            plaq = -9999;
 
-			  phi = tciter->momentum().phi() / math_pi*180.0;
-			  eta = tciter->momentum().eta();
-			  
-			  const int maxPixelCol = (*matchedhit).cluster()->maxPixelCol();
-			  const int maxPixelRow = (*matchedhit).cluster()->maxPixelRow();
-			  const int minPixelCol = (*matchedhit).cluster()->minPixelCol();
-			  const int minPixelRow = (*matchedhit).cluster()->minPixelRow();
-					  
-			  // check whether the cluster is at the module edge 
-			  if ( theTopol->isItEdgePixelInX( minPixelRow ) || 
-			       theTopol->isItEdgePixelInX( maxPixelRow ) )
-			    edgex = 1;
-			  else 
-			    edgex = 0;
-			  
-			  if ( theTopol->isItEdgePixelInY( minPixelCol ) || 
-			       theTopol->isItEdgePixelInY( maxPixelCol ) )
-			    edgey = 1;
-			  else 
-			    edgey = 0;
-			  
-			  // check whether this rechit contains big pixels
-			  if ( theTopol->containsBigPixelInX(minPixelRow, maxPixelRow) )
-			    bigx = 1;
-			  else 
-			    bigx = 0;
-			  
-			  if ( theTopol->containsBigPixelInY(minPixelCol, maxPixelCol) )
-			    bigy = 1;
-			  else 
-			    bigy = 0;
-			  
-			  subdetId = (int)detId.subdetId();
-			  
-			  if ( (int)detId.subdetId() == (int)PixelSubdetector::PixelBarrel ) 
-			    { 
-	  
-			      int tmp_nrows = theGeomDet->specificTopology().nrows();
-			      if ( tmp_nrows == 80 ) 
-				half = 1;
-			      else if ( tmp_nrows == 160 ) 
-				half = 0;
-			      else 
-				cout << "-------------------------------------------------- Wrong module size !!!" << endl;
-			      
-			      float tmp1 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,0.)).perp();
-			      float tmp2 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,1.)).perp();
-			      
-			      if ( tmp2<tmp1 ) 
-				flipped = 1;
-			      else 
-				flipped = 0;
-			      
-			      
-			      layer  = tTopo->pxbLayer(detId);   // Layer: 1,2,3.
-			      ladder = tTopo->pxbLadder(detId);  // Ladder: 1-20, 32, 44. 
-			      mod   = tTopo->pxbModule(detId);  // Mod: 1-8.
-			    }			  
-			  else if ( (int)detId.subdetId() == (int)PixelSubdetector::PixelEndcap )
-			    {
-			      
-			      side  = tTopo->pxfSide(detId);
-			      disk  = tTopo->pxfDisk(detId);
-			      blade = tTopo->pxfBlade(detId);
-			      panel = tTopo->pxfPanel(detId);
-			      plaq  = tTopo->pxfModule(detId); // also known as plaquette
-			      
-			      float tmp1 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,0.)).perp();
-			      float tmp2 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,1.)).perp();
-			      
-			      if ( tmp2<tmp1 ) 
-				flipped = 1;
-			      else 
-				flipped = 0;
-			      
-			    } // else if ( detId.subdetId()==PixelSubdetector::PixelEndcap )
-			  //else std::// cout << "We are not in the pixel detector. detId.subdetId() = " << (int)detId.subdetId() << endl;
-			  
-			  ttree_track_hits_->Fill();
-			  
-			} // if ( !matched.empty() )
-		      else
-			cout << "---------------- RecHit with no associated SimHit !!! -------------------------- " << endl;
-		      
-		    } // if ( matchedhit )
-		  
-		} // end of loop on hits
-	      
-	    } //end of loop on track 
-      
-	} // tracks > 0.
-     
-    } // if ( include_trk_hits_ )
+            half = -9999;
+            flipped = -9999;
 
- 
+            nsimhit = -9999;
+            pidhit = -9999;
+            simproc = -9999;
+
+            simhitx = -9999.9;
+            simhity = -9999.9;
+
+            hit_probx = -9999.9;
+            hit_proby = -9999.9;
+            hit_cprob0 = -9999.9;
+            hit_cprob1 = -9999.9;
+            hit_cprob2 = -9999.9;
+
+            pixel_split = -9999;
+
+            pixel_clst_err_x = -9999.9;
+            pixel_clst_err_y = -9999.9;
+
+            position = hit->localPosition();
+            error = hit->localPositionError();
+
+            rechitx = position.x();
+            rechity = position.y();
+            rechitz = position.z();
+            rechiterrx = sqrt(error.xx());
+            rechiterry = sqrt(error.yy());
+
+            npix = matchedhit->cluster()->size();
+            nxpix = matchedhit->cluster()->sizeX();
+            nypix = matchedhit->cluster()->sizeY();
+            charge = matchedhit->cluster()->charge();
+
+            if (matchedhit->cluster()->getSplitClusterErrorX() > 0.0 &&
+                matchedhit->cluster()->getSplitClusterErrorY() > 0.0)
+              pixel_split = 1;
+            else
+              pixel_split = 0;
+
+            pixel_clst_err_x = matchedhit->cluster()->getSplitClusterErrorX();
+            pixel_clst_err_y = matchedhit->cluster()->getSplitClusterErrorY();
+
+            //hit_probx  = (float)matchedhit->probabilityX();
+            //hit_proby  = (float)matchedhit->probabilityY();
+            hit_cprob0 = (float)matchedhit->clusterProbability(0);
+            hit_cprob1 = (float)matchedhit->clusterProbability(1);
+            hit_cprob2 = (float)matchedhit->clusterProbability(2);
+
+            //Association of the rechit to the simhit
+            matched.clear();
+            matched = associate.associateHit(*matchedhit);
+
+            nsimhit = (int)matched.size();
+
+            if (!matched.empty()) {
+              mindist = 999999.9;
+              float distx, disty, dist;
+              bool found_hit_from_generated_particle = false;
+
+              int n_assoc_muon = 0;
+
+              vector<PSimHit>::const_iterator closestit = matched.begin();
+              for (vector<PSimHit>::const_iterator m = matched.begin(); m < matched.end(); ++m) {
+                if (checkType_) {  // only consider associated simhits with the generated pid (muons)
+                  int pid = (*m).particleType();
+                  if (abs(pid) != genType_)
+                    continue;
+                }
+
+                float simhitx = 0.5 * ((*m).entryPoint().x() + (*m).exitPoint().x());
+                float simhity = 0.5 * ((*m).entryPoint().y() + (*m).exitPoint().y());
+
+                distx = fabs(rechitx - simhitx);
+                disty = fabs(rechity - simhity);
+                dist = sqrt(distx * distx + disty * disty);
+
+                if (dist < mindist) {
+                  n_assoc_muon++;
+
+                  mindist = dist;
+                  closestit = m;
+                  found_hit_from_generated_particle = true;
+                }
+              }  // for (vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++)
+
+              // This recHit does not have any simHit with the same particleType as the particles generated
+              // Ignore it as most probably come from delta rays.
+              if (checkType_ && !found_hit_from_generated_particle)
+                continue;
+
+              //if ( n_assoc_muon > 1 )
+              //{
+              //  // cout << " ----- This is not good: n_assoc_muon = " << n_assoc_muon << endl;
+              //  // cout << "evt = " << evt << endl;
+              //}
+
+              DetId detId = hit->geographicalId();
+
+              const PixelGeomDetUnit* theGeomDet = dynamic_cast<const PixelGeomDetUnit*>((*tracker).idToDet(detId));
+
+              const PixelTopology* theTopol = &(theGeomDet->specificTopology());
+
+              pidhit = (*closestit).particleType();
+              simproc = (int)(*closestit).processType();
+
+              simhitx = 0.5 * ((*closestit).entryPoint().x() + (*closestit).exitPoint().x());
+              simhity = 0.5 * ((*closestit).entryPoint().y() + (*closestit).exitPoint().y());
+
+              rechitresx = rechitx - simhitx;
+              rechitresy = rechity - simhity;
+              rechitpullx = (rechitx - simhitx) / sqrt(error.xx());
+              rechitpully = (rechity - simhity) / sqrt(error.yy());
+
+              float simhitpx = (*closestit).momentumAtEntry().x();
+              float simhitpy = (*closestit).momentumAtEntry().y();
+              float simhitpz = (*closestit).momentumAtEntry().z();
+
+              beta = atan2(simhitpz, simhitpy) * radtodeg;
+              alpha = atan2(simhitpz, simhitpx) * radtodeg;
+
+              //beta  = fabs(atan2(simhitpz, simhitpy)) * radtodeg;
+              //alpha = fabs(atan2(simhitpz, simhitpx)) * radtodeg;
+
+              // calculate alpha and beta exactly as in PixelCPEBase.cc
+              float locx = simhitpx;
+              float locy = simhitpy;
+              float locz = simhitpz;
+
+              bool isFlipped = false;
+              float tmp1 = theGeomDet->surface().toGlobal(Local3DPoint(0., 0., 0.)).perp();
+              float tmp2 = theGeomDet->surface().toGlobal(Local3DPoint(0., 0., 1.)).perp();
+              if (tmp2 < tmp1)
+                isFlipped = true;
+              else
+                isFlipped = false;
+
+              trk_alpha = acos(locx / sqrt(locx * locx + locz * locz)) * radtodeg;
+              if (isFlipped)  // &&& check for FPIX !!!
+                trk_alpha = 180.0 - trk_alpha;
+
+              trk_beta = acos(locy / sqrt(locy * locy + locz * locz)) * radtodeg;
+
+              phi = tciter->momentum().phi() / math_pi * 180.0;
+              eta = tciter->momentum().eta();
+
+              const int maxPixelCol = (*matchedhit).cluster()->maxPixelCol();
+              const int maxPixelRow = (*matchedhit).cluster()->maxPixelRow();
+              const int minPixelCol = (*matchedhit).cluster()->minPixelCol();
+              const int minPixelRow = (*matchedhit).cluster()->minPixelRow();
+
+              // check whether the cluster is at the module edge
+              if (theTopol->isItEdgePixelInX(minPixelRow) || theTopol->isItEdgePixelInX(maxPixelRow))
+                edgex = 1;
+              else
+                edgex = 0;
+
+              if (theTopol->isItEdgePixelInY(minPixelCol) || theTopol->isItEdgePixelInY(maxPixelCol))
+                edgey = 1;
+              else
+                edgey = 0;
+
+              // check whether this rechit contains big pixels
+              if (theTopol->containsBigPixelInX(minPixelRow, maxPixelRow))
+                bigx = 1;
+              else
+                bigx = 0;
+
+              if (theTopol->containsBigPixelInY(minPixelCol, maxPixelCol))
+                bigy = 1;
+              else
+                bigy = 0;
+
+              subdetId = (int)detId.subdetId();
+
+              if ((int)detId.subdetId() == (int)PixelSubdetector::PixelBarrel) {
+                int tmp_nrows = theGeomDet->specificTopology().nrows();
+                if (tmp_nrows == 80)
+                  half = 1;
+                else if (tmp_nrows == 160)
+                  half = 0;
+                else
+                  cout << "-------------------------------------------------- Wrong module size !!!" << endl;
+
+                float tmp1 = theGeomDet->surface().toGlobal(Local3DPoint(0., 0., 0.)).perp();
+                float tmp2 = theGeomDet->surface().toGlobal(Local3DPoint(0., 0., 1.)).perp();
+
+                if (tmp2 < tmp1)
+                  flipped = 1;
+                else
+                  flipped = 0;
+
+                layer = tTopo->pxbLayer(detId);    // Layer: 1,2,3.
+                ladder = tTopo->pxbLadder(detId);  // Ladder: 1-20, 32, 44.
+                mod = tTopo->pxbModule(detId);     // Mod: 1-8.
+              } else if ((int)detId.subdetId() == (int)PixelSubdetector::PixelEndcap) {
+                side = tTopo->pxfSide(detId);
+                disk = tTopo->pxfDisk(detId);
+                blade = tTopo->pxfBlade(detId);
+                panel = tTopo->pxfPanel(detId);
+                plaq = tTopo->pxfModule(detId);  // also known as plaquette
+
+                float tmp1 = theGeomDet->surface().toGlobal(Local3DPoint(0., 0., 0.)).perp();
+                float tmp2 = theGeomDet->surface().toGlobal(Local3DPoint(0., 0., 1.)).perp();
+
+                if (tmp2 < tmp1)
+                  flipped = 1;
+                else
+                  flipped = 0;
+
+              }  // else if ( detId.subdetId()==PixelSubdetector::PixelEndcap )
+              //else std::// cout << "We are not in the pixel detector. detId.subdetId() = " << (int)detId.subdetId() << endl;
+
+              ttree_track_hits_->Fill();
+
+            }  // if ( !matched.empty() )
+            else
+              cout << "---------------- RecHit with no associated SimHit !!! -------------------------- " << endl;
+
+          }  // if ( matchedhit )
+
+        }  // end of loop on hits
+
+      }  //end of loop on track
+
+    }  // tracks > 0.
+
+  }  // if ( include_trk_hits_ )
 
   // ----------------------------------------------- track hits only -----------------------------------------------------------
-  
 }
 
-void SiPixelErrorEstimation::
-computeAnglesFromDetPosition(const SiPixelCluster & cl, 
-			     const GeomDetUnit    & det, 
-			     float& alpha, float& beta )
-{
+void SiPixelErrorEstimation::computeAnglesFromDetPosition(const SiPixelCluster& cl,
+                                                          const GeomDetUnit& det,
+                                                          float& alpha,
+                                                          float& beta) {
   //--- This is a new det unit, so cache it
-  const PixelGeomDetUnit* theDet = dynamic_cast<const PixelGeomDetUnit*>( &det );
-  if (! theDet) 
-    {
-      cout << "---------------------------------------------- Not a pixel detector !!!!!!!!!!!!!!" << endl;
-      assert(0);
-    }
+  const PixelGeomDetUnit* theDet = dynamic_cast<const PixelGeomDetUnit*>(&det);
+  if (!theDet) {
+    cout << "---------------------------------------------- Not a pixel detector !!!!!!!!!!!!!!" << endl;
+    assert(0);
+  }
 
   const PixelTopology* theTopol = &(theDet->specificTopology());
 
   // get cluster center of gravity (of charge)
   float xcenter = cl.x();
   float ycenter = cl.y();
-  
-  // get the cluster position in local coordinates (cm) 
-  LocalPoint lp = theTopol->localPosition( MeasurementPoint(xcenter, ycenter) );
+
+  // get the cluster position in local coordinates (cm)
+  LocalPoint lp = theTopol->localPosition(MeasurementPoint(xcenter, ycenter));
   //float lp_mod = sqrt( lp.x()*lp.x() + lp.y()*lp.y() + lp.z()*lp.z() );
 
   // get the cluster position in global coordinates (cm)
-  GlobalPoint gp = theDet->surface().toGlobal( lp );
-  float gp_mod = sqrt( gp.x()*gp.x() + gp.y()*gp.y() + gp.z()*gp.z() );
+  GlobalPoint gp = theDet->surface().toGlobal(lp);
+  float gp_mod = sqrt(gp.x() * gp.x() + gp.y() * gp.y() + gp.z() * gp.z());
 
   // normalize
-  float gpx = gp.x()/gp_mod;
-  float gpy = gp.y()/gp_mod;
-  float gpz = gp.z()/gp_mod;
+  float gpx = gp.x() / gp_mod;
+  float gpy = gp.y() / gp_mod;
+  float gpz = gp.z() / gp_mod;
 
-  // make a global vector out of the global point; this vector will point from the 
+  // make a global vector out of the global point; this vector will point from the
   // origin of the detector to the cluster
   GlobalVector gv(gpx, gpy, gpz);
 
@@ -1707,30 +1570,30 @@ computeAnglesFromDetPosition(const SiPixelCluster & cl,
   const Local3DVector lvx(1.0, 0.0, 0.0);
 
   // get the unit X vector in global coordinates/
-  GlobalVector gvx = theDet->surface().toGlobal( lvx );
+  GlobalVector gvx = theDet->surface().toGlobal(lvx);
 
   // make local unit vector along local Y axis
   const Local3DVector lvy(0.0, 1.0, 0.0);
 
   // get the unit Y vector in global coordinates
-  GlobalVector gvy = theDet->surface().toGlobal( lvy );
-   
+  GlobalVector gvy = theDet->surface().toGlobal(lvy);
+
   // make local unit vector along local Z axis
   const Local3DVector lvz(0.0, 0.0, 1.0);
 
   // get the unit Z vector in global coordinates
-  GlobalVector gvz = theDet->surface().toGlobal( lvz );
-    
-  // calculate the components of gv (the unit vector pointing to the cluster) 
+  GlobalVector gvz = theDet->surface().toGlobal(lvz);
+
+  // calculate the components of gv (the unit vector pointing to the cluster)
   // in the local coordinate system given by the basis {gvx, gvy, gvz}
   // note that both gv and the basis {gvx, gvy, gvz} are given in global coordinates
-  float gv_dot_gvx = gv.x()*gvx.x() + gv.y()*gvx.y() + gv.z()*gvx.z();
-  float gv_dot_gvy = gv.x()*gvy.x() + gv.y()*gvy.y() + gv.z()*gvy.z();
-  float gv_dot_gvz = gv.x()*gvz.x() + gv.y()*gvz.y() + gv.z()*gvz.z();
+  float gv_dot_gvx = gv.x() * gvx.x() + gv.y() * gvx.y() + gv.z() * gvx.z();
+  float gv_dot_gvy = gv.x() * gvy.x() + gv.y() * gvy.y() + gv.z() * gvy.z();
+  float gv_dot_gvz = gv.x() * gvz.x() + gv.y() * gvz.y() + gv.z() * gvz.z();
 
   // calculate angles
-  alpha = atan2( gv_dot_gvz, gv_dot_gvx );
-  beta  = atan2( gv_dot_gvz, gv_dot_gvy );
+  alpha = atan2(gv_dot_gvz, gv_dot_gvx);
+  beta = atan2(gv_dot_gvz, gv_dot_gvy);
 
   // calculate cotalpha and cotbeta
   //   cotalpha_ = 1.0/tan(alpha_);

--- a/CalibTracker/SiStripDCS/interface/SiStripCoralIface.h
+++ b/CalibTracker/SiStripDCS/interface/SiStripCoralIface.h
@@ -9,33 +9,42 @@
 #include <string>
 #include <map>
 
-
 /**	
    \class SiStripCoralIface
    \brief An interface class to the PVSS cond DB
    \author J.Chen, J.Cole
 */
-class SiStripCoralIface
-{
- public:	
+class SiStripCoralIface {
+public:
   /** constructor */
-  SiStripCoralIface( std::string connectionString , std::string authenticationPath, const bool debug);
+  SiStripCoralIface(std::string connectionString, std::string authenticationPath, const bool debug);
   /** destructor*/
   ~SiStripCoralIface();
   /** Method to retrieve information from status change table or lastValue table.  queryType defines which table is to be accessed.*/
-  void doQuery(std::string queryType, const coral::TimeStamp& startTime, const coral::TimeStamp& endTime, std::vector<coral::TimeStamp>&, std::vector<float>&, std::vector<std::string>& );
+  void doQuery(std::string queryType,
+               const coral::TimeStamp& startTime,
+               const coral::TimeStamp& endTime,
+               std::vector<coral::TimeStamp>&,
+               std::vector<float>&,
+               std::vector<std::string>&);
   /** Method to access the settings for each channel stored in the status change table*/
-  void doSettingsQuery(const coral::TimeStamp& startTime,const coral::TimeStamp& endTime,std::vector<coral::TimeStamp>&,std::vector<float>&,std::vector<std::string>&,std::vector<uint32_t>&);
+  void doSettingsQuery(const coral::TimeStamp& startTime,
+                       const coral::TimeStamp& endTime,
+                       std::vector<coral::TimeStamp>&,
+                       std::vector<float>&,
+                       std::vector<std::string>&,
+                       std::vector<uint32_t>&);
   //
-  void doNameQuery(std::vector<std::string> &vec_dpname, std::vector<uint32_t> &vec_dpid);
- private:
+  void doNameQuery(std::vector<std::string>& vec_dpname, std::vector<uint32_t>& vec_dpid);
+
+private:
   /** Set up the connection to the database*/
   void initialize();
 
   /* member variables*/
   std::string m_connectionString;
   std::string m_authPath;
-  std::map<std::string,unsigned int> m_id_map;
+  std::map<std::string, unsigned int> m_id_map;
   cond::persistency::Session m_session;
   std::unique_ptr<cond::persistency::TransactionScope> m_transaction;
   // cond::CoralTransaction* m_coraldb;

--- a/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
+++ b/CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h
@@ -2,7 +2,6 @@
 #define SISTRIPDETVOFF_SRC_BUILDER_H
 #define USING_NEW_CORAL
 
-
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -22,7 +21,6 @@
 #include "CondFormats/Common/interface/TimeConversions.h"
 //#include "DataFormats/Provenance/interface/Timestamp.h"
 
-
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -36,71 +34,70 @@
 // Unit test class for SiStripDetVOffBuilder
 class TestSiStripDetVOffBuilder;
 
-class SiStripDetVOffBuilder
-{
+class SiStripDetVOffBuilder {
   friend class TestSiStripDetVOffBuilder;
 
- public:
+public:
   /** Destructor. */
   ~SiStripDetVOffBuilder();
   /** Default constructor. */
-  SiStripDetVOffBuilder(const edm::ParameterSet&,const edm::ActivityRegistry&);
+  SiStripDetVOffBuilder(const edm::ParameterSet&, const edm::ActivityRegistry&);
   /** Build the SiStripDetVOff object for transfer. */
   void BuildDetVOffObj();
   /** Return modules Off vector of objects. */
-  std::vector< std::pair<SiStripDetVOff*,cond::Time_t> > getModulesVOff() {
+  std::vector<std::pair<SiStripDetVOff*, cond::Time_t> > getModulesVOff() {
     reduction(deltaTmin_, maxIOVlength_);
     return modulesOff;
   }
   /** Return statistics about payloads transferred for storage in logDB. */
-  std::vector< std::vector<uint32_t> > getPayloadStats() {return payloadStats;}
+  std::vector<std::vector<uint32_t> > getPayloadStats() { return payloadStats; }
   /** Store the last payload transferred to DB as starting point for creation of new object list.
       ONLY WORKS FOR STATUSCHANGE OPTION. */
-  void setLastSiStripDetVOff( SiStripDetVOff * lastPayload, cond::Time_t lastTimeStamp );
+  void setLastSiStripDetVOff(SiStripDetVOff* lastPayload, cond::Time_t lastTimeStamp);
 
   /// Operates the reduction of the fast sequences of ramping up and down of the voltages
-  void reduce( std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator & it,
-	       std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator & initialIt,
-	       std::vector< std::pair<SiStripDetVOff*,cond::Time_t> > & resultVec,
-	       const bool last = false);
+  void reduce(std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator& it,
+              std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator& initialIt,
+              std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >& resultVec,
+              const bool last = false);
 
   void reduction(const uint32_t deltaTmin, const uint32_t maxIOVlength);
 
   /// Removes IOVs as dictated by reduction
-  void discardIOVs( std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator & it,
-                    std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator & initialIt,
-                    std::vector< std::pair<SiStripDetVOff*,cond::Time_t> > & resultVec,
-                    const bool last, const unsigned int first );
+  void discardIOVs(std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator& it,
+                   std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator& initialIt,
+                   std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >& resultVec,
+                   const bool last,
+                   const unsigned int first);
   bool FileExists(std::string filename);
- private:
+
+private:
   // typedefs
-  typedef std::vector< std::pair< std::vector<uint32_t>,coral::TimeStamp> > DetIdTimeStampVector;
-  
+  typedef std::vector<std::pair<std::vector<uint32_t>, coral::TimeStamp> > DetIdTimeStampVector;
 
   bool whichQuery;
 
-
   void printPar(std::stringstream& ss, const std::vector<int>& par);
 
-  std::string timeToStream(const coral::TimeStamp & coralTime, const string & comment = "");
-  std::string timeToStream(const cond::Time_t & condTime, const string & comment = "");
+  std::string timeToStream(const coral::TimeStamp& coralTime, const string& comment = "");
+  std::string timeToStream(const cond::Time_t& condTime, const string& comment = "");
 
   /** Returns the PSU channel setting, based on date.  Works from DP ID. */
-  int findSetting(uint32_t id, 
-		  const coral::TimeStamp& changeDate, 
-		  const std::vector<uint32_t>& settingID, 
-		  const std::vector<coral::TimeStamp>& settingDate);
+  int findSetting(uint32_t id,
+                  const coral::TimeStamp& changeDate,
+                  const std::vector<uint32_t>& settingID,
+                  const std::vector<coral::TimeStamp>& settingDate);
 
   /** Returns the PSU channel setting, based on date.  Works from PSU channel name. Overloaded. */
-  int findSetting(std::string dpname, 
-		  const coral::TimeStamp& changeDate, 
-		  const std::vector<std::string>& settingDpname, 
-		  const std::vector<coral::TimeStamp>& settingDate);
+  int findSetting(std::string dpname,
+                  const coral::TimeStamp& changeDate,
+                  const std::vector<std::string>& settingDpname,
+                  const std::vector<coral::TimeStamp>& settingDate);
 
   /** Extract the lastValue values from file rather than from the PVSS cond DB. */
-  void readLastValueFromFile(std::vector<uint32_t> &dpIDs,
-			     std::vector<float> &vmonValues, 
-			     std::vector<coral::TimeStamp> &dateChange);
+  void readLastValueFromFile(std::vector<uint32_t>& dpIDs,
+                             std::vector<float>& vmonValues,
+                             std::vector<coral::TimeStamp>& dateChange);
 
   /** Utility code to convert a coral timestamp to the correct time format for O2O timestamp. */
   cond::Time_t getCondTime(const coral::TimeStamp& coralTime);
@@ -109,15 +106,15 @@ class SiStripDetVOffBuilder
   coral::TimeStamp getCoralTime(cond::Time_t iovTime);
 
   /** Utility code to remove all the duplicates from a vector of uint32_t. */
-  void removeDuplicates( std::vector<uint32_t> & vec );
+  void removeDuplicates(std::vector<uint32_t>& vec);
   /** */
-  cond::Time_t findMostRecentTimeStamp( const std::vector<coral::TimeStamp>& coralDate );
-  
+  cond::Time_t findMostRecentTimeStamp(const std::vector<coral::TimeStamp>& coralDate);
+
   // member data
-  std::vector< std::vector<uint32_t> > payloadStats;
-  std::vector< std::pair<SiStripDetVOff*,cond::Time_t> > modulesOff;
-  std::pair<SiStripDetVOff *, cond::Time_t> lastStoredCondObj;
-  
+  std::vector<std::vector<uint32_t> > payloadStats;
+  std::vector<std::pair<SiStripDetVOff*, cond::Time_t> > modulesOff;
+  std::pair<SiStripDetVOff*, cond::Time_t> lastStoredCondObj;
+
   // configurable parameters
   std::string onlineDbConnectionString;
   std::string authenticationPath;
@@ -136,24 +133,18 @@ class SiStripDetVOffBuilder
   double highVoltageOnThreshold_;
 
   // Structure used to store variables needed when building the database objects
-  struct TimesAndValues
-  {
-    TimesAndValues() :
-      latestTime(0)
-    {}
-    std::vector<coral::TimeStamp> changeDate;    // used by both
-    std::vector<std::string>      dpname;        // only used by DB access, not file access
-    std::vector<float>            actualValue;   // only used by DB access, not file access
-    std::vector<uint32_t>         dpid;          // only used by file access
-    std::vector<int>              actualStatus;  // filled using actualValue info
-    cond::Time_t                  latestTime;    // used for timestamp when using lastValue from file
+  struct TimesAndValues {
+    TimesAndValues() : latestTime(0) {}
+    std::vector<coral::TimeStamp> changeDate;  // used by both
+    std::vector<std::string> dpname;           // only used by DB access, not file access
+    std::vector<float> actualValue;            // only used by DB access, not file access
+    std::vector<uint32_t> dpid;                // only used by file access
+    std::vector<int> actualStatus;             // filled using actualValue info
+    cond::Time_t latestTime;                   // used for timestamp when using lastValue from file
   };
-  
-  struct DetIdListTimeAndStatus
-  {
-    DetIdListTimeAndStatus() :
-      notMatched(0)
-    {}
+
+  struct DetIdListTimeAndStatus {
+    DetIdListTimeAndStatus() : notMatched(0) {}
     DetIdTimeStampVector detidV;
     std::vector<bool> StatusGood;
     unsigned int notMatched;
@@ -161,16 +152,17 @@ class SiStripDetVOffBuilder
     std::vector<unsigned int> isHV;
   };
 
-  void statusChange( cond::Time_t & lastTime, TimesAndValues & tStruct );
-  void lastValue( TimesAndValues & tStruct );
-  void lastValueFromFile( TimesAndValues & tStruct );
+  void statusChange(cond::Time_t& lastTime, TimesAndValues& tStruct);
+  void lastValue(TimesAndValues& tStruct);
+  void lastValueFromFile(TimesAndValues& tStruct);
 
-  void buildPSUdetIdMap(TimesAndValues & tStruct, DetIdListTimeAndStatus & dStruct);
+  void buildPSUdetIdMap(TimesAndValues& tStruct, DetIdListTimeAndStatus& dStruct);
 
   void setPayloadStats(const uint32_t afterV, const uint32_t numAdded, const uint32_t numRemoved);
-  std::pair<int, int> extractDetIdVector(const unsigned int i, SiStripDetVOff * modV, DetIdListTimeAndStatus & detIdStruct);
+  std::pair<int, int> extractDetIdVector(const unsigned int i,
+                                         SiStripDetVOff* modV,
+                                         DetIdListTimeAndStatus& detIdStruct);
 
   std::unique_ptr<SiStripCoralIface> coralInterface;
-
 };
 #endif

--- a/CalibTracker/SiStripDCS/interface/SiStripPsuDetIdMap.h
+++ b/CalibTracker/SiStripDCS/interface/SiStripPsuDetIdMap.h
@@ -30,22 +30,28 @@ class SiStripConfigDb;
    \author J.Cole
 */
 
-class SiStripPsuDetIdMap
-{
- public:
+class SiStripPsuDetIdMap {
+public:
   /** Constructor */
   SiStripPsuDetIdMap();
   /** Destructor */
   ~SiStripPsuDetIdMap();
 
   std::vector<uint32_t> getLvDetID(std::string psu);
-  void getHvDetID(std::string psuchannel, std::vector<uint32_t> & ids, std::vector<uint32_t> & unmapped_ids, std::vector<uint32_t> & crosstalking_ids );
+  void getHvDetID(std::string psuchannel,
+                  std::vector<uint32_t> &ids,
+                  std::vector<uint32_t> &unmapped_ids,
+                  std::vector<uint32_t> &crosstalking_ids);
 
   //Produces 3 list of detIDs:
   //1-detids (positively matching the PSUChannel for HV case, positively matching the PSU for the LV case)
   //2-unmapped_detids (matching the PSUChannel000 for the HV case, empty for LV case)
   //3-crosstalking_detids (matching the PSUChannel999 for the HV case, empty for the LV case)
-  void getDetID(std::string pvss, bool, std::vector<uint32_t> & detids,std::vector<uint32_t> & unmapped_detids,std::vector<uint32_t> & crosstalking_detids);
+  void getDetID(std::string pvss,
+                bool,
+                std::vector<uint32_t> &detids,
+                std::vector<uint32_t> &unmapped_detids,
+                std::vector<uint32_t> &crosstalking_detids);
   /** Returns the PSU channel name for the specified Det ID, for power groups only. */
   std::string getPSUName(uint32_t detid);
   /** Returns the PSU channel name for the specified Det ID. */
@@ -60,30 +66,30 @@ class SiStripPsuDetIdMap
   uint32_t getDcuId(std::string pvss);
   /** Returns the DCU ID associated to the specified Det ID.  NB.  This checks power groups only, by definition. */
   uint32_t getDcuId(uint32_t detid);
-  
+
   //Return the HVUnmapped PSU channels as a map initialized to all channels (002/003) OFF (false):
-  std::map<std::string,std::vector<uint32_t> > getHVUnmappedMap() {return HVUnmapped_Map;}
+  std::map<std::string, std::vector<uint32_t> > getHVUnmappedMap() { return HVUnmapped_Map; }
   //Return the HVCrosstalking PSU channels as a map initialized to all channels (002/003) OFF (false):
-  std::map<std::string,std::vector<uint32_t> > getHVCrosstalkingMap() {return HVCrosstalking_Map;}
+  std::map<std::string, std::vector<uint32_t> > getHVCrosstalkingMap() { return HVCrosstalking_Map; }
   //PsuDetIdMap getHVUnmappedDetIdMap() {return HVUnmapped_Map}
   //Return the HVUnmapped PSUchannel to (HV status) map initialized to all OFF:
   //PsuDetIdMap getHVUnmappedChannelMap() {return HVUnmapped_ChanStatus}
   //PsuDetIdMap getHVCrosstalkingChannelMap() {return HVCrossTalking_ChanStatus}
   /** Return the PG PSU-DETID map as a vector. */
-  std::vector< std::pair<uint32_t, std::string> > getPsuDetIdMap() {return pgMap;}
+  std::vector<std::pair<uint32_t, std::string> > getPsuDetIdMap() { return pgMap; }
   /** Return the PG detector locations as a vector - one-to-one correspondance with the contents of the PSU-DetID map vector. */
-  std::vector<std::string> getDetectorLocations() {return detectorLocations;}
+  std::vector<std::string> getDetectorLocations() { return detectorLocations; }
   /** Return the DCU IDs associated to the PG map. */
-  std::vector<uint32_t> getDcuIds() {return dcuIds;}
+  std::vector<uint32_t> getDcuIds() { return dcuIds; }
   /** Return the CG PSU-DETID map as a vector. */
-  std::vector< std::pair<uint32_t, std::string> > getControlPsuDetIdMap() {return cgMap;}
+  std::vector<std::pair<uint32_t, std::string> > getControlPsuDetIdMap() { return cgMap; }
   /** Return the CG detector locations as a vector - one-to-one correspondance with the contents of the PSU-DetID map vector. */
-  std::vector<std::string> getControlDetectorLocations() {return controlLocations;}
+  std::vector<std::string> getControlDetectorLocations() { return controlLocations; }
   /** Return the module DCU IDs associated to the CG map. */
-  std::vector<uint32_t> getCgDcuIds() {return cgDcuIds;}
+  std::vector<uint32_t> getCgDcuIds() { return cgDcuIds; }
   /** Return the CCU DCU IDs associated to the CG map. */
-  std::vector<uint32_t> getCcuDcuIds() {return ccuDcuIds;}
-  
+  std::vector<uint32_t> getCcuDcuIds() { return ccuDcuIds; }
+
   /** Produces a formatted printout of the PSU-DETID map. */
   void printMap();
   /** Produces a formatted printout of the control PSU-DETID map. */
@@ -94,47 +100,53 @@ class SiStripPsuDetIdMap
    * Build the map from given file.
    * ATTENTION: this will only build the pgMap, not the cgMap.
    */
-  void BuildMap( const std::string & mapFile, const bool debug );
+  void BuildMap(const std::string &mapFile, const bool debug);
   //Old "rawmap" (vector of pairs) method to be used by excludeddetids:
-  void BuildMap( const std::string & mapFile, std::vector<std::pair<uint32_t,std::string> > & rawmap);
+  void BuildMap(const std::string &mapFile, std::vector<std::pair<uint32_t, std::string> > &rawmap);
   /// Overloaded method that does the buidling
-  void BuildMap( const std::string & mapFile, const bool debug, std::map<std::string,std::vector<uint32_t> > & LVmap, std::map<std::string,std::vector<uint32_t> > & HVmap, std::map<std::string,std::vector<uint32_t> > & HVUnmappedmap, std::map<std::string,std::vector<uint32_t> > & HVCrosstalkingmap);
+  void BuildMap(const std::string &mapFile,
+                const bool debug,
+                std::map<std::string, std::vector<uint32_t> > &LVmap,
+                std::map<std::string, std::vector<uint32_t> > &HVmap,
+                std::map<std::string, std::vector<uint32_t> > &HVUnmappedmap,
+                std::map<std::string, std::vector<uint32_t> > &HVCrosstalkingmap);
 
   //Service function to remove duplicated from vectors of detids:
-  void RemoveDuplicateDetIDs(std::vector<uint32_t> & detids);
+  void RemoveDuplicateDetIDs(std::vector<uint32_t> &detids);
 
   /** Returns the DCU-PSU map as a vector. */
-  std::vector< std::pair<uint32_t, std::string> > getDcuPsuMap();
+  std::vector<std::pair<uint32_t, std::string> > getDcuPsuMap();
   /** Returns 1 if the specified PSU channel is a HV channel, 0 if it is a LV channel.  -1 means error. */
   int IsHVChannel(std::string pvss);
-  
- private:
+
+private:
   // typedefs
-  typedef std::vector<TkDcuPsuMap *> DcuPsuVector ;
-  typedef std::map<std::string,std::vector<uint32_t> > PsuDetIdMap;
-  typedef edm::MapOfVectors<std::string,TkDcuPsuMap*> DcuPsus;
+  typedef std::vector<TkDcuPsuMap *> DcuPsuVector;
+  typedef std::map<std::string, std::vector<uint32_t> > PsuDetIdMap;
+  typedef edm::MapOfVectors<std::string, TkDcuPsuMap *> DcuPsus;
   typedef DcuPsus::range DcuPsusRange;
   /** Extracts the DCU-PSU map from the DB. */
   void getDcuPsuMap(DcuPsusRange &pRange, DcuPsusRange &cRange, std::string partition);
   /** Extracts the DCU device descriptions and stores them for further use. Only used for control groups. */
   //  std::vector< std::pair<uint32_t, SiStripConfigDb::DeviceAddress> >  retrieveDcuDeviceAddresses(std::string partition);
-  std::vector< std::pair< std::vector<uint16_t> , std::vector<uint32_t> > > retrieveDcuDeviceAddresses(std::string partition);
+  std::vector<std::pair<std::vector<uint16_t>, std::vector<uint32_t> > > retrieveDcuDeviceAddresses(
+      std::string partition);
   /** Searches the DCU device descriptions for the specified DCU ID. Needed for control groups. */
-  std::vector<uint32_t>  findDcuIdFromDeviceAddress(uint32_t dcuid_);
+  std::vector<uint32_t> findDcuIdFromDeviceAddress(uint32_t dcuid_);
   /** Utility to clone a DCU-PSU map. */
   void clone(DcuPsuVector &input, DcuPsuVector &output);
   /** Produces a detailed debug of the input values. */
   // for debugging
-  void checkMapInputValues(const SiStripConfigDb::DcuDetIdsV& dcuDetIds_, const DcuPsuVector& dcuPsus_);
-  
+  void checkMapInputValues(const SiStripConfigDb::DcuDetIdsV &dcuDetIds_, const DcuPsuVector &dcuPsus_);
+
   // member variables
   edm::Service<SiStripConfigDb> db_;
   PsuDetIdMap LVMap, HVMap, HVUnmapped_Map, HVCrosstalking_Map;
-  std::vector< std::pair<uint32_t, std::string> > pgMap, cgMap;
+  std::vector<std::pair<uint32_t, std::string> > pgMap, cgMap;
   std::vector<std::string> detectorLocations, controlLocations;
   std::vector<uint32_t> dcuIds, cgDcuIds, ccuDcuIds;
   DcuPsus DcuPsuMapPG_, DcuPsuMapCG_;
   //  std::vector< std::pair<uint32_t, SiStripConfigDb::DeviceAddress> > dcu_device_addr_vector;
-  std::vector< std::pair< std::vector<uint16_t> , std::vector<uint32_t> > > dcu_device_addr_vector;
+  std::vector<std::pair<std::vector<uint16_t>, std::vector<uint32_t> > > dcu_device_addr_vector;
 };
 #endif

--- a/CalibTracker/SiStripDCS/plugins/FilterTrackerOn.cc
+++ b/CalibTracker/SiStripDCS/plugins/FilterTrackerOn.cc
@@ -8,24 +8,19 @@
 #include <iostream>
 #include <algorithm>
 
-FilterTrackerOn::FilterTrackerOn(const edm::ParameterSet& iConfig) :
-  minModulesWithHVoff_(iConfig.getParameter<int>("MinModulesWithHVoff"))
-{
-}
+FilterTrackerOn::FilterTrackerOn(const edm::ParameterSet& iConfig)
+    : minModulesWithHVoff_(iConfig.getParameter<int>("MinModulesWithHVoff")) {}
 
-FilterTrackerOn::~FilterTrackerOn()
-{
-}
+FilterTrackerOn::~FilterTrackerOn() {}
 
-bool FilterTrackerOn::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+bool FilterTrackerOn::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   ESHandle<SiStripDetVOff> detVOff;
-  iSetup.get<SiStripDetVOffRcd>().get( detVOff );
+  iSetup.get<SiStripDetVOffRcd>().get(detVOff);
 
   // std::cout << "detVOff->getHVoffCounts() = " << detVOff->getHVoffCounts() << " < " << minModulesWithHVoff_;
-  if( detVOff->getHVoffCounts() > minModulesWithHVoff_ ) {
+  if (detVOff->getHVoffCounts() > minModulesWithHVoff_) {
     // std::cout << " skipping event" << std::endl;
     return false;
   }
@@ -34,11 +29,7 @@ bool FilterTrackerOn::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void FilterTrackerOn::beginJob()
-{
-}
+void FilterTrackerOn::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void FilterTrackerOn::endJob()
-{
-}
+void FilterTrackerOn::endJob() {}

--- a/CalibTracker/SiStripDCS/plugins/FilterTrackerOn.h
+++ b/CalibTracker/SiStripDCS/plugins/FilterTrackerOn.h
@@ -2,7 +2,7 @@
 //
 // Package:    CalibTracker/SiStripDCS/plugins
 // Class:      SyncDCSO2O
-// 
+//
 /**\class FilterTrackerOn FilterTrackerOn.cc
 
  Description: EDFilter returning true when the number of modules with HV on in the Tracker is
@@ -27,16 +27,15 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FilterTrackerOn : public edm::EDFilter
-{
- public:
+class FilterTrackerOn : public edm::EDFilter {
+public:
   explicit FilterTrackerOn(const edm::ParameterSet&);
   ~FilterTrackerOn() override;
 
- private:
-  void beginJob() override ;
+private:
+  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
+  void endJob() override;
 
   int minModulesWithHVoff_;
 };

--- a/CalibTracker/SiStripDCS/plugins/SealModules.cc
+++ b/CalibTracker/SiStripDCS/plugins/SealModules.cc
@@ -1,7 +1,6 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h"
 DEFINE_FWK_SERVICE(SiStripDetVOffBuilder);

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffHandler.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffHandler.cc
@@ -11,12 +11,11 @@
 
 #include "CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h"
 
-
 class SiStripDetVOffHandler : public edm::EDAnalyzer {
 public:
-  explicit SiStripDetVOffHandler(const edm::ParameterSet& iConfig );
+  explicit SiStripDetVOffHandler(const edm::ParameterSet& iConfig);
   ~SiStripDetVOffHandler() override;
-  void analyze( const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+  void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
   void endJob() override;
 
 private:
@@ -27,24 +26,24 @@ private:
 
   int maxTimeBeforeNewIOV_;
 
-  std::vector< std::pair<SiStripDetVOff*,cond::Time_t> > newPayloads;
+  std::vector<std::pair<SiStripDetVOff*, cond::Time_t> > newPayloads;
   edm::Service<SiStripDetVOffBuilder> modHVBuilder;
 };
 
-SiStripDetVOffHandler::SiStripDetVOffHandler(const edm::ParameterSet& iConfig):
-    m_connectionPool(),
-    m_condDb( iConfig.getParameter< std::string >("conditionDatabase") ),
-    m_localCondDbFile( iConfig.getParameter< std::string >("condDbFile") ),
-    m_targetTag( iConfig.getParameter< std::string >("targetTag") ),
-    maxTimeBeforeNewIOV_( iConfig.getUntrackedParameter< int >("maxTimeBeforeNewIOV", 24) ){
-  m_connectionPool.setParameters( iConfig.getParameter<edm::ParameterSet>("DBParameters")  );
+SiStripDetVOffHandler::SiStripDetVOffHandler(const edm::ParameterSet& iConfig)
+    : m_connectionPool(),
+      m_condDb(iConfig.getParameter<std::string>("conditionDatabase")),
+      m_localCondDbFile(iConfig.getParameter<std::string>("condDbFile")),
+      m_targetTag(iConfig.getParameter<std::string>("targetTag")),
+      maxTimeBeforeNewIOV_(iConfig.getUntrackedParameter<int>("maxTimeBeforeNewIOV", 24)) {
+  m_connectionPool.setParameters(iConfig.getParameter<edm::ParameterSet>("DBParameters"));
   m_connectionPool.configure();
   // get last IOV from local sqlite file if "conditionDatabase" is empty
-  if (m_condDb.empty()) m_condDb = m_localCondDbFile;
+  if (m_condDb.empty())
+    m_condDb = m_localCondDbFile;
 }
 
-SiStripDetVOffHandler::~SiStripDetVOffHandler() {
-}
+SiStripDetVOffHandler::~SiStripDetVOffHandler() {}
 
 void SiStripDetVOffHandler::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
   // get last payload from condDb
@@ -52,43 +51,45 @@ void SiStripDetVOffHandler::analyze(const edm::Event& evt, const edm::EventSetup
   std::shared_ptr<SiStripDetVOff> lastPayload;
 
   edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
-      << "Retrieve last IOV from " << m_condDb;
-  cond::persistency::Session condDbSession = m_connectionPool.createSession( m_condDb );
-  condDbSession.transaction().start( true );
-  if ( m_condDb.find("sqlite")==0 && (!condDbSession.existsDatabase()) ){
+                                        << "Retrieve last IOV from " << m_condDb;
+  cond::persistency::Session condDbSession = m_connectionPool.createSession(m_condDb);
+  condDbSession.transaction().start(true);
+  if (m_condDb.find("sqlite") == 0 && (!condDbSession.existsDatabase())) {
     // Source of last IOV is empty
-    edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
+    edm::LogInfo("SiStripDetVOffHandler")
+        << "[SiStripDetVOffHandler::" << __func__ << "] "
         << "No information can be retrieved from " << m_condDb << " because the file is empty.\n"
         << "Will assume all HV/LV's are off.";
-  }else{
-    cond::persistency::IOVProxy iovProxy = condDbSession.readIov( m_targetTag );
+  } else {
+    cond::persistency::IOVProxy iovProxy = condDbSession.readIov(m_targetTag);
     cond::Hash lastPayloadHash = iovProxy.getLast().payloadId;
-    if ( !lastPayloadHash.empty() ) {
-      lastPayload = condDbSession.fetchPayload<SiStripDetVOff>( lastPayloadHash );
-      lastIov = iovProxy.getLast().since; // move to LastValidatedTime?
+    if (!lastPayloadHash.empty()) {
+      lastPayload = condDbSession.fetchPayload<SiStripDetVOff>(lastPayloadHash);
+      lastIov = iovProxy.getLast().since;  // move to LastValidatedTime?
     }
     edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
-        << " ... last IOV: " << lastIov << " , " << "last Payload: " << lastPayloadHash;
+                                          << " ... last IOV: " << lastIov << " , "
+                                          << "last Payload: " << lastPayloadHash;
   }
   condDbSession.transaction().commit();
 
   // build the object!
   newPayloads.clear();
-  modHVBuilder->setLastSiStripDetVOff( lastPayload.get(), lastIov );
+  modHVBuilder->setLastSiStripDetVOff(lastPayload.get(), lastIov);
   modHVBuilder->BuildDetVOffObj();
   newPayloads = modHVBuilder->getModulesVOff();
   edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
-      << "Finished building " << newPayloads.size() << " new payloads.";
+                                        << "Finished building " << newPayloads.size() << " new payloads.";
 
   // write the payloads to sqlite file
   edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
-      << "Write new payloads to sqlite file " << m_localCondDbFile;
-  cond::persistency::Session localFileSession = m_connectionPool.createSession( m_localCondDbFile, true );
-  localFileSession.transaction().start( false );
-  if ( lastPayload && newPayloads.size() == 1 && *newPayloads[0].first == *lastPayload ){
+                                        << "Write new payloads to sqlite file " << m_localCondDbFile;
+  cond::persistency::Session localFileSession = m_connectionPool.createSession(m_localCondDbFile, true);
+  localFileSession.transaction().start(false);
+  if (lastPayload && newPayloads.size() == 1 && *newPayloads[0].first == *lastPayload) {
     // if no HV/LV transition was found in this period
     edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
-        << "No HV/LV transition was found from PVSS query.";
+                                          << "No HV/LV transition was found from PVSS query.";
     bool forceNewIOV = true;
     if (maxTimeBeforeNewIOV_ < 0)
       forceNewIOV = false;
@@ -96,40 +97,41 @@ void SiStripDetVOffHandler::analyze(const edm::Event& evt, const edm::EventSetup
       auto deltaT = cond::time::to_boost(newPayloads[0].second) - cond::time::to_boost(lastIov);
       forceNewIOV = deltaT > boost::posix_time::hours(maxTimeBeforeNewIOV_);
     }
-    if ( !forceNewIOV ){
+    if (!forceNewIOV) {
       newPayloads.erase(newPayloads.begin());
       edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
-          << " ... No payload transfered.";
-    }else {
-      edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
-          << " ... The last IOV is too old. Will start a new IOV from " << newPayloads[0].second
-          << "(" << boost::posix_time::to_simple_string(cond::time::to_boost(newPayloads[0].second)) << ") with the same payload.";
+                                            << " ... No payload transfered.";
+    } else {
+      edm::LogInfo("SiStripDetVOffHandler")
+          << "[SiStripDetVOffHandler::" << __func__ << "] "
+          << " ... The last IOV is too old. Will start a new IOV from " << newPayloads[0].second << "("
+          << boost::posix_time::to_simple_string(cond::time::to_boost(newPayloads[0].second))
+          << ") with the same payload.";
     }
   }
 
   cond::persistency::IOVEditor iovEditor;
-  if (localFileSession.existsDatabase() && localFileSession.existsIov(m_targetTag)){
-    edm::LogWarning("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
+  if (localFileSession.existsDatabase() && localFileSession.existsIov(m_targetTag)) {
+    edm::LogWarning("SiStripDetVOffHandler")
+        << "[SiStripDetVOffHandler::" << __func__ << "] "
         << "IOV of tag " << m_targetTag << " already exists in sqlite file " << m_localCondDbFile;
     iovEditor = localFileSession.editIov(m_targetTag);
-  }else {
-    iovEditor = localFileSession.createIov<SiStripDetVOff>( m_targetTag, cond::timestamp );
-    iovEditor.setDescription( "New IOV" );
+  } else {
+    iovEditor = localFileSession.createIov<SiStripDetVOff>(m_targetTag, cond::timestamp);
+    iovEditor.setDescription("New IOV");
   }
-  for (const auto &payload : newPayloads){
-    cond::Hash thePayloadHash = localFileSession.storePayload<SiStripDetVOff>( *payload.first );
-    iovEditor.insert( payload.second, thePayloadHash );
+  for (const auto& payload : newPayloads) {
+    cond::Hash thePayloadHash = localFileSession.storePayload<SiStripDetVOff>(*payload.first);
+    iovEditor.insert(payload.second, thePayloadHash);
   }
   iovEditor.flush();
   localFileSession.transaction().commit();
 
-  edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] "
-      << newPayloads.size() << " payloads written to sqlite file.";
-
+  edm::LogInfo("SiStripDetVOffHandler") << "[SiStripDetVOffHandler::" << __func__ << "] " << newPayloads.size()
+                                        << " payloads written to sqlite file.";
 }
 
-void SiStripDetVOffHandler::endJob() {
-}
+void SiStripDetVOffHandler::endJob() {}
 
 // -------------------------------------------------------
 typedef SiStripDetVOffHandler SiStripO2ODetVOff;

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffPrinter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffPrinter.cc
@@ -24,18 +24,15 @@
 #include <TGraph.h>
 #include <TH1.h>
 
-
 class SiStripDetVOffPrinter : public edm::one::EDAnalyzer<> {
 public:
-
-  explicit SiStripDetVOffPrinter(const edm::ParameterSet& iConfig );
+  explicit SiStripDetVOffPrinter(const edm::ParameterSet& iConfig);
   ~SiStripDetVOffPrinter() override;
-  void analyze( const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+  void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
   void endJob() override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-
   cond::persistency::ConnectionPool m_connectionPool;
   std::string m_condDb;
   std::string m_tagName;
@@ -48,74 +45,72 @@ private:
   edm::Service<SiStripDetInfoFileReader> detidReader;
 
   //          IOV                 DETIDs
-  std::map<cond::Time_t, std::set< uint32_t > > iovMap_HVOff;
-  std::map<cond::Time_t, std::set< uint32_t > > iovMap_LVOff;
+  std::map<cond::Time_t, std::set<uint32_t> > iovMap_HVOff;
+  std::map<cond::Time_t, std::set<uint32_t> > iovMap_LVOff;
   //          DETIDs              IOV
-  std::map<uint32_t, std::vector< cond::Time_t > > detidMap;
+  std::map<uint32_t, std::vector<cond::Time_t> > detidMap;
 };
 
-SiStripDetVOffPrinter::SiStripDetVOffPrinter(const edm::ParameterSet& iConfig):
-  m_connectionPool(),
-  m_condDb( iConfig.getParameter< std::string >("conditionDatabase") ),
-  m_tagName( iConfig.getParameter< std::string >("tagName") ),
-  m_startTime( iConfig.getParameter< std::string >("startTime") ),
-  m_endTime( iConfig.getParameter< std::string >("endTime") ),
-  m_output( iConfig.getParameter< std::string >("output") )
-{
-  m_connectionPool.setParameters( iConfig.getParameter<edm::ParameterSet>("DBParameters")  );
+SiStripDetVOffPrinter::SiStripDetVOffPrinter(const edm::ParameterSet& iConfig)
+    : m_connectionPool(),
+      m_condDb(iConfig.getParameter<std::string>("conditionDatabase")),
+      m_tagName(iConfig.getParameter<std::string>("tagName")),
+      m_startTime(iConfig.getParameter<std::string>("startTime")),
+      m_endTime(iConfig.getParameter<std::string>("endTime")),
+      m_output(iConfig.getParameter<std::string>("output")) {
+  m_connectionPool.setParameters(iConfig.getParameter<edm::ParameterSet>("DBParameters"));
   m_connectionPool.configure();
 }
 
-SiStripDetVOffPrinter::~SiStripDetVOffPrinter() {
-}
+SiStripDetVOffPrinter::~SiStripDetVOffPrinter() {}
 
 void SiStripDetVOffPrinter::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
-  
   // get total number of modules
   //auto num_modules = detidReader->getAllDetIds().size();
 
   // use start and end time from config file
   boost::posix_time::ptime p_start, p_end;
   p_start = boost::posix_time::time_from_string(m_startTime);
-  p_end   = boost::posix_time::time_from_string(m_endTime);
+  p_end = boost::posix_time::time_from_string(m_endTime);
   cond::Time_t startIov = cond::time::from_boost(p_start);
-  cond::Time_t endIov   = cond::time::from_boost(p_end);
+  cond::Time_t endIov = cond::time::from_boost(p_end);
   if (startIov > endIov)
     throw cms::Exception("endTime must be greater than startTime!");
   edm::LogInfo("SiStripDetVOffPrinter") << "[SiStripDetVOffPrinter::" << __func__ << "] "
-					<< "Set start time " << startIov << " (" << boost::posix_time::to_simple_string(p_start) << ")"
-					<< "\n ... Set end time " << endIov << " (" << boost::posix_time::to_simple_string(p_end) << ")" ;
+                                        << "Set start time " << startIov << " ("
+                                        << boost::posix_time::to_simple_string(p_start) << ")"
+                                        << "\n ... Set end time " << endIov << " ("
+                                        << boost::posix_time::to_simple_string(p_end) << ")";
 
   // open db session
   edm::LogInfo("SiStripDetVOffPrinter") << "[SiStripDetVOffPrinter::" << __func__ << "] "
-					<< "Query the condition database " << m_condDb;
-  cond::persistency::Session condDbSession = m_connectionPool.createSession( m_condDb );
-  condDbSession.transaction().start( true );
+                                        << "Query the condition database " << m_condDb;
+  cond::persistency::Session condDbSession = m_connectionPool.createSession(m_condDb);
+  condDbSession.transaction().start(true);
 
   std::stringstream ss;
   // list of times with new IOVs within the time range
-  std::vector< cond::Time_t > vTime;
-  
+  std::vector<cond::Time_t> vTime;
+
   // query the database
   edm::LogInfo("SiStripDetVOffPrinter") << "[SiStripDetVOffPrinter::" << __func__ << "] "
-					<< "Reading IOVs from tag " << m_tagName;
-  cond::persistency::IOVProxy iovProxy = condDbSession.readIov(m_tagName, true); // load all?
+                                        << "Reading IOVs from tag " << m_tagName;
+  cond::persistency::IOVProxy iovProxy = condDbSession.readIov(m_tagName, true);  // load all?
   auto iiov = iovProxy.find(startIov);
   auto eiov = iovProxy.find(endIov);
   int niov = 0;
-  while (iiov != iovProxy.end() && (*iiov).since <= (*eiov).since){
+  while (iiov != iovProxy.end() && (*iiov).since <= (*eiov).since) {
     // convert cond::Time_t to seconds since epoch
-    if ((*iiov).since<startIov){
+    if ((*iiov).since < startIov) {
       vTime.push_back(startIov);
     } else {
       vTime.push_back((*iiov).since);
     }
-    auto payload = condDbSession.fetchPayload<SiStripDetVOff>( (*iiov).payloadId );
+    auto payload = condDbSession.fetchPayload<SiStripDetVOff>((*iiov).payloadId);
     // print IOVs summary
-    ss  << boost::posix_time::to_simple_string(cond::time::to_boost((*iiov).since))
-	<< " (" << (*iiov).since <<  ")"
-	<< ", # HV Off=" << std::setw(6) << payload->getHVoffCounts()
-	<< ", # LV Off=" << std::setw(6) << payload->getLVoffCounts() << std::endl;
+    ss << boost::posix_time::to_simple_string(cond::time::to_boost((*iiov).since)) << " (" << (*iiov).since << ")"
+       << ", # HV Off=" << std::setw(6) << payload->getHVoffCounts() << ", # LV Off=" << std::setw(6)
+       << payload->getLVoffCounts() << std::endl;
 
     // list of detids with HV/LV Off
     std::vector<uint32_t> detIds;
@@ -123,111 +118,112 @@ void SiStripDetVOffPrinter::analyze(const edm::Event& evt, const edm::EventSetup
     std::set<uint32_t> detIds_HVOff;
     std::set<uint32_t> detIds_LVOff;
     std::vector<uint32_t>::const_iterator it = detIds.begin();
-    for( ; it!=detIds.end(); ++it ) {
-      if(payload->IsModuleHVOff(*it) ) detIds_HVOff.insert(*it);
-      if(payload->IsModuleLVOff(*it) ) detIds_LVOff.insert(*it);
-      
-      if(detidMap.find(*it)==detidMap.end()) {
-	std::vector< cond::Time_t > vec;
-	detidMap[*it] = vec;		  
+    for (; it != detIds.end(); ++it) {
+      if (payload->IsModuleHVOff(*it))
+        detIds_HVOff.insert(*it);
+      if (payload->IsModuleLVOff(*it))
+        detIds_LVOff.insert(*it);
+
+      if (detidMap.find(*it) == detidMap.end()) {
+        std::vector<cond::Time_t> vec;
+        detidMap[*it] = vec;
       }
-      
+
       // for each module concerned by the IOV, add the time in an history vector
       detidMap[*it].push_back(vTime.back());
     }
-    
+
     // fill list of channels Off at a given time
     iovMap_HVOff[vTime.back()] = detIds_HVOff;
     iovMap_LVOff[vTime.back()] = detIds_LVOff;
-    
+
     /*std::vector<uint32_t>::const_iterator it = detIds.begin();
       for( ; it!=detIds.end(); ++it ) {
       std::cout << *it << std::endl;
       }*/
-    
+
     ++iiov;
     ++niov;
   }
-  vTime.push_back(endIov); // used to compute last IOV duration
+  vTime.push_back(endIov);  // used to compute last IOV duration
 
   edm::LogInfo("SiStripDetVOffPrinter") << "[SiStripDetVOffPrinter::" << __func__ << "] "
-					<< "Read " << niov << " IOVs from tag " << m_tagName << " corresponding to the specified time interval.\n" << ss.str();
-
+                                        << "Read " << niov << " IOVs from tag " << m_tagName
+                                        << " corresponding to the specified time interval.\n"
+                                        << ss.str();
 
   // Create a map of IOVs time_duration
-  std::map< cond::Time_t, boost::posix_time::time_duration > mIOVsDuration;
-  std::vector< cond::Time_t >::const_iterator itTime = ++vTime.begin();
-  std::vector< cond::Time_t >::const_iterator itPreviousTime = vTime.begin();
+  std::map<cond::Time_t, boost::posix_time::time_duration> mIOVsDuration;
+  std::vector<cond::Time_t>::const_iterator itTime = ++vTime.begin();
+  std::vector<cond::Time_t>::const_iterator itPreviousTime = vTime.begin();
   //std::vector< cond::Time_t >::const_iterator itLastTime = --vTime.end();
-  for( ; itTime!=vTime.end(); ++itTime ) {
-    mIOVsDuration[ *itPreviousTime ] = cond::time::to_boost(*itTime) - cond::time::to_boost(*itPreviousTime);
+  for (; itTime != vTime.end(); ++itTime) {
+    mIOVsDuration[*itPreviousTime] = cond::time::to_boost(*itTime) - cond::time::to_boost(*itPreviousTime);
     itPreviousTime = itTime;
   }
-  boost::posix_time::time_duration time_period = cond::time::to_boost(*(--vTime.end())) - cond::time::to_boost(*(vTime.begin()));
-  
+  boost::posix_time::time_duration time_period =
+      cond::time::to_boost(*(--vTime.end())) - cond::time::to_boost(*(vTime.begin()));
+
   // debug
   /*for( itTime=vTime.begin(); itTime!=itLastTime; ++itTime ) {
 	std::cout<<boost::posix_time::to_simple_string( cond::time::to_boost(*itTime) ) << "    " <<boost::posix_time::to_simple_string(mIOVsDuration[ *itTime ])<<std::endl;
   }*/
 
-  // Print summary per module	
-  edm::LogInfo("SiStripDetVOffPrinter") << "[SiStripDetVOffPrinter::" << __func__ << "] "
-					<< detidMap.size() << " modules were Off at some point during the time interval";
+  // Print summary per module
+  edm::LogInfo("SiStripDetVOffPrinter") << "[SiStripDetVOffPrinter::" << __func__ << "] " << detidMap.size()
+                                        << " modules were Off at some point during the time interval";
   ss.str("");
-  
+
   // Loop over detIds
-  std::map<uint32_t, std::vector< cond::Time_t > >::const_iterator itMap = detidMap.begin();
-  for( ; itMap!=detidMap.end(); ++itMap ) {
-    std::vector< cond::Time_t > vecTime = itMap->second;
-    
-    boost::posix_time::time_duration cumul_time_HVOff(0,0,0,0);
-    boost::posix_time::time_duration cumul_time_LVOff(0,0,0,0);
+  std::map<uint32_t, std::vector<cond::Time_t> >::const_iterator itMap = detidMap.begin();
+  for (; itMap != detidMap.end(); ++itMap) {
+    std::vector<cond::Time_t> vecTime = itMap->second;
+
+    boost::posix_time::time_duration cumul_time_HVOff(0, 0, 0, 0);
+    boost::posix_time::time_duration cumul_time_LVOff(0, 0, 0, 0);
     // Loop over IOVs
-    std::vector< cond::Time_t >::const_iterator itTime = vecTime.begin();
-    for( ; itTime!=vecTime.end(); ++itTime ) {
-      if(iovMap_HVOff[*itTime].find(itMap->first) != iovMap_HVOff[*itTime].end()) cumul_time_HVOff+=mIOVsDuration[*itTime];
-      if(iovMap_LVOff[*itTime].find(itMap->first) != iovMap_LVOff[*itTime].end()) cumul_time_LVOff+=mIOVsDuration[*itTime];
+    std::vector<cond::Time_t>::const_iterator itTime = vecTime.begin();
+    for (; itTime != vecTime.end(); ++itTime) {
+      if (iovMap_HVOff[*itTime].find(itMap->first) != iovMap_HVOff[*itTime].end())
+        cumul_time_HVOff += mIOVsDuration[*itTime];
+      if (iovMap_LVOff[*itTime].find(itMap->first) != iovMap_LVOff[*itTime].end())
+        cumul_time_LVOff += mIOVsDuration[*itTime];
     }
-    ss<<"detId "<< itMap->first <<" #IOVs: "<<vecTime.size()
-      <<"  HVOff: "<<cumul_time_HVOff<<" "<<cumul_time_HVOff.total_milliseconds()*100.0/time_period.total_milliseconds()<<"% "
-      <<"  LVOff: "<<cumul_time_LVOff<<" "<<cumul_time_LVOff.total_milliseconds()*100.0/time_period.total_milliseconds()<<"%"<<std::endl;
-    
+    ss << "detId " << itMap->first << " #IOVs: " << vecTime.size() << "  HVOff: " << cumul_time_HVOff << " "
+       << cumul_time_HVOff.total_milliseconds() * 100.0 / time_period.total_milliseconds() << "% "
+       << "  LVOff: " << cumul_time_LVOff << " "
+       << cumul_time_LVOff.total_milliseconds() * 100.0 / time_period.total_milliseconds() << "%" << std::endl;
   }
 
   condDbSession.transaction().commit();
- 
+
   if (!m_output.empty()) {
     std::ofstream fout;
     fout.open(m_output);
     fout << ss.str();
     fout.close();
-  }  
+  }
 }
 
-void
-SiStripDetVOffPrinter::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-
+void SiStripDetVOffPrinter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("conditionDatabase","frontier://FrontierProd/CMS_CONDITIONS");
-  desc.add<std::string>("tagName","SiStripDetVOff_1hourDelay_v1_Validation");
-  desc.add<std::string>("startTime","2002-01-20 23:59:59.000");
-  desc.add<std::string>("endTime","2002-01-20 23:59:59.000");
-  desc.add<std::string>("output","PerModuleSummary.txt");
-  desc.add<std::string>("connect","");
+  desc.add<std::string>("conditionDatabase", "frontier://FrontierProd/CMS_CONDITIONS");
+  desc.add<std::string>("tagName", "SiStripDetVOff_1hourDelay_v1_Validation");
+  desc.add<std::string>("startTime", "2002-01-20 23:59:59.000");
+  desc.add<std::string>("endTime", "2002-01-20 23:59:59.000");
+  desc.add<std::string>("output", "PerModuleSummary.txt");
+  desc.add<std::string>("connect", "");
 
   edm::ParameterSetDescription descDBParameters;
-  descDBParameters.addUntracked<std::string>("authenticationPath","");  
-  descDBParameters.addUntracked<int>("authenticationSystem",0);  
-  descDBParameters.addUntracked<std::string>("security","");  
-  descDBParameters.addUntracked<int>("messageLevel",0);  
+  descDBParameters.addUntracked<std::string>("authenticationPath", "");
+  descDBParameters.addUntracked<int>("authenticationSystem", 0);
+  descDBParameters.addUntracked<std::string>("security", "");
+  descDBParameters.addUntracked<int>("messageLevel", 0);
 
-  desc.add<edm::ParameterSetDescription>("DBParameters",descDBParameters);
+  desc.add<edm::ParameterSetDescription>("DBParameters", descDBParameters);
   descriptions.add("siStripDetVOffPrinter", desc);
 }
 
-
-void SiStripDetVOffPrinter::endJob() {
-}
+void SiStripDetVOffPrinter::endJob() {}
 
 DEFINE_FWK_MODULE(SiStripDetVOffPrinter);
-

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTkMapPlotter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTkMapPlotter.cc
@@ -19,16 +19,15 @@
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 
-
 class SiStripDetVOffTkMapPlotter : public edm::EDAnalyzer {
 public:
-  explicit SiStripDetVOffTkMapPlotter(const edm::ParameterSet& iConfig );
+  explicit SiStripDetVOffTkMapPlotter(const edm::ParameterSet& iConfig);
   ~SiStripDetVOffTkMapPlotter() override;
-  void analyze( const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+  void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
   void endJob() override;
 
 private:
-  std::string formatIOV(cond::Time_t iov, std::string format="%Y-%m-%d__%H_%M_%S");
+  std::string formatIOV(cond::Time_t iov, std::string format = "%Y-%m-%d__%H_%M_%S");
 
   cond::persistency::ConnectionPool m_connectionPool;
   std::string m_condDb;
@@ -46,64 +45,63 @@ private:
   edm::Service<SiStripDetInfoFileReader> detidReader;
 };
 
-SiStripDetVOffTkMapPlotter::SiStripDetVOffTkMapPlotter(const edm::ParameterSet& iConfig):
-    m_connectionPool(),
-    m_condDb( iConfig.getParameter< std::string >("conditionDatabase") ),
-    m_plotTag( iConfig.getParameter< std::string >("Tag") ),
-    m_IOV( iConfig.getUntrackedParameter< cond::Time_t >("IOV", 0) ),
-    m_Time( iConfig.getUntrackedParameter< std::string >("Time", "") ),
-    m_plotFormat( iConfig.getUntrackedParameter< std::string >("plotFormat", "png") ),
-    m_outputFile( iConfig.getUntrackedParameter< std::string >("outputFile", "") ){
-  m_connectionPool.setParameters( iConfig.getParameter<edm::ParameterSet>("DBParameters")  );
+SiStripDetVOffTkMapPlotter::SiStripDetVOffTkMapPlotter(const edm::ParameterSet& iConfig)
+    : m_connectionPool(),
+      m_condDb(iConfig.getParameter<std::string>("conditionDatabase")),
+      m_plotTag(iConfig.getParameter<std::string>("Tag")),
+      m_IOV(iConfig.getUntrackedParameter<cond::Time_t>("IOV", 0)),
+      m_Time(iConfig.getUntrackedParameter<std::string>("Time", "")),
+      m_plotFormat(iConfig.getUntrackedParameter<std::string>("plotFormat", "png")),
+      m_outputFile(iConfig.getUntrackedParameter<std::string>("outputFile", "")) {
+  m_connectionPool.setParameters(iConfig.getParameter<edm::ParameterSet>("DBParameters"));
   m_connectionPool.configure();
 }
 
-SiStripDetVOffTkMapPlotter::~SiStripDetVOffTkMapPlotter() {
-}
+SiStripDetVOffTkMapPlotter::~SiStripDetVOffTkMapPlotter() {}
 
 void SiStripDetVOffTkMapPlotter::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
-
   cond::Time_t theIov = 0;
-  if (m_IOV != 0){
+  if (m_IOV != 0) {
     theIov = m_IOV;
-  }else if (!m_Time.empty()){
-    theIov = cond::time::from_boost( boost::posix_time::time_from_string(m_Time) );
-  }else{
+  } else if (!m_Time.empty()) {
+    theIov = cond::time::from_boost(boost::posix_time::time_from_string(m_Time));
+  } else {
     // Use the current time if no input. Will get the last IOV.
-    theIov = cond::time::from_boost( boost::posix_time::second_clock::universal_time() );
+    theIov = cond::time::from_boost(boost::posix_time::second_clock::universal_time());
   }
 
   // open db session
   edm::LogInfo("SiStripDetVOffMapPlotter") << "[SiStripDetVOffMapPlotter::" << __func__ << "] "
-      << "Query the condition database " << m_condDb << " for tag " << m_plotTag;
-  cond::persistency::Session condDbSession = m_connectionPool.createSession( m_condDb );
-  condDbSession.transaction().start( true );
+                                           << "Query the condition database " << m_condDb << " for tag " << m_plotTag;
+  cond::persistency::Session condDbSession = m_connectionPool.createSession(m_condDb);
+  condDbSession.transaction().start(true);
   cond::persistency::IOVProxy iovProxy = condDbSession.readIov(m_plotTag, true);
   auto iiov = iovProxy.find(theIov);
-  if (iiov==iovProxy.end())
-    throw cms::Exception("Input IOV "+std::to_string(m_IOV)+"/"+m_Time+" is invalid!");
+  if (iiov == iovProxy.end())
+    throw cms::Exception("Input IOV " + std::to_string(m_IOV) + "/" + m_Time + " is invalid!");
 
   theIov = (*iiov).since;
   edm::LogInfo("SiStripDetVOffMapPlotter") << "[SiStripDetVOffMapPlotter::" << __func__ << "] "
-      << "Make tkMap for IOV " << theIov << " (" << boost::posix_time::to_simple_string(cond::time::to_boost(theIov)) << ")";
-  auto payload = condDbSession.fetchPayload<SiStripDetVOff>( (*iiov).payloadId );
+                                           << "Make tkMap for IOV " << theIov << " ("
+                                           << boost::posix_time::to_simple_string(cond::time::to_boost(theIov)) << ")";
+  auto payload = condDbSession.fetchPayload<SiStripDetVOff>((*iiov).payloadId);
 
   edm::ESHandle<TkDetMap> tkDetMapHandle;
   evtSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
   const TkDetMap* tkDetMap = tkDetMapHandle.product();
-  TrackerMap lvmap,hvmap;
-  TkHistoMap lvhisto(tkDetMap, "LV_Status","LV_Status",-1);
-  TkHistoMap hvhisto(tkDetMap, "HV_Status","HV_Status",-1);
+  TrackerMap lvmap, hvmap;
+  TkHistoMap lvhisto(tkDetMap, "LV_Status", "LV_Status", -1);
+  TkHistoMap hvhisto(tkDetMap, "HV_Status", "HV_Status", -1);
 
   auto detids = detidReader->getAllDetIds();
-  for (auto id : detids){
+  for (auto id : detids) {
     if (payload->IsModuleLVOff(id))
-      lvhisto.fill(id, 1); // RED
+      lvhisto.fill(id, 1);  // RED
     else
       lvhisto.fill(id, 0.5);
 
     if (payload->IsModuleHVOff(id))
-      hvhisto.fill(id, 1); // RED
+      hvhisto.fill(id, 1);  // RED
     else
       hvhisto.fill(id, 0.5);
   }
@@ -112,26 +110,23 @@ void SiStripDetVOffTkMapPlotter::analyze(const edm::Event& evt, const edm::Event
   hvhisto.dumpInTkMap(&hvmap);
   lvmap.setPalette(1);
   hvmap.setPalette(1);
-  lvmap.save(true,0,0,"LV_tkMap_"+formatIOV(theIov)+"."+m_plotFormat);
-  hvmap.save(true,0,0,"HV_tkMap_"+formatIOV(theIov)+"."+m_plotFormat);
+  lvmap.save(true, 0, 0, "LV_tkMap_" + formatIOV(theIov) + "." + m_plotFormat);
+  hvmap.save(true, 0, 0, "HV_tkMap_" + formatIOV(theIov) + "." + m_plotFormat);
 
-  if (!m_outputFile.empty()){
+  if (!m_outputFile.empty()) {
     lvhisto.save(m_outputFile);
     hvhisto.save(m_outputFile);
   }
-
 }
 
-void SiStripDetVOffTkMapPlotter::endJob() {
-}
+void SiStripDetVOffTkMapPlotter::endJob() {}
 
 std::string SiStripDetVOffTkMapPlotter::formatIOV(cond::Time_t iov, std::string format) {
   auto facet = new boost::posix_time::time_facet(format.c_str());
-   std::ostringstream stream;
-   stream.imbue(std::locale(stream.getloc(), facet));
-   stream << cond::time::to_boost(iov);
-   return stream.str();
+  std::ostringstream stream;
+  stream.imbue(std::locale(stream.getloc(), facet));
+  stream << cond::time::to_boost(iov);
+  return stream.str();
 }
 
 DEFINE_FWK_MODULE(SiStripDetVOffTkMapPlotter);
-

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTrendPlotter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTrendPlotter.cc
@@ -23,18 +23,17 @@
 #include <TGraph.h>
 #include <TH1.h>
 
-
 class SiStripDetVOffTrendPlotter : public edm::EDAnalyzer {
 public:
-  const std::vector<Color_t> PLOT_COLORS {kRed, kBlue, kBlack, kOrange, kMagenta};
+  const std::vector<Color_t> PLOT_COLORS{kRed, kBlue, kBlack, kOrange, kMagenta};
 
-  explicit SiStripDetVOffTrendPlotter(const edm::ParameterSet& iConfig );
+  explicit SiStripDetVOffTrendPlotter(const edm::ParameterSet &iConfig);
   ~SiStripDetVOffTrendPlotter() override;
-  void analyze( const edm::Event& evt, const edm::EventSetup& evtSetup) override;
+  void analyze(const edm::Event &evt, const edm::EventSetup &evtSetup) override;
   void endJob() override;
 
 private:
-  std::string formatIOV(cond::Time_t iov, std::string format="%Y-%m-%d__%H_%M_%S");
+  std::string formatIOV(cond::Time_t iov, std::string format = "%Y-%m-%d__%H_%M_%S");
   void prepGraph(TGraph *gr, TString name, TString title, Color_t color);
   void dumpCSV(bool isHV);
 
@@ -60,101 +59,104 @@ private:
   std::map<cond::Time_t, std::map<std::string, std::pair<int, int>>> iovMap;
 };
 
-SiStripDetVOffTrendPlotter::SiStripDetVOffTrendPlotter(const edm::ParameterSet& iConfig):
-    m_connectionPool(),
-    m_condDb( iConfig.getParameter< std::string >("conditionDatabase") ),
-    m_plotTags( iConfig.getParameter< std::vector<std::string> >("plotTags") ),
-    m_interval( iConfig.getParameter< int >("timeInterval") ),
-    m_startTime( iConfig.getUntrackedParameter< std::string >("startTime", "") ),
-    m_endTime( iConfig.getUntrackedParameter< std::string >("endTime", "") ),
-    m_outputPlot( iConfig.getUntrackedParameter< std::string >("outputPlot", "") ),
-    m_outputRootFile( iConfig.getUntrackedParameter< std::string >("outputRootFile", "") ),
-    m_outputCSV( iConfig.getUntrackedParameter< std::string >("outputCSV", "") ),
-    fout(nullptr){
-  m_connectionPool.setParameters( iConfig.getParameter<edm::ParameterSet>("DBParameters")  );
+SiStripDetVOffTrendPlotter::SiStripDetVOffTrendPlotter(const edm::ParameterSet &iConfig)
+    : m_connectionPool(),
+      m_condDb(iConfig.getParameter<std::string>("conditionDatabase")),
+      m_plotTags(iConfig.getParameter<std::vector<std::string>>("plotTags")),
+      m_interval(iConfig.getParameter<int>("timeInterval")),
+      m_startTime(iConfig.getUntrackedParameter<std::string>("startTime", "")),
+      m_endTime(iConfig.getUntrackedParameter<std::string>("endTime", "")),
+      m_outputPlot(iConfig.getUntrackedParameter<std::string>("outputPlot", "")),
+      m_outputRootFile(iConfig.getUntrackedParameter<std::string>("outputRootFile", "")),
+      m_outputCSV(iConfig.getUntrackedParameter<std::string>("outputCSV", "")),
+      fout(nullptr) {
+  m_connectionPool.setParameters(iConfig.getParameter<edm::ParameterSet>("DBParameters"));
   m_connectionPool.configure();
-  if (!m_outputRootFile.empty()) fout = new TFile(m_outputRootFile.data(), "RECREATE");
+  if (!m_outputRootFile.empty())
+    fout = new TFile(m_outputRootFile.data(), "RECREATE");
 }
 
 SiStripDetVOffTrendPlotter::~SiStripDetVOffTrendPlotter() {
-  if (fout) fout->Close();
+  if (fout)
+    fout->Close();
 }
 
-void SiStripDetVOffTrendPlotter::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
-
+void SiStripDetVOffTrendPlotter::analyze(const edm::Event &evt, const edm::EventSetup &evtSetup) {
   // get total number of modules
   auto num_modules = detidReader->getAllDetIds().size();
 
   // get start and end time for DB query
   boost::posix_time::ptime p_start, p_end;
-  if (m_interval > 0){
+  if (m_interval > 0) {
     // from m_interval hours ago to now
     p_end = boost::posix_time::second_clock::universal_time();
     p_start = p_end - boost::posix_time::hours(m_interval);
-  }else {
+  } else {
     // use start and end time from config file
     p_start = boost::posix_time::time_from_string(m_startTime);
-    p_end   = boost::posix_time::time_from_string(m_endTime);
+    p_end = boost::posix_time::time_from_string(m_endTime);
   }
   cond::Time_t startIov = cond::time::from_boost(p_start);
-  cond::Time_t endIov   = cond::time::from_boost(p_end);
+  cond::Time_t endIov = cond::time::from_boost(p_end);
   if (startIov > endIov)
     throw cms::Exception("endTime must be greater than startTime!");
-  edm::LogInfo("SiStripDetVOffTrendPlotter") << "[SiStripDetVOffTrendPlotter::" << __func__ << "] "
+  edm::LogInfo("SiStripDetVOffTrendPlotter")
+      << "[SiStripDetVOffTrendPlotter::" << __func__ << "] "
       << "Set start IOV " << startIov << " (" << boost::posix_time::to_simple_string(p_start) << ")"
-      << "\n ... Set end IOV " << endIov << " (" << boost::posix_time::to_simple_string(p_end) << ")" ;
+      << "\n ... Set end IOV " << endIov << " (" << boost::posix_time::to_simple_string(p_end) << ")";
 
   // open db session
   edm::LogInfo("SiStripDetVOffTrendPlotter") << "[SiStripDetVOffTrendPlotter::" << __func__ << "] "
-      << "Query the condition database " << m_condDb;
-  cond::persistency::Session condDbSession = m_connectionPool.createSession( m_condDb );
-  condDbSession.transaction().start( true );
+                                             << "Query the condition database " << m_condDb;
+  cond::persistency::Session condDbSession = m_connectionPool.createSession(m_condDb);
+  condDbSession.transaction().start(true);
 
   // loop over all tags to plot
-  std::vector<TGraph*> hvgraphs, lvgraphs;
+  std::vector<TGraph *> hvgraphs, lvgraphs;
   TLegend *leg_hv = new TLegend(0.6, 0.87, 0.99, 0.99);
   TLegend *leg_lv = new TLegend(0.6, 0.87, 0.99, 0.99);
-  for (unsigned itag=0; itag<m_plotTags.size(); ++itag){
+  for (unsigned itag = 0; itag < m_plotTags.size(); ++itag) {
     auto tag = m_plotTags.at(itag);
-    auto color = itag<PLOT_COLORS.size() ? PLOT_COLORS.at(itag) : kGreen+itag;
+    auto color = itag < PLOT_COLORS.size() ? PLOT_COLORS.at(itag) : kGreen + itag;
 
     std::vector<double> vTime;
     std::vector<double> vHVOffPercent, vLVOffPercent;
 
     // query the database
     edm::LogInfo("SiStripDetVOffTrendPlotter") << "[SiStripDetVOffTrendPlotter::" << __func__ << "] "
-        << "Reading IOVs from tag " << tag;
-    cond::persistency::IOVProxy iovProxy = condDbSession.readIov(tag, true); // load all?
+                                               << "Reading IOVs from tag " << tag;
+    cond::persistency::IOVProxy iovProxy = condDbSession.readIov(tag, true);  // load all?
     auto iiov = iovProxy.find(startIov);
     auto eiov = iovProxy.find(endIov);
     int niov = 0;
-    while (iiov != iovProxy.end() && (*iiov).since <= (*eiov).since){
+    while (iiov != iovProxy.end() && (*iiov).since <= (*eiov).since) {
       // convert cond::Time_t to seconds since epoch
-      if ((*iiov).since<startIov)
+      if ((*iiov).since < startIov)
         vTime.push_back(cond::time::unpack(startIov).first);
       else
         vTime.push_back(cond::time::unpack((*iiov).since).first);
-      auto payload = condDbSession.fetchPayload<SiStripDetVOff>( (*iiov).payloadId );
-      vHVOffPercent.push_back( 1.0*payload->getHVoffCounts()/num_modules );
-      vLVOffPercent.push_back( 1.0*payload->getLVoffCounts()/num_modules );
+      auto payload = condDbSession.fetchPayload<SiStripDetVOff>((*iiov).payloadId);
+      vHVOffPercent.push_back(1.0 * payload->getHVoffCounts() / num_modules);
+      vLVOffPercent.push_back(1.0 * payload->getLVoffCounts() / num_modules);
       iovMap[(*iiov).since][tag] = {payload->getHVoffCounts(), payload->getLVoffCounts()};
       // debug
-      std::cout << boost::posix_time::to_simple_string(cond::time::to_boost((*iiov).since))
-          << " (" << (*iiov).since <<  ")"
-          << ", # HV Off=" << std::setw(6) << payload->getHVoffCounts()
-          << ", # LV Off=" << std::setw(6) << payload->getLVoffCounts() << std::endl;
+      std::cout << boost::posix_time::to_simple_string(cond::time::to_boost((*iiov).since)) << " (" << (*iiov).since
+                << ")"
+                << ", # HV Off=" << std::setw(6) << payload->getHVoffCounts() << ", # LV Off=" << std::setw(6)
+                << payload->getLVoffCounts() << std::endl;
       ++iiov;
       ++niov;
     }
-    edm::LogInfo("SiStripDetVOffTrendPlotter") << "[SiStripDetVOffTrendPlotter::" << __func__ << "] "
+    edm::LogInfo("SiStripDetVOffTrendPlotter")
+        << "[SiStripDetVOffTrendPlotter::" << __func__ << "] "
         << "Read " << niov << " IOVs from tag " << tag << " in the specified interval.";
 
     TGraph *hv = new TGraph(vTime.size(), vTime.data(), vHVOffPercent.data());
-    prepGraph(hv, TString("HVOff_")+tag, ";UTC;Fraction of HV off", color);
+    prepGraph(hv, TString("HVOff_") + tag, ";UTC;Fraction of HV off", color);
     leg_hv->AddEntry(hv, tag.data(), "LP");
 
     TGraph *lv = new TGraph(vTime.size(), vTime.data(), vLVOffPercent.data());
-    prepGraph(lv, TString("LVOff_")+tag, ";UTC;Fraction of LV off", color);
+    prepGraph(lv, TString("LVOff_") + tag, ";UTC;Fraction of LV off", color);
     leg_lv->AddEntry(lv, tag.data(), "LP");
 
     hvgraphs.push_back(hv);
@@ -169,53 +171,52 @@ void SiStripDetVOffTrendPlotter::analyze(const edm::Event& evt, const edm::Event
   c.SetBottomMargin(0.08);
   c.SetGridx();
   c.SetGridy();
-  for (const auto hv : hvgraphs){
-    if (hv==hvgraphs.front())
+  for (const auto hv : hvgraphs) {
+    if (hv == hvgraphs.front())
       hv->Draw("ALP");
     else
       hv->Draw("LPsame");
-    if (fout){
+    if (fout) {
       fout->cd();
       hv->Write();
     }
   }
   leg_hv->Draw();
-  std::string plot_postfix = !m_outputPlot.empty() ? m_outputPlot : "from_" + formatIOV(startIov) + "_to_" + formatIOV(endIov) + ".png";
-  c.Print( ("HVOff_" + plot_postfix).data() );
+  std::string plot_postfix =
+      !m_outputPlot.empty() ? m_outputPlot : "from_" + formatIOV(startIov) + "_to_" + formatIOV(endIov) + ".png";
+  c.Print(("HVOff_" + plot_postfix).data());
 
   c.Clear();
-  for (const auto lv : lvgraphs){
-    if (lv==lvgraphs.front())
+  for (const auto lv : lvgraphs) {
+    if (lv == lvgraphs.front())
       lv->Draw("ALP");
     else
       lv->Draw("LPsame");
-    if (fout){
+    if (fout) {
       fout->cd();
       lv->Write();
     }
   }
   leg_lv->Draw();
-  c.Print( ("LVOff_" + plot_postfix).data() );
+  c.Print(("LVOff_" + plot_postfix).data());
 
   if (!m_outputCSV.empty()) {
     dumpCSV(true);
     dumpCSV(false);
   }
-
 }
 
-void SiStripDetVOffTrendPlotter::endJob() {
-}
+void SiStripDetVOffTrendPlotter::endJob() {}
 
 std::string SiStripDetVOffTrendPlotter::formatIOV(cond::Time_t iov, std::string format) {
   auto facet = new boost::posix_time::time_facet(format.c_str());
-   std::ostringstream stream;
-   stream.imbue(std::locale(stream.getloc(), facet));
-   stream << cond::time::to_boost(iov);
-   return stream.str();
+  std::ostringstream stream;
+  stream.imbue(std::locale(stream.getloc(), facet));
+  stream << cond::time::to_boost(iov);
+  return stream.str();
 }
 
-void SiStripDetVOffTrendPlotter::prepGraph(TGraph* gr, TString name, TString title, Color_t color) {
+void SiStripDetVOffTrendPlotter::prepGraph(TGraph *gr, TString name, TString title, Color_t color) {
   gr->SetName(name);
   gr->SetTitle(title);
   gr->SetLineColor(color);
@@ -234,29 +235,29 @@ void SiStripDetVOffTrendPlotter::prepGraph(TGraph* gr, TString name, TString tit
 }
 
 void SiStripDetVOffTrendPlotter::dumpCSV(bool isHV) {
-
   // get total number of modules
   auto num_modules = detidReader->getAllDetIds().size();
 
-  std::string outCSV = isHV ? "HVOff_table_"+m_outputCSV : "LVOff_table_"+m_outputCSV;
+  std::string outCSV = isHV ? "HVOff_table_" + m_outputCSV : "LVOff_table_" + m_outputCSV;
   std::ofstream csv;
   csv.open(outCSV);
   csv << "IOV,Timestamp(UTC),";
-  for (const auto &tag : m_plotTags) csv << tag << ",";
+  for (const auto &tag : m_plotTags)
+    csv << tag << ",";
   csv << std::endl;
 
   csv << std::fixed << std::setprecision(1);
 
-  for (const auto &v : iovMap){
+  for (const auto &v : iovMap) {
     auto iov = v.first;
     auto timestamp = boost::posix_time::to_simple_string(cond::time::to_boost(iov));
     csv << iov << "," << timestamp << ",";
-    for (const auto &tag : m_plotTags){
-      if (v.second.find(tag)!=v.second.end()){
+    for (const auto &tag : m_plotTags) {
+      if (v.second.find(tag) != v.second.end()) {
         int count = isHV ? v.second.at(tag).first : v.second.at(tag).second;
-        csv << count << " (" << 100.*count/num_modules << "%)";
+        csv << count << " (" << 100. * count / num_modules << "%)";
       }
-        csv << ",";
+      csv << ",";
     }
     csv << std::endl;
   }
@@ -265,4 +266,3 @@ void SiStripDetVOffTrendPlotter::dumpCSV(bool isHV) {
 }
 
 DEFINE_FWK_MODULE(SiStripDetVOffTrendPlotter);
-

--- a/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTrendPlotter.cc
+++ b/CalibTracker/SiStripDCS/plugins/SiStripDetVOffTrendPlotter.cc
@@ -73,7 +73,7 @@ SiStripDetVOffTrendPlotter::SiStripDetVOffTrendPlotter(const edm::ParameterSet& 
     fout(nullptr){
   m_connectionPool.setParameters( iConfig.getParameter<edm::ParameterSet>("DBParameters")  );
   m_connectionPool.configure();
-  if (m_outputRootFile!="") fout = new TFile(m_outputRootFile.data(), "RECREATE");
+  if (!m_outputRootFile.empty()) fout = new TFile(m_outputRootFile.data(), "RECREATE");
 }
 
 SiStripDetVOffTrendPlotter::~SiStripDetVOffTrendPlotter() {
@@ -180,7 +180,7 @@ void SiStripDetVOffTrendPlotter::analyze(const edm::Event& evt, const edm::Event
     }
   }
   leg_hv->Draw();
-  std::string plot_postfix = m_outputPlot!="" ? m_outputPlot : "from_" + formatIOV(startIov) + "_to_" + formatIOV(endIov) + ".png";
+  std::string plot_postfix = !m_outputPlot.empty() ? m_outputPlot : "from_" + formatIOV(startIov) + "_to_" + formatIOV(endIov) + ".png";
   c.Print( ("HVOff_" + plot_postfix).data() );
 
   c.Clear();
@@ -197,7 +197,7 @@ void SiStripDetVOffTrendPlotter::analyze(const edm::Event& evt, const edm::Event
   leg_lv->Draw();
   c.Print( ("LVOff_" + plot_postfix).data() );
 
-  if (m_outputCSV!="") {
+  if (!m_outputCSV.empty()) {
     dumpCSV(true);
     dumpCSV(false);
   }

--- a/CalibTracker/SiStripDCS/plugins/TkVoltageMapCreator.cc
+++ b/CalibTracker/SiStripDCS/plugins/TkVoltageMapCreator.cc
@@ -22,7 +22,7 @@
 
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-#include "DQM/SiStripCommon/interface/TkHistoMap.h" 
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 
 //
@@ -30,25 +30,23 @@
 //
 
 class TkVoltageMapCreator : public edm::EDAnalyzer {
- public:
-    explicit TkVoltageMapCreator(const edm::ParameterSet&);
-    ~TkVoltageMapCreator() override;
+public:
+  explicit TkVoltageMapCreator(const edm::ParameterSet&);
+  ~TkVoltageMapCreator() override;
 
+private:
+  void beginJob() override;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
-   private:
-      void beginJob() override ;
-      void beginRun(const edm::Run&, const edm::EventSetup&) override ;
-      void endRun(const edm::Run&, const edm::EventSetup&) override ;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
-
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 
   const std::string _lvfile;
   const std::string _lvtkmapname;
   const std::string _hvfile;
   const std::string _hvtkmapname;
-
 };
 
 //
@@ -62,50 +60,38 @@ class TkVoltageMapCreator : public edm::EDAnalyzer {
 //
 // constructors and destructor
 //
-TkVoltageMapCreator::TkVoltageMapCreator(const edm::ParameterSet& iConfig):
-  _lvfile(iConfig.getParameter<std::string>("LVStatusFile")),
-  _lvtkmapname(iConfig.getParameter<std::string>("LVTkMapName")),
-  _hvfile(iConfig.getParameter<std::string>("HVStatusFile")),
-  _hvtkmapname(iConfig.getParameter<std::string>("HVTkMapName"))
+TkVoltageMapCreator::TkVoltageMapCreator(const edm::ParameterSet& iConfig)
+    : _lvfile(iConfig.getParameter<std::string>("LVStatusFile")),
+      _lvtkmapname(iConfig.getParameter<std::string>("LVTkMapName")),
+      _hvfile(iConfig.getParameter<std::string>("HVStatusFile")),
+      _hvtkmapname(iConfig.getParameter<std::string>("HVTkMapName"))
 
 {
-   //now do what ever initialization is needed
+  //now do what ever initialization is needed
 }
 
-
-TkVoltageMapCreator::~TkVoltageMapCreator()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+TkVoltageMapCreator::~TkVoltageMapCreator() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-TkVoltageMapCreator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
+void TkVoltageMapCreator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) { using namespace edm; }
 
-}
-
-void 
-TkVoltageMapCreator::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup)
-{
+void TkVoltageMapCreator::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   edm::ESHandle<TkDetMap> tkDetMapHandle;
   iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
   const TkDetMap* tkDetMap = tkDetMapHandle.product();
 
-  TrackerMap lvmap,hvmap;
+  TrackerMap lvmap, hvmap;
 
-  TkHistoMap lvhisto(tkDetMap, "LV_Status","LV_Status",-1);
-  TkHistoMap hvhisto(tkDetMap, "HV_Status","HV_Status",-1);
-  
+  TkHistoMap lvhisto(tkDetMap, "LV_Status", "LV_Status", -1);
+  TkHistoMap hvhisto(tkDetMap, "HV_Status", "HV_Status", -1);
+
   std::ifstream lvdata(_lvfile.c_str());
   std::ifstream hvdata(_hvfile.c_str());
 
@@ -113,21 +99,25 @@ TkVoltageMapCreator::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
 
   unsigned int detid;
   std::string lvstatus;
-  
-  while(lvdata >> detid >> lvstatus) {
-    double cha =0.;
-    if(lvstatus=="ON") cha = 0.5; //GREEN
-    if(lvstatus=="OFF") cha = 1.; //RED
-    lvhisto.fill(detid,cha);
+
+  while (lvdata >> detid >> lvstatus) {
+    double cha = 0.;
+    if (lvstatus == "ON")
+      cha = 0.5;  //GREEN
+    if (lvstatus == "OFF")
+      cha = 1.;  //RED
+    lvhisto.fill(detid, cha);
   }
-  
+
   std::string hvstatus;
 
-  while(hvdata >> detid >> hvstatus) {
-    double cha =0.;
-    if(hvstatus=="ON") cha = 0.5; //GREEN
-    if(hvstatus=="OFF") cha = 1.; //RED
-    hvhisto.fill(detid,cha);
+  while (hvdata >> detid >> hvstatus) {
+    double cha = 0.;
+    if (hvstatus == "ON")
+      cha = 0.5;  //GREEN
+    if (hvstatus == "OFF")
+      cha = 1.;  //RED
+    hvhisto.fill(detid, cha);
   }
 
   lvmap.setPalette(1);
@@ -136,8 +126,8 @@ TkVoltageMapCreator::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
   lvhisto.dumpInTkMap(&lvmap);
   hvhisto.dumpInTkMap(&hvmap);
 
-  lvmap.save(true,0,0,_lvtkmapname);
-  hvmap.save(true,0,0,_hvtkmapname);
+  lvmap.save(true, 0, 0, _lvtkmapname);
+  hvmap.save(true, 0, 0, _hvtkmapname);
 
   //TODO could make the root file name a parameter to avoid overwriting everytime...
   std::string rootmapname = "VoltageStatus.root";
@@ -145,23 +135,13 @@ TkVoltageMapCreator::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
   hvhisto.save(rootmapname);
 }
 
-void 
-TkVoltageMapCreator::endRun(const edm::Run& iRun, const edm::EventSetup&)
-{
-}
-
+void TkVoltageMapCreator::endRun(const edm::Run& iRun, const edm::EventSetup&) {}
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-TkVoltageMapCreator::beginJob()
-{
-
-}
+void TkVoltageMapCreator::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-TkVoltageMapCreator::endJob() {}
-
+void TkVoltageMapCreator::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(TkVoltageMapCreator);

--- a/CalibTracker/SiStripDCS/src/SiStripCoralIface.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripCoralIface.cc
@@ -18,90 +18,100 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // constructor
-SiStripCoralIface::SiStripCoralIface( std::string connectionString , std::string authenticationPath, const bool debug) : m_connectionString(connectionString), m_authPath( authenticationPath ), m_session(), debug_(debug)
-{
+SiStripCoralIface::SiStripCoralIface(std::string connectionString, std::string authenticationPath, const bool debug)
+    : m_connectionString(connectionString), m_authPath(authenticationPath), m_session(), debug_(debug) {
   std::cout << "Building coral interface" << std::endl;
   initialize();
 }
 
 // destructor
-SiStripCoralIface::~SiStripCoralIface() {	
-  LogTrace("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] Destructor called."; 
+SiStripCoralIface::~SiStripCoralIface() {
+  LogTrace("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] Destructor called.";
   // m_connection.close();
 }
 
 // open DB connection
-void  SiStripCoralIface::initialize() {
+void SiStripCoralIface::initialize() {
   cond::persistency::ConnectionPool connection;
   connection.setAuthenticationPath(m_authPath);
   connection.configure();
   m_session = connection.createSession(m_connectionString);
   try {
-    m_transaction.reset( new cond::persistency::TransactionScope(m_session.transaction()) );
+    m_transaction.reset(new cond::persistency::TransactionScope(m_session.transaction()));
     m_transaction->start(true);
-    LogTrace("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] Database connection opened"; 
-  }
-  catch (...) {
-    edm::LogError("SiStripCoralIface") << "Database connection failed";     
+    LogTrace("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] Database connection opened";
+  } catch (...) {
+    edm::LogError("SiStripCoralIface") << "Database connection failed";
     exit(1);
   }
 }
 
 // access the status change or lastValue tables
-void SiStripCoralIface::doQuery(std::string queryType, const coral::TimeStamp& startTime, const coral::TimeStamp& endTime, std::vector<coral::TimeStamp> &vec_changedate, 
-				std::vector<float> &vec_actualValue, std::vector<std::string> &vec_dpname)
-{
-  std::unique_ptr<coral::IQuery> query( m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
+void SiStripCoralIface::doQuery(std::string queryType,
+                                const coral::TimeStamp& startTime,
+                                const coral::TimeStamp& endTime,
+                                std::vector<coral::TimeStamp>& vec_changedate,
+                                std::vector<float>& vec_actualValue,
+                                std::vector<std::string>& vec_dpname) {
+  std::unique_ptr<coral::IQuery> query(
+      m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
   std::string condition;
 
   LogTrace("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] table to be accessed: " << queryType;
 
   if (queryType == "STATUSCHANGE") {
-    query->addToOutputList("FWCAENCHANNEL.CHANGE_DATE","CHANGE_DATE");
-    query->addToOutputList("FWCAENCHANNEL.ACTUAL_STATUS","ACTUAL_STATUS");
-    query->addToOutputList("DP_NAME2ID.DPNAME","DPNAME");
+    query->addToOutputList("FWCAENCHANNEL.CHANGE_DATE", "CHANGE_DATE");
+    query->addToOutputList("FWCAENCHANNEL.ACTUAL_STATUS", "ACTUAL_STATUS");
+    query->addToOutputList("DP_NAME2ID.DPNAME", "DPNAME");
     query->addToOrderList("FWCAENCHANNEL.CHANGE_DATE");
     query->addToTableList("FWCAENCHANNEL");
     query->addToTableList("DP_NAME2ID");
-    condition = "FWCAENCHANNEL.DPID = DP_NAME2ID.ID AND FWCAENCHANNEL.CHANGE_DATE<=:tmax AND FWCAENCHANNEL.ACTUAL_STATUS IS NOT NULL AND FWCAENCHANNEL.CHANGE_DATE >=:tmin AND (DP_NAME2ID.DPNAME like '%easyBoard%')";
+    condition =
+        "FWCAENCHANNEL.DPID = DP_NAME2ID.ID AND FWCAENCHANNEL.CHANGE_DATE<=:tmax AND FWCAENCHANNEL.ACTUAL_STATUS IS "
+        "NOT NULL AND FWCAENCHANNEL.CHANGE_DATE >=:tmin AND (DP_NAME2ID.DPNAME like '%easyBoard%')";
   } else if (queryType == "LASTVALUE") {
-    query->addToOutputList("DCSLASTVALUE_VOLTAGE.CHANGE_DATE","CHANGE_DATE");
-    query->addToOutputList("DCSLASTVALUE_VOLTAGE.ACTUAL_VMON","ACTUAL_VMON");
-    query->addToOutputList("DP_NAME2ID.DPNAME","DPNAME");
+    query->addToOutputList("DCSLASTVALUE_VOLTAGE.CHANGE_DATE", "CHANGE_DATE");
+    query->addToOutputList("DCSLASTVALUE_VOLTAGE.ACTUAL_VMON", "ACTUAL_VMON");
+    query->addToOutputList("DP_NAME2ID.DPNAME", "DPNAME");
     query->addToOrderList("DCSLASTVALUE_VOLTAGE.CHANGE_DATE");
     query->addToTableList("DCSLASTVALUE_VOLTAGE");
     query->addToTableList("DP_NAME2ID");
-    condition = "DCSLASTVALUE_VOLTAGE.DPID = DP_NAME2ID.ID AND DCSLASTVALUE_VOLTAGE.CHANGE_DATE<=:tmax AND DCSLASTVALUE_VOLTAGE.CHANGE_DATE>=:tmin AND DCSLASTVALUE_VOLTAGE.ACTUAL_VMON IS NOT NULL AND (DP_NAME2ID.DPNAME like '%easyBoard%')";
+    condition =
+        "DCSLASTVALUE_VOLTAGE.DPID = DP_NAME2ID.ID AND DCSLASTVALUE_VOLTAGE.CHANGE_DATE<=:tmax AND "
+        "DCSLASTVALUE_VOLTAGE.CHANGE_DATE>=:tmin AND DCSLASTVALUE_VOLTAGE.ACTUAL_VMON IS NOT NULL AND "
+        "(DP_NAME2ID.DPNAME like '%easyBoard%')";
   }
 
   coral::AttributeList conditionData;
-  conditionData.extend<coral::TimeStamp>( "tmax" );
-  conditionData.extend<coral::TimeStamp>( "tmin" );
-  query->setCondition( condition, conditionData );
+  conditionData.extend<coral::TimeStamp>("tmax");
+  conditionData.extend<coral::TimeStamp>("tmin");
+  query->setCondition(condition, conditionData);
   conditionData[0].data<coral::TimeStamp>() = endTime;
   conditionData[1].data<coral::TimeStamp>() = startTime;
 
-  query->setMemoryCacheSize( 100 );
-  std::cout<<"Executing query"<<std::endl;
-  if (debug_) std::cout<<"[SiStripCoralIface::"<<__func__<<"] Dumping all query results:"<<std::endl;
+  query->setMemoryCacheSize(100);
+  std::cout << "Executing query" << std::endl;
+  if (debug_)
+    std::cout << "[SiStripCoralIface::" << __func__ << "] Dumping all query results:" << std::endl;
   coral::ICursor& cursor = query->execute();
-  int numberRow=0;
-  while( cursor.next() ){
+  int numberRow = 0;
+  while (cursor.next()) {
     const coral::AttributeList& row = cursor.currentRow();
     //DEBUG
     //Output the query results directly to cout,
     //Can be subsequently parsed by Python validation code
-    if( debug_ ) row.toOutputStream( std::cout ) << std::endl;
+    if (debug_)
+      row.toOutputStream(std::cout) << std::endl;
     numberRow++;
     if (queryType == "STATUSCHANGE") {
-      coral::TimeStamp ts =  row["CHANGE_DATE"].data<coral::TimeStamp>();
+      coral::TimeStamp ts = row["CHANGE_DATE"].data<coral::TimeStamp>();
       vec_changedate.push_back(ts);
       float as = (float)row["ACTUAL_STATUS"].data<float>();
       vec_actualValue.push_back(as);
       std::string id_name = (std::string)row["DPNAME"].data<std::string>();
       vec_dpname.push_back(id_name);
     } else if (queryType == "LASTVALUE") {
-      coral::TimeStamp ts =  row["CHANGE_DATE"].data<coral::TimeStamp>();
+      coral::TimeStamp ts = row["CHANGE_DATE"].data<coral::TimeStamp>();
       vec_changedate.push_back(ts);
       float av = (float)row["ACTUAL_VMON"].data<float>();
       vec_actualValue.push_back(av);
@@ -110,39 +120,49 @@ void SiStripCoralIface::doQuery(std::string queryType, const coral::TimeStamp& s
     }
   }
   cursor.close();
-  if (debug_) std::cout<<"[SiStripCoralIface::"<<__func__<<"] Finished dumping query results, "<< numberRow<<" rows were retrieved from PVSS Cond DB (both Pixel and Strip CAEN supplies)"<<std::endl;
-  edm::LogInfo("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] " << numberRow << " rows retrieved from PVSS Cond DB";
+  if (debug_)
+    std::cout << "[SiStripCoralIface::" << __func__ << "] Finished dumping query results, " << numberRow
+              << " rows were retrieved from PVSS Cond DB (both Pixel and Strip CAEN supplies)" << std::endl;
+  edm::LogInfo("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] " << numberRow
+                                    << " rows retrieved from PVSS Cond DB";
 }
 
 // access the channel settings in the status change table
-void SiStripCoralIface::doSettingsQuery(const coral::TimeStamp& startTime, const coral::TimeStamp& endTime, std::vector<coral::TimeStamp> &vec_changedate,
-					std::vector<float> &vec_settings, std::vector<std::string> &vec_dpname, std::vector<uint32_t> &vec_dpid) 
-{
-  std::unique_ptr<coral::IQuery> query( m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
-  query->addToOutputList("FWCAENCHANNEL.CHANGE_DATE","CHANGE_DATE");
-  query->addToOutputList("FWCAENCHANNEL.SETTINGS_V0","VSET");
-  query->addToOutputList("FWCAENCHANNEL.DPID","DPID");
-  query->addToOutputList("DP_NAME2ID.DPNAME","DPNAME");
+void SiStripCoralIface::doSettingsQuery(const coral::TimeStamp& startTime,
+                                        const coral::TimeStamp& endTime,
+                                        std::vector<coral::TimeStamp>& vec_changedate,
+                                        std::vector<float>& vec_settings,
+                                        std::vector<std::string>& vec_dpname,
+                                        std::vector<uint32_t>& vec_dpid) {
+  std::unique_ptr<coral::IQuery> query(
+      m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
+  query->addToOutputList("FWCAENCHANNEL.CHANGE_DATE", "CHANGE_DATE");
+  query->addToOutputList("FWCAENCHANNEL.SETTINGS_V0", "VSET");
+  query->addToOutputList("FWCAENCHANNEL.DPID", "DPID");
+  query->addToOutputList("DP_NAME2ID.DPNAME", "DPNAME");
   query->addToOrderList("FWCAENCHANNEL.CHANGE_DATE");
   query->addToTableList("FWCAENCHANNEL");
   query->addToTableList("DP_NAME2ID");
-  std::string condition = "FWCAENCHANNEL.DPID = DP_NAME2ID.ID AND FWCAENCHANNEL.CHANGE_DATE<=:tmax AND FWCAENCHANNEL.SETTINGS_V0 IS NOT NULL AND FWCAENCHANNEL.CHANGE_DATE >=:tmin AND (DP_NAME2ID.DPNAME like '%easyBoard%')";
+  std::string condition =
+      "FWCAENCHANNEL.DPID = DP_NAME2ID.ID AND FWCAENCHANNEL.CHANGE_DATE<=:tmax AND FWCAENCHANNEL.SETTINGS_V0 IS NOT "
+      "NULL AND FWCAENCHANNEL.CHANGE_DATE >=:tmin AND (DP_NAME2ID.DPNAME like '%easyBoard%')";
 
   coral::AttributeList conditionData;
-  conditionData.extend<coral::TimeStamp>( "tmax" );
-  conditionData.extend<coral::TimeStamp>( "tmin" );
-  query->setCondition( condition, conditionData );
+  conditionData.extend<coral::TimeStamp>("tmax");
+  conditionData.extend<coral::TimeStamp>("tmin");
+  query->setCondition(condition, conditionData);
   conditionData[0].data<coral::TimeStamp>() = endTime;
   conditionData[1].data<coral::TimeStamp>() = startTime;
 
-  query->setMemoryCacheSize( 100 );
+  query->setMemoryCacheSize(100);
   coral::ICursor& cursor = query->execute();
-  int numberRow=0;
-  while( cursor.next() ){
+  int numberRow = 0;
+  while (cursor.next()) {
     const coral::AttributeList& row = cursor.currentRow();
-    if( debug_ ) row.toOutputStream( std::cout ) << std::endl;
+    if (debug_)
+      row.toOutputStream(std::cout) << std::endl;
     numberRow++;
-    coral::TimeStamp ts =  row["CHANGE_DATE"].data<coral::TimeStamp>();
+    coral::TimeStamp ts = row["CHANGE_DATE"].data<coral::TimeStamp>();
     vec_changedate.push_back(ts);
     float vs = (float)row["VSET"].data<float>();
     vec_settings.push_back(vs);
@@ -152,23 +172,24 @@ void SiStripCoralIface::doSettingsQuery(const coral::TimeStamp& startTime, const
     vec_dpname.push_back(id_name);
   }
   cursor.close();
-  edm::LogInfo("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] " << numberRow << " rows retrieved from PVSS Cond DB";
+  edm::LogInfo("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] " << numberRow
+                                    << " rows retrieved from PVSS Cond DB";
 }
 
-void SiStripCoralIface::doNameQuery(std::vector<std::string> &vec_dpname, std::vector<uint32_t> &vec_dpid) 
-{
-  std::unique_ptr<coral::IQuery> query( m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
-  query->addToOutputList("DP_NAME2ID.DPNAME","DPNAME");
-  query->addToOutputList("DP_NAME2ID.ID","DPID");
+void SiStripCoralIface::doNameQuery(std::vector<std::string>& vec_dpname, std::vector<uint32_t>& vec_dpid) {
+  std::unique_ptr<coral::IQuery> query(
+      m_session.coralSession().schema(std::string("CMS_TRK_DCS_PVSS_COND")).newQuery());
+  query->addToOutputList("DP_NAME2ID.DPNAME", "DPNAME");
+  query->addToOutputList("DP_NAME2ID.ID", "DPID");
   query->addToTableList("DP_NAME2ID");
 
   std::string condition = "DP_NAME2ID.DPNAME like '%easyBoard%' ";
-  query->setCondition( condition, coral::AttributeList() );
+  query->setCondition(condition, coral::AttributeList());
 
-  query->setMemoryCacheSize( 100 );
+  query->setMemoryCacheSize(100);
   coral::ICursor& cursor = query->execute();
-  int numberRow=0;
-  while( cursor.next() ){
+  int numberRow = 0;
+  while (cursor.next()) {
     const coral::AttributeList& row = cursor.currentRow();
     numberRow++;
     uint32_t id = (uint32_t)row["DPID"].data<float>();
@@ -177,5 +198,6 @@ void SiStripCoralIface::doNameQuery(std::vector<std::string> &vec_dpname, std::v
     vec_dpname.push_back(id_name);
   }
   cursor.close();
-  edm::LogInfo("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] " << numberRow << " rows retrieved from PVSS Cond DB";
+  edm::LogInfo("SiStripCoralIface") << "[SiStripCoralIface::" << __func__ << "] " << numberRow
+                                    << " rows retrieved from PVSS Cond DB";
 }

--- a/CalibTracker/SiStripDCS/src/SiStripDetVOffBuilder.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripDetVOffBuilder.cc
@@ -2,24 +2,23 @@
 #include <sys/stat.h>
 
 // constructor
-SiStripDetVOffBuilder::SiStripDetVOffBuilder(const edm::ParameterSet& pset, const edm::ActivityRegistry&) : 
-  onlineDbConnectionString(pset.getParameter<std::string>("onlineDB")),
-  authenticationPath(pset.getParameter<std::string>("authPath")),
-  whichTable(pset.getParameter<std::string>("queryType")),
-  lastValueFileName(pset.getParameter<std::string>("lastValueFile")),
-  fromFile(pset.getParameter<bool>("lastValueFromFile")),
-  psuDetIdMapFile_(pset.getParameter<std::string>("PsuDetIdMapFile")),
-  debug_(pset.getParameter<bool>("debugModeOn")),
-  tDefault(7,0),
-  tmax_par(pset.getParameter< std::vector<int> >("Tmax")),
-  tmin_par(pset.getParameter< std::vector<int> >("Tmin")),
-  tset_par(pset.getParameter< std::vector<int> >("TSetMin")),
-  deltaTmin_(pset.getParameter<uint32_t>("DeltaTmin")),
-  maxIOVlength_(pset.getParameter<uint32_t>("MaxIOVlength")),
-  detIdListFile_(pset.getParameter< std::string >("DetIdListFile")),
-  excludedDetIdListFile_(pset.getParameter< std::string >("ExcludedDetIdListFile")),
-  highVoltageOnThreshold_(pset.getParameter<double>("HighVoltageOnThreshold"))
-{ 
+SiStripDetVOffBuilder::SiStripDetVOffBuilder(const edm::ParameterSet& pset, const edm::ActivityRegistry&)
+    : onlineDbConnectionString(pset.getParameter<std::string>("onlineDB")),
+      authenticationPath(pset.getParameter<std::string>("authPath")),
+      whichTable(pset.getParameter<std::string>("queryType")),
+      lastValueFileName(pset.getParameter<std::string>("lastValueFile")),
+      fromFile(pset.getParameter<bool>("lastValueFromFile")),
+      psuDetIdMapFile_(pset.getParameter<std::string>("PsuDetIdMapFile")),
+      debug_(pset.getParameter<bool>("debugModeOn")),
+      tDefault(7, 0),
+      tmax_par(pset.getParameter<std::vector<int> >("Tmax")),
+      tmin_par(pset.getParameter<std::vector<int> >("Tmin")),
+      tset_par(pset.getParameter<std::vector<int> >("TSetMin")),
+      deltaTmin_(pset.getParameter<uint32_t>("DeltaTmin")),
+      maxIOVlength_(pset.getParameter<uint32_t>("MaxIOVlength")),
+      detIdListFile_(pset.getParameter<std::string>("DetIdListFile")),
+      excludedDetIdListFile_(pset.getParameter<std::string>("ExcludedDetIdListFile")),
+      highVoltageOnThreshold_(pset.getParameter<double>("HighVoltageOnThreshold")) {
   lastStoredCondObj.first = nullptr;
   lastStoredCondObj.second = 0;
 
@@ -27,98 +26,111 @@ SiStripDetVOffBuilder::SiStripDetVOffBuilder(const edm::ParameterSet& pset, cons
 
   // set up vectors based on pset parameters (tDefault purely for initialization)
 
-  whichQuery=(whichTable == "STATUSCHANGE" || (whichTable == "LASTVALUE" && !fromFile));
+  whichQuery = (whichTable == "STATUSCHANGE" || (whichTable == "LASTVALUE" && !fromFile));
 
   //Define the query interval [Tmin, Tmax]
   //where Tmax comes from the cfg
-  //      Tmin comes from the cfg for the first o2o, after that it is extracted from Offline DB 
+  //      Tmin comes from the cfg for the first o2o, after that it is extracted from Offline DB
 
-  tmax = coral::TimeStamp(tmax_par[0],tmax_par[1],tmax_par[2],tmax_par[3],tmax_par[4],tmax_par[5],tmax_par[6]);
+  tmax = coral::TimeStamp(tmax_par[0], tmax_par[1], tmax_par[2], tmax_par[3], tmax_par[4], tmax_par[5], tmax_par[6]);
 
   if (whichQuery) {
     // Is there a better way to do this?  TODO - investigate
-    tmin=coral::TimeStamp(tmin_par[0],tmin_par[1],tmin_par[2],tmin_par[3],tmin_par[4],tmin_par[5],tmin_par[6]);
+    tmin = coral::TimeStamp(tmin_par[0], tmin_par[1], tmin_par[2], tmin_par[3], tmin_par[4], tmin_par[5], tmin_par[6]);
   }
-  
+
   if (whichTable == "LASTVALUE") {
-    tsetmin = coral::TimeStamp(tset_par[0],tset_par[1],tset_par[2],tset_par[3],tset_par[4],tset_par[5],tset_par[6]);
+    tsetmin =
+        coral::TimeStamp(tset_par[0], tset_par[1], tset_par[2], tset_par[3], tset_par[4], tset_par[5], tset_par[6]);
   }
-  
+
   if (onlineDbConnectionString.empty()) {
-    edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::SiStripDetVOffBuilder] DB name has not been set properly ... Returning ...";
+    edm::LogError("SiStripDetVOffBuilder")
+        << "[SiStripDetVOffBuilder::SiStripDetVOffBuilder] DB name has not been set properly ... Returning ...";
     return;
   }
-  
+
   if (fromFile && whichTable == "LASTVALUE" && lastValueFileName.empty()) {
-    edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::SiStripDetVOffBuilder] File expected for lastValue table, but filename not specified ... Returning ...";
+    edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::SiStripDetVOffBuilder] File expected for "
+                                              "lastValue table, but filename not specified ... Returning ...";
     return;
   }
-  
+
   // write out the parameters
   std::stringstream ss;
-  ss << "[SiStripDetVOffBuilder::SiStripDetVOffBuilder]\n" 
-     << "     Parameters:\n" 
+  ss << "[SiStripDetVOffBuilder::SiStripDetVOffBuilder]\n"
+     << "     Parameters:\n"
      << "     DB connection string: " << onlineDbConnectionString << "\n"
-     << "     Authentication path: "  << authenticationPath       << "\n"
-     << "     Table to be queried: "  << whichTable               << "\n"
-     << "     MapFile: "  << psuDetIdMapFile_                << "\n";
-  
-  if (whichQuery){
-    ss << "     Tmin: "; printPar(ss,tmin_par);  ss << std::endl;
-  }
-  ss << "     Tmax: "  ; printPar(ss,tmax_par);  ss << std::endl;
+     << "     Authentication path: " << authenticationPath << "\n"
+     << "     Table to be queried: " << whichTable << "\n"
+     << "     MapFile: " << psuDetIdMapFile_ << "\n";
 
-  if (whichTable == "LASTVALUE"){ 
-    ss << "     TSetMin: "; printPar(ss,tset_par);  ss << std::endl;
+  if (whichQuery) {
+    ss << "     Tmin: ";
+    printPar(ss, tmin_par);
+    ss << std::endl;
   }
-   edm::LogError("SiStripDetVOffBuilder") << ss.str();
+  ss << "     Tmax: ";
+  printPar(ss, tmax_par);
+  ss << std::endl;
 
+  if (whichTable == "LASTVALUE") {
+    ss << "     TSetMin: ";
+    printPar(ss, tset_par);
+    ss << std::endl;
+  }
+  edm::LogError("SiStripDetVOffBuilder") << ss.str();
 }
 
 // destructor
-SiStripDetVOffBuilder::~SiStripDetVOffBuilder() { 
+SiStripDetVOffBuilder::~SiStripDetVOffBuilder() {
   edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::" << __func__ << "]: destructing ...";
 }
 
-void SiStripDetVOffBuilder::printPar(std::stringstream& ss, const std::vector<int>& par){
-  for(int val : par){
+void SiStripDetVOffBuilder::printPar(std::stringstream& ss, const std::vector<int>& par) {
+  for (int val : par) {
     ss << val << " ";
   }
 }
 
-void SiStripDetVOffBuilder::BuildDetVOffObj()
-{
+void SiStripDetVOffBuilder::BuildDetVOffObj() {
   // vectors for storing output from DB or text file
   TimesAndValues timesAndValues;
 
   // Open the PVSS DB connection
-  coralInterface.reset( new SiStripCoralIface(onlineDbConnectionString, authenticationPath, debug_) );
-  edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Query type is " << whichTable << endl;
+  coralInterface.reset(new SiStripCoralIface(onlineDbConnectionString, authenticationPath, debug_));
+  edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Query type is " << whichTable
+                                         << endl;
 
-  if (whichTable == "LASTVALUE") {edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Use file? " << ((fromFile) ? "TRUE" : "FALSE");}
+  if (whichTable == "LASTVALUE") {
+    edm::LogError("SiStripDetVOffBuilder")
+        << "[SiStripDetVOffBuilder::BuildDetVOff]: Use file? " << ((fromFile) ? "TRUE" : "FALSE");
+  }
 
-  if (lastStoredCondObj.second > 0) {edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: retrieved last time stamp from DB: " 
-									    << lastStoredCondObj.second  << endl;}
+  if (lastStoredCondObj.second > 0) {
+    edm::LogError("SiStripDetVOffBuilder")
+        << "[SiStripDetVOffBuilder::BuildDetVOff]: retrieved last time stamp from DB: " << lastStoredCondObj.second
+        << endl;
+  }
   // access the information!
   //We've been using the STATUSCHANGE query only in last year or so... LASTVALUE may have untested issues...
   //In either case the idea is that the results of the query are saved into the timesAndValues struct
   //ready to be anaylized (i.e. translated into detIDs, HV/LV statuses)
 
   if (whichQuery) {
-    if( whichTable == "STATUSCHANGE" ) {
-      statusChange( lastStoredCondObj.second, timesAndValues );
+    if (whichTable == "STATUSCHANGE") {
+      statusChange(lastStoredCondObj.second, timesAndValues);
     }
-    if( whichTable == "LASTVALUE" ) {
-      if( fromFile ) {
-	lastValueFromFile(timesAndValues);
-      }
-      else {
-	lastValue(timesAndValues);
+    if (whichTable == "LASTVALUE") {
+      if (fromFile) {
+        lastValueFromFile(timesAndValues);
+      } else {
+        lastValue(timesAndValues);
       }
     }
   }
 
-  //Initialize the stuct that will be used to keep the detID-translated information 
+  //Initialize the stuct that will be used to keep the detID-translated information
   DetIdListTimeAndStatus dStruct;
 
   // build PSU - det ID map
@@ -127,11 +139,9 @@ void SiStripDetVOffBuilder::BuildDetVOffObj()
   //populating the DetIDListTimeAndStatus struct that will hold the information by detid.
   buildPSUdetIdMap(timesAndValues, dStruct);
 
-
   // initialize variables
   modulesOff.clear();
   cond::Time_t saveIovTime = 0;
-  
 
   // - If there is already an object stored in the database
   // -- store it in the modulesOff vector
@@ -143,37 +153,38 @@ void SiStripDetVOffBuilder::BuildDetVOffObj()
   // --- LASTVALUE -> iovtime settato a latestTime
   // --- altrimenti iovtime = tempo associato al detId vector del loop
 
-
   // check if there is already an object stored in the DB
   // This happens only if you are using STATUSCHANGE
   if (lastStoredCondObj.first != nullptr && lastStoredCondObj.second > 0) {
-    modulesOff.push_back( lastStoredCondObj );
+    modulesOff.push_back(lastStoredCondObj);
     saveIovTime = lastStoredCondObj.second;
     setPayloadStats(0, 0, 0);
   }
 
-
   //Master loop over all the results of the query stored in the dStruct (that contains vectors with vectors of detids, statuses, isHV flags, etc and in particular a vector of timestamps for which the info is valid... basically it is a loop over the timestamps (i.e. IOVs).
   for (unsigned int i = 0; i < dStruct.detidV.size(); i++) {
- 
     //     std::vector<uint32_t> detids = dStruct.detidV[i].first;
     //     removeDuplicates(detids);
-    std::vector<uint32_t> * detids = &(dStruct.detidV[i].first);
+    std::vector<uint32_t>* detids = &(dStruct.detidV[i].first);
 
     // set the condition time for the transfer
     cond::Time_t iovtime = 0;
 
-    if (whichTable == "LASTVALUE") {iovtime = timesAndValues.latestTime;}
+    if (whichTable == "LASTVALUE") {
+      iovtime = timesAndValues.latestTime;
+    }
 
-    else {iovtime = getCondTime((dStruct.detidV[i]).second);}
+    else {
+      iovtime = getCondTime((dStruct.detidV[i]).second);
+    }
 
     // decide how to initialize modV
-    SiStripDetVOff *modV = nullptr;
+    SiStripDetVOff* modV = nullptr;
 
     // When using STATUSCHANGE they are equal only for the first
     // When using LASTVALUE they are equal only if the tmin was set to tsetmin
 
-    if (iovtime != saveIovTime) { // time is different, so create new object
+    if (iovtime != saveIovTime) {  // time is different, so create new object
 
       // This can be only when using LASTVALUE or with a new tag
       if (modulesOff.empty()) {
@@ -183,57 +194,62 @@ void SiStripDetVOffBuilder::BuildDetVOffObj()
         // Use the file
         edm::FileInPath fp(detIdListFile_);
         SiStripDetInfoFileReader reader(fp.fullPath());
-        const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >& detInfos  = reader.getAllData();
+        const std::map<uint32_t, SiStripDetInfoFileReader::DetInfo>& detInfos = reader.getAllData();
 
-	//FIXME:
-	//Following code is actually broken (well not until the cfg has "" for excludedDetIDListFile parameter!
-	//Fix it if felt necessary (remember that it assumes that whatever detids are excluded should NOT be in the regular map
-	//breaking our current situation with a fully mapped (LV-wise) tracker...
+        //FIXME:
+        //Following code is actually broken (well not until the cfg has "" for excludedDetIDListFile parameter!
+        //Fix it if felt necessary (remember that it assumes that whatever detids are excluded should NOT be in the regular map
+        //breaking our current situation with a fully mapped (LV-wise) tracker...
         // Careful: if a module is in the exclusion list it must be ignored and the initial status is set to ON.
         // These modules are expected to not be in the PSU-DetId map, so they will never get any status change from the query.
         SiStripPsuDetIdMap map;
-	std::vector< std::pair<uint32_t, std::string> > excludedDetIdMap;
-        if( !excludedDetIdListFile_.empty() ) {
+        std::vector<std::pair<uint32_t, std::string> > excludedDetIdMap;
+        if (!excludedDetIdListFile_.empty()) {
           map.BuildMap(excludedDetIdListFile_, excludedDetIdMap);
         }
-        for(std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >::const_iterator it = detInfos.begin(); it != detInfos.end(); ++it) {
-	  std::vector< std::pair<uint32_t, std::string> >::const_iterator exclIt = excludedDetIdMap.begin();
+        for (std::map<uint32_t, SiStripDetInfoFileReader::DetInfo>::const_iterator it = detInfos.begin();
+             it != detInfos.end();
+             ++it) {
+          std::vector<std::pair<uint32_t, std::string> >::const_iterator exclIt = excludedDetIdMap.begin();
           bool excluded = false;
-          for( ; exclIt != excludedDetIdMap.end(); ++exclIt ) {
-            if( it->first == exclIt->first ) {
+          for (; exclIt != excludedDetIdMap.end(); ++exclIt) {
+            if (it->first == exclIt->first) {
               excluded = true;
               break;
             }
           }
-          if( !excluded ) {
-            modV->put( it->first, 1, 1 );
+          if (!excluded) {
+            modV->put(it->first, 1, 1);
           }
         }
 
-      }
-      else {modV = new SiStripDetVOff( *(modulesOff.back().first) );} // start from copy of previous object
-    }
-    else {
-      modV = (modulesOff.back()).first; // modify previous object (TEST THIS if possible! it's fundamental in handling changes at the edges of O2O executions and also in case of PVSS DB buffering!
+      } else {
+        modV = new SiStripDetVOff(*(modulesOff.back().first));
+      }  // start from copy of previous object
+    } else {
+      modV =
+          (modulesOff.back())
+              .first;  // modify previous object (TEST THIS if possible! it's fundamental in handling changes at the edges of O2O executions and also in case of PVSS DB buffering!
     }
 
-
-    
     // extract the detID vector before modifying for stats calculation
     std::vector<uint32_t> beforeV;
     modV->getDetIds(beforeV);
 
     //CHECKTHIS
-    //The following method call is potentially problematic: 
+    //The following method call is potentially problematic:
     //passing modV as argument while extracting information about dStruct,
     //modV is not currently used in the method!
-    std::pair<int, int> hvlv = extractDetIdVector(i, modV, dStruct);//Returns a pair like this HV OFF->1,-1 HV ON->0,-1 LV OFF->-1,1 LV ON->-1,0
+    std::pair<int, int> hvlv = extractDetIdVector(
+        i, modV, dStruct);  //Returns a pair like this HV OFF->1,-1 HV ON->0,-1 LV OFF->-1,1 LV ON->-1,0
     //Basically a LV OFF of -1  means that the information (IOV) in question is from an HV channel turning on or off and viceversa for an HVOFF of -1.
     //This could be confusing when reading the debug output!
- 
+
     for (unsigned int j = 0; j < detids->size(); j++) {
-      if( debug_ ) cout << "at time = " << iovtime << " detid["<<j<<"] = " << (*detids)[j] << " has hv = " << hvlv.first << " and lv = " << hvlv.second << endl;
-      modV->put((*detids)[j],hvlv.first,hvlv.second);
+      if (debug_)
+        cout << "at time = " << iovtime << " detid[" << j << "] = " << (*detids)[j] << " has hv = " << hvlv.first
+             << " and lv = " << hvlv.second << endl;
+      modV->put((*detids)[j], hvlv.first, hvlv.second);
     }
 
     // calculate the stats for storage
@@ -245,20 +261,21 @@ void SiStripDetVOffBuilder::BuildDetVOffObj()
     }
     std::vector<uint32_t> afterV;
     modV->getDetIds(afterV);
-    
+
     if ((afterV.size() - beforeV.size()) > 0) {
       numAdded += afterV.size() - beforeV.size();
     } else if ((beforeV.size() - afterV.size()) > 0) {
       numRemoved += beforeV.size() - afterV.size();
     }
 
-    
     // store the object if it's a new object
     if (iovtime != saveIovTime) {
-      SiStripDetVOff * testV = nullptr;
-      if (!modulesOff.empty()) {testV = modulesOff.back().first;}
-      if (modulesOff.empty() ||  !(*modV == *testV) ) {
-        modulesOff.push_back( std::make_pair(modV,iovtime) );
+      SiStripDetVOff* testV = nullptr;
+      if (!modulesOff.empty()) {
+        testV = modulesOff.back().first;
+      }
+      if (modulesOff.empty() || !(*modV == *testV)) {
+        modulesOff.push_back(std::make_pair(modV, iovtime));
         // save the time of the object
         saveIovTime = iovtime;
         // save stats
@@ -274,21 +291,20 @@ void SiStripDetVOffBuilder::BuildDetVOffObj()
     }
   }
 
-
   // compare the first element and the last from previous transfer
   if (lastStoredCondObj.first != nullptr && lastStoredCondObj.second > 0) {
-    if ( *(lastStoredCondObj.first) == *(modulesOff[0].first) ) {
-      if ( modulesOff.size() == 1 ){
+    if (*(lastStoredCondObj.first) == *(modulesOff[0].first)) {
+      if (modulesOff.size() == 1) {
         // if no HV/LV transition was found in this period: update the last IOV to be tmax
         modulesOff[0].second = getCondTime(tmax);
-      }else{
+      } else {
         // HV/LV transitions found: remove the first one (which came from previous transfer)
         modulesOff.erase(modulesOff.begin());
         payloadStats.erase(payloadStats.begin());
       }
     }
   }
-  
+
   if (debug_) {
     std::cout << std::endl;
     std::cout << "Size of modulesOff = " << modulesOff.size() << std::endl;
@@ -298,22 +314,32 @@ void SiStripDetVOffBuilder::BuildDetVOffObj()
       std::cout << "Index = " << i << " Size of DetIds vector = " << finalids.size() << std::endl;
       std::cout << "Time = " << modulesOff[i].second << std::endl;
       for (unsigned int j = 0; j < finalids.size(); j++) {
-	std::cout << "detid = " << finalids[j] << " LV off = " << (modulesOff[i].first)->IsModuleLVOff(finalids[j]) << " HV off = " 
-		  << (modulesOff[i].first)->IsModuleHVOff(finalids[j]) << std::endl;
+        std::cout << "detid = " << finalids[j] << " LV off = " << (modulesOff[i].first)->IsModuleLVOff(finalids[j])
+                  << " HV off = " << (modulesOff[i].first)->IsModuleHVOff(finalids[j]) << std::endl;
       }
     }
   }
 }
 
-int SiStripDetVOffBuilder::findSetting(uint32_t id, const coral::TimeStamp& changeDate, const std::vector<uint32_t>& settingID, const std::vector<coral::TimeStamp>& settingDate) {
+int SiStripDetVOffBuilder::findSetting(uint32_t id,
+                                       const coral::TimeStamp& changeDate,
+                                       const std::vector<uint32_t>& settingID,
+                                       const std::vector<coral::TimeStamp>& settingDate) {
   int setting = -1;
   // find out how many channel entries there are
   std::vector<int> locations;
-  for (unsigned int i = 0; i < settingID.size(); i++) { if (settingID[i] == id) {locations.push_back((int)i);} }
+  for (unsigned int i = 0; i < settingID.size(); i++) {
+    if (settingID[i] == id) {
+      locations.push_back((int)i);
+    }
+  }
 
   // simple cases
-  if (locations.empty()) {setting = -1;}
-  else if (locations.size() == 1) {setting = locations[0];}
+  if (locations.empty()) {
+    setting = -1;
+  } else if (locations.size() == 1) {
+    setting = locations[0];
+  }
   // more than one entry for this channel
   // NB.  entries ordered by date!
   else {
@@ -325,21 +351,33 @@ int SiStripDetVOffBuilder::findSetting(uint32_t id, const coral::TimeStamp& chan
       long testSec = changeDate.time().ns();
       long limitSec = settingDate[(unsigned int)locations[j]].time().ns();
 #endif
-      if (testSec >= limitSec) {setting = locations[j];}
+      if (testSec >= limitSec) {
+        setting = locations[j];
+      }
     }
   }
   return setting;
 }
 
-int SiStripDetVOffBuilder::findSetting(std::string dpname, const coral::TimeStamp& changeDate, const std::vector<std::string>& settingDpname, const std::vector<coral::TimeStamp>& settingDate) {
+int SiStripDetVOffBuilder::findSetting(std::string dpname,
+                                       const coral::TimeStamp& changeDate,
+                                       const std::vector<std::string>& settingDpname,
+                                       const std::vector<coral::TimeStamp>& settingDate) {
   int setting = -1;
   // find out how many channel entries there are
   std::vector<int> locations;
-  for (unsigned int i = 0; i < settingDpname.size(); i++) { if (settingDpname[i] == dpname) {locations.push_back((int)i);} }
-  
+  for (unsigned int i = 0; i < settingDpname.size(); i++) {
+    if (settingDpname[i] == dpname) {
+      locations.push_back((int)i);
+    }
+  }
+
   // simple cases
-  if (locations.empty()) {setting = -1;}
-  else if (locations.size() == 1) {setting = locations[0];}
+  if (locations.empty()) {
+    setting = -1;
+  } else if (locations.size() == 1) {
+    setting = locations[0];
+  }
   // more than one entry for this channel
   // NB.  entries ordered by date!
   else {
@@ -351,16 +389,21 @@ int SiStripDetVOffBuilder::findSetting(std::string dpname, const coral::TimeStam
       long testSec = changeDate.time().ns();
       long limitSec = settingDate[(unsigned int)locations[j]].time().ns();
 #endif
-      if (testSec >= limitSec) {setting = locations[j];}
+      if (testSec >= limitSec) {
+        setting = locations[j];
+      }
     }
   }
   return setting;
 }
 
-void SiStripDetVOffBuilder::readLastValueFromFile(std::vector<uint32_t> &dpIDs, std::vector<float> &vmonValues, std::vector<coral::TimeStamp> &dateChange) {
+void SiStripDetVOffBuilder::readLastValueFromFile(std::vector<uint32_t>& dpIDs,
+                                                  std::vector<float>& vmonValues,
+                                                  std::vector<coral::TimeStamp>& dateChange) {
   std::ifstream lastValueFile(lastValueFileName.c_str());
   if (lastValueFile.bad()) {
-    edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::" << __func__ << "]: last Value file does not exist!";
+    edm::LogError("SiStripDetVOffBuilder")
+        << "[SiStripDetVOffBuilder::" << __func__ << "]: last Value file does not exist!";
     return;
   }
 
@@ -374,7 +417,7 @@ void SiStripDetVOffBuilder::readLastValueFromFile(std::vector<uint32_t> &dpIDs, 
   //  std::getline(lastValueFile,line);
   //  line.clear();
   // now extract data
-  while( std::getline(lastValueFile,line) ) {
+  while (std::getline(lastValueFile, line)) {
     std::istringstream ss(line);
     uint32_t dpid;
     float vmon;
@@ -384,43 +427,44 @@ void SiStripDetVOffBuilder::readLastValueFromFile(std::vector<uint32_t> &dpIDs, 
     vmonValues.push_back(vmon);
     changeDates.push_back(changeDate);
   }
-  lastValueFile.close();  
+  lastValueFile.close();
 
   // Now convert dates to coral::TimeStamp
   for (unsigned int i = 0; i < changeDates.size(); i++) {
-    std::string part = changeDates[i].substr(0,4);
+    std::string part = changeDates[i].substr(0, 4);
     int year = atoi(part.c_str());
     part.clear();
 
-    part = changeDates[i].substr(5,2);
+    part = changeDates[i].substr(5, 2);
     int month = atoi(part.c_str());
     part.clear();
 
-    part = changeDates[i].substr(8,2);
+    part = changeDates[i].substr(8, 2);
     int day = atoi(part.c_str());
     part.clear();
 
-    part = changeDates[i].substr(11,2);
+    part = changeDates[i].substr(11, 2);
     int hour = atoi(part.c_str());
     part.clear();
 
-    part = changeDates[i].substr(14,2);
+    part = changeDates[i].substr(14, 2);
     int minute = atoi(part.c_str());
     part.clear();
 
-    part = changeDates[i].substr(17,2);
+    part = changeDates[i].substr(17, 2);
     int second = atoi(part.c_str());
     part.clear();
 
-    coral::TimeStamp date(year,month,day,hour,minute,second,0);
+    coral::TimeStamp date(year, month, day, hour, minute, second, 0);
     dateChange.push_back(date);
   }
 
-  if (changeDates.size() != dateChange.size()) {edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::" << __func__ << "]: date conversion failed!!";}
+  if (changeDates.size() != dateChange.size()) {
+    edm::LogError("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::" << __func__ << "]: date conversion failed!!";
+  }
 }
 
 cond::Time_t SiStripDetVOffBuilder::getCondTime(const coral::TimeStamp& coralTime) {
-
   // const boost::posix_time::ptime& t = coralTime.time();
   cond::Time_t condTime = cond::time::from_boost(coralTime.time());
 
@@ -430,47 +474,44 @@ cond::Time_t SiStripDetVOffBuilder::getCondTime(const coral::TimeStamp& coralTim
   return condTime;
 }
 
-coral::TimeStamp SiStripDetVOffBuilder::getCoralTime(cond::Time_t iovTime)
-{
+coral::TimeStamp SiStripDetVOffBuilder::getCoralTime(cond::Time_t iovTime) {
   // This method is defined in the TimeConversions header and it does the following:
   // - takes the seconds part of the iovTime (bit-shifting of 32)
   // - adds the nanoseconds part (first 32 bits mask)
   // - adds the time0 that is the time from begin of times (boost::posix_time::from_time_t(0);)
   coral::TimeStamp coralTime(cond::time::to_boost(iovTime));
 
-  if( debug_ ) {
+  if (debug_) {
     unsigned long long iovSec = iovTime >> 32;
     uint32_t iovNanoSec = uint32_t(iovTime);
-    cond::Time_t testTime=getCondTime(coralTime);
+    cond::Time_t testTime = getCondTime(coralTime);
     cout << "[SiStripDetVOffBuilder::getCoralTime] Converting CondTime into CoralTime: "
-	 << " condTime = " <<  iovSec << " - " << iovNanoSec 
-	 << " getCondTime(coralTime) = " << (testTime>>32) << " - " << (testTime&0xFFFFFFFF)  << endl;
+         << " condTime = " << iovSec << " - " << iovNanoSec << " getCondTime(coralTime) = " << (testTime >> 32) << " - "
+         << (testTime & 0xFFFFFFFF) << endl;
   }
 
   return coralTime;
 }
 
-void SiStripDetVOffBuilder::removeDuplicates( std::vector<uint32_t> & vec ) {
-  std::sort(vec.begin(),vec.end());
-  std::vector<uint32_t>::iterator it = std::unique(vec.begin(),vec.end());
-  vec.resize( it - vec.begin() );
+void SiStripDetVOffBuilder::removeDuplicates(std::vector<uint32_t>& vec) {
+  std::sort(vec.begin(), vec.end());
+  std::vector<uint32_t>::iterator it = std::unique(vec.begin(), vec.end());
+  vec.resize(it - vec.begin());
 }
 
-void SiStripDetVOffBuilder::setLastSiStripDetVOff( SiStripDetVOff * lastPayload, cond::Time_t lastTimeStamp ) {
+void SiStripDetVOffBuilder::setLastSiStripDetVOff(SiStripDetVOff* lastPayload, cond::Time_t lastTimeStamp) {
   lastStoredCondObj.first = lastPayload;
   lastStoredCondObj.second = lastTimeStamp;
 }
 
-cond::Time_t SiStripDetVOffBuilder::findMostRecentTimeStamp( const std::vector<coral::TimeStamp>& coralDate ) {
+cond::Time_t SiStripDetVOffBuilder::findMostRecentTimeStamp(const std::vector<coral::TimeStamp>& coralDate) {
   cond::Time_t latestDate = getCondTime(coralDate[0]);
-  
-  if( debug_ ) {
-    std::cout << "latestDate: condTime = " 
-	      << (latestDate>>32) 
-	      << " - " 
-	      << (latestDate&0xFFFFFFFF) 
-      //<< " coralTime= " << coralDate[0] 
-	      << std::endl;
+
+  if (debug_) {
+    std::cout << "latestDate: condTime = " << (latestDate >> 32) << " - "
+              << (latestDate & 0xFFFFFFFF)
+              //<< " coralTime= " << coralDate[0]
+              << std::endl;
   }
 
   for (unsigned int i = 1; i < coralDate.size(); i++) {
@@ -482,112 +523,116 @@ cond::Time_t SiStripDetVOffBuilder::findMostRecentTimeStamp( const std::vector<c
   return latestDate;
 }
 
-void SiStripDetVOffBuilder::reduce( std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator & it,
-				    std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator & initialIt,
-				    std::vector< std::pair<SiStripDetVOff*,cond::Time_t> > & resultVec,
-				    const bool last )
-{
+void SiStripDetVOffBuilder::reduce(std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator& it,
+                                   std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator& initialIt,
+                                   std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >& resultVec,
+                                   const bool last) {
   //const bool last is set to false by default in the header file...
   int first = 0;
   // Check if it is the first
-  if( distance(resultVec.begin(), initialIt) == 0 ) {
+  if (distance(resultVec.begin(), initialIt) == 0) {
     first = 1;
   }
 
-  if( debug_ && ( it->first->getLVoffCounts() - initialIt->first->getLVoffCounts() == 0 ) && ( it->first->getHVoffCounts() - initialIt->first->getHVoffCounts() == 0 ) ) {
-    cout << "Same number of LV and HV at start and end of sequence: LV off = " << it->first->getLVoffCounts() << " HV off = " << it->first->getHVoffCounts() << endl;
+  if (debug_ && (it->first->getLVoffCounts() - initialIt->first->getLVoffCounts() == 0) &&
+      (it->first->getHVoffCounts() - initialIt->first->getHVoffCounts() == 0)) {
+    cout << "Same number of LV and HV at start and end of sequence: LV off = " << it->first->getLVoffCounts()
+         << " HV off = " << it->first->getHVoffCounts() << endl;
   }
 
   // if it was going off
-  if( ( it->first->getLVoffCounts() - initialIt->first->getLVoffCounts() > 0 ) || ( it->first->getHVoffCounts() - initialIt->first->getHVoffCounts() > 0 ) ) {
+  if ((it->first->getLVoffCounts() - initialIt->first->getLVoffCounts() > 0) ||
+      (it->first->getHVoffCounts() - initialIt->first->getHVoffCounts() > 0)) {
     // Set the time of the current (last) iov as the time of the initial iov of the sequence
     // replace the first iov with the last one
-    //Naughty use of const bool last... by default it is false (=0), and for the case of the last timestamp in the query results it is set to true(=1) in the call 
-    (it+last)->second = (initialIt)->second;
+    //Naughty use of const bool last... by default it is false (=0), and for the case of the last timestamp in the query results it is set to true(=1) in the call
+    (it + last)->second = (initialIt)->second;
     discardIOVs(it, initialIt, resultVec, last, 0);
-    if( debug_ ) cout << "Reducing IOV sequence (going off)" << endl;
+    if (debug_)
+      cout << "Reducing IOV sequence (going off)" << endl;
   }
   // if it was going on
-  else if( ( it->first->getLVoffCounts() - initialIt->first->getLVoffCounts() <= 0 ) || ( it->first->getHVoffCounts() - initialIt->first->getHVoffCounts() <= 0 ) ) {
+  else if ((it->first->getLVoffCounts() - initialIt->first->getLVoffCounts() <= 0) ||
+           (it->first->getHVoffCounts() - initialIt->first->getHVoffCounts() <= 0)) {
     // replace the last minus one iov with the first one
     discardIOVs(it, initialIt, resultVec, last, first);
-    if( debug_ ) cout << "Reducing IOV sequence (going on)" << endl;
+    if (debug_)
+      cout << "Reducing IOV sequence (going on)" << endl;
   }
 }
 
-void SiStripDetVOffBuilder::discardIOVs( std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator & it,
-                                         std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator & initialIt,
-                                         std::vector< std::pair<SiStripDetVOff*,cond::Time_t> > & resultVec,
-                                         const bool last, const unsigned int first )
-{
-  if( debug_ ) {
-    cout << "first (1->means the sequence started at the first timestamp in the query results, 0-> that it did not)= " << first << endl;
-    cout << "initial->first (initial SiStripDetVOff object of the IOV sequence)= " << initialIt->first << ", second (initial timestamp of the IOV sequence) = " << initialIt->second << endl;
-    cout << "last (0->means that the sequence is not ending with the last item in the query results, 1-> that it DOES!)= " << last << endl;
+void SiStripDetVOffBuilder::discardIOVs(std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator& it,
+                                        std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator& initialIt,
+                                        std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >& resultVec,
+                                        const bool last,
+                                        const unsigned int first) {
+  if (debug_) {
+    cout << "first (1->means the sequence started at the first timestamp in the query results, 0-> that it did not)= "
+         << first << endl;
+    cout << "initial->first (initial SiStripDetVOff object of the IOV sequence)= " << initialIt->first
+         << ", second (initial timestamp of the IOV sequence) = " << initialIt->second << endl;
+    cout << "last (0->means that the sequence is not ending with the last item in the query results, 1-> that it "
+            "DOES!)= "
+         << last << endl;
   }
-  if( last == true ) {
-    resultVec.erase(initialIt+first, it+1);
+  if (last == true) {
+    resultVec.erase(initialIt + first, it + 1);
     // Minus 2 because it will be incremented at the end of the loop becoming end()-1.
-    it = resultVec.end()-2;
-  }
-  else {
-    it = resultVec.erase(initialIt+first, it);
+    it = resultVec.end() - 2;
+  } else {
+    it = resultVec.erase(initialIt + first, it);
   }
 }
 
 //This is the method that (called by GetModulesOff, declared in the header file) executes the reduction by massaging modulesOff
-void SiStripDetVOffBuilder::reduction(const uint32_t deltaTmin, const uint32_t maxIOVlength)
-{
-
+void SiStripDetVOffBuilder::reduction(const uint32_t deltaTmin, const uint32_t maxIOVlength) {
   int count = 0;
-  std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator initialIt;
+  std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator initialIt;
 
   int resultVecSize = modulesOff.size();
   int resultsIndex = 0;
 
-  if( resultVecSize > 1 ) {
-  std::vector< std::pair<SiStripDetVOff*,cond::Time_t> >::iterator it = modulesOff.begin();
-    for( ; it != modulesOff.end()-1; ++it, ++resultsIndex ) {
-      unsigned long long deltaT = ((it+1)->second - it->second) >> 32;
+  if (resultVecSize > 1) {
+    std::vector<std::pair<SiStripDetVOff*, cond::Time_t> >::iterator it = modulesOff.begin();
+    for (; it != modulesOff.end() - 1; ++it, ++resultsIndex) {
+      unsigned long long deltaT = ((it + 1)->second - it->second) >> 32;
       unsigned long long deltaTsequence = 0;
-      if( count > 1 ) {
-	deltaTsequence = ((it+1)->second - initialIt->second) >> 32;
+      if (count > 1) {
+        deltaTsequence = ((it + 1)->second - initialIt->second) >> 32;
       }
       // Save the initial pair
-      if( (deltaT < deltaTmin) && ( (count == 0) || ( deltaTsequence < maxIOVlength ) ) ) {
-	// If we are not in a the sequence
-	if( count == 0 ) {
-	  initialIt = it;
-	}
-	// Increase the counter in any case.
-	++count;
+      if ((deltaT < deltaTmin) && ((count == 0) || (deltaTsequence < maxIOVlength))) {
+        // If we are not in a the sequence
+        if (count == 0) {
+          initialIt = it;
+        }
+        // Increase the counter in any case.
+        ++count;
       }
       // We do it only if the sequence is bigger than two cases
-      else if( count > 1 ) {
-	reduce(it, initialIt, modulesOff);
-	// reset all
-	count = 0;
-      }
-      else {
-	// reset all
-	count = 0;
+      else if (count > 1) {
+        reduce(it, initialIt, modulesOff);
+        // reset all
+        count = 0;
+      } else {
+        // reset all
+        count = 0;
       }
       // Border case
-      if( resultsIndex == resultVecSize-2 && count != 0 ) {
-	reduce(it, initialIt, modulesOff, true);
+      if (resultsIndex == resultVecSize - 2 && count != 0) {
+        reduce(it, initialIt, modulesOff, true);
       }
     }
   }
 }
 
-void SiStripDetVOffBuilder::statusChange( cond::Time_t & lastTime, TimesAndValues & tStruct )
-{
+void SiStripDetVOffBuilder::statusChange(cond::Time_t& lastTime, TimesAndValues& tStruct) {
   // Setting tmin to the last value IOV of the database tag
-  if( lastTime > 0 ) {
+  if (lastTime > 0) {
     tmin = getCoralTime(lastTime);
   }
-  
-  coralInterface->doQuery(whichTable, tmin ,tmax, tStruct.changeDate, tStruct.actualValue, tStruct.dpname);
+
+  coralInterface->doQuery(whichTable, tmin, tmax, tStruct.changeDate, tStruct.actualValue, tStruct.dpname);
   //UNIT TEST DEBUG to bypass the query wait time!!!
   //coral::TimeStamp testtime=getCoralTime(lastTime);
   //tStruct.changeDate.push_back(testtime);
@@ -597,74 +642,82 @@ void SiStripDetVOffBuilder::statusChange( cond::Time_t & lastTime, TimesAndValue
   // preset the size of the status vector
   tStruct.actualStatus.resize(tStruct.actualValue.size());
   tStruct.actualStatus.clear();
-  
-  for(float val : tStruct.actualValue) {
+
+  for (float val : tStruct.actualValue) {
     tStruct.actualStatus.push_back(static_cast<int>(val));
   }
 }
 
-void SiStripDetVOffBuilder::lastValue(TimesAndValues & tStruct)
-{
-  coralInterface->doQuery(whichTable, tmin ,tmax, tStruct.changeDate, tStruct.actualValue, tStruct.dpname);
-  
-  tStruct.latestTime = findMostRecentTimeStamp( tStruct.changeDate );
-  
+void SiStripDetVOffBuilder::lastValue(TimesAndValues& tStruct) {
+  coralInterface->doQuery(whichTable, tmin, tmax, tStruct.changeDate, tStruct.actualValue, tStruct.dpname);
+
+  tStruct.latestTime = findMostRecentTimeStamp(tStruct.changeDate);
+
   // preset the size of the status vector
   tStruct.actualStatus.resize(tStruct.actualValue.size());
-  
+
   // retrieve the channel settings from the PVSS DB
   std::vector<coral::TimeStamp> settingDate;
   std::vector<float> settingValue;
   std::vector<std::string> settingDpname;
   std::vector<uint32_t> settingDpid;
-  coralInterface->doSettingsQuery(tsetmin,tmax,settingDate,settingValue,settingDpname,settingDpid);
+  coralInterface->doSettingsQuery(tsetmin, tmax, settingDate, settingValue, settingDpname, settingDpid);
   LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Channel settings retrieved";
-  LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Number of PSU channels: " << settingDpname.size();
-    
+  LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Number of PSU channels: "
+                                    << settingDpname.size();
+
   unsigned int missing = 0;
   std::stringstream ss;
   for (unsigned int j = 0; j < tStruct.dpname.size(); j++) {
-    int setting = findSetting(tStruct.dpname[j],tStruct.changeDate[j],settingDpname,settingDate);
+    int setting = findSetting(tStruct.dpname[j], tStruct.changeDate[j], settingDpname, settingDate);
     if (setting >= 0) {
-      if (tStruct.actualValue[j] > (highVoltageOnThreshold_*(settingValue[setting]))) {tStruct.actualStatus[j] = 1;}
-      else {tStruct.actualStatus[j] = 0;}
+      if (tStruct.actualValue[j] > (highVoltageOnThreshold_ * (settingValue[setting]))) {
+        tStruct.actualStatus[j] = 1;
+      } else {
+        tStruct.actualStatus[j] = 0;
+      }
     } else {
       tStruct.actualStatus[j] = -1;
       missing++;
       ss << "Channel = " << tStruct.dpname[j] << std::endl;
     }
   }
-  LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Number of channels with no setting information " << missing;
-  LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Number of entries in dpname vector " << tStruct.dpname.size();
+  LogDebug("SiStripDetVOffBuilder")
+      << "[SiStripDetVOffBuilder::BuildDetVOff]: Number of channels with no setting information " << missing;
+  LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Number of entries in dpname vector "
+                                    << tStruct.dpname.size();
 }
 
-void SiStripDetVOffBuilder::lastValueFromFile(TimesAndValues & tStruct)
-{
-  readLastValueFromFile(tStruct.dpid,tStruct.actualValue,tStruct.changeDate);
-  tStruct.latestTime = findMostRecentTimeStamp( tStruct.changeDate );
-  LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: File access complete \n\t Number of values read from file: " << tStruct.dpid.size();
-  
+void SiStripDetVOffBuilder::lastValueFromFile(TimesAndValues& tStruct) {
+  readLastValueFromFile(tStruct.dpid, tStruct.actualValue, tStruct.changeDate);
+  tStruct.latestTime = findMostRecentTimeStamp(tStruct.changeDate);
+  LogDebug("SiStripDetVOffBuilder")
+      << "[SiStripDetVOffBuilder::BuildDetVOff]: File access complete \n\t Number of values read from file: "
+      << tStruct.dpid.size();
+
   // retrieve the channel settings from the PVSS DB
   std::vector<coral::TimeStamp> settingDate;
   std::vector<float> settingValue;
   std::vector<std::string> settingDpname;
   std::vector<uint32_t> settingDpid;
-  
-  coralInterface->doSettingsQuery(tsetmin,tmax,settingDate,settingValue,settingDpname,settingDpid);
+
+  coralInterface->doSettingsQuery(tsetmin, tmax, settingDate, settingValue, settingDpname, settingDpid);
   LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Channel settings retrieved";
-  LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Number of PSU channels: " << settingDpname.size();
-  
+  LogDebug("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff]: Number of PSU channels: "
+                                    << settingDpname.size();
+
   unsigned int missing = 0;
   std::stringstream ss;
   // need to get the PSU channel names from settings
   tStruct.dpname.clear();
-  tStruct.dpname.resize(tStruct. dpid.size());
+  tStruct.dpname.resize(tStruct.dpid.size());
   for (unsigned int j = 0; j < tStruct.dpid.size(); j++) {
-    int setting = findSetting(tStruct.dpid[j],tStruct.changeDate[j],settingDpid,settingDate);
+    int setting = findSetting(tStruct.dpid[j], tStruct.changeDate[j], settingDpid, settingDate);
     if (setting >= 0) {
-      if (tStruct.actualValue[j] > (highVoltageOnThreshold_*settingValue[setting])) {tStruct.actualStatus[j] = 1;}
-      else {
-	tStruct.actualStatus[j] = 0;
+      if (tStruct.actualValue[j] > (highVoltageOnThreshold_ * settingValue[setting])) {
+        tStruct.actualStatus[j] = 1;
+      } else {
+        tStruct.actualStatus[j] = 0;
       }
       tStruct.dpname[j] = settingDpname[setting];
     } else {
@@ -678,23 +731,17 @@ void SiStripDetVOffBuilder::lastValueFromFile(TimesAndValues & tStruct)
   LogDebug("SiStripDetVOffBuilder") << "IDs are: = " << ss.str();
 }
 
-string SiStripDetVOffBuilder::timeToStream(const cond::Time_t & condTime, const string & comment)
-{
+string SiStripDetVOffBuilder::timeToStream(const cond::Time_t& condTime, const string& comment) {
   stringstream ss;
-  ss << comment << (condTime>> 32) << " - " << (condTime & 0xFFFFFFFF) << std::endl;
+  ss << comment << (condTime >> 32) << " - " << (condTime & 0xFFFFFFFF) << std::endl;
   return ss.str();
 }
 
-string SiStripDetVOffBuilder::timeToStream(const coral::TimeStamp & coralTime, const string & comment)
-{
+string SiStripDetVOffBuilder::timeToStream(const coral::TimeStamp& coralTime, const string& comment) {
   stringstream ss;
-  ss << "Starting from IOV time in the database : year = " << coralTime.year()
-     << ", month = " << coralTime.month()
-     << ", day = " << coralTime.day()
-     << ", hour = " << coralTime.hour()
-     << ", minute = " << coralTime.minute()
-     << ", second = " << coralTime.second()
-     << ", nanosecond = " << coralTime.nanosecond() << std::endl;
+  ss << "Starting from IOV time in the database : year = " << coralTime.year() << ", month = " << coralTime.month()
+     << ", day = " << coralTime.day() << ", hour = " << coralTime.hour() << ", minute = " << coralTime.minute()
+     << ", second = " << coralTime.second() << ", nanosecond = " << coralTime.nanosecond() << std::endl;
   return ss.str();
 }
 bool SiStripDetVOffBuilder::FileExists(string FileName) {
@@ -703,33 +750,33 @@ bool SiStripDetVOffBuilder::FileExists(string FileName) {
   bool Existence;
   int Stat;
   //Try to get file attributes
-  Stat=stat(FileName.c_str(),&FileInfo);
-  if (Stat==0) {
-    Existence=true;
-  }
-  else {
-    Existence=false;
+  Stat = stat(FileName.c_str(), &FileInfo);
+  if (Stat == 0) {
+    Existence = true;
+  } else {
+    Existence = false;
   }
   return Existence;
 }
 
-void SiStripDetVOffBuilder::buildPSUdetIdMap(TimesAndValues & psuStruct, DetIdListTimeAndStatus & detIdStruct)
+void SiStripDetVOffBuilder::buildPSUdetIdMap(TimesAndValues& psuStruct, DetIdListTimeAndStatus& detIdStruct)
 //This function builds a PSU to DetID map one way or the other. Then it processes the psuStruct that contains
 //the results of the CAEN status query to the Online DB, filling the detIdStruct with the detIDs corresponding
 //to the PSU (channel in some cases, PSU only in others) reported in the CAEN status query to the Online DB.
 //It may make sense to split this method eventually.
 {
   SiStripPsuDetIdMap map_;
-  if( psuDetIdMapFile_.empty() ) {
-    std::cout<<"PLEASE provide the name of a valid PSUDetIDMapFile in the cfg: currently still necessary to have a file, soon will access the info straight from the DB!"<<endl;
+  if (psuDetIdMapFile_.empty()) {
+    std::cout << "PLEASE provide the name of a valid PSUDetIDMapFile in the cfg: currently still necessary to have a "
+                 "file, soon will access the info straight from the DB!"
+              << endl;
     //map_.BuildMap();//This method is not currently used (it would try to build a map based on a query to SiStripConfigDB, and the info there is STALE!)
+  } else {
+    map_.BuildMap(psuDetIdMapFile_, debug_);  //This is the method used to build the map.
   }
-  else {
-    map_.BuildMap(psuDetIdMapFile_,debug_); //This is the method used to build the map.
-  }
-  LogTrace("SiStripDetVOffBuilder") <<"[SiStripDetVOffBuilder::BuildDetVOff] PSU(Channel)-detID map(s) built";
+  LogTrace("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::BuildDetVOff] PSU(Channel)-detID map(s) built";
   //Following method to be replaced by printMaps... to print all 4 maps built!
-  map_.printMap(); //This method prints to the info.log file, notice that it is overwritten by each individual O2O job running in the same dir.
+  map_.printMap();  //This method prints to the info.log file, notice that it is overwritten by each individual O2O job running in the same dir.
 
   // use map info to build input for list of objects
   // no need to check for duplicates, as put method for SiStripDetVOff checks for you!
@@ -741,164 +788,178 @@ void SiStripDetVOffBuilder::buildPSUdetIdMap(TimesAndValues & psuStruct, DetIdLi
   //Create 2 extra maps that we'll use to keep track of unmapped and crosstalking detids when turning ON and OFF HV:
   //-unmapped need to be both turned OFF when any HV goes OFF and to be turned ON when both are ON
   //-crosstaling need to be both turned ON when any HV goes ON and to be turned OFF ONLY when BOTH are OFF.
-  std::map<std::string,bool> UnmappedState, CrosstalkingState;
+  std::map<std::string, bool> UnmappedState, CrosstalkingState;
   //Get the HVUnmapped map from the map, so that we can set know which PSU are unmapped:
-  std::map<std::string,std::vector<uint32_t> > UnmappedPSUs=map_.getHVUnmappedMap();
+  std::map<std::string, std::vector<uint32_t> > UnmappedPSUs = map_.getHVUnmappedMap();
   //Check here if there is a file already, otherwise initialize to OFF all channels in these PSU!
   if (FileExists("HVUnmappedChannelState.dat")) {
-    std::cout<<"File HVUnmappedChannelState.dat exists!"<<std::endl;
+    std::cout << "File HVUnmappedChannelState.dat exists!" << std::endl;
     std::ifstream ifs("HVUnmappedChannelState.dat");
     string line;
-    while( getline( ifs, line ) ) {
-      if( !line.empty() ) {
-	// split the line and insert in the map
-	stringstream ss(line);
-	string PSUChannel;
-	bool HVStatus;
-	ss >> PSUChannel;
-	ss >> HVStatus;
-	//Extract the PSU from the PSUChannel (since the HVUnmapped_Map uses PSU as key
-	std::string PSU=PSUChannel.substr(0,PSUChannel.size()-10);
-	//Look for the PSU in the unmapped map!
-	std::map<std::string,std::vector<uint32_t> >::iterator iter=UnmappedPSUs.find(PSU);
-	if (iter!=UnmappedPSUs.end()) {
-	  UnmappedState[PSUChannel]=HVStatus;
-	}
-	else {
-	  std::cout<<"WARNING!!! There are channels in the local file with the channel status for HVUnmapped channels, that ARE NOT CONSIDERED AS UNMAPPED in the current map!"<<std::endl;
-	}
+    while (getline(ifs, line)) {
+      if (!line.empty()) {
+        // split the line and insert in the map
+        stringstream ss(line);
+        string PSUChannel;
+        bool HVStatus;
+        ss >> PSUChannel;
+        ss >> HVStatus;
+        //Extract the PSU from the PSUChannel (since the HVUnmapped_Map uses PSU as key
+        std::string PSU = PSUChannel.substr(0, PSUChannel.size() - 10);
+        //Look for the PSU in the unmapped map!
+        std::map<std::string, std::vector<uint32_t> >::iterator iter = UnmappedPSUs.find(PSU);
+        if (iter != UnmappedPSUs.end()) {
+          UnmappedState[PSUChannel] = HVStatus;
+        } else {
+          std::cout << "WARNING!!! There are channels in the local file with the channel status for HVUnmapped "
+                       "channels, that ARE NOT CONSIDERED AS UNMAPPED in the current map!"
+                    << std::endl;
+        }
       }
-    }//End of the while loop reading and initializing UnmappedState map from file
+    }  //End of the while loop reading and initializing UnmappedState map from file
     //Extra check:
     //Should check if there any HVUnmapped channels in the map that are not listed in the local file!
-    bool MissingChannels=false;
-    for (std::map<std::string, vector<uint32_t> >::iterator it=UnmappedPSUs.begin(); it!=UnmappedPSUs.end(); it++) {
-      std::string chan002=it->first+"channel002";
-      std::string chan003=it->first+"channel003";
-      std::map<std::string,bool>::iterator iter=UnmappedState.find(chan002);
-      if (iter==UnmappedState.end()) {
-	std::cout<<"ERROR! The local file with the channel status for HVUnmapped channels IS MISSING one of the following unmapped channel voltage status information:"<<std::endl;
-	std::cout<<chan002<<std::endl;
-	MissingChannels=true;
+    bool MissingChannels = false;
+    for (std::map<std::string, vector<uint32_t> >::iterator it = UnmappedPSUs.begin(); it != UnmappedPSUs.end(); it++) {
+      std::string chan002 = it->first + "channel002";
+      std::string chan003 = it->first + "channel003";
+      std::map<std::string, bool>::iterator iter = UnmappedState.find(chan002);
+      if (iter == UnmappedState.end()) {
+        std::cout << "ERROR! The local file with the channel status for HVUnmapped channels IS MISSING one of the "
+                     "following unmapped channel voltage status information:"
+                  << std::endl;
+        std::cout << chan002 << std::endl;
+        MissingChannels = true;
       }
-      iter=UnmappedState.find(chan003);
-      if (iter==UnmappedState.end()) {
-	std::cout<<"ERROR! The local file with the channel status for HVUnmapped channels IS MISSING one of the following unmapped channel voltage status information:"<<std::endl;
-	std::cout<<chan003<<std::endl;
-	MissingChannels=true;
+      iter = UnmappedState.find(chan003);
+      if (iter == UnmappedState.end()) {
+        std::cout << "ERROR! The local file with the channel status for HVUnmapped channels IS MISSING one of the "
+                     "following unmapped channel voltage status information:"
+                  << std::endl;
+        std::cout << chan003 << std::endl;
+        MissingChannels = true;
       }
     }
     //Now if any channel WAS missing, exit!
     if (MissingChannels) {
-      std::cout<<"!!!!\n"<<"Exiting now... please check the local HVUnmappedChannelState.dat and the mapfile you provided ("<<psuDetIdMapFile_<<")"<<std::endl;
+      std::cout << "!!!!\n"
+                << "Exiting now... please check the local HVUnmappedChannelState.dat and the mapfile you provided ("
+                << psuDetIdMapFile_ << ")" << std::endl;
       exit(1);
     }
-  }
-  else { //If the file HVUnmappedChannelState.dat does not exist, initialize the map to all OFF. 
-    //(see below for creating the file at the end of the execution with the latest state of unmapped channels. 
-    for (std::map<std::string, vector<uint32_t> >::iterator it=UnmappedPSUs.begin(); it!=UnmappedPSUs.end(); it++) {
-      std::string chan002=it->first+"channel002";
-      std::string chan003=it->first+"channel003";
-      UnmappedState[chan002]=false;
-      UnmappedState[chan003]=false;
+  } else {  //If the file HVUnmappedChannelState.dat does not exist, initialize the map to all OFF.
+    //(see below for creating the file at the end of the execution with the latest state of unmapped channels.
+    for (std::map<std::string, vector<uint32_t> >::iterator it = UnmappedPSUs.begin(); it != UnmappedPSUs.end(); it++) {
+      std::string chan002 = it->first + "channel002";
+      std::string chan003 = it->first + "channel003";
+      UnmappedState[chan002] = false;
+      UnmappedState[chan003] = false;
     }
   }
   //Get the HVCrosstalking map from the map, so that we can set know which PSU are crosstalking:
-  std::map<std::string,std::vector<uint32_t> > CrosstalkingPSUs=map_.getHVCrosstalkingMap();
+  std::map<std::string, std::vector<uint32_t> > CrosstalkingPSUs = map_.getHVCrosstalkingMap();
   //Check here if there is a file already, otherwise initialize to OFF all channels in these PSU!
   if (FileExists("HVCrosstalkingChannelState.dat")) {
-    std::cout<<"File HVCrosstalkingChannelState.dat exists!"<<std::endl;
+    std::cout << "File HVCrosstalkingChannelState.dat exists!" << std::endl;
     std::ifstream ifs("HVCrosstalkingChannelState.dat");
     string line;
-    while( getline( ifs, line ) ) {
-      if( !line.empty() ) {
-	// split the line and insert in the map
-	stringstream ss(line);
-	string PSUChannel;
-	bool HVStatus;
-	ss >> PSUChannel;
-	ss >> HVStatus;
-	//Extract the PSU from the PSUChannel (since the HVCrosstalking_Map uses PSU as key
-	std::string PSU=PSUChannel.substr(0,PSUChannel.size()-10);
-	//Look for the PSU in the unmapped map!
-	std::map<std::string,std::vector<uint32_t> >::iterator iter=CrosstalkingPSUs.find(PSU);
-	if (iter!=CrosstalkingPSUs.end()) {
-	  CrosstalkingState[PSUChannel]=HVStatus;
-	}
-	else {
-	  std::cout<<"WARNING!!! There are channels in the local file with the channel status for HVUnmapped channels, that ARE NOT CONSIDERED AS UNMAPPED in the current map!"<<std::endl;
-	}
+    while (getline(ifs, line)) {
+      if (!line.empty()) {
+        // split the line and insert in the map
+        stringstream ss(line);
+        string PSUChannel;
+        bool HVStatus;
+        ss >> PSUChannel;
+        ss >> HVStatus;
+        //Extract the PSU from the PSUChannel (since the HVCrosstalking_Map uses PSU as key
+        std::string PSU = PSUChannel.substr(0, PSUChannel.size() - 10);
+        //Look for the PSU in the unmapped map!
+        std::map<std::string, std::vector<uint32_t> >::iterator iter = CrosstalkingPSUs.find(PSU);
+        if (iter != CrosstalkingPSUs.end()) {
+          CrosstalkingState[PSUChannel] = HVStatus;
+        } else {
+          std::cout << "WARNING!!! There are channels in the local file with the channel status for HVUnmapped "
+                       "channels, that ARE NOT CONSIDERED AS UNMAPPED in the current map!"
+                    << std::endl;
+        }
       }
-    }//End of the while loop reading and initializing CrosstalkingState map from file
+    }  //End of the while loop reading and initializing CrosstalkingState map from file
     //Extra check:
     //Should check if there any HVCrosstalking channels in the map that are not listed in the local file!
-    bool MissingChannels=false;
-    for (std::map<std::string, vector<uint32_t> >::iterator it=CrosstalkingPSUs.begin(); it!=CrosstalkingPSUs.end(); it++) {
-      std::string chan002=it->first+"channel002";
-      std::string chan003=it->first+"channel003";
-      std::map<std::string,bool>::iterator iter=CrosstalkingState.find(chan002);
-      if (iter==CrosstalkingState.end()) {
-	std::cout<<"ERROR! The local file with the channel status for HVCrosstalking channels IS MISSING one of the following unmapped channel voltage status information:"<<std::endl;
-	std::cout<<chan002<<std::endl;
-	MissingChannels=true;
+    bool MissingChannels = false;
+    for (std::map<std::string, vector<uint32_t> >::iterator it = CrosstalkingPSUs.begin(); it != CrosstalkingPSUs.end();
+         it++) {
+      std::string chan002 = it->first + "channel002";
+      std::string chan003 = it->first + "channel003";
+      std::map<std::string, bool>::iterator iter = CrosstalkingState.find(chan002);
+      if (iter == CrosstalkingState.end()) {
+        std::cout << "ERROR! The local file with the channel status for HVCrosstalking channels IS MISSING one of the "
+                     "following unmapped channel voltage status information:"
+                  << std::endl;
+        std::cout << chan002 << std::endl;
+        MissingChannels = true;
       }
-      iter=CrosstalkingState.find(chan003);
-      if (iter==CrosstalkingState.end()) {
-	std::cout<<"ERROR! The local file with the channel status for HVCrosstalking channels IS MISSING one of the following unmapped channel voltage status information:"<<std::endl;
-	std::cout<<chan003<<std::endl;
-	MissingChannels=true;
+      iter = CrosstalkingState.find(chan003);
+      if (iter == CrosstalkingState.end()) {
+        std::cout << "ERROR! The local file with the channel status for HVCrosstalking channels IS MISSING one of the "
+                     "following unmapped channel voltage status information:"
+                  << std::endl;
+        std::cout << chan003 << std::endl;
+        MissingChannels = true;
       }
     }
     //Now if any channel WAS missing, exit!
     if (MissingChannels) {
-      std::cout<<"!!!!\n"<<"Exiting now... please check the local HVCrosstalkingChannelState.dat and the mapfile you provided ("<<psuDetIdMapFile_<<")"<<std::endl;
+      std::cout << "!!!!\n"
+                << "Exiting now... please check the local HVCrosstalkingChannelState.dat and the mapfile you provided ("
+                << psuDetIdMapFile_ << ")" << std::endl;
       exit(1);
     }
-  }
-  else { //If the file HVCrosstalkingChannelState.dat does not exist, initialize the map to all OFF. 
-    //(see below for creating the file at the end of the execution with the latest state of unmapped channels. 
-    for (std::map<std::string, vector<uint32_t> >::iterator it=CrosstalkingPSUs.begin(); it!=CrosstalkingPSUs.end(); it++) {
-      std::string chan002=it->first+"channel002";
-      std::string chan003=it->first+"channel003";
-      CrosstalkingState[chan002]=false;
-      CrosstalkingState[chan003]=false;
+  } else {  //If the file HVCrosstalkingChannelState.dat does not exist, initialize the map to all OFF.
+    //(see below for creating the file at the end of the execution with the latest state of unmapped channels.
+    for (std::map<std::string, vector<uint32_t> >::iterator it = CrosstalkingPSUs.begin(); it != CrosstalkingPSUs.end();
+         it++) {
+      std::string chan002 = it->first + "channel002";
+      std::string chan003 = it->first + "channel003";
+      CrosstalkingState[chan002] = false;
+      CrosstalkingState[chan003] = false;
     }
   }
-  
+
   if (debug_) {
     //print out the UnmappedState map:
-    std::cout<<"Printing the UnmappedChannelState initial map:"<<std::endl;
-    std::cout<<"PSUChannel\t\tHVON?(true or false)"<<std::endl;
-    for (std::map<std::string,bool>::iterator it=UnmappedState.begin(); it!=UnmappedState.end(); it++) {
-      std::cout<<it->first<<"\t\t"<<it->second<<std::endl;
+    std::cout << "Printing the UnmappedChannelState initial map:" << std::endl;
+    std::cout << "PSUChannel\t\tHVON?(true or false)" << std::endl;
+    for (std::map<std::string, bool>::iterator it = UnmappedState.begin(); it != UnmappedState.end(); it++) {
+      std::cout << it->first << "\t\t" << it->second << std::endl;
     }
     //print out the CrosstalkingState map:
-    std::cout<<"Printing the CrosstalkingChannelState initial map:"<<std::endl;
-    std::cout<<"PSUChannel\t\tHVON?(true or false)"<<std::endl;
-    for (std::map<std::string,bool>::iterator it=CrosstalkingState.begin(); it!=CrosstalkingState.end(); it++) {
-      std::cout<<it->first<<"\t\t"<<it->second<<std::endl;
+    std::cout << "Printing the CrosstalkingChannelState initial map:" << std::endl;
+    std::cout << "PSUChannel\t\tHVON?(true or false)" << std::endl;
+    for (std::map<std::string, bool>::iterator it = CrosstalkingState.begin(); it != CrosstalkingState.end(); it++) {
+      std::cout << it->first << "\t\t" << it->second << std::endl;
     }
   }
-  
+
   //Loop over the psuStruct (DB query results), lopping over the PSUChannels
-  //This will probably change int he future when we will change the query itself 
+  //This will probably change int he future when we will change the query itself
   //to report directly the detIDs associated with a channel
-  //Probably we will report in the query results the detID, the changeDate 
+  //Probably we will report in the query results the detID, the changeDate
   //and whether the channel is HV mapped, HV unmapped, HV crosstalking using a flag...
   for (unsigned int dp = 0; dp < psuStruct.dpname.size(); dp++) {
     //FIX ME:
     //Check if the following if condition can EVER be true!
-    std::string PSUChannel=psuStruct.dpname[dp];
+    std::string PSUChannel = psuStruct.dpname[dp];
     if (PSUChannel != "UNKNOWN") {
-
       // figure out the channel and the PSU individually
-      std::string Channel = PSUChannel.substr(PSUChannel.size()-10); //Channel is the channel, i.e. channel000, channel001 etc
-      std::string PSU = PSUChannel.substr(0,PSUChannel.size()-10);
-      
+      std::string Channel =
+          PSUChannel.substr(PSUChannel.size() - 10);  //Channel is the channel, i.e. channel000, channel001 etc
+      std::string PSU = PSUChannel.substr(0, PSUChannel.size() - 10);
+
       // Get the detIDs corresponding to the given PSU channel using the getDetID function of SiStripPsuDetIdMap.cc
       //NOTA BENE
       //Need to make sure the information is treated consistently here:
-      //The map by convention has 
+      //The map by convention has
       //detID-> channel002 or channel003 IF the channel is HV mapped,
       //detID->channel000 if it is not HV mapped
       //We want to differentiate the behavior depending on the status reported for the channel for channels that are unmapped!
@@ -908,10 +969,10 @@ void SiStripDetVOffBuilder::buildPSUdetIdMap(TimesAndValues & psuStruct, DetIdLi
 
       //Fixed SiStripPSUdetidMap.cc to make sure now getDetID gets the correct list of detIDs:
       //-for channels 000/001 all the detIDs connected to the PSU
-      //-for channels 002/003 HV1/HV2 modules only (exclusively) 
-      //UPDATE for HV channels: 
-      //actually fixed it to report also detIDs listed as 
-      //channel000 on the same supply of channel002 or channel003 
+      //-for channels 002/003 HV1/HV2 modules only (exclusively)
+      //UPDATE for HV channels:
+      //actually fixed it to report also detIDs listed as
+      //channel000 on the same supply of channel002 or channel003
       //and the crosstalking ones (channel999) too..
 
       //Get the detIDs associated with the DPNAME (i.e. PSUChannel) reported by the query
@@ -924,303 +985,332 @@ void SiStripDetVOffBuilder::buildPSUdetIdMap(TimesAndValues & psuStruct, DetIdLi
       //getHvDetID
 
       //Declaring the two vector needed for the HV case in this scope.
-      std::vector<uint32_t> unmapped_ids,crosstalking_ids;
+      std::vector<uint32_t> unmapped_ids, crosstalking_ids;
       bool LVCase;
       //LV CASE
-      if (Channel=="channel000" || Channel=="channel001") {
-	LVCase=true;
-	ids=map_.getLvDetID(PSU); //Since in the LV case only 1 list of detids is returned (unmapped and crosstalking are irrelevant for LV) return the vector directly
+      if (Channel == "channel000" || Channel == "channel001") {
+        LVCase = true;
+        ids = map_.getLvDetID(
+            PSU);  //Since in the LV case only 1 list of detids is returned (unmapped and crosstalking are irrelevant for LV) return the vector directly
       }
       //HV CASE
-      else { //if (Channel=="channel002" || Channel=="channel003") {
-	LVCase=false;
-	map_.getHvDetID(PSUChannel,ids,unmapped_ids,crosstalking_ids); //In the HV case since 3 vectors are filled, use reference parameters
+      else {  //if (Channel=="channel002" || Channel=="channel003") {
+        LVCase = false;
+        map_.getHvDetID(PSUChannel,
+                        ids,
+                        unmapped_ids,
+                        crosstalking_ids);  //In the HV case since 3 vectors are filled, use reference parameters
       }
 
-      if ( debug_ ) {
-	cout <<"dpname["<<dp<<"] = "<<PSUChannel<<", for time = "<<timeToStream(psuStruct.changeDate[dp])<<endl;
-	if (!ids.empty()) {
-	  if (Channel=="channel000" || Channel=="channel001") {
-	    cout << "Corresponding to LV (PSU-)matching detids: "<<endl;
-	    for (unsigned int i_detid=0;i_detid<ids.size();i_detid++) {
-	      cout<< ids[i_detid] << std::endl;
-	    }
-	  }
-	  else {
-	    cout << "Corresponding to straight HV matching detids: "<<endl;
-	    for (unsigned int i_detid=0;i_detid<ids.size();i_detid++) {
-	      cout<< ids[i_detid] << std::endl;
-	    }
-	  }
-	}
-	//The unmapped_ids and crosstalking_ids are only filled for HV channels!
-	if (!unmapped_ids.empty()) {
-	  cout << "Corresponding to HV unmapped (PSU-)matching detids: "<<endl;
-	  for (unsigned int i_detid=0;i_detid<unmapped_ids.size();i_detid++) {
-	    cout<< unmapped_ids[i_detid] << std::endl;
-	  }
-	}
-	if (!crosstalking_ids.empty()) {
-	  cout << "Corresponding to HV crosstalking (PSU-)matching detids: "<<endl;
-	  for (unsigned int i_detid=0;i_detid<crosstalking_ids.size();i_detid++) {
-	    cout<< crosstalking_ids[i_detid] << std::endl;
-	  }
-	}
+      if (debug_) {
+        cout << "dpname[" << dp << "] = " << PSUChannel << ", for time = " << timeToStream(psuStruct.changeDate[dp])
+             << endl;
+        if (!ids.empty()) {
+          if (Channel == "channel000" || Channel == "channel001") {
+            cout << "Corresponding to LV (PSU-)matching detids: " << endl;
+            for (unsigned int i_detid = 0; i_detid < ids.size(); i_detid++) {
+              cout << ids[i_detid] << std::endl;
+            }
+          } else {
+            cout << "Corresponding to straight HV matching detids: " << endl;
+            for (unsigned int i_detid = 0; i_detid < ids.size(); i_detid++) {
+              cout << ids[i_detid] << std::endl;
+            }
+          }
+        }
+        //The unmapped_ids and crosstalking_ids are only filled for HV channels!
+        if (!unmapped_ids.empty()) {
+          cout << "Corresponding to HV unmapped (PSU-)matching detids: " << endl;
+          for (unsigned int i_detid = 0; i_detid < unmapped_ids.size(); i_detid++) {
+            cout << unmapped_ids[i_detid] << std::endl;
+          }
+        }
+        if (!crosstalking_ids.empty()) {
+          cout << "Corresponding to HV crosstalking (PSU-)matching detids: " << endl;
+          for (unsigned int i_detid = 0; i_detid < crosstalking_ids.size(); i_detid++) {
+            cout << crosstalking_ids[i_detid] << std::endl;
+          }
+        }
       }
-	      
+
       //NOW implement the new logic using the detids, unmapped_detids, crosstalking_detids!
 
       //First check whether the channel we're looking at is turning OFF or turning ON!
-      
+
       //TURN OFF case:
       if (psuStruct.actualStatus[dp] != 1) {
-	//Behavior is different for LV vs HV channels:
-	//LV case:
-	if (LVCase) {
-	  //Turn OFF all: 
-	  //-positively matching 
-	  //-unmapped matching
-	  //-crosstalking
-	  //for the LV case all the detids are automatically reported in the ids vector
-	  //unmapped and crosstalking are only differentiated (relevant) for HV.
-	  if (!ids.empty()) {
-	    //debug variables increment
-	    ch0bad++;
-	    ch1bad++;
-	    
-	    //Create a pair with the relevant detIDs (vector) and its timestamp
-	    //And put it in the detidV vector of the detIdStruct that will contain all the 
-	    //results
-	    detIdStruct.detidV.push_back( std::make_pair(ids,psuStruct.changeDate[dp]) );
-	    
-	    //Set the status to OFF
-	    detIdStruct.StatusGood.push_back(false);
-	    
-	    //debug variable population
-	    numLvBad.insert(numLvBad.end(),ids.begin(),ids.end());
+        //Behavior is different for LV vs HV channels:
+        //LV case:
+        if (LVCase) {
+          //Turn OFF all:
+          //-positively matching
+          //-unmapped matching
+          //-crosstalking
+          //for the LV case all the detids are automatically reported in the ids vector
+          //unmapped and crosstalking are only differentiated (relevant) for HV.
+          if (!ids.empty()) {
+            //debug variables increment
+            ch0bad++;
+            ch1bad++;
 
-	    //Set the flag for LV/HV:
-	    detIdStruct.isHV.push_back(0); //LV
+            //Create a pair with the relevant detIDs (vector) and its timestamp
+            //And put it in the detidV vector of the detIdStruct that will contain all the
+            //results
+            detIdStruct.detidV.push_back(std::make_pair(ids, psuStruct.changeDate[dp]));
 
-	    //Set the PSUChannel (I guess for debug purposes?)
-	    detIdStruct.psuName.push_back( PSUChannel );
-	  }
-	}
-	//HV case:
-	else { //if (!LVCase) {
-	  //Debug variables increment:
-	  if (!ids.empty() || !unmapped_ids.empty() || !crosstalking_ids.empty()) {
-	    if (Channel=="channel002") {
-	      ch2bad++;
-	    }
-	    else if (Channel=="channel003") {
-	      ch3bad++;
-	    }
-	  }
-	  //First sum the ids (positively matching detids) and the unmapped_ids (since both should be TURNED OFF):
-	  std::vector<uint32_t> OFFids;
-	  OFFids.insert(OFFids.end(),ids.begin(),ids.end()); //Add the ids (if any!)
-	  OFFids.insert(OFFids.end(),unmapped_ids.begin(),unmapped_ids.end()); //Add the unmapped_ids (if any!)
-	  //Now for the cross-talking ids this is a bit more complicated!
-	  if (!crosstalking_ids.empty()) {//This already means that the PSUChannel is one of the crosstalking ones (even if only a few modules in that PSU are showing crosstalking behavior both its channels have to be considered crosstalking of course!
-	    //Set the channel OFF in the CrosstalkingState map!
-	    CrosstalkingState[PSUChannel]=false; //Turn OFF the channel in the state map!
-	    
-	    //Need to check if both channels (HV1==channel002 or HV2==channel003) are OFF!
-	    if (!CrosstalkingState[PSUChannel.substr(0,PSUChannel.size()-1)+"2"] && !CrosstalkingState[PSUChannel.substr(0,PSUChannel.size()-1)+"3"]) { //if HV1 & HV2 both OFF (false)
-		OFFids.insert(OFFids.end(),crosstalking_ids.begin(),crosstalking_ids.end()); //Add the crosstalking_ids (if any!) since both HV1 and HV2 are OFF!
-		if (debug_) {
-		  std::cout<<"Adding the unmapped detids corresponding to (HV1/2 cross-talking) PSU "<<PSUChannel.substr(0,PSUChannel.size()-10)<<" to the list of detids turning OFF"<<std::endl;
-		}
-	    }
-	  }
-	  //Handle the crosstalking channel by setting it to OFF in the CrosstalkingState map!
-	  if (!unmapped_ids.empty()) {//This already means that the PSUChannel is one of the unmapped ones (even if only a few modules in that PSU are unmapped both its channels have to be considered crosstalking of course!
-	    UnmappedState[PSUChannel]=false; //Turn OFF the channel in the state map!
-	  }
-	  if (!OFFids.empty()) {
-	    //Create a pair with the relevant detIDs (vector) and its timestamp
-	    //And put it in the detidV vector of the detIdStruct that will contain all the 
-	    //results
-	    
-	    //Going OFF HV:
-	    //report not only ids, but also unmapped_ids.
-	    //have to handle crosstalking_ids here... (only OFF if they corresponding PSU HV1/HV2 is off already...
-	    //then add all three vectors to the pair below...
-	    detIdStruct.detidV.push_back( std::make_pair(OFFids,psuStruct.changeDate[dp]) );
-	    
-	    //Set the status to OFF
-	    detIdStruct.StatusGood.push_back(false);
-	    
-	    //debug variable population
-	    numHvBad.insert(numHvBad.end(),ids.begin(),ids.end());
+            //Set the status to OFF
+            detIdStruct.StatusGood.push_back(false);
 
-	    //Set the flag for LV/HV:
-	    detIdStruct.isHV.push_back(1); //HV
+            //debug variable population
+            numLvBad.insert(numLvBad.end(), ids.begin(), ids.end());
 
-	    //Set the PSUChannel (I guess for debug purposes?)
-	    detIdStruct.psuName.push_back( PSUChannel );
-	  }
-	}
+            //Set the flag for LV/HV:
+            detIdStruct.isHV.push_back(0);  //LV
+
+            //Set the PSUChannel (I guess for debug purposes?)
+            detIdStruct.psuName.push_back(PSUChannel);
+          }
+        }
+        //HV case:
+        else {  //if (!LVCase) {
+          //Debug variables increment:
+          if (!ids.empty() || !unmapped_ids.empty() || !crosstalking_ids.empty()) {
+            if (Channel == "channel002") {
+              ch2bad++;
+            } else if (Channel == "channel003") {
+              ch3bad++;
+            }
+          }
+          //First sum the ids (positively matching detids) and the unmapped_ids (since both should be TURNED OFF):
+          std::vector<uint32_t> OFFids;
+          OFFids.insert(OFFids.end(), ids.begin(), ids.end());                    //Add the ids (if any!)
+          OFFids.insert(OFFids.end(), unmapped_ids.begin(), unmapped_ids.end());  //Add the unmapped_ids (if any!)
+          //Now for the cross-talking ids this is a bit more complicated!
+          if (!crosstalking_ids
+                   .empty()) {  //This already means that the PSUChannel is one of the crosstalking ones (even if only a few modules in that PSU are showing crosstalking behavior both its channels have to be considered crosstalking of course!
+            //Set the channel OFF in the CrosstalkingState map!
+            CrosstalkingState[PSUChannel] = false;  //Turn OFF the channel in the state map!
+
+            //Need to check if both channels (HV1==channel002 or HV2==channel003) are OFF!
+            if (!CrosstalkingState[PSUChannel.substr(0, PSUChannel.size() - 1) + "2"] &&
+                !CrosstalkingState[PSUChannel.substr(0, PSUChannel.size() - 1) + "3"]) {  //if HV1 & HV2 both OFF (false)
+              OFFids.insert(
+                  OFFids.end(),
+                  crosstalking_ids.begin(),
+                  crosstalking_ids.end());  //Add the crosstalking_ids (if any!) since both HV1 and HV2 are OFF!
+              if (debug_) {
+                std::cout << "Adding the unmapped detids corresponding to (HV1/2 cross-talking) PSU "
+                          << PSUChannel.substr(0, PSUChannel.size() - 10) << " to the list of detids turning OFF"
+                          << std::endl;
+              }
+            }
+          }
+          //Handle the crosstalking channel by setting it to OFF in the CrosstalkingState map!
+          if (!unmapped_ids
+                   .empty()) {  //This already means that the PSUChannel is one of the unmapped ones (even if only a few modules in that PSU are unmapped both its channels have to be considered crosstalking of course!
+            UnmappedState[PSUChannel] = false;  //Turn OFF the channel in the state map!
+          }
+          if (!OFFids.empty()) {
+            //Create a pair with the relevant detIDs (vector) and its timestamp
+            //And put it in the detidV vector of the detIdStruct that will contain all the
+            //results
+
+            //Going OFF HV:
+            //report not only ids, but also unmapped_ids.
+            //have to handle crosstalking_ids here... (only OFF if they corresponding PSU HV1/HV2 is off already...
+            //then add all three vectors to the pair below...
+            detIdStruct.detidV.push_back(std::make_pair(OFFids, psuStruct.changeDate[dp]));
+
+            //Set the status to OFF
+            detIdStruct.StatusGood.push_back(false);
+
+            //debug variable population
+            numHvBad.insert(numHvBad.end(), ids.begin(), ids.end());
+
+            //Set the flag for LV/HV:
+            detIdStruct.isHV.push_back(1);  //HV
+
+            //Set the PSUChannel (I guess for debug purposes?)
+            detIdStruct.psuName.push_back(PSUChannel);
+          }
+        }
       }
       //TURNING ON CASE
       else {
-	//Implement the rest of the logic!
-	//Behavior is different for LV vs HV channels:
-	//LV case:
-	if (LVCase) {
-	  //Turn ON all (PSU)matching detids: 
-	  //for the LV case all the detids are automatically reported in the ids vector
-	  //unmapped and crosstalking are only differentiated (relevant) for HV.
-	  if (!ids.empty()) {
-	    //Create a pair with the relevant detIDs (vector) and its timestamp
-	    //And put it in the detidV vector of the detIdStruct that will contain all the 
-	    //results
-	    detIdStruct.detidV.push_back( std::make_pair(ids,psuStruct.changeDate[dp]) );
-	    
-	    //Set the status to ON
-	    detIdStruct.StatusGood.push_back(true);
-	    
-	    //Set the flag for LV/HV:
-	    detIdStruct.isHV.push_back(0); //LV
+        //Implement the rest of the logic!
+        //Behavior is different for LV vs HV channels:
+        //LV case:
+        if (LVCase) {
+          //Turn ON all (PSU)matching detids:
+          //for the LV case all the detids are automatically reported in the ids vector
+          //unmapped and crosstalking are only differentiated (relevant) for HV.
+          if (!ids.empty()) {
+            //Create a pair with the relevant detIDs (vector) and its timestamp
+            //And put it in the detidV vector of the detIdStruct that will contain all the
+            //results
+            detIdStruct.detidV.push_back(std::make_pair(ids, psuStruct.changeDate[dp]));
 
-	    //Set the PSUChannel (I guess for debug purposes?)
-	    detIdStruct.psuName.push_back( PSUChannel );
-	  }
-	}
-	//HV case:
-	else { //if (!LVCase) {
-	  //First sum the ids (positively matching detids) and the crosstalking_ids (since all ids on a crosstalking PSU should be TURNED ON when at least one HV channel is ON):
-	  std::vector<uint32_t> ONids;
-	  ONids.insert(ONids.end(),ids.begin(),ids.end()); //Add the ids (if any!)
-	  ONids.insert(ONids.end(),crosstalking_ids.begin(),crosstalking_ids.end()); //Add the crosstalking_ids (if any!)
-	  //Now for the unmapped ids this is a bit more complicated!
-	  if (!unmapped_ids.empty()) {//This already means that the PSUChannel is one of the unmapped ones (even if only a few modules in that PSU are unmapped both its channels have to be considered unmapped of course!
-	    //Set the HV1 channel on in the UnmappedState map!
-	    UnmappedState[PSUChannel]=true; //Turn ON the channel in the state map!
+            //Set the status to ON
+            detIdStruct.StatusGood.push_back(true);
 
-	    //Need to check if BOTH channels (HV1==channel002 or HV2==channel003) are ON!
-	    if (UnmappedState[PSUChannel.substr(0,PSUChannel.size()-1)+"2"] && UnmappedState[PSUChannel.substr(0,PSUChannel.size()-1)+"3"]) { //if HV1 & HV2 are both ON (true)
-	      ONids.insert(ONids.end(),unmapped_ids.begin(),unmapped_ids.end()); //Add the unmapped_ids (if any!) since both HV1 and HV2 are ON!
-	      if (debug_) {
-		  std::cout<<"Adding the detids corresponding to HV-unmapped PSU "<<PSUChannel.substr(0,PSUChannel.size()-10)<<" to the list of detids turning ON"<<std::endl;
-		}
-	    }
-	  }
-	  //Handle the crosstalking channel by setting it to OFF in the CrosstalkingState map!
-	  if (!crosstalking_ids.empty()) {//This already means that the PSUChannel is one of the crosstalking ones (even if only a few modules in that PSU are showing crosstalking behavior both its channels have to be considered crosstalking of course!
-	    CrosstalkingState[PSUChannel]=true; //Turn ON the channel in the state map!
-	  }
-	  if (!ONids.empty()) {
-	    //Create a pair with the relevant detIDs (vector) and its timestamp
-	    //And put it in the detidV vector of the detIdStruct that will contain all the 
-	    //results
-	    
-	    //Going OFF HV:
-	    //report not only ids, but also unmapped_ids.
-	    //have to handle crosstalking_ids here... (only OFF if they corresponding PSU HV1/HV2 is off already...
-	    //then add all three vectors to the pair below...
-	    detIdStruct.detidV.push_back( std::make_pair(ONids,psuStruct.changeDate[dp]) );
-	    
-	    //Set the status to ON
-	    detIdStruct.StatusGood.push_back(true);
-	    
-	    //Set the flag for LV/HV:
-	    detIdStruct.isHV.push_back(1); //HV
+            //Set the flag for LV/HV:
+            detIdStruct.isHV.push_back(0);  //LV
 
-	    //Set the PSUChannel (I guess for debug purposes?)
-	    detIdStruct.psuName.push_back( PSUChannel );
-	  }
-	}
+            //Set the PSUChannel (I guess for debug purposes?)
+            detIdStruct.psuName.push_back(PSUChannel);
+          }
+        }
+        //HV case:
+        else {  //if (!LVCase) {
+          //First sum the ids (positively matching detids) and the crosstalking_ids (since all ids on a crosstalking PSU should be TURNED ON when at least one HV channel is ON):
+          std::vector<uint32_t> ONids;
+          ONids.insert(ONids.end(), ids.begin(), ids.end());  //Add the ids (if any!)
+          ONids.insert(
+              ONids.end(), crosstalking_ids.begin(), crosstalking_ids.end());  //Add the crosstalking_ids (if any!)
+          //Now for the unmapped ids this is a bit more complicated!
+          if (!unmapped_ids
+                   .empty()) {  //This already means that the PSUChannel is one of the unmapped ones (even if only a few modules in that PSU are unmapped both its channels have to be considered unmapped of course!
+            //Set the HV1 channel on in the UnmappedState map!
+            UnmappedState[PSUChannel] = true;  //Turn ON the channel in the state map!
+
+            //Need to check if BOTH channels (HV1==channel002 or HV2==channel003) are ON!
+            if (UnmappedState[PSUChannel.substr(0, PSUChannel.size() - 1) + "2"] &&
+                UnmappedState[PSUChannel.substr(0, PSUChannel.size() - 1) + "3"]) {  //if HV1 & HV2 are both ON (true)
+              ONids.insert(ONids.end(),
+                           unmapped_ids.begin(),
+                           unmapped_ids.end());  //Add the unmapped_ids (if any!) since both HV1 and HV2 are ON!
+              if (debug_) {
+                std::cout << "Adding the detids corresponding to HV-unmapped PSU "
+                          << PSUChannel.substr(0, PSUChannel.size() - 10) << " to the list of detids turning ON"
+                          << std::endl;
+              }
+            }
+          }
+          //Handle the crosstalking channel by setting it to OFF in the CrosstalkingState map!
+          if (!crosstalking_ids
+                   .empty()) {  //This already means that the PSUChannel is one of the crosstalking ones (even if only a few modules in that PSU are showing crosstalking behavior both its channels have to be considered crosstalking of course!
+            CrosstalkingState[PSUChannel] = true;  //Turn ON the channel in the state map!
+          }
+          if (!ONids.empty()) {
+            //Create a pair with the relevant detIDs (vector) and its timestamp
+            //And put it in the detidV vector of the detIdStruct that will contain all the
+            //results
+
+            //Going OFF HV:
+            //report not only ids, but also unmapped_ids.
+            //have to handle crosstalking_ids here... (only OFF if they corresponding PSU HV1/HV2 is off already...
+            //then add all three vectors to the pair below...
+            detIdStruct.detidV.push_back(std::make_pair(ONids, psuStruct.changeDate[dp]));
+
+            //Set the status to ON
+            detIdStruct.StatusGood.push_back(true);
+
+            //Set the flag for LV/HV:
+            detIdStruct.isHV.push_back(1);  //HV
+
+            //Set the PSUChannel (I guess for debug purposes?)
+            detIdStruct.psuName.push_back(PSUChannel);
+          }
+        }
       }
-    }//End of if dpname not "UNKNOWN" 
+    }  //End of if dpname not "UNKNOWN"
     else {
       //if (debug) {
       //std::cout<<"PSU Channel name WAS NOT RECOGNIZED"<<std::endl;
       //}
       detIdStruct.notMatched++;
     }
-  }//End of the loop over all PSUChannels reported by the DB query.
+  }  //End of the loop over all PSUChannels reported by the DB query.
   //At this point we need to (over)write the 2 files that will keep the HVUnmapped and HVCrosstalking channels status:
   std::ofstream ofsUnmapped("HVUnmappedChannelState.dat");
-  for (std::map<std::string,bool>::iterator it=UnmappedState.begin(); it!=UnmappedState.end(); it++) {
-    ofsUnmapped<<it->first<<"\t"<<it->second<<std::endl;
+  for (std::map<std::string, bool>::iterator it = UnmappedState.begin(); it != UnmappedState.end(); it++) {
+    ofsUnmapped << it->first << "\t" << it->second << std::endl;
   }
   std::ofstream ofsCrosstalking("HVCrosstalkingChannelState.dat");
-  for (std::map<std::string,bool>::iterator it=CrosstalkingState.begin(); it!=CrosstalkingState.end(); it++) {
-    ofsCrosstalking<<it->first<<"\t"<<it->second<<std::endl;
+  for (std::map<std::string, bool>::iterator it = CrosstalkingState.begin(); it != CrosstalkingState.end(); it++) {
+    ofsCrosstalking << it->first << "\t" << it->second << std::endl;
   }
 
   removeDuplicates(numLvBad);
   removeDuplicates(numHvBad);
 
-
   // useful debugging stuff!
-  if( debug_ ) {
-    std::cout << "Number of channels that turned OFF in this O2O interval"<<std::endl;
+  if (debug_) {
+    std::cout << "Number of channels that turned OFF in this O2O interval" << std::endl;
     std::cout << "Channel000 = " << ch0bad << " Channel001 = " << ch1bad << std::endl;
     std::cout << "Channel002 = " << ch2bad << " Channel003 = " << ch3bad << std::endl;
     std::cout << "Number of LV detIDs that turned OFF in this O2O interval = " << numLvBad.size() << std::endl;
     std::cout << "Number of HV detIDs that turned OFF in this O2O interval = " << numHvBad.size() << std::endl;
   }
 
-  LogTrace("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::" << __func__ << "]: Number of PSUs retrieved from DB with map information    " << detIdStruct.detidV.size();
-  LogTrace("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::" << __func__ << "]: Number of PSUs retrieved from DB with no map information " << detIdStruct.notMatched;
-  
+  LogTrace("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::" << __func__
+                                    << "]: Number of PSUs retrieved from DB with map information    "
+                                    << detIdStruct.detidV.size();
+  LogTrace("SiStripDetVOffBuilder") << "[SiStripDetVOffBuilder::" << __func__
+                                    << "]: Number of PSUs retrieved from DB with no map information "
+                                    << detIdStruct.notMatched;
+
   unsigned int dupCount = 0;
   for (unsigned int t = 0; t < numLvBad.size(); t++) {
-    std::vector<unsigned int>::iterator iter = std::find(numHvBad.begin(),numHvBad.end(),numLvBad[t]);
-    if (iter != numHvBad.end()) {dupCount++;}
+    std::vector<unsigned int>::iterator iter = std::find(numHvBad.begin(), numHvBad.end(), numLvBad[t]);
+    if (iter != numHvBad.end()) {
+      dupCount++;
+    }
   }
-  if( debug_ ) std::cout << "Number of channels for which LV & HV turned OFF in this O2O interval = " << dupCount << std::endl;
-  
+  if (debug_)
+    std::cout << "Number of channels for which LV & HV turned OFF in this O2O interval = " << dupCount << std::endl;
 }
 
-void SiStripDetVOffBuilder::setPayloadStats(const uint32_t afterV, const uint32_t numAdded, const uint32_t numRemoved)
-{
-  std::vector<uint32_t> pStats(3,0);
+void SiStripDetVOffBuilder::setPayloadStats(const uint32_t afterV, const uint32_t numAdded, const uint32_t numRemoved) {
+  std::vector<uint32_t> pStats(3, 0);
   pStats.push_back(afterV);
   pStats.push_back(numAdded);
   pStats.push_back(numRemoved);
   payloadStats.push_back(pStats);
 }
 
-pair<int, int> SiStripDetVOffBuilder::extractDetIdVector( const unsigned int i, SiStripDetVOff * modV, DetIdListTimeAndStatus & detIdStruct )
-{
+pair<int, int> SiStripDetVOffBuilder::extractDetIdVector(const unsigned int i,
+                                                         SiStripDetVOff* modV,
+                                                         DetIdListTimeAndStatus& detIdStruct) {
   // set the LV and HV off flags ready for storing
   int lv_off = -1, hv_off = -1;
-  if (detIdStruct.isHV[i] == 0) {lv_off = !(detIdStruct.StatusGood[i]);}
+  if (detIdStruct.isHV[i] == 0) {
+    lv_off = !(detIdStruct.StatusGood[i]);
+  }
   if (detIdStruct.isHV[i] == 1) {
     hv_off = !(detIdStruct.StatusGood[i]);
 
     // TESTING WITHOUT THE FIX
     // -----------------------
 
-    if( psuDetIdMapFile_.empty() ) {
+    if (psuDetIdMapFile_.empty()) {
       // temporary fix to handle the fact that we don't know which HV channel the detIDs are associated to
       if (i > 0) {
-	std::string iChannel = detIdStruct.psuName[i].substr( (detIdStruct.psuName[i].size()-3) );
-	std::string iPsu = detIdStruct.psuName[i].substr(0, (detIdStruct.psuName[i].size()-3) );
-	if (iChannel == "002" || iChannel == "003") {
-	  bool lastStatusOfOtherChannel = true;
-	  for (unsigned int j = 0; j < i; j++) {
-	    std::string jPsu = detIdStruct.psuName[j].substr(0, (detIdStruct.psuName[j].size()-3) );
-	    std::string jChannel = detIdStruct.psuName[j].substr( (detIdStruct.psuName[j].size()-3) );
-	    if (iPsu == jPsu && iChannel != jChannel && (jChannel == "002" || jChannel == "003")) {
-	      if( debug_ ) cout << "psu["<<i<<"] = " << detIdStruct.psuName[i] << " with status = " << detIdStruct.StatusGood[i] << " and psu["<<j<<"] = " << detIdStruct.psuName[j] << " with status " << detIdStruct.StatusGood[j] << endl;
-	      lastStatusOfOtherChannel = detIdStruct.StatusGood[j];
-	    }
-	  }
-	  if (detIdStruct.StatusGood[i] != lastStatusOfOtherChannel) {
-	    if( debug_ ) cout << "turning off hv" << endl;
-	    hv_off = 1;
-	  }
-	}
+        std::string iChannel = detIdStruct.psuName[i].substr((detIdStruct.psuName[i].size() - 3));
+        std::string iPsu = detIdStruct.psuName[i].substr(0, (detIdStruct.psuName[i].size() - 3));
+        if (iChannel == "002" || iChannel == "003") {
+          bool lastStatusOfOtherChannel = true;
+          for (unsigned int j = 0; j < i; j++) {
+            std::string jPsu = detIdStruct.psuName[j].substr(0, (detIdStruct.psuName[j].size() - 3));
+            std::string jChannel = detIdStruct.psuName[j].substr((detIdStruct.psuName[j].size() - 3));
+            if (iPsu == jPsu && iChannel != jChannel && (jChannel == "002" || jChannel == "003")) {
+              if (debug_)
+                cout << "psu[" << i << "] = " << detIdStruct.psuName[i]
+                     << " with status = " << detIdStruct.StatusGood[i] << " and psu[" << j
+                     << "] = " << detIdStruct.psuName[j] << " with status " << detIdStruct.StatusGood[j] << endl;
+              lastStatusOfOtherChannel = detIdStruct.StatusGood[j];
+            }
+          }
+          if (detIdStruct.StatusGood[i] != lastStatusOfOtherChannel) {
+            if (debug_)
+              cout << "turning off hv" << endl;
+            hv_off = 1;
+          }
+        }
       }
     }
 
     // -----------------------
-
   }
 
   return make_pair(hv_off, lv_off);

--- a/CalibTracker/SiStripDCS/src/SiStripPsuDetIdMap.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripPsuDetIdMap.cc
@@ -37,7 +37,7 @@ void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, std::vector<std:
   std::ifstream ifs( file.fullPath().c_str() );
   string line;
   while( getline( ifs, line ) ) {
-    if( line != "" ) {
+    if( !line.empty() ) {
       // split the line and insert in the map
       stringstream ss(line);
       string PSUChannel;
@@ -64,7 +64,7 @@ void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, const bool debug
   std::ifstream ifs( file.fullPath().c_str() );
   string line;
   while( getline( ifs, line ) ) {
-    if( line != "" ) {
+    if( !line.empty() ) {
       // split the line and insert in the map
       stringstream ss(line);
       string PSUChannel;
@@ -516,7 +516,7 @@ std::vector< std::pair< std::vector<uint16_t> , std::vector<uint32_t> > > SiStri
   SiStripConfigDb::DeviceType device_ = DCU;
   
   for (iter = dbParams_.partitions().begin(); iter != dbParams_.partitions().end(); ++iter) {
-    if ( partition == "" || partition == iter->second.partitionName() ) {
+    if ( partition.empty() || partition == iter->second.partitionName() ) {
       if ( iter->second.partitionName() == SiStripPartition::defaultPartitionName_ ) { continue; }
       if (iter->second.dcuVersion().first > 0 && iter->second.fecVersion().first > 0) {
 	SiStripConfigDb::DeviceDescriptionsRange range = db_->getDeviceDescriptions(device_,iter->second.partitionName());

--- a/CalibTracker/SiStripDCS/src/SiStripPsuDetIdMap.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripPsuDetIdMap.cc
@@ -17,40 +17,49 @@
 using namespace sistrip;
 
 // only one constructor
-SiStripPsuDetIdMap::SiStripPsuDetIdMap() { LogTrace("SiStripPsuDetIdMap") << "[SiStripPsuDetIdMap::" << __func__ << "] Constructing ..."; }
+SiStripPsuDetIdMap::SiStripPsuDetIdMap() {
+  LogTrace("SiStripPsuDetIdMap") << "[SiStripPsuDetIdMap::" << __func__ << "] Constructing ...";
+}
 // destructor
-SiStripPsuDetIdMap::~SiStripPsuDetIdMap() {LogTrace("SiStripPsuDetIdMap") << "[SiStripPsuDetIdMap::" << __func__ << "] Destructing ..."; }
+SiStripPsuDetIdMap::~SiStripPsuDetIdMap() {
+  LogTrace("SiStripPsuDetIdMap") << "[SiStripPsuDetIdMap::" << __func__ << "] Destructing ...";
+}
 
 // Build PSU-DETID map
-void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, const bool debug )
-{
+void SiStripPsuDetIdMap::BuildMap(const std::string& mapFile, const bool debug) {
   BuildMap(mapFile, debug, LVMap, HVMap, HVUnmapped_Map, HVCrosstalking_Map);
 }
 
-void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, std::vector<std::pair<uint32_t,std::string> > & rawmap) {
-  //This method is a remnant of the old method, that provided a vector type of map, based on the 
+void SiStripPsuDetIdMap::BuildMap(const std::string& mapFile, std::vector<std::pair<uint32_t, std::string> >& rawmap) {
+  //This method is a remnant of the old method, that provided a vector type of map, based on the
   //raw reading of a file, with no processing.
   //FIXME:
-  //This is not currently used, but I think we could slim this down to just a vector with 
+  //This is not currently used, but I think we could slim this down to just a vector with
   //the detIDs since the PSUChannel part of the excludedlist (if it ever is in a file) is never used!
   edm::FileInPath file(mapFile.c_str());
-  std::ifstream ifs( file.fullPath().c_str() );
+  std::ifstream ifs(file.fullPath().c_str());
   string line;
-  while( getline( ifs, line ) ) {
-    if( !line.empty() ) {
+  while (getline(ifs, line)) {
+    if (!line.empty()) {
       // split the line and insert in the map
       stringstream ss(line);
       string PSUChannel;
       uint32_t detId;
       ss >> detId;
       ss >> PSUChannel;
-      rawmap.push_back(std::make_pair(detId, PSUChannel) );
+      rawmap.push_back(std::make_pair(detId, PSUChannel));
     }
   }
 }
 
 //The following is the currently used method (called from SiStripDetVOffBuilder::buildPSUdetIdMap)
-void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, const bool debug, PsuDetIdMap & LVmap, PsuDetIdMap & HVmap,PsuDetIdMap & HVUnmappedmap,PsuDetIdMap & HVCrosstalkingmap ) //Maybe it would be nicer to return the map instead of using a reference...
+void SiStripPsuDetIdMap::BuildMap(
+    const std::string& mapFile,
+    const bool debug,
+    PsuDetIdMap& LVmap,
+    PsuDetIdMap& HVmap,
+    PsuDetIdMap& HVUnmappedmap,
+    PsuDetIdMap& HVCrosstalkingmap)  //Maybe it would be nicer to return the map instead of using a reference...
 {
   //This method reads the map from the mapfile indicated in the cfg
   //It populates the 4 maps (private data members of the SiStripPSUDetIdMap in question) (all maps are std::map<std::string,uint32_t > ):
@@ -58,13 +67,13 @@ void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, const bool debug
   //HVMap
   //HVUnmapped_Map
   //HVCrosstalking_Map
-  //These maps are accessed, based on the LV/HV case, to extract the detIDs connected to a given PSUChannel... 
+  //These maps are accessed, based on the LV/HV case, to extract the detIDs connected to a given PSUChannel...
   //see the getDetIDs method...
   edm::FileInPath file(mapFile.c_str());
-  std::ifstream ifs( file.fullPath().c_str() );
+  std::ifstream ifs(file.fullPath().c_str());
   string line;
-  while( getline( ifs, line ) ) {
-    if( !line.empty() ) {
+  while (getline(ifs, line)) {
+    if (!line.empty()) {
       // split the line and insert in the map
       stringstream ss(line);
       string PSUChannel;
@@ -74,21 +83,21 @@ void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, const bool debug
       //Old "vector of pairs" map!
       //map.push_back( std::make_pair(detId, dpName) );//This "map" is normally the pgMap of the map of which we are executing BuildMap()...
       //Using a map to make the look-up easy and avoid lots of lookup loops.
-      std::string PSU=PSUChannel.substr(0,PSUChannel.size()-10);
-      std::string Channel=PSUChannel.substr(PSUChannel.size()-10);
-      LVmap[PSU].push_back(detId); // LVmap uses simply the PSU since there is no channel distinction necessary
-      if (Channel=="channel000") {
-	HVUnmappedmap[PSU].push_back(detId); //Populate HV Unmapped map, by PSU listing all detids unmapped in that PSU (not necessarily all will be unmapped)
-      }
-      else if (Channel=="channel999") {
-	HVCrosstalkingmap[PSU].push_back(detId); //Populate HV Crosstalking map, by PSU listing all detids crosstalking in that PSU (usually all will be unmapped)
-      }
-      else {
-	HVmap[PSUChannel].push_back(detId); //HV map for HV mapped channels, populated by PSU channel!
+      std::string PSU = PSUChannel.substr(0, PSUChannel.size() - 10);
+      std::string Channel = PSUChannel.substr(PSUChannel.size() - 10);
+      LVmap[PSU].push_back(detId);  // LVmap uses simply the PSU since there is no channel distinction necessary
+      if (Channel == "channel000") {
+        HVUnmappedmap[PSU].push_back(
+            detId);  //Populate HV Unmapped map, by PSU listing all detids unmapped in that PSU (not necessarily all will be unmapped)
+      } else if (Channel == "channel999") {
+        HVCrosstalkingmap[PSU].push_back(
+            detId);  //Populate HV Crosstalking map, by PSU listing all detids crosstalking in that PSU (usually all will be unmapped)
+      } else {
+        HVmap[PSUChannel].push_back(detId);  //HV map for HV mapped channels, populated by PSU channel!
       }
     }
   }
-  
+
   //Remove duplicates for all 4 maps
   for (PsuDetIdMap::iterator psu = LVMap.begin(); psu != LVMap.end(); psu++) {
     RemoveDuplicateDetIDs(psu->second);
@@ -104,76 +113,78 @@ void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, const bool debug
   }
   if (debug) {
     //Print out all the 4 maps:
-    std::cout<<"Dumping the LV map"<<std::endl;
-    std::cout<<"PSU->detids"<<std::endl;
+    std::cout << "Dumping the LV map" << std::endl;
+    std::cout << "PSU->detids" << std::endl;
     for (PsuDetIdMap::iterator psu = LVMap.begin(); psu != LVMap.end(); psu++) {
-      std::cout<<psu->first<<" corresponds to following detids"<<endl;
-      for (unsigned int i=0; i<psu->second.size(); i++) {
-	std::cout<<"\t\t"<<psu->second[i]<<std::endl;
+      std::cout << psu->first << " corresponds to following detids" << endl;
+      for (unsigned int i = 0; i < psu->second.size(); i++) {
+        std::cout << "\t\t" << psu->second[i] << std::endl;
       }
     }
-    std::cout<<"Dumping the HV map for HV mapped channels"<<std::endl;
-    std::cout<<"PSUChannel->detids"<<std::endl;
+    std::cout << "Dumping the HV map for HV mapped channels" << std::endl;
+    std::cout << "PSUChannel->detids" << std::endl;
     for (PsuDetIdMap::iterator psuchan = HVMap.begin(); psuchan != HVMap.end(); psuchan++) {
-      std::cout<<psuchan->first<<" corresponds to following detids"<<endl;
-      for (unsigned int i=0; i<psuchan->second.size(); i++) {
-	std::cout<<"\t\t"<<psuchan->second[i]<<std::endl;
+      std::cout << psuchan->first << " corresponds to following detids" << endl;
+      for (unsigned int i = 0; i < psuchan->second.size(); i++) {
+        std::cout << "\t\t" << psuchan->second[i] << std::endl;
       }
     }
-    std::cout<<"Dumping the HV map for HV UNmapped channels"<<std::endl;
-    std::cout<<"PSU->detids"<<std::endl;
+    std::cout << "Dumping the HV map for HV UNmapped channels" << std::endl;
+    std::cout << "PSU->detids" << std::endl;
     for (PsuDetIdMap::iterator psu = HVUnmapped_Map.begin(); psu != HVUnmapped_Map.end(); psu++) {
-      std::cout<<psu->first<<" corresponds to following detids"<<endl;
-      for (unsigned int i=0; i<psu->second.size(); i++) {
-	std::cout<<"\t\t"<<psu->second[i]<<std::endl;
+      std::cout << psu->first << " corresponds to following detids" << endl;
+      for (unsigned int i = 0; i < psu->second.size(); i++) {
+        std::cout << "\t\t" << psu->second[i] << std::endl;
       }
     }
-    std::cout<<"Dumping the HV map for HV Crosstalking channels"<<std::endl;
-    std::cout<<"PSU->detids"<<std::endl;
+    std::cout << "Dumping the HV map for HV Crosstalking channels" << std::endl;
+    std::cout << "PSU->detids" << std::endl;
     for (PsuDetIdMap::iterator psu = HVCrosstalking_Map.begin(); psu != HVCrosstalking_Map.end(); psu++) {
-      std::cout<<psu->first<<" corresponds to following detids"<<endl;
-      for (unsigned int i=0; i<psu->second.size(); i++) {
-	std::cout<<"\t\t"<<psu->second[i]<<std::endl;
+      std::cout << psu->first << " corresponds to following detids" << endl;
+      for (unsigned int i = 0; i < psu->second.size(); i++) {
+        std::cout << "\t\t" << psu->second[i] << std::endl;
       }
     }
     //Could add here consistency checks against the list of detIDs for Strip or Pixels
-    //Number of total detIDs LVMapped, HV Mapped, HVunmapped, HV crosstalking... 
+    //Number of total detIDs LVMapped, HV Mapped, HVunmapped, HV crosstalking...
   }
 }
 
-void SiStripPsuDetIdMap::RemoveDuplicateDetIDs(std::vector<uint32_t> & detids) {
+void SiStripPsuDetIdMap::RemoveDuplicateDetIDs(std::vector<uint32_t>& detids) {
   //Function to remove duplicates from a vector of detids
-  if (!detids.empty()) { //Leave empty vector alone ;)
-    std::sort(detids.begin(),detids.end());
-    std::vector<uint32_t>::iterator it = std::unique(detids.begin(),detids.end());
-    detids.resize( it - detids.begin() );
+  if (!detids.empty()) {  //Leave empty vector alone ;)
+    std::sort(detids.begin(), detids.end());
+    std::vector<uint32_t>::iterator it = std::unique(detids.begin(), detids.end());
+    detids.resize(it - detids.begin());
   }
 }
 
 std::vector<uint32_t> SiStripPsuDetIdMap::getLvDetID(std::string PSU) {
-  //Function that returns a vector with all detids associated with a PSU 
+  //Function that returns a vector with all detids associated with a PSU
   //(no channel information is saved in the map since it is not relevant for LV!)
-  if (LVMap.find(PSU)!=LVMap.end()) {
+  if (LVMap.find(PSU) != LVMap.end()) {
     return LVMap[PSU];
-  }
-  else {
+  } else {
     std::vector<uint32_t> detids;
     return detids;
   }
 }
 
-void SiStripPsuDetIdMap::getHvDetID(std::string PSUChannel, std::vector<uint32_t> & ids, std::vector<uint32_t> & unmapped_ids, std::vector<uint32_t> & crosstalking_ids ) {
+void SiStripPsuDetIdMap::getHvDetID(std::string PSUChannel,
+                                    std::vector<uint32_t>& ids,
+                                    std::vector<uint32_t>& unmapped_ids,
+                                    std::vector<uint32_t>& crosstalking_ids) {
   //Function that (via reference parameters) populates ids, unmapped_ids, crosstalking_ids vectors of detids associated with a given PSU *HV* channel.
-  if (HVMap.find(PSUChannel)!=HVMap.end()) {
-    ids=HVMap[PSUChannel];
+  if (HVMap.find(PSUChannel) != HVMap.end()) {
+    ids = HVMap[PSUChannel];
   }
   //Extract the PSU to check the unmapped and crosstalking maps too corresponding to this channel
-  std::string PSU = PSUChannel.substr(0,PSUChannel.size()-10);
-  if (HVUnmapped_Map.find(PSU)!=HVUnmapped_Map.end()) {
-    unmapped_ids=HVUnmapped_Map[PSU];
+  std::string PSU = PSUChannel.substr(0, PSUChannel.size() - 10);
+  if (HVUnmapped_Map.find(PSU) != HVUnmapped_Map.end()) {
+    unmapped_ids = HVUnmapped_Map[PSU];
   }
-  if (HVCrosstalking_Map.find(PSU)!=HVCrosstalking_Map.end()) {
-    crosstalking_ids=HVCrosstalking_Map[PSU];
+  if (HVCrosstalking_Map.find(PSU) != HVCrosstalking_Map.end()) {
+    crosstalking_ids = HVCrosstalking_Map[PSU];
   }
 }
 
@@ -181,30 +192,35 @@ void SiStripPsuDetIdMap::getHvDetID(std::string PSUChannel, std::vector<uint32_t
 // Currently, channel number is ignored for mapping purposes
 // check both PG and CG as the channels should be unique
 
-void SiStripPsuDetIdMap::getDetID(std::string PSUChannel,const bool debug,std::vector<uint32_t> & detids,std::vector<uint32_t> & unmapped_detids,std::vector<uint32_t> & crosstalking_detids ) {
+void SiStripPsuDetIdMap::getDetID(std::string PSUChannel,
+                                  const bool debug,
+                                  std::vector<uint32_t>& detids,
+                                  std::vector<uint32_t>& unmapped_detids,
+                                  std::vector<uint32_t>& crosstalking_detids) {
   //This function takes as argument the PSUChannel (i.e. the dpname as it comes from the PVSS query, e.g. cms_trk_dcs_02:CAEN/CMS_TRACKER_SY1527_2/branchController05/easyCrate0/easyBoard12/channel001)
   //And it returns 3 vectors:
   //1-detids->all the detids positively matching the PSUChannel in question
   //2-unmapped_detids->the detids that are matching the PSU in question but that are not HV mapped
   //3-crosstalking_detids->the detids that are matching the PSU in question but exhibit the HV channel cross-talking behavior (they are ON as long as ANY of the 2 HV channels of the supply is ON, so they only go OFF when both channels are OFF)
   //The second and third vectors are only relevant for the HV case, when unmapped and cross-talking channels need further processing before being turned ON and OFF.
-  
+
   const std::string& PSUChannelFromQuery = PSUChannel;
 
   //Get the channel to see if it is LV or HV, they will be treated differently
-  std::string ChannelFromQuery=PSUChannelFromQuery.substr(PSUChannelFromQuery.size()-10);
+  std::string ChannelFromQuery = PSUChannelFromQuery.substr(PSUChannelFromQuery.size() - 10);
   //Get the PSU from Query, to be used for LVMap and for the HVUnmapped and HVCrosstalking maps:
-  std::string PSUFromQuery=PSUChannelFromQuery.substr(0,PSUChannelFromQuery.size()-10);
+  std::string PSUFromQuery = PSUChannelFromQuery.substr(0, PSUChannelFromQuery.size() - 10);
   if (debug) {
     //FIXME:
     //Should handle all the couts with MessageLogger!
-    std::cout << "DPNAME from QUERY: "<<PSUChannelFromQuery<<", Channel: "<<ChannelFromQuery<<"PSU: "<<PSUFromQuery<<std::endl;
+    std::cout << "DPNAME from QUERY: " << PSUChannelFromQuery << ", Channel: " << ChannelFromQuery
+              << "PSU: " << PSUFromQuery << std::endl;
   }
 
   //First prepare the strings needed to do the matching of the PSUChannel from the query to the ones in the map
 
   //Handle the LV case first:
-  if (ChannelFromQuery=="channel000" or ChannelFromQuery=="channel001") {
+  if (ChannelFromQuery == "channel000" or ChannelFromQuery == "channel001") {
     //For LV channels we need to look for any detID that is reported either as channel000 (not HV mapped)
     //but also as channel002 and channel003 (if they are HV mapped), or as channel999 (if they are in a crosstalking PSU)
     //Get the PSU to do a PSU-only matching to get all detIDs connected to the LV channel:
@@ -218,14 +234,14 @@ void SiStripPsuDetIdMap::getDetID(std::string PSUChannel,const bool debug,std::v
     //  }
     //}
     //No need to loop over if we use an actual map!
-    
-    if (LVMap.find(PSUFromQuery)!=LVMap.end()) {
-      detids=LVMap[PSUFromQuery];
+
+    if (LVMap.find(PSUFromQuery) != LVMap.end()) {
+      detids = LVMap[PSUFromQuery];
     }
   }
   //Handle the HV case too:
-  else if (ChannelFromQuery=="channel002" or ChannelFromQuery=="channel003") {
-    //For the HV channel we need to look at the actual positive matching detIDs, 
+  else if (ChannelFromQuery == "channel002" or ChannelFromQuery == "channel003") {
+    //For the HV channel we need to look at the actual positive matching detIDs,
     //but also to the unmapped one (channel000) and the crosstalking ones (channel999).
     //Assemble the corresponding channel000 (unmapped channels) replacing the last character in PSUChannelFromQuery:
     //  std::string ZeroedPSUChannelFromQuery= PSUChannelFromQuery;
@@ -256,26 +272,24 @@ void SiStripPsuDetIdMap::getDetID(std::string PSUChannel,const bool debug,std::v
     //  	crosstalking_detids.push_back(iter->first); //Fill the crosstalking_detids vector with the all detids matching the channel999 for the PSU from the query!
     //    }
     //  }
-    if (HVMap.find(PSUChannelFromQuery)!=HVMap.end()) {
-      detids=HVMap[PSUChannelFromQuery];
-    }
-    else if (HVUnmapped_Map.find(PSUFromQuery)!=HVUnmapped_Map.end()) {
-      unmapped_detids=HVUnmapped_Map[PSUFromQuery];
-    }
-    else if (HVCrosstalking_Map.find(PSUFromQuery)!=HVCrosstalking_Map.end()) {
-      crosstalking_detids=HVCrosstalking_Map[PSUFromQuery];
+    if (HVMap.find(PSUChannelFromQuery) != HVMap.end()) {
+      detids = HVMap[PSUChannelFromQuery];
+    } else if (HVUnmapped_Map.find(PSUFromQuery) != HVUnmapped_Map.end()) {
+      unmapped_detids = HVUnmapped_Map[PSUFromQuery];
+    } else if (HVCrosstalking_Map.find(PSUFromQuery) != HVCrosstalking_Map.end()) {
+      crosstalking_detids = HVCrosstalking_Map[PSUFromQuery];
     }
   }
-  //  
-  //  
+  //
+  //
   //  //With the new code above that makes use of the channel00X information in the map
   //  //we should no more need to remove duplicates by construction.
-  //  //The following code was used when there was no channel information in the map, 
+  //  //The following code was used when there was no channel information in the map,
   //  //to elegantly eliminate duplicates.
   //  //We can now use it as a cross-check (still removing duplicates in case they happen, but writing a message out)
-  //  
+  //
   //  // remove duplicates
-  //  
+  //
   //  //First sort detIDs vector, so that duplicates will be consecutive
   //  if (!detids.empty()) {
   //    std::sort(detids.begin(),detids.end());
@@ -327,32 +341,37 @@ void SiStripPsuDetIdMap::getDetID(std::string PSUChannel,const bool debug,std::v
   //      }
   //    }
   //  }
-  //  
+  //
   //  //Using reference parameters since we are returning multiple objects.
   //  //return detids;
-
 }
 
 // returns PSU channel name for a given DETID
 std::string SiStripPsuDetIdMap::getPSUName(uint32_t detid) {
-  std::vector< std::pair<uint32_t, std::string> >::iterator iter;
+  std::vector<std::pair<uint32_t, std::string> >::iterator iter;
   for (iter = pgMap.begin(); iter != pgMap.end(); iter++) {
-    if (iter->first && iter->first == detid) {return iter->second;}
+    if (iter->first && iter->first == detid) {
+      return iter->second;
+    }
   }
   // if we reach here, then we didn't find the detid in the map
   return "UNKNOWN";
 }
 
 std::string SiStripPsuDetIdMap::getPSUName(uint32_t detid, std::string group) {
-  std::vector< std::pair<uint32_t, std::string> >::iterator iter;
+  std::vector<std::pair<uint32_t, std::string> >::iterator iter;
   if (group == "PG") {
     for (iter = pgMap.begin(); iter != pgMap.end(); iter++) {
-      if (iter->first && iter->first == detid) {return iter->second;}
+      if (iter->first && iter->first == detid) {
+        return iter->second;
+      }
     }
   }
   if (group == "CG") {
     for (iter = cgMap.begin(); iter != cgMap.end(); iter++) {
-      if (iter->first && iter->first == detid) {return iter->second;}
+      if (iter->first && iter->first == detid) {
+        return iter->second;
+      }
     }
   }
   // if we reach here, then we didn't find the detid in the map
@@ -362,7 +381,9 @@ std::string SiStripPsuDetIdMap::getPSUName(uint32_t detid, std::string group) {
 // returns the PVSS name for a given DETID
 std::string SiStripPsuDetIdMap::getDetectorLocation(uint32_t detid) {
   for (unsigned int i = 0; i < pgMap.size(); i++) {
-    if (pgMap[i].first == detid) {return detectorLocations[i];}
+    if (pgMap[i].first == detid) {
+      return detectorLocations[i];
+    }
   }
   return "UNKNOWN";
 }
@@ -371,12 +392,16 @@ std::string SiStripPsuDetIdMap::getDetectorLocation(uint32_t detid) {
 std::string SiStripPsuDetIdMap::getDetectorLocation(uint32_t detid, std::string group) {
   if (group == "PG") {
     for (unsigned int i = 0; i < pgMap.size(); i++) {
-      if (pgMap[i].first == detid) {return detectorLocations[i];}
+      if (pgMap[i].first == detid) {
+        return detectorLocations[i];
+      }
     }
   }
   if (group == "CG") {
     for (unsigned int i = 0; i < cgMap.size(); i++) {
-      if (cgMap[i].first == detid) {return controlLocations[i];}
+      if (cgMap[i].first == detid) {
+        return controlLocations[i];
+      }
     }
   }
   return "UNKNOWN";
@@ -385,10 +410,14 @@ std::string SiStripPsuDetIdMap::getDetectorLocation(uint32_t detid, std::string 
 // returns the PVSS name for a given PSU channel
 std::string SiStripPsuDetIdMap::getDetectorLocation(std::string PSUChannel) {
   for (unsigned int i = 0; i < pgMap.size(); i++) {
-    if (pgMap[i].second == PSUChannel) {return detectorLocations[i];}
+    if (pgMap[i].second == PSUChannel) {
+      return detectorLocations[i];
+    }
   }
   for (unsigned int i = 0; i < cgMap.size(); i++) {
-    if (cgMap[i].second == PSUChannel) {return controlLocations[i];}
+    if (cgMap[i].second == PSUChannel) {
+      return controlLocations[i];
+    }
   }
   return "UNKNOWN";
 }
@@ -396,17 +425,23 @@ std::string SiStripPsuDetIdMap::getDetectorLocation(std::string PSUChannel) {
 // returns the DCU ID for a given PSU channel
 uint32_t SiStripPsuDetIdMap::getDcuId(std::string PSUChannel) {
   for (unsigned int i = 0; i < pgMap.size(); i++) {
-    if (pgMap[i].second == PSUChannel) {return dcuIds[i];}
+    if (pgMap[i].second == PSUChannel) {
+      return dcuIds[i];
+    }
   }
   for (unsigned int i = 0; i < cgMap.size(); i++) {
-    if (cgMap[i].second == PSUChannel) {return cgDcuIds[i];}
+    if (cgMap[i].second == PSUChannel) {
+      return cgDcuIds[i];
+    }
   }
   return 0;
 }
 
 uint32_t SiStripPsuDetIdMap::getDcuId(uint32_t detid) {
   for (unsigned int i = 0; i < pgMap.size(); i++) {
-    if (pgMap[i].first == detid) {return dcuIds[i];}
+    if (pgMap[i].first == detid) {
+      return dcuIds[i];
+    }
   }
   return 0;
 }
@@ -415,25 +450,27 @@ uint32_t SiStripPsuDetIdMap::getDcuId(uint32_t detid) {
 int SiStripPsuDetIdMap::IsHVChannel(std::string PSUChannel) {
   // isHV = 0 means LV, = 1 means HV, = -1 means error
   int isHV = 0;
-  std::string::size_type loc = PSUChannel.find( "channel", 0 );
+  std::string::size_type loc = PSUChannel.find("channel", 0);
   if (loc != std::string::npos) {
-    std::string chNumber = PSUChannel.substr(loc+7,3);
+    std::string chNumber = PSUChannel.substr(loc + 7, 3);
     if (chNumber == "002" || chNumber == "003") {
       isHV = 1;
     } else if (chNumber == "000" || chNumber == "001") {
       isHV = 0;
     } else {
-      edm::LogWarning("SiStripPsuDetIdMap") << "[SiStripPsuDetIdMap::" << __func__ << "] channel number of unexpected format, setting error flag!";
+      edm::LogWarning("SiStripPsuDetIdMap")
+          << "[SiStripPsuDetIdMap::" << __func__ << "] channel number of unexpected format, setting error flag!";
       isHV = -1;
     }
   } else {
-    edm::LogWarning("SiStripPsuDetIdMap") << "[SiStripPsuDetIdMap::" << __func__ << "] channel number not located in PSU channel name, setting error flag!";
+    edm::LogWarning("SiStripPsuDetIdMap") << "[SiStripPsuDetIdMap::" << __func__
+                                          << "] channel number not located in PSU channel name, setting error flag!";
     isHV = -1;
   }
   return isHV;
 }
 
-void SiStripPsuDetIdMap::clone(DcuPsuVector &input, DcuPsuVector &output) {
+void SiStripPsuDetIdMap::clone(DcuPsuVector& input, DcuPsuVector& output) {
   output.clear();
   for (unsigned int i = 0; i < input.size(); i++) {
     output.push_back(new TkDcuPsuMap(*(input[i])));
@@ -442,8 +479,7 @@ void SiStripPsuDetIdMap::clone(DcuPsuVector &input, DcuPsuVector &output) {
 
 void SiStripPsuDetIdMap::printMap() {
   stringstream pg;
-  pg << "Map of power supplies to DET IDs: " << std::endl
-     << "-- PSU name --          -- Det Id --" << std::endl;
+  pg << "Map of power supplies to DET IDs: " << std::endl << "-- PSU name --          -- Det Id --" << std::endl;
   for (unsigned int p = 0; p < pgMap.size(); p++) {
     pg << pgMap[p].first << "         " << pgMap[p].second << std::endl;
   }
@@ -460,32 +496,38 @@ void SiStripPsuDetIdMap::printControlMap() {
   edm::LogInfo("SiStripPsuDetIdMap") << "[SiStripPsuDetIdMap::" << __func__ << "] " << cg.str();
 }
 
-std::vector< std::pair<uint32_t, std::string> > SiStripPsuDetIdMap::getDcuPsuMap() {
-  if (!pgMap.empty()) { return pgMap; }
-  std::vector< std::pair<uint32_t, std::string> > emptyVec;
+std::vector<std::pair<uint32_t, std::string> > SiStripPsuDetIdMap::getDcuPsuMap() {
+  if (!pgMap.empty()) {
+    return pgMap;
+  }
+  std::vector<std::pair<uint32_t, std::string> > emptyVec;
   return emptyVec;
 }
 
-void SiStripPsuDetIdMap::checkMapInputValues(const SiStripConfigDb::DcuDetIdsV& dcuDetIds_, const DcuPsuVector& dcuPsus_) {
+void SiStripPsuDetIdMap::checkMapInputValues(const SiStripConfigDb::DcuDetIdsV& dcuDetIds_,
+                                             const DcuPsuVector& dcuPsus_) {
   std::cout << "Number of entries in DCU-PSU map:    " << dcuPsus_.size() << std::endl;
   std::cout << "Number of entries in DCU-DETID map:  " << dcuDetIds_.size() << std::endl;
   std::cout << std::endl;
-  
-  std::vector<bool> ddUsed(dcuDetIds_.size(),false);
-  std::vector<bool> dpUsed(dcuPsus_.size(),false);
+
+  std::vector<bool> ddUsed(dcuDetIds_.size(), false);
+  std::vector<bool> dpUsed(dcuPsus_.size(), false);
 
   for (unsigned int dp = 0; dp < dcuPsus_.size(); dp++) {
     for (unsigned int dd = 0; dd < dcuDetIds_.size(); dd++) {
       if (dcuPsus_[dp]->getDcuHardId() == dcuDetIds_[dd].second->getDcuHardId()) {
-	dpUsed[dp] = true;
-	ddUsed[dd] = true;
+        dpUsed[dp] = true;
+        ddUsed[dd] = true;
       }
     }
   }
   unsigned int numDpUsed = 0, numDpNotUsed = 0;
   for (unsigned int dp = 0; dp < dpUsed.size(); dp++) {
-    if (dpUsed[dp]) { numDpUsed++; }
-    else { numDpNotUsed++; }
+    if (dpUsed[dp]) {
+      numDpUsed++;
+    } else {
+      numDpNotUsed++;
+    }
   }
 
   std::cout << "Number of used DCU-PSU entries:   " << numDpUsed << std::endl;
@@ -493,8 +535,11 @@ void SiStripPsuDetIdMap::checkMapInputValues(const SiStripConfigDb::DcuDetIdsV& 
 
   unsigned int numDdUsed = 0, numDdNotUsed = 0;
   for (unsigned int dd = 0; dd < ddUsed.size(); dd++) {
-    if (ddUsed[dd]) { numDdUsed++; }
-    else { numDdNotUsed++; }
+    if (ddUsed[dd]) {
+      numDdUsed++;
+    } else {
+      numDdNotUsed++;
+    }
   }
 
   std::cout << "Number of used DCU-DETID entries:   " << numDdUsed << std::endl;
@@ -505,68 +550,72 @@ void SiStripPsuDetIdMap::checkMapInputValues(const SiStripConfigDb::DcuDetIdsV& 
 }
 
 //std::vector< std::pair<uint32_t, SiStripConfigDb::DeviceAddress> > SiStripPsuDetIdMap::retrieveDcuDeviceAddresses(std::string partition) {
-std::vector< std::pair< std::vector<uint16_t> , std::vector<uint32_t> > > SiStripPsuDetIdMap::retrieveDcuDeviceAddresses(std::string partition) {
+std::vector<std::pair<std::vector<uint16_t>, std::vector<uint32_t> > > SiStripPsuDetIdMap::retrieveDcuDeviceAddresses(
+    std::string partition) {
   // get the DB parameters
   SiStripDbParams dbParams_ = db_->dbParams();
   SiStripDbParams::SiStripPartitions::const_iterator iter;
-  
-  std::vector< std::pair<uint32_t, SiStripConfigDb::DeviceAddress> > resultVec;
-  
+
+  std::vector<std::pair<uint32_t, SiStripConfigDb::DeviceAddress> > resultVec;
+
   SiStripConfigDb::DeviceDescriptionsV dcuDevices_;
   SiStripConfigDb::DeviceType device_ = DCU;
-  
+
   for (iter = dbParams_.partitions().begin(); iter != dbParams_.partitions().end(); ++iter) {
-    if ( partition.empty() || partition == iter->second.partitionName() ) {
-      if ( iter->second.partitionName() == SiStripPartition::defaultPartitionName_ ) { continue; }
+    if (partition.empty() || partition == iter->second.partitionName()) {
+      if (iter->second.partitionName() == SiStripPartition::defaultPartitionName_) {
+        continue;
+      }
       if (iter->second.dcuVersion().first > 0 && iter->second.fecVersion().first > 0) {
-	SiStripConfigDb::DeviceDescriptionsRange range = db_->getDeviceDescriptions(device_,iter->second.partitionName());
-	if (!range.empty()) {
-	  SiStripConfigDb::DeviceDescriptionsV nextVec( range.begin(), range.end() );
-	  for (unsigned int i = 0; i < nextVec.size(); i++) {
-	    dcuDescription * desc = dynamic_cast<dcuDescription *>(nextVec[i]);
-	    resultVec.push_back( std::make_pair( desc->getDcuHardId(), db_->deviceAddress(*(nextVec[i])) ) );
-	  }
-	}
+        SiStripConfigDb::DeviceDescriptionsRange range =
+            db_->getDeviceDescriptions(device_, iter->second.partitionName());
+        if (!range.empty()) {
+          SiStripConfigDb::DeviceDescriptionsV nextVec(range.begin(), range.end());
+          for (unsigned int i = 0; i < nextVec.size(); i++) {
+            dcuDescription* desc = dynamic_cast<dcuDescription*>(nextVec[i]);
+            resultVec.push_back(std::make_pair(desc->getDcuHardId(), db_->deviceAddress(*(nextVec[i]))));
+          }
+        }
       }
     }
   }
 
-  std::vector< std::pair< std::vector<uint16_t> , std::vector<uint32_t> > > testVec;
-  std::vector< std::pair<uint32_t, SiStripConfigDb::DeviceAddress> >::iterator reorg_iter = resultVec.begin();
+  std::vector<std::pair<std::vector<uint16_t>, std::vector<uint32_t> > > testVec;
+  std::vector<std::pair<uint32_t, SiStripConfigDb::DeviceAddress> >::iterator reorg_iter = resultVec.begin();
 
-  for ( ; reorg_iter != resultVec.end(); reorg_iter++) {
-    std::vector<uint16_t> fecInfo(4,0);
+  for (; reorg_iter != resultVec.end(); reorg_iter++) {
+    std::vector<uint16_t> fecInfo(4, 0);
     fecInfo[0] = reorg_iter->second.fecCrate_;
     fecInfo[1] = reorg_iter->second.fecSlot_;
     fecInfo[2] = reorg_iter->second.fecRing_;
     fecInfo[3] = reorg_iter->second.ccuAddr_;
     std::vector<uint32_t> dcuids;
-    std::vector< std::pair<uint32_t, SiStripConfigDb::DeviceAddress> >::iterator jter = reorg_iter;
-    for ( ; jter != resultVec.end(); jter++) {
+    std::vector<std::pair<uint32_t, SiStripConfigDb::DeviceAddress> >::iterator jter = reorg_iter;
+    for (; jter != resultVec.end(); jter++) {
       if (reorg_iter->second.fecCrate_ == jter->second.fecCrate_ &&
-	  reorg_iter->second.fecSlot_ == jter->second.fecSlot_ &&
-	  reorg_iter->second.fecRing_ == jter->second.fecRing_ &&
-	  reorg_iter->second.ccuAddr_ == jter->second.ccuAddr_) {
-	dcuids.push_back(jter->first);
+          reorg_iter->second.fecSlot_ == jter->second.fecSlot_ &&
+          reorg_iter->second.fecRing_ == jter->second.fecRing_ &&
+          reorg_iter->second.ccuAddr_ == jter->second.ccuAddr_) {
+        dcuids.push_back(jter->first);
       }
     }
     // handle duplicates
     bool isDup = false;
     for (unsigned int i = 0; i < testVec.size(); i++) {
       if (fecInfo == testVec[i].first) {
-	isDup = true;
-	dcuids.insert(dcuids.end(), (testVec[i].second).begin(), (testVec[i].second).end() );
-	std::sort(dcuids.begin(),dcuids.end());
-	std::vector<uint32_t>::iterator it = std::unique(dcuids.begin(),dcuids.end());
-	dcuids.resize( it - dcuids.begin() );
-	testVec[i].second = dcuids;
+        isDup = true;
+        dcuids.insert(dcuids.end(), (testVec[i].second).begin(), (testVec[i].second).end());
+        std::sort(dcuids.begin(), dcuids.end());
+        std::vector<uint32_t>::iterator it = std::unique(dcuids.begin(), dcuids.end());
+        dcuids.resize(it - dcuids.begin());
+        testVec[i].second = dcuids;
       }
     }
     if (!isDup) {
-      std::sort(dcuids.begin(),dcuids.end());
-      std::vector<uint32_t>::iterator it = std::unique(dcuids.begin(),dcuids.end());
-      dcuids.resize( it - dcuids.begin() );
-      testVec.push_back(std::make_pair(fecInfo,dcuids));
+      std::sort(dcuids.begin(), dcuids.end());
+      std::vector<uint32_t>::iterator it = std::unique(dcuids.begin(), dcuids.end());
+      dcuids.resize(it - dcuids.begin());
+      testVec.push_back(std::make_pair(fecInfo, dcuids));
     }
   }
   //  return resultVec;
@@ -574,27 +623,31 @@ std::vector< std::pair< std::vector<uint16_t> , std::vector<uint32_t> > > SiStri
 }
 
 std::vector<uint32_t> SiStripPsuDetIdMap::findDcuIdFromDeviceAddress(uint32_t dcuid_) {
-  std::vector< std::pair< std::vector<uint16_t> , std::vector<uint32_t> > >::iterator iter = dcu_device_addr_vector.begin();
-  std::vector< std::pair< std::vector<uint16_t> , std::vector<uint32_t> > >::iterator res_iter = dcu_device_addr_vector.end();
+  std::vector<std::pair<std::vector<uint16_t>, std::vector<uint32_t> > >::iterator iter =
+      dcu_device_addr_vector.begin();
+  std::vector<std::pair<std::vector<uint16_t>, std::vector<uint32_t> > >::iterator res_iter =
+      dcu_device_addr_vector.end();
   std::vector<uint32_t> pgDcu;
 
-  for ( ; iter != dcu_device_addr_vector.end(); iter++) {
+  for (; iter != dcu_device_addr_vector.end(); iter++) {
     std::vector<uint32_t> dcuids = iter->second;
-    std::vector<uint32_t>::iterator dcu_iter = std::find(dcuids.begin(),dcuids.end(),dcuid_);
+    std::vector<uint32_t>::iterator dcu_iter = std::find(dcuids.begin(), dcuids.end(), dcuid_);
     bool alreadyFound = false;
-    if (res_iter != dcu_device_addr_vector.end()) {alreadyFound = true;}
+    if (res_iter != dcu_device_addr_vector.end()) {
+      alreadyFound = true;
+    }
     if (dcu_iter != dcuids.end()) {
       res_iter = iter;
       if (!alreadyFound) {
-	for (unsigned int i = 0; i < dcuids.size(); i++) {
-	  if (dcuids[i] != dcuid_) {pgDcu.push_back(dcuids[i]);}
-	}
+        for (unsigned int i = 0; i < dcuids.size(); i++) {
+          if (dcuids[i] != dcuid_) {
+            pgDcu.push_back(dcuids[i]);
+          }
+        }
       } else {
-	std::cout << "Oh oh ... we have a duplicate :-(" << std::endl;
+        std::cout << "Oh oh ... we have a duplicate :-(" << std::endl;
       }
     }
   }
   return pgDcu;
 }
-
-

--- a/CalibTracker/SiStripDCS/test/Synchronization/SealModules.cc
+++ b/CalibTracker/SiStripDCS/test/Synchronization/SealModules.cc
@@ -1,5 +1,4 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.h"
 DEFINE_FWK_MODULE(SyncDCSO2O);

--- a/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.cc
+++ b/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.cc
@@ -14,30 +14,28 @@
 #include "TFile.h"
 #include "TCanvas.h"
 
-SyncDCSO2O::SyncDCSO2O(const edm::ParameterSet& iConfig)
-{
+SyncDCSO2O::SyncDCSO2O(const edm::ParameterSet& iConfig) {
   // get all digi collections
   digiProducersList_ = iConfig.getParameter<Parameters>("DigiProducersList");
 }
 
-SyncDCSO2O::~SyncDCSO2O()
-{
+SyncDCSO2O::~SyncDCSO2O() {
   std::cout << "Analyzed events with digis = " << timeInfo_.size() << std::endl;
 
   // First sort the timeInfo vector by time
   std::sort(timeInfo_.begin(), timeInfo_.end(), SortByTime());
 
-  TFile * outputFile = new TFile("digisAndHVvsTime.root", "RECREATE");
+  TFile* outputFile = new TFile("digisAndHVvsTime.root", "RECREATE");
   outputFile->cd();
 
-  TH1F * digis            = new TH1F("digis",            "digis",            timeInfo_.size(), 0, timeInfo_.size());
-  TH1F * digisWithMasking = new TH1F("digisWithMasking", "digisWithMasking", timeInfo_.size(), 0, timeInfo_.size());
-  TH1F * HVoff            = new TH1F("HVoff",            "HVoff",            timeInfo_.size(), 0, timeInfo_.size());
-  TH1F * time             = new TH1F("time",             "time",             timeInfo_.size(), 0, timeInfo_.size());
+  TH1F* digis = new TH1F("digis", "digis", timeInfo_.size(), 0, timeInfo_.size());
+  TH1F* digisWithMasking = new TH1F("digisWithMasking", "digisWithMasking", timeInfo_.size(), 0, timeInfo_.size());
+  TH1F* HVoff = new TH1F("HVoff", "HVoff", timeInfo_.size(), 0, timeInfo_.size());
+  TH1F* time = new TH1F("time", "time", timeInfo_.size(), 0, timeInfo_.size());
   std::vector<TimeInfo>::const_iterator it = timeInfo_.begin();
   // Float_t * timeArray = new Float_t[timeInfo_.size()];
-  unsigned int i=1;
-  for( ; it != timeInfo_.end(); ++it, ++i ) {
+  unsigned int i = 1;
+  for (; it != timeInfo_.end(); ++it, ++i) {
     digis->SetBinContent(i, it->digiOccupancy);
     digisWithMasking->SetBinContent(i, it->digiOccupancyWithMasking);
     HVoff->SetBinContent(i, it->HVoff);
@@ -46,7 +44,12 @@ SyncDCSO2O::~SyncDCSO2O()
     coral::TimeStamp coralTime(cond::time::to_boost(it->time));
     // N.B. we add 1 hour to the coralTime because it is the conversion from posix_time which is non-adjusted.
     // The shift of +1 gives the CERN time zone.
-    TDatime date1(coralTime.year(), coralTime.month(), coralTime.day(), coralTime.hour()+1, coralTime.minute(), coralTime.second());
+    TDatime date1(coralTime.year(),
+                  coralTime.month(),
+                  coralTime.day(),
+                  coralTime.hour() + 1,
+                  coralTime.minute(),
+                  coralTime.second());
     // timeArray[i-1] = date1.Convert();
     time->SetBinContent(i, date1.Convert());
   }
@@ -68,12 +71,12 @@ SyncDCSO2O::~SyncDCSO2O()
   time->Draw("same");
   time->Write();
 
-//   TGraph * digisGraph = buildGraph(digis, timeArray);
-//   digisGraph->Write("digisGraph");
-//   TGraph * digisWithMaskingGraph = buildGraph(digisWithMasking, timeArray);
-//   digisWithMaskingGraph->Write("digisWithMaskingGraph");
-//   TGraph * HVoffGraph = buildGraph(HVoff, timeArray);
-//   HVoffGraph->Write("HVoffGraph");
+  //   TGraph * digisGraph = buildGraph(digis, timeArray);
+  //   digisGraph->Write("digisGraph");
+  //   TGraph * digisWithMaskingGraph = buildGraph(digisWithMasking, timeArray);
+  //   digisWithMaskingGraph->Write("digisWithMaskingGraph");
+  //   TGraph * HVoffGraph = buildGraph(HVoff, timeArray);
+  //   HVoffGraph->Write("HVoffGraph");
 
   outputFile->Write();
   outputFile->Close();
@@ -82,12 +85,11 @@ SyncDCSO2O::~SyncDCSO2O()
 }
 
 // ------------ method called to for each event  ------------
-void SyncDCSO2O::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void SyncDCSO2O::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   ESHandle<SiStripDetVOff> detVOff;
-  iSetup.get<SiStripDetVOffRcd>().get( detVOff );
+  iSetup.get<SiStripDetVOffRcd>().get(detVOff);
 
   std::vector<uint32_t> detIds;
   detVOff->getDetIds(detIds);
@@ -98,7 +100,7 @@ void SyncDCSO2O::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   // std::cout << ss.str() << std::endl;
 
   // double seconds = (iEvent.time().value() >> 32);
-  std::cout << "event time = "  << iEvent.time().value() << std::endl;
+  std::cout << "event time = " << iEvent.time().value() << std::endl;
   // std::cout << "event time in seconds = "  << seconds << std::endl;
 
   coral::TimeStamp coralTime(cond::time::to_boost(iEvent.time().value()));
@@ -106,56 +108,56 @@ void SyncDCSO2O::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   std::cout << "year = " << coralTime.year() << ", month = " << coralTime.month() << ", day = " << coralTime.day();
   // N.B. we add 1 hour to the coralTime because it is the conversion from posix_time which is non-adjusted.
   // The shift of +1 gives the CERN time zone.
-  std::cout << ", hour = " << coralTime.hour()+1 << ", minute = " << coralTime.minute() << ", second = " << coralTime.second();
+  std::cout << ", hour = " << coralTime.hour() + 1 << ", minute = " << coralTime.minute()
+            << ", second = " << coralTime.second();
   std::cout << ", nanosecond = " << coralTime.nanosecond() << std::endl;
 
   getDigis(iEvent);
-  if( !(digiDetsetVector_[0].isValid()) ) std::cout << "NOT VALID DIGI COLLECTION 0" << std::endl;
+  if (!(digiDetsetVector_[0].isValid()))
+    std::cout << "NOT VALID DIGI COLLECTION 0" << std::endl;
   else {
     edm::DetSetVector<SiStripDigi>::const_iterator it = digiDetsetVector_[0]->begin();
     unsigned int totDigis = 0;
     unsigned int totDigisWithMasking = 0;
-    for( ; it != digiDetsetVector_[0]->end(); ++it ) {
+    for (; it != digiDetsetVector_[0]->end(); ++it) {
       totDigis += it->size();
       // Compute also number of digis masking detIds off according to DetVOff
-      if( !(detVOff->IsModuleHVOff(it->detId())) ) {
+      if (!(detVOff->IsModuleHVOff(it->detId()))) {
         totDigisWithMasking += it->size();
       }
     }
     std::cout << "digis = " << totDigis << std::endl;
-    timeInfo_.push_back( TimeInfo(iEvent.time().value(), totDigis, totDigisWithMasking, detVOff->getHVoffCounts()) );
+    timeInfo_.push_back(TimeInfo(iEvent.time().value(), totDigis, totDigisWithMasking, detVOff->getHVoffCounts()));
   }
 }
 
-void SyncDCSO2O::getDigis(const edm::Event& iEvent)
-{
+void SyncDCSO2O::getDigis(const edm::Event& iEvent) {
   using namespace edm;
 
   int icoll = 0;
   Parameters::iterator itDigiProducersList = digiProducersList_.begin();
-  for(; itDigiProducersList != digiProducersList_.end(); ++itDigiProducersList ) {
+  for (; itDigiProducersList != digiProducersList_.end(); ++itDigiProducersList) {
     std::string digiProducer = itDigiProducersList->getParameter<std::string>("DigiProducer");
     std::string digiLabel = itDigiProducersList->getParameter<std::string>("DigiLabel");
     // std::cout << "Reading digi for " << digiProducer << " with label: " << digiLabel << std::endl;
-    iEvent.getByLabel(digiProducer,digiLabel,digiDetsetVector_[icoll]);
+    iEvent.getByLabel(digiProducer, digiLabel, digiDetsetVector_[icoll]);
     icoll++;
   }
 }
 
 /// Build TGraphs with quantity vs time
-TGraph * SyncDCSO2O::buildGraph(TH1F * histo, Float_t * timeArray)
-{
+TGraph* SyncDCSO2O::buildGraph(TH1F* histo, Float_t* timeArray) {
   unsigned int arraySize = histo->GetNbinsX();
   // Note that the array reported has [0] = underflow and [Nbins+1] = overflow
-  Float_t * valueArray = (histo->GetArray())+1;
+  Float_t* valueArray = (histo->GetArray()) + 1;
 
-  TGraph * graph = new TGraph(arraySize, valueArray, timeArray);
+  TGraph* graph = new TGraph(arraySize, valueArray, timeArray);
   graph->Draw("A*");
   graph->GetXaxis()->SetTimeDisplay(1);
   graph->GetXaxis()->SetLabelOffset(0.02);
   graph->GetXaxis()->SetTimeFormat("#splitline{  %d}{%H:%M}");
-  graph->GetXaxis()->SetTimeOffset(0,"gmt");
-  graph->GetYaxis()->SetRangeUser(0,16000);
+  graph->GetXaxis()->SetTimeOffset(0, "gmt");
+  graph->GetYaxis()->SetRangeUser(0, 16000);
   graph->GetXaxis()->SetTitle("day/hour");
   graph->GetXaxis()->SetTitleSize(0.03);
   graph->GetXaxis()->SetTitleColor(kBlack);
@@ -170,11 +172,7 @@ TGraph * SyncDCSO2O::buildGraph(TH1F * histo, Float_t * timeArray)
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void SyncDCSO2O::beginJob()
-{
-}
+void SyncDCSO2O::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void SyncDCSO2O::endJob()
-{
-}
+void SyncDCSO2O::endJob() {}

--- a/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.h
+++ b/CalibTracker/SiStripDCS/test/Synchronization/SyncDCSO2O.h
@@ -2,7 +2,7 @@
 //
 // Package:    CalibTracker/SiStripDCS/test/Synchronization
 // Class:      SyncDCSO2O
-// 
+//
 /**\class SyncDCSO2O SyncDCSO2O.cc
 
  Description: Produces a histogram with the digi occupancy vs time and the change of payload.
@@ -42,24 +42,28 @@ public:
   ~SyncDCSO2O();
 
 private:
-  virtual void beginJob() ;
+  virtual void beginJob();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void endJob();
 
   void getDigis(const edm::Event& iEvent);
   /// Build TGraphs with quantity vs time
-  TGraph * buildGraph(TH1F * histo, Float_t * timeArray);
+  TGraph* buildGraph(TH1F* histo, Float_t* timeArray);
 
   // ----------member data ---------------------------
-  edm::Handle< edm::DetSetVector<SiStripDigi> > digiDetsetVector_[4];
+  edm::Handle<edm::DetSetVector<SiStripDigi> > digiDetsetVector_[4];
   typedef std::vector<edm::ParameterSet> Parameters;
   Parameters digiProducersList_;
 
-  struct TimeInfo
-  {
-    TimeInfo(unsigned long long inputTime, unsigned int inputDigiOccupancy, unsigned int inputDigiOccupancyWithMasking, unsigned int inputHVoff) :
-      time(inputTime), digiOccupancy(inputDigiOccupancy), digiOccupancyWithMasking(inputDigiOccupancyWithMasking), HVoff(inputHVoff)
-    {}
+  struct TimeInfo {
+    TimeInfo(unsigned long long inputTime,
+             unsigned int inputDigiOccupancy,
+             unsigned int inputDigiOccupancyWithMasking,
+             unsigned int inputHVoff)
+        : time(inputTime),
+          digiOccupancy(inputDigiOccupancy),
+          digiOccupancyWithMasking(inputDigiOccupancyWithMasking),
+          HVoff(inputHVoff) {}
 
     unsigned long long time;
     unsigned int digiOccupancy;
@@ -67,12 +71,8 @@ private:
     unsigned int HVoff;
   };
 
-  struct SortByTime
-  {
-    bool operator()(const TimeInfo & timeInfo1, const TimeInfo & timeInfo2)
-    {
-      return( timeInfo1.time < timeInfo2.time );
-    }
+  struct SortByTime {
+    bool operator()(const TimeInfo& timeInfo1, const TimeInfo& timeInfo2) { return (timeInfo1.time < timeInfo2.time); }
   };
 
   std::vector<TimeInfo> timeInfo_;

--- a/CalibTracker/SiStripDCS/test/UnitTests/TestSiStripDetVOffBuilder.cc
+++ b/CalibTracker/SiStripDCS/test/UnitTests/TestSiStripDetVOffBuilder.cc
@@ -11,11 +11,13 @@
 
 #include "CalibTracker/SiStripDCS/interface/SiStripDetVOffBuilder.h"
 
-std::vector<int> vectorDate(const int year, const int month,
-			    const int day, const int hour,
-			    const int minute, const int second,
-			    const int microsecond)
-{
+std::vector<int> vectorDate(const int year,
+                            const int month,
+                            const int day,
+                            const int hour,
+                            const int minute,
+                            const int second,
+                            const int microsecond) {
   std::vector<int> timeVector;
   timeVector.push_back(year);
   timeVector.push_back(month);
@@ -27,12 +29,11 @@ std::vector<int> vectorDate(const int year, const int month,
   return timeVector;
 }
 
-class TestSiStripDetVOffBuilder : public CppUnit::TestFixture { 
-public: 
+class TestSiStripDetVOffBuilder : public CppUnit::TestFixture {
+public:
   TestSiStripDetVOffBuilder() {}
 
-  void setUp()
-  {
+  void setUp() {
     edm::ParameterSet pset;
     // Must set the string type explicitly or it will take it as bool
     pset.addParameter("onlineDB", std::string("onlineDBString"));
@@ -43,7 +44,7 @@ public:
 
     pset.addParameter("debugModeOn", true);
 
-    pset.addParameter("Tmin", vectorDate(2009, 12, 7,  12,  0, 0, 000));
+    pset.addParameter("Tmin", vectorDate(2009, 12, 7, 12, 0, 0, 000));
     pset.addParameter("Tmax", vectorDate(2009, 12, 8, 9, 0, 0, 000));
     pset.addParameter("TSetMin", vectorDate(2007, 11, 26, 0, 0, 0, 0));
     pset.addParameter<uint32_t>("DeltaTmin", 2);
@@ -57,37 +58,31 @@ public:
     detVoff = new SiStripDetVOff;
   }
 
-  void tearDown()
-  {
+  void tearDown() {
     delete object;
     delete detVoff;
   }
 
-  void testConstructor()
-  {
-    CPPUNIT_ASSERT( object->highVoltageOnThreshold_ == 0.97 );
-    CPPUNIT_ASSERT( object->whichTable == "STATUSCHANGE" );
+  void testConstructor() {
+    CPPUNIT_ASSERT(object->highVoltageOnThreshold_ == 0.97);
+    CPPUNIT_ASSERT(object->whichTable == "STATUSCHANGE");
   }
-
 
   // Factorize the methods in SiStripDetVOffBuilder, do not call
   // coralInterface, but provide a list of modules built here.
 
-
-  void testStatusChange()
-  {
-    object->coralInterface.reset( new SiStripCoralIface(object->onlineDbConnectionString,object->authenticationPath,false) );
+  void testStatusChange() {
+    object->coralInterface.reset(
+        new SiStripCoralIface(object->onlineDbConnectionString, object->authenticationPath, false));
     SiStripDetVOffBuilder::TimesAndValues tStruct;
-    object->statusChange( object->lastStoredCondObj.second, tStruct );
+    object->statusChange(object->lastStoredCondObj.second, tStruct);
     CPPUNIT_ASSERT(tStruct.actualStatus.size() != 0);
   }
-  void testBuildDetVOffObj()
-  {
+  void testBuildDetVOffObj() {
     // CPPUNIT_ASSERT( object->BuildDetVOffObj() );
   }
 
-  void testReduction()
-  {
+  void testReduction() {
     fillModulesOff();
 
     cout << "number of IOVs before reduction = " << object->modulesOff.size() << endl;
@@ -96,7 +91,7 @@ public:
 
     cout << "number of IOVs after reduction = " << object->modulesOff.size() << endl;
     vector<pair<SiStripDetVOff *, cond::Time_t> >::const_iterator iovContent = object->modulesOff.begin();
-    for( ; iovContent != object->modulesOff.end(); ++iovContent ) {
+    for (; iovContent != object->modulesOff.end(); ++iovContent) {
       coral::TimeStamp coralTime(object->getCoralTime(iovContent->second));
       cout << "iov seconds = " << coralTime.second() << ", nanoseconds = " << coralTime.nanosecond();
       cout << ", number of modules with HV off = " << iovContent->first->getHVoffCounts() << endl;
@@ -106,58 +101,58 @@ public:
     CPPUNIT_ASSERT(object->modulesOff.size() == 5);
   }
 
-  void fillModulesOff()
-  {
+  void fillModulesOff() {
     // Initialization: all off
-    fillModule( 1,  1, 1,   0, 0 );
-    fillModule( 2,  1, 1,   0, 1000 );
-    fillModule( 3,  1, 1,   0, 2000 );
+    fillModule(1, 1, 1, 0, 0);
+    fillModule(2, 1, 1, 0, 1000);
+    fillModule(3, 1, 1, 0, 2000);
 
     // Ramping up phase: LV going on
-    fillModule( 1,  1, 0,   5, 0 );
-    fillModule( 2,  1, 0,   5, 1000 );
-    fillModule( 3,  1, 0,   5, 2000 );
+    fillModule(1, 1, 0, 5, 0);
+    fillModule(2, 1, 0, 5, 1000);
+    fillModule(3, 1, 0, 5, 2000);
     // HV going on
-    fillModule( 1,  0, 0,  10, 0 );
-    fillModule( 2,  0, 0,  10, 1000 );
-    fillModule( 3,  0, 0,  10, 2000 );
+    fillModule(1, 0, 0, 10, 0);
+    fillModule(2, 0, 0, 10, 1000);
+    fillModule(3, 0, 0, 10, 2000);
 
     // Wait some time, then switch off HV
-    fillModule( 1,  1, 0,  15, 0 );
-    fillModule( 2,  1, 0,  15, 1000 );
-    fillModule( 3,  1, 0,  15, 2000 );
+    fillModule(1, 1, 0, 15, 0);
+    fillModule(2, 1, 0, 15, 1000);
+    fillModule(3, 1, 0, 15, 2000);
     // LV off
-    fillModule( 1,  1, 1,  20, 0 );
-    fillModule( 2,  1, 1,  20, 1000 );
-    fillModule( 3,  1, 1,  20, 2000 );
+    fillModule(1, 1, 1, 20, 0);
+    fillModule(2, 1, 1, 20, 1000);
+    fillModule(3, 1, 1, 20, 2000);
 
     // fillModule( 3,  1, 0,  25, 0 );
   }
 
-  void fillModule(const unsigned int detId, const unsigned int HVoff, const unsigned int LVoff, const unsigned int seconds, const unsigned int nanoseconds)
-  {
-    // Build the cond time from the 
-    cond::Time_t condTime = object->getCondTime( coral::TimeStamp(2009, 12, 1, 1, 0, seconds, nanoseconds) );
+  void fillModule(const unsigned int detId,
+                  const unsigned int HVoff,
+                  const unsigned int LVoff,
+                  const unsigned int seconds,
+                  const unsigned int nanoseconds) {
+    // Build the cond time from the
+    cond::Time_t condTime = object->getCondTime(coral::TimeStamp(2009, 12, 1, 1, 0, seconds, nanoseconds));
     // Carefull, there is a memory leakage here. Fine if the program is kept simple.
     detVoff->put(detId, HVoff, LVoff);
-    SiStripDetVOff * localDetVoff = new SiStripDetVOff(*detVoff);
-    object->modulesOff.push_back( make_pair(localDetVoff, condTime) );
+    SiStripDetVOff *localDetVoff = new SiStripDetVOff(*detVoff);
+    object->modulesOff.push_back(make_pair(localDetVoff, condTime));
   }
 
-
   // Declare and build the test suite
-  CPPUNIT_TEST_SUITE( TestSiStripDetVOffBuilder );
-  CPPUNIT_TEST( testConstructor );
+  CPPUNIT_TEST_SUITE(TestSiStripDetVOffBuilder);
+  CPPUNIT_TEST(testConstructor);
   // CPPUNIT_TEST( testStatusChange );
-  CPPUNIT_TEST( testReduction );
+  CPPUNIT_TEST(testReduction);
   CPPUNIT_TEST_SUITE_END();
 
-
-  SiStripDetVOffBuilder * object;
-  SiStripDetVOff * detVoff;
+  SiStripDetVOffBuilder *object;
+  SiStripDetVOff *detVoff;
 };
 
 // Register the test suite in the registry.
 // This way we will have to only pass the registry to the runner
 // and it will contain all the registered test suites.
-CPPUNIT_TEST_SUITE_REGISTRATION( TestSiStripDetVOffBuilder );
+CPPUNIT_TEST_SUITE_REGISTRATION(TestSiStripDetVOffBuilder);

--- a/CalibTracker/SiStripQuality/interface/SiStripBadAPVAlgorithmFromClusterOccupancy.h
+++ b/CalibTracker/SiStripQuality/interface/SiStripBadAPVAlgorithmFromClusterOccupancy.h
@@ -2,7 +2,7 @@
 //
 // Package:    SiStripQuality
 // Class:      SiStripBadAPVAlgorithmFromClusterOccupancy
-// 
+//
 /**\class SiStripBadAPVAlgorithmFromClusterOccupancy SiStripBadAPVAlgorithmFromClusterOccupancy.h CalibTracker/SiStripQuality/src/SiStripBadAPVAlgorithmFromClusterOccupancy.cc
 
  Description: <one line class summary>
@@ -38,30 +38,30 @@
 class SiStripQuality;
 class TrackerTopology;
 
-class SiStripBadAPVAlgorithmFromClusterOccupancy{
-
+class SiStripBadAPVAlgorithmFromClusterOccupancy {
 public:
-  typedef SiStrip::QualityHistosMap HistoMap;  
-  
+  typedef SiStrip::QualityHistosMap HistoMap;
+
   SiStripBadAPVAlgorithmFromClusterOccupancy(const edm::ParameterSet&, const TrackerTopology*);
 
   virtual ~SiStripBadAPVAlgorithmFromClusterOccupancy();
 
-  void setLowOccupancyThreshold(long double low_occupancy){lowoccupancy_=low_occupancy;}
-  void setHighOccupancyThreshold(long double high_occupancy){highoccupancy_=high_occupancy;}
-  void setAbsoluteLowThreshold(long double absolute_low){absolutelow_=absolute_low;}
-  void setNumberIterations(int number_iterations){numberiterations_=number_iterations;}
-  void setAbsoluteOccupancyThreshold(long double occupancy){occupancy_=occupancy;}
-  void setNumberOfEvents(double Nevents){Nevents_=Nevents;}
+  void setLowOccupancyThreshold(long double low_occupancy) { lowoccupancy_ = low_occupancy; }
+  void setHighOccupancyThreshold(long double high_occupancy) { highoccupancy_ = high_occupancy; }
+  void setAbsoluteLowThreshold(long double absolute_low) { absolutelow_ = absolute_low; }
+  void setNumberIterations(int number_iterations) { numberiterations_ = number_iterations; }
+  void setAbsoluteOccupancyThreshold(long double occupancy) { occupancy_ = occupancy; }
+  void setNumberOfEvents(double Nevents) { Nevents_ = Nevents; }
   void setMinNumOfEvents();
-  void setOutputFileName(std::string OutputFileName, bool WriteOutputFile){OutFileName_=OutputFileName; WriteOutputFile_=WriteOutputFile;}
-  void setTrackerGeometry(const TrackerGeometry* tkgeom){TkGeom = tkgeom;}
-  void extractBadAPVs(SiStripQuality*,HistoMap&,edm::ESHandle<SiStripQuality>&);
+  void setOutputFileName(std::string OutputFileName, bool WriteOutputFile) {
+    OutFileName_ = OutputFileName;
+    WriteOutputFile_ = WriteOutputFile;
+  }
+  void setTrackerGeometry(const TrackerGeometry* tkgeom) { TkGeom = tkgeom; }
+  void extractBadAPVs(SiStripQuality*, HistoMap&, edm::ESHandle<SiStripQuality>&);
 
- private:
-
-  struct Apv{   
-
+private:
+  struct Apv {
     uint32_t detrawId;
     int modulePosition;
     int numberApvs;
@@ -69,13 +69,16 @@ public:
     double apvabsoluteOccupancy[6];
   };
 
-  void CalculateMeanAndRMS(const std::vector<Apv>&, std::pair<double,double>*, int);
+  void CalculateMeanAndRMS(const std::vector<Apv>&, std::pair<double, double>*, int);
 
-  void AnalyzeOccupancy(SiStripQuality*, std::vector<Apv>&, std::pair<double,double>*, std::vector<unsigned int>&, edm::ESHandle<SiStripQuality>&);
+  void AnalyzeOccupancy(SiStripQuality*,
+                        std::vector<Apv>&,
+                        std::pair<double, double>*,
+                        std::vector<unsigned int>&,
+                        edm::ESHandle<SiStripQuality>&);
 
-  struct pHisto{   
-
-    pHisto():_NEntries(0),_NBins(0){};
+  struct pHisto {
+    pHisto() : _NEntries(0), _NBins(0){};
     TH1F* _th1f;
     int _NEntries;
     int _NBins;
@@ -94,51 +97,84 @@ public:
   const TrackerGeometry* TkGeom;
   const TrackerTopology* tTopo;
 
-  SiStripQuality *pQuality;
+  SiStripQuality* pQuality;
 
   double stripOccupancy[6][128];
   double stripWeight[6][128];
 
-  std::vector<Apv> medianValues_TIB_Layer1; std::pair<double,double> MeanAndRms_TIB_Layer1[7];
-  std::vector<Apv> medianValues_TIB_Layer2; std::pair<double,double> MeanAndRms_TIB_Layer2[7];
-  std::vector<Apv> medianValues_TIB_Layer3; std::pair<double,double> MeanAndRms_TIB_Layer3[7];
-  std::vector<Apv> medianValues_TIB_Layer4; std::pair<double,double> MeanAndRms_TIB_Layer4[7];
+  std::vector<Apv> medianValues_TIB_Layer1;
+  std::pair<double, double> MeanAndRms_TIB_Layer1[7];
+  std::vector<Apv> medianValues_TIB_Layer2;
+  std::pair<double, double> MeanAndRms_TIB_Layer2[7];
+  std::vector<Apv> medianValues_TIB_Layer3;
+  std::pair<double, double> MeanAndRms_TIB_Layer3[7];
+  std::vector<Apv> medianValues_TIB_Layer4;
+  std::pair<double, double> MeanAndRms_TIB_Layer4[7];
 
-  std::vector<Apv> medianValues_TOB_Layer1; std::pair<double,double> MeanAndRms_TOB_Layer1[7];
-  std::vector<Apv> medianValues_TOB_Layer2; std::pair<double,double> MeanAndRms_TOB_Layer2[7];
-  std::vector<Apv> medianValues_TOB_Layer3; std::pair<double,double> MeanAndRms_TOB_Layer3[7];
-  std::vector<Apv> medianValues_TOB_Layer4; std::pair<double,double> MeanAndRms_TOB_Layer4[7];
-  std::vector<Apv> medianValues_TOB_Layer5; std::pair<double,double> MeanAndRms_TOB_Layer5[7];
-  std::vector<Apv> medianValues_TOB_Layer6; std::pair<double,double> MeanAndRms_TOB_Layer6[7];
+  std::vector<Apv> medianValues_TOB_Layer1;
+  std::pair<double, double> MeanAndRms_TOB_Layer1[7];
+  std::vector<Apv> medianValues_TOB_Layer2;
+  std::pair<double, double> MeanAndRms_TOB_Layer2[7];
+  std::vector<Apv> medianValues_TOB_Layer3;
+  std::pair<double, double> MeanAndRms_TOB_Layer3[7];
+  std::vector<Apv> medianValues_TOB_Layer4;
+  std::pair<double, double> MeanAndRms_TOB_Layer4[7];
+  std::vector<Apv> medianValues_TOB_Layer5;
+  std::pair<double, double> MeanAndRms_TOB_Layer5[7];
+  std::vector<Apv> medianValues_TOB_Layer6;
+  std::pair<double, double> MeanAndRms_TOB_Layer6[7];
 
-  std::vector<Apv> medianValues_TIDPlus_Disc1; std::pair<double,double> MeanAndRms_TIDPlus_Disc1[7];
-  std::vector<Apv> medianValues_TIDPlus_Disc2; std::pair<double,double> MeanAndRms_TIDPlus_Disc2[7];
-  std::vector<Apv> medianValues_TIDPlus_Disc3; std::pair<double,double> MeanAndRms_TIDPlus_Disc3[7];
+  std::vector<Apv> medianValues_TIDPlus_Disc1;
+  std::pair<double, double> MeanAndRms_TIDPlus_Disc1[7];
+  std::vector<Apv> medianValues_TIDPlus_Disc2;
+  std::pair<double, double> MeanAndRms_TIDPlus_Disc2[7];
+  std::vector<Apv> medianValues_TIDPlus_Disc3;
+  std::pair<double, double> MeanAndRms_TIDPlus_Disc3[7];
 
-  std::vector<Apv> medianValues_TIDMinus_Disc1; std::pair<double,double> MeanAndRms_TIDMinus_Disc1[7];
-  std::vector<Apv> medianValues_TIDMinus_Disc2; std::pair<double,double> MeanAndRms_TIDMinus_Disc2[7];
-  std::vector<Apv> medianValues_TIDMinus_Disc3; std::pair<double,double> MeanAndRms_TIDMinus_Disc3[7];
+  std::vector<Apv> medianValues_TIDMinus_Disc1;
+  std::pair<double, double> MeanAndRms_TIDMinus_Disc1[7];
+  std::vector<Apv> medianValues_TIDMinus_Disc2;
+  std::pair<double, double> MeanAndRms_TIDMinus_Disc2[7];
+  std::vector<Apv> medianValues_TIDMinus_Disc3;
+  std::pair<double, double> MeanAndRms_TIDMinus_Disc3[7];
 
-  std::vector<Apv> medianValues_TECPlus_Disc1; std::pair<double,double> MeanAndRms_TECPlus_Disc1[7];
-  std::vector<Apv> medianValues_TECPlus_Disc2; std::pair<double,double> MeanAndRms_TECPlus_Disc2[7];
-  std::vector<Apv> medianValues_TECPlus_Disc3; std::pair<double,double> MeanAndRms_TECPlus_Disc3[7];
-  std::vector<Apv> medianValues_TECPlus_Disc4; std::pair<double,double> MeanAndRms_TECPlus_Disc4[7];
-  std::vector<Apv> medianValues_TECPlus_Disc5; std::pair<double,double> MeanAndRms_TECPlus_Disc5[7];
-  std::vector<Apv> medianValues_TECPlus_Disc6; std::pair<double,double> MeanAndRms_TECPlus_Disc6[7];
-  std::vector<Apv> medianValues_TECPlus_Disc7; std::pair<double,double> MeanAndRms_TECPlus_Disc7[7];
-  std::vector<Apv> medianValues_TECPlus_Disc8; std::pair<double,double> MeanAndRms_TECPlus_Disc8[7];
-  std::vector<Apv> medianValues_TECPlus_Disc9; std::pair<double,double> MeanAndRms_TECPlus_Disc9[7];
+  std::vector<Apv> medianValues_TECPlus_Disc1;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc1[7];
+  std::vector<Apv> medianValues_TECPlus_Disc2;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc2[7];
+  std::vector<Apv> medianValues_TECPlus_Disc3;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc3[7];
+  std::vector<Apv> medianValues_TECPlus_Disc4;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc4[7];
+  std::vector<Apv> medianValues_TECPlus_Disc5;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc5[7];
+  std::vector<Apv> medianValues_TECPlus_Disc6;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc6[7];
+  std::vector<Apv> medianValues_TECPlus_Disc7;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc7[7];
+  std::vector<Apv> medianValues_TECPlus_Disc8;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc8[7];
+  std::vector<Apv> medianValues_TECPlus_Disc9;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc9[7];
 
-  std::vector<Apv> medianValues_TECMinus_Disc1; std::pair<double,double> MeanAndRms_TECMinus_Disc1[7];
-  std::vector<Apv> medianValues_TECMinus_Disc2; std::pair<double,double> MeanAndRms_TECMinus_Disc2[7];
-  std::vector<Apv> medianValues_TECMinus_Disc3; std::pair<double,double> MeanAndRms_TECMinus_Disc3[7];
-  std::vector<Apv> medianValues_TECMinus_Disc4; std::pair<double,double> MeanAndRms_TECMinus_Disc4[7];
-  std::vector<Apv> medianValues_TECMinus_Disc5; std::pair<double,double> MeanAndRms_TECMinus_Disc5[7];
-  std::vector<Apv> medianValues_TECMinus_Disc6; std::pair<double,double> MeanAndRms_TECMinus_Disc6[7];
-  std::vector<Apv> medianValues_TECMinus_Disc7; std::pair<double,double> MeanAndRms_TECMinus_Disc7[7];
-  std::vector<Apv> medianValues_TECMinus_Disc8; std::pair<double,double> MeanAndRms_TECMinus_Disc8[7];
-  std::vector<Apv> medianValues_TECMinus_Disc9; std::pair<double,double> MeanAndRms_TECMinus_Disc9[7];
-
+  std::vector<Apv> medianValues_TECMinus_Disc1;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc1[7];
+  std::vector<Apv> medianValues_TECMinus_Disc2;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc2[7];
+  std::vector<Apv> medianValues_TECMinus_Disc3;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc3[7];
+  std::vector<Apv> medianValues_TECMinus_Disc4;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc4[7];
+  std::vector<Apv> medianValues_TECMinus_Disc5;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc5[7];
+  std::vector<Apv> medianValues_TECMinus_Disc6;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc6[7];
+  std::vector<Apv> medianValues_TECMinus_Disc7;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc7[7];
+  std::vector<Apv> medianValues_TECMinus_Disc8;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc8[7];
+  std::vector<Apv> medianValues_TECMinus_Disc9;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc9[7];
 
   TFile* f;
   TTree* apvtree;
@@ -164,7 +200,6 @@ public:
   double apvAbsoluteOccupancy;
   double apvMedianOccupancy;
 
-  std::stringstream ss;   
+  std::stringstream ss;
 };
 #endif
-

--- a/CalibTracker/SiStripQuality/interface/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.h
+++ b/CalibTracker/SiStripQuality/interface/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.h
@@ -2,7 +2,7 @@
 //
 // Package:    SiStripQuality
 // Class:      SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy
-// 
+//
 /**\class SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.h CalibTracker/SiStripQuality/src/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.cc
 
  Description: <one line class summary>
@@ -41,33 +41,38 @@
 class SiStripQuality;
 class TrackerTopology;
 
-class SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy{
-
+class SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy {
 public:
-  typedef SiStrip::QualityHistosMap HistoMap;  
-  
+  typedef SiStrip::QualityHistosMap HistoMap;
+
   SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy(const edm::ParameterSet&, const TrackerTopology*);
 
   virtual ~SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy();
 
-  void setProbabilityThreshold(long double prob){prob_=prob;}
-  void setMinNumEntries(unsigned short m){MinNumEntries_=m;}
-  void setMinNumEntriesPerStrip(unsigned short m){MinNumEntriesPerStrip_=m;}
-  void setLowOccupancyThreshold(long double low_occupancy){lowoccupancy_=low_occupancy;}
-  void setHighOccupancyThreshold(long double high_occupancy){highoccupancy_=high_occupancy;}
-  void setAbsoluteLowThreshold(long double absolute_low){absolutelow_=absolute_low;}
-  void setNumberIterations(int number_iterations){numberiterations_=number_iterations;}
-  void setAbsoluteOccupancyThreshold(long double absolute_occupancy){absolute_occupancy_=absolute_occupancy;}
-  void setNumberOfEvents(double Nevents){Nevents_=Nevents;}
+  void setProbabilityThreshold(long double prob) { prob_ = prob; }
+  void setMinNumEntries(unsigned short m) { MinNumEntries_ = m; }
+  void setMinNumEntriesPerStrip(unsigned short m) { MinNumEntriesPerStrip_ = m; }
+  void setLowOccupancyThreshold(long double low_occupancy) { lowoccupancy_ = low_occupancy; }
+  void setHighOccupancyThreshold(long double high_occupancy) { highoccupancy_ = high_occupancy; }
+  void setAbsoluteLowThreshold(long double absolute_low) { absolutelow_ = absolute_low; }
+  void setNumberIterations(int number_iterations) { numberiterations_ = number_iterations; }
+  void setAbsoluteOccupancyThreshold(long double absolute_occupancy) { absolute_occupancy_ = absolute_occupancy; }
+  void setNumberOfEvents(double Nevents) { Nevents_ = Nevents; }
   void setMinNumOfEvents();
-  void setOutputFileName(std::string OutputFileName, bool WriteOutputFile, std::string DQMOutfileName, bool WriteDQMHistograms){OutFileName_=OutputFileName; WriteOutputFile_=WriteOutputFile; DQMOutfileName_=DQMOutfileName; WriteDQMHistograms_=WriteDQMHistograms;}
-  void setTrackerGeometry(const TrackerGeometry* tkgeom){TkGeom = tkgeom;}
-  void extractBadAPVSandStrips(SiStripQuality*,HistoMap&,edm::ESHandle<SiStripQuality>&);
+  void setOutputFileName(std::string OutputFileName,
+                         bool WriteOutputFile,
+                         std::string DQMOutfileName,
+                         bool WriteDQMHistograms) {
+    OutFileName_ = OutputFileName;
+    WriteOutputFile_ = WriteOutputFile;
+    DQMOutfileName_ = DQMOutfileName;
+    WriteDQMHistograms_ = WriteDQMHistograms;
+  }
+  void setTrackerGeometry(const TrackerGeometry* tkgeom) { TkGeom = tkgeom; }
+  void extractBadAPVSandStrips(SiStripQuality*, HistoMap&, edm::ESHandle<SiStripQuality>&);
 
- private:
-
-  struct Apv{   
-
+private:
+  struct Apv {
     uint32_t detrawId;
     int modulePosition;
     int numberApvs;
@@ -78,13 +83,17 @@ public:
     int NEmptyBins[6];
   };
 
-  void CalculateMeanAndRMS(const std::vector<Apv>&, std::pair<double,double>*, int);
+  void CalculateMeanAndRMS(const std::vector<Apv>&, std::pair<double, double>*, int);
 
-  void AnalyzeOccupancy(SiStripQuality*, std::vector<Apv>&, std::pair<double,double>*, std::vector<unsigned int>&, edm::ESHandle<SiStripQuality>&);
+  void AnalyzeOccupancy(SiStripQuality*,
+                        std::vector<Apv>&,
+                        std::pair<double, double>*,
+                        std::vector<unsigned int>&,
+                        edm::ESHandle<SiStripQuality>&);
 
-  void iterativeSearch(Apv&,std::vector<unsigned int>&,int);
+  void iterativeSearch(Apv&, std::vector<unsigned int>&, int);
 
-  void evaluatePoissonian(std::vector<long double>& , long double& meanVal);
+  void evaluatePoissonian(std::vector<long double>&, long double& meanVal);
 
   void setBasicTreeParameters(int detid);
 
@@ -111,51 +120,84 @@ public:
   const TrackerGeometry* TkGeom;
   const TrackerTopology* tTopo;
 
-  SiStripQuality *pQuality;
+  SiStripQuality* pQuality;
 
   double stripOccupancy[6][128];
   double stripWeight[6][128];
 
-  std::vector<Apv> medianValues_TIB_Layer1; std::pair<double,double> MeanAndRms_TIB_Layer1[7];
-  std::vector<Apv> medianValues_TIB_Layer2; std::pair<double,double> MeanAndRms_TIB_Layer2[7];
-  std::vector<Apv> medianValues_TIB_Layer3; std::pair<double,double> MeanAndRms_TIB_Layer3[7];
-  std::vector<Apv> medianValues_TIB_Layer4; std::pair<double,double> MeanAndRms_TIB_Layer4[7];
+  std::vector<Apv> medianValues_TIB_Layer1;
+  std::pair<double, double> MeanAndRms_TIB_Layer1[7];
+  std::vector<Apv> medianValues_TIB_Layer2;
+  std::pair<double, double> MeanAndRms_TIB_Layer2[7];
+  std::vector<Apv> medianValues_TIB_Layer3;
+  std::pair<double, double> MeanAndRms_TIB_Layer3[7];
+  std::vector<Apv> medianValues_TIB_Layer4;
+  std::pair<double, double> MeanAndRms_TIB_Layer4[7];
 
-  std::vector<Apv> medianValues_TOB_Layer1; std::pair<double,double> MeanAndRms_TOB_Layer1[7];
-  std::vector<Apv> medianValues_TOB_Layer2; std::pair<double,double> MeanAndRms_TOB_Layer2[7];
-  std::vector<Apv> medianValues_TOB_Layer3; std::pair<double,double> MeanAndRms_TOB_Layer3[7];
-  std::vector<Apv> medianValues_TOB_Layer4; std::pair<double,double> MeanAndRms_TOB_Layer4[7];
-  std::vector<Apv> medianValues_TOB_Layer5; std::pair<double,double> MeanAndRms_TOB_Layer5[7];
-  std::vector<Apv> medianValues_TOB_Layer6; std::pair<double,double> MeanAndRms_TOB_Layer6[7];
+  std::vector<Apv> medianValues_TOB_Layer1;
+  std::pair<double, double> MeanAndRms_TOB_Layer1[7];
+  std::vector<Apv> medianValues_TOB_Layer2;
+  std::pair<double, double> MeanAndRms_TOB_Layer2[7];
+  std::vector<Apv> medianValues_TOB_Layer3;
+  std::pair<double, double> MeanAndRms_TOB_Layer3[7];
+  std::vector<Apv> medianValues_TOB_Layer4;
+  std::pair<double, double> MeanAndRms_TOB_Layer4[7];
+  std::vector<Apv> medianValues_TOB_Layer5;
+  std::pair<double, double> MeanAndRms_TOB_Layer5[7];
+  std::vector<Apv> medianValues_TOB_Layer6;
+  std::pair<double, double> MeanAndRms_TOB_Layer6[7];
 
-  std::vector<Apv> medianValues_TIDPlus_Disc1; std::pair<double,double> MeanAndRms_TIDPlus_Disc1[7];
-  std::vector<Apv> medianValues_TIDPlus_Disc2; std::pair<double,double> MeanAndRms_TIDPlus_Disc2[7];
-  std::vector<Apv> medianValues_TIDPlus_Disc3; std::pair<double,double> MeanAndRms_TIDPlus_Disc3[7];
+  std::vector<Apv> medianValues_TIDPlus_Disc1;
+  std::pair<double, double> MeanAndRms_TIDPlus_Disc1[7];
+  std::vector<Apv> medianValues_TIDPlus_Disc2;
+  std::pair<double, double> MeanAndRms_TIDPlus_Disc2[7];
+  std::vector<Apv> medianValues_TIDPlus_Disc3;
+  std::pair<double, double> MeanAndRms_TIDPlus_Disc3[7];
 
-  std::vector<Apv> medianValues_TIDMinus_Disc1; std::pair<double,double> MeanAndRms_TIDMinus_Disc1[7];
-  std::vector<Apv> medianValues_TIDMinus_Disc2; std::pair<double,double> MeanAndRms_TIDMinus_Disc2[7];
-  std::vector<Apv> medianValues_TIDMinus_Disc3; std::pair<double,double> MeanAndRms_TIDMinus_Disc3[7];
+  std::vector<Apv> medianValues_TIDMinus_Disc1;
+  std::pair<double, double> MeanAndRms_TIDMinus_Disc1[7];
+  std::vector<Apv> medianValues_TIDMinus_Disc2;
+  std::pair<double, double> MeanAndRms_TIDMinus_Disc2[7];
+  std::vector<Apv> medianValues_TIDMinus_Disc3;
+  std::pair<double, double> MeanAndRms_TIDMinus_Disc3[7];
 
-  std::vector<Apv> medianValues_TECPlus_Disc1; std::pair<double,double> MeanAndRms_TECPlus_Disc1[7];
-  std::vector<Apv> medianValues_TECPlus_Disc2; std::pair<double,double> MeanAndRms_TECPlus_Disc2[7];
-  std::vector<Apv> medianValues_TECPlus_Disc3; std::pair<double,double> MeanAndRms_TECPlus_Disc3[7];
-  std::vector<Apv> medianValues_TECPlus_Disc4; std::pair<double,double> MeanAndRms_TECPlus_Disc4[7];
-  std::vector<Apv> medianValues_TECPlus_Disc5; std::pair<double,double> MeanAndRms_TECPlus_Disc5[7];
-  std::vector<Apv> medianValues_TECPlus_Disc6; std::pair<double,double> MeanAndRms_TECPlus_Disc6[7];
-  std::vector<Apv> medianValues_TECPlus_Disc7; std::pair<double,double> MeanAndRms_TECPlus_Disc7[7];
-  std::vector<Apv> medianValues_TECPlus_Disc8; std::pair<double,double> MeanAndRms_TECPlus_Disc8[7];
-  std::vector<Apv> medianValues_TECPlus_Disc9; std::pair<double,double> MeanAndRms_TECPlus_Disc9[7];
+  std::vector<Apv> medianValues_TECPlus_Disc1;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc1[7];
+  std::vector<Apv> medianValues_TECPlus_Disc2;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc2[7];
+  std::vector<Apv> medianValues_TECPlus_Disc3;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc3[7];
+  std::vector<Apv> medianValues_TECPlus_Disc4;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc4[7];
+  std::vector<Apv> medianValues_TECPlus_Disc5;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc5[7];
+  std::vector<Apv> medianValues_TECPlus_Disc6;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc6[7];
+  std::vector<Apv> medianValues_TECPlus_Disc7;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc7[7];
+  std::vector<Apv> medianValues_TECPlus_Disc8;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc8[7];
+  std::vector<Apv> medianValues_TECPlus_Disc9;
+  std::pair<double, double> MeanAndRms_TECPlus_Disc9[7];
 
-  std::vector<Apv> medianValues_TECMinus_Disc1; std::pair<double,double> MeanAndRms_TECMinus_Disc1[7];
-  std::vector<Apv> medianValues_TECMinus_Disc2; std::pair<double,double> MeanAndRms_TECMinus_Disc2[7];
-  std::vector<Apv> medianValues_TECMinus_Disc3; std::pair<double,double> MeanAndRms_TECMinus_Disc3[7];
-  std::vector<Apv> medianValues_TECMinus_Disc4; std::pair<double,double> MeanAndRms_TECMinus_Disc4[7];
-  std::vector<Apv> medianValues_TECMinus_Disc5; std::pair<double,double> MeanAndRms_TECMinus_Disc5[7];
-  std::vector<Apv> medianValues_TECMinus_Disc6; std::pair<double,double> MeanAndRms_TECMinus_Disc6[7];
-  std::vector<Apv> medianValues_TECMinus_Disc7; std::pair<double,double> MeanAndRms_TECMinus_Disc7[7];
-  std::vector<Apv> medianValues_TECMinus_Disc8; std::pair<double,double> MeanAndRms_TECMinus_Disc8[7];
-  std::vector<Apv> medianValues_TECMinus_Disc9; std::pair<double,double> MeanAndRms_TECMinus_Disc9[7];
-
+  std::vector<Apv> medianValues_TECMinus_Disc1;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc1[7];
+  std::vector<Apv> medianValues_TECMinus_Disc2;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc2[7];
+  std::vector<Apv> medianValues_TECMinus_Disc3;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc3[7];
+  std::vector<Apv> medianValues_TECMinus_Disc4;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc4[7];
+  std::vector<Apv> medianValues_TECMinus_Disc5;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc5[7];
+  std::vector<Apv> medianValues_TECMinus_Disc6;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc6[7];
+  std::vector<Apv> medianValues_TECMinus_Disc7;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc7[7];
+  std::vector<Apv> medianValues_TECMinus_Disc8;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc8[7];
+  std::vector<Apv> medianValues_TECMinus_Disc9;
+  std::pair<double, double> MeanAndRms_TECMinus_Disc9[7];
 
   TFile* f;
   TTree* apvtree;
@@ -181,9 +223,9 @@ public:
   float strip_global_position_y;
   float strip_global_position_z;
 
-  int    apvAbsoluteOccupancy;
+  int apvAbsoluteOccupancy;
   double apvMedianOccupancy;
-  int    isBad;
+  int isBad;
 
   TTree* striptree;
   int strip_number;
@@ -220,7 +262,7 @@ public:
   // indexes in these arrays are [SubDetId-2][LayerN]
   // histograms for [SubDetId-2][0] are global for the subdetector
   // histogram for [0][0] is global for the tracker
-  
+
   TH2F* medianVsAbsoluteOccupancy[5][10];
   TH1F* medianOccupancy[5][10];
   TH1F* absoluteOccupancy[5][10];
@@ -249,7 +291,7 @@ public:
   std::vector<TH2F*> poissonProbGoodStripsVsStripNumber;
   std::vector<TProfile*> pfxPoissonProbGoodStripsVsStripNumber;
   std::vector<TH1F*> projYPoissonProbGoodStripsVsStripNumber;
-   
+
   std::vector<TH2F*> nHitsVsStripNumber;
   std::vector<TProfile*> pfxNHitsVsStripNumber;
   std::vector<TH1F*> projXNHitsVsStripNumber;
@@ -274,4 +316,3 @@ public:
   std::string outfilename;
 };
 #endif
-

--- a/CalibTracker/SiStripQuality/interface/SiStripHotStripAlgorithmFromClusterOccupancy.h
+++ b/CalibTracker/SiStripQuality/interface/SiStripHotStripAlgorithmFromClusterOccupancy.h
@@ -2,7 +2,7 @@
 //
 // Package:    SiStripQuality
 // Class:      SiStripHotStripAlgorithmFromClusterOccupancy
-// 
+//
 /**\class SiStripHotStripAlgorithmFromClusterOccupancy SiStripHotStripAlgorithmFromClusterOccupancy.h CalibTracker/SiStripQuality/src/SiStripHotStripAlgorithmFromClusterOccupancy.cc
 
  Description: <one line class summary>
@@ -49,43 +49,45 @@
 class SiStripQuality;
 class TrackerTopology;
 
-class SiStripHotStripAlgorithmFromClusterOccupancy{
-
+class SiStripHotStripAlgorithmFromClusterOccupancy {
 public:
-  typedef SiStrip::QualityHistosMap HistoMap;  
-  
+  typedef SiStrip::QualityHistosMap HistoMap;
 
   SiStripHotStripAlgorithmFromClusterOccupancy(const edm::ParameterSet&, const TrackerTopology*);
 
   virtual ~SiStripHotStripAlgorithmFromClusterOccupancy();
 
-  void setProbabilityThreshold(long double prob){prob_=prob;}
-  void setMinNumEntries(unsigned short m){MinNumEntries_=m;}
-  void setMinNumEntriesPerStrip(unsigned short m){MinNumEntriesPerStrip_=m;}
-  void setOccupancyThreshold(long double occupancy){occupancy_=occupancy;minNevents_=occupancy_*Nevents_;}
+  void setProbabilityThreshold(long double prob) { prob_ = prob; }
+  void setMinNumEntries(unsigned short m) { MinNumEntries_ = m; }
+  void setMinNumEntriesPerStrip(unsigned short m) { MinNumEntriesPerStrip_ = m; }
+  void setOccupancyThreshold(long double occupancy) {
+    occupancy_ = occupancy;
+    minNevents_ = occupancy_ * Nevents_;
+  }
   void setNumberOfEvents(double Nevents);
-  void setOutputFileName(std::string OutputFileName, bool WriteOutputFile){OutFileName_=OutputFileName; WriteOutputFile_=WriteOutputFile;}
-  void setTrackerGeometry(const TrackerGeometry* tkgeom){TkGeom = tkgeom;}
-  void extractBadStrips(SiStripQuality*,HistoMap&,  edm::ESHandle<SiStripQuality>&);
+  void setOutputFileName(std::string OutputFileName, bool WriteOutputFile) {
+    OutFileName_ = OutputFileName;
+    WriteOutputFile_ = WriteOutputFile;
+  }
+  void setTrackerGeometry(const TrackerGeometry* tkgeom) { TkGeom = tkgeom; }
+  void extractBadStrips(SiStripQuality*, HistoMap&, edm::ESHandle<SiStripQuality>&);
 
- private:
-
+private:
   // unsigned long long m_cacheID_;
   //std::string dataLabel_;
   //edm::FileInPath fp_;
   //SiStripDetInfoFileReader* reader;
 
-  struct pHisto{   
-
-    pHisto():_NEntries(0),_NEmptyBins(0),_SubdetId(0){};
+  struct pHisto {
+    pHisto() : _NEntries(0), _NEmptyBins(0), _SubdetId(0){};
     TH1F* _th1f;
     int _NEntries;
     int _NEmptyBins;
     int _SubdetId;
   };
 
-  void iterativeSearch(pHisto&,std::vector<unsigned int>&,int);
-  void evaluatePoissonian(std::vector<long double>& , long double& meanVal);
+  void iterativeSearch(pHisto&, std::vector<unsigned int>&, int);
+  void evaluatePoissonian(std::vector<long double>&, long double& meanVal);
 
   long double prob_;
   long double ratio_;
@@ -99,7 +101,7 @@ public:
   const TrackerGeometry* TkGeom;
   const TrackerTopology* tTopo;
 
-  SiStripQuality *pQuality;
+  SiStripQuality* pQuality;
 
   TFile* f;
   TTree* striptree;
@@ -140,8 +142,6 @@ public:
   double medianapvhits[6];
   double avgapvhits[6];
 
-
-  std::stringstream ss;   
+  std::stringstream ss;
 };
 #endif
-

--- a/CalibTracker/SiStripQuality/interface/SiStripQualityHistos.h
+++ b/CalibTracker/SiStripQuality/interface/SiStripQualityHistos.h
@@ -1,11 +1,11 @@
 #ifndef SiStripQualityHistos_H
-#define  SiStripQualityHistos_H
+#define SiStripQualityHistos_H
 
 #include "boost/shared_ptr.hpp"
 #include <ext/hash_map>
 #include "TH1F.h"
 
-namespace SiStrip{
-  typedef __gnu_cxx::hash_map< unsigned int, boost::shared_ptr<TH1F> > QualityHistosMap;  
+namespace SiStrip {
+  typedef __gnu_cxx::hash_map<unsigned int, boost::shared_ptr<TH1F> > QualityHistosMap;
 }
-#endif 
+#endif

--- a/CalibTracker/SiStripQuality/plugins/SealModules.cc
+++ b/CalibTracker/SiStripQuality/plugins/SealModules.cc
@@ -5,7 +5,6 @@
 #include "CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.h"
 #include "CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.h"
 
-
 DEFINE_FWK_MODULE(SiStripBadModuleByHandBuilder);
 DEFINE_FWK_MODULE(SiStripQualityStatistics);
 DEFINE_FWK_MODULE(SiStripQualityHotStripIdentifier);

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.cc
@@ -1,50 +1,44 @@
 #include "CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.h"
 
-
 #include <iostream>
 #include <fstream>
 
-
-SiStripBadModuleByHandBuilder::SiStripBadModuleByHandBuilder(const edm::ParameterSet& iConfig) : ConditionDBWriter<SiStripBadStrip>(iConfig){
-
-  fp_ = iConfig.getUntrackedParameter<edm::FileInPath>("file",edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"));
+SiStripBadModuleByHandBuilder::SiStripBadModuleByHandBuilder(const edm::ParameterSet& iConfig)
+    : ConditionDBWriter<SiStripBadStrip>(iConfig) {
+  fp_ = iConfig.getUntrackedParameter<edm::FileInPath>(
+      "file", edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"));
   BadModuleList_ = iConfig.getUntrackedParameter<std::vector<uint32_t> >("BadModuleList");
-  printdebug_ = iConfig.getUntrackedParameter<bool>("printDebug",false);
+  printdebug_ = iConfig.getUntrackedParameter<bool>("printDebug", false);
 
-  reader = new SiStripDetInfoFileReader(fp_.fullPath());  
+  reader = new SiStripDetInfoFileReader(fp_.fullPath());
 }
 
+SiStripBadModuleByHandBuilder::~SiStripBadModuleByHandBuilder() {}
 
-SiStripBadModuleByHandBuilder::~SiStripBadModuleByHandBuilder(){
-}
-
-std::unique_ptr<SiStripBadStrip> SiStripBadModuleByHandBuilder::getNewObject(){
-  
+std::unique_ptr<SiStripBadStrip> SiStripBadModuleByHandBuilder::getNewObject() {
   auto obj = std::make_unique<SiStripBadStrip>();
 
-  unsigned int firstBadStrip=0;
+  unsigned int firstBadStrip = 0;
   unsigned short NconsecutiveBadStrips;
-  unsigned int theBadStripRange; 
+  unsigned int theBadStripRange;
 
-  for(std::vector<uint32_t>::const_iterator it=BadModuleList_.begin(); it!=BadModuleList_.end(); ++it){
-    
+  for (std::vector<uint32_t>::const_iterator it = BadModuleList_.begin(); it != BadModuleList_.end(); ++it) {
     std::vector<unsigned int> theSiStripVector;
-    
-    NconsecutiveBadStrips=reader->getNumberOfApvsAndStripLength(*it).first*128;
-    theBadStripRange = obj->encode(firstBadStrip,NconsecutiveBadStrips);
+
+    NconsecutiveBadStrips = reader->getNumberOfApvsAndStripLength(*it).first * 128;
+    theBadStripRange = obj->encode(firstBadStrip, NconsecutiveBadStrips);
     if (printdebug_)
-      edm::LogInfo("SiStripBadModuleByHandBuilder") << " BadModule " << *it << " \t"
-						   << " firstBadStrip " << firstBadStrip << "\t "
-						   << " NconsecutiveBadStrips " << NconsecutiveBadStrips << "\t "
-						   << " packed integer " << std::hex << theBadStripRange  << std::dec
-						   << std::endl; 	    
-    
+      edm::LogInfo("SiStripBadModuleByHandBuilder")
+          << " BadModule " << *it << " \t"
+          << " firstBadStrip " << firstBadStrip << "\t "
+          << " NconsecutiveBadStrips " << NconsecutiveBadStrips << "\t "
+          << " packed integer " << std::hex << theBadStripRange << std::dec << std::endl;
+
     theSiStripVector.push_back(theBadStripRange);
-    SiStripBadStrip::Range range(theSiStripVector.begin(),theSiStripVector.end());
-    if ( ! obj->put(*it,range) )
-      edm::LogError("SiStripBadModuleByHandBuilder")<<"[SiStripBadModuleByHandBuilder::analyze] detid already exists"<<std::endl;
+    SiStripBadStrip::Range range(theSiStripVector.begin(), theSiStripVector.end());
+    if (!obj->put(*it, range))
+      edm::LogError("SiStripBadModuleByHandBuilder")
+          << "[SiStripBadModuleByHandBuilder::analyze] detid already exists" << std::endl;
   }
   return obj;
 }
-
-

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.h
@@ -15,15 +15,11 @@
 #include <ext/hash_map>
 
 class SiStripBadModuleByHandBuilder : public ConditionDBWriter<SiStripBadStrip> {
-
 public:
-
   explicit SiStripBadModuleByHandBuilder(const edm::ParameterSet&);
   ~SiStripBadModuleByHandBuilder() override;
 
-
 private:
-
   std::unique_ptr<SiStripBadStrip> getNewObject() override;
 
 private:
@@ -31,6 +27,5 @@ private:
   bool printdebug_;
   std::vector<uint32_t> BadModuleList_;
   SiStripDetInfoFileReader* reader;
-
 };
 #endif

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.cc
@@ -3,13 +3,11 @@
 #include <cstdio>
 #include <string>
 
-
 // user include files
-
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
@@ -18,122 +16,123 @@
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
-
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandGauss.h"
 
-
-
 #include "CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.h"
-
-
 
 using namespace std;
 
-SiStripBadStripFromASCIIFile::SiStripBadStripFromASCIIFile( const edm::ParameterSet& iConfig ):
-  ConditionDBWriter<SiStripBadStrip>( iConfig),
-  printdebug_(iConfig.getUntrackedParameter<bool>("printDebug",false))
-{
-  fp_ = iConfig.getUntrackedParameter<edm::FileInPath>("file",edm::FileInPath("CalibTracker/SiStripQuality/data/DefectsFromConstructionDB.dat"));
- }
-
+SiStripBadStripFromASCIIFile::SiStripBadStripFromASCIIFile(const edm::ParameterSet& iConfig)
+    : ConditionDBWriter<SiStripBadStrip>(iConfig),
+      printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)) {
+  fp_ = iConfig.getUntrackedParameter<edm::FileInPath>(
+      "file", edm::FileInPath("CalibTracker/SiStripQuality/data/DefectsFromConstructionDB.dat"));
+}
 
 std::unique_ptr<SiStripBadStrip> SiStripBadStripFromASCIIFile::getNewObject() {
-
   auto SiStripBadStrip_ = std::make_unique<SiStripBadStrip>();
 
-   // open file and fill DB
+  // open file and fill DB
   ifstream infile((fp_.fullPath()).c_str());
-  if(!infile){std::cout << "Problem while trying to open File: " << (fp_.fullPath()).c_str() << std::endl;}
-  
+  if (!infile) {
+    std::cout << "Problem while trying to open File: " << (fp_.fullPath()).c_str() << std::endl;
+  }
 
   //variables needed for reading file and filling of SiStripBadStripObject
   uint32_t detid;
   short flag;
   short channel;
- 
-  bool firstrun=true;
-  short tempchannel=0;
-  int count =0;
+
+  bool firstrun = true;
+  short tempchannel = 0;
+  int count = 0;
   std::vector<unsigned int> theSiStripVector;
-  short tempflag=0;
-  uint32_t tempdetid=0;
+  short tempflag = 0;
+  uint32_t tempdetid = 0;
 
-
-   while(!infile.eof()){
-
-    // get data from file: 
+  while (!infile.eof()) {
+    // get data from file:
     //infile >> detid >> channel >> flag;
 
     //if no flag is available, use the following:
     infile >> detid >> channel;
     flag = 1;
 
-    unsigned int theBadStripRange=0;
+    unsigned int theBadStripRange = 0;
 
     // first loop ?
-    if(firstrun) {
-      tempdetid=detid;
-      tempchannel=channel;
-      tempflag=flag;
-      count =0;
-      firstrun=false;
+    if (firstrun) {
+      tempdetid = detid;
+      tempchannel = channel;
+      tempflag = flag;
+      count = 0;
+      firstrun = false;
     }
 
+    if (detid == tempdetid) {
+      if (channel != tempchannel + count || flag != tempflag) {
+        // 1.badstrip, nconsectrips, flag
+        theBadStripRange = SiStripBadStrip_->encode(
+            tempchannel - 1,
+            count,
+            tempflag);  // In the quality object, strips are counted from 0 to 767!!! Therefore "tempchannel-1"!
+                        // In the input txt-file, they have to be from 1 to 768 instead!!!
+        edm::LogInfo("SiStripBadStripFromASCIIFile")
+            << "detid " << tempdetid << " \t"
+            << " firstBadStrip " << tempchannel << "\t "
+            << " NconsecutiveBadStrips " << count << "\t "
+            << "flag " << tempflag << "\t"
+            << " packed integer " << std::hex << theBadStripRange << std::dec << std::endl;
 
-    if(detid==tempdetid){
-      if (channel!=tempchannel+count || flag != tempflag){
-	                                  // 1.badstrip, nconsectrips, flag
-	theBadStripRange = SiStripBadStrip_->encode(tempchannel-1, count, tempflag); // In the quality object, strips are counted from 0 to 767!!! Therefore "tempchannel-1"!
-	                                                                             // In the input txt-file, they have to be from 1 to 768 instead!!!
-	  edm::LogInfo("SiStripBadStripFromASCIIFile")<< "detid " << tempdetid << " \t"
-							   << " firstBadStrip " << tempchannel << "\t "
-							   << " NconsecutiveBadStrips " << count  << "\t "
-	                                                   <<"flag " << tempflag << "\t"
-							   << " packed integer " << std::hex << theBadStripRange  << std::dec
-						           << std::endl; 	    
+        theSiStripVector.push_back(theBadStripRange);
 
-	  theSiStripVector.push_back(theBadStripRange);
+        if (infile.eof()) {  // Don't forget to save the last strip before eof!!!
+          SiStripBadStrip::Range range(theSiStripVector.begin(), theSiStripVector.end());
+          if (!SiStripBadStrip_->put(tempdetid, range))
+            edm::LogError("SiStripBadStripFromASCIIFile")
+                << "[SiStripBadStripFromASCIIFile::GetNewObject] detid already exists" << std::endl;
+          theSiStripVector.clear();
+        }
 
-	  if (infile.eof()){ // Don't forget to save the last strip before eof!!!
-	    SiStripBadStrip::Range range(theSiStripVector.begin(),theSiStripVector.end());
-	    if ( ! SiStripBadStrip_->put(tempdetid,range) )
-	      edm::LogError("SiStripBadStripFromASCIIFile")<<"[SiStripBadStripFromASCIIFile::GetNewObject] detid already exists"<<std::endl;
-	    theSiStripVector.clear();
-	  }
+        count = 1;
+        tempchannel = channel;
+        tempflag = flag;
 
-	  count=1;
-	  tempchannel=channel;
-	  tempflag=flag;
-	  	
-      }else{count++;}
+      } else {
+        count++;
+      }
     }
-    
-    if(detid!=tempdetid){
-                                                    // 1.badstrip, nconsectrips, flag
-	  theBadStripRange = SiStripBadStrip_->encode(tempchannel-1, count, tempflag); // In the quality object, strips are counted from 0 to 767!!! Therefore "tempchannel-1"!
-	                                                                               // In the input txt-file, they have to be from 1 to 768 instead!!!
-	  edm::LogInfo("SiStripBadStripFromASCIIFile")<< "detid " << tempdetid << " \t"
-							   << " firstBadStrip " << tempchannel << "\t "
-							   << " NconsecutiveBadStrips " << count  << "\t "
-	                                                   <<"flag " << tempflag << "\t"
-							   << " packed integer " << std::hex << theBadStripRange  << std::dec
-						           << std::endl; 	    
-	  
-	  theSiStripVector.push_back(theBadStripRange);
-	  
-	  // populate db  object
-	  SiStripBadStrip::Range range(theSiStripVector.begin(),theSiStripVector.end());
-    if ( ! SiStripBadStrip_->put(tempdetid,range) )
-      edm::LogError("SiStripBadStripFromASCIIFile")<<"[SiStripBadStripFromASCIIFile::GetNewObject] detid already exists"<<std::endl;
-    theSiStripVector.clear();
-    
-    count=1;
-    tempdetid=detid;
-    tempchannel=channel;
-    tempflag=flag;
+
+    if (detid != tempdetid) {
+      // 1.badstrip, nconsectrips, flag
+      theBadStripRange = SiStripBadStrip_->encode(
+          tempchannel - 1,
+          count,
+          tempflag);  // In the quality object, strips are counted from 0 to 767!!! Therefore "tempchannel-1"!
+                      // In the input txt-file, they have to be from 1 to 768 instead!!!
+      edm::LogInfo("SiStripBadStripFromASCIIFile")
+          << "detid " << tempdetid << " \t"
+          << " firstBadStrip " << tempchannel << "\t "
+          << " NconsecutiveBadStrips " << count << "\t "
+          << "flag " << tempflag << "\t"
+          << " packed integer " << std::hex << theBadStripRange << std::dec << std::endl;
+
+      theSiStripVector.push_back(theBadStripRange);
+
+      // populate db  object
+      SiStripBadStrip::Range range(theSiStripVector.begin(), theSiStripVector.end());
+      if (!SiStripBadStrip_->put(tempdetid, range))
+        edm::LogError("SiStripBadStripFromASCIIFile")
+            << "[SiStripBadStripFromASCIIFile::GetNewObject] detid already exists" << std::endl;
+      theSiStripVector.clear();
+
+      count = 1;
+      tempdetid = detid;
+      tempchannel = channel;
+      tempflag = flag;
     }
-   }
- 
+  }
+
   return SiStripBadStrip_;
 }

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadStripFromASCIIFile.h
@@ -1,7 +1,6 @@
 #ifndef SiStripBadStripFromASCIIFile_H
 #define SiStripBadStripFromASCIIFile_H
 
-
 #include "CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h"
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
 
@@ -9,18 +8,13 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
-
-class SiStripBadStripFromASCIIFile:public ConditionDBWriter<SiStripBadStrip> {
-
- public:
-
-  explicit SiStripBadStripFromASCIIFile( const edm::ParameterSet& iConfig);
+class SiStripBadStripFromASCIIFile : public ConditionDBWriter<SiStripBadStrip> {
+public:
+  explicit SiStripBadStripFromASCIIFile(const edm::ParameterSet& iConfig);
 
   ~SiStripBadStripFromASCIIFile() override{};
 
-
-
- private:
+private:
   std::unique_ptr<SiStripBadStrip> getNewObject() override;
   edm::FileInPath fp_;
   bool printdebug_;

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.cc
@@ -16,200 +16,203 @@
 //Insert here the include to the algos
 #include "CalibTracker/SiStripQuality/interface/SiStripHotStripAlgorithmFromClusterOccupancy.h"
 
+SiStripQualityHotStripIdentifier::SiStripQualityHotStripIdentifier(const edm::ParameterSet& iConfig)
+    : ConditionDBWriter<SiStripBadStrip>(iConfig),
+      m_cacheID_(0),
+      dataLabel_(iConfig.getUntrackedParameter<std::string>("dataLabel", "")),
+      conf_(iConfig),
+      fp_(iConfig.getUntrackedParameter<edm::FileInPath>(
+          "file", edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))),
+      Cluster_src_(iConfig.getParameter<edm::InputTag>("Cluster_src")),
+      Track_src_(iConfig.getUntrackedParameter<edm::InputTag>("Track_src")),
+      tracksCollection_in_EventTree(iConfig.getUntrackedParameter<bool>("RemoveTrackClusters", false)),
+      tTopo(nullptr) {
+  reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
-
-SiStripQualityHotStripIdentifier::SiStripQualityHotStripIdentifier(const edm::ParameterSet& iConfig) : ConditionDBWriter<SiStripBadStrip>(iConfig),
-  m_cacheID_(0), 
-  dataLabel_(iConfig.getUntrackedParameter<std::string>("dataLabel","")),
-  conf_(iConfig), 
-  fp_(iConfig.getUntrackedParameter<edm::FileInPath>("file",edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))),
-  Cluster_src_(iConfig.getParameter<edm::InputTag>( "Cluster_src" )),
-  Track_src_(iConfig.getUntrackedParameter<edm::InputTag>( "Track_src" )),
-  tracksCollection_in_EventTree(iConfig.getUntrackedParameter<bool>("RemoveTrackClusters",false)),
-  tTopo(nullptr)
-{
-  reader = new SiStripDetInfoFileReader(fp_.fullPath());  
-
-  edm::ParameterSet pset=iConfig.getUntrackedParameter< edm::ParameterSet > ("ClusterSelection",edm::ParameterSet());
-  MinClusterWidth_=pset.getUntrackedParameter<uint32_t>("minWidth",1);
-  MaxClusterWidth_=pset.getUntrackedParameter<uint32_t>("maxWidth",1000);
+  edm::ParameterSet pset = iConfig.getUntrackedParameter<edm::ParameterSet>("ClusterSelection", edm::ParameterSet());
+  MinClusterWidth_ = pset.getUntrackedParameter<uint32_t>("minWidth", 1);
+  MaxClusterWidth_ = pset.getUntrackedParameter<uint32_t>("maxWidth", 1000);
 
   bookHistos();
 }
 
-SiStripQualityHotStripIdentifier::~SiStripQualityHotStripIdentifier(){
-}
+SiStripQualityHotStripIdentifier::~SiStripQualityHotStripIdentifier() {}
 
-std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifier::getNewObject(){
-
+std::unique_ptr<SiStripBadStrip> SiStripQualityHotStripIdentifier::getNewObject() {
   auto obj = std::make_unique<SiStripBadStrip>();
-  
-  edm::ParameterSet parameters=conf_.getParameter<edm::ParameterSet>("AlgoParameters");
+
+  edm::ParameterSet parameters = conf_.getParameter<edm::ParameterSet>("AlgoParameters");
   std::string AlgoName = parameters.getParameter<std::string>("AlgoName");
-  if (AlgoName=="SiStripHotStripAlgorithmFromClusterOccupancy"){
-    
-    edm::LogInfo("SiStripQualityHotStripIdentifier") <<" [SiStripQualityHotStripIdentifier::getNewObject] call to SiStripHotStripAlgorithmFromClusterOccupancy"<<std::endl;
+  if (AlgoName == "SiStripHotStripAlgorithmFromClusterOccupancy") {
+    edm::LogInfo("SiStripQualityHotStripIdentifier")
+        << " [SiStripQualityHotStripIdentifier::getNewObject] call to SiStripHotStripAlgorithmFromClusterOccupancy"
+        << std::endl;
 
     SiStripHotStripAlgorithmFromClusterOccupancy theIdentifier(conf_, tTopo);
-    theIdentifier.setProbabilityThreshold(parameters.getUntrackedParameter<double>("ProbabilityThreshold",1.E-7));
-    theIdentifier.setMinNumEntries(parameters.getUntrackedParameter<uint32_t>("MinNumEntries",100));
-    theIdentifier.setMinNumEntriesPerStrip(parameters.getUntrackedParameter<uint32_t>("MinNumEntriesPerStrip",5));
+    theIdentifier.setProbabilityThreshold(parameters.getUntrackedParameter<double>("ProbabilityThreshold", 1.E-7));
+    theIdentifier.setMinNumEntries(parameters.getUntrackedParameter<uint32_t>("MinNumEntries", 100));
+    theIdentifier.setMinNumEntriesPerStrip(parameters.getUntrackedParameter<uint32_t>("MinNumEntriesPerStrip", 5));
 
     SiStripQuality* qobj = new SiStripQuality();
-    theIdentifier.extractBadStrips(qobj,ClusterPositionHistoMap,SiStripQuality_);
+    theIdentifier.extractBadStrips(qobj, ClusterPositionHistoMap, SiStripQuality_);
 
-    edm::LogInfo("SiStripQualityHotStripIdentifier") <<" [SiStripQualityHotStripIdentifier::getNewObject] copy SiStripObject in SiStripBadStrip"<<std::endl;
+    edm::LogInfo("SiStripQualityHotStripIdentifier")
+        << " [SiStripQualityHotStripIdentifier::getNewObject] copy SiStripObject in SiStripBadStrip" << std::endl;
 
-    std::stringstream ss;  
-  
-    SiStripBadStrip::RegistryIterator rIter=qobj->getRegistryVectorBegin();
-    SiStripBadStrip::RegistryIterator rIterEnd=qobj->getRegistryVectorEnd();
-    for(;rIter!=rIterEnd;++rIter){
-      SiStripBadStrip::Range range(qobj->getDataVectorBegin()+rIter->ibegin,qobj->getDataVectorBegin()+rIter->iend);
-      if ( ! obj->put(rIter->detid,range) )
-	edm::LogError("SiStripQualityHotStripIdentifier")<<"[SiStripQualityHotStripIdentifier::getNewObject] detid already exists"<<std::endl;
+    std::stringstream ss;
+
+    SiStripBadStrip::RegistryIterator rIter = qobj->getRegistryVectorBegin();
+    SiStripBadStrip::RegistryIterator rIterEnd = qobj->getRegistryVectorEnd();
+    for (; rIter != rIterEnd; ++rIter) {
+      SiStripBadStrip::Range range(qobj->getDataVectorBegin() + rIter->ibegin,
+                                   qobj->getDataVectorBegin() + rIter->iend);
+      if (!obj->put(rIter->detid, range))
+        edm::LogError("SiStripQualityHotStripIdentifier")
+            << "[SiStripQualityHotStripIdentifier::getNewObject] detid already exists" << std::endl;
     }
-    edm::LogInfo("SiStripQualityHotStripIdentifier") <<" [SiStripQualityHotStripIdentifier::getNewObject] " << ss.str() << std::endl;
+    edm::LogInfo("SiStripQualityHotStripIdentifier")
+        << " [SiStripQualityHotStripIdentifier::getNewObject] " << ss.str() << std::endl;
 
   } else {
-    edm::LogError("SiStripQualityHotStripIdentifier") <<" [SiStripQualityHotStripIdentifier::getNewObject] call for a unknow HotStrip identification algoritm"<<std::endl;
+    edm::LogError("SiStripQualityHotStripIdentifier")
+        << " [SiStripQualityHotStripIdentifier::getNewObject] call for a unknow HotStrip identification algoritm"
+        << std::endl;
 
     std::vector<uint32_t> a;
-    SiStripBadStrip::Range range(a.begin(),a.end());
-    if ( ! obj->put(0xFFFFFFFF,range) )
-      edm::LogError("SiStripQualityHotStripIdentifier")<<"[SiStripQualityHotStripIdentifier::getNewObject] detid already exists"<<std::endl;
+    SiStripBadStrip::Range range(a.begin(), a.end());
+    if (!obj->put(0xFFFFFFFF, range))
+      edm::LogError("SiStripQualityHotStripIdentifier")
+          << "[SiStripQualityHotStripIdentifier::getNewObject] detid already exists" << std::endl;
   }
-  
+
   return obj;
 }
 
-void SiStripQualityHotStripIdentifier::algoBeginRun(const edm::Run& run, const edm::EventSetup& iSetup){
+void SiStripQualityHotStripIdentifier::algoBeginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   tTopo = tTopoHandle.product();
- 
-  resetHistos(); 
+
+  resetHistos();
   unsigned long long cacheID = iSetup.get<SiStripQualityRcd>().cacheIdentifier();
 
-  if (m_cacheID_ == cacheID) 
+  if (m_cacheID_ == cacheID)
     return;
 
-  m_cacheID_ = cacheID; 
+  m_cacheID_ = cacheID;
 
-  iSetup.get<SiStripQualityRcd>().get(dataLabel_,SiStripQuality_);
-
+  iSetup.get<SiStripQualityRcd>().get(dataLabel_, SiStripQuality_);
 }
 
-void SiStripQualityHotStripIdentifier::algoEndJob(){
+void SiStripQualityHotStripIdentifier::algoEndJob() {
   //Clear map
   ClusterPositionHistoMap.clear();
 }
 
-void SiStripQualityHotStripIdentifier::resetHistos(){
-  edm::LogInfo("SiStripQualityHotStripIdentifier") <<" [SiStripQualityHotStripIdentifier::resetHistos] " << std::endl;
-  SiStrip::QualityHistosMap::iterator it=ClusterPositionHistoMap.begin();
-  SiStrip::QualityHistosMap::iterator iEnd=ClusterPositionHistoMap.end();
-  for (;it!=iEnd;++it){
+void SiStripQualityHotStripIdentifier::resetHistos() {
+  edm::LogInfo("SiStripQualityHotStripIdentifier") << " [SiStripQualityHotStripIdentifier::resetHistos] " << std::endl;
+  SiStrip::QualityHistosMap::iterator it = ClusterPositionHistoMap.begin();
+  SiStrip::QualityHistosMap::iterator iEnd = ClusterPositionHistoMap.end();
+  for (; it != iEnd; ++it) {
     it->second->Reset();
   }
 }
 
-void SiStripQualityHotStripIdentifier::bookHistos(){
-  edm::LogInfo("SiStripQualityHotStripIdentifier") <<" [SiStripQualityHotStripIdentifier::bookHistos] " << std::endl;
+void SiStripQualityHotStripIdentifier::bookHistos() {
+  edm::LogInfo("SiStripQualityHotStripIdentifier") << " [SiStripQualityHotStripIdentifier::bookHistos] " << std::endl;
   char hname[1024];
-  std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >::const_iterator it =reader->getAllData().begin();
-  std::map<uint32_t, SiStripDetInfoFileReader::DetInfo >::const_iterator iEnd =reader->getAllData().end();
-  for(; it!=iEnd; ++it){    
-    sprintf(hname,"h_%d",it->first);
-    SiStrip::QualityHistosMap::iterator ref=ClusterPositionHistoMap.find(it->first);
-    if (ref==ClusterPositionHistoMap.end()){
-      ClusterPositionHistoMap[it->first]=boost::shared_ptr<TH1F>(new TH1F(hname,hname,it->second.nApvs*128,-0.5,it->second.nApvs*128-0.5));
-    }
-    else 
-      edm::LogError("SiStripQualityHotStripIdentifier") <<" [SiStripQualityHotStripIdentifier::bookHistos] DetId " << it->first << " already found in map. Ignoring new data"<<std::endl;
+  std::map<uint32_t, SiStripDetInfoFileReader::DetInfo>::const_iterator it = reader->getAllData().begin();
+  std::map<uint32_t, SiStripDetInfoFileReader::DetInfo>::const_iterator iEnd = reader->getAllData().end();
+  for (; it != iEnd; ++it) {
+    sprintf(hname, "h_%d", it->first);
+    SiStrip::QualityHistosMap::iterator ref = ClusterPositionHistoMap.find(it->first);
+    if (ref == ClusterPositionHistoMap.end()) {
+      ClusterPositionHistoMap[it->first] =
+          boost::shared_ptr<TH1F>(new TH1F(hname, hname, it->second.nApvs * 128, -0.5, it->second.nApvs * 128 - 0.5));
+    } else
+      edm::LogError("SiStripQualityHotStripIdentifier")
+          << " [SiStripQualityHotStripIdentifier::bookHistos] DetId " << it->first
+          << " already found in map. Ignoring new data" << std::endl;
   }
 }
 
-void SiStripQualityHotStripIdentifier::fillHisto(uint32_t detid,float value){
-  
-  SiStrip::QualityHistosMap::iterator ref=ClusterPositionHistoMap.find(detid);
-  if (ref!=ClusterPositionHistoMap.end())
+void SiStripQualityHotStripIdentifier::fillHisto(uint32_t detid, float value) {
+  SiStrip::QualityHistosMap::iterator ref = ClusterPositionHistoMap.find(detid);
+  if (ref != ClusterPositionHistoMap.end())
     ref->second->Fill(value);
   else
-    edm::LogError("SiStripQualityHotStripIdentifier") <<" [SiStripQualityHotStripIdentifier::fillHisto] Histogram not found in the list for DetId " << detid << " Ignoring data value "<< value <<std::endl;
+    edm::LogError("SiStripQualityHotStripIdentifier")
+        << " [SiStripQualityHotStripIdentifier::fillHisto] Histogram not found in the list for DetId " << detid
+        << " Ignoring data value " << value << std::endl;
 }
 
+void SiStripQualityHotStripIdentifier::algoAnalyze(const edm::Event& e, const edm::EventSetup& eSetup) {
+  edm::Handle<edm::DetSetVector<SiStripCluster> > dsv_SiStripCluster;
+  e.getByLabel(Cluster_src_, dsv_SiStripCluster);
 
-void SiStripQualityHotStripIdentifier::algoAnalyze(const edm::Event& e, const edm::EventSetup& eSetup){
-  edm::Handle< edm::DetSetVector<SiStripCluster> >  dsv_SiStripCluster;
-  e.getByLabel( Cluster_src_, dsv_SiStripCluster);    
-      
   edm::Handle<reco::TrackCollection> trackCollection;
-  if(tracksCollection_in_EventTree){
+  if (tracksCollection_in_EventTree) {
     e.getByLabel(Track_src_, trackCollection);
-    if(!trackCollection.isValid()){
-      edm::LogError("SiStripQualityHotStripIdentifier")<<" [SiStripQualityHotStripIdentifier::algoAnalyze] missing trackCollection with label " << Track_src_ <<std::endl;
+    if (!trackCollection.isValid()) {
+      edm::LogError("SiStripQualityHotStripIdentifier")
+          << " [SiStripQualityHotStripIdentifier::algoAnalyze] missing trackCollection with label " << Track_src_
+          << std::endl;
     }
   }
 
-  std::set<const void*> vPSiStripCluster;    
+  std::set<const void*> vPSiStripCluster;
   //Perform track study
-  if (tracksCollection_in_EventTree){
-   
+  if (tracksCollection_in_EventTree) {
     const reco::TrackCollection tC = *(trackCollection.product());
-    int i=0;
-    for (reco::TrackCollection::const_iterator track=tC.begin(); track!=tC.end(); track++){
+    int i = 0;
+    for (reco::TrackCollection::const_iterator track = tC.begin(); track != tC.end(); track++) {
       LogTrace("SiStripQualityHotStripIdentifier")
-	<< "Track number "<< i+1 
-	<< "\n\tmomentum: " << track->momentum()
-	<< "\n\tPT: " << track->pt()
-	<< "\n\tvertex: " << track->vertex()
-	<< "\n\timpact parameter: " << track->d0()
-	<< "\n\tcharge: " << track->charge()
-	<< "\n\tnormalizedChi2: " << track->normalizedChi2() 
-	<<"\n\tFrom EXTRA : "
-	<<"\n\t\touter PT "<< track->outerPt()<<std::endl;
+          << "Track number " << i + 1 << "\n\tmomentum: " << track->momentum() << "\n\tPT: " << track->pt()
+          << "\n\tvertex: " << track->vertex() << "\n\timpact parameter: " << track->d0()
+          << "\n\tcharge: " << track->charge() << "\n\tnormalizedChi2: " << track->normalizedChi2()
+          << "\n\tFrom EXTRA : "
+          << "\n\t\touter PT " << track->outerPt() << std::endl;
 
       //Loop on rechits
-      for(auto const& recHit : track->recHits()) {
-	
-	if (!recHit->isValid()){
-	  LogTrace("SiStripQualityHotStripIdentifier") <<"\t\t Invalid Hit "<<std::endl;
-	  continue;
-	}
-	
-	const SiStripRecHit2D* singleHit=dynamic_cast<const SiStripRecHit2D*>(recHit);
-	const SiStripMatchedRecHit2D* matchedHit=dynamic_cast<const SiStripMatchedRecHit2D*>(recHit);
-	const ProjectedSiStripRecHit2D* projectedHit=dynamic_cast<const ProjectedSiStripRecHit2D*>(recHit);
+      for (auto const& recHit : track->recHits()) {
+        if (!recHit->isValid()) {
+          LogTrace("SiStripQualityHotStripIdentifier") << "\t\t Invalid Hit " << std::endl;
+          continue;
+        }
 
-	if(matchedHit){
-	  vPSiStripCluster.insert((void *)&(matchedHit->monoCluster())); 
-	  vPSiStripCluster.insert((void *)&(matchedHit->stereoCluster()));         
-	} else if(projectedHit){
-	  vPSiStripCluster.insert((void *)&*(projectedHit->originalHit().cluster())); 
-	} else if(singleHit){
-          vPSiStripCluster.insert((void*)&*(singleHit->cluster())); 
-	}else{
-	  LogTrace("SiStripQualityHotStripIdentifier") << "NULL hit" << std::endl;
-	}
+        const SiStripRecHit2D* singleHit = dynamic_cast<const SiStripRecHit2D*>(recHit);
+        const SiStripMatchedRecHit2D* matchedHit = dynamic_cast<const SiStripMatchedRecHit2D*>(recHit);
+        const ProjectedSiStripRecHit2D* projectedHit = dynamic_cast<const ProjectedSiStripRecHit2D*>(recHit);
+
+        if (matchedHit) {
+          vPSiStripCluster.insert((void*)&(matchedHit->monoCluster()));
+          vPSiStripCluster.insert((void*)&(matchedHit->stereoCluster()));
+        } else if (projectedHit) {
+          vPSiStripCluster.insert((void*)&*(projectedHit->originalHit().cluster()));
+        } else if (singleHit) {
+          vPSiStripCluster.insert((void*)&*(singleHit->cluster()));
+        } else {
+          LogTrace("SiStripQualityHotStripIdentifier") << "NULL hit" << std::endl;
+        }
       }
     }
   }
-	
-  std::stringstream ss;   
+
+  std::stringstream ss;
   //Loop on Det Clusters
-  edm::DetSetVector<SiStripCluster>::const_iterator DSViter=dsv_SiStripCluster->begin();
-  for (; DSViter!=dsv_SiStripCluster->end();DSViter++){
+  edm::DetSetVector<SiStripCluster>::const_iterator DSViter = dsv_SiStripCluster->begin();
+  for (; DSViter != dsv_SiStripCluster->end(); DSViter++) {
     edm::DetSet<SiStripCluster>::const_iterator ClusIter = DSViter->data.begin();
     edm::DetSet<SiStripCluster>::const_iterator ClusIterEnd = DSViter->data.end();
-    for(; ClusIter!=ClusIterEnd; ++ClusIter) {    
-      if (MinClusterWidth_<=ClusIter->amplitudes().size() && ClusIter->amplitudes().size()<=MaxClusterWidth_) {
-	if (std::find(vPSiStripCluster.begin(),vPSiStripCluster.end(),(void*) &*ClusIter) == vPSiStripCluster.end()){
-	  if ( edm::isDebugEnabled() ) 
-	    ss << " adding cluster to histo for detid " << DSViter->id << " with barycenter "<< ClusIter->barycenter() << std::endl;
-	  fillHisto(DSViter->id,ClusIter->barycenter());
-	}
+    for (; ClusIter != ClusIterEnd; ++ClusIter) {
+      if (MinClusterWidth_ <= ClusIter->amplitudes().size() && ClusIter->amplitudes().size() <= MaxClusterWidth_) {
+        if (std::find(vPSiStripCluster.begin(), vPSiStripCluster.end(), (void*)&*ClusIter) == vPSiStripCluster.end()) {
+          if (edm::isDebugEnabled())
+            ss << " adding cluster to histo for detid " << DSViter->id << " with barycenter " << ClusIter->barycenter()
+               << std::endl;
+          fillHisto(DSViter->id, ClusIter->barycenter());
+        }
       }
     }
   }

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityHotStripIdentifier.h
@@ -20,33 +20,28 @@
 class TrackerTopology;
 
 class SiStripQualityHotStripIdentifier : public ConditionDBWriter<SiStripBadStrip> {
-
 public:
-
-  explicit SiStripQualityHotStripIdentifier(const edm::ParameterSet&);
+  explicit SiStripQualityHotStripIdentifier(const edm::ParameterSet &);
   ~SiStripQualityHotStripIdentifier() override;
 
 private:
-
- //Will be called at the beginning of the job
-  void algoBeginJob(const edm::EventSetup&) override{}
+  //Will be called at the beginning of the job
+  void algoBeginJob(const edm::EventSetup &) override {}
   //Will be called at the beginning of each run in the job
   void algoBeginRun(const edm::Run &, const edm::EventSetup &) override;
   //Will be called at the beginning of each luminosity block in the run
-  void algoBeginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override{ resetHistos(); }
+  void algoBeginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override { resetHistos(); }
   //Will be called at the end of the job
   void algoEndJob() override;
 
-
   //Will be called at every event
-  void algoAnalyze(const edm::Event&, const edm::EventSetup&) override;
+  void algoAnalyze(const edm::Event &, const edm::EventSetup &) override;
 
   std::unique_ptr<SiStripBadStrip> getNewObject() override;
 
-
   void bookHistos();
   void resetHistos();
-  void fillHisto(uint32_t detid,float value);
+  void fillHisto(uint32_t detid, float value);
 
 private:
   unsigned long long m_cacheID_;
@@ -54,11 +49,11 @@ private:
   edm::ESHandle<SiStripQuality> SiStripQuality_;
   const edm::ParameterSet conf_;
   edm::FileInPath fp_;
-  SiStripDetInfoFileReader* reader;
+  SiStripDetInfoFileReader *reader;
   edm::InputTag Cluster_src_;
   edm::InputTag Track_src_;
   bool tracksCollection_in_EventTree;
-  const TrackerTopology* tTopo;
+  const TrackerTopology *tTopo;
 
   unsigned short MinClusterWidth_, MaxClusterWidth_;
 

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SiStripQualityStatistics
 // Class:      SiStripQualityStatistics
-// 
+//
 /**\class SiStripQualityStatistics SiStripQualityStatistics.h CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
 
  Description: <one line class summary>
@@ -27,308 +27,307 @@
 #include <cstdio>
 #include <sys/time.h>
 
-
-SiStripQualityStatistics::SiStripQualityStatistics( const edm::ParameterSet& iConfig ):
-  m_cacheID_(0), 
-  dataLabel_(iConfig.getUntrackedParameter<std::string>("dataLabel","")),
-  TkMapFileName_(iConfig.getUntrackedParameter<std::string>("TkMapFileName","")),
-  fp_(iConfig.getUntrackedParameter<edm::FileInPath>("file",edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))),
-  saveTkHistoMap_(iConfig.getUntrackedParameter<bool>("SaveTkHistoMap",true)),
-  tkMap(nullptr),tkMapFullIOVs(nullptr)
-{
+SiStripQualityStatistics::SiStripQualityStatistics(const edm::ParameterSet& iConfig)
+    : m_cacheID_(0),
+      dataLabel_(iConfig.getUntrackedParameter<std::string>("dataLabel", "")),
+      TkMapFileName_(iConfig.getUntrackedParameter<std::string>("TkMapFileName", "")),
+      fp_(iConfig.getUntrackedParameter<edm::FileInPath>(
+          "file", edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"))),
+      saveTkHistoMap_(iConfig.getUntrackedParameter<bool>("SaveTkHistoMap", true)),
+      tkMap(nullptr),
+      tkMapFullIOVs(nullptr) {
   reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
-  tkMapFullIOVs=new TrackerMap( "BadComponents" );
-  tkhisto=nullptr;
+  tkMapFullIOVs = new TrackerMap("BadComponents");
+  tkhisto = nullptr;
 }
 
-SiStripQualityStatistics::~SiStripQualityStatistics()
-{
-  this->EndJob();
-}
+SiStripQualityStatistics::~SiStripQualityStatistics() { this->EndJob(); }
 
-void SiStripQualityStatistics::EndJob(){
+void SiStripQualityStatistics::EndJob() {
+  std::string filename = TkMapFileName_;
+  if (!filename.empty()) {
+    tkMapFullIOVs->save(false, 0, 0, filename);
+    filename.erase(filename.begin() + filename.find("."), filename.end());
+    tkMapFullIOVs->print(false, 0, 0, filename);
 
-  std::string filename=TkMapFileName_;
-  if (!filename.empty()){
-    tkMapFullIOVs->save(false,0,0,filename);
-    filename.erase(filename.begin()+filename.find("."),filename.end());
-    tkMapFullIOVs->print(false,0,0,filename);
-  
-    if(saveTkHistoMap_){
-      tkhisto->save(filename+".root");
-      tkhisto->saveAsCanvas(filename+"_Canvas.root","E");
+    if (saveTkHistoMap_) {
+      tkhisto->save(filename + ".root");
+      tkhisto->saveAsCanvas(filename + "_Canvas.root", "E");
     }
   }
 }
 
-void SiStripQualityStatistics::bookHistograms(DQMStore::IBooker & ibooker , const edm::Run & run, const edm::EventSetup & es)
-{
-}
+void SiStripQualityStatistics::bookHistograms(DQMStore::IBooker& ibooker,
+                                              const edm::Run& run,
+                                              const edm::EventSetup& es) {}
 
-void SiStripQualityStatistics::analyze( const edm::Event& e, const edm::EventSetup& iSetup){
+void SiStripQualityStatistics::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
-  if ( ( ! tkhisto ) && ( ! TkMapFileName_.empty() ) ) {
+  if ((!tkhisto) && (!TkMapFileName_.empty())) {
     edm::ESHandle<TkDetMap> tkDetMapHandle;
     iSetup.get<TrackerTopologyRcd>().get(tkDetMapHandle);
     //here the baseline (the value of the empty,not assigned bins) is put to -1 (default is zero)
-    tkhisto = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "BadComp","BadComp",-1.);
+    tkhisto = std::make_unique<TkHistoMap>(tkDetMapHandle.product(), "BadComp", "BadComp", -1.);
   }
 
   unsigned long long cacheID = iSetup.get<SiStripQualityRcd>().cacheIdentifier();
 
   std::stringstream ss;
 
-  if (m_cacheID_ == cacheID) 
+  if (m_cacheID_ == cacheID)
     return;
 
-  m_cacheID_ = cacheID; 
+  m_cacheID_ = cacheID;
 
   edm::ESHandle<SiStripQuality> SiStripQuality_;
-  iSetup.get<SiStripQualityRcd>().get(dataLabel_,SiStripQuality_);
-    
-  for(int i=0;i<4;++i){
-    NTkBadComponent[i]=0;
-    for(int j=0;j<19;++j){
+  iSetup.get<SiStripQualityRcd>().get(dataLabel_, SiStripQuality_);
+
+  for (int i = 0; i < 4; ++i) {
+    NTkBadComponent[i] = 0;
+    for (int j = 0; j < 19; ++j) {
       ssV[i][j].str("");
-      for(int k=0;k<4;++k)
-	NBadComponent[i][j][k]=0;
+      for (int k = 0; k < 4; ++k)
+        NBadComponent[i][j][k] = 0;
     }
   }
 
   if (tkMap)
     delete tkMap;
-  tkMap=new TrackerMap( "BadComponents" );
+  tkMap = new TrackerMap("BadComponents");
 
-
-  ss.str(""); 
-  std::vector<uint32_t> detids=reader->getAllDetIds();
-  std::vector<uint32_t>::const_iterator idet=detids.begin();
-  for(;idet!=detids.end();++idet){
+  ss.str("");
+  std::vector<uint32_t> detids = reader->getAllDetIds();
+  std::vector<uint32_t>::const_iterator idet = detids.begin();
+  for (; idet != detids.end(); ++idet) {
     ss << "detid " << (*idet) << " IsModuleUsable " << SiStripQuality_->IsModuleUsable((*idet)) << "\n";
     if (SiStripQuality_->IsModuleUsable((*idet)))
-      tkMap->fillc(*idet,0x00ff00);
+      tkMap->fillc(*idet, 0x00ff00);
   }
   LogDebug("SiStripQualityStatistics") << ss.str() << std::endl;
 
-
   std::vector<SiStripQuality::BadComponent> BC = SiStripQuality_->getBadComponentList();
-  
-  for (size_t i=0;i<BC.size();++i){
-    
+
+  for (size_t i = 0; i < BC.size(); ++i) {
     //&&&&&&&&&&&&&
     //Full Tk
     //&&&&&&&&&&&&&
 
-    if (BC[i].BadModule) 
+    if (BC[i].BadModule)
       NTkBadComponent[0]++;
-    if (BC[i].BadFibers) 
-      NTkBadComponent[1]+= ( (BC[i].BadFibers>>2)&0x1 )+ ( (BC[i].BadFibers>>1)&0x1 ) + ( (BC[i].BadFibers)&0x1 );
+    if (BC[i].BadFibers)
+      NTkBadComponent[1] += ((BC[i].BadFibers >> 2) & 0x1) + ((BC[i].BadFibers >> 1) & 0x1) + ((BC[i].BadFibers) & 0x1);
     if (BC[i].BadApvs)
-      NTkBadComponent[2]+= ( (BC[i].BadApvs>>5)&0x1 )+ ( (BC[i].BadApvs>>4)&0x1 ) + ( (BC[i].BadApvs>>3)&0x1 ) + 
-	( (BC[i].BadApvs>>2)&0x1 )+ ( (BC[i].BadApvs>>1)&0x1 ) + ( (BC[i].BadApvs)&0x1 );
+      NTkBadComponent[2] += ((BC[i].BadApvs >> 5) & 0x1) + ((BC[i].BadApvs >> 4) & 0x1) + ((BC[i].BadApvs >> 3) & 0x1) +
+                            ((BC[i].BadApvs >> 2) & 0x1) + ((BC[i].BadApvs >> 1) & 0x1) + ((BC[i].BadApvs) & 0x1);
 
     //&&&&&&&&&&&&&&&&&
     //Single SubSyste
     //&&&&&&&&&&&&&&&&&
     int component;
-    DetId detectorId=DetId(BC[i].detid);
+    DetId detectorId = DetId(BC[i].detid);
     int subDet = detectorId.subdetId();
-    if ( subDet == StripSubdetector::TIB ){
+    if (subDet == StripSubdetector::TIB) {
       //&&&&&&&&&&&&&&&&&
       //TIB
       //&&&&&&&&&&&&&&&&&
-      
-      component=tTopo->tibLayer(BC[i].detid);
-      SetBadComponents(0, component, BC[i]);         
 
-    } else if ( subDet == StripSubdetector::TID ) {
+      component = tTopo->tibLayer(BC[i].detid);
+      SetBadComponents(0, component, BC[i]);
+
+    } else if (subDet == StripSubdetector::TID) {
       //&&&&&&&&&&&&&&&&&
       //TID
       //&&&&&&&&&&&&&&&&&
 
-      component=tTopo->tidSide(BC[i].detid)==2?tTopo->tidWheel(BC[i].detid):tTopo->tidWheel(BC[i].detid)+3;
-      SetBadComponents(1, component, BC[i]);         
+      component = tTopo->tidSide(BC[i].detid) == 2 ? tTopo->tidWheel(BC[i].detid) : tTopo->tidWheel(BC[i].detid) + 3;
+      SetBadComponents(1, component, BC[i]);
 
-    } else if ( subDet == StripSubdetector::TOB ) {
+    } else if (subDet == StripSubdetector::TOB) {
       //&&&&&&&&&&&&&&&&&
       //TOB
       //&&&&&&&&&&&&&&&&&
 
-      component=tTopo->tobLayer(BC[i].detid);
-      SetBadComponents(2, component, BC[i]);         
+      component = tTopo->tobLayer(BC[i].detid);
+      SetBadComponents(2, component, BC[i]);
 
-    } else if ( subDet == StripSubdetector::TEC ) {
+    } else if (subDet == StripSubdetector::TEC) {
       //&&&&&&&&&&&&&&&&&
       //TEC
       //&&&&&&&&&&&&&&&&&
 
-      component=tTopo->tecSide(BC[i].detid)==2?tTopo->tecWheel(BC[i].detid):tTopo->tecWheel(BC[i].detid)+9;
-      SetBadComponents(3, component, BC[i]);         
-
-    }    
+      component = tTopo->tecSide(BC[i].detid) == 2 ? tTopo->tecWheel(BC[i].detid) : tTopo->tecWheel(BC[i].detid) + 9;
+      SetBadComponents(3, component, BC[i]);
+    }
   }
 
   //&&&&&&&&&&&&&&&&&&
   // Single Strip Info
   //&&&&&&&&&&&&&&&&&&
-  float percentage=0;
+  float percentage = 0;
 
   SiStripQuality::RegistryIterator rbegin = SiStripQuality_->getRegistryVectorBegin();
-  SiStripQuality::RegistryIterator rend   = SiStripQuality_->getRegistryVectorEnd();
-  
-  for (SiStripBadStrip::RegistryIterator rp=rbegin; rp != rend; ++rp) {
-    uint32_t detid=rp->detid;
+  SiStripQuality::RegistryIterator rend = SiStripQuality_->getRegistryVectorEnd();
 
-    int subdet=-999; int component=-999;
-    DetId detectorId=DetId(detid);
+  for (SiStripBadStrip::RegistryIterator rp = rbegin; rp != rend; ++rp) {
+    uint32_t detid = rp->detid;
+
+    int subdet = -999;
+    int component = -999;
+    DetId detectorId = DetId(detid);
     int subDet = detectorId.subdetId();
-    if ( subDet == StripSubdetector::TIB ){
-      subdet=0;
-      component=tTopo->tibLayer(detid);
-    } else if ( subDet == StripSubdetector::TID ) {
-      subdet=1;
-      component=tTopo->tidSide(detid)==2?tTopo->tidWheel(detid):tTopo->tidWheel(detid)+3;
-    } else if ( subDet == StripSubdetector::TOB ) {
-      subdet=2;
-      component=tTopo->tobLayer(detid);
-    } else if ( subDet == StripSubdetector::TEC ) {
-      subdet=3;
-      component=tTopo->tecSide(detid)==2?tTopo->tecWheel(detid):tTopo->tecWheel(detid)+9;
-    } 
-
-    SiStripQuality::Range sqrange = SiStripQuality::Range( SiStripQuality_->getDataVectorBegin()+rp->ibegin , SiStripQuality_->getDataVectorBegin()+rp->iend );
-        
-    percentage=0;
-    for(int it=0;it<sqrange.second-sqrange.first;it++){
-      unsigned int range=SiStripQuality_->decode( *(sqrange.first+it) ).range;
-      NTkBadComponent[3]+=range;
-      NBadComponent[subdet][0][3]+=range;
-      NBadComponent[subdet][component][3]+=range;
-      percentage+=range;
+    if (subDet == StripSubdetector::TIB) {
+      subdet = 0;
+      component = tTopo->tibLayer(detid);
+    } else if (subDet == StripSubdetector::TID) {
+      subdet = 1;
+      component = tTopo->tidSide(detid) == 2 ? tTopo->tidWheel(detid) : tTopo->tidWheel(detid) + 3;
+    } else if (subDet == StripSubdetector::TOB) {
+      subdet = 2;
+      component = tTopo->tobLayer(detid);
+    } else if (subDet == StripSubdetector::TEC) {
+      subdet = 3;
+      component = tTopo->tecSide(detid) == 2 ? tTopo->tecWheel(detid) : tTopo->tecWheel(detid) + 9;
     }
-    if(percentage!=0)
-      percentage/=128.*reader->getNumberOfApvsAndStripLength(detid).first;
-    if(percentage>1)
-      edm::LogError("SiStripQualityStatistics") <<  "PROBLEM detid " << detid << " value " << percentage<< std::endl;
+
+    SiStripQuality::Range sqrange = SiStripQuality::Range(SiStripQuality_->getDataVectorBegin() + rp->ibegin,
+                                                          SiStripQuality_->getDataVectorBegin() + rp->iend);
+
+    percentage = 0;
+    for (int it = 0; it < sqrange.second - sqrange.first; it++) {
+      unsigned int range = SiStripQuality_->decode(*(sqrange.first + it)).range;
+      NTkBadComponent[3] += range;
+      NBadComponent[subdet][0][3] += range;
+      NBadComponent[subdet][component][3] += range;
+      percentage += range;
+    }
+    if (percentage != 0)
+      percentage /= 128. * reader->getNumberOfApvsAndStripLength(detid).first;
+    if (percentage > 1)
+      edm::LogError("SiStripQualityStatistics") << "PROBLEM detid " << detid << " value " << percentage << std::endl;
 
     //------- Global Statistics on percentage of bad components along the IOVs ------//
-    tkMapFullIOVs->fill(detid,percentage);
-    if(tkhisto!=nullptr)
-      tkhisto->fill(detid,percentage);
+    tkMapFullIOVs->fill(detid, percentage);
+    if (tkhisto != nullptr)
+      tkhisto->fill(detid, percentage);
   }
-  
- 
+
   //&&&&&&&&&&&&&&&&&&
   // printout
   //&&&&&&&&&&&&&&&&&&
 
   ss.str("");
-  ss << "\n-----------------\nNew IOV starting from run " <<   e.id().run() << " event " << e.id().event() << " lumiBlock " << e.luminosityBlock() << " time " << e.time().value() << " chacheID " << m_cacheID_ << "\n-----------------\n";
+  ss << "\n-----------------\nNew IOV starting from run " << e.id().run() << " event " << e.id().event()
+     << " lumiBlock " << e.luminosityBlock() << " time " << e.time().value() << " chacheID " << m_cacheID_
+     << "\n-----------------\n";
   ss << "\n-----------------\nGlobal Info\n-----------------";
-  ss << "\nBadComponent \t   Modules \tFibers \tApvs\tStrips\n----------------------------------------------------------------";
-  ss << "\nTracker:\t\t"<<NTkBadComponent[0]<<"\t"<<NTkBadComponent[1]<<"\t"<<NTkBadComponent[2]<<"\t"<<NTkBadComponent[3];
-  ss<< "\n";
-  ss << "\nTIB:\t\t\t"<<NBadComponent[0][0][0]<<"\t"<<NBadComponent[0][0][1]<<"\t"<<NBadComponent[0][0][2]<<"\t"<<NBadComponent[0][0][3];
-  ss << "\nTID:\t\t\t"<<NBadComponent[1][0][0]<<"\t"<<NBadComponent[1][0][1]<<"\t"<<NBadComponent[1][0][2]<<"\t"<<NBadComponent[1][0][3];
-  ss << "\nTOB:\t\t\t"<<NBadComponent[2][0][0]<<"\t"<<NBadComponent[2][0][1]<<"\t"<<NBadComponent[2][0][2]<<"\t"<<NBadComponent[2][0][3];
-  ss << "\nTEC:\t\t\t"<<NBadComponent[3][0][0]<<"\t"<<NBadComponent[3][0][1]<<"\t"<<NBadComponent[3][0][2]<<"\t"<<NBadComponent[3][0][3];
+  ss << "\nBadComponent \t   Modules \tFibers "
+        "\tApvs\tStrips\n----------------------------------------------------------------";
+  ss << "\nTracker:\t\t" << NTkBadComponent[0] << "\t" << NTkBadComponent[1] << "\t" << NTkBadComponent[2] << "\t"
+     << NTkBadComponent[3];
+  ss << "\n";
+  ss << "\nTIB:\t\t\t" << NBadComponent[0][0][0] << "\t" << NBadComponent[0][0][1] << "\t" << NBadComponent[0][0][2]
+     << "\t" << NBadComponent[0][0][3];
+  ss << "\nTID:\t\t\t" << NBadComponent[1][0][0] << "\t" << NBadComponent[1][0][1] << "\t" << NBadComponent[1][0][2]
+     << "\t" << NBadComponent[1][0][3];
+  ss << "\nTOB:\t\t\t" << NBadComponent[2][0][0] << "\t" << NBadComponent[2][0][1] << "\t" << NBadComponent[2][0][2]
+     << "\t" << NBadComponent[2][0][3];
+  ss << "\nTEC:\t\t\t" << NBadComponent[3][0][0] << "\t" << NBadComponent[3][0][1] << "\t" << NBadComponent[3][0][2]
+     << "\t" << NBadComponent[3][0][3];
   ss << "\n";
 
-  for (int i=1;i<5;++i)
-    ss << "\nTIB Layer " << i   << " :\t\t"<<NBadComponent[0][i][0]<<"\t"<<NBadComponent[0][i][1]<<"\t"<<NBadComponent[0][i][2]<<"\t"<<NBadComponent[0][i][3];
+  for (int i = 1; i < 5; ++i)
+    ss << "\nTIB Layer " << i << " :\t\t" << NBadComponent[0][i][0] << "\t" << NBadComponent[0][i][1] << "\t"
+       << NBadComponent[0][i][2] << "\t" << NBadComponent[0][i][3];
   ss << "\n";
-  for (int i=1;i<4;++i)
-    ss << "\nTID+ Disk " << i   << " :\t\t"<<NBadComponent[1][i][0]<<"\t"<<NBadComponent[1][i][1]<<"\t"<<NBadComponent[1][i][2]<<"\t"<<NBadComponent[1][i][3];
-  for (int i=4;i<7;++i)
-    ss << "\nTID- Disk " << i-3 << " :\t\t"<<NBadComponent[1][i][0]<<"\t"<<NBadComponent[1][i][1]<<"\t"<<NBadComponent[1][i][2]<<"\t"<<NBadComponent[1][i][3];
+  for (int i = 1; i < 4; ++i)
+    ss << "\nTID+ Disk " << i << " :\t\t" << NBadComponent[1][i][0] << "\t" << NBadComponent[1][i][1] << "\t"
+       << NBadComponent[1][i][2] << "\t" << NBadComponent[1][i][3];
+  for (int i = 4; i < 7; ++i)
+    ss << "\nTID- Disk " << i - 3 << " :\t\t" << NBadComponent[1][i][0] << "\t" << NBadComponent[1][i][1] << "\t"
+       << NBadComponent[1][i][2] << "\t" << NBadComponent[1][i][3];
   ss << "\n";
-  for (int i=1;i<7;++i)
-    ss << "\nTOB Layer " << i   << " :\t\t"<<NBadComponent[2][i][0]<<"\t"<<NBadComponent[2][i][1]<<"\t"<<NBadComponent[2][i][2]<<"\t"<<NBadComponent[2][i][3];
+  for (int i = 1; i < 7; ++i)
+    ss << "\nTOB Layer " << i << " :\t\t" << NBadComponent[2][i][0] << "\t" << NBadComponent[2][i][1] << "\t"
+       << NBadComponent[2][i][2] << "\t" << NBadComponent[2][i][3];
   ss << "\n";
-  for (int i=1;i<10;++i)
-    ss << "\nTEC+ Disk " << i   << " :\t\t"<<NBadComponent[3][i][0]<<"\t"<<NBadComponent[3][i][1]<<"\t"<<NBadComponent[3][i][2]<<"\t"<<NBadComponent[3][i][3];
-  for (int i=10;i<19;++i)
-    ss << "\nTEC- Disk " << i-9 << " :\t\t"<<NBadComponent[3][i][0]<<"\t"<<NBadComponent[3][i][1]<<"\t"<<NBadComponent[3][i][2]<<"\t"<<NBadComponent[3][i][3];
-  ss<< "\n";
+  for (int i = 1; i < 10; ++i)
+    ss << "\nTEC+ Disk " << i << " :\t\t" << NBadComponent[3][i][0] << "\t" << NBadComponent[3][i][1] << "\t"
+       << NBadComponent[3][i][2] << "\t" << NBadComponent[3][i][3];
+  for (int i = 10; i < 19; ++i)
+    ss << "\nTEC- Disk " << i - 9 << " :\t\t" << NBadComponent[3][i][0] << "\t" << NBadComponent[3][i][1] << "\t"
+       << NBadComponent[3][i][2] << "\t" << NBadComponent[3][i][3];
+  ss << "\n";
 
-  ss << "\n----------------------------------------------------------------\n\t\t   Detid  \tModules Fibers Apvs\n----------------------------------------------------------------";
-  for (int i=1;i<5;++i)
+  ss << "\n----------------------------------------------------------------\n\t\t   Detid  \tModules Fibers "
+        "Apvs\n----------------------------------------------------------------";
+  for (int i = 1; i < 5; ++i)
     ss << "\nTIB Layer " << i << " :" << ssV[0][i].str();
   ss << "\n";
-  for (int i=1;i<4;++i)
+  for (int i = 1; i < 4; ++i)
     ss << "\nTID+ Disk " << i << " :" << ssV[1][i].str();
-  for (int i=4;i<7;++i)
-    ss << "\nTID- Disk " << i-3 << " :" << ssV[1][i].str();
+  for (int i = 4; i < 7; ++i)
+    ss << "\nTID- Disk " << i - 3 << " :" << ssV[1][i].str();
   ss << "\n";
-  for (int i=1;i<7;++i)
+  for (int i = 1; i < 7; ++i)
     ss << "\nTOB Layer " << i << " :" << ssV[2][i].str();
   ss << "\n";
-  for (int i=1;i<10;++i)
+  for (int i = 1; i < 10; ++i)
     ss << "\nTEC+ Disk " << i << " :" << ssV[3][i].str();
-  for (int i=10;i<19;++i)
-    ss << "\nTEC- Disk " << i-9 << " :" << ssV[3][i].str();
-
+  for (int i = 10; i < 19; ++i)
+    ss << "\nTEC- Disk " << i - 9 << " :" << ssV[3][i].str();
 
   edm::LogInfo("SiStripQualityStatistics") << ss.str() << std::endl;
 
-  std::string filetype=TkMapFileName_,filename=TkMapFileName_;
-  std::stringstream sRun; sRun.str("");
-  sRun << "_Run_"  << std::setw(6) << std::setfill('0')<< e.id().run() << std::setw(0) ;
-    
-  if (!filename.empty()){
-    filename.insert(filename.find("."),sRun.str());
-    tkMap->save(true,0,0,filename);
-    filename.erase(filename.begin()+filename.find("."),filename.end());
-    tkMap->print(true,0,0,filename);
+  std::string filetype = TkMapFileName_, filename = TkMapFileName_;
+  std::stringstream sRun;
+  sRun.str("");
+  sRun << "_Run_" << std::setw(6) << std::setfill('0') << e.id().run() << std::setw(0);
+
+  if (!filename.empty()) {
+    filename.insert(filename.find("."), sRun.str());
+    tkMap->save(true, 0, 0, filename);
+    filename.erase(filename.begin() + filename.find("."), filename.end());
+    tkMap->print(true, 0, 0, filename);
   }
 }
 
+void SiStripQualityStatistics::SetBadComponents(int i, int component, SiStripQuality::BadComponent& BC) {
+  int napv = reader->getNumberOfApvsAndStripLength(BC.detid).first;
 
-void SiStripQualityStatistics::SetBadComponents(int i, int component,SiStripQuality::BadComponent& BC){
+  ssV[i][component] << "\n\t\t " << BC.detid << " \t " << BC.BadModule << " \t " << ((BC.BadFibers) & 0x1) << " ";
+  if (napv == 4)
+    ssV[i][component] << "x " << ((BC.BadFibers >> 1) & 0x1);
 
-  int napv=reader->getNumberOfApvsAndStripLength(BC.detid).first;
+  if (napv == 6)
+    ssV[i][component] << ((BC.BadFibers >> 1) & 0x1) << " " << ((BC.BadFibers >> 2) & 0x1);
+  ssV[i][component] << " \t " << ((BC.BadApvs) & 0x1) << " " << ((BC.BadApvs >> 1) & 0x1) << " ";
+  if (napv == 4)
+    ssV[i][component] << "x x " << ((BC.BadApvs >> 2) & 0x1) << " " << ((BC.BadApvs >> 3) & 0x1);
+  if (napv == 6)
+    ssV[i][component] << ((BC.BadApvs >> 2) & 0x1) << " " << ((BC.BadApvs >> 3) & 0x1) << " "
+                      << ((BC.BadApvs >> 4) & 0x1) << " " << ((BC.BadApvs >> 5) & 0x1) << " ";
 
-  ssV[i][component] << "\n\t\t " 
-		    << BC.detid 
-		    << " \t " << BC.BadModule << " \t " 
-		    << ( (BC.BadFibers)&0x1 ) << " ";
-  if (napv==4)
-    ssV[i][component] << "x " <<( (BC.BadFibers>>1)&0x1 );
-  
-  if (napv==6)
-    ssV[i][component] << ( (BC.BadFibers>>1)&0x1 ) << " "
-		      << ( (BC.BadFibers>>2)&0x1 );
-  ssV[i][component] << " \t " 
-		    << ( (BC.BadApvs)&0x1 ) << " " 
-		    << ( (BC.BadApvs>>1)&0x1 ) << " ";
-  if (napv==4) 
-    ssV[i][component] << "x x " << ( (BC.BadApvs>>2)&0x1 ) << " " 
-		      << ( (BC.BadApvs>>3)&0x1 );
-  if (napv==6) 
-    ssV[i][component] << ( (BC.BadApvs>>2)&0x1 ) << " " 
-		      << ( (BC.BadApvs>>3)&0x1 ) << " " 
-		      << ( (BC.BadApvs>>4)&0x1 ) << " " 
-		      << ( (BC.BadApvs>>5)&0x1 ) << " "; 
-
-  if (BC.BadApvs){
-    NBadComponent[i][0][2]+= ( (BC.BadApvs>>5)&0x1 )+ ( (BC.BadApvs>>4)&0x1 ) + ( (BC.BadApvs>>3)&0x1 ) + 
-      ( (BC.BadApvs>>2)&0x1 )+ ( (BC.BadApvs>>1)&0x1 ) + ( (BC.BadApvs)&0x1 );
-    NBadComponent[i][component][2]+= ( (BC.BadApvs>>5)&0x1 )+ ( (BC.BadApvs>>4)&0x1 ) + ( (BC.BadApvs>>3)&0x1 ) + 
-      ( (BC.BadApvs>>2)&0x1 )+ ( (BC.BadApvs>>1)&0x1 ) + ( (BC.BadApvs)&0x1 );
-    tkMap->fillc(BC.detid,0xff0000);
+  if (BC.BadApvs) {
+    NBadComponent[i][0][2] += ((BC.BadApvs >> 5) & 0x1) + ((BC.BadApvs >> 4) & 0x1) + ((BC.BadApvs >> 3) & 0x1) +
+                              ((BC.BadApvs >> 2) & 0x1) + ((BC.BadApvs >> 1) & 0x1) + ((BC.BadApvs) & 0x1);
+    NBadComponent[i][component][2] += ((BC.BadApvs >> 5) & 0x1) + ((BC.BadApvs >> 4) & 0x1) +
+                                      ((BC.BadApvs >> 3) & 0x1) + ((BC.BadApvs >> 2) & 0x1) +
+                                      ((BC.BadApvs >> 1) & 0x1) + ((BC.BadApvs) & 0x1);
+    tkMap->fillc(BC.detid, 0xff0000);
   }
-  if (BC.BadFibers){ 
-    NBadComponent[i][0][1]+= ( (BC.BadFibers>>2)&0x1 )+ ( (BC.BadFibers>>1)&0x1 ) + ( (BC.BadFibers)&0x1 );
-    NBadComponent[i][component][1]+= ( (BC.BadFibers>>2)&0x1 )+ ( (BC.BadFibers>>1)&0x1 ) + ( (BC.BadFibers)&0x1 );
-    tkMap->fillc(BC.detid,0x0000ff);
-  }   
-  if (BC.BadModule){
+  if (BC.BadFibers) {
+    NBadComponent[i][0][1] += ((BC.BadFibers >> 2) & 0x1) + ((BC.BadFibers >> 1) & 0x1) + ((BC.BadFibers) & 0x1);
+    NBadComponent[i][component][1] +=
+        ((BC.BadFibers >> 2) & 0x1) + ((BC.BadFibers >> 1) & 0x1) + ((BC.BadFibers) & 0x1);
+    tkMap->fillc(BC.detid, 0x0000ff);
+  }
+  if (BC.BadModule) {
     NBadComponent[i][0][0]++;
     NBadComponent[i][component][0]++;
-    tkMap->fillc(BC.detid,0x0);
+    tkMap->fillc(BC.detid, 0x0);
   }
 }

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
@@ -50,7 +50,7 @@ SiStripQualityStatistics::~SiStripQualityStatistics()
 void SiStripQualityStatistics::EndJob(){
 
   std::string filename=TkMapFileName_;
-  if (filename!=""){
+  if (!filename.empty()){
     tkMapFullIOVs->save(false,0,0,filename);
     filename.erase(filename.begin()+filename.find("."),filename.end());
     tkMapFullIOVs->print(false,0,0,filename);
@@ -279,7 +279,7 @@ void SiStripQualityStatistics::analyze( const edm::Event& e, const edm::EventSet
   std::stringstream sRun; sRun.str("");
   sRun << "_Run_"  << std::setw(6) << std::setfill('0')<< e.id().run() << std::setw(0) ;
     
-  if (filename!=""){
+  if (!filename.empty()){
     filename.insert(filename.find("."),sRun.str());
     tkMap->save(true,0,0,filename);
     filename.erase(filename.begin()+filename.find("."),filename.end());

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.h
@@ -28,8 +28,8 @@ class SiStripQualityStatistics : public DQMEDAnalyzer {
   explicit SiStripQualityStatistics( const edm::ParameterSet& );
   ~SiStripQualityStatistics() override;
   
-  virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override; 
-  virtual void analyze( const edm::Event&, const edm::EventSetup& ) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override; 
+  void analyze( const edm::Event&, const edm::EventSetup& ) override;
   
  
  private:

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.h
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.h
@@ -18,40 +18,36 @@
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "DQM/SiStripCommon/interface/TkHistoMap.h" 
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
 
 #include <sstream>
 
 class SiStripQualityStatistics : public DQMEDAnalyzer {
-
- public:
-  explicit SiStripQualityStatistics( const edm::ParameterSet& );
+public:
+  explicit SiStripQualityStatistics(const edm::ParameterSet&);
   ~SiStripQualityStatistics() override;
-  
-  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override; 
-  void analyze( const edm::Event&, const edm::EventSetup& ) override;
-  
- 
- private:
 
-  void SetBadComponents(int,int,SiStripQuality::BadComponent&);
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  void SetBadComponents(int, int, SiStripQuality::BadComponent&);
   void EndJob();
-  
-  
+
   unsigned long long m_cacheID_;
   std::string dataLabel_;
   std::string TkMapFileName_;
   edm::FileInPath fp_;
   bool saveTkHistoMap_;
   //Global Info
-  int NTkBadComponent[4]; //k: 0=BadModule, 1=BadFiber, 2=BadApv, 3=BadStrips
-  int NBadComponent[4][19][4];  
+  int NTkBadComponent[4];  //k: 0=BadModule, 1=BadFiber, 2=BadApv, 3=BadStrips
+  int NBadComponent[4][19][4];
   //legend: NBadComponent[i][j][k]= SubSystem i, layer/disk/wheel j, BadModule/Fiber/Apv k
   //     i: 0=TIB, 1=TID, 2=TOB, 3=TEC
   //     k: 0=BadModule, 1=BadFiber, 2=BadApv, 3=BadStrips
   std::stringstream ssV[4][19];
 
-  TrackerMap * tkMap, *tkMapFullIOVs;
+  TrackerMap *tkMap, *tkMapFullIOVs;
   SiStripDetInfoFileReader* reader;
   std::unique_ptr<TkHistoMap> tkhisto;
 };

--- a/CalibTracker/SiStripQuality/src/SiStripBadAPVAlgorithmFromClusterOccupancy.cc
+++ b/CalibTracker/SiStripQuality/src/SiStripBadAPVAlgorithmFromClusterOccupancy.cc
@@ -1,6 +1,5 @@
 #include "CalibTracker/SiStripQuality/interface/SiStripBadAPVAlgorithmFromClusterOccupancy.h"
 
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
@@ -8,431 +7,486 @@
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 
-
-SiStripBadAPVAlgorithmFromClusterOccupancy::SiStripBadAPVAlgorithmFromClusterOccupancy(const edm::ParameterSet& iConfig, const TrackerTopology* theTopo):
-  lowoccupancy_(0),
-  highoccupancy_(100),
-  absolutelow_(0),
-  numberiterations_(2),
-  Nevents_(0),
-  occupancy_(0),
-  OutFileName_("Occupancy.root"),
-  UseInputDB_(iConfig.getUntrackedParameter<bool>("UseInputDB",false)),
-  tTopo(theTopo)
-  {
-    minNevents_=Nevents_*occupancy_;
-  }
-
-SiStripBadAPVAlgorithmFromClusterOccupancy::~SiStripBadAPVAlgorithmFromClusterOccupancy(){
-  LogTrace("SiStripBadAPVAlgorithmFromClusterOccupancy")<<"[SiStripBadAPVAlgorithmFromClusterOccupancy::~SiStripBadAPVAlgorithmFromClusterOccupancy] "<<std::endl;
+SiStripBadAPVAlgorithmFromClusterOccupancy::SiStripBadAPVAlgorithmFromClusterOccupancy(const edm::ParameterSet& iConfig,
+                                                                                       const TrackerTopology* theTopo)
+    : lowoccupancy_(0),
+      highoccupancy_(100),
+      absolutelow_(0),
+      numberiterations_(2),
+      Nevents_(0),
+      occupancy_(0),
+      OutFileName_("Occupancy.root"),
+      UseInputDB_(iConfig.getUntrackedParameter<bool>("UseInputDB", false)),
+      tTopo(theTopo) {
+  minNevents_ = Nevents_ * occupancy_;
 }
 
-void SiStripBadAPVAlgorithmFromClusterOccupancy::extractBadAPVs(SiStripQuality* siStripQuality,HistoMap& DM, edm::ESHandle<SiStripQuality>& inSiStripQuality){
+SiStripBadAPVAlgorithmFromClusterOccupancy::~SiStripBadAPVAlgorithmFromClusterOccupancy() {
+  LogTrace("SiStripBadAPVAlgorithmFromClusterOccupancy")
+      << "[SiStripBadAPVAlgorithmFromClusterOccupancy::~SiStripBadAPVAlgorithmFromClusterOccupancy] " << std::endl;
+}
 
-  LogTrace("SiStripBadAPVAlgorithmFromClusterOccupancy")<<"[SiStripBadAPVAlgorithmFromClusterOccupancy::extractBadAPVs] "<<std::endl;
+void SiStripBadAPVAlgorithmFromClusterOccupancy::extractBadAPVs(SiStripQuality* siStripQuality,
+                                                                HistoMap& DM,
+                                                                edm::ESHandle<SiStripQuality>& inSiStripQuality) {
+  LogTrace("SiStripBadAPVAlgorithmFromClusterOccupancy")
+      << "[SiStripBadAPVAlgorithmFromClusterOccupancy::extractBadAPVs] " << std::endl;
 
-  if (WriteOutputFile_==true){
-  f = new TFile(OutFileName_.c_str(),"RECREATE");
-  f->cd();
+  if (WriteOutputFile_ == true) {
+    f = new TFile(OutFileName_.c_str(), "RECREATE");
+    f->cd();
 
-  apvtree = new TTree("moduleOccupancy","tree");
+    apvtree = new TTree("moduleOccupancy", "tree");
 
-  apvtree->Branch("DetRawId",                &detrawid,                "DetRawId/I");
-  apvtree->Branch("SubDetId",                &subdetid,                "SubDetId/I");
-  apvtree->Branch("Layer_Ring",              &layer_ring,              "Layer_Ring/I");
-  apvtree->Branch("Disc",                    &disc,                    "Disc/I");
-  apvtree->Branch("IsBack",                  &isback,                  "IsBack/I");
-  apvtree->Branch("IsExternalString",        &isexternalstring,        "IsExternalString/I");
-  apvtree->Branch("IsZMinusSide",            &iszminusside,            "IsZMinusSide/I");
-  apvtree->Branch("RodStringPetal",          &rodstringpetal,          "RodStringPetal/I");
-  apvtree->Branch("IsStereo",                &isstereo,                "IsStereo/I");
-  apvtree->Branch("ModuleNumber",            &module_number,           "ModuleNumber/I");
-  apvtree->Branch("NumberOfStrips",          &number_strips,           "NumberOfStrips/I");
-  apvtree->Branch("APVGlobalPositionX",      &global_position_x,       "APVGlobalPositionX/F");
-  apvtree->Branch("APVGlobalPositionY",      &global_position_y,       "APVGlobalPositionY/F");
-  apvtree->Branch("APVGlobalPositionZ",      &global_position_z,       "APVGlobalPositionZ/F");
-  apvtree->Branch("APVNumber",               &apv_number,              "APVNumber/I");
-  apvtree->Branch("APVAbsoluteOccupancy",    &apvAbsoluteOccupancy,    "apvAbsoluteOccupancy/D");
-  apvtree->Branch("APVMedianOccupancy",      &apvMedianOccupancy,      "apvMedianOccupancy/D");
+    apvtree->Branch("DetRawId", &detrawid, "DetRawId/I");
+    apvtree->Branch("SubDetId", &subdetid, "SubDetId/I");
+    apvtree->Branch("Layer_Ring", &layer_ring, "Layer_Ring/I");
+    apvtree->Branch("Disc", &disc, "Disc/I");
+    apvtree->Branch("IsBack", &isback, "IsBack/I");
+    apvtree->Branch("IsExternalString", &isexternalstring, "IsExternalString/I");
+    apvtree->Branch("IsZMinusSide", &iszminusside, "IsZMinusSide/I");
+    apvtree->Branch("RodStringPetal", &rodstringpetal, "RodStringPetal/I");
+    apvtree->Branch("IsStereo", &isstereo, "IsStereo/I");
+    apvtree->Branch("ModuleNumber", &module_number, "ModuleNumber/I");
+    apvtree->Branch("NumberOfStrips", &number_strips, "NumberOfStrips/I");
+    apvtree->Branch("APVGlobalPositionX", &global_position_x, "APVGlobalPositionX/F");
+    apvtree->Branch("APVGlobalPositionY", &global_position_y, "APVGlobalPositionY/F");
+    apvtree->Branch("APVGlobalPositionZ", &global_position_z, "APVGlobalPositionZ/F");
+    apvtree->Branch("APVNumber", &apv_number, "APVNumber/I");
+    apvtree->Branch("APVAbsoluteOccupancy", &apvAbsoluteOccupancy, "apvAbsoluteOccupancy/D");
+    apvtree->Branch("APVMedianOccupancy", &apvMedianOccupancy, "apvMedianOccupancy/D");
   }
 
-  HistoMap::iterator it=DM.begin();
-  HistoMap::iterator itEnd=DM.end();
+  HistoMap::iterator it = DM.begin();
+  HistoMap::iterator itEnd = DM.end();
   std::vector<unsigned int> badStripList;
   uint32_t detid;
-  for (;it!=itEnd;++it){
-
+  for (; it != itEnd; ++it) {
     Apv APV;
 
-    for (int apv=0; apv<6; apv++)
-      {
-	APV.apvMedian[apv]            = 0;
-	APV.apvabsoluteOccupancy[apv] = 0;
+    for (int apv = 0; apv < 6; apv++) {
+      APV.apvMedian[apv] = 0;
+      APV.apvabsoluteOccupancy[apv] = 0;
 
-	for (int strip=0; strip<128; strip++)
-	  {
-	    stripOccupancy[apv][strip] = 0;
-	    stripWeight[apv][strip]    = 0;
-	  }
+      for (int strip = 0; strip < 128; strip++) {
+        stripOccupancy[apv][strip] = 0;
+        stripWeight[apv][strip] = 0;
       }
+    }
 
     pHisto phisto;
     phisto._th1f = it->second.get();
     phisto._NEntries = (int)phisto._th1f->GetEntries();
     phisto._NBins = phisto._th1f->GetNbinsX();
 
-    number_strips  = (int)phisto._NBins;
-    number_apvs    = number_strips/128;
+    number_strips = (int)phisto._NBins;
+    number_apvs = number_strips / 128;
     APV.numberApvs = number_apvs;
 
-    for (int apv=0; apv<number_apvs; apv++)
-      {
-	for (int strip=0; strip<128; strip++)
-	  {
-	    stripOccupancy[apv][strip]     = phisto._th1f->GetBinContent((apv*128)+strip+1); // Remember: Bin=0 is underflow bin!
-	    stripWeight[apv][strip]        = 1;
-	    APV.apvabsoluteOccupancy[apv] += phisto._th1f->GetBinContent((apv*128)+strip+1); // Remember: Bin=0 is underflow bin!
-	  }
+    for (int apv = 0; apv < number_apvs; apv++) {
+      for (int strip = 0; strip < 128; strip++) {
+        stripOccupancy[apv][strip] =
+            phisto._th1f->GetBinContent((apv * 128) + strip + 1);  // Remember: Bin=0 is underflow bin!
+        stripWeight[apv][strip] = 1;
+        APV.apvabsoluteOccupancy[apv] +=
+            phisto._th1f->GetBinContent((apv * 128) + strip + 1);  // Remember: Bin=0 is underflow bin!
       }
+    }
 
-    for (int apv=0; apv<number_apvs; apv++)
-      {
-	APV.apvMedian[apv] = TMath::Median(128,stripOccupancy[apv],stripWeight[apv]);
-      }
+    for (int apv = 0; apv < number_apvs; apv++) {
+      APV.apvMedian[apv] = TMath::Median(128, stripOccupancy[apv], stripWeight[apv]);
+    }
 
-    detid=it->first;
-    DetId detectorId=DetId(detid);
+    detid = it->first;
+    DetId detectorId = DetId(detid);
 
     if (edm::isDebugEnabled())
-      LogTrace("SiStripBadAPV") << "Analyzing detid " << detid<< std::endl;
+      LogTrace("SiStripBadAPV") << "Analyzing detid " << detid << std::endl;
 
-    detrawid     = detid;
+    detrawid = detid;
     APV.detrawId = detrawid;
-    subdetid     = detectorId.subdetId();
-    switch (detectorId.subdetId())
-      {
-      case StripSubdetector::TIB :
-	layer_ring = tTopo->tibLayer(detrawid);
-	disc       = -1;
-	isstereo   = tTopo->tibIsStereo(detrawid);
-	isback     = -1;
-	if (tTopo->tibIsExternalString(detrawid)) isexternalstring = 1;
-	else                                       isexternalstring = 0;
-	if (tTopo->tibIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
-	rodstringpetal     = tTopo->tibString(detrawid);
-	module_number      = tTopo->tibModule(detrawid);
-	APV.modulePosition = module_number;
+    subdetid = detectorId.subdetId();
+    switch (detectorId.subdetId()) {
+      case StripSubdetector::TIB:
+        layer_ring = tTopo->tibLayer(detrawid);
+        disc = -1;
+        isstereo = tTopo->tibIsStereo(detrawid);
+        isback = -1;
+        if (tTopo->tibIsExternalString(detrawid))
+          isexternalstring = 1;
+        else
+          isexternalstring = 0;
+        if (tTopo->tibIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
+        rodstringpetal = tTopo->tibString(detrawid);
+        module_number = tTopo->tibModule(detrawid);
+        APV.modulePosition = module_number;
 
-	if      (layer_ring == 1) medianValues_TIB_Layer1.push_back(APV);
-	else if (layer_ring == 2) medianValues_TIB_Layer2.push_back(APV);
-	else if (layer_ring == 3) medianValues_TIB_Layer3.push_back(APV);
-	else if (layer_ring == 4) medianValues_TIB_Layer4.push_back(APV);
-	break;
+        if (layer_ring == 1)
+          medianValues_TIB_Layer1.push_back(APV);
+        else if (layer_ring == 2)
+          medianValues_TIB_Layer2.push_back(APV);
+        else if (layer_ring == 3)
+          medianValues_TIB_Layer3.push_back(APV);
+        else if (layer_ring == 4)
+          medianValues_TIB_Layer4.push_back(APV);
+        break;
 
-      case StripSubdetector::TID :
-	layer_ring = tTopo->tidRing(detrawid);
-	disc       = tTopo->tidWheel(detrawid);
-	isstereo   = tTopo->tidIsStereo(detrawid);
-	if (tTopo->tidIsBackRing(detrawid)) isback = 1;
-	else                                 isback = 0;
-	if (tTopo->tidIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
-	isexternalstring   = -1;
-	rodstringpetal     = -1;
-	module_number      = tTopo->tidModule(detrawid);
-	APV.modulePosition = layer_ring;
+      case StripSubdetector::TID:
+        layer_ring = tTopo->tidRing(detrawid);
+        disc = tTopo->tidWheel(detrawid);
+        isstereo = tTopo->tidIsStereo(detrawid);
+        if (tTopo->tidIsBackRing(detrawid))
+          isback = 1;
+        else
+          isback = 0;
+        if (tTopo->tidIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
+        isexternalstring = -1;
+        rodstringpetal = -1;
+        module_number = tTopo->tidModule(detrawid);
+        APV.modulePosition = layer_ring;
 
-	if (iszminusside==0)
-	  {
-	    if      (disc==1) medianValues_TIDPlus_Disc1.push_back(APV);
-	    else if (disc==2) medianValues_TIDPlus_Disc2.push_back(APV);
-	    else if (disc==3) medianValues_TIDPlus_Disc3.push_back(APV);
-	  }
-	else if (iszminusside==1)
-	  {
-	    if      (disc==1) medianValues_TIDMinus_Disc1.push_back(APV);
-	    else if (disc==2) medianValues_TIDMinus_Disc2.push_back(APV);
-	    else if (disc==3) medianValues_TIDMinus_Disc3.push_back(APV);
-	  }
-	break;
+        if (iszminusside == 0) {
+          if (disc == 1)
+            medianValues_TIDPlus_Disc1.push_back(APV);
+          else if (disc == 2)
+            medianValues_TIDPlus_Disc2.push_back(APV);
+          else if (disc == 3)
+            medianValues_TIDPlus_Disc3.push_back(APV);
+        } else if (iszminusside == 1) {
+          if (disc == 1)
+            medianValues_TIDMinus_Disc1.push_back(APV);
+          else if (disc == 2)
+            medianValues_TIDMinus_Disc2.push_back(APV);
+          else if (disc == 3)
+            medianValues_TIDMinus_Disc3.push_back(APV);
+        }
+        break;
 
-      case StripSubdetector::TOB :
-	layer_ring = tTopo->tobLayer(detrawid);
-	disc       = -1;
-	isstereo   = tTopo->tobIsStereo(detrawid);
-	isback     = -1;
-	if (tTopo->tobIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
-	isexternalstring   = -1;
-	rodstringpetal     = tTopo->tobRod(detrawid);
-	module_number      = tTopo->tobModule(detrawid);
-	APV.modulePosition = module_number;
+      case StripSubdetector::TOB:
+        layer_ring = tTopo->tobLayer(detrawid);
+        disc = -1;
+        isstereo = tTopo->tobIsStereo(detrawid);
+        isback = -1;
+        if (tTopo->tobIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
+        isexternalstring = -1;
+        rodstringpetal = tTopo->tobRod(detrawid);
+        module_number = tTopo->tobModule(detrawid);
+        APV.modulePosition = module_number;
 
-	if      (layer_ring == 1) medianValues_TOB_Layer1.push_back(APV);
-	else if (layer_ring == 2) medianValues_TOB_Layer2.push_back(APV);
-	else if (layer_ring == 3) medianValues_TOB_Layer3.push_back(APV);
-	else if (layer_ring == 4) medianValues_TOB_Layer4.push_back(APV);
-	else if (layer_ring == 5) medianValues_TOB_Layer5.push_back(APV);
-	else if (layer_ring == 6) medianValues_TOB_Layer6.push_back(APV);
-	break;
+        if (layer_ring == 1)
+          medianValues_TOB_Layer1.push_back(APV);
+        else if (layer_ring == 2)
+          medianValues_TOB_Layer2.push_back(APV);
+        else if (layer_ring == 3)
+          medianValues_TOB_Layer3.push_back(APV);
+        else if (layer_ring == 4)
+          medianValues_TOB_Layer4.push_back(APV);
+        else if (layer_ring == 5)
+          medianValues_TOB_Layer5.push_back(APV);
+        else if (layer_ring == 6)
+          medianValues_TOB_Layer6.push_back(APV);
+        break;
 
-      case StripSubdetector::TEC :
-	layer_ring = tTopo->tecRing(detrawid);
-	disc       = tTopo->tecWheel(detrawid);
-	isstereo   = tTopo->tecIsStereo(detrawid);
-	if (tTopo->tecIsBackPetal(detrawid)) isback = 1;
-	else                                  isback = 0;
-	if (tTopo->tecIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
-	isexternalstring   = -1;
-	rodstringpetal     = tTopo->tecPetalNumber(detrawid);
-	module_number      = tTopo->tecModule(detrawid);
-	APV.modulePosition = layer_ring;
+      case StripSubdetector::TEC:
+        layer_ring = tTopo->tecRing(detrawid);
+        disc = tTopo->tecWheel(detrawid);
+        isstereo = tTopo->tecIsStereo(detrawid);
+        if (tTopo->tecIsBackPetal(detrawid))
+          isback = 1;
+        else
+          isback = 0;
+        if (tTopo->tecIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
+        isexternalstring = -1;
+        rodstringpetal = tTopo->tecPetalNumber(detrawid);
+        module_number = tTopo->tecModule(detrawid);
+        APV.modulePosition = layer_ring;
 
-	if (iszminusside==0)
-	  {
-	    if      (disc==1) medianValues_TECPlus_Disc1.push_back(APV);
-	    else if (disc==2) medianValues_TECPlus_Disc2.push_back(APV);
-	    else if (disc==3) medianValues_TECPlus_Disc3.push_back(APV);
-	    else if (disc==4) medianValues_TECPlus_Disc4.push_back(APV);
-	    else if (disc==5) medianValues_TECPlus_Disc5.push_back(APV);
-	    else if (disc==6) medianValues_TECPlus_Disc6.push_back(APV);
-	    else if (disc==7) medianValues_TECPlus_Disc7.push_back(APV);
-	    else if (disc==8) medianValues_TECPlus_Disc8.push_back(APV);
-	    else if (disc==9) medianValues_TECPlus_Disc9.push_back(APV);
-	  }
-	else if (iszminusside==1)
-	  {
-	    if      (disc==1) medianValues_TECMinus_Disc1.push_back(APV);
-	    else if (disc==2) medianValues_TECMinus_Disc2.push_back(APV);
-	    else if (disc==3) medianValues_TECMinus_Disc3.push_back(APV);
-	    else if (disc==4) medianValues_TECMinus_Disc4.push_back(APV);
-	    else if (disc==5) medianValues_TECMinus_Disc5.push_back(APV);
-	    else if (disc==6) medianValues_TECMinus_Disc6.push_back(APV);
-	    else if (disc==7) medianValues_TECMinus_Disc7.push_back(APV);
-	    else if (disc==8) medianValues_TECMinus_Disc8.push_back(APV);
-	    else if (disc==9) medianValues_TECMinus_Disc9.push_back(APV);
-	  }
-	break;
+        if (iszminusside == 0) {
+          if (disc == 1)
+            medianValues_TECPlus_Disc1.push_back(APV);
+          else if (disc == 2)
+            medianValues_TECPlus_Disc2.push_back(APV);
+          else if (disc == 3)
+            medianValues_TECPlus_Disc3.push_back(APV);
+          else if (disc == 4)
+            medianValues_TECPlus_Disc4.push_back(APV);
+          else if (disc == 5)
+            medianValues_TECPlus_Disc5.push_back(APV);
+          else if (disc == 6)
+            medianValues_TECPlus_Disc6.push_back(APV);
+          else if (disc == 7)
+            medianValues_TECPlus_Disc7.push_back(APV);
+          else if (disc == 8)
+            medianValues_TECPlus_Disc8.push_back(APV);
+          else if (disc == 9)
+            medianValues_TECPlus_Disc9.push_back(APV);
+        } else if (iszminusside == 1) {
+          if (disc == 1)
+            medianValues_TECMinus_Disc1.push_back(APV);
+          else if (disc == 2)
+            medianValues_TECMinus_Disc2.push_back(APV);
+          else if (disc == 3)
+            medianValues_TECMinus_Disc3.push_back(APV);
+          else if (disc == 4)
+            medianValues_TECMinus_Disc4.push_back(APV);
+          else if (disc == 5)
+            medianValues_TECMinus_Disc5.push_back(APV);
+          else if (disc == 6)
+            medianValues_TECMinus_Disc6.push_back(APV);
+          else if (disc == 7)
+            medianValues_TECMinus_Disc7.push_back(APV);
+          else if (disc == 8)
+            medianValues_TECMinus_Disc8.push_back(APV);
+          else if (disc == 9)
+            medianValues_TECMinus_Disc9.push_back(APV);
+        }
+        break;
 
-      default :
-	std::cout << "### Detector does not belong to TIB, TID, TOB or TEC !? ###" << std::endl;
-	std::cout << "### DetRawId: " << detrawid << " ###" << std::endl;
-      }
+      default:
+        std::cout << "### Detector does not belong to TIB, TID, TOB or TEC !? ###" << std::endl;
+        std::cout << "### DetRawId: " << detrawid << " ###" << std::endl;
+    }
 
-    const StripGeomDetUnit*  theStripDet = dynamic_cast<const StripGeomDetUnit*>( (TkGeom->idToDet(detectorId)) );
-    const StripTopology* theStripTopol   = dynamic_cast<const StripTopology*>( &(theStripDet->specificTopology()) );
+    const StripGeomDetUnit* theStripDet = dynamic_cast<const StripGeomDetUnit*>((TkGeom->idToDet(detectorId)));
+    const StripTopology* theStripTopol = dynamic_cast<const StripTopology*>(&(theStripDet->specificTopology()));
 
-    for (int apv=0; apv<number_apvs; apv++)
-      {
-	apv_number           = apv+1;
-	apvMedianOccupancy   = APV.apvMedian[apv];
-	apvAbsoluteOccupancy = APV.apvabsoluteOccupancy[apv];
+    for (int apv = 0; apv < number_apvs; apv++) {
+      apv_number = apv + 1;
+      apvMedianOccupancy = APV.apvMedian[apv];
+      apvAbsoluteOccupancy = APV.apvabsoluteOccupancy[apv];
 
-	LocalPoint  pos_strip_local  = theStripTopol->localPosition((apv*128));
-        GlobalPoint pos_strip_global = (TkGeom->idToDet(detectorId))->surface().toGlobal(pos_strip_local);
+      LocalPoint pos_strip_local = theStripTopol->localPosition((apv * 128));
+      GlobalPoint pos_strip_global = (TkGeom->idToDet(detectorId))->surface().toGlobal(pos_strip_local);
 
-        global_position_x = pos_strip_global.x();
-        global_position_y = pos_strip_global.y();
-        global_position_z = pos_strip_global.z();
+      global_position_x = pos_strip_global.x();
+      global_position_y = pos_strip_global.y();
+      global_position_z = pos_strip_global.z();
 
-	if (WriteOutputFile_==true) apvtree->Fill();
-      }
+      if (WriteOutputFile_ == true)
+        apvtree->Fill();
+    }
 
-  } // end loop on modules
+  }  // end loop on modules
 
   // Calculate Mean and RMS for each Layer
-  CalculateMeanAndRMS(medianValues_TIB_Layer1,MeanAndRms_TIB_Layer1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIB_Layer2,MeanAndRms_TIB_Layer2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIB_Layer3,MeanAndRms_TIB_Layer3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIB_Layer4,MeanAndRms_TIB_Layer4,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIB_Layer1, MeanAndRms_TIB_Layer1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIB_Layer2, MeanAndRms_TIB_Layer2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIB_Layer3, MeanAndRms_TIB_Layer3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIB_Layer4, MeanAndRms_TIB_Layer4, numberiterations_);
 
-  CalculateMeanAndRMS(medianValues_TOB_Layer1,MeanAndRms_TOB_Layer1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer2,MeanAndRms_TOB_Layer2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer3,MeanAndRms_TOB_Layer3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer4,MeanAndRms_TOB_Layer4,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer5,MeanAndRms_TOB_Layer5,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer6,MeanAndRms_TOB_Layer6,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer1, MeanAndRms_TOB_Layer1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer2, MeanAndRms_TOB_Layer2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer3, MeanAndRms_TOB_Layer3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer4, MeanAndRms_TOB_Layer4, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer5, MeanAndRms_TOB_Layer5, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer6, MeanAndRms_TOB_Layer6, numberiterations_);
 
-  CalculateMeanAndRMS(medianValues_TIDPlus_Disc1,MeanAndRms_TIDPlus_Disc1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDPlus_Disc2,MeanAndRms_TIDPlus_Disc2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDPlus_Disc3,MeanAndRms_TIDPlus_Disc3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDMinus_Disc1,MeanAndRms_TIDMinus_Disc1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDMinus_Disc2,MeanAndRms_TIDMinus_Disc2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDMinus_Disc3,MeanAndRms_TIDMinus_Disc3,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDPlus_Disc1, MeanAndRms_TIDPlus_Disc1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDPlus_Disc2, MeanAndRms_TIDPlus_Disc2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDPlus_Disc3, MeanAndRms_TIDPlus_Disc3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDMinus_Disc1, MeanAndRms_TIDMinus_Disc1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDMinus_Disc2, MeanAndRms_TIDMinus_Disc2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDMinus_Disc3, MeanAndRms_TIDMinus_Disc3, numberiterations_);
 
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc1,MeanAndRms_TECPlus_Disc1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc2,MeanAndRms_TECPlus_Disc2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc3,MeanAndRms_TECPlus_Disc3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc4,MeanAndRms_TECPlus_Disc4,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc5,MeanAndRms_TECPlus_Disc5,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc6,MeanAndRms_TECPlus_Disc6,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc7,MeanAndRms_TECPlus_Disc7,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc8,MeanAndRms_TECPlus_Disc8,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc9,MeanAndRms_TECPlus_Disc9,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc1, MeanAndRms_TECPlus_Disc1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc2, MeanAndRms_TECPlus_Disc2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc3, MeanAndRms_TECPlus_Disc3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc4, MeanAndRms_TECPlus_Disc4, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc5, MeanAndRms_TECPlus_Disc5, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc6, MeanAndRms_TECPlus_Disc6, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc7, MeanAndRms_TECPlus_Disc7, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc8, MeanAndRms_TECPlus_Disc8, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc9, MeanAndRms_TECPlus_Disc9, numberiterations_);
 
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc1,MeanAndRms_TECMinus_Disc1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc2,MeanAndRms_TECMinus_Disc2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc3,MeanAndRms_TECMinus_Disc3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc4,MeanAndRms_TECMinus_Disc4,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc5,MeanAndRms_TECMinus_Disc5,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc6,MeanAndRms_TECMinus_Disc6,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc7,MeanAndRms_TECMinus_Disc7,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc8,MeanAndRms_TECMinus_Disc8,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc9,MeanAndRms_TECMinus_Disc9,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc1, MeanAndRms_TECMinus_Disc1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc2, MeanAndRms_TECMinus_Disc2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc3, MeanAndRms_TECMinus_Disc3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc4, MeanAndRms_TECMinus_Disc4, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc5, MeanAndRms_TECMinus_Disc5, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc6, MeanAndRms_TECMinus_Disc6, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc7, MeanAndRms_TECMinus_Disc7, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc8, MeanAndRms_TECMinus_Disc8, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc9, MeanAndRms_TECMinus_Disc9, numberiterations_);
 
-  pQuality=siStripQuality;
+  pQuality = siStripQuality;
   badStripList.clear();
 
   // Analyze the APV Occupancy for hot APVs
-  AnalyzeOccupancy(siStripQuality,medianValues_TIB_Layer1,MeanAndRms_TIB_Layer1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIB_Layer2,MeanAndRms_TIB_Layer2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIB_Layer3,MeanAndRms_TIB_Layer3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIB_Layer4,MeanAndRms_TIB_Layer4,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TIB_Layer1, MeanAndRms_TIB_Layer1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TIB_Layer2, MeanAndRms_TIB_Layer2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TIB_Layer3, MeanAndRms_TIB_Layer3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TIB_Layer4, MeanAndRms_TIB_Layer4, badStripList, inSiStripQuality);
 
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer1,MeanAndRms_TOB_Layer1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer2,MeanAndRms_TOB_Layer2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer3,MeanAndRms_TOB_Layer3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer4,MeanAndRms_TOB_Layer4,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer5,MeanAndRms_TOB_Layer5,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer6,MeanAndRms_TOB_Layer6,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer1, MeanAndRms_TOB_Layer1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer2, MeanAndRms_TOB_Layer2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer3, MeanAndRms_TOB_Layer3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer4, MeanAndRms_TOB_Layer4, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer5, MeanAndRms_TOB_Layer5, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer6, MeanAndRms_TOB_Layer6, badStripList, inSiStripQuality);
 
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDPlus_Disc1,MeanAndRms_TIDPlus_Disc1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDPlus_Disc2,MeanAndRms_TIDPlus_Disc2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDPlus_Disc3,MeanAndRms_TIDPlus_Disc3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDMinus_Disc1,MeanAndRms_TIDMinus_Disc1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDMinus_Disc2,MeanAndRms_TIDMinus_Disc2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDMinus_Disc3,MeanAndRms_TIDMinus_Disc3,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDPlus_Disc1, MeanAndRms_TIDPlus_Disc1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDPlus_Disc2, MeanAndRms_TIDPlus_Disc2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDPlus_Disc3, MeanAndRms_TIDPlus_Disc3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDMinus_Disc1, MeanAndRms_TIDMinus_Disc1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDMinus_Disc2, MeanAndRms_TIDMinus_Disc2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDMinus_Disc3, MeanAndRms_TIDMinus_Disc3, badStripList, inSiStripQuality);
 
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc1,MeanAndRms_TECPlus_Disc1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc2,MeanAndRms_TECPlus_Disc2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc3,MeanAndRms_TECPlus_Disc3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc4,MeanAndRms_TECPlus_Disc4,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc5,MeanAndRms_TECPlus_Disc5,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc6,MeanAndRms_TECPlus_Disc6,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc7,MeanAndRms_TECPlus_Disc7,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc8,MeanAndRms_TECPlus_Disc8,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc9,MeanAndRms_TECPlus_Disc9,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc1, MeanAndRms_TECPlus_Disc1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc2, MeanAndRms_TECPlus_Disc2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc3, MeanAndRms_TECPlus_Disc3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc4, MeanAndRms_TECPlus_Disc4, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc5, MeanAndRms_TECPlus_Disc5, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc6, MeanAndRms_TECPlus_Disc6, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc7, MeanAndRms_TECPlus_Disc7, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc8, MeanAndRms_TECPlus_Disc8, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc9, MeanAndRms_TECPlus_Disc9, badStripList, inSiStripQuality);
 
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc1,MeanAndRms_TECMinus_Disc1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc2,MeanAndRms_TECMinus_Disc2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc3,MeanAndRms_TECMinus_Disc3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc4,MeanAndRms_TECMinus_Disc4,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc5,MeanAndRms_TECMinus_Disc5,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc6,MeanAndRms_TECMinus_Disc6,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc7,MeanAndRms_TECMinus_Disc7,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc8,MeanAndRms_TECMinus_Disc8,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc9,MeanAndRms_TECMinus_Disc9,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc1, MeanAndRms_TECMinus_Disc1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc2, MeanAndRms_TECMinus_Disc2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc3, MeanAndRms_TECMinus_Disc3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc4, MeanAndRms_TECMinus_Disc4, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc5, MeanAndRms_TECMinus_Disc5, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc6, MeanAndRms_TECMinus_Disc6, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc7, MeanAndRms_TECMinus_Disc7, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc8, MeanAndRms_TECMinus_Disc8, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc9, MeanAndRms_TECMinus_Disc9, badStripList, inSiStripQuality);
 
   siStripQuality->fillBadComponents();
 
-  if (WriteOutputFile_==true){
-  f->cd();
-  apvtree->Write();
-  f->Close();
+  if (WriteOutputFile_ == true) {
+    f->cd();
+    apvtree->Write();
+    f->Close();
   }
 
   LogTrace("SiStripBadAPV") << ss.str() << std::endl;
 }
 
-
-void SiStripBadAPVAlgorithmFromClusterOccupancy::CalculateMeanAndRMS(const std::vector<Apv>& a, std::pair<double,double>* MeanRMS, int number_iterations)
-{
+void SiStripBadAPVAlgorithmFromClusterOccupancy::CalculateMeanAndRMS(const std::vector<Apv>& a,
+                                                                     std::pair<double, double>* MeanRMS,
+                                                                     int number_iterations) {
   Double_t tot[7], tot2[7];
   Double_t n[7];
 
   Double_t Mean[7] = {0};
-  Double_t Rms[7]  = {1000,1000,1000,1000,1000,1000,1000};
+  Double_t Rms[7] = {1000, 1000, 1000, 1000, 1000, 1000, 1000};
 
   int Moduleposition;
 
-  for (int i=0; i<number_iterations; i++)
-    {
-      for (int j=0; j<7; j++)
-	{
-	  n[j]    = 0;
-	  tot[j]  = 0;
-	  tot2[j] = 0;
-	}
-
-      for (uint32_t it=0; it<a.size(); it++)
-	{
-	  Moduleposition = (a[it].modulePosition)-1;
-
-	  for (int apv=0; apv<a[it].numberApvs; apv++)
-	    {
-	      if (i>0)
-		{
-		  if (a[it].apvMedian[apv]<(Mean[Moduleposition]-3*Rms[Moduleposition]) || (a[it].apvMedian[apv]>(Mean[Moduleposition]+5*Rms[Moduleposition])))
-		    {
-		      continue;
-		    }
-		}
-	      tot[Moduleposition]  += a[it].apvMedian[apv];
-	      tot2[Moduleposition] += (a[it].apvMedian[apv])*(a[it].apvMedian[apv]);
-	      n[Moduleposition]++;
-	    }
-	}
-
-      for (int j=0; j<7; j++)
-	{
-	  if (n[j]!=0)
-	    {
-	      Mean[j] = tot[j]/n[j];
-	      Rms[j]  = TMath::Sqrt(TMath::Abs(tot2[j]/n[j] -Mean[j]*Mean[j]));
-	    }
-	}
+  for (int i = 0; i < number_iterations; i++) {
+    for (int j = 0; j < 7; j++) {
+      n[j] = 0;
+      tot[j] = 0;
+      tot2[j] = 0;
     }
 
-  for (int j=0; j<7; j++)
-    {
-      MeanRMS[j] = std::make_pair(Mean[j],Rms[j]);
+    for (uint32_t it = 0; it < a.size(); it++) {
+      Moduleposition = (a[it].modulePosition) - 1;
+
+      for (int apv = 0; apv < a[it].numberApvs; apv++) {
+        if (i > 0) {
+          if (a[it].apvMedian[apv] < (Mean[Moduleposition] - 3 * Rms[Moduleposition]) ||
+              (a[it].apvMedian[apv] > (Mean[Moduleposition] + 5 * Rms[Moduleposition]))) {
+            continue;
+          }
+        }
+        tot[Moduleposition] += a[it].apvMedian[apv];
+        tot2[Moduleposition] += (a[it].apvMedian[apv]) * (a[it].apvMedian[apv]);
+        n[Moduleposition]++;
+      }
     }
 
+    for (int j = 0; j < 7; j++) {
+      if (n[j] != 0) {
+        Mean[j] = tot[j] / n[j];
+        Rms[j] = TMath::Sqrt(TMath::Abs(tot2[j] / n[j] - Mean[j] * Mean[j]));
+      }
+    }
+  }
+
+  for (int j = 0; j < 7; j++) {
+    MeanRMS[j] = std::make_pair(Mean[j], Rms[j]);
+  }
 }
 
-void SiStripBadAPVAlgorithmFromClusterOccupancy::AnalyzeOccupancy(SiStripQuality* quality, std::vector<Apv>& medianValues, std::pair<double,double>* MeanAndRms, std::vector<unsigned int>& BadStripList, edm::ESHandle<SiStripQuality>& InSiStripQuality)
-{
+void SiStripBadAPVAlgorithmFromClusterOccupancy::AnalyzeOccupancy(SiStripQuality* quality,
+                                                                  std::vector<Apv>& medianValues,
+                                                                  std::pair<double, double>* MeanAndRms,
+                                                                  std::vector<unsigned int>& BadStripList,
+                                                                  edm::ESHandle<SiStripQuality>& InSiStripQuality) {
   int Moduleposition;
   uint32_t Detid;
 
-  for (uint32_t it=0; it<medianValues.size(); it++)
-    {
-      Moduleposition = (medianValues[it].modulePosition)-1;
-      Detid          = medianValues[it].detrawId;
+  for (uint32_t it = 0; it < medianValues.size(); it++) {
+    Moduleposition = (medianValues[it].modulePosition) - 1;
+    Detid = medianValues[it].detrawId;
 
-      for (int apv=0; apv<medianValues[it].numberApvs; apv++)
-	{
-	  if(UseInputDB_)
-	    {
-	      if(InSiStripQuality->IsApvBad(Detid,apv) )
-		{
-		  continue;//if the apv is already flagged as bad, continue.
-		}
-	    }
-	  if (medianValues[it].apvMedian[apv] > minNevents_)
-	    {
-	      if ((medianValues[it].apvMedian[apv]>(MeanAndRms[Moduleposition].first+highoccupancy_*MeanAndRms[Moduleposition].second)) && (medianValues[it].apvMedian[apv]>absolutelow_))
-		BadStripList.push_back(pQuality->encode((apv*128),128,0));
-	    }
-	  else if (medianValues[it].apvMedian[apv]<(MeanAndRms[Moduleposition].first-lowoccupancy_*MeanAndRms[Moduleposition].second) && (MeanAndRms[Moduleposition].first>2 || medianValues[it].apvabsoluteOccupancy[apv]==0))
-	    {
-	      BadStripList.push_back(pQuality->encode((apv*128),128,0));
-	      std::cout << "Dead APV! DetId: " << medianValues[it].detrawId << ", APV number: " << apv+1 << ", APVMedian: " << medianValues[it].apvMedian[apv] << ", Mean: " << MeanAndRms[Moduleposition].first << ", RMS: " << MeanAndRms[Moduleposition].second << ", LowThreshold: " << lowoccupancy_ << ", Mean-Low*RMS: " << (MeanAndRms[Moduleposition].first-lowoccupancy_*MeanAndRms[Moduleposition].second) << std::endl;
-	    }
-	}
-      if (BadStripList.begin()!=BadStripList.end())
-	{
-	  quality->compact(Detid,BadStripList);
-	  SiStripQuality::Range range(BadStripList.begin(),BadStripList.end());
-	  quality->put(Detid,range);
-	}
-      BadStripList.clear();
+    for (int apv = 0; apv < medianValues[it].numberApvs; apv++) {
+      if (UseInputDB_) {
+        if (InSiStripQuality->IsApvBad(Detid, apv)) {
+          continue;  //if the apv is already flagged as bad, continue.
+        }
+      }
+      if (medianValues[it].apvMedian[apv] > minNevents_) {
+        if ((medianValues[it].apvMedian[apv] >
+             (MeanAndRms[Moduleposition].first + highoccupancy_ * MeanAndRms[Moduleposition].second)) &&
+            (medianValues[it].apvMedian[apv] > absolutelow_))
+          BadStripList.push_back(pQuality->encode((apv * 128), 128, 0));
+      } else if (medianValues[it].apvMedian[apv] <
+                     (MeanAndRms[Moduleposition].first - lowoccupancy_ * MeanAndRms[Moduleposition].second) &&
+                 (MeanAndRms[Moduleposition].first > 2 || medianValues[it].apvabsoluteOccupancy[apv] == 0)) {
+        BadStripList.push_back(pQuality->encode((apv * 128), 128, 0));
+        std::cout << "Dead APV! DetId: " << medianValues[it].detrawId << ", APV number: " << apv + 1
+                  << ", APVMedian: " << medianValues[it].apvMedian[apv]
+                  << ", Mean: " << MeanAndRms[Moduleposition].first << ", RMS: " << MeanAndRms[Moduleposition].second
+                  << ", LowThreshold: " << lowoccupancy_ << ", Mean-Low*RMS: "
+                  << (MeanAndRms[Moduleposition].first - lowoccupancy_ * MeanAndRms[Moduleposition].second)
+                  << std::endl;
+      }
     }
+    if (BadStripList.begin() != BadStripList.end()) {
+      quality->compact(Detid, BadStripList);
+      SiStripQuality::Range range(BadStripList.begin(), BadStripList.end());
+      quality->put(Detid, range);
+    }
+    BadStripList.clear();
+  }
 }
 
-void SiStripBadAPVAlgorithmFromClusterOccupancy::setMinNumOfEvents()
-{
-  minNevents_=occupancy_*Nevents_;
-}
+void SiStripBadAPVAlgorithmFromClusterOccupancy::setMinNumOfEvents() { minNevents_ = occupancy_ * Nevents_; }

--- a/CalibTracker/SiStripQuality/src/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.cc
+++ b/CalibTracker/SiStripQuality/src/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.cc
@@ -8,355 +8,414 @@
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 
-
-SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy(const edm::ParameterSet& iConfig, const TrackerTopology* theTopo):
-  ratio_(1.5),
-  lowoccupancy_(0),
-  highoccupancy_(100),
-  absolutelow_(0),
-  numberiterations_(2),
-  Nevents_(0),
-  absolute_occupancy_(0),
-  OutFileName_("Occupancy.root"),
-  DQMOutfileName_("DQMOutput"),
-  UseInputDB_(iConfig.getUntrackedParameter<bool>("UseInputDB",false)),
-  tTopo(theTopo)
-  {
-    minNevents_=Nevents_*absolute_occupancy_;
-  }
-
-SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::~SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy(){
-  LogTrace("SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy")<<"[SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::~SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy] "<<std::endl;
+SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy(
+    const edm::ParameterSet& iConfig, const TrackerTopology* theTopo)
+    : ratio_(1.5),
+      lowoccupancy_(0),
+      highoccupancy_(100),
+      absolutelow_(0),
+      numberiterations_(2),
+      Nevents_(0),
+      absolute_occupancy_(0),
+      OutFileName_("Occupancy.root"),
+      DQMOutfileName_("DQMOutput"),
+      UseInputDB_(iConfig.getUntrackedParameter<bool>("UseInputDB", false)),
+      tTopo(theTopo) {
+  minNevents_ = Nevents_ * absolute_occupancy_;
 }
 
-void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::extractBadAPVSandStrips(SiStripQuality* siStripQuality,HistoMap& DM, edm::ESHandle<SiStripQuality>& inSiStripQuality){
+SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::~SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy() {
+  LogTrace("SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy")
+      << "[SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::~"
+         "SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy] "
+      << std::endl;
+}
 
-  LogTrace("SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy")<<"[SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::extractBadAPVs] "<<std::endl;
+void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::extractBadAPVSandStrips(
+    SiStripQuality* siStripQuality, HistoMap& DM, edm::ESHandle<SiStripQuality>& inSiStripQuality) {
+  LogTrace("SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy")
+      << "[SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::extractBadAPVs] " << std::endl;
 
-  if (WriteOutputFile_== true)
-    {
-      f = new TFile(OutFileName_.c_str(),"RECREATE");
-      f->cd();
+  if (WriteOutputFile_ == true) {
+    f = new TFile(OutFileName_.c_str(), "RECREATE");
+    f->cd();
 
-      apvtree = new TTree("moduleOccupancy","tree");
+    apvtree = new TTree("moduleOccupancy", "tree");
 
-      apvtree->Branch("DetRawId",                &detrawid,                "DetRawId/I");
-      apvtree->Branch("SubDetId",                &subdetid,                "SubDetId/I");
-      apvtree->Branch("Layer_Ring",              &layer_ring,              "Layer_Ring/I");
-      apvtree->Branch("Disc",                    &disc,                    "Disc/I");
-      apvtree->Branch("IsBack",                  &isback,                  "IsBack/I");
-      apvtree->Branch("IsExternalString",        &isexternalstring,        "IsExternalString/I");
-      apvtree->Branch("IsZMinusSide",            &iszminusside,            "IsZMinusSide/I");
-      apvtree->Branch("RodStringPetal",          &rodstringpetal,          "RodStringPetal/I");
-      apvtree->Branch("IsStereo",                &isstereo,                "IsStereo/I");
-      apvtree->Branch("ModuleNumber",            &module_number,           "ModuleNumber/I");
-      apvtree->Branch("NumberOfStrips",          &number_strips,           "NumberOfStrips/I");
-      apvtree->Branch("APVGlobalPositionX",      &global_position_x,       "APVGlobalPositionX/F");
-      apvtree->Branch("APVGlobalPositionY",      &global_position_y,       "APVGlobalPositionY/F");
-      apvtree->Branch("APVGlobalPositionZ",      &global_position_z,       "APVGlobalPositionZ/F");
-      apvtree->Branch("APVNumber",               &apv_number,              "APVNumber/I");
-      apvtree->Branch("APVAbsoluteOccupancy",    &apvAbsoluteOccupancy,    "apvAbsoluteOccupancy/I");
-      apvtree->Branch("APVMedianOccupancy",      &apvMedianOccupancy,      "apvMedianOccupancy/D");
-      apvtree->Branch("IsBad",                   &isBad,                   "IsBad/I");
+    apvtree->Branch("DetRawId", &detrawid, "DetRawId/I");
+    apvtree->Branch("SubDetId", &subdetid, "SubDetId/I");
+    apvtree->Branch("Layer_Ring", &layer_ring, "Layer_Ring/I");
+    apvtree->Branch("Disc", &disc, "Disc/I");
+    apvtree->Branch("IsBack", &isback, "IsBack/I");
+    apvtree->Branch("IsExternalString", &isexternalstring, "IsExternalString/I");
+    apvtree->Branch("IsZMinusSide", &iszminusside, "IsZMinusSide/I");
+    apvtree->Branch("RodStringPetal", &rodstringpetal, "RodStringPetal/I");
+    apvtree->Branch("IsStereo", &isstereo, "IsStereo/I");
+    apvtree->Branch("ModuleNumber", &module_number, "ModuleNumber/I");
+    apvtree->Branch("NumberOfStrips", &number_strips, "NumberOfStrips/I");
+    apvtree->Branch("APVGlobalPositionX", &global_position_x, "APVGlobalPositionX/F");
+    apvtree->Branch("APVGlobalPositionY", &global_position_y, "APVGlobalPositionY/F");
+    apvtree->Branch("APVGlobalPositionZ", &global_position_z, "APVGlobalPositionZ/F");
+    apvtree->Branch("APVNumber", &apv_number, "APVNumber/I");
+    apvtree->Branch("APVAbsoluteOccupancy", &apvAbsoluteOccupancy, "apvAbsoluteOccupancy/I");
+    apvtree->Branch("APVMedianOccupancy", &apvMedianOccupancy, "apvMedianOccupancy/D");
+    apvtree->Branch("IsBad", &isBad, "IsBad/I");
 
-      striptree = new TTree("stripOccupancy","tree");
+    striptree = new TTree("stripOccupancy", "tree");
 
-      striptree->Branch("DetRawId",             &detrawid,          "DetRawId/I");
-      striptree->Branch("SubDetId",             &subdetid,          "SubDetId/I");
-      striptree->Branch("Layer_Ring",           &layer_ring,        "Layer_Ring/I");
-      striptree->Branch("Disc",                 &disc,              "Disc/I");
-      striptree->Branch("IsBack",               &isback,            "IsBack/I");
-      striptree->Branch("IsExternalString",     &isexternalstring,  "IsExternalString/I");
-      striptree->Branch("IsZMinusSide",         &iszminusside,      "IsZMinusSide/I");
-      striptree->Branch("RodStringPetal",       &rodstringpetal,    "RodStringPetal/I");
-      striptree->Branch("IsStereo",             &isstereo,          "IsStereo/I");
-      striptree->Branch("ModulePosition",       &module_number,     "ModulePosition/I");
-      striptree->Branch("NumberOfStrips",       &number_strips,     "NumberOfStrips/I");
-      striptree->Branch("StripNumber",          &strip_number,      "StripNumber/I");
-      striptree->Branch("APVChannel",           &apv_channel,       "APVChannel/I");
-      striptree->Branch("StripGlobalPositionX", &strip_global_position_x, "StripGlobalPositionX/F");
-      striptree->Branch("StripGlobalPositionY", &strip_global_position_y, "StripGlobalPositionY/F");
-      striptree->Branch("StripGlobalPositionZ", &strip_global_position_z, "StripGlobalPositionZ/F");
-      striptree->Branch("IsHot",                &isHot,             "IsHot/I");
-      striptree->Branch("HotStripsPerAPV",      &hotStripsPerAPV,   "HotStripsPerAPV/I");
-      striptree->Branch("HotStripsPerModule",   &hotStripsPerModule,"HotStripsPerModule/I");
-      striptree->Branch("StripOccupancy",       &singleStripOccupancy, "StripOccupancy/D");
-      striptree->Branch("StripHits",            &stripHits,         "StripHits/I");
-      striptree->Branch("PoissonProb",          &poissonProb,       "PoissonProb/D");
-      striptree->Branch("MedianAPVHits",        &medianAPVHits,     "MedianAPVHits/D");
-      striptree->Branch("AvgAPVHits",           &avgAPVHits,        "AvgAPVHits/D");
-    }
+    striptree->Branch("DetRawId", &detrawid, "DetRawId/I");
+    striptree->Branch("SubDetId", &subdetid, "SubDetId/I");
+    striptree->Branch("Layer_Ring", &layer_ring, "Layer_Ring/I");
+    striptree->Branch("Disc", &disc, "Disc/I");
+    striptree->Branch("IsBack", &isback, "IsBack/I");
+    striptree->Branch("IsExternalString", &isexternalstring, "IsExternalString/I");
+    striptree->Branch("IsZMinusSide", &iszminusside, "IsZMinusSide/I");
+    striptree->Branch("RodStringPetal", &rodstringpetal, "RodStringPetal/I");
+    striptree->Branch("IsStereo", &isstereo, "IsStereo/I");
+    striptree->Branch("ModulePosition", &module_number, "ModulePosition/I");
+    striptree->Branch("NumberOfStrips", &number_strips, "NumberOfStrips/I");
+    striptree->Branch("StripNumber", &strip_number, "StripNumber/I");
+    striptree->Branch("APVChannel", &apv_channel, "APVChannel/I");
+    striptree->Branch("StripGlobalPositionX", &strip_global_position_x, "StripGlobalPositionX/F");
+    striptree->Branch("StripGlobalPositionY", &strip_global_position_y, "StripGlobalPositionY/F");
+    striptree->Branch("StripGlobalPositionZ", &strip_global_position_z, "StripGlobalPositionZ/F");
+    striptree->Branch("IsHot", &isHot, "IsHot/I");
+    striptree->Branch("HotStripsPerAPV", &hotStripsPerAPV, "HotStripsPerAPV/I");
+    striptree->Branch("HotStripsPerModule", &hotStripsPerModule, "HotStripsPerModule/I");
+    striptree->Branch("StripOccupancy", &singleStripOccupancy, "StripOccupancy/D");
+    striptree->Branch("StripHits", &stripHits, "StripHits/I");
+    striptree->Branch("PoissonProb", &poissonProb, "PoissonProb/D");
+    striptree->Branch("MedianAPVHits", &medianAPVHits, "MedianAPVHits/D");
+    striptree->Branch("AvgAPVHits", &avgAPVHits, "AvgAPVHits/D");
+  }
 
-  HistoMap::iterator it=DM.begin();
-  HistoMap::iterator itEnd=DM.end();
+  HistoMap::iterator it = DM.begin();
+  HistoMap::iterator itEnd = DM.end();
   std::vector<unsigned int> badStripList;
   uint32_t detid;
-  for (;it!=itEnd;++it){
-
+  for (; it != itEnd; ++it) {
     Apv APV;
 
-    for (int apv=0; apv<6; apv++)
-      {
-	APV.apvMedian[apv]            = 0;
-	APV.apvabsoluteOccupancy[apv] = 0;
-	APV.NEntries[apv]            = 0;
-	APV.NEmptyBins[apv]          = 0;
+    for (int apv = 0; apv < 6; apv++) {
+      APV.apvMedian[apv] = 0;
+      APV.apvabsoluteOccupancy[apv] = 0;
+      APV.NEntries[apv] = 0;
+      APV.NEmptyBins[apv] = 0;
 
-	for (int strip=0; strip<128; strip++)
-	  {
-	    stripOccupancy[apv][strip] = 0;
-	    stripWeight[apv][strip]    = 0;
-	  }
+      for (int strip = 0; strip < 128; strip++) {
+        stripOccupancy[apv][strip] = 0;
+        stripWeight[apv][strip] = 0;
       }
+    }
 
-    number_strips  = (int)((it->second.get())->GetNbinsX());
-    number_apvs    = number_strips/128;
+    number_strips = (int)((it->second.get())->GetNbinsX());
+    number_apvs = number_strips / 128;
     APV.numberApvs = number_apvs;
 
-    for (int apv=0; apv<number_apvs; apv++)
-      {
-	APV.th1f[apv] = new TH1F("tmp","tmp",128,0.5,128.5);
-	int NumberEntriesPerAPV=0;
+    for (int apv = 0; apv < number_apvs; apv++) {
+      APV.th1f[apv] = new TH1F("tmp", "tmp", 128, 0.5, 128.5);
+      int NumberEntriesPerAPV = 0;
 
-	for (int strip=0; strip<128; strip++)
-	  {
-	    stripOccupancy[apv][strip] = (it->second.get())->GetBinContent((apv*128)+strip+1); // Remember: Bin=0 is underflow bin!
-	    stripWeight[apv][strip]    = 1;
-	    APV.apvabsoluteOccupancy[apv] += (it->second.get())->GetBinContent((apv*128)+strip+1); // Remember: Bin=0 is underflow bin!
-	    APV.th1f[apv]->SetBinContent(strip+1,(it->second.get())->GetBinContent((apv*128)+strip+1));
-	    NumberEntriesPerAPV += (int)(it->second.get())->GetBinContent((apv*128)+strip+1);
-	  }
-
-	APV.th1f[apv]->SetEntries(NumberEntriesPerAPV);
-	APV.NEntries[apv]=(int)APV.th1f[apv]->GetEntries();
+      for (int strip = 0; strip < 128; strip++) {
+        stripOccupancy[apv][strip] =
+            (it->second.get())->GetBinContent((apv * 128) + strip + 1);  // Remember: Bin=0 is underflow bin!
+        stripWeight[apv][strip] = 1;
+        APV.apvabsoluteOccupancy[apv] +=
+            (it->second.get())->GetBinContent((apv * 128) + strip + 1);  // Remember: Bin=0 is underflow bin!
+        APV.th1f[apv]->SetBinContent(strip + 1, (it->second.get())->GetBinContent((apv * 128) + strip + 1));
+        NumberEntriesPerAPV += (int)(it->second.get())->GetBinContent((apv * 128) + strip + 1);
       }
 
-    for (int apv=0; apv<number_apvs; apv++)
-      {
-	APV.apvMedian[apv] = TMath::Median(128,stripOccupancy[apv],stripWeight[apv]);
-      }
+      APV.th1f[apv]->SetEntries(NumberEntriesPerAPV);
+      APV.NEntries[apv] = (int)APV.th1f[apv]->GetEntries();
+    }
 
-    detid=it->first;
-    DetId detectorId=DetId(detid);
+    for (int apv = 0; apv < number_apvs; apv++) {
+      APV.apvMedian[apv] = TMath::Median(128, stripOccupancy[apv], stripWeight[apv]);
+    }
+
+    detid = it->first;
+    DetId detectorId = DetId(detid);
 
     if (edm::isDebugEnabled())
-      LogTrace("SiStripBadAPV") << "Analyzing detid " << detid<< std::endl;
+      LogTrace("SiStripBadAPV") << "Analyzing detid " << detid << std::endl;
 
-    detrawid     = detid;
+    detrawid = detid;
     APV.detrawId = detrawid;
-    subdetid     = detectorId.subdetId();
+    subdetid = detectorId.subdetId();
 
-    switch (detectorId.subdetId())
-      {
-      case StripSubdetector::TIB :
-	layer_ring         = tTopo->tibLayer(detrawid);
-	module_number      = tTopo->tibModule(detrawid);
-	APV.modulePosition = module_number;
+    switch (detectorId.subdetId()) {
+      case StripSubdetector::TIB:
+        layer_ring = tTopo->tibLayer(detrawid);
+        module_number = tTopo->tibModule(detrawid);
+        APV.modulePosition = module_number;
 
-	if      (layer_ring == 1) medianValues_TIB_Layer1.push_back(APV);
-	else if (layer_ring == 2) medianValues_TIB_Layer2.push_back(APV);
-	else if (layer_ring == 3) medianValues_TIB_Layer3.push_back(APV);
-	else if (layer_ring == 4) medianValues_TIB_Layer4.push_back(APV);
-	break;
+        if (layer_ring == 1)
+          medianValues_TIB_Layer1.push_back(APV);
+        else if (layer_ring == 2)
+          medianValues_TIB_Layer2.push_back(APV);
+        else if (layer_ring == 3)
+          medianValues_TIB_Layer3.push_back(APV);
+        else if (layer_ring == 4)
+          medianValues_TIB_Layer4.push_back(APV);
+        break;
 
-      case StripSubdetector::TID :
-	layer_ring         = tTopo->tidRing(detrawid);
-	disc               = tTopo->tidWheel(detrawid);
-	APV.modulePosition = layer_ring;
+      case StripSubdetector::TID:
+        layer_ring = tTopo->tidRing(detrawid);
+        disc = tTopo->tidWheel(detrawid);
+        APV.modulePosition = layer_ring;
 
-	if (tTopo->tidIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
+        if (tTopo->tidIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
 
-	if (iszminusside==0)
-	  {
-	    if      (disc==1) medianValues_TIDPlus_Disc1.push_back(APV);
-	    else if (disc==2) medianValues_TIDPlus_Disc2.push_back(APV);
-	    else if (disc==3) medianValues_TIDPlus_Disc3.push_back(APV);
-	  }
-	else if (iszminusside==1)
-	  {
-	    if      (disc==1) medianValues_TIDMinus_Disc1.push_back(APV);
-	    else if (disc==2) medianValues_TIDMinus_Disc2.push_back(APV);
-	    else if (disc==3) medianValues_TIDMinus_Disc3.push_back(APV);
-	  }
-	break;
+        if (iszminusside == 0) {
+          if (disc == 1)
+            medianValues_TIDPlus_Disc1.push_back(APV);
+          else if (disc == 2)
+            medianValues_TIDPlus_Disc2.push_back(APV);
+          else if (disc == 3)
+            medianValues_TIDPlus_Disc3.push_back(APV);
+        } else if (iszminusside == 1) {
+          if (disc == 1)
+            medianValues_TIDMinus_Disc1.push_back(APV);
+          else if (disc == 2)
+            medianValues_TIDMinus_Disc2.push_back(APV);
+          else if (disc == 3)
+            medianValues_TIDMinus_Disc3.push_back(APV);
+        }
+        break;
 
-      case StripSubdetector::TOB :
-	layer_ring         = tTopo->tobLayer(detrawid);
-	module_number      = tTopo->tobModule(detrawid);
-	APV.modulePosition = module_number;
+      case StripSubdetector::TOB:
+        layer_ring = tTopo->tobLayer(detrawid);
+        module_number = tTopo->tobModule(detrawid);
+        APV.modulePosition = module_number;
 
-	if      (layer_ring == 1) medianValues_TOB_Layer1.push_back(APV);
-	else if (layer_ring == 2) medianValues_TOB_Layer2.push_back(APV);
-	else if (layer_ring == 3) medianValues_TOB_Layer3.push_back(APV);
-	else if (layer_ring == 4) medianValues_TOB_Layer4.push_back(APV);
-	else if (layer_ring == 5) medianValues_TOB_Layer5.push_back(APV);
-	else if (layer_ring == 6) medianValues_TOB_Layer6.push_back(APV);
-	break;
+        if (layer_ring == 1)
+          medianValues_TOB_Layer1.push_back(APV);
+        else if (layer_ring == 2)
+          medianValues_TOB_Layer2.push_back(APV);
+        else if (layer_ring == 3)
+          medianValues_TOB_Layer3.push_back(APV);
+        else if (layer_ring == 4)
+          medianValues_TOB_Layer4.push_back(APV);
+        else if (layer_ring == 5)
+          medianValues_TOB_Layer5.push_back(APV);
+        else if (layer_ring == 6)
+          medianValues_TOB_Layer6.push_back(APV);
+        break;
 
-      case StripSubdetector::TEC :
-	layer_ring         = tTopo->tecRing(detrawid);
-	disc               = tTopo->tecWheel(detrawid);
-	APV.modulePosition = layer_ring;
+      case StripSubdetector::TEC:
+        layer_ring = tTopo->tecRing(detrawid);
+        disc = tTopo->tecWheel(detrawid);
+        APV.modulePosition = layer_ring;
 
-	if (tTopo->tecIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
+        if (tTopo->tecIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
 
-	if (iszminusside==0)
-	  {
-	    if      (disc==1) medianValues_TECPlus_Disc1.push_back(APV);
-	    else if (disc==2) medianValues_TECPlus_Disc2.push_back(APV);
-	    else if (disc==3) medianValues_TECPlus_Disc3.push_back(APV);
-	    else if (disc==4) medianValues_TECPlus_Disc4.push_back(APV);
-	    else if (disc==5) medianValues_TECPlus_Disc5.push_back(APV);
-	    else if (disc==6) medianValues_TECPlus_Disc6.push_back(APV);
-	    else if (disc==7) medianValues_TECPlus_Disc7.push_back(APV);
-	    else if (disc==8) medianValues_TECPlus_Disc8.push_back(APV);
-	    else if (disc==9) medianValues_TECPlus_Disc9.push_back(APV);
-	  }
-	else if (iszminusside==1)
-	  {
-	    if      (disc==1) medianValues_TECMinus_Disc1.push_back(APV);
-	    else if (disc==2) medianValues_TECMinus_Disc2.push_back(APV);
-	    else if (disc==3) medianValues_TECMinus_Disc3.push_back(APV);
-	    else if (disc==4) medianValues_TECMinus_Disc4.push_back(APV);
-	    else if (disc==5) medianValues_TECMinus_Disc5.push_back(APV);
-	    else if (disc==6) medianValues_TECMinus_Disc6.push_back(APV);
-	    else if (disc==7) medianValues_TECMinus_Disc7.push_back(APV);
-	    else if (disc==8) medianValues_TECMinus_Disc8.push_back(APV);
-	    else if (disc==9) medianValues_TECMinus_Disc9.push_back(APV);
-	  }
-	break;
+        if (iszminusside == 0) {
+          if (disc == 1)
+            medianValues_TECPlus_Disc1.push_back(APV);
+          else if (disc == 2)
+            medianValues_TECPlus_Disc2.push_back(APV);
+          else if (disc == 3)
+            medianValues_TECPlus_Disc3.push_back(APV);
+          else if (disc == 4)
+            medianValues_TECPlus_Disc4.push_back(APV);
+          else if (disc == 5)
+            medianValues_TECPlus_Disc5.push_back(APV);
+          else if (disc == 6)
+            medianValues_TECPlus_Disc6.push_back(APV);
+          else if (disc == 7)
+            medianValues_TECPlus_Disc7.push_back(APV);
+          else if (disc == 8)
+            medianValues_TECPlus_Disc8.push_back(APV);
+          else if (disc == 9)
+            medianValues_TECPlus_Disc9.push_back(APV);
+        } else if (iszminusside == 1) {
+          if (disc == 1)
+            medianValues_TECMinus_Disc1.push_back(APV);
+          else if (disc == 2)
+            medianValues_TECMinus_Disc2.push_back(APV);
+          else if (disc == 3)
+            medianValues_TECMinus_Disc3.push_back(APV);
+          else if (disc == 4)
+            medianValues_TECMinus_Disc4.push_back(APV);
+          else if (disc == 5)
+            medianValues_TECMinus_Disc5.push_back(APV);
+          else if (disc == 6)
+            medianValues_TECMinus_Disc6.push_back(APV);
+          else if (disc == 7)
+            medianValues_TECMinus_Disc7.push_back(APV);
+          else if (disc == 8)
+            medianValues_TECMinus_Disc8.push_back(APV);
+          else if (disc == 9)
+            medianValues_TECMinus_Disc9.push_back(APV);
+        }
+        break;
 
-      default :
-	std::cout << "### Detector does not belong to TIB, TID, TOB or TEC !? ###" << std::endl;
-	std::cout << "### DetRawId: " << detrawid << " ###" << std::endl;
-      }
+      default:
+        std::cout << "### Detector does not belong to TIB, TID, TOB or TEC !? ###" << std::endl;
+        std::cout << "### DetRawId: " << detrawid << " ###" << std::endl;
+    }
 
-  } // end loop on modules
+  }  // end loop on modules
 
   // Calculate Mean and RMS for each Layer
-  CalculateMeanAndRMS(medianValues_TIB_Layer1,MeanAndRms_TIB_Layer1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIB_Layer2,MeanAndRms_TIB_Layer2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIB_Layer3,MeanAndRms_TIB_Layer3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIB_Layer4,MeanAndRms_TIB_Layer4,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIB_Layer1, MeanAndRms_TIB_Layer1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIB_Layer2, MeanAndRms_TIB_Layer2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIB_Layer3, MeanAndRms_TIB_Layer3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIB_Layer4, MeanAndRms_TIB_Layer4, numberiterations_);
 
-  CalculateMeanAndRMS(medianValues_TOB_Layer1,MeanAndRms_TOB_Layer1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer2,MeanAndRms_TOB_Layer2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer3,MeanAndRms_TOB_Layer3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer4,MeanAndRms_TOB_Layer4,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer5,MeanAndRms_TOB_Layer5,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TOB_Layer6,MeanAndRms_TOB_Layer6,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer1, MeanAndRms_TOB_Layer1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer2, MeanAndRms_TOB_Layer2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer3, MeanAndRms_TOB_Layer3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer4, MeanAndRms_TOB_Layer4, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer5, MeanAndRms_TOB_Layer5, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TOB_Layer6, MeanAndRms_TOB_Layer6, numberiterations_);
 
-  CalculateMeanAndRMS(medianValues_TIDPlus_Disc1,MeanAndRms_TIDPlus_Disc1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDPlus_Disc2,MeanAndRms_TIDPlus_Disc2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDPlus_Disc3,MeanAndRms_TIDPlus_Disc3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDMinus_Disc1,MeanAndRms_TIDMinus_Disc1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDMinus_Disc2,MeanAndRms_TIDMinus_Disc2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TIDMinus_Disc3,MeanAndRms_TIDMinus_Disc3,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDPlus_Disc1, MeanAndRms_TIDPlus_Disc1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDPlus_Disc2, MeanAndRms_TIDPlus_Disc2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDPlus_Disc3, MeanAndRms_TIDPlus_Disc3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDMinus_Disc1, MeanAndRms_TIDMinus_Disc1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDMinus_Disc2, MeanAndRms_TIDMinus_Disc2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TIDMinus_Disc3, MeanAndRms_TIDMinus_Disc3, numberiterations_);
 
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc1,MeanAndRms_TECPlus_Disc1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc2,MeanAndRms_TECPlus_Disc2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc3,MeanAndRms_TECPlus_Disc3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc4,MeanAndRms_TECPlus_Disc4,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc5,MeanAndRms_TECPlus_Disc5,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc6,MeanAndRms_TECPlus_Disc6,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc7,MeanAndRms_TECPlus_Disc7,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc8,MeanAndRms_TECPlus_Disc8,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECPlus_Disc9,MeanAndRms_TECPlus_Disc9,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc1, MeanAndRms_TECPlus_Disc1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc2, MeanAndRms_TECPlus_Disc2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc3, MeanAndRms_TECPlus_Disc3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc4, MeanAndRms_TECPlus_Disc4, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc5, MeanAndRms_TECPlus_Disc5, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc6, MeanAndRms_TECPlus_Disc6, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc7, MeanAndRms_TECPlus_Disc7, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc8, MeanAndRms_TECPlus_Disc8, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECPlus_Disc9, MeanAndRms_TECPlus_Disc9, numberiterations_);
 
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc1,MeanAndRms_TECMinus_Disc1,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc2,MeanAndRms_TECMinus_Disc2,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc3,MeanAndRms_TECMinus_Disc3,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc4,MeanAndRms_TECMinus_Disc4,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc5,MeanAndRms_TECMinus_Disc5,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc6,MeanAndRms_TECMinus_Disc6,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc7,MeanAndRms_TECMinus_Disc7,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc8,MeanAndRms_TECMinus_Disc8,numberiterations_);
-  CalculateMeanAndRMS(medianValues_TECMinus_Disc9,MeanAndRms_TECMinus_Disc9,numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc1, MeanAndRms_TECMinus_Disc1, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc2, MeanAndRms_TECMinus_Disc2, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc3, MeanAndRms_TECMinus_Disc3, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc4, MeanAndRms_TECMinus_Disc4, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc5, MeanAndRms_TECMinus_Disc5, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc6, MeanAndRms_TECMinus_Disc6, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc7, MeanAndRms_TECMinus_Disc7, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc8, MeanAndRms_TECMinus_Disc8, numberiterations_);
+  CalculateMeanAndRMS(medianValues_TECMinus_Disc9, MeanAndRms_TECMinus_Disc9, numberiterations_);
 
-  pQuality=siStripQuality;
+  pQuality = siStripQuality;
   badStripList.clear();
 
   // Initialize the DQM output histograms
   initializeDQMHistograms();
 
   // Analyze the Occupancy for both APVs and Strips
-  AnalyzeOccupancy(siStripQuality,medianValues_TIB_Layer1,MeanAndRms_TIB_Layer1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIB_Layer2,MeanAndRms_TIB_Layer2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIB_Layer3,MeanAndRms_TIB_Layer3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIB_Layer4,MeanAndRms_TIB_Layer4,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TIB_Layer1, MeanAndRms_TIB_Layer1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TIB_Layer2, MeanAndRms_TIB_Layer2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TIB_Layer3, MeanAndRms_TIB_Layer3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TIB_Layer4, MeanAndRms_TIB_Layer4, badStripList, inSiStripQuality);
 
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer1,MeanAndRms_TOB_Layer1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer2,MeanAndRms_TOB_Layer2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer3,MeanAndRms_TOB_Layer3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer4,MeanAndRms_TOB_Layer4,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer5,MeanAndRms_TOB_Layer5,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TOB_Layer6,MeanAndRms_TOB_Layer6,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer1, MeanAndRms_TOB_Layer1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer2, MeanAndRms_TOB_Layer2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer3, MeanAndRms_TOB_Layer3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer4, MeanAndRms_TOB_Layer4, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer5, MeanAndRms_TOB_Layer5, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(siStripQuality, medianValues_TOB_Layer6, MeanAndRms_TOB_Layer6, badStripList, inSiStripQuality);
 
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDPlus_Disc1,MeanAndRms_TIDPlus_Disc1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDPlus_Disc2,MeanAndRms_TIDPlus_Disc2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDPlus_Disc3,MeanAndRms_TIDPlus_Disc3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDMinus_Disc1,MeanAndRms_TIDMinus_Disc1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDMinus_Disc2,MeanAndRms_TIDMinus_Disc2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TIDMinus_Disc3,MeanAndRms_TIDMinus_Disc3,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDPlus_Disc1, MeanAndRms_TIDPlus_Disc1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDPlus_Disc2, MeanAndRms_TIDPlus_Disc2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDPlus_Disc3, MeanAndRms_TIDPlus_Disc3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDMinus_Disc1, MeanAndRms_TIDMinus_Disc1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDMinus_Disc2, MeanAndRms_TIDMinus_Disc2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TIDMinus_Disc3, MeanAndRms_TIDMinus_Disc3, badStripList, inSiStripQuality);
 
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc1,MeanAndRms_TECPlus_Disc1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc2,MeanAndRms_TECPlus_Disc2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc3,MeanAndRms_TECPlus_Disc3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc4,MeanAndRms_TECPlus_Disc4,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc5,MeanAndRms_TECPlus_Disc5,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc6,MeanAndRms_TECPlus_Disc6,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc7,MeanAndRms_TECPlus_Disc7,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc8,MeanAndRms_TECPlus_Disc8,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECPlus_Disc9,MeanAndRms_TECPlus_Disc9,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc1, MeanAndRms_TECPlus_Disc1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc2, MeanAndRms_TECPlus_Disc2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc3, MeanAndRms_TECPlus_Disc3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc4, MeanAndRms_TECPlus_Disc4, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc5, MeanAndRms_TECPlus_Disc5, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc6, MeanAndRms_TECPlus_Disc6, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc7, MeanAndRms_TECPlus_Disc7, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc8, MeanAndRms_TECPlus_Disc8, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECPlus_Disc9, MeanAndRms_TECPlus_Disc9, badStripList, inSiStripQuality);
 
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc1,MeanAndRms_TECMinus_Disc1,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc2,MeanAndRms_TECMinus_Disc2,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc3,MeanAndRms_TECMinus_Disc3,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc4,MeanAndRms_TECMinus_Disc4,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc5,MeanAndRms_TECMinus_Disc5,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc6,MeanAndRms_TECMinus_Disc6,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc7,MeanAndRms_TECMinus_Disc7,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc8,MeanAndRms_TECMinus_Disc8,badStripList,inSiStripQuality);
-  AnalyzeOccupancy(siStripQuality,medianValues_TECMinus_Disc9,MeanAndRms_TECMinus_Disc9,badStripList,inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc1, MeanAndRms_TECMinus_Disc1, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc2, MeanAndRms_TECMinus_Disc2, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc3, MeanAndRms_TECMinus_Disc3, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc4, MeanAndRms_TECMinus_Disc4, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc5, MeanAndRms_TECMinus_Disc5, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc6, MeanAndRms_TECMinus_Disc6, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc7, MeanAndRms_TECMinus_Disc7, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc8, MeanAndRms_TECMinus_Disc8, badStripList, inSiStripQuality);
+  AnalyzeOccupancy(
+      siStripQuality, medianValues_TECMinus_Disc9, MeanAndRms_TECMinus_Disc9, badStripList, inSiStripQuality);
 
   siStripQuality->fillBadComponents();
 
   // Fill DQM histograms
-  for(unsigned int i = 0; i < subDetName.size(); i++)
-    {
-      projYDistanceVsStripNumber[i]->Add((TH1F*)distanceVsStripNumber[i]->ProjectionY());
-      pfxDistanceVsStripNumber[i]->Add(distanceVsStripNumber[i]->ProfileX(pfxDistanceVsStripNumber[i]->GetName(),1,998));
-      projYNHitsVsStripNumber[i]->Add(nHitsVsStripNumber[i]->ProjectionY());
-      projYNHitsGoodStripsVsStripNumber[i]->Add(nHitsGoodStripsVsStripNumber[i]->ProjectionY());
-      projYNHitsHotStripsVsStripNumber[i]->Add(nHitsHotStripsVsStripNumber[i]->ProjectionY());
-      projYOccupancyVsStripNumber[i]->Add(occupancyVsStripNumber[i]->ProjectionY());
-      projYOccupancyGoodStripsVsStripNumber[i]->Add(occupancyGoodStripsVsStripNumber[i]->ProjectionY());
-      projYOccupancyHotStripsVsStripNumber[i]->Add(occupancyHotStripsVsStripNumber[i]->ProjectionY());
-      pfxOccupancyVsStripNumber[i]->Add(occupancyVsStripNumber[i]->ProfileX(pfxOccupancyVsStripNumber[i]->GetName(),-8.,0.));
-      pfxOccupancyGoodStripsVsStripNumber[i]->Add(occupancyGoodStripsVsStripNumber[i]->ProfileX(pfxOccupancyGoodStripsVsStripNumber[i]->GetName(),-8.,0.));
-      pfxOccupancyHotStripsVsStripNumber[i]->Add(occupancyHotStripsVsStripNumber[i]->ProfileX(pfxOccupancyHotStripsVsStripNumber[i]->GetName(),-8.,0.));
-      projYPoissonProbVsStripNumber[i]->Add(poissonProbVsStripNumber[i]->ProjectionY());
-      projYPoissonProbGoodStripsVsStripNumber[i]->Add(poissonProbGoodStripsVsStripNumber[i]->ProjectionY());
-      projYPoissonProbHotStripsVsStripNumber[i]->Add(poissonProbHotStripsVsStripNumber[i]->ProjectionY());
-      pfxPoissonProbVsStripNumber[i]->Add(poissonProbVsStripNumber[i]->ProfileX(pfxPoissonProbVsStripNumber[i]->GetName(),-18., 0.));
-      pfxPoissonProbGoodStripsVsStripNumber[i]->Add(poissonProbGoodStripsVsStripNumber[i]->ProfileX(pfxPoissonProbGoodStripsVsStripNumber[i]->GetName(),-18., 0.));
-      pfxPoissonProbHotStripsVsStripNumber[i]->Add(poissonProbHotStripsVsStripNumber[i]->ProfileX(pfxPoissonProbHotStripsVsStripNumber[i]->GetName(),-18., 0.));
-      projXDistanceVsStripNumber[i]->Add(distanceVsStripNumber[i]->ProjectionX(projXDistanceVsStripNumber[i]->GetName(),1,998));
-
-    }
+  for (unsigned int i = 0; i < subDetName.size(); i++) {
+    projYDistanceVsStripNumber[i]->Add((TH1F*)distanceVsStripNumber[i]->ProjectionY());
+    pfxDistanceVsStripNumber[i]->Add(
+        distanceVsStripNumber[i]->ProfileX(pfxDistanceVsStripNumber[i]->GetName(), 1, 998));
+    projYNHitsVsStripNumber[i]->Add(nHitsVsStripNumber[i]->ProjectionY());
+    projYNHitsGoodStripsVsStripNumber[i]->Add(nHitsGoodStripsVsStripNumber[i]->ProjectionY());
+    projYNHitsHotStripsVsStripNumber[i]->Add(nHitsHotStripsVsStripNumber[i]->ProjectionY());
+    projYOccupancyVsStripNumber[i]->Add(occupancyVsStripNumber[i]->ProjectionY());
+    projYOccupancyGoodStripsVsStripNumber[i]->Add(occupancyGoodStripsVsStripNumber[i]->ProjectionY());
+    projYOccupancyHotStripsVsStripNumber[i]->Add(occupancyHotStripsVsStripNumber[i]->ProjectionY());
+    pfxOccupancyVsStripNumber[i]->Add(
+        occupancyVsStripNumber[i]->ProfileX(pfxOccupancyVsStripNumber[i]->GetName(), -8., 0.));
+    pfxOccupancyGoodStripsVsStripNumber[i]->Add(
+        occupancyGoodStripsVsStripNumber[i]->ProfileX(pfxOccupancyGoodStripsVsStripNumber[i]->GetName(), -8., 0.));
+    pfxOccupancyHotStripsVsStripNumber[i]->Add(
+        occupancyHotStripsVsStripNumber[i]->ProfileX(pfxOccupancyHotStripsVsStripNumber[i]->GetName(), -8., 0.));
+    projYPoissonProbVsStripNumber[i]->Add(poissonProbVsStripNumber[i]->ProjectionY());
+    projYPoissonProbGoodStripsVsStripNumber[i]->Add(poissonProbGoodStripsVsStripNumber[i]->ProjectionY());
+    projYPoissonProbHotStripsVsStripNumber[i]->Add(poissonProbHotStripsVsStripNumber[i]->ProjectionY());
+    pfxPoissonProbVsStripNumber[i]->Add(
+        poissonProbVsStripNumber[i]->ProfileX(pfxPoissonProbVsStripNumber[i]->GetName(), -18., 0.));
+    pfxPoissonProbGoodStripsVsStripNumber[i]->Add(
+        poissonProbGoodStripsVsStripNumber[i]->ProfileX(pfxPoissonProbGoodStripsVsStripNumber[i]->GetName(), -18., 0.));
+    pfxPoissonProbHotStripsVsStripNumber[i]->Add(
+        poissonProbHotStripsVsStripNumber[i]->ProfileX(pfxPoissonProbHotStripsVsStripNumber[i]->GetName(), -18., 0.));
+    projXDistanceVsStripNumber[i]->Add(
+        distanceVsStripNumber[i]->ProjectionX(projXDistanceVsStripNumber[i]->GetName(), 1, 998));
+  }
 
   // Save output files
 
-  if (WriteOutputFile_==true){
-  f->cd();
-  apvtree->Write();
-  striptree->Write();
-  f->Close();
+  if (WriteOutputFile_ == true) {
+    f->cd();
+    apvtree->Write();
+    striptree->Write();
+    f->Close();
   }
 
-  if (WriteDQMHistograms_==true){
+  if (WriteDQMHistograms_ == true) {
     dqmStore->cd();
     dqmStore->save(DQMOutfileName_);
   }
@@ -364,448 +423,447 @@ void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::extractBadAPVSandStr
   LogTrace("SiStripBadAPV") << ss.str() << std::endl;
 }
 
-
-void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::CalculateMeanAndRMS(const std::vector<Apv>& a, std::pair<double,double>* MeanRMS, int number_iterations)
-{
+void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::CalculateMeanAndRMS(const std::vector<Apv>& a,
+                                                                                std::pair<double, double>* MeanRMS,
+                                                                                int number_iterations) {
   Double_t tot[7], tot2[7];
   Double_t n[7];
 
   Double_t Mean[7] = {0};
-  Double_t Rms[7]  = {1000,1000,1000,1000,1000,1000,1000};
+  Double_t Rms[7] = {1000, 1000, 1000, 1000, 1000, 1000, 1000};
 
   int Moduleposition;
 
-  for (int i=0; i<number_iterations; i++)
-    {
-      for (int j=0; j<7; j++)
-	{
-	  n[j]    = 0;
-	  tot[j]  = 0;
-	  tot2[j] = 0;
-	}
-
-      for (uint32_t it=0; it<a.size(); it++)
-	{
-	  Moduleposition = (a[it].modulePosition)-1;
-
-	  for (int apv=0; apv<a[it].numberApvs; apv++)
-	    {
-	      if (i>0)
-		{
-		  if (a[it].apvMedian[apv]<(Mean[Moduleposition]-3*Rms[Moduleposition]) || (a[it].apvMedian[apv]>(Mean[Moduleposition]+5*Rms[Moduleposition])))
-		    {
-		      continue;
-		    }
-		}
-	      tot[Moduleposition]  += a[it].apvMedian[apv];
-	      tot2[Moduleposition] += (a[it].apvMedian[apv])*(a[it].apvMedian[apv]);
-	      n[Moduleposition]++;
-	    }
-	}
-
-      for (int j=0; j<7; j++)
-	{
-	  if (n[j]!=0)
-	    {
-	      Mean[j] = tot[j]/n[j];
-	      Rms[j]  = TMath::Sqrt(TMath::Abs(tot2[j]/n[j] -Mean[j]*Mean[j]));
-	    }
-	}
+  for (int i = 0; i < number_iterations; i++) {
+    for (int j = 0; j < 7; j++) {
+      n[j] = 0;
+      tot[j] = 0;
+      tot2[j] = 0;
     }
 
-  for (int j=0; j<7; j++)
-    {
-      MeanRMS[j] = std::make_pair(Mean[j],Rms[j]);
+    for (uint32_t it = 0; it < a.size(); it++) {
+      Moduleposition = (a[it].modulePosition) - 1;
+
+      for (int apv = 0; apv < a[it].numberApvs; apv++) {
+        if (i > 0) {
+          if (a[it].apvMedian[apv] < (Mean[Moduleposition] - 3 * Rms[Moduleposition]) ||
+              (a[it].apvMedian[apv] > (Mean[Moduleposition] + 5 * Rms[Moduleposition]))) {
+            continue;
+          }
+        }
+        tot[Moduleposition] += a[it].apvMedian[apv];
+        tot2[Moduleposition] += (a[it].apvMedian[apv]) * (a[it].apvMedian[apv]);
+        n[Moduleposition]++;
+      }
     }
 
+    for (int j = 0; j < 7; j++) {
+      if (n[j] != 0) {
+        Mean[j] = tot[j] / n[j];
+        Rms[j] = TMath::Sqrt(TMath::Abs(tot2[j] / n[j] - Mean[j] * Mean[j]));
+      }
+    }
+  }
+
+  for (int j = 0; j < 7; j++) {
+    MeanRMS[j] = std::make_pair(Mean[j], Rms[j]);
+  }
 }
 
-void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::AnalyzeOccupancy(SiStripQuality* quality, std::vector<Apv>& medianValues, std::pair<double,double>* MeanAndRms, std::vector<unsigned int>& BadStripList, edm::ESHandle<SiStripQuality>& InSiStripQuality)
-{
+void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::AnalyzeOccupancy(
+    SiStripQuality* quality,
+    std::vector<Apv>& medianValues,
+    std::pair<double, double>* MeanAndRms,
+    std::vector<unsigned int>& BadStripList,
+    edm::ESHandle<SiStripQuality>& InSiStripQuality) {
   int Moduleposition;
   uint32_t Detid;
 
-  for (uint32_t it=0; it<medianValues.size(); it++)
-    {
-      Moduleposition = (medianValues[it].modulePosition)-1;
-      Detid          = medianValues[it].detrawId;
+  for (uint32_t it = 0; it < medianValues.size(); it++) {
+    Moduleposition = (medianValues[it].modulePosition) - 1;
+    Detid = medianValues[it].detrawId;
 
-      setBasicTreeParameters(Detid);
+    setBasicTreeParameters(Detid);
 
-      DetId DetectorId=DetId(Detid);
-      const StripGeomDetUnit*  TheStripDet   = dynamic_cast<const StripGeomDetUnit*>( (TkGeom->idToDet(DetectorId)) );
-      const StripTopology*     TheStripTopol = dynamic_cast<const StripTopology*>( &(TheStripDet->specificTopology()) );
+    DetId DetectorId = DetId(Detid);
+    const StripGeomDetUnit* TheStripDet = dynamic_cast<const StripGeomDetUnit*>((TkGeom->idToDet(DetectorId)));
+    const StripTopology* TheStripTopol = dynamic_cast<const StripTopology*>(&(TheStripDet->specificTopology()));
 
-      //Analyze the occupancies
-      hotstripspermodule = 0;
-      vHotStripsInModule.clear();
+    //Analyze the occupancies
+    hotstripspermodule = 0;
+    vHotStripsInModule.clear();
 
-      for (int apv=0; apv<medianValues[it].numberApvs; apv++)
-	{
-	  double logMedianOccupancy = -1;
-	  double logAbsoluteOccupancy = -1;
+    for (int apv = 0; apv < medianValues[it].numberApvs; apv++) {
+      double logMedianOccupancy = -1;
+      double logAbsoluteOccupancy = -1;
 
-	  for (int i=0; i<128; i++)
-	    {
-	      ishot[i]               = 0;
-	      stripoccupancy[i]      = 0;
-	      striphits[i]           = 0;
-	      poissonprob[i]         = 0;
-	    }
+      for (int i = 0; i < 128; i++) {
+        ishot[i] = 0;
+        stripoccupancy[i] = 0;
+        striphits[i] = 0;
+        poissonprob[i] = 0;
+      }
 
-	  number_strips        = (medianValues[it].numberApvs)*128;
-	  apv_number           = apv+1;
-	  apvMedianOccupancy   = medianValues[it].apvMedian[apv];
-	  apvAbsoluteOccupancy = medianValues[it].apvabsoluteOccupancy[apv];
-	  isBad                = 0;
-	  hotstripsperapv[apv] = 0;
+      number_strips = (medianValues[it].numberApvs) * 128;
+      apv_number = apv + 1;
+      apvMedianOccupancy = medianValues[it].apvMedian[apv];
+      apvAbsoluteOccupancy = medianValues[it].apvabsoluteOccupancy[apv];
+      isBad = 0;
+      hotstripsperapv[apv] = 0;
 
-	  LocalPoint  pos_apv_local  = TheStripTopol->localPosition((apv*128));
-	  GlobalPoint pos_apv_global = (TkGeom->idToDet(DetectorId))->surface().toGlobal(pos_apv_local);
+      LocalPoint pos_apv_local = TheStripTopol->localPosition((apv * 128));
+      GlobalPoint pos_apv_global = (TkGeom->idToDet(DetectorId))->surface().toGlobal(pos_apv_local);
 
-	  global_position_x = pos_apv_global.x();
-	  global_position_y = pos_apv_global.y();
-	  global_position_z = pos_apv_global.z();
+      global_position_x = pos_apv_global.x();
+      global_position_y = pos_apv_global.y();
+      global_position_z = pos_apv_global.z();
 
-	  if (apvMedianOccupancy>0) logMedianOccupancy = log10(apvMedianOccupancy);
-	  if (apvAbsoluteOccupancy>0) logAbsoluteOccupancy = log10(apvAbsoluteOccupancy);
+      if (apvMedianOccupancy > 0)
+        logMedianOccupancy = log10(apvMedianOccupancy);
+      if (apvAbsoluteOccupancy > 0)
+        logAbsoluteOccupancy = log10(apvAbsoluteOccupancy);
 
-	  //Fill the DQM histograms
-	  unsigned int layer = 0;
-	  if(subdetid==3 || subdetid==5)
-	    layer=layer_ring;
-	  else
-	    layer=disc;
+      //Fill the DQM histograms
+      unsigned int layer = 0;
+      if (subdetid == 3 || subdetid == 5)
+        layer = layer_ring;
+      else
+        layer = disc;
 
-	  // Fill histograms for all the tracker
-	  medianVsAbsoluteOccupancy[0][0]->Fill(logAbsoluteOccupancy,logMedianOccupancy);
-	  medianOccupancy[0][0]->Fill(logMedianOccupancy);
-	  absoluteOccupancy[0][0]->Fill(logAbsoluteOccupancy);
-	  // Fill summary histograms for each subdetector
-	  medianVsAbsoluteOccupancy[subdetid-2][0]->Fill(logAbsoluteOccupancy,logMedianOccupancy);
-	  medianOccupancy[subdetid-2][0]->Fill(logMedianOccupancy);
-	  absoluteOccupancy[subdetid-2][0]->Fill(logAbsoluteOccupancy);
-	  // Fill histograms for each layer/disk
-	  medianVsAbsoluteOccupancy[subdetid-2][layer]->Fill(logAbsoluteOccupancy,logMedianOccupancy);
-	  medianOccupancy[subdetid-2][layer]->Fill(logMedianOccupancy);
-	  absoluteOccupancy[subdetid-2][layer]->Fill(logAbsoluteOccupancy);
+      // Fill histograms for all the tracker
+      medianVsAbsoluteOccupancy[0][0]->Fill(logAbsoluteOccupancy, logMedianOccupancy);
+      medianOccupancy[0][0]->Fill(logMedianOccupancy);
+      absoluteOccupancy[0][0]->Fill(logAbsoluteOccupancy);
+      // Fill summary histograms for each subdetector
+      medianVsAbsoluteOccupancy[subdetid - 2][0]->Fill(logAbsoluteOccupancy, logMedianOccupancy);
+      medianOccupancy[subdetid - 2][0]->Fill(logMedianOccupancy);
+      absoluteOccupancy[subdetid - 2][0]->Fill(logAbsoluteOccupancy);
+      // Fill histograms for each layer/disk
+      medianVsAbsoluteOccupancy[subdetid - 2][layer]->Fill(logAbsoluteOccupancy, logMedianOccupancy);
+      medianOccupancy[subdetid - 2][layer]->Fill(logMedianOccupancy);
+      absoluteOccupancy[subdetid - 2][layer]->Fill(logAbsoluteOccupancy);
 
-	  if(UseInputDB_)
-	    {
-	      if(InSiStripQuality->IsApvBad(Detid,apv) )
-		{
-		  if (WriteOutputFile_==true)
-		    {
-		      apvtree->Fill();
-		      for (int strip=0; strip<128; strip++)
-			{
-			  strip_number         = (apv*128)+strip+1;
-			  apv_channel          = apv+1;
-			  isHot                = ishot[strip];
-			  singleStripOccupancy = stripoccupancy[strip];
-			  stripHits            = striphits[strip];
-			  poissonProb          = poissonprob[strip];
+      if (UseInputDB_) {
+        if (InSiStripQuality->IsApvBad(Detid, apv)) {
+          if (WriteOutputFile_ == true) {
+            apvtree->Fill();
+            for (int strip = 0; strip < 128; strip++) {
+              strip_number = (apv * 128) + strip + 1;
+              apv_channel = apv + 1;
+              isHot = ishot[strip];
+              singleStripOccupancy = stripoccupancy[strip];
+              stripHits = striphits[strip];
+              poissonProb = poissonprob[strip];
 
-			  hotStripsPerModule = hotstripspermodule;
-			  hotStripsPerAPV    = hotstripsperapv[apv];
+              hotStripsPerModule = hotstripspermodule;
+              hotStripsPerAPV = hotstripsperapv[apv];
 
-			  LocalPoint  pos_strip_local  = TheStripTopol->localPosition(strip);
-			  GlobalPoint pos_strip_global = (TkGeom->idToDet(DetectorId))->surface().toGlobal(pos_strip_local);
+              LocalPoint pos_strip_local = TheStripTopol->localPosition(strip);
+              GlobalPoint pos_strip_global = (TkGeom->idToDet(DetectorId))->surface().toGlobal(pos_strip_local);
 
-			  strip_global_position_x = pos_strip_global.x();
-			  strip_global_position_y = pos_strip_global.y();
-			  strip_global_position_z = pos_strip_global.z();
-			  striptree->Fill();
+              strip_global_position_x = pos_strip_global.x();
+              strip_global_position_y = pos_strip_global.y();
+              strip_global_position_z = pos_strip_global.z();
+              striptree->Fill();
 
-			  // Fill the strip DQM Plots
-			  fillStripDQMHistograms();
-			}
-     
-		      if(vHotStripsInModule.size()==1)
-			{
-			  distance = 999;
-			  distanceVsStripNumber[0]->Fill(vHotStripsInModule[0], distance);
-			  distanceVsStripNumber[subdetid-2]->Fill(vHotStripsInModule[0], distance);
-			}
-		      else if(vHotStripsInModule.size()>1)
-			{
-			  for(unsigned int iVec = 0; iVec != vHotStripsInModule.size(); iVec++)
-			    {
-			      if(iVec==0)
-				distance = vHotStripsInModule[1] - vHotStripsInModule[0];
-			      else if(iVec==vHotStripsInModule.size()-1)
-				{
-				  distance = vHotStripsInModule[vHotStripsInModule.size()-1] - vHotStripsInModule[vHotStripsInModule.size() -2];
-				}
-			      else if(vHotStripsInModule.size()>2)
-				{
-				  distanceR = vHotStripsInModule[iVec + 1] -  vHotStripsInModule[iVec];
-				  distanceL = vHotStripsInModule[iVec] - vHotStripsInModule[iVec - 1];
-				  distance = distanceL>distanceR?distanceR:distanceL;
-				}
-			      else
-				{
-				  std::cout << "ERROR! distance is never computed!!!\n";
-				}
-			      distanceVsStripNumber[0]->Fill(vHotStripsInModule[iVec], distance);
-			      distanceVsStripNumber[subdetid-2]->Fill(vHotStripsInModule[iVec], distance);
-			    }
-			}
+              // Fill the strip DQM Plots
+              fillStripDQMHistograms();
+            }
 
-		    }
-		  continue;//if the apv is already flagged as bad, continue.
-		}
-	    }
+            if (vHotStripsInModule.size() == 1) {
+              distance = 999;
+              distanceVsStripNumber[0]->Fill(vHotStripsInModule[0], distance);
+              distanceVsStripNumber[subdetid - 2]->Fill(vHotStripsInModule[0], distance);
+            } else if (vHotStripsInModule.size() > 1) {
+              for (unsigned int iVec = 0; iVec != vHotStripsInModule.size(); iVec++) {
+                if (iVec == 0)
+                  distance = vHotStripsInModule[1] - vHotStripsInModule[0];
+                else if (iVec == vHotStripsInModule.size() - 1) {
+                  distance = vHotStripsInModule[vHotStripsInModule.size() - 1] -
+                             vHotStripsInModule[vHotStripsInModule.size() - 2];
+                } else if (vHotStripsInModule.size() > 2) {
+                  distanceR = vHotStripsInModule[iVec + 1] - vHotStripsInModule[iVec];
+                  distanceL = vHotStripsInModule[iVec] - vHotStripsInModule[iVec - 1];
+                  distance = distanceL > distanceR ? distanceR : distanceL;
+                } else {
+                  std::cout << "ERROR! distance is never computed!!!\n";
+                }
+                distanceVsStripNumber[0]->Fill(vHotStripsInModule[iVec], distance);
+                distanceVsStripNumber[subdetid - 2]->Fill(vHotStripsInModule[iVec], distance);
+              }
+            }
+          }
+          continue;  //if the apv is already flagged as bad, continue.
+        }
+      }
 
-	  if (medianValues[it].apvMedian[apv] > minNevents_)
-	    {
-	      if ((medianValues[it].apvMedian[apv]>(MeanAndRms[Moduleposition].first+highoccupancy_*MeanAndRms[Moduleposition].second)) && (medianValues[it].apvMedian[apv]>absolutelow_))
-		{
-		  BadStripList.push_back(pQuality->encode((apv*128),128,0));
-		  isBad = 1;
-		}
-	    }
-	  else if (medianValues[it].apvMedian[apv]<(MeanAndRms[Moduleposition].first-lowoccupancy_*MeanAndRms[Moduleposition].second) && (MeanAndRms[Moduleposition].first>2 || medianValues[it].apvabsoluteOccupancy[apv]==0))
-	    {
-	      BadStripList.push_back(pQuality->encode((apv*128),128,0));
-	      isBad = 1;
-	    }
+      if (medianValues[it].apvMedian[apv] > minNevents_) {
+        if ((medianValues[it].apvMedian[apv] >
+             (MeanAndRms[Moduleposition].first + highoccupancy_ * MeanAndRms[Moduleposition].second)) &&
+            (medianValues[it].apvMedian[apv] > absolutelow_)) {
+          BadStripList.push_back(pQuality->encode((apv * 128), 128, 0));
+          isBad = 1;
+        }
+      } else if (medianValues[it].apvMedian[apv] <
+                     (MeanAndRms[Moduleposition].first - lowoccupancy_ * MeanAndRms[Moduleposition].second) &&
+                 (MeanAndRms[Moduleposition].first > 2 || medianValues[it].apvabsoluteOccupancy[apv] == 0)) {
+        BadStripList.push_back(pQuality->encode((apv * 128), 128, 0));
+        isBad = 1;
+      }
 
-	  if (isBad!=1)
-	    {
-	      iterativeSearch(medianValues[it],BadStripList,apv);
-	    }
+      if (isBad != 1) {
+        iterativeSearch(medianValues[it], BadStripList, apv);
+      }
 
-	  if (WriteOutputFile_==true)
-	    {
-	      apvtree->Fill();
-	      for (int strip=0; strip<128; strip++)
-		{
-		  strip_number         = (apv*128)+strip+1;
-		  apv_channel          = apv+1;
-		  isHot                = ishot[strip];
-		  singleStripOccupancy = stripoccupancy[strip];
-		  stripHits            = striphits[strip];
-		  poissonProb          = poissonprob[strip];
+      if (WriteOutputFile_ == true) {
+        apvtree->Fill();
+        for (int strip = 0; strip < 128; strip++) {
+          strip_number = (apv * 128) + strip + 1;
+          apv_channel = apv + 1;
+          isHot = ishot[strip];
+          singleStripOccupancy = stripoccupancy[strip];
+          stripHits = striphits[strip];
+          poissonProb = poissonprob[strip];
 
-		  hotStripsPerModule = hotstripspermodule;
-		  hotStripsPerAPV    = hotstripsperapv[apv];
+          hotStripsPerModule = hotstripspermodule;
+          hotStripsPerAPV = hotstripsperapv[apv];
 
-		  LocalPoint  pos_strip_local  = TheStripTopol->localPosition(strip);
-		  GlobalPoint pos_strip_global = (TkGeom->idToDet(DetectorId))->surface().toGlobal(pos_strip_local);
+          LocalPoint pos_strip_local = TheStripTopol->localPosition(strip);
+          GlobalPoint pos_strip_global = (TkGeom->idToDet(DetectorId))->surface().toGlobal(pos_strip_local);
 
-		  strip_global_position_x = pos_strip_global.x();
-		  strip_global_position_y = pos_strip_global.y();
-		  strip_global_position_z = pos_strip_global.z();
-		  striptree->Fill();
+          strip_global_position_x = pos_strip_global.x();
+          strip_global_position_y = pos_strip_global.y();
+          strip_global_position_z = pos_strip_global.z();
+          striptree->Fill();
 
-		  // Fill the strip DQM Plots
-		  fillStripDQMHistograms();
-		}
-	      if(vHotStripsInModule.size()==1)
-		{
-		  distance = 999;
-		  distanceVsStripNumber[0]->Fill(vHotStripsInModule[0], distance);
-		  distanceVsStripNumber[subdetid-2]->Fill(vHotStripsInModule[0], distance);
-		}
-	      else if(vHotStripsInModule.size()>1)
-		{
-		  for(unsigned int iVec = 0; iVec != vHotStripsInModule.size(); iVec++)
-		    {
-		      if(iVec==0)
-			distance = vHotStripsInModule[1] - vHotStripsInModule[0];
-		      else if(iVec==vHotStripsInModule.size()-1)
-			{
-			  distance = vHotStripsInModule[vHotStripsInModule.size()-1] - vHotStripsInModule[vHotStripsInModule.size() -2];
-			}
-		      else if(vHotStripsInModule.size()>2)
-			{
-			  distanceR = vHotStripsInModule[iVec + 1] -  vHotStripsInModule[iVec];
-			  distanceL = vHotStripsInModule[iVec] - vHotStripsInModule[iVec - 1];
-			  distance = distanceL>distanceR?distanceR:distanceL;
-			}
-		      else
-			{
-			  std::cout << "ERROR! distance is never computed!!!\n";
-			}
-		      distanceVsStripNumber[0]->Fill(vHotStripsInModule[iVec], distance);
-		      distanceVsStripNumber[subdetid-2]->Fill(vHotStripsInModule[iVec], distance);
-		    }
-		}
-	    }
-	}
-
-      if (BadStripList.begin()!=BadStripList.end())
-	{
-	  quality->compact(Detid,BadStripList);
-	  SiStripQuality::Range range(BadStripList.begin(),BadStripList.end());
-	  quality->put(Detid,range);
-	}
-      BadStripList.clear();
+          // Fill the strip DQM Plots
+          fillStripDQMHistograms();
+        }
+        if (vHotStripsInModule.size() == 1) {
+          distance = 999;
+          distanceVsStripNumber[0]->Fill(vHotStripsInModule[0], distance);
+          distanceVsStripNumber[subdetid - 2]->Fill(vHotStripsInModule[0], distance);
+        } else if (vHotStripsInModule.size() > 1) {
+          for (unsigned int iVec = 0; iVec != vHotStripsInModule.size(); iVec++) {
+            if (iVec == 0)
+              distance = vHotStripsInModule[1] - vHotStripsInModule[0];
+            else if (iVec == vHotStripsInModule.size() - 1) {
+              distance =
+                  vHotStripsInModule[vHotStripsInModule.size() - 1] - vHotStripsInModule[vHotStripsInModule.size() - 2];
+            } else if (vHotStripsInModule.size() > 2) {
+              distanceR = vHotStripsInModule[iVec + 1] - vHotStripsInModule[iVec];
+              distanceL = vHotStripsInModule[iVec] - vHotStripsInModule[iVec - 1];
+              distance = distanceL > distanceR ? distanceR : distanceL;
+            } else {
+              std::cout << "ERROR! distance is never computed!!!\n";
+            }
+            distanceVsStripNumber[0]->Fill(vHotStripsInModule[iVec], distance);
+            distanceVsStripNumber[subdetid - 2]->Fill(vHotStripsInModule[iVec], distance);
+          }
+        }
+      }
     }
+
+    if (BadStripList.begin() != BadStripList.end()) {
+      quality->compact(Detid, BadStripList);
+      SiStripQuality::Range range(BadStripList.begin(), BadStripList.end());
+      quality->put(Detid, range);
+    }
+    BadStripList.clear();
+  }
 }
 
-void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::iterativeSearch(Apv& histo,std::vector<unsigned int>& vect, int apv){
-  if (!histo.NEntries[apv] || histo.NEntries[apv] <=MinNumEntries_ || histo.NEntries[apv] <= minNevents_)
+void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::iterativeSearch(Apv& histo,
+                                                                            std::vector<unsigned int>& vect,
+                                                                            int apv) {
+  if (!histo.NEntries[apv] || histo.NEntries[apv] <= MinNumEntries_ || histo.NEntries[apv] <= minNevents_)
     return;
-  
-  size_t startingSize=vect.size();
-  long double diff=1.-prob_; 
-  
-  size_t Nbins     = histo.th1f[apv]->GetNbinsX();
-  size_t ibinStart = 1; 
-  size_t ibinStop  = Nbins+1; 
-  int MaxEntry  = (int)histo.th1f[apv]->GetMaximum();
 
-  std::vector<long double> vPoissonProbs(MaxEntry+1,0);
-  long double meanVal=1.*histo.NEntries[apv]/(1.*Nbins-histo.NEmptyBins[apv]); 
-  evaluatePoissonian(vPoissonProbs,meanVal);
+  size_t startingSize = vect.size();
+  long double diff = 1. - prob_;
+
+  size_t Nbins = histo.th1f[apv]->GetNbinsX();
+  size_t ibinStart = 1;
+  size_t ibinStop = Nbins + 1;
+  int MaxEntry = (int)histo.th1f[apv]->GetMaximum();
+
+  std::vector<long double> vPoissonProbs(MaxEntry + 1, 0);
+  long double meanVal = 1. * histo.NEntries[apv] / (1. * Nbins - histo.NEmptyBins[apv]);
+  evaluatePoissonian(vPoissonProbs, meanVal);
 
   // Find median occupancy, taking into account only good strips
   unsigned int goodstripentries[128];
   int nGoodStrips = 0;
-  for (size_t i=ibinStart; i<ibinStop; ++i){
-    if (ishot[(apv*128)+i-1]==0){
+  for (size_t i = ibinStart; i < ibinStop; ++i) {
+    if (ishot[(apv * 128) + i - 1] == 0) {
       goodstripentries[nGoodStrips] = (unsigned int)histo.th1f[apv]->GetBinContent(i);
       nGoodStrips++;
     }
   }
-  double median = TMath::Median(nGoodStrips,goodstripentries);
+  double median = TMath::Median(nGoodStrips, goodstripentries);
 
-  for (size_t i=ibinStart; i<ibinStop; ++i){
-    unsigned int entries= (unsigned int)histo.th1f[apv]->GetBinContent(i);
+  for (size_t i = ibinStart; i < ibinStop; ++i) {
+    unsigned int entries = (unsigned int)histo.th1f[apv]->GetBinContent(i);
 
-    if (ishot[i-1]==0){
-      stripoccupancy[i-1] = entries/(double) Nevents_;
-      striphits[i-1]      = entries;
-      poissonprob[i-1]    = 1-vPoissonProbs[entries];
-      medianapvhits[apv]  = median;
+    if (ishot[i - 1] == 0) {
+      stripoccupancy[i - 1] = entries / (double)Nevents_;
+      striphits[i - 1] = entries;
+      poissonprob[i - 1] = 1 - vPoissonProbs[entries];
+      medianapvhits[apv] = median;
       avgapvhits[apv] = meanVal;
     }
 
-    if (entries<=MinNumEntriesPerStrip_ || entries <= minNevents_ || entries / median < ratio_) continue;
+    if (entries <= MinNumEntriesPerStrip_ || entries <= minNevents_ || entries / median < ratio_)
+      continue;
 
-    if(diff<vPoissonProbs[entries]){
-      ishot[i-1] = 1;
+    if (diff < vPoissonProbs[entries]) {
+      ishot[i - 1] = 1;
       hotstripspermodule++;
       hotstripsperapv[apv]++;
-      histo.th1f[apv]->SetBinContent(i,0.);
-      histo.NEntries[apv]-=entries;
+      histo.th1f[apv]->SetBinContent(i, 0.);
+      histo.NEntries[apv] -= entries;
       histo.NEmptyBins[apv]++;
       if (edm::isDebugEnabled())
-	LogTrace("SiStripHotStrip")<< " rejecting strip " << (apv*128)+i-1 << " value " << entries << " diff  " << diff << " prob " << vPoissonProbs[entries]<< std::endl;
-      vect.push_back(pQuality->encode((apv*128)+i-1,1,0));
+        LogTrace("SiStripHotStrip") << " rejecting strip " << (apv * 128) + i - 1 << " value " << entries << " diff  "
+                                    << diff << " prob " << vPoissonProbs[entries] << std::endl;
+      vect.push_back(pQuality->encode((apv * 128) + i - 1, 1, 0));
     }
-
   }
   if (edm::isDebugEnabled())
-    LogTrace("SiStripHotStrip") << " [SiStripHotStripAlgorithmFromClusterOccupancy::iterativeSearch] Nbins="<< Nbins << " MaxEntry="<<MaxEntry << " meanVal=" << meanVal << " NEmptyBins="<<histo.NEmptyBins[apv]<< " NEntries=" << histo.NEntries[apv] << " thEntries " << histo.th1f[apv]->GetEntries()<< " startingSize " << startingSize << " vector.size " << vect.size() << std::endl;
+    LogTrace("SiStripHotStrip") << " [SiStripHotStripAlgorithmFromClusterOccupancy::iterativeSearch] Nbins=" << Nbins
+                                << " MaxEntry=" << MaxEntry << " meanVal=" << meanVal
+                                << " NEmptyBins=" << histo.NEmptyBins[apv] << " NEntries=" << histo.NEntries[apv]
+                                << " thEntries " << histo.th1f[apv]->GetEntries() << " startingSize " << startingSize
+                                << " vector.size " << vect.size() << std::endl;
 
-  if (vect.size()!=startingSize)
-    iterativeSearch(histo,vect,apv);
+  if (vect.size() != startingSize)
+    iterativeSearch(histo, vect, apv);
 }
 
-void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::evaluatePoissonian(std::vector<long double>& vPoissonProbs, long double& meanVal){
-  for(size_t i=0;i<vPoissonProbs.size();++i){
-    vPoissonProbs[i]= (i==0)?TMath::Poisson(i,meanVal):vPoissonProbs[i-1]+TMath::Poisson(i,meanVal);
+void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::evaluatePoissonian(std::vector<long double>& vPoissonProbs,
+                                                                               long double& meanVal) {
+  for (size_t i = 0; i < vPoissonProbs.size(); ++i) {
+    vPoissonProbs[i] = (i == 0) ? TMath::Poisson(i, meanVal) : vPoissonProbs[i - 1] + TMath::Poisson(i, meanVal);
   }
 }
 
-void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::setBasicTreeParameters(int detid){
-  DetId DetectorID=DetId(detid);
+void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::setBasicTreeParameters(int detid) {
+  DetId DetectorID = DetId(detid);
 
   detrawid = detid;
   subdetid = DetectorID.subdetId();
 
-  switch (DetectorID.subdetId())
-    {
-    case StripSubdetector::TIB :
+  switch (DetectorID.subdetId()) {
+    case StripSubdetector::TIB:
       layer_ring = tTopo->tibLayer(detid);
-      disc       = -1;
-      isstereo   = tTopo->tibIsStereo(detid);
-      isback     = -1;
-      if (tTopo->tibIsExternalString(detid)) isexternalstring = 1;
-      else                                    isexternalstring = 0;
-      if (tTopo->tibIsZMinusSide(detid)) iszminusside = 1;
-      else                                iszminusside = 0;
-      rodstringpetal     = tTopo->tibString(detid);
-      module_number      = tTopo->tibModule(detid);
+      disc = -1;
+      isstereo = tTopo->tibIsStereo(detid);
+      isback = -1;
+      if (tTopo->tibIsExternalString(detid))
+        isexternalstring = 1;
+      else
+        isexternalstring = 0;
+      if (tTopo->tibIsZMinusSide(detid))
+        iszminusside = 1;
+      else
+        iszminusside = 0;
+      rodstringpetal = tTopo->tibString(detid);
+      module_number = tTopo->tibModule(detid);
 
       break;
 
-    case StripSubdetector::TID :
+    case StripSubdetector::TID:
       layer_ring = tTopo->tidRing(detid);
-      disc       = tTopo->tidWheel(detid);
-      isstereo   = tTopo->tidIsStereo(detid);
-      if (tTopo->tidIsBackRing(detid)) isback = 1;
-      else                              isback = 0;
-      if (tTopo->tidIsZMinusSide(detid)) iszminusside = 1;
-      else                                iszminusside = 0;
-      isexternalstring   = -1;
-      rodstringpetal     = -1;
-      module_number      = tTopo->tidModule(detid);
+      disc = tTopo->tidWheel(detid);
+      isstereo = tTopo->tidIsStereo(detid);
+      if (tTopo->tidIsBackRing(detid))
+        isback = 1;
+      else
+        isback = 0;
+      if (tTopo->tidIsZMinusSide(detid))
+        iszminusside = 1;
+      else
+        iszminusside = 0;
+      isexternalstring = -1;
+      rodstringpetal = -1;
+      module_number = tTopo->tidModule(detid);
 
       break;
 
-    case StripSubdetector::TOB :
+    case StripSubdetector::TOB:
       layer_ring = tTopo->tobLayer(detid);
-      disc       = -1;
-      isstereo   = tTopo->tobIsStereo(detid);
-      isback     = -1;
-      if (tTopo->tobIsZMinusSide(detid)) iszminusside = 1;
-      else                                iszminusside = 0;
-      isexternalstring   = -1;
-      rodstringpetal     = tTopo->tobRod(detid);
-      module_number      = tTopo->tobModule(detid);
+      disc = -1;
+      isstereo = tTopo->tobIsStereo(detid);
+      isback = -1;
+      if (tTopo->tobIsZMinusSide(detid))
+        iszminusside = 1;
+      else
+        iszminusside = 0;
+      isexternalstring = -1;
+      rodstringpetal = tTopo->tobRod(detid);
+      module_number = tTopo->tobModule(detid);
 
       break;
 
-    case StripSubdetector::TEC :
+    case StripSubdetector::TEC:
       layer_ring = tTopo->tecRing(detid);
-      disc       = tTopo->tecWheel(detid);
-      isstereo   = tTopo->tecIsStereo(detid);
-      if (tTopo->tecIsBackPetal(detid)) isback = 1;
-      else                               isback = 0;
-      if (tTopo->tecIsZMinusSide(detid)) iszminusside = 1;
-      else                                iszminusside = 0;
-      isexternalstring   = -1;
-      rodstringpetal     = tTopo->tecPetalNumber(detid);
-      module_number      = tTopo->tecModule(detid);
+      disc = tTopo->tecWheel(detid);
+      isstereo = tTopo->tecIsStereo(detid);
+      if (tTopo->tecIsBackPetal(detid))
+        isback = 1;
+      else
+        isback = 0;
+      if (tTopo->tecIsZMinusSide(detid))
+        iszminusside = 1;
+      else
+        iszminusside = 0;
+      isexternalstring = -1;
+      rodstringpetal = tTopo->tecPetalNumber(detid);
+      module_number = tTopo->tecModule(detid);
 
       break;
 
-    default :
+    default:
       std::cout << "### Detector does not belong to TIB, TID, TOB or TEC !? ###" << std::endl;
       std::cout << "### DetRawId: " << detid << " ###" << std::endl;
-    }
+  }
 }
 
-void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::setMinNumOfEvents()
-{
-  minNevents_=absolute_occupancy_*Nevents_;
+void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::setMinNumOfEvents() {
+  minNevents_ = absolute_occupancy_ * Nevents_;
 }
 
-void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::initializeDQMHistograms()
-{
+void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::initializeDQMHistograms() {
   oss.str("");
-  oss << 1; //runNumber
+  oss << 1;  //runNumber
 
   dqmStore = edm::Service<DQMStore>().operator->();
   dqmStore->setCurrentFolder("ChannelStatusPlots");
 
   // Initialize histograms
-  subDetName.push_back(""); subDetName.push_back("TIB"); subDetName.push_back("TID"); subDetName.push_back("TOB"); subDetName.push_back("TEC");
-  nLayers.push_back(0); nLayers.push_back(4); nLayers.push_back(3); nLayers.push_back(6); nLayers.push_back(9);
-  layerName.push_back(""); layerName.push_back("Layer"); layerName.push_back("Disk"); layerName.push_back("Layer"); layerName.push_back("Disk");
-  
+  subDetName.push_back("");
+  subDetName.push_back("TIB");
+  subDetName.push_back("TID");
+  subDetName.push_back("TOB");
+  subDetName.push_back("TEC");
+  nLayers.push_back(0);
+  nLayers.push_back(4);
+  nLayers.push_back(3);
+  nLayers.push_back(6);
+  nLayers.push_back(9);
+  layerName.push_back("");
+  layerName.push_back("Layer");
+  layerName.push_back("Disk");
+  layerName.push_back("Layer");
+  layerName.push_back("Disk");
+
   std::string histoName;
   std::string histoTitle;
 
-  for(unsigned int i = 0; i < subDetName.size(); i++)
-  {
+  for (unsigned int i = 0; i < subDetName.size(); i++) {
     histoName = "distanceVsStripNumber" + subDetName[i];
     histoTitle = "Distance between hot strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 999, 0.5, 999.5);
     distanceVsStripNumber.push_back(tmp->getTH2F());
@@ -819,160 +877,160 @@ void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::initializeDQMHistogr
 
     histoName = "projXDistanceVsStripNumber" + subDetName[i];
     histoTitle = "Number of hot strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     projXDistanceVsStripNumber.push_back(tmp->getTH1F());
     projXDistanceVsStripNumber[i]->GetXaxis()->SetTitle("Strip");
     projXDistanceVsStripNumber[i]->GetYaxis()->SetTitle("N_{hot}");
-    
+
     histoName = "projYDistanceVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of distance between hot strips";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 999, 0.5, 999.5);
     projYDistanceVsStripNumber.push_back(tmp->getTH1F());
     projYDistanceVsStripNumber[i]->GetXaxis()->SetTitle("Distance");
     projYDistanceVsStripNumber[i]->GetYaxis()->SetTitle("N_{strips}");
-    
+
     //
     histoName = "occupancyVsStripNumber" + subDetName[i];
     histoTitle = "Occupancy of strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
-    tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 1000, -8.,0.);
+    tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 1000, -8., 0.);
     occupancyVsStripNumber.push_back(tmp->getTH2F());
-    
+
     histoName = "pfxOccupancyVsStripNumber" + subDetName[i];
     tmp_prof = new TProfile(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     tmp = dqmStore->bookProfile(histoName.c_str(), tmp_prof);
     pfxOccupancyVsStripNumber.push_back(tmp->getTProfile());
     pfxOccupancyVsStripNumber[i]->GetXaxis()->SetTitle("Strip");
     pfxOccupancyVsStripNumber[i]->GetYaxis()->SetTitle("log_{10}(Occupancy)");
-    
+
     histoName = "projYOccupancyVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of strip occupancy";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 1000, -8., 0.);
     projYOccupancyVsStripNumber.push_back(tmp->getTH1F());
     projYOccupancyVsStripNumber[i]->GetXaxis()->SetTitle("log_{10}(Occupancy)");
     projYOccupancyVsStripNumber[i]->GetYaxis()->SetTitle("N_{strips}");
-    
+
     //
     histoName = "occupancyHotStripsVsStripNumber" + subDetName[i];
     histoTitle = "Occupancy of hot strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 1000, -8., 0.);
     occupancyHotStripsVsStripNumber.push_back(tmp->getTH2F());
-    
+
     histoName = "pfxOccupancyHotStripsVsStripNumber" + subDetName[i];
     tmp_prof = new TProfile(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     tmp = dqmStore->bookProfile(histoName.c_str(), tmp_prof);
     pfxOccupancyHotStripsVsStripNumber.push_back(tmp->getTProfile());
     pfxOccupancyHotStripsVsStripNumber[i]->GetXaxis()->SetTitle("Strip");
     pfxOccupancyHotStripsVsStripNumber[i]->GetYaxis()->SetTitle("log_{10}(Occupancy)");
-    
+
     histoName = "projYOccupancyHotStripsVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of hot strip occupancy";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 1000, -8., 0.);
     projYOccupancyHotStripsVsStripNumber.push_back(tmp->getTH1F());
     projYOccupancyHotStripsVsStripNumber[i]->GetXaxis()->SetTitle("log_{10}(Occupancy)");
     projYOccupancyHotStripsVsStripNumber[i]->GetYaxis()->SetTitle("N_{strips}");
-    
+
     //
     histoName = "occupancyGoodStripsVsStripNumber" + subDetName[i];
     histoTitle = "Occupancy of good strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 1000, -8., 0.);
     occupancyGoodStripsVsStripNumber.push_back(tmp->getTH2F());
-    
+
     histoName = "pfxOccupancyGoodStripsVsStripNumber" + subDetName[i];
     tmp_prof = new TProfile(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     tmp = dqmStore->bookProfile(histoName.c_str(), tmp_prof);
     pfxOccupancyGoodStripsVsStripNumber.push_back(tmp->getTProfile());
     pfxOccupancyGoodStripsVsStripNumber[i]->GetXaxis()->SetTitle("Strip");
     pfxOccupancyGoodStripsVsStripNumber[i]->GetYaxis()->SetTitle("log_{10}(Occupancy)");
-    
+
     histoName = "projYOccupancyGoodStripsVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of good strip occupancy";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 1000, -8., 0.);
     projYOccupancyGoodStripsVsStripNumber.push_back(tmp->getTH1F());
     projYOccupancyGoodStripsVsStripNumber[i]->GetXaxis()->SetTitle("log_{10}(Occupancy)");
     projYOccupancyGoodStripsVsStripNumber[i]->GetYaxis()->SetTitle("N_{strips}");
-    
+
     //
     histoName = "poissonProbVsStripNumber" + subDetName[i];
     histoTitle = "Poisson probability of strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 1000, -18., 0.);
     poissonProbVsStripNumber.push_back(tmp->getTH2F());
-    
+
     histoName = "pfxPoissonProbVsStripNumber" + subDetName[i];
     tmp_prof = new TProfile(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     tmp = dqmStore->bookProfile(histoName.c_str(), tmp_prof);
     pfxPoissonProbVsStripNumber.push_back(tmp->getTProfile());
     pfxPoissonProbVsStripNumber[i]->GetXaxis()->SetTitle("Strip");
     pfxPoissonProbVsStripNumber[i]->GetYaxis()->SetTitle("log_{10}(Probability)");
-    
+
     histoName = "projYPoissonProbVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of strip Poisson probability";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 1000, -18., 0.);
     projYPoissonProbVsStripNumber.push_back(tmp->getTH1F());
     projYPoissonProbVsStripNumber[i]->GetXaxis()->SetTitle("log_{10}(Probability)");
     projYPoissonProbVsStripNumber[i]->GetYaxis()->SetTitle("N_{strips}");
-    
+
     //
     histoName = "poissonProbHotStripsVsStripNumber" + subDetName[i];
     histoTitle = "Poisson probability of hot strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 1000, -18., 0.);
     poissonProbHotStripsVsStripNumber.push_back(tmp->getTH2F());
-    
+
     histoName = "pfxPoissonProbHotStripsVsStripNumber" + subDetName[i];
     tmp_prof = new TProfile(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     tmp = dqmStore->bookProfile(histoName.c_str(), tmp_prof);
     pfxPoissonProbHotStripsVsStripNumber.push_back(tmp->getTProfile());
     pfxPoissonProbHotStripsVsStripNumber[i]->GetXaxis()->SetTitle("Strip");
     pfxPoissonProbHotStripsVsStripNumber[i]->GetYaxis()->SetTitle("log_{10}(Probability)");
-    
+
     histoName = "projYPoissonProbHotStripsVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of hot strip Poisson probability";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 1000, -18., 0.);
     projYPoissonProbHotStripsVsStripNumber.push_back(tmp->getTH1F());
     projYPoissonProbHotStripsVsStripNumber[i]->GetXaxis()->SetTitle("log_{10}(Probability)");
     projYPoissonProbHotStripsVsStripNumber[i]->GetYaxis()->SetTitle("N_{strips}");
-    
+
     //
     histoName = "poissonProbGoodStripsVsStripNumber" + subDetName[i];
     histoTitle = "Poisson probability of good strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 1000, -18., 0.);
     poissonProbGoodStripsVsStripNumber.push_back(tmp->getTH2F());
-    
+
     histoName = "pfxPoissonProbGoodStripsVsStripNumber" + subDetName[i];
     tmp_prof = new TProfile(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     tmp = dqmStore->bookProfile(histoName.c_str(), tmp_prof);
     pfxPoissonProbGoodStripsVsStripNumber.push_back(tmp->getTProfile());
     pfxPoissonProbGoodStripsVsStripNumber[i]->GetXaxis()->SetTitle("Strip");
     pfxPoissonProbGoodStripsVsStripNumber[i]->GetYaxis()->SetTitle("log_{10}(Probability)");
-    
+
     histoName = "projYPoissonProbGoodStripsVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of good strip Poisson probability";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 1000, -18., 0.);
     projYPoissonProbGoodStripsVsStripNumber.push_back(tmp->getTH1F());
@@ -982,124 +1040,119 @@ void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::initializeDQMHistogr
     //
     histoName = "nHitsVsStripNumber" + subDetName[i];
     histoTitle = "NHits in strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 10000, -0.5, 9999.5);
     nHitsVsStripNumber.push_back(tmp->getTH2F());
-    
+
     histoName = "pfxNHitsVsStripNumber" + subDetName[i];
     tmp_prof = new TProfile(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     tmp = dqmStore->bookProfile(histoName.c_str(), tmp_prof);
     pfxNHitsVsStripNumber.push_back(tmp->getTProfile());
-    
+
     histoName = "projXNHitsVsStripNumber" + subDetName[i];
     histoTitle = "Cumulative nHits in strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     projXNHitsVsStripNumber.push_back(tmp->getTH1F());
-    
+
     histoName = "projYNHitsVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of nHits for all strips";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 10000, -0.5, 9999.5);
     projYNHitsVsStripNumber.push_back(tmp->getTH1F());
     projYNHitsVsStripNumber[i]->GetXaxis()->SetTitle("N_{hits}");
     projYNHitsVsStripNumber[i]->GetYaxis()->SetTitle("N_{strips}");
-    
+
     //
     histoName = "nHitsHotStripsVsStripNumber" + subDetName[i];
     histoTitle = "NHits in hot strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 10000, -0.5, 9999.5);
     nHitsHotStripsVsStripNumber.push_back(tmp->getTH2F());
-    
+
     histoName = "pfxNHitsHotStripsVsStripNumber" + subDetName[i];
     tmp_prof = new TProfile(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     tmp = dqmStore->bookProfile(histoName.c_str(), tmp_prof);
     pfxNHitsHotStripsVsStripNumber.push_back(tmp->getTProfile());
-    
+
     histoName = "projXNHitsHotStripsVsStripNumber" + subDetName[i];
     histoTitle = "Cumulative nHits in hot strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     projXNHitsHotStripsVsStripNumber.push_back(tmp->getTH1F());
-    
+
     histoName = "projYNHitsHotStripsVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of nHits for hot strips";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 10000, -0.5, 9999.5);
     projYNHitsHotStripsVsStripNumber.push_back(tmp->getTH1F());
     projYNHitsHotStripsVsStripNumber[i]->GetXaxis()->SetTitle("N_{hits}");
     projYNHitsHotStripsVsStripNumber[i]->GetYaxis()->SetTitle("N_{strips}");
-    
+
     //
     histoName = "nHitsGoodStripsVsStripNumber" + subDetName[i];
     histoTitle = "NHits in good strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5, 10000, -0.5, 9999.5);
     nHitsGoodStripsVsStripNumber.push_back(tmp->getTH2F());
-    
+
     histoName = "pfxNHitsGoodStripsVsStripNumber" + subDetName[i];
     tmp_prof = new TProfile(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     tmp = dqmStore->bookProfile(histoName.c_str(), tmp_prof);
     pfxNHitsGoodStripsVsStripNumber.push_back(tmp->getTProfile());
-    
+
     histoName = "projXNHitsGoodStripsVsStripNumber" + subDetName[i];
     histoTitle = "Cumulative nHits in good strips vs. strip number";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 768, 0.5, 768.5);
     projXNHitsGoodStripsVsStripNumber.push_back(tmp->getTH1F());
-    
+
     histoName = "projYNHitsGoodStripsVsStripNumber" + subDetName[i];
     histoTitle = "Distribution of nHits for good strips";
-    if(i!=0)
+    if (i != 0)
       histoTitle += " in " + subDetName[i];
     tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 10000, -0.5, 9999.5);
     projYNHitsGoodStripsVsStripNumber.push_back(tmp->getTH1F());
     projYNHitsGoodStripsVsStripNumber[i]->GetXaxis()->SetTitle("N_{hits}");
     projYNHitsGoodStripsVsStripNumber[i]->GetYaxis()->SetTitle("N_{strips}");
 
-    for(unsigned int j = 0; j <= nLayers[i]; j++)
-    {
+    for (unsigned int j = 0; j <= nLayers[i]; j++) {
       histoName = "medianVsAbsoluteOccupancy" + subDetName[i];
-      if(j!=0)
-      {
+      if (j != 0) {
         oss.str("");
         oss << j;
         histoName += layerName[i] + oss.str();
       }
       histoTitle = "Median APV occupancy vs. absolute APV occupancy";
-      if(i!=0)
+      if (i != 0)
         histoTitle += " in " + subDetName[i];
-      if(j!=0)
-      {
+      if (j != 0) {
         histoTitle += " " + layerName[i] + " " + oss.str();
       }
       tmp = dqmStore->book2D(histoName.c_str(), histoTitle.c_str(), 1000, 0., 6., 1000, -1., 3.);
       medianVsAbsoluteOccupancy[i][j] = tmp->getTH2F();
-      medianVsAbsoluteOccupancy[i][j]->Rebin2D(10,10);
+      medianVsAbsoluteOccupancy[i][j]->Rebin2D(10, 10);
       medianVsAbsoluteOccupancy[i][j]->GetXaxis()->SetTitle("log_{10}(Abs. Occupancy)");
       medianVsAbsoluteOccupancy[i][j]->GetYaxis()->SetTitle("log_{10}(Median Occupancy)");
       //
       histoName = "medianOccupancy" + subDetName[i];
-      if(j!=0)
-      {
+      if (j != 0) {
         oss.str("");
         oss << j;
         histoName += layerName[i] + oss.str();
       }
       histoTitle = "Median APV occupancy";
-      if(i!=0)
+      if (i != 0)
         histoTitle += " in " + subDetName[i];
-      if(j!=0)
-      {
+      if (j != 0) {
         histoTitle += " " + layerName[i] + " " + oss.str();
       }
       tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 1000, -1., 3.);
@@ -1108,17 +1161,15 @@ void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::initializeDQMHistogr
       medianOccupancy[i][j]->GetYaxis()->SetTitle("APVs");
       //
       histoName = "absoluteOccupancy" + subDetName[i];
-      if(j!=0)
-      {
+      if (j != 0) {
         oss.str("");
         oss << j;
         histoName += layerName[i] + oss.str();
       }
       histoTitle = "Absolute APV occupancy";
-      if(i!=0)
+      if (i != 0)
         histoTitle += " in " + subDetName[i];
-      if(j!=0)
-      {
+      if (j != 0) {
         histoTitle += " " + layerName[i] + " " + oss.str();
       }
       tmp = dqmStore->book1D(histoName.c_str(), histoTitle.c_str(), 1000, 0., 6.);
@@ -1129,38 +1180,36 @@ void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::initializeDQMHistogr
   }
 }
 
-void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::fillStripDQMHistograms()
-{
+void SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy::fillStripDQMHistograms() {
   double logStripOccupancy = -1;
   double logPoissonProb = -1;
 
-  if (singleStripOccupancy>0) logStripOccupancy = log10(singleStripOccupancy);
-  if (poissonProb>0) logPoissonProb = log10(fabs(poissonProb));
+  if (singleStripOccupancy > 0)
+    logStripOccupancy = log10(singleStripOccupancy);
+  if (poissonProb > 0)
+    logPoissonProb = log10(fabs(poissonProb));
 
-  occupancyVsStripNumber[0]->Fill(strip_number,logStripOccupancy);
-  occupancyVsStripNumber[subdetid-2]->Fill(strip_number,logStripOccupancy);
-  poissonProbVsStripNumber[0]->Fill(strip_number,logPoissonProb);
-  poissonProbVsStripNumber[subdetid-2]->Fill(strip_number,logPoissonProb);
-  nHitsVsStripNumber[0]->Fill(strip_number,stripHits);
-  nHitsVsStripNumber[subdetid-2]->Fill(strip_number,stripHits);
-       
-  if(isHot)
-    {
-      vHotStripsInModule.push_back(strip_number);
-      occupancyHotStripsVsStripNumber[0]->Fill(strip_number,logStripOccupancy);
-      occupancyHotStripsVsStripNumber[subdetid-2]->Fill(strip_number,logStripOccupancy);
-      poissonProbHotStripsVsStripNumber[0]->Fill(strip_number,logPoissonProb);
-      poissonProbHotStripsVsStripNumber[subdetid-2]->Fill(strip_number,logPoissonProb);
-      nHitsHotStripsVsStripNumber[0]->Fill(strip_number,stripHits);
-      nHitsHotStripsVsStripNumber[subdetid-2]->Fill(strip_number,stripHits);
-    }
-  else
-    {
-      occupancyGoodStripsVsStripNumber[0]->Fill(strip_number,logStripOccupancy);
-      occupancyGoodStripsVsStripNumber[subdetid-2]->Fill(strip_number,logStripOccupancy);
-      poissonProbGoodStripsVsStripNumber[0]->Fill(strip_number,logPoissonProb);
-      poissonProbGoodStripsVsStripNumber[subdetid-2]->Fill(strip_number,logPoissonProb);
-      nHitsGoodStripsVsStripNumber[0]->Fill(strip_number,stripHits);
-      nHitsGoodStripsVsStripNumber[subdetid-2]->Fill(strip_number,stripHits);
-    }
+  occupancyVsStripNumber[0]->Fill(strip_number, logStripOccupancy);
+  occupancyVsStripNumber[subdetid - 2]->Fill(strip_number, logStripOccupancy);
+  poissonProbVsStripNumber[0]->Fill(strip_number, logPoissonProb);
+  poissonProbVsStripNumber[subdetid - 2]->Fill(strip_number, logPoissonProb);
+  nHitsVsStripNumber[0]->Fill(strip_number, stripHits);
+  nHitsVsStripNumber[subdetid - 2]->Fill(strip_number, stripHits);
+
+  if (isHot) {
+    vHotStripsInModule.push_back(strip_number);
+    occupancyHotStripsVsStripNumber[0]->Fill(strip_number, logStripOccupancy);
+    occupancyHotStripsVsStripNumber[subdetid - 2]->Fill(strip_number, logStripOccupancy);
+    poissonProbHotStripsVsStripNumber[0]->Fill(strip_number, logPoissonProb);
+    poissonProbHotStripsVsStripNumber[subdetid - 2]->Fill(strip_number, logPoissonProb);
+    nHitsHotStripsVsStripNumber[0]->Fill(strip_number, stripHits);
+    nHitsHotStripsVsStripNumber[subdetid - 2]->Fill(strip_number, stripHits);
+  } else {
+    occupancyGoodStripsVsStripNumber[0]->Fill(strip_number, logStripOccupancy);
+    occupancyGoodStripsVsStripNumber[subdetid - 2]->Fill(strip_number, logStripOccupancy);
+    poissonProbGoodStripsVsStripNumber[0]->Fill(strip_number, logPoissonProb);
+    poissonProbGoodStripsVsStripNumber[subdetid - 2]->Fill(strip_number, logPoissonProb);
+    nHitsGoodStripsVsStripNumber[0]->Fill(strip_number, stripHits);
+    nHitsGoodStripsVsStripNumber[subdetid - 2]->Fill(strip_number, stripHits);
+  }
 }

--- a/CalibTracker/SiStripQuality/src/SiStripHotStripAlgorithmFromClusterOccupancy.cc
+++ b/CalibTracker/SiStripQuality/src/SiStripHotStripAlgorithmFromClusterOccupancy.cc
@@ -1,310 +1,329 @@
 #include "CalibTracker/SiStripQuality/interface/SiStripHotStripAlgorithmFromClusterOccupancy.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
+SiStripHotStripAlgorithmFromClusterOccupancy::SiStripHotStripAlgorithmFromClusterOccupancy(
+    const edm::ParameterSet& iConfig, const TrackerTopology* theTopo)
+    : prob_(1.E-7),
+      ratio_(1.5),
+      MinNumEntries_(0),
+      MinNumEntriesPerStrip_(0),
+      Nevents_(0),
+      occupancy_(0),
+      OutFileName_("Occupancy.root"),
+      tTopo(theTopo),
+      UseInputDB_(iConfig.getUntrackedParameter<bool>("UseInputDB", false)) {
+  minNevents_ = Nevents_ * occupancy_;
+}
 
+SiStripHotStripAlgorithmFromClusterOccupancy::~SiStripHotStripAlgorithmFromClusterOccupancy() {
+  LogTrace("SiStripHotStripAlgorithmFromClusterOccupancy")
+      << "[SiStripHotStripAlgorithmFromClusterOccupancy::~SiStripHotStripAlgorithmFromClusterOccupancy] " << std::endl;
+}
 
+void SiStripHotStripAlgorithmFromClusterOccupancy::extractBadStrips(SiStripQuality* OutSiStripQuality,
+                                                                    HistoMap& DM,
+                                                                    edm::ESHandle<SiStripQuality>& InSiStripQuality) {
+  LogTrace("SiStripHotStripAlgorithmFromClusterOccupancy")
+      << "[SiStripHotStripAlgorithmFromClusterOccupancy::extractBadStrips] " << std::endl;
 
-SiStripHotStripAlgorithmFromClusterOccupancy::SiStripHotStripAlgorithmFromClusterOccupancy(const edm::ParameterSet& iConfig, const TrackerTopology* theTopo):
-    prob_(1.E-7),
-    ratio_(1.5),
-    MinNumEntries_(0),
-    MinNumEntriesPerStrip_(0),
-    Nevents_(0),
-    occupancy_(0),
-    OutFileName_("Occupancy.root"),
-    tTopo(theTopo),
-    UseInputDB_(iConfig.getUntrackedParameter<bool>("UseInputDB",false))
-  {  
-    minNevents_=Nevents_*occupancy_;
+  if (WriteOutputFile_ == true) {
+    f = new TFile(OutFileName_.c_str(), "RECREATE");
+    f->cd();
+
+    striptree = new TTree("stripOccupancy", "tree");
+
+    striptree->Branch("DetRawId", &detrawid, "DetRawId/I");
+    striptree->Branch("SubDetId", &subdetid, "SubDetId/I");
+    striptree->Branch("Layer_Ring", &layer_ring, "Layer_Ring/I");
+    striptree->Branch("Disc", &disc, "Disc/I");
+    striptree->Branch("IsBack", &isback, "IsBack/I");
+    striptree->Branch("IsExternalString", &isexternalstring, "IsExternalString/I");
+    striptree->Branch("IsZMinusSide", &iszminusside, "IsZMinusSide/I");
+    striptree->Branch("RodStringPetal", &rodstringpetal, "RodStringPetal/I");
+    striptree->Branch("IsStereo", &isstereo, "IsStereo/I");
+    striptree->Branch("ModulePosition", &module_position, "ModulePosition/I");
+    striptree->Branch("NumberOfStrips", &number_strips, "NumberOfStrips/I");
+    striptree->Branch("StripNumber", &strip_number, "StripNumber/I");
+    striptree->Branch("APVChannel", &apv_channel, "APVChannel/I");
+    striptree->Branch("StripGlobalPositionX", &global_position_x, "StripGlobalPositionX/F");
+    striptree->Branch("StripGlobalPositionY", &global_position_y, "StripGlobalPositionY/F");
+    striptree->Branch("StripGlobalPositionZ", &global_position_z, "StripGlobalPositionZ/F");
+    striptree->Branch("IsHot", &isHot, "IsHot/I");
+    striptree->Branch("HotStripsPerAPV", &hotStripsPerAPV, "HotStripsPerAPV/I");
+    striptree->Branch("HotStripsPerModule", &hotStripsPerModule, "HotStripsPerModule/I");
+    striptree->Branch("StripOccupancy", &stripOccupancy, "StripOccupancy/D");
+    striptree->Branch("StripHits", &stripHits, "StripHits/I");
+    striptree->Branch("PoissonProb", &poissonProb, "PoissonProb/D");
+    striptree->Branch("MedianAPVHits", &medianAPVHits, "MedianAPVHits/D");
+    striptree->Branch("AvgAPVHits", &avgAPVHits, "AvgAPVHits/D");
   }
 
-
-SiStripHotStripAlgorithmFromClusterOccupancy::~SiStripHotStripAlgorithmFromClusterOccupancy(){
-  LogTrace("SiStripHotStripAlgorithmFromClusterOccupancy")<<"[SiStripHotStripAlgorithmFromClusterOccupancy::~SiStripHotStripAlgorithmFromClusterOccupancy] "<<std::endl;
-}
-
-void SiStripHotStripAlgorithmFromClusterOccupancy::extractBadStrips(SiStripQuality* OutSiStripQuality,HistoMap& DM,edm::ESHandle<SiStripQuality>& InSiStripQuality){
-
-  LogTrace("SiStripHotStripAlgorithmFromClusterOccupancy")<<"[SiStripHotStripAlgorithmFromClusterOccupancy::extractBadStrips] "<<std::endl;
-
-
-  
-  if (WriteOutputFile_==true){
-  f = new TFile(OutFileName_.c_str(),"RECREATE");
-  f->cd();
-
-  striptree = new TTree("stripOccupancy","tree");
-
-  striptree->Branch("DetRawId",             &detrawid,          "DetRawId/I");
-  striptree->Branch("SubDetId",             &subdetid,          "SubDetId/I");
-  striptree->Branch("Layer_Ring",           &layer_ring,        "Layer_Ring/I");
-  striptree->Branch("Disc",                 &disc,              "Disc/I");
-  striptree->Branch("IsBack",               &isback,            "IsBack/I");
-  striptree->Branch("IsExternalString",     &isexternalstring,  "IsExternalString/I");
-  striptree->Branch("IsZMinusSide",         &iszminusside,      "IsZMinusSide/I");
-  striptree->Branch("RodStringPetal",       &rodstringpetal,    "RodStringPetal/I");
-  striptree->Branch("IsStereo",             &isstereo,          "IsStereo/I");
-  striptree->Branch("ModulePosition",       &module_position,   "ModulePosition/I");
-  striptree->Branch("NumberOfStrips",       &number_strips,     "NumberOfStrips/I");
-  striptree->Branch("StripNumber",          &strip_number,      "StripNumber/I");
-  striptree->Branch("APVChannel",           &apv_channel,       "APVChannel/I");
-  striptree->Branch("StripGlobalPositionX", &global_position_x, "StripGlobalPositionX/F");
-  striptree->Branch("StripGlobalPositionY", &global_position_y, "StripGlobalPositionY/F");
-  striptree->Branch("StripGlobalPositionZ", &global_position_z, "StripGlobalPositionZ/F");
-  striptree->Branch("IsHot",                &isHot,             "IsHot/I");
-  striptree->Branch("HotStripsPerAPV",      &hotStripsPerAPV,   "HotStripsPerAPV/I");
-  striptree->Branch("HotStripsPerModule",   &hotStripsPerModule,"HotStripsPerModule/I");
-  striptree->Branch("StripOccupancy",       &stripOccupancy,    "StripOccupancy/D");
-  striptree->Branch("StripHits",            &stripHits,         "StripHits/I");
-  striptree->Branch("PoissonProb",          &poissonProb,       "PoissonProb/D");
-  striptree->Branch("MedianAPVHits",        &medianAPVHits,     "MedianAPVHits/D");
-  striptree->Branch("AvgAPVHits",           &avgAPVHits,        "AvgAPVHits/D");
-}
-
-  
-  HistoMap::iterator it=DM.begin();
-  HistoMap::iterator itEnd=DM.end();
+  HistoMap::iterator it = DM.begin();
+  HistoMap::iterator itEnd = DM.end();
   std::vector<unsigned int> badStripList;
   uint32_t detid;
-  for (;it!=itEnd;++it){
+  for (; it != itEnd; ++it) {
     pHisto phisto;
-    detid=it->first;
+    detid = it->first;
 
-    DetId detectorId=DetId(detid);
-    phisto._SubdetId=detectorId.subdetId();
-    
+    DetId detectorId = DetId(detid);
+    phisto._SubdetId = detectorId.subdetId();
+
     if (edm::isDebugEnabled())
-      LogTrace("SiStripHotStrip") << "Analyzing detid " << detid<< std::endl;
-    
-    int numberAPVs = (int)(it->second.get())->GetNbinsX()/128;
+      LogTrace("SiStripHotStrip") << "Analyzing detid " << detid << std::endl;
+
+    int numberAPVs = (int)(it->second.get())->GetNbinsX() / 128;
 
     // Set the values for the tree:
 
     detrawid = detid;
     subdetid = detectorId.subdetId();
     number_strips = (int)(it->second.get())->GetNbinsX();
-    switch (detectorId.subdetId())
-      {
-      case StripSubdetector::TIB :
-	layer_ring = tTopo->tibLayer(detrawid);
-	disc       = -1;
-	isstereo = tTopo->tibIsStereo(detrawid);
-	isback     = -1;
-	if (tTopo->tibIsExternalString(detrawid)) isexternalstring = 1;
-	else                                       isexternalstring = 0;
-	if (tTopo->tibIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
-	rodstringpetal  = tTopo->tibString(detrawid);
-	module_position = tTopo->tibModule(detrawid);
-	break;
+    switch (detectorId.subdetId()) {
+      case StripSubdetector::TIB:
+        layer_ring = tTopo->tibLayer(detrawid);
+        disc = -1;
+        isstereo = tTopo->tibIsStereo(detrawid);
+        isback = -1;
+        if (tTopo->tibIsExternalString(detrawid))
+          isexternalstring = 1;
+        else
+          isexternalstring = 0;
+        if (tTopo->tibIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
+        rodstringpetal = tTopo->tibString(detrawid);
+        module_position = tTopo->tibModule(detrawid);
+        break;
 
-      case StripSubdetector::TID :
-	layer_ring = tTopo->tidRing(detrawid);
-	disc       = tTopo->tidWheel(detrawid);
-	isstereo = tTopo->tidIsStereo(detrawid);
-	if (tTopo->tidIsBackRing(detrawid)) isback = 1;
-	else                                 isback = 0;
-	if (tTopo->tidIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
-	isexternalstring = -1;
-	rodstringpetal   = -1;
-	module_position  = tTopo->tidModule(detrawid);
-	break;
+      case StripSubdetector::TID:
+        layer_ring = tTopo->tidRing(detrawid);
+        disc = tTopo->tidWheel(detrawid);
+        isstereo = tTopo->tidIsStereo(detrawid);
+        if (tTopo->tidIsBackRing(detrawid))
+          isback = 1;
+        else
+          isback = 0;
+        if (tTopo->tidIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
+        isexternalstring = -1;
+        rodstringpetal = -1;
+        module_position = tTopo->tidModule(detrawid);
+        break;
 
-      case StripSubdetector::TOB :
-	layer_ring = tTopo->tobLayer(detrawid);
-	disc       = -1;
-	isstereo = tTopo->tobIsStereo(detrawid);
-	isback     = -1;
-	if (tTopo->tobIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
-	isexternalstring = -1;
-	rodstringpetal   = tTopo->tobRod(detrawid);
-	module_position  = tTopo->tobModule(detrawid);
-	break;
+      case StripSubdetector::TOB:
+        layer_ring = tTopo->tobLayer(detrawid);
+        disc = -1;
+        isstereo = tTopo->tobIsStereo(detrawid);
+        isback = -1;
+        if (tTopo->tobIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
+        isexternalstring = -1;
+        rodstringpetal = tTopo->tobRod(detrawid);
+        module_position = tTopo->tobModule(detrawid);
+        break;
 
-      case StripSubdetector::TEC :
-	layer_ring = tTopo->tecRing(detrawid);
-	disc       = tTopo->tecWheel(detrawid);
-	isstereo = tTopo->tecIsStereo(detrawid);
-	if (tTopo->tecIsBackPetal(detrawid)) isback = 1;
-	else                                  isback = 0;
-	if (tTopo->tecIsZMinusSide(detrawid)) iszminusside = 1;
-	else                                   iszminusside = 0;
-	isexternalstring = -1;
-	rodstringpetal   = tTopo->tecPetalNumber(detrawid);
-	module_position  = tTopo->tecModule(detrawid);
-	break;
+      case StripSubdetector::TEC:
+        layer_ring = tTopo->tecRing(detrawid);
+        disc = tTopo->tecWheel(detrawid);
+        isstereo = tTopo->tecIsStereo(detrawid);
+        if (tTopo->tecIsBackPetal(detrawid))
+          isback = 1;
+        else
+          isback = 0;
+        if (tTopo->tecIsZMinusSide(detrawid))
+          iszminusside = 1;
+        else
+          iszminusside = 0;
+        isexternalstring = -1;
+        rodstringpetal = tTopo->tecPetalNumber(detrawid);
+        module_position = tTopo->tecModule(detrawid);
+        break;
 
-      default :
-	std::cout << "### Detector does not belong to TIB, TID, TOB or TEC !? ###" << std::endl;
-	std::cout << "### DetRawId: " << detrawid << " ###" << std::endl;
-      }
+      default:
+        std::cout << "### Detector does not belong to TIB, TID, TOB or TEC !? ###" << std::endl;
+        std::cout << "### DetRawId: " << detrawid << " ###" << std::endl;
+    }
 
     // End: Set the values for the tree.
 
-
-    pQuality=OutSiStripQuality;
+    pQuality = OutSiStripQuality;
     badStripList.clear();
 
-    for (int i=0; i<768; i++){
-      ishot[i]               = 0;
-      stripoccupancy[i]      = 0;
-      striphits[i]           = 0;
-      poissonprob[i]         = 0;
-      hotstripsperapv[i/128] = 0;
-	}
+    for (int i = 0; i < 768; i++) {
+      ishot[i] = 0;
+      stripoccupancy[i] = 0;
+      striphits[i] = 0;
+      poissonprob[i] = 0;
+      hotstripsperapv[i / 128] = 0;
+    }
 
     hotstripspermodule = 0;
 
-    for (int apv=0; apv<numberAPVs; apv++){
-      if(UseInputDB_){
-	if(InSiStripQuality->IsApvBad(detid,apv) ){
-	  if(edm::isDebugEnabled())
-	    LogTrace("SiStripHotStrip")<<"(Module and Apv number) "<<detid<<" , "<<apv<<" excluded by input ESetup."<<std::endl;
-	  continue;//if the apv is already flagged as bad, continue.
-	}
-	else{
-	  if(edm::isDebugEnabled())
-	    LogTrace("SiStripHotStrip")<<"(Module and Apv number) "<<detid<<" , "<<apv<<" good by input ESetup."<<std::endl;
-	}
+    for (int apv = 0; apv < numberAPVs; apv++) {
+      if (UseInputDB_) {
+        if (InSiStripQuality->IsApvBad(detid, apv)) {
+          if (edm::isDebugEnabled())
+            LogTrace("SiStripHotStrip") << "(Module and Apv number) " << detid << " , " << apv
+                                        << " excluded by input ESetup." << std::endl;
+          continue;  //if the apv is already flagged as bad, continue.
+        } else {
+          if (edm::isDebugEnabled())
+            LogTrace("SiStripHotStrip") << "(Module and Apv number) " << detid << " , " << apv
+                                        << " good by input ESetup." << std::endl;
+        }
       }
 
-      phisto._th1f = new TH1F("tmp","tmp",128,0.5,128.5);
-      int NumberEntriesPerAPV=0;
-      
-      for (int strip=0; strip<128; strip++){
-	phisto._th1f->SetBinContent(strip+1,(it->second.get())->GetBinContent((apv*128)+strip+1));
-	NumberEntriesPerAPV += (int)(it->second.get())->GetBinContent((apv*128)+strip+1);
+      phisto._th1f = new TH1F("tmp", "tmp", 128, 0.5, 128.5);
+      int NumberEntriesPerAPV = 0;
+
+      for (int strip = 0; strip < 128; strip++) {
+        phisto._th1f->SetBinContent(strip + 1, (it->second.get())->GetBinContent((apv * 128) + strip + 1));
+        NumberEntriesPerAPV += (int)(it->second.get())->GetBinContent((apv * 128) + strip + 1);
       }
 
       phisto._th1f->SetEntries(NumberEntriesPerAPV);
-      phisto._NEntries=(int)phisto._th1f->GetEntries();
-      phisto._NEmptyBins=0;
+      phisto._NEntries = (int)phisto._th1f->GetEntries();
+      phisto._NEmptyBins = 0;
 
       LogTrace("SiStripHotStrip") << "Number of clusters in APV " << apv << ": " << NumberEntriesPerAPV << std::endl;
 
-      iterativeSearch(phisto,badStripList,apv);
+      iterativeSearch(phisto, badStripList, apv);
 
       delete phisto._th1f;
     }
 
-    const StripGeomDetUnit*  theStripDet = dynamic_cast<const StripGeomDetUnit*>( (TkGeom->idToDet(detectorId)) );
-    const StripTopology* theStripTopol   = dynamic_cast<const StripTopology*>( &(theStripDet->specificTopology()) );  
+    const StripGeomDetUnit* theStripDet = dynamic_cast<const StripGeomDetUnit*>((TkGeom->idToDet(detectorId)));
+    const StripTopology* theStripTopol = dynamic_cast<const StripTopology*>(&(theStripDet->specificTopology()));
 
-    for (int strip=0; strip<number_strips; strip++)
-      {
-	strip_number   = strip+1;
-	apv_channel    = (strip%128)+1;
-	isHot          = ishot[strip];
-	stripOccupancy = stripoccupancy[strip];
-	stripHits      = striphits[strip];
-	poissonProb    = poissonprob[strip];
-	medianAPVHits  = medianapvhits[strip/128];
-	avgAPVHits     = avgapvhits[strip/128];
+    for (int strip = 0; strip < number_strips; strip++) {
+      strip_number = strip + 1;
+      apv_channel = (strip % 128) + 1;
+      isHot = ishot[strip];
+      stripOccupancy = stripoccupancy[strip];
+      stripHits = striphits[strip];
+      poissonProb = poissonprob[strip];
+      medianAPVHits = medianapvhits[strip / 128];
+      avgAPVHits = avgapvhits[strip / 128];
 
-	hotStripsPerModule = hotstripspermodule;
-	hotStripsPerAPV    = hotstripsperapv[strip/128];
+      hotStripsPerModule = hotstripspermodule;
+      hotStripsPerAPV = hotstripsperapv[strip / 128];
 
-	LocalPoint  pos_strip_local  = theStripTopol->localPosition(strip);
-	GlobalPoint pos_strip_global = (TkGeom->idToDet(detectorId))->surface().toGlobal(pos_strip_local);
+      LocalPoint pos_strip_local = theStripTopol->localPosition(strip);
+      GlobalPoint pos_strip_global = (TkGeom->idToDet(detectorId))->surface().toGlobal(pos_strip_local);
 
-	global_position_x = pos_strip_global.x();
-	global_position_y = pos_strip_global.y();
-	global_position_z = pos_strip_global.z();
+      global_position_x = pos_strip_global.x();
+      global_position_y = pos_strip_global.y();
+      global_position_z = pos_strip_global.z();
 
-	if (WriteOutputFile_==true) striptree->Fill();
-      }
+      if (WriteOutputFile_ == true)
+        striptree->Fill();
+    }
 
-    if (badStripList.begin()==badStripList.end())
+    if (badStripList.begin() == badStripList.end())
       continue;
 
-    OutSiStripQuality->compact(detid,badStripList);
+    OutSiStripQuality->compact(detid, badStripList);
 
-    SiStripQuality::Range range(badStripList.begin(),badStripList.end());
-    if ( ! OutSiStripQuality->put(detid,range) )
-      edm::LogError("SiStripHotStrip")<<"[SiStripHotStripAlgorithmFromClusterOccupancy::extractBadStrips] detid already exists"<<std::endl;
+    SiStripQuality::Range range(badStripList.begin(), badStripList.end());
+    if (!OutSiStripQuality->put(detid, range))
+      edm::LogError("SiStripHotStrip")
+          << "[SiStripHotStripAlgorithmFromClusterOccupancy::extractBadStrips] detid already exists" << std::endl;
   }
   OutSiStripQuality->fillBadComponents();
 
-  if (WriteOutputFile_==true){
-  f->cd();
-  striptree->Write();
-  f->Close();
+  if (WriteOutputFile_ == true) {
+    f->cd();
+    striptree->Write();
+    f->Close();
   }
 
   LogTrace("SiStripHotStrip") << ss.str() << std::endl;
 }
 
-  
-void SiStripHotStripAlgorithmFromClusterOccupancy::iterativeSearch(pHisto& histo,std::vector<unsigned int>& vect, int apv){
-  if (!histo._NEntries || histo._NEntries <=MinNumEntries_ || histo._NEntries <= minNevents_)
+void SiStripHotStripAlgorithmFromClusterOccupancy::iterativeSearch(pHisto& histo,
+                                                                   std::vector<unsigned int>& vect,
+                                                                   int apv) {
+  if (!histo._NEntries || histo._NEntries <= MinNumEntries_ || histo._NEntries <= minNevents_)
     return;
-  
-  size_t startingSize=vect.size();
-  long double diff=1.-prob_; 
-  
-  size_t Nbins     = histo._th1f->GetNbinsX();
-  size_t ibinStart = 1; 
-  size_t ibinStop  = Nbins+1; 
-  int MaxEntry  = (int)histo._th1f->GetMaximum();
 
-  std::vector<long double> vPoissonProbs(MaxEntry+1,0);
-  long double meanVal=1.*histo._NEntries/(1.*Nbins-histo._NEmptyBins); 
-  evaluatePoissonian(vPoissonProbs,meanVal);
+  size_t startingSize = vect.size();
+  long double diff = 1. - prob_;
+
+  size_t Nbins = histo._th1f->GetNbinsX();
+  size_t ibinStart = 1;
+  size_t ibinStop = Nbins + 1;
+  int MaxEntry = (int)histo._th1f->GetMaximum();
+
+  std::vector<long double> vPoissonProbs(MaxEntry + 1, 0);
+  long double meanVal = 1. * histo._NEntries / (1. * Nbins - histo._NEmptyBins);
+  evaluatePoissonian(vPoissonProbs, meanVal);
 
   // Find median occupancy, taking into account only good strips
   unsigned int goodstripentries[128];
   int nGoodStrips = 0;
-  for (size_t i=ibinStart; i<ibinStop; ++i){
-    if (ishot[(apv*128)+i-1]==0){
+  for (size_t i = ibinStart; i < ibinStop; ++i) {
+    if (ishot[(apv * 128) + i - 1] == 0) {
       goodstripentries[nGoodStrips] = (unsigned int)histo._th1f->GetBinContent(i);
       nGoodStrips++;
     }
   }
-  double median = TMath::Median(nGoodStrips,goodstripentries);
+  double median = TMath::Median(nGoodStrips, goodstripentries);
 
-  for (size_t i=ibinStart; i<ibinStop; ++i){
-    unsigned int entries= (unsigned int)histo._th1f->GetBinContent(i);
+  for (size_t i = ibinStart; i < ibinStop; ++i) {
+    unsigned int entries = (unsigned int)histo._th1f->GetBinContent(i);
 
-    if (ishot[(apv*128)+i-1]==0){
-      stripoccupancy[(apv*128)+i-1] = entries/(double) Nevents_;
-      striphits[(apv*128)+i-1]      = entries;
-      poissonprob[(apv*128)+i-1]    = 1-vPoissonProbs[entries];
-      medianapvhits[apv]  = median;
+    if (ishot[(apv * 128) + i - 1] == 0) {
+      stripoccupancy[(apv * 128) + i - 1] = entries / (double)Nevents_;
+      striphits[(apv * 128) + i - 1] = entries;
+      poissonprob[(apv * 128) + i - 1] = 1 - vPoissonProbs[entries];
+      medianapvhits[apv] = median;
       avgapvhits[apv] = meanVal;
     }
-    if (entries<=MinNumEntriesPerStrip_ || entries <= minNevents_ || entries / median < ratio_) continue;
+    if (entries <= MinNumEntriesPerStrip_ || entries <= minNevents_ || entries / median < ratio_)
+      continue;
 
-    if(diff<vPoissonProbs[entries]){
-      ishot[(apv*128)+i-1] = 1;
+    if (diff < vPoissonProbs[entries]) {
+      ishot[(apv * 128) + i - 1] = 1;
       hotstripspermodule++;
       hotstripsperapv[apv]++;
-      histo._th1f->SetBinContent(i,0.);
-      histo._NEntries-=entries;
+      histo._th1f->SetBinContent(i, 0.);
+      histo._NEntries -= entries;
       histo._NEmptyBins++;
       if (edm::isDebugEnabled())
-	LogTrace("SiStripHotStrip")<< " rejecting strip " << (apv*128)+i-1 << " value " << entries << " diff  " << diff << " prob " << vPoissonProbs[entries]<< std::endl;
-      vect.push_back(pQuality->encode((apv*128)+i-1,1,0));
+        LogTrace("SiStripHotStrip") << " rejecting strip " << (apv * 128) + i - 1 << " value " << entries << " diff  "
+                                    << diff << " prob " << vPoissonProbs[entries] << std::endl;
+      vect.push_back(pQuality->encode((apv * 128) + i - 1, 1, 0));
     }
-
   }
   if (edm::isDebugEnabled())
-    LogTrace("SiStripHotStrip") << " [SiStripHotStripAlgorithmFromClusterOccupancy::iterativeSearch] Nbins="<< Nbins << " MaxEntry="<<MaxEntry << " meanVal=" << meanVal << " NEmptyBins="<<histo._NEmptyBins<< " NEntries=" << histo._NEntries << " thEntries " << histo._th1f->GetEntries()<< " startingSize " << startingSize << " vector.size " << vect.size() << std::endl;
+    LogTrace("SiStripHotStrip") << " [SiStripHotStripAlgorithmFromClusterOccupancy::iterativeSearch] Nbins=" << Nbins
+                                << " MaxEntry=" << MaxEntry << " meanVal=" << meanVal
+                                << " NEmptyBins=" << histo._NEmptyBins << " NEntries=" << histo._NEntries
+                                << " thEntries " << histo._th1f->GetEntries() << " startingSize " << startingSize
+                                << " vector.size " << vect.size() << std::endl;
 
-  if (vect.size()!=startingSize)
-    iterativeSearch(histo,vect,apv);
+  if (vect.size() != startingSize)
+    iterativeSearch(histo, vect, apv);
 }
 
-void SiStripHotStripAlgorithmFromClusterOccupancy::evaluatePoissonian(std::vector<long double>& vPoissonProbs, long double& meanVal){
-  for(size_t i=0;i<vPoissonProbs.size();++i){
-    vPoissonProbs[i]= (i==0)?TMath::Poisson(i,meanVal):vPoissonProbs[i-1]+TMath::Poisson(i,meanVal);
+void SiStripHotStripAlgorithmFromClusterOccupancy::evaluatePoissonian(std::vector<long double>& vPoissonProbs,
+                                                                      long double& meanVal) {
+  for (size_t i = 0; i < vPoissonProbs.size(); ++i) {
+    vPoissonProbs[i] = (i == 0) ? TMath::Poisson(i, meanVal) : vPoissonProbs[i - 1] + TMath::Poisson(i, meanVal);
   }
 }
 
-void SiStripHotStripAlgorithmFromClusterOccupancy::setNumberOfEvents(double Nevents){
-  Nevents_=Nevents;
-  minNevents_=occupancy_*Nevents_; 
-  if (edm::isDebugEnabled())                                                                                                                                                                          
-    LogTrace("SiStripHotStrip")<<" [SiStripHotStripAlgorithmFromClusterOccupancy::setNumberOfEvents] minNumber of Events per strip used to consider a strip bad" << minNevents_ << " for occupancy " << occupancy_ << std::endl;
+void SiStripHotStripAlgorithmFromClusterOccupancy::setNumberOfEvents(double Nevents) {
+  Nevents_ = Nevents;
+  minNevents_ = occupancy_ * Nevents_;
+  if (edm::isDebugEnabled())
+    LogTrace("SiStripHotStrip") << " [SiStripHotStripAlgorithmFromClusterOccupancy::setNumberOfEvents] minNumber of "
+                                   "Events per strip used to consider a strip bad"
+                                << minNevents_ << " for occupancy " << occupancy_ << std::endl;
 }

--- a/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCProducer.cc
@@ -7,7 +7,6 @@ authors:Sam Higginbotham (shigginb@cern.ch) and Chris Palmer (capalmer@cern.ch)
 
 ________________________________________________________________**/
 
-
 // C++ standard
 #include <string>
 // CMS
@@ -29,95 +28,92 @@ ________________________________________________________________**/
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include "TMath.h"
-//The class 
-class AlcaPCCProducer : public edm::one::EDProducer<edm::EndLuminosityBlockProducer,edm::one::WatchLuminosityBlocks>{
-  public:
-    explicit AlcaPCCProducer(const edm::ParameterSet&);
-    ~AlcaPCCProducer() override;
+//The class
+class AlcaPCCProducer : public edm::one::EDProducer<edm::EndLuminosityBlockProducer, edm::one::WatchLuminosityBlocks> {
+public:
+  explicit AlcaPCCProducer(const edm::ParameterSet&);
+  ~AlcaPCCProducer() override;
 
-  private:
-    void beginLuminosityBlock     (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override ;
-    void endLuminosityBlock       (edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override ;
-    void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) override ;
-    void produce                  (edm::Event& iEvent, const edm::EventSetup& iSetup) override ;
- 
-    edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> >  pixelToken;
-    edm::InputTag   fPixelClusterLabel;
+private:
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override;
+  void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-    std::string trigstring_;      //specifies the trigger Rand or ZeroBias 
-    int countEvt_;       //counter
-    int countLumi_;      //counter
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelToken;
+  edm::InputTag fPixelClusterLabel;
 
-    std::unique_ptr<reco::PixelClusterCounts> thePCCob;
+  std::string trigstring_;  //specifies the trigger Rand or ZeroBias
+  int countEvt_;            //counter
+  int countLumi_;           //counter
 
+  std::unique_ptr<reco::PixelClusterCounts> thePCCob;
 };
 
 //--------------------------------------------------------------------------------------------------
-AlcaPCCProducer::AlcaPCCProducer(const edm::ParameterSet& iConfig)
-{
-    fPixelClusterLabel = iConfig.getParameter<edm::ParameterSet>("AlcaPCCProducerParameters").getParameter<edm::InputTag>("pixelClusterLabel");
-    trigstring_ = iConfig.getParameter<edm::ParameterSet>("AlcaPCCProducerParameters").getUntrackedParameter<std::string>("trigstring","alcaPCC");
+AlcaPCCProducer::AlcaPCCProducer(const edm::ParameterSet& iConfig) {
+  fPixelClusterLabel = iConfig.getParameter<edm::ParameterSet>("AlcaPCCProducerParameters")
+                           .getParameter<edm::InputTag>("pixelClusterLabel");
+  trigstring_ = iConfig.getParameter<edm::ParameterSet>("AlcaPCCProducerParameters")
+                    .getUntrackedParameter<std::string>("trigstring", "alcaPCC");
 
-    countLumi_ = 0;
+  countLumi_ = 0;
 
-    produces<reco::PixelClusterCounts, edm::Transition::EndLuminosityBlock>(trigstring_);
-    pixelToken=consumes<edmNew::DetSetVector<SiPixelCluster> >(fPixelClusterLabel);
+  produces<reco::PixelClusterCounts, edm::Transition::EndLuminosityBlock>(trigstring_);
+  pixelToken = consumes<edmNew::DetSetVector<SiPixelCluster> >(fPixelClusterLabel);
 }
 
 //--------------------------------------------------------------------------------------------------
-AlcaPCCProducer::~AlcaPCCProducer(){
-}
+AlcaPCCProducer::~AlcaPCCProducer() {}
 
 //--------------------------------------------------------------------------------------------------
-void AlcaPCCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
-    countEvt_++;
+void AlcaPCCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  countEvt_++;
 
-    unsigned int bx=iEvent.bunchCrossing();
-    //std::cout<<"The Bunch Crossing"<<bx<<std::endl;
-    thePCCob->eventCounter(bx);
+  unsigned int bx = iEvent.bunchCrossing();
+  //std::cout<<"The Bunch Crossing"<<bx<<std::endl;
+  thePCCob->eventCounter(bx);
 
-    //Looping over the clusters and adding the counts up  
-    edm::Handle< edmNew::DetSetVector<SiPixelCluster> > hClusterColl;
-    iEvent.getByToken(pixelToken,hClusterColl);
+  //Looping over the clusters and adding the counts up
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > hClusterColl;
+  iEvent.getByToken(pixelToken, hClusterColl);
 
-    const edmNew::DetSetVector<SiPixelCluster>& clustColl = *(hClusterColl.product()); 
-    // ----------------------------------------------------------------------
-    // -- Clusters without tracks
-    for (auto const & mod: clustColl) {
-        if(mod.empty()) { continue; }
-        DetId detId = mod.id();
-
-        //--The following will be used when we make a theshold for the clusters.
-        //--Keeping this for features that may be implemented later.
-        // -- clusters on this det
-        //edmNew::DetSet<SiPixelCluster>::const_iterator  di;
-        //int nClusterCount=0;
-        //for (di = mod.begin(); di != mod.end(); ++di) {
-        //    nClusterCount++;
-        //}
-        int nCluster = mod.size();
-        thePCCob->increment(detId(), bx, nCluster);
+  const edmNew::DetSetVector<SiPixelCluster>& clustColl = *(hClusterColl.product());
+  // ----------------------------------------------------------------------
+  // -- Clusters without tracks
+  for (auto const& mod : clustColl) {
+    if (mod.empty()) {
+      continue;
     }
+    DetId detId = mod.id();
+
+    //--The following will be used when we make a theshold for the clusters.
+    //--Keeping this for features that may be implemented later.
+    // -- clusters on this det
+    //edmNew::DetSet<SiPixelCluster>::const_iterator  di;
+    //int nClusterCount=0;
+    //for (di = mod.begin(); di != mod.end(); ++di) {
+    //    nClusterCount++;
+    //}
+    int nCluster = mod.size();
+    thePCCob->increment(detId(), bx, nCluster);
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
-void AlcaPCCProducer::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup){
-    //New PCC object at the beginning of each lumi section
-    thePCCob = std::make_unique<reco::PixelClusterCounts>(); 
-    countLumi_++;
-
+void AlcaPCCProducer::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) {
+  //New PCC object at the beginning of each lumi section
+  thePCCob = std::make_unique<reco::PixelClusterCounts>();
+  countLumi_++;
 }
 
 //--------------------------------------------------------------------------------------------------
-void AlcaPCCProducer::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup){
-}
+void AlcaPCCProducer::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) {}
 
 //--------------------------------------------------------------------------------------------------
-void AlcaPCCProducer::endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup){
-
-    //Saving the PCC object
-    lumiSeg.put(std::move(thePCCob), std::string(trigstring_)); 
-
+void AlcaPCCProducer::endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) {
+  //Saving the PCC object
+  lumiSeg.put(std::move(thePCCob), std::string(trigstring_));
 }
 
 DEFINE_FWK_MODULE(AlcaPCCProducer);

--- a/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/CorrPCCProducer.cc
@@ -12,7 +12,7 @@ ________________________________________________________________**/
 #include <string>
 #include <vector>
 #include <boost/serialization/vector.hpp>
-#include <iostream> 
+#include <iostream>
 #include <map>
 #include <utility>
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
@@ -53,603 +53,610 @@ class DQMStore;
 class MonitorElement;
 
 class CorrPCCProducer : public one::DQMEDAnalyzer<edm::one::WatchLuminosityBlocks> {
-    public:
-        explicit CorrPCCProducer(const edm::ParameterSet&);
-        ~CorrPCCProducer() override;
+public:
+  explicit CorrPCCProducer(const edm::ParameterSet&);
+  ~CorrPCCProducer() override;
 
-    private:
-        void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
-        void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
-        void endRun(edm::Run const& runSeg, const edm::EventSetup& iSetup) final;
-        void endRunProduce(edm::Run& runSeg, const edm::EventSetup& iSetup) final;
-        void endJob()  final;
+private:
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) final;
+  void endRun(edm::Run const& runSeg, const edm::EventSetup& iSetup) final;
+  void endRunProduce(edm::Run& runSeg, const edm::EventSetup& iSetup) final;
+  void endJob() final;
 
-        void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
+  void makeCorrectionTemplate();
+  float getMaximum(std::vector<float>);
+  void estimateType1Frac(std::vector<float>, float&);
+  void evaluateCorrectionResiduals(std::vector<float>);
+  void calculateCorrections(std::vector<float>, std::vector<float>&, float&);
+  void resetBlock();
 
-        void makeCorrectionTemplate ();
-        float getMaximum(std::vector<float>);
-        void estimateType1Frac(std::vector<float>, float& );
-        void evaluateCorrectionResiduals(std::vector<float>); 
-        void calculateCorrections (std::vector<float>, std::vector<float>&, float&);
-        void resetBlock();
+  edm::EDGetTokenT<LumiInfo> lumiInfoToken;
+  std::string pccSrc_;    //input file EDproducer module label
+  std::string prodInst_;  //input file product instance
 
-        edm::EDGetTokenT<LumiInfo>  lumiInfoToken;
-        std::string   pccSrc_;//input file EDproducer module label 
-        std::string   prodInst_;//input file product instance 
+  std::vector<float> rawlumiBX_;         //new vector containing clusters per bxid
+  std::vector<float> errOnLumiByBX_;     //standard error per bx
+  std::vector<float> totalLumiByBX_;     //summed lumi
+  std::vector<float> totalLumiByBXAvg_;  //summed lumi
+  std::vector<float> events_;            //Number of events in each BX
+  std::vector<float> correctionTemplate_;
+  std::vector<float> correctionScaleFactors_;  //list of scale factors to apply.
+  float overallCorrection_;                    //The Overall correction to the integrated luminosity
 
-        std::vector<float> rawlumiBX_;//new vector containing clusters per bxid 
-        std::vector<float> errOnLumiByBX_;//standard error per bx
-        std::vector<float> totalLumiByBX_;//summed lumi
-        std::vector<float> totalLumiByBXAvg_;//summed lumi
-        std::vector<float> events_;//Number of events in each BX
-        std::vector<float> correctionTemplate_;
-        std::vector<float> correctionScaleFactors_;//list of scale factors to apply.
-        float overallCorrection_;//The Overall correction to the integrated luminosity
+  unsigned int iBlock = 0;
+  unsigned int minimumNumberOfEvents;
 
-        unsigned int iBlock=0;
-        unsigned int minimumNumberOfEvents;
+  std::map<unsigned int, LumiInfo*> lumiInfoMapPerLS;
+  std::vector<unsigned int> lumiSections;
+  std::map<std::pair<unsigned int, unsigned int>, LumiInfo*>::iterator lumiInfoMapIterator;
+  std::map<std::pair<unsigned int, unsigned int>, LumiInfo*>
+      lumiInfoMap;  //map to obtain iov for lumiOb corrections to the luminosity.
+  std::map<std::pair<unsigned int, unsigned int>, unsigned int> lumiInfoCounter;  // number of lumiSections in this block
 
-        std::map<unsigned int, LumiInfo*> lumiInfoMapPerLS;
-        std::vector<unsigned int> lumiSections;
-        std::map<std::pair<unsigned int,unsigned int>, LumiInfo*>::iterator lumiInfoMapIterator; 
-        std::map<std::pair<unsigned int,unsigned int>, LumiInfo*> lumiInfoMap;//map to obtain iov for lumiOb corrections to the luminosity. 
-        std::map<std::pair<unsigned int,unsigned int>, unsigned int> lumiInfoCounter; // number of lumiSections in this block
+  TH1F* corrlumiAvg_h;
+  TH1F* scaleFactorAvg_h;
+  TH1F* lumiAvg_h;
+  TH1F* type1FracHist;
+  TH1F* type1resHist;
+  TH1F* type2resHist;
 
-        TH1F *corrlumiAvg_h;
-        TH1F *scaleFactorAvg_h;
-        TH1F *lumiAvg_h;
-        TH1F *type1FracHist;
-        TH1F *type1resHist;
-        TH1F *type2resHist;
+  unsigned int maxLS = 3500;
+  MonitorElement* Type1FracMon;
+  MonitorElement* Type1ResMon;
+  MonitorElement* Type2ResMon;
 
-        unsigned int maxLS=3500;
-        MonitorElement* Type1FracMon;
-        MonitorElement* Type1ResMon;
-        MonitorElement* Type2ResMon;
+  TGraphErrors* type1FracGraph;
+  TGraphErrors* type1resGraph;
+  TGraphErrors* type2resGraph;
+  TList* hlist;  //list for the clusters and corrections
+  TFile* histoFile;
 
-        TGraphErrors *type1FracGraph;
-        TGraphErrors *type1resGraph;
-        TGraphErrors *type2resGraph;
-        TList *hlist;//list for the clusters and corrections 
-        TFile * histoFile;
+  float type1Frac;
+  float mean_type1_residual;          //Type 1 residual
+  float mean_type2_residual;          //Type 2 residual
+  float mean_type1_residual_unc;      //Type 1 residual uncertainty rms
+  float mean_type2_residual_unc;      //Type 2 residual uncertainty rms
+  unsigned int nTrain;                //Number of bunch trains used in calc type 1 and 2 res, frac.
+  unsigned int countLumi_;            //The lumisection count... the size of the lumiblock
+  unsigned int approxLumiBlockSize_;  //The number of lumisections per block.
+  unsigned int thisLS;                //Ending lumisection for the iov that we save with the lumiInfo object.
 
-        float type1Frac;
-        float mean_type1_residual;//Type 1 residual 
-        float mean_type2_residual;//Type 2 residual 
-        float mean_type1_residual_unc;//Type 1 residual uncertainty rms 
-        float mean_type2_residual_unc;//Type 2 residual uncertainty rms 
-        unsigned int nTrain;//Number of bunch trains used in calc type 1 and 2 res, frac.
-        unsigned int countLumi_;//The lumisection count... the size of the lumiblock
-        unsigned int approxLumiBlockSize_;//The number of lumisections per block.
-        unsigned int thisLS;//Ending lumisection for the iov that we save with the lumiInfo object.
+  double type2_a_;  //amplitude for the type 2 correction
+  double type2_b_;  //decay width for the type 2 correction
 
-        double type2_a_;//amplitude for the type 2 correction 
-        double type2_b_;//decay width for the type 2 correction
+  LumiCorrections* pccCorrections;
 
-
-        LumiCorrections* pccCorrections;
-
-        edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
 };
 
 //--------------------------------------------------------------------------------------------------
-CorrPCCProducer::CorrPCCProducer(const edm::ParameterSet& iConfig)
-{
-    pccSrc_ = iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<std::string>("inLumiObLabel");
-    prodInst_ = iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<std::string>("ProdInst");
-    approxLumiBlockSize_=iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<int>("approxLumiBlockSize");
-    type2_a_ = iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<double>("type2_a");
-    type2_b_ = iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<double>("type2_b");
-    countLumi_=0;
-    minimumNumberOfEvents=1000;
+CorrPCCProducer::CorrPCCProducer(const edm::ParameterSet& iConfig) {
+  pccSrc_ =
+      iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<std::string>("inLumiObLabel");
+  prodInst_ =
+      iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<std::string>("ProdInst");
+  approxLumiBlockSize_ =
+      iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<int>("approxLumiBlockSize");
+  type2_a_ = iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<double>("type2_a");
+  type2_b_ = iConfig.getParameter<edm::ParameterSet>("CorrPCCProducerParameters").getParameter<double>("type2_b");
+  countLumi_ = 0;
+  minimumNumberOfEvents = 1000;
 
-    totalLumiByBX_.resize(LumiConstants::numBX);
-    totalLumiByBXAvg_.resize(LumiConstants::numBX);
-    events_.resize(LumiConstants::numBX);
-    correctionScaleFactors_.resize(LumiConstants::numBX);
-    correctionTemplate_.resize(LumiConstants::numBX);
+  totalLumiByBX_.resize(LumiConstants::numBX);
+  totalLumiByBXAvg_.resize(LumiConstants::numBX);
+  events_.resize(LumiConstants::numBX);
+  correctionScaleFactors_.resize(LumiConstants::numBX);
+  correctionTemplate_.resize(LumiConstants::numBX);
 
-    resetBlock();
+  resetBlock();
 
-    makeCorrectionTemplate(); 
+  makeCorrectionTemplate();
 
-    edm::InputTag inputPCCTag_(pccSrc_, prodInst_);
+  edm::InputTag inputPCCTag_(pccSrc_, prodInst_);
 
-    lumiInfoToken=consumes<LumiInfo, edm::InLumi>(inputPCCTag_);
+  lumiInfoToken = consumes<LumiInfo, edm::InLumi>(inputPCCTag_);
 
-    histoFile = new TFile("CorrectionHisto.root","RECREATE");
+  histoFile = new TFile("CorrectionHisto.root", "RECREATE");
 
-    type1FracGraph= new TGraphErrors();
-    type1resGraph = new TGraphErrors();
-    type2resGraph = new TGraphErrors();
-    type1FracGraph->SetName("Type1Fraction");
-    type1resGraph->SetName("Type1Res");
-    type2resGraph->SetName("Type2Res");
-    type1FracGraph->GetYaxis()->SetTitle("Type 1 Fraction");
-    type1resGraph->GetYaxis()->SetTitle("Type 1 Residual");
-    type2resGraph->GetYaxis()->SetTitle("Type 2 Residual");
-    type1FracGraph->GetXaxis()->SetTitle("Unique LS ID");
-    type1resGraph->GetXaxis()->SetTitle("Unique LS ID");
-    type2resGraph->GetXaxis()->SetTitle("Unique LS ID");
-    type1FracGraph->SetMarkerStyle(8);
-    type1resGraph->SetMarkerStyle(8);
-    type2resGraph->SetMarkerStyle(8);
+  type1FracGraph = new TGraphErrors();
+  type1resGraph = new TGraphErrors();
+  type2resGraph = new TGraphErrors();
+  type1FracGraph->SetName("Type1Fraction");
+  type1resGraph->SetName("Type1Res");
+  type2resGraph->SetName("Type2Res");
+  type1FracGraph->GetYaxis()->SetTitle("Type 1 Fraction");
+  type1resGraph->GetYaxis()->SetTitle("Type 1 Residual");
+  type2resGraph->GetYaxis()->SetTitle("Type 2 Residual");
+  type1FracGraph->GetXaxis()->SetTitle("Unique LS ID");
+  type1resGraph->GetXaxis()->SetTitle("Unique LS ID");
+  type2resGraph->GetXaxis()->SetTitle("Unique LS ID");
+  type1FracGraph->SetMarkerStyle(8);
+  type1resGraph->SetMarkerStyle(8);
+  type2resGraph->SetMarkerStyle(8);
 }
 
 //--------------------------------------------------------------------------------------------------
-CorrPCCProducer::~CorrPCCProducer(){
-}
+CorrPCCProducer::~CorrPCCProducer() {}
 
 //--------------------------------------------------------------------------------------------------
 // This method builds the single bunch response given an exponential function (type 2 only)
-void  CorrPCCProducer::makeCorrectionTemplate(){
-    for(unsigned int bx=1;bx<LumiConstants::numBX;bx++){
-        correctionTemplate_.at(bx)=type2_a_*exp(-(float(bx)-1)*type2_b_);
-    }
+void CorrPCCProducer::makeCorrectionTemplate() {
+  for (unsigned int bx = 1; bx < LumiConstants::numBX; bx++) {
+    correctionTemplate_.at(bx) = type2_a_ * exp(-(float(bx) - 1) * type2_b_);
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
 // Finds max lumi value
-float CorrPCCProducer::getMaximum(std::vector<float> lumi_vector){
-    float max_lumi=0;
-    for(size_t i=0; i<lumi_vector.size(); i++){
-        if(lumi_vector.at(i)>max_lumi)  max_lumi = lumi_vector.at(i);
-    }   
-    return max_lumi;
+float CorrPCCProducer::getMaximum(std::vector<float> lumi_vector) {
+  float max_lumi = 0;
+  for (size_t i = 0; i < lumi_vector.size(); i++) {
+    if (lumi_vector.at(i) > max_lumi)
+      max_lumi = lumi_vector.at(i);
+  }
+  return max_lumi;
 }
 
-
-
 //--------------------------------------------------------------------------------------------------
-// This method takes luminosity from the last bunch in a train and makes a comparison with 
+// This method takes luminosity from the last bunch in a train and makes a comparison with
 // the follow non-active bunch crossing to estimate the spill over fraction (type 1 afterglow).
-void CorrPCCProducer::estimateType1Frac(std::vector<float> uncorrPCCPerBX, float &type1Frac){
-    std::vector<float> corrected_tmp_; 
-    for(size_t i=0; i<uncorrPCCPerBX.size(); i++){
-        corrected_tmp_.push_back(uncorrPCCPerBX.at(i));
+void CorrPCCProducer::estimateType1Frac(std::vector<float> uncorrPCCPerBX, float& type1Frac) {
+  std::vector<float> corrected_tmp_;
+  for (size_t i = 0; i < uncorrPCCPerBX.size(); i++) {
+    corrected_tmp_.push_back(uncorrPCCPerBX.at(i));
+  }
+
+  //Apply initial type 1 correction
+  for (size_t k = 0; k < LumiConstants::numBX - 1; k++) {
+    float bin_k = corrected_tmp_.at(k);
+    corrected_tmp_.at(k + 1) = corrected_tmp_.at(k + 1) - type1Frac * bin_k;
+  }
+
+  //Apply type 2 correction
+  for (size_t i = 0; i < LumiConstants::numBX - 1; i++) {
+    for (size_t j = i + 1; j < i + LumiConstants::numBX - 1; j++) {
+      float bin_i = corrected_tmp_.at(i);
+      if (j < LumiConstants::numBX) {
+        corrected_tmp_.at(j) = corrected_tmp_.at(j) - bin_i * correctionTemplate_.at(j - i);
+      } else {
+        corrected_tmp_.at(j - LumiConstants::numBX) =
+            corrected_tmp_.at(j - LumiConstants::numBX) - bin_i * correctionTemplate_.at(j - i);
+      }
     }
+  }
 
-
-    //Apply initial type 1 correction
-    for(size_t k=0;k<LumiConstants::numBX-1; k++){ 
-        float bin_k = corrected_tmp_.at(k);
-        corrected_tmp_.at(k+1)=corrected_tmp_.at(k+1)-type1Frac*bin_k; 
-    }
-
-
-    //Apply type 2 correction
-    for(size_t i=0; i<LumiConstants::numBX-1; i++){
-        for(size_t j=i+1; j<i+LumiConstants::numBX-1; j++){
-            float bin_i = corrected_tmp_.at(i);
-            if (j<LumiConstants::numBX){
-                corrected_tmp_.at(j)=corrected_tmp_.at(j)-bin_i*correctionTemplate_.at(j-i);
-            } else {
-                corrected_tmp_.at(j-LumiConstants::numBX) = corrected_tmp_.at(j-LumiConstants::numBX)-bin_i*correctionTemplate_.at(j-i);
-            }
-        }
-    }
-
-    //Apply additional iteration for type 1 correction
-    evaluateCorrectionResiduals(corrected_tmp_); 
-    type1Frac+=mean_type1_residual;
-}
-
-
-//--------------------------------------------------------------------------------------------------
-void CorrPCCProducer::evaluateCorrectionResiduals(std::vector<float> corrected_tmp_){
-    float lumiMax = getMaximum(corrected_tmp_);
-    float threshold = lumiMax*0.2; 
-
-    mean_type1_residual = 0;  
-    mean_type2_residual = 0;  
-    nTrain = 0;
-    float lumi=0;
-    std::vector<float> afterGlow;
-    TH1F type1("type1","",1000,-0.5,0.5);
-    TH1F type2("type2","",1000,-0.5,0.5);
-    for(size_t ibx=2; ibx<LumiConstants::numBX-5; ibx++){
-        lumi   = corrected_tmp_.at(ibx);
-        afterGlow.clear();
-        afterGlow.push_back(corrected_tmp_.at(ibx+1));
-        afterGlow.push_back(corrected_tmp_.at(ibx+2));
-
-        //Where type 1 and type 2 residuals are computed
-        if(lumi>threshold && afterGlow[0]<threshold && afterGlow[1]<threshold){
-            for(int index=3; index<6; index++){
-                float thisAfterGlow=corrected_tmp_.at(ibx+index);
-                if(thisAfterGlow<threshold){
-                    afterGlow.push_back(thisAfterGlow);
-                } else {
-                    break;
-                }
-            }
-            float thisType1=0;
-            float thisType2=0;
-            if(afterGlow.size()>1){
-                int nAfter=0;
-                for(unsigned int index=1; index<afterGlow.size(); index++){
-                    thisType2+=afterGlow[index];
-                    type2.Fill(afterGlow[index]/lumi);
-                    nAfter++;
-                }
-                thisType2/=nAfter;
-            }
-            thisType1=(afterGlow[0]-thisType2)/lumi;
-
-            type1.Fill(thisType1);
-            nTrain+=1;
-        }
-    } 
-
-    mean_type1_residual=type1.GetMean();//Calculate the mean value of the type 1 residual 
-    mean_type2_residual=type2.GetMean();//Calculate the mean value of the type 2 residual 
-    mean_type1_residual_unc=type1.GetMeanError();
-    mean_type2_residual_unc=type2.GetMeanError();
-
-    histoFile->cd();
-    type1.Write();
-    type2.Write();
-}
-
-
-//--------------------------------------------------------------------------------------------------
-void CorrPCCProducer::calculateCorrections (std::vector<float> uncorrected, std::vector<float>& correctionScaleFactors_, float& overallCorrection_){
-    type1Frac = 0;
-
-    int nTrials=4;
-
-    for(int trial=0;trial<nTrials;trial++){
-        estimateType1Frac(uncorrected, type1Frac);
-        edm::LogInfo("INFO") <<"type 1 fraction after iteration "<<trial<<" is  "<<type1Frac;
-    }
-
-    //correction should never be negative
-    type1Frac=std::max(0.0,(double)type1Frac); 
-
-    std::vector<float> corrected_tmp_;
-    for(size_t i=0; i<uncorrected.size(); i++){
-        corrected_tmp_.push_back(uncorrected.at(i));
-    }
-
-
-    //Apply all corrections
-    for(size_t i=0; i<LumiConstants::numBX-1; i++){
-        // type 1 - first (spillover from previous BXs real clusters)
-        float bin_i = corrected_tmp_.at(i);
-        corrected_tmp_.at(i+1)=corrected_tmp_.at(i+1)-type1Frac*bin_i;
-
-        // type 2 - after (comes from real activation)
-        bin_i = corrected_tmp_.at(i);
-        for(size_t j=i+1; j<i+LumiConstants::numBX-1; j++){
-            if(j<LumiConstants::numBX){
-                corrected_tmp_.at(j)=corrected_tmp_.at(j)-bin_i*correctionTemplate_.at(j-i);
-            }else{
-                corrected_tmp_.at(j-LumiConstants::numBX) = corrected_tmp_.at(j-LumiConstants::numBX)-bin_i*correctionTemplate_.at(j-i);
-            }
-        }
-    }
-
-    evaluateCorrectionResiduals(corrected_tmp_);
-
-    float integral_uncorr_clusters=0;
-    float integral_corr_clusters = 0;
-
-    //Calculate Per-BX correction factor and overall correction factor
-    float lumiMax = getMaximum(corrected_tmp_);
-    float threshold = lumiMax*0.2;
-    for (size_t ibx=0; ibx<corrected_tmp_.size(); ibx++){
-        if(corrected_tmp_.at(ibx)>threshold){
-            integral_uncorr_clusters+=uncorrected.at(ibx);
-            integral_corr_clusters+=corrected_tmp_.at(ibx);
-        }
-        if(corrected_tmp_.at(ibx)!=0.0&&uncorrected.at(ibx)!=0.0){ 
-            correctionScaleFactors_.at(ibx) = corrected_tmp_.at(ibx)/uncorrected.at(ibx);
-        }else{
-            correctionScaleFactors_.at(ibx) = 0.0;
-        }
-    }
-
-    overallCorrection_ = integral_corr_clusters/integral_uncorr_clusters;  
+  //Apply additional iteration for type 1 correction
+  evaluateCorrectionResiduals(corrected_tmp_);
+  type1Frac += mean_type1_residual;
 }
 
 //--------------------------------------------------------------------------------------------------
-void CorrPCCProducer::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup){
-    countLumi_++;
-}
+void CorrPCCProducer::evaluateCorrectionResiduals(std::vector<float> corrected_tmp_) {
+  float lumiMax = getMaximum(corrected_tmp_);
+  float threshold = lumiMax * 0.2;
 
+  mean_type1_residual = 0;
+  mean_type2_residual = 0;
+  nTrain = 0;
+  float lumi = 0;
+  std::vector<float> afterGlow;
+  TH1F type1("type1", "", 1000, -0.5, 0.5);
+  TH1F type2("type2", "", 1000, -0.5, 0.5);
+  for (size_t ibx = 2; ibx < LumiConstants::numBX - 5; ibx++) {
+    lumi = corrected_tmp_.at(ibx);
+    afterGlow.clear();
+    afterGlow.push_back(corrected_tmp_.at(ibx + 1));
+    afterGlow.push_back(corrected_tmp_.at(ibx + 2));
 
-//--------------------------------------------------------------------------------------------------
-void CorrPCCProducer::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup){
-
-    thisLS = lumiSeg.luminosityBlock();
-
-    edm::Handle<LumiInfo> PCCHandle; 
-    lumiSeg.getByToken(lumiInfoToken,PCCHandle);
-
-    const LumiInfo& inLumiOb = *(PCCHandle.product()); 
-
-    errOnLumiByBX_= inLumiOb.getErrorLumiAllBX();
-
-    unsigned int totalEvents=0;
-    for(unsigned int bx=0;bx<LumiConstants::numBX;bx++){
-        totalEvents+=errOnLumiByBX_[bx];
-    }
-
-    if(totalEvents<minimumNumberOfEvents){
-        edm::LogInfo("INFO") <<"number of events in this LS is too few "<<totalEvents;
-        //return;
-    }
-    else{
-         
-        edm::LogInfo("INFO") <<"Skipping Lumisection "<<thisLS;
-    }
-
-    lumiInfoMapPerLS[thisLS] = new LumiInfo();
-    totalLumiByBX_=inLumiOb.getInstLumiAllBX();
-    events_=inLumiOb.getErrorLumiAllBX();
-    lumiInfoMapPerLS[thisLS]->setInstLumiAllBX(totalLumiByBX_);
-    lumiInfoMapPerLS[thisLS]->setErrorLumiAllBX(events_);
-    lumiSections.push_back(thisLS);
-}
-
-//--------------------------------------------------------------------------------------------------
-void CorrPCCProducer::endRun(edm::Run const& runSeg, const edm::EventSetup& iSetup){
-}
-
-//--------------------------------------------------------------------------------------------------
-void CorrPCCProducer::endRunProduce(edm::Run& runSeg, const edm::EventSetup& iSetup){
-    if(lumiSections.empty()){
-        return;
-    }
-
-    std::sort (lumiSections.begin(), lumiSections.end());
-
-    edm::LogInfo("INFO") <<"Number of Lumisections "<<lumiSections.size()<<" in run "<<runSeg.run() ;
-
-    //Determining integer number of blocks
-    float nBlocks_f = float(lumiSections.size())/approxLumiBlockSize_;
-    unsigned int nBlocks=1;
-    if(nBlocks_f>1){
-        if(nBlocks_f - lumiSections.size()/approxLumiBlockSize_ < 0.5){
-            nBlocks=lumiSections.size()/approxLumiBlockSize_;
+    //Where type 1 and type 2 residuals are computed
+    if (lumi > threshold && afterGlow[0] < threshold && afterGlow[1] < threshold) {
+      for (int index = 3; index < 6; index++) {
+        float thisAfterGlow = corrected_tmp_.at(ibx + index);
+        if (thisAfterGlow < threshold) {
+          afterGlow.push_back(thisAfterGlow);
         } else {
-            nBlocks=lumiSections.size()/approxLumiBlockSize_+1;
+          break;
         }
+      }
+      float thisType1 = 0;
+      float thisType2 = 0;
+      if (afterGlow.size() > 1) {
+        int nAfter = 0;
+        for (unsigned int index = 1; index < afterGlow.size(); index++) {
+          thisType2 += afterGlow[index];
+          type2.Fill(afterGlow[index] / lumi);
+          nAfter++;
+        }
+        thisType2 /= nAfter;
+      }
+      thisType1 = (afterGlow[0] - thisType2) / lumi;
+
+      type1.Fill(thisType1);
+      nTrain += 1;
+    }
+  }
+
+  mean_type1_residual = type1.GetMean();  //Calculate the mean value of the type 1 residual
+  mean_type2_residual = type2.GetMean();  //Calculate the mean value of the type 2 residual
+  mean_type1_residual_unc = type1.GetMeanError();
+  mean_type2_residual_unc = type2.GetMeanError();
+
+  histoFile->cd();
+  type1.Write();
+  type2.Write();
+}
+
+//--------------------------------------------------------------------------------------------------
+void CorrPCCProducer::calculateCorrections(std::vector<float> uncorrected,
+                                           std::vector<float>& correctionScaleFactors_,
+                                           float& overallCorrection_) {
+  type1Frac = 0;
+
+  int nTrials = 4;
+
+  for (int trial = 0; trial < nTrials; trial++) {
+    estimateType1Frac(uncorrected, type1Frac);
+    edm::LogInfo("INFO") << "type 1 fraction after iteration " << trial << " is  " << type1Frac;
+  }
+
+  //correction should never be negative
+  type1Frac = std::max(0.0, (double)type1Frac);
+
+  std::vector<float> corrected_tmp_;
+  for (size_t i = 0; i < uncorrected.size(); i++) {
+    corrected_tmp_.push_back(uncorrected.at(i));
+  }
+
+  //Apply all corrections
+  for (size_t i = 0; i < LumiConstants::numBX - 1; i++) {
+    // type 1 - first (spillover from previous BXs real clusters)
+    float bin_i = corrected_tmp_.at(i);
+    corrected_tmp_.at(i + 1) = corrected_tmp_.at(i + 1) - type1Frac * bin_i;
+
+    // type 2 - after (comes from real activation)
+    bin_i = corrected_tmp_.at(i);
+    for (size_t j = i + 1; j < i + LumiConstants::numBX - 1; j++) {
+      if (j < LumiConstants::numBX) {
+        corrected_tmp_.at(j) = corrected_tmp_.at(j) - bin_i * correctionTemplate_.at(j - i);
+      } else {
+        corrected_tmp_.at(j - LumiConstants::numBX) =
+            corrected_tmp_.at(j - LumiConstants::numBX) - bin_i * correctionTemplate_.at(j - i);
+      }
+    }
+  }
+
+  evaluateCorrectionResiduals(corrected_tmp_);
+
+  float integral_uncorr_clusters = 0;
+  float integral_corr_clusters = 0;
+
+  //Calculate Per-BX correction factor and overall correction factor
+  float lumiMax = getMaximum(corrected_tmp_);
+  float threshold = lumiMax * 0.2;
+  for (size_t ibx = 0; ibx < corrected_tmp_.size(); ibx++) {
+    if (corrected_tmp_.at(ibx) > threshold) {
+      integral_uncorr_clusters += uncorrected.at(ibx);
+      integral_corr_clusters += corrected_tmp_.at(ibx);
+    }
+    if (corrected_tmp_.at(ibx) != 0.0 && uncorrected.at(ibx) != 0.0) {
+      correctionScaleFactors_.at(ibx) = corrected_tmp_.at(ibx) / uncorrected.at(ibx);
+    } else {
+      correctionScaleFactors_.at(ibx) = 0.0;
+    }
+  }
+
+  overallCorrection_ = integral_corr_clusters / integral_uncorr_clusters;
+}
+
+//--------------------------------------------------------------------------------------------------
+void CorrPCCProducer::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) {
+  countLumi_++;
+}
+
+//--------------------------------------------------------------------------------------------------
+void CorrPCCProducer::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) {
+  thisLS = lumiSeg.luminosityBlock();
+
+  edm::Handle<LumiInfo> PCCHandle;
+  lumiSeg.getByToken(lumiInfoToken, PCCHandle);
+
+  const LumiInfo& inLumiOb = *(PCCHandle.product());
+
+  errOnLumiByBX_ = inLumiOb.getErrorLumiAllBX();
+
+  unsigned int totalEvents = 0;
+  for (unsigned int bx = 0; bx < LumiConstants::numBX; bx++) {
+    totalEvents += errOnLumiByBX_[bx];
+  }
+
+  if (totalEvents < minimumNumberOfEvents) {
+    edm::LogInfo("INFO") << "number of events in this LS is too few " << totalEvents;
+    //return;
+  } else {
+    edm::LogInfo("INFO") << "Skipping Lumisection " << thisLS;
+  }
+
+  lumiInfoMapPerLS[thisLS] = new LumiInfo();
+  totalLumiByBX_ = inLumiOb.getInstLumiAllBX();
+  events_ = inLumiOb.getErrorLumiAllBX();
+  lumiInfoMapPerLS[thisLS]->setInstLumiAllBX(totalLumiByBX_);
+  lumiInfoMapPerLS[thisLS]->setErrorLumiAllBX(events_);
+  lumiSections.push_back(thisLS);
+}
+
+//--------------------------------------------------------------------------------------------------
+void CorrPCCProducer::endRun(edm::Run const& runSeg, const edm::EventSetup& iSetup) {}
+
+//--------------------------------------------------------------------------------------------------
+void CorrPCCProducer::endRunProduce(edm::Run& runSeg, const edm::EventSetup& iSetup) {
+  if (lumiSections.empty()) {
+    return;
+  }
+
+  std::sort(lumiSections.begin(), lumiSections.end());
+
+  edm::LogInfo("INFO") << "Number of Lumisections " << lumiSections.size() << " in run " << runSeg.run();
+
+  //Determining integer number of blocks
+  float nBlocks_f = float(lumiSections.size()) / approxLumiBlockSize_;
+  unsigned int nBlocks = 1;
+  if (nBlocks_f > 1) {
+    if (nBlocks_f - lumiSections.size() / approxLumiBlockSize_ < 0.5) {
+      nBlocks = lumiSections.size() / approxLumiBlockSize_;
+    } else {
+      nBlocks = lumiSections.size() / approxLumiBlockSize_ + 1;
+    }
+  }
+
+  float nLSPerBlock = float(lumiSections.size()) / nBlocks;
+
+  std::vector<std::pair<unsigned int, unsigned int>> lsKeys;
+  lsKeys.clear();
+
+  //Constructing nBlocks IOVs
+  for (unsigned iKey = 0; iKey < nBlocks; iKey++) {
+    lsKeys.push_back(std::make_pair(lumiSections[(unsigned int)(iKey * nLSPerBlock)],
+                                    lumiSections[(unsigned int)((iKey + 1) * nLSPerBlock) - 1]));
+  }
+
+  lsKeys[0].first = 1;
+
+  for (unsigned int lumiSection = 0; lumiSection < lumiSections.size(); lumiSection++) {
+    thisLS = lumiSections[lumiSection];
+
+    std::pair<unsigned int, unsigned int> lsKey;
+
+    bool foundKey = false;
+
+    for (unsigned iKey = 0; iKey < nBlocks; iKey++) {
+      if ((thisLS >= lsKeys[iKey].first) && (thisLS <= lsKeys[iKey].second)) {
+        lsKey = lsKeys[iKey];
+        foundKey = true;
+        break;
+      }
     }
 
-    float nLSPerBlock = float(lumiSections.size())/nBlocks;
-
-    std::vector<std::pair<unsigned int, unsigned int>> lsKeys;
-    lsKeys.clear();
-
-    //Constructing nBlocks IOVs 
-    for(unsigned iKey=0; iKey<nBlocks; iKey++){
-        lsKeys.push_back(std::make_pair(lumiSections[(unsigned int)(iKey*nLSPerBlock)], lumiSections[(unsigned int)((iKey+1)*nLSPerBlock)-1]));
-    }
-    
-    lsKeys[0].first=1;
-
-    for(unsigned int lumiSection=0; lumiSection<lumiSections.size(); lumiSection++){
-        thisLS=lumiSections[lumiSection];
-
-        std::pair<unsigned int,unsigned int> lsKey;
-
-        bool foundKey=false;
-
-        for(unsigned iKey=0; iKey<nBlocks; iKey++){
-            if( (thisLS >= lsKeys[iKey].first) && (thisLS<= lsKeys[iKey].second) ){
-                lsKey=lsKeys[iKey];
-                foundKey=true;
-                break;
-            }
-        }
-
-        if(!foundKey){
-            edm::LogInfo("WARNING")<<"Didn't find key "<<thisLS;
-            continue;
-        }
-
-        if(lumiInfoMap.count( lsKey ) == 0 ) {
-            lumiInfoMap[lsKey] = new LumiInfo();
-        }
-
-        //Sum all lumi in IOV of lsKey 
-        totalLumiByBX_=lumiInfoMap[lsKey]->getInstLumiAllBX();
-        events_       =lumiInfoMap[lsKey]->getErrorLumiAllBX();
-
-        rawlumiBX_    =lumiInfoMapPerLS[thisLS]->getInstLumiAllBX();
-        errOnLumiByBX_=lumiInfoMapPerLS[thisLS]->getErrorLumiAllBX();
-
-        for(unsigned int bx=0;bx<LumiConstants::numBX;bx++){
-            totalLumiByBX_[bx]+=rawlumiBX_[bx];
-            events_[bx]+=errOnLumiByBX_[bx];
-        }
-        lumiInfoMap[lsKey]->setInstLumiAllBX(totalLumiByBX_);
-        lumiInfoMap[lsKey]->setErrorLumiAllBX(events_);
-        lumiInfoCounter[lsKey]++;
+    if (!foundKey) {
+      edm::LogInfo("WARNING") << "Didn't find key " << thisLS;
+      continue;
     }
 
-
-    cond::Time_t thisIOV = 1;
-
-    char *histname1 = new char[100];
-    char *histname2 = new char[100];
-    char *histname3 = new char[100];
-    char *histTitle1 = new char[100];
-    char *histTitle2 = new char[100];
-    char *histTitle3 = new char[100];
-    sprintf(histTitle1,"Type1Fraction_%d",runSeg.run());
-    sprintf(histTitle2,"Type1Res_%d",runSeg.run());
-    sprintf(histTitle3,"Type2Res_%d",runSeg.run());
-    type1FracHist = new TH1F(histTitle1,histTitle1,1000,-0.5,0.5);
-    type1resHist  = new TH1F(histTitle2,histTitle2,4000,-0.2,0.2);
-    type2resHist  = new TH1F(histTitle3,histTitle3,4000,-0.2,0.2);
-    delete[] histTitle1;
-    delete[] histTitle2;
-    delete[] histTitle3;
-
-    for(lumiInfoMapIterator=lumiInfoMap.begin(); (lumiInfoMapIterator!=lumiInfoMap.end()); ++lumiInfoMapIterator) {
-
-        totalLumiByBX_=lumiInfoMapIterator->second->getInstLumiAllBX();
-        events_=lumiInfoMapIterator->second->getErrorLumiAllBX();
-
-        if(events_.empty()){
-            continue;
-        }
-
-        edm::LuminosityBlockID lu(runSeg.id().run(),edm::LuminosityBlockNumber_t (lumiInfoMapIterator->first.first));
-        thisIOV = (cond::Time_t)(lu.value()); 
-
-        sprintf(histname1, "CorrectedLumiAvg_%d_%d_%d_%d",runSeg.run(),iBlock,lumiInfoMapIterator->first.first,lumiInfoMapIterator->first.second);
-        sprintf(histname2, "ScaleFactorsAvg_%d_%d_%d_%d",runSeg.run(),iBlock,lumiInfoMapIterator->first.first,lumiInfoMapIterator->first.second);
-        sprintf(histname3, "RawLumiAvg_%d_%d_%d_%d",runSeg.run(),iBlock,lumiInfoMapIterator->first.first,lumiInfoMapIterator->first.second);
-
-        corrlumiAvg_h   = new TH1F(histname1,"",LumiConstants::numBX,1,LumiConstants::numBX);
-        scaleFactorAvg_h= new TH1F(histname2,"",LumiConstants::numBX,1,LumiConstants::numBX);
-        lumiAvg_h       = new TH1F(histname3,"",LumiConstants::numBX,1,LumiConstants::numBX); 
-
-
-        //Averaging by the number of events
-        for(unsigned int i=0;i<LumiConstants::numBX;i++){
-            if(events_.at(i)!=0){
-                totalLumiByBXAvg_[i] =  totalLumiByBX_[i]/events_[i];
-            }else{
-                totalLumiByBXAvg_[i]=0.0;
-            }
-        }
-
-        calculateCorrections(totalLumiByBXAvg_,correctionScaleFactors_, overallCorrection_); 
-
-        for(unsigned int bx=0;bx<LumiConstants::numBX;bx++){
-            corrlumiAvg_h->SetBinContent(bx,totalLumiByBXAvg_[bx]*correctionScaleFactors_[bx]);
-            if(events_.at(bx)!=0){
-                corrlumiAvg_h->SetBinError(bx,totalLumiByBXAvg_[bx]*correctionScaleFactors_[bx]/TMath::Sqrt(events_.at(bx)));
-            }else{
-                corrlumiAvg_h->SetBinError(bx,0.0);
-            }
-
-            scaleFactorAvg_h->SetBinContent(bx,correctionScaleFactors_[bx]);
-            lumiAvg_h->SetBinContent(bx,totalLumiByBXAvg_[bx]);
-        }
-
-        //Writing the corrections to SQL lite file for db 
-        pccCorrections = new LumiCorrections();
-        pccCorrections->setOverallCorrection(overallCorrection_);
-        pccCorrections->setType1Fraction(type1Frac);
-        pccCorrections->setType1Residual(mean_type1_residual);
-        pccCorrections->setType2Residual(mean_type2_residual);
-        pccCorrections->setCorrectionsBX(correctionScaleFactors_);
-        
-
-        if( poolDbService.isAvailable() ){ 
-            poolDbService->writeOne<LumiCorrections>(pccCorrections,thisIOV,"LumiCorrectionsRcd"); 
-        }
-        else{
-            throw std::runtime_error("PoolDBService required.");
-        }
-
-        delete pccCorrections;
-
-        histoFile->cd();
-        corrlumiAvg_h->Write();
-        scaleFactorAvg_h->Write();
-        lumiAvg_h->Write();
-
-        delete corrlumiAvg_h;
-        delete scaleFactorAvg_h;
-        delete lumiAvg_h;
-
-        type1FracHist->Fill(type1Frac);
-        type1resHist->Fill(mean_type1_residual);
-        type2resHist->Fill(mean_type2_residual);
-
-        for(unsigned int ils=lumiInfoMapIterator->first.first;ils<lumiInfoMapIterator->first.second+1;ils++){
-            if(ils>maxLS){
-            std::cout<<"ils out of maxLS range!!"<<std::endl;
-            break;
-            } 
-            Type1FracMon->setBinContent(ils,type1Frac);
-            Type1FracMon->setBinError(ils,mean_type1_residual_unc);
-            Type1ResMon->setBinContent(ils,mean_type1_residual);
-            Type1ResMon->setBinError(ils,mean_type1_residual_unc);
-            Type2ResMon->setBinContent(ils,mean_type2_residual);
-            Type2ResMon->setBinError(ils,mean_type2_residual_unc);
-        }
-
-
-        type1FracGraph->SetPoint(iBlock,thisIOV+approxLumiBlockSize_/2.0,type1Frac);
-        type1resGraph->SetPoint(iBlock,thisIOV+approxLumiBlockSize_/2.0,mean_type1_residual);
-        type2resGraph->SetPoint(iBlock,thisIOV+approxLumiBlockSize_/2.0,mean_type2_residual);
-        type1FracGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0,mean_type1_residual_unc);
-        type1resGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0, mean_type1_residual_unc);
-        type2resGraph->SetPointError(iBlock,approxLumiBlockSize_/2.0, mean_type2_residual_unc);
-
-        edm::LogInfo("INFO") <<"iBlock type1Frac mean_type1_residual mean_type2_residual mean_type1_residual_unc mean_type2_residual_unc "<<iBlock<<" "<<type1Frac<<" "<<mean_type1_residual<<" "<<mean_type2_residual<<" "<<mean_type1_residual_unc<<" "<<mean_type2_residual_unc;
-
-        type1Frac=0.0;
-        mean_type1_residual=0.0;
-        mean_type2_residual=0.0;
-        mean_type1_residual_unc=0;
-        mean_type2_residual_unc=0;
-
-        iBlock++;    
-
-        resetBlock();
+    if (lumiInfoMap.count(lsKey) == 0) {
+      lumiInfoMap[lsKey] = new LumiInfo();
     }
+
+    //Sum all lumi in IOV of lsKey
+    totalLumiByBX_ = lumiInfoMap[lsKey]->getInstLumiAllBX();
+    events_ = lumiInfoMap[lsKey]->getErrorLumiAllBX();
+
+    rawlumiBX_ = lumiInfoMapPerLS[thisLS]->getInstLumiAllBX();
+    errOnLumiByBX_ = lumiInfoMapPerLS[thisLS]->getErrorLumiAllBX();
+
+    for (unsigned int bx = 0; bx < LumiConstants::numBX; bx++) {
+      totalLumiByBX_[bx] += rawlumiBX_[bx];
+      events_[bx] += errOnLumiByBX_[bx];
+    }
+    lumiInfoMap[lsKey]->setInstLumiAllBX(totalLumiByBX_);
+    lumiInfoMap[lsKey]->setErrorLumiAllBX(events_);
+    lumiInfoCounter[lsKey]++;
+  }
+
+  cond::Time_t thisIOV = 1;
+
+  char* histname1 = new char[100];
+  char* histname2 = new char[100];
+  char* histname3 = new char[100];
+  char* histTitle1 = new char[100];
+  char* histTitle2 = new char[100];
+  char* histTitle3 = new char[100];
+  sprintf(histTitle1, "Type1Fraction_%d", runSeg.run());
+  sprintf(histTitle2, "Type1Res_%d", runSeg.run());
+  sprintf(histTitle3, "Type2Res_%d", runSeg.run());
+  type1FracHist = new TH1F(histTitle1, histTitle1, 1000, -0.5, 0.5);
+  type1resHist = new TH1F(histTitle2, histTitle2, 4000, -0.2, 0.2);
+  type2resHist = new TH1F(histTitle3, histTitle3, 4000, -0.2, 0.2);
+  delete[] histTitle1;
+  delete[] histTitle2;
+  delete[] histTitle3;
+
+  for (lumiInfoMapIterator = lumiInfoMap.begin(); (lumiInfoMapIterator != lumiInfoMap.end()); ++lumiInfoMapIterator) {
+    totalLumiByBX_ = lumiInfoMapIterator->second->getInstLumiAllBX();
+    events_ = lumiInfoMapIterator->second->getErrorLumiAllBX();
+
+    if (events_.empty()) {
+      continue;
+    }
+
+    edm::LuminosityBlockID lu(runSeg.id().run(), edm::LuminosityBlockNumber_t(lumiInfoMapIterator->first.first));
+    thisIOV = (cond::Time_t)(lu.value());
+
+    sprintf(histname1,
+            "CorrectedLumiAvg_%d_%d_%d_%d",
+            runSeg.run(),
+            iBlock,
+            lumiInfoMapIterator->first.first,
+            lumiInfoMapIterator->first.second);
+    sprintf(histname2,
+            "ScaleFactorsAvg_%d_%d_%d_%d",
+            runSeg.run(),
+            iBlock,
+            lumiInfoMapIterator->first.first,
+            lumiInfoMapIterator->first.second);
+    sprintf(histname3,
+            "RawLumiAvg_%d_%d_%d_%d",
+            runSeg.run(),
+            iBlock,
+            lumiInfoMapIterator->first.first,
+            lumiInfoMapIterator->first.second);
+
+    corrlumiAvg_h = new TH1F(histname1, "", LumiConstants::numBX, 1, LumiConstants::numBX);
+    scaleFactorAvg_h = new TH1F(histname2, "", LumiConstants::numBX, 1, LumiConstants::numBX);
+    lumiAvg_h = new TH1F(histname3, "", LumiConstants::numBX, 1, LumiConstants::numBX);
+
+    //Averaging by the number of events
+    for (unsigned int i = 0; i < LumiConstants::numBX; i++) {
+      if (events_.at(i) != 0) {
+        totalLumiByBXAvg_[i] = totalLumiByBX_[i] / events_[i];
+      } else {
+        totalLumiByBXAvg_[i] = 0.0;
+      }
+    }
+
+    calculateCorrections(totalLumiByBXAvg_, correctionScaleFactors_, overallCorrection_);
+
+    for (unsigned int bx = 0; bx < LumiConstants::numBX; bx++) {
+      corrlumiAvg_h->SetBinContent(bx, totalLumiByBXAvg_[bx] * correctionScaleFactors_[bx]);
+      if (events_.at(bx) != 0) {
+        corrlumiAvg_h->SetBinError(bx,
+                                   totalLumiByBXAvg_[bx] * correctionScaleFactors_[bx] / TMath::Sqrt(events_.at(bx)));
+      } else {
+        corrlumiAvg_h->SetBinError(bx, 0.0);
+      }
+
+      scaleFactorAvg_h->SetBinContent(bx, correctionScaleFactors_[bx]);
+      lumiAvg_h->SetBinContent(bx, totalLumiByBXAvg_[bx]);
+    }
+
+    //Writing the corrections to SQL lite file for db
+    pccCorrections = new LumiCorrections();
+    pccCorrections->setOverallCorrection(overallCorrection_);
+    pccCorrections->setType1Fraction(type1Frac);
+    pccCorrections->setType1Residual(mean_type1_residual);
+    pccCorrections->setType2Residual(mean_type2_residual);
+    pccCorrections->setCorrectionsBX(correctionScaleFactors_);
+
+    if (poolDbService.isAvailable()) {
+      poolDbService->writeOne<LumiCorrections>(pccCorrections, thisIOV, "LumiCorrectionsRcd");
+    } else {
+      throw std::runtime_error("PoolDBService required.");
+    }
+
+    delete pccCorrections;
+
     histoFile->cd();
-    type1FracHist->Write();
-    type1resHist->Write();
-    type2resHist->Write();
+    corrlumiAvg_h->Write();
+    scaleFactorAvg_h->Write();
+    lumiAvg_h->Write();
 
-    delete type1FracHist;
-    delete type1resHist;
-    delete type2resHist;
+    delete corrlumiAvg_h;
+    delete scaleFactorAvg_h;
+    delete lumiAvg_h;
 
-    delete[] histname1;
-    delete[] histname2;
-    delete[] histname3;
+    type1FracHist->Fill(type1Frac);
+    type1resHist->Fill(mean_type1_residual);
+    type2resHist->Fill(mean_type2_residual);
 
-    for(lumiInfoMapIterator=lumiInfoMap.begin(); (lumiInfoMapIterator!=lumiInfoMap.end()); ++lumiInfoMapIterator) {
-        delete lumiInfoMapIterator->second; 
+    for (unsigned int ils = lumiInfoMapIterator->first.first; ils < lumiInfoMapIterator->first.second + 1; ils++) {
+      if (ils > maxLS) {
+        std::cout << "ils out of maxLS range!!" << std::endl;
+        break;
+      }
+      Type1FracMon->setBinContent(ils, type1Frac);
+      Type1FracMon->setBinError(ils, mean_type1_residual_unc);
+      Type1ResMon->setBinContent(ils, mean_type1_residual);
+      Type1ResMon->setBinError(ils, mean_type1_residual_unc);
+      Type2ResMon->setBinContent(ils, mean_type2_residual);
+      Type2ResMon->setBinError(ils, mean_type2_residual_unc);
     }
-    for(unsigned int lumiSection=0; lumiSection<lumiSections.size(); lumiSection++){
-        thisLS=lumiSections[lumiSection];
-        delete lumiInfoMapPerLS[thisLS];
-    }
-    lumiInfoMap.clear();
-    lumiInfoMapPerLS.clear();
-    lumiSections.clear();
-    lumiInfoCounter.clear();
+
+    type1FracGraph->SetPoint(iBlock, thisIOV + approxLumiBlockSize_ / 2.0, type1Frac);
+    type1resGraph->SetPoint(iBlock, thisIOV + approxLumiBlockSize_ / 2.0, mean_type1_residual);
+    type2resGraph->SetPoint(iBlock, thisIOV + approxLumiBlockSize_ / 2.0, mean_type2_residual);
+    type1FracGraph->SetPointError(iBlock, approxLumiBlockSize_ / 2.0, mean_type1_residual_unc);
+    type1resGraph->SetPointError(iBlock, approxLumiBlockSize_ / 2.0, mean_type1_residual_unc);
+    type2resGraph->SetPointError(iBlock, approxLumiBlockSize_ / 2.0, mean_type2_residual_unc);
+
+    edm::LogInfo("INFO")
+        << "iBlock type1Frac mean_type1_residual mean_type2_residual mean_type1_residual_unc mean_type2_residual_unc "
+        << iBlock << " " << type1Frac << " " << mean_type1_residual << " " << mean_type2_residual << " "
+        << mean_type1_residual_unc << " " << mean_type2_residual_unc;
+
+    type1Frac = 0.0;
+    mean_type1_residual = 0.0;
+    mean_type2_residual = 0.0;
+    mean_type1_residual_unc = 0;
+    mean_type2_residual_unc = 0;
+
+    iBlock++;
+
+    resetBlock();
+  }
+  histoFile->cd();
+  type1FracHist->Write();
+  type1resHist->Write();
+  type2resHist->Write();
+
+  delete type1FracHist;
+  delete type1resHist;
+  delete type2resHist;
+
+  delete[] histname1;
+  delete[] histname2;
+  delete[] histname3;
+
+  for (lumiInfoMapIterator = lumiInfoMap.begin(); (lumiInfoMapIterator != lumiInfoMap.end()); ++lumiInfoMapIterator) {
+    delete lumiInfoMapIterator->second;
+  }
+  for (unsigned int lumiSection = 0; lumiSection < lumiSections.size(); lumiSection++) {
+    thisLS = lumiSections[lumiSection];
+    delete lumiInfoMapPerLS[thisLS];
+  }
+  lumiInfoMap.clear();
+  lumiInfoMapPerLS.clear();
+  lumiSections.clear();
+  lumiInfoCounter.clear();
 }
 
 //--------------------------------------------------------------------------------------------------
-void CorrPCCProducer::resetBlock(){
-    for(unsigned int bx=0;bx<LumiConstants::numBX;bx++){
-        totalLumiByBX_[bx]=0;
-        totalLumiByBXAvg_[bx]=0;
-        events_[bx]=0;
-        correctionScaleFactors_[bx]=1.0;
-    }
+void CorrPCCProducer::resetBlock() {
+  for (unsigned int bx = 0; bx < LumiConstants::numBX; bx++) {
+    totalLumiByBX_[bx] = 0;
+    totalLumiByBXAvg_[bx] = 0;
+    events_[bx] = 0;
+    correctionScaleFactors_[bx] = 1.0;
+  }
 }
 //--------------------------------------------------------------------------------------------------
-void CorrPCCProducer::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & iRun, edm::EventSetup const & context){
-        ibooker.setCurrentFolder("AlCaReco/LumiPCC/") ;
-        Type1FracMon = ibooker.book1D("type1Fraction","Type1Fraction;Lumisection;Type 1 Fraction",maxLS,0,maxLS);
-        Type1ResMon = ibooker.book1D("type1Residual","Type1Residual;Lumisection;Type 1 Residual",maxLS,0,maxLS);
-        Type2ResMon = ibooker.book1D("type2Residual","Type2Residual;Lumisection;Type 2 Residual",maxLS,0,maxLS);
+void CorrPCCProducer::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& context) {
+  ibooker.setCurrentFolder("AlCaReco/LumiPCC/");
+  Type1FracMon = ibooker.book1D("type1Fraction", "Type1Fraction;Lumisection;Type 1 Fraction", maxLS, 0, maxLS);
+  Type1ResMon = ibooker.book1D("type1Residual", "Type1Residual;Lumisection;Type 1 Residual", maxLS, 0, maxLS);
+  Type2ResMon = ibooker.book1D("type2Residual", "Type2Residual;Lumisection;Type 2 Residual", maxLS, 0, maxLS);
 }
 //--------------------------------------------------------------------------------------------------
-void CorrPCCProducer::endJob(){
-    histoFile->cd();
-    type1FracGraph->Write();
-    type1resGraph->Write();
-    type2resGraph->Write();
-    histoFile->Write();
-    histoFile->Close();
-    delete type1FracGraph;
-    delete type1resGraph;
-    delete type2resGraph;
+void CorrPCCProducer::endJob() {
+  histoFile->cd();
+  type1FracGraph->Write();
+  type1resGraph->Write();
+  type2resGraph->Write();
+  histoFile->Write();
+  histoFile->Close();
+  delete type1FracGraph;
+  delete type1resGraph;
+  delete type2resGraph;
 }
 
 DEFINE_FWK_MODULE(CorrPCCProducer);

--- a/Calibration/LumiAlCaRecoProducers/plugins/RawPCCProducer.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/RawPCCProducer.cc
@@ -8,8 +8,8 @@ authors:Sam Higginbotham (shigginb@cern.ch) and Chris Palmer (capalmer@cern.ch)
 
 ________________________________________________________________**/
 #include <string>
-#include <iostream> 
-#include <fstream> 
+#include <iostream>
+#include <fstream>
 #include <vector>
 #include <mutex>
 #include <cmath>
@@ -32,162 +32,163 @@ ________________________________________________________________**/
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 class RawPCCProducer : public edm::global::EDProducer<edm::EndLuminosityBlockProducer> {
-        public:
-            explicit RawPCCProducer(const edm::ParameterSet&);
-            ~RawPCCProducer() override;
+public:
+  explicit RawPCCProducer(const edm::ParameterSet&);
+  ~RawPCCProducer() override;
 
-        private:
-            void globalEndLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) const final;
-            void produce                  (edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const final;
+private:
+  void globalEndLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) const final;
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const final;
 
+  edm::EDGetTokenT<reco::PixelClusterCounts> pccToken_;
+  const edm::EDPutTokenT<LumiInfo> putToken_;
+  const std::string takeAverageValue_;  //Output average values
 
-            edm::EDGetTokenT<reco::PixelClusterCounts>  pccToken_;
-            const edm::EDPutTokenT<LumiInfo> putToken_;
-            const std::string   takeAverageValue_;      //Output average values 
+  const std::vector<int> modVeto_;  //The list of modules to skip in the lumi calc.
 
-            const std::vector<int>   modVeto_;          //The list of modules to skip in the lumi calc. 
+  const std::string csvOutLabel_;
+  mutable std::mutex fileLock_;
+  const bool saveCSVFile_;
 
-            const std::string csvOutLabel_;
-            mutable std::mutex fileLock_;
-            const bool saveCSVFile_;
-
-            const bool applyCorr_;
-    };
+  const bool applyCorr_;
+};
 
 //--------------------------------------------------------------------------------------------------
-RawPCCProducer::RawPCCProducer(const edm::ParameterSet& iConfig):
-  putToken_{ produces<LumiInfo, edm::Transition::EndLuminosityBlock>(iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<std::string>("outputProductName","alcaLumi"))},
-  takeAverageValue_ {iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<std::string>("OutputValue",std::string("Totals"))},
-  modVeto_{ iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::vector<int>>("modVeto")},
-  csvOutLabel_{ iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<std::string>("label",std::string("rawPCC.csv")) },
-  saveCSVFile_{ iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<bool>("saveCSVFile",false)},
-  applyCorr_{ iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getUntrackedParameter<bool>("ApplyCorrections",false) }
-{
-    auto pccSource = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::string>("inputPccLabel");
-    auto prodInst = iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::string>("ProdInst");
+RawPCCProducer::RawPCCProducer(const edm::ParameterSet& iConfig)
+    : putToken_{produces<LumiInfo, edm::Transition::EndLuminosityBlock>(
+          iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters")
+              .getUntrackedParameter<std::string>("outputProductName", "alcaLumi"))},
+      takeAverageValue_{iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters")
+                            .getUntrackedParameter<std::string>("OutputValue", std::string("Totals"))},
+      modVeto_{
+          iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::vector<int>>("modVeto")},
+      csvOutLabel_{iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters")
+                       .getUntrackedParameter<std::string>("label", std::string("rawPCC.csv"))},
+      saveCSVFile_{iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters")
+                       .getUntrackedParameter<bool>("saveCSVFile", false)},
+      applyCorr_{iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters")
+                     .getUntrackedParameter<bool>("ApplyCorrections", false)} {
+  auto pccSource =
+      iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::string>("inputPccLabel");
+  auto prodInst =
+      iConfig.getParameter<edm::ParameterSet>("RawPCCProducerParameters").getParameter<std::string>("ProdInst");
 
-    pccToken_=consumes<reco::PixelClusterCounts, edm::InLumi>(edm::InputTag(pccSource, prodInst));
+  pccToken_ = consumes<reco::PixelClusterCounts, edm::InLumi>(edm::InputTag(pccSource, prodInst));
 }
 
 //--------------------------------------------------------------------------------------------------
-RawPCCProducer::~RawPCCProducer(){
-}
+RawPCCProducer::~RawPCCProducer() {}
 
 //--------------------------------------------------------------------------------------------------
-void RawPCCProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
-
-
-}
+void RawPCCProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {}
 
 //--------------------------------------------------------------------------------------------------
-void RawPCCProducer::globalEndLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) const {
-    float totalLumi=0.0; //The total raw luminosity from the pixel clusters - not scaled
-    float statErrOnLumi=0.0; //the statistical error on the lumi - large num ie sqrt(N)
+void RawPCCProducer::globalEndLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg,
+                                                     const edm::EventSetup& iSetup) const {
+  float totalLumi = 0.0;      //The total raw luminosity from the pixel clusters - not scaled
+  float statErrOnLumi = 0.0;  //the statistical error on the lumi - large num ie sqrt(N)
 
-    //new vector containing clusters per bxid
-    std::vector<int> clustersPerBXOutput(LumiConstants::numBX,0);
-    //new vector containing clusters per bxid with afterglow corrections 
-    std::vector<float> corrClustersPerBXOutput(LumiConstants::numBX,0);
+  //new vector containing clusters per bxid
+  std::vector<int> clustersPerBXOutput(LumiConstants::numBX, 0);
+  //new vector containing clusters per bxid with afterglow corrections
+  std::vector<float> corrClustersPerBXOutput(LumiConstants::numBX, 0);
 
-    //The indicies of all the good modules - not vetoed
-    std::vector<int> goodMods;                 
+  //The indicies of all the good modules - not vetoed
+  std::vector<int> goodMods;
 
-    edm::Handle<reco::PixelClusterCounts> pccHandle; 
-    lumiSeg.getByToken(pccToken_,pccHandle);
+  edm::Handle<reco::PixelClusterCounts> pccHandle;
+  lumiSeg.getByToken(pccToken_, pccHandle);
 
-    const reco::PixelClusterCounts& inputPcc = *(pccHandle.product()); 
+  const reco::PixelClusterCounts& inputPcc = *(pccHandle.product());
 
-    //vector with Module IDs 1-1 map to bunch x-ing in clusers
-    auto modID = inputPcc.readModID();
-    //vector with total events at each bxid.
-    auto events= inputPcc.readEvents();
-    auto clustersPerBXInput = inputPcc.readCounts();
+  //vector with Module IDs 1-1 map to bunch x-ing in clusers
+  auto modID = inputPcc.readModID();
+  //vector with total events at each bxid.
+  auto events = inputPcc.readEvents();
+  auto clustersPerBXInput = inputPcc.readCounts();
 
-    //making list of modules to sum over
-    for (unsigned int i=0;i<modID.size();i++){
-        if (std::find(modVeto_.begin(),modVeto_.end(), modID.at(i)) == modVeto_.end()){
-            goodMods.push_back(i);
-        }
+  //making list of modules to sum over
+  for (unsigned int i = 0; i < modID.size(); i++) {
+    if (std::find(modVeto_.begin(), modVeto_.end(), modID.at(i)) == modVeto_.end()) {
+      goodMods.push_back(i);
     }
+  }
 
-    //summing over good modules only 
-    for (int bx=0;bx<int(LumiConstants::numBX);bx++){
-        for (unsigned int i=0;i<goodMods.size();i++){
-            clustersPerBXOutput.at(bx)+=clustersPerBXInput.at(goodMods.at(i)*int(LumiConstants::numBX)+bx);
-
-        }
+  //summing over good modules only
+  for (int bx = 0; bx < int(LumiConstants::numBX); bx++) {
+    for (unsigned int i = 0; i < goodMods.size(); i++) {
+      clustersPerBXOutput.at(bx) += clustersPerBXInput.at(goodMods.at(i) * int(LumiConstants::numBX) + bx);
     }
+  }
 
-    std::vector<float> correctionScaleFactors;
-    if(applyCorr_){
-        edm::ESHandle< LumiCorrections > corrHandle;
-        iSetup.get<LumiCorrectionsRcd>().get(corrHandle);
-        const LumiCorrections *pccCorrections = corrHandle.product();
-        correctionScaleFactors = pccCorrections->getCorrectionsBX();
+  std::vector<float> correctionScaleFactors;
+  if (applyCorr_) {
+    edm::ESHandle<LumiCorrections> corrHandle;
+    iSetup.get<LumiCorrectionsRcd>().get(corrHandle);
+    const LumiCorrections* pccCorrections = corrHandle.product();
+    correctionScaleFactors = pccCorrections->getCorrectionsBX();
+  } else {
+    correctionScaleFactors.resize(LumiConstants::numBX, 1.0);
+  }
+
+  for (unsigned int i = 0; i < clustersPerBXOutput.size(); i++) {
+    if (events.at(i) != 0) {
+      corrClustersPerBXOutput[i] = clustersPerBXOutput[i] * correctionScaleFactors[i];
     } else {
-        correctionScaleFactors.resize(LumiConstants::numBX,1.0);
+      corrClustersPerBXOutput[i] = 0.0;
+    }
+    totalLumi += corrClustersPerBXOutput[i];
+    statErrOnLumi += float(events[i]);
+  }
+
+  std::vector<float> errorPerBX;  //Stat error (or number of events)
+  errorPerBX.assign(events.begin(), events.end());
+
+  if (takeAverageValue_ == "Average") {
+    unsigned int NActiveBX = 0;
+    for (int bx = 0; bx < int(LumiConstants::numBX); bx++) {
+      if (events[bx] > 0) {
+        NActiveBX++;
+        // Counting where events are will only work
+        // for ZeroBias or AlwaysTrue triggers.
+        // Random triggers will get all BXs.
+        corrClustersPerBXOutput[bx] /= float(events[bx]);
+        errorPerBX[bx] = 1 / sqrt(float(events[bx]));
+      }
+    }
+    if (statErrOnLumi != 0) {
+      totalLumi = totalLumi / statErrOnLumi * float(NActiveBX);
+      statErrOnLumi = 1 / sqrt(statErrOnLumi) * totalLumi;
+    }
+  }
+
+  LumiInfo outputLumiInfo;
+
+  outputLumiInfo.setTotalInstLumi(totalLumi);
+  outputLumiInfo.setTotalInstStatError(statErrOnLumi);
+
+  outputLumiInfo.setErrorLumiAllBX(errorPerBX);
+  outputLumiInfo.setInstLumiAllBX(corrClustersPerBXOutput);
+
+  if (saveCSVFile_) {
+    std::lock_guard<std::mutex> lock(fileLock_);
+    std::ofstream csfile(csvOutLabel_, std::ios_base::app);
+    csfile << std::to_string(lumiSeg.run()) << ",";
+    csfile << std::to_string(lumiSeg.luminosityBlock()) << ",";
+    csfile << std::to_string(totalLumi);
+
+    if (totalLumi > 0) {
+      for (unsigned int bx = 0; bx < LumiConstants::numBX; bx++) {
+        csfile << "," << std::to_string(corrClustersPerBXOutput[bx]);
+      }
+      csfile << std::endl;
+    } else if (totalLumi < 0) {
+      edm::LogInfo("WARNING") << "WHY IS LUMI NEGATIVE?!?!?!? " << totalLumi;
     }
 
-    for (unsigned int i=0;i<clustersPerBXOutput.size();i++){
-        if (events.at(i)!=0){
-            corrClustersPerBXOutput[i]=clustersPerBXOutput[i]*correctionScaleFactors[i];
-        }else{
-            corrClustersPerBXOutput[i]=0.0;
-        }
-        totalLumi+=corrClustersPerBXOutput[i];
-        statErrOnLumi+=float(events[i]);
-    }
-
-    std::vector<float> errorPerBX;             //Stat error (or number of events)
-    errorPerBX.assign(events.begin(),events.end()); 
-
-    if(takeAverageValue_=="Average"){
-        unsigned int NActiveBX=0;
-        for (int bx=0;bx<int(LumiConstants::numBX);bx++){
-            if(events[bx]>0){
-                NActiveBX++;  
-                // Counting where events are will only work 
-                // for ZeroBias or AlwaysTrue triggers.
-                // Random triggers will get all BXs.
-                corrClustersPerBXOutput[bx]/=float(events[bx]);
-                errorPerBX[bx]=1/sqrt(float(events[bx]));
-            }
-        }
-        if (statErrOnLumi!=0) {
-            totalLumi=totalLumi/statErrOnLumi*float(NActiveBX);
-            statErrOnLumi=1/sqrt(statErrOnLumi)*totalLumi;
-        }
-    }
-
-    LumiInfo outputLumiInfo;
-
-
-    outputLumiInfo.setTotalInstLumi(totalLumi);
-    outputLumiInfo.setTotalInstStatError(statErrOnLumi);
-
-    outputLumiInfo.setErrorLumiAllBX(errorPerBX);
-    outputLumiInfo.setInstLumiAllBX(corrClustersPerBXOutput);
-
-    if(saveCSVFile_){
-        std::lock_guard<std::mutex> lock(fileLock_);
-        std::ofstream csfile(csvOutLabel_, std::ios_base::app);
-        csfile<<std::to_string(lumiSeg.run())<<",";
-        csfile<<std::to_string(lumiSeg.luminosityBlock())<<",";
-        csfile<<std::to_string(totalLumi);
-        
-        if(totalLumi>0){
-            for(unsigned int bx=0;bx<LumiConstants::numBX;bx++){
-                csfile<<","<<std::to_string(corrClustersPerBXOutput[bx]);
-            }
-            csfile<<std::endl;   
-        } else if (totalLumi<0) {
-            edm::LogInfo("WARNING")<<"WHY IS LUMI NEGATIVE?!?!?!? "<<totalLumi;
-        }
-
-        csfile.close();
-    }
-    lumiSeg.emplace(putToken_, std::move(outputLumiInfo) ); 
-
+    csfile.close();
+  }
+  lumiSeg.emplace(putToken_, std::move(outputLumiInfo));
 }
 
 DEFINE_FWK_MODULE(RawPCCProducer);

--- a/IORawData/CaloPatterns/interface/HcalFiberPattern.h
+++ b/IORawData/CaloPatterns/interface/HcalFiberPattern.h
@@ -19,6 +19,7 @@ public:
   int crate() const { return crate_; }
   int slot() const { return slot_; }
   int fiber() const { return fiber_; }
+
 private:
   HcalQIESample unpack(int bc, int fc);
   int crate_, slot_, tb_, fiber_, spigot_, dcc_;

--- a/IORawData/CaloPatterns/interface/HcalPatternXMLParser.h
+++ b/IORawData/CaloPatterns/interface/HcalPatternXMLParser.h
@@ -13,11 +13,16 @@ class HcalPatternXMLParser {
 public:
   HcalPatternXMLParser();
   ~HcalPatternXMLParser();
-  void parse(const std::string& xmlDocument, std::map<std::string,std::string>& parameters, std::vector<std::string>& items, std::string& encoding);
-  void parse(const std::string& xmlDocument, std::map<std::string,std::string>& parameters, std::vector<uint32_t>& items);
+  void parse(const std::string& xmlDocument,
+             std::map<std::string, std::string>& parameters,
+             std::vector<std::string>& items,
+             std::string& encoding);
+  void parse(const std::string& xmlDocument,
+             std::map<std::string, std::string>& parameters,
+             std::vector<uint32_t>& items);
+
 private:
   HcalPatternXMLParserImpl* m_parser;
 };
 
-
-#endif // HcalPatternXMLParser_hh_included
+#endif  // HcalPatternXMLParser_hh_included

--- a/IORawData/CaloPatterns/src/HcalFiberPattern.cc
+++ b/IORawData/CaloPatterns/src/HcalFiberPattern.cc
@@ -1,64 +1,72 @@
 #include "IORawData/CaloPatterns/interface/HcalFiberPattern.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-static inline int setIf(const std::string& name,const std::map<std::string, std::string>& params) {
-  std::map<std::string, std::string>::const_iterator j=params.find(name);
-  if (j==params.end()) throw cms::Exception("InvalidFormat") << "Missing parameter '" << name << "'";
-  else return strtol(j->second.c_str(),nullptr,0);
-} 
+static inline int setIf(const std::string& name, const std::map<std::string, std::string>& params) {
+  std::map<std::string, std::string>::const_iterator j = params.find(name);
+  if (j == params.end())
+    throw cms::Exception("InvalidFormat") << "Missing parameter '" << name << "'";
+  else
+    return strtol(j->second.c_str(), nullptr, 0);
+}
 
-HcalFiberPattern::HcalFiberPattern(const std::map<std::string, std::string>& params, const std::vector<uint32_t>& data) : pattern_(data) {
-  crate_=setIf("CRATE",params);
-  slot_=setIf("SLOT",params);
-  fiber_=setIf("FIBER",params);
-  dcc_=setIf("DCC",params);
-  spigot_=setIf("SPIGOT",params);
-  tb_=setIf("TOPBOTTOM",params);
+HcalFiberPattern::HcalFiberPattern(const std::map<std::string, std::string>& params, const std::vector<uint32_t>& data)
+    : pattern_(data) {
+  crate_ = setIf("CRATE", params);
+  slot_ = setIf("SLOT", params);
+  fiber_ = setIf("FIBER", params);
+  dcc_ = setIf("DCC", params);
+  spigot_ = setIf("SPIGOT", params);
+  tb_ = setIf("TOPBOTTOM", params);
 }
 
 HcalQIESample HcalFiberPattern::unpack(int bc, int fc) {
-  uint32_t w1=pattern_[bc*2]; // lsw
-  uint32_t w2=pattern_[bc*2+1]; // msw
+  uint32_t w1 = pattern_[bc * 2];      // lsw
+  uint32_t w2 = pattern_[bc * 2 + 1];  // msw
 
-  int adc=0, capid=0;
-  bool dv=(w1&0x10000)!=0;
-  bool er=(w1&0x20000)!=0;
-  
+  int adc = 0, capid = 0;
+  bool dv = (w1 & 0x10000) != 0;
+  bool er = (w1 & 0x20000) != 0;
+
   switch (fc) {
-  case (0):
-    adc=(w2&0xFE00)>>9;
-    capid=(w1&0x0180)>>7;
-    break;
-  case (1):
-    adc=(w2&0xFE)>>1;
-    capid=(w1&0x0060)>>5;
-    break;
-  case (2):
-    adc=(w1&0xFE00)>>9;
-    capid=(w1&0x0018)>>3;
-    break;
-  default:
-    break;
+    case (0):
+      adc = (w2 & 0xFE00) >> 9;
+      capid = (w1 & 0x0180) >> 7;
+      break;
+    case (1):
+      adc = (w2 & 0xFE) >> 1;
+      capid = (w1 & 0x0060) >> 5;
+      break;
+    case (2):
+      adc = (w1 & 0xFE00) >> 9;
+      capid = (w1 & 0x0018) >> 3;
+      break;
+    default:
+      break;
   }
-  return HcalQIESample(adc,capid,fiber_,fc,dv,er);
+  return HcalQIESample(adc, capid, fiber_, fc, dv, er);
 }
 
 std::vector<HcalQIESample> HcalFiberPattern::getSamples(int bunch, int npresamples, int nsamples, int fiberChan) {
-  if (bunch<npresamples) throw cms::Exception("InvalidArgument") << "Asked for " << npresamples << " presamples with event at bunch " << bunch;
-  if (nsamples-npresamples+bunch>=(int)(pattern_.size()/2)) throw cms::Exception("InvalidArgument") << "Asked for " << nsamples << " with event at " << bunch << " and " << npresamples << " presamples, but only " << pattern_.size()/2 << " bunches are available";
+  if (bunch < npresamples)
+    throw cms::Exception("InvalidArgument")
+        << "Asked for " << npresamples << " presamples with event at bunch " << bunch;
+  if (nsamples - npresamples + bunch >= (int)(pattern_.size() / 2))
+    throw cms::Exception("InvalidArgument")
+        << "Asked for " << nsamples << " with event at " << bunch << " and " << npresamples << " presamples, but only "
+        << pattern_.size() / 2 << " bunches are available";
 
   std::vector<HcalQIESample> retval;
   retval.reserve(nsamples);
 
-  for (int i=0; i<nsamples; i++) {
-    int bc=bunch+i-npresamples;
-    retval.push_back(unpack(bc,fiberChan));
+  for (int i = 0; i < nsamples; i++) {
+    int bc = bunch + i - npresamples;
+    retval.push_back(unpack(bc, fiberChan));
   }
   return retval;
 }
 
 HcalElectronicsId HcalFiberPattern::getId(int fiberChan) {
-  HcalElectronicsId retval(fiberChan,fiber_,spigot_,dcc_);
-  retval.setHTR(crate_,slot_,tb_);
+  HcalElectronicsId retval(fiberChan, fiber_, spigot_, dcc_);
+  retval.setHTR(crate_, slot_, tb_);
   return retval;
 }

--- a/IORawData/CaloPatterns/src/HcalPatternSource.cc
+++ b/IORawData/CaloPatterns/src/HcalPatternSource.cc
@@ -11,11 +11,10 @@
 #include <wordexp.h>
 #include <cstdio>
 
-HcalPatternSource::HcalPatternSource(const edm::ParameterSet & pset) : 
-  bunches_(pset.getUntrackedParameter<std::vector<int> >("Bunches",std::vector<int>())),
-  presamples_(pset.getUntrackedParameter<int>("Presamples",4)),
-  samples_(pset.getUntrackedParameter<int>("Samples",10))
-{
+HcalPatternSource::HcalPatternSource(const edm::ParameterSet& pset)
+    : bunches_(pset.getUntrackedParameter<std::vector<int> >("Bunches", std::vector<int>())),
+      presamples_(pset.getUntrackedParameter<int>("Presamples", 4)),
+      samples_(pset.getUntrackedParameter<int>("Samples", 10)) {
   loadPatterns(pset.getUntrackedParameter<std::string>("Patterns"));
   produces<HBHEDigiCollection>();
   produces<HODigiCollection>();
@@ -23,61 +22,66 @@ HcalPatternSource::HcalPatternSource(const edm::ParameterSet & pset) :
 }
 
 void HcalPatternSource::produce(edm::Event& e, const edm::EventSetup& es) {
-  if (e.id().event()>bunches_.size()) return;
+  if (e.id().event() > bunches_.size())
+    return;
 
   edm::ESHandle<HcalElectronicsMap> item;
   es.get<HcalElectronicsMapRcd>().get(item);
-  const HcalElectronicsMap *elecmap=item.product();
+  const HcalElectronicsMap* elecmap = item.product();
 
   auto hbhe = std::make_unique<HBHEDigiCollection>();
   auto hf = std::make_unique<HFDigiCollection>();
   auto ho = std::make_unique<HODigiCollection>();
 
-  int bc=bunches_[e.id().event()-1];
-  for (std::vector<HcalFiberPattern>::iterator i=patterns_.begin(); i!=patterns_.end(); i++) {
+  int bc = bunches_[e.id().event() - 1];
+  for (std::vector<HcalFiberPattern>::iterator i = patterns_.begin(); i != patterns_.end(); i++) {
     std::vector<HcalQIESample> samples;
-    for (int fc=0; fc<3; fc++) {
-      samples=i->getSamples(bc,presamples_, samples_, fc);
-      HcalElectronicsId eid=i->getId(fc);
+    for (int fc = 0; fc < 3; fc++) {
+      samples = i->getSamples(bc, presamples_, samples_, fc);
+      HcalElectronicsId eid = i->getId(fc);
 
       HcalDetId did(elecmap->lookup(eid));
 
       if (did.null()) {
-	edm::LogWarning("HCAL") << "No electronics map match for id " << eid;
-	continue;
+        edm::LogWarning("HCAL") << "No electronics map match for id " << eid;
+        continue;
       }
 
       switch (did.subdet()) {
-      case (HcalBarrel):
-      case (HcalEndcap):
-	hbhe->push_back(HBHEDataFrame(did));
-	hbhe->back().setSize(samples_);
-	hbhe->back().setPresamples(presamples_);
-	for (int i=0; i<samples_; i++) hbhe->back().setSample(i,samples[i]);
-	hbhe->back().setReadoutIds(eid);
-	break;
-      case (HcalForward):
-	hf->push_back(HFDataFrame(did));
-	hf->back().setSize(samples_);
-	hf->back().setPresamples(presamples_);
-	for (int i=0; i<samples_; i++) hf->back().setSample(i,samples[i]);
-	hf->back().setReadoutIds(eid);
-	break;
-      case (HcalOuter) :
-	ho->push_back(HODataFrame(did));
-	ho->back().setSize(samples_);
-	ho->back().setPresamples(presamples_);
-	for (int i=0; i<samples_; i++) ho->back().setSample(i,samples[i]);
-	ho->back().setReadoutIds(eid);
-	break;
-      default: continue;
+        case (HcalBarrel):
+        case (HcalEndcap):
+          hbhe->push_back(HBHEDataFrame(did));
+          hbhe->back().setSize(samples_);
+          hbhe->back().setPresamples(presamples_);
+          for (int i = 0; i < samples_; i++)
+            hbhe->back().setSample(i, samples[i]);
+          hbhe->back().setReadoutIds(eid);
+          break;
+        case (HcalForward):
+          hf->push_back(HFDataFrame(did));
+          hf->back().setSize(samples_);
+          hf->back().setPresamples(presamples_);
+          for (int i = 0; i < samples_; i++)
+            hf->back().setSample(i, samples[i]);
+          hf->back().setReadoutIds(eid);
+          break;
+        case (HcalOuter):
+          ho->push_back(HODataFrame(did));
+          ho->back().setSize(samples_);
+          ho->back().setPresamples(presamples_);
+          for (int i = 0; i < samples_; i++)
+            ho->back().setSample(i, samples[i]);
+          ho->back().setReadoutIds(eid);
+          break;
+        default:
+          continue;
       }
-    }        
+    }
   }
   hbhe->sort();
   ho->sort();
   hf->sort();
-  
+
   e.put(std::move(hbhe));
   e.put(std::move(ho));
   e.put(std::move(hf));
@@ -86,12 +90,12 @@ void HcalPatternSource::produce(edm::Event& e, const edm::EventSetup& es) {
 void HcalPatternSource::loadPatterns(const std::string& patspec) {
   wordexp_t p;
   char** files;
-  wordexp(patspec.c_str(),&p, WRDE_NOCMD); // do not run shell commands!
-  files=p.we_wordv;
-  for (unsigned int i=0; i<p.we_wordc; i++) {
-    LogDebug ("HCAL") << "Reading pattern file '" << files[i] << "'";
+  wordexp(patspec.c_str(), &p, WRDE_NOCMD);  // do not run shell commands!
+  files = p.we_wordv;
+  for (unsigned int i = 0; i < p.we_wordc; i++) {
+    LogDebug("HCAL") << "Reading pattern file '" << files[i] << "'";
     loadPatternFile(files[i]);
-    LogDebug ("HCAL") << "Fibers so far " << patterns_.size();
+    LogDebug("HCAL") << "Fibers so far " << patterns_.size();
   }
   wordfree(&p);
 }
@@ -99,35 +103,34 @@ void HcalPatternSource::loadPatterns(const std::string& patspec) {
 void HcalPatternSource::loadPatternFile(const std::string& filename) {
   HcalPatternXMLParser parser;
   std::string buffer, element;
-  std::map<std::string,std::string> params;
+  std::map<std::string, std::string> params;
   std::vector<uint32_t> data;
-  FILE* f=fopen(filename.c_str(), "r");
-  if (f==nullptr) return;
+  FILE* f = fopen(filename.c_str(), "r");
+  if (f == nullptr)
+    return;
   else {
     char block[4096];
     while (!feof(f)) {
-      int read=fread(block,1,4096,f);
-      buffer.append(block,block+read);
-    }  
+      int read = fread(block, 1, 4096, f);
+      buffer.append(block, block + read);
+    }
     fclose(f);
   }
-  if (buffer.find("<?xml")!=0) {
+  if (buffer.find("<?xml") != 0) {
     throw cms::Exception("InvalidFormat") << "Not a valid XML file: " << filename;
   }
-  std::string::size_type i=0,j;
-  while (buffer.find("<CFGBrick>",i)!=std::string::npos) {
-    i=buffer.find("<CFGBrick>",i);
-    j=buffer.find("</CFGBrick>",i);
-    element="<?xml version='1.0'?>\n";
-    element.append(buffer,i,j-i);
+  std::string::size_type i = 0, j;
+  while (buffer.find("<CFGBrick>", i) != std::string::npos) {
+    i = buffer.find("<CFGBrick>", i);
+    j = buffer.find("</CFGBrick>", i);
+    element = "<?xml version='1.0'?>\n";
+    element.append(buffer, i, j - i);
     element.append("</CFGBrick>");
     //    LogDebug("HCAL") << element;
     params.clear();
     data.clear();
-    parser.parse(element,params,data);
-    patterns_.push_back(HcalFiberPattern(params,data));
-    i=j+5;
+    parser.parse(element, params, data);
+    patterns_.push_back(HcalFiberPattern(params, data));
+    i = j + 5;
   }
-  
-  
 }

--- a/IORawData/CaloPatterns/src/HcalPatternSource.h
+++ b/IORawData/CaloPatterns/src/HcalPatternSource.h
@@ -11,9 +11,10 @@
   */
 class HcalPatternSource : public edm::EDProducer {
 public:
-  HcalPatternSource(const edm::ParameterSet & pset);
+  HcalPatternSource(const edm::ParameterSet& pset);
   void produce(edm::Event& e, const edm::EventSetup& c) override;
-private:  
+
+private:
   void loadPatterns(const std::string& patspec);
   void loadPatternFile(const std::string& filename);
   std::vector<int> bunches_;

--- a/IORawData/CaloPatterns/src/HcalPatternXMLParser.cc
+++ b/IORawData/CaloPatterns/src/HcalPatternXMLParser.cc
@@ -13,14 +13,13 @@ public:
   std::unique_ptr<SAX2XMLReader> parser;
 };
 
-HcalPatternXMLParser::HcalPatternXMLParser() {
-  m_parser=nullptr;
-}
+HcalPatternXMLParser::HcalPatternXMLParser() { m_parser = nullptr; }
 HcalPatternXMLParser::~HcalPatternXMLParser() {
-  if (m_parser!=nullptr) delete m_parser;
+  if (m_parser != nullptr)
+    delete m_parser;
 }
 
-  /*
+/*
     Example
     <pre>
     <CFGBrick>
@@ -42,139 +41,168 @@ HcalPatternXMLParser::~HcalPatternXMLParser() {
     </pre>
   */
 
-  class ConfigurationDBHandler : public DefaultHandler {
-    enum { md_Idle, md_Parameter, md_Data } m_mode;
-  public:
-    ConfigurationDBHandler(std::map<std::string,std::string>& parameters, std::vector<std::string>& items, std::string& encoding) : m_dataEncoding(encoding), m_items(items), m_parameters(parameters) {
-      m_mode=md_Idle;
-      xc_Parameter=XMLString::transcode("Parameter");
-      xc_Data=XMLString::transcode("Data");
-      xc_name=XMLString::transcode("name");
-      xc_type=XMLString::transcode("type");
-      xc_elements=XMLString::transcode("elements");      
-      xc_encoding=XMLString::transcode("encoding");
-      m_items.clear();
-      m_parameters.clear();
-    }
-    ~ConfigurationDBHandler() override {
-      XMLString::release(&xc_Parameter);
-      XMLString::release(&xc_Data);
-      XMLString::release(&xc_name);
-      XMLString::release(&xc_type);
-      XMLString::release(&xc_elements);
-      XMLString::release(&xc_encoding);
-    }
-    void startElement (const XMLCh *const uri, const XMLCh *const localname, const XMLCh *const qname, const Attributes &attrs) override;
-    void endElement (const XMLCh *const uri, const XMLCh *const localname, const XMLCh *const qname) override;
-    void characters (const XMLCh *const chars, const XMLSize_t length) override;
-    void ignorableWhitespace (const XMLCh *const chars, const XMLSize_t length) override;
-  private:
-    inline bool cvt2String(const XMLCh* val, std::string& ou) {
-      if (val==nullptr) return false;
-      char* tool=XMLString::transcode(val);
-      ou=tool;
-      XMLString::release(&tool);
-      return true;
-    }
-    XMLCh *xc_Parameter, *xc_Data, *xc_name, *xc_type, *xc_elements, *xc_encoding;
-    std::string m_pname, m_ptype, m_text;
-    int n_elements;
-    std::string& m_dataEncoding;
-    std::vector<std::string>& m_items;
-    std::map<std::string,std::string>& m_parameters;
-    char m_workc[512];
-    XMLCh m_workx[256];
-  };
+class ConfigurationDBHandler : public DefaultHandler {
+  enum { md_Idle, md_Parameter, md_Data } m_mode;
 
-  void ConfigurationDBHandler::startElement (const XMLCh *const uri, const XMLCh *const localname, const XMLCh *const qname, const Attributes &attrs) {
-    if (m_mode!=md_Idle) return; 
-    if (!XMLString::compareIString(localname,xc_Parameter)) {
-      // parameter name
-      if (!cvt2String(attrs.getValue(xc_name),m_pname)) return;
-      // parameter type
-      if (!cvt2String(attrs.getValue(xc_type),m_ptype)) return;
-      // switch mode
-      m_mode=md_Parameter;
-      m_text="";
-    } else if (!XMLString::compareIString(localname,xc_Data)) {
-      // elements
-      std::string strElements;
-      if (!cvt2String(attrs.getValue(xc_elements),strElements)) return;
-      n_elements=atoi(strElements.c_str());
-      // encoding
-      m_dataEncoding="";
-      cvt2String(attrs.getValue(xc_encoding),m_dataEncoding);
-      // switch mode
-      m_mode=md_Data;
-      m_text="";
-    }
-   
+public:
+  ConfigurationDBHandler(std::map<std::string, std::string>& parameters,
+                         std::vector<std::string>& items,
+                         std::string& encoding)
+      : m_dataEncoding(encoding), m_items(items), m_parameters(parameters) {
+    m_mode = md_Idle;
+    xc_Parameter = XMLString::transcode("Parameter");
+    xc_Data = XMLString::transcode("Data");
+    xc_name = XMLString::transcode("name");
+    xc_type = XMLString::transcode("type");
+    xc_elements = XMLString::transcode("elements");
+    xc_encoding = XMLString::transcode("encoding");
+    m_items.clear();
+    m_parameters.clear();
   }
-  void ConfigurationDBHandler::endElement (const XMLCh *const uri, const XMLCh *const localname, const XMLCh *const qname) {
-    if (m_mode==md_Idle) return;
+  ~ConfigurationDBHandler() override {
+    XMLString::release(&xc_Parameter);
+    XMLString::release(&xc_Data);
+    XMLString::release(&xc_name);
+    XMLString::release(&xc_type);
+    XMLString::release(&xc_elements);
+    XMLString::release(&xc_encoding);
+  }
+  void startElement(const XMLCh* const uri,
+                    const XMLCh* const localname,
+                    const XMLCh* const qname,
+                    const Attributes& attrs) override;
+  void endElement(const XMLCh* const uri, const XMLCh* const localname, const XMLCh* const qname) override;
+  void characters(const XMLCh* const chars, const XMLSize_t length) override;
+  void ignorableWhitespace(const XMLCh* const chars, const XMLSize_t length) override;
 
-    if (m_mode==md_Parameter) {
-      m_parameters[m_pname]=m_text; // ignore the type for now...
-    } else if (m_mode==md_Data) {
-      // parse the text
-      std::string entry;
-      for (std::string::iterator q=m_text.begin(); q!=m_text.end(); q++) {
-	if (isspace(*q)) {
-	  if (entry.empty()) continue;
-	  m_items.push_back(entry);
-	  entry="";
-	} else entry+=*q;
-      }
-    }
+private:
+  inline bool cvt2String(const XMLCh* val, std::string& ou) {
+    if (val == nullptr)
+      return false;
+    char* tool = XMLString::transcode(val);
+    ou = tool;
+    XMLString::release(&tool);
+    return true;
+  }
+  XMLCh *xc_Parameter, *xc_Data, *xc_name, *xc_type, *xc_elements, *xc_encoding;
+  std::string m_pname, m_ptype, m_text;
+  int n_elements;
+  std::string& m_dataEncoding;
+  std::vector<std::string>& m_items;
+  std::map<std::string, std::string>& m_parameters;
+  char m_workc[512];
+  XMLCh m_workx[256];
+};
 
-    m_mode=md_Idle;
+void ConfigurationDBHandler::startElement(const XMLCh* const uri,
+                                          const XMLCh* const localname,
+                                          const XMLCh* const qname,
+                                          const Attributes& attrs) {
+  if (m_mode != md_Idle)
+    return;
+  if (!XMLString::compareIString(localname, xc_Parameter)) {
+    // parameter name
+    if (!cvt2String(attrs.getValue(xc_name), m_pname))
+      return;
+    // parameter type
+    if (!cvt2String(attrs.getValue(xc_type), m_ptype))
+      return;
+    // switch mode
+    m_mode = md_Parameter;
+    m_text = "";
+  } else if (!XMLString::compareIString(localname, xc_Data)) {
+    // elements
+    std::string strElements;
+    if (!cvt2String(attrs.getValue(xc_elements), strElements))
+      return;
+    n_elements = atoi(strElements.c_str());
+    // encoding
+    m_dataEncoding = "";
+    cvt2String(attrs.getValue(xc_encoding), m_dataEncoding);
+    // switch mode
+    m_mode = md_Data;
+    m_text = "";
   }
-  void ConfigurationDBHandler::ignorableWhitespace(const   XMLCh* chars, const XMLSize_t length) {
-    if (m_mode==md_Idle) return;
-    m_text+=' ';
-  }
-  void ConfigurationDBHandler::characters(const XMLCh* chars, const XMLSize_t length) {
-    if (m_mode==md_Idle) return;
-    unsigned int offset=0;
-    while (offset<length) {
-      unsigned int i=0;
-      for (i=0; i<length-offset && i<255; i++) m_workx[i]=chars[i+offset];
-      m_workx[i]=0; // terminate string
-      XMLString::transcode(m_workx,m_workc,511);
-      m_text+=m_workc;
-      offset+=i;
-    }
-  }
+}
+void ConfigurationDBHandler::endElement(const XMLCh* const uri,
+                                        const XMLCh* const localname,
+                                        const XMLCh* const qname) {
+  if (m_mode == md_Idle)
+    return;
 
-void HcalPatternXMLParser::parse(const std::string& xmlDocument, std::map<std::string,std::string>& parameters, std::vector<std::string>& items, std::string& encoding) {
-    // uses XERCES SAX2 parser
-    ConfigurationDBHandler handler(parameters,items,encoding);
-    
-    try {
-      if (m_parser==nullptr) {
-	m_parser=new HcalPatternXMLParserImpl();
-	m_parser->parser=std::unique_ptr<xercesc::SAX2XMLReader>(xercesc::XMLReaderFactory::createXMLReader());
-      }
-	 
-      MemBufInputSource src((const unsigned char*)xmlDocument.c_str(), xmlDocument.length(),"hcal::PatternReader");
-      m_parser->parser->setContentHandler(&handler);
-      m_parser->parser->parse(src);
-    } catch (std::exception& ex) {
-      throw cms::Exception("ParseError") << ex.what();
+  if (m_mode == md_Parameter) {
+    m_parameters[m_pname] = m_text;  // ignore the type for now...
+  } else if (m_mode == md_Data) {
+    // parse the text
+    std::string entry;
+    for (std::string::iterator q = m_text.begin(); q != m_text.end(); q++) {
+      if (isspace(*q)) {
+        if (entry.empty())
+          continue;
+        m_items.push_back(entry);
+        entry = "";
+      } else
+        entry += *q;
     }
   }
 
-void HcalPatternXMLParser::parse(const std::string& xmlDocument, std::map<std::string,std::string>& parameters, std::vector<uint32_t>& data) {
+  m_mode = md_Idle;
+}
+void ConfigurationDBHandler::ignorableWhitespace(const XMLCh* chars, const XMLSize_t length) {
+  if (m_mode == md_Idle)
+    return;
+  m_text += ' ';
+}
+void ConfigurationDBHandler::characters(const XMLCh* chars, const XMLSize_t length) {
+  if (m_mode == md_Idle)
+    return;
+  unsigned int offset = 0;
+  while (offset < length) {
+    unsigned int i = 0;
+    for (i = 0; i < length - offset && i < 255; i++)
+      m_workx[i] = chars[i + offset];
+    m_workx[i] = 0;  // terminate string
+    XMLString::transcode(m_workx, m_workc, 511);
+    m_text += m_workc;
+    offset += i;
+  }
+}
+
+void HcalPatternXMLParser::parse(const std::string& xmlDocument,
+                                 std::map<std::string, std::string>& parameters,
+                                 std::vector<std::string>& items,
+                                 std::string& encoding) {
+  // uses XERCES SAX2 parser
+  ConfigurationDBHandler handler(parameters, items, encoding);
+
+  try {
+    if (m_parser == nullptr) {
+      m_parser = new HcalPatternXMLParserImpl();
+      m_parser->parser = std::unique_ptr<xercesc::SAX2XMLReader>(xercesc::XMLReaderFactory::createXMLReader());
+    }
+
+    MemBufInputSource src((const unsigned char*)xmlDocument.c_str(), xmlDocument.length(), "hcal::PatternReader");
+    m_parser->parser->setContentHandler(&handler);
+    m_parser->parser->parse(src);
+  } catch (std::exception& ex) {
+    throw cms::Exception("ParseError") << ex.what();
+  }
+}
+
+void HcalPatternXMLParser::parse(const std::string& xmlDocument,
+                                 std::map<std::string, std::string>& parameters,
+                                 std::vector<uint32_t>& data) {
   std::vector<std::string> items;
   std::string encoding;
 
-  this->parse(xmlDocument,parameters,items,encoding);
-  int formatting=0;
-  if (encoding=="dec") formatting=10;
-  if (encoding=="hex") formatting=16;
+  this->parse(xmlDocument, parameters, items, encoding);
+  int formatting = 0;
+  if (encoding == "dec")
+    formatting = 10;
+  if (encoding == "hex")
+    formatting = 16;
 
   data.clear();
-  for (std::vector<std::string>::const_iterator i=items.begin(); i!=items.end(); i++)
-    data.push_back(strtol(i->c_str(),nullptr,formatting));
-
+  for (std::vector<std::string>::const_iterator i = items.begin(); i != items.end(); i++)
+    data.push_back(strtol(i->c_str(), nullptr, formatting));
 }

--- a/IORawData/CaloPatterns/src/HtrXmlPattern.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPattern.cc
@@ -10,163 +10,165 @@
 #include "HtrXmlPatternTool.h"
 #include "HtrXmlPatternToolParameters.h"
 
-HtrXmlPattern::HtrXmlPattern(const edm::ParameterSet& iConfig)
-{
-  m_filled=false;
-  m_fill_by_hand        = iConfig.getUntrackedParameter<bool>("fill_by_hand");
-  m_hand_pattern_number = iConfig.getUntrackedParameter<int> ("hand_pattern_number");
-  m_sets_to_show        = iConfig.getUntrackedParameter<int> ("sets_to_show");
-  m_write_root_file     = iConfig.getUntrackedParameter<bool>("write_root_file");
+HtrXmlPattern::HtrXmlPattern(const edm::ParameterSet& iConfig) {
+  m_filled = false;
+  m_fill_by_hand = iConfig.getUntrackedParameter<bool>("fill_by_hand");
+  m_hand_pattern_number = iConfig.getUntrackedParameter<int>("hand_pattern_number");
+  m_sets_to_show = iConfig.getUntrackedParameter<int>("sets_to_show");
+  m_write_root_file = iConfig.getUntrackedParameter<bool>("write_root_file");
 
   m_toolparameters = new HtrXmlPatternToolParameters;
-  m_toolparameters->m_show_errors            = iConfig.getUntrackedParameter<bool>       ("show_errors");
-  m_toolparameters->m_presamples_per_event   = iConfig.getUntrackedParameter<int>        ("presamples_per_event");
-  m_toolparameters->m_samples_per_event      = iConfig.getUntrackedParameter<int>        ("samples_per_event");
+  m_toolparameters->m_show_errors = iConfig.getUntrackedParameter<bool>("show_errors");
+  m_toolparameters->m_presamples_per_event = iConfig.getUntrackedParameter<int>("presamples_per_event");
+  m_toolparameters->m_samples_per_event = iConfig.getUntrackedParameter<int>("samples_per_event");
 
-  m_toolparameters->m_XML_file_mode          = iConfig.getUntrackedParameter<int>        ("XML_file_mode");
-  m_toolparameters->m_file_tag               = iConfig.getUntrackedParameter<std::string>("file_tag");
-  m_toolparameters->m_user_output_directory  = iConfig.getUntrackedParameter<std::string>("user_output_directory");
+  m_toolparameters->m_XML_file_mode = iConfig.getUntrackedParameter<int>("XML_file_mode");
+  m_toolparameters->m_file_tag = iConfig.getUntrackedParameter<std::string>("file_tag");
+  m_toolparameters->m_user_output_directory = iConfig.getUntrackedParameter<std::string>("user_output_directory");
 
-  std::string out_dir=m_toolparameters->m_user_output_directory;
-  while (out_dir.find_last_of('/')==out_dir.length()-1) out_dir.erase(out_dir.find_last_of('/'));
-  m_toolparameters->m_output_directory=out_dir+"/"+(m_toolparameters->m_file_tag)+"/";
+  std::string out_dir = m_toolparameters->m_user_output_directory;
+  while (out_dir.find_last_of('/') == out_dir.length() - 1)
+    out_dir.erase(out_dir.find_last_of('/'));
+  m_toolparameters->m_output_directory = out_dir + "/" + (m_toolparameters->m_file_tag) + "/";
 
   m_tool = new HtrXmlPatternTool(m_toolparameters);
 }
 
-
-HtrXmlPattern::~HtrXmlPattern()
-{
+HtrXmlPattern::~HtrXmlPattern() {
   delete m_tool;
   delete m_toolparameters;
 }
 
 // ------------ method called to for each event  ------------
-void HtrXmlPattern::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace std;
+void HtrXmlPattern::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace std;
 
-   if (m_filled) return;
+  if (m_filled)
+    return;
 
-   edm::ESHandle<HcalDbService> pSetup;
-   iSetup.get<HcalDbRecord>().get( pSetup );
-   const HcalElectronicsMap* readoutMap=pSetup->getHcalMapping();
+  edm::ESHandle<HcalDbService> pSetup;
+  iSetup.get<HcalDbRecord>().get(pSetup);
+  const HcalElectronicsMap* readoutMap = pSetup->getHcalMapping();
 
-   if (m_fill_by_hand) {
-     do_hand_fill(readoutMap);
-     m_filled=true;
-     return;
-   }
-  
-   std::vector<edm::Handle<HBHEDigiCollection> > hbhe;
-   std::vector<edm::Handle<HODigiCollection> > ho;
-   std::vector<edm::Handle<HFDigiCollection> > hf;
-   std::vector<edm::Handle<ZDCDigiCollection> > zdc;
-   std::vector<edm::Handle<HcalCalibDigiCollection> > hc;
-   std::vector<edm::Handle<HcalTrigPrimDigiCollection> > htp;
-   std::vector<edm::Handle<HcalHistogramDigiCollection> > hh;  
-
-   iEvent.getManyByType(hbhe);
-   if (hbhe.empty()) {
-     cout << "No HB/HE Digis." << endl;
-   } else {
-     std::vector<edm::Handle<HBHEDigiCollection> >::iterator i;
-     for (i=hbhe.begin(); i!=hbhe.end(); i++) {
-       const HBHEDigiCollection& c=*(*i);
-   
-       int count=0;
-       for (HBHEDigiCollection::const_iterator j=c.begin(); j!=c.end(); j++) {
-   	 const HcalElectronicsId HEID = readoutMap->lookup(j->id());
-   	 m_tool->Fill(HEID,j);
-
-   	 if ( count++<m_sets_to_show || m_sets_to_show<0 ) {
-   	   cout << *j << std::endl;
-   	   cout << HEID << endl;
-   	   cout << "count: " << count << endl;
-   	 }
-       }
-       if (m_sets_to_show!=0) cout << "HB/HE count: " << count << endl;
-     }
+  if (m_fill_by_hand) {
+    do_hand_fill(readoutMap);
+    m_filled = true;
+    return;
   }
-  
-   iEvent.getManyByType(hf);
-   if (hf.empty()) {
-     cout << "No HF Digis." << endl;
+
+  std::vector<edm::Handle<HBHEDigiCollection> > hbhe;
+  std::vector<edm::Handle<HODigiCollection> > ho;
+  std::vector<edm::Handle<HFDigiCollection> > hf;
+  std::vector<edm::Handle<ZDCDigiCollection> > zdc;
+  std::vector<edm::Handle<HcalCalibDigiCollection> > hc;
+  std::vector<edm::Handle<HcalTrigPrimDigiCollection> > htp;
+  std::vector<edm::Handle<HcalHistogramDigiCollection> > hh;
+
+  iEvent.getManyByType(hbhe);
+  if (hbhe.empty()) {
+    cout << "No HB/HE Digis." << endl;
   } else {
-     std::vector<edm::Handle<HFDigiCollection> >::iterator i;
-     for (i=hf.begin(); i!=hf.end(); i++) {
-       const HFDigiCollection& c=*(*i);
-   
-       int count=0;
-       for (HFDigiCollection::const_iterator j=c.begin(); j!=c.end(); j++) {
-   	 const HcalElectronicsId HEID = readoutMap->lookup(j->id());
-   	 m_tool->Fill(HEID,j);
-   	 
-   	 if ( count++<m_sets_to_show || m_sets_to_show<0 ) {
-   	   cout << *j << std::endl;
-   	   cout << HEID << endl;
-   	   cout << "count: " << count << endl;
-   	 }
-       }
-       if (m_sets_to_show!=0) cout << "HF    count: " << count << endl;
-     }
-  }
-   
-   iEvent.getManyByType(ho);
-   if (ho.empty()) {
-     cout << "No HO Digis." << endl;
-  } else {
-     std::vector<edm::Handle<HODigiCollection> >::iterator i;
-     for (i=ho.begin(); i!=ho.end(); i++) {
-       const HODigiCollection& c=*(*i);
-       
-       int count=0;
-       for (HODigiCollection::const_iterator j=c.begin(); j!=c.end(); j++) {
-   	 const HcalElectronicsId HEID = readoutMap->lookup(j->id());
-   	 m_tool->Fill(HEID,j);
-   	 
-   	 if ( count++<m_sets_to_show || m_sets_to_show<0 ) {
-   	   cout << *j << std::endl;
-   	   cout << HEID << endl;
-   	   cout << "count: " << count << endl;
-   	 }
-       }
-       if (m_sets_to_show!=0) cout << "HO    count: " << count << endl;
-     }
-  }
+    std::vector<edm::Handle<HBHEDigiCollection> >::iterator i;
+    for (i = hbhe.begin(); i != hbhe.end(); i++) {
+      const HBHEDigiCollection& c = *(*i);
 
-   cout << endl;    
+      int count = 0;
+      for (HBHEDigiCollection::const_iterator j = c.begin(); j != c.end(); j++) {
+        const HcalElectronicsId HEID = readoutMap->lookup(j->id());
+        m_tool->Fill(HEID, j);
 
-}
-
-
-void HtrXmlPattern::do_hand_fill(const HcalElectronicsMap *emap)
-{
-  HtrXmlPatternSet *hxps=m_tool->GetPatternSet();
-
-  for (int iCrate=0;iCrate<ChannelPattern::NUM_CRATES;iCrate++) {
-    CrateData *cd=hxps->getCrate(iCrate);
-    if (!cd) continue;
-    for (int iSlot=0;iSlot<ChannelPattern::NUM_SLOTS;iSlot++) {
-      for (int iTb=0;iTb<2;iTb++) {
-	HalfHtrData* hhd=cd->getHalfHtrData(iSlot,iTb);
-	if (!hhd) continue;
-	for (int iChannel=1;iChannel<25;iChannel++) {
-	  ChannelPattern *cp=hhd->getPattern(iChannel);
-	  if (!cp) continue;
-	  cp->Fill_by_hand(emap,m_hand_pattern_number);
-	}
-      }      
+        if (count++ < m_sets_to_show || m_sets_to_show < 0) {
+          cout << *j << std::endl;
+          cout << HEID << endl;
+          cout << "count: " << count << endl;
+        }
+      }
+      if (m_sets_to_show != 0)
+        cout << "HB/HE count: " << count << endl;
     }
   }
 
+  iEvent.getManyByType(hf);
+  if (hf.empty()) {
+    cout << "No HF Digis." << endl;
+  } else {
+    std::vector<edm::Handle<HFDigiCollection> >::iterator i;
+    for (i = hf.begin(); i != hf.end(); i++) {
+      const HFDigiCollection& c = *(*i);
+
+      int count = 0;
+      for (HFDigiCollection::const_iterator j = c.begin(); j != c.end(); j++) {
+        const HcalElectronicsId HEID = readoutMap->lookup(j->id());
+        m_tool->Fill(HEID, j);
+
+        if (count++ < m_sets_to_show || m_sets_to_show < 0) {
+          cout << *j << std::endl;
+          cout << HEID << endl;
+          cout << "count: " << count << endl;
+        }
+      }
+      if (m_sets_to_show != 0)
+        cout << "HF    count: " << count << endl;
+    }
+  }
+
+  iEvent.getManyByType(ho);
+  if (ho.empty()) {
+    cout << "No HO Digis." << endl;
+  } else {
+    std::vector<edm::Handle<HODigiCollection> >::iterator i;
+    for (i = ho.begin(); i != ho.end(); i++) {
+      const HODigiCollection& c = *(*i);
+
+      int count = 0;
+      for (HODigiCollection::const_iterator j = c.begin(); j != c.end(); j++) {
+        const HcalElectronicsId HEID = readoutMap->lookup(j->id());
+        m_tool->Fill(HEID, j);
+
+        if (count++ < m_sets_to_show || m_sets_to_show < 0) {
+          cout << *j << std::endl;
+          cout << HEID << endl;
+          cout << "count: " << count << endl;
+        }
+      }
+      if (m_sets_to_show != 0)
+        cout << "HO    count: " << count << endl;
+    }
+  }
+
+  cout << endl;
+}
+
+void HtrXmlPattern::do_hand_fill(const HcalElectronicsMap* emap) {
+  HtrXmlPatternSet* hxps = m_tool->GetPatternSet();
+
+  for (int iCrate = 0; iCrate < ChannelPattern::NUM_CRATES; iCrate++) {
+    CrateData* cd = hxps->getCrate(iCrate);
+    if (!cd)
+      continue;
+    for (int iSlot = 0; iSlot < ChannelPattern::NUM_SLOTS; iSlot++) {
+      for (int iTb = 0; iTb < 2; iTb++) {
+        HalfHtrData* hhd = cd->getHalfHtrData(iSlot, iTb);
+        if (!hhd)
+          continue;
+        for (int iChannel = 1; iChannel < 25; iChannel++) {
+          ChannelPattern* cp = hhd->getPattern(iChannel);
+          if (!cp)
+            continue;
+          cp->Fill_by_hand(emap, m_hand_pattern_number);
+        }
+      }
+    }
+  }
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-HtrXmlPattern::endJob() {
-  bool modeg0=m_toolparameters->m_XML_file_mode>0;
-  if (modeg0 || m_write_root_file) m_tool->prepareDirs();
-  if (modeg0)                      m_tool->writeXML();
-  if (m_write_root_file)           m_tool->createHists();
+void HtrXmlPattern::endJob() {
+  bool modeg0 = m_toolparameters->m_XML_file_mode > 0;
+  if (modeg0 || m_write_root_file)
+    m_tool->prepareDirs();
+  if (modeg0)
+    m_tool->writeXML();
+  if (m_write_root_file)
+    m_tool->createHists();
 }

--- a/IORawData/CaloPatterns/src/HtrXmlPattern.h
+++ b/IORawData/CaloPatterns/src/HtrXmlPattern.h
@@ -20,17 +20,17 @@
 
 class HtrXmlPattern : public edm::EDAnalyzer {
 public:
-  explicit HtrXmlPattern(const edm::ParameterSet&);
+  explicit HtrXmlPattern(const edm::ParameterSet &);
   ~HtrXmlPattern() override;
 
 private:
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
-  virtual void do_hand_fill(const HcalElectronicsMap*);
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void endJob() override;
+  virtual void do_hand_fill(const HcalElectronicsMap *);
   HtrXmlPatternTool *m_tool;
   HtrXmlPatternToolParameters *m_toolparameters;
-  int  m_sets_to_show;
-  int  m_hand_pattern_number;
+  int m_sets_to_show;
+  int m_hand_pattern_number;
   bool m_fill_by_hand;
   bool m_filled;
   bool m_write_root_file;

--- a/IORawData/CaloPatterns/src/HtrXmlPatternSet.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternSet.cc
@@ -3,64 +3,94 @@
 #include <iostream>
 
 ChannelPattern::ChannelPattern() {
-  for (int i=0; i<SAMPLES; i++) {
-    fCReal[i]=0;
-    fCCoded[i]=0;
-    fCQuantized[i]=0;
+  for (int i = 0; i < SAMPLES; i++) {
+    fCReal[i] = 0;
+    fCCoded[i] = 0;
+    fCQuantized[i] = 0;
   }
-  m_sample_pos=0;
+  m_sample_pos = 0;
 }
 
-void ChannelPattern::Fill_by_hand(const HcalElectronicsMap *emap,int pattern_number) {
-
-  for (int iSample=0;iSample<SAMPLES;iSample++) {
-    fCCoded    [iSample]=0;
-    fCQuantized[iSample]=0;
+void ChannelPattern::Fill_by_hand(const HcalElectronicsMap* emap, int pattern_number) {
+  for (int iSample = 0; iSample < SAMPLES; iSample++) {
+    fCCoded[iSample] = 0;
+    fCQuantized[iSample] = 0;
   }
 
   int dcc9[NUM_CRATES];
   int dcc19[NUM_CRATES];
-  for (int jCrate=0;jCrate<NUM_CRATES;jCrate++) {
-    dcc9[jCrate]=-1;
-    dcc19[jCrate]=-1;
+  for (int jCrate = 0; jCrate < NUM_CRATES; jCrate++) {
+    dcc9[jCrate] = -1;
+    dcc19[jCrate] = -1;
   }
 
   int iCrate;
-  iCrate=4 ; dcc9[iCrate]=700; dcc19[iCrate]=701;
-  iCrate=0 ; dcc9[iCrate]=702; dcc19[iCrate]=703;
-  iCrate=1 ; dcc9[iCrate]=704; dcc19[iCrate]=705;
-  iCrate=5 ; dcc9[iCrate]=706; dcc19[iCrate]=707;
-  iCrate=11; dcc9[iCrate]=708; dcc19[iCrate]=709;
-  iCrate=15; dcc9[iCrate]=710; dcc19[iCrate]=711;
-  iCrate=17; dcc9[iCrate]=712; dcc19[iCrate]=713;
-  iCrate=14; dcc9[iCrate]=714; dcc19[iCrate]=715;
-  iCrate=10; dcc9[iCrate]=716; dcc19[iCrate]=717;
-  iCrate=2 ; dcc9[iCrate]=718; dcc19[iCrate]=719;
-  iCrate=9 ; dcc9[iCrate]=720; dcc19[iCrate]=721;
-  iCrate=12; dcc9[iCrate]=722; dcc19[iCrate]=723;
-  iCrate=3 ; dcc9[iCrate]=724; dcc19[iCrate]=725;
-  iCrate=7 ; dcc9[iCrate]=726; dcc19[iCrate]=727;
-  iCrate=6 ; dcc9[iCrate]=728; dcc19[iCrate]=729;
-  iCrate=13; dcc9[iCrate]=730; dcc19[iCrate]=731;
+  iCrate = 4;
+  dcc9[iCrate] = 700;
+  dcc19[iCrate] = 701;
+  iCrate = 0;
+  dcc9[iCrate] = 702;
+  dcc19[iCrate] = 703;
+  iCrate = 1;
+  dcc9[iCrate] = 704;
+  dcc19[iCrate] = 705;
+  iCrate = 5;
+  dcc9[iCrate] = 706;
+  dcc19[iCrate] = 707;
+  iCrate = 11;
+  dcc9[iCrate] = 708;
+  dcc19[iCrate] = 709;
+  iCrate = 15;
+  dcc9[iCrate] = 710;
+  dcc19[iCrate] = 711;
+  iCrate = 17;
+  dcc9[iCrate] = 712;
+  dcc19[iCrate] = 713;
+  iCrate = 14;
+  dcc9[iCrate] = 714;
+  dcc19[iCrate] = 715;
+  iCrate = 10;
+  dcc9[iCrate] = 716;
+  dcc19[iCrate] = 717;
+  iCrate = 2;
+  dcc9[iCrate] = 718;
+  dcc19[iCrate] = 719;
+  iCrate = 9;
+  dcc9[iCrate] = 720;
+  dcc19[iCrate] = 721;
+  iCrate = 12;
+  dcc9[iCrate] = 722;
+  dcc19[iCrate] = 723;
+  iCrate = 3;
+  dcc9[iCrate] = 724;
+  dcc19[iCrate] = 725;
+  iCrate = 7;
+  dcc9[iCrate] = 726;
+  dcc19[iCrate] = 727;
+  iCrate = 6;
+  dcc9[iCrate] = 728;
+  dcc19[iCrate] = 729;
+  iCrate = 13;
+  dcc9[iCrate] = 730;
+  dcc19[iCrate] = 731;
 
-  int *dcc=nullptr;
-  int spigot=-100;
-  if (m_slot>=2 && m_slot<=8) {
-    spigot=2*m_slot-m_tb-3;
-    dcc=dcc9;
-  }
-  else if (m_slot>=13 && m_slot<=18) {
-    spigot=2*m_slot-m_tb-25;
-    dcc=dcc19;
-  }
-  else return;
+  int* dcc = nullptr;
+  int spigot = -100;
+  if (m_slot >= 2 && m_slot <= 8) {
+    spigot = 2 * m_slot - m_tb - 3;
+    dcc = dcc9;
+  } else if (m_slot >= 13 && m_slot <= 18) {
+    spigot = 2 * m_slot - m_tb - 25;
+    dcc = dcc19;
+  } else
+    return;
 
-  int fiber_channel=(m_chan-1)%3;
-  int fiber=(m_chan-fiber_channel-1)/3 +1;
-  int dcc_num=dcc[m_crate]-700;
+  int fiber_channel = (m_chan - 1) % 3;
+  int fiber = (m_chan - fiber_channel - 1) / 3 + 1;
+  int dcc_num = dcc[m_crate] - 700;
 
-  HcalElectronicsId heid(fiber_channel,fiber,spigot,dcc_num);
-  heid.setHTR(m_crate,m_slot,m_tb);
+  HcalElectronicsId heid(fiber_channel, fiber, spigot, dcc_num);
+  heid.setHTR(m_crate, m_slot, m_tb);
 
   //if (heid.readoutVMECrateId()!=m_crate) std::cout << "crate: " << heid.readoutVMECrateId() << "; " << m_crate << std::endl;
   //if (heid.htrSlot()!=m_slot) std::cout << "slot:  " << heid.htrSlot() << "; " << m_slot << std::endl;
@@ -72,173 +102,199 @@ void ChannelPattern::Fill_by_hand(const HcalElectronicsMap *emap,int pattern_num
   //}
 
   try {
-    const HcalDetId hdid=emap->lookup(heid);
+    const HcalDetId hdid = emap->lookup(heid);
 
-    int etaabs=hdid.ietaAbs();
-    int phi=hdid.iphi();
-    int side=hdid.zside();
-    int depth=hdid.depth();
-    int subdet=hdid.subdet();
+    int etaabs = hdid.ietaAbs();
+    int phi = hdid.iphi();
+    int side = hdid.zside();
+    int depth = hdid.depth();
+    int subdet = hdid.subdet();
 
     ///////////////////////////////
-    if (pattern_number==1) {
-      if (m_crate==2 || m_crate==9 || m_crate==12) return;
+    if (pattern_number == 1) {
+      if (m_crate == 2 || m_crate == 9 || m_crate == 12)
+        return;
       //fill only one channel per half-crate
-      if (m_slot!=2 && m_slot!=13) return;
-      if (m_tb!=0) return;
-      if (m_chan!=5) return;
-  
+      if (m_slot != 2 && m_slot != 13)
+        return;
+      if (m_tb != 0)
+        return;
+      if (m_chan != 5)
+        return;
+
       //put some data here
-      fCCoded[31]=17;
+      fCCoded[31] = 17;
     }
     ///////////////////////////////
-    if (pattern_number==2) {
-      if (depth>1) return;
-      if (subdet==4 && etaabs<30) return;
-      
-      if ((etaabs+2)%4!=0) return;
-      int i=(etaabs+2)/4;
-      if (i<1 || i>7) return;
-      
-      if ((phi+3)%4!=0) return;
-      int j=(phi+3)/4;
-      if (j<1 || j>18) return;
-      
+    if (pattern_number == 2) {
+      if (depth > 1)
+        return;
+      if (subdet == 4 && etaabs < 30)
+        return;
+
+      if ((etaabs + 2) % 4 != 0)
+        return;
+      int i = (etaabs + 2) / 4;
+      if (i < 1 || i > 7)
+        return;
+
+      if ((phi + 3) % 4 != 0)
+        return;
+      int j = (phi + 3) / 4;
+      if (j < 1 || j > 18)
+        return;
+
       //add one to BX?
-      if (side<0) fCCoded[phi+10]=i;
-      if (side>0) fCCoded[phi+10]=i+16;
+      if (side < 0)
+        fCCoded[phi + 10] = i;
+      if (side > 0)
+        fCCoded[phi + 10] = i + 16;
     }
     ///////////////////////////////
-    if (pattern_number==3) {
-      if (depth>1 || etaabs!=18 || side!=1 || phi!=32) return;
+    if (pattern_number == 3) {
+      if (depth > 1 || etaabs != 18 || side != 1 || phi != 32)
+        return;
       std::cout << "hello" << std::endl;
       //add one to BX?
-      if (side>0) fCCoded[15]=20;
+      if (side > 0)
+        fCCoded[15] = 20;
     }
-    
+
+  } catch (...) {
+    return;
   }
-  catch (...) {return;}
 }
 
-void ChannelPattern::Fill(HtrXmlPatternToolParameters* params,HBHEDigiCollection::const_iterator data) {
+void ChannelPattern::Fill(HtrXmlPatternToolParameters* params, HBHEDigiCollection::const_iterator data) {
   //first fill with pedestal value (currently hard-coded to 0)
-  for (int samples=0; samples<params->m_samples_per_event; samples++) {
+  for (int samples = 0; samples < params->m_samples_per_event; samples++) {
     int index = m_sample_pos + samples;
-    if (index>=SAMPLES) continue;
+    if (index >= SAMPLES)
+      continue;
 
-    fCCoded    [index] = 0;
+    fCCoded[index] = 0;
     fCQuantized[index] = 0;
   }
 
   //now fill with actual samples
-  for (int samples=0; samples<data->size(); samples++) {
+  for (int samples = 0; samples < data->size(); samples++) {
     int index = m_sample_pos + params->m_presamples_per_event - data->presamples() + samples;
-    if (index<m_sample_pos || 
-	index>=(m_sample_pos+params->m_samples_per_event) ||
-	index>=SAMPLES) continue;
+    if (index < m_sample_pos || index >= (m_sample_pos + params->m_samples_per_event) || index >= SAMPLES)
+      continue;
 
-    fCCoded    [index] = data->sample(samples).adc();
+    fCCoded[index] = data->sample(samples).adc();
     fCQuantized[index] = data->sample(samples).nominal_fC();
   }
-  
-  m_sample_pos+=params->m_samples_per_event;
+
+  m_sample_pos += params->m_samples_per_event;
 }
 
-void ChannelPattern::Fill(HtrXmlPatternToolParameters* params,HFDigiCollection::const_iterator data) {
+void ChannelPattern::Fill(HtrXmlPatternToolParameters* params, HFDigiCollection::const_iterator data) {
   //first fill with pedestal value (currently hard-coded to 0)
-  for (int samples=0; samples<params->m_samples_per_event; samples++) {
+  for (int samples = 0; samples < params->m_samples_per_event; samples++) {
     int index = m_sample_pos + samples;
-    if (index>=SAMPLES) continue;
+    if (index >= SAMPLES)
+      continue;
 
-    fCCoded    [index] = 0;
+    fCCoded[index] = 0;
     fCQuantized[index] = 0;
   }
 
   //now fill with actual samples
-  for (int samples=0; samples<data->size(); samples++) {
+  for (int samples = 0; samples < data->size(); samples++) {
     int index = m_sample_pos + params->m_presamples_per_event - data->presamples() + samples;
-    if (index<m_sample_pos || 
-	index>=(m_sample_pos+params->m_samples_per_event) ||
-	index>=SAMPLES) continue;
+    if (index < m_sample_pos || index >= (m_sample_pos + params->m_samples_per_event) || index >= SAMPLES)
+      continue;
 
-    fCCoded    [index] = data->sample(samples).adc();
+    fCCoded[index] = data->sample(samples).adc();
     fCQuantized[index] = data->sample(samples).nominal_fC();
   }
-  
-  m_sample_pos+=params->m_samples_per_event;
+
+  m_sample_pos += params->m_samples_per_event;
 }
 
-void ChannelPattern::Fill(HtrXmlPatternToolParameters* params,HODigiCollection::const_iterator data) {
+void ChannelPattern::Fill(HtrXmlPatternToolParameters* params, HODigiCollection::const_iterator data) {
   //first fill with pedestal value (currently hard-coded to 0)
-  for (int samples=0; samples<params->m_samples_per_event; samples++) {
+  for (int samples = 0; samples < params->m_samples_per_event; samples++) {
     int index = m_sample_pos + samples;
-    if (index>=SAMPLES) continue;
+    if (index >= SAMPLES)
+      continue;
 
-    fCCoded    [index] = 0;
+    fCCoded[index] = 0;
     fCQuantized[index] = 0;
   }
 
   //now fill with actual samples
-  for (int samples=0; samples<data->size(); samples++) {
+  for (int samples = 0; samples < data->size(); samples++) {
     int index = m_sample_pos + params->m_presamples_per_event - data->presamples() + samples;
-    if (index<m_sample_pos || 
-	index>=(m_sample_pos+params->m_samples_per_event) ||
-	index>=SAMPLES) continue;
+    if (index < m_sample_pos || index >= (m_sample_pos + params->m_samples_per_event) || index >= SAMPLES)
+      continue;
 
-    fCCoded    [index] = data->sample(samples).adc();
+    fCCoded[index] = data->sample(samples).adc();
     fCQuantized[index] = data->sample(samples).nominal_fC();
   }
-  
-  m_sample_pos+=params->m_samples_per_event;
+
+  m_sample_pos += params->m_samples_per_event;
 }
 
 HalfHtrData::HalfHtrData(int crate, int slot, int tb) {
-  for (int i=0; i<24; i++)
-    m_patterns[i].setLoc(crate,slot,tb,i+1);
-  m_crate=crate;
-  m_slot=slot;
-  m_tb=tb;
+  for (int i = 0; i < 24; i++)
+    m_patterns[i].setLoc(crate, slot, tb, i + 1);
+  m_crate = crate;
+  m_slot = slot;
+  m_tb = tb;
   //these are set later with map data
-  m_dcc=0;
-  m_spigot=0;
+  m_dcc = 0;
+  m_spigot = 0;
 }
 
 CrateData::CrateData(int crate, int slotsActive[ChannelPattern::NUM_SLOTS]) {
-  for (int slot=0; slot<ChannelPattern::NUM_SLOTS; slot++) {
-    for (int tb=0;tb<2;tb++) {
-      if (slotsActive[slot]) m_slotsDoubled[slot][tb] = new HalfHtrData(crate,slot,tb);
-      else                   m_slotsDoubled[slot][tb] = nullptr;
+  for (int slot = 0; slot < ChannelPattern::NUM_SLOTS; slot++) {
+    for (int tb = 0; tb < 2; tb++) {
+      if (slotsActive[slot])
+        m_slotsDoubled[slot][tb] = new HalfHtrData(crate, slot, tb);
+      else
+        m_slotsDoubled[slot][tb] = nullptr;
     }
   }
 }
 
 CrateData::~CrateData() {
-  for (int slot=0; slot<ChannelPattern::NUM_SLOTS; slot++) {
-    for (int tb=0;tb<2;tb++) {
-      if (m_slotsDoubled[slot][tb]) delete m_slotsDoubled[slot][tb];
+  for (int slot = 0; slot < ChannelPattern::NUM_SLOTS; slot++) {
+    for (int tb = 0; tb < 2; tb++) {
+      if (m_slotsDoubled[slot][tb])
+        delete m_slotsDoubled[slot][tb];
     }
   }
 }
 
 HalfHtrData* CrateData::getHalfHtrData(int slot, int tb) {
-  if ( slot>=0 && slot<ChannelPattern::NUM_SLOTS && (tb==0 || tb==1) ) return m_slotsDoubled[slot][tb];
-  else return nullptr;
+  if (slot >= 0 && slot < ChannelPattern::NUM_SLOTS && (tb == 0 || tb == 1))
+    return m_slotsDoubled[slot][tb];
+  else
+    return nullptr;
 }
 
-HtrXmlPatternSet::HtrXmlPatternSet(int cratesActive[ChannelPattern::NUM_CRATES], int slotsActive[ChannelPattern::NUM_SLOTS]) {
-  for (int crate=0; crate<ChannelPattern::NUM_CRATES; crate++) {
-    if (cratesActive[crate]) m_crates[crate] = new CrateData(crate,slotsActive);
-    else                     m_crates[crate] = nullptr;
+HtrXmlPatternSet::HtrXmlPatternSet(int cratesActive[ChannelPattern::NUM_CRATES],
+                                   int slotsActive[ChannelPattern::NUM_SLOTS]) {
+  for (int crate = 0; crate < ChannelPattern::NUM_CRATES; crate++) {
+    if (cratesActive[crate])
+      m_crates[crate] = new CrateData(crate, slotsActive);
+    else
+      m_crates[crate] = nullptr;
   }
 }
 
 HtrXmlPatternSet::~HtrXmlPatternSet() {
-  for (int crate=0; crate<ChannelPattern::NUM_CRATES; crate++) {
-    if (m_crates[crate]) delete m_crates[crate];
+  for (int crate = 0; crate < ChannelPattern::NUM_CRATES; crate++) {
+    if (m_crates[crate])
+      delete m_crates[crate];
   }
 }
 
 CrateData* HtrXmlPatternSet::getCrate(int crate) {
-  if (crate>=0 && crate<ChannelPattern::NUM_CRATES) return m_crates[crate];
-  else return nullptr;
+  if (crate >= 0 && crate < ChannelPattern::NUM_CRATES)
+    return m_crates[crate];
+  else
+    return nullptr;
 }

--- a/IORawData/CaloPatterns/src/HtrXmlPatternSet.h
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternSet.h
@@ -7,13 +7,18 @@
 
 class ChannelPattern {
 public:
-  static const int SAMPLES    = 512;
-  static const int NUM_CRATES =  18;
+  static const int SAMPLES = 512;
+  static const int NUM_CRATES = 18;
   //this is one larger than it 'needs' to be so that the array index can match the physical slot number
-  static const int NUM_SLOTS  =  22;
+  static const int NUM_SLOTS = 22;
 
   ChannelPattern();
-  void setLoc(int crate, int slot, int tb, int chan) { m_crate=crate; m_slot=slot; m_tb=tb; m_chan=chan; }
+  void setLoc(int crate, int slot, int tb, int chan) {
+    m_crate = crate;
+    m_slot = slot;
+    m_tb = tb;
+    m_chan = chan;
+  }
   int getCrate() const { return m_crate; }
   int getSlot() const { return m_slot; }
   int getTB() const { return m_tb; }
@@ -23,10 +28,11 @@ public:
   void encode();
   int getCoded(int bc) const { return fCCoded[bc]; }
   double getQuantized(int bc) const { return fCQuantized[bc]; }
-  void Fill(HtrXmlPatternToolParameters *params,HBHEDigiCollection::const_iterator data);
-  void Fill(HtrXmlPatternToolParameters *params,HFDigiCollection::const_iterator data);
-  void Fill(HtrXmlPatternToolParameters *params,HODigiCollection::const_iterator data);
-  void Fill_by_hand(const HcalElectronicsMap*,int);
+  void Fill(HtrXmlPatternToolParameters* params, HBHEDigiCollection::const_iterator data);
+  void Fill(HtrXmlPatternToolParameters* params, HFDigiCollection::const_iterator data);
+  void Fill(HtrXmlPatternToolParameters* params, HODigiCollection::const_iterator data);
+  void Fill_by_hand(const HcalElectronicsMap*, int);
+
 private:
   double fCReal[SAMPLES];
   double fCQuantized[SAMPLES];
@@ -38,7 +44,7 @@ private:
 class HalfHtrData {
 public:
   HalfHtrData(int crate, int slot, int tb);
-  ChannelPattern* getPattern(int chan) { return (chan>=1 && chan<=24)?(&m_patterns[chan-1]):(nullptr); }
+  ChannelPattern* getPattern(int chan) { return (chan >= 1 && chan <= 24) ? (&m_patterns[chan - 1]) : (nullptr); }
   int getCrate() const { return m_crate; }
   int getSlot() const { return m_slot; }
   int getTB() const { return m_tb; }
@@ -46,6 +52,7 @@ public:
   int getDCC() const { return m_dcc; }
   void setSpigot(int spigot) { m_spigot = spigot; }
   void setDCC(int dcc) { m_dcc = dcc; }
+
 private:
   ChannelPattern m_patterns[24];
   int m_crate, m_slot, m_tb;
@@ -57,6 +64,7 @@ public:
   CrateData(int crate, int slotsActive[ChannelPattern::NUM_SLOTS]);
   ~CrateData();
   HalfHtrData* getHalfHtrData(int slot, int one_two_tb);
+
 private:
   HalfHtrData* m_slotsDoubled[ChannelPattern::NUM_SLOTS][2];
 };
@@ -66,6 +74,7 @@ public:
   HtrXmlPatternSet(int cratesActive[ChannelPattern::NUM_CRATES], int slotsActive[ChannelPattern::NUM_SLOTS]);
   ~HtrXmlPatternSet();
   CrateData* getCrate(int crate);
+
 private:
   CrateData* m_crates[ChannelPattern::NUM_CRATES];
 };

--- a/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
@@ -12,117 +12,110 @@ HtrXmlPatternTool::HtrXmlPatternTool(HtrXmlPatternToolParameters* params) {
   m_params = params;
 
   //slotsOn array index corresponds to physical number (e.g., slotsOn[1] for slot 1)
-  int slotsOn [ChannelPattern::NUM_SLOTS];
+  int slotsOn[ChannelPattern::NUM_SLOTS];
   int cratesOn[ChannelPattern::NUM_CRATES];
 
   //turn off all slots
-  for (int i=0; i<ChannelPattern::NUM_SLOTS; i++) slotsOn[i]=0;
+  for (int i = 0; i < ChannelPattern::NUM_SLOTS; i++)
+    slotsOn[i] = 0;
   //turn on slots 2,3,4,5,6,7,8
-  for (int i=2; i<9; i++)   slotsOn[i]=1;
+  for (int i = 2; i < 9; i++)
+    slotsOn[i] = 1;
   //turn on slots 13,14,15,16,17,18
-  for (int i=13; i<19; i++) slotsOn[i]=1;
+  for (int i = 13; i < 19; i++)
+    slotsOn[i] = 1;
 
   //turn on all crates
-  for (int i=0; i<ChannelPattern::NUM_CRATES; i++) cratesOn[i]=1;
+  for (int i = 0; i < ChannelPattern::NUM_CRATES; i++)
+    cratesOn[i] = 1;
   //turn off two unused crates
-  cratesOn[ 8] = 0;
+  cratesOn[8] = 0;
   cratesOn[16] = 0;
 
-  m_patternSet=new HtrXmlPatternSet(cratesOn,slotsOn);
+  m_patternSet = new HtrXmlPatternSet(cratesOn, slotsOn);
   m_xmlWriter.setTagName(m_params->m_file_tag);
-
 }
 
-HtrXmlPatternTool::~HtrXmlPatternTool() {
-  delete m_patternSet;
-}
+HtrXmlPatternTool::~HtrXmlPatternTool() { delete m_patternSet; }
 
-void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID,HBHEDigiCollection::const_iterator data) {
-  CrateData* cd=m_patternSet->getCrate(HEID.readoutVMECrateId());
-  HalfHtrData* hd=nullptr;
-  ChannelPattern* cp=nullptr;
+void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID, HBHEDigiCollection::const_iterator data) {
+  CrateData* cd = m_patternSet->getCrate(HEID.readoutVMECrateId());
+  HalfHtrData* hd = nullptr;
+  ChannelPattern* cp = nullptr;
 
   if (cd) {
-    hd=cd->getHalfHtrData(HEID.htrSlot(),HEID.htrTopBottom());
+    hd = cd->getHalfHtrData(HEID.htrSlot(), HEID.htrTopBottom());
     if (hd) {
       hd->setSpigot(HEID.spigot());
       hd->setDCC(HEID.dccid());
 
-      cp=hd->getPattern(HEID.htrChanId());
-      if (cp) cp->Fill(m_params,data);
-      else if(m_params->m_show_errors) std::cerr << "Bad (crate,slot,channel): (" 
-						 << HEID.readoutVMECrateId() << "," 
-						 << HEID.htrSlot()           << "," 
-						 << HEID.htrChanId()         << ")" << std::endl;
-    }
-    else if(m_params->m_show_errors) std::cerr << "Bad (crate,slot): (" 
-					       << HEID.readoutVMECrateId() << "," 
-					       << HEID.htrSlot()           << ")" << std::endl;
-  }
-  else if(m_params->m_show_errors) std::cerr << "Bad (crate): (" << HEID.readoutVMECrateId() << ")" << std::endl;
+      cp = hd->getPattern(HEID.htrChanId());
+      if (cp)
+        cp->Fill(m_params, data);
+      else if (m_params->m_show_errors)
+        std::cerr << "Bad (crate,slot,channel): (" << HEID.readoutVMECrateId() << "," << HEID.htrSlot() << ","
+                  << HEID.htrChanId() << ")" << std::endl;
+    } else if (m_params->m_show_errors)
+      std::cerr << "Bad (crate,slot): (" << HEID.readoutVMECrateId() << "," << HEID.htrSlot() << ")" << std::endl;
+  } else if (m_params->m_show_errors)
+    std::cerr << "Bad (crate): (" << HEID.readoutVMECrateId() << ")" << std::endl;
 }
 
-void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID,HFDigiCollection::const_iterator data) {
-  CrateData* cd=m_patternSet->getCrate(HEID.readoutVMECrateId());
-  HalfHtrData* hd=nullptr;
-  ChannelPattern* cp=nullptr;
+void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID, HFDigiCollection::const_iterator data) {
+  CrateData* cd = m_patternSet->getCrate(HEID.readoutVMECrateId());
+  HalfHtrData* hd = nullptr;
+  ChannelPattern* cp = nullptr;
 
   if (cd) {
-    hd=cd->getHalfHtrData(HEID.htrSlot(),HEID.htrTopBottom());
+    hd = cd->getHalfHtrData(HEID.htrSlot(), HEID.htrTopBottom());
     if (hd) {
       hd->setSpigot(HEID.spigot());
       hd->setDCC(HEID.dccid());
 
-      cp=hd->getPattern(HEID.htrChanId());
-      if (cp) cp->Fill(m_params,data);
-      else if(m_params->m_show_errors) std::cerr << "Bad (crate,slot,channel): (" 
-						 << HEID.readoutVMECrateId() << "," 
-						 << HEID.htrSlot()           << "," 
-						 << HEID.htrChanId()         << ")" << std::endl;
-    }
-    else if(m_params->m_show_errors) std::cerr << "Bad (crate,slot): (" 
-					       << HEID.readoutVMECrateId() << "," 
-					       << HEID.htrSlot()           << ")" << std::endl;
-  }
-  else if(m_params->m_show_errors) std::cerr << "Bad (crate): (" << HEID.readoutVMECrateId() << ")" << std::endl;
+      cp = hd->getPattern(HEID.htrChanId());
+      if (cp)
+        cp->Fill(m_params, data);
+      else if (m_params->m_show_errors)
+        std::cerr << "Bad (crate,slot,channel): (" << HEID.readoutVMECrateId() << "," << HEID.htrSlot() << ","
+                  << HEID.htrChanId() << ")" << std::endl;
+    } else if (m_params->m_show_errors)
+      std::cerr << "Bad (crate,slot): (" << HEID.readoutVMECrateId() << "," << HEID.htrSlot() << ")" << std::endl;
+  } else if (m_params->m_show_errors)
+    std::cerr << "Bad (crate): (" << HEID.readoutVMECrateId() << ")" << std::endl;
 }
 
-void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID,HODigiCollection::const_iterator data) {
-  CrateData* cd=m_patternSet->getCrate(HEID.readoutVMECrateId());
-  HalfHtrData* hd=nullptr;
-  ChannelPattern* cp=nullptr;
+void HtrXmlPatternTool::Fill(const HcalElectronicsId HEID, HODigiCollection::const_iterator data) {
+  CrateData* cd = m_patternSet->getCrate(HEID.readoutVMECrateId());
+  HalfHtrData* hd = nullptr;
+  ChannelPattern* cp = nullptr;
 
   if (cd) {
-    hd=cd->getHalfHtrData(HEID.htrSlot(),HEID.htrTopBottom());
+    hd = cd->getHalfHtrData(HEID.htrSlot(), HEID.htrTopBottom());
     if (hd) {
       hd->setSpigot(HEID.spigot());
       hd->setDCC(HEID.dccid());
 
-      cp=hd->getPattern(HEID.htrChanId());
-      if (cp) cp->Fill(m_params,data);
-      else if(m_params->m_show_errors) std::cerr << "Bad (crate,slot,channel): (" 
-						 << HEID.readoutVMECrateId() << "," 
-						 << HEID.htrSlot()           << "," 
-						 << HEID.htrChanId()         << ")" << std::endl;
-    }
-    else if(m_params->m_show_errors) std::cerr << "Bad (crate,slot): (" 
-					       << HEID.readoutVMECrateId() << "," 
-					       << HEID.htrSlot()           << ")" << std::endl;
-  }
-  else if(m_params->m_show_errors) std::cerr << "Bad (crate): (" << HEID.readoutVMECrateId() << ")" << std::endl;
+      cp = hd->getPattern(HEID.htrChanId());
+      if (cp)
+        cp->Fill(m_params, data);
+      else if (m_params->m_show_errors)
+        std::cerr << "Bad (crate,slot,channel): (" << HEID.readoutVMECrateId() << "," << HEID.htrSlot() << ","
+                  << HEID.htrChanId() << ")" << std::endl;
+    } else if (m_params->m_show_errors)
+      std::cerr << "Bad (crate,slot): (" << HEID.readoutVMECrateId() << "," << HEID.htrSlot() << ")" << std::endl;
+  } else if (m_params->m_show_errors)
+    std::cerr << "Bad (crate): (" << HEID.readoutVMECrateId() << ")" << std::endl;
 }
 
-void HtrXmlPatternTool::prepareDirs() {
-  boost::filesystem::create_directory(m_params->m_output_directory);
-}
+void HtrXmlPatternTool::prepareDirs() { boost::filesystem::create_directory(m_params->m_output_directory); }
 
 void HtrXmlPatternTool::writeXML() {
   std::cout << "Writing XML..." << std::endl;
-  std::ofstream* of=nullptr;
+  std::ofstream* of = nullptr;
 
-  if (m_params->m_XML_file_mode==1) {
-    std::string name=m_params->m_output_directory+(m_params->m_file_tag)+"_all.xml";
-    of=new std::ofstream(name.c_str(),std::ios_base::out|std::ios_base::trunc);
+  if (m_params->m_XML_file_mode == 1) {
+    std::string name = m_params->m_output_directory + (m_params->m_file_tag) + "_all.xml";
+    of = new std::ofstream(name.c_str(), std::ios_base::out | std::ios_base::trunc);
     if (!of->good()) {
       std::cerr << "XML output file " << name << " is bad." << std::endl;
       return;
@@ -131,76 +124,77 @@ void HtrXmlPatternTool::writeXML() {
     (*of) << "<CFGBrickSet name='" << m_params->m_file_tag << "'>" << std::endl;
   }
 
-  for (int crate=0; crate<ChannelPattern::NUM_CRATES; crate++) {
-    CrateData* cd=m_patternSet->getCrate(crate);
-    if (cd==nullptr) continue;
+  for (int crate = 0; crate < ChannelPattern::NUM_CRATES; crate++) {
+    CrateData* cd = m_patternSet->getCrate(crate);
+    if (cd == nullptr)
+      continue;
 
-    if (m_params->m_XML_file_mode==2) {
-      std::string name=m_params->m_output_directory+(m_params->m_file_tag);
+    if (m_params->m_XML_file_mode == 2) {
+      std::string name = m_params->m_output_directory + (m_params->m_file_tag);
       char cr_name[256];
-      snprintf(cr_name,256,"_crate_%d.xml",crate);
+      snprintf(cr_name, 256, "_crate_%d.xml", crate);
       name += cr_name;
-      of=new std::ofstream(name.c_str(),std::ios_base::out|std::ios_base::trunc);
+      of = new std::ofstream(name.c_str(), std::ios_base::out | std::ios_base::trunc);
       if (!of->good()) {
-	std::cerr << "XML output file " << name << " is bad." << std::endl;
-    delete of;
-	return;
+        std::cerr << "XML output file " << name << " is bad." << std::endl;
+        delete of;
+        return;
       }
       (*of) << "<?xml version='1.0' encoding='UTF-8'?>" << std::endl;
       (*of) << "<CFGBrickSet name='" << m_params->m_file_tag << "'>" << std::endl;
     }
 
-    for (int slot=0; slot<ChannelPattern::NUM_SLOTS; slot++) {
-      for (int tb=0; tb<=1; tb++) {
-	HalfHtrData* hd=cd->getHalfHtrData(slot,tb);
-	if (hd==nullptr) continue;
-	for (int fiber=1; fiber<=8; fiber++) {
+    for (int slot = 0; slot < ChannelPattern::NUM_SLOTS; slot++) {
+      for (int tb = 0; tb <= 1; tb++) {
+        HalfHtrData* hd = cd->getHalfHtrData(slot, tb);
+        if (hd == nullptr)
+          continue;
+        for (int fiber = 1; fiber <= 8; fiber++) {
+          if (m_params->m_XML_file_mode == 3) {
+            std::string name = m_params->m_output_directory + (m_params->m_file_tag);
+            char cr_name[256];
+            snprintf(cr_name, 256, "_crate_%d_slot_%d_tb_%d_fiber_%d.xml", crate, slot, tb, fiber);
+            name += cr_name;
+            of = new std::ofstream(name.c_str(), std::ios_base::out | std::ios_base::trunc);
+            if (!of->good()) {
+              std::cerr << "XML output file " << name << " is bad." << std::endl;
+              delete of;
+              return;
+            }
+            (*of) << "<?xml version='1.0' encoding='UTF-8'?>" << std::endl;
+          }
+          m_xmlWriter.writePattern(hd, fiber, *of, 1);
+          if (m_params->m_XML_file_mode == 3) {
+            of->close();
+            delete of;
+            of = nullptr;
+          }
 
-	  if (m_params->m_XML_file_mode==3) {
-	    std::string name=m_params->m_output_directory+(m_params->m_file_tag);
-	    char cr_name[256];
-	    snprintf(cr_name,256,"_crate_%d_slot_%d_tb_%d_fiber_%d.xml",crate,slot,tb,fiber);
-	    name += cr_name;
-	    of=new std::ofstream(name.c_str(),std::ios_base::out|std::ios_base::trunc);
-	    if (!of->good()) {
-	      std::cerr << "XML output file " << name << " is bad." << std::endl;
-          delete of;
-	      return;
-	    }
-	    (*of) << "<?xml version='1.0' encoding='UTF-8'?>" << std::endl;
-	  }
-	  m_xmlWriter.writePattern(hd,fiber,*of,1);
-	  if (m_params->m_XML_file_mode==3) {
-	    of->close();
-	    delete of;
-	    of=nullptr;
-	  }
+        }  //end fiber loop
+      }    // end tb loop
+    }      //end slot loop
 
-	} //end fiber loop
-      } // end tb loop
-    } //end slot loop
-    
-    if (m_params->m_XML_file_mode==2) {
+    if (m_params->m_XML_file_mode == 2) {
       (*of) << "</CFGBrickSet>" << std::endl;
       of->close();
       delete of;
-      of=nullptr;
+      of = nullptr;
     }
-    
-  } //end crate loop
-  
-  if (m_params->m_XML_file_mode==1) {
+
+  }  //end crate loop
+
+  if (m_params->m_XML_file_mode == 1) {
     (*of) << "</CFGBrickSet>" << std::endl;
     of->close();
     delete of;
-    of=nullptr;
+    of = nullptr;
   }
 }
 
 void HtrXmlPatternTool::createHists() {
   std::cout << "Writing root file..." << std::endl;
-  std::string name=m_params->m_output_directory+"/"+(m_params->m_file_tag)+".root";
-  TFile of(name.c_str(),"RECREATE");
+  std::string name = m_params->m_output_directory + "/" + (m_params->m_file_tag) + ".root";
+  TFile of(name.c_str(), "RECREATE");
   if (of.IsZombie()) {
     std::cerr << "root output file " << name << " is bad." << std::endl;
     return;
@@ -208,40 +202,40 @@ void HtrXmlPatternTool::createHists() {
 
   of.mkdir("adc");
 
-  for (int crate=0; crate<ChannelPattern::NUM_CRATES; crate++) {
-    CrateData* cd=m_patternSet->getCrate(crate);
-    if (cd==nullptr) continue;
-    for (int slot=0; slot<ChannelPattern::NUM_SLOTS; slot++) {
-      for (int tb=0; tb<=1; tb++) {
-	HalfHtrData* hd=cd->getHalfHtrData(slot,tb);
-	if (hd==nullptr) continue;
-	for (int chan=1; chan<=24; chan++) {
-	  ChannelPattern* cp=hd->getPattern(chan);
-	  char hname[128];
-	  sprintf(hname,"Exact fC Cr%d,%d%s-%d",crate,slot,
-		  ((tb==1)?("t"):("b")),chan);
-	  TH1* hp=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  hp->SetDirectory(nullptr);
-	  sprintf(hname,"Quantized fC Cr%d,%d%s-%d",crate,slot,
-		  ((tb==1)?("t"):("b")),chan);
-	  TH1* hq=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  hp->SetDirectory(nullptr);
-	  sprintf(hname,"Encoded fC Cr%d,%d%s-%d",crate,slot,
-		  ((tb==1)?("t"):("b")),chan);
-	  TH1* ha=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  ha->SetDirectory(nullptr);
-	  for (int i=0; i<ChannelPattern::SAMPLES; i++) {
-	    hp->Fill(i*1.0,(*cp)[i]);
-	    hq->Fill(i*1.0,cp->getQuantized(i));
-	    ha->Fill(i*1.0,cp->getCoded(i));
-	  }
-	  //of.cd("perfect");   hp->Write();
-	  //of.cd("quantized"); hq->Write();
-	  of.cd("adc");       ha->Write();
-	  delete hp;
-	  delete hq;
-	  delete ha;
-	}
+  for (int crate = 0; crate < ChannelPattern::NUM_CRATES; crate++) {
+    CrateData* cd = m_patternSet->getCrate(crate);
+    if (cd == nullptr)
+      continue;
+    for (int slot = 0; slot < ChannelPattern::NUM_SLOTS; slot++) {
+      for (int tb = 0; tb <= 1; tb++) {
+        HalfHtrData* hd = cd->getHalfHtrData(slot, tb);
+        if (hd == nullptr)
+          continue;
+        for (int chan = 1; chan <= 24; chan++) {
+          ChannelPattern* cp = hd->getPattern(chan);
+          char hname[128];
+          sprintf(hname, "Exact fC Cr%d,%d%s-%d", crate, slot, ((tb == 1) ? ("t") : ("b")), chan);
+          TH1* hp = new TH1F(hname, hname, ChannelPattern::SAMPLES, -0.5, ChannelPattern::SAMPLES - 0.5);
+          hp->SetDirectory(nullptr);
+          sprintf(hname, "Quantized fC Cr%d,%d%s-%d", crate, slot, ((tb == 1) ? ("t") : ("b")), chan);
+          TH1* hq = new TH1F(hname, hname, ChannelPattern::SAMPLES, -0.5, ChannelPattern::SAMPLES - 0.5);
+          hp->SetDirectory(nullptr);
+          sprintf(hname, "Encoded fC Cr%d,%d%s-%d", crate, slot, ((tb == 1) ? ("t") : ("b")), chan);
+          TH1* ha = new TH1F(hname, hname, ChannelPattern::SAMPLES, -0.5, ChannelPattern::SAMPLES - 0.5);
+          ha->SetDirectory(nullptr);
+          for (int i = 0; i < ChannelPattern::SAMPLES; i++) {
+            hp->Fill(i * 1.0, (*cp)[i]);
+            hq->Fill(i * 1.0, cp->getQuantized(i));
+            ha->Fill(i * 1.0, cp->getCoded(i));
+          }
+          //of.cd("perfect");   hp->Write();
+          //of.cd("quantized"); hq->Write();
+          of.cd("adc");
+          ha->Write();
+          delete hp;
+          delete hq;
+          delete ha;
+        }
       }
     }
   }

--- a/IORawData/CaloPatterns/src/HtrXmlPatternTool.h
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternTool.h
@@ -10,13 +10,14 @@ class HtrXmlPatternTool {
 public:
   HtrXmlPatternTool(HtrXmlPatternToolParameters* m_params);
   ~HtrXmlPatternTool();
-  void Fill(const HcalElectronicsId HEID,HBHEDigiCollection::const_iterator data);
-  void Fill(const HcalElectronicsId HEID,HFDigiCollection::const_iterator data);
-  void Fill(const HcalElectronicsId HEID,HODigiCollection::const_iterator data);
+  void Fill(const HcalElectronicsId HEID, HBHEDigiCollection::const_iterator data);
+  void Fill(const HcalElectronicsId HEID, HFDigiCollection::const_iterator data);
+  void Fill(const HcalElectronicsId HEID, HODigiCollection::const_iterator data);
   void prepareDirs();
   void createHists();
   void writeXML();
-  HtrXmlPatternSet* GetPatternSet() {return m_patternSet;}
+  HtrXmlPatternSet* GetPatternSet() { return m_patternSet; }
+
 private:
   HtrXmlPatternSet* m_patternSet;
   HtrXmlPatternToolParameters* m_params;

--- a/IORawData/CaloPatterns/src/HtrXmlPatternToolParameters.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternToolParameters.cc
@@ -1,19 +1,17 @@
 #include "HtrXmlPatternToolParameters.h"
 #include <iostream>
 
-HtrXmlPatternToolParameters::HtrXmlPatternToolParameters() {
-}
+HtrXmlPatternToolParameters::HtrXmlPatternToolParameters() {}
 
-HtrXmlPatternToolParameters::~HtrXmlPatternToolParameters() {
-}
+HtrXmlPatternToolParameters::~HtrXmlPatternToolParameters() {}
 
 void HtrXmlPatternToolParameters::Print() {
   using namespace std;
-  cout << "show_errors           = " << m_show_errors           << endl;
-  cout << "presamples_per_event  = " << m_presamples_per_event  << endl;
-  cout << "samples_per_event     = " << m_samples_per_event     << endl;
-  cout << "XML_file_mode         = " << m_XML_file_mode         << endl;
-  cout << "file_tag              = " << m_file_tag              << endl;
+  cout << "show_errors           = " << m_show_errors << endl;
+  cout << "presamples_per_event  = " << m_presamples_per_event << endl;
+  cout << "samples_per_event     = " << m_samples_per_event << endl;
+  cout << "XML_file_mode         = " << m_XML_file_mode << endl;
+  cout << "file_tag              = " << m_file_tag << endl;
   cout << "user_output_directory = " << m_user_output_directory << endl;
-  cout << "output_directory      = " << m_output_directory      << endl;
+  cout << "output_directory      = " << m_output_directory << endl;
 }

--- a/IORawData/CaloPatterns/src/HtrXmlPatternToolParameters.h
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternToolParameters.h
@@ -9,14 +9,15 @@ public:
   ~HtrXmlPatternToolParameters();
   void Print();
 
-  bool         m_show_errors;
-  int          m_presamples_per_event;
-  int          m_samples_per_event;
+  bool m_show_errors;
+  int m_presamples_per_event;
+  int m_samples_per_event;
 
-  int          m_XML_file_mode;
-  std::string  m_file_tag;
-  std::string  m_user_output_directory;
-  std::string  m_output_directory;
+  int m_XML_file_mode;
+  std::string m_file_tag;
+  std::string m_user_output_directory;
+  std::string m_output_directory;
+
 protected:
 private:
 };

--- a/IORawData/CaloPatterns/src/HtrXmlPatternWriter.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternWriter.cc
@@ -2,71 +2,74 @@
 
 static const char* tabbing(int level) {
   static char tab[50];
-  for (int i=0; i<level*2; i++)
-    tab[i]=' ';
-  tab[level*2]=0;
+  for (int i = 0; i < level * 2; i++)
+    tab[i] = ' ';
+  tab[level * 2] = 0;
   return tab;
 }
 
 HtrXmlPatternWriter::HtrXmlPatternWriter() {
   // set the timestamp!
-  time_t now1=time(nullptr);
-  struct tm* now=localtime(&now1);
+  time_t now1 = time(nullptr);
+  struct tm* now = localtime(&now1);
 
   char buffer[1024];
-  strftime(buffer,1024,"%Y-%m-%d %H:%M:%S",now);
+  strftime(buffer, 1024, "%Y-%m-%d %H:%M:%S", now);
 
-  m_stamp=buffer;
+  m_stamp = buffer;
 }
 
 void HtrXmlPatternWriter::writePattern(HalfHtrData* spigotData, int fiber, std::ostream& os, int level) {
-
   os << tabbing(level) << "<CFGBrick>" << std::endl;
-  os << tabbing(level+1) << "<Parameter name='DCC' type='int'>" << std::dec << spigotData->getDCC() << "</Parameter>" << std::endl;
-  os << tabbing(level+1) << "<Parameter name='SPIGOT' type='int'>" << std::dec << spigotData->getSpigot() << "</Parameter>" << std::endl;
-  os << tabbing(level+1) << "<Parameter name='CRATE' type='int'>" << std::dec << spigotData->getCrate() << "</Parameter>" << std::endl;
-  os << tabbing(level+1) << "<Parameter name='SLOT' type='int'>" << spigotData->getSlot() << "</Parameter>" << std::endl;
-  os << tabbing(level+1) << "<Parameter name='TOPBOTTOM' type='int'>" << spigotData->getTB() << "</Parameter>" << std::endl;
-  os << tabbing(level+1) << "<Parameter name='FIBER' type='int'>" << fiber << "</Parameter>" << std::endl;
-  
-  int genIndex=fiber+(spigotData->getTB()*10)+(spigotData->getSlot()*100)+(spigotData->getCrate()*10000);
-  os << tabbing(level+1) << "<Parameter name='GENERALIZEDINDEX' type='int'>" << std::dec << genIndex << "</Parameter>" << std::endl;
-  os << tabbing(level+1) << "<Parameter name='CREATIONTAG' type='string'>" << m_tagName << "</Parameter>" << std::endl;
-  os << tabbing(level+1) << "<Parameter name='CREATIONSTAMP' type='string'>" << m_stamp << "</Parameter>" << std::endl;
-  os << tabbing(level+1) << "<Parameter name='PATTERN_SPEC_NAME' type='string'>" << m_tagName << "</Parameter>" << std::endl;
-  
+  os << tabbing(level + 1) << "<Parameter name='DCC' type='int'>" << std::dec << spigotData->getDCC() << "</Parameter>"
+     << std::endl;
+  os << tabbing(level + 1) << "<Parameter name='SPIGOT' type='int'>" << std::dec << spigotData->getSpigot()
+     << "</Parameter>" << std::endl;
+  os << tabbing(level + 1) << "<Parameter name='CRATE' type='int'>" << std::dec << spigotData->getCrate()
+     << "</Parameter>" << std::endl;
+  os << tabbing(level + 1) << "<Parameter name='SLOT' type='int'>" << spigotData->getSlot() << "</Parameter>"
+     << std::endl;
+  os << tabbing(level + 1) << "<Parameter name='TOPBOTTOM' type='int'>" << spigotData->getTB() << "</Parameter>"
+     << std::endl;
+  os << tabbing(level + 1) << "<Parameter name='FIBER' type='int'>" << fiber << "</Parameter>" << std::endl;
+
+  int genIndex = fiber + (spigotData->getTB() * 10) + (spigotData->getSlot() * 100) + (spigotData->getCrate() * 10000);
+  os << tabbing(level + 1) << "<Parameter name='GENERALIZEDINDEX' type='int'>" << std::dec << genIndex << "</Parameter>"
+     << std::endl;
+  os << tabbing(level + 1) << "<Parameter name='CREATIONTAG' type='string'>" << m_tagName << "</Parameter>"
+     << std::endl;
+  os << tabbing(level + 1) << "<Parameter name='CREATIONSTAMP' type='string'>" << m_stamp << "</Parameter>"
+     << std::endl;
+  os << tabbing(level + 1) << "<Parameter name='PATTERN_SPEC_NAME' type='string'>" << m_tagName << "</Parameter>"
+     << std::endl;
 
   // CREATIONTAG, CREATIONSTAMP, PATTERN_SPEC_NAME
-  
-  os << tabbing(level+1) << "<Data elements='1024' encoding='hex'>" << std::endl;
-  
-  ChannelPattern* p1=spigotData->getPattern((fiber-1)*3+1);
-  ChannelPattern* p2=spigotData->getPattern((fiber-1)*3+2);
-  ChannelPattern* p3=spigotData->getPattern((fiber-1)*3+3);
 
+  os << tabbing(level + 1) << "<Data elements='1024' encoding='hex'>" << std::endl;
 
-  unsigned int w1,w2;
-  for (int i=0; i<512; i++) {
-    packWordsStd(p1->getCoded(i),p2->getCoded(i),p3->getCoded(i),i%4,w1,w2);
+  ChannelPattern* p1 = spigotData->getPattern((fiber - 1) * 3 + 1);
+  ChannelPattern* p2 = spigotData->getPattern((fiber - 1) * 3 + 2);
+  ChannelPattern* p3 = spigotData->getPattern((fiber - 1) * 3 + 3);
+
+  unsigned int w1, w2;
+  for (int i = 0; i < 512; i++) {
+    packWordsStd(p1->getCoded(i), p2->getCoded(i), p3->getCoded(i), i % 4, w1, w2);
     os << std::hex << w1 << ' ' << std::hex << w2 << ' ';
   }
 
-  os << std::endl << tabbing(level+1) << "</Data>" << std::endl;
-  
+  os << std::endl << tabbing(level + 1) << "</Data>" << std::endl;
+
   os << tabbing(level) << "</CFGBrick>" << std::endl;
 }
 
 void HtrXmlPatternWriter::packWordsStd(int adc0, int adc1, int adc2, int capid, unsigned int& w1, unsigned int& w2) {
-  w1=0x3;
-  w1|=(capid&0x3)<<3;
-  w1|=(capid&0x3)<<5;
-  w1|=(capid&0x3)<<7;
-  w1|=adc2<<9;
-  w1|=0x10000; // data valid
-  w2=adc1<<1;
-  w2|=adc0<<9;
-  w2|=0x10000; // data valid
+  w1 = 0x3;
+  w1 |= (capid & 0x3) << 3;
+  w1 |= (capid & 0x3) << 5;
+  w1 |= (capid & 0x3) << 7;
+  w1 |= adc2 << 9;
+  w1 |= 0x10000;  // data valid
+  w2 = adc1 << 1;
+  w2 |= adc0 << 9;
+  w2 |= 0x10000;  // data valid
 }
-  
-
-

--- a/IORawData/CaloPatterns/src/HtrXmlPatternWriter.h
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternWriter.h
@@ -7,8 +7,9 @@
 class HtrXmlPatternWriter {
 public:
   HtrXmlPatternWriter();
-  void setTagName(std::string tn) { m_tagName=tn; }
-  void writePattern(HalfHtrData* spigotData, int fiber, std::ostream& os, int level=0); 
+  void setTagName(std::string tn) { m_tagName = tn; }
+  void writePattern(HalfHtrData* spigotData, int fiber, std::ostream& os, int level = 0);
+
 private:
   void packWordsStd(int adc0, int adc1, int adc2, int capid, unsigned int& w1, unsigned int& w2);
   std::string m_tagName, m_stamp;


### PR DESCRIPTION

Applying code-format for CMSSW category alca.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/200//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Same as #26676 but with correct CMS clang-format customization (see #26686)
