### PR TITLE
Update the RelMon blacklist file for histos in DT/Run summary/EventInfo/DCSContents with Nans 

### DIFF
--- a/Utilities/RelMon/data/blacklist.txt
+++ b/Utilities/RelMon/data/blacklist.txt
@@ -60,6 +60,11 @@ DT/EventInfo/DCSContents/hActiveUnits-2
 DT/EventInfo/DCSContents/hActiveUnits0
 DT/EventInfo/DCSContents/hActiveUnits1
 DT/EventInfo/DCSContents/hActiveUnits2
+DT/EventInfo/DCSContents/hDCSFracTrendWh-1
+DT/EventInfo/DCSContents/hDCSFracTrendWh-2
+DT/EventInfo/DCSContents/hDCSFracTrendWh0
+DT/EventInfo/DCSContents/hDCSFracTrendWh1
+DT/EventInfo/DCSContents/hDCSFracTrendWh2
 EcalBarrel/EBIntegrityTask/EBIT
 EcalBarrel/EBRawDataTask/EBRDT
 EcalBarrel/EBStatusFlagsTask/FEStatus/EBSFT


### PR DESCRIPTION
#### PR description:

My recent fix of #26593 excited error messages from comparison of 2-d histograms filled by Nans (probably adjusting the range for the comparison). The problem in itself is present since a while, linked to the module DTDCSByLumiSummary and apparently known, as in the RelMon blacklist some 1-d histograms from that module are already inserted https://cmssdt.cern.ch/lxr/source/Utilities/RelMon/data/blacklist.txt#0058
I update the blacklist to add also these 2-d histograms and avoid spurious failures in the PR tests. The issue should be revisited separately.

#### PR validation:

Unfortunately cms-bot always uses RelMon from the base release, so my previous test #26756 was inconclusive. Running manually a comparison for wf 136.85 with the same set of options used by the bot shows that the problem is reproducible and fixed by this update:

```
15:07 cmsdev25 6778> compare_using_files.py -d DT -B DQM/TimerService@3 -o out -C -R -p --no_successes -s b2b -t 0.9999999999 --standalone /build/fabiocos/106X/crash/due/CMSSW_10_6_X_2019-05-10-1100/work/136.85_RunEGamma2018A+RunEGamma2018A+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM/DQM_V0001_R000315489__Global__CMSSW_X_Y_Z__RECO.root /build/fabiocos/106X/crash/due/std/CMSSW_10_6_X_2019-05-10-1100/work/136.85_RunEGamma2018A+RunEGamma2018A+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM/DQM_V0001_R000315489__Global__CMSSW_X_Y_Z__RECO.root 
Analysing Histograms located in directory DT at: 
 o /build/fabiocos/106X/crash/due/CMSSW_10_6_X_2019-05-10-1100/work/136.85_RunEGamma2018A+RunEGamma2018A+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM/DQM_V0001_R000315489__Global__CMSSW_X_Y_Z__RECO.root
 o /build/fabiocos/106X/crash/due/std/CMSSW_10_6_X_2019-05-10-1100/work/136.85_RunEGamma2018A+RunEGamma2018A+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM/DQM_V0001_R000315489__Global__CMSSW_X_Y_Z__RECO.root
We have a Blacklist:
 o Directory TimerService at level 3
++++++++++++++++++++++++++++++
Output Directory will be  out
Studying directory Run summary, 1/1
Bin 1bin: bindiff nan
Histogram hDCSFracTrendWh-1 differs: nok: 2.0 ntot: 3
This comparison failed 0.666667
Bin 1bin: bindiff nan
Histogram hDCSFracTrendWh-2 differs: nok: 2.0 ntot: 3
This comparison failed 0.666667
Bin 1bin: bindiff nan
Histogram hDCSFracTrendWh2 differs: nok: 2.0 ntot: 3
This comparison failed 0.666667
Bin 1bin: bindiff nan
Histogram hDCSFracTrendWh0 differs: nok: 2.0 ntot: 3
This comparison failed 0.666667
Bin 1bin: bindiff nan
Histogram hDCSFracTrendWh1 differs: nok: 2.0 ntot: 3
This comparison failed 0.666667
 ->Appending Run summary... Appended.
Finished
Waiting for 1 threads to finish...
      * DT/Run summary/EventInfo/DCSContents:
       - hDCSFracTrendWh-1: BinToBin Test Failed (pval = 0.666666666667) 
       - hDCSFracTrendWh-2: BinToBin Test Failed (pval = 0.666666666667) 
       - hDCSFracTrendWh0: BinToBin Test Failed (pval = 0.666666666667) 
       - hDCSFracTrendWh1: BinToBin Test Failed (pval = 0.666666666667) 
       - hDCSFracTrendWh2: BinToBin Test Failed (pval = 0.666666666667) 

DT - summary of 2170 tests:
 o Failiures: 0.23% (5/2170)
 o Nulls: 0.00% (0/2170) 
 o Successes: 99.77% (2165/2170) 
 o Skipped: 0.00% (0/2170) 
 o Missing objects: 0
Pickleing the directory as out.pkl in dir /build/fabiocos/106X/relmon/CMSSW_10_6_X_2019-05-13-1100/work/out
Reading directory from out.pkl
Calculating stats for the directory...
Producing html...
15:09 cmsdev25 6779> compare_using_files.py -d DT -B DQM/TimerService@3 -o out -C -R -p --no_successes --use_black_file -s b2b -t 0.9999999999 --standalone /build/fabiocos/106X/crash/due/CMSSW_10_6_X_2019-05-10-1100/work/136.85_RunEGamma2018A+RunEGamma2018A+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM/DQM_V0001_R000315489__Global__CMSSW_X_Y_Z__RECO.root /build/fabiocos/106X/crash/due/std/CMSSW_10_6_X_2019-05-10-1100/work/136.85_RunEGamma2018A+RunEGamma2018A+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM/DQM_V0001_R000315489__Global__CMSSW_X_Y_Z__RECO.root  
Analysing Histograms located in directory DT at: 
 o /build/fabiocos/106X/crash/due/CMSSW_10_6_X_2019-05-10-1100/work/136.85_RunEGamma2018A+RunEGamma2018A+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM/DQM_V0001_R000315489__Global__CMSSW_X_Y_Z__RECO.root
 o /build/fabiocos/106X/crash/due/std/CMSSW_10_6_X_2019-05-10-1100/work/136.85_RunEGamma2018A+RunEGamma2018A+HLTDR2_2018+RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM+HARVEST2018_L1TEgDQM/DQM_V0001_R000315489__Global__CMSSW_X_Y_Z__RECO.root
We have a Blacklist:
 o Directory TimerService at level 3
++++++++++++++++++++++++++++++
Output Directory will be  out
Studying directory Run summary, 1/1
  Skipping DT/Run summary/EventInfo/DCSContents/hActiveUnits-2
  Skipping DT/Run summary/EventInfo/DCSContents/hActiveUnits-1
  Skipping DT/Run summary/EventInfo/DCSContents/hActiveUnits2
  Skipping DT/Run summary/EventInfo/DCSContents/hActiveUnits1
  Skipping DT/Run summary/EventInfo/DCSContents/hActiveUnits0
  Skipping DT/Run summary/EventInfo/DCSContents/hDCSFracTrendWh-1
  Skipping DT/Run summary/EventInfo/DCSContents/hDCSFracTrendWh-2
  Skipping DT/Run summary/EventInfo/DCSContents/hDCSFracTrendWh2
  Skipping DT/Run summary/EventInfo/DCSContents/hDCSFracTrendWh0
  Skipping DT/Run summary/EventInfo/DCSContents/hDCSFracTrendWh1
 ->Appending Run summary... Appended.
Finished

DT - summary of 2170 tests:
 o Failiures: 0.00% (0/2170)
 o Nulls: 0.00% (0/2170) 
 o Successes: 99.54% (2160/2170) 
 o Skipped: 0.46% (10/2170) 
 o Missing objects: 0
Pickleing the directory as out.pkl in dir /build/fabiocos/106X/relmon/CMSSW_10_6_X_2019-05-13-1100/work/out
Reading directory from out.pkl
Calculating stats for the directory...
Producing html...

```