### PR TITLE
updating SC reg corrector for UL regression

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -40,7 +40,8 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
-       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')
+       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
+       applySigmaIetaIphiBug = cms.bool(False)
        ),
 
     #threshold for final SuperCluster Et
@@ -109,7 +110,8 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
-       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')
+       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
+       applySigmaIetaIphiBug = cms.bool(False)
        ),
        
     #threshold for final SuperCluster Et

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -325,6 +325,7 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   {
     edm::ParameterSetDescription psd0;
     psd0.add<bool>("isHLT", false);
+    psd0.add<bool>("applySigmaIetaIphiBug", false);
     psd0.add<edm::InputTag>("ecalRecHitsEE",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
     psd0.add<edm::InputTag>("ecalRecHitsEB",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
     psd0.add<std::string>("regressionKeyEB","pfscecal_EBCorrection_offline_v1");

--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -68,6 +68,7 @@ class SCEnergyCorrectorSemiParm {
 
  private:
   bool isHLT_;
+  bool applySigmaIetaIphiBug_; //there was a bug in sigmaIetaIphi for the 74X application
   int nHitsAboveThreshold_;
   float eThreshold_;
 };


### PR DESCRIPTION
#### PR description:

This PR updates the mustache supercluster energy regression for incoming UL regression. 

The 2017 regression will be coming soon to a global tag and then 2016/2018 will follow in a few weeks. 

This PR is backwards compatible with the existing supercluster regression, as in it will work just fine with what is in the global tag right now. There are two changes

1) seed eta is added to the endcap as an input variable to help the regression be more stable with high eta. This is the last variable the regression and the current 74X regressions simply ignore it. 

2) a bug was fixed in the calculation of sigmaIEtaIPhi, it was always not set as sigmaIPhiIPhi was always set to std::numeric_limits<float>::max() when it was being constructed.   The option to reapply that bug is available. 

By default, this bug will be fixed which means the 74X regressions will get this fix and therefore the correction value for a given supercluster will change slightly after this change. This I do not consider an issue as

1. it only effects mustache superclusters whose exact energy is not terribly important except for the ECAL DPG who are the main users of this (most people use refined superclusters). It does enter E/gamma seeding though so can have some minor  effect there
1. the existing regressions are regardless broken right now when being run on 106X samples as they are not adapted to the new thresholds
1. the change is on average small.
https://sharper.web.cern.ch/sharper/cms/egamma/2019/May13th/cruijffSigmaBugComp.png
https://sharper.web.cern.ch/sharper/cms/egamma/2019/May13th/cruijffMeanBugComp.png
(with the differences being just bad fits)

#### PR validation:

The result of the new regression (which is not yet active, needs GT updates)
https://indico.cern.ch/event/817696/contributions/3423912/attachments/1840813/3018110/superClusterRegressionUL_ecalFollowup.pdf
https://indico.cern.ch/event/817696/contributions/3423665/attachments/1840744/3017891/UL_10X_regV2.pdf

Validating running this regression in CMSSW vs the ntuple training, saw 57 out 19,408,000 electrons have a difference between the two of more than 1 MeV. All were <0.5 GeV except one which had a delta of 1 GeV. Not entirely sure why, but very rare process and is good enough :)


