### PR TITLE
Enforce ESInputTag label separation

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
+++ b/DetectorDescription/DDCMS/plugins/DDCMSDetector.cc
@@ -39,7 +39,7 @@ void
 DDCMSDetector::analyze(const Event&, const EventSetup& iEventSetup)
 {
   ESTransientHandle<DDDetector> det;
-  iEventSetup.get<GeometryFileRcd>().get(m_tag.module(), det);
+  iEventSetup.get<GeometryFileRcd>().get(m_tag, det);
 
   LogVerbatim("Geometry") << "Iterate over the detectors:\n";
   LogVerbatim("Geometry").log([&](auto& log) {
@@ -51,7 +51,7 @@ DDCMSDetector::analyze(const Event&, const EventSetup& iEventSetup)
   LogVerbatim("Geometry") << "..done!";
   
   ESTransientHandle<DDVectorRegistry> registry;
-  iEventSetup.get<DDVectorRegistryRcd>().get(m_tag.module(), registry);
+  iEventSetup.get<DDVectorRegistryRcd>().get(m_tag, registry);
 
   LogVerbatim("Geometry") << "DD Vector Registry size: " << registry->vectors.size();
   LogVerbatim("Geometry").log([&](auto& log) {

--- a/DetectorDescription/DDCMS/plugins/DDTestDumpFile.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestDumpFile.cc
@@ -45,7 +45,7 @@ DDTestDumpFile::analyze(const Event&, const EventSetup& iEventSetup)
 {
   LogVerbatim("Geometry") << "DDTestDumpFile::analyze: " << m_label;
   ESTransientHandle<DDDetector> det;
-  iEventSetup.get<GeometryFileRcd>().get(m_label.module(), det);
+  iEventSetup.get<GeometryFileRcd>().get(m_label, det);
 
   TGeoManager& geom = det->description()->manager();
   

--- a/DetectorDescription/DDCMS/plugins/DDTestDumpGeometry.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestDumpGeometry.cc
@@ -40,7 +40,7 @@ DDTestDumpGeometry::analyze(const Event&, const EventSetup& iEventSetup)
 {
   LogVerbatim("Geometry") << "DDTestDumpGeometry::analyze: " << m_tag;
   ESTransientHandle<DDDetector> det;
-  iEventSetup.get<GeometryFileRcd>().get(m_tag.module(), det);
+  iEventSetup.get<GeometryFileRcd>().get(m_tag, det);
 
   TGeoManager const& geom = det->description()->manager();
 

--- a/DetectorDescription/DDCMS/plugins/DDTestNavigateGeometry.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestNavigateGeometry.cc
@@ -49,7 +49,7 @@ DDTestNavigateGeometry::analyze(const Event&, const EventSetup& iEventSetup)
 
   const DDVectorRegistryRcd& regRecord = iEventSetup.get<DDVectorRegistryRcd>();
   ESTransientHandle<DDVectorRegistry> reg;
-  regRecord.get(m_tag.module(), reg);
+  regRecord.get(m_tag, reg);
 
   LogVerbatim("Geometry").log([&reg](auto& log) {
       for(const auto& p: reg->vectors) {
@@ -61,7 +61,7 @@ DDTestNavigateGeometry::analyze(const Event&, const EventSetup& iEventSetup)
   
   const GeometryFileRcd& ddRecord = iEventSetup.get<GeometryFileRcd>();
   ESTransientHandle<DDDetector> ddd;
-  ddRecord.get(m_tag.module(), ddd);
+  ddRecord.get(m_tag, ddd);
     
   const dd4hep::Detector& detector = *ddd->description();
  

--- a/DetectorDescription/DDCMS/plugins/DDTestSpecPars.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestSpecPars.cc
@@ -30,7 +30,7 @@ DDTestSpecPars::analyze(const Event&, const EventSetup& iEventSetup)
 {
   LogVerbatim("Geometry") << "DDTestSpecPars::analyze: " << m_tag;
   ESTransientHandle<DDSpecParRegistry> registry;
-  iEventSetup.get<DDSpecParRegistryRcd>().get(m_tag.module(), registry);
+  iEventSetup.get<DDSpecParRegistryRcd>().get(m_tag, registry);
 
   LogVerbatim("Geometry").log([&registry](auto& log) {
       log << "DD SpecPar Registry size: " << registry->specpars.size();

--- a/DetectorDescription/DDCMS/plugins/DDTestSpecParsFilter.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestSpecParsFilter.cc
@@ -35,9 +35,9 @@ DDTestSpecParsFilter::analyze(const Event&, const EventSetup& iEventSetup)
 {
   LogVerbatim("Geometry") << "DDTestSpecParsFilter::analyze: " << m_tag;
   ESTransientHandle<DDSpecParRegistry> registry;
-  iEventSetup.get<DDSpecParRegistryRcd>().get(m_tag.module(), registry);
+  iEventSetup.get<DDSpecParRegistryRcd>().get(m_tag, registry);
 
-  LogVerbatim("Geometry") << "DDTestSpecParsFilter::analyze: " << m_tag.module()
+  LogVerbatim("Geometry") << "DDTestSpecParsFilter::analyze: " << m_tag
 			  << " for attribute " << m_attribute << " and value " << m_value;
   LogVerbatim("Geometry") << "DD SpecPar Registry size: " << registry->specpars.size();
 

--- a/DetectorDescription/DDCMS/plugins/DDTestVectors.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestVectors.cc
@@ -31,7 +31,7 @@ DDTestVectors::analyze( const Event&, const EventSetup& iEventSetup)
 {
   LogVerbatim("Geometry") << "DDTestVectors::analyze: " << m_tag;
   ESTransientHandle<DDVectorRegistry> registry;
-  iEventSetup.get<DDVectorRegistryRcd>().get(m_tag.module(), registry);
+  iEventSetup.get<DDVectorRegistryRcd>().get(m_tag, registry);
 
   LogVerbatim("Geometry").log([&registry](auto& log) {
       log << "DD Vector Registry size: " << registry->vectors.size();

--- a/DetectorDescription/DDCMS/test/python/dump.py
+++ b/DetectorDescription/DDCMS/test/python/dump.py
@@ -17,15 +17,15 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
                                                     )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              DDDetector = cms.ESInputTag('CMS')
+                              DDDetector = cms.ESInputTag('','CMS')
                               )
 
 process.testVectors = cms.EDAnalyzer("DDTestVectors",
-                                     DDDetector = cms.ESInputTag('CMS')
+                                     DDDetector = cms.ESInputTag('','CMS')
                                      )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  DDDetector = cms.ESInputTag('CMS')
+                                  DDDetector = cms.ESInputTag('','CMS')
                                   )
 
 process.p = cms.Path(process.test+process.testVectors+process.testDump)

--- a/DetectorDescription/DDCMS/test/python/dumpMuonGeometry.py
+++ b/DetectorDescription/DDCMS/test/python/dumpMuonGeometry.py
@@ -13,7 +13,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  DDDetector = cms.ESInputTag('MUON')
+                                  DDDetector = cms.ESInputTag('','MUON')
                                   )
 
 process.p = cms.Path(process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testDDAngularAlgorithm.py
+++ b/DetectorDescription/DDCMS/test/python/testDDAngularAlgorithm.py
@@ -13,7 +13,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  DDDetector = cms.ESInputTag('TestAngular')
+                                  DDDetector = cms.ESInputTag('','TestAngular')
                                   )
 
 process.p = cms.Path(process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
+++ b/DetectorDescription/DDCMS/test/python/testDDDetectorESProducer.py
@@ -48,7 +48,7 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
                                                     )
 
 process.test = cms.EDAnalyzer("DDTestNavigateGeometry",
-                              DDDetector = cms.ESInputTag('MUON'),
+                              DDDetector = cms.ESInputTag('','MUON'),
                               detElementPath = cms.string(''),
                               placedVolumePath = cms.string('/world_volume_1/OCMS_1/CMSE_1/MUON_1')
                               )

--- a/DetectorDescription/DDCMS/test/python/testDDHGCalCellAlgorithm.py
+++ b/DetectorDescription/DDCMS/test/python/testDDHGCalCellAlgorithm.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  DDDetector = cms.ESInputTag('TestDDHGCalCell')
+                                  DDDetector = cms.ESInputTag('','TestDDHGCalCell')
                                   )
 
 process.p = cms.Path(process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testDDSpecPars.py
+++ b/DetectorDescription/DDCMS/test/python/testDDSpecPars.py
@@ -48,7 +48,7 @@ process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProduce
                                                      )
 
 process.test = cms.EDAnalyzer("DDTestSpecPars",
-                              DDDetector = cms.ESInputTag('MUON')
+                              DDDetector = cms.ESInputTag('','MUON')
                               )
 
 process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testDDSpecParsFilter.py
+++ b/DetectorDescription/DDCMS/test/python/testDDSpecParsFilter.py
@@ -47,7 +47,7 @@ process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProduce
                                                      )
 
 process.test = cms.EDAnalyzer("DDTestSpecParsFilter",
-                              DDDetector = cms.ESInputTag('MUON'),
+                              DDDetector = cms.ESInputTag('','MUON'),
                               attribute = cms.untracked.string('MuStructure'),
                               value = cms.untracked.string('MuonBarrelDT')
                               )

--- a/DetectorDescription/DDCMS/test/python/testDDSpecParsFilterG4ProdCuts.py
+++ b/DetectorDescription/DDCMS/test/python/testDDSpecParsFilterG4ProdCuts.py
@@ -48,7 +48,7 @@ process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProduce
                                                  )
 
 process.test = cms.EDAnalyzer("DDTestSpecParsFilter",
-                              DDDetector = cms.ESInputTag('MUON'),
+                              DDDetector = cms.ESInputTag('','MUON'),
                               attribute = cms.untracked.string('CMSCutsRegion'),
                               value = cms.untracked.string('Muon')
                           )

--- a/DetectorDescription/DDCMS/test/python/testDDTIDAxialCableAlgorithm.py
+++ b/DetectorDescription/DDCMS/test/python/testDDTIDAxialCableAlgorithm.py
@@ -45,7 +45,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
 )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-    DDDetector = cms.ESInputTag('TestTIDAxialCable')
+    DDDetector = cms.ESInputTag('','TestTIDAxialCable')
 )
 
 process.p = cms.Path(process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testDDVectors.py
+++ b/DetectorDescription/DDCMS/test/python/testDDVectors.py
@@ -16,7 +16,7 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
                                                     appendToDataLabel = cms.string('CMS'))
 
 process.test = cms.EDAnalyzer("DDTestVectors",
-                              DDDetector = cms.ESInputTag('CMS')
+                              DDDetector = cms.ESInputTag('','CMS')
                               )
 
 process.p = cms.Path(process.test)

--- a/DetectorDescription/DDCMS/test/python/testMFGeometry.py
+++ b/DetectorDescription/DDCMS/test/python/testMFGeometry.py
@@ -13,7 +13,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  DDDetector = cms.ESInputTag('MagneticField')
+                                  DDDetector = cms.ESInputTag('','MagneticField')
                                   )
 
 process.p = cms.Path(process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testMuonGeometry.py
+++ b/DetectorDescription/DDCMS/test/python/testMuonGeometry.py
@@ -24,7 +24,7 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
                                                     )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              DDDetector = cms.ESInputTag('CMS')
+                              DDDetector = cms.ESInputTag('','CMS')
                               )
 
 process.DDVectorRegistryESProducer2 = cms.ESProducer("DDVectorRegistryESProducer",
@@ -32,17 +32,17 @@ process.DDVectorRegistryESProducer2 = cms.ESProducer("DDVectorRegistryESProducer
                                                      )
 
 process.test2 = cms.EDAnalyzer("DDCMSDetector",
-                               DDDetector = cms.ESInputTag('MagneticField')
+                               DDDetector = cms.ESInputTag('','MagneticField')
                                )
 
 process.testVectors = cms.EDAnalyzer("DDTestVectors",
-                                     DDDetector = cms.ESInputTag('CMS')
+                                     DDDetector = cms.ESInputTag('','CMS')
                                      )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile")
 
 process.testGeoIter = cms.EDAnalyzer("DDTestDumpGeometry",
-                                     DDDetector = cms.ESInputTag('CMS')
+                                     DDDetector = cms.ESInputTag('','CMS')
                                      )
 
 process.p = cms.Path(

--- a/DetectorDescription/DDCMS/test/python/testNavigateGeometry.py
+++ b/DetectorDescription/DDCMS/test/python/testNavigateGeometry.py
@@ -46,7 +46,7 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
                                                     appendToDataLabel = cms.string('MUON'))
 
 process.test = cms.EDAnalyzer("DDTestNavigateGeometry",
-                              DDDetector = cms.ESInputTag('MUON'),
+                              DDDetector = cms.ESInputTag('','MUON'),
                               detElementPath = cms.string('detElementPath'),
                               placedVolumePath = cms.string('placedVolPath')
                               )

--- a/DetectorDescription/DDCMS/test/python/testShapes.py
+++ b/DetectorDescription/DDCMS/test/python/testShapes.py
@@ -17,15 +17,15 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
                                                     )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              DDDetector = cms.ESInputTag('TestShapes')
+                              DDDetector = cms.ESInputTag('','TestShapes')
                               )
 
 process.testVectors = cms.EDAnalyzer("DDTestVectors",
-                                     DDDetector = cms.ESInputTag('TestShapes')
+                                     DDDetector = cms.ESInputTag('','TestShapes')
                                      )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  DDDetector = cms.ESInputTag('TestShapes')
+                                  DDDetector = cms.ESInputTag('','TestShapes')
                                   )
 
 process.p = cms.Path(process.test+process.testVectors+process.testDump)

--- a/DetectorDescription/DDCMS/test/python/testTGeoIterator.py
+++ b/DetectorDescription/DDCMS/test/python/testTGeoIterator.py
@@ -43,7 +43,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             appendToDataLabel = cms.string('CMS')
                                             )
 process.test = cms.EDAnalyzer("DDTestDumpGeometry",
-                              DDDetector = cms.ESInputTag('CMS')
+                              DDDetector = cms.ESInputTag('','CMS')
                               )
 
 process.p = cms.Path(process.test)

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -605,7 +605,7 @@ class ESInputTag(_ParameterTypeBase):
         if dataLabel is None:
             if moduleLabel:
                 if  -1 == moduleLabel.find(":"):
-                    raise RuntimeError("ESInputTag passed one string '"+str(moduleLabel)+"' which does not contain a ':'. If you want to specify more than one label, please pass them as separate arguments.")
+                    raise RuntimeError("ESInputTag passed one string '"+str(moduleLabel)+"' which does not contain a ':'. Please add ':' to explicitly separate the module (1st) and data (2nd) label or use two strings.")
                 toks = moduleLabel.split(":")
                 self.__moduleLabel = toks[0]
                 if len(toks) > 1:

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -541,7 +541,7 @@ class InputTag(_ParameterTypeBase):
         parameterSet.addInputTag(self.isTracked(), myname, self.cppTag(parameterSet))
 
 class ESInputTag(_ParameterTypeBase):
-    def __init__(self,module='',data=''):
+    def __init__(self,module='',data= None):
         super(ESInputTag,self).__init__()
         self._setValues(module, data)
     def getModuleLabel(self):
@@ -559,9 +559,7 @@ class ESInputTag(_ParameterTypeBase):
             self._isModified=True
     dataLabel = property(getDataLabel,setDataLabel,"data label for the product")
     def configValue(self, options=PrintOptions()):
-        result = self.__moduleLabel
-        if self.__data != "":
-            result += ':' + self.__data
+        result = self.__moduleLabel + ':' + self.__data
         if result == "":
             result = '\"\"'
         return result;
@@ -601,18 +599,22 @@ class ESInputTag(_ParameterTypeBase):
     def setValue(self,v):
         self._setValues(v)
         self._isModified=True
-    def _setValues(self,moduleLabel='',dataLabel=''):
+    def _setValues(self,moduleLabel='',dataLabel=None):
         self.__moduleLabel = moduleLabel
         self.__data = dataLabel
-        if -1 != moduleLabel.find(":"):
-        #    raise RuntimeError("the module label '"+str(moduleLabel)+"' contains a ':'. If you want to specify more than one label, please pass them as separate arguments.")
-        # tolerate it, at least for the translation phase
-            toks = moduleLabel.split(":")
-            self.__moduleLabel = toks[0]
-            if len(toks) > 1:
-                self.__data = toks[1]
-            if len(toks) > 2:
-                raise RuntimeError("an ESInputTag was passed the value'"+moduleLabel+"' which contains more than one ':'")
+        if dataLabel is None:
+            if moduleLabel:
+                if  -1 == moduleLabel.find(":"):
+                    raise RuntimeError("ESInputTag passed one string '"+str(moduleLabel)+"' which does not contain a ':'. If you want to specify more than one label, please pass them as separate arguments.")
+                toks = moduleLabel.split(":")
+                self.__moduleLabel = toks[0]
+                if len(toks) > 1:
+                    self.__data = toks[1]
+                if len(toks) > 2:
+                    raise RuntimeError("an ESInputTag was passed the value'"+moduleLabel+"' which contains more than one ':'")
+            else:
+                self.__data = ''
+            
 
     # convert to the wrapper class for C++ ESInputTags
     def cppTag(self, parameterSet):
@@ -1408,10 +1410,10 @@ if __name__ == "__main__":
             self.assertEqual(it.getModuleLabel(), "")
             self.assertEqual(it.getDataLabel(), "data")
             self.assertEqual(repr(it), "cms.ESInputTag(\"\",\"data\")")
-            vit = VESInputTag(ESInputTag("label1"), ESInputTag("label2"))
-            self.assertEqual(repr(vit), "cms.VESInputTag(cms.ESInputTag(\"label1\"), cms.ESInputTag(\"label2\"))")
-            vit = VESInputTag("label1", "label2:label3")
-            self.assertEqual(repr(vit), "cms.VESInputTag(\"label1\", \"label2:label3\")")
+            vit = VESInputTag(ESInputTag("label1:"), ESInputTag("label2:"))
+            self.assertEqual(repr(vit), 'cms.VESInputTag(cms.ESInputTag("label1",""), cms.ESInputTag("label2",""))')
+            vit = VESInputTag("label1:", "label2:label3")
+            self.assertEqual(repr(vit), "cms.VESInputTag(\"label1:\", \"label2:label3\")")
 
         def testPSet(self):
             p1 = PSet(anInt = int32(1), a = PSet(b = int32(1)))
@@ -1557,8 +1559,8 @@ if __name__ == "__main__":
 
         def testPSetConversion(self):
             p = PSet(a = untracked.int32(7),
-                     b = untracked.InputTag("b"),
-                     c = untracked.ESInputTag("c"),
+                     b = untracked.InputTag("b:"),
+                     c = untracked.ESInputTag("c:"),
                      d = EventID(1,1,1),
                      e = LuminosityBlockID(1,1),
                      f = EventRange(1,1,1,8,8,8),
@@ -1571,8 +1573,8 @@ if __name__ == "__main__":
                      m = untracked.double(7.0),
                      n = FileInPath("xxx"),
                      o = untracked.vint32(7,8),
-                     p = untracked.VInputTag(InputTag("b"),InputTag("c")),
-                     q = untracked.VESInputTag(ESInputTag("c"),ESInputTag("d")),
+                     p = untracked.VInputTag(InputTag("b:"),InputTag("c:")),
+                     q = untracked.VESInputTag(ESInputTag("c:"),ESInputTag("d:")),
                      r = untracked.VEventID(EventID(1,1,1),EventID(2,2,2)),
                      s = untracked.VLuminosityBlockID(LuminosityBlockID(1,1),LuminosityBlockID(2,3)),
                      t = untracked.VEventRange(EventRange(1,1,1,8,8,8), EventRange(9,9,9,18,18,18)),

--- a/FWCore/ParameterSet/src/types.cc
+++ b/FWCore/ParameterSet/src/types.cc
@@ -627,12 +627,19 @@ bool edm::encode(std::string& to, std::vector<InputTag> const& from) {
 // ----------------------------------------------------------------------
 
 bool edm::decode(ESInputTag& to, std::string const& from) {
-  to = ESInputTag(from);
+  if(not from.empty() and std::string::npos == from.find(':')) {
+    to = ESInputTag(from,"");
+  } else {
+    to = ESInputTag(from);
+  }
   return true;
 }  // decode to InputTag
 
 bool edm::encode(std::string& to, ESInputTag const& from) {
   to = from.encode();
+  if(not to.empty() and to.back() ==':') {
+    to.pop_back();
+  }
   return true;
 }
 

--- a/FWCore/ParameterSet/src/types.cc
+++ b/FWCore/ParameterSet/src/types.cc
@@ -627,8 +627,8 @@ bool edm::encode(std::string& to, std::vector<InputTag> const& from) {
 // ----------------------------------------------------------------------
 
 bool edm::decode(ESInputTag& to, std::string const& from) {
-  if(not from.empty() and std::string::npos == from.find(':')) {
-    to = ESInputTag(from,"");
+  if (not from.empty() and std::string::npos == from.find(':')) {
+    to = ESInputTag(from, "");
   } else {
     to = ESInputTag(from);
   }
@@ -637,7 +637,7 @@ bool edm::decode(ESInputTag& to, std::string const& from) {
 
 bool edm::encode(std::string& to, ESInputTag const& from) {
   to = from.encode();
-  if(not to.empty() and to.back() ==':') {
+  if (not to.empty() and to.back() == ':') {
     to.pop_back();
   }
   return true;

--- a/FWCore/ParameterSet/test/ps_t.cppunit.cc
+++ b/FWCore/ParameterSet/test/ps_t.cppunit.cc
@@ -291,6 +291,22 @@ void testps::idTest() {
 
   CPPUNIT_ASSERT(a != b);
   CPPUNIT_ASSERT(a.id() != b.id());
+
+  {
+    //Check that changes to ESInputTag do not affect ID
+    // as that would affect reading back stored PSets
+
+    edm::ParameterSet ps;
+    ps.addParameter<edm::ESInputTag>("default",edm::ESInputTag());
+    ps.addParameter<edm::ESInputTag>("moduleOnly",edm::ESInputTag("Prod",""));
+    ps.addParameter<edm::ESInputTag>("dataOnly",edm::ESInputTag("","data"));
+    ps.addParameter<edm::ESInputTag>("allLabels",edm::ESInputTag("Prod","data"));
+    ps.registerIt();
+
+    std::string stringValue;
+    ps.id().toString(stringValue);
+    CPPUNIT_ASSERT(stringValue == "01642a9a7311dea2df2f9ee430855a99");
+  }
 }
 
 void testps::calculateIDTest() {

--- a/FWCore/ParameterSet/test/ps_t.cppunit.cc
+++ b/FWCore/ParameterSet/test/ps_t.cppunit.cc
@@ -297,10 +297,10 @@ void testps::idTest() {
     // as that would affect reading back stored PSets
 
     edm::ParameterSet ps;
-    ps.addParameter<edm::ESInputTag>("default",edm::ESInputTag());
-    ps.addParameter<edm::ESInputTag>("moduleOnly",edm::ESInputTag("Prod",""));
-    ps.addParameter<edm::ESInputTag>("dataOnly",edm::ESInputTag("","data"));
-    ps.addParameter<edm::ESInputTag>("allLabels",edm::ESInputTag("Prod","data"));
+    ps.addParameter<edm::ESInputTag>("default", edm::ESInputTag());
+    ps.addParameter<edm::ESInputTag>("moduleOnly", edm::ESInputTag("Prod", ""));
+    ps.addParameter<edm::ESInputTag>("dataOnly", edm::ESInputTag("", "data"));
+    ps.addParameter<edm::ESInputTag>("allLabels", edm::ESInputTag("Prod", "data"));
     ps.registerIt();
 
     std::string stringValue;

--- a/FWCore/PyDevParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PyDevParameterSet/test/makepset_t.cppunit.cc
@@ -346,11 +346,11 @@ void testmakepset::typesTest() {
       "    vlumis = cms.VLuminosityBlockID('75:85', '95:105'),\n"
       "    einput1 = cms.ESInputTag(),\n"
       "    einput2 = cms.ESInputTag(data='blah'),\n"
-      "    einput3 = cms.ESInputTag('ESProd'),\n"
+      "    einput3 = cms.ESInputTag('ESProd:'),\n"
       "    einput4 = cms.ESInputTag('ESProd','something'),\n"
       "    einput5 = cms.ESInputTag('ESProd:something'),\n"
       "    veinput1 = cms.VESInputTag(),\n"
-      "    veinput2 = cms.VESInputTag(cms.ESInputTag(data='blah'),cms.ESInputTag('ESProd'))\n"
+      "    veinput2 = cms.VESInputTag(cms.ESInputTag(data='blah'),cms.ESInputTag('ESProd:'))\n"
       ")\n"
 
       ;

--- a/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
@@ -346,11 +346,11 @@ void testmakepset::typesTest() {
       "    vlumis = cms.VLuminosityBlockID('75:85', '95:105'),\n"
       "    einput1 = cms.ESInputTag(),\n"
       "    einput2 = cms.ESInputTag(data='blah'),\n"
-      "    einput3 = cms.ESInputTag('ESProd'),\n"
+      "    einput3 = cms.ESInputTag('ESProd:'),\n"
       "    einput4 = cms.ESInputTag('ESProd','something'),\n"
       "    einput5 = cms.ESInputTag('ESProd:something'),\n"
       "    veinput1 = cms.VESInputTag(),\n"
-      "    veinput2 = cms.VESInputTag(cms.ESInputTag(data='blah'),cms.ESInputTag('ESProd'))\n"
+      "    veinput2 = cms.VESInputTag(cms.ESInputTag(data='blah'),cms.ESInputTag('ESProd:'))\n"
       ")\n"
 
       ;

--- a/FWCore/Utilities/src/ESInputTag.cc
+++ b/FWCore/Utilities/src/ESInputTag.cc
@@ -35,9 +35,9 @@ ESInputTag::ESInputTag(const std::string& iEncodedValue) {
         << "ESInputTag " << iEncodedValue << " has " << nwords << " tokens but only up two 2 are allowed.";
   }
   if (nwords > 0) {
-    if(nwords != 2) {
-    throw edm::Exception(errors::Configuration, "ESInputTag")
-        << "ESInputTag " << iEncodedValue << " must contain a ':' to separate the module and data labels.";
+    if (nwords != 2) {
+      throw edm::Exception(errors::Configuration, "ESInputTag")
+          << "ESInputTag " << iEncodedValue << " must contain a ':' to separate the module and data labels.";
     }
     module_ = tokens[0];
     data_ = tokens[1];
@@ -53,7 +53,7 @@ bool ESInputTag::operator==(const edm::ESInputTag& iRHS) const {
 
 std::string ESInputTag::encode() const {
   std::string result = module_;
-  result +=":";
+  result += ":";
   if (!data_.empty()) {
     result += data_;
   }

--- a/FWCore/Utilities/src/ESInputTag.cc
+++ b/FWCore/Utilities/src/ESInputTag.cc
@@ -34,10 +34,14 @@ ESInputTag::ESInputTag(const std::string& iEncodedValue) {
     throw edm::Exception(errors::Configuration, "ESInputTag")
         << "ESInputTag " << iEncodedValue << " has " << nwords << " tokens but only up two 2 are allowed.";
   }
-  if (nwords > 0)
+  if (nwords > 0) {
+    if(nwords != 2) {
+    throw edm::Exception(errors::Configuration, "ESInputTag")
+        << "ESInputTag " << iEncodedValue << " must contain a ':' to separate the module and data labels.";
+    }
     module_ = tokens[0];
-  if (nwords > 1)
     data_ = tokens[1];
+  }
 }
 
 //
@@ -48,10 +52,10 @@ bool ESInputTag::operator==(const edm::ESInputTag& iRHS) const {
 }
 
 std::string ESInputTag::encode() const {
-  static std::string const separator(":");
   std::string result = module_;
+  result +=":";
   if (!data_.empty()) {
-    result += separator + data_;
+    result += data_;
   }
   return result;
 }

--- a/FWCore/Utilities/test/esinputtag.cppunit.cpp
+++ b/FWCore/Utilities/test/esinputtag.cppunit.cpp
@@ -62,18 +62,17 @@ void testESInputTag::encodedTags() {
     CPPUNIT_ASSERT_EQUAL(tag.data(), data_label);
   };
 
-  ESInputTag const moduleOnly{"ML"};
   ESInputTag const moduleOnlywToken{"ML:"};
   ESInputTag const dataOnlywToken{":DL"};
   ESInputTag const bothFields{"ML:DL"};
 
-  require_labels(moduleOnly, "ML", "");
   require_labels(moduleOnlywToken, "ML", "");
   require_labels(dataOnlywToken, "", "DL");
   require_labels(bothFields, "ML", "DL");
 
   // Too many colons
   CPPUNIT_ASSERT_THROW((ESInputTag{"ML:DL:"}), cms::Exception);
+  CPPUNIT_ASSERT_THROW((ESInputTag{"ML"}), cms::Exception);
 }
 
 void testESInputTag::mixedConstructors() {

--- a/Geometry/DTGeometryBuilder/test/python/testDTGeometry.py
+++ b/Geometry/DTGeometryBuilder/test/python/testDTGeometry.py
@@ -44,7 +44,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.DTGeometryESProducer = cms.ESProducer("DTGeometryESProducer",
-                                              DDDetector = cms.ESInputTag('MUON'),
+                                              DDDetector = cms.ESInputTag('','MUON'),
                                               appendToDataLabel = cms.string(''),
                                               applyAlignment = cms.bool(False),
                                               alignmentsLabel = cms.string(''),
@@ -63,7 +63,7 @@ process.MuonNumberingESProducer = cms.ESProducer("MuonNumberingESProducer",
                                                  )
 
 process.test = cms.EDAnalyzer("DTGeometryTest",
-                              DDDetector = cms.ESInputTag('MUON')
+                              DDDetector = cms.ESInputTag('','MUON')
                               )
 
 process.p = cms.Path(process.test)

--- a/Geometry/DTGeometryBuilder/test/python/testDTGeometryAndDump.py
+++ b/Geometry/DTGeometryBuilder/test/python/testDTGeometryAndDump.py
@@ -44,7 +44,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.DTGeometryESProducer = cms.ESProducer("DTGeometryESProducer",
-                                              DDDetector = cms.ESInputTag('MUON'),
+                                              DDDetector = cms.ESInputTag('','MUON'),
                                               appendToDataLabel = cms.string(''),
                                               applyAlignment = cms.bool(False),
                                               alignmentsLabel = cms.string(''),
@@ -63,11 +63,11 @@ process.MuonNumberingESProducer = cms.ESProducer("MuonNumberingESProducer",
                                                  )
 
 process.test = cms.EDAnalyzer("DTGeometryTest",
-                              DDDetector = cms.ESInputTag('MUON')
+                              DDDetector = cms.ESInputTag('','MUON')
                               )
 
 process.dump = cms.EDAnalyzer("DDTestDumpGeometry",
-                              DDDetector = cms.ESInputTag('MUON')
+                              DDDetector = cms.ESInputTag('','MUON')
                               )
 
 process.p = cms.Path(process.test+process.dump)

--- a/Geometry/DTGeometryBuilder/test/python/validateDTGeometry_cfg.py
+++ b/Geometry/DTGeometryBuilder/test/python/validateDTGeometry_cfg.py
@@ -13,7 +13,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.DTGeometryESProducer = cms.ESProducer("DTGeometryESProducer",
-                                              DDDetector = cms.ESInputTag('MUON'),
+                                              DDDetector = cms.ESInputTag('','MUON'),
                                               appendToDataLabel = cms.string(''),
                                               applyAlignment = cms.bool(False),
                                               alignmentsLabel = cms.string(''),

--- a/Geometry/EcalAlgo/test/python/testEcalGeometry.py
+++ b/Geometry/EcalAlgo/test/python/testEcalGeometry.py
@@ -52,7 +52,7 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
                                                     )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              DDDetector = cms.ESInputTag('Ecal')
+                              DDDetector = cms.ESInputTag('', 'Ecal')
                               )
 
 process.p = cms.Path(process.test)

--- a/Geometry/MTDGeometryBuilder/test/python/testMTDGeometry.py
+++ b/Geometry/MTDGeometryBuilder/test/python/testMTDGeometry.py
@@ -52,11 +52,11 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
                                                     )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              DDDetector = cms.ESInputTag('MTD')
+                              DDDetector = cms.ESInputTag('','MTD')
                               )
 
 process.dump = cms.EDAnalyzer("DDTestDumpFile",
-                              DDDetector = cms.ESInputTag('MTD')
+                              DDDetector = cms.ESInputTag('','MTD')
                               )
 
 process.p = cms.Path(process.test+process.dump)

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerGeometry.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerGeometry.py
@@ -52,7 +52,7 @@ process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer"
                                                     )
 
 process.test = cms.EDAnalyzer("DDCMSDetector",
-                              DDDetector = cms.ESInputTag('Tracker')
+                              DDDetector = cms.ESInputTag('','Tracker')
                               )
 
 process.p = cms.Path(process.test)

--- a/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
@@ -16,7 +16,7 @@ charmTagsComputerCvsL = cms.ESProducer(
       ),
    weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_sklearn.weight.xml'),
    variables = c_vs_l_vars_vpset,
-   computer = cms.ESInputTag('combinedSecondaryVertexSoftLeptonComputer'),
+   computer = cms.ESInputTag('combinedSecondaryVertexSoftLeptonComputer',''),
    tagInfos = cms.VInputTag(
       cms.InputTag('pfImpactParameterTagInfos'),
       cms.InputTag('pfInclusiveSecondaryVertexFinderCvsLTagInfos'),


### PR DESCRIPTION
#### PR description:

When constructing an ESInputTag using only one non empty string, that string must now contain a ':' to denote the separation between the module and data labels. 

This is meant to catch a common error where the single string was meant to only specify the data label, but was instead specifying the module label.

As part of the change, I corrected the incorrect use of ESInputTags in various geometry modules.
#### PR validation:

The code compiles and all unit tests I could find which use ESInputTag pass.
