### PR TITLE
PPS: bugfix in proton reconstruction.

### DIFF
--- a/CalibPPS/ESProducers/plugins/CTPPSInterpolatedOpticalFunctionsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSInterpolatedOpticalFunctionsESSource.cc
@@ -74,11 +74,12 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSInterpolatedO
     return currentData_;
 
   // is crossing angle reasonable (LHCInfo is correctly filled in DB)?
-  if (currentCrossingAngle_ == 0.)
+  if (hLHCInfo->crossingAngle() == 0.)
   {
     edm::LogInfo("CTPPSInterpolatedOpticalFunctionsESSource") << "Invalid crossing angle, no optical functions produced.";
 
     currentDataValid_ = false;
+    currentCrossingAngle_ = -1;
     currentData_ = std::make_shared<LHCInterpolatedOpticalFunctionsSetCollection>();
 
     return currentData_;

--- a/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -104,7 +104,7 @@ class CTPPSProtonProducer : public edm::stream::EDProducer<>
     ProtonReconstructionAlgorithm algorithm_;
 
     bool opticsValid_;
-    float currentCrossingAngle_;
+    edm::ESWatcher<CTPPSInterpolatedOpticsRcd> opticsWatcher_;
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -126,8 +126,7 @@ CTPPSProtonProducer::CTPPSProtonProducer(const edm::ParameterSet& iConfig) :
   max_n_timing_tracks_        (iConfig.getParameter<unsigned int>("max_n_timing_tracks")),
 
   algorithm_                  (iConfig.getParameter<bool>("fitVtxY"), iConfig.getParameter<bool>("useImprovedInitialEstimate"), verbosity_),
-  opticsValid_(false),
-  currentCrossingAngle_(-1.)
+  opticsValid_(false)
 {
   for (const std::string &sector : { "45", "56" })
   {
@@ -219,10 +218,8 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     iSetup.get<VeryForwardRealGeometryRecord>().get(hGeometry);
 
     // re-initialise algorithm upon crossing-angle change
-    if (hLHCInfo->crossingAngle() != currentCrossingAngle_)
+    if (opticsWatcher_.check(iSetup))
     {
-      currentCrossingAngle_ = hLHCInfo->crossingAngle();
-
       if (hOpticalFunctions->empty()) {
         edm::LogInfo("CTPPSProtonProducer") << "No optical functions available, reconstruction disabled.";
         algorithm_.release();


### PR DESCRIPTION
#### PR description:

This PR fixes two problems observed in rare conditions:
  * Fixed logic condition in ``CTPPSInterpolatedOpticalFunctionsESSource`` - the aim is to check the freshly-obtained xangle value, not the buffered one.
  * In ``CTPPSProtonProducer``, the re-initialisation is triggered with the help of an ESWatcher. With the recently introduced ``!hTracks->empty()`` condition, not all xangle transitions are seen anymore. Using ESWatcher is better anyway - the decision on updating optics-related data is made just on one place.

The fix is important for the UL re-reco. We apologise for the late submission.

#### PR validation:

Comparison on selected datasets, below, shows no difference wrt. the current master: blue = with this PR, red dashed = before this PR.
![make_cmp](https://user-images.githubusercontent.com/17830858/57527944-3c134b80-7331-11e9-98eb-cac0e85fc71b.png)

The problems addressed in this PR were discovered in a systematic test applied to (almost) all fills in which PPS Roman Pots participated (2016 to 2018). The problems occurred in about 5 out of 400 tests. After the fix all tests pass successfully. For the record, some of the originally failing input files were copied here:
  * /afs/cern.ch/user/j/jkaspar/public/ctpps/proton_reco_debug/fill5405_xangle140_beta0.30_ZeroBias.root
  * /afs/cern.ch/user/j/jkaspar/public/ctpps/proton_reco_debug/fill6960_xangle130_beta0.30_SingleMuon.root

These files are skims from the "official" AOD ntuples.

Finally, AddOnTests were run on LXPLUS, yielding:  46 tests passed, 1 failed. The failing test was running PhysicsTools/PatAlgos/test/IntegrationTest_cfg.py and the failure was due to an XROOT problem.
