### PR TITLE
Run3-hcx202 Neutal density filter kept for HB in Run3

### DIFF
--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2019/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2019/hcalSimNumbering.xml
@@ -66,7 +66,7 @@
     15, 29,  4, 10,  5,  2,  4, 18, 19, 11, 12, 13, 14,  3,  4,  3,  1,  0
   </Vector>
   <Vector name="Layer0Wt" type="numeric" nEntries="2">
-    1.2, 1.2
+    0.5, 1.2
   </Vector>
   <Vector name="HBGains" type="numeric" nEntries="4">
     117.0, 117.0, 117.0, 217.0

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/2021/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/2021/hcalSimNumbering.xml
@@ -66,7 +66,7 @@
     15, 29,  4, 10,  5,  2,  4, 18, 19, 11, 12, 13, 14,  3,  4,  3,  1,  0
   </Vector>
   <Vector name="Layer0Wt" type="numeric" nEntries="2">
-    1.2, 1.2
+    0.5, 1.2
   </Vector>
   <Vector name="HBGains" type="numeric" nEntries="4">
     117.0, 117.0, 117.0, 217.0


### PR DESCRIPTION
#### PR description:

In presence of neutral density filter in HB, the run3 scenario should use the older layer 0 weight

#### PR validation:

Tested with runTheMatrix -l limited

#### if this PR is a backport please specify the original PR:

No backporting is necessary