### PR TITLE
Running code-format for simulation

### DIFF
--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.h
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProduction.h
@@ -2,7 +2,7 @@
 // File name:     CMSDarkPairProduction
 //
 // Author:        Dustin Stolp (dostolp@ucdavis.edu)
-//                Sushil S. Chauhan (schauhan@cern.ch)  
+//                Sushil S. Chauhan (schauhan@cern.ch)
 // Creation date: 01.22.2015
 // -------------------------------------------------------------------
 //
@@ -16,25 +16,22 @@
 #include "G4NistManager.hh"
 #include "G4VEmModel.hh"
 
-class CMSDarkPairProduction : public G4PairProductionRelModel
-{
+class CMSDarkPairProduction : public G4PairProductionRelModel {
 public:
   CMSDarkPairProduction(const G4ParticleDefinition* p = nullptr,
-		        G4double df = 1.0,
+                        G4double df = 1.0,
                         const G4String& nam = "BetheHeitlerLPM");
 
   ~CMSDarkPairProduction() override;
 
-  G4double ComputeCrossSectionPerAtom(
-                      const G4ParticleDefinition*,
-                      G4double kinEnergy,
-                      G4double Z,
-                      G4double A=0.,
-                      G4double cut=0.,
-                      G4double emax=DBL_MAX) override;
+  G4double ComputeCrossSectionPerAtom(const G4ParticleDefinition*,
+                                      G4double kinEnergy,
+                                      G4double Z,
+                                      G4double A = 0.,
+                                      G4double cut = 0.,
+                                      G4double emax = DBL_MAX) override;
 
 private:
-
   G4double dark_factor;
 };
 #endif

--- a/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.h
+++ b/SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.h
@@ -1,8 +1,8 @@
-//--------------------------------------------------------   
+//--------------------------------------------------------
 // File name:     CMSDarkPairProductionProcess
-// 
+//
 //  Author:        Dustin Stolp (dostolp@ucdavis.edu)
-//                 Sushil S. Chauhan (schauhan@cern.ch)  
+//                 Sushil S. Chauhan (schauhan@cern.ch)
 // --------------------------------------------------------
 #ifndef SimG4Core_CustomPhysics_CMSDarkPairProductionProcess_h
 #define SimG4Core_CustomPhysics_CMSDarkPairProductionProcess_h
@@ -11,7 +11,6 @@
 #include "globals.hh"
 #include "G4VEmProcess.hh"
 #include "G4Gamma.hh"
-
 
 class G4ParticleDefinition;
 class G4VEmModel;
@@ -22,32 +21,26 @@ class CMSDarkPairProductionProcess : public G4VEmProcess
 
 {
 public:  // with description
-
   CMSDarkPairProductionProcess(G4double df = 1E0,
-  		      const G4String& processName ="conv",
-		      G4ProcessType type = fElectromagnetic);
+                               const G4String& processName = "conv",
+                               G4ProcessType type = fElectromagnetic);
 
   ~CMSDarkPairProductionProcess() override;
 
   // true for Gamma only.
   G4bool IsApplicable(const G4ParticleDefinition&) override;
 
-  G4double MinPrimaryEnergy(const G4ParticleDefinition*,
-				    const G4Material*) override;
+  G4double MinPrimaryEnergy(const G4ParticleDefinition*, const G4Material*) override;
 
   // Print few lines of informations about the process: validity range,
   void PrintInfo() override;
 
 protected:
-
   void InitialiseProcess(const G4ParticleDefinition*) override;
 
 private:
-  G4bool  isInitialised;
+  G4bool isInitialised;
   G4double darkFactor;
-
 };
 
-  
 #endif
- 

--- a/SimG4Core/CustomPhysics/interface/CMSExoticaPhysics.h
+++ b/SimG4Core/CustomPhysics/interface/CMSExoticaPhysics.h
@@ -1,20 +1,19 @@
 #ifndef SimG4Core_CustomPhysics_CMSExoticaPhysics_H
 #define SimG4Core_CustomPhysics_CMSExoticaPhysics_H
- 
-// 
+
+//
 //
 // Author: V.Ivantchenko  7 May 2018
-//     
-// Description: general interface to exotic particle physics 
+//
+// Description: general interface to exotic particle physics
 //
 
 #include "SimG4Core/Physics/interface/PhysicsList.h"
- 
-class CMSExoticaPhysics{
 
+class CMSExoticaPhysics {
 public:
-  CMSExoticaPhysics(PhysicsList* phys, const edm::ParameterSet & p);
+  CMSExoticaPhysics(PhysicsList* phys, const edm::ParameterSet& p);
   ~CMSExoticaPhysics() = default;
 };
- 
+
 #endif

--- a/SimG4Core/CustomPhysics/interface/CustomPDGParser.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPDGParser.h
@@ -1,27 +1,25 @@
 #ifndef SimG4Core_CustomPhysics_CustomPDGParser_h
-#define SimG4Core_CustomPhysics_CustomPDGParser_h 
+#define SimG4Core_CustomPhysics_CustomPDGParser_h
 
 #include <vector>
 
-class CustomPDGParser
-{
+class CustomPDGParser {
 public:
- static bool s_isRHadron(int pdg);
- static bool s_isstopHadron(int pdg);
- static bool s_issbottomHadron(int pdg) ;
- static bool s_isSLepton(int pdg);
- static bool s_isRBaryon(int pdg);
- static bool s_isRMeson(int pdg);
- static bool s_isMesonino(int pdg);
- static bool s_isSbaryon(int pdg);
- static bool s_isRGlueball(int pdg);
- static bool s_isDphoton(int pdg);
- static bool s_isChargino(int pdg);
- static double s_charge(int pdg);
- static double s_spin(int pdg);
- static std::vector<int> s_containedQuarks(int pdg);
- static int s_containedQuarksCode(int pdg);
-
+  static bool s_isRHadron(int pdg);
+  static bool s_isstopHadron(int pdg);
+  static bool s_issbottomHadron(int pdg);
+  static bool s_isSLepton(int pdg);
+  static bool s_isRBaryon(int pdg);
+  static bool s_isRMeson(int pdg);
+  static bool s_isMesonino(int pdg);
+  static bool s_isSbaryon(int pdg);
+  static bool s_isRGlueball(int pdg);
+  static bool s_isDphoton(int pdg);
+  static bool s_isChargino(int pdg);
+  static double s_charge(int pdg);
+  static double s_spin(int pdg);
+  static std::vector<int> s_containedQuarks(int pdg);
+  static int s_containedQuarksCode(int pdg);
 };
 
 #endif

--- a/SimG4Core/CustomPhysics/interface/CustomParticle.h
+++ b/SimG4Core/CustomPhysics/interface/CustomParticle.h
@@ -8,34 +8,41 @@
 // ###                          CustomParticle                        ###
 // ######################################################################
 
-class CustomParticle : public G4ParticleDefinition
-{
- public:
-   CustomParticle(
-       const G4String&     aName,        G4double            mass,
-       G4double            width,        G4double            charge,   
-       G4int               iSpin,        G4int               iParity,    
-       G4int               iConjugation, G4int               iIsospin,   
-       G4int               iIsospin3,    G4int               gParity,
-       const G4String&     pType,        G4int               lepton,      
-       G4int               baryon,       G4int               encoding,
-       G4bool              stable,       G4double            lifetime,
-       G4DecayTable        *decaytable
-   );
- private:
-   G4ParticleDefinition* m_cloud;
-   G4ParticleDefinition* m_spec;
- public:
-   void SetCloud(G4ParticleDefinition* theCloud);
-   void SetSpectator(G4ParticleDefinition* theSpectator);
-   G4ParticleDefinition* GetCloud();
-   G4ParticleDefinition* GetSpectator();
-   ~CustomParticle() override {}
+class CustomParticle : public G4ParticleDefinition {
+public:
+  CustomParticle(const G4String& aName,
+                 G4double mass,
+                 G4double width,
+                 G4double charge,
+                 G4int iSpin,
+                 G4int iParity,
+                 G4int iConjugation,
+                 G4int iIsospin,
+                 G4int iIsospin3,
+                 G4int gParity,
+                 const G4String& pType,
+                 G4int lepton,
+                 G4int baryon,
+                 G4int encoding,
+                 G4bool stable,
+                 G4double lifetime,
+                 G4DecayTable* decaytable);
+
+private:
+  G4ParticleDefinition* m_cloud;
+  G4ParticleDefinition* m_spec;
+
+public:
+  void SetCloud(G4ParticleDefinition* theCloud);
+  void SetSpectator(G4ParticleDefinition* theSpectator);
+  G4ParticleDefinition* GetCloud();
+  G4ParticleDefinition* GetSpectator();
+  ~CustomParticle() override {}
 };
 
-inline void CustomParticle::SetCloud(G4ParticleDefinition* theCloud){ m_cloud = theCloud; }
-inline G4ParticleDefinition* CustomParticle::GetCloud(){ return m_cloud; }
-inline void CustomParticle::SetSpectator(G4ParticleDefinition* theSpectator){ m_spec = theSpectator; }
-inline G4ParticleDefinition* CustomParticle::GetSpectator(){ return m_spec; }
+inline void CustomParticle::SetCloud(G4ParticleDefinition* theCloud) { m_cloud = theCloud; }
+inline G4ParticleDefinition* CustomParticle::GetCloud() { return m_cloud; }
+inline void CustomParticle::SetSpectator(G4ParticleDefinition* theSpectator) { m_spec = theSpectator; }
+inline G4ParticleDefinition* CustomParticle::GetSpectator() { return m_spec; }
 
 #endif

--- a/SimG4Core/CustomPhysics/interface/CustomParticleFactory.h
+++ b/SimG4Core/CustomPhysics/interface/CustomParticleFactory.h
@@ -10,29 +10,25 @@ class G4DecayTable;
 class G4ParticleDefinition;
 
 class CustomParticleFactory {
-
 public:
-
   explicit CustomParticleFactory();
   ~CustomParticleFactory();
 
-  void loadCustomParticles(const std::string & filePath);
-  const std::vector<G4ParticleDefinition *>& GetCustomParticles();
+  void loadCustomParticles(const std::string &filePath);
+  const std::vector<G4ParticleDefinition *> &GetCustomParticles();
 
 private:
-
-  void addCustomParticle(int pdgCode, double mass, const std::string & name );
+  void addCustomParticle(int pdgCode, double mass, const std::string &name);
   void getMassTable(std::ifstream *configFile);
-  G4DecayTable* getDecayTable(std::ifstream *configFile, int pdgId);
-  G4DecayTable* getAntiDecayTable(int pdgId, G4DecayTable *theDecayTable);
-  std::string ToLower(std::string str);  
+  G4DecayTable *getDecayTable(std::ifstream *configFile, int pdgId);
+  G4DecayTable *getAntiDecayTable(int pdgId, G4DecayTable *theDecayTable);
+  std::string ToLower(std::string str);
 
   static bool loaded;
   static std::vector<G4ParticleDefinition *> m_particles;
 #ifdef G4MULTITHREADED
   static G4Mutex customParticleFactoryMutex;
 #endif
-  
 };
 
 #endif

--- a/SimG4Core/CustomPhysics/interface/CustomPhysics.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysics.h
@@ -1,13 +1,12 @@
 #ifndef SimG4Core_CustomPhysics_CustomPhysics_H
 #define SimG4Core_CustomPhysics_CustomPhysics_H
- 
+
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class CustomPhysics : public PhysicsList
-{
+
+class CustomPhysics : public PhysicsList {
 public:
-    CustomPhysics(const edm::ParameterSet & p);
+  CustomPhysics(const edm::ParameterSet& p);
 };
- 
+
 #endif

--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
@@ -1,7 +1,7 @@
 #ifndef SimG4Core_CustomPhysics_CustomPhysicsList_H
 #define SimG4Core_CustomPhysics_CustomPhysicsList_H
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h" 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "G4VPhysicsConstructor.hh"
 
 #include <string>
@@ -9,18 +9,15 @@
 class G4ProcessHelper;
 class CustomParticleFactory;
 
-class CustomPhysicsList : public G4VPhysicsConstructor 
-{
+class CustomPhysicsList : public G4VPhysicsConstructor {
 public:
-  CustomPhysicsList(const std::string& name, const edm::ParameterSet & p, 
-		    bool useuni = false);
+  CustomPhysicsList(const std::string& name, const edm::ParameterSet& p, bool useuni = false);
   ~CustomPhysicsList() override;
 
   void ConstructParticle() override;
   void ConstructProcess() override;
 
 private:
-
   static G4ThreadLocal std::unique_ptr<G4ProcessHelper> myHelper;
   std::unique_ptr<CustomParticleFactory> fParticleFactory;
 
@@ -32,5 +29,5 @@ private:
   std::string processDefFilePath;
   double dfactor;
 };
- 
+
 #endif

--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
@@ -1,7 +1,7 @@
 #ifndef SimG4Core_CustomPhysics_CustomPhysicsListSS_H
 #define SimG4Core_CustomPhysics_CustomPhysicsListSS_H
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h" 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "G4VPhysicsConstructor.hh"
 #include <string>
 
@@ -9,18 +9,15 @@ class G4ProcessHelper;
 class G4Decay;
 class CustomParticleFactory;
 
-class CustomPhysicsListSS : public G4VPhysicsConstructor 
-{
+class CustomPhysicsListSS : public G4VPhysicsConstructor {
 public:
-  CustomPhysicsListSS(const std::string& name, const edm::ParameterSet & p,
-		      bool useuni = false);
+  CustomPhysicsListSS(const std::string& name, const edm::ParameterSet& p, bool useuni = false);
   ~CustomPhysicsListSS() override;
 
   void ConstructParticle() override;
   void ConstructProcess() override;
 
 private:
-
   static G4ThreadLocal std::unique_ptr<G4Decay> fDecayProcess;
   static G4ThreadLocal std::unique_ptr<G4ProcessHelper> myHelper;
 
@@ -34,5 +31,5 @@ private:
   std::string processDefFilePath;
   double dfactor;
 };
- 
+
 #endif

--- a/SimG4Core/CustomPhysics/interface/Decay3Body.h
+++ b/SimG4Core/CustomPhysics/interface/Decay3Body.h
@@ -4,17 +4,17 @@
 #include "G4LorentzVector.hh"
 
 class Decay3Body {
-  public:
-    Decay3Body();
-    ~Decay3Body();
+public:
+  Decay3Body();
+  ~Decay3Body();
 
-    void doDecay(const G4LorentzVector & mother,
-                       G4LorentzVector & daughter1,
-                       G4LorentzVector & daughter2,
-                       G4LorentzVector & daughter3);
+  void doDecay(const G4LorentzVector& mother,
+               G4LorentzVector& daughter1,
+               G4LorentzVector& daughter2,
+               G4LorentzVector& daughter3);
 
-  private:
-    inline double sqr(double a);
+private:
+  inline double sqr(double a);
 };
 
 #endif

--- a/SimG4Core/CustomPhysics/interface/DummyChargeFlipProcess.h
+++ b/SimG4Core/CustomPhysics/interface/DummyChargeFlipProcess.h
@@ -1,6 +1,6 @@
 #ifndef SimG4Core_CustomPhysics_DummyChargeFlipProcess_h
 #define SimG4Core_CustomPhysics_DummyChargeFlipProcess_h 1
- 
+
 #include "globals.hh"
 #include "G4HadronicProcess.hh"
 #include "G4CrossSectionDataStore.hh"
@@ -14,28 +14,21 @@
 
 #include <iostream>
 
-class DummyChargeFlipProcess : public G4HadronicProcess
-{
+class DummyChargeFlipProcess : public G4HadronicProcess {
 public:
+  DummyChargeFlipProcess(const G4String& processName = "Dummy");
 
-   DummyChargeFlipProcess(const G4String& processName = "Dummy");
+  ~DummyChargeFlipProcess() override;
 
-   ~DummyChargeFlipProcess() override;
- 
-   G4VParticleChange* PostStepDoIt(const G4Track& aTrack, const G4Step& aStep) override;
+  G4VParticleChange* PostStepDoIt(const G4Track& aTrack, const G4Step& aStep) override;
 
+  G4bool IsApplicable(const G4ParticleDefinition& aParticleType) override;
 
-   G4bool IsApplicable(const G4ParticleDefinition& aParticleType) override;
+  void BuildPhysicsTable(const G4ParticleDefinition& aParticleType) override;
 
-   void BuildPhysicsTable(const G4ParticleDefinition& aParticleType) override;
-
-   void DumpPhysicsTable(const G4ParticleDefinition& aParticleType);
+  void DumpPhysicsTable(const G4ParticleDefinition& aParticleType);
 
 private:
-
-   G4double GetMicroscopicCrossSection(const G4DynamicParticle* aParticle,
-                                       const G4Element* anElement,
-				       G4double aTemp);
-
+  G4double GetMicroscopicCrossSection(const G4DynamicParticle* aParticle, const G4Element* anElement, G4double aTemp);
 };
 #endif

--- a/SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.h
+++ b/SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.h
@@ -13,61 +13,53 @@
 
 class G4ProcessHelper;
 
-class FullModelHadronicProcess : public G4VDiscreteProcess
-{
+class FullModelHadronicProcess : public G4VDiscreteProcess {
 public:
-  
-  FullModelHadronicProcess(G4ProcessHelper * aHelper, 
-			   const G4String& processName = "FullModelHadronicProcess");
-    
+  FullModelHadronicProcess(G4ProcessHelper *aHelper, const G4String &processName = "FullModelHadronicProcess");
+
   ~FullModelHadronicProcess() override;
 
-  
-  G4bool IsApplicable(const G4ParticleDefinition& aP) override;
-  
+  G4bool IsApplicable(const G4ParticleDefinition &aP) override;
+
   G4VParticleChange *PostStepDoIt(const G4Track &aTrack, const G4Step &aStep) override;
 
 protected:
-  
   const G4ParticleDefinition *theParticle;
   G4ParticleDefinition *newParticle;
-  
+
   G4ParticleChange theParticleChange;
-  
-private:    
-  
-  virtual G4double GetMicroscopicCrossSection( const G4DynamicParticle *aParticle, 
-					       const G4Element *anElement, 
-					       G4double aTemp );
 
-  G4double GetMeanFreePath(const G4Track& aTrack, G4double, G4ForceCondition*) override;
-  
-  void CalculateMomenta( G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-			 G4int &vecLen,
-			 const G4HadProjectile *originalIncident,
-			 const G4DynamicParticle *originalTarget,
-			 G4ReactionProduct &modifiedOriginal,
-			 G4Nucleus &targetNucleus,
-			 G4ReactionProduct &currentParticle,
-			 G4ReactionProduct &targetParticle,
-			 G4bool &incidentHasChanged,
-			 G4bool &targetHasChanged,
-			 G4bool quasiElastic );
+private:
+  virtual G4double GetMicroscopicCrossSection(const G4DynamicParticle *aParticle,
+                                              const G4Element *anElement,
+                                              G4double aTemp);
 
-  G4bool MarkLeadingStrangeParticle(
-				    const G4ReactionProduct &currentParticle,
-				    const G4ReactionProduct &targetParticle,
-				    G4ReactionProduct &leadParticle );
-    
-  void Rotate(G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec, G4int &vecLen);
+  G4double GetMeanFreePath(const G4Track &aTrack, G4double, G4ForceCondition *) override;
 
-  const G4DynamicParticle* FindRhadron(G4ParticleChange*);
+  void CalculateMomenta(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                        G4int &vecLen,
+                        const G4HadProjectile *originalIncident,
+                        const G4DynamicParticle *originalTarget,
+                        G4ReactionProduct &modifiedOriginal,
+                        G4Nucleus &targetNucleus,
+                        G4ReactionProduct &currentParticle,
+                        G4ReactionProduct &targetParticle,
+                        G4bool &incidentHasChanged,
+                        G4bool &targetHasChanged,
+                        G4bool quasiElastic);
 
-  G4ProcessHelper* theHelper;
+  G4bool MarkLeadingStrangeParticle(const G4ReactionProduct &currentParticle,
+                                    const G4ReactionProduct &targetParticle,
+                                    G4ReactionProduct &leadParticle);
+
+  void Rotate(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec, G4int &vecLen);
+
+  const G4DynamicParticle *FindRhadron(G4ParticleChange *);
+
+  G4ProcessHelper *theHelper;
   G4bool toyModel;
   G4double cache;
   G4ThreeVector what;
 };
 
 #endif
- 

--- a/SimG4Core/CustomPhysics/interface/FullModelReactionDynamics.h
+++ b/SimG4Core/CustomPhysics/interface/FullModelReactionDynamics.h
@@ -1,13 +1,13 @@
 
- //
- // Hadronic Process: Reaction Dynamics
- // original by H.P. Wellisch
- // Modified by J.L.Chuma 19-Nov-96
- // Modified by J.L.Chuma 27-Mar-97
- // Modified by J.L.Chuma 30-Apr-97
- // Modified by J.L.Chuma 06-Aug-97  to include the original incident particle
- //                                  before Fermi motion and evaporation effects
- 
+//
+// Hadronic Process: Reaction Dynamics
+// original by H.P. Wellisch
+// Modified by J.L.Chuma 19-Nov-96
+// Modified by J.L.Chuma 27-Mar-97
+// Modified by J.L.Chuma 30-Apr-97
+// Modified by J.L.Chuma 06-Aug-97  to include the original incident particle
+//                                  before Fermi motion and evaporation effects
+
 #ifndef SimG4Core_CustomPhysics_FullModelReactionDynamics_h
 #define SimG4Core_CustomPhysics_FullModelReactionDynamics_h 1
 
@@ -18,140 +18,127 @@
 #include "G4FastVector.hh"
 #include "G4HadProjectile.hh"
 
-enum{ MYGHADLISTSIZE=256};
+enum { MYGHADLISTSIZE = 256 };
 
- class FullModelReactionDynamics 
- {
- public:
-    
-    FullModelReactionDynamics() {}
-    
-    virtual ~FullModelReactionDynamics() {}
-    
-    virtual G4double FindInelasticity()
-    { return 0.0; }
-    
-    virtual G4double FindTimeDelay()
-    { return 0.0; }
-    
-    G4bool GenerateXandPt(                   // derived from GENXPT
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen,
-     G4ReactionProduct &modifiedOriginal, // Fermi motion & evap. effect included
-     const G4HadProjectile *originalIncident,
-     G4ReactionProduct &currentParticle,
-     G4ReactionProduct &targetParticle,
-     const G4Nucleus &targetNucleus,
-     G4bool &incidentHasChanged, 
-     G4bool &targetHasChanged,
-     G4bool leadFlag,
-     G4ReactionProduct &leadingStrangeParticle );
-    
-    void SuppressChargedPions(
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen,
-     const G4ReactionProduct &modifiedOriginal,
-     G4ReactionProduct &currentParticle,
-     G4ReactionProduct &targetParticle,
-     const G4Nucleus &targetNucleus,
-     G4bool &incidentHasChanged,
-     G4bool &targetHasChanged );
-      
-    G4bool TwoCluster(                       // derived from TWOCLU
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen,
-     G4ReactionProduct &modifiedOriginal, // Fermi motion & evap. effect included
-     const G4HadProjectile *originalIncident,
-     G4ReactionProduct &currentParticle,
-     G4ReactionProduct &targetParticle,
-     const G4Nucleus &targetNucleus,
-     G4bool &incidentHasChanged, 
-     G4bool &targetHasChanged,
-     G4bool leadFlag,
-     G4ReactionProduct &leadingStrangeParticle );
-    
-    void TwoBody(                         // derived from TWOB
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen,
-     G4ReactionProduct &modifiedOriginal,
-     const G4DynamicParticle *originalTarget,
-     G4ReactionProduct &currentParticle,
-     G4ReactionProduct &targetParticle,
-     const G4Nucleus &targetNucleus,
-     G4bool &targetHasChanged );
-    
-    G4int Factorial( G4int n );
-    
-    G4double GenerateNBodyEvent(                // derived from PHASP
-     const G4double totalEnergy,
-     const G4bool constantCrossSection,
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen );
-    
-    void ProduceStrangeParticlePairs(
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen,
-     const G4ReactionProduct &modifiedOriginal,
-     const G4DynamicParticle *originalTarget, 
-     G4ReactionProduct &currentParticle,
-     G4ReactionProduct &targetParticle,
-     G4bool &incidentHasChanged,
-     G4bool &targetHasChanged );
-    
-    void NuclearReaction(                     // derived from NUCREC
-     G4FastVector<G4ReactionProduct,4> &vec,
-     G4int &vecLen,
-     const G4HadProjectile *originalIncident,
-     const G4Nucleus &aNucleus,
-     const G4double theAtomicMass,
-     const G4double *massVec );
-    
- private:
-    
-    void Rotate(
-     const G4double numberofFinalStateNucleons,
-     const G4ThreeVector &temp,
-     const G4ReactionProduct &modifiedOriginal, // Fermi motion & evap. effect included
-     const G4HadProjectile *originalIncident,
-     const G4Nucleus &targetNucleus,
-     G4ReactionProduct &currentParticle,
-     G4ReactionProduct &targetParticle,
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen );
-    
-    void Defs1(
-     const G4ReactionProduct &modifiedOriginal,
-     G4ReactionProduct &currentParticle,
-     G4ReactionProduct &targetParticle,
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen );
-    
-    void AddBlackTrackParticles(
-     const G4double epnb,
-     const G4int npnb,
-     const G4double edta,
-     const G4int ndta,
-     const G4double sprob,
-     const G4double kineticMinimum,
-     const G4double kineticFactor,
-     const G4ReactionProduct &modifiedOriginal,
-     G4double spall,
-     const G4Nucleus &aNucleus,
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen );
-    
-    void MomentumCheck(
-     const G4ReactionProduct &modifiedOriginal,
-     G4ReactionProduct &currentParticle,
-     G4ReactionProduct &targetParticle,
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen );
-    
-    G4double normal();
-    
-    G4int Poisson( G4double x );
-   
- };
- 
+class FullModelReactionDynamics {
+public:
+  FullModelReactionDynamics() {}
+
+  virtual ~FullModelReactionDynamics() {}
+
+  virtual G4double FindInelasticity() { return 0.0; }
+
+  virtual G4double FindTimeDelay() { return 0.0; }
+
+  G4bool GenerateXandPt(  // derived from GENXPT
+      G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+      G4int &vecLen,
+      G4ReactionProduct &modifiedOriginal,  // Fermi motion & evap. effect included
+      const G4HadProjectile *originalIncident,
+      G4ReactionProduct &currentParticle,
+      G4ReactionProduct &targetParticle,
+      const G4Nucleus &targetNucleus,
+      G4bool &incidentHasChanged,
+      G4bool &targetHasChanged,
+      G4bool leadFlag,
+      G4ReactionProduct &leadingStrangeParticle);
+
+  void SuppressChargedPions(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                            G4int &vecLen,
+                            const G4ReactionProduct &modifiedOriginal,
+                            G4ReactionProduct &currentParticle,
+                            G4ReactionProduct &targetParticle,
+                            const G4Nucleus &targetNucleus,
+                            G4bool &incidentHasChanged,
+                            G4bool &targetHasChanged);
+
+  G4bool TwoCluster(  // derived from TWOCLU
+      G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+      G4int &vecLen,
+      G4ReactionProduct &modifiedOriginal,  // Fermi motion & evap. effect included
+      const G4HadProjectile *originalIncident,
+      G4ReactionProduct &currentParticle,
+      G4ReactionProduct &targetParticle,
+      const G4Nucleus &targetNucleus,
+      G4bool &incidentHasChanged,
+      G4bool &targetHasChanged,
+      G4bool leadFlag,
+      G4ReactionProduct &leadingStrangeParticle);
+
+  void TwoBody(  // derived from TWOB
+      G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+      G4int &vecLen,
+      G4ReactionProduct &modifiedOriginal,
+      const G4DynamicParticle *originalTarget,
+      G4ReactionProduct &currentParticle,
+      G4ReactionProduct &targetParticle,
+      const G4Nucleus &targetNucleus,
+      G4bool &targetHasChanged);
+
+  G4int Factorial(G4int n);
+
+  G4double GenerateNBodyEvent(  // derived from PHASP
+      const G4double totalEnergy,
+      const G4bool constantCrossSection,
+      G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+      G4int &vecLen);
+
+  void ProduceStrangeParticlePairs(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                                   G4int &vecLen,
+                                   const G4ReactionProduct &modifiedOriginal,
+                                   const G4DynamicParticle *originalTarget,
+                                   G4ReactionProduct &currentParticle,
+                                   G4ReactionProduct &targetParticle,
+                                   G4bool &incidentHasChanged,
+                                   G4bool &targetHasChanged);
+
+  void NuclearReaction(  // derived from NUCREC
+      G4FastVector<G4ReactionProduct, 4> &vec,
+      G4int &vecLen,
+      const G4HadProjectile *originalIncident,
+      const G4Nucleus &aNucleus,
+      const G4double theAtomicMass,
+      const G4double *massVec);
+
+private:
+  void Rotate(const G4double numberofFinalStateNucleons,
+              const G4ThreeVector &temp,
+              const G4ReactionProduct &modifiedOriginal,  // Fermi motion & evap. effect included
+              const G4HadProjectile *originalIncident,
+              const G4Nucleus &targetNucleus,
+              G4ReactionProduct &currentParticle,
+              G4ReactionProduct &targetParticle,
+              G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+              G4int &vecLen);
+
+  void Defs1(const G4ReactionProduct &modifiedOriginal,
+             G4ReactionProduct &currentParticle,
+             G4ReactionProduct &targetParticle,
+             G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+             G4int &vecLen);
+
+  void AddBlackTrackParticles(const G4double epnb,
+                              const G4int npnb,
+                              const G4double edta,
+                              const G4int ndta,
+                              const G4double sprob,
+                              const G4double kineticMinimum,
+                              const G4double kineticFactor,
+                              const G4ReactionProduct &modifiedOriginal,
+                              G4double spall,
+                              const G4Nucleus &aNucleus,
+                              G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                              G4int &vecLen);
+
+  void MomentumCheck(const G4ReactionProduct &modifiedOriginal,
+                     G4ReactionProduct &currentParticle,
+                     G4ReactionProduct &targetParticle,
+                     G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                     G4int &vecLen);
+
+  G4double normal();
+
+  G4int Poisson(G4double x);
+};
+
 #endif
- 

--- a/SimG4Core/CustomPhysics/interface/G4ProcessHelper.h
+++ b/SimG4Core/CustomPhysics/interface/G4ProcessHelper.h
@@ -1,21 +1,21 @@
 #ifndef SimG4Core_CustomPhysics_G4ProcessHelper_H
 #define SimG4Core_CustomPhysics_G4ProcessHelper_H
 
-#include"globals.hh"
-#include"G4ParticleDefinition.hh"
-#include"G4DynamicParticle.hh"
-#include"G4Element.hh"
-#include"G4Track.hh"
+#include "globals.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4DynamicParticle.hh"
+#include "G4Element.hh"
+#include "G4Track.hh"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include<vector>
-#include<map>
+#include <vector>
+#include <map>
 
 //Typedefs just made to make life easier :-)
 typedef std::vector<G4int> ReactionProduct;
-typedef std::vector<ReactionProduct > ReactionProductList;
-typedef std::map<G4int , ReactionProductList> ReactionMap;
+typedef std::vector<ReactionProduct> ReactionProductList;
+typedef std::map<G4int, ReactionProductList> ReactionMap;
 
 class G4ParticleTable;
 class CustomParticleFactory;
@@ -24,25 +24,21 @@ class TProfile;
 class TH1D;
 
 class G4ProcessHelper {
-
 public:
-
-  G4ProcessHelper(const edm::ParameterSet & p, CustomParticleFactory* ptr);
+  G4ProcessHelper(const edm::ParameterSet& p, CustomParticleFactory* ptr);
 
   ~G4ProcessHelper();
- 
+
   G4bool ApplicabilityTester(const G4ParticleDefinition& aPart);
 
-  G4double GetInclusiveCrossSection(const G4DynamicParticle *aParticle,
-				    const G4Element *anElement);
+  G4double GetInclusiveCrossSection(const G4DynamicParticle* aParticle, const G4Element* anElement);
 
   //Make sure the element is known (for n/p-decision)
-  ReactionProduct GetFinalState(const G4Track& aTrack,G4ParticleDefinition*& aTarget);
+  ReactionProduct GetFinalState(const G4Track& aTrack, G4ParticleDefinition*& aTarget);
 
 private:
-
   G4ProcessHelper(const G4ProcessHelper&) = delete;
-  G4ProcessHelper& operator= (const G4ProcessHelper&) = delete;
+  G4ProcessHelper& operator=(const G4ProcessHelper&) = delete;
 
   G4double Regge(const double boost);
   G4double Pom(const double boost);
@@ -56,26 +52,24 @@ private:
   G4ParticleDefinition* theNeutron;
   G4ParticleDefinition* theRmesoncloud;
   G4ParticleDefinition* theRbaryoncloud;
-  
+
   ReactionMap* theReactionMap;
 
-  G4double PhaseSpace(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle);
-  
-  G4double ReactionProductMass(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle);
+  G4double PhaseSpace(const ReactionProduct& aReaction, const G4DynamicParticle* aDynamicParticle);
+
+  G4double ReactionProductMass(const ReactionProduct& aReaction, const G4DynamicParticle* aDynamicParticle);
 
   G4bool ReactionGivesBaryon(const ReactionProduct& aReaction);
 
-  G4bool ReactionIsPossible(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle);
+  G4bool ReactionIsPossible(const ReactionProduct& aReaction, const G4DynamicParticle* aDynamicParticle);
 
-  void ReadAndParse(const G4String& str,
-		    std::vector<G4String>& tokens,
-		    const G4String& delimiters = " ");
+  void ReadAndParse(const G4String& str, std::vector<G4String>& tokens, const G4String& delimiters = " ");
 
   //Map of applicable particles
-  std::map<const G4ParticleDefinition*,G4bool> known_particles;
+  std::map<const G4ParticleDefinition*, G4bool> known_particles;
 
   //Map for physics parameters, name to value
-  std::map<G4String,G4double> parameters;
+  std::map<G4String, G4double> parameters;
 
   //The parameters themselves
   bool resonant;
@@ -86,7 +80,6 @@ private:
   bool reggemodel;
   double hadronlifetime;
   double mixing;
-
 
   //Proton-scattering processes
   ReactionMap pReactionMap;
@@ -102,6 +95,5 @@ private:
   TH1D* h_sqrts;
   TProfile* h_q_p;
   TProfile* h_q_gamma;
-
 };
 #endif

--- a/SimG4Core/CustomPhysics/interface/HadronicProcessHelper.h
+++ b/SimG4Core/CustomPhysics/interface/HadronicProcessHelper.h
@@ -1,70 +1,67 @@
 #ifndef SimG4Core_CustomPhysics_HadronicProcessHelper_H
 #define SimG4Core_CustomPhysics_HadronicProcessHelper_H
 
-#include"globals.hh"
-#include"G4ParticleDefinition.hh"
-#include"G4DynamicParticle.hh"
-#include"G4Element.hh"
-#include"G4Track.hh"
+#include "globals.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4DynamicParticle.hh"
+#include "G4Element.hh"
+#include "G4Track.hh"
 
-#include<vector>
-#include<map>
+#include <vector>
+#include <map>
 #include <string>
 
 class G4ParticleTable;
 
 class HadronicProcessHelper {
-
 public:
-
-//Typedefs just made to make life easier :-) 
+  //Typedefs just made to make life easier :-)
   typedef std::vector<G4int> ReactionProduct;
-  typedef std::vector<ReactionProduct > ReactionProductList;
-  typedef std::map<G4int , ReactionProductList> ReactionMap;
+  typedef std::vector<ReactionProduct> ReactionProductList;
+  typedef std::map<G4int, ReactionProductList> ReactionMap;
 
-  HadronicProcessHelper(const std::string & fileName);
-  
+  HadronicProcessHelper(const std::string& fileName);
+
   HadronicProcessHelper(const HadronicProcessHelper&);
-  
-  HadronicProcessHelper& operator= (const HadronicProcessHelper&);
 
-  HadronicProcessHelper* instance() {return this;};
+  HadronicProcessHelper& operator=(const HadronicProcessHelper&);
+
+  HadronicProcessHelper* instance() { return this; };
 
   G4bool applicabilityTester(const G4ParticleDefinition& particle);
 
-  G4double inclusiveCrossSection(const G4DynamicParticle *particle,
-				    const G4Element *element);
+  G4double inclusiveCrossSection(const G4DynamicParticle* particle, const G4Element* element);
 
   //Make sure the element is known (for n/p-decision)
-  ReactionProduct finalState(const G4Track& track,G4ParticleDefinition*& target)
-  {
-   return finalState(track.GetDynamicParticle(),track.GetMaterial(),  target);
+  ReactionProduct finalState(const G4Track& track, G4ParticleDefinition*& target) {
+    return finalState(track.GetDynamicParticle(), track.GetMaterial(), target);
   }
-  ReactionProduct finalState(const G4DynamicParticle *  particle, const G4Material* material, G4ParticleDefinition*& target);
-
+  ReactionProduct finalState(const G4DynamicParticle* particle,
+                             const G4Material* material,
+                             G4ParticleDefinition*& target);
 
 private:
-
   G4ParticleDefinition* m_proton;
   G4ParticleDefinition* m_neutron;
 
-//  ReactionMap* m_reactionMap;
+  //  ReactionMap* m_reactionMap;
 
-  G4double m_phaseSpace(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle,
-		        G4ParticleDefinition* target);
-  
-  G4double m_reactionProductMass(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle,
-		        G4ParticleDefinition* target);
+  G4double m_phaseSpace(const ReactionProduct& aReaction,
+                        const G4DynamicParticle* aDynamicParticle,
+                        G4ParticleDefinition* target);
 
-  G4bool m_reactionIsPossible(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle,
-		        G4ParticleDefinition* target);
+  G4double m_reactionProductMass(const ReactionProduct& aReaction,
+                                 const G4DynamicParticle* aDynamicParticle,
+                                 G4ParticleDefinition* target);
 
-  void m_readAndParse(const G4String& str,
-		    std::vector<G4String>& tokens,
-		    const G4String& delimiters = " ");
+  G4bool m_reactionIsPossible(const ReactionProduct& aReaction,
+                              const G4DynamicParticle* aDynamicParticle,
+                              G4ParticleDefinition* target);
+
+  void m_readAndParse(const G4String& str, std::vector<G4String>& tokens, const G4String& delimiters = " ");
 
   //Map of applicable particles
-  std::map<const G4ParticleDefinition*,G4bool> m_knownParticles;
+  std::map<const G4ParticleDefinition*, G4bool> m_knownParticles;
 
   //Proton-scattering processes
   ReactionMap m_protonReactionMap;
@@ -74,11 +71,10 @@ private:
 
   G4ParticleTable* m_particleTable;
 
-////Debug stuff
+  ////Debug stuff
   G4double m_checkFraction;
   G4int m_n22;
   G4int m_n23;
-
 };
 
 #endif

--- a/SimG4Core/CustomPhysics/interface/RHStopDump.h
+++ b/SimG4Core/CustomPhysics/interface/RHStopDump.h
@@ -1,5 +1,5 @@
 #ifndef SimG4Core_CustomPhysics_RHStopDump_H
-#define SimG4Core_CustomPhysics_RHStopDump_H 
+#define SimG4Core_CustomPhysics_RHStopDump_H
 //
 // Dump stopping points from the Event into ASCII file
 // F.Ratnikov, Apr. 8, 2010
@@ -10,11 +10,12 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 class RHStopDump : public edm::one::EDAnalyzer<edm::one::SharedResources> {
- public:
+public:
   explicit RHStopDump(const edm::ParameterSet&);
-  ~RHStopDump() override {};
+  ~RHStopDump() override{};
   void analyze(const edm::Event&, const edm::EventSetup&) override;
- private:
+
+private:
   std::ofstream mStream;
   std::string mProducer;
 };

--- a/SimG4Core/CustomPhysics/interface/RHStopTracer.h
+++ b/SimG4Core/CustomPhysics/interface/RHStopTracer.h
@@ -15,25 +15,25 @@ class EndOfTrack;
 class G4Step;
 class G4ParticleDefinition;
 
-class RHStopTracer :  public SimProducer,
-		      public Observer<const BeginOfRun *>, 
-		      public Observer<const BeginOfEvent *>, 
-		      public Observer<const BeginOfTrack *>,
-		      public Observer<const EndOfTrack *>
-{
- public:
-  RHStopTracer(edm::ParameterSet const & p);
+class RHStopTracer : public SimProducer,
+                     public Observer<const BeginOfRun *>,
+                     public Observer<const BeginOfEvent *>,
+                     public Observer<const BeginOfTrack *>,
+                     public Observer<const EndOfTrack *> {
+public:
+  RHStopTracer(edm::ParameterSet const &p);
   ~RHStopTracer() override;
   void update(const BeginOfRun *) override;
   void update(const BeginOfEvent *) override;
   void update(const BeginOfTrack *) override;
   void update(const EndOfTrack *) override;
-  void produce(edm::Event&, const edm::EventSetup&) override;
- private:
+  void produce(edm::Event &, const edm::EventSetup &) override;
+
+private:
   struct StopPoint {
-    StopPoint (const std::string& fName, double fX, double fY, double fZ, double fT, int fId, double fMass, double fCharge) 
-    : name(fName), x(fX), y(fY), z(fZ), t(fT), id(fId), mass(fMass), charge(fCharge) 
-    {}
+    StopPoint(
+        const std::string &fName, double fX, double fY, double fZ, double fT, int fId, double fMass, double fCharge)
+        : name(fName), x(fX), y(fY), z(fZ), t(fT), id(fId), mass(fMass), charge(fCharge) {}
     std::string name;
     double x;
     double y;
@@ -50,7 +50,7 @@ class RHStopTracer :  public SimProducer,
   int otherPdgId;
   std::string mTraceParticleName;
   std::regex rePartName;
-  std::vector <StopPoint> mStopPoints;
+  std::vector<StopPoint> mStopPoints;
 };
 
 #endif

--- a/SimG4Core/CustomPhysics/plugins/RHStopDump.cc
+++ b/SimG4Core/CustomPhysics/plugins/RHStopDump.cc
@@ -4,38 +4,35 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-RHStopDump::RHStopDump(edm::ParameterSet const & parameters) 
-  : mStream (parameters.getParameter<std::string>("stoppedFile").c_str()),
-    mProducer (parameters.getUntrackedParameter<std::string>("producer", "g4SimHits"))
-{}
+RHStopDump::RHStopDump(edm::ParameterSet const& parameters)
+    : mStream(parameters.getParameter<std::string>("stoppedFile").c_str()),
+      mProducer(parameters.getUntrackedParameter<std::string>("producer", "g4SimHits")) {}
 
- void RHStopDump::analyze(const edm::Event& fEvent, const edm::EventSetup&) {
-   edm::Handle<std::vector<std::string> > names;
-   fEvent.getByLabel (mProducer, "StoppedParticlesName", names);
-   edm::Handle<std::vector<float> > xs;
-   fEvent.getByLabel (mProducer, "StoppedParticlesX", xs);
-   edm::Handle<std::vector<float> > ys;
-   fEvent.getByLabel (mProducer, "StoppedParticlesY", ys);
-   edm::Handle<std::vector<float> > zs;
-   fEvent.getByLabel (mProducer, "StoppedParticlesZ", zs);
-   edm::Handle<std::vector<float> > ts;
-   fEvent.getByLabel (mProducer, "StoppedParticlesTime", ts);
-   edm::Handle<std::vector<int> > ids;
-   fEvent.getByLabel (mProducer, "StoppedParticlesPdgId", ids);
-   edm::Handle<std::vector<float> > masses;
-   fEvent.getByLabel (mProducer, "StoppedParticlesMass", masses);
-   edm::Handle<std::vector<float> > charges;
-   fEvent.getByLabel (mProducer, "StoppedParticlesCharge", charges);
+void RHStopDump::analyze(const edm::Event& fEvent, const edm::EventSetup&) {
+  edm::Handle<std::vector<std::string> > names;
+  fEvent.getByLabel(mProducer, "StoppedParticlesName", names);
+  edm::Handle<std::vector<float> > xs;
+  fEvent.getByLabel(mProducer, "StoppedParticlesX", xs);
+  edm::Handle<std::vector<float> > ys;
+  fEvent.getByLabel(mProducer, "StoppedParticlesY", ys);
+  edm::Handle<std::vector<float> > zs;
+  fEvent.getByLabel(mProducer, "StoppedParticlesZ", zs);
+  edm::Handle<std::vector<float> > ts;
+  fEvent.getByLabel(mProducer, "StoppedParticlesTime", ts);
+  edm::Handle<std::vector<int> > ids;
+  fEvent.getByLabel(mProducer, "StoppedParticlesPdgId", ids);
+  edm::Handle<std::vector<float> > masses;
+  fEvent.getByLabel(mProducer, "StoppedParticlesMass", masses);
+  edm::Handle<std::vector<float> > charges;
+  fEvent.getByLabel(mProducer, "StoppedParticlesCharge", charges);
 
-   if (names->size() != xs->size() || xs->size() != ys->size() || ys->size() != zs->size()) {
-     edm::LogError ("RHStopDump") << "mismatch array sizes name/x/y/z:"
-				  << names->size() << '/' << xs->size() << '/' << ys->size() << '/' << zs->size()
-				  << std::endl;
-   }
-   else {
-     for (size_t i = 0; i < names->size(); ++i) {
-       mStream << (*names)[i] << ' ' << (*xs)[i] << ' ' << (*ys)[i] << ' ' << (*zs)[i] << ' ' << (*ts)[i] << std::endl;
-       mStream << (*ids)[i] << ' ' << (*masses)[i] << ' ' << (*charges)[i] << std::endl;
-     }
-   }
- }
+  if (names->size() != xs->size() || xs->size() != ys->size() || ys->size() != zs->size()) {
+    edm::LogError("RHStopDump") << "mismatch array sizes name/x/y/z:" << names->size() << '/' << xs->size() << '/'
+                                << ys->size() << '/' << zs->size() << std::endl;
+  } else {
+    for (size_t i = 0; i < names->size(); ++i) {
+      mStream << (*names)[i] << ' ' << (*xs)[i] << ' ' << (*ys)[i] << ' ' << (*zs)[i] << ' ' << (*ts)[i] << std::endl;
+      mStream << (*ids)[i] << ' ' << (*masses)[i] << ' ' << (*charges)[i] << std::endl;
+    }
+  }
+}

--- a/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
+++ b/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
@@ -9,7 +9,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-  
+
 #include "G4Track.hh"
 #include "G4Run.hh"
 #include "G4Event.hh"
@@ -17,97 +17,87 @@
 #include "G4ParticleTable.hh"
 #include "G4ParticleDefinition.hh"
 
-RHStopTracer::RHStopTracer(edm::ParameterSet const & p) {
+RHStopTracer::RHStopTracer(edm::ParameterSet const& p) {
   edm::ParameterSet parameters = p.getParameter<edm::ParameterSet>("RHStopTracer");
   mStopRegular = parameters.getUntrackedParameter<bool>("stopRegularParticles", false);
-  mTraceEnergy = parameters.getUntrackedParameter<double>("traceEnergy", 1.e20); 
+  mTraceEnergy = parameters.getUntrackedParameter<double>("traceEnergy", 1.e20);
   mTraceParticleName = parameters.getParameter<std::string>("traceParticle");
-  minPdgId = parameters.getUntrackedParameter<int>("minPdgId", 1000000); 
-  maxPdgId = parameters.getUntrackedParameter<int>("maxPdgId", 2000000); 
-  otherPdgId = parameters.getUntrackedParameter<int>("otherPdgId", 17); 
-  produces< std::vector<std::string> >("StoppedParticlesName");
-  produces< std::vector<float> >("StoppedParticlesX");
-  produces< std::vector<float> >("StoppedParticlesY");
-  produces< std::vector<float> >("StoppedParticlesZ");
-  produces< std::vector<float> >("StoppedParticlesTime");
-  produces< std::vector<int> >("StoppedParticlesPdgId");
-  produces< std::vector<float> >("StoppedParticlesMass");
-  produces< std::vector<float> >("StoppedParticlesCharge");
+  minPdgId = parameters.getUntrackedParameter<int>("minPdgId", 1000000);
+  maxPdgId = parameters.getUntrackedParameter<int>("maxPdgId", 2000000);
+  otherPdgId = parameters.getUntrackedParameter<int>("otherPdgId", 17);
+  produces<std::vector<std::string> >("StoppedParticlesName");
+  produces<std::vector<float> >("StoppedParticlesX");
+  produces<std::vector<float> >("StoppedParticlesY");
+  produces<std::vector<float> >("StoppedParticlesZ");
+  produces<std::vector<float> >("StoppedParticlesTime");
+  produces<std::vector<int> >("StoppedParticlesPdgId");
+  produces<std::vector<float> >("StoppedParticlesMass");
+  produces<std::vector<float> >("StoppedParticlesCharge");
 
   mTraceEnergy *= CLHEP::GeV;
   rePartName = mTraceParticleName;
 
-  edm::LogInfo("SimG4CoreCustomPhysics")
-    << "RHStopTracer::RHStopTracer " << mTraceParticleName 
-    << " Eth(GeV)= " << mTraceEnergy;
-
+  edm::LogInfo("SimG4CoreCustomPhysics") << "RHStopTracer::RHStopTracer " << mTraceParticleName
+                                         << " Eth(GeV)= " << mTraceEnergy;
 }
 
-RHStopTracer::~RHStopTracer() {
+RHStopTracer::~RHStopTracer() {}
+
+void RHStopTracer::update(const BeginOfRun* fRun) {
+  LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::update-> begin of the run " << (*fRun)()->GetRunID();
 }
 
-void RHStopTracer::update (const BeginOfRun * fRun) {
-  LogDebug("SimG4CoreCustomPhysics")
-    << "RHStopTracer::update-> begin of the run " << (*fRun)()->GetRunID(); 
+void RHStopTracer::update(const BeginOfEvent* fEvent) {
+  LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::update-> begin of the event " << (*fEvent)()->GetEventID();
 }
 
-void RHStopTracer::update (const BeginOfEvent * fEvent) {
-  LogDebug("SimG4CoreCustomPhysics")
-    << "RHStopTracer::update-> begin of the event " << (*fEvent)()->GetEventID(); 
-}
-
-void RHStopTracer::update (const BeginOfTrack * fTrack) {
+void RHStopTracer::update(const BeginOfTrack* fTrack) {
   const G4Track* track = (*fTrack)();
   const G4ParticleDefinition* part = track->GetDefinition();
   const std::string& stringPartName = part->GetParticleName();
   bool matched = false;
   int pdgid = std::abs(part->GetPDGEncoding());
-  if( (pdgid>minPdgId && pdgid<maxPdgId) || pdgid==otherPdgId )
-     matched = std::regex_match(stringPartName,rePartName);
-  if( matched ||  track->GetKineticEnergy() > mTraceEnergy) {
-    LogDebug("SimG4CoreCustomPhysics")
-      << "RHStopTracer::update-> new track: ID/Name/pdgId/mass/charge/Parent: " 
-      << track->GetTrackID() << '/' << part->GetParticleName() << '/' 
-      << part->GetPDGEncoding() << '/'
-      << part->GetPDGMass()/GeV <<" GeV/" << part->GetPDGCharge() << '/'
-      << track->GetParentID()
-      << " Position: " << track->GetPosition() << ' ' 
-      << " R/phi: " << track->GetPosition().perp() << '/' << track->GetPosition().phi()
-      << "   4vec " << track->GetMomentum();
-  } else if (mStopRegular) { // kill regular particles
+  if ((pdgid > minPdgId && pdgid < maxPdgId) || pdgid == otherPdgId)
+    matched = std::regex_match(stringPartName, rePartName);
+  if (matched || track->GetKineticEnergy() > mTraceEnergy) {
+    LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::update-> new track: ID/Name/pdgId/mass/charge/Parent: "
+                                       << track->GetTrackID() << '/' << part->GetParticleName() << '/'
+                                       << part->GetPDGEncoding() << '/' << part->GetPDGMass() / GeV << " GeV/"
+                                       << part->GetPDGCharge() << '/' << track->GetParentID()
+                                       << " Position: " << track->GetPosition() << ' '
+                                       << " R/phi: " << track->GetPosition().perp() << '/' << track->GetPosition().phi()
+                                       << "   4vec " << track->GetMomentum();
+  } else if (mStopRegular) {  // kill regular particles
     const_cast<G4Track*>(track)->SetTrackStatus(fStopAndKill);
   }
 }
 
-void RHStopTracer::update (const EndOfTrack * fTrack) {
+void RHStopTracer::update(const EndOfTrack* fTrack) {
   const G4Track* track = (*fTrack)();
   const G4ParticleDefinition* part = track->GetDefinition();
   const std::string& stringPartName = part->GetParticleName();
   bool matched = false;
   int pdgid = std::abs(part->GetPDGEncoding());
-  if( (pdgid>minPdgId && pdgid<maxPdgId) || pdgid==otherPdgId )
-     matched = std::regex_match(stringPartName,rePartName);
-  if( matched ||  track->GetKineticEnergy() > mTraceEnergy) {
-    LogDebug("SimG4CoreCustomPhysics")
-      << "RHStopTracer::update-> stop track: ID/Name/pdgId/mass/charge/Parent: " 
-      << track->GetTrackID() << '/' << part->GetParticleName() << '/' 
-      << part->GetPDGEncoding() << '/'
-      << part->GetPDGMass()/GeV <<" GeV/" << part->GetPDGCharge() << '/'
-      << track->GetParentID()
-      << " Position: " << track->GetPosition() << ' ' 
-      << " R/phi: " << track->GetPosition().perp() << '/' << track->GetPosition().phi()
-      << "   4vec " << track->GetMomentum();
-    if (track->GetMomentum().mag () < 0.001) {
-      LogDebug("SimG4CoreCustomPhysics") <<
-	"RHStopTracer:: track has stopped, so making StopPoint";
-      mStopPoints.push_back (StopPoint (track->GetDefinition()->GetParticleName(),
-					track->GetPosition().x(),
-					track->GetPosition().y(),
-					track->GetPosition().z(),
-					track->GetGlobalTime(),
-					track->GetDefinition()->GetPDGEncoding(),
-                                        track->GetDefinition()->GetPDGMass()/GeV,
-                                        track->GetDefinition()->GetPDGCharge() ));
+  if ((pdgid > minPdgId && pdgid < maxPdgId) || pdgid == otherPdgId)
+    matched = std::regex_match(stringPartName, rePartName);
+  if (matched || track->GetKineticEnergy() > mTraceEnergy) {
+    LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::update-> stop track: ID/Name/pdgId/mass/charge/Parent: "
+                                       << track->GetTrackID() << '/' << part->GetParticleName() << '/'
+                                       << part->GetPDGEncoding() << '/' << part->GetPDGMass() / GeV << " GeV/"
+                                       << part->GetPDGCharge() << '/' << track->GetParentID()
+                                       << " Position: " << track->GetPosition() << ' '
+                                       << " R/phi: " << track->GetPosition().perp() << '/' << track->GetPosition().phi()
+                                       << "   4vec " << track->GetMomentum();
+    if (track->GetMomentum().mag() < 0.001) {
+      LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer:: track has stopped, so making StopPoint";
+      mStopPoints.push_back(StopPoint(track->GetDefinition()->GetParticleName(),
+                                      track->GetPosition().x(),
+                                      track->GetPosition().y(),
+                                      track->GetPosition().z(),
+                                      track->GetGlobalTime(),
+                                      track->GetDefinition()->GetPDGEncoding(),
+                                      track->GetDefinition()->GetPDGMass() / GeV,
+                                      track->GetDefinition()->GetPDGCharge()));
     }
   }
 }
@@ -115,33 +105,33 @@ void RHStopTracer::update (const EndOfTrack * fTrack) {
 void RHStopTracer::produce(edm::Event& fEvent, const edm::EventSetup&) {
   LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::produce->";
 
-   std::unique_ptr<std::vector<std::string> > names(new std::vector<std::string>); 
-   std::unique_ptr<std::vector<float> > xs(new std::vector<float>);
-   std::unique_ptr<std::vector<float> > ys(new std::vector<float>);
-   std::unique_ptr<std::vector<float> > zs(new std::vector<float>);
-   std::unique_ptr<std::vector<float> > ts(new std::vector<float>);
-   std::unique_ptr<std::vector<int> > ids(new std::vector<int>);
-   std::unique_ptr<std::vector<float> > masses(new std::vector<float>);
-   std::unique_ptr<std::vector<float> > charges(new std::vector<float>);
+  std::unique_ptr<std::vector<std::string> > names(new std::vector<std::string>);
+  std::unique_ptr<std::vector<float> > xs(new std::vector<float>);
+  std::unique_ptr<std::vector<float> > ys(new std::vector<float>);
+  std::unique_ptr<std::vector<float> > zs(new std::vector<float>);
+  std::unique_ptr<std::vector<float> > ts(new std::vector<float>);
+  std::unique_ptr<std::vector<int> > ids(new std::vector<int>);
+  std::unique_ptr<std::vector<float> > masses(new std::vector<float>);
+  std::unique_ptr<std::vector<float> > charges(new std::vector<float>);
 
-   std::vector <StopPoint>::const_iterator stopPoint = mStopPoints.begin ();
-   for (;  stopPoint != mStopPoints.end(); ++stopPoint) {
-     names->push_back (stopPoint->name);
-     xs->push_back (stopPoint->x);
-     ys->push_back (stopPoint->y);
-     zs->push_back (stopPoint->z);
-     ts->push_back (stopPoint->t);
-     ids->push_back (stopPoint->id);
-     masses->push_back (stopPoint->mass);
-     charges->push_back (stopPoint->charge);
-   }
-   fEvent.put(std::move(names), "StoppedParticlesName");
-   fEvent.put(std::move(xs), "StoppedParticlesX");
-   fEvent.put(std::move(ys), "StoppedParticlesY");
-   fEvent.put(std::move(zs), "StoppedParticlesZ");
-   fEvent.put(std::move(ts), "StoppedParticlesTime");
-   fEvent.put(std::move(ids), "StoppedParticlesPdgId");
-   fEvent.put(std::move(masses), "StoppedParticlesMass");
-   fEvent.put(std::move(charges), "StoppedParticlesCharge");
-   mStopPoints.clear ();
+  std::vector<StopPoint>::const_iterator stopPoint = mStopPoints.begin();
+  for (; stopPoint != mStopPoints.end(); ++stopPoint) {
+    names->push_back(stopPoint->name);
+    xs->push_back(stopPoint->x);
+    ys->push_back(stopPoint->y);
+    zs->push_back(stopPoint->z);
+    ts->push_back(stopPoint->t);
+    ids->push_back(stopPoint->id);
+    masses->push_back(stopPoint->mass);
+    charges->push_back(stopPoint->charge);
+  }
+  fEvent.put(std::move(names), "StoppedParticlesName");
+  fEvent.put(std::move(xs), "StoppedParticlesX");
+  fEvent.put(std::move(ys), "StoppedParticlesY");
+  fEvent.put(std::move(zs), "StoppedParticlesZ");
+  fEvent.put(std::move(ts), "StoppedParticlesTime");
+  fEvent.put(std::move(ids), "StoppedParticlesPdgId");
+  fEvent.put(std::move(masses), "StoppedParticlesMass");
+  fEvent.put(std::move(charges), "StoppedParticlesCharge");
+  mStopPoints.clear();
 }

--- a/SimG4Core/CustomPhysics/plugins/module.cc
+++ b/SimG4Core/CustomPhysics/plugins/module.cc
@@ -9,6 +9,5 @@
 #include "SimG4Core/CustomPhysics/interface/RHStopTracer.h"
 
 DEFINE_PHYSICSLIST(CustomPhysics);
-DEFINE_FWK_MODULE(RHStopDump) ;
+DEFINE_FWK_MODULE(RHStopDump);
 DEFINE_SIMWATCHER(RHStopTracer);
-

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProduction.cc
@@ -1,6 +1,6 @@
 //
 // Authors of this file:        Dustin Stolp (dostolp@ucdavis.edu)
-//                              Sushil S. Chauhan (schauhan@cern.ch) 
+//                              Sushil S. Chauhan (schauhan@cern.ch)
 // Creation date: 01.22.2015
 //
 // -------------------------------------------------------------------
@@ -12,14 +12,12 @@
 
 using namespace std;
 
-CMSDarkPairProduction::CMSDarkPairProduction(const G4ParticleDefinition* p,G4double df,
-   const G4String& nam) : G4PairProductionRelModel(p,nam), dark_factor(df) {}
+CMSDarkPairProduction::CMSDarkPairProduction(const G4ParticleDefinition* p, G4double df, const G4String& nam)
+    : G4PairProductionRelModel(p, nam), dark_factor(df) {}
 
-CMSDarkPairProduction::~CMSDarkPairProduction(){}
+CMSDarkPairProduction::~CMSDarkPairProduction() {}
 
-G4double CMSDarkPairProduction::ComputeCrossSectionPerAtom(const G4ParticleDefinition* p,
-         G4double e, G4double Z, G4double e1, G4double e2, G4double e3)
-{
-  return dark_factor
-    *G4PairProductionRelModel::ComputeCrossSectionPerAtom(p, e, Z, e1, e2, e3);
+G4double CMSDarkPairProduction::ComputeCrossSectionPerAtom(
+    const G4ParticleDefinition* p, G4double e, G4double Z, G4double e1, G4double e2, G4double e3) {
+  return dark_factor * G4PairProductionRelModel::ComputeCrossSectionPerAtom(p, e, Z, e1, e2, e3);
 }

--- a/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
+++ b/SimG4Core/CustomPhysics/src/CMSDarkPairProductionProcess.cc
@@ -1,7 +1,7 @@
 //
 // ********************************************************************
 // Authors of this file: Dustin Stolp (dostolp@ucdavis.edu)
-//                       Sushil S. Chauhan (schauhan@cern.ch)   
+//                       Sushil S. Chauhan (schauhan@cern.ch)
 //
 // -----------------------------------------------------------------------------
 
@@ -14,13 +14,9 @@
 
 using namespace std;
 
-CMSDarkPairProductionProcess::CMSDarkPairProductionProcess(
-  G4double df,
-  const G4String& processName,  
-  G4ProcessType type):G4VEmProcess (processName, type),
-		      isInitialised(false), darkFactor(df)
-{ 
-  SetMinKinEnergy(2.0*electron_mass_c2);
+CMSDarkPairProductionProcess::CMSDarkPairProductionProcess(G4double df, const G4String& processName, G4ProcessType type)
+    : G4VEmProcess(processName, type), isInitialised(false), darkFactor(df) {
+  SetMinKinEnergy(2.0 * electron_mass_c2);
   SetProcessSubType(fGammaConversion);
   SetStartFromNullFlag(true);
   SetBuildTableFlag(true);
@@ -28,35 +24,22 @@ CMSDarkPairProductionProcess::CMSDarkPairProductionProcess(
   SetLambdaBinning(220);
 }
 
- 
-CMSDarkPairProductionProcess::~CMSDarkPairProductionProcess()
-{}
+CMSDarkPairProductionProcess::~CMSDarkPairProductionProcess() {}
 
-
-G4bool CMSDarkPairProductionProcess::IsApplicable(const G4ParticleDefinition& p)
-{
-  return (p.GetParticleType()=="darkpho");
+G4bool CMSDarkPairProductionProcess::IsApplicable(const G4ParticleDefinition& p) {
+  return (p.GetParticleType() == "darkpho");
 }
 
-
-void CMSDarkPairProductionProcess::InitialiseProcess(const G4ParticleDefinition* p)
-{
-  if(!isInitialised) {
+void CMSDarkPairProductionProcess::InitialiseProcess(const G4ParticleDefinition* p) {
+  if (!isInitialised) {
     isInitialised = true;
-    
-       AddEmModel(0, new CMSDarkPairProduction(p,darkFactor));
 
+    AddEmModel(0, new CMSDarkPairProduction(p, darkFactor));
   }
 }
 
-
-G4double CMSDarkPairProductionProcess::MinPrimaryEnergy(const G4ParticleDefinition*,
-					     const G4Material*)
-{
-  return 2*electron_mass_c2;
+G4double CMSDarkPairProductionProcess::MinPrimaryEnergy(const G4ParticleDefinition*, const G4Material*) {
+  return 2 * electron_mass_c2;
 }
 
-
-void CMSDarkPairProductionProcess::PrintInfo()
-{}         
-
+void CMSDarkPairProductionProcess::PrintInfo() {}

--- a/SimG4Core/CustomPhysics/src/CMSExoticaPhysics.cc
+++ b/SimG4Core/CustomPhysics/src/CMSExoticaPhysics.cc
@@ -2,14 +2,13 @@
 #include "SimG4Core/CustomPhysics/interface/CustomPhysicsList.h"
 #include "SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
- 
-CMSExoticaPhysics::CMSExoticaPhysics(PhysicsList* phys, const edm::ParameterSet & p) {
 
-  bool ssPhys  = p.getUntrackedParameter<bool>("ExoticaPhysicsSS",false);
-                 
-  if(ssPhys) {
-    phys->RegisterPhysics(new CustomPhysicsListSS("custom",p,true));
+CMSExoticaPhysics::CMSExoticaPhysics(PhysicsList* phys, const edm::ParameterSet& p) {
+  bool ssPhys = p.getUntrackedParameter<bool>("ExoticaPhysicsSS", false);
+
+  if (ssPhys) {
+    phys->RegisterPhysics(new CustomPhysicsListSS("custom", p, true));
   } else {
-    phys->RegisterPhysics(new CustomPhysicsList("custom",p,true));    
+    phys->RegisterPhysics(new CustomPhysicsList("custom", p, true));
   }
 }

--- a/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPDGParser.cc
@@ -7,184 +7,165 @@
 
 }*/
 
-bool CustomPDGParser::s_isRHadron(int pdg) 
-{
- int pdgAbs=abs(pdg);
- return ( (pdgAbs % 100000 / 10000 == 9) ||  (pdgAbs % 10000 / 1000 == 9) || s_isRGlueball(pdg) );
-}
-
-bool CustomPDGParser::s_isstopHadron(int pdg) 
-{
- int pdgAbs=abs(pdg);
- return ( (pdgAbs % 10000 / 1000 == 6) ||  (pdgAbs % 1000 / 100 == 6)  );
-}
-
-bool CustomPDGParser::s_issbottomHadron(int pdg) 
-{
- int pdgAbs=abs(pdg);
- return ( (pdgAbs % 10000 / 1000 == 5) ||  (pdgAbs % 10000 / 100 == 5)  );
-}
-
-bool CustomPDGParser::s_isSLepton(int pdg)
-{
- int pdgAbs=abs(pdg);
- return (pdgAbs / 100 % 10000 == 0 && pdgAbs / 10 % 10 == 1);
-}
-
-bool CustomPDGParser::s_isRBaryon(int pdg)
-{
- int pdgAbs=abs(pdg);
- return  (pdgAbs % 100000 / 10000 == 9);
-
-}
-
-bool CustomPDGParser::s_isRGlueball(int pdg)
-{
- int pdgAbs=abs(pdg);
- return  (pdgAbs % 100000 / 10 == 99);
-
-}
-
-bool CustomPDGParser::s_isDphoton(int pdg)
-{                      
- int pdgAbs=abs(pdg);  
- return  (pdgAbs == 1072000);
-                       
-}
-
-bool CustomPDGParser::s_isRMeson(int pdg)
-{
- int pdgAbs=abs(pdg);
- return (pdgAbs % 10000 / 1000 == 9);
-
-}
-
-bool CustomPDGParser::s_isMesonino(int pdg)
-{
- int pdgAbs=abs(pdg);
- return ((pdgAbs % 10000 / 100 == 6 ) || (pdgAbs % 10000 / 100 == 5));
-
-
-}
-
-bool CustomPDGParser::s_isSbaryon(int pdg)
-{
- int pdgAbs=abs(pdg);
- return ((pdgAbs % 10000 / 1000 == 6) || (pdgAbs % 10000 / 1000 == 5));
-
-}
-
-bool CustomPDGParser::s_isChargino( int pdg )
-{
+bool CustomPDGParser::s_isRHadron(int pdg) {
   int pdgAbs = abs(pdg);
-  return (pdgAbs == 1000024);  
+  return ((pdgAbs % 100000 / 10000 == 9) || (pdgAbs % 10000 / 1000 == 9) || s_isRGlueball(pdg));
 }
 
-
-double CustomPDGParser::s_charge(int pdg)
-{
-      float charge=0,sign=1;
-      int pdgAbs=abs(pdg);
-      if(pdg < 0 ) sign=-1;
-
-      if(s_isSLepton(pdg))     //Sleptons
-        {
-	  if(pdgAbs %2 == 0) 
-	      return 0;
-           else
-      	      return -sign;
-	}
-
-      if(s_isDphoton(pdg)){                                                                                                                           
-          return charge;
-      }
-      if (s_isChargino(pdg)) {
-	return sign;
-      } 
-      if(s_isRMeson(pdg))
-      {
-        std::vector<int> quarks = s_containedQuarks(pdg);
-        if((quarks[1] % 2 == 0 && quarks[0] % 2 == 1)||(quarks[1] % 2 == 1 && quarks[0] % 2 == 0 )) charge=1;
-        charge*=sign;       
-       return charge;
-      }
-
-      if(s_isRBaryon(pdg))
-      {
-       int baryon = s_containedQuarksCode(pdg);
-       for(int q=1; q< 1000; q*=10)
-       {
-        if(baryon / q % 2 == 0) charge+=2; else charge -=1; 
-       }
-        charge/=3;
-	charge*=sign;
-	return charge;
-      }
-
-      if(s_isMesonino(pdg))
-	{
-	  int quark = s_containedQuarks(pdg)[0];
-	  int squark = abs(pdg/100%10);
-	  if (squark % 2 == 0 && quark % 2 == 1) charge = 1;
-	  if (squark % 2 == 1 && quark % 2 == 0) charge = 1;
-	  charge *= sign;
-	  if(s_issbottomHadron(pdg)) charge*=-1;
-	  return charge;
-	}
-
-      if(s_isSbaryon(pdg))
-	{
-	  int baryon = s_containedQuarksCode(pdg)+100*(abs(pdg/1000%10));//Adding the squark back on
-	  for(int q=1; q< 1000; q*=10)
-	    {
-	      if(baryon / q % 2 == 0) charge+=2; else charge -=1; 
-	    }
-	  charge/=3;
-	  charge*=sign;
-	  if(s_issbottomHadron(pdg)) charge*=-1;
-	  return charge;
-	}
-
-return 0; 
+bool CustomPDGParser::s_isstopHadron(int pdg) {
+  int pdgAbs = abs(pdg);
+  return ((pdgAbs % 10000 / 1000 == 6) || (pdgAbs % 1000 / 100 == 6));
 }
 
-double CustomPDGParser::s_spin(int pdg)
-{
-  // The PDG numbering is described in the Review of Particle Physics: 
+bool CustomPDGParser::s_issbottomHadron(int pdg) {
+  int pdgAbs = abs(pdg);
+  return ((pdgAbs % 10000 / 1000 == 5) || (pdgAbs % 10000 / 100 == 5));
+}
+
+bool CustomPDGParser::s_isSLepton(int pdg) {
+  int pdgAbs = abs(pdg);
+  return (pdgAbs / 100 % 10000 == 0 && pdgAbs / 10 % 10 == 1);
+}
+
+bool CustomPDGParser::s_isRBaryon(int pdg) {
+  int pdgAbs = abs(pdg);
+  return (pdgAbs % 100000 / 10000 == 9);
+}
+
+bool CustomPDGParser::s_isRGlueball(int pdg) {
+  int pdgAbs = abs(pdg);
+  return (pdgAbs % 100000 / 10 == 99);
+}
+
+bool CustomPDGParser::s_isDphoton(int pdg) {
+  int pdgAbs = abs(pdg);
+  return (pdgAbs == 1072000);
+}
+
+bool CustomPDGParser::s_isRMeson(int pdg) {
+  int pdgAbs = abs(pdg);
+  return (pdgAbs % 10000 / 1000 == 9);
+}
+
+bool CustomPDGParser::s_isMesonino(int pdg) {
+  int pdgAbs = abs(pdg);
+  return ((pdgAbs % 10000 / 100 == 6) || (pdgAbs % 10000 / 100 == 5));
+}
+
+bool CustomPDGParser::s_isSbaryon(int pdg) {
+  int pdgAbs = abs(pdg);
+  return ((pdgAbs % 10000 / 1000 == 6) || (pdgAbs % 10000 / 1000 == 5));
+}
+
+bool CustomPDGParser::s_isChargino(int pdg) {
+  int pdgAbs = abs(pdg);
+  return (pdgAbs == 1000024);
+}
+
+double CustomPDGParser::s_charge(int pdg) {
+  float charge = 0, sign = 1;
+  int pdgAbs = abs(pdg);
+  if (pdg < 0)
+    sign = -1;
+
+  if (s_isSLepton(pdg))  //Sleptons
+  {
+    if (pdgAbs % 2 == 0)
+      return 0;
+    else
+      return -sign;
+  }
+
+  if (s_isDphoton(pdg)) {
+    return charge;
+  }
+  if (s_isChargino(pdg)) {
+    return sign;
+  }
+  if (s_isRMeson(pdg)) {
+    std::vector<int> quarks = s_containedQuarks(pdg);
+    if ((quarks[1] % 2 == 0 && quarks[0] % 2 == 1) || (quarks[1] % 2 == 1 && quarks[0] % 2 == 0))
+      charge = 1;
+    charge *= sign;
+    return charge;
+  }
+
+  if (s_isRBaryon(pdg)) {
+    int baryon = s_containedQuarksCode(pdg);
+    for (int q = 1; q < 1000; q *= 10) {
+      if (baryon / q % 2 == 0)
+        charge += 2;
+      else
+        charge -= 1;
+    }
+    charge /= 3;
+    charge *= sign;
+    return charge;
+  }
+
+  if (s_isMesonino(pdg)) {
+    int quark = s_containedQuarks(pdg)[0];
+    int squark = abs(pdg / 100 % 10);
+    if (squark % 2 == 0 && quark % 2 == 1)
+      charge = 1;
+    if (squark % 2 == 1 && quark % 2 == 0)
+      charge = 1;
+    charge *= sign;
+    if (s_issbottomHadron(pdg))
+      charge *= -1;
+    return charge;
+  }
+
+  if (s_isSbaryon(pdg)) {
+    int baryon = s_containedQuarksCode(pdg) + 100 * (abs(pdg / 1000 % 10));  //Adding the squark back on
+    for (int q = 1; q < 1000; q *= 10) {
+      if (baryon / q % 2 == 0)
+        charge += 2;
+      else
+        charge -= 1;
+    }
+    charge /= 3;
+    charge *= sign;
+    if (s_issbottomHadron(pdg))
+      charge *= -1;
+    return charge;
+  }
+
+  return 0;
+}
+
+double CustomPDGParser::s_spin(int pdg) {
+  // The PDG numbering is described in the Review of Particle Physics:
   // "3. In composite quark systems (diquarks, mesons, and baryons) ...
-  // the rightmost digit nJ = 2J + 1 gives the system's spin."  
-  // Since this does not apply to SUSY / exotic particles, 
-  // if the spin is important for the simulation 
-  // it should be hard-coded based on PDG ID in this function.  
- int pdgAbs=abs(pdg);
- return pdgAbs % 10;    
+  // the rightmost digit nJ = 2J + 1 gives the system's spin."
+  // Since this does not apply to SUSY / exotic particles,
+  // if the spin is important for the simulation
+  // it should be hard-coded based on PDG ID in this function.
+  int pdgAbs = abs(pdg);
+  return pdgAbs % 10;
 }
 
- std::vector<int> CustomPDGParser::s_containedQuarks(int pdg)
-{
- std::vector<int> quarks;
- for(int i=s_containedQuarksCode(pdg); i > 0; i /= 10)
- {
+std::vector<int> CustomPDGParser::s_containedQuarks(int pdg) {
+  std::vector<int> quarks;
+  for (int i = s_containedQuarksCode(pdg); i > 0; i /= 10) {
     quarks.push_back(i % 10);
- }
- return quarks; 
+  }
+  return quarks;
 }
 
- int CustomPDGParser::s_containedQuarksCode(int pdg)
-{
- int pdgAbs=abs(pdg);
- if(s_isRBaryon(pdg))
-   return pdgAbs / 10 % 1000;
+int CustomPDGParser::s_containedQuarksCode(int pdg) {
+  int pdgAbs = abs(pdg);
+  if (s_isRBaryon(pdg))
+    return pdgAbs / 10 % 1000;
 
- if(s_isRMeson(pdg))
-   return pdgAbs / 10 % 100;
+  if (s_isRMeson(pdg))
+    return pdgAbs / 10 % 100;
 
- if(s_isMesonino(pdg))
-   return pdgAbs / 10 % 1000 % 10;
+  if (s_isMesonino(pdg))
+    return pdgAbs / 10 % 1000 % 10;
 
- if(s_isSbaryon(pdg))
-   return pdgAbs / 10 % 1000 % 100;
+  if (s_isSbaryon(pdg))
+    return pdgAbs / 10 % 1000 % 100;
 
-
-return 0;
+  return 0;
 }

--- a/SimG4Core/CustomPhysics/src/CustomParticle.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticle.cc
@@ -4,17 +4,37 @@
 // ###                           CustomParticle                       ###
 // ######################################################################
 
-CustomParticle::CustomParticle(
-       const G4String&     aName,        G4double            mass,
-       G4double            width,        G4double            charge,   
-       G4int               iSpin,        G4int               iParity,    
-       G4int               iConjugation, G4int               iIsospin,   
-       G4int               iIsospin3,    G4int               gParity,
-       const G4String&     pType,        G4int               lepton,      
-       G4int               baryon,       G4int               encoding,
-       G4bool              stable,       G4double            lifetime,
-       G4DecayTable        *decaytable )
- : G4ParticleDefinition( aName,mass,width,charge,iSpin,iParity,
-              iConjugation,iIsospin,iIsospin3,gParity,pType,
-              lepton,baryon,encoding,stable,lifetime,decaytable )
-{}
+CustomParticle::CustomParticle(const G4String& aName,
+                               G4double mass,
+                               G4double width,
+                               G4double charge,
+                               G4int iSpin,
+                               G4int iParity,
+                               G4int iConjugation,
+                               G4int iIsospin,
+                               G4int iIsospin3,
+                               G4int gParity,
+                               const G4String& pType,
+                               G4int lepton,
+                               G4int baryon,
+                               G4int encoding,
+                               G4bool stable,
+                               G4double lifetime,
+                               G4DecayTable* decaytable)
+    : G4ParticleDefinition(aName,
+                           mass,
+                           width,
+                           charge,
+                           iSpin,
+                           iParity,
+                           iConjugation,
+                           iIsospin,
+                           iIsospin3,
+                           gParity,
+                           pType,
+                           lepton,
+                           baryon,
+                           encoding,
+                           stable,
+                           lifetime,
+                           decaytable) {}

--- a/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
@@ -23,123 +23,129 @@ std::vector<G4ParticleDefinition *> CustomParticleFactory::m_particles;
 G4Mutex CustomParticleFactory::customParticleFactoryMutex = G4MUTEX_INITIALIZER;
 #endif
 
-CustomParticleFactory::CustomParticleFactory()
-{}
+CustomParticleFactory::CustomParticleFactory() {}
 
-CustomParticleFactory::~CustomParticleFactory()
-{}
+CustomParticleFactory::~CustomParticleFactory() {}
 
-void CustomParticleFactory::loadCustomParticles(const std::string & filePath){
-
-  if(loaded) { return; }
+void CustomParticleFactory::loadCustomParticles(const std::string &filePath) {
+  if (loaded) {
+    return;
+  }
 #ifdef G4MULTITHREADED
   G4MUTEXLOCK(&customParticleFactoryMutex);
-  if(loaded) { return; } 
+  if (loaded) {
+    return;
+  }
 #endif
 
   // loading once
-  loaded = true; 
+  loaded = true;
   std::ifstream configFile(filePath.c_str());
 
   std::string line;
-  edm::LogInfo("SimG4CoreCustomPhysics") 
-    <<"CustomParticleFactory: Reading Custom Particle and G4DecayTable from \n" 
-    << filePath; 
-  // This should be compatible IMO to SLHA 
-  G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
-  while(getline(configFile, line)){
-    line.erase(0, line.find_first_not_of(" \t"));            // Remove leading whitespace.
-    if (line.length()==0 || line.at(0) == '#') { continue; } // Skip blank lines and comments.  
+  edm::LogInfo("SimG4CoreCustomPhysics") << "CustomParticleFactory: Reading Custom Particle and G4DecayTable from \n"
+                                         << filePath;
+  // This should be compatible IMO to SLHA
+  G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
+  while (getline(configFile, line)) {
+    line.erase(0, line.find_first_not_of(" \t"));  // Remove leading whitespace.
+    if (line.length() == 0 || line.at(0) == '#') {
+      continue;
+    }  // Skip blank lines and comments.
     // The mass table begins with a line containing "BLOCK MASS"
-    if (ToLower(line).find("block") < line.npos &&        
-	ToLower(line).find("mass")  < line.npos) {
-      edm::LogInfo("SimG4CoreCustomPhysics") <<"CustomParticleFactory: Retrieving mass table."; 
+    if (ToLower(line).find("block") < line.npos && ToLower(line).find("mass") < line.npos) {
+      edm::LogInfo("SimG4CoreCustomPhysics") << "CustomParticleFactory: Retrieving mass table.";
       getMassTable(&configFile);
     }
-    if(line.find("DECAY")<line.npos) {
+    if (line.find("DECAY") < line.npos) {
       int pdgId;
-      double width; 
+      double width;
       std::string tmpString;
       std::stringstream lineStream(line);
-      lineStream >> tmpString >> pdgId >> width; 
+      lineStream >> tmpString >> pdgId >> width;
       // assume SLHA format, e.g.: DECAY  1000021  5.50675438E+00   # gluino decays
-      edm::LogInfo("SimG4CoreCustomPhysics") 
-	<<"CustomParticleFactory: entry to G4DecayTable: pdgID, width " 
-	<< pdgId << ",  " << width; 
+      edm::LogInfo("SimG4CoreCustomPhysics")
+          << "CustomParticleFactory: entry to G4DecayTable: pdgID, width " << pdgId << ",  " << width;
       G4ParticleDefinition *aParticle = theParticleTable->FindParticle(pdgId);
-      if (!aParticle || width == 0.0) { continue; }    
-      G4DecayTable* aDecayTable = getDecayTable(&configFile, pdgId);      
-      aParticle->SetDecayTable(aDecayTable); 
+      if (!aParticle || width == 0.0) {
+        continue;
+      }
+      G4DecayTable *aDecayTable = getDecayTable(&configFile, pdgId);
+      aParticle->SetDecayTable(aDecayTable);
       aParticle->SetPDGStable(false);
-      aParticle->SetPDGLifeTime(1.0/(width*CLHEP::GeV)*6.582122e-22*CLHEP::MeV*CLHEP::s);      
+      aParticle->SetPDGLifeTime(1.0 / (width * CLHEP::GeV) * 6.582122e-22 * CLHEP::MeV * CLHEP::s);
       G4ParticleDefinition *aAntiParticle = theParticleTable->FindAntiParticle(pdgId);
-      if(aAntiParticle && aAntiParticle->GetPDGEncoding() != pdgId){	
-	aAntiParticle->SetDecayTable(getAntiDecayTable(pdgId,aDecayTable)); 
-	aAntiParticle->SetPDGStable(false);
-	aAntiParticle->SetPDGLifeTime(1.0/(width*CLHEP::GeV)*6.582122e-22*CLHEP::MeV*CLHEP::s);
+      if (aAntiParticle && aAntiParticle->GetPDGEncoding() != pdgId) {
+        aAntiParticle->SetDecayTable(getAntiDecayTable(pdgId, aDecayTable));
+        aAntiParticle->SetPDGStable(false);
+        aAntiParticle->SetPDGLifeTime(1.0 / (width * CLHEP::GeV) * 6.582122e-22 * CLHEP::MeV * CLHEP::s);
       }
     }
   }
 #ifdef G4MULTITHREADED
-  G4MUTEXUNLOCK(&customParticleFactoryMutex); 
+  G4MUTEXUNLOCK(&customParticleFactoryMutex);
 #endif
 }
 
-void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, 
-                                              const std::string & name){
-  
-  if(std::abs(pdgCode)%100 <14 && std::abs(pdgCode)/1000000 == 0){
-    edm::LogError("CustomParticleFactory::addCustomParticle") 
-      << "Pdg code too low " << pdgCode << " "<<std::abs(pdgCode)/1000000; 
+void CustomParticleFactory::addCustomParticle(int pdgCode, double mass, const std::string &name) {
+  if (std::abs(pdgCode) % 100 < 14 && std::abs(pdgCode) / 1000000 == 0) {
+    edm::LogError("CustomParticleFactory::addCustomParticle")
+        << "Pdg code too low " << pdgCode << " " << std::abs(pdgCode) / 1000000;
     return;
   }
-    
+
   /////////////////////// Check!!!!!!!!!!!!!
-  G4String pType="custom";
-  G4String pSubType="";
+  G4String pType = "custom";
+  G4String pSubType = "";
   G4double spectatormass = 0.0;
-  G4ParticleDefinition* spectator = nullptr; 
+  G4ParticleDefinition *spectator = nullptr;
   //////////////////////
-  if(CustomPDGParser::s_isRHadron(pdgCode)) { pType = "rhadron"; }
-  if(CustomPDGParser::s_isSLepton(pdgCode)) { pType = "sLepton"; }
-  if(CustomPDGParser::s_isMesonino(pdgCode)){ pType = "mesonino"; }
-  if(CustomPDGParser::s_isSbaryon(pdgCode)) { pType = "sbaryon"; }
- 
-  double massGeV = mass*CLHEP::GeV;
-  double width   = 0.0;
-  double charge  = CLHEP::eplus* CustomPDGParser::s_charge(pdgCode);
-  if (name.compare(0,4,"~HIP") == 0)
-    {
-      if ((name.compare(0,7,"~HIPbar") == 0))  {
-	std::string str = name.substr(7); 
-	charge=CLHEP::eplus*atoi(str.c_str())/3.;
-      } else {
-	std::string str = name.substr(4); 
-	charge=-CLHEP::eplus*atoi(str.c_str())/3.;  
-      }
+  if (CustomPDGParser::s_isRHadron(pdgCode)) {
+    pType = "rhadron";
+  }
+  if (CustomPDGParser::s_isSLepton(pdgCode)) {
+    pType = "sLepton";
+  }
+  if (CustomPDGParser::s_isMesonino(pdgCode)) {
+    pType = "mesonino";
+  }
+  if (CustomPDGParser::s_isSbaryon(pdgCode)) {
+    pType = "sbaryon";
+  }
+
+  double massGeV = mass * CLHEP::GeV;
+  double width = 0.0;
+  double charge = CLHEP::eplus * CustomPDGParser::s_charge(pdgCode);
+  if (name.compare(0, 4, "~HIP") == 0) {
+    if ((name.compare(0, 7, "~HIPbar") == 0)) {
+      std::string str = name.substr(7);
+      charge = CLHEP::eplus * atoi(str.c_str()) / 3.;
+    } else {
+      std::string str = name.substr(4);
+      charge = -CLHEP::eplus * atoi(str.c_str()) / 3.;
     }
-  if (name.compare(0,9,"anti_~HIP") == 0)
-    {
-      if ((name.compare(0,12,"anti_~HIPbar") == 0))  {
-	std::string str = name.substr (12); 
-	charge=-CLHEP::eplus*atoi(str.c_str())/3.;
-      } else {
-	std::string str = name.substr (9); 
-	charge=CLHEP::eplus*atoi(str.c_str())/3.;  
-      }
+  }
+  if (name.compare(0, 9, "anti_~HIP") == 0) {
+    if ((name.compare(0, 12, "anti_~HIPbar") == 0)) {
+      std::string str = name.substr(12);
+      charge = -CLHEP::eplus * atoi(str.c_str()) / 3.;
+    } else {
+      std::string str = name.substr(9);
+      charge = CLHEP::eplus * atoi(str.c_str()) / 3.;
     }
-  int spin =  (int)CustomPDGParser::s_spin(pdgCode)-1;
+  }
+  int spin = (int)CustomPDGParser::s_spin(pdgCode) - 1;
   int parity = +1;
   int conjugation = 0;
   int isospin = 0;
   int isospinZ = 0;
   int gParity = 0;
   int lepton = 0;  //FIXME:
-  int baryon = 1;  //FIXME: 
+  int baryon = 1;  //FIXME:
   bool stable = true;
   double lifetime = -1;
 
-  if(CustomPDGParser::s_isDphoton(pdgCode)){
+  if (CustomPDGParser::s_isDphoton(pdgCode)) {
     pType = "darkpho";
     spin = 2;
     parity = -1;
@@ -148,276 +154,264 @@ void CustomParticleFactory::addCustomParticle(int pdgCode, double mass,
     isospinZ = 0;
     gParity = 0;
     lepton = 0;
-    baryon =0;
+    baryon = 0;
     stable = true;
     lifetime = -1;
-  }    
- 
-  G4DecayTable *decaytable = nullptr;
-  G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
+  }
 
-  CustomParticle *particle  = new CustomParticle(name, massGeV, width, charge, spin, 
-						 parity, conjugation, isospin, isospinZ,
-						 gParity, pType, lepton, baryon, pdgCode,
-						 stable, lifetime, decaytable);
- 
-  if(pType == "rhadron" && name!="~g"){  
-    G4String cloudname = name+"cloud";
-    G4String cloudtype = pType+"cloud";
+  G4DecayTable *decaytable = nullptr;
+  G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
+
+  CustomParticle *particle = new CustomParticle(name,
+                                                massGeV,
+                                                width,
+                                                charge,
+                                                spin,
+                                                parity,
+                                                conjugation,
+                                                isospin,
+                                                isospinZ,
+                                                gParity,
+                                                pType,
+                                                lepton,
+                                                baryon,
+                                                pdgCode,
+                                                stable,
+                                                lifetime,
+                                                decaytable);
+
+  if (pType == "rhadron" && name != "~g") {
+    G4String cloudname = name + "cloud";
+    G4String cloudtype = pType + "cloud";
     spectator = theParticleTable->FindParticle(1000021);
     spectatormass = spectator->GetPDGMass();
     G4double cloudmass = massGeV - spectatormass;
-    CustomParticle *tmpParticle  = new CustomParticle(
-						      cloudname,  cloudmass,     0.0,  0, 
-						      0,              +1,        0,          
-						      0,               0,        0,             
-						      cloudtype,       0,       +1,    0,
-						      true,           -1.0,    nullptr );
+    CustomParticle *tmpParticle =
+        new CustomParticle(cloudname, cloudmass, 0.0, 0, 0, +1, 0, 0, 0, 0, cloudtype, 0, +1, 0, true, -1.0, nullptr);
     particle->SetCloud(tmpParticle);
     particle->SetSpectator(spectator);
-    
-    edm::LogInfo("SimG4CoreCustomPhysics")
-      <<"CustomParticleFactory: " <<name<<" being assigned spectator"
-      << spectator->GetParticleName() << " and cloud " <<cloudname << "\n" 
-      <<"                        Masses: "<<mass<<" Gev, "
-      <<spectatormass/CLHEP::GeV<<" GeV and "<<cloudmass/CLHEP::GeV<<" GeV."; 
-  } else if(pType == "mesonino" || pType == "sbaryon") {
-    int sign=1;
-    if(pdgCode < 0 ) sign=-1;
 
-    G4String cloudname = name+"cloud";
-    G4String cloudtype = pType+"cloud";
-    if(CustomPDGParser::s_isstopHadron(pdgCode)) {
-      spectator = theParticleTable->FindParticle(1000006*sign);
-    }
-    else { 
+    edm::LogInfo("SimG4CoreCustomPhysics")
+        << "CustomParticleFactory: " << name << " being assigned spectator" << spectator->GetParticleName()
+        << " and cloud " << cloudname << "\n"
+        << "                        Masses: " << mass << " Gev, " << spectatormass / CLHEP::GeV << " GeV and "
+        << cloudmass / CLHEP::GeV << " GeV.";
+  } else if (pType == "mesonino" || pType == "sbaryon") {
+    int sign = 1;
+    if (pdgCode < 0)
+      sign = -1;
+
+    G4String cloudname = name + "cloud";
+    G4String cloudtype = pType + "cloud";
+    if (CustomPDGParser::s_isstopHadron(pdgCode)) {
+      spectator = theParticleTable->FindParticle(1000006 * sign);
+    } else {
       if (CustomPDGParser::s_issbottomHadron(pdgCode)) {
-	spectator = theParticleTable->FindParticle(1000005*sign);
+        spectator = theParticleTable->FindParticle(1000005 * sign);
       } else {
         spectator = nullptr;
-        edm::LogError("SimG4CoreCustomPhysics")<< "CustomParticleFactory: Cannot find spectator parton";
+        edm::LogError("SimG4CoreCustomPhysics") << "CustomParticleFactory: Cannot find spectator parton";
       }
     }
-    if(spectator) { spectatormass = spectator->GetPDGMass(); }
+    if (spectator) {
+      spectatormass = spectator->GetPDGMass();
+    }
     G4double cloudmass = massGeV - spectatormass;
-    CustomParticle *tmpParticle  = new CustomParticle(
-                                                      cloudname, cloudmass,    0.0,  0 ,
-                                                      0,              +1,      0,
-                                                      0,               0,      0,
-                                                      cloudtype,       0,     +1,     0,
-                                                      true,           -1.0,   nullptr);
+    CustomParticle *tmpParticle =
+        new CustomParticle(cloudname, cloudmass, 0.0, 0, 0, +1, 0, 0, 0, 0, cloudtype, 0, +1, 0, true, -1.0, nullptr);
     particle->SetCloud(tmpParticle);
     particle->SetSpectator(spectator);
 
-    if(spectator) edm::LogVerbatim("SimG4CoreCustomPhysics")
-      <<"CustomParticleFactory: " <<name<<" being assigned spectator"
-      << spectator->GetParticleName() << " and cloud " <<cloudname << "\n" 
-      <<"                        Masses: "<<mass<<" Gev, "
-      <<spectatormass/CLHEP::GeV<<" GeV and "<<cloudmass/CLHEP::GeV<<" GeV."; 
-  }
-  else{
+    if (spectator)
+      edm::LogVerbatim("SimG4CoreCustomPhysics")
+          << "CustomParticleFactory: " << name << " being assigned spectator" << spectator->GetParticleName()
+          << " and cloud " << cloudname << "\n"
+          << "                        Masses: " << mass << " Gev, " << spectatormass / CLHEP::GeV << " GeV and "
+          << cloudmass / CLHEP::GeV << " GeV.";
+  } else {
     particle->SetCloud(nullptr);
     particle->SetSpectator(nullptr);
-  } 
+  }
   m_particles.push_back(particle);
 }
 
-void  CustomParticleFactory::getMassTable(std::ifstream *configFile) {
-
+void CustomParticleFactory::getMassTable(std::ifstream *configFile) {
   int pdgId;
   double mass;
   std::string name, tmp;
   std::string line;
-  G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
+  G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
 
-  // This should be compatible IMO to SLHA 
-  while (getline(*configFile,line)) {
-    line.erase(0, line.find_first_not_of(" \t"));         // remove leading whitespace
-    if (line.length()==0 || line.at(0) == '#') continue;  // skip blank lines and comments
+  // This should be compatible IMO to SLHA
+  while (getline(*configFile, line)) {
+    line.erase(0, line.find_first_not_of(" \t"));  // remove leading whitespace
+    if (line.length() == 0 || line.at(0) == '#')
+      continue;  // skip blank lines and comments
     if (ToLower(line).find("block") < line.npos) {
-      edm::LogInfo("SimG4CoreCustomPhysics") 
-	<<"CustomParticleFactory: Finished the Mass Table "; 
+      edm::LogInfo("SimG4CoreCustomPhysics") << "CustomParticleFactory: Finished the Mass Table ";
       break;
     }
     std::stringstream sstr(line);
-    sstr >> pdgId >> mass >> tmp >> name;  // Assume SLHA format, e.g.: 1000001 5.68441109E+02 # ~d_L 
+    sstr >> pdgId >> mass >> tmp >> name;  // Assume SLHA format, e.g.: 1000001 5.68441109E+02 # ~d_L
 
     mass = std::max(mass, 0.0);
-    if(theParticleTable->FindParticle(pdgId)) { continue; }
+    if (theParticleTable->FindParticle(pdgId)) {
+      continue;
+    }
 
-    edm::LogInfo("SimG4CoreCustomPhysics") 
-      <<"CustomParticleFactory: Calling addCustomParticle for pdgId: " << pdgId 
-      << ", mass " << mass << " GeV  " <<  name 
-      << ", isRHadron: " << CustomPDGParser::s_isRHadron(pdgId)    
-      << ", isstopHadron: " << CustomPDGParser::s_isstopHadron(pdgId); 
+    edm::LogInfo("SimG4CoreCustomPhysics")
+        << "CustomParticleFactory: Calling addCustomParticle for pdgId: " << pdgId << ", mass " << mass << " GeV  "
+        << name << ", isRHadron: " << CustomPDGParser::s_isRHadron(pdgId)
+        << ", isstopHadron: " << CustomPDGParser::s_isstopHadron(pdgId);
     addCustomParticle(pdgId, mass, name);
 
     ////Find SM particle partner and check for the antiparticle.
-    int pdgIdPartner = pdgId%100;
+    int pdgIdPartner = pdgId % 100;
     G4ParticleDefinition *aParticle = theParticleTable->FindParticle(pdgIdPartner);
     //Add antiparticles for SUSY particles only, not for rHadrons.
-    if(aParticle) {
-      edm::LogInfo("SimG4CoreCustomPhysics") 
-	<<"CustomParticleFactory: Found partner particle for " << " pdgId= " << pdgId
-	<< ", pdgIdPartner= " << pdgIdPartner << " " << aParticle->GetParticleName();
+    if (aParticle) {
+      edm::LogInfo("SimG4CoreCustomPhysics")
+          << "CustomParticleFactory: Found partner particle for "
+          << " pdgId= " << pdgId << ", pdgIdPartner= " << pdgIdPartner << " " << aParticle->GetParticleName();
     }
-    
-    if (aParticle && 
-	!CustomPDGParser::s_isRHadron(pdgId)    && 
-	!CustomPDGParser::s_isstopHadron(pdgId) && 
-	pdgId!=1000006 && 
-	pdgId!=-1000006  && 
-	pdgId!=25 && 
-	pdgId!=35 && 
-	pdgId!=36 && 
-	pdgId!=37){ 
-      int sign = aParticle->GetAntiPDGEncoding()/pdgIdPartner;   
-      edm::LogInfo("SimG4CoreCustomPhysics") 
-	<<"CustomParticleFactory: For " << aParticle->GetParticleName()
-	<<" pdg= " << pdgIdPartner 
-	<< ", GetAntiPDGEncoding() " << aParticle->GetAntiPDGEncoding() 
-	<< " sign= " << sign;
 
-      if(std::abs(sign)!=1) {
-	edm::LogInfo("SimG4CoreCustomPhysics")
-	  <<"CustomParticleFactory: sign= "<<sign<<" a: "
-	  <<aParticle->GetAntiPDGEncoding()<<" b: "<<pdgIdPartner; 
-	aParticle->DumpTable();
+    if (aParticle && !CustomPDGParser::s_isRHadron(pdgId) && !CustomPDGParser::s_isstopHadron(pdgId) &&
+        pdgId != 1000006 && pdgId != -1000006 && pdgId != 25 && pdgId != 35 && pdgId != 36 && pdgId != 37) {
+      int sign = aParticle->GetAntiPDGEncoding() / pdgIdPartner;
+      edm::LogInfo("SimG4CoreCustomPhysics")
+          << "CustomParticleFactory: For " << aParticle->GetParticleName() << " pdg= " << pdgIdPartner
+          << ", GetAntiPDGEncoding() " << aParticle->GetAntiPDGEncoding() << " sign= " << sign;
+
+      if (std::abs(sign) != 1) {
+        edm::LogInfo("SimG4CoreCustomPhysics") << "CustomParticleFactory: sign= " << sign
+                                               << " a: " << aParticle->GetAntiPDGEncoding() << " b: " << pdgIdPartner;
+        aParticle->DumpTable();
       }
-      if(sign==-1 && pdgId!=25 && pdgId!=35 && pdgId!=36 && pdgId!=37 && pdgId!=1000039){
-	tmp = "anti_"+name;
-	if(!theParticleTable->FindParticle(-pdgId)) {
-	  edm::LogInfo("SimG4CoreCustomPhysics") 
-	    <<"CustomParticleFactory: Calling addCustomParticle for antiparticle with pdgId: " 
-	    << -pdgId << ", mass " << mass << " GeV, name " << tmp; 
-	  addCustomParticle(-pdgId, mass, tmp);
-	  theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(-pdgId);
-	}
-      }
-      else theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(pdgId);      
+      if (sign == -1 && pdgId != 25 && pdgId != 35 && pdgId != 36 && pdgId != 37 && pdgId != 1000039) {
+        tmp = "anti_" + name;
+        if (!theParticleTable->FindParticle(-pdgId)) {
+          edm::LogInfo("SimG4CoreCustomPhysics")
+              << "CustomParticleFactory: Calling addCustomParticle for antiparticle with pdgId: " << -pdgId << ", mass "
+              << mass << " GeV, name " << tmp;
+          addCustomParticle(-pdgId, mass, tmp);
+          theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(-pdgId);
+        }
+      } else
+        theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(pdgId);
     }
-    
-    if(pdgId==1000039) theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(pdgId); // gravitino     
-    if(pdgId==1000024 || pdgId==1000037 || pdgId==37) {   
-      tmp = "anti_"+name;
-      if(!theParticleTable->FindParticle(-pdgId)) {
-	edm::LogInfo("SimG4CoreCustomPhysics") 
-	  <<"CustomParticleFactory: Calling addCustomParticle for antiparticle (2) with pdgId: " 
-	  << -pdgId << ", mass " << mass << " GeV, name " << tmp; 
-	addCustomParticle(-pdgId, mass, tmp);
-	theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(-pdgId);
+
+    if (pdgId == 1000039)
+      theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(pdgId);  // gravitino
+    if (pdgId == 1000024 || pdgId == 1000037 || pdgId == 37) {
+      tmp = "anti_" + name;
+      if (!theParticleTable->FindParticle(-pdgId)) {
+        edm::LogInfo("SimG4CoreCustomPhysics")
+            << "CustomParticleFactory: Calling addCustomParticle for antiparticle (2) with pdgId: " << -pdgId
+            << ", mass " << mass << " GeV, name " << tmp;
+        addCustomParticle(-pdgId, mass, tmp);
+        theParticleTable->FindParticle(pdgId)->SetAntiPDGEncoding(-pdgId);
       }
     }
   }
 }
 
-G4DecayTable*  CustomParticleFactory::getDecayTable(std::ifstream *configFile, int pdgId) {
-
+G4DecayTable *CustomParticleFactory::getDecayTable(std::ifstream *configFile, int pdgId) {
   double br;
   int nDaughters;
   int pdg[4] = {0};
   std::string line;
 
-  G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
+  G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
 
   std::string parentName = theParticleTable->FindParticle(pdgId)->GetParticleName();
-  G4DecayTable *decaytable= new G4DecayTable();
+  G4DecayTable *decaytable = new G4DecayTable();
 
-  while(getline(*configFile,line)) {
-    
-    line.erase(0, line.find_first_not_of(" \t"));         // remove leading whitespace
-    if (line.length()==0) continue;                       // skip blank lines 
-    if (line.at(0) == '#' && 
-	ToLower(line).find("br")  < line.npos &&
-	ToLower(line).find("nda") < line.npos) continue;  // skip a comment of the form:  # BR  NDA  ID1  ID2
-    if (line.at(0) == '#' || ToLower(line).find("block") < line.npos) {   
-      edm::LogInfo("SimG4CoreCustomPhysics") <<"CustomParticleFactory: Finished the Decay Table "; 
+  while (getline(*configFile, line)) {
+    line.erase(0, line.find_first_not_of(" \t"));  // remove leading whitespace
+    if (line.length() == 0)
+      continue;  // skip blank lines
+    if (line.at(0) == '#' && ToLower(line).find("br") < line.npos && ToLower(line).find("nda") < line.npos)
+      continue;  // skip a comment of the form:  # BR  NDA  ID1  ID2
+    if (line.at(0) == '#' || ToLower(line).find("block") < line.npos) {
+      edm::LogInfo("SimG4CoreCustomPhysics") << "CustomParticleFactory: Finished the Decay Table ";
       break;
     }
 
-    std::stringstream sstr(line);  
+    std::stringstream sstr(line);
     sstr >> br >> nDaughters;  // assume SLHA format, e.g.:  1.49435135E-01  2  -15  16  # BR(H+ -> tau+ nu_tau)
-    LogDebug("SimG4CoreCustomPhysics") 
-      <<"CustomParticleFactory: Branching Ratio: " << br << ", Number of Daughters: " << nDaughters; 
+    LogDebug("SimG4CoreCustomPhysics") << "CustomParticleFactory: Branching Ratio: " << br
+                                       << ", Number of Daughters: " << nDaughters;
     if (nDaughters > 4) {
-      edm::LogError("SimG4CoreCustomPhysics") 
-	<<"CustomParticleFactory: Number of daughters is too large (max = 4): " << nDaughters 
-	<< " for pdgId: " << pdgId; 
-      break; 
+      edm::LogError("SimG4CoreCustomPhysics")
+          << "CustomParticleFactory: Number of daughters is too large (max = 4): " << nDaughters
+          << " for pdgId: " << pdgId;
+      break;
     }
     if (br <= 0.0) {
-      edm::LogError("SimG4CoreCustomPhysics") 
-	<<"CustomParticleFactory: Branching ratio is " << br  
-	<< " for pdgId: " << pdgId; 
-      break; 
+      edm::LogError("SimG4CoreCustomPhysics")
+          << "CustomParticleFactory: Branching ratio is " << br << " for pdgId: " << pdgId;
+      break;
     }
     std::string name[4] = {""};
-    for(int i=0; i<nDaughters; ++i) {
+    for (int i = 0; i < nDaughters; ++i) {
       sstr >> pdg[i];
-      LogDebug("SimG4CoreCustomPhysics") <<"CustomParticleFactory: Daughter ID " << pdg[i]; 
-      const G4ParticleDefinition* part = theParticleTable->FindParticle(pdg[i]);
+      LogDebug("SimG4CoreCustomPhysics") << "CustomParticleFactory: Daughter ID " << pdg[i];
+      const G4ParticleDefinition *part = theParticleTable->FindParticle(pdg[i]);
       if (!part) {
-	edm::LogWarning("SimG4CoreCustomPhysics")
-	  <<"CustomParticleFactory: particle with PDG code"<<pdg[i] <<" not found!"; 
-	continue;
+        edm::LogWarning("SimG4CoreCustomPhysics")
+            << "CustomParticleFactory: particle with PDG code" << pdg[i] << " not found!";
+        continue;
       }
       name[i] = part->GetParticleName();
     }
     ////Set the G4 decay
-    G4PhaseSpaceDecayChannel *aDecayChannel = new G4PhaseSpaceDecayChannel(parentName, br, nDaughters,
-									   name[0],name[1],name[2],name[3]);
-    decaytable->Insert(aDecayChannel);  
-    edm::LogInfo("SimG4CoreCustomPhysics") <<"CustomParticleFactory: inserted decay channel "
-					   <<" for pdgID= " << pdgId << "  " << parentName
-					   <<" BR= " << br << " Daughters: " << name[0] 
-					   <<"  " << name[1]<< "  " << name[2]<< "  " << name[3]; 
+    G4PhaseSpaceDecayChannel *aDecayChannel =
+        new G4PhaseSpaceDecayChannel(parentName, br, nDaughters, name[0], name[1], name[2], name[3]);
+    decaytable->Insert(aDecayChannel);
+    edm::LogInfo("SimG4CoreCustomPhysics")
+        << "CustomParticleFactory: inserted decay channel "
+        << " for pdgID= " << pdgId << "  " << parentName << " BR= " << br << " Daughters: " << name[0] << "  "
+        << name[1] << "  " << name[2] << "  " << name[3];
   }
   return decaytable;
 }
 
-G4DecayTable*  CustomParticleFactory::getAntiDecayTable(int pdgId,  G4DecayTable *theDecayTable) {
-
+G4DecayTable *CustomParticleFactory::getAntiDecayTable(int pdgId, G4DecayTable *theDecayTable) {
   std::string name[4] = {""};
-  G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
+  G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
 
   std::string parentName = theParticleTable->FindParticle(-pdgId)->GetParticleName();
-  G4DecayTable *decaytable= new G4DecayTable();
+  G4DecayTable *decaytable = new G4DecayTable();
 
-  for(int i=0;i<theDecayTable->entries(); ++i){
-    G4VDecayChannel *theDecayChannel = theDecayTable->GetDecayChannel(i); 
+  for (int i = 0; i < theDecayTable->entries(); ++i) {
+    G4VDecayChannel *theDecayChannel = theDecayTable->GetDecayChannel(i);
     int nd = std::min(4, theDecayChannel->GetNumberOfDaughters());
-    for(int j=0; j<nd; ++j){
+    for (int j = 0; j < nd; ++j) {
       int id = theDecayChannel->GetDaughter(j)->GetAntiPDGEncoding();
-      const G4ParticleDefinition* part = theParticleTable->FindParticle(id);
+      const G4ParticleDefinition *part = theParticleTable->FindParticle(id);
       if (!part) {
-	edm::LogWarning("SimG4CoreCustomPhysics")
-	  <<"CustomParticleFactory: antiparticle with PDG code"<<id <<" not found!"; 
-	continue;
+        edm::LogWarning("SimG4CoreCustomPhysics")
+            << "CustomParticleFactory: antiparticle with PDG code" << id << " not found!";
+        continue;
       }
       name[j] = part->GetParticleName();
     }
-    G4PhaseSpaceDecayChannel *aDecayChannel = 
-      new G4PhaseSpaceDecayChannel(parentName, 
-				   theDecayChannel->GetBR(), nd,
-				   name[0],name[1],name[2],name[3]);  
+    G4PhaseSpaceDecayChannel *aDecayChannel =
+        new G4PhaseSpaceDecayChannel(parentName, theDecayChannel->GetBR(), nd, name[0], name[1], name[2], name[3]);
     decaytable->Insert(aDecayChannel);
-    edm::LogInfo("SimG4CoreCustomPhysics") <<"CustomParticleFactory: inserted decay channel "
-					   <<" for pdgID= " << -pdgId << "  " << parentName
-					   <<" BR= " << theDecayChannel->GetBR() 
-					   << " Daughters: " << name[0] 
-					   <<"  " << name[1]<< "  " << name[2]<< "  " << name[3]; 
+    edm::LogInfo("SimG4CoreCustomPhysics")
+        << "CustomParticleFactory: inserted decay channel "
+        << " for pdgID= " << -pdgId << "  " << parentName << " BR= " << theDecayChannel->GetBR()
+        << " Daughters: " << name[0] << "  " << name[1] << "  " << name[2] << "  " << name[3];
   }
   return decaytable;
 }
 
 std::string CustomParticleFactory::ToLower(std::string str) {
   std::locale loc;
-  for (std::string::size_type i=0; i<str.length(); ++i)
-    str.at(i) = std::tolower(str.at(i),loc);
-  return str; 	
+  for (std::string::size_type i = 0; i < str.length(); ++i)
+    str.at(i) = std::tolower(str.at(i), loc);
+  return str;
 }
 
-const std::vector<G4ParticleDefinition *>& CustomParticleFactory::GetCustomParticles()
-{
-  return m_particles;
-}
+const std::vector<G4ParticleDefinition *> &CustomParticleFactory::GetCustomParticles() { return m_particles; }

--- a/SimG4Core/CustomPhysics/src/CustomPhysics.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysics.cc
@@ -8,26 +8,24 @@
 #include "G4EmExtraPhysics.hh"
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
-#include "G4HadronElasticPhysics.hh" 
+#include "G4HadronElasticPhysics.hh"
 #include "G4NeutronTrackingCut.hh"
 
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 #include "G4SystemOfUnits.hh"
- 
-CustomPhysics::CustomPhysics(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
 
+CustomPhysics::CustomPhysics(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
 
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  bool ssPhys  = p.getUntrackedParameter<bool>("ExoticaPhysicsSS",false);
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  bool ssPhys = p.getUntrackedParameter<bool>("ExoticaPhysicsSS", false);
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EMM for regular particles \n"
-			      << "CustomPhysicsList " << ssPhys << " for exotics; "
-                              << " tracking cut " << tracking << "  t(ns)= " << timeLimit/ns;
+                              << "FTFP_BERT_EMM for regular particles \n"
+                              << "CustomPhysicsList " << ssPhys << " for exotics; "
+                              << " tracking cut " << tracking << "  t(ns)= " << timeLimit / ns;
   // EM Physics
   RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
 
@@ -38,7 +36,7 @@ CustomPhysics::CustomPhysics(const edm::ParameterSet & p)
   RegisterPhysics(new G4DecayPhysics(ver));
 
   // Hadron Elastic scattering
-  RegisterPhysics(new G4HadronElasticPhysics(ver)); 
+  RegisterPhysics(new G4HadronElasticPhysics(ver));
 
   // Hadron Physics
   RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
@@ -51,15 +49,15 @@ CustomPhysics::CustomPhysics(const edm::ParameterSet & p)
 
   // Neutron tracking cut
   if (tracking) {
-    G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+    G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
     ncut->SetTimeLimit(timeLimit);
     RegisterPhysics(ncut);
   }
 
   // Custom Physics
-  if(ssPhys) {
-    RegisterPhysics(new CustomPhysicsListSS("custom",p));
+  if (ssPhys) {
+    RegisterPhysics(new CustomPhysicsListSS("custom", p));
   } else {
-    RegisterPhysics(new CustomPhysicsList("custom",p));    
+    RegisterPhysics(new CustomPhysicsList("custom", p));
   }
 }

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -20,12 +20,10 @@ using namespace CLHEP;
 
 G4ThreadLocal std::unique_ptr<G4ProcessHelper> CustomPhysicsList::myHelper;
 
-CustomPhysicsList::CustomPhysicsList(const std::string& name, 
-				     const edm::ParameterSet & p, bool apinew)  
-  :  G4VPhysicsConstructor(name) 
-{  
+CustomPhysicsList::CustomPhysicsList(const std::string& name, const edm::ParameterSet& p, bool apinew)
+    : G4VPhysicsConstructor(name) {
   myConfig = p;
-  if(apinew) {
+  if (apinew) {
     dfactor = p.getParameter<double>("DarkMPFactor");
     fHadronicInteraction = p.getParameter<bool>("RhadronPhysics");
   } else {
@@ -38,53 +36,49 @@ CustomPhysicsList::CustomPhysicsList(const std::string& name,
   fParticleFactory.reset(new CustomParticleFactory());
   myHelper.reset(nullptr);
 
-  edm::LogVerbatim("SimG4CoreCustomPhysics") 
-    << "CustomPhysicsList: Path for custom particle definition file: \n"
-    <<particleDefFilePath << "\n" << "      dark_factor= " << dfactor;
+  edm::LogVerbatim("SimG4CoreCustomPhysics") << "CustomPhysicsList: Path for custom particle definition file: \n"
+                                             << particleDefFilePath << "\n"
+                                             << "      dark_factor= " << dfactor;
 }
 
-CustomPhysicsList::~CustomPhysicsList() {
-}
- 
-void CustomPhysicsList::ConstructParticle(){
-  edm::LogVerbatim("SimG4CoreCustomPhysics") 
-    << "===== CustomPhysicsList::ConstructParticle ";
+CustomPhysicsList::~CustomPhysicsList() {}
+
+void CustomPhysicsList::ConstructParticle() {
+  edm::LogVerbatim("SimG4CoreCustomPhysics") << "===== CustomPhysicsList::ConstructParticle ";
   fParticleFactory.get()->loadCustomParticles(particleDefFilePath);
 }
- 
+
 void CustomPhysicsList::ConstructProcess() {
-  
-  edm::LogVerbatim("SimG4CoreCustomPhysics") 
-    <<"CustomPhysicsList: adding CustomPhysics processes "
-    << "for the list of particles";
+  edm::LogVerbatim("SimG4CoreCustomPhysics") << "CustomPhysicsList: adding CustomPhysics processes "
+                                             << "for the list of particles";
 
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  for(auto particle : fParticleFactory.get()->GetCustomParticles()) {
+  for (auto particle : fParticleFactory.get()->GetCustomParticles()) {
     CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
-    if(cp) {
+    if (cp) {
       G4ProcessManager* pmanager = particle->GetProcessManager();
-      edm::LogVerbatim("SimG4CoreCustomPhysics") 
-	<<"CustomPhysicsList: " << particle->GetParticleName()
-	<<"  PDGcode= " << particle->GetPDGEncoding()
-	<< "  Mass= " << particle->GetPDGMass()/GeV  <<" GeV.";
-      if(pmanager) {
-	if(particle->GetPDGCharge() != 0.0) {
-	  ph->RegisterProcess(new G4hMultipleScattering, particle);
-	  ph->RegisterProcess(new G4hIonisation, particle);
-	}
-	if(cp->GetCloud() && fHadronicInteraction && 
-	   CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
-	  edm::LogVerbatim("SimG4CoreCustomPhysics") 
-	    <<"CustomPhysicsList: " << particle->GetParticleName()
-	    <<" CloudMass= " <<cp->GetCloud()->GetPDGMass()/GeV
-	    <<" GeV; SpectatorMass= " << cp->GetSpectator()->GetPDGMass()/GeV<<" GeV.";
-       
-          if(!myHelper.get()) { myHelper.reset(new G4ProcessHelper(myConfig, fParticleFactory.get())); }
-	  pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper.get()));
-	}
-        if(particle->GetParticleType()=="darkpho"){
-          CMSDarkPairProductionProcess * darkGamma = new CMSDarkPairProductionProcess(dfactor);
+      edm::LogVerbatim("SimG4CoreCustomPhysics")
+          << "CustomPhysicsList: " << particle->GetParticleName() << "  PDGcode= " << particle->GetPDGEncoding()
+          << "  Mass= " << particle->GetPDGMass() / GeV << " GeV.";
+      if (pmanager) {
+        if (particle->GetPDGCharge() != 0.0) {
+          ph->RegisterProcess(new G4hMultipleScattering, particle);
+          ph->RegisterProcess(new G4hIonisation, particle);
+        }
+        if (cp->GetCloud() && fHadronicInteraction && CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
+          edm::LogVerbatim("SimG4CoreCustomPhysics")
+              << "CustomPhysicsList: " << particle->GetParticleName()
+              << " CloudMass= " << cp->GetCloud()->GetPDGMass() / GeV
+              << " GeV; SpectatorMass= " << cp->GetSpectator()->GetPDGMass() / GeV << " GeV.";
+
+          if (!myHelper.get()) {
+            myHelper.reset(new G4ProcessHelper(myConfig, fParticleFactory.get()));
+          }
+          pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper.get()));
+        }
+        if (particle->GetParticleType() == "darkpho") {
+          CMSDarkPairProductionProcess* darkGamma = new CMSDarkPairProductionProcess(dfactor);
           pmanager->AddDiscreteProcess(darkGamma);
         }
       }

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
@@ -22,13 +22,11 @@ using namespace CLHEP;
 
 G4ThreadLocal std::unique_ptr<G4Decay> CustomPhysicsListSS::fDecayProcess;
 G4ThreadLocal std::unique_ptr<G4ProcessHelper> CustomPhysicsListSS::myHelper;
- 
-CustomPhysicsListSS::CustomPhysicsListSS(const std::string& name,
-					 const edm::ParameterSet & p, bool apinew)  
-  :  G4VPhysicsConstructor(name) 
-{  
+
+CustomPhysicsListSS::CustomPhysicsListSS(const std::string& name, const edm::ParameterSet& p, bool apinew)
+    : G4VPhysicsConstructor(name) {
   myConfig = p;
-  if(apinew) {
+  if (apinew) {
     dfactor = p.getParameter<double>("DarkMPFactor");
     fHadronicInteraction = p.getParameter<bool>("RhadronPhysics");
   } else {
@@ -42,57 +40,51 @@ CustomPhysicsListSS::CustomPhysicsListSS(const std::string& name,
   fDecayProcess.reset(nullptr);
   myHelper.reset(nullptr);
 
-  edm::LogVerbatim("SimG4CoreCustomPhysics")
-    <<"CustomPhysicsListSS: Path for custom particle definition file: \n" 
-    <<particleDefFilePath;
+  edm::LogVerbatim("SimG4CoreCustomPhysics") << "CustomPhysicsListSS: Path for custom particle definition file: \n"
+                                             << particleDefFilePath;
 }
 
-CustomPhysicsListSS::~CustomPhysicsListSS() {
-}
- 
-void CustomPhysicsListSS::ConstructParticle(){
-  edm::LogVerbatim("SimG4CoreCustomPhysicsSS") 
-    << "===== CustomPhysicsList::ConstructParticle ";
+CustomPhysicsListSS::~CustomPhysicsListSS() {}
+
+void CustomPhysicsListSS::ConstructParticle() {
+  edm::LogVerbatim("SimG4CoreCustomPhysicsSS") << "===== CustomPhysicsList::ConstructParticle ";
   fParticleFactory.get()->loadCustomParticles(particleDefFilePath);
 }
- 
-void CustomPhysicsListSS::ConstructProcess() {
 
-  edm::LogVerbatim("SimG4CoreCustomPhysicsSS") 
-    <<"CustomPhysicsListSS: adding CustomPhysics processes";
+void CustomPhysicsListSS::ConstructProcess() {
+  edm::LogVerbatim("SimG4CoreCustomPhysicsSS") << "CustomPhysicsListSS: adding CustomPhysics processes";
 
   fDecayProcess.reset(new G4Decay());
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  for(auto particle : fParticleFactory.get()->GetCustomParticles()) {
-
+  for (auto particle : fParticleFactory.get()->GetCustomParticles()) {
     CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
-    if(cp) {
+    if (cp) {
       G4ProcessManager* pmanager = particle->GetProcessManager();
-      edm::LogVerbatim("SimG4CoreCustomPhysics") 
-	<<"CustomPhysicsListSS: " << particle->GetParticleName()
-	<<" PDGcode= " << particle->GetPDGEncoding()
-	<< " Mass= " << particle->GetPDGMass()/GeV  <<" GeV.";
-      if(pmanager) {
-	if(particle->GetPDGCharge() != 0.0) {
-	  ph->RegisterProcess(new G4hMultipleScattering, particle);
-	  ph->RegisterProcess(new G4hIonisation, particle);
-	}
-	if(fDecayProcess.get()->IsApplicable(*particle)) {
-	  ph->RegisterProcess(fDecayProcess.get(), particle);
-	}
-	if(cp->GetCloud() && fHadronicInteraction &&
-	   CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
-	  edm::LogVerbatim("SimG4CoreCustomPhysics") 
-	    <<"CustomPhysicsListSS: " << particle->GetParticleName()
-	    <<" CloudMass= " <<cp->GetCloud()->GetPDGMass()/GeV
-	    <<" GeV; SpectatorMass= " << cp->GetSpectator()->GetPDGMass()/GeV <<" GeV.";
-       
-	  if(!myHelper.get()) { myHelper.reset(new G4ProcessHelper(myConfig, fParticleFactory.get())); }
-	  pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper.get()));
-	}
-        if(particle->GetParticleType()=="darkpho"){
-          CMSDarkPairProductionProcess * darkGamma = new CMSDarkPairProductionProcess(dfactor);
+      edm::LogVerbatim("SimG4CoreCustomPhysics")
+          << "CustomPhysicsListSS: " << particle->GetParticleName() << " PDGcode= " << particle->GetPDGEncoding()
+          << " Mass= " << particle->GetPDGMass() / GeV << " GeV.";
+      if (pmanager) {
+        if (particle->GetPDGCharge() != 0.0) {
+          ph->RegisterProcess(new G4hMultipleScattering, particle);
+          ph->RegisterProcess(new G4hIonisation, particle);
+        }
+        if (fDecayProcess.get()->IsApplicable(*particle)) {
+          ph->RegisterProcess(fDecayProcess.get(), particle);
+        }
+        if (cp->GetCloud() && fHadronicInteraction && CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
+          edm::LogVerbatim("SimG4CoreCustomPhysics")
+              << "CustomPhysicsListSS: " << particle->GetParticleName()
+              << " CloudMass= " << cp->GetCloud()->GetPDGMass() / GeV
+              << " GeV; SpectatorMass= " << cp->GetSpectator()->GetPDGMass() / GeV << " GeV.";
+
+          if (!myHelper.get()) {
+            myHelper.reset(new G4ProcessHelper(myConfig, fParticleFactory.get()));
+          }
+          pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper.get()));
+        }
+        if (particle->GetParticleType() == "darkpho") {
+          CMSDarkPairProductionProcess* darkGamma = new CMSDarkPairProductionProcess(dfactor);
           pmanager->AddDiscreteProcess(darkGamma);
         }
       }

--- a/SimG4Core/CustomPhysics/src/Decay3Body.cc
+++ b/SimG4Core/CustomPhysics/src/Decay3Body.cc
@@ -8,127 +8,124 @@
 #include "Math/GenVector/Rotation3D.h"
 #include "Math/GenVector/EulerAngles.h"
 #include "Math/GenVector/Boost.h"
-#include <vector> 
+#include <vector>
 #include <cmath>
 
 #include "Randomize.hh"
 
-Decay3Body::Decay3Body() {
-}
+Decay3Body::Decay3Body() {}
 
-Decay3Body::~Decay3Body() {
-}
+Decay3Body::~Decay3Body() {}
 
-
-void Decay3Body::doDecay(const G4LorentzVector & mother,
-                               G4LorentzVector & daughter1,
-                               G4LorentzVector & daughter2,
-                               G4LorentzVector & daughter3) {
-
+void Decay3Body::doDecay(const G4LorentzVector& mother,
+                         G4LorentzVector& daughter1,
+                         G4LorentzVector& daughter2,
+                         G4LorentzVector& daughter3) {
   double m0 = mother.m();
   double m1 = daughter1.m();
   double m2 = daughter2.m();
   double m3 = daughter3.m();
-  double sumM2 = m0*m0 + m1*m1 + m2*m2 + m3*m3;
+  double sumM2 = m0 * m0 + m1 * m1 + m2 * m2 + m3 * m3;
   double tolerance = 1.0e-9;
 
-  math::XYZTLorentzVectorD mmm(mother.px(),mother.py(),mother.pz(),mother.e());
+  math::XYZTLorentzVectorD mmm(mother.px(), mother.py(), mother.pz(), mother.e());
 
-  if (m0 < m1+m2+m3) {
-	std::cout << "Error: Daughters too heavy!" << std::endl;
-    std::cout << "M: " << m0/GeV <<
-       " < m1+m2+m3: " << m1/GeV + m2/GeV + m3/GeV << std::endl;
+  if (m0 < m1 + m2 + m3) {
+    std::cout << "Error: Daughters too heavy!" << std::endl;
+    std::cout << "M: " << m0 / GeV << " < m1+m2+m3: " << m1 / GeV + m2 / GeV + m3 / GeV << std::endl;
     return;
   } else {
-    double m2_12max = sqr(m0-m3);
-    double m2_12min = sqr(m1+m2);
-    double m2_23max = sqr(m0-m1);
-    double m2_23min = sqr(m2+m3);
+    double m2_12max = sqr(m0 - m3);
+    double m2_12min = sqr(m1 + m2);
+    double m2_23max = sqr(m0 - m1);
+    double m2_23min = sqr(m2 + m3);
 
-    double x1,x2;
+    double x1, x2;
     double m2_12 = 0.0;
     double m2_23 = 0.0;
-    double E2_12,E3_12;
-	double m2_23max_12,m2_23min_12;
+    double E2_12, E3_12;
+    double m2_23max_12, m2_23min_12;
 
     do {
-// Pick values for m2_12 and m2_23 uniformly:
+      // Pick values for m2_12 and m2_23 uniformly:
       x1 = G4UniformRand();
-      m2_12 = m2_12min + x1*(m2_12max-m2_12min);
+      m2_12 = m2_12min + x1 * (m2_12max - m2_12min);
       x2 = G4UniformRand();
-      m2_23 = m2_23min + x2*(m2_23max-m2_23min);
+      m2_23 = m2_23min + x2 * (m2_23max - m2_23min);
 
-// From the allowed range of m2_23 (given m2_12), determine if the point is valid:
-// (formulae taken from PDG booklet 2004 kinematics, page 305, Eqs. 38.22a+b)
-      E2_12 = (m2_12 - m1*m1 + m2*m2)/(2.0*sqrt(m2_12));
-      E3_12 = (m0*m0 - m2_12 - m3*m3)/(2.0*sqrt(m2_12));
-      m2_23max_12 = sqr(E2_12+E3_12)-sqr(sqrt(sqr(E2_12)-m2*m2)-sqrt(sqr(E3_12)-m3*m3));
-      m2_23min_12 = sqr(E2_12+E3_12)-sqr(sqrt(sqr(E2_12)-m2*m2)+sqrt(sqr(E3_12)-m3*m3));
+      // From the allowed range of m2_23 (given m2_12), determine if the point is valid:
+      // (formulae taken from PDG booklet 2004 kinematics, page 305, Eqs. 38.22a+b)
+      E2_12 = (m2_12 - m1 * m1 + m2 * m2) / (2.0 * sqrt(m2_12));
+      E3_12 = (m0 * m0 - m2_12 - m3 * m3) / (2.0 * sqrt(m2_12));
+      m2_23max_12 = sqr(E2_12 + E3_12) - sqr(sqrt(sqr(E2_12) - m2 * m2) - sqrt(sqr(E3_12) - m3 * m3));
+      m2_23min_12 = sqr(E2_12 + E3_12) - sqr(sqrt(sqr(E2_12) - m2 * m2) + sqrt(sqr(E3_12) - m3 * m3));
     } while ((m2_23 > m2_23max_12) || (m2_23 < m2_23min_12));
 
-// Determine the value of the third invariant mass squared:
+    // Determine the value of the third invariant mass squared:
     double m2_13 = sumM2 - m2_12 - m2_23;
 
-// Calculate the energy and size of the momentum of the three daughters:  
-    double e1 = (m0*m0 + m1*m1 - m2_23)/(2.0*m0);
-    double e2 = (m0*m0 + m2*m2 - m2_13)/(2.0*m0);
-    double e3 = (m0*m0 + m3*m3 - m2_12)/(2.0*m0);
-    double p1 = sqrt(e1*e1 - m1*m1);
-    double p2 = sqrt(e2*e2 - m2*m2);
-    double p3 = sqrt(e3*e3 - m3*m3);
+    // Calculate the energy and size of the momentum of the three daughters:
+    double e1 = (m0 * m0 + m1 * m1 - m2_23) / (2.0 * m0);
+    double e2 = (m0 * m0 + m2 * m2 - m2_13) / (2.0 * m0);
+    double e3 = (m0 * m0 + m3 * m3 - m2_12) / (2.0 * m0);
+    double p1 = sqrt(e1 * e1 - m1 * m1);
+    double p2 = sqrt(e2 * e2 - m2 * m2);
+    double p3 = sqrt(e3 * e3 - m3 * m3);
 
-// Calculate cosine of the relative angles between the three daughters:
-    double cos12 = (m1*m1 + m2*m2 + 2.0*e1*e2 - m2_12)/(2.0*p1*p2);
-    double cos13 = (m1*m1 + m3*m3 + 2.0*e1*e3 - m2_13)/(2.0*p1*p3);
-    double cos23 = (m2*m2 + m3*m3 + 2.0*e2*e3 - m2_23)/(2.0*p2*p3);
-    if (fabs(cos12) > 1.0) std::cout << "Error: Undefined angle12!" << std::endl;
-    if (fabs(cos13) > 1.0) std::cout << "Error: Undefined angle13!" << std::endl;
-    if (fabs(cos23) > 1.0) std::cout << "Error: Undefined angle23!" << std::endl;
+    // Calculate cosine of the relative angles between the three daughters:
+    double cos12 = (m1 * m1 + m2 * m2 + 2.0 * e1 * e2 - m2_12) / (2.0 * p1 * p2);
+    double cos13 = (m1 * m1 + m3 * m3 + 2.0 * e1 * e3 - m2_13) / (2.0 * p1 * p3);
+    double cos23 = (m2 * m2 + m3 * m3 + 2.0 * e2 * e3 - m2_23) / (2.0 * p2 * p3);
+    if (fabs(cos12) > 1.0)
+      std::cout << "Error: Undefined angle12!" << std::endl;
+    if (fabs(cos13) > 1.0)
+      std::cout << "Error: Undefined angle13!" << std::endl;
+    if (fabs(cos23) > 1.0)
+      std::cout << "Error: Undefined angle23!" << std::endl;
 
-// Find the four vectors of the particles in a chosen (i.e. simple) frame:
-    double xi    = 2.0 * pi * G4UniformRand();
-    math::XYZVectorD q1(0.0,0.0,p1);
-    math::XYZVectorD q2( sin(acos(cos12))*cos(xi)*p2, sin(acos(cos12))*sin(xi)*p2,cos12*p2);
-    math::XYZVectorD q3(-sin(acos(cos13))*cos(xi)*p3,-sin(acos(cos13))*sin(xi)*p3,cos13*p3);
+    // Find the four vectors of the particles in a chosen (i.e. simple) frame:
+    double xi = 2.0 * pi * G4UniformRand();
+    math::XYZVectorD q1(0.0, 0.0, p1);
+    math::XYZVectorD q2(sin(acos(cos12)) * cos(xi) * p2, sin(acos(cos12)) * sin(xi) * p2, cos12 * p2);
+    math::XYZVectorD q3(-sin(acos(cos13)) * cos(xi) * p3, -sin(acos(cos13)) * sin(xi) * p3, cos13 * p3);
 
-// Rotate all three daughters momentum with the angles theta and phi:
+    // Rotate all three daughters momentum with the angles theta and phi:
     double theta = acos(2.0 * G4UniformRand() - 1.0);
-    double phi   = 2.0 * pi * G4UniformRand();
-    double psi   = 2.0 * pi * G4UniformRand();
-    
-    ROOT::Math::EulerAngles ang(phi,theta,psi);
+    double phi = 2.0 * pi * G4UniformRand();
+    double psi = 2.0 * pi * G4UniformRand();
+
+    ROOT::Math::EulerAngles ang(phi, theta, psi);
     ROOT::Math::Rotation3D rot(ang);
 
-    math::XYZVectorD q1rot = rot*q1;
-    math::XYZVectorD q2rot = rot*q2;
-    math::XYZVectorD q3rot = rot*q3;
+    math::XYZVectorD q1rot = rot * q1;
+    math::XYZVectorD q2rot = rot * q2;
+    math::XYZVectorD q3rot = rot * q3;
 
-    math::XYZTLorentzVectorD daughter1_orig(q1rot.X(),q1rot.Y(),q1rot.Z(),e1);
-    math::XYZTLorentzVectorD daughter2_orig(q2rot.X(),q2rot.Y(),q2rot.Z(),e2);
-    math::XYZTLorentzVectorD daughter3_orig(q3rot.X(),q3rot.Y(),q3rot.Z(),e3);
+    math::XYZTLorentzVectorD daughter1_orig(q1rot.X(), q1rot.Y(), q1rot.Z(), e1);
+    math::XYZTLorentzVectorD daughter2_orig(q2rot.X(), q2rot.Y(), q2rot.Z(), e2);
+    math::XYZTLorentzVectorD daughter3_orig(q3rot.X(), q3rot.Y(), q3rot.Z(), e3);
 
     ROOT::Math::Boost cmboost(mmm.BoostToCM());
 
     // Check of total angle and momentum:
-    if (acos(cos12)+acos(cos13)+acos(cos23)-2.0*pi > tolerance)
-      std::cout << "Error: Total angle not 2pi! " <<
-	acos(cos12)+acos(cos13)+acos(cos23)-2.0*pi << std::endl;
-    if (fabs(daughter1_orig.px()+daughter2_orig.px()+daughter3_orig.px())/GeV > tolerance)
-      std::cout << "Error: Total 3B Px not conserved! " << 
-	(daughter1_orig.px()+daughter2_orig.px()+daughter3_orig.px())/GeV << std::endl;
-    if (fabs(daughter1_orig.py()+daughter2_orig.py()+daughter3_orig.py())/GeV > tolerance)
-      std::cout << "Error: Total 3B Py not conserved! " << 
-	(daughter1_orig.py()+daughter2_orig.py()+daughter3_orig.py())/GeV << std::endl;
-    if (fabs(daughter1_orig.pz()+daughter2_orig.pz()+daughter3_orig.pz())/GeV > tolerance)
-      std::cout << "Error: Total 3B Pz not conserved! " << 
-	(daughter1.pz()+daughter2.pz()+daughter3.pz())/GeV << std::endl;
-    
+    if (acos(cos12) + acos(cos13) + acos(cos23) - 2.0 * pi > tolerance)
+      std::cout << "Error: Total angle not 2pi! " << acos(cos12) + acos(cos13) + acos(cos23) - 2.0 * pi << std::endl;
+    if (fabs(daughter1_orig.px() + daughter2_orig.px() + daughter3_orig.px()) / GeV > tolerance)
+      std::cout << "Error: Total 3B Px not conserved! "
+                << (daughter1_orig.px() + daughter2_orig.px() + daughter3_orig.px()) / GeV << std::endl;
+    if (fabs(daughter1_orig.py() + daughter2_orig.py() + daughter3_orig.py()) / GeV > tolerance)
+      std::cout << "Error: Total 3B Py not conserved! "
+                << (daughter1_orig.py() + daughter2_orig.py() + daughter3_orig.py()) / GeV << std::endl;
+    if (fabs(daughter1_orig.pz() + daughter2_orig.pz() + daughter3_orig.pz()) / GeV > tolerance)
+      std::cout << "Error: Total 3B Pz not conserved! " << (daughter1.pz() + daughter2.pz() + daughter3.pz()) / GeV
+                << std::endl;
+
     // Boost the daughters back to the frame of the mother:
 
     math::XYZTLorentzVectorD temp1(cmboost(daughter1_orig));
     math::XYZTLorentzVectorD temp2(cmboost(daughter2_orig));
     math::XYZTLorentzVectorD temp3(cmboost(daughter3_orig));
-    
+
     daughter1.setPx(temp1.Px());
     daughter1.setPy(temp1.Py());
     daughter1.setPz(temp1.Pz());
@@ -148,8 +145,4 @@ void Decay3Body::doDecay(const G4LorentzVector & mother,
   }
 }
 
-
-double Decay3Body::sqr(double a) {
-  return a*a;
-}
-
+double Decay3Body::sqr(double a) { return a * a; }

--- a/SimG4Core/CustomPhysics/src/DummyChargeFlipProcess.cc
+++ b/SimG4Core/CustomPhysics/src/DummyChargeFlipProcess.cc
@@ -6,65 +6,41 @@
 
 using namespace CLHEP;
 
-DummyChargeFlipProcess::
-DummyChargeFlipProcess(const G4String& processName) : 
-      G4HadronicProcess(processName)
-{
+DummyChargeFlipProcess::DummyChargeFlipProcess(const G4String& processName) : G4HadronicProcess(processName) {
   AddDataSet(new G4HadronElasticDataSet);
 }
 
-DummyChargeFlipProcess::~DummyChargeFlipProcess()
-{
-}
- 
+DummyChargeFlipProcess::~DummyChargeFlipProcess() {}
 
-void DummyChargeFlipProcess::
-BuildPhysicsTable(const G4ParticleDefinition& aParticleType)
-{
-   if (!G4HadronicProcess::GetCrossSectionDataStore()) {
-      return;
-   }
-   G4HadronicProcess::GetCrossSectionDataStore()->BuildPhysicsTable(aParticleType);
+void DummyChargeFlipProcess::BuildPhysicsTable(const G4ParticleDefinition& aParticleType) {
+  if (!G4HadronicProcess::GetCrossSectionDataStore()) {
+    return;
+  }
+  G4HadronicProcess::GetCrossSectionDataStore()->BuildPhysicsTable(aParticleType);
 }
 
-
-G4double DummyChargeFlipProcess::
-GetMicroscopicCrossSection(
-      const G4DynamicParticle* /*aParticle*/, const G4Element* element, G4double /*aTemp*/)
-{
-
-   return 30*millibarn*element->GetN(); 
+G4double DummyChargeFlipProcess::GetMicroscopicCrossSection(const G4DynamicParticle* /*aParticle*/,
+                                                            const G4Element* element,
+                                                            G4double /*aTemp*/) {
+  return 30 * millibarn * element->GetN();
 }
 
-
-G4bool
-DummyChargeFlipProcess::
-IsApplicable(const G4ParticleDefinition& aParticleType)
-{
-   if(aParticleType.GetParticleType()  == "rhadron")
+G4bool DummyChargeFlipProcess::IsApplicable(const G4ParticleDefinition& aParticleType) {
+  if (aParticleType.GetParticleType() == "rhadron")
     return true;
   else
     return false;
 }
 
+void DummyChargeFlipProcess::DumpPhysicsTable(const G4ParticleDefinition& /*aParticleType*/) {}
 
-void 
-DummyChargeFlipProcess::
-DumpPhysicsTable(const G4ParticleDefinition& /*aParticleType*/)
-{
-
-}
-
-
-G4VParticleChange *DummyChargeFlipProcess::PostStepDoIt(
-  const G4Track &aTrack, const G4Step &/*aStep*/)
-{
-  G4ParticleChange * pc = new G4ParticleChange();
+G4VParticleChange* DummyChargeFlipProcess::PostStepDoIt(const G4Track& aTrack, const G4Step& /*aStep*/) {
+  G4ParticleChange* pc = new G4ParticleChange();
   pc->Initialize(aTrack);
   const G4DynamicParticle* aParticle = aTrack.GetDynamicParticle();
   //G4ParticleDefinition* aParticleDef = aParticle->GetDefinition();
 
-  G4double   ParentEnergy  = aParticle->GetTotalEnergy();
+  G4double ParentEnergy = aParticle->GetTotalEnergy();
   const G4ThreeVector& ParentDirection(aParticle->GetMomentumDirection());
 
   G4double energyDeposit = 0.0;
@@ -79,21 +55,18 @@ G4VParticleChange *DummyChargeFlipProcess::PostStepDoIt(
   // create a new track object
   G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
   float randomParticle = G4UniformRand();
-  G4ParticleDefinition * newType;
-  if(randomParticle < 0.333)
-    newType=particleTable->FindParticle(1009213);
-  else if(randomParticle > 0.667)
-    newType=particleTable->FindParticle(-1009213);
+  G4ParticleDefinition* newType;
+  if (randomParticle < 0.333)
+    newType = particleTable->FindParticle(1009213);
+  else if (randomParticle > 0.667)
+    newType = particleTable->FindParticle(-1009213);
   else
-    newType=particleTable->FindParticle(1009113);
-     
+    newType = particleTable->FindParticle(1009113);
+
   G4cout << "RHADRON: New charge = " << newType->GetPDGCharge() << G4endl;
-       
-  G4DynamicParticle * newP =  new G4DynamicParticle(newType,ParentDirection,ParentEnergy);
-  G4Track* secondary = new G4Track( newP ,
-				    finalGlobalTime ,
-				    aTrack.GetPosition()
-				    );
+
+  G4DynamicParticle* newP = new G4DynamicParticle(newType, ParentDirection, ParentEnergy);
+  G4Track* secondary = new G4Track(newP, finalGlobalTime, aTrack.GetPosition());
   // switch on good for tracking flag
   secondary->SetGoodForTrackingFlag();
   secondary->SetTouchableHandle(thand);
@@ -101,12 +74,11 @@ G4VParticleChange *DummyChargeFlipProcess::PostStepDoIt(
   pc->AddSecondary(secondary);
 
   // Kill the parent particle
-  pc->ProposeTrackStatus( fStopAndKill ) ;
-  pc->ProposeLocalEnergyDeposit(energyDeposit); 
-  pc->ProposeGlobalTime( finalGlobalTime );
+  pc->ProposeTrackStatus(fStopAndKill);
+  pc->ProposeLocalEnergyDeposit(energyDeposit);
+  pc->ProposeGlobalTime(finalGlobalTime);
   // Clear NumberOfInteractionLengthLeft
   ClearNumberOfInteractionLengthLeft();
 
   return pc;
 }
-

--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -10,56 +10,46 @@
 
 using namespace CLHEP;
 
-FullModelHadronicProcess::FullModelHadronicProcess(G4ProcessHelper * aHelper, 
-						   const G4String& processName) :
-  G4VDiscreteProcess(processName), theHelper(aHelper)
-{}
+FullModelHadronicProcess::FullModelHadronicProcess(G4ProcessHelper* aHelper, const G4String& processName)
+    : G4VDiscreteProcess(processName), theHelper(aHelper) {}
 
-FullModelHadronicProcess::~FullModelHadronicProcess()
-{}
-  
-G4bool FullModelHadronicProcess::IsApplicable(const G4ParticleDefinition& aP)
-{
-  return theHelper->ApplicabilityTester(aP);  
+FullModelHadronicProcess::~FullModelHadronicProcess() {}
+
+G4bool FullModelHadronicProcess::IsApplicable(const G4ParticleDefinition& aP) {
+  return theHelper->ApplicabilityTester(aP);
 }
 
-G4double FullModelHadronicProcess::GetMicroscopicCrossSection(const G4DynamicParticle *aParticle,
-							      const G4Element *anElement,
-							      G4double aTemp)
-{
+G4double FullModelHadronicProcess::GetMicroscopicCrossSection(const G4DynamicParticle* aParticle,
+                                                              const G4Element* anElement,
+                                                              G4double aTemp) {
   //Get the cross section for this particle/element combination from the ProcessHelper
-  G4double InclXsec = theHelper->GetInclusiveCrossSection(aParticle,anElement);
+  G4double InclXsec = theHelper->GetInclusiveCrossSection(aParticle, anElement);
   //  G4cout<<"Returned cross section from helper was: "<<InclXsec/millibarn<<" millibarn"<<G4endl;
   return InclXsec;
 }
 
-G4double FullModelHadronicProcess::GetMeanFreePath(const G4Track& aTrack, G4double, 
-						   G4ForceCondition*)
-{
-  G4Material *aMaterial = aTrack.GetMaterial();
-  const G4DynamicParticle *aParticle = aTrack.GetDynamicParticle();
+G4double FullModelHadronicProcess::GetMeanFreePath(const G4Track& aTrack, G4double, G4ForceCondition*) {
+  G4Material* aMaterial = aTrack.GetMaterial();
+  const G4DynamicParticle* aParticle = aTrack.GetDynamicParticle();
   G4double sigma = 0.0;
 
   G4int nElements = aMaterial->GetNumberOfElements();
-  
-  const G4double *theAtomicNumDensityVector =
-    aMaterial->GetAtomicNumDensityVector();
+
+  const G4double* theAtomicNumDensityVector = aMaterial->GetAtomicNumDensityVector();
   G4double aTemp = aMaterial->GetTemperature();
-  
-  for( G4int i=0; i<nElements; ++i )
-    {
-      G4double xSection =
-	GetMicroscopicCrossSection( aParticle, (*aMaterial->GetElementVector())[i], aTemp);
-      sigma += theAtomicNumDensityVector[i] * xSection;
-    }
+
+  for (G4int i = 0; i < nElements; ++i) {
+    G4double xSection = GetMicroscopicCrossSection(aParticle, (*aMaterial->GetElementVector())[i], aTemp);
+    sigma += theAtomicNumDensityVector[i] * xSection;
+  }
   G4double res = DBL_MAX;
-  if(sigma > 0.0) { res = 1./sigma; }
+  if (sigma > 0.0) {
+    res = 1. / sigma;
+  }
   return res;
 }
 
-G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
-							  const G4Step&  aStep)
-{
+G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep) {
   //  G4cout<<"**** Entering FullModelHadronicProcess::PostStepDoIt       ******"<<G4endl;
   const G4TouchableHandle& thisTouchable(aTrack.GetTouchableHandle());
 
@@ -75,9 +65,9 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4bool IncidentSurvives = false;
   G4bool TargetSurvives = false;
   G4Nucleus targetNucleus(aTrack.GetMaterial());
-  G4ParticleDefinition* outgoingRhadron=nullptr;
-  G4ParticleDefinition* outgoingCloud=nullptr;
-  G4ParticleDefinition* outgoingTarget=nullptr;
+  G4ParticleDefinition* outgoingRhadron = nullptr;
+  G4ParticleDefinition* outgoingCloud = nullptr;
+  G4ParticleDefinition* outgoingTarget = nullptr;
 
   G4ThreeVector p_0 = IncidentRhadron->GetMomentum();
   G4double e_kin_0 = IncidentRhadron->GetKineticEnergy();
@@ -92,28 +82,25 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   */
   cloudParticle->SetDefinition(CustomIncident->GetCloud());
 
-  if(cloudParticle->GetDefinition() == nullptr) 
-     {
-      G4cout << "FullModelHadronicProcess::PostStepDoIt  Definition of particle cloud not available!!" << G4endl;
-     }
+  if (cloudParticle->GetDefinition() == nullptr) {
+    G4cout << "FullModelHadronicProcess::PostStepDoIt  Definition of particle cloud not available!!" << G4endl;
+  }
   /*
   G4cout<<"Incoming particle was "<<IncidentRhadron->GetDefinition()->GetParticleName()
   <<". Corresponding cloud is "<<cloudParticle->GetDefinition()->GetParticleName()<<G4endl;
   G4cout<<"Kinetic energy was: "<<IncidentRhadron->GetKineticEnergy()/GeV<<" GeV"<<G4endl;
   */
-  double scale=cloudParticle->GetDefinition()->GetPDGMass()
-    /IncidentRhadron->GetDefinition()->GetPDGMass();
+  double scale = cloudParticle->GetDefinition()->GetPDGMass() / IncidentRhadron->GetDefinition()->GetPDGMass();
   //  G4cout<<"Mass ratio: "<<scale<<G4endl;
-  G4LorentzVector cloudMomentum(IncidentRhadron->GetMomentum()*scale,
-				cloudParticle->GetDefinition()->GetPDGMass());
-  G4LorentzVector gluinoMomentum(IncidentRhadron->GetMomentum()*(1.-scale),
-				 CustomIncident->GetSpectator()->GetPDGMass()); 
+  G4LorentzVector cloudMomentum(IncidentRhadron->GetMomentum() * scale, cloudParticle->GetDefinition()->GetPDGMass());
+  G4LorentzVector gluinoMomentum(IncidentRhadron->GetMomentum() * (1. - scale),
+                                 CustomIncident->GetSpectator()->GetPDGMass());
 
   //These two for getting CMS transforms later (histogramming purposes...)
   G4LorentzVector FullRhadron4Momentum = IncidentRhadron->Get4Momentum();
   const G4LorentzVector& Cloud4Momentum = cloudMomentum;
 
-  cloudParticle->Set4Momentum(cloudMomentum);         	
+  cloudParticle->Set4Momentum(cloudMomentum);
 
   G4DynamicParticle* OrgPart = cloudParticle;
 
@@ -131,59 +118,60 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4double ek = OrgPart->GetKineticEnergy();
   G4double amas = OrgPart->GetDefinition()->GetPDGMass();
   G4ThreeVector dir = (OrgPart->GetMomentum()).unit();
-  G4double tkin = targetNucleus.Cinema( ek );
+  G4double tkin = targetNucleus.Cinema(ek);
   ek += tkin;
-  
-  // calculate black track energies
-  tkin = targetNucleus.EvaporationEffects( ek );  
-  ek -= tkin; 
 
-  if(ek+gluinoMomentum.e()-gluinoMomentum.m()<=0.1*MeV||ek<=0.) {
+  // calculate black track energies
+  tkin = targetNucleus.EvaporationEffects(ek);
+  ek -= tkin;
+
+  if (ek + gluinoMomentum.e() - gluinoMomentum.m() <= 0.1 * MeV || ek <= 0.) {
     //Very rare event...
-    G4cout<<"Kinetic energy is sick"<<G4endl;
-    G4cout<<"Full R-hadron: "<<(ek+gluinoMomentum.e()-gluinoMomentum.m())/MeV<<" MeV" <<G4endl;
-    G4cout<<"Quark system: "<<ek/MeV<<" MeV"<<G4endl;
-    aParticleChange.ProposeTrackStatus( fStopButAlive ); // AR_NEWCODE_IMPORT
+    G4cout << "Kinetic energy is sick" << G4endl;
+    G4cout << "Full R-hadron: " << (ek + gluinoMomentum.e() - gluinoMomentum.m()) / MeV << " MeV" << G4endl;
+    G4cout << "Quark system: " << ek / MeV << " MeV" << G4endl;
+    aParticleChange.ProposeTrackStatus(fStopButAlive);  // AR_NEWCODE_IMPORT
     return &aParticleChange;
   }
-  OrgPart->SetKineticEnergy( ek );
-  G4double p = std::sqrt(ek*(ek + 2*amas));
+  OrgPart->SetKineticEnergy(ek);
+  G4double p = std::sqrt(ek * (ek + 2 * amas));
   OrgPart->SetMomentum(dir * p);
 
-  //Get the final state particles  
-  G4ParticleDefinition* aTarget; 
-  ReactionProduct rp = theHelper->GetFinalState(aTrack,aTarget);
+  //Get the final state particles
+  G4ParticleDefinition* aTarget;
+  ReactionProduct rp = theHelper->GetFinalState(aTrack, aTarget);
   G4bool force2to2 = false;
-  //  G4cout<<"Trying to get final state..."<<G4endl; 
-  while(rp.size()!=2 && force2to2){
-    rp = theHelper->GetFinalState(aTrack,aTarget);
+  //  G4cout<<"Trying to get final state..."<<G4endl;
+  while (rp.size() != 2 && force2to2) {
+    rp = theHelper->GetFinalState(aTrack, aTarget);
   }
   G4int NumberOfSecondaries = rp.size();
   //  G4cout<<"Multiplicity of selected final state: "<<rp.size()<<G4endl;
 
   //Getting CMS transforms. Boosting is done at histogram filling
-  G4LorentzVector Target4Momentum(0.,0.,0.,aTarget->GetPDGMass());
+  G4LorentzVector Target4Momentum(0., 0., 0., aTarget->GetPDGMass());
 
   G4LorentzVector psum_full = FullRhadron4Momentum + Target4Momentum;
   G4LorentzVector psum_cloud = Cloud4Momentum + Target4Momentum;
-  G4ThreeVector trafo_full_cms = (-1)*psum_full.boostVector();
-  G4ThreeVector trafo_cloud_cms = (-1)*psum_cloud.boostVector();
+  G4ThreeVector trafo_full_cms = (-1) * psum_full.boostVector();
+  G4ThreeVector trafo_cloud_cms = (-1) * psum_cloud.boostVector();
 
   // OK Let's make some particles :-)
   // We're not using them for anything yet, I know, but let's make sure the machinery is there
-  for(ReactionProduct::iterator it  = rp.begin();
-      it != rp.end(); ++it) {
+  for (ReactionProduct::iterator it = rp.begin(); it != rp.end(); ++it) {
     G4ParticleDefinition* tempDef = theParticleTable->FindParticle(*it);
     CustomParticle* tempCust = dynamic_cast<CustomParticle*>(tempDef);
-    if (tempDef==aTarget) TargetSurvives = true;
+    if (tempDef == aTarget)
+      TargetSurvives = true;
 
     //      if (tempDef->GetParticleType()=="rhadron")
-    if (tempCust!=nullptr) {
-      outgoingRhadron = tempDef; 
+    if (tempCust != nullptr) {
+      outgoingRhadron = tempDef;
       //Setting outgoing cloud definition
-      outgoingCloud=tempCust->GetCloud();
-      if(outgoingCloud == nullptr) {
-	G4cout << "FullModelHadronicProcess::PostStepDoIt  Definition of outgoing particle cloud not available!" << G4endl;
+      outgoingCloud = tempCust->GetCloud();
+      if (outgoingCloud == nullptr) {
+        G4cout << "FullModelHadronicProcess::PostStepDoIt  Definition of outgoing particle cloud not available!"
+               << G4endl;
       }
       /*
 	G4cout<<"Outgoing Rhadron is: "<<outgoingRhadron->GetParticleName()<<G4endl;
@@ -191,16 +179,19 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       */
     }
 
-    if (tempDef==G4Proton::Proton()||tempDef==G4Neutron::Neutron()) outgoingTarget = tempDef;
-    if (tempCust==nullptr&&rp.size()==2) outgoingTarget = tempDef;
-    if (tempDef->GetPDGEncoding()==theIncidentPDG) {
+    if (tempDef == G4Proton::Proton() || tempDef == G4Neutron::Neutron())
+      outgoingTarget = tempDef;
+    if (tempCust == nullptr && rp.size() == 2)
+      outgoingTarget = tempDef;
+    if (tempDef->GetPDGEncoding() == theIncidentPDG) {
       IncidentSurvives = true;
     } else {
       theParticleDefinitions.push_back(tempDef);
     }
   }
 
-  if (outgoingTarget==nullptr) outgoingTarget = theParticleTable->FindParticle(rp[1]);
+  if (outgoingTarget == nullptr)
+    outgoingTarget = theParticleTable->FindParticle(rp[1]);
 
   // A little debug information
   /*
@@ -214,31 +205,32 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   */
   // If the incident particle survives it is not a "secondary", although
   // it would probably be easier to fStopAndKill the track every time.
-  if(IncidentSurvives) NumberOfSecondaries--;
+  if (IncidentSurvives)
+    NumberOfSecondaries--;
   aParticleChange.SetNumberOfSecondaries(NumberOfSecondaries);
 
   // ADAPTED FROM G4LEPionMinusInelastic::ApplyYourself
   // It is bloody ugly, but such is the way of cut 'n' paste
 
   // Set up the incident
-  // This is where rotation to z-axis is done 
+  // This is where rotation to z-axis is done
   const G4HadProjectile* originalIncident = new G4HadProjectile(*OrgPart);
 
-  //Maybe I need to calculate trafo from R-hadron... Bollocks! Labframe does not move. CMS does.  
+  //Maybe I need to calculate trafo from R-hadron... Bollocks! Labframe does not move. CMS does.
   G4HadProjectile* org2 = new G4HadProjectile(*OrgPart);
   G4LorentzRotation trans = org2->GetTrafoToLab();
   delete org2;
-  
+
   // create the target particle
-  
-  G4DynamicParticle *originalTarget = new G4DynamicParticle;
+
+  G4DynamicParticle* originalTarget = new G4DynamicParticle;
   originalTarget->SetDefinition(aTarget);
-  
+
   G4ReactionProduct targetParticle(aTarget);
-  
-  G4ReactionProduct currentParticle(const_cast<G4ParticleDefinition *>(originalIncident->GetDefinition() ) );
-  currentParticle.SetMomentum( originalIncident->Get4Momentum().vect() );
-  currentParticle.SetKineticEnergy( originalIncident->GetKineticEnergy() );
+
+  G4ReactionProduct currentParticle(const_cast<G4ParticleDefinition*>(originalIncident->GetDefinition()));
+  currentParticle.SetMomentum(originalIncident->Get4Momentum().vect());
+  currentParticle.SetKineticEnergy(originalIncident->GetKineticEnergy());
 
   /*
   G4cout<<"After creation:"<<G4endl;
@@ -248,38 +240,42 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   */
 
   G4ReactionProduct modifiedOriginal = currentParticle;
-  
-  currentParticle.SetSide( 1 ); // incident always goes in forward hemisphere
-  targetParticle.SetSide( -1 );  // target always goes in backward hemisphere
+
+  currentParticle.SetSide(1);  // incident always goes in forward hemisphere
+  targetParticle.SetSide(-1);  // target always goes in backward hemisphere
   G4bool incidentHasChanged = false;
-  if (!IncidentSurvives) incidentHasChanged = true; //I wonder if I am supposed to do this...
+  if (!IncidentSurvives)
+    incidentHasChanged = true;  //I wonder if I am supposed to do this...
   G4bool targetHasChanged = false;
-  if (!TargetSurvives) targetHasChanged = true; //Ditto here
+  if (!TargetSurvives)
+    targetHasChanged = true;  //Ditto here
   G4bool quasiElastic = false;
-  if (rp.size()==2) quasiElastic = true; //Oh well...
-  G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> vec;  // vec will contain the secondary particles
+  if (rp.size() == 2)
+    quasiElastic = true;                                //Oh well...
+  G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> vec;  // vec will contain the secondary particles
   G4int vecLen = 0;
-  vec.Initialize( 0 );
-  
+  vec.Initialize(0);
+
   // I hope my understanding of "secondary" is correct here
   // I think that it entails only what is not a surviving incident of target
-  
-  for (G4int i = 0; i!=NumberOfSecondaries;i++){
-    if(theParticleDefinitions[i]!=aTarget 
-       && theParticleDefinitions[i]!=originalIncident->GetDefinition()
-       && theParticleDefinitions[i]!=outgoingRhadron
-       && theParticleDefinitions[i]!=outgoingTarget)
-      { 
-	G4ReactionProduct* pa = new G4ReactionProduct;
-	pa->SetDefinition( theParticleDefinitions[i] );
-	(G4UniformRand() < 0.5) ? pa->SetSide( -1 ) : pa->SetSide( 1 );
-	vec.SetElement( vecLen++, pa );
-      }
+
+  for (G4int i = 0; i != NumberOfSecondaries; i++) {
+    if (theParticleDefinitions[i] != aTarget && theParticleDefinitions[i] != originalIncident->GetDefinition() &&
+        theParticleDefinitions[i] != outgoingRhadron && theParticleDefinitions[i] != outgoingTarget) {
+      G4ReactionProduct* pa = new G4ReactionProduct;
+      pa->SetDefinition(theParticleDefinitions[i]);
+      (G4UniformRand() < 0.5) ? pa->SetSide(-1) : pa->SetSide(1);
+      vec.SetElement(vecLen++, pa);
+    }
   }
 
-  if (incidentHasChanged) currentParticle.SetDefinitionAndUpdateE( outgoingCloud );
-  if (incidentHasChanged) modifiedOriginal.SetDefinition( outgoingCloud );//Is this correct? It solves the "free energy" checking in ReactionDynamics
-  if (targetHasChanged) targetParticle.SetDefinitionAndUpdateE( outgoingTarget );
+  if (incidentHasChanged)
+    currentParticle.SetDefinitionAndUpdateE(outgoingCloud);
+  if (incidentHasChanged)
+    modifiedOriginal.SetDefinition(
+        outgoingCloud);  //Is this correct? It solves the "free energy" checking in ReactionDynamics
+  if (targetHasChanged)
+    targetParticle.SetDefinitionAndUpdateE(outgoingTarget);
 
   //  G4cout<<"Calling CalculateMomenta... "<<G4endl;
   /*
@@ -288,10 +284,17 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4cout<<"May be killed?: "<<currentParticle.GetMayBeKilled()<<G4endl;
   */
 
-  CalculateMomenta( vec, vecLen,
-		    originalIncident, originalTarget, modifiedOriginal,
-		    targetNucleus, currentParticle, targetParticle,
-		    incidentHasChanged, targetHasChanged, quasiElastic );
+  CalculateMomenta(vec,
+                   vecLen,
+                   originalIncident,
+                   originalTarget,
+                   modifiedOriginal,
+                   targetNucleus,
+                   currentParticle,
+                   targetParticle,
+                   incidentHasChanged,
+                   targetHasChanged,
+                   quasiElastic);
 
   //  G4cout <<"Cloud loss: "<<(e_temp-currentParticle.GetKineticEnergy())/GeV<<" GeV"<<G4endl;
 
@@ -322,9 +325,9 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   */
   // G4cout<<"Done!"<<G4endl;
 
-  aParticleChange.SetNumberOfSecondaries(vecLen+NumberOfSecondaries);
-  G4double e_kin=0;
-  G4LorentzVector cloud_p4_new; //Cloud 4-momentum in lab after collision
+  aParticleChange.SetNumberOfSecondaries(vecLen + NumberOfSecondaries);
+  G4double e_kin = 0;
+  G4LorentzVector cloud_p4_new;  //Cloud 4-momentum in lab after collision
   //  n++;
   //  G4cout << n << G4endl;
   /*
@@ -336,285 +339,270 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
     //    n=0;
   }
   */
-  cloud_p4_new.setVectM(currentParticle.GetMomentum(),currentParticle.GetMass());
+  cloud_p4_new.setVectM(currentParticle.GetMomentum(), currentParticle.GetMass());
   cloud_p4_new *= trans;
 
-  G4LorentzVector cloud_p4_old_full = Cloud4Momentum; //quark system in CMS BEFORE collision
+  G4LorentzVector cloud_p4_old_full = Cloud4Momentum;  //quark system in CMS BEFORE collision
   cloud_p4_old_full.boost(trafo_full_cms);
-  G4LorentzVector cloud_p4_old_cloud = Cloud4Momentum; //quark system in cloud CMS BEFORE collision
+  G4LorentzVector cloud_p4_old_cloud = Cloud4Momentum;  //quark system in cloud CMS BEFORE collision
   cloud_p4_old_cloud.boost(trafo_cloud_cms);
-  G4LorentzVector cloud_p4_full = cloud_p4_new; //quark system in CMS AFTER collision
+  G4LorentzVector cloud_p4_full = cloud_p4_new;  //quark system in CMS AFTER collision
   cloud_p4_full.boost(trafo_full_cms);
-  G4LorentzVector cloud_p4_cloud = cloud_p4_new; //quark system in cloud CMS AFTER collision
+  G4LorentzVector cloud_p4_cloud = cloud_p4_new;  //quark system in cloud CMS AFTER collision
   cloud_p4_cloud.boost(trafo_cloud_cms);
 
-  G4LorentzVector p_g_cms = gluinoMomentum; //gluino in CMS BEFORE collision
+  G4LorentzVector p_g_cms = gluinoMomentum;  //gluino in CMS BEFORE collision
   p_g_cms.boost(trafo_full_cms);
 
   double e = cloud_p4_new.e() + gluinoMomentum.e();
-  if(outgoingRhadron) e += outgoingRhadron->GetPDGMass();
-  G4LorentzVector p4_new( cloud_p4_new.v() + gluinoMomentum.v(), e );
+  if (outgoingRhadron)
+    e += outgoingRhadron->GetPDGMass();
+  G4LorentzVector p4_new(cloud_p4_new.v() + gluinoMomentum.v(), e);
   //  G4cout<<"P4-diff: "<<(p4_new-cloud_p4_new-gluinoMomentum)/GeV<<", magnitude: "
   // <<(p4_new-cloud_p4_new-gluinoMomentum).m()/MeV<<" MeV" <<G4endl;
 
   G4ThreeVector p_new = p4_new.vect();
 
-  aParticleChange.ProposeLocalEnergyDeposit((p4_new-cloud_p4_new-gluinoMomentum).m());
+  aParticleChange.ProposeLocalEnergyDeposit((p4_new - cloud_p4_new - gluinoMomentum).m());
 
-  if( incidentHasChanged )
-    {
-      G4DynamicParticle* p0 = new G4DynamicParticle;
-      p0->SetDefinition( outgoingRhadron );
-      p0->SetMomentum( p_new ); 
+  if (incidentHasChanged) {
+    G4DynamicParticle* p0 = new G4DynamicParticle;
+    p0->SetDefinition(outgoingRhadron);
+    p0->SetMomentum(p_new);
 
-      // May need to run SetDefinitionAndUpdateE here...
-      G4Track* Track0 = new G4Track(p0,
-				    aTrack.GetGlobalTime(),
-				    aPosition);
-      Track0->SetTouchableHandle(thisTouchable);
-      aParticleChange.AddSecondary(Track0);
-      /*
+    // May need to run SetDefinitionAndUpdateE here...
+    G4Track* Track0 = new G4Track(p0, aTrack.GetGlobalTime(), aPosition);
+    Track0->SetTouchableHandle(thisTouchable);
+    aParticleChange.AddSecondary(Track0);
+    /*
       G4cout<<"Adding a particle "<<p0->GetDefinition()->GetParticleName()<<G4endl;
       G4cout<<"with momentum: "<<p0->GetMomentum()/GeV<<" GeV"<<G4endl;
       G4cout<<"and kinetic energy: "<<p0->GetKineticEnergy()/GeV<<" GeV"<<G4endl;
       */
-      if(p0->GetKineticEnergy()>e_kin_0) {
-	G4cout<<"ALAAAAARM!!! (incident changed from "
-	      <<IncidentRhadron->GetDefinition()->GetParticleName()
-	      <<" to "<<p0->GetDefinition()->GetParticleName()<<")"<<G4endl;
-	G4cout<<"Energy loss: "<<(e_kin_0-p0->GetKineticEnergy())/GeV
-	      <<" GeV (should be positive)"<<G4endl;
-	//Turns out problem is only in 2 -> 3 (Won't fix 2 -> 2 energy deposition)
-	if(rp.size()!=3) G4cout<<"DOUBLE ALAAAAARM!!!"<<G4endl;
-      } /*else {
+    if (p0->GetKineticEnergy() > e_kin_0) {
+      G4cout << "ALAAAAARM!!! (incident changed from " << IncidentRhadron->GetDefinition()->GetParticleName() << " to "
+             << p0->GetDefinition()->GetParticleName() << ")" << G4endl;
+      G4cout << "Energy loss: " << (e_kin_0 - p0->GetKineticEnergy()) / GeV << " GeV (should be positive)" << G4endl;
+      //Turns out problem is only in 2 -> 3 (Won't fix 2 -> 2 energy deposition)
+      if (rp.size() != 3)
+        G4cout << "DOUBLE ALAAAAARM!!!" << G4endl;
+    } /*else {
 	G4cout<<"NO ALAAAAARM!!!"<<G4endl;
 	}*/
-      if(std::abs(p0->GetKineticEnergy()-e_kin_0)>100*GeV) {
-	G4cout<<"Diff. too big"<<G4endl;
-      }
-      aParticleChange.ProposeTrackStatus( fStopAndKill );
+    if (std::abs(p0->GetKineticEnergy() - e_kin_0) > 100 * GeV) {
+      G4cout << "Diff. too big" << G4endl;
     }
-  else
-    {
-      G4double p = p_new.mag();
-      if( p > DBL_MIN )
-	aParticleChange.ProposeMomentumDirection( p_new.x()/p, p_new.y()/p, p_new.z()/p );
-      else
-	aParticleChange.ProposeMomentumDirection( 1.0, 0.0, 0.0 );
-    }
-  
+    aParticleChange.ProposeTrackStatus(fStopAndKill);
+  } else {
+    G4double p = p_new.mag();
+    if (p > DBL_MIN)
+      aParticleChange.ProposeMomentumDirection(p_new.x() / p, p_new.y() / p, p_new.z() / p);
+    else
+      aParticleChange.ProposeMomentumDirection(1.0, 0.0, 0.0);
+  }
+
   //    return G4VDiscreteProcess::PostStepDoIt( aTrack, aStep);
-  if( targetParticle.GetMass() > 0.0 )  // targetParticle can be eliminated in TwoBody
-    {
-      G4DynamicParticle *p1 = new G4DynamicParticle;
-      p1->SetDefinition( targetParticle.GetDefinition() );
-      //G4cout<<"Target secondary: "<<targetParticle.GetDefinition()->GetParticleName()<<G4endl;
-      G4ThreeVector momentum = targetParticle.GetMomentum();
-      momentum = momentum.rotate(cache,what);
-      p1->SetMomentum( momentum );
-      p1->SetMomentum( (trans*p1->Get4Momentum()).vect());
-      G4Track* Track1 = new G4Track(p1,
-				    aTrack.GetGlobalTime(),
-				    aPosition);
-      Track1->SetTouchableHandle(thisTouchable); 
-      aParticleChange.AddSecondary(Track1);
-    }
-  G4DynamicParticle *pa;
+  if (targetParticle.GetMass() > 0.0)  // targetParticle can be eliminated in TwoBody
+  {
+    G4DynamicParticle* p1 = new G4DynamicParticle;
+    p1->SetDefinition(targetParticle.GetDefinition());
+    //G4cout<<"Target secondary: "<<targetParticle.GetDefinition()->GetParticleName()<<G4endl;
+    G4ThreeVector momentum = targetParticle.GetMomentum();
+    momentum = momentum.rotate(cache, what);
+    p1->SetMomentum(momentum);
+    p1->SetMomentum((trans * p1->Get4Momentum()).vect());
+    G4Track* Track1 = new G4Track(p1, aTrack.GetGlobalTime(), aPosition);
+    Track1->SetTouchableHandle(thisTouchable);
+    aParticleChange.AddSecondary(Track1);
+  }
+  G4DynamicParticle* pa;
   /*
     G4cout<<"vecLen: "<<vecLen<<G4endl;
     G4cout<<"#sec's: "<<aParticleChange.GetNumberOfSecondaries()<<G4endl;
   */
-  
-  for(int i=0; i<vecLen; ++i )
-    {
-      pa = new G4DynamicParticle();
-      pa->SetDefinition( vec[i]->GetDefinition() );
-      pa->SetMomentum( vec[i]->GetMomentum() );
-      pa->Set4Momentum(trans*(pa->Get4Momentum()));
-      G4ThreeVector pvec = pa->GetMomentum();
-      G4Track* Trackn = new G4Track(pa,
-				    aTrack.GetGlobalTime(),
-				    aPosition);
-      Trackn->SetTouchableHandle(thisTouchable);
-      aParticleChange.AddSecondary(Trackn);
 
-      delete vec[i];
-    } 
+  for (int i = 0; i < vecLen; ++i) {
+    pa = new G4DynamicParticle();
+    pa->SetDefinition(vec[i]->GetDefinition());
+    pa->SetMomentum(vec[i]->GetMomentum());
+    pa->Set4Momentum(trans * (pa->Get4Momentum()));
+    G4ThreeVector pvec = pa->GetMomentum();
+    G4Track* Trackn = new G4Track(pa, aTrack.GetGlobalTime(), aPosition);
+    Trackn->SetTouchableHandle(thisTouchable);
+    aParticleChange.AddSecondary(Trackn);
 
-  // Histogram filling  
+    delete vec[i];
+  }
+
+  // Histogram filling
   const G4DynamicParticle* theRhadron = FindRhadron(&aParticleChange);
-  
-  if (theRhadron!=nullptr||IncidentSurvives) {      
+
+  if (theRhadron != nullptr || IncidentSurvives) {
     double E_new;
-    if(IncidentSurvives) {
+    if (IncidentSurvives) {
       E_new = e_kin;
     } else {
       E_new = theRhadron->GetKineticEnergy();
-      if(CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding())
-	 !=CustomPDGParser::s_isRMeson(theIncidentPDG)
-	 ||
-	 CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding())
-	 !=CustomPDGParser::s_isMesonino(theIncidentPDG)
-	 ) {
-	G4cout<<"Rm: "<<CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding())
-	      <<" vs: "<<CustomPDGParser::s_isRMeson(theIncidentPDG)<<G4endl;
-	G4cout<<"Sm: "<<CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding())
-	      <<" vs: "<<CustomPDGParser::s_isMesonino(theIncidentPDG)<<G4endl;
-
+      if (CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding()) !=
+              CustomPDGParser::s_isRMeson(theIncidentPDG) ||
+          CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding()) !=
+              CustomPDGParser::s_isMesonino(theIncidentPDG)) {
+        G4cout << "Rm: " << CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding())
+               << " vs: " << CustomPDGParser::s_isRMeson(theIncidentPDG) << G4endl;
+        G4cout << "Sm: " << CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding())
+               << " vs: " << CustomPDGParser::s_isMesonino(theIncidentPDG) << G4endl;
       }
     }
-      
+
     //Calculating relevant scattering angles.
-    G4LorentzVector p4_old_full = FullRhadron4Momentum; //R-hadron in CMS BEFORE collision
+    G4LorentzVector p4_old_full = FullRhadron4Momentum;  //R-hadron in CMS BEFORE collision
     p4_old_full.boost(trafo_full_cms);
-    G4LorentzVector p4_old_cloud = FullRhadron4Momentum; //R-hadron in cloud CMS BEFORE collision
+    G4LorentzVector p4_old_cloud = FullRhadron4Momentum;  //R-hadron in cloud CMS BEFORE collision
     p4_old_cloud.boost(trafo_cloud_cms);
-    G4LorentzVector p4_full = p4_new; //R-hadron in CMS AFTER collision
+    G4LorentzVector p4_full = p4_new;  //R-hadron in CMS AFTER collision
     //      G4cout<<p4_full.v()/GeV<<G4endl;
-    p4_full=p4_full.boost(trafo_full_cms);
+    p4_full = p4_full.boost(trafo_full_cms);
     // G4cout<<p4_full.m()<<" / "<<(cloud_p4_new+gluinoMomentum).boost(trafo_full_cms).m()<<G4endl;
-    G4LorentzVector p4_cloud = p4_new; //R-hadron in cloud CMS AFTER collision
+    G4LorentzVector p4_cloud = p4_new;  //R-hadron in cloud CMS AFTER collision
     p4_cloud.boost(trafo_cloud_cms);
 
-    G4double AbsDeltaE = E_0-E_new;
+    G4double AbsDeltaE = E_0 - E_new;
     //      G4cout <<"Energy loss: "<<AbsDeltaE/GeV<<G4endl;
-    if (AbsDeltaE > 10*GeV) {
-      G4cout<<"Energy loss larger than 10 GeV..."<<G4endl;
-      G4cout<<"E_0: "<<E_0/GeV<<" GeV"<<G4endl;
-      G4cout<<"E_new: "<<E_new/GeV<<" GeV"<<G4endl;
-      G4cout<<"Gamma: "<<IncidentRhadron->GetTotalEnergy()/IncidentRhadron->GetDefinition()->GetPDGMass()<<G4endl;
-      G4cout<<"x: "<<aPosition.x()/cm<<" cm"<<G4endl;
+    if (AbsDeltaE > 10 * GeV) {
+      G4cout << "Energy loss larger than 10 GeV..." << G4endl;
+      G4cout << "E_0: " << E_0 / GeV << " GeV" << G4endl;
+      G4cout << "E_new: " << E_new / GeV << " GeV" << G4endl;
+      G4cout << "Gamma: " << IncidentRhadron->GetTotalEnergy() / IncidentRhadron->GetDefinition()->GetPDGMass()
+             << G4endl;
+      G4cout << "x: " << aPosition.x() / cm << " cm" << G4endl;
     }
-  } 
+  }
   delete originalIncident;
   delete originalTarget;
   //  aParticleChange.DumpInfo();
   //  G4cout << "Exiting FullModelHadronicProcess::PostStepDoIt"<<G4endl;
 
-  //clear interaction length      
+  //clear interaction length
   ClearNumberOfInteractionLengthLeft();
 
-  return &aParticleChange;  
+  return &aParticleChange;
 }
 
-
 void FullModelHadronicProcess::CalculateMomenta(
-     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-     G4int &vecLen,
-     const G4HadProjectile *originalIncident,   // the original incident particle
-     const G4DynamicParticle *originalTarget,
-     G4ReactionProduct &modifiedOriginal,   // Fermi motion and evap. effects included
-     G4Nucleus &targetNucleus,
-     G4ReactionProduct &currentParticle,
-     G4ReactionProduct &targetParticle,
-     G4bool &incidentHasChanged,
-     G4bool &targetHasChanged,
-     G4bool quasiElastic )
-{
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& vec,
+    G4int& vecLen,
+    const G4HadProjectile* originalIncident,  // the original incident particle
+    const G4DynamicParticle* originalTarget,
+    G4ReactionProduct& modifiedOriginal,  // Fermi motion and evap. effects included
+    G4Nucleus& targetNucleus,
+    G4ReactionProduct& currentParticle,
+    G4ReactionProduct& targetParticle,
+    G4bool& incidentHasChanged,
+    G4bool& targetHasChanged,
+    G4bool quasiElastic) {
   FullModelReactionDynamics theReactionDynamics;
 
   cache = 0;
   what = originalIncident->Get4Momentum().vect();
 
-  if( quasiElastic )
-    {
-      //      G4cout<<"We are calling TwoBody..."<<G4endl;
-      theReactionDynamics.TwoBody( vec, vecLen,
-                                   modifiedOriginal, originalTarget,
-                                   currentParticle, targetParticle,
-                                   targetNucleus, targetHasChanged );
+  if (quasiElastic) {
+    //      G4cout<<"We are calling TwoBody..."<<G4endl;
+    theReactionDynamics.TwoBody(
+        vec, vecLen, modifiedOriginal, originalTarget, currentParticle, targetParticle, targetNucleus, targetHasChanged);
 
-      return;
-    }
+    return;
+  }
 
   //If ProduceStrangeParticlePairs is commented out, let's cut this one as well
   G4ReactionProduct leadingStrangeParticle;
-  G4bool leadFlag = MarkLeadingStrangeParticle( currentParticle,
-						targetParticle,
-						leadingStrangeParticle );
+  G4bool leadFlag = MarkLeadingStrangeParticle(currentParticle, targetParticle, leadingStrangeParticle);
 
   //
   // Note: the number of secondaries can be reduced in GenerateXandPt and TwoCluster
   //
   G4bool finishedGenXPt = false;
   G4bool annihilation = false;
-  if( originalIncident->GetDefinition()->GetPDGEncoding() < 0 &&
-      currentParticle.GetMass() == 0.0 && targetParticle.GetMass() == 0.0 )
-    {
-      // original was an anti-particle and annihilation has taken place
-      annihilation = true;
-      G4double ekcor = 1.0;
-      G4double ek = originalIncident->GetKineticEnergy();
-      G4double ekOrg = ek;
+  if (originalIncident->GetDefinition()->GetPDGEncoding() < 0 && currentParticle.GetMass() == 0.0 &&
+      targetParticle.GetMass() == 0.0) {
+    // original was an anti-particle and annihilation has taken place
+    annihilation = true;
+    G4double ekcor = 1.0;
+    G4double ek = originalIncident->GetKineticEnergy();
+    G4double ekOrg = ek;
 
-      const G4double tarmas = originalTarget->GetDefinition()->GetPDGMass();
-      if( ek > 1.0*GeV )ekcor = 1./(ek/GeV);
-      const G4double atomicWeight = G4double(targetNucleus.GetN_asInt());
-      ek = 2*tarmas + ek*(1.+ekcor/atomicWeight);
+    const G4double tarmas = originalTarget->GetDefinition()->GetPDGMass();
+    if (ek > 1.0 * GeV)
+      ekcor = 1. / (ek / GeV);
+    const G4double atomicWeight = G4double(targetNucleus.GetN_asInt());
+    ek = 2 * tarmas + ek * (1. + ekcor / atomicWeight);
 
-      G4double tkin = targetNucleus.Cinema( ek );
-      //ek += tkin;
-      ekOrg += tkin;
-      modifiedOriginal.SetKineticEnergy( ekOrg );
-    }
+    G4double tkin = targetNucleus.Cinema(ek);
+    //ek += tkin;
+    ekOrg += tkin;
+    modifiedOriginal.SetKineticEnergy(ekOrg);
+  }
 
-  const G4double twsup[] = { 1.0, 0.7, 0.5, 0.3, 0.2, 0.1 };
+  const G4double twsup[] = {1.0, 0.7, 0.5, 0.3, 0.2, 0.1};
   G4double rand1 = G4UniformRand();
   G4double rand2 = G4UniformRand();
-  if( (annihilation || (vecLen >= 6) || (modifiedOriginal.GetKineticEnergy()/GeV >= 1.0)) && 
-      (((originalIncident->GetDefinition() == G4KaonPlus::KaonPlus()) || 
-         (originalIncident->GetDefinition() == G4KaonMinus::KaonMinus()) || 
-         (originalIncident->GetDefinition() == G4KaonZeroLong::KaonZeroLong()) || 
-         (originalIncident->GetDefinition() == G4KaonZeroShort::KaonZeroShort())) && 
+  if ((annihilation || (vecLen >= 6) || (modifiedOriginal.GetKineticEnergy() / GeV >= 1.0)) &&
+      (((originalIncident->GetDefinition() == G4KaonPlus::KaonPlus()) ||
+        (originalIncident->GetDefinition() == G4KaonMinus::KaonMinus()) ||
+        (originalIncident->GetDefinition() == G4KaonZeroLong::KaonZeroLong()) ||
+        (originalIncident->GetDefinition() == G4KaonZeroShort::KaonZeroShort())) &&
        ((rand1 < 0.5) || (rand2 > twsup[vecLen]))))
-    finishedGenXPt =
-      theReactionDynamics.GenerateXandPt( vec, vecLen,
-					  modifiedOriginal, originalIncident,
-					  currentParticle, targetParticle,
-					  targetNucleus, incidentHasChanged,
-					  targetHasChanged, leadFlag,
-					  leadingStrangeParticle );
-  if( finishedGenXPt )
-    {
-      Rotate(vec, vecLen);
-      return;
-    }
+    finishedGenXPt = theReactionDynamics.GenerateXandPt(vec,
+                                                        vecLen,
+                                                        modifiedOriginal,
+                                                        originalIncident,
+                                                        currentParticle,
+                                                        targetParticle,
+                                                        targetNucleus,
+                                                        incidentHasChanged,
+                                                        targetHasChanged,
+                                                        leadFlag,
+                                                        leadingStrangeParticle);
+  if (finishedGenXPt) {
+    Rotate(vec, vecLen);
+    return;
+  }
 
   G4bool finishedTwoClu = false;
-  if( modifiedOriginal.GetTotalMomentum()/MeV < 1.0 )
-    {
+  if (modifiedOriginal.GetTotalMomentum() / MeV < 1.0) {
+    for (G4int i = 0; i < vecLen; i++)
+      delete vec[i];
+    vecLen = 0;
+  } else {
+    theReactionDynamics.SuppressChargedPions(vec,
+                                             vecLen,
+                                             modifiedOriginal,
+                                             currentParticle,
+                                             targetParticle,
+                                             targetNucleus,
+                                             incidentHasChanged,
+                                             targetHasChanged);
 
-      for(G4int i=0; i<vecLen; i++) delete vec[i];
-      vecLen = 0;
+    try {
+      finishedTwoClu = theReactionDynamics.TwoCluster(vec,
+                                                      vecLen,
+                                                      modifiedOriginal,
+                                                      originalIncident,
+                                                      currentParticle,
+                                                      targetParticle,
+                                                      targetNucleus,
+                                                      incidentHasChanged,
+                                                      targetHasChanged,
+                                                      leadFlag,
+                                                      leadingStrangeParticle);
+    } catch (G4HadReentrentException& aC) {
+      aC.Report(G4cout);
+      throw G4HadReentrentException(__FILE__, __LINE__, "Failing to calculate momenta");
     }
-  else
-    {
-
-      theReactionDynamics.SuppressChargedPions( vec, vecLen,
-						modifiedOriginal, currentParticle,
-                                                targetParticle, targetNucleus,
-                                                incidentHasChanged, targetHasChanged );
-
-      try
-	{
-	  finishedTwoClu = theReactionDynamics.TwoCluster( vec, vecLen,
-							   modifiedOriginal, originalIncident,
-							   currentParticle, targetParticle,
-							   targetNucleus, incidentHasChanged,
-							   targetHasChanged, leadFlag,
-							   leadingStrangeParticle );
-	}
-      catch(G4HadReentrentException &aC)
-	{
-	  aC.Report(G4cout);
-	  throw G4HadReentrentException(__FILE__, __LINE__, "Failing to calculate momenta");
-	}
-    }
-  if( finishedTwoClu )
-    {
-      Rotate(vec, vecLen);
-      return;
-    }
+  }
+  if (finishedTwoClu) {
+    Rotate(vec, vecLen);
+    return;
+  }
 
   //
   // PNBlackTrackEnergy is the kinetic energy available for
@@ -627,68 +615,60 @@ void FullModelHadronicProcess::CalculateMomenta(
   //     or for deuteron/triton/alpha black track particles
   // For diffraction scattering on heavy nuclei use elastic routines instead
 
-  theReactionDynamics.TwoBody( vec, vecLen,
-			       modifiedOriginal, originalTarget,
-			       currentParticle, targetParticle,
-			       targetNucleus, targetHasChanged );
+  theReactionDynamics.TwoBody(
+      vec, vecLen, modifiedOriginal, originalTarget, currentParticle, targetParticle, targetNucleus, targetHasChanged);
 }
 
-G4bool FullModelHadronicProcess::MarkLeadingStrangeParticle(
-       const G4ReactionProduct &currentParticle,
-       const G4ReactionProduct &targetParticle,
-       G4ReactionProduct &leadParticle )
-{
+G4bool FullModelHadronicProcess::MarkLeadingStrangeParticle(const G4ReactionProduct& currentParticle,
+                                                            const G4ReactionProduct& targetParticle,
+                                                            G4ReactionProduct& leadParticle) {
   // the following was in GenerateXandPt and TwoCluster
   // add a parameter to the GenerateXandPt function telling it about the strange particle
   //
   // assumes that the original particle was a strange particle
   //
   G4bool lead = false;
-  if( (currentParticle.GetMass() >= G4KaonPlus::KaonPlus()->GetPDGMass()) &&
+  if ((currentParticle.GetMass() >= G4KaonPlus::KaonPlus()->GetPDGMass()) &&
       (currentParticle.GetDefinition() != G4Proton::Proton()) &&
-      (currentParticle.GetDefinition() != G4Neutron::Neutron()) )
-    {
-      lead = true;
-      leadParticle = currentParticle;              //  set lead to the incident particle
-    }
-  else if( (targetParticle.GetMass() >= G4KaonPlus::KaonPlus()->GetPDGMass()) &&
-	   (targetParticle.GetDefinition() != G4Proton::Proton()) &&
-	   (targetParticle.GetDefinition() != G4Neutron::Neutron()) )
-    {
-      lead = true;
-      leadParticle = targetParticle;              //   set lead to the target particle
-    }
+      (currentParticle.GetDefinition() != G4Neutron::Neutron())) {
+    lead = true;
+    leadParticle = currentParticle;  //  set lead to the incident particle
+  } else if ((targetParticle.GetMass() >= G4KaonPlus::KaonPlus()->GetPDGMass()) &&
+             (targetParticle.GetDefinition() != G4Proton::Proton()) &&
+             (targetParticle.GetDefinition() != G4Neutron::Neutron())) {
+    lead = true;
+    leadParticle = targetParticle;  //   set lead to the target particle
+  }
   return lead;
 }
 
-void FullModelHadronicProcess::Rotate(G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec, 
-				      G4int &vecLen)
-{
-  G4double rotation = 2.*pi*G4UniformRand();
+void FullModelHadronicProcess::Rotate(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE>& vec, G4int& vecLen) {
+  G4double rotation = 2. * pi * G4UniformRand();
   cache = rotation;
   G4int i;
-  for( i=0; i<vecLen; ++i )
-    {
-      G4ThreeVector momentum = vec[i]->GetMomentum();
-      momentum = momentum.rotate(rotation, what);
-      vec[i]->SetMomentum(momentum);
-    }
-}      
+  for (i = 0; i < vecLen; ++i) {
+    G4ThreeVector momentum = vec[i]->GetMomentum();
+    momentum = momentum.rotate(rotation, what);
+    vec[i]->SetMomentum(momentum);
+  }
+}
 
-const G4DynamicParticle* FullModelHadronicProcess::FindRhadron(G4ParticleChange* aParticleChange)
-{
+const G4DynamicParticle* FullModelHadronicProcess::FindRhadron(G4ParticleChange* aParticleChange) {
   G4int nsec = aParticleChange->GetNumberOfSecondaries();
-  if (nsec==0) return nullptr;
+  if (nsec == 0)
+    return nullptr;
   int i = 0;
   G4bool found = false;
-  while (i!=nsec && !found){
+  while (i != nsec && !found) {
     //    G4cout<<"Checking "<<aParticleChange->GetSecondary(i)->GetDynamicParticle()->GetDefinition()->GetParticleName()<<G4endl;
     //    if (aParticleChange->GetSecondary(i)->GetDynamicParticle()->GetDefinition()->GetParticleType()=="rhadron") found = true;
-    if (dynamic_cast<CustomParticle*>(aParticleChange->GetSecondary(i)->GetDynamicParticle()->GetDefinition())!=nullptr) found = true;
+    if (dynamic_cast<CustomParticle*>(aParticleChange->GetSecondary(i)->GetDynamicParticle()->GetDefinition()) !=
+        nullptr)
+      found = true;
     i++;
   }
   i--;
-  if(found) return aParticleChange->GetSecondary(i)->GetDynamicParticle();
+  if (found)
+    return aParticleChange->GetSecondary(i)->GetDynamicParticle();
   return nullptr;
 }
-

--- a/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelReactionDynamics.cc
@@ -22,32 +22,32 @@
 //
 //
 //
- // Hadronic Process: Reaction Dynamics
- // original by H.P. Wellisch
- // modified by J.L. Chuma, TRIUMF, 19-Nov-1996
- // Last modified: 27-Mar-1997
- // modified by H.P. Wellisch, 24-Apr-97
- // H.P. Wellisch, 25.Apr-97: Side of current and target particle taken into account
- // H.P. Wellisch, 29.Apr-97: Bug fix in NuclearReaction. (pseudo1 was without energy)
- // J.L. Chuma, 30-Apr-97:  Changed return value for GenerateXandPt.  It seems possible
- //                         that GenerateXandPt could eliminate some secondaries, but
- //                         still finish its calculations, thus we would not want to
- //                         then use TwoCluster to again calculate the momenta if vecLen
- //                         was less than 6.
- // J.L. Chuma, 10-Jun-97:  Modified NuclearReaction.  Was not creating ReactionProduct's
- //                         with the new operator, thus they would be meaningless when
- //                         going out of scope.
- // J.L. Chuma, 20-Jun-97:  Modified GenerateXandPt and TwoCluster to fix units problems
- // J.L. Chuma, 23-Jun-97:  Modified ProduceStrangeParticlePairs to fix units problems
- // J.L. Chuma, 26-Jun-97:  Modified ProduceStrangeParticlePairs to fix array indices
- //                         which were sometimes going out of bounds
- // J.L. Chuma, 04-Jul-97:  Many minor modifications to GenerateXandPt and TwoCluster
- // J.L. Chuma, 06-Aug-97:  Added original incident particle, before Fermi motion and
- //                         evaporation effects are included, needed for self absorption
- //                         and corrections for single particle spectra (shower particles)
- // logging stopped 1997
- // J. Allison, 17-Jun-99:  Replaced a min function to get correct behaviour on DEC.
- 
+// Hadronic Process: Reaction Dynamics
+// original by H.P. Wellisch
+// modified by J.L. Chuma, TRIUMF, 19-Nov-1996
+// Last modified: 27-Mar-1997
+// modified by H.P. Wellisch, 24-Apr-97
+// H.P. Wellisch, 25.Apr-97: Side of current and target particle taken into account
+// H.P. Wellisch, 29.Apr-97: Bug fix in NuclearReaction. (pseudo1 was without energy)
+// J.L. Chuma, 30-Apr-97:  Changed return value for GenerateXandPt.  It seems possible
+//                         that GenerateXandPt could eliminate some secondaries, but
+//                         still finish its calculations, thus we would not want to
+//                         then use TwoCluster to again calculate the momenta if vecLen
+//                         was less than 6.
+// J.L. Chuma, 10-Jun-97:  Modified NuclearReaction.  Was not creating ReactionProduct's
+//                         with the new operator, thus they would be meaningless when
+//                         going out of scope.
+// J.L. Chuma, 20-Jun-97:  Modified GenerateXandPt and TwoCluster to fix units problems
+// J.L. Chuma, 23-Jun-97:  Modified ProduceStrangeParticlePairs to fix units problems
+// J.L. Chuma, 26-Jun-97:  Modified ProduceStrangeParticlePairs to fix array indices
+//                         which were sometimes going out of bounds
+// J.L. Chuma, 04-Jul-97:  Many minor modifications to GenerateXandPt and TwoCluster
+// J.L. Chuma, 06-Aug-97:  Added original incident particle, before Fermi motion and
+//                         evaporation effects are included, needed for self absorption
+//                         and corrections for single particle spectra (shower particles)
+// logging stopped 1997
+// J. Allison, 17-Jun-99:  Replaced a min function to get correct behaviour on DEC.
+
 #include "SimG4Core/CustomPhysics/interface/FullModelReactionDynamics.h"
 #include "G4AntiProton.hh"
 #include "G4AntiNeutron.hh"
@@ -59,992 +59,1764 @@
 
 using namespace CLHEP;
 
- G4bool FullModelReactionDynamics::GenerateXandPt(
-   G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-   G4int &vecLen,
-   G4ReactionProduct &modifiedOriginal,   // Fermi motion & evap. effects included
-   const G4HadProjectile *originalIncident,   // the original incident particle
-   G4ReactionProduct &currentParticle,
-   G4ReactionProduct &targetParticle,
-   const G4Nucleus &targetNucleus,
-   G4bool &incidentHasChanged,
-   G4bool &targetHasChanged,
-   G4bool leadFlag,
-   G4ReactionProduct &leadingStrangeParticle )
+G4bool FullModelReactionDynamics::GenerateXandPt(
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+    G4int &vecLen,
+    G4ReactionProduct &modifiedOriginal,      // Fermi motion & evap. effects included
+    const G4HadProjectile *originalIncident,  // the original incident particle
+    G4ReactionProduct &currentParticle,
+    G4ReactionProduct &targetParticle,
+    const G4Nucleus &targetNucleus,
+    G4bool &incidentHasChanged,
+    G4bool &targetHasChanged,
+    G4bool leadFlag,
+    G4ReactionProduct &leadingStrangeParticle) {
+  //
+  // derived from original FORTRAN code GENXPT by H. Fesefeldt (11-Oct-1987)
+  //
+  //  Generation of X- and PT- values for incident, target, and all secondary particles
+  //  A simple single variable description E D3S/DP3= F(Q) with
+  //  Q^2 = (M*X)^2 + PT^2 is used. Final state kinematic is produced
+  //  by an FF-type iterative cascade method
+  //
+  //  internal units are GeV
+  //
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+
+  // Protection in case no secondary has been created; cascades down to two-body.
+  if (vecLen == 0)
+    return false;
+
+  G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
+  // G4ParticleDefinition *anAntiProton = G4AntiProton::AntiProton();
+  // G4ParticleDefinition *anAntiNeutron = G4AntiNeutron::AntiNeutron();
+  G4ParticleDefinition *aProton = G4Proton::Proton();
+  G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
+  G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
+  G4ParticleDefinition *aPiZero = G4PionZero::PionZero();
+  G4ParticleDefinition *aKaonPlus = G4KaonPlus::KaonPlus();
+  G4ParticleDefinition *aKaonMinus = G4KaonMinus::KaonMinus();
+  G4ParticleDefinition *aKaonZeroS = G4KaonZeroShort::KaonZeroShort();
+  G4ParticleDefinition *aKaonZeroL = G4KaonZeroLong::KaonZeroLong();
+
+  G4int i, l;
+  //    G4double forVeryForward = 0.;
+  G4bool veryForward = false;
+
+  const G4double ekOriginal = modifiedOriginal.GetKineticEnergy() / GeV;
+  const G4double etOriginal = modifiedOriginal.GetTotalEnergy() / GeV;
+  const G4double mOriginal = modifiedOriginal.GetMass() / GeV;
+  const G4double pOriginal = modifiedOriginal.GetMomentum().mag() / GeV;
+  G4double targetMass = targetParticle.GetDefinition()->GetPDGMass() / GeV;
+  G4double centerofmassEnergy =
+      std::sqrt(mOriginal * mOriginal + targetMass * targetMass + 2.0 * targetMass * etOriginal);  // GeV
+  G4double currentMass = currentParticle.GetMass() / GeV;
+  targetMass = targetParticle.GetMass() / GeV;
+  //
+  //  randomize the order of the secondary particles
+  //  note that the current and target particles are not affected
+  //
+  for (i = 0; i < vecLen; ++i) {
+    G4int itemp = G4int(G4UniformRand() * vecLen);
+    G4ReactionProduct pTemp = *vec[itemp];
+    *vec[itemp] = *vec[i];
+    *vec[i] = pTemp;
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  }
+
+  if (currentMass == 0.0 && targetMass == 0.0)  // annihilation
   {
-    // 
-    // derived from original FORTRAN code GENXPT by H. Fesefeldt (11-Oct-1987)
-    //
-    //  Generation of X- and PT- values for incident, target, and all secondary particles 
-    //  A simple single variable description E D3S/DP3= F(Q) with
-    //  Q^2 = (M*X)^2 + PT^2 is used. Final state kinematic is produced
-    //  by an FF-type iterative cascade method
-    //
-    //  internal units are GeV
-    //
-    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    
-    // Protection in case no secondary has been created; cascades down to two-body.
-    if(vecLen == 0) return false;
+    // no kinetic energy in target .....
+    G4double ek = currentParticle.GetKineticEnergy();
+    G4ThreeVector m = currentParticle.GetMomentum();
+    currentParticle = *vec[0];
+    targetParticle = *vec[1];
+    for (i = 0; i < (vecLen - 2); ++i)
+      *vec[i] = *vec[i + 2];
+    G4ReactionProduct *temp = vec[vecLen - 1];
+    delete temp;
+    temp = vec[vecLen - 2];
+    delete temp;
+    vecLen -= 2;
+    currentMass = currentParticle.GetMass() / GeV;
+    targetMass = targetParticle.GetMass() / GeV;
+    incidentHasChanged = true;
+    targetHasChanged = true;
+    currentParticle.SetKineticEnergy(ek);
+    currentParticle.SetMomentum(m);
+    veryForward = true;
+  }
+  const G4double atomicWeight = targetNucleus.GetN_asInt();
+  const G4double atomicNumber = targetNucleus.GetZ_asInt();
+  const G4double protonMass = aProton->GetPDGMass() / MeV;
+  if ((originalIncident->GetDefinition() == aKaonMinus || originalIncident->GetDefinition() == aKaonZeroL ||
+       originalIncident->GetDefinition() == aKaonZeroS || originalIncident->GetDefinition() == aKaonPlus) &&
+      G4UniformRand() >= 0.7) {
+    G4ReactionProduct temp = currentParticle;
+    currentParticle = targetParticle;
+    targetParticle = temp;
+    incidentHasChanged = true;
+    targetHasChanged = true;
+    currentMass = currentParticle.GetMass() / GeV;
+    targetMass = targetParticle.GetMass() / GeV;
+  }
+  const G4double afc = std::min(0.75,
+                                0.312 + 0.200 * std::log(std::log(centerofmassEnergy * centerofmassEnergy)) +
+                                    std::pow(centerofmassEnergy * centerofmassEnergy, 1.5) / 6000.0);
 
-    G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
-    // G4ParticleDefinition *anAntiProton = G4AntiProton::AntiProton();
-    // G4ParticleDefinition *anAntiNeutron = G4AntiNeutron::AntiNeutron();
-    G4ParticleDefinition *aProton = G4Proton::Proton();
-    G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
-    G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
-    G4ParticleDefinition *aPiZero = G4PionZero::PionZero();
-    G4ParticleDefinition *aKaonPlus = G4KaonPlus::KaonPlus();
-    G4ParticleDefinition *aKaonMinus = G4KaonMinus::KaonMinus();
-    G4ParticleDefinition *aKaonZeroS = G4KaonZeroShort::KaonZeroShort();
-    G4ParticleDefinition *aKaonZeroL = G4KaonZeroLong::KaonZeroLong();
+  // PROBLEMET ER HER!!!
 
-    G4int i, l;
-    //    G4double forVeryForward = 0.;
-    G4bool veryForward = false;
-    
-    const G4double ekOriginal = modifiedOriginal.GetKineticEnergy()/GeV;
-    const G4double etOriginal = modifiedOriginal.GetTotalEnergy()/GeV;
-    const G4double mOriginal = modifiedOriginal.GetMass()/GeV;
-    const G4double pOriginal = modifiedOriginal.GetMomentum().mag()/GeV;
-    G4double targetMass = targetParticle.GetDefinition()->GetPDGMass()/GeV;
-    G4double centerofmassEnergy = std::sqrt( mOriginal*mOriginal +
-                                        targetMass*targetMass +
-                                        2.0*targetMass*etOriginal );  // GeV
-    G4double currentMass = currentParticle.GetMass()/GeV;
-    targetMass = targetParticle.GetMass()/GeV;
-    //
-    //  randomize the order of the secondary particles
-    //  note that the current and target particles are not affected
-    //
-    for( i=0; i<vecLen; ++i )
-    {
-      G4int itemp = G4int( G4UniformRand()*vecLen );
-      G4ReactionProduct pTemp = *vec[itemp];
-      *vec[itemp] = *vec[i];
-      *vec[i] = pTemp;
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  G4double freeEnergy = centerofmassEnergy - currentMass - targetMass;
+
+  if (freeEnergy < 0) {
+    G4cout << "Free energy < 0!" << G4endl;
+    G4cout << "E_CMS = " << centerofmassEnergy << " GeV" << G4endl;
+    G4cout << "m_curr = " << currentMass << " GeV" << G4endl;
+    G4cout << "m_orig = " << mOriginal << " GeV" << G4endl;
+    G4cout << "m_targ = " << targetMass << " GeV" << G4endl;
+    G4cout << "E_free = " << freeEnergy << " GeV" << G4endl;
+  }
+
+  G4double forwardEnergy = freeEnergy / 2.;
+  G4int forwardCount = 1;  // number of particles in forward hemisphere
+
+  G4double backwardEnergy = freeEnergy / 2.;
+  G4int backwardCount = 1;  // number of particles in backward hemisphere
+  if (veryForward) {
+    if (currentParticle.GetSide() == -1) {
+      forwardEnergy += currentMass;
+      forwardCount--;
+      backwardEnergy -= currentMass;
+      backwardCount++;
     }
-
-    if( currentMass == 0.0 && targetMass == 0.0 )       // annihilation
-    {
-      // no kinetic energy in target .....
-      G4double ek = currentParticle.GetKineticEnergy();
-      G4ThreeVector m = currentParticle.GetMomentum();
-      currentParticle = *vec[0];
-      targetParticle = *vec[1];
-      for( i=0; i<(vecLen-2); ++i )*vec[i] = *vec[i+2];
-      G4ReactionProduct *temp = vec[vecLen-1];
-      delete temp;
-      temp = vec[vecLen-2];
-      delete temp;
-      vecLen -= 2;
-      currentMass = currentParticle.GetMass()/GeV;
-      targetMass = targetParticle.GetMass()/GeV;
-      incidentHasChanged = true;
-      targetHasChanged = true;
-      currentParticle.SetKineticEnergy( ek );
-      currentParticle.SetMomentum( m );
-      veryForward = true;
+    if (targetParticle.GetSide() != -1) {
+      backwardEnergy += targetMass;
+      backwardCount--;
+      forwardEnergy -= targetMass;
+      forwardCount++;
     }
-    const G4double atomicWeight = targetNucleus.GetN_asInt();
-    const G4double atomicNumber = targetNucleus.GetZ_asInt();
-    const G4double protonMass = aProton->GetPDGMass()/MeV;
-    if( (originalIncident->GetDefinition() == aKaonMinus ||
-         originalIncident->GetDefinition() == aKaonZeroL ||
-         originalIncident->GetDefinition() == aKaonZeroS ||
-         originalIncident->GetDefinition() == aKaonPlus) &&
-        G4UniformRand() >= 0.7 )
-    {
-      G4ReactionProduct temp = currentParticle;
-      currentParticle = targetParticle;
-      targetParticle = temp;
-      incidentHasChanged = true;
-      targetHasChanged = true;
-      currentMass = currentParticle.GetMass()/GeV;
-      targetMass = targetParticle.GetMass()/GeV;
+  }
+  for (i = 0; i < vecLen; ++i) {
+    if (vec[i]->GetSide() == -1) {
+      ++backwardCount;
+      backwardEnergy -= vec[i]->GetMass() / GeV;
+    } else {
+      ++forwardCount;
+      forwardEnergy -= vec[i]->GetMass() / GeV;
     }
-    const G4double afc = std::min( 0.75,
-                              0.312+0.200*std::log(std::log(centerofmassEnergy*centerofmassEnergy))+
-                              std::pow(centerofmassEnergy*centerofmassEnergy,1.5)/6000.0 );
-
-    // PROBLEMET ER HER!!!
-    
-    G4double freeEnergy = centerofmassEnergy-currentMass-targetMass;
-
-    if(freeEnergy<0) 
-      {
-	G4cout<<"Free energy < 0!"<<G4endl;
-	G4cout<<"E_CMS = "<<centerofmassEnergy<<" GeV"<<G4endl;
-	G4cout<<"m_curr = "<<currentMass<<" GeV"<<G4endl;
-	G4cout<<"m_orig = "<<mOriginal<<" GeV"<<G4endl;
-	G4cout<<"m_targ = "<<targetMass<<" GeV"<<G4endl;
-	G4cout<<"E_free = "<<freeEnergy<<" GeV"<<G4endl;
-      }
-
-    G4double forwardEnergy = freeEnergy/2.;
-    G4int forwardCount = 1;            // number of particles in forward hemisphere
-    
-    G4double backwardEnergy = freeEnergy/2.;
-    G4int backwardCount = 1;           // number of particles in backward hemisphere
-    if(veryForward)
-    {
-      if(currentParticle.GetSide()==-1)
-      {
-        forwardEnergy += currentMass;
-	forwardCount --;
-	backwardEnergy -= currentMass;
-	backwardCount ++;
-      }
-      if(targetParticle.GetSide()!=-1)
-      {
-        backwardEnergy += targetMass;
-	backwardCount --;
-	forwardEnergy -= targetMass;
-	forwardCount ++;
-      }
-    }
-    for( i=0; i<vecLen; ++i )
-    {
-      if( vec[i]->GetSide() == -1 )
-      {
-        ++backwardCount;
-        backwardEnergy -= vec[i]->GetMass()/GeV;
-      } else {
-        ++forwardCount;
-        forwardEnergy -= vec[i]->GetMass()/GeV;
-      }
-    }
+  }
+  //
+  //  add particles from intranuclear cascade
+  //  nuclearExcitationCount = number of new secondaries produced by nuclear excitation
+  //  extraCount = number of nucleons within these new secondaries
+  //
+  G4double xtarg;
+  if (centerofmassEnergy < (2.0 + G4UniformRand()))
+    xtarg = afc * (std::pow(atomicWeight, 0.33) - 1.0) * (2.0 * backwardCount + vecLen + 2) / 2.0;
+  else
+    xtarg = afc * (std::pow(atomicWeight, 0.33) - 1.0) * (2.0 * backwardCount);
+  if (xtarg <= 0.0)
+    xtarg = 0.01;
+  G4int nuclearExcitationCount = Poisson(xtarg);
+  if (atomicWeight < 1.0001)
+    nuclearExcitationCount = 0;
+  G4int extraNucleonCount = 0;
+  G4double extraNucleonMass = 0.0;
+  if (nuclearExcitationCount > 0) {
+    const G4double nucsup[] = {1.00, 0.7, 0.5, 0.4, 0.35, 0.3};
+    const G4double psup[] = {3., 6., 20., 50., 100., 1000.};
+    G4int momentumBin = 0;
+    while ((momentumBin < 6) && (modifiedOriginal.GetTotalMomentum() / GeV > psup[momentumBin]))
+      ++momentumBin;
+    momentumBin = std::min(5, momentumBin);
     //
-    //  add particles from intranuclear cascade
-    //  nuclearExcitationCount = number of new secondaries produced by nuclear excitation
-    //  extraCount = number of nucleons within these new secondaries
+    //  NOTE: in GENXPT, these new particles were given negative codes
+    //        here I use  NewlyAdded = true  instead
     //
-    G4double xtarg;
-    if( centerofmassEnergy < (2.0+G4UniformRand()) )
-      xtarg = afc * (std::pow(atomicWeight,0.33)-1.0) * (2.0*backwardCount+vecLen+2)/2.0;
-    else
-      xtarg = afc * (std::pow(atomicWeight,0.33)-1.0) * (2.0*backwardCount);
-    if( xtarg <= 0.0 )xtarg = 0.01;
-    G4int nuclearExcitationCount = Poisson( xtarg );
-    if(atomicWeight<1.0001) nuclearExcitationCount = 0;
-    G4int extraNucleonCount = 0;
-    G4double extraNucleonMass = 0.0;
-    if( nuclearExcitationCount > 0 )
-    {
-      const G4double nucsup[] = { 1.00, 0.7, 0.5, 0.4, 0.35, 0.3 };
-      const G4double psup[] = { 3., 6., 20., 50., 100., 1000. };
-      G4int momentumBin = 0;
-      while( (momentumBin < 6) &&
-             (modifiedOriginal.GetTotalMomentum()/GeV > psup[momentumBin]) )
-        ++momentumBin;
-      momentumBin = std::min( 5, momentumBin );
-      //
-      //  NOTE: in GENXPT, these new particles were given negative codes
-      //        here I use  NewlyAdded = true  instead
-      //
-      for( i=0; i<nuclearExcitationCount; ++i )
-      {
-        G4ReactionProduct * pVec = new G4ReactionProduct();
-        if( G4UniformRand() < nucsup[momentumBin] )
-        {
-          if( G4UniformRand() > 1.0-atomicNumber/atomicWeight )
-            pVec->SetDefinition( aProton );
-          else
-            pVec->SetDefinition( aNeutron );
-          pVec->SetSide( -2 );                // -2 means backside nucleon
-          ++extraNucleonCount;
-          backwardEnergy += pVec->GetMass()/GeV;
-          extraNucleonMass += pVec->GetMass()/GeV;
-        }
+    for (i = 0; i < nuclearExcitationCount; ++i) {
+      G4ReactionProduct *pVec = new G4ReactionProduct();
+      if (G4UniformRand() < nucsup[momentumBin]) {
+        if (G4UniformRand() > 1.0 - atomicNumber / atomicWeight)
+          pVec->SetDefinition(aProton);
         else
-        {
-          G4double ran = G4UniformRand();
-          if( ran < 0.3181 )
-            pVec->SetDefinition( aPiPlus );
-          else if( ran < 0.6819 )
-            pVec->SetDefinition( aPiZero );
-          else
-            pVec->SetDefinition( aPiMinus );
-          pVec->SetSide( -1 );                // backside particle, but not a nucleon
-        }
-        pVec->SetNewlyAdded( true );                // true is the same as IPA(i)<0
-        vec.SetElement( vecLen++, pVec );    
-        // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-        backwardEnergy -= pVec->GetMass()/GeV;
-        ++backwardCount;
+          pVec->SetDefinition(aNeutron);
+        pVec->SetSide(-2);  // -2 means backside nucleon
+        ++extraNucleonCount;
+        backwardEnergy += pVec->GetMass() / GeV;
+        extraNucleonMass += pVec->GetMass() / GeV;
+      } else {
+        G4double ran = G4UniformRand();
+        if (ran < 0.3181)
+          pVec->SetDefinition(aPiPlus);
+        else if (ran < 0.6819)
+          pVec->SetDefinition(aPiZero);
+        else
+          pVec->SetDefinition(aPiMinus);
+        pVec->SetSide(-1);  // backside particle, but not a nucleon
       }
-    }
-    //
-    //  assume conservation of kinetic energy in forward & backward hemispheres
-    //
-    G4int is, iskip;
-    while( forwardEnergy <= 0.0 )  // must eliminate a particle from the forward side
-    {
+      pVec->SetNewlyAdded(true);  // true is the same as IPA(i)<0
+      vec.SetElement(vecLen++, pVec);
       // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      iskip = G4int(G4UniformRand()*forwardCount) + 1; // 1 <= iskip <= forwardCount
-      is = 0;
-      G4int forwardParticlesLeft = 0;
-      for( i=(vecLen-1); i>=0; --i )
-      {
-        if( vec[i]->GetSide() == 1 && vec[i]->GetMayBeKilled())
+      backwardEnergy -= pVec->GetMass() / GeV;
+      ++backwardCount;
+    }
+  }
+  //
+  //  assume conservation of kinetic energy in forward & backward hemispheres
+  //
+  G4int is, iskip;
+  while (forwardEnergy <= 0.0)  // must eliminate a particle from the forward side
+  {
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    iskip = G4int(G4UniformRand() * forwardCount) + 1;  // 1 <= iskip <= forwardCount
+    is = 0;
+    G4int forwardParticlesLeft = 0;
+    for (i = (vecLen - 1); i >= 0; --i) {
+      if (vec[i]->GetSide() == 1 && vec[i]->GetMayBeKilled()) {
+        forwardParticlesLeft = 1;
+        if (++is == iskip) {
+          forwardEnergy += vec[i]->GetMass() / GeV;
+          for (G4int j = i; j < (vecLen - 1); j++)
+            *vec[j] = *vec[j + 1];  // shift up
+          --forwardCount;
+          G4ReactionProduct *temp = vec[vecLen - 1];
+          delete temp;
+          if (--vecLen == 0)
+            return false;  // all the secondaries have been eliminated
+          break;           // --+
+        }                  //   |
+      }                    //   |
+    }                      // break goes down to here
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    if (forwardParticlesLeft == 0) {
+      forwardEnergy += currentParticle.GetMass() / GeV;
+      currentParticle.SetDefinitionAndUpdateE(targetParticle.GetDefinition());
+      targetParticle.SetDefinitionAndUpdateE(vec[0]->GetDefinition());
+      // above two lines modified 20-oct-97: were just simple equalities
+      --forwardCount;
+      for (G4int j = 0; j < (vecLen - 1); ++j)
+        *vec[j] = *vec[j + 1];
+      G4ReactionProduct *temp = vec[vecLen - 1];
+      delete temp;
+      if (--vecLen == 0)
+        return false;  // all the secondaries have been eliminated
+      break;
+    }
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  while (backwardEnergy <= 0.0)  // must eliminate a particle from the backward side
+  {
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    iskip = G4int(G4UniformRand() * backwardCount) + 1;  // 1 <= iskip <= backwardCount
+    is = 0;
+    G4int backwardParticlesLeft = 0;
+    for (i = (vecLen - 1); i >= 0; --i) {
+      if (vec[i]->GetSide() < 0 && vec[i]->GetMayBeKilled()) {
+        backwardParticlesLeft = 1;
+        if (++is == iskip)  // eliminate the i'th particle
         {
-          forwardParticlesLeft = 1;  
-          if( ++is == iskip )
-          { 
-            forwardEnergy += vec[i]->GetMass()/GeV;
-            for( G4int j=i; j<(vecLen-1); j++ )*vec[j] = *vec[j+1];    // shift up
-            --forwardCount;
-            G4ReactionProduct *temp = vec[vecLen-1];
-            delete temp;
-            if( --vecLen == 0 )return false;  // all the secondaries have been eliminated
-            break;  // --+
-          }         //   |
-        }           //   |
-      }             // break goes down to here
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      if( forwardParticlesLeft == 0 )
-      {
-        forwardEnergy += currentParticle.GetMass()/GeV;
-        currentParticle.SetDefinitionAndUpdateE( targetParticle.GetDefinition() );
-        targetParticle.SetDefinitionAndUpdateE( vec[0]->GetDefinition() );
-        // above two lines modified 20-oct-97: were just simple equalities
-        --forwardCount;
-        for( G4int j=0; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];
-        G4ReactionProduct *temp = vec[vecLen-1];
-        delete temp;
-        if( --vecLen == 0 )return false;  // all the secondaries have been eliminated
-        break;
-      }
-    }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    while( backwardEnergy <= 0.0 )  // must eliminate a particle from the backward side
-    {
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      iskip = G4int(G4UniformRand()*backwardCount) + 1; // 1 <= iskip <= backwardCount
-      is = 0;
-      G4int backwardParticlesLeft = 0;
-      for( i=(vecLen-1); i>=0; --i )
-      {
-        if( vec[i]->GetSide() < 0 && vec[i]->GetMayBeKilled())
-	{
-          backwardParticlesLeft = 1;
-          if( ++is == iskip )        // eliminate the i'th particle
-          {
-            if( vec[i]->GetSide() == -2 )
-            {
-              --extraNucleonCount;
-              extraNucleonMass -= vec[i]->GetMass()/GeV;
-              backwardEnergy -= vec[i]->GetTotalEnergy()/GeV;
-            }
-            backwardEnergy += vec[i]->GetTotalEnergy()/GeV;
-            for( G4int j=i; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];   // shift up
-            --backwardCount;
-            G4ReactionProduct *temp = vec[vecLen-1];
-            delete temp;
-            if( --vecLen == 0 )return false;  // all the secondaries have been eliminated
-            break;
+          if (vec[i]->GetSide() == -2) {
+            --extraNucleonCount;
+            extraNucleonMass -= vec[i]->GetMass() / GeV;
+            backwardEnergy -= vec[i]->GetTotalEnergy() / GeV;
           }
+          backwardEnergy += vec[i]->GetTotalEnergy() / GeV;
+          for (G4int j = i; j < (vecLen - 1); ++j)
+            *vec[j] = *vec[j + 1];  // shift up
+          --backwardCount;
+          G4ReactionProduct *temp = vec[vecLen - 1];
+          delete temp;
+          if (--vecLen == 0)
+            return false;  // all the secondaries have been eliminated
+          break;
         }
-      }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      if( backwardParticlesLeft == 0 )
-      {
-	backwardEnergy += targetParticle.GetMass()/GeV;
-        targetParticle = *vec[0];
-        --backwardCount;
-        for( G4int j=0; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];
-        G4ReactionProduct *temp = vec[vecLen-1];
-        delete temp;
-        if( --vecLen == 0 )return false;  // all the secondaries have been eliminated
-        break;
       }
     }
     // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    //
-    //  define initial state vectors for Lorentz transformations
-    //  the pseudoParticles have non-standard masses, hence the "pseudo"
-    //
-    G4ReactionProduct pseudoParticle[10];
-    for( i=0; i<10; ++i )pseudoParticle[i].SetZero();
-    
-    pseudoParticle[0].SetMass( mOriginal*GeV );
-    pseudoParticle[0].SetMomentum( 0.0, 0.0, pOriginal*GeV );
-    pseudoParticle[0].SetTotalEnergy(
-     std::sqrt( pOriginal*pOriginal + mOriginal*mOriginal )*GeV );
-    
-    pseudoParticle[1].SetMass( protonMass*MeV );        // this could be targetMass
-    pseudoParticle[1].SetTotalEnergy( protonMass*MeV );
-    
-    pseudoParticle[3].SetMass( protonMass*(1+extraNucleonCount)*MeV );
-    pseudoParticle[3].SetTotalEnergy( protonMass*(1+extraNucleonCount)*MeV );
-    
-    pseudoParticle[8].SetMomentum( 1.0*GeV, 0.0, 0.0 );
-    
-    pseudoParticle[2] = pseudoParticle[0] + pseudoParticle[1];
-    pseudoParticle[3] = pseudoParticle[3] + pseudoParticle[0];
-    
-    pseudoParticle[0].Lorentz( pseudoParticle[0], pseudoParticle[2] );
-    pseudoParticle[1].Lorentz( pseudoParticle[1], pseudoParticle[2] );
-    
-    G4double dndl[20];
-    //
-    //  main loop for 4-momentum generation
-    //  see Pitha-report (Aachen) for a detailed description of the method
-    //
-    G4double aspar, pt, et, x, pp, pp1, rthnve, phinve, rmb, wgt;
-    G4int    innerCounter, outerCounter;
-    G4bool   eliminateThisParticle, resetEnergies, constantCrossSection;
-    
-    G4double forwardKinetic = 0.0, backwardKinetic = 0.0;
-    //
-    // process the secondary particles in reverse order
-    // the incident particle is Done after the secondaries
-    // nucleons, including the target, in the backward hemisphere are also Done later
-    //
-    G4double binl[20] = {0.,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.11,1.25,
-                         1.43,1.67,2.0,2.5,3.33,5.00,10.00};
-    G4int backwardNucleonCount = 0;       // number of nucleons in backward hemisphere
-    G4double totalEnergy, kineticEnergy, vecMass;
+    if (backwardParticlesLeft == 0) {
+      backwardEnergy += targetParticle.GetMass() / GeV;
+      targetParticle = *vec[0];
+      --backwardCount;
+      for (G4int j = 0; j < (vecLen - 1); ++j)
+        *vec[j] = *vec[j + 1];
+      G4ReactionProduct *temp = vec[vecLen - 1];
+      delete temp;
+      if (--vecLen == 0)
+        return false;  // all the secondaries have been eliminated
+      break;
+    }
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  //
+  //  define initial state vectors for Lorentz transformations
+  //  the pseudoParticles have non-standard masses, hence the "pseudo"
+  //
+  G4ReactionProduct pseudoParticle[10];
+  for (i = 0; i < 10; ++i)
+    pseudoParticle[i].SetZero();
 
-    for( i=(vecLen-1); i>=0; --i )
+  pseudoParticle[0].SetMass(mOriginal * GeV);
+  pseudoParticle[0].SetMomentum(0.0, 0.0, pOriginal * GeV);
+  pseudoParticle[0].SetTotalEnergy(std::sqrt(pOriginal * pOriginal + mOriginal * mOriginal) * GeV);
+
+  pseudoParticle[1].SetMass(protonMass * MeV);  // this could be targetMass
+  pseudoParticle[1].SetTotalEnergy(protonMass * MeV);
+
+  pseudoParticle[3].SetMass(protonMass * (1 + extraNucleonCount) * MeV);
+  pseudoParticle[3].SetTotalEnergy(protonMass * (1 + extraNucleonCount) * MeV);
+
+  pseudoParticle[8].SetMomentum(1.0 * GeV, 0.0, 0.0);
+
+  pseudoParticle[2] = pseudoParticle[0] + pseudoParticle[1];
+  pseudoParticle[3] = pseudoParticle[3] + pseudoParticle[0];
+
+  pseudoParticle[0].Lorentz(pseudoParticle[0], pseudoParticle[2]);
+  pseudoParticle[1].Lorentz(pseudoParticle[1], pseudoParticle[2]);
+
+  G4double dndl[20];
+  //
+  //  main loop for 4-momentum generation
+  //  see Pitha-report (Aachen) for a detailed description of the method
+  //
+  G4double aspar, pt, et, x, pp, pp1, rthnve, phinve, rmb, wgt;
+  G4int innerCounter, outerCounter;
+  G4bool eliminateThisParticle, resetEnergies, constantCrossSection;
+
+  G4double forwardKinetic = 0.0, backwardKinetic = 0.0;
+  //
+  // process the secondary particles in reverse order
+  // the incident particle is Done after the secondaries
+  // nucleons, including the target, in the backward hemisphere are also Done later
+  //
+  G4double binl[20] = {0.,  0.1,  0.2,  0.3,  0.4,  0.5, 0.6, 0.7,  0.8,  0.9,
+                       1.0, 1.11, 1.25, 1.43, 1.67, 2.0, 2.5, 3.33, 5.00, 10.00};
+  G4int backwardNucleonCount = 0;  // number of nucleons in backward hemisphere
+  G4double totalEnergy, kineticEnergy, vecMass;
+
+  for (i = (vecLen - 1); i >= 0; --i) {
+    G4double phi = G4UniformRand() * twopi;
+    if (vec[i]->GetNewlyAdded())  // added from intranuclear cascade
     {
-      G4double phi = G4UniformRand()*twopi;
-      if( vec[i]->GetNewlyAdded() )           // added from intranuclear cascade
+      if (vec[i]->GetSide() == -2)  //  is a nucleon
       {
-        if( vec[i]->GetSide() == -2 )         //  is a nucleon
+        if (backwardNucleonCount < 18) {
+          if (vec[i]->GetDefinition() == G4PionMinus::PionMinus() ||
+              vec[i]->GetDefinition() == G4PionPlus::PionPlus() || vec[i]->GetDefinition() == G4PionZero::PionZero()) {
+            for (G4int i = 0; i < vecLen; i++)
+              delete vec[i];
+            vecLen = 0;
+            throw G4HadReentrentException(
+                __FILE__,
+                __LINE__,
+                "FullModelReactionDynamics::GenerateXandPt : a pion has been counted as a backward nucleon");
+          }
+          vec[i]->SetSide(-3);
+          ++backwardNucleonCount;
+          continue;
+        }
+      }
+    }
+    //
+    //  set pt and phi values, they are changed somewhat in the iteration loop
+    //  set mass parameter for lambda fragmentation model
+    //
+    vecMass = vec[i]->GetMass() / GeV;
+    G4double ran = -std::log(1.0 - G4UniformRand()) / 3.5;
+    if (vec[i]->GetSide() == -2)  // backward nucleon
+    {
+      if (vec[i]->GetDefinition() == aKaonMinus || vec[i]->GetDefinition() == aKaonZeroL ||
+          vec[i]->GetDefinition() == aKaonZeroS || vec[i]->GetDefinition() == aKaonPlus ||
+          vec[i]->GetDefinition() == aPiMinus || vec[i]->GetDefinition() == aPiZero ||
+          vec[i]->GetDefinition() == aPiPlus) {
+        aspar = 0.75;
+        pt = std::sqrt(std::pow(ran, 1.7));
+      } else {         // vec[i] must be a proton, neutron,
+        aspar = 0.20;  //  lambda, sigma, xsi, or ion
+        pt = std::sqrt(std::pow(ran, 1.2));
+      }
+    } else {  // not a backward nucleon
+      if (vec[i]->GetDefinition() == aPiMinus || vec[i]->GetDefinition() == aPiZero ||
+          vec[i]->GetDefinition() == aPiPlus) {
+        aspar = 0.75;
+        pt = std::sqrt(std::pow(ran, 1.7));
+      } else if (vec[i]->GetDefinition() == aKaonMinus || vec[i]->GetDefinition() == aKaonZeroL ||
+                 vec[i]->GetDefinition() == aKaonZeroS || vec[i]->GetDefinition() == aKaonPlus) {
+        aspar = 0.70;
+        pt = std::sqrt(std::pow(ran, 1.7));
+      } else {         // vec[i] must be a proton, neutron,
+        aspar = 0.65;  //  lambda, sigma, xsi, or ion
+        pt = std::sqrt(std::pow(ran, 1.5));
+      }
+    }
+    pt = std::max(0.001, pt);
+    vec[i]->SetMomentum(pt * std::cos(phi) * GeV, pt * std::sin(phi) * GeV);
+    for (G4int j = 0; j < 20; ++j)
+      binl[j] = j / (19. * pt);
+    if (vec[i]->GetSide() > 0)
+      et = pseudoParticle[0].GetTotalEnergy() / GeV;
+    else
+      et = pseudoParticle[1].GetTotalEnergy() / GeV;
+    dndl[0] = 0.0;
+    //
+    //   start of outer iteration loop
+    //
+    outerCounter = 0;
+    eliminateThisParticle = true;
+    resetEnergies = true;
+    while (++outerCounter < 3) {
+      for (l = 1; l < 20; ++l) {
+        x = (binl[l] + binl[l - 1]) / 2.;
+        pt = std::max(0.001, pt);
+        if (x > 1.0 / pt)
+          dndl[l] += dndl[l - 1];  //  changed from just  =  on 02 April 98
+        else
+          dndl[l] = et * aspar / std::sqrt(std::pow((1. + aspar * x * aspar * x), 3)) * (binl[l] - binl[l - 1]) /
+                        std::sqrt(pt * x * et * pt * x * et + pt * pt + vecMass * vecMass) +
+                    dndl[l - 1];
+      }
+      innerCounter = 0;
+      vec[i]->SetMomentum(pt * std::cos(phi) * GeV, pt * std::sin(phi) * GeV);
+      //
+      //   start of inner iteration loop
+      //
+      while (++innerCounter < 7) {
+        ran = G4UniformRand() * dndl[19];
+        l = 1;
+        while ((ran >= dndl[l]) && (l < 20))
+          l++;
+        l = std::min(19, l);
+        x = std::min(1.0, pt * (binl[l - 1] + G4UniformRand() * (binl[l] - binl[l - 1]) / 2.));
+        if (vec[i]->GetSide() < 0)
+          x *= -1.;
+        vec[i]->SetMomentum(x * et * GeV);  // set the z-momentum
+        totalEnergy = std::sqrt(x * et * x * et + pt * pt + vecMass * vecMass);
+        vec[i]->SetTotalEnergy(totalEnergy * GeV);
+        kineticEnergy = vec[i]->GetKineticEnergy() / GeV;
+        if (vec[i]->GetSide() > 0)  // forward side
         {
-          if( backwardNucleonCount < 18 )
+          if ((forwardKinetic + kineticEnergy) < 0.95 * forwardEnergy) {
+            pseudoParticle[4] = pseudoParticle[4] + (*vec[i]);
+            forwardKinetic += kineticEnergy;
+            pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
+            pseudoParticle[6].SetMomentum(0.0);  // set the z-momentum
+            phi = pseudoParticle[6].Angle(pseudoParticle[8]);
+            if (pseudoParticle[6].GetMomentum().y() / MeV < 0.0)
+              phi = twopi - phi;
+            phi += pi + normal() * pi / 12.0;
+            if (phi > twopi)
+              phi -= twopi;
+            if (phi < 0.0)
+              phi = twopi - phi;
+            outerCounter = 2;               // leave outer loop
+            eliminateThisParticle = false;  // don't eliminate this particle
+            resetEnergies = false;
+            break;  // leave inner loop
+          }
+          if (innerCounter > 5)
+            break;                        // leave inner loop
+          if (backwardEnergy >= vecMass)  // switch sides
           {
-            if( vec[i]->GetDefinition() == G4PionMinus::PionMinus() ||
-                vec[i]->GetDefinition() == G4PionPlus::PionPlus() ||
-                vec[i]->GetDefinition() == G4PionZero::PionZero() )
-            {
-              for(G4int i=0; i<vecLen; i++) delete vec[i];
-   	      vecLen = 0;
-              throw G4HadReentrentException(__FILE__, __LINE__,
-	      "FullModelReactionDynamics::GenerateXandPt : a pion has been counted as a backward nucleon");
+            vec[i]->SetSide(-1);
+            forwardEnergy += vecMass;
+            backwardEnergy -= vecMass;
+            ++backwardCount;
+          }
+        } else {  // backward side
+          G4double xxx = 0.95 + 0.05 * extraNucleonCount / 20.0;
+          if ((backwardKinetic + kineticEnergy) < xxx * backwardEnergy) {
+            pseudoParticle[5] = pseudoParticle[5] + (*vec[i]);
+            backwardKinetic += kineticEnergy;
+            pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
+            pseudoParticle[6].SetMomentum(0.0);  // set the z-momentum
+            phi = pseudoParticle[6].Angle(pseudoParticle[8]);
+            if (pseudoParticle[6].GetMomentum().y() / MeV < 0.0)
+              phi = twopi - phi;
+            phi += pi + normal() * pi / 12.0;
+            if (phi > twopi)
+              phi -= twopi;
+            if (phi < 0.0)
+              phi = twopi - phi;
+            outerCounter = 2;               // leave outer loop
+            eliminateThisParticle = false;  // don't eliminate this particle
+            resetEnergies = false;
+            break;  // leave inner loop
+          }
+          if (innerCounter > 5)
+            break;                       // leave inner loop
+          if (forwardEnergy >= vecMass)  // switch sides
+          {
+            vec[i]->SetSide(1);
+            forwardEnergy -= vecMass;
+            backwardEnergy += vecMass;
+            backwardCount--;
+          }
+        }
+        G4ThreeVector momentum = vec[i]->GetMomentum();
+        vec[i]->SetMomentum(momentum.x() * 0.9, momentum.y() * 0.9);
+        pt *= 0.9;
+        dndl[19] *= 0.9;
+      }  // closes inner loop
+      if (resetEnergies) {
+        //   if we get to here, the inner loop has been Done 6 Times
+        //   reset the kinetic energies of previously Done particles, if they are lighter
+        //    than protons and in the forward hemisphere
+        //   then continue with outer loop
+        //
+        forwardKinetic = 0.0;
+        backwardKinetic = 0.0;
+        pseudoParticle[4].SetZero();
+        pseudoParticle[5].SetZero();
+        for (l = i + 1; l < vecLen; ++l) {
+          if (vec[l]->GetSide() > 0 || vec[l]->GetDefinition() == aKaonMinus || vec[l]->GetDefinition() == aKaonZeroL ||
+              vec[l]->GetDefinition() == aKaonZeroS || vec[l]->GetDefinition() == aKaonPlus ||
+              vec[l]->GetDefinition() == aPiMinus || vec[l]->GetDefinition() == aPiZero ||
+              vec[l]->GetDefinition() == aPiPlus) {
+            G4double tempMass = vec[l]->GetMass() / MeV;
+            totalEnergy = 0.95 * vec[l]->GetTotalEnergy() / MeV + 0.05 * tempMass;
+            totalEnergy = std::max(tempMass, totalEnergy);
+            vec[l]->SetTotalEnergy(totalEnergy * MeV);
+            pp = std::sqrt(std::abs(totalEnergy * totalEnergy - tempMass * tempMass));
+            pp1 = vec[l]->GetMomentum().mag() / MeV;
+            if (pp1 < 1.0e-6 * GeV) {
+              G4double rthnve = pi * G4UniformRand();
+              G4double phinve = twopi * G4UniformRand();
+              G4double srth = std::sin(rthnve);
+              vec[l]->SetMomentum(
+                  pp * srth * std::cos(phinve) * MeV, pp * srth * std::sin(phinve) * MeV, pp * std::cos(rthnve) * MeV);
+            } else {
+              vec[l]->SetMomentum(vec[l]->GetMomentum() * (pp / pp1));
             }
-            vec[i]->SetSide( -3 );
-            ++backwardNucleonCount;
-            continue;
+            G4double px = vec[l]->GetMomentum().x() / MeV;
+            G4double py = vec[l]->GetMomentum().y() / MeV;
+            pt = std::max(1.0, std::sqrt(px * px + py * py)) / GeV;
+            if (vec[l]->GetSide() > 0) {
+              forwardKinetic += vec[l]->GetKineticEnergy() / GeV;
+              pseudoParticle[4] = pseudoParticle[4] + (*vec[l]);
+            } else {
+              backwardKinetic += vec[l]->GetKineticEnergy() / GeV;
+              pseudoParticle[5] = pseudoParticle[5] + (*vec[l]);
+            }
           }
         }
       }
-      //
-      //  set pt and phi values, they are changed somewhat in the iteration loop
-      //  set mass parameter for lambda fragmentation model
-      //
-      vecMass = vec[i]->GetMass()/GeV;
-      G4double ran = -std::log(1.0-G4UniformRand())/3.5;
-      if( vec[i]->GetSide() == -2 )   // backward nucleon
-      {
-        if( vec[i]->GetDefinition() == aKaonMinus ||
-            vec[i]->GetDefinition() == aKaonZeroL ||
-            vec[i]->GetDefinition() == aKaonZeroS ||
-            vec[i]->GetDefinition() == aKaonPlus ||
-            vec[i]->GetDefinition() == aPiMinus ||
-            vec[i]->GetDefinition() == aPiZero ||
-            vec[i]->GetDefinition() == aPiPlus )
-        {
-          aspar = 0.75;
-          pt = std::sqrt( std::pow( ran, 1.7 ) );
-        } else {                          // vec[i] must be a proton, neutron,
-          aspar = 0.20;                   //  lambda, sigma, xsi, or ion
-          pt = std::sqrt( std::pow( ran, 1.2 ) );
+    }  // closes outer loop
+
+    if (eliminateThisParticle && vec[i]->GetMayBeKilled())  // not enough energy, eliminate this particle
+    {
+      if (vec[i]->GetSide() > 0) {
+        --forwardCount;
+        forwardEnergy += vecMass;
+      } else {
+        if (vec[i]->GetSide() == -2) {
+          --extraNucleonCount;
+          extraNucleonMass -= vecMass;
+          backwardEnergy -= vecMass;
         }
-      } else {                          // not a backward nucleon
-        if( vec[i]->GetDefinition() == aPiMinus ||
-            vec[i]->GetDefinition() == aPiZero ||
-            vec[i]->GetDefinition() == aPiPlus )
-        {
-          aspar = 0.75;
-          pt = std::sqrt( std::pow( ran, 1.7 ) );
-        } else if( vec[i]->GetDefinition() == aKaonMinus ||
-                   vec[i]->GetDefinition() == aKaonZeroL ||
-                   vec[i]->GetDefinition() == aKaonZeroS ||
-                   vec[i]->GetDefinition() == aKaonPlus )
-        {
-          aspar = 0.70;
-          pt = std::sqrt( std::pow( ran, 1.7 ) );
-        } else {                        // vec[i] must be a proton, neutron, 
-          aspar = 0.65;                 //  lambda, sigma, xsi, or ion
-          pt = std::sqrt( std::pow( ran, 1.5 ) );
-        }
+        --backwardCount;
+        backwardEnergy += vecMass;
       }
-      pt = std::max( 0.001, pt );
-      vec[i]->SetMomentum( pt*std::cos(phi)*GeV, pt*std::sin(phi)*GeV );
-      for( G4int j=0; j<20; ++j )binl[j] = j/(19.*pt);
-      if( vec[i]->GetSide() > 0 )
-        et = pseudoParticle[0].GetTotalEnergy()/GeV;
-      else
-        et = pseudoParticle[1].GetTotalEnergy()/GeV;
-      dndl[0] = 0.0;
-      //
-      //   start of outer iteration loop
-      //
-      outerCounter = 0;
-      eliminateThisParticle = true;
-      resetEnergies = true;
-      while( ++outerCounter < 3 )
+      for (G4int j = i; j < (vecLen - 1); ++j)
+        *vec[j] = *vec[j + 1];  // shift up
+      G4ReactionProduct *temp = vec[vecLen - 1];
+      delete temp;
+      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+      if (--vecLen == 0)
+        return false;  // all the secondaries have been eliminated
+      pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
+      pseudoParticle[6].SetMomentum(0.0);  // set z-momentum
+    }
+  }  // closes main for loop
+
+  //
+  //  for the incident particle:  it was placed in the forward hemisphere
+  //   set pt and phi values, they are changed somewhat in the iteration loop
+  //   set mass parameter for lambda fragmentation model
+  //
+  G4double phi = G4UniformRand() * twopi;
+  G4double ran = -std::log(1.0 - G4UniformRand());
+  if (currentParticle.GetDefinition() == aPiMinus || currentParticle.GetDefinition() == aPiZero ||
+      currentParticle.GetDefinition() == aPiPlus) {
+    aspar = 0.60;
+    pt = std::sqrt(std::pow(ran / 6.0, 1.7));
+  } else if (currentParticle.GetDefinition() == aKaonMinus || currentParticle.GetDefinition() == aKaonZeroL ||
+             currentParticle.GetDefinition() == aKaonZeroS || currentParticle.GetDefinition() == aKaonPlus) {
+    aspar = 0.50;
+    pt = std::sqrt(std::pow(ran / 5.0, 1.4));
+  } else {
+    aspar = 0.40;
+    pt = std::sqrt(std::pow(ran / 4.0, 1.2));
+  }
+  for (G4int j = 0; j < 20; ++j)
+    binl[j] = j / (19. * pt);
+  currentParticle.SetMomentum(pt * std::cos(phi) * GeV, pt * std::sin(phi) * GeV);
+  et = pseudoParticle[0].GetTotalEnergy() / GeV;
+  dndl[0] = 0.0;
+  vecMass = currentParticle.GetMass() / GeV;
+  for (l = 1; l < 20; ++l) {
+    x = (binl[l] + binl[l - 1]) / 2.;
+    if (x > 1.0 / pt)
+      dndl[l] += dndl[l - 1];  //  changed from just  =   on 02 April 98
+    else
+      dndl[l] = aspar / std::sqrt(std::pow((1. + sqr(aspar * x)), 3)) * (binl[l] - binl[l - 1]) * et /
+                    std::sqrt(pt * x * et * pt * x * et + pt * pt + vecMass * vecMass) +
+                dndl[l - 1];
+  }
+  ran = G4UniformRand() * dndl[19];
+  l = 1;
+  while ((ran > dndl[l]) && (l < 20))
+    l++;
+  l = std::min(19, l);
+  x = std::min(1.0, pt * (binl[l - 1] + G4UniformRand() * (binl[l] - binl[l - 1]) / 2.));
+  currentParticle.SetMomentum(x * et * GeV);  // set the z-momentum
+  if (forwardEnergy < forwardKinetic)
+    totalEnergy = vecMass + 0.04 * std::fabs(normal());
+  else
+    totalEnergy = vecMass + forwardEnergy - forwardKinetic;
+  currentParticle.SetTotalEnergy(totalEnergy * GeV);
+  pp = std::sqrt(std::abs(totalEnergy * totalEnergy - vecMass * vecMass)) * GeV;
+  pp1 = currentParticle.GetMomentum().mag() / MeV;
+  if (pp1 < 1.0e-6 * GeV) {
+    G4double rthnve = pi * G4UniformRand();
+    G4double phinve = twopi * G4UniformRand();
+    G4double srth = std::sin(rthnve);
+    currentParticle.SetMomentum(
+        pp * srth * std::cos(phinve) * MeV, pp * srth * std::sin(phinve) * MeV, pp * std::cos(rthnve) * MeV);
+  } else {
+    currentParticle.SetMomentum(currentParticle.GetMomentum() * (pp / pp1));
+  }
+  pseudoParticle[4] = pseudoParticle[4] + currentParticle;
+  //
+  // this finishes the current particle
+  // now for the target particle
+  //
+  if (backwardNucleonCount < 18) {
+    targetParticle.SetSide(-3);
+    ++backwardNucleonCount;
+  } else {
+    //  set pt and phi values, they are changed somewhat in the iteration loop
+    //  set mass parameter for lambda fragmentation model
+    //
+    vecMass = targetParticle.GetMass() / GeV;
+    ran = -std::log(1.0 - G4UniformRand());
+    aspar = 0.40;
+    pt = std::max(0.001, std::sqrt(std::pow(ran / 4.0, 1.2)));
+    targetParticle.SetMomentum(pt * std::cos(phi) * GeV, pt * std::sin(phi) * GeV);
+    for (G4int j = 0; j < 20; ++j)
+      binl[j] = (j - 1.) / (19. * pt);
+    et = pseudoParticle[1].GetTotalEnergy() / GeV;
+    dndl[0] = 0.0;
+    outerCounter = 0;
+    resetEnergies = true;
+    while (++outerCounter < 3)  // start of outer iteration loop
+    {
+      for (l = 1; l < 20; ++l) {
+        x = (binl[l] + binl[l - 1]) / 2.;
+        if (x > 1.0 / pt)
+          dndl[l] += dndl[l - 1];  // changed from just  =  on 02 April 98
+        else
+          dndl[l] = aspar / std::sqrt(std::pow((1. + aspar * x * aspar * x), 3)) * (binl[l] - binl[l - 1]) * et /
+                        std::sqrt(pt * x * et * pt * x * et + pt * pt + vecMass * vecMass) +
+                    dndl[l - 1];
+      }
+      innerCounter = 0;
+      while (++innerCounter < 7)  // start of inner iteration loop
       {
-        for( l=1; l<20; ++l )
-        {
-          x = (binl[l]+binl[l-1])/2.;
-          pt = std::max( 0.001, pt );
-          if( x > 1.0/pt )
-            dndl[l] += dndl[l-1];   //  changed from just  =  on 02 April 98
-          else
-            dndl[l] = et * aspar/std::sqrt( std::pow((1.+aspar*x*aspar*x),3) )
-              * (binl[l]-binl[l-1]) / std::sqrt( pt*x*et*pt*x*et + pt*pt + vecMass*vecMass )
-              + dndl[l-1];
-        }
-        innerCounter = 0;
-        vec[i]->SetMomentum( pt*std::cos(phi)*GeV, pt*std::sin(phi)*GeV );
-        //
-        //   start of inner iteration loop
-        //
-        while( ++innerCounter < 7 )
-        {
-          ran = G4UniformRand()*dndl[19];
-          l = 1;
-          while( ( ran >= dndl[l] ) && ( l < 20 ) )l++;
-          l = std::min( 19, l );
-          x = std::min( 1.0, pt*(binl[l-1] + G4UniformRand()*(binl[l]-binl[l-1])/2.) );
-          if( vec[i]->GetSide() < 0 )x *= -1.;
-          vec[i]->SetMomentum( x*et*GeV );              // set the z-momentum
-          totalEnergy = std::sqrt( x*et*x*et + pt*pt + vecMass*vecMass );
-          vec[i]->SetTotalEnergy( totalEnergy*GeV );
-          kineticEnergy = vec[i]->GetKineticEnergy()/GeV;
-          if( vec[i]->GetSide() > 0 )                            // forward side
-          {
-            if( (forwardKinetic+kineticEnergy) < 0.95*forwardEnergy )
-            {
-              pseudoParticle[4] = pseudoParticle[4] + (*vec[i]);
-              forwardKinetic += kineticEnergy;
-              pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
-              pseudoParticle[6].SetMomentum( 0.0 );           // set the z-momentum
-              phi = pseudoParticle[6].Angle( pseudoParticle[8] );
-              if( pseudoParticle[6].GetMomentum().y()/MeV < 0.0 )phi = twopi - phi;
-              phi += pi + normal()*pi/12.0;
-              if( phi > twopi )phi -= twopi;
-              if( phi < 0.0 )phi = twopi - phi;
-              outerCounter = 2;                     // leave outer loop
-              eliminateThisParticle = false;        // don't eliminate this particle
-              resetEnergies = false;
-              break;                                // leave inner loop
-            }
-            if( innerCounter > 5 )break;           // leave inner loop
-            if( backwardEnergy >= vecMass )  // switch sides
-            {
-              vec[i]->SetSide( -1 );
-              forwardEnergy += vecMass;
-              backwardEnergy -= vecMass;
-              ++backwardCount;
-            }
-          } else {                                                 // backward side
-           G4double xxx = 0.95+0.05*extraNucleonCount/20.0;
-           if( (backwardKinetic+kineticEnergy) < xxx*backwardEnergy )
-            {
-              pseudoParticle[5] = pseudoParticle[5] + (*vec[i]);
-              backwardKinetic += kineticEnergy;
-              pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
-              pseudoParticle[6].SetMomentum( 0.0 );           // set the z-momentum
-              phi = pseudoParticle[6].Angle( pseudoParticle[8] );
-              if( pseudoParticle[6].GetMomentum().y()/MeV < 0.0 )phi = twopi - phi;
-              phi += pi + normal() * pi / 12.0;
-              if( phi > twopi )phi -= twopi;
-              if( phi < 0.0 )phi = twopi - phi;
-              outerCounter = 2;                    // leave outer loop
-              eliminateThisParticle = false;       // don't eliminate this particle
-              resetEnergies = false;
-              break;                               // leave inner loop
-            }
-            if( innerCounter > 5 )break;           // leave inner loop
-            if( forwardEnergy >= vecMass )  // switch sides
-            {
-              vec[i]->SetSide( 1 );
-              forwardEnergy -= vecMass;
-              backwardEnergy += vecMass;
-              backwardCount--;
-            }
+        l = 1;
+        ran = G4UniformRand() * dndl[19];
+        while ((ran >= dndl[l]) && (l < 20))
+          l++;
+        l = std::min(19, l);
+        x = std::min(1.0, pt * (binl[l - 1] + G4UniformRand() * (binl[l] - binl[l - 1]) / 2.));
+        if (targetParticle.GetSide() < 0)
+          x *= -1.;
+        targetParticle.SetMomentum(x * et * GeV);  // set the z-momentum
+        totalEnergy = std::sqrt(x * et * x * et + pt * pt + vecMass * vecMass);
+        targetParticle.SetTotalEnergy(totalEnergy * GeV);
+        if (targetParticle.GetSide() < 0) {
+          G4double xxx = 0.95 + 0.05 * extraNucleonCount / 20.0;
+          if ((backwardKinetic + totalEnergy - vecMass) < xxx * backwardEnergy) {
+            pseudoParticle[5] = pseudoParticle[5] + targetParticle;
+            backwardKinetic += totalEnergy - vecMass;
+            pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
+            pseudoParticle[6].SetMomentum(0.0);  // set z-momentum
+            outerCounter = 2;                    // leave outer loop
+            resetEnergies = false;
+            break;  // leave inner loop
           }
-          G4ThreeVector momentum = vec[i]->GetMomentum();
-          vec[i]->SetMomentum( momentum.x() * 0.9, momentum.y() * 0.9 );
+          if (innerCounter > 5)
+            break;                       // leave inner loop
+          if (forwardEnergy >= vecMass)  // switch sides
+          {
+            targetParticle.SetSide(1);
+            forwardEnergy -= vecMass;
+            backwardEnergy += vecMass;
+            --backwardCount;
+          }
+          G4ThreeVector momentum = targetParticle.GetMomentum();
+          targetParticle.SetMomentum(momentum.x() * 0.9, momentum.y() * 0.9);
           pt *= 0.9;
           dndl[19] *= 0.9;
-        }                       // closes inner loop
-        if( resetEnergies )
+        } else  // target has gone to forward side
         {
-          //   if we get to here, the inner loop has been Done 6 Times
-          //   reset the kinetic energies of previously Done particles, if they are lighter
-          //    than protons and in the forward hemisphere
-          //   then continue with outer loop
-          //
-          forwardKinetic = 0.0;
-          backwardKinetic = 0.0;
-          pseudoParticle[4].SetZero();
-          pseudoParticle[5].SetZero();
-          for( l=i+1; l<vecLen; ++l )
-          {
-            if( vec[l]->GetSide() > 0 ||
-                vec[l]->GetDefinition() == aKaonMinus ||
-                vec[l]->GetDefinition() == aKaonZeroL ||
-                vec[l]->GetDefinition() == aKaonZeroS ||
-                vec[l]->GetDefinition() == aKaonPlus ||
-                vec[l]->GetDefinition() == aPiMinus ||
-                vec[l]->GetDefinition() == aPiZero ||
-                vec[l]->GetDefinition() == aPiPlus )
-            {
-              G4double tempMass = vec[l]->GetMass()/MeV;
-              totalEnergy = 0.95*vec[l]->GetTotalEnergy()/MeV + 0.05*tempMass;
-              totalEnergy = std::max( tempMass, totalEnergy );
-              vec[l]->SetTotalEnergy( totalEnergy*MeV );
-              pp = std::sqrt( std::abs( totalEnergy*totalEnergy - tempMass*tempMass ) );
-              pp1 = vec[l]->GetMomentum().mag()/MeV;
-              if( pp1 < 1.0e-6*GeV )
-              {
-                G4double rthnve = pi*G4UniformRand();
-                G4double phinve = twopi*G4UniformRand();
-                G4double srth = std::sin(rthnve);
-                vec[l]->SetMomentum( pp*srth*std::cos(phinve)*MeV,
-                                     pp*srth*std::sin(phinve)*MeV,
-                                     pp*std::cos(rthnve)*MeV ) ;
-              } else {
-                vec[l]->SetMomentum( vec[l]->GetMomentum() * (pp/pp1) );
-              }
-              G4double px = vec[l]->GetMomentum().x()/MeV;
-              G4double py = vec[l]->GetMomentum().y()/MeV;
-              pt = std::max( 1.0, std::sqrt( px*px + py*py ) )/GeV;
-              if( vec[l]->GetSide() > 0 )
-              {
-                forwardKinetic += vec[l]->GetKineticEnergy()/GeV;
-                pseudoParticle[4] = pseudoParticle[4] + (*vec[l]);
-              } else {
-                backwardKinetic += vec[l]->GetKineticEnergy()/GeV;
-                pseudoParticle[5] = pseudoParticle[5] + (*vec[l]);
-              }
-            }
-          }
-        }
-      }    // closes outer loop
-              
-      if( eliminateThisParticle && vec[i]->GetMayBeKilled())  // not enough energy, eliminate this particle
-      {
-        if( vec[i]->GetSide() > 0 )
-        {
-          --forwardCount;
-          forwardEnergy += vecMass;
-        } else {
-          if( vec[i]->GetSide() == -2 )
-          {
-            --extraNucleonCount;
-            extraNucleonMass -= vecMass;
-            backwardEnergy -= vecMass;
-          }
-          --backwardCount;
-          backwardEnergy += vecMass;
-        }
-        for( G4int j=i; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];    // shift up
-        G4ReactionProduct *temp = vec[vecLen-1];
-        delete temp;
-        // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-        if( --vecLen == 0 )return false;  // all the secondaries have been eliminated
-        pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
-        pseudoParticle[6].SetMomentum( 0.0 );                 // set z-momentum
-      }
-    }   // closes main for loop
-
-    //
-    //  for the incident particle:  it was placed in the forward hemisphere
-    //   set pt and phi values, they are changed somewhat in the iteration loop
-    //   set mass parameter for lambda fragmentation model
-    //
-    G4double phi = G4UniformRand()*twopi;
-    G4double ran = -std::log(1.0-G4UniformRand());
-    if( currentParticle.GetDefinition() == aPiMinus ||
-        currentParticle.GetDefinition() == aPiZero ||
-        currentParticle.GetDefinition() == aPiPlus )
-    {
-      aspar = 0.60;
-      pt = std::sqrt( std::pow( ran/6.0, 1.7 ) );
-    } else if( currentParticle.GetDefinition() == aKaonMinus ||
-               currentParticle.GetDefinition() == aKaonZeroL ||
-               currentParticle.GetDefinition() == aKaonZeroS ||
-               currentParticle.GetDefinition() == aKaonPlus )
-    {
-      aspar = 0.50;
-      pt = std::sqrt( std::pow( ran/5.0, 1.4 ) );
-    } else {
-      aspar = 0.40;
-      pt = std::sqrt( std::pow( ran/4.0, 1.2 ) );
-    }
-    for( G4int j=0; j<20; ++j )binl[j] = j/(19.*pt);
-    currentParticle.SetMomentum( pt*std::cos(phi)*GeV, pt*std::sin(phi)*GeV );
-    et = pseudoParticle[0].GetTotalEnergy()/GeV;
-    dndl[0] = 0.0;
-    vecMass = currentParticle.GetMass()/GeV;
-    for( l=1; l<20; ++l )
-    {
-      x = (binl[l]+binl[l-1])/2.;
-      if( x > 1.0/pt )
-        dndl[l] += dndl[l-1];   //  changed from just  =   on 02 April 98
-      else
-        dndl[l] = aspar/std::sqrt( std::pow((1.+sqr(aspar*x)),3) ) *
-          (binl[l]-binl[l-1]) * et / std::sqrt( pt*x*et*pt*x*et + pt*pt + vecMass*vecMass ) +
-          dndl[l-1];
-    }
-    ran = G4UniformRand()*dndl[19];
-    l = 1;
-    while( (ran>dndl[l]) && (l<20) )l++;
-    l = std::min( 19, l );
-    x = std::min( 1.0, pt*(binl[l-1] + G4UniformRand()*(binl[l]-binl[l-1])/2.) );   
-    currentParticle.SetMomentum( x*et*GeV );                 // set the z-momentum
-    if( forwardEnergy < forwardKinetic )
-      totalEnergy = vecMass + 0.04*std::fabs(normal());
-    else
-      totalEnergy = vecMass + forwardEnergy - forwardKinetic;
-    currentParticle.SetTotalEnergy( totalEnergy*GeV );
-    pp = std::sqrt( std::abs( totalEnergy*totalEnergy - vecMass*vecMass ) )*GeV;
-    pp1 = currentParticle.GetMomentum().mag()/MeV;
-    if( pp1 < 1.0e-6*GeV )
-    {
-      G4double rthnve = pi*G4UniformRand();
-      G4double phinve = twopi*G4UniformRand();
-      G4double srth = std::sin(rthnve);
-      currentParticle.SetMomentum( pp*srth*std::cos(phinve)*MeV,
-                                   pp*srth*std::sin(phinve)*MeV,
-                                   pp*std::cos(rthnve)*MeV );
-    } else {
-      currentParticle.SetMomentum( currentParticle.GetMomentum() * (pp/pp1) );
-    }
-    pseudoParticle[4] = pseudoParticle[4] + currentParticle;
-    //
-    // this finishes the current particle
-    // now for the target particle
-    //
-    if( backwardNucleonCount < 18 )
-    {
-      targetParticle.SetSide( -3 );
-      ++backwardNucleonCount;
-    }
-    else
-    {
-      //  set pt and phi values, they are changed somewhat in the iteration loop
-      //  set mass parameter for lambda fragmentation model
-      //
-      vecMass = targetParticle.GetMass()/GeV;
-      ran = -std::log(1.0-G4UniformRand());
-      aspar = 0.40;
-      pt = std::max( 0.001, std::sqrt( std::pow( ran/4.0, 1.2 ) ) );
-      targetParticle.SetMomentum( pt*std::cos(phi)*GeV, pt*std::sin(phi)*GeV );
-      for( G4int j=0; j<20; ++j )binl[j] = (j-1.)/(19.*pt);
-      et = pseudoParticle[1].GetTotalEnergy()/GeV;
-      dndl[0] = 0.0;
-      outerCounter = 0;
-      resetEnergies = true;
-      while( ++outerCounter < 3 )     // start of outer iteration loop
-      {
-        for( l=1; l<20; ++l )
-        {
-          x = (binl[l]+binl[l-1])/2.;
-          if( x > 1.0/pt )
-            dndl[l] += dndl[l-1];   // changed from just  =  on 02 April 98
+          if (forwardEnergy < forwardKinetic)
+            totalEnergy = vecMass + 0.04 * std::fabs(normal());
           else
-            dndl[l] = aspar/std::sqrt( std::pow((1.+aspar*x*aspar*x),3) ) *
-              (binl[l]-binl[l-1])*et / std::sqrt( pt*x*et*pt*x*et+pt*pt+vecMass*vecMass ) +
-              dndl[l-1];
+            totalEnergy = vecMass + forwardEnergy - forwardKinetic;
+          targetParticle.SetTotalEnergy(totalEnergy * GeV);
+          pp = std::sqrt(std::abs(totalEnergy * totalEnergy - vecMass * vecMass)) * GeV;
+          pp1 = targetParticle.GetMomentum().mag() / MeV;
+          if (pp1 < 1.0e-6 * GeV) {
+            G4double rthnve = pi * G4UniformRand();
+            G4double phinve = twopi * G4UniformRand();
+            G4double srth = std::sin(rthnve);
+            targetParticle.SetMomentum(
+                pp * srth * std::cos(phinve) * MeV, pp * srth * std::sin(phinve) * MeV, pp * std::cos(rthnve) * MeV);
+          } else
+            targetParticle.SetMomentum(targetParticle.GetMomentum() * (pp / pp1));
+
+          pseudoParticle[4] = pseudoParticle[4] + targetParticle;
+          outerCounter = 2;  // leave outer loop
+          //eliminateThisParticle = false;       // don't eliminate this particle
+          resetEnergies = false;
+          break;  // leave inner loop
         }
-        innerCounter = 0;
-        while( ++innerCounter < 7 )    // start of inner iteration loop
+      }  // closes inner loop
+      if (resetEnergies) {
+        //   if we get to here, the inner loop has been Done 6 Times
+        //   reset the kinetic energies of previously Done particles, if they are lighter
+        //    than protons and in the forward hemisphere
+        //   then continue with outer loop
+
+        forwardKinetic = backwardKinetic = 0.0;
+        pseudoParticle[4].SetZero();
+        pseudoParticle[5].SetZero();
+        for (l = 0; l < vecLen; ++l)  // changed from l=1  on 02 April 98
         {
-          l = 1;
-          ran = G4UniformRand()*dndl[19];
-          while( ( ran >= dndl[l] ) && ( l < 20 ) )l++;
-          l = std::min( 19, l );
-          x = std::min( 1.0, pt*(binl[l-1] + G4UniformRand()*(binl[l]-binl[l-1])/2.) );
-          if( targetParticle.GetSide() < 0 )x *= -1.;
-          targetParticle.SetMomentum( x*et*GeV );                // set the z-momentum
-          totalEnergy = std::sqrt( x*et*x*et + pt*pt + vecMass*vecMass );
-          targetParticle.SetTotalEnergy( totalEnergy*GeV );
-          if( targetParticle.GetSide() < 0 )
-          {
-            G4double xxx = 0.95+0.05*extraNucleonCount/20.0;
-            if( (backwardKinetic+totalEnergy-vecMass) < xxx*backwardEnergy )
-            {
-              pseudoParticle[5] = pseudoParticle[5] + targetParticle;
-              backwardKinetic += totalEnergy - vecMass;
-              pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
-              pseudoParticle[6].SetMomentum( 0.0 );                      // set z-momentum
-              outerCounter = 2;                    // leave outer loop
-              resetEnergies = false;
-              break;                               // leave inner loop
-            }
-            if( innerCounter > 5 )break;           // leave inner loop
-            if( forwardEnergy >= vecMass )  // switch sides
-            {
-              targetParticle.SetSide( 1 );
-              forwardEnergy -= vecMass;
-              backwardEnergy += vecMass;
-              --backwardCount;
-            }
-            G4ThreeVector momentum = targetParticle.GetMomentum();
-            targetParticle.SetMomentum( momentum.x() * 0.9, momentum.y() * 0.9 );
-            pt *= 0.9;
-            dndl[19] *= 0.9;
-          }
-          else                    // target has gone to forward side
-          {
-            if( forwardEnergy < forwardKinetic )
-              totalEnergy = vecMass + 0.04*std::fabs(normal());
-            else
-              totalEnergy = vecMass + forwardEnergy - forwardKinetic;
-            targetParticle.SetTotalEnergy( totalEnergy*GeV );
-            pp = std::sqrt( std::abs( totalEnergy*totalEnergy - vecMass*vecMass ) )*GeV;
-            pp1 = targetParticle.GetMomentum().mag()/MeV;
-            if( pp1 < 1.0e-6*GeV )
-            {
-              G4double rthnve = pi*G4UniformRand();
-              G4double phinve = twopi*G4UniformRand();
+          if (vec[l]->GetSide() > 0 || vec[l]->GetDefinition() == aKaonMinus || vec[l]->GetDefinition() == aKaonZeroL ||
+              vec[l]->GetDefinition() == aKaonZeroS || vec[l]->GetDefinition() == aKaonPlus ||
+              vec[l]->GetDefinition() == aPiMinus || vec[l]->GetDefinition() == aPiZero ||
+              vec[l]->GetDefinition() == aPiPlus) {
+            G4double tempMass = vec[l]->GetMass() / GeV;
+            totalEnergy = std::max(tempMass, 0.95 * vec[l]->GetTotalEnergy() / GeV + 0.05 * tempMass);
+            vec[l]->SetTotalEnergy(totalEnergy * GeV);
+            pp = std::sqrt(std::abs(totalEnergy * totalEnergy - tempMass * tempMass)) * GeV;
+            pp1 = vec[l]->GetMomentum().mag() / MeV;
+            if (pp1 < 1.0e-6 * GeV) {
+              G4double rthnve = pi * G4UniformRand();
+              G4double phinve = twopi * G4UniformRand();
               G4double srth = std::sin(rthnve);
-              targetParticle.SetMomentum( pp*srth*std::cos(phinve)*MeV,
-                                          pp*srth*std::sin(phinve)*MeV,
-                                          pp*std::cos(rthnve)*MeV );
-            }
-            else
-              targetParticle.SetMomentum( targetParticle.GetMomentum() * (pp/pp1) );
+              vec[l]->SetMomentum(
+                  pp * srth * std::cos(phinve) * MeV, pp * srth * std::sin(phinve) * MeV, pp * std::cos(rthnve) * MeV);
+            } else
+              vec[l]->SetMomentum(vec[l]->GetMomentum() * (pp / pp1));
 
-            pseudoParticle[4] = pseudoParticle[4] + targetParticle;
-            outerCounter = 2;                    // leave outer loop
-            //eliminateThisParticle = false;       // don't eliminate this particle
-            resetEnergies = false;
-            break;                               // leave inner loop
-          }
-        }    // closes inner loop
-        if( resetEnergies )
-        {
-          //   if we get to here, the inner loop has been Done 6 Times
-          //   reset the kinetic energies of previously Done particles, if they are lighter
-          //    than protons and in the forward hemisphere
-          //   then continue with outer loop
-          
-          forwardKinetic = backwardKinetic = 0.0;
-          pseudoParticle[4].SetZero();
-          pseudoParticle[5].SetZero();
-          for( l=0; l<vecLen; ++l ) // changed from l=1  on 02 April 98
-          {
-            if( vec[l]->GetSide() > 0 ||
-                vec[l]->GetDefinition() == aKaonMinus ||
-                vec[l]->GetDefinition() == aKaonZeroL ||
-                vec[l]->GetDefinition() == aKaonZeroS ||
-                vec[l]->GetDefinition() == aKaonPlus ||
-                vec[l]->GetDefinition() == aPiMinus ||
-                vec[l]->GetDefinition() == aPiZero ||
-                vec[l]->GetDefinition() == aPiPlus )
-            {
-              G4double tempMass = vec[l]->GetMass()/GeV;
-              totalEnergy =
-                std::max( tempMass, 0.95*vec[l]->GetTotalEnergy()/GeV + 0.05*tempMass );
-              vec[l]->SetTotalEnergy( totalEnergy*GeV );
-              pp = std::sqrt( std::abs( totalEnergy*totalEnergy - tempMass*tempMass ) )*GeV;
-              pp1 = vec[l]->GetMomentum().mag()/MeV;
-              if( pp1 < 1.0e-6*GeV )
-              {
-                G4double rthnve = pi*G4UniformRand();
-                G4double phinve = twopi*G4UniformRand();
-                G4double srth = std::sin(rthnve);
-                vec[l]->SetMomentum( pp*srth*std::cos(phinve)*MeV,
-                                     pp*srth*std::sin(phinve)*MeV,
-                                     pp*std::cos(rthnve)*MeV );
-              }
-              else
-                vec[l]->SetMomentum( vec[l]->GetMomentum() * (pp/pp1) );
-
-              pt = std::max( 0.001*GeV, std::sqrt( sqr(vec[l]->GetMomentum().x()/MeV) +
-                                         sqr(vec[l]->GetMomentum().y()/MeV) ) )/GeV;
-              if( vec[l]->GetSide() > 0)
-              {
-                forwardKinetic += vec[l]->GetKineticEnergy()/GeV;
-                pseudoParticle[4] = pseudoParticle[4] + (*vec[l]);
-              } else {
-                backwardKinetic += vec[l]->GetKineticEnergy()/GeV;
-                pseudoParticle[5] = pseudoParticle[5] + (*vec[l]);
-              }
+            pt = std::max(0.001 * GeV,
+                          std::sqrt(sqr(vec[l]->GetMomentum().x() / MeV) + sqr(vec[l]->GetMomentum().y() / MeV))) /
+                 GeV;
+            if (vec[l]->GetSide() > 0) {
+              forwardKinetic += vec[l]->GetKineticEnergy() / GeV;
+              pseudoParticle[4] = pseudoParticle[4] + (*vec[l]);
+            } else {
+              backwardKinetic += vec[l]->GetKineticEnergy() / GeV;
+              pseudoParticle[5] = pseudoParticle[5] + (*vec[l]);
             }
           }
         }
-      }    // closes outer loop
+      }
+    }  // closes outer loop
+  }
+  //
+  //  this finishes the target particle
+  // backward nucleons produced with a cluster model
+  //
+  pseudoParticle[6].Lorentz(pseudoParticle[3], pseudoParticle[2]);
+  pseudoParticle[6] = pseudoParticle[6] - pseudoParticle[4];
+  pseudoParticle[6] = pseudoParticle[6] - pseudoParticle[5];
+  if (backwardNucleonCount == 1)  // target particle is the only backward nucleon
+  {
+    G4double ekin = std::min(backwardEnergy - backwardKinetic, centerofmassEnergy / 2.0 - protonMass / GeV);
+    if (ekin < 0.04)
+      ekin = 0.04 * std::fabs(normal());
+    vecMass = targetParticle.GetMass() / GeV;
+    totalEnergy = ekin + vecMass;
+    targetParticle.SetTotalEnergy(totalEnergy * GeV);
+    pp = std::sqrt(std::abs(totalEnergy * totalEnergy - vecMass * vecMass)) * GeV;
+    pp1 = pseudoParticle[6].GetMomentum().mag() / MeV;
+    if (pp1 < 1.0e-6 * GeV) {
+      rthnve = pi * G4UniformRand();
+      phinve = twopi * G4UniformRand();
+      G4double srth = std::sin(rthnve);
+      targetParticle.SetMomentum(
+          pp * srth * std::cos(phinve) * MeV, pp * srth * std::sin(phinve) * MeV, pp * std::cos(rthnve) * MeV);
+    } else {
+      targetParticle.SetMomentum(pseudoParticle[6].GetMomentum() * (pp / pp1));
     }
-    //
-    //  this finishes the target particle
-    // backward nucleons produced with a cluster model
-    //
-    pseudoParticle[6].Lorentz( pseudoParticle[3], pseudoParticle[2] );
-    pseudoParticle[6] = pseudoParticle[6] - pseudoParticle[4];
-    pseudoParticle[6] = pseudoParticle[6] - pseudoParticle[5];
-    if( backwardNucleonCount == 1 )  // target particle is the only backward nucleon
-    {
-      G4double ekin =
-        std::min( backwardEnergy-backwardKinetic, centerofmassEnergy/2.0-protonMass/GeV );
-      if( ekin < 0.04 )ekin = 0.04 * std::fabs( normal() );
-      vecMass = targetParticle.GetMass()/GeV;
-      totalEnergy = ekin+vecMass;
-      targetParticle.SetTotalEnergy( totalEnergy*GeV );
-      pp = std::sqrt( std::abs( totalEnergy*totalEnergy - vecMass*vecMass ) )*GeV;
-      pp1 = pseudoParticle[6].GetMomentum().mag()/MeV;
-      if( pp1 < 1.0e-6*GeV )
-      { 
-        rthnve = pi*G4UniformRand();
-        phinve = twopi*G4UniformRand();
-        G4double srth = std::sin(rthnve);
-        targetParticle.SetMomentum( pp*srth*std::cos(phinve)*MeV,
-                                    pp*srth*std::sin(phinve)*MeV,
-                                    pp*std::cos(rthnve)*MeV );
+    pseudoParticle[5] = pseudoParticle[5] + targetParticle;
+  } else  // more than one backward nucleon
+  {
+    const G4double cpar[] = {0.6, 0.6, 0.35, 0.15, 0.10};
+    const G4double gpar[] = {2.6, 2.6, 1.80, 1.30, 1.20};
+    // Replaced the following min function to get correct behaviour on DEC.
+    G4int tempCount = std::max(1, std::min(5, backwardNucleonCount)) - 1;
+    //cout << "backwardNucleonCount " << backwardNucleonCount << G4endl;
+    //cout << "tempCount " << tempCount << G4endl;
+    G4double rmb0 = 0.0;
+    if (targetParticle.GetSide() == -3)
+      rmb0 += targetParticle.GetMass() / GeV;
+    for (i = 0; i < vecLen; ++i) {
+      if (vec[i]->GetSide() == -3)
+        rmb0 += vec[i]->GetMass() / GeV;
+    }
+    rmb = rmb0 + std::pow(-std::log(1.0 - G4UniformRand()), cpar[tempCount]) / gpar[tempCount];
+    totalEnergy = pseudoParticle[6].GetTotalEnergy() / GeV;
+    vecMass = std::min(rmb, totalEnergy);
+    pseudoParticle[6].SetMass(vecMass * GeV);
+    pp = std::sqrt(std::abs(totalEnergy * totalEnergy - vecMass * vecMass)) * GeV;
+    pp1 = pseudoParticle[6].GetMomentum().mag() / MeV;
+    if (pp1 < 1.0e-6 * GeV) {
+      rthnve = pi * G4UniformRand();
+      phinve = twopi * G4UniformRand();
+      G4double srth = std::sin(rthnve);
+      pseudoParticle[6].SetMomentum(
+          -pp * srth * std::cos(phinve) * MeV, -pp * srth * std::sin(phinve) * MeV, -pp * std::cos(rthnve) * MeV);
+    } else
+      pseudoParticle[6].SetMomentum(pseudoParticle[6].GetMomentum() * (-pp / pp1));
+
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> tempV;  // tempV contains the backward nucleons
+    tempV.Initialize(backwardNucleonCount);
+    G4int tempLen = 0;
+    if (targetParticle.GetSide() == -3)
+      tempV.SetElement(tempLen++, &targetParticle);
+    for (i = 0; i < vecLen; ++i) {
+      if (vec[i]->GetSide() == -3)
+        tempV.SetElement(tempLen++, vec[i]);
+    }
+    if (tempLen != backwardNucleonCount) {
+      G4cerr << "tempLen is not the same as backwardNucleonCount" << G4endl;
+      G4cerr << "tempLen = " << tempLen;
+      G4cerr << ", backwardNucleonCount = " << backwardNucleonCount << G4endl;
+      G4cerr << "targetParticle side = " << targetParticle.GetSide() << G4endl;
+      G4cerr << "currentParticle side = " << currentParticle.GetSide() << G4endl;
+      for (i = 0; i < vecLen; ++i)
+        G4cerr << "particle #" << i << " side = " << vec[i]->GetSide() << G4endl;
+      exit(EXIT_FAILURE);
+    }
+    constantCrossSection = true;
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    if (tempLen >= 2) {
+      GenerateNBodyEvent(pseudoParticle[6].GetMass(), constantCrossSection, tempV, tempLen);
+      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+      if (targetParticle.GetSide() == -3) {
+        targetParticle.Lorentz(targetParticle, pseudoParticle[6]);
+        // tempV contains the real stuff
+        pseudoParticle[5] = pseudoParticle[5] + targetParticle;
+      }
+      for (i = 0; i < vecLen; ++i) {
+        if (vec[i]->GetSide() == -3) {
+          vec[i]->Lorentz(*vec[i], pseudoParticle[6]);
+          pseudoParticle[5] = pseudoParticle[5] + (*vec[i]);
+        }
+      }
+      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    }
+  }
+  //
+  //  Lorentz transformation in lab system
+  //
+  if (vecLen == 0)
+    return false;  // all the secondaries have been eliminated
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+
+  G4int numberofFinalStateNucleons = 0;
+  if (currentParticle.GetDefinition() == aProton || currentParticle.GetDefinition() == aNeutron ||
+      currentParticle.GetDefinition() == G4SigmaMinus::SigmaMinus() ||
+      currentParticle.GetDefinition() == G4SigmaPlus::SigmaPlus() ||
+      currentParticle.GetDefinition() == G4SigmaZero::SigmaZero() ||
+      currentParticle.GetDefinition() == G4XiZero::XiZero() ||
+      currentParticle.GetDefinition() == G4XiMinus::XiMinus() ||
+      currentParticle.GetDefinition() == G4OmegaMinus::OmegaMinus() ||
+      currentParticle.GetDefinition() == G4Lambda::Lambda())
+    ++numberofFinalStateNucleons;
+  currentParticle.Lorentz(currentParticle, pseudoParticle[1]);
+
+  if (targetParticle.GetDefinition() == aProton || targetParticle.GetDefinition() == aNeutron ||
+      targetParticle.GetDefinition() == G4Lambda::Lambda() || targetParticle.GetDefinition() == G4XiZero::XiZero() ||
+      targetParticle.GetDefinition() == G4XiMinus::XiMinus() ||
+      targetParticle.GetDefinition() == G4OmegaMinus::OmegaMinus() ||
+      targetParticle.GetDefinition() == G4SigmaZero::SigmaZero() ||
+      targetParticle.GetDefinition() == G4SigmaPlus::SigmaPlus() ||
+      targetParticle.GetDefinition() == G4SigmaMinus::SigmaMinus())
+    ++numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiProton::AntiProton())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiNeutron::AntiNeutron())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiSigmaMinus::AntiSigmaMinus())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiSigmaPlus::AntiSigmaPlus())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiSigmaZero::AntiSigmaZero())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiXiZero::AntiXiZero())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiXiMinus::AntiXiMinus())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiOmegaMinus::AntiOmegaMinus())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiLambda::AntiLambda())
+    --numberofFinalStateNucleons;
+  targetParticle.Lorentz(targetParticle, pseudoParticle[1]);
+
+  for (i = 0; i < vecLen; ++i) {
+    if (vec[i]->GetDefinition() == aProton || vec[i]->GetDefinition() == aNeutron ||
+        vec[i]->GetDefinition() == G4Lambda::Lambda() || vec[i]->GetDefinition() == G4XiZero::XiZero() ||
+        vec[i]->GetDefinition() == G4XiMinus::XiMinus() || vec[i]->GetDefinition() == G4OmegaMinus::OmegaMinus() ||
+        vec[i]->GetDefinition() == G4SigmaPlus::SigmaPlus() || vec[i]->GetDefinition() == G4SigmaZero::SigmaZero() ||
+        vec[i]->GetDefinition() == G4SigmaMinus::SigmaMinus())
+      ++numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiProton::AntiProton())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiNeutron::AntiNeutron())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiSigmaMinus::AntiSigmaMinus())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiSigmaPlus::AntiSigmaPlus())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiSigmaZero::AntiSigmaZero())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiLambda::AntiLambda())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiXiZero::AntiXiZero())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiXiMinus::AntiXiMinus())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiOmegaMinus::AntiOmegaMinus())
+      --numberofFinalStateNucleons;
+    vec[i]->Lorentz(*vec[i], pseudoParticle[1]);
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  if (veryForward)
+    numberofFinalStateNucleons++;
+  numberofFinalStateNucleons = std::max(1, numberofFinalStateNucleons);
+  //
+  // leadFlag will be true
+  //  iff original particle is at least as heavy as K+ and not a proton or neutron AND
+  //   if
+  //    incident particle is at least as heavy as K+ and it is not a proton or neutron
+  //     leadFlag is set to the incident particle
+  //   or
+  //    target particle is at least as heavy as K+ and it is not a proton or neutron
+  //     leadFlag is set to the target particle
+  //
+  G4bool leadingStrangeParticleHasChanged = true;
+  if (leadFlag) {
+    if (currentParticle.GetDefinition() == leadingStrangeParticle.GetDefinition())
+      leadingStrangeParticleHasChanged = false;
+    if (leadingStrangeParticleHasChanged && (targetParticle.GetDefinition() == leadingStrangeParticle.GetDefinition()))
+      leadingStrangeParticleHasChanged = false;
+    if (leadingStrangeParticleHasChanged) {
+      for (i = 0; i < vecLen; i++) {
+        if (vec[i]->GetDefinition() == leadingStrangeParticle.GetDefinition()) {
+          leadingStrangeParticleHasChanged = false;
+          break;
+        }
+      }
+    }
+    if (leadingStrangeParticleHasChanged) {
+      G4bool leadTest =
+          (leadingStrangeParticle.GetDefinition() == aKaonMinus ||
+           leadingStrangeParticle.GetDefinition() == aKaonZeroL ||
+           leadingStrangeParticle.GetDefinition() == aKaonZeroS ||
+           leadingStrangeParticle.GetDefinition() == aKaonPlus || leadingStrangeParticle.GetDefinition() == aPiMinus ||
+           leadingStrangeParticle.GetDefinition() == aPiZero || leadingStrangeParticle.GetDefinition() == aPiPlus);
+      G4bool targetTest = false;
+
+      // following modified by JLC 22-Oct-97
+
+      if ((leadTest && targetTest) || !(leadTest || targetTest))  // both true or both false
+      {
+        targetParticle.SetDefinitionAndUpdateE(leadingStrangeParticle.GetDefinition());
+        targetHasChanged = true;
+        // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
       } else {
-        targetParticle.SetMomentum( pseudoParticle[6].GetMomentum() * (pp/pp1) );
+        currentParticle.SetDefinitionAndUpdateE(leadingStrangeParticle.GetDefinition());
+        incidentHasChanged = false;
+        // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
       }
-      pseudoParticle[5] = pseudoParticle[5] + targetParticle;
     }
-    else  // more than one backward nucleon
-    {
-      const G4double cpar[] = { 0.6, 0.6, 0.35, 0.15, 0.10 };
-      const G4double gpar[] = { 2.6, 2.6, 1.80, 1.30, 1.20 };
-      // Replaced the following min function to get correct behaviour on DEC.
-      G4int tempCount = std::max(1,std::min( 5, backwardNucleonCount )) - 1;
-      //cout << "backwardNucleonCount " << backwardNucleonCount << G4endl;
-      //cout << "tempCount " << tempCount << G4endl;
-      G4double rmb0 = 0.0;
-      if( targetParticle.GetSide() == -3 )
-        rmb0 += targetParticle.GetMass()/GeV;
-      for( i=0; i<vecLen; ++i )
-      {
-        if( vec[i]->GetSide() == -3 )rmb0 += vec[i]->GetMass()/GeV;
+  }  // end of if( leadFlag )
+
+  pseudoParticle[3].SetMomentum(0.0, 0.0, pOriginal * GeV);
+  pseudoParticle[3].SetMass(mOriginal * GeV);
+  pseudoParticle[3].SetTotalEnergy(std::sqrt(pOriginal * pOriginal + mOriginal * mOriginal) * GeV);
+
+  const G4ParticleDefinition *aOrgDef = modifiedOriginal.GetDefinition();
+  G4int diff = 0;
+  if (aOrgDef == G4Proton::Proton() || aOrgDef == G4Neutron::Neutron())
+    diff = 1;
+  if (numberofFinalStateNucleons == 1)
+    diff = 0;
+  pseudoParticle[4].SetMomentum(0.0, 0.0, 0.0);
+  pseudoParticle[4].SetMass(protonMass * (numberofFinalStateNucleons - diff) * MeV);
+  pseudoParticle[4].SetTotalEnergy(protonMass * (numberofFinalStateNucleons - diff) * MeV);
+
+  G4double theoreticalKinetic = pseudoParticle[3].GetTotalEnergy() / MeV + pseudoParticle[4].GetTotalEnergy() / MeV -
+                                currentParticle.GetMass() / MeV - targetParticle.GetMass() / MeV;
+
+  G4double simulatedKinetic = currentParticle.GetKineticEnergy() / MeV + targetParticle.GetKineticEnergy() / MeV;
+
+  pseudoParticle[5] = pseudoParticle[3] + pseudoParticle[4];
+  pseudoParticle[3].Lorentz(pseudoParticle[3], pseudoParticle[5]);
+  pseudoParticle[4].Lorentz(pseudoParticle[4], pseudoParticle[5]);
+
+  pseudoParticle[7].SetZero();
+  pseudoParticle[7] = pseudoParticle[7] + currentParticle;
+  pseudoParticle[7] = pseudoParticle[7] + targetParticle;
+
+  for (i = 0; i < vecLen; ++i) {
+    pseudoParticle[7] = pseudoParticle[7] + *vec[i];
+    simulatedKinetic += vec[i]->GetKineticEnergy() / MeV;
+    theoreticalKinetic -= vec[i]->GetMass() / MeV;
+  }
+  if (vecLen <= 16 && vecLen > 0) {
+    // must create a new set of ReactionProducts here because GenerateNBody will
+    // modify the momenta for the particles, and we don't want to do this
+    //
+    G4ReactionProduct tempR[130];
+    tempR[0] = currentParticle;
+    tempR[1] = targetParticle;
+    for (i = 0; i < vecLen; ++i)
+      tempR[i + 2] = *vec[i];
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> tempV;
+    tempV.Initialize(vecLen + 2);
+    G4int tempLen = 0;
+    for (i = 0; i < vecLen + 2; ++i)
+      tempV.SetElement(tempLen++, &tempR[i]);
+    constantCrossSection = true;
+
+    wgt = GenerateNBodyEvent(pseudoParticle[3].GetTotalEnergy() / MeV + pseudoParticle[4].GetTotalEnergy() / MeV,
+                             constantCrossSection,
+                             tempV,
+                             tempLen);
+    if (wgt > -.5) {
+      theoreticalKinetic = 0.0;
+      for (i = 0; i < tempLen; ++i) {
+        pseudoParticle[6].Lorentz(*tempV[i], pseudoParticle[4]);
+        theoreticalKinetic += pseudoParticle[6].GetKineticEnergy() / MeV;
       }
-      rmb = rmb0 + std::pow(-std::log(1.0-G4UniformRand()),cpar[tempCount]) / gpar[tempCount];
-      totalEnergy = pseudoParticle[6].GetTotalEnergy()/GeV;
-      vecMass = std::min( rmb, totalEnergy );
-      pseudoParticle[6].SetMass( vecMass*GeV );
-      pp = std::sqrt( std::abs( totalEnergy*totalEnergy - vecMass*vecMass ) )*GeV;
-      pp1 = pseudoParticle[6].GetMomentum().mag()/MeV;
-      if( pp1 < 1.0e-6*GeV )
-      {
+    }
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  }
+  //
+  //  Make sure, that the kinetic energies are correct
+  //
+  if (simulatedKinetic != 0.0) {
+    wgt = (theoreticalKinetic) / simulatedKinetic;
+    theoreticalKinetic = currentParticle.GetKineticEnergy() / MeV * wgt;
+    simulatedKinetic = theoreticalKinetic;
+    currentParticle.SetKineticEnergy(theoreticalKinetic * MeV);
+    pp = currentParticle.GetTotalMomentum() / MeV;
+    pp1 = currentParticle.GetMomentum().mag() / MeV;
+    if (pp1 < 1.0e-6 * GeV) {
+      rthnve = pi * G4UniformRand();
+      phinve = twopi * G4UniformRand();
+      currentParticle.SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                                  pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                                  pp * std::cos(rthnve) * MeV);
+    } else {
+      currentParticle.SetMomentum(currentParticle.GetMomentum() * (pp / pp1));
+    }
+    theoreticalKinetic = targetParticle.GetKineticEnergy() / MeV * wgt;
+    targetParticle.SetKineticEnergy(theoreticalKinetic * MeV);
+    simulatedKinetic += theoreticalKinetic;
+    pp = targetParticle.GetTotalMomentum() / MeV;
+    pp1 = targetParticle.GetMomentum().mag() / MeV;
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    if (pp1 < 1.0e-6 * GeV) {
+      rthnve = pi * G4UniformRand();
+      phinve = twopi * G4UniformRand();
+      targetParticle.SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                                 pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                                 pp * std::cos(rthnve) * MeV);
+    } else {
+      targetParticle.SetMomentum(targetParticle.GetMomentum() * (pp / pp1));
+    }
+    for (i = 0; i < vecLen; ++i) {
+      theoreticalKinetic = vec[i]->GetKineticEnergy() / MeV * wgt;
+      simulatedKinetic += theoreticalKinetic;
+      vec[i]->SetKineticEnergy(theoreticalKinetic * MeV);
+      pp = vec[i]->GetTotalMomentum() / MeV;
+      pp1 = vec[i]->GetMomentum().mag() / MeV;
+      if (pp1 < 1.0e-6 * GeV) {
         rthnve = pi * G4UniformRand();
         phinve = twopi * G4UniformRand();
-        G4double srth = std::sin(rthnve);
-        pseudoParticle[6].SetMomentum( -pp*srth*std::cos(phinve)*MeV,
-                                       -pp*srth*std::sin(phinve)*MeV,
-                                       -pp*std::cos(rthnve)*MeV );
-      }
+        vec[i]->SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                            pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                            pp * std::cos(rthnve) * MeV);
+      } else
+        vec[i]->SetMomentum(vec[i]->GetMomentum() * (pp / pp1));
+    }
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  Rotate(numberofFinalStateNucleons,
+         pseudoParticle[3].GetMomentum(),
+         modifiedOriginal,
+         originalIncident,
+         targetNucleus,
+         currentParticle,
+         targetParticle,
+         vec,
+         vecLen);
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  //
+  // add black track particles
+  // the total number of particles produced is restricted to 198
+  // this may have influence on very high energies
+  //
+  if (atomicWeight >= 1.5) {
+    // npnb is number of proton/neutron black track particles
+    // ndta is the number of deuterons, tritons, and alphas produced
+    // epnb is the kinetic energy available for proton/neutron black track particles
+    // edta is the kinetic energy available for deuteron/triton/alpha particles
+    //
+    G4double epnb, edta;
+    G4int npnb = 0;
+    G4int ndta = 0;
+
+    epnb = targetNucleus.GetPNBlackTrackEnergy();   // was enp1 in fortran code
+    edta = targetNucleus.GetDTABlackTrackEnergy();  // was enp3 in fortran code
+    const G4double pnCutOff = 0.001;
+    const G4double dtaCutOff = 0.001;
+    const G4double kineticMinimum = 1.e-6;
+    const G4double kineticFactor = -0.010;
+    G4double sprob = 0.0;  // sprob = probability of self-absorption in heavy molecules
+    const G4double ekIncident = originalIncident->GetKineticEnergy() / GeV;
+    if (ekIncident >= 5.0)
+      sprob = std::min(1.0, 0.6 * std::log(ekIncident - 4.0));
+    if (epnb >= pnCutOff) {
+      npnb = Poisson((1.5 + 1.25 * numberofFinalStateNucleons) * epnb / (epnb + edta));
+      if (numberofFinalStateNucleons + npnb > atomicWeight)
+        npnb = G4int(atomicWeight + 0.00001 - numberofFinalStateNucleons);
+      npnb = std::min(npnb, 127 - vecLen);
+    }
+    if (edta >= dtaCutOff) {
+      ndta = Poisson((1.5 + 1.25 * numberofFinalStateNucleons) * edta / (epnb + edta));
+      ndta = std::min(ndta, 127 - vecLen);
+    }
+    G4double spall = numberofFinalStateNucleons;
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+
+    AddBlackTrackParticles(epnb,
+                           npnb,
+                           edta,
+                           ndta,
+                           sprob,
+                           kineticMinimum,
+                           kineticFactor,
+                           modifiedOriginal,
+                           spall,
+                           targetNucleus,
+                           vec,
+                           vecLen);
+
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  }
+  //
+  //  calculate time delay for nuclear reactions
+  //
+  if ((atomicWeight >= 1.5) && (atomicWeight <= 230.0) && (ekOriginal <= 0.2))
+    currentParticle.SetTOF(1.0 - 500.0 * std::exp(-ekOriginal / 0.04) * std::log(G4UniformRand()));
+  else
+    currentParticle.SetTOF(1.0);
+  return true;
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+}
+
+void FullModelReactionDynamics::SuppressChargedPions(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                                                     G4int &vecLen,
+                                                     const G4ReactionProduct &modifiedOriginal,
+                                                     G4ReactionProduct &currentParticle,
+                                                     G4ReactionProduct &targetParticle,
+                                                     const G4Nucleus &targetNucleus,
+                                                     G4bool &incidentHasChanged,
+                                                     G4bool &targetHasChanged) {
+  // this code was originally in the fortran code TWOCLU
+  //
+  // suppress charged pions, for various reasons
+  //
+  const G4double atomicWeight = targetNucleus.GetN_asInt();
+  const G4double atomicNumber = targetNucleus.GetZ_asInt();
+  const G4double pOriginal = modifiedOriginal.GetTotalMomentum() / GeV;
+
+  // G4ParticleDefinition *aGamma = G4Gamma::Gamma();
+  G4ParticleDefinition *aProton = G4Proton::Proton();
+  G4ParticleDefinition *anAntiProton = G4AntiProton::AntiProton();
+  G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
+  G4ParticleDefinition *anAntiNeutron = G4AntiNeutron::AntiNeutron();
+  G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
+  G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
+
+  const G4bool antiTest =
+      modifiedOriginal.GetDefinition() != anAntiProton && modifiedOriginal.GetDefinition() != anAntiNeutron;
+  if (antiTest &&
+      (
+          // currentParticle.GetDefinition() == aGamma ||
+          currentParticle.GetDefinition() == aPiPlus || currentParticle.GetDefinition() == aPiMinus) &&
+      (G4UniformRand() <= (10.0 - pOriginal) / 6.0) && (G4UniformRand() <= atomicWeight / 300.0)) {
+    if (G4UniformRand() > atomicNumber / atomicWeight)
+      currentParticle.SetDefinitionAndUpdateE(aNeutron);
+    else
+      currentParticle.SetDefinitionAndUpdateE(aProton);
+    incidentHasChanged = true;
+  }
+  for (G4int i = 0; i < vecLen; ++i) {
+    if (antiTest &&
+        (
+            // vec[i]->GetDefinition() == aGamma ||
+            vec[i]->GetDefinition() == aPiPlus || vec[i]->GetDefinition() == aPiMinus) &&
+        (G4UniformRand() <= (10.0 - pOriginal) / 6.0) && (G4UniformRand() <= atomicWeight / 300.0)) {
+      if (G4UniformRand() > atomicNumber / atomicWeight)
+        vec[i]->SetDefinitionAndUpdateE(aNeutron);
       else
-        pseudoParticle[6].SetMomentum( pseudoParticle[6].GetMomentum() * (-pp/pp1) );
-      
-      G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> tempV;  // tempV contains the backward nucleons
-      tempV.Initialize( backwardNucleonCount );
-      G4int tempLen = 0;
-      if( targetParticle.GetSide() == -3 )tempV.SetElement( tempLen++, &targetParticle );
-      for( i=0; i<vecLen; ++i )
-      {
-        if( vec[i]->GetSide() == -3 )tempV.SetElement( tempLen++, vec[i] );
-      }
-      if( tempLen != backwardNucleonCount )
-      {
-        G4cerr << "tempLen is not the same as backwardNucleonCount" << G4endl;
-        G4cerr << "tempLen = " << tempLen;
-        G4cerr << ", backwardNucleonCount = " << backwardNucleonCount << G4endl;
-        G4cerr << "targetParticle side = " << targetParticle.GetSide() << G4endl;
-        G4cerr << "currentParticle side = " << currentParticle.GetSide() << G4endl;
-        for( i=0; i<vecLen; ++i )
-          G4cerr << "particle #" << i << " side = " << vec[i]->GetSide() << G4endl;
-        exit( EXIT_FAILURE );
-      }
-      constantCrossSection = true;
+        vec[i]->SetDefinitionAndUpdateE(aProton);
       // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      if( tempLen >= 2 )
+    }
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+}
+
+G4bool FullModelReactionDynamics::TwoCluster(
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+    G4int &vecLen,
+    G4ReactionProduct &modifiedOriginal,      // Fermi motion & evap. effects included
+    const G4HadProjectile *originalIncident,  // the original incident particle
+    G4ReactionProduct &currentParticle,
+    G4ReactionProduct &targetParticle,
+    const G4Nucleus &targetNucleus,
+    G4bool &incidentHasChanged,
+    G4bool &targetHasChanged,
+    G4bool leadFlag,
+    G4ReactionProduct &leadingStrangeParticle) {
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  // derived from original FORTRAN code TWOCLU by H. Fesefeldt (11-Oct-1987)
+  //
+  //  Generation of X- and PT- values for incident, target, and all secondary particles
+  //
+  //  A simple two cluster model is used.
+  //  This should be sufficient for low energy interactions.
+  //
+
+  // + debugging
+  // raise(SIGSEGV);
+  // - debugging
+
+  G4int i;
+  G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
+  G4ParticleDefinition *aProton = G4Proton::Proton();
+  G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
+  G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
+  G4ParticleDefinition *aPiZero = G4PionZero::PionZero();
+  G4ParticleDefinition *aSigmaMinus = G4SigmaMinus::SigmaMinus();
+  const G4double protonMass = aProton->GetPDGMass() / MeV;
+  const G4double ekOriginal = modifiedOriginal.GetKineticEnergy() / GeV;
+  const G4double etOriginal = modifiedOriginal.GetTotalEnergy() / GeV;
+  const G4double mOriginal = modifiedOriginal.GetMass() / GeV;
+  const G4double pOriginal = modifiedOriginal.GetMomentum().mag() / GeV;
+  G4double targetMass = targetParticle.GetDefinition()->GetPDGMass() / GeV;
+  G4double centerofmassEnergy =
+      std::sqrt(mOriginal * mOriginal + targetMass * targetMass + 2.0 * targetMass * etOriginal);  // GeV
+  G4double currentMass = currentParticle.GetMass() / GeV;
+  targetMass = targetParticle.GetMass() / GeV;
+
+  if (currentMass == 0.0 && targetMass == 0.0) {
+    G4double ek = currentParticle.GetKineticEnergy();
+    G4ThreeVector m = currentParticle.GetMomentum();
+    currentParticle = *vec[0];
+    targetParticle = *vec[1];
+    for (i = 0; i < (vecLen - 2); ++i)
+      *vec[i] = *vec[i + 2];
+    if (vecLen < 2) {
+      for (G4int i = 0; i < vecLen; i++)
+        delete vec[i];
+      vecLen = 0;
+      throw G4HadReentrentException(
+          __FILE__, __LINE__, "FullModelReactionDynamics::TwoCluster: Negative number of particles");
+    }
+    delete vec[vecLen - 1];
+    delete vec[vecLen - 2];
+    vecLen -= 2;
+    incidentHasChanged = true;
+    targetHasChanged = true;
+    currentParticle.SetKineticEnergy(ek);
+    currentParticle.SetMomentum(m);
+  }
+  const G4double atomicWeight = targetNucleus.GetN_asInt();
+  const G4double atomicNumber = targetNucleus.GetZ_asInt();
+  //
+  // particles have been distributed in forward and backward hemispheres
+  // in center of mass system of the hadron nucleon interaction
+  //
+  // incident is always in forward hemisphere
+  G4int forwardCount = 1;  // number of particles in forward hemisphere
+  currentParticle.SetSide(1);
+  G4double forwardMass = currentParticle.GetMass() / GeV;
+  G4double cMass = forwardMass;
+
+  // target is always in backward hemisphere
+  G4int backwardCount = 1;         // number of particles in backward hemisphere
+  G4int backwardNucleonCount = 1;  // number of nucleons in backward hemisphere
+  targetParticle.SetSide(-1);
+  G4double backwardMass = targetParticle.GetMass() / GeV;
+  G4double bMass = backwardMass;
+
+  for (i = 0; i < vecLen; ++i) {
+    if (vec[i]->GetSide() < 0)
+      vec[i]->SetSide(-1);  // added by JLC, 2Jul97
+    // to take care of the case where vec has been preprocessed by GenerateXandPt
+    // and some of them have been set to -2 or -3
+    if (vec[i]->GetSide() == -1) {
+      ++backwardCount;
+      backwardMass += vec[i]->GetMass() / GeV;
+    } else {
+      ++forwardCount;
+      forwardMass += vec[i]->GetMass() / GeV;
+    }
+  }
+  //
+  // nucleons and some pions from intranuclear cascade
+  //
+  G4double term1 = std::log(centerofmassEnergy * centerofmassEnergy);
+  if (term1 < 0)
+    term1 = 0.0001;  // making sure xtarg<0;
+  const G4double afc = 0.312 + 0.2 * std::log(term1);
+  G4double xtarg;
+  if (centerofmassEnergy < 2.0 + G4UniformRand())  // added +2 below, JLC 4Jul97
+    xtarg = afc * (std::pow(atomicWeight, 0.33) - 1.0) * (2 * backwardCount + vecLen + 2) / 2.0;
+  else
+    xtarg = afc * (std::pow(atomicWeight, 0.33) - 1.0) * (2 * backwardCount);
+  if (xtarg <= 0.0)
+    xtarg = 0.01;
+  G4int nuclearExcitationCount = Poisson(xtarg);
+  if (atomicWeight < 1.0001)
+    nuclearExcitationCount = 0;
+  G4int extraNucleonCount = 0;
+  G4double extraMass = 0.0;
+  G4double extraNucleonMass = 0.0;
+  if (nuclearExcitationCount > 0) {
+    G4int momentumBin = std::min(4, G4int(pOriginal / 3.0));
+    const G4double nucsup[] = {1.0, 0.8, 0.6, 0.5, 0.4};
+    //
+    //  NOTE: in TWOCLU, these new particles were given negative codes
+    //        here we use  NewlyAdded = true  instead
+    //
+    for (i = 0; i < nuclearExcitationCount; ++i) {
+      G4ReactionProduct *pVec = new G4ReactionProduct();
+      if (G4UniformRand() < nucsup[momentumBin])  // add proton or neutron
       {
-        GenerateNBodyEvent(
-         pseudoParticle[6].GetMass(), constantCrossSection, tempV, tempLen );
-         // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-        if( targetParticle.GetSide() == -3 )
-        {
-          targetParticle.Lorentz( targetParticle, pseudoParticle[6] );
-          // tempV contains the real stuff
-          pseudoParticle[5] = pseudoParticle[5] + targetParticle;
-        }
-        for( i=0; i<vecLen; ++i )
-        {
-          if( vec[i]->GetSide() == -3 )
-          {
-            vec[i]->Lorentz( *vec[i], pseudoParticle[6] );
-            pseudoParticle[5] = pseudoParticle[5] + (*vec[i]);
-          }
-        }
+        if (G4UniformRand() > 1.0 - atomicNumber / atomicWeight)
+          // HPW: looks like a gheisha bug
+          pVec->SetDefinition(aProton);
+        else
+          pVec->SetDefinition(aNeutron);
+        ++backwardNucleonCount;
+        ++extraNucleonCount;
+        extraNucleonMass += pVec->GetMass() / GeV;
+      } else {  // add a pion
+        G4double ran = G4UniformRand();
+        if (ran < 0.3181)
+          pVec->SetDefinition(aPiPlus);
+        else if (ran < 0.6819)
+          pVec->SetDefinition(aPiZero);
+        else
+          pVec->SetDefinition(aPiMinus);
+      }
+      pVec->SetSide(-2);  // backside particle
+      extraMass += pVec->GetMass() / GeV;
+      pVec->SetNewlyAdded(true);
+      vec.SetElement(vecLen++, pVec);
       // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    }
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  G4double forwardEnergy = (centerofmassEnergy - cMass - bMass) / 2.0 + cMass - forwardMass;
+  G4double backwardEnergy = (centerofmassEnergy - cMass - bMass) / 2.0 + bMass - backwardMass;
+  G4double eAvailable = centerofmassEnergy - (forwardMass + backwardMass);
+  G4bool secondaryDeleted;
+  G4double pMass;
+  while (eAvailable <= 0.0)  // must eliminate a particle
+  {
+    secondaryDeleted = false;
+    for (i = (vecLen - 1); i >= 0; --i) {
+      if (vec[i]->GetSide() == 1 && vec[i]->GetMayBeKilled()) {
+        pMass = vec[i]->GetMass() / GeV;
+        for (G4int j = i; j < (vecLen - 1); ++j)
+          *vec[j] = *vec[j + 1];  // shift up
+        --forwardCount;
+        forwardEnergy += pMass;
+        forwardMass -= pMass;
+        secondaryDeleted = true;
+        break;
+      } else if (vec[i]->GetSide() == -1 && vec[i]->GetMayBeKilled()) {
+        pMass = vec[i]->GetMass() / GeV;
+        for (G4int j = i; j < (vecLen - 1); ++j)
+          *vec[j] = *vec[j + 1];  // shift up
+        --backwardCount;
+        backwardEnergy += pMass;
+        backwardMass -= pMass;
+        secondaryDeleted = true;
+        break;
+      }
+    }  // breaks go down to here
+    if (secondaryDeleted) {
+      G4ReactionProduct *temp = vec[vecLen - 1];
+      delete temp;
+      --vecLen;
+      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    } else {
+      if (vecLen == 0) {
+        return false;  // all secondaries have been eliminated
+      }
+      if (targetParticle.GetSide() == -1) {
+        pMass = targetParticle.GetMass() / GeV;
+        targetParticle = *vec[0];
+        for (G4int j = 0; j < (vecLen - 1); ++j)
+          *vec[j] = *vec[j + 1];  // shift up
+        --backwardCount;
+        backwardEnergy += pMass;
+        backwardMass -= pMass;
+        secondaryDeleted = true;
+      } else if (targetParticle.GetSide() == 1) {
+        pMass = targetParticle.GetMass() / GeV;
+        targetParticle = *vec[0];
+        for (G4int j = 0; j < (vecLen - 1); ++j)
+          *vec[j] = *vec[j + 1];  // shift up
+        --forwardCount;
+        forwardEnergy += pMass;
+        forwardMass -= pMass;
+        secondaryDeleted = true;
+      }
+      if (secondaryDeleted) {
+        G4ReactionProduct *temp = vec[vecLen - 1];
+        delete temp;
+        --vecLen;
+        // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+      } else {
+        if (currentParticle.GetSide() == -1) {
+          pMass = currentParticle.GetMass() / GeV;
+          currentParticle = *vec[0];
+          for (G4int j = 0; j < (vecLen - 1); ++j)
+            *vec[j] = *vec[j + 1];  // shift up
+          --backwardCount;
+          backwardEnergy += pMass;
+          backwardMass -= pMass;
+          secondaryDeleted = true;
+        } else if (currentParticle.GetSide() == 1) {
+          pMass = currentParticle.GetMass() / GeV;
+          currentParticle = *vec[0];
+          for (G4int j = 0; j < (vecLen - 1); ++j)
+            *vec[j] = *vec[j + 1];  // shift up
+          --forwardCount;           //This line can cause infinite loop
+          forwardEnergy += pMass;
+          forwardMass -= pMass;
+          secondaryDeleted = true;
+        }
+        if (secondaryDeleted) {
+          G4ReactionProduct *temp = vec[vecLen - 1];
+          delete temp;
+          --vecLen;
+          // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+        } else
+          break;
       }
     }
-    //
-    //  Lorentz transformation in lab system
-    //
-    if( vecLen == 0 )return false;  // all the secondaries have been eliminated
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    
-    G4int numberofFinalStateNucleons = 0;
-    if( currentParticle.GetDefinition() ==aProton ||
-        currentParticle.GetDefinition() == aNeutron ||
-	currentParticle.GetDefinition() == G4SigmaMinus::SigmaMinus()||
-	currentParticle.GetDefinition() == G4SigmaPlus::SigmaPlus()||
-	currentParticle.GetDefinition() == G4SigmaZero::SigmaZero()||
-	currentParticle.GetDefinition() == G4XiZero::XiZero()||
-	currentParticle.GetDefinition() == G4XiMinus::XiMinus()||
-	currentParticle.GetDefinition() == G4OmegaMinus::OmegaMinus()||
-	currentParticle.GetDefinition() == G4Lambda::Lambda()) ++numberofFinalStateNucleons;
-    currentParticle.Lorentz( currentParticle, pseudoParticle[1] );
-    
-    if( targetParticle.GetDefinition() ==aProton ||
-        targetParticle.GetDefinition() == aNeutron ||
-        targetParticle.GetDefinition() == G4Lambda::Lambda() ||
-	targetParticle.GetDefinition() == G4XiZero::XiZero()||
-	targetParticle.GetDefinition() == G4XiMinus::XiMinus()||
-	targetParticle.GetDefinition() == G4OmegaMinus::OmegaMinus()||
-	targetParticle.GetDefinition() == G4SigmaZero::SigmaZero()||
-	targetParticle.GetDefinition() == G4SigmaPlus::SigmaPlus()||
-	targetParticle.GetDefinition() == G4SigmaMinus::SigmaMinus()) ++numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiProton::AntiProton()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiNeutron::AntiNeutron()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiSigmaMinus::AntiSigmaMinus()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiSigmaPlus::AntiSigmaPlus()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiSigmaZero::AntiSigmaZero()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiXiZero::AntiXiZero()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiXiMinus::AntiXiMinus()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiOmegaMinus::AntiOmegaMinus()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiLambda::AntiLambda()) --numberofFinalStateNucleons;
-    targetParticle.Lorentz( targetParticle, pseudoParticle[1] );
-    
-    for( i=0; i<vecLen; ++i )
-    {
-      if( vec[i]->GetDefinition() ==aProton ||
-          vec[i]->GetDefinition() == aNeutron ||
-          vec[i]->GetDefinition() == G4Lambda::Lambda() ||
-          vec[i]->GetDefinition() == G4XiZero::XiZero() ||
-          vec[i]->GetDefinition() == G4XiMinus::XiMinus() ||
-          vec[i]->GetDefinition() == G4OmegaMinus::OmegaMinus() ||
-	  vec[i]->GetDefinition() == G4SigmaPlus::SigmaPlus()||
-	  vec[i]->GetDefinition() == G4SigmaZero::SigmaZero()||
-	  vec[i]->GetDefinition() == G4SigmaMinus::SigmaMinus()) ++numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiProton::AntiProton()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiNeutron::AntiNeutron()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiSigmaMinus::AntiSigmaMinus()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiSigmaPlus::AntiSigmaPlus()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiSigmaZero::AntiSigmaZero()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiLambda::AntiLambda()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiXiZero::AntiXiZero()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiXiMinus::AntiXiMinus()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiOmegaMinus::AntiOmegaMinus()) --numberofFinalStateNucleons;
-     vec[i]->Lorentz( *vec[i], pseudoParticle[1] );
+    eAvailable = centerofmassEnergy - (forwardMass + backwardMass);
+  }
+  //
+  // This is the start of the TwoCluster function
+  //  Choose masses for the 3 clusters:
+  //   forward cluster
+  //   backward meson cluster
+  //   backward nucleon cluster
+  //
+  G4double rmc = 0.0, rmd = 0.0;  // rme = 0.0;
+  const G4double cpar[] = {0.6, 0.6, 0.35, 0.15, 0.10};
+  const G4double gpar[] = {2.6, 2.6, 1.8, 1.30, 1.20};
+
+  if (forwardCount == 0)
+    return false;
+
+  if (forwardCount == 1)
+    rmc = forwardMass;
+  else {
+    G4int ntc = std::max(1, std::min(5, forwardCount)) - 1;  // check if offset by 1 @@
+    rmc = forwardMass + std::pow(-std::log(1.0 - G4UniformRand()), cpar[ntc]) / gpar[ntc];
+  }
+  if (backwardCount == 1)
+    rmd = backwardMass;
+  else {
+    G4int ntc = std::max(1, std::min(5, backwardCount)) - 1;  // check, if offfset by 1 @@
+    rmd = backwardMass + std::pow(-std::log(1.0 - G4UniformRand()), cpar[ntc]) / gpar[ntc];
+  }
+  while (rmc + rmd > centerofmassEnergy) {
+    if ((rmc <= forwardMass) && (rmd <= backwardMass)) {
+      G4double temp = 0.999 * centerofmassEnergy / (rmc + rmd);
+      rmc *= temp;
+      rmd *= temp;
+    } else {
+      rmc = 0.1 * forwardMass + 0.9 * rmc;
+      rmd = 0.1 * backwardMass + 0.9 * rmd;
     }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    if(veryForward) numberofFinalStateNucleons++;
-    numberofFinalStateNucleons = std::max( 1, numberofFinalStateNucleons );
-    //
+  }
+  //
+  //  Set beam, target of first interaction in centre of mass system
+  //
+  G4ReactionProduct pseudoParticle[8];
+  for (i = 0; i < 8; ++i)
+    pseudoParticle[i].SetZero();
+
+  pseudoParticle[1].SetMass(mOriginal * GeV);
+  pseudoParticle[1].SetTotalEnergy(etOriginal * GeV);
+  pseudoParticle[1].SetMomentum(0.0, 0.0, pOriginal * GeV);
+
+  pseudoParticle[2].SetMass(protonMass * MeV);
+  pseudoParticle[2].SetTotalEnergy(protonMass * MeV);
+  pseudoParticle[2].SetMomentum(0.0, 0.0, 0.0);
+  //
+  //  transform into centre of mass system
+  //
+  pseudoParticle[0] = pseudoParticle[1] + pseudoParticle[2];
+  pseudoParticle[1].Lorentz(pseudoParticle[1], pseudoParticle[0]);
+  pseudoParticle[2].Lorentz(pseudoParticle[2], pseudoParticle[0]);
+
+  const G4double pfMin = 0.0001;
+  G4double pf = (centerofmassEnergy * centerofmassEnergy + rmd * rmd - rmc * rmc);
+  pf *= pf;
+  pf -= 4 * centerofmassEnergy * centerofmassEnergy * rmd * rmd;
+  pf = std::sqrt(std::max(pf, pfMin)) / (2.0 * centerofmassEnergy);
+  //
+  //  set final state masses and energies in centre of mass system
+  //
+  pseudoParticle[3].SetMass(rmc * GeV);
+  pseudoParticle[3].SetTotalEnergy(std::sqrt(pf * pf + rmc * rmc) * GeV);
+
+  pseudoParticle[4].SetMass(rmd * GeV);
+  pseudoParticle[4].SetTotalEnergy(std::sqrt(pf * pf + rmd * rmd) * GeV);
+  //
+  // set |T| and |TMIN|
+  //
+  const G4double bMin = 0.01;
+  const G4double b1 = 4.0;
+  const G4double b2 = 1.6;
+  G4double t = std::log(1.0 - G4UniformRand()) / std::max(bMin, b1 + b2 * std::log(pOriginal));
+  G4double t1 = pseudoParticle[1].GetTotalEnergy() / GeV - pseudoParticle[3].GetTotalEnergy() / GeV;
+  G4double pin = pseudoParticle[1].GetMomentum().mag() / GeV;
+  G4double tacmin = t1 * t1 - (pin - pf) * (pin - pf);
+  //
+  // calculate (std::sin(teta/2.)^2 and std::cos(teta), set azimuth angle phi
+  //
+  const G4double smallValue = 1.0e-10;
+  G4double dumnve = 4.0 * pin * pf;
+  if (dumnve == 0.0)
+    dumnve = smallValue;
+  G4double ctet = std::max(-1.0, std::min(1.0, 1.0 + 2.0 * (t - tacmin) / dumnve));
+  dumnve = std::max(0.0, 1.0 - ctet * ctet);
+  G4double stet = std::sqrt(dumnve);
+  G4double phi = G4UniformRand() * twopi;
+  //
+  // calculate final state momenta in centre of mass system
+  //
+  pseudoParticle[3].SetMomentum(pf * stet * std::sin(phi) * GeV, pf * stet * std::cos(phi) * GeV, pf * ctet * GeV);
+  pseudoParticle[4].SetMomentum(pseudoParticle[3].GetMomentum() * (-1.0));
+  //
+  // simulate backward nucleon cluster in lab. system and transform in cms
+  //
+  G4double pp, pp1, rthnve, phinve;
+  if (nuclearExcitationCount > 0) {
+    const G4double ga = 1.2;
+    G4double ekit1 = 0.04;
+    G4double ekit2 = 0.6;
+    if (ekOriginal <= 5.0) {
+      ekit1 *= ekOriginal * ekOriginal / 25.0;
+      ekit2 *= ekOriginal * ekOriginal / 25.0;
+    }
+    const G4double a = (1.0 - ga) / (std::pow(ekit2, (1.0 - ga)) - std::pow(ekit1, (1.0 - ga)));
+    for (i = 0; i < vecLen; ++i) {
+      if (vec[i]->GetSide() == -2) {
+        G4double kineticE =
+            std::pow((G4UniformRand() * (1.0 - ga) / a + std::pow(ekit1, (1.0 - ga))), (1.0 / (1.0 - ga)));
+        vec[i]->SetKineticEnergy(kineticE * GeV);
+        G4double vMass = vec[i]->GetMass() / MeV;
+        G4double totalE = kineticE + vMass;
+        pp = std::sqrt(std::abs(totalE * totalE - vMass * vMass));
+        G4double cost = std::min(1.0, std::max(-1.0, std::log(2.23 * G4UniformRand() + 0.383) / 0.96));
+        G4double sint = std::sqrt(std::max(0.0, (1.0 - cost * cost)));
+        phi = twopi * G4UniformRand();
+        vec[i]->SetMomentum(pp * sint * std::sin(phi) * MeV, pp * sint * std::cos(phi) * MeV, pp * cost * MeV);
+        vec[i]->Lorentz(*vec[i], pseudoParticle[0]);
+      }
+    }
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  }
+  //
+  // fragmentation of forward cluster and backward meson cluster
+  //
+  currentParticle.SetMomentum(pseudoParticle[3].GetMomentum());
+  currentParticle.SetTotalEnergy(pseudoParticle[3].GetTotalEnergy());
+
+  targetParticle.SetMomentum(pseudoParticle[4].GetMomentum());
+  targetParticle.SetTotalEnergy(pseudoParticle[4].GetTotalEnergy());
+
+  pseudoParticle[5].SetMomentum(pseudoParticle[3].GetMomentum() * (-1.0));
+  pseudoParticle[5].SetMass(pseudoParticle[3].GetMass());
+  pseudoParticle[5].SetTotalEnergy(pseudoParticle[3].GetTotalEnergy());
+
+  pseudoParticle[6].SetMomentum(pseudoParticle[4].GetMomentum() * (-1.0));
+  pseudoParticle[6].SetMass(pseudoParticle[4].GetMass());
+  pseudoParticle[6].SetTotalEnergy(pseudoParticle[4].GetTotalEnergy());
+
+  G4double wgt;
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  if (forwardCount > 1)  // tempV will contain the forward particles
+  {
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> tempV;
+    tempV.Initialize(forwardCount);
+    G4bool constantCrossSection = true;
+    G4int tempLen = 0;
+    if (currentParticle.GetSide() == 1)
+      tempV.SetElement(tempLen++, &currentParticle);
+    if (targetParticle.GetSide() == 1)
+      tempV.SetElement(tempLen++, &targetParticle);
+    for (i = 0; i < vecLen; ++i) {
+      if (vec[i]->GetSide() == 1) {
+        if (tempLen < 18)
+          tempV.SetElement(tempLen++, vec[i]);
+        else {
+          vec[i]->SetSide(-1);
+          continue;
+        }
+      }
+    }
+    if (tempLen >= 2) {
+      GenerateNBodyEvent(pseudoParticle[3].GetMass() / MeV, constantCrossSection, tempV, tempLen);
+      if (currentParticle.GetSide() == 1)
+        currentParticle.Lorentz(currentParticle, pseudoParticle[5]);
+      if (targetParticle.GetSide() == 1)
+        targetParticle.Lorentz(targetParticle, pseudoParticle[5]);
+      for (i = 0; i < vecLen; ++i) {
+        if (vec[i]->GetSide() == 1)
+          vec[i]->Lorentz(*vec[i], pseudoParticle[5]);
+      }
+    }
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  if (backwardCount > 1)  //  tempV will contain the backward particles,
+  {                       //  but not those created from the intranuclear cascade
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> tempV;
+    tempV.Initialize(backwardCount);
+    G4bool constantCrossSection = true;
+    G4int tempLen = 0;
+    if (currentParticle.GetSide() == -1)
+      tempV.SetElement(tempLen++, &currentParticle);
+    if (targetParticle.GetSide() == -1)
+      tempV.SetElement(tempLen++, &targetParticle);
+    for (i = 0; i < vecLen; ++i) {
+      if (vec[i]->GetSide() == -1) {
+        if (tempLen < 18)
+          tempV.SetElement(tempLen++, vec[i]);
+        else {
+          vec[i]->SetSide(-2);
+          vec[i]->SetKineticEnergy(0.0);
+          vec[i]->SetMomentum(0.0, 0.0, 0.0);
+          continue;
+        }
+      }
+    }
+    if (tempLen >= 2) {
+      GenerateNBodyEvent(pseudoParticle[4].GetMass() / MeV, constantCrossSection, tempV, tempLen);
+      if (currentParticle.GetSide() == -1)
+        currentParticle.Lorentz(currentParticle, pseudoParticle[6]);
+      if (targetParticle.GetSide() == -1)
+        targetParticle.Lorentz(targetParticle, pseudoParticle[6]);
+      for (i = 0; i < vecLen; ++i) {
+        if (vec[i]->GetSide() == -1)
+          vec[i]->Lorentz(*vec[i], pseudoParticle[6]);
+      }
+    }
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  //
+  // Lorentz transformation in lab system
+  //
+  G4int numberofFinalStateNucleons = 0;
+  if (currentParticle.GetDefinition() == aProton || currentParticle.GetDefinition() == aNeutron ||
+      currentParticle.GetDefinition() == aSigmaMinus || currentParticle.GetDefinition() == G4SigmaPlus::SigmaPlus() ||
+      currentParticle.GetDefinition() == G4SigmaZero::SigmaZero() ||
+      currentParticle.GetDefinition() == G4XiZero::XiZero() ||
+      currentParticle.GetDefinition() == G4XiMinus::XiMinus() ||
+      currentParticle.GetDefinition() == G4OmegaMinus::OmegaMinus() ||
+      currentParticle.GetDefinition() == G4Lambda::Lambda())
+    ++numberofFinalStateNucleons;
+  currentParticle.Lorentz(currentParticle, pseudoParticle[2]);
+  if (targetParticle.GetDefinition() == aProton || targetParticle.GetDefinition() == aNeutron ||
+      targetParticle.GetDefinition() == G4Lambda::Lambda() || targetParticle.GetDefinition() == G4XiZero::XiZero() ||
+      targetParticle.GetDefinition() == G4XiMinus::XiMinus() ||
+      targetParticle.GetDefinition() == G4OmegaMinus::OmegaMinus() ||
+      targetParticle.GetDefinition() == G4SigmaZero::SigmaZero() ||
+      targetParticle.GetDefinition() == G4SigmaPlus::SigmaPlus() || targetParticle.GetDefinition() == aSigmaMinus)
+    ++numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiProton::AntiProton())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiNeutron::AntiNeutron())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiSigmaMinus::AntiSigmaMinus())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiSigmaPlus::AntiSigmaPlus())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiSigmaZero::AntiSigmaZero())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiXiZero::AntiXiZero())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiXiMinus::AntiXiMinus())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiOmegaMinus::AntiOmegaMinus())
+    --numberofFinalStateNucleons;
+  if (targetParticle.GetDefinition() == G4AntiLambda::AntiLambda())
+    --numberofFinalStateNucleons;
+  targetParticle.Lorentz(targetParticle, pseudoParticle[2]);
+  for (i = 0; i < vecLen; ++i) {
+    if (vec[i]->GetDefinition() == aProton || vec[i]->GetDefinition() == aNeutron ||
+        vec[i]->GetDefinition() == G4Lambda::Lambda() || vec[i]->GetDefinition() == G4XiZero::XiZero() ||
+        vec[i]->GetDefinition() == G4XiMinus::XiMinus() || vec[i]->GetDefinition() == G4OmegaMinus::OmegaMinus() ||
+        vec[i]->GetDefinition() == G4SigmaPlus::SigmaPlus() || vec[i]->GetDefinition() == G4SigmaZero::SigmaZero() ||
+        vec[i]->GetDefinition() == aSigmaMinus)
+      ++numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiProton::AntiProton())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiNeutron::AntiNeutron())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiSigmaMinus::AntiSigmaMinus())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiSigmaPlus::AntiSigmaPlus())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiSigmaZero::AntiSigmaZero())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiLambda::AntiLambda())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiXiZero::AntiXiZero())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiXiMinus::AntiXiMinus())
+      --numberofFinalStateNucleons;
+    if (vec[i]->GetDefinition() == G4AntiOmegaMinus::AntiOmegaMinus())
+      --numberofFinalStateNucleons;
+    vec[i]->Lorentz(*vec[i], pseudoParticle[2]);
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  numberofFinalStateNucleons = std::max(1, numberofFinalStateNucleons);
+  //
+  // sometimes the leading strange particle is lost, set it back
+  //
+  G4bool dum = true;
+  if (leadFlag) {
     // leadFlag will be true
     //  iff original particle is at least as heavy as K+ and not a proton or neutron AND
     //   if
@@ -1054,1194 +1826,319 @@ using namespace CLHEP;
     //    target particle is at least as heavy as K+ and it is not a proton or neutron
     //     leadFlag is set to the target particle
     //
-    G4bool leadingStrangeParticleHasChanged = true;
-    if( leadFlag )
-    {
-      if( currentParticle.GetDefinition() == leadingStrangeParticle.GetDefinition() )
-        leadingStrangeParticleHasChanged = false;
-      if( leadingStrangeParticleHasChanged &&
-          ( targetParticle.GetDefinition() == leadingStrangeParticle.GetDefinition() ) )
-        leadingStrangeParticleHasChanged = false;
-      if( leadingStrangeParticleHasChanged )
-      {
-        for( i=0; i<vecLen; i++ )
-        {
-          if( vec[i]->GetDefinition() == leadingStrangeParticle.GetDefinition() )
-          {
-            leadingStrangeParticleHasChanged = false;
-            break;
-          }
-        }
-      }
-      if( leadingStrangeParticleHasChanged )
-      {
-        G4bool leadTest = 
-          (leadingStrangeParticle.GetDefinition() == aKaonMinus ||
-           leadingStrangeParticle.GetDefinition() == aKaonZeroL ||
-           leadingStrangeParticle.GetDefinition() == aKaonZeroS ||
-           leadingStrangeParticle.GetDefinition() == aKaonPlus ||
-           leadingStrangeParticle.GetDefinition() == aPiMinus ||
-           leadingStrangeParticle.GetDefinition() == aPiZero ||
-           leadingStrangeParticle.GetDefinition() == aPiPlus);
-        G4bool targetTest = false;
-
-        // following modified by JLC 22-Oct-97
-          
-        if( (leadTest&&targetTest) || !(leadTest||targetTest) ) // both true or both false
-        {
-          targetParticle.SetDefinitionAndUpdateE( leadingStrangeParticle.GetDefinition() );
-          targetHasChanged = true;
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-        }
-        else
-        {
-          currentParticle.SetDefinitionAndUpdateE( leadingStrangeParticle.GetDefinition() );
-          incidentHasChanged = false;
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-        }
-      }
-    }   // end of if( leadFlag )
-    
-    pseudoParticle[3].SetMomentum( 0.0, 0.0, pOriginal*GeV );
-    pseudoParticle[3].SetMass( mOriginal*GeV );
-    pseudoParticle[3].SetTotalEnergy(
-     std::sqrt( pOriginal*pOriginal + mOriginal*mOriginal )*GeV );
-    
-    const G4ParticleDefinition * aOrgDef = modifiedOriginal.GetDefinition();
-    G4int diff = 0;
-    if(aOrgDef == G4Proton::Proton() || aOrgDef == G4Neutron::Neutron() )  diff = 1;
-    if(numberofFinalStateNucleons == 1) diff = 0;
-    pseudoParticle[4].SetMomentum( 0.0, 0.0, 0.0 );
-    pseudoParticle[4].SetMass( protonMass*(numberofFinalStateNucleons-diff)*MeV );
-    pseudoParticle[4].SetTotalEnergy( protonMass*(numberofFinalStateNucleons-diff)*MeV );
-    
-    G4double theoreticalKinetic =
-      pseudoParticle[3].GetTotalEnergy()/MeV +
-      pseudoParticle[4].GetTotalEnergy()/MeV -
-      currentParticle.GetMass()/MeV -
-      targetParticle.GetMass()/MeV;
-    
-    G4double simulatedKinetic =
-      currentParticle.GetKineticEnergy()/MeV + targetParticle.GetKineticEnergy()/MeV;
-    
-    pseudoParticle[5] = pseudoParticle[3] + pseudoParticle[4];
-    pseudoParticle[3].Lorentz( pseudoParticle[3], pseudoParticle[5] );
-    pseudoParticle[4].Lorentz( pseudoParticle[4], pseudoParticle[5] );
-    
-    pseudoParticle[7].SetZero();
-    pseudoParticle[7] = pseudoParticle[7] + currentParticle;
-    pseudoParticle[7] = pseudoParticle[7] + targetParticle;
-
-    for( i=0; i<vecLen; ++i )
-    {
-      pseudoParticle[7] = pseudoParticle[7] + *vec[i];
-      simulatedKinetic += vec[i]->GetKineticEnergy()/MeV;
-      theoreticalKinetic -= vec[i]->GetMass()/MeV;
-    }
-    if( vecLen <= 16 && vecLen > 0 )
-    {
-      // must create a new set of ReactionProducts here because GenerateNBody will
-      // modify the momenta for the particles, and we don't want to do this
-      //
-      G4ReactionProduct tempR[130];
-      tempR[0] = currentParticle;
-      tempR[1] = targetParticle;
-      for( i=0; i<vecLen; ++i )tempR[i+2] = *vec[i];
-      G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> tempV;
-      tempV.Initialize( vecLen+2 );
-      G4int tempLen = 0;
-      for( i=0; i<vecLen+2; ++i )tempV.SetElement( tempLen++, &tempR[i] );
-      constantCrossSection = true;
-
-      wgt = GenerateNBodyEvent( pseudoParticle[3].GetTotalEnergy()/MeV+
-                                pseudoParticle[4].GetTotalEnergy()/MeV,
-       constantCrossSection, tempV, tempLen );
-      if(wgt>-.5)
-      {
-        theoreticalKinetic = 0.0;
-        for( i=0; i<tempLen; ++i )
-        {
-          pseudoParticle[6].Lorentz( *tempV[i], pseudoParticle[4] );
-          theoreticalKinetic += pseudoParticle[6].GetKineticEnergy()/MeV;
-        }
-      }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    }
-    //
-    //  Make sure, that the kinetic energies are correct
-    //
-    if( simulatedKinetic != 0.0 )
-    {
-      wgt = (theoreticalKinetic)/simulatedKinetic;
-      theoreticalKinetic = currentParticle.GetKineticEnergy()/MeV * wgt;
-      simulatedKinetic = theoreticalKinetic;
-      currentParticle.SetKineticEnergy( theoreticalKinetic*MeV );
-      pp = currentParticle.GetTotalMomentum()/MeV;
-      pp1 = currentParticle.GetMomentum().mag()/MeV;
-      if( pp1 < 1.0e-6*GeV )
-      {
-        rthnve = pi*G4UniformRand();
-        phinve = twopi*G4UniformRand();
-        currentParticle.SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                     pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                     pp*std::cos(rthnve)*MeV );
-      }
-      else
-      {
-        currentParticle.SetMomentum( currentParticle.GetMomentum() * (pp/pp1) );
-      }
-      theoreticalKinetic = targetParticle.GetKineticEnergy()/MeV * wgt;
-      targetParticle.SetKineticEnergy( theoreticalKinetic*MeV );
-      simulatedKinetic += theoreticalKinetic;
-      pp = targetParticle.GetTotalMomentum()/MeV;
-      pp1 = targetParticle.GetMomentum().mag()/MeV;
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      if( pp1 < 1.0e-6*GeV )
-      {
-        rthnve = pi*G4UniformRand();
-        phinve = twopi*G4UniformRand();
-        targetParticle.SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                    pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                    pp*std::cos(rthnve)*MeV );
-      } else {
-        targetParticle.SetMomentum( targetParticle.GetMomentum() * (pp/pp1) );
-      }
-      for( i=0; i<vecLen; ++i )
-      {
-        theoreticalKinetic = vec[i]->GetKineticEnergy()/MeV * wgt;
-        simulatedKinetic += theoreticalKinetic;
-        vec[i]->SetKineticEnergy( theoreticalKinetic*MeV );
-        pp = vec[i]->GetTotalMomentum()/MeV;
-        pp1 = vec[i]->GetMomentum().mag()/MeV;
-        if( pp1 < 1.0e-6*GeV )
-        {
-          rthnve = pi*G4UniformRand();
-          phinve = twopi*G4UniformRand();
-          vec[i]->SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                               pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                               pp*std::cos(rthnve)*MeV );
-        }
-        else
-          vec[i]->SetMomentum( vec[i]->GetMomentum() * (pp/pp1) );
-      }
-    }
-    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    Rotate( numberofFinalStateNucleons, pseudoParticle[3].GetMomentum(),
-            modifiedOriginal, originalIncident, targetNucleus,
-            currentParticle, targetParticle, vec, vecLen );
-    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    //
-    // add black track particles
-    // the total number of particles produced is restricted to 198
-    // this may have influence on very high energies
-    //
-    if( atomicWeight >= 1.5 )
-    {
-      // npnb is number of proton/neutron black track particles
-      // ndta is the number of deuterons, tritons, and alphas produced
-      // epnb is the kinetic energy available for proton/neutron black track particles
-      // edta is the kinetic energy available for deuteron/triton/alpha particles
-      //
-      G4double epnb, edta;
-      G4int npnb = 0;
-      G4int ndta = 0;
-      
-      epnb = targetNucleus.GetPNBlackTrackEnergy();            // was enp1 in fortran code
-      edta = targetNucleus.GetDTABlackTrackEnergy();           // was enp3 in fortran code
-      const G4double pnCutOff = 0.001;
-      const G4double dtaCutOff = 0.001;
-      const G4double kineticMinimum = 1.e-6;
-      const G4double kineticFactor = -0.010;
-      G4double sprob = 0.0; // sprob = probability of self-absorption in heavy molecules
-      const G4double ekIncident = originalIncident->GetKineticEnergy()/GeV;
-      if( ekIncident >= 5.0 )sprob = std::min( 1.0, 0.6*std::log(ekIncident-4.0) );
-      if( epnb >= pnCutOff )
-      {
-        npnb = Poisson((1.5+1.25*numberofFinalStateNucleons)*epnb/(epnb+edta));
-        if( numberofFinalStateNucleons + npnb > atomicWeight )
-          npnb = G4int(atomicWeight+0.00001 - numberofFinalStateNucleons);
-        npnb = std::min( npnb, 127-vecLen );
-      }
-      if( edta >= dtaCutOff )
-      {
-        ndta = Poisson( (1.5+1.25*numberofFinalStateNucleons)*edta/(epnb+edta) );
-        ndta = std::min( ndta, 127-vecLen );
-      }
-      G4double spall = numberofFinalStateNucleons;
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-
-      AddBlackTrackParticles( epnb, npnb, edta, ndta, sprob, kineticMinimum, kineticFactor,
-                             modifiedOriginal, spall, targetNucleus,
-                              vec, vecLen );
-
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    }
-    //
-    //  calculate time delay for nuclear reactions
-    //
-    if( (atomicWeight >= 1.5) && (atomicWeight <= 230.0) && (ekOriginal <= 0.2) )
-      currentParticle.SetTOF( 1.0-500.0*std::exp(-ekOriginal/0.04)*std::log(G4UniformRand()) );
-    else
-      currentParticle.SetTOF( 1.0 );
-    return true;
-    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-  }
- 
- void FullModelReactionDynamics::SuppressChargedPions(
-   G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-   G4int &vecLen,
-   const G4ReactionProduct &modifiedOriginal,
-   G4ReactionProduct &currentParticle,
-   G4ReactionProduct &targetParticle,
-   const G4Nucleus &targetNucleus,
-   G4bool &incidentHasChanged,
-   G4bool &targetHasChanged )
-  {
-    // this code was originally in the fortran code TWOCLU
-    //
-    // suppress charged pions, for various reasons
-    //
-    const G4double atomicWeight = targetNucleus.GetN_asInt();
-    const G4double atomicNumber = targetNucleus.GetZ_asInt();
-    const G4double pOriginal = modifiedOriginal.GetTotalMomentum()/GeV;
-    
-    // G4ParticleDefinition *aGamma = G4Gamma::Gamma();
-    G4ParticleDefinition *aProton = G4Proton::Proton();
-    G4ParticleDefinition *anAntiProton = G4AntiProton::AntiProton();
-    G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
-    G4ParticleDefinition *anAntiNeutron = G4AntiNeutron::AntiNeutron();
-    G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
-    G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
-    
-    const G4bool antiTest =
-      modifiedOriginal.GetDefinition() != anAntiProton &&
-      modifiedOriginal.GetDefinition() != anAntiNeutron;
-    if( antiTest && (
-       // currentParticle.GetDefinition() == aGamma ||
-          currentParticle.GetDefinition() == aPiPlus ||
-          currentParticle.GetDefinition() == aPiMinus ) &&
-        ( G4UniformRand() <= (10.0-pOriginal)/6.0 ) &&
-        ( G4UniformRand() <= atomicWeight/300.0 ) )
-    {
-      if( G4UniformRand() > atomicNumber/atomicWeight )
-        currentParticle.SetDefinitionAndUpdateE( aNeutron );
-      else
-        currentParticle.SetDefinitionAndUpdateE( aProton );
-      incidentHasChanged = true;
-    }
-    for( G4int i=0; i<vecLen; ++i )
-    {
-      if( antiTest && (
-         // vec[i]->GetDefinition() == aGamma ||
-            vec[i]->GetDefinition() == aPiPlus ||
-            vec[i]->GetDefinition() == aPiMinus ) &&
-          ( G4UniformRand() <= (10.0-pOriginal)/6.0 ) &&
-          ( G4UniformRand() <= atomicWeight/300.0 ) )
-      {
-        if( G4UniformRand() > atomicNumber/atomicWeight )
-          vec[i]->SetDefinitionAndUpdateE( aNeutron );
-        else
-          vec[i]->SetDefinitionAndUpdateE( aProton );
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      }
-    }
-    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-  }
- 
- G4bool FullModelReactionDynamics::TwoCluster(
-   G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-   G4int &vecLen,
-   G4ReactionProduct &modifiedOriginal, // Fermi motion & evap. effects included
-   const G4HadProjectile *originalIncident, // the original incident particle
-   G4ReactionProduct &currentParticle,
-   G4ReactionProduct &targetParticle,
-   const G4Nucleus &targetNucleus,
-   G4bool &incidentHasChanged,
-   G4bool &targetHasChanged,
-   G4bool leadFlag,
-   G4ReactionProduct &leadingStrangeParticle )
-  {
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    // derived from original FORTRAN code TWOCLU by H. Fesefeldt (11-Oct-1987)
-    //
-    //  Generation of X- and PT- values for incident, target, and all secondary particles 
-    //  
-    //  A simple two cluster model is used.
-    //  This should be sufficient for low energy interactions.
-    //
-
-    // + debugging
-    // raise(SIGSEGV);
-    // - debugging
-
-    G4int i;
-    G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
-    G4ParticleDefinition *aProton = G4Proton::Proton();
-    G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
-    G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
-    G4ParticleDefinition *aPiZero = G4PionZero::PionZero();
-    G4ParticleDefinition *aSigmaMinus = G4SigmaMinus::SigmaMinus();
-    const G4double protonMass = aProton->GetPDGMass()/MeV;
-    const G4double ekOriginal = modifiedOriginal.GetKineticEnergy()/GeV;
-    const G4double etOriginal = modifiedOriginal.GetTotalEnergy()/GeV;
-    const G4double mOriginal = modifiedOriginal.GetMass()/GeV;
-    const G4double pOriginal = modifiedOriginal.GetMomentum().mag()/GeV;
-    G4double targetMass = targetParticle.GetDefinition()->GetPDGMass()/GeV;
-    G4double centerofmassEnergy = std::sqrt( mOriginal*mOriginal +
-                                        targetMass*targetMass +
-                                        2.0*targetMass*etOriginal );  // GeV
-    G4double currentMass = currentParticle.GetMass()/GeV;
-    targetMass = targetParticle.GetMass()/GeV;
-
-    if( currentMass == 0.0 && targetMass == 0.0 )
-    {
-      G4double ek = currentParticle.GetKineticEnergy();
-      G4ThreeVector m = currentParticle.GetMomentum();
-      currentParticle = *vec[0];
-      targetParticle = *vec[1];
-      for( i=0; i<(vecLen-2); ++i )*vec[i] = *vec[i+2];
-      if(vecLen<2) 
-      {
-        for(G4int i=0; i<vecLen; i++) delete vec[i];
-	vecLen = 0;
-        throw G4HadReentrentException(__FILE__, __LINE__,
-	"FullModelReactionDynamics::TwoCluster: Negative number of particles");
-      }
-      delete vec[vecLen-1];
-      delete vec[vecLen-2];
-      vecLen -= 2;
-      incidentHasChanged = true;
-      targetHasChanged = true;
-      currentParticle.SetKineticEnergy( ek );
-      currentParticle.SetMomentum( m );
-    }
-    const G4double atomicWeight = targetNucleus.GetN_asInt();
-    const G4double atomicNumber = targetNucleus.GetZ_asInt();
-    //
-    // particles have been distributed in forward and backward hemispheres
-    // in center of mass system of the hadron nucleon interaction
-    //
-    // incident is always in forward hemisphere
-    G4int forwardCount = 1;            // number of particles in forward hemisphere
-    currentParticle.SetSide( 1 );
-    G4double forwardMass = currentParticle.GetMass()/GeV;
-    G4double cMass = forwardMass;
-    
-    // target is always in backward hemisphere
-    G4int backwardCount = 1;           // number of particles in backward hemisphere
-    G4int backwardNucleonCount = 1;    // number of nucleons in backward hemisphere
-    targetParticle.SetSide( -1 );
-    G4double backwardMass = targetParticle.GetMass()/GeV;
-    G4double bMass = backwardMass;
-    
-    for( i=0; i<vecLen; ++i )
-    {
-      if( vec[i]->GetSide() < 0 )vec[i]->SetSide( -1 ); // added by JLC, 2Jul97
-      // to take care of the case where vec has been preprocessed by GenerateXandPt
-      // and some of them have been set to -2 or -3
-      if( vec[i]->GetSide() == -1 )
-      {
-        ++backwardCount;
-        backwardMass += vec[i]->GetMass()/GeV;
-      }
-      else
-      {
-        ++forwardCount;
-        forwardMass += vec[i]->GetMass()/GeV;
-      }
-    }
-    //
-    // nucleons and some pions from intranuclear cascade
-    //
-    G4double term1 = std::log(centerofmassEnergy*centerofmassEnergy);
-    if(term1 < 0) term1 = 0.0001; // making sure xtarg<0;
-    const G4double afc = 0.312 + 0.2 * std::log(term1);
-    G4double xtarg;
-    if( centerofmassEnergy < 2.0+G4UniformRand() )        // added +2 below, JLC 4Jul97
-      xtarg = afc * (std::pow(atomicWeight,0.33)-1.0) * (2*backwardCount+vecLen+2)/2.0;
-    else
-      xtarg = afc * (std::pow(atomicWeight,0.33)-1.0) * (2*backwardCount);
-    if( xtarg <= 0.0 )xtarg = 0.01;
-    G4int nuclearExcitationCount = Poisson( xtarg );
-    if(atomicWeight<1.0001) nuclearExcitationCount = 0;
-    G4int extraNucleonCount = 0;
-    G4double extraMass = 0.0;
-    G4double extraNucleonMass = 0.0;
-    if( nuclearExcitationCount > 0 )
-    {
-      G4int momentumBin = std::min( 4, G4int(pOriginal/3.0) );     
-      const G4double nucsup[] = { 1.0, 0.8, 0.6, 0.5, 0.4 };
-      //
-      //  NOTE: in TWOCLU, these new particles were given negative codes
-      //        here we use  NewlyAdded = true  instead
-      //
-      for( i=0; i<nuclearExcitationCount; ++i )
-      {
-        G4ReactionProduct* pVec = new G4ReactionProduct();
-        if( G4UniformRand() < nucsup[momentumBin] )  // add proton or neutron
-        {
-          if( G4UniformRand() > 1.0-atomicNumber/atomicWeight )
-            // HPW: looks like a gheisha bug 
-            pVec->SetDefinition( aProton );
-          else
-            pVec->SetDefinition( aNeutron );
-          ++backwardNucleonCount;
-          ++extraNucleonCount;
-          extraNucleonMass += pVec->GetMass()/GeV;
-        }
-        else
-        {                                       // add a pion
-          G4double ran = G4UniformRand();
-          if( ran < 0.3181 )
-            pVec->SetDefinition( aPiPlus );
-          else if( ran < 0.6819 )
-            pVec->SetDefinition( aPiZero );
-          else
-            pVec->SetDefinition( aPiMinus );
-        }
-        pVec->SetSide( -2 );    // backside particle
-        extraMass += pVec->GetMass()/GeV;
-        pVec->SetNewlyAdded( true );
-        vec.SetElement( vecLen++, pVec );
-        // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      }
-    }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    G4double forwardEnergy = (centerofmassEnergy-cMass-bMass)/2.0 +cMass - forwardMass;
-    G4double backwardEnergy = (centerofmassEnergy-cMass-bMass)/2.0 +bMass - backwardMass;
-    G4double eAvailable = centerofmassEnergy - (forwardMass+backwardMass);
-    G4bool secondaryDeleted;
-    G4double pMass;
-    while( eAvailable <= 0.0 )   // must eliminate a particle
-    {
-      secondaryDeleted = false;
-      for( i=(vecLen-1); i>=0; --i )
-      {
-        if( vec[i]->GetSide() == 1 && vec[i]->GetMayBeKilled())
-        {
-          pMass = vec[i]->GetMass()/GeV;
-          for( G4int j=i; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];     // shift up
-          --forwardCount;
-          forwardEnergy += pMass;
-          forwardMass -= pMass;
-          secondaryDeleted = true;
+    if (currentParticle.GetDefinition() == leadingStrangeParticle.GetDefinition())
+      dum = false;
+    else if (targetParticle.GetDefinition() == leadingStrangeParticle.GetDefinition())
+      dum = false;
+    else {
+      for (i = 0; i < vecLen; ++i) {
+        if (vec[i]->GetDefinition() == leadingStrangeParticle.GetDefinition()) {
+          dum = false;
           break;
         }
-        else if( vec[i]->GetSide() == -1 && vec[i]->GetMayBeKilled())
-        {
-          pMass = vec[i]->GetMass()/GeV;
-          for( G4int j=i; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];    // shift up
-          --backwardCount;
-          backwardEnergy += pMass;
-          backwardMass -= pMass;
-          secondaryDeleted = true;
-          break;
-        }
-      }           // breaks go down to here
-      if( secondaryDeleted )
-      {      
-        G4ReactionProduct *temp = vec[vecLen-1];
-        delete temp;
-        --vecLen;
-        // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      }
-      else
-      {
-        if( vecLen == 0 )
-	{
-	  return false;  // all secondaries have been eliminated
-	}
-        if( targetParticle.GetSide() == -1 )
-        {
-          pMass = targetParticle.GetMass()/GeV;
-          targetParticle = *vec[0];
-          for( G4int j=0; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];    // shift up
-          --backwardCount;
-          backwardEnergy += pMass;
-          backwardMass -= pMass;
-          secondaryDeleted = true;
-        }
-        else if( targetParticle.GetSide() == 1 )
-        {
-          pMass = targetParticle.GetMass()/GeV;
-          targetParticle = *vec[0];
-          for( G4int j=0; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];    // shift up
-          --forwardCount;
-          forwardEnergy += pMass;
-          forwardMass -= pMass;
-          secondaryDeleted = true;
-        }
-        if( secondaryDeleted )
-        {
-          G4ReactionProduct *temp = vec[vecLen-1];
-          delete temp;
-          --vecLen;
-          // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-        }
-        else
-        {
-          if( currentParticle.GetSide() == -1 )
-          {
-            pMass = currentParticle.GetMass()/GeV;
-            currentParticle = *vec[0];
-            for( G4int j=0; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];    // shift up
-            --backwardCount;
-            backwardEnergy += pMass;
-            backwardMass -= pMass;
-            secondaryDeleted = true;
-          }
-          else if( currentParticle.GetSide() == 1 )
-          {
-            pMass = currentParticle.GetMass()/GeV;
-            currentParticle = *vec[0];
-            for( G4int j=0; j<(vecLen-1); ++j )*vec[j] = *vec[j+1];    // shift up
-            --forwardCount;//This line can cause infinite loop
-            forwardEnergy += pMass;
-            forwardMass -= pMass;
-            secondaryDeleted = true;
-          }
-          if( secondaryDeleted )
-          {
-            G4ReactionProduct *temp = vec[vecLen-1];
-            delete temp;
-            --vecLen;
-            // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-          }
-          else break;
-        }
-      }
-      eAvailable = centerofmassEnergy - (forwardMass+backwardMass);
-    }
-    //
-    // This is the start of the TwoCluster function
-    //  Choose masses for the 3 clusters:
-    //   forward cluster
-    //   backward meson cluster
-    //   backward nucleon cluster
-    //
-    G4double rmc = 0.0, rmd = 0.0; // rme = 0.0;
-    const G4double cpar[] = { 0.6, 0.6, 0.35, 0.15, 0.10 };
-    const G4double gpar[] = { 2.6, 2.6, 1.8, 1.30, 1.20 };
-    
-    if( forwardCount == 0) return false;
-
-    if( forwardCount == 1 )rmc = forwardMass;
-    else
-    {
-      G4int ntc = std::max(1, std::min(5,forwardCount))-1; // check if offset by 1 @@
-      rmc = forwardMass + std::pow(-std::log(1.0-G4UniformRand()),cpar[ntc])/gpar[ntc];
-    }
-    if( backwardCount == 1 )rmd = backwardMass;
-    else
-    {
-      G4int ntc = std::max(1, std::min(5,backwardCount))-1; // check, if offfset by 1 @@
-      rmd = backwardMass + std::pow(-std::log(1.0-G4UniformRand()),cpar[ntc])/gpar[ntc];
-    }
-    while( rmc+rmd > centerofmassEnergy )
-    {
-      if( (rmc <= forwardMass) && (rmd <= backwardMass) )
-      {
-        G4double temp = 0.999*centerofmassEnergy/(rmc+rmd);
-        rmc *= temp;
-        rmd *= temp;
-      }
-      else
-      {
-        rmc = 0.1*forwardMass + 0.9*rmc;
-        rmd = 0.1*backwardMass + 0.9*rmd;
       }
     }
-    //
-    //  Set beam, target of first interaction in centre of mass system
-    //
-    G4ReactionProduct pseudoParticle[8];
-    for( i=0; i<8; ++i )pseudoParticle[i].SetZero();
-    
-    pseudoParticle[1].SetMass( mOriginal*GeV );
-    pseudoParticle[1].SetTotalEnergy( etOriginal*GeV );
-    pseudoParticle[1].SetMomentum( 0.0, 0.0, pOriginal*GeV );
-    
-    pseudoParticle[2].SetMass( protonMass*MeV );
-    pseudoParticle[2].SetTotalEnergy( protonMass*MeV );
-    pseudoParticle[2].SetMomentum( 0.0, 0.0, 0.0 );
-    //
-    //  transform into centre of mass system
-    //
-    pseudoParticle[0] = pseudoParticle[1] + pseudoParticle[2];
-    pseudoParticle[1].Lorentz( pseudoParticle[1], pseudoParticle[0] );
-    pseudoParticle[2].Lorentz( pseudoParticle[2], pseudoParticle[0] );
-    
-    const G4double pfMin = 0.0001;
-    G4double pf = (centerofmassEnergy*centerofmassEnergy+rmd*rmd-rmc*rmc);
-    pf *= pf;
-    pf -= 4*centerofmassEnergy*centerofmassEnergy*rmd*rmd;
-    pf = std::sqrt( std::max(pf,pfMin) )/(2.0*centerofmassEnergy);
-    //
-    //  set final state masses and energies in centre of mass system
-    //
-    pseudoParticle[3].SetMass( rmc*GeV );
-    pseudoParticle[3].SetTotalEnergy( std::sqrt(pf*pf+rmc*rmc)*GeV );
-    
-    pseudoParticle[4].SetMass( rmd*GeV );
-    pseudoParticle[4].SetTotalEnergy( std::sqrt(pf*pf+rmd*rmd)*GeV );
-    //
-    // set |T| and |TMIN|
-    //
-    const G4double bMin = 0.01;
-    const G4double b1 = 4.0;
-    const G4double b2 = 1.6;
-    G4double t = std::log( 1.0-G4UniformRand() ) / std::max( bMin, b1+b2*std::log(pOriginal) );
-    G4double t1 =
-      pseudoParticle[1].GetTotalEnergy()/GeV - pseudoParticle[3].GetTotalEnergy()/GeV;
-    G4double pin = pseudoParticle[1].GetMomentum().mag()/GeV;
-    G4double tacmin = t1*t1 - (pin-pf)*(pin-pf);
-    //
-    // calculate (std::sin(teta/2.)^2 and std::cos(teta), set azimuth angle phi
-    //
-    const G4double smallValue = 1.0e-10;
-    G4double dumnve = 4.0*pin*pf;
-    if( dumnve == 0.0 )dumnve = smallValue;
-    G4double ctet = std::max( -1.0, std::min( 1.0, 1.0+2.0*(t-tacmin)/dumnve ) );
-    dumnve = std::max( 0.0, 1.0-ctet*ctet );
-    G4double stet = std::sqrt(dumnve);
-    G4double phi = G4UniformRand() * twopi;
-    //
-    // calculate final state momenta in centre of mass system
-    //
-    pseudoParticle[3].SetMomentum( pf*stet*std::sin(phi)*GeV,
-                                   pf*stet*std::cos(phi)*GeV,
-                                   pf*ctet*GeV );
-    pseudoParticle[4].SetMomentum( pseudoParticle[3].GetMomentum() * (-1.0) );
-    //
-    // simulate backward nucleon cluster in lab. system and transform in cms
-    //
-    G4double pp, pp1, rthnve, phinve;
-    if( nuclearExcitationCount > 0 )
-    {
-      const G4double ga = 1.2;
-      G4double ekit1 = 0.04;
-      G4double ekit2 = 0.6;
-      if( ekOriginal <= 5.0 )
-      {
-        ekit1 *= ekOriginal*ekOriginal/25.0;
-        ekit2 *= ekOriginal*ekOriginal/25.0;
-      }
-      const G4double a = (1.0-ga)/(std::pow(ekit2,(1.0-ga)) - std::pow(ekit1,(1.0-ga)));
-      for( i=0; i<vecLen; ++i )
-      {
-        if( vec[i]->GetSide() == -2 )
-        {
-          G4double kineticE =
-            std::pow( (G4UniformRand()*(1.0-ga)/a+std::pow(ekit1,(1.0-ga))), (1.0/(1.0-ga)) );
-          vec[i]->SetKineticEnergy( kineticE*GeV );
-          G4double vMass = vec[i]->GetMass()/MeV;
-          G4double totalE = kineticE + vMass;
-          pp = std::sqrt( std::abs(totalE*totalE-vMass*vMass) );
-          G4double cost = std::min( 1.0, std::max( -1.0, std::log(2.23*G4UniformRand()+0.383)/0.96 ) );
-          G4double sint = std::sqrt( std::max( 0.0, (1.0-cost*cost) ) );
-          phi = twopi*G4UniformRand();
-          vec[i]->SetMomentum( pp*sint*std::sin(phi)*MeV,
-                               pp*sint*std::cos(phi)*MeV,
-                               pp*cost*MeV );
-          vec[i]->Lorentz( *vec[i], pseudoParticle[0] );
-        }
-      }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    }
-    //
-    // fragmentation of forward cluster and backward meson cluster
-    //
-    currentParticle.SetMomentum( pseudoParticle[3].GetMomentum() );
-    currentParticle.SetTotalEnergy( pseudoParticle[3].GetTotalEnergy() );
-    
-    targetParticle.SetMomentum( pseudoParticle[4].GetMomentum() );
-    targetParticle.SetTotalEnergy( pseudoParticle[4].GetTotalEnergy() );
-    
-    pseudoParticle[5].SetMomentum( pseudoParticle[3].GetMomentum() * (-1.0) );
-    pseudoParticle[5].SetMass( pseudoParticle[3].GetMass() );
-    pseudoParticle[5].SetTotalEnergy( pseudoParticle[3].GetTotalEnergy() );
-    
-    pseudoParticle[6].SetMomentum( pseudoParticle[4].GetMomentum() * (-1.0) );
-    pseudoParticle[6].SetMass( pseudoParticle[4].GetMass() );
-    pseudoParticle[6].SetTotalEnergy( pseudoParticle[4].GetTotalEnergy() );
-    
-    G4double wgt;
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    if( forwardCount > 1 )     // tempV will contain the forward particles
-    {
-      G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> tempV;
-      tempV.Initialize( forwardCount );
-      G4bool constantCrossSection = true;
-      G4int tempLen = 0;
-      if( currentParticle.GetSide() == 1 )
-        tempV.SetElement( tempLen++, &currentParticle );
-      if( targetParticle.GetSide() == 1 )
-        tempV.SetElement( tempLen++, &targetParticle );
-      for( i=0; i<vecLen; ++i )
-      {
-        if( vec[i]->GetSide() == 1 )
-        {
-          if( tempLen < 18 )
-            tempV.SetElement( tempLen++, vec[i] );
-          else
-          {
-            vec[i]->SetSide( -1 );
-            continue;
-          }
-        }
-      }
-      if( tempLen >= 2 )
-      {
-        GenerateNBodyEvent( pseudoParticle[3].GetMass()/MeV,
-                                  constantCrossSection, tempV, tempLen );
-        if( currentParticle.GetSide() == 1 )
-          currentParticle.Lorentz( currentParticle, pseudoParticle[5] );
-        if( targetParticle.GetSide() == 1 )
-          targetParticle.Lorentz( targetParticle, pseudoParticle[5] );
-        for( i=0; i<vecLen; ++i )
-        {
-          if( vec[i]->GetSide() == 1 )vec[i]->Lorentz( *vec[i], pseudoParticle[5] );
-        }
-      }
-    }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    if( backwardCount > 1 )   //  tempV will contain the backward particles,
-    {                         //  but not those created from the intranuclear cascade
-      G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> tempV;
-      tempV.Initialize( backwardCount );
-      G4bool constantCrossSection = true;
-      G4int tempLen = 0;
-      if( currentParticle.GetSide() == -1 )
-        tempV.SetElement( tempLen++, &currentParticle );
-      if( targetParticle.GetSide() == -1 )
-        tempV.SetElement( tempLen++, &targetParticle );
-      for( i=0; i<vecLen; ++i )
-      {
-        if( vec[i]->GetSide() == -1 )
-        {
-          if( tempLen < 18 )
-            tempV.SetElement( tempLen++, vec[i] );
-          else
-          {
-            vec[i]->SetSide( -2 );
-            vec[i]->SetKineticEnergy( 0.0 );
-            vec[i]->SetMomentum( 0.0, 0.0, 0.0 );
-            continue;
-          }
-        }
-      }
-      if( tempLen >= 2 )
-      {
-        GenerateNBodyEvent( pseudoParticle[4].GetMass()/MeV,
-                                  constantCrossSection, tempV, tempLen );
-        if( currentParticle.GetSide() == -1 )
-          currentParticle.Lorentz( currentParticle, pseudoParticle[6] );
-        if( targetParticle.GetSide() == -1 )
-          targetParticle.Lorentz( targetParticle, pseudoParticle[6] );
-        for( i=0; i<vecLen; ++i )
-        {
-          if( vec[i]->GetSide() == -1 )vec[i]->Lorentz( *vec[i], pseudoParticle[6] );
-        }
-      }
-    }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    //
-    // Lorentz transformation in lab system
-    //
-    G4int numberofFinalStateNucleons = 0;
-    if( currentParticle.GetDefinition() ==aProton ||
-        currentParticle.GetDefinition() == aNeutron ||
-	currentParticle.GetDefinition() == aSigmaMinus||
-	currentParticle.GetDefinition() == G4SigmaPlus::SigmaPlus()||
-	currentParticle.GetDefinition() == G4SigmaZero::SigmaZero()||
-	currentParticle.GetDefinition() == G4XiZero::XiZero()||
-	currentParticle.GetDefinition() == G4XiMinus::XiMinus()||
-	currentParticle.GetDefinition() == G4OmegaMinus::OmegaMinus()||
-	currentParticle.GetDefinition() == G4Lambda::Lambda()) ++numberofFinalStateNucleons;
-    currentParticle.Lorentz( currentParticle, pseudoParticle[2] );
-    if( targetParticle.GetDefinition() ==aProton ||
-        targetParticle.GetDefinition() == aNeutron ||
-        targetParticle.GetDefinition() == G4Lambda::Lambda() ||
-	targetParticle.GetDefinition() == G4XiZero::XiZero()||
-	targetParticle.GetDefinition() == G4XiMinus::XiMinus()||
-	targetParticle.GetDefinition() == G4OmegaMinus::OmegaMinus()||
-	targetParticle.GetDefinition() == G4SigmaZero::SigmaZero()||
-	targetParticle.GetDefinition() == G4SigmaPlus::SigmaPlus()||
-	targetParticle.GetDefinition() == aSigmaMinus) ++numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiProton::AntiProton()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiNeutron::AntiNeutron()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiSigmaMinus::AntiSigmaMinus()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiSigmaPlus::AntiSigmaPlus()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiSigmaZero::AntiSigmaZero()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiXiZero::AntiXiZero()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiXiMinus::AntiXiMinus()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiOmegaMinus::AntiOmegaMinus()) --numberofFinalStateNucleons;
-    if( targetParticle.GetDefinition() ==G4AntiLambda::AntiLambda()) --numberofFinalStateNucleons;
-    targetParticle.Lorentz( targetParticle, pseudoParticle[2] );
-    for( i=0; i<vecLen; ++i )
-    {
-      if( vec[i]->GetDefinition() ==aProton ||
-          vec[i]->GetDefinition() == aNeutron ||
-          vec[i]->GetDefinition() == G4Lambda::Lambda() ||
-          vec[i]->GetDefinition() == G4XiZero::XiZero() ||
-          vec[i]->GetDefinition() == G4XiMinus::XiMinus() ||
-          vec[i]->GetDefinition() == G4OmegaMinus::OmegaMinus() ||
-	  vec[i]->GetDefinition() == G4SigmaPlus::SigmaPlus()||
-	  vec[i]->GetDefinition() == G4SigmaZero::SigmaZero()||
-	  vec[i]->GetDefinition() == aSigmaMinus) ++numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiProton::AntiProton()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiNeutron::AntiNeutron()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiSigmaMinus::AntiSigmaMinus()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiSigmaPlus::AntiSigmaPlus()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiSigmaZero::AntiSigmaZero()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiLambda::AntiLambda()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiXiZero::AntiXiZero()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiXiMinus::AntiXiMinus()) --numberofFinalStateNucleons;
-      if( vec[i]->GetDefinition() ==G4AntiOmegaMinus::AntiOmegaMinus()) --numberofFinalStateNucleons;
-      vec[i]->Lorentz( *vec[i], pseudoParticle[2] );
-    }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    numberofFinalStateNucleons = std::max( 1, numberofFinalStateNucleons );
-    //
-    // sometimes the leading strange particle is lost, set it back
-    //
-    G4bool dum = true;
-    if( leadFlag )
-    {
-      // leadFlag will be true
-      //  iff original particle is at least as heavy as K+ and not a proton or neutron AND
-      //   if
-      //    incident particle is at least as heavy as K+ and it is not a proton or neutron
-      //     leadFlag is set to the incident particle
-      //   or
-      //    target particle is at least as heavy as K+ and it is not a proton or neutron
-      //     leadFlag is set to the target particle
-      //
-      if( currentParticle.GetDefinition() == leadingStrangeParticle.GetDefinition() )
-        dum = false;
-      else if( targetParticle.GetDefinition() == leadingStrangeParticle.GetDefinition() )
-        dum = false;
-      else
-      {
-        for( i=0; i<vecLen; ++i )
-        {
-          if( vec[i]->GetDefinition() == leadingStrangeParticle.GetDefinition() )
-          {
-            dum = false;
-            break;
-          }
-        }
-      }
-      if( dum )
-      {
-        G4double leadMass = leadingStrangeParticle.GetMass()/MeV;
-        G4double ekin;
-        if( ((leadMass <  protonMass) && (targetParticle.GetMass()/MeV <  protonMass)) ||
-            ((leadMass >= protonMass) && (targetParticle.GetMass()/MeV >= protonMass)) )
-        {
-          ekin = targetParticle.GetKineticEnergy()/GeV;
-          pp1 = targetParticle.GetMomentum().mag()/MeV; // old momentum
-          targetParticle.SetDefinition( leadingStrangeParticle.GetDefinition() );
-          targetParticle.SetKineticEnergy( ekin*GeV );
-          pp = targetParticle.GetTotalMomentum()/MeV;   // new momentum
-          if( pp1 < 1.0e-3 )
-          {
-            rthnve = pi*G4UniformRand();
-            phinve = twopi*G4UniformRand();
-            targetParticle.SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                        pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                        pp*std::cos(rthnve)*MeV );
-          }
-          else
-            targetParticle.SetMomentum( targetParticle.GetMomentum() * (pp/pp1) );
-          
-          targetHasChanged = true;
-        }
-        else
-        {
-          ekin = currentParticle.GetKineticEnergy()/GeV;
-          pp1 = currentParticle.GetMomentum().mag()/MeV;
-          currentParticle.SetDefinition( leadingStrangeParticle.GetDefinition() );
-          currentParticle.SetKineticEnergy( ekin*GeV );
-          pp = currentParticle.GetTotalMomentum()/MeV;
-          if( pp1 < 1.0e-3 )
-          {
-            rthnve = pi*G4UniformRand();
-            phinve = twopi*G4UniformRand();
-            currentParticle.SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                         pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                         pp*std::cos(rthnve)*MeV );
-          }
-          else
-            currentParticle.SetMomentum( currentParticle.GetMomentum() * (pp/pp1) );
-          
-          incidentHasChanged = true;
-        }
-      }
-    }    // end of if( leadFlag )
-    //
-    //  for various reasons, the energy balance is not sufficient,
-    //  check that,  energy balance, angle of final system, etc.
-    //
-    pseudoParticle[4].SetMass( mOriginal*GeV );
-    pseudoParticle[4].SetTotalEnergy( etOriginal*GeV );
-    pseudoParticle[4].SetMomentum( 0.0, 0.0, pOriginal*GeV );
-    
-    const G4ParticleDefinition * aOrgDef = modifiedOriginal.GetDefinition();
-    G4int diff = 0;
-    if(aOrgDef == G4Proton::Proton() || aOrgDef == G4Neutron::Neutron() )  diff = 1;
-    if(numberofFinalStateNucleons == 1) diff = 0;
-    pseudoParticle[5].SetMomentum( 0.0, 0.0, 0.0 );
-    pseudoParticle[5].SetMass( protonMass*(numberofFinalStateNucleons-diff)*MeV );
-    pseudoParticle[5].SetTotalEnergy( protonMass*(numberofFinalStateNucleons-diff)*MeV );
-    
-//    G4double ekin0 = pseudoParticle[4].GetKineticEnergy()/GeV;
-    G4double theoreticalKinetic =
-      pseudoParticle[4].GetTotalEnergy()/GeV + pseudoParticle[5].GetTotalEnergy()/GeV;
-    
-    pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
-    pseudoParticle[4].Lorentz( pseudoParticle[4], pseudoParticle[6] );
-    pseudoParticle[5].Lorentz( pseudoParticle[5], pseudoParticle[6] );
-     
-    if( vecLen < 16 )
-    {
-      G4ReactionProduct tempR[130];
-      //G4ReactionProduct *tempR = new G4ReactionProduct [vecLen+2];
-      tempR[0] = currentParticle;
-      tempR[1] = targetParticle;
-      for( i=0; i<vecLen; ++i )tempR[i+2] = *vec[i];
-
-      G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> tempV;
-      tempV.Initialize( vecLen+2 );
-      G4bool constantCrossSection = true;
-      G4int tempLen = 0;
-      for( i=0; i<vecLen+2; ++i )tempV.SetElement( tempLen++, &tempR[i] );
-
-      if( tempLen >= 2 )
-      {
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-        GenerateNBodyEvent(
-         pseudoParticle[4].GetTotalEnergy()/MeV+pseudoParticle[5].GetTotalEnergy()/MeV,
-         constantCrossSection, tempV, tempLen );
-        theoreticalKinetic = 0.0;
-        for( i=0; i<vecLen+2; ++i )
-        {
-          pseudoParticle[7].SetMomentum( tempV[i]->GetMomentum() );
-          pseudoParticle[7].SetMass( tempV[i]->GetMass() );
-          pseudoParticle[7].SetTotalEnergy( tempV[i]->GetTotalEnergy() );
-          pseudoParticle[7].Lorentz( pseudoParticle[7], pseudoParticle[5] );
-          theoreticalKinetic += pseudoParticle[7].GetKineticEnergy()/GeV;
-        }
-      }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      //delete [] tempR;
-    }
-    else
-    {
-      theoreticalKinetic -=
-        ( currentParticle.GetMass()/GeV + targetParticle.GetMass()/GeV );
-      for( i=0; i<vecLen; ++i )theoreticalKinetic -= vec[i]->GetMass()/GeV;
-    }
-    G4double simulatedKinetic =
-      currentParticle.GetKineticEnergy()/GeV + targetParticle.GetKineticEnergy()/GeV;
-    for( i=0; i<vecLen; ++i )simulatedKinetic += vec[i]->GetKineticEnergy()/GeV;
-    //
-    // make sure that kinetic energies are correct
-    // the backward nucleon cluster is not produced within proper kinematics!!!
-    //
-    
-    if( simulatedKinetic != 0.0 )
-    {
-      wgt = (theoreticalKinetic)/simulatedKinetic;
-      currentParticle.SetKineticEnergy( wgt*currentParticle.GetKineticEnergy() );
-      pp = currentParticle.GetTotalMomentum()/MeV;
-      pp1 = currentParticle.GetMomentum().mag()/MeV;
-      if( pp1 < 0.001*MeV )
-      {
-        rthnve = pi * G4UniformRand();
-        phinve = twopi * G4UniformRand();
-        currentParticle.SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                     pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                     pp*std::cos(rthnve)*MeV );
-      }
-      else
-        currentParticle.SetMomentum( currentParticle.GetMomentum() * (pp/pp1) );
-      
-      targetParticle.SetKineticEnergy( wgt*targetParticle.GetKineticEnergy() );
-      pp = targetParticle.GetTotalMomentum()/MeV;
-      pp1 = targetParticle.GetMomentum().mag()/MeV;
-      if( pp1 < 0.001*MeV )
-      {
-        rthnve = pi * G4UniformRand();
-        phinve = twopi * G4UniformRand();
-        targetParticle.SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                    pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                    pp*std::cos(rthnve)*MeV );
-      }
-      else
-        targetParticle.SetMomentum( targetParticle.GetMomentum() * (pp/pp1) );
-      
-      for( i=0; i<vecLen; ++i )
-      {
-        vec[i]->SetKineticEnergy( wgt*vec[i]->GetKineticEnergy() );
-        pp = vec[i]->GetTotalMomentum()/MeV;
-        pp1 = vec[i]->GetMomentum().mag()/MeV;
-        if( pp1 < 0.001 )
-        {
+    if (dum) {
+      G4double leadMass = leadingStrangeParticle.GetMass() / MeV;
+      G4double ekin;
+      if (((leadMass < protonMass) && (targetParticle.GetMass() / MeV < protonMass)) ||
+          ((leadMass >= protonMass) && (targetParticle.GetMass() / MeV >= protonMass))) {
+        ekin = targetParticle.GetKineticEnergy() / GeV;
+        pp1 = targetParticle.GetMomentum().mag() / MeV;  // old momentum
+        targetParticle.SetDefinition(leadingStrangeParticle.GetDefinition());
+        targetParticle.SetKineticEnergy(ekin * GeV);
+        pp = targetParticle.GetTotalMomentum() / MeV;  // new momentum
+        if (pp1 < 1.0e-3) {
           rthnve = pi * G4UniformRand();
           phinve = twopi * G4UniformRand();
-          vec[i]->SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                               pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                               pp*std::cos(rthnve)*MeV );
-        }
-        else
-          vec[i]->SetMomentum( vec[i]->GetMomentum() * (pp/pp1) );
+          targetParticle.SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                                     pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                                     pp * std::cos(rthnve) * MeV);
+        } else
+          targetParticle.SetMomentum(targetParticle.GetMomentum() * (pp / pp1));
+
+        targetHasChanged = true;
+      } else {
+        ekin = currentParticle.GetKineticEnergy() / GeV;
+        pp1 = currentParticle.GetMomentum().mag() / MeV;
+        currentParticle.SetDefinition(leadingStrangeParticle.GetDefinition());
+        currentParticle.SetKineticEnergy(ekin * GeV);
+        pp = currentParticle.GetTotalMomentum() / MeV;
+        if (pp1 < 1.0e-3) {
+          rthnve = pi * G4UniformRand();
+          phinve = twopi * G4UniformRand();
+          currentParticle.SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                                      pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                                      pp * std::cos(rthnve) * MeV);
+        } else
+          currentParticle.SetMomentum(currentParticle.GetMomentum() * (pp / pp1));
+
+        incidentHasChanged = true;
       }
     }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    Rotate( numberofFinalStateNucleons, pseudoParticle[4].GetMomentum(),
-            modifiedOriginal, originalIncident, targetNucleus,
-            currentParticle, targetParticle, vec, vecLen );
-    //
-    //  add black track particles
-    //  the total number of particles produced is restricted to 198
-    //  this may have influence on very high energies
-    //
-    if( atomicWeight >= 1.5 )
-    {
-      // npnb is number of proton/neutron black track particles
-      // ndta is the number of deuterons, tritons, and alphas produced
-      // epnb is the kinetic energy available for proton/neutron black track particles
-      // edta is the kinetic energy available for deuteron/triton/alpha particles
-      //
-      G4double epnb, edta;
-      G4int npnb = 0;
-      G4int ndta = 0;
-      
-      epnb = targetNucleus.GetPNBlackTrackEnergy();            // was enp1 in fortran code
-      edta = targetNucleus.GetDTABlackTrackEnergy();           // was enp3 in fortran code
-      const G4double pnCutOff = 0.001;     // GeV
-      const G4double dtaCutOff = 0.001;    // GeV
-      const G4double kineticMinimum = 1.e-6;
-      const G4double kineticFactor = -0.005;
-      
-      G4double sprob = 0.0; // sprob = probability of self-absorption in heavy molecules
-      const G4double ekIncident = originalIncident->GetKineticEnergy()/GeV;
-      if( ekIncident >= 5.0 )sprob = std::min( 1.0, 0.6*std::log(ekIncident-4.0) );
-      
-      if( epnb >= pnCutOff )
-      {
-        npnb = Poisson((1.5+1.25*numberofFinalStateNucleons)*epnb/(epnb+edta));
-        if( numberofFinalStateNucleons + npnb > atomicWeight )
-          npnb = G4int(atomicWeight - numberofFinalStateNucleons);
-        npnb = std::min( npnb, 127-vecLen );
-      }
-      if( edta >= dtaCutOff )
-      {
-        ndta = Poisson( (1.5+1.25*numberofFinalStateNucleons)*edta/(epnb+edta) );
-        ndta = std::min( ndta, 127-vecLen );
-      }
-      G4double spall = numberofFinalStateNucleons;
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  }  // end of if( leadFlag )
+  //
+  //  for various reasons, the energy balance is not sufficient,
+  //  check that,  energy balance, angle of final system, etc.
+  //
+  pseudoParticle[4].SetMass(mOriginal * GeV);
+  pseudoParticle[4].SetTotalEnergy(etOriginal * GeV);
+  pseudoParticle[4].SetMomentum(0.0, 0.0, pOriginal * GeV);
 
-      AddBlackTrackParticles( epnb, npnb, edta, ndta, sprob, kineticMinimum, kineticFactor,
-                              modifiedOriginal, spall, targetNucleus,
-                              vec, vecLen );
+  const G4ParticleDefinition *aOrgDef = modifiedOriginal.GetDefinition();
+  G4int diff = 0;
+  if (aOrgDef == G4Proton::Proton() || aOrgDef == G4Neutron::Neutron())
+    diff = 1;
+  if (numberofFinalStateNucleons == 1)
+    diff = 0;
+  pseudoParticle[5].SetMomentum(0.0, 0.0, 0.0);
+  pseudoParticle[5].SetMass(protonMass * (numberofFinalStateNucleons - diff) * MeV);
+  pseudoParticle[5].SetTotalEnergy(protonMass * (numberofFinalStateNucleons - diff) * MeV);
 
+  //    G4double ekin0 = pseudoParticle[4].GetKineticEnergy()/GeV;
+  G4double theoreticalKinetic = pseudoParticle[4].GetTotalEnergy() / GeV + pseudoParticle[5].GetTotalEnergy() / GeV;
+
+  pseudoParticle[6] = pseudoParticle[4] + pseudoParticle[5];
+  pseudoParticle[4].Lorentz(pseudoParticle[4], pseudoParticle[6]);
+  pseudoParticle[5].Lorentz(pseudoParticle[5], pseudoParticle[6]);
+
+  if (vecLen < 16) {
+    G4ReactionProduct tempR[130];
+    //G4ReactionProduct *tempR = new G4ReactionProduct [vecLen+2];
+    tempR[0] = currentParticle;
+    tempR[1] = targetParticle;
+    for (i = 0; i < vecLen; ++i)
+      tempR[i + 2] = *vec[i];
+
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> tempV;
+    tempV.Initialize(vecLen + 2);
+    G4bool constantCrossSection = true;
+    G4int tempLen = 0;
+    for (i = 0; i < vecLen + 2; ++i)
+      tempV.SetElement(tempLen++, &tempR[i]);
+
+    if (tempLen >= 2) {
       // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+      GenerateNBodyEvent(pseudoParticle[4].GetTotalEnergy() / MeV + pseudoParticle[5].GetTotalEnergy() / MeV,
+                         constantCrossSection,
+                         tempV,
+                         tempLen);
+      theoreticalKinetic = 0.0;
+      for (i = 0; i < vecLen + 2; ++i) {
+        pseudoParticle[7].SetMomentum(tempV[i]->GetMomentum());
+        pseudoParticle[7].SetMass(tempV[i]->GetMass());
+        pseudoParticle[7].SetTotalEnergy(tempV[i]->GetTotalEnergy());
+        pseudoParticle[7].Lorentz(pseudoParticle[7], pseudoParticle[5]);
+        theoreticalKinetic += pseudoParticle[7].GetKineticEnergy() / GeV;
+      }
     }
-    //if( centerofmassEnergy <= (4.0+G4UniformRand()) )
-    //  MomentumCheck( modifiedOriginal, currentParticle, targetParticle, vec, vecLen );
-    //
-    //  calculate time delay for nuclear reactions
-    //
-    if( (atomicWeight >= 1.5) && (atomicWeight <= 230.0) && (ekOriginal <= 0.2) )
-      currentParticle.SetTOF( 1.0-500.0*std::exp(-ekOriginal/0.04)*std::log(G4UniformRand()) );
-    else
-      currentParticle.SetTOF( 1.0 );
-    
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    return true;
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    //delete [] tempR;
+  } else {
+    theoreticalKinetic -= (currentParticle.GetMass() / GeV + targetParticle.GetMass() / GeV);
+    for (i = 0; i < vecLen; ++i)
+      theoreticalKinetic -= vec[i]->GetMass() / GeV;
   }
- 
- void FullModelReactionDynamics::TwoBody(
-  G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-  G4int &vecLen,
-  G4ReactionProduct &modifiedOriginal,
-  const G4DynamicParticle */*originalTarget*/,
-  G4ReactionProduct &currentParticle,
-  G4ReactionProduct &targetParticle,
-  const G4Nucleus &targetNucleus,
-  G4bool &/* targetHasChanged*/ )
-  {
-    //    G4cout<<"TwoBody called"<<G4endl;
-    // 
-    // derived from original FORTRAN code TWOB by H. Fesefeldt (15-Sep-1987)
-    //
-    // Generation of momenta for elastic and quasi-elastic 2 body reactions
-    //
-    // The simple formula ds/d|t| = s0* std::exp(-b*|t|) is used.
-    // The b values are parametrizations from experimental data.
-    // Not available values are taken from those of similar reactions.
-    //
-    G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
-    G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
-    G4ParticleDefinition *aPiZero = G4PionZero::PionZero();
-    G4ParticleDefinition *aKaonPlus = G4KaonPlus::KaonPlus();
-    G4ParticleDefinition *aKaonMinus = G4KaonMinus::KaonMinus();
-    G4ParticleDefinition *aKaonZeroS = G4KaonZeroShort::KaonZeroShort();
-    G4ParticleDefinition *aKaonZeroL = G4KaonZeroLong::KaonZeroLong();
-    
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);    
-    static const G4double expxu =  82.;           // upper bound for arg. of exp
-    static const G4double expxl = -expxu;         // lower bound for arg. of exp
-    
-    const G4double ekOriginal = modifiedOriginal.GetKineticEnergy()/GeV;
-    const G4double pOriginal = modifiedOriginal.GetMomentum().mag()/GeV;
-    G4double currentMass = currentParticle.GetMass()/GeV;
-    G4double targetMass = targetParticle.GetMass()/GeV;
-    const G4double atomicWeight = targetNucleus.GetN_asInt();
-    //    G4cout<<"Atomic weight is found to be: "<<atomicWeight<<G4endl;
-    G4double etCurrent = currentParticle.GetTotalEnergy()/GeV;
-    G4double pCurrent = currentParticle.GetTotalMomentum()/GeV;
+  G4double simulatedKinetic = currentParticle.GetKineticEnergy() / GeV + targetParticle.GetKineticEnergy() / GeV;
+  for (i = 0; i < vecLen; ++i)
+    simulatedKinetic += vec[i]->GetKineticEnergy() / GeV;
+  //
+  // make sure that kinetic energies are correct
+  // the backward nucleon cluster is not produced within proper kinematics!!!
+  //
 
-    G4double cmEnergy = std::sqrt( currentMass*currentMass +
-                              targetMass*targetMass +
-                              2.0*targetMass*etCurrent );  // in GeV
+  if (simulatedKinetic != 0.0) {
+    wgt = (theoreticalKinetic) / simulatedKinetic;
+    currentParticle.SetKineticEnergy(wgt * currentParticle.GetKineticEnergy());
+    pp = currentParticle.GetTotalMomentum() / MeV;
+    pp1 = currentParticle.GetMomentum().mag() / MeV;
+    if (pp1 < 0.001 * MeV) {
+      rthnve = pi * G4UniformRand();
+      phinve = twopi * G4UniformRand();
+      currentParticle.SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                                  pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                                  pp * std::cos(rthnve) * MeV);
+    } else
+      currentParticle.SetMomentum(currentParticle.GetMomentum() * (pp / pp1));
 
-    //if( (pOriginal < 0.1) ||
-    //    (centerofmassEnergy < 0.01) ) // 2-body scattering not possible
-    // Continue with original particle, but spend the nuclear evaporation energy
-    //  targetParticle.SetMass( 0.0 );  // flag that the target doesn't exist
-    //else                           // Two-body scattering is possible
+    targetParticle.SetKineticEnergy(wgt * targetParticle.GetKineticEnergy());
+    pp = targetParticle.GetTotalMomentum() / MeV;
+    pp1 = targetParticle.GetMomentum().mag() / MeV;
+    if (pp1 < 0.001 * MeV) {
+      rthnve = pi * G4UniformRand();
+      phinve = twopi * G4UniformRand();
+      targetParticle.SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                                 pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                                 pp * std::cos(rthnve) * MeV);
+    } else
+      targetParticle.SetMomentum(targetParticle.GetMomentum() * (pp / pp1));
 
-    if( (pCurrent < 0.1) || (cmEnergy < 0.01) ) // 2-body scattering not possible
-    {
-      targetParticle.SetMass( 0.0 );  // flag that the target particle doesn't exist
+    for (i = 0; i < vecLen; ++i) {
+      vec[i]->SetKineticEnergy(wgt * vec[i]->GetKineticEnergy());
+      pp = vec[i]->GetTotalMomentum() / MeV;
+      pp1 = vec[i]->GetMomentum().mag() / MeV;
+      if (pp1 < 0.001) {
+        rthnve = pi * G4UniformRand();
+        phinve = twopi * G4UniformRand();
+        vec[i]->SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                            pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                            pp * std::cos(rthnve) * MeV);
+      } else
+        vec[i]->SetMomentum(vec[i]->GetMomentum() * (pp / pp1));
     }
-    else
-    {
-// moved this if-block to a later stage, i.e. to the assignment of the scattering angle
-// @@@@@ double-check.
-//      if( targetParticle.GetDefinition() == aKaonMinus ||
-//          targetParticle.GetDefinition() == aKaonZeroL ||
-//          targetParticle.GetDefinition() == aKaonZeroS ||
-//          targetParticle.GetDefinition() == aKaonPlus ||
-//          targetParticle.GetDefinition() == aPiMinus ||
-//          targetParticle.GetDefinition() == aPiZero ||
-//          targetParticle.GetDefinition() == aPiPlus )
-//      {
-//        if( G4UniformRand() < 0.5 )
-//          targetParticle.SetDefinitionAndUpdateE( aNeutron );
-//        else
-//          targetParticle.SetDefinitionAndUpdateE( aProton );
-//        targetHasChanged = true;
-//        targetMass = targetParticle.GetMass()/GeV;
-//      }
-      //
-      // Set masses and momenta for final state particles
-      //
-      /*
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  Rotate(numberofFinalStateNucleons,
+         pseudoParticle[4].GetMomentum(),
+         modifiedOriginal,
+         originalIncident,
+         targetNucleus,
+         currentParticle,
+         targetParticle,
+         vec,
+         vecLen);
+  //
+  //  add black track particles
+  //  the total number of particles produced is restricted to 198
+  //  this may have influence on very high energies
+  //
+  if (atomicWeight >= 1.5) {
+    // npnb is number of proton/neutron black track particles
+    // ndta is the number of deuterons, tritons, and alphas produced
+    // epnb is the kinetic energy available for proton/neutron black track particles
+    // edta is the kinetic energy available for deuteron/triton/alpha particles
+    //
+    G4double epnb, edta;
+    G4int npnb = 0;
+    G4int ndta = 0;
+
+    epnb = targetNucleus.GetPNBlackTrackEnergy();   // was enp1 in fortran code
+    edta = targetNucleus.GetDTABlackTrackEnergy();  // was enp3 in fortran code
+    const G4double pnCutOff = 0.001;                // GeV
+    const G4double dtaCutOff = 0.001;               // GeV
+    const G4double kineticMinimum = 1.e-6;
+    const G4double kineticFactor = -0.005;
+
+    G4double sprob = 0.0;  // sprob = probability of self-absorption in heavy molecules
+    const G4double ekIncident = originalIncident->GetKineticEnergy() / GeV;
+    if (ekIncident >= 5.0)
+      sprob = std::min(1.0, 0.6 * std::log(ekIncident - 4.0));
+
+    if (epnb >= pnCutOff) {
+      npnb = Poisson((1.5 + 1.25 * numberofFinalStateNucleons) * epnb / (epnb + edta));
+      if (numberofFinalStateNucleons + npnb > atomicWeight)
+        npnb = G4int(atomicWeight - numberofFinalStateNucleons);
+      npnb = std::min(npnb, 127 - vecLen);
+    }
+    if (edta >= dtaCutOff) {
+      ndta = Poisson((1.5 + 1.25 * numberofFinalStateNucleons) * edta / (epnb + edta));
+      ndta = std::min(ndta, 127 - vecLen);
+    }
+    G4double spall = numberofFinalStateNucleons;
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+
+    AddBlackTrackParticles(epnb,
+                           npnb,
+                           edta,
+                           ndta,
+                           sprob,
+                           kineticMinimum,
+                           kineticFactor,
+                           modifiedOriginal,
+                           spall,
+                           targetNucleus,
+                           vec,
+                           vecLen);
+
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  }
+  //if( centerofmassEnergy <= (4.0+G4UniformRand()) )
+  //  MomentumCheck( modifiedOriginal, currentParticle, targetParticle, vec, vecLen );
+  //
+  //  calculate time delay for nuclear reactions
+  //
+  if ((atomicWeight >= 1.5) && (atomicWeight <= 230.0) && (ekOriginal <= 0.2))
+    currentParticle.SetTOF(1.0 - 500.0 * std::exp(-ekOriginal / 0.04) * std::log(G4UniformRand()));
+  else
+    currentParticle.SetTOF(1.0);
+
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  return true;
+}
+
+void FullModelReactionDynamics::TwoBody(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                                        G4int &vecLen,
+                                        G4ReactionProduct &modifiedOriginal,
+                                        const G4DynamicParticle * /*originalTarget*/,
+                                        G4ReactionProduct &currentParticle,
+                                        G4ReactionProduct &targetParticle,
+                                        const G4Nucleus &targetNucleus,
+                                        G4bool & /* targetHasChanged*/) {
+  //    G4cout<<"TwoBody called"<<G4endl;
+  //
+  // derived from original FORTRAN code TWOB by H. Fesefeldt (15-Sep-1987)
+  //
+  // Generation of momenta for elastic and quasi-elastic 2 body reactions
+  //
+  // The simple formula ds/d|t| = s0* std::exp(-b*|t|) is used.
+  // The b values are parametrizations from experimental data.
+  // Not available values are taken from those of similar reactions.
+  //
+  G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
+  G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
+  G4ParticleDefinition *aPiZero = G4PionZero::PionZero();
+  G4ParticleDefinition *aKaonPlus = G4KaonPlus::KaonPlus();
+  G4ParticleDefinition *aKaonMinus = G4KaonMinus::KaonMinus();
+  G4ParticleDefinition *aKaonZeroS = G4KaonZeroShort::KaonZeroShort();
+  G4ParticleDefinition *aKaonZeroL = G4KaonZeroLong::KaonZeroLong();
+
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  static const G4double expxu = 82.;     // upper bound for arg. of exp
+  static const G4double expxl = -expxu;  // lower bound for arg. of exp
+
+  const G4double ekOriginal = modifiedOriginal.GetKineticEnergy() / GeV;
+  const G4double pOriginal = modifiedOriginal.GetMomentum().mag() / GeV;
+  G4double currentMass = currentParticle.GetMass() / GeV;
+  G4double targetMass = targetParticle.GetMass() / GeV;
+  const G4double atomicWeight = targetNucleus.GetN_asInt();
+  //    G4cout<<"Atomic weight is found to be: "<<atomicWeight<<G4endl;
+  G4double etCurrent = currentParticle.GetTotalEnergy() / GeV;
+  G4double pCurrent = currentParticle.GetTotalMomentum() / GeV;
+
+  G4double cmEnergy =
+      std::sqrt(currentMass * currentMass + targetMass * targetMass + 2.0 * targetMass * etCurrent);  // in GeV
+
+  //if( (pOriginal < 0.1) ||
+  //    (centerofmassEnergy < 0.01) ) // 2-body scattering not possible
+  // Continue with original particle, but spend the nuclear evaporation energy
+  //  targetParticle.SetMass( 0.0 );  // flag that the target doesn't exist
+  //else                           // Two-body scattering is possible
+
+  if ((pCurrent < 0.1) || (cmEnergy < 0.01))  // 2-body scattering not possible
+  {
+    targetParticle.SetMass(0.0);  // flag that the target particle doesn't exist
+  } else {
+    // moved this if-block to a later stage, i.e. to the assignment of the scattering angle
+    // @@@@@ double-check.
+    //      if( targetParticle.GetDefinition() == aKaonMinus ||
+    //          targetParticle.GetDefinition() == aKaonZeroL ||
+    //          targetParticle.GetDefinition() == aKaonZeroS ||
+    //          targetParticle.GetDefinition() == aKaonPlus ||
+    //          targetParticle.GetDefinition() == aPiMinus ||
+    //          targetParticle.GetDefinition() == aPiZero ||
+    //          targetParticle.GetDefinition() == aPiPlus )
+    //      {
+    //        if( G4UniformRand() < 0.5 )
+    //          targetParticle.SetDefinitionAndUpdateE( aNeutron );
+    //        else
+    //          targetParticle.SetDefinitionAndUpdateE( aProton );
+    //        targetHasChanged = true;
+    //        targetMass = targetParticle.GetMass()/GeV;
+    //      }
+    //
+    // Set masses and momenta for final state particles
+    //
+    /*
       G4cout<<"Check 0"<<G4endl;
       G4cout<<"target E_kin: "<<targetParticle.GetKineticEnergy()/GeV<<G4endl;
       G4cout<<"target mass: "<<targetParticle.GetMass()/GeV<<G4endl;
@@ -2250,92 +2147,83 @@ using namespace CLHEP;
       G4cout<<"current mass: "<<currentParticle.GetMass()/GeV<<G4endl;
       G4cout<<currentParticle.GetDefinition()->GetParticleName()<<G4endl;
       */
-      G4double pf = cmEnergy*cmEnergy + targetMass*targetMass - currentMass*currentMass;
-      pf = pf*pf - 4*cmEnergy*cmEnergy*targetMass*targetMass;
-      //      G4cout << "pf: " << pf<< G4endl;
-      
-      if( pf <= 0.)// 0.001 )
-      {
-        for(G4int i=0; i<vecLen; i++) delete vec[i];
-        vecLen = 0;
-	throw G4HadronicException(__FILE__, __LINE__, "FullModelReactionDynamics::TwoBody: pf is too small ");
-      }
-      
-      pf = std::sqrt( pf ) / ( 2.0*cmEnergy );
-      //
-      // Set beam and target in centre of mass system
-      //
-      G4ReactionProduct pseudoParticle[3];
-      pseudoParticle[0].SetMass( currentMass*GeV );
-      pseudoParticle[0].SetTotalEnergy( etCurrent*GeV );
-      pseudoParticle[0].SetMomentum( 0.0, 0.0, pCurrent*GeV );
-      
-      pseudoParticle[1].SetMomentum( 0.0, 0.0, 0.0 );
-      pseudoParticle[1].SetMass( targetMass*GeV );
-      pseudoParticle[1].SetKineticEnergy( 0.0 );
-      //
-      // Transform into centre of mass system
-      //
-      pseudoParticle[2] = pseudoParticle[0] + pseudoParticle[1];
-      pseudoParticle[0].Lorentz( pseudoParticle[0], pseudoParticle[2] );
-      pseudoParticle[1].Lorentz( pseudoParticle[1], pseudoParticle[2] );
-      //
-      // Set final state masses and energies in centre of mass system
-      //
-      currentParticle.SetTotalEnergy( std::sqrt(pf*pf+currentMass*currentMass)*GeV );
-      targetParticle.SetTotalEnergy( std::sqrt(pf*pf+targetMass*targetMass)*GeV );
-      //
-      // Set |t| and |tmin|
-      //
-      const G4double cb = 0.01;
-      const G4double b1 = 4.225;
-      const G4double b2 = 1.795;
-      //
-      // Calculate slope b for elastic scattering on proton/neutron
-      //
-      G4double b = std::max( cb, b1+b2*std::log(pOriginal) );     
-      //      G4double b = std::max( cb, b1+b2*std::log(ptemp) );     
-      G4double btrang = b * 4.0 * pf * pseudoParticle[0].GetMomentum().mag()/GeV;
-      
-      G4double exindt = -1.0;
-      exindt += std::exp(std::max(-btrang,expxl));
-      //
-      // Calculate sqr(std::sin(teta/2.) and std::cos(teta), set azimuth angle phi
-      //
-      G4double ctet = 1.0 + 2*std::log( 1.0+G4UniformRand()*exindt ) / btrang;
-      if( std::fabs(ctet) > 1.0 )ctet > 0.0 ? ctet = 1.0 : ctet = -1.0;
-      G4double stet = std::sqrt( (1.0-ctet)*(1.0+ctet) );
-      G4double phi = twopi * G4UniformRand();
-      //
-      // Calculate final state momenta in centre of mass system
-      //
-      if(
-	targetParticle.GetDefinition() == aKaonMinus ||
-	targetParticle.GetDefinition() == aKaonZeroL ||
-	targetParticle.GetDefinition() == aKaonZeroS ||
-	targetParticle.GetDefinition() == aKaonPlus ||
-	targetParticle.GetDefinition() == aPiMinus ||
-	targetParticle.GetDefinition() == aPiZero ||
-	targetParticle.GetDefinition() == aPiPlus )
-      {
-        currentParticle.SetMomentum( -pf*stet*std::sin(phi)*GeV,
-                                     -pf*stet*std::cos(phi)*GeV,
-                                     -pf*ctet*GeV );
-      }
-      else
-      {
-        currentParticle.SetMomentum( pf*stet*std::sin(phi)*GeV,
-                                     pf*stet*std::cos(phi)*GeV,
-                                     pf*ctet*GeV );
-      }
-      targetParticle.SetMomentum( currentParticle.GetMomentum() * (-1.0) );
-      //
-      // Transform into lab system
-      //
-      currentParticle.Lorentz( currentParticle, pseudoParticle[1] );
-      targetParticle.Lorentz( targetParticle, pseudoParticle[1] );
+    G4double pf = cmEnergy * cmEnergy + targetMass * targetMass - currentMass * currentMass;
+    pf = pf * pf - 4 * cmEnergy * cmEnergy * targetMass * targetMass;
+    //      G4cout << "pf: " << pf<< G4endl;
 
-      /*
+    if (pf <= 0.)  // 0.001 )
+    {
+      for (G4int i = 0; i < vecLen; i++)
+        delete vec[i];
+      vecLen = 0;
+      throw G4HadronicException(__FILE__, __LINE__, "FullModelReactionDynamics::TwoBody: pf is too small ");
+    }
+
+    pf = std::sqrt(pf) / (2.0 * cmEnergy);
+    //
+    // Set beam and target in centre of mass system
+    //
+    G4ReactionProduct pseudoParticle[3];
+    pseudoParticle[0].SetMass(currentMass * GeV);
+    pseudoParticle[0].SetTotalEnergy(etCurrent * GeV);
+    pseudoParticle[0].SetMomentum(0.0, 0.0, pCurrent * GeV);
+
+    pseudoParticle[1].SetMomentum(0.0, 0.0, 0.0);
+    pseudoParticle[1].SetMass(targetMass * GeV);
+    pseudoParticle[1].SetKineticEnergy(0.0);
+    //
+    // Transform into centre of mass system
+    //
+    pseudoParticle[2] = pseudoParticle[0] + pseudoParticle[1];
+    pseudoParticle[0].Lorentz(pseudoParticle[0], pseudoParticle[2]);
+    pseudoParticle[1].Lorentz(pseudoParticle[1], pseudoParticle[2]);
+    //
+    // Set final state masses and energies in centre of mass system
+    //
+    currentParticle.SetTotalEnergy(std::sqrt(pf * pf + currentMass * currentMass) * GeV);
+    targetParticle.SetTotalEnergy(std::sqrt(pf * pf + targetMass * targetMass) * GeV);
+    //
+    // Set |t| and |tmin|
+    //
+    const G4double cb = 0.01;
+    const G4double b1 = 4.225;
+    const G4double b2 = 1.795;
+    //
+    // Calculate slope b for elastic scattering on proton/neutron
+    //
+    G4double b = std::max(cb, b1 + b2 * std::log(pOriginal));
+    //      G4double b = std::max( cb, b1+b2*std::log(ptemp) );
+    G4double btrang = b * 4.0 * pf * pseudoParticle[0].GetMomentum().mag() / GeV;
+
+    G4double exindt = -1.0;
+    exindt += std::exp(std::max(-btrang, expxl));
+    //
+    // Calculate sqr(std::sin(teta/2.) and std::cos(teta), set azimuth angle phi
+    //
+    G4double ctet = 1.0 + 2 * std::log(1.0 + G4UniformRand() * exindt) / btrang;
+    if (std::fabs(ctet) > 1.0)
+      ctet > 0.0 ? ctet = 1.0 : ctet = -1.0;
+    G4double stet = std::sqrt((1.0 - ctet) * (1.0 + ctet));
+    G4double phi = twopi * G4UniformRand();
+    //
+    // Calculate final state momenta in centre of mass system
+    //
+    if (targetParticle.GetDefinition() == aKaonMinus || targetParticle.GetDefinition() == aKaonZeroL ||
+        targetParticle.GetDefinition() == aKaonZeroS || targetParticle.GetDefinition() == aKaonPlus ||
+        targetParticle.GetDefinition() == aPiMinus || targetParticle.GetDefinition() == aPiZero ||
+        targetParticle.GetDefinition() == aPiPlus) {
+      currentParticle.SetMomentum(-pf * stet * std::sin(phi) * GeV, -pf * stet * std::cos(phi) * GeV, -pf * ctet * GeV);
+    } else {
+      currentParticle.SetMomentum(pf * stet * std::sin(phi) * GeV, pf * stet * std::cos(phi) * GeV, pf * ctet * GeV);
+    }
+    targetParticle.SetMomentum(currentParticle.GetMomentum() * (-1.0));
+    //
+    // Transform into lab system
+    //
+    currentParticle.Lorentz(currentParticle, pseudoParticle[1]);
+    targetParticle.Lorentz(targetParticle, pseudoParticle[1]);
+
+    /*
       G4cout<<"Check 1"<<G4endl;
       G4cout<<"target E_kin: "<<targetParticle.GetKineticEnergy()<<G4endl;
       G4cout<<"target mass: "<<targetParticle.GetMass()<<G4endl;
@@ -2343,76 +2231,72 @@ using namespace CLHEP;
       G4cout<<"current mass: "<<currentParticle.GetMass()<<G4endl;
       */
 
-      Defs1( modifiedOriginal, currentParticle, targetParticle, vec, vecLen );
-      
-      G4double pp, pp1, ekin;
-      if( atomicWeight >= 1.5 )
-      {
-        const G4double cfa = 0.025*((atomicWeight-1.)/120.)*std::exp(-(atomicWeight-1.)/120.);
-        pp1 = currentParticle.GetMomentum().mag()/MeV;
-        if( pp1 >= 1.0 )
-        {
-          ekin = currentParticle.GetKineticEnergy()/MeV - cfa*(1.0+0.5*normal())*GeV;
-          ekin = std::max( 0.0001*GeV, ekin );
-          currentParticle.SetKineticEnergy( ekin*MeV );
-          pp = currentParticle.GetTotalMomentum()/MeV;
-          currentParticle.SetMomentum( currentParticle.GetMomentum() * (pp/pp1) );
-        }
-        pp1 = targetParticle.GetMomentum().mag()/MeV;
-        if( pp1 >= 1.0 )
-        {
-          ekin = targetParticle.GetKineticEnergy()/MeV - cfa*(1.0+normal()/2.)*GeV;
-          ekin = std::max( 0.0001*GeV, ekin );
-          targetParticle.SetKineticEnergy( ekin*MeV );
-          pp = targetParticle.GetTotalMomentum()/MeV;
-          targetParticle.SetMomentum( targetParticle.GetMomentum() * (pp/pp1) );
-        }
+    Defs1(modifiedOriginal, currentParticle, targetParticle, vec, vecLen);
+
+    G4double pp, pp1, ekin;
+    if (atomicWeight >= 1.5) {
+      const G4double cfa = 0.025 * ((atomicWeight - 1.) / 120.) * std::exp(-(atomicWeight - 1.) / 120.);
+      pp1 = currentParticle.GetMomentum().mag() / MeV;
+      if (pp1 >= 1.0) {
+        ekin = currentParticle.GetKineticEnergy() / MeV - cfa * (1.0 + 0.5 * normal()) * GeV;
+        ekin = std::max(0.0001 * GeV, ekin);
+        currentParticle.SetKineticEnergy(ekin * MeV);
+        pp = currentParticle.GetTotalMomentum() / MeV;
+        currentParticle.SetMomentum(currentParticle.GetMomentum() * (pp / pp1));
+      }
+      pp1 = targetParticle.GetMomentum().mag() / MeV;
+      if (pp1 >= 1.0) {
+        ekin = targetParticle.GetKineticEnergy() / MeV - cfa * (1.0 + normal() / 2.) * GeV;
+        ekin = std::max(0.0001 * GeV, ekin);
+        targetParticle.SetKineticEnergy(ekin * MeV);
+        pp = targetParticle.GetTotalMomentum() / MeV;
+        targetParticle.SetMomentum(targetParticle.GetMomentum() * (pp / pp1));
       }
     }
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    if( atomicWeight >= 1.5 )
-    {
-      // Add black track particles
-      //  the procedure is somewhat different than in TwoCluster and GenerateXandPt.
-      //  The reason is that we have to also simulate the nuclear reactions
-      //  at low energies like a(h,p)b, a(h,p p)b, a(h,n)b etc.
-      //
-      // npnb is number of proton/neutron black track particles
-      // ndta is the number of deuterons, tritons, and alphas produced
-      // epnb is the kinetic energy available for proton/neutron black track particles
-      // edta is the kinetic energy available for deuteron/triton/alpha particles
-      //
-      G4double epnb, edta;
-      G4int npnb=0, ndta=0;
-      
-      epnb = targetNucleus.GetPNBlackTrackEnergy();            // was enp1 in fortran code
-      edta = targetNucleus.GetDTABlackTrackEnergy();           // was enp3 in fortran code
-      const G4double pnCutOff = 0.0001;       // GeV
-      const G4double dtaCutOff = 0.0001;      // GeV
-      const G4double kineticMinimum = 0.0001;
-      const G4double kineticFactor = -0.010;
-      G4double sprob = 0.0; // sprob = probability of self-absorption in heavy molecules
-      if( epnb >= pnCutOff )
-      {
-        npnb = Poisson( epnb/0.02 );
-	/*
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  if (atomicWeight >= 1.5) {
+    // Add black track particles
+    //  the procedure is somewhat different than in TwoCluster and GenerateXandPt.
+    //  The reason is that we have to also simulate the nuclear reactions
+    //  at low energies like a(h,p)b, a(h,p p)b, a(h,n)b etc.
+    //
+    // npnb is number of proton/neutron black track particles
+    // ndta is the number of deuterons, tritons, and alphas produced
+    // epnb is the kinetic energy available for proton/neutron black track particles
+    // edta is the kinetic energy available for deuteron/triton/alpha particles
+    //
+    G4double epnb, edta;
+    G4int npnb = 0, ndta = 0;
+
+    epnb = targetNucleus.GetPNBlackTrackEnergy();   // was enp1 in fortran code
+    edta = targetNucleus.GetDTABlackTrackEnergy();  // was enp3 in fortran code
+    const G4double pnCutOff = 0.0001;               // GeV
+    const G4double dtaCutOff = 0.0001;              // GeV
+    const G4double kineticMinimum = 0.0001;
+    const G4double kineticFactor = -0.010;
+    G4double sprob = 0.0;  // sprob = probability of self-absorption in heavy molecules
+    if (epnb >= pnCutOff) {
+      npnb = Poisson(epnb / 0.02);
+      /*
 	G4cout<<"A couple of Poisson numbers:"<<G4endl;
 	for (int n=0;n!=10;n++) G4cout<<Poisson(epnb/0.02)<<", ";
 	G4cout<<G4endl;
 	*/
-        if( npnb > atomicWeight )npnb = G4int(atomicWeight);
-        if( (epnb > pnCutOff) && (npnb <= 0) )npnb = 1;
-        npnb = std::min( npnb, 127-vecLen );
-      }
-      if( edta >= dtaCutOff )
-      {
-        ndta = G4int(2.0 * std::log(atomicWeight));
-        ndta = std::min( ndta, 127-vecLen );
-      }
-      G4double spall = 0.0;
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+      if (npnb > atomicWeight)
+        npnb = G4int(atomicWeight);
+      if ((epnb > pnCutOff) && (npnb <= 0))
+        npnb = 1;
+      npnb = std::min(npnb, 127 - vecLen);
+    }
+    if (edta >= dtaCutOff) {
+      ndta = G4int(2.0 * std::log(atomicWeight));
+      ndta = std::min(ndta, 127 - vecLen);
+    }
+    G4double spall = 0.0;
+    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
 
-      /*
+    /*
       G4cout<<"Check 2"<<G4endl;
       G4cout<<"target E_kin: "<<targetParticle.GetKineticEnergy()<<G4endl;
       G4cout<<"target mass: "<<targetParticle.GetMass()<<G4endl;
@@ -2428,1449 +2312,1340 @@ using namespace CLHEP;
       G4cout<<"------------------------------------------------------------------------"<<G4endl;
       */
 
-      AddBlackTrackParticles( epnb, npnb, edta, ndta, sprob, kineticMinimum, kineticFactor,
-			      modifiedOriginal, spall, targetNucleus,
-                              vec, vecLen );
+    AddBlackTrackParticles(epnb,
+                           npnb,
+                           edta,
+                           ndta,
+                           sprob,
+                           kineticMinimum,
+                           kineticFactor,
+                           modifiedOriginal,
+                           spall,
+                           targetNucleus,
+                           vec,
+                           vecLen);
 
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    }
-    //
-    //  calculate time delay for nuclear reactions
-    //
-    if( (atomicWeight >= 1.5) && (atomicWeight <= 230.0) && (ekOriginal <= 0.2) )
-      currentParticle.SetTOF( 1.0-500.0*std::exp(-ekOriginal/0.04)*std::log(G4UniformRand()) );
-    else
-      currentParticle.SetTOF( 1.0 );
-    return;
-  }
- 
- G4double FullModelReactionDynamics::GenerateNBodyEvent(
-  const G4double totalEnergy,                // MeV
-  const G4bool constantCrossSection,
-  G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-  G4int &vecLen )
-  {
     // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    // derived from original FORTRAN code PHASP by H. Fesefeldt (02-Dec-1986)
-    // Returns the weight of the event
-    //
-    G4int i;
-    const G4double expxu =  82.;           // upper bound for arg. of exp
-    const G4double expxl = -expxu;         // lower bound for arg. of exp
-    if( vecLen < 2 )
-    {
-      G4cerr << "*** Error in FullModelReactionDynamics::GenerateNBodyEvent" << G4endl;
-      G4cerr << "    number of particles < 2" << G4endl;
-      G4cerr << "totalEnergy = " << totalEnergy << "MeV, vecLen = " << vecLen << G4endl;
-      return -1.0;
-    }
-    G4double mass[18];    // mass of each particle
-    G4double energy[18];  // total energy of each particle
-    G4double pcm[3][18];           // pcm is an array with 3 rows and vecLen columns    
-    G4double totalMass = 0.0;
-    G4double extraMass = 0;
-    G4double sm[18];
-    
-    for( i=0; i<vecLen; ++i )
-    {
-      mass[i] = vec[i]->GetMass()/GeV;
-      if(vec[i]->GetSide() == -2) extraMass+=vec[i]->GetMass()/GeV;
-      vec[i]->SetMomentum( 0.0, 0.0, 0.0 );
-      pcm[0][i] = 0.0;      // x-momentum of i-th particle
-      pcm[1][i] = 0.0;      // y-momentum of i-th particle
-      pcm[2][i] = 0.0;      // z-momentum of i-th particle
-      energy[i] = mass[i];  // total energy of i-th particle
-      totalMass += mass[i];
-      sm[i] = totalMass;
-    }
-    G4double totalE = totalEnergy/GeV;
-    if( totalMass > totalE )
-    {
-      return -1.0;
-    }
-    G4double kineticEnergy = totalE - totalMass;
-    G4double emm[18];
-    //G4double *emm = new G4double [vecLen];
-    emm[0] = mass[0];
-    emm[vecLen-1] = totalE;
-    if( vecLen > 2 )          // the random numbers are sorted
-    {
-      G4double ran[18];
-      for( i=0; i<vecLen; ++i )ran[i] = G4UniformRand();
-      for( i=0; i<vecLen-2; ++i )
-      {
-        for( G4int j=vecLen-2; j>i; --j )
-        {
-          if( ran[i] > ran[j] )
-          {
-            G4double temp = ran[i];
-            ran[i] = ran[j];
-            ran[j] = temp;
-          }
+  }
+  //
+  //  calculate time delay for nuclear reactions
+  //
+  if ((atomicWeight >= 1.5) && (atomicWeight <= 230.0) && (ekOriginal <= 0.2))
+    currentParticle.SetTOF(1.0 - 500.0 * std::exp(-ekOriginal / 0.04) * std::log(G4UniformRand()));
+  else
+    currentParticle.SetTOF(1.0);
+  return;
+}
+
+G4double FullModelReactionDynamics::GenerateNBodyEvent(const G4double totalEnergy,  // MeV
+                                                       const G4bool constantCrossSection,
+                                                       G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                                                       G4int &vecLen) {
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  // derived from original FORTRAN code PHASP by H. Fesefeldt (02-Dec-1986)
+  // Returns the weight of the event
+  //
+  G4int i;
+  const G4double expxu = 82.;     // upper bound for arg. of exp
+  const G4double expxl = -expxu;  // lower bound for arg. of exp
+  if (vecLen < 2) {
+    G4cerr << "*** Error in FullModelReactionDynamics::GenerateNBodyEvent" << G4endl;
+    G4cerr << "    number of particles < 2" << G4endl;
+    G4cerr << "totalEnergy = " << totalEnergy << "MeV, vecLen = " << vecLen << G4endl;
+    return -1.0;
+  }
+  G4double mass[18];    // mass of each particle
+  G4double energy[18];  // total energy of each particle
+  G4double pcm[3][18];  // pcm is an array with 3 rows and vecLen columns
+  G4double totalMass = 0.0;
+  G4double extraMass = 0;
+  G4double sm[18];
+
+  for (i = 0; i < vecLen; ++i) {
+    mass[i] = vec[i]->GetMass() / GeV;
+    if (vec[i]->GetSide() == -2)
+      extraMass += vec[i]->GetMass() / GeV;
+    vec[i]->SetMomentum(0.0, 0.0, 0.0);
+    pcm[0][i] = 0.0;      // x-momentum of i-th particle
+    pcm[1][i] = 0.0;      // y-momentum of i-th particle
+    pcm[2][i] = 0.0;      // z-momentum of i-th particle
+    energy[i] = mass[i];  // total energy of i-th particle
+    totalMass += mass[i];
+    sm[i] = totalMass;
+  }
+  G4double totalE = totalEnergy / GeV;
+  if (totalMass > totalE) {
+    return -1.0;
+  }
+  G4double kineticEnergy = totalE - totalMass;
+  G4double emm[18];
+  //G4double *emm = new G4double [vecLen];
+  emm[0] = mass[0];
+  emm[vecLen - 1] = totalE;
+  if (vecLen > 2)  // the random numbers are sorted
+  {
+    G4double ran[18];
+    for (i = 0; i < vecLen; ++i)
+      ran[i] = G4UniformRand();
+    for (i = 0; i < vecLen - 2; ++i) {
+      for (G4int j = vecLen - 2; j > i; --j) {
+        if (ran[i] > ran[j]) {
+          G4double temp = ran[i];
+          ran[i] = ran[j];
+          ran[j] = temp;
         }
       }
-      for( i=1; i<vecLen-1; ++i )emm[i] = ran[i-1]*kineticEnergy + sm[i];
     }
-    //   Weight is the sum of logarithms of terms instead of the product of terms
-    G4bool lzero = true;    
-    G4double wtmax = 0.0;
-    if( constantCrossSection )     // this is KGENEV=1 in PHASP
+    for (i = 1; i < vecLen - 1; ++i)
+      emm[i] = ran[i - 1] * kineticEnergy + sm[i];
+  }
+  //   Weight is the sum of logarithms of terms instead of the product of terms
+  G4bool lzero = true;
+  G4double wtmax = 0.0;
+  if (constantCrossSection)  // this is KGENEV=1 in PHASP
+  {
+    G4double emmax = kineticEnergy + mass[0];
+    G4double emmin = 0.0;
+    for (i = 1; i < vecLen; ++i) {
+      emmin += mass[i - 1];
+      emmax += mass[i];
+      G4double wtfc = 0.0;
+      if (emmax * emmax > 0.0) {
+        G4double arg = emmax * emmax +
+                       (emmin * emmin - mass[i] * mass[i]) * (emmin * emmin - mass[i] * mass[i]) / (emmax * emmax) -
+                       2.0 * (emmin * emmin + mass[i] * mass[i]);
+        if (arg > 0.0)
+          wtfc = 0.5 * std::sqrt(arg);
+      }
+      if (wtfc == 0.0) {
+        lzero = false;
+        break;
+      }
+      wtmax += std::log(wtfc);
+    }
+    if (lzero)
+      wtmax = -wtmax;
+    else
+      wtmax = expxu;
+  } else {
+    //   ffq(n) = pi*(2*pi)^(n-2)/(n-2)!
+    const G4double ffq[18] = {0.,
+                              3.141592,
+                              19.73921,
+                              62.01255,
+                              129.8788,
+                              204.0131,
+                              256.3704,
+                              268.4705,
+                              240.9780,
+                              189.2637,
+                              132.1308,
+                              83.0202,
+                              47.4210,
+                              24.8295,
+                              12.0006,
+                              5.3858,
+                              2.2560,
+                              0.8859};
+    wtmax = std::log(std::pow(kineticEnergy, vecLen - 2) * ffq[vecLen - 1] / totalE);
+  }
+  lzero = true;
+  G4double pd[50];
+  //G4double *pd = new G4double [vecLen-1];
+  for (i = 0; i < vecLen - 1; ++i) {
+    pd[i] = 0.0;
+    if (emm[i + 1] * emm[i + 1] > 0.0) {
+      G4double arg = emm[i + 1] * emm[i + 1] +
+                     (emm[i] * emm[i] - mass[i + 1] * mass[i + 1]) * (emm[i] * emm[i] - mass[i + 1] * mass[i + 1]) /
+                         (emm[i + 1] * emm[i + 1]) -
+                     2.0 * (emm[i] * emm[i] + mass[i + 1] * mass[i + 1]);
+      if (arg > 0.0)
+        pd[i] = 0.5 * std::sqrt(arg);
+    }
+    if (pd[i] <= 0.0)  //  changed from  ==  on 02 April 98
+      lzero = false;
+    else
+      wtmax += std::log(pd[i]);
+  }
+  G4double weight = 0.0;  // weight is returned by GenerateNBodyEvent
+  if (lzero)
+    weight = std::exp(std::max(std::min(wtmax, expxu), expxl));
+
+  G4double bang, cb, sb, s0, s1, s2, c, s, esys, a, b, gama, beta;
+  pcm[0][0] = 0.0;
+  pcm[1][0] = pd[0];
+  pcm[2][0] = 0.0;
+  for (i = 1; i < vecLen; ++i) {
+    pcm[0][i] = 0.0;
+    pcm[1][i] = -pd[i - 1];
+    pcm[2][i] = 0.0;
+    bang = twopi * G4UniformRand();
+    cb = std::cos(bang);
+    sb = std::sin(bang);
+    c = 2.0 * G4UniformRand() - 1.0;
+    s = std::sqrt(std::fabs(1.0 - c * c));
+    if (i < vecLen - 1) {
+      esys = std::sqrt(pd[i] * pd[i] + emm[i] * emm[i]);
+      beta = pd[i] / esys;
+      gama = esys / emm[i];
+      for (G4int j = 0; j <= i; ++j) {
+        s0 = pcm[0][j];
+        s1 = pcm[1][j];
+        s2 = pcm[2][j];
+        energy[j] = std::sqrt(s0 * s0 + s1 * s1 + s2 * s2 + mass[j] * mass[j]);
+        a = s0 * c - s1 * s;  //  rotation
+        pcm[1][j] = s0 * s + s1 * c;
+        b = pcm[2][j];
+        pcm[0][j] = a * cb - b * sb;
+        pcm[2][j] = a * sb + b * cb;
+        pcm[1][j] = gama * (pcm[1][j] + beta * energy[j]);
+      }
+    } else {
+      for (G4int j = 0; j <= i; ++j) {
+        s0 = pcm[0][j];
+        s1 = pcm[1][j];
+        s2 = pcm[2][j];
+        energy[j] = std::sqrt(s0 * s0 + s1 * s1 + s2 * s2 + mass[j] * mass[j]);
+        a = s0 * c - s1 * s;  //  rotation
+        pcm[1][j] = s0 * s + s1 * c;
+        b = pcm[2][j];
+        pcm[0][j] = a * cb - b * sb;
+        pcm[2][j] = a * sb + b * cb;
+      }
+    }
+  }
+  for (i = 0; i < vecLen; ++i) {
+    vec[i]->SetMomentum(pcm[0][i] * GeV, pcm[1][i] * GeV, pcm[2][i] * GeV);
+    vec[i]->SetTotalEnergy(energy[i] * GeV);
+  }
+  // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+  return weight;
+}
+
+G4double FullModelReactionDynamics::normal() {
+  G4double ran = -6.0;
+  for (G4int i = 0; i < 12; ++i)
+    ran += G4UniformRand();
+  return ran;
+}
+
+G4int FullModelReactionDynamics::Poisson(G4double x)  // generation of poisson distribution
+{
+  G4int iran;
+  G4double ran;
+
+  if (x > 9.9)  // use normal distribution with sigma^2 = <x>
+    iran = static_cast<G4int>(std::max(0.0, x + normal() * std::sqrt(x)));
+  else {
+    G4int mm = G4int(5.0 * x);
+    if (mm <= 0)  // for very small x try iran=1,2,3
     {
-      G4double emmax = kineticEnergy + mass[0];
-      G4double emmin = 0.0;
-      for( i=1; i<vecLen; ++i )
-      {
-        emmin += mass[i-1];
-        emmax += mass[i];
-        G4double wtfc = 0.0;
-        if( emmax*emmax > 0.0 )
-        {
-          G4double arg = emmax*emmax
-            + (emmin*emmin-mass[i]*mass[i])*(emmin*emmin-mass[i]*mass[i])/(emmax*emmax)
-            - 2.0*(emmin*emmin+mass[i]*mass[i]);
-          if( arg > 0.0 )wtfc = 0.5*std::sqrt( arg );
+      G4double p1 = x * std::exp(-x);
+      G4double p2 = x * p1 / 2.0;
+      G4double p3 = x * p2 / 3.0;
+      ran = G4UniformRand();
+      if (ran < p3)
+        iran = 3;
+      else if (ran < p2)  // this is original Geisha, it should be ran < p2+p3
+        iran = 2;
+      else if (ran < p1)  // should be ran < p1+p2+p3
+        iran = 1;
+      else
+        iran = 0;
+    } else {
+      iran = 0;
+      G4double r = std::exp(-x);
+      ran = G4UniformRand();
+      if (ran > r) {
+        G4double rrr;
+        G4double rr = r;
+        for (G4int i = 1; i <= mm; ++i) {
+          iran++;
+          if (i > 5)  // Stirling's formula for large numbers
+            rrr = std::exp(i * std::log(x) - (i + 0.5) * std::log((G4double)i) + i - 0.9189385);
+          else
+            rrr = std::pow(x, i) / Factorial(i);
+          rr += r * rrr;
+          if (ran <= rr)
+            break;
         }
-        if( wtfc == 0.0 )
+      }
+    }
+  }
+  return iran;
+}
+
+G4int FullModelReactionDynamics::Factorial(G4int n) {  // calculates factorial( n ) = n*(n-1)*(n-2)*...*1
+  G4int m = std::min(n, 10);
+  G4int result = 1;
+  if (m <= 1)
+    return result;
+  for (G4int i = 2; i <= m; ++i)
+    result *= i;
+  return result;
+}
+
+void FullModelReactionDynamics::Defs1(const G4ReactionProduct &modifiedOriginal,
+                                      G4ReactionProduct &currentParticle,
+                                      G4ReactionProduct &targetParticle,
+                                      G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                                      G4int &vecLen) {
+  const G4double pjx = modifiedOriginal.GetMomentum().x() / MeV;
+  const G4double pjy = modifiedOriginal.GetMomentum().y() / MeV;
+  const G4double pjz = modifiedOriginal.GetMomentum().z() / MeV;
+  const G4double p = modifiedOriginal.GetMomentum().mag() / MeV;
+  if (pjx * pjx + pjy * pjy > 0.0) {
+    G4double cost, sint, ph, cosp, sinp, pix, piy, piz;
+    cost = pjz / p;
+    sint = 0.5 * (std::sqrt(std::abs((1.0 - cost) * (1.0 + cost))) + std::sqrt(pjx * pjx + pjy * pjy) / p);
+    if (pjy < 0.0)
+      ph = 3 * halfpi;
+    else
+      ph = halfpi;
+    if (std::abs(pjx) > 0.001 * MeV)
+      ph = std::atan2(pjy, pjx);
+    cosp = std::cos(ph);
+    sinp = std::sin(ph);
+    pix = currentParticle.GetMomentum().x() / MeV;
+    piy = currentParticle.GetMomentum().y() / MeV;
+    piz = currentParticle.GetMomentum().z() / MeV;
+    currentParticle.SetMomentum(cost * cosp * pix * MeV - sinp * piy + sint * cosp * piz * MeV,
+                                cost * sinp * pix * MeV + cosp * piy + sint * sinp * piz * MeV,
+                                -sint * pix * MeV + cost * piz * MeV);
+    pix = targetParticle.GetMomentum().x() / MeV;
+    piy = targetParticle.GetMomentum().y() / MeV;
+    piz = targetParticle.GetMomentum().z() / MeV;
+    targetParticle.SetMomentum(cost * cosp * pix * MeV - sinp * piy + sint * cosp * piz * MeV,
+                               cost * sinp * pix * MeV + cosp * piy + sint * sinp * piz * MeV,
+                               -sint * pix * MeV + cost * piz * MeV);
+    for (G4int i = 0; i < vecLen; ++i) {
+      pix = vec[i]->GetMomentum().x() / MeV;
+      piy = vec[i]->GetMomentum().y() / MeV;
+      piz = vec[i]->GetMomentum().z() / MeV;
+      vec[i]->SetMomentum(cost * cosp * pix * MeV - sinp * piy + sint * cosp * piz * MeV,
+                          cost * sinp * pix * MeV + cosp * piy + sint * sinp * piz * MeV,
+                          -sint * pix * MeV + cost * piz * MeV);
+    }
+  } else {
+    if (pjz < 0.0) {
+      currentParticle.SetMomentum(-currentParticle.GetMomentum().z());
+      targetParticle.SetMomentum(-targetParticle.GetMomentum().z());
+      for (G4int i = 0; i < vecLen; ++i)
+        vec[i]->SetMomentum(-vec[i]->GetMomentum().z());
+    }
+  }
+}
+
+void FullModelReactionDynamics::Rotate(
+    const G4double numberofFinalStateNucleons,
+    const G4ThreeVector &temp,
+    const G4ReactionProduct &modifiedOriginal,  // Fermi motion & evap. effect included
+    const G4HadProjectile *originalIncident,    // original incident particle
+    const G4Nucleus &targetNucleus,
+    G4ReactionProduct &currentParticle,
+    G4ReactionProduct &targetParticle,
+    G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+    G4int &vecLen) {
+  // derived from original FORTRAN code in GENXPT and TWOCLU by H. Fesefeldt
+  //
+  //   Rotate in direction of z-axis, this does disturb in some way our
+  //    inclusive distributions, but it is necessary for momentum conservation
+  //
+  const G4double atomicWeight = targetNucleus.GetN_asInt();
+  const G4double logWeight = std::log(atomicWeight);
+
+  G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
+  G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
+  G4ParticleDefinition *aPiZero = G4PionZero::PionZero();
+
+  G4int i;
+  G4ThreeVector pseudoParticle[4];
+  for (i = 0; i < 4; ++i)
+    pseudoParticle[i].set(0, 0, 0);
+  pseudoParticle[0] = currentParticle.GetMomentum() + targetParticle.GetMomentum();
+  for (i = 0; i < vecLen; ++i)
+    pseudoParticle[0] = pseudoParticle[0] + (vec[i]->GetMomentum());
+  //
+  //  Some smearing in transverse direction from Fermi motion
+  //
+  G4float pp, pp1;
+  G4double alekw, p, rthnve, phinve;
+  G4double r1, r2, a1, ran1, ran2, xxh, exh, pxTemp, pyTemp, pzTemp;
+
+  r1 = twopi * G4UniformRand();
+  r2 = G4UniformRand();
+  a1 = std::sqrt(-2.0 * std::log(r2));
+  ran1 = a1 * std::sin(r1) * 0.020 * numberofFinalStateNucleons * GeV;
+  ran2 = a1 * std::cos(r1) * 0.020 * numberofFinalStateNucleons * GeV;
+  G4ThreeVector fermi(ran1, ran2, 0);
+
+  pseudoParticle[0] = pseudoParticle[0] + fermi;  // all particles + fermi
+  pseudoParticle[2] = temp;                       // original in cms system
+  pseudoParticle[3] = pseudoParticle[0];
+
+  pseudoParticle[1] = pseudoParticle[2].cross(pseudoParticle[3]);
+  G4double rotation = 2. * pi * G4UniformRand();
+  pseudoParticle[1] = pseudoParticle[1].rotate(rotation, pseudoParticle[3]);
+  pseudoParticle[2] = pseudoParticle[3].cross(pseudoParticle[1]);
+  for (G4int ii = 1; ii <= 3; ii++) {
+    p = pseudoParticle[ii].mag();
+    if (p == 0.0)
+      pseudoParticle[ii] = G4ThreeVector(0.0, 0.0, 0.0);
+    else
+      pseudoParticle[ii] = pseudoParticle[ii] * (1. / p);
+  }
+
+  pxTemp = pseudoParticle[1].dot(currentParticle.GetMomentum());
+  pyTemp = pseudoParticle[2].dot(currentParticle.GetMomentum());
+  pzTemp = pseudoParticle[3].dot(currentParticle.GetMomentum());
+  currentParticle.SetMomentum(pxTemp, pyTemp, pzTemp);
+
+  pxTemp = pseudoParticle[1].dot(targetParticle.GetMomentum());
+  pyTemp = pseudoParticle[2].dot(targetParticle.GetMomentum());
+  pzTemp = pseudoParticle[3].dot(targetParticle.GetMomentum());
+  targetParticle.SetMomentum(pxTemp, pyTemp, pzTemp);
+
+  for (i = 0; i < vecLen; ++i) {
+    pxTemp = pseudoParticle[1].dot(vec[i]->GetMomentum());
+    pyTemp = pseudoParticle[2].dot(vec[i]->GetMomentum());
+    pzTemp = pseudoParticle[3].dot(vec[i]->GetMomentum());
+    vec[i]->SetMomentum(pxTemp, pyTemp, pzTemp);
+  }
+  //
+  //  Rotate in direction of primary particle, subtract binding energies
+  //   and make some further corrections if required
+  //
+  Defs1(modifiedOriginal, currentParticle, targetParticle, vec, vecLen);
+  G4double ekin;
+  G4double dekin = 0.0;
+  G4double ek1 = 0.0;
+  G4int npions = 0;
+  if (atomicWeight >= 1.5)  // self-absorption in heavy molecules
+  {
+    // corrections for single particle spectra (shower particles)
+    //
+    const G4double alem[] = {1.40, 2.30, 2.70, 3.00, 3.40, 4.60, 7.00};
+    const G4double val0[] = {0.00, 0.40, 0.48, 0.51, 0.54, 0.60, 0.65};
+    alekw = std::log(originalIncident->GetKineticEnergy() / GeV);
+    exh = 1.0;
+    if (alekw > alem[0])  //   get energy bin
+    {
+      exh = val0[6];
+      for (G4int j = 1; j < 7; ++j) {
+        if (alekw < alem[j])  // use linear interpolation/extrapolation
         {
-          lzero = false;
+          G4double rcnve = (val0[j] - val0[j - 1]) / (alem[j] - alem[j - 1]);
+          exh = rcnve * alekw + val0[j - 1] - rcnve * alem[j - 1];
           break;
         }
-        wtmax += std::log( wtfc );
       }
-      if( lzero )
-        wtmax = -wtmax;
-      else
-        wtmax = expxu;
+      exh = 1.0 - exh;
     }
-    else
-    {
-      //   ffq(n) = pi*(2*pi)^(n-2)/(n-2)!
-      const G4double ffq[18] = { 0., 3.141592, 19.73921, 62.01255, 129.8788, 204.0131,
-                                 256.3704, 268.4705, 240.9780, 189.2637,
-                                 132.1308,  83.0202,  47.4210,  24.8295,
-                                 12.0006,   5.3858,   2.2560,   0.8859 };
-      wtmax = std::log( std::pow( kineticEnergy, vecLen-2 ) * ffq[vecLen-1] / totalE );
+    const G4double cfa = 0.025 * ((atomicWeight - 1.) / 120.) * std::exp(-(atomicWeight - 1.) / 120.);
+    ekin = currentParticle.GetKineticEnergy() / GeV - cfa * (1 + normal() / 2.0);
+    ekin = std::max(1.0e-6, ekin);
+    xxh = 1.0;
+    dekin += ekin * (1.0 - xxh);
+    ekin *= xxh;
+    currentParticle.SetKineticEnergy(ekin * GeV);
+    pp = currentParticle.GetTotalMomentum() / MeV;
+    pp1 = currentParticle.GetMomentum().mag() / MeV;
+    if (pp1 < 0.001 * MeV) {
+      rthnve = pi * G4UniformRand();
+      phinve = twopi * G4UniformRand();
+      currentParticle.SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                                  pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                                  pp * std::cos(rthnve) * MeV);
+    } else
+      currentParticle.SetMomentum(currentParticle.GetMomentum() * (pp / pp1));
+    ekin = targetParticle.GetKineticEnergy() / GeV - cfa * (1 + normal() / 2.0);
+    ekin = std::max(1.0e-6, ekin);
+    xxh = 1.0;
+    if (((modifiedOriginal.GetDefinition() == aPiPlus) || (modifiedOriginal.GetDefinition() == aPiMinus)) &&
+        (targetParticle.GetDefinition() == aPiZero) && (G4UniformRand() < logWeight))
+      xxh = exh;
+    dekin += ekin * (1.0 - xxh);
+    ekin *= xxh;
+    if ((targetParticle.GetDefinition() == aPiPlus) || (targetParticle.GetDefinition() == aPiZero) ||
+        (targetParticle.GetDefinition() == aPiMinus)) {
+      ++npions;
+      ek1 += ekin;
     }
-    lzero = true;
-    G4double pd[50];
-    //G4double *pd = new G4double [vecLen-1];
-    for( i=0; i<vecLen-1; ++i )
-    {
-      pd[i] = 0.0;
-      if( emm[i+1]*emm[i+1] > 0.0 )
-      {
-        G4double arg = emm[i+1]*emm[i+1]
-          + (emm[i]*emm[i]-mass[i+1]*mass[i+1])*(emm[i]*emm[i]-mass[i+1]*mass[i+1])
-            /(emm[i+1]*emm[i+1])
-          - 2.0*(emm[i]*emm[i]+mass[i+1]*mass[i+1]);
-        if( arg > 0.0 )pd[i] = 0.5*std::sqrt( arg );
-      }
-      if( pd[i] <= 0.0 )    //  changed from  ==  on 02 April 98
-        lzero = false;
-      else
-        wtmax += std::log( pd[i] );
-    }
-    G4double weight = 0.0;           // weight is returned by GenerateNBodyEvent
-    if( lzero )weight = std::exp( std::max(std::min(wtmax,expxu),expxl) );
-    
-    G4double bang, cb, sb, s0, s1, s2, c, s, esys, a, b, gama, beta;
-    pcm[0][0] = 0.0;
-    pcm[1][0] = pd[0];
-    pcm[2][0] = 0.0;
-    for( i=1; i<vecLen; ++i )
-    {
-      pcm[0][i] = 0.0;
-      pcm[1][i] = -pd[i-1];
-      pcm[2][i] = 0.0;
-      bang = twopi*G4UniformRand();
-      cb = std::cos(bang);
-      sb = std::sin(bang);
-      c = 2.0*G4UniformRand() - 1.0;
-      s = std::sqrt( std::fabs( 1.0-c*c ) );
-      if( i < vecLen-1 )
-      {
-        esys = std::sqrt(pd[i]*pd[i] + emm[i]*emm[i]);
-        beta = pd[i]/esys;
-        gama = esys/emm[i];
-        for( G4int j=0; j<=i; ++j )
-        {
-          s0 = pcm[0][j];
-          s1 = pcm[1][j];
-          s2 = pcm[2][j];
-          energy[j] = std::sqrt( s0*s0 + s1*s1 + s2*s2 + mass[j]*mass[j] );
-          a = s0*c - s1*s;                           //  rotation
-          pcm[1][j] = s0*s + s1*c;
-          b = pcm[2][j];
-          pcm[0][j] = a*cb - b*sb;
-          pcm[2][j] = a*sb + b*cb;
-          pcm[1][j] = gama*(pcm[1][j] + beta*energy[j]);
-        }
-      }
-      else
-      {
-        for( G4int j=0; j<=i; ++j )
-        {
-          s0 = pcm[0][j];
-          s1 = pcm[1][j];
-          s2 = pcm[2][j];
-          energy[j] = std::sqrt( s0*s0 + s1*s1 + s2*s2 + mass[j]*mass[j] );
-          a = s0*c - s1*s;                           //  rotation
-          pcm[1][j] = s0*s + s1*c;
-          b = pcm[2][j];
-          pcm[0][j] = a*cb - b*sb;
-          pcm[2][j] = a*sb + b*cb;
-        }
-      }
-    }
-    for( i=0; i<vecLen; ++i )
-    {
-      vec[i]->SetMomentum( pcm[0][i]*GeV, pcm[1][i]*GeV, pcm[2][i]*GeV );
-      vec[i]->SetTotalEnergy( energy[i]*GeV );
-    }
-    // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-    return weight;
-  }
- 
- G4double
-   FullModelReactionDynamics::normal()
-   {
-     G4double ran = -6.0;
-     for( G4int i=0; i<12; ++i )ran += G4UniformRand();
-     return ran;
-   }
- 
- G4int
-   FullModelReactionDynamics::Poisson( G4double x )  // generation of poisson distribution
-   {
-     G4int iran;
-     G4double ran;
-     
-     if( x > 9.9 )    // use normal distribution with sigma^2 = <x>
-       iran = static_cast<G4int>(std::max( 0.0, x+normal()*std::sqrt(x) ) );
-     else {
-      G4int mm = G4int(5.0*x);
-      if( mm <= 0 )   // for very small x try iran=1,2,3
-      {
-        G4double p1 = x*std::exp(-x);
-        G4double p2 = x*p1/2.0;
-        G4double p3 = x*p2/3.0;
-        ran = G4UniformRand();
-        if( ran < p3 )
-          iran = 3;
-        else if( ran < p2 )   // this is original Geisha, it should be ran < p2+p3
-          iran = 2;
-        else if( ran < p1 )   // should be ran < p1+p2+p3
-          iran = 1;
-        else
-          iran = 0;
-      }
-      else
-      {
-        iran = 0;
-        G4double r = std::exp(-x);
-        ran = G4UniformRand();
-        if( ran > r )
-        {
-          G4double rrr;
-          G4double rr = r;
-          for( G4int i=1; i<=mm; ++i )
-          {
-            iran++;
-            if( i > 5 )   // Stirling's formula for large numbers
-              rrr = std::exp(i*std::log(x)-(i+0.5)*std::log((G4double)i)+i-0.9189385);
-            else
-              rrr = std::pow(x,i)/Factorial(i);
-            rr += r*rrr;
-            if( ran <= rr )break;
-          }
-        }
-      }
-    }
-    return iran;
-  }
- 
- G4int
-   FullModelReactionDynamics::Factorial( G4int n )
-   {   // calculates factorial( n ) = n*(n-1)*(n-2)*...*1
-     G4int m = std::min(n,10);
-     G4int result = 1;
-     if( m <= 1 )return result;
-     for( G4int i=2; i<=m; ++i )result *= i;
-     return result;
-   }
- 
- void FullModelReactionDynamics::Defs1(
-   const G4ReactionProduct &modifiedOriginal,
-   G4ReactionProduct &currentParticle,
-   G4ReactionProduct &targetParticle,
-   G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-   G4int &vecLen )
-  {
-    const G4double pjx = modifiedOriginal.GetMomentum().x()/MeV;
-    const G4double pjy = modifiedOriginal.GetMomentum().y()/MeV;
-    const G4double pjz = modifiedOriginal.GetMomentum().z()/MeV;
-    const G4double p = modifiedOriginal.GetMomentum().mag()/MeV;
-    if( pjx*pjx+pjy*pjy > 0.0 )
-    {
-      G4double cost, sint, ph, cosp, sinp, pix, piy, piz;
-      cost = pjz/p;
-      sint = 0.5 * ( std::sqrt(std::abs((1.0-cost)*(1.0+cost))) + std::sqrt(pjx*pjx+pjy*pjy)/p );
-      if( pjy < 0.0 )
-        ph = 3*halfpi;
-      else
-        ph = halfpi;
-      if( std::abs( pjx ) > 0.001*MeV )ph = std::atan2(pjy,pjx);
-      cosp = std::cos(ph);
-      sinp = std::sin(ph);
-      pix = currentParticle.GetMomentum().x()/MeV;
-      piy = currentParticle.GetMomentum().y()/MeV;
-      piz = currentParticle.GetMomentum().z()/MeV;
-      currentParticle.SetMomentum( cost*cosp*pix*MeV - sinp*piy+sint*cosp*piz*MeV,
-                                   cost*sinp*pix*MeV + cosp*piy+sint*sinp*piz*MeV,
-                                   -sint*pix*MeV     + cost*piz*MeV );
-      pix = targetParticle.GetMomentum().x()/MeV;
-      piy = targetParticle.GetMomentum().y()/MeV;
-      piz = targetParticle.GetMomentum().z()/MeV;
-      targetParticle.SetMomentum( cost*cosp*pix*MeV - sinp*piy+sint*cosp*piz*MeV,
-                                  cost*sinp*pix*MeV + cosp*piy+sint*sinp*piz*MeV,
-                                  -sint*pix*MeV     + cost*piz*MeV );
-      for( G4int i=0; i<vecLen; ++i )
-      {
-        pix = vec[i]->GetMomentum().x()/MeV;
-        piy = vec[i]->GetMomentum().y()/MeV;
-        piz = vec[i]->GetMomentum().z()/MeV;
-        vec[i]->SetMomentum( cost*cosp*pix*MeV - sinp*piy+sint*cosp*piz*MeV,
-                             cost*sinp*pix*MeV + cosp*piy+sint*sinp*piz*MeV,
-                             -sint*pix*MeV     + cost*piz*MeV );
-      }
-    }
-    else
-    {
-      if( pjz < 0.0 )
-      {
-        currentParticle.SetMomentum( -currentParticle.GetMomentum().z() );
-        targetParticle.SetMomentum( -targetParticle.GetMomentum().z() );
-        for( G4int i=0; i<vecLen; ++i )
-          vec[i]->SetMomentum( -vec[i]->GetMomentum().z() );
-      }
-    }
-  }
- 
- void FullModelReactionDynamics::Rotate(
-  const G4double numberofFinalStateNucleons,
-  const G4ThreeVector &temp,
-  const G4ReactionProduct &modifiedOriginal, // Fermi motion & evap. effect included
-  const G4HadProjectile *originalIncident, // original incident particle
-  const G4Nucleus &targetNucleus,
-  G4ReactionProduct &currentParticle,
-  G4ReactionProduct &targetParticle,
-  G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-  G4int &vecLen )
-  {
-    // derived from original FORTRAN code in GENXPT and TWOCLU by H. Fesefeldt
-    //
-    //   Rotate in direction of z-axis, this does disturb in some way our
-    //    inclusive distributions, but it is necessary for momentum conservation
-    //
-    const G4double atomicWeight = targetNucleus.GetN_asInt();
-    const G4double logWeight = std::log(atomicWeight);
-    
-    G4ParticleDefinition *aPiMinus = G4PionMinus::PionMinus();
-    G4ParticleDefinition *aPiPlus = G4PionPlus::PionPlus();
-    G4ParticleDefinition *aPiZero = G4PionZero::PionZero();
-    
-    G4int i;
-    G4ThreeVector pseudoParticle[4];
-    for( i=0; i<4; ++i )pseudoParticle[i].set(0,0,0);
-    pseudoParticle[0] = currentParticle.GetMomentum()
-                        + targetParticle.GetMomentum();
-    for( i=0; i<vecLen; ++i )
-      pseudoParticle[0] = pseudoParticle[0] + (vec[i]->GetMomentum());
-    //
-    //  Some smearing in transverse direction from Fermi motion
-    //
-    G4float pp, pp1;
-    G4double alekw, p, rthnve, phinve;
-    G4double r1, r2, a1, ran1, ran2, xxh, exh, pxTemp, pyTemp, pzTemp;
-    
-    r1 = twopi*G4UniformRand();
-    r2 = G4UniformRand();
-    a1 = std::sqrt(-2.0*std::log(r2));
-    ran1 = a1*std::sin(r1)*0.020*numberofFinalStateNucleons*GeV;
-    ran2 = a1*std::cos(r1)*0.020*numberofFinalStateNucleons*GeV;
-    G4ThreeVector fermi(ran1, ran2, 0);
-
-    pseudoParticle[0] = pseudoParticle[0]+fermi; // all particles + fermi
-    pseudoParticle[2] = temp; // original in cms system
-    pseudoParticle[3] = pseudoParticle[0];
-    
-    pseudoParticle[1] = pseudoParticle[2].cross(pseudoParticle[3]);
-    G4double rotation = 2.*pi*G4UniformRand();
-    pseudoParticle[1] = pseudoParticle[1].rotate(rotation, pseudoParticle[3]);
-    pseudoParticle[2] = pseudoParticle[3].cross(pseudoParticle[1]);    
-    for(G4int ii=1; ii<=3; ii++)
-    { 
-      p = pseudoParticle[ii].mag();
-      if( p == 0.0 )
-        pseudoParticle[ii]= G4ThreeVector( 0.0, 0.0, 0.0 );
-      else
-        pseudoParticle[ii]= pseudoParticle[ii] * (1./p);
-    }
-    
-    pxTemp = pseudoParticle[1].dot(currentParticle.GetMomentum());
-    pyTemp = pseudoParticle[2].dot(currentParticle.GetMomentum());
-    pzTemp = pseudoParticle[3].dot(currentParticle.GetMomentum());
-    currentParticle.SetMomentum( pxTemp, pyTemp, pzTemp );
-    
-    pxTemp = pseudoParticle[1].dot(targetParticle.GetMomentum());
-    pyTemp = pseudoParticle[2].dot(targetParticle.GetMomentum());
-    pzTemp = pseudoParticle[3].dot(targetParticle.GetMomentum());
-    targetParticle.SetMomentum( pxTemp, pyTemp, pzTemp );
-    
-    for( i=0; i<vecLen; ++i )
-    {
-      pxTemp = pseudoParticle[1].dot(vec[i]->GetMomentum());
-      pyTemp = pseudoParticle[2].dot(vec[i]->GetMomentum());
-      pzTemp = pseudoParticle[3].dot(vec[i]->GetMomentum());
-      vec[i]->SetMomentum( pxTemp, pyTemp, pzTemp );
-    }
-    //
-    //  Rotate in direction of primary particle, subtract binding energies
-    //   and make some further corrections if required
-    //
-    Defs1( modifiedOriginal, currentParticle, targetParticle, vec, vecLen );
-    G4double ekin;
-    G4double dekin = 0.0;
-    G4double ek1 = 0.0;
-    G4int npions = 0;
-    if( atomicWeight >= 1.5 )            // self-absorption in heavy molecules
-    {
-      // corrections for single particle spectra (shower particles)
-      //
-      const G4double alem[] = { 1.40, 2.30, 2.70, 3.00, 3.40, 4.60, 7.00 };
-      const G4double val0[] = { 0.00, 0.40, 0.48, 0.51, 0.54, 0.60, 0.65 };
-      alekw = std::log( originalIncident->GetKineticEnergy()/GeV );
-      exh = 1.0;
-      if( alekw > alem[0] )   //   get energy bin
-      {
-        exh = val0[6];
-        for( G4int j=1; j<7; ++j )
-        {
-          if( alekw < alem[j] ) // use linear interpolation/extrapolation
-          {
-            G4double rcnve = (val0[j] - val0[j-1]) / (alem[j] - alem[j-1]);
-            exh = rcnve * alekw + val0[j-1] - rcnve * alem[j-1];
-            break;
-          }
-        }
-        exh = 1.0 - exh;
-      }
-      const G4double cfa = 0.025*((atomicWeight-1.)/120.)*std::exp(-(atomicWeight-1.)/120.);
-      ekin = currentParticle.GetKineticEnergy()/GeV - cfa*(1+normal()/2.0);
-      ekin = std::max( 1.0e-6, ekin );
+    targetParticle.SetKineticEnergy(ekin * GeV);
+    pp = targetParticle.GetTotalMomentum() / MeV;
+    pp1 = targetParticle.GetMomentum().mag() / MeV;
+    if (pp1 < 0.001 * MeV) {
+      rthnve = pi * G4UniformRand();
+      phinve = twopi * G4UniformRand();
+      targetParticle.SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                                 pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                                 pp * std::cos(rthnve) * MeV);
+    } else
+      targetParticle.SetMomentum(targetParticle.GetMomentum() * (pp / pp1));
+    for (i = 0; i < vecLen; ++i) {
+      ekin = vec[i]->GetKineticEnergy() / GeV - cfa * (1 + normal() / 2.0);
+      ekin = std::max(1.0e-6, ekin);
       xxh = 1.0;
-      dekin += ekin*(1.0-xxh);
+      if (((modifiedOriginal.GetDefinition() == aPiPlus) || (modifiedOriginal.GetDefinition() == aPiMinus)) &&
+          (vec[i]->GetDefinition() == aPiZero) && (G4UniformRand() < logWeight))
+        xxh = exh;
+      dekin += ekin * (1.0 - xxh);
       ekin *= xxh;
-      currentParticle.SetKineticEnergy( ekin*GeV );
-      pp = currentParticle.GetTotalMomentum()/MeV;
-      pp1 = currentParticle.GetMomentum().mag()/MeV;
-      if( pp1 < 0.001*MeV )
-      {
-        rthnve = pi*G4UniformRand();
-        phinve = twopi*G4UniformRand();
-        currentParticle.SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                     pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                     pp*std::cos(rthnve)*MeV );
-      }
-      else
-        currentParticle.SetMomentum( currentParticle.GetMomentum() * (pp/pp1) );
-      ekin = targetParticle.GetKineticEnergy()/GeV - cfa*(1+normal()/2.0);
-      ekin = std::max( 1.0e-6, ekin );
-      xxh = 1.0;
-      if( ( (modifiedOriginal.GetDefinition() == aPiPlus) ||
-            (modifiedOriginal.GetDefinition() == aPiMinus) ) &&
-          (targetParticle.GetDefinition() == aPiZero) &&
-          (G4UniformRand() < logWeight) )xxh = exh;
-      dekin += ekin*(1.0-xxh);
-      ekin *= xxh;
-      if( (targetParticle.GetDefinition() == aPiPlus) ||
-          (targetParticle.GetDefinition() == aPiZero) ||
-          (targetParticle.GetDefinition() == aPiMinus) )
-      {
+      if ((vec[i]->GetDefinition() == aPiPlus) || (vec[i]->GetDefinition() == aPiZero) ||
+          (vec[i]->GetDefinition() == aPiMinus)) {
         ++npions;
         ek1 += ekin;
       }
-      targetParticle.SetKineticEnergy( ekin*GeV );
-      pp = targetParticle.GetTotalMomentum()/MeV;
-      pp1 = targetParticle.GetMomentum().mag()/MeV;
-      if( pp1 < 0.001*MeV )
-      {
-        rthnve = pi*G4UniformRand();
-        phinve = twopi*G4UniformRand();
-        targetParticle.SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                    pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                    pp*std::cos(rthnve)*MeV );
-      }
-      else
-        targetParticle.SetMomentum( targetParticle.GetMomentum() * (pp/pp1) );
-      for( i=0; i<vecLen; ++i )
-      {
-        ekin = vec[i]->GetKineticEnergy()/GeV - cfa*(1+normal()/2.0);
-        ekin = std::max( 1.0e-6, ekin );
-        xxh = 1.0;
-        if( ( (modifiedOriginal.GetDefinition() == aPiPlus) ||
-              (modifiedOriginal.GetDefinition() == aPiMinus) ) &&
-            (vec[i]->GetDefinition() == aPiZero) &&
-            (G4UniformRand() < logWeight) )xxh = exh;
-        dekin += ekin*(1.0-xxh);
-        ekin *= xxh;
-        if( (vec[i]->GetDefinition() == aPiPlus) ||
-            (vec[i]->GetDefinition() == aPiZero) ||
-            (vec[i]->GetDefinition() == aPiMinus) )
-        {
-          ++npions;
-          ek1 += ekin;
-        }
-        vec[i]->SetKineticEnergy( ekin*GeV );
-        pp = vec[i]->GetTotalMomentum()/MeV;
-        pp1 = vec[i]->GetMomentum().mag()/MeV;
-        if( pp1 < 0.001*MeV )
-        {
-          rthnve = pi*G4UniformRand();
-          phinve = twopi*G4UniformRand();
-          vec[i]->SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                               pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                               pp*std::cos(rthnve)*MeV );
-        }
-        else
-          vec[i]->SetMomentum( vec[i]->GetMomentum() * (pp/pp1) );
-      }
+      vec[i]->SetKineticEnergy(ekin * GeV);
+      pp = vec[i]->GetTotalMomentum() / MeV;
+      pp1 = vec[i]->GetMomentum().mag() / MeV;
+      if (pp1 < 0.001 * MeV) {
+        rthnve = pi * G4UniformRand();
+        phinve = twopi * G4UniformRand();
+        vec[i]->SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                            pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                            pp * std::cos(rthnve) * MeV);
+      } else
+        vec[i]->SetMomentum(vec[i]->GetMomentum() * (pp / pp1));
     }
-    if( (ek1 != 0.0) && (npions > 0) )
-    {
-      dekin = 1.0 + dekin/ek1;
-      //
-      //  first do the incident particle
-      //
-      if( (currentParticle.GetDefinition() == aPiPlus) ||
-          (currentParticle.GetDefinition() == aPiZero) ||
-          (currentParticle.GetDefinition() == aPiMinus) )
-      {
-        currentParticle.SetKineticEnergy(
-         std::max( 0.001*MeV, dekin*currentParticle.GetKineticEnergy() ) );
-        pp = currentParticle.GetTotalMomentum()/MeV;
-        pp1 = currentParticle.GetMomentum().mag()/MeV;
-        if( pp1 < 0.001 )
-        {
-          rthnve = pi*G4UniformRand();
-          phinve = twopi*G4UniformRand();
-          currentParticle.SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                       pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                       pp*std::cos(rthnve)*MeV );
-        }
-        else
-          currentParticle.SetMomentum( currentParticle.GetMomentum() * (pp/pp1) );
-      }
-      for( i=0; i<vecLen; ++i )
-      {
-        if( (vec[i]->GetDefinition() == aPiPlus) ||
-            (vec[i]->GetDefinition() == aPiZero) ||
-            (vec[i]->GetDefinition() == aPiMinus) )
-        {
-          vec[i]->SetKineticEnergy( std::max( 0.001*MeV, dekin*vec[i]->GetKineticEnergy() ) );
-          pp = vec[i]->GetTotalMomentum()/MeV;
-          pp1 = vec[i]->GetMomentum().mag()/MeV;
-          if( pp1 < 0.001 )
-          {
-            rthnve = pi*G4UniformRand();
-            phinve = twopi*G4UniformRand();
-            vec[i]->SetMomentum( pp*std::sin(rthnve)*std::cos(phinve)*MeV,
-                                 pp*std::sin(rthnve)*std::sin(phinve)*MeV,
-                                 pp*std::cos(rthnve)*MeV );
-          }
-          else
-            vec[i]->SetMomentum( vec[i]->GetMomentum() * (pp/pp1) );
-        }
+  }
+  if ((ek1 != 0.0) && (npions > 0)) {
+    dekin = 1.0 + dekin / ek1;
+    //
+    //  first do the incident particle
+    //
+    if ((currentParticle.GetDefinition() == aPiPlus) || (currentParticle.GetDefinition() == aPiZero) ||
+        (currentParticle.GetDefinition() == aPiMinus)) {
+      currentParticle.SetKineticEnergy(std::max(0.001 * MeV, dekin * currentParticle.GetKineticEnergy()));
+      pp = currentParticle.GetTotalMomentum() / MeV;
+      pp1 = currentParticle.GetMomentum().mag() / MeV;
+      if (pp1 < 0.001) {
+        rthnve = pi * G4UniformRand();
+        phinve = twopi * G4UniformRand();
+        currentParticle.SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                                    pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                                    pp * std::cos(rthnve) * MeV);
+      } else
+        currentParticle.SetMomentum(currentParticle.GetMomentum() * (pp / pp1));
+    }
+    for (i = 0; i < vecLen; ++i) {
+      if ((vec[i]->GetDefinition() == aPiPlus) || (vec[i]->GetDefinition() == aPiZero) ||
+          (vec[i]->GetDefinition() == aPiMinus)) {
+        vec[i]->SetKineticEnergy(std::max(0.001 * MeV, dekin * vec[i]->GetKineticEnergy()));
+        pp = vec[i]->GetTotalMomentum() / MeV;
+        pp1 = vec[i]->GetMomentum().mag() / MeV;
+        if (pp1 < 0.001) {
+          rthnve = pi * G4UniformRand();
+          phinve = twopi * G4UniformRand();
+          vec[i]->SetMomentum(pp * std::sin(rthnve) * std::cos(phinve) * MeV,
+                              pp * std::sin(rthnve) * std::sin(phinve) * MeV,
+                              pp * std::cos(rthnve) * MeV);
+        } else
+          vec[i]->SetMomentum(vec[i]->GetMomentum() * (pp / pp1));
       }
     }
   }
- 
- void FullModelReactionDynamics::AddBlackTrackParticles(
-   const G4double epnb,            // GeV
-   const G4int npnb,
-   const G4double edta,            // GeV
-   const G4int ndta,
-   const G4double sprob,
-   const G4double kineticMinimum,  // GeV
-   const G4double kineticFactor,   // GeV
-   const G4ReactionProduct &modifiedOriginal,
-   G4double spall,
-   const G4Nucleus &targetNucleus,
-   G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-   G4int &vecLen )
-  {
-    // derived from original FORTRAN code in GENXPT and TWOCLU by H. Fesefeldt
-    //
-    // npnb is number of proton/neutron black track particles
-    // ndta is the number of deuterons, tritons, and alphas produced
-    // epnb is the kinetic energy available for proton/neutron black track particles
-    // edta is the kinetic energy available for deuteron/triton/alpha particles
-    //
-    
-    G4ParticleDefinition *aProton = G4Proton::Proton();
-    G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
-    G4ParticleDefinition *aDeuteron = G4Deuteron::Deuteron();
-    G4ParticleDefinition *aTriton = G4Triton::Triton();
-    G4ParticleDefinition *anAlpha = G4Alpha::Alpha();
-    
-    const G4double ekOriginal = modifiedOriginal.GetKineticEnergy()/MeV;
-    G4double atomicWeight = targetNucleus.GetN_asInt();
-    G4double atomicNumber = targetNucleus.GetZ_asInt();
-    
-    const G4double ika1 = 3.6;
-    const G4double ika2 = 35.56;
-    const G4double ika3 = 6.45;
-    const G4double sp1 = 1.066;
-    
-    G4int i;
-    G4double pp;
-    // G4double totalQ = 0;
-    G4double kinCreated = 0;
-    G4double cfa = 0.025*((atomicWeight-1.0)/120.0) * std::exp(-(atomicWeight-1.0)/120.0);
-    if( npnb > 0)  // first add protons and neutrons
-    {
-      G4double backwardKinetic = 0.0;
-      G4int local_npnb = npnb;
-      for( i=0; i<npnb; ++i ) if( G4UniformRand() < sprob ) local_npnb--;
-      G4double ekin = epnb/local_npnb;
-      
-      for( i=0; i<local_npnb; ++i )
-      {
-        G4ReactionProduct * p1 = new G4ReactionProduct();
-        if( backwardKinetic > epnb )
-        {
-          delete p1;
-          break;    
-        }
-        G4double ran = G4UniformRand();
-        G4double kinetic = -ekin*std::log(ran) - cfa*(1.0+0.5*normal());
-        if( kinetic < 0.0 )kinetic = -0.010*std::log(ran);
-        backwardKinetic += kinetic;
-        if( backwardKinetic > epnb )
-          kinetic = std::max( kineticMinimum, epnb-(backwardKinetic-kinetic) );
-        if( G4UniformRand() > (1.0-atomicNumber/atomicWeight) )
-          p1->SetDefinition( aProton );
-        else
-          p1->SetDefinition( aNeutron );
-        vec.SetElement( vecLen, p1 );
-        ++spall;
-        G4double cost = G4UniformRand() * 2.0 - 1.0;
-        G4double sint = std::sqrt(std::fabs(1.0-cost*cost));
-        G4double phi = twopi * G4UniformRand();
-        vec[vecLen]->SetNewlyAdded( true );
-        vec[vecLen]->SetKineticEnergy( kinetic*GeV );
-	kinCreated+=kinetic;
-        pp = vec[vecLen]->GetTotalMomentum()/MeV;
-        vec[vecLen]->SetMomentum( pp*sint*std::sin(phi)*MeV,
-                                    pp*sint*std::cos(phi)*MeV,
-                                    pp*cost*MeV );
-	vecLen++;
-	// DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      }
-      if( (atomicWeight >= 10.0) && (ekOriginal <= 2.0*GeV) )
-      {
-        G4double ekw = ekOriginal/GeV;
-        G4int ika, kk = 0;
-        if( ekw > 1.0 )ekw *= ekw;
-        ekw = std::max( 0.1, ekw );
-        ika = G4int(ika1*std::exp((atomicNumber*atomicNumber/atomicWeight-ika2)/ika3)/ekw);
-        if( ika > 0 )
-        {
-          for( i=(vecLen-1); i>=0; --i )
-          {
-            if( (vec[i]->GetDefinition() == aProton) && vec[i]->GetNewlyAdded() )
-            {
-              vec[i]->SetDefinitionAndUpdateE( aNeutron );  // modified 22-Oct-97
-              if( ++kk > ika )break;
-            }
-          }
-        }
-      }
-    }
-    if( ndta > 0 )    //  now, try to add deuterons, tritons and alphas
-    {
-      G4double backwardKinetic = 0.0;
-      G4int local_ndta=ndta;
-      for( i=0; i<ndta; ++i )if( G4UniformRand() < sprob )local_ndta--;
-      G4double ekin = edta/local_ndta;
+}
 
-      for( i=0; i<local_ndta; ++i )
-      {
-        G4ReactionProduct *p2 = new G4ReactionProduct();
-        if( backwardKinetic > edta )
-        {
-          delete p2;
-          break;
-        }
-        G4double ran = G4UniformRand();
-        G4double kinetic = -ekin*std::log(ran)-cfa*(1.+0.5*normal());
-        if( kinetic < 0.0 )kinetic = kineticFactor*std::log(ran);
-        backwardKinetic += kinetic;
-        if( backwardKinetic > edta )kinetic = edta-(backwardKinetic-kinetic);
-        if( kinetic < 0.0 )kinetic = kineticMinimum;
-        G4double cost = 2.0*G4UniformRand() - 1.0;
-        G4double sint = std::sqrt(std::max(0.0,(1.0-cost*cost)));
-        G4double phi = twopi*G4UniformRand();
-        ran = G4UniformRand();
-        if( ran <= 0.60 )
-          p2->SetDefinition( aDeuteron );
-        else if( ran <= 0.90 )
-          p2->SetDefinition( aTriton );
-        else
-          p2->SetDefinition( anAlpha );
-        spall += p2->GetMass()/GeV * sp1;
-        if( spall > atomicWeight )
-	{
-	  delete p2;
-	  break;
-	}
-        vec.SetElement( vecLen, p2 );
-        vec[vecLen]->SetNewlyAdded( true );
-        vec[vecLen]->SetKineticEnergy( kinetic*GeV );
-	kinCreated+=kinetic;
-        pp = vec[vecLen]->GetTotalMomentum()/MeV;
-        vec[vecLen++]->SetMomentum( pp*sint*std::sin(phi)*MeV,
-                                    pp*sint*std::cos(phi)*MeV,
-                                    pp*cost*MeV );
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      }
-    }
-    // G4double delta = epnb+edta - kinCreated;
-  }
- 
- void FullModelReactionDynamics::MomentumCheck(
-   const G4ReactionProduct &modifiedOriginal,
-   G4ReactionProduct &currentParticle,
-   G4ReactionProduct &targetParticle,
-   G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-   G4int &vecLen )
-  {
-    const G4double pOriginal = modifiedOriginal.GetTotalMomentum()/MeV;
-    G4double testMomentum = currentParticle.GetMomentum().mag()/MeV;
-    G4double pMass;
-    if( testMomentum >= pOriginal )
-    {
-      pMass = currentParticle.GetMass()/MeV;
-      currentParticle.SetTotalEnergy(
-       std::sqrt( pMass*pMass + pOriginal*pOriginal )*MeV );
-      currentParticle.SetMomentum(
-       currentParticle.GetMomentum() * (pOriginal/testMomentum) );
-    }
-    testMomentum = targetParticle.GetMomentum().mag()/MeV;
-    if( testMomentum >= pOriginal )
-    {
-      pMass = targetParticle.GetMass()/MeV;
-      targetParticle.SetTotalEnergy(
-       std::sqrt( pMass*pMass + pOriginal*pOriginal )*MeV );
-      targetParticle.SetMomentum(
-       targetParticle.GetMomentum() * (pOriginal/testMomentum) );
-    }
-    for( G4int i=0; i<vecLen; ++i )
-    {
-      testMomentum = vec[i]->GetMomentum().mag()/MeV;
-      if( testMomentum >= pOriginal )
-      {
-        pMass = vec[i]->GetMass()/MeV;
-        vec[i]->SetTotalEnergy(
-         std::sqrt( pMass*pMass + pOriginal*pOriginal )*MeV );
-        vec[i]->SetMomentum( vec[i]->GetMomentum() * (pOriginal/testMomentum) );
-      }
-    }
-  }
+void FullModelReactionDynamics::AddBlackTrackParticles(const G4double epnb,  // GeV
+                                                       const G4int npnb,
+                                                       const G4double edta,  // GeV
+                                                       const G4int ndta,
+                                                       const G4double sprob,
+                                                       const G4double kineticMinimum,  // GeV
+                                                       const G4double kineticFactor,   // GeV
+                                                       const G4ReactionProduct &modifiedOriginal,
+                                                       G4double spall,
+                                                       const G4Nucleus &targetNucleus,
+                                                       G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                                                       G4int &vecLen) {
+  // derived from original FORTRAN code in GENXPT and TWOCLU by H. Fesefeldt
+  //
+  // npnb is number of proton/neutron black track particles
+  // ndta is the number of deuterons, tritons, and alphas produced
+  // epnb is the kinetic energy available for proton/neutron black track particles
+  // edta is the kinetic energy available for deuteron/triton/alpha particles
+  //
 
- void FullModelReactionDynamics::ProduceStrangeParticlePairs(
-   G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-   G4int &vecLen,
-   const G4ReactionProduct &modifiedOriginal,
-   const G4DynamicParticle *originalTarget, 
-   G4ReactionProduct &currentParticle,
-   G4ReactionProduct &targetParticle,
-   G4bool &incidentHasChanged,
-   G4bool &targetHasChanged )
-  {
-    // derived from original FORTRAN code STPAIR by H. Fesefeldt (16-Dec-1987)
-    //
-    // Choose charge combinations K+ K-, K+ K0B, K0 K0B, K0 K-,
-    //                            K+ Y0, K0 Y+,  K0 Y-
-    // For antibaryon induced reactions half of the cross sections KB YB
-    // pairs are produced.  Charge is not conserved, no experimental data available
-    // for exclusive reactions, therefore some average behaviour assumed.
-    // The ratio L/SIGMA is taken as 3:1 (from experimental low energy)
-    //
-    if( vecLen == 0 )return;
-    //
-    // the following protects against annihilation processes
-    //
-    if( currentParticle.GetMass() == 0.0 || targetParticle.GetMass() == 0.0 )return;
-    
-    const G4double etOriginal = modifiedOriginal.GetTotalEnergy()/GeV;
-    const G4double mOriginal = modifiedOriginal.GetDefinition()->GetPDGMass()/GeV;
-    G4double targetMass = originalTarget->GetDefinition()->GetPDGMass()/GeV;
-    G4double centerofmassEnergy = std::sqrt( mOriginal*mOriginal +
-                                        targetMass*targetMass +
-                                        2.0*targetMass*etOriginal );  // GeV
-    G4double currentMass = currentParticle.GetMass()/GeV;
-    G4double availableEnergy = centerofmassEnergy-(targetMass+currentMass);
-    if( availableEnergy <= 1.0 )return;
-    
-    G4ParticleDefinition *aProton = G4Proton::Proton();
-    G4ParticleDefinition *anAntiProton = G4AntiProton::AntiProton();
-    G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
-    G4ParticleDefinition *anAntiNeutron = G4AntiNeutron::AntiNeutron();
-    G4ParticleDefinition *aSigmaMinus = G4SigmaMinus::SigmaMinus();
-    G4ParticleDefinition *aSigmaPlus = G4SigmaPlus::SigmaPlus();
-    G4ParticleDefinition *aSigmaZero = G4SigmaZero::SigmaZero();
-    G4ParticleDefinition *anAntiSigmaMinus = G4AntiSigmaMinus::AntiSigmaMinus();
-    G4ParticleDefinition *anAntiSigmaPlus = G4AntiSigmaPlus::AntiSigmaPlus();
-    G4ParticleDefinition *anAntiSigmaZero = G4AntiSigmaZero::AntiSigmaZero();
-    G4ParticleDefinition *aKaonMinus = G4KaonMinus::KaonMinus();
-    G4ParticleDefinition *aKaonPlus = G4KaonPlus::KaonPlus();
-    G4ParticleDefinition *aKaonZL = G4KaonZeroLong::KaonZeroLong();
-    G4ParticleDefinition *aKaonZS = G4KaonZeroShort::KaonZeroShort();
-    G4ParticleDefinition *aLambda = G4Lambda::Lambda();
-    G4ParticleDefinition *anAntiLambda = G4AntiLambda::AntiLambda();
-    
-    const G4double protonMass = aProton->GetPDGMass()/GeV;
-    const G4double sigmaMinusMass = aSigmaMinus->GetPDGMass()/GeV;
-    //
-    // determine the center of mass energy bin
-    //
-    const G4double avrs[] = {3.,4.,5.,6.,7.,8.,9.,10.,20.,30.,40.,50.};
+  G4ParticleDefinition *aProton = G4Proton::Proton();
+  G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
+  G4ParticleDefinition *aDeuteron = G4Deuteron::Deuteron();
+  G4ParticleDefinition *aTriton = G4Triton::Triton();
+  G4ParticleDefinition *anAlpha = G4Alpha::Alpha();
 
-    G4int ibin, i3, i4;
-    G4double avk, avy, avn, ran;
-    G4int i = 1;
-    while( (i<12) && (centerofmassEnergy>avrs[i]) )++i;
-    if( i == 12 )
-      ibin = 11;
-    else
-      ibin = i;
-    //
-    // the fortran code chooses a random replacement of produced kaons
-    //  but does not take into account charge conservation 
-    //
-    if( vecLen == 1 )  // we know that vecLen > 0
-    {
-      i3 = 0;
-      i4 = 1;   // note that we will be adding a new secondary particle in this case only
-    }
-    else               // otherwise  0 <= i3,i4 < vecLen
-    {
-      G4double ran = G4UniformRand();
-      while( ran == 1.0 )ran = G4UniformRand();
-      i4 = i3 = G4int( vecLen*ran );
-      while( i3 == i4 )
-      {
-        ran = G4UniformRand();
-        while( ran == 1.0 )ran = G4UniformRand();
-        i4 = G4int( vecLen*ran );
-      }
-    }
-    //
-    // use linear interpolation or extrapolation by y=centerofmassEnergy*x+b
-    //
-    const G4double avkkb[] = { 0.0015, 0.005, 0.012, 0.0285, 0.0525, 0.075,
-                               0.0975, 0.123, 0.28,  0.398,  0.495,  0.573 };
-    const G4double avky[] = { 0.005, 0.03,  0.064, 0.095, 0.115, 0.13,
-                              0.145, 0.155, 0.20,  0.205, 0.210, 0.212 };
-    const G4double avnnb[] = { 0.00001, 0.0001, 0.0006, 0.0025, 0.01, 0.02,
-                               0.04,    0.05,   0.12,   0.15,   0.18, 0.20 };
-    
-    avk = (std::log(avkkb[ibin])-std::log(avkkb[ibin-1]))*(centerofmassEnergy-avrs[ibin-1])
-      /(avrs[ibin]-avrs[ibin-1]) + std::log(avkkb[ibin-1]);
-    avk = std::exp(avk);
-    
-    avy = (std::log(avky[ibin])-std::log(avky[ibin-1]))*(centerofmassEnergy-avrs[ibin-1])
-      /(avrs[ibin]-avrs[ibin-1]) + std::log(avky[ibin-1]);
-    avy = std::exp(avy);
-    
-    avn = (std::log(avnnb[ibin])-std::log(avnnb[ibin-1]))*(centerofmassEnergy-avrs[ibin-1])
-      /(avrs[ibin]-avrs[ibin-1]) + std::log(avnnb[ibin-1]);
-    avn = std::exp(avn);
-    
-    if( avk+avy+avn <= 0.0 )return;
-    
-    if( currentMass < protonMass )avy /= 2.0;
-    if( targetMass < protonMass )avy = 0.0;
-    avy += avk+avn;
-    avk += avn;
-    ran = G4UniformRand();
-    if(  ran < avn )
-    {
-      if( availableEnergy < 2.0 )return;
-      if( vecLen == 1 )                              // add a new secondary
-      {
-        G4ReactionProduct *p1 = new G4ReactionProduct;
-        if( G4UniformRand() < 0.5 )
-        {
-          vec[0]->SetDefinition( aNeutron );
-          p1->SetDefinition( anAntiNeutron );
-          (G4UniformRand() < 0.5) ? p1->SetSide( -1 ) : p1->SetSide( 1 );
-	  vec[0]->SetMayBeKilled(false);
-	  p1->SetMayBeKilled(false);
-        }
-        else
-        {
-          vec[0]->SetDefinition( aProton );
-          p1->SetDefinition( anAntiProton );
-          (G4UniformRand() < 0.5) ? p1->SetSide( -1 ) : p1->SetSide( 1 );
-	  vec[0]->SetMayBeKilled(false);
-	  p1->SetMayBeKilled(false);
-        }
-        vec.SetElement( vecLen++, p1 );
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      }
-      else
-      {                                             // replace two secondaries
-        if( G4UniformRand() < 0.5 )
-        {
-          vec[i3]->SetDefinition( aNeutron );
-          vec[i4]->SetDefinition( anAntiNeutron );
-	  vec[i3]->SetMayBeKilled(false);
-	  vec[i4]->SetMayBeKilled(false);
-        }
-        else
-        {
-          vec[i3]->SetDefinition( aProton );
-          vec[i4]->SetDefinition( anAntiProton );
-	  vec[i3]->SetMayBeKilled(false);
-	  vec[i4]->SetMayBeKilled(false);
-        }
-      }
-    }
-    else if( ran < avk )
-    {
-      if( availableEnergy < 1.0 )return;
-      
-      const G4double kkb[] = { 0.2500, 0.3750, 0.5000, 0.5625, 0.6250,
-                               0.6875, 0.7500, 0.8750, 1.000 };
-      const G4int ipakkb1[] = { 10, 10, 10, 11, 11, 12, 12, 11, 12 };
-      const G4int ipakkb2[] = { 13, 11, 12, 11, 12, 11, 12, 13, 13 };
-      ran = G4UniformRand();
-      i = 0;
-      while( (i<9) && (ran>=kkb[i]) )++i;
-      if( i == 9 )return;
-      //
-      // ipakkb[] = { 10,13, 10,11, 10,12, 11,11, 11,12, 12,11, 12,12, 11,13, 12,13 };
-      // charge       +  -   +  0   +  0   0  0   0  0   0  0   0  0   0  -   0  -
-      //
-      switch( ipakkb1[i] )
-      {
-       case 10:
-         vec[i3]->SetDefinition( aKaonPlus );
-	 vec[i3]->SetMayBeKilled(false);
-         break;
-       case 11:
-         vec[i3]->SetDefinition( aKaonZS );
-	 vec[i3]->SetMayBeKilled(false);
-         break;
-       case 12:
-         vec[i3]->SetDefinition( aKaonZL );
-	 vec[i3]->SetMayBeKilled(false);
-         break;
-      }
-      if( vecLen == 1 )                          // add a secondary
-      {
-        G4ReactionProduct *p1 = new G4ReactionProduct;
-        switch( ipakkb2[i] )
-        {
-         case 11:
-           p1->SetDefinition( aKaonZS );
-	   p1->SetMayBeKilled(false);
-           break;
-         case 12:
-           p1->SetDefinition( aKaonZL );
-	   p1->SetMayBeKilled(false);
-           break;
-         case 13:
-           p1->SetDefinition( aKaonMinus );
-	   p1->SetMayBeKilled(false);
-           break;
-        }
-        (G4UniformRand() < 0.5) ? p1->SetSide( -1 ) : p1->SetSide( 1 );
-        vec.SetElement( vecLen++, p1 );
-      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
-      }
-      else                                        // replace
-      {
-        switch( ipakkb2[i] )
-        {
-         case 11:
-           vec[i4]->SetDefinition( aKaonZS );
-	   vec[i4]->SetMayBeKilled(false);
-           break;
-         case 12:
-           vec[i4]->SetDefinition( aKaonZL );
-	   vec[i4]->SetMayBeKilled(false);
-           break;
-         case 13:
-           vec[i4]->SetDefinition( aKaonMinus );
-	   vec[i4]->SetMayBeKilled(false);
-           break;
-        }
-      }
-    }
-    else if( ran < avy )
-    {
-      if( availableEnergy < 1.6 )return;
-      
-      const G4double ky[] = { 0.200, 0.300, 0.400, 0.550, 0.625, 0.700,
-                              0.800, 0.850, 0.900, 0.950, 0.975, 1.000 };
-      const G4int ipaky1[] = { 18, 18, 18, 20, 20, 20, 21, 21, 21, 22, 22, 22 };
-      const G4int ipaky2[] = { 10, 11, 12, 10, 11, 12, 10, 11, 12, 10, 11, 12 };
-      const G4int ipakyb1[] = { 19, 19, 19, 23, 23, 23, 24, 24, 24, 25, 25, 25 };
-      const G4int ipakyb2[] = { 13, 12, 11, 13, 12, 11, 13, 12, 11, 13, 12, 11 };
-      ran = G4UniformRand();
-      i = 0;
-      while( (i<12) && (ran>ky[i]) )++i;
-      if( i == 12 )return;
-      if( (currentMass<protonMass) || (G4UniformRand()<0.5) )
-      {
-        // ipaky[] = { 18,10, 18,11, 18,12, 20,10, 20,11, 20,12,
-        //             0  +   0  0   0  0   +  +   +  0   +  0
-        //
-        //             21,10, 21,11, 21,12, 22,10, 22,11, 22,12 }
-        //             0  +   0  0   0  0   -  +   -  0   -  0
-        switch( ipaky1[i] )
-        {
-         case 18:
-           targetParticle.SetDefinition( aLambda );
-           break;
-         case 20:
-           targetParticle.SetDefinition( aSigmaPlus );
-           break;
-         case 21:
-           targetParticle.SetDefinition( aSigmaZero );
-           break;
-         case 22:
-           targetParticle.SetDefinition( aSigmaMinus );
-           break;
-        }
-        targetHasChanged = true;
-        switch( ipaky2[i] )
-        {
-         case 10:
-           vec[i3]->SetDefinition( aKaonPlus ); 
-	   vec[i3]->SetMayBeKilled(false);
-           break;
-         case 11:
-           vec[i3]->SetDefinition( aKaonZS );
-	   vec[i3]->SetMayBeKilled(false);
-           break;
-         case 12:
-           vec[i3]->SetDefinition( aKaonZL );
-	   vec[i3]->SetMayBeKilled(false);
-           break;
-        }
-      }
-      else  // (currentMass >= protonMass) && (G4UniformRand() >= 0.5)
-      {
-        if( (currentParticle.GetDefinition() == anAntiProton) ||
-            (currentParticle.GetDefinition() == anAntiNeutron) ||
-            (currentParticle.GetDefinition() == anAntiLambda) ||
-            (currentMass > sigmaMinusMass) )
-        {
-          switch( ipakyb1[i] )
-          {
-           case 19:
-             currentParticle.SetDefinitionAndUpdateE( anAntiLambda );
-             break;
-           case 23:
-             currentParticle.SetDefinitionAndUpdateE( anAntiSigmaPlus );
-             break;
-           case 24:
-             currentParticle.SetDefinitionAndUpdateE( anAntiSigmaZero );
-             break;
-           case 25:
-             currentParticle.SetDefinitionAndUpdateE( anAntiSigmaMinus );
-             break;
-          }
-          incidentHasChanged = true;
-          switch( ipakyb2[i] )
-          {
-           case 11:
-             vec[i3]->SetDefinition( aKaonZS ); 
-	     vec[i3]->SetMayBeKilled(false);
-             break;
-           case 12:
-             vec[i3]->SetDefinition( aKaonZL );
-	     vec[i3]->SetMayBeKilled(false);
-             break;
-           case 13:
-             vec[i3]->SetDefinition( aKaonMinus );
-	     vec[i3]->SetMayBeKilled(false);
-             break;
-          }
-        }
-        else
-        {
-          switch( ipaky1[i] )
-          {
-           case 18:
-             currentParticle.SetDefinitionAndUpdateE( aLambda );
-             break;
-           case 20:
-             currentParticle.SetDefinitionAndUpdateE( aSigmaPlus );
-             break;
-           case 21:
-             currentParticle.SetDefinitionAndUpdateE( aSigmaZero );
-             break;
-           case 22:
-             currentParticle.SetDefinitionAndUpdateE( aSigmaMinus );
-             break;
-          }
-          incidentHasChanged = true;
-          switch( ipaky2[i] )
-          {
-           case 10:
-             vec[i3]->SetDefinition( aKaonPlus ); 
-	     vec[i3]->SetMayBeKilled(false);
-             break;
-           case 11:
-             vec[i3]->SetDefinition( aKaonZS );
-	     vec[i3]->SetMayBeKilled(false);
-             break;
-           case 12:
-             vec[i3]->SetDefinition( aKaonZL );
-	     vec[i3]->SetMayBeKilled(false);
-             break;
-          }
-        }
-      }
-    }
-    else return;
-    //
-    //  check the available energy
-    //   if there is not enough energy for kkb/ky pair production
-    //   then reduce the number of secondary particles 
-    //  NOTE:
-    //        the number of secondaries may have been changed
-    //        the incident and/or target particles may have changed
-    //        charge conservation is ignored (as well as strangness conservation)
-    //
-    currentMass = currentParticle.GetMass()/GeV;
-    targetMass = targetParticle.GetMass()/GeV;
-    
-    G4double energyCheck = centerofmassEnergy-(currentMass+targetMass);
-    for( i=0; i<vecLen; ++i )
-    {
-      energyCheck -= vec[i]->GetMass()/GeV;
-      if( energyCheck < 0.0 )      // chop off the secondary List
-      {
-        vecLen = std::max( 0, --i ); // looks like a memory leak @@@@@@@@@@@@
-	G4int j;
-	for(j=i; j<vecLen; j++) delete vec[j];
+  const G4double ekOriginal = modifiedOriginal.GetKineticEnergy() / MeV;
+  G4double atomicWeight = targetNucleus.GetN_asInt();
+  G4double atomicNumber = targetNucleus.GetZ_asInt();
+
+  const G4double ika1 = 3.6;
+  const G4double ika2 = 35.56;
+  const G4double ika3 = 6.45;
+  const G4double sp1 = 1.066;
+
+  G4int i;
+  G4double pp;
+  // G4double totalQ = 0;
+  G4double kinCreated = 0;
+  G4double cfa = 0.025 * ((atomicWeight - 1.0) / 120.0) * std::exp(-(atomicWeight - 1.0) / 120.0);
+  if (npnb > 0)  // first add protons and neutrons
+  {
+    G4double backwardKinetic = 0.0;
+    G4int local_npnb = npnb;
+    for (i = 0; i < npnb; ++i)
+      if (G4UniformRand() < sprob)
+        local_npnb--;
+    G4double ekin = epnb / local_npnb;
+
+    for (i = 0; i < local_npnb; ++i) {
+      G4ReactionProduct *p1 = new G4ReactionProduct();
+      if (backwardKinetic > epnb) {
+        delete p1;
         break;
       }
+      G4double ran = G4UniformRand();
+      G4double kinetic = -ekin * std::log(ran) - cfa * (1.0 + 0.5 * normal());
+      if (kinetic < 0.0)
+        kinetic = -0.010 * std::log(ran);
+      backwardKinetic += kinetic;
+      if (backwardKinetic > epnb)
+        kinetic = std::max(kineticMinimum, epnb - (backwardKinetic - kinetic));
+      if (G4UniformRand() > (1.0 - atomicNumber / atomicWeight))
+        p1->SetDefinition(aProton);
+      else
+        p1->SetDefinition(aNeutron);
+      vec.SetElement(vecLen, p1);
+      ++spall;
+      G4double cost = G4UniformRand() * 2.0 - 1.0;
+      G4double sint = std::sqrt(std::fabs(1.0 - cost * cost));
+      G4double phi = twopi * G4UniformRand();
+      vec[vecLen]->SetNewlyAdded(true);
+      vec[vecLen]->SetKineticEnergy(kinetic * GeV);
+      kinCreated += kinetic;
+      pp = vec[vecLen]->GetTotalMomentum() / MeV;
+      vec[vecLen]->SetMomentum(pp * sint * std::sin(phi) * MeV, pp * sint * std::cos(phi) * MeV, pp * cost * MeV);
+      vecLen++;
+      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
     }
-    return;
+    if ((atomicWeight >= 10.0) && (ekOriginal <= 2.0 * GeV)) {
+      G4double ekw = ekOriginal / GeV;
+      G4int ika, kk = 0;
+      if (ekw > 1.0)
+        ekw *= ekw;
+      ekw = std::max(0.1, ekw);
+      ika = G4int(ika1 * std::exp((atomicNumber * atomicNumber / atomicWeight - ika2) / ika3) / ekw);
+      if (ika > 0) {
+        for (i = (vecLen - 1); i >= 0; --i) {
+          if ((vec[i]->GetDefinition() == aProton) && vec[i]->GetNewlyAdded()) {
+            vec[i]->SetDefinitionAndUpdateE(aNeutron);  // modified 22-Oct-97
+            if (++kk > ika)
+              break;
+          }
+        }
+      }
+    }
   }
-
- void
-  FullModelReactionDynamics::NuclearReaction(
-   G4FastVector<G4ReactionProduct,4> &vec,
-   G4int &vecLen,
-   const G4HadProjectile *originalIncident,
-   const G4Nucleus &targetNucleus,
-   const G4double theAtomicMass,
-   const G4double *mass )
+  if (ndta > 0)  //  now, try to add deuterons, tritons and alphas
   {
-    // derived from original FORTRAN code NUCREC by H. Fesefeldt (12-Feb-1987)
-    //
-    // Nuclear reaction kinematics at low energies
-    //
-    G4ParticleDefinition *aGamma = G4Gamma::Gamma();
-    G4ParticleDefinition *aProton = G4Proton::Proton();
-    G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
-    G4ParticleDefinition *aDeuteron = G4Deuteron::Deuteron();
-    G4ParticleDefinition *aTriton = G4Triton::Triton();
-    G4ParticleDefinition *anAlpha = G4Alpha::Alpha();
-    
-    const G4double aProtonMass = aProton->GetPDGMass()/MeV;
-    const G4double aNeutronMass = aNeutron->GetPDGMass()/MeV;
-    const G4double aDeuteronMass = aDeuteron->GetPDGMass()/MeV;
-    const G4double aTritonMass = aTriton->GetPDGMass()/MeV;
-    const G4double anAlphaMass = anAlpha->GetPDGMass()/MeV;
+    G4double backwardKinetic = 0.0;
+    G4int local_ndta = ndta;
+    for (i = 0; i < ndta; ++i)
+      if (G4UniformRand() < sprob)
+        local_ndta--;
+    G4double ekin = edta / local_ndta;
 
-    G4ReactionProduct currentParticle;
-    currentParticle = *originalIncident;
-    //
-    // Set beam particle, take kinetic energy of current particle as the
-    // fundamental quantity.  Due to the difficult kinematic, all masses have to
-    // be assigned the best measured values
-    //
-    G4double p = currentParticle.GetTotalMomentum();
-    G4double pp = currentParticle.GetMomentum().mag();
-    if( pp <= 0.001*MeV )
-    {
-      G4double phinve = twopi*G4UniformRand();
-      G4double rthnve = std::acos( std::max( -1.0, std::min( 1.0, -1.0 + 2.0*G4UniformRand() ) ) );
-      currentParticle.SetMomentum( p*std::sin(rthnve)*std::cos(phinve),
-                                   p*std::sin(rthnve)*std::sin(phinve),
-                                   p*std::cos(rthnve) );
-    }
-    else
-      currentParticle.SetMomentum( currentParticle.GetMomentum() * (p/pp) );
-    //
-    // calculate Q-value of reactions
-    //
-    G4double currentKinetic = currentParticle.GetKineticEnergy()/MeV;
-    G4double currentMass = currentParticle.GetDefinition()->GetPDGMass()/MeV;
-    G4double qv = currentKinetic + theAtomicMass + currentMass;
-    
-    G4double qval[9];
-    qval[0] = qv - mass[0];
-    qval[1] = qv - mass[1] - aNeutronMass;
-    qval[2] = qv - mass[2] - aProtonMass;
-    qval[3] = qv - mass[3] - aDeuteronMass;
-    qval[4] = qv - mass[4] - aTritonMass;
-    qval[5] = qv - mass[5] - anAlphaMass;
-    qval[6] = qv - mass[6] - aNeutronMass - aNeutronMass;
-    qval[7] = qv - mass[7] - aNeutronMass - aProtonMass;
-    qval[8] = qv - mass[8] - aProtonMass  - aProtonMass;
-    
-    if( currentParticle.GetDefinition() == aNeutron )
-    {
-      const G4double A = targetNucleus.GetN_asInt();    // atomic weight
-      if( G4UniformRand() > ((A-1.0)/230.0)*((A-1.0)/230.0) )
-        qval[0] = 0.0;
-      if( G4UniformRand() >= currentKinetic/7.9254*A )
-        qval[2] = qval[3] = qval[4] = qval[5] = qval[8] = 0.0;
-    }
-    else
-      qval[0] = 0.0;
-    
-    G4int i;
-    qv = 0.0;
-    for( i=0; i<9; ++i )
-    {
-      if( mass[i] < 500.0*MeV )qval[i] = 0.0;
-      if( qval[i] < 0.0 )qval[i] = 0.0;
-      qv += qval[i];
-    }
-    G4double qv1 = 0.0;
-    G4double ran = G4UniformRand();
-    G4int index;
-    for( index=0; index<9; ++index )
-    {
-      if( qval[index] > 0.0 )
-      {
-        qv1 += qval[index]/qv;
-        if( ran <= qv1 )break;
+    for (i = 0; i < local_ndta; ++i) {
+      G4ReactionProduct *p2 = new G4ReactionProduct();
+      if (backwardKinetic > edta) {
+        delete p2;
+        break;
       }
-    }
-    if( index == 9 )  // loop continued to the end
-    {
-      throw G4HadronicException(__FILE__, __LINE__,
-           "FullModelReactionDynamics::NuclearReaction: inelastic reaction kinematically not possible");
-    }
-    G4double ke = currentParticle.GetKineticEnergy()/GeV;
-    G4int nt = 2;
-    if( (index>=6) || (G4UniformRand()<std::min(0.5,ke*10.0)) )nt = 3;
-    
-    G4ReactionProduct **v = new G4ReactionProduct * [3];
-    v[0] =  new G4ReactionProduct;
-    v[1] =  new G4ReactionProduct;
-    v[2] =  new G4ReactionProduct;
-    
-    v[0]->SetMass( mass[index]*MeV );
-    switch( index )
-    {
-     case 0:
-       v[1]->SetDefinition( aGamma );
-       v[2]->SetDefinition( aGamma );
-       break;
-     case 1:
-       v[1]->SetDefinition( aNeutron );
-       v[2]->SetDefinition( aGamma );
-       break;
-     case 2:
-       v[1]->SetDefinition( aProton );
-       v[2]->SetDefinition( aGamma );
-       break;
-     case 3:
-       v[1]->SetDefinition( aDeuteron );
-       v[2]->SetDefinition( aGamma );
-       break;
-     case 4:
-       v[1]->SetDefinition( aTriton );
-       v[2]->SetDefinition( aGamma );
-       break;
-     case 5:
-       v[1]->SetDefinition( anAlpha );
-       v[2]->SetDefinition( aGamma );
-       break;
-     case 6:
-       v[1]->SetDefinition( aNeutron );
-       v[2]->SetDefinition( aNeutron );
-       break;
-     case 7:
-       v[1]->SetDefinition( aNeutron );
-       v[2]->SetDefinition( aProton );
-       break;
-     case 8:
-       v[1]->SetDefinition( aProton );
-       v[2]->SetDefinition( aProton );
-       break;
-    }
-    //
-    // calculate centre of mass energy
-    //
-    G4ReactionProduct pseudo1;
-    pseudo1.SetMass( theAtomicMass*MeV );
-    pseudo1.SetTotalEnergy( theAtomicMass*MeV );
-    G4ReactionProduct pseudo2 = currentParticle + pseudo1;
-    pseudo2.SetMomentum( pseudo2.GetMomentum() * (-1.0) );
-    //
-    // use phase space routine in centre of mass system
-    //
-    G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> tempV;
-    tempV.Initialize( nt );
-    G4int tempLen = 0;
-    tempV.SetElement( tempLen++, v[0] );
-    tempV.SetElement( tempLen++, v[1] );
-    if( nt == 3 )tempV.SetElement( tempLen++, v[2] );
-    G4bool constantCrossSection = true;
-    GenerateNBodyEvent( pseudo2.GetMass()/MeV, constantCrossSection, tempV, tempLen );
-    v[0]->Lorentz( *v[0], pseudo2 );
-    v[1]->Lorentz( *v[1], pseudo2 );
-    if( nt == 3 )v[2]->Lorentz( *v[2], pseudo2 );
-    
-    G4bool particleIsDefined = false;
-    if( v[0]->GetMass()/MeV - aProtonMass < 0.1 )
-    {
-      v[0]->SetDefinition( aProton );
-      particleIsDefined = true;
-    }
-    else if( v[0]->GetMass()/MeV - aNeutronMass < 0.1 )
-    {
-      v[0]->SetDefinition( aNeutron );
-      particleIsDefined = true;
-    }
-    else if( v[0]->GetMass()/MeV - aDeuteronMass < 0.1 )
-    {
-      v[0]->SetDefinition( aDeuteron );
-      particleIsDefined = true;
-    }
-    else if( v[0]->GetMass()/MeV - aTritonMass < 0.1 )
-    {
-      v[0]->SetDefinition( aTriton );
-      particleIsDefined = true;
-    }
-    else if( v[0]->GetMass()/MeV - anAlphaMass < 0.1 )
-    {
-      v[0]->SetDefinition( anAlpha );
-      particleIsDefined = true;
-    }
-    currentParticle.SetKineticEnergy(
-     std::max( 0.001, currentParticle.GetKineticEnergy()/MeV ) );
-    p = currentParticle.GetTotalMomentum();
-    pp = currentParticle.GetMomentum().mag();
-    if( pp <= 0.001*MeV )
-    {
-      G4double phinve = twopi*G4UniformRand();
-      G4double rthnve = std::acos( std::max( -1.0, std::min( 1.0, -1.0 + 2.0*G4UniformRand() ) ) );
-      currentParticle.SetMomentum( p*std::sin(rthnve)*std::cos(phinve),
-                                   p*std::sin(rthnve)*std::sin(phinve),
-                                   p*std::cos(rthnve) );
-    }
-    else
-      currentParticle.SetMomentum( currentParticle.GetMomentum() * (p/pp) );
-    
-    if( particleIsDefined )
-    {
-      v[0]->SetKineticEnergy(
-       std::max( 0.001, 0.5*G4UniformRand()*v[0]->GetKineticEnergy()/MeV ) );
-      p = v[0]->GetTotalMomentum();
-      pp = v[0]->GetMomentum().mag();
-      if( pp <= 0.001*MeV )
-      {
-        G4double phinve = twopi*G4UniformRand();
-        G4double rthnve = std::acos( std::max(-1.0,std::min(1.0,-1.0+2.0*G4UniformRand())) );
-        v[0]->SetMomentum( p*std::sin(rthnve)*std::cos(phinve),
-                          p*std::sin(rthnve)*std::sin(phinve),
-                          p*std::cos(rthnve) );
+      G4double ran = G4UniformRand();
+      G4double kinetic = -ekin * std::log(ran) - cfa * (1. + 0.5 * normal());
+      if (kinetic < 0.0)
+        kinetic = kineticFactor * std::log(ran);
+      backwardKinetic += kinetic;
+      if (backwardKinetic > edta)
+        kinetic = edta - (backwardKinetic - kinetic);
+      if (kinetic < 0.0)
+        kinetic = kineticMinimum;
+      G4double cost = 2.0 * G4UniformRand() - 1.0;
+      G4double sint = std::sqrt(std::max(0.0, (1.0 - cost * cost)));
+      G4double phi = twopi * G4UniformRand();
+      ran = G4UniformRand();
+      if (ran <= 0.60)
+        p2->SetDefinition(aDeuteron);
+      else if (ran <= 0.90)
+        p2->SetDefinition(aTriton);
+      else
+        p2->SetDefinition(anAlpha);
+      spall += p2->GetMass() / GeV * sp1;
+      if (spall > atomicWeight) {
+        delete p2;
+        break;
       }
-      else
-        v[0]->SetMomentum( v[0]->GetMomentum() * (p/pp) );
+      vec.SetElement(vecLen, p2);
+      vec[vecLen]->SetNewlyAdded(true);
+      vec[vecLen]->SetKineticEnergy(kinetic * GeV);
+      kinCreated += kinetic;
+      pp = vec[vecLen]->GetTotalMomentum() / MeV;
+      vec[vecLen++]->SetMomentum(pp * sint * std::sin(phi) * MeV, pp * sint * std::cos(phi) * MeV, pp * cost * MeV);
+      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
     }
-    if( (v[1]->GetDefinition() == aDeuteron) ||
-        (v[1]->GetDefinition() == aTriton)   ||
-        (v[1]->GetDefinition() == anAlpha) ) 
-      v[1]->SetKineticEnergy(
-       std::max( 0.001, 0.5*G4UniformRand()*v[1]->GetKineticEnergy()/MeV ) );
-    else
-      v[1]->SetKineticEnergy( std::max( 0.001, v[1]->GetKineticEnergy()/MeV ) );
-    
-    p = v[1]->GetTotalMomentum();
-    pp = v[1]->GetMomentum().mag();
-    if( pp <= 0.001*MeV )
-    {
-      G4double phinve = twopi*G4UniformRand();
-      G4double rthnve = std::acos( std::max(-1.0,std::min(1.0,-1.0+2.0*G4UniformRand())) );
-      v[1]->SetMomentum( p*std::sin(rthnve)*std::cos(phinve),
-                        p*std::sin(rthnve)*std::sin(phinve),
-                        p*std::cos(rthnve) );
-    }
-    else
-      v[1]->SetMomentum( v[1]->GetMomentum() * (p/pp) );
-    
-    if( nt == 3 )
-    {
-      if( (v[2]->GetDefinition() == aDeuteron) ||
-          (v[2]->GetDefinition() == aTriton)   ||
-          (v[2]->GetDefinition() == anAlpha) ) 
-        v[2]->SetKineticEnergy(
-         std::max( 0.001, 0.5*G4UniformRand()*v[2]->GetKineticEnergy()/MeV ) );
-      else
-        v[2]->SetKineticEnergy( std::max( 0.001, v[2]->GetKineticEnergy()/MeV ) );
-      
-      p = v[2]->GetTotalMomentum();
-      pp = v[2]->GetMomentum().mag();
-      if( pp <= 0.001*MeV )
-      {
-        G4double phinve = twopi*G4UniformRand();
-        G4double rthnve = std::acos( std::max(-1.0,std::min(1.0,-1.0+2.0*G4UniformRand())) );
-        v[2]->SetMomentum( p*std::sin(rthnve)*std::cos(phinve),
-                          p*std::sin(rthnve)*std::sin(phinve),
-                          p*std::cos(rthnve) );
-      }
-      else
-        v[2]->SetMomentum( v[2]->GetMomentum() * (p/pp) );
-    }
-    G4int del;
-    for(del=0; del<vecLen; del++) delete vec[del];
-    vecLen = 0;
-    if( particleIsDefined )
-    {
-      vec.SetElement( vecLen++, v[0] );
-    }
-    else
-    {
-      delete v[0];
-    }
-    vec.SetElement( vecLen++, v[1] );
-    if( nt == 3 )
-    {
-      vec.SetElement( vecLen++, v[2] );
-    }
-    else
-    {
-      delete v[2];
-    }
-    delete [] v;
-    return;
   }
- 
- /* end of file */
- 
+  // G4double delta = epnb+edta - kinCreated;
+}
+
+void FullModelReactionDynamics::MomentumCheck(const G4ReactionProduct &modifiedOriginal,
+                                              G4ReactionProduct &currentParticle,
+                                              G4ReactionProduct &targetParticle,
+                                              G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                                              G4int &vecLen) {
+  const G4double pOriginal = modifiedOriginal.GetTotalMomentum() / MeV;
+  G4double testMomentum = currentParticle.GetMomentum().mag() / MeV;
+  G4double pMass;
+  if (testMomentum >= pOriginal) {
+    pMass = currentParticle.GetMass() / MeV;
+    currentParticle.SetTotalEnergy(std::sqrt(pMass * pMass + pOriginal * pOriginal) * MeV);
+    currentParticle.SetMomentum(currentParticle.GetMomentum() * (pOriginal / testMomentum));
+  }
+  testMomentum = targetParticle.GetMomentum().mag() / MeV;
+  if (testMomentum >= pOriginal) {
+    pMass = targetParticle.GetMass() / MeV;
+    targetParticle.SetTotalEnergy(std::sqrt(pMass * pMass + pOriginal * pOriginal) * MeV);
+    targetParticle.SetMomentum(targetParticle.GetMomentum() * (pOriginal / testMomentum));
+  }
+  for (G4int i = 0; i < vecLen; ++i) {
+    testMomentum = vec[i]->GetMomentum().mag() / MeV;
+    if (testMomentum >= pOriginal) {
+      pMass = vec[i]->GetMass() / MeV;
+      vec[i]->SetTotalEnergy(std::sqrt(pMass * pMass + pOriginal * pOriginal) * MeV);
+      vec[i]->SetMomentum(vec[i]->GetMomentum() * (pOriginal / testMomentum));
+    }
+  }
+}
+
+void FullModelReactionDynamics::ProduceStrangeParticlePairs(G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> &vec,
+                                                            G4int &vecLen,
+                                                            const G4ReactionProduct &modifiedOriginal,
+                                                            const G4DynamicParticle *originalTarget,
+                                                            G4ReactionProduct &currentParticle,
+                                                            G4ReactionProduct &targetParticle,
+                                                            G4bool &incidentHasChanged,
+                                                            G4bool &targetHasChanged) {
+  // derived from original FORTRAN code STPAIR by H. Fesefeldt (16-Dec-1987)
+  //
+  // Choose charge combinations K+ K-, K+ K0B, K0 K0B, K0 K-,
+  //                            K+ Y0, K0 Y+,  K0 Y-
+  // For antibaryon induced reactions half of the cross sections KB YB
+  // pairs are produced.  Charge is not conserved, no experimental data available
+  // for exclusive reactions, therefore some average behaviour assumed.
+  // The ratio L/SIGMA is taken as 3:1 (from experimental low energy)
+  //
+  if (vecLen == 0)
+    return;
+  //
+  // the following protects against annihilation processes
+  //
+  if (currentParticle.GetMass() == 0.0 || targetParticle.GetMass() == 0.0)
+    return;
+
+  const G4double etOriginal = modifiedOriginal.GetTotalEnergy() / GeV;
+  const G4double mOriginal = modifiedOriginal.GetDefinition()->GetPDGMass() / GeV;
+  G4double targetMass = originalTarget->GetDefinition()->GetPDGMass() / GeV;
+  G4double centerofmassEnergy =
+      std::sqrt(mOriginal * mOriginal + targetMass * targetMass + 2.0 * targetMass * etOriginal);  // GeV
+  G4double currentMass = currentParticle.GetMass() / GeV;
+  G4double availableEnergy = centerofmassEnergy - (targetMass + currentMass);
+  if (availableEnergy <= 1.0)
+    return;
+
+  G4ParticleDefinition *aProton = G4Proton::Proton();
+  G4ParticleDefinition *anAntiProton = G4AntiProton::AntiProton();
+  G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
+  G4ParticleDefinition *anAntiNeutron = G4AntiNeutron::AntiNeutron();
+  G4ParticleDefinition *aSigmaMinus = G4SigmaMinus::SigmaMinus();
+  G4ParticleDefinition *aSigmaPlus = G4SigmaPlus::SigmaPlus();
+  G4ParticleDefinition *aSigmaZero = G4SigmaZero::SigmaZero();
+  G4ParticleDefinition *anAntiSigmaMinus = G4AntiSigmaMinus::AntiSigmaMinus();
+  G4ParticleDefinition *anAntiSigmaPlus = G4AntiSigmaPlus::AntiSigmaPlus();
+  G4ParticleDefinition *anAntiSigmaZero = G4AntiSigmaZero::AntiSigmaZero();
+  G4ParticleDefinition *aKaonMinus = G4KaonMinus::KaonMinus();
+  G4ParticleDefinition *aKaonPlus = G4KaonPlus::KaonPlus();
+  G4ParticleDefinition *aKaonZL = G4KaonZeroLong::KaonZeroLong();
+  G4ParticleDefinition *aKaonZS = G4KaonZeroShort::KaonZeroShort();
+  G4ParticleDefinition *aLambda = G4Lambda::Lambda();
+  G4ParticleDefinition *anAntiLambda = G4AntiLambda::AntiLambda();
+
+  const G4double protonMass = aProton->GetPDGMass() / GeV;
+  const G4double sigmaMinusMass = aSigmaMinus->GetPDGMass() / GeV;
+  //
+  // determine the center of mass energy bin
+  //
+  const G4double avrs[] = {3., 4., 5., 6., 7., 8., 9., 10., 20., 30., 40., 50.};
+
+  G4int ibin, i3, i4;
+  G4double avk, avy, avn, ran;
+  G4int i = 1;
+  while ((i < 12) && (centerofmassEnergy > avrs[i]))
+    ++i;
+  if (i == 12)
+    ibin = 11;
+  else
+    ibin = i;
+  //
+  // the fortran code chooses a random replacement of produced kaons
+  //  but does not take into account charge conservation
+  //
+  if (vecLen == 1)  // we know that vecLen > 0
+  {
+    i3 = 0;
+    i4 = 1;  // note that we will be adding a new secondary particle in this case only
+  } else     // otherwise  0 <= i3,i4 < vecLen
+  {
+    G4double ran = G4UniformRand();
+    while (ran == 1.0)
+      ran = G4UniformRand();
+    i4 = i3 = G4int(vecLen * ran);
+    while (i3 == i4) {
+      ran = G4UniformRand();
+      while (ran == 1.0)
+        ran = G4UniformRand();
+      i4 = G4int(vecLen * ran);
+    }
+  }
+  //
+  // use linear interpolation or extrapolation by y=centerofmassEnergy*x+b
+  //
+  const G4double avkkb[] = {0.0015, 0.005, 0.012, 0.0285, 0.0525, 0.075, 0.0975, 0.123, 0.28, 0.398, 0.495, 0.573};
+  const G4double avky[] = {0.005, 0.03, 0.064, 0.095, 0.115, 0.13, 0.145, 0.155, 0.20, 0.205, 0.210, 0.212};
+  const G4double avnnb[] = {0.00001, 0.0001, 0.0006, 0.0025, 0.01, 0.02, 0.04, 0.05, 0.12, 0.15, 0.18, 0.20};
+
+  avk = (std::log(avkkb[ibin]) - std::log(avkkb[ibin - 1])) * (centerofmassEnergy - avrs[ibin - 1]) /
+            (avrs[ibin] - avrs[ibin - 1]) +
+        std::log(avkkb[ibin - 1]);
+  avk = std::exp(avk);
+
+  avy = (std::log(avky[ibin]) - std::log(avky[ibin - 1])) * (centerofmassEnergy - avrs[ibin - 1]) /
+            (avrs[ibin] - avrs[ibin - 1]) +
+        std::log(avky[ibin - 1]);
+  avy = std::exp(avy);
+
+  avn = (std::log(avnnb[ibin]) - std::log(avnnb[ibin - 1])) * (centerofmassEnergy - avrs[ibin - 1]) /
+            (avrs[ibin] - avrs[ibin - 1]) +
+        std::log(avnnb[ibin - 1]);
+  avn = std::exp(avn);
+
+  if (avk + avy + avn <= 0.0)
+    return;
+
+  if (currentMass < protonMass)
+    avy /= 2.0;
+  if (targetMass < protonMass)
+    avy = 0.0;
+  avy += avk + avn;
+  avk += avn;
+  ran = G4UniformRand();
+  if (ran < avn) {
+    if (availableEnergy < 2.0)
+      return;
+    if (vecLen == 1)  // add a new secondary
+    {
+      G4ReactionProduct *p1 = new G4ReactionProduct;
+      if (G4UniformRand() < 0.5) {
+        vec[0]->SetDefinition(aNeutron);
+        p1->SetDefinition(anAntiNeutron);
+        (G4UniformRand() < 0.5) ? p1->SetSide(-1) : p1->SetSide(1);
+        vec[0]->SetMayBeKilled(false);
+        p1->SetMayBeKilled(false);
+      } else {
+        vec[0]->SetDefinition(aProton);
+        p1->SetDefinition(anAntiProton);
+        (G4UniformRand() < 0.5) ? p1->SetSide(-1) : p1->SetSide(1);
+        vec[0]->SetMayBeKilled(false);
+        p1->SetMayBeKilled(false);
+      }
+      vec.SetElement(vecLen++, p1);
+      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    } else {  // replace two secondaries
+      if (G4UniformRand() < 0.5) {
+        vec[i3]->SetDefinition(aNeutron);
+        vec[i4]->SetDefinition(anAntiNeutron);
+        vec[i3]->SetMayBeKilled(false);
+        vec[i4]->SetMayBeKilled(false);
+      } else {
+        vec[i3]->SetDefinition(aProton);
+        vec[i4]->SetDefinition(anAntiProton);
+        vec[i3]->SetMayBeKilled(false);
+        vec[i4]->SetMayBeKilled(false);
+      }
+    }
+  } else if (ran < avk) {
+    if (availableEnergy < 1.0)
+      return;
+
+    const G4double kkb[] = {0.2500, 0.3750, 0.5000, 0.5625, 0.6250, 0.6875, 0.7500, 0.8750, 1.000};
+    const G4int ipakkb1[] = {10, 10, 10, 11, 11, 12, 12, 11, 12};
+    const G4int ipakkb2[] = {13, 11, 12, 11, 12, 11, 12, 13, 13};
+    ran = G4UniformRand();
+    i = 0;
+    while ((i < 9) && (ran >= kkb[i]))
+      ++i;
+    if (i == 9)
+      return;
+    //
+    // ipakkb[] = { 10,13, 10,11, 10,12, 11,11, 11,12, 12,11, 12,12, 11,13, 12,13 };
+    // charge       +  -   +  0   +  0   0  0   0  0   0  0   0  0   0  -   0  -
+    //
+    switch (ipakkb1[i]) {
+      case 10:
+        vec[i3]->SetDefinition(aKaonPlus);
+        vec[i3]->SetMayBeKilled(false);
+        break;
+      case 11:
+        vec[i3]->SetDefinition(aKaonZS);
+        vec[i3]->SetMayBeKilled(false);
+        break;
+      case 12:
+        vec[i3]->SetDefinition(aKaonZL);
+        vec[i3]->SetMayBeKilled(false);
+        break;
+    }
+    if (vecLen == 1)  // add a secondary
+    {
+      G4ReactionProduct *p1 = new G4ReactionProduct;
+      switch (ipakkb2[i]) {
+        case 11:
+          p1->SetDefinition(aKaonZS);
+          p1->SetMayBeKilled(false);
+          break;
+        case 12:
+          p1->SetDefinition(aKaonZL);
+          p1->SetMayBeKilled(false);
+          break;
+        case 13:
+          p1->SetDefinition(aKaonMinus);
+          p1->SetMayBeKilled(false);
+          break;
+      }
+      (G4UniformRand() < 0.5) ? p1->SetSide(-1) : p1->SetSide(1);
+      vec.SetElement(vecLen++, p1);
+      // DEBUGGING --> DumpFrames::DumpFrame(vec, vecLen);
+    } else  // replace
+    {
+      switch (ipakkb2[i]) {
+        case 11:
+          vec[i4]->SetDefinition(aKaonZS);
+          vec[i4]->SetMayBeKilled(false);
+          break;
+        case 12:
+          vec[i4]->SetDefinition(aKaonZL);
+          vec[i4]->SetMayBeKilled(false);
+          break;
+        case 13:
+          vec[i4]->SetDefinition(aKaonMinus);
+          vec[i4]->SetMayBeKilled(false);
+          break;
+      }
+    }
+  } else if (ran < avy) {
+    if (availableEnergy < 1.6)
+      return;
+
+    const G4double ky[] = {0.200, 0.300, 0.400, 0.550, 0.625, 0.700, 0.800, 0.850, 0.900, 0.950, 0.975, 1.000};
+    const G4int ipaky1[] = {18, 18, 18, 20, 20, 20, 21, 21, 21, 22, 22, 22};
+    const G4int ipaky2[] = {10, 11, 12, 10, 11, 12, 10, 11, 12, 10, 11, 12};
+    const G4int ipakyb1[] = {19, 19, 19, 23, 23, 23, 24, 24, 24, 25, 25, 25};
+    const G4int ipakyb2[] = {13, 12, 11, 13, 12, 11, 13, 12, 11, 13, 12, 11};
+    ran = G4UniformRand();
+    i = 0;
+    while ((i < 12) && (ran > ky[i]))
+      ++i;
+    if (i == 12)
+      return;
+    if ((currentMass < protonMass) || (G4UniformRand() < 0.5)) {
+      // ipaky[] = { 18,10, 18,11, 18,12, 20,10, 20,11, 20,12,
+      //             0  +   0  0   0  0   +  +   +  0   +  0
+      //
+      //             21,10, 21,11, 21,12, 22,10, 22,11, 22,12 }
+      //             0  +   0  0   0  0   -  +   -  0   -  0
+      switch (ipaky1[i]) {
+        case 18:
+          targetParticle.SetDefinition(aLambda);
+          break;
+        case 20:
+          targetParticle.SetDefinition(aSigmaPlus);
+          break;
+        case 21:
+          targetParticle.SetDefinition(aSigmaZero);
+          break;
+        case 22:
+          targetParticle.SetDefinition(aSigmaMinus);
+          break;
+      }
+      targetHasChanged = true;
+      switch (ipaky2[i]) {
+        case 10:
+          vec[i3]->SetDefinition(aKaonPlus);
+          vec[i3]->SetMayBeKilled(false);
+          break;
+        case 11:
+          vec[i3]->SetDefinition(aKaonZS);
+          vec[i3]->SetMayBeKilled(false);
+          break;
+        case 12:
+          vec[i3]->SetDefinition(aKaonZL);
+          vec[i3]->SetMayBeKilled(false);
+          break;
+      }
+    } else  // (currentMass >= protonMass) && (G4UniformRand() >= 0.5)
+    {
+      if ((currentParticle.GetDefinition() == anAntiProton) || (currentParticle.GetDefinition() == anAntiNeutron) ||
+          (currentParticle.GetDefinition() == anAntiLambda) || (currentMass > sigmaMinusMass)) {
+        switch (ipakyb1[i]) {
+          case 19:
+            currentParticle.SetDefinitionAndUpdateE(anAntiLambda);
+            break;
+          case 23:
+            currentParticle.SetDefinitionAndUpdateE(anAntiSigmaPlus);
+            break;
+          case 24:
+            currentParticle.SetDefinitionAndUpdateE(anAntiSigmaZero);
+            break;
+          case 25:
+            currentParticle.SetDefinitionAndUpdateE(anAntiSigmaMinus);
+            break;
+        }
+        incidentHasChanged = true;
+        switch (ipakyb2[i]) {
+          case 11:
+            vec[i3]->SetDefinition(aKaonZS);
+            vec[i3]->SetMayBeKilled(false);
+            break;
+          case 12:
+            vec[i3]->SetDefinition(aKaonZL);
+            vec[i3]->SetMayBeKilled(false);
+            break;
+          case 13:
+            vec[i3]->SetDefinition(aKaonMinus);
+            vec[i3]->SetMayBeKilled(false);
+            break;
+        }
+      } else {
+        switch (ipaky1[i]) {
+          case 18:
+            currentParticle.SetDefinitionAndUpdateE(aLambda);
+            break;
+          case 20:
+            currentParticle.SetDefinitionAndUpdateE(aSigmaPlus);
+            break;
+          case 21:
+            currentParticle.SetDefinitionAndUpdateE(aSigmaZero);
+            break;
+          case 22:
+            currentParticle.SetDefinitionAndUpdateE(aSigmaMinus);
+            break;
+        }
+        incidentHasChanged = true;
+        switch (ipaky2[i]) {
+          case 10:
+            vec[i3]->SetDefinition(aKaonPlus);
+            vec[i3]->SetMayBeKilled(false);
+            break;
+          case 11:
+            vec[i3]->SetDefinition(aKaonZS);
+            vec[i3]->SetMayBeKilled(false);
+            break;
+          case 12:
+            vec[i3]->SetDefinition(aKaonZL);
+            vec[i3]->SetMayBeKilled(false);
+            break;
+        }
+      }
+    }
+  } else
+    return;
+  //
+  //  check the available energy
+  //   if there is not enough energy for kkb/ky pair production
+  //   then reduce the number of secondary particles
+  //  NOTE:
+  //        the number of secondaries may have been changed
+  //        the incident and/or target particles may have changed
+  //        charge conservation is ignored (as well as strangness conservation)
+  //
+  currentMass = currentParticle.GetMass() / GeV;
+  targetMass = targetParticle.GetMass() / GeV;
+
+  G4double energyCheck = centerofmassEnergy - (currentMass + targetMass);
+  for (i = 0; i < vecLen; ++i) {
+    energyCheck -= vec[i]->GetMass() / GeV;
+    if (energyCheck < 0.0)  // chop off the secondary List
+    {
+      vecLen = std::max(0, --i);  // looks like a memory leak @@@@@@@@@@@@
+      G4int j;
+      for (j = i; j < vecLen; j++)
+        delete vec[j];
+      break;
+    }
+  }
+  return;
+}
+
+void FullModelReactionDynamics::NuclearReaction(G4FastVector<G4ReactionProduct, 4> &vec,
+                                                G4int &vecLen,
+                                                const G4HadProjectile *originalIncident,
+                                                const G4Nucleus &targetNucleus,
+                                                const G4double theAtomicMass,
+                                                const G4double *mass) {
+  // derived from original FORTRAN code NUCREC by H. Fesefeldt (12-Feb-1987)
+  //
+  // Nuclear reaction kinematics at low energies
+  //
+  G4ParticleDefinition *aGamma = G4Gamma::Gamma();
+  G4ParticleDefinition *aProton = G4Proton::Proton();
+  G4ParticleDefinition *aNeutron = G4Neutron::Neutron();
+  G4ParticleDefinition *aDeuteron = G4Deuteron::Deuteron();
+  G4ParticleDefinition *aTriton = G4Triton::Triton();
+  G4ParticleDefinition *anAlpha = G4Alpha::Alpha();
+
+  const G4double aProtonMass = aProton->GetPDGMass() / MeV;
+  const G4double aNeutronMass = aNeutron->GetPDGMass() / MeV;
+  const G4double aDeuteronMass = aDeuteron->GetPDGMass() / MeV;
+  const G4double aTritonMass = aTriton->GetPDGMass() / MeV;
+  const G4double anAlphaMass = anAlpha->GetPDGMass() / MeV;
+
+  G4ReactionProduct currentParticle;
+  currentParticle = *originalIncident;
+  //
+  // Set beam particle, take kinetic energy of current particle as the
+  // fundamental quantity.  Due to the difficult kinematic, all masses have to
+  // be assigned the best measured values
+  //
+  G4double p = currentParticle.GetTotalMomentum();
+  G4double pp = currentParticle.GetMomentum().mag();
+  if (pp <= 0.001 * MeV) {
+    G4double phinve = twopi * G4UniformRand();
+    G4double rthnve = std::acos(std::max(-1.0, std::min(1.0, -1.0 + 2.0 * G4UniformRand())));
+    currentParticle.SetMomentum(
+        p * std::sin(rthnve) * std::cos(phinve), p * std::sin(rthnve) * std::sin(phinve), p * std::cos(rthnve));
+  } else
+    currentParticle.SetMomentum(currentParticle.GetMomentum() * (p / pp));
+  //
+  // calculate Q-value of reactions
+  //
+  G4double currentKinetic = currentParticle.GetKineticEnergy() / MeV;
+  G4double currentMass = currentParticle.GetDefinition()->GetPDGMass() / MeV;
+  G4double qv = currentKinetic + theAtomicMass + currentMass;
+
+  G4double qval[9];
+  qval[0] = qv - mass[0];
+  qval[1] = qv - mass[1] - aNeutronMass;
+  qval[2] = qv - mass[2] - aProtonMass;
+  qval[3] = qv - mass[3] - aDeuteronMass;
+  qval[4] = qv - mass[4] - aTritonMass;
+  qval[5] = qv - mass[5] - anAlphaMass;
+  qval[6] = qv - mass[6] - aNeutronMass - aNeutronMass;
+  qval[7] = qv - mass[7] - aNeutronMass - aProtonMass;
+  qval[8] = qv - mass[8] - aProtonMass - aProtonMass;
+
+  if (currentParticle.GetDefinition() == aNeutron) {
+    const G4double A = targetNucleus.GetN_asInt();  // atomic weight
+    if (G4UniformRand() > ((A - 1.0) / 230.0) * ((A - 1.0) / 230.0))
+      qval[0] = 0.0;
+    if (G4UniformRand() >= currentKinetic / 7.9254 * A)
+      qval[2] = qval[3] = qval[4] = qval[5] = qval[8] = 0.0;
+  } else
+    qval[0] = 0.0;
+
+  G4int i;
+  qv = 0.0;
+  for (i = 0; i < 9; ++i) {
+    if (mass[i] < 500.0 * MeV)
+      qval[i] = 0.0;
+    if (qval[i] < 0.0)
+      qval[i] = 0.0;
+    qv += qval[i];
+  }
+  G4double qv1 = 0.0;
+  G4double ran = G4UniformRand();
+  G4int index;
+  for (index = 0; index < 9; ++index) {
+    if (qval[index] > 0.0) {
+      qv1 += qval[index] / qv;
+      if (ran <= qv1)
+        break;
+    }
+  }
+  if (index == 9)  // loop continued to the end
+  {
+    throw G4HadronicException(
+        __FILE__,
+        __LINE__,
+        "FullModelReactionDynamics::NuclearReaction: inelastic reaction kinematically not possible");
+  }
+  G4double ke = currentParticle.GetKineticEnergy() / GeV;
+  G4int nt = 2;
+  if ((index >= 6) || (G4UniformRand() < std::min(0.5, ke * 10.0)))
+    nt = 3;
+
+  G4ReactionProduct **v = new G4ReactionProduct *[3];
+  v[0] = new G4ReactionProduct;
+  v[1] = new G4ReactionProduct;
+  v[2] = new G4ReactionProduct;
+
+  v[0]->SetMass(mass[index] * MeV);
+  switch (index) {
+    case 0:
+      v[1]->SetDefinition(aGamma);
+      v[2]->SetDefinition(aGamma);
+      break;
+    case 1:
+      v[1]->SetDefinition(aNeutron);
+      v[2]->SetDefinition(aGamma);
+      break;
+    case 2:
+      v[1]->SetDefinition(aProton);
+      v[2]->SetDefinition(aGamma);
+      break;
+    case 3:
+      v[1]->SetDefinition(aDeuteron);
+      v[2]->SetDefinition(aGamma);
+      break;
+    case 4:
+      v[1]->SetDefinition(aTriton);
+      v[2]->SetDefinition(aGamma);
+      break;
+    case 5:
+      v[1]->SetDefinition(anAlpha);
+      v[2]->SetDefinition(aGamma);
+      break;
+    case 6:
+      v[1]->SetDefinition(aNeutron);
+      v[2]->SetDefinition(aNeutron);
+      break;
+    case 7:
+      v[1]->SetDefinition(aNeutron);
+      v[2]->SetDefinition(aProton);
+      break;
+    case 8:
+      v[1]->SetDefinition(aProton);
+      v[2]->SetDefinition(aProton);
+      break;
+  }
+  //
+  // calculate centre of mass energy
+  //
+  G4ReactionProduct pseudo1;
+  pseudo1.SetMass(theAtomicMass * MeV);
+  pseudo1.SetTotalEnergy(theAtomicMass * MeV);
+  G4ReactionProduct pseudo2 = currentParticle + pseudo1;
+  pseudo2.SetMomentum(pseudo2.GetMomentum() * (-1.0));
+  //
+  // use phase space routine in centre of mass system
+  //
+  G4FastVector<G4ReactionProduct, MYGHADLISTSIZE> tempV;
+  tempV.Initialize(nt);
+  G4int tempLen = 0;
+  tempV.SetElement(tempLen++, v[0]);
+  tempV.SetElement(tempLen++, v[1]);
+  if (nt == 3)
+    tempV.SetElement(tempLen++, v[2]);
+  G4bool constantCrossSection = true;
+  GenerateNBodyEvent(pseudo2.GetMass() / MeV, constantCrossSection, tempV, tempLen);
+  v[0]->Lorentz(*v[0], pseudo2);
+  v[1]->Lorentz(*v[1], pseudo2);
+  if (nt == 3)
+    v[2]->Lorentz(*v[2], pseudo2);
+
+  G4bool particleIsDefined = false;
+  if (v[0]->GetMass() / MeV - aProtonMass < 0.1) {
+    v[0]->SetDefinition(aProton);
+    particleIsDefined = true;
+  } else if (v[0]->GetMass() / MeV - aNeutronMass < 0.1) {
+    v[0]->SetDefinition(aNeutron);
+    particleIsDefined = true;
+  } else if (v[0]->GetMass() / MeV - aDeuteronMass < 0.1) {
+    v[0]->SetDefinition(aDeuteron);
+    particleIsDefined = true;
+  } else if (v[0]->GetMass() / MeV - aTritonMass < 0.1) {
+    v[0]->SetDefinition(aTriton);
+    particleIsDefined = true;
+  } else if (v[0]->GetMass() / MeV - anAlphaMass < 0.1) {
+    v[0]->SetDefinition(anAlpha);
+    particleIsDefined = true;
+  }
+  currentParticle.SetKineticEnergy(std::max(0.001, currentParticle.GetKineticEnergy() / MeV));
+  p = currentParticle.GetTotalMomentum();
+  pp = currentParticle.GetMomentum().mag();
+  if (pp <= 0.001 * MeV) {
+    G4double phinve = twopi * G4UniformRand();
+    G4double rthnve = std::acos(std::max(-1.0, std::min(1.0, -1.0 + 2.0 * G4UniformRand())));
+    currentParticle.SetMomentum(
+        p * std::sin(rthnve) * std::cos(phinve), p * std::sin(rthnve) * std::sin(phinve), p * std::cos(rthnve));
+  } else
+    currentParticle.SetMomentum(currentParticle.GetMomentum() * (p / pp));
+
+  if (particleIsDefined) {
+    v[0]->SetKineticEnergy(std::max(0.001, 0.5 * G4UniformRand() * v[0]->GetKineticEnergy() / MeV));
+    p = v[0]->GetTotalMomentum();
+    pp = v[0]->GetMomentum().mag();
+    if (pp <= 0.001 * MeV) {
+      G4double phinve = twopi * G4UniformRand();
+      G4double rthnve = std::acos(std::max(-1.0, std::min(1.0, -1.0 + 2.0 * G4UniformRand())));
+      v[0]->SetMomentum(
+          p * std::sin(rthnve) * std::cos(phinve), p * std::sin(rthnve) * std::sin(phinve), p * std::cos(rthnve));
+    } else
+      v[0]->SetMomentum(v[0]->GetMomentum() * (p / pp));
+  }
+  if ((v[1]->GetDefinition() == aDeuteron) || (v[1]->GetDefinition() == aTriton) || (v[1]->GetDefinition() == anAlpha))
+    v[1]->SetKineticEnergy(std::max(0.001, 0.5 * G4UniformRand() * v[1]->GetKineticEnergy() / MeV));
+  else
+    v[1]->SetKineticEnergy(std::max(0.001, v[1]->GetKineticEnergy() / MeV));
+
+  p = v[1]->GetTotalMomentum();
+  pp = v[1]->GetMomentum().mag();
+  if (pp <= 0.001 * MeV) {
+    G4double phinve = twopi * G4UniformRand();
+    G4double rthnve = std::acos(std::max(-1.0, std::min(1.0, -1.0 + 2.0 * G4UniformRand())));
+    v[1]->SetMomentum(
+        p * std::sin(rthnve) * std::cos(phinve), p * std::sin(rthnve) * std::sin(phinve), p * std::cos(rthnve));
+  } else
+    v[1]->SetMomentum(v[1]->GetMomentum() * (p / pp));
+
+  if (nt == 3) {
+    if ((v[2]->GetDefinition() == aDeuteron) || (v[2]->GetDefinition() == aTriton) ||
+        (v[2]->GetDefinition() == anAlpha))
+      v[2]->SetKineticEnergy(std::max(0.001, 0.5 * G4UniformRand() * v[2]->GetKineticEnergy() / MeV));
+    else
+      v[2]->SetKineticEnergy(std::max(0.001, v[2]->GetKineticEnergy() / MeV));
+
+    p = v[2]->GetTotalMomentum();
+    pp = v[2]->GetMomentum().mag();
+    if (pp <= 0.001 * MeV) {
+      G4double phinve = twopi * G4UniformRand();
+      G4double rthnve = std::acos(std::max(-1.0, std::min(1.0, -1.0 + 2.0 * G4UniformRand())));
+      v[2]->SetMomentum(
+          p * std::sin(rthnve) * std::cos(phinve), p * std::sin(rthnve) * std::sin(phinve), p * std::cos(rthnve));
+    } else
+      v[2]->SetMomentum(v[2]->GetMomentum() * (p / pp));
+  }
+  G4int del;
+  for (del = 0; del < vecLen; del++)
+    delete vec[del];
+  vecLen = 0;
+  if (particleIsDefined) {
+    vec.SetElement(vecLen++, v[0]);
+  } else {
+    delete v[0];
+  }
+  vec.SetElement(vecLen++, v[1]);
+  if (nt == 3) {
+    vec.SetElement(vecLen++, v[2]);
+  } else {
+    delete v[2];
+  }
+  delete[] v;
+  return;
+}
+
+/* end of file */

--- a/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
@@ -7,191 +7,184 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include"G4ParticleTable.hh" 
+#include "G4ParticleTable.hh"
 #include "Randomize.hh"
 
-#include<iostream>
-#include<fstream>
+#include <iostream>
+#include <fstream>
 #include <string>
 
 using namespace CLHEP;
 
-G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p, 
-                                 CustomParticleFactory* ptr) {
+G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet& p, CustomParticleFactory* ptr) {
   fParticleFactory = ptr;
 
   particleTable = G4ParticleTable::GetParticleTable();
 
   theProton = particleTable->FindParticle("proton");
   theNeutron = particleTable->FindParticle("neutron");
-  
+
   G4String line;
 
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("processesDef");
   std::string processDefFilePath = fp.fullPath();
-  std::ifstream process_stream (processDefFilePath.c_str());
+  std::ifstream process_stream(processDefFilePath.c_str());
 
   resonant = p.getParameter<bool>("resonant");
-  ek_0 = p.getParameter<double>("resonanceEnergy")*GeV;
-  gamma = p.getParameter<double>("gamma")*GeV;
-  amplitude = p.getParameter<double>("amplitude")*millibarn;
+  ek_0 = p.getParameter<double>("resonanceEnergy") * GeV;
+  gamma = p.getParameter<double>("gamma") * GeV;
+  amplitude = p.getParameter<double>("amplitude") * millibarn;
   suppressionfactor = p.getParameter<double>("reggeSuppression");
   hadronlifetime = p.getParameter<double>("hadronLifeTime");
   reggemodel = p.getParameter<bool>("reggeModel");
   mixing = p.getParameter<double>("mixing");
-  
-  edm::LogInfo("SimG4CoreCustomPhysics")
-    <<"ProcessHelper: Read in physics parameters:"
-    <<"\n Resonant = "<< resonant 
-    <<"\n ResonanceEnergy = "<<ek_0/GeV<<" GeV"
-    <<"\n Gamma = "<<gamma/GeV<<" GeV"
-    <<"\n Amplitude = "<<amplitude/millibarn<<" millibarn"
-    <<"ReggeSuppression = "<<100*suppressionfactor<<" %"
-    <<"HadronLifeTime = "<<hadronlifetime<<" s"
-    <<"ReggeModel = "<< reggemodel 
-    <<"Mixing = "<< mixing*100 <<" %";
+
+  edm::LogInfo("SimG4CoreCustomPhysics") << "ProcessHelper: Read in physics parameters:"
+                                         << "\n Resonant = " << resonant << "\n ResonanceEnergy = " << ek_0 / GeV
+                                         << " GeV"
+                                         << "\n Gamma = " << gamma / GeV << " GeV"
+                                         << "\n Amplitude = " << amplitude / millibarn << " millibarn"
+                                         << "ReggeSuppression = " << 100 * suppressionfactor << " %"
+                                         << "HadronLifeTime = " << hadronlifetime << " s"
+                                         << "ReggeModel = " << reggemodel << "Mixing = " << mixing * 100 << " %";
 
   checkfraction = 0;
   n_22 = 0;
   n_23 = 0;
 
-  while(getline(process_stream,line)){
+  while (getline(process_stream, line)) {
     std::vector<G4String> tokens;
     //Getting a line
-    ReadAndParse(line,tokens,"#");
+    ReadAndParse(line, tokens, "#");
     //Important info
     G4String incident = tokens[0];
-    
+
     G4ParticleDefinition* incidentDef = particleTable->FindParticle(incident);
     //particleTable->DumpTable();
     G4int incidentPDG = incidentDef->GetPDGEncoding();
-    known_particles[incidentDef]=true;
+    known_particles[incidentDef] = true;
 
     G4String target = tokens[1];
-    edm::LogInfo("SimG4CoreCustomPhysics")
-      <<"ProcessHelper: Incident "<<incident
-      <<"; Target "<<target;
-    
+    edm::LogInfo("SimG4CoreCustomPhysics") << "ProcessHelper: Incident " << incident << "; Target " << target;
+
     // Making a ReactionProduct
     ReactionProduct prod;
-    for (size_t i = 2; i != tokens.size();i++){
+    for (size_t i = 2; i != tokens.size(); i++) {
       G4String part = tokens[i];
-      if (particleTable->contains(part))
-	{
-	  prod.push_back(particleTable->FindParticle(part)->GetPDGEncoding());
-	} else {
-	  G4Exception("G4ProcessHelper", "UnkownParticle", FatalException,
-		      "Initialization: The reaction product list contained an unknown particle");
-	}
-    }
-    if (target == "proton")
-      {
-	pReactionMap[incidentPDG].push_back(prod);
-      } else if (target == "neutron") {
-	nReactionMap[incidentPDG].push_back(prod);
+      if (particleTable->contains(part)) {
+        prod.push_back(particleTable->FindParticle(part)->GetPDGEncoding());
       } else {
-	G4Exception("G4ProcessHelper", "IllegalTarget", FatalException,
-		    "Initialization: The reaction product list contained an illegal target particle");
+        G4Exception("G4ProcessHelper",
+                    "UnkownParticle",
+                    FatalException,
+                    "Initialization: The reaction product list contained an unknown particle");
       }
-   }
+    }
+    if (target == "proton") {
+      pReactionMap[incidentPDG].push_back(prod);
+    } else if (target == "neutron") {
+      nReactionMap[incidentPDG].push_back(prod);
+    } else {
+      G4Exception("G4ProcessHelper",
+                  "IllegalTarget",
+                  FatalException,
+                  "Initialization: The reaction product list contained an illegal target particle");
+    }
+  }
 
   process_stream.close();
 
-  for(auto part : fParticleFactory->GetCustomParticles()) {
+  for (auto part : fParticleFactory->GetCustomParticles()) {
     CustomParticle* particle = dynamic_cast<CustomParticle*>(part);
-    if(particle) {
-      edm::LogInfo("SimG4CoreCustomPhysics")
-	<<"ProcessHelper: Lifetime of "<<part->GetParticleName()<<" set to "
-	<<particle->GetPDGLifeTime()/s<<" s;"
-	<<" isStable: "<<particle->GetPDGStable();
+    if (particle) {
+      edm::LogInfo("SimG4CoreCustomPhysics") << "ProcessHelper: Lifetime of " << part->GetParticleName() << " set to "
+                                             << particle->GetPDGLifeTime() / s << " s;"
+                                             << " isStable: " << particle->GetPDGStable();
     }
   }
 }
 
-G4ProcessHelper::~G4ProcessHelper(){
-}
+G4ProcessHelper::~G4ProcessHelper() {}
 
-G4bool G4ProcessHelper::ApplicabilityTester(const G4ParticleDefinition& aPart){
-  const G4ParticleDefinition* aP = &aPart; 
-  if (known_particles[aP]) return true;
+G4bool G4ProcessHelper::ApplicabilityTester(const G4ParticleDefinition& aPart) {
+  const G4ParticleDefinition* aP = &aPart;
+  if (known_particles[aP])
+    return true;
   return false;
 }
 
-G4double G4ProcessHelper::GetInclusiveCrossSection(const G4DynamicParticle *aParticle,
-						   const G4Element *anElement){
-
+G4double G4ProcessHelper::GetInclusiveCrossSection(const G4DynamicParticle* aParticle, const G4Element* anElement) {
   //We really do need a dedicated class to handle the cross sections. They might not always be constant
-
 
   //Disassemble the PDG-code
 
   G4int thePDGCode = aParticle->GetDefinition()->GetPDGEncoding();
-  double boost = (aParticle->GetKineticEnergy()+aParticle->GetMass())/aParticle->GetMass();
+  double boost = (aParticle->GetKineticEnergy() + aParticle->GetMass()) / aParticle->GetMass();
   //  G4cout<<"thePDGCode: "<<thePDGCode<<G4endl;
   G4double theXsec = 0;
   G4String name = aParticle->GetDefinition()->GetParticleName();
-  if(!reggemodel)
-  {
-  //Flat cross section
-  if(CustomPDGParser::s_isRGlueball(thePDGCode)) {
-    theXsec = 24 * millibarn;
-  } else {
-    std::vector<G4int> nq=CustomPDGParser::s_containedQuarks(thePDGCode);
-    //    edm::LogInfo("SimG4CoreCustomPhysics")<<"Number of quarks: "<<nq.size()<<G4endl;
-    for (std::vector<G4int>::iterator it = nq.begin();
-	 it != nq.end();
-	 it++)
-      {
-	//	  edm::LogInfo("SimG4CoreCustomPhysics")<<"Quarkvector: "<<*it<<G4endl;
-	if (*it == 1 || *it == 2) theXsec += 12 * millibarn;
-	if (*it == 3) theXsec += 6 * millibarn;
+  if (!reggemodel) {
+    //Flat cross section
+    if (CustomPDGParser::s_isRGlueball(thePDGCode)) {
+      theXsec = 24 * millibarn;
+    } else {
+      std::vector<G4int> nq = CustomPDGParser::s_containedQuarks(thePDGCode);
+      //    edm::LogInfo("SimG4CoreCustomPhysics")<<"Number of quarks: "<<nq.size()<<G4endl;
+      for (std::vector<G4int>::iterator it = nq.begin(); it != nq.end(); it++) {
+        //	  edm::LogInfo("SimG4CoreCustomPhysics")<<"Quarkvector: "<<*it<<G4endl;
+        if (*it == 1 || *it == 2)
+          theXsec += 12 * millibarn;
+        if (*it == 3)
+          theXsec += 6 * millibarn;
       }
-   }
-  } 
-  else 
-  {  //reggemodel
+    }
+  } else {  //reggemodel
     double R = Regge(boost);
     double P = Pom(boost);
-    if(thePDGCode>0)
-      {
-	if(CustomPDGParser::s_isMesonino(thePDGCode)) theXsec=(P+R)*millibarn;
-	if(CustomPDGParser::s_isSbaryon(thePDGCode)) theXsec=2*P*millibarn;
-	if(CustomPDGParser::s_isRMeson(thePDGCode)||CustomPDGParser::s_isRGlueball(thePDGCode)) theXsec=(R+2*P)*millibarn;
-	if(CustomPDGParser::s_isRBaryon(thePDGCode)) theXsec=3*P*millibarn;
-      }
-    else
-      {
-	if(CustomPDGParser::s_isMesonino(thePDGCode)) theXsec=P*millibarn;
-	if(CustomPDGParser::s_isSbaryon(thePDGCode)) theXsec=(2*(P+R)+30/sqrt(boost))*millibarn;
-	if(CustomPDGParser::s_isRMeson(thePDGCode)||CustomPDGParser::s_isRGlueball(thePDGCode)) theXsec=(R+2*P)*millibarn;
-	if(CustomPDGParser::s_isRBaryon(thePDGCode)) theXsec=3*P*millibarn;
-      }
+    if (thePDGCode > 0) {
+      if (CustomPDGParser::s_isMesonino(thePDGCode))
+        theXsec = (P + R) * millibarn;
+      if (CustomPDGParser::s_isSbaryon(thePDGCode))
+        theXsec = 2 * P * millibarn;
+      if (CustomPDGParser::s_isRMeson(thePDGCode) || CustomPDGParser::s_isRGlueball(thePDGCode))
+        theXsec = (R + 2 * P) * millibarn;
+      if (CustomPDGParser::s_isRBaryon(thePDGCode))
+        theXsec = 3 * P * millibarn;
+    } else {
+      if (CustomPDGParser::s_isMesonino(thePDGCode))
+        theXsec = P * millibarn;
+      if (CustomPDGParser::s_isSbaryon(thePDGCode))
+        theXsec = (2 * (P + R) + 30 / sqrt(boost)) * millibarn;
+      if (CustomPDGParser::s_isRMeson(thePDGCode) || CustomPDGParser::s_isRGlueball(thePDGCode))
+        theXsec = (R + 2 * P) * millibarn;
+      if (CustomPDGParser::s_isRBaryon(thePDGCode))
+        theXsec = 3 * P * millibarn;
+    }
   }
   //Adding resonance
-  if(resonant)
-    {
-      double e_0 = ek_0 + aParticle->GetDefinition()->GetPDGMass(); //Now total energy
+  if (resonant) {
+    double e_0 = ek_0 + aParticle->GetDefinition()->GetPDGMass();  //Now total energy
 
-      e_0 = sqrt(aParticle->GetDefinition()->GetPDGMass()*aParticle->GetDefinition()->GetPDGMass()
-		 + theProton->GetPDGMass()*theProton->GetPDGMass()
-		 + 2.*e_0*theProton->GetPDGMass());
-      //      edm::LogInfo("SimG4CoreCustomPhysics")<<e_0/GeV<<G4endl;
-      //      edm::LogInfo("SimG4CoreCustomPhysics")<<ek_0/GeV<<" "<<aParticle->GetDefinition()->GetPDGMass()/GeV<<" "<<theProton->GetPDGMass()/GeV<<G4endl;
-      double sqrts=sqrt(aParticle->GetDefinition()->GetPDGMass()*aParticle->GetDefinition()->GetPDGMass()
-			+ theProton->GetPDGMass()*theProton->GetPDGMass() + 2*aParticle->GetTotalEnergy()*theProton->GetPDGMass());
+    e_0 = sqrt(aParticle->GetDefinition()->GetPDGMass() * aParticle->GetDefinition()->GetPDGMass() +
+               theProton->GetPDGMass() * theProton->GetPDGMass() + 2. * e_0 * theProton->GetPDGMass());
+    //      edm::LogInfo("SimG4CoreCustomPhysics")<<e_0/GeV<<G4endl;
+    //      edm::LogInfo("SimG4CoreCustomPhysics")<<ek_0/GeV<<" "<<aParticle->GetDefinition()->GetPDGMass()/GeV<<" "<<theProton->GetPDGMass()/GeV<<G4endl;
+    double sqrts = sqrt(aParticle->GetDefinition()->GetPDGMass() * aParticle->GetDefinition()->GetPDGMass() +
+                        theProton->GetPDGMass() * theProton->GetPDGMass() +
+                        2 * aParticle->GetTotalEnergy() * theProton->GetPDGMass());
 
-      double res_result = amplitude*(gamma*gamma/4.)/((sqrts-e_0)*(sqrts-e_0)+(gamma*gamma/4.));//Non-relativistic Breit Wigner
+    double res_result = amplitude * (gamma * gamma / 4.) /
+                        ((sqrts - e_0) * (sqrts - e_0) + (gamma * gamma / 4.));  //Non-relativistic Breit Wigner
 
-      theXsec += res_result;
-      //      if(fabs(aParticle->GetKineticEnergy()/GeV-200)<10)  std::cout<<sqrts/GeV<<" "<<theXsec/millibarn<<std::endl;
-    }
+    theXsec += res_result;
+    //      if(fabs(aParticle->GetKineticEnergy()/GeV-200)<10)  std::cout<<sqrts/GeV<<" "<<theXsec/millibarn<<std::endl;
+  }
 
   //  std::cout<<"Xsec/nucleon: "<<theXsec/millibarn<<"millibarn, Total Xsec: "<<theXsec * anElement->GetN()/millibarn<<" millibarn"<<std::endl;
-  return theXsec * pow(anElement->GetN(),0.7)*1.25;// * 0.523598775598299;
+  return theXsec * pow(anElement->GetN(), 0.7) * 1.25;  // * 0.523598775598299;
 }
 
-ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4ParticleDefinition*& aTarget){
-
+ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4ParticleDefinition*& aTarget) {
   const G4DynamicParticle* aDynamicParticle = aTrack.GetDynamicParticle();
 
   //-----------------------------------------------
@@ -200,57 +193,45 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
   //-----------------------------------------------
 
   G4Material* aMaterial = aTrack.GetMaterial();
-  const G4ElementVector* theElementVector = aMaterial->GetElementVector() ;
+  const G4ElementVector* theElementVector = aMaterial->GetElementVector();
   const G4double* NbOfAtomsPerVolume = aMaterial->GetVecNbOfAtomsPerVolume();
 
-  G4double NumberOfProtons=0;
-  G4double NumberOfNucleons=0;
+  G4double NumberOfProtons = 0;
+  G4double NumberOfNucleons = 0;
 
-  for ( size_t elm=0 ; elm < aMaterial->GetNumberOfElements() ; elm++ )
-    {
-      //Summing number of protons per unit volume
-      NumberOfProtons += NbOfAtomsPerVolume[elm]*(*theElementVector)[elm]->GetZ();
-      //Summing nucleons (not neutrons)
-      NumberOfNucleons += NbOfAtomsPerVolume[elm]*(*theElementVector)[elm]->GetN();
-    }
+  for (size_t elm = 0; elm < aMaterial->GetNumberOfElements(); elm++) {
+    //Summing number of protons per unit volume
+    NumberOfProtons += NbOfAtomsPerVolume[elm] * (*theElementVector)[elm]->GetZ();
+    //Summing nucleons (not neutrons)
+    NumberOfNucleons += NbOfAtomsPerVolume[elm] * (*theElementVector)[elm]->GetN();
+  }
 
-  if(G4UniformRand()<NumberOfProtons/NumberOfNucleons)
-    {
-      theReactionMap = &pReactionMap;
-      theTarget = theProton;
-    } else {
-      theReactionMap = &nReactionMap;
-      theTarget = theNeutron;
-    }
+  if (G4UniformRand() < NumberOfProtons / NumberOfNucleons) {
+    theReactionMap = &pReactionMap;
+    theTarget = theProton;
+  } else {
+    theReactionMap = &nReactionMap;
+    theTarget = theNeutron;
+  }
   aTarget = theTarget;
 
   G4int theIncidentPDG = aDynamicParticle->GetDefinition()->GetPDGEncoding();
 
-  if(reggemodel
-     &&CustomPDGParser::s_isMesonino(theIncidentPDG)
-     && G4UniformRand()*mixing>0.5
-     &&aDynamicParticle->GetDefinition()->GetPDGCharge()==0.
-     ) 
-    {
-      //      G4cout<<"Oscillating..."<<G4endl;
-      theIncidentPDG *= -1;
-    }
+  if (reggemodel && CustomPDGParser::s_isMesonino(theIncidentPDG) && G4UniformRand() * mixing > 0.5 &&
+      aDynamicParticle->GetDefinition()->GetPDGCharge() == 0.) {
+    //      G4cout<<"Oscillating..."<<G4endl;
+    theIncidentPDG *= -1;
+  }
 
+  bool baryonise = false;
 
-  bool baryonise=false;
-  
-  if(reggemodel
-     && G4UniformRand()>0.9
-     &&(
-	(CustomPDGParser::s_isMesonino(theIncidentPDG)&&theIncidentPDG>0)
-	||
-	CustomPDGParser::s_isRMeson(theIncidentPDG)
-	)
-     )  
-    baryonise=true;
+  if (reggemodel && G4UniformRand() > 0.9 &&
+      ((CustomPDGParser::s_isMesonino(theIncidentPDG) && theIncidentPDG > 0) ||
+       CustomPDGParser::s_isRMeson(theIncidentPDG)))
+    baryonise = true;
 
   //Making a pointer directly to the ReactionProductList we are looking at. Makes life easier :-)
-  ReactionProductList*  aReactionProductList = &((*theReactionMap)[theIncidentPDG]);
+  ReactionProductList* aReactionProductList = &((*theReactionMap)[theIncidentPDG]);
 
   //-----------------------------------------------
   // Count processes
@@ -258,38 +239,29 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
   // compute number of 2 -> 2 and 2 -> 3 processes
   //-----------------------------------------------
 
-  G4int N22 = 0; //Number of 2 -> 2 processes
-  G4int N23 = 0; //Number of 2 -> 3 processes. Couldn't think of more informative names
-  
+  G4int N22 = 0;  //Number of 2 -> 2 processes
+  G4int N23 = 0;  //Number of 2 -> 3 processes. Couldn't think of more informative names
+
   //This is the list to be populated
   ReactionProductList theReactionProductList;
   std::vector<bool> theChargeChangeList;
 
-  for (ReactionProductList::iterator prod_it = aReactionProductList->begin();
-       prod_it != aReactionProductList->end();
-       prod_it++){
+  for (ReactionProductList::iterator prod_it = aReactionProductList->begin(); prod_it != aReactionProductList->end();
+       prod_it++) {
     G4int secondaries = prod_it->size();
     // If the reaction is not possible we will not consider it
-    if(ReactionIsPossible(*prod_it,aDynamicParticle)
-       && (!reggemodel ||
-	  (baryonise&&ReactionGivesBaryon(*prod_it)) 
-	  ||
-	   (!baryonise&&!ReactionGivesBaryon(*prod_it))
-	  ||
-	  (CustomPDGParser::s_isSbaryon(theIncidentPDG))
-	  ||
-	  (CustomPDGParser::s_isRBaryon(theIncidentPDG))
-	  )
-       )
-      {
+    if (ReactionIsPossible(*prod_it, aDynamicParticle) &&
+        (!reggemodel || (baryonise && ReactionGivesBaryon(*prod_it)) ||
+         (!baryonise && !ReactionGivesBaryon(*prod_it)) || (CustomPDGParser::s_isSbaryon(theIncidentPDG)) ||
+         (CustomPDGParser::s_isRBaryon(theIncidentPDG)))) {
       // The reaction is possible. Let's store and count it
       theReactionProductList.push_back(*prod_it);
-      if (secondaries == 2){
-	N22++;
-      } else if (secondaries ==3) {
-	N23++;
+      if (secondaries == 2) {
+        N22++;
+      } else if (secondaries == 3) {
+        N23++;
       } else {
-	G4cerr << "ReactionProduct has unsupported number of secondaries: "<<secondaries<<G4endl;
+        G4cerr << "ReactionProduct has unsupported number of secondaries: " << secondaries << G4endl;
       }
     } /*else {
       edm::LogInfo("SimG4CoreCustomPhysics")<<"There was an impossible process"<<G4endl;
@@ -297,36 +269,38 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
   }
   //  edm::LogInfo("SimG4CoreCustomPhysics")<<"The size of the ReactionProductList is: "<<theReactionProductList.size()<<G4endl;
 
-  if (theReactionProductList.empty()) G4Exception("G4ProcessHelper", "NoProcessPossible", FatalException,
-						    "GetFinalState: No process could be selected from the given list.");
+  if (theReactionProductList.empty())
+    G4Exception("G4ProcessHelper",
+                "NoProcessPossible",
+                FatalException,
+                "GetFinalState: No process could be selected from the given list.");
 
   // For the Regge model no phase space considerations. We pick a process at random
-  if(reggemodel)
-    {
-      int n_rps = theReactionProductList.size();
-      int select = (int)( G4UniformRand()*n_rps);
-      //      G4cout<<"Possible: "<<n_rps<<", chosen: "<<select<<G4endl;
-      return theReactionProductList[select];
-    }
+  if (reggemodel) {
+    int n_rps = theReactionProductList.size();
+    int select = (int)(G4UniformRand() * n_rps);
+    //      G4cout<<"Possible: "<<n_rps<<", chosen: "<<select<<G4endl;
+    return theReactionProductList[select];
+  }
 
   // Fill a probability map. Remember total probability
   // 2->2 is 0.15*1/n_22 2->3 uses phase space
   G4double p22 = 0.15;
-  G4double p23 = 1-p22; // :-)
+  G4double p23 = 1 - p22;  // :-)
 
   std::vector<G4double> Probabilities;
   std::vector<G4bool> TwotoThreeFlag;
-  
+
   G4double CumulatedProbability = 0;
 
   // To each ReactionProduct we assign a cumulated probability and a flag
   // discerning between 2 -> 2 and 2 -> 3
-  for (unsigned int i = 0; i != theReactionProductList.size(); i++){
+  for (unsigned int i = 0; i != theReactionProductList.size(); i++) {
     if (theReactionProductList[i].size() == 2) {
-      CumulatedProbability += p22/N22;
+      CumulatedProbability += p22 / N22;
       TwotoThreeFlag.push_back(false);
     } else {
-      CumulatedProbability += p23/N23;
+      CumulatedProbability += p23 / N23;
       TwotoThreeFlag.push_back(true);
     }
     Probabilities.push_back(CumulatedProbability);
@@ -335,13 +309,10 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
 
   //Renormalising probabilities
   //  edm::LogInfo("SimG4CoreCustomPhysics")<<"Probs: ";
-  for (std::vector<G4double>::iterator it = Probabilities.begin();
-       it != Probabilities.end();
-       it++)
-    {
-      *it /= CumulatedProbability;
-      //      edm::LogInfo("SimG4CoreCustomPhysics")<<*it<<" ";
-    }
+  for (std::vector<G4double>::iterator it = Probabilities.begin(); it != Probabilities.end(); it++) {
+    *it /= CumulatedProbability;
+    //      edm::LogInfo("SimG4CoreCustomPhysics")<<*it<<" ";
+  }
   //  edm::LogInfo("SimG4CoreCustomPhysics")<<G4endl;
 
   // Choosing ReactionProduct
@@ -350,61 +321,65 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
   G4int tries = 0;
   //  ReactionProductList::iterator prod_it;
 
-  //Keep looping over the list until we have a choice, or until we have tried 100 times  
+  //Keep looping over the list until we have a choice, or until we have tried 100 times
   unsigned int i;
-  while(!selected && tries < 100){
-    i=0;
+  while (!selected && tries < 100) {
+    i = 0;
     G4double dice = G4UniformRand();
     // edm::LogInfo("SimG4CoreCustomPhysics")<<"What's the dice?"<<dice<<G4endl;
-    while(dice>Probabilities[i] && i<theReactionProductList.size()){
+    while (dice > Probabilities[i] && i < theReactionProductList.size()) {
       //      edm::LogInfo("SimG4CoreCustomPhysics")<<"i: "<<i<<G4endl;
       i++;
     }
 
     //    edm::LogInfo("SimG4CoreCustomPhysics")<<"Chosen i: "<<i<<G4endl;
 
-    if(!TwotoThreeFlag[i]) {
+    if (!TwotoThreeFlag[i]) {
       // 2 -> 2 processes are chosen immediately
       selected = true;
     } else {
       // 2 -> 3 processes require a phase space lookup
-      if (PhaseSpace(theReactionProductList[i],aDynamicParticle)>G4UniformRand()) selected = true;
+      if (PhaseSpace(theReactionProductList[i], aDynamicParticle) > G4UniformRand())
+        selected = true;
       //selected = true;
     }
     //    double suppressionfactor=0.5;
-    if(selected&&particleTable->FindParticle(theReactionProductList[i][0])->GetPDGCharge()!=aDynamicParticle->GetDefinition()->GetPDGCharge())
-      {
-	/*
+    if (selected && particleTable->FindParticle(theReactionProductList[i][0])->GetPDGCharge() !=
+                        aDynamicParticle->GetDefinition()->GetPDGCharge()) {
+      /*
 	edm::LogInfo("SimG4CoreCustomPhysics")<<"Incoming particle "<<aDynamicParticle->GetDefinition()->GetParticleName()
 	      <<" has charge "<<aDynamicParticle->GetDefinition()->GetPDGCharge()<<G4endl;
 	edm::LogInfo("SimG4CoreCustomPhysics")<<"Suggested particle "<<particleTable->FindParticle(theReactionProductList[i][0])->GetParticleName()
 	      <<" has charge "<<particleTable->FindParticle(theReactionProductList[i][0])->GetPDGCharge()<<G4endl;
 	*/
-	if(G4UniformRand()<suppressionfactor) selected = false;
-      }
+      if (G4UniformRand() < suppressionfactor)
+        selected = false;
+    }
     tries++;
     //    edm::LogInfo("SimG4CoreCustomPhysics")<<"Tries: "<<tries<<G4endl;
   }
-  if(tries>=100) G4cerr<<"Could not select process!!!!"<<G4endl;
+  if (tries >= 100)
+    G4cerr << "Could not select process!!!!" << G4endl;
 
   //  edm::LogInfo("SimG4CoreCustomPhysics")<<"So far so good"<<G4endl;
   //  edm::LogInfo("SimG4CoreCustomPhysics")<<"Sec's: "<<theReactionProductList[i].size()<<G4endl;
-  
+
   //Updating checkfraction:
-  if (theReactionProductList[i].size()==2) {
+  if (theReactionProductList[i].size() == 2) {
     n_22++;
   } else {
     n_23++;
   }
 
-  checkfraction = (1.0*n_22)/(n_22+n_23);
+  checkfraction = (1.0 * n_22) / (n_22 + n_23);
   //  edm::LogInfo("SimG4CoreCustomPhysics")<<"n_22: "<<n_22<<" n_23: "<<n_23<<" Checkfraction: "<<checkfraction<<G4endl;
   //  edm::LogInfo("SimG4CoreCustomPhysics") <<"Biig number: "<<n_22+n_23<<G4endl;
   //Return the chosen ReactionProduct
   return theReactionProductList[i];
 }
 
-G4double G4ProcessHelper::ReactionProductMass(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle){
+G4double G4ProcessHelper::ReactionProductMass(const ReactionProduct& aReaction,
+                                              const G4DynamicParticle* aDynamicParticle) {
   // Incident energy:
   G4double E_incident = aDynamicParticle->GetTotalEnergy();
   //edm::LogInfo("SimG4CoreCustomPhysics")<<"Total energy: "<<E_incident<<" Kinetic: "<<aDynamicParticle->GetKineticEnergy()<<G4endl;
@@ -412,11 +387,11 @@ G4double G4ProcessHelper::ReactionProductMass(const ReactionProduct& aReaction,c
   G4double m_1 = aDynamicParticle->GetDefinition()->GetPDGMass();
   G4double m_2 = theTarget->GetPDGMass();
   //edm::LogInfo("SimG4CoreCustomPhysics")<<"M_R: "<<m_1/GeV<<" GeV, M_np: "<<m_2/GeV<<" GeV"<<G4endl;
-  G4double sqrts = sqrt(m_1*m_1 + m_2*(m_2 + 2 * E_incident));
+  G4double sqrts = sqrt(m_1 * m_1 + m_2 * (m_2 + 2 * E_incident));
   //edm::LogInfo("SimG4CoreCustomPhysics")<<"sqrt(s) = "<<sqrts/GeV<<" GeV"<<G4endl;
   // Sum of rest masses after reaction:
   G4double M_after = 0;
-  for (ReactionProduct::const_iterator r_it = aReaction.begin(); r_it !=aReaction.end(); r_it++){
+  for (ReactionProduct::const_iterator r_it = aReaction.begin(); r_it != aReaction.end(); r_it++) {
     //edm::LogInfo("SimG4CoreCustomPhysics")<<"Mass contrib: "<<(particleTable->FindParticle(*r_it)->GetPDGMass())/MeV<<" MeV"<<G4endl;
     M_after += particleTable->FindParticle(*r_it)->GetPDGMass();
   }
@@ -424,62 +399,59 @@ G4double G4ProcessHelper::ReactionProductMass(const ReactionProduct& aReaction,c
   return sqrts - M_after;
 }
 
-G4bool G4ProcessHelper::ReactionIsPossible(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle){
-  if (ReactionProductMass(aReaction,aDynamicParticle)>0) return true;
+G4bool G4ProcessHelper::ReactionIsPossible(const ReactionProduct& aReaction,
+                                           const G4DynamicParticle* aDynamicParticle) {
+  if (ReactionProductMass(aReaction, aDynamicParticle) > 0)
+    return true;
   return false;
 }
 
-G4bool G4ProcessHelper::ReactionGivesBaryon(const ReactionProduct& aReaction){
-  for (ReactionProduct::const_iterator it = aReaction.begin();it!=aReaction.end();it++)
-    if(CustomPDGParser::s_isSbaryon(*it)||CustomPDGParser::s_isRBaryon(*it)) return true;
+G4bool G4ProcessHelper::ReactionGivesBaryon(const ReactionProduct& aReaction) {
+  for (ReactionProduct::const_iterator it = aReaction.begin(); it != aReaction.end(); it++)
+    if (CustomPDGParser::s_isSbaryon(*it) || CustomPDGParser::s_isRBaryon(*it))
+      return true;
   return false;
 }
 
-G4double G4ProcessHelper::PhaseSpace(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle){
-  G4double qValue = ReactionProductMass(aReaction,aDynamicParticle);
-  G4double phi = sqrt(1+qValue/(2*0.139*GeV))*pow(qValue/(1.1*GeV),3./2.);
-  return (phi/(1+phi));
+G4double G4ProcessHelper::PhaseSpace(const ReactionProduct& aReaction, const G4DynamicParticle* aDynamicParticle) {
+  G4double qValue = ReactionProductMass(aReaction, aDynamicParticle);
+  G4double phi = sqrt(1 + qValue / (2 * 0.139 * GeV)) * pow(qValue / (1.1 * GeV), 3. / 2.);
+  return (phi / (1 + phi));
 }
 
-void G4ProcessHelper::ReadAndParse(const G4String& str,
-				   std::vector<G4String>& tokens,
-				   const G4String& delimiters)
-{
+void G4ProcessHelper::ReadAndParse(const G4String& str, std::vector<G4String>& tokens, const G4String& delimiters) {
   // Skip delimiters at beginning.
   G4String::size_type lastPos = str.find_first_not_of(delimiters, 0);
   // Find first "non-delimiter".
-  G4String::size_type pos     = str.find_first_of(delimiters, lastPos);
-  
-  while (G4String::npos != pos || G4String::npos != lastPos)
-    {
-      //Skipping leading / trailing whitespaces
-      G4String temp = str.substr(lastPos, pos - lastPos);
-      while(temp.c_str()[0] == ' ') temp.erase(0,1);
-      while(temp[temp.size()-1] == ' ') temp.erase(temp.size()-1,1);
-      // Found a token, add it to the vector.
-      tokens.push_back(temp);
-      // Skip delimiters.  Note the "not_of"
-      lastPos = str.find_first_not_of(delimiters, pos);
-      // Find next "non-delimiter"
-      pos = str.find_first_of(delimiters, lastPos);
-    }
+  G4String::size_type pos = str.find_first_of(delimiters, lastPos);
+
+  while (G4String::npos != pos || G4String::npos != lastPos) {
+    //Skipping leading / trailing whitespaces
+    G4String temp = str.substr(lastPos, pos - lastPos);
+    while (temp.c_str()[0] == ' ')
+      temp.erase(0, 1);
+    while (temp[temp.size() - 1] == ' ')
+      temp.erase(temp.size() - 1, 1);
+    // Found a token, add it to the vector.
+    tokens.push_back(temp);
+    // Skip delimiters.  Note the "not_of"
+    lastPos = str.find_first_not_of(delimiters, pos);
+    // Find next "non-delimiter"
+    pos = str.find_first_of(delimiters, lastPos);
+  }
 }
 
-double G4ProcessHelper::Regge(const double boost)
-{
-  double a=2.165635078566177;
-  double b=0.1467453738547229;
-  double c=-0.9607903711871166;
-  return 1.5*exp(a+b/boost+c*log(boost));
+double G4ProcessHelper::Regge(const double boost) {
+  double a = 2.165635078566177;
+  double b = 0.1467453738547229;
+  double c = -0.9607903711871166;
+  return 1.5 * exp(a + b / boost + c * log(boost));
 }
 
-
-double G4ProcessHelper::Pom(const double boost)
-{
-  double a=4.138224000651535;
-  double b=1.50377557581421;
-  double c=-0.05449742257808247;
-  double d=0.0008221235048211401;
-  return a + b*sqrt(boost) + c*boost + d*pow(boost,1.5);
+double G4ProcessHelper::Pom(const double boost) {
+  double a = 4.138224000651535;
+  double b = 1.50377557581421;
+  double c = -0.05449742257808247;
+  double d = 0.0008221235048211401;
+  return a + b * sqrt(boost) + c * boost + d * pow(boost, 1.5);
 }
-

--- a/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
@@ -1,5 +1,5 @@
 #include "Randomize.hh"
-#include "G4ParticleTable.hh" 
+#include "G4ParticleTable.hh"
 
 #include <iostream>
 #include <fstream>
@@ -13,53 +13,54 @@
 
 using namespace CLHEP;
 
-HadronicProcessHelper::HadronicProcessHelper(const std::string & fileName){
-
+HadronicProcessHelper::HadronicProcessHelper(const std::string& fileName) {
   m_particleTable = G4ParticleTable::GetParticleTable();
   m_proton = m_particleTable->FindParticle("proton");
   m_neutron = m_particleTable->FindParticle("neutron");
 
   G4String line;
 
-  std::ifstream processListStream (fileName.c_str());
+  std::ifstream processListStream(fileName.c_str());
 
-  while(getline(processListStream,line)){
+  while (getline(processListStream, line)) {
     std::vector<G4String> tokens;
 
     //Getting a line
-    m_readAndParse(line,tokens,"#");
-    
+    m_readAndParse(line, tokens, "#");
+
     //Important info
     G4String incident = tokens[0];
     G4ParticleDefinition* incidentDef = m_particleTable->FindParticle(incident);
     G4int incidentPDG = incidentDef->GetPDGEncoding();
-    m_knownParticles[incidentDef]=true;
+    m_knownParticles[incidentDef] = true;
     //    G4cout<<"Incident: "<<incident<<G4endl;
     G4String target = tokens[1];
     //    G4cout<<"Target: "<<target<<G4endl;
-    
+
     // Making a ReactionProduct
     ReactionProduct prod;
-    for (size_t i = 2; i != tokens.size();i++){
+    for (size_t i = 2; i != tokens.size(); i++) {
       G4String part = tokens[i];
-      if (m_particleTable->contains(part))
-	{
-	  prod.push_back(m_particleTable->FindParticle(part)->GetPDGEncoding());
-	} else {
-	  G4Exception("HadronicProcessHelper", "UnkownParticle", FatalException,
-		      "Initialization: The reaction product list contained an unknown particle");
-	}
-    }
-    if (target == "proton")
-      {
-	m_protonReactionMap[incidentPDG].push_back(prod);
-      } else if (target == "neutron") {
-	m_neutronReactionMap[incidentPDG].push_back(prod);
+      if (m_particleTable->contains(part)) {
+        prod.push_back(m_particleTable->FindParticle(part)->GetPDGEncoding());
       } else {
-	G4Exception("HadronicProcessHelper", "IllegalTarget", FatalException,
-		    "Initialization: The reaction product list contained an illegal target particle");
+        G4Exception("HadronicProcessHelper",
+                    "UnkownParticle",
+                    FatalException,
+                    "Initialization: The reaction product list contained an unknown particle");
       }
-   }
+    }
+    if (target == "proton") {
+      m_protonReactionMap[incidentPDG].push_back(prod);
+    } else if (target == "neutron") {
+      m_neutronReactionMap[incidentPDG].push_back(prod);
+    } else {
+      G4Exception("HadronicProcessHelper",
+                  "IllegalTarget",
+                  FatalException,
+                  "Initialization: The reaction product list contained an illegal target particle");
+    }
+  }
 
   processListStream.close();
 
@@ -68,46 +69,44 @@ HadronicProcessHelper::HadronicProcessHelper(const std::string & fileName){
   m_n23 = 0;
 }
 
-G4bool HadronicProcessHelper::applicabilityTester(const G4ParticleDefinition& aPart){
-  const G4ParticleDefinition* aP = &aPart; 
-  if (m_knownParticles[aP]) return true;
+G4bool HadronicProcessHelper::applicabilityTester(const G4ParticleDefinition& aPart) {
+  const G4ParticleDefinition* aP = &aPart;
+  if (m_knownParticles[aP])
+    return true;
   return false;
 }
 
-G4double HadronicProcessHelper::inclusiveCrossSection(const G4DynamicParticle *particle,
-						   const G4Element *element){
-
+G4double HadronicProcessHelper::inclusiveCrossSection(const G4DynamicParticle* particle, const G4Element* element) {
   //We really do need a dedicated class to handle the cross sections. They might not always be constant
 
   G4int pdgCode = particle->GetDefinition()->GetPDGEncoding();
 
   //24mb for gluino-balls
-  if(CustomPDGParser::s_isRGlueball(pdgCode)) return 24 * millibarn * element->GetN();
-  
+  if (CustomPDGParser::s_isRGlueball(pdgCode))
+    return 24 * millibarn * element->GetN();
+
   //get quark vector
-  std::vector<G4int> quarks=CustomPDGParser::s_containedQuarks(pdgCode);
-  
+  std::vector<G4int> quarks = CustomPDGParser::s_containedQuarks(pdgCode);
+
   G4double totalNucleonCrossSection = 0;
 
-  for (std::vector<G4int>::iterator it = quarks.begin();
-       it != quarks.end();
-       it++)
-    {
-      // 12mb for each 'up' or 'down'
-      if (*it == 1 || *it == 2) totalNucleonCrossSection += 12 * millibarn;
-      //  6mb for each 'strange'
-      if (*it == 3) totalNucleonCrossSection += 6 * millibarn;
-    }
-  
+  for (std::vector<G4int>::iterator it = quarks.begin(); it != quarks.end(); it++) {
+    // 12mb for each 'up' or 'down'
+    if (*it == 1 || *it == 2)
+      totalNucleonCrossSection += 12 * millibarn;
+    //  6mb for each 'strange'
+    if (*it == 3)
+      totalNucleonCrossSection += 6 * millibarn;
+  }
+
   //Convert to xsec per nucleus
   //  return totalNucleonCrossSection * element->GetN();
-  return totalNucleonCrossSection * pow(element->GetN(),0.7)*1.25;// * 0.523598775598299;
+  return totalNucleonCrossSection * pow(element->GetN(), 0.7) * 1.25;  // * 0.523598775598299;
 }
 
-HadronicProcessHelper::ReactionProduct HadronicProcessHelper::finalState(const G4DynamicParticle* incidentDynamicParticle,
-   const G4Material *material, G4ParticleDefinition*& target){
-
-//  const G4DynamicParticle* incidentDynamicParticle = track.GetDynamicParticle();
+HadronicProcessHelper::ReactionProduct HadronicProcessHelper::finalState(
+    const G4DynamicParticle* incidentDynamicParticle, const G4Material* material, G4ParticleDefinition*& target) {
+  //  const G4DynamicParticle* incidentDynamicParticle = track.GetDynamicParticle();
 
   //-----------------------------------------------
   // Choose n / p as target
@@ -115,35 +114,33 @@ HadronicProcessHelper::ReactionProduct HadronicProcessHelper::finalState(const G
   //-----------------------------------------------
   ReactionMap* m_reactionMap;
   //G4Material* material = track.GetMaterial();
-  const G4ElementVector* elementVector = material->GetElementVector() ;
+  const G4ElementVector* elementVector = material->GetElementVector();
   const G4double* numberOfAtomsPerVolume = material->GetVecNbOfAtomsPerVolume();
 
-  G4double numberOfProtons=0;
-  G4double numberOfNucleons=0;
+  G4double numberOfProtons = 0;
+  G4double numberOfNucleons = 0;
 
-  //Loop on elements 
-  for ( size_t elm=0 ; elm < material->GetNumberOfElements() ; elm++ )
-    {
-      //Summing number of protons per unit volume
-      numberOfProtons += numberOfAtomsPerVolume[elm]*(*elementVector)[elm]->GetZ();
-      //Summing nucleons (not neutrons)
-      numberOfNucleons += numberOfAtomsPerVolume[elm]*(*elementVector)[elm]->GetN();
-    }
-  
+  //Loop on elements
+  for (size_t elm = 0; elm < material->GetNumberOfElements(); elm++) {
+    //Summing number of protons per unit volume
+    numberOfProtons += numberOfAtomsPerVolume[elm] * (*elementVector)[elm]->GetZ();
+    //Summing nucleons (not neutrons)
+    numberOfNucleons += numberOfAtomsPerVolume[elm] * (*elementVector)[elm]->GetN();
+  }
+
   //random decision of the target
-  if(G4UniformRand()<numberOfProtons/numberOfNucleons)
-    { //target is a proton
-      m_reactionMap = &m_protonReactionMap;
-      target = m_proton;
-    } else { //target is a neutron
-      m_reactionMap = &m_neutronReactionMap;
-      target = m_neutron;
-    }
-  
+  if (G4UniformRand() < numberOfProtons / numberOfNucleons) {  //target is a proton
+    m_reactionMap = &m_protonReactionMap;
+    target = m_proton;
+  } else {  //target is a neutron
+    m_reactionMap = &m_neutronReactionMap;
+    target = m_neutron;
+  }
+
   const G4int incidentPDG = incidentDynamicParticle->GetDefinition()->GetPDGEncoding();
 
   //Making a pointer directly to the ReactionProductList we are looking at. Makes life easier :-)
-  ReactionProductList*  reactionProductList = &((*m_reactionMap)[incidentPDG]);
+  ReactionProductList* reactionProductList = &((*m_reactionMap)[incidentPDG]);
 
   //-----------------------------------------------
   // Count processes
@@ -151,26 +148,25 @@ HadronicProcessHelper::ReactionProduct HadronicProcessHelper::finalState(const G
   // compute number of 2 -> 2 and 2 -> 3 processes
   //-----------------------------------------------
 
-  G4int good22 = 0; //Number of 2 -> 2 processes that are possible
-  G4int good23 = 0; //Number of 2 -> 3 processes that are possible
-  
+  G4int good22 = 0;  //Number of 2 -> 2 processes that are possible
+  G4int good23 = 0;  //Number of 2 -> 3 processes that are possible
+
   //This is the list to be populated
   ReactionProductList goodReactionProductList;
 
-  for (ReactionProductList::iterator prod_it = reactionProductList->begin();
-       prod_it != reactionProductList->end();
-       prod_it++){
+  for (ReactionProductList::iterator prod_it = reactionProductList->begin(); prod_it != reactionProductList->end();
+       prod_it++) {
     G4int secondaries = prod_it->size();
     // If the reaction is not possible we will not consider it
-    if(m_reactionIsPossible(*prod_it,incidentDynamicParticle,target)){
+    if (m_reactionIsPossible(*prod_it, incidentDynamicParticle, target)) {
       // The reaction is possible. Let's store and count it
       goodReactionProductList.push_back(*prod_it);
-      if (secondaries == 2){
-	good22++;
-      } else if (secondaries ==3) {
-	good23++;
+      if (secondaries == 2) {
+        good22++;
+      } else if (secondaries == 3) {
+        good23++;
       } else {
-	G4cerr << "ReactionProduct has unsupported number of secondaries: "<<secondaries<<G4endl;
+        G4cerr << "ReactionProduct has unsupported number of secondaries: " << secondaries << G4endl;
       }
     } /*else {
       G4cout<<"There was an impossible process"<<G4endl;
@@ -178,90 +174,93 @@ HadronicProcessHelper::ReactionProduct HadronicProcessHelper::finalState(const G
   }
   //  G4cout<<"The size of the ReactionProductList is: "<<theReactionProductList.size()<<G4endl;
 
-  if (goodReactionProductList.empty()) G4Exception("HadronicProcessHelper", "NoProcessPossible", FatalException,
-						    "GetFinalState: No process could be selected from the given list.");
+  if (goodReactionProductList.empty())
+    G4Exception("HadronicProcessHelper",
+                "NoProcessPossible",
+                FatalException,
+                "GetFinalState: No process could be selected from the given list.");
   // Fill a probability map. Remember total probability
   // 2->2 is 0.15*1/n_22 2->3 uses phase space
   G4double prob22 = 0.15;
-  G4double prob23 = 1-prob22; // :-)
+  G4double prob23 = 1 - prob22;  // :-)
 
   std::vector<G4double> probabilities;
   std::vector<G4bool> twoToThreeFlag;
-  
+
   G4double cumulatedProbability = 0;
 
   // To each ReactionProduct we assign a cumulated probability and a flag
   // discerning between 2 -> 2 and 2 -> 3
   size_t numberOfReactions = goodReactionProductList.size();
-  for (size_t i = 0; i != numberOfReactions; i++){
+  for (size_t i = 0; i != numberOfReactions; i++) {
     if (goodReactionProductList[i].size() == 2) {
-      cumulatedProbability += prob22/good22;
+      cumulatedProbability += prob22 / good22;
       twoToThreeFlag.push_back(false);
     } else {
-      cumulatedProbability += prob23/good23;
+      cumulatedProbability += prob23 / good23;
       twoToThreeFlag.push_back(true);
     }
     probabilities.push_back(cumulatedProbability);
   }
 
   //Normalising probabilities to 1
-  for (std::vector<G4double>::iterator it = probabilities.begin();
-       it != probabilities.end();
-       it++)
-    {
-      *it /= cumulatedProbability;
-    }
+  for (std::vector<G4double>::iterator it = probabilities.begin(); it != probabilities.end(); it++) {
+    *it /= cumulatedProbability;
+  }
 
   // Choosing ReactionProduct
   G4bool selected = false;
   G4int tries = 0;
   //  ReactionProductList::iterator prod_it;
 
-  //Keep looping over the list until we have a choice, or until we have tried 100 times  
+  //Keep looping over the list until we have a choice, or until we have tried 100 times
   size_t i;
-  while(!selected && tries < 100){
-    i=0;
+  while (!selected && tries < 100) {
+    i = 0;
     G4double dice = G4UniformRand();
     //select the process using the dice
-    while(dice>probabilities[i] && i<numberOfReactions)  i++;
+    while (dice > probabilities[i] && i < numberOfReactions)
+      i++;
 
-    if(twoToThreeFlag[i]) {
+    if (twoToThreeFlag[i]) {
       // 2 -> 3 processes require a phase space lookup
-      if (m_phaseSpace(goodReactionProductList[i],incidentDynamicParticle,target)>G4UniformRand()) selected = true;
+      if (m_phaseSpace(goodReactionProductList[i], incidentDynamicParticle, target) > G4UniformRand())
+        selected = true;
     } else {
       // 2 -> 2 processes are chosen immediately
       selected = true;
     }
     tries++;
   }
-  if(tries>=100) G4cerr<<"Could not select process!!!!"<<G4endl;
+  if (tries >= 100)
+    G4cerr << "Could not select process!!!!" << G4endl;
 
-  
   //Debugging stuff
   //Updating checkfraction:
-  if (goodReactionProductList[i].size()==2) {
+  if (goodReactionProductList[i].size() == 2) {
     m_n22++;
   } else {
     m_n23++;
   }
-  m_checkFraction = (1.0*m_n22)/(m_n22+m_n23);
-  
+  m_checkFraction = (1.0 * m_n22) / (m_n22 + m_n23);
+
   //return the selected productList
   return goodReactionProductList[i];
 }
 
 G4double HadronicProcessHelper::m_reactionProductMass(const ReactionProduct& reactionProd,
-  const G4DynamicParticle* incidentDynamicParticle,G4ParticleDefinition* target){
+                                                      const G4DynamicParticle* incidentDynamicParticle,
+                                                      G4ParticleDefinition* target) {
   // Incident energy:
   G4double incidentEnergy = incidentDynamicParticle->GetTotalEnergy();
   G4double m_1 = incidentDynamicParticle->GetDefinition()->GetPDGMass();
   G4double m_2 = target->GetPDGMass();
   //square root of "s"
-  G4double sqrtS = sqrt(m_1*m_1 + m_2*(m_2 + 2 * incidentEnergy));
+  G4double sqrtS = sqrt(m_1 * m_1 + m_2 * (m_2 + 2 * incidentEnergy));
   // Sum of rest masses after reaction:
   G4double productsMass = 0;
   //Loop on reaction producs
-  for (ReactionProduct::const_iterator r_it = reactionProd.begin(); r_it !=reactionProd.end(); r_it++){
+  for (ReactionProduct::const_iterator r_it = reactionProd.begin(); r_it != reactionProd.end(); r_it++) {
     //Sum the masses of the products
     productsMass += m_particleTable->FindParticle(*r_it)->GetPDGMass();
   }
@@ -270,38 +269,41 @@ G4double HadronicProcessHelper::m_reactionProductMass(const ReactionProduct& rea
 }
 
 G4bool HadronicProcessHelper::m_reactionIsPossible(const ReactionProduct& aReaction,
-     const G4DynamicParticle* aDynamicParticle,G4ParticleDefinition* target){
-  if (m_reactionProductMass(aReaction,aDynamicParticle,target)>0) return true;
+                                                   const G4DynamicParticle* aDynamicParticle,
+                                                   G4ParticleDefinition* target) {
+  if (m_reactionProductMass(aReaction, aDynamicParticle, target) > 0)
+    return true;
   return false;
 }
 
 G4double HadronicProcessHelper::m_phaseSpace(const ReactionProduct& aReaction,
-     const G4DynamicParticle* aDynamicParticle,G4ParticleDefinition* target){
-  G4double qValue = m_reactionProductMass(aReaction,aDynamicParticle,target);
-  G4double phi = sqrt(1+qValue/(2*0.139*GeV))*pow(qValue/(1.1*GeV),3./2.);
-  return (phi/(1+phi));
+                                             const G4DynamicParticle* aDynamicParticle,
+                                             G4ParticleDefinition* target) {
+  G4double qValue = m_reactionProductMass(aReaction, aDynamicParticle, target);
+  G4double phi = sqrt(1 + qValue / (2 * 0.139 * GeV)) * pow(qValue / (1.1 * GeV), 3. / 2.);
+  return (phi / (1 + phi));
 }
 
 void HadronicProcessHelper::m_readAndParse(const G4String& str,
-				   std::vector<G4String>& tokens,
-				   const G4String& delimiters)
-{
+                                           std::vector<G4String>& tokens,
+                                           const G4String& delimiters) {
   // Skip delimiters at beginning.
   G4String::size_type lastPos = str.find_first_not_of(delimiters, 0);
   // Find first "non-delimiter".
-  G4String::size_type pos     = str.find_first_of(delimiters, lastPos);
-  
-  while (G4String::npos != pos || G4String::npos != lastPos)
-    {
-      //Skipping leading / trailing whitespaces
-      G4String temp = str.substr(lastPos, pos - lastPos);
-      while(temp.c_str()[0] == ' ') temp.erase(0,1);
-      while(temp[temp.size()-1] == ' ') temp.erase(temp.size()-1,1);
-      // Found a token, add it to the vector.
-      tokens.push_back(temp);
-      // Skip delimiters.  Note the "not_of"
-      lastPos = str.find_first_not_of(delimiters, pos);
-      // Find next "non-delimiter"
-      pos = str.find_first_of(delimiters, lastPos);
-    }
+  G4String::size_type pos = str.find_first_of(delimiters, lastPos);
+
+  while (G4String::npos != pos || G4String::npos != lastPos) {
+    //Skipping leading / trailing whitespaces
+    G4String temp = str.substr(lastPos, pos - lastPos);
+    while (temp.c_str()[0] == ' ')
+      temp.erase(0, 1);
+    while (temp[temp.size() - 1] == ' ')
+      temp.erase(temp.size() - 1, 1);
+    // Found a token, add it to the vector.
+    tokens.push_back(temp);
+    // Skip delimiters.  Note the "not_of"
+    lastPos = str.find_first_not_of(delimiters, pos);
+    // Find next "non-delimiter"
+    pos = str.find_first_of(delimiters, lastPos);
+  }
 }

--- a/SimG4Core/PhysicsLists/interface/CMSEmNoDeltaRay.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmNoDeltaRay.h
@@ -7,8 +7,7 @@
 #include <string>
 
 class CMSEmNoDeltaRay : public G4VPhysicsConstructor {
-
-public: 
+public:
   CMSEmNoDeltaRay(const G4String& name, G4int ver, const std::string& reg);
   ~CMSEmNoDeltaRay() override;
 
@@ -16,14 +15,8 @@ public:
   void ConstructProcess() override;
 
 private:
-  G4int               verbose;
-  std::string         region;
+  G4int verbose;
+  std::string region;
 };
 
 #endif
-
-
-
-
-
-

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h
@@ -5,8 +5,7 @@
 #include "globals.hh"
 
 class CMSEmStandardPhysics : public G4VPhysicsConstructor {
-
-public: 
+public:
   CMSEmStandardPhysics(G4int ver);
   ~CMSEmStandardPhysics() override;
 
@@ -14,13 +13,7 @@ public:
   void ConstructProcess() override;
 
 private:
-  G4int               verbose;
+  G4int verbose;
 };
 
 #endif
-
-
-
-
-
-

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95.h
@@ -7,8 +7,7 @@
 #include <string>
 
 class CMSEmStandardPhysics95 : public G4VPhysicsConstructor {
-
-public: 
+public:
   CMSEmStandardPhysics95(const G4String& name, G4int ver, const std::string& reg);
   ~CMSEmStandardPhysics95() override;
 
@@ -16,14 +15,8 @@ public:
   void ConstructProcess() override;
 
 private:
-  G4int               verbose;
-  std::string         region;
+  G4int verbose;
+  std::string region;
 };
 
 #endif
-
-
-
-
-
-

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95msc93.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics95msc93.h
@@ -7,8 +7,7 @@
 #include <string>
 
 class CMSEmStandardPhysics95msc93 : public G4VPhysicsConstructor {
-
-public: 
+public:
   CMSEmStandardPhysics95msc93(const G4String& name, G4int ver, const std::string& reg);
   ~CMSEmStandardPhysics95msc93() override;
 
@@ -16,14 +15,8 @@ public:
   void ConstructProcess() override;
 
 private:
-  G4int               verbose;
-  std::string         region;
+  G4int verbose;
+  std::string region;
 };
 
 #endif
-
-
-
-
-
-

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h
@@ -6,8 +6,7 @@
 #include "globals.hh"
 
 class CMSEmStandardPhysicsLPM : public G4VPhysicsConstructor {
-
-public: 
+public:
   CMSEmStandardPhysicsLPM(G4int ver);
   ~CMSEmStandardPhysicsLPM() override;
 
@@ -15,13 +14,7 @@ public:
   void ConstructProcess() override;
 
 private:
-  G4int               verbose;
+  G4int verbose;
 };
 
 #endif
-
-
-
-
-
-

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsXS.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsXS.h
@@ -5,8 +5,7 @@
 #include "globals.hh"
 
 class CMSEmStandardPhysicsXS : public G4VPhysicsConstructor {
-
-public: 
+public:
   CMSEmStandardPhysicsXS(G4int ver);
   ~CMSEmStandardPhysicsXS() override;
 
@@ -14,13 +13,7 @@ public:
   void ConstructProcess() override;
 
 private:
-  G4int               verbose;
+  G4int verbose;
 };
 
 #endif
-
-
-
-
-
-

--- a/SimG4Core/PhysicsLists/interface/CMSFTFPNeutronBuilder.hh
+++ b/SimG4Core/PhysicsLists/interface/CMSFTFPNeutronBuilder.hh
@@ -18,34 +18,32 @@
 #include "G4ExcitedStringDecay.hh"
 #include "G4QuasiElasticChannel.hh"
 
-class CMSFTFPNeutronBuilder : public G4VNeutronBuilder
-{
-  public: 
-    CMSFTFPNeutronBuilder(G4bool quasiElastic=false);
-    ~CMSFTFPNeutronBuilder() override;
+class CMSFTFPNeutronBuilder : public G4VNeutronBuilder {
+public:
+  CMSFTFPNeutronBuilder(G4bool quasiElastic = false);
+  ~CMSFTFPNeutronBuilder() override;
 
-  public: 
-    void Build(G4HadronElasticProcess * aP) override;
-    void Build(G4HadronFissionProcess * aP) override;
-    void Build(G4HadronCaptureProcess * aP) override;
-    void Build(G4NeutronInelasticProcess * aP) override;
-    
-    void SetMinEnergy(G4double aM) override {theMin = aM;}
-    void SetMaxEnergy(G4double aM) override {theMax = aM;}
+public:
+  void Build(G4HadronElasticProcess* aP) override;
+  void Build(G4HadronFissionProcess* aP) override;
+  void Build(G4HadronCaptureProcess* aP) override;
+  void Build(G4NeutronInelasticProcess* aP) override;
 
-  private:
-    G4TheoFSGenerator * theModel;
-    G4PreCompoundModel * thePreEquilib;
-    G4GeneratorPrecompoundInterface * theCascade;
-    G4FTFModel * theStringModel;
-    G4ExcitedStringDecay * theStringDecay;
-    G4QuasiElasticChannel * theQuasiElastic;
+  void SetMinEnergy(G4double aM) override { theMin = aM; }
+  void SetMaxEnergy(G4double aM) override { theMax = aM; }
 
-    G4double theMin;
-    G4double theMax;
+private:
+  G4TheoFSGenerator* theModel;
+  G4PreCompoundModel* thePreEquilib;
+  G4GeneratorPrecompoundInterface* theCascade;
+  G4FTFModel* theStringModel;
+  G4ExcitedStringDecay* theStringDecay;
+  G4QuasiElasticChannel* theQuasiElastic;
+
+  G4double theMin;
+  G4double theMax;
 };
 
 // 2002 by J.P. Wellisch
 
 #endif
-

--- a/SimG4Core/PhysicsLists/interface/CMSFTFPPiKBuilder.hh
+++ b/SimG4Core/PhysicsLists/interface/CMSFTFPPiKBuilder.hh
@@ -20,39 +20,36 @@
 
 #include "G4PiNuclearCrossSection.hh"
 
-class CMSFTFPPiKBuilder : public G4VPiKBuilder
-{
-  public: 
-    CMSFTFPPiKBuilder(G4bool quasiElastic=false);
-    ~CMSFTFPPiKBuilder() override;
+class CMSFTFPPiKBuilder : public G4VPiKBuilder {
+public:
+  CMSFTFPPiKBuilder(G4bool quasiElastic = false);
+  ~CMSFTFPPiKBuilder() override;
 
-  public: 
-    void Build(G4HadronElasticProcess * aP) override;
-    void Build(G4PionPlusInelasticProcess * aP) override;
-    void Build(G4PionMinusInelasticProcess * aP) override;
-    void Build(G4KaonPlusInelasticProcess * aP) override;
-    void Build(G4KaonMinusInelasticProcess * aP) override;
-    void Build(G4KaonZeroLInelasticProcess * aP) override;
-    void Build(G4KaonZeroSInelasticProcess * aP) override;
-    
-    void SetMinEnergy(G4double aM) override {theMin = aM;}
-    void SetMaxEnergy(G4double aM) override {theMax = aM;}
+public:
+  void Build(G4HadronElasticProcess* aP) override;
+  void Build(G4PionPlusInelasticProcess* aP) override;
+  void Build(G4PionMinusInelasticProcess* aP) override;
+  void Build(G4KaonPlusInelasticProcess* aP) override;
+  void Build(G4KaonMinusInelasticProcess* aP) override;
+  void Build(G4KaonZeroLInelasticProcess* aP) override;
+  void Build(G4KaonZeroSInelasticProcess* aP) override;
 
-  private:
-    G4TheoFSGenerator * theModel;
-    G4PreCompoundModel * thePreEquilib;
-    G4GeneratorPrecompoundInterface * theCascade;
-    G4FTFModel * theStringModel;
-    G4ExcitedStringDecay * theStringDecay;
-    G4QuasiElasticChannel * theQuasiElastic;
+  void SetMinEnergy(G4double aM) override { theMin = aM; }
+  void SetMaxEnergy(G4double aM) override { theMax = aM; }
 
-    G4PiNuclearCrossSection* thePiData;
-    G4double theMin;
-    G4double theMax;
+private:
+  G4TheoFSGenerator* theModel;
+  G4PreCompoundModel* thePreEquilib;
+  G4GeneratorPrecompoundInterface* theCascade;
+  G4FTFModel* theStringModel;
+  G4ExcitedStringDecay* theStringDecay;
+  G4QuasiElasticChannel* theQuasiElastic;
 
+  G4PiNuclearCrossSection* thePiData;
+  G4double theMin;
+  G4double theMax;
 };
 
 // 2002 by J.P. Wellisch
 
 #endif
-

--- a/SimG4Core/PhysicsLists/interface/CMSFTFPProtonBuilder.hh
+++ b/SimG4Core/PhysicsLists/interface/CMSFTFPProtonBuilder.hh
@@ -1,5 +1,5 @@
 #ifndef SimG4Core_PhysicsLists_CMSFTFPProtonBuilder_h
-#define SimG4Core_PhysicsLists_CMSFTFPProtonBuilder_h 
+#define SimG4Core_PhysicsLists_CMSFTFPProtonBuilder_h
 
 #include "globals.hh"
 
@@ -18,33 +18,30 @@
 #include "G4ExcitedStringDecay.hh"
 #include "G4QuasiElasticChannel.hh"
 
-class CMSFTFPProtonBuilder : public G4VProtonBuilder
-{
-  public: 
-    CMSFTFPProtonBuilder(G4bool quasiElastic=false);
-    ~CMSFTFPProtonBuilder() override;
+class CMSFTFPProtonBuilder : public G4VProtonBuilder {
+public:
+  CMSFTFPProtonBuilder(G4bool quasiElastic = false);
+  ~CMSFTFPProtonBuilder() override;
 
-  public: 
-    void Build(G4HadronElasticProcess * aP) override;
-    void Build(G4ProtonInelasticProcess * aP) override;
-    
-    void SetMinEnergy(G4double aM) override {theMin = aM;}
-    void SetMaxEnergy(G4double aM) override {theMax = aM;}
+public:
+  void Build(G4HadronElasticProcess* aP) override;
+  void Build(G4ProtonInelasticProcess* aP) override;
 
-  private:
-    G4TheoFSGenerator * theModel;
-    G4PreCompoundModel * thePreEquilib;
-    G4GeneratorPrecompoundInterface * theCascade;
-    G4FTFModel * theStringModel;
-    G4ExcitedStringDecay * theStringDecay;
-    G4QuasiElasticChannel * theQuasiElastic;
+  void SetMinEnergy(G4double aM) override { theMin = aM; }
+  void SetMaxEnergy(G4double aM) override { theMax = aM; }
 
-    G4double theMin;
-    G4double theMax;
+private:
+  G4TheoFSGenerator* theModel;
+  G4PreCompoundModel* thePreEquilib;
+  G4GeneratorPrecompoundInterface* theCascade;
+  G4FTFModel* theStringModel;
+  G4ExcitedStringDecay* theStringDecay;
+  G4QuasiElasticChannel* theQuasiElastic;
 
+  G4double theMin;
+  G4double theMax;
 };
 
 // 2002 by J.P. Wellisch
 
 #endif
-

--- a/SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT.h
+++ b/SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT.h
@@ -21,46 +21,45 @@
 class G4ComponentGGHadronNucleusXsc;
 class G4VCrossSectionDataSet;
 
-class CMSHadronPhysicsFTFP_BERT : public G4VPhysicsConstructor
-{
-  public: 
-    explicit CMSHadronPhysicsFTFP_BERT(G4int verbose =1);
-    ~CMSHadronPhysicsFTFP_BERT() override;
+class CMSHadronPhysicsFTFP_BERT : public G4VPhysicsConstructor {
+public:
+  explicit CMSHadronPhysicsFTFP_BERT(G4int verbose = 1);
+  ~CMSHadronPhysicsFTFP_BERT() override;
 
-    void ConstructParticle() override;
-    //This will call in order:
-    // DumpBanner (for master)
-    // CreateModels
-    // ExtraConfiguation
-    void ConstructProcess() override;
+  void ConstructParticle() override;
+  //This will call in order:
+  // DumpBanner (for master)
+  // CreateModels
+  // ExtraConfiguation
+  void ConstructProcess() override;
 
-    void TerminateWorker() override;
-  protected:
-    G4bool QuasiElastic;
-    //This calls the specific ones for the different particles in order
-    virtual void CreateModels();
-    virtual void Neutron();
-    virtual void Proton();
-    virtual void Pion();
-    virtual void Kaon();
-    virtual void Others();
-    virtual void DumpBanner();
-    //This contains extra configurataion specific to this PL
-    virtual void ExtraConfiguration();
+  void TerminateWorker() override;
 
-    G4double minFTFP_pion;
-    G4double maxBERT_pion;
-    G4double minFTFP_kaon;
-    G4double maxBERT_kaon;
-    G4double minFTFP_proton;
-    G4double maxBERT_proton;
-    G4double minFTFP_neutron;
-    G4double maxBERT_neutron;
+protected:
+  G4bool QuasiElastic;
+  //This calls the specific ones for the different particles in order
+  virtual void CreateModels();
+  virtual void Neutron();
+  virtual void Proton();
+  virtual void Pion();
+  virtual void Kaon();
+  virtual void Others();
+  virtual void DumpBanner();
+  //This contains extra configurataion specific to this PL
+  virtual void ExtraConfiguration();
 
-    //Thread-private data write them here to delete them
-    G4VectorCache<G4VCrossSectionDataSet*> xs_ds;
-    G4Cache<G4ComponentGGHadronNucleusXsc*> xs_k;
+  G4double minFTFP_pion;
+  G4double maxBERT_pion;
+  G4double minFTFP_kaon;
+  G4double maxBERT_kaon;
+  G4double minFTFP_proton;
+  G4double maxBERT_proton;
+  G4double minFTFP_neutron;
+  G4double maxBERT_neutron;
+
+  //Thread-private data write them here to delete them
+  G4VectorCache<G4VCrossSectionDataSet*> xs_ds;
+  G4Cache<G4ComponentGGHadronNucleusXsc*> xs_k;
 };
 
 #endif
-

--- a/SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT_ATL.h
+++ b/SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT_ATL.h
@@ -36,44 +36,42 @@
 
 class G4ComponentGGHadronNucleusXsc;
 
-class CMSHadronPhysicsFTFP_BERT_ATL : public G4VPhysicsConstructor
-{
-  public:
-    CMSHadronPhysicsFTFP_BERT_ATL(G4int verbose =1);
-    ~CMSHadronPhysicsFTFP_BERT_ATL() override;
+class CMSHadronPhysicsFTFP_BERT_ATL : public G4VPhysicsConstructor {
+public:
+  CMSHadronPhysicsFTFP_BERT_ATL(G4int verbose = 1);
+  ~CMSHadronPhysicsFTFP_BERT_ATL() override;
 
-    void ConstructParticle() override;
-    void ConstructProcess() override;
+  void ConstructParticle() override;
+  void ConstructProcess() override;
 
-  private:
-    void CreateModels();
-    G4bool QuasiElastic;
+private:
+  void CreateModels();
+  G4bool QuasiElastic;
 
-    // Simplify handling of TLS data, encapsulate everyhing in a structure
-    struct ThreadPrivate { 
-      G4NeutronBuilder * theNeutrons;
-      G4BertiniNeutronBuilder * theBertiniNeutron;
-      G4FTFPNeutronBuilder * theFTFPNeutron;
- 
-      G4PiKBuilder * thePiK;
-      G4BertiniPiKBuilder * theBertiniPiK;
-      G4FTFPPiKBuilder * theFTFPPiK;
-    
-      G4ProtonBuilder * thePro;
-      G4BertiniProtonBuilder * theBertiniPro;
-      G4FTFPProtonBuilder * theFTFPPro;    
-    
-      G4HyperonFTFPBuilder * theHyperon;
-    
-      G4AntiBarionBuilder * theAntiBaryon;
-      G4FTFPAntiBarionBuilder * theFTFPAntiBaryon;
+  // Simplify handling of TLS data, encapsulate everyhing in a structure
+  struct ThreadPrivate {
+    G4NeutronBuilder* theNeutrons;
+    G4BertiniNeutronBuilder* theBertiniNeutron;
+    G4FTFPNeutronBuilder* theFTFPNeutron;
 
-      G4ComponentGGHadronNucleusXsc * xsKaon;
-      G4VCrossSectionDataSet * xsNeutronInelasticXS;
-      G4VCrossSectionDataSet * xsNeutronCaptureXS;
-    };
-    static G4ThreadLocal ThreadPrivate* tpdata;
+    G4PiKBuilder* thePiK;
+    G4BertiniPiKBuilder* theBertiniPiK;
+    G4FTFPPiKBuilder* theFTFPPiK;
+
+    G4ProtonBuilder* thePro;
+    G4BertiniProtonBuilder* theBertiniPro;
+    G4FTFPProtonBuilder* theFTFPPro;
+
+    G4HyperonFTFPBuilder* theHyperon;
+
+    G4AntiBarionBuilder* theAntiBaryon;
+    G4FTFPAntiBarionBuilder* theFTFPAntiBaryon;
+
+    G4ComponentGGHadronNucleusXsc* xsKaon;
+    G4VCrossSectionDataSet* xsNeutronInelasticXS;
+    G4VCrossSectionDataSet* xsNeutronCaptureXS;
+  };
+  static G4ThreadLocal ThreadPrivate* tpdata;
 };
 
 #endif
-

--- a/SimG4Core/PhysicsLists/interface/CMSMonopolePhysics.h
+++ b/SimG4Core/PhysicsLists/interface/CMSMonopolePhysics.h
@@ -16,22 +16,20 @@ namespace sim {
 }
 
 class CMSMonopolePhysics : public G4VPhysicsConstructor {
-
-public: 
-  CMSMonopolePhysics(const HepPDT::ParticleDataTable * table_, const edm::ParameterSet & p);
+public:
+  CMSMonopolePhysics(const HepPDT::ParticleDataTable* table_, const edm::ParameterSet& p);
   ~CMSMonopolePhysics() override;
 
   void ConstructParticle() override;
   void ConstructProcess() override;
 
 private:
-
-  G4int                    verbose, magCharge;
-  G4bool                   deltaRay, multiSc, transport;
+  G4int verbose, magCharge;
+  G4bool deltaRay, multiSc, transport;
   std::vector<std::string> names;
-  std::vector<double>      masses;
-  std::vector<int>         elCharges, pdgEncodings;
-  std::vector<Monopole*>   monopoles;
+  std::vector<double> masses;
+  std::vector<int> elCharges, pdgEncodings;
+  std::vector<Monopole*> monopoles;
 };
 
 #endif

--- a/SimG4Core/PhysicsLists/interface/CMSThermalNeutrons.h
+++ b/SimG4Core/PhysicsLists/interface/CMSThermalNeutrons.h
@@ -5,21 +5,14 @@
 #include "globals.hh"
 
 class CMSThermalNeutrons : public G4VHadronPhysics {
-
-public: 
+public:
   CMSThermalNeutrons(G4int ver);
   ~CMSThermalNeutrons() override;
 
   void ConstructProcess() override;
 
 private:
-  G4int               verbose;
+  G4int verbose;
 };
 
 #endif
-
-
-
-
-
-

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisation.h
@@ -14,8 +14,8 @@
 //
 // This class manages the ionisation process for a magnetic monopole
 // it inherites from G4VContinuousDiscreteProcess via G4VEnergyLossProcess.
-// Magnetic charge of the monopole should be defined in the constructor of 
-// the process, unless it is assumed that it is classic Dirac monopole with 
+// Magnetic charge of the monopole should be defined in the constructor of
+// the process, unless it is assumed that it is classic Dirac monopole with
 // the charge 67.5*eplus. The name of the particle should be "monopole".
 //
 
@@ -32,20 +32,15 @@
 class G4Material;
 class G4VEmFluctuationModel;
 
-class CMSmplIonisation : public G4VEnergyLossProcess
-{
-
+class CMSmplIonisation : public G4VEnergyLossProcess {
 public:
-
-  explicit CMSmplIonisation(G4double mCharge = 0.0, 
-                           const G4String& name = "mplIoni");
+  explicit CMSmplIonisation(G4double mCharge = 0.0, const G4String& name = "mplIoni");
 
   ~CMSmplIonisation() override;
 
   G4bool IsApplicable(const G4ParticleDefinition& p) override;
 
-  G4double MinPrimaryEnergy(const G4ParticleDefinition* p,
-                                    const G4Material*, G4double cut) final;
+  G4double MinPrimaryEnergy(const G4ParticleDefinition* p, const G4Material*, G4double cut) final;
 
   // Print out of the class parameters
   void PrintInfo() override;
@@ -54,14 +49,11 @@ public:
   void ProcessDescription(std::ostream&) const override;
 
 protected:
-
-  void InitialiseEnergyLossProcess(const G4ParticleDefinition*,
-                                   const G4ParticleDefinition*) override;
+  void InitialiseEnergyLossProcess(const G4ParticleDefinition*, const G4ParticleDefinition*) override;
 
 private:
-
-  G4double    magneticCharge;
-  G4bool      isInitialised;
+  G4double magneticCharge;
+  G4bool isInitialised;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....

--- a/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
+++ b/SimG4Core/PhysicsLists/interface/CMSmplIonisationWithDeltaModel.h
@@ -26,73 +26,58 @@
 
 class G4ParticleChangeForLoss;
 
-class CMSmplIonisationWithDeltaModel : public G4VEmModel, public G4VEmFluctuationModel
-{
-
+class CMSmplIonisationWithDeltaModel : public G4VEmModel, public G4VEmFluctuationModel {
 public:
-
-  explicit CMSmplIonisationWithDeltaModel(G4double mCharge, 
-                                const G4String& nam = "mplIonisationWithDelta");
+  explicit CMSmplIonisationWithDeltaModel(G4double mCharge, const G4String& nam = "mplIonisationWithDelta");
 
   ~CMSmplIonisationWithDeltaModel() override;
 
-  void Initialise(const G4ParticleDefinition*, 
-                          const G4DataVector&) override;
+  void Initialise(const G4ParticleDefinition*, const G4DataVector&) override;
 
   G4double ComputeDEDXPerVolume(const G4Material*,
-                                        const G4ParticleDefinition*,
-                                        G4double kineticEnergy,
-                                        G4double cutEnergy) override;
+                                const G4ParticleDefinition*,
+                                G4double kineticEnergy,
+                                G4double cutEnergy) override;
 
-  virtual G4double ComputeCrossSectionPerElectron(
-                                 const G4ParticleDefinition*,
-                                 G4double kineticEnergy,
-                                 G4double cutEnergy,
-                                 G4double maxEnergy);
+  virtual G4double ComputeCrossSectionPerElectron(const G4ParticleDefinition*,
+                                                  G4double kineticEnergy,
+                                                  G4double cutEnergy,
+                                                  G4double maxEnergy);
 
-  G4double ComputeCrossSectionPerAtom(
-                                 const G4ParticleDefinition*,
-                                 G4double kineticEnergy,
-                                 G4double Z, G4double A,
-                                 G4double cutEnergy,
-                                 G4double maxEnergy) override;
+  G4double ComputeCrossSectionPerAtom(const G4ParticleDefinition*,
+                                      G4double kineticEnergy,
+                                      G4double Z,
+                                      G4double A,
+                                      G4double cutEnergy,
+                                      G4double maxEnergy) override;
 
   void SampleSecondaries(std::vector<G4DynamicParticle*>*,
-                                 const G4MaterialCutsCouple*,
-                                 const G4DynamicParticle*,
-                                 G4double tmin,
-                                 G4double maxEnergy) override;
-
+                         const G4MaterialCutsCouple*,
+                         const G4DynamicParticle*,
+                         G4double tmin,
+                         G4double maxEnergy) override;
 
   G4double SampleFluctuations(const G4MaterialCutsCouple*,
-                                      const G4DynamicParticle*,
-                                      G4double tmax,
-                                      G4double length,
-                                      G4double meanLoss) override;
-
-  G4double Dispersion(const G4Material*,
                               const G4DynamicParticle*,
                               G4double tmax,
-                              G4double length) override;
+                              G4double length,
+                              G4double meanLoss) override;
 
-  G4double MinEnergyCut(const G4ParticleDefinition*,
-                                const G4MaterialCutsCouple* couple) override;
+  G4double Dispersion(const G4Material*, const G4DynamicParticle*, G4double tmax, G4double length) override;
+
+  G4double MinEnergyCut(const G4ParticleDefinition*, const G4MaterialCutsCouple* couple) override;
 
   void SetParticle(const G4ParticleDefinition* p);
 
 protected:
-
-  G4double MaxSecondaryEnergy(const G4ParticleDefinition*,
-                                      G4double kinEnergy) override;
+  G4double MaxSecondaryEnergy(const G4ParticleDefinition*, G4double kinEnergy) override;
 
 private:
-
-  G4double ComputeDEDXAhlen(const G4Material* material, G4double bg2, 
-                            G4double cut);
+  G4double ComputeDEDXAhlen(const G4Material* material, G4double bg2, G4double cut);
 
   const G4ParticleDefinition* monopole;
-  G4ParticleDefinition*       theElectron;
-  G4ParticleChangeForLoss*    fParticleChange;
+  G4ParticleDefinition* theElectron;
+  G4ParticleChangeForLoss* fParticleChange;
 
   G4double mass;
   G4double magCharge;
@@ -103,7 +88,7 @@ private:
   G4double bg2lim;
   G4double chargeSquare;
   G4double dedxlim;
-  G4int    nmpl;
+  G4int nmpl;
   G4double pi_hbarc2_over_mc2;
 
   static std::vector<G4double>* dedx0;

--- a/SimG4Core/PhysicsLists/interface/DummyEMPhysics.h
+++ b/SimG4Core/PhysicsLists/interface/DummyEMPhysics.h
@@ -1,12 +1,11 @@
 #ifndef SimG4Core_PhysicsLists_DummyEMPhysics_h
 #define SimG4Core_PhysicsLists_DummyEMPhysics_h
 
-// Physics List equivalent to GeantV 
+// Physics List equivalent to GeantV
 
 #include "G4VPhysicsConstructor.hh"
 
 class DummyEMPhysics : public G4VPhysicsConstructor {
-
 public:
   DummyEMPhysics(G4int verb);
   ~DummyEMPhysics() override = default;
@@ -14,9 +13,7 @@ public:
   void ConstructProcess() override;
 
 private:
-
   G4int verbose;
 };
 
 #endif
-

--- a/SimG4Core/PhysicsLists/interface/EmParticleList.h
+++ b/SimG4Core/PhysicsLists/interface/EmParticleList.h
@@ -2,15 +2,13 @@
 #define SimG4Core_PhysicsList_EmParticleList_h 1
 
 // V.Ivanchenko 6 March 2017
-// List of Geant4 basic particle names used in SIM step 
+// List of Geant4 basic particle names used in SIM step
 
 #include "globals.hh"
 #include <vector>
 
 class EmParticleList {
-
 public:
-
   explicit EmParticleList();
 
   ~EmParticleList();
@@ -18,9 +16,7 @@ public:
   const std::vector<G4String>& PartNames() const;
 
 private:
-  std::vector<G4String>  pNames; 
-  
+  std::vector<G4String> pNames;
 };
 
 #endif
-

--- a/SimG4Core/PhysicsLists/interface/HadronPhysicsCMS.h
+++ b/SimG4Core/PhysicsLists/interface/HadronPhysicsCMS.h
@@ -24,50 +24,45 @@
 #include "G4FTFPNeutronBuilder.hh"
 #include "G4QGSPNeutronBuilder.hh"
 
-#include "G4FTFBinaryNeutronBuilder.hh"  
+#include "G4FTFBinaryNeutronBuilder.hh"
 #include "G4FTFBinaryPiKBuilder.hh"
 #include "G4FTFBinaryProtonBuilder.hh"
 
 class HadronPhysicsCMS : public G4VPhysicsConstructor {
-
 public:
-
-  HadronPhysicsCMS(const G4String& name ="QGSP", G4bool quasiElastic=true);
+  HadronPhysicsCMS(const G4String& name = "QGSP", G4bool quasiElastic = true);
   ~HadronPhysicsCMS() override;
 
   void ConstructParticle() override;
   void ConstructProcess() override;
 
 private:
-
   void CreateModels();
 
-  G4NeutronBuilder          * theNeutrons;
-  G4BertiniNeutronBuilder   * theBertiniNeutron;
-  G4BinaryNeutronBuilder    * theBinaryNeutron;
-  G4FTFPNeutronBuilder      * theFTFPNeutron;
-  G4QGSPNeutronBuilder      * theQGSPNeutron;
-    
-  G4PiKBuilder              * thePiK;
-  G4BertiniPiKBuilder       * theBertiniPiK;
-  G4BinaryPiKBuilder        * theBinaryPiK;
-  G4FTFPPiKBuilder          * theFTFPPiK;
-  G4QGSPPiKBuilder          * theQGSPPiK;
-    
-  G4ProtonBuilder           * thePro;
-  G4BertiniProtonBuilder    * theBertiniPro;
-  G4BinaryProtonBuilder     * theBinaryPro;
-  G4FTFPProtonBuilder       * theFTFPPro;
-  G4QGSPProtonBuilder       * theQGSPPro;    
-    
+  G4NeutronBuilder* theNeutrons;
+  G4BertiniNeutronBuilder* theBertiniNeutron;
+  G4BinaryNeutronBuilder* theBinaryNeutron;
+  G4FTFPNeutronBuilder* theFTFPNeutron;
+  G4QGSPNeutronBuilder* theQGSPNeutron;
 
-  G4FTFBinaryNeutronBuilder * theFTFNeutron;
-  G4FTFBinaryPiKBuilder     * theFTFPiK;
-  G4FTFBinaryProtonBuilder  * theFTFPro;
+  G4PiKBuilder* thePiK;
+  G4BertiniPiKBuilder* theBertiniPiK;
+  G4BinaryPiKBuilder* theBinaryPiK;
+  G4FTFPPiKBuilder* theFTFPPiK;
+  G4QGSPPiKBuilder* theQGSPPiK;
 
-  G4String                    modelName;
-  G4bool                      QuasiElastic;
+  G4ProtonBuilder* thePro;
+  G4BertiniProtonBuilder* theBertiniPro;
+  G4BinaryProtonBuilder* theBinaryPro;
+  G4FTFPProtonBuilder* theFTFPPro;
+  G4QGSPProtonBuilder* theQGSPPro;
+
+  G4FTFBinaryNeutronBuilder* theFTFNeutron;
+  G4FTFBinaryPiKBuilder* theFTFPiK;
+  G4FTFBinaryProtonBuilder* theFTFPro;
+
+  G4String modelName;
+  G4bool QuasiElastic;
 };
 
 #endif
-

--- a/SimG4Core/PhysicsLists/interface/HadronPhysicsQGSPCMS_FTFP_BERT.h
+++ b/SimG4Core/PhysicsLists/interface/HadronPhysicsQGSPCMS_FTFP_BERT.h
@@ -25,41 +25,39 @@
 #include "G4AntiBarionBuilder.hh"
 #include "G4FTFPAntiBarionBuilder.hh"
 
-class HadronPhysicsQGSPCMS_FTFP_BERT : public G4VPhysicsConstructor
-{
-  public:
-    HadronPhysicsQGSPCMS_FTFP_BERT(G4int verbose);
-    ~HadronPhysicsQGSPCMS_FTFP_BERT() override;
+class HadronPhysicsQGSPCMS_FTFP_BERT : public G4VPhysicsConstructor {
+public:
+  HadronPhysicsQGSPCMS_FTFP_BERT(G4int verbose);
+  ~HadronPhysicsQGSPCMS_FTFP_BERT() override;
 
-    void ConstructParticle() override;
-    void ConstructProcess() override;
+  void ConstructParticle() override;
+  void ConstructProcess() override;
 
-  private:
-    void CreateModels();
+private:
+  void CreateModels();
 
-    struct ThreadPrivate {
-      G4NeutronBuilder * theNeutrons;
-      G4FTFPNeutronBuilder * theFTFPNeutron;
-      G4QGSPNeutronBuilder * theQGSPNeutron;
-      G4BertiniNeutronBuilder * theBertiniNeutron;
-    
-      G4PiKBuilder * thePiK;
-      G4FTFPPiKBuilder * theFTFPPiK;
-      G4QGSPPiKBuilder * theQGSPPiK;
-      G4BertiniPiKBuilder * theBertiniPiK;
-    
-      G4ProtonBuilder * thePro;
-      G4FTFPProtonBuilder * theFTFPPro;
-      G4QGSPProtonBuilder * theQGSPPro; 
-      G4BertiniProtonBuilder * theBertiniPro;
-    
-      G4HyperonFTFPBuilder *theHyperon;
+  struct ThreadPrivate {
+    G4NeutronBuilder *theNeutrons;
+    G4FTFPNeutronBuilder *theFTFPNeutron;
+    G4QGSPNeutronBuilder *theQGSPNeutron;
+    G4BertiniNeutronBuilder *theBertiniNeutron;
 
-      G4AntiBarionBuilder     *theAntiBaryon;
-      G4FTFPAntiBarionBuilder *theFTFPAntiBaryon;
-    };
-    static G4ThreadLocal ThreadPrivate* tpdata;    
+    G4PiKBuilder *thePiK;
+    G4FTFPPiKBuilder *theFTFPPiK;
+    G4QGSPPiKBuilder *theQGSPPiK;
+    G4BertiniPiKBuilder *theBertiniPiK;
+
+    G4ProtonBuilder *thePro;
+    G4FTFPProtonBuilder *theFTFPPro;
+    G4QGSPProtonBuilder *theQGSPPro;
+    G4BertiniProtonBuilder *theBertiniPro;
+
+    G4HyperonFTFPBuilder *theHyperon;
+
+    G4AntiBarionBuilder *theAntiBaryon;
+    G4FTFPAntiBarionBuilder *theFTFPAntiBaryon;
+  };
+  static G4ThreadLocal ThreadPrivate *tpdata;
 };
 
 #endif
-

--- a/SimG4Core/PhysicsLists/interface/MonopoleTransportation.h
+++ b/SimG4Core/PhysicsLists/interface/MonopoleTransportation.h
@@ -3,23 +3,23 @@
 //
 // Class MonopoleTransportation
 //
-// Created:  3 May 2010, J. Apostolakis, B. Bozsogi 
+// Created:  3 May 2010, J. Apostolakis, B. Bozsogi
 //                       G4MonopoleTransportation class for
 //                       Geant4 extended example "monopole"
 //
 // Adopted for CMSSW by V.Ivanchenko 30 April 2018
-// from Geant4 global tag geant4-10-04-ref-03                   
+// from Geant4 global tag geant4-10-04-ref-03
 //
 // =======================================================================
-// 
+//
 // Class description:
 //
-// G4MonopoleTransportation is a process responsible for the transportation of 
-// magnetic monopoles, i.e. the geometrical propagation encountering the 
+// G4MonopoleTransportation is a process responsible for the transportation of
+// magnetic monopoles, i.e. the geometrical propagation encountering the
 // geometrical sub-volumes of the detectors.
 // It is also tasked with part of updating the "safety".
 // For monopoles, uses a different equation of motion and ignores energy
-// conservation. 
+// conservation.
 //
 
 #ifndef SimG4Core_PhysicsLists_MonopoleTransportation_h
@@ -38,112 +38,97 @@
 
 #include <memory>
 
-class G4SafetyHelper; 
+class G4SafetyHelper;
 class Monopole;
 class CMSFieldManager;
 
-class MonopoleTransportation : public G4VProcess 
-{
-public: 
+class MonopoleTransportation : public G4VProcess {
+public:
+  MonopoleTransportation(const Monopole* p, G4int verbosityLevel = 1);
+  ~MonopoleTransportation() override;
 
-  MonopoleTransportation(const Monopole* p, G4int verbosityLevel= 1);
-  ~MonopoleTransportation() override; 
+  G4double AlongStepGetPhysicalInteractionLength(const G4Track& track,
+                                                 G4double previousStepSize,
+                                                 G4double currentMinimumStep,
+                                                 G4double& currentSafety,
+                                                 G4GPILSelection* selection) override;
 
-  G4double AlongStepGetPhysicalInteractionLength(
-                             const G4Track& track,
-                                   G4double  previousStepSize,
-                                   G4double  currentMinimumStep, 
-                                   G4double& currentSafety,
-                                   G4GPILSelection* selection
-							 ) override;
+  G4VParticleChange* AlongStepDoIt(const G4Track& track, const G4Step& stepData) override;
 
-  G4VParticleChange* AlongStepDoIt(
-                             const G4Track& track,
-                             const G4Step& stepData
-					   ) override;
-
-  G4VParticleChange* PostStepDoIt(
-                             const G4Track& track,
-                             const G4Step&  stepData
-					  ) override;
+  G4VParticleChange* PostStepDoIt(const G4Track& track, const G4Step& stepData) override;
   // Responsible for the relocation.
 
-  G4double PostStepGetPhysicalInteractionLength(
-                             const G4Track& ,
-                             G4double   previousStepSize,
-                             G4ForceCondition* pForceCond
-							) override;
-  // Forces the PostStepDoIt action to be called, 
+  G4double PostStepGetPhysicalInteractionLength(const G4Track&,
+                                                G4double previousStepSize,
+                                                G4ForceCondition* pForceCond) override;
+  // Forces the PostStepDoIt action to be called,
   // but does not limit the step.
 
   G4PropagatorInField* GetPropagatorInField();
-  void SetPropagatorInField( G4PropagatorInField* pFieldPropagator);
+  void SetPropagatorInField(G4PropagatorInField* pFieldPropagator);
   // Access/set the assistant class that Propagate in a Field.
 
-  inline G4double GetThresholdWarningEnergy() const; 
-  inline G4double GetThresholdImportantEnergy() const; 
-  inline G4int GetThresholdTrials() const; 
+  inline G4double GetThresholdWarningEnergy() const;
+  inline G4double GetThresholdImportantEnergy() const;
+  inline G4int GetThresholdTrials() const;
 
-  inline void SetThresholdWarningEnergy( G4double newEnWarn ); 
-  inline void SetThresholdImportantEnergy( G4double newEnImp ); 
-  inline void SetThresholdTrials(G4int newMaxTrials ); 
+  inline void SetThresholdWarningEnergy(G4double newEnWarn);
+  inline void SetThresholdImportantEnergy(G4double newEnImp);
+  inline void SetThresholdTrials(G4int newMaxTrials);
 
-  // Get/Set parameters for killing loopers: 
-  //   Above 'important' energy a 'looping' particle in field will 
+  // Get/Set parameters for killing loopers:
+  //   Above 'important' energy a 'looping' particle in field will
   //   *NOT* be abandoned, except after fThresholdTrials attempts.
   // Below Warning energy, no verbosity for looping particles is issued
 
-  inline G4double GetMaxEnergyKilled() const; 
+  inline G4double GetMaxEnergyKilled() const;
   inline G4double GetSumEnergyKilled() const;
-  void ResetKilledStatistics( G4int report = 1);      
+  void ResetKilledStatistics(G4int report = 1);
   // Statistics for tracks killed (currently due to looping in field)
 
-  inline void EnableShortStepOptimisation(G4bool optimise=true); 
+  inline void EnableShortStepOptimisation(G4bool optimise = true);
   // Whether short steps < safety will avoid to call Navigator (if field=0)
 
-  G4double AtRestGetPhysicalInteractionLength(const G4Track&,
-                                              G4ForceCondition*) override;
+  G4double AtRestGetPhysicalInteractionLength(const G4Track&, G4ForceCondition*) override;
 
   G4VParticleChange* AtRestDoIt(const G4Track&, const G4Step&) override;
   // No operation in  AtRestDoIt.
 
   void StartTracking(G4Track* aTrack) override;
-  // Reset state for new (potentially resumed) track 
+  // Reset state for new (potentially resumed) track
 
 protected:
-
-  G4bool               DoesGlobalFieldExist();
+  G4bool DoesGlobalFieldExist();
   // Checks whether a field exists for the "global" field manager.
 
 private:
-
   const Monopole* fParticleDef;
-  
-  CMSFieldManager*     fieldMgrCMS;
-    
-  G4Navigator*         fLinearNavigator;
+
+  CMSFieldManager* fieldMgrCMS;
+
+  G4Navigator* fLinearNavigator;
   G4PropagatorInField* fFieldPropagator;
   // The Propagators used to transport the particle
 
-  G4ThreeVector        fTransportEndPosition;
-  G4ThreeVector        fTransportEndMomentumDir;
-  G4double             fTransportEndKineticEnergy;
-  G4ThreeVector        fTransportEndSpin;
-  G4bool               fMomentumChanged;
+  G4ThreeVector fTransportEndPosition;
+  G4ThreeVector fTransportEndMomentumDir;
+  G4double fTransportEndKineticEnergy;
+  G4ThreeVector fTransportEndSpin;
+  G4bool fMomentumChanged;
 
-  G4bool               fEndGlobalTimeComputed; 
-  G4double             fCandidateEndGlobalTime;
+  G4bool fEndGlobalTimeComputed;
+  G4double fCandidateEndGlobalTime;
   // The particle's state after this Step, Store for DoIt
 
-  G4bool               fParticleIsLooping;
+  G4bool fParticleIsLooping;
 
-  G4TouchableHandle    fCurrentTouchableHandle;
+  G4TouchableHandle fCurrentTouchableHandle;
 
   G4bool fGeometryLimitedStep;
   // Flag to determine whether a boundary was reached.
 
-  G4ThreeVector  fPreviousSftOrigin;
-  G4double       fPreviousSafety; 
+  G4ThreeVector fPreviousSftOrigin;
+  G4double fPreviousSafety;
   // Remember last safety origin & value.
 
   G4ParticleChangeForTransport fParticleChange;
@@ -151,96 +136,66 @@ private:
 
   G4double endpointDistance;
 
-  // Thresholds for looping particles: 
-  // 
-  G4double fThreshold_Warning_Energy;     //  Warn above this energy
-  G4double fThreshold_Important_Energy;   //  Hesitate above this
-  G4int    fThresholdTrials;              //    for this no of trials
-  // Above 'important' energy a 'looping' particle in field will 
+  // Thresholds for looping particles:
+  //
+  G4double fThreshold_Warning_Energy;    //  Warn above this energy
+  G4double fThreshold_Important_Energy;  //  Hesitate above this
+  G4int fThresholdTrials;                //    for this no of trials
+  // Above 'important' energy a 'looping' particle in field will
   //   *NOT* be abandoned, except after fThresholdTrials attempts.
 
   // Counter for steps in which particle reports 'looping',
-  //   if it is above 'Important' Energy 
-  G4int    fNoLooperTrials; 
+  //   if it is above 'Important' Energy
+  G4int fNoLooperTrials;
   // Statistics for tracks abandoned
   G4double fSumEnergyKilled;
   G4double fMaxEnergyKilled;
 
   // Whether to avoid calling G4Navigator for short step ( < safety)
   //   If using it, the safety estimate for endpoint will likely be smaller.
-  G4bool   fShortStepOptimisation; 
+  G4bool fShortStepOptimisation;
 
   G4SafetyHelper* fpSafetyHelper;  // To pass it the safety value obtained
-
 };
 
-inline void
-MonopoleTransportation::SetPropagatorInField( G4PropagatorInField* pFieldPropagator)
-{
-  fFieldPropagator= pFieldPropagator;
+inline void MonopoleTransportation::SetPropagatorInField(G4PropagatorInField* pFieldPropagator) {
+  fFieldPropagator = pFieldPropagator;
 }
 
-inline G4PropagatorInField* MonopoleTransportation::GetPropagatorInField()
-{
-  return fFieldPropagator;
-}
+inline G4PropagatorInField* MonopoleTransportation::GetPropagatorInField() { return fFieldPropagator; }
 
-inline G4bool MonopoleTransportation::DoesGlobalFieldExist()
-{
-  G4TransportationManager* transportMgr = 
-    G4TransportationManager::GetTransportationManager();
+inline G4bool MonopoleTransportation::DoesGlobalFieldExist() {
+  G4TransportationManager* transportMgr = G4TransportationManager::GetTransportationManager();
   return transportMgr->GetFieldManager()->DoesFieldExist();
 }
 
-inline G4double MonopoleTransportation::GetThresholdWarningEnergy() const
-{
-  return fThreshold_Warning_Energy;
-}
- 
-inline G4double MonopoleTransportation::GetThresholdImportantEnergy() const
-{ 
-  return fThreshold_Important_Energy;
-} 
+inline G4double MonopoleTransportation::GetThresholdWarningEnergy() const { return fThreshold_Warning_Energy; }
 
-inline G4int MonopoleTransportation::GetThresholdTrials() const
-{
-  return fThresholdTrials;
+inline G4double MonopoleTransportation::GetThresholdImportantEnergy() const { return fThreshold_Important_Energy; }
+
+inline G4int MonopoleTransportation::GetThresholdTrials() const { return fThresholdTrials; }
+
+inline void MonopoleTransportation::SetThresholdWarningEnergy(G4double newEnWarn) {
+  fThreshold_Warning_Energy = newEnWarn;
 }
 
-inline void MonopoleTransportation::SetThresholdWarningEnergy( G4double newEnWarn )
-{
-  fThreshold_Warning_Energy= newEnWarn;
+inline void MonopoleTransportation::SetThresholdImportantEnergy(G4double newEnImp) {
+  fThreshold_Important_Energy = newEnImp;
 }
 
-inline void MonopoleTransportation::SetThresholdImportantEnergy( G4double newEnImp )
-{
-  fThreshold_Important_Energy = newEnImp; 
-}
+inline void MonopoleTransportation::SetThresholdTrials(G4int newMaxTrials) { fThresholdTrials = newMaxTrials; }
 
-inline void MonopoleTransportation::SetThresholdTrials(G4int newMaxTrials )
-{
-  fThresholdTrials = newMaxTrials; 
-}
-
-// Get parameters for killing loopers: 
-//   Above 'important' energy a 'looping' particle in field will 
+// Get parameters for killing loopers:
+//   Above 'important' energy a 'looping' particle in field will
 //   *NOT* be abandoned, except after fThresholdTrials attempts.
 // Below Warning energy, no verbosity for looping particles is issued
 
-inline G4double MonopoleTransportation::GetMaxEnergyKilled() const
-{
-  return fMaxEnergyKilled; 
+inline G4double MonopoleTransportation::GetMaxEnergyKilled() const { return fMaxEnergyKilled; }
+
+inline G4double MonopoleTransportation::GetSumEnergyKilled() const { return fSumEnergyKilled; }
+
+inline void MonopoleTransportation::EnableShortStepOptimisation(G4bool optimiseShortStep) {
+  fShortStepOptimisation = optimiseShortStep;
 }
 
-inline G4double MonopoleTransportation::GetSumEnergyKilled() const
-{
-  return fSumEnergyKilled;
-}
-
-inline void 
-MonopoleTransportation::EnableShortStepOptimisation(G4bool optimiseShortStep)
-{ 
-  fShortStepOptimisation=optimiseShortStep;
-}
-
-#endif  
+#endif

--- a/SimG4Core/PhysicsLists/interface/UrbanMscModel93.h
+++ b/SimG4Core/PhysicsLists/interface/UrbanMscModel93.h
@@ -1,39 +1,39 @@
 // -------------------------------------------------------------------
 //
 //
-// GEANT4 Class header file 
+// GEANT4 Class header file
 //
 //
 // File name: UrbanMscModel93
 //
-// Original author:    Laszlo Urban, 
+// Original author:    Laszlo Urban,
 //
 //    V.Ivanchenko have copied from G4UrbanMscModel93 class
-//                 of Geant4 global tag geant4-09-06-ref-07 
+//                 of Geant4 global tag geant4-09-06-ref-07
 //                 and have adopted to CMSSW
 //
-// Creation date: 21.08.2013 
+// Creation date: 21.08.2013
 //
 // Class Description:
 //
 // Implementation of the model of multiple scattering based on
-// H.W.Lewis Phys Rev 78 (1950) 526 
+// H.W.Lewis Phys Rev 78 (1950) 526
 // L.Urban CERN-OPEN-2006-077, Dec. 2006
 // V.N.Ivanchenko et al., J.Phys: Conf. Ser. 219 (2010) 032045
 
 // -------------------------------------------------------------------
-// In its present form the model can be  used for simulation 
+// In its present form the model can be  used for simulation
 //   of the e-/e+, muon and charged hadron multiple scattering
-// 
-// This code was copied from Geant4 at the moment when it was removed 
+//
+// This code was copied from Geant4 at the moment when it was removed
 // from Geant4 completly (together with G4UrbanMscModel91, 95, 96).
 // Since that time Geant4 supports the unique class G4UrbanMscModel.
 // It was shown in Geant4 internal validations that this last class
 // provides more accurate simulation for various thin target tests.
-// This main Geant4 model does is not provide exactly the same results 
+// This main Geant4 model does is not provide exactly the same results
 // for CMS calorimeters run1 versus run2. To keep calorimeter response
 // unchanged, CMS private version of the Urban model was created. It is
-// basically the the same model used for run1 but it includes several 
+// basically the the same model used for run1 but it includes several
 // technical fixed introduced after run1. There fixes do not change
 // results but allow to avoid numerical problems for very small steps
 // and to improve a bit of the CPU performance.
@@ -56,11 +56,8 @@ class G4LossTableManager;
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-class UrbanMscModel93 : public G4VMscModel
-{
-
+class UrbanMscModel93 : public G4VMscModel {
 public:
-
   UrbanMscModel93(const G4String& nam = "UrbanMsc93");
 
   ~UrbanMscModel93() override;
@@ -70,26 +67,23 @@ public:
   void StartTracking(G4Track*) override;
 
   G4double ComputeCrossSectionPerAtom(const G4ParticleDefinition* particle,
-				      G4double KineticEnergy,
-				      G4double AtomicNumber,
-				      G4double AtomicWeight=0., 
-				      G4double cut =0.,
-				      G4double emax=DBL_MAX) override;
+                                      G4double KineticEnergy,
+                                      G4double AtomicNumber,
+                                      G4double AtomicWeight = 0.,
+                                      G4double cut = 0.,
+                                      G4double emax = DBL_MAX) override;
 
   G4ThreeVector& SampleScattering(const G4ThreeVector&, G4double safety) override;
 
-  G4double ComputeTruePathLengthLimit(const G4Track& track,
-				      G4double& currentMinimalStep) override;
+  G4double ComputeTruePathLengthLimit(const G4Track& track, G4double& currentMinimalStep) override;
 
   G4double ComputeGeomPathLength(G4double truePathLength) override;
 
   G4double ComputeTrueStepLength(G4double geomStepLength) override;
 
-  inline G4double ComputeTheta0(G4double truePathLength,
-				G4double KineticEnergy);
+  inline G4double ComputeTheta0(G4double truePathLength, G4double KineticEnergy);
 
 private:
-
   G4double SampleCosineTheta(G4double trueStepLength, G4double KineticEnergy);
 
   G4double SampleDisplacement();
@@ -103,18 +97,18 @@ private:
   inline G4double SimpleScattering(G4double xmeanth, G4double x2meanth);
 
   //  hide assignment operator
-  UrbanMscModel93 & operator=(const  UrbanMscModel93 &right) = delete;
-  UrbanMscModel93(const  UrbanMscModel93&) = delete;
+  UrbanMscModel93& operator=(const UrbanMscModel93& right) = delete;
+  UrbanMscModel93(const UrbanMscModel93&) = delete;
 
   const G4ParticleDefinition* particle;
-  G4ParticleChangeForMSC*     fParticleChange;
+  G4ParticleChangeForMSC* fParticleChange;
 
   const G4MaterialCutsCouple* couple;
-  G4LossTableManager*         theManager;
+  G4LossTableManager* theManager;
 
   G4double mass;
-  G4double charge,ChargeSquare;
-  G4double masslimite,lambdalimit,fr;
+  G4double charge, ChargeSquare;
+  G4double masslimite, lambdalimit, fr;
 
   G4double taubig;
   G4double tausmall;
@@ -137,107 +131,98 @@ private:
   G4double lambdaeff;
   G4double tPathLength;
   G4double zPathLength;
-  G4double par1,par2,par3;
+  G4double par1, par2, par3;
 
   G4double stepmin;
 
   G4double currentKinEnergy;
-  G4double currentRange; 
+  G4double currentRange;
   G4double rangeinit;
   G4double currentRadLength;
 
   G4double numlim, xsi, ea, eaa;
 
-  G4double theta0max,rellossmax;
+  G4double theta0max, rellossmax;
   G4double third;
 
-  G4int    currentMaterialIndex;
+  G4int currentMaterialIndex;
 
   G4double y;
   G4double Zold;
-  G4double Zeff,Z2,Z23,lnZ;
-  G4double coeffth1,coeffth2;
-  G4double coeffc1,coeffc2;
-  G4double scr1ini,scr2ini,scr1,scr2;
+  G4double Zeff, Z2, Z23, lnZ;
+  G4double coeffth1, coeffth2;
+  G4double coeffc1, coeffc2;
+  G4double scr1ini, scr2ini, scr1, scr2;
 
-  G4bool   firstStep;
-  G4bool   inside;
-  G4bool   insideskin;
+  G4bool firstStep;
+  G4bool inside;
+  G4bool insideskin;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-inline
-void UrbanMscModel93::SetParticle(const G4ParticleDefinition* p)
-{
+inline void UrbanMscModel93::SetParticle(const G4ParticleDefinition* p) {
   if (p != particle) {
     particle = p;
     mass = p->GetPDGMass();
-    charge = p->GetPDGCharge()/CLHEP::eplus;
-    ChargeSquare = charge*charge;
+    charge = p->GetPDGCharge() / CLHEP::eplus;
+    ChargeSquare = charge * charge;
   }
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-inline
-void UrbanMscModel93::UpdateCache()                                   
-{
+inline void UrbanMscModel93::UpdateCache() {
   lnZ = G4Log(Zeff);
   //new correction in theta0 formula
-  coeffth1 = (1.-8.7780e-2/Zeff)*(0.87+0.03*lnZ);                   
-  coeffth2 = (4.0780e-2+1.7315e-4*Zeff)*(0.87+0.03*lnZ);              
+  coeffth1 = (1. - 8.7780e-2 / Zeff) * (0.87 + 0.03 * lnZ);
+  coeffth2 = (4.0780e-2 + 1.7315e-4 * Zeff) * (0.87 + 0.03 * lnZ);
   // tail parameters
-  G4double lnZ1 = G4Log(Zeff+1.);
-  coeffc1  = 2.943-0.197*lnZ1;                  
-  coeffc2  = 0.0987-0.0143*lnZ1;                              
+  G4double lnZ1 = G4Log(Zeff + 1.);
+  coeffc1 = 2.943 - 0.197 * lnZ1;
+  coeffc2 = 0.0987 - 0.0143 * lnZ1;
   // for single scattering
-  Z2   = Zeff*Zeff;
-  Z23  = G4Exp(2.*lnZ/3.);
-  scr1 = scr1ini*Z23;
-  scr2 = scr2ini*Z2*ChargeSquare;
-                                              
+  Z2 = Zeff * Zeff;
+  Z23 = G4Exp(2. * lnZ / 3.);
+  scr1 = scr1ini * Z23;
+  scr2 = scr2ini * Z2 * ChargeSquare;
+
   Zold = Zeff;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-inline
-G4double UrbanMscModel93::ComputeTheta0(G4double trueStepLength,
-					G4double KineticEnergy)
-{
+inline G4double UrbanMscModel93::ComputeTheta0(G4double trueStepLength, G4double KineticEnergy) {
   // for all particles take the width of the central part
   //  from a  parametrization similar to the Highland formula
   // ( Highland formula: Particle Physics Booklet, July 2002, eq. 26.10)
-  static const G4double c_highland = 13.6*CLHEP::MeV;
-  G4double invbetacp = sqrt((currentKinEnergy+mass)*(KineticEnergy+mass)/
-			    (currentKinEnergy*(currentKinEnergy+2.*mass)*
-			     KineticEnergy*(KineticEnergy+2.*mass)));
-  y = trueStepLength/currentRadLength;
-  G4double theta0 = c_highland*std::abs(charge)*sqrt(y)*invbetacp;
+  static const G4double c_highland = 13.6 * CLHEP::MeV;
+  G4double invbetacp =
+      sqrt((currentKinEnergy + mass) * (KineticEnergy + mass) /
+           (currentKinEnergy * (currentKinEnergy + 2. * mass) * KineticEnergy * (KineticEnergy + 2. * mass)));
+  y = trueStepLength / currentRadLength;
+  G4double theta0 = c_highland * std::abs(charge) * sqrt(y) * invbetacp;
   // correction factor from e- scattering data
-  theta0 *= (coeffth1+coeffth2*G4Log(y));             
+  theta0 *= (coeffth1 + coeffth2 * G4Log(y));
 
   return theta0;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-inline
-G4double UrbanMscModel93::SimpleScattering(G4double xmeanth, G4double x2meanth)
-{
+inline G4double UrbanMscModel93::SimpleScattering(G4double xmeanth, G4double x2meanth) {
   // 'large angle scattering'
   // 2 model functions with correct xmean and x2mean
-  G4double a = (2.*xmeanth+9.*x2meanth-3.)/(2.*xmeanth-3.*x2meanth+1.);
-  G4double prob = (a+2.)*xmeanth/a;
+  G4double a = (2. * xmeanth + 9. * x2meanth - 3.) / (2. * xmeanth - 3. * x2meanth + 1.);
+  G4double prob = (a + 2.) * xmeanth / a;
 
   // sampling
   G4double cth = 1.;
-  if(G4UniformRand() < prob) {
-    cth = -1.+2.*G4Exp(G4Log(G4UniformRand())/(a+1.));
+  if (G4UniformRand() < prob) {
+    cth = -1. + 2. * G4Exp(G4Log(G4UniformRand()) / (a + 1.));
   } else {
-    cth = -1.+2.*G4UniformRand();
+    cth = -1. + 2. * G4UniformRand();
   }
   return cth;
 }
@@ -245,4 +230,3 @@ G4double UrbanMscModel93::SimpleScattering(G4double xmeanth, G4double x2meanth)
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 #endif
-

--- a/SimG4Core/PhysicsLists/plugins/DummyPhysics.cc
+++ b/SimG4Core/PhysicsLists/plugins/DummyPhysics.cc
@@ -4,16 +4,12 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "G4DecayPhysics.hh"
 
-DummyPhysics::DummyPhysics(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
+DummyPhysics::DummyPhysics(const edm::ParameterSet& p) : PhysicsList(p) {
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
   if (emPhys) {
     RegisterPhysics(new DummyEMPhysics(ver));
   }
   RegisterPhysics(new G4DecayPhysics(ver));
-  edm::LogInfo("PhysicsList") << "DummyPhysics constructed with EM Physics "
-			      << emPhys << " and Decay";
+  edm::LogInfo("PhysicsList") << "DummyPhysics constructed with EM Physics " << emPhys << " and Decay";
 }
-

--- a/SimG4Core/PhysicsLists/plugins/DummyPhysics.h
+++ b/SimG4Core/PhysicsLists/plugins/DummyPhysics.h
@@ -5,10 +5,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class DummyPhysics : public PhysicsList {
-
 public:
   DummyPhysics(const edm::ParameterSet &);
   ~DummyPhysics() override = default;
 };
- 
+
 #endif

--- a/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.cc
@@ -13,23 +13,20 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTF_BIC.hh"
 
-FTFCMS_BIC::FTFCMS_BIC(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFCMS_BIC::FTFCMS_BIC(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTF_BIC with Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+                              << "FTF_BIC with Flags for EM Physics " << emPhys << ", for Hadronic Physics " << hadPhys
+                              << " and tracking cut " << tracking;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new G4EmStandardPhysics(ver));
+    RegisterPhysics(new G4EmStandardPhysics(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -37,27 +34,26 @@ FTFCMS_BIC::FTFCMS_BIC(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics( new G4HadronPhysicsFTF_BIC(ver));
+    RegisterPhysics(new G4HadronPhysicsFTF_BIC(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      RegisterPhysics(new G4NeutronTrackingCut(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFCMS_BIC: public PhysicsList {
-
+class FTFCMS_BIC : public PhysicsList {
 public:
-  FTFCMS_BIC(const edm::ParameterSet & p);
+  FTFCMS_BIC(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
@@ -13,25 +13,21 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
-FTFPCMS_BERT::FTFPCMS_BERT(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT::FTFPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "FTFP_BERT \n Flags for EM Physics " << emPhys << ", for Hadronic Physics " << hadPhys
+                              << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new G4EmStandardPhysics(ver));
+    RegisterPhysics(new G4EmStandardPhysics(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -39,29 +35,28 @@ FTFPCMS_BERT::FTFPCMS_BERT(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT: public PhysicsList {
-
+class FTFPCMS_BERT : public PhysicsList {
 public:
-  FTFPCMS_BERT(const edm::ParameterSet & p);
+  FTFPCMS_BERT(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.cc
@@ -13,25 +13,21 @@
 
 #include "G4DataQuestionaire.hh"
 
-FTFPCMS_BERT_ATL_EMM::FTFPCMS_BERT_ATL_EMM(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_ATL_EMM::FTFPCMS_BERT_ATL_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_ATL_EMM \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "FTFP_BERT_ATL_EMM \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -39,29 +35,28 @@ FTFPCMS_BERT_ATL_EMM::FTFPCMS_BERT_ATL_EMM(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new CMSHadronPhysicsFTFP_BERT_ATL(ver));
+    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT_ATL(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_ATL_EMM.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_ATL_EMM: public PhysicsList {
-
+class FTFPCMS_BERT_ATL_EMM : public PhysicsList {
 public:
-  FTFPCMS_BERT_ATL_EMM(const edm::ParameterSet & p);
+  FTFPCMS_BERT_ATL_EMM(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
@@ -13,25 +13,21 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
-FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EML: \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "FTFP_BERT_EML: \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysics(ver));
+    RegisterPhysics(new CMSEmStandardPhysics(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -39,29 +35,28 @@ FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_EML: public PhysicsList {
-
+class FTFPCMS_BERT_EML : public PhysicsList {
 public:
-  FTFPCMS_BERT_EML(const edm::ParameterSet & p);
+  FTFPCMS_BERT_EML(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.cc
@@ -13,25 +13,21 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
-FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EMM \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "FTFP_BERT_EMM \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -39,29 +35,28 @@ FTFPCMS_BERT_EMM::FTFPCMS_BERT_EMM(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_EMM: public PhysicsList {
-
+class FTFPCMS_BERT_EMM : public PhysicsList {
 public:
-  FTFPCMS_BERT_EMM(const edm::ParameterSet & p);
+  FTFPCMS_BERT_EMM(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.cc
@@ -13,25 +13,21 @@
 
 #include "G4DataQuestionaire.hh"
 
-FTFPCMS_BERT_EMM_TRK::FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_EMM_TRK::FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EMM_TRK \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "FTFP_BERT_EMM_TRK \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -39,29 +35,28 @@ FTFPCMS_BERT_EMM_TRK::FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new CMSHadronPhysicsFTFP_BERT(ver));
+    RegisterPhysics(new CMSHadronPhysicsFTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMM_TRK.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_EMM_TRK: public PhysicsList {
-
+class FTFPCMS_BERT_EMM_TRK : public PhysicsList {
 public:
-  FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet & p);
+  FTFPCMS_BERT_EMM_TRK(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
@@ -13,25 +13,21 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
-FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EMN \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "FTFP_BERT_EMN \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsXS(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsXS(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -39,29 +35,28 @@ FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_EMN: public PhysicsList {
-
+class FTFPCMS_BERT_EMN : public PhysicsList {
 public:
-  FTFPCMS_BERT_EMN(const edm::ParameterSet & p);
+  FTFPCMS_BERT_EMN(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
@@ -13,23 +13,20 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
-FTFPCMS_BERT_EMV::FTFPCMS_BERT_EMV(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_EMV::FTFPCMS_BERT_EMV(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EMV \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+                              << "FTFP_BERT_EMV \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new G4EmStandardPhysics_option1(ver));
+    RegisterPhysics(new G4EmStandardPhysics_option1(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -37,27 +34,26 @@ FTFPCMS_BERT_EMV::FTFPCMS_BERT_EMV(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      RegisterPhysics(new G4NeutronTrackingCut(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_EMV: public PhysicsList {
-
+class FTFPCMS_BERT_EMV : public PhysicsList {
 public:
-  FTFPCMS_BERT_EMV(const edm::ParameterSet & p);
+  FTFPCMS_BERT_EMV(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.cc
@@ -13,23 +13,20 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
-FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EMY \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+                              << "FTFP_BERT_EMY \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new G4EmStandardPhysics_option3(ver));
+    RegisterPhysics(new G4EmStandardPhysics_option3(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -37,27 +34,26 @@ FTFPCMS_BERT_EMY::FTFPCMS_BERT_EMY(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      RegisterPhysics(new G4NeutronTrackingCut(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMY.h
@@ -1,23 +1,19 @@
 #ifndef SimG4Core_PhysicsLists_FTFPCMS_BERT_EMY_H
 #define SimG4Core_PhysicsLists_FTFPCMS_BERT_EMY_H
 
-// FTFP_BERT_EMY is a standard Geant4 Physics List FTFP_BERT with Option3 
-//               EM Physics configuration: forced more steps of e+- near 
-//               geometry boundary. This configuration may be used for R&D of 
+// FTFP_BERT_EMY is a standard Geant4 Physics List FTFP_BERT with Option3
+//               EM Physics configuration: forced more steps of e+- near
+//               geometry boundary. This configuration may be used for R&D of
 //               tracker and HGCal detector performnace. The similation
-//               is expected to be approximately two times slower then 
+//               is expected to be approximately two times slower then
 //               with the CMS production Physics List
 
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_EMY: public PhysicsList {
-
+class FTFPCMS_BERT_EMY : public PhysicsList {
 public:
-  FTFPCMS_BERT_EMY(const edm::ParameterSet & p);
+  FTFPCMS_BERT_EMY(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
@@ -13,21 +13,17 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
-FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EMZ \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "FTFP_BERT_EMZ \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
@@ -39,29 +35,28 @@ FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.h
@@ -3,19 +3,18 @@
 
 // FTFP_BERT_EMZ is a standard Geant4 Physics List FTFP_BERT with Option4
 //               EM Physics configuration: used GS multiple scattering model
-//               for e+- below 100 MeV. Very precised simulation for thin  
-//               layers. This configuration may be used for R&D of 
+//               for e+- below 100 MeV. Very precised simulation for thin
+//               layers. This configuration may be used for R&D of
 //               tracker and HGCal detector performnace. The similation
-//               is expected to be approximately two times slower then 
+//               is expected to be approximately two times slower then
 //               with the CMS production Physics List
 
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_EMZ: public PhysicsList {
-
+class FTFPCMS_BERT_EMZ : public PhysicsList {
 public:
-  FTFPCMS_BERT_EMZ(const edm::ParameterSet & p);
+  FTFPCMS_BERT_EMZ(const edm::ParameterSet& p);
 };
 
 #endif

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.cc
@@ -15,27 +15,23 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT_HP.hh"
 
-FTFPCMS_BERT_HP_EML::FTFPCMS_BERT_HP_EML(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_HP_EML::FTFPCMS_BERT_HP_EML(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   bool thermal = p.getUntrackedParameter<bool>("ThermalNeutrons");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_HP_EML \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns
-			      << " ThermalNeutrons: " << thermal;
+                              << "FTFP_BERT_HP_EML \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns
+                              << " ThermalNeutrons: " << thermal;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsXS(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsXS(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -43,32 +39,31 @@ FTFPCMS_BERT_HP_EML::FTFPCMS_BERT_HP_EML(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysicsHP(ver));
+    RegisterPhysics(new G4HadronElasticPhysicsHP(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT_HP(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT_HP(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
-    if(thermal) {
+    if (thermal) {
       RegisterPhysics(new CMSThermalNeutrons(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_HP_EML: public PhysicsList {
-
+class FTFPCMS_BERT_HP_EML : public PhysicsList {
 public:
-  FTFPCMS_BERT_HP_EML(const edm::ParameterSet & p);
+  FTFPCMS_BERT_HP_EML(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EMM.cc
@@ -15,27 +15,23 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT_HP.hh"
 
-FTFPCMS_BERT_HP_EMM::FTFPCMS_BERT_HP_EMM(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_HP_EMM::FTFPCMS_BERT_HP_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   bool thermal = p.getUntrackedParameter<bool>("ThermalNeutrons");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_HP_EMM \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns
-			      << " ThermalNeutrons: " << thermal;
+                              << "FTFP_BERT_HP_EMM \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns
+                              << " ThermalNeutrons: " << thermal;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -43,32 +39,31 @@ FTFPCMS_BERT_HP_EMM::FTFPCMS_BERT_HP_EMM(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysicsHP(ver));
+    RegisterPhysics(new G4HadronElasticPhysicsHP(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT_HP(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT_HP(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
-    if(thermal) {
+    if (thermal) {
       RegisterPhysics(new CMSThermalNeutrons(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EMM.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EMM.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_HP_EMM: public PhysicsList {
-
+class FTFPCMS_BERT_HP_EMM : public PhysicsList {
 public:
-  FTFPCMS_BERT_HP_EMM(const edm::ParameterSet & p);
+  FTFPCMS_BERT_HP_EMM(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.cc
@@ -15,27 +15,23 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsFTFP_BERT.hh"
 
-FTFPCMS_BERT_XS_EML::FTFPCMS_BERT_XS_EML(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_BERT_XS_EML::FTFPCMS_BERT_XS_EML(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   bool thermal = p.getUntrackedParameter<bool>("ThermalNeutrons");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_XS_EML \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns
-			      << " ThermalNeutrons: " << thermal;
+                              << "FTFP_BERT_XS_EML \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns
+                              << " ThermalNeutrons: " << thermal;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsXS(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsXS(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -43,32 +39,31 @@ FTFPCMS_BERT_XS_EML::FTFPCMS_BERT_XS_EML(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysicsXS(ver));
+    RegisterPhysics(new G4HadronElasticPhysicsXS(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
-    if(thermal) {
+    if (thermal) {
       RegisterPhysics(new CMSThermalNeutrons(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_BERT_XS_EML: public PhysicsList {
-
+class FTFPCMS_BERT_XS_EML : public PhysicsList {
 public:
-  FTFPCMS_BERT_XS_EML(const edm::ParameterSet & p);
+  FTFPCMS_BERT_XS_EML(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_EMM.cc
@@ -13,25 +13,21 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsINCLXX.hh"
 
-FTFPCMS_INCLXX_EMM::FTFPCMS_INCLXX_EMM(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_INCLXX_EMM::FTFPCMS_INCLXX_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_INCLXX_EMM \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "FTFP_INCLXX_EMM \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -39,29 +35,28 @@ FTFPCMS_INCLXX_EMM::FTFPCMS_INCLXX_EMM(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics( new G4HadronPhysicsINCLXX(ver,true,false,true));
+    RegisterPhysics(new G4HadronPhysicsINCLXX(ver, true, false, true));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonINCLXXPhysics(ver));
+    RegisterPhysics(new G4IonINCLXXPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_EMM.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_EMM.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_INCLXX_EMM: public PhysicsList {
-
+class FTFPCMS_INCLXX_EMM : public PhysicsList {
 public:
-  FTFPCMS_INCLXX_EMM(const edm::ParameterSet & p);
+  FTFPCMS_INCLXX_EMM(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_HP_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_HP_EMM.cc
@@ -15,27 +15,23 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsINCLXX.hh"
 
-FTFPCMS_INCLXX_HP_EMM::FTFPCMS_INCLXX_HP_EMM(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+FTFPCMS_INCLXX_HP_EMM::FTFPCMS_INCLXX_HP_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   bool thermal = p.getUntrackedParameter<bool>("ThermalNeutrons");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_INCLXX_HP_EMM \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns
-			      << " ThermalNeutrons: " << thermal;
+                              << "FTFP_INCLXX_HP_EMM \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns
+                              << " ThermalNeutrons: " << thermal;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysicsLPM(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsLPM(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -43,32 +39,31 @@ FTFPCMS_INCLXX_HP_EMM::FTFPCMS_INCLXX_HP_EMM(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysicsHP(ver));
+    RegisterPhysics(new G4HadronElasticPhysicsHP(ver));
 
     // Hadron Physics
-    RegisterPhysics( new G4HadronPhysicsINCLXX(ver,true,true,true));
+    RegisterPhysics(new G4HadronPhysicsINCLXX(ver, true, true, true));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonINCLXXPhysics(ver));
+    RegisterPhysics(new G4IonINCLXXPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
-    if(thermal) {
+    if (thermal) {
       RegisterPhysics(new CMSThermalNeutrons(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_HP_EMM.h
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_INCLXX_HP_EMM.h
@@ -4,13 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class FTFPCMS_INCLXX_HP_EMM: public PhysicsList {
-
+class FTFPCMS_INCLXX_HP_EMM : public PhysicsList {
 public:
-  FTFPCMS_INCLXX_HP_EMM(const edm::ParameterSet & p);
+  FTFPCMS_INCLXX_HP_EMM(const edm::ParameterSet& p);
 };
 
 #endif
-
-
-

--- a/SimG4Core/PhysicsLists/plugins/QBBCCMS.cc
+++ b/SimG4Core/PhysicsLists/plugins/QBBCCMS.cc
@@ -13,24 +13,20 @@
 #include "G4IonPhysics.hh"
 #include "G4NeutronTrackingCut.hh"
 
-QBBCCMS::QBBCCMS(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QBBCCMS::QBBCCMS(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QBBC \n Flags for EM Physics "
-			      << emPhys << " and for Hadronic Physics "
-			      << hadPhys 
-			      << " and tracking cut " << tracking;
+                              << "QBBC \n Flags for EM Physics " << emPhys << " and for Hadronic Physics " << hadPhys
+                              << " and tracking cut " << tracking;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new G4EmStandardPhysics(ver));
+    RegisterPhysics(new G4EmStandardPhysics(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -47,7 +43,7 @@ QBBCCMS::QBBCCMS(const edm::ParameterSet & p)
     RegisterPhysics(new G4HadronElasticPhysicsXS(ver));
 
     // Hadron Physics
-    RegisterPhysics( new G4HadronInelasticQBBC(ver));
+    RegisterPhysics(new G4HadronInelasticQBBC(ver));
 
     // Stopping Physics
     RegisterPhysics(new G4StoppingPhysics(ver));
@@ -57,8 +53,7 @@ QBBCCMS::QBBCCMS(const edm::ParameterSet & p)
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      RegisterPhysics(new G4NeutronTrackingCut(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QBBCCMS.h
+++ b/SimG4Core/PhysicsLists/plugins/QBBCCMS.h
@@ -4,11 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class QBBCCMS: public PhysicsList {
-
+class QBBCCMS : public PhysicsList {
 public:
-  QBBCCMS(const edm::ParameterSet & p);
+  QBBCCMS(const edm::ParameterSet& p);
 };
 
 #endif
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.cc
@@ -13,23 +13,20 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_BERT.hh"
 
-QGSPCMS_BERT::QGSPCMS_BERT(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_BERT::QGSPCMS_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_BERT \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+                              << "QGSP_BERT \n Flags for EM Physics " << emPhys << ", for Hadronic Physics " << hadPhys
+                              << " and tracking cut " << tracking;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new G4EmStandardPhysics(ver));
+    RegisterPhysics(new G4EmStandardPhysics(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -37,27 +34,26 @@ QGSPCMS_BERT::QGSPCMS_BERT(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsQGSP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsQGSP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      RegisterPhysics(new G4NeutronTrackingCut(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.h
@@ -1,15 +1,12 @@
 #ifndef SimG4Core_PhysicsLists_QGSPCMS_BERT_H
 #define SimG4Core_PhysicsLists_QGSPCMS_BERT_H
- 
+
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class QGSPCMS_BERT: public PhysicsList {
 
+class QGSPCMS_BERT : public PhysicsList {
 public:
-  QGSPCMS_BERT(const edm::ParameterSet & p);
+  QGSPCMS_BERT(const edm::ParameterSet& p);
 };
 
 #endif
-
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
@@ -13,23 +13,20 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_BERT.hh"
 
-QGSPCMS_BERT_EML::QGSPCMS_BERT_EML(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_BERT_EML::QGSPCMS_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_BERT_EMY with Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+                              << "QGSP_BERT_EMY with Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysics(ver));
+    RegisterPhysics(new CMSEmStandardPhysics(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -37,27 +34,26 @@ QGSPCMS_BERT_EML::QGSPCMS_BERT_EML(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsQGSP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsQGSP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      RegisterPhysics(new G4NeutronTrackingCut(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.h
@@ -1,15 +1,12 @@
 #ifndef SimG4Core_PhysicsLists_QGSPCMS_BERT_EML_H
 #define SimG4Core_PhysicsLists_QGSPCMS_BERT_EML_H
- 
+
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class QGSPCMS_BERT_EML: public PhysicsList {
 
+class QGSPCMS_BERT_EML : public PhysicsList {
 public:
-  QGSPCMS_BERT_EML(const edm::ParameterSet & p);
+  QGSPCMS_BERT_EML(const edm::ParameterSet& p);
 };
 
 #endif
-
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.cc
@@ -13,23 +13,20 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_BERT.hh"
 
-QGSPCMS_BERT_EMV::QGSPCMS_BERT_EMV(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_BERT_EMV::QGSPCMS_BERT_EMV(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_BERT_EMV \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+                              << "QGSP_BERT_EMV \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new G4EmStandardPhysics_option1(ver));
+    RegisterPhysics(new G4EmStandardPhysics_option1(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -37,27 +34,26 @@ QGSPCMS_BERT_EMV::QGSPCMS_BERT_EMV(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsQGSP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsQGSP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      RegisterPhysics(new G4NeutronTrackingCut(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.h
@@ -1,15 +1,12 @@
 #ifndef SimG4Core_PhysicsLists_QGSPCMS_BERT_EMV_H
 #define SimG4Core_PhysicsLists_QGSPCMS_BERT_EMV_H
- 
+
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class QGSPCMS_BERT_EMV: public PhysicsList {
 
+class QGSPCMS_BERT_EMV : public PhysicsList {
 public:
-  QGSPCMS_BERT_EMV(const edm::ParameterSet & p);
+  QGSPCMS_BERT_EMV(const edm::ParameterSet& p);
 };
 
 #endif
-
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
@@ -13,23 +13,20 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_BERT_HP.hh"
 
-QGSPCMS_BERT_HP_EML::QGSPCMS_BERT_HP_EML(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_BERT_HP_EML::QGSPCMS_BERT_HP_EML(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_BERT_HP_EML \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+                              << "QGSP_BERT_HP_EML \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new CMSEmStandardPhysics(ver));
+    RegisterPhysics(new CMSEmStandardPhysics(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -37,27 +34,26 @@ QGSPCMS_BERT_HP_EML::QGSPCMS_BERT_HP_EML(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysicsHP(ver));
+    RegisterPhysics(new G4HadronElasticPhysicsHP(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsQGSP_BERT_HP(ver));
+    RegisterPhysics(new G4HadronPhysicsQGSP_BERT_HP(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      RegisterPhysics(new G4NeutronTrackingCut(ver));
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.h
@@ -4,11 +4,9 @@
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class QGSPCMS_BERT_HP_EML: public PhysicsList {
-
+class QGSPCMS_BERT_HP_EML : public PhysicsList {
 public:
-  QGSPCMS_BERT_HP_EML(const edm::ParameterSet & p);
+  QGSPCMS_BERT_HP_EML(const edm::ParameterSet& p);
 };
 
 #endif
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.cc
@@ -13,25 +13,21 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
-QGSPCMS_FTFP_BERT::QGSPCMS_FTFP_BERT(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_FTFP_BERT::QGSPCMS_FTFP_BERT(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "QGSP_FTFP_BERT \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics( new G4EmStandardPhysics(ver));
+    RegisterPhysics(new G4EmStandardPhysics(ver));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
@@ -39,29 +35,28 @@ QGSPCMS_FTFP_BERT::QGSPCMS_FTFP_BERT(const edm::ParameterSet & p)
   }
 
   // Decays
-  this->RegisterPhysics( new G4DecayPhysics(ver) );
+  this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
 
     // Hadron Elastic scattering
-    RegisterPhysics( new G4HadronElasticPhysics(ver));
+    RegisterPhysics(new G4HadronElasticPhysics(ver));
 
     // Hadron Physics
-    RegisterPhysics(  new G4HadronPhysicsQGSP_FTFP_BERT(ver));
+    RegisterPhysics(new G4HadronPhysicsQGSP_FTFP_BERT(ver));
 
     // Stopping Physics
-    RegisterPhysics( new G4StoppingPhysics(ver));
+    RegisterPhysics(new G4StoppingPhysics(ver));
 
     // Ion Physics
-    RegisterPhysics( new G4IonPhysics(ver));
+    RegisterPhysics(new G4IonPhysics(ver));
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.h
@@ -1,15 +1,12 @@
 #ifndef SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_H
 #define SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_H
- 
+
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class QGSPCMS_FTFP_BERT: public PhysicsList {
 
+class QGSPCMS_FTFP_BERT : public PhysicsList {
 public:
-  QGSPCMS_FTFP_BERT(const edm::ParameterSet & p);
+  QGSPCMS_FTFP_BERT(const edm::ParameterSet& p);
 };
 
 #endif
-
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
@@ -13,21 +13,17 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
-QGSPCMS_FTFP_BERT_EML::QGSPCMS_FTFP_BERT_EML(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_FTFP_BERT_EML::QGSPCMS_FTFP_BERT_EML(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EML \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "QGSP_FTFP_BERT_EML \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
@@ -39,7 +35,7 @@ QGSPCMS_FTFP_BERT_EML::QGSPCMS_FTFP_BERT_EML(const edm::ParameterSet & p)
   }
 
   // Decays
-  RegisterPhysics(new G4DecayPhysics(ver) );
+  RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
@@ -58,10 +54,9 @@ QGSPCMS_FTFP_BERT_EML::QGSPCMS_FTFP_BERT_EML(const edm::ParameterSet & p)
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.h
@@ -1,15 +1,12 @@
 #ifndef SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_EML_H
 #define SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_EML_H
- 
+
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class QGSPCMS_FTFP_BERT_EML: public PhysicsList {
 
+class QGSPCMS_FTFP_BERT_EML : public PhysicsList {
 public:
-  QGSPCMS_FTFP_BERT_EML(const edm::ParameterSet & p);
+  QGSPCMS_FTFP_BERT_EML(const edm::ParameterSet& p);
 };
 
 #endif
-
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.cc
@@ -13,21 +13,17 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
-QGSPCMS_FTFP_BERT_EMM::QGSPCMS_FTFP_BERT_EMM(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_FTFP_BERT_EMM::QGSPCMS_FTFP_BERT_EMM(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EMM \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "QGSP_FTFP_BERT_EMM \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
@@ -39,7 +35,7 @@ QGSPCMS_FTFP_BERT_EMM::QGSPCMS_FTFP_BERT_EMM(const edm::ParameterSet & p)
   }
 
   // Decays
-  RegisterPhysics(new G4DecayPhysics(ver) );
+  RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
@@ -58,10 +54,9 @@ QGSPCMS_FTFP_BERT_EMM::QGSPCMS_FTFP_BERT_EMM(const edm::ParameterSet & p)
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMM.h
@@ -1,15 +1,12 @@
 #ifndef SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_EMM_H
 #define SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_EMM_H
- 
+
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class QGSPCMS_FTFP_BERT_EMM: public PhysicsList {
 
+class QGSPCMS_FTFP_BERT_EMM : public PhysicsList {
 public:
-  QGSPCMS_FTFP_BERT_EMM(const edm::ParameterSet & p);
+  QGSPCMS_FTFP_BERT_EMM(const edm::ParameterSet& p);
 };
 
 #endif
-
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.cc
@@ -13,21 +13,17 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
-QGSPCMS_FTFP_BERT_EMN::QGSPCMS_FTFP_BERT_EMN(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_FTFP_BERT_EMN::QGSPCMS_FTFP_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EMN \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "QGSP_FTFP_BERT_EMN \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
@@ -39,7 +35,7 @@ QGSPCMS_FTFP_BERT_EMN::QGSPCMS_FTFP_BERT_EMN(const edm::ParameterSet & p)
   }
 
   // Decays
-  RegisterPhysics(new G4DecayPhysics(ver) );
+  RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
@@ -58,10 +54,9 @@ QGSPCMS_FTFP_BERT_EMN::QGSPCMS_FTFP_BERT_EMN(const edm::ParameterSet & p)
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMN.h
@@ -1,15 +1,12 @@
 #ifndef SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_EMN_H
 #define SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_EMN_H
- 
+
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class QGSPCMS_FTFP_BERT_EMN: public PhysicsList {
 
+class QGSPCMS_FTFP_BERT_EMN : public PhysicsList {
 public:
-  QGSPCMS_FTFP_BERT_EMN(const edm::ParameterSet & p);
+  QGSPCMS_FTFP_BERT_EMN(const edm::ParameterSet& p);
 };
 
 #endif
-
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.cc
@@ -13,21 +13,17 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
-QGSPCMS_FTFP_BERT_EMY::QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_FTFP_BERT_EMY::QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EMY \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "QGSP_FTFP_BERT_EMY \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
@@ -39,7 +35,7 @@ QGSPCMS_FTFP_BERT_EMY::QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet & p)
   }
 
   // Decays
-  RegisterPhysics(new G4DecayPhysics(ver) );
+  RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
@@ -58,10 +54,9 @@ QGSPCMS_FTFP_BERT_EMY::QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet & p)
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMY.h
@@ -1,23 +1,19 @@
 #ifndef SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_EMY_H
 #define SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_EMY_H 1
 
-// QGSP_FTFP_BERT_EMY  is a standard Geant4 Physics List QGSP_FTFP_BERT 
-//                     with Option3 EM Physics configuration: forced more steps 
+// QGSP_FTFP_BERT_EMY  is a standard Geant4 Physics List QGSP_FTFP_BERT
+//                     with Option3 EM Physics configuration: forced more steps
 //                     of e+- near geometry boundary. This configuration may be
-//                     used for R&D of tracker and HGCal detector performnace. 
+//                     used for R&D of tracker and HGCal detector performnace.
 //                     The similation is expected to be approximately two times
 //                     slower then with the CMS production Physics List
 
- 
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class QGSPCMS_FTFP_BERT_EMY: public PhysicsList {
 
+class QGSPCMS_FTFP_BERT_EMY : public PhysicsList {
 public:
-  QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet & p);
+  QGSPCMS_FTFP_BERT_EMY(const edm::ParameterSet& p);
 };
 
 #endif
-
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMZ.cc
@@ -13,21 +13,17 @@
 #include "G4DataQuestionaire.hh"
 #include "G4HadronPhysicsQGSP_FTFP_BERT.hh"
 
-QGSPCMS_FTFP_BERT_EMZ::QGSPCMS_FTFP_BERT_EMZ(const edm::ParameterSet & p) 
-  : PhysicsList(p) {
-
+QGSPCMS_FTFP_BERT_EMZ::QGSPCMS_FTFP_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) {
   G4DataQuestionaire it(photon);
-  
-  int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
-  bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
-  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
-  bool tracking= p.getParameter<bool>("TrackingCut");
-  double timeLimit = p.getParameter<double>("MaxTrackTime")*CLHEP::ns;
+
+  int ver = p.getUntrackedParameter<int>("Verbosity", 0);
+  bool emPhys = p.getUntrackedParameter<bool>("EMPhysics", true);
+  bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics", true);
+  bool tracking = p.getParameter<bool>("TrackingCut");
+  double timeLimit = p.getParameter<double>("MaxTrackTime") * CLHEP::ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EMZ \n Flags for EM Physics "
-			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking
-			      << "   t(ns)= " << timeLimit/CLHEP::ns;
+                              << "QGSP_FTFP_BERT_EMZ \n Flags for EM Physics " << emPhys << ", for Hadronic Physics "
+                              << hadPhys << " and tracking cut " << tracking << "   t(ns)= " << timeLimit / CLHEP::ns;
 
   if (emPhys) {
     // EM Physics
@@ -39,7 +35,7 @@ QGSPCMS_FTFP_BERT_EMZ::QGSPCMS_FTFP_BERT_EMZ(const edm::ParameterSet & p)
   }
 
   // Decays
-  RegisterPhysics(new G4DecayPhysics(ver) );
+  RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
     G4HadronicProcessStore::Instance()->SetVerbose(ver);
@@ -58,10 +54,9 @@ QGSPCMS_FTFP_BERT_EMZ::QGSPCMS_FTFP_BERT_EMZ(const edm::ParameterSet & p)
 
     // Neutron tracking cut
     if (tracking) {
-      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      G4NeutronTrackingCut* ncut = new G4NeutronTrackingCut(ver);
       ncut->SetTimeLimit(timeLimit);
       RegisterPhysics(ncut);
     }
   }
 }
-

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMZ.h
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EMZ.h
@@ -2,22 +2,19 @@
 #define SimG4Core_PhysicsLists_QGSPCMS_FTFP_BERT_EMZ_H 1
 
 // QGSP_FTFP_BERT_EMZ is a standard Geant4 Physics List FTFP_BERT with Option4
-//                    EM Physics configuration: used GS multiple scattering 
-//                    model for e+- below 100 MeV. Very precised simulation 
-//                    for thin layers. This configuration may be used for R&D 
+//                    EM Physics configuration: used GS multiple scattering
+//                    model for e+- below 100 MeV. Very precised simulation
+//                    for thin layers. This configuration may be used for R&D
 //                    of tracker and HGCal detector performnace. The similation
-//                    is expected to be approximately two times slower then 
+//                    is expected to be approximately two times slower then
 //                    with the CMS production Physics List
- 
+
 #include "SimG4Core/Physics/interface/PhysicsList.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
-class QGSPCMS_FTFP_BERT_EMZ: public PhysicsList {
 
+class QGSPCMS_FTFP_BERT_EMZ : public PhysicsList {
 public:
-  QGSPCMS_FTFP_BERT_EMZ(const edm::ParameterSet & p);
+  QGSPCMS_FTFP_BERT_EMZ(const edm::ParameterSet& p);
 };
 
 #endif
-
-

--- a/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmNoDeltaRay.cc
@@ -66,8 +66,8 @@
 #include "G4BuilderType.hh"
 #include "G4SystemOfUnits.hh"
 
-CMSEmNoDeltaRay::CMSEmNoDeltaRay(const G4String& name, G4int ver, const std::string& reg):
-  G4VPhysicsConstructor(name), verbose(ver), region(reg) {
+CMSEmNoDeltaRay::CMSEmNoDeltaRay(const G4String& name, G4int ver, const std::string& reg)
+    : G4VPhysicsConstructor(name), verbose(ver), region(reg) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
   param->SetVerbose(verbose);
@@ -135,104 +135,72 @@ void CMSEmNoDeltaRay::ConstructProcess() {
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
   EmParticleList emList;
-  for(const auto& particleName : emList.PartNames()) {
+  for (const auto& particleName : emList.PartNames()) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
     G4ProcessManager* pmanager = particle->GetProcessManager();
-    if(verbose > 1)
-      G4cout << "### " << GetPhysicsName() << " instantiates for " 
-	     << particleName << " at " << particle << G4endl;
+    if (verbose > 1)
+      G4cout << "### " << GetPhysicsName() << " instantiates for " << particleName << " at " << particle << G4endl;
 
     if (particleName == "gamma") {
-
       pmanager->AddDiscreteProcess(new G4PhotoElectricEffect);
       pmanager->AddDiscreteProcess(new G4ComptonScattering);
       pmanager->AddDiscreteProcess(new G4GammaConversion);
 
     } else if (particleName == "e-") {
-
       G4eMultipleScattering* msc = new G4eMultipleScattering;
       msc->SetStepLimitType(fMinimal);
       if (reg != nullptr) {
-	G4UrbanMscModel* msc_el  = new G4UrbanMscModel();
-	msc_el->SetRangeFactor(0.04);
-	msc->AddEmModel(0,msc_el,reg);
+        G4UrbanMscModel* msc_el = new G4UrbanMscModel();
+        msc_el->SetRangeFactor(0.04);
+        msc->AddEmModel(0, msc_el, reg);
       }
-      pmanager->AddProcess(msc,                   -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation,    -1, 2, 2);
-      pmanager->AddProcess(new G4eBremsstrahlung, -1,-3, 3);
+      pmanager->AddProcess(msc, -1, 1, 1);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
+      pmanager->AddProcess(new G4eBremsstrahlung, -1, -3, 3);
 
     } else if (particleName == "e+") {
-
       //      G4eIonisation* eioni = new G4eIonisation();
       //      eioni->SetStepFunction(0.8, 1.0*mm);
       G4eMultipleScattering* msc = new G4eMultipleScattering;
       msc->SetStepLimitType(fMinimal);
       if (reg != nullptr) {
-	G4UrbanMscModel* msc_pos  = new G4UrbanMscModel();
-	msc_pos->SetRangeFactor(0.04);
-	msc->AddEmModel(0,msc_pos,reg);
+        G4UrbanMscModel* msc_pos = new G4UrbanMscModel();
+        msc_pos->SetRangeFactor(0.04);
+        msc->AddEmModel(0, msc_pos, reg);
       }
-      pmanager->AddProcess(msc,                     -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation,      -1, 2, 2);
-      pmanager->AddProcess(new G4eBremsstrahlung,   -1,-3, 3);
-      pmanager->AddProcess(new G4eplusAnnihilation,  0,-1, 4);
+      pmanager->AddProcess(msc, -1, 1, 1);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
+      pmanager->AddProcess(new G4eBremsstrahlung, -1, -3, 3);
+      pmanager->AddProcess(new G4eplusAnnihilation, 0, -1, 4);
 
-    } else if (particleName == "mu+" ||
-               particleName == "mu-"    ) {
-
+    } else if (particleName == "mu+" || particleName == "mu-") {
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation,        -1, 2, 2);
-      pmanager->AddProcess(new G4MuBremsstrahlung,    -1,-3, 3);
-      pmanager->AddProcess(new G4MuPairProduction,    -1,-4, 4);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
+      pmanager->AddProcess(new G4MuBremsstrahlung, -1, -3, 3);
+      pmanager->AddProcess(new G4MuPairProduction, -1, -4, 4);
 
-    } else if (particleName == "alpha" ||
-               particleName == "He3" ||
-               particleName == "GenericIon") {
-
+    } else if (particleName == "alpha" || particleName == "He3" || particleName == "GenericIon") {
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation,        -1, 2, 2);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
 
-    } else if (particleName == "pi+" ||
-	       particleName == "kaon+" ||
-	       particleName == "kaon-" ||
-	       particleName == "proton" ||
-	       particleName == "pi-" ) {
-
+    } else if (particleName == "pi+" || particleName == "kaon+" || particleName == "kaon-" ||
+               particleName == "proton" || particleName == "pi-") {
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation,        -1, 2, 2);
-      pmanager->AddProcess(new G4hBremsstrahlung(),   -1,-3, 3);
-      pmanager->AddProcess(new G4hPairProduction(),   -1,-4, 4);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
+      pmanager->AddProcess(new G4hBremsstrahlung(), -1, -3, 3);
+      pmanager->AddProcess(new G4hPairProduction(), -1, -4, 4);
 
-    } else if (particleName == "B+" ||
-	       particleName == "B-" ||
-	       particleName == "D+" ||
-	       particleName == "D-" ||
-	       particleName == "Ds+" ||
-	       particleName == "Ds-" ||
-               particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" ||
-               particleName == "anti_proton" ||
-               particleName == "anti_sigma_c+" ||
-               particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" ||
-               particleName == "anti_sigma-" ||
-               particleName == "anti_xi_c+" ||
-               particleName == "anti_xi-" ||
-               particleName == "deuteron" ||
-	       particleName == "lambda_c+" ||
-               particleName == "omega-" ||
-               particleName == "sigma_c+" ||
-               particleName == "sigma_c++" ||
-               particleName == "sigma+" ||
-               particleName == "sigma-" ||
-               particleName == "tau+" ||
-               particleName == "tau-" ||
-               particleName == "triton" ||
-               particleName == "xi_c+" ||
-               particleName == "xi-" ) {
-
+    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
+               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_lambda_c+" ||
+               particleName == "anti_omega-" || particleName == "anti_proton" || particleName == "anti_sigma_c+" ||
+               particleName == "anti_sigma_c++" || particleName == "anti_sigma+" || particleName == "anti_sigma-" ||
+               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
+               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
+               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
+               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
+               particleName == "xi_c+" || particleName == "xi-") {
       pmanager->AddProcess(new G4hMultipleScattering, -1, 1, 1);
-      pmanager->AddProcess(new G4hhIonisation,        -1, 2, 2);
+      pmanager->AddProcess(new G4hhIonisation, -1, 2, 2);
     }
   }
 }

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -72,13 +72,12 @@
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver) :
-  G4VPhysicsConstructor("CMSEmStandard_eml"), verbose(ver) {
+CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver) : G4VPhysicsConstructor("CMSEmStandard_eml"), verbose(ver) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
   param->SetVerbose(verbose);
   param->SetApplyCuts(true);
-  param->SetStepFunction(0.8, 1*CLHEP::mm);
+  param->SetStepFunction(0.8, 1 * CLHEP::mm);
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
   SetPhysicsType(bElectromagnetic);
@@ -133,8 +132,7 @@ void CMSEmStandardPhysics::ConstructParticle() {
 }
 
 void CMSEmStandardPhysics::ConstructProcess() {
-
-  if(verbose > 0) {
+  if (verbose > 0) {
     G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
   }
 
@@ -156,9 +154,9 @@ void CMSEmStandardPhysics::ConstructProcess() {
 
   // muon & hadron multiple scattering
   G4MuMultipleScattering* mumsc = nullptr;
-  G4hMultipleScattering*  pimsc = nullptr;
-  G4hMultipleScattering*  kmsc = nullptr;
-  G4hMultipleScattering*  hmsc = nullptr;
+  G4hMultipleScattering* pimsc = nullptr;
+  G4hMultipleScattering* kmsc = nullptr;
+  G4hMultipleScattering* hmsc = nullptr;
 
   // muon and hadron single scattering
   G4CoulombScattering* muss = nullptr;
@@ -166,21 +164,19 @@ void CMSEmStandardPhysics::ConstructProcess() {
   G4CoulombScattering* kss = nullptr;
 
   // high energy limit for e+- scattering models and bremsstrahlung
-  G4double highEnergyLimit = 100*MeV;
+  G4double highEnergyLimit = 100 * MeV;
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
   EmParticleList emList;
-  for(const auto& particleName : emList.PartNames()) {
+  for (const auto& particleName : emList.PartNames()) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
 
     if (particleName == "gamma") {
-
       ph->RegisterProcess(new G4PhotoElectricEffect(), particle);
       ph->RegisterProcess(new G4ComptonScattering(), particle);
       ph->RegisterProcess(new G4GammaConversion(), particle);
 
     } else if (particleName == "e-") {
-
       G4eIonisation* eioni = new G4eIonisation();
 
       G4eMultipleScattering* msc = new G4eMultipleScattering;
@@ -191,9 +187,9 @@ void CMSEmStandardPhysics::ConstructProcess() {
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
 
-      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel(); 
+      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();
-      ss->SetEmModel(ssm); 
+      ss->SetEmModel(ssm);
       ss->SetMinKinEnergy(highEnergyLimit);
       ssm->SetLowEnergyLimit(highEnergyLimit);
       ssm->SetActivationLowEnergyLimit(highEnergyLimit);
@@ -204,7 +200,6 @@ void CMSEmStandardPhysics::ConstructProcess() {
       ph->RegisterProcess(ss, particle);
 
     } else if (particleName == "e+") {
-
       G4eIonisation* eioni = new G4eIonisation();
 
       G4eMultipleScattering* msc = new G4eMultipleScattering;
@@ -215,9 +210,9 @@ void CMSEmStandardPhysics::ConstructProcess() {
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
 
-      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel(); 
+      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();
-      ss->SetEmModel(ssm); 
+      ss->SetEmModel(ssm);
       ss->SetMinKinEnergy(highEnergyLimit);
       ssm->SetLowEnergyLimit(highEnergyLimit);
       ssm->SetActivationLowEnergyLimit(highEnergyLimit);
@@ -228,14 +223,12 @@ void CMSEmStandardPhysics::ConstructProcess() {
       ph->RegisterProcess(new G4eplusAnnihilation(), particle);
       ph->RegisterProcess(ss, particle);
 
-    } else if (particleName == "mu+" ||
-               particleName == "mu-" ) {
-
-      if(nullptr == mub) {
-	mub = new G4MuBremsstrahlung();
-	mup = new G4MuPairProduction();
-	mumsc = new G4MuMultipleScattering();
-	mumsc->SetEmModel(new G4WentzelVIModel());
+    } else if (particleName == "mu+" || particleName == "mu-") {
+      if (nullptr == mub) {
+        mub = new G4MuBremsstrahlung();
+        mup = new G4MuPairProduction();
+        mumsc = new G4MuMultipleScattering();
+        mumsc->SetEmModel(new G4WentzelVIModel());
         muss = new G4CoulombScattering();
       }
       ph->RegisterProcess(mumsc, particle);
@@ -244,28 +237,23 @@ void CMSEmStandardPhysics::ConstructProcess() {
       ph->RegisterProcess(mup, particle);
       ph->RegisterProcess(muss, particle);
 
-    } else if (particleName == "alpha" || 
-	       particleName == "He3" ) {
-
+    } else if (particleName == "alpha" || particleName == "He3") {
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
 
     } else if (particleName == "GenericIon") {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
 
-    } else if (particleName == "pi+" || 
-	       particleName == "pi-" ) {
-
-      if(nullptr == pib) {
-	pib = new G4hBremsstrahlung();
-	pip = new G4hPairProduction();
-	pimsc = new G4hMultipleScattering();
-	pimsc->SetEmModel(new G4WentzelVIModel());
+    } else if (particleName == "pi+" || particleName == "pi-") {
+      if (nullptr == pib) {
+        pib = new G4hBremsstrahlung();
+        pip = new G4hPairProduction();
+        pimsc = new G4hMultipleScattering();
+        pimsc->SetEmModel(new G4WentzelVIModel());
         piss = new G4CoulombScattering();
       }
       ph->RegisterProcess(pimsc, particle);
@@ -274,14 +262,12 @@ void CMSEmStandardPhysics::ConstructProcess() {
       ph->RegisterProcess(pip, particle);
       ph->RegisterProcess(piss, particle);
 
-    } else if (particleName == "kaon+" ||
-               particleName == "kaon-" ) {
-
-      if(nullptr == kb) {
-	kb = new G4hBremsstrahlung();
+    } else if (particleName == "kaon+" || particleName == "kaon-") {
+      if (nullptr == kb) {
+        kb = new G4hBremsstrahlung();
         kp = new G4hPairProduction();
-	kmsc = new G4hMultipleScattering();
-	kmsc->SetEmModel(new G4WentzelVIModel());
+        kmsc = new G4hMultipleScattering();
+        kmsc->SetEmModel(new G4WentzelVIModel());
         kss = new G4CoulombScattering();
       }
       ph->RegisterProcess(kmsc, particle);
@@ -290,12 +276,10 @@ void CMSEmStandardPhysics::ConstructProcess() {
       ph->RegisterProcess(kp, particle);
       ph->RegisterProcess(kss, particle);
 
-    } else if (particleName == "proton" ||
-	       particleName == "anti_proton") {
-
-      if(nullptr == pb) {
-	pb = new G4hBremsstrahlung();
-	pp = new G4hPairProduction();
+    } else if (particleName == "proton" || particleName == "anti_proton") {
+      if (nullptr == pb) {
+        pb = new G4hBremsstrahlung();
+        pp = new G4hPairProduction();
       }
       G4hMultipleScattering* pmsc = new G4hMultipleScattering();
       pmsc->SetEmModel(new G4WentzelVIModel());
@@ -307,39 +291,18 @@ void CMSEmStandardPhysics::ConstructProcess() {
       ph->RegisterProcess(pp, particle);
       ph->RegisterProcess(pss, particle);
 
-    } else if (particleName == "B+" ||
-	       particleName == "B-" ||
-	       particleName == "D+" ||
-	       particleName == "D-" ||
-	       particleName == "Ds+" ||
-	       particleName == "Ds-" ||
-               particleName == "anti_He3" ||
-               particleName == "anti_alpha" ||
-               particleName == "anti_deuteron" ||
-               particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" ||
-               particleName == "anti_sigma_c+" ||
-               particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" ||
-               particleName == "anti_sigma-" ||
-               particleName == "anti_triton" ||
-               particleName == "anti_xi_c+" ||
-               particleName == "anti_xi-" ||
-               particleName == "deuteron" ||
-	       particleName == "lambda_c+" ||
-               particleName == "omega-" ||
-               particleName == "sigma_c+" ||
-               particleName == "sigma_c++" ||
-               particleName == "sigma+" ||
-               particleName == "sigma-" ||
-               particleName == "tau+" ||
-               particleName == "tau-" ||
-               particleName == "triton" ||
-               particleName == "xi_c+" ||
-               particleName == "xi-" ) {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
+               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_He3" ||
+               particleName == "anti_alpha" || particleName == "anti_deuteron" || particleName == "anti_lambda_c+" ||
+               particleName == "anti_omega-" || particleName == "anti_sigma_c+" || particleName == "anti_sigma_c++" ||
+               particleName == "anti_sigma+" || particleName == "anti_sigma-" || particleName == "anti_triton" ||
+               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
+               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
+               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
+               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
+               particleName == "xi_c+" || particleName == "xi-") {
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95.cc
@@ -70,14 +70,13 @@
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysics95::CMSEmStandardPhysics95(const G4String& name, G4int ver, 
-					       const std::string& reg):
-  G4VPhysicsConstructor(name), verbose(ver), region(reg) {
+CMSEmStandardPhysics95::CMSEmStandardPhysics95(const G4String& name, G4int ver, const std::string& reg)
+    : G4VPhysicsConstructor(name), verbose(ver), region(reg) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
   param->SetVerbose(verbose);
   param->SetApplyCuts(true);
-  param->SetStepFunction(0.8, 1*CLHEP::mm);
+  param->SetStepFunction(0.8, 1 * CLHEP::mm);
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
   SetPhysicsType(bElectromagnetic);
@@ -131,8 +130,7 @@ void CMSEmStandardPhysics95::ConstructParticle() {
   G4GenericIon::GenericIonDefinition();
 }
 
-void CMSEmStandardPhysics95::ConstructProcess() 
-{
+void CMSEmStandardPhysics95::ConstructProcess() {
   // This EM builder takes default models of Geant4 EMV.
   // Multiple scattering by Urban for all particles
 
@@ -150,28 +148,25 @@ void CMSEmStandardPhysics95::ConstructProcess()
 
   // muon & hadron multiple scattering
   G4MuMultipleScattering* mumsc = nullptr;
-  G4hMultipleScattering*  pimsc = nullptr;
-  G4hMultipleScattering*  kmsc = nullptr;
-  G4hMultipleScattering*  pmsc = nullptr;
-  G4hMultipleScattering*  hmsc = nullptr;
+  G4hMultipleScattering* pimsc = nullptr;
+  G4hMultipleScattering* kmsc = nullptr;
+  G4hMultipleScattering* pmsc = nullptr;
+  G4hMultipleScattering* hmsc = nullptr;
 
   // Add standard EM Processes
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
   EmParticleList emList;
-  for(const auto& particleName : emList.PartNames()) {
+  for (const auto& particleName : emList.PartNames()) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
-    if(verbose > 1)
-      G4cout << "### " << GetPhysicsName() << " instantiates for " 
-	     << particleName << G4endl;
+    if (verbose > 1)
+      G4cout << "### " << GetPhysicsName() << " instantiates for " << particleName << G4endl;
 
     if (particleName == "gamma") {
-
       ph->RegisterProcess(new G4PhotoElectricEffect(), particle);
       ph->RegisterProcess(new G4ComptonScattering(), particle);
       ph->RegisterProcess(new G4GammaConversion(), particle);
 
     } else if (particleName == "e-") {
-
       G4eIonisation* eioni = new G4eIonisation();
       G4eMultipleScattering* msc = new G4eMultipleScattering();
       G4eBremsstrahlung* ebrem = new G4eBremsstrahlung();
@@ -181,7 +176,6 @@ void CMSEmStandardPhysics95::ConstructProcess()
       ph->RegisterProcess(ebrem, particle);
 
     } else if (particleName == "e+") {
-
       G4eIonisation* eioni = new G4eIonisation();
       G4eMultipleScattering* msc = new G4eMultipleScattering();
       G4eBremsstrahlung* ebrem = new G4eBremsstrahlung();
@@ -191,65 +185,54 @@ void CMSEmStandardPhysics95::ConstructProcess()
       ph->RegisterProcess(ebrem, particle);
       ph->RegisterProcess(new G4eplusAnnihilation(), particle);
 
-    } else if (particleName == "mu+" ||
-               particleName == "mu-" ) {
-
-      if(nullptr == mub) {
-	mub = new G4MuBremsstrahlung();
-	mup = new G4MuPairProduction();
-	mumsc = new G4MuMultipleScattering();
+    } else if (particleName == "mu+" || particleName == "mu-") {
+      if (nullptr == mub) {
+        mub = new G4MuBremsstrahlung();
+        mup = new G4MuPairProduction();
+        mumsc = new G4MuMultipleScattering();
       }
       ph->RegisterProcess(mumsc, particle);
       ph->RegisterProcess(new G4MuIonisation(), particle);
       ph->RegisterProcess(mub, particle);
       ph->RegisterProcess(mup, particle);
 
-    } else if (particleName == "alpha" || 
-	       particleName == "He3" ) {
-
+    } else if (particleName == "alpha" || particleName == "He3") {
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
 
     } else if (particleName == "GenericIon") {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
 
-    } else if (particleName == "pi+" || 
-	       particleName == "pi-" ) {
-
-      if(nullptr == pib) {
-	pib = new G4hBremsstrahlung();
-	pip = new G4hPairProduction();
-	pimsc = new G4hMultipleScattering();
+    } else if (particleName == "pi+" || particleName == "pi-") {
+      if (nullptr == pib) {
+        pib = new G4hBremsstrahlung();
+        pip = new G4hPairProduction();
+        pimsc = new G4hMultipleScattering();
       }
       ph->RegisterProcess(pimsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pib, particle);
       ph->RegisterProcess(pip, particle);
 
-    } else if (particleName == "kaon+" ||
-               particleName == "kaon-" ) {
-
-      if(nullptr == kb) {
-	kb = new G4hBremsstrahlung();
+    } else if (particleName == "kaon+" || particleName == "kaon-") {
+      if (nullptr == kb) {
+        kb = new G4hBremsstrahlung();
         kp = new G4hPairProduction();
-	kmsc = new G4hMultipleScattering();
+        kmsc = new G4hMultipleScattering();
       }
       ph->RegisterProcess(kmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(kb, particle);
       ph->RegisterProcess(kp, particle);
 
-    } else if (particleName == "proton" ||
-	       particleName == "anti_proton") {
-
-      if(nullptr == pb) {
-	pb = new G4hBremsstrahlung();
-	pp = new G4hPairProduction();
+    } else if (particleName == "proton" || particleName == "anti_proton") {
+      if (nullptr == pb) {
+        pb = new G4hBremsstrahlung();
+        pp = new G4hPairProduction();
       }
       pmsc = new G4hMultipleScattering();
       ph->RegisterProcess(pmsc, particle);
@@ -257,39 +240,18 @@ void CMSEmStandardPhysics95::ConstructProcess()
       ph->RegisterProcess(pb, particle);
       ph->RegisterProcess(pp, particle);
 
-    } else if (particleName == "B+" ||
-	       particleName == "B-" ||
-	       particleName == "D+" ||
-	       particleName == "D-" ||
-	       particleName == "Ds+" ||
-	       particleName == "Ds-" ||
-               particleName == "anti_He3" ||
-               particleName == "anti_alpha" ||
-               particleName == "anti_deuteron" ||
-               particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" ||
-               particleName == "anti_sigma_c+" ||
-               particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" ||
-               particleName == "anti_sigma-" ||
-               particleName == "anti_triton" ||
-               particleName == "anti_xi_c+" ||
-               particleName == "anti_xi-" ||
-               particleName == "deuteron" ||
-	       particleName == "lambda_c+" ||
-               particleName == "omega-" ||
-               particleName == "sigma_c+" ||
-               particleName == "sigma_c++" ||
-               particleName == "sigma+" ||
-               particleName == "sigma-" ||
-               particleName == "tau+" ||
-               particleName == "tau-" ||
-               particleName == "triton" ||
-               particleName == "xi_c+" ||
-               particleName == "xi-" ) {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
+               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_He3" ||
+               particleName == "anti_alpha" || particleName == "anti_deuteron" || particleName == "anti_lambda_c+" ||
+               particleName == "anti_omega-" || particleName == "anti_sigma_c+" || particleName == "anti_sigma_c++" ||
+               particleName == "anti_sigma+" || particleName == "anti_sigma-" || particleName == "anti_triton" ||
+               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
+               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
+               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
+               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
+               particleName == "xi_c+" || particleName == "xi-") {
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics95msc93.cc
@@ -70,15 +70,13 @@
 #include "G4BuilderType.hh"
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysics95msc93::CMSEmStandardPhysics95msc93(const G4String& name, 
-							 G4int ver, 
-							 const std::string& reg)
-: G4VPhysicsConstructor(name), verbose(ver), region(reg) {
+CMSEmStandardPhysics95msc93::CMSEmStandardPhysics95msc93(const G4String& name, G4int ver, const std::string& reg)
+    : G4VPhysicsConstructor(name), verbose(ver), region(reg) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
   param->SetVerbose(verbose);
   param->SetApplyCuts(true);
-  param->SetStepFunction(0.8, 1*CLHEP::mm);
+  param->SetStepFunction(0.8, 1 * CLHEP::mm);
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
   SetPhysicsType(bElectromagnetic);
@@ -132,8 +130,7 @@ void CMSEmStandardPhysics95msc93::ConstructParticle() {
   G4GenericIon::GenericIonDefinition();
 }
 
-void CMSEmStandardPhysics95msc93::ConstructProcess() 
-{
+void CMSEmStandardPhysics95msc93::ConstructProcess() {
   // Add standard EM Processes
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
@@ -149,9 +146,9 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
 
   // muon & hadron multiple scattering
   G4MuMultipleScattering* mumsc = nullptr;
-  G4hMultipleScattering*  pimsc = nullptr;
-  G4hMultipleScattering*  kmsc = nullptr;
-  G4hMultipleScattering*  pmsc = nullptr;
+  G4hMultipleScattering* pimsc = nullptr;
+  G4hMultipleScattering* kmsc = nullptr;
+  G4hMultipleScattering* pmsc = nullptr;
   G4hMultipleScattering* hmsc = nullptr;
 
   // This EM builder takes default models of Geant4 10 EMV.
@@ -160,20 +157,17 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
   EmParticleList emList;
-  for(const auto& particleName : emList.PartNames()) {
+  for (const auto& particleName : emList.PartNames()) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
-    if(verbose > 1)
-      G4cout << "### " << GetPhysicsName() << " instantiates for " 
-	     << particleName << " at " << particle << G4endl;
+    if (verbose > 1)
+      G4cout << "### " << GetPhysicsName() << " instantiates for " << particleName << " at " << particle << G4endl;
 
     if (particleName == "gamma") {
-
       ph->RegisterProcess(new G4PhotoElectricEffect(), particle);
       ph->RegisterProcess(new G4ComptonScattering(), particle);
       ph->RegisterProcess(new G4GammaConversion(), particle);
 
     } else if (particleName == "e-") {
-
       G4eIonisation* eioni = new G4eIonisation();
       G4eMultipleScattering* msc = new G4eMultipleScattering;
       msc->SetEmModel(new UrbanMscModel93());
@@ -185,7 +179,6 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
       ph->RegisterProcess(ebrem, particle);
 
     } else if (particleName == "e+") {
-
       G4eIonisation* eioni = new G4eIonisation();
 
       G4eMultipleScattering* msc = new G4eMultipleScattering;
@@ -198,65 +191,54 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
       ph->RegisterProcess(ebrem, particle);
       ph->RegisterProcess(new G4eplusAnnihilation(), particle);
 
-    } else if (particleName == "mu+" ||
-               particleName == "mu-" ) {
-
-      if(nullptr == mub) {
-	mub = new G4MuBremsstrahlung();
-	mup = new G4MuPairProduction();
-	mumsc = new G4MuMultipleScattering();
+    } else if (particleName == "mu+" || particleName == "mu-") {
+      if (nullptr == mub) {
+        mub = new G4MuBremsstrahlung();
+        mup = new G4MuPairProduction();
+        mumsc = new G4MuMultipleScattering();
       }
       ph->RegisterProcess(mumsc, particle);
       ph->RegisterProcess(new G4MuIonisation(), particle);
       ph->RegisterProcess(mub, particle);
       ph->RegisterProcess(mup, particle);
 
-    } else if (particleName == "alpha" || 
-	       particleName == "He3" ) {
-
+    } else if (particleName == "alpha" || particleName == "He3") {
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
 
     } else if (particleName == "GenericIon") {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
 
-    } else if (particleName == "pi+" || 
-	       particleName == "pi-" ) {
-
-      if(nullptr == pib) {
-	pib = new G4hBremsstrahlung();
-	pip = new G4hPairProduction();
-	pimsc = new G4hMultipleScattering();
+    } else if (particleName == "pi+" || particleName == "pi-") {
+      if (nullptr == pib) {
+        pib = new G4hBremsstrahlung();
+        pip = new G4hPairProduction();
+        pimsc = new G4hMultipleScattering();
       }
       ph->RegisterProcess(pimsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(pib, particle);
       ph->RegisterProcess(pip, particle);
 
-    } else if (particleName == "kaon+" ||
-               particleName == "kaon-" ) {
-
-      if(nullptr == kb) {
-	kb = new G4hBremsstrahlung();
+    } else if (particleName == "kaon+" || particleName == "kaon-") {
+      if (nullptr == kb) {
+        kb = new G4hBremsstrahlung();
         kp = new G4hPairProduction();
-	kmsc = new G4hMultipleScattering();
+        kmsc = new G4hMultipleScattering();
       }
       ph->RegisterProcess(kmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
       ph->RegisterProcess(kb, particle);
       ph->RegisterProcess(kp, particle);
 
-    } else if (particleName == "proton" ||
-	       particleName == "anti_proton") {
-
-      if(nullptr == pb) {
-	pb = new G4hBremsstrahlung();
-	pp = new G4hPairProduction();
+    } else if (particleName == "proton" || particleName == "anti_proton") {
+      if (nullptr == pb) {
+        pb = new G4hBremsstrahlung();
+        pp = new G4hPairProduction();
       }
       pmsc = new G4hMultipleScattering();
 
@@ -265,36 +247,17 @@ void CMSEmStandardPhysics95msc93::ConstructProcess()
       ph->RegisterProcess(pb, particle);
       ph->RegisterProcess(pp, particle);
 
-    } else if (particleName == "B+" ||
-	       particleName == "B-" ||
-	       particleName == "D+" ||
-	       particleName == "D-" ||
-	       particleName == "Ds+" ||
-	       particleName == "Ds-" ||
-               particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" ||
-               particleName == "anti_proton" ||
-               particleName == "anti_sigma_c+" ||
-               particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" ||
-               particleName == "anti_sigma-" ||
-               particleName == "anti_xi_c+" ||
-               particleName == "anti_xi-" ||
-               particleName == "deuteron" ||
-	       particleName == "lambda_c+" ||
-               particleName == "omega-" ||
-               particleName == "sigma_c+" ||
-               particleName == "sigma_c++" ||
-               particleName == "sigma+" ||
-               particleName == "sigma-" ||
-               particleName == "tau+" ||
-               particleName == "tau-" ||
-               particleName == "triton" ||
-               particleName == "xi_c+" ||
-               particleName == "xi-" ) {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
+               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_lambda_c+" ||
+               particleName == "anti_omega-" || particleName == "anti_proton" || particleName == "anti_sigma_c+" ||
+               particleName == "anti_sigma_c++" || particleName == "anti_sigma+" || particleName == "anti_sigma-" ||
+               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
+               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
+               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
+               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
+               particleName == "xi_c+" || particleName == "xi-") {
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -74,13 +74,12 @@
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) :
-  G4VPhysicsConstructor("CMSEmStandard_emm"), verbose(ver) {
+CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) : G4VPhysicsConstructor("CMSEmStandard_emm"), verbose(ver) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
   param->SetVerbose(verbose);
   param->SetApplyCuts(true);
-  param->SetStepFunction(0.8, 1*CLHEP::mm);
+  param->SetStepFunction(0.8, 1 * CLHEP::mm);
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
   SetPhysicsType(bElectromagnetic);
@@ -135,8 +134,7 @@ void CMSEmStandardPhysicsLPM::ConstructParticle() {
 }
 
 void CMSEmStandardPhysicsLPM::ConstructProcess() {
-
-  if(verbose > 0) {
+  if (verbose > 0) {
     G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
   }
 
@@ -158,10 +156,10 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
 
   // muon & hadron multiple scattering
   G4MuMultipleScattering* mumsc = nullptr;
-  G4hMultipleScattering*  pimsc = nullptr;
-  G4hMultipleScattering*  kmsc = nullptr;
-  G4hMultipleScattering*  pmsc = nullptr;
-  G4hMultipleScattering*  hmsc = nullptr;
+  G4hMultipleScattering* pimsc = nullptr;
+  G4hMultipleScattering* kmsc = nullptr;
+  G4hMultipleScattering* pmsc = nullptr;
+  G4hMultipleScattering* hmsc = nullptr;
 
   // muon and hadron single scattering
   G4CoulombScattering* muss = nullptr;
@@ -169,26 +167,22 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
   G4CoulombScattering* kss = nullptr;
 
   // high energy limit for e+- scattering models and bremsstrahlung
-  G4double highEnergyLimit = 100*MeV;
+  G4double highEnergyLimit = 100 * MeV;
 
-  G4Region* aRegion = 
-    G4RegionStore::GetInstance()->GetRegion("HcalRegion",false);
-  G4Region* bRegion = 
-    G4RegionStore::GetInstance()->GetRegion("HGCalRegion",false);
+  G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion", false);
+  G4Region* bRegion = G4RegionStore::GetInstance()->GetRegion("HGCalRegion", false);
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
   EmParticleList emList;
-  for(const auto& particleName : emList.PartNames()) {
+  for (const auto& particleName : emList.PartNames()) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
 
     if (particleName == "gamma") {
-
       ph->RegisterProcess(new G4PhotoElectricEffect(), particle);
       ph->RegisterProcess(new G4ComptonScattering(), particle);
       ph->RegisterProcess(new G4GammaConversion(), particle);
 
     } else if (particleName == "e-") {
-
       G4eIonisation* eioni = new G4eIonisation();
 
       G4eMultipleScattering* msc = new G4eMultipleScattering;
@@ -197,18 +191,19 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       G4UrbanMscModel* msc3 = new G4UrbanMscModel();
       //--- VI: these line should be moved down
       msc3->SetLocked(true);
-      //--- 
+      //---
       msc1->SetHighEnergyLimit(highEnergyLimit);
       msc2->SetLowEnergyLimit(highEnergyLimit);
       msc3->SetHighEnergyLimit(highEnergyLimit);
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
       msc->AddEmModel(-1, msc3, aRegion);
-      if (bRegion) msc->AddEmModel(-1, msc3, bRegion);
+      if (bRegion)
+        msc->AddEmModel(-1, msc3, bRegion);
 
-      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel(); 
+      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();
-      ss->SetEmModel(ssm); 
+      ss->SetEmModel(ssm);
       ss->SetMinKinEnergy(highEnergyLimit);
       ssm->SetLowEnergyLimit(highEnergyLimit);
       ssm->SetActivationLowEnergyLimit(highEnergyLimit);
@@ -219,7 +214,6 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(ss, particle);
 
     } else if (particleName == "e+") {
-
       G4eIonisation* eioni = new G4eIonisation();
 
       G4eMultipleScattering* msc = new G4eMultipleScattering;
@@ -233,11 +227,12 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
       msc->AddEmModel(-1, msc3, aRegion);
-      if (bRegion) msc->AddEmModel(-1, msc3, bRegion);
+      if (bRegion)
+        msc->AddEmModel(-1, msc3, bRegion);
 
-      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel(); 
+      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();
-      ss->SetEmModel(ssm); 
+      ss->SetEmModel(ssm);
       ss->SetMinKinEnergy(highEnergyLimit);
       ssm->SetLowEnergyLimit(highEnergyLimit);
       ssm->SetActivationLowEnergyLimit(highEnergyLimit);
@@ -248,14 +243,12 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(new G4eplusAnnihilation(), particle);
       ph->RegisterProcess(ss, particle);
 
-    } else if (particleName == "mu+" ||
-               particleName == "mu-" ) {
-
-      if(nullptr == mub) {
-	mub = new G4MuBremsstrahlung();
-	mup = new G4MuPairProduction();
-	mumsc = new G4MuMultipleScattering();
-	mumsc->SetEmModel(new G4WentzelVIModel());
+    } else if (particleName == "mu+" || particleName == "mu-") {
+      if (nullptr == mub) {
+        mub = new G4MuBremsstrahlung();
+        mup = new G4MuPairProduction();
+        mumsc = new G4MuMultipleScattering();
+        mumsc->SetEmModel(new G4WentzelVIModel());
         muss = new G4CoulombScattering();
       }
       ph->RegisterProcess(mumsc, particle);
@@ -264,28 +257,23 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(mup, particle);
       ph->RegisterProcess(muss, particle);
 
-    } else if (particleName == "alpha" || 
-	       particleName == "He3" ) {
-
+    } else if (particleName == "alpha" || particleName == "He3") {
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
 
     } else if (particleName == "GenericIon") {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
 
-    } else if (particleName == "pi+" || 
-	       particleName == "pi-" ) {
-
-      if(nullptr == pib) {
-	pib = new G4hBremsstrahlung();
-	pip = new G4hPairProduction();
-	pimsc = new G4hMultipleScattering();
-	pimsc->SetEmModel(new G4WentzelVIModel());
+    } else if (particleName == "pi+" || particleName == "pi-") {
+      if (nullptr == pib) {
+        pib = new G4hBremsstrahlung();
+        pip = new G4hPairProduction();
+        pimsc = new G4hMultipleScattering();
+        pimsc->SetEmModel(new G4WentzelVIModel());
         piss = new G4CoulombScattering();
       }
       ph->RegisterProcess(pimsc, particle);
@@ -294,14 +282,12 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(pip, particle);
       ph->RegisterProcess(piss, particle);
 
-    } else if (particleName == "kaon+" ||
-               particleName == "kaon-" ) {
-
-      if(nullptr == kb) {
-	kb = new G4hBremsstrahlung();
+    } else if (particleName == "kaon+" || particleName == "kaon-") {
+      if (nullptr == kb) {
+        kb = new G4hBremsstrahlung();
         kp = new G4hPairProduction();
-	kmsc = new G4hMultipleScattering();
-	kmsc->SetEmModel(new G4WentzelVIModel());
+        kmsc = new G4hMultipleScattering();
+        kmsc->SetEmModel(new G4WentzelVIModel());
         kss = new G4CoulombScattering();
       }
       ph->RegisterProcess(kmsc, particle);
@@ -310,16 +296,14 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(kp, particle);
       ph->RegisterProcess(kss, particle);
 
-    } else if (particleName == "proton" ||
-	       particleName == "anti_proton") {
-
-      if(nullptr == pb) {
-	pb = new G4hBremsstrahlung();
-	pp = new G4hPairProduction();
-	//--- VI: these lines should be moved out of the brackets
-	pmsc = new G4hMultipleScattering();
-	pmsc->SetEmModel(new G4WentzelVIModel());
-	//---
+    } else if (particleName == "proton" || particleName == "anti_proton") {
+      if (nullptr == pb) {
+        pb = new G4hBremsstrahlung();
+        pp = new G4hPairProduction();
+        //--- VI: these lines should be moved out of the brackets
+        pmsc = new G4hMultipleScattering();
+        pmsc->SetEmModel(new G4WentzelVIModel());
+        //---
       }
 
       ph->RegisterProcess(pmsc, particle);
@@ -328,39 +312,18 @@ void CMSEmStandardPhysicsLPM::ConstructProcess() {
       ph->RegisterProcess(pp, particle);
       ph->RegisterProcess(new G4CoulombScattering(), particle);
 
-    } else if (particleName == "B+" ||
-	       particleName == "B-" ||
-	       particleName == "D+" ||
-	       particleName == "D-" ||
-	       particleName == "Ds+" ||
-	       particleName == "Ds-" ||
-               particleName == "anti_He3" ||
-               particleName == "anti_alpha" ||
-               particleName == "anti_deuteron" ||
-               particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" ||
-               particleName == "anti_sigma_c+" ||
-               particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" ||
-               particleName == "anti_sigma-" ||
-               particleName == "anti_triton" ||
-               particleName == "anti_xi_c+" ||
-               particleName == "anti_xi-" ||
-               particleName == "deuteron" ||
-	       particleName == "lambda_c+" ||
-               particleName == "omega-" ||
-               particleName == "sigma_c+" ||
-               particleName == "sigma_c++" ||
-               particleName == "sigma+" ||
-               particleName == "sigma-" ||
-               particleName == "tau+" ||
-               particleName == "tau-" ||
-               particleName == "triton" ||
-               particleName == "xi_c+" ||
-               particleName == "xi-" ) {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
+               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_He3" ||
+               particleName == "anti_alpha" || particleName == "anti_deuteron" || particleName == "anti_lambda_c+" ||
+               particleName == "anti_omega-" || particleName == "anti_sigma_c+" || particleName == "anti_sigma_c++" ||
+               particleName == "anti_sigma+" || particleName == "anti_sigma-" || particleName == "anti_triton" ||
+               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
+               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
+               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
+               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
+               particleName == "xi_c+" || particleName == "xi-") {
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -89,15 +89,14 @@
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysicsXS::CMSEmStandardPhysicsXS(G4int ver) :
-  G4VPhysicsConstructor("CMSEmStandard_emn"), verbose(ver) {
+CMSEmStandardPhysicsXS::CMSEmStandardPhysicsXS(G4int ver) : G4VPhysicsConstructor("CMSEmStandard_emn"), verbose(ver) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
   param->SetVerbose(verbose);
   param->SetApplyCuts(true);
-  param->SetLowestElectronEnergy(100*eV);
-  param->SetStepFunction(0.8, 1*CLHEP::mm);
-  param->SetUseMottCorrection(true); // use Mott-correction for e-/e+ msc gs
+  param->SetLowestElectronEnergy(100 * eV);
+  param->SetStepFunction(0.8, 1 * CLHEP::mm);
+  param->SetUseMottCorrection(true);  // use Mott-correction for e-/e+ msc gs
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
   param->SetFluo(true);
@@ -153,8 +152,7 @@ void CMSEmStandardPhysicsXS::ConstructParticle() {
 }
 
 void CMSEmStandardPhysicsXS::ConstructProcess() {
-
-  if(verbose > 0) {
+  if (verbose > 0) {
     G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
   }
 
@@ -177,9 +175,9 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
 
   // muon & hadron multiple scattering
   G4MuMultipleScattering* mumsc = nullptr;
-  G4hMultipleScattering*  pimsc = nullptr;
-  G4hMultipleScattering*  kmsc = nullptr;
-  G4hMultipleScattering*  hmsc = nullptr;
+  G4hMultipleScattering* pimsc = nullptr;
+  G4hMultipleScattering* kmsc = nullptr;
+  G4hMultipleScattering* hmsc = nullptr;
 
   // muon and hadron single scattering
   G4CoulombScattering* muss = nullptr;
@@ -187,23 +185,20 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
   G4CoulombScattering* kss = nullptr;
 
   // high energy limit for e+- scattering models and bremsstrahlung
-  G4double highEnergyLimit = 100*MeV;
+  G4double highEnergyLimit = 100 * MeV;
 
   // nuclear stopping
   G4NuclearStopping* pnuc = nullptr;
 
-  G4Region* aRegion = 
-    G4RegionStore::GetInstance()->GetRegion("HcalRegion",false);
-  G4Region* bRegion = 
-    G4RegionStore::GetInstance()->GetRegion("HGCalRegion",false);
+  G4Region* aRegion = G4RegionStore::GetInstance()->GetRegion("HcalRegion", false);
+  G4Region* bRegion = G4RegionStore::GetInstance()->GetRegion("HGCalRegion", false);
 
   G4ParticleTable* table = G4ParticleTable::GetParticleTable();
   EmParticleList emList;
-  for(const auto& particleName : emList.PartNames()) {
+  for (const auto& particleName : emList.PartNames()) {
     G4ParticleDefinition* particle = table->FindParticle(particleName);
 
     if (particleName == "gamma") {
-
       G4PhotoElectricEffect* photo = new G4PhotoElectricEffect();
       photo->SetEmModel(new G4LivermorePhotoElectricModel());
       ph->RegisterProcess(photo, particle);
@@ -213,13 +208,12 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       ph->RegisterProcess(new G4GammaConversion(), particle);
 
     } else if (particleName == "e-") {
-
       G4eIonisation* eioni = new G4eIonisation();
 
       G4eMultipleScattering* msc = new G4eMultipleScattering;
-      G4UrbanMscModel* msc1  = new G4UrbanMscModel();
+      G4UrbanMscModel* msc1 = new G4UrbanMscModel();
       G4WentzelVIModel* msc2 = new G4WentzelVIModel();
-      G4GoudsmitSaundersonMscModel* msc3  = new G4GoudsmitSaundersonMscModel();
+      G4GoudsmitSaundersonMscModel* msc3 = new G4GoudsmitSaundersonMscModel();
       msc3->SetStepLimitType(fUseSafetyPlus);
       msc3->SetRangeFactor(0.08);
       msc3->SetSkin(3.0);
@@ -230,11 +224,12 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
       msc->AddEmModel(-1, msc3, aRegion);
-      if (bRegion) msc->AddEmModel(-1, msc3, bRegion);
+      if (bRegion)
+        msc->AddEmModel(-1, msc3, bRegion);
 
-      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel(); 
+      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();
-      ss->SetEmModel(ssm); 
+      ss->SetEmModel(ssm);
       ss->SetMinKinEnergy(highEnergyLimit);
       ssm->SetLowEnergyLimit(highEnergyLimit);
       ssm->SetActivationLowEnergyLimit(highEnergyLimit);
@@ -249,7 +244,9 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       brem->SetEmModel(br2);
       br1->SetHighEnergyLimit(GeV);
 
-      if(!ee) { ee = new G4ePairProduction(); }
+      if (!ee) {
+        ee = new G4ePairProduction();
+      }
 
       ph->RegisterProcess(msc, particle);
       ph->RegisterProcess(eioni, particle);
@@ -258,13 +255,12 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       ph->RegisterProcess(ss, particle);
 
     } else if (particleName == "e+") {
-
       G4eIonisation* eioni = new G4eIonisation();
 
       G4eMultipleScattering* msc = new G4eMultipleScattering;
       G4UrbanMscModel* msc1 = new G4UrbanMscModel();
-      G4WentzelVIModel* msc2= new G4WentzelVIModel();
-      G4GoudsmitSaundersonMscModel* msc3  = new G4GoudsmitSaundersonMscModel();
+      G4WentzelVIModel* msc2 = new G4WentzelVIModel();
+      G4GoudsmitSaundersonMscModel* msc3 = new G4GoudsmitSaundersonMscModel();
       msc3->SetStepLimitType(fUseSafetyPlus);
       msc3->SetRangeFactor(0.08);
       msc3->SetSkin(3.0);
@@ -275,11 +271,12 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       msc->SetEmModel(msc1);
       msc->SetEmModel(msc2);
       msc->AddEmModel(-1, msc3, aRegion);
-      if (bRegion) msc->AddEmModel(-1, msc3, bRegion);
+      if (bRegion)
+        msc->AddEmModel(-1, msc3, bRegion);
 
-      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel(); 
+      G4eCoulombScatteringModel* ssm = new G4eCoulombScatteringModel();
       G4CoulombScattering* ss = new G4CoulombScattering();
-      ss->SetEmModel(ssm); 
+      ss->SetEmModel(ssm);
       ss->SetMinKinEnergy(highEnergyLimit);
       ssm->SetLowEnergyLimit(highEnergyLimit);
       ssm->SetActivationLowEnergyLimit(highEnergyLimit);
@@ -294,7 +291,9 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       brem->SetEmModel(br2);
       br1->SetHighEnergyLimit(GeV);
 
-      if(!ee) { ee = new G4ePairProduction(); }
+      if (!ee) {
+        ee = new G4ePairProduction();
+      }
 
       ph->RegisterProcess(msc, particle);
       ph->RegisterProcess(eioni, particle);
@@ -303,14 +302,12 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       ph->RegisterProcess(ee, particle);
       ph->RegisterProcess(ss, particle);
 
-    } else if (particleName == "mu+" ||
-               particleName == "mu-" ) {
-
-      if(nullptr == mub) {
-	mub = new G4MuBremsstrahlung();
-	mup = new G4MuPairProduction();
-	mumsc = new G4MuMultipleScattering();
-	mumsc->SetEmModel(new G4WentzelVIModel());
+    } else if (particleName == "mu+" || particleName == "mu-") {
+      if (nullptr == mub) {
+        mub = new G4MuBremsstrahlung();
+        mup = new G4MuPairProduction();
+        mumsc = new G4MuMultipleScattering();
+        mumsc->SetEmModel(new G4WentzelVIModel());
         muss = new G4CoulombScattering();
       }
       ph->RegisterProcess(mumsc, particle);
@@ -319,33 +316,32 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       ph->RegisterProcess(mup, particle);
       ph->RegisterProcess(muss, particle);
 
-    } else if (particleName == "alpha" || 
-	       particleName == "He3" ) {
-
-      if(!pnuc) { pnuc = new G4NuclearStopping(); }
+    } else if (particleName == "alpha" || particleName == "He3") {
+      if (!pnuc) {
+        pnuc = new G4NuclearStopping();
+      }
 
       ph->RegisterProcess(new G4hMultipleScattering(), particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
       ph->RegisterProcess(pnuc, particle);
 
     } else if (particleName == "GenericIon") {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
-      if(!pnuc) { pnuc = new G4NuclearStopping(); }
+      if (!pnuc) {
+        pnuc = new G4NuclearStopping();
+      }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4ionIonisation(), particle);
       ph->RegisterProcess(pnuc, particle);
 
-    } else if (particleName == "pi+" || 
-	       particleName == "pi-" ) {
-
-      if(nullptr == pib) {
-	pib = new G4hBremsstrahlung();
-	pip = new G4hPairProduction();
-	pimsc = new G4hMultipleScattering();
-	pimsc->SetEmModel(new G4WentzelVIModel());
+    } else if (particleName == "pi+" || particleName == "pi-") {
+      if (nullptr == pib) {
+        pib = new G4hBremsstrahlung();
+        pip = new G4hPairProduction();
+        pimsc = new G4hMultipleScattering();
+        pimsc->SetEmModel(new G4WentzelVIModel());
         piss = new G4CoulombScattering();
       }
       ph->RegisterProcess(pimsc, particle);
@@ -354,14 +350,12 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       ph->RegisterProcess(pip, particle);
       ph->RegisterProcess(piss, particle);
 
-    } else if (particleName == "kaon+" ||
-               particleName == "kaon-" ) {
-
-      if(nullptr == kb) {
-	kb = new G4hBremsstrahlung();
+    } else if (particleName == "kaon+" || particleName == "kaon-") {
+      if (nullptr == kb) {
+        kb = new G4hBremsstrahlung();
         kp = new G4hPairProduction();
-	kmsc = new G4hMultipleScattering();
-	kmsc->SetEmModel(new G4WentzelVIModel());
+        kmsc = new G4hMultipleScattering();
+        kmsc->SetEmModel(new G4WentzelVIModel());
         kss = new G4CoulombScattering();
       }
       ph->RegisterProcess(kmsc, particle);
@@ -370,14 +364,14 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       ph->RegisterProcess(kp, particle);
       ph->RegisterProcess(kss, particle);
 
-    } else if (particleName == "proton" ||
-	       particleName == "anti_proton") {
-
-      if(nullptr == pb) {
-	pb = new G4hBremsstrahlung();
-	pp = new G4hPairProduction();
+    } else if (particleName == "proton" || particleName == "anti_proton") {
+      if (nullptr == pb) {
+        pb = new G4hBremsstrahlung();
+        pp = new G4hPairProduction();
       }
-      if(!pnuc) { pnuc = new G4NuclearStopping(); }
+      if (!pnuc) {
+        pnuc = new G4NuclearStopping();
+      }
 
       G4hMultipleScattering* pmsc = new G4hMultipleScattering();
       pmsc->SetEmModel(new G4WentzelVIModel());
@@ -390,45 +384,26 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
       ph->RegisterProcess(pp, particle);
       ph->RegisterProcess(pss, particle);
 
-    } else if (particleName == "B+" ||
-	       particleName == "B-" ||
-	       particleName == "D+" ||
-	       particleName == "D-" ||
-	       particleName == "Ds+" ||
-	       particleName == "Ds-" ||
-               particleName == "anti_He3" ||
-               particleName == "anti_alpha" ||
-               particleName == "anti_deuteron" ||
-               particleName == "anti_lambda_c+" ||
-               particleName == "anti_omega-" ||
-               particleName == "anti_sigma_c+" ||
-               particleName == "anti_sigma_c++" ||
-               particleName == "anti_sigma+" ||
-               particleName == "anti_sigma-" ||
-               particleName == "anti_triton" ||
-               particleName == "anti_xi_c+" ||
-               particleName == "anti_xi-" ||
-               particleName == "deuteron" ||
-	       particleName == "lambda_c+" ||
-               particleName == "omega-" ||
-               particleName == "sigma_c+" ||
-               particleName == "sigma_c++" ||
-               particleName == "sigma+" ||
-               particleName == "sigma-" ||
-               particleName == "tau+" ||
-               particleName == "tau-" ||
-               particleName == "triton" ||
-               particleName == "xi_c+" ||
-               particleName == "xi-" ) {
-
-      if(nullptr == hmsc) {
-	hmsc = new G4hMultipleScattering("ionmsc");
+    } else if (particleName == "B+" || particleName == "B-" || particleName == "D+" || particleName == "D-" ||
+               particleName == "Ds+" || particleName == "Ds-" || particleName == "anti_He3" ||
+               particleName == "anti_alpha" || particleName == "anti_deuteron" || particleName == "anti_lambda_c+" ||
+               particleName == "anti_omega-" || particleName == "anti_sigma_c+" || particleName == "anti_sigma_c++" ||
+               particleName == "anti_sigma+" || particleName == "anti_sigma-" || particleName == "anti_triton" ||
+               particleName == "anti_xi_c+" || particleName == "anti_xi-" || particleName == "deuteron" ||
+               particleName == "lambda_c+" || particleName == "omega-" || particleName == "sigma_c+" ||
+               particleName == "sigma_c++" || particleName == "sigma+" || particleName == "sigma-" ||
+               particleName == "tau+" || particleName == "tau-" || particleName == "triton" ||
+               particleName == "xi_c+" || particleName == "xi-") {
+      if (nullptr == hmsc) {
+        hmsc = new G4hMultipleScattering("ionmsc");
       }
       ph->RegisterProcess(hmsc, particle);
       ph->RegisterProcess(new G4hIonisation(), particle);
     }
   }
-  if(pnuc) { pnuc->SetMaxKinEnergy(MeV); }
+  if (pnuc) {
+    pnuc->SetMaxKinEnergy(MeV);
+  }
   // Deexcitation
   //
   G4VAtomDeexcitation* de = new G4UAtomicDeexcitation();

--- a/SimG4Core/PhysicsLists/src/CMSFTFPNeutronBuilder.cc
+++ b/SimG4Core/PhysicsLists/src/CMSFTFPNeutronBuilder.cc
@@ -5,10 +5,9 @@
 #include "G4NeutronInelasticCrossSection.hh"
 #include "G4SystemOfUnits.hh"
 
-CMSFTFPNeutronBuilder::CMSFTFPNeutronBuilder(G4bool quasiElastic) 
-{
-  theMin =   4*GeV;
-  theMax = 100*TeV;
+CMSFTFPNeutronBuilder::CMSFTFPNeutronBuilder(G4bool quasiElastic) {
+  theMin = 4 * GeV;
+  theMax = 100 * TeV;
   theModel = new G4TheoFSGenerator("FTFP");
 
   theStringModel = new G4FTFModel;
@@ -17,52 +16,40 @@ CMSFTFPNeutronBuilder::CMSFTFPNeutronBuilder(G4bool quasiElastic)
 
   theCascade = new G4GeneratorPrecompoundInterface;
   thePreEquilib = new G4PreCompoundModel(new G4ExcitationHandler);
-  theCascade->SetDeExcitation(thePreEquilib);  
+  theCascade->SetDeExcitation(thePreEquilib);
 
   theModel->SetTransport(theCascade);
 
   theModel->SetHighEnergyGenerator(theStringModel);
-  if (quasiElastic)
-  {
-     theQuasiElastic=new G4QuasiElasticChannel;
-     theModel->SetQuasiElasticChannel(theQuasiElastic);
-  } else 
-  {  theQuasiElastic=nullptr;}  
+  if (quasiElastic) {
+    theQuasiElastic = new G4QuasiElasticChannel;
+    theModel->SetQuasiElasticChannel(theQuasiElastic);
+  } else {
+    theQuasiElastic = nullptr;
+  }
 
   theModel->SetMinEnergy(theMin);
-  theModel->SetMaxEnergy(100*TeV);
+  theModel->SetMaxEnergy(100 * TeV);
 }
 
-CMSFTFPNeutronBuilder::
-~CMSFTFPNeutronBuilder() 
-{
+CMSFTFPNeutronBuilder::~CMSFTFPNeutronBuilder() {
   delete theStringDecay;
   delete theStringModel;
   delete thePreEquilib;
   delete theCascade;
-  if ( theQuasiElastic ) delete theQuasiElastic;
+  if (theQuasiElastic)
+    delete theQuasiElastic;
 }
 
-void CMSFTFPNeutronBuilder::
-Build(G4HadronElasticProcess * )
-{
-}
+void CMSFTFPNeutronBuilder::Build(G4HadronElasticProcess*) {}
 
-void CMSFTFPNeutronBuilder::
-Build(G4HadronFissionProcess * )
-{
-}
+void CMSFTFPNeutronBuilder::Build(G4HadronFissionProcess*) {}
 
-void CMSFTFPNeutronBuilder::
-Build(G4HadronCaptureProcess * )
-{
-}
+void CMSFTFPNeutronBuilder::Build(G4HadronCaptureProcess*) {}
 
-void CMSFTFPNeutronBuilder::
-Build(G4NeutronInelasticProcess * aP)
-{
+void CMSFTFPNeutronBuilder::Build(G4NeutronInelasticProcess* aP) {
   theModel->SetMinEnergy(theMin);
   theModel->SetMaxEnergy(theMax);
   aP->RegisterMe(theModel);
-  aP->AddDataSet(new G4NeutronInelasticCrossSection);  
+  aP->AddDataSet(new G4NeutronInelasticCrossSection);
 }

--- a/SimG4Core/PhysicsLists/src/CMSFTFPPiKBuilder.cc
+++ b/SimG4Core/PhysicsLists/src/CMSFTFPPiKBuilder.cc
@@ -4,92 +4,78 @@
 #include "G4ProcessManager.hh"
 #include "G4SystemOfUnits.hh"
 
-CMSFTFPPiKBuilder::CMSFTFPPiKBuilder(G4bool quasiElastic) 
- {
-   thePiData = new G4PiNuclearCrossSection;
-   theMin = 4*GeV;
-   theMax = 100*TeV;
-   theModel = new G4TheoFSGenerator("FTFP");
+CMSFTFPPiKBuilder::CMSFTFPPiKBuilder(G4bool quasiElastic) {
+  thePiData = new G4PiNuclearCrossSection;
+  theMin = 4 * GeV;
+  theMax = 100 * TeV;
+  theModel = new G4TheoFSGenerator("FTFP");
 
-   theStringModel = new G4FTFModel;
-   theStringDecay = new G4ExcitedStringDecay(new G4LundStringFragmentation);
-   theStringModel->SetFragmentationModel(theStringDecay);
+  theStringModel = new G4FTFModel;
+  theStringDecay = new G4ExcitedStringDecay(new G4LundStringFragmentation);
+  theStringModel->SetFragmentationModel(theStringDecay);
 
-   theCascade = new G4GeneratorPrecompoundInterface;
-   thePreEquilib = new G4PreCompoundModel(new G4ExcitationHandler);
-   theCascade->SetDeExcitation(thePreEquilib);  
+  theCascade = new G4GeneratorPrecompoundInterface;
+  thePreEquilib = new G4PreCompoundModel(new G4ExcitationHandler);
+  theCascade->SetDeExcitation(thePreEquilib);
 
-   theModel->SetHighEnergyGenerator(theStringModel);
-   if (quasiElastic)
-   {
-      theQuasiElastic=new G4QuasiElasticChannel;
-      theModel->SetQuasiElasticChannel(theQuasiElastic);
-   } else 
-   {  theQuasiElastic=nullptr;}  
+  theModel->SetHighEnergyGenerator(theStringModel);
+  if (quasiElastic) {
+    theQuasiElastic = new G4QuasiElasticChannel;
+    theModel->SetQuasiElasticChannel(theQuasiElastic);
+  } else {
+    theQuasiElastic = nullptr;
+  }
 
-   theModel->SetTransport(theCascade);
-   theModel->SetMinEnergy(theMin);
-   theModel->SetMaxEnergy(100*TeV);
- }
+  theModel->SetTransport(theCascade);
+  theModel->SetMinEnergy(theMin);
+  theModel->SetMaxEnergy(100 * TeV);
+}
 
-CMSFTFPPiKBuilder::~CMSFTFPPiKBuilder() 
- {
-   delete theCascade;
-   delete theStringDecay;
-   delete theStringModel;
-   delete theModel;
-   if ( theQuasiElastic ) delete theQuasiElastic;
- }
+CMSFTFPPiKBuilder::~CMSFTFPPiKBuilder() {
+  delete theCascade;
+  delete theStringDecay;
+  delete theStringModel;
+  delete theModel;
+  if (theQuasiElastic)
+    delete theQuasiElastic;
+}
 
-void CMSFTFPPiKBuilder::
-Build(G4HadronElasticProcess * ) {}
+void CMSFTFPPiKBuilder::Build(G4HadronElasticProcess*) {}
 
-void CMSFTFPPiKBuilder::
-Build(G4PionPlusInelasticProcess * aP)
- {
-   theModel->SetMinEnergy(theMin);
-   theModel->SetMaxEnergy(theMax);
-   aP->AddDataSet(thePiData);
-   aP->RegisterMe(theModel);
- }
+void CMSFTFPPiKBuilder::Build(G4PionPlusInelasticProcess* aP) {
+  theModel->SetMinEnergy(theMin);
+  theModel->SetMaxEnergy(theMax);
+  aP->AddDataSet(thePiData);
+  aP->RegisterMe(theModel);
+}
 
-void CMSFTFPPiKBuilder::
-Build(G4PionMinusInelasticProcess * aP)
- {
-   theModel->SetMinEnergy(theMin);
-   theModel->SetMaxEnergy(theMax);
-   aP->AddDataSet(thePiData);
-   aP->RegisterMe(theModel);
- }
+void CMSFTFPPiKBuilder::Build(G4PionMinusInelasticProcess* aP) {
+  theModel->SetMinEnergy(theMin);
+  theModel->SetMaxEnergy(theMax);
+  aP->AddDataSet(thePiData);
+  aP->RegisterMe(theModel);
+}
 
-void CMSFTFPPiKBuilder::
-Build(G4KaonPlusInelasticProcess * aP)
- {
-   theModel->SetMinEnergy(theMin);
-   theModel->SetMaxEnergy(theMax);
-   aP->RegisterMe(theModel);
- }
+void CMSFTFPPiKBuilder::Build(G4KaonPlusInelasticProcess* aP) {
+  theModel->SetMinEnergy(theMin);
+  theModel->SetMaxEnergy(theMax);
+  aP->RegisterMe(theModel);
+}
 
-void CMSFTFPPiKBuilder::
-Build(G4KaonMinusInelasticProcess * aP)
- {
-   theModel->SetMinEnergy(theMin);
-   theModel->SetMaxEnergy(theMax);
-   aP->RegisterMe(theModel);
- }
+void CMSFTFPPiKBuilder::Build(G4KaonMinusInelasticProcess* aP) {
+  theModel->SetMinEnergy(theMin);
+  theModel->SetMaxEnergy(theMax);
+  aP->RegisterMe(theModel);
+}
 
-void CMSFTFPPiKBuilder::
-Build(G4KaonZeroLInelasticProcess * aP)
- {
-   theModel->SetMinEnergy(theMin);
-   theModel->SetMaxEnergy(theMax);
-   aP->RegisterMe(theModel);
- }
+void CMSFTFPPiKBuilder::Build(G4KaonZeroLInelasticProcess* aP) {
+  theModel->SetMinEnergy(theMin);
+  theModel->SetMaxEnergy(theMax);
+  aP->RegisterMe(theModel);
+}
 
-void CMSFTFPPiKBuilder::
-Build(G4KaonZeroSInelasticProcess * aP)
- {
-   theModel->SetMinEnergy(theMin);
-   theModel->SetMaxEnergy(theMax);
-   aP->RegisterMe(theModel);
- }
+void CMSFTFPPiKBuilder::Build(G4KaonZeroSInelasticProcess* aP) {
+  theModel->SetMinEnergy(theMin);
+  theModel->SetMaxEnergy(theMax);
+  aP->RegisterMe(theModel);
+}

--- a/SimG4Core/PhysicsLists/src/CMSFTFPProtonBuilder.cc
+++ b/SimG4Core/PhysicsLists/src/CMSFTFPProtonBuilder.cc
@@ -5,10 +5,9 @@
 #include "G4ProtonInelasticCrossSection.hh"
 #include "G4SystemOfUnits.hh"
 
-CMSFTFPProtonBuilder::CMSFTFPProtonBuilder(G4bool quasiElastic) 
-{
-  theMin = 4*GeV;
-  theMax = 100.*TeV; 
+CMSFTFPProtonBuilder::CMSFTFPProtonBuilder(G4bool quasiElastic) {
+  theMin = 4 * GeV;
+  theMax = 100. * TeV;
   theModel = new G4TheoFSGenerator("FTFP");
 
   theStringModel = new G4FTFModel;
@@ -17,40 +16,35 @@ CMSFTFPProtonBuilder::CMSFTFPProtonBuilder(G4bool quasiElastic)
 
   theCascade = new G4GeneratorPrecompoundInterface;
   thePreEquilib = new G4PreCompoundModel(new G4ExcitationHandler);
-  theCascade->SetDeExcitation(thePreEquilib);  
+  theCascade->SetDeExcitation(thePreEquilib);
 
   theModel->SetHighEnergyGenerator(theStringModel);
-  if (quasiElastic)
-  {
-     theQuasiElastic=new G4QuasiElasticChannel;
-     theModel->SetQuasiElasticChannel(theQuasiElastic);
-  } else 
-  {  theQuasiElastic=nullptr;}  
+  if (quasiElastic) {
+    theQuasiElastic = new G4QuasiElasticChannel;
+    theModel->SetQuasiElasticChannel(theQuasiElastic);
+  } else {
+    theQuasiElastic = nullptr;
+  }
 
   theModel->SetTransport(theCascade);
   theModel->SetMinEnergy(theMin);
-  theModel->SetMaxEnergy(100*TeV);
+  theModel->SetMaxEnergy(100 * TeV);
 }
 
-void CMSFTFPProtonBuilder::Build(G4ProtonInelasticProcess * aP)
-{
+void CMSFTFPProtonBuilder::Build(G4ProtonInelasticProcess* aP) {
   theModel->SetMinEnergy(theMin);
   theModel->SetMaxEnergy(theMax);
   aP->RegisterMe(theModel);
-  aP->AddDataSet(new G4ProtonInelasticCrossSection);  
+  aP->AddDataSet(new G4ProtonInelasticCrossSection);
 }
 
-CMSFTFPProtonBuilder::
-~CMSFTFPProtonBuilder() 
-{
+CMSFTFPProtonBuilder::~CMSFTFPProtonBuilder() {
   delete theStringDecay;
   delete theStringModel;
   delete theModel;
   delete theCascade;
-  if ( theQuasiElastic ) delete theQuasiElastic;
+  if (theQuasiElastic)
+    delete theQuasiElastic;
 }
 
-void CMSFTFPProtonBuilder::
-Build(G4HadronElasticProcess * )
-{
-}
+void CMSFTFPProtonBuilder::Build(G4HadronElasticProcess*) {}

--- a/SimG4Core/PhysicsLists/src/CMSHadronPhysicsFTFP_BERT.cc
+++ b/SimG4Core/PhysicsLists/src/CMSHadronPhysicsFTFP_BERT.cc
@@ -1,5 +1,5 @@
 //
-#include <iomanip>   
+#include <iomanip>
 
 #include "SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT.h"
 
@@ -47,9 +47,7 @@
 #include "G4Threading.hh"
 
 CMSHadronPhysicsFTFP_BERT::CMSHadronPhysicsFTFP_BERT(G4int)
-  :  G4VPhysicsConstructor("hInelastic CMS FTFP_BERT")
-  , QuasiElastic(false)
-{
+    : G4VPhysicsConstructor("hInelastic CMS FTFP_BERT"), QuasiElastic(false) {
   minFTFP_pion = 4.0 * GeV;
   maxBERT_pion = 5.0 * GeV;
   minFTFP_kaon = 4.0 * GeV;
@@ -60,15 +58,13 @@ CMSHadronPhysicsFTFP_BERT::CMSHadronPhysicsFTFP_BERT(G4int)
   maxBERT_neutron = 5.0 * GeV;
 }
 
-CMSHadronPhysicsFTFP_BERT::~CMSHadronPhysicsFTFP_BERT()
-{
+CMSHadronPhysicsFTFP_BERT::~CMSHadronPhysicsFTFP_BERT() {
   //Detele master-owned stuff
   delete xs_k.Get();
-  std::for_each( xs_ds.Begin(), xs_ds.End(),[](G4VCrossSectionDataSet* el){ delete el;});
+  std::for_each(xs_ds.Begin(), xs_ds.End(), [](G4VCrossSectionDataSet* el) { delete el; });
 }
 
-void CMSHadronPhysicsFTFP_BERT::ConstructParticle()
-{
+void CMSHadronPhysicsFTFP_BERT::ConstructParticle() {
   G4MesonConstructor pMesonConstructor;
   pMesonConstructor.ConstructParticle();
 
@@ -79,27 +75,22 @@ void CMSHadronPhysicsFTFP_BERT::ConstructParticle()
   pShortLivedConstructor.ConstructParticle();
 }
 
-void CMSHadronPhysicsFTFP_BERT::TerminateWorker()
-{
+void CMSHadronPhysicsFTFP_BERT::TerminateWorker() {
   delete xs_k.Get();
-  std::for_each( xs_ds.Begin(), xs_ds.End(),[](G4VCrossSectionDataSet* el){ delete el;});
+  std::for_each(xs_ds.Begin(), xs_ds.End(), [](G4VCrossSectionDataSet* el) { delete el; });
   xs_ds.Clear();
   G4VPhysicsConstructor::TerminateWorker();
 }
 
-void CMSHadronPhysicsFTFP_BERT::DumpBanner()
-{
-  G4cout << G4endl
-       << " FTFP_BERT : new threshold between BERT and FTFP is over the interval " << G4endl
-       << " for pions :   " << minFTFP_pion/GeV << " to " << maxBERT_pion/GeV  << " GeV" << G4endl
-       << " for kaons :   " << minFTFP_kaon/GeV << " to " << maxBERT_kaon/GeV  << " GeV" << G4endl
-       << " for proton :  " << minFTFP_proton/GeV << " to " << maxBERT_proton/GeV  << " GeV" << G4endl
-       << " for neutron : " << minFTFP_neutron/GeV << " to " << maxBERT_neutron/GeV  << " GeV" << G4endl
-       << G4endl;
+void CMSHadronPhysicsFTFP_BERT::DumpBanner() {
+  G4cout << G4endl << " FTFP_BERT : new threshold between BERT and FTFP is over the interval " << G4endl
+         << " for pions :   " << minFTFP_pion / GeV << " to " << maxBERT_pion / GeV << " GeV" << G4endl
+         << " for kaons :   " << minFTFP_kaon / GeV << " to " << maxBERT_kaon / GeV << " GeV" << G4endl
+         << " for proton :  " << minFTFP_proton / GeV << " to " << maxBERT_proton / GeV << " GeV" << G4endl
+         << " for neutron : " << minFTFP_neutron / GeV << " to " << maxBERT_neutron / GeV << " GeV" << G4endl << G4endl;
 }
 
-void CMSHadronPhysicsFTFP_BERT::CreateModels()
-{
+void CMSHadronPhysicsFTFP_BERT::CreateModels() {
   Neutron();
   Proton();
   Pion();
@@ -107,8 +98,7 @@ void CMSHadronPhysicsFTFP_BERT::CreateModels()
   Others();
 }
 
-void CMSHadronPhysicsFTFP_BERT::Neutron()
-{
+void CMSHadronPhysicsFTFP_BERT::Neutron() {
   //General schema:
   // 1) Create a builder
   // 2) Call AddBuilder
@@ -117,19 +107,18 @@ void CMSHadronPhysicsFTFP_BERT::Neutron()
   auto neu = new G4NeutronBuilder;
   AddBuilder(neu);
   auto ftfpn = new G4FTFPNeutronBuilder(QuasiElastic);
-  AddBuilder( ftfpn );
+  AddBuilder(ftfpn);
   neu->RegisterMe(ftfpn);
   ftfpn->SetMinEnergy(minFTFP_neutron);
   auto bertn = new G4BertiniNeutronBuilder;
   AddBuilder(bertn);
   neu->RegisterMe(bertn);
-  bertn->SetMinEnergy(0.*GeV);
+  bertn->SetMinEnergy(0. * GeV);
   bertn->SetMaxEnergy(maxBERT_neutron);
   neu->Build();
 }
 
-void CMSHadronPhysicsFTFP_BERT::Proton()
-{
+void CMSHadronPhysicsFTFP_BERT::Proton() {
   auto pro = new G4ProtonBuilder;
   AddBuilder(pro);
   auto ftfpp = new G4FTFPProtonBuilder(QuasiElastic);
@@ -143,8 +132,7 @@ void CMSHadronPhysicsFTFP_BERT::Proton()
   pro->Build();
 }
 
-void CMSHadronPhysicsFTFP_BERT::Pion()
-{
+void CMSHadronPhysicsFTFP_BERT::Pion() {
   auto pi = new G4PionBuilder;
   AddBuilder(pi);
   auto ftfppi = new G4FTFPPionBuilder(QuasiElastic);
@@ -158,26 +146,24 @@ void CMSHadronPhysicsFTFP_BERT::Pion()
   pi->Build();
 }
 
-void CMSHadronPhysicsFTFP_BERT::Kaon()
-{
+void CMSHadronPhysicsFTFP_BERT::Kaon() {
   auto k = new G4KaonBuilder;
   AddBuilder(k);
   auto ftfpk = new G4FTFPKaonBuilder(QuasiElastic);
   AddBuilder(ftfpk);
   k->RegisterMe(ftfpk);
   ftfpk->SetMinEnergy(minFTFP_kaon);
-  auto bertk  = new G4BertiniKaonBuilder;
+  auto bertk = new G4BertiniKaonBuilder;
   AddBuilder(bertk);
   k->RegisterMe(bertk);
   bertk->SetMaxEnergy(maxBERT_kaon);
   k->Build();
 }
 
-void CMSHadronPhysicsFTFP_BERT::Others()
-{
+void CMSHadronPhysicsFTFP_BERT::Others() {
   //===== Hyperons ====== //
   auto hyp = new G4HyperonFTFPBuilder;
-  AddBuilder( hyp );
+  AddBuilder(hyp);
   hyp->Build();
 
   ///===== Anti-barions==== //
@@ -189,21 +175,19 @@ void CMSHadronPhysicsFTFP_BERT::Others()
   abar->Build();
 }
 
-void CMSHadronPhysicsFTFP_BERT::ConstructProcess()
-{
-  if(G4Threading::IsMasterThread()) {
-      DumpBanner();
+void CMSHadronPhysicsFTFP_BERT::ConstructProcess() {
+  if (G4Threading::IsMasterThread()) {
+    DumpBanner();
   }
   CreateModels();
   ExtraConfiguration();
 }
 
-void CMSHadronPhysicsFTFP_BERT::ExtraConfiguration()
-{
+void CMSHadronPhysicsFTFP_BERT::ExtraConfiguration() {
   //Modify XS for kaons
   auto xsk = new G4ComponentGGHadronNucleusXsc();
   xs_k.Put(xsk);
-  G4VCrossSectionDataSet * kaonxs = new G4CrossSectionInelastic(xsk);
+  G4VCrossSectionDataSet* kaonxs = new G4CrossSectionInelastic(xsk);
   xs_ds.Push_back(kaonxs);
   G4PhysListUtil::FindInelasticProcess(G4KaonMinus::KaonMinus())->AddDataSet(kaonxs);
   G4PhysListUtil::FindInelasticProcess(G4KaonPlus::KaonPlus())->AddDataSet(kaonxs);
@@ -211,23 +195,25 @@ void CMSHadronPhysicsFTFP_BERT::ExtraConfiguration()
   G4PhysListUtil::FindInelasticProcess(G4KaonZeroLong::KaonZeroLong())->AddDataSet(kaonxs);
 
   //Modify Neutrons
-  auto xs_n_in = (G4NeutronInelasticXS*)G4CrossSectionDataSetRegistry::Instance()->GetCrossSectionDataSet(G4NeutronInelasticXS::Default_Name());
-  xs_ds.Push_back(xs_n_in);//TODO: Is this needed? Who owns the pointer?
-  G4PhysListUtil::FindInelasticProcess(G4Neutron::Neutron())->AddDataSet( xs_n_in );
+  auto xs_n_in = (G4NeutronInelasticXS*)G4CrossSectionDataSetRegistry::Instance()->GetCrossSectionDataSet(
+      G4NeutronInelasticXS::Default_Name());
+  xs_ds.Push_back(xs_n_in);  //TODO: Is this needed? Who owns the pointer?
+  G4PhysListUtil::FindInelasticProcess(G4Neutron::Neutron())->AddDataSet(xs_n_in);
   G4HadronicProcess* capture = nullptr;
   G4ProcessManager* pmanager = G4Neutron::Neutron()->GetProcessManager();
-  G4ProcessVector*  pv = pmanager->GetProcessList();
-  for ( size_t i=0; i < static_cast<size_t>(pv->size()); ++i ) {
-    if ( fCapture == ((*pv)[i])->GetProcessSubType() ) {
+  G4ProcessVector* pv = pmanager->GetProcessList();
+  for (size_t i = 0; i < static_cast<size_t>(pv->size()); ++i) {
+    if (fCapture == ((*pv)[i])->GetProcessSubType()) {
       capture = static_cast<G4HadronicProcess*>((*pv)[i]);
     }
   }
-  if ( ! capture ) {
+  if (!capture) {
     capture = new G4HadronCaptureProcess("nCapture");
     pmanager->AddDiscreteProcess(capture);
   }
-  auto xs_n_c = (G4NeutronCaptureXS*)G4CrossSectionDataSetRegistry::Instance()->GetCrossSectionDataSet(G4NeutronCaptureXS::Default_Name());
+  auto xs_n_c = (G4NeutronCaptureXS*)G4CrossSectionDataSetRegistry::Instance()->GetCrossSectionDataSet(
+      G4NeutronCaptureXS::Default_Name());
   xs_ds.Push_back(xs_n_c);
-  capture->AddDataSet( xs_n_c );
-  capture->RegisterMe( new G4NeutronRadCapture() );
+  capture->AddDataSet(xs_n_c);
+  capture->RegisterMe(new G4NeutronRadCapture());
 }

--- a/SimG4Core/PhysicsLists/src/CMSHadronPhysicsFTFP_BERT_ATL.cc
+++ b/SimG4Core/PhysicsLists/src/CMSHadronPhysicsFTFP_BERT_ATL.cc
@@ -9,7 +9,7 @@
 // energy region [9, 12] GeV (instead of [4, 5] GeV as in FTFP_BERT).
 //---------------------------------------------------------------------------
 //
-#include <iomanip>   
+#include <iomanip>
 
 #include "SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT_ATL.h"
 
@@ -34,50 +34,46 @@
 
 #include "G4PhysListUtil.hh"
 
-G4ThreadLocal CMSHadronPhysicsFTFP_BERT_ATL::ThreadPrivate* CMSHadronPhysicsFTFP_BERT_ATL::tpdata=nullptr;
+G4ThreadLocal CMSHadronPhysicsFTFP_BERT_ATL::ThreadPrivate* CMSHadronPhysicsFTFP_BERT_ATL::tpdata = nullptr;
 
 CMSHadronPhysicsFTFP_BERT_ATL::CMSHadronPhysicsFTFP_BERT_ATL(G4int)
-    :  G4VPhysicsConstructor("hInelastic FTFP_BERT_ATL")
-    , QuasiElastic(false)
-{}
+    : G4VPhysicsConstructor("hInelastic FTFP_BERT_ATL"), QuasiElastic(false) {}
 
-void CMSHadronPhysicsFTFP_BERT_ATL::CreateModels()
-{
-  G4double minFTFP =  9.0 * GeV;
+void CMSHadronPhysicsFTFP_BERT_ATL::CreateModels() {
+  G4double minFTFP = 9.0 * GeV;
   G4double maxBERT = 12.0 * GeV;
-  G4cout << " CMS_FTFP_BERT_ATL : new threshold between BERT and FTFP" 
-         << " is over the interval " << minFTFP/GeV << " to " << maxBERT/GeV 
-         << " GeV." << G4endl;
-  QuasiElastic= false; 
+  G4cout << " CMS_FTFP_BERT_ATL : new threshold between BERT and FTFP"
+         << " is over the interval " << minFTFP / GeV << " to " << maxBERT / GeV << " GeV." << G4endl;
+  QuasiElastic = false;
 
-  tpdata->theNeutrons=new G4NeutronBuilder;
-  tpdata->theNeutrons->RegisterMe(tpdata->theFTFPNeutron=new G4FTFPNeutronBuilder(QuasiElastic));
+  tpdata->theNeutrons = new G4NeutronBuilder;
+  tpdata->theNeutrons->RegisterMe(tpdata->theFTFPNeutron = new G4FTFPNeutronBuilder(QuasiElastic));
   tpdata->theFTFPNeutron->SetMinEnergy(minFTFP);
-  tpdata->theNeutrons->RegisterMe(tpdata->theBertiniNeutron=new G4BertiniNeutronBuilder);
-  tpdata->theBertiniNeutron->SetMinEnergy(0.0*GeV);
+  tpdata->theNeutrons->RegisterMe(tpdata->theBertiniNeutron = new G4BertiniNeutronBuilder);
+  tpdata->theBertiniNeutron->SetMinEnergy(0.0 * GeV);
   tpdata->theBertiniNeutron->SetMaxEnergy(maxBERT);
 
-  tpdata->thePro=new G4ProtonBuilder;
-  tpdata->thePro->RegisterMe(tpdata->theFTFPPro=new G4FTFPProtonBuilder(QuasiElastic));
+  tpdata->thePro = new G4ProtonBuilder;
+  tpdata->thePro->RegisterMe(tpdata->theFTFPPro = new G4FTFPProtonBuilder(QuasiElastic));
   tpdata->theFTFPPro->SetMinEnergy(minFTFP);
-  tpdata->thePro->RegisterMe(tpdata->theBertiniPro=new G4BertiniProtonBuilder);
+  tpdata->thePro->RegisterMe(tpdata->theBertiniPro = new G4BertiniProtonBuilder);
   tpdata->theBertiniPro->SetMaxEnergy(maxBERT);
 
-  tpdata->thePiK=new G4PiKBuilder;
-  tpdata->thePiK->RegisterMe(tpdata->theFTFPPiK=new G4FTFPPiKBuilder(QuasiElastic));
+  tpdata->thePiK = new G4PiKBuilder;
+  tpdata->thePiK->RegisterMe(tpdata->theFTFPPiK = new G4FTFPPiKBuilder(QuasiElastic));
   tpdata->theFTFPPiK->SetMinEnergy(minFTFP);
-  tpdata->thePiK->RegisterMe(tpdata->theBertiniPiK=new G4BertiniPiKBuilder);
+  tpdata->thePiK->RegisterMe(tpdata->theBertiniPiK = new G4BertiniPiKBuilder);
   tpdata->theBertiniPiK->SetMaxEnergy(maxBERT);
-  
-  tpdata->theHyperon=new G4HyperonFTFPBuilder;
-    
-  tpdata->theAntiBaryon=new G4AntiBarionBuilder;
-  tpdata->theAntiBaryon->RegisterMe(tpdata->theFTFPAntiBaryon=new G4FTFPAntiBarionBuilder(QuasiElastic));
+
+  tpdata->theHyperon = new G4HyperonFTFPBuilder;
+
+  tpdata->theAntiBaryon = new G4AntiBarionBuilder;
+  tpdata->theAntiBaryon->RegisterMe(tpdata->theFTFPAntiBaryon = new G4FTFPAntiBarionBuilder(QuasiElastic));
 }
 
-CMSHadronPhysicsFTFP_BERT_ATL::~CMSHadronPhysicsFTFP_BERT_ATL()
-{
-  if (!tpdata) return;
+CMSHadronPhysicsFTFP_BERT_ATL::~CMSHadronPhysicsFTFP_BERT_ATL() {
+  if (!tpdata)
+    return;
 
   delete tpdata->theNeutrons;
   delete tpdata->theBertiniNeutron;
@@ -86,23 +82,23 @@ CMSHadronPhysicsFTFP_BERT_ATL::~CMSHadronPhysicsFTFP_BERT_ATL()
   delete tpdata->thePiK;
   delete tpdata->theBertiniPiK;
   delete tpdata->theFTFPPiK;
-    
+
   delete tpdata->thePro;
   delete tpdata->theBertiniPro;
-  delete tpdata->theFTFPPro;    
-    
+  delete tpdata->theFTFPPro;
+
   delete tpdata->theHyperon;
   delete tpdata->theAntiBaryon;
   delete tpdata->theFTFPAntiBaryon;
- 
+
   //Note that here we need to set to 0 the pointer
   //since tpdata is static and if thread are "reused"
   //it can be problematic
-  delete tpdata; tpdata = nullptr;
+  delete tpdata;
+  tpdata = nullptr;
 }
 
-void CMSHadronPhysicsFTFP_BERT_ATL::ConstructParticle()
-{
+void CMSHadronPhysicsFTFP_BERT_ATL::ConstructParticle() {
   G4MesonConstructor pMesonConstructor;
   pMesonConstructor.ConstructParticle();
 
@@ -110,13 +106,13 @@ void CMSHadronPhysicsFTFP_BERT_ATL::ConstructParticle()
   pBaryonConstructor.ConstructParticle();
 
   G4ShortLivedConstructor pShortLivedConstructor;
-  pShortLivedConstructor.ConstructParticle();  
+  pShortLivedConstructor.ConstructParticle();
 }
 
 #include "G4ProcessManager.hh"
-void CMSHadronPhysicsFTFP_BERT_ATL::ConstructProcess()
-{
-  if ( tpdata == nullptr ) tpdata = new ThreadPrivate;
+void CMSHadronPhysicsFTFP_BERT_ATL::ConstructProcess() {
+  if (tpdata == nullptr)
+    tpdata = new ThreadPrivate;
   CreateModels();
   tpdata->theNeutrons->Build();
   tpdata->thePro->Build();
@@ -124,12 +120,12 @@ void CMSHadronPhysicsFTFP_BERT_ATL::ConstructProcess()
 
   // --- Kaons ---
   tpdata->xsKaon = new G4ComponentGGHadronNucleusXsc();
-  G4VCrossSectionDataSet * kaonxs = new G4CrossSectionInelastic(tpdata->xsKaon);
+  G4VCrossSectionDataSet* kaonxs = new G4CrossSectionInelastic(tpdata->xsKaon);
   G4PhysListUtil::FindInelasticProcess(G4KaonMinus::KaonMinus())->AddDataSet(kaonxs);
   G4PhysListUtil::FindInelasticProcess(G4KaonPlus::KaonPlus())->AddDataSet(kaonxs);
   G4PhysListUtil::FindInelasticProcess(G4KaonZeroShort::KaonZeroShort())->AddDataSet(kaonxs);
   G4PhysListUtil::FindInelasticProcess(G4KaonZeroLong::KaonZeroLong())->AddDataSet(kaonxs);
-    
+
   tpdata->theHyperon->Build();
   tpdata->theAntiBaryon->Build();
 
@@ -138,13 +134,13 @@ void CMSHadronPhysicsFTFP_BERT_ATL::ConstructProcess()
 
   G4HadronicProcess* capture = nullptr;
   G4ProcessManager* pmanager = G4Neutron::Neutron()->GetProcessManager();
-  G4ProcessVector*  pv = pmanager->GetProcessList();
-  for ( size_t i=0; i < static_cast<size_t>(pv->size()); ++i ) {
-    if ( fCapture == ((*pv)[i])->GetProcessSubType() ) {
+  G4ProcessVector* pv = pmanager->GetProcessList();
+  for (size_t i = 0; i < static_cast<size_t>(pv->size()); ++i) {
+    if (fCapture == ((*pv)[i])->GetProcessSubType()) {
       capture = static_cast<G4HadronicProcess*>((*pv)[i]);
     }
   }
-  if ( ! capture ) {
+  if (!capture) {
     capture = new G4HadronCaptureProcess("nCapture");
     pmanager->AddDiscreteProcess(capture);
   }

--- a/SimG4Core/PhysicsLists/src/CMSMonopolePhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSMonopolePhysics.cc
@@ -14,69 +14,58 @@
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-CMSMonopolePhysics::CMSMonopolePhysics(const HepPDT::ParticleDataTable * pdt,
-				       const edm::ParameterSet & p) :
-  G4VPhysicsConstructor("Monopole Physics")
-{  
-  verbose   = p.getUntrackedParameter<int>("Verbosity",0);
-  magCharge = p.getUntrackedParameter<int>("MonopoleCharge",1);
-  deltaRay  = p.getUntrackedParameter<bool>("MonopoleDeltaRay",true);
-  multiSc   = p.getUntrackedParameter<bool>("MonopoleMultiScatter",false);
-  transport = p.getUntrackedParameter<bool>("MonopoleTransport",true);
-  double mass = p.getUntrackedParameter<double>("MonopoleMass",200);
+CMSMonopolePhysics::CMSMonopolePhysics(const HepPDT::ParticleDataTable* pdt, const edm::ParameterSet& p)
+    : G4VPhysicsConstructor("Monopole Physics") {
+  verbose = p.getUntrackedParameter<int>("Verbosity", 0);
+  magCharge = p.getUntrackedParameter<int>("MonopoleCharge", 1);
+  deltaRay = p.getUntrackedParameter<bool>("MonopoleDeltaRay", true);
+  multiSc = p.getUntrackedParameter<bool>("MonopoleMultiScatter", false);
+  transport = p.getUntrackedParameter<bool>("MonopoleTransport", true);
+  double mass = p.getUntrackedParameter<double>("MonopoleMass", 200);
   if (pdt && mass > 0.0) {
-    int ii=0;
-    for (HepPDT::ParticleDataTable::const_iterator p=pdt->begin(); 
-	 p != pdt->end(); ++p,++ii) {
+    int ii = 0;
+    for (HepPDT::ParticleDataTable::const_iterator p = pdt->begin(); p != pdt->end(); ++p, ++ii) {
       HepPDT::ParticleData particle = (p->second);
-      std::string particleName = (particle.name()).substr(0,8);
-      if (strcmp(particleName.c_str(),"Monopole") == 0) {
-	names.push_back(particle.name());
-	masses.push_back(mass*CLHEP::GeV);
-	elCharges.push_back((int)(particle.charge()));
-	pdgEncodings.push_back(particle.pid());
-	monopoles.push_back(nullptr);
-	if (verbose > 0) G4cout << "CMSMonopolePhysics: Monopole[" << ii
-				<< "] " << particleName << " Mass "
-				<< particle.mass() << " GeV, Magnetic Charge "
-				<< magCharge << ", Electric Charge "
-				<< particle.charge() << G4endl;
-      } else if(strcmp(particleName.c_str(),"AntiMono") == 0) {
-	names.push_back(particle.name());
-	masses.push_back(mass*CLHEP::GeV);
-	elCharges.push_back((int)(particle.charge()));
-	pdgEncodings.push_back(particle.pid());
-	monopoles.push_back(nullptr);
-	if (verbose > 0) G4cout << "CMSMonopolePhysics: Monopole[" << ii
-				<< "] " << particleName << " Mass "
-				<< particle.mass() << " GeV, Magnetic Charge "
-				<< magCharge << ", Electric Charge "
-				<< particle.charge() << G4endl; 
+      std::string particleName = (particle.name()).substr(0, 8);
+      if (strcmp(particleName.c_str(), "Monopole") == 0) {
+        names.push_back(particle.name());
+        masses.push_back(mass * CLHEP::GeV);
+        elCharges.push_back((int)(particle.charge()));
+        pdgEncodings.push_back(particle.pid());
+        monopoles.push_back(nullptr);
+        if (verbose > 0)
+          G4cout << "CMSMonopolePhysics: Monopole[" << ii << "] " << particleName << " Mass " << particle.mass()
+                 << " GeV, Magnetic Charge " << magCharge << ", Electric Charge " << particle.charge() << G4endl;
+      } else if (strcmp(particleName.c_str(), "AntiMono") == 0) {
+        names.push_back(particle.name());
+        masses.push_back(mass * CLHEP::GeV);
+        elCharges.push_back((int)(particle.charge()));
+        pdgEncodings.push_back(particle.pid());
+        monopoles.push_back(nullptr);
+        if (verbose > 0)
+          G4cout << "CMSMonopolePhysics: Monopole[" << ii << "] " << particleName << " Mass " << particle.mass()
+                 << " GeV, Magnetic Charge " << magCharge << ", Electric Charge " << particle.charge() << G4endl;
       }
     }
   }
-  if (verbose > 0) G4cout << "CMSMonopolePhysics has " << names.size()
-			  << " monopole candidates and delta Ray option " 
-			  << deltaRay << G4endl;
+  if (verbose > 0)
+    G4cout << "CMSMonopolePhysics has " << names.size() << " monopole candidates and delta Ray option " << deltaRay
+           << G4endl;
 }
 
 CMSMonopolePhysics::~CMSMonopolePhysics() {}
 
 void CMSMonopolePhysics::ConstructParticle() {
-  
-  for (unsigned int ii=0; ii<names.size(); ++ii) {
+  for (unsigned int ii = 0; ii < names.size(); ++ii) {
     // monopoles are created once in the master thread
     if (!monopoles[ii]) {
-      G4int mc = (pdgEncodings[ii] >= 0 ) ? magCharge : -magCharge;
-      Monopole* mpl = new Monopole(names[ii], pdgEncodings[ii], masses[ii],
-                                   mc, elCharges[ii]);
+      G4int mc = (pdgEncodings[ii] >= 0) ? magCharge : -magCharge;
+      Monopole* mpl = new Monopole(names[ii], pdgEncodings[ii], masses[ii], mc, elCharges[ii]);
       monopoles[ii] = mpl;
-      if (verbose > 0) G4cout << "Create Monopole " << names[ii] 
-			      << " of mass " << masses[ii]/CLHEP::GeV
-			      << " GeV, magnetic charge " << mc 
-			      << ", electric charge " << elCharges[ii]
-			      << " and PDG encoding " << pdgEncodings[ii]
-			      << " at " << monopoles[ii] << G4endl;
+      if (verbose > 0)
+        G4cout << "Create Monopole " << names[ii] << " of mass " << masses[ii] / CLHEP::GeV << " GeV, magnetic charge "
+               << mc << ", electric charge " << elCharges[ii] << " and PDG encoding " << pdgEncodings[ii] << " at "
+               << monopoles[ii] << G4endl;
     }
   }
 }
@@ -88,52 +77,51 @@ void CMSMonopolePhysics::ConstructProcess() {
   }
   G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  for (unsigned int ii=0; ii<monopoles.size(); ++ii) {
+  for (unsigned int ii = 0; ii < monopoles.size(); ++ii) {
     if (monopoles[ii]) {
       Monopole* mpl = monopoles[ii];
-      G4ProcessManager *pmanager = mpl->GetProcessManager();
-      if(!pmanager) {
+      G4ProcessManager* pmanager = mpl->GetProcessManager();
+      if (!pmanager) {
         std::ostringstream o;
         o << "Monopole without a Process Manager";
-        throw edm::Exception( edm::errors::Configuration, o.str().c_str());
+        throw edm::Exception(edm::errors::Configuration, o.str().c_str());
         return;
       }
 
       G4double magn = mpl->MagneticCharge();
       G4double mass = mpl->GetPDGMass();
       if (verbose > 1) {
-	G4cout << "### CMSMonopolePhysics instantiates for " 
-	       << mpl->GetParticleName()
-	       << " at " << mpl << " Mass " << mass/CLHEP::GeV 
-	       << " GeV Mag " << magn  << " Process manager " << pmanager 
-	       << G4endl;
+        G4cout << "### CMSMonopolePhysics instantiates for " << mpl->GetParticleName() << " at " << mpl << " Mass "
+               << mass / CLHEP::GeV << " GeV Mag " << magn << " Process manager " << pmanager << G4endl;
       }
-  
+
       if (magn != 0.0) {
         G4int idxt(0);
         pmanager->RemoveProcess(idxt);
-        pmanager->AddProcess(new MonopoleTransportation(mpl,verbose),-1,0,0);
+        pmanager->AddProcess(new MonopoleTransportation(mpl, verbose), -1, 0, 0);
       }
 
       if (mpl->GetPDGCharge() != 0.0) {
-	if (multiSc) {
-	  G4hMultipleScattering* hmsc = new G4hMultipleScattering();
-	  ph->RegisterProcess(hmsc, mpl);
-	}
-	G4hIonisation* hioni = new G4hIonisation();
-	ph->RegisterProcess(hioni, mpl);
+        if (multiSc) {
+          G4hMultipleScattering* hmsc = new G4hMultipleScattering();
+          ph->RegisterProcess(hmsc, mpl);
+        }
+        G4hIonisation* hioni = new G4hIonisation();
+        ph->RegisterProcess(hioni, mpl);
       }
-      if(magn != 0.0) {
-	CMSmplIonisation* mplioni = new CMSmplIonisation(magn);
-        if(!deltaRay) {
-          G4mplIonisationModel* ion = new G4mplIonisationModel(magn,"PAI");
+      if (magn != 0.0) {
+        CMSmplIonisation* mplioni = new CMSmplIonisation(magn);
+        if (!deltaRay) {
+          G4mplIonisationModel* ion = new G4mplIonisationModel(magn, "PAI");
           ion->SetParticle(mpl);
-          mplioni->AddEmModel(0,ion,ion);
-	}
-	ph->RegisterProcess(mplioni, mpl);
+          mplioni->AddEmModel(0, ion, ion);
+        }
+        ph->RegisterProcess(mplioni, mpl);
       }
       pmanager->AddDiscreteProcess(new G4StepLimiter());
-      if (verbose > 1) { pmanager->DumpInfo(); }
+      if (verbose > 1) {
+        pmanager->DumpInfo();
+      }
     }
   }
 }

--- a/SimG4Core/PhysicsLists/src/CMSThermalNeutrons.cc
+++ b/SimG4Core/PhysicsLists/src/CMSThermalNeutrons.cc
@@ -11,35 +11,28 @@
 
 #include "G4SystemOfUnits.hh"
 
-CMSThermalNeutrons::CMSThermalNeutrons(G4int ver) :
-  G4VHadronPhysics("CMSThermalNeutrons"), verbose(ver) {
-}
+CMSThermalNeutrons::CMSThermalNeutrons(G4int ver) : G4VHadronPhysics("CMSThermalNeutrons"), verbose(ver) {}
 
 CMSThermalNeutrons::~CMSThermalNeutrons() {}
 
 void CMSThermalNeutrons::ConstructProcess() {
- 
-  if(verbose > 0) {
+  if (verbose > 0) {
     G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
   }
   G4Neutron* part = G4Neutron::Neutron();
   G4HadronicProcess* hpel = FindElasticProcess(part);
-  if(!hpel) {
-    G4cout << "### " << GetPhysicsName() 
-	   << " WARNING: Fail to add thermal neutron scattering" << G4endl;
+  if (!hpel) {
+    G4cout << "### " << GetPhysicsName() << " WARNING: Fail to add thermal neutron scattering" << G4endl;
     return;
   }
 
   G4int ni = (hpel->GetHadronicInteractionList()).size();
-  if(ni < 1) {
-    G4cout << "### " << GetPhysicsName() 
-	   << " WARNING: Fail to add thermal neutron scattering - Nint= " 
-	   << ni << G4endl;
+  if (ni < 1) {
+    G4cout << "### " << GetPhysicsName() << " WARNING: Fail to add thermal neutron scattering - Nint= " << ni << G4endl;
     return;
   }
-  (hpel->GetHadronicInteractionList())[ni-1]->SetMinEnergy(4*CLHEP::eV);
+  (hpel->GetHadronicInteractionList())[ni - 1]->SetMinEnergy(4 * CLHEP::eV);
 
   hpel->RegisterMe(new G4ParticleHPThermalScattering());
   hpel->AddDataSet(new G4ParticleHPThermalScatteringData());
-  
 }

--- a/SimG4Core/PhysicsLists/src/CMSmplIonisation.cc
+++ b/SimG4Core/PhysicsLists/src/CMSmplIonisation.cc
@@ -28,63 +28,54 @@
 using namespace std;
 
 CMSmplIonisation::CMSmplIonisation(G4double mCharge, const G4String& name)
-  : G4VEnergyLossProcess(name),
-    magneticCharge(mCharge),
-    isInitialised(false)
-{
+    : G4VEnergyLossProcess(name), magneticCharge(mCharge), isInitialised(false) {
   // By default classical magnetic charge is used
-  if(magneticCharge == 0.0) { magneticCharge = eplus*0.5/fine_structure_const; }
+  if (magneticCharge == 0.0) {
+    magneticCharge = eplus * 0.5 / fine_structure_const;
+  }
 
   SetVerboseLevel(0);
   SetProcessSubType(fIonisation);
-  SetStepFunction(0.2, 1*mm);
+  SetStepFunction(0.2, 1 * mm);
   SetSecondaryParticle(G4Electron::Electron());
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-CMSmplIonisation::~CMSmplIonisation()
-{}
+CMSmplIonisation::~CMSmplIonisation() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-G4bool CMSmplIonisation::IsApplicable(const G4ParticleDefinition&)
-{
-  return true;
+G4bool CMSmplIonisation::IsApplicable(const G4ParticleDefinition&) { return true; }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4double CMSmplIonisation::MinPrimaryEnergy(const G4ParticleDefinition* mpl, const G4Material*, G4double cut) {
+  G4double x = 0.5 * cut / electron_mass_c2;
+  G4double mass = mpl->GetPDGMass();
+  G4double ratio = electron_mass_c2 / mass;
+  G4double gam = x * ratio + std::sqrt((1. + x) * (1. + x * ratio * ratio));
+  return mass * (gam - 1.0);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-G4double CMSmplIonisation::MinPrimaryEnergy(const G4ParticleDefinition* mpl,
-                                           const G4Material*,
-                                           G4double cut)
-{
-  G4double x = 0.5*cut/electron_mass_c2;
-  G4double mass  = mpl->GetPDGMass();
-  G4double ratio = electron_mass_c2/mass;
-  G4double gam   = x*ratio + std::sqrt((1. + x)*(1. + x*ratio*ratio));
-  return mass*(gam - 1.0);
-}
-
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
-
-void CMSmplIonisation::InitialiseEnergyLossProcess(const G4ParticleDefinition* p,
-                                                   const G4ParticleDefinition*)
-{
-  if(isInitialised) { return; }
+void CMSmplIonisation::InitialiseEnergyLossProcess(const G4ParticleDefinition* p, const G4ParticleDefinition*) {
+  if (isInitialised) {
+    return;
+  }
 
   SetBaseParticle(nullptr);
 
   // monopole model is responsible both for energy loss and fluctuations
-  CMSmplIonisationWithDeltaModel* ion =
-    new CMSmplIonisationWithDeltaModel(magneticCharge,"PAI");
+  CMSmplIonisationWithDeltaModel* ion = new CMSmplIonisationWithDeltaModel(magneticCharge, "PAI");
   ion->SetParticle(p);
 
   // define size of dedx and range tables
   G4EmParameters* param = G4EmParameters::Instance();
-  G4double emin  = std::min(param->MinKinEnergy(),ion->LowEnergyLimit());
-  G4double emax  = std::max(param->MaxKinEnergy(),ion->HighEnergyLimit());
-  G4int bin = G4lrint(param->NumberOfBinsPerDecade()*std::log10(emax/emin));
+  G4double emin = std::min(param->MinKinEnergy(), ion->LowEnergyLimit());
+  G4double emax = std::max(param->MaxKinEnergy(), ion->HighEnergyLimit());
+  G4int bin = G4lrint(param->NumberOfBinsPerDecade() * std::log10(emax / emin));
   ion->SetLowEnergyLimit(emin);
   ion->SetHighEnergyLimit(emax);
   SetMinKinEnergy(emin);
@@ -92,23 +83,20 @@ void CMSmplIonisation::InitialiseEnergyLossProcess(const G4ParticleDefinition* p
   SetDEDXBinning(bin);
 
   SetEmModel(ion);
-  AddEmModel(1,ion,ion);
+  AddEmModel(1, ion, ion);
 
   isInitialised = true;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-void CMSmplIonisation::PrintInfo()
-{}
+void CMSmplIonisation::PrintInfo() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-void CMSmplIonisation::ProcessDescription(std::ostream& out) const
-{
+void CMSmplIonisation::ProcessDescription(std::ostream& out) const {
   out << "No description available." << G4endl;
   G4VEnergyLossProcess::ProcessDescription(out);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
-

--- a/SimG4Core/PhysicsLists/src/CMSmplIonisationWithDeltaModel.cc
+++ b/SimG4Core/PhysicsLists/src/CMSmplIonisationWithDeltaModel.cc
@@ -4,18 +4,17 @@
 //
 // File name:     CMSmplIonisationWithDeltaModel
 //
-// Author:        Vladimir Ivanchenko 
+// Author:        Vladimir Ivanchenko
 //
 // Creation date: 02.03.2019 copied from Geant4 10.5p01
 //
 //
 // -------------------------------------------------------------------
 // References
-// [1] Steven P. Ahlen: Energy loss of relativistic heavy ionizing particles, 
+// [1] Steven P. Ahlen: Energy loss of relativistic heavy ionizing particles,
 //     S.P. Ahlen, Rev. Mod. Phys 52(1980), p121
 // [2] K.A. Milton arXiv:hep-ex/0602040
 // [3] S.P. Ahlen and K. Kinoshita, Phys. Rev. D26 (1982) 2347
-
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
@@ -38,126 +37,122 @@ using namespace std;
 
 std::vector<G4double>* CMSmplIonisationWithDeltaModel::dedx0 = nullptr;
 
-CMSmplIonisationWithDeltaModel::CMSmplIonisationWithDeltaModel(G4double mCharge,
-                                                               const G4String& nam)
-  : G4VEmModel(nam),G4VEmFluctuationModel(nam),
-  magCharge(mCharge),
-  twoln10(std::log(100.0)),
-  betalow(0.01),
-  betalim(0.1),
-  beta2lim(betalim*betalim),
-  bg2lim(beta2lim*(1.0 + beta2lim))
-{
+CMSmplIonisationWithDeltaModel::CMSmplIonisationWithDeltaModel(G4double mCharge, const G4String& nam)
+    : G4VEmModel(nam),
+      G4VEmFluctuationModel(nam),
+      magCharge(mCharge),
+      twoln10(std::log(100.0)),
+      betalow(0.01),
+      betalim(0.1),
+      beta2lim(betalim * betalim),
+      bg2lim(beta2lim * (1.0 + beta2lim)) {
   nmpl = G4lrint(std::abs(magCharge) * 2 * fine_structure_const);
-  if(nmpl > 6)      { nmpl = 6; }
-  else if(nmpl < 1) { nmpl = 1; }
+  if (nmpl > 6) {
+    nmpl = 6;
+  } else if (nmpl < 1) {
+    nmpl = 1;
+  }
   pi_hbarc2_over_mc2 = pi * hbarc * hbarc / electron_mass_c2;
   chargeSquare = magCharge * magCharge;
-  dedxlim = 45.*nmpl*nmpl*GeV*cm2/g;
+  dedxlim = 45. * nmpl * nmpl * GeV * cm2 / g;
   fParticleChange = nullptr;
   theElectron = G4Electron::Electron();
-  G4cout << "### Monopole ionisation model with d-electron production, Gmag= " 
-         << magCharge/eplus << G4endl;
+  G4cout << "### Monopole ionisation model with d-electron production, Gmag= " << magCharge / eplus << G4endl;
   monopole = nullptr;
   mass = 0.0;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-CMSmplIonisationWithDeltaModel::~CMSmplIonisationWithDeltaModel()
-{
-  if(IsMaster()) { delete dedx0; }
+CMSmplIonisationWithDeltaModel::~CMSmplIonisationWithDeltaModel() {
+  if (IsMaster()) {
+    delete dedx0;
+  }
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-void CMSmplIonisationWithDeltaModel::SetParticle(const G4ParticleDefinition* p)
-{
+void CMSmplIonisationWithDeltaModel::SetParticle(const G4ParticleDefinition* p) {
   monopole = p;
-  mass     = monopole->GetPDGMass();
-  G4double emin = 
-    std::min(LowEnergyLimit(),0.1*mass*(1./sqrt(1. - betalow*betalow) - 1.)); 
-  G4double emax = 
-    std::max(HighEnergyLimit(),10*mass*(1./sqrt(1. - beta2lim) - 1.)); 
+  mass = monopole->GetPDGMass();
+  G4double emin = std::min(LowEnergyLimit(), 0.1 * mass * (1. / sqrt(1. - betalow * betalow) - 1.));
+  G4double emax = std::max(HighEnergyLimit(), 10 * mass * (1. / sqrt(1. - beta2lim) - 1.));
   SetLowEnergyLimit(emin);
   SetHighEnergyLimit(emax);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-void 
-CMSmplIonisationWithDeltaModel::Initialise(const G4ParticleDefinition* p,
-                                           const G4DataVector&)
-{
-  if(!monopole) { SetParticle(p); }
-  if(!fParticleChange) { fParticleChange = GetParticleChangeForLoss(); }
-  if(IsMaster()) {
-    if(!dedx0) { dedx0 = new std::vector<G4double>; }
-    G4ProductionCutsTable* theCoupleTable=
-      G4ProductionCutsTable::GetProductionCutsTable();
+void CMSmplIonisationWithDeltaModel::Initialise(const G4ParticleDefinition* p, const G4DataVector&) {
+  if (!monopole) {
+    SetParticle(p);
+  }
+  if (!fParticleChange) {
+    fParticleChange = GetParticleChangeForLoss();
+  }
+  if (IsMaster()) {
+    if (!dedx0) {
+      dedx0 = new std::vector<G4double>;
+    }
+    G4ProductionCutsTable* theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
     G4int numOfCouples = theCoupleTable->GetTableSize();
     G4int n = dedx0->size();
-    if(n < numOfCouples) { dedx0->resize(numOfCouples); }
+    if (n < numOfCouples) {
+      dedx0->resize(numOfCouples);
+    }
     G4Pow* g4calc = G4Pow::GetInstance();
 
     // initialise vector
-    for(G4int i=0; i<numOfCouples; ++i) {
-
-      const G4Material* material = 
-        theCoupleTable->GetMaterialCutsCouple(i)->GetMaterial();
+    for (G4int i = 0; i < numOfCouples; ++i) {
+      const G4Material* material = theCoupleTable->GetMaterialCutsCouple(i)->GetMaterial();
       G4double eDensity = material->GetElectronDensity();
-      G4double vF = electron_Compton_length*g4calc->A13(3.*pi*pi*eDensity);
-      (*dedx0)[i] = pi_hbarc2_over_mc2*eDensity*nmpl*nmpl*
-        (G4Log(2*vF/fine_structure_const) - 0.5)/vF;
+      G4double vF = electron_Compton_length * g4calc->A13(3. * pi * pi * eDensity);
+      (*dedx0)[i] = pi_hbarc2_over_mc2 * eDensity * nmpl * nmpl * (G4Log(2 * vF / fine_structure_const) - 0.5) / vF;
     }
   }
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double 
-CMSmplIonisationWithDeltaModel::MinEnergyCut(const G4ParticleDefinition*,
-                                             const G4MaterialCutsCouple* couple)
-{
+G4double CMSmplIonisationWithDeltaModel::MinEnergyCut(const G4ParticleDefinition*, const G4MaterialCutsCouple* couple) {
   return couple->GetMaterial()->GetIonisation()->GetMeanExcitationEnergy();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-G4double 
-CMSmplIonisationWithDeltaModel::ComputeDEDXPerVolume(const G4Material* material,
-                                                     const G4ParticleDefinition* p,
-                                                     G4double kineticEnergy,
-                                                     G4double maxEnergy)
-{
-  if(!monopole) { SetParticle(p); }
-  G4double tmax = MaxSecondaryEnergy(p,kineticEnergy);
+G4double CMSmplIonisationWithDeltaModel::ComputeDEDXPerVolume(const G4Material* material,
+                                                              const G4ParticleDefinition* p,
+                                                              G4double kineticEnergy,
+                                                              G4double maxEnergy) {
+  if (!monopole) {
+    SetParticle(p);
+  }
+  G4double tmax = MaxSecondaryEnergy(p, kineticEnergy);
   G4double cutEnergy = std::min(tmax, maxEnergy);
   cutEnergy = std::max(LowEnergyLimit(), cutEnergy);
-  G4double tau   = kineticEnergy / mass;
-  G4double gam   = tau + 1.0;
-  G4double bg2   = tau * (tau + 2.0);
+  G4double tau = kineticEnergy / mass;
+  G4double gam = tau + 1.0;
+  G4double bg2 = tau * (tau + 2.0);
   G4double beta2 = bg2 / (gam * gam);
-  G4double beta  = sqrt(beta2);
+  G4double beta = sqrt(beta2);
 
   // low-energy asymptotic formula
-  G4double dedx = (*dedx0)[CurrentCouple()->GetIndex()]*beta;
+  G4double dedx = (*dedx0)[CurrentCouple()->GetIndex()] * beta;
 
   // above asymptotic
-  if(beta > betalow) {
-
+  if (beta > betalow) {
     // high energy
-    if(beta >= betalim) {
+    if (beta >= betalim) {
       dedx = ComputeDEDXAhlen(material, bg2, cutEnergy);
 
     } else {
-      G4double dedx1 = (*dedx0)[CurrentCouple()->GetIndex()]*betalow;
+      G4double dedx1 = (*dedx0)[CurrentCouple()->GetIndex()] * betalow;
       G4double dedx2 = ComputeDEDXAhlen(material, bg2lim, cutEnergy);
 
-      // extrapolation between two formula 
+      // extrapolation between two formula
       G4double kapa2 = beta - betalow;
       G4double kapa1 = betalim - beta;
-      dedx = (kapa1*dedx1 + kapa2*dedx2)/(kapa1 + kapa2);
+      dedx = (kapa1 * dedx1 + kapa2 * dedx2) / (kapa1 + kapa2);
     }
   }
   return dedx;
@@ -165,33 +160,32 @@ CMSmplIonisationWithDeltaModel::ComputeDEDXPerVolume(const G4Material* material,
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-G4double 
-CMSmplIonisationWithDeltaModel::ComputeDEDXAhlen(const G4Material* material, 
-                                                 G4double bg2, 
-                                                 G4double cutEnergy)
-{
+G4double CMSmplIonisationWithDeltaModel::ComputeDEDXAhlen(const G4Material* material,
+                                                          G4double bg2,
+                                                          G4double cutEnergy) {
   G4double eDensity = material->GetElectronDensity();
-  G4double eexc  = material->GetIonisation()->GetMeanExcitationEnergy();
+  G4double eexc = material->GetIonisation()->GetMeanExcitationEnergy();
 
   // Ahlen's formula for nonconductors, [1]p157, f(5.7)
-  G4double dedx = 
-    0.5*(G4Log(2.0*electron_mass_c2*bg2*cutEnergy/(eexc*eexc)) -1.0);
+  G4double dedx = 0.5 * (G4Log(2.0 * electron_mass_c2 * bg2 * cutEnergy / (eexc * eexc)) - 1.0);
 
   // Kazama et al. cross-section correction
-  G4double  k = 0.406;
-  if(nmpl > 1) { k = 0.346; }
+  G4double k = 0.406;
+  if (nmpl > 1) {
+    k = 0.346;
+  }
 
   // Bloch correction
-  const G4double B[7] = { 0.0, 0.248, 0.672, 1.022, 1.243, 1.464, 1.685}; 
+  const G4double B[7] = {0.0, 0.248, 0.672, 1.022, 1.243, 1.464, 1.685};
 
   dedx += 0.5 * k - B[nmpl];
 
   // density effect correction
-  G4double x = G4Log(bg2)/twoln10;
+  G4double x = G4Log(bg2) / twoln10;
   dedx -= material->GetIonisation()->DensityCorrection(x);
 
   // now compute the total ionization loss
-  dedx *=  pi_hbarc2_over_mc2 * eDensity * nmpl * nmpl;
+  dedx *= pi_hbarc2_over_mc2 * eDensity * nmpl * nmpl;
 
   dedx = std::max(dedx, 0.0);
   return dedx;
@@ -199,91 +193,83 @@ CMSmplIonisationWithDeltaModel::ComputeDEDXAhlen(const G4Material* material,
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double
-CMSmplIonisationWithDeltaModel::ComputeCrossSectionPerElectron(
-                                           const G4ParticleDefinition* p,
-                                           G4double kineticEnergy,
-                                           G4double cut,
-                                           G4double maxKinEnergy)
-{
-  if(!monopole) { SetParticle(p); }
+G4double CMSmplIonisationWithDeltaModel::ComputeCrossSectionPerElectron(const G4ParticleDefinition* p,
+                                                                        G4double kineticEnergy,
+                                                                        G4double cut,
+                                                                        G4double maxKinEnergy) {
+  if (!monopole) {
+    SetParticle(p);
+  }
   G4double tmax = MaxSecondaryEnergy(p, kineticEnergy);
   G4double maxEnergy = std::min(tmax, maxKinEnergy);
   G4double cutEnergy = std::max(LowEnergyLimit(), cut);
-  G4double cross = (cutEnergy < maxEnergy) 
-    ? (0.5/cutEnergy - 0.5/maxEnergy)*pi_hbarc2_over_mc2 * nmpl * nmpl : 0.0;
+  G4double cross =
+      (cutEnergy < maxEnergy) ? (0.5 / cutEnergy - 0.5 / maxEnergy) * pi_hbarc2_over_mc2 * nmpl * nmpl : 0.0;
   return cross;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double 
-CMSmplIonisationWithDeltaModel::ComputeCrossSectionPerAtom(
-                                          const G4ParticleDefinition* p,
-                                          G4double kineticEnergy,
-                                          G4double Z, G4double,
-                                          G4double cutEnergy,
-                                          G4double maxEnergy)
-{
-  G4double cross = 
-    Z*ComputeCrossSectionPerElectron(p,kineticEnergy,cutEnergy,maxEnergy);
+G4double CMSmplIonisationWithDeltaModel::ComputeCrossSectionPerAtom(const G4ParticleDefinition* p,
+                                                                    G4double kineticEnergy,
+                                                                    G4double Z,
+                                                                    G4double,
+                                                                    G4double cutEnergy,
+                                                                    G4double maxEnergy) {
+  G4double cross = Z * ComputeCrossSectionPerElectron(p, kineticEnergy, cutEnergy, maxEnergy);
   return cross;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-void 
-CMSmplIonisationWithDeltaModel::SampleSecondaries(vector<G4DynamicParticle*>* vdp,
-                                                  const G4MaterialCutsCouple*,
-                                                  const G4DynamicParticle* dp,
-                                                  G4double minKinEnergy,
-                                                  G4double maxEnergy)
-{
+void CMSmplIonisationWithDeltaModel::SampleSecondaries(vector<G4DynamicParticle*>* vdp,
+                                                       const G4MaterialCutsCouple*,
+                                                       const G4DynamicParticle* dp,
+                                                       G4double minKinEnergy,
+                                                       G4double maxEnergy) {
   G4double kineticEnergy = dp->GetKineticEnergy();
-  G4double tmax = MaxSecondaryEnergy(dp->GetDefinition(),kineticEnergy);
+  G4double tmax = MaxSecondaryEnergy(dp->GetDefinition(), kineticEnergy);
 
-  G4double maxKinEnergy = std::min(maxEnergy,tmax);
-  if(minKinEnergy >= maxKinEnergy) { return; }
+  G4double maxKinEnergy = std::min(maxEnergy, tmax);
+  if (minKinEnergy >= maxKinEnergy) {
+    return;
+  }
 
   //G4cout << "CMSmplIonisationWithDeltaModel::SampleSecondaries: E(GeV)= "
   //         << kineticEnergy/GeV << " M(GeV)= " << mass/GeV
   //         << " tmin(MeV)= " << minKinEnergy/MeV << G4endl;
 
-  G4double totEnergy     = kineticEnergy + mass;
-  G4double etot2         = totEnergy*totEnergy;
-  G4double beta2         = kineticEnergy*(kineticEnergy + 2.0*mass)/etot2;
-  
+  G4double totEnergy = kineticEnergy + mass;
+  G4double etot2 = totEnergy * totEnergy;
+  G4double beta2 = kineticEnergy * (kineticEnergy + 2.0 * mass) / etot2;
+
   // sampling without nuclear size effect
   G4double q = G4UniformRand();
-  G4double deltaKinEnergy = minKinEnergy*maxKinEnergy
-    /(minKinEnergy*(1.0 - q) + maxKinEnergy*q);
+  G4double deltaKinEnergy = minKinEnergy * maxKinEnergy / (minKinEnergy * (1.0 - q) + maxKinEnergy * q);
 
   // delta-electron is produced
-  G4double totMomentum = totEnergy*sqrt(beta2);
-  G4double deltaMomentum =
-           sqrt(deltaKinEnergy * (deltaKinEnergy + 2.0*electron_mass_c2));
-  G4double cost = deltaKinEnergy * (totEnergy + electron_mass_c2) /
-                                   (deltaMomentum * totMomentum);
+  G4double totMomentum = totEnergy * sqrt(beta2);
+  G4double deltaMomentum = sqrt(deltaKinEnergy * (deltaKinEnergy + 2.0 * electron_mass_c2));
+  G4double cost = deltaKinEnergy * (totEnergy + electron_mass_c2) / (deltaMomentum * totMomentum);
   cost = std::min(cost, 1.0);
 
-  G4double sint = sqrt((1.0 - cost)*(1.0 + cost));
+  G4double sint = sqrt((1.0 - cost) * (1.0 + cost));
 
-  G4double phi = twopi * G4UniformRand() ;
+  G4double phi = twopi * G4UniformRand();
 
-  G4ThreeVector deltaDirection(sint*cos(phi),sint*sin(phi), cost);
+  G4ThreeVector deltaDirection(sint * cos(phi), sint * sin(phi), cost);
   const G4ThreeVector& direction = dp->GetMomentumDirection();
   deltaDirection.rotateUz(direction);
 
   // create G4DynamicParticle object for delta ray
-  G4DynamicParticle* delta = 
-    new G4DynamicParticle(theElectron,deltaDirection,deltaKinEnergy);
+  G4DynamicParticle* delta = new G4DynamicParticle(theElectron, deltaDirection, deltaKinEnergy);
 
   vdp->push_back(delta);
 
   // Change kinematics of primary particle
-  kineticEnergy       -= deltaKinEnergy;
-  G4ThreeVector finalP = direction*totMomentum - deltaDirection*deltaMomentum;
-  finalP               = finalP.unit();
+  kineticEnergy -= deltaKinEnergy;
+  G4ThreeVector finalP = direction * totMomentum - deltaDirection * deltaMomentum;
+  finalP = finalP.unit();
 
   fParticleChange->SetProposedKineticEnergy(kineticEnergy);
   fParticleChange->SetProposedMomentumDirection(finalP);
@@ -291,28 +277,26 @@ CMSmplIonisationWithDeltaModel::SampleSecondaries(vector<G4DynamicParticle*>* vd
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-G4double CMSmplIonisationWithDeltaModel::SampleFluctuations(
-                                       const G4MaterialCutsCouple* couple,
-                                       const G4DynamicParticle* dp,
-                                       G4double tmax,
-                                       G4double length,
-                                       G4double meanLoss)
-{
-  G4double siga = Dispersion(couple->GetMaterial(),dp,tmax,length);
+G4double CMSmplIonisationWithDeltaModel::SampleFluctuations(const G4MaterialCutsCouple* couple,
+                                                            const G4DynamicParticle* dp,
+                                                            G4double tmax,
+                                                            G4double length,
+                                                            G4double meanLoss) {
+  G4double siga = Dispersion(couple->GetMaterial(), dp, tmax, length);
   G4double loss = meanLoss;
   siga = sqrt(siga);
   G4double twomeanLoss = meanLoss + meanLoss;
 
-  if(twomeanLoss < siga) {
+  if (twomeanLoss < siga) {
     G4double x;
     do {
-      loss = twomeanLoss*G4UniformRand();
-      x = (loss - meanLoss)/siga;
+      loss = twomeanLoss * G4UniformRand();
+      x = (loss - meanLoss) / siga;
       // Loop checking, 07-Aug-2015, Vladimir Ivanchenko
-    } while (1.0 - 0.5*x*x < G4UniformRand());
+    } while (1.0 - 0.5 * x * x < G4UniformRand());
   } else {
     do {
-      loss = G4RandGauss::shoot(meanLoss,siga);
+      loss = G4RandGauss::shoot(meanLoss, siga);
       // Loop checking, 07-Aug-2015, Vladimir Ivanchenko
     } while (0.0 > loss || loss > twomeanLoss);
   }
@@ -321,32 +305,26 @@ G4double CMSmplIonisationWithDeltaModel::SampleFluctuations(
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-G4double 
-CMSmplIonisationWithDeltaModel::Dispersion(const G4Material* material,
-                                           const G4DynamicParticle* dp,
-                                           G4double tmax,
-                                           G4double length)
-{
+G4double CMSmplIonisationWithDeltaModel::Dispersion(const G4Material* material,
+                                                    const G4DynamicParticle* dp,
+                                                    G4double tmax,
+                                                    G4double length) {
   G4double siga = 0.0;
-  G4double tau   = dp->GetKineticEnergy()/mass;
-  if(tau > 0.0) { 
+  G4double tau = dp->GetKineticEnergy() / mass;
+  if (tau > 0.0) {
     G4double electronDensity = material->GetElectronDensity();
-    G4double gam   = tau + 1.0;
-    G4double invbeta2 = (gam*gam)/(tau * (tau+2.0));
-    siga  = (invbeta2 - 0.5) * twopi_mc2_rcl2 * tmax * length
-      * electronDensity * chargeSquare;
+    G4double gam = tau + 1.0;
+    G4double invbeta2 = (gam * gam) / (tau * (tau + 2.0));
+    siga = (invbeta2 - 0.5) * twopi_mc2_rcl2 * tmax * length * electronDensity * chargeSquare;
   }
   return siga;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-G4double 
-CMSmplIonisationWithDeltaModel::MaxSecondaryEnergy(const G4ParticleDefinition*,
-                                                   G4double kinEnergy)
-{
-  G4double tau = kinEnergy/mass;
-  return 2.0*electron_mass_c2*tau*(tau + 2.);
+G4double CMSmplIonisationWithDeltaModel::MaxSecondaryEnergy(const G4ParticleDefinition*, G4double kinEnergy) {
+  G4double tau = kinEnergy / mass;
+  return 2.0 * electron_mass_c2 * tau * (tau + 2.);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....

--- a/SimG4Core/PhysicsLists/src/DummyEMPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/DummyEMPhysics.cc
@@ -23,13 +23,12 @@
 
 #include "G4SystemOfUnits.hh"
 
-DummyEMPhysics::DummyEMPhysics(G4int ver) :
-  G4VPhysicsConstructor("CMSEmGeantV"), verbose(ver) {
+DummyEMPhysics::DummyEMPhysics(G4int ver) : G4VPhysicsConstructor("CMSEmGeantV"), verbose(ver) {
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
   param->SetVerbose(verbose);
   param->SetApplyCuts(true);
-  param->SetStepFunction(0.8, 1*CLHEP::mm);
+  param->SetStepFunction(0.8, 1 * CLHEP::mm);
   param->SetLossFluctuations(false);
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
@@ -49,8 +48,7 @@ void DummyEMPhysics::ConstructParticle() {
 }
 
 void DummyEMPhysics::ConstructProcess() {
-
-  if(verbose > 0) {
+  if (verbose > 0) {
     G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
   }
 

--- a/SimG4Core/PhysicsLists/src/EmParticleList.cc
+++ b/SimG4Core/PhysicsLists/src/EmParticleList.cc
@@ -1,26 +1,52 @@
 #include "SimG4Core/PhysicsLists/interface/EmParticleList.h"
 
-EmParticleList::EmParticleList() 
-{
-  pNames = 
-    { 
-        "gamma",            "e-",           "e+",           "mu+",        "mu-",
-          "pi+",           "pi-",        "kaon+",         "kaon-",     "proton",
-  "anti_proton",         "alpha",          "He3",    "GenericIon",         "B+",
-           "B-",            "D+",           "D-",           "Ds+",        "Ds-",
-     "anti_He3",    "anti_alpha","anti_deuteron","anti_lambda_c+","anti_omega-",
-"anti_sigma_c+","anti_sigma_c++",  "anti_sigma+",   "anti_sigma-","anti_triton",
-   "anti_xi_c+",      "anti_xi-",     "deuteron",     "lambda_c+",     "omega-",
-     "sigma_c+",     "sigma_c++",       "sigma+",        "sigma-",       "tau+",
-         "tau-",        "triton",        "xi_c+",           "xi-"
-    };
+EmParticleList::EmParticleList() {
+  pNames = {"gamma",
+            "e-",
+            "e+",
+            "mu+",
+            "mu-",
+            "pi+",
+            "pi-",
+            "kaon+",
+            "kaon-",
+            "proton",
+            "anti_proton",
+            "alpha",
+            "He3",
+            "GenericIon",
+            "B+",
+            "B-",
+            "D+",
+            "D-",
+            "Ds+",
+            "Ds-",
+            "anti_He3",
+            "anti_alpha",
+            "anti_deuteron",
+            "anti_lambda_c+",
+            "anti_omega-",
+            "anti_sigma_c+",
+            "anti_sigma_c++",
+            "anti_sigma+",
+            "anti_sigma-",
+            "anti_triton",
+            "anti_xi_c+",
+            "anti_xi-",
+            "deuteron",
+            "lambda_c+",
+            "omega-",
+            "sigma_c+",
+            "sigma_c++",
+            "sigma+",
+            "sigma-",
+            "tau+",
+            "tau-",
+            "triton",
+            "xi_c+",
+            "xi-"};
 }
 
-EmParticleList::~EmParticleList() 
-{}
+EmParticleList::~EmParticleList() {}
 
-const std::vector<G4String>& EmParticleList::PartNames() const
-{
-  return pNames;
-}
-
+const std::vector<G4String>& EmParticleList::PartNames() const { return pNames; }

--- a/SimG4Core/PhysicsLists/src/HadronPhysicsCMS.cc
+++ b/SimG4Core/PhysicsLists/src/HadronPhysicsCMS.cc
@@ -2,7 +2,7 @@
 
 #include "globals.hh"
 #include "G4ios.hh"
-#include <iomanip>   
+#include <iomanip>
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTable.hh"
 
@@ -11,100 +11,121 @@
 #include "G4ShortLivedConstructor.hh"
 #include "G4SystemOfUnits.hh"
 
-HadronPhysicsCMS::HadronPhysicsCMS(const G4String& name, G4bool quasiElastic) :
-  G4VPhysicsConstructor("hadron"), theNeutrons(nullptr), theBertiniNeutron(nullptr),
-  theBinaryNeutron(nullptr), theFTFPNeutron(nullptr), 
-  theQGSPNeutron(nullptr), thePiK(nullptr), theBertiniPiK(nullptr),
-  theBinaryPiK(nullptr), theFTFPPiK(nullptr), 
-  theQGSPPiK(nullptr), thePro(nullptr),theBertiniPro(nullptr),
-  theBinaryPro(nullptr), theFTFPPro(nullptr), 
-  theQGSPPro(nullptr),
-  theFTFNeutron(nullptr), theFTFPiK(nullptr), theFTFPro(nullptr), 
-  modelName(name), 
-  QuasiElastic(quasiElastic) 
-{}
+HadronPhysicsCMS::HadronPhysicsCMS(const G4String& name, G4bool quasiElastic)
+    : G4VPhysicsConstructor("hadron"),
+      theNeutrons(nullptr),
+      theBertiniNeutron(nullptr),
+      theBinaryNeutron(nullptr),
+      theFTFPNeutron(nullptr),
+      theQGSPNeutron(nullptr),
+      thePiK(nullptr),
+      theBertiniPiK(nullptr),
+      theBinaryPiK(nullptr),
+      theFTFPPiK(nullptr),
+      theQGSPPiK(nullptr),
+      thePro(nullptr),
+      theBertiniPro(nullptr),
+      theBinaryPro(nullptr),
+      theFTFPPro(nullptr),
+      theQGSPPro(nullptr),
+      theFTFNeutron(nullptr),
+      theFTFPiK(nullptr),
+      theFTFPro(nullptr),
+      modelName(name),
+      QuasiElastic(quasiElastic) {}
 
 void HadronPhysicsCMS::CreateModels() {
-
   theNeutrons = new G4NeutronBuilder;
-  thePro      = new G4ProtonBuilder;
-  thePiK      = new G4PiKBuilder;
+  thePro = new G4ProtonBuilder;
+  thePiK = new G4PiKBuilder;
 
   if (modelName == "Bertini") {
     theBertiniNeutron = new G4BertiniNeutronBuilder();
-    theBertiniNeutron->SetMaxEnergy(30.0*GeV);
+    theBertiniNeutron->SetMaxEnergy(30.0 * GeV);
     theNeutrons->RegisterMe(theBertiniNeutron);
-    theBertiniPro     = new G4BertiniProtonBuilder();
-    theBertiniPro->SetMaxEnergy(30.0*GeV);
+    theBertiniPro = new G4BertiniProtonBuilder();
+    theBertiniPro->SetMaxEnergy(30.0 * GeV);
     thePro->RegisterMe(theBertiniPro);
-    theBertiniPiK     = new G4BertiniPiKBuilder();
-    theBertiniPiK->SetMaxEnergy(30.0*GeV);
+    theBertiniPiK = new G4BertiniPiKBuilder();
+    theBertiniPiK->SetMaxEnergy(30.0 * GeV);
     thePiK->RegisterMe(theBertiniPiK);
   } else if (modelName == "Binary") {
     theBinaryNeutron = new G4BinaryNeutronBuilder();
-    theBinaryNeutron->SetMaxEnergy(30.0*GeV);
+    theBinaryNeutron->SetMaxEnergy(30.0 * GeV);
     theNeutrons->RegisterMe(theBinaryNeutron);
-    theBinaryPro     = new G4BinaryProtonBuilder();
-    theBinaryPro->SetMaxEnergy(30.0*GeV);
+    theBinaryPro = new G4BinaryProtonBuilder();
+    theBinaryPro->SetMaxEnergy(30.0 * GeV);
     thePro->RegisterMe(theBinaryPro);
-    theBinaryPiK     = new G4BinaryPiKBuilder(); 
-    theBinaryPiK->SetMaxEnergy(30.0*GeV);
+    theBinaryPiK = new G4BinaryPiKBuilder();
+    theBinaryPiK->SetMaxEnergy(30.0 * GeV);
     thePiK->RegisterMe(theBinaryPiK);
   } else if (modelName == "FTFP") {
     theFTFPNeutron = new G4FTFPNeutronBuilder();
-    theFTFPNeutron->SetMinEnergy(0.1*GeV);
+    theFTFPNeutron->SetMinEnergy(0.1 * GeV);
     theNeutrons->RegisterMe(theFTFPNeutron);
-    theFTFPPro     = new G4FTFPProtonBuilder();
-    theFTFPPro->SetMinEnergy(0.1*GeV);
+    theFTFPPro = new G4FTFPProtonBuilder();
+    theFTFPPro->SetMinEnergy(0.1 * GeV);
     thePro->RegisterMe(theFTFPPro);
-    theFTFPPiK     = new G4FTFPPiKBuilder();
-    theFTFPPiK->SetMinEnergy(0.1*GeV);
+    theFTFPPiK = new G4FTFPPiKBuilder();
+    theFTFPPiK->SetMinEnergy(0.1 * GeV);
     thePiK->RegisterMe(theFTFPPiK);
   } else if (modelName == "FTF") {
-    theFTFNeutron  = new G4FTFBinaryNeutronBuilder();
+    theFTFNeutron = new G4FTFBinaryNeutronBuilder();
     theNeutrons->RegisterMe(theFTFNeutron);
-    theFTFPro      = new G4FTFBinaryProtonBuilder();
+    theFTFPro = new G4FTFBinaryProtonBuilder();
     thePro->RegisterMe(theFTFPro);
-    theFTFPiK      = new G4FTFBinaryPiKBuilder();
+    theFTFPiK = new G4FTFBinaryPiKBuilder();
     thePiK->RegisterMe(theFTFPiK);
   } else {
     theQGSPNeutron = new G4QGSPNeutronBuilder(QuasiElastic);
-    theQGSPNeutron->SetMinEnergy(0.1*GeV);
+    theQGSPNeutron->SetMinEnergy(0.1 * GeV);
     theNeutrons->RegisterMe(theQGSPNeutron);
-    theQGSPPro     = new G4QGSPProtonBuilder(QuasiElastic);
-    theQGSPPro->SetMinEnergy(0.1*GeV);
+    theQGSPPro = new G4QGSPProtonBuilder(QuasiElastic);
+    theQGSPPro->SetMinEnergy(0.1 * GeV);
     thePro->RegisterMe(theQGSPPro);
-    theQGSPPiK     = new G4QGSPPiKBuilder(QuasiElastic);
-    theQGSPPiK->SetMinEnergy(0.1*GeV);
+    theQGSPPiK = new G4QGSPPiKBuilder(QuasiElastic);
+    theQGSPPiK->SetMinEnergy(0.1 * GeV);
     thePiK->RegisterMe(theQGSPPiK);
   }
-  
 }
 
 HadronPhysicsCMS::~HadronPhysicsCMS() {
-  if (theBertiniNeutron)   delete theBertiniNeutron;
-  if (theBinaryNeutron)    delete theBinaryNeutron;
-  if (theFTFPNeutron)      delete theFTFPNeutron;
-  if (theQGSPNeutron)      delete theQGSPNeutron;
-  if (theFTFNeutron)       delete theFTFNeutron;
+  if (theBertiniNeutron)
+    delete theBertiniNeutron;
+  if (theBinaryNeutron)
+    delete theBinaryNeutron;
+  if (theFTFPNeutron)
+    delete theFTFPNeutron;
+  if (theQGSPNeutron)
+    delete theQGSPNeutron;
+  if (theFTFNeutron)
+    delete theFTFNeutron;
   delete theNeutrons;
-  if (theBertiniPro)       delete theBertiniPro;
-  if (theBinaryPro)        delete theBinaryPro;
-  if (theFTFPPro)          delete theFTFPPro;
-  if (theQGSPPro)          delete theQGSPPro; 
-  if (theFTFPro)           delete theFTFPro;
+  if (theBertiniPro)
+    delete theBertiniPro;
+  if (theBinaryPro)
+    delete theBinaryPro;
+  if (theFTFPPro)
+    delete theFTFPPro;
+  if (theQGSPPro)
+    delete theQGSPPro;
+  if (theFTFPro)
+    delete theFTFPro;
   delete thePro;
-  if (theBertiniPiK)       delete theBertiniPiK;
-  if (theBinaryPiK)        delete theBinaryPiK;
-  if (theFTFPPiK)          delete theFTFPPiK;
-  if (theQGSPPiK)          delete theQGSPPiK;
-  if (theFTFPiK)           delete theFTFPiK;
+  if (theBertiniPiK)
+    delete theBertiniPiK;
+  if (theBinaryPiK)
+    delete theBinaryPiK;
+  if (theFTFPPiK)
+    delete theFTFPPiK;
+  if (theQGSPPiK)
+    delete theQGSPPiK;
+  if (theFTFPiK)
+    delete theFTFPiK;
   delete thePiK;
 }
 
-
 void HadronPhysicsCMS::ConstructParticle() {
-
   G4MesonConstructor pMesonConstructor;
   pMesonConstructor.ConstructParticle();
 
@@ -112,16 +133,14 @@ void HadronPhysicsCMS::ConstructParticle() {
   pBaryonConstructor.ConstructParticle();
 
   G4ShortLivedConstructor pShortLivedConstructor;
-  pShortLivedConstructor.ConstructParticle();  
+  pShortLivedConstructor.ConstructParticle();
 }
 
 #include "G4ProcessManager.hh"
 void HadronPhysicsCMS::ConstructProcess() {
-
   CreateModels();
   theNeutrons->Build();
   thePro->Build();
   thePiK->Build();
   //  theMiscLHEP->Build();
 }
-

--- a/SimG4Core/PhysicsLists/src/HadronPhysicsQGSPCMS_FTFP_BERT.cc
+++ b/SimG4Core/PhysicsLists/src/HadronPhysicsQGSPCMS_FTFP_BERT.cc
@@ -2,7 +2,7 @@
 
 #include "globals.hh"
 #include "G4ios.hh"
-#include <iomanip>   
+#include <iomanip>
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTable.hh"
 
@@ -19,108 +19,94 @@
 #include "G4PhysListUtil.hh"
 #include "G4SystemOfUnits.hh"
 
-G4ThreadLocal HadronPhysicsQGSPCMS_FTFP_BERT::ThreadPrivate* 
-HadronPhysicsQGSPCMS_FTFP_BERT::tpdata = nullptr;
+G4ThreadLocal HadronPhysicsQGSPCMS_FTFP_BERT::ThreadPrivate* HadronPhysicsQGSPCMS_FTFP_BERT::tpdata = nullptr;
 
 HadronPhysicsQGSPCMS_FTFP_BERT::HadronPhysicsQGSPCMS_FTFP_BERT(G4int)
-  :  G4VPhysicsConstructor("hInelasticQGSPCMS_FTFP_BERT")
-{}
+    : G4VPhysicsConstructor("hInelasticQGSPCMS_FTFP_BERT") {}
 
-void HadronPhysicsQGSPCMS_FTFP_BERT::CreateModels()
-{
+void HadronPhysicsQGSPCMS_FTFP_BERT::CreateModels() {
   // First transition, between BERT and FTF/P
-  G4double minFTFP= 6.0 * GeV;  
-  G4double maxBERT= 8.0 * GeV;  
+  G4double minFTFP = 6.0 * GeV;
+  G4double maxBERT = 8.0 * GeV;
   // Second transition, between FTF/P and QGS/P
-  G4double minQGSP= 12.0 * GeV;
-  G4double maxFTFP= 25.0 * GeV; 
+  G4double minQGSP = 12.0 * GeV;
+  G4double maxFTFP = 25.0 * GeV;
 
-  G4bool   quasiElasFTF= false;   // Use built-in quasi-elastic (not add-on)
-  G4bool   quasiElasQGS= true;    // For QGS, it must use it.
+  G4bool quasiElasFTF = false;  // Use built-in quasi-elastic (not add-on)
+  G4bool quasiElasQGS = true;   // For QGS, it must use it.
 
   G4cout << " New QGSPCMS_FTFP_BERT hadronic inealstic physics" << G4endl;
   G4cout << "   Thresholds: " << G4endl;
-  G4cout << "     1) between BERT  and FTFP over the interval " 
-	 << minFTFP/GeV << " to " << maxBERT/GeV << " GeV. " << G4endl;
-  G4cout << "     2) between FTFP and QGSP over the interval " 
-	 << minQGSP/GeV << " to " << maxFTFP/GeV << " GeV. " << G4endl;
+  G4cout << "     1) between BERT  and FTFP over the interval " << minFTFP / GeV << " to " << maxBERT / GeV << " GeV. "
+         << G4endl;
+  G4cout << "     2) between FTFP and QGSP over the interval " << minQGSP / GeV << " to " << maxFTFP / GeV << " GeV. "
+         << G4endl;
   G4cout << "   QuasiElastic: " << quasiElasQGS << " for QGS "
-	 << " and " << quasiElasFTF << " for FTF " << G4endl;
+         << " and " << quasiElasFTF << " for FTF " << G4endl;
 
-  tpdata->theNeutrons=new G4NeutronBuilder;
-  tpdata->theNeutrons->RegisterMe(
-    tpdata->theQGSPNeutron=new G4QGSPNeutronBuilder(quasiElasQGS));
-  tpdata->theQGSPNeutron->SetMinEnergy(minQGSP);   
-  tpdata->theNeutrons->RegisterMe(
-    tpdata->theFTFPNeutron=new G4FTFPNeutronBuilder(quasiElasFTF));
-  tpdata->theFTFPNeutron->SetMinEnergy(minFTFP);   
-  tpdata->theFTFPNeutron->SetMaxEnergy(maxFTFP);   
+  tpdata->theNeutrons = new G4NeutronBuilder;
+  tpdata->theNeutrons->RegisterMe(tpdata->theQGSPNeutron = new G4QGSPNeutronBuilder(quasiElasQGS));
+  tpdata->theQGSPNeutron->SetMinEnergy(minQGSP);
+  tpdata->theNeutrons->RegisterMe(tpdata->theFTFPNeutron = new G4FTFPNeutronBuilder(quasiElasFTF));
+  tpdata->theFTFPNeutron->SetMinEnergy(minFTFP);
+  tpdata->theFTFPNeutron->SetMaxEnergy(maxFTFP);
 
-  tpdata->theNeutrons->RegisterMe(
-    tpdata->theBertiniNeutron=new G4BertiniNeutronBuilder);
-  tpdata->theBertiniNeutron->SetMinEnergy(0.0*GeV);
-  tpdata->theBertiniNeutron->SetMaxEnergy(maxBERT);  
+  tpdata->theNeutrons->RegisterMe(tpdata->theBertiniNeutron = new G4BertiniNeutronBuilder);
+  tpdata->theBertiniNeutron->SetMinEnergy(0.0 * GeV);
+  tpdata->theBertiniNeutron->SetMaxEnergy(maxBERT);
 
-  tpdata->thePro=new G4ProtonBuilder;
-  tpdata->thePro->RegisterMe(
-    tpdata->theQGSPPro=new G4QGSPProtonBuilder(quasiElasQGS));
-  tpdata->theQGSPPro->SetMinEnergy(minQGSP);   
-  tpdata->thePro->RegisterMe(
-    tpdata->theFTFPPro=new G4FTFPProtonBuilder(quasiElasFTF));
-  tpdata->theFTFPPro->SetMinEnergy(minFTFP);   
-  tpdata->theFTFPPro->SetMaxEnergy(maxFTFP);   
-  tpdata->thePro->RegisterMe(
-    tpdata->theBertiniPro=new G4BertiniProtonBuilder);
-  tpdata->theBertiniPro->SetMaxEnergy(maxBERT); 
-  
-  tpdata->thePiK=new G4PiKBuilder;
-  tpdata->thePiK->RegisterMe(
-    tpdata->theQGSPPiK=new G4QGSPPiKBuilder(quasiElasQGS));
-  tpdata->theQGSPPiK->SetMinEnergy(minQGSP);   
-  tpdata->thePiK->RegisterMe(
-    tpdata->theFTFPPiK=new G4FTFPPiKBuilder(quasiElasFTF));
-  tpdata->theFTFPPiK->SetMaxEnergy(maxFTFP);  
-  tpdata->theFTFPPiK->SetMinEnergy(minFTFP); 
-  tpdata->thePiK->RegisterMe(tpdata->theBertiniPiK=new G4BertiniPiKBuilder);
-  tpdata->theBertiniPiK->SetMaxEnergy(maxBERT); 
-  
+  tpdata->thePro = new G4ProtonBuilder;
+  tpdata->thePro->RegisterMe(tpdata->theQGSPPro = new G4QGSPProtonBuilder(quasiElasQGS));
+  tpdata->theQGSPPro->SetMinEnergy(minQGSP);
+  tpdata->thePro->RegisterMe(tpdata->theFTFPPro = new G4FTFPProtonBuilder(quasiElasFTF));
+  tpdata->theFTFPPro->SetMinEnergy(minFTFP);
+  tpdata->theFTFPPro->SetMaxEnergy(maxFTFP);
+  tpdata->thePro->RegisterMe(tpdata->theBertiniPro = new G4BertiniProtonBuilder);
+  tpdata->theBertiniPro->SetMaxEnergy(maxBERT);
+
+  tpdata->thePiK = new G4PiKBuilder;
+  tpdata->thePiK->RegisterMe(tpdata->theQGSPPiK = new G4QGSPPiKBuilder(quasiElasQGS));
+  tpdata->theQGSPPiK->SetMinEnergy(minQGSP);
+  tpdata->thePiK->RegisterMe(tpdata->theFTFPPiK = new G4FTFPPiKBuilder(quasiElasFTF));
+  tpdata->theFTFPPiK->SetMaxEnergy(maxFTFP);
+  tpdata->theFTFPPiK->SetMinEnergy(minFTFP);
+  tpdata->thePiK->RegisterMe(tpdata->theBertiniPiK = new G4BertiniPiKBuilder);
+  tpdata->theBertiniPiK->SetMaxEnergy(maxBERT);
+
   // Hyperons use FTF
-  tpdata->theHyperon=new G4HyperonFTFPBuilder;
+  tpdata->theHyperon = new G4HyperonFTFPBuilder;
 
-  tpdata->theAntiBaryon=new G4AntiBarionBuilder;
-  tpdata->theAntiBaryon->RegisterMe(
-    tpdata->theFTFPAntiBaryon=new G4FTFPAntiBarionBuilder(quasiElasFTF));
+  tpdata->theAntiBaryon = new G4AntiBarionBuilder;
+  tpdata->theAntiBaryon->RegisterMe(tpdata->theFTFPAntiBaryon = new G4FTFPAntiBarionBuilder(quasiElasFTF));
 }
 
-HadronPhysicsQGSPCMS_FTFP_BERT::~HadronPhysicsQGSPCMS_FTFP_BERT()
-{
-  if(nullptr != tpdata) {
-   delete tpdata->theQGSPNeutron;
-   delete tpdata->theFTFPNeutron;
-   delete tpdata->theBertiniNeutron;
-   delete tpdata->theNeutrons;
+HadronPhysicsQGSPCMS_FTFP_BERT::~HadronPhysicsQGSPCMS_FTFP_BERT() {
+  if (nullptr != tpdata) {
+    delete tpdata->theQGSPNeutron;
+    delete tpdata->theFTFPNeutron;
+    delete tpdata->theBertiniNeutron;
+    delete tpdata->theNeutrons;
 
-   delete tpdata->theQGSPPro;
-   delete tpdata->theFTFPPro;
-   delete tpdata->thePro;
-   delete tpdata->theBertiniPro;
+    delete tpdata->theQGSPPro;
+    delete tpdata->theFTFPPro;
+    delete tpdata->thePro;
+    delete tpdata->theBertiniPro;
 
-   delete tpdata->theQGSPPiK;
-   delete tpdata->theFTFPPiK;
-   delete tpdata->theBertiniPiK;
-   delete tpdata->thePiK;
+    delete tpdata->theQGSPPiK;
+    delete tpdata->theFTFPPiK;
+    delete tpdata->theBertiniPiK;
+    delete tpdata->thePiK;
 
-   delete tpdata->theHyperon;
-   delete tpdata->theAntiBaryon;
-   delete tpdata->theFTFPAntiBaryon;
-   
-   delete tpdata;
-   tpdata = nullptr;
+    delete tpdata->theHyperon;
+    delete tpdata->theAntiBaryon;
+    delete tpdata->theFTFPAntiBaryon;
+
+    delete tpdata;
+    tpdata = nullptr;
   }
 }
 
-void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructParticle()
-{
+void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructParticle() {
   G4MesonConstructor pMesonConstructor;
   pMesonConstructor.ConstructParticle();
 
@@ -128,40 +114,39 @@ void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructParticle()
   pBaryonConstructor.ConstructParticle();
 
   G4ShortLivedConstructor pShortLivedConstructor;
-  pShortLivedConstructor.ConstructParticle();  
+  pShortLivedConstructor.ConstructParticle();
 
   G4IonConstructor pIonConstructor;
   pIonConstructor.ConstructParticle();
 }
 
 #include "G4ProcessManager.hh"
-void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructProcess()
-{
-  if ( tpdata == nullptr ) { tpdata = new ThreadPrivate; }
+void HadronPhysicsQGSPCMS_FTFP_BERT::ConstructProcess() {
+  if (tpdata == nullptr) {
+    tpdata = new ThreadPrivate;
+  }
   CreateModels();
   tpdata->theNeutrons->Build();
   tpdata->thePro->Build();
   tpdata->thePiK->Build();
-  tpdata->theHyperon->Build(); 
-  tpdata->theAntiBaryon->Build(); 
+  tpdata->theHyperon->Build();
+  tpdata->theAntiBaryon->Build();
 
   // --- Neutrons ---
-  G4PhysListUtil::FindInelasticProcess(G4Neutron::Neutron())
-    ->AddDataSet(new G4NeutronInelasticXS());
+  G4PhysListUtil::FindInelasticProcess(G4Neutron::Neutron())->AddDataSet(new G4NeutronInelasticXS());
 
   G4HadronicProcess* capture = nullptr;
   G4ProcessManager* pmanager = G4Neutron::Neutron()->GetProcessManager();
-  G4ProcessVector*  pv = pmanager->GetProcessList();
-  for ( size_t i=0; i < static_cast<size_t>(pv->size()); ++i ) {
-    if ( fCapture == ((*pv)[i])->GetProcessSubType() ) {
+  G4ProcessVector* pv = pmanager->GetProcessList();
+  for (size_t i = 0; i < static_cast<size_t>(pv->size()); ++i) {
+    if (fCapture == ((*pv)[i])->GetProcessSubType()) {
       capture = static_cast<G4HadronicProcess*>((*pv)[i]);
     }
   }
-  if ( ! capture ) {
+  if (!capture) {
     capture = new G4HadronCaptureProcess("nCapture");
     pmanager->AddDiscreteProcess(capture);
   }
   capture->AddDataSet(new G4NeutronCaptureXS());
   capture->RegisterMe(new G4NeutronRadCapture());
 }
-

--- a/SimG4Core/PhysicsLists/src/MonopoleTransportation.cc
+++ b/SimG4Core/PhysicsLists/src/MonopoleTransportation.cc
@@ -1,16 +1,16 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //
-// This class is a process responsible for the transportation of 
-// magnetic monopoles, ie the geometrical propagation that encounters the 
+// This class is a process responsible for the transportation of
+// magnetic monopoles, ie the geometrical propagation that encounters the
 // geometrical sub-volumes of the detectors.
 //
 // =======================================================================
-// Created:  3 May 2010, J. Apostolakis, B. Bozsogi 
+// Created:  3 May 2010, J. Apostolakis, B. Bozsogi
 //                       G4MonopoleTransportation class for
 //                       Geant4 extended example "monopole"
 //
-// Adopted for CMSSW by V.Ivanchenko 30 April 2018 
+// Adopted for CMSSW by V.Ivanchenko 30 April 2018
 //
 // =======================================================================
 
@@ -31,67 +31,64 @@ class G4VSensitiveDetector;
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 MonopoleTransportation::MonopoleTransportation(const Monopole* mpl, G4int verb)
-  : G4VProcess( G4String("MonopoleTransportation"), fTransportation ),
-    fParticleDef(mpl),
-    fieldMgrCMS(nullptr),
-    fLinearNavigator(nullptr),
-    fFieldPropagator(nullptr),
-    fParticleIsLooping( false ),
-    fPreviousSftOrigin (0.,0.,0.),
-    fPreviousSafety    ( 0.0 ),
-    fThreshold_Warning_Energy( 100 * MeV ),  
-    fThreshold_Important_Energy( 250 * MeV ), 
-    fThresholdTrials( 10 ), 
-    fNoLooperTrials(0),
-    fSumEnergyKilled( 0.0 ), fMaxEnergyKilled( 0.0 ), 
-    fShortStepOptimisation(false),    // Old default: true (=fast short steps)
-    fpSafetyHelper(nullptr)
-{
+    : G4VProcess(G4String("MonopoleTransportation"), fTransportation),
+      fParticleDef(mpl),
+      fieldMgrCMS(nullptr),
+      fLinearNavigator(nullptr),
+      fFieldPropagator(nullptr),
+      fParticleIsLooping(false),
+      fPreviousSftOrigin(0., 0., 0.),
+      fPreviousSafety(0.0),
+      fThreshold_Warning_Energy(100 * MeV),
+      fThreshold_Important_Energy(250 * MeV),
+      fThresholdTrials(10),
+      fNoLooperTrials(0),
+      fSumEnergyKilled(0.0),
+      fMaxEnergyKilled(0.0),
+      fShortStepOptimisation(false),  // Old default: true (=fast short steps)
+      fpSafetyHelper(nullptr) {
   verboseLevel = verb;
 
   // set Process Sub Type
-  SetProcessSubType(TRANSPORTATION);  
+  SetProcessSubType(TRANSPORTATION);
 
 #ifdef G4MULTITHREADED
-  // Do not finalize the MonopoleTransportation class 
-  if (G4Threading::IsMasterThread())
-    {
-      return;
-    }
+  // Do not finalize the MonopoleTransportation class
+  if (G4Threading::IsMasterThread()) {
+    return;
+  }
 #endif
 
-  G4TransportationManager* transportMgr = 
-    G4TransportationManager::GetTransportationManager(); 
+  G4TransportationManager* transportMgr = G4TransportationManager::GetTransportationManager();
 
-  fLinearNavigator = transportMgr->GetNavigatorForTracking() ; 
+  fLinearNavigator = transportMgr->GetNavigatorForTracking();
 
-  fFieldPropagator = transportMgr->GetPropagatorInField() ;
-  fpSafetyHelper =   transportMgr->GetSafetyHelper();  
+  fFieldPropagator = transportMgr->GetPropagatorInField();
+  fpSafetyHelper = transportMgr->GetSafetyHelper();
 
   // Cannot determine whether a field exists here,
-  //  because it would only work if the field manager has informed 
-  //  about the detector's field before this transportation process 
+  //  because it would only work if the field manager has informed
+  //  about the detector's field before this transportation process
   //  is constructed.
   // Instead later the method DoesGlobalFieldExist() is called
 
-  fCurrentTouchableHandle = nullptr; 
+  fCurrentTouchableHandle = nullptr;
 
-  fEndGlobalTimeComputed  = false;
+  fEndGlobalTimeComputed = false;
   fCandidateEndGlobalTime = 0;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-MonopoleTransportation::~MonopoleTransportation()
-{
-  if( (verboseLevel > 0) && (fSumEnergyKilled > 0.0 ) ){ 
+MonopoleTransportation::~MonopoleTransportation() {
+  if ((verboseLevel > 0) && (fSumEnergyKilled > 0.0)) {
     /*
     G4cout << " MonopoleTransportation: Statistics for looping particles " 
            << G4endl;
     G4cout << "   Sum of energy of loopers killed: " <<  fSumEnergyKilled << G4endl;
     G4cout << "   Max energy of loopers killed: " <<  fMaxEnergyKilled << G4endl;
     */
-  } 
+  }
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -101,255 +98,230 @@ MonopoleTransportation::~MonopoleTransportation()
 //    Calculate the new value of the safety and return it.
 //    Store the final time, position and momentum.
 
-G4double MonopoleTransportation::
-AlongStepGetPhysicalInteractionLength( const G4Track&  track,
-                                             G4double, //  previousStepSize
-                                             G4double  currentMinimumStep,
-                                             G4double& currentSafety,
-                                             G4GPILSelection* selection )
-{  
+G4double MonopoleTransportation::AlongStepGetPhysicalInteractionLength(const G4Track& track,
+                                                                       G4double,  //  previousStepSize
+                                                                       G4double currentMinimumStep,
+                                                                       G4double& currentSafety,
+                                                                       G4GPILSelection* selection) {
   // change to monopole equation
   fieldMgrCMS->SetMonopoleTracking(true);
 
-  G4double geometryStepLength, newSafety ; 
-  fParticleIsLooping = false ;
+  G4double geometryStepLength, newSafety;
+  fParticleIsLooping = false;
 
-  // Initial actions moved to  StartTrack()   
+  // Initial actions moved to  StartTrack()
   // --------------------------------------
   // Note: in case another process changes touchable handle
-  //    it will be necessary to add here (for all steps)   
+  //    it will be necessary to add here (for all steps)
   // fCurrentTouchableHandle = aTrack->GetTouchableHandle();
 
   // GPILSelection is set to defaule value of CandidateForSelection
   // It is a return value
   //
-  *selection = CandidateForSelection ;
+  *selection = CandidateForSelection;
 
   // Get initial Energy/Momentum of the track
   //
-  const G4DynamicParticle* pParticle      = track.GetDynamicParticle() ;
-  const G4ThreeVector& startMomentumDir   = pParticle->GetMomentumDirection() ;
-  G4ThreeVector startPosition             = track.GetPosition() ;
+  const G4DynamicParticle* pParticle = track.GetDynamicParticle();
+  const G4ThreeVector& startMomentumDir = pParticle->GetMomentumDirection();
+  G4ThreeVector startPosition = track.GetPosition();
 
-  // The Step Point safety can be limited by other geometries and/or the 
+  // The Step Point safety can be limited by other geometries and/or the
   // assumptions of any process - it's not always the geometrical safety.
   // We calculate the starting point's isotropic safety here.
   //
-  G4ThreeVector OriginShift = startPosition - fPreviousSftOrigin ;
-  G4double      MagSqShift  = OriginShift.mag2() ;
-  if( MagSqShift >= sqr(fPreviousSafety) )
-  {
-     currentSafety = 0.0 ;
-  }
-  else
-  {
-     currentSafety = fPreviousSafety - std::sqrt(MagSqShift) ;
+  G4ThreeVector OriginShift = startPosition - fPreviousSftOrigin;
+  G4double MagSqShift = OriginShift.mag2();
+  if (MagSqShift >= sqr(fPreviousSafety)) {
+    currentSafety = 0.0;
+  } else {
+    currentSafety = fPreviousSafety - std::sqrt(MagSqShift);
   }
 
   // Is the monopole charged ?
   //
-  G4double particleMagneticCharge = fParticleDef->MagneticCharge() ; 
+  G4double particleMagneticCharge = fParticleDef->MagneticCharge();
   G4double particleElectricCharge = pParticle->GetCharge();
 
-  fGeometryLimitedStep = false ;
+  fGeometryLimitedStep = false;
 
   // There is no need to locate the current volume. It is Done elsewhere:
-  //   On track construction 
+  //   On track construction
   //   By the tracking, after all AlongStepDoIts, in "Relocation"
 
   // Check whether the particle have an (EM) field force exerting upon it
-  G4bool          fieldExertsForce = false ;
-    
-  if(particleMagneticCharge != 0.0 && fieldMgrCMS) {
+  G4bool fieldExertsForce = false;
+
+  if (particleMagneticCharge != 0.0 && fieldMgrCMS) {
     // Message the field Manager, to configure it for this track
-    fieldMgrCMS->ConfigureForTrack( &track );
+    fieldMgrCMS->ConfigureForTrack(&track);
     // Moved here, in order to allow a transition
     //   from a zero-field  status (with fieldMgr->(field)0
     //   to a finite field  status
 
     // If the field manager has no field, there is no field !
-    fieldExertsForce = (fieldMgrCMS->GetDetectorField() != nullptr);      
+    fieldExertsForce = (fieldMgrCMS->GetDetectorField() != nullptr);
   }
 
   // G4cout << " G4Transport:  field exerts force= " << fieldExertsForce
   //          << "  fieldMgr= " << fieldMgr << G4endl;
 
-  // Choose the calculation of the transportation: Field or not 
+  // Choose the calculation of the transportation: Field or not
   //
-  if( !fieldExertsForce ) 
+  if (!fieldExertsForce) {
+    G4double linearStepLength;
+    if (fShortStepOptimisation && (currentMinimumStep <= currentSafety)) {
+      // The Step is guaranteed to be taken
+      //
+      geometryStepLength = currentMinimumStep;
+      fGeometryLimitedStep = false;
+    } else {
+      //  Find whether the straight path intersects a volume
+      //
+      linearStepLength = fLinearNavigator->ComputeStep(startPosition, startMomentumDir, currentMinimumStep, newSafety);
+      // Remember last safety origin & value.
+      //
+      fPreviousSftOrigin = startPosition;
+      fPreviousSafety = newSafety;
+      // fpSafetyHelper->SetCurrentSafety( newSafety, startPosition);
+
+      // The safety at the initial point has been re-calculated:
+      //
+      currentSafety = newSafety;
+
+      fGeometryLimitedStep = (linearStepLength <= currentMinimumStep);
+      if (fGeometryLimitedStep) {
+        // The geometry limits the Step size (an intersection was found.)
+        geometryStepLength = linearStepLength;
+      } else {
+        // The full Step is taken.
+        geometryStepLength = currentMinimumStep;
+      }
+    }
+    endpointDistance = geometryStepLength;
+
+    // Calculate final position
+    //
+    fTransportEndPosition = startPosition + geometryStepLength * startMomentumDir;
+
+    // Momentum direction, energy and polarisation are unchanged by transport
+    //
+    fTransportEndMomentumDir = startMomentumDir;
+    fTransportEndKineticEnergy = track.GetKineticEnergy();
+    fTransportEndSpin = track.GetPolarization();
+    fParticleIsLooping = false;
+    fMomentumChanged = false;
+    fEndGlobalTimeComputed = false;
+  } else  //  A field exerts force
   {
-     G4double linearStepLength ;
-     if( fShortStepOptimisation && (currentMinimumStep <= currentSafety) )
-     {
-       // The Step is guaranteed to be taken
-       //
-       geometryStepLength   = currentMinimumStep ;
-       fGeometryLimitedStep = false ;
-     }
-     else
-     {
-       //  Find whether the straight path intersects a volume
-       //
-       linearStepLength = fLinearNavigator->ComputeStep( startPosition, 
-                                                         startMomentumDir,
-                                                         currentMinimumStep, 
-                                                         newSafety) ;
-       // Remember last safety origin & value.
-       //
-       fPreviousSftOrigin = startPosition ;
-       fPreviousSafety    = newSafety ; 
-       // fpSafetyHelper->SetCurrentSafety( newSafety, startPosition);
+    G4double momentumMagnitude = pParticle->GetTotalMomentum();
+    G4ThreeVector EndUnitMomentum;
+    G4double lengthAlongCurve;
+    G4double restMass = fParticleDef->GetPDGMass();
 
-       // The safety at the initial point has been re-calculated:
-       //
-       currentSafety = newSafety ;
-          
-       fGeometryLimitedStep= (linearStepLength <= currentMinimumStep); 
-       if( fGeometryLimitedStep )
-       {
-         // The geometry limits the Step size (an intersection was found.)
-         geometryStepLength   = linearStepLength ;
-       } 
-       else
-       {
-         // The full Step is taken.
-         geometryStepLength   = currentMinimumStep ;
-       }
-     }
-     endpointDistance = geometryStepLength ;
+    G4ChargeState chargeState(particleElectricCharge,  // The charge can change (dynamic)
+                              fParticleDef->GetPDGSpin(),
+                              0,                        //  Magnetic moment:  pParticleDef->GetMagneticMoment(),
+                              0,                        //  Electric Dipole moment - not in Particle Definition
+                              particleMagneticCharge);  // in Mev/c
 
-     // Calculate final position
-     //
-     fTransportEndPosition = startPosition+geometryStepLength*startMomentumDir ;
+    G4EquationOfMotion* equationOfMotion =
+        fFieldPropagator->GetChordFinder()->GetIntegrationDriver()->GetEquationOfMotion();
 
-     // Momentum direction, energy and polarisation are unchanged by transport
-     //
-     fTransportEndMomentumDir   = startMomentumDir ; 
-     fTransportEndKineticEnergy = track.GetKineticEnergy() ;
-     fTransportEndSpin          = track.GetPolarization();
-     fParticleIsLooping         = false ;
-     fMomentumChanged           = false ; 
-     fEndGlobalTimeComputed     = false ;
-  }
-  else   //  A field exerts force
-  {
-     G4double       momentumMagnitude = pParticle->GetTotalMomentum() ;
-     G4ThreeVector  EndUnitMomentum ;
-     G4double       lengthAlongCurve ;
-     G4double       restMass = fParticleDef->GetPDGMass() ;
+    equationOfMotion->SetChargeMomentumMass(chargeState,        //  Was particleMagneticCharge - in Mev/c
+                                            momentumMagnitude,  //  Was particleElectricCharge
+                                            restMass);
+    // SetChargeMomentumMass now passes both the electric and magnetic charge - in chargeState
 
-     G4ChargeState chargeState(particleElectricCharge,  // The charge can change (dynamic)
-                               fParticleDef->GetPDGSpin(),
-                               0,   //  Magnetic moment:  pParticleDef->GetMagneticMoment(),
-                               0,   //  Electric Dipole moment - not in Particle Definition 
-                               particleMagneticCharge );   // in Mev/c 
+    G4ThreeVector spin = track.GetPolarization();
+    G4FieldTrack aFieldTrack = G4FieldTrack(startPosition,
+                                            track.GetMomentumDirection(),
+                                            0.0,
+                                            track.GetKineticEnergy(),
+                                            restMass,
+                                            track.GetVelocity(),
+                                            track.GetGlobalTime(),  // Lab.
+                                            track.GetProperTime(),  // Part.
+                                            &spin);
+    if (currentMinimumStep > 0) {
+      // Do the Transport in the field (non recti-linear)
+      //
+      lengthAlongCurve =
+          fFieldPropagator->ComputeStep(aFieldTrack, currentMinimumStep, currentSafety, track.GetVolume());
+      fGeometryLimitedStep = lengthAlongCurve < currentMinimumStep;
+      if (fGeometryLimitedStep) {
+        geometryStepLength = lengthAlongCurve;
+      } else {
+        geometryStepLength = currentMinimumStep;
+      }
+    } else {
+      geometryStepLength = lengthAlongCurve = 0.0;
+      fGeometryLimitedStep = false;
+    }
 
-     G4EquationOfMotion* equationOfMotion = 
-       fFieldPropagator->GetChordFinder()->GetIntegrationDriver()->GetEquationOfMotion();
+    // Remember last safety origin & value.
+    //
+    fPreviousSftOrigin = startPosition;
+    fPreviousSafety = currentSafety;
+    // fpSafetyHelper->SetCurrentSafety( newSafety, startPosition);
 
-     equationOfMotion
-       ->SetChargeMomentumMass( chargeState,       //  Was particleMagneticCharge - in Mev/c
-                                momentumMagnitude, //  Was particleElectricCharge 
-                                restMass ) ;  
-     // SetChargeMomentumMass now passes both the electric and magnetic charge - in chargeState
+    // Get the End-Position and End-Momentum (Dir-ection)
+    //
+    fTransportEndPosition = aFieldTrack.GetPosition();
 
-     G4ThreeVector spin        = track.GetPolarization() ;
-     G4FieldTrack  aFieldTrack = G4FieldTrack( startPosition, 
-                                               track.GetMomentumDirection(),
-                                               0.0, 
-                                               track.GetKineticEnergy(),
-                                               restMass,
-                                               track.GetVelocity(),
-                                               track.GetGlobalTime(), // Lab.
-                                               track.GetProperTime(), // Part.
-                                               &spin                  ) ;
-     if( currentMinimumStep > 0 ) 
-     {
-        // Do the Transport in the field (non recti-linear)
-        //
-        lengthAlongCurve = fFieldPropagator->ComputeStep( aFieldTrack,
-                                                          currentMinimumStep, 
-                                                          currentSafety,
-                                                          track.GetVolume() ) ;
-        fGeometryLimitedStep= lengthAlongCurve < currentMinimumStep; 
-        if( fGeometryLimitedStep ) {
-           geometryStepLength   = lengthAlongCurve ;
-        } else {
-           geometryStepLength   = currentMinimumStep ;
-        }
-     }
-     else
-     {
-        geometryStepLength   = lengthAlongCurve= 0.0 ;
-        fGeometryLimitedStep = false ;
-     }
+    // Momentum:  Magnitude and direction can be changed too now ...
+    //
+    fMomentumChanged = true;
+    fTransportEndMomentumDir = aFieldTrack.GetMomentumDir();
 
-     // Remember last safety origin & value.
-     //
-     fPreviousSftOrigin = startPosition ;
-     fPreviousSafety    = currentSafety ;         
-     // fpSafetyHelper->SetCurrentSafety( newSafety, startPosition);
-       
-     // Get the End-Position and End-Momentum (Dir-ection)
-     //
-     fTransportEndPosition = aFieldTrack.GetPosition() ;
+    fTransportEndKineticEnergy = aFieldTrack.GetKineticEnergy();
 
-     // Momentum:  Magnitude and direction can be changed too now ...
-     //
-     fMomentumChanged         = true ; 
-     fTransportEndMomentumDir = aFieldTrack.GetMomentumDir() ;
+    fCandidateEndGlobalTime = aFieldTrack.GetLabTimeOfFlight();
+    fEndGlobalTimeComputed = true;
 
-     fTransportEndKineticEnergy  = aFieldTrack.GetKineticEnergy() ; 
-
-     fCandidateEndGlobalTime   = aFieldTrack.GetLabTimeOfFlight();
-     fEndGlobalTimeComputed    = true;
-
-     fTransportEndSpin = aFieldTrack.GetSpin();
-     fParticleIsLooping = fFieldPropagator->IsParticleLooping() ;
-     endpointDistance   = (fTransportEndPosition - startPosition).mag() ;
+    fTransportEndSpin = aFieldTrack.GetSpin();
+    fParticleIsLooping = fFieldPropagator->IsParticleLooping();
+    endpointDistance = (fTransportEndPosition - startPosition).mag();
   }
 
   // If we are asked to go a step length of 0, and we are on a boundary
   // then a boundary will also limit the step -> we must flag this.
   //
-  if( currentMinimumStep == 0.0 ) 
-  {
-      if( currentSafety == 0.0 )  fGeometryLimitedStep = true ;
+  if (currentMinimumStep == 0.0) {
+    if (currentSafety == 0.0)
+      fGeometryLimitedStep = true;
   }
 
   // Update the safety starting from the end-point,
   // if it will become negative at the end-point.
   //
-  if( currentSafety < endpointDistance ) 
-  {
-      if( particleMagneticCharge != 0.0 ) {
+  if (currentSafety < endpointDistance) {
+    if (particleMagneticCharge != 0.0) {
+      G4double endSafety = fLinearNavigator->ComputeSafety(fTransportEndPosition);
+      currentSafety = endSafety;
+      fPreviousSftOrigin = fTransportEndPosition;
+      fPreviousSafety = currentSafety;
+      fpSafetyHelper->SetCurrentSafety(currentSafety, fTransportEndPosition);
 
-         G4double endSafety =
-               fLinearNavigator->ComputeSafety( fTransportEndPosition) ;
-         currentSafety      = endSafety ;
-         fPreviousSftOrigin = fTransportEndPosition ;
-         fPreviousSafety    = currentSafety ; 
-         fpSafetyHelper->SetCurrentSafety( currentSafety, fTransportEndPosition);
+      // Because the Stepping Manager assumes it is from the start point,
+      //  add the StepLength
+      //
+      currentSafety += endpointDistance;
 
-         // Because the Stepping Manager assumes it is from the start point, 
-         //  add the StepLength
-         //
-         currentSafety     += endpointDistance ;
-
-#ifdef G4DEBUG_TRANSPORT 
-         G4cout.precision(12) ;
-         G4cout << "***MonopoleTransportation::AlongStepGPIL ** " << G4endl  ;
-         G4cout << "  Called Navigator->ComputeSafety at " << fTransportEndPosition
-                << "    and it returned safety= " << endSafety << G4endl ; 
-         G4cout << "  Adding endpoint distance " << endpointDistance 
-                << "   to obtain pseudo-safety= " << currentSafety << G4endl ; 
+#ifdef G4DEBUG_TRANSPORT
+      G4cout.precision(12);
+      G4cout << "***MonopoleTransportation::AlongStepGPIL ** " << G4endl;
+      G4cout << "  Called Navigator->ComputeSafety at " << fTransportEndPosition
+             << "    and it returned safety= " << endSafety << G4endl;
+      G4cout << "  Adding endpoint distance " << endpointDistance << "   to obtain pseudo-safety= " << currentSafety
+             << G4endl;
 #endif
-      }
-  }            
+    }
+  }
 
-  fParticleChange.ProposeTrueStepLength(geometryStepLength) ;
+  fParticleChange.ProposeTrueStepLength(geometryStepLength);
 
-  return geometryStepLength ;
+  return geometryStepLength;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -357,244 +329,207 @@ AlongStepGetPhysicalInteractionLength( const G4Track&  track,
 //   Initialize ParticleChange  (by setting all its members equal
 //                               to corresponding members in G4Track)
 
-G4VParticleChange* MonopoleTransportation::AlongStepDoIt( const G4Track& track,
-                                                          const G4Step&  stepData )
-{
-  fParticleChange.Initialize(track) ;
+G4VParticleChange* MonopoleTransportation::AlongStepDoIt(const G4Track& track, const G4Step& stepData) {
+  fParticleChange.Initialize(track);
 
-  //  Code for specific process 
+  //  Code for specific process
   //
-  fParticleChange.ProposePosition(fTransportEndPosition) ;
-  fParticleChange.ProposeMomentumDirection(fTransportEndMomentumDir) ;
-  fParticleChange.ProposeEnergy(fTransportEndKineticEnergy) ;
-  fParticleChange.SetMomentumChanged(fMomentumChanged) ;
+  fParticleChange.ProposePosition(fTransportEndPosition);
+  fParticleChange.ProposeMomentumDirection(fTransportEndMomentumDir);
+  fParticleChange.ProposeEnergy(fTransportEndKineticEnergy);
+  fParticleChange.SetMomentumChanged(fMomentumChanged);
 
   fParticleChange.ProposePolarization(fTransportEndSpin);
-  
-  G4double deltaTime = 0.0 ;
+
+  G4double deltaTime = 0.0;
 
   // Calculate  Lab Time of Flight (ONLY if field Equations used it!)
-  G4double startTime = track.GetGlobalTime() ;
-  
-  if (!fEndGlobalTimeComputed)
-  {
-     // The time was not integrated .. make the best estimate possible
-     //
-     G4double finalVelocity   = track.GetVelocity() ;
-     G4double initialVelocity = stepData.GetPreStepPoint()->GetVelocity() ;
-     G4double stepLength      = track.GetStepLength() ;
+  G4double startTime = track.GetGlobalTime();
 
-     deltaTime= 0.0;  // in case initialVelocity = 0 
-     if (finalVelocity > 0.0)
-     {
-        G4double meanInverseVelocity ;
-        meanInverseVelocity = 0.5
-                            * ( 1.0 / initialVelocity + 1.0 / finalVelocity ) ;
-        deltaTime = stepLength * meanInverseVelocity ;
-     }
-     else if( initialVelocity > 0.0 )
-     {
-        deltaTime = stepLength/initialVelocity ;
-     }
-     fCandidateEndGlobalTime   = startTime + deltaTime ;
-  }
-  else
-  {
-     deltaTime = fCandidateEndGlobalTime - startTime ;
+  if (!fEndGlobalTimeComputed) {
+    // The time was not integrated .. make the best estimate possible
+    //
+    G4double finalVelocity = track.GetVelocity();
+    G4double initialVelocity = stepData.GetPreStepPoint()->GetVelocity();
+    G4double stepLength = track.GetStepLength();
+
+    deltaTime = 0.0;  // in case initialVelocity = 0
+    if (finalVelocity > 0.0) {
+      G4double meanInverseVelocity;
+      meanInverseVelocity = 0.5 * (1.0 / initialVelocity + 1.0 / finalVelocity);
+      deltaTime = stepLength * meanInverseVelocity;
+    } else if (initialVelocity > 0.0) {
+      deltaTime = stepLength / initialVelocity;
+    }
+    fCandidateEndGlobalTime = startTime + deltaTime;
+  } else {
+    deltaTime = fCandidateEndGlobalTime - startTime;
   }
 
-  fParticleChange.ProposeGlobalTime( fCandidateEndGlobalTime ) ;
+  fParticleChange.ProposeGlobalTime(fCandidateEndGlobalTime);
 
   // Now Correct by Lorentz factor to get "proper" deltaTime
-  
-  G4double  restMass       = track.GetDynamicParticle()->GetMass() ;
-  G4double deltaProperTime = deltaTime*( restMass/track.GetTotalEnergy() ) ;
 
-  fParticleChange.ProposeProperTime(track.GetProperTime() + deltaProperTime) ;
+  G4double restMass = track.GetDynamicParticle()->GetMass();
+  G4double deltaProperTime = deltaTime * (restMass / track.GetTotalEnergy());
+
+  fParticleChange.ProposeProperTime(track.GetProperTime() + deltaProperTime);
   //fParticleChange. ProposeTrueStepLength( track.GetStepLength() ) ;
 
   // If the particle is caught looping or is stuck (in very difficult
-  // boundaries) in a magnetic field (doing many steps) 
+  // boundaries) in a magnetic field (doing many steps)
   //   THEN this kills it ...
   //
-  if ( fParticleIsLooping )
-  {
-      G4double endEnergy= fTransportEndKineticEnergy;
+  if (fParticleIsLooping) {
+    G4double endEnergy = fTransportEndKineticEnergy;
 
-      if( (endEnergy < fThreshold_Important_Energy) 
-          || (fNoLooperTrials >= fThresholdTrials ) ){
-        // Kill the looping particle 
-        //
-        fParticleChange.ProposeTrackStatus( fStopAndKill )  ;
+    if ((endEnergy < fThreshold_Important_Energy) || (fNoLooperTrials >= fThresholdTrials)) {
+      // Kill the looping particle
+      //
+      fParticleChange.ProposeTrackStatus(fStopAndKill);
 
-        // 'Bare' statistics
-        fSumEnergyKilled += endEnergy; 
-        if( endEnergy > fMaxEnergyKilled) { fMaxEnergyKilled= endEnergy; }
+      // 'Bare' statistics
+      fSumEnergyKilled += endEnergy;
+      if (endEnergy > fMaxEnergyKilled) {
+        fMaxEnergyKilled = endEnergy;
+      }
 
 #ifdef G4VERBOSE
-        if( (verboseLevel > 1) || 
-            ( endEnergy > fThreshold_Warning_Energy )  ) { 
-          G4cout << " MonopoleTransportation is killing track that is looping or stuck "
-                 << G4endl
-                 << "   This track has " << track.GetKineticEnergy() / MeV
-                 << " MeV energy." << G4endl;
-          G4cout << "   Number of trials = " << fNoLooperTrials 
-                 << "   No of calls to AlongStepDoIt = " << noCalls 
-                 << G4endl;
-        }
-#endif
-        fNoLooperTrials=0; 
+      if ((verboseLevel > 1) || (endEnergy > fThreshold_Warning_Energy)) {
+        G4cout << " MonopoleTransportation is killing track that is looping or stuck " << G4endl << "   This track has "
+               << track.GetKineticEnergy() / MeV << " MeV energy." << G4endl;
+        G4cout << "   Number of trials = " << fNoLooperTrials << "   No of calls to AlongStepDoIt = " << noCalls
+               << G4endl;
       }
-      else{
-        fNoLooperTrials ++; 
+#endif
+      fNoLooperTrials = 0;
+    } else {
+      fNoLooperTrials++;
 #ifdef G4VERBOSE
-        if( (verboseLevel > 2) ){
-          G4cout << "   MonopoleTransportation::AlongStepDoIt(): Particle looping -  "
-                 << "   Number of trials = " << fNoLooperTrials 
-                 << "   No of calls to  = " << noCalls 
-                 << G4endl;
-        }
-#endif
+      if ((verboseLevel > 2)) {
+        G4cout << "   MonopoleTransportation::AlongStepDoIt(): Particle looping -  "
+               << "   Number of trials = " << fNoLooperTrials << "   No of calls to  = " << noCalls << G4endl;
       }
-  }else{
-      fNoLooperTrials=0; 
+#endif
+    }
+  } else {
+    fNoLooperTrials = 0;
   }
 
   // Another (sometimes better way) is to use a user-limit maximum Step size
-  // to alleviate this problem .. 
+  // to alleviate this problem ..
 
   // Introduce smooth curved trajectories to particle-change
   //
-  fParticleChange.SetPointerToVectorOfAuxiliaryPoints
-    (fFieldPropagator->GimmeTrajectoryVectorAndForgetIt() );
+  fParticleChange.SetPointerToVectorOfAuxiliaryPoints(fFieldPropagator->GimmeTrajectoryVectorAndForgetIt());
 
-  return &fParticleChange ;
+  return &fParticleChange;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //
 //  This ensures that the PostStep action is always called,
 //  so that it can do the relocation if it is needed.
-// 
+//
 
-G4double MonopoleTransportation::
-PostStepGetPhysicalInteractionLength( const G4Track&,
-                                            G4double, // previousStepSize
-                                            G4ForceCondition* pForceCond )
-{  
-  *pForceCond = Forced ; 
-  return DBL_MAX ;  // was kInfinity ; but convention now is DBL_MAX
+G4double MonopoleTransportation::PostStepGetPhysicalInteractionLength(const G4Track&,
+                                                                      G4double,  // previousStepSize
+                                                                      G4ForceCondition* pForceCond) {
+  *pForceCond = Forced;
+  return DBL_MAX;  // was kInfinity ; but convention now is DBL_MAX
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4VParticleChange* MonopoleTransportation::PostStepDoIt( const G4Track& track,
-                                                   const G4Step& )
-{
-  G4TouchableHandle retCurrentTouchable ;   // The one to return
+G4VParticleChange* MonopoleTransportation::PostStepDoIt(const G4Track& track, const G4Step&) {
+  G4TouchableHandle retCurrentTouchable;  // The one to return
 
-  fParticleChange.ProposeTrackStatus(track.GetTrackStatus()) ;
+  fParticleChange.ProposeTrackStatus(track.GetTrackStatus());
 
   // If the Step was determined by the volume boundary,
   // logically relocate the particle
-  
-  if(fGeometryLimitedStep)
-  {  
-    // fCurrentTouchable will now become the previous touchable, 
+
+  if (fGeometryLimitedStep) {
+    // fCurrentTouchable will now become the previous touchable,
     // and what was the previous will be freed.
     // (Needed because the preStepPoint can point to the previous touchable)
 
-    fLinearNavigator->SetGeometricallyLimitedStep() ;
-    fLinearNavigator->
-    LocateGlobalPointAndUpdateTouchableHandle( track.GetPosition(),
-                                               track.GetMomentumDirection(),
-                                               fCurrentTouchableHandle,
-                                               true                      ) ;
-    // Check whether the particle is out of the world volume 
+    fLinearNavigator->SetGeometricallyLimitedStep();
+    fLinearNavigator->LocateGlobalPointAndUpdateTouchableHandle(
+        track.GetPosition(), track.GetMomentumDirection(), fCurrentTouchableHandle, true);
+    // Check whether the particle is out of the world volume
     // If so it has exited and must be killed.
     //
-    if( fCurrentTouchableHandle->GetVolume() == nullptr )
-    {
-       fParticleChange.ProposeTrackStatus( fStopAndKill ) ;
+    if (fCurrentTouchableHandle->GetVolume() == nullptr) {
+      fParticleChange.ProposeTrackStatus(fStopAndKill);
     }
-    retCurrentTouchable = fCurrentTouchableHandle ;
-    fParticleChange.SetTouchableHandle( fCurrentTouchableHandle ) ;
-  }
-  else                 // fGeometryLimitedStep  is false
-  {                    
+    retCurrentTouchable = fCurrentTouchableHandle;
+    fParticleChange.SetTouchableHandle(fCurrentTouchableHandle);
+  } else  // fGeometryLimitedStep  is false
+  {
     // This serves only to move the Navigator's location
     //
-    fLinearNavigator->LocateGlobalPointWithinVolume( track.GetPosition() ) ;
+    fLinearNavigator->LocateGlobalPointWithinVolume(track.GetPosition());
 
-    // The value of the track's current Touchable is retained. 
+    // The value of the track's current Touchable is retained.
     // (and it must be correct because we must use it below to
     // overwrite the (unset) one in particle change)
     //  It must be fCurrentTouchable too ??
     //
-    fParticleChange.SetTouchableHandle( track.GetTouchableHandle() ) ;
-    retCurrentTouchable = track.GetTouchableHandle() ;
-  }         // endif ( fGeometryLimitedStep ) 
+    fParticleChange.SetTouchableHandle(track.GetTouchableHandle());
+    retCurrentTouchable = track.GetTouchableHandle();
+  }  // endif ( fGeometryLimitedStep )
 
-  const G4VPhysicalVolume* pNewVol = retCurrentTouchable->GetVolume() ;
-  const G4Material* pNewMaterial   = nullptr ;
-  const G4VSensitiveDetector* pNewSensitiveDetector   = nullptr ;
-                                                                                       
-  if( pNewVol != nullptr )
-  {
-    pNewMaterial= pNewVol->GetLogicalVolume()->GetMaterial();
-    pNewSensitiveDetector= pNewVol->GetLogicalVolume()->GetSensitiveDetector();
+  const G4VPhysicalVolume* pNewVol = retCurrentTouchable->GetVolume();
+  const G4Material* pNewMaterial = nullptr;
+  const G4VSensitiveDetector* pNewSensitiveDetector = nullptr;
+
+  if (pNewVol != nullptr) {
+    pNewMaterial = pNewVol->GetLogicalVolume()->GetMaterial();
+    pNewSensitiveDetector = pNewVol->GetLogicalVolume()->GetSensitiveDetector();
   }
 
-  fParticleChange.SetMaterialInTouchable( 
-                     (G4Material *) pNewMaterial ) ;
-  fParticleChange.SetSensitiveDetectorInTouchable( 
-                     (G4VSensitiveDetector *) pNewSensitiveDetector ) ;
+  fParticleChange.SetMaterialInTouchable((G4Material*)pNewMaterial);
+  fParticleChange.SetSensitiveDetectorInTouchable((G4VSensitiveDetector*)pNewSensitiveDetector);
 
   const G4MaterialCutsCouple* pNewMaterialCutsCouple = nullptr;
-  if( pNewVol != nullptr )
-  {
-    pNewMaterialCutsCouple=pNewVol->GetLogicalVolume()->GetMaterialCutsCouple();
+  if (pNewVol != nullptr) {
+    pNewMaterialCutsCouple = pNewVol->GetLogicalVolume()->GetMaterialCutsCouple();
   }
 
-  if( pNewVol!=nullptr && pNewMaterialCutsCouple!=nullptr && 
-      pNewMaterialCutsCouple->GetMaterial()!=pNewMaterial )
-  {
+  if (pNewVol != nullptr && pNewMaterialCutsCouple != nullptr &&
+      pNewMaterialCutsCouple->GetMaterial() != pNewMaterial) {
     // for parametrized volume
     //
-    pNewMaterialCutsCouple =
-      G4ProductionCutsTable::GetProductionCutsTable()
-                             ->GetMaterialCutsCouple(pNewMaterial,
-                               pNewMaterialCutsCouple->GetProductionCuts());
+    pNewMaterialCutsCouple = G4ProductionCutsTable::GetProductionCutsTable()->GetMaterialCutsCouple(
+        pNewMaterial, pNewMaterialCutsCouple->GetProductionCuts());
   }
-  fParticleChange.SetMaterialCutsCoupleInTouchable( pNewMaterialCutsCouple );
+  fParticleChange.SetMaterialCutsCoupleInTouchable(pNewMaterialCutsCouple);
 
-  // temporarily until Get/Set Material of ParticleChange, 
-  // and StepPoint can be made const. 
+  // temporarily until Get/Set Material of ParticleChange,
+  // and StepPoint can be made const.
   // Set the touchable in ParticleChange
   // this must always be done because the particle change always
   // uses this value to overwrite the current touchable pointer.
   //
-  fParticleChange.SetTouchableHandle(retCurrentTouchable) ;
+  fParticleChange.SetTouchableHandle(retCurrentTouchable);
 
   // change to normal equation
   fieldMgrCMS->SetMonopoleTracking(false);
-  
-  return &fParticleChange ;
+
+  return &fParticleChange;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-// New method takes over the responsibility to reset the state 
-// of MonopoleTransportation object at the start of a new track 
-// or the resumption of a suspended track. 
+// New method takes over the responsibility to reset the state
+// of MonopoleTransportation object at the start of a new track
+// or the resumption of a suspended track.
 
-void 
-MonopoleTransportation::StartTracking(G4Track* aTrack)
-{
+void MonopoleTransportation::StartTracking(G4Track* aTrack) {
   // initialise pointer
-  if(!fieldMgrCMS) {
-    G4FieldManager* fieldMgr = 
-      fFieldPropagator->FindAndSetFieldManager(aTrack->GetVolume()); 
+  if (!fieldMgrCMS) {
+    G4FieldManager* fieldMgr = fFieldPropagator->FindAndSetFieldManager(aTrack->GetVolume());
     fieldMgrCMS = static_cast<CMSFieldManager*>(fieldMgr);
   }
 
@@ -605,27 +540,28 @@ MonopoleTransportation::StartTracking(G4Track* aTrack)
 
   // reset safety value and center
   //
-  fPreviousSafety    = 0.0 ; 
-  fPreviousSftOrigin = G4ThreeVector(0.,0.,0.) ;
-  
+  fPreviousSafety = 0.0;
+  fPreviousSftOrigin = G4ThreeVector(0., 0., 0.);
+
   // reset looping counter -- for motion in field
-  fNoLooperTrials= 0; 
+  fNoLooperTrials = 0;
   // Must clear this state .. else it depends on last track's value
 
   // ChordFinder reset internal state
   //
-  if( DoesGlobalFieldExist() ) {
-     fFieldPropagator->ClearPropagatorState();   
-       // Resets all state of field propagator class (ONLY)
-       //  including safety values (in case of overlaps and to wipe for first track).
+  if (DoesGlobalFieldExist()) {
+    fFieldPropagator->ClearPropagatorState();
+    // Resets all state of field propagator class (ONLY)
+    //  including safety values (in case of overlaps and to wipe for first track).
 
-     G4ChordFinder* chordF= fFieldPropagator->GetChordFinder();
-     if( chordF ) chordF->ResetStepEstimate();
+    G4ChordFinder* chordF = fFieldPropagator->GetChordFinder();
+    if (chordF)
+      chordF->ResetStepEstimate();
   }
 
   // Make sure to clear the chord finders of all fields (ie managers)
-  G4FieldManagerStore* fieldMgrStore= G4FieldManagerStore::GetInstance();
-  fieldMgrStore->ClearAllChordFindersState(); 
+  G4FieldManagerStore* fieldMgrStore = G4FieldManagerStore::GetInstance();
+  fieldMgrStore->ClearAllChordFindersState();
 
   // Update the current touchable handle  (from the track's)
   //
@@ -634,35 +570,25 @@ MonopoleTransportation::StartTracking(G4Track* aTrack)
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double MonopoleTransportation::AtRestGetPhysicalInteractionLength(
-                             const G4Track& ,
-                             G4ForceCondition*) 
-{ 
-  return -1.0; 
-}
+G4double MonopoleTransportation::AtRestGetPhysicalInteractionLength(const G4Track&, G4ForceCondition*) { return -1.0; }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4VParticleChange* MonopoleTransportation::AtRestDoIt(const G4Track&,
-                                                      const G4Step&)
-{
-  return nullptr;
-}
+G4VParticleChange* MonopoleTransportation::AtRestDoIt(const G4Track&, const G4Step&) { return nullptr; }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void MonopoleTransportation::ResetKilledStatistics(G4int report)
 // Statistics for tracks killed (currently due to looping in field)
 {
-  if( report ) { 
+  if (report) {
     G4cout << " MonopoleTransportation: Statistics for looping particles " << G4endl;
-    G4cout << "   Sum of energy of loopers killed: " <<  fSumEnergyKilled << G4endl;
-    G4cout << "   Max energy of loopers killed: " <<  fMaxEnergyKilled << G4endl;
-  } 
+    G4cout << "   Sum of energy of loopers killed: " << fSumEnergyKilled << G4endl;
+    G4cout << "   Max energy of loopers killed: " << fMaxEnergyKilled << G4endl;
+  }
 
-  fSumEnergyKilled= 0;
-  fMaxEnergyKilled= -1.0*CLHEP::GeV;
+  fSumEnergyKilled = 0;
+  fMaxEnergyKilled = -1.0 * CLHEP::GeV;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-

--- a/SimG4Core/PhysicsLists/src/UrbanMscModel93.cc
+++ b/SimG4Core/PhysicsLists/src/UrbanMscModel93.cc
@@ -1,14 +1,14 @@
 // -------------------------------------------------------------------
-//   
+//
 // GEANT4 Class file
-//    
+//
 //
 // File name:   UrbanMscModel93
 //
-// Original author:    Laszlo Urban, 
+// Original author:    Laszlo Urban,
 //
 //    V.Ivanchenko have copied from G4UrbanMscModel93 class
-//                 of Geant4 global tag geant4-09-06-ref-07 
+//                 of Geant4 global tag geant4-09-06-ref-07
 //                 and have adopted to CMSSW
 //
 // -------------------------------------------------------------------
@@ -36,66 +36,63 @@ static const G4double kappa = 2.5;
 static const G4double kappapl1 = 3.5;
 static const G4double kappami1 = 1.5;
 
-UrbanMscModel93::UrbanMscModel93(const G4String& nam)
-  : G4VMscModel(nam)
-{
-  masslimite    = 0.6*MeV;
-  lambdalimit   = 1.*mm;
-  fr            = 0.02;
-  taubig        = 8.0;
-  tausmall      = 1.e-16;
-  taulim        = 1.e-6;
-  currentTau    = taulim;
-  tlimitminfix  = 1.e-6*mm;            
-  stepmin       = tlimitminfix;
-  smallstep     = 1.e10;
-  currentRange  = 0. ;
-  rangeinit     = 0.;
-  tlimit        = 1.e10*mm;
-  tlimitmin     = 10.*tlimitminfix;            
-  tgeom         = 1.e50*mm;
-  geombig       = 1.e50*mm;
-  geommin       = 1.e-3*mm;
-  geomlimit     = geombig;
-  presafety     = 0.*mm;
-                          
-  y             = 0.;
+UrbanMscModel93::UrbanMscModel93(const G4String& nam) : G4VMscModel(nam) {
+  masslimite = 0.6 * MeV;
+  lambdalimit = 1. * mm;
+  fr = 0.02;
+  taubig = 8.0;
+  tausmall = 1.e-16;
+  taulim = 1.e-6;
+  currentTau = taulim;
+  tlimitminfix = 1.e-6 * mm;
+  stepmin = tlimitminfix;
+  smallstep = 1.e10;
+  currentRange = 0.;
+  rangeinit = 0.;
+  tlimit = 1.e10 * mm;
+  tlimitmin = 10. * tlimitminfix;
+  tgeom = 1.e50 * mm;
+  geombig = 1.e50 * mm;
+  geommin = 1.e-3 * mm;
+  geomlimit = geombig;
+  presafety = 0. * mm;
 
-  Zold          = 0.;
-  Zeff          = 1.;
-  Z2            = 1.;                
-  Z23           = 1.;                    
-  lnZ           = 0.;
-  coeffth1      = 0.;
-  coeffth2      = 0.;
-  coeffc1       = 0.;
-  coeffc2       = 0.;
-  scr1ini       = fine_structure_const*fine_structure_const*
-                  electron_mass_c2*electron_mass_c2/(0.885*0.885*4.*pi);
-  scr2ini       = 3.76*fine_structure_const*fine_structure_const;
-  scr1          = 0.;
-  scr2          = 0.;
+  y = 0.;
 
-  theta0max     = pi/6.;
-  rellossmax    = 0.50;
-  third         = 1./3.;
-  particle      = nullptr;
-  theManager    = G4LossTableManager::Instance(); 
-  firstStep     = true; 
-  inside        = false;  
-  insideskin    = false;
+  Zold = 0.;
+  Zeff = 1.;
+  Z2 = 1.;
+  Z23 = 1.;
+  lnZ = 0.;
+  coeffth1 = 0.;
+  coeffth2 = 0.;
+  coeffc1 = 0.;
+  coeffc2 = 0.;
+  scr1ini =
+      fine_structure_const * fine_structure_const * electron_mass_c2 * electron_mass_c2 / (0.885 * 0.885 * 4. * pi);
+  scr2ini = 3.76 * fine_structure_const * fine_structure_const;
+  scr1 = 0.;
+  scr2 = 0.;
 
-  numlim        = 0.01;
-  xsi           = 3.;
-  ea            = G4Exp(-xsi);
-  eaa           = 1.-ea ;
+  theta0max = pi / 6.;
+  rellossmax = 0.50;
+  third = 1. / 3.;
+  particle = nullptr;
+  theManager = G4LossTableManager::Instance();
+  firstStep = true;
+  inside = false;
+  insideskin = false;
 
-  skindepth = skin*stepmin;
+  numlim = 0.01;
+  xsi = 3.;
+  ea = G4Exp(-xsi);
+  eaa = 1. - ea;
+
+  skindepth = skin * stepmin;
 
   mass = proton_mass_c2;
   charge = ChargeSquare = 1.0;
-  currentKinEnergy = currentRadLength = lambda0 = lambdaeff = tPathLength 
-    = zPathLength = par1 = par2 = par3 = 0;
+  currentKinEnergy = currentRadLength = lambda0 = lambdaeff = tPathLength = zPathLength = par1 = par2 = par3 = 0;
 
   currentMaterialIndex = -1;
   fParticleChange = nullptr;
@@ -105,24 +102,19 @@ UrbanMscModel93::UrbanMscModel93(const G4String& nam)
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-UrbanMscModel93::~UrbanMscModel93()
-{}
+UrbanMscModel93::~UrbanMscModel93() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void UrbanMscModel93::Initialise(const G4ParticleDefinition* p,
-				 const G4DataVector&)
-{
-  skindepth = skin*stepmin;
+void UrbanMscModel93::Initialise(const G4ParticleDefinition* p, const G4DataVector&) {
+  skindepth = skin * stepmin;
 
   // set values of some data members
   SetParticle(p);
 
-  if(p->GetPDGMass() > MeV) {
-    G4cout << "### WARNING: UrbanMscModel93 model is used for " 
-	   << p->GetParticleName() << " !!! " << G4endl;
-    G4cout << "###          This model should be used only for e+-" 
-	   << G4endl;
+  if (p->GetPDGMass() > MeV) {
+    G4cout << "### WARNING: UrbanMscModel93 model is used for " << p->GetParticleName() << " !!! " << G4endl;
+    G4cout << "###          This model should be used only for e+-" << G4endl;
   }
 
   fParticleChange = GetParticleChangeForMSC(p);
@@ -130,145 +122,113 @@ void UrbanMscModel93::Initialise(const G4ParticleDefinition* p,
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double UrbanMscModel93::ComputeCrossSectionPerAtom( 
-                             const G4ParticleDefinition* part,
-                                   G4double KineticEnergy,
-                                   G4double AtomicNumber,G4double,
-				   G4double, G4double)
-{
-  static const G4double sigmafactor = 
-    twopi*classic_electr_radius*classic_electr_radius;
-  static const G4double epsfactor = 2.*electron_mass_c2*electron_mass_c2*
-                            Bohr_radius*Bohr_radius/(hbarc*hbarc);
-  static const G4double epsmin = 1.e-4 , epsmax = 1.e10;
+G4double UrbanMscModel93::ComputeCrossSectionPerAtom(
+    const G4ParticleDefinition* part, G4double KineticEnergy, G4double AtomicNumber, G4double, G4double, G4double) {
+  static const G4double sigmafactor = twopi * classic_electr_radius * classic_electr_radius;
+  static const G4double epsfactor =
+      2. * electron_mass_c2 * electron_mass_c2 * Bohr_radius * Bohr_radius / (hbarc * hbarc);
+  static const G4double epsmin = 1.e-4, epsmax = 1.e10;
 
-  static const G4double Zdat[15] = { 4.,  6., 13., 20., 26., 29., 32., 38., 47.,
-				     50., 56., 64., 74., 79., 82. };
+  static const G4double Zdat[15] = {4., 6., 13., 20., 26., 29., 32., 38., 47., 50., 56., 64., 74., 79., 82.};
 
-  static const G4double Tdat[22] = { 100*eV,  200*eV,  400*eV,  700*eV,
-				     1*keV,   2*keV,   4*keV,   7*keV,
-				     10*keV,  20*keV,  40*keV,  70*keV,
-				     100*keV, 200*keV, 400*keV, 700*keV,
-				     1*MeV,   2*MeV,   4*MeV,   7*MeV,
-				     10*MeV,  20*MeV};
+  static const G4double Tdat[22] = {100 * eV, 200 * eV, 400 * eV, 700 * eV, 1 * keV,   2 * keV,   4 * keV,   7 * keV,
+                                    10 * keV, 20 * keV, 40 * keV, 70 * keV, 100 * keV, 200 * keV, 400 * keV, 700 * keV,
+                                    1 * MeV,  2 * MeV,  4 * MeV,  7 * MeV,  10 * MeV,  20 * MeV};
 
   // corr. factors for e-/e+ lambda for T <= Tlim
-  static const G4double celectron[15][22] =
-          {{1.125,1.072,1.051,1.047,1.047,1.050,1.052,1.054,
-            1.054,1.057,1.062,1.069,1.075,1.090,1.105,1.111,
-            1.112,1.108,1.100,1.093,1.089,1.087            },
-           {1.408,1.246,1.143,1.096,1.077,1.059,1.053,1.051,
-            1.052,1.053,1.058,1.065,1.072,1.087,1.101,1.108,
-            1.109,1.105,1.097,1.090,1.086,1.082            },
-           {2.833,2.268,1.861,1.612,1.486,1.309,1.204,1.156,
-            1.136,1.114,1.106,1.106,1.109,1.119,1.129,1.132,
-            1.131,1.124,1.113,1.104,1.099,1.098            },
-           {3.879,3.016,2.380,2.007,1.818,1.535,1.340,1.236,
-            1.190,1.133,1.107,1.099,1.098,1.103,1.110,1.113,
-            1.112,1.105,1.096,1.089,1.085,1.098            },
-           {6.937,4.330,2.886,2.256,1.987,1.628,1.395,1.265,
-            1.203,1.122,1.080,1.065,1.061,1.063,1.070,1.073,
-            1.073,1.070,1.064,1.059,1.056,1.056            },
-           {9.616,5.708,3.424,2.551,2.204,1.762,1.485,1.330,
-            1.256,1.155,1.099,1.077,1.070,1.068,1.072,1.074,
-            1.074,1.070,1.063,1.059,1.056,1.052            },
-           {11.72,6.364,3.811,2.806,2.401,1.884,1.564,1.386,
-            1.300,1.180,1.112,1.082,1.073,1.066,1.068,1.069,
-            1.068,1.064,1.059,1.054,1.051,1.050            },
-           {18.08,8.601,4.569,3.183,2.662,2.025,1.646,1.439,
-            1.339,1.195,1.108,1.068,1.053,1.040,1.039,1.039,
-            1.039,1.037,1.034,1.031,1.030,1.036            },
-           {18.22,10.48,5.333,3.713,3.115,2.367,1.898,1.631,
-            1.498,1.301,1.171,1.105,1.077,1.048,1.036,1.033,
-            1.031,1.028,1.024,1.022,1.021,1.024            },
-           {14.14,10.65,5.710,3.929,3.266,2.453,1.951,1.669,
-            1.528,1.319,1.178,1.106,1.075,1.040,1.027,1.022,
-            1.020,1.017,1.015,1.013,1.013,1.020            },
-           {14.11,11.73,6.312,4.240,3.478,2.566,2.022,1.720,
-            1.569,1.342,1.186,1.102,1.065,1.022,1.003,0.997,
-            0.995,0.993,0.993,0.993,0.993,1.011            },
-           {22.76,20.01,8.835,5.287,4.144,2.901,2.219,1.855,
-            1.677,1.410,1.224,1.121,1.073,1.014,0.986,0.976,
-            0.974,0.972,0.973,0.974,0.975,0.987            },
-           {50.77,40.85,14.13,7.184,5.284,3.435,2.520,2.059,
-            1.837,1.512,1.283,1.153,1.091,1.010,0.969,0.954,
-            0.950,0.947,0.949,0.952,0.954,0.963            },
-           {65.87,59.06,15.87,7.570,5.567,3.650,2.682,2.182,
-            1.939,1.579,1.325,1.178,1.108,1.014,0.965,0.947,
-            0.941,0.938,0.940,0.944,0.946,0.954            },
-           {55.60,47.34,15.92,7.810,5.755,3.767,2.760,2.239,
-            1.985,1.609,1.343,1.188,1.113,1.013,0.960,0.939,
-            0.933,0.930,0.933,0.936,0.939,0.949            }};
-	    
+  static const G4double celectron[15][22] = {
+      {1.125, 1.072, 1.051, 1.047, 1.047, 1.050, 1.052, 1.054, 1.054, 1.057, 1.062,
+       1.069, 1.075, 1.090, 1.105, 1.111, 1.112, 1.108, 1.100, 1.093, 1.089, 1.087},
+      {1.408, 1.246, 1.143, 1.096, 1.077, 1.059, 1.053, 1.051, 1.052, 1.053, 1.058,
+       1.065, 1.072, 1.087, 1.101, 1.108, 1.109, 1.105, 1.097, 1.090, 1.086, 1.082},
+      {2.833, 2.268, 1.861, 1.612, 1.486, 1.309, 1.204, 1.156, 1.136, 1.114, 1.106,
+       1.106, 1.109, 1.119, 1.129, 1.132, 1.131, 1.124, 1.113, 1.104, 1.099, 1.098},
+      {3.879, 3.016, 2.380, 2.007, 1.818, 1.535, 1.340, 1.236, 1.190, 1.133, 1.107,
+       1.099, 1.098, 1.103, 1.110, 1.113, 1.112, 1.105, 1.096, 1.089, 1.085, 1.098},
+      {6.937, 4.330, 2.886, 2.256, 1.987, 1.628, 1.395, 1.265, 1.203, 1.122, 1.080,
+       1.065, 1.061, 1.063, 1.070, 1.073, 1.073, 1.070, 1.064, 1.059, 1.056, 1.056},
+      {9.616, 5.708, 3.424, 2.551, 2.204, 1.762, 1.485, 1.330, 1.256, 1.155, 1.099,
+       1.077, 1.070, 1.068, 1.072, 1.074, 1.074, 1.070, 1.063, 1.059, 1.056, 1.052},
+      {11.72, 6.364, 3.811, 2.806, 2.401, 1.884, 1.564, 1.386, 1.300, 1.180, 1.112,
+       1.082, 1.073, 1.066, 1.068, 1.069, 1.068, 1.064, 1.059, 1.054, 1.051, 1.050},
+      {18.08, 8.601, 4.569, 3.183, 2.662, 2.025, 1.646, 1.439, 1.339, 1.195, 1.108,
+       1.068, 1.053, 1.040, 1.039, 1.039, 1.039, 1.037, 1.034, 1.031, 1.030, 1.036},
+      {18.22, 10.48, 5.333, 3.713, 3.115, 2.367, 1.898, 1.631, 1.498, 1.301, 1.171,
+       1.105, 1.077, 1.048, 1.036, 1.033, 1.031, 1.028, 1.024, 1.022, 1.021, 1.024},
+      {14.14, 10.65, 5.710, 3.929, 3.266, 2.453, 1.951, 1.669, 1.528, 1.319, 1.178,
+       1.106, 1.075, 1.040, 1.027, 1.022, 1.020, 1.017, 1.015, 1.013, 1.013, 1.020},
+      {14.11, 11.73, 6.312, 4.240, 3.478, 2.566, 2.022, 1.720, 1.569, 1.342, 1.186,
+       1.102, 1.065, 1.022, 1.003, 0.997, 0.995, 0.993, 0.993, 0.993, 0.993, 1.011},
+      {22.76, 20.01, 8.835, 5.287, 4.144, 2.901, 2.219, 1.855, 1.677, 1.410, 1.224,
+       1.121, 1.073, 1.014, 0.986, 0.976, 0.974, 0.972, 0.973, 0.974, 0.975, 0.987},
+      {50.77, 40.85, 14.13, 7.184, 5.284, 3.435, 2.520, 2.059, 1.837, 1.512, 1.283,
+       1.153, 1.091, 1.010, 0.969, 0.954, 0.950, 0.947, 0.949, 0.952, 0.954, 0.963},
+      {65.87, 59.06, 15.87, 7.570, 5.567, 3.650, 2.682, 2.182, 1.939, 1.579, 1.325,
+       1.178, 1.108, 1.014, 0.965, 0.947, 0.941, 0.938, 0.940, 0.944, 0.946, 0.954},
+      {55.60, 47.34, 15.92, 7.810, 5.755, 3.767, 2.760, 2.239, 1.985, 1.609, 1.343,
+       1.188, 1.113, 1.013, 0.960, 0.939, 0.933, 0.930, 0.933, 0.936, 0.939, 0.949}};
+
   static const G4double cpositron[15][22] = {
-           {2.589,2.044,1.658,1.446,1.347,1.217,1.144,1.110,
-            1.097,1.083,1.080,1.086,1.092,1.108,1.123,1.131,
-            1.131,1.126,1.117,1.108,1.103,1.100            },
-           {3.904,2.794,2.079,1.710,1.543,1.325,1.202,1.145,
-            1.122,1.096,1.089,1.092,1.098,1.114,1.130,1.137,
-            1.138,1.132,1.122,1.113,1.108,1.102            },
-           {7.970,6.080,4.442,3.398,2.872,2.127,1.672,1.451,
-            1.357,1.246,1.194,1.179,1.178,1.188,1.201,1.205,
-            1.203,1.190,1.173,1.159,1.151,1.145            },
-           {9.714,7.607,5.747,4.493,3.815,2.777,2.079,1.715,
-            1.553,1.353,1.253,1.219,1.211,1.214,1.225,1.228,
-            1.225,1.210,1.191,1.175,1.166,1.174            },
-           {17.97,12.95,8.628,6.065,4.849,3.222,2.275,1.820,
-            1.624,1.382,1.259,1.214,1.202,1.202,1.214,1.219,
-            1.217,1.203,1.184,1.169,1.160,1.151            },
-           {24.83,17.06,10.84,7.355,5.767,3.707,2.546,1.996,
-            1.759,1.465,1.311,1.252,1.234,1.228,1.238,1.241,
-            1.237,1.222,1.201,1.184,1.174,1.159            },
-           {23.26,17.15,11.52,8.049,6.375,4.114,2.792,2.155,
-            1.880,1.535,1.353,1.281,1.258,1.247,1.254,1.256,
-            1.252,1.234,1.212,1.194,1.183,1.170            },
-           {22.33,18.01,12.86,9.212,7.336,4.702,3.117,2.348,
-            2.015,1.602,1.385,1.297,1.268,1.251,1.256,1.258,
-            1.254,1.237,1.214,1.195,1.185,1.179            },
-           {33.91,24.13,15.71,10.80,8.507,5.467,3.692,2.808,
-            2.407,1.873,1.564,1.425,1.374,1.330,1.324,1.320,
-            1.312,1.288,1.258,1.235,1.221,1.205            },
-           {32.14,24.11,16.30,11.40,9.015,5.782,3.868,2.917,
-            2.490,1.925,1.596,1.447,1.391,1.342,1.332,1.327,
-            1.320,1.294,1.264,1.240,1.226,1.214            },
-           {29.51,24.07,17.19,12.28,9.766,6.238,4.112,3.066,
-            2.602,1.995,1.641,1.477,1.414,1.356,1.342,1.336,
-            1.328,1.302,1.270,1.245,1.231,1.233            },
-           {38.19,30.85,21.76,15.35,12.07,7.521,4.812,3.498,
-            2.926,2.188,1.763,1.563,1.484,1.405,1.382,1.371,
-            1.361,1.330,1.294,1.267,1.251,1.239            },
-           {49.71,39.80,27.96,19.63,15.36,9.407,5.863,4.155,
-            3.417,2.478,1.944,1.692,1.589,1.480,1.441,1.423,
-            1.409,1.372,1.330,1.298,1.280,1.258            },
-           {59.25,45.08,30.36,20.83,16.15,9.834,6.166,4.407,
-            3.641,2.648,2.064,1.779,1.661,1.531,1.482,1.459,
-            1.442,1.400,1.354,1.319,1.299,1.272            },
-           {56.38,44.29,30.50,21.18,16.51,10.11,6.354,4.542,
-            3.752,2.724,2.116,1.817,1.692,1.554,1.499,1.474,
-            1.456,1.412,1.364,1.328,1.307,1.282            }};
+      {2.589, 2.044, 1.658, 1.446, 1.347, 1.217, 1.144, 1.110, 1.097, 1.083, 1.080,
+       1.086, 1.092, 1.108, 1.123, 1.131, 1.131, 1.126, 1.117, 1.108, 1.103, 1.100},
+      {3.904, 2.794, 2.079, 1.710, 1.543, 1.325, 1.202, 1.145, 1.122, 1.096, 1.089,
+       1.092, 1.098, 1.114, 1.130, 1.137, 1.138, 1.132, 1.122, 1.113, 1.108, 1.102},
+      {7.970, 6.080, 4.442, 3.398, 2.872, 2.127, 1.672, 1.451, 1.357, 1.246, 1.194,
+       1.179, 1.178, 1.188, 1.201, 1.205, 1.203, 1.190, 1.173, 1.159, 1.151, 1.145},
+      {9.714, 7.607, 5.747, 4.493, 3.815, 2.777, 2.079, 1.715, 1.553, 1.353, 1.253,
+       1.219, 1.211, 1.214, 1.225, 1.228, 1.225, 1.210, 1.191, 1.175, 1.166, 1.174},
+      {17.97, 12.95, 8.628, 6.065, 4.849, 3.222, 2.275, 1.820, 1.624, 1.382, 1.259,
+       1.214, 1.202, 1.202, 1.214, 1.219, 1.217, 1.203, 1.184, 1.169, 1.160, 1.151},
+      {24.83, 17.06, 10.84, 7.355, 5.767, 3.707, 2.546, 1.996, 1.759, 1.465, 1.311,
+       1.252, 1.234, 1.228, 1.238, 1.241, 1.237, 1.222, 1.201, 1.184, 1.174, 1.159},
+      {23.26, 17.15, 11.52, 8.049, 6.375, 4.114, 2.792, 2.155, 1.880, 1.535, 1.353,
+       1.281, 1.258, 1.247, 1.254, 1.256, 1.252, 1.234, 1.212, 1.194, 1.183, 1.170},
+      {22.33, 18.01, 12.86, 9.212, 7.336, 4.702, 3.117, 2.348, 2.015, 1.602, 1.385,
+       1.297, 1.268, 1.251, 1.256, 1.258, 1.254, 1.237, 1.214, 1.195, 1.185, 1.179},
+      {33.91, 24.13, 15.71, 10.80, 8.507, 5.467, 3.692, 2.808, 2.407, 1.873, 1.564,
+       1.425, 1.374, 1.330, 1.324, 1.320, 1.312, 1.288, 1.258, 1.235, 1.221, 1.205},
+      {32.14, 24.11, 16.30, 11.40, 9.015, 5.782, 3.868, 2.917, 2.490, 1.925, 1.596,
+       1.447, 1.391, 1.342, 1.332, 1.327, 1.320, 1.294, 1.264, 1.240, 1.226, 1.214},
+      {29.51, 24.07, 17.19, 12.28, 9.766, 6.238, 4.112, 3.066, 2.602, 1.995, 1.641,
+       1.477, 1.414, 1.356, 1.342, 1.336, 1.328, 1.302, 1.270, 1.245, 1.231, 1.233},
+      {38.19, 30.85, 21.76, 15.35, 12.07, 7.521, 4.812, 3.498, 2.926, 2.188, 1.763,
+       1.563, 1.484, 1.405, 1.382, 1.371, 1.361, 1.330, 1.294, 1.267, 1.251, 1.239},
+      {49.71, 39.80, 27.96, 19.63, 15.36, 9.407, 5.863, 4.155, 3.417, 2.478, 1.944,
+       1.692, 1.589, 1.480, 1.441, 1.423, 1.409, 1.372, 1.330, 1.298, 1.280, 1.258},
+      {59.25, 45.08, 30.36, 20.83, 16.15, 9.834, 6.166, 4.407, 3.641, 2.648, 2.064,
+       1.779, 1.661, 1.531, 1.482, 1.459, 1.442, 1.400, 1.354, 1.319, 1.299, 1.272},
+      {56.38, 44.29, 30.50, 21.18, 16.51, 10.11, 6.354, 4.542, 3.752, 2.724, 2.116,
+       1.817, 1.692, 1.554, 1.499, 1.474, 1.456, 1.412, 1.364, 1.328, 1.307, 1.282}};
 
-  //data/corrections for T > Tlim  
-  static const G4double Tlim = 10.*MeV;
-  static const G4double beta2lim = Tlim*(Tlim+2.*electron_mass_c2)/
-                      ((Tlim+electron_mass_c2)*(Tlim+electron_mass_c2));
-  static const G4double bg2lim   = Tlim*(Tlim+2.*electron_mass_c2)/
-                      (electron_mass_c2*electron_mass_c2);
+  //data/corrections for T > Tlim
+  static const G4double Tlim = 10. * MeV;
+  static const G4double beta2lim =
+      Tlim * (Tlim + 2. * electron_mass_c2) / ((Tlim + electron_mass_c2) * (Tlim + electron_mass_c2));
+  static const G4double bg2lim = Tlim * (Tlim + 2. * electron_mass_c2) / (electron_mass_c2 * electron_mass_c2);
 
-  static const G4double sig0[15] = {
-                     0.2672*barn,  0.5922*barn, 2.653*barn,  6.235*barn,
-                      11.69*barn  , 13.24*barn  , 16.12*barn, 23.00*barn ,
-		      35.13*barn  , 39.95*barn  , 50.85*barn, 67.19*barn ,
-                      91.15*barn  , 104.4*barn  , 113.1*barn};
-		      		       
+  static const G4double sig0[15] = {0.2672 * barn,
+                                    0.5922 * barn,
+                                    2.653 * barn,
+                                    6.235 * barn,
+                                    11.69 * barn,
+                                    13.24 * barn,
+                                    16.12 * barn,
+                                    23.00 * barn,
+                                    35.13 * barn,
+                                    39.95 * barn,
+                                    50.85 * barn,
+                                    67.19 * barn,
+                                    91.15 * barn,
+                                    104.4 * barn,
+                                    113.1 * barn};
+
   static const G4double hecorr[15] = {
-                         120.70, 117.50, 105.00, 92.92, 79.23,  74.510,  68.29,
-                          57.39,  41.97,  36.14, 24.53, 10.21,  -7.855, -16.84,
-			 -22.30};
+      120.70, 117.50, 105.00, 92.92, 79.23, 74.510, 68.29, 57.39, 41.97, 36.14, 24.53, 10.21, -7.855, -16.84, -22.30};
 
   G4double sigma;
   SetParticle(part);
 
-  Z23 = pow(AtomicNumber,2./3.); 
+  Z23 = pow(AtomicNumber, 2. / 3.);
 
   // correction if particle .ne. e-/e+
   // compute equivalent kinetic energy
@@ -276,446 +236,432 @@ G4double UrbanMscModel93::ComputeCrossSectionPerAtom(
 
   G4double eKineticEnergy = KineticEnergy;
 
-  if(mass > electron_mass_c2)
-  {
-     G4double TAU = KineticEnergy/mass ;
-     G4double c = mass*TAU*(TAU+2.)/(electron_mass_c2*(TAU+1.)) ;
-     G4double w = c-2. ;
-     G4double tau = 0.5*(w+sqrt(w*w+4.*c)) ;
-     eKineticEnergy = electron_mass_c2*tau ;
+  if (mass > electron_mass_c2) {
+    G4double TAU = KineticEnergy / mass;
+    G4double c = mass * TAU * (TAU + 2.) / (electron_mass_c2 * (TAU + 1.));
+    G4double w = c - 2.;
+    G4double tau = 0.5 * (w + sqrt(w * w + 4. * c));
+    eKineticEnergy = electron_mass_c2 * tau;
   }
 
-  G4double eTotalEnergy = eKineticEnergy + electron_mass_c2 ;
-  G4double beta2 = eKineticEnergy*(eTotalEnergy+electron_mass_c2)
-                                 /(eTotalEnergy*eTotalEnergy);
-  G4double bg2   = eKineticEnergy*(eTotalEnergy+electron_mass_c2)
-                                 /(electron_mass_c2*electron_mass_c2);
+  G4double eTotalEnergy = eKineticEnergy + electron_mass_c2;
+  G4double beta2 = eKineticEnergy * (eTotalEnergy + electron_mass_c2) / (eTotalEnergy * eTotalEnergy);
+  G4double bg2 = eKineticEnergy * (eTotalEnergy + electron_mass_c2) / (electron_mass_c2 * electron_mass_c2);
 
-  G4double eps = epsfactor*bg2/Z23;
+  G4double eps = epsfactor * bg2 / Z23;
 
-  if     (eps<epsmin)  sigma = 2.*eps*eps;
-  else if(eps<epsmax)  sigma = G4Log(1.+2.*eps)-2.*eps/(1.+2.*eps);
-  else                 sigma = G4Log(2.*eps)-1.+1./eps;
+  if (eps < epsmin)
+    sigma = 2. * eps * eps;
+  else if (eps < epsmax)
+    sigma = G4Log(1. + 2. * eps) - 2. * eps / (1. + 2. * eps);
+  else
+    sigma = G4Log(2. * eps) - 1. + 1. / eps;
 
-  sigma *= ChargeSquare*AtomicNumber*AtomicNumber/(beta2*bg2);
+  sigma *= ChargeSquare * AtomicNumber * AtomicNumber / (beta2 * bg2);
 
-  // interpolate in AtomicNumber and beta2 
-  G4double c1,c2,cc1,cc2,corr;
+  // interpolate in AtomicNumber and beta2
+  G4double c1, c2, cc1, cc2, corr;
 
   // get bin number in Z
   G4int iZ = 14;
-  while ((iZ>=0)&&(Zdat[iZ]>=AtomicNumber)) iZ -= 1;
-  if (iZ==14)                               iZ = 13;
-  if (iZ==-1)                               iZ = 0 ;
+  while ((iZ >= 0) && (Zdat[iZ] >= AtomicNumber))
+    iZ -= 1;
+  if (iZ == 14)
+    iZ = 13;
+  if (iZ == -1)
+    iZ = 0;
 
   G4double ZZ1 = Zdat[iZ];
-  G4double ZZ2 = Zdat[iZ+1];
-  G4double ratZ = (AtomicNumber-ZZ1)*(AtomicNumber+ZZ1)/
-                  ((ZZ2-ZZ1)*(ZZ2+ZZ1));
+  G4double ZZ2 = Zdat[iZ + 1];
+  G4double ratZ = (AtomicNumber - ZZ1) * (AtomicNumber + ZZ1) / ((ZZ2 - ZZ1) * (ZZ2 + ZZ1));
 
-  if(eKineticEnergy <= Tlim) 
-  {
+  if (eKineticEnergy <= Tlim) {
     // get bin number in T (beta2)
     G4int iT = 21;
-    while ((iT>=0)&&(Tdat[iT]>=eKineticEnergy)) iT -= 1;
-    if(iT==21)                                  iT = 20;
-    if(iT==-1)                                  iT = 0 ;
+    while ((iT >= 0) && (Tdat[iT] >= eKineticEnergy))
+      iT -= 1;
+    if (iT == 21)
+      iT = 20;
+    if (iT == -1)
+      iT = 0;
 
     //  calculate betasquare values
-    G4double T = Tdat[iT],   E = T + electron_mass_c2;
-    G4double b2small = T*(E+electron_mass_c2)/(E*E);
+    G4double T = Tdat[iT], E = T + electron_mass_c2;
+    G4double b2small = T * (E + electron_mass_c2) / (E * E);
 
-    T = Tdat[iT+1]; E = T + electron_mass_c2;
-    G4double b2big = T*(E+electron_mass_c2)/(E*E);
-    G4double ratb2 = (beta2-b2small)/(b2big-b2small);
+    T = Tdat[iT + 1];
+    E = T + electron_mass_c2;
+    G4double b2big = T * (E + electron_mass_c2) / (E * E);
+    G4double ratb2 = (beta2 - b2small) / (b2big - b2small);
 
-    if (charge < 0.)
-    {
-       c1 = celectron[iZ][iT];
-       c2 = celectron[iZ+1][iT];
-       cc1 = c1+ratZ*(c2-c1);
+    if (charge < 0.) {
+      c1 = celectron[iZ][iT];
+      c2 = celectron[iZ + 1][iT];
+      cc1 = c1 + ratZ * (c2 - c1);
 
-       c1 = celectron[iZ][iT+1];
-       c2 = celectron[iZ+1][iT+1];
-       cc2 = c1+ratZ*(c2-c1);
+      c1 = celectron[iZ][iT + 1];
+      c2 = celectron[iZ + 1][iT + 1];
+      cc2 = c1 + ratZ * (c2 - c1);
 
-       corr = cc1+ratb2*(cc2-cc1);
+      corr = cc1 + ratb2 * (cc2 - cc1);
 
-       sigma *= sigmafactor/corr;
+      sigma *= sigmafactor / corr;
+    } else {
+      c1 = cpositron[iZ][iT];
+      c2 = cpositron[iZ + 1][iT];
+      cc1 = c1 + ratZ * (c2 - c1);
+
+      c1 = cpositron[iZ][iT + 1];
+      c2 = cpositron[iZ + 1][iT + 1];
+      cc2 = c1 + ratZ * (c2 - c1);
+
+      corr = cc1 + ratb2 * (cc2 - cc1);
+
+      sigma *= sigmafactor / corr;
     }
-    else              
-    {
-       c1 = cpositron[iZ][iT];
-       c2 = cpositron[iZ+1][iT];
-       cc1 = c1+ratZ*(c2-c1);
-
-       c1 = cpositron[iZ][iT+1];
-       c2 = cpositron[iZ+1][iT+1];
-       cc2 = c1+ratZ*(c2-c1);
-
-       corr = cc1+ratb2*(cc2-cc1);
-
-       sigma *= sigmafactor/corr;
-    }
-  }
-  else
-  {
-    c1 = bg2lim*sig0[iZ]*(1.+hecorr[iZ]*(beta2-beta2lim))/bg2;
-    c2 = bg2lim*sig0[iZ+1]*(1.+hecorr[iZ+1]*(beta2-beta2lim))/bg2;
-    if((AtomicNumber >= ZZ1) && (AtomicNumber <= ZZ2))
-      sigma = c1+ratZ*(c2-c1) ;
-    else if(AtomicNumber < ZZ1)
-      sigma = AtomicNumber*AtomicNumber*c1/(ZZ1*ZZ1);
-    else if(AtomicNumber > ZZ2)
-      sigma = AtomicNumber*AtomicNumber*c2/(ZZ2*ZZ2);
+  } else {
+    c1 = bg2lim * sig0[iZ] * (1. + hecorr[iZ] * (beta2 - beta2lim)) / bg2;
+    c2 = bg2lim * sig0[iZ + 1] * (1. + hecorr[iZ + 1] * (beta2 - beta2lim)) / bg2;
+    if ((AtomicNumber >= ZZ1) && (AtomicNumber <= ZZ2))
+      sigma = c1 + ratZ * (c2 - c1);
+    else if (AtomicNumber < ZZ1)
+      sigma = AtomicNumber * AtomicNumber * c1 / (ZZ1 * ZZ1);
+    else if (AtomicNumber > ZZ2)
+      sigma = AtomicNumber * AtomicNumber * c2 / (ZZ2 * ZZ2);
   }
   return sigma;
-
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void UrbanMscModel93::StartTracking(G4Track* track)
-{
+void UrbanMscModel93::StartTracking(G4Track* track) {
   SetParticle(track->GetDynamicParticle()->GetDefinition());
-  firstStep = true; 
+  firstStep = true;
   inside = false;
   insideskin = false;
   tlimit = geombig;
-  stepmin = tlimitminfix ;
-  tlimitmin = 10.*stepmin ;
+  stepmin = tlimitminfix;
+  tlimitmin = 10. * stepmin;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double UrbanMscModel93::ComputeTruePathLengthLimit(
-                             const G4Track& track,
-			     G4double& currentMinimalStep)
-{
+G4double UrbanMscModel93::ComputeTruePathLengthLimit(const G4Track& track, G4double& currentMinimalStep) {
   tPathLength = currentMinimalStep;
   const G4DynamicParticle* dp = track.GetDynamicParticle();
   G4StepPoint* sp = track.GetStep()->GetPreStepPoint();
   G4StepStatus stepStatus = sp->GetStepStatus();
   couple = track.GetMaterialCutsCouple();
-  SetCurrentCouple(couple); 
+  SetCurrentCouple(couple);
   currentMaterialIndex = couple->GetIndex();
   currentKinEnergy = dp->GetKineticEnergy();
-  currentRange = GetRange(particle,currentKinEnergy,couple);
-  lambda0 = GetTransportMeanFreePath(particle,currentKinEnergy);
+  currentRange = GetRange(particle, currentKinEnergy, couple);
+  lambda0 = GetTransportMeanFreePath(particle, currentKinEnergy);
 
   // stop here if small range particle
-  if(inside || tPathLength < tlimitminfix) { 
-    return ConvertTrueToGeom(tPathLength, currentMinimalStep); 
-  } 
-  
-  if(tPathLength > currentRange) { tPathLength = currentRange; }
+  if (inside || tPathLength < tlimitminfix) {
+    return ConvertTrueToGeom(tPathLength, currentMinimalStep);
+  }
+
+  if (tPathLength > currentRange) {
+    tPathLength = currentRange;
+  }
 
   presafety = sp->GetSafety();
 
-  // G4cout << "Urban2::StepLimit tPathLength= " 
+  // G4cout << "Urban2::StepLimit tPathLength= "
   // 	 <<tPathLength<<" safety= " << presafety
   //        << " range= " <<currentRange<< " lambda= "<<lambda0
   // 	 << " Alg: " << steppingAlgorithm <<G4endl;
 
   // far from geometry boundary
-  if(currentRange < presafety)
-    {
-      inside = true;
-      return ConvertTrueToGeom(tPathLength, currentMinimalStep);  
-    }
+  if (currentRange < presafety) {
+    inside = true;
+    return ConvertTrueToGeom(tPathLength, currentMinimalStep);
+  }
 
   // standard  version
   //
-  if (steppingAlgorithm == fUseDistanceToBoundary)
-    {
-      //compute geomlimit and presafety 
-      geomlimit = ComputeGeomLimit(track, presafety, currentRange);
+  if (steppingAlgorithm == fUseDistanceToBoundary) {
+    //compute geomlimit and presafety
+    geomlimit = ComputeGeomLimit(track, presafety, currentRange);
 
-      // is it far from boundary ?
-      if(currentRange < presafety)
-	{
-	  inside = true;
-	  return ConvertTrueToGeom(tPathLength, currentMinimalStep);   
-	}
+    // is it far from boundary ?
+    if (currentRange < presafety) {
+      inside = true;
+      return ConvertTrueToGeom(tPathLength, currentMinimalStep);
+    }
 
-      smallstep += 1.;
-      insideskin = false;
+    smallstep += 1.;
+    insideskin = false;
 
-      if(firstStep || stepStatus == fGeomBoundary)
-        {
-          rangeinit = currentRange;
-          if(firstStep) smallstep = 1.e10;
-          else  smallstep = 1.;
-
-          //define stepmin here (it depends on lambda!)
-          //rough estimation of lambda_elastic/lambda_transport
-          G4double rat = currentKinEnergy/MeV ;
-          rat = 1.e-3/(rat*(10.+rat)) ;
-          //stepmin ~ lambda_elastic
-          stepmin = rat*lambda0;
-          skindepth = skin*stepmin;
-          //define tlimitmin
-          tlimitmin = 10.*stepmin;
-          if(tlimitmin < tlimitminfix) tlimitmin = tlimitminfix;
-	  //G4cout << "rangeinit= " << rangeinit << " stepmin= " << stepmin
-	  //	 << " tlimitmin= " << tlimitmin << " geomlimit= " << geomlimit <<G4endl;
-          // constraint from the geometry
-          if((geomlimit < geombig) && (geomlimit > geommin))
-            {
-              // geomlimit is a geometrical step length
-              // transform it to true path length (estimation)
-              if((1.-geomlimit/lambda0) > 0.)
-                geomlimit = -lambda0*G4Log(1.-geomlimit/lambda0)+tlimitmin ;
-
-              if(stepStatus == fGeomBoundary)
-                tgeom = geomlimit/facgeom;
-              else
-                tgeom = 2.*geomlimit/facgeom;
-            }
-            else
-              tgeom = geombig;
-        }
-
-
-      //step limit 
-      tlimit = facrange*rangeinit;              
-      if(tlimit < facsafety*presafety)
-        tlimit = facsafety*presafety; 
-
-      //lower limit for tlimit
-      if(tlimit < tlimitmin) tlimit = tlimitmin;
-
-      if(tlimit > tgeom) tlimit = tgeom;
-
-      //G4cout << "tgeom= " << tgeom << " geomlimit= " << geomlimit  
-      //      << " tlimit= " << tlimit << " presafety= " << presafety << G4endl;
-
-      // shortcut
-      if((tPathLength < tlimit) && (tPathLength < presafety) &&
-         (smallstep >= skin) && (tPathLength < geomlimit-0.999*skindepth))
-	return ConvertTrueToGeom(tPathLength, currentMinimalStep);   
-
-      // step reduction near to boundary
-      if(smallstep < skin)
-	{
-	  tlimit = stepmin;
-	  insideskin = true;
-	}
-      else if(geomlimit < geombig)
-	{
-	  if(geomlimit > skindepth)
-	    {
-	      if(tlimit > geomlimit-0.999*skindepth)
-		tlimit = geomlimit-0.999*skindepth;
-	    }
-	  else
-	    {
-	      insideskin = true;
-	      if(tlimit > stepmin) tlimit = stepmin;
-	    }
-	}
-
-      if(tlimit < stepmin) tlimit = stepmin;
-
-      // randomize 1st step or 1st 'normal' step in volume
-      if(firstStep || ((smallstep == skin) && !insideskin)) 
-        { 
-          G4double temptlimit = tlimit;
-          if(temptlimit > tlimitmin)
-          {
-            do {
-              temptlimit = G4RandGauss::shoot(tlimit,0.3*tlimit);        
-               } while ((temptlimit < tlimitmin) || 
-                        (temptlimit > 2.*tlimit-tlimitmin));
-          }
-          else
-            temptlimit = tlimitmin;
-          if(tPathLength > temptlimit) tPathLength = temptlimit;
-        }
+    if (firstStep || stepStatus == fGeomBoundary) {
+      rangeinit = currentRange;
+      if (firstStep)
+        smallstep = 1.e10;
       else
-        {  
-          if(tPathLength > tlimit) tPathLength = tlimit  ; 
-        }
+        smallstep = 1.;
 
+      //define stepmin here (it depends on lambda!)
+      //rough estimation of lambda_elastic/lambda_transport
+      G4double rat = currentKinEnergy / MeV;
+      rat = 1.e-3 / (rat * (10. + rat));
+      //stepmin ~ lambda_elastic
+      stepmin = rat * lambda0;
+      skindepth = skin * stepmin;
+      //define tlimitmin
+      tlimitmin = 10. * stepmin;
+      if (tlimitmin < tlimitminfix)
+        tlimitmin = tlimitminfix;
+      //G4cout << "rangeinit= " << rangeinit << " stepmin= " << stepmin
+      //	 << " tlimitmin= " << tlimitmin << " geomlimit= " << geomlimit <<G4endl;
+      // constraint from the geometry
+      if ((geomlimit < geombig) && (geomlimit > geommin)) {
+        // geomlimit is a geometrical step length
+        // transform it to true path length (estimation)
+        if ((1. - geomlimit / lambda0) > 0.)
+          geomlimit = -lambda0 * G4Log(1. - geomlimit / lambda0) + tlimitmin;
+
+        if (stepStatus == fGeomBoundary)
+          tgeom = geomlimit / facgeom;
+        else
+          tgeom = 2. * geomlimit / facgeom;
+      } else
+        tgeom = geombig;
     }
-    // for 'normal' simulation with or without magnetic field 
-    //  there no small step/single scattering at boundaries
-  else if(steppingAlgorithm == fUseSafety)
-    {
-      // compute presafety again if presafety <= 0 and no boundary
-      // i.e. when it is needed for optimization purposes
-      if((stepStatus != fGeomBoundary) && (presafety < tlimitminfix)) 
-	presafety = ComputeSafety(sp->GetPosition(),tPathLength); 
 
-      // is far from boundary
-      if(currentRange < presafety)
-        {
-          inside = true;
-          return ConvertTrueToGeom(tPathLength, currentMinimalStep);  
-        }
+    //step limit
+    tlimit = facrange * rangeinit;
+    if (tlimit < facsafety * presafety)
+      tlimit = facsafety * presafety;
 
-      if(firstStep || stepStatus == fGeomBoundary)
-      {
-        rangeinit = currentRange;
-        fr = facrange;
-        // 9.1 like stepping for e+/e- only (not for muons,hadrons)
-        if(mass < masslimite) 
-        {
-          if(lambda0 > currentRange)
-            rangeinit = lambda0;
-          if(lambda0 > lambdalimit)
-            fr *= 0.75+0.25*lambda0/lambdalimit;
-        }
+    //lower limit for tlimit
+    if (tlimit < tlimitmin)
+      tlimit = tlimitmin;
 
-        //lower limit for tlimit
-        G4double rat = currentKinEnergy/MeV ;
-        rat = 1.e-3/(rat*(10.+rat)) ;
-        tlimitmin = 10.*lambda0*rat;
-        if(tlimitmin < tlimitminfix) tlimitmin = tlimitminfix;
+    if (tlimit > tgeom)
+      tlimit = tgeom;
+
+    //G4cout << "tgeom= " << tgeom << " geomlimit= " << geomlimit
+    //      << " tlimit= " << tlimit << " presafety= " << presafety << G4endl;
+
+    // shortcut
+    if ((tPathLength < tlimit) && (tPathLength < presafety) && (smallstep >= skin) &&
+        (tPathLength < geomlimit - 0.999 * skindepth))
+      return ConvertTrueToGeom(tPathLength, currentMinimalStep);
+
+    // step reduction near to boundary
+    if (smallstep < skin) {
+      tlimit = stepmin;
+      insideskin = true;
+    } else if (geomlimit < geombig) {
+      if (geomlimit > skindepth) {
+        if (tlimit > geomlimit - 0.999 * skindepth)
+          tlimit = geomlimit - 0.999 * skindepth;
+      } else {
+        insideskin = true;
+        if (tlimit > stepmin)
+          tlimit = stepmin;
       }
-      //step limit
-      tlimit = fr*rangeinit;               
+    }
 
-      if(tlimit < facsafety*presafety)
-        tlimit = facsafety*presafety;
+    if (tlimit < stepmin)
+      tlimit = stepmin;
+
+    // randomize 1st step or 1st 'normal' step in volume
+    if (firstStep || ((smallstep == skin) && !insideskin)) {
+      G4double temptlimit = tlimit;
+      if (temptlimit > tlimitmin) {
+        do {
+          temptlimit = G4RandGauss::shoot(tlimit, 0.3 * tlimit);
+        } while ((temptlimit < tlimitmin) || (temptlimit > 2. * tlimit - tlimitmin));
+      } else
+        temptlimit = tlimitmin;
+      if (tPathLength > temptlimit)
+        tPathLength = temptlimit;
+    } else {
+      if (tPathLength > tlimit)
+        tPathLength = tlimit;
+    }
+
+  }
+  // for 'normal' simulation with or without magnetic field
+  //  there no small step/single scattering at boundaries
+  else if (steppingAlgorithm == fUseSafety) {
+    // compute presafety again if presafety <= 0 and no boundary
+    // i.e. when it is needed for optimization purposes
+    if ((stepStatus != fGeomBoundary) && (presafety < tlimitminfix))
+      presafety = ComputeSafety(sp->GetPosition(), tPathLength);
+
+    // is far from boundary
+    if (currentRange < presafety) {
+      inside = true;
+      return ConvertTrueToGeom(tPathLength, currentMinimalStep);
+    }
+
+    if (firstStep || stepStatus == fGeomBoundary) {
+      rangeinit = currentRange;
+      fr = facrange;
+      // 9.1 like stepping for e+/e- only (not for muons,hadrons)
+      if (mass < masslimite) {
+        if (lambda0 > currentRange)
+          rangeinit = lambda0;
+        if (lambda0 > lambdalimit)
+          fr *= 0.75 + 0.25 * lambda0 / lambdalimit;
+      }
 
       //lower limit for tlimit
-      if(tlimit < tlimitmin) tlimit = tlimitmin;
-      
-      if(tPathLength > tlimit) tPathLength = tlimit;
-
+      G4double rat = currentKinEnergy / MeV;
+      rat = 1.e-3 / (rat * (10. + rat));
+      tlimitmin = 10. * lambda0 * rat;
+      if (tlimitmin < tlimitminfix)
+        tlimitmin = tlimitminfix;
     }
-  
+    //step limit
+    tlimit = fr * rangeinit;
+
+    if (tlimit < facsafety * presafety)
+      tlimit = facsafety * presafety;
+
+    //lower limit for tlimit
+    if (tlimit < tlimitmin)
+      tlimit = tlimitmin;
+
+    if (tPathLength > tlimit)
+      tPathLength = tlimit;
+
+  }
+
   // version similar to 7.1 (needed for some experiments)
-  else
-    {
-      if (stepStatus == fGeomBoundary)
-	{
-	  if (currentRange > lambda0) tlimit = facrange*currentRange;
-	  else                        tlimit = facrange*lambda0;
+  else {
+    if (stepStatus == fGeomBoundary) {
+      if (currentRange > lambda0)
+        tlimit = facrange * currentRange;
+      else
+        tlimit = facrange * lambda0;
 
-	  if(tlimit < tlimitmin) tlimit = tlimitmin;
-	  if(tPathLength > tlimit) tPathLength = tlimit;
-	}
+      if (tlimit < tlimitmin)
+        tlimit = tlimitmin;
+      if (tPathLength > tlimit)
+        tPathLength = tlimit;
     }
-  //G4cout << "tPathLength= " << tPathLength 
+  }
+  //G4cout << "tPathLength= " << tPathLength
   //	 << " currentMinimalStep= " << currentMinimalStep << G4endl;
   return ConvertTrueToGeom(tPathLength, currentMinimalStep);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double UrbanMscModel93::ComputeGeomPathLength(G4double)
-{
-  firstStep = false; 
+G4double UrbanMscModel93::ComputeGeomPathLength(G4double) {
+  firstStep = false;
   lambdaeff = lambda0;
-  par1 = -1. ;  
-  par2 = par3 = 0. ;  
+  par1 = -1.;
+  par2 = par3 = 0.;
 
   //  do the true -> geom transformation
   zPathLength = tPathLength;
 
   // z = t for very small tPathLength
-  if(tPathLength < tlimitminfix) return zPathLength;
+  if (tPathLength < tlimitminfix)
+    return zPathLength;
 
   // this correction needed to run MSC with eIoni and eBrem inactivated
   // and makes no harm for a normal run
-  if(tPathLength > currentRange)
-    tPathLength = currentRange ;
+  if (tPathLength > currentRange)
+    tPathLength = currentRange;
 
-  G4double tau   = tPathLength/lambda0 ;
+  G4double tau = tPathLength / lambda0;
 
   if ((tau <= tausmall) || insideskin) {
-    zPathLength  = tPathLength;
-    if(zPathLength > lambda0) zPathLength = lambda0;
+    zPathLength = tPathLength;
+    if (zPathLength > lambda0)
+      zPathLength = lambda0;
     return zPathLength;
   }
 
   G4double zmean;
-  if (tPathLength < currentRange*dtrl) {
-    if(tau < taulim) zmean = tPathLength*(1.-0.5*tau) ;
-    else             zmean = lambda0*(1.-G4Exp(-tau));
-  } else if(currentKinEnergy < mass || tPathLength == currentRange)  {
-    par1 = 1./currentRange ;
-    par2 = 1./(par1*lambda0) ;
-    par3 = 1.+par2 ;
-    if(tPathLength < currentRange)
-      zmean = (1.-G4Exp(par3*G4Log(1.-tPathLength/currentRange)))/(par1*par3) ;
+  if (tPathLength < currentRange * dtrl) {
+    if (tau < taulim)
+      zmean = tPathLength * (1. - 0.5 * tau);
     else
-      zmean = 1./(par1*par3) ;
+      zmean = lambda0 * (1. - G4Exp(-tau));
+  } else if (currentKinEnergy < mass || tPathLength == currentRange) {
+    par1 = 1. / currentRange;
+    par2 = 1. / (par1 * lambda0);
+    par3 = 1. + par2;
+    if (tPathLength < currentRange)
+      zmean = (1. - G4Exp(par3 * G4Log(1. - tPathLength / currentRange))) / (par1 * par3);
+    else
+      zmean = 1. / (par1 * par3);
   } else {
-    G4double T1 = GetEnergy(particle,currentRange-tPathLength,couple);
-    G4double lambda1 = GetTransportMeanFreePath(particle,T1);
+    G4double T1 = GetEnergy(particle, currentRange - tPathLength, couple);
+    G4double lambda1 = GetTransportMeanFreePath(particle, T1);
 
-    par1 = (lambda0-lambda1)/(lambda0*tPathLength) ;
-    par2 = 1./(par1*lambda0) ;
-    par3 = 1.+par2 ;
-    zmean = (1.-G4Exp(par3*G4Log(lambda1/lambda0)))/(par1*par3) ;
+    par1 = (lambda0 - lambda1) / (lambda0 * tPathLength);
+    par2 = 1. / (par1 * lambda0);
+    par3 = 1. + par2;
+    zmean = (1. - G4Exp(par3 * G4Log(lambda1 / lambda0))) / (par1 * par3);
   }
 
-  zPathLength = zmean ;
+  zPathLength = zmean;
 
   //  sample z
-  if(samplez)
-  {
-    const G4double  ztmax = 0.99 ;
-    G4double zt = zmean/tPathLength ;
+  if (samplez) {
+    const G4double ztmax = 0.99;
+    G4double zt = zmean / tPathLength;
 
-    if (tPathLength > stepmin && zt < ztmax)              
-    {
-      G4double u,cz1;
-      if(zt >= third)
-      {
-        G4double cz = 0.5*(3.*zt-1.)/(1.-zt) ;
-        cz1 = 1.+cz ;
-        G4double u0 = cz/cz1 ;
-        G4double grej ;
+    if (tPathLength > stepmin && zt < ztmax) {
+      G4double u, cz1;
+      if (zt >= third) {
+        G4double cz = 0.5 * (3. * zt - 1.) / (1. - zt);
+        cz1 = 1. + cz;
+        G4double u0 = cz / cz1;
+        G4double grej;
         do {
-            u = G4Exp(G4Log(G4UniformRand())/cz1) ;
-            grej = G4Exp(cz*G4Log(u/u0))*(1.-u)/(1.-u0) ;
-           } while (grej < G4UniformRand()) ;
+          u = G4Exp(G4Log(G4UniformRand()) / cz1);
+          grej = G4Exp(cz * G4Log(u / u0)) * (1. - u) / (1. - u0);
+        } while (grej < G4UniformRand());
+      } else {
+        cz1 = 1. / zt - 1.;
+        u = 1. - G4Exp(G4Log(G4UniformRand()) / cz1);
       }
-      else
-      {
-        cz1 = 1./zt-1.;
-        u = 1.-G4Exp(G4Log(G4UniformRand())/cz1) ;
-      }
-      zPathLength = tPathLength*u ;
+      zPathLength = tPathLength * u;
     }
   }
 
-  if(zPathLength > lambda0) zPathLength = lambda0;
+  if (zPathLength > lambda0)
+    zPathLength = lambda0;
   //G4cout << "zPathLength= " << zPathLength << " lambda1= " << lambda0 << G4endl;
   return zPathLength;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double UrbanMscModel93::ComputeTrueStepLength(G4double geomStepLength)
-{
-  // step defined other than transportation 
-  if(geomStepLength == zPathLength && tPathLength <= currentRange)
+G4double UrbanMscModel93::ComputeTrueStepLength(G4double geomStepLength) {
+  // step defined other than transportation
+  if (geomStepLength == zPathLength && tPathLength <= currentRange)
     return tPathLength;
 
   // t = z for very small step
   zPathLength = geomStepLength;
   tPathLength = geomStepLength;
-  if(geomStepLength < tlimitminfix) return tPathLength;
-  
+  if (geomStepLength < tlimitminfix)
+    return tPathLength;
+
   // recalculation
-  if((geomStepLength > lambda0*tausmall) && !insideskin)
-  {
-    if(par1 <  0.)
-      tPathLength = -lambda0*G4Log(1.-geomStepLength/lambda0) ;
-    else 
-    {
-      if(par1*par3*geomStepLength < 1.)
-        tPathLength = (1.-G4Exp(G4Log(1.-par1*par3*geomStepLength)/par3))/par1 ;
-      else 
+  if ((geomStepLength > lambda0 * tausmall) && !insideskin) {
+    if (par1 < 0.)
+      tPathLength = -lambda0 * G4Log(1. - geomStepLength / lambda0);
+    else {
+      if (par1 * par3 * geomStepLength < 1.)
+        tPathLength = (1. - G4Exp(G4Log(1. - par1 * par3 * geomStepLength) / par3)) / par1;
+      else
         tPathLength = currentRange;
-    }  
+    }
   }
-  if(tPathLength < geomStepLength) tPathLength = geomStepLength;
+  if (tPathLength < geomStepLength)
+    tPathLength = geomStepLength;
 
   //G4cout << "tPathLength= " << tPathLength << " step= " << geomStepLength << G4endl;
 
@@ -724,31 +670,31 @@ G4double UrbanMscModel93::ComputeTrueStepLength(G4double geomStepLength)
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4ThreeVector& 
-UrbanMscModel93::SampleScattering(const G4ThreeVector& oldDirection,
-				    G4double safety)
-{
-  fDisplacement.set(0.0,0.0,0.0);
+G4ThreeVector& UrbanMscModel93::SampleScattering(const G4ThreeVector& oldDirection, G4double safety) {
+  fDisplacement.set(0.0, 0.0, 0.0);
   G4double kineticEnergy = currentKinEnergy;
-  if (tPathLength > currentRange*dtrl) {
-    kineticEnergy = GetEnergy(particle,currentRange-tPathLength,couple);
+  if (tPathLength > currentRange * dtrl) {
+    kineticEnergy = GetEnergy(particle, currentRange - tPathLength, couple);
   } else {
-    kineticEnergy -= tPathLength*GetDEDX(particle,currentKinEnergy,couple);
+    kineticEnergy -= tPathLength * GetDEDX(particle, currentKinEnergy, couple);
   }
-  if((kineticEnergy <= eV) || (tPathLength <= tlimitminfix) ||
-     (tPathLength/tausmall < lambda0)) { return  fDisplacement; }
+  if ((kineticEnergy <= eV) || (tPathLength <= tlimitminfix) || (tPathLength / tausmall < lambda0)) {
+    return fDisplacement;
+  }
 
-  G4double cth  = SampleCosineTheta(tPathLength,kineticEnergy);
+  G4double cth = SampleCosineTheta(tPathLength, kineticEnergy);
 
   // protection against 'bad' cth values
-  if(std::fabs(cth) > 1.) { return  fDisplacement; }
+  if (std::fabs(cth) > 1.) {
+    return fDisplacement;
+  }
 
-  // extra protection agaist high energy particles backscattered 
-  //  if(cth < 1.0 - 1000*tPathLength/lambda0 && kineticEnergy > 20*MeV) { 
-    //G4cout << "Warning: large scattering E(MeV)= " << kineticEnergy 
-    //	   << " s(mm)= " << tPathLength/mm
-    //	   << " 1-cosTheta= " << 1.0 - cth << G4endl;
-    // do Gaussian central scattering
+  // extra protection agaist high energy particles backscattered
+  //  if(cth < 1.0 - 1000*tPathLength/lambda0 && kineticEnergy > 20*MeV) {
+  //G4cout << "Warning: large scattering E(MeV)= " << kineticEnergy
+  //	   << " s(mm)= " << tPathLength/mm
+  //	   << " 1-cosTheta= " << 1.0 - cth << G4endl;
+  // do Gaussian central scattering
   //  if(kineticEnergy > 0.5*GeV && cth < 0.9) {
   /*
   if(cth < 1.0 - 1000*tPathLength/lambda0 && 
@@ -766,17 +712,16 @@ UrbanMscModel93::SampleScattering(const G4ThreeVector& oldDirection,
   }
   */
 
-  G4double sth  = sqrt((1.0 - cth)*(1.0 + cth));
-  G4double phi  = twopi*G4UniformRand();
-  G4double dirx = sth*cos(phi);
-  G4double diry = sth*sin(phi);
+  G4double sth = sqrt((1.0 - cth) * (1.0 + cth));
+  G4double phi = twopi * G4UniformRand();
+  G4double dirx = sth * cos(phi);
+  G4double diry = sth * sin(phi);
 
-  G4ThreeVector newDirection(dirx,diry,cth);
+  G4ThreeVector newDirection(dirx, diry, cth);
   newDirection.rotateUz(oldDirection);
   fParticleChange->ProposeMomentumDirection(newDirection);
 
   if (latDisplasment && safety > tlimitminfix) {
-
     G4double r = SampleDisplacement();
     /*    
     G4cout << "UrbanMscModel93::SampleSecondaries: e(MeV)= " << kineticEnergy
@@ -785,148 +730,142 @@ UrbanMscModel93::SampleScattering(const G4ThreeVector& oldDirection,
            << " geomStep(mm)= " << zPathLength
            << G4endl;
     */
-    if(r > 0.)
-      {
-        G4double latcorr = LatCorrelation();
-        if(latcorr > r) latcorr = r;
+    if (r > 0.) {
+      G4double latcorr = LatCorrelation();
+      if (latcorr > r)
+        latcorr = r;
 
-        // sample direction of lateral displacement
-        // compute it from the lateral correlation
-        G4double Phi = 0.;
-        if(std::abs(r*sth) < latcorr)
-          Phi  = twopi*G4UniformRand();
+      // sample direction of lateral displacement
+      // compute it from the lateral correlation
+      G4double Phi = 0.;
+      if (std::abs(r * sth) < latcorr)
+        Phi = twopi * G4UniformRand();
+      else {
+        G4double psi = std::acos(latcorr / (r * sth));
+        if (G4UniformRand() < 0.5)
+          Phi = phi + psi;
         else
-        {
-          G4double psi = std::acos(latcorr/(r*sth));
-          if(G4UniformRand() < 0.5)
-            Phi = phi+psi;
-          else
-            Phi = phi-psi;
-        }
-
-        dirx = r*std::cos(Phi);
-        diry = r*std::sin(Phi);
-
-	fDisplacement.set(dirx,diry,0.0);
-	fDisplacement.rotateUz(oldDirection);
+          Phi = phi - psi;
       }
+
+      dirx = r * std::cos(Phi);
+      diry = r * std::sin(Phi);
+
+      fDisplacement.set(dirx, diry, 0.0);
+      fDisplacement.rotateUz(oldDirection);
+    }
   }
   return fDisplacement;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double UrbanMscModel93::SampleCosineTheta(G4double trueStepLength,
-					    G4double KineticEnergy)
-{
-  G4double cth = 1. ;
-  G4double tau = trueStepLength/lambda0 ;
+G4double UrbanMscModel93::SampleCosineTheta(G4double trueStepLength, G4double KineticEnergy) {
+  G4double cth = 1.;
+  G4double tau = trueStepLength / lambda0;
 
-  Zeff = couple->GetMaterial()->GetTotNbOfElectPerVolume()/
-         couple->GetMaterial()->GetTotNbOfAtomsPerVolume() ;
+  Zeff = couple->GetMaterial()->GetTotNbOfElectPerVolume() / couple->GetMaterial()->GetTotNbOfAtomsPerVolume();
 
-  if(Zold != Zeff)  
+  if (Zold != Zeff)
     UpdateCache();
 
-  if(insideskin)
-  {
+  if (insideskin) {
     //no scattering, single or plural scattering
-    G4double mean = trueStepLength/stepmin ;
+    G4double mean = trueStepLength / stepmin;
 
     G4int n = G4Poisson(mean);
-    if(n > 0)
-    {
+    if (n > 0) {
       //screening (Moliere-Bethe)
-      G4double mom2 = KineticEnergy*(2.*mass+KineticEnergy);
-      G4double beta2 = mom2/((KineticEnergy+mass)*(KineticEnergy+mass));
-      G4double ascr = scr1/mom2;
-      ascr *= 1.13+scr2/beta2;
-      G4double ascr1 = 1.+2.*ascr;
-      G4double bp1=ascr1+1.;
-      G4double bm1=ascr1-1.;
+      G4double mom2 = KineticEnergy * (2. * mass + KineticEnergy);
+      G4double beta2 = mom2 / ((KineticEnergy + mass) * (KineticEnergy + mass));
+      G4double ascr = scr1 / mom2;
+      ascr *= 1.13 + scr2 / beta2;
+      G4double ascr1 = 1. + 2. * ascr;
+      G4double bp1 = ascr1 + 1.;
+      G4double bm1 = ascr1 - 1.;
 
       // single scattering from screened Rutherford x-section
-      G4double ct,st,phi;
-      G4double sx=0.,sy=0.,sz=0.;
-      for(G4int i=1; i<=n; i++)
-      {
-        ct = ascr1-bp1*bm1/(2.*G4UniformRand()+bm1);
-        if(ct < -1.) ct = -1.;
-        if(ct >  1.) ct =  1.; 
-        st = sqrt(1.-ct*ct);
-        phi = twopi*G4UniformRand();
-        sx += st*cos(phi);
-        sy += st*sin(phi);
+      G4double ct, st, phi;
+      G4double sx = 0., sy = 0., sz = 0.;
+      for (G4int i = 1; i <= n; i++) {
+        ct = ascr1 - bp1 * bm1 / (2. * G4UniformRand() + bm1);
+        if (ct < -1.)
+          ct = -1.;
+        if (ct > 1.)
+          ct = 1.;
+        st = sqrt(1. - ct * ct);
+        phi = twopi * G4UniformRand();
+        sx += st * cos(phi);
+        sy += st * sin(phi);
         sz += ct;
       }
-      cth = sz/sqrt(sx*sx+sy*sy+sz*sz);
+      cth = sz / sqrt(sx * sx + sy * sy + sz * sz);
     }
-  }
-  else
-  {
-    if(trueStepLength >= currentRange*dtrl) 
-    {
-      if(par1*trueStepLength < 1.)
-	tau = -par2*G4Log(1.-par1*trueStepLength) ;
+  } else {
+    if (trueStepLength >= currentRange * dtrl) {
+      if (par1 * trueStepLength < 1.)
+        tau = -par2 * G4Log(1. - par1 * trueStepLength);
       // for the case if ioni/brems are inactivated
-      // see the corresponding condition in ComputeGeomPathLength 
-      else if(1.-KineticEnergy/currentKinEnergy > taulim)
-	tau = taubig ;
+      // see the corresponding condition in ComputeGeomPathLength
+      else if (1. - KineticEnergy / currentKinEnergy > taulim)
+        tau = taubig;
     }
-    currentTau = tau ;
-    lambdaeff = trueStepLength/currentTau;
+    currentTau = tau;
+    lambdaeff = trueStepLength / currentTau;
     currentRadLength = couple->GetMaterial()->GetRadlen();
 
-    if (tau >= taubig) cth = -1.+2.*G4UniformRand();
-    else if (tau >= tausmall)
-    {
+    if (tau >= taubig)
+      cth = -1. + 2. * G4UniformRand();
+    else if (tau >= tausmall) {
       G4double xmeanth, x2meanth;
-      if(tau < numlim) {
-	xmeanth = 1.0 - tau*(1.0 - 0.5*tau);
-        x2meanth= 1.0 - tau*(5.0 - 6.25*tau)*third;
+      if (tau < numlim) {
+        xmeanth = 1.0 - tau * (1.0 - 0.5 * tau);
+        x2meanth = 1.0 - tau * (5.0 - 6.25 * tau) * third;
       } else {
-	xmeanth = G4Exp(-tau);
-	x2meanth = (1.+2.*G4Exp(-2.5*tau))*third;
+        xmeanth = G4Exp(-tau);
+        x2meanth = (1. + 2. * G4Exp(-2.5 * tau)) * third;
       }
-      G4double relloss = 1.-KineticEnergy/currentKinEnergy;
+      G4double relloss = 1. - KineticEnergy / currentKinEnergy;
 
-      if(relloss > rellossmax) 
-        return SimpleScattering(xmeanth,x2meanth);
+      if (relloss > rellossmax)
+        return SimpleScattering(xmeanth, x2meanth);
 
-      G4double theta0 = ComputeTheta0(trueStepLength,KineticEnergy);
+      G4double theta0 = ComputeTheta0(trueStepLength, KineticEnergy);
 
-      //G4cout << "Theta0= " << theta0 << " theta0max= " << theta0max 
+      //G4cout << "Theta0= " << theta0 << " theta0max= " << theta0max
       //	     << "  sqrt(tausmall)= " << sqrt(tausmall) << G4endl;
 
       // protection for very small angles
-      G4double theta2 = theta0*theta0;
+      G4double theta2 = theta0 * theta0;
 
-      if(theta2 < tausmall) { return cth; }
-    
-      if(theta0 > theta0max) {
-        return SimpleScattering(xmeanth,x2meanth);
+      if (theta2 < tausmall) {
+        return cth;
       }
 
-      G4double x = theta2*(1.0 - theta2/12.);
-      if(theta2 > numlim) {
-	G4double sth = 2.*sin(0.5*theta0);
-	x = sth*sth;
+      if (theta0 > theta0max) {
+        return SimpleScattering(xmeanth, x2meanth);
       }
 
-      G4double xmean1 = 1.-(1.-(1.+xsi)*ea)*x/eaa;
-      G4double x0 = 1. - xsi*x;
+      G4double x = theta2 * (1.0 - theta2 / 12.);
+      if (theta2 > numlim) {
+        G4double sth = 2. * sin(0.5 * theta0);
+        x = sth * sth;
+      }
+
+      G4double xmean1 = 1. - (1. - (1. + xsi) * ea) * x / eaa;
+      G4double x0 = 1. - xsi * x;
 
       // G4cout << " xmean1= " << xmean1 << "  xmeanth= " << xmeanth << G4endl;
 
-      if(xmean1 <= 0.999*xmeanth) {
-        return SimpleScattering(xmeanth,x2meanth);
+      if (xmean1 <= 0.999 * xmeanth) {
+        return SimpleScattering(xmeanth, x2meanth);
       }
-      // from e- and muon scattering data                    
-      G4double c = coeffc1+coeffc2*y; 
+      // from e- and muon scattering data
+      G4double c = coeffc1 + coeffc2 * y;
 
       // tail should not be too big
-      if(c < 1.9) { 
-	/*
+      if (c < 1.9) {
+        /*
 	if(KineticEnergy > 200*MeV && c < 1.6) {
 	  G4cout << "UrbanMscModel93::SampleCosineTheta: E(GeV)= " 
 		 << KineticEnergy/GeV 
@@ -936,113 +875,110 @@ G4double UrbanMscModel93::SampleCosineTheta(G4double trueStepLength,
 		 << " tau= " << tau << G4endl;
 	}
 	*/
-	c = 1.9; 
+        c = 1.9;
       }
 
-      if(fabs(c-3.) < 0.001)      { c = 3.001; }
-      else if(fabs(c-2.) < 0.001) { c = 2.001; }
+      if (fabs(c - 3.) < 0.001) {
+        c = 3.001;
+      } else if (fabs(c - 2.) < 0.001) {
+        c = 2.001;
+      }
 
-      G4double c1 = c-1.;
+      G4double c1 = c - 1.;
 
       //from continuity of derivatives
-      G4double b = 1.+(c-xsi)*x;
+      G4double b = 1. + (c - xsi) * x;
 
-      G4double b1 = b+1.;
-      G4double bx = c*x;
+      G4double b1 = b + 1.;
+      G4double bx = c * x;
 
-      G4double eb1 = pow(b1,c1);
-      G4double ebx = pow(bx,c1);
-      G4double d = ebx/eb1;
+      G4double eb1 = pow(b1, c1);
+      G4double ebx = pow(bx, c1);
+      G4double d = ebx / eb1;
 
       // G4double xmean2 = (x0*eb1+ebx-(eb1*bx-b1*ebx)/(c-2.))/(eb1-ebx);
-      G4double xmean2 = (x0 + d - (bx - b1*d)/(c-2.))/(1. - d);
-      
-      G4double f1x0 = ea/eaa;
-      G4double f2x0 = c1/(c*(1. - d));
-      G4double prob = f2x0/(f1x0+f2x0);
+      G4double xmean2 = (x0 + d - (bx - b1 * d) / (c - 2.)) / (1. - d);
 
-      G4double qprob = xmeanth/(prob*xmean1+(1.-prob)*xmean2);
+      G4double f1x0 = ea / eaa;
+      G4double f2x0 = c1 / (c * (1. - d));
+      G4double prob = f2x0 / (f1x0 + f2x0);
+
+      G4double qprob = xmeanth / (prob * xmean1 + (1. - prob) * xmean2);
 
       // sampling of costheta
       //G4cout << "c= " << c << " qprob= " << qprob << " eb1= " << eb1
       // << " c1= " << c1 << " b1= " << b1 << " bx= " << bx << " eb1= " << eb1
       //	     << G4endl;
-      if(G4UniformRand() < qprob)
-      {
+      if (G4UniformRand() < qprob) {
         G4double var = 0;
-        if(G4UniformRand() < prob) {
-          cth = 1.+G4Log(ea+G4UniformRand()*eaa)*x;
+        if (G4UniformRand() < prob) {
+          cth = 1. + G4Log(ea + G4UniformRand() * eaa) * x;
         } else {
-          var = (1.0 - d)*G4UniformRand();
-          if(var < numlim*d) {
-            var /= (d*c1); 
-            cth = -1.0 + var*(1.0 - 0.5*var*c)*(2. + (c - xsi)*x);
-	  } else {
-	    cth = 1. + x*(c - xsi - c*pow(var + d, -1.0/c1));
-	    //b-b1*bx/G4Exp(log(ebx+(eb1-ebx)*G4UniformRand())/c1) ;
-	  }
-	}
-	if(KineticEnergy > 5*GeV && cth < 0.9) {
-	  G4cout << "UrbanMscModel93::SampleCosineTheta: E(GeV)= " 
-		 << KineticEnergy/GeV 
-		 << " 1-cosT= " << 1 - cth
-		 << " length(mm)= " << trueStepLength << " Zeff= " << Zeff 
-		 << " tau= " << tau
-		 << " prob= " << prob << " var= " << var << G4endl;
-	  G4cout << "  c= " << c << " qprob= " << qprob << " eb1= " << eb1
-		 << " ebx= " << ebx
-		 << " c1= " << c1 << " b= " << b << " b1= " << b1 
-		 << " bx= " << bx << " d= " << d
-		 << " ea= " << ea << " eaa= " << eaa << G4endl;
-	}
-      }
-      else {
-        cth = -1.+2.*G4UniformRand();
-	if(KineticEnergy > 5*GeV) {
-	  G4cout << "UrbanMscModel93::SampleCosineTheta: E(GeV)= " 
-		 << KineticEnergy/GeV 
-		 << " length(mm)= " << trueStepLength << " Zeff= " << Zeff 
-		 << " qprob= " << qprob << G4endl;
-	}
+          var = (1.0 - d) * G4UniformRand();
+          if (var < numlim * d) {
+            var /= (d * c1);
+            cth = -1.0 + var * (1.0 - 0.5 * var * c) * (2. + (c - xsi) * x);
+          } else {
+            cth = 1. + x * (c - xsi - c * pow(var + d, -1.0 / c1));
+            //b-b1*bx/G4Exp(log(ebx+(eb1-ebx)*G4UniformRand())/c1) ;
+          }
+        }
+        if (KineticEnergy > 5 * GeV && cth < 0.9) {
+          G4cout << "UrbanMscModel93::SampleCosineTheta: E(GeV)= " << KineticEnergy / GeV << " 1-cosT= " << 1 - cth
+                 << " length(mm)= " << trueStepLength << " Zeff= " << Zeff << " tau= " << tau << " prob= " << prob
+                 << " var= " << var << G4endl;
+          G4cout << "  c= " << c << " qprob= " << qprob << " eb1= " << eb1 << " ebx= " << ebx << " c1= " << c1
+                 << " b= " << b << " b1= " << b1 << " bx= " << bx << " d= " << d << " ea= " << ea << " eaa= " << eaa
+                 << G4endl;
+        }
+      } else {
+        cth = -1. + 2. * G4UniformRand();
+        if (KineticEnergy > 5 * GeV) {
+          G4cout << "UrbanMscModel93::SampleCosineTheta: E(GeV)= " << KineticEnergy / GeV
+                 << " length(mm)= " << trueStepLength << " Zeff= " << Zeff << " qprob= " << qprob << G4endl;
+        }
       }
     }
-  }  
-  return cth ;
+  }
+  return cth;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double UrbanMscModel93::SampleDisplacement()
-{
+G4double UrbanMscModel93::SampleDisplacement() {
   // Compute rmean = sqrt(<r**2>) from theory
   G4double rmean = 0.0;
   if ((currentTau >= tausmall) && !insideskin) {
     if (currentTau < taulim) {
-      rmean = kappa*currentTau*currentTau*currentTau*
-             (1.-kappapl1*currentTau*0.25)/6. ;
+      rmean = kappa * currentTau * currentTau * currentTau * (1. - kappapl1 * currentTau * 0.25) / 6.;
 
     } else {
       G4double etau = 0.0;
-      if (currentTau<taubig) etau = G4Exp(-currentTau);
-      rmean = -kappa*currentTau;
-      rmean = -G4Exp(rmean)/(kappa*kappami1);
-      rmean += currentTau-kappapl1/kappa+kappa*etau/kappami1;
+      if (currentTau < taubig)
+        etau = G4Exp(-currentTau);
+      rmean = -kappa * currentTau;
+      rmean = -G4Exp(rmean) / (kappa * kappami1);
+      rmean += currentTau - kappapl1 / kappa + kappa * etau / kappami1;
     }
-    if (rmean>0.) rmean = 2.*lambdaeff*sqrt(rmean*third);
-    else          rmean = 0.;
+    if (rmean > 0.)
+      rmean = 2. * lambdaeff * sqrt(rmean * third);
+    else
+      rmean = 0.;
   }
 
-  if(rmean == 0.) return rmean;
+  if (rmean == 0.)
+    return rmean;
 
   // protection against z > t ...........................
-  G4double rmax = (tPathLength-zPathLength)*(tPathLength+zPathLength);
-    if(rmax <= 0.)
-      rmax = 0.;
-    else
-      rmax = sqrt(rmax);
+  G4double rmax = (tPathLength - zPathLength) * (tPathLength + zPathLength);
+  if (rmax <= 0.)
+    rmax = 0.;
+  else
+    rmax = sqrt(rmax);
 
-  if(rmean >= rmax) return rmax;
-     
+  if (rmean >= rmax)
+    return rmax;
+
   return rmean;
   // VI comment out for the time being
   /*
@@ -1062,22 +998,19 @@ G4double UrbanMscModel93::SampleDisplacement()
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-G4double UrbanMscModel93::LatCorrelation()
-{
+G4double UrbanMscModel93::LatCorrelation() {
   G4double latcorr = 0.;
-  if((currentTau >= tausmall) && !insideskin)
-  {
-    if(currentTau < taulim)
-      latcorr = lambdaeff*kappa*currentTau*currentTau*
-                (1.-kappapl1*currentTau*third)*third;
-    else
-    {
+  if ((currentTau >= tausmall) && !insideskin) {
+    if (currentTau < taulim)
+      latcorr = lambdaeff * kappa * currentTau * currentTau * (1. - kappapl1 * currentTau * third) * third;
+    else {
       G4double etau = 0.;
-      if(currentTau < taubig) etau = G4Exp(-currentTau);
-      latcorr = -kappa*currentTau;
-      latcorr = G4Exp(latcorr)/kappami1;
-      latcorr += 1.-kappa*etau/kappami1 ;
-      latcorr *= 2.*lambdaeff*third ;
+      if (currentTau < taubig)
+        etau = G4Exp(-currentTau);
+      latcorr = -kappa * currentTau;
+      latcorr = G4Exp(latcorr) / kappami1;
+      latcorr += 1. - kappa * etau / kappami1;
+      latcorr *= 2. * lambdaeff * third;
     }
   }
 

--- a/SimG4Core/PrintGeomInfo/interface/PrintGeomInfoAction.h
+++ b/SimG4Core/PrintGeomInfo/interface/PrintGeomInfoAction.h
@@ -4,7 +4,7 @@
 #include "SimG4Core/Watcher/interface/SimWatcher.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-    
+
 #include "G4NavigationHistory.hh"
 
 #include <iostream>
@@ -18,46 +18,45 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
 
-typedef std::map< G4VPhysicalVolume*, G4VPhysicalVolume*, std::less<G4VPhysicalVolume*> > mpvpv;
-typedef std::multimap< G4LogicalVolume*, G4VPhysicalVolume*, std::less<G4LogicalVolume*> > mmlvpv;
+typedef std::map<G4VPhysicalVolume*, G4VPhysicalVolume*, std::less<G4VPhysicalVolume*> > mpvpv;
+typedef std::multimap<G4LogicalVolume*, G4VPhysicalVolume*, std::less<G4LogicalVolume*> > mmlvpv;
 
-class PrintGeomInfoAction : public SimWatcher,
-			    public Observer<const BeginOfJob *>,
-			    public Observer<const BeginOfRun *> {
-
+class PrintGeomInfoAction : public SimWatcher, public Observer<const BeginOfJob*>, public Observer<const BeginOfRun*> {
 public:
-  PrintGeomInfoAction(edm::ParameterSet const & p);
+  PrintGeomInfoAction(edm::ParameterSet const& p);
   ~PrintGeomInfoAction() override;
+
 private:
-  void update(const BeginOfJob * job) override;
-  void update(const BeginOfRun * run) override;
+  void update(const BeginOfJob* job) override;
+  void update(const BeginOfRun* run) override;
   void dumpSummary(std::ostream& out = std::cout);
   void dumpG4LVList(std::ostream& out = std::cout);
   void dumpG4LVTree(std::ostream& out = std::cout);
   void dumpMaterialList(std::ostream& out = std::cout);
-  void dumpG4LVLeaf(G4LogicalVolume * lv, unsigned int leafDepth, unsigned int count, std::ostream & out = std::cout);
+  void dumpG4LVLeaf(G4LogicalVolume* lv, unsigned int leafDepth, unsigned int count, std::ostream& out = std::cout);
   int countNoTouchables();
-  void add1touchable(G4LogicalVolume * lv, int & nTouch);
+  void add1touchable(G4LogicalVolume* lv, int& nTouch);
   void dumpHierarchyTreePVLV(std::ostream& out = std::cout);
-  void dumpHierarchyLeafPVLV(G4LogicalVolume * lv, unsigned int leafDepth, std::ostream & out = std::cout);
-  void dumpLV(G4LogicalVolume * lv, unsigned int leafDepth, std::ostream & out = std::cout);
-  void dumpPV(G4VPhysicalVolume * pv, unsigned int leafDepth, std::ostream & out = std::cout);
-  void dumpTouch(G4VPhysicalVolume * pv, unsigned int leafDepth, std::ostream & out = std::cout);
+  void dumpHierarchyLeafPVLV(G4LogicalVolume* lv, unsigned int leafDepth, std::ostream& out = std::cout);
+  void dumpLV(G4LogicalVolume* lv, unsigned int leafDepth, std::ostream& out = std::cout);
+  void dumpPV(G4VPhysicalVolume* pv, unsigned int leafDepth, std::ostream& out = std::cout);
+  void dumpTouch(G4VPhysicalVolume* pv, unsigned int leafDepth, std::ostream& out = std::cout);
   std::string spacesFromLeafDepth(unsigned int leafDepth);
-  void dumpSolid(G4VSolid * sol, unsigned int leafDepth, std::ostream & out = std::cout);
-  G4VPhysicalVolume * getTopPV();
-  G4LogicalVolume * getTopLV();
+  void dumpSolid(G4VSolid* sol, unsigned int leafDepth, std::ostream& out = std::cout);
+  G4VPhysicalVolume* getTopPV();
+  G4LogicalVolume* getTopLV();
+
 private:
-  bool                     _dumpSummary, _dumpLVTree, _dumpLVList;
-  bool                     _dumpMaterial;
-  bool                     _dumpLV, _dumpSolid, _dumpAtts, _dumpSense;
-  bool                     _dumpPV, _dumpRotation, _dumpReplica, _dumpTouch;
-  std::string              name;
-  int                      nchar;
+  bool _dumpSummary, _dumpLVTree, _dumpLVList;
+  bool _dumpMaterial;
+  bool _dumpLV, _dumpSolid, _dumpAtts, _dumpSense;
+  bool _dumpPV, _dumpRotation, _dumpReplica, _dumpTouch;
+  std::string name;
+  int nchar;
   std::vector<std::string> names;
-  mpvpv                    thePVTree;
-  G4VPhysicalVolume *      theTopPV; 
-  G4NavigationHistory      fHistory;
+  mpvpv thePVTree;
+  G4VPhysicalVolume* theTopPV;
+  G4NavigationHistory fHistory;
 };
 
 #endif

--- a/SimG4Core/PrintGeomInfo/interface/PrintGeomSummary.h
+++ b/SimG4Core/PrintGeomInfo/interface/PrintGeomSummary.h
@@ -5,7 +5,7 @@
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "DetectorDescription/Core/interface/DDSolidShapes.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-    
+
 #include "G4NavigationHistory.hh"
 
 #include <algorithm>
@@ -21,32 +21,29 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
 
-class PrintGeomSummary : public SimWatcher,
-                         public Observer<const BeginOfJob *>,
-                         public Observer<const BeginOfRun *> {
-
+class PrintGeomSummary : public SimWatcher, public Observer<const BeginOfJob *>, public Observer<const BeginOfRun *> {
 public:
-  PrintGeomSummary(edm::ParameterSet const & p);
+  PrintGeomSummary(edm::ParameterSet const &p);
   ~PrintGeomSummary() override;
 
 private:
-  void update(const BeginOfJob * job) override;
-  void update(const BeginOfRun * run) override;
-  void addSolid(const DDLogicalPart & part);
-  void fillLV(G4LogicalVolume * lv);
-  void dumpSummary(std::ostream& out, std::string name);
-  G4VPhysicalVolume * getTopPV();
+  void update(const BeginOfJob *job) override;
+  void update(const BeginOfRun *run) override;
+  void addSolid(const DDLogicalPart &part);
+  void fillLV(G4LogicalVolume *lv);
+  void dumpSummary(std::ostream &out, std::string name);
+  G4VPhysicalVolume *getTopPV();
   void addName(std::string name);
-  void printSummary(std::ostream & out);
+  void printSummary(std::ostream &out);
 
 private:
-  std::vector<std::string>           nodeNames_;
-  std::map<DDSolidShape,std::string> solidShape_;
-  std::map<std::string,DDSolidShape> solidMap_;
-  G4VPhysicalVolume *                theTopPV_; 
-  std::vector<G4LogicalVolume*>      lvs_, touch_;
-  std::vector<G4VSolid*>             sls_;
-  std::map<DDSolidShape,std::pair<int,int> > kount_;
+  std::vector<std::string> nodeNames_;
+  std::map<DDSolidShape, std::string> solidShape_;
+  std::map<std::string, DDSolidShape> solidMap_;
+  G4VPhysicalVolume *theTopPV_;
+  std::vector<G4LogicalVolume *> lvs_, touch_;
+  std::vector<G4VSolid *> sls_;
+  std::map<DDSolidShape, std::pair<int, int> > kount_;
 };
 
 #endif

--- a/SimG4Core/PrintGeomInfo/interface/PrintMaterialBudgetInfo.h
+++ b/SimG4Core/PrintGeomInfo/interface/PrintMaterialBudgetInfo.h
@@ -18,42 +18,48 @@ class G4LogicalVolume;
 class G4VPhysicalVolume;
 class G4VSolid;
 
-typedef std::map< G4VPhysicalVolume*, G4VPhysicalVolume*, std::less<G4VPhysicalVolume*> > mpvpv;
-typedef std::multimap< G4LogicalVolume*, G4VPhysicalVolume*, std::less<G4LogicalVolume*> > mmlvpv;
+typedef std::map<G4VPhysicalVolume*, G4VPhysicalVolume*, std::less<G4VPhysicalVolume*> > mpvpv;
+typedef std::multimap<G4LogicalVolume*, G4VPhysicalVolume*, std::less<G4LogicalVolume*> > mmlvpv;
 
 class PrintMaterialBudgetInfo : public SimWatcher,
-				public Observer<const BeginOfJob*>,
-				public Observer<const BeginOfRun*> {
-
+                                public Observer<const BeginOfJob*>,
+                                public Observer<const BeginOfRun*> {
 public:
-  PrintMaterialBudgetInfo(edm::ParameterSet const & p);
+  PrintMaterialBudgetInfo(edm::ParameterSet const& p);
   ~PrintMaterialBudgetInfo() override;
+
 private:
-  void update(const BeginOfJob* job) override {};
+  void update(const BeginOfJob* job) override{};
   void update(const BeginOfRun* run) override;
   void dumpHeader(std::ostream& out = std::cout);
   void dumpLaTeXHeader(std::ostream& out = std::cout);
-  void dumpHierarchyLeaf(G4VPhysicalVolume* pv, G4LogicalVolume* lv, unsigned int leafDepth,
-			 std::ostream& weightOut = std::cout, std::ostream& texOut = std::cout);
-  void printInfo(G4VPhysicalVolume* pv, G4LogicalVolume* lv, unsigned int leafDepth,
-		 std::ostream& weightOut = std::cout, std::ostream& texOut = std::cout);
+  void dumpHierarchyLeaf(G4VPhysicalVolume* pv,
+                         G4LogicalVolume* lv,
+                         unsigned int leafDepth,
+                         std::ostream& weightOut = std::cout,
+                         std::ostream& texOut = std::cout);
+  void printInfo(G4VPhysicalVolume* pv,
+                 G4LogicalVolume* lv,
+                 unsigned int leafDepth,
+                 std::ostream& weightOut = std::cout,
+                 std::ostream& texOut = std::cout);
   void dumpElementMassFraction(std::ostream& elementOut = std::cout);
   void dumpLaTeXFooter(std::ostream& out = std::cout);
-  
+
 private:
-  std::string              name;
-  int                      nchar;
-  mpvpv                    thePVTree;
-  G4VPhysicalVolume*       theTopPV; 
-  G4NavigationHistory      fHistory;
-  bool                     volumeFound;
-  unsigned int             levelFound;
-  std::ofstream            weightOutputFile;
-  std::ofstream            elementOutputFile;
-  std::ofstream            texOutputFile;
+  std::string name;
+  int nchar;
+  mpvpv thePVTree;
+  G4VPhysicalVolume* theTopPV;
+  G4NavigationHistory fHistory;
+  bool volumeFound;
+  unsigned int levelFound;
+  std::ofstream weightOutputFile;
+  std::ofstream elementOutputFile;
+  std::ofstream texOutputFile;
   std::vector<std::string> elementNames;
-  std::vector<double>      elementTotalWeight;
-  std::vector<double>      elementWeightFraction;
+  std::vector<double> elementTotalWeight;
+  std::vector<double> elementWeightFraction;
   //
   std::string stringLaTeXUnderscore(std::string stringname);
   std::string stringLaTeXSuperscript(std::string stringname);

--- a/SimG4Core/PrintGeomInfo/interface/PrintSensitive.h
+++ b/SimG4Core/PrintGeomInfo/interface/PrintSensitive.h
@@ -4,7 +4,7 @@
 #include "SimG4Core/Watcher/interface/SimWatcher.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-    
+
 #include "G4NavigationHistory.hh"
 
 #include <iostream>
@@ -13,25 +13,20 @@
 class BeginOfRun;
 class G4VPhysicalVolume;
 
-class PrintSensitive : public SimWatcher,
-                       public Observer<const BeginOfRun *> {
-
+class PrintSensitive : public SimWatcher, public Observer<const BeginOfRun *> {
 public:
-
-  PrintSensitive(edm::ParameterSet const & p);
+  PrintSensitive(edm::ParameterSet const &p);
   ~PrintSensitive() override;
 
 private:
-
-  void update(const BeginOfRun * run) override;
-  void dumpTouch(G4VPhysicalVolume * pv, unsigned int leafDepth, bool printIt,
-		 std::ostream & out = std::cout);
-  G4VPhysicalVolume * getTopPV();
+  void update(const BeginOfRun *run) override;
+  void dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, bool printIt, std::ostream &out = std::cout);
+  G4VPhysicalVolume *getTopPV();
 
 private:
-  std::string              name;
-  int                      nchar;
-  G4NavigationHistory      fHistory;
+  std::string name;
+  int nchar;
+  G4NavigationHistory fHistory;
 };
 
 #endif

--- a/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
@@ -31,98 +31,93 @@
 using namespace CLHEP;
 
 PrintGeomInfoAction::PrintGeomInfoAction(const edm::ParameterSet &p) {
-
   _dumpSummary = p.getUntrackedParameter<bool>("DumpSummary", true);
-  _dumpLVTree  = p.getUntrackedParameter<bool>("DumpLVTree",  true);
-  _dumpMaterial= p.getUntrackedParameter<bool>("DumpMaterial",false);
-  _dumpLVList  = p.getUntrackedParameter<bool>("DumpLVList",  false);
-  _dumpLV      = p.getUntrackedParameter<bool>("DumpLV",      false);
-  _dumpSolid   = p.getUntrackedParameter<bool>("DumpSolid",   false);
-  _dumpAtts    = p.getUntrackedParameter<bool>("DumpAttributes", false);
-  _dumpPV      = p.getUntrackedParameter<bool>("DumpPV",      false);
-  _dumpRotation= p.getUntrackedParameter<bool>("DumpRotation",false);
+  _dumpLVTree = p.getUntrackedParameter<bool>("DumpLVTree", true);
+  _dumpMaterial = p.getUntrackedParameter<bool>("DumpMaterial", false);
+  _dumpLVList = p.getUntrackedParameter<bool>("DumpLVList", false);
+  _dumpLV = p.getUntrackedParameter<bool>("DumpLV", false);
+  _dumpSolid = p.getUntrackedParameter<bool>("DumpSolid", false);
+  _dumpAtts = p.getUntrackedParameter<bool>("DumpAttributes", false);
+  _dumpPV = p.getUntrackedParameter<bool>("DumpPV", false);
+  _dumpRotation = p.getUntrackedParameter<bool>("DumpRotation", false);
   _dumpReplica = p.getUntrackedParameter<bool>("DumpReplica", false);
-  _dumpTouch   = p.getUntrackedParameter<bool>("DumpTouch",   false);
-  _dumpSense   = p.getUntrackedParameter<bool>("DumpSense",   false);
-  name  = p.getUntrackedParameter<std::string>("Name","*");
+  _dumpTouch = p.getUntrackedParameter<bool>("DumpTouch", false);
+  _dumpSense = p.getUntrackedParameter<bool>("DumpSense", false);
+  name = p.getUntrackedParameter<std::string>("Name", "*");
   nchar = name.find("*");
-  name.assign(name,0,nchar);
+  name.assign(name, 0, nchar);
   names = p.getUntrackedParameter<std::vector<std::string> >("Names");
   G4cout << "PrintGeomInfoAction:: initialised with verbosity levels:"
-	 << " Summary   " << _dumpSummary << " LVTree   " << _dumpLVTree
-	 << " LVList    " << _dumpLVList  << " Material " << _dumpMaterial
-	 << "\n                                                        "
-	 << " LV        " << _dumpLV      << " Solid    " << _dumpSolid 
-	 << " Attribs   " << _dumpAtts
-	 << "\n                                                        "
-	 << " PV        " << _dumpPV      << " Rotation " << _dumpRotation
-	 << " Replica   " << _dumpReplica
-	 << "\n                                                        "
-	 << " Touchable " << _dumpTouch << " for names (0-" << nchar 
-	 << ") = " << name 
-	 << "\n                                                        "
-	 << " Sensitive " << _dumpSense << " for " << names.size()
-	 << " namess";
-  for (unsigned int i=0; i<names.size(); i++) G4cout << " " << names[i];
+         << " Summary   " << _dumpSummary << " LVTree   " << _dumpLVTree << " LVList    " << _dumpLVList << " Material "
+         << _dumpMaterial << "\n                                                        "
+         << " LV        " << _dumpLV << " Solid    " << _dumpSolid << " Attribs   " << _dumpAtts
+         << "\n                                                        "
+         << " PV        " << _dumpPV << " Rotation " << _dumpRotation << " Replica   " << _dumpReplica
+         << "\n                                                        "
+         << " Touchable " << _dumpTouch << " for names (0-" << nchar << ") = " << name
+         << "\n                                                        "
+         << " Sensitive " << _dumpSense << " for " << names.size() << " namess";
+  for (unsigned int i = 0; i < names.size(); i++)
+    G4cout << " " << names[i];
   G4cout << G4endl;
 }
- 
-PrintGeomInfoAction::~PrintGeomInfoAction() {}
- 
-void PrintGeomInfoAction::update(const BeginOfJob * job) {
 
+PrintGeomInfoAction::~PrintGeomInfoAction() {}
+
+void PrintGeomInfoAction::update(const BeginOfJob *job) {
   if (_dumpSense) {
     edm::ESTransientHandle<DDCompactView> pDD;
     (*job)()->get<IdealGeometryRecord>().get(pDD);
 
-    G4cout << "PrintGeomInfoAction::Get Printout of Sensitive Volumes " 
-	   << "for " << names.size() << " Readout Units" << G4endl;
-    for (unsigned int i=0; i<names.size(); i++) {
+    G4cout << "PrintGeomInfoAction::Get Printout of Sensitive Volumes "
+           << "for " << names.size() << " Readout Units" << G4endl;
+    for (unsigned int i = 0; i < names.size(); i++) {
       std::string attribute = "ReadOutName";
-      std::string sd        = names[i];
-      DDSpecificsMatchesValueFilter filter{DDValue(attribute,sd,0)};
-      DDFilteredView fv(*pDD,filter);
-      G4cout << "PrintGeomInfoAction:: Get Filtered view for " 
-	     << attribute << " = " << sd << G4endl;
+      std::string sd = names[i];
+      DDSpecificsMatchesValueFilter filter{DDValue(attribute, sd, 0)};
+      DDFilteredView fv(*pDD, filter);
+      G4cout << "PrintGeomInfoAction:: Get Filtered view for " << attribute << " = " << sd << G4endl;
       bool dodet = fv.firstChild();
-      
+
       std::string spaces = spacesFromLeafDepth(1);
 
       while (dodet) {
-	const DDLogicalPart & log = fv.logicalPart();
-	std::string lvname = log.name().name();
-	DDTranslation tran = fv.translation();
-	std::vector<int> copy = fv.copyNumbers();
+        const DDLogicalPart &log = fv.logicalPart();
+        std::string lvname = log.name().name();
+        DDTranslation tran = fv.translation();
+        std::vector<int> copy = fv.copyNumbers();
 
-	unsigned int leafDepth = copy.size();
-	G4cout << leafDepth << spaces << "### VOLUME = " << lvname 
-	       << " Copy No";
-	for (int k=leafDepth-1; k>=0; k--) G4cout << " " << copy[k];
-	G4cout << " Centre at " << tran << " (r = " << tran.Rho()
-	       << ", phi = " << tran.phi()/deg << ")" << G4endl;
-	dodet = fv.next();
+        unsigned int leafDepth = copy.size();
+        G4cout << leafDepth << spaces << "### VOLUME = " << lvname << " Copy No";
+        for (int k = leafDepth - 1; k >= 0; k--)
+          G4cout << " " << copy[k];
+        G4cout << " Centre at " << tran << " (r = " << tran.Rho() << ", phi = " << tran.phi() / deg << ")" << G4endl;
+        dodet = fv.next();
       }
     }
   }
 }
-  
-void PrintGeomInfoAction::update(const BeginOfRun * run) {
 
+void PrintGeomInfoAction::update(const BeginOfRun *run) {
   theTopPV = getTopPV();
-  
-  if (_dumpSummary)  dumpSummary(G4cout);
-  if (_dumpLVTree)   dumpG4LVTree(G4cout);
-    
+
+  if (_dumpSummary)
+    dumpSummary(G4cout);
+  if (_dumpLVTree)
+    dumpG4LVTree(G4cout);
+
   //---------- Dump list of objects of each class with detail of parameters
-  if (_dumpMaterial) dumpMaterialList(G4cout);
-  if (_dumpLVList)   dumpG4LVList(G4cout);
+  if (_dumpMaterial)
+    dumpMaterialList(G4cout);
+  if (_dumpLVList)
+    dumpG4LVList(G4cout);
 
   //---------- Dump LV and PV information
-  if (_dumpLV || _dumpPV || _dumpTouch) dumpHierarchyTreePVLV(G4cout);
+  if (_dumpLV || _dumpPV || _dumpTouch)
+    dumpHierarchyTreePVLV(G4cout);
 }
 
-void PrintGeomInfoAction::dumpSummary(std::ostream & out) {
-
+void PrintGeomInfoAction::dumpSummary(std::ostream &out) {
   //---------- Dump number of objects of each class
   out << " @@@@@@@@@@@@@@@@@@ Dumping G4 geometry objects Summary " << G4endl;
   if (theTopPV == nullptr) {
@@ -131,276 +126,266 @@ void PrintGeomInfoAction::dumpSummary(std::ostream & out) {
   }
   out << " @@@ Geometry built inside world volume: " << theTopPV->GetName() << G4endl;
   // Get number of solids (< # LV if several LV share a solid)
-  const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
+  const G4LogicalVolumeStore *lvs = G4LogicalVolumeStore::GetInstance();
   std::vector<G4LogicalVolume *>::const_iterator lvcite;
   std::set<G4VSolid *> theSolids;
-  for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
+  for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++)
     theSolids.insert((*lvcite)->GetSolid());
   out << " Number of G4VSolid's: " << theSolids.size() << G4endl;
   out << " Number of G4LogicalVolume's: " << lvs->size() << G4endl;
-  const G4PhysicalVolumeStore * pvs = G4PhysicalVolumeStore::GetInstance();
+  const G4PhysicalVolumeStore *pvs = G4PhysicalVolumeStore::GetInstance();
   out << " Number of G4VPhysicalVolume's: " << pvs->size() << G4endl;
   out << " Number of Touchable's: " << countNoTouchables() << G4endl;
-  const G4MaterialTable * matTab = G4Material::GetMaterialTable();
+  const G4MaterialTable *matTab = G4Material::GetMaterialTable();
   out << " Number of G4Material's: " << matTab->size() << G4endl;
 }
 
-void PrintGeomInfoAction::dumpG4LVList(std::ostream & out) {
-
+void PrintGeomInfoAction::dumpG4LVList(std::ostream &out) {
   out << " @@@@@@@@@@@@@@@@ DUMPING G4LogicalVolume's List  " << G4endl;
-  const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
-  std::vector<G4LogicalVolume*>::const_iterator lvcite;
-  for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) 
+  const G4LogicalVolumeStore *lvs = G4LogicalVolumeStore::GetInstance();
+  std::vector<G4LogicalVolume *>::const_iterator lvcite;
+  for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++)
     out << "LV:" << (*lvcite)->GetName() << "\tMaterial: " << (*lvcite)->GetMaterial()->GetName() << G4endl;
 }
 
-void PrintGeomInfoAction::dumpG4LVTree(std::ostream & out) {
-
+void PrintGeomInfoAction::dumpG4LVTree(std::ostream &out) {
   out << " @@@@@@@@@@@@@@@@ DUMPING G4LogicalVolume's Tree  " << G4endl;
-  G4LogicalVolume * lv = getTopLV(); 
-  dumpG4LVLeaf(lv,0,1,out);
+  G4LogicalVolume *lv = getTopLV();
+  dumpG4LVLeaf(lv, 0, 1, out);
 }
 
-void PrintGeomInfoAction::dumpMaterialList(std::ostream & out) {
-
+void PrintGeomInfoAction::dumpMaterialList(std::ostream &out) {
   out << " @@@@@@@@@@@@@@@@ DUMPING G4Material List ";
-  const G4MaterialTable * matTab = G4Material::GetMaterialTable();
+  const G4MaterialTable *matTab = G4Material::GetMaterialTable();
   out << " with " << matTab->size() << " materials " << G4endl;
-  std::vector<G4Material*>::const_iterator matite;
+  std::vector<G4Material *>::const_iterator matite;
   for (matite = matTab->begin(); matite != matTab->end(); matite++)
     out << "Material: " << (*matite) << G4endl;
 }
 
-void PrintGeomInfoAction::dumpG4LVLeaf(G4LogicalVolume * lv, unsigned int leafDepth, unsigned int count, std::ostream & out) {
-
-  for (unsigned int ii=0; ii < leafDepth; ii++) out << "  ";
-  out << " LV:(" << leafDepth << ") " << lv->GetName() << " (" << count
-      << ")" << G4endl;
+void PrintGeomInfoAction::dumpG4LVLeaf(G4LogicalVolume *lv,
+                                       unsigned int leafDepth,
+                                       unsigned int count,
+                                       std::ostream &out) {
+  for (unsigned int ii = 0; ii < leafDepth; ii++)
+    out << "  ";
+  out << " LV:(" << leafDepth << ") " << lv->GetName() << " (" << count << ")" << G4endl;
   //--- If a volume is placed n types as daughter of this LV, it should only be counted once
-  std::map<G4LogicalVolume*, unsigned int> lvCount;
-  std::map<G4LogicalVolume*, unsigned int>::const_iterator cite;
+  std::map<G4LogicalVolume *, unsigned int> lvCount;
+  std::map<G4LogicalVolume *, unsigned int>::const_iterator cite;
   for (int ii = 0; ii < lv->GetNoDaughters(); ii++) {
     cite = lvCount.find(lv->GetDaughter(ii)->GetLogicalVolume());
-    if (cite != lvCount.end()) lvCount[cite->first] = (cite->second) + 1;
-    else lvCount.insert(std::pair< G4LogicalVolume*,unsigned int>(lv->GetDaughter(ii)->GetLogicalVolume(),1));
+    if (cite != lvCount.end())
+      lvCount[cite->first] = (cite->second) + 1;
+    else
+      lvCount.insert(std::pair<G4LogicalVolume *, unsigned int>(lv->GetDaughter(ii)->GetLogicalVolume(), 1));
   }
-  for (cite = lvCount.begin(); cite != lvCount.end(); cite++) 
-    dumpG4LVLeaf((cite->first), leafDepth+1, (cite->second), out);
+  for (cite = lvCount.begin(); cite != lvCount.end(); cite++)
+    dumpG4LVLeaf((cite->first), leafDepth + 1, (cite->second), out);
 }
 
 int PrintGeomInfoAction::countNoTouchables() {
-
   int nTouch = 0;
-  G4LogicalVolume * lv = getTopLV();
+  G4LogicalVolume *lv = getTopLV();
   add1touchable(lv, nTouch);
   return nTouch;
 }
 
-void PrintGeomInfoAction::add1touchable(G4LogicalVolume * lv, int & nTouch) {
-
+void PrintGeomInfoAction::add1touchable(G4LogicalVolume *lv, int &nTouch) {
   int siz = lv->GetNoDaughters();
-  for(int ii = 0; ii < siz; ii++)
+  for (int ii = 0; ii < siz; ii++)
     add1touchable(lv->GetDaughter(ii)->GetLogicalVolume(), ++nTouch);
 }
- 
-void PrintGeomInfoAction::dumpHierarchyTreePVLV(std::ostream & out) {
 
-  //dumps in the following order: 
+void PrintGeomInfoAction::dumpHierarchyTreePVLV(std::ostream &out) {
+  //dumps in the following order:
   //    1) a LV with details
   //    2) list of PVs daughters of this LV with details
   //    3) list of LVs daughters of this LV and for each go to 1)
-  
+
   //----- Get top PV
-  G4LogicalVolume*  topLV = getTopLV();
-  
+  G4LogicalVolume *topLV = getTopLV();
+
   //----- Dump this leaf (it will recursively dump all the tree)
   dumpHierarchyLeafPVLV(topLV, 0, out);
   dumpPV(theTopPV, 0, out);
-  
+
   //----- Dump the touchables (it will recursively dump all the tree)
-  if (_dumpTouch) dumpTouch(theTopPV, 0, out);
+  if (_dumpTouch)
+    dumpTouch(theTopPV, 0, out);
 }
 
-void PrintGeomInfoAction::dumpHierarchyLeafPVLV(G4LogicalVolume * lv, unsigned int leafDepth, std::ostream & out) {
-
-  //----- Dump this LV 
+void PrintGeomInfoAction::dumpHierarchyLeafPVLV(G4LogicalVolume *lv, unsigned int leafDepth, std::ostream &out) {
+  //----- Dump this LV
   dumpLV(lv, leafDepth, out);
 
   //----- Get LV daughters from list of PV daughters
   mmlvpv lvpvDaughters;
-  std::set< G4LogicalVolume * > lvDaughters;
+  std::set<G4LogicalVolume *> lvDaughters;
   int NoDaughters = lv->GetNoDaughters();
-  while ((NoDaughters--)>0) {
-    G4VPhysicalVolume * pvD = lv->GetDaughter(NoDaughters);
+  while ((NoDaughters--) > 0) {
+    G4VPhysicalVolume *pvD = lv->GetDaughter(NoDaughters);
     lvpvDaughters.insert(mmlvpv::value_type(pvD->GetLogicalVolume(), pvD));
     lvDaughters.insert(pvD->GetLogicalVolume());
   }
- 
-  std::set< G4LogicalVolume * >::const_iterator scite;
+
+  std::set<G4LogicalVolume *>::const_iterator scite;
   mmlvpv::const_iterator mmcite;
 
   //----- Dump daughters PV and LV
   for (scite = lvDaughters.begin(); scite != lvDaughters.end(); scite++) {
-    std::pair< mmlvpv::iterator, mmlvpv::iterator > mmER = lvpvDaughters.equal_range(*scite);    
+    std::pair<mmlvpv::iterator, mmlvpv::iterator> mmER = lvpvDaughters.equal_range(*scite);
     //----- Dump daughters PV of this LV
-    for (mmcite = mmER.first ; mmcite != mmER.second; mmcite++) 
-      dumpPV((*mmcite).second, leafDepth+1, out);
+    for (mmcite = mmER.first; mmcite != mmER.second; mmcite++)
+      dumpPV((*mmcite).second, leafDepth + 1, out);
     //----- Dump daughters LV
-    dumpHierarchyLeafPVLV(*scite, leafDepth+1, out );
+    dumpHierarchyLeafPVLV(*scite, leafDepth + 1, out);
   }
 }
- 
-void PrintGeomInfoAction::dumpLV(G4LogicalVolume * lv, unsigned int leafDepth, std::ostream & out) {
 
+void PrintGeomInfoAction::dumpLV(G4LogicalVolume *lv, unsigned int leafDepth, std::ostream &out) {
   std::string spaces = spacesFromLeafDepth(leafDepth);
 
-  //----- dump name 
-  if (_dumpLV) { 
-    out << leafDepth << spaces << "$$$ VOLUME = " << lv->GetName()
-	<< "  Solid: " << lv->GetSolid()->GetName() << "  MATERIAL: "
-	<< lv->GetMaterial()->GetName() << G4endl;
+  //----- dump name
+  if (_dumpLV) {
+    out << leafDepth << spaces << "$$$ VOLUME = " << lv->GetName() << "  Solid: " << lv->GetSolid()->GetName()
+        << "  MATERIAL: " << lv->GetMaterial()->GetName() << G4endl;
     if (_dumpSolid)
-      dumpSolid(lv->GetSolid(), leafDepth, out); //----- dump solid
+      dumpSolid(lv->GetSolid(), leafDepth, out);  //----- dump solid
 
-    //----- dump LV info 
-    //--- material 
+    //----- dump LV info
+    //--- material
     if (_dumpAtts) {
       //--- Visualisation attributes
-      const G4VisAttributes * fVA = lv->GetVisAttributes();
-      if (fVA!=nullptr) {
-	out <<  spaces << "  VISUALISATION ATTRIBUTES: " << G4endl;
-	out <<  spaces << "    IsVisible " << fVA->IsVisible() << G4endl;
-	out <<  spaces << "    IsDaughtersInvisible " << fVA->IsDaughtersInvisible() << G4endl;
-	out <<  spaces << "    Colour " << fVA->GetColour() << G4endl;
-	out <<  spaces << "    LineStyle " << fVA->GetLineStyle() << G4endl;
-	out <<  spaces << "    LineWidth " << fVA->GetLineWidth() << G4endl;
-	out <<  spaces << "    IsForceDrawingStyle " << fVA->IsForceDrawingStyle() << G4endl;
-	out <<  spaces << "    ForcedDrawingStyle " << fVA->GetForcedDrawingStyle() << G4endl;
-      }    
-    
-      //--- User Limits
-      G4UserLimits * fUL = lv->GetUserLimits();
-      G4Track dummy;
-      if (fUL!=nullptr) {
-	out <<  spaces << "    MaxAllowedStep " << fUL->GetMaxAllowedStep(dummy) << G4endl;
-	out <<  spaces << "    UserMaxTrackLength " << fUL->GetUserMaxTrackLength(dummy) << G4endl;
-	out <<  spaces << "    UserMaxTime " << fUL->GetUserMaxTime(dummy) << G4endl;
-	out <<  spaces << "    UserMinEkine " << fUL->GetUserMinEkine(dummy) << G4endl;
-	out <<  spaces << "    UserMinRange " << fUL->GetUserMinRange(dummy) << G4endl;
+      const G4VisAttributes *fVA = lv->GetVisAttributes();
+      if (fVA != nullptr) {
+        out << spaces << "  VISUALISATION ATTRIBUTES: " << G4endl;
+        out << spaces << "    IsVisible " << fVA->IsVisible() << G4endl;
+        out << spaces << "    IsDaughtersInvisible " << fVA->IsDaughtersInvisible() << G4endl;
+        out << spaces << "    Colour " << fVA->GetColour() << G4endl;
+        out << spaces << "    LineStyle " << fVA->GetLineStyle() << G4endl;
+        out << spaces << "    LineWidth " << fVA->GetLineWidth() << G4endl;
+        out << spaces << "    IsForceDrawingStyle " << fVA->IsForceDrawingStyle() << G4endl;
+        out << spaces << "    ForcedDrawingStyle " << fVA->GetForcedDrawingStyle() << G4endl;
       }
-    
+
+      //--- User Limits
+      G4UserLimits *fUL = lv->GetUserLimits();
+      G4Track dummy;
+      if (fUL != nullptr) {
+        out << spaces << "    MaxAllowedStep " << fUL->GetMaxAllowedStep(dummy) << G4endl;
+        out << spaces << "    UserMaxTrackLength " << fUL->GetUserMaxTrackLength(dummy) << G4endl;
+        out << spaces << "    UserMaxTime " << fUL->GetUserMaxTime(dummy) << G4endl;
+        out << spaces << "    UserMinEkine " << fUL->GetUserMinEkine(dummy) << G4endl;
+        out << spaces << "    UserMinRange " << fUL->GetUserMinRange(dummy) << G4endl;
+      }
+
       //--- other LV info
-      if (lv->GetSensitiveDetector()) 
-	out << spaces << "  IS SENSITIVE DETECTOR " << G4endl;
-      if (lv->GetFieldManager()) 
-	out << spaces << "  FIELD ON " << G4endl;
+      if (lv->GetSensitiveDetector())
+        out << spaces << "  IS SENSITIVE DETECTOR " << G4endl;
+      if (lv->GetFieldManager())
+        out << spaces << "  FIELD ON " << G4endl;
 
       // Pointer (possibly NULL) to optimisation info objects.
-      out <<  spaces  
-	  << "        Quality for optimisation, average number of voxels to be spent per content " 
-	  << lv->GetSmartless() << G4endl;
+      out << spaces << "        Quality for optimisation, average number of voxels to be spent per content "
+          << lv->GetSmartless() << G4endl;
 
       // Pointer (possibly NULL) to G4FastSimulationManager object.
-      if (lv->GetFastSimulationManager()) 
-	out << spaces << "     Logical Volume is an envelope for a FastSimulationManager " 
-	    << G4endl;
-      out << spaces << "     Weight used in the event biasing technique = " 
-	  << lv->GetBiasWeight() << G4endl;
-    } 
+      if (lv->GetFastSimulationManager())
+        out << spaces << "     Logical Volume is an envelope for a FastSimulationManager " << G4endl;
+      out << spaces << "     Weight used in the event biasing technique = " << lv->GetBiasWeight() << G4endl;
+    }
   }
-}	
+}
 
-void PrintGeomInfoAction::dumpPV(G4VPhysicalVolume * pv, unsigned int leafDepth, std::ostream & out) {
-
+void PrintGeomInfoAction::dumpPV(G4VPhysicalVolume *pv, unsigned int leafDepth, std::ostream &out) {
   std::string spaces = spacesFromLeafDepth(leafDepth);
 
   //----- PV info
   if (_dumpPV) {
     std::string mother = "World";
-    if (pv->GetMotherLogical()) mother = pv->GetMotherLogical()->GetName();
-    out << leafDepth << spaces << "### VOLUME = " << pv->GetName() 
-	<< " Copy No " << pv->GetCopyNo() << " in " << mother
-	<< " at " << pv->GetTranslation();
+    if (pv->GetMotherLogical())
+      mother = pv->GetMotherLogical()->GetName();
+    out << leafDepth << spaces << "### VOLUME = " << pv->GetName() << " Copy No " << pv->GetCopyNo() << " in " << mother
+        << " at " << pv->GetTranslation();
   }
   if (!pv->IsReplicated()) {
     if (_dumpPV) {
-      if(pv->GetRotation() == nullptr) out << " with no rotation" << G4endl;
-      else  if(!_dumpRotation)   out << " with rotation" << G4endl; //just rotation name
-      else                       out << " with rotation " << *(pv->GetRotation()) << G4endl;
+      if (pv->GetRotation() == nullptr)
+        out << " with no rotation" << G4endl;
+      else if (!_dumpRotation)
+        out << " with rotation" << G4endl;  //just rotation name
+      else
+        out << " with rotation " << *(pv->GetRotation()) << G4endl;
     }
   } else {
-    if (_dumpReplica ) {
+    if (_dumpReplica) {
       out << spaces << "    It is replica: " << G4endl;
-      EAxis axis; 
-      int nReplicas; 
-      double width; 
-      double offset; 
+      EAxis axis;
+      int nReplicas;
+      double width;
+      double offset;
       bool consuming;
       pv->GetReplicationData(axis, nReplicas, width, offset, consuming);
-      out << spaces << "     axis " << axis << G4endl
-	  << spaces << "     nReplicas " << nReplicas << G4endl;
-      if (pv->GetParameterisation() != nullptr) 
-	out << spaces << "    It is parameterisation " << G4endl;
-      else 
-	out << spaces << "     width " << width << G4endl
-	    << spaces << "     offset " << offset << G4endl
-	    << spaces << "     consuming" <<  consuming << G4endl;
-      if (pv->GetParameterisation() != nullptr) 
-	out << spaces << "    It is parameterisation " << G4endl;
+      out << spaces << "     axis " << axis << G4endl << spaces << "     nReplicas " << nReplicas << G4endl;
+      if (pv->GetParameterisation() != nullptr)
+        out << spaces << "    It is parameterisation " << G4endl;
+      else
+        out << spaces << "     width " << width << G4endl << spaces << "     offset " << offset << G4endl << spaces
+            << "     consuming" << consuming << G4endl;
+      if (pv->GetParameterisation() != nullptr)
+        out << spaces << "    It is parameterisation " << G4endl;
     }
   }
 }
 
-void PrintGeomInfoAction::dumpTouch(G4VPhysicalVolume * pv, unsigned int leafDepth, std::ostream & out) {
-
+void PrintGeomInfoAction::dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, std::ostream &out) {
   std::string spaces = spacesFromLeafDepth(leafDepth);
-  if (leafDepth == 0) fHistory.SetFirstEntry(pv);
-  else fHistory.NewLevel(pv, kNormal, pv->GetCopyNo());
+  if (leafDepth == 0)
+    fHistory.SetFirstEntry(pv);
+  else
+    fHistory.NewLevel(pv, kNormal, pv->GetCopyNo());
 
-  G4ThreeVector globalpoint = fHistory.GetTopTransform().Inverse().TransformPoint(G4ThreeVector(0,0,0));
-  G4LogicalVolume * lv = pv->GetLogicalVolume();
+  G4ThreeVector globalpoint = fHistory.GetTopTransform().Inverse().TransformPoint(G4ThreeVector(0, 0, 0));
+  G4LogicalVolume *lv = pv->GetLogicalVolume();
 
   std::string mother = "World";
-  if (pv->GetMotherLogical()) mother = pv->GetMotherLogical()->GetName();
+  if (pv->GetMotherLogical())
+    mother = pv->GetMotherLogical()->GetName();
   std::string lvname = lv->GetName();
-  lvname.assign(lvname,0,nchar);
+  lvname.assign(lvname, 0, nchar);
   if (lvname == name)
-    out << leafDepth << spaces << "### VOLUME = " << lv->GetName() 
-	<< " Copy No " << pv->GetCopyNo() << " in " << mother
-	<< " global position of centre " << globalpoint << " (r = " 
-	<<  globalpoint.perp() << ", phi = " <<  globalpoint.phi()/deg
-	<< ")" << G4endl;
+    out << leafDepth << spaces << "### VOLUME = " << lv->GetName() << " Copy No " << pv->GetCopyNo() << " in " << mother
+        << " global position of centre " << globalpoint << " (r = " << globalpoint.perp()
+        << ", phi = " << globalpoint.phi() / deg << ")" << G4endl;
 
   int NoDaughters = lv->GetNoDaughters();
-  while ((NoDaughters--)>0) {
-    G4VPhysicalVolume * pvD = lv->GetDaughter(NoDaughters);
-    if (!pvD->IsReplicated()) dumpTouch(pvD, leafDepth+1, out);
+  while ((NoDaughters--) > 0) {
+    G4VPhysicalVolume *pvD = lv->GetDaughter(NoDaughters);
+    if (!pvD->IsReplicated())
+      dumpTouch(pvD, leafDepth + 1, out);
   }
 
-  if (leafDepth > 0) fHistory.BackLevel();
+  if (leafDepth > 0)
+    fHistory.BackLevel();
 }
 
 std::string PrintGeomInfoAction::spacesFromLeafDepth(unsigned int leafDepth) {
-
   std::string spaces;
   unsigned int ii;
-  for(ii = 0; ii < leafDepth; ii++) { spaces += "  "; }
+  for (ii = 0; ii < leafDepth; ii++) {
+    spaces += "  ";
+  }
   return spaces;
 }
 
-void PrintGeomInfoAction::dumpSolid(G4VSolid * sol, unsigned int leafDepth, std::ostream & out) {
-
+void PrintGeomInfoAction::dumpSolid(G4VSolid *sol, unsigned int leafDepth, std::ostream &out) {
   std::string spaces = spacesFromLeafDepth(leafDepth);
   out << spaces << *(sol) << G4endl;
 }
 
-G4VPhysicalVolume * PrintGeomInfoAction::getTopPV() {
-  
+G4VPhysicalVolume *PrintGeomInfoAction::getTopPV() {
   return G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
 }
 
-G4LogicalVolume * PrintGeomInfoAction::getTopLV() { 
-  return theTopPV->GetLogicalVolume(); 
-}
-
-
+G4LogicalVolume *PrintGeomInfoAction::getTopLV() { return theTopPV->GetLogicalVolume(); }

--- a/SimG4Core/PrintGeomInfo/src/PrintGeomSummary.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintGeomSummary.cc
@@ -29,150 +29,145 @@
 #include <set>
 #include <map>
 
-PrintGeomSummary::PrintGeomSummary(const edm::ParameterSet &p) : theTopPV_(nullptr) {
+PrintGeomSummary::PrintGeomSummary(const edm::ParameterSet& p) : theTopPV_(nullptr) {
   std::vector<std::string> defNames;
-  nodeNames_  = p.getUntrackedParameter<std::vector<std::string> >("NodeNames",defNames);
-  G4cout << "PrintGeomSummary:: initialised for " << nodeNames_.size()
-	 << " nodes:" << G4endl;
-  for (unsigned int ii=0; ii<nodeNames_.size(); ii++)
+  nodeNames_ = p.getUntrackedParameter<std::vector<std::string>>("NodeNames", defNames);
+  G4cout << "PrintGeomSummary:: initialised for " << nodeNames_.size() << " nodes:" << G4endl;
+  for (unsigned int ii = 0; ii < nodeNames_.size(); ii++)
     G4cout << "Node[" << ii << "] : " << nodeNames_[ii] << G4endl;
 
-  solidShape_[DDSolidShape::ddbox]            = "Box";
-  solidShape_[DDSolidShape::ddtubs]           = "Tube";
-  solidShape_[DDSolidShape::ddtrap]           = "Trapezoid";
-  solidShape_[DDSolidShape::ddcons]           = "Cone";
-  solidShape_[DDSolidShape::ddpolycone_rz]    = "Polycone_rz";
-  solidShape_[DDSolidShape::ddpolyhedra_rz]   = "Polyhedra_rz";
-  solidShape_[DDSolidShape::ddpolycone_rrz]   = "Polycone_rrz";
-  solidShape_[DDSolidShape::ddpolyhedra_rrz]  = "Polyhedra_rrz";
-  solidShape_[DDSolidShape::ddtorus]          = "Torus";
-  solidShape_[DDSolidShape::ddunion]          = "UnionSolid";
-  solidShape_[DDSolidShape::ddsubtraction]    = "SubtractionSolid"; 
-  solidShape_[DDSolidShape::ddintersection]   = "IntersectionSolid";
-  solidShape_[DDSolidShape::ddshapeless]      = "ShapelessSolid";
-  solidShape_[DDSolidShape::ddpseudotrap]     = "PseudoTrapezoid";
-  solidShape_[DDSolidShape::ddtrunctubs]      = "TruncatedTube";
-  solidShape_[DDSolidShape::ddsphere]         = "Sphere"; 
+  solidShape_[DDSolidShape::ddbox] = "Box";
+  solidShape_[DDSolidShape::ddtubs] = "Tube";
+  solidShape_[DDSolidShape::ddtrap] = "Trapezoid";
+  solidShape_[DDSolidShape::ddcons] = "Cone";
+  solidShape_[DDSolidShape::ddpolycone_rz] = "Polycone_rz";
+  solidShape_[DDSolidShape::ddpolyhedra_rz] = "Polyhedra_rz";
+  solidShape_[DDSolidShape::ddpolycone_rrz] = "Polycone_rrz";
+  solidShape_[DDSolidShape::ddpolyhedra_rrz] = "Polyhedra_rrz";
+  solidShape_[DDSolidShape::ddtorus] = "Torus";
+  solidShape_[DDSolidShape::ddunion] = "UnionSolid";
+  solidShape_[DDSolidShape::ddsubtraction] = "SubtractionSolid";
+  solidShape_[DDSolidShape::ddintersection] = "IntersectionSolid";
+  solidShape_[DDSolidShape::ddshapeless] = "ShapelessSolid";
+  solidShape_[DDSolidShape::ddpseudotrap] = "PseudoTrapezoid";
+  solidShape_[DDSolidShape::ddtrunctubs] = "TruncatedTube";
+  solidShape_[DDSolidShape::ddsphere] = "Sphere";
   solidShape_[DDSolidShape::ddellipticaltube] = "EllipticalTube";
-  solidShape_[DDSolidShape::ddcuttubs]        = "CutTubs";
-  solidShape_[DDSolidShape::ddextrudedpolygon]= "ExtrudedPolygon";
-  solidShape_[DDSolidShape::dd_not_init]      = "Unknown";
+  solidShape_[DDSolidShape::ddcuttubs] = "CutTubs";
+  solidShape_[DDSolidShape::ddextrudedpolygon] = "ExtrudedPolygon";
+  solidShape_[DDSolidShape::dd_not_init] = "Unknown";
 }
- 
-PrintGeomSummary::~PrintGeomSummary() {}
- 
-void PrintGeomSummary::update(const BeginOfJob * job) {
 
+PrintGeomSummary::~PrintGeomSummary() {}
+
+void PrintGeomSummary::update(const BeginOfJob* job) {
   edm::ESTransientHandle<DDCompactView> pDD;
   (*job)()->get<IdealGeometryRecord>().get(pDD);
   const DDCompactView* cpv = &(*pDD);
 
-  const auto & gra = cpv->graph();
+  const auto& gra = cpv->graph();
 
   using Graph = DDCompactView::Graph;
   using adjl_iterator = Graph::const_adj_iterator;
 
-  Graph::index_type i=0;
+  Graph::index_type i = 0;
   solidMap_.clear();
-  for( adjl_iterator git=gra.begin();
-       git != gra.end(); ++git) {
-    const DDLogicalPart & ddLP = gra.nodeData(git);
+  for (adjl_iterator git = gra.begin(); git != gra.end(); ++git) {
+    const DDLogicalPart& ddLP = gra.nodeData(git);
     addSolid(ddLP);
     ++i;
     if (!git->empty()) {
-      // ask for children of ddLP  
-      for( Graph::edge_list::const_iterator cit  = git->begin();
-	   cit != git->end(); ++cit) {
-	const DDLogicalPart & ddcurLP = gra.nodeData(cit->first);
-	addSolid(ddcurLP);
+      // ask for children of ddLP
+      for (Graph::edge_list::const_iterator cit = git->begin(); cit != git->end(); ++cit) {
+        const DDLogicalPart& ddcurLP = gra.nodeData(cit->first);
+        addSolid(ddcurLP);
       }
     }
   }
-  G4cout << "Finds " << solidMap_.size() << " different solids in the tree" 
-	 << G4endl;
+  G4cout << "Finds " << solidMap_.size() << " different solids in the tree" << G4endl;
 }
 
-void PrintGeomSummary::addSolid(const DDLogicalPart & part) {
+void PrintGeomSummary::addSolid(const DDLogicalPart& part) {
   const DDSolid& solid = part.solid();
-  std::map<DDSolidShape,std::string>::iterator it = solidShape_.find(solid.shape());
+  std::map<DDSolidShape, std::string>::iterator it = solidShape_.find(solid.shape());
   std::string name = solid.name().name();
-  if (it == solidShape_.end()) solidMap_[name] = DDSolidShape::dd_not_init;
-  else                         solidMap_[name] = it->first;
-//G4cout << "Solid " << name << " is of shape " << solidMap_[name] << G4endl;
-}  
+  if (it == solidShape_.end())
+    solidMap_[name] = DDSolidShape::dd_not_init;
+  else
+    solidMap_[name] = it->first;
+  //G4cout << "Solid " << name << " is of shape " << solidMap_[name] << G4endl;
+}
 
-void PrintGeomSummary::update(const BeginOfRun * run) {
+void PrintGeomSummary::update(const BeginOfRun* run) {
   theTopPV_ = getTopPV();
   if (theTopPV_) {
-    lvs_.clear(); sls_.clear(); touch_.clear();
-    fillLV(theTopPV_->GetLogicalVolume()); 
+    lvs_.clear();
+    sls_.clear();
+    touch_.clear();
+    fillLV(theTopPV_->GetLogicalVolume());
     std::string name = theTopPV_->GetName();
-    dumpSummary(G4cout,name);
+    dumpSummary(G4cout, name);
 
-    for (unsigned int k=0; k<nodeNames_.size(); ++k) {
-      const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
-      std::vector<G4LogicalVolume *>::const_iterator lvcite;
+    for (unsigned int k = 0; k < nodeNames_.size(); ++k) {
+      const G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();
+      std::vector<G4LogicalVolume*>::const_iterator lvcite;
       for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) {
-	if ((*lvcite)->GetName() == (G4String)(nodeNames_[k])) {
-	  lvs_.clear(); sls_.clear(); touch_.clear();
-	  fillLV(*lvcite); 
-	  dumpSummary(G4cout,nodeNames_[k]);
-	}
+        if ((*lvcite)->GetName() == (G4String)(nodeNames_[k])) {
+          lvs_.clear();
+          sls_.clear();
+          touch_.clear();
+          fillLV(*lvcite);
+          dumpSummary(G4cout, nodeNames_[k]);
+        }
       }
     }
   }
 }
 
-void PrintGeomSummary::fillLV(G4LogicalVolume * lv) {
-
-  if (std::find(lvs_.begin(),lvs_.end(),lv) == lvs_.end()) lvs_.push_back(lv);
+void PrintGeomSummary::fillLV(G4LogicalVolume* lv) {
+  if (std::find(lvs_.begin(), lvs_.end(), lv) == lvs_.end())
+    lvs_.push_back(lv);
   G4VSolid* sl = lv->GetSolid();
-  if (std::find(sls_.begin(),sls_.end(),sl) == sls_.end()) sls_.push_back(sl);
+  if (std::find(sls_.begin(), sls_.end(), sl) == sls_.end())
+    sls_.push_back(sl);
   touch_.push_back(lv);
-  for(int ii = 0; ii < (int)(lv->GetNoDaughters()); ii++)
+  for (int ii = 0; ii < (int)(lv->GetNoDaughters()); ii++)
     fillLV(lv->GetDaughter(ii)->GetLogicalVolume());
 }
 
-void PrintGeomSummary::dumpSummary(std::ostream & out, std::string name) {
-
+void PrintGeomSummary::dumpSummary(std::ostream& out, std::string name) {
   //---------- Dump number of objects of each class
-  out << G4endl << G4endl
-      << "@@@@@@@@@@@@@@@@@@ Dumping Summary For Node " << name << G4endl;
+  out << G4endl << G4endl << "@@@@@@@@@@@@@@@@@@ Dumping Summary For Node " << name << G4endl;
   out << " Number of G4VSolid's: " << sls_.size() << G4endl;
   out << " Number of G4LogicalVolume's: " << lvs_.size() << G4endl;
   out << " Number of Touchable's: " << touch_.size() << G4endl;
   //First the solids
   out << G4endl << "Occurence of each type of shape among Solids" << G4endl;
   kount_.clear();
-  for (std::vector<G4VSolid*>::iterator it=sls_.begin(); it!=sls_.end(); ++it) {
+  for (std::vector<G4VSolid*>::iterator it = sls_.begin(); it != sls_.end(); ++it) {
     std::string name = (*it)->GetName();
     addName(name);
   }
   printSummary(out);
   //Then the logical volumes
-  out << G4endl << "Occurence of each type of shape among Logical Volumes" 
-      << G4endl;
+  out << G4endl << "Occurence of each type of shape among Logical Volumes" << G4endl;
   kount_.clear();
-  for (std::vector<G4LogicalVolume*>::iterator it = lvs_.begin(); 
-       it != lvs_.end(); ++it) {
+  for (std::vector<G4LogicalVolume*>::iterator it = lvs_.begin(); it != lvs_.end(); ++it) {
     std::string name = ((*it)->GetSolid())->GetName();
     addName(name);
   }
   printSummary(out);
   //Finally the touchables
-  out << G4endl << "Occurence of each type of shape among Touchables" 
-      << G4endl;
+  out << G4endl << "Occurence of each type of shape among Touchables" << G4endl;
   kount_.clear();
-  for (std::vector<G4LogicalVolume*>::iterator it = touch_.begin(); 
-       it != touch_.end(); ++it) {
+  for (std::vector<G4LogicalVolume*>::iterator it = touch_.begin(); it != touch_.end(); ++it) {
     std::string name = ((*it)->GetSolid())->GetName();
     addName(name);
   }
   printSummary(out);
 }
 
-G4VPhysicalVolume * PrintGeomSummary::getTopPV() {
-  
+G4VPhysicalVolume* PrintGeomSummary::getTopPV() {
   return G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
 }
 
@@ -180,27 +175,23 @@ void PrintGeomSummary::addName(std::string name) {
   bool refl(false);
   if (name.find("_refl") < name.size()) {
     refl = true;
-    name = name.substr(0,(name.find("_refl")));
+    name = name.substr(0, (name.find("_refl")));
   }
-  std::map<std::string,DDSolidShape>::const_iterator jt=solidMap_.find(name);
-  DDSolidShape shape =  (jt == solidMap_.end()) ? DDSolidShape::dd_not_init : jt->second;
-  std::map<DDSolidShape,std::pair<int,int>>::iterator itr = kount_.find(shape);
+  std::map<std::string, DDSolidShape>::const_iterator jt = solidMap_.find(name);
+  DDSolidShape shape = (jt == solidMap_.end()) ? DDSolidShape::dd_not_init : jt->second;
+  std::map<DDSolidShape, std::pair<int, int>>::iterator itr = kount_.find(shape);
   if (itr == kount_.end()) {
-    kount_[shape] = (refl) ? std::pair<int,int>(0,1) : std::pair<int,int>(1,0);
+    kount_[shape] = (refl) ? std::pair<int, int>(0, 1) : std::pair<int, int>(1, 0);
   } else {
-    kount_[shape] = (refl) ? 
-      std::pair<int,int>(((itr->second).first),++((itr->second).second)) :
-      std::pair<int,int>(++((itr->second).first),((itr->second).second));
+    kount_[shape] = (refl) ? std::pair<int, int>(((itr->second).first), ++((itr->second).second))
+                           : std::pair<int, int>(++((itr->second).first), ((itr->second).second));
   }
 }
 
-void PrintGeomSummary::printSummary(std::ostream & out) {
+void PrintGeomSummary::printSummary(std::ostream& out) {
   int k(0);
-  for (std::map<DDSolidShape,std::pair<int,int> >::iterator itr=kount_.begin();
-       itr != kount_.end(); ++itr, ++k) {
+  for (std::map<DDSolidShape, std::pair<int, int>>::iterator itr = kount_.begin(); itr != kount_.end(); ++itr, ++k) {
     std::string shape = solidShape_[itr->first];
-    out << "Shape [" << k << "]  " << shape << " # " << (itr->second).first
-	<< " : " << (itr->second).second << G4endl;
+    out << "Shape [" << k << "]  " << shape << " # " << (itr->second).first << " : " << (itr->second).second << G4endl;
   }
 }
-

--- a/SimG4Core/PrintGeomInfo/src/PrintMaterialBudgetInfo.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintMaterialBudgetInfo.cc
@@ -30,20 +30,20 @@
 #include <set>
 
 PrintMaterialBudgetInfo::PrintMaterialBudgetInfo(const edm::ParameterSet& p) {
-  name  = p.getUntrackedParameter<std::string>("Name","*");
+  name = p.getUntrackedParameter<std::string>("Name", "*");
   nchar = name.find("*");
-  name.assign(name,0,nchar);
+  name.assign(name, 0, nchar);
   std::cout << "PrintMaterialBudget selected volume " << name << std::endl;
   volumeFound = false;
-  std::string weightFileName = name+".weight";
-  weightOutputFile.open( weightFileName.c_str() );
-  std::string elementFileName = name+".element";
-  elementOutputFile.open( elementFileName.c_str() );
-  std::string texFileName = name+"_table.tex";
-  texOutputFile.open( texFileName.c_str() );
-  std::cout << "PrintMaterialBudget output file " << weightFileName  << std::endl;
+  std::string weightFileName = name + ".weight";
+  weightOutputFile.open(weightFileName.c_str());
+  std::string elementFileName = name + ".element";
+  elementOutputFile.open(elementFileName.c_str());
+  std::string texFileName = name + "_table.tex";
+  texOutputFile.open(texFileName.c_str());
+  std::cout << "PrintMaterialBudget output file " << weightFileName << std::endl;
   std::cout << "PrintMaterialBudget output file " << elementFileName << std::endl;
-  std::cout << "PrintMaterialBudget output file " << texFileName     << std::endl;
+  std::cout << "PrintMaterialBudget output file " << texFileName << std::endl;
   elementNames.clear();
   elementTotalWeight.clear();
   elementWeightFraction.clear();
@@ -52,19 +52,17 @@ PrintMaterialBudgetInfo::PrintMaterialBudgetInfo(const edm::ParameterSet& p) {
 PrintMaterialBudgetInfo::~PrintMaterialBudgetInfo() {}
 
 void PrintMaterialBudgetInfo::update(const BeginOfRun* run) {
-  
   G4Random::setTheEngine(new CLHEP::RanecuEngine);
   // Physical Volume
   theTopPV = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
   assert(theTopPV);
   // Logical Volume
-  G4LogicalVolume*  lv = theTopPV->GetLogicalVolume();
+  G4LogicalVolume* lv = theTopPV->GetLogicalVolume();
   unsigned int leafDepth = 0;
   // the first time fill the vectors of elements
-  if( elementNames.empty() && elementTotalWeight.empty() && elementWeightFraction.empty()) {
-    for(unsigned int iElement = 0;
-	iElement < G4Element::GetNumberOfElements();
-	iElement++) { // first element in table is 0
+  if (elementNames.empty() && elementTotalWeight.empty() && elementWeightFraction.empty()) {
+    for (unsigned int iElement = 0; iElement < G4Element::GetNumberOfElements();
+         iElement++) {  // first element in table is 0
       elementNames.push_back("rr");
       elementTotalWeight.push_back(0);
       elementWeightFraction.push_back(0);
@@ -78,211 +76,230 @@ void PrintMaterialBudgetInfo::update(const BeginOfRun* run) {
   //
 }
 
-void PrintMaterialBudgetInfo::dumpHeader(std::ostream& out ) {
-  out << "Geom."      << "\t"
-      << "Volume"     << "\t" << "\t"
-      << "Copy"       << "\t"
-      << "Solid"      << "\t" << "\t"
-      << "Material"   << "\t"
-      << "Density"    << "\t" << "\t"
-      << "Mass"       << "\t" << "\t"
-      << std::endl;
-  out << "Level"     << "\t"
-      << "Name"      << "\t" << "\t"
-      << "Number"    << "\t"
-      << "Name"      << "\t" << "\t"
-      << "Name"      << "\t" << "\t"
-      << "[g/cm3]"   << "\t" << "\t"
-      << "[g]    "   << "\t" << "\t"
-      << std::endl;
+void PrintMaterialBudgetInfo::dumpHeader(std::ostream& out) {
+  out << "Geom."
+      << "\t"
+      << "Volume"
+      << "\t"
+      << "\t"
+      << "Copy"
+      << "\t"
+      << "Solid"
+      << "\t"
+      << "\t"
+      << "Material"
+      << "\t"
+      << "Density"
+      << "\t"
+      << "\t"
+      << "Mass"
+      << "\t"
+      << "\t" << std::endl;
+  out << "Level"
+      << "\t"
+      << "Name"
+      << "\t"
+      << "\t"
+      << "Number"
+      << "\t"
+      << "Name"
+      << "\t"
+      << "\t"
+      << "Name"
+      << "\t"
+      << "\t"
+      << "[g/cm3]"
+      << "\t"
+      << "\t"
+      << "[g]    "
+      << "\t"
+      << "\t" << std::endl;
 }
 
-void PrintMaterialBudgetInfo::dumpLaTeXHeader(std::ostream& out ) {
-  out << "\\begin{table}[h!]"                                     << std::endl
-      << "  \\caption{\\textsf {" << name << "} volume list.}"               << std::endl
-      << "  \\label{tab: " << name << "}"                         << std::endl
-      << "  \\begin{center}"                                      << std::endl
-      << "    \\begin{tabular}{ccccccc}"                          << std::endl
-      << "      \\hline"                                          << std::endl;
-  out << "      Geom."      << "\t & "
-      << "      Volume"     << "\t & "
-      << "      Copy"       << "\t & "
-      << "      Solid"      << "\t & "
-      << "      Material"   << "\t & "
-      << "      Density"    << "\t & "
-      << "      Mass"       << "\t \\\\ "
-      << std::endl;
-  out << "      Level"      << "\t & "
-      << "      Name"       << "\t & "
-      << "      Number"     << "\t & "
-      << "      Name"       << "\t & "
-      << "      Name"       << "\t & "
-      << "                " << "\t & "
-      << "                " << "\t \\\\ "
-      << std::endl
-      << "      \\hline\\hline"
-      << std::endl;
+void PrintMaterialBudgetInfo::dumpLaTeXHeader(std::ostream& out) {
+  out << "\\begin{table}[h!]" << std::endl
+      << "  \\caption{\\textsf {" << name << "} volume list.}" << std::endl
+      << "  \\label{tab: " << name << "}" << std::endl
+      << "  \\begin{center}" << std::endl
+      << "    \\begin{tabular}{ccccccc}" << std::endl
+      << "      \\hline" << std::endl;
+  out << "      Geom."
+      << "\t & "
+      << "      Volume"
+      << "\t & "
+      << "      Copy"
+      << "\t & "
+      << "      Solid"
+      << "\t & "
+      << "      Material"
+      << "\t & "
+      << "      Density"
+      << "\t & "
+      << "      Mass"
+      << "\t \\\\ " << std::endl;
+  out << "      Level"
+      << "\t & "
+      << "      Name"
+      << "\t & "
+      << "      Number"
+      << "\t & "
+      << "      Name"
+      << "\t & "
+      << "      Name"
+      << "\t & "
+      << "                "
+      << "\t & "
+      << "                "
+      << "\t \\\\ " << std::endl
+      << "      \\hline\\hline" << std::endl;
 }
 
-void PrintMaterialBudgetInfo::dumpLaTeXFooter(std::ostream& out ) {
-  out << "      \\hline"      << std::endl
+void PrintMaterialBudgetInfo::dumpLaTeXFooter(std::ostream& out) {
+  out << "      \\hline" << std::endl
       << "    \\end{tabular}" << std::endl
-      << "  \\end{center}"    << std::endl
-      << "\\end{table}"       << std::endl;
+      << "  \\end{center}" << std::endl
+      << "\\end{table}" << std::endl;
 }
 
-void PrintMaterialBudgetInfo::dumpHierarchyLeaf(G4VPhysicalVolume* pv, G4LogicalVolume* lv,
-						unsigned int leafDepth,
-						std::ostream& weightOut,
-						std::ostream& texOut ) {
-  
-  if( volumeFound && ( leafDepth <= levelFound ) ) return; 
-  if( volumeFound && ( leafDepth >  levelFound ) ) printInfo(pv, lv, leafDepth, weightOut, texOut);
-  
+void PrintMaterialBudgetInfo::dumpHierarchyLeaf(
+    G4VPhysicalVolume* pv, G4LogicalVolume* lv, unsigned int leafDepth, std::ostream& weightOut, std::ostream& texOut) {
+  if (volumeFound && (leafDepth <= levelFound))
+    return;
+  if (volumeFound && (leafDepth > levelFound))
+    printInfo(pv, lv, leafDepth, weightOut, texOut);
+
   // choose mother volume
   std::string lvname = lv->GetName();
-  lvname.assign(lvname,0,nchar);
+  lvname.assign(lvname, 0, nchar);
   if (lvname == name) {
     volumeFound = true;
-    levelFound  = leafDepth;
+    levelFound = leafDepth;
     printInfo(pv, lv, leafDepth, weightOut, texOut);
     texOut << "      \\hline" << std::endl;
   }
-  
+
   //----- Get LV daughters from list of PV daughters
   mmlvpv lvpvDaughters;
-  std::set< G4LogicalVolume* > lvDaughters;
+  std::set<G4LogicalVolume*> lvDaughters;
   int NoDaughters = lv->GetNoDaughters();
-  while ((NoDaughters--)>0)
-    {
-      G4VPhysicalVolume* pvD = lv->GetDaughter(NoDaughters);
-      lvpvDaughters.insert(mmlvpv::value_type(pvD->GetLogicalVolume(), pvD));
-      lvDaughters.insert(pvD->GetLogicalVolume());
-    }
-  
-  std::set< G4LogicalVolume* >::const_iterator scite;
+  while ((NoDaughters--) > 0) {
+    G4VPhysicalVolume* pvD = lv->GetDaughter(NoDaughters);
+    lvpvDaughters.insert(mmlvpv::value_type(pvD->GetLogicalVolume(), pvD));
+    lvDaughters.insert(pvD->GetLogicalVolume());
+  }
+
+  std::set<G4LogicalVolume*>::const_iterator scite;
   mmlvpv::const_iterator mmcite;
-  
+
   //----- Dump daughters PV and LV
   for (scite = lvDaughters.begin(); scite != lvDaughters.end(); scite++) {
-    std::pair< mmlvpv::iterator, mmlvpv::iterator > mmER = lvpvDaughters.equal_range(*scite);    
+    std::pair<mmlvpv::iterator, mmlvpv::iterator> mmER = lvpvDaughters.equal_range(*scite);
     //----- Dump daughters PV of this LV
-    for (mmcite = mmER.first ; mmcite != mmER.second; mmcite++) 
-      dumpHierarchyLeaf((*mmcite).second, *scite, leafDepth+1, weightOut, texOut );
+    for (mmcite = mmER.first; mmcite != mmER.second; mmcite++)
+      dumpHierarchyLeaf((*mmcite).second, *scite, leafDepth + 1, weightOut, texOut);
   }
-  
 }
 
-void PrintMaterialBudgetInfo::printInfo(G4VPhysicalVolume* pv, G4LogicalVolume* lv, unsigned int leafDepth,
-					std::ostream& weightOut, std::ostream& texOut ) {
-  
+void PrintMaterialBudgetInfo::printInfo(
+    G4VPhysicalVolume* pv, G4LogicalVolume* lv, unsigned int leafDepth, std::ostream& weightOut, std::ostream& texOut) {
   double density = lv->GetMaterial()->GetDensity();
-  double weight  = lv->GetMass(false,false);
-  
+  double weight = lv->GetMass(false, false);
+
   std::string volumeName = lv->GetName();
-  if(volumeName.size()<8) volumeName.append("\t");
-  
+  if (volumeName.size() < 8)
+    volumeName.append("\t");
+
   std::string solidName = lv->GetSolid()->GetName();
-  if(solidName.size()<8) solidName.append("\t");
-    
+  if (solidName.size() < 8)
+    solidName.append("\t");
+
   std::string materialName = lv->GetMaterial()->GetName();
-  if(materialName.size()<8) materialName.append("\t");
-  
-  //----- dump info 
-  weightOut << leafDepth                                            << "\t"
-	    << volumeName                                           << "\t"
-	    << pv->GetCopyNo()                                      << "\t"
-	    << solidName                                            << "\t"
-	    << materialName                                         << "\t"
-	    << G4BestUnit(density,"Volumic Mass")                   << "\t"
-	    << G4BestUnit(weight,"Mass")                            << "\t"
-	    << std::endl;
+  if (materialName.size() < 8)
+    materialName.append("\t");
+
+  //----- dump info
+  weightOut << leafDepth << "\t" << volumeName << "\t" << pv->GetCopyNo() << "\t" << solidName << "\t" << materialName
+            << "\t" << G4BestUnit(density, "Volumic Mass") << "\t" << G4BestUnit(weight, "Mass") << "\t" << std::endl;
   //
-  texOut << "\t" 
-	 << leafDepth                                                  << "\t & "
-	 << stringLaTeXUnderscore(volumeName)                          << "\t & "
-	 << pv->GetCopyNo()                                            << "\t & "
-	 << stringLaTeXUnderscore(solidName)                           << "\t & "
-	 << stringLaTeXUnderscore(materialName)                        << "\t & "
-	 << stringLaTeXSuperscript(G4BestUnit(density,"Volumic Mass")) << "\t & "
-	 << stringLaTeXSuperscript(G4BestUnit(weight,"Mass"))          << "\t \\\\ "
-	 << std::endl;
-  //  
-  for(unsigned int iElement = 0; iElement<(unsigned int)lv->GetMaterial()->GetNumberOfElements(); iElement++) {
+  texOut << "\t" << leafDepth << "\t & " << stringLaTeXUnderscore(volumeName) << "\t & " << pv->GetCopyNo() << "\t & "
+         << stringLaTeXUnderscore(solidName) << "\t & " << stringLaTeXUnderscore(materialName) << "\t & "
+         << stringLaTeXSuperscript(G4BestUnit(density, "Volumic Mass")) << "\t & "
+         << stringLaTeXSuperscript(G4BestUnit(weight, "Mass")) << "\t \\\\ " << std::endl;
+  //
+  for (unsigned int iElement = 0; iElement < (unsigned int)lv->GetMaterial()->GetNumberOfElements(); iElement++) {
     // exclude Air in element weight fraction computation
-    if(materialName.find("Air")) {
+    if (materialName.find("Air")) {
       std::string elementName = lv->GetMaterial()->GetElement(iElement)->GetName();
       double elementMassFraction = lv->GetMaterial()->GetFractionVector()[iElement];
-      double elementWeight = weight*elementMassFraction;
+      double elementWeight = weight * elementMassFraction;
       unsigned int elementIndex = (unsigned int)lv->GetMaterial()->GetElement(iElement)->GetIndex();
-      elementNames[elementIndex]        = elementName;
+      elementNames[elementIndex] = elementName;
       elementTotalWeight[elementIndex] += elementWeight;
     }
   }
 }
 
-void PrintMaterialBudgetInfo::dumpElementMassFraction(std::ostream& elementOut ) {
+void PrintMaterialBudgetInfo::dumpElementMassFraction(std::ostream& elementOut) {
   // calculate mass fraction
-  double totalWeight   = 0.0;
+  double totalWeight = 0.0;
   double totalFraction = 0.0;
-  for(unsigned int iElement = 0; iElement<(unsigned int)elementTotalWeight.size(); iElement++) {
-    totalWeight+=elementTotalWeight[iElement];
+  for (unsigned int iElement = 0; iElement < (unsigned int)elementTotalWeight.size(); iElement++) {
+    totalWeight += elementTotalWeight[iElement];
   }
   // calculate element mass fractions
-  for(unsigned int iElement = 0; iElement<(unsigned int)elementTotalWeight.size(); iElement++) {
-    elementWeightFraction[iElement] = elementTotalWeight[iElement]/totalWeight;
-    totalFraction+=elementWeightFraction[iElement];
+  for (unsigned int iElement = 0; iElement < (unsigned int)elementTotalWeight.size(); iElement++) {
+    elementWeightFraction[iElement] = elementTotalWeight[iElement] / totalWeight;
+    totalFraction += elementWeightFraction[iElement];
   }
   // header
-  elementOut << "Element"        << "\t\t"
-	     << "Index"          << "\t"
-	     << "Total Mass"     << "\t"
-	     << "Mass Fraction " << "\t"
-	     << std::endl;
+  elementOut << "Element"
+             << "\t\t"
+             << "Index"
+             << "\t"
+             << "Total Mass"
+             << "\t"
+             << "Mass Fraction "
+             << "\t" << std::endl;
   // dump
-  for(unsigned int iElement = 0; iElement<(unsigned int)elementTotalWeight.size(); iElement++) {
-    if(elementNames[iElement]!="rr") {
-      if(elementNames[iElement].size()<8) elementNames[iElement].append("\t");
-      elementOut << elementNames[iElement]                          << "\t"
-		 << iElement                                        << "\t"
-		 << G4BestUnit(elementTotalWeight[iElement],"Mass") << "\t"
-		 << elementWeightFraction[iElement]
-		 << std::endl;
+  for (unsigned int iElement = 0; iElement < (unsigned int)elementTotalWeight.size(); iElement++) {
+    if (elementNames[iElement] != "rr") {
+      if (elementNames[iElement].size() < 8)
+        elementNames[iElement].append("\t");
+      elementOut << elementNames[iElement] << "\t" << iElement << "\t"
+                 << G4BestUnit(elementTotalWeight[iElement], "Mass") << "\t" << elementWeightFraction[iElement]
+                 << std::endl;
     }
   }
-  elementOut << "\n\t\tTotal Weight without Air " << G4BestUnit(totalWeight,"Mass")
-	     << "\tTotal Fraction "   << totalFraction
-	     << std::endl;
+  elementOut << "\n\t\tTotal Weight without Air " << G4BestUnit(totalWeight, "Mass") << "\tTotal Fraction "
+             << totalFraction << std::endl;
 }
 
 std::string PrintMaterialBudgetInfo::stringLaTeXUnderscore(std::string stringname) {
   // To replace '\' with '\_' to compile LaTeX output
   std::string stringoutput;
-  
-  for (unsigned int  i=0; i<stringname.length() ; i++) {
-    if (stringname.substr(i,1) == "_") {
+
+  for (unsigned int i = 0; i < stringname.length(); i++) {
+    if (stringname.substr(i, 1) == "_") {
       stringoutput += "\\_";
     } else {
-      stringoutput += stringname.substr(i,1);
+      stringoutput += stringname.substr(i, 1);
     }
   }
-  
+
   return stringoutput;
-  
 }
 
 std::string PrintMaterialBudgetInfo::stringLaTeXSuperscript(std::string stringname) {
   // To replace 'm3' with 'm$^3$' to compile LaTeX output
-  std::string stringoutput = stringname.substr(0,1);
-  
-  for (unsigned int  i=1; i<stringname.length() ; i++) {
-    if (stringname.substr(i-1,1) == "m" && stringname.substr(i,1) == "3") {
+  std::string stringoutput = stringname.substr(0, 1);
+
+  for (unsigned int i = 1; i < stringname.length(); i++) {
+    if (stringname.substr(i - 1, 1) == "m" && stringname.substr(i, 1) == "3") {
       stringoutput += "$^3$";
     } else {
-      stringoutput += stringname.substr(i,1);
+      stringoutput += stringname.substr(i, 1);
     }
   }
-    
+
   return stringoutput;
-  
 }

--- a/SimG4Core/PrintGeomInfo/src/PrintSensitive.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintSensitive.cc
@@ -13,55 +13,54 @@
 using namespace CLHEP;
 
 PrintSensitive::PrintSensitive(const edm::ParameterSet &p) {
-  name  = p.getUntrackedParameter<std::string>("Name","*");
+  name = p.getUntrackedParameter<std::string>("Name", "*");
   nchar = name.find("*");
-  name.assign(name,0,nchar);
+  name.assign(name, 0, nchar);
   std::cout << "PrintSensitive:: Print position of all Sensitive Touchables: "
-	    << " for names (0-" << nchar << ") = " << name << "\n";
+            << " for names (0-" << nchar << ") = " << name << "\n";
 }
- 
-PrintSensitive::~PrintSensitive() {}
-  
-void PrintSensitive::update(const BeginOfRun * run) {
 
-  G4VPhysicalVolume * theTopPV = getTopPV();
+PrintSensitive::~PrintSensitive() {}
+
+void PrintSensitive::update(const BeginOfRun *run) {
+  G4VPhysicalVolume *theTopPV = getTopPV();
   dumpTouch(theTopPV, 0, false, std::cout);
 }
 
-void PrintSensitive::dumpTouch(G4VPhysicalVolume * pv, unsigned int leafDepth, 
-			       bool printIt, std::ostream & out) {
+void PrintSensitive::dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, bool printIt, std::ostream &out) {
+  if (leafDepth == 0)
+    fHistory.SetFirstEntry(pv);
+  else
+    fHistory.NewLevel(pv, kNormal, pv->GetCopyNo());
 
-  if (leafDepth == 0) fHistory.SetFirstEntry(pv);
-  else fHistory.NewLevel(pv, kNormal, pv->GetCopyNo());
-
-  G4ThreeVector globalpoint = fHistory.GetTopTransform().Inverse().
-    TransformPoint(G4ThreeVector(0,0,0));
-  G4LogicalVolume * lv = pv->GetLogicalVolume();
+  G4ThreeVector globalpoint = fHistory.GetTopTransform().Inverse().TransformPoint(G4ThreeVector(0, 0, 0));
+  G4LogicalVolume *lv = pv->GetLogicalVolume();
 
   std::string mother = "World";
-  if (pv->GetMotherLogical()) mother = pv->GetMotherLogical()->GetName();
+  if (pv->GetMotherLogical())
+    mother = pv->GetMotherLogical()->GetName();
   std::string lvname = lv->GetName();
-  lvname.assign(lvname,0,nchar);
-  if (lvname == name) printIt = true;
+  lvname.assign(lvname, 0, nchar);
+  if (lvname == name)
+    printIt = true;
 
   if (lv->GetSensitiveDetector() && printIt) {
-    out << leafDepth << " ### VOLUME = " << lv->GetName() 
-	<< " Copy No " << pv->GetCopyNo() << " in " << mother
-	<< " global position of centre " << globalpoint << " (r=" 
-	<<  globalpoint.perp() << ", phi=" <<  globalpoint.phi()/deg
-	<< ")\n";
+    out << leafDepth << " ### VOLUME = " << lv->GetName() << " Copy No " << pv->GetCopyNo() << " in " << mother
+        << " global position of centre " << globalpoint << " (r=" << globalpoint.perp()
+        << ", phi=" << globalpoint.phi() / deg << ")\n";
   }
 
   int NoDaughters = lv->GetNoDaughters();
-  while ((NoDaughters--)>0)  {
-    G4VPhysicalVolume * pvD = lv->GetDaughter(NoDaughters);
-    if (!pvD->IsReplicated()) dumpTouch(pvD, leafDepth+1, printIt, out);
+  while ((NoDaughters--) > 0) {
+    G4VPhysicalVolume *pvD = lv->GetDaughter(NoDaughters);
+    if (!pvD->IsReplicated())
+      dumpTouch(pvD, leafDepth + 1, printIt, out);
   }
 
-  if (leafDepth > 0) fHistory.BackLevel();
+  if (leafDepth > 0)
+    fHistory.BackLevel();
 }
 
-G4VPhysicalVolume * PrintSensitive::getTopPV() {
-  return G4TransportationManager::GetTransportationManager()
-    ->GetNavigatorForTracking()->GetWorldVolume();
+G4VPhysicalVolume *PrintSensitive::getTopPV() {
+  return G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
 }

--- a/SimG4Core/PrintGeomInfo/src/module.cc
+++ b/SimG4Core/PrintGeomInfo/src/module.cc
@@ -4,7 +4,6 @@
 #include "SimG4Core/PrintGeomInfo/interface/PrintSensitive.h"
 #include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
-   
 
 DEFINE_SIMWATCHER(PrintGeomInfoAction);
 DEFINE_SIMWATCHER(PrintGeomSummary);

--- a/SimG4Core/TrackingVerbose/interface/TrackingVerboseAction.h
+++ b/SimG4Core/TrackingVerbose/interface/TrackingVerboseAction.h
@@ -12,7 +12,7 @@
 // each fTVTrackStep tracks (starting at 1, not 0) and if the trackNo is
 //     fTVTrackMin <= trackNo <= fTVTrackMax
 // each fTVTrackStep tracks (starting at 1, not 0)
-// 
+//
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef SimG4Core_TrackingVerbose_h
@@ -21,7 +21,7 @@
 #include "SimG4Core/Watcher/interface/SimWatcher.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-  
+
 #include "G4Step.hh"
 
 #include <vector>
@@ -34,27 +34,28 @@ class G4Track;
 class G4TrackingManager;
 class G4VSteppingVerbose;
 
-class TrackingVerboseAction :  public SimWatcher,
-			       public Observer<const BeginOfRun *>, 
-			       public Observer<const BeginOfEvent *>, 
-			       public Observer<const BeginOfTrack *>,
-                               public Observer<const EndOfTrack *>,
-                               public Observer<const G4Step *> {
-
+class TrackingVerboseAction : public SimWatcher,
+                              public Observer<const BeginOfRun *>,
+                              public Observer<const BeginOfEvent *>,
+                              public Observer<const BeginOfTrack *>,
+                              public Observer<const EndOfTrack *>,
+                              public Observer<const G4Step *> {
 public:
-  TrackingVerboseAction(edm::ParameterSet const & p);
+  TrackingVerboseAction(edm::ParameterSet const &p);
   ~TrackingVerboseAction() override;
   void update(const BeginOfRun *) override;
   void update(const BeginOfEvent *) override;
   void update(const BeginOfTrack *) override;
   void update(const EndOfTrack *) override;
-  void update(const G4Step*) override;
+  void update(const G4Step *) override;
+
 private:
   void setTrackingVerbose(int verblev);
-  bool checkTrackingVerbose(const G4Track*);
-  void printTrackInfo(const G4Track*);
+  bool checkTrackingVerbose(const G4Track *);
+  void printTrackInfo(const G4Track *);
+
 private:
-  int  fLarge;
+  int fLarge;
   bool fDEBUG;
   bool fG4Verbose;
   bool fHighEtPhotons;
@@ -68,8 +69,8 @@ private:
   bool fTrackingVerboseON;
   bool fTkVerbThisEventON;
   std::vector<int> fPdgIds;
-  G4TrackingManager * theTrackingManager;
-  G4VSteppingVerbose* fVerbose;
+  G4TrackingManager *theTrackingManager;
+  G4VSteppingVerbose *fVerbose;
 };
 
 #endif

--- a/SimG4Core/TrackingVerbose/src/TrackingVerboseAction.cc
+++ b/SimG4Core/TrackingVerbose/src/TrackingVerboseAction.cc
@@ -22,55 +22,49 @@
 #include "G4VSteppingVerbose.hh"
 #include "G4UnitsTable.hh"
 
-#include<algorithm>
+#include <algorithm>
 
 using namespace CLHEP;
 
-TrackingVerboseAction::TrackingVerboseAction(edm::ParameterSet const & p) :
-  theTrackingManager(nullptr), fVerbose(nullptr) {
-
+TrackingVerboseAction::TrackingVerboseAction(edm::ParameterSet const& p)
+    : theTrackingManager(nullptr), fVerbose(nullptr) {
   fLarge = int(1E10);
-  fDEBUG = p.getUntrackedParameter<bool>("DEBUG",false);
-  fHighEtPhotons = p.getUntrackedParameter<bool>("CheckForHighEtPhotons",false);
-  fG4Verbose = p.getUntrackedParameter<bool>("G4Verbose",false);
+  fDEBUG = p.getUntrackedParameter<bool>("DEBUG", false);
+  fHighEtPhotons = p.getUntrackedParameter<bool>("CheckForHighEtPhotons", false);
+  fG4Verbose = p.getUntrackedParameter<bool>("G4Verbose", false);
 
   //----- Set which events are verbose
-  fTVEventMin  = p.getUntrackedParameter<int>("EventMin",0);
-  fTVEventMax  = p.getUntrackedParameter<int>("EventMax",fLarge);
-  fTVEventStep = p.getUntrackedParameter<int>("EventStep",1);
+  fTVEventMin = p.getUntrackedParameter<int>("EventMin", 0);
+  fTVEventMax = p.getUntrackedParameter<int>("EventMax", fLarge);
+  fTVEventStep = p.getUntrackedParameter<int>("EventStep", 1);
 
   //----- Set which tracks of those events are verbose
-  fTVTrackMin  = p.getUntrackedParameter<int>("TrackMin",0);
-  fTVTrackMax  = p.getUntrackedParameter<int>("TrackMax",fLarge);
-  fTVTrackStep = p.getUntrackedParameter<int>("TrackStep",1);
+  fTVTrackMin = p.getUntrackedParameter<int>("TrackMin", 0);
+  fTVTrackMax = p.getUntrackedParameter<int>("TrackMax", fLarge);
+  fTVTrackStep = p.getUntrackedParameter<int>("TrackStep", 1);
 
   //----- Set the verbosity level
-  fVerboseLevel = p.getUntrackedParameter<int>("VerboseLevel",1);
-  fPdgIds       = p.getUntrackedParameter<std::vector<int> >("PDGids");
+  fVerboseLevel = p.getUntrackedParameter<int>("VerboseLevel", 1);
+  fPdgIds = p.getUntrackedParameter<std::vector<int> >("PDGids");
   if (fDEBUG) {
-    G4cout << "TV: fTVTrackMin " << fTVTrackMin 
-	   << " fTVTrackMax "    <<  fTVTrackMax 
-	   <<  " fTVTrackStep "  << fTVTrackStep  
-	   << " fTVEventMin "    << fTVEventMin 
-	   << " fTVEventMax "    << fTVEventMax   
-	   << " fTVEventStep "   << fTVEventStep 
-	   << " fVerboseLevel "  << fVerboseLevel 
-	   << " fG4Verbose "     << fG4Verbose 
-	   << " PDGIds     "     << fPdgIds.size() << G4endl;
-    for (unsigned int ii=0; ii<fPdgIds.size(); ++ii) 
+    G4cout << "TV: fTVTrackMin " << fTVTrackMin << " fTVTrackMax " << fTVTrackMax << " fTVTrackStep " << fTVTrackStep
+           << " fTVEventMin " << fTVEventMin << " fTVEventMax " << fTVEventMax << " fTVEventStep " << fTVEventStep
+           << " fVerboseLevel " << fVerboseLevel << " fG4Verbose " << fG4Verbose << " PDGIds     " << fPdgIds.size()
+           << G4endl;
+    for (unsigned int ii = 0; ii < fPdgIds.size(); ++ii)
       G4cout << "TV: PDGId[" << ii << "] = " << fPdgIds[ii] << G4endl;
   }
-  
+
   //----- Set verbosity off to start
   fTrackingVerboseON = false;
   fTkVerbThisEventON = false;
-  
+
   G4cout << " TrackingVerbose constructed " << G4endl;
 }
 
 TrackingVerboseAction::~TrackingVerboseAction() {}
 
-void TrackingVerboseAction::update(const BeginOfRun * run) {
+void TrackingVerboseAction::update(const BeginOfRun* run) {
   /*
   TrackingAction * ta = 
     dynamic_cast<TrackingAction*>(G4EventManager::GetEventManager()->GetUserTrackingAction());
@@ -78,46 +72,50 @@ void TrackingVerboseAction::update(const BeginOfRun * run) {
   */
   fVerbose = G4VSteppingVerbose::GetInstance();
   if (fDEBUG)
-    G4cout << " TV: Get the Tracking Manager: " << theTrackingManager
-	   << " and the SteppingVerbose: " << fVerbose << G4endl;
+    G4cout << " TV: Get the Tracking Manager: " << theTrackingManager << " and the SteppingVerbose: " << fVerbose
+           << G4endl;
 }
 
-void TrackingVerboseAction::update(const BeginOfEvent * evt) {
-  if (evt==nullptr) return;
-  const G4Event * anEvent = (*evt)();
-  if (anEvent==nullptr) return;
+void TrackingVerboseAction::update(const BeginOfEvent* evt) {
+  if (evt == nullptr)
+    return;
+  const G4Event* anEvent = (*evt)();
+  if (anEvent == nullptr)
+    return;
 
-  //----------- Set /tracking/verbose for this event 
+  //----------- Set /tracking/verbose for this event
   int eventNo = anEvent->GetEventID();
-  if (fDEBUG) G4cout << "TV: trackID: NEW EVENT " << eventNo << G4endl;
+  if (fDEBUG)
+    G4cout << "TV: trackID: NEW EVENT " << eventNo << G4endl;
 
   fTkVerbThisEventON = false;
   //----- Check if event is in the selected range
   if (eventNo >= fTVEventMin && eventNo <= fTVEventMax) {
-    if ((eventNo-fTVEventMin) % fTVEventStep == 0) fTkVerbThisEventON = true;
+    if ((eventNo - fTVEventMin) % fTVEventStep == 0)
+      fTkVerbThisEventON = true;
   }
 
   if (fDEBUG)
-    G4cout << " TV: fTkVerbThisEventON " <<  fTkVerbThisEventON 
-	   << " fTrackingVerboseON " << fTrackingVerboseON 
-	   << " fTVEventMin " << fTVEventMin << " fTVEventMax " << fTVEventMax << G4endl;
+    G4cout << " TV: fTkVerbThisEventON " << fTkVerbThisEventON << " fTrackingVerboseON " << fTrackingVerboseON
+           << " fTVEventMin " << fTVEventMin << " fTVEventMax " << fTVEventMax << G4endl;
   //----- check if verbosity has to be changed
   if ((fTkVerbThisEventON) && (!fTrackingVerboseON)) {
-    if (fTVTrackMin == 0 && fTVTrackMax == fLarge && fTVTrackStep != 1)	{
+    if (fTVTrackMin == 0 && fTVTrackMax == fLarge && fTVTrackStep != 1) {
       setTrackingVerbose(fVerboseLevel);
       fTrackingVerboseON = true;
-      if (fDEBUG) G4cout << "TV: VERBOSEet1 " << eventNo << G4endl;
+      if (fDEBUG)
+        G4cout << "TV: VERBOSEet1 " << eventNo << G4endl;
     }
-  } else if ((!fTkVerbThisEventON) && (fTrackingVerboseON) ) {
+  } else if ((!fTkVerbThisEventON) && (fTrackingVerboseON)) {
     setTrackingVerbose(0);
     fTrackingVerboseON = false;
-    if (fDEBUG) G4cout << "TV: VERBOSEet0 " << eventNo << G4endl;
+    if (fDEBUG)
+      G4cout << "TV: VERBOSEet0 " << eventNo << G4endl;
   }
-
 }
 
-void TrackingVerboseAction::update(const BeginOfTrack * trk) {
-  const G4Track * aTrack = (*trk)();
+void TrackingVerboseAction::update(const BeginOfTrack* trk) {
+  const G4Track* aTrack = (*trk)();
 
   //----- High ET photon printout
   //---------- Set /tracking/verbose
@@ -131,146 +129,138 @@ void TrackingVerboseAction::update(const BeginOfTrack * trk) {
   double tvty = aTrack->GetVertexPosition().y();
   double tvtz = aTrack->GetVertexPosition().z();
 
-  double g4t_phi=atan2(tkPy,tkPx);
+  double g4t_phi = atan2(tkPy, tkPx);
 
-  double drpart=sqrt(tkPx*tkPx + tkPy*tkPy);
+  double drpart = sqrt(tkPx * tkPx + tkPy * tkPy);
 
-  double mythetapart=acos(tkPz/sqrt(drpart*drpart+tkPz*tkPz));
+  double mythetapart = acos(tkPz / sqrt(drpart * drpart + tkPz * tkPz));
 
-  double g4t_eta=-log(tan(mythetapart/2.));
+  double g4t_eta = -log(tan(mythetapart / 2.));
   G4int MytrackNo = aTrack->GetTrackID();
-    
+
   if (fHighEtPhotons) {
-    if (aTrack->GetDefinition()->GetParticleName() == "gamma" && aTrack->GetParentID() !=0) {
-      if((tkPx*tkPx + tkPy*tkPy + tkPz*tkPz)>1000.0*1000.0 &&
-	 aTrack->GetCreatorProcess()->GetProcessName() == "LCapture") {
-	G4cout << "MY NEW GAMMA " << G4endl;
-	G4cout << "**********************************************************************"  << G4endl;
-	G4cout << "MY NEW TRACK ID = " << MytrackNo << "("
-	       << aTrack->GetDefinition()->GetParticleName()
-	       <<")"<< " PARENT ="<< aTrack->GetParentID() << G4endl;
-	G4cout << "Primary particle: " 
-	       << aTrack->GetDynamicParticle()->GetPrimaryParticle() << G4endl;
-	G4cout << "Process type: " << aTrack->GetCreatorProcess()->GetProcessType()
-	       << " Process name: " 
-	       << aTrack->GetCreatorProcess()->GetProcessName() << G4endl;
-	G4cout << "ToT E = " << aTrack->GetTotalEnergy() 
-	       << " KineE = " << aTrack->GetKineticEnergy()
-	       << " Tot P = " << tkP << " Pt = " << sqrt(tkPx*tkPx + tkPy*tkPy) 
-	       << " VTX=(" << tvtx << "," << tvty << "," << tvtz << ")" << G4endl;
-	if (aTrack->GetKineticEnergy() > 1.*GeV 
-	    && aTrack->GetCreatorProcess()->GetProcessName() != "LCapture")
-	  G4cout << " KineE > 1 GeV !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << G4endl;
-	const G4VTouchable* touchable=aTrack->GetTouchable();
-	if (touchable!=nullptr && touchable->GetVolume()!=nullptr &&
-	    touchable->GetVolume()->GetLogicalVolume()!=nullptr) {
-	  G4Material* material=touchable->GetVolume()->GetLogicalVolume()->GetMaterial();
-	  G4cout << "G4LCapture Gamma E(GeV) " 
-		 << aTrack->GetTotalEnergy()/GeV << "  "
-		 << material->GetName()<< " " 
-		 << touchable->GetVolume()->GetName() << G4endl;
-	  G4cout << "G4LCapture Gamma position(m): " 
-		 << aTrack->GetPosition()/m << G4endl;
-	  G4cout << "G4LCapture created Gamma direction " 
-		 << aTrack->GetMomentumDirection() << G4endl;
-	  G4cout << "G4LCapture gamma (eta,phi) = " 
-		 << "(" << g4t_eta << "," << g4t_phi << ")" << G4endl;
-	}
-	aTrack->GetUserInformation()->Print();
-	G4cout << "**********************************************************************"  << G4endl;
+    if (aTrack->GetDefinition()->GetParticleName() == "gamma" && aTrack->GetParentID() != 0) {
+      if ((tkPx * tkPx + tkPy * tkPy + tkPz * tkPz) > 1000.0 * 1000.0 &&
+          aTrack->GetCreatorProcess()->GetProcessName() == "LCapture") {
+        G4cout << "MY NEW GAMMA " << G4endl;
+        G4cout << "**********************************************************************" << G4endl;
+        G4cout << "MY NEW TRACK ID = " << MytrackNo << "(" << aTrack->GetDefinition()->GetParticleName() << ")"
+               << " PARENT =" << aTrack->GetParentID() << G4endl;
+        G4cout << "Primary particle: " << aTrack->GetDynamicParticle()->GetPrimaryParticle() << G4endl;
+        G4cout << "Process type: " << aTrack->GetCreatorProcess()->GetProcessType()
+               << " Process name: " << aTrack->GetCreatorProcess()->GetProcessName() << G4endl;
+        G4cout << "ToT E = " << aTrack->GetTotalEnergy() << " KineE = " << aTrack->GetKineticEnergy()
+               << " Tot P = " << tkP << " Pt = " << sqrt(tkPx * tkPx + tkPy * tkPy) << " VTX=(" << tvtx << "," << tvty
+               << "," << tvtz << ")" << G4endl;
+        if (aTrack->GetKineticEnergy() > 1. * GeV && aTrack->GetCreatorProcess()->GetProcessName() != "LCapture")
+          G4cout << " KineE > 1 GeV !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << G4endl;
+        const G4VTouchable* touchable = aTrack->GetTouchable();
+        if (touchable != nullptr && touchable->GetVolume() != nullptr &&
+            touchable->GetVolume()->GetLogicalVolume() != nullptr) {
+          G4Material* material = touchable->GetVolume()->GetLogicalVolume()->GetMaterial();
+          G4cout << "G4LCapture Gamma E(GeV) " << aTrack->GetTotalEnergy() / GeV << "  " << material->GetName() << " "
+                 << touchable->GetVolume()->GetName() << G4endl;
+          G4cout << "G4LCapture Gamma position(m): " << aTrack->GetPosition() / m << G4endl;
+          G4cout << "G4LCapture created Gamma direction " << aTrack->GetMomentumDirection() << G4endl;
+          G4cout << "G4LCapture gamma (eta,phi) = "
+                 << "(" << g4t_eta << "," << g4t_phi << ")" << G4endl;
+        }
+        aTrack->GetUserInformation()->Print();
+        G4cout << "**********************************************************************" << G4endl;
       }
     }
 
     if (aTrack->GetDefinition()->GetParticleName() == "gamma") {
-      const G4VProcess * proc = aTrack->GetCreatorProcess();
+      const G4VProcess* proc = aTrack->GetCreatorProcess();
       double Tgamma = aTrack->GetKineticEnergy();
       std::string ProcName;
-      const  std::string nullstr ("Null_prc");
-      if (proc) ProcName = proc->GetProcessName();
-      else      ProcName = nullstr;
-      if (Tgamma > 2.5*GeV ) { //&& ProcName!="Decay" && ProcName!="eBrem")
-	std::string volumeName("_Unknown_Vol_");
-	std::string materialName("_Unknown_Mat_");
-	G4Material * material = nullptr;
-	G4VPhysicalVolume * pvolume = nullptr;
-	G4LogicalVolume * lvolume = nullptr;
-	const G4VTouchable * touchable = aTrack->GetTouchable();
-	if (touchable) pvolume = touchable->GetVolume();
-	if (pvolume) {
-	  volumeName = pvolume->GetName();
-	  lvolume = pvolume->GetLogicalVolume();
-	}
-	if (lvolume) material = lvolume->GetMaterial();
-	if (material) materialName = material->GetName();
-	G4cout << "**** ALL photons > 2.5 GeV ****" << G4endl;
-	G4cout << ProcName << "**** ALL photons: gamma E(GeV) "
-	       << aTrack->GetTotalEnergy()/GeV << "  "
-	       <<  materialName << " " << volumeName << G4endl;
-	G4cout << ProcName << "**** ALL photons: gamma position(m): " 
-	       << aTrack->GetPosition()/m << G4endl;
-	G4cout << ProcName << "**** ALL photons: gamma direction " 
-	       << aTrack->GetMomentumDirection() << G4endl;
-	G4cout << "**********************************************************************"  << G4endl;
+      const std::string nullstr("Null_prc");
+      if (proc)
+        ProcName = proc->GetProcessName();
+      else
+        ProcName = nullstr;
+      if (Tgamma > 2.5 * GeV) {  //&& ProcName!="Decay" && ProcName!="eBrem")
+        std::string volumeName("_Unknown_Vol_");
+        std::string materialName("_Unknown_Mat_");
+        G4Material* material = nullptr;
+        G4VPhysicalVolume* pvolume = nullptr;
+        G4LogicalVolume* lvolume = nullptr;
+        const G4VTouchable* touchable = aTrack->GetTouchable();
+        if (touchable)
+          pvolume = touchable->GetVolume();
+        if (pvolume) {
+          volumeName = pvolume->GetName();
+          lvolume = pvolume->GetLogicalVolume();
+        }
+        if (lvolume)
+          material = lvolume->GetMaterial();
+        if (material)
+          materialName = material->GetName();
+        G4cout << "**** ALL photons > 2.5 GeV ****" << G4endl;
+        G4cout << ProcName << "**** ALL photons: gamma E(GeV) " << aTrack->GetTotalEnergy() / GeV << "  "
+               << materialName << " " << volumeName << G4endl;
+        G4cout << ProcName << "**** ALL photons: gamma position(m): " << aTrack->GetPosition() / m << G4endl;
+        G4cout << ProcName << "**** ALL photons: gamma direction " << aTrack->GetMomentumDirection() << G4endl;
+        G4cout << "**********************************************************************" << G4endl;
       }
-    }                                               
+    }
   }
-    
+
   //---------- Set /tracking/verbose
   //----- track is verbose only if event is verbose
   if (fTkVerbThisEventON) {
     bool trackingVerboseThisTrack = checkTrackingVerbose(aTrack);
 
-    //----- Set the /tracking/verbose for this track 
-    if ((trackingVerboseThisTrack) && (!fTrackingVerboseON) ) {
+    //----- Set the /tracking/verbose for this track
+    if ((trackingVerboseThisTrack) && (!fTrackingVerboseON)) {
       setTrackingVerbose(fVerboseLevel);
       fTrackingVerboseON = true;
-      if (fDEBUG) G4cout << "TV: VERBOSEtt1 " << aTrack->GetTrackID()
-			 << G4endl;
+      if (fDEBUG)
+        G4cout << "TV: VERBOSEtt1 " << aTrack->GetTrackID() << G4endl;
       printTrackInfo(aTrack);
-    } else if ((!trackingVerboseThisTrack) && ( fTrackingVerboseON )) {
+    } else if ((!trackingVerboseThisTrack) && (fTrackingVerboseON)) {
       setTrackingVerbose(0);
       fTrackingVerboseON = false;
-      if (fDEBUG) G4cout << "TV: VERBOSEtt0 " << aTrack->GetTrackID()
-			 << G4endl;
+      if (fDEBUG)
+        G4cout << "TV: VERBOSEtt0 " << aTrack->GetTrackID() << G4endl;
     }
   }
 }
 
-void TrackingVerboseAction::update(const EndOfTrack * trk) {
-  const G4Track * aTrack = (*trk)();
+void TrackingVerboseAction::update(const EndOfTrack* trk) {
+  const G4Track* aTrack = (*trk)();
   if (fTkVerbThisEventON) {
     bool trackingVerboseThisTrack = checkTrackingVerbose(aTrack);
-    if ((trackingVerboseThisTrack) && (fTrackingVerboseON ) &&
-	(fTVTrackMax < fLarge || fTVTrackStep != 1)) {
+    if ((trackingVerboseThisTrack) && (fTrackingVerboseON) && (fTVTrackMax < fLarge || fTVTrackStep != 1)) {
       setTrackingVerbose(0);
       fTrackingVerboseON = false;
-      if (fDEBUG) G4cout << "TV: VERBOSEtt0 " << aTrack->GetTrackID()
-			 << G4endl;
+      if (fDEBUG)
+        G4cout << "TV: VERBOSEtt0 " << aTrack->GetTrackID() << G4endl;
     }
   }
 }
 
 void TrackingVerboseAction::update(const G4Step* fStep) {
-
   if ((fG4Verbose) && (fTrackingVerboseON)) {
     G4Track* fTrack = fStep->GetTrack();
-    G4cout << std::setw( 5) << fTrack->GetCurrentStepNumber() << " "
-	   << std::setw( 8) << G4BestUnit(fTrack->GetPosition().x() , "Length") << " "
-	   << std::setw( 8) << G4BestUnit(fTrack->GetPosition().y() , "Length") << " "
-	   << std::setw( 8) << G4BestUnit(fTrack->GetPosition().z() , "Length") << " "
-	   << std::setw( 9) << G4BestUnit(fTrack->GetKineticEnergy() , "Energy") << " "
-	   << std::setw( 8) << G4BestUnit(fStep->GetTotalEnergyDeposit(), "Energy") << " "
-	   << std::setw( 8) << G4BestUnit(fStep->GetStepLength() , "Length") << " "
-	   << std::setw( 9) << G4BestUnit(fTrack->GetTrackLength() , "Length") << " "
-	   << std::setw( 9) << G4BestUnit(fTrack->GetGlobalTime(), "Time") << " ";
+    G4cout << std::setw(5) << fTrack->GetCurrentStepNumber() << " " << std::setw(8)
+           << G4BestUnit(fTrack->GetPosition().x(), "Length") << " " << std::setw(8)
+           << G4BestUnit(fTrack->GetPosition().y(), "Length") << " " << std::setw(8)
+           << G4BestUnit(fTrack->GetPosition().z(), "Length") << " " << std::setw(9)
+           << G4BestUnit(fTrack->GetKineticEnergy(), "Energy") << " " << std::setw(8)
+           << G4BestUnit(fStep->GetTotalEnergyDeposit(), "Energy") << " " << std::setw(8)
+           << G4BestUnit(fStep->GetStepLength(), "Length") << " " << std::setw(9)
+           << G4BestUnit(fTrack->GetTrackLength(), "Length") << " " << std::setw(9)
+           << G4BestUnit(fTrack->GetGlobalTime(), "Time") << " ";
 
     // Put cut comment here
-    if( fTrack->GetNextVolume() != nullptr ) {
+    if (fTrack->GetNextVolume() != nullptr) {
       G4cout << std::setw(11) << fTrack->GetNextVolume()->GetName() << " ";
     } else {
-      G4cout << std::setw(11) << "OutOfWorld" << " ";
+      G4cout << std::setw(11) << "OutOfWorld"
+             << " ";
     }
-    if(fStep->GetPostStepPoint()->GetProcessDefinedStep() != nullptr){
+    if (fStep->GetPostStepPoint()->GetProcessDefinedStep() != nullptr) {
       G4cout << fStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();
     } else {
       G4cout << "User Limit";
@@ -280,36 +270,36 @@ void TrackingVerboseAction::update(const G4Step* fStep) {
 }
 
 void TrackingVerboseAction::setTrackingVerbose(int verblev) {
-  if (fDEBUG) G4cout << " setting verbose level " << verblev << G4endl;
-  if (theTrackingManager!=nullptr) theTrackingManager->SetVerboseLevel(verblev);
+  if (fDEBUG)
+    G4cout << " setting verbose level " << verblev << G4endl;
+  if (theTrackingManager != nullptr)
+    theTrackingManager->SetVerboseLevel(verblev);
 }
- 
+
 bool TrackingVerboseAction::checkTrackingVerbose(const G4Track* aTrack) {
-  int trackNo = aTrack->GetTrackID();    
+  int trackNo = aTrack->GetTrackID();
   bool trackingVerboseThisTrack = false;
   //----- Check if track is in the selected range
   if (trackNo >= fTVTrackMin && trackNo <= fTVTrackMax) {
-    if ((trackNo-fTVTrackMin) % fTVTrackStep == 0) trackingVerboseThisTrack = true;
+    if ((trackNo - fTVTrackMin) % fTVTrackStep == 0)
+      trackingVerboseThisTrack = true;
   }
   if (trackingVerboseThisTrack && (!fPdgIds.empty())) {
     int pdgId = aTrack->GetDefinition()->GetPDGEncoding();
-    if (std::count(fPdgIds.begin(),fPdgIds.end(),pdgId) == 0) trackingVerboseThisTrack = false;
+    if (std::count(fPdgIds.begin(), fPdgIds.end(), pdgId) == 0)
+      trackingVerboseThisTrack = false;
   }
   return trackingVerboseThisTrack;
 }
 
 void TrackingVerboseAction::printTrackInfo(const G4Track* aTrack) {
-  G4cout << G4endl
-	 << "*******************************************************"
-	 << "**************************************************" << G4endl
-	 << "* G4Track Information: "
-	 << "  Particle = " << aTrack->GetDefinition()->GetParticleName()
-	 << ","
-	 << "   Track ID = " << aTrack->GetTrackID()
-	 << ","
-	 << "   Parent ID = " << aTrack->GetParentID() << G4endl
-	 << "*******************************************************"
-	 << "**************************************************"
-	 << G4endl << G4endl;
-  if (fVerbose) fVerbose->TrackingStarted();
+  G4cout << G4endl << "*******************************************************"
+         << "**************************************************" << G4endl << "* G4Track Information: "
+         << "  Particle = " << aTrack->GetDefinition()->GetParticleName() << ","
+         << "   Track ID = " << aTrack->GetTrackID() << ","
+         << "   Parent ID = " << aTrack->GetParentID() << G4endl
+         << "*******************************************************"
+         << "**************************************************" << G4endl << G4endl;
+  if (fVerbose)
+    fVerbose->TrackingStarted();
 }

--- a/SimG4Core/TrackingVerbose/src/module.cc
+++ b/SimG4Core/TrackingVerbose/src/module.cc
@@ -1,6 +1,5 @@
 #include "SimG4Core/TrackingVerbose/interface/TrackingVerboseAction.h"
 #include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
-   
 
 DEFINE_SIMWATCHER(TrackingVerboseAction);

--- a/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
+++ b/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
@@ -40,41 +40,38 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
 
-
 //
 // class declaration
 //
 
-class CaloParticleDebugger : public edm::one::EDAnalyzer<>  {
-   public:
-      explicit CaloParticleDebugger(const edm::ParameterSet&);
-      ~CaloParticleDebugger() override;
+class CaloParticleDebugger : public edm::one::EDAnalyzer<> {
+public:
+  explicit CaloParticleDebugger(const edm::ParameterSet&);
+  ~CaloParticleDebugger() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
-      void fillSimHits(std::map<int, float> &,
-          const edm::Event& , const edm::EventSetup &);
-      edm::InputTag simTracks_;
-      edm::InputTag genParticles_;
-      edm::InputTag simVertices_;
-      edm::InputTag trackingParticles_;
-      edm::InputTag caloParticles_;
-      edm::InputTag simClusters_;
-      std::vector<edm::InputTag> collectionTags_;
-      edm::EDGetTokenT<std::vector<SimTrack> > simTracksToken_;
-      edm::EDGetTokenT<std::vector<reco::GenParticle> > genParticlesToken_;
-      edm::EDGetTokenT<std::vector<SimVertex> > simVerticesToken_;
-      edm::EDGetTokenT<std::vector<TrackingParticle> > trackingParticlesToken_;
-      edm::EDGetTokenT<std::vector<CaloParticle> > caloParticlesToken_;
-      edm::EDGetTokenT<std::vector<SimCluster>> simClustersToken_;
-      std::vector<edm::EDGetTokenT<std::vector<PCaloHit> > > collectionTagsToken_;
-      int geometryType_ = 0;
-      // ----------member data ---------------------------
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+  void fillSimHits(std::map<int, float>&, const edm::Event&, const edm::EventSetup&);
+  edm::InputTag simTracks_;
+  edm::InputTag genParticles_;
+  edm::InputTag simVertices_;
+  edm::InputTag trackingParticles_;
+  edm::InputTag caloParticles_;
+  edm::InputTag simClusters_;
+  std::vector<edm::InputTag> collectionTags_;
+  edm::EDGetTokenT<std::vector<SimTrack>> simTracksToken_;
+  edm::EDGetTokenT<std::vector<reco::GenParticle>> genParticlesToken_;
+  edm::EDGetTokenT<std::vector<SimVertex>> simVerticesToken_;
+  edm::EDGetTokenT<std::vector<TrackingParticle>> trackingParticlesToken_;
+  edm::EDGetTokenT<std::vector<CaloParticle>> caloParticlesToken_;
+  edm::EDGetTokenT<std::vector<SimCluster>> simClustersToken_;
+  std::vector<edm::EDGetTokenT<std::vector<PCaloHit>>> collectionTagsToken_;
+  int geometryType_ = 0;
+  // ----------member data ---------------------------
 };
 
 //
@@ -89,101 +86,93 @@ class CaloParticleDebugger : public edm::one::EDAnalyzer<>  {
 // constructors and destructor
 //
 CaloParticleDebugger::CaloParticleDebugger(const edm::ParameterSet& iConfig)
-  : simTracks_(iConfig.getParameter<edm::InputTag>("simTracks")),
-  genParticles_(iConfig.getParameter<edm::InputTag>("genParticles")),
-  simVertices_(iConfig.getParameter<edm::InputTag>("simVertices")),
-  trackingParticles_(iConfig.getParameter<edm::InputTag>("trackingParticles")),
-  caloParticles_(iConfig.getParameter<edm::InputTag>("caloParticles")),
-  simClusters_(iConfig.getParameter<edm::InputTag>("simClusters")),
-  collectionTags_(iConfig.getParameter<std::vector<edm::InputTag> >("collectionTags")) {
+    : simTracks_(iConfig.getParameter<edm::InputTag>("simTracks")),
+      genParticles_(iConfig.getParameter<edm::InputTag>("genParticles")),
+      simVertices_(iConfig.getParameter<edm::InputTag>("simVertices")),
+      trackingParticles_(iConfig.getParameter<edm::InputTag>("trackingParticles")),
+      caloParticles_(iConfig.getParameter<edm::InputTag>("caloParticles")),
+      simClusters_(iConfig.getParameter<edm::InputTag>("simClusters")),
+      collectionTags_(iConfig.getParameter<std::vector<edm::InputTag>>("collectionTags")) {
   edm::ConsumesCollector&& iC = consumesCollector();
-  simTracksToken_ = iC.consumes<std::vector<SimTrack> >(simTracks_);
-  genParticlesToken_ = iC.consumes<std::vector<reco::GenParticle> > (genParticles_);
-  simVerticesToken_ = iC.consumes<std::vector<SimVertex> >(simVertices_);
-  trackingParticlesToken_ = iC.consumes<std::vector<TrackingParticle> >(trackingParticles_);
-  caloParticlesToken_ = iC.consumes<std::vector<CaloParticle> >(caloParticles_);
-  simClustersToken_ = iC.consumes<std::vector<SimCluster> >(simClusters_);
-  for (auto const & collectionTag : collectionTags_) {
-    collectionTagsToken_.push_back(iC.consumes<std::vector<PCaloHit> >(collectionTag));
+  simTracksToken_ = iC.consumes<std::vector<SimTrack>>(simTracks_);
+  genParticlesToken_ = iC.consumes<std::vector<reco::GenParticle>>(genParticles_);
+  simVerticesToken_ = iC.consumes<std::vector<SimVertex>>(simVertices_);
+  trackingParticlesToken_ = iC.consumes<std::vector<TrackingParticle>>(trackingParticles_);
+  caloParticlesToken_ = iC.consumes<std::vector<CaloParticle>>(caloParticles_);
+  simClustersToken_ = iC.consumes<std::vector<SimCluster>>(simClusters_);
+  for (auto const& collectionTag : collectionTags_) {
+    collectionTagsToken_.push_back(iC.consumes<std::vector<PCaloHit>>(collectionTag));
   }
 }
 
 CaloParticleDebugger::~CaloParticleDebugger() {}
-
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   using std::begin;
   using std::end;
-  using std::sort;
   using std::iota;
+  using std::sort;
 
-  edm::Handle<std::vector<SimTrack> > simTracksH;
-  edm::Handle<std::vector<reco::GenParticle> > genParticlesH;
-  edm::Handle<std::vector<SimVertex> > simVerticesH;
-  edm::Handle<std::vector<TrackingParticle> > trackingParticlesH;
-  edm::Handle<std::vector<CaloParticle> > caloParticlesH;
-  edm::Handle<std::vector<SimCluster> > simClustersH;
+  edm::Handle<std::vector<SimTrack>> simTracksH;
+  edm::Handle<std::vector<reco::GenParticle>> genParticlesH;
+  edm::Handle<std::vector<SimVertex>> simVerticesH;
+  edm::Handle<std::vector<TrackingParticle>> trackingParticlesH;
+  edm::Handle<std::vector<CaloParticle>> caloParticlesH;
+  edm::Handle<std::vector<SimCluster>> simClustersH;
 
   iEvent.getByToken(simTracksToken_, simTracksH);
-  auto const & tracks = *simTracksH.product();
+  auto const& tracks = *simTracksH.product();
   std::vector<int> sorted_tracks_idx(tracks.size());
   iota(begin(sorted_tracks_idx), end(sorted_tracks_idx), 0);
-  sort(begin(sorted_tracks_idx),
-       end(sorted_tracks_idx),
-       [&tracks] (int i, int j) {
-        return tracks[i].momentum().eta() < tracks[j].momentum().eta();
-        });
+  sort(begin(sorted_tracks_idx), end(sorted_tracks_idx), [&tracks](int i, int j) {
+    return tracks[i].momentum().eta() < tracks[j].momentum().eta();
+  });
 
   iEvent.getByToken(genParticlesToken_, genParticlesH);
-  auto const & genParticles = *genParticlesH.product();
+  auto const& genParticles = *genParticlesH.product();
   std::vector<int> sorted_genParticles_idx(genParticles.size());
   iota(begin(sorted_genParticles_idx), end(sorted_genParticles_idx), 0);
-  sort(begin(sorted_genParticles_idx),
-       end(sorted_genParticles_idx), [&genParticles](int i, int j) {
-       return genParticles[i].momentum().eta() < genParticles[j].momentum().eta();});
+  sort(begin(sorted_genParticles_idx), end(sorted_genParticles_idx), [&genParticles](int i, int j) {
+    return genParticles[i].momentum().eta() < genParticles[j].momentum().eta();
+  });
 
   iEvent.getByToken(simVerticesToken_, simVerticesH);
-  auto const & vertices = *simVerticesH.product();
+  auto const& vertices = *simVerticesH.product();
   std::vector<int> sorted_vertices_idx(vertices.size());
   iota(begin(sorted_vertices_idx), end(sorted_vertices_idx), 0);
-  sort(begin(sorted_vertices_idx),
-       end(sorted_vertices_idx), [&vertices](int i, int j){
-        return vertices[i].vertexId() < vertices[j].vertexId();
-      });
+  sort(begin(sorted_vertices_idx), end(sorted_vertices_idx), [&vertices](int i, int j) {
+    return vertices[i].vertexId() < vertices[j].vertexId();
+  });
 
   iEvent.getByToken(trackingParticlesToken_, trackingParticlesH);
-  auto const & trackingpart = *trackingParticlesH.product();
+  auto const& trackingpart = *trackingParticlesH.product();
   std::vector<int> sorted_tp_idx(trackingpart.size());
   iota(begin(sorted_tp_idx), end(sorted_tp_idx), 0);
-  sort(begin(sorted_tp_idx),
-       end(sorted_tp_idx), [&trackingpart] (int i, int j){
-        return trackingpart[i].eta() < trackingpart[j].eta();
-       });
+  sort(begin(sorted_tp_idx), end(sorted_tp_idx), [&trackingpart](int i, int j) {
+    return trackingpart[i].eta() < trackingpart[j].eta();
+  });
 
   iEvent.getByToken(caloParticlesToken_, caloParticlesH);
-  auto const & calopart = *caloParticlesH.product();
+  auto const& calopart = *caloParticlesH.product();
   std::vector<int> sorted_cp_idx(calopart.size());
-  iota(begin(sorted_cp_idx),
-       end(sorted_cp_idx), 0);
-  sort(begin(sorted_cp_idx),
-       end(sorted_cp_idx), [&calopart](int i, int j){
-       return calopart[i].eta() < calopart[j].eta();});
+  iota(begin(sorted_cp_idx), end(sorted_cp_idx), 0);
+  sort(begin(sorted_cp_idx), end(sorted_cp_idx), [&calopart](int i, int j) {
+    return calopart[i].eta() < calopart[j].eta();
+  });
 
   iEvent.getByToken(simClustersToken_, simClustersH);
-  auto const & simclusters = *simClustersH.product();
+  auto const& simclusters = *simClustersH.product();
   std::vector<int> sorted_simcl_idx(simclusters.size());
-  iota(begin(sorted_simcl_idx),
-       end(sorted_simcl_idx), 0);
-  sort(begin(sorted_simcl_idx),
-       end(sorted_simcl_idx), [&simclusters](int i, int j){
-       return simclusters[i].eta() < simclusters[j].eta();});
+  iota(begin(sorted_simcl_idx), end(sorted_simcl_idx), 0);
+  sort(begin(sorted_simcl_idx), end(sorted_simcl_idx), [&simclusters](int i, int j) {
+    return simclusters[i].eta() < simclusters[j].eta();
+  });
 
   // Let's first fill in hits information
   std::map<int, float> detIdToTotalSimEnergy;
@@ -195,7 +184,7 @@ CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   std::cout << "Printing SimTracks information" << std::endl;
   std::cout << "IDX\tTrackId\tPDGID\tMOMENTUM(x,y,z,E)\tVertexIdx\tGenPartIdx" << std::endl;
   for (auto i : sorted_tracks_idx) {
-    auto const & t = tracks[i];
+    auto const& t = tracks[i];
     std::cout << idx << "\t" << t.trackId() << "\t" << t << std::endl;
     trackid_to_track_index[t.trackId()] = idx;
     idx++;
@@ -204,53 +193,48 @@ CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   std::cout << "Printing GenParticles information" << std::endl;
   std::cout << "IDX\tPDGID\tMOMENTUM(x,y,z)\tVertex(x,y,z)" << std::endl;
   for (auto i : sorted_genParticles_idx) {
-    auto const & gp = genParticles[i];
-    std::cout << i
-      << "\t" << gp.pdgId()
-      << "\t" << gp.momentum()
-      << "\t" << gp.vertex() << std::endl;
+    auto const& gp = genParticles[i];
+    std::cout << i << "\t" << gp.pdgId() << "\t" << gp.momentum() << "\t" << gp.vertex() << std::endl;
   }
 
   std::cout << "Printing SimVertex information" << std::endl;
   std::cout << "IDX\tPOSITION(x,y,z)\tPARENT_INDEX\tVERTEX_ID" << std::endl;
   for (auto i : sorted_vertices_idx) {
-    auto const & v = vertices[i];
-      std::cout << i << "\t" << v << std::endl;
+    auto const& v = vertices[i];
+    std::cout << i << "\t" << v << std::endl;
   }
   std::cout << "Printing TrackingParticles information" << std::endl;
   for (auto i : sorted_tp_idx) {
-    auto const & tp = trackingpart[i];
+    auto const& tp = trackingpart[i];
     std::cout << i << "\t" << tp << std::endl;
   }
 
   std::cout << "Printing CaloParticles information" << std::endl;
   idx = 0;
   for (auto i : sorted_cp_idx) {
-    auto const & cp = calopart[i];
-    std::cout << "\n\n" << idx++ << " |Eta|: " << std::abs(cp.momentum().eta())
-              << "\tType: " << cp.pdgId()
-              << "\tEnergy: " << cp.energy()
-              << "\tIdx: " << cp.g4Tracks()[0].trackId() << std::endl; // << cp << std::endl;
+    auto const& cp = calopart[i];
+    std::cout << "\n\n"
+              << idx++ << " |Eta|: " << std::abs(cp.momentum().eta()) << "\tType: " << cp.pdgId()
+              << "\tEnergy: " << cp.energy() << "\tIdx: " << cp.g4Tracks()[0].trackId()
+              << std::endl;  // << cp << std::endl;
     double total_sim_energy = 0.;
     double total_cp_energy = 0.;
     std::cout << "--> Overall simclusters's size: " << cp.simClusters().size() << std::endl;
     // All the next mess just to print the simClusters ordered
-    auto const & simcs = cp.simClusters();
+    auto const& simcs = cp.simClusters();
     std::vector<int> sorted_sc_idx(simcs.size());
     iota(begin(sorted_sc_idx), end(sorted_sc_idx), 0);
-    sort(begin(sorted_sc_idx),
-        end(sorted_sc_idx),
-        [&simcs] (int i, int j) {
-        return simcs[i]->momentum().eta() < simcs[j]->momentum().eta();
-        });
+    sort(begin(sorted_sc_idx), end(sorted_sc_idx), [&simcs](int i, int j) {
+      return simcs[i]->momentum().eta() < simcs[j]->momentum().eta();
+    });
     for (auto i : sorted_sc_idx) {
-      std::cout <<  *(simcs[i]);
+      std::cout << *(simcs[i]);
     }
 
-    for (auto const & sc : cp.simClusters()) {
-      for (auto const & cl : sc->hits_and_fractions()) {
-        total_sim_energy += detIdToTotalSimEnergy[cl.first]*cl.second;
-        total_cp_energy += cp.energy()*cl.second;
+    for (auto const& sc : cp.simClusters()) {
+      for (auto const& cl : sc->hits_and_fractions()) {
+        total_sim_energy += detIdToTotalSimEnergy[cl.first] * cl.second;
+        total_cp_energy += cp.energy() * cl.second;
       }
     }
     std::cout << "--> Overall SC energy (sum using sim energies): " << total_sim_energy << std::endl;
@@ -260,49 +244,47 @@ CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   idx = 0;
   std::cout << "Printing SimClusters information" << std::endl;
   for (auto i : sorted_simcl_idx) {
-    auto const & simcl = simclusters[i];
-    std::cout << "\n\n" << idx++ << " |Eta|: " << std::abs(simcl.momentum().eta())
-              << "\tType: " << simcl.pdgId()
-              << "\tEnergy: " << simcl.energy()
-              << "\tKey: " << i << std::endl; // << simcl << std::endl;
+    auto const& simcl = simclusters[i];
+    std::cout << "\n\n"
+              << idx++ << " |Eta|: " << std::abs(simcl.momentum().eta()) << "\tType: " << simcl.pdgId()
+              << "\tEnergy: " << simcl.energy() << "\tKey: " << i << std::endl;  // << simcl << std::endl;
     double total_sim_energy = 0.;
     std::cout << "--> Overall simclusters's size: " << simcl.numberOfRecHits() << std::endl;
-    for (auto const & cl : simcl.hits_and_fractions()) {
-      total_sim_energy += detIdToTotalSimEnergy[cl.first]*cl.second;
+    for (auto const& cl : simcl.hits_and_fractions()) {
+      total_sim_energy += detIdToTotalSimEnergy[cl.first] * cl.second;
     }
     std::cout << simcl << std::endl;
     std::cout << "--> Overall SimCluster energy (sum using sim energies): " << total_sim_energy << std::endl;
   }
 }
 
-
 // ------------ method called once each job just before starting event loop  ------------
-void
-CaloParticleDebugger::beginJob() {}
+void CaloParticleDebugger::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-CaloParticleDebugger::endJob() {}
+void CaloParticleDebugger::endJob() {}
 
-void CaloParticleDebugger::fillSimHits(
-    std::map<int, float> & detIdToTotalSimEnergy,
-    const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
+void CaloParticleDebugger::fillSimHits(std::map<int, float>& detIdToTotalSimEnergy,
+                                       const edm::Event& iEvent,
+                                       const edm::EventSetup& iSetup) {
   // Taken needed quantities from the EventSetup
   edm::ESHandle<CaloGeometry> geom;
   iSetup.get<CaloGeometryRecord>().get(geom);
   const HGCalGeometry *eegeom = nullptr, *fhgeom = nullptr, *bhgeomnew = nullptr;
-  const HcalGeometry *bhgeom = nullptr;
+  const HcalGeometry* bhgeom = nullptr;
   const HGCalDDDConstants* hgddd[3];
-  const HGCalTopology*     hgtopo[3];
+  const HGCalTopology* hgtopo[3];
   const HcalDDDRecConstants* hcddd = nullptr;
-  eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalEE,ForwardSubdetector::ForwardEmpty));
+  eegeom =
+      static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalEE, ForwardSubdetector::ForwardEmpty));
   //check if it's the new geometry
-  if(eegeom){
+  if (eegeom) {
     geometryType_ = 1;
-    fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSi,ForwardSubdetector::ForwardEmpty));
-    bhgeomnew = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::HGCalHSc,ForwardSubdetector::ForwardEmpty));
-  }
-  else {
+    fhgeom = static_cast<const HGCalGeometry*>(
+        geom->getSubdetectorGeometry(DetId::HGCalHSi, ForwardSubdetector::ForwardEmpty));
+    bhgeomnew = static_cast<const HGCalGeometry*>(
+        geom->getSubdetectorGeometry(DetId::HGCalHSc, ForwardSubdetector::ForwardEmpty));
+  } else {
     geometryType_ = 0;
     eegeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCEE));
     fhgeom = static_cast<const HGCalGeometry*>(geom->getSubdetectorGeometry(DetId::Forward, HGCHEF));
@@ -310,54 +292,57 @@ void CaloParticleDebugger::fillSimHits(
   }
   hgtopo[0] = &(eegeom->topology());
   hgtopo[1] = &(fhgeom->topology());
-  if(bhgeomnew) hgtopo[2] = &(bhgeomnew->topology());
+  if (bhgeomnew)
+    hgtopo[2] = &(bhgeomnew->topology());
 
   for (unsigned i = 0; i < 3; ++i) {
-    if(hgtopo[i]) hgddd[i] = &(hgtopo[i]->dddConstants());
+    if (hgtopo[i])
+      hgddd[i] = &(hgtopo[i]->dddConstants());
   }
 
-  if(bhgeom) hcddd = bhgeom->topology().dddConstants();
+  if (bhgeom)
+    hcddd = bhgeom->topology().dddConstants();
 
   // loop over the collections
   int token = 0;
   for (auto const& collectionTag : collectionTags_) {
-    edm::Handle< std::vector<PCaloHit> > hSimHits;
-    const bool isHcal = ( collectionTag.instance().find("HcalHits") != std::string::npos );
+    edm::Handle<std::vector<PCaloHit>> hSimHits;
+    const bool isHcal = (collectionTag.instance().find("HcalHits") != std::string::npos);
     iEvent.getByToken(collectionTagsToken_[token++], hSimHits);
     for (auto const& simHit : *hSimHits) {
       DetId id(0);
       const uint32_t simId = simHit.id();
-      if (geometryType_==1) {
-                //no test numbering in new geometry
+      if (geometryType_ == 1) {
+        //no test numbering in new geometry
         id = simId;
-      }
-      else if (isHcal) {
+      } else if (isHcal) {
         assert(hcddd);
         HcalDetId hid = HcalHitRelabeller::relabel(simId, hcddd);
-        if (hid.subdet() == HcalEndcap) id = hid;
+        if (hid.subdet() == HcalEndcap)
+          id = hid;
       } else {
         int subdet, layer, cell, sec, subsec, zp;
         HGCalTestNumbering::unpackHexagonIndex(simId, subdet, zp, layer, sec, subsec, cell);
-        const HGCalDDDConstants* ddd = hgddd[subdet-3];
-        std::pair<int, int> recoLayerCell = ddd->simToReco(cell, layer, sec,
-            hgtopo[subdet-3]->detectorType());
-        cell  = recoLayerCell.first;
+        const HGCalDDDConstants* ddd = hgddd[subdet - 3];
+        std::pair<int, int> recoLayerCell = ddd->simToReco(cell, layer, sec, hgtopo[subdet - 3]->detectorType());
+        cell = recoLayerCell.first;
         layer = recoLayerCell.second;
         // skip simhits with bad barcodes or non-existant layers
-        if (layer == -1 || simHit.geantTrackId() == 0) continue;
+        if (layer == -1 || simHit.geantTrackId() == 0)
+          continue;
         id = HGCalDetId((ForwardSubdetector)subdet, zp, layer, subsec, sec, cell);
       }
 
-      if (DetId(0) == id) continue;
+      if (DetId(0) == id)
+        continue;
 
       detIdToTotalSimEnergy[id.rawId()] += simHit.energy();
     }
-  } // end of loop over InputTags
+  }  // end of loop over InputTags
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-CaloParticleDebugger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void CaloParticleDebugger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("simTracks", edm::InputTag("g4SimHits"));
   desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"));
@@ -365,10 +350,10 @@ CaloParticleDebugger::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
   desc.add<edm::InputTag>("caloParticles", edm::InputTag("mix", "MergedCaloTruth"));
   desc.add<edm::InputTag>("simClusters", edm::InputTag("mix", "MergedCaloTruth"));
-  desc.add<std::vector<edm::InputTag> >("collectionTags",
-      { edm::InputTag("g4SimHits", "HGCHitsEE"),
-        edm::InputTag("g4SimHits", "HGCHitsHEfront"),
-        edm::InputTag("g4SimHits", "HcalHits")});
+  desc.add<std::vector<edm::InputTag>>("collectionTags",
+                                       {edm::InputTag("g4SimHits", "HGCHitsEE"),
+                                        edm::InputTag("g4SimHits", "HGCHitsHEfront"),
+                                        edm::InputTag("g4SimHits", "HcalHits")});
   descriptions.add("caloParticleDebugger", desc);
 }
 

--- a/SimMuon/Neutron/interface/SubsystemNeutronReader.h
+++ b/SimMuon/Neutron/interface/SubsystemNeutronReader.h
@@ -9,7 +9,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-#include<vector>
+#include <vector>
 
 class NeutronReader;
 
@@ -17,36 +17,31 @@ namespace CLHEP {
   class HepRandomEngine;
 }
 
-class SubsystemNeutronReader 
-{
-public:  
+class SubsystemNeutronReader {
+public:
   /// the hits will be distributed flat in time between startTime and endTime
   /// eventOccupancy is the expected chamber occupancy from a single
   /// min bias event for each chamber type
-  SubsystemNeutronReader(const edm::ParameterSet & pset);
+  SubsystemNeutronReader(const edm::ParameterSet& pset);
   virtual ~SubsystemNeutronReader();
 
   /// this class makes sure the same chamberIndex isn't called twice
   /// for an event
-  void generateChamberNoise(int chamberType, int chamberIndex, edm::PSimHitContainer & result,
-                            CLHEP::HepRandomEngine*);
+  void generateChamberNoise(int chamberType, int chamberIndex, edm::PSimHitContainer& result, CLHEP::HepRandomEngine*);
 
-  void clear() {theChambersDone.clear();}
+  void clear() { theChambersDone.clear(); }
 
 protected:
   /// detector-specific way to get the global detector
   /// ID, given the local one.
-  virtual int detId(int chamberIndex, int localDetId ) = 0;
-  
+  virtual int detId(int chamberIndex, int localDetId) = 0;
 
 private:
-
-  NeutronReader * theHitReader;
+  NeutronReader* theHitReader;
 
   /// just makes sure chambers aren't done twice
   std::vector<int> theChambersDone;
 
- 
   /// in units of 10**34, set by Muon:NeutronLuminosity
   float theLuminosity;
   float theStartTime;
@@ -54,9 +49,7 @@ private:
   /// how many collsions happened between theStartTime and theEndTime
   float theEventsInWindow;
 
-  std::vector<double> theEventOccupancy; // Placed here so ctor init list order OK
-
+  std::vector<double> theEventOccupancy;  // Placed here so ctor init list order OK
 };
 
 #endif
-

--- a/SimMuon/Neutron/interface/SubsystemNeutronWriter.h
+++ b/SimMuon/Neutron/interface/SubsystemNeutronWriter.h
@@ -11,7 +11,7 @@
  * signal event to define something as a Neutron Event
  * with the configurable Muon:NeutronTimeCut
  */
- 
+
 #include <vector>
 #include <map>
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
@@ -25,10 +25,8 @@ namespace CLHEP {
 class NeutronWriter;
 
 /// doesn't have to be a producer.  Can act as an analyzer, too.
-class SubsystemNeutronWriter : public edm::stream::EDProducer<>
-{
+class SubsystemNeutronWriter : public edm::stream::EDProducer<> {
 public:
-
   explicit SubsystemNeutronWriter(edm::ParameterSet const& pset);
 
   /// destructor prints statistics on number of events written
@@ -36,7 +34,7 @@ public:
 
   void printStats();
 
-  void produce(edm::Event & e, edm::EventSetup const& c) override;
+  void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   virtual int localDetId(int globalDetId) const = 0;
 
@@ -45,25 +43,24 @@ public:
   virtual int chamberId(int globalDetId) const = 0;
 
   /// decides whether this cluster is good enough to be included
-  virtual bool accept(const edm::PSimHitContainer & cluster) const = 0;
+  virtual bool accept(const edm::PSimHitContainer& cluster) const = 0;
 
   /// good practice to do once for each chamber type
   void initialize(int chamberType);
 
 protected:
+  virtual void writeHits(int chamberType, edm::PSimHitContainer& chamberHits, CLHEP::HepRandomEngine*);
 
-  virtual void writeHits(int chamberType, edm::PSimHitContainer & chamberHits, CLHEP::HepRandomEngine*);
-
-  void writeCluster(int chamberType, const edm::PSimHitContainer & cluster);
+  void writeCluster(int chamberType, const edm::PSimHitContainer& cluster);
 
   /// helper to add time offsets and local det ID
-  void adjust(PSimHit & h, float timeOffset, float smearing);
+  void adjust(PSimHit& h, float timeOffset, float smearing);
 
   /// updates the counter
   void updateCount(int chamberType);
 
 private:
-  NeutronWriter * theHitWriter;
+  NeutronWriter* theHitWriter;
   bool useRandFlat;
   edm::InputTag theInputTag;
   double theNeutronTimeCut;
@@ -77,4 +74,3 @@ private:
 };
 
 #endif
-

--- a/SimMuon/Neutron/plugins/EmptyHepMCProducer.cc
+++ b/SimMuon/Neutron/plugins/EmptyHepMCProducer.cc
@@ -28,28 +28,20 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
-
-class EmptyHepMCProducer : public edm::stream::EDProducer<>
-{
+class EmptyHepMCProducer : public edm::stream::EDProducer<> {
 public:
   explicit EmptyHepMCProducer(const edm::ParameterSet&);
-  ~EmptyHepMCProducer() override {};
+  ~EmptyHepMCProducer() override{};
 
 private:
   virtual void beginJob();
   void produce(edm::Event&, const edm::EventSetup&) override;
   virtual void endJob();
-
 };
 
-EmptyHepMCProducer::EmptyHepMCProducer(const edm::ParameterSet& iConfig)
-{
-  produces<edm::HepMCProduct>();
-}
+EmptyHepMCProducer::EmptyHepMCProducer(const edm::ParameterSet& iConfig) { produces<edm::HepMCProduct>(); }
 
-void
-EmptyHepMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void EmptyHepMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // create an empty output collection
   std::unique_ptr<edm::HepMCProduct> theOutput(new edm::HepMCProduct());
   //theOutput->addHepMCData(theEvent);

--- a/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
+++ b/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
@@ -33,13 +33,10 @@
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
-
-
-class NeutronHitsCollector : public edm::stream::EDProducer<>
-{
+class NeutronHitsCollector : public edm::stream::EDProducer<> {
 public:
   explicit NeutronHitsCollector(const edm::ParameterSet&);
-  ~NeutronHitsCollector() override {};
+  ~NeutronHitsCollector() override{};
 
 private:
   virtual void beginJob();
@@ -51,13 +48,10 @@ private:
   std::string neutron_label_rpc;
 };
 
-
-
-NeutronHitsCollector::NeutronHitsCollector(const edm::ParameterSet& iConfig)
-{
-  neutron_label_csc = iConfig.getUntrackedParameter<std::string>("neutronLabelCSC","");
-  neutron_label_dt  = iConfig.getUntrackedParameter<std::string>("neutronLabelDT","");
-  neutron_label_rpc = iConfig.getUntrackedParameter<std::string>("neutronLabelRPC","");
+NeutronHitsCollector::NeutronHitsCollector(const edm::ParameterSet& iConfig) {
+  neutron_label_csc = iConfig.getUntrackedParameter<std::string>("neutronLabelCSC", "");
+  neutron_label_dt = iConfig.getUntrackedParameter<std::string>("neutronLabelDT", "");
+  neutron_label_rpc = iConfig.getUntrackedParameter<std::string>("neutronLabelRPC", "");
 
   // The following list duplicates
   // http://cmslxr.fnal.gov/lxr/source/SimG4Core/Application/plugins/OscarProducer.cc
@@ -103,44 +97,41 @@ NeutronHitsCollector::NeutronHitsCollector(const edm::ParameterSet& iConfig)
   //produces<edm::PCaloHitContainer>("ChamberHits");
   //produces<edm::PCaloHitContainer>("FibreHits");
   //produces<edm::PCaloHitContainer>("WedgeHits");
-
 }
 
-
-void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::PSimHitContainer::const_iterator hit;
 
   // ----- MuonCSCHits -----
   //
   std::unique_ptr<edm::PSimHitContainer> simCSC(new edm::PSimHitContainer);
-  if (neutron_label_csc.length()>0)
-  {
+  if (neutron_label_csc.length() > 0) {
     edm::Handle<edm::PSimHitContainer> MuonCSCHits;
-    iEvent.getByLabel(neutron_label_csc,MuonCSCHits);
-    for (hit = MuonCSCHits->begin();  hit != MuonCSCHits->end();  ++hit) simCSC->push_back(*hit);
+    iEvent.getByLabel(neutron_label_csc, MuonCSCHits);
+    for (hit = MuonCSCHits->begin(); hit != MuonCSCHits->end(); ++hit)
+      simCSC->push_back(*hit);
   }
   iEvent.put(std::move(simCSC), "MuonCSCHits");
 
   // ----- MuonDTHits -----
   //
   std::unique_ptr<edm::PSimHitContainer> simDT(new edm::PSimHitContainer);
-  if (neutron_label_dt.length()>0)
-  {
+  if (neutron_label_dt.length() > 0) {
     edm::Handle<edm::PSimHitContainer> MuonDTHits;
-    iEvent.getByLabel(neutron_label_dt,MuonDTHits);
-    for (hit = MuonDTHits->begin();  hit != MuonDTHits->end();  ++hit) simDT->push_back(*hit);
+    iEvent.getByLabel(neutron_label_dt, MuonDTHits);
+    for (hit = MuonDTHits->begin(); hit != MuonDTHits->end(); ++hit)
+      simDT->push_back(*hit);
   }
   iEvent.put(std::move(simDT), "MuonDTHits");
 
   // ----- MuonRPCHits -----
   //
   std::unique_ptr<edm::PSimHitContainer> simRPC(new edm::PSimHitContainer);
-  if (neutron_label_rpc.length()>0)
-  {
+  if (neutron_label_rpc.length() > 0) {
     edm::Handle<edm::PSimHitContainer> MuonRPCHits;
-    iEvent.getByLabel(neutron_label_rpc,MuonRPCHits);
-    for (hit = MuonRPCHits->begin();  hit != MuonRPCHits->end();  ++hit) simRPC->push_back(*hit);
+    iEvent.getByLabel(neutron_label_rpc, MuonRPCHits);
+    for (hit = MuonRPCHits->begin(); hit != MuonRPCHits->end(); ++hit)
+      simRPC->push_back(*hit);
   }
   iEvent.put(std::move(simRPC), "MuonRPCHits");
 
@@ -225,16 +216,11 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   iEvent.put(std::move(simTr));
   std::unique_ptr<edm::SimVertexContainer> simVe(new edm::SimVertexContainer);
   iEvent.put(std::move(simVe));
-
-
 }
-
 
 void NeutronHitsCollector::beginJob() {}
 
-
 void NeutronHitsCollector::endJob() {}
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(NeutronHitsCollector);

--- a/SimMuon/Neutron/src/AsciiNeutronReader.cc
+++ b/SimMuon/Neutron/src/AsciiNeutronReader.cc
@@ -3,56 +3,49 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include <sstream>
-#include<iostream>
+#include <iostream>
 
 using namespace std;
 
-AsciiNeutronReader::AsciiNeutronReader(string fileNameBase) :
-  theFileNameBase(fileNameBase),
-  //theStreamPos(nChamberTypes+1, 0) //TODO WON"T WORK!  replace with a map 
-  theStreamPos(11,0)
-{
-}
+AsciiNeutronReader::AsciiNeutronReader(string fileNameBase)
+    : theFileNameBase(fileNameBase),
+      //theStreamPos(nChamberTypes+1, 0) //TODO WON"T WORK!  replace with a map
+      theStreamPos(11, 0) {}
 
-
-void AsciiNeutronReader::readNextEvent(int chamberType, edm::PSimHitContainer & result) {
+void AsciiNeutronReader::readNextEvent(int chamberType, edm::PSimHitContainer& result) {
   stringstream fileName;
   fileName << theFileNameBase << chamberType;
   ifstream fin(fileName.str().c_str(), ios::in);
-  if(!fin.is_open()) {
-    throw cms::Exception("NeutronReader") 
-      << "Muon neutron noise file missing " << fileName.str();
+  if (!fin.is_open()) {
+    throw cms::Exception("NeutronReader") << "Muon neutron noise file missing " << fileName.str();
   }
 
   int nhits = read_nhits(fin, chamberType);
-  for(int ihit = 0; ihit < nhits; ++ihit) {
+  for (int ihit = 0; ihit < nhits; ++ihit) {
     float entryX, entryY, entryZ, exitX, exitY, exitZ;
     float p, tof, eloss, theta, phi;
     int type, layer, track;
 
-    fin >> entryX >> entryY >> entryZ
-        >> exitX  >> exitY  >> exitZ
-        >> p >> tof >> eloss >> type >> layer >> track >> theta >> phi;
+    fin >> entryX >> entryY >> entryZ >> exitX >> exitY >> exitZ >> p >> tof >> eloss >> type >> layer >> track >>
+        theta >> phi;
     LocalPoint entry(entryX, entryY, entryZ);
-    LocalPoint exit (exitX,  exitY,  exitZ);
+    LocalPoint exit(exitX, exitY, exitZ);
     PSimHit phit(entry, exit, p, tof, eloss, type, layer, track, theta, phi);
     result.push_back(phit);
   }
   theStreamPos[chamberType] = fin.tellg();
 }
 
-
-int AsciiNeutronReader::read_nhits(ifstream & fin, int chamberType) {
+int AsciiNeutronReader::read_nhits(ifstream& fin, int chamberType) {
   int nhits = 0;
-    // go to the last saved place
+  // go to the last saved place
   fin.seekg(theStreamPos[chamberType]);
-  if(fin.eof()) {
+  if (fin.eof()) {
     resetStreampos(fin, chamberType);
   }
-  LogDebug("NeutronReader") << "starting from pos " << theStreamPos[chamberType] 
-                  << " EOF " << fin.eof();
+  LogDebug("NeutronReader") << "starting from pos " << theStreamPos[chamberType] << " EOF " << fin.eof();
   fin >> nhits;
-  if(fin.eof()) {
+  if (fin.eof()) {
     resetStreampos(fin, chamberType);
     fin >> nhits;
   }
@@ -60,11 +53,9 @@ int AsciiNeutronReader::read_nhits(ifstream & fin, int chamberType) {
   return nhits;
 }
 
-
-void AsciiNeutronReader::resetStreampos(ifstream & fin, int chamberType) {
+void AsciiNeutronReader::resetStreampos(ifstream& fin, int chamberType) {
   LogDebug("NeutronReader") << "reached EOF, resetting streampos ";
   theStreamPos[chamberType] = 0;
   fin.clear();
   fin.seekg(0, ios::beg);
 }
-

--- a/SimMuon/Neutron/src/AsciiNeutronReader.h
+++ b/SimMuon/Neutron/src/AsciiNeutronReader.h
@@ -14,21 +14,18 @@
  * back to the beginning when it reaches EOF
  */
 
-class AsciiNeutronReader : public NeutronReader
-{
+class AsciiNeutronReader : public NeutronReader {
 public:
   AsciiNeutronReader(std::string fileNameBase);
 
-  void  readNextEvent(int chamberType, edm::PSimHitContainer & result) override;
+  void readNextEvent(int chamberType, edm::PSimHitContainer& result) override;
 
 private:
-
-  int read_nhits(std::ifstream & fin, int chamberType);
-  void resetStreampos(std::ifstream & fin, int chamberType);
+  int read_nhits(std::ifstream& fin, int chamberType);
+  void resetStreampos(std::ifstream& fin, int chamberType);
 
   std::string theFileNameBase;
   std::vector<std::streampos> theStreamPos;
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/AsciiNeutronWriter.cc
+++ b/SimMuon/Neutron/src/AsciiNeutronWriter.cc
@@ -5,17 +5,11 @@
 
 using namespace std;
 
-AsciiNeutronWriter::AsciiNeutronWriter(string fileNameBase) :
-  theFileNameBase(fileNameBase)  {
-}
+AsciiNeutronWriter::AsciiNeutronWriter(string fileNameBase) : theFileNameBase(fileNameBase) {}
 
+AsciiNeutronWriter::~AsciiNeutronWriter() {}
 
-AsciiNeutronWriter::~AsciiNeutronWriter() {
-}
-
-
-void AsciiNeutronWriter::writeCluster(int chamberType, const edm::PSimHitContainer & hits) 
-{
+void AsciiNeutronWriter::writeCluster(int chamberType, const edm::PSimHitContainer& hits) {
   // open the correct file
   stringstream s;
   s << theFileNameBase << chamberType;
@@ -23,15 +17,11 @@ void AsciiNeutronWriter::writeCluster(int chamberType, const edm::PSimHitContain
   ofstream os;
   os.open(s.str().c_str(), ofstream::app);
   os << hits.size() << endl;
-  for(size_t i = 0; i < hits.size(); ++i) {
+  for (size_t i = 0; i < hits.size(); ++i) {
     PSimHit h = hits[i];
-    os << h.entryPoint().x() << " " << h.entryPoint().y() << " " 
-       << h.entryPoint().z() << " " << h.exitPoint().x() << " " 
-       << h.exitPoint().y() << " " << h.exitPoint().z() << " "
-       << h.pabs() << " " << " " << h.timeOfFlight() << " " 
-       << h.energyLoss() << " " <<h.particleType() << " " 
-       << h.detUnitId() << " " << h.trackId() << " " 
-       << h.momentumAtEntry().theta() << " " << h.momentumAtEntry().phi() << endl;
+    os << h.entryPoint().x() << " " << h.entryPoint().y() << " " << h.entryPoint().z() << " " << h.exitPoint().x()
+       << " " << h.exitPoint().y() << " " << h.exitPoint().z() << " " << h.pabs() << " "
+       << " " << h.timeOfFlight() << " " << h.energyLoss() << " " << h.particleType() << " " << h.detUnitId() << " "
+       << h.trackId() << " " << h.momentumAtEntry().theta() << " " << h.momentumAtEntry().phi() << endl;
   }
 }
-

--- a/SimMuon/Neutron/src/AsciiNeutronWriter.h
+++ b/SimMuon/Neutron/src/AsciiNeutronWriter.h
@@ -8,19 +8,16 @@
  *   hits to a muon chamber
  */
 
-
-class AsciiNeutronWriter : public NeutronWriter
-{
+class AsciiNeutronWriter : public NeutronWriter {
 public:
   AsciiNeutronWriter(std::string fileNameBase);
   ~AsciiNeutronWriter() override;
 
 protected:
-  void writeCluster(int chamberType, const edm::PSimHitContainer & hits) override;
+  void writeCluster(int chamberType, const edm::PSimHitContainer& hits) override;
 
 private:
   std::string theFileNameBase;
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/EDMNeutronWriter.cc
+++ b/SimMuon/Neutron/src/EDMNeutronWriter.cc
@@ -1,31 +1,17 @@
 #include "SimMuon/Neutron/src/EDMNeutronWriter.h"
 #include "FWCore/Framework/interface/Event.h"
 
-EDMNeutronWriter::EDMNeutronWriter()
-: theEvent(nullptr),
-  theHits(nullptr)
-{
-}
-
+EDMNeutronWriter::EDMNeutronWriter() : theEvent(nullptr), theHits(nullptr) {}
 
 EDMNeutronWriter::~EDMNeutronWriter() {}
 
-
-void EDMNeutronWriter::writeCluster(int detType, const edm::PSimHitContainer & simHits)
-{
+void EDMNeutronWriter::writeCluster(int detType, const edm::PSimHitContainer& simHits) {
   theHits->insert(theHits->end(), simHits.begin(), simHits.end());
 }
 
-
-void EDMNeutronWriter::beginEvent(edm::Event & e, const edm::EventSetup & es)
-{
+void EDMNeutronWriter::beginEvent(edm::Event& e, const edm::EventSetup& es) {
   theEvent = &e;
   theHits = std::unique_ptr<edm::PSimHitContainer>(new edm::PSimHitContainer());
 }
 
-void EDMNeutronWriter::endEvent()
-{
-  theEvent->put(std::move(theHits));
-}
-
-
+void EDMNeutronWriter::endEvent() { theEvent->put(std::move(theHits)); }

--- a/SimMuon/Neutron/src/EDMNeutronWriter.h
+++ b/SimMuon/Neutron/src/EDMNeutronWriter.h
@@ -6,21 +6,20 @@
 
 #include "SimMuon/Neutron/src/NeutronWriter.h"
 
-class EDMNeutronWriter: public NeutronWriter {
+class EDMNeutronWriter : public NeutronWriter {
 public:
   EDMNeutronWriter();
   ~EDMNeutronWriter() override;
 
-  ///  writes out a list of SimHits. 
-  void writeCluster(int detType, const edm::PSimHitContainer & simHits) override;
-  void beginEvent(edm::Event & e, const edm::EventSetup & es) override;
+  ///  writes out a list of SimHits.
+  void writeCluster(int detType, const edm::PSimHitContainer& simHits) override;
+  void beginEvent(edm::Event& e, const edm::EventSetup& es) override;
   void endEvent() override;
   void initialize(int detType) override {}
 
 private:
-  edm::Event * theEvent;
+  edm::Event* theEvent;
   std::unique_ptr<edm::PSimHitContainer> theHits;
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/NeutronReader.h
+++ b/SimMuon/Neutron/src/NeutronReader.h
@@ -6,16 +6,14 @@
  */
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include<vector>
+#include <vector>
 
-class NeutronReader
-{
-public:  
-  NeutronReader() {};
-  virtual ~NeutronReader() {};
+class NeutronReader {
+public:
+  NeutronReader(){};
+  virtual ~NeutronReader(){};
 
-  virtual void readNextEvent(int chamberType, edm::PSimHitContainer & result) = 0;
+  virtual void readNextEvent(int chamberType, edm::PSimHitContainer& result) = 0;
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/NeutronWriter.h
+++ b/SimMuon/Neutron/src/NeutronWriter.h
@@ -8,20 +8,18 @@
  * int muon chambers.
  *
  */
- 
+
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 class NeutronWriter {
 public:
-  ///  writes out a list of SimHits. 
-  virtual void writeCluster(int detType, const edm::PSimHitContainer & simHits) = 0;
+  ///  writes out a list of SimHits.
+  virtual void writeCluster(int detType, const edm::PSimHitContainer& simHits) = 0;
   virtual void initialize(int detType) {}
-  virtual void beginEvent(edm::Event & e, const edm::EventSetup & es) {}
+  virtual void beginEvent(edm::Event& e, const edm::EventSetup& es) {}
   virtual void endEvent() {}
   virtual ~NeutronWriter() {}
-
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/RootChamberReader.cc
+++ b/SimMuon/Neutron/src/RootChamberReader.cc
@@ -4,55 +4,38 @@
 #include "TClonesArray.h"
 using namespace std;
 
-RootChamberReader::RootChamberReader()
-: theTree(nullptr),
-  theHits(nullptr),
-  thePosition(0),
-  theSize(0)
-{
-}
+RootChamberReader::RootChamberReader() : theTree(nullptr), theHits(nullptr), thePosition(0), theSize(0) {}
 
-
-RootChamberReader::RootChamberReader(TFile * file, const std::string & treeName)
-: theTree( (TTree *) file->Get(treeName.c_str()) ),
-  theHits(new TClonesArray("RootSimHit")),
-  thePosition(-1),
-  theSize(0)
-{
-  if(theTree != nullptr) 
-  {
+RootChamberReader::RootChamberReader(TFile *file, const std::string &treeName)
+    : theTree((TTree *)file->Get(treeName.c_str())),
+      theHits(new TClonesArray("RootSimHit")),
+      thePosition(-1),
+      theSize(0) {
+  if (theTree != nullptr) {
     theTree->SetBranchAddress("Hits", &theHits);
     theSize = theTree->GetEntries();
   }
 }
 
-
-RootChamberReader::~RootChamberReader()
-{
-//  delete theHits;
-//  delete theTree;
+RootChamberReader::~RootChamberReader() {
+  //  delete theHits;
+  //  delete theTree;
 }
 
-
-void RootChamberReader::read(edm::PSimHitContainer & hits)
-{
+void RootChamberReader::read(edm::PSimHitContainer &hits) {
   // if there's no tree, make no events
-  if(theTree != nullptr && theSize != 0)
-  {
+  if (theTree != nullptr && theSize != 0) {
     ++thePosition;
     // start again from the beginning, if needed
-    if(thePosition >= theSize) thePosition = 0;
+    if (thePosition >= theSize)
+      thePosition = 0;
     theTree->GetEntry(thePosition);
 
     TIter next(theHits);
-    RootSimHit * rootHit;
-    while( (rootHit = (RootSimHit *) next()) )
-    {
+    RootSimHit *rootHit;
+    while ((rootHit = (RootSimHit *)next())) {
       hits.push_back(rootHit->get());
     }
-    LogTrace("Neutrons") << "Event " << thePosition << " OF " << theSize 
-         << " has " << hits.size() << " hits ";
+    LogTrace("Neutrons") << "Event " << thePosition << " OF " << theSize << " has " << hits.size() << " hits ";
   }
 }
-
-

--- a/SimMuon/Neutron/src/RootChamberReader.h
+++ b/SimMuon/Neutron/src/RootChamberReader.h
@@ -5,23 +5,21 @@
 #include <TTree.h>
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-class RootChamberReader
-{
+class RootChamberReader {
 public:
   /// default ctor, for STL
   RootChamberReader();
-  RootChamberReader(TFile * file, const std::string & treeName);
+  RootChamberReader(TFile* file, const std::string& treeName);
   /// writes the tree, and deletes everything
   ~RootChamberReader();
 
-  void read(edm::PSimHitContainer & hits);
+  void read(edm::PSimHitContainer& hits);
 
 private:
-  TTree * theTree;
-  TClonesArray * theHits;
+  TTree* theTree;
+  TClonesArray* theHits;
   int thePosition;
   int theSize;
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/RootChamberWriter.cc
+++ b/SimMuon/Neutron/src/RootChamberWriter.cc
@@ -4,34 +4,26 @@
 #include <iostream>
 using namespace std;
 
-
-RootChamberWriter::RootChamberWriter(const std::string & treeName)
-{
+RootChamberWriter::RootChamberWriter(const std::string& treeName) {
   theHits = new TClonesArray("RootSimHit");
   theTree = new TTree(treeName.c_str(), "Neutron Background");
   theTree->Bronch("Hits", "TClonesArray", &theHits);
 }
 
-
-RootChamberWriter::~RootChamberWriter()
-{
-//std::cout << "WRITING " << theTree->GetEntries() << std::endl;
-//  theTree->Write();
+RootChamberWriter::~RootChamberWriter() {
+  //std::cout << "WRITING " << theTree->GetEntries() << std::endl;
+  //  theTree->Write();
   //delete theHits;
   //delete theTree;
 }
 
-
-void RootChamberWriter::write(const edm::PSimHitContainer & hits)
-{
-std::cout << "ENTRIES BEFORE " << theTree->GetEntries() << std::endl;
+void RootChamberWriter::write(const edm::PSimHitContainer& hits) {
+  std::cout << "ENTRIES BEFORE " << theTree->GetEntries() << std::endl;
   theHits->Delete();
   theHits->Expand(hits.size());
-  for(unsigned int i = 0; i < hits.size(); ++i)
-  {
-    new((*theHits)[i]) RootSimHit(hits[i]);
+  for (unsigned int i = 0; i < hits.size(); ++i) {
+    new ((*theHits)[i]) RootSimHit(hits[i]);
   }
   theTree->Fill();
-std::cout << "ENTRIES AFTER " << theTree->GetEntries() << std::endl;
+  std::cout << "ENTRIES AFTER " << theTree->GetEntries() << std::endl;
 }
-

--- a/SimMuon/Neutron/src/RootChamberWriter.h
+++ b/SimMuon/Neutron/src/RootChamberWriter.h
@@ -5,24 +5,22 @@
 #include <TClonesArray.h>
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-class RootChamberWriter
-{
+class RootChamberWriter {
 public:
   /// default ctor, for STL
   RootChamberWriter() : theTree(nullptr), theHits(nullptr) {}
-  RootChamberWriter(const std::string & treeName);
+  RootChamberWriter(const std::string& treeName);
 
   /// writes the tree, and deletes everything
   ~RootChamberWriter();
 
-  void write(const edm::PSimHitContainer & hits);
+  void write(const edm::PSimHitContainer& hits);
 
-  TTree * tree() {return theTree;}
+  TTree* tree() { return theTree; }
 
 private:
-  TTree * theTree;
-  TClonesArray * theHits;
+  TTree* theTree;
+  TClonesArray* theHits;
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/RootNeutronReader.cc
+++ b/SimMuon/Neutron/src/RootNeutronReader.cc
@@ -1,23 +1,14 @@
 #include "SimMuon/Neutron/src/RootNeutronReader.h"
 #include <sstream>
 
-RootNeutronReader::RootNeutronReader(const std::string & fileName)
-: theFile(new TFile(fileName.c_str()))
-{
-}
+RootNeutronReader::RootNeutronReader(const std::string& fileName) : theFile(new TFile(fileName.c_str())) {}
 
+RootChamberReader& RootNeutronReader::chamberReader(int chamberType) {
+  std::map<int, RootChamberReader>::iterator mapItr = theChamberReaders.find(chamberType);
 
-RootChamberReader & RootNeutronReader::chamberReader(int chamberType)
-{
-  std::map<int, RootChamberReader>::iterator mapItr
-    = theChamberReaders.find(chamberType);
-
-  if(mapItr != theChamberReaders.end())
-  {
+  if (mapItr != theChamberReaders.end()) {
     return mapItr->second;
-  }
-  else
-  {
+  } else {
     // make a new one
     std::ostringstream treeName;
     treeName << "ChamberType" << chamberType;
@@ -26,10 +17,6 @@ RootChamberReader & RootNeutronReader::chamberReader(int chamberType)
   }
 }
 
-
-void RootNeutronReader::readNextEvent(int chamberType, edm::PSimHitContainer & result)
-{
-   chamberReader(chamberType).read(result);
+void RootNeutronReader::readNextEvent(int chamberType, edm::PSimHitContainer& result) {
+  chamberReader(chamberType).read(result);
 }
-
-

--- a/SimMuon/Neutron/src/RootNeutronReader.h
+++ b/SimMuon/Neutron/src/RootNeutronReader.h
@@ -12,19 +12,17 @@
  * back to the beginning when it reaches EOF
  */
 
-class RootNeutronReader : public NeutronReader
-{
+class RootNeutronReader : public NeutronReader {
 public:
-  RootNeutronReader(const std::string & fileName);
+  RootNeutronReader(const std::string& fileName);
 
-  void readNextEvent(int chamberType, edm::PSimHitContainer & result) override;
+  void readNextEvent(int chamberType, edm::PSimHitContainer& result) override;
 
-  RootChamberReader & chamberReader(int chamberType);
+  RootChamberReader& chamberReader(int chamberType);
 
 private:
-  TFile * theFile;
+  TFile* theFile;
   std::map<int, RootChamberReader> theChamberReaders;
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/RootNeutronWriter.cc
+++ b/SimMuon/Neutron/src/RootNeutronWriter.cc
@@ -3,55 +3,40 @@
 
 using namespace std;
 #include <iostream>
-RootNeutronWriter::RootNeutronWriter(const string & fileName) 
-{
-  theFile = new TFile(fileName.c_str(),"update");
-}
+RootNeutronWriter::RootNeutronWriter(const string& fileName) { theFile = new TFile(fileName.c_str(), "update"); }
 
-
-RootNeutronWriter::~RootNeutronWriter() 
-{
-  for(std::map<int, RootChamberWriter>::iterator mapItr = theChamberWriters.begin();
-      mapItr != theChamberWriters.end(); ++mapItr)
-  {
+RootNeutronWriter::~RootNeutronWriter() {
+  for (std::map<int, RootChamberWriter>::iterator mapItr = theChamberWriters.begin(); mapItr != theChamberWriters.end();
+       ++mapItr) {
     mapItr->second.tree()->Print();
     // the tree will remember which file it's from
     theFile = mapItr->second.tree()->GetCurrentFile();
   }
   theFile->Write();
-//  theFile->Close();
+  //  theFile->Close();
 }
 
-
-void RootNeutronWriter::initialize(int chamberType)
-{
-    ostringstream treeName;
-    treeName << "ChamberType" << chamberType;
-    theChamberWriters[chamberType] = RootChamberWriter(treeName.str());
+void RootNeutronWriter::initialize(int chamberType) {
+  ostringstream treeName;
+  treeName << "ChamberType" << chamberType;
+  theChamberWriters[chamberType] = RootChamberWriter(treeName.str());
 }
 
-RootChamberWriter & RootNeutronWriter::chamberWriter(int chamberType)
-{
+RootChamberWriter& RootNeutronWriter::chamberWriter(int chamberType) {
   std::map<int, RootChamberWriter>::iterator mapItr = theChamberWriters.find(chamberType);
-  if(mapItr != theChamberWriters.end())
-  {
+  if (mapItr != theChamberWriters.end()) {
     return mapItr->second;
-  }
-  else
-  {
+  } else {
     throw cms::Exception("NeutronWriter") << "It's dangerous to create ROOT chamber "
-      << "writers during processing.  The global file may change";
-      
+                                          << "writers during processing.  The global file may change";
+
     // make a new one
     initialize(chamberType);
     return theChamberWriters[chamberType];
   }
 }
 
-
-void RootNeutronWriter::writeCluster(int chamberType, const edm::PSimHitContainer & hits) 
-{
-std::cout << "ROOTNEUTRONWRITER " << chamberType << " HITS SIZE " << hits.size() <<std::endl;
+void RootNeutronWriter::writeCluster(int chamberType, const edm::PSimHitContainer& hits) {
+  std::cout << "ROOTNEUTRONWRITER " << chamberType << " HITS SIZE " << hits.size() << std::endl;
   chamberWriter(chamberType).write(hits);
 }
-

--- a/SimMuon/Neutron/src/RootNeutronWriter.h
+++ b/SimMuon/Neutron/src/RootNeutronWriter.h
@@ -10,25 +10,22 @@
  *   hits to a muon chamber
  */
 
-
-class RootNeutronWriter : public NeutronWriter
-{
+class RootNeutronWriter : public NeutronWriter {
 public:
-  RootNeutronWriter(const std::string & fileName);
+  RootNeutronWriter(const std::string& fileName);
   ~RootNeutronWriter() override;
 
   /// users should use this to create chamberwriters
   /// for each chamber type just after creation
   void initialize(int detType) override;
 
-  RootChamberWriter & chamberWriter(int chamberType);
+  RootChamberWriter& chamberWriter(int chamberType);
 
-  void writeCluster(int chamberType, const edm::PSimHitContainer & hits) override;
+  void writeCluster(int chamberType, const edm::PSimHitContainer& hits) override;
 
 private:
   std::map<int, RootChamberWriter> theChamberWriters;
-  TFile * theFile;
+  TFile* theFile;
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/RootSimHit.cc
+++ b/SimMuon/Neutron/src/RootSimHit.cc
@@ -1,32 +1,33 @@
 #include "SimMuon/Neutron/src/RootSimHit.h"
 ClassImp(RootSimHit);
 
+RootSimHit::RootSimHit(const PSimHit& hit)
+    : theEntryX(hit.entryPoint().x()),
+      theEntryY(hit.entryPoint().y()),
+      theEntryZ(hit.entryPoint().z()),
+      theExitX(hit.exitPoint().x()),
+      theExitY(hit.exitPoint().y()),
+      theExitZ(hit.exitPoint().z()),
+      thePabs(hit.pabs()),
+      theEnergyLoss(hit.energyLoss()),
+      theThetaAtEntry(hit.thetaAtEntry()),
+      thePhiAtEntry(hit.phiAtEntry()),
+      theTof(hit.tof()),
+      theParticleType(hit.particleType()),
+      theProcessType(hit.processType()),
+      theDetUnitId(hit.detUnitId()),
+      theTrackId(hit.trackId()) {}
 
-RootSimHit::RootSimHit(const PSimHit & hit)
-: theEntryX(hit.entryPoint().x()),
-  theEntryY(hit.entryPoint().y()),
-  theEntryZ(hit.entryPoint().z()),
-  theExitX(hit.exitPoint().x()),
-  theExitY(hit.exitPoint().y()),
-  theExitZ(hit.exitPoint().z()),
-  thePabs(hit.pabs()),
-  theEnergyLoss(hit.energyLoss()),
-  theThetaAtEntry(hit.thetaAtEntry()), thePhiAtEntry(hit.phiAtEntry()),
-  theTof(hit.tof()),
-  theParticleType(hit.particleType()), theProcessType(hit.processType()),
-  theDetUnitId( hit.detUnitId()), theTrackId( hit.trackId())
-{
+PSimHit RootSimHit::get() const {
+  return PSimHit(Local3DPoint(theEntryX, theEntryY, theEntryZ),
+                 Local3DPoint(theExitX, theExitY, theExitZ),
+                 thePabs,
+                 theTof,
+                 theEnergyLoss,
+                 theParticleType,
+                 theDetUnitId,
+                 theTrackId,
+                 theThetaAtEntry,
+                 thePhiAtEntry,
+                 theProcessType);
 }
-
-
-PSimHit RootSimHit::get() const
-{
- return PSimHit(Local3DPoint(theEntryX, theEntryY, theEntryZ),
-                Local3DPoint(theExitX, theExitY, theExitZ),
-                thePabs, theTof,
-                theEnergyLoss, theParticleType, theDetUnitId, theTrackId,
-                theThetaAtEntry,  thePhiAtEntry, theProcessType);
-}
-
-
-

--- a/SimMuon/Neutron/src/RootSimHit.h
+++ b/SimMuon/Neutron/src/RootSimHit.h
@@ -4,37 +4,36 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include <TObject.h>
 
-class RootSimHit : public TObject
-{
+class RootSimHit : public TObject {
 public:
   RootSimHit() {}
-  RootSimHit(const PSimHit & hit);
+  RootSimHit(const PSimHit& hit);
   PSimHit get() const;
+
 private:
   // properties
-//  Local3DPoint    theEntryPoint;    // position at entry
-//  Local3DPoint   theExitPoint;     // exitPos 
-  float           theEntryX;
-  float           theEntryY;
-  float           theEntryZ;
-  float           theExitX;
-  float           theExitY;
-  float           theExitZ;
-  float           thePabs;          // momentum
-  float           theEnergyLoss;    // Energy loss
-  float           theThetaAtEntry;
-  float           thePhiAtEntry;
+  //  Local3DPoint    theEntryPoint;    // position at entry
+  //  Local3DPoint   theExitPoint;     // exitPos
+  float theEntryX;
+  float theEntryY;
+  float theEntryZ;
+  float theExitX;
+  float theExitY;
+  float theExitZ;
+  float thePabs;        // momentum
+  float theEnergyLoss;  // Energy loss
+  float theThetaAtEntry;
+  float thePhiAtEntry;
 
-  float           theTof;           // Time Of Flight
-  short           theParticleType;
-  unsigned short  theProcessType;   // ID of the process which created the track
-                                    // which created the PSimHit
+  float theTof;  // Time Of Flight
+  short theParticleType;
+  unsigned short theProcessType;  // ID of the process which created the track
+                                  // which created the PSimHit
 
   // association
-  unsigned int    theDetUnitId;
-  unsigned int    theTrackId;
+  unsigned int theDetUnitId;
+  unsigned int theTrackId;
   ClassDef(RootSimHit, 1)
 };
 
 #endif
-

--- a/SimMuon/Neutron/src/SubsystemNeutronWriter.cc
+++ b/SimMuon/Neutron/src/SubsystemNeutronWriter.cc
@@ -18,184 +18,162 @@ using namespace std;
 
 class SortByTime {
 public:
-  bool operator()(const PSimHit & h1, const PSimHit & h2) {
-   return (h1.tof() < h2.tof());
-  }
+  bool operator()(const PSimHit& h1, const PSimHit& h2) { return (h1.tof() < h2.tof()); }
 };
 
-SubsystemNeutronWriter::SubsystemNeutronWriter(edm::ParameterSet const& pset) 
-: theHitWriter(nullptr),
-  useRandFlat(false),
-  theInputTag(pset.getParameter<edm::InputTag>("input")),
-  theNeutronTimeCut(pset.getParameter<double>("neutronTimeCut")),
-  theTimeWindow(pset.getParameter<double>("timeWindow")),
-  theT0(pset.getParameter<double>("t0")),
-  theNEvents(0),
-  initialized(false),
-  useLocalDetId_(true)
-{
+SubsystemNeutronWriter::SubsystemNeutronWriter(edm::ParameterSet const& pset)
+    : theHitWriter(nullptr),
+      useRandFlat(false),
+      theInputTag(pset.getParameter<edm::InputTag>("input")),
+      theNeutronTimeCut(pset.getParameter<double>("neutronTimeCut")),
+      theTimeWindow(pset.getParameter<double>("timeWindow")),
+      theT0(pset.getParameter<double>("t0")),
+      theNEvents(0),
+      initialized(false),
+      useLocalDetId_(true) {
   string writer = pset.getParameter<string>("writer");
   string output = pset.getParameter<string>("output");
-  if(writer == "ASCII")
-  {
+  if (writer == "ASCII") {
     theHitWriter = new AsciiNeutronWriter(output);
-  }
-  else if (writer == "ROOT")
-  {
+  } else if (writer == "ROOT") {
     theHitWriter = new RootNeutronWriter(output);
-  }
-  else if (writer == "EDM")
-  {
+  } else if (writer == "EDM") {
     produces<edm::PSimHitContainer>();
     theHitWriter = new EDMNeutronWriter();
     // write out the real DetId, not the local one
     useLocalDetId_ = false;
     // smear the times
     edm::Service<edm::RandomNumberGenerator> rng;
-    if ( ! rng.isAvailable()) {
-     throw cms::Exception("Configuration")
-       << "SubsystemNeutronWriter requires the RandomNumberGeneratorService\n"
-          "which is not present in the configuration file.  You must add the service\n"
-          "in the configuration file or remove the modules that require it.";
+    if (!rng.isAvailable()) {
+      throw cms::Exception("Configuration")
+          << "SubsystemNeutronWriter requires the RandomNumberGeneratorService\n"
+             "which is not present in the configuration file.  You must add the service\n"
+             "in the configuration file or remove the modules that require it.";
     }
     useRandFlat = true;
+  } else {
+    throw cms::Exception("NeutronWriter") << "Bad writer: " << writer;
   }
-  else 
-  {
-    throw cms::Exception("NeutronWriter") << "Bad writer: "
-      << writer;
-  } 
 }
 
-SubsystemNeutronWriter::~SubsystemNeutronWriter()
-{
+SubsystemNeutronWriter::~SubsystemNeutronWriter() {
   printStats();
   delete theHitWriter;
 }
 
 void SubsystemNeutronWriter::printStats() {
   edm::LogInfo("SubsystemNeutronWriter") << "SubsystemNeutronWriter Statistics:\n";
-  for(map<int,int>::iterator mapItr = theCountPerChamberType.begin();
-      mapItr != theCountPerChamberType.end();  ++mapItr) {
-     edm::LogInfo("SubsystemNeutronWriter") << "   theEventOccupancy[" << mapItr->first << "] = "
-         << mapItr->second << " / " << theNEvents << " / NCT \n";
+  for (map<int, int>::iterator mapItr = theCountPerChamberType.begin(); mapItr != theCountPerChamberType.end();
+       ++mapItr) {
+    edm::LogInfo("SubsystemNeutronWriter")
+        << "   theEventOccupancy[" << mapItr->first << "] = " << mapItr->second << " / " << theNEvents << " / NCT \n";
   }
 }
 
-void SubsystemNeutronWriter::produce(edm::Event & e, edm::EventSetup const& c)
-{
+void SubsystemNeutronWriter::produce(edm::Event& e, edm::EventSetup const& c) {
   CLHEP::HepRandomEngine* engine = nullptr;
-  if(useRandFlat) {
+  if (useRandFlat) {
     edm::Service<edm::RandomNumberGenerator> rng;
     engine = &rng->getEngine(e.streamID());
   }
-  theHitWriter->beginEvent(e,c);
+  theHitWriter->beginEvent(e, c);
   ++theNEvents;
   edm::Handle<edm::PSimHitContainer> hits;
   e.getByLabel(theInputTag, hits);
 
   // sort hits by chamber
   map<int, edm::PSimHitContainer> hitsByChamber;
-  for(edm::PSimHitContainer::const_iterator hitItr = hits->begin();
-      hitItr != hits->end(); ++hitItr)
-  {
+  for (edm::PSimHitContainer::const_iterator hitItr = hits->begin(); hitItr != hits->end(); ++hitItr) {
     int chamberIndex = chamberId(hitItr->detUnitId());
     hitsByChamber[chamberIndex].push_back(*hitItr);
   }
 
   // now write out each chamber's contents
-  for(map<int, edm::PSimHitContainer>::iterator hitsByChamberItr = hitsByChamber.begin();
-      hitsByChamberItr != hitsByChamber.end(); ++hitsByChamberItr)
-  {
+  for (map<int, edm::PSimHitContainer>::iterator hitsByChamberItr = hitsByChamber.begin();
+       hitsByChamberItr != hitsByChamber.end();
+       ++hitsByChamberItr) {
     int chambertype = chamberType(hitsByChamberItr->first);
     writeHits(chambertype, hitsByChamberItr->second, engine);
   }
   theHitWriter->endEvent();
 }
 
-
-void SubsystemNeutronWriter::initialize(int chamberType)
-{
+void SubsystemNeutronWriter::initialize(int chamberType) {
   // should instantiate one of every chamber type, just so
   // ROOT knows what file to associate them with
   theHitWriter->initialize(chamberType);
 }
 
-
-void SubsystemNeutronWriter::writeHits(int chamberType, edm::PSimHitContainer & chamberHits,
-                                       CLHEP::HepRandomEngine* engine)
-{
-
+void SubsystemNeutronWriter::writeHits(int chamberType,
+                                       edm::PSimHitContainer& chamberHits,
+                                       CLHEP::HepRandomEngine* engine) {
   sort(chamberHits.begin(), chamberHits.end(), SortByTime());
   edm::PSimHitContainer cluster;
   float startTime = -1000.;
   float smearing = 0.;
-  for(size_t i = 0; i < chamberHits.size(); ++i) {
+  for (size_t i = 0; i < chamberHits.size(); ++i) {
     PSimHit hit = chamberHits[i];
     float tof = hit.tof();
-    LogDebug("SubsystemNeutronWriter") << "found hit from part type " << hit.particleType()
-                   << " at tof " << tof << " p " << hit.pabs() 
-                   << " on det " << hit.detUnitId() 
-                   << " chamber type " << chamberType;
-    if(tof > theNeutronTimeCut) {
-      if(tof > (startTime + theTimeWindow) ) { // 1st in cluster
+    LogDebug("SubsystemNeutronWriter") << "found hit from part type " << hit.particleType() << " at tof " << tof
+                                       << " p " << hit.pabs() << " on det " << hit.detUnitId() << " chamber type "
+                                       << chamberType;
+    if (tof > theNeutronTimeCut) {
+      if (tof > (startTime + theTimeWindow)) {  // 1st in cluster
         startTime = tof;
         // set the time to be [t0, t0+25] at start of event
         smearing = theT0;
-        if(useRandFlat) {
+        if (useRandFlat) {
           smearing += CLHEP::RandFlat::shoot(engine, 25.);
         }
-        if(!cluster.empty()) {
+        if (!cluster.empty()) {
           LogDebug("SubsystemNeutronWriter") << "filling old cluster";
           writeCluster(chamberType, cluster);
           cluster.clear();
         }
-        LogDebug("SubsystemNeutronWriter") << "starting neutron cluster at time " << startTime 
-          << " on detType " << chamberType;
+        LogDebug("SubsystemNeutronWriter")
+            << "starting neutron cluster at time " << startTime << " on detType " << chamberType;
       }
-      adjust(hit, -1.*startTime, smearing);
-      cluster.push_back( hit );
+      adjust(hit, -1. * startTime, smearing);
+      cluster.push_back(hit);
     }
   }
   // get any leftover cluster
-  if(!cluster.empty()) {
+  if (!cluster.empty()) {
     writeCluster(chamberType, cluster);
   }
 }
 
-
-void SubsystemNeutronWriter::writeCluster(int chamberType, const edm::PSimHitContainer & cluster)
-{
-  if(accept(cluster))
-  {
+void SubsystemNeutronWriter::writeCluster(int chamberType, const edm::PSimHitContainer& cluster) {
+  if (accept(cluster)) {
     theHitWriter->writeCluster(chamberType, cluster);
     updateCount(chamberType);
   }
 }
 
-
-void SubsystemNeutronWriter::adjust(PSimHit & h, float timeOffset, float smearing) {
+void SubsystemNeutronWriter::adjust(PSimHit& h, float timeOffset, float smearing) {
   unsigned int detId = useLocalDetId_ ? localDetId(h.detUnitId()) : h.detUnitId();
   float htime = h.timeOfFlight() + timeOffset + smearing;
   // prevent float precision loss
   if (h.timeOfFlight() > 1.E+6) {
     htime = smearing;
   }
-  h = PSimHit( h.entryPoint(), h.exitPoint(), h.pabs(), htime,
-               h.energyLoss(), h.particleType(), 
-               detId, h.trackId(),
-               h.momentumAtEntry().theta(),
-               h.momentumAtEntry().phi() );
+  h = PSimHit(h.entryPoint(),
+              h.exitPoint(),
+              h.pabs(),
+              htime,
+              h.energyLoss(),
+              h.particleType(),
+              detId,
+              h.trackId(),
+              h.momentumAtEntry().theta(),
+              h.momentumAtEntry().phi());
 }
 
-
 void SubsystemNeutronWriter::updateCount(int chamberType) {
-  map<int,int>::iterator entry = theCountPerChamberType.find(chamberType);
-  if(entry == theCountPerChamberType.end()) {
-    theCountPerChamberType.insert( pair<int,int>(chamberType, 1) );
+  map<int, int>::iterator entry = theCountPerChamberType.find(chamberType);
+  if (entry == theCountPerChamberType.end()) {
+    theCountPerChamberType.insert(pair<int, int>(chamberType, 1));
   } else {
     ++(entry->second);
   }
 }
-
-

--- a/SimMuon/Neutron/src/classes.h
+++ b/SimMuon/Neutron/src/classes.h
@@ -1,6 +1,5 @@
 #include "SimMuon/Neutron/src/RootSimHit.h"
 
 namespace SimMuon_Neutron {
-  struct dictionary {
-  };
-}
+  struct dictionary {};
+}  // namespace SimMuon_Neutron

--- a/SimPPS/PPSSimTrackProducer/plugins/PPSSimTrackProducer.cc
+++ b/SimPPS/PPSSimTrackProducer/plugins/PPSSimTrackProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    SimPPS/PPSSimTrackProducer
 // Class:      PPSSimTrackProducer
-// 
+//
 /**\class PPSSimTrackProducer PPSSimTrackProducer.cc SimPPS/PPSSimTrackProducer/plugins/PPSSimTrackProducer.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Sun, 03 Dec 2017 00:25:54 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -44,32 +43,30 @@
 //
 
 class PPSSimTrackProducer : public edm::stream::EDProducer<> {
-   public:
-      explicit PPSSimTrackProducer(const edm::ParameterSet&);
-      ~PPSSimTrackProducer() override;
+public:
+  explicit PPSSimTrackProducer(const edm::ParameterSet&);
+  ~PPSSimTrackProducer() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void beginStream(edm::StreamID) override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endStream() override;
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-      // ----------member data ---------------------------
-             bool m_verbosity;
-             ProtonTransport* theTransporter = nullptr;
-             edm::InputTag  m_InTag;
-             edm::EDGetTokenT<edm::HepMCProduct> m_InTagToken;
+  // ----------member data ---------------------------
+  bool m_verbosity;
+  ProtonTransport* theTransporter = nullptr;
+  edm::InputTag m_InTag;
+  edm::EDGetTokenT<edm::HepMCProduct> m_InTagToken;
 
-             std::string m_transportMethod;
-             int m_eventsAnalysed; //!< just to count events that have been analysed
-    
+  std::string m_transportMethod;
+  int m_eventsAnalysed;  //!< just to count events that have been analysed
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -78,122 +75,113 @@ class PPSSimTrackProducer : public edm::stream::EDProducer<> {
 //
 // constructors and destructor
 //
-PPSSimTrackProducer::PPSSimTrackProducer(const edm::ParameterSet& iConfig)
-{
-   //now do what ever other initialization is needed
-    // TransportHector
-    m_InTag          = iConfig.getParameter<edm::InputTag>("HepMCProductLabel") ;
-    m_InTagToken     = consumes<edm::HepMCProduct>(m_InTag);
+PPSSimTrackProducer::PPSSimTrackProducer(const edm::ParameterSet& iConfig) {
+  //now do what ever other initialization is needed
+  // TransportHector
+  m_InTag = iConfig.getParameter<edm::InputTag>("HepMCProductLabel");
+  m_InTagToken = consumes<edm::HepMCProduct>(m_InTag);
 
-    m_verbosity      = iConfig.getParameter<bool>("Verbosity");
-    m_transportMethod = iConfig.getParameter<std::string>("TransportMethod");
+  m_verbosity = iConfig.getParameter<bool>("Verbosity");
+  m_transportMethod = iConfig.getParameter<std::string>("TransportMethod");
 
-    produces<edm::HepMCProduct>();
-    produces<edm::LHCTransportLinkContainer>();
+  produces<edm::HepMCProduct>();
+  produces<edm::LHCTransportLinkContainer>();
 
+  theTransporter = nullptr;
+
+  if (m_transportMethod == "Totem") {
+    theTransporter = new TotemTransport(iConfig, m_verbosity);
+  } else if (m_transportMethod == "Hector") {
+    theTransporter = new HectorTransport(iConfig, m_verbosity);
+  } else {
+    throw cms::Exception("Configuration")
+        << "LHCTransport (ProtonTransport) requires a Method (Hector or Totem) \n"
+           "which is not present in the configuration file. You should add one of the method\n"
+           "above in the configuration file or remove the module that requires it.";
+  }
+
+  edm::Service<edm::RandomNumberGenerator> rng;
+  if (!rng.isAvailable()) {
+    throw cms::Exception("Configuration")
+        << "LHCTransport (ProtonTransport) requires the RandomNumberGeneratorService\n"
+           "which is not present in the configuration file.  You must add the service\n"
+           "in the configuration file or remove the modules that require it.";
+  }
+}
+
+PPSSimTrackProducer::~PPSSimTrackProducer() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+  if (theTransporter) {
+    delete theTransporter;
     theTransporter = nullptr;
-
-    if (m_transportMethod=="Totem")       {theTransporter = new TotemTransport(iConfig, m_verbosity);}
-    else if (m_transportMethod=="Hector") {theTransporter = new HectorTransport(iConfig, m_verbosity);}
-    else {
-         throw cms::Exception("Configuration")
-               << "LHCTransport (ProtonTransport) requires a Method (Hector or Totem) \n"
-                  "which is not present in the configuration file. You should add one of the method\n"
-                  "above in the configuration file or remove the module that requires it.";
-    }
-
-    edm::Service<edm::RandomNumberGenerator> rng;
-    if ( ! rng.isAvailable() ) {
-        throw cms::Exception("Configuration")
-            << "LHCTransport (ProtonTransport) requires the RandomNumberGeneratorService\n"
-            "which is not present in the configuration file.  You must add the service\n"
-            "in the configuration file or remove the modules that require it.";
-    }
-  
+  }
 }
-
-
-PPSSimTrackProducer::~PPSSimTrackProducer()
-{
- 
-   // do anything here that needs to be done at destruction time
-   // (e.g. close files, deallocate resources etc.)
-   if (theTransporter) { 
-      delete theTransporter; 
-      theTransporter = nullptr;
-   } 
-
-}
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-PPSSimTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    using namespace edm;
-    using namespace std;
-    HepMC::GenEvent * evt;
-    edm::Service<edm::RandomNumberGenerator> rng;
-    CLHEP::HepRandomEngine* engine = &rng->getEngine(iEvent.streamID());
-    if ( engine->name() != "TRandom3" ) {
-        throw cms::Exception("Configuration")
-            << "The TRandom3 engine type must be used with ProtonTransport, Random Number Generator Service not correctly configured!";
-    }
+void PPSSimTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
+  HepMC::GenEvent* evt;
+  edm::Service<edm::RandomNumberGenerator> rng;
+  CLHEP::HepRandomEngine* engine = &rng->getEngine(iEvent.streamID());
+  if (engine->name() != "TRandom3") {
+    throw cms::Exception("Configuration") << "The TRandom3 engine type must be used with ProtonTransport, Random "
+                                             "Number Generator Service not correctly configured!";
+  }
 
-    m_eventsAnalysed++;
-    Handle<HepMCProduct>  HepMCEvt;   
-    iEvent.getByToken( m_InTagToken, HepMCEvt ) ;
+  m_eventsAnalysed++;
+  Handle<HepMCProduct> HepMCEvt;
+  iEvent.getByToken(m_InTagToken, HepMCEvt);
 
-    if ( !HepMCEvt.isValid() ){
-        throw cms::Exception("InvalidReference")
-            << "Invalid reference to HepMCProduct\n";
-    }
+  if (!HepMCEvt.isValid()) {
+    throw cms::Exception("InvalidReference") << "Invalid reference to HepMCProduct\n";
+  }
 
-    if ( HepMCEvt.provenance()->moduleLabel() == "LHCTransport" ){
-        throw cms::Exception("LogicError")
-            << "HectorTrasported HepMCProduce already exists\n";
-    }
+  if (HepMCEvt.provenance()->moduleLabel() == "LHCTransport") {
+    throw cms::Exception("LogicError") << "HectorTrasported HepMCProduce already exists\n";
+  }
 
-    evt = new HepMC::GenEvent( *HepMCEvt->GetEvent() );
+  evt = new HepMC::GenEvent(*HepMCEvt->GetEvent());
 
-    theTransporter->clear();
-    theTransporter->process( evt ,iSetup ,engine);
+  theTransporter->clear();
+  theTransporter->process(evt, iSetup, engine);
 
-    if (m_verbosity)  evt->print();
+  if (m_verbosity)
+    evt->print();
 
-    unique_ptr<HepMCProduct> newProduct(new edm::HepMCProduct()) ;
-    newProduct->addHepMCData( evt ) ;
+  unique_ptr<HepMCProduct> newProduct(new edm::HepMCProduct());
+  newProduct->addHepMCData(evt);
 
-    iEvent.put(std::move(newProduct)) ;
+  iEvent.put(std::move(newProduct));
 
-    unique_ptr<LHCTransportLinkContainer> NewCorrespondenceMap(new edm::LHCTransportLinkContainer() );
-    edm::LHCTransportLinkContainer thisLink(theTransporter->getCorrespondenceMap());
-    (*NewCorrespondenceMap).swap(thisLink);
+  unique_ptr<LHCTransportLinkContainer> NewCorrespondenceMap(new edm::LHCTransportLinkContainer());
+  edm::LHCTransportLinkContainer thisLink(theTransporter->getCorrespondenceMap());
+  (*NewCorrespondenceMap).swap(thisLink);
 
-    if ( m_verbosity ) {
-        for ( unsigned int i = 0; i < (*NewCorrespondenceMap).size(); i++) 
-            LogDebug("HectorEventProcessing") << "Hector correspondence table: " << (*NewCorrespondenceMap)[i];
-    }
+  if (m_verbosity) {
+    for (unsigned int i = 0; i < (*NewCorrespondenceMap).size(); i++)
+      LogDebug("HectorEventProcessing") << "Hector correspondence table: " << (*NewCorrespondenceMap)[i];
+  }
 
-    iEvent.put(std::move(NewCorrespondenceMap));
-    // There is no need to delete the pointer to the event, since it is deleted in HepMCProduct,
-    // in fact, it MUST NOT be delete here, as a protection is missing in above package
+  iEvent.put(std::move(NewCorrespondenceMap));
+  // There is no need to delete the pointer to the event, since it is deleted in HepMCProduct,
+  // in fact, it MUST NOT be delete here, as a protection is missing in above package
 }
 // The methods below are pure virtual, so it needs to be implemented even if not used
 //
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void PPSSimTrackProducer::beginStream(edm::StreamID) { }
+void PPSSimTrackProducer::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void PPSSimTrackProducer::endStream() { } 
+void PPSSimTrackProducer::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-PPSSimTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PPSSimTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/SimTracker/SiStripDigitizer/interface/SiDigitalConverter.h
+++ b/SimTracker/SiStripDigitizer/interface/SiDigitalConverter.h
@@ -10,13 +10,13 @@
  * Base class for ADC simulation.
  */
 class SiDigitalConverter {
- public:
-  typedef std::vector<SiStripDigi>         DigitalVecType;
-  typedef std::vector<SiStripRawDigi>      DigitalRawVecType;
-  
-  virtual ~SiDigitalConverter() { }
-  virtual DigitalVecType    convert(const std::vector<float> &,  edm::ESHandle<SiStripGain>& ,unsigned int detid) = 0;
-  virtual DigitalRawVecType convertRaw(const std::vector<float> &,  edm::ESHandle<SiStripGain>& ,unsigned int detid) = 0;  
+public:
+  typedef std::vector<SiStripDigi> DigitalVecType;
+  typedef std::vector<SiStripRawDigi> DigitalRawVecType;
+
+  virtual ~SiDigitalConverter() {}
+  virtual DigitalVecType convert(const std::vector<float>&, edm::ESHandle<SiStripGain>&, unsigned int detid) = 0;
+  virtual DigitalRawVecType convertRaw(const std::vector<float>&, edm::ESHandle<SiStripGain>&, unsigned int detid) = 0;
 };
 
 #endif

--- a/SimTracker/SiStripDigitizer/interface/SiGaussianTailNoiseAdder.h
+++ b/SimTracker/SiStripDigitizer/interface/SiGaussianTailNoiseAdder.h
@@ -14,20 +14,19 @@ namespace CLHEP {
   class HepRandomEngine;
 }
 
-class SiGaussianTailNoiseAdder : public SiNoiseAdder{
- public:
+class SiGaussianTailNoiseAdder : public SiNoiseAdder {
+public:
   SiGaussianTailNoiseAdder(float);
   ~SiGaussianTailNoiseAdder() override;
-  void addNoise(std::vector<float>&, size_t&, size_t&, int, float, CLHEP::HepRandomEngine*) const override;
-  
-  void addNoiseVR(std::vector<float> &, std::vector<float> &, CLHEP::HepRandomEngine*) const override;
+  void addNoise(std::vector<float> &, size_t &, size_t &, int, float, CLHEP::HepRandomEngine *) const override;
+
+  void addNoiseVR(std::vector<float> &, std::vector<float> &, CLHEP::HepRandomEngine *) const override;
   void addPedestals(std::vector<float> &, std::vector<float> &) const override;
-  void addCMNoise(std::vector<float> &, float, std::vector<bool> &, CLHEP::HepRandomEngine*) const override;
+  void addCMNoise(std::vector<float> &, float, std::vector<bool> &, CLHEP::HepRandomEngine *) const override;
   void addBaselineShift(std::vector<float> &, std::vector<bool> &) const override;
-  
- private:
+
+private:
   const float threshold;
   std::unique_ptr<GaussianTailNoiseGenerator> genNoise;
 };
 #endif
- 

--- a/SimTracker/SiStripDigitizer/interface/SiNoiseAdder.h
+++ b/SimTracker/SiStripDigitizer/interface/SiNoiseAdder.h
@@ -4,23 +4,23 @@
 #include "SimTracker/SiStripDigitizer/interface/SiPileUpSignals.h"
 
 namespace CLHEP {
-   class HepRandomEngine;
+  class HepRandomEngine;
 }
 
 /**
  * Base class to add noise to the strips.
  */
-class SiNoiseAdder{
- public:
-  virtual ~SiNoiseAdder() { }
-  virtual void addNoise(std::vector<float>&,size_t&,size_t&,int,float, CLHEP::HepRandomEngine*) const = 0;
+class SiNoiseAdder {
+public:
+  virtual ~SiNoiseAdder() {}
+  virtual void addNoise(std::vector<float> &, size_t &, size_t &, int, float, CLHEP::HepRandomEngine *) const = 0;
   //virtual void createRaw(std::vector<float>&,size_t&,size_t&,int,float,float) const = 0;
-  
-  virtual void addNoiseVR(std::vector<float> &, std::vector<float> &, CLHEP::HepRandomEngine*) const=0;
-  virtual void addPedestals(std::vector<float> &, std::vector<float> &) const=0;
-  virtual void addCMNoise(std::vector<float> &, float,  std::vector<bool> &, CLHEP::HepRandomEngine*) const=0;
-  virtual void addBaselineShift(std::vector<float> &, std::vector<bool> &) const=0;
- 
+
+  virtual void addNoiseVR(std::vector<float> &, std::vector<float> &, CLHEP::HepRandomEngine *) const = 0;
+  virtual void addPedestals(std::vector<float> &, std::vector<float> &) const = 0;
+  virtual void addCMNoise(std::vector<float> &, float, std::vector<bool> &, CLHEP::HepRandomEngine *) const = 0;
+  virtual void addBaselineShift(std::vector<float> &, std::vector<bool> &) const = 0;
+
   //virtual void addNoiseVR(std::vector<float> &, std::vector<std::pair<int, float> > &) const=0;
   //virtual void addPedestals(std::vector<float> &, std::vector<std::pair<int, float> > &) const=0;
   //virtual void addConstNoise(std::vector<float> &, float) const=0;
@@ -29,6 +29,5 @@ class SiNoiseAdder{
   //virtual void addRealPed(std::vector<float> &, std::vector<float> &) const=0;
   //virtual void addCMNoise(std::vector<float> &, std::vector<std::pair<int, float> > &) const=0;
   //virtual void addBaselineShift(std::vector<float> &, std::vector<std::pair<int, float> > &) const=0;
- 
 };
 #endif

--- a/SimTracker/SiStripDigitizer/interface/SiPileUpSignals.h
+++ b/SimTracker/SiStripDigitizer/interface/SiPileUpSignals.h
@@ -11,34 +11,35 @@ class SimHit;
  * Class which takes the responses from each SimHit and piles-up them, within a given module.
  * More precisely, it keeps for each strip the link to each individual measurement.
  */
-class SiPileUpSignals{ 
- public:
+class SiPileUpSignals {
+public:
   // type used to describe the amplitude on a strip
   typedef float Amplitude;
-  // associates to each strip a vector of amplitudes. 
+  // associates to each strip a vector of amplitudes.
   // That allows later to comput the fraction of the contribution of each simhit to the ADC value
-  typedef std::map<int, Amplitude>  SignalMapType;
-  typedef std::map<uint32_t, SignalMapType>  signalMaps;
-  
+  typedef std::map<int, Amplitude> SignalMapType;
+  typedef std::map<uint32_t, SignalMapType> signalMaps;
+
   SiPileUpSignals() { reset(); }
 
-  virtual ~SiPileUpSignals() { }
-  
+  virtual ~SiPileUpSignals() {}
+
   virtual void add(uint32_t detID,
                    const std::vector<float>& locAmpl,
-                   const size_t& firstChannelWithSignal, const size_t& lastChannelWithSignal);
+                   const size_t& firstChannelWithSignal,
+                   const size_t& lastChannelWithSignal);
 
-  void reset(){ resetSignals(); }
-  
+  void reset() { resetSignals(); }
+
   const SignalMapType* getSignal(uint32_t detID) const {
     auto where = signal_.find(detID);
-    if(where == signal_.end()) {
+    if (where == signal_.end()) {
       return nullptr;
     }
     return &where->second;
   }
-  
- private:
+
+private:
   void resetSignals();
   signalMaps signal_;
 };

--- a/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
+++ b/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
@@ -5,26 +5,23 @@
 /**
  * Concrete implementation of SiDigitalConverter.
  */
-class SiTrivialDigitalConverter: public SiDigitalConverter{
- public:
-
+class SiTrivialDigitalConverter : public SiDigitalConverter {
+public:
   SiTrivialDigitalConverter(float in, bool PreMix);
-  
-  DigitalVecType    convert(const std::vector<float>&,  edm::ESHandle<SiStripGain>& ,unsigned int detid) override;
-  DigitalRawVecType convertRaw(const std::vector<float>&,  edm::ESHandle<SiStripGain>& ,unsigned int detid) override;  
 
- private:
+  DigitalVecType convert(const std::vector<float>&, edm::ESHandle<SiStripGain>&, unsigned int detid) override;
+  DigitalRawVecType convertRaw(const std::vector<float>&, edm::ESHandle<SiStripGain>&, unsigned int detid) override;
 
-  int convert(float in){return truncate(in/electronperADC);}
-  int convertRaw(float in){return truncateRaw(in/electronperADC);}
+private:
+  int convert(float in) { return truncate(in / electronperADC); }
+  int convertRaw(float in) { return truncateRaw(in / electronperADC); }
   int truncate(float in_adc) const;
   int truncateRaw(float in_adc) const;
-  
+
   const float electronperADC;
   SiDigitalConverter::DigitalVecType _temp;
   SiDigitalConverter::DigitalRawVecType _tempRaw;
   bool PreMixing_;
-
 };
- 
+
 #endif

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.cc
@@ -17,38 +17,37 @@
 #define CBOLTZ (1.38E-23)
 #define e_SI (1.6E-19)
 
-DigiSimLinkAlgorithm::DigiSimLinkAlgorithm(const edm::ParameterSet& conf):
-  conf_(conf) {
-  theThreshold              = conf_.getParameter<double>("NoiseSigmaThreshold");
-  theFedAlgo                = conf_.getParameter<int>("FedAlgorithm");
-  peakMode                  = conf_.getParameter<bool>("APVpeakmode");
-  theElectronPerADC         = conf_.getParameter<double>( peakMode ? "electronPerAdcPeak" : "electronPerAdcDec" );
-  noise                     = conf_.getParameter<bool>("Noise");
-  zeroSuppression           = conf_.getParameter<bool>("ZeroSuppression");
-  theTOFCutForPeak          = conf_.getParameter<double>("TOFCutForPeak");
+DigiSimLinkAlgorithm::DigiSimLinkAlgorithm(const edm::ParameterSet& conf) : conf_(conf) {
+  theThreshold = conf_.getParameter<double>("NoiseSigmaThreshold");
+  theFedAlgo = conf_.getParameter<int>("FedAlgorithm");
+  peakMode = conf_.getParameter<bool>("APVpeakmode");
+  theElectronPerADC = conf_.getParameter<double>(peakMode ? "electronPerAdcPeak" : "electronPerAdcDec");
+  noise = conf_.getParameter<bool>("Noise");
+  zeroSuppression = conf_.getParameter<bool>("ZeroSuppression");
+  theTOFCutForPeak = conf_.getParameter<double>("TOFCutForPeak");
   theTOFCutForDeconvolution = conf_.getParameter<double>("TOFCutForDeconvolution");
-  cosmicShift               = conf_.getUntrackedParameter<double>("CosmicDelayShift");
-  inefficiency              = conf_.getParameter<double>("Inefficiency");
-  RealPedestals             = conf_.getParameter<bool>("RealPedestals"); 
-  SingleStripNoise          = conf_.getParameter<bool>("SingleStripNoise");
-  CommonModeNoise           = conf_.getParameter<bool>("CommonModeNoise");
-  BaselineShift             = conf_.getParameter<bool>("BaselineShift");
-  APVSaturationFromHIP      = conf_.getParameter<bool>("APVSaturationFromHIP");
-  APVSaturationProb         = conf_.getParameter<double>("APVSaturationProb");
-  cmnRMStib                 = conf_.getParameter<double>("cmnRMStib");
-  cmnRMStob                 = conf_.getParameter<double>("cmnRMStob");
-  cmnRMStid                 = conf_.getParameter<double>("cmnRMStid");
-  cmnRMStec                 = conf_.getParameter<double>("cmnRMStec");
-  pedOffset                 = (unsigned int)conf_.getParameter<double>("PedestalsOffset");
-  PreMixing_                = conf_.getParameter<bool>("PreMixingMode");
+  cosmicShift = conf_.getUntrackedParameter<double>("CosmicDelayShift");
+  inefficiency = conf_.getParameter<double>("Inefficiency");
+  RealPedestals = conf_.getParameter<bool>("RealPedestals");
+  SingleStripNoise = conf_.getParameter<bool>("SingleStripNoise");
+  CommonModeNoise = conf_.getParameter<bool>("CommonModeNoise");
+  BaselineShift = conf_.getParameter<bool>("BaselineShift");
+  APVSaturationFromHIP = conf_.getParameter<bool>("APVSaturationFromHIP");
+  APVSaturationProb = conf_.getParameter<double>("APVSaturationProb");
+  cmnRMStib = conf_.getParameter<double>("cmnRMStib");
+  cmnRMStob = conf_.getParameter<double>("cmnRMStob");
+  cmnRMStid = conf_.getParameter<double>("cmnRMStid");
+  cmnRMStec = conf_.getParameter<double>("cmnRMStec");
+  pedOffset = (unsigned int)conf_.getParameter<double>("PedestalsOffset");
+  PreMixing_ = conf_.getParameter<bool>("PreMixingMode");
   if (peakMode) {
-    tofCut=theTOFCutForPeak;
-    LogDebug("StripDigiInfo")<<"APVs running in peak mode (poor time resolution)";
+    tofCut = theTOFCutForPeak;
+    LogDebug("StripDigiInfo") << "APVs running in peak mode (poor time resolution)";
   } else {
-    tofCut=theTOFCutForDeconvolution;
-    LogDebug("StripDigiInfo")<<"APVs running in deconvolution mode (good time resolution)";
+    tofCut = theTOFCutForDeconvolution;
+    LogDebug("StripDigiInfo") << "APVs running in deconvolution mode (good time resolution)";
   };
-  
+
   theSiHitDigitizer = new SiHitDigitizer(conf_);
   theDigiSimLinkPileUpSignals = new DigiSimLinkPileUpSignals();
   theSiNoiseAdder = new SiGaussianTailNoiseAdder(theThreshold);
@@ -56,7 +55,7 @@ DigiSimLinkAlgorithm::DigiSimLinkAlgorithm(const edm::ParameterSet& conf):
   theSiZeroSuppress = new SiStripFedZeroSuppression(theFedAlgo);
 }
 
-DigiSimLinkAlgorithm::~DigiSimLinkAlgorithm(){
+DigiSimLinkAlgorithm::~DigiSimLinkAlgorithm() {
   delete theSiHitDigitizer;
   delete theDigiSimLinkPileUpSignals;
   delete theSiNoiseAdder;
@@ -70,16 +69,17 @@ DigiSimLinkAlgorithm::~DigiSimLinkAlgorithm(){
 //  ------------------------------------
 
 void DigiSimLinkAlgorithm::run(edm::DetSet<SiStripDigi>& outdigi,
-			       edm::DetSet<SiStripRawDigi>& outrawdigi,
-			       const std::vector<std::pair<const PSimHit*, int > > &input,
-			       StripGeomDetUnit const *det,
-			       GlobalVector bfield,float langle, 
-			       edm::ESHandle<SiStripGain> & gainHandle,
-			       edm::ESHandle<SiStripThreshold> & thresholdHandle,
-			       edm::ESHandle<SiStripNoises> & noiseHandle,
-			       edm::ESHandle<SiStripPedestals> & pedestalHandle,
-			       edm::ESHandle<SiStripBadStrip> & deadChannelHandle,
-			       const TrackerTopology *tTopo,
+                               edm::DetSet<SiStripRawDigi>& outrawdigi,
+                               const std::vector<std::pair<const PSimHit*, int> >& input,
+                               StripGeomDetUnit const* det,
+                               GlobalVector bfield,
+                               float langle,
+                               edm::ESHandle<SiStripGain>& gainHandle,
+                               edm::ESHandle<SiStripThreshold>& thresholdHandle,
+                               edm::ESHandle<SiStripNoises>& noiseHandle,
+                               edm::ESHandle<SiStripPedestals>& pedestalHandle,
+                               edm::ESHandle<SiStripBadStrip>& deadChannelHandle,
+                               const TrackerTopology* tTopo,
                                CLHEP::HepRandomEngine* engine) {
   theDigiSimLinkPileUpSignals->reset();
   unsigned int detID = det->geographicalId().rawId();
@@ -87,299 +87,327 @@ void DigiSimLinkAlgorithm::run(edm::DetSet<SiStripDigi>& outdigi,
   SiStripApvGain::Range detGainRange = gainHandle->getRange(detID);
   SiStripPedestals::Range detPedestalRange = pedestalHandle->getRange(detID);
   SiStripBadStrip::Range detBadStripRange = deadChannelHandle->getRange(detID);
-  numStrips = (det->specificTopology()).nstrips();  
-  
+  numStrips = (det->specificTopology()).nstrips();
+
   //stroing the bad stip of the the module. the module is not removed but just signal put to 0
   std::vector<bool> badChannels;
   badChannels.clear();
-  badChannels.insert(badChannels.begin(),numStrips,false);
+  badChannels.insert(badChannels.begin(), numStrips, false);
   SiStripBadStrip::data fs;
-  for(SiStripBadStrip::ContainerIterator it=detBadStripRange.first;it!=detBadStripRange.second;++it){
-  	fs=deadChannelHandle->decode(*it);
-    for(int strip = fs.firstStrip; strip <fs.firstStrip+fs.range; ++strip )badChannels[strip] = true;
+  for (SiStripBadStrip::ContainerIterator it = detBadStripRange.first; it != detBadStripRange.second; ++it) {
+    fs = deadChannelHandle->decode(*it);
+    for (int strip = fs.firstStrip; strip < fs.firstStrip + fs.range; ++strip)
+      badChannels[strip] = true;
   }
 
-     
   // local amplitude of detector channels (from processed PSimHit)
-//  locAmpl.clear();
+  //  locAmpl.clear();
   detAmpl.clear();
-//  locAmpl.insert(locAmpl.begin(),numStrips,0.);
+  //  locAmpl.insert(locAmpl.begin(),numStrips,0.);
   // total amplitude of detector channels
-  detAmpl.insert(detAmpl.begin(),numStrips,0.);
+  detAmpl.insert(detAmpl.begin(), numStrips, 0.);
 
   firstChannelWithSignal = numStrips;
-  lastChannelWithSignal  = 0;
+  lastChannelWithSignal = 0;
 
   // First: loop on the SimHits
-  std::vector<std::pair<const PSimHit*, int > >::const_iterator simHitIter = input.begin();
-  std::vector<std::pair<const PSimHit*, int > >::const_iterator simHitIterEnd = input.end();
-  if(CLHEP::RandFlat::shoot(engine) > inefficiency) {
-    for (;simHitIter != simHitIterEnd; ++simHitIter) {
+  std::vector<std::pair<const PSimHit*, int> >::const_iterator simHitIter = input.begin();
+  std::vector<std::pair<const PSimHit*, int> >::const_iterator simHitIterEnd = input.end();
+  if (CLHEP::RandFlat::shoot(engine) > inefficiency) {
+    for (; simHitIter != simHitIterEnd; ++simHitIter) {
       locAmpl.clear();
-      locAmpl.insert(locAmpl.begin(),numStrips,0.);
+      locAmpl.insert(locAmpl.begin(), numStrips, 0.);
       // check TOF
-      if ( std::fabs( ((*simHitIter).first)->tof() - cosmicShift - det->surface().toGlobal(((*simHitIter).first)->localPosition()).mag()/30.) < tofCut && ((*simHitIter).first)->energyLoss()>0) {
+      if (std::fabs(((*simHitIter).first)->tof() - cosmicShift -
+                    det->surface().toGlobal(((*simHitIter).first)->localPosition()).mag() / 30.) < tofCut &&
+          ((*simHitIter).first)->energyLoss() > 0) {
         localFirstChannel = numStrips;
-        localLastChannel  = 0;
+        localLastChannel = 0;
         // process the hit
-        theSiHitDigitizer->processHit(((*simHitIter).first),*det,bfield,langle, locAmpl, localFirstChannel, localLastChannel, tTopo, engine);
-          
-		  //APV Killer to simulate HIP effect
-		  //------------------------------------------------------
-		  
-		  if(APVSaturationFromHIP&&!zeroSuppression){
-		    int pdg_id = ((*simHitIter).first)->particleType();
-			particle = pdt->particle(pdg_id);
-			if(particle != nullptr){
-				float charge = particle->charge();
-				bool isHadron = particle->isHadron();
-			    if(charge!=0 && isHadron){
-					if(CLHEP::RandFlat::shoot(engine) < APVSaturationProb){
-			 	   	 	int FirstAPV = localFirstChannel/128;
-				 		int LastAPV = localLastChannel/128;
-						std::cout << "-------------------HIP--------------" << std::endl;
-						std::cout << "Killing APVs " << FirstAPV << " - " <<LastAPV << " " << detID <<std::endl;
-				 		for(int strip = FirstAPV*128; strip < LastAPV*128 +128; ++strip) badChannels[strip] = true; //doing like that I remove the signal information only after the 
-																													//stip that got the HIP but it remains the signal of the previous
-																													//one. I'll make a further loop to remove all signal																										
-						
-			  		}
-				}
-			}
-	      }             
-		
-		
-		theDigiSimLinkPileUpSignals->add(locAmpl, localFirstChannel, localLastChannel, ((*simHitIter).first), (*simHitIter).second);
-    
-		// sum signal on strips
-        for (size_t iChannel=localFirstChannel; iChannel<localLastChannel; iChannel++) {
-          if(locAmpl[iChannel]>0.) {
-		    //if(!badChannels[iChannel]) detAmpl[iChannel]+=locAmpl[iChannel];
-			//locAmpl[iChannel]=0;
-			detAmpl[iChannel]+=locAmpl[iChannel];
-           }
+        theSiHitDigitizer->processHit(
+            ((*simHitIter).first), *det, bfield, langle, locAmpl, localFirstChannel, localLastChannel, tTopo, engine);
+
+        //APV Killer to simulate HIP effect
+        //------------------------------------------------------
+
+        if (APVSaturationFromHIP && !zeroSuppression) {
+          int pdg_id = ((*simHitIter).first)->particleType();
+          particle = pdt->particle(pdg_id);
+          if (particle != nullptr) {
+            float charge = particle->charge();
+            bool isHadron = particle->isHadron();
+            if (charge != 0 && isHadron) {
+              if (CLHEP::RandFlat::shoot(engine) < APVSaturationProb) {
+                int FirstAPV = localFirstChannel / 128;
+                int LastAPV = localLastChannel / 128;
+                std::cout << "-------------------HIP--------------" << std::endl;
+                std::cout << "Killing APVs " << FirstAPV << " - " << LastAPV << " " << detID << std::endl;
+                for (int strip = FirstAPV * 128; strip < LastAPV * 128 + 128; ++strip)
+                  badChannels[strip] = true;  //doing like that I remove the signal information only after the
+                                              //stip that got the HIP but it remains the signal of the previous
+                                              //one. I'll make a further loop to remove all signal
+              }
+            }
+          }
         }
-        if(firstChannelWithSignal>localFirstChannel) firstChannelWithSignal=localFirstChannel;
-        if(lastChannelWithSignal<localLastChannel) lastChannelWithSignal=localLastChannel;
+
+        theDigiSimLinkPileUpSignals->add(
+            locAmpl, localFirstChannel, localLastChannel, ((*simHitIter).first), (*simHitIter).second);
+
+        // sum signal on strips
+        for (size_t iChannel = localFirstChannel; iChannel < localLastChannel; iChannel++) {
+          if (locAmpl[iChannel] > 0.) {
+            //if(!badChannels[iChannel]) detAmpl[iChannel]+=locAmpl[iChannel];
+            //locAmpl[iChannel]=0;
+            detAmpl[iChannel] += locAmpl[iChannel];
+          }
+        }
+        if (firstChannelWithSignal > localFirstChannel)
+          firstChannelWithSignal = localFirstChannel;
+        if (lastChannelWithSignal < localLastChannel)
+          lastChannelWithSignal = localLastChannel;
       }
-	}
+    }
   }
-  
+
   //removing signal from the dead (and HIP effected) strips
-  for(int strip =0; strip < numStrips; ++strip) if(badChannels[strip]) detAmpl[strip] =0;
-  
-  const DigiSimLinkPileUpSignals::HitToDigisMapType& theLink(theDigiSimLinkPileUpSignals->dumpLink());  
-  const DigiSimLinkPileUpSignals::HitCounterToDigisMapType& theCounterLink(theDigiSimLinkPileUpSignals->dumpCounterLink());  
-  
-  if(zeroSuppression){
-    if(noise){
-	  int RefStrip = int(numStrips/2.);
-	  while(RefStrip<numStrips&&badChannels[RefStrip]){ //if the refstrip is bad, I move up to when I don't find it
-	  	RefStrip++;
-	  }
-	  if(RefStrip<numStrips){
-	 	float noiseRMS = noiseHandle->getNoise(RefStrip,detNoiseRange);
-		float gainValue = gainHandle->getStripGain(RefStrip, detGainRange);
-		theSiNoiseAdder->addNoise(detAmpl,firstChannelWithSignal,lastChannelWithSignal,numStrips,noiseRMS*theElectronPerADC/gainValue, engine);
-	  }
-	}
+  for (int strip = 0; strip < numStrips; ++strip)
+    if (badChannels[strip])
+      detAmpl[strip] = 0;
+
+  const DigiSimLinkPileUpSignals::HitToDigisMapType& theLink(theDigiSimLinkPileUpSignals->dumpLink());
+  const DigiSimLinkPileUpSignals::HitCounterToDigisMapType& theCounterLink(
+      theDigiSimLinkPileUpSignals->dumpCounterLink());
+
+  if (zeroSuppression) {
+    if (noise) {
+      int RefStrip = int(numStrips / 2.);
+      while (RefStrip < numStrips &&
+             badChannels[RefStrip]) {  //if the refstrip is bad, I move up to when I don't find it
+        RefStrip++;
+      }
+      if (RefStrip < numStrips) {
+        float noiseRMS = noiseHandle->getNoise(RefStrip, detNoiseRange);
+        float gainValue = gainHandle->getStripGain(RefStrip, detGainRange);
+        theSiNoiseAdder->addNoise(detAmpl,
+                                  firstChannelWithSignal,
+                                  lastChannelWithSignal,
+                                  numStrips,
+                                  noiseRMS * theElectronPerADC / gainValue,
+                                  engine);
+      }
+    }
     digis.clear();
-    theSiZeroSuppress->suppress(theSiDigitalConverter->convert(detAmpl, gainHandle, detID), digis, detID,noiseHandle,thresholdHandle);
-    push_link(digis, theLink, theCounterLink, detAmpl,detID);
+    theSiZeroSuppress->suppress(
+        theSiDigitalConverter->convert(detAmpl, gainHandle, detID), digis, detID, noiseHandle, thresholdHandle);
+    push_link(digis, theLink, theCounterLink, detAmpl, detID);
     outdigi.data = digis;
   }
-  
-  
-  if(!zeroSuppression){
+
+  if (!zeroSuppression) {
     //if(noise){
-      // the constant pedestal offset is needed because
-      //   negative adc counts are not allowed in case
-      //   Pedestal and CMN subtraction is performed.
-      //   The pedestal value read from the conditions
-      //   is pedValue and after the pedestal subtraction
-      //   the baseline is zero. The Common Mode Noise
-      //   is not subtracted from the negative adc counts
-      //   channels. Adding pedOffset the baseline is set
-      //   to pedOffset after pedestal subtraction and CMN
-      //   is subtracted to all the channels since none of
-      //   them has negative adc value. The pedOffset is
-      //   treated as a constant component in the CMN
-      //   estimation and subtracted as CMN.
-      
-         
-		//calculating the charge deposited on each APV and subtracting the shift
-		//------------------------------------------------------
-		if(BaselineShift){
-		   theSiNoiseAdder->addBaselineShift(detAmpl, badChannels);
-		}
-		
-		//Adding the strip noise
-		//------------------------------------------------------						 
-		if(noise){
-		    std::vector<float> noiseRMSv;
-			noiseRMSv.clear();
-		    noiseRMSv.insert(noiseRMSv.begin(),numStrips,0.);
-			
-		    if(SingleStripNoise){
-			    for(int strip=0; strip< numStrips; ++strip){
-			  		if(!badChannels[strip]) noiseRMSv[strip] = (noiseHandle->getNoise(strip,detNoiseRange))* theElectronPerADC;
-			  	}
-			
-	    	} else {
-			    int RefStrip = 0; //int(numStrips/2.);
-		    	    while(RefStrip<numStrips&&badChannels[RefStrip]){ //if the refstrip is bad, I move up to when I don't find it
-					RefStrip++;
-				}
-				if(RefStrip<numStrips){
-					float noiseRMS = noiseHandle->getNoise(RefStrip,detNoiseRange) *theElectronPerADC;
-					for(int strip=0; strip< numStrips; ++strip){
-			       		if(!badChannels[strip]) noiseRMSv[strip] = noiseRMS;
-			  		}
-				}
-			}
-			
-                    theSiNoiseAdder->addNoiseVR(detAmpl, noiseRMSv, engine);
-		}			
-		
-		//adding the CMN
-		//------------------------------------------------------
-        if(CommonModeNoise){
-		  float cmnRMS = 0.;
-		  DetId  detId(detID);
-		  uint32_t SubDet = detId.subdetId();
-		  if(SubDet==3){
-		    cmnRMS = cmnRMStib;
-		  }else if(SubDet==4){
-		    cmnRMS = cmnRMStid;
-		  }else if(SubDet==5){
-		    cmnRMS = cmnRMStob;
-		  }else if(SubDet==6){
-		    cmnRMS = cmnRMStec;
-		  }
-		  cmnRMS *= theElectronPerADC;
-                  theSiNoiseAdder->addCMNoise(detAmpl, cmnRMS, badChannels, engine);
-		}
-		
-        		
-		//Adding the pedestals
-		//------------------------------------------------------
-		
-		std::vector<float> vPeds;
-		vPeds.clear();
-		vPeds.insert(vPeds.begin(),numStrips,0.);
-		
-		if(RealPedestals){
-		    for(int strip=0; strip< numStrips; ++strip){
-			   if(!badChannels[strip]) vPeds[strip] = (pedestalHandle->getPed(strip,detPedestalRange)+pedOffset)* theElectronPerADC;
-		    }
-        } else {
-		    for(int strip=0; strip< numStrips; ++strip){
-			  if(!badChannels[strip]) vPeds[strip] = pedOffset* theElectronPerADC;
-			}
-		}
-		
-		theSiNoiseAdder->addPedestals(detAmpl, vPeds);	
-		
-		 
-	//if(!RealPedestals&&!CommonModeNoise&&!noise&&!BaselineShift&&!APVSaturationFromHIP){
+    // the constant pedestal offset is needed because
+    //   negative adc counts are not allowed in case
+    //   Pedestal and CMN subtraction is performed.
+    //   The pedestal value read from the conditions
+    //   is pedValue and after the pedestal subtraction
+    //   the baseline is zero. The Common Mode Noise
+    //   is not subtracted from the negative adc counts
+    //   channels. Adding pedOffset the baseline is set
+    //   to pedOffset after pedestal subtraction and CMN
+    //   is subtracted to all the channels since none of
+    //   them has negative adc value. The pedOffset is
+    //   treated as a constant component in the CMN
+    //   estimation and subtracted as CMN.
+
+    //calculating the charge deposited on each APV and subtracting the shift
+    //------------------------------------------------------
+    if (BaselineShift) {
+      theSiNoiseAdder->addBaselineShift(detAmpl, badChannels);
+    }
+
+    //Adding the strip noise
+    //------------------------------------------------------
+    if (noise) {
+      std::vector<float> noiseRMSv;
+      noiseRMSv.clear();
+      noiseRMSv.insert(noiseRMSv.begin(), numStrips, 0.);
+
+      if (SingleStripNoise) {
+        for (int strip = 0; strip < numStrips; ++strip) {
+          if (!badChannels[strip])
+            noiseRMSv[strip] = (noiseHandle->getNoise(strip, detNoiseRange)) * theElectronPerADC;
+        }
+
+      } else {
+        int RefStrip = 0;  //int(numStrips/2.);
+        while (RefStrip < numStrips &&
+               badChannels[RefStrip]) {  //if the refstrip is bad, I move up to when I don't find it
+          RefStrip++;
+        }
+        if (RefStrip < numStrips) {
+          float noiseRMS = noiseHandle->getNoise(RefStrip, detNoiseRange) * theElectronPerADC;
+          for (int strip = 0; strip < numStrips; ++strip) {
+            if (!badChannels[strip])
+              noiseRMSv[strip] = noiseRMS;
+          }
+        }
+      }
+
+      theSiNoiseAdder->addNoiseVR(detAmpl, noiseRMSv, engine);
+    }
+
+    //adding the CMN
+    //------------------------------------------------------
+    if (CommonModeNoise) {
+      float cmnRMS = 0.;
+      DetId detId(detID);
+      uint32_t SubDet = detId.subdetId();
+      if (SubDet == 3) {
+        cmnRMS = cmnRMStib;
+      } else if (SubDet == 4) {
+        cmnRMS = cmnRMStid;
+      } else if (SubDet == 5) {
+        cmnRMS = cmnRMStob;
+      } else if (SubDet == 6) {
+        cmnRMS = cmnRMStec;
+      }
+      cmnRMS *= theElectronPerADC;
+      theSiNoiseAdder->addCMNoise(detAmpl, cmnRMS, badChannels, engine);
+    }
+
+    //Adding the pedestals
+    //------------------------------------------------------
+
+    std::vector<float> vPeds;
+    vPeds.clear();
+    vPeds.insert(vPeds.begin(), numStrips, 0.);
+
+    if (RealPedestals) {
+      for (int strip = 0; strip < numStrips; ++strip) {
+        if (!badChannels[strip])
+          vPeds[strip] = (pedestalHandle->getPed(strip, detPedestalRange) + pedOffset) * theElectronPerADC;
+      }
+    } else {
+      for (int strip = 0; strip < numStrips; ++strip) {
+        if (!badChannels[strip])
+          vPeds[strip] = pedOffset * theElectronPerADC;
+      }
+    }
+
+    theSiNoiseAdder->addPedestals(detAmpl, vPeds);
+
+    //if(!RealPedestals&&!CommonModeNoise&&!noise&&!BaselineShift&&!APVSaturationFromHIP){
     //  edm::LogWarning("DigiSimLinkAlgorithm")<<"You are running the digitizer without Noise generation and without applying Zero Suppression. ARE YOU SURE???";
-    //}else{							 
-    
-	rawdigis.clear();
+    //}else{
+
+    rawdigis.clear();
     rawdigis = theSiDigitalConverter->convertRaw(detAmpl, gainHandle, detID);
-    push_link_raw(rawdigis, theLink, theCounterLink, detAmpl,detID);
+    push_link_raw(rawdigis, theLink, theCounterLink, detAmpl, detID);
     outrawdigi.data = rawdigis;
-	
-	//}
+
+    //}
   }
 }
 
-void DigiSimLinkAlgorithm::push_link(const DigitalVecType &digis,
-					  const HitToDigisMapType& htd,
-					  const HitCounterToDigisMapType& hctd,
-					  const std::vector<float>& afterNoise,
-					  unsigned int detID) {
-  link_coll.clear();  
-  for ( DigitalVecType::const_iterator i=digis.begin(); i!=digis.end(); i++) {
+void DigiSimLinkAlgorithm::push_link(const DigitalVecType& digis,
+                                     const HitToDigisMapType& htd,
+                                     const HitCounterToDigisMapType& hctd,
+                                     const std::vector<float>& afterNoise,
+                                     unsigned int detID) {
+  link_coll.clear();
+  for (DigitalVecType::const_iterator i = digis.begin(); i != digis.end(); i++) {
     // Instead of checking the validity of the links against the digis,
     //  let's loop over digis and push the corresponding link
-    HitToDigisMapType::const_iterator mi(htd.find(i->strip()));  
-    if (mi == htd.end()) continue;
-    HitCounterToDigisMapType::const_iterator cmi(hctd.find(i->strip()));  
-    std::map<const PSimHit *, Amplitude> totalAmplitudePerSimHit;
-    for (std::vector < std::pair < const PSimHit*, Amplitude > >::const_iterator simul = 
-	   (*mi).second.begin() ; simul != (*mi).second.end(); simul ++){
+    HitToDigisMapType::const_iterator mi(htd.find(i->strip()));
+    if (mi == htd.end())
+      continue;
+    HitCounterToDigisMapType::const_iterator cmi(hctd.find(i->strip()));
+    std::map<const PSimHit*, Amplitude> totalAmplitudePerSimHit;
+    for (std::vector<std::pair<const PSimHit*, Amplitude> >::const_iterator simul = (*mi).second.begin();
+         simul != (*mi).second.end();
+         simul++) {
       totalAmplitudePerSimHit[(*simul).first] += (*simul).second;
     }
-    
+
     //--- include the noise as well
     double totalAmplitude1 = afterNoise[(*mi).first];
-    
+
     //--- digisimlink
-    int sim_counter=0;
-    for (std::map<const PSimHit *, Amplitude>::const_iterator iter = totalAmplitudePerSimHit.begin(); 
-	 iter != totalAmplitudePerSimHit.end(); iter++){
+    int sim_counter = 0;
+    for (std::map<const PSimHit*, Amplitude>::const_iterator iter = totalAmplitudePerSimHit.begin();
+         iter != totalAmplitudePerSimHit.end();
+         iter++) {
       float threshold = 0.;
-      float fraction = (*iter).second/totalAmplitude1;
+      float fraction = (*iter).second / totalAmplitude1;
       if (fraction >= threshold) {
-	// Noise fluctuation could make fraction>1. Unphysical, set it by hand = 1.
-	if(fraction > 1.) fraction = 1.;
-        for (std::vector<std::pair<const PSimHit*, int > >::const_iterator
-               simcount = (*cmi).second.begin() ; simcount != (*cmi).second.end(); ++simcount){
-          if((*iter).first == (*simcount).first) sim_counter = (*simcount).second;
+        // Noise fluctuation could make fraction>1. Unphysical, set it by hand = 1.
+        if (fraction > 1.)
+          fraction = 1.;
+        for (std::vector<std::pair<const PSimHit*, int> >::const_iterator simcount = (*cmi).second.begin();
+             simcount != (*cmi).second.end();
+             ++simcount) {
+          if ((*iter).first == (*simcount).first)
+            sim_counter = (*simcount).second;
         }
-	link_coll.push_back(StripDigiSimLink( (*mi).first, //channel
-					      ((*iter).first)->trackId(), //simhit trackId
-                                              sim_counter, //simhit counter
-					      ((*iter).first)->eventId(), //simhit eventId
-                                              fraction)); //fraction 
+        link_coll.push_back(StripDigiSimLink((*mi).first,                 //channel
+                                             ((*iter).first)->trackId(),  //simhit trackId
+                                             sim_counter,                 //simhit counter
+                                             ((*iter).first)->eventId(),  //simhit eventId
+                                             fraction));                  //fraction
       }
     }
   }
 }
 
-void DigiSimLinkAlgorithm::push_link_raw(const DigitalRawVecType &digis,
-					      const HitToDigisMapType& htd,
-					      const HitCounterToDigisMapType& hctd,
-					      const std::vector<float>& afterNoise,
-					      unsigned int detID) {
-  link_coll.clear();  
+void DigiSimLinkAlgorithm::push_link_raw(const DigitalRawVecType& digis,
+                                         const HitToDigisMapType& htd,
+                                         const HitCounterToDigisMapType& hctd,
+                                         const std::vector<float>& afterNoise,
+                                         unsigned int detID) {
+  link_coll.clear();
   int nstrip = -1;
-  for ( DigitalRawVecType::const_iterator i=digis.begin(); i!=digis.end(); i++) {
+  for (DigitalRawVecType::const_iterator i = digis.begin(); i != digis.end(); i++) {
     nstrip++;
     // Instead of checking the validity of the links against the digis,
     //  let's loop over digis and push the corresponding link
-    HitToDigisMapType::const_iterator mi(htd.find(nstrip));  
-    HitCounterToDigisMapType::const_iterator cmi(hctd.find(nstrip));  
-    if (mi == htd.end()) continue;
-    std::map<const PSimHit *, Amplitude> totalAmplitudePerSimHit;
-    for (std::vector < std::pair < const PSimHit*, Amplitude > >::const_iterator simul = 
-	   (*mi).second.begin() ; simul != (*mi).second.end(); simul ++){
+    HitToDigisMapType::const_iterator mi(htd.find(nstrip));
+    HitCounterToDigisMapType::const_iterator cmi(hctd.find(nstrip));
+    if (mi == htd.end())
+      continue;
+    std::map<const PSimHit*, Amplitude> totalAmplitudePerSimHit;
+    for (std::vector<std::pair<const PSimHit*, Amplitude> >::const_iterator simul = (*mi).second.begin();
+         simul != (*mi).second.end();
+         simul++) {
       totalAmplitudePerSimHit[(*simul).first] += (*simul).second;
     }
-    
+
     //--- include the noise as well
     double totalAmplitude1 = afterNoise[(*mi).first];
-    
+
     //--- digisimlink
-    int sim_counter_raw=0;
-    for (std::map<const PSimHit *, Amplitude>::const_iterator iter = totalAmplitudePerSimHit.begin(); 
-	 iter != totalAmplitudePerSimHit.end(); iter++){
+    int sim_counter_raw = 0;
+    for (std::map<const PSimHit*, Amplitude>::const_iterator iter = totalAmplitudePerSimHit.begin();
+         iter != totalAmplitudePerSimHit.end();
+         iter++) {
       float threshold = 0.;
-      float fraction = (*iter).second/totalAmplitude1;
+      float fraction = (*iter).second / totalAmplitude1;
       if (fraction >= threshold) {
-	//Noise fluctuation could make fraction>1. Unphysical, set it by hand.
-	if(fraction >1.) fraction = 1.;
+        //Noise fluctuation could make fraction>1. Unphysical, set it by hand.
+        if (fraction > 1.)
+          fraction = 1.;
         //add counter information
-        for (std::vector<std::pair<const PSimHit*, int > >::const_iterator
-               simcount = (*cmi).second.begin() ; simcount != (*cmi).second.end(); ++simcount){
-          if((*iter).first == (*simcount).first) sim_counter_raw = (*simcount).second;
+        for (std::vector<std::pair<const PSimHit*, int> >::const_iterator simcount = (*cmi).second.begin();
+             simcount != (*cmi).second.end();
+             ++simcount) {
+          if ((*iter).first == (*simcount).first)
+            sim_counter_raw = (*simcount).second;
         }
-	link_coll.push_back(StripDigiSimLink( (*mi).first, //channel
-					      ((*iter).first)->trackId(), //simhit trackId
-                                              sim_counter_raw, //simhit counter
-					      ((*iter).first)->eventId(), //simhit eventId
-                                              fraction)); //fraction
+        link_coll.push_back(StripDigiSimLink((*mi).first,                 //channel
+                                             ((*iter).first)->trackId(),  //simhit trackId
+                                             sim_counter_raw,             //simhit counter
+                                             ((*iter).first)->eventId(),  //simhit eventId
+                                             fraction));                  //fraction
       }
     }
   }

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.h
@@ -39,39 +39,45 @@ namespace CLHEP {
 class TrackerTopolgoy;
 
 class DigiSimLinkAlgorithm {
- public:
+public:
   typedef SiDigitalConverter::DigitalVecType DigitalVecType;
   typedef SiDigitalConverter::DigitalRawVecType DigitalRawVecType;
   typedef DigiSimLinkPileUpSignals::HitToDigisMapType HitToDigisMapType;
   typedef DigiSimLinkPileUpSignals::HitCounterToDigisMapType HitCounterToDigisMapType;
-  typedef std::map< int, float, std::less<int> > hit_map_type;
+  typedef std::map<int, float, std::less<int> > hit_map_type;
   typedef float Amplitude;
-  
+
   // Constructor
-  DigiSimLinkAlgorithm(const edm::ParameterSet& conf);
+  DigiSimLinkAlgorithm(const edm::ParameterSet &conf);
 
   // Destructor
   ~DigiSimLinkAlgorithm();
 
   // Runs the algorithm
-  void  run(edm::DetSet<SiStripDigi>&, edm::DetSet<SiStripRawDigi>&,
-            const std::vector<std::pair<const PSimHit*, int > >  &, 
-            StripGeomDetUnit const *, GlobalVector, float, 
-            edm::ESHandle<SiStripGain> &, edm::ESHandle<SiStripThreshold> &, 
-            edm::ESHandle<SiStripNoises> &, edm::ESHandle<SiStripPedestals> &, edm::ESHandle<SiStripBadStrip> &,
-	    const TrackerTopology *tTopo,
-            CLHEP::HepRandomEngine*);
+  void run(edm::DetSet<SiStripDigi> &,
+           edm::DetSet<SiStripRawDigi> &,
+           const std::vector<std::pair<const PSimHit *, int> > &,
+           StripGeomDetUnit const *,
+           GlobalVector,
+           float,
+           edm::ESHandle<SiStripGain> &,
+           edm::ESHandle<SiStripThreshold> &,
+           edm::ESHandle<SiStripNoises> &,
+           edm::ESHandle<SiStripPedestals> &,
+           edm::ESHandle<SiStripBadStrip> &,
+           const TrackerTopology *tTopo,
+           CLHEP::HepRandomEngine *);
 
   // digisimlink
   std::vector<StripDigiSimLink> make_link() { return link_coll; }
 
   // ParticleDataTable
-  void setParticleDataTable(const ParticleDataTable * pardt) {
-  	theSiHitDigitizer->setParticleDataTable(pardt); 
-  	pdt= pardt; 
+  void setParticleDataTable(const ParticleDataTable *pardt) {
+    theSiHitDigitizer->setParticleDataTable(pardt);
+    pdt = pardt;
   }
-  
- private:
+
+private:
   edm::ParameterSet conf_;
   double theElectronPerADC;
   double theThreshold;
@@ -79,29 +85,28 @@ class DigiSimLinkAlgorithm {
   double cmnRMStob;
   double cmnRMStid;
   double cmnRMStec;
-  double APVSaturationProb;          
+  double APVSaturationProb;
   bool peakMode;
   bool noise;
-  bool RealPedestals;              
-  bool SingleStripNoise;          
-  bool CommonModeNoise;           
-  bool BaselineShift;             
+  bool RealPedestals;
+  bool SingleStripNoise;
+  bool CommonModeNoise;
+  bool BaselineShift;
   bool APVSaturationFromHIP;
-  
+
   int theFedAlgo;
   bool zeroSuppression;
   double theTOFCutForPeak;
   double theTOFCutForDeconvolution;
   double tofCut;
-  int numStrips; 
-  int strip;     
+  int numStrips;
+  int strip;
   //double noiseRMS;
   //double pedValue;
   double cosmicShift;
   double inefficiency;
   double pedOffset;
   bool PreMixing_;
-
 
   size_t firstChannelWithSignal;
   size_t lastChannelWithSignal;
@@ -113,30 +118,30 @@ class DigiSimLinkAlgorithm {
   // total amplitude of detector channels
   std::vector<float> detAmpl;
 
-  const ParticleDataTable * pdt;
-  const ParticleData * particle;
-  
-  SiHitDigitizer* theSiHitDigitizer;
-  DigiSimLinkPileUpSignals* theDigiSimLinkPileUpSignals;
-  SiGaussianTailNoiseAdder* theSiNoiseAdder;
-  SiTrivialDigitalConverter* theSiDigitalConverter;
-  SiStripFedZeroSuppression* theSiZeroSuppress;
+  const ParticleDataTable *pdt;
+  const ParticleData *particle;
+
+  SiHitDigitizer *theSiHitDigitizer;
+  DigiSimLinkPileUpSignals *theDigiSimLinkPileUpSignals;
+  SiGaussianTailNoiseAdder *theSiNoiseAdder;
+  SiTrivialDigitalConverter *theSiDigitalConverter;
+  SiStripFedZeroSuppression *theSiZeroSuppress;
 
   DigitalVecType digis;
   DigitalRawVecType rawdigis;
   std::vector<StripDigiSimLink> link_coll;
 
-  void push_link(const DigitalVecType&,
-		 const HitToDigisMapType&,
-		 const HitCounterToDigisMapType&,
-		 const std::vector<float>&,
-		 unsigned int);
-  
-  void push_link_raw(const DigitalRawVecType&,
-		     const HitToDigisMapType&,
-		     const HitCounterToDigisMapType&,
-		     const std::vector<float>&,
-		     unsigned int);
+  void push_link(const DigitalVecType &,
+                 const HitToDigisMapType &,
+                 const HitCounterToDigisMapType &,
+                 const std::vector<float> &,
+                 unsigned int);
+
+  void push_link_raw(const DigitalRawVecType &,
+                     const HitToDigisMapType &,
+                     const HitCounterToDigisMapType &,
+                     const std::vector<float> &,
+                     unsigned int);
 };
 
 #endif

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkPileUpSignals.cc
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkPileUpSignals.cc
@@ -1,17 +1,18 @@
 #include "DigiSimLinkPileUpSignals.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
-void DigiSimLinkPileUpSignals::resetLink(){
+void DigiSimLinkPileUpSignals::resetLink() {
   theMapLink.clear();
   theCounterMapLink.clear();
 }
 
 void DigiSimLinkPileUpSignals::add(const std::vector<float>& locAmpl,
-			  const size_t& firstChannelWithSignal, const size_t& lastChannelWithSignal,
-			  const PSimHit* hit,const int& counter){
-  for (size_t iChannel=firstChannelWithSignal; iChannel<lastChannelWithSignal; ++iChannel) {
-    theMapLink[iChannel].push_back(std::pair < const PSimHit*, Amplitude >(hit,Amplitude(locAmpl[iChannel])));
+                                   const size_t& firstChannelWithSignal,
+                                   const size_t& lastChannelWithSignal,
+                                   const PSimHit* hit,
+                                   const int& counter) {
+  for (size_t iChannel = firstChannelWithSignal; iChannel < lastChannelWithSignal; ++iChannel) {
+    theMapLink[iChannel].push_back(std::pair<const PSimHit*, Amplitude>(hit, Amplitude(locAmpl[iChannel])));
     theCounterMapLink[iChannel].push_back(std::make_pair(hit, counter));
   }
 }
-

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkPileUpSignals.h
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkPileUpSignals.h
@@ -10,32 +10,34 @@ class SimHit;
  * Class which takes the responses from each SimHit and piles-up them, within a given module.
  * More precisely, it keeps for each strip the link to each individual measurement.
  */
-class DigiSimLinkPileUpSignals{ 
- public:
+class DigiSimLinkPileUpSignals {
+public:
   // type used to describe the amplitude on a strip
   typedef float Amplitude;
-  // associates to each strip a vector of pairs {simhit,amplitude}. 
+  // associates to each strip a vector of pairs {simhit,amplitude}.
   // That allows later to comput the fraction of the contribution of each simhit to the ADC value
-  typedef std::map< int , std::vector < std::pair < const PSimHit*, Amplitude > >, std::less<int> >  HitToDigisMapType;
+  typedef std::map<int, std::vector<std::pair<const PSimHit*, Amplitude> >, std::less<int> > HitToDigisMapType;
   // associates to each strip a vector of pairs {simhit,index_in_the_allhit_collection}
   // That allows to build the links properly
-  typedef std::map< int , std::vector < std::pair < const PSimHit*, int > >, std::less<int> >  HitCounterToDigisMapType;
-  
+  typedef std::map<int, std::vector<std::pair<const PSimHit*, int> >, std::less<int> > HitCounterToDigisMapType;
+
   DigiSimLinkPileUpSignals() { reset(); }
 
-  virtual ~DigiSimLinkPileUpSignals() { }
-  
+  virtual ~DigiSimLinkPileUpSignals() {}
+
   virtual void add(const std::vector<float>& locAmpl,
-		   const size_t& firstChannelWithSignal, const size_t& lastChannelWithSignal,
-		   const PSimHit* hit,const int& counter);
-		   
-  void reset(){ resetLink(); }
-  
+                   const size_t& firstChannelWithSignal,
+                   const size_t& lastChannelWithSignal,
+                   const PSimHit* hit,
+                   const int& counter);
+
+  void reset() { resetLink(); }
+
   const HitToDigisMapType& dumpLink() const { return theMapLink; }
-  
+
   const HitCounterToDigisMapType& dumpCounterLink() const { return theCounterMapLink; }
-  
- private:
+
+private:
   void resetLink();
   HitToDigisMapType theMapLink;
   HitCounterToDigisMapType theCounterMapLink;

--- a/SimTracker/SiStripDigitizer/plugins/EnergyDepositUnit.h
+++ b/SimTracker/SiStripDigitizer/plugins/EnergyDepositUnit.h
@@ -7,21 +7,19 @@
  * Class which allows to "follow" an elementary charge in the silicon.
  * It basically defines a quantum of energy in the bulk, with a 3D position.
  */
-class EnergyDepositUnit{
- public:
-  EnergyDepositUnit(): _energy(0),_position(0,0,0){}
-  EnergyDepositUnit(float energy,float x, float y, float z):
-    _energy(energy),_position(x,y,z){}
-  EnergyDepositUnit(float energy, const Local3DPoint& position):
-    _energy(energy),_position(position){}
-  float x() const{return _position.x();}
-  float y() const{return _position.y();}
-  float z() const{return _position.z();}
-  float energy() const { return _energy;}
- private:
-  float _energy;
-  Local3DPoint _position;  
-};
+class EnergyDepositUnit {
+public:
+  EnergyDepositUnit() : _energy(0), _position(0, 0, 0) {}
+  EnergyDepositUnit(float energy, float x, float y, float z) : _energy(energy), _position(x, y, z) {}
+  EnergyDepositUnit(float energy, const Local3DPoint& position) : _energy(energy), _position(position) {}
+  float x() const { return _position.x(); }
+  float y() const { return _position.y(); }
+  float z() const { return _position.z(); }
+  float energy() const { return _energy; }
 
+private:
+  float _energy;
+  Local3DPoint _position;
+};
 
 #endif

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -39,38 +39,37 @@
 #include <map>
 #include <memory>
 
-class PreMixingSiStripWorker: public PreMixingWorker {
+class PreMixingSiStripWorker : public PreMixingWorker {
 public:
-  PreMixingSiStripWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector && iC);
+  PreMixingSiStripWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector&& iC);
   ~PreMixingSiStripWorker() override = default;
 
   void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
   void addSignals(edm::Event const& e, edm::EventSetup const& es) override;
   void addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& es) override;
-  void put(edm::Event &e, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bs) override;
+  void put(edm::Event& e, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bs) override;
 
 private:
-  void DMinitializeDetUnit(StripGeomDetUnit const * det, const edm::EventSetup& iSetup );
+  void DMinitializeDetUnit(StripGeomDetUnit const* det, const edm::EventSetup& iSetup);
 
   // data specifiers
 
-  edm::InputTag SistripLabelSig_ ;        // name given to collection of SiStrip digis
-  edm::InputTag SiStripPileInputTag_ ;    // InputTag for pileup strips
-  std::string SiStripDigiCollectionDM_  ; // secondary name to be given to new SiStrip digis
+  edm::InputTag SistripLabelSig_;        // name given to collection of SiStrip digis
+  edm::InputTag SiStripPileInputTag_;    // InputTag for pileup strips
+  std::string SiStripDigiCollectionDM_;  // secondary name to be given to new SiStrip digis
 
-  edm::InputTag SistripAPVLabelSig_;      // where to find vector of dead APVs
+  edm::InputTag SistripAPVLabelSig_;  // where to find vector of dead APVs
   edm::InputTag SiStripAPVPileInputTag_;
-  std::string SistripAPVListDM_;          // output tag
+  std::string SistripAPVListDM_;  // output tag
 
-
-  // 
+  //
 
   typedef float Amplitude;
   typedef std::pair<uint16_t, Amplitude> RawDigi;  // Replacement for SiStripDigi with pulse height instead of integer ADC
-  typedef std::vector<SiStripDigi> OneDetectorMap;   // maps by strip ID for later combination - can have duplicate strips
-  typedef std::vector<RawDigi> OneDetectorRawMap;   // maps by strip ID for later combination - can have duplicate strips
-  typedef std::map<uint32_t, OneDetectorMap> SiGlobalIndex; // map to all data for each detector ID
-  typedef std::map<uint32_t, OneDetectorRawMap> SiGlobalRawIndex; // map to all data for each detector ID
+  typedef std::vector<SiStripDigi> OneDetectorMap;  // maps by strip ID for later combination - can have duplicate strips
+  typedef std::vector<RawDigi> OneDetectorRawMap;  // maps by strip ID for later combination - can have duplicate strips
+  typedef std::map<uint32_t, OneDetectorMap> SiGlobalIndex;        // map to all data for each detector ID
+  typedef std::map<uint32_t, OneDetectorRawMap> SiGlobalRawIndex;  // map to all data for each detector ID
 
   typedef SiDigitalConverter::DigitalVecType DigitalVecType;
 
@@ -78,12 +77,12 @@ private:
   SiGlobalRawIndex SiRawDigis_;
 
   // variables for temporary storage of mixed hits:
-  typedef std::map<int, Amplitude>  SignalMapType;
-  typedef std::map<uint32_t, SignalMapType>  signalMaps;
+  typedef std::map<int, Amplitude> SignalMapType;
+  typedef std::map<uint32_t, SignalMapType> signalMaps;
 
   const SignalMapType* getSignal(uint32_t detID) const {
     auto where = signals_.find(detID);
-    if(where == signals_.end()) {
+    if (where == signals_.end()) {
       return nullptr;
     }
     return &where->second;
@@ -92,7 +91,7 @@ private:
   signalMaps signals_;
 
   // to keep track of dead APVs from HIP interactions
-  typedef std::multimap< uint32_t, std::bitset<6> > APVMap;
+  typedef std::multimap<uint32_t, std::bitset<6>> APVMap;
 
   APVMap theAffectedAPVmap_;
 
@@ -114,84 +113,81 @@ private:
   edm::ESHandle<TrackerGeometry> pDD;
 
   // bad channels for each detector ID
-  std::map<unsigned int, std::vector<bool> > allBadChannels;
+  std::map<unsigned int, std::vector<bool>> allBadChannels;
   // channels killed by HIP interactions for each detector ID
-  std::map<unsigned int, std::vector<bool> > allHIPChannels;
+  std::map<unsigned int, std::vector<bool>> allHIPChannels;
   // first and last channel wit signal for each detector ID
   std::map<unsigned int, size_t> firstChannelsWithSignal;
   std::map<unsigned int, size_t> lastChannelsWithSignal;
 
   //----------------------------
 
-  class StrictWeakOrdering{
+  class StrictWeakOrdering {
   public:
-    bool operator() (SiStripDigi i,SiStripDigi j) const {return i.strip() < j.strip();}
+    bool operator()(SiStripDigi i, SiStripDigi j) const { return i.strip() < j.strip(); }
   };
 
-  class StrictWeakRawOrdering{
+  class StrictWeakRawOrdering {
   public:
-    bool operator() (RawDigi i,RawDigi j) const {return i.first < j.first;}
+    bool operator()(RawDigi i, RawDigi j) const { return i.first < j.first; }
   };
-
 };
 
-PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps, edm::ProducerBase& producer, edm::ConsumesCollector && iC): 
-  gainLabel(ps.getParameter<std::string>("Gain")),
-  SingleStripNoise(ps.getParameter<bool>("SingleStripNoise")),
-  peakMode(ps.getParameter<bool>("APVpeakmode")),
-  theThreshold(ps.getParameter<double>("NoiseSigmaThreshold")),
-  theElectronPerADC(ps.getParameter<double>( peakMode ? "electronPerAdcPeak" : "electronPerAdcDec" )),
-  APVSaturationFromHIP_(ps.getParameter<bool>("APVSaturationFromHIP")),
-  theFedAlgo(ps.getParameter<int>("FedAlgorithm_PM")),
-  geometryType(ps.getParameter<std::string>("GeometryType")),
-  theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
-  theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, false)) // no premixing
+PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
+                                               edm::ProducerBase& producer,
+                                               edm::ConsumesCollector&& iC)
+    : gainLabel(ps.getParameter<std::string>("Gain")),
+      SingleStripNoise(ps.getParameter<bool>("SingleStripNoise")),
+      peakMode(ps.getParameter<bool>("APVpeakmode")),
+      theThreshold(ps.getParameter<double>("NoiseSigmaThreshold")),
+      theElectronPerADC(ps.getParameter<double>(peakMode ? "electronPerAdcPeak" : "electronPerAdcDec")),
+      APVSaturationFromHIP_(ps.getParameter<bool>("APVSaturationFromHIP")),
+      theFedAlgo(ps.getParameter<int>("FedAlgorithm_PM")),
+      geometryType(ps.getParameter<std::string>("GeometryType")),
+      theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
+      theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, false))  // no premixing
 
-{                                                         
+{
   // declare the products to produce
 
-  SistripLabelSig_   = ps.getParameter<edm::InputTag>("SistripLabelSig");
+  SistripLabelSig_ = ps.getParameter<edm::InputTag>("SistripLabelSig");
   SiStripPileInputTag_ = ps.getParameter<edm::InputTag>("SiStripPileInputTag");
 
-  SiStripDigiCollectionDM_  = ps.getParameter<std::string>("SiStripDigiCollectionDM");
-  SistripAPVListDM_= ps.getParameter<std::string>("SiStripAPVListDM");
+  SiStripDigiCollectionDM_ = ps.getParameter<std::string>("SiStripDigiCollectionDM");
+  SistripAPVListDM_ = ps.getParameter<std::string>("SiStripAPVListDM");
 
-  producer.produces< edm::DetSetVector<SiStripDigi> > (SiStripDigiCollectionDM_);
+  producer.produces<edm::DetSetVector<SiStripDigi>>(SiStripDigiCollectionDM_);
 
-  if(APVSaturationFromHIP_) { 
+  if (APVSaturationFromHIP_) {
     SistripAPVLabelSig_ = ps.getParameter<edm::InputTag>("SistripAPVLabelSig");
     SiStripAPVPileInputTag_ = ps.getParameter<edm::InputTag>("SistripAPVPileInputTag");
-    iC.consumes< std::vector<std::pair<int,std::bitset<6>> > >(SistripAPVLabelSig_);
+    iC.consumes<std::vector<std::pair<int, std::bitset<6>>>>(SistripAPVLabelSig_);
   }
   iC.consumes<edm::DetSetVector<SiStripDigi>>(SistripLabelSig_);
-  // clear local storage for this event                                                                     
+  // clear local storage for this event
   SiHitStorage_.clear();
 
   edm::Service<edm::RandomNumberGenerator> rng;
-  if ( ! rng.isAvailable()) {
-    throw cms::Exception("Psiguration")
-      << "SiStripDigitizer requires the RandomNumberGeneratorService\n"
-      "which is not present in the psiguration file.  You must add the service\n"
-      "in the configuration file or remove the modules that require it.";
+  if (!rng.isAvailable()) {
+    throw cms::Exception("Psiguration") << "SiStripDigitizer requires the RandomNumberGeneratorService\n"
+                                           "which is not present in the psiguration file.  You must add the service\n"
+                                           "in the configuration file or remove the modules that require it.";
   }
-  
+
   theSiNoiseAdder.reset(new SiGaussianTailNoiseAdder(theThreshold));
 }
-	       
-void PreMixingSiStripWorker::initializeEvent(const edm::Event &e, edm::EventSetup const& iSetup) {
+
+void PreMixingSiStripWorker::initializeEvent(const edm::Event& e, edm::EventSetup const& iSetup) {
   // initialize individual detectors so we can copy real digitization code:
 
-  iSetup.get<TrackerDigiGeometryRecord>().get(geometryType,pDD);
+  iSetup.get<TrackerDigiGeometryRecord>().get(geometryType, pDD);
 
-  for(auto iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); ++iu) {
+  for (auto iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); ++iu) {
     unsigned int detId = (*iu)->geographicalId().rawId();
-    DetId idet=DetId(detId);
-    unsigned int isub=idet.subdetId();
-    if((isub == StripSubdetector::TIB) ||
-       (isub == StripSubdetector::TID) ||
-       (isub == StripSubdetector::TOB) ||
-       (isub == StripSubdetector::TEC)) {
-
+    DetId idet = DetId(detId);
+    unsigned int isub = idet.subdetId();
+    if ((isub == StripSubdetector::TIB) || (isub == StripSubdetector::TID) || (isub == StripSubdetector::TOB) ||
+        (isub == StripSubdetector::TEC)) {
       auto stripdet = dynamic_cast<StripGeomDetUnit const*>((*iu));
       assert(stripdet != nullptr);
       DMinitializeDetUnit(stripdet, iSetup);
@@ -199,14 +195,12 @@ void PreMixingSiStripWorker::initializeEvent(const edm::Event &e, edm::EventSetu
   }
 }
 
-
-void PreMixingSiStripWorker::DMinitializeDetUnit(StripGeomDetUnit const * det, const edm::EventSetup& iSetup ) { 
-
+void PreMixingSiStripWorker::DMinitializeDetUnit(StripGeomDetUnit const* det, const edm::EventSetup& iSetup) {
   edm::ESHandle<SiStripBadStrip> deadChannelHandle;
   iSetup.get<SiStripBadChannelRcd>().get(deadChannelHandle);
 
   unsigned int detId = det->geographicalId().rawId();
-  int numStrips = (det->specificTopology()).nstrips();  
+  int numStrips = (det->specificTopology()).nstrips();
 
   SiStripBadStrip::Range detBadStripRange = deadChannelHandle->getRange(detId);
   //storing the bad strip of the the module. the module is not removed but just signal put to 0
@@ -217,38 +211,36 @@ void PreMixingSiStripWorker::DMinitializeDetUnit(StripGeomDetUnit const * det, c
   hipChannels.clear();
   hipChannels.insert(hipChannels.begin(), numStrips, false);
 
-  for(SiStripBadStrip::ContainerIterator it = detBadStripRange.first; it != detBadStripRange.second; ++it) {
+  for (SiStripBadStrip::ContainerIterator it = detBadStripRange.first; it != detBadStripRange.second; ++it) {
     SiStripBadStrip::data fs = deadChannelHandle->decode(*it);
-    for(int strip = fs.firstStrip; strip < fs.firstStrip + fs.range; ++strip) badChannels[strip] = true;
+    for (int strip = fs.firstStrip; strip < fs.firstStrip + fs.range; ++strip)
+      badChannels[strip] = true;
   }
   firstChannelsWithSignal[detId] = numStrips;
-  lastChannelsWithSignal[detId]= 0;
+  lastChannelsWithSignal[detId] = 0;
 }
 
-
-void PreMixingSiStripWorker::addSignals(const edm::Event &e, edm::EventSetup const& es) { 
+void PreMixingSiStripWorker::addSignals(const edm::Event& e, edm::EventSetup const& es) {
   // fill in maps of hits
 
-  edm::Handle< edm::DetSetVector<SiStripDigi> >  input;
+  edm::Handle<edm::DetSetVector<SiStripDigi>> input;
 
-  if( e.getByLabel(SistripLabelSig_,input) ) {
+  if (e.getByLabel(SistripLabelSig_, input)) {
     OneDetectorMap LocalMap;
 
     //loop on all detsets (detectorIDs) inside the input collection
-    edm::DetSetVector<SiStripDigi>::const_iterator DSViter=input->begin();
-    for (; DSViter!=input->end();DSViter++){
-
+    edm::DetSetVector<SiStripDigi>::const_iterator DSViter = input->begin();
+    for (; DSViter != input->end(); DSViter++) {
 #ifdef DEBUG
-      LogDebug("PreMixingSiStripWorker")  << "Processing DetID " << DSViter->id;
+      LogDebug("PreMixingSiStripWorker") << "Processing DetID " << DSViter->id;
 #endif
 
       LocalMap.clear();
       LocalMap.reserve((DSViter->data).size());
-      LocalMap.insert(LocalMap.end(),(DSViter->data).begin(),(DSViter->data).end());	
-	
-      SiHitStorage_.insert( SiGlobalIndex::value_type( DSViter->id, LocalMap ) );
+      LocalMap.insert(LocalMap.end(), (DSViter->data).begin(), (DSViter->data).end());
+
+      SiHitStorage_.insert(SiGlobalIndex::value_type(DSViter->id, LocalMap));
     }
- 
   }
 
   // keep here for future reference.  In current implementation, HIP killing is done once in PU file
@@ -264,29 +256,27 @@ void PreMixingSiStripWorker::addSignals(const edm::Event &e, edm::EventSetup con
       }
       } */
 
-} // end of addSiStripSignals
-
-
+}  // end of addSiStripSignals
 
 void PreMixingSiStripWorker::addPileups(PileUpEventPrincipal const& pep, edm::EventSetup const& es) {
-  LogDebug("PreMixingSiStripWorker") <<"\n===============> adding pileups from event  "<<pep.principal().id()<<" for bunchcrossing "<<pep.bunchCrossing();
+  LogDebug("PreMixingSiStripWorker") << "\n===============> adding pileups from event  " << pep.principal().id()
+                                     << " for bunchcrossing " << pep.bunchCrossing();
 
   // fill in maps of hits; same code as addSignals, except now applied to the pileup events
 
   edm::Handle<edm::DetSetVector<SiStripDigi>> inputHandle;
   pep.getByLabel(SiStripPileInputTag_, inputHandle);
 
-  if(inputHandle.isValid()) {
+  if (inputHandle.isValid()) {
     const auto& input = *inputHandle;
 
     OneDetectorMap LocalMap;
 
     //loop on all detsets (detectorIDs) inside the input collection
-    edm::DetSetVector<SiStripDigi>::const_iterator DSViter=input.begin();
-    for (; DSViter!=input.end();DSViter++){
-
+    edm::DetSetVector<SiStripDigi>::const_iterator DSViter = input.begin();
+    for (; DSViter != input.end(); DSViter++) {
 #ifdef DEBUG
-      LogDebug("PreMixingSiStripWorker")  << "Pileups: Processing DetID " << DSViter->id;
+      LogDebug("PreMixingSiStripWorker") << "Pileups: Processing DetID " << DSViter->id;
 #endif
 
       // find correct local map (or new one) for this detector ID
@@ -295,54 +285,52 @@ void PreMixingSiStripWorker::addPileups(PileUpEventPrincipal const& pep, edm::Ev
 
       itest = SiHitStorage_.find(DSViter->id);
 
-      if(itest!=SiHitStorage_.end()) {  // this detID already has hits, add to existing map
+      if (itest != SiHitStorage_.end()) {  // this detID already has hits, add to existing map
 
         LocalMap = itest->second;
 
         // fill in local map with extra channels
-        LocalMap.insert(LocalMap.end(),(DSViter->data).begin(),(DSViter->data).end());
-        std::stable_sort(LocalMap.begin(),LocalMap.end(),PreMixingSiStripWorker::StrictWeakOrdering());
-        SiHitStorage_[DSViter->id]=LocalMap;
-	  
-      }
-      else{ // fill local storage with this information, put in global collection
+        LocalMap.insert(LocalMap.end(), (DSViter->data).begin(), (DSViter->data).end());
+        std::stable_sort(LocalMap.begin(), LocalMap.end(), PreMixingSiStripWorker::StrictWeakOrdering());
+        SiHitStorage_[DSViter->id] = LocalMap;
+
+      } else {  // fill local storage with this information, put in global collection
 
         LocalMap.clear();
         LocalMap.reserve((DSViter->data).size());
-        LocalMap.insert(LocalMap.end(),(DSViter->data).begin(),(DSViter->data).end());
+        LocalMap.insert(LocalMap.end(), (DSViter->data).begin(), (DSViter->data).end());
 
-        SiHitStorage_.insert( SiGlobalIndex::value_type( DSViter->id, LocalMap ) );
+        SiHitStorage_.insert(SiGlobalIndex::value_type(DSViter->id, LocalMap));
       }
     }
 
-    if(APVSaturationFromHIP_) {
-      edm::Handle<std::vector<std::pair<int,std::bitset<6>>>> inputAPVHandle;
+    if (APVSaturationFromHIP_) {
+      edm::Handle<std::vector<std::pair<int, std::bitset<6>>>> inputAPVHandle;
       pep.getByLabel(SiStripAPVPileInputTag_, inputAPVHandle);
 
-      if(inputAPVHandle.isValid()) {
+      if (inputAPVHandle.isValid()) {
+        const auto& APVinput = inputAPVHandle;
 
-        const auto &APVinput = inputAPVHandle;
-
-        std::vector<std::pair<int,std::bitset<6>> >::const_iterator entry = APVinput->begin();
-        for( ; entry != APVinput->end(); entry++) {
-          theAffectedAPVmap_.insert( APVMap::value_type(entry->first, entry->second ));
+        std::vector<std::pair<int, std::bitset<6>>>::const_iterator entry = APVinput->begin();
+        for (; entry != APVinput->end(); entry++) {
+          theAffectedAPVmap_.insert(APVMap::value_type(entry->first, entry->second));
         }
       }
     }
   }
 }
 
-
- 
-void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, std::vector<PileupSummaryInfo> const& ps, int bs) {
-
+void PreMixingSiStripWorker::put(edm::Event& e,
+                                 edm::EventSetup const& iSetup,
+                                 std::vector<PileupSummaryInfo> const& ps,
+                                 int bs) {
   // set up machinery to do proper noise adding:
   edm::ESHandle<SiStripGain> gainHandle;
   edm::ESHandle<SiStripNoises> noiseHandle;
   edm::ESHandle<SiStripThreshold> thresholdHandle;
   edm::ESHandle<SiStripPedestals> pedestalHandle;
   edm::ESHandle<SiStripBadStrip> deadChannelHandle;
-  iSetup.get<SiStripGainSimRcd>().get(gainLabel,gainHandle);
+  iSetup.get<SiStripGainSimRcd>().get(gainLabel, gainHandle);
   iSetup.get<SiStripNoisesRcd>().get(noiseHandle);
   iSetup.get<SiStripThresholdRcd>().get(thresholdHandle);
   iSetup.get<SiStripPedestalsRcd>().get(pedestalHandle);
@@ -350,21 +338,20 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
 
-  std::map< int,std::bitset<6>>  DeadAPVList;
+  std::map<int, std::bitset<6>> DeadAPVList;
   DeadAPVList.clear();
 
-
   // First, have to convert all ADC counts to raw pulse heights so that values can be added properly
-  // In PreMixing, pulse heights are saved with ADC = sqrt(9.0*PulseHeight) - have to undo. 
+  // In PreMixing, pulse heights are saved with ADC = sqrt(9.0*PulseHeight) - have to undo.
 
-  // This is done here because it's the only place we have access to EventSetup 
-  // Simultaneously, merge lists of hit channels in each DetId.                
+  // This is done here because it's the only place we have access to EventSetup
+  // Simultaneously, merge lists of hit channels in each DetId.
   // Signal Digis are in the list first, have to merge lists of hit strips on the fly,
-  // add signals on duplicates later                                                       
+  // add signals on duplicates later
 
   OneDetectorRawMap LocalRawMap;
 
-  // Now, loop over hits and add them to the map in the proper sorted order        
+  // Now, loop over hits and add them to the map in the proper sorted order
   // Note: We are assuming that the hits from the Signal events have been created in
   // "PreMix" mode, rather than in the standard ADC conversion routines.  If not, this
   // doesn't work at all.
@@ -372,11 +359,9 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
   // At the moment, both Signal and Reconstituted PU hits have the same compression algorithm.
   // If this were different, and one needed gains, the conversion back to pulse height can only
   // be done in this routine.  So, yes, there is an extra loop over hits here in the current code,
-  // because, in principle, one could convert to pulse height during the read/store phase.    
+  // because, in principle, one could convert to pulse height during the read/store phase.
 
-  for(SiGlobalIndex::const_iterator IDet = SiHitStorage_.begin();
-      IDet != SiHitStorage_.end(); IDet++) {
-
+  for (SiGlobalIndex::const_iterator IDet = SiHitStorage_.begin(); IDet != SiHitStorage_.end(); IDet++) {
     uint32_t detID = IDet->first;
 
     OneDetectorMap LocalMap = IDet->second;
@@ -385,43 +370,42 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
 
     LocalRawMap.clear();
 
-    OneDetectorMap::const_iterator iLocal  = LocalMap.begin();
-    for(;iLocal != LocalMap.end(); ++iLocal) {
-
+    OneDetectorMap::const_iterator iLocal = LocalMap.begin();
+    for (; iLocal != LocalMap.end(); ++iLocal) {
       uint16_t currentStrip = iLocal->strip();
       float signal = float(iLocal->adc());
-      if(iLocal->adc() == 1022) signal = 1500.;  // average values for overflows
-      if(iLocal->adc() == 1023) signal = 3000.;
+      if (iLocal->adc() == 1022)
+        signal = 1500.;  // average values for overflows
+      if (iLocal->adc() == 1023)
+        signal = 3000.;
 
-      //convert signals back to raw counts 
+      //convert signals back to raw counts
 
-      float ReSignal = signal*signal/9.0;  // The PreMixing conversion is adc = sqrt(9.0*pulseHeight)
+      float ReSignal = signal * signal / 9.0;  // The PreMixing conversion is adc = sqrt(9.0*pulseHeight)
 
-      RawDigi NewRawDigi = std::make_pair(currentStrip,ReSignal);
+      RawDigi NewRawDigi = std::make_pair(currentStrip, ReSignal);
 
       LocalRawMap.push_back(NewRawDigi);
-
     }
 
     // save information for this detiD into global map
-    SiRawDigis_.insert( SiGlobalRawIndex::value_type( detID, LocalRawMap ) );
+    SiRawDigis_.insert(SiGlobalRawIndex::value_type(detID, LocalRawMap));
   }
 
   // If we are killing APVs, merge list of dead ones before we digitize
 
-  int NumberOfBxBetweenHIPandEvent=1e3;
+  int NumberOfBxBetweenHIPandEvent = 1e3;
 
-  if(APVSaturationFromHIP_) { 
-
+  if (APVSaturationFromHIP_) {
     // calculate affected BX parameter
 
-    bool HasAtleastOneAffectedAPV=false;
-    while(!HasAtleastOneAffectedAPV){
-      for(int bx=floor(300.0/25.0);bx>0;bx--){ //Reminder: make these numbers not hard coded!!
-        float temp=CLHEP::RandFlat::shoot(engine)<0.5?1:0;
-        if(temp==1 && bx<NumberOfBxBetweenHIPandEvent){
-          NumberOfBxBetweenHIPandEvent=bx;
-          HasAtleastOneAffectedAPV=true;
+    bool HasAtleastOneAffectedAPV = false;
+    while (!HasAtleastOneAffectedAPV) {
+      for (int bx = floor(300.0 / 25.0); bx > 0; bx--) {  //Reminder: make these numbers not hard coded!!
+        float temp = CLHEP::RandFlat::shoot(engine) < 0.5 ? 1 : 0;
+        if (temp == 1 && bx < NumberOfBxBetweenHIPandEvent) {
+          NumberOfBxBetweenHIPandEvent = bx;
+          HasAtleastOneAffectedAPV = true;
         }
       }
     }
@@ -431,36 +415,32 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
     uint32_t currentID;
     std::bitset<6> NewAPVBits;
 
-    for(APVMap::const_iterator iAPV  = theAffectedAPVmap_.begin();
-        iAPV != theAffectedAPVmap_.end(); ++iAPV) {
-
+    for (APVMap::const_iterator iAPV = theAffectedAPVmap_.begin(); iAPV != theAffectedAPVmap_.end(); ++iAPV) {
       currentID = iAPV->first;
 
-      if (currentID == formerID) { // we have to OR these
-        for( int ibit=0; ibit<6; ++ibit){
-          NewAPVBits[ibit] = NewAPVBits[ibit]||(iAPV->second)[ibit];
+      if (currentID == formerID) {  // we have to OR these
+        for (int ibit = 0; ibit < 6; ++ibit) {
+          NewAPVBits[ibit] = NewAPVBits[ibit] || (iAPV->second)[ibit];
         }
-      }
-      else {
-        DeadAPVList[currentID]=NewAPVBits;          
-        //save pointers for next iteration                                 
+      } else {
+        DeadAPVList[currentID] = NewAPVBits;
+        //save pointers for next iteration
         formerID = currentID;
         NewAPVBits = iAPV->second;
       }
 
       iAPVchk = iAPV;
-      if((++iAPVchk) == theAffectedAPVmap_.end()) {  //make sure not to lose the last one 
-        DeadAPVList[currentID]=NewAPVBits;          
+      if ((++iAPVchk) == theAffectedAPVmap_.end()) {  //make sure not to lose the last one
+        DeadAPVList[currentID] = NewAPVBits;
       }
     }
-
   }
-  // 
+  //
 
-  //  Ok, done with merging raw signals and APVs - now add signals on duplicate strips 
+  //  Ok, done with merging raw signals and APVs - now add signals on duplicate strips
 
   // collection of Digis to put in the event
-  std::vector< edm::DetSet<SiStripDigi> > vSiStripDigi;
+  std::vector<edm::DetSet<SiStripDigi>> vSiStripDigi;
 
   // loop through our collection of detectors, merging hits and making a new list of "signal" digis
 
@@ -469,9 +449,7 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
   signals_.clear();
 
   // big loop over Detector IDs:
-  for(SiGlobalRawIndex::const_iterator IDet = SiRawDigis_.begin();
-      IDet != SiRawDigis_.end(); IDet++) {
-
+  for (SiGlobalRawIndex::const_iterator IDet = SiRawDigis_.begin(); IDet != SiRawDigis_.end(); IDet++) {
     uint32_t detID = IDet->first;
 
     SignalMapType Signals;
@@ -484,47 +462,43 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
     int currentStrip;
     float ADCSum = 0;
 
-    //loop over hit strips for this DetId, add duplicates 
+    //loop over hit strips for this DetId, add duplicates
 
     OneDetectorRawMap::const_iterator iLocalchk;
-    OneDetectorRawMap::const_iterator iLocal  = LocalMap.begin();
-    for(;iLocal != LocalMap.end(); ++iLocal) {
+    OneDetectorRawMap::const_iterator iLocal = LocalMap.begin();
+    for (; iLocal != LocalMap.end(); ++iLocal) {
+      currentStrip = iLocal->first;  // strip is first element
 
-      currentStrip = iLocal->first;  // strip is first element 
+      if (currentStrip == formerStrip) {  // we have to add these digis together
 
-      if (currentStrip == formerStrip) { // we have to add these digis together 
-
-        ADCSum+=iLocal->second ;          // raw pulse height is second element. 
-      }
-      else{
-        if(formerStrip!=-1){
-          Signals.insert( std::make_pair(formerStrip, ADCSum));
+        ADCSum += iLocal->second;  // raw pulse height is second element.
+      } else {
+        if (formerStrip != -1) {
+          Signals.insert(std::make_pair(formerStrip, ADCSum));
         }
-        // save pointers for next iteration 
+        // save pointers for next iteration
         formerStrip = currentStrip;
-        ADCSum = iLocal->second; // lone ADC  
+        ADCSum = iLocal->second;  // lone ADC
       }
 
       iLocalchk = iLocal;
-      if((++iLocalchk) == LocalMap.end()) {  //make sure not to lose the last one  
-        Signals.insert( std::make_pair(formerStrip, ADCSum));
+      if ((++iLocalchk) == LocalMap.end()) {  //make sure not to lose the last one
+        Signals.insert(std::make_pair(formerStrip, ADCSum));
       }
     }
-    // save merged map: 
-    signals_.insert( std::make_pair( detID, Signals));
+    // save merged map:
+    signals_.insert(std::make_pair(detID, Signals));
   }
 
   //Now, do noise, zero suppression, take into account bad channels, etc.
   // This section stolen from SiStripDigitizerAlgorithm
   // must loop over all detIds in the tracker to get all of the noise added properly.
-  for( const auto& iu : pDD->detUnits()) {
-
+  for (const auto& iu : pDD->detUnits()) {
     const StripGeomDetUnit* sgd = dynamic_cast<const StripGeomDetUnit*>(iu);
-    if (sgd != nullptr){
-
+    if (sgd != nullptr) {
       uint32_t detID = sgd->geographicalId().rawId();
 
-      edm::DetSet<SiStripDigi> SSD(detID); // Make empty collection with this detector ID
+      edm::DetSet<SiStripDigi> SSD(detID);  // Make empty collection with this detector ID
 
       int numStrips = (sgd->specificTopology()).nstrips();
 
@@ -533,8 +507,8 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
       const SignalMapType* theSignal(getSignal(detID));
 
       std::vector<float> detAmpl(numStrips, 0.);
-      if(theSignal) {
-        for(const auto& amp : *theSignal) {
+      if (theSignal) {
+        for (const auto& amp : *theSignal) {
           detAmpl[amp.first] = amp.second;
         }
       }
@@ -542,23 +516,25 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
       //removing signal from the dead (and HIP effected) strips
       std::vector<bool>& badChannels = allBadChannels[detID];
 
-      for(int strip =0; strip < numStrips; ++strip) {
-        if(badChannels[strip]) detAmpl[strip] = 0.;
+      for (int strip = 0; strip < numStrips; ++strip) {
+        if (badChannels[strip])
+          detAmpl[strip] = 0.;
       }
-         
-      if(APVSaturationFromHIP_) {
-        std::bitset<6> & bs=DeadAPVList[detID];
 
-        if(bs.any()){
+      if (APVSaturationFromHIP_) {
+        std::bitset<6>& bs = DeadAPVList[detID];
+
+        if (bs.any()) {
           // Here below is the scaling function which describes the evolution of the baseline (i.e. how the charge is suppressed).
           // This must be replaced as soon as we have a proper modeling of the baseline evolution from VR runs
-          float Shift=1-NumberOfBxBetweenHIPandEvent/floor(300.0/25.0); //Reminder: make these numbers not hardcoded!! 
-          float randomX=CLHEP::RandFlat::shoot(engine);
-          float scalingValue=(randomX-Shift)*10.0/7.0-3.0/7.0;
+          float Shift =
+              1 - NumberOfBxBetweenHIPandEvent / floor(300.0 / 25.0);  //Reminder: make these numbers not hardcoded!!
+          float randomX = CLHEP::RandFlat::shoot(engine);
+          float scalingValue = (randomX - Shift) * 10.0 / 7.0 - 3.0 / 7.0;
 
-          for(int strip =0; strip < numStrips; ++strip) {
-            if(!badChannels[strip] &&  bs[strip/128]==1){
-              detAmpl[strip] *=scalingValue>0?scalingValue:0.0;
+          for (int strip = 0; strip < numStrips; ++strip) {
+            if (!badChannels[strip] && bs[strip / 128] == 1) {
+              detAmpl[strip] *= scalingValue > 0 ? scalingValue : 0.0;
             }
           }
         }
@@ -582,7 +558,7 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
         }
         }
       */
-	
+
       //SiStripPedestals::Range detPedestalRange = pedestalHandle->getRange(detID);
 
       // -----------------------------------------------------------
@@ -590,53 +566,55 @@ void PreMixingSiStripWorker::put(edm::Event &e, edm::EventSetup const& iSetup, s
       size_t firstChannelWithSignal = 0;
       size_t lastChannelWithSignal = numStrips;
 
-      if(SingleStripNoise){
+      if (SingleStripNoise) {
         std::vector<float> noiseRMSv;
         noiseRMSv.clear();
-        noiseRMSv.insert(noiseRMSv.begin(),numStrips,0.);
-        for(int strip=0; strip< numStrips; ++strip){
-          if(!badChannels[strip]){
+        noiseRMSv.insert(noiseRMSv.begin(), numStrips, 0.);
+        for (int strip = 0; strip < numStrips; ++strip) {
+          if (!badChannels[strip]) {
             float gainValue = gainHandle->getStripGain(strip, detGainRange);
-            noiseRMSv[strip] = (noiseHandle->getNoise(strip,detNoiseRange))* theElectronPerADC/gainValue;
+            noiseRMSv[strip] = (noiseHandle->getNoise(strip, detNoiseRange)) * theElectronPerADC / gainValue;
           }
         }
         theSiNoiseAdder->addNoiseVR(detAmpl, noiseRMSv, engine);
       } else {
-        int RefStrip = int(numStrips/2.);
-        while(RefStrip<numStrips&&badChannels[RefStrip]){ //if the refstrip is bad, I move up to when I don't find it                                            
+        int RefStrip = int(numStrips / 2.);
+        while (RefStrip < numStrips &&
+               badChannels[RefStrip]) {  //if the refstrip is bad, I move up to when I don't find it
           RefStrip++;
         }
-        if(RefStrip<numStrips){
+        if (RefStrip < numStrips) {
           float RefgainValue = gainHandle->getStripGain(RefStrip, detGainRange);
-          float RefnoiseRMS = noiseHandle->getNoise(RefStrip,detNoiseRange) *theElectronPerADC/RefgainValue;
+          float RefnoiseRMS = noiseHandle->getNoise(RefStrip, detNoiseRange) * theElectronPerADC / RefgainValue;
 
-          theSiNoiseAdder->addNoise(detAmpl,firstChannelWithSignal,lastChannelWithSignal,numStrips,RefnoiseRMS, engine);
+          theSiNoiseAdder->addNoise(
+              detAmpl, firstChannelWithSignal, lastChannelWithSignal, numStrips, RefnoiseRMS, engine);
         }
       }
-	
-      DigitalVecType digis;
-      theSiZeroSuppress->suppress(theSiDigitalConverter->convert(detAmpl, gainHandle, detID), digis, detID,noiseHandle,thresholdHandle);
 
+      DigitalVecType digis;
+      theSiZeroSuppress->suppress(
+          theSiDigitalConverter->convert(detAmpl, gainHandle, detID), digis, detID, noiseHandle, thresholdHandle);
 
       SSD.data = digis;
 
       // stick this into the global vector of detector info
       vSiStripDigi.push_back(SSD);
-	
-    } // end of loop over one detector
 
-  } // end of big loop over all detector IDs
+    }  // end of loop over one detector
 
-    // put the collection of digis in the event   
-  edm::LogInfo("PreMixingSiStripWorker") << "total # Merged strips: " << vSiStripDigi.size() ;
+  }  // end of big loop over all detector IDs
+
+  // put the collection of digis in the event
+  edm::LogInfo("PreMixingSiStripWorker") << "total # Merged strips: " << vSiStripDigi.size();
 
   // make new digi collection
-    
-  std::unique_ptr< edm::DetSetVector<SiStripDigi> > MySiStripDigis(new edm::DetSetVector<SiStripDigi>(vSiStripDigi) );
+
+  std::unique_ptr<edm::DetSetVector<SiStripDigi>> MySiStripDigis(new edm::DetSetVector<SiStripDigi>(vSiStripDigi));
 
   // put collection
 
-  e.put(std::move(MySiStripDigis), SiStripDigiCollectionDM_ );
+  e.put(std::move(MySiStripDigis), SiStripDigiCollectionDM_);
 
   // clear local storage for this event
   SiHitStorage_.clear();

--- a/SimTracker/SiStripDigitizer/plugins/SiChargeCollectionDrifter.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiChargeCollectionDrifter.h
@@ -5,18 +5,17 @@
 #include "SignalPoint.h"
 #include "EnergyDepositUnit.h"
 
-#include<vector>
+#include <vector>
 /**
  * Base class for the drifting of charges in the silicon.
  */
-class SiChargeCollectionDrifter{
- public:  
-  typedef std::vector <SignalPoint> collection_type;
-  typedef std::vector <EnergyDepositUnit> ionization_type;
+class SiChargeCollectionDrifter {
+public:
+  typedef std::vector<SignalPoint> collection_type;
+  typedef std::vector<EnergyDepositUnit> ionization_type;
 
-  virtual ~SiChargeCollectionDrifter() { }
-  virtual collection_type drift (const ionization_type&, const LocalVector&,double,double) = 0;
+  virtual ~SiChargeCollectionDrifter() {}
+  virtual collection_type drift(const ionization_type&, const LocalVector&, double, double) = 0;
 };
 
 #endif
-

--- a/SimTracker/SiStripDigitizer/plugins/SiChargeDivider.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiChargeDivider.h
@@ -9,20 +9,20 @@
 
 #include <vector>
 
-namespace CLHEP{
+namespace CLHEP {
   class HepRandomEngine;
 }
 
 /**
  * Base class for the division of a Geant energy deposit in smaller elementary charges inside the silicon
  */
-class SiChargeDivider{
- public:
-  typedef std::vector< EnergyDepositUnit > ionization_type;
-  virtual ~SiChargeDivider() { }
-  virtual ionization_type divide(const PSimHit*, const LocalVector&, double, const StripGeomDetUnit& det, CLHEP::HepRandomEngine* engine ) = 0;
-  virtual void setParticleDataTable(const ParticleDataTable * pdt) = 0;
+class SiChargeDivider {
+public:
+  typedef std::vector<EnergyDepositUnit> ionization_type;
+  virtual ~SiChargeDivider() {}
+  virtual ionization_type divide(
+      const PSimHit*, const LocalVector&, double, const StripGeomDetUnit& det, CLHEP::HepRandomEngine* engine) = 0;
+  virtual void setParticleDataTable(const ParticleDataTable* pdt) = 0;
 };
-
 
 #endif

--- a/SimTracker/SiStripDigitizer/plugins/SiHitDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiHitDigitizer.h
@@ -1,6 +1,6 @@
 #ifndef _TRACKER_SiHitDigitizer_H_
 #define _TRACKER_SiHitDigitizer_H_
- 
+
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
@@ -21,7 +21,7 @@ class TrackerTopology;
 
 class SiStripDetType;
 
-namespace CLHEP{
+namespace CLHEP {
   class HepRandomEngine;
 }
 
@@ -29,33 +29,30 @@ namespace CLHEP{
 * Digitizes the response for a single SimHit.
 */
 class SiHitDigitizer {
- public:
-
+public:
   SiHitDigitizer(const edm::ParameterSet& conf);
 
   ~SiHitDigitizer();
 
-  void setChargeDivider(SiChargeDivider* cd) {
-    theSiChargeDivider.reset(cd);
-  }
+  void setChargeDivider(SiChargeDivider* cd) { theSiChargeDivider.reset(cd); }
 
-  void setChargeCollectionDrifter(SiChargeCollectionDrifter* cd) {
-    theSiChargeCollectionDrifter.reset(cd);
-  }
+  void setChargeCollectionDrifter(SiChargeCollectionDrifter* cd) { theSiChargeCollectionDrifter.reset(cd); }
 
-  void setInduceChargeOnStrips(SiInduceChargeOnStrips* cd) {
-    theSiInduceChargeOnStrips.reset(cd);
-  }
-  
-  void setParticleDataTable(const ParticleDataTable * pdt) { 
-    theSiChargeDivider->setParticleDataTable(pdt); 
-  }
+  void setInduceChargeOnStrips(SiInduceChargeOnStrips* cd) { theSiInduceChargeOnStrips.reset(cd); }
 
-  void processHit(const PSimHit*, const StripGeomDetUnit&, GlobalVector,float,
-		  std::vector<float>&, size_t&, size_t&,
-		  const TrackerTopology *tTopo, CLHEP::HepRandomEngine*);
-  
- private:
+  void setParticleDataTable(const ParticleDataTable* pdt) { theSiChargeDivider->setParticleDataTable(pdt); }
+
+  void processHit(const PSimHit*,
+                  const StripGeomDetUnit&,
+                  GlobalVector,
+                  float,
+                  std::vector<float>&,
+                  size_t&,
+                  size_t&,
+                  const TrackerTopology* tTopo,
+                  CLHEP::HepRandomEngine*);
+
+private:
   const double depletionVoltage;
   const double chargeMobility;
   std::unique_ptr<SiChargeDivider> theSiChargeDivider;
@@ -63,12 +60,11 @@ class SiHitDigitizer {
   std::unique_ptr<const SiInduceChargeOnStrips> theSiInduceChargeOnStrips;
 
   typedef GloballyPositioned<double> Frame;
-  
-  LocalVector DriftDirection(const StripGeomDetUnit* _detp, GlobalVector _bfield, float langle) {
-    LocalVector Bfield=Frame(_detp->surface().position(),_detp->surface().rotation()).toLocal(_bfield);
-    return LocalVector(-langle * Bfield.y(),langle * Bfield.x(),1.);
-  }
 
+  LocalVector DriftDirection(const StripGeomDetUnit* _detp, GlobalVector _bfield, float langle) {
+    LocalVector Bfield = Frame(_detp->surface().position(), _detp->surface().rotation()).toLocal(_bfield);
+    return LocalVector(-langle * Bfield.y(), langle * Bfield.x(), 1.);
+  }
 };
 
 #endif

--- a/SimTracker/SiStripDigitizer/plugins/SiInduceChargeOnStrips.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiInduceChargeOnStrips.h
@@ -5,7 +5,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "SimTracker/SiStripDigitizer/interface/SiPileUpSignals.h"
 
-#include<map>
+#include <map>
 
 class TrackerTopology;
 class StripDet;
@@ -14,14 +14,14 @@ class StripDet;
  * Given a SignalPoint, computes the charge on each strip.
  */
 
-
-class SiInduceChargeOnStrips{
+class SiInduceChargeOnStrips {
 public:
-  
-  virtual ~SiInduceChargeOnStrips() { }
-  virtual void induce(const SiChargeCollectionDrifter::collection_type&, const StripGeomDetUnit&, 
-		      std::vector<float>&, size_t&, size_t&,
-		      const TrackerTopology *tTopo) const=0;
-
+  virtual ~SiInduceChargeOnStrips() {}
+  virtual void induce(const SiChargeCollectionDrifter::collection_type &,
+                      const StripGeomDetUnit &,
+                      std::vector<float> &,
+                      size_t &,
+                      size_t &,
+                      const TrackerTopology *tTopo) const = 0;
 };
 #endif

--- a/SimTracker/SiStripDigitizer/plugins/SiLinearChargeCollectionDrifter.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiLinearChargeCollectionDrifter.cc
@@ -1,49 +1,44 @@
 #include "SiLinearChargeCollectionDrifter.h"
 #include "vdt/log.h"
 
-SiLinearChargeCollectionDrifter::SiLinearChargeCollectionDrifter(double dc,
-								 double cdr,
-								 double dv,
-								 double av) :
-  // Everything which does not depend on the specific det
-  diffusionConstant(dc),
-  chargeDistributionRMS(cdr),
-  depletionVoltage(dv),
-  appliedVoltage(av)
-{
-}
+SiLinearChargeCollectionDrifter::SiLinearChargeCollectionDrifter(double dc, double cdr, double dv, double av)
+    :  // Everything which does not depend on the specific det
+      diffusionConstant(dc),
+      chargeDistributionRMS(cdr),
+      depletionVoltage(dv),
+      appliedVoltage(av) {}
 
-SiChargeCollectionDrifter::collection_type SiLinearChargeCollectionDrifter::drift(const SiChargeCollectionDrifter::ionization_type& ion, 
-										  const LocalVector& driftDir,double mt, double tn) {
+SiChargeCollectionDrifter::collection_type SiLinearChargeCollectionDrifter::drift(
+    const SiChargeCollectionDrifter::ionization_type& ion, const LocalVector& driftDir, double mt, double tn) {
   // prepare output
   collection_type _temp;
   _temp.resize(ion.size());
   // call the drift method for each deposit
-  for (size_t i=0; i<ion.size(); i++){
+  for (size_t i = 0; i < ion.size(); i++) {
     _temp[i] = drift(ion[i], driftDir, mt, tn);
   }
   return _temp;
 }
 
-SignalPoint SiLinearChargeCollectionDrifter::drift
-(const EnergyDepositUnit& edu, const LocalVector& drift, double moduleThickness, double timeNormalisation) {
+SignalPoint SiLinearChargeCollectionDrifter::drift(const EnergyDepositUnit& edu,
+                                                   const LocalVector& drift,
+                                                   double moduleThickness,
+                                                   double timeNormalisation) {
   // computes the fraction of the module the charge has to drift through,
   // ensuring it is bounded in [0,1]
-  double depth = (moduleThickness/2.-edu.z());
-  double thicknessFraction = depth/moduleThickness ; 
-  thicknessFraction = thicknessFraction>0. ? thicknessFraction : 0. ;
-  thicknessFraction = thicknessFraction<1. ? thicknessFraction : 1. ;
-  
+  double depth = (moduleThickness / 2. - edu.z());
+  double thicknessFraction = depth / moduleThickness;
+  thicknessFraction = thicknessFraction > 0. ? thicknessFraction : 0.;
+  thicknessFraction = thicknessFraction < 1. ? thicknessFraction : 1.;
+
   // computes the drift time in the sensor
-  double driftTime = -timeNormalisation*
-    vdt::fast_log(1.-2*depletionVoltage*thicknessFraction/
-	(depletionVoltage+appliedVoltage))
-    +chargeDistributionRMS;  
-  
+  double driftTime = -timeNormalisation * vdt::fast_log(1. - 2 * depletionVoltage * thicknessFraction /
+                                                                 (depletionVoltage + appliedVoltage)) +
+                     chargeDistributionRMS;
+
   // returns the signal: an energy on the surface, with a size due to diffusion.
-  return SignalPoint(edu.x() + depth*drift.x()/drift.z(),
-                     edu.y() + depth*drift.y()/drift.z(),
-                     sqrt(2.*diffusionConstant*driftTime),
+  return SignalPoint(edu.x() + depth * drift.x() / drift.z(),
+                     edu.y() + depth * drift.y() / drift.z(),
+                     sqrt(2. * diffusionConstant * driftTime),
                      edu.energy());
 }
-

--- a/SimTracker/SiStripDigitizer/plugins/SiLinearChargeCollectionDrifter.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiLinearChargeCollectionDrifter.h
@@ -9,18 +9,21 @@
  * The resulting position depends on the Lorentz angle, and a sigma is computed                                        
  * that describes the diffusion.               
  */
-class SiLinearChargeCollectionDrifter : public SiChargeCollectionDrifter{
- public:
-  SiLinearChargeCollectionDrifter(double,double,double,double);
-  SiChargeCollectionDrifter::collection_type drift(const SiChargeCollectionDrifter::ionization_type&, 
-                                                   const LocalVector&,double,double) override;
- private:
-  SignalPoint drift(const EnergyDepositUnit&, const LocalVector&,double,double);
- private:
+class SiLinearChargeCollectionDrifter : public SiChargeCollectionDrifter {
+public:
+  SiLinearChargeCollectionDrifter(double, double, double, double);
+  SiChargeCollectionDrifter::collection_type drift(const SiChargeCollectionDrifter::ionization_type&,
+                                                   const LocalVector&,
+                                                   double,
+                                                   double) override;
+
+private:
+  SignalPoint drift(const EnergyDepositUnit&, const LocalVector&, double, double);
+
+private:
   const double diffusionConstant;
   const double chargeDistributionRMS;
   const double depletionVoltage;
   const double appliedVoltage;
 };
 #endif
-

--- a/SimTracker/SiStripDigitizer/plugins/SiLinearChargeDivider.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiLinearChargeDivider.cc
@@ -6,101 +6,105 @@
 #include <fstream>
 #include <string>
 
-SiLinearChargeDivider::SiLinearChargeDivider(const edm::ParameterSet& conf) :
-  // Run APV in peak instead of deconvolution mode, which degrades the time resolution.
-  peakMode(conf.getParameter<bool>("APVpeakmode")),
-  // Enable interstrip Landau fluctuations within a cluster.
-  fluctuateCharge(conf.getParameter<bool>("LandauFluctuations")),
-  // Number of segments per strip into which charge is divided during
-  // simulation. If large, precision of simulation improves.
-  chargedivisionsPerStrip(conf.getParameter<int>("chargeDivisionsPerStrip")),
-  // delta cutoff in MeV, has to be same as in Geant (0.120425 MeV corresponding to 100um range for electrons)
-  deltaCut(conf.getParameter<double>("DeltaProductionCut")),
-  //Offset for digitization during the MTCC and in general for taking cosmic particle
-  //The value to be used it must be evaluated and depend on the volume defnition used
-  //for the cosimc generation (Considering only the tracker the value is 11 ns)
-  cosmicShift(conf.getUntrackedParameter<double>("CosmicDelayShift")),
-  theParticleDataTable(nullptr),
-  // Geant4 engine used to fluctuate the charge from segment to segment
-  fluctuate(new SiG4UniversalFluctuation())
+SiLinearChargeDivider::SiLinearChargeDivider(const edm::ParameterSet& conf)
+    :  // Run APV in peak instead of deconvolution mode, which degrades the time resolution.
+      peakMode(conf.getParameter<bool>("APVpeakmode")),
+      // Enable interstrip Landau fluctuations within a cluster.
+      fluctuateCharge(conf.getParameter<bool>("LandauFluctuations")),
+      // Number of segments per strip into which charge is divided during
+      // simulation. If large, precision of simulation improves.
+      chargedivisionsPerStrip(conf.getParameter<int>("chargeDivisionsPerStrip")),
+      // delta cutoff in MeV, has to be same as in Geant (0.120425 MeV corresponding to 100um range for electrons)
+      deltaCut(conf.getParameter<double>("DeltaProductionCut")),
+      //Offset for digitization during the MTCC and in general for taking cosmic particle
+      //The value to be used it must be evaluated and depend on the volume defnition used
+      //for the cosimc generation (Considering only the tracker the value is 11 ns)
+      cosmicShift(conf.getUntrackedParameter<double>("CosmicDelayShift")),
+      theParticleDataTable(nullptr),
+      // Geant4 engine used to fluctuate the charge from segment to segment
+      fluctuate(new SiG4UniversalFluctuation())
 
 {
   readPulseShape(conf.getParameter<edm::FileInPath>(peakMode ? "APVShapePeakFile" : "APVShapeDecoFile").fullPath());
 }
 
+SiLinearChargeDivider::~SiLinearChargeDivider() {}
 
-SiLinearChargeDivider::~SiLinearChargeDivider(){
-}
-
-void SiLinearChargeDivider::readPulseShape(const std::string& pulseShapeFileName)
-{
+void SiLinearChargeDivider::readPulseShape(const std::string& pulseShapeFileName) {
   // Pulse shape file format: empty lines and comments (lines starting with '#') are ignored
   // one line "resolution: value" is interpreted as the resolution
   // all other lines are read as consecutive values of the shape
   std::ifstream shapeFile(pulseShapeFileName.c_str());
-  if ( ! shapeFile.good() ) {
+  if (!shapeFile.good()) {
     throw cms::Exception("FileError") << "Problem opening APV Shape file: " << pulseShapeFileName;
   }
   pulseResolution = -1.;
   std::string line;
   const std::string resoPrefix{"resolution: "};
-  while ( std::getline(shapeFile, line) ) {
-    if ( ( ! line.empty() ) && ( line.substr(1) != "#" ) ) {
+  while (std::getline(shapeFile, line)) {
+    if ((!line.empty()) && (line.substr(1) != "#")) {
       std::istringstream lStr{line};
-      if ( line.substr(0,resoPrefix.size()) == resoPrefix) {
-	lStr.seekg(resoPrefix.size());
-	lStr >> pulseResolution;
+      if (line.substr(0, resoPrefix.size()) == resoPrefix) {
+        lStr.seekg(resoPrefix.size());
+        lStr >> pulseResolution;
       } else {
-	double value;
-	while ( lStr >> value ) {
-	  pulseValues.push_back(value);
-	}
+        double value;
+        while (lStr >> value) {
+          pulseValues.push_back(value);
+        }
       }
     }
   }
-  if ( pulseValues.empty() || ( pulseResolution == -1. ) ) {
-    throw cms::Exception("WrongAPVPulseShape") << "Problem reading from APV pulse shape file " << pulseShapeFileName << ": " << (pulseValues.empty() ? "no values" : "no resolution");
+  if (pulseValues.empty() || (pulseResolution == -1.)) {
+    throw cms::Exception("WrongAPVPulseShape") << "Problem reading from APV pulse shape file " << pulseShapeFileName
+                                               << ": " << (pulseValues.empty() ? "no values" : "no resolution");
   }
   const auto maxIt = std::max_element(pulseValues.begin(), pulseValues.end());
-  if ( std::abs((*maxIt)-1.) > std::numeric_limits<double>::epsilon() ) {
-    throw cms::Exception("WrongAPVPulseShape") << "The max value of the APV pulse shape stored in the text file used in SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py is not equal to 1. Need to be fixed.";
+  if (std::abs((*maxIt) - 1.) > std::numeric_limits<double>::epsilon()) {
+    throw cms::Exception("WrongAPVPulseShape")
+        << "The max value of the APV pulse shape stored in the text file used in "
+           "SimGeneral/MixingModule/python/SiStripSimParameters_cfi.py is not equal to 1. Need to be fixed.";
   }
   pulset0Idx = std::distance(pulseValues.begin(), maxIt);
 }
 
-SiChargeDivider::ionization_type 
-SiLinearChargeDivider::divide(const PSimHit* hit, const LocalVector& driftdir, double moduleThickness, const StripGeomDetUnit& det, CLHEP::HepRandomEngine* engine) {
-
+SiChargeDivider::ionization_type SiLinearChargeDivider::divide(const PSimHit* hit,
+                                                               const LocalVector& driftdir,
+                                                               double moduleThickness,
+                                                               const StripGeomDetUnit& det,
+                                                               CLHEP::HepRandomEngine* engine) {
   // signal after pulse shape correction
   float const decSignal = TimeResponse(hit, det);
 
   // if out of time go home!
-  if (0==decSignal) return ionization_type();
+  if (0 == decSignal)
+    return ionization_type();
 
   // Get the nass if the particle, in MeV.
   // Protect from particles with Mass = 0, assuming then the pion mass
   assert(theParticleDataTable != nullptr);
-  ParticleData const * particle = theParticleDataTable->particle( hit->particleType() );
-  double const particleMass = particle ? particle->mass()*1000 : 139.57;
+  ParticleData const* particle = theParticleDataTable->particle(hit->particleType());
+  double const particleMass = particle ? particle->mass() * 1000 : 139.57;
   double const particleCharge = particle ? particle->charge() : 1.;
 
-  if(!particle) {
-    LogDebug("SiLinearChargeDivider") << "Cannot find particle of type "<< hit->particleType() 
+  if (!particle) {
+    LogDebug("SiLinearChargeDivider") << "Cannot find particle of type " << hit->particleType()
                                       << " in the PDT we assign to this particle the mass and charge of the Pion";
   }
 
-  int NumberOfSegmentation = 
-    // if neutral: just one deposit....
-    (fabs(particleMass)<1.e-6 || particleCharge==0) ? 1 :
-    // computes the number of segments from number of segments per strip times number of strips.
-    (int)(1 + chargedivisionsPerStrip*fabs(driftXPos(hit->exitPoint(), driftdir, moduleThickness)-
-					   driftXPos(hit->entryPoint(), driftdir, moduleThickness) )
-	  /det.specificTopology().localPitch(hit->localPosition())         ); 
- 
+  int NumberOfSegmentation =
+      // if neutral: just one deposit....
+      (fabs(particleMass) < 1.e-6 || particleCharge == 0)
+          ? 1
+          :
+          // computes the number of segments from number of segments per strip times number of strips.
+          (int)(1 + chargedivisionsPerStrip *
+                        fabs(driftXPos(hit->exitPoint(), driftdir, moduleThickness) -
+                             driftXPos(hit->entryPoint(), driftdir, moduleThickness)) /
+                        det.specificTopology().localPitch(hit->localPosition()));
 
   // Eloss in GeV
   float eLoss = hit->energyLoss();
-
 
   // Prepare output
   ionization_type _ionization_points;
@@ -108,70 +112,75 @@ SiLinearChargeDivider::divide(const PSimHit* hit, const LocalVector& driftdir, d
 
   // Fluctuate charge in track subsegments
   LocalVector direction = hit->exitPoint() - hit->entryPoint();
-  if (NumberOfSegmentation <=1) {
+  if (NumberOfSegmentation <= 1) {
     // here I need a random... not 0.5
-    _ionization_points[0] = EnergyDepositUnit(eLoss*decSignal/eLoss,
-					      hit->entryPoint()+0.5f*direction);
-  }else {
+    _ionization_points[0] = EnergyDepositUnit(eLoss * decSignal / eLoss, hit->entryPoint() + 0.5f * direction);
+  } else {
     float eLossVector[NumberOfSegmentation];
-    if( fluctuateCharge ) {
+    if (fluctuateCharge) {
       fluctuateEloss(particleMass, hit->pabs(), eLoss, direction.mag(), NumberOfSegmentation, eLossVector, engine);
       // Save the energy of each segment
-      for ( int i = 0; i != NumberOfSegmentation; i++) {
-	// take energy value from vector eLossVector, 
-	_ionization_points[i] = EnergyDepositUnit(eLossVector[i]*decSignal/eLoss,
-						  hit->entryPoint()+float((i+0.5)/NumberOfSegmentation)*direction);
+      for (int i = 0; i != NumberOfSegmentation; i++) {
+        // take energy value from vector eLossVector,
+        _ionization_points[i] =
+            EnergyDepositUnit(eLossVector[i] * decSignal / eLoss,
+                              hit->entryPoint() + float((i + 0.5) / NumberOfSegmentation) * direction);
       }
     } else {
       // Save the energy of each segment
-      for ( int i = 0; i != NumberOfSegmentation; i++) {
-	// take energy value from eLoss average over n.segments.
-	_ionization_points[i] = EnergyDepositUnit(decSignal/float(NumberOfSegmentation),
-						  hit->entryPoint()+float((i+0.5)/NumberOfSegmentation)*direction);
+      for (int i = 0; i != NumberOfSegmentation; i++) {
+        // take energy value from eLoss average over n.segments.
+        _ionization_points[i] =
+            EnergyDepositUnit(decSignal / float(NumberOfSegmentation),
+                              hit->entryPoint() + float((i + 0.5) / NumberOfSegmentation) * direction);
       }
     }
   }
   return _ionization_points;
 }
 
-void SiLinearChargeDivider::fluctuateEloss(double particleMass, float particleMomentum, 
-                                           float eloss, float length, 
-                                           int NumberOfSegs,float elossVector[],
+void SiLinearChargeDivider::fluctuateEloss(double particleMass,
+                                           float particleMomentum,
+                                           float eloss,
+                                           float length,
+                                           int NumberOfSegs,
+                                           float elossVector[],
                                            CLHEP::HepRandomEngine* engine) {
-
-
   // Generate charge fluctuations.
-  float sum=0.;
+  float sum = 0.;
   double deltaCutoff;
-  double mom = particleMomentum*1000.;
-  double seglen = length/NumberOfSegs*10.;
-  double segeloss = (1000.*eloss)/NumberOfSegs;
-  for (int i=0;i<NumberOfSegs;i++) {
+  double mom = particleMomentum * 1000.;
+  double seglen = length / NumberOfSegs * 10.;
+  double segeloss = (1000. * eloss) / NumberOfSegs;
+  for (int i = 0; i < NumberOfSegs; i++) {
     // The G4 routine needs momentum in MeV, mass in MeV, delta-cut in MeV,
-    // track segment length in mm, segment eloss in MeV 
+    // track segment length in mm, segment eloss in MeV
     // Returns fluctuated eloss in MeV
     // the cutoff is sometimes redefined inside, so fix it.
     deltaCutoff = deltaCut;
-    sum += (elossVector[i] = fluctuate->SampleFluctuations(mom,particleMass,deltaCutoff,seglen,segeloss, engine)/1000.);
+    sum += (elossVector[i] =
+                fluctuate->SampleFluctuations(mom, particleMass, deltaCutoff, seglen, segeloss, engine) / 1000.);
   }
-  
-  if(sum>0.) {  // If fluctuations give eloss>0.
+
+  if (sum > 0.) {  // If fluctuations give eloss>0.
     // Rescale to the same total eloss
-    float ratio = eloss/sum;
-    for (int ii=0;ii<NumberOfSegs;ii++) elossVector[ii]= ratio*elossVector[ii];
+    float ratio = eloss / sum;
+    for (int ii = 0; ii < NumberOfSegs; ii++)
+      elossVector[ii] = ratio * elossVector[ii];
   } else {  // If fluctuations gives 0 eloss
-    float averageEloss = eloss/NumberOfSegs;
-    for (int ii=0;ii<NumberOfSegs;ii++) elossVector[ii]= averageEloss; 
+    float averageEloss = eloss / NumberOfSegs;
+    for (int ii = 0; ii < NumberOfSegs; ii++)
+      elossVector[ii] = averageEloss;
   }
   return;
 }
 
-float SiLinearChargeDivider::TimeResponse( const PSimHit* hit, const StripGeomDetUnit& det)
-{
+float SiLinearChargeDivider::TimeResponse(const PSimHit* hit, const StripGeomDetUnit& det) {
   // x is difference between the tof and the tof for a photon (reference)
   // converted into a bin number
-  const auto dTOF = det.surface().toGlobal(hit->localPosition()).mag()/30. + cosmicShift - hit->tof();
-  const int x= int(dTOF/pulseResolution) + pulset0Idx;
-  if(x < 0 || x >= int(pulseValues.size())) return 0;
-  return hit->energyLoss()*pulseValues[std::size_t(x)];
+  const auto dTOF = det.surface().toGlobal(hit->localPosition()).mag() / 30. + cosmicShift - hit->tof();
+  const int x = int(dTOF / pulseResolution) + pulset0Idx;
+  if (x < 0 || x >= int(pulseValues.size()))
+    return 0;
+  return hit->energyLoss() * pulseValues[std::size_t(x)];
 }

--- a/SimTracker/SiStripDigitizer/plugins/SiLinearChargeDivider.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiLinearChargeDivider.h
@@ -13,7 +13,7 @@
 
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 
-namespace CLHEP{
+namespace CLHEP {
   class HepRandomEngine;
 }
 
@@ -24,9 +24,8 @@ namespace CLHEP{
  * - fluctuations of the charge deposit fronm segment to segment
  * - pulse shape ( in peak of deconvolution mode)
  */
-class SiLinearChargeDivider : public SiChargeDivider{
- public:
-
+class SiLinearChargeDivider : public SiChargeDivider {
+public:
   // constructor
   SiLinearChargeDivider(const edm::ParameterSet& conf);
 
@@ -34,35 +33,41 @@ class SiLinearChargeDivider : public SiChargeDivider{
   ~SiLinearChargeDivider() override;
 
   // main method: divide the charge (from the PSimHit) into several energy deposits in the bulk
-  SiChargeDivider::ionization_type divide(const PSimHit*, const LocalVector&, double, const StripGeomDetUnit& det, CLHEP::HepRandomEngine*) override;
+  SiChargeDivider::ionization_type divide(
+      const PSimHit*, const LocalVector&, double, const StripGeomDetUnit& det, CLHEP::HepRandomEngine*) override;
 
   // set the ParticleDataTable (used to fluctuate the charge properly)
-  void setParticleDataTable(const ParticleDataTable * pdt) override { theParticleDataTable = pdt; }
-  
- private:
+  void setParticleDataTable(const ParticleDataTable* pdt) override { theParticleDataTable = pdt; }
+
+private:
   // configuration data
-  const bool   peakMode;
-  const bool   fluctuateCharge;
-  const int    chargedivisionsPerStrip;
-  const double deltaCut ;
+  const bool peakMode;
+  const bool fluctuateCharge;
+  const int chargedivisionsPerStrip;
+  const double deltaCut;
   const double cosmicShift;
-  const ParticleDataTable * theParticleDataTable;
+  const ParticleDataTable* theParticleDataTable;
   double pulseResolution;
   unsigned int pulset0Idx;
   std::vector<double> pulseValues;
-  
+
   // Geant4 engine used by fluctuateEloss()
-  std::unique_ptr<SiG4UniversalFluctuation> fluctuate; 
+  std::unique_ptr<SiG4UniversalFluctuation> fluctuate;
   // utility: drifts the charge to the surface to estimate the number of relevant strips
-  inline float driftXPos(const Local3DPoint& pos, const LocalVector& drift, double thickness) { 
-    return pos.x()+(thickness/2.-pos.z())*drift.x()/drift.z();
+  inline float driftXPos(const Local3DPoint& pos, const LocalVector& drift, double thickness) {
+    return pos.x() + (thickness / 2. - pos.z()) * drift.x() / drift.z();
   }
   // fluctuate the Eloss
-  void fluctuateEloss(double const particleMass, float momentum, float eloss, float length, int NumberOfSegmentation, float elossVector[], CLHEP::HepRandomEngine*);
+  void fluctuateEloss(double const particleMass,
+                      float momentum,
+                      float eloss,
+                      float length,
+                      int NumberOfSegmentation,
+                      float elossVector[],
+                      CLHEP::HepRandomEngine*);
   // time response (from the pulse shape)
-  float TimeResponse( const PSimHit* hit, const StripGeomDetUnit& det);
+  float TimeResponse(const PSimHit* hit, const StripGeomDetUnit& det);
   void readPulseShape(const std::string& pulseShapeFileName);
-
 };
 
 #endif

--- a/SimTracker/SiStripDigitizer/plugins/SiPileUpSignals.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiPileUpSignals.cc
@@ -1,16 +1,16 @@
 #include "SimTracker/SiStripDigitizer/interface/SiPileUpSignals.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
-void SiPileUpSignals::resetSignals(){
-  signal_.clear();
-}
+void SiPileUpSignals::resetSignals() { signal_.clear(); }
 
-void SiPileUpSignals::add(uint32_t detID, const std::vector<float>& locAmpl,
-                          const size_t& firstChannelWithSignal, const size_t& lastChannelWithSignal) {
+void SiPileUpSignals::add(uint32_t detID,
+                          const std::vector<float>& locAmpl,
+                          const size_t& firstChannelWithSignal,
+                          const size_t& lastChannelWithSignal) {
   SignalMapType& theSignal = signal_[detID];
-  for (size_t iChannel=firstChannelWithSignal; iChannel<lastChannelWithSignal; ++iChannel) {
-    if(locAmpl[iChannel] != 0.0) {
-      if(theSignal.find(iChannel) == theSignal.end()) {
+  for (size_t iChannel = firstChannelWithSignal; iChannel < lastChannelWithSignal; ++iChannel) {
+    if (locAmpl[iChannel] != 0.0) {
+      if (theSignal.find(iChannel) == theSignal.end()) {
         theSignal.insert(std::make_pair(iChannel, locAmpl[iChannel]));
       } else {
         theSignal[iChannel] += locAmpl[iChannel];

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -55,124 +55,127 @@
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC) : 
-  gainLabel(conf.getParameter<std::string>("Gain")),
-  hitsProducer(conf.getParameter<std::string>("hitsProducer")),
-  trackerContainers(conf.getParameter<std::vector<std::string> >("ROUList")),
-  ZSDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("ZSDigi")),
-  SCDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("SCDigi")),
-  VRDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("VRDigi")),
-  PRDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("PRDigi")),
-  geometryType(conf.getParameter<std::string>("GeometryType")),
-  useConfFromDB(conf.getParameter<bool>("TrackerConfigurationFromDB")),
-  zeroSuppression(conf.getParameter<bool>("ZeroSuppression")),
-  makeDigiSimLinks_(conf.getUntrackedParameter<bool>("makeDigiSimLinks", false))
-{ 
+SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC)
+    : gainLabel(conf.getParameter<std::string>("Gain")),
+      hitsProducer(conf.getParameter<std::string>("hitsProducer")),
+      trackerContainers(conf.getParameter<std::vector<std::string>>("ROUList")),
+      ZSDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("ZSDigi")),
+      SCDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("SCDigi")),
+      VRDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("VRDigi")),
+      PRDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("PRDigi")),
+      geometryType(conf.getParameter<std::string>("GeometryType")),
+      useConfFromDB(conf.getParameter<bool>("TrackerConfigurationFromDB")),
+      zeroSuppression(conf.getParameter<bool>("ZeroSuppression")),
+      makeDigiSimLinks_(conf.getUntrackedParameter<bool>("makeDigiSimLinks", false)) {
   const std::string alias("simSiStripDigis");
-  
-  mixMod.produces<edm::DetSetVector<SiStripDigi> >(ZSDigi).setBranchAlias(ZSDigi);
-  mixMod.produces<edm::DetSetVector<SiStripRawDigi> >(SCDigi).setBranchAlias(alias + SCDigi);
-  mixMod.produces<edm::DetSetVector<SiStripRawDigi> >(VRDigi).setBranchAlias(alias + VRDigi);
-  mixMod.produces<edm::DetSetVector<SiStripRawDigi> >(PRDigi).setBranchAlias(alias + PRDigi);
-  mixMod.produces<edm::DetSetVector<StripDigiSimLink> >().setBranchAlias(alias + "siStripDigiSimLink");
-  mixMod.produces<std::vector<std::pair<int,std::bitset<6>>>>("AffectedAPVList").setBranchAlias(alias + "AffectedAPV");
-  for(auto const& trackerContainer : trackerContainers) {
+
+  mixMod.produces<edm::DetSetVector<SiStripDigi>>(ZSDigi).setBranchAlias(ZSDigi);
+  mixMod.produces<edm::DetSetVector<SiStripRawDigi>>(SCDigi).setBranchAlias(alias + SCDigi);
+  mixMod.produces<edm::DetSetVector<SiStripRawDigi>>(VRDigi).setBranchAlias(alias + VRDigi);
+  mixMod.produces<edm::DetSetVector<SiStripRawDigi>>(PRDigi).setBranchAlias(alias + PRDigi);
+  mixMod.produces<edm::DetSetVector<StripDigiSimLink>>().setBranchAlias(alias + "siStripDigiSimLink");
+  mixMod.produces<std::vector<std::pair<int, std::bitset<6>>>>("AffectedAPVList").setBranchAlias(alias + "AffectedAPV");
+  for (auto const& trackerContainer : trackerContainers) {
     edm::InputTag tag(hitsProducer, trackerContainer);
-    iC.consumes<std::vector<PSimHit> >(edm::InputTag(hitsProducer, trackerContainer));  
+    iC.consumes<std::vector<PSimHit>>(edm::InputTag(hitsProducer, trackerContainer));
   }
   edm::Service<edm::RandomNumberGenerator> rng;
-  if ( ! rng.isAvailable()) {
+  if (!rng.isAvailable()) {
     throw cms::Exception("Configuration")
-      << "SiStripDigitizer requires the RandomNumberGeneratorService\n"
-      "which is not present in the configuration file.  You must add the service\n"
-      "in the configuration file or remove the modules that require it.";
+        << "SiStripDigitizer requires the RandomNumberGeneratorService\n"
+           "which is not present in the configuration file.  You must add the service\n"
+           "in the configuration file or remove the modules that require it.";
   }
   theDigiAlgo.reset(new SiStripDigitizerAlgorithm(conf));
 }
 
 // Virtual destructor needed.
-SiStripDigitizer::~SiStripDigitizer() { 
-}  
+SiStripDigitizer::~SiStripDigitizer() {}
 
-void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit> > hSimHits,
-					   const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin) {
+void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit>> hSimHits,
+                                           const TrackerTopology* tTopo,
+                                           size_t globalSimHitIndex,
+                                           const unsigned int tofBin) {
   // globalSimHitIndex is the index the sim hit will have when it is put in a collection
   // of sim hits for all crossings. This is only used when creating digi-sim links if
   // configured to do so.
 
-  if(hSimHits.isValid()) {
+  if (hSimHits.isValid()) {
     std::set<unsigned int> detIds;
     std::vector<PSimHit> const& simHits = *hSimHits.product();
-    for(std::vector<PSimHit>::const_iterator it = simHits.begin(), itEnd = simHits.end(); it != itEnd; ++it, ++globalSimHitIndex ) {
+    for (std::vector<PSimHit>::const_iterator it = simHits.begin(), itEnd = simHits.end(); it != itEnd;
+         ++it, ++globalSimHitIndex) {
       unsigned int detId = (*it).detUnitId();
-      if(detIds.insert(detId).second) {
+      if (detIds.insert(detId).second) {
         // The insert succeeded, so this detector element has not yet been processed.
-	assert(detectorUnits[detId]);
-	if(detectorUnits[detId]->type().isTrackerStrip()) { // this test can be removed and replaced by stripdet!=0
-	  auto stripdet = detectorUnits[detId];
-	  //access to magnetic field in global coordinates
-	  GlobalVector bfield = pSetup->inTesla(stripdet->surface().position());
-	  LogDebug ("Digitizer ") << "B-field(T) at " << stripdet->surface().position() << "(cm): "
-				  << pSetup->inTesla(stripdet->surface().position());
-	  theDigiAlgo->accumulateSimHits(it, itEnd, globalSimHitIndex, tofBin, stripdet, bfield, tTopo, randomEngine_);
-	}
+        assert(detectorUnits[detId]);
+        if (detectorUnits[detId]->type().isTrackerStrip()) {  // this test can be removed and replaced by stripdet!=0
+          auto stripdet = detectorUnits[detId];
+          //access to magnetic field in global coordinates
+          GlobalVector bfield = pSetup->inTesla(stripdet->surface().position());
+          LogDebug("Digitizer ") << "B-field(T) at " << stripdet->surface().position()
+                                 << "(cm): " << pSetup->inTesla(stripdet->surface().position());
+          theDigiAlgo->accumulateSimHits(it, itEnd, globalSimHitIndex, tofBin, stripdet, bfield, tTopo, randomEngine_);
+        }
       }
-    } // end of loop over sim hits
+    }  // end of loop over sim hits
   }
 }
 
 // Functions that gets called by framework every event
-  void
-  SiStripDigitizer::accumulate(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
-    //Retrieve tracker topology from geometry
-    edm::ESHandle<TrackerTopology> tTopoHand;
-    iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-    const TrackerTopology *tTopo=tTopoHand.product();
+void SiStripDigitizer::accumulate(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+  //Retrieve tracker topology from geometry
+  edm::ESHandle<TrackerTopology> tTopoHand;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
+  const TrackerTopology* tTopo = tTopoHand.product();
 
-    // Step A: Get Inputs
-    for(auto const& trackerContainer : trackerContainers) {
-      edm::Handle<std::vector<PSimHit> > simHits;
-      edm::InputTag tag(hitsProducer, trackerContainer);
-      unsigned int tofBin = StripDigiSimLink::LowTof;
-      if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+  // Step A: Get Inputs
+  for (auto const& trackerContainer : trackerContainers) {
+    edm::Handle<std::vector<PSimHit>> simHits;
+    edm::InputTag tag(hitsProducer, trackerContainer);
+    unsigned int tofBin = StripDigiSimLink::LowTof;
+    if (trackerContainer.find(std::string("HighTof")) != std::string::npos)
+      tofBin = StripDigiSimLink::HighTof;
 
-      iEvent.getByLabel(tag, simHits);
-      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin);
-      // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
-      // the global counter. Next time accumulateStripHits() is called it will count the sim hits
-      // as though they were on the end of this collection.
-      // Note that this is only used for creating digi-sim links (if configured to do so).
-      if( simHits.isValid() ) crossingSimHitIndexOffset_[tag.encode()]+=simHits->size();
-    }
+    iEvent.getByLabel(tag, simHits);
+    accumulateStripHits(simHits, tTopo, crossingSimHitIndexOffset_[tag.encode()], tofBin);
+    // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
+    // the global counter. Next time accumulateStripHits() is called it will count the sim hits
+    // as though they were on the end of this collection.
+    // Note that this is only used for creating digi-sim links (if configured to do so).
+    if (simHits.isValid())
+      crossingSimHitIndexOffset_[tag.encode()] += simHits->size();
   }
+}
 
-  void
-  SiStripDigitizer::accumulate(PileUpEventPrincipal const& iEvent, edm::EventSetup const& iSetup, edm::StreamID const& streamID) {
+void SiStripDigitizer::accumulate(PileUpEventPrincipal const& iEvent,
+                                  edm::EventSetup const& iSetup,
+                                  edm::StreamID const& streamID) {
+  edm::ESHandle<TrackerTopology> tTopoHand;
+  iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
+  const TrackerTopology* tTopo = tTopoHand.product();
 
-    edm::ESHandle<TrackerTopology> tTopoHand;
-    iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-    const TrackerTopology *tTopo=tTopoHand.product();
+  //Re-compute luminosity for accumulation for HIP effects
+  theDigiAlgo->calculateInstlumiScale(PileupInfo_.get());
 
-    //Re-compute luminosity for accumulation for HIP effects
-    theDigiAlgo->calculateInstlumiScale(PileupInfo_.get());
+  // Step A: Get Inputs
+  for (auto const& trackerContainer : trackerContainers) {
+    edm::Handle<std::vector<PSimHit>> simHits;
+    edm::InputTag tag(hitsProducer, trackerContainer);
+    unsigned int tofBin = StripDigiSimLink::LowTof;
+    if (trackerContainer.find(std::string("HighTof")) != std::string::npos)
+      tofBin = StripDigiSimLink::HighTof;
 
-    // Step A: Get Inputs
-    for(auto const& trackerContainer : trackerContainers) {
-      edm::Handle<std::vector<PSimHit> > simHits;
-      edm::InputTag tag(hitsProducer, trackerContainer);
-      unsigned int tofBin = StripDigiSimLink::LowTof;
-      if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof; 
-
-      iEvent.getByLabel(tag, simHits);
-      accumulateStripHits(simHits,tTopo,crossingSimHitIndexOffset_[tag.encode()], tofBin);
-      // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
-      // the global counter. Next time accumulateStripHits() is called it will count the sim hits
-      // as though they were on the end of this collection.
-      // Note that this is only used for creating digi-sim links (if configured to do so).
-      if( simHits.isValid() ) crossingSimHitIndexOffset_[tag.encode()]+=simHits->size();
-    }
+    iEvent.getByLabel(tag, simHits);
+    accumulateStripHits(simHits, tTopo, crossingSimHitIndexOffset_[tag.encode()], tofBin);
+    // Now that the hits have been processed, I'll add the amount of hits in this crossing on to
+    // the global counter. Next time accumulateStripHits() is called it will count the sim hits
+    // as though they were on the end of this collection.
+    // Note that this is only used for creating digi-sim links (if configured to do so).
+    if (simHits.isValid())
+      crossingSimHitIndexOffset_[tag.encode()] += simHits->size();
   }
-
+}
 
 void SiStripDigitizer::initializeEvent(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   // Make sure that the first crossing processed starts indexing the sim hits from zero.
@@ -183,7 +186,7 @@ void SiStripDigitizer::initializeEvent(edm::Event const& iEvent, edm::EventSetup
   theAffectedAPVvector.clear();
   // Step A: Get Inputs
 
-  if(useConfFromDB){
+  if (useConfFromDB) {
     edm::ESHandle<SiStripDetCabling> detCabling;
     iSetup.get<SiStripDetCablingRcd>().get(detCabling);
     detCabling->addConnected(theDetIdList);
@@ -195,20 +198,20 @@ void SiStripDigitizer::initializeEvent(edm::Event const& iEvent, edm::EventSetup
 
   theDigiAlgo->initializeEvent(iSetup);
 
-  iSetup.get<TrackerDigiGeometryRecord>().get(geometryType,pDD);
+  iSetup.get<TrackerDigiGeometryRecord>().get(geometryType, pDD);
   iSetup.get<IdealMagneticFieldRecord>().get(pSetup);
 
   // FIX THIS! We only need to clear and (re)fill detectorUnits when the geometry type IOV changes.  Use ESWatcher to determine this.
   bool changes = true;
-  if(changes) { // Replace with ESWatcher
+  if (changes) {  // Replace with ESWatcher
     detectorUnits.clear();
   }
-  for( const auto& iu : pDD->detUnits()) {
+  for (const auto& iu : pDD->detUnits()) {
     unsigned int detId = iu->geographicalId().rawId();
-    if(iu->type().isTrackerStrip()) {
+    if (iu->type().isTrackerStrip()) {
       auto stripdet = dynamic_cast<StripGeomDetUnit const*>(iu);
       assert(stripdet != nullptr);
-      if(changes) { // Replace with ESWatcher
+      if (changes) {  // Replace with ESWatcher
         detectorUnits.insert(std::make_pair(detId, stripdet));
       }
       theDigiAlgo->initializeDetUnit(stripdet, iSetup);
@@ -221,72 +224,87 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
   edm::ESHandle<SiStripNoises> noiseHandle;
   edm::ESHandle<SiStripThreshold> thresholdHandle;
   edm::ESHandle<SiStripPedestals> pedestalHandle;
-  iSetup.get<SiStripGainSimRcd>().get(gainLabel,gainHandle);
+  iSetup.get<SiStripGainSimRcd>().get(gainLabel, gainHandle);
   iSetup.get<SiStripNoisesRcd>().get(noiseHandle);
   iSetup.get<SiStripThresholdRcd>().get(thresholdHandle);
   iSetup.get<SiStripPedestalsRcd>().get(pedestalHandle);
 
-  std::vector<edm::DetSet<SiStripDigi> > theDigiVector;
-  std::vector<edm::DetSet<SiStripRawDigi> > theRawDigiVector;
-  std::unique_ptr< edm::DetSetVector<StripDigiSimLink> > pOutputDigiSimLink( new edm::DetSetVector<StripDigiSimLink> );
- 
- 
+  std::vector<edm::DetSet<SiStripDigi>> theDigiVector;
+  std::vector<edm::DetSet<SiStripRawDigi>> theRawDigiVector;
+  std::unique_ptr<edm::DetSetVector<StripDigiSimLink>> pOutputDigiSimLink(new edm::DetSetVector<StripDigiSimLink>);
+
   // Step B: LOOP on StripGeomDetUnit
   theDigiVector.reserve(10000);
   theDigiVector.clear();
 
-  for( const auto& iu : pDD->detUnits()) {
-    if(useConfFromDB){
-      //apply the cable map _before_ digitization: consider only the detis that are connected 
-      if(theDetIdList.find(iu->geographicalId().rawId())==theDetIdList.end())
+  for (const auto& iu : pDD->detUnits()) {
+    if (useConfFromDB) {
+      //apply the cable map _before_ digitization: consider only the detis that are connected
+      if (theDetIdList.find(iu->geographicalId().rawId()) == theDetIdList.end())
         continue;
     }
     auto sgd = dynamic_cast<StripGeomDetUnit const*>(iu);
-    if (sgd != nullptr){
+    if (sgd != nullptr) {
       edm::DetSet<SiStripDigi> collectorZS(iu->geographicalId().rawId());
       edm::DetSet<SiStripRawDigi> collectorRaw(iu->geographicalId().rawId());
       edm::DetSet<StripDigiSimLink> collectorLink(iu->geographicalId().rawId());
-      theDigiAlgo->digitize(collectorZS,collectorRaw,collectorLink,sgd,
-                            gainHandle,thresholdHandle,noiseHandle,pedestalHandle,theAffectedAPVvector,randomEngine_);
-      if(zeroSuppression){
-        if(!collectorZS.data.empty()){
+      theDigiAlgo->digitize(collectorZS,
+                            collectorRaw,
+                            collectorLink,
+                            sgd,
+                            gainHandle,
+                            thresholdHandle,
+                            noiseHandle,
+                            pedestalHandle,
+                            theAffectedAPVvector,
+                            randomEngine_);
+      if (zeroSuppression) {
+        if (!collectorZS.data.empty()) {
           theDigiVector.push_back(collectorZS);
-          if( !collectorLink.data.empty() ) pOutputDigiSimLink->insert(collectorLink);
+          if (!collectorLink.data.empty())
+            pOutputDigiSimLink->insert(collectorLink);
         }
-      }else{
-        if(!collectorRaw.data.empty()){
+      } else {
+        if (!collectorRaw.data.empty()) {
           theRawDigiVector.push_back(collectorRaw);
-          if( !collectorLink.data.empty() ) pOutputDigiSimLink->insert(collectorLink);
+          if (!collectorLink.data.empty())
+            pOutputDigiSimLink->insert(collectorLink);
         }
       }
     }
   }
-  if(zeroSuppression){
+  if (zeroSuppression) {
     // Step C: create output collection
-    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_virginraw(new edm::DetSetVector<SiStripRawDigi>());
-    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_scopemode(new edm::DetSetVector<SiStripRawDigi>());
-    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_processedraw(new edm::DetSetVector<SiStripRawDigi>());
-    std::unique_ptr<edm::DetSetVector<SiStripDigi> > output(new edm::DetSetVector<SiStripDigi>(theDigiVector) );
-    std::unique_ptr<std::vector<std::pair<int,std::bitset<6>>> > AffectedAPVList(new std::vector<std::pair<int,std::bitset<6>>>(theAffectedAPVvector));
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi>> output_virginraw(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi>> output_scopemode(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi>> output_processedraw(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripDigi>> output(new edm::DetSetVector<SiStripDigi>(theDigiVector));
+    std::unique_ptr<std::vector<std::pair<int, std::bitset<6>>>> AffectedAPVList(
+        new std::vector<std::pair<int, std::bitset<6>>>(theAffectedAPVvector));
     // Step D: write output to file
     iEvent.put(std::move(output), ZSDigi);
     iEvent.put(std::move(output_scopemode), SCDigi);
     iEvent.put(std::move(output_virginraw), VRDigi);
     iEvent.put(std::move(output_processedraw), PRDigi);
-    iEvent.put(std::move(AffectedAPVList),"AffectedAPVList");
-    if( makeDigiSimLinks_ ) iEvent.put(std::move(pOutputDigiSimLink)); // The previous EDProducer didn't name this collection so I won't either
-  }else{
+    iEvent.put(std::move(AffectedAPVList), "AffectedAPVList");
+    if (makeDigiSimLinks_)
+      iEvent.put(
+          std::move(pOutputDigiSimLink));  // The previous EDProducer didn't name this collection so I won't either
+  } else {
     // Step C: create output collection
-    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_virginraw(new edm::DetSetVector<SiStripRawDigi>(theRawDigiVector));
-    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_scopemode(new edm::DetSetVector<SiStripRawDigi>());
-    std::unique_ptr<edm::DetSetVector<SiStripRawDigi> > output_processedraw(new edm::DetSetVector<SiStripRawDigi>());
-    std::unique_ptr<edm::DetSetVector<SiStripDigi> > output(new edm::DetSetVector<SiStripDigi>() );
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi>> output_virginraw(
+        new edm::DetSetVector<SiStripRawDigi>(theRawDigiVector));
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi>> output_scopemode(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripRawDigi>> output_processedraw(new edm::DetSetVector<SiStripRawDigi>());
+    std::unique_ptr<edm::DetSetVector<SiStripDigi>> output(new edm::DetSetVector<SiStripDigi>());
     // Step D: write output to file
     iEvent.put(std::move(output), ZSDigi);
     iEvent.put(std::move(output_scopemode), SCDigi);
     iEvent.put(std::move(output_virginraw), VRDigi);
     iEvent.put(std::move(output_processedraw), PRDigi);
-    if( makeDigiSimLinks_ ) iEvent.put(std::move(pOutputDigiSimLink)); // The previous EDProducer didn't name this collection so I won't either
+    if (makeDigiSimLinks_)
+      iEvent.put(
+          std::move(pOutputDigiSimLink));  // The previous EDProducer didn't name this collection so I won't either
   }
-  randomEngine_ = nullptr; // to prevent access outside event
+  randomEngine_ = nullptr;  // to prevent access outside event
 }

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -22,9 +22,10 @@ namespace edm {
   class Event;
   class EventSetup;
   class ParameterSet;
-  template<typename T> class Handle;
+  template <typename T>
+  class Handle;
   class StreamID;
-}
+}  // namespace edm
 
 class MagneticField;
 class PileUpEventPrincipal;
@@ -44,29 +45,33 @@ class TrackerGeometry;
 class SiStripDigitizer : public DigiAccumulatorMixMod {
 public:
   explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::ProducerBase& mixMod, edm::ConsumesCollector& iC);
-  
+
   ~SiStripDigitizer() override;
-  
+
   void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
   void accumulate(edm::Event const& e, edm::EventSetup const& c) override;
   void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, edm::StreamID const&) override;
   void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
 
-  void StorePileupInformation( std::vector<int> &numInteractionList,
-				       std::vector<int> &bunchCrossingList,
-				       std::vector<float> &TrueInteractionList,
-				       std::vector<edm::EventID> &eventInfoList, int bunchSpacing) override{
-    PileupInfo_ = std::make_unique<PileupMixingContent>(numInteractionList, bunchCrossingList, TrueInteractionList, eventInfoList, bunchSpacing);
-  } 
+  void StorePileupInformation(std::vector<int>& numInteractionList,
+                              std::vector<int>& bunchCrossingList,
+                              std::vector<float>& TrueInteractionList,
+                              std::vector<edm::EventID>& eventInfoList,
+                              int bunchSpacing) override {
+    PileupInfo_ = std::make_unique<PileupMixingContent>(
+        numInteractionList, bunchCrossingList, TrueInteractionList, eventInfoList, bunchSpacing);
+  }
 
   PileupMixingContent* getEventPileupInfo() override { return PileupInfo_.get(); }
 
-  
 private:
-  void accumulateStripHits(edm::Handle<std::vector<PSimHit> >, const TrackerTopology *tTopo, size_t globalSimHitIndex, const unsigned int tofBin);
+  void accumulateStripHits(edm::Handle<std::vector<PSimHit>>,
+                           const TrackerTopology* tTopo,
+                           size_t globalSimHitIndex,
+                           const unsigned int tofBin);
 
   typedef std::vector<std::string> vstring;
-  typedef std::map<unsigned int, std::vector<std::pair<const PSimHit*, int> >,std::less<unsigned int> > simhit_map;
+  typedef std::map<unsigned int, std::vector<std::pair<const PSimHit*, int>>, std::less<unsigned int>> simhit_map;
   typedef simhit_map::iterator simhit_map_iterator;
 
   const std::string gainLabel;
@@ -79,7 +84,7 @@ private:
   const std::string geometryType;
   const bool useConfFromDB;
   const bool zeroSuppression;
-  const bool makeDigiSimLinks_; 
+  const bool makeDigiSimLinks_;
 
   ///< Whether or not to create the association to sim truth collection. Set in configuration.
   /** @brief Offset to add to the index of each sim hit to account for which crossing it's in.
@@ -90,18 +95,17 @@ private:
    * hit in a given crossing. This assumes that the crossings are processed in the same order here as they are
    * put into the crossing frame, which I'm pretty sure is true.<br/>
    * The key is the name of the sim hit collection. */
-  std::map<std::string,size_t> crossingSimHitIndexOffset_;
+  std::map<std::string, size_t> crossingSimHitIndexOffset_;
 
   std::unique_ptr<SiStripDigitizerAlgorithm> theDigiAlgo;
-  std::map<uint32_t, std::vector<int> > theDetIdList;
+  std::map<uint32_t, std::vector<int>> theDetIdList;
   edm::ESHandle<TrackerGeometry> pDD;
   edm::ESHandle<MagneticField> pSetup;
-  std::map<unsigned int, StripGeomDetUnit const *> detectorUnits;
+  std::map<unsigned int, StripGeomDetUnit const*> detectorUnits;
   CLHEP::HepRandomEngine* randomEngine_ = nullptr;
-  std::vector<std::pair<int,std::bitset<6>>> theAffectedAPVvector;
+  std::vector<std::pair<int, std::bitset<6>>> theAffectedAPVvector;
 
   std::unique_ptr<PileupMixingContent> PileupInfo_;
-
 };
 
 #endif

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
@@ -35,90 +35,92 @@
 
 #include <boost/algorithm/string.hpp>
 
-SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& conf):
-  lorentzAngleName(conf.getParameter<std::string>("LorentzAngle")),
-  theThreshold(conf.getParameter<double>("NoiseSigmaThreshold")),
-  cmnRMStib(conf.getParameter<double>("cmnRMStib")),
-  cmnRMStob(conf.getParameter<double>("cmnRMStob")),
-  cmnRMStid(conf.getParameter<double>("cmnRMStid")),
-  cmnRMStec(conf.getParameter<double>("cmnRMStec")),
-  APVSaturationProbScaling_(conf.getParameter<double>("APVSaturationProbScaling")),
-  makeDigiSimLinks_(conf.getUntrackedParameter<bool>("makeDigiSimLinks", false)),
-  peakMode(conf.getParameter<bool>("APVpeakmode")),
-  noise(conf.getParameter<bool>("Noise")),
-  RealPedestals(conf.getParameter<bool>("RealPedestals")), 
-  SingleStripNoise(conf.getParameter<bool>("SingleStripNoise")),
-  CommonModeNoise(conf.getParameter<bool>("CommonModeNoise")),
-  BaselineShift(conf.getParameter<bool>("BaselineShift")),
-  APVSaturationFromHIP(conf.getParameter<bool>("APVSaturationFromHIP")),
-  theFedAlgo(conf.getParameter<int>("FedAlgorithm")),
-  zeroSuppression(conf.getParameter<bool>("ZeroSuppression")),
-  theElectronPerADC(conf.getParameter<double>( peakMode ? "electronPerAdcPeak" : "electronPerAdcDec" )),
-  theTOFCutForPeak(conf.getParameter<double>("TOFCutForPeak")),
-  theTOFCutForDeconvolution(conf.getParameter<double>("TOFCutForDeconvolution")),
-  tofCut(peakMode ? theTOFCutForPeak : theTOFCutForDeconvolution),
-  cosmicShift(conf.getUntrackedParameter<double>("CosmicDelayShift")),
-  inefficiency(conf.getParameter<double>("Inefficiency")),
-  pedOffset((unsigned int)conf.getParameter<double>("PedestalsOffset")),
-  PreMixing_(conf.getParameter<bool>("PreMixingMode")),
-  theSiHitDigitizer(new SiHitDigitizer(conf)),
-  theSiPileUpSignals(new SiPileUpSignals()),
-  theSiNoiseAdder(new SiGaussianTailNoiseAdder(theThreshold)),
-  theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, PreMixing_)),
-  theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
-  APVProbabilityFile(conf.getParameter<edm::FileInPath>("APVProbabilityFile")) {
-
+SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& conf)
+    : lorentzAngleName(conf.getParameter<std::string>("LorentzAngle")),
+      theThreshold(conf.getParameter<double>("NoiseSigmaThreshold")),
+      cmnRMStib(conf.getParameter<double>("cmnRMStib")),
+      cmnRMStob(conf.getParameter<double>("cmnRMStob")),
+      cmnRMStid(conf.getParameter<double>("cmnRMStid")),
+      cmnRMStec(conf.getParameter<double>("cmnRMStec")),
+      APVSaturationProbScaling_(conf.getParameter<double>("APVSaturationProbScaling")),
+      makeDigiSimLinks_(conf.getUntrackedParameter<bool>("makeDigiSimLinks", false)),
+      peakMode(conf.getParameter<bool>("APVpeakmode")),
+      noise(conf.getParameter<bool>("Noise")),
+      RealPedestals(conf.getParameter<bool>("RealPedestals")),
+      SingleStripNoise(conf.getParameter<bool>("SingleStripNoise")),
+      CommonModeNoise(conf.getParameter<bool>("CommonModeNoise")),
+      BaselineShift(conf.getParameter<bool>("BaselineShift")),
+      APVSaturationFromHIP(conf.getParameter<bool>("APVSaturationFromHIP")),
+      theFedAlgo(conf.getParameter<int>("FedAlgorithm")),
+      zeroSuppression(conf.getParameter<bool>("ZeroSuppression")),
+      theElectronPerADC(conf.getParameter<double>(peakMode ? "electronPerAdcPeak" : "electronPerAdcDec")),
+      theTOFCutForPeak(conf.getParameter<double>("TOFCutForPeak")),
+      theTOFCutForDeconvolution(conf.getParameter<double>("TOFCutForDeconvolution")),
+      tofCut(peakMode ? theTOFCutForPeak : theTOFCutForDeconvolution),
+      cosmicShift(conf.getUntrackedParameter<double>("CosmicDelayShift")),
+      inefficiency(conf.getParameter<double>("Inefficiency")),
+      pedOffset((unsigned int)conf.getParameter<double>("PedestalsOffset")),
+      PreMixing_(conf.getParameter<bool>("PreMixingMode")),
+      theSiHitDigitizer(new SiHitDigitizer(conf)),
+      theSiPileUpSignals(new SiPileUpSignals()),
+      theSiNoiseAdder(new SiGaussianTailNoiseAdder(theThreshold)),
+      theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, PreMixing_)),
+      theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
+      APVProbabilityFile(conf.getParameter<edm::FileInPath>("APVProbabilityFile")) {
   if (peakMode) {
-    LogDebug("StripDigiInfo")<<"APVs running in peak mode (poor time resolution)";
+    LogDebug("StripDigiInfo") << "APVs running in peak mode (poor time resolution)";
   } else {
-    LogDebug("StripDigiInfo")<<"APVs running in deconvolution mode (good time resolution)";
+    LogDebug("StripDigiInfo") << "APVs running in deconvolution mode (good time resolution)";
   };
-  if(SingleStripNoise) LogDebug("SiStripDigitizerAlgorithm")<<" SingleStripNoise: ON";
-  else LogDebug("SiStripDigitizerAlgorithm")<<" SingleStripNoise: OFF";
-  if(CommonModeNoise) LogDebug("SiStripDigitizerAlgorithm")<<" CommonModeNoise: ON";
-  else LogDebug("SiStripDigitizerAlgorithm")<<" CommonModeNoise: OFF";
-  if(PreMixing_ && APVSaturationFromHIP) throw cms::Exception("PreMixing does not work with HIP loss simulation yet");
-  if(APVSaturationFromHIP){  
-    std::string line; 
+  if (SingleStripNoise)
+    LogDebug("SiStripDigitizerAlgorithm") << " SingleStripNoise: ON";
+  else
+    LogDebug("SiStripDigitizerAlgorithm") << " SingleStripNoise: OFF";
+  if (CommonModeNoise)
+    LogDebug("SiStripDigitizerAlgorithm") << " CommonModeNoise: ON";
+  else
+    LogDebug("SiStripDigitizerAlgorithm") << " CommonModeNoise: OFF";
+  if (PreMixing_ && APVSaturationFromHIP)
+    throw cms::Exception("PreMixing does not work with HIP loss simulation yet");
+  if (APVSaturationFromHIP) {
+    std::string line;
     APVProbaFile.open((APVProbabilityFile.fullPath()).c_str());
-    if (APVProbaFile.is_open()){
-      while ( getline (APVProbaFile,line) ){
+    if (APVProbaFile.is_open()) {
+      while (getline(APVProbaFile, line)) {
         std::vector<std::string> strs;
-          boost::split(strs,line,boost::is_any_of(" "));
-          if(strs.size()==2){
-            mapOfAPVprobabilities[std::stoi(strs.at(0))]=std::stof(strs.at(1));
-          }
+        boost::split(strs, line, boost::is_any_of(" "));
+        if (strs.size() == 2) {
+          mapOfAPVprobabilities[std::stoi(strs.at(0))] = std::stof(strs.at(1));
+        }
       }
       APVProbaFile.close();
-    }else throw cms::Exception("MissingInput")
-         << "It seems that the APV probability list is missing\n";
+    } else
+      throw cms::Exception("MissingInput") << "It seems that the APV probability list is missing\n";
   }
 }
 
-SiStripDigitizerAlgorithm::~SiStripDigitizerAlgorithm(){
-}
+SiStripDigitizerAlgorithm::~SiStripDigitizerAlgorithm() {}
 
-void
-SiStripDigitizerAlgorithm::initializeDetUnit(StripGeomDetUnit const * det, const edm::EventSetup& iSetup){
+void SiStripDigitizerAlgorithm::initializeDetUnit(StripGeomDetUnit const* det, const edm::EventSetup& iSetup) {
   edm::ESHandle<SiStripBadStrip> deadChannelHandle;
   iSetup.get<SiStripBadChannelRcd>().get(deadChannelHandle);
 
   unsigned int detId = det->geographicalId().rawId();
-  int numStrips = (det->specificTopology()).nstrips();  
+  int numStrips = (det->specificTopology()).nstrips();
 
   SiStripBadStrip::Range detBadStripRange = deadChannelHandle->getRange(detId);
   //storing the bad strip of the the module. the module is not removed but just signal put to 0
   std::vector<bool>& badChannels = allBadChannels[detId];
   badChannels.clear();
   badChannels.insert(badChannels.begin(), numStrips, false);
-  for(SiStripBadStrip::ContainerIterator it = detBadStripRange.first; it != detBadStripRange.second; ++it) {
+  for (SiStripBadStrip::ContainerIterator it = detBadStripRange.first; it != detBadStripRange.second; ++it) {
     SiStripBadStrip::data fs = deadChannelHandle->decode(*it);
-    for(int strip = fs.firstStrip; strip < fs.firstStrip + fs.range; ++strip) {
-		badChannels[strip] = true;
-	}
+    for (int strip = fs.firstStrip; strip < fs.firstStrip + fs.range; ++strip) {
+      badChannels[strip] = true;
+    }
   }
   firstChannelsWithSignal[detId] = numStrips;
-  lastChannelsWithSignal[detId]= 0;
+  lastChannelsWithSignal[detId] = 0;
 
   //  if(APVSaturationFromHIP){
   //  std::bitset<6> &bs=SiStripTrackerAffectedAPVMap[detId];
@@ -126,8 +128,7 @@ SiStripDigitizerAlgorithm::initializeDetUnit(StripGeomDetUnit const * det, const
   //}
 }
 
-void
-SiStripDigitizerAlgorithm::initializeEvent(const edm::EventSetup& iSetup) {
+void SiStripDigitizerAlgorithm::initializeEvent(const edm::EventSetup& iSetup) {
   theSiPileUpSignals->reset();
   // This should be clear by after all calls to digitize(), but I might as well make sure
   associationInfoForDetId_.clear();
@@ -141,24 +142,23 @@ SiStripDigitizerAlgorithm::initializeEvent(const edm::EventSetup& iSetup) {
   edm::ESHandle<ParticleDataTable> pdt;
   iSetup.getData(pdt);
   setParticleDataTable(&*pdt);
-  iSetup.get<SiStripLorentzAngleSimRcd>().get(lorentzAngleName,lorentzAngleHandle);
+  iSetup.get<SiStripLorentzAngleSimRcd>().get(lorentzAngleName, lorentzAngleHandle);
 }
 
 //  Run the algorithm for a given module
 //  ------------------------------------
 
-void
-SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterator inputBegin,
-                                             std::vector<PSimHit>::const_iterator inputEnd,
-                                             size_t inputBeginGlobalIndex,
-					     unsigned int tofBin,
-                                             const StripGeomDetUnit* det,
-                                             const GlobalVector& bfield,
-					     const TrackerTopology *tTopo,
-                                             CLHEP::HepRandomEngine* engine) {
+void SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterator inputBegin,
+                                                  std::vector<PSimHit>::const_iterator inputEnd,
+                                                  size_t inputBeginGlobalIndex,
+                                                  unsigned int tofBin,
+                                                  const StripGeomDetUnit* det,
+                                                  const GlobalVector& bfield,
+                                                  const TrackerTopology* tTopo,
+                                                  CLHEP::HepRandomEngine* engine) {
   // produce SignalPoints for all SimHits in detector
   unsigned int detID = det->geographicalId().rawId();
-  int numStrips = (det->specificTopology()).nstrips();  
+  int numStrips = (det->specificTopology()).nstrips();
 
   size_t thisFirstChannelWithSignal = numStrips;
   size_t thisLastChannelWithSignal = 0;
@@ -171,381 +171,415 @@ SiStripDigitizerAlgorithm::accumulateSimHits(std::vector<PSimHit>::const_iterato
 
   uint32_t detId = det->geographicalId().rawId();
   // First: loop on the SimHits
-  if(CLHEP::RandFlat::shoot(engine) > inefficiency) {
-    AssociationInfoForChannel* pDetIDAssociationInfo; // I only need this if makeDigiSimLinks_ is true...
-    if( makeDigiSimLinks_ ) pDetIDAssociationInfo=&(associationInfoForDetId_[detId]); // ...so only search the map if that is the case
-    std::vector<float> previousLocalAmplitude; // Only used if makeDigiSimLinks_ is true. Needed to work out the change in amplitude.
+  if (CLHEP::RandFlat::shoot(engine) > inefficiency) {
+    AssociationInfoForChannel* pDetIDAssociationInfo;  // I only need this if makeDigiSimLinks_ is true...
+    if (makeDigiSimLinks_)
+      pDetIDAssociationInfo = &(associationInfoForDetId_[detId]);  // ...so only search the map if that is the case
+    std::vector<float>
+        previousLocalAmplitude;  // Only used if makeDigiSimLinks_ is true. Needed to work out the change in amplitude.
 
-    size_t simHitGlobalIndex=inputBeginGlobalIndex; // This needs to stored to create the digi-sim link later
-    for (std::vector<PSimHit>::const_iterator simHitIter = inputBegin; simHitIter != inputEnd; ++simHitIter, ++simHitGlobalIndex ) {
+    size_t simHitGlobalIndex = inputBeginGlobalIndex;  // This needs to stored to create the digi-sim link later
+    for (std::vector<PSimHit>::const_iterator simHitIter = inputBegin; simHitIter != inputEnd;
+         ++simHitIter, ++simHitGlobalIndex) {
       // skip hits not in this detector.
-      if((*simHitIter).detUnitId() != detId) {
+      if ((*simHitIter).detUnitId() != detId) {
         continue;
       }
       // check TOF
-      if (std::fabs(simHitIter->tof() - cosmicShift - det->surface().toGlobal(simHitIter->localPosition()).mag()/30.) < tofCut && simHitIter->energyLoss()>0) {
-        if( makeDigiSimLinks_ ) previousLocalAmplitude=locAmpl; // Not needed except to make the sim link association.
+      if (std::fabs(simHitIter->tof() - cosmicShift -
+                    det->surface().toGlobal(simHitIter->localPosition()).mag() / 30.) < tofCut &&
+          simHitIter->energyLoss() > 0) {
+        if (makeDigiSimLinks_)
+          previousLocalAmplitude = locAmpl;  // Not needed except to make the sim link association.
         size_t localFirstChannel = numStrips;
-        size_t localLastChannel  = 0;
+        size_t localLastChannel = 0;
         // process the hit
-        theSiHitDigitizer->processHit(&*simHitIter, *det, bfield, langle, locAmpl, localFirstChannel, localLastChannel, tTopo, engine);
- 
-        if(thisFirstChannelWithSignal > localFirstChannel) thisFirstChannelWithSignal = localFirstChannel;
-        if(thisLastChannelWithSignal < localLastChannel) thisLastChannelWithSignal = localLastChannel;
+        theSiHitDigitizer->processHit(
+            &*simHitIter, *det, bfield, langle, locAmpl, localFirstChannel, localLastChannel, tTopo, engine);
 
-        if( makeDigiSimLinks_ ) { // No need to do any of this if truth association was turned off in the configuration
-          for( size_t stripIndex=0; stripIndex<locAmpl.size(); ++stripIndex ) {
+        if (thisFirstChannelWithSignal > localFirstChannel)
+          thisFirstChannelWithSignal = localFirstChannel;
+        if (thisLastChannelWithSignal < localLastChannel)
+          thisLastChannelWithSignal = localLastChannel;
+
+        if (makeDigiSimLinks_) {  // No need to do any of this if truth association was turned off in the configuration
+          for (size_t stripIndex = 0; stripIndex < locAmpl.size(); ++stripIndex) {
             // Work out the amplitude from this SimHit from the difference of what it was before and what it is now
-            float signalFromThisSimHit=locAmpl[stripIndex]-previousLocalAmplitude[stripIndex];
-            if( signalFromThisSimHit!=0 ) { // If this SimHit had any contribution I need to record it.
-              auto& associationVector=(*pDetIDAssociationInfo)[stripIndex];
-              bool addNewEntry=true;
+            float signalFromThisSimHit = locAmpl[stripIndex] - previousLocalAmplitude[stripIndex];
+            if (signalFromThisSimHit != 0) {  // If this SimHit had any contribution I need to record it.
+              auto& associationVector = (*pDetIDAssociationInfo)[stripIndex];
+              bool addNewEntry = true;
               // Make sure the hit isn't in already. I've seen this a few times, it always seems to happen in pairs so I think
               // it's something to do with the stereo strips.
-              for( auto& associationInfo : associationVector ) {
-                if( associationInfo.trackID==simHitIter->trackId() && associationInfo.eventID==simHitIter->eventId() ) {
+              for (auto& associationInfo : associationVector) {
+                if (associationInfo.trackID == simHitIter->trackId() &&
+                    associationInfo.eventID == simHitIter->eventId()) {
                   // The hit is already in, so add this second contribution and move on
-                  associationInfo.contributionToADC+=signalFromThisSimHit;
-                  addNewEntry=false;
+                  associationInfo.contributionToADC += signalFromThisSimHit;
+                  addNewEntry = false;
                   break;
                 }
-              } // end of loop over associationVector
+              }  // end of loop over associationVector
               // If the hit wasn't already in create a new association info structure.
-              if( addNewEntry ) associationVector.push_back( AssociationInfo{ simHitIter->trackId(), simHitIter->eventId(), signalFromThisSimHit, simHitGlobalIndex, tofBin } );
-            } // end of "if( signalFromThisSimHit!=0 )"
-          } // end of loop over locAmpl strips
-        } // end of "if( makeDigiSimLinks_ )"
-      } // end of TOF check
-    } // end for
+              if (addNewEntry)
+                associationVector.push_back(AssociationInfo{
+                    simHitIter->trackId(), simHitIter->eventId(), signalFromThisSimHit, simHitGlobalIndex, tofBin});
+            }  // end of "if( signalFromThisSimHit!=0 )"
+          }    // end of loop over locAmpl strips
+        }      // end of "if( makeDigiSimLinks_ )"
+      }        // end of TOF check
+    }          // end for
   }
   theSiPileUpSignals->add(detID, locAmpl, thisFirstChannelWithSignal, thisLastChannelWithSignal);
 
-  if(firstChannelsWithSignal[detID] > thisFirstChannelWithSignal) firstChannelsWithSignal[detID] = thisFirstChannelWithSignal;
-  if(lastChannelsWithSignal[detID] < thisLastChannelWithSignal) lastChannelsWithSignal[detID] = thisLastChannelWithSignal;
+  if (firstChannelsWithSignal[detID] > thisFirstChannelWithSignal)
+    firstChannelsWithSignal[detID] = thisFirstChannelWithSignal;
+  if (lastChannelsWithSignal[detID] < thisLastChannelWithSignal)
+    lastChannelsWithSignal[detID] = thisLastChannelWithSignal;
 }
 
-//============================================================================                
-void SiStripDigitizerAlgorithm::calculateInstlumiScale(PileupMixingContent* puInfo){
-  //Instlumi scalefactor calculating for dynamic inefficiency                                 
+//============================================================================
+void SiStripDigitizerAlgorithm::calculateInstlumiScale(PileupMixingContent* puInfo) {
+  //Instlumi scalefactor calculating for dynamic inefficiency
 
   if (puInfo && FirstLumiCalc_) {
-
     const std::vector<int>& bunchCrossing = puInfo->getMix_bunchCrossing();
     const std::vector<float>& TrueInteractionList = puInfo->getMix_TrueInteractions();
-    const int bunchSpacing = puInfo->getMix_bunchSpacing();                                 
+    const int bunchSpacing = puInfo->getMix_bunchSpacing();
 
     double RevFreq = 11245.;
     double minBXsec = 70.0E-27;  // use 70mb as an approximation
     double Bunch = 2100.;        // 2016 value
-    if (bunchSpacing == 50) Bunch = Bunch/2.;
+    if (bunchSpacing == 50)
+      Bunch = Bunch / 2.;
 
     int pui = 0, p = 0;
     std::vector<int>::const_iterator pu;
     std::vector<int>::const_iterator pu0 = bunchCrossing.end();
 
-    for (pu=bunchCrossing.begin(); pu!=bunchCrossing.end(); ++pu) {
-      if (*pu==0) {
+    for (pu = bunchCrossing.begin(); pu != bunchCrossing.end(); ++pu) {
+      if (*pu == 0) {
         pu0 = pu;
         p = pui;
       }
       pui++;
     }
-    if (pu0!=bunchCrossing.end()) {  // found the in-time interaction
+    if (pu0 != bunchCrossing.end()) {  // found the in-time interaction
       double Tintr = TrueInteractionList.at(p);
-      double instLumi = Bunch*Tintr*RevFreq/minBXsec;
-      APVSaturationProb_ = instLumi/6.0E33;      
+      double instLumi = Bunch * Tintr * RevFreq / minBXsec;
+      APVSaturationProb_ = instLumi / 6.0E33;
     }
     FirstLumiCalc_ = false;
   }
 }
 
-//============================================================================                
+//============================================================================
 
-
-void
-SiStripDigitizerAlgorithm::digitize(
-			   edm::DetSet<SiStripDigi>& outdigi,
-			   edm::DetSet<SiStripRawDigi>& outrawdigi,
-			   edm::DetSet<StripDigiSimLink>& outLink,
-			   const StripGeomDetUnit *det,
-			   edm::ESHandle<SiStripGain> & gainHandle,
-			   edm::ESHandle<SiStripThreshold> & thresholdHandle,
-			   edm::ESHandle<SiStripNoises> & noiseHandle,
-			   edm::ESHandle<SiStripPedestals> & pedestalHandle,
-			   std::vector<std::pair<int,std::bitset<6>>> & theAffectedAPVvector,
-                           CLHEP::HepRandomEngine* engine) {
+void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
+                                         edm::DetSet<SiStripRawDigi>& outrawdigi,
+                                         edm::DetSet<StripDigiSimLink>& outLink,
+                                         const StripGeomDetUnit* det,
+                                         edm::ESHandle<SiStripGain>& gainHandle,
+                                         edm::ESHandle<SiStripThreshold>& thresholdHandle,
+                                         edm::ESHandle<SiStripNoises>& noiseHandle,
+                                         edm::ESHandle<SiStripPedestals>& pedestalHandle,
+                                         std::vector<std::pair<int, std::bitset<6>>>& theAffectedAPVvector,
+                                         CLHEP::HepRandomEngine* engine) {
   unsigned int detID = det->geographicalId().rawId();
-  int numStrips = (det->specificTopology()).nstrips();  
+  int numStrips = (det->specificTopology()).nstrips();
 
-  const SiPileUpSignals::SignalMapType* theSignal(theSiPileUpSignals->getSignal(detID));  
+  const SiPileUpSignals::SignalMapType* theSignal(theSiPileUpSignals->getSignal(detID));
 
   std::vector<float> detAmpl(numStrips, 0.);
-  if(theSignal) {
-    for(const auto& amp : *theSignal) {
+  if (theSignal) {
+    for (const auto& amp : *theSignal) {
       detAmpl[amp.first] = amp.second;
     }
   }
 
   //removing signal from the dead (and HIP effected) strips
   std::vector<bool>& badChannels = allBadChannels[detID];
-  for(int strip =0; strip < numStrips; ++strip) {
-    if(badChannels[strip]) {detAmpl[strip] = 0.;}
-  } 
+  for (int strip = 0; strip < numStrips; ++strip) {
+    if (badChannels[strip]) {
+      detAmpl[strip] = 0.;
+    }
+  }
 
-  if(APVSaturationFromHIP){
+  if (APVSaturationFromHIP) {
     //Implementation of the proper charge scaling function. Need consider resaturation effect:
     //The probability map gives  the probability that at least one HIP happened during the last N bunch crossings (cfr APV recovery time).
     //The impact on the charge depends on the clostest HIP occurance (in terms of bunch crossing).
     //The function discribing the APV recovery is therefore the weighted average function which takes into account all possibilities of HIP occurances across the last bx's.
 
     // do this step here because we now have access to luminosity information
-    if(FirstDigitize_) {
-
-      for(std::map<int,float>::iterator iter = mapOfAPVprobabilities.begin(); iter != mapOfAPVprobabilities.end(); ++iter){
-	std::bitset<6> bs;
-	for(int Napv=0;Napv<6;Napv++){
-	  float cursor=CLHEP::RandFlat::shoot(engine);
-	  bs[Napv]=cursor < iter->second*APVSaturationProb_ ? true:false;  //APVSaturationProb has been scaled by PU luminosity
-	}
-	SiStripTrackerAffectedAPVMap[iter->first]=bs;
+    if (FirstDigitize_) {
+      for (std::map<int, float>::iterator iter = mapOfAPVprobabilities.begin(); iter != mapOfAPVprobabilities.end();
+           ++iter) {
+        std::bitset<6> bs;
+        for (int Napv = 0; Napv < 6; Napv++) {
+          float cursor = CLHEP::RandFlat::shoot(engine);
+          bs[Napv] = cursor < iter->second * APVSaturationProb_
+                         ? true
+                         : false;  //APVSaturationProb has been scaled by PU luminosity
+        }
+        SiStripTrackerAffectedAPVMap[iter->first] = bs;
       }
 
-      NumberOfBxBetweenHIPandEvent=1e3;
-      bool HasAtleastOneAffectedAPV=false;
-      while(!HasAtleastOneAffectedAPV){
-	for(int bx=floor(300.0/25.0);bx>0;bx--){ //Reminder: make these numbers not hard coded!!
-	  float temp=CLHEP::RandFlat::shoot(engine)<0.5?1:0;
-	  if(temp==1 && bx<NumberOfBxBetweenHIPandEvent){
-	    NumberOfBxBetweenHIPandEvent=bx;
-	    HasAtleastOneAffectedAPV=true;
-	  }
-	}
+      NumberOfBxBetweenHIPandEvent = 1e3;
+      bool HasAtleastOneAffectedAPV = false;
+      while (!HasAtleastOneAffectedAPV) {
+        for (int bx = floor(300.0 / 25.0); bx > 0; bx--) {  //Reminder: make these numbers not hard coded!!
+          float temp = CLHEP::RandFlat::shoot(engine) < 0.5 ? 1 : 0;
+          if (temp == 1 && bx < NumberOfBxBetweenHIPandEvent) {
+            NumberOfBxBetweenHIPandEvent = bx;
+            HasAtleastOneAffectedAPV = true;
+          }
+        }
       }
 
       FirstDigitize_ = false;
     }
 
-    std::bitset<6> & bs=SiStripTrackerAffectedAPVMap[detID];
+    std::bitset<6>& bs = SiStripTrackerAffectedAPVMap[detID];
 
-    if(bs.any()){
+    if (bs.any()) {
       // store this information so it can be saved to the event later
-      theAffectedAPVvector.push_back(std::make_pair(detID,bs));
+      theAffectedAPVvector.push_back(std::make_pair(detID, bs));
 
-      if(!PreMixing_) {
+      if (!PreMixing_) {
+        // Here below is the scaling function which describes the evolution of the baseline (i.e. how the charge is suppressed).
+        // This must be replaced as soon as we have a proper modeling of the baseline evolution from VR runs
+        float Shift =
+            1 - NumberOfBxBetweenHIPandEvent / floor(300.0 / 25.0);  //Reminder: make these numbers not hardcoded!!
+        float randomX = CLHEP::RandFlat::shoot(engine);
+        float scalingValue = (randomX - Shift) * 10.0 / 7.0 - 3.0 / 7.0;
 
-	// Here below is the scaling function which describes the evolution of the baseline (i.e. how the charge is suppressed).
-	// This must be replaced as soon as we have a proper modeling of the baseline evolution from VR runs
-	float Shift=1-NumberOfBxBetweenHIPandEvent/floor(300.0/25.0); //Reminder: make these numbers not hardcoded!! 
-	float randomX=CLHEP::RandFlat::shoot(engine);
-	float scalingValue=(randomX-Shift)*10.0/7.0-3.0/7.0;
-
-	for(int strip =0; strip < numStrips; ++strip) {
-	  if(!badChannels[strip] &&  bs[strip/128]==1){
-	    detAmpl[strip] *=scalingValue>0?scalingValue:0.0;
-	  }
-	}
+        for (int strip = 0; strip < numStrips; ++strip) {
+          if (!badChannels[strip] && bs[strip / 128] == 1) {
+            detAmpl[strip] *= scalingValue > 0 ? scalingValue : 0.0;
+          }
+        }
       }
     }
   }
-
 
   SiStripNoises::Range detNoiseRange = noiseHandle->getRange(detID);
   SiStripApvGain::Range detGainRange = gainHandle->getRange(detID);
   SiStripPedestals::Range detPedestalRange = pedestalHandle->getRange(detID);
 
-// -----------------------------------------------------------
+  // -----------------------------------------------------------
 
   auto& firstChannelWithSignal = firstChannelsWithSignal[detID];
   auto& lastChannelWithSignal = lastChannelsWithSignal[detID];
-  auto iAssociationInfoByChannel=associationInfoForDetId_.find(detID); // Use an iterator so that I can easily remove it once finished
+  auto iAssociationInfoByChannel =
+      associationInfoForDetId_.find(detID);  // Use an iterator so that I can easily remove it once finished
 
-  if(zeroSuppression){
-
+  if (zeroSuppression) {
     //Adding the strip noise
-    //------------------------------------------------------  
-    if(noise){ 
-                         
-      if(SingleStripNoise){
-//      std::cout<<"In SSN, detId="<<detID<<std::endl;
-	std::vector<float> noiseRMSv; 
-	noiseRMSv.clear(); 
-	noiseRMSv.insert(noiseRMSv.begin(),numStrips,0.); 
-	for(int strip=0; strip< numStrips; ++strip){ 
-	  if(!badChannels[strip]){
-	    float gainValue = gainHandle->getStripGain(strip, detGainRange); 
-	    noiseRMSv[strip] = (noiseHandle->getNoise(strip,detNoiseRange))* theElectronPerADC/gainValue;
-	    //std::cout<<"<SiStripDigitizerAlgorithm::digitize>: gainValue: "<<gainValue<<"\tnoiseRMSv["<<strip<<"]: "<<noiseRMSv[strip]<<std::endl;
-	  }
-	}
-	theSiNoiseAdder->addNoiseVR(detAmpl, noiseRMSv, engine);
+    //------------------------------------------------------
+    if (noise) {
+      if (SingleStripNoise) {
+        //      std::cout<<"In SSN, detId="<<detID<<std::endl;
+        std::vector<float> noiseRMSv;
+        noiseRMSv.clear();
+        noiseRMSv.insert(noiseRMSv.begin(), numStrips, 0.);
+        for (int strip = 0; strip < numStrips; ++strip) {
+          if (!badChannels[strip]) {
+            float gainValue = gainHandle->getStripGain(strip, detGainRange);
+            noiseRMSv[strip] = (noiseHandle->getNoise(strip, detNoiseRange)) * theElectronPerADC / gainValue;
+            //std::cout<<"<SiStripDigitizerAlgorithm::digitize>: gainValue: "<<gainValue<<"\tnoiseRMSv["<<strip<<"]: "<<noiseRMSv[strip]<<std::endl;
+          }
+        }
+        theSiNoiseAdder->addNoiseVR(detAmpl, noiseRMSv, engine);
       } else {
-	int RefStrip = int(numStrips/2.);
-	while(RefStrip<numStrips&&badChannels[RefStrip]){ //if the refstrip is bad, I move up to when I don't find it 
-	  RefStrip++;
-	} 
-	if(RefStrip<numStrips){
-	  float RefgainValue = gainHandle->getStripGain(RefStrip, detGainRange);
-	  float RefnoiseRMS = noiseHandle->getNoise(RefStrip,detNoiseRange) *theElectronPerADC/RefgainValue; 
-	
-	  theSiNoiseAdder->addNoise(detAmpl,firstChannelWithSignal,lastChannelWithSignal,numStrips,RefnoiseRMS, engine);
-	  //std::cout<<"<SiStripDigitizerAlgorithm::digitize>: RefgainValue: "<<RefgainValue<<"\tRefnoiseRMS: "<<RefnoiseRMS<<std::endl;
-	}
+        int RefStrip = int(numStrips / 2.);
+        while (RefStrip < numStrips &&
+               badChannels[RefStrip]) {  //if the refstrip is bad, I move up to when I don't find it
+          RefStrip++;
+        }
+        if (RefStrip < numStrips) {
+          float RefgainValue = gainHandle->getStripGain(RefStrip, detGainRange);
+          float RefnoiseRMS = noiseHandle->getNoise(RefStrip, detNoiseRange) * theElectronPerADC / RefgainValue;
+
+          theSiNoiseAdder->addNoise(
+              detAmpl, firstChannelWithSignal, lastChannelWithSignal, numStrips, RefnoiseRMS, engine);
+          //std::cout<<"<SiStripDigitizerAlgorithm::digitize>: RefgainValue: "<<RefgainValue<<"\tRefnoiseRMS: "<<RefnoiseRMS<<std::endl;
+        }
       }
-    }//if noise
+    }  //if noise
 
     DigitalVecType digis;
-    theSiZeroSuppress->suppress(theSiDigitalConverter->convert(detAmpl, gainHandle, detID), digis, detID,noiseHandle,thresholdHandle);
+    theSiZeroSuppress->suppress(
+        theSiDigitalConverter->convert(detAmpl, gainHandle, detID), digis, detID, noiseHandle, thresholdHandle);
     // Now do the association to truth. Note that if truth association was turned off in the configuration this map
     // will be empty and the iterator will always equal associationInfoForDetId_.end().
-    if( iAssociationInfoByChannel!=associationInfoForDetId_.end() ) { // make sure the readings for this DetID aren't completely from noise
-      for( const auto& iDigi : digis ) {
-        auto& associationInfoByChannel=iAssociationInfoByChannel->second;
-        const std::vector<AssociationInfo>& associationInfo=associationInfoByChannel[iDigi.channel()];
+    if (iAssociationInfoByChannel !=
+        associationInfoForDetId_.end()) {  // make sure the readings for this DetID aren't completely from noise
+      for (const auto& iDigi : digis) {
+        auto& associationInfoByChannel = iAssociationInfoByChannel->second;
+        const std::vector<AssociationInfo>& associationInfo = associationInfoByChannel[iDigi.channel()];
 
         // Need to find the total from all sim hits, because this might not be the same as the total
         // digitised due to noise or whatever.
-        float totalSimADC=0;
-        for( const auto& iAssociationInfo : associationInfo ) totalSimADC+=iAssociationInfo.contributionToADC;
+        float totalSimADC = 0;
+        for (const auto& iAssociationInfo : associationInfo)
+          totalSimADC += iAssociationInfo.contributionToADC;
         // Now I know that I can loop again and create the links
-        for( const auto& iAssociationInfo : associationInfo ) {
+        for (const auto& iAssociationInfo : associationInfo) {
           // Note simHitGlobalIndex used to have +1 because TrackerHitAssociator (the only place I can find this value being used)
           // expected counting to start at 1, not 0.  Now changed.
-          outLink.push_back( StripDigiSimLink( iDigi.channel(), iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex, iAssociationInfo.tofBin, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
-        } // end of loop over associationInfo
-      } // end of loop over the digis
-    } // end of check that iAssociationInfoByChannel is a valid iterator
+          outLink.push_back(StripDigiSimLink(iDigi.channel(),
+                                             iAssociationInfo.trackID,
+                                             iAssociationInfo.simHitGlobalIndex,
+                                             iAssociationInfo.tofBin,
+                                             iAssociationInfo.eventID,
+                                             iAssociationInfo.contributionToADC / totalSimADC));
+        }  // end of loop over associationInfo
+      }    // end of loop over the digis
+    }      // end of check that iAssociationInfoByChannel is a valid iterator
     outdigi.data = digis;
-  }//if zeroSuppression
+  }  //if zeroSuppression
 
-  if(!zeroSuppression){
+  if (!zeroSuppression) {
     //if(noise){
-      // the constant pedestal offset is needed because
-      //   negative adc counts are not allowed in case
-      //   Pedestal and CMN subtraction is performed.
-      //   The pedestal value read from the conditions
-      //   is pedValue and after the pedestal subtraction
-      //   the baseline is zero. The Common Mode Noise
-      //   is not subtracted from the negative adc counts
-      //   channels. Adding pedOffset the baseline is set
-      //   to pedOffset after pedestal subtraction and CMN
-      //   is subtracted to all the channels since none of
-      //   them has negative adc value. The pedOffset is
-      //   treated as a constant component in the CMN
-      //   estimation and subtracted as CMN.
-      
-         
-		//calculating the charge deposited on each APV and subtracting the shift
-		//------------------------------------------------------
-		if(BaselineShift){
-		   theSiNoiseAdder->addBaselineShift(detAmpl, badChannels);
-		}
-		
-		//Adding the strip noise
-		//------------------------------------------------------						 
-		if(noise){
-		    std::vector<float> noiseRMSv;
-			noiseRMSv.clear();
-		    noiseRMSv.insert(noiseRMSv.begin(),numStrips,0.);
-			
-		    if(SingleStripNoise){
-			    for(int strip=0; strip< numStrips; ++strip){
-			  		if(!badChannels[strip]) noiseRMSv[strip] = (noiseHandle->getNoise(strip,detNoiseRange))* theElectronPerADC;
-			  	}
-			
-	    	} else {
-			    int RefStrip = 0; //int(numStrips/2.);
-		    	    while(RefStrip<numStrips&&badChannels[RefStrip]){ //if the refstrip is bad, I move up to when I don't find it
-					RefStrip++;
-				}
-				if(RefStrip<numStrips){
-					float noiseRMS = noiseHandle->getNoise(RefStrip,detNoiseRange) *theElectronPerADC;
-					for(int strip=0; strip< numStrips; ++strip){
-			       		if(!badChannels[strip]) noiseRMSv[strip] = noiseRMS;
-			  		}
-				}
-			}
-			
-                    theSiNoiseAdder->addNoiseVR(detAmpl, noiseRMSv, engine);
-		}			
-		
-		//adding the CMN
-		//------------------------------------------------------
-        if(CommonModeNoise){
-		  float cmnRMS = 0.;
-		  DetId  detId(detID);
-		  uint32_t SubDet = detId.subdetId();
-		  if(SubDet==3){
-		    cmnRMS = cmnRMStib;
-		  }else if(SubDet==4){
-		    cmnRMS = cmnRMStid;
-		  }else if(SubDet==5){
-		    cmnRMS = cmnRMStob;
-		  }else if(SubDet==6){
-		    cmnRMS = cmnRMStec;
-		  }
-		  cmnRMS *= theElectronPerADC;
-                  theSiNoiseAdder->addCMNoise(detAmpl, cmnRMS, badChannels, engine);
-		}
-		
-        		
-		//Adding the pedestals
-		//------------------------------------------------------
-		
-		std::vector<float> vPeds;
-		vPeds.clear();
-		vPeds.insert(vPeds.begin(),numStrips,0.);
-		
-		if(RealPedestals){
-		    for(int strip=0; strip< numStrips; ++strip){
-			   if(!badChannels[strip]) vPeds[strip] = (pedestalHandle->getPed(strip,detPedestalRange)+pedOffset)* theElectronPerADC;
-		    }
-        } else {
-		    for(int strip=0; strip< numStrips; ++strip){
-			  if(!badChannels[strip]) vPeds[strip] = pedOffset* theElectronPerADC;
-			}
-		}
-		
-		theSiNoiseAdder->addPedestals(detAmpl, vPeds);	
-		
-		 
-	//if(!RealPedestals&&!CommonModeNoise&&!noise&&!BaselineShift&&!APVSaturationFromHIP){
+    // the constant pedestal offset is needed because
+    //   negative adc counts are not allowed in case
+    //   Pedestal and CMN subtraction is performed.
+    //   The pedestal value read from the conditions
+    //   is pedValue and after the pedestal subtraction
+    //   the baseline is zero. The Common Mode Noise
+    //   is not subtracted from the negative adc counts
+    //   channels. Adding pedOffset the baseline is set
+    //   to pedOffset after pedestal subtraction and CMN
+    //   is subtracted to all the channels since none of
+    //   them has negative adc value. The pedOffset is
+    //   treated as a constant component in the CMN
+    //   estimation and subtracted as CMN.
+
+    //calculating the charge deposited on each APV and subtracting the shift
+    //------------------------------------------------------
+    if (BaselineShift) {
+      theSiNoiseAdder->addBaselineShift(detAmpl, badChannels);
+    }
+
+    //Adding the strip noise
+    //------------------------------------------------------
+    if (noise) {
+      std::vector<float> noiseRMSv;
+      noiseRMSv.clear();
+      noiseRMSv.insert(noiseRMSv.begin(), numStrips, 0.);
+
+      if (SingleStripNoise) {
+        for (int strip = 0; strip < numStrips; ++strip) {
+          if (!badChannels[strip])
+            noiseRMSv[strip] = (noiseHandle->getNoise(strip, detNoiseRange)) * theElectronPerADC;
+        }
+
+      } else {
+        int RefStrip = 0;  //int(numStrips/2.);
+        while (RefStrip < numStrips &&
+               badChannels[RefStrip]) {  //if the refstrip is bad, I move up to when I don't find it
+          RefStrip++;
+        }
+        if (RefStrip < numStrips) {
+          float noiseRMS = noiseHandle->getNoise(RefStrip, detNoiseRange) * theElectronPerADC;
+          for (int strip = 0; strip < numStrips; ++strip) {
+            if (!badChannels[strip])
+              noiseRMSv[strip] = noiseRMS;
+          }
+        }
+      }
+
+      theSiNoiseAdder->addNoiseVR(detAmpl, noiseRMSv, engine);
+    }
+
+    //adding the CMN
+    //------------------------------------------------------
+    if (CommonModeNoise) {
+      float cmnRMS = 0.;
+      DetId detId(detID);
+      uint32_t SubDet = detId.subdetId();
+      if (SubDet == 3) {
+        cmnRMS = cmnRMStib;
+      } else if (SubDet == 4) {
+        cmnRMS = cmnRMStid;
+      } else if (SubDet == 5) {
+        cmnRMS = cmnRMStob;
+      } else if (SubDet == 6) {
+        cmnRMS = cmnRMStec;
+      }
+      cmnRMS *= theElectronPerADC;
+      theSiNoiseAdder->addCMNoise(detAmpl, cmnRMS, badChannels, engine);
+    }
+
+    //Adding the pedestals
+    //------------------------------------------------------
+
+    std::vector<float> vPeds;
+    vPeds.clear();
+    vPeds.insert(vPeds.begin(), numStrips, 0.);
+
+    if (RealPedestals) {
+      for (int strip = 0; strip < numStrips; ++strip) {
+        if (!badChannels[strip])
+          vPeds[strip] = (pedestalHandle->getPed(strip, detPedestalRange) + pedOffset) * theElectronPerADC;
+      }
+    } else {
+      for (int strip = 0; strip < numStrips; ++strip) {
+        if (!badChannels[strip])
+          vPeds[strip] = pedOffset * theElectronPerADC;
+      }
+    }
+
+    theSiNoiseAdder->addPedestals(detAmpl, vPeds);
+
+    //if(!RealPedestals&&!CommonModeNoise&&!noise&&!BaselineShift&&!APVSaturationFromHIP){
     //  edm::LogWarning("SiStripDigitizer")<<"You are running the digitizer without Noise generation and without applying Zero Suppression. ARE YOU SURE???";
-    //}else{							 
-    
+    //}else{
+
     DigitalRawVecType rawdigis = theSiDigitalConverter->convertRaw(detAmpl, gainHandle, detID);
 
     // Now do the association to truth. Note that if truth association was turned off in the configuration this map
     // will be empty and the iterator will always equal associationInfoForDetId_.end().
-    if( iAssociationInfoByChannel!=associationInfoForDetId_.end() ) { // make sure the readings for this DetID aren't completely from noise
+    if (iAssociationInfoByChannel !=
+        associationInfoForDetId_.end()) {  // make sure the readings for this DetID aren't completely from noise
       // N.B. For the raw digis the channel is inferred from the position in the vector.
       // I'VE NOT TESTED THIS YET!!!!!
       // ToDo Test this properly.
-      for( size_t channel=0; channel<rawdigis.size(); ++channel ) {
-        auto& associationInfoByChannel=iAssociationInfoByChannel->second;
-        const auto iAssociationInfo=associationInfoByChannel.find(channel);
-        if( iAssociationInfo==associationInfoByChannel.end() ) continue; // Skip if there is no sim information for this channel (i.e. it's all noise)
-        const std::vector<AssociationInfo>& associationInfo=iAssociationInfo->second;
+      for (size_t channel = 0; channel < rawdigis.size(); ++channel) {
+        auto& associationInfoByChannel = iAssociationInfoByChannel->second;
+        const auto iAssociationInfo = associationInfoByChannel.find(channel);
+        if (iAssociationInfo == associationInfoByChannel.end())
+          continue;  // Skip if there is no sim information for this channel (i.e. it's all noise)
+        const std::vector<AssociationInfo>& associationInfo = iAssociationInfo->second;
 
         // Need to find the total from all sim hits, because this might not be the same as the total
         // digitised due to noise or whatever.
-        float totalSimADC=0;
-        for( const auto& iAssociationInfo : associationInfo ) totalSimADC+=iAssociationInfo.contributionToADC;
+        float totalSimADC = 0;
+        for (const auto& iAssociationInfo : associationInfo)
+          totalSimADC += iAssociationInfo.contributionToADC;
         // Now I know that I can loop again and create the links
-        for( const auto& iAssociationInfo : associationInfo ) {
+        for (const auto& iAssociationInfo : associationInfo) {
           // Note simHitGlobalIndex used to have +1 because TrackerHitAssociator (the only place I can find this value being used)
           // expected counting to start at 1, not 0.  Now changed.
-          outLink.push_back( StripDigiSimLink( channel, iAssociationInfo.trackID, iAssociationInfo.simHitGlobalIndex, iAssociationInfo.tofBin, iAssociationInfo.eventID, iAssociationInfo.contributionToADC/totalSimADC ) );
-        } // end of loop over associationInfo
-      } // end of loop over the digis
-    } // end of check that iAssociationInfoByChannel is a valid iterator
+          outLink.push_back(StripDigiSimLink(channel,
+                                             iAssociationInfo.trackID,
+                                             iAssociationInfo.simHitGlobalIndex,
+                                             iAssociationInfo.tofBin,
+                                             iAssociationInfo.eventID,
+                                             iAssociationInfo.contributionToADC / totalSimADC));
+        }  // end of loop over associationInfo
+      }    // end of loop over the digis
+    }      // end of check that iAssociationInfoByChannel is a valid iterator
 
     outrawdigi.data = rawdigis;
-	
-	//}
+
+    //}
   }
 
   // Now that I've finished with this entry in the map of associations, I can remove it.
   // Note that there might not be an association if the ADC reading is from noise in which
   // case associationIsValid will be false.
-  if( iAssociationInfoByChannel!=associationInfoForDetId_.end() ) associationInfoForDetId_.erase(iAssociationInfoByChannel);
+  if (iAssociationInfoByChannel != associationInfoForDetId_.end())
+    associationInfoForDetId_.erase(iAssociationInfoByChannel);
 }

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
@@ -51,20 +51,20 @@ namespace CLHEP {
 }
 
 class SiStripDigitizerAlgorithm {
- public:
+public:
   typedef SiDigitalConverter::DigitalVecType DigitalVecType;
   typedef SiDigitalConverter::DigitalRawVecType DigitalRawVecType;
   typedef SiPileUpSignals::SignalMapType SignalMapType;
-  typedef std::map< int, float, std::less<int> > hit_map_type;
+  typedef std::map<int, float, std::less<int>> hit_map_type;
   typedef float Amplitude;
-  
+
   // Constructor
   SiStripDigitizerAlgorithm(const edm::ParameterSet& conf);
 
   // Destructor
   ~SiStripDigitizerAlgorithm();
 
-  void initializeDetUnit(StripGeomDetUnit const * det, const edm::EventSetup& iSetup);
+  void initializeDetUnit(StripGeomDetUnit const* det, const edm::EventSetup& iSetup);
 
   void initializeEvent(const edm::EventSetup& iSetup);
 
@@ -72,49 +72,49 @@ class SiStripDigitizerAlgorithm {
   void accumulateSimHits(const std::vector<PSimHit>::const_iterator inputBegin,
                          const std::vector<PSimHit>::const_iterator inputEnd,
                          size_t inputBeginGlobalIndex,
-			 unsigned int tofBin,
-                         const StripGeomDetUnit *stripdet,
+                         unsigned int tofBin,
+                         const StripGeomDetUnit* stripdet,
                          const GlobalVector& bfield,
-			 const TrackerTopology *tTopo,
+                         const TrackerTopology* tTopo,
                          CLHEP::HepRandomEngine*);
 
-  void digitize(
-                edm::DetSet<SiStripDigi>& outDigis,
+  void digitize(edm::DetSet<SiStripDigi>& outDigis,
                 edm::DetSet<SiStripRawDigi>& outRawDigis,
                 edm::DetSet<StripDigiSimLink>& outLink,
                 const StripGeomDetUnit* stripdet,
                 edm::ESHandle<SiStripGain>&,
-                edm::ESHandle<SiStripThreshold>&, 
+                edm::ESHandle<SiStripThreshold>&,
                 edm::ESHandle<SiStripNoises>&,
                 edm::ESHandle<SiStripPedestals>&,
-		std::vector<std::pair<int,std::bitset<6>>> & theAffectedAPVvector,
+                std::vector<std::pair<int, std::bitset<6>>>& theAffectedAPVvector,
                 CLHEP::HepRandomEngine*);
 
   void calculateInstlumiScale(PileupMixingContent* puInfo);
 
   // ParticleDataTable
-  void setParticleDataTable(const ParticleDataTable * pardt) {
-  	theSiHitDigitizer->setParticleDataTable(pardt); 
-  	pdt= pardt; 
+  void setParticleDataTable(const ParticleDataTable* pardt) {
+    theSiHitDigitizer->setParticleDataTable(pardt);
+    pdt = pardt;
   }
-  
- private:
+
+private:
   const std::string lorentzAngleName;
   const double theThreshold;
   const double cmnRMStib;
   const double cmnRMStob;
   const double cmnRMStid;
   const double cmnRMStec;
-  const double APVSaturationProbScaling_;          
-  const bool makeDigiSimLinks_; //< Whether or not to create the association to sim truth collection. Set in configuration.
+  const double APVSaturationProbScaling_;
+  const bool
+      makeDigiSimLinks_;  //< Whether or not to create the association to sim truth collection. Set in configuration.
   const bool peakMode;
   const bool noise;
-  const bool RealPedestals;              
-  const bool SingleStripNoise;          
-  const bool CommonModeNoise;           
-  const bool BaselineShift;             
+  const bool RealPedestals;
+  const bool SingleStripNoise;
+  const bool CommonModeNoise;
+  const bool BaselineShift;
   const bool APVSaturationFromHIP;
-  
+
   const int theFedAlgo;
   const bool zeroSuppression;
   const double theElectronPerADC;
@@ -126,13 +126,13 @@ class SiStripDigitizerAlgorithm {
   const double pedOffset;
   const bool PreMixing_;
 
-  const ParticleDataTable * pdt;
-  const ParticleData * particle;
+  const ParticleDataTable* pdt;
+  const ParticleData* particle;
 
   double APVSaturationProb_;
   bool FirstLumiCalc_;
   bool FirstDigitize_;
-  
+
   const std::unique_ptr<SiHitDigitizer> theSiHitDigitizer;
   const std::unique_ptr<SiPileUpSignals> theSiPileUpSignals;
   const std::unique_ptr<const SiGaussianTailNoiseAdder> theSiNoiseAdder;
@@ -140,8 +140,8 @@ class SiStripDigitizerAlgorithm {
   const std::unique_ptr<SiStripFedZeroSuppression> theSiZeroSuppress;
 
   // bad channels for each detector ID
-  std::map<unsigned int, std::vector<bool> > allBadChannels;
-  std::map<unsigned int, std::vector<bool> > allHIPChannels;
+  std::map<unsigned int, std::vector<bool>> allBadChannels;
+  std::map<unsigned int, std::vector<bool>> allHIPChannels;
   // first and last channel wit signal for each detector ID
   std::map<unsigned int, size_t> firstChannelsWithSignal;
   std::map<unsigned int, size_t> lastChannelsWithSignal;
@@ -151,25 +151,24 @@ class SiStripDigitizerAlgorithm {
 
   /** This structure is used to keep track of the SimTrack that contributed to each digi
       so that the truth association can be created.*/
-  struct AssociationInfo
-  {
+  struct AssociationInfo {
     unsigned int trackID;
     EncodedEventId eventID;
     float contributionToADC;
-    size_t simHitGlobalIndex; ///< The array index of the sim hit, but in the array for all crossings
+    size_t simHitGlobalIndex;  ///< The array index of the sim hit, but in the array for all crossings
     unsigned int tofBin;  // Needed along with subDet to determine which PSimHit collection simHitGlobalIndex indexes
   };
 
-  typedef std::map<int, std::vector<AssociationInfo> >  AssociationInfoForChannel;
-  typedef std::map<uint32_t, AssociationInfoForChannel>  AssociationInfoForDetId;
+  typedef std::map<int, std::vector<AssociationInfo>> AssociationInfoForChannel;
+  typedef std::map<uint32_t, AssociationInfoForChannel> AssociationInfoForDetId;
   /// Structure that holds the information on the SimTrack contributions. Only filled if makeDigiSimLinks_ is true.
   AssociationInfoForDetId associationInfoForDetId_;
-  
+
   edm::FileInPath APVProbabilityFile;
 
   std::ifstream APVProbaFile;
-  std::map < int , float> mapOfAPVprobabilities;
-  std::map < int , std::bitset<6> > SiStripTrackerAffectedAPVMap;
+  std::map<int, float> mapOfAPVprobabilities;
+  std::map<int, std::bitset<6>> SiStripTrackerAffectedAPVMap;
   int NumberOfBxBetweenHIPandEvent;
 };
 

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.cc
@@ -16,99 +16,117 @@ namespace {
     Count() {}
 #ifdef SISTRIP_COUNT
     // note: this code is not thread safe, counts will be inaccurate if run with multiple threads
-    double ncall=0;
-    double ndep=0, ndep2=0, maxdep=0;
-    double nstr=0, nstr2=0;
-    double ncv=0, nval=0, nval2=0, maxv=0;
-    double dzero=0;
-    void dep(double d) { ncall++; ndep+=d; ndep2+=d*d;maxdep=std::max(d,maxdep);}
-    void str(double d) { nstr+=d; nstr2+=d*d;}
-    void val(double d) { ncv++; nval+=d; nval2+=d*d; maxv=std::max(d,maxv);}
-    void zero() { dzero++;}    
+    double ncall = 0;
+    double ndep = 0, ndep2 = 0, maxdep = 0;
+    double nstr = 0, nstr2 = 0;
+    double ncv = 0, nval = 0, nval2 = 0, maxv = 0;
+    double dzero = 0;
+    void dep(double d) {
+      ncall++;
+      ndep += d;
+      ndep2 += d * d;
+      maxdep = std::max(d, maxdep);
+    }
+    void str(double d) {
+      nstr += d;
+      nstr2 += d * d;
+    }
+    void val(double d) {
+      ncv++;
+      nval += d;
+      nval2 += d * d;
+      maxv = std::max(d, maxv);
+    }
+    void zero() { dzero++; }
     ~Count() {
-      std::cout << "deposits " << ncall << " " << maxdep << " " << ndep/ncall << " " << std::sqrt(ndep2*ncall -ndep*ndep)/ncall << std::endl;
+      std::cout << "deposits " << ncall << " " << maxdep << " " << ndep / ncall << " "
+                << std::sqrt(ndep2 * ncall - ndep * ndep) / ncall << std::endl;
       std::cout << "zeros " << dzero << std::endl;
-      std::cout << "strips  " << nstr/ndep << " " << std::sqrt(nstr2*ndep -nstr*nstr)/ndep << std::endl;
-      std::cout << "vaules  " << ncv << " " << maxv << " " << nval/ncv << " " << std::sqrt(nval2*ncv -nval*nval)/ncv << std::endl;
+      std::cout << "strips  " << nstr / ndep << " " << std::sqrt(nstr2 * ndep - nstr * nstr) / ndep << std::endl;
+      std::cout << "vaules  " << ncv << " " << maxv << " " << nval / ncv << " "
+                << std::sqrt(nval2 * ncv - nval * nval) / ncv << std::endl;
     }
   };
- Count count;
+  Count count;
 #else
     void dep(double) const {}
     void str(double) const {}
     void val(double) const {}
-    void zero() const {}    
- };
- const Count count;
+    void zero() const {}
+  };
+  const Count count;
 #endif
-  
-}
 
+}  // namespace
 
 namespace {
   constexpr int Ntypes = 14;
   //                                   0     1      2     3     4    5      6     7
-  const std::string type[Ntypes] = { "IB1", "IB2","OB1","OB2","W1a","W2a","W3a","W1b","W2b","W3b","W4","W5","W6","W7"};
-  enum { indexOfIB1=0, indexOfIB2=1,  indexOfOB1=2, indexOfOB2=3, indexOfW1a=4, indexOfW1b=7}; 
+  const std::string type[Ntypes] = {
+      "IB1", "IB2", "OB1", "OB2", "W1a", "W2a", "W3a", "W1b", "W2b", "W3b", "W4", "W5", "W6", "W7"};
+  enum { indexOfIB1 = 0, indexOfIB2 = 1, indexOfOB1 = 2, indexOfOB2 = 3, indexOfW1a = 4, indexOfW1b = 7 };
 
-  inline
-  std::vector<std::vector<float> >
-  fillSignalCoupling(const edm::ParameterSet& conf, int nTypes, const std::string* typeArray) {
+  inline std::vector<std::vector<float> > fillSignalCoupling(const edm::ParameterSet& conf,
+                                                             int nTypes,
+                                                             const std::string* typeArray) {
     std::vector<std::vector<float> > signalCoupling;
     signalCoupling.reserve(nTypes);
     std::string mode = conf.getParameter<bool>("APVpeakmode") ? "Peak" : "Dec";
-    for(int i=0; i<nTypes; ++i) {
-
+    for (int i = 0; i < nTypes; ++i) {
       std::string version = "";
-      if( typeArray[i].find("W") != std::string::npos && mode == "Dec" )
-        version =  conf.getParameter<bool>("CouplingConstantsRunIIDecW") ? "RunII" : "";
-      else if( typeArray[i].find("B") != std::string::npos  && mode == "Dec")
-        version =  conf.getParameter<bool>("CouplingConstantsRunIIDecB") ? "RunII" : "";
+      if (typeArray[i].find("W") != std::string::npos && mode == "Dec")
+        version = conf.getParameter<bool>("CouplingConstantsRunIIDecW") ? "RunII" : "";
+      else if (typeArray[i].find("B") != std::string::npos && mode == "Dec")
+        version = conf.getParameter<bool>("CouplingConstantsRunIIDecB") ? "RunII" : "";
 
-      auto dc = conf.getParameter<std::vector<double> >("CouplingConstant"+version+mode+typeArray[i]);
-      signalCoupling.emplace_back(dc.begin(),dc.end());
+      auto dc = conf.getParameter<std::vector<double> >("CouplingConstant" + version + mode + typeArray[i]);
+      signalCoupling.emplace_back(dc.begin(), dc.end());
     }
     return signalCoupling;
   }
 
-  inline unsigned int typeOf(const StripGeomDetUnit& det, const TrackerTopology *tTopo) {
+  inline unsigned int typeOf(const StripGeomDetUnit& det, const TrackerTopology* tTopo) {
     DetId id = det.geographicalId();
     switch (det.specificType().subDetector()) {
-    case GeomDetEnumerators::TIB: {return (tTopo->tibLayer(id) < 3) ? indexOfIB1 : indexOfIB2;}
-    case GeomDetEnumerators::TOB: {return (tTopo->tobLayer(id) > 4) ? indexOfOB1 : indexOfOB2;}
-    case GeomDetEnumerators::TID: {return indexOfW1a -1 + tTopo->tidRing(id);} //fragile: relies on ordering of 'type'
-    case GeomDetEnumerators::TEC: {return indexOfW1b -1 + tTopo->tecRing(id);} //fragile: relies on ordering of 'type'
-    default: throw cms::Exception("Invalid subdetector") << id();
+      case GeomDetEnumerators::TIB: {
+        return (tTopo->tibLayer(id) < 3) ? indexOfIB1 : indexOfIB2;
+      }
+      case GeomDetEnumerators::TOB: {
+        return (tTopo->tobLayer(id) > 4) ? indexOfOB1 : indexOfOB2;
+      }
+      case GeomDetEnumerators::TID: {
+        return indexOfW1a - 1 + tTopo->tidRing(id);
+      }  //fragile: relies on ordering of 'type'
+      case GeomDetEnumerators::TEC: {
+        return indexOfW1b - 1 + tTopo->tecRing(id);
+      }  //fragile: relies on ordering of 'type'
+      default:
+        throw cms::Exception("Invalid subdetector") << id();
     }
   }
 
-  inline double
-  chargeDeposited(size_t strip, size_t Nstrips, double amplitude, double chargeSpread, double chargePosition)  {
-    double integralUpToStrip = (strip == 0)         ? 0. : ( approx_erf(   (strip-chargePosition)/chargeSpread/1.41421356237309515 ) );
-    double integralUpToNext  = (strip+1 == Nstrips) ? 1. : ( approx_erf(   (strip+1-chargePosition)/chargeSpread/1.41421356237309515 ) );
-    
-    return  0.5 * (integralUpToNext - integralUpToStrip) * amplitude;
+  inline double chargeDeposited(
+      size_t strip, size_t Nstrips, double amplitude, double chargeSpread, double chargePosition) {
+    double integralUpToStrip =
+        (strip == 0) ? 0. : (approx_erf((strip - chargePosition) / chargeSpread / 1.41421356237309515));
+    double integralUpToNext =
+        (strip + 1 == Nstrips) ? 1. : (approx_erf((strip + 1 - chargePosition) / chargeSpread / 1.41421356237309515));
+
+    return 0.5 * (integralUpToNext - integralUpToStrip) * amplitude;
   }
-  
-}
 
+}  // namespace
 
-SiTrivialInduceChargeOnStrips::
-SiTrivialInduceChargeOnStrips(const edm::ParameterSet& conf,double g) 
-  : signalCoupling(fillSignalCoupling(conf, Ntypes, type)), Nsigma(3.), geVperElectron(g)  {
-}
+SiTrivialInduceChargeOnStrips::SiTrivialInduceChargeOnStrips(const edm::ParameterSet& conf, double g)
+    : signalCoupling(fillSignalCoupling(conf, Ntypes, type)), Nsigma(3.), geVperElectron(g) {}
 
-void 
-SiTrivialInduceChargeOnStrips::
-induce(const SiChargeCollectionDrifter::collection_type& collection_points, 
-       const StripGeomDetUnit& det, 
-       std::vector<float>& localAmplitudes,
-       size_t& recordMinAffectedStrip, 
-       size_t& recordMaxAffectedStrip,
-       const TrackerTopology *tTopo) const {
-
-
-   induceVector(collection_points, det, localAmplitudes, recordMinAffectedStrip, recordMaxAffectedStrip, tTopo);
+void SiTrivialInduceChargeOnStrips::induce(const SiChargeCollectionDrifter::collection_type& collection_points,
+                                           const StripGeomDetUnit& det,
+                                           std::vector<float>& localAmplitudes,
+                                           size_t& recordMinAffectedStrip,
+                                           size_t& recordMaxAffectedStrip,
+                                           const TrackerTopology* tTopo) const {
+  induceVector(collection_points, det, localAmplitudes, recordMinAffectedStrip, recordMaxAffectedStrip, tTopo);
 
   /*
   auto ominA=recordMinAffectedStrip, omaxA=recordMaxAffectedStrip;
@@ -143,33 +161,30 @@ induce(const SiChargeCollectionDrifter::collection_type& collection_points,
   recordMinAffectedStrip=minA;
   recordMaxAffectedStrip=maxA;
   */
-
 }
 
-void 
-SiTrivialInduceChargeOnStrips::
-induceVector(const SiChargeCollectionDrifter::collection_type& collection_points, 
-	       const StripGeomDetUnit& det, 
-	       std::vector<float>& localAmplitudes, 
-	       size_t& recordMinAffectedStrip, 
-	       size_t& recordMaxAffectedStrip,
-	       const TrackerTopology *tTopo) const {
-
-
-  auto const & coupling = signalCoupling[typeOf(det,tTopo)];
+void SiTrivialInduceChargeOnStrips::induceVector(const SiChargeCollectionDrifter::collection_type& collection_points,
+                                                 const StripGeomDetUnit& det,
+                                                 std::vector<float>& localAmplitudes,
+                                                 size_t& recordMinAffectedStrip,
+                                                 size_t& recordMaxAffectedStrip,
+                                                 const TrackerTopology* tTopo) const {
+  auto const& coupling = signalCoupling[typeOf(det, tTopo)];
   const StripTopology& topology = dynamic_cast<const StripTopology&>(det.specificTopology());
-  const int Nstrips =  topology.nstrips();
+  const int Nstrips = topology.nstrips();
 
-  if (Nstrips == 0) return;
+  if (Nstrips == 0)
+    return;
 
   const int NP = collection_points.size();
-  if(0==NP) return;
+  if (0 == NP)
+    return;
 
   constexpr int MaxN = 512;
   // if NP too large split...
 
-  for (int ip=0; ip<NP; ip+=MaxN) {
-    auto N = std::min(NP-ip,MaxN);
+  for (int ip = 0; ip < NP; ip += MaxN) {
+    auto N = std::min(NP - ip, MaxN);
 
     count.dep(N);
     float amplitude[N];
@@ -180,129 +195,132 @@ induceVector(const SiChargeCollectionDrifter::collection_type& collection_points
 
     // load not vectorize
     //In strip coordinates:
-    for (int i=0; i!=N;++i) {
-      auto j = ip+i;
-      if (0==collection_points[j].amplitude()) count.zero();
-      chargePosition[i]=topology.strip(collection_points[j].position());
-      chargeSpread[i]= collection_points[j].sigma() / topology.localPitch(collection_points[j].position());
-      amplitude[i]=0.5f*collection_points[j].amplitude() / geVperElectron;
+    for (int i = 0; i != N; ++i) {
+      auto j = ip + i;
+      if (0 == collection_points[j].amplitude())
+        count.zero();
+      chargePosition[i] = topology.strip(collection_points[j].position());
+      chargeSpread[i] = collection_points[j].sigma() / topology.localPitch(collection_points[j].position());
+      amplitude[i] = 0.5f * collection_points[j].amplitude() / geVperElectron;
     }
-    
+
     // this vectorize
-    for (int i=0; i!=N;++i) {
-      fromStrip[i]  = std::max( 0,  int(std::floor( chargePosition[i] - Nsigma*chargeSpread[i])) );
-      nStrip[i] = std::min( Nstrips, int(std::ceil( chargePosition[i] + Nsigma*chargeSpread[i])) ) - fromStrip[i];
+    for (int i = 0; i != N; ++i) {
+      fromStrip[i] = std::max(0, int(std::floor(chargePosition[i] - Nsigma * chargeSpread[i])));
+      nStrip[i] = std::min(Nstrips, int(std::ceil(chargePosition[i] + Nsigma * chargeSpread[i]))) - fromStrip[i];
     }
-    int tot=0;
-    for (int i=0; i!=N;++i) tot += nStrip[i];
-    tot+=N; // add last strip 
+    int tot = 0;
+    for (int i = 0; i != N; ++i)
+      tot += nStrip[i];
+    tot += N;  // add last strip
     count.val(tot);
     float value[tot];
-    
+
     // assign relative position (lower bound of strip) in value;
-    int kk=0;
-    for (int i=0; i!=N;++i) {
-      auto delta = 1.f/(std::sqrt(2.f)*chargeSpread[i]);
-      auto pos = delta*(float(fromStrip[i])-chargePosition[i]);
+    int kk = 0;
+    for (int i = 0; i != N; ++i) {
+      auto delta = 1.f / (std::sqrt(2.f) * chargeSpread[i]);
+      auto pos = delta * (float(fromStrip[i]) - chargePosition[i]);
 
       // VI: before value[0] was not defined and value[tot] was filled
       //     to fix this the loop below was changed
-      for (int j=0;j<=nStrip[i]; ++j) { /// include last strip
-	value[kk] = pos+float(j)*delta;
-        ++kk;  
+      for (int j = 0; j <= nStrip[i]; ++j) {  /// include last strip
+        value[kk] = pos + float(j) * delta;
+        ++kk;
       }
     }
-    assert(kk==tot);
-    
+    assert(kk == tot);
+
     // main loop fully vectorized
-    for (int k=0;k!=tot; ++k)
+    for (int k = 0; k != tot; ++k)
       value[k] = approx_erf(value[k]);
-    
+
     // saturate 0 & NStrips strip to 0 and 1???
-    kk=0;
-    for (int i=0; i!=N;++i) {
-      if (0 == fromStrip[i])  value[kk]=0;
-      kk+=nStrip[i];
-      if (Nstrips == fromStrip[i]+nStrip[i]) value[kk]=1.f;
+    kk = 0;
+    for (int i = 0; i != N; ++i) {
+      if (0 == fromStrip[i])
+        value[kk] = 0;
+      kk += nStrip[i];
+      if (Nstrips == fromStrip[i] + nStrip[i])
+        value[kk] = 1.f;
       ++kk;
     }
-    assert(kk==tot);
-    
-    // compute integral over strip (lower bound becomes the value)
-    for (int k=0;k!=tot-1; ++k)
-      value[k]-=value[k+1];  // this is negative!
-    
-    
-    float charge[Nstrips]; for (int i=0;i!=Nstrips; ++i) charge[i]=0;
-    kk=0;
-    for (int i=0; i!=N;++i){ 
-      for (int j=0;j!=nStrip[i]; ++j)
-	charge[fromStrip[i]+j]-= amplitude[i]*value[kk++];
-      ++kk; // skip last "strip"
-    }
-    assert(kk==tot);
-    
-    
-    /// do crosstalk... (can be done better, most probably not worth)
-    int minA=recordMinAffectedStrip, maxA=recordMaxAffectedStrip;
-    int sc = coupling.size();
-    for (int i=0;i!=Nstrips; ++i) {
-      int strip = i;
-      if (0==charge[i]) continue;
-      auto affectedFromStrip  = std::max( 0, strip - sc + 1);
-      auto affectedUntilStrip = std::min(Nstrips, strip + sc);  
-      for (auto affectedStrip=affectedFromStrip;  affectedStrip < affectedUntilStrip;  ++affectedStrip)
-	localAmplitudes[affectedStrip] += charge[i] * coupling[std::abs(affectedStrip - strip)] ;
-      
-      if( affectedFromStrip  < minA ) minA = affectedFromStrip;
-      if( affectedUntilStrip > maxA ) maxA = affectedUntilStrip;
-    }
-    recordMinAffectedStrip=minA;
-    recordMaxAffectedStrip=maxA;
-  }  // end loop ip
+    assert(kk == tot);
 
+    // compute integral over strip (lower bound becomes the value)
+    for (int k = 0; k != tot - 1; ++k)
+      value[k] -= value[k + 1];  // this is negative!
+
+    float charge[Nstrips];
+    for (int i = 0; i != Nstrips; ++i)
+      charge[i] = 0;
+    kk = 0;
+    for (int i = 0; i != N; ++i) {
+      for (int j = 0; j != nStrip[i]; ++j)
+        charge[fromStrip[i] + j] -= amplitude[i] * value[kk++];
+      ++kk;  // skip last "strip"
+    }
+    assert(kk == tot);
+
+    /// do crosstalk... (can be done better, most probably not worth)
+    int minA = recordMinAffectedStrip, maxA = recordMaxAffectedStrip;
+    int sc = coupling.size();
+    for (int i = 0; i != Nstrips; ++i) {
+      int strip = i;
+      if (0 == charge[i])
+        continue;
+      auto affectedFromStrip = std::max(0, strip - sc + 1);
+      auto affectedUntilStrip = std::min(Nstrips, strip + sc);
+      for (auto affectedStrip = affectedFromStrip; affectedStrip < affectedUntilStrip; ++affectedStrip)
+        localAmplitudes[affectedStrip] += charge[i] * coupling[std::abs(affectedStrip - strip)];
+
+      if (affectedFromStrip < minA)
+        minA = affectedFromStrip;
+      if (affectedUntilStrip > maxA)
+        maxA = affectedUntilStrip;
+    }
+    recordMinAffectedStrip = minA;
+    recordMaxAffectedStrip = maxA;
+  }  // end loop ip
 }
 
-void 
-SiTrivialInduceChargeOnStrips::
-induceOriginal(const SiChargeCollectionDrifter::collection_type& collection_points, 
-	       const StripGeomDetUnit& det, 
-	       std::vector<float>& localAmplitudes, 
-	       size_t& recordMinAffectedStrip, 
-	       size_t& recordMaxAffectedStrip,
-	       const TrackerTopology *tTopo) const {
-
-
-  auto const & coupling = signalCoupling[typeOf(det,tTopo)];
+void SiTrivialInduceChargeOnStrips::induceOriginal(const SiChargeCollectionDrifter::collection_type& collection_points,
+                                                   const StripGeomDetUnit& det,
+                                                   std::vector<float>& localAmplitudes,
+                                                   size_t& recordMinAffectedStrip,
+                                                   size_t& recordMaxAffectedStrip,
+                                                   const TrackerTopology* tTopo) const {
+  auto const& coupling = signalCoupling[typeOf(det, tTopo)];
   const StripTopology& topology = dynamic_cast<const StripTopology&>(det.specificTopology());
-  size_t Nstrips =  topology.nstrips();
+  size_t Nstrips = topology.nstrips();
 
-  if (!collection_points.empty()) count.dep(collection_points.size());
+  if (!collection_points.empty())
+    count.dep(collection_points.size());
 
-  for (auto signalpoint = collection_points.begin();  signalpoint != collection_points.end();  signalpoint++ ) {
-    
+  for (auto signalpoint = collection_points.begin(); signalpoint != collection_points.end(); signalpoint++) {
     //In strip coordinates:
     double chargePosition = topology.strip(signalpoint->position());
     double chargeSpread = signalpoint->sigma() / topology.localPitch(signalpoint->position());
-    
-    size_t fromStrip  = size_t(std::max( 0,          int(std::floor( chargePosition - Nsigma*chargeSpread))));
-    size_t untilStrip = size_t(std::min( Nstrips, size_t(std::ceil( chargePosition + Nsigma*chargeSpread) )));
 
-    count.str(std::max(0,int(untilStrip)-int(fromStrip)));
-    for (size_t strip = fromStrip;  strip < untilStrip; strip++) {
+    size_t fromStrip = size_t(std::max(0, int(std::floor(chargePosition - Nsigma * chargeSpread))));
+    size_t untilStrip = size_t(std::min(Nstrips, size_t(std::ceil(chargePosition + Nsigma * chargeSpread))));
 
-      double chargeDepositedOnStrip = chargeDeposited( strip, Nstrips, signalpoint->amplitude() / geVperElectron, chargeSpread, chargePosition);
+    count.str(std::max(0, int(untilStrip) - int(fromStrip)));
+    for (size_t strip = fromStrip; strip < untilStrip; strip++) {
+      double chargeDepositedOnStrip =
+          chargeDeposited(strip, Nstrips, signalpoint->amplitude() / geVperElectron, chargeSpread, chargePosition);
 
-      size_t affectedFromStrip  = size_t(std::max( 0, int(strip - coupling.size() + 1)));
-      size_t affectedUntilStrip = size_t(std::min( Nstrips, strip + coupling.size())   );  
-      for (size_t affectedStrip = affectedFromStrip;  affectedStrip < affectedUntilStrip;  affectedStrip++) {
-	localAmplitudes.at( affectedStrip ) += chargeDepositedOnStrip * coupling.at((size_t)std::abs( (int)affectedStrip - (int)strip )) ;
+      size_t affectedFromStrip = size_t(std::max(0, int(strip - coupling.size() + 1)));
+      size_t affectedUntilStrip = size_t(std::min(Nstrips, strip + coupling.size()));
+      for (size_t affectedStrip = affectedFromStrip; affectedStrip < affectedUntilStrip; affectedStrip++) {
+        localAmplitudes.at(affectedStrip) +=
+            chargeDepositedOnStrip * coupling.at((size_t)std::abs((int)affectedStrip - (int)strip));
       }
 
-      if( affectedFromStrip  < recordMinAffectedStrip ) recordMinAffectedStrip = affectedFromStrip;
-      if( affectedUntilStrip > recordMaxAffectedStrip ) recordMaxAffectedStrip = affectedUntilStrip;
+      if (affectedFromStrip < recordMinAffectedStrip)
+        recordMinAffectedStrip = affectedFromStrip;
+      if (affectedUntilStrip > recordMaxAffectedStrip)
+        recordMaxAffectedStrip = affectedUntilStrip;
     }
   }
-
 }
-

--- a/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiTrivialInduceChargeOnStrips.h
@@ -6,37 +6,34 @@
 
 class TrackerTopology;
 
-class SiTrivialInduceChargeOnStrips: public SiInduceChargeOnStrips {
- public:
-  SiTrivialInduceChargeOnStrips(const edm::ParameterSet& conf,double g);
+class SiTrivialInduceChargeOnStrips : public SiInduceChargeOnStrips {
+public:
+  SiTrivialInduceChargeOnStrips(const edm::ParameterSet& conf, double g);
   ~SiTrivialInduceChargeOnStrips() override {}
-  void  induce(const SiChargeCollectionDrifter::collection_type& collection_points,
-	       const StripGeomDetUnit& det,
-	       std::vector<float>& localAmplitudes,
-	       size_t& recordMinAffectedStrip,
-	       size_t& recordMaxAffectedStrip,
-	       const TrackerTopology *tTopo) const override;
-  
- private:
+  void induce(const SiChargeCollectionDrifter::collection_type& collection_points,
+              const StripGeomDetUnit& det,
+              std::vector<float>& localAmplitudes,
+              size_t& recordMinAffectedStrip,
+              size_t& recordMaxAffectedStrip,
+              const TrackerTopology* tTopo) const override;
 
-  void  induceOriginal(const SiChargeCollectionDrifter::collection_type& collection_points,
-		  const StripGeomDetUnit& det,
-		  std::vector<float>& localAmplitudes,
-		  size_t& recordMinAffectedStrip,
-		  size_t& recordMaxAffectedStrip,
-		  const TrackerTopology *tTopo) const;
- 
+private:
+  void induceOriginal(const SiChargeCollectionDrifter::collection_type& collection_points,
+                      const StripGeomDetUnit& det,
+                      std::vector<float>& localAmplitudes,
+                      size_t& recordMinAffectedStrip,
+                      size_t& recordMaxAffectedStrip,
+                      const TrackerTopology* tTopo) const;
 
-  void  induceVector(const SiChargeCollectionDrifter::collection_type& collection_points,
-		     const StripGeomDetUnit& det,
-		     std::vector<float>& localAmplitudes,
-		     size_t& recordMinAffectedStrip,
-		     size_t& recordMaxAffectedStrip,
-		     const TrackerTopology *tTopo) const;
+  void induceVector(const SiChargeCollectionDrifter::collection_type& collection_points,
+                    const StripGeomDetUnit& det,
+                    std::vector<float>& localAmplitudes,
+                    size_t& recordMinAffectedStrip,
+                    size_t& recordMaxAffectedStrip,
+                    const TrackerTopology* tTopo) const;
 
+  const std::vector<std::vector<float> > signalCoupling;
 
-  const std::vector<std::vector<float> > signalCoupling; 
-  
   const float Nsigma;
   const float geVperElectron;
 };

--- a/SimTracker/SiStripDigitizer/plugins/SignalPoint.h
+++ b/SimTracker/SiStripDigitizer/plugins/SignalPoint.h
@@ -1,7 +1,6 @@
 #ifndef Tracker_SignalPoint_H
 #define Tracker_SignalPoint_H
 
-
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 
@@ -10,21 +9,24 @@
  * That describes the drifted charge seen on the surface of the sensors.
  */
 class SignalPoint {
- public:
-  SignalPoint() : _pos(0,0), _sigma(0), _amplitude(0) {}
-  
-  SignalPoint( float x, float y, float s,float a=1.0) : 
-    _pos(x,y), _sigma(s), _amplitude(a) {}
-  
-  const LocalPoint& position() const { return _pos;}
-  float x()         const { return _pos.x();}
-  float y()         const { return _pos.y();}
-  float sigma()     const { return _sigma;}
-  float amplitude() const { return _amplitude;}
-  SignalPoint& set_amplitude( float amp) { _amplitude = amp; return *this;} 
- private:
-  LocalPoint      _pos;
-  float           _sigma;
-  float           _amplitude;
-  };
+public:
+  SignalPoint() : _pos(0, 0), _sigma(0), _amplitude(0) {}
+
+  SignalPoint(float x, float y, float s, float a = 1.0) : _pos(x, y), _sigma(s), _amplitude(a) {}
+
+  const LocalPoint& position() const { return _pos; }
+  float x() const { return _pos.x(); }
+  float y() const { return _pos.y(); }
+  float sigma() const { return _sigma; }
+  float amplitude() const { return _amplitude; }
+  SignalPoint& set_amplitude(float amp) {
+    _amplitude = amp;
+    return *this;
+  }
+
+private:
+  LocalPoint _pos;
+  float _sigma;
+  float _amplitude;
+};
 #endif

--- a/SimTracker/SiStripDigitizer/src/SiGaussianTailNoiseAdder.cc
+++ b/SimTracker/SiStripDigitizer/src/SiGaussianTailNoiseAdder.cc
@@ -1,86 +1,91 @@
 #include "SimTracker/SiStripDigitizer/interface/SiGaussianTailNoiseAdder.h"
 #include "CLHEP/Random/RandGaussQ.h"
 
-SiGaussianTailNoiseAdder::SiGaussianTailNoiseAdder(float th):
-  threshold(th),
-  genNoise(new GaussianTailNoiseGenerator())
-{
-}
+SiGaussianTailNoiseAdder::SiGaussianTailNoiseAdder(float th)
+    : threshold(th), genNoise(new GaussianTailNoiseGenerator()) {}
 
-SiGaussianTailNoiseAdder::~SiGaussianTailNoiseAdder(){
-}
+SiGaussianTailNoiseAdder::~SiGaussianTailNoiseAdder() {}
 
 void SiGaussianTailNoiseAdder::addNoise(std::vector<float> &in,
-					size_t& minChannel, size_t& maxChannel,
-					int numStrips, float noiseRMS,
-                                        CLHEP::HepRandomEngine* engine) const {
- 
-  std::vector<std::pair<int,float> > generatedNoise;
-  genNoise->generate(numStrips,threshold,noiseRMS,generatedNoise, engine);
-  
+                                        size_t &minChannel,
+                                        size_t &maxChannel,
+                                        int numStrips,
+                                        float noiseRMS,
+                                        CLHEP::HepRandomEngine *engine) const {
+  std::vector<std::pair<int, float> > generatedNoise;
+  genNoise->generate(numStrips, threshold, noiseRMS, generatedNoise, engine);
+
   // noise on strips with signal:
-  for (size_t iChannel=minChannel; iChannel<maxChannel; iChannel++) {
-    if(in[iChannel] != 0) {
+  for (size_t iChannel = minChannel; iChannel < maxChannel; iChannel++) {
+    if (in[iChannel] != 0) {
       in[iChannel] += CLHEP::RandGaussQ::shoot(engine, 0., noiseRMS);
     }
   }
 
   // Noise on the other strips
-  typedef std::vector<std::pair<int,float> >::const_iterator VI;  
-  for(VI p = generatedNoise.begin(); p != generatedNoise.end(); p++){
-    if(in[(*p).first] == 0) {
+  typedef std::vector<std::pair<int, float> >::const_iterator VI;
+  for (VI p = generatedNoise.begin(); p != generatedNoise.end(); p++) {
+    if (in[(*p).first] == 0) {
       in[(*p).first] += (*p).second;
     }
   }
 }
 
-void SiGaussianTailNoiseAdder::addNoiseVR(std::vector<float> &in, std::vector<float> &noiseRMS, CLHEP::HepRandomEngine* engine) const {
+void SiGaussianTailNoiseAdder::addNoiseVR(std::vector<float> &in,
+                                          std::vector<float> &noiseRMS,
+                                          CLHEP::HepRandomEngine *engine) const {
   // Add noise
   // Full Gaussian noise is added everywhere
-  for (size_t iChannel=0; iChannel!=in.size(); iChannel++) {
-    if(noiseRMS[iChannel] > 0.) in[iChannel] += CLHEP::RandGaussQ::shoot(engine, 0., noiseRMS[iChannel]);
+  for (size_t iChannel = 0; iChannel != in.size(); iChannel++) {
+    if (noiseRMS[iChannel] > 0.)
+      in[iChannel] += CLHEP::RandGaussQ::shoot(engine, 0., noiseRMS[iChannel]);
   }
 }
 
-void SiGaussianTailNoiseAdder::addPedestals(std::vector<float> &in,std::vector<float> & ped) const {
-	for (size_t iChannel=0; iChannel!=in.size(); iChannel++) {
-      if(ped[iChannel]>0.) in[iChannel] += ped[iChannel];      
-    }
+void SiGaussianTailNoiseAdder::addPedestals(std::vector<float> &in, std::vector<float> &ped) const {
+  for (size_t iChannel = 0; iChannel != in.size(); iChannel++) {
+    if (ped[iChannel] > 0.)
+      in[iChannel] += ped[iChannel];
+  }
 }
 
-void SiGaussianTailNoiseAdder::addCMNoise(std::vector<float> &in, float cmnRMS, std::vector<bool> &badChannels, CLHEP::HepRandomEngine* engine) const {
-  int nAPVs = in.size()/128;
+void SiGaussianTailNoiseAdder::addCMNoise(std::vector<float> &in,
+                                          float cmnRMS,
+                                          std::vector<bool> &badChannels,
+                                          CLHEP::HepRandomEngine *engine) const {
+  int nAPVs = in.size() / 128;
   std::vector<float> CMNv;
-  for(int APVn =0; APVn < nAPVs; ++APVn) CMNv.push_back(CLHEP::RandGaussQ::shoot(engine, 0., cmnRMS));
-  for (size_t iChannel=0; iChannel!=in.size(); iChannel++) {
-     if(!badChannels[iChannel]) in[iChannel] += CMNv[(int)(iChannel/128)];
+  for (int APVn = 0; APVn < nAPVs; ++APVn)
+    CMNv.push_back(CLHEP::RandGaussQ::shoot(engine, 0., cmnRMS));
+  for (size_t iChannel = 0; iChannel != in.size(); iChannel++) {
+    if (!badChannels[iChannel])
+      in[iChannel] += CMNv[(int)(iChannel / 128)];
   }
 }
 
 void SiGaussianTailNoiseAdder::addBaselineShift(std::vector<float> &in, std::vector<bool> &badChannels) const {
-  size_t nAPVs = in.size()/128;
+  size_t nAPVs = in.size() / 128;
   std::vector<float> vShift;
   double apvCharge, apvMult;
-  
+
   size_t iChannel;
-  for(size_t APVn =0; APVn < nAPVs; ++APVn){
-   	apvMult=0; apvCharge=0;
-	for(iChannel=APVn*128; iChannel!=APVn*128+128; ++iChannel) {
-  	   if(in[iChannel]>0){
-	   	 ++apvMult;
-	   	  apvCharge+= in[iChannel];
-	   }
-	   if(apvMult==0) vShift.push_back(0);
-	   else vShift.push_back(apvCharge/apvMult);
-  	}
+  for (size_t APVn = 0; APVn < nAPVs; ++APVn) {
+    apvMult = 0;
+    apvCharge = 0;
+    for (iChannel = APVn * 128; iChannel != APVn * 128 + 128; ++iChannel) {
+      if (in[iChannel] > 0) {
+        ++apvMult;
+        apvCharge += in[iChannel];
+      }
+      if (apvMult == 0)
+        vShift.push_back(0);
+      else
+        vShift.push_back(apvCharge / apvMult);
+    }
   }
-     
-  for (iChannel=0; iChannel!=in.size(); ++iChannel) {
-     if(!badChannels[iChannel]) in[iChannel] -= vShift[(int)(iChannel/128)];
+
+  for (iChannel = 0; iChannel != in.size(); ++iChannel) {
+    if (!badChannels[iChannel])
+      in[iChannel] -= vShift[(int)(iChannel / 128)];
   }
 }
-
-
-
-
-

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
@@ -37,18 +37,17 @@
 #include "MaterialAccountingGroup.h"
 #include "TrackingMaterialPlotter.h"
 
-static
-bool dddGetStringRaw(const DDFilteredView & view, const std::string & name, std::string & value) {
+static bool dddGetStringRaw(const DDFilteredView &view, const std::string &name, std::string &value) {
   std::vector<const DDsvalues_type *> result;
   view.specificsV(result);
-  for (std::vector<const DDsvalues_type *>::iterator it = result.begin(); it != result.end(); ++it)   {
+  for (std::vector<const DDsvalues_type *>::iterator it = result.begin(); it != result.end(); ++it) {
     DDValue parameter(name);
     if (DDfetch(*it, parameter)) {
       if (parameter.strings().size() == 1) {
         value = parameter.strings().front();
         return true;
       } else {
-        throw cms::Exception("Configuration")<< " ERROR: multiple " << name << " tags encountered";
+        throw cms::Exception("Configuration") << " ERROR: multiple " << name << " tags encountered";
         return false;
       }
     }
@@ -67,8 +66,7 @@ double dddGetDouble(const std::string & s, DDFilteredView const & view) {
 }
 */
 
-static inline
-std::string dddGetString(const std::string & s, DDFilteredView const & view) {
+static inline std::string dddGetString(const std::string &s, DDFilteredView const &view) {
   std::string value;
   if (dddGetStringRaw(view, s, value))
     return value;
@@ -76,8 +74,7 @@ std::string dddGetString(const std::string & s, DDFilteredView const & view) {
     return std::string();
 }
 
-class ListGroups : public edm::one::EDAnalyzer<>
-{
+class ListGroups : public edm::one::EDAnalyzer<> {
 public:
   ListGroups(const edm::ParameterSet &);
   ~ListGroups() override;
@@ -94,7 +91,7 @@ private:
   bool m_saveSummaryPlot;
   std::vector<TH2F *> m_plots;
   std::set<std::string> m_group_names;
-  std::vector<MaterialAccountingGroup *>    m_groups;
+  std::vector<MaterialAccountingGroup *> m_groups;
   std::vector<unsigned int> m_color;
   std::vector<int> m_gradient;
 
@@ -111,7 +108,7 @@ private:
   std::map<std::string, std::pair<float, float> > m_values;
 };
 
-ListGroups::ListGroups(const edm::ParameterSet & iPSet) {
+ListGroups::ListGroups(const edm::ParameterSet &iPSet) {
   m_saveSummaryPlot = iPSet.getUntrackedParameter<bool>("SaveSummaryPlot");
   m_plots.clear();
   m_groups.clear();
@@ -261,15 +258,13 @@ void ListGroups::fillMaterialDifferences() {
   m_values["TrackerRecMaterialPixelEndcapDisk1Fw_Inner"] = std::make_pair<float, float>(0.039127, 0.000086);
   m_values["TrackerRecMaterialTECDisk0_R40"] = std::make_pair<float, float>(0.084231, 0.000209);
   m_values["TrackerRecMaterialTIDDisk2_R30"] = std::make_pair<float, float>(0.065109, 0.000143);
-
 }
 
-void ListGroups::fillGradient(void)
-{
+void ListGroups::fillGradient(void) {
   m_gradient.reserve(200);
   unsigned int steps = 100;
   // if no index was given, find the highest used one and start from that plus one
-  unsigned int index = ((TObjArray*) gROOT->GetListOfColors())->GetLast() + 1;
+  unsigned int index = ((TObjArray *)gROOT->GetListOfColors())->GetLast() + 1;
 
   float r1, g1, b1, r2, g2, b2;
   static_cast<TColor *>(gROOT->GetListOfColors()->At(kBlue + 1))->GetRGB(r1, g1, b1);
@@ -278,14 +273,14 @@ void ListGroups::fillGradient(void)
   float delta_g = (g2 - g1) / (steps - 1);
   float delta_b = (b2 - b1) / (steps - 1);
 
-  m_gradient.push_back(kBlue + 4); // Underflow lowest bin
+  m_gradient.push_back(kBlue + 4);  // Underflow lowest bin
   unsigned int ii = 0;
   for (unsigned int i = 0; i < steps; ++i, ++ii) {
     new TColor(static_cast<Int_t>(index + ii), r1 + delta_r * i, g1 + delta_g * i, b1 + delta_b * i);
     m_gradient.push_back(index + ii);
   }
 
-  m_gradient.push_back(kWhite); // 0 level perfectly white
+  m_gradient.push_back(kWhite);  // 0 level perfectly white
 
   static_cast<TColor *>(gROOT->GetListOfColors()->At(kOrange))->GetRGB(r1, g1, b1);
   static_cast<TColor *>(gROOT->GetListOfColors()->At(kOrange + 7))->GetRGB(r2, g2, b2);
@@ -296,7 +291,7 @@ void ListGroups::fillGradient(void)
     new TColor(static_cast<Int_t>(index + ii), r1 + delta_r * i, g1 + delta_g * i, b1 + delta_b * i);
     m_gradient.push_back(index + ii);
   }
-  m_gradient.push_back(kRed); // Overflow highest bin
+  m_gradient.push_back(kRed);  // Overflow highest bin
 }
 
 void ListGroups::fillColor(void) {
@@ -306,93 +301,92 @@ void ListGroups::fillColor(void) {
   // define some reasonable set and loop over it in case the number of grouping
   // is larger than the number of colors.
 
-  m_color.push_back(kBlack);          // unassigned
+  m_color.push_back(kBlack);  // unassigned
 
-  m_color.push_back(kAzure);          // PixelBarrelLayer0_Z0
-  m_color.push_back(kAzure - 1);      // PixelBarrelLayer0_Z20
-  m_color.push_back(kAzure + 1) ;     // Layer1_Z0
-  m_color.push_back(kAzure + 2) ;     // Layer1_Z20
+  m_color.push_back(kAzure);      // PixelBarrelLayer0_Z0
+  m_color.push_back(kAzure - 1);  // PixelBarrelLayer0_Z20
+  m_color.push_back(kAzure + 1);  // Layer1_Z0
+  m_color.push_back(kAzure + 2);  // Layer1_Z20
 
-  m_color.push_back(kGreen);          // EndCapDisk1_R0
-  m_color.push_back(kGreen + 2);      // EndcapDisk1_R11
-  m_color.push_back(kGreen + 4);      // EndcapDisk1_R7
-  m_color.push_back(kSpring + 9);     // EndcapDisk2_R0
-  m_color.push_back(kSpring + 4);     // EndcapDisk2_R7
-  m_color.push_back(kSpring    );     // EndcapDisk2_R7
+  m_color.push_back(kGreen);       // EndCapDisk1_R0
+  m_color.push_back(kGreen + 2);   // EndcapDisk1_R11
+  m_color.push_back(kGreen + 4);   // EndcapDisk1_R7
+  m_color.push_back(kSpring + 9);  // EndcapDisk2_R0
+  m_color.push_back(kSpring + 4);  // EndcapDisk2_R7
+  m_color.push_back(kSpring);      // EndcapDisk2_R7
 
-  m_color.push_back(kRed);            // TECDisk0_R20
-  m_color.push_back(kRed + 2);        // TECDisk0_R40
-  m_color.push_back(kRed - 7);        // TECDisk0_R50
-  m_color.push_back(kRed - 5);        // TECDisk0_R60
-  m_color.push_back(kRed - 10);       // TECDisk0_R90
-  m_color.push_back(kRed - 1);        // TECDisk1_Inner
-  m_color.push_back(kRed - 2);        // TECDisk1_Outer
-  m_color.push_back(kRed - 3);        // TECDisk1_R20
-  m_color.push_back(kPink - 2);       // TECDisk2_Inner
-  m_color.push_back(kPink - 3);       // TECDisk2_Outer
-  m_color.push_back(kPink - 4);       // TECDisk2_R20
-  m_color.push_back(kPink + 9);       // TECDisk3_Inner
-  m_color.push_back(kPink + 8);       // TECDisk3_Outer
-  m_color.push_back(kPink + 7);       // TECDisk3
-  m_color.push_back(kMagenta - 2);    // TECDisk4_Inner
-  m_color.push_back(kMagenta - 3);    // TECDisk4_Outer
-  m_color.push_back(kMagenta - 4);    // TECDisk4_R33
-  m_color.push_back(kMagenta - 5);    // TECDisk5_Inner
-  m_color.push_back(kMagenta - 6);    // TECDisk5_Outer
-  m_color.push_back(kMagenta - 7);    // TECDisk5_R33
-  m_color.push_back(kRed);            // TECDisk6
-  m_color.push_back(kMagenta - 9);    // TECDisk7_R40
-  m_color.push_back(kViolet);         // TECDisk8
+  m_color.push_back(kRed);          // TECDisk0_R20
+  m_color.push_back(kRed + 2);      // TECDisk0_R40
+  m_color.push_back(kRed - 7);      // TECDisk0_R50
+  m_color.push_back(kRed - 5);      // TECDisk0_R60
+  m_color.push_back(kRed - 10);     // TECDisk0_R90
+  m_color.push_back(kRed - 1);      // TECDisk1_Inner
+  m_color.push_back(kRed - 2);      // TECDisk1_Outer
+  m_color.push_back(kRed - 3);      // TECDisk1_R20
+  m_color.push_back(kPink - 2);     // TECDisk2_Inner
+  m_color.push_back(kPink - 3);     // TECDisk2_Outer
+  m_color.push_back(kPink - 4);     // TECDisk2_R20
+  m_color.push_back(kPink + 9);     // TECDisk3_Inner
+  m_color.push_back(kPink + 8);     // TECDisk3_Outer
+  m_color.push_back(kPink + 7);     // TECDisk3
+  m_color.push_back(kMagenta - 2);  // TECDisk4_Inner
+  m_color.push_back(kMagenta - 3);  // TECDisk4_Outer
+  m_color.push_back(kMagenta - 4);  // TECDisk4_R33
+  m_color.push_back(kMagenta - 5);  // TECDisk5_Inner
+  m_color.push_back(kMagenta - 6);  // TECDisk5_Outer
+  m_color.push_back(kMagenta - 7);  // TECDisk5_R33
+  m_color.push_back(kRed);          // TECDisk6
+  m_color.push_back(kMagenta - 9);  // TECDisk7_R40
+  m_color.push_back(kViolet);       // TECDisk8
 
-  m_color.push_back(kOrange + 9);     // TIBLayer0_Z0
-  m_color.push_back(kOrange + 7);     // TIBLayer0_Z20
-  m_color.push_back(kOrange + 5);     // TIBLayer0_Z40
-  m_color.push_back(kOrange - 2);     // TIBLayer1_Z0
-  m_color.push_back(kOrange - 3);     // TIBLayer1_Z30
-  m_color.push_back(kOrange - 6);     // TIBLayer1_Z60
-  m_color.push_back(kOrange + 4);     // TIBLayer2_Z0
-  m_color.push_back(kOrange - 7);     // TIBLayer2_Z40
-  m_color.push_back(kOrange);         // TIBLayer3_Z0
-  m_color.push_back(kOrange + 10);    // TIBLayer3_Z50
+  m_color.push_back(kOrange + 9);   // TIBLayer0_Z0
+  m_color.push_back(kOrange + 7);   // TIBLayer0_Z20
+  m_color.push_back(kOrange + 5);   // TIBLayer0_Z40
+  m_color.push_back(kOrange - 2);   // TIBLayer1_Z0
+  m_color.push_back(kOrange - 3);   // TIBLayer1_Z30
+  m_color.push_back(kOrange - 6);   // TIBLayer1_Z60
+  m_color.push_back(kOrange + 4);   // TIBLayer2_Z0
+  m_color.push_back(kOrange - 7);   // TIBLayer2_Z40
+  m_color.push_back(kOrange);       // TIBLayer3_Z0
+  m_color.push_back(kOrange + 10);  // TIBLayer3_Z50
 
-  m_color.push_back(kViolet + 10);    // TIDDisk1_R0
-  m_color.push_back(kViolet + 6);     // TIDDisk1_R30
-  m_color.push_back(kViolet + 3);     // TIDDisk1_R40
-  m_color.push_back(kViolet - 7);     // TIDDisk2_R25
-  m_color.push_back(kViolet - 1);     // TIDDisk2_R30
-  m_color.push_back(kViolet + 9);     // TIDDisk2_R40
-  m_color.push_back(kViolet - 5);     // TIDDisk3_R24
-  m_color.push_back(kViolet - 3);     // TIDDisk3_R30
-  m_color.push_back(kViolet);         // TIDDisk3_R40
+  m_color.push_back(kViolet + 10);  // TIDDisk1_R0
+  m_color.push_back(kViolet + 6);   // TIDDisk1_R30
+  m_color.push_back(kViolet + 3);   // TIDDisk1_R40
+  m_color.push_back(kViolet - 7);   // TIDDisk2_R25
+  m_color.push_back(kViolet - 1);   // TIDDisk2_R30
+  m_color.push_back(kViolet + 9);   // TIDDisk2_R40
+  m_color.push_back(kViolet - 5);   // TIDDisk3_R24
+  m_color.push_back(kViolet - 3);   // TIDDisk3_R30
+  m_color.push_back(kViolet);       // TIDDisk3_R40
 
-  m_color.push_back(kAzure    );    // TOBLayer0_Z0
-  m_color.push_back(kAzure + 8);    // TOBLayer0_Z20
-  m_color.push_back(kAzure + 2);    // TOBLayer0_Z70
-  m_color.push_back(kAzure + 4);    // TOBLayer0_Z80
-  m_color.push_back(kCyan + 1);     // TOBLayer1_Z0
-  m_color.push_back(kCyan - 9);     // TOBLayer1_Z20
-  m_color.push_back(kCyan + 3);     // TOBLayer1_Z80
-  m_color.push_back(kCyan + 4);     // TOBLayer1_Z90
-  m_color.push_back(kAzure    );    // TOBLayer2_Z0
-  m_color.push_back(kAzure + 8);    // TOBLayer2_Z25
-  m_color.push_back(kAzure + 2);    // TOBLayer2_Z80
-  m_color.push_back(kAzure + 5);    // TOBLayer2_Z90
-  m_color.push_back(kCyan + 1);     // TOBLayer3_Z0
-  m_color.push_back(kCyan - 9);     // TOBLayer3_Z25
-  m_color.push_back(kCyan + 3);     // TOBLayer3_Z80
-  m_color.push_back(kCyan + 4);     // TOBLayer3_Z90
-  m_color.push_back(kAzure    );    // TOBLayer4_Z0
-  m_color.push_back(kAzure + 8);    // TOBLayer4_Z25
-  m_color.push_back(kAzure + 2);    // TOBLayer4_Z80
-  m_color.push_back(kAzure + 5);    // TOBLayer4_Z90
-  m_color.push_back(kCyan + 1);     // TOBLayer5_Z0
-  m_color.push_back(kCyan - 9);     // TOBLayer5_Z25
-  m_color.push_back(kCyan + 3);     // TOBLayer5_Z80
-  m_color.push_back(kCyan + 4);     // TOBLayer5_Z90
+  m_color.push_back(kAzure);      // TOBLayer0_Z0
+  m_color.push_back(kAzure + 8);  // TOBLayer0_Z20
+  m_color.push_back(kAzure + 2);  // TOBLayer0_Z70
+  m_color.push_back(kAzure + 4);  // TOBLayer0_Z80
+  m_color.push_back(kCyan + 1);   // TOBLayer1_Z0
+  m_color.push_back(kCyan - 9);   // TOBLayer1_Z20
+  m_color.push_back(kCyan + 3);   // TOBLayer1_Z80
+  m_color.push_back(kCyan + 4);   // TOBLayer1_Z90
+  m_color.push_back(kAzure);      // TOBLayer2_Z0
+  m_color.push_back(kAzure + 8);  // TOBLayer2_Z25
+  m_color.push_back(kAzure + 2);  // TOBLayer2_Z80
+  m_color.push_back(kAzure + 5);  // TOBLayer2_Z90
+  m_color.push_back(kCyan + 1);   // TOBLayer3_Z0
+  m_color.push_back(kCyan - 9);   // TOBLayer3_Z25
+  m_color.push_back(kCyan + 3);   // TOBLayer3_Z80
+  m_color.push_back(kCyan + 4);   // TOBLayer3_Z90
+  m_color.push_back(kAzure);      // TOBLayer4_Z0
+  m_color.push_back(kAzure + 8);  // TOBLayer4_Z25
+  m_color.push_back(kAzure + 2);  // TOBLayer4_Z80
+  m_color.push_back(kAzure + 5);  // TOBLayer4_Z90
+  m_color.push_back(kCyan + 1);   // TOBLayer5_Z0
+  m_color.push_back(kCyan - 9);   // TOBLayer5_Z25
+  m_color.push_back(kCyan + 3);   // TOBLayer5_Z80
+  m_color.push_back(kCyan + 4);   // TOBLayer5_Z90
 }
 
-std::vector<std::pair<std::shared_ptr<TLine>, std::shared_ptr<TText> > >
-ListGroups::overlayEtaReferences() {
+std::vector<std::pair<std::shared_ptr<TLine>, std::shared_ptr<TText> > > ListGroups::overlayEtaReferences() {
   std::vector<std::pair<std::shared_ptr<TLine>, std::shared_ptr<TText> > > lines;
 
   lines.reserve(40);
@@ -401,43 +395,34 @@ ListGroups::overlayEtaReferences() {
   float text_size = 0.033;
 
   for (float eta = 0.; eta <= 3.8; eta += 0.2) {
-    float theta = 2. * atan (exp(-eta));
+    float theta = 2. * atan(exp(-eta));
     if (eta >= 1.8) {
-      lines.push_back(
-          std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> > (
-              std::make_shared<TLine>(
-                  deltaZ.first, deltaZ.first * tan(theta), deltaZ.second, deltaZ.second * tan(theta)),
-              std::make_shared<TText>(
-                  deltaZ.first, deltaZ.first * tan(theta), str(boost::format("%2.1f") % eta).c_str())));
+      lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> >(
+          std::make_shared<TLine>(deltaZ.first, deltaZ.first * tan(theta), deltaZ.second, deltaZ.second * tan(theta)),
+          std::make_shared<TText>(deltaZ.first, deltaZ.first * tan(theta), str(boost::format("%2.1f") % eta).c_str())));
       lines.back().second->SetTextFont(42);
       lines.back().second->SetTextSize(text_size);
       lines.back().second->SetTextAlign(33);
-      lines.push_back(
-          std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> > (
-              std::make_shared<TLine>(
-                  -deltaZ.first, deltaZ.first * tan(theta), -deltaZ.second, deltaZ.second * tan(theta)),
-              std::make_shared<TText>(
-                  -deltaZ.first, deltaZ.first * tan(theta), str(boost::format("-%2.1f") % eta).c_str())));
+      lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> >(
+          std::make_shared<TLine>(-deltaZ.first, deltaZ.first * tan(theta), -deltaZ.second, deltaZ.second * tan(theta)),
+          std::make_shared<TText>(
+              -deltaZ.first, deltaZ.first * tan(theta), str(boost::format("-%2.1f") % eta).c_str())));
       lines.back().second->SetTextFont(42);
       lines.back().second->SetTextSize(text_size);
       lines.back().second->SetTextAlign(13);
     } else {
-      lines.push_back(
-          std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> > (
-              std::make_shared<TLine>(
-                  deltaR.first / tan(theta), deltaR.first, deltaR.second / tan(theta), deltaR.second),
-              std::make_shared<TText>(
-                  deltaR.first / tan(theta), deltaR.first, str(boost::format("%2.1f") % eta).c_str())));
+      lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> >(
+          std::make_shared<TLine>(deltaR.first / tan(theta), deltaR.first, deltaR.second / tan(theta), deltaR.second),
+          std::make_shared<TText>(deltaR.first / tan(theta), deltaR.first, str(boost::format("%2.1f") % eta).c_str())));
       lines.back().second->SetTextFont(42);
       lines.back().second->SetTextSize(text_size);
       lines.back().second->SetTextAlign(23);
       if (eta != 0) {
-        lines.push_back(
-            std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> > (
-                std::make_shared<TLine>(
-                    - deltaR.first / tan(theta), deltaR.first, - deltaR.second / tan(theta), deltaR.second),
-                std::make_shared<TText>(
-                    - deltaR.first / tan(theta), deltaR.first, str(boost::format("-%2.1f") % eta).c_str())));
+        lines.push_back(std::make_pair<std::shared_ptr<TLine>, std::shared_ptr<TText> >(
+            std::make_shared<TLine>(
+                -deltaR.first / tan(theta), deltaR.first, -deltaR.second / tan(theta), deltaR.second),
+            std::make_shared<TText>(
+                -deltaR.first / tan(theta), deltaR.first, str(boost::format("-%2.1f") % eta).c_str())));
         lines.back().second->SetTextFont(42);
         lines.back().second->SetTextSize(text_size);
         lines.back().second->SetTextAlign(23);
@@ -447,52 +432,54 @@ ListGroups::overlayEtaReferences() {
   return lines;
 }
 
-
 void ListGroups::produceAndSaveSummaryPlot(const edm::EventSetup &setup) {
   const double scale = 10.;
   std::vector<TText *> nukem_text;
-  static int markerStyles[10] = {kFullCircle, kFullSquare, kFullTriangleUp, kFullTriangleDown, kOpenCircle, kOpenSquare, kOpenTriangleUp, kOpenDiamond, kOpenCross, kFullStar};
+  static int markerStyles[10] = {kFullCircle,
+                                 kFullSquare,
+                                 kFullTriangleUp,
+                                 kFullTriangleDown,
+                                 kOpenCircle,
+                                 kOpenSquare,
+                                 kOpenTriangleUp,
+                                 kOpenDiamond,
+                                 kOpenCross,
+                                 kFullStar};
 
   edm::ESTransientHandle<DDCompactView> hDdd;
-  setup.get<IdealGeometryRecord>().get( hDdd );
+  setup.get<IdealGeometryRecord>().get(hDdd);
 
   for (auto n : m_group_names) {
-    m_groups.push_back( new MaterialAccountingGroup(n, *hDdd) );
+    m_groups.push_back(new MaterialAccountingGroup(n, *hDdd));
   };
 
   std::unique_ptr<TCanvas> canvas(
-      new TCanvas("Grouping_rz", "Grouping - RZ view",
-                  (int) (600 * scale * 1.25),  (int) (120 * scale * 1.50)));
+      new TCanvas("Grouping_rz", "Grouping - RZ view", (int)(600 * scale * 1.25), (int)(120 * scale * 1.50)));
   canvas->GetFrame()->SetFillColor(kWhite);
   gStyle->SetOptStat(0);
 
   unsigned int color_index = 1;
   // Setup the legend
-  std::unique_ptr<TLegend> leg(new TLegend(0.1,0.1,0.23,0.34));
+  std::unique_ptr<TLegend> leg(new TLegend(0.1, 0.1, 0.23, 0.34));
   leg->SetHeader("Tracker Material Grouping");
   leg->SetTextFont(42);
   leg->SetTextSize(0.008);
   leg->SetNColumns(3);
   std::unique_ptr<TProfile2D> radlen(
-      new TProfile2D( "OverallRadLen", "OverallRadLen",
-                      600., -300., 300, 120., 0., 120.));
+      new TProfile2D("OverallRadLen", "OverallRadLen", 600., -300., 300, 120., 0., 120.));
   std::unique_ptr<TProfile2D> eneloss(
-      new TProfile2D( "OverallEnergyLoss", "OverallEnergyLoss",
-                      600., -300., 300, 120., 0., 120.));
+      new TProfile2D("OverallEnergyLoss", "OverallEnergyLoss", 600., -300., 300, 120., 0., 120.));
   std::unique_ptr<TProfile2D> radlen_diff(
-      new TProfile2D( "OverallDifferencesRadLen", "OverallDifferencesRadLen",
-                      600., -300., 300, 120., 0., 120.));
+      new TProfile2D("OverallDifferencesRadLen", "OverallDifferencesRadLen", 600., -300., 300, 120., 0., 120.));
   std::unique_ptr<TProfile2D> eneloss_diff(
-      new TProfile2D( "OverallDifferencesEnergyLoss", "OverallDifferencesEnergyLoss",
-                      600., -300., 300, 120., 0., 120.));
+      new TProfile2D("OverallDifferencesEnergyLoss", "OverallDifferencesEnergyLoss", 600., -300., 300, 120., 0., 120.));
 
   for (auto g : m_groups) {
     m_plots.push_back(
-        new TH2F( g->name().c_str(), g->name().c_str(),
-                  6000., -300., 300, 1200., 0., 120.)); // 10x10 points per cm2
+        new TH2F(g->name().c_str(), g->name().c_str(), 6000., -300., 300, 1200., 0., 120.));  // 10x10 points per cm2
     TH2F &current = *m_plots.back();
     current.SetMarkerColor(m_color[color_index]);
-    current.SetMarkerStyle(markerStyles[color_index%10]);
+    current.SetMarkerStyle(markerStyles[color_index % 10]);
     current.SetMarkerSize(0.8);
     current.SetLineWidth(1);
     for (auto element : g->elements()) {
@@ -508,12 +495,12 @@ void ListGroups::produceAndSaveSummaryPlot(const edm::EventSetup &setup) {
     else
       current.Draw("SAME");
 
-    leg->AddEntry(&current , g->name().c_str(), "lp")->SetTextColor(m_color[color_index]);
+    leg->AddEntry(&current, g->name().c_str(), "lp")->SetTextColor(m_color[color_index]);
     color_index++;
 
     // Loop over the same chromatic scale in case the number of
     // allocated colors is not big enough.
-    color_index  = color_index%m_color.size();
+    color_index = color_index % m_color.size();
   }
   leg->Draw();
   canvas->SaveAs("Grouping.png");
@@ -543,8 +530,8 @@ void ListGroups::produceAndSaveSummaryPlot(const edm::EventSetup &setup) {
   canvas->SaveAs("EnergyLossValues.png");
 
   canvas->Clear();
-  gStyle->SetPalette( m_gradient.size(), & m_gradient.front() );
-  gStyle->SetNumberContours( m_gradient.size() );
+  gStyle->SetPalette(m_gradient.size(), &m_gradient.front());
+  gStyle->SetNumberContours(m_gradient.size());
   radlen_diff->SetMinimum(-100);
   radlen_diff->SetMaximum(100);
   radlen_diff->Draw("COLZ");
@@ -568,17 +555,14 @@ void ListGroups::produceAndSaveSummaryPlot(const edm::EventSetup &setup) {
 
   for (auto g : nukem_text)
     delete g;
-
 }
 
-
-void
-ListGroups::analyze(const edm::Event& evt, const edm::EventSetup& setup) {
+void ListGroups::analyze(const edm::Event &evt, const edm::EventSetup &setup) {
   edm::ESTransientHandle<DDCompactView> hDdd;
-  setup.get<IdealGeometryRecord>().get( hDdd );
+  setup.get<IdealGeometryRecord>().get(hDdd);
 
   DDSpecificsHasNamedValueFilter filter{"TrackingMaterialGroup"};
-  DDFilteredView fv(*hDdd,filter);
+  DDFilteredView fv(*hDdd, filter);
 
   while (fv.next()) {
     // print the group name and full hierarchy of all items
@@ -586,16 +570,14 @@ ListGroups::analyze(const edm::Event& evt, const edm::EventSetup& setup) {
     m_group_names.insert(dddGetString("TrackingMaterialGroup", fv));
 
     // start from 2 to skip the leading /OCMS[0]/CMSE[1] part
-    const DDGeoHistory & history = fv.geoHistory();
+    const DDGeoHistory &history = fv.geoHistory();
     std::cout << '/';
     for (unsigned int h = 2; h < history.size(); ++h)
       std::cout << '/' << history[h].logicalPart().name().name() << '[' << history[h].copyno() << ']';
 
     // DD3Vector and DDTranslation are the same type as math::XYZVector
     math::XYZVector position = fv.translation() / 10.;  // mm -> cm
-    std::cout << "\t(" << position.x()
-              << ", " << position.y()
-              << ", " << position.z() << ") "
+    std::cout << "\t(" << position.x() << ", " << position.y() << ", " << position.z() << ") "
               << "[rho] " << position.Rho() << std::endl;
   };
   std::cout << std::endl;
@@ -604,9 +586,7 @@ ListGroups::analyze(const edm::Event& evt, const edm::EventSetup& setup) {
     produceAndSaveSummaryPlot(setup);
 }
 
-void
-ListGroups::endJob() {
-}
+void ListGroups::endJob() {}
 
 //-------------------------------------------------------------------------
 // define as a plugin

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
@@ -25,13 +25,12 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-static
-bool dddGetStringRaw(const DDFilteredView & view, const std::string & name, std::string & value) {
+static bool dddGetStringRaw(const DDFilteredView &view, const std::string &name, std::string &value) {
   DDValue parameter(name);
   std::vector<const DDsvalues_type *> result;
   view.specificsV(result);
   for (std::vector<const DDsvalues_type *>::iterator it = result.begin(); it != result.end(); ++it) {
-    if (DDfetch(*it,parameter)) {
+    if (DDfetch(*it, parameter)) {
       if (parameter.strings().size() == 1) {
         value = parameter.strings().front();
         return true;
@@ -54,8 +53,7 @@ double dddGetDouble(const std::string & s, const DDFilteredView & view) {
 }
 */
 
-static inline
-std::string dddGetString(const std::string & s, const DDFilteredView & view) {
+static inline std::string dddGetString(const std::string &s, const DDFilteredView &view) {
   std::string value;
   if (dddGetStringRaw(view, s, value))
     return value;
@@ -63,13 +61,11 @@ std::string dddGetString(const std::string & s, const DDFilteredView & view) {
     return std::string();
 }
 
-static inline
-std::ostream & operator<<(std::ostream & out, const math::XYZVector & v) {
+static inline std::ostream &operator<<(std::ostream &out, const math::XYZVector &v) {
   return out << "(" << v.rho() << ", " << v.z() << ", " << v.phi() << ")";
 }
 
-class ListIds : public edm::one::EDAnalyzer<>
-{
+class ListIds : public edm::one::EDAnalyzer<> {
 public:
   ListIds(const edm::ParameterSet &);
   ~ListIds() override;
@@ -86,24 +82,21 @@ private:
   std::vector<std::string> materials_;
 };
 
-ListIds::ListIds(const edm::ParameterSet & pset)
- : printMaterial_(pset.getUntrackedParameter<bool>("printMaterial")),
-   materials_(pset.getUntrackedParameter<std::vector<std::string> >("materials")) {
-}
+ListIds::ListIds(const edm::ParameterSet &pset)
+    : printMaterial_(pset.getUntrackedParameter<bool>("printMaterial")),
+      materials_(pset.getUntrackedParameter<std::vector<std::string> >("materials")) {}
 
-ListIds::~ListIds() {
-}
+ListIds::~ListIds() {}
 
-void
-ListIds::analyze(const edm::Event& evt, const edm::EventSetup& setup){
+void ListIds::analyze(const edm::Event &evt, const edm::EventSetup &setup) {
   std::cout << "______________________________ DDD ______________________________" << std::endl;
   edm::ESTransientHandle<DDCompactView> hDdd;
-  setup.get<IdealGeometryRecord>().get( hDdd );
+  setup.get<IdealGeometryRecord>().get(hDdd);
 
   std::string attribute = "TkDDDStructure";
   CmsTrackerStringToEnum theCmsTrackerStringToEnum;
   DDSpecificsHasNamedValueFilter filter{attribute};
-  DDFilteredView fv(*hDdd,filter);
+  DDFilteredView fv(*hDdd, filter);
   if (theCmsTrackerStringToEnum.type(dddGetString(attribute, fv)) != GeometricDet::Tracker) {
     fv.firstChild();
     if (theCmsTrackerStringToEnum.type(dddGetString(attribute, fv)) != GeometricDet::Tracker)
@@ -120,16 +113,14 @@ ListIds::analyze(const edm::Event& evt, const edm::EventSetup& setup){
     // keyword ANY (in any location of the vector)
     // will select all elements.
     if (printAnyMaterial ||
-        (std::find(materials_.begin(),
-                   materials_.end(),
-                   fv.logicalPart().material().name().fullname()) != materials_.end())) {
-
+        (std::find(materials_.begin(), materials_.end(), fv.logicalPart().material().name().fullname()) !=
+         materials_.end())) {
       // start from 2 to skip the leading /OCMS[0]/CMSE[1] part
-      const DDGeoHistory & history = fv.geoHistory();
+      const DDGeoHistory &history = fv.geoHistory();
       std::cout << '/';
       for (unsigned int h = 2; h < history.size(); ++h) {
-        std::cout << '/' << history[h].logicalPart().name().ns()
-                  << ":" << history[h].logicalPart().name().name() << '[' << history[h].copyno() << ']';
+        std::cout << '/' << history[h].logicalPart().name().ns() << ":" << history[h].logicalPart().name().name() << '['
+                  << history[h].copyno() << ']';
       }
       if (printMaterial_)
         std::cout << " Material: |" << fv.logicalPart().material().name() << "|";
@@ -140,25 +131,24 @@ ListIds::analyze(const edm::Event& evt, const edm::EventSetup& setup){
   } while (fv.next());
   std::cout << std::endl;
 
-  std::cout << "______________________________ std::vector<GeomDet*> from TrackerGeometry::dets() ______________________________" << std::endl;
+  std::cout << "______________________________ std::vector<GeomDet*> from TrackerGeometry::dets() "
+               "______________________________"
+            << std::endl;
   edm::ESHandle<TrackerGeometry> hGeo;
-  setup.get<TrackerDigiGeometryRecord>().get( hGeo );
+  setup.get<TrackerDigiGeometryRecord>().get(hGeo);
 
   std::cout << std::fixed << std::setprecision(3);
-  auto const & dets = hGeo->dets();
+  auto const &dets = hGeo->dets();
   for (unsigned int i = 0; i < dets.size(); ++i) {
-    const GeomDet & det = *dets[i];
+    const GeomDet &det = *dets[i];
 
     // Surface::PositionType is a typedef for Point3DBase<float,GlobalTag> a.k.a. GlobalPoint
-    const Surface::PositionType & p = det.position();
+    const Surface::PositionType &p = det.position();
     math::XYZVector position(p.x(), p.y(), p.z());
 
-    std::cout << det.subDetector() << '\t'
-              << det.geographicalId().det() << '\t'
-              << det.geographicalId().subdetId() << '\t'
-              << det.geographicalId().rawId() << "\t"
-              << position;
-    const std::vector<const GeomDet*> & parts = det.components();
+    std::cout << det.subDetector() << '\t' << det.geographicalId().det() << '\t' << det.geographicalId().subdetId()
+              << '\t' << det.geographicalId().rawId() << "\t" << position;
+    const std::vector<const GeomDet *> &parts = det.components();
     if (!parts.empty()) {
       std::cout << "\t[" << parts[0]->geographicalId().rawId();
       for (unsigned int j = 1; j < parts.size(); ++j)
@@ -167,12 +157,9 @@ ListIds::analyze(const edm::Event& evt, const edm::EventSetup& setup){
     }
     std::cout << std::endl;
   }
-
 }
 
-void
-ListIds::endJob() {
-}
+void ListIds::endJob() {}
 
 //-------------------------------------------------------------------------
 // define as a plugin

--- a/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
@@ -17,32 +17,31 @@
 #include "SimDataFormats/ValidationFormats/interface/MaterialAccountingDetector.h"
 #include "MaterialAccountingGroup.h"
 
-double const MaterialAccountingGroup::s_tolerance = 0.01; // 100um should be small enough that no elements from different layers/groups are so close
+double const MaterialAccountingGroup::s_tolerance =
+    0.01;  // 100um should be small enough that no elements from different layers/groups are so close
 
-MaterialAccountingGroup::MaterialAccountingGroup( const std::string & name, const DDCompactView & geometry ) :
-  m_name( name ),
-  m_elements(),
-  m_boundingbox(),
-  m_accounting(),
-  m_errors(),
-  m_tracks( 0 ),
-  m_counted( false ),
-  m_file( nullptr )
-{
+MaterialAccountingGroup::MaterialAccountingGroup(const std::string& name, const DDCompactView& geometry)
+    : m_name(name),
+      m_elements(),
+      m_boundingbox(),
+      m_accounting(),
+      m_errors(),
+      m_tracks(0),
+      m_counted(false),
+      m_file(nullptr) {
   // retrieve the elements from DDD
   DDSpecificsMatchesValueFilter filter{DDValue("TrackingMaterialGroup", name)};
-  DDFilteredView fv( geometry,filter );
+  DDFilteredView fv(geometry, filter);
   LogTrace("MaterialAccountingGroup") << "Elements within: " << name << std::endl;
   while (fv.next()) {
     // DD3Vector and DDTranslation are the same type as math::XYZVector
     math::XYZVector position = fv.translation() / 10.;  // mm -> cm
     LogTrace("MaterialAccountingGroup") << "Adding element at(r,z): ("
-              << GlobalPoint(position.x(), position.y(), position.z()).perp()
-              << ", " << GlobalPoint(position.x(), position.y(), position.z()).z()
-              << ") cm" << std::endl;
-    LogTrace("MaterialAccountingGroup") << "Name of added element: "
-                                        << fv.logicalPart().toString() << std::endl;
-    m_elements.push_back( GlobalPoint(position.x(), position.y(), position.z()) );
+                                        << GlobalPoint(position.x(), position.y(), position.z()).perp() << ", "
+                                        << GlobalPoint(position.x(), position.y(), position.z()).z() << ") cm"
+                                        << std::endl;
+    LogTrace("MaterialAccountingGroup") << "Name of added element: " << fv.logicalPart().toString() << std::endl;
+    m_elements.push_back(GlobalPoint(position.x(), position.y(), position.z()));
   }
 
   // grow the bounding box
@@ -50,34 +49,31 @@ MaterialAccountingGroup::MaterialAccountingGroup( const std::string & name, cons
     m_boundingbox.grow(m_elements[i].perp(), m_elements[i].z());
   }
   m_boundingbox.grow(s_tolerance);
-  LogTrace("MaterialAccountingGroup") << "Final BBox r_range: "
-            << m_boundingbox.range_r().first << ", " << m_boundingbox.range_r().second
-            << std::endl
-            << "Final BBox z_range: "
-            << m_boundingbox.range_z().first << ", " << m_boundingbox.range_z().second
-            << std::endl;
+  LogTrace("MaterialAccountingGroup") << "Final BBox r_range: " << m_boundingbox.range_r().first << ", "
+                                      << m_boundingbox.range_r().second << std::endl
+                                      << "Final BBox z_range: " << m_boundingbox.range_z().first << ", "
+                                      << m_boundingbox.range_z().second << std::endl;
 
   // initialize the histograms
-  m_dedx_spectrum   = new TH1F((m_name + "_dedx_spectrum").c_str(),     "Energy loss spectrum",       1000,    0,   1);
-  m_radlen_spectrum = new TH1F((m_name + "_radlen_spectrum").c_str(),   "Radiation lengths spectrum", 1000,    0,   1);
-  m_dedx_vs_eta     = new TProfile((m_name + "_dedx_vs_eta").c_str(),   "Energy loss vs. eta",         600,   -3,   3);
-  m_dedx_vs_z       = new TProfile((m_name + "_dedx_vs_z").c_str(),     "Energy loss vs. Z",          6000, -300, 300);
-  m_dedx_vs_r       = new TProfile((m_name + "_dedx_vs_r").c_str(),     "Energy loss vs. R",          1200,    0, 120);
-  m_radlen_vs_eta   = new TProfile((m_name + "_radlen_vs_eta").c_str(), "Radiation lengths vs. eta",   600,   -3,   3);
-  m_radlen_vs_z     = new TProfile((m_name + "_radlen_vs_z").c_str(),   "Radiation lengths vs. Z",    6000, -300, 300);
-  m_radlen_vs_r     = new TProfile((m_name + "_radlen_vs_r").c_str(),   "Radiation lengths vs. R",    1200,    0, 120);
-  m_dedx_spectrum->SetDirectory( nullptr );
-  m_radlen_spectrum->SetDirectory( nullptr );
-  m_dedx_vs_eta->SetDirectory( nullptr );
-  m_dedx_vs_z->SetDirectory( nullptr );
-  m_dedx_vs_r->SetDirectory( nullptr );
-  m_radlen_vs_eta->SetDirectory( nullptr );
-  m_radlen_vs_z->SetDirectory( nullptr );
-  m_radlen_vs_r->SetDirectory( nullptr );
+  m_dedx_spectrum = new TH1F((m_name + "_dedx_spectrum").c_str(), "Energy loss spectrum", 1000, 0, 1);
+  m_radlen_spectrum = new TH1F((m_name + "_radlen_spectrum").c_str(), "Radiation lengths spectrum", 1000, 0, 1);
+  m_dedx_vs_eta = new TProfile((m_name + "_dedx_vs_eta").c_str(), "Energy loss vs. eta", 600, -3, 3);
+  m_dedx_vs_z = new TProfile((m_name + "_dedx_vs_z").c_str(), "Energy loss vs. Z", 6000, -300, 300);
+  m_dedx_vs_r = new TProfile((m_name + "_dedx_vs_r").c_str(), "Energy loss vs. R", 1200, 0, 120);
+  m_radlen_vs_eta = new TProfile((m_name + "_radlen_vs_eta").c_str(), "Radiation lengths vs. eta", 600, -3, 3);
+  m_radlen_vs_z = new TProfile((m_name + "_radlen_vs_z").c_str(), "Radiation lengths vs. Z", 6000, -300, 300);
+  m_radlen_vs_r = new TProfile((m_name + "_radlen_vs_r").c_str(), "Radiation lengths vs. R", 1200, 0, 120);
+  m_dedx_spectrum->SetDirectory(nullptr);
+  m_radlen_spectrum->SetDirectory(nullptr);
+  m_dedx_vs_eta->SetDirectory(nullptr);
+  m_dedx_vs_z->SetDirectory(nullptr);
+  m_dedx_vs_r->SetDirectory(nullptr);
+  m_radlen_vs_eta->SetDirectory(nullptr);
+  m_radlen_vs_z->SetDirectory(nullptr);
+  m_radlen_vs_r->SetDirectory(nullptr);
 }
 
-MaterialAccountingGroup::~MaterialAccountingGroup(void)
-{
+MaterialAccountingGroup::~MaterialAccountingGroup(void) {
   delete m_dedx_spectrum;
   delete m_dedx_vs_eta;
   delete m_dedx_vs_z;
@@ -92,37 +88,28 @@ MaterialAccountingGroup::~MaterialAccountingGroup(void)
 // (sorting the m_elements, partitioning the bounding box, ...)
 // but is it worth?
 // especially with the segmentation of the layers ?
-bool MaterialAccountingGroup::inside( const MaterialAccountingDetector& detector ) const
-{
-  const GlobalPoint & position = detector.position();
+bool MaterialAccountingGroup::inside(const MaterialAccountingDetector& detector) const {
+  const GlobalPoint& position = detector.position();
   // first check to see if the point is inside the bounding box
-  LogTrace("MaterialAccountingGroup") << "Testing position: (x, y, z, r) = "
-            << position.x() << ", " << position.y()
-            << ", " << position.z() << ", " << position.perp()
-            << std::endl;
+  LogTrace("MaterialAccountingGroup") << "Testing position: (x, y, z, r) = " << position.x() << ", " << position.y()
+                                      << ", " << position.z() << ", " << position.perp() << std::endl;
   if (not m_boundingbox.inside(position.perp(), position.z())) {
-    LogTrace("MaterialAccountingGroup") << "r outside of: ("
-              << m_boundingbox.range_r().first << ", "
-              << m_boundingbox.range_r().second
-              << "), Z ouside of: ("
-              << m_boundingbox.range_z().first << ", "
-              << m_boundingbox.range_z().second << ")" << std::endl;
+    LogTrace("MaterialAccountingGroup") << "r outside of: (" << m_boundingbox.range_r().first << ", "
+                                        << m_boundingbox.range_r().second << "), Z ouside of: ("
+                                        << m_boundingbox.range_z().first << ", " << m_boundingbox.range_z().second
+                                        << ")" << std::endl;
     return false;
   } else {
     // now check if the point is actually close enough to any element
-    LogTrace("MaterialAccountingGroup") << "r within: ("
-              << m_boundingbox.range_r().first << ", "
-              << m_boundingbox.range_r().second
-              << "), Z within: ("
-              << m_boundingbox.range_z().first << ", "
-              << m_boundingbox.range_z().second << ")" << std::endl;
+    LogTrace("MaterialAccountingGroup") << "r within: (" << m_boundingbox.range_r().first << ", "
+                                        << m_boundingbox.range_r().second << "), Z within: ("
+                                        << m_boundingbox.range_z().first << ", " << m_boundingbox.range_z().second
+                                        << ")" << std::endl;
     for (unsigned int i = 0; i < m_elements.size(); ++i) {
-      LogTrace("MaterialAccountingGroup") << "Closest testing agains(x, y, z, r): ("
-                << m_elements[i].x() << ", " << m_elements[i].y()
-                << ", " << m_elements[i].z() << ", " << m_elements[i].perp() << ") --> "
-                << (position - m_elements[i]).mag()
-                << " vs tolerance: " << s_tolerance
-                << std::endl;
+      LogTrace("MaterialAccountingGroup")
+          << "Closest testing agains(x, y, z, r): (" << m_elements[i].x() << ", " << m_elements[i].y() << ", "
+          << m_elements[i].z() << ", " << m_elements[i].perp() << ") --> " << (position - m_elements[i]).mag()
+          << " vs tolerance: " << s_tolerance << std::endl;
       if ((position - m_elements[i]).mag2() < (s_tolerance * s_tolerance))
         return true;
     }
@@ -130,8 +117,7 @@ bool MaterialAccountingGroup::inside( const MaterialAccountingDetector& detector
   }
 }
 
-bool MaterialAccountingGroup::addDetector( const MaterialAccountingDetector& detector )
-{
+bool MaterialAccountingGroup::addDetector(const MaterialAccountingDetector& detector) {
   if (not inside(detector))
     return false;
 
@@ -147,30 +133,29 @@ void MaterialAccountingGroup::endOfTrack(void) {
   // add a detector
   if (m_counted) {
     m_accounting += m_buffer;
-    m_errors     += m_buffer * m_buffer;
+    m_errors += m_buffer * m_buffer;
     ++m_tracks;
 
-    GlobalPoint average( (m_buffer.in().x() + m_buffer.out().x()) / 2.,
-                         (m_buffer.in().y() + m_buffer.out().y()) / 2.,
-                         (m_buffer.in().z() + m_buffer.out().z()) / 2. );
-    m_dedx_spectrum->Fill(   m_buffer.energyLoss() );
-    m_radlen_spectrum->Fill( m_buffer.radiationLengths() );
-    m_dedx_vs_eta->Fill(   average.eta(),  m_buffer.energyLoss(),       1. );
-    m_dedx_vs_z->Fill(     average.z(),    m_buffer.energyLoss(),       1. );
-    m_dedx_vs_r->Fill(     average.perp(), m_buffer.energyLoss(),       1. );
-    m_radlen_vs_eta->Fill( average.eta(),  m_buffer.radiationLengths(), 1. );
-    m_radlen_vs_z->Fill(   average.z(),    m_buffer.radiationLengths(), 1. );
-    m_radlen_vs_r->Fill(   average.perp(), m_buffer.radiationLengths(), 1. );
+    GlobalPoint average((m_buffer.in().x() + m_buffer.out().x()) / 2.,
+                        (m_buffer.in().y() + m_buffer.out().y()) / 2.,
+                        (m_buffer.in().z() + m_buffer.out().z()) / 2.);
+    m_dedx_spectrum->Fill(m_buffer.energyLoss());
+    m_radlen_spectrum->Fill(m_buffer.radiationLengths());
+    m_dedx_vs_eta->Fill(average.eta(), m_buffer.energyLoss(), 1.);
+    m_dedx_vs_z->Fill(average.z(), m_buffer.energyLoss(), 1.);
+    m_dedx_vs_r->Fill(average.perp(), m_buffer.energyLoss(), 1.);
+    m_radlen_vs_eta->Fill(average.eta(), m_buffer.radiationLengths(), 1.);
+    m_radlen_vs_z->Fill(average.z(), m_buffer.radiationLengths(), 1.);
+    m_radlen_vs_r->Fill(average.perp(), m_buffer.radiationLengths(), 1.);
   }
   m_counted = false;
-  m_buffer  = MaterialAccountingStep();
+  m_buffer = MaterialAccountingStep();
 }
 
-void MaterialAccountingGroup::savePlot(TH1F * plot, const std::string & name)
-{
+void MaterialAccountingGroup::savePlot(TH1F* plot, const std::string& name) {
   TCanvas canvas(name.c_str(), plot->GetTitle(), 1280, 1024);
-  plot->SetFillColor(15);       // grey
-  plot->SetLineColor(1);        // black
+  plot->SetFillColor(15);  // grey
+  plot->SetLineColor(1);   // black
   plot->Draw("c e");
   canvas.GetFrame()->SetFillColor(kWhite);
   canvas.Draw();
@@ -180,22 +165,22 @@ void MaterialAccountingGroup::savePlot(TH1F * plot, const std::string & name)
   plot->SetDirectory(m_file);
 }
 
-void MaterialAccountingGroup::savePlot(TProfile * plot, float average, const std::string & name)
-{
+void MaterialAccountingGroup::savePlot(TProfile* plot, float average, const std::string& name) {
   // Nota Bene:
   // these "line" plots are not deleted explicitly since
   //   - deleting them before saving them to a TFile will not save them
   //   - deleting them after the TFile they're stored into results in a SEGV
   // ROOT is probably "taking care" (read: messing things up) somehow...
-  TH1F * line = new TH1F((name + "_par").c_str(), "Parametrization", 1, plot->GetXaxis()->GetXmin(), plot->GetXaxis()->GetXmax());
+  TH1F* line =
+      new TH1F((name + "_par").c_str(), "Parametrization", 1, plot->GetXaxis()->GetXmin(), plot->GetXaxis()->GetXmax());
   line->SetBinContent(1, average);
 
   TCanvas canvas(name.c_str(), plot->GetTitle(), 1280, 1024);
-  plot->SetFillColor(15);       // grey
-  plot->SetLineColor(1);        // black
+  plot->SetFillColor(15);  // grey
+  plot->SetLineColor(1);   // black
   plot->SetLineWidth(2);
   plot->Draw("c e6");
-  line->SetLineColor(2);        // red
+  line->SetLineColor(2);  // red
   line->SetLineWidth(2);
   line->Draw("same");
   canvas.GetFrame()->SetFillColor(kWhite);
@@ -208,28 +193,28 @@ void MaterialAccountingGroup::savePlot(TProfile * plot, float average, const std
 }
 
 /// get some infos
-std::string MaterialAccountingGroup::info(void) const
-{
+std::string MaterialAccountingGroup::info(void) const {
   std::stringstream out;
-  out << std::setw(48) << std::left << m_name << std::right << std::fixed;;
-  out << "BBox: " << std::setprecision(1) << std::setw(6) << m_boundingbox.range_z().first << " < Z < " << std::setprecision(1) << std::setw(6) << m_boundingbox.range_z().second;
-  out << ", "     << std::setprecision(1) << std::setw(5) << m_boundingbox.range_r().first << " < R < " << std::setprecision(1) << std::setw(5) << m_boundingbox.range_r().second;
+  out << std::setw(48) << std::left << m_name << std::right << std::fixed;
+  ;
+  out << "BBox: " << std::setprecision(1) << std::setw(6) << m_boundingbox.range_z().first << " < Z < "
+      << std::setprecision(1) << std::setw(6) << m_boundingbox.range_z().second;
+  out << ", " << std::setprecision(1) << std::setw(5) << m_boundingbox.range_r().first << " < R < "
+      << std::setprecision(1) << std::setw(5) << m_boundingbox.range_r().second;
   out << "   Elements: " << std::setw(6) << m_elements.size();
   return out.str();
 }
 
-
-void MaterialAccountingGroup::savePlots(void)
-{
+void MaterialAccountingGroup::savePlots(void) {
   m_file = new TFile((m_name + ".root").c_str(), "RECREATE");
-  savePlot(m_dedx_spectrum,   m_name + "_dedx_spectrum");
+  savePlot(m_dedx_spectrum, m_name + "_dedx_spectrum");
   savePlot(m_radlen_spectrum, m_name + "_radlen_spectrum");
-  savePlot(m_dedx_vs_eta,     averageEnergyLoss(),       m_name + "_dedx_vs_eta");
-  savePlot(m_dedx_vs_z,       averageEnergyLoss(),       m_name + "_dedx_vs_z");
-  savePlot(m_dedx_vs_r,       averageEnergyLoss(),       m_name + "_dedx_vs_r");
-  savePlot(m_radlen_vs_eta,   averageRadiationLengths(), m_name + "_radlen_vs_eta");
-  savePlot(m_radlen_vs_z,     averageRadiationLengths(), m_name + "_radlen_vs_z");
-  savePlot(m_radlen_vs_r,     averageRadiationLengths(), m_name + "_radlen_vs_r");
+  savePlot(m_dedx_vs_eta, averageEnergyLoss(), m_name + "_dedx_vs_eta");
+  savePlot(m_dedx_vs_z, averageEnergyLoss(), m_name + "_dedx_vs_z");
+  savePlot(m_dedx_vs_r, averageEnergyLoss(), m_name + "_dedx_vs_r");
+  savePlot(m_radlen_vs_eta, averageRadiationLengths(), m_name + "_radlen_vs_eta");
+  savePlot(m_radlen_vs_z, averageRadiationLengths(), m_name + "_radlen_vs_z");
+  savePlot(m_radlen_vs_r, averageRadiationLengths(), m_name + "_radlen_vs_r");
   m_file->Write();
   m_file->Close();
 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.h
@@ -18,50 +18,37 @@ class DDCompactView;
 
 class MaterialAccountingGroup {
 private:
-
   // quick implementation of a bounding cilinder
   class BoundingBox {
   public:
+    BoundingBox(double min_r, double max_r, double min_z, double max_z)
+        : r_min(min_r), r_max(max_r), z_min(min_z), z_max(max_z) {}
 
-    BoundingBox(double min_r, double max_r, double min_z, double max_z) :
-      r_min(min_r),
-      r_max(max_r),
-      z_min(min_z),
-      z_max(max_z)
-    { }
-
-    BoundingBox() :
-      r_min(0.),
-      r_max(0.),
-      z_min(0.),
-      z_max(0.)
-    { }
+    BoundingBox() : r_min(0.), r_max(0.), z_min(0.), z_max(0.) {}
 
     void grow(double r, double z) {
-      if (r < r_min) r_min = r;
-      if (r > r_max) r_max = r;
-      if (z < z_min) z_min = z;
-      if (z > z_max) z_max = z;
+      if (r < r_min)
+        r_min = r;
+      if (r > r_max)
+        r_max = r;
+      if (z < z_min)
+        z_min = z;
+      if (z > z_max)
+        z_max = z;
     }
 
     void grow(double skin) {
-      r_min -= skin;    // yes, we allow r_min to go negative
+      r_min -= skin;  // yes, we allow r_min to go negative
       r_max += skin;
       z_min -= skin;
       z_max += skin;
     }
 
-    bool inside(double r, double z) const {
-      return (r >= r_min and r <= r_max and z >= z_min and z <= z_max);
-    }
+    bool inside(double r, double z) const { return (r >= r_min and r <= r_max and z >= z_min and z <= z_max); }
 
-    std::pair<double, double> range_r() const {
-      return std::make_pair(r_min, r_max);
-    }
+    std::pair<double, double> range_r() const { return std::make_pair(r_min, r_max); }
 
-    std::pair<double, double> range_z() const {
-      return std::make_pair(z_min, z_max);
-    }
+    std::pair<double, double> range_z() const { return std::make_pair(z_min, z_max); }
 
   private:
     double r_min;
@@ -69,90 +56,71 @@ private:
     double z_min;
     double z_max;
   };
-  
+
 public:
   /// explicit constructors
-  MaterialAccountingGroup( const std::string & name, const DDCompactView & geometry );
-    
+  MaterialAccountingGroup(const std::string& name, const DDCompactView& geometry);
+
   /// destructor
-  ~MaterialAccountingGroup( void );
+  ~MaterialAccountingGroup(void);
 
 private:
   /// stop default copy ctor
-  MaterialAccountingGroup(const MaterialAccountingGroup & layer) = delete;
+  MaterialAccountingGroup(const MaterialAccountingGroup& layer) = delete;
 
   /// stop default assignment operator
-  MaterialAccountingGroup& operator=( const MaterialAccountingGroup & layer) = delete;
+  MaterialAccountingGroup& operator=(const MaterialAccountingGroup& layer) = delete;
 
 public:
   /// buffer material from a detector, if the detector is inside the DetLayer bounds
-  bool addDetector( const MaterialAccountingDetector& detector );
- 
+  bool addDetector(const MaterialAccountingDetector& detector);
+
   /// commit the buffer and reset the "already hit by this track" flag
-  void endOfTrack( void );
-  
-  /// check if detector is inside any part of this layer 
-  bool inside( const MaterialAccountingDetector& detector ) const;
+  void endOfTrack(void);
+
+  /// check if detector is inside any part of this layer
+  bool inside(const MaterialAccountingDetector& detector) const;
 
   /// Return the bouding limit in R for the hosted Group
-  std::pair<double, double> getBoundingR() const {return m_boundingbox.range_r();};
+  std::pair<double, double> getBoundingR() const { return m_boundingbox.range_r(); };
 
   /// Return the bouding limit in Z for the hosted Group
-  std::pair<double, double> getBoundingZ() const {return m_boundingbox.range_z();};
+  std::pair<double, double> getBoundingZ() const { return m_boundingbox.range_z(); };
 
   /// return the average normalized material accounting informations
-  MaterialAccountingStep average(void) const 
-  {
-    return m_tracks ? m_accounting / m_tracks : MaterialAccountingStep();
-  }
+  MaterialAccountingStep average(void) const { return m_tracks ? m_accounting / m_tracks : MaterialAccountingStep(); }
 
   /// return the average normalized layer thickness
-  double averageLength(void) const 
-  {
-    return m_tracks ? m_accounting.length() / m_tracks : 0.;
-  }
-  
+  double averageLength(void) const { return m_tracks ? m_accounting.length() / m_tracks : 0.; }
+
   /// return the average normalized number of radiation lengths
-  double averageRadiationLengths(void) const 
-  {
-    return m_tracks ? m_accounting.radiationLengths() / m_tracks : 0.;
-  }
-  
+  double averageRadiationLengths(void) const { return m_tracks ? m_accounting.radiationLengths() / m_tracks : 0.; }
+
   /// return the average normalized energy loss density factor for Bethe-Bloch
-  double averageEnergyLoss(void) const 
-  {
-    return m_tracks ? m_accounting.energyLoss() / m_tracks : 0.;
-  }
- 
+  double averageEnergyLoss(void) const { return m_tracks ? m_accounting.energyLoss() / m_tracks : 0.; }
+
   /// return the sigma of the normalized layer thickness
-  double sigmaLength(void) const 
-  {
-    return m_tracks ? std::sqrt(m_errors.length() / m_tracks - averageLength()*averageLength()) : 0.;
+  double sigmaLength(void) const {
+    return m_tracks ? std::sqrt(m_errors.length() / m_tracks - averageLength() * averageLength()) : 0.;
   }
-  
+
   /// return the sigma of the normalized number of radiation lengths
-  double sigmaRadiationLengths(void) const 
-  {
-    return m_tracks ? std::sqrt(m_errors.radiationLengths() / m_tracks - averageRadiationLengths()*averageRadiationLengths()) : 0.;
+  double sigmaRadiationLengths(void) const {
+    return m_tracks ? std::sqrt(m_errors.radiationLengths() / m_tracks -
+                                averageRadiationLengths() * averageRadiationLengths())
+                    : 0.;
   }
-  
+
   /// return the sigma of the normalized energy loss density factor for Bethe-Bloch
-  double sigmaEnergyLoss(void) const 
-  {
-    return m_tracks ? std::sqrt(m_errors.energyLoss() / m_tracks - averageEnergyLoss()*averageEnergyLoss()) : 0.;
+  double sigmaEnergyLoss(void) const {
+    return m_tracks ? std::sqrt(m_errors.energyLoss() / m_tracks - averageEnergyLoss() * averageEnergyLoss()) : 0.;
   }
- 
-  /// return the number of tracks that hit this layer 
-  unsigned int tracks(void) const 
-  {
-    return m_tracks;
-  }
- 
-  /// get the layer name 
-  const std::string & name(void) const
-  {
-    return m_name;
-  }
+
+  /// return the number of tracks that hit this layer
+  unsigned int tracks(void) const { return m_tracks; }
+
+  /// get the layer name
+  const std::string& name(void) const { return m_name; }
 
   /// get some infos
   std::string info(void) const;
@@ -164,39 +132,37 @@ public:
   // correspond, roughly, to the center of each subcomponent of this
   // group.
 
-  const std::vector<GlobalPoint> & elements(void) const {
-    return m_elements;
-  }
+  const std::vector<GlobalPoint>& elements(void) const { return m_elements; }
 
 private:
-  void savePlot(TH1F * plot, const std::string & name);
-  void savePlot(TProfile * plot, float average, const std::string & name);
- 
-  std::string                   m_name;
-  std::vector<GlobalPoint>      m_elements;
-  BoundingBox                   m_boundingbox;
-  MaterialAccountingStep        m_accounting;
-  MaterialAccountingStep        m_errors;
-  unsigned int                  m_tracks;
-  bool                          m_counted;
-  MaterialAccountingStep        m_buffer;
-  
+  void savePlot(TH1F* plot, const std::string& name);
+  void savePlot(TProfile* plot, float average, const std::string& name);
+
+  std::string m_name;
+  std::vector<GlobalPoint> m_elements;
+  BoundingBox m_boundingbox;
+  MaterialAccountingStep m_accounting;
+  MaterialAccountingStep m_errors;
+  unsigned int m_tracks;
+  bool m_counted;
+  MaterialAccountingStep m_buffer;
+
   // plots of material effects distribution
-  TH1F * m_dedx_spectrum;
-  TH1F * m_radlen_spectrum;
+  TH1F* m_dedx_spectrum;
+  TH1F* m_radlen_spectrum;
   // plots of material effects vs. η / Z / R
-  TProfile * m_dedx_vs_eta;
-  TProfile * m_dedx_vs_z;
-  TProfile * m_dedx_vs_r;
-  TProfile * m_radlen_vs_eta;
-  TProfile * m_radlen_vs_z;
-  TProfile * m_radlen_vs_r;
+  TProfile* m_dedx_vs_eta;
+  TProfile* m_dedx_vs_z;
+  TProfile* m_dedx_vs_r;
+  TProfile* m_radlen_vs_eta;
+  TProfile* m_radlen_vs_z;
+  TProfile* m_radlen_vs_r;
 
   // file to store plots into
-  mutable TFile * m_file;
+  mutable TFile* m_file;
 
   // 100um should be small enough that no elements from different layers/groups are so close
   static double const s_tolerance;
 };
 
-#endif // MaterialAccountingGroup_h
+#endif  // MaterialAccountingGroup_h

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.cc
@@ -1,4 +1,4 @@
-#include <iostream>     // FIXME: switch to MessagLogger & friends
+#include <iostream>  // FIXME: switch to MessagLogger & friends
 #include <fstream>
 #include <sstream>
 #include <vector>
@@ -26,12 +26,11 @@
 #include "TrackingMaterialPlotter.h"
 
 //-------------------------------------------------------------------------
-TrackingMaterialAnalyser::TrackingMaterialAnalyser(const edm::ParameterSet& iPSet)
-{
-  m_materialToken           = consumes<std::vector<MaterialAccountingTrack> >(
-      iPSet.getParameter<edm::InputTag>("MaterialAccounting"));
-  m_groupNames              = iPSet.getParameter<std::vector<std::string> >("Groups");
-  const std::string & splitmode = iPSet.getParameter<std::string>("SplitMode");
+TrackingMaterialAnalyser::TrackingMaterialAnalyser(const edm::ParameterSet& iPSet) {
+  m_materialToken =
+      consumes<std::vector<MaterialAccountingTrack> >(iPSet.getParameter<edm::InputTag>("MaterialAccounting"));
+  m_groupNames = iPSet.getParameter<std::vector<std::string> >("Groups");
+  const std::string& splitmode = iPSet.getParameter<std::string>("SplitMode");
   if (strcasecmp(splitmode.c_str(), "NearestLayer") == 0) {
     m_splitMode = NEAREST_LAYER;
   } else if (strcasecmp(splitmode.c_str(), "InnerLayer") == 0) {
@@ -40,45 +39,49 @@ TrackingMaterialAnalyser::TrackingMaterialAnalyser(const edm::ParameterSet& iPSe
     m_splitMode = OUTER_LAYER;
   } else {
     m_splitMode = UNDEFINED;
-    throw edm::Exception(edm::errors::LogicError) << "Invalid SplitMode \"" << splitmode << "\". Acceptable values are \"NearestLayer\", \"InnerLayer\", \"OuterLayer\".";
+    throw edm::Exception(edm::errors::LogicError)
+        << "Invalid SplitMode \"" << splitmode
+        << "\". Acceptable values are \"NearestLayer\", \"InnerLayer\", \"OuterLayer\".";
   }
-  m_skipAfterLastDetector   = iPSet.getParameter<bool>("SkipAfterLastDetector");
+  m_skipAfterLastDetector = iPSet.getParameter<bool>("SkipAfterLastDetector");
   m_skipBeforeFirstDetector = iPSet.getParameter<bool>("SkipBeforeFirstDetector");
-  m_saveSummaryPlot         = iPSet.getParameter<bool>("SaveSummaryPlot");
-  m_saveDetailedPlots       = iPSet.getParameter<bool>("SaveDetailedPlots");
-  m_saveParameters          = iPSet.getParameter<bool>("SaveParameters");
-  m_saveXml                 = iPSet.getParameter<bool>("SaveXML");
+  m_saveSummaryPlot = iPSet.getParameter<bool>("SaveSummaryPlot");
+  m_saveDetailedPlots = iPSet.getParameter<bool>("SaveDetailedPlots");
+  m_saveParameters = iPSet.getParameter<bool>("SaveParameters");
+  m_saveXml = iPSet.getParameter<bool>("SaveXML");
   if (m_saveSummaryPlot)
-    m_plotter               = new TrackingMaterialPlotter( 300., 120., 10 );      // 10x10 points per cm2
+    m_plotter = new TrackingMaterialPlotter(300., 120., 10);  // 10x10 points per cm2
   else
-    m_plotter               = nullptr;
+    m_plotter = nullptr;
 }
 
 //-------------------------------------------------------------------------
-TrackingMaterialAnalyser::~TrackingMaterialAnalyser(void)
-{
+TrackingMaterialAnalyser::~TrackingMaterialAnalyser(void) {
   if (m_plotter)
     delete m_plotter;
 }
 
 //-------------------------------------------------------------------------
-void TrackingMaterialAnalyser::saveParameters(const char* name)
-{
+void TrackingMaterialAnalyser::saveParameters(const char* name) {
   std::ofstream parameters(name);
   std::cout << std::endl;
   for (unsigned int i = 0; i < m_groups.size(); ++i) {
-    MaterialAccountingGroup & layer = *(m_groups[i]);
+    MaterialAccountingGroup& layer = *(m_groups[i]);
     std::cout << layer.name() << std::endl;
     std::cout << boost::format("\tnumber of hits:               %9d") % layer.tracks() << std::endl;
-    std::cout << boost::format("\tnormalized segment length:    %9.1f ± %9.1f cm")  % layer.averageLength()           % layer.sigmaLength()           << std::endl;
-    std::cout << boost::format("\tnormalized radiation lengths: %9.3f ± %9.3f")     % layer.averageRadiationLengths() % layer.sigmaRadiationLengths() << std::endl;
-    std::cout << boost::format("\tnormalized energy loss:       %6.5fe-03 ± %6.5fe-03 GeV") % layer.averageEnergyLoss()       % layer.sigmaEnergyLoss()       << std::endl;
-    parameters << boost::format("%-20s\t%7d\t%5.1f ± %5.1f cm\t%6.4f ± %6.4f \t%6.4fe-03 ± %6.4fe-03 GeV")
-                                % layer.name()
-                                % layer.tracks()
-                                % layer.averageLength()               % layer.sigmaLength()
-                                % layer.averageRadiationLengths()     % layer.sigmaRadiationLengths()
-                                % layer.averageEnergyLoss()           % layer.sigmaEnergyLoss()
+    std::cout << boost::format("\tnormalized segment length:    %9.1f ± %9.1f cm") % layer.averageLength() %
+                     layer.sigmaLength()
+              << std::endl;
+    std::cout << boost::format("\tnormalized radiation lengths: %9.3f ± %9.3f") % layer.averageRadiationLengths() %
+                     layer.sigmaRadiationLengths()
+              << std::endl;
+    std::cout << boost::format("\tnormalized energy loss:       %6.5fe-03 ± %6.5fe-03 GeV") %
+                     layer.averageEnergyLoss() % layer.sigmaEnergyLoss()
+              << std::endl;
+    parameters << boost::format("%-20s\t%7d\t%5.1f ± %5.1f cm\t%6.4f ± %6.4f \t%6.4fe-03 ± %6.4fe-03 GeV") %
+                      layer.name() % layer.tracks() % layer.averageLength() % layer.sigmaLength() %
+                      layer.averageRadiationLengths() % layer.sigmaRadiationLengths() % layer.averageEnergyLoss() %
+                      layer.sigmaEnergyLoss()
                << std::endl;
   }
   std::cout << std::endl;
@@ -87,13 +90,12 @@ void TrackingMaterialAnalyser::saveParameters(const char* name)
 }
 
 //-------------------------------------------------------------------------
-void TrackingMaterialAnalyser::saveXml(const char* name)
-{
+void TrackingMaterialAnalyser::saveXml(const char* name) {
   std::ofstream xml(name);
   xml << "<?xml version=\"1.0\" encoding=\"utf-8\"?>" << std::endl;
   xml << "<Groups>" << std::endl;
   for (unsigned int i = 0; i < m_groups.size(); ++i) {
-    MaterialAccountingGroup & layer = *(m_groups[i]);
+    MaterialAccountingGroup& layer = *(m_groups[i]);
     xml << "  <Group name=\"" << layer.name() << "\">\n"
         << "    <Parameter name=\"TrackerRadLength\" value=\"" << layer.averageRadiationLengths() << "\"/>\n"
         << "    <Parameter name=\"TrackerXi\" value=\"" << layer.averageEnergyLoss() << "\"/>\n"
@@ -104,17 +106,15 @@ void TrackingMaterialAnalyser::saveXml(const char* name)
 }
 
 //-------------------------------------------------------------------------
-void TrackingMaterialAnalyser::saveLayerPlots()
-{
+void TrackingMaterialAnalyser::saveLayerPlots() {
   for (unsigned int i = 0; i < m_groups.size(); ++i) {
-    MaterialAccountingGroup & layer = *(m_groups[i]);
+    MaterialAccountingGroup& layer = *(m_groups[i]);
     layer.savePlots();
   }
 }
 
 //-------------------------------------------------------------------------
-void TrackingMaterialAnalyser::endJob(void)
-{
+void TrackingMaterialAnalyser::endJob(void) {
   if (m_saveParameters)
     saveParameters("parameters");
 
@@ -133,32 +133,30 @@ void TrackingMaterialAnalyser::endJob(void)
 //-------------------------------------------------------------------------
 
 //-------------------------------------------------------------------------
-void TrackingMaterialAnalyser::analyze(const edm::Event& event, const edm::EventSetup& setup)
-{
+void TrackingMaterialAnalyser::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   using namespace edm;
   ESTransientHandle<DDCompactView> hDDD;
-  setup.get<IdealGeometryRecord>().get( hDDD );
+  setup.get<IdealGeometryRecord>().get(hDDD);
 
-  m_groups.reserve( m_groupNames.size() );
+  m_groups.reserve(m_groupNames.size());
   // Initialize m_groups iff it has size equal to zero, so that we are
   // sure it will never be repopulated with the same entries over and
   // over again in the eventloop, at each call of the analyze method.
   if (m_groups.empty()) {
     for (unsigned int i = 0; i < m_groupNames.size(); ++i)
-      m_groups.push_back( new MaterialAccountingGroup( m_groupNames[i], * hDDD) );
+      m_groups.push_back(new MaterialAccountingGroup(m_groupNames[i], *hDDD));
 
-    LogInfo("TrackingMaterialAnalyser")
-        << "TrackingMaterialAnalyser: List of the tracker groups: " << std::endl;
+    LogInfo("TrackingMaterialAnalyser") << "TrackingMaterialAnalyser: List of the tracker groups: " << std::endl;
     for (unsigned int i = 0; i < m_groups.size(); ++i)
-      LogInfo("TrackingMaterialAnalyser")
-        << i << " TrackingMaterialAnalyser:\t" << m_groups[i]->info() << std::endl;
+      LogInfo("TrackingMaterialAnalyser") << i << " TrackingMaterialAnalyser:\t" << m_groups[i]->info() << std::endl;
   }
-  Handle< std::vector<MaterialAccountingTrack> > h_tracks;
+  Handle<std::vector<MaterialAccountingTrack> > h_tracks;
   event.getByToken(m_materialToken, h_tracks);
 
-  for (std::vector<MaterialAccountingTrack>::const_iterator t = h_tracks->begin(), end = h_tracks->end(); t != end; ++t) {
+  for (std::vector<MaterialAccountingTrack>::const_iterator t = h_tracks->begin(), end = h_tracks->end(); t != end;
+       ++t) {
     MaterialAccountingTrack track(*t);
-    split( track );
+    split(track);
   }
 }
 
@@ -171,24 +169,20 @@ void TrackingMaterialAnalyser::analyze(const edm::Event& event, const edm::Event
 // each track are consecutive and adjacent, and that no step can span
 // across 3 layers, since all steps should split at layer boundaries
 
-void TrackingMaterialAnalyser::split( MaterialAccountingTrack & track )
-{
+void TrackingMaterialAnalyser::split(MaterialAccountingTrack& track) {
   using namespace edm;
   // group sensitive detectors by their DetLayer
-  std::vector<int> group( track.detectors().size() );
+  std::vector<int> group(track.detectors().size());
   for (unsigned int i = 0; i < track.detectors().size(); ++i)
-    group[i] = findLayer( track.detectors()[i] );
+    group[i] = findLayer(track.detectors()[i]);
 
   for (unsigned int i = 0; i < group.size(); ++i)
     if (group[i] > 0)
-      LogInfo("TrackingMaterialAnalyser") << "For detector i: " << i << " index: "
-                                          << group[i] << " R-ranges: "
-                                          << m_groups[group[i]-1]->getBoundingR().first
-                                          << ", " << m_groups[group[i]-1]->getBoundingR().second
-                                          << group[i] << " Z-ranges: "
-                                          << m_groups[group[i]-1]->getBoundingZ().first
-                                          << ", " << m_groups[group[i]-1]->getBoundingZ().second
-                                          << std::endl;
+      LogInfo("TrackingMaterialAnalyser") << "For detector i: " << i << " index: " << group[i]
+                                          << " R-ranges: " << m_groups[group[i] - 1]->getBoundingR().first << ", "
+                                          << m_groups[group[i] - 1]->getBoundingR().second << group[i]
+                                          << " Z-ranges: " << m_groups[group[i] - 1]->getBoundingZ().first << ", "
+                                          << m_groups[group[i] - 1]->getBoundingZ().second << std::endl;
 
   unsigned int detectors = track.detectors().size();
   if (detectors == 0) {
@@ -196,21 +190,21 @@ void TrackingMaterialAnalyser::split( MaterialAccountingTrack & track )
     // keep al material as unassigned
     if (m_plotter)
       for (unsigned int i = 1; i < track.steps().size(); ++i)
-        m_plotter->plotSegmentUnassigned( track.steps()[i] );
+        m_plotter->plotSegmentUnassigned(track.steps()[i]);
   } else {
-    const double TOLERANCE = 0.0001;    // 1 um tolerance
+    const double TOLERANCE = 0.0001;  // 1 um tolerance
     std::vector<double> limits(detectors + 2);
 
     // define the trivial limits
     if (m_skipBeforeFirstDetector)
       limits[0] = track.detectors()[0].m_curvilinearIn - TOLERANCE;
     else
-      limits[0] = - TOLERANCE;
+      limits[0] = -TOLERANCE;
     if (m_skipAfterLastDetector)
-      limits[detectors] = track.detectors()[detectors-1].m_curvilinearOut + TOLERANCE;
+      limits[detectors] = track.detectors()[detectors - 1].m_curvilinearOut + TOLERANCE;
     else
       limits[detectors] = track.summary().length() + TOLERANCE;
-    limits[detectors+1] = INFINITY;     // this is probably no more needed, but doesn't harm...
+    limits[detectors + 1] = INFINITY;  // this is probably no more needed, but doesn't harm...
 
     // pick the algorithm to define the non-trivial limits
     switch (m_splitMode) {
@@ -218,7 +212,7 @@ void TrackingMaterialAnalyser::split( MaterialAccountingTrack & track )
       // e.g. the material between pixel barrel 3 and TIB 1 will be split among the two
       case NEAREST_LAYER:
         for (unsigned int i = 1; i < detectors; ++i) {
-          limits[i] = (track.detectors()[i-1].m_curvilinearOut + track.detectors()[i].m_curvilinearIn) / 2.;
+          limits[i] = (track.detectors()[i - 1].m_curvilinearOut + track.detectors()[i].m_curvilinearIn) / 2.;
         }
         break;
 
@@ -233,7 +227,7 @@ void TrackingMaterialAnalyser::split( MaterialAccountingTrack & track )
       // e.g. all material between pixel barrel 3 and TIB 1 will go into the TIB
       case OUTER_LAYER:
         for (unsigned int i = 1; i < detectors; ++i)
-          limits[i] = track.detectors()[i-1].m_curvilinearOut + TOLERANCE;
+          limits[i] = track.detectors()[i - 1].m_curvilinearOut + TOLERANCE;
         break;
 
       case UNDEFINED:
@@ -242,33 +236,32 @@ void TrackingMaterialAnalyser::split( MaterialAccountingTrack & track )
         throw edm::Exception(edm::errors::LogicError) << "Invalid SplitMode";
     }
 
-
-    double begin = 0.;          // beginning of step, along the track
-    double end   = 0.;          // end of step, along the track
-    unsigned int i = 1;         // step conter
+    double begin = 0.;   // beginning of step, along the track
+    double end = 0.;     // end of step, along the track
+    unsigned int i = 1;  // step conter
 
     // skip the material before the first layer
     while (end < limits[0]) {
-      const MaterialAccountingStep & step = track.steps()[i++];
+      const MaterialAccountingStep& step = track.steps()[i++];
       end = begin + step.length();
 
       // do not account material before the first layer
       if (m_plotter)
-        m_plotter->plotSegmentUnassigned( step );
+        m_plotter->plotSegmentUnassigned(step);
 
       begin = end;
     }
 
-    unsigned int index = 0;     // which detector
+    unsigned int index = 0;  // which detector
     while (i < track.steps().size()) {
-      const MaterialAccountingStep & step = track.steps()[i++];
+      const MaterialAccountingStep& step = track.steps()[i++];
 
       end = begin + step.length();
 
       if (begin > limits[detectors]) {
         // segment after last layer and skipping requested in configuation
         if (m_plotter)
-          m_plotter->plotSegmentUnassigned( step );
+          m_plotter->plotSegmentUnassigned(step);
         begin = end;
         continue;
       }
@@ -277,51 +270,51 @@ void TrackingMaterialAnalyser::split( MaterialAccountingTrack & track )
       //   limits[index] <= begin < end <= limits[index+1]
       // or possibly split between 2 layers
       //   limits[index] < begin < limits[index+1] < end <  limits[index+2]
-      if (begin < limits[index] or end > limits[index+2]) {
+      if (begin < limits[index] or end > limits[index + 2]) {
         // sanity check
-        std::cerr << "MaterialAccountingTrack::split(): ERROR: internal logic error, expected " << limits[index] << " < " << begin << " < " << limits[index+1] << std::endl;
+        std::cerr << "MaterialAccountingTrack::split(): ERROR: internal logic error, expected " << limits[index]
+                  << " < " << begin << " < " << limits[index + 1] << std::endl;
         break;
       }
 
-      if (limits[index] <= begin and end <= limits[index+1]) {
+      if (limits[index] <= begin and end <= limits[index + 1]) {
         // step completely inside current detector range
-        track.detectors()[index].account( step, begin, end );
+        track.detectors()[index].account(step, begin, end);
         if (m_plotter)
-          m_plotter->plotSegmentInLayer( step, group[index] );
+          m_plotter->plotSegmentInLayer(step, group[index]);
       } else {
         // step shared beteewn two detectors, transition at limits[index+1]
-        double fraction = (limits[index+1] - begin) / (end - begin);
+        double fraction = (limits[index + 1] - begin) / (end - begin);
         assert(fraction < 1.);
         std::pair<MaterialAccountingStep, MaterialAccountingStep> parts = step.split(fraction);
 
         if (m_plotter) {
           if (index > 0)
-            m_plotter->plotSegmentInLayer( parts.first, group[index] );
+            m_plotter->plotSegmentInLayer(parts.first, group[index]);
           else
             // track outside acceptance, keep as unassocated
-            m_plotter->plotSegmentUnassigned( parts.first );
+            m_plotter->plotSegmentUnassigned(parts.first);
 
-          if (index+1 < detectors)
-            m_plotter->plotSegmentInLayer( parts.second,  group[index+1] );
+          if (index + 1 < detectors)
+            m_plotter->plotSegmentInLayer(parts.second, group[index + 1]);
           else
             // track outside acceptance, keep as unassocated
-            m_plotter->plotSegmentUnassigned( parts.second );
+            m_plotter->plotSegmentUnassigned(parts.second);
         }
 
-        track.detectors()[index].account( parts.first, begin, limits[index+1] );
-        ++index;          // next layer
+        track.detectors()[index].account(parts.first, begin, limits[index + 1]);
+        ++index;  // next layer
         if (index < detectors)
-          track.detectors()[index].account( parts.second, limits[index+1], end );
+          track.detectors()[index].account(parts.second, limits[index + 1], end);
       }
       begin = end;
     }
-
   }
 
   // add the material from each detector to its layer (if there is one and only one)
   for (unsigned int i = 0; i < track.detectors().size(); ++i)
     if (group[i] != 0)
-      m_groups[group[i]-1]->addDetector( track.detectors()[i] );
+      m_groups[group[i] - 1]->addDetector(track.detectors()[i]);
 
   // end of track: commit internal buffers and reset the m_groups internal state for a new track
   for (unsigned int i = 0; i < m_groups.size(); ++i)
@@ -332,32 +325,31 @@ void TrackingMaterialAnalyser::split( MaterialAccountingTrack & track )
 // find the layer index (0: none, 1-3: PixelBarrel,
 //                       4-7: TID, 8-13: TOB, 14-15,28-29: PixelEndcap,
 //                       16-18,30-32: TID, 19-27,33-41: TEC)
-int TrackingMaterialAnalyser::findLayer( const MaterialAccountingDetector & detector )
-{
-  int    index  = 0;
+int TrackingMaterialAnalyser::findLayer(const MaterialAccountingDetector& detector) {
+  int index = 0;
   size_t inside = 0;
   for (size_t i = 0; i < m_groups.size(); ++i)
     if (m_groups[i]->inside(detector)) {
       ++inside;
-      index = i+1;
+      index = i + 1;
     }
   if (inside == 0) {
     index = 0;
-    std::cerr << "TrackingMaterialAnalyser::findLayer(...): ERROR: detector does not belong to any DetLayer" << std::endl;
+    std::cerr << "TrackingMaterialAnalyser::findLayer(...): ERROR: detector does not belong to any DetLayer"
+              << std::endl;
     std::cerr << "TrackingMaterialAnalyser::findLayer(...): detector position: " << std::fixed
               << " (r: " << std::setprecision(1) << std::setw(5) << detector.position().perp()
               << ", z: " << std::setprecision(1) << std::setw(6) << detector.position().z()
-              << ", phi: " << std::setprecision(3) << std::setw(6) << detector.position().phi() << ")"
-              << std::endl;
+              << ", phi: " << std::setprecision(3) << std::setw(6) << detector.position().phi() << ")" << std::endl;
   }
   if (inside > 1) {
     index = 0;
-    std::cerr << "TrackingMaterialAnalyser::findLayer(...): ERROR: detector belongs to " << inside << " DetLayers" << std::endl;
+    std::cerr << "TrackingMaterialAnalyser::findLayer(...): ERROR: detector belongs to " << inside << " DetLayers"
+              << std::endl;
     std::cerr << "TrackingMaterialAnalyser::findLayer(...): detector position: " << std::fixed
               << " (r: " << std::setprecision(1) << std::setw(5) << detector.position().perp()
               << ", z: " << std::setprecision(1) << std::setw(6) << detector.position().z()
-              << ", phi: " << std::setprecision(3) << std::setw(6) << detector.position().phi() << ")"
-              << std::endl;
+              << ", phi: " << std::setprecision(3) << std::setw(6) << detector.position().phi() << ")" << std::endl;
   }
 
   return index;

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialAnalyser.h
@@ -13,42 +13,36 @@
 #include "MaterialAccountingGroup.h"
 #include "TrackingMaterialPlotter.h"
 
-class TrackingMaterialAnalyser : public edm::one::EDAnalyzer<>
-{
+class TrackingMaterialAnalyser : public edm::one::EDAnalyzer<> {
 public:
   explicit TrackingMaterialAnalyser(const edm::ParameterSet &);
   ~TrackingMaterialAnalyser() override;
-  
+
 private:
-  enum SplitMode {
-    NEAREST_LAYER,
-    INNER_LAYER,
-    OUTER_LAYER,
-    UNDEFINED
-  };
-  
+  enum SplitMode { NEAREST_LAYER, INNER_LAYER, OUTER_LAYER, UNDEFINED };
+
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void beginJob() override {}
   void endJob() override;
 
-  void split( MaterialAccountingTrack & track );
-  int  findLayer( const MaterialAccountingDetector & detector );
+  void split(MaterialAccountingTrack &track);
+  int findLayer(const MaterialAccountingDetector &detector);
 
-  void saveParameters(const char* name);
-  void saveXml(const char* name);
+  void saveParameters(const char *name);
+  void saveXml(const char *name);
   void saveLayerPlots();
-  
+
   edm::EDGetTokenT<std::vector<MaterialAccountingTrack> > m_materialToken;
-  SplitMode                                 m_splitMode;
-  bool                                      m_skipAfterLastDetector;
-  bool                                      m_skipBeforeFirstDetector;
-  bool                                      m_saveSummaryPlot;
-  bool                                      m_saveDetailedPlots;
-  bool                                      m_saveParameters;
-  bool                                      m_saveXml;
-  std::vector<MaterialAccountingGroup *>    m_groups;
-  std::vector<std::string>                  m_groupNames;
-  TrackingMaterialPlotter *                 m_plotter;
+  SplitMode m_splitMode;
+  bool m_skipAfterLastDetector;
+  bool m_skipBeforeFirstDetector;
+  bool m_saveSummaryPlot;
+  bool m_saveDetailedPlots;
+  bool m_saveParameters;
+  bool m_saveXml;
+  std::vector<MaterialAccountingGroup *> m_groups;
+  std::vector<std::string> m_groupNames;
+  TrackingMaterialPlotter *m_plotter;
 };
 
-#endif // TrackingMaterialAnalyser_h
+#endif  // TrackingMaterialAnalyser_h

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialPlotter.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialPlotter.cc
@@ -11,72 +11,72 @@
 
 #include "SimDataFormats/ValidationFormats/interface/MaterialAccountingStep.h"
 
-void TrackingMaterialPlotter::fill_color(void)
-{
-  m_color.push_back(kBlack);          // unassigned
-  m_color.push_back(kAzure);          // PixelBarrel
-  m_color.push_back(kAzure + 1) ;     //
-  m_color.push_back(kAzure + 1) ;     //
-  m_color.push_back(kAzure + 3) ;     //
-  m_color.push_back(kAzure + 3) ;     //
-  m_color.push_back(kGreen);          // TIB
-  m_color.push_back(kGreen);      //
-  m_color.push_back(kGreen + 2);      //
-  m_color.push_back(kGreen + 2);      //
-  m_color.push_back(kGreen - 3);      //
-  m_color.push_back(kGreen - 3);      //
-  m_color.push_back(kGreen - 1);      //
-  m_color.push_back(kGreen - 1);      //
-  m_color.push_back(kRed);            // TOB
-  m_color.push_back(kRed);      //
-  m_color.push_back(kRed);      //
+void TrackingMaterialPlotter::fill_color(void) {
+  m_color.push_back(kBlack);        // unassigned
+  m_color.push_back(kAzure);        // PixelBarrel
+  m_color.push_back(kAzure + 1);    //
+  m_color.push_back(kAzure + 1);    //
+  m_color.push_back(kAzure + 3);    //
+  m_color.push_back(kAzure + 3);    //
+  m_color.push_back(kGreen);        // TIB
+  m_color.push_back(kGreen);        //
+  m_color.push_back(kGreen + 2);    //
+  m_color.push_back(kGreen + 2);    //
+  m_color.push_back(kGreen - 3);    //
+  m_color.push_back(kGreen - 3);    //
+  m_color.push_back(kGreen - 1);    //
+  m_color.push_back(kGreen - 1);    //
+  m_color.push_back(kRed);          // TOB
+  m_color.push_back(kRed);          //
+  m_color.push_back(kRed);          //
   m_color.push_back(kRed + 3);      //
   m_color.push_back(kRed + 3);      //
   m_color.push_back(kRed + 3);      //
   m_color.push_back(kRed - 3);      //
   m_color.push_back(kRed - 3);      //
-  m_color.push_back(kRed - 3);    //
-  m_color.push_back(kOrange + 9);     //
-  m_color.push_back(kOrange + 9);     //
-  m_color.push_back(kOrange + 9);     //
-  m_color.push_back(kOrange + 7);     //
-  m_color.push_back(kOrange + 7);     //
-  m_color.push_back(kOrange + 7);     //
-  m_color.push_back(kOrange + 5);     //
-  m_color.push_back(kOrange + 5);     //
-  m_color.push_back(kOrange + 5);     //
-  m_color.push_back(kOrange + 8);         // PixelEndcap Z-
-  m_color.push_back(kOrange + 10);         //
-  m_color.push_back(kOrange - 3);         //
-  m_color.push_back(kOrange - 1);     // PixelEndcap Z+
-  m_color.push_back(kOrange - 8);     //
-  m_color.push_back(kYellow);         // TID Z-
-  m_color.push_back(kYellow);         //
-  m_color.push_back(kYellow + 2);     //
-  m_color.push_back(kYellow + 2);     //
-  m_color.push_back(kYellow + 2);     //
-  m_color.push_back(kYellow + 3);     //
-  m_color.push_back(kMagenta);            //
-  m_color.push_back(kMagenta);            //
-  m_color.push_back(kMagenta);            //
-  m_color.push_back(kMagenta);            //
-  m_color.push_back(kMagenta);            //
-  m_color.push_back(kMagenta + 1);        //
-  m_color.push_back(kMagenta + 2);        //
-  m_color.push_back(kMagenta + 3);        //
-  m_color.push_back(kMagenta + 4);        //
-  m_color.push_back(kMagenta + 5);        //
-  m_color.push_back(kMagenta + 6);        //
-  m_color.push_back(kMagenta + 7);        //
-  m_color.push_back(kMagenta + 8);        //
+  m_color.push_back(kRed - 3);      //
+  m_color.push_back(kOrange + 9);   //
+  m_color.push_back(kOrange + 9);   //
+  m_color.push_back(kOrange + 9);   //
+  m_color.push_back(kOrange + 7);   //
+  m_color.push_back(kOrange + 7);   //
+  m_color.push_back(kOrange + 7);   //
+  m_color.push_back(kOrange + 5);   //
+  m_color.push_back(kOrange + 5);   //
+  m_color.push_back(kOrange + 5);   //
+  m_color.push_back(kOrange + 8);   // PixelEndcap Z-
+  m_color.push_back(kOrange + 10);  //
+  m_color.push_back(kOrange - 3);   //
+  m_color.push_back(kOrange - 1);   // PixelEndcap Z+
+  m_color.push_back(kOrange - 8);   //
+  m_color.push_back(kYellow);       // TID Z-
+  m_color.push_back(kYellow);       //
+  m_color.push_back(kYellow + 2);   //
+  m_color.push_back(kYellow + 2);   //
+  m_color.push_back(kYellow + 2);   //
+  m_color.push_back(kYellow + 3);   //
+  m_color.push_back(kMagenta);      //
+  m_color.push_back(kMagenta);      //
+  m_color.push_back(kMagenta);      //
+  m_color.push_back(kMagenta);      //
+  m_color.push_back(kMagenta);      //
+  m_color.push_back(kMagenta + 1);  //
+  m_color.push_back(kMagenta + 2);  //
+  m_color.push_back(kMagenta + 3);  //
+  m_color.push_back(kMagenta + 4);  //
+  m_color.push_back(kMagenta + 5);  //
+  m_color.push_back(kMagenta + 6);  //
+  m_color.push_back(kMagenta + 7);  //
+  m_color.push_back(kMagenta + 8);  //
 }
 
-
-unsigned int TrackingMaterialPlotter::fill_gradient(const TColor & first, const TColor & last, unsigned int steps /*= 100*/, unsigned int index /* = 0*/)
-{
+unsigned int TrackingMaterialPlotter::fill_gradient(const TColor& first,
+                                                    const TColor& last,
+                                                    unsigned int steps /*= 100*/,
+                                                    unsigned int index /* = 0*/) {
   if (index == 0) {
     // if no index was given, find the highest used one and start from that plus one
-    index = ((TObjArray*) gROOT->GetListOfColors())->GetLast() + 1;
+    index = ((TObjArray*)gROOT->GetListOfColors())->GetLast() + 1;
   }
 
   float r1, g1, b1, r2, g2, b2;
@@ -95,61 +95,64 @@ unsigned int TrackingMaterialPlotter::fill_gradient(const TColor & first, const 
   return index;
 }
 
-unsigned int TrackingMaterialPlotter::fill_gradient(unsigned int first, unsigned int last, unsigned int steps /*= 100*/, unsigned int index /* = 0*/)
-{
-  return fill_gradient(* (TColor *) gROOT->GetListOfColors()->At(first), * (TColor *) gROOT->GetListOfColors()->At(last), steps, index);
+unsigned int TrackingMaterialPlotter::fill_gradient(unsigned int first,
+                                                    unsigned int last,
+                                                    unsigned int steps /*= 100*/,
+                                                    unsigned int index /* = 0*/) {
+  return fill_gradient(
+      *(TColor*)gROOT->GetListOfColors()->At(first), *(TColor*)gROOT->GetListOfColors()->At(last), steps, index);
 }
 
-TrackingMaterialPlotter::TrackingMaterialPlotter( float maxZ, float maxR, float resolution )
-{
-  const float rzMinZ  = -maxZ;
-  const float rzMaxZ  =  maxZ;
-  const float rzMinR  =    0.;
-  const float rzMaxR  =  maxR;
-  const int   rzBinsZ = (int) (2. * maxZ * resolution);
-  const int   rzBinsR = (int) (     maxR * resolution);
+TrackingMaterialPlotter::TrackingMaterialPlotter(float maxZ, float maxR, float resolution) {
+  const float rzMinZ = -maxZ;
+  const float rzMaxZ = maxZ;
+  const float rzMinR = 0.;
+  const float rzMaxR = maxR;
+  const int rzBinsZ = (int)(2. * maxZ * resolution);
+  const int rzBinsR = (int)(maxR * resolution);
 
   std::vector<double> max;
-  max.push_back( 0.08 );
-  max.push_back( 0.00016 );
-  m_tracker = XHistogram( 2, rzBinsZ, rzBinsR, std::make_pair(rzMinZ, rzMaxZ), std::make_pair(rzMinR, rzMaxR), m_color.size(), max);
+  max.push_back(0.08);
+  max.push_back(0.00016);
+  m_tracker = XHistogram(
+      2, rzBinsZ, rzBinsR, std::make_pair(rzMinZ, rzMaxZ), std::make_pair(rzMinR, rzMaxR), m_color.size(), max);
 
   TColor::InitializeColors();
   fill_color();
-  fill_gradient( kWhite, kBlack, 100);              // 100-steps gradient from white to black
+  fill_gradient(kWhite, kBlack, 100);  // 100-steps gradient from white to black
 }
 
-void TrackingMaterialPlotter::plotSegmentUnassigned( const MaterialAccountingStep & step )
-{
+void TrackingMaterialPlotter::plotSegmentUnassigned(const MaterialAccountingStep& step) {
   std::vector<double> w(2);
   w[0] = step.radiationLengths();
   w[1] = step.energyLoss();
-  m_tracker.fill( std::make_pair(step.in().z(), step.out().z()),
-                  std::make_pair(step.in().perp(), step.out().perp()),
-                  w, step.length(), 1 );             // 0 is empty, 1 is unassigned
+  m_tracker.fill(std::make_pair(step.in().z(), step.out().z()),
+                 std::make_pair(step.in().perp(), step.out().perp()),
+                 w,
+                 step.length(),
+                 1);  // 0 is empty, 1 is unassigned
 }
 
-void TrackingMaterialPlotter::plotSegmentInLayer( const MaterialAccountingStep & step, int layer )
-{
+void TrackingMaterialPlotter::plotSegmentInLayer(const MaterialAccountingStep& step, int layer) {
   std::vector<double> w(2);
   w[0] = step.radiationLengths();
   w[1] = step.energyLoss();
-  m_tracker.fill( std::make_pair(step.in().z(), step.out().z()),
-                  std::make_pair(step.in().perp(), step.out().perp()),
-                  w, step.length(), layer+1 );       // layer is 1-based, but plot uses: 0 is empty, 1 is unassigned
+  m_tracker.fill(std::make_pair(step.in().z(), step.out().z()),
+                 std::make_pair(step.in().perp(), step.out().perp()),
+                 w,
+                 step.length(),
+                 layer + 1);  // layer is 1-based, but plot uses: 0 is empty, 1 is unassigned
 }
 
-
-void TrackingMaterialPlotter::draw( void )
-{
+void TrackingMaterialPlotter::draw(void) {
   const double scale = 10.;
   TCanvas* canvas;
 
   XHistogram::Histogram* radlen = m_tracker.get(0);
-  canvas = new TCanvas("radlen_rz", "RadiationLengths - RZ view", (int) (600 * scale * 1.25),  (int) (120 * scale * 1.50));
+  canvas = new TCanvas("radlen_rz", "RadiationLengths - RZ view", (int)(600 * scale * 1.25), (int)(120 * scale * 1.50));
   gStyle->SetOptStat(0);
-  gStyle->SetPalette( m_gradient.size(), & m_gradient.front() );
-  gStyle->SetNumberContours( m_gradient.size() );
+  gStyle->SetPalette(m_gradient.size(), &m_gradient.front());
+  gStyle->SetNumberContours(m_gradient.size());
   canvas->GetFrame()->SetFillColor(kWhite);
   radlen->Draw("colz");
   radlen->Draw("same axis y+");
@@ -159,16 +162,21 @@ void TrackingMaterialPlotter::draw( void )
   // positions
   int white_slots = 1;
   int MyPalette[100];
-  double stops[9] = { 0.0000, 0.1250, 0.2500, 0.3750, 0.5000, 0.6250, 0.7500, 0.8750, 1.0000};
-  double red[9]   = { 0./255.,   5./255.,  15./255.,  35./255., 102./255., 196./255., 208./255., 199./255., 110./255.};
-  double green[9] = { 0./255.,  48./255., 124./255., 192./255., 206./255., 226./255.,  97./255.,  16./255.,   0./255.};
-  double blue[9]  = { 99./255., 142./255., 198./255., 201./255.,  90./255.,  22./255.,  13./255.,   8./255.,   2./255.};
+  double stops[9] = {0.0000, 0.1250, 0.2500, 0.3750, 0.5000, 0.6250, 0.7500, 0.8750, 1.0000};
+  double red[9] = {
+      0. / 255., 5. / 255., 15. / 255., 35. / 255., 102. / 255., 196. / 255., 208. / 255., 199. / 255., 110. / 255.};
+  double green[9] = {
+      0. / 255., 48. / 255., 124. / 255., 192. / 255., 206. / 255., 226. / 255., 97. / 255., 16. / 255., 0. / 255.};
+  double blue[9] = {
+      99. / 255., 142. / 255., 198. / 255., 201. / 255., 90. / 255., 22. / 255., 13. / 255., 8. / 255., 2. / 255.};
   int palette_index = TColor::CreateGradientColorTable(9, stops, red, green, blue, 100 - white_slots);
-  for (int i=0; i<white_slots; i++) MyPalette[i] = kWhite;
-  for (int i=0; i<100-white_slots; i++) MyPalette[i + white_slots] = palette_index + i;
+  for (int i = 0; i < white_slots; i++)
+    MyPalette[i] = kWhite;
+  for (int i = 0; i < 100 - white_slots; i++)
+    MyPalette[i + white_slots] = palette_index + i;
   canvas->Clear();
-  gStyle->SetNumberContours( 100 );
-  gStyle->SetPalette(100, MyPalette); // ROOT Rainbow color palette
+  gStyle->SetNumberContours(100);
+  gStyle->SetPalette(100, MyPalette);  // ROOT Rainbow color palette
   radlen->Draw("colz");
   radlen->Draw("same axis y+");
   canvas->SaveAs("radlenColor.png");
@@ -176,35 +184,34 @@ void TrackingMaterialPlotter::draw( void )
   delete canvas;
 
   XHistogram::Histogram* dedx = m_tracker.get(1);
-  canvas = new TCanvas("dedx_rz", "-dE/dx term - RZ view", (int) (600 * scale * 1.25),  (int) (120 * scale * 1.50));
+  canvas = new TCanvas("dedx_rz", "-dE/dx term - RZ view", (int)(600 * scale * 1.25), (int)(120 * scale * 1.50));
   canvas->GetFrame()->SetFillColor(kWhite);
   gStyle->SetOptStat(0);
-  gStyle->SetPalette( m_gradient.size(), & m_gradient.front() );
-  gStyle->SetNumberContours( m_gradient.size() );
+  gStyle->SetPalette(m_gradient.size(), &m_gradient.front());
+  gStyle->SetNumberContours(m_gradient.size());
   dedx->Draw("colz");
   dedx->Draw("same axis y+");
   dedx->SaveAs("dedx.root");
   canvas->SaveAs("dedx.png");
   canvas->Clear();
-  gStyle->SetNumberContours( 100 );
-  gStyle->SetPalette(100, MyPalette); // ROOT Rainbow color palette
+  gStyle->SetNumberContours(100);
+  gStyle->SetPalette(100, MyPalette);  // ROOT Rainbow color palette
   dedx->Draw("colz");
   dedx->Draw("same axis y+");
   canvas->SaveAs("dedxColor.png");
   delete canvas;
 
   XHistogram::ColorMap* colormap = m_tracker.colormap();
-  canvas = new TCanvas("layer_rz", "Layers - RZ view", (int) (600 * scale * 1.25),  (int) (120 * scale * 1.50));
+  canvas = new TCanvas("layer_rz", "Layers - RZ view", (int)(600 * scale * 1.25), (int)(120 * scale * 1.50));
   canvas->GetFrame()->SetFillColor(kWhite);
   gStyle->SetOptStat(0);
-  gStyle->SetPalette( m_color.size(), & m_color.front() );
-  gStyle->SetNumberContours( m_color.size() );
-  colormap->SetMinimum( 1 );
-  colormap->SetMaximum( m_color.size() );
+  gStyle->SetPalette(m_color.size(), &m_color.front());
+  gStyle->SetNumberContours(m_color.size());
+  colormap->SetMinimum(1);
+  colormap->SetMaximum(m_color.size());
   colormap->Draw("col");
   colormap->Draw("same axis y+");
   colormap->SaveAs("layers.root");
   canvas->SaveAs("layers.png");
   delete canvas;
 }
-

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialPlotter.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialPlotter.h
@@ -15,18 +15,15 @@ class MaterialAccountingStep;
 
 class TrackingMaterialPlotter {
 public:
-  
   typedef std::pair<double, double> Range;
 
-  TrackingMaterialPlotter( float maxZ, float maxR, float resolution );
-  void plotSegmentUnassigned( const MaterialAccountingStep & step );
-  void plotSegmentInLayer( const MaterialAccountingStep & step, int layer );
+  TrackingMaterialPlotter(float maxZ, float maxR, float resolution);
+  void plotSegmentUnassigned(const MaterialAccountingStep& step);
+  void plotSegmentInLayer(const MaterialAccountingStep& step, int layer);
 
-  void normalize( void ) {
-    m_tracker.normalize();
-  }
+  void normalize(void) { m_tracker.normalize(); }
 
-  void draw( void );
+  void draw(void);
 
 private:
   XHistogram m_tracker;
@@ -35,9 +32,8 @@ private:
   std::vector<int> m_gradient;
 
   void fill_color();
-  unsigned int fill_gradient(const TColor & first, const TColor & last, unsigned int steps = 100, unsigned int index = 0);
+  unsigned int fill_gradient(const TColor& first, const TColor& last, unsigned int steps = 100, unsigned int index = 0);
   unsigned int fill_gradient(unsigned int first, unsigned int last, unsigned int steps = 100, unsigned int index = 0);
-
 };
 
-#endif // TrackingMaterialPlotter_h
+#endif  // TrackingMaterialPlotter_h

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -1,4 +1,4 @@
-#include <iostream>     // FIXME: switch to MessagLogger & friends
+#include <iostream>  // FIXME: switch to MessagLogger & friends
 #include <vector>
 #include <string>
 #include <cassert>
@@ -38,28 +38,25 @@ using namespace CLHEP;
 using edm::LogInfo;
 
 // missing from GEANT4 < 9.0 : G4LogicalVolumeStore::GetVolume( name )
-static
-const G4LogicalVolume* GetVolume(const std::string& name) {
+static const G4LogicalVolume* GetVolume(const std::string& name) {
   const G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();
 
 #ifdef DEBUG_G4_VOLUMES
   for (G4LogicalVolumeStore::const_iterator volume = lvs->begin(); volume != lvs->end(); ++volume)
-    LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: G4 registered volumes "
-                                         << (*volume)->GetName() << std::endl;
+    LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: G4 registered volumes " << (*volume)->GetName()
+                                        << std::endl;
 #endif
 
   for (G4LogicalVolumeStore::const_iterator volume = lvs->begin(); volume != lvs->end(); ++volume) {
-    if ((const std::string&) (*volume)->GetName() == name)
+    if ((const std::string&)(*volume)->GetName() == name)
       return (*volume);
   }
   return nullptr;
 }
 
 // missing from GEANT4 : G4TouchableHistory::GetTransform( depth )
-static inline
-const G4AffineTransform& GetTransform(const G4TouchableHistory* touchable, int depth)
-{
-  return touchable->GetHistory()->GetTransform( touchable->GetHistory()->GetDepth() - depth );
+static inline const G4AffineTransform& GetTransform(const G4TouchableHistory* touchable, int depth) {
+  return touchable->GetHistory()->GetTransform(touchable->GetHistory()->GetDepth() - depth);
 }
 
 // navigate up the hierarchy of volumes until one with an attached sensitive detector is found
@@ -68,10 +65,9 @@ const G4AffineTransform& GetTransform(const G4TouchableHistory* touchable, int d
 //   - how may steps up in the hierarchy it is (0 is the starting volume)
 // if no sensitive detector is found, return a NULL pointer and 0
 
-std::tuple<const G4VPhysicalVolume*, int> GetSensitiveVolume( const G4VTouchable* touchable )
-{
+std::tuple<const G4VPhysicalVolume*, int> GetSensitiveVolume(const G4VTouchable* touchable) {
   int depth = touchable->GetHistoryDepth();
-  for (int level = 0; level < depth; ++level) {      // 0 is self
+  for (int level = 0; level < depth; ++level) {  // 0 is self
     const G4VPhysicalVolume* volume = touchable->GetVolume(level);
     if (volume->GetLogicalVolume()->GetSensitiveDetector() != nullptr) {
       return std::make_tuple(volume, level);
@@ -81,59 +77,52 @@ std::tuple<const G4VPhysicalVolume*, int> GetSensitiveVolume( const G4VTouchable
 }
 
 //-------------------------------------------------------------------------
-TrackingMaterialProducer::TrackingMaterialProducer(const edm::ParameterSet& iPSet)
-{
+TrackingMaterialProducer::TrackingMaterialProducer(const edm::ParameterSet& iPSet) {
   edm::ParameterSet config = iPSet.getParameter<edm::ParameterSet>("TrackingMaterialProducer");
-  m_selectedNames       = config.getParameter< std::vector<std::string> >("SelectedVolumes");
-  m_primaryTracks       = config.getParameter<bool>("PrimaryTracksOnly");
-  m_tracks              = nullptr;
+  m_selectedNames = config.getParameter<std::vector<std::string> >("SelectedVolumes");
+  m_primaryTracks = config.getParameter<bool>("PrimaryTracksOnly");
+  m_tracks = nullptr;
 
-  produces< std::vector<MaterialAccountingTrack> >();
+  produces<std::vector<MaterialAccountingTrack> >();
   output_file_ = new TFile("radLen_vs_eta_fromProducer.root", "RECREATE");
   output_file_->cd();
   radLen_vs_eta_ = new TProfile("radLen", "radLen", 250., -5., 5., 0, 10.);
 }
 
 //-------------------------------------------------------------------------
-TrackingMaterialProducer::~TrackingMaterialProducer(void)
-{
-}
+TrackingMaterialProducer::~TrackingMaterialProducer(void) {}
 
 //-------------------------------------------------------------------------
-void TrackingMaterialProducer::update(const EndOfJob* event)
-{
+void TrackingMaterialProducer::update(const EndOfJob* event) {
   radLen_vs_eta_->Write();
   output_file_->Close();
 }
 //-------------------------------------------------------------------------
-void TrackingMaterialProducer::update(const BeginOfJob* event)
-{
+void TrackingMaterialProducer::update(const BeginOfJob* event) {
   // INFO
   LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: List of the selected volumes: " << std::endl;
   for (std::vector<std::string>::const_iterator volume_name = m_selectedNames.begin();
-       volume_name != m_selectedNames.end(); ++volume_name) {
+       volume_name != m_selectedNames.end();
+       ++volume_name) {
     const G4LogicalVolume* volume = GetVolume(*volume_name);
     if (volume) {
       LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: " << *volume_name << std::endl;
-      m_selectedVolumes.push_back( volume );
+      m_selectedVolumes.push_back(volume);
     } else {
       // FIXME: throw an exception ?
-      std::cerr << "TrackingMaterialProducer::update(const BeginOfJob*): WARNING: selected volume \"" << *volume_name << "\" not found in geometry " << std::endl;
+      std::cerr << "TrackingMaterialProducer::update(const BeginOfJob*): WARNING: selected volume \"" << *volume_name
+                << "\" not found in geometry " << std::endl;
     }
   }
 }
 
-
 //-------------------------------------------------------------------------
-void TrackingMaterialProducer::update(const BeginOfEvent* event)
-{
+void TrackingMaterialProducer::update(const BeginOfEvent* event) {
   m_tracks = new std::vector<MaterialAccountingTrack>();
 }
 
-
 //-------------------------------------------------------------------------
-void TrackingMaterialProducer::update(const BeginOfTrack* event)
-{
+void TrackingMaterialProducer::update(const BeginOfTrack* event) {
   m_track.reset();
 
   // prevent secondary tracks from propagating
@@ -144,119 +133,105 @@ void TrackingMaterialProducer::update(const BeginOfTrack* event)
 }
 
 bool TrackingMaterialProducer::isSelectedFast(const G4TouchableHistory* touchable) {
-  for (int d = touchable->GetHistoryDepth() -1; d >=0;  --d) {
-      if (
-           std::find(
-                     m_selectedNames.begin(),
-                     m_selectedNames.end(),
-                     touchable->GetVolume(d)->GetName())
-        != m_selectedNames.end())
-        return true;
-    }
+  for (int d = touchable->GetHistoryDepth() - 1; d >= 0; --d) {
+    if (std::find(m_selectedNames.begin(), m_selectedNames.end(), touchable->GetVolume(d)->GetName()) !=
+        m_selectedNames.end())
+      return true;
+  }
   return false;
 }
 
 //-------------------------------------------------------------------------
-void TrackingMaterialProducer::update(const G4Step* step)
-{
+void TrackingMaterialProducer::update(const G4Step* step) {
   const G4TouchableHistory* touchable = static_cast<const G4TouchableHistory*>(step->GetTrack()->GetTouchable());
-  if (not isSelectedFast( touchable )) {
+  if (not isSelectedFast(touchable)) {
     LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer:\t[...] skipping "
-                                         << touchable->GetVolume()->GetName() << std::endl;
+                                        << touchable->GetVolume()->GetName() << std::endl;
     return;
   }
 
   // material and step proterties
   const G4Material* material = touchable->GetVolume()->GetLogicalVolume()->GetMaterial();
-  double length = step->GetStepLength() / cm;          // mm -> cm
-  double X0 = material->GetRadlen() / cm;              // mm -> cm
-  double Ne = material->GetElectronDensity() * cm3;    // 1/mm3 -> 1/cm3
-  double Xi = Ne / 6.0221415e23 * 0.307075 / 2;        // MeV / cm
-  double radiationLengths = length / X0;               //
-  double energyLoss       = length * Xi / 1000.;       // GeV
+  double length = step->GetStepLength() / cm;        // mm -> cm
+  double X0 = material->GetRadlen() / cm;            // mm -> cm
+  double Ne = material->GetElectronDensity() * cm3;  // 1/mm3 -> 1/cm3
+  double Xi = Ne / 6.0221415e23 * 0.307075 / 2;      // MeV / cm
+  double radiationLengths = length / X0;             //
+  double energyLoss = length * Xi / 1000.;           // GeV
   //double energyLoss = step->GetDeltaEnergy()/MeV;  should we use this??
 
-  G4ThreeVector globalPosPre  = step->GetPreStepPoint()->GetPosition();
+  G4ThreeVector globalPosPre = step->GetPreStepPoint()->GetPosition();
   G4ThreeVector globalPosPost = step->GetPostStepPoint()->GetPosition();
-  GlobalPoint globalPositionIn(  globalPosPre.x()  / cm, globalPosPre.y()  / cm, globalPosPre.z() / cm );    // mm -> cm
-  GlobalPoint globalPositionOut( globalPosPost.x() / cm, globalPosPost.y() / cm, globalPosPost.z() / cm );   // mm -> cm
+  GlobalPoint globalPositionIn(globalPosPre.x() / cm, globalPosPre.y() / cm, globalPosPre.z() / cm);      // mm -> cm
+  GlobalPoint globalPositionOut(globalPosPost.x() / cm, globalPosPost.y() / cm, globalPosPost.z() / cm);  // mm -> cm
 
   // check for a sensitive detector
   bool enter_sensitive = false;
   bool leave_sensitive = false;
-  double cosThetaPre  = 0.0;
+  double cosThetaPre = 0.0;
   double cosThetaPost = 0.0;
   int level = 0;
   const G4VPhysicalVolume* sensitive = nullptr;
   GlobalPoint position;
   std::tie(sensitive, level) = GetSensitiveVolume(touchable);
   if (sensitive) {
-    const G4VSolid &          solid     = *touchable->GetSolid( level );
-    const G4AffineTransform & transform = GetTransform( touchable, level );
-    G4ThreeVector pos = transform.Inverse().TransformPoint( G4ThreeVector( 0., 0., 0. ) );
-    position = GlobalPoint( pos.x() / cm, pos.y() / cm, pos.z() / cm );  // mm -> cm
+    const G4VSolid& solid = *touchable->GetSolid(level);
+    const G4AffineTransform& transform = GetTransform(touchable, level);
+    G4ThreeVector pos = transform.Inverse().TransformPoint(G4ThreeVector(0., 0., 0.));
+    position = GlobalPoint(pos.x() / cm, pos.y() / cm, pos.z() / cm);  // mm -> cm
 
-    G4ThreeVector localPosPre   = transform.TransformPoint( globalPosPre );
-    EInside       statusPre     = solid.Inside( localPosPre );
+    G4ThreeVector localPosPre = transform.TransformPoint(globalPosPre);
+    EInside statusPre = solid.Inside(localPosPre);
     if (statusPre == kSurface) {
       enter_sensitive = true;
-      G4ThreeVector globalDirPre  = step->GetPreStepPoint()->GetMomentumDirection();
-      G4ThreeVector localDirPre   = transform.TransformAxis( globalDirPre );
-      G4ThreeVector normalPre     = solid.SurfaceNormal( localPosPre );
-      cosThetaPre  = normalPre.cosTheta( -localDirPre );
+      G4ThreeVector globalDirPre = step->GetPreStepPoint()->GetMomentumDirection();
+      G4ThreeVector localDirPre = transform.TransformAxis(globalDirPre);
+      G4ThreeVector normalPre = solid.SurfaceNormal(localPosPre);
+      cosThetaPre = normalPre.cosTheta(-localDirPre);
     }
 
-    G4ThreeVector localPosPost  = transform.TransformPoint( globalPosPost );
-    EInside       statusPost    = solid.Inside( localPosPost );
+    G4ThreeVector localPosPost = transform.TransformPoint(globalPosPost);
+    EInside statusPost = solid.Inside(localPosPost);
     if (statusPost == kSurface) {
       leave_sensitive = true;
       G4ThreeVector globalDirPost = step->GetPostStepPoint()->GetMomentumDirection();
-      G4ThreeVector localDirPost  = transform.TransformAxis( globalDirPost );
-      G4ThreeVector normalPost    = solid.SurfaceNormal( localPosPost );
-      cosThetaPost = normalPost.cosTheta( localDirPost );
+      G4ThreeVector localDirPost = transform.TransformAxis(globalDirPost);
+      G4ThreeVector normalPost = solid.SurfaceNormal(localPosPost);
+      cosThetaPost = normalPost.cosTheta(localDirPost);
     }
   }
 
   // update track accounting
   if (enter_sensitive)
-    m_track.enterDetector( sensitive, position, cosThetaPre );
-  m_track.step(MaterialAccountingStep( length, radiationLengths, energyLoss, globalPositionIn, globalPositionOut ));
+    m_track.enterDetector(sensitive, position, cosThetaPre);
+  m_track.step(MaterialAccountingStep(length, radiationLengths, energyLoss, globalPositionIn, globalPositionOut));
   if (leave_sensitive)
-    m_track.leaveDetector( sensitive, cosThetaPost );
+    m_track.leaveDetector(sensitive, cosThetaPost);
 
   if (sensitive)
-    LogInfo("TrackingMaterialProducer") << "Track was near sensitive     volume "
-                                         << sensitive->GetName() << std::endl;
+    LogInfo("TrackingMaterialProducer") << "Track was near sensitive     volume " << sensitive->GetName() << std::endl;
   else
-    LogInfo("TrackingMaterialProducer") << "Track was near non-sensitive volume "
-                                         << touchable->GetVolume()->GetName() << std::endl;
-  LogInfo("TrackingMaterialProducer")  << "Step length:             "
-                                       << length << " cm\n"
-                                       << "globalPreStep(r,z): (" << globalPositionIn.perp()
-                                       << ", " << globalPositionIn.z() << ") cm\n"
-                                       << "globalPostStep(r,z): (" << globalPositionOut.perp()
-                                       << ", " << globalPositionOut.z() << ") cm\n"
-                                       << "position(r,z): ("
-                                       << position.perp()
-                                       << ", " << position.z() << ") cm\n"
-                                       << "Radiation lengths:       "
-                                       << radiationLengths << " \t\t(X0: "
-                                       << X0 << " cm)\n"
-                                       << "Energy loss:             "
-                                       << energyLoss << " MeV  \t(Xi: "
-                                       << Xi << " MeV/cm)\n"
-                                       << "Track was " << (enter_sensitive ? "entering " : "in none ")
-                                       << "sensitive volume\n"
-                                       << "Track was " << (leave_sensitive ? "leaving  " : "in none ")
-                                       << "sensitive volume\n";
-
+    LogInfo("TrackingMaterialProducer") << "Track was near non-sensitive volume " << touchable->GetVolume()->GetName()
+                                        << std::endl;
+  LogInfo("TrackingMaterialProducer") << "Step length:             " << length << " cm\n"
+                                      << "globalPreStep(r,z): (" << globalPositionIn.perp() << ", "
+                                      << globalPositionIn.z() << ") cm\n"
+                                      << "globalPostStep(r,z): (" << globalPositionOut.perp() << ", "
+                                      << globalPositionOut.z() << ") cm\n"
+                                      << "position(r,z): (" << position.perp() << ", " << position.z() << ") cm\n"
+                                      << "Radiation lengths:       " << radiationLengths << " \t\t(X0: " << X0
+                                      << " cm)\n"
+                                      << "Energy loss:             " << energyLoss << " MeV  \t(Xi: " << Xi
+                                      << " MeV/cm)\n"
+                                      << "Track was " << (enter_sensitive ? "entering " : "in none ")
+                                      << "sensitive volume\n"
+                                      << "Track was " << (leave_sensitive ? "leaving  " : "in none ")
+                                      << "sensitive volume\n";
 }
 
-
 //-------------------------------------------------------------------------
-void TrackingMaterialProducer::update(const EndOfTrack* event)
-{
-  const G4Track * track = (*event)();
+void TrackingMaterialProducer::update(const EndOfTrack* event) {
+  const G4Track* track = (*event)();
   if (m_primaryTracks and track->GetParentID() != 0)
     return;
 
@@ -264,36 +239,30 @@ void TrackingMaterialProducer::update(const EndOfTrack* event)
   m_tracks->push_back(m_track);
 
   // LogInfo
-  LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: this track took "
-                                       << m_track.steps().size()
-                                       << " steps, and passed through "
-                                       << m_track.detectors().size()
-                                       << " sensitive detectors" << std::endl;
-  LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: track length:       "
-                                       << m_track.summary().length()
-                                       << " cm" << std::endl;
+  LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: this track took " << m_track.steps().size()
+                                      << " steps, and passed through " << m_track.detectors().size()
+                                      << " sensitive detectors" << std::endl;
+  LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: track length:       " << m_track.summary().length()
+                                      << " cm" << std::endl;
   LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: radiation lengths: "
-                                       << m_track.summary().radiationLengths() << std::endl;
+                                      << m_track.summary().radiationLengths() << std::endl;
   LogInfo("TrackingMaterialProducer") << "TrackingMaterialProducer: energy loss:        "
-                                       << m_track.summary().energyLoss()
-                                       << " MeV" << std::endl;
+                                      << m_track.summary().energyLoss() << " MeV" << std::endl;
 }
 
 //-------------------------------------------------------------------------
-void TrackingMaterialProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void TrackingMaterialProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // transfer ownership to the Event
-  std::unique_ptr<std::vector<MaterialAccountingTrack> > tracks( m_tracks );
+  std::unique_ptr<std::vector<MaterialAccountingTrack> > tracks(m_tracks);
   iEvent.put(std::move(tracks));
   m_tracks = nullptr;
 }
 
 //-------------------------------------------------------------------------
-bool TrackingMaterialProducer::isSelected( const G4VTouchable* touchable )
-{
+bool TrackingMaterialProducer::isSelected(const G4VTouchable* touchable) {
   for (size_t i = 0; i < m_selectedVolumes.size(); ++i)
-    if (m_selectedVolumes[i]->IsAncestor( touchable->GetVolume() )
-        or m_selectedVolumes[i] == touchable->GetVolume()->GetLogicalVolume())
+    if (m_selectedVolumes[i]->IsAncestor(touchable->GetVolume()) or
+        m_selectedVolumes[i] == touchable->GetVolume()->GetLogicalVolume())
       return true;
 
   return false;

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.h
@@ -2,7 +2,7 @@
 #define TrackingMaterialProducer_h
 #include <string>
 #include <vector>
- 
+
 #include "SimG4Core/Watcher/interface/SimProducer.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 
@@ -25,7 +25,9 @@ class G4VTouchable;
 class G4VPhysicalVolume;
 class G4LogicalVolume;
 class G4TouchableHistory;
-namespace edm {class ParameterSet;}
+namespace edm {
+  class ParameterSet;
+}
 
 class TrackingMaterialProducer : public SimProducer,
                                  public Observer<const BeginOfJob*>,
@@ -33,12 +35,11 @@ class TrackingMaterialProducer : public SimProducer,
                                  public Observer<const BeginOfEvent*>,
                                  public Observer<const BeginOfTrack*>,
                                  public Observer<const G4Step*>,
-                                 public Observer<const EndOfTrack*>
-{
+                                 public Observer<const EndOfTrack*> {
 public:
   TrackingMaterialProducer(const edm::ParameterSet&);
   ~TrackingMaterialProducer() override;
-  
+
 private:
   void update(const BeginOfJob*) override;
   void update(const BeginOfEvent*) override;
@@ -47,18 +48,18 @@ private:
   void update(const EndOfTrack*) override;
   void update(const EndOfJob*) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
- 
-  bool isSelected( const G4VTouchable* touch );
-  bool isSelectedFast( const G4TouchableHistory* touch );
+
+  bool isSelected(const G4VTouchable* touch);
+  bool isSelectedFast(const G4TouchableHistory* touch);
 
 private:
-  bool                                  m_primaryTracks;
-  std::vector<std::string>              m_selectedNames; 
-  std::vector<const G4LogicalVolume *>  m_selectedVolumes;
-  MaterialAccountingTrack               m_track;
-  std::vector<MaterialAccountingTrack>* m_tracks;  
-  TFile * output_file_;
-  TProfile *  radLen_vs_eta_;
+  bool m_primaryTracks;
+  std::vector<std::string> m_selectedNames;
+  std::vector<const G4LogicalVolume*> m_selectedVolumes;
+  MaterialAccountingTrack m_track;
+  std::vector<MaterialAccountingTrack>* m_tracks;
+  TFile* output_file_;
+  TProfile* radLen_vs_eta_;
 };
 
-#endif // TrackingMaterialProducer_h
+#endif  // TrackingMaterialProducer_h

--- a/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.cc
@@ -4,8 +4,7 @@
 
 #include "XHistogram.h"
 
-std::vector<XHistogram::position> XHistogram::splitSegment( Range rangeX, Range rangeY ) const
-{
+std::vector<XHistogram::position> XHistogram::splitSegment(Range rangeX, Range rangeY) const {
   double deltaX = rangeX.second - rangeX.first;
   double deltaY = rangeY.second - rangeY.first;
   double length = hypot(deltaX, deltaY);
@@ -14,115 +13,111 @@ std::vector<XHistogram::position> XHistogram::splitSegment( Range rangeX, Range 
 
   int min_i, max_i, min_j, max_j;
   if (rangeX.first < rangeX.second) {
-    min_i = (int) ceil(rangeX.first / stepX);            // included
-    max_i = (int) floor(rangeX.second / stepX) + 1;      // excluded
+    min_i = (int)ceil(rangeX.first / stepX);        // included
+    max_i = (int)floor(rangeX.second / stepX) + 1;  // excluded
   } else {
-    min_i = (int) ceil(rangeX.second / stepX);
-    max_i = (int) floor(rangeX.first / stepX) + 1;
+    min_i = (int)ceil(rangeX.second / stepX);
+    max_i = (int)floor(rangeX.first / stepX) + 1;
   }
   if (rangeY.first < rangeY.second) {
-    min_j = (int) ceil(rangeY.first / stepY);
-    max_j = (int) floor(rangeY.second / stepY) + 1;
+    min_j = (int)ceil(rangeY.first / stepY);
+    max_j = (int)floor(rangeY.second / stepY) + 1;
   } else {
-    min_j = (int) ceil(rangeY.second / stepY);
-    max_j = (int) floor(rangeY.first / stepY) + 1;
+    min_j = (int)ceil(rangeY.second / stepY);
+    max_j = (int)floor(rangeY.first / stepY) + 1;
   }
 
-  int steps = max_i-min_i + max_j-min_j + 2;
+  int steps = max_i - min_i + max_j - min_j + 2;
   std::vector<position> v;
   v.clear();
   v.reserve(steps);
 
-  v.push_back( position(0., rangeX.first, rangeY.first) );
+  v.push_back(position(0., rangeX.first, rangeY.first));
   double x, y, f;
   for (int i = min_i; i < max_i; ++i) {
     x = i * stepX;
     y = rangeY.first + (x - rangeX.first) * deltaY / deltaX;
-    f = std::fabs( (x - rangeX.first) / deltaX );
-    v.push_back( position(f, x, y) );
+    f = std::fabs((x - rangeX.first) / deltaX);
+    v.push_back(position(f, x, y));
   }
   for (int i = min_j; i < max_j; ++i) {
     y = i * stepY;
     x = rangeX.first + (y - rangeY.first) * deltaX / deltaY;
-    f = std::fabs( (y - rangeY.first) / deltaY );
-    v.push_back( position(f, x, y) );
+    f = std::fabs((y - rangeY.first) / deltaY);
+    v.push_back(position(f, x, y));
   }
-  v.push_back( position(1., rangeX.second, rangeY.second) );
+  v.push_back(position(1., rangeX.second, rangeY.second));
 
   // sort by distance from the start of the segment
   std::sort(v.begin(), v.end());
 
   // filter away the fragments shorter than m_minDl, and save the center of each fragment along with its fractionary length
   std::vector<position> result;
-  result.push_back( v.front() );
+  result.push_back(v.front());
   for (int i = 1, s = v.size(); i < s; ++i) {
-    double mx = (v[i].x + v[i-1].x) / 2.;
-    double my = (v[i].y + v[i-1].y) / 2.;
-    double df = (v[i].f - v[i-1].f);
+    double mx = (v[i].x + v[i - 1].x) / 2.;
+    double my = (v[i].y + v[i - 1].y) / 2.;
+    double df = (v[i].f - v[i - 1].f);
     if (df * length < m_minDl)
       continue;
-    result.push_back( position( df, mx, my ) );
+    result.push_back(position(df, mx, my));
   }
 
   return result;
 }
 
 /// fill one point
-void XHistogram::fill( double x, double y, const std::vector<double> & weight, double norm )
-{
-  check_weight( weight );
+void XHistogram::fill(double x, double y, const std::vector<double>& weight, double norm) {
+  check_weight(weight);
 
   for (size_t h = 0; h < m_size; ++h)
-    m_histograms[h]->Fill( x, y, weight[h] );
-  m_normalization->Fill( x, y, norm );
+    m_histograms[h]->Fill(x, y, weight[h]);
+  m_normalization->Fill(x, y, norm);
 }
 
 /// fill one point and set its color
-void XHistogram::fill( double x, double y, const std::vector<double> & weight, double norm, unsigned int colour )
-{
-  check_weight( weight );
+void XHistogram::fill(double x, double y, const std::vector<double>& weight, double norm, unsigned int colour) {
+  check_weight(weight);
 
   for (size_t h = 0; h < m_size; ++h)
-    m_histograms[h]->Fill( x, y, weight[h] );
-  m_normalization->Fill( x, y, norm );
-  m_colormap->SetBinContent( m_colormap->FindBin(x, y), (float) colour );
+    m_histograms[h]->Fill(x, y, weight[h]);
+  m_normalization->Fill(x, y, norm);
+  m_colormap->SetBinContent(m_colormap->FindBin(x, y), (float)colour);
 }
-  
-/// fill one segment, normalizing each bin's weight to the fraction of the segment it contains
-void XHistogram::fill( const Range& x, const Range& y, const std::vector<double> & weight, double norm )
-{
-  check_weight( weight );
 
-  std::vector<position> v = splitSegment( x, y );
+/// fill one segment, normalizing each bin's weight to the fraction of the segment it contains
+void XHistogram::fill(const Range& x, const Range& y, const std::vector<double>& weight, double norm) {
+  check_weight(weight);
+
+  std::vector<position> v = splitSegment(x, y);
   for (size_t i = 0, s = v.size(); i < s; ++i) {
     for (size_t h = 0; h < m_size; ++h)
-      m_histograms[h]->Fill( v[i].x, v[i].y, v[i].f * weight[h] );
-    m_normalization->Fill( v[i].x, v[i].y, v[i].f * norm );
+      m_histograms[h]->Fill(v[i].x, v[i].y, v[i].f * weight[h]);
+    m_normalization->Fill(v[i].x, v[i].y, v[i].f * norm);
   }
 }
-  
-/// fill one segment and set its color, normalizing each bin's weight to the fraction of the segment it contains
-void XHistogram::fill( const Range& x, const Range& y, const std::vector<double> & weight, double norm, unsigned int colour )
-{
-  check_weight( weight );
 
-  std::vector<position> v = splitSegment( x, y );
+/// fill one segment and set its color, normalizing each bin's weight to the fraction of the segment it contains
+void XHistogram::fill(
+    const Range& x, const Range& y, const std::vector<double>& weight, double norm, unsigned int colour) {
+  check_weight(weight);
+
+  std::vector<position> v = splitSegment(x, y);
   for (size_t i = 0, s = v.size(); i < s; ++i) {
     for (size_t h = 0; h < m_size; ++h)
-      m_histograms[h]->Fill( v[i].x, v[i].y, v[i].f * weight[h] );
-    m_normalization->Fill( v[i].x, v[i].y, v[i].f * norm );
-    m_colormap->SetBinContent( m_colormap->FindBin(v[i].x, v[i].y), (float) colour );
+      m_histograms[h]->Fill(v[i].x, v[i].y, v[i].f * weight[h]);
+    m_normalization->Fill(v[i].x, v[i].y, v[i].f * norm);
+    m_colormap->SetBinContent(m_colormap->FindBin(v[i].x, v[i].y), (float)colour);
   }
 }
 
 /// normalize the histograms
-void XHistogram::normalize(void)
-{
+void XHistogram::normalize(void) {
   for (int i = 0; i < m_normalization->GetSize(); ++i) {
     if ((*m_normalization)[i] > 0.) {
       for (size_t h = 0; h < m_size; ++h)
         (*m_histograms[h])[i] /= (*m_normalization)[i];
       (*m_normalization)[i] = 1.;
-    } 
+    }
   }
 }

--- a/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/XHistogram.h
@@ -10,135 +10,118 @@
 #include <TH2F.h>
 #include <TH2I.h>
 
-class XHistogram 
-{
+class XHistogram {
 public:
-  typedef TH2I                      ColorMap;
-  typedef TH2F                      Histogram;
+  typedef TH2I ColorMap;
+  typedef TH2F Histogram;
   typedef std::pair<double, double> Range;
 
 protected:
   double m_minDl;
-  Range  m_xRange;
-  Range  m_yRange;
+  Range m_xRange;
+  Range m_yRange;
   size_t m_xBins;
   size_t m_yBins;
   size_t m_size;
 
-  std::vector< std::shared_ptr<Histogram> > m_histograms;
+  std::vector<std::shared_ptr<Histogram> > m_histograms;
   std::shared_ptr<Histogram> m_normalization;
-  std::shared_ptr<ColorMap>  m_colormap;
+  std::shared_ptr<ColorMap> m_colormap;
   std::shared_ptr<Histogram> m_dummy;
 
 public:
-  /// default CTOR 
-  XHistogram(void) :
-    m_minDl( 0.000001 ),
-    m_xRange(),
-    m_yRange(),
-    m_xBins(),
-    m_yBins(),
-    m_size(),
-    m_histograms(),
-    m_normalization(),
-    m_colormap(),
-    m_dummy()
-  { }
- 
+  /// default CTOR
+  XHistogram(void)
+      : m_minDl(0.000001),
+        m_xRange(),
+        m_yRange(),
+        m_xBins(),
+        m_yBins(),
+        m_size(),
+        m_histograms(),
+        m_normalization(),
+        m_colormap(),
+        m_dummy() {}
+
   // explicit CTOR
-  XHistogram( size_t size, size_t bins_x, size_t bins_y, Range x, Range y, size_t zones, const std::vector<double>& max ) :
-    m_minDl( 0.000001 ),
-    m_xRange( x ),
-    m_yRange( y ),
-    m_xBins( bins_x ),
-    m_yBins( bins_y ),
-    m_size( size ),
-    m_histograms( m_size ),
-    m_normalization(),
-    m_colormap()
-  {
+  XHistogram(size_t size, size_t bins_x, size_t bins_y, Range x, Range y, size_t zones, const std::vector<double>& max)
+      : m_minDl(0.000001),
+        m_xRange(x),
+        m_yRange(y),
+        m_xBins(bins_x),
+        m_yBins(bins_y),
+        m_size(size),
+        m_histograms(m_size),
+        m_normalization(),
+        m_colormap() {
     // setup unnamed ROOT histograms
     for (size_t i = 0; i < m_size; ++i) {
-      m_histograms[i].reset(new Histogram( nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second ));
-      m_histograms[i]->SetMinimum( 0. );
-      m_histograms[i]->SetMaximum( max[i] );
+      m_histograms[i].reset(new Histogram(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second));
+      m_histograms[i]->SetMinimum(0.);
+      m_histograms[i]->SetMaximum(max[i]);
     }
-    m_normalization.reset(new Histogram( nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second ));
-    m_colormap.reset(new ColorMap( nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second ));
-    m_colormap->SetMinimum( 0 );
-    m_colormap->SetMaximum( zones );
-    Histogram( nullptr, nullptr, 0, 0., 0., 0, 0., 0. );        // make ROOT "forget" about unnamed histograms
+    m_normalization.reset(new Histogram(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second));
+    m_colormap.reset(new ColorMap(nullptr, nullptr, bins_x, x.first, x.second, bins_y, y.first, y.second));
+    m_colormap->SetMinimum(0);
+    m_colormap->SetMaximum(zones);
+    Histogram(nullptr, nullptr, 0, 0., 0., 0, 0., 0.);  // make ROOT "forget" about unnamed histograms
   }
 
   /// fill one point
-  void fill( double x, double y, const std::vector<double> & weight, double norm );
- 
+  void fill(double x, double y, const std::vector<double>& weight, double norm);
+
   /// fill one point and set its color
-  void fill( double x, double y, const std::vector<double> & weight, double norm, unsigned int colour );
-    
+  void fill(double x, double y, const std::vector<double>& weight, double norm, unsigned int colour);
+
   /// fill one segment, normalizing each bin's weight to the fraction of the segment it contains
-  void fill( const Range& x, const Range& y, const std::vector<double> & weight, double norm );
-    
+  void fill(const Range& x, const Range& y, const std::vector<double>& weight, double norm);
+
   /// fill one segment and set its color, normalizing each bin's weight to the fraction of the segment it contains
-  void fill( const Range& x, const Range& y, const std::vector<double> & weight, double norm, unsigned int colour );
+  void fill(const Range& x, const Range& y, const std::vector<double>& weight, double norm, unsigned int colour);
 
   /// normalize the histograms
   void normalize(void);
 
   /// access one of the histograms
-  Histogram * get(size_t h = 0) const
-  {
+  Histogram* get(size_t h = 0) const {
     if (h < m_size)
-      return (Histogram *) m_histograms[h]->Clone(nullptr);
+      return (Histogram*)m_histograms[h]->Clone(nullptr);
     else
       return nullptr;
   }
 
   /// access the normalization
-  Histogram * normalization(void) const
-  {
-    return (Histogram *) m_normalization->Clone(nullptr);
-  }
+  Histogram* normalization(void) const { return (Histogram*)m_normalization->Clone(nullptr); }
 
   /// access the colormap
-  ColorMap * colormap(void) const
-  {
-    return (ColorMap *) m_colormap->Clone(nullptr);
-  }
+  ColorMap* colormap(void) const { return (ColorMap*)m_colormap->Clone(nullptr); }
 
   /// set the minimum length of sub-segment a segment should be split into:
   /// when splitting across bin boundaries with splitSegment(...), sub-segments shorter than this are skipped
-  void setMinDl( double dl )
-  {
-    m_minDl = dl;
-  }
- 
+  void setMinDl(double dl) { m_minDl = dl; }
+
 protected:
   struct position {
     double f;
     double x;
     double y;
 
-    position() : f(0), x(0), y(0) { }
+    position() : f(0), x(0), y(0) {}
 
-    position(double f_, double x_, double y_) : f(f_), x(x_), y(y_) { }
+    position(double f_, double x_, double y_) : f(f_), x(x_), y(y_) {}
 
-    bool operator<(const position& other) const {
-      return f < other.f;
-    }
+    bool operator<(const position& other) const { return f < other.f; }
   };
 
   /// split a segment into a vector of points
-  std::vector<position> splitSegment( Range x, Range y ) const;
+  std::vector<position> splitSegment(Range x, Range y) const;
 
   /// check the weights passed as an std::vector have the correct size
-  void check_weight(const std::vector<double> & weight) noexcept(false)
-  {
+  void check_weight(const std::vector<double>& weight) noexcept(false) {
     // run time check for vector size
     if (weight.size() != m_size)
-       throw std::invalid_argument("weight: wrong number of elements");
+      throw std::invalid_argument("weight: wrong number of elements");
   }
-
 };
 
-#endif // XHistogram_h
+#endif  // XHistogram_h

--- a/SimTransport/TotemRPProtonTransportParametrization/interface/LHCOpticsApproximator.h
+++ b/SimTransport/TotemRPProtonTransportParametrization/interface/LHCOpticsApproximator.h
@@ -11,13 +11,12 @@
 
 #include "SimTransport/TotemRPProtonTransportParametrization/interface/TMultiDimFet.h"
 
-struct MadKinematicDescriptor
-{
-	double x;         ///< m
-	double theta_x;   ///< rad
-	double y;         ///< m
-	double theta_y;   ///< rad
-	double ksi;       ///< 1
+struct MadKinematicDescriptor {
+  double x;        ///< m
+  double theta_x;  ///< rad
+  double y;        ///< m
+  double theta_y;  ///< rad
+  double ksi;      ///< 1
 };
 
 class LHCApertureApproximator;
@@ -27,138 +26,207 @@ class LHCApertureApproximator;
  * 5 phase space variables are taken in to configuration: x, y, theta_x, theta_y, xi
  * xi < 0 for momentum losses (that is for diffractive protons)
 **/
-class LHCOpticsApproximator : public TNamed
-{
+class LHCOpticsApproximator : public TNamed {
 public:
-	LHCOpticsApproximator();
-	/// begin and end position along the beam of the particle to transport, training_tree, prefix of data branch in the tree
-	LHCOpticsApproximator(std::string name, std::string title, TMultiDimFet::EMDFPolyType polynom_type,
-						  std::string beam_direction, double nominal_beam_momentum);
-	LHCOpticsApproximator(const LHCOpticsApproximator &org);
-	const LHCOpticsApproximator & operator=(const LHCOpticsApproximator &org);
+  LHCOpticsApproximator();
+  /// begin and end position along the beam of the particle to transport, training_tree, prefix of data branch in the tree
+  LHCOpticsApproximator(std::string name,
+                        std::string title,
+                        TMultiDimFet::EMDFPolyType polynom_type,
+                        std::string beam_direction,
+                        double nominal_beam_momentum);
+  LHCOpticsApproximator(const LHCOpticsApproximator &org);
+  const LHCOpticsApproximator &operator=(const LHCOpticsApproximator &org);
 
-	enum polynomials_selection{AUTOMATIC, PREDEFINED};
-	enum beam_type{lhcb1, lhcb2};
-	void Train(TTree *inp_tree, std::string data_prefix = std::string("def"), polynomials_selection mode = PREDEFINED, int max_degree_x = 10, int max_degree_tx = 10, int max_degree_y = 10, int max_degree_ty = 10, bool common_terms = false, double *prec=nullptr);
-	void Test(TTree *inp_tree, TFile *f_out, std::string data_prefix = std::string("def"), std::string base_out_dir = std::string(""));
-	void TestAperture(TTree *in_tree, TTree *out_tree);  ///< x, theta_x, y, theta_y, ksi, mad_accepted, parametriz_accepted
+  enum polynomials_selection { AUTOMATIC, PREDEFINED };
+  enum beam_type { lhcb1, lhcb2 };
+  void Train(TTree *inp_tree,
+             std::string data_prefix = std::string("def"),
+             polynomials_selection mode = PREDEFINED,
+             int max_degree_x = 10,
+             int max_degree_tx = 10,
+             int max_degree_y = 10,
+             int max_degree_ty = 10,
+             bool common_terms = false,
+             double *prec = nullptr);
+  void Test(TTree *inp_tree,
+            TFile *f_out,
+            std::string data_prefix = std::string("def"),
+            std::string base_out_dir = std::string(""));
+  void TestAperture(TTree *in_tree,
+                    TTree *out_tree);  ///< x, theta_x, y, theta_y, ksi, mad_accepted, parametriz_accepted
 
-	double ParameterOutOfRangePenalty(double par_m[], bool invert_beam_coord_sytems=true) const;
+  double ParameterOutOfRangePenalty(double par_m[], bool invert_beam_coord_sytems = true) const;
 
-	/// Basic 3D transport method
-	/// MADX canonical variables
-	/// IN/OUT: (x, theta_x, y, theta_y, xi) [m, rad, m, rad, 1]
-	/// returns true if transport possible
-	/// if theta is calculated from momentum p, use theta_x = p.x() / p.mag() and theta_y = p.y() / p.mag()
-	bool Transport(const double *in, double *out, bool check_apertures=false, bool invert_beam_coord_sytems=true) const;
-	bool Transport(const MadKinematicDescriptor *in, MadKinematicDescriptor *out, bool check_apertures=false, bool invert_beam_coord_sytems=true) const;  //return true if transport possible
+  /// Basic 3D transport method
+  /// MADX canonical variables
+  /// IN/OUT: (x, theta_x, y, theta_y, xi) [m, rad, m, rad, 1]
+  /// returns true if transport possible
+  /// if theta is calculated from momentum p, use theta_x = p.x() / p.mag() and theta_y = p.y() / p.mag()
+  bool Transport(const double *in,
+                 double *out,
+                 bool check_apertures = false,
+                 bool invert_beam_coord_sytems = true) const;
+  bool Transport(const MadKinematicDescriptor *in,
+                 MadKinematicDescriptor *out,
+                 bool check_apertures = false,
+                 bool invert_beam_coord_sytems = true) const;  //return true if transport possible
 
-	/// Basic 2D transport method
-	/// MADX canonical variables
-	/// IN : (x, theta_x, y, theta_y, xi) [m, rad, m, rad, 1]
-	/// OUT : (x, y) [m, m]
-	/// returns true if transport possible
-	bool Transport2D(const double *in, double *out, bool check_apertures=false, bool invert_beam_coord_sytems=true) const;
+  /// Basic 2D transport method
+  /// MADX canonical variables
+  /// IN : (x, theta_x, y, theta_y, xi) [m, rad, m, rad, 1]
+  /// OUT : (x, y) [m, m]
+  /// returns true if transport possible
+  bool Transport2D(const double *in,
+                   double *out,
+                   bool check_apertures = false,
+                   bool invert_beam_coord_sytems = true) const;
 
-	bool Transport_m_GeV(double in_pos[3], double in_momentum[3], double out_pos[3], double out_momentum[3],
-						 bool check_apertures, double z2_z1_dist) const;  ///< pos, momentum: x,y,z;  pos in m, momentum in GeV/c
+  bool Transport_m_GeV(double in_pos[3],
+                       double in_momentum[3],
+                       double out_pos[3],
+                       double out_momentum[3],
+                       bool check_apertures,
+                       double z2_z1_dist) const;  ///< pos, momentum: x,y,z;  pos in m, momentum in GeV/c
 
-	void PrintInputRange();
-	bool CheckInputRange(const double *in, bool invert_beam_coord_sytems=true) const;
-	void AddRectEllipseAperture(const LHCOpticsApproximator &in, double rect_x, double rect_y, double r_el_x, double r_el_y);
-	void PrintOpticalFunctions();
-	void PrintCoordinateOpticalFunctions(TMultiDimFet &parametrization, const std::string &coord_name, const std::vector<std::string> &input_vars);
+  void PrintInputRange();
+  bool CheckInputRange(const double *in, bool invert_beam_coord_sytems = true) const;
+  void AddRectEllipseAperture(
+      const LHCOpticsApproximator &in, double rect_x, double rect_y, double r_el_x, double r_el_y);
+  void PrintOpticalFunctions();
+  void PrintCoordinateOpticalFunctions(TMultiDimFet &parametrization,
+                                       const std::string &coord_name,
+                                       const std::vector<std::string> &input_vars);
 
-	/**
+  /**
      *\brief returns linearised transport matrix for x projection
      * |  dx_out/dx_in    dx_out/dthx_in   |
      * | dthx_out/dx_in  dthx_out/dthx_in  |
      *
      * input:  [m], [rad], xi:-1...0
      */
-	void GetLineariasedTransportMatrixX(double mad_init_x, double mad_init_thx, double mad_init_y, double mad_init_thy,
-										double mad_init_xi, TMatrixD &tr_matrix, double d_mad_x=10e-6, double d_mad_thx=10e-6);
+  void GetLineariasedTransportMatrixX(double mad_init_x,
+                                      double mad_init_thx,
+                                      double mad_init_y,
+                                      double mad_init_thy,
+                                      double mad_init_xi,
+                                      TMatrixD &tr_matrix,
+                                      double d_mad_x = 10e-6,
+                                      double d_mad_thx = 10e-6);
 
-	/**
+  /**
      *\brief returns linearised transport matrix for y projection
      * |  dy_out/dy_in    dy_out/dthy_in   |
      * | dthy_out/dy_in  dthy_out/dthy_in  |
      *
      * input:  [m], [rad], xi:-1...0
      */
-	void GetLineariasedTransportMatrixY(
-			double mad_init_x, double mad_init_thx, double mad_init_y, double mad_init_thy,
-			double mad_init_xi, TMatrixD &tr_matrix, double d_mad_y=10e-6, double d_mad_thy=10e-6);
+  void GetLineariasedTransportMatrixY(double mad_init_x,
+                                      double mad_init_thx,
+                                      double mad_init_y,
+                                      double mad_init_thy,
+                                      double mad_init_xi,
+                                      TMatrixD &tr_matrix,
+                                      double d_mad_y = 10e-6,
+                                      double d_mad_thy = 10e-6);
 
-	double GetDx(double mad_init_x, double mad_init_thx, double mad_init_y,
-				 double mad_init_thy, double mad_init_xi, double d_mad_xi=0.001);
-	double GetDxds(double mad_init_x, double mad_init_thx, double mad_init_y,
-				   double mad_init_thy, double mad_init_xi, double d_mad_xi=0.001);
-	inline beam_type GetBeamType() const {return beam;}
+  double GetDx(double mad_init_x,
+               double mad_init_thx,
+               double mad_init_y,
+               double mad_init_thy,
+               double mad_init_xi,
+               double d_mad_xi = 0.001);
+  double GetDxds(double mad_init_x,
+                 double mad_init_thx,
+                 double mad_init_y,
+                 double mad_init_thy,
+                 double mad_init_xi,
+                 double d_mad_xi = 0.001);
+  inline beam_type GetBeamType() const { return beam; }
 
-	/// returns linear approximation of the transport parameterization
-	/// takes numerical derivatives (see parameter ep) around point `atPoint' (this array has the same structure as `in' parameter in Transport method)
-	/// the linearized transport: x = Cx + Lx*theta_x + vx*x_star
-	void GetLinearApproximation(double atPoint[], double &Cx, double &Lx, double &vx, double &Cy, double &Ly, double &vy, double &D, double ep = 1E-5);
+  /// returns linear approximation of the transport parameterization
+  /// takes numerical derivatives (see parameter ep) around point `atPoint' (this array has the same structure as `in' parameter in Transport method)
+  /// the linearized transport: x = Cx + Lx*theta_x + vx*x_star
+  void GetLinearApproximation(double atPoint[],
+                              double &Cx,
+                              double &Lx,
+                              double &vx,
+                              double &Cy,
+                              double &Ly,
+                              double &vy,
+                              double &D,
+                              double ep = 1E-5);
 
 private:
-	void Init();
-	double s_begin_;                                  ///< begin of transport along the reference orbit
-	double s_end_;                                    ///< end of transport along the reference orbit
-	beam_type beam;
-	double nominal_beam_energy_;                      ///< GeV
-	double nominal_beam_momentum_;                    ///< GeV/c
-	bool trained_;                                    ///< trained polynomials
-	std::vector<TMultiDimFet*> out_polynomials;       //! pointers to polynomials
-	std::vector<std::string> coord_names;
-	std::vector<LHCApertureApproximator> apertures_;  ///< apertures on the way
+  void Init();
+  double s_begin_;  ///< begin of transport along the reference orbit
+  double s_end_;    ///< end of transport along the reference orbit
+  beam_type beam;
+  double nominal_beam_energy_;                  ///< GeV
+  double nominal_beam_momentum_;                ///< GeV/c
+  bool trained_;                                ///< trained polynomials
+  std::vector<TMultiDimFet *> out_polynomials;  //! pointers to polynomials
+  std::vector<std::string> coord_names;
+  std::vector<LHCApertureApproximator> apertures_;  ///< apertures on the way
 
-	#ifndef __CINT_
-	friend class ProtonTransportFunctionsESSource;
-	#endif // __CINT__
+#ifndef __CINT_
+  friend class ProtonTransportFunctionsESSource;
+#endif  // __CINT__
 
-	TMultiDimFet x_parametrisation;                   ///< polynomial approximation for x
-	TMultiDimFet theta_x_parametrisation;             ///< polynomial approximation for theta_x
-	TMultiDimFet y_parametrisation;                   ///< polynomial approximation for y
-	TMultiDimFet theta_y_parametrisation;             ///< polynomial approximation for theta_y
+  TMultiDimFet x_parametrisation;        ///< polynomial approximation for x
+  TMultiDimFet theta_x_parametrisation;  ///< polynomial approximation for theta_x
+  TMultiDimFet y_parametrisation;        ///< polynomial approximation for y
+  TMultiDimFet theta_y_parametrisation;  ///< polynomial approximation for theta_y
 
-	//train_mode mode_;  //polynomial selection mode - selection done by fitting function or selection from the list according to the specified order
-	enum class VariableType {X, THETA_X, Y, THETA_Y};
-	//internal methods
-	void InitializeApproximators(polynomials_selection mode, int max_degree_x, int max_degree_tx, int max_degree_y, int max_degree_ty, bool common_terms);
-	void SetDefaultAproximatorSettings(TMultiDimFet &approximator, VariableType var_type, int max_degree);
-	void SetTermsManually(TMultiDimFet &approximator, VariableType variable, int max_degree, bool common_terms);
+  //train_mode mode_;  //polynomial selection mode - selection done by fitting function or selection from the list according to the specified order
+  enum class VariableType { X, THETA_X, Y, THETA_Y };
+  //internal methods
+  void InitializeApproximators(polynomials_selection mode,
+                               int max_degree_x,
+                               int max_degree_tx,
+                               int max_degree_y,
+                               int max_degree_ty,
+                               bool common_terms);
+  void SetDefaultAproximatorSettings(TMultiDimFet &approximator, VariableType var_type, int max_degree);
+  void SetTermsManually(TMultiDimFet &approximator, VariableType variable, int max_degree, bool common_terms);
 
-	void AllocateErrorHists(TH1D *err_hists[4]);
-	void AllocateErrorInputCorHists(TH2D *err_inp_cor_hists[4][5]);
-	void AllocateErrorOutputCorHists(TH2D *err_out_cor_hists[4][5]);
+  void AllocateErrorHists(TH1D *err_hists[4]);
+  void AllocateErrorInputCorHists(TH2D *err_inp_cor_hists[4][5]);
+  void AllocateErrorOutputCorHists(TH2D *err_out_cor_hists[4][5]);
 
-	void DeleteErrorHists(TH1D *err_hists[4]);
-	void DeleteErrorCorHistograms(TH2D *err_cor_hists[4][5]);
+  void DeleteErrorHists(TH1D *err_hists[4]);
+  void DeleteErrorCorHistograms(TH2D *err_cor_hists[4][5]);
 
-	void FillErrorHistograms(double errors[4], TH1D *err_hists[4]);
-	void FillErrorDataCorHistograms(double errors[4], double var[5], TH2D *err_cor_hists[4][5]);
+  void FillErrorHistograms(double errors[4], TH1D *err_hists[4]);
+  void FillErrorDataCorHistograms(double errors[4], double var[5], TH2D *err_cor_hists[4][5]);
 
-	void WriteHistograms(TH1D *err_hists[4], TH2D *err_inp_cor_hists[4][5], TH2D *err_out_cor_hists[4][5], TFile *f_out, std::string base_out_dir);
+  void WriteHistograms(TH1D *err_hists[4],
+                       TH2D *err_inp_cor_hists[4][5],
+                       TH2D *err_out_cor_hists[4][5],
+                       TFile *f_out,
+                       std::string base_out_dir);
 
-	ClassDef(LHCOpticsApproximator,1) // Proton transport approximator
+  ClassDef(LHCOpticsApproximator, 1)  // Proton transport approximator
 };
 
-class LHCApertureApproximator : public LHCOpticsApproximator
-{
+class LHCApertureApproximator : public LHCOpticsApproximator {
 public:
-	enum class ApertureType {NO_APERTURE, RECTELLIPSE};
+  enum class ApertureType { NO_APERTURE, RECTELLIPSE };
 
-	LHCApertureApproximator();
-	LHCApertureApproximator(const LHCOpticsApproximator &in, double rect_x, double rect_y, double r_el_x, double r_el_y,
-							ApertureType type = ApertureType::RECTELLIPSE);
+  LHCApertureApproximator();
+  LHCApertureApproximator(const LHCOpticsApproximator &in,
+                          double rect_x,
+                          double rect_y,
+                          double r_el_x,
+                          double r_el_y,
+                          ApertureType type = ApertureType::RECTELLIPSE);
 
-	bool CheckAperture(const double *in, bool invert_beam_coord_sytems=true) const;  //x, thx. y, thy, ksi
-	//bool CheckAperture(MadKinematicDescriptor *in);  //x, thx. y, thy, ksi
+  bool CheckAperture(const double *in, bool invert_beam_coord_sytems = true) const;  //x, thx. y, thy, ksi
+  //bool CheckAperture(MadKinematicDescriptor *in);  //x, thx. y, thy, ksi
 private:
-	double rect_x_, rect_y_, r_el_x_, r_el_y_;
-	ApertureType ap_type_;
+  double rect_x_, rect_y_, r_el_x_, r_el_y_;
+  ApertureType ap_type_;
 
-	ClassDef(LHCApertureApproximator,1) // Aperture approximator
+  ClassDef(LHCApertureApproximator, 1)  // Aperture approximator
 };
 #endif  //TotemRPProtonTransportParametrization_LHC_OPTICS_APPROXIMATOR_H

--- a/SimTransport/TotemRPProtonTransportParametrization/interface/TMultiDimFet.h
+++ b/SimTransport/TotemRPProtonTransportParametrization/interface/TMultiDimFet.h
@@ -34,198 +34,184 @@
 //class TBrowser;
 
 class TMultiDimFet : public TNamed {
-
 public:
-   enum EMDFPolyType {
-      kMonomials,
-      kChebyshev,
-      kLegendre
-   };
+  enum EMDFPolyType { kMonomials, kChebyshev, kLegendre };
 
 protected:
+  TVectorD fQuantity;          //! Training sample, dependent quantity
+  TVectorD fSqError;           //! Training sample, error in quantity
+  Double_t fMeanQuantity;      // Mean of dependent quantity
+  Double_t fMaxQuantity;       //! Max value of dependent quantity
+  Double_t fMinQuantity;       //! Min value of dependent quantity
+  Double_t fSumSqQuantity;     //! SumSquare of dependent quantity
+  Double_t fSumSqAvgQuantity;  //! Sum of squares away from mean
 
-   TVectorD     fQuantity;             //! Training sample, dependent quantity
-   TVectorD     fSqError;              //! Training sample, error in quantity
-   Double_t     fMeanQuantity;         // Mean of dependent quantity
-   Double_t     fMaxQuantity;          //! Max value of dependent quantity
-   Double_t     fMinQuantity;          //! Min value of dependent quantity
-   Double_t     fSumSqQuantity;        //! SumSquare of dependent quantity
-   Double_t     fSumSqAvgQuantity;     //! Sum of squares away from mean
+  TVectorD fVariables;      //! Training sample, independent variables
+  Int_t fNVariables;        // Number of independent variables
+  TVectorD fMeanVariables;  //! mean value of independent variables
+  TVectorD fMaxVariables;   // max value of independent variables
+  TVectorD fMinVariables;   // min value of independent variables
 
-   TVectorD     fVariables;            //! Training sample, independent variables
-   Int_t        fNVariables;           // Number of independent variables
-   TVectorD     fMeanVariables;        //! mean value of independent variables
-   TVectorD     fMaxVariables;         // max value of independent variables
-   TVectorD     fMinVariables;         // min value of independent variables
+  Int_t fSampleSize;  //! Size of training sample
 
-   Int_t        fSampleSize;           //! Size of training sample
+  TVectorD fTestQuantity;   //! Test sample, dependent quantity
+  TVectorD fTestSqError;    //! Test sample, Error in quantity
+  TVectorD fTestVariables;  //! Test sample, independent variables
 
-   TVectorD     fTestQuantity;         //! Test sample, dependent quantity
-   TVectorD     fTestSqError;          //! Test sample, Error in quantity
-   TVectorD     fTestVariables;        //! Test sample, independent variables
+  Int_t fTestSampleSize;  //! Size of test sample
 
-   Int_t        fTestSampleSize;       //! Size of test sample
+  Double_t fMinAngle;             //! Min angle for acepting new function
+  Double_t fMaxAngle;             //! Max angle for acepting new function
+  Int_t fMaxTerms;                // Max terms expected in final expr.
+  Double_t fMinRelativeError;     //! Min relative error accepted
+  std::vector<Int_t> fMaxPowers;  //! maximum powers, ex-array
+  Double_t fPowerLimit;           //! Control parameter
 
-   Double_t     fMinAngle;             //! Min angle for acepting new function
-   Double_t     fMaxAngle;             //! Max angle for acepting new function
-   Int_t        fMaxTerms;             // Max terms expected in final expr.
-   Double_t     fMinRelativeError;     //! Min relative error accepted
-   std::vector<Int_t> fMaxPowers;     //! maximum powers, ex-array
-   Double_t     fPowerLimit;           //! Control parameter
+  TMatrixD fFunctions;                //! Functions evaluated over sample
+  Int_t fMaxFunctions;                // max number of functions
+  std::vector<Int_t> fFunctionCodes;  //! acceptance code, ex-array
+  Int_t fMaxStudy;                    //! max functions to study
 
+  TMatrixD fOrthFunctions;      //! As above, but orthogonalised
+  TVectorD fOrthFunctionNorms;  //! Norm of the evaluated functions
 
-   TMatrixD     fFunctions;            //! Functions evaluated over sample
-   Int_t        fMaxFunctions;         // max number of functions
-   std::vector<Int_t> fFunctionCodes;  //! acceptance code, ex-array
-   Int_t        fMaxStudy;             //! max functions to study
+  std::vector<Int_t> fMaxPowersFinal;  //! maximum powers from fit, ex-array
+  Int_t fMaxFunctionsTimesNVariables;  // fMaxFunctionsTimesNVariables
+  std::vector<Int_t> fPowers;          // ex-array
+  std::vector<Int_t> fPowerIndex;      // Index of accepted powers, ex-array
 
-   TMatrixD     fOrthFunctions;        //! As above, but orthogonalised
-   TVectorD     fOrthFunctionNorms;    //! Norm of the evaluated functions
+  TVectorD fResiduals;      //! Vector of the final residuals
+  Double_t fMaxResidual;    //! Max redsidual value
+  Double_t fMinResidual;    //! Min redsidual value
+  Int_t fMaxResidualRow;    //! Row giving max residual
+  Int_t fMinResidualRow;    //! Row giving min residual
+  Double_t fSumSqResidual;  //! Sum of Square residuals
 
+  Int_t fNCoefficients;           // Dimension of model coefficients
+  TVectorD fOrthCoefficients;     //! The model coefficients
+  TMatrixD fOrthCurvatureMatrix;  //! Model matrix
+  TVectorD fCoefficients;         // Vector of the final coefficients
+  TVectorD fCoefficientsRMS;      //! Vector of RMS of coefficients
+  Double_t fRMS;                  //! Root mean square of fit
+  Double_t fChi2;                 //! Chi square of fit
+  Int_t fParameterisationCode;    //! Exit code of parameterisation
 
-   std::vector<Int_t> fMaxPowersFinal; //! maximum powers from fit, ex-array
-   Int_t  fMaxFunctionsTimesNVariables; // fMaxFunctionsTimesNVariables
-   std::vector<Int_t> fPowers;         // ex-array
-   std::vector<Int_t> fPowerIndex;     // Index of accepted powers, ex-array
+  Double_t fError;                 //! Error from parameterization
+  Double_t fTestError;             //! Error from test
+  Double_t fPrecision;             //! Relative precision of param
+  Double_t fTestPrecision;         //! Relative precision of test
+  Double_t fCorrelationCoeff;      //! Multi Correlation coefficient
+  TMatrixD fCorrelationMatrix;     //! Correlation matrix
+  Double_t fTestCorrelationCoeff;  //! Multi Correlation coefficient
 
-   TVectorD     fResiduals;            //! Vector of the final residuals
-   Double_t     fMaxResidual;          //! Max redsidual value
-   Double_t     fMinResidual;          //! Min redsidual value
-   Int_t        fMaxResidualRow;       //! Row giving max residual
-   Int_t        fMinResidualRow;       //! Row giving min residual
-   Double_t     fSumSqResidual;        //! Sum of Square residuals
+  TList *fHistograms;     //! List of histograms
+  Byte_t fHistogramMask;  //! Bit pattern of hisograms used
 
-   Int_t        fNCoefficients;        // Dimension of model coefficients
-   TVectorD     fOrthCoefficients;     //! The model coefficients
-   TMatrixD     fOrthCurvatureMatrix;  //! Model matrix
-   TVectorD     fCoefficients;         // Vector of the final coefficients
-   TVectorD     fCoefficientsRMS;      //! Vector of RMS of coefficients
-   Double_t     fRMS;                  //! Root mean square of fit
-   Double_t     fChi2;                 //! Chi square of fit
-   Int_t        fParameterisationCode; //! Exit code of parameterisation
+  //TVirtualFitter* fFitter;            //! Fit object (MINUIT)
 
-   Double_t     fError;                //! Error from parameterization
-   Double_t     fTestError;            //! Error from test
-   Double_t     fPrecision;            //! Relative precision of param
-   Double_t     fTestPrecision;        //! Relative precision of test
-   Double_t     fCorrelationCoeff;     //! Multi Correlation coefficient
-   TMatrixD     fCorrelationMatrix;    //! Correlation matrix
-   Double_t     fTestCorrelationCoeff; //! Multi Correlation coefficient
+  EMDFPolyType fPolyType;   // Type of polynomials to use
+  Bool_t fShowCorrelation;  // print correlation matrix
+  Bool_t fIsUserFunction;   // Flag for user defined function
+  Bool_t fIsVerbose;        //
 
-   TList*       fHistograms;           //! List of histograms
-   Byte_t       fHistogramMask;        //! Bit pattern of hisograms used
-
-   //TVirtualFitter* fFitter;            //! Fit object (MINUIT)
-
-   EMDFPolyType fPolyType;             // Type of polynomials to use
-   Bool_t       fShowCorrelation;      // print correlation matrix
-   Bool_t       fIsUserFunction;       // Flag for user defined function
-   Bool_t       fIsVerbose;            //
-
-   virtual Double_t EvalFactor(Int_t p, Double_t x) const;
-   virtual Double_t EvalControl(const Int_t *powers);
-   virtual void     MakeCoefficientErrors();
-   virtual void     MakeCorrelation();
-   virtual Double_t MakeGramSchmidt(Int_t function);
-   virtual void     MakeCoefficients();
-   virtual void     MakeCandidates();
-   virtual void     MakeNormalized();
-   virtual void     MakeParameterization();
-   virtual void     MakeRealCode(const char *filename,
-                                 const char *classname,
-                                 Option_t   *option="");
-   virtual Bool_t   Select(const Int_t *iv);
-   virtual Bool_t   TestFunction(Double_t squareResidual,
-                                 Double_t dResidur);
+  virtual Double_t EvalFactor(Int_t p, Double_t x) const;
+  virtual Double_t EvalControl(const Int_t *powers);
+  virtual void MakeCoefficientErrors();
+  virtual void MakeCorrelation();
+  virtual Double_t MakeGramSchmidt(Int_t function);
+  virtual void MakeCoefficients();
+  virtual void MakeCandidates();
+  virtual void MakeNormalized();
+  virtual void MakeParameterization();
+  virtual void MakeRealCode(const char *filename, const char *classname, Option_t *option = "");
+  virtual Bool_t Select(const Int_t *iv);
+  virtual Bool_t TestFunction(Double_t squareResidual, Double_t dResidur);
 
 public:
-   TMultiDimFet();
-//   TMultiDimFet(const TMultiDimFet &in);
-   const TMultiDimFet &operator=(const TMultiDimFet &in);
+  TMultiDimFet();
+  //   TMultiDimFet(const TMultiDimFet &in);
+  const TMultiDimFet &operator=(const TMultiDimFet &in);
 
-   TMultiDimFet(Int_t dimension,
-                EMDFPolyType type=kMonomials,
-                Option_t *option="");
-   ~TMultiDimFet() override;
+  TMultiDimFet(Int_t dimension, EMDFPolyType type = kMonomials, Option_t *option = "");
+  ~TMultiDimFet() override;
 
-   virtual void     AddRow(const Double_t *x, Double_t D, Double_t E=0);
-   virtual void     AddTestRow(const Double_t *x, Double_t D, Double_t E=0);
-   //void     Browse(TBrowser* b) override;
-   void     Clear(Option_t *option="") override; // *MENU*
-   //void     Draw(Option_t * ="d") override { }
-   virtual Double_t Eval(const Double_t *x, const Double_t *coeff=nullptr) const;
-   virtual void     FindParameterization(double precision); // *MENU*
-   //virtual void     Fit(Option_t *option=""); // *MENU*
+  virtual void AddRow(const Double_t *x, Double_t D, Double_t E = 0);
+  virtual void AddTestRow(const Double_t *x, Double_t D, Double_t E = 0);
+  //void     Browse(TBrowser* b) override;
+  void Clear(Option_t *option = "") override;  // *MENU*
+  //void     Draw(Option_t * ="d") override { }
+  virtual Double_t Eval(const Double_t *x, const Double_t *coeff = nullptr) const;
+  virtual void FindParameterization(double precision);  // *MENU*
+  //virtual void     Fit(Option_t *option=""); // *MENU*
 
-   Double_t         GetChi2()              const { return fChi2; }
-   const TMatrixD*  GetCorrelationMatrix() const { return &fCorrelationMatrix; }
-   const TVectorD*  GetCoefficients()      const { return &fCoefficients; }
-   Double_t         GetError()             const { return fError; }
-   std::vector<Int_t> GetFunctionCodes()     const { return fFunctionCodes; }
-   const TMatrixD*  GetFunctions()         const { return &fFunctions; }
-   virtual TList*   GetHistograms()        const { return fHistograms; }
-   Double_t         GetMaxAngle()          const { return fMaxAngle; }
-   Int_t            GetMaxFunctions()      const { return fMaxFunctions; }
-   std::vector<Int_t> GetMaxPowers()         const { return fMaxPowers; }
-   Double_t         GetMaxQuantity()       const { return fMaxQuantity; }
-   Int_t            GetMaxStudy()          const { return fMaxStudy; }
-   Int_t            GetMaxTerms()          const { return fMaxTerms; }
-   const TVectorD*  GetMaxVariables()      const { return &fMaxVariables; }
-   Double_t         GetMeanQuantity()      const { return fMeanQuantity; }
-   const TVectorD*  GetMeanVariables()     const { return &fMeanVariables; }
-   Double_t         GetMinAngle()          const { return fMinAngle; }
-   Double_t         GetMinQuantity()       const { return fMinQuantity; }
-   Double_t         GetMinRelativeError()  const { return fMinRelativeError; }
-   const TVectorD*  GetMinVariables()      const { return &fMinVariables; }
-   Int_t            GetNVariables()        const { return fNVariables; }
-   Int_t            GetNCoefficients()     const { return fNCoefficients; }
-   Int_t            GetPolyType()          const { return fPolyType; }
-   std::vector<Int_t> GetPowerIndex()        const { return fPowerIndex; }
-   Double_t         GetPowerLimit()        const { return fPowerLimit; }
-   std::vector<Int_t> GetPowers()            const { return fPowers; }
-   Double_t         GetPrecision()         const { return fPrecision; }
-   const TVectorD*  GetQuantity()          const { return &fQuantity; }
-   Double_t         GetResidualMax()       const { return fMaxResidual; }
-   Double_t         GetResidualMin()       const { return fMinResidual; }
-   Int_t            GetResidualMaxRow()    const { return fMaxResidualRow; }
-   Int_t            GetResidualMinRow()    const { return fMinResidualRow; }
-   Double_t         GetResidualSumSq()     const { return fSumSqResidual; }
-   Double_t         GetRMS()               const { return fRMS; }
-   Int_t            GetSampleSize()        const { return fSampleSize; }
-   const TVectorD*  GetSqError()           const { return &fSqError; }
-   Double_t         GetSumSqAvgQuantity()  const { return fSumSqAvgQuantity; }
-   Double_t         GetSumSqQuantity()     const { return fSumSqQuantity; }
-   Double_t         GetTestError()         const { return fTestError; }
-   Double_t         GetTestPrecision()     const { return fTestPrecision; }
-   const TVectorD*  GetTestQuantity()      const { return &fTestQuantity; }
-   Int_t            GetTestSampleSize()    const { return fTestSampleSize; }
-   const TVectorD*  GetTestSqError()       const { return &fTestSqError; }
-   const TVectorD*  GetTestVariables()     const { return &fTestVariables; }
-   const TVectorD*  GetVariables()         const { return &fVariables; }
+  Double_t GetChi2() const { return fChi2; }
+  const TMatrixD *GetCorrelationMatrix() const { return &fCorrelationMatrix; }
+  const TVectorD *GetCoefficients() const { return &fCoefficients; }
+  Double_t GetError() const { return fError; }
+  std::vector<Int_t> GetFunctionCodes() const { return fFunctionCodes; }
+  const TMatrixD *GetFunctions() const { return &fFunctions; }
+  virtual TList *GetHistograms() const { return fHistograms; }
+  Double_t GetMaxAngle() const { return fMaxAngle; }
+  Int_t GetMaxFunctions() const { return fMaxFunctions; }
+  std::vector<Int_t> GetMaxPowers() const { return fMaxPowers; }
+  Double_t GetMaxQuantity() const { return fMaxQuantity; }
+  Int_t GetMaxStudy() const { return fMaxStudy; }
+  Int_t GetMaxTerms() const { return fMaxTerms; }
+  const TVectorD *GetMaxVariables() const { return &fMaxVariables; }
+  Double_t GetMeanQuantity() const { return fMeanQuantity; }
+  const TVectorD *GetMeanVariables() const { return &fMeanVariables; }
+  Double_t GetMinAngle() const { return fMinAngle; }
+  Double_t GetMinQuantity() const { return fMinQuantity; }
+  Double_t GetMinRelativeError() const { return fMinRelativeError; }
+  const TVectorD *GetMinVariables() const { return &fMinVariables; }
+  Int_t GetNVariables() const { return fNVariables; }
+  Int_t GetNCoefficients() const { return fNCoefficients; }
+  Int_t GetPolyType() const { return fPolyType; }
+  std::vector<Int_t> GetPowerIndex() const { return fPowerIndex; }
+  Double_t GetPowerLimit() const { return fPowerLimit; }
+  std::vector<Int_t> GetPowers() const { return fPowers; }
+  Double_t GetPrecision() const { return fPrecision; }
+  const TVectorD *GetQuantity() const { return &fQuantity; }
+  Double_t GetResidualMax() const { return fMaxResidual; }
+  Double_t GetResidualMin() const { return fMinResidual; }
+  Int_t GetResidualMaxRow() const { return fMaxResidualRow; }
+  Int_t GetResidualMinRow() const { return fMinResidualRow; }
+  Double_t GetResidualSumSq() const { return fSumSqResidual; }
+  Double_t GetRMS() const { return fRMS; }
+  Int_t GetSampleSize() const { return fSampleSize; }
+  const TVectorD *GetSqError() const { return &fSqError; }
+  Double_t GetSumSqAvgQuantity() const { return fSumSqAvgQuantity; }
+  Double_t GetSumSqQuantity() const { return fSumSqQuantity; }
+  Double_t GetTestError() const { return fTestError; }
+  Double_t GetTestPrecision() const { return fTestPrecision; }
+  const TVectorD *GetTestQuantity() const { return &fTestQuantity; }
+  Int_t GetTestSampleSize() const { return fTestSampleSize; }
+  const TVectorD *GetTestSqError() const { return &fTestSqError; }
+  const TVectorD *GetTestVariables() const { return &fTestVariables; }
+  const TVectorD *GetVariables() const { return &fVariables; }
 
-   //static TMultiDimFet* Instance()               { return fgInstance; }
-   Bool_t   IsFolder()             const override { return kTRUE; }
-   virtual Double_t MakeChi2(const Double_t* coeff=nullptr);
-   virtual void     MakeCode(const char *functionName="MDF", Option_t *option=""); // *MENU*
-   virtual void     MakeHistograms(Option_t* option="A"); // *MENU*
-   virtual void     MakeMethod(const Char_t* className="MDF", Option_t* option=""); // *MENU*
-   void     Print(Option_t *option="ps") const override; // *MENU*
-   virtual void     PrintPolynomialsSpecial(Option_t *option="m") const; // *MENU*
+  //static TMultiDimFet* Instance()               { return fgInstance; }
+  Bool_t IsFolder() const override { return kTRUE; }
+  virtual Double_t MakeChi2(const Double_t *coeff = nullptr);
+  virtual void MakeCode(const char *functionName = "MDF", Option_t *option = "");   // *MENU*
+  virtual void MakeHistograms(Option_t *option = "A");                              // *MENU*
+  virtual void MakeMethod(const Char_t *className = "MDF", Option_t *option = "");  // *MENU*
+  void Print(Option_t *option = "ps") const override;                               // *MENU*
+  virtual void PrintPolynomialsSpecial(Option_t *option = "m") const;               // *MENU*
 
-   void             SetMaxAngle(Double_t angle=0);
-   void             SetMaxFunctions(Int_t n) { fMaxFunctions = n; }
-   void             SetMaxPowers(const Int_t *powers);
-   void             SetMaxStudy(Int_t n) { fMaxStudy  = n; }
-   void             SetMaxTerms(Int_t terms) { fMaxTerms = terms; }
-   void             SetMinRelativeError(Double_t error);
-   void             SetMinAngle(Double_t angle=1);
-   void             SetPowerLimit(Double_t limit=1e-3);
-   virtual void     SetPowers(const Int_t *powers, Int_t terms);
+  void SetMaxAngle(Double_t angle = 0);
+  void SetMaxFunctions(Int_t n) { fMaxFunctions = n; }
+  void SetMaxPowers(const Int_t *powers);
+  void SetMaxStudy(Int_t n) { fMaxStudy = n; }
+  void SetMaxTerms(Int_t terms) { fMaxTerms = terms; }
+  void SetMinRelativeError(Double_t error);
+  void SetMinAngle(Double_t angle = 1);
+  void SetPowerLimit(Double_t limit = 1e-3);
+  virtual void SetPowers(const Int_t *powers, Int_t terms);
 
-   void ReducePolynomial(double error);
-   void ZeroDoubiousCoefficients(double error);
+  void ReducePolynomial(double error);
+  void ZeroDoubiousCoefficients(double error);
 
-   ClassDefOverride(TMultiDimFet,1) // Multi dimensional fit class
+  ClassDefOverride(TMultiDimFet, 1)  // Multi dimensional fit class
 };
 #endif  //SimG4Core_TotemRPProtonTransportParametrization_TMultiDimFet_H
-

--- a/SimTransport/TotemRPProtonTransportParametrization/src/SimTransportTotemRPProtTranspParLinkDef.h
+++ b/SimTransport/TotemRPProtonTransportParametrization/src/SimTransportTotemRPProtTranspParLinkDef.h
@@ -2,18 +2,16 @@
 #include "SimTransport/TotemRPProtonTransportParametrization/interface/LHCOpticsApproximator.h"
 #include <vector>
 
-
 #ifdef __CINT__
 
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class TMultiDimFet+;
-#pragma link C++ class LHCOpticsApproximator+;
-#pragma link C++ class LHCApertureApproximator+;
-#pragma link C++ class vector<LHCOpticsApproximator>+;
-#pragma link C++ class vector<LHCApertureApproximator>+;
-
+#pragma link C++ class TMultiDimFet + ;
+#pragma link C++ class LHCOpticsApproximator + ;
+#pragma link C++ class LHCApertureApproximator + ;
+#pragma link C++ class vector < LHCOpticsApproximator> + ;
+#pragma link C++ class vector < LHCApertureApproximator> + ;
 
 #endif

--- a/SimTransport/TotemRPProtonTransportParametrization/src/TMultiDimFet.cc
+++ b/SimTransport/TotemRPProtonTransportParametrization/src/TMultiDimFet.cc
@@ -10,7 +10,6 @@
 *
 ****************************************************************************/
 
-
 #include "Riostream.h"
 #include "SimTransport/TotemRPProtonTransportParametrization/interface/TMultiDimFet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -24,19 +23,18 @@
 
 #define RADDEG (180. / TMath::Pi())
 #define DEGRAD (TMath::Pi() / 180.)
-#define HIST_XORIG     0
-#define HIST_DORIG     1
-#define HIST_XNORM     2
-#define HIST_DSHIF     3
-#define HIST_RX        4
-#define HIST_RD        5
-#define HIST_RTRAI     6
-#define HIST_RTEST     7
+#define HIST_XORIG 0
+#define HIST_DORIG 1
+#define HIST_XNORM 2
+#define HIST_DSHIF 3
+#define HIST_RX 4
+#define HIST_RD 5
+#define HIST_RTRAI 6
+#define HIST_RTEST 7
 #define PARAM_MAXSTUDY 1
-#define PARAM_SEVERAL  2
-#define PARAM_RELERR   3
+#define PARAM_SEVERAL 2
+#define PARAM_RELERR 3
 #define PARAM_MAXTERMS 4
-
 
 //____________________________________________________________________
 //static void mdfHelper(int&, double*, double&, double*, int);
@@ -48,488 +46,458 @@ ClassImp(TMultiDimFet);
 // Static instance. Used with mdfHelper and TMinuit
 //TMultiDimFet* TMultiDimFet::fgInstance = nullptr;
 
+//____________________________________________________________________
+TMultiDimFet::TMultiDimFet() {
+  // Empty CTOR. Do not use
+  fMeanQuantity = 0;
+  fMaxQuantity = 0;
+  fMinQuantity = 0;
+  fSumSqQuantity = 0;
+  fSumSqAvgQuantity = 0;
+  fPowerLimit = 1;
+
+  fMaxAngle = 0;
+  fMinAngle = 1;
+
+  fNVariables = 0;
+  fMaxVariables = 0;
+  fMinVariables = 0;
+  fSampleSize = 0;
+
+  fMaxAngle = 0;
+  fMinAngle = 0;
+
+  fPolyType = kMonomials;
+  fShowCorrelation = kFALSE;
+
+  fIsUserFunction = kFALSE;
+
+  fHistograms = nullptr;
+  fHistogramMask = 0;
+
+  //fFitter                  = nullptr;
+  //fgInstance               = nullptr;
+}
+
+const TMultiDimFet &TMultiDimFet::operator=(const TMultiDimFet &in) {
+  if (this == &in) {
+    return in;
+  }
+
+  fMeanQuantity = in.fMeanQuantity;  // Mean of dependent quantity
+
+  fMaxQuantity = 0.0;       //! Max value of dependent quantity
+  fMinQuantity = 0.0;       //! Min value of dependent quantity
+  fSumSqQuantity = 0.0;     //! SumSquare of dependent quantity
+  fSumSqAvgQuantity = 0.0;  //! Sum of squares away from mean
+
+  fNVariables = in.fNVariables;  // Number of independent variables
+
+  fMaxVariables.ResizeTo(in.fMaxVariables.GetLwb(), in.fMaxVariables.GetUpb());
+  fMaxVariables = in.fMaxVariables;  // max value of independent variables
+
+  fMinVariables.ResizeTo(in.fMinVariables.GetLwb(), in.fMinVariables.GetUpb());
+  fMinVariables = in.fMinVariables;  // min value of independent variables
+
+  fSampleSize = 0;      //! Size of training sample
+  fTestSampleSize = 0;  //! Size of test sample
+  fMinAngle = 1;        //! Min angle for acepting new function
+  fMaxAngle = 0.0;      //! Max angle for acepting new function
+
+  fMaxTerms = in.fMaxTerms;  // Max terms expected in final expr.
+
+  fMinRelativeError = 0.0;  //! Min relative error accepted
+
+  fMaxPowers.clear();  //! [fNVariables] maximum powers
+  fPowerLimit = 1;     //! Control parameter
+
+  fMaxFunctions = in.fMaxFunctions;  // max number of functions
+
+  fFunctionCodes.clear();  //! [fMaxFunctions] acceptance code
+  fMaxStudy = 0;           //! max functions to study
+
+  fMaxPowersFinal.clear();  //! [fNVariables] maximum powers from fit;
+
+  fMaxFunctionsTimesNVariables = in.fMaxFunctionsTimesNVariables;  // fMaxFunctionsTimesNVariables
+  fPowers = in.fPowers;
+
+  fPowerIndex = in.fPowerIndex;  // [fMaxTerms] Index of accepted powers
+
+  fMaxResidual = 0.0;    //! Max redsidual value
+  fMinResidual = 0.0;    //! Min redsidual value
+  fMaxResidualRow = 0;   //! Row giving max residual
+  fMinResidualRow = 0;   //! Row giving min residual
+  fSumSqResidual = 0.0;  //! Sum of Square residuals
+
+  fNCoefficients = in.fNCoefficients;  // Dimension of model coefficients
+
+  fCoefficients.ResizeTo(in.fCoefficients.GetLwb(), in.fCoefficients.GetUpb());
+  fCoefficients = in.fCoefficients;  // Vector of the final coefficients
+
+  fRMS = 0.0;                   //! Root mean square of fit
+  fChi2 = 0.0;                  //! Chi square of fit
+  fParameterisationCode = 0;    //! Exit code of parameterisation
+  fError = 0.0;                 //! Error from parameterization
+  fTestError = 0.0;             //! Error from test
+  fPrecision = 0.0;             //! Relative precision of param
+  fTestPrecision = 0.0;         //! Relative precision of test
+  fCorrelationCoeff = 0.0;      //! Multi Correlation coefficient
+  fTestCorrelationCoeff = 0.0;  //! Multi Correlation coefficient
+  fHistograms = nullptr;        //! List of histograms
+  fHistogramMask = 0;           //! Bit pattern of hisograms used
+  //fFitter = nullptr;            //! Fit object (MINUIT)
+
+  fPolyType = in.fPolyType;                // Type of polynomials to use
+  fShowCorrelation = in.fShowCorrelation;  // print correlation matrix
+  fIsUserFunction = in.fIsUserFunction;    // Flag for user defined function
+  fIsVerbose = in.fIsVerbose;              //
+  return in;
+}
 
 //____________________________________________________________________
-TMultiDimFet::TMultiDimFet()
-{
-   // Empty CTOR. Do not use
-   fMeanQuantity            = 0;
-   fMaxQuantity             = 0;
-   fMinQuantity             = 0;
-   fSumSqQuantity           = 0;
-   fSumSqAvgQuantity        = 0;
-   fPowerLimit              = 1;
+TMultiDimFet::TMultiDimFet(Int_t dimension, EMDFPolyType type, Option_t *option)
+    : TNamed("multidimfit", "Multi-dimensional fit object"),
+      fQuantity(dimension),
+      fSqError(dimension),
+      fVariables(dimension * 100),
+      fMeanVariables(dimension),
+      fMaxVariables(dimension),
+      fMinVariables(dimension) {
+  // Constructor
+  // Second argument is the type of polynomials to use in
+  // parameterisation, one of:
+  //      TMultiDimFet::kMonomials
+  //      TMultiDimFet::kChebyshev
+  //      TMultiDimFet::kLegendre
+  //
+  // Options:
+  //   K      Compute (k)correlation matrix
+  //   V      Be verbose
+  //
+  // Default is no options.
+  //
 
-   fMaxAngle                = 0;
-   fMinAngle                = 1;
+  //fgInstance = this;
 
-   fNVariables              = 0;
-   fMaxVariables            = 0;
-   fMinVariables            = 0;
-   fSampleSize              = 0;
+  fMeanQuantity = 0;
+  fMaxQuantity = 0;
+  fMinQuantity = 0;
+  fSumSqQuantity = 0;
+  fSumSqAvgQuantity = 0;
+  fPowerLimit = 1;
 
-   fMaxAngle                = 0;
-   fMinAngle                = 0;
+  fMaxAngle = 0;
+  fMinAngle = 1;
 
-   fPolyType                = kMonomials;
-   fShowCorrelation         = kFALSE;
+  fNVariables = dimension;
+  fMaxVariables = 0;
+  fMaxFunctionsTimesNVariables = fMaxFunctions * fNVariables;
+  fMinVariables = 0;
+  fSampleSize = 0;
+  fTestSampleSize = 0;
+  fMinRelativeError = 0.01;
+  fError = 0;
+  fTestError = 0;
+  fPrecision = 0;
+  fTestPrecision = 0;
+  fParameterisationCode = 0;
 
-   fIsUserFunction          = kFALSE;
+  fPolyType = type;
+  fShowCorrelation = kFALSE;
+  fIsVerbose = kFALSE;
 
-   fHistograms              = nullptr;
-   fHistogramMask           = 0;
+  TString opt = option;
+  opt.ToLower();
 
-   //fFitter                  = nullptr;
-   //fgInstance               = nullptr;
+  if (opt.Contains("k"))
+    fShowCorrelation = kTRUE;
+  if (opt.Contains("v"))
+    fIsVerbose = kTRUE;
+
+  fIsUserFunction = kFALSE;
+
+  fHistograms = nullptr;
+  fHistogramMask = 0;
+
+  fMaxPowers.resize(dimension);
+  fMaxPowersFinal.resize(dimension);
+  //fFitter                 = nullptr;
 }
-
-const TMultiDimFet &TMultiDimFet::operator=(const TMultiDimFet &in)
-{
-   if(this==&in)
-   {
-     return in;
-   }
-
-   fMeanQuantity = in.fMeanQuantity;         // Mean of dependent quantity
-
-   fMaxQuantity = 0.0;          //! Max value of dependent quantity
-   fMinQuantity = 0.0;          //! Min value of dependent quantity
-   fSumSqQuantity = 0.0;        //! SumSquare of dependent quantity
-   fSumSqAvgQuantity = 0.0;     //! Sum of squares away from mean
-
-   fNVariables = in.fNVariables;           // Number of independent variables
-
-   fMaxVariables.ResizeTo(in.fMaxVariables.GetLwb(), in.fMaxVariables.GetUpb());
-   fMaxVariables = in.fMaxVariables;         // max value of independent variables
-
-   fMinVariables.ResizeTo(in.fMinVariables.GetLwb(), in.fMinVariables.GetUpb());
-   fMinVariables = in.fMinVariables;         // min value of independent variables
-
-   fSampleSize = 0;           //! Size of training sample
-   fTestSampleSize = 0;       //! Size of test sample
-   fMinAngle = 1;             //! Min angle for acepting new function
-   fMaxAngle = 0.0;             //! Max angle for acepting new function
-
-   fMaxTerms = in.fMaxTerms;             // Max terms expected in final expr.
-
-   fMinRelativeError = 0.0;     //! Min relative error accepted
-
-   fMaxPowers.clear();            //! [fNVariables] maximum powers
-   fPowerLimit = 1;           //! Control parameter
-
-   fMaxFunctions = in.fMaxFunctions;         // max number of functions
-
-   fFunctionCodes.clear();        //! [fMaxFunctions] acceptance code
-   fMaxStudy = 0;             //! max functions to study
-
-   fMaxPowersFinal.clear();       //! [fNVariables] maximum powers from fit;
-
-   fMaxFunctionsTimesNVariables = in.fMaxFunctionsTimesNVariables;  // fMaxFunctionsTimesNVariables
-   fPowers = in.fPowers;
-
-   fPowerIndex = in.fPowerIndex;           // [fMaxTerms] Index of accepted powers
-
-   fMaxResidual = 0.0;          //! Max redsidual value
-   fMinResidual = 0.0;          //! Min redsidual value
-   fMaxResidualRow = 0;       //! Row giving max residual
-   fMinResidualRow = 0;       //! Row giving min residual
-   fSumSqResidual = 0.0;        //! Sum of Square residuals
-
-   fNCoefficients = in.fNCoefficients;        // Dimension of model coefficients
-
-   fCoefficients.ResizeTo(in.fCoefficients.GetLwb(), in.fCoefficients.GetUpb());
-   fCoefficients = in.fCoefficients;         // Vector of the final coefficients
-
-   fRMS = 0.0;                  //! Root mean square of fit
-   fChi2 = 0.0;                 //! Chi square of fit
-   fParameterisationCode = 0; //! Exit code of parameterisation
-   fError = 0.0;                //! Error from parameterization
-   fTestError = 0.0;            //! Error from test
-   fPrecision = 0.0;            //! Relative precision of param
-   fTestPrecision = 0.0;        //! Relative precision of test
-   fCorrelationCoeff = 0.0;     //! Multi Correlation coefficient
-   fTestCorrelationCoeff = 0.0; //! Multi Correlation coefficient
-   fHistograms = nullptr;           //! List of histograms
-   fHistogramMask = 0;        //! Bit pattern of hisograms used
-   //fFitter = nullptr;            //! Fit object (MINUIT)
-
-   fPolyType = in.fPolyType;             // Type of polynomials to use
-   fShowCorrelation = in.fShowCorrelation;      // print correlation matrix
-   fIsUserFunction = in.fIsUserFunction;       // Flag for user defined function
-   fIsVerbose = in.fIsVerbose;            //
-   return in;
-}
-
 
 //____________________________________________________________________
-TMultiDimFet::TMultiDimFet(Int_t dimension,
-                           EMDFPolyType type,
-                           Option_t *option)
-  : TNamed("multidimfit","Multi-dimensional fit object"),
-    fQuantity(dimension),
-    fSqError(dimension),
-    fVariables(dimension*100),
-    fMeanVariables(dimension),
-    fMaxVariables(dimension),
-    fMinVariables(dimension)
-{
-   // Constructor
-   // Second argument is the type of polynomials to use in
-   // parameterisation, one of:
-   //      TMultiDimFet::kMonomials
-   //      TMultiDimFet::kChebyshev
-   //      TMultiDimFet::kLegendre
-   //
-   // Options:
-   //   K      Compute (k)correlation matrix
-   //   V      Be verbose
-   //
-   // Default is no options.
-   //
-
-   //fgInstance = this;
-
-   fMeanQuantity           = 0;
-   fMaxQuantity            = 0;
-   fMinQuantity            = 0;
-   fSumSqQuantity          = 0;
-   fSumSqAvgQuantity       = 0;
-   fPowerLimit             = 1;
-
-   fMaxAngle               = 0;
-   fMinAngle               = 1;
-
-   fNVariables             = dimension;
-   fMaxVariables           = 0;
-   fMaxFunctionsTimesNVariables = fMaxFunctions * fNVariables;
-   fMinVariables           = 0;
-   fSampleSize             = 0;
-   fTestSampleSize         = 0;
-   fMinRelativeError       = 0.01;
-   fError                  = 0;
-   fTestError              = 0;
-   fPrecision              = 0;
-   fTestPrecision          = 0;
-   fParameterisationCode   = 0;
-
-   fPolyType               = type;
-   fShowCorrelation        = kFALSE;
-   fIsVerbose              = kFALSE;
-
-   TString opt             = option;
-   opt.ToLower();
-
-   if (opt.Contains("k")) fShowCorrelation = kTRUE;
-   if (opt.Contains("v")) fIsVerbose       = kTRUE;
-
-   fIsUserFunction         = kFALSE;
-
-   fHistograms             = nullptr;
-   fHistogramMask          = 0;
-
-   fMaxPowers.resize(dimension);
-   fMaxPowersFinal.resize(dimension);
-   //fFitter                 = nullptr;
+TMultiDimFet::~TMultiDimFet() {
+  if (fHistograms)
+    fHistograms->Clear("nodelete");
+  delete fHistograms;
 }
-
 
 //____________________________________________________________________
-TMultiDimFet::~TMultiDimFet()
-{
-   if (fHistograms) fHistograms->Clear("nodelete");
-     delete fHistograms;
-}
-
-
-//____________________________________________________________________
-void TMultiDimFet::AddRow(const Double_t *x, Double_t D, Double_t E)
-{
-   // Add a row consisting of fNVariables independent variables, the
-   // known, dependent quantity, and optionally, the square error in
-   // the dependent quantity, to the training sample to be used for the
-   // parameterization.
-   // The mean of the variables and quantity is calculated on the fly,
-   // as outlined in TPrincipal::AddRow.
-   // This sample should be representive of the problem at hand.
-   // Please note, that if no error is given Poisson statistics is
-   // assumed and the square error is set to the value of dependent
-   // quantity.  See also the
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   if (!x)
-      return;
-
-   if (++fSampleSize == 1) {
-      fMeanQuantity  = D;
-      fMaxQuantity   = D;
-      fMinQuantity   = D;
-   }
-   else {
-      fMeanQuantity  *= 1 - 1./Double_t(fSampleSize);
-      fMeanQuantity  += D / Double_t(fSampleSize);
-      fSumSqQuantity += D * D;
-
-      if (D >= fMaxQuantity) fMaxQuantity = D;
-      if (D <= fMinQuantity) fMinQuantity = D;
-   }
-
-
-   // If the vector isn't big enough to hold the new data, then
-   // expand the vector by half it's size.
-   Int_t size = fQuantity.GetNrows();
-   if (fSampleSize > size) {
-      fQuantity.ResizeTo(size + size/2);
-      fSqError.ResizeTo(size + size/2);
-   }
-
-   // Store the value
-   fQuantity(fSampleSize-1) = D;
-   fSqError(fSampleSize-1) = (E == 0 ? D : E);
-
-   // Store data point in internal vector
-   // If the vector isn't big enough to hold the new data, then
-   // expand the vector by half it's size
-   size = fVariables.GetNrows();
-   if (fSampleSize * fNVariables > size)
-      fVariables.ResizeTo(size + size/2);
-
-
-   // Increment the data point counter
-   Int_t i,j;
-   for (i = 0; i < fNVariables; i++) {
-      if (fSampleSize == 1) {
-         fMeanVariables(i) = x[i];
-         fMaxVariables(i)  = x[i];
-         fMinVariables(i)  = x[i];
-      }
-      else {
-         fMeanVariables(i) *= 1 - 1./Double_t(fSampleSize);
-         fMeanVariables(i) += x[i] / Double_t(fSampleSize);
-
-         // Update the maximum value for this component
-         if (x[i] >= fMaxVariables(i)) fMaxVariables(i)  = x[i];
-
-         // Update the minimum value for this component
-         if (x[i] <= fMinVariables(i)) fMinVariables(i)  = x[i];
-
-      }
-
-      // Store the data.
-      j = (fSampleSize-1) * fNVariables + i;
-      fVariables(j) = x[i];
-   }
-}
-
-
-//____________________________________________________________________
-void TMultiDimFet::AddTestRow(const Double_t *x, Double_t D, Double_t E)
-{
-   // Add a row consisting of fNVariables independent variables, the
-   // known, dependent quantity, and optionally, the square error in
-   // the dependent quantity, to the test sample to be used for the
-   // test of the parameterization.
-   // This sample needn't be representive of the problem at hand.
-   // Please note, that if no error is given Poisson statistics is
-   // assumed and the square error is set to the value of dependent
-   // quantity.  See also the
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   if (fTestSampleSize++ == 0) {
-      fTestQuantity.ResizeTo(fNVariables);
-      fTestSqError.ResizeTo(fNVariables);
-      fTestVariables.ResizeTo(fNVariables * 100);
-   }
-
-   // If the vector isn't big enough to hold the new data, then
-   // expand the vector by half it's size.
-   Int_t size = fTestQuantity.GetNrows();
-   if (fTestSampleSize > size) {
-      fTestQuantity.ResizeTo(size + size/2);
-      fTestSqError.ResizeTo(size + size/2);
-   }
-
-   // Store the value
-   fTestQuantity(fTestSampleSize-1) = D;
-   fTestSqError(fTestSampleSize-1) = (E == 0 ? D : E);
-
-   // Store data point in internal vector
-   // If the vector isn't big enough to hold the new data, then
-   // expand the vector by half it's size
-   size = fTestVariables.GetNrows();
-   if (fTestSampleSize * fNVariables > size)
-      fTestVariables.ResizeTo(size + size/2);
-
-
-   // Increment the data point counter
-   Int_t i,j;
-   for (i = 0; i < fNVariables; i++) {
-      j = fNVariables * (fTestSampleSize - 1) + i;
-      fTestVariables(j) = x[i];
-
-      if (x[i] > fMaxVariables(i))
-         Warning("AddTestRow", "variable %d (row: %d) too large: %f > %f",
-         i, fTestSampleSize, x[i], fMaxVariables(i));
-      if (x[i] < fMinVariables(i))
-         Warning("AddTestRow", "variable %d (row: %d) too small: %f < %f",
-         i, fTestSampleSize, x[i], fMinVariables(i));
-   }
-}
-
-
-//____________________________________________________________________
-void TMultiDimFet::Clear(Option_t *option)
-{
-   // Clear internal structures and variables
-   Int_t i, j, n = fNVariables, m = fMaxFunctions;
-
-   // Training sample, dependent quantity
-   fQuantity.Zero();
-   fSqError.Zero();
-   fMeanQuantity                 = 0;
-   fMaxQuantity                  = 0;
-   fMinQuantity                  = 0;
-   fSumSqQuantity                = 0;
-   fSumSqAvgQuantity             = 0;
-
-   // Training sample, independent variables
-   fVariables.Zero();
-   fNVariables                   = 0;
-   fSampleSize                   = 0;
-   fMeanVariables.Zero();
-   fMaxVariables.Zero();
-   fMinVariables.Zero();
-
-   // Test sample
-   fTestQuantity.Zero();
-   fTestSqError.Zero();
-   fTestVariables.Zero();
-   fTestSampleSize               = 0;
-
-   // Functions
-   fFunctions.Zero();
-   fMaxFunctions                 = 0;
-   fMaxStudy                     = 0;
-   fMaxFunctionsTimesNVariables  = 0;
-   fOrthFunctions.Zero();
-   fOrthFunctionNorms.Zero();
-
-   // Control parameters
-   fMinRelativeError             = 0;
-   fMinAngle                     = 0;
-   fMaxAngle                     = 0;
-   fMaxTerms                     = 0;
-
-   // Powers
-   for (i = 0; i < n; i++) {
-      fMaxPowers[i]               = 0;
-      fMaxPowersFinal[i]          = 0;
-      for (j = 0; j < m; j++)
-         fPowers[i * n + j]        = 0;
-   }
-   fPowerLimit                   = 0;
-
-   // Residuals
-   fMaxResidual                  = 0;
-   fMinResidual                  = 0;
-   fMaxResidualRow               = 0;
-   fMinResidualRow               = 0;
-   fSumSqResidual                = 0;
-
-   // Fit
-   fNCoefficients                = 0;
-   fOrthCoefficients             = 0;
-   fOrthCurvatureMatrix          = 0;
-   fRMS                          = 0;
-   fCorrelationMatrix.Zero();
-   fError                        = 0;
-   fTestError                    = 0;
-   fPrecision                    = 0;
-   fTestPrecision                = 0;
-
-   // Coefficients
-   fCoefficients.Zero();
-   fCoefficientsRMS.Zero();
-   fResiduals.Zero();
-   fHistograms->Clear(option);
-
-   // Options
-   fPolyType                     = kMonomials;
-   fShowCorrelation              = kFALSE;
-   fIsUserFunction               = kFALSE;
-}
-
-
-//____________________________________________________________________
-Double_t TMultiDimFet::Eval(const Double_t *x, const Double_t* coeff) const
-{
-   // Evaluate parameterization at point x. Optional argument coeff is
-   // a vector of coefficients for the parameterisation, fNCoefficients
-   // elements long.
-//   int fMaxFunctionsTimesNVariables = fMaxFunctions * fNVariables;
-   Double_t returnValue = fMeanQuantity;
-   Double_t term        = 0;
-   Int_t    i, j;
-
-   for (i = 0; i < fNCoefficients; i++) {
-      // Evaluate the ith term in the expansion
-      term = (coeff ? coeff[i] : fCoefficients(i));
-      for (j = 0; j < fNVariables; j++) {
-         // Evaluate the factor (polynomial) in the j-th variable.
-         Int_t    p  =  fPowers[fPowerIndex[i] * fNVariables + j];
-         Double_t y  =  1 + 2. / (fMaxVariables(j) - fMinVariables(j))
-            * (x[j] - fMaxVariables(j));
-         term        *= EvalFactor(p,y);
-      }
-      // Add this term to the final result
-      returnValue += term;
-   }
-   return returnValue;
-}
-
-
-void TMultiDimFet::ReducePolynomial(double error)
-{
-  if(error == 0.0)
+void TMultiDimFet::AddRow(const Double_t *x, Double_t D, Double_t E) {
+  // Add a row consisting of fNVariables independent variables, the
+  // known, dependent quantity, and optionally, the square error in
+  // the dependent quantity, to the training sample to be used for the
+  // parameterization.
+  // The mean of the variables and quantity is calculated on the fly,
+  // as outlined in TPrincipal::AddRow.
+  // This sample should be representive of the problem at hand.
+  // Please note, that if no error is given Poisson statistics is
+  // assumed and the square error is set to the value of dependent
+  // quantity.  See also the
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  if (!x)
     return;
-  else
-  {
+
+  if (++fSampleSize == 1) {
+    fMeanQuantity = D;
+    fMaxQuantity = D;
+    fMinQuantity = D;
+  } else {
+    fMeanQuantity *= 1 - 1. / Double_t(fSampleSize);
+    fMeanQuantity += D / Double_t(fSampleSize);
+    fSumSqQuantity += D * D;
+
+    if (D >= fMaxQuantity)
+      fMaxQuantity = D;
+    if (D <= fMinQuantity)
+      fMinQuantity = D;
+  }
+
+  // If the vector isn't big enough to hold the new data, then
+  // expand the vector by half it's size.
+  Int_t size = fQuantity.GetNrows();
+  if (fSampleSize > size) {
+    fQuantity.ResizeTo(size + size / 2);
+    fSqError.ResizeTo(size + size / 2);
+  }
+
+  // Store the value
+  fQuantity(fSampleSize - 1) = D;
+  fSqError(fSampleSize - 1) = (E == 0 ? D : E);
+
+  // Store data point in internal vector
+  // If the vector isn't big enough to hold the new data, then
+  // expand the vector by half it's size
+  size = fVariables.GetNrows();
+  if (fSampleSize * fNVariables > size)
+    fVariables.ResizeTo(size + size / 2);
+
+  // Increment the data point counter
+  Int_t i, j;
+  for (i = 0; i < fNVariables; i++) {
+    if (fSampleSize == 1) {
+      fMeanVariables(i) = x[i];
+      fMaxVariables(i) = x[i];
+      fMinVariables(i) = x[i];
+    } else {
+      fMeanVariables(i) *= 1 - 1. / Double_t(fSampleSize);
+      fMeanVariables(i) += x[i] / Double_t(fSampleSize);
+
+      // Update the maximum value for this component
+      if (x[i] >= fMaxVariables(i))
+        fMaxVariables(i) = x[i];
+
+      // Update the minimum value for this component
+      if (x[i] <= fMinVariables(i))
+        fMinVariables(i) = x[i];
+    }
+
+    // Store the data.
+    j = (fSampleSize - 1) * fNVariables + i;
+    fVariables(j) = x[i];
+  }
+}
+
+//____________________________________________________________________
+void TMultiDimFet::AddTestRow(const Double_t *x, Double_t D, Double_t E) {
+  // Add a row consisting of fNVariables independent variables, the
+  // known, dependent quantity, and optionally, the square error in
+  // the dependent quantity, to the test sample to be used for the
+  // test of the parameterization.
+  // This sample needn't be representive of the problem at hand.
+  // Please note, that if no error is given Poisson statistics is
+  // assumed and the square error is set to the value of dependent
+  // quantity.  See also the
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  if (fTestSampleSize++ == 0) {
+    fTestQuantity.ResizeTo(fNVariables);
+    fTestSqError.ResizeTo(fNVariables);
+    fTestVariables.ResizeTo(fNVariables * 100);
+  }
+
+  // If the vector isn't big enough to hold the new data, then
+  // expand the vector by half it's size.
+  Int_t size = fTestQuantity.GetNrows();
+  if (fTestSampleSize > size) {
+    fTestQuantity.ResizeTo(size + size / 2);
+    fTestSqError.ResizeTo(size + size / 2);
+  }
+
+  // Store the value
+  fTestQuantity(fTestSampleSize - 1) = D;
+  fTestSqError(fTestSampleSize - 1) = (E == 0 ? D : E);
+
+  // Store data point in internal vector
+  // If the vector isn't big enough to hold the new data, then
+  // expand the vector by half it's size
+  size = fTestVariables.GetNrows();
+  if (fTestSampleSize * fNVariables > size)
+    fTestVariables.ResizeTo(size + size / 2);
+
+  // Increment the data point counter
+  Int_t i, j;
+  for (i = 0; i < fNVariables; i++) {
+    j = fNVariables * (fTestSampleSize - 1) + i;
+    fTestVariables(j) = x[i];
+
+    if (x[i] > fMaxVariables(i))
+      Warning("AddTestRow", "variable %d (row: %d) too large: %f > %f", i, fTestSampleSize, x[i], fMaxVariables(i));
+    if (x[i] < fMinVariables(i))
+      Warning("AddTestRow", "variable %d (row: %d) too small: %f < %f", i, fTestSampleSize, x[i], fMinVariables(i));
+  }
+}
+
+//____________________________________________________________________
+void TMultiDimFet::Clear(Option_t *option) {
+  // Clear internal structures and variables
+  Int_t i, j, n = fNVariables, m = fMaxFunctions;
+
+  // Training sample, dependent quantity
+  fQuantity.Zero();
+  fSqError.Zero();
+  fMeanQuantity = 0;
+  fMaxQuantity = 0;
+  fMinQuantity = 0;
+  fSumSqQuantity = 0;
+  fSumSqAvgQuantity = 0;
+
+  // Training sample, independent variables
+  fVariables.Zero();
+  fNVariables = 0;
+  fSampleSize = 0;
+  fMeanVariables.Zero();
+  fMaxVariables.Zero();
+  fMinVariables.Zero();
+
+  // Test sample
+  fTestQuantity.Zero();
+  fTestSqError.Zero();
+  fTestVariables.Zero();
+  fTestSampleSize = 0;
+
+  // Functions
+  fFunctions.Zero();
+  fMaxFunctions = 0;
+  fMaxStudy = 0;
+  fMaxFunctionsTimesNVariables = 0;
+  fOrthFunctions.Zero();
+  fOrthFunctionNorms.Zero();
+
+  // Control parameters
+  fMinRelativeError = 0;
+  fMinAngle = 0;
+  fMaxAngle = 0;
+  fMaxTerms = 0;
+
+  // Powers
+  for (i = 0; i < n; i++) {
+    fMaxPowers[i] = 0;
+    fMaxPowersFinal[i] = 0;
+    for (j = 0; j < m; j++)
+      fPowers[i * n + j] = 0;
+  }
+  fPowerLimit = 0;
+
+  // Residuals
+  fMaxResidual = 0;
+  fMinResidual = 0;
+  fMaxResidualRow = 0;
+  fMinResidualRow = 0;
+  fSumSqResidual = 0;
+
+  // Fit
+  fNCoefficients = 0;
+  fOrthCoefficients = 0;
+  fOrthCurvatureMatrix = 0;
+  fRMS = 0;
+  fCorrelationMatrix.Zero();
+  fError = 0;
+  fTestError = 0;
+  fPrecision = 0;
+  fTestPrecision = 0;
+
+  // Coefficients
+  fCoefficients.Zero();
+  fCoefficientsRMS.Zero();
+  fResiduals.Zero();
+  fHistograms->Clear(option);
+
+  // Options
+  fPolyType = kMonomials;
+  fShowCorrelation = kFALSE;
+  fIsUserFunction = kFALSE;
+}
+
+//____________________________________________________________________
+Double_t TMultiDimFet::Eval(const Double_t *x, const Double_t *coeff) const {
+  // Evaluate parameterization at point x. Optional argument coeff is
+  // a vector of coefficients for the parameterisation, fNCoefficients
+  // elements long.
+  //   int fMaxFunctionsTimesNVariables = fMaxFunctions * fNVariables;
+  Double_t returnValue = fMeanQuantity;
+  Double_t term = 0;
+  Int_t i, j;
+
+  for (i = 0; i < fNCoefficients; i++) {
+    // Evaluate the ith term in the expansion
+    term = (coeff ? coeff[i] : fCoefficients(i));
+    for (j = 0; j < fNVariables; j++) {
+      // Evaluate the factor (polynomial) in the j-th variable.
+      Int_t p = fPowers[fPowerIndex[i] * fNVariables + j];
+      Double_t y = 1 + 2. / (fMaxVariables(j) - fMinVariables(j)) * (x[j] - fMaxVariables(j));
+      term *= EvalFactor(p, y);
+    }
+    // Add this term to the final result
+    returnValue += term;
+  }
+  return returnValue;
+}
+
+void TMultiDimFet::ReducePolynomial(double error) {
+  if (error == 0.0)
+    return;
+  else {
     ZeroDoubiousCoefficients(error);
   }
 }
 
-void TMultiDimFet::ZeroDoubiousCoefficients(double error)
-{
+void TMultiDimFet::ZeroDoubiousCoefficients(double error) {
   typedef std::multimap<double, int> cmt;
   cmt m;
 
-  for (int i = 0; i < fNCoefficients; i++)
-  {
+  for (int i = 0; i < fNCoefficients; i++) {
     m.insert(std::pair<double, int>(TMath::Abs(fCoefficients(i)), i));
   }
 
-  double del_error_abs=0;
-  int deleted_terms_count=0;
+  double del_error_abs = 0;
+  int deleted_terms_count = 0;
 
-  for(cmt::iterator it = m.begin(); it!=m.end() && del_error_abs<error; ++it)
-  {
-    if(TMath::Abs(it->first)+del_error_abs<error)
-    {
-      fCoefficients(it->second)=0.0;
-      del_error_abs = TMath::Abs(it->first)+del_error_abs;
+  for (cmt::iterator it = m.begin(); it != m.end() && del_error_abs < error; ++it) {
+    if (TMath::Abs(it->first) + del_error_abs < error) {
+      fCoefficients(it->second) = 0.0;
+      del_error_abs = TMath::Abs(it->first) + del_error_abs;
       deleted_terms_count++;
-    }
-    else
+    } else
       break;
   }
 
-  int fNCoefficients_new = fNCoefficients-deleted_terms_count;
+  int fNCoefficients_new = fNCoefficients - deleted_terms_count;
   TVectorD fCoefficients_new(fNCoefficients_new);
   std::vector<Int_t> fPowerIndex_new;
 
-  int ind=0;
-  for(int i = 0; i < fNCoefficients; i++)
-  {
-    if(fCoefficients(i)!=0.0)
-    {
-      fCoefficients_new(ind)=fCoefficients(i);
+  int ind = 0;
+  for (int i = 0; i < fNCoefficients; i++) {
+    if (fCoefficients(i) != 0.0) {
+      fCoefficients_new(ind) = fCoefficients(i);
       fPowerIndex_new.push_back(fPowerIndex[i]);
       ind++;
     }
@@ -538,75 +506,71 @@ void TMultiDimFet::ZeroDoubiousCoefficients(double error)
   fCoefficients.ResizeTo(fNCoefficients);
   fCoefficients = fCoefficients_new;
   fPowerIndex = fPowerIndex_new;
-  edm::LogInfo("TMultiDimFet")<<deleted_terms_count<<" terms removed"<<"\n";
-}
-
-
-//____________________________________________________________________
-Double_t TMultiDimFet::EvalControl(const Int_t *iv)
-{
-   // PRIVATE METHOD:
-   // Calculate the control parameter from the passed powers
-   Double_t s = 0;
-   Double_t epsilon = 1e-6; // a small number
-   for (Int_t i = 0; i < fNVariables; i++) {
-      if (fMaxPowers[i] != 1)
-         s += (epsilon + iv[i] - 1) / (epsilon + fMaxPowers[i] - 1);
-   }
-   return s;
+  edm::LogInfo("TMultiDimFet") << deleted_terms_count << " terms removed"
+                               << "\n";
 }
 
 //____________________________________________________________________
-Double_t TMultiDimFet::EvalFactor(Int_t p, Double_t x) const
-{
-   // PRIVATE METHOD:
-   // Evaluate function with power p at variable value x
-   Int_t    i   = 0;
-   Double_t p1  = 1;
-   Double_t p2  = 0;
-   Double_t p3  = 0;
-   Double_t r   = 0;
-
-   switch(p) {
-      case 1:
-         r = 1;
-         break;
-      case 2:
-         r =  x;
-         break;
-      default:
-         p2 = x;
-         for (i = 3; i <= p; i++) {
-            p3 = p2 * x;
-            if (fPolyType == kLegendre)
-            p3 = ((2 * i - 3) * p2 * x - (i - 2) * p1) / (i - 1);
-            else if (fPolyType == kChebyshev)
-            p3 = 2 * x * p2 - p1;
-            p1 = p2;
-            p2 = p3;
-         }
-         r = p3;
-   }
-
-   return r;
+Double_t TMultiDimFet::EvalControl(const Int_t *iv) {
+  // PRIVATE METHOD:
+  // Calculate the control parameter from the passed powers
+  Double_t s = 0;
+  Double_t epsilon = 1e-6;  // a small number
+  for (Int_t i = 0; i < fNVariables; i++) {
+    if (fMaxPowers[i] != 1)
+      s += (epsilon + iv[i] - 1) / (epsilon + fMaxPowers[i] - 1);
+  }
+  return s;
 }
 
+//____________________________________________________________________
+Double_t TMultiDimFet::EvalFactor(Int_t p, Double_t x) const {
+  // PRIVATE METHOD:
+  // Evaluate function with power p at variable value x
+  Int_t i = 0;
+  Double_t p1 = 1;
+  Double_t p2 = 0;
+  Double_t p3 = 0;
+  Double_t r = 0;
+
+  switch (p) {
+    case 1:
+      r = 1;
+      break;
+    case 2:
+      r = x;
+      break;
+    default:
+      p2 = x;
+      for (i = 3; i <= p; i++) {
+        p3 = p2 * x;
+        if (fPolyType == kLegendre)
+          p3 = ((2 * i - 3) * p2 * x - (i - 2) * p1) / (i - 1);
+        else if (fPolyType == kChebyshev)
+          p3 = 2 * x * p2 - p1;
+        p1 = p2;
+        p2 = p3;
+      }
+      r = p3;
+  }
+
+  return r;
+}
 
 //____________________________________________________________________
-void TMultiDimFet::FindParameterization(double precision)
-{
-   // Find the parameterization
-   //
-   // Options:
-   //     None so far
-   //
-   // For detailed description of what this entails, please refer to the
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   MakeNormalized();
-   MakeCandidates();
-   MakeParameterization();
-   MakeCoefficients();
-   ReducePolynomial(precision);
+void TMultiDimFet::FindParameterization(double precision) {
+  // Find the parameterization
+  //
+  // Options:
+  //     None so far
+  //
+  // For detailed description of what this entails, please refer to the
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  MakeNormalized();
+  MakeCandidates();
+  MakeParameterization();
+  MakeCoefficients();
+  ReducePolynomial(precision);
 }
 
 //____________________________________________________________________
@@ -690,1426 +654,1449 @@ void TMultiDimFet::Fit(Option_t *option)
 */
 
 //____________________________________________________________________
-void TMultiDimFet::MakeCandidates()
-{
-   // PRIVATE METHOD:
-   // Create list of candidate functions for the parameterisation. See
-   // also
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   Int_t i = 0;
-   Int_t j = 0;
-   Int_t k = 0;
+void TMultiDimFet::MakeCandidates() {
+  // PRIVATE METHOD:
+  // Create list of candidate functions for the parameterisation. See
+  // also
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  Int_t i = 0;
+  Int_t j = 0;
+  Int_t k = 0;
 
-   // The temporary array to store the powers in. We don't need to
-   // initialize this array however.
-   Int_t *powers = new Int_t[fNVariables * fMaxFunctions];
+  // The temporary array to store the powers in. We don't need to
+  // initialize this array however.
+  Int_t *powers = new Int_t[fNVariables * fMaxFunctions];
 
-   // store of `control variables'
-   Double_t* control  = new Double_t[fMaxFunctions];
+  // store of `control variables'
+  Double_t *control = new Double_t[fMaxFunctions];
 
-   // We've better initialize the variables
-   Int_t *iv = new Int_t[fNVariables];
-   for (i = 0; i < fNVariables; i++)
-      iv[i] = 1;
+  // We've better initialize the variables
+  Int_t *iv = new Int_t[fNVariables];
+  for (i = 0; i < fNVariables; i++)
+    iv[i] = 1;
 
-   if (!fIsUserFunction) {
+  if (!fIsUserFunction) {
+    // Number of funcs selected
+    Int_t numberFunctions = 0;
 
-      // Number of funcs selected
-      Int_t     numberFunctions = 0;
+    // Absolute max number of functions
+    Int_t maxNumberFunctions = 1;
+    for (i = 0; i < fNVariables; i++)
+      maxNumberFunctions *= fMaxPowers[i];
 
-      // Absolute max number of functions
-      Int_t maxNumberFunctions = 1;
-      for (i = 0; i < fNVariables; i++)
-         maxNumberFunctions *= fMaxPowers[i];
+    while (kTRUE) {
+      // Get the control value for this function
+      Double_t s = EvalControl(iv);
 
-      while (kTRUE) {
-         // Get the control value for this function
-         Double_t s = EvalControl(iv);
+      if (s <= fPowerLimit) {
+        // Call over-loadable method Select, as to allow the user to
+        // interfere with the selection of functions.
+        if (Select(iv)) {
+          numberFunctions++;
 
-         if (s <= fPowerLimit) {
-
-            // Call over-loadable method Select, as to allow the user to
-            // interfere with the selection of functions.
-            if (Select(iv)) {
-               numberFunctions++;
-
-               // If we've reached the user defined limit of how many
-               // functions we can consider, break out of the loop
-               if (numberFunctions > fMaxFunctions)
-                  break;
-
-               // Store the control value, so we can sort array of powers
-               // later on
-               control[numberFunctions-1] = Int_t(1.0e+6*s);
-
-               // Store the powers in powers array.
-               for (i = 0; i < fNVariables; i++) {
-                  j = (numberFunctions - 1) * fNVariables + i;
-                  powers[j] = iv[i];
-               }
-            } // if (Select())
-         } // if (s <= fPowerLimit)
-
-         for (i = 0; i < fNVariables; i++)
-            if (iv[i] < fMaxPowers[i])
-               break;
-
-         // If all variables have reached their maximum power, then we
-         // break out of the loop
-         if (i == fNVariables) {
-            fMaxFunctions = numberFunctions;
-            fMaxFunctionsTimesNVariables = fMaxFunctions * fNVariables;
+          // If we've reached the user defined limit of how many
+          // functions we can consider, break out of the loop
+          if (numberFunctions > fMaxFunctions)
             break;
-         }
 
-         // Next power in variable i
-         iv[i]++;
+          // Store the control value, so we can sort array of powers
+          // later on
+          control[numberFunctions - 1] = Int_t(1.0e+6 * s);
 
-         for (j = 0; j < i; j++)
-            iv[j] = 1;
-      } // while (kTRUE)
-   }
-   else {
-      // In case the user gave an explicit function
-      for (i = 0; i < fMaxFunctions; i++) {
-         // Copy the powers to working arrays
-         for (j = 0; j < fNVariables; j++) {
-            powers[i * fNVariables + j] = fPowers[i * fNVariables + j];
-            iv[j]                 = fPowers[i * fNVariables + j];
-         }
+          // Store the powers in powers array.
+          for (i = 0; i < fNVariables; i++) {
+            j = (numberFunctions - 1) * fNVariables + i;
+            powers[j] = iv[i];
+          }
+        }  // if (Select())
+      }    // if (s <= fPowerLimit)
 
-         control[i] = Int_t(1.0e+6*EvalControl(iv));
-      }
-   }
+      for (i = 0; i < fNVariables; i++)
+        if (iv[i] < fMaxPowers[i])
+          break;
 
-   // Now we need to sort the powers according to least `control
-   // variable'
-   Int_t *order = new Int_t[fMaxFunctions];
-   for (i = 0; i < fMaxFunctions; i++)
-      order[i] = i;
-   fPowers.resize(fMaxFunctions * fNVariables);
-
-   for (i = 0; i < fMaxFunctions; i++) {
-      Double_t x = control[i];
-      Int_t    l = order[i];
-      k = i;
-
-      for (j = i; j < fMaxFunctions; j++) {
-         if (control[j] <= x) {
-            x = control[j];
-            l = order[j];
-            k = j;
-         }
+      // If all variables have reached their maximum power, then we
+      // break out of the loop
+      if (i == fNVariables) {
+        fMaxFunctions = numberFunctions;
+        fMaxFunctionsTimesNVariables = fMaxFunctions * fNVariables;
+        break;
       }
 
-      if (k != i) {
-         control[k] = control[i];
-         control[i] = x;
-         order[k]   = order[i];
-         order[i]   = l;
+      // Next power in variable i
+      iv[i]++;
+
+      for (j = 0; j < i; j++)
+        iv[j] = 1;
+    }  // while (kTRUE)
+  } else {
+    // In case the user gave an explicit function
+    for (i = 0; i < fMaxFunctions; i++) {
+      // Copy the powers to working arrays
+      for (j = 0; j < fNVariables; j++) {
+        powers[i * fNVariables + j] = fPowers[i * fNVariables + j];
+        iv[j] = fPowers[i * fNVariables + j];
       }
-   }
 
-   for (i = 0; i < fMaxFunctions; i++)
-      for (j = 0; j < fNVariables; j++)
-         fPowers[i * fNVariables + j] = powers[order[i] * fNVariables + j];
+      control[i] = Int_t(1.0e+6 * EvalControl(iv));
+    }
+  }
 
-   delete [] control;
-   delete [] powers;
-   delete [] order;
-   delete [] iv;
+  // Now we need to sort the powers according to least `control
+  // variable'
+  Int_t *order = new Int_t[fMaxFunctions];
+  for (i = 0; i < fMaxFunctions; i++)
+    order[i] = i;
+  fPowers.resize(fMaxFunctions * fNVariables);
+
+  for (i = 0; i < fMaxFunctions; i++) {
+    Double_t x = control[i];
+    Int_t l = order[i];
+    k = i;
+
+    for (j = i; j < fMaxFunctions; j++) {
+      if (control[j] <= x) {
+        x = control[j];
+        l = order[j];
+        k = j;
+      }
+    }
+
+    if (k != i) {
+      control[k] = control[i];
+      control[i] = x;
+      order[k] = order[i];
+      order[i] = l;
+    }
+  }
+
+  for (i = 0; i < fMaxFunctions; i++)
+    for (j = 0; j < fNVariables; j++)
+      fPowers[i * fNVariables + j] = powers[order[i] * fNVariables + j];
+
+  delete[] control;
+  delete[] powers;
+  delete[] order;
+  delete[] iv;
 }
 
+Double_t TMultiDimFet::MakeChi2(const Double_t *coeff) {
+  // Calculate Chi square over either the test sample. The optional
+  // argument coeff is a vector of coefficients to use in the
+  // evaluation of the parameterisation. If coeff == 0, then the found
+  // coefficients is used.
+  // Used my MINUIT for fit (see TMultDimFit::Fit)
+  fChi2 = 0;
+  Int_t i, j;
+  Double_t *x = new Double_t[fNVariables];
+  for (i = 0; i < fTestSampleSize; i++) {
+    // Get the stored point
+    for (j = 0; j < fNVariables; j++)
+      x[j] = fTestVariables(i * fNVariables + j);
 
-Double_t TMultiDimFet::MakeChi2(const Double_t* coeff)
-{
-   // Calculate Chi square over either the test sample. The optional
-   // argument coeff is a vector of coefficients to use in the
-   // evaluation of the parameterisation. If coeff == 0, then the found
-   // coefficients is used.
-   // Used my MINUIT for fit (see TMultDimFit::Fit)
-   fChi2 = 0;
-   Int_t i, j;
-   Double_t* x = new Double_t[fNVariables];
-   for (i = 0; i < fTestSampleSize; i++) {
-      // Get the stored point
-      for (j = 0; j < fNVariables; j++)
-         x[j] = fTestVariables(i * fNVariables + j);
+    // Evaluate function. Scale to shifted values
+    Double_t f = Eval(x, coeff);
 
-      // Evaluate function. Scale to shifted values
-      Double_t f = Eval(x,coeff);
+    // Calculate contribution to Chic square
+    fChi2 += 1. / TMath::Max(fTestSqError(i), 1e-20) * (fTestQuantity(i) - f) * (fTestQuantity(i) - f);
+  }
 
-      // Calculate contribution to Chic square
-      fChi2 += 1. / TMath::Max(fTestSqError(i),1e-20)
-         * (fTestQuantity(i) - f) * (fTestQuantity(i) - f);
-   }
+  // Clean up
+  delete[] x;
 
-   // Clean up
-   delete [] x;
-
-   return fChi2;
+  return fChi2;
 }
-
 
 //____________________________________________________________________
-void TMultiDimFet::MakeCode(const char* filename, Option_t *option)
-{
-   // Generate the file <filename> with .C appended if argument doesn't
-   // end in .cxx or .C. The contains the implementation of the
-   // function:
-   //
-   //   Double_t <funcname>(Double_t *x)
-   //
-   // which does the same as TMultiDimFet::Eval. Please refer to this
-   // method.
-   //
-   // Further, the static variables:
-   //
-   //     Int_t    gNVariables
-   //     Int_t    gNCoefficients
-   //     Double_t gDMean
-   //     Double_t gXMean[]
-   //     Double_t gXMin[]
-   //     Double_t gXMax[]
-   //     Double_t gCoefficient[]
-   //     Int_t    gPower[]
-   //
-   // are initialized. The only ROOT header file needed is Rtypes.h
-   //
-   // See TMultiDimFet::MakeRealCode for a list of options
+void TMultiDimFet::MakeCode(const char *filename, Option_t *option) {
+  // Generate the file <filename> with .C appended if argument doesn't
+  // end in .cxx or .C. The contains the implementation of the
+  // function:
+  //
+  //   Double_t <funcname>(Double_t *x)
+  //
+  // which does the same as TMultiDimFet::Eval. Please refer to this
+  // method.
+  //
+  // Further, the static variables:
+  //
+  //     Int_t    gNVariables
+  //     Int_t    gNCoefficients
+  //     Double_t gDMean
+  //     Double_t gXMean[]
+  //     Double_t gXMin[]
+  //     Double_t gXMax[]
+  //     Double_t gCoefficient[]
+  //     Int_t    gPower[]
+  //
+  // are initialized. The only ROOT header file needed is Rtypes.h
+  //
+  // See TMultiDimFet::MakeRealCode for a list of options
 
+  TString outName(filename);
+  if (!outName.EndsWith(".C") && !outName.EndsWith(".cxx"))
+    outName += ".C";
 
-   TString outName(filename);
-   if (!outName.EndsWith(".C") && !outName.EndsWith(".cxx"))
-      outName += ".C";
-
-   MakeRealCode(outName.Data(),"",option);
+  MakeRealCode(outName.Data(), "", option);
 }
 
+void TMultiDimFet::MakeCoefficientErrors() {
+  // PRIVATE METHOD:
+  // Compute the errors on the coefficients. For this to be done, the
+  // curvature matrix of the non-orthogonal functions, is computed.
+  Int_t i = 0;
+  Int_t j = 0;
+  Int_t k = 0;
+  TVectorD iF(fSampleSize);
+  TVectorD jF(fSampleSize);
+  fCoefficientsRMS.ResizeTo(fNCoefficients);
 
-void TMultiDimFet::MakeCoefficientErrors()
-{
-   // PRIVATE METHOD:
-   // Compute the errors on the coefficients. For this to be done, the
-   // curvature matrix of the non-orthogonal functions, is computed.
-   Int_t    i = 0;
-   Int_t    j = 0;
-   Int_t    k = 0;
-   TVectorD iF(fSampleSize);
-   TVectorD jF(fSampleSize);
-   fCoefficientsRMS.ResizeTo(fNCoefficients);
+  TMatrixDSym curvatureMatrix(fNCoefficients);
 
-   TMatrixDSym curvatureMatrix(fNCoefficients);
-
-   // Build the curvature matrix
-   for (i = 0; i < fNCoefficients; i++) {
-      iF = TMatrixDRow(fFunctions,i);
-      for (j = 0; j <= i; j++) {
-         jF = TMatrixDRow(fFunctions,j);
-         for (k = 0; k < fSampleSize; k++)
-            curvatureMatrix(i,j) +=
-            1 / TMath::Max(fSqError(k), 1e-20) * iF(k) * jF(k);
-         curvatureMatrix(j,i) = curvatureMatrix(i,j);
-      }
-   }
-
-   // Calculate Chi Square
-   fChi2 = 0;
-   for (i = 0; i < fSampleSize; i++) {
-      Double_t f = 0;
-      for (j = 0; j < fNCoefficients; j++)
-         f += fCoefficients(j) * fFunctions(j,i);
-      fChi2 += 1. / TMath::Max(fSqError(i),1e-20) * (fQuantity(i) - f)
-         * (fQuantity(i) - f);
-   }
-
-   // Invert the curvature matrix
-   const TVectorD diag = TMatrixDDiag_const(curvatureMatrix);
-   curvatureMatrix.NormByDiag(diag);
-
-   TDecompChol chol(curvatureMatrix);
-   if (!chol.Decompose())
-      Error("MakeCoefficientErrors", "curvature matrix is singular");
-   chol.Invert(curvatureMatrix);
-
-   curvatureMatrix.NormByDiag(diag);
-
-   for (i = 0; i < fNCoefficients; i++)
-      fCoefficientsRMS(i) = TMath::Sqrt(curvatureMatrix(i,i));
-}
-
-
-//____________________________________________________________________
-void TMultiDimFet::MakeCoefficients()
-{
-   // PRIVATE METHOD:
-   // Invert the model matrix B, and compute final coefficients. For a
-   // more thorough discussion of what this means, please refer to the
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   //
-   // First we invert the lower triangle matrix fOrthCurvatureMatrix
-   // and store the inverted matrix in the upper triangle.
-
-   Int_t i = 0, j = 0;
-   Int_t col = 0, row = 0;
-
-   // Invert the B matrix
-   for (col = 1; col < fNCoefficients; col++) {
-      for (row = col - 1; row > -1; row--) {
-         fOrthCurvatureMatrix(row,col) = 0;
-         for (i = row; i <= col ; i++)
-            fOrthCurvatureMatrix(row,col) -=
-            fOrthCurvatureMatrix(i,row)
-            * fOrthCurvatureMatrix(i,col);
-      }
-   }
-
-   // Compute the final coefficients
-   fCoefficients.ResizeTo(fNCoefficients);
-
-   for (i = 0; i < fNCoefficients; i++) {
-      Double_t sum = 0;
-      for (j = i; j < fNCoefficients; j++)
-         sum += fOrthCurvatureMatrix(i,j) * fOrthCoefficients(j);
-      fCoefficients(i) = sum;
-   }
-
-   // Compute the final residuals
-   fResiduals.ResizeTo(fSampleSize);
-   for (i = 0; i < fSampleSize; i++)
-      fResiduals(i) = fQuantity(i);
-
-   for (i = 0; i < fNCoefficients; i++)
-      for (j = 0; j < fSampleSize; j++)
-         fResiduals(j) -= fCoefficients(i) * fFunctions(i,j);
-
-   // Compute the max and minimum, and squared sum of the evaluated
-   // residuals
-   fMinResidual = 10e10;
-   fMaxResidual = -10e10;
-   Double_t sqRes  = 0;
-   for (i = 0; i < fSampleSize; i++){
-      sqRes += fResiduals(i) * fResiduals(i);
-      if (fResiduals(i) <= fMinResidual) {
-         fMinResidual     = fResiduals(i);
-         fMinResidualRow  = i;
-      }
-      if (fResiduals(i) >= fMaxResidual) {
-         fMaxResidual     = fResiduals(i);
-         fMaxResidualRow  = i;
-      }
-   }
-
-   fCorrelationCoeff = fSumSqResidual / fSumSqAvgQuantity;
-   fPrecision        = TMath::Sqrt(sqRes / fSumSqQuantity);
-
-   // If we use histograms, fill some more
-   if (TESTBIT(fHistogramMask,HIST_RD) ||
-      TESTBIT(fHistogramMask,HIST_RTRAI) ||
-      TESTBIT(fHistogramMask,HIST_RX)) {
-         for (i = 0; i < fSampleSize; i++) {
-            if (TESTBIT(fHistogramMask,HIST_RD))
-               ((TH2D*)fHistograms->FindObject("res_d"))->Fill(fQuantity(i),
-               fResiduals(i));
-            if (TESTBIT(fHistogramMask,HIST_RTRAI))
-               ((TH1D*)fHistograms->FindObject("res_train"))->Fill(fResiduals(i));
-
-            if (TESTBIT(fHistogramMask,HIST_RX))
-               for (j = 0; j < fNVariables; j++)
-                  ((TH2D*)fHistograms->FindObject(Form("res_x_%d",j)))
-                  ->Fill(fVariables(i * fNVariables + j),fResiduals(i));
-         }
-   } // If histograms
-
-}
-
-
-//____________________________________________________________________
-void TMultiDimFet::MakeCorrelation()
-{
-   // PRIVATE METHOD:
-   // Compute the correlation matrix
-   if (!fShowCorrelation)
-      return;
-
-   fCorrelationMatrix.ResizeTo(fNVariables,fNVariables+1);
-
-   Double_t d2      = 0;
-   Double_t ddotXi  = 0; // G.Q. needs to be reinitialized in the loop over i fNVariables
-   Double_t xiNorm  = 0; // G.Q. needs to be reinitialized in the loop over i fNVariables
-   Double_t xidotXj = 0; // G.Q. needs to be reinitialized in the loop over j fNVariables
-   Double_t xjNorm  = 0; // G.Q. needs to be reinitialized in the loop over j fNVariables
-
-   Int_t i, j, k, l, m;  // G.Q. added m variable
-   for (i = 0; i < fSampleSize; i++)
-      d2 += fQuantity(i) * fQuantity(i);
-
-   for (i = 0; i < fNVariables; i++) {
-      ddotXi = 0.; // G.Q. reinitialisation
-      xiNorm = 0.; // G.Q. reinitialisation
-      for (j = 0; j< fSampleSize; j++) {
-         // Index of sample j of variable i
-         k =  j * fNVariables + i;
-         ddotXi += fQuantity(j) * (fVariables(k) - fMeanVariables(i));
-         xiNorm += (fVariables(k) - fMeanVariables(i))
-            * (fVariables(k) - fMeanVariables(i));
-      }
-      fCorrelationMatrix(i,0) = ddotXi / TMath::Sqrt(d2 * xiNorm);
-
-      for (j = 0; j < i; j++) {
-         xidotXj = 0.; // G.Q. reinitialisation
-         xjNorm = 0.; // G.Q. reinitialisation
-         for (k = 0; k < fSampleSize; k++) {
-            // Index of sample j of variable i
-            // l =  j * fNVariables + k;  // G.Q.
-            l =  k * fNVariables + j; // G.Q.
-            m =  k * fNVariables + i; // G.Q.
-            // G.Q.        xidotXj += (fVariables(i) - fMeanVariables(i))
-            // G.Q.          * (fVariables(l) - fMeanVariables(j));
-            xidotXj += (fVariables(m) - fMeanVariables(i))
-               * (fVariables(l) - fMeanVariables(j));  // G.Q. modified index for Xi
-            xjNorm  += (fVariables(l) - fMeanVariables(j))
-               * (fVariables(l) - fMeanVariables(j));
-         }
-         fCorrelationMatrix(i,j+1) = xidotXj / TMath::Sqrt(xiNorm * xjNorm);
-      }
-   }
-}
-
-
-
-//____________________________________________________________________
-Double_t TMultiDimFet::MakeGramSchmidt(Int_t function)
-{
-   // PRIVATE METHOD:
-   // Make Gram-Schmidt orthogonalisation. The class description gives
-   // a thorough account of this algorithm, as well as
-   // references. Please refer to the
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-
-
-   // calculate w_i, that is, evaluate the current function at data
-   // point i
-   Double_t f2                        = 0;
-   fOrthCoefficients(fNCoefficients)      = 0;
-   fOrthFunctionNorms(fNCoefficients)  = 0;
-   Int_t j        = 0;
-   Int_t k        = 0;
-
-   for (j = 0; j < fSampleSize; j++) {
-      fFunctions(fNCoefficients, j) = 1;
-      fOrthFunctions(fNCoefficients, j) = 0;
-      // First, however, we need to calculate f_fNCoefficients
-      for (k = 0; k < fNVariables; k++) {
-         Int_t    p   =  fPowers[function * fNVariables + k];
-         Double_t x   =  fVariables(j * fNVariables + k);
-         fFunctions(fNCoefficients, j) *= EvalFactor(p,x);
-      }
-
-      // Calculate f dot f in f2
-      f2 += fFunctions(fNCoefficients,j) *  fFunctions(fNCoefficients,j);
-      // Assign to w_fNCoefficients f_fNCoefficients
-      fOrthFunctions(fNCoefficients, j) = fFunctions(fNCoefficients, j);
-   }
-
-   // the first column of w is equal to f
-   for (j = 0; j < fNCoefficients; j++) {
-      Double_t fdw = 0;
-      // Calculate (f_fNCoefficients dot w_j) / w_j^2
-      for (k = 0; k < fSampleSize; k++) {
-         fdw += fFunctions(fNCoefficients, k) * fOrthFunctions(j,k)
-            / fOrthFunctionNorms(j);
-      }
-
-      fOrthCurvatureMatrix(fNCoefficients,j) = fdw;
-      // and subtract it from the current value of w_ij
+  // Build the curvature matrix
+  for (i = 0; i < fNCoefficients; i++) {
+    iF = TMatrixDRow(fFunctions, i);
+    for (j = 0; j <= i; j++) {
+      jF = TMatrixDRow(fFunctions, j);
       for (k = 0; k < fSampleSize; k++)
-         fOrthFunctions(fNCoefficients,k) -= fdw * fOrthFunctions(j,k);
-   }
+        curvatureMatrix(i, j) += 1 / TMath::Max(fSqError(k), 1e-20) * iF(k) * jF(k);
+      curvatureMatrix(j, i) = curvatureMatrix(i, j);
+    }
+  }
 
-   for (j = 0; j < fSampleSize; j++) {
-      // calculate squared length of w_fNCoefficients
-      fOrthFunctionNorms(fNCoefficients) +=
-         fOrthFunctions(fNCoefficients,j)
-         * fOrthFunctions(fNCoefficients,j);
+  // Calculate Chi Square
+  fChi2 = 0;
+  for (i = 0; i < fSampleSize; i++) {
+    Double_t f = 0;
+    for (j = 0; j < fNCoefficients; j++)
+      f += fCoefficients(j) * fFunctions(j, i);
+    fChi2 += 1. / TMath::Max(fSqError(i), 1e-20) * (fQuantity(i) - f) * (fQuantity(i) - f);
+  }
 
-      // calculate D dot w_fNCoefficients in A
-      fOrthCoefficients(fNCoefficients) += fQuantity(j)
-         * fOrthFunctions(fNCoefficients, j);
-   }
+  // Invert the curvature matrix
+  const TVectorD diag = TMatrixDDiag_const(curvatureMatrix);
+  curvatureMatrix.NormByDiag(diag);
 
-   // First test, but only if didn't user specify
-   if (!fIsUserFunction)
-      if (TMath::Sqrt(fOrthFunctionNorms(fNCoefficients) / (f2 + 1e-10))
-         < TMath::Sin(fMinAngle*DEGRAD))
-         return 0;
+  TDecompChol chol(curvatureMatrix);
+  if (!chol.Decompose())
+    Error("MakeCoefficientErrors", "curvature matrix is singular");
+  chol.Invert(curvatureMatrix);
 
-   // The result found by this code for the first residual is always
-   // much less then the one found be MUDIFI. That's because it's
-   // supposed to be. The cause is the improved precision of Double_t
-   // over DOUBLE PRECISION!
-   fOrthCurvatureMatrix(fNCoefficients,fNCoefficients) = 1;
-   Double_t b = fOrthCoefficients(fNCoefficients);
-   fOrthCoefficients(fNCoefficients) /= fOrthFunctionNorms(fNCoefficients);
+  curvatureMatrix.NormByDiag(diag);
 
-   // Calculate the residual from including this fNCoefficients.
-   Double_t dResidur = fOrthCoefficients(fNCoefficients) * b;
-
-   return dResidur;
+  for (i = 0; i < fNCoefficients; i++)
+    fCoefficientsRMS(i) = TMath::Sqrt(curvatureMatrix(i, i));
 }
 
-
 //____________________________________________________________________
-void TMultiDimFet::MakeHistograms(Option_t *option)
-{
-   // Make histograms of the result of the analysis. This message
-   // should be sent after having read all data points, but before
-   // finding the parameterization
-   //
-   // Options:
-   //     A         All the below
-   //     X         Original independent variables
-   //     D         Original dependent variables
-   //     N         Normalised independent variables
-   //     S         Shifted dependent variables
-   //     R1        Residuals versus normalised independent variables
-   //     R2        Residuals versus dependent variable
-   //     R3        Residuals computed on training sample
-   //     R4        Residuals computed on test sample
-   //
-   // For a description of these quantities, refer to
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   TString opt(option);
-   opt.ToLower();
+void TMultiDimFet::MakeCoefficients() {
+  // PRIVATE METHOD:
+  // Invert the model matrix B, and compute final coefficients. For a
+  // more thorough discussion of what this means, please refer to the
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  //
+  // First we invert the lower triangle matrix fOrthCurvatureMatrix
+  // and store the inverted matrix in the upper triangle.
 
-   if (opt.Length() < 1)
-      return;
+  Int_t i = 0, j = 0;
+  Int_t col = 0, row = 0;
 
-   if (!fHistograms)
-      fHistograms = new TList;
+  // Invert the B matrix
+  for (col = 1; col < fNCoefficients; col++) {
+    for (row = col - 1; row > -1; row--) {
+      fOrthCurvatureMatrix(row, col) = 0;
+      for (i = row; i <= col; i++)
+        fOrthCurvatureMatrix(row, col) -= fOrthCurvatureMatrix(i, row) * fOrthCurvatureMatrix(i, col);
+    }
+  }
 
-   // Counter variable
-   Int_t i = 0;
+  // Compute the final coefficients
+  fCoefficients.ResizeTo(fNCoefficients);
 
-   // Histogram of original variables
-   if (opt.Contains("x") || opt.Contains("a")) {
-      SETBIT(fHistogramMask,HIST_XORIG);
-      for (i = 0; i < fNVariables; i++)
-         if (!fHistograms->FindObject(Form("x_%d_orig",i)))
-            fHistograms->Add(new TH1D(Form("x_%d_orig",i),
-            Form("Original variable # %d",i),
-            100, fMinVariables(i),
-            fMaxVariables(i)));
-   }
+  for (i = 0; i < fNCoefficients; i++) {
+    Double_t sum = 0;
+    for (j = i; j < fNCoefficients; j++)
+      sum += fOrthCurvatureMatrix(i, j) * fOrthCoefficients(j);
+    fCoefficients(i) = sum;
+  }
 
-   // Histogram of original dependent variable
-   if (opt.Contains("d") || opt.Contains("a")) {
-      SETBIT(fHistogramMask,HIST_DORIG);
-      if (!fHistograms->FindObject("d_orig"))
-         fHistograms->Add(new TH1D("d_orig", "Original Quantity",
-         100, fMinQuantity, fMaxQuantity));
-   }
+  // Compute the final residuals
+  fResiduals.ResizeTo(fSampleSize);
+  for (i = 0; i < fSampleSize; i++)
+    fResiduals(i) = fQuantity(i);
 
-   // Histograms of normalized variables
-   if (opt.Contains("n") || opt.Contains("a")) {
-      SETBIT(fHistogramMask,HIST_XNORM);
-      for (i = 0; i < fNVariables; i++)
-         if (!fHistograms->FindObject(Form("x_%d_norm",i)))
-            fHistograms->Add(new TH1D(Form("x_%d_norm",i),
-            Form("Normalized variable # %d",i),
-            100, -1,1));
-   }
+  for (i = 0; i < fNCoefficients; i++)
+    for (j = 0; j < fSampleSize; j++)
+      fResiduals(j) -= fCoefficients(i) * fFunctions(i, j);
 
-   // Histogram of shifted dependent variable
-   if (opt.Contains("s") || opt.Contains("a")) {
-      SETBIT(fHistogramMask,HIST_DSHIF);
-      if (!fHistograms->FindObject("d_shifted"))
-         fHistograms->Add(new TH1D("d_shifted", "Shifted Quantity",
-         100, fMinQuantity - fMeanQuantity,
-         fMaxQuantity - fMeanQuantity));
-   }
+  // Compute the max and minimum, and squared sum of the evaluated
+  // residuals
+  fMinResidual = 10e10;
+  fMaxResidual = -10e10;
+  Double_t sqRes = 0;
+  for (i = 0; i < fSampleSize; i++) {
+    sqRes += fResiduals(i) * fResiduals(i);
+    if (fResiduals(i) <= fMinResidual) {
+      fMinResidual = fResiduals(i);
+      fMinResidualRow = i;
+    }
+    if (fResiduals(i) >= fMaxResidual) {
+      fMaxResidual = fResiduals(i);
+      fMaxResidualRow = i;
+    }
+  }
 
-   // Residual from training sample versus independent variables
-   if (opt.Contains("r1") || opt.Contains("a")) {
-      SETBIT(fHistogramMask,HIST_RX);
-      for (i = 0; i < fNVariables; i++)
-         if (!fHistograms->FindObject(Form("res_x_%d",i)))
-            fHistograms->Add(new TH2D(Form("res_x_%d",i),
-            Form("Computed residual versus x_%d", i),
-            100, -1,    1,
-            35,
-            fMinQuantity - fMeanQuantity,
-            fMaxQuantity - fMeanQuantity));
-   }
+  fCorrelationCoeff = fSumSqResidual / fSumSqAvgQuantity;
+  fPrecision = TMath::Sqrt(sqRes / fSumSqQuantity);
 
-   // Residual from training sample versus. dependent variable
-   if (opt.Contains("r2") || opt.Contains("a")) {
-      SETBIT(fHistogramMask,HIST_RD);
-      if (!fHistograms->FindObject("res_d"))
-         fHistograms->Add(new TH2D("res_d",
-         "Computed residuals vs Quantity",
-         100,
-         fMinQuantity - fMeanQuantity,
-         fMaxQuantity - fMeanQuantity,
-         35,
-         fMinQuantity - fMeanQuantity,
-         fMaxQuantity - fMeanQuantity));
-   }
+  // If we use histograms, fill some more
+  if (TESTBIT(fHistogramMask, HIST_RD) || TESTBIT(fHistogramMask, HIST_RTRAI) || TESTBIT(fHistogramMask, HIST_RX)) {
+    for (i = 0; i < fSampleSize; i++) {
+      if (TESTBIT(fHistogramMask, HIST_RD))
+        ((TH2D *)fHistograms->FindObject("res_d"))->Fill(fQuantity(i), fResiduals(i));
+      if (TESTBIT(fHistogramMask, HIST_RTRAI))
+        ((TH1D *)fHistograms->FindObject("res_train"))->Fill(fResiduals(i));
 
-   // Residual from training sample
-   if (opt.Contains("r3") || opt.Contains("a")) {
-      SETBIT(fHistogramMask,HIST_RTRAI);
-      if (!fHistograms->FindObject("res_train"))
-         fHistograms->Add(new TH1D("res_train",
-         "Computed residuals over training sample",
-         100, fMinQuantity - fMeanQuantity,
-         fMaxQuantity - fMeanQuantity));
-
-   }
-   if (opt.Contains("r4") || opt.Contains("a")) {
-      SETBIT(fHistogramMask,HIST_RTEST);
-      if (!fHistograms->FindObject("res_test"))
-         fHistograms->Add(new TH1D("res_test",
-         "Distribution of residuals from test",
-         100,fMinQuantity - fMeanQuantity,
-         fMaxQuantity - fMeanQuantity));
-   }
+      if (TESTBIT(fHistogramMask, HIST_RX))
+        for (j = 0; j < fNVariables; j++)
+          ((TH2D *)fHistograms->FindObject(Form("res_x_%d", j)))->Fill(fVariables(i * fNVariables + j), fResiduals(i));
+    }
+  }  // If histograms
 }
 
-
 //____________________________________________________________________
-void TMultiDimFet::MakeMethod(const Char_t* classname, Option_t* option)
-{
-   // Generate the file <classname>MDF.cxx which contains the
-   // implementation of the method:
-   //
-   //   Double_t <classname>::MDF(Double_t *x)
-   //
-   // which does the same as  TMultiDimFet::Eval. Please refer to this
-   // method.
-   //
-   // Further, the public static members:
-   //
-   //   Int_t    <classname>::fgNVariables
-   //   Int_t    <classname>::fgNCoefficients
-   //   Double_t <classname>::fgDMean
-   //   Double_t <classname>::fgXMean[]       //[fgNVariables]
-   //   Double_t <classname>::fgXMin[]        //[fgNVariables]
-   //   Double_t <classname>::fgXMax[]        //[fgNVariables]
-   //   Double_t <classname>::fgCoefficient[] //[fgNCoeffficents]
-   //   Int_t    <classname>::fgPower[]       //[fgNCoeffficents*fgNVariables]
-   //
-   // are initialized, and assumed to exist. The class declaration is
-   // assumed to be in <classname>.h and assumed to be provided by the
-   // user.
-   //
-   // See TMultiDimFet::MakeRealCode for a list of options
-   //
-   // The minimal class definition is:
-   //
-   //   class <classname> {
-   //   public:
-   //     Int_t    <classname>::fgNVariables;     // Number of variables
-   //     Int_t    <classname>::fgNCoefficients;  // Number of terms
-   //     Double_t <classname>::fgDMean;          // Mean from training sample
-   //     Double_t <classname>::fgXMean[];        // Mean from training sample
-   //     Double_t <classname>::fgXMin[];         // Min from training sample
-   //     Double_t <classname>::fgXMax[];         // Max from training sample
-   //     Double_t <classname>::fgCoefficient[];  // Coefficients
-   //     Int_t    <classname>::fgPower[];        // Function powers
-   //
-   //     Double_t Eval(Double_t *x);
-   //   };
-   //
-   // Whether the method <classname>::Eval should be static or not, is
-   // up to the user.
+void TMultiDimFet::MakeCorrelation() {
+  // PRIVATE METHOD:
+  // Compute the correlation matrix
+  if (!fShowCorrelation)
+    return;
 
-   MakeRealCode(Form("%sMDF.cxx", classname), classname, option);
+  fCorrelationMatrix.ResizeTo(fNVariables, fNVariables + 1);
+
+  Double_t d2 = 0;
+  Double_t ddotXi = 0;   // G.Q. needs to be reinitialized in the loop over i fNVariables
+  Double_t xiNorm = 0;   // G.Q. needs to be reinitialized in the loop over i fNVariables
+  Double_t xidotXj = 0;  // G.Q. needs to be reinitialized in the loop over j fNVariables
+  Double_t xjNorm = 0;   // G.Q. needs to be reinitialized in the loop over j fNVariables
+
+  Int_t i, j, k, l, m;  // G.Q. added m variable
+  for (i = 0; i < fSampleSize; i++)
+    d2 += fQuantity(i) * fQuantity(i);
+
+  for (i = 0; i < fNVariables; i++) {
+    ddotXi = 0.;  // G.Q. reinitialisation
+    xiNorm = 0.;  // G.Q. reinitialisation
+    for (j = 0; j < fSampleSize; j++) {
+      // Index of sample j of variable i
+      k = j * fNVariables + i;
+      ddotXi += fQuantity(j) * (fVariables(k) - fMeanVariables(i));
+      xiNorm += (fVariables(k) - fMeanVariables(i)) * (fVariables(k) - fMeanVariables(i));
+    }
+    fCorrelationMatrix(i, 0) = ddotXi / TMath::Sqrt(d2 * xiNorm);
+
+    for (j = 0; j < i; j++) {
+      xidotXj = 0.;  // G.Q. reinitialisation
+      xjNorm = 0.;   // G.Q. reinitialisation
+      for (k = 0; k < fSampleSize; k++) {
+        // Index of sample j of variable i
+        // l =  j * fNVariables + k;  // G.Q.
+        l = k * fNVariables + j;  // G.Q.
+        m = k * fNVariables + i;  // G.Q.
+        // G.Q.        xidotXj += (fVariables(i) - fMeanVariables(i))
+        // G.Q.          * (fVariables(l) - fMeanVariables(j));
+        xidotXj +=
+            (fVariables(m) - fMeanVariables(i)) * (fVariables(l) - fMeanVariables(j));  // G.Q. modified index for Xi
+        xjNorm += (fVariables(l) - fMeanVariables(j)) * (fVariables(l) - fMeanVariables(j));
+      }
+      fCorrelationMatrix(i, j + 1) = xidotXj / TMath::Sqrt(xiNorm * xjNorm);
+    }
+  }
 }
 
-
-
 //____________________________________________________________________
-void TMultiDimFet::MakeNormalized()
-{
-   // PRIVATE METHOD:
-   // Normalize data to the interval [-1;1]. This is needed for the
-   // classes method to work.
+Double_t TMultiDimFet::MakeGramSchmidt(Int_t function) {
+  // PRIVATE METHOD:
+  // Make Gram-Schmidt orthogonalisation. The class description gives
+  // a thorough account of this algorithm, as well as
+  // references. Please refer to the
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
 
-   Int_t i = 0;
-   Int_t j = 0;
-   Int_t k = 0;
+  // calculate w_i, that is, evaluate the current function at data
+  // point i
+  Double_t f2 = 0;
+  fOrthCoefficients(fNCoefficients) = 0;
+  fOrthFunctionNorms(fNCoefficients) = 0;
+  Int_t j = 0;
+  Int_t k = 0;
 
-   for (i = 0; i < fSampleSize; i++) {
-      if (TESTBIT(fHistogramMask,HIST_DORIG))
-         ((TH1D*)fHistograms->FindObject("d_orig"))->Fill(fQuantity(i));
+  for (j = 0; j < fSampleSize; j++) {
+    fFunctions(fNCoefficients, j) = 1;
+    fOrthFunctions(fNCoefficients, j) = 0;
+    // First, however, we need to calculate f_fNCoefficients
+    for (k = 0; k < fNVariables; k++) {
+      Int_t p = fPowers[function * fNVariables + k];
+      Double_t x = fVariables(j * fNVariables + k);
+      fFunctions(fNCoefficients, j) *= EvalFactor(p, x);
+    }
 
-      fQuantity(i) -= fMeanQuantity;
-      fSumSqAvgQuantity  += fQuantity(i) * fQuantity(i);
+    // Calculate f dot f in f2
+    f2 += fFunctions(fNCoefficients, j) * fFunctions(fNCoefficients, j);
+    // Assign to w_fNCoefficients f_fNCoefficients
+    fOrthFunctions(fNCoefficients, j) = fFunctions(fNCoefficients, j);
+  }
 
-      if (TESTBIT(fHistogramMask,HIST_DSHIF))
-         ((TH1D*)fHistograms->FindObject("d_shifted"))->Fill(fQuantity(i));
+  // the first column of w is equal to f
+  for (j = 0; j < fNCoefficients; j++) {
+    Double_t fdw = 0;
+    // Calculate (f_fNCoefficients dot w_j) / w_j^2
+    for (k = 0; k < fSampleSize; k++) {
+      fdw += fFunctions(fNCoefficients, k) * fOrthFunctions(j, k) / fOrthFunctionNorms(j);
+    }
 
-      for (j = 0; j < fNVariables; j++) {
-         Double_t range = 1. / (fMaxVariables(j) - fMinVariables(j));
-         k              = i * fNVariables + j;
+    fOrthCurvatureMatrix(fNCoefficients, j) = fdw;
+    // and subtract it from the current value of w_ij
+    for (k = 0; k < fSampleSize; k++)
+      fOrthFunctions(fNCoefficients, k) -= fdw * fOrthFunctions(j, k);
+  }
 
-         // Fill histograms of original independent variables
-         if (TESTBIT(fHistogramMask,HIST_XORIG))
-            ((TH1D*)fHistograms->FindObject(Form("x_%d_orig",j)))
-            ->Fill(fVariables(k));
+  for (j = 0; j < fSampleSize; j++) {
+    // calculate squared length of w_fNCoefficients
+    fOrthFunctionNorms(fNCoefficients) += fOrthFunctions(fNCoefficients, j) * fOrthFunctions(fNCoefficients, j);
 
-         // Normalise independent variables
-         fVariables(k) = 1 + 2 * range * (fVariables(k) - fMaxVariables(j));
+    // calculate D dot w_fNCoefficients in A
+    fOrthCoefficients(fNCoefficients) += fQuantity(j) * fOrthFunctions(fNCoefficients, j);
+  }
 
-         // Fill histograms of normalised independent variables
-         if (TESTBIT(fHistogramMask,HIST_XNORM))
-            ((TH1D*)fHistograms->FindObject(Form("x_%d_norm",j)))
-            ->Fill(fVariables(k));
+  // First test, but only if didn't user specify
+  if (!fIsUserFunction)
+    if (TMath::Sqrt(fOrthFunctionNorms(fNCoefficients) / (f2 + 1e-10)) < TMath::Sin(fMinAngle * DEGRAD))
+      return 0;
 
-      }
-   }
-   // Shift min and max of dependent variable
-   fMaxQuantity -= fMeanQuantity;
-   fMinQuantity -= fMeanQuantity;
+  // The result found by this code for the first residual is always
+  // much less then the one found be MUDIFI. That's because it's
+  // supposed to be. The cause is the improved precision of Double_t
+  // over DOUBLE PRECISION!
+  fOrthCurvatureMatrix(fNCoefficients, fNCoefficients) = 1;
+  Double_t b = fOrthCoefficients(fNCoefficients);
+  fOrthCoefficients(fNCoefficients) /= fOrthFunctionNorms(fNCoefficients);
 
-   // Shift mean of independent variables
-   for (i = 0; i < fNVariables; i++) {
-      Double_t range = 1. / (fMaxVariables(i) - fMinVariables(i));
-      fMeanVariables(i) = 1 + 2 * range * (fMeanVariables(i)
-         - fMaxVariables(i));
-   }
+  // Calculate the residual from including this fNCoefficients.
+  Double_t dResidur = fOrthCoefficients(fNCoefficients) * b;
+
+  return dResidur;
 }
 
-
 //____________________________________________________________________
-void TMultiDimFet::MakeParameterization()
-{
-   // PRIVATE METHOD:
-   // Find the parameterization over the training sample. A full account
-   // of the algorithm is given in the
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+void TMultiDimFet::MakeHistograms(Option_t *option) {
+  // Make histograms of the result of the analysis. This message
+  // should be sent after having read all data points, but before
+  // finding the parameterization
+  //
+  // Options:
+  //     A         All the below
+  //     X         Original independent variables
+  //     D         Original dependent variables
+  //     N         Normalised independent variables
+  //     S         Shifted dependent variables
+  //     R1        Residuals versus normalised independent variables
+  //     R2        Residuals versus dependent variable
+  //     R3        Residuals computed on training sample
+  //     R4        Residuals computed on test sample
+  //
+  // For a description of these quantities, refer to
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  TString opt(option);
+  opt.ToLower();
 
-   Int_t     i              = -1;
-   Int_t     j              = 0;
-   Int_t     k              = 0;
-   Int_t     maxPass        = 3;
-   Int_t     studied        = 0;
-   Double_t  squareResidual = fSumSqAvgQuantity;
-   fNCoefficients            = 0;
-   fSumSqResidual           = fSumSqAvgQuantity;
-   fFunctions.ResizeTo(fMaxTerms,fSampleSize);
-   fOrthFunctions.ResizeTo(fMaxTerms,fSampleSize);
-   fOrthFunctionNorms.ResizeTo(fMaxTerms);
-   fOrthCoefficients.ResizeTo(fMaxTerms);
-   fOrthCurvatureMatrix.ResizeTo(fMaxTerms,fMaxTerms);
-   fFunctions = 1;
+  if (opt.Length() < 1)
+    return;
 
-   fFunctionCodes.resize(fMaxFunctions);
-   fPowerIndex.resize(fMaxTerms);
-   Int_t l;
-   for (l=0;l<fMaxFunctions;l++) fFunctionCodes[l] = 0;
-   for (l=0;l<fMaxTerms;l++)     fPowerIndex[l]    = 0;
+  if (!fHistograms)
+    fHistograms = new TList;
 
-   if (fMaxAngle != 0)  maxPass = 100;
-   if (fIsUserFunction) maxPass = 1;
+  // Counter variable
+  Int_t i = 0;
 
-   // Loop over the number of functions we want to study.
-   // increment inspection counter
-   while(kTRUE) {
+  // Histogram of original variables
+  if (opt.Contains("x") || opt.Contains("a")) {
+    SETBIT(fHistogramMask, HIST_XORIG);
+    for (i = 0; i < fNVariables; i++)
+      if (!fHistograms->FindObject(Form("x_%d_orig", i)))
+        fHistograms->Add(
+            new TH1D(Form("x_%d_orig", i), Form("Original variable # %d", i), 100, fMinVariables(i), fMaxVariables(i)));
+  }
 
-      // Reach user defined limit of studies
-      if (studied++ >= fMaxStudy) {
-         fParameterisationCode = PARAM_MAXSTUDY;
-         break;
-      }
+  // Histogram of original dependent variable
+  if (opt.Contains("d") || opt.Contains("a")) {
+    SETBIT(fHistogramMask, HIST_DORIG);
+    if (!fHistograms->FindObject("d_orig"))
+      fHistograms->Add(new TH1D("d_orig", "Original Quantity", 100, fMinQuantity, fMaxQuantity));
+  }
 
-      // Considered all functions several times
-      if (k >= maxPass) {
-         fParameterisationCode = PARAM_SEVERAL;
-         break;
-      }
+  // Histograms of normalized variables
+  if (opt.Contains("n") || opt.Contains("a")) {
+    SETBIT(fHistogramMask, HIST_XNORM);
+    for (i = 0; i < fNVariables; i++)
+      if (!fHistograms->FindObject(Form("x_%d_norm", i)))
+        fHistograms->Add(new TH1D(Form("x_%d_norm", i), Form("Normalized variable # %d", i), 100, -1, 1));
+  }
 
-      // increment function counter
-      i++;
+  // Histogram of shifted dependent variable
+  if (opt.Contains("s") || opt.Contains("a")) {
+    SETBIT(fHistogramMask, HIST_DSHIF);
+    if (!fHistograms->FindObject("d_shifted"))
+      fHistograms->Add(
+          new TH1D("d_shifted", "Shifted Quantity", 100, fMinQuantity - fMeanQuantity, fMaxQuantity - fMeanQuantity));
+  }
 
-      // If we've reached the end of the functions, restart pass
-      if (i == fMaxFunctions) {
-         if (fMaxAngle != 0)
-            fMaxAngle += (90 - fMaxAngle) / 2;
-         i = 0;
-         studied--;
-         k++;
-         continue;
-      }
-      if (studied == 1)
-         fFunctionCodes[i] = 0;
-      else if (fFunctionCodes[i] >= 2)
-         continue;
+  // Residual from training sample versus independent variables
+  if (opt.Contains("r1") || opt.Contains("a")) {
+    SETBIT(fHistogramMask, HIST_RX);
+    for (i = 0; i < fNVariables; i++)
+      if (!fHistograms->FindObject(Form("res_x_%d", i)))
+        fHistograms->Add(new TH2D(Form("res_x_%d", i),
+                                  Form("Computed residual versus x_%d", i),
+                                  100,
+                                  -1,
+                                  1,
+                                  35,
+                                  fMinQuantity - fMeanQuantity,
+                                  fMaxQuantity - fMeanQuantity));
+  }
 
-      // Print a happy message
-      if (fIsVerbose && studied == 1)
-         edm::LogInfo("TMultiDimFet") << "Coeff   SumSqRes    Contrib   Angle      QM   Func"
-         << "     Value        W^2  Powers" << "\n";
+  // Residual from training sample versus. dependent variable
+  if (opt.Contains("r2") || opt.Contains("a")) {
+    SETBIT(fHistogramMask, HIST_RD);
+    if (!fHistograms->FindObject("res_d"))
+      fHistograms->Add(new TH2D("res_d",
+                                "Computed residuals vs Quantity",
+                                100,
+                                fMinQuantity - fMeanQuantity,
+                                fMaxQuantity - fMeanQuantity,
+                                35,
+                                fMinQuantity - fMeanQuantity,
+                                fMaxQuantity - fMeanQuantity));
+  }
 
-      // Make the Gram-Schmidt
-      Double_t dResidur = MakeGramSchmidt(i);
-
-      if (dResidur == 0) {
-         // This function is no good!
-         // First test is in MakeGramSchmidt
-         fFunctionCodes[i] = 1;
-         continue;
-      }
-
-      // If user specified function, assume she/he knows what he's doing
-      if (!fIsUserFunction) {
-         // Flag this function as considered
-         fFunctionCodes[i] = 2;
-
-         // Test if this function contributes to the fit
-         if (!TestFunction(squareResidual, dResidur)) {
-            fFunctionCodes[i] = 1;
-            continue;
-         }
-      }
-
-      // If we get to here, the function currently considered is
-      // fNCoefficients, so we increment the counter
-      // Flag this function as OK, and store and the number in the
-      // index.
-      fFunctionCodes[i]          = 3;
-      fPowerIndex[fNCoefficients] = i;
-      fNCoefficients++;
-
-      // We add the current contribution to the sum of square of
-      // residuals;
-      squareResidual -= dResidur;
-
-
-      // Calculate control parameter from this function
-      for (j = 0; j < fNVariables; j++) {
-         if (fNCoefficients == 1
-            || fMaxPowersFinal[j] <= fPowers[i * fNVariables + j] - 1)
-            fMaxPowersFinal[j] = fPowers[i * fNVariables + j] - 1;
-      }
-      Double_t s = EvalControl(&fPowers[i * fNVariables]);
-
-      // Print the statistics about this function
-      if (fIsVerbose) {
-         edm::LogVerbatim("TMultiDimFet") << std::setw(5)  << fNCoefficients << " "
-            << std::setw(10) << std::setprecision(4) << squareResidual << " "
-            << std::setw(10) << std::setprecision(4) << dResidur << " "
-            << std::setw(7)  << std::setprecision(3) << fMaxAngle << " "
-            << std::setw(7)  << std::setprecision(3) << s << " "
-            << std::setw(5)  << i << " "
-            << std::setw(10) << std::setprecision(4)
-            << fOrthCoefficients(fNCoefficients-1) << " "
-            << std::setw(10) << std::setprecision(4)
-            << fOrthFunctionNorms(fNCoefficients-1) << " "
-            << std::flush;
-         for (j = 0; j < fNVariables; j++)
-            edm::LogInfo("TMultiDimFet") << " " << fPowers[i * fNVariables + j] - 1 << std::flush;
-         edm::LogInfo("TMultiDimFet") << "\n";
-      }
-
-      if (fNCoefficients >= fMaxTerms /* && fIsVerbose */) {
-         fParameterisationCode = PARAM_MAXTERMS;
-         break;
-      }
-
-      Double_t err  = TMath::Sqrt(TMath::Max(1e-20,squareResidual) /
-         fSumSqAvgQuantity);
-      if (err < fMinRelativeError) {
-         fParameterisationCode = PARAM_RELERR;
-         break;
-      }
-
-   }
-
-   fError          = TMath::Max(1e-20,squareResidual);
-   fSumSqResidual -= fError;
-   fRMS = TMath::Sqrt(fError / fSampleSize);
+  // Residual from training sample
+  if (opt.Contains("r3") || opt.Contains("a")) {
+    SETBIT(fHistogramMask, HIST_RTRAI);
+    if (!fHistograms->FindObject("res_train"))
+      fHistograms->Add(new TH1D("res_train",
+                                "Computed residuals over training sample",
+                                100,
+                                fMinQuantity - fMeanQuantity,
+                                fMaxQuantity - fMeanQuantity));
+  }
+  if (opt.Contains("r4") || opt.Contains("a")) {
+    SETBIT(fHistogramMask, HIST_RTEST);
+    if (!fHistograms->FindObject("res_test"))
+      fHistograms->Add(new TH1D("res_test",
+                                "Distribution of residuals from test",
+                                100,
+                                fMinQuantity - fMeanQuantity,
+                                fMaxQuantity - fMeanQuantity));
+  }
 }
 
-
 //____________________________________________________________________
-void TMultiDimFet::MakeRealCode(const char *filename,
-                                const char *classname,
-                                Option_t *)
-{
-   // PRIVATE METHOD:
-   // This is the method that actually generates the code for the
-   // evaluation the parameterization on some point.
-   // It's called by TMultiDimFet::MakeCode and TMultiDimFet::MakeMethod.
-   //
-   // The options are: NONE so far
-   Int_t i, j;
+void TMultiDimFet::MakeMethod(const Char_t *classname, Option_t *option) {
+  // Generate the file <classname>MDF.cxx which contains the
+  // implementation of the method:
+  //
+  //   Double_t <classname>::MDF(Double_t *x)
+  //
+  // which does the same as  TMultiDimFet::Eval. Please refer to this
+  // method.
+  //
+  // Further, the public static members:
+  //
+  //   Int_t    <classname>::fgNVariables
+  //   Int_t    <classname>::fgNCoefficients
+  //   Double_t <classname>::fgDMean
+  //   Double_t <classname>::fgXMean[]       //[fgNVariables]
+  //   Double_t <classname>::fgXMin[]        //[fgNVariables]
+  //   Double_t <classname>::fgXMax[]        //[fgNVariables]
+  //   Double_t <classname>::fgCoefficient[] //[fgNCoeffficents]
+  //   Int_t    <classname>::fgPower[]       //[fgNCoeffficents*fgNVariables]
+  //
+  // are initialized, and assumed to exist. The class declaration is
+  // assumed to be in <classname>.h and assumed to be provided by the
+  // user.
+  //
+  // See TMultiDimFet::MakeRealCode for a list of options
+  //
+  // The minimal class definition is:
+  //
+  //   class <classname> {
+  //   public:
+  //     Int_t    <classname>::fgNVariables;     // Number of variables
+  //     Int_t    <classname>::fgNCoefficients;  // Number of terms
+  //     Double_t <classname>::fgDMean;          // Mean from training sample
+  //     Double_t <classname>::fgXMean[];        // Mean from training sample
+  //     Double_t <classname>::fgXMin[];         // Min from training sample
+  //     Double_t <classname>::fgXMax[];         // Max from training sample
+  //     Double_t <classname>::fgCoefficient[];  // Coefficients
+  //     Int_t    <classname>::fgPower[];        // Function powers
+  //
+  //     Double_t Eval(Double_t *x);
+  //   };
+  //
+  // Whether the method <classname>::Eval should be static or not, is
+  // up to the user.
 
-   Bool_t  isMethod     = (classname[0] == '\0' ? kFALSE : kTRUE);
-   const char *prefix   = (isMethod ? Form("%s::", classname) : "");
-   const char *cv_qual  = (isMethod ? "" : "static ");
-
-   std::ofstream outFile(filename,std::ios::out|std::ios::trunc);
-   if (!outFile) {
-      Error("MakeRealCode","couldn't open output file '%s'",filename);
-      return;
-   }
-
-   if (fIsVerbose)
-      edm::LogInfo("TMultiDimFet") << "Writing on file \"" << filename << "\" ... " << std::flush;
-   //
-   // Write header of file
-   //
-   // Emacs mode line ;-)
-   outFile << "// -*- mode: c++ -*-" << "\n";
-   // Info about creator
-   outFile << "// " << "\n"
-      << "// File " << filename
-      << " generated by TMultiDimFet::MakeRealCode" << "\n";
-   // Time stamp
-   TDatime date;
-   outFile << "// on " << date.AsString() << "\n";
-   // ROOT version info
-   outFile << "// ROOT version " << gROOT->GetVersion()
-      << "\n" << "//" << "\n";
-   // General information on the code
-   outFile << "// This file contains the function " << "\n"
-      << "//" << "\n"
-      << "//    double  " << prefix << "MDF(double *x); " << "\n"
-      << "//" << "\n"
-      << "// For evaluating the parameterization obtained" << "\n"
-      << "// from TMultiDimFet and the point x" << "\n"
-      << "// " << "\n"
-      << "// See TMultiDimFet class documentation for more "
-      << "information " << "\n" << "// " << "\n";
-   // Header files
-   if (isMethod)
-      // If these are methods, we need the class header
-      outFile << "#include \"" << classname << ".h\"" << "\n";
-
-   //
-   // Now for the data
-   //
-   outFile << "//" << "\n"
-      << "// Static data variables"  << "\n"
-      << "//" << "\n";
-   outFile << cv_qual << "int    " << prefix << "gNVariables    = "
-      << fNVariables << ";" << "\n";
-   outFile << cv_qual << "int    " << prefix << "gNCoefficients = "
-      << fNCoefficients << ";" << "\n";
-   outFile << cv_qual << "double " << prefix << "gDMean         = "
-      << fMeanQuantity << ";" << "\n";
-
-   // Assignment to mean vector.
-   outFile << "// Assignment to mean vector." << "\n";
-   outFile << cv_qual << "double " << prefix
-      << "gXMean[] = {" << "\n";
-   for (i = 0; i < fNVariables; i++)
-      outFile << (i != 0 ? ", " : "  ") << fMeanVariables(i) << std::flush;
-   outFile << " };" << "\n" << "\n";
-
-   // Assignment to minimum vector.
-   outFile << "// Assignment to minimum vector." << "\n";
-   outFile << cv_qual << "double " << prefix
-      << "gXMin[] = {" << "\n";
-   for (i = 0; i < fNVariables; i++)
-      outFile << (i != 0 ? ", " : "  ") << fMinVariables(i) << std::flush;
-   outFile << " };" << "\n" << "\n";
-
-   // Assignment to maximum vector.
-   outFile << "// Assignment to maximum vector." << "\n";
-   outFile << cv_qual << "double " << prefix
-      << "gXMax[] = {" << "\n";
-   for (i = 0; i < fNVariables; i++)
-      outFile << (i != 0 ? ", " : "  ") << fMaxVariables(i) << std::flush;
-   outFile << " };" << "\n" << "\n";
-
-   // Assignment to coefficients vector.
-   outFile << "// Assignment to coefficients vector." << "\n";
-   outFile << cv_qual << "double " << prefix
-      << "gCoefficient[] = {" << std::flush;
-   for (i = 0; i < fNCoefficients; i++)
-      outFile << (i != 0 ? "," : "") << "\n"
-      << "  " << fCoefficients(i) << std::flush;
-   outFile << "\n" << " };" << "\n" << "\n";
-
-   // Assignment to powers vector.
-   outFile << "// Assignment to powers vector." << "\n"
-      << "// The powers are stored row-wise, that is" << "\n"
-      << "//  p_ij = " << prefix
-      << "gPower[i * NVariables + j];" << "\n";
-   outFile << cv_qual << "int    " << prefix
-      << "gPower[] = {" << std::flush;
-   for (i = 0; i < fNCoefficients; i++) {
-      for (j = 0; j < fNVariables; j++) {
-         if (j != 0) outFile << std::flush << "  ";
-         else        outFile << "\n" << "  ";
-         outFile << fPowers[fPowerIndex[i] * fNVariables + j]
-         << (i == fNCoefficients - 1 && j == fNVariables - 1 ? "" : ",")
-            << std::flush;
-      }
-   }
-   outFile << "\n" << "};" << "\n" << "\n";
-
-
-   //
-   // Finally we reach the function itself
-   //
-   outFile << "// " << "\n"
-      << "// The "
-      << (isMethod ? "method " : "function ")
-      << "  double " << prefix
-      << "MDF(double *x)"
-      << "\n" << "// " << "\n";
-   outFile << "double " << prefix
-      << "MDF(double *x) {" << "\n"
-      << "  double returnValue = " << prefix << "gDMean;" << "\n"
-      << "  int    i = 0, j = 0, k = 0;" << "\n"
-      << "  for (i = 0; i < " << prefix << "gNCoefficients ; i++) {"
-      << "\n"
-      << "    // Evaluate the ith term in the expansion" << "\n"
-      << "    double term = " << prefix << "gCoefficient[i];"
-      << "\n"
-      << "    for (j = 0; j < " << prefix << "gNVariables; j++) {"
-      << "\n"
-      << "      // Evaluate the polynomial in the jth variable." << "\n"
-      << "      int power = "<< prefix << "gPower["
-      << prefix << "gNVariables * i + j]; " << "\n"
-      << "      double p1 = 1, p2 = 0, p3 = 0, r = 0;" << "\n"
-      << "      double v =  1 + 2. / ("
-      << prefix << "gXMax[j] - " << prefix
-      << "gXMin[j]) * (x[j] - " << prefix << "gXMax[j]);" << "\n"
-      << "      // what is the power to use!" << "\n"
-      << "      switch(power) {" << "\n"
-      << "      case 1: r = 1; break; " << "\n"
-      << "      case 2: r = v; break; " << "\n"
-      << "      default: " << "\n"
-      << "        p2 = v; " << "\n"
-      << "        for (k = 3; k <= power; k++) { " << "\n"
-      << "          p3 = p2 * v;" << "\n";
-   if (fPolyType == kLegendre)
-      outFile << "          p3 = ((2 * i - 3) * p2 * v - (i - 2) * p1)"
-      << " / (i - 1);" << "\n";
-   if (fPolyType == kChebyshev)
-      outFile << "          p3 = 2 * v * p2 - p1; " << "\n";
-   outFile << "          p1 = p2; p2 = p3; " << "\n" << "        }" << "\n"
-      << "        r = p3;" << "\n" << "      }" << "\n"
-      << "      // multiply this term by the poly in the jth var" << "\n"
-      << "      term *= r; " << "\n" << "    }" << "\n"
-      << "    // Add this term to the final result" << "\n"
-      << "    returnValue += term;" << "\n" << "  }" << "\n"
-      << "  return returnValue;" << "\n" << "}" << "\n" << "\n";
-
-   // EOF
-   outFile << "// EOF for " << filename << "\n";
-
-   // Close the file
-   outFile.close();
-
-   if (fIsVerbose)
-      edm::LogInfo("TMultiDimFet") << "done" << "\n";
+  MakeRealCode(Form("%sMDF.cxx", classname), classname, option);
 }
 
+//____________________________________________________________________
+void TMultiDimFet::MakeNormalized() {
+  // PRIVATE METHOD:
+  // Normalize data to the interval [-1;1]. This is needed for the
+  // classes method to work.
+
+  Int_t i = 0;
+  Int_t j = 0;
+  Int_t k = 0;
+
+  for (i = 0; i < fSampleSize; i++) {
+    if (TESTBIT(fHistogramMask, HIST_DORIG))
+      ((TH1D *)fHistograms->FindObject("d_orig"))->Fill(fQuantity(i));
+
+    fQuantity(i) -= fMeanQuantity;
+    fSumSqAvgQuantity += fQuantity(i) * fQuantity(i);
+
+    if (TESTBIT(fHistogramMask, HIST_DSHIF))
+      ((TH1D *)fHistograms->FindObject("d_shifted"))->Fill(fQuantity(i));
+
+    for (j = 0; j < fNVariables; j++) {
+      Double_t range = 1. / (fMaxVariables(j) - fMinVariables(j));
+      k = i * fNVariables + j;
+
+      // Fill histograms of original independent variables
+      if (TESTBIT(fHistogramMask, HIST_XORIG))
+        ((TH1D *)fHistograms->FindObject(Form("x_%d_orig", j)))->Fill(fVariables(k));
+
+      // Normalise independent variables
+      fVariables(k) = 1 + 2 * range * (fVariables(k) - fMaxVariables(j));
+
+      // Fill histograms of normalised independent variables
+      if (TESTBIT(fHistogramMask, HIST_XNORM))
+        ((TH1D *)fHistograms->FindObject(Form("x_%d_norm", j)))->Fill(fVariables(k));
+    }
+  }
+  // Shift min and max of dependent variable
+  fMaxQuantity -= fMeanQuantity;
+  fMinQuantity -= fMeanQuantity;
+
+  // Shift mean of independent variables
+  for (i = 0; i < fNVariables; i++) {
+    Double_t range = 1. / (fMaxVariables(i) - fMinVariables(i));
+    fMeanVariables(i) = 1 + 2 * range * (fMeanVariables(i) - fMaxVariables(i));
+  }
+}
 
 //____________________________________________________________________
-void TMultiDimFet::Print(Option_t *option) const
-{
-   // Print statistics etc.
-   // Options are
-   //   P        Parameters
-   //   S        Statistics
-   //   C        Coefficients
-   //   R        Result of parameterisation
-   //   F        Result of fit
-   //   K        Correlation Matrix
-   //   M        Pretty print formula
-   //
-   Int_t i = 0;
-   Int_t j = 0;
+void TMultiDimFet::MakeParameterization() {
+  // PRIVATE METHOD:
+  // Find the parameterization over the training sample. A full account
+  // of the algorithm is given in the
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
 
-   TString opt(option);
-   opt.ToLower();
+  Int_t i = -1;
+  Int_t j = 0;
+  Int_t k = 0;
+  Int_t maxPass = 3;
+  Int_t studied = 0;
+  Double_t squareResidual = fSumSqAvgQuantity;
+  fNCoefficients = 0;
+  fSumSqResidual = fSumSqAvgQuantity;
+  fFunctions.ResizeTo(fMaxTerms, fSampleSize);
+  fOrthFunctions.ResizeTo(fMaxTerms, fSampleSize);
+  fOrthFunctionNorms.ResizeTo(fMaxTerms);
+  fOrthCoefficients.ResizeTo(fMaxTerms);
+  fOrthCurvatureMatrix.ResizeTo(fMaxTerms, fMaxTerms);
+  fFunctions = 1;
 
-   if (opt.Contains("p")) {
-      // Print basic parameters for this object
-      edm::LogInfo("TMultiDimFet") << "User parameters:" << "\n"
-         << "----------------" << "\n"
-         << " Variables:                    " << fNVariables << "\n"
-         << " Data points:                  " << fSampleSize << "\n"
-         << " Max Terms:                    " << fMaxTerms << "\n"
-         << " Power Limit Parameter:        " << fPowerLimit << "\n"
-         << " Max functions:                " << fMaxFunctions << "\n"
-         << " Max functions to study:       " << fMaxStudy << "\n"
-         << " Max angle (optional):         " << fMaxAngle << "\n"
-         << " Min angle:                    " << fMinAngle << "\n"
-         << " Relative Error accepted:      " << fMinRelativeError << "\n"
-         << " Maximum Powers:               " << std::flush;
-      for (i = 0; i < fNVariables; i++)
-         edm::LogInfo("TMultiDimFet") << " " << fMaxPowers[i] - 1 << std::flush;
-      edm::LogInfo("TMultiDimFet") << "\n" << "\n"
-         << " Parameterisation will be done using " << std::flush;
-      if (fPolyType == kChebyshev)
-         edm::LogInfo("TMultiDimFet") << "Chebyshev polynomials" << "\n";
-      else if (fPolyType == kLegendre)
-         edm::LogInfo("TMultiDimFet") << "Legendre polynomials" << "\n";
-      else
-         edm::LogInfo("TMultiDimFet") << "Monomials" << "\n";
-      edm::LogInfo("TMultiDimFet") << "\n";
-   }
+  fFunctionCodes.resize(fMaxFunctions);
+  fPowerIndex.resize(fMaxTerms);
+  Int_t l;
+  for (l = 0; l < fMaxFunctions; l++)
+    fFunctionCodes[l] = 0;
+  for (l = 0; l < fMaxTerms; l++)
+    fPowerIndex[l] = 0;
 
-   if (opt.Contains("s")) {
-      // Print statistics for read data
-      edm::LogInfo("TMultiDimFet") << "Sample statistics:" << "\n"
-         << "------------------" << "\n"
-         << "                 D"  << std::flush;
-      for (i = 0; i < fNVariables; i++)
-         edm::LogInfo("TMultiDimFet") << " " << std::setw(10) << i+1 << std::flush;
-      edm::LogInfo("TMultiDimFet") << "\n" << " Max:   " << std::setw(10) << std::setprecision(7)
-         << fMaxQuantity << std::flush;
-      for (i = 0; i < fNVariables; i++)
-         edm::LogInfo("TMultiDimFet") << " " << std::setw(10) << std::setprecision(4)
-         << fMaxVariables(i) << std::flush;
-      edm::LogInfo("TMultiDimFet") << "\n" << " Min:   " << std::setw(10) << std::setprecision(7)
-         << fMinQuantity << std::flush;
-      for (i = 0; i < fNVariables; i++)
-         edm::LogInfo("TMultiDimFet") << " " << std::setw(10) << std::setprecision(4)
-         << fMinVariables(i) << std::flush;
-      edm::LogInfo("TMultiDimFet") << "\n" << " Mean:  " << std::setw(10) << std::setprecision(7)
-         << fMeanQuantity << std::flush;
-      for (i = 0; i < fNVariables; i++)
-         edm::LogInfo("TMultiDimFet") << " " << std::setw(10) << std::setprecision(4)
-         << fMeanVariables(i) << std::flush;
-      edm::LogInfo("TMultiDimFet") << "\n" << " Function Sum Squares:         " << fSumSqQuantity
-         << "\n" << "\n";
-   }
+  if (fMaxAngle != 0)
+    maxPass = 100;
+  if (fIsUserFunction)
+    maxPass = 1;
 
-   if (opt.Contains("r")) {
-      edm::LogInfo("TMultiDimFet") << "Results of Parameterisation:" << "\n"
-         << "----------------------------" << "\n"
-         << " Total reduction of square residuals    "
-         << fSumSqResidual << "\n"
-         << " Relative precision obtained:           "
-         << fPrecision   << "\n"
-         << " Error obtained:                        "
-         << fError << "\n"
-         << " Multiple correlation coefficient:      "
-         << fCorrelationCoeff   << "\n"
-         << " Reduced Chi square over sample:        "
-         << fChi2 / (fSampleSize - fNCoefficients) << "\n"
-         << " Maximum residual value:                "
-         << fMaxResidual << "\n"
-         << " Minimum residual value:                "
-         << fMinResidual << "\n"
-         << " Estimated root mean square:            "
-         << fRMS << "\n"
-         << " Maximum powers used:                   " << std::flush;
+  // Loop over the number of functions we want to study.
+  // increment inspection counter
+  while (kTRUE) {
+    // Reach user defined limit of studies
+    if (studied++ >= fMaxStudy) {
+      fParameterisationCode = PARAM_MAXSTUDY;
+      break;
+    }
+
+    // Considered all functions several times
+    if (k >= maxPass) {
+      fParameterisationCode = PARAM_SEVERAL;
+      break;
+    }
+
+    // increment function counter
+    i++;
+
+    // If we've reached the end of the functions, restart pass
+    if (i == fMaxFunctions) {
+      if (fMaxAngle != 0)
+        fMaxAngle += (90 - fMaxAngle) / 2;
+      i = 0;
+      studied--;
+      k++;
+      continue;
+    }
+    if (studied == 1)
+      fFunctionCodes[i] = 0;
+    else if (fFunctionCodes[i] >= 2)
+      continue;
+
+    // Print a happy message
+    if (fIsVerbose && studied == 1)
+      edm::LogInfo("TMultiDimFet") << "Coeff   SumSqRes    Contrib   Angle      QM   Func"
+                                   << "     Value        W^2  Powers"
+                                   << "\n";
+
+    // Make the Gram-Schmidt
+    Double_t dResidur = MakeGramSchmidt(i);
+
+    if (dResidur == 0) {
+      // This function is no good!
+      // First test is in MakeGramSchmidt
+      fFunctionCodes[i] = 1;
+      continue;
+    }
+
+    // If user specified function, assume she/he knows what he's doing
+    if (!fIsUserFunction) {
+      // Flag this function as considered
+      fFunctionCodes[i] = 2;
+
+      // Test if this function contributes to the fit
+      if (!TestFunction(squareResidual, dResidur)) {
+        fFunctionCodes[i] = 1;
+        continue;
+      }
+    }
+
+    // If we get to here, the function currently considered is
+    // fNCoefficients, so we increment the counter
+    // Flag this function as OK, and store and the number in the
+    // index.
+    fFunctionCodes[i] = 3;
+    fPowerIndex[fNCoefficients] = i;
+    fNCoefficients++;
+
+    // We add the current contribution to the sum of square of
+    // residuals;
+    squareResidual -= dResidur;
+
+    // Calculate control parameter from this function
+    for (j = 0; j < fNVariables; j++) {
+      if (fNCoefficients == 1 || fMaxPowersFinal[j] <= fPowers[i * fNVariables + j] - 1)
+        fMaxPowersFinal[j] = fPowers[i * fNVariables + j] - 1;
+    }
+    Double_t s = EvalControl(&fPowers[i * fNVariables]);
+
+    // Print the statistics about this function
+    if (fIsVerbose) {
+      edm::LogVerbatim("TMultiDimFet") << std::setw(5) << fNCoefficients << " " << std::setw(10) << std::setprecision(4)
+                                       << squareResidual << " " << std::setw(10) << std::setprecision(4) << dResidur
+                                       << " " << std::setw(7) << std::setprecision(3) << fMaxAngle << " "
+                                       << std::setw(7) << std::setprecision(3) << s << " " << std::setw(5) << i << " "
+                                       << std::setw(10) << std::setprecision(4) << fOrthCoefficients(fNCoefficients - 1)
+                                       << " " << std::setw(10) << std::setprecision(4)
+                                       << fOrthFunctionNorms(fNCoefficients - 1) << " " << std::flush;
       for (j = 0; j < fNVariables; j++)
-         edm::LogInfo("TMultiDimFet") << fMaxPowersFinal[j] << " " << std::flush;
-      edm::LogInfo("TMultiDimFet") << "\n"
-         << " Function codes of candidate functions." << "\n"
-         << "  1: considered,"
-         << "  2: too little contribution,"
-         << "  3: accepted." << std::flush;
-      for (i = 0; i < fMaxFunctions; i++) {
-         if (i % 60 == 0)
-            edm::LogInfo("TMultiDimFet") << "\n" << " " << std::flush;
-         else if (i % 10 == 0)
-            edm::LogInfo("TMultiDimFet") << " " << std::flush;
-         edm::LogInfo("TMultiDimFet") << fFunctionCodes[i];
-      }
-      edm::LogInfo("TMultiDimFet") << "\n" << " Loop over candidates stopped because " << std::flush;
-      switch(fParameterisationCode){
-         case PARAM_MAXSTUDY:
-            edm::LogInfo("TMultiDimFet") << "max allowed studies reached" << "\n"; break;
-         case PARAM_SEVERAL:
-            edm::LogInfo("TMultiDimFet") << "all candidates considered several times" << "\n"; break;
-         case PARAM_RELERR:
-            edm::LogInfo("TMultiDimFet") << "wanted relative error obtained" << "\n"; break;
-         case PARAM_MAXTERMS:
-            edm::LogInfo("TMultiDimFet") << "max number of terms reached" << "\n"; break;
-         default:
-            edm::LogInfo("TMultiDimFet") << "some unknown reason" << "\n";
-            break;
-      }
+        edm::LogInfo("TMultiDimFet") << " " << fPowers[i * fNVariables + j] - 1 << std::flush;
       edm::LogInfo("TMultiDimFet") << "\n";
-   }
+    }
 
-   if (opt.Contains("f")) {
-      edm::LogInfo("TMultiDimFet") << "Results of Fit:" << "\n"
-         << "---------------" << "\n"
-         << " Test sample size:                      "
-         << fTestSampleSize << "\n"
-         << " Multiple correlation coefficient:      "
-         << fTestCorrelationCoeff << "\n"
-         << " Relative precision obtained:           "
-         << fTestPrecision   << "\n"
-         << " Error obtained:                        "
-         << fTestError << "\n"
-         << " Reduced Chi square over sample:        "
-         << fChi2 / (fSampleSize - fNCoefficients) << "\n"
-         << "\n";
-/*
+    if (fNCoefficients >= fMaxTerms /* && fIsVerbose */) {
+      fParameterisationCode = PARAM_MAXTERMS;
+      break;
+    }
+
+    Double_t err = TMath::Sqrt(TMath::Max(1e-20, squareResidual) / fSumSqAvgQuantity);
+    if (err < fMinRelativeError) {
+      fParameterisationCode = PARAM_RELERR;
+      break;
+    }
+  }
+
+  fError = TMath::Max(1e-20, squareResidual);
+  fSumSqResidual -= fError;
+  fRMS = TMath::Sqrt(fError / fSampleSize);
+}
+
+//____________________________________________________________________
+void TMultiDimFet::MakeRealCode(const char *filename, const char *classname, Option_t *) {
+  // PRIVATE METHOD:
+  // This is the method that actually generates the code for the
+  // evaluation the parameterization on some point.
+  // It's called by TMultiDimFet::MakeCode and TMultiDimFet::MakeMethod.
+  //
+  // The options are: NONE so far
+  Int_t i, j;
+
+  Bool_t isMethod = (classname[0] == '\0' ? kFALSE : kTRUE);
+  const char *prefix = (isMethod ? Form("%s::", classname) : "");
+  const char *cv_qual = (isMethod ? "" : "static ");
+
+  std::ofstream outFile(filename, std::ios::out | std::ios::trunc);
+  if (!outFile) {
+    Error("MakeRealCode", "couldn't open output file '%s'", filename);
+    return;
+  }
+
+  if (fIsVerbose)
+    edm::LogInfo("TMultiDimFet") << "Writing on file \"" << filename << "\" ... " << std::flush;
+  //
+  // Write header of file
+  //
+  // Emacs mode line ;-)
+  outFile << "// -*- mode: c++ -*-"
+          << "\n";
+  // Info about creator
+  outFile << "// "
+          << "\n"
+          << "// File " << filename << " generated by TMultiDimFet::MakeRealCode"
+          << "\n";
+  // Time stamp
+  TDatime date;
+  outFile << "// on " << date.AsString() << "\n";
+  // ROOT version info
+  outFile << "// ROOT version " << gROOT->GetVersion() << "\n"
+          << "//"
+          << "\n";
+  // General information on the code
+  outFile << "// This file contains the function "
+          << "\n"
+          << "//"
+          << "\n"
+          << "//    double  " << prefix << "MDF(double *x); "
+          << "\n"
+          << "//"
+          << "\n"
+          << "// For evaluating the parameterization obtained"
+          << "\n"
+          << "// from TMultiDimFet and the point x"
+          << "\n"
+          << "// "
+          << "\n"
+          << "// See TMultiDimFet class documentation for more "
+          << "information "
+          << "\n"
+          << "// "
+          << "\n";
+  // Header files
+  if (isMethod)
+    // If these are methods, we need the class header
+    outFile << "#include \"" << classname << ".h\""
+            << "\n";
+
+  //
+  // Now for the data
+  //
+  outFile << "//"
+          << "\n"
+          << "// Static data variables"
+          << "\n"
+          << "//"
+          << "\n";
+  outFile << cv_qual << "int    " << prefix << "gNVariables    = " << fNVariables << ";"
+          << "\n";
+  outFile << cv_qual << "int    " << prefix << "gNCoefficients = " << fNCoefficients << ";"
+          << "\n";
+  outFile << cv_qual << "double " << prefix << "gDMean         = " << fMeanQuantity << ";"
+          << "\n";
+
+  // Assignment to mean vector.
+  outFile << "// Assignment to mean vector."
+          << "\n";
+  outFile << cv_qual << "double " << prefix << "gXMean[] = {"
+          << "\n";
+  for (i = 0; i < fNVariables; i++)
+    outFile << (i != 0 ? ", " : "  ") << fMeanVariables(i) << std::flush;
+  outFile << " };"
+          << "\n"
+          << "\n";
+
+  // Assignment to minimum vector.
+  outFile << "// Assignment to minimum vector."
+          << "\n";
+  outFile << cv_qual << "double " << prefix << "gXMin[] = {"
+          << "\n";
+  for (i = 0; i < fNVariables; i++)
+    outFile << (i != 0 ? ", " : "  ") << fMinVariables(i) << std::flush;
+  outFile << " };"
+          << "\n"
+          << "\n";
+
+  // Assignment to maximum vector.
+  outFile << "// Assignment to maximum vector."
+          << "\n";
+  outFile << cv_qual << "double " << prefix << "gXMax[] = {"
+          << "\n";
+  for (i = 0; i < fNVariables; i++)
+    outFile << (i != 0 ? ", " : "  ") << fMaxVariables(i) << std::flush;
+  outFile << " };"
+          << "\n"
+          << "\n";
+
+  // Assignment to coefficients vector.
+  outFile << "// Assignment to coefficients vector."
+          << "\n";
+  outFile << cv_qual << "double " << prefix << "gCoefficient[] = {" << std::flush;
+  for (i = 0; i < fNCoefficients; i++)
+    outFile << (i != 0 ? "," : "") << "\n"
+            << "  " << fCoefficients(i) << std::flush;
+  outFile << "\n"
+          << " };"
+          << "\n"
+          << "\n";
+
+  // Assignment to powers vector.
+  outFile << "// Assignment to powers vector."
+          << "\n"
+          << "// The powers are stored row-wise, that is"
+          << "\n"
+          << "//  p_ij = " << prefix << "gPower[i * NVariables + j];"
+          << "\n";
+  outFile << cv_qual << "int    " << prefix << "gPower[] = {" << std::flush;
+  for (i = 0; i < fNCoefficients; i++) {
+    for (j = 0; j < fNVariables; j++) {
+      if (j != 0)
+        outFile << std::flush << "  ";
+      else
+        outFile << "\n"
+                << "  ";
+      outFile << fPowers[fPowerIndex[i] * fNVariables + j]
+              << (i == fNCoefficients - 1 && j == fNVariables - 1 ? "" : ",") << std::flush;
+    }
+  }
+  outFile << "\n"
+          << "};"
+          << "\n"
+          << "\n";
+
+  //
+  // Finally we reach the function itself
+  //
+  outFile << "// "
+          << "\n"
+          << "// The " << (isMethod ? "method " : "function ") << "  double " << prefix << "MDF(double *x)"
+          << "\n"
+          << "// "
+          << "\n";
+  outFile << "double " << prefix << "MDF(double *x) {"
+          << "\n"
+          << "  double returnValue = " << prefix << "gDMean;"
+          << "\n"
+          << "  int    i = 0, j = 0, k = 0;"
+          << "\n"
+          << "  for (i = 0; i < " << prefix << "gNCoefficients ; i++) {"
+          << "\n"
+          << "    // Evaluate the ith term in the expansion"
+          << "\n"
+          << "    double term = " << prefix << "gCoefficient[i];"
+          << "\n"
+          << "    for (j = 0; j < " << prefix << "gNVariables; j++) {"
+          << "\n"
+          << "      // Evaluate the polynomial in the jth variable."
+          << "\n"
+          << "      int power = " << prefix << "gPower[" << prefix << "gNVariables * i + j]; "
+          << "\n"
+          << "      double p1 = 1, p2 = 0, p3 = 0, r = 0;"
+          << "\n"
+          << "      double v =  1 + 2. / (" << prefix << "gXMax[j] - " << prefix << "gXMin[j]) * (x[j] - " << prefix
+          << "gXMax[j]);"
+          << "\n"
+          << "      // what is the power to use!"
+          << "\n"
+          << "      switch(power) {"
+          << "\n"
+          << "      case 1: r = 1; break; "
+          << "\n"
+          << "      case 2: r = v; break; "
+          << "\n"
+          << "      default: "
+          << "\n"
+          << "        p2 = v; "
+          << "\n"
+          << "        for (k = 3; k <= power; k++) { "
+          << "\n"
+          << "          p3 = p2 * v;"
+          << "\n";
+  if (fPolyType == kLegendre)
+    outFile << "          p3 = ((2 * i - 3) * p2 * v - (i - 2) * p1)"
+            << " / (i - 1);"
+            << "\n";
+  if (fPolyType == kChebyshev)
+    outFile << "          p3 = 2 * v * p2 - p1; "
+            << "\n";
+  outFile << "          p1 = p2; p2 = p3; "
+          << "\n"
+          << "        }"
+          << "\n"
+          << "        r = p3;"
+          << "\n"
+          << "      }"
+          << "\n"
+          << "      // multiply this term by the poly in the jth var"
+          << "\n"
+          << "      term *= r; "
+          << "\n"
+          << "    }"
+          << "\n"
+          << "    // Add this term to the final result"
+          << "\n"
+          << "    returnValue += term;"
+          << "\n"
+          << "  }"
+          << "\n"
+          << "  return returnValue;"
+          << "\n"
+          << "}"
+          << "\n"
+          << "\n";
+
+  // EOF
+  outFile << "// EOF for " << filename << "\n";
+
+  // Close the file
+  outFile.close();
+
+  if (fIsVerbose)
+    edm::LogInfo("TMultiDimFet") << "done"
+                                 << "\n";
+}
+
+//____________________________________________________________________
+void TMultiDimFet::Print(Option_t *option) const {
+  // Print statistics etc.
+  // Options are
+  //   P        Parameters
+  //   S        Statistics
+  //   C        Coefficients
+  //   R        Result of parameterisation
+  //   F        Result of fit
+  //   K        Correlation Matrix
+  //   M        Pretty print formula
+  //
+  Int_t i = 0;
+  Int_t j = 0;
+
+  TString opt(option);
+  opt.ToLower();
+
+  if (opt.Contains("p")) {
+    // Print basic parameters for this object
+    edm::LogInfo("TMultiDimFet") << "User parameters:"
+                                 << "\n"
+                                 << "----------------"
+                                 << "\n"
+                                 << " Variables:                    " << fNVariables << "\n"
+                                 << " Data points:                  " << fSampleSize << "\n"
+                                 << " Max Terms:                    " << fMaxTerms << "\n"
+                                 << " Power Limit Parameter:        " << fPowerLimit << "\n"
+                                 << " Max functions:                " << fMaxFunctions << "\n"
+                                 << " Max functions to study:       " << fMaxStudy << "\n"
+                                 << " Max angle (optional):         " << fMaxAngle << "\n"
+                                 << " Min angle:                    " << fMinAngle << "\n"
+                                 << " Relative Error accepted:      " << fMinRelativeError << "\n"
+                                 << " Maximum Powers:               " << std::flush;
+    for (i = 0; i < fNVariables; i++)
+      edm::LogInfo("TMultiDimFet") << " " << fMaxPowers[i] - 1 << std::flush;
+    edm::LogInfo("TMultiDimFet") << "\n"
+                                 << "\n"
+                                 << " Parameterisation will be done using " << std::flush;
+    if (fPolyType == kChebyshev)
+      edm::LogInfo("TMultiDimFet") << "Chebyshev polynomials"
+                                   << "\n";
+    else if (fPolyType == kLegendre)
+      edm::LogInfo("TMultiDimFet") << "Legendre polynomials"
+                                   << "\n";
+    else
+      edm::LogInfo("TMultiDimFet") << "Monomials"
+                                   << "\n";
+    edm::LogInfo("TMultiDimFet") << "\n";
+  }
+
+  if (opt.Contains("s")) {
+    // Print statistics for read data
+    edm::LogInfo("TMultiDimFet") << "Sample statistics:"
+                                 << "\n"
+                                 << "------------------"
+                                 << "\n"
+                                 << "                 D" << std::flush;
+    for (i = 0; i < fNVariables; i++)
+      edm::LogInfo("TMultiDimFet") << " " << std::setw(10) << i + 1 << std::flush;
+    edm::LogInfo("TMultiDimFet") << "\n"
+                                 << " Max:   " << std::setw(10) << std::setprecision(7) << fMaxQuantity << std::flush;
+    for (i = 0; i < fNVariables; i++)
+      edm::LogInfo("TMultiDimFet") << " " << std::setw(10) << std::setprecision(4) << fMaxVariables(i) << std::flush;
+    edm::LogInfo("TMultiDimFet") << "\n"
+                                 << " Min:   " << std::setw(10) << std::setprecision(7) << fMinQuantity << std::flush;
+    for (i = 0; i < fNVariables; i++)
+      edm::LogInfo("TMultiDimFet") << " " << std::setw(10) << std::setprecision(4) << fMinVariables(i) << std::flush;
+    edm::LogInfo("TMultiDimFet") << "\n"
+                                 << " Mean:  " << std::setw(10) << std::setprecision(7) << fMeanQuantity << std::flush;
+    for (i = 0; i < fNVariables; i++)
+      edm::LogInfo("TMultiDimFet") << " " << std::setw(10) << std::setprecision(4) << fMeanVariables(i) << std::flush;
+    edm::LogInfo("TMultiDimFet") << "\n"
+                                 << " Function Sum Squares:         " << fSumSqQuantity << "\n"
+                                 << "\n";
+  }
+
+  if (opt.Contains("r")) {
+    edm::LogInfo("TMultiDimFet") << "Results of Parameterisation:"
+                                 << "\n"
+                                 << "----------------------------"
+                                 << "\n"
+                                 << " Total reduction of square residuals    " << fSumSqResidual << "\n"
+                                 << " Relative precision obtained:           " << fPrecision << "\n"
+                                 << " Error obtained:                        " << fError << "\n"
+                                 << " Multiple correlation coefficient:      " << fCorrelationCoeff << "\n"
+                                 << " Reduced Chi square over sample:        " << fChi2 / (fSampleSize - fNCoefficients)
+                                 << "\n"
+                                 << " Maximum residual value:                " << fMaxResidual << "\n"
+                                 << " Minimum residual value:                " << fMinResidual << "\n"
+                                 << " Estimated root mean square:            " << fRMS << "\n"
+                                 << " Maximum powers used:                   " << std::flush;
+    for (j = 0; j < fNVariables; j++)
+      edm::LogInfo("TMultiDimFet") << fMaxPowersFinal[j] << " " << std::flush;
+    edm::LogInfo("TMultiDimFet") << "\n"
+                                 << " Function codes of candidate functions."
+                                 << "\n"
+                                 << "  1: considered,"
+                                 << "  2: too little contribution,"
+                                 << "  3: accepted." << std::flush;
+    for (i = 0; i < fMaxFunctions; i++) {
+      if (i % 60 == 0)
+        edm::LogInfo("TMultiDimFet") << "\n"
+                                     << " " << std::flush;
+      else if (i % 10 == 0)
+        edm::LogInfo("TMultiDimFet") << " " << std::flush;
+      edm::LogInfo("TMultiDimFet") << fFunctionCodes[i];
+    }
+    edm::LogInfo("TMultiDimFet") << "\n"
+                                 << " Loop over candidates stopped because " << std::flush;
+    switch (fParameterisationCode) {
+      case PARAM_MAXSTUDY:
+        edm::LogInfo("TMultiDimFet") << "max allowed studies reached"
+                                     << "\n";
+        break;
+      case PARAM_SEVERAL:
+        edm::LogInfo("TMultiDimFet") << "all candidates considered several times"
+                                     << "\n";
+        break;
+      case PARAM_RELERR:
+        edm::LogInfo("TMultiDimFet") << "wanted relative error obtained"
+                                     << "\n";
+        break;
+      case PARAM_MAXTERMS:
+        edm::LogInfo("TMultiDimFet") << "max number of terms reached"
+                                     << "\n";
+        break;
+      default:
+        edm::LogInfo("TMultiDimFet") << "some unknown reason"
+                                     << "\n";
+        break;
+    }
+    edm::LogInfo("TMultiDimFet") << "\n";
+  }
+
+  if (opt.Contains("f")) {
+    edm::LogInfo("TMultiDimFet") << "Results of Fit:"
+                                 << "\n"
+                                 << "---------------"
+                                 << "\n"
+                                 << " Test sample size:                      " << fTestSampleSize << "\n"
+                                 << " Multiple correlation coefficient:      " << fTestCorrelationCoeff << "\n"
+                                 << " Relative precision obtained:           " << fTestPrecision << "\n"
+                                 << " Error obtained:                        " << fTestError << "\n"
+                                 << " Reduced Chi square over sample:        " << fChi2 / (fSampleSize - fNCoefficients)
+                                 << "\n"
+                                 << "\n";
+    /*
       if (fFitter) {
          fFitter->PrintResults(1,1);
          edm::LogInfo("TMultiDimFet") << "\n";
       }
 */
-   }
+  }
 
-   if (opt.Contains("c")){
-      edm::LogInfo("TMultiDimFet") << "Coefficients:" << "\n"
-         << "-------------" << "\n"
-         << "   #         Value        Error   Powers" << "\n"
-         << " ---------------------------------------" << "\n";
-      for (i = 0; i < fNCoefficients; i++) {
-         edm::LogInfo("TMultiDimFet") << " " << std::setw(3) << i << "  "
-            << std::setw(12) << fCoefficients(i) << "  "
-            << std::setw(12) << fCoefficientsRMS(i) << "  " << std::flush;
-         for (j = 0; j < fNVariables; j++)
-            edm::LogInfo("TMultiDimFet") << " " << std::setw(3)
-            << fPowers[fPowerIndex[i] * fNVariables + j] - 1 << std::flush;
-         edm::LogInfo("TMultiDimFet") << "\n";
-      }
+  if (opt.Contains("c")) {
+    edm::LogInfo("TMultiDimFet") << "Coefficients:"
+                                 << "\n"
+                                 << "-------------"
+                                 << "\n"
+                                 << "   #         Value        Error   Powers"
+                                 << "\n"
+                                 << " ---------------------------------------"
+                                 << "\n";
+    for (i = 0; i < fNCoefficients; i++) {
+      edm::LogInfo("TMultiDimFet") << " " << std::setw(3) << i << "  " << std::setw(12) << fCoefficients(i) << "  "
+                                   << std::setw(12) << fCoefficientsRMS(i) << "  " << std::flush;
+      for (j = 0; j < fNVariables; j++)
+        edm::LogInfo("TMultiDimFet") << " " << std::setw(3) << fPowers[fPowerIndex[i] * fNVariables + j] - 1
+                                     << std::flush;
       edm::LogInfo("TMultiDimFet") << "\n";
-   }
-   if (opt.Contains("k") && fCorrelationMatrix.IsValid()) {
-      edm::LogInfo("TMultiDimFet") << "Correlation Matrix:" << "\n"
-         << "-------------------";
-      fCorrelationMatrix.Print();
-   }
+    }
+    edm::LogInfo("TMultiDimFet") << "\n";
+  }
+  if (opt.Contains("k") && fCorrelationMatrix.IsValid()) {
+    edm::LogInfo("TMultiDimFet") << "Correlation Matrix:"
+                                 << "\n"
+                                 << "-------------------";
+    fCorrelationMatrix.Print();
+  }
 
-   if (opt.Contains("m")) {
-      edm::LogInfo("TMultiDimFet")<<std::setprecision(25);
-      edm::LogInfo("TMultiDimFet") << "Parameterization:" << "\n"
-         << "-----------------" << "\n"
-         << "  Normalised variables: " << "\n";
-      for (i = 0; i < fNVariables; i++)
-         edm::LogInfo("TMultiDimFet") << "\ty" << i << "\t:= 1 + 2 * (x" << i << " - "
-         << fMaxVariables(i) << ") / (" 
-         << fMaxVariables(i) << " - " << fMinVariables(i) << ")" 
-         << "\n";
-      edm::LogInfo("TMultiDimFet") << "\n"
-         << "  f[";
-      for (i = 0; i < fNVariables; i++) {
-         edm::LogInfo("TMultiDimFet") << "y" << i;
-         if (i != fNVariables-1) edm::LogInfo("TMultiDimFet") << ", ";
-      }
-      edm::LogInfo("TMultiDimFet") << "] := ";
-      for (Int_t i = 0; i < fNCoefficients; i++) {
-         if (i != 0)
-            edm::LogInfo("TMultiDimFet") << " " << (fCoefficients(i) < 0 ? "- " : "+ ")
-            << TMath::Abs(fCoefficients(i));
-         else 
-            edm::LogInfo("TMultiDimFet") << fCoefficients(i);
-         for (Int_t j = 0; j < fNVariables; j++) {
-            Int_t p = fPowers[fPowerIndex[i] * fNVariables + j];
-            switch (p) { 
-               case 1: break;
-               case 2: edm::LogInfo("TMultiDimFet") << " * y" << j; break;
-               default:
-                  switch(fPolyType) {
-                     case kLegendre:  edm::LogInfo("TMultiDimFet") << " * L" << p-1 << "(y" << j << ")"; break;
-                     case kChebyshev: edm::LogInfo("TMultiDimFet") << " * C" << p-1 << "(y" << j << ")"; break;
-                     default:         edm::LogInfo("TMultiDimFet") << " * y" << j << "^" << p-1; break;
-                  }
+  if (opt.Contains("m")) {
+    edm::LogInfo("TMultiDimFet") << std::setprecision(25);
+    edm::LogInfo("TMultiDimFet") << "Parameterization:"
+                                 << "\n"
+                                 << "-----------------"
+                                 << "\n"
+                                 << "  Normalised variables: "
+                                 << "\n";
+    for (i = 0; i < fNVariables; i++)
+      edm::LogInfo("TMultiDimFet") << "\ty" << i << "\t:= 1 + 2 * (x" << i << " - " << fMaxVariables(i) << ") / ("
+                                   << fMaxVariables(i) << " - " << fMinVariables(i) << ")"
+                                   << "\n";
+    edm::LogInfo("TMultiDimFet") << "\n"
+                                 << "  f[";
+    for (i = 0; i < fNVariables; i++) {
+      edm::LogInfo("TMultiDimFet") << "y" << i;
+      if (i != fNVariables - 1)
+        edm::LogInfo("TMultiDimFet") << ", ";
+    }
+    edm::LogInfo("TMultiDimFet") << "] := ";
+    for (Int_t i = 0; i < fNCoefficients; i++) {
+      if (i != 0)
+        edm::LogInfo("TMultiDimFet") << " " << (fCoefficients(i) < 0 ? "- " : "+ ") << TMath::Abs(fCoefficients(i));
+      else
+        edm::LogInfo("TMultiDimFet") << fCoefficients(i);
+      for (Int_t j = 0; j < fNVariables; j++) {
+        Int_t p = fPowers[fPowerIndex[i] * fNVariables + j];
+        switch (p) {
+          case 1:
+            break;
+          case 2:
+            edm::LogInfo("TMultiDimFet") << " * y" << j;
+            break;
+          default:
+            switch (fPolyType) {
+              case kLegendre:
+                edm::LogInfo("TMultiDimFet") << " * L" << p - 1 << "(y" << j << ")";
+                break;
+              case kChebyshev:
+                edm::LogInfo("TMultiDimFet") << " * C" << p - 1 << "(y" << j << ")";
+                break;
+              default:
+                edm::LogInfo("TMultiDimFet") << " * y" << j << "^" << p - 1;
+                break;
             }
-
-         }
+        }
       }
-      edm::LogInfo("TMultiDimFet") << "\n";
-   }
+    }
+    edm::LogInfo("TMultiDimFet") << "\n";
+  }
 }
 
 //____________________________________________________________________
-void TMultiDimFet::PrintPolynomialsSpecial(Option_t *option) const
-{
-   //   M        Pretty print formula
-   //
-   Int_t i = 0;
-//   Int_t j = 0;
+void TMultiDimFet::PrintPolynomialsSpecial(Option_t *option) const {
+  //   M        Pretty print formula
+  //
+  Int_t i = 0;
+  //   Int_t j = 0;
 
-   TString opt(option);
-   opt.ToLower();
+  TString opt(option);
+  opt.ToLower();
 
-   if (opt.Contains("m")) {
-      edm::LogInfo("TMultiDimFet")<<std::setprecision(25);
-      edm::LogInfo("TMultiDimFet") << "Parameterization:" << "\n"
-         << "-----------------" << "\n"
-         << "  Normalised variables: " << "\n";
-      for (i = 0; i < fNVariables; i++)
-         edm::LogInfo("TMultiDimFet") << "\tdouble y" << i << "\t=1+2*(x" << i << "-"
-         << fMaxVariables(i) << ")/("
-         << fMaxVariables(i) << "-" << fMinVariables(i) <<");"
-         << "\n";
-      edm::LogInfo("TMultiDimFet") << "\n"
-         << "  f[";
-      for (i = 0; i < fNVariables; i++) {
-         edm::LogInfo("TMultiDimFet") << "y" << i;
-         if (i != fNVariables-1) edm::LogInfo("TMultiDimFet") << ", ";
-      }
-      edm::LogInfo("TMultiDimFet") << "] := "<<fMeanQuantity<<" + ";
-      for (Int_t i = 0; i < fNCoefficients; i++) {
-         if (i != 0)
-            edm::LogInfo("TMultiDimFet") << " " << (fCoefficients(i) < 0 ? "-" : "+")
-            << TMath::Abs(fCoefficients(i));
-         else
-            edm::LogInfo("TMultiDimFet") << fCoefficients(i);
-         for (Int_t j = 0; j < fNVariables; j++) {
-            Int_t p = fPowers[fPowerIndex[i] * fNVariables + j];
-            switch (p) {
-               case 1: break;
-               case 2: edm::LogInfo("TMultiDimFet") << "*y" << j; break;
-               default:
-                  switch(fPolyType) {
-                     case kLegendre:  edm::LogInfo("TMultiDimFet") << "*Leg(" << p-1 << ",y" << j << ")"; break;
-                     case kChebyshev: edm::LogInfo("TMultiDimFet") << "*C" << p-1 << "(y" << j << ")"; break;
-                     default:         edm::LogInfo("TMultiDimFet") << "*y" << j << "**" << p-1; break;
-                  }
+  if (opt.Contains("m")) {
+    edm::LogInfo("TMultiDimFet") << std::setprecision(25);
+    edm::LogInfo("TMultiDimFet") << "Parameterization:"
+                                 << "\n"
+                                 << "-----------------"
+                                 << "\n"
+                                 << "  Normalised variables: "
+                                 << "\n";
+    for (i = 0; i < fNVariables; i++)
+      edm::LogInfo("TMultiDimFet") << "\tdouble y" << i << "\t=1+2*(x" << i << "-" << fMaxVariables(i) << ")/("
+                                   << fMaxVariables(i) << "-" << fMinVariables(i) << ");"
+                                   << "\n";
+    edm::LogInfo("TMultiDimFet") << "\n"
+                                 << "  f[";
+    for (i = 0; i < fNVariables; i++) {
+      edm::LogInfo("TMultiDimFet") << "y" << i;
+      if (i != fNVariables - 1)
+        edm::LogInfo("TMultiDimFet") << ", ";
+    }
+    edm::LogInfo("TMultiDimFet") << "] := " << fMeanQuantity << " + ";
+    for (Int_t i = 0; i < fNCoefficients; i++) {
+      if (i != 0)
+        edm::LogInfo("TMultiDimFet") << " " << (fCoefficients(i) < 0 ? "-" : "+") << TMath::Abs(fCoefficients(i));
+      else
+        edm::LogInfo("TMultiDimFet") << fCoefficients(i);
+      for (Int_t j = 0; j < fNVariables; j++) {
+        Int_t p = fPowers[fPowerIndex[i] * fNVariables + j];
+        switch (p) {
+          case 1:
+            break;
+          case 2:
+            edm::LogInfo("TMultiDimFet") << "*y" << j;
+            break;
+          default:
+            switch (fPolyType) {
+              case kLegendre:
+                edm::LogInfo("TMultiDimFet") << "*Leg(" << p - 1 << ",y" << j << ")";
+                break;
+              case kChebyshev:
+                edm::LogInfo("TMultiDimFet") << "*C" << p - 1 << "(y" << j << ")";
+                break;
+              default:
+                edm::LogInfo("TMultiDimFet") << "*y" << j << "**" << p - 1;
+                break;
             }
-
-         }
-   edm::LogInfo("TMultiDimFet")<<"\n";
+        }
       }
       edm::LogInfo("TMultiDimFet") << "\n";
-   }
-}
-
-
-//____________________________________________________________________
-Bool_t TMultiDimFet::Select(const Int_t *)
-{
-   // Selection method. User can override this method for specialized
-   // selection of acceptable functions in fit. Default is to select
-   // all. This message is sent during the build-up of the function
-   // candidates table once for each set of powers in
-   // variables. Notice, that the argument array contains the powers
-   // PLUS ONE. For example, to De select the function
-   //     f = x1^2 * x2^4 * x3^5,
-   // this method should return kFALSE if given the argument
-   //     { 3, 4, 6 }
-   return kTRUE;
+    }
+    edm::LogInfo("TMultiDimFet") << "\n";
+  }
 }
 
 //____________________________________________________________________
-void TMultiDimFet::SetMaxAngle(Double_t ang)
-{
-   // Set the max angle (in degrees) between the initial data vector to
-   // be fitted, and the new candidate function to be included in the
-   // fit.  By default it is 0, which automatically chooses another
-   // selection criteria. See also
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   if (ang >= 90 || ang < 0) {
-      Warning("SetMaxAngle", "angle must be in [0,90)");
-      return;
-   }
-
-   fMaxAngle = ang;
+Bool_t TMultiDimFet::Select(const Int_t *) {
+  // Selection method. User can override this method for specialized
+  // selection of acceptable functions in fit. Default is to select
+  // all. This message is sent during the build-up of the function
+  // candidates table once for each set of powers in
+  // variables. Notice, that the argument array contains the powers
+  // PLUS ONE. For example, to De select the function
+  //     f = x1^2 * x2^4 * x3^5,
+  // this method should return kFALSE if given the argument
+  //     { 3, 4, 6 }
+  return kTRUE;
 }
 
 //____________________________________________________________________
-void TMultiDimFet::SetMinAngle(Double_t ang)
-{
-   // Set the min angle (in degrees) between a new candidate function
-   // and the subspace spanned by the previously accepted
-   // functions. See also
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   if (ang > 90 || ang <= 0) {
-      Warning("SetMinAngle", "angle must be in [0,90)");
-      return;
-   }
+void TMultiDimFet::SetMaxAngle(Double_t ang) {
+  // Set the max angle (in degrees) between the initial data vector to
+  // be fitted, and the new candidate function to be included in the
+  // fit.  By default it is 0, which automatically chooses another
+  // selection criteria. See also
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  if (ang >= 90 || ang < 0) {
+    Warning("SetMaxAngle", "angle must be in [0,90)");
+    return;
+  }
 
-   fMinAngle = ang;
-
-}
-
-
-//____________________________________________________________________
-void TMultiDimFet::SetPowers(const Int_t* powers, Int_t terms)
-{
-   // Define a user function. The input array must be of the form
-   // (p11, ..., p1N, ... ,pL1, ..., pLN)
-   // Where N is the dimension of the data sample, L is the number of
-   // terms (given in terms) and the first number, labels the term, the
-   // second the variable.  More information is given in the
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   fIsUserFunction = kTRUE;
-   fMaxFunctions   = terms;
-   fMaxTerms       = terms;
-   fMaxStudy       = terms;
-   fMaxFunctionsTimesNVariables = fMaxFunctions * fNVariables;
-   fPowers.resize(fMaxFunctions * fNVariables);
-   Int_t i, j;
-   for (i = 0; i < fMaxFunctions; i++)
-      for(j = 0; j < fNVariables; j++)
-         fPowers[i * fNVariables + j] = powers[i * fNVariables + j]  + 1;
+  fMaxAngle = ang;
 }
 
 //____________________________________________________________________
-void TMultiDimFet::SetPowerLimit(Double_t limit)
-{
-   // Set the user parameter for the function selection. The bigger the
-   // limit, the more functions are used. The meaning of this variable
-   // is defined in the
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   fPowerLimit = limit;
+void TMultiDimFet::SetMinAngle(Double_t ang) {
+  // Set the min angle (in degrees) between a new candidate function
+  // and the subspace spanned by the previously accepted
+  // functions. See also
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  if (ang > 90 || ang <= 0) {
+    Warning("SetMinAngle", "angle must be in [0,90)");
+    return;
+  }
+
+  fMinAngle = ang;
 }
 
 //____________________________________________________________________
-void TMultiDimFet::SetMaxPowers(const Int_t* powers)
-{
-   // Set the maximum power to be considered in the fit for each
-   // variable. See also
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   if (!powers)
-      return;
-
-   for (Int_t i = 0; i < fNVariables; i++)
-      fMaxPowers[i] = powers[i]+1;
+void TMultiDimFet::SetPowers(const Int_t *powers, Int_t terms) {
+  // Define a user function. The input array must be of the form
+  // (p11, ..., p1N, ... ,pL1, ..., pLN)
+  // Where N is the dimension of the data sample, L is the number of
+  // terms (given in terms) and the first number, labels the term, the
+  // second the variable.  More information is given in the
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  fIsUserFunction = kTRUE;
+  fMaxFunctions = terms;
+  fMaxTerms = terms;
+  fMaxStudy = terms;
+  fMaxFunctionsTimesNVariables = fMaxFunctions * fNVariables;
+  fPowers.resize(fMaxFunctions * fNVariables);
+  Int_t i, j;
+  for (i = 0; i < fMaxFunctions; i++)
+    for (j = 0; j < fNVariables; j++)
+      fPowers[i * fNVariables + j] = powers[i * fNVariables + j] + 1;
 }
 
 //____________________________________________________________________
-void TMultiDimFet::SetMinRelativeError(Double_t error)
-{
-   // Set the acceptable relative error for when sum of square
-   // residuals is considered minimized. For a full account, refer to
-   // the
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
-   fMinRelativeError = error;
+void TMultiDimFet::SetPowerLimit(Double_t limit) {
+  // Set the user parameter for the function selection. The bigger the
+  // limit, the more functions are used. The meaning of this variable
+  // is defined in the
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  fPowerLimit = limit;
 }
 
+//____________________________________________________________________
+void TMultiDimFet::SetMaxPowers(const Int_t *powers) {
+  // Set the maximum power to be considered in the fit for each
+  // variable. See also
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  if (!powers)
+    return;
+
+  for (Int_t i = 0; i < fNVariables; i++)
+    fMaxPowers[i] = powers[i] + 1;
+}
 
 //____________________________________________________________________
-Bool_t TMultiDimFet::TestFunction(Double_t squareResidual,
-                                  Double_t dResidur)
-{
-   // PRIVATE METHOD:
-   // Test whether the currently considered function contributes to the
-   // fit. See also
-   // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+void TMultiDimFet::SetMinRelativeError(Double_t error) {
+  // Set the acceptable relative error for when sum of square
+  // residuals is considered minimized. For a full account, refer to
+  // the
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+  fMinRelativeError = error;
+}
 
-   if (fNCoefficients != 0) {
-      // Now for the second test:
-      if (fMaxAngle == 0) {
-         // If the user hasn't supplied a max angle do the test as,
-         if (dResidur <
-            squareResidual / (fMaxTerms - fNCoefficients + 1 + 1E-10)) {
-               return kFALSE;
-         }
+//____________________________________________________________________
+Bool_t TMultiDimFet::TestFunction(Double_t squareResidual, Double_t dResidur) {
+  // PRIVATE METHOD:
+  // Test whether the currently considered function contributes to the
+  // fit. See also
+  // Begin_Html<a href="#TMultiDimFet:description">class description</a>End_Html
+
+  if (fNCoefficients != 0) {
+    // Now for the second test:
+    if (fMaxAngle == 0) {
+      // If the user hasn't supplied a max angle do the test as,
+      if (dResidur < squareResidual / (fMaxTerms - fNCoefficients + 1 + 1E-10)) {
+        return kFALSE;
       }
-      else {
-         // If the user has provided a max angle, test if the calculated
-         // angle is less then the max angle.
-         if (TMath::Sqrt(dResidur/fSumSqAvgQuantity) <
-            TMath::Cos(fMaxAngle*DEGRAD)) {
-               return kFALSE;
-         }
+    } else {
+      // If the user has provided a max angle, test if the calculated
+      // angle is less then the max angle.
+      if (TMath::Sqrt(dResidur / fSumSqAvgQuantity) < TMath::Cos(fMaxAngle * DEGRAD)) {
+        return kFALSE;
       }
-   }
-   // If we get here, the function is OK
-   return kTRUE;
+    }
+  }
+  // If we get here, the function is OK
+  return kTRUE;
 }
-
 
 //____________________________________________________________________
 //void mdfHelper(int& /*npar*/, double* /*divs*/, double& chi2,


### PR DESCRIPTION

Applying code-format for CMSSW category simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/201//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build

Same as #26677 but with correct CMS clang-format customization (see #26686)
