### PR TITLE
Update 106X global tags in data and 2021/2023 MC [backport]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,11 +64,11 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '106X_postLS2_design_v4', # GT containing design conditions for postLS2
+    'phase1_2021_design'       : '106X_upgrade2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v1',
+    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '106X_upgrade2023_realistic_v2'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -30,10 +30,10 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '106X_dataRun2_relval_v10',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v5',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v6',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v6',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v6',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v7',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v7',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v10',
+    'run1_data'         :   '106X_dataRun2_v11',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v10',
+    'run2_data'         :   '106X_dataRun2_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v9',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v10',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v5',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -70,7 +70,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '106X_upgrade2023_realistic_v2'
+    'phase2_realistic'         : '106X_upgrade2023_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR updates offline, prompt-like and 2021 MC global tags in 10_6_X. It is a backport of PR #26773 to 10_6_X. 

#### PR validation:

See the description in PR #26773.

#### if this PR is a backport please specify the original PR:

This is a backport of PR #26773 to 10_6_X.
