### PR TITLE
Fix in preselection of low pt muon mva (muon POG)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -742,11 +742,14 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	muon.setSelector(reco::Muon::MvaTight,  muon.mvaValue()> 0.15);
 	muon.setSelector(reco::Muon::MvaVTight,  muon.mvaValue()> 0.45);
 	muon.setSelector(reco::Muon::MvaVVTight,  muon.mvaValue()> 0.9);
+      }
+      if (muon.pt()>5 and muon.isLooseMuon() and
+	  sip3D<4 and dB2D < 0.5 and dz < 1){
 	muon.setSelector(reco::Muon::LowPtMvaLoose,  muon.lowptMvaValue()>-0.60);
 	muon.setSelector(reco::Muon::LowPtMvaMedium, muon.lowptMvaValue()>-0.20);
       }
     }
-
+    
     //SOFT MVA
     if (computeSoftMuonMVA_){
       float mva = globalCache()->softMuonMvaEstimator()->computeMva(muon);


### PR DESCRIPTION
#### PR description:

Bugfix in preselection for low pt lepton MVA. The preselection for the low pt lepton mva is buggy, as it includes additional isolation and IP cuts. The bug affects only the selection decision, and not the MVA value, as it is always calculated regardless of the preselection. 

@Fedespring @bmahakud 