### PR TITLE
Fix: dump HGCal rechit center

### DIFF
--- a/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
@@ -158,33 +158,7 @@ void FWCaloClusterProxyBuilder::build(const reco::CaloCluster &iData, unsigned i
             marker->SetLineWidth(1);
 
             // center of RecHit
-            float center[3] = {
-                corners[0], corners[1], corners[2] + shapes[3] * 0.5f};
-
-            if (isScintillator)
-            {
-               constexpr int offset = 9;
-
-               center[0] = (corners[6] + corners[6 + offset]) / 2;
-               center[1] = (corners[7] + corners[7 + offset]) / 2;
-            }
-            else
-            {
-               float min[2] = {1e3f, 1e3f};
-               float max[2] = {-1e3f, -1e3f};
-
-               for (int i = 0; i < total_points; ++i)
-               {
-                  min[0] = fmin(min[0], corners[i * 3]);
-                  min[1] = fmin(min[1], corners[i * 3 + 1]);
-
-                  max[0] = fmax(max[0], corners[i * 3]);
-                  max[1] = fmax(max[1], corners[i * 3 + 1]);
-               }
-
-               center[0] = (min[0] + max[0]) / 2.0f;
-               center[1] = (min[1] + max[1]) / 2.0f;
-            }
+            const float center[3] = { corners[total_points*3 + 0], corners[total_points*3+ 1], corners[total_points*3 + 2] + shapes[3] * 0.5f };
 
             // draw 3D cross
             const float crossScale = 1.0f + fmin(iData.energy(), 5.0f);

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -565,6 +565,12 @@ FWRecoGeometryESProducer::addCaloGeometry( FWRecoGeometry& fwRecoGeometry )
         fwRecoGeometry.idToName[id].points[i*3+2] = cor[i].z();
       }
 
+      // center
+      auto center = geom->getPosition(*it);
+      fwRecoGeometry.idToName[id].points[(cor.size()-1)*3 + 0] = center.x();
+      fwRecoGeometry.idToName[id].points[(cor.size()-1)*3 + 1] = center.y();
+      fwRecoGeometry.idToName[id].points[(cor.size()-1)*3 + 2] = center.z();
+
       // thickness
       fwRecoGeometry.idToName[id].shape[3] = cor[cor.size()-1].z();
 


### PR DESCRIPTION
The center was not correct for Scintillator rechits due to geometry changes.
Now the center is being dumped with the rest of the geometry.

@rovere @deguio 