### PR TITLE
cleanup: use LocalError.h directly from GeometrySurface instead of indirectly via GeometryCommonDetAlgo

### DIFF
--- a/Alignment/APEEstimation/plugins/ApeEstimator.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimator.cc
@@ -49,7 +49,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
-#include "DataFormats/GeometryCommonDetAlgo/interface/LocalError.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"

--- a/Alignment/CommonAlignment/src/Alignable.cc
+++ b/Alignment/CommonAlignment/src/Alignable.cc
@@ -13,6 +13,7 @@
 #include "CondFormats/Alignment/interface/AlignmentSurfaceDeformations.h"
 
 #include "Geometry/CommonTopologies/interface/SurfaceDeformation.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 //__________________________________________________________________________________________________
 Alignable::Alignable(align::ID id, const AlignableSurface& surf):

--- a/DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h
+++ b/DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h
@@ -2,8 +2,9 @@
 #define ErrorFrameTransformer_H
 
 #include "DataFormats/GeometrySurface/interface/Surface.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometrySurface/interface/LocalErrorExtended.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
-#include "DataFormats/GeometryCommonDetAlgo/interface/LocalError.h"
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
 
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"

--- a/DataFormats/GeometryCommonDetAlgo/interface/LocalError.h
+++ b/DataFormats/GeometryCommonDetAlgo/interface/LocalError.h
@@ -1,7 +1,0 @@
-#ifndef LocalError_H
-#define LocalError_H
-
-#include "DataFormats/GeometrySurface/interface/LocalError.h"
-#include "DataFormats/GeometrySurface/interface/LocalErrorExtended.h"
-
-#endif  // LocalError_H

--- a/Geometry/CommonDetUnit/interface/MuonGeomDet.h
+++ b/Geometry/CommonDetUnit/interface/MuonGeomDet.h
@@ -3,7 +3,8 @@
 
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "DataFormats/GeometryCommonDetAlgo/interface/LocalError.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+#include "DataFormats/GeometrySurface/interface/LocalErrorExtended.h"
 
 class MuonGeomDet : public GeomDet {
 protected :

--- a/Geometry/CommonTopologies/interface/Topology.h
+++ b/Geometry/CommonTopologies/interface/Topology.h
@@ -2,7 +2,7 @@
 #define Geometry_CommonTopologies_Topology_H
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
-#include "DataFormats/GeometryCommonDetAlgo/interface/LocalError.h"
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"


### PR DESCRIPTION
#### PR description:

Remove GeometryCommonDetAlgo/interface/LocalError.h and use GeometrySurface/interface/LocalError.h directly. This avoids duplicate LocalError definitions with root CXXModules

#### PR validation:

Local compilation works
```
git checkdeps -a
scram build
```

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
