### PR TITLE
TkAl: Improving job output copying + error reporting

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
@@ -56,6 +56,7 @@ for i in xrange(len(lib.JOBID)):
     cmdNotFound = 0
     insuffPriv = 0
     quotaspace = 0
+    copyerr=0
 
     kill_reason = None
     pedeLogErrStr = ""
@@ -102,6 +103,8 @@ for i in xrange(len(lib.JOBID)):
                     # AP 26.11.2009 Insufficient privileges to rfcp files
                     if re.search(re.compile('stage_put: Insufficient user privileges',re.M), line):
                         insuffPriv = 1
+                    if re.search(re.compile('Give up doing',re.M), line):
+                        copyerr = 1
                     # AP 05.11.2015 Extract cpu-time.
                     # STDOUT doesn't contain NCU anymore. Now KSI2K and HS06 seconds are displayed.
                     # The ncuFactor is calculated from few samples by comparing KSI2K seconds with
@@ -217,7 +220,7 @@ for i in xrange(len(lib.JOBID)):
                         nEvent = int(array[5])
 
             if logZipped == 'true':
-                os.system('gzip '+eazeLog)
+                os.system('gzip -f '+eazeLog)
 
         else:   # no access to alignment.log
             print('mps_check.py cannot find',eazeLog,'to test')
@@ -325,7 +328,7 @@ for i in xrange(len(lib.JOBID)):
                             pedeLogWrnStr += line
 
                 if logZipped == 'true':
-                    os.system('gzip '+eazeLog)
+                    os.system('gzip -f '+eazeLog)
             else:
                 print('mps_check.py cannot find',eazeLog,'to test')
 
@@ -353,7 +356,7 @@ for i in xrange(len(lib.JOBID)):
                                 pedeLogErr = 1
                                 pedeLogErrStr += line
                 if logZipped == 'true':
-                    os.system('gzip '+eazeLog)
+                    os.system('gzip -f '+eazeLog)
             else:
                 print('mps_check.py cannot find',eazeLog,'to test')
 
@@ -442,6 +445,11 @@ for i in xrange(len(lib.JOBID)):
             print(lib.JOBDIR[i],lib.JOBID[i],'Job not ended')
             remark = 'job not ended'
             okStatus = 'FAIL'
+        if copyerr == 1:
+            print(lib.JOBDIR[i],lib.JOBID[i],'Copy to eos failed')
+            remark = 'copy to eos failed'
+            okStatus = 'FAIL'
+
 
         # print warning line to stdout
         if okStatus != "OK":

--- a/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/templates/mps_runMille_template.sh
@@ -25,7 +25,7 @@ trap clean_up HUP INT TERM SEGV USR2 XCPU XFSZ IO
 # a helper function to repeatedly try failing copy commands
 untilSuccess () {
 # trying "${1} ${2} ${3} > /dev/null" until success, if ${4} is a
-# positive number run {1} with -f flag,
+# positive number run {1} with -f flag and using --cksum md5,
 # break after ${5} tries (with four arguments do up to 5 tries).
     if  [[ ${#} -lt 4 || ${#} -gt 5 ]]
     then
@@ -43,7 +43,7 @@ untilSuccess () {
 
     if [[ ${4} -gt 0 ]]
     then 
-        ${1} -f ${2} ${3} > /dev/null
+        ${1} -f --cksum md5 ${2} ${3} > /dev/null
     else 
         ${1} ${2} ${3} > /dev/null
     fi
@@ -53,7 +53,7 @@ untilSuccess () {
         then # ... but not until infinity!
             if [[ ${4} -gt 0 ]]
             then
-                echo ${0}: Give up doing \"${1} -f ${2} ${3} \> /dev/null\".
+                echo ${0}: Give up doing \"${1} -f --cksum md5 ${2} ${3} \> /dev/null\".
                 return 1
             else
                 echo ${0}: Give up doing \"${1} ${2} ${3} \> /dev/null\".
@@ -63,9 +63,9 @@ untilSuccess () {
         TRIES=$((${TRIES}+1))
         if [[ ${4} -gt 0 ]]
         then
-            echo ${0}: WARNING, problems with \"${1} -f ${2} ${3} \> /dev/null\", try again.
+            echo ${0}: WARNING, problems with \"${1} -f --cksum md5 ${2} ${3} \> /dev/null\", try again.
             sleep $((${TRIES}*5)) # for before each wait a litte longer...
-            ${1} -f ${2} ${3} > /dev/null
+            ${1} -f --cksum md5 ${2} ${3} > /dev/null
         else
             echo ${0}: WARNING, problems with \"${1} ${2} ${3} \> /dev/null\", try again.
             sleep $((${TRIES}*5)) # for before each wait a litte longer...
@@ -75,7 +75,7 @@ untilSuccess () {
 
     if [[ ${4} -gt 0 ]]
     then
-        echo successfully executed \"${1} -f ${2} ${3} \> /dev/null\"
+        echo successfully executed \"${1} -f --cksum md5 ${2} ${3} \> /dev/null\"
     else
         echo successfully executed \"${1} ${2} ${3} \> /dev/null\"
     fi


### PR DESCRIPTION
#### PR description:
This improves the mille step of the MillePede alignment algorithm. At the end of the job, the output is copied from the batch node to eos. Recently we have noticed more frequent failures in this procedure. The changes in this PR add a checksum check to the xrdcp command used to copy the files. In addition, in the job status accounting at the end, copy failures are now reported

#### PR validation:
Tested on around 300 jobs, works as expected. Only affects jobs run as part of millepede alignment - no other dependencies. Should not affect the output of standard tests

#### if this PR is a backport please specify the original PR:
Not a backport
