### PR TITLE
Migrate HcalTrigTowerGeometryESProducer to EventSetup consumes

### DIFF
--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
@@ -1,13 +1,11 @@
 #include "HcalTrigTowerGeometryESProducer.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include <memory>
 
 HcalTrigTowerGeometryESProducer::HcalTrigTowerGeometryESProducer( const edm::ParameterSet & config )
-{
-  setWhatProduced( this );
-}
+  : topologyToken_{setWhatProduced( this ).consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{})}
+{}
 
 HcalTrigTowerGeometryESProducer::~HcalTrigTowerGeometryESProducer( void ) 
 {}
@@ -15,10 +13,8 @@ HcalTrigTowerGeometryESProducer::~HcalTrigTowerGeometryESProducer( void )
 std::unique_ptr<HcalTrigTowerGeometry>
 HcalTrigTowerGeometryESProducer::produce( const CaloGeometryRecord & iRecord )
 {
-    edm::ESHandle<HcalTopology> hcalTopology;
-    iRecord.getRecord<HcalRecNumberingRecord>().get( hcalTopology );
-
-    return std::make_unique<HcalTrigTowerGeometry>(&*hcalTopology);
+  const auto& hcalTopology = iRecord.get(topologyToken_);
+  return std::make_unique<HcalTrigTowerGeometry>(&hcalTopology);
 }
 
 void HcalTrigTowerGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
@@ -4,6 +4,7 @@
 # include <memory>
 
 # include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 # include "Geometry/Records/interface/CaloGeometryRecord.h"
 # include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 
@@ -20,6 +21,9 @@ public:
   std::unique_ptr<HcalTrigTowerGeometry> produce( const CaloGeometryRecord & );
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
+private:
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
 };
 
 #endif // HCAL_TOWER_ALGO_HCAL_TRIG_TOWER_GEOMETRY_ES_PRODUCER_H


### PR DESCRIPTION
#### PR description:

This PR migrates `HcalTrigTowerGeometryESProducer` (the sole ESProducer in Geometry/HcalTowerAlgo package) to EventSetup consumes (#26584).

#### PR validation:

The code compiles.
