### PR TITLE
Adding a fine-tuned version of the 'betastar' kind of variables.

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -222,8 +222,10 @@ jetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         chEmEF = Var("chargedEmEnergyFraction()", float, doc="charged Electromagnetic Energy Fraction", precision= 6),
         neEmEF = Var("neutralEmEnergyFraction()", float, doc="neutral Electromagnetic Energy Fraction", precision= 6),
         muEF = Var("muonEnergyFraction()", float, doc="muon Energy Fraction", precision= 6),
-        jercCHPUF = Var("userFloat('jercCHPUF')", float, doc="Pileup Charged Hadron Energy Fraction with the JERC group definition", precision= 6),
-        jercCHF = Var("userFloat('jercCHF')", float, doc="Charged Hadron Energy Fraction with the JERC group definition", precision= 6),
+        chFPV0EF = Var("userFloat('chFPV0EF')", float, doc="charged energy fraction with fromPV==0 (removed by the CHS method), w.r.t. Raw (un    corrected) CHS jet energy. Previously called betastar.", precision= 6),
+        chFPV1EF = Var("userFloat('chFPV1EF')", float, doc="charged energy fraction with fromPV==1 (included by the CHS method), w.r.t. Raw (u    ncorrected) CHS jet energy.", precision= 6),
+        chFPV2EF = Var("userFloat('chFPV2EF')", float, doc="charged energy fraction with fromPV==2 (included by the CHS method), w.r.t. Raw (u    ncorrected) CHS jet energy.", precision= 6),
+        chFPV3EF = Var("userFloat('chFPV3EF')", float, doc="charged energy fraction with fromPV==3 (included by the CHS method), w.r.t. Raw (u    ncorrected) CHS jet energy.", precision= 6),
     )
 )
 

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -137,8 +137,10 @@ updatedJetsWithUserData = cms.EDProducer("PATJetUserDataEmbedder",
          ptD = cms.InputTag("bJetVars:ptD"),
          genPtwNu = cms.InputTag("bJetVars:genPtwNu"),
          qgl = cms.InputTag('qgtagger:qgLikelihood'),
-         jercCHPUF = cms.InputTag("jercVars:chargedHadronPUEnergyFraction"),
-         jercCHF = cms.InputTag("jercVars:chargedHadronCHSEnergyFraction"),
+         chFPV0EF = cms.InputTag("jercVars:chargedFromPV0EnergyFraction"),
+         chFPV1EF = cms.InputTag("jercVars:chargedFromPV1EnergyFraction"),
+         chFPV2EF = cms.InputTag("jercVars:chargedFromPV2EnergyFraction"),
+         chFPV3EF = cms.InputTag("jercVars:chargedFromPV3EnergyFraction"),         
          ),
      userInts = cms.PSet(
         tightId = cms.InputTag("tightJetId"),
@@ -560,7 +562,7 @@ from RecoJets.JetProducers.QGTagger_cfi import  QGTagger
 qgtagger=QGTagger.clone(srcJets="updatedJets",srcVertexCollection="offlineSlimmedPrimaryVertices")
 
 #before cross linking
-jetSequence = cms.Sequence(jetCorrFactorsNano+updatedJets+tightJetId+tightJetIdLepVeto+bJetVars+jercVars+qgtagger+updatedJetsWithUserData+jetCorrFactorsAK8+updatedJetsAK8+tightJetIdAK8+tightJetIdLepVetoAK8+updatedJetsAK8WithUserData+chsForSATkJets+softActivityJets+softActivityJets2+softActivityJets5+softActivityJets10+finalJets+finalJetsAK8)
+jetSequence = cms.Sequence(jetCorrFactorsNano+updatedJets+tightJetId+tightJetIdLepVeto+bJetVars+qgtagger+jercVars+updatedJetsWithUserData+jetCorrFactorsAK8+updatedJetsAK8+tightJetIdAK8+tightJetIdLepVetoAK8+updatedJetsAK8WithUserData+chsForSATkJets+softActivityJets+softActivityJets2+softActivityJets5+softActivityJets10+finalJets+finalJetsAK8)
 
 _jetSequence_2016 = jetSequence.copy()
 _jetSequence_2016.insert(_jetSequence_2016.index(tightJetId), looseJetId)


### PR DESCRIPTION
#### PR description:

Adding some algorithmical and technical clarifications to the "Betastar" variables needed by the JERC group - originally implemented by @rappoccio . In the original implementation there were two variables: "chargedHadronCHSEnergyFraction" and "chargedHadronPUEnergyFraction". The latter was what we really needed - and corresponds to the old definition of a "betastar" variable. This means the fraction of charged energy removed by the CHS algorithm, w.r.t. the CHS jet energy. The former was added by @rappoccio , as our algorithms produced a slightly different charged hadron energy fraction than the standard algorithms. Below, a closer listing of updates and reasons for them is given.

- The term "Hadron" was removed from the naming scheme, as we are actually monitoring all charged particles.
- For JERC-related debugging purposes, "chargedHadronCHSEnergyFraction" is not an interesting variable, but its subcategories (fromPV==1, fromPV==2, fromPV==3) are. Hence, "chargedHadronCHSEnergyFraction" was replaced by three such variables, the sum of which gives the original "chargedHadronCHSEnergyFraction".
- It was decided to not use the old and confusing naming schemes (beta, betastar), but to continue with clear and straighforward variable names: "chargedFromPV0EnergyFraction", "chargedFromPV1EnergyFraction", "chargedFromPV2EnergyFraction" and "chargedFromPV3EnergyFraction".
- It is acknowledged that making changes to the variable names now - as the original naming scheme has already been integrated to cmssw - carries its problems. However, as the corresponding NANOAOD PR [1] has not yet been accepted, no working piece of code uses these variables, currently. Moreover, we are at the present the main consumers of these "betastar" variables and therefore now seems like a good time to think the variable names through thoroughly (to make things easier and more understandable for people using these pieces of code in the future).
- The algorithmical part was clarified for "chargedFromPV0EnergyFraction" (former "chargedHadronPUEnergyFraction"): we associate each charged particle with fromPV==0 to the jet that it is closest to (in eta-phi plane), and keep it only if it is close enough to the jet axis (typically, delta R < 0.4). The formerly used algorithm allowed double-counting of charged particles, as they could have been associated with multiple jets.
- For the variables "chargedFromPVXEnergyFraction" (X=1,2,3) we simply loop through the jet constituents and look at the value of fromPV.

#### PR validation:

The code has been privately tested using the generic NANOAOD production line. The file jets_cff.py (in PhysicsTools/NanoAOD/python) was replaced by the one found in the open pull request by @rappoccio : [1]

[1] https://github.com/cms-nanoAOD/cmssw/pull/246

Tagging @kirschen for the reference.