### PR TITLE
DyT v2 on up to eta 1p2

### DIFF
--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -29,8 +29,8 @@ GlobalTrackQualityProducer::GlobalTrackQualityProducer(const edm::ParameterSet& 
 {
   // service parameters
   edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
-  theService = new MuonServiceProxy(serviceParameters);     
-  
+  theService = new MuonServiceProxy(serviceParameters);
+
   // TrackRefitter parameters
   edm::ConsumesCollector iC  = consumesCollector();
   edm::ParameterSet refitterParameters = iConfig.getParameter<edm::ParameterSet>("RefitterParameters");
@@ -60,7 +60,7 @@ void
 GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   const std::string theCategory = "Muon|RecoMuon|GlobalTrackQualityProducer";
-  
+
   theService->update(iSetup);
 
   theGlbRefitter->setEvent(iEvent);
@@ -70,7 +70,7 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   // Take the GLB muon container(s)
   edm::Handle<reco::TrackCollection> glbMuons;
   iEvent.getByToken(glbMuonsToken,glbMuons);
-  
+
   edm::Handle<reco::MuonTrackLinksCollection>    linkCollectionHandle;
   iEvent.getByToken(linkCollectionToken,linkCollectionHandle);
 
@@ -83,7 +83,7 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   // reserve some space
   std::vector<reco::MuonQuality> valuesQual;
   valuesQual.reserve(glbMuons->size());
-  
+
   int trackIndex = 0;
   for (reco::TrackCollection::const_iterator track = glbMuons->begin(); track!=glbMuons->end(); ++track , ++trackIndex) {
     reco::TrackRef glbRef(glbMuons,trackIndex);
@@ -92,13 +92,13 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
     std::vector<Trajectory> refitted=theGlbRefitter->refit(*track,1,tTopo);
 
     LogTrace(theCategory)<<"GLBQual N refitted " << refitted.size();
-    
+
     std::pair<double,double> thisKink;
     double relative_muon_chi2 = 0.0;
     double relative_tracker_chi2 = 0.0;
     double glbTrackProbability = 0.0;
     if(!refitted.empty()) {
-      thisKink = kink(refitted.front()) ;      
+      thisKink = kink(refitted.front()) ;
       std::pair<double,double> chi = newChi2(refitted.front());
       relative_muon_chi2 = chi.second; //normalized inside to /sum(muHits.dimension)
       relative_tracker_chi2 = chi.first; //normalized inside to /sum(tkHits.dimension)
@@ -120,7 +120,7 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 	{
 	  if ( links->trackerTrack().isNull() ||
 	       links->standAloneTrack().isNull() ||
-	       links->globalTrack().isNull() ) 
+	       links->globalTrack().isNull() )
 	    {
 	      edm::LogWarning(theCategory) << "Global muon links to constituent tracks are invalid. There should be no such object. Muon is skipped.";
 	      continue;
@@ -167,7 +167,7 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   edm::ValueMap<reco::MuonQuality>::Filler fillerQual(*outQual);
   fillerQual.insert(glbMuons, valuesQual.begin(), valuesQual.end());
   fillerQual.fill();
-  
+
   // put value map into event
   iEvent.put(std::move(outQual));
 }
@@ -175,22 +175,22 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 std::pair<double,double> GlobalTrackQualityProducer::kink(Trajectory& muon) const {
 
   const std::string theCategory = "Muon|RecoMuon|GlobalTrackQualityProducer";
-   
+
   using namespace std;
   using namespace edm;
   using namespace reco;
- 
+
   double result = 0.0;
   double resultGlb = 0.0;
 
-     
+
   typedef TransientTrackingRecHit::ConstRecHitPointer 	ConstRecHitPointer;
   typedef ConstRecHitPointer RecHit;
   typedef std::vector<TrajectoryMeasurement>::const_iterator TMI;
 
 
   vector<TrajectoryMeasurement> meas = muon.measurements();
-  
+
   for ( TMI m = meas.begin(); m != meas.end(); m++ ) {
     TransientTrackingRecHit::ConstRecHitPointer hit = m->recHit();
 
@@ -203,7 +203,7 @@ std::pair<double,double> GlobalTrackQualityProducer::kink(Trajectory& muon) cons
     }
 
     //if ( !ok ) continue;
-    
+
     const TrajectoryStateOnSurface& tsos = (*m).predictedState();
 
 
@@ -233,12 +233,12 @@ std::pair<double,double> GlobalTrackQualityProducer::kink(Trajectory& muon) cons
       if(ok) result += s;
       resultGlb += s;
     }
-    
+
   }
-  
-  
+
+
   return std::pair<double,double>(result,resultGlb);
-  
+
 }
 
 std::pair<double,double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) const {
@@ -252,7 +252,7 @@ std::pair<double,double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) c
   double tkChi2 = 0.0;
   unsigned int muNdof = 0;
   unsigned int tkNdof = 0;
-  
+
   typedef TransientTrackingRecHit::ConstRecHitPointer 	ConstRecHitPointer;
   typedef ConstRecHitPointer RecHit;
   typedef vector<TrajectoryMeasurement>::const_iterator TMI;
@@ -269,7 +269,7 @@ std::pair<double,double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) c
     if (preciseHit->isValid() && uptsos.isValid()) {
       estimate = theEstimator->estimate(uptsos, *preciseHit ).second;
     }
-    
+
     //LogTrace(theCategory) << "estimate " << estimate << " TM.est " << m->estimate();
     //UNUSED:    double tkDiff = 0.0;
     //UNUSED:    double staDiff = 0.0;
@@ -284,7 +284,7 @@ std::pair<double,double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) c
       muNdof += hit->dimension();
     }
   }
-  
+
   //For tkNdof < 6, should a large number or something else
   // be used instead of just tkChi2 directly?
   if (tkNdof > 5 ) {tkChi2 /= (tkNdof-5.); }
@@ -294,16 +294,16 @@ std::pair<double,double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) c
   if (muNdof > 5 ) {muChi2 /= (muNdof-5.); }
 
   return std::pair<double,double>(tkChi2,muChi2);
-       
+
 }
 
 //
 // calculate the tail probability (-ln(P)) of a fit
 //
-double 
+double
 GlobalTrackQualityProducer::trackProbability(Trajectory& track) const {
 
-  if ( track.ndof() > 0 && track.chiSquared() > 0 ) { 
+  if ( track.ndof() > 0 && track.chiSquared() > 0 ) {
     return -LnChiSquaredProbability(track.chiSquared(), track.ndof());
   } else {
     return 0.0;
@@ -349,7 +349,7 @@ void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions
     descGlbMuonRefitter.add<int>("DYTselector",1);
     descGlbMuonRefitter.add<bool>("DYTupdator", false);
     descGlbMuonRefitter.add<bool>("DYTuseAPE", false );
-    descGlbMuonRefitter.add<bool>("DYTuseThrsParametrization", false);
+    descGlbMuonRefitter.add<bool>("DYTuseThrsParametrization", true);
     {
       edm::ParameterSetDescription descDYTthrs;
       descDYTthrs.add<std::vector<double>>("eta0p8", {1,-0.919853, 0.990742});

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -33,7 +33,7 @@ GlobalMuonRefitter = cms.PSet(
     DYTupdator = cms.bool(True),
     DYTuseAPE = cms.bool(False),
     ## Parameters for DYT threshold parametrization
-    DYTuseThrsParametrization = cms.bool(False),
+    DYTuseThrsParametrization = cms.bool(True),
     DYTthrsParameters = cms.PSet(
                                   eta0p8 = cms.vdouble(1, -0.919853, 0.990742),
                                   eta1p2 = cms.vdouble(1, -0.897354, 0.987738),

--- a/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalTrajectoryBuilderCommon_cff.py
@@ -57,7 +57,7 @@ GlobalTrajectoryBuilderCommon = cms.PSet(
         DYTupdator = cms.bool(False),
         DYTuseAPE = cms.bool(False),
         ## Parameters for DYT threshold parametrization
-        DYTuseThrsParametrization = cms.bool(False),
+        DYTuseThrsParametrization = cms.bool(True),
         DYTthrsParameters = cms.PSet(
                                   eta0p8 = cms.vdouble(1, -0.919853, 0.990742),
                                   eta1p2 = cms.vdouble(1, -0.897354, 0.987738),

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -79,7 +79,7 @@ void DynamicTruncation::updateWithDThits(TrajectoryStateOnSurface& tsos, DTRecSe
   ConstRecHitContainer tmprecHits;
   vector<const TrackingRecHit*> DTrh = bestDTSeg.recHits();
   for (vector<const TrackingRecHit*>::iterator it = DTrh.begin(); it != DTrh.end(); it++) {
-    tmprecHits.push_back(theMuonRecHitBuilder->build(*it)); 
+    tmprecHits.push_back(theMuonRecHitBuilder->build(*it));
   }
   sort(tmprecHits);
   for (ConstRecHitContainer::const_iterator it = tmprecHits.begin(); it != tmprecHits.end(); ++it) {
@@ -101,7 +101,7 @@ void DynamicTruncation::updateWithCSChits(TrajectoryStateOnSurface& tsos, CSCSeg
   sort(tmprecHits);
   for (ConstRecHitContainer::const_iterator it = tmprecHits.begin(); it != tmprecHits.end(); ++it) {
     const CSCLayer* cscLayer = cscGeom->layer((*it)->det()->geographicalId());
-    TrajectoryStateOnSurface temp = propagator->propagate(tsos, cscLayer->surface());  
+    TrajectoryStateOnSurface temp = propagator->propagate(tsos, cscLayer->surface());
     if (temp.isValid()) {
       TrajectoryStateOnSurface tempTsos = updatorHandle->update(temp, **it);
       if (tempTsos.isValid() ) tsos = tempTsos;
@@ -199,7 +199,7 @@ void DynamicTruncation::filteringAlgo() {
   compatibleDets(currentState, compatibleIds);
 
   // Fill segment maps
-  fillSegmentMaps(compatibleIds, dtSegMap, cscSegMap); 
+  fillSegmentMaps(compatibleIds, dtSegMap, cscSegMap);
 
   // Do a preliminary fit
   if (useDBforThr) preliminaryFit(compatibleIds, dtSegMap, cscSegMap);
@@ -214,7 +214,7 @@ void DynamicTruncation::filteringAlgo() {
     vector<DTRecSegment4D> dtSegs   = dtSegMap[it->first];
     vector<CSCSegment> cscSegs      = cscSegMap[it->first];
 
-    // DT case: find the most compatible segment 
+    // DT case: find the most compatible segment
     TrajectoryStateOnSurface tsosDTlayer;
     testDTstation(currentState, dtSegs, bestDTEstimator, bestDTSeg, tsosDTlayer);
 
@@ -224,7 +224,7 @@ void DynamicTruncation::filteringAlgo() {
 
     // Decide whether to keep the layer or not
     bool chosenLayer = chooseLayers(incompConLay, bestDTEstimator, bestDTSeg, tsosDTlayer, bestCSCEstimator, bestCSCSeg, tsosCSClayer);
-    fillDYTInfos(stLayer, chosenLayer, incompConLay, bestDTEstimator, bestCSCEstimator, bestDTSeg, bestCSCSeg); 
+    fillDYTInfos(stLayer, chosenLayer, incompConLay, bestDTEstimator, bestCSCEstimator, bestDTSeg, bestCSCSeg);
   }
   //cout << "Number of used stations = " << nStationsUsed << endl;
 }
@@ -245,7 +245,7 @@ int DynamicTruncation::stationfromDet(DetId const& det) {
 
 
 //===> fillDYTInfos
-void DynamicTruncation::fillDYTInfos(int const &st, bool const &chosenLayer, int &incompConLay, 
+void DynamicTruncation::fillDYTInfos(int const &st, bool const &chosenLayer, int &incompConLay,
 				     double const &bestDTEstimator, double const &bestCSCEstimator,
 				     DTRecSegment4D const &bestDTSeg, CSCSegment const &bestCSCSeg) {
   if (chosenLayer) {
@@ -253,7 +253,7 @@ void DynamicTruncation::fillDYTInfos(int const &st, bool const &chosenLayer, int
     incompConLay = 0;
     if (bestDTEstimator <= bestCSCEstimator) {
       estimatorMap[st] = bestDTEstimator;
-      DetId id(bestDTSeg.chamberId()); 
+      DetId id(bestDTSeg.chamberId());
       idChamberMap[st] = id;
     } else {
       DetId id(bestCSCSeg.cscDetId());
@@ -282,7 +282,7 @@ void DynamicTruncation::compatibleDets(TrajectoryStateOnSurface &tsos, map<int, 
 	navLayers[ilayer]->subDetector() != GeomDetEnumerators::CSC) continue;
     ilayerCorrected++;
     vector<DetLayer::DetWithState> comps = navLayers[ilayer]->compatibleDets(currentState, *propagatorCompatibleDet, *theEstimator);
-    //cout << comps.size() << " compatible Dets with " << navLayers[ilayer]->subDetector() << " Layer " << ilayer << " " 
+    //cout << comps.size() << " compatible Dets with " << navLayers[ilayer]->subDetector() << " Layer " << ilayer << " "
     //<< dumper.dumpLayer(navLayers[ilayer]);
     if (!comps.empty()) {
       for ( unsigned int icomp=0; icomp<comps.size(); icomp++ ) {
@@ -318,7 +318,7 @@ void DynamicTruncation::fillSegmentMaps( map<int, vector<DetId> > &compatibleIds
 
 
 //===> testDTstation
-void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState, vector<DTRecSegment4D> const &segments, 
+void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState, vector<DTRecSegment4D> const &segments,
 				      double &bestEstimator, DTRecSegment4D &bestSeg, TrajectoryStateOnSurface &tsosdt) {
   if (segments.empty()) return;
   for (unsigned int iSeg = 0; iSeg < segments.size(); iSeg++) {
@@ -331,7 +331,7 @@ void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState, v
     StateSegmentMatcher estim(tsosdt, segments[iSeg], apeLoc);
     double estimator = estim.value();
     //cout << "estimator DT = " << estimator << endl;
-    if (estimator >= bestEstimator) continue; 
+    if (estimator >= bestEstimator) continue;
     bestEstimator = estimator;
     bestSeg = segments[iSeg];
   }
@@ -339,7 +339,7 @@ void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState, v
 
 
 //===> testCSCstation
-void DynamicTruncation::testCSCstation(TrajectoryStateOnSurface &startingState, vector<CSCSegment> const &segments, 
+void DynamicTruncation::testCSCstation(TrajectoryStateOnSurface &startingState, vector<CSCSegment> const &segments,
 				       double &bestEstimator, CSCSegment &bestSeg, TrajectoryStateOnSurface &tsoscsc) {
   if (segments.empty()) return;
   for (unsigned int iSeg = 0; iSeg < segments.size(); iSeg++) {
@@ -367,7 +367,7 @@ void DynamicTruncation::useSegment(DTRecSegment4D const &bestDTSeg, TrajectorySt
 }
 
 
-//===> useSegment 
+//===> useSegment
 void DynamicTruncation::useSegment(CSCSegment const &bestCSCSeg, TrajectoryStateOnSurface const &tsosCSC) {
   result.push_back(theMuonRecHitBuilder->build(&bestCSCSeg));
   if (doUpdateOfKFStates) updateWithCSChits(currentState, bestCSCSeg);
@@ -423,9 +423,9 @@ void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, m
   }
   if (!prelFitMeas.empty()) prelFitMeas.pop_back();
   for (auto imrh = prelFitMeas.rbegin(); imrh != prelFitMeas.rend(); ++imrh) {
-    DetId id = (*imrh)->geographicalId(); 
+    DetId id = (*imrh)->geographicalId();
     TrajectoryStateOnSurface tmp = propagatorPF->propagate(prelFitState, theG->idToDet(id)->surface());
-    if (tmp.isValid()) prelFitState = tmp; 
+    if (tmp.isValid()) prelFitState = tmp;
   }
   muonPTest  = prelFitState.globalMomentum().perp();
   muonETAest = prelFitState.globalMomentum().eta();
@@ -433,17 +433,17 @@ void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, m
 
 
 //===> chooseLayers
-bool DynamicTruncation::chooseLayers(int &incompLayers, double const &bestDTEstimator, DTRecSegment4D const &bestDTSeg, TrajectoryStateOnSurface const &tsosDT, 
+bool DynamicTruncation::chooseLayers(int &incompLayers, double const &bestDTEstimator, DTRecSegment4D const &bestDTSeg, TrajectoryStateOnSurface const &tsosDT,
 				     double const &bestCSCEstimator, CSCSegment const &bestCSCSeg, TrajectoryStateOnSurface const &tsosCSC) {
   double initThr = MAX_THR;
   if (bestDTEstimator == MAX_THR && bestCSCEstimator == MAX_THR) return false;
   if (bestDTEstimator <= bestCSCEstimator) {
     // Get threshold for the chamber
     if (useDBforThr) getThresholdFromDB(initThr, DetId(bestDTSeg.chamberId()));
-    else getThresholdFromCFG(initThr, DetId(bestDTSeg.chamberId())); 
+    else getThresholdFromCFG(initThr, DetId(bestDTSeg.chamberId()));
     if (DYTselector == 0 || (DYTselector == 1 && bestDTEstimator < initThr) ||
 	(DYTselector == 2 && incompLayers < 2 && bestDTEstimator < initThr)) {
-      useSegment(bestDTSeg, tsosDT); 
+      useSegment(bestDTSeg, tsosDT);
       return true;
     }
   } else {
@@ -484,7 +484,9 @@ void DynamicTruncation::correctThrByPAndEta(double& thr) {
       return thr50 * ( 1 + p0*p_reco + std::pow( this->p_reco, p1));
     };
 
-    thr = parametricThreshold();
+    std::set<dyt_utils::etaRegion> regionsToExclude = {dyt_utils::etaRegion::eta2p0,dyt_utils::etaRegion::eta2p2, dyt_utils::etaRegion::eta2p4 };
+
+    if ( ! regionsToExclude.count(this->region) ) thr = parametricThreshold();
 }
 
 void DynamicTruncation::setEtaRegion(){
@@ -512,6 +514,7 @@ void DynamicTruncation::getThresholdFromCFG(double& thr, DetId const& id) {
   }
 
   if (useParametrizedThr) correctThrByPAndEta(thr);
+
 }
 
 

--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
@@ -1,5 +1,5 @@
 /**  \class L3MuonProducer
- * 
+ *
  *   L3 muon reconstructor:
  *   reconstructs muons using DT, CSC, RPC and tracker
  *   information,<BR>
@@ -51,18 +51,18 @@ L3MuonProducer::L3MuonProducer(const ParameterSet& parameterSet) {
 
   // TrackLoader parameters
   ParameterSet trackLoaderParameters = parameterSet.getParameter<ParameterSet>("TrackLoaderParameters");
-  
+
   // the services
   theService = new MuonServiceProxy(serviceParameters);
   ConsumesCollector iC = consumesCollector();
-  
+
   // instantiate the concrete trajectory builder in the Track Finder
   MuonTrackLoader* mtl = new MuonTrackLoader(trackLoaderParameters,iC,theService);
   L3MuonTrajectoryBuilder* l3mtb = new L3MuonTrajectoryBuilder(trajectoryBuilderParameters, theService,iC);
   theTrackFinder = new MuonTrackFinder(l3mtb, mtl);
 
   theL2SeededTkLabel = trackLoaderParameters.getUntrackedParameter<std::string>("MuonSeededTracksInstance",std::string());
-  
+
   produces<reco::TrackCollection>(theL2SeededTkLabel);
   produces<TrackingRecHitCollection>(theL2SeededTkLabel);
   produces<reco::TrackExtraCollection>(theL2SeededTkLabel);
@@ -96,9 +96,9 @@ L3MuonProducer::~L3MuonProducer() {
 // reconstruct muons
 //
 void L3MuonProducer::produce(Event& event, const EventSetup& eventSetup) {
-  const string metname = "Muon|RecoMuon|L3MuonProducer";  
+  const string metname = "Muon|RecoMuon|L3MuonProducer";
   LogTrace(metname)<<endl<<endl<<endl;
-  LogTrace(metname)<<"L3 Muon Reconstruction started"<<endl;  
+  LogTrace(metname)<<"L3 Muon Reconstruction started"<<endl;
 
   typedef vector<Trajectory> TrajColl;
 
@@ -116,7 +116,7 @@ void L3MuonProducer::produce(Event& event, const EventSetup& eventSetup) {
   vector<MuonTrajectoryBuilder::TrackCand> L2TrackCands;
 
 
-  event.getByToken(l2MuonTrajToken_, L2MuonsTraj);      
+  event.getByToken(l2MuonTrajToken_, L2MuonsTraj);
 
   edm::Handle<TrajTrackAssociationCollection> L2AssoMap;
   event.getByToken(l2AssoMapToken_,L2AssoMap);
@@ -125,8 +125,8 @@ void L3MuonProducer::produce(Event& event, const EventSetup& eventSetup) {
   event.getByToken(updatedL2AssoMapToken_,updatedL2AssoMap);
 
 
-      
-  for(TrajTrackAssociationCollection::const_iterator it = L2AssoMap->begin(); it != L2AssoMap->end(); ++it){	
+
+  for(TrajTrackAssociationCollection::const_iterator it = L2AssoMap->begin(); it != L2AssoMap->end(); ++it){
     const Ref<vector<Trajectory> > traj = it->key;
     const reco::TrackRef tkRegular  = it->val;
     reco::TrackRef tkUpdated;
@@ -137,20 +137,20 @@ void L3MuonProducer::produce(Event& event, const EventSetup& eventSetup) {
       iii = updatedL2AssoMap->find(it->val);
       if (iii != iEnd ) tkUpdated = (*updatedL2AssoMap)[it->val] ;
     }
-    
-    const reco::TrackRef tk = ( tkUpdated.isNonnull() ) ? tkUpdated : tkRegular ;      
-    
+
+    const reco::TrackRef tk = ( tkUpdated.isNonnull() ) ? tkUpdated : tkRegular ;
+
     MuonTrajectoryBuilder::TrackCand L2Cand = MuonTrajectoryBuilder::TrackCand((Trajectory*)nullptr,tk);
     if( traj->isValid() ) L2Cand.first = &*traj ;
     L2TrackCands.push_back(L2Cand);
   }
-  
+
   theTrackFinder->reconstruct(L2TrackCands, event, eventSetup);
-  
+
   LogTrace(metname)<<"Event loaded"
                    <<"================================"
                    <<endl<<endl;
-    
+
 }
 
 void L3MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -220,7 +220,7 @@ void L3MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
       psd1.add<int>("DYTselector",1);
       psd1.add<bool>("DYTupdator", false);
       psd1.add<bool>("DYTuseAPE", false );
-      psd1.add<bool>("DYTuseThrsParametrization", false);
+      psd1.add<bool>("DYTuseThrsParametrization", true);
       {
         edm::ParameterSetDescription psd2;
         psd2.add<std::vector<double>>("eta0p8", {1,-0.919853, 0.990742});
@@ -291,7 +291,7 @@ void L3MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 					    true, // refit rpc hits
 					    "hltESPTTRHBWithTrackAngle", // tracker rechit builder
 					    "hltESPMuonTransientTrackingRecHitBuilder" // muon rechit builder
-					    );      
+					    );
       psd0.add<edm::ParameterSetDescription>("TrackTransformer", psd1);
     }
     {


### PR DESCRIPTION
#### PR description:

This PR activate the new threshold parameterization for the DyT algorithm (introduced in #26343 ) only for muons up to eta 1.2, while using the old DyT threshold for eta greater than 1.2.

This choice has been made after validating the new parameterization in all the eta range [link](https://indico.cern.ch/event/820640/)

The PR changes the default flag for selecting the parameterization mode from False to True and modifies `DynamicTruncation::correctThrByPAndEta` adding:

```cpp
std::set<dyt_utils::etaRegion> regionsToExclude = {dyt_utils::etaRegion::eta2p0, dyt_utils::etaRegion::eta2p2,  dyt_utils::etaRegion::eta2p4 };
if ( ! regionsToExclude.count(this->region) ) thr = parametricThreshold();
```

Parameters for `dyt_utils::etaRegion::eta2p0, dyt_utils::etaRegion::eta2p2, dyt_utils::etaRegion::eta2p4` are left in for future development.

#### PR validation:
Validation has been performed using:
```bash
runTheMatrix.py --nThreads=4 -l 10809.0
```
output
```
10809.0_SingleMuPt1000+SingleMuPt1000_pythia8_2018_GenSimFull+DigiFull_2018+RecoFull_2018+HARVESTFull_2018+ALCAFull_2018+NanoFull_2018 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED Step5-PASSED  - time date Tue May 14 12:50:00 2019-date Tue May 14 12:18:38 2019; exit: 0 0 0 0 0 0
1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 failed
```