### PR TITLE
updating SC reg corrector for UL regression: 106X

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -40,7 +40,8 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
-       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')
+       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
+       applySigmaIetaIphiBug = cms.bool(False)
        ),
 
     #threshold for final SuperCluster Et
@@ -109,7 +110,8 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
-       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')
+       ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE'),
+       applySigmaIetaIphiBug = cms.bool(False)
        ),
        
     #threshold for final SuperCluster Et

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -325,6 +325,7 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   {
     edm::ParameterSetDescription psd0;
     psd0.add<bool>("isHLT", false);
+    psd0.add<bool>("applySigmaIetaIphiBug", false);
     psd0.add<edm::InputTag>("ecalRecHitsEE",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
     psd0.add<edm::InputTag>("ecalRecHitsEB",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
     psd0.add<std::string>("regressionKeyEB","pfscecal_EBCorrection_offline_v1");

--- a/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEgamma/EgammaTools/interface/SCEnergyCorrectorSemiParm.h
@@ -68,6 +68,7 @@ class SCEnergyCorrectorSemiParm {
 
  private:
   bool isHLT_;
+  bool applySigmaIetaIphiBug_; //there was a bug in sigmaIetaIphi for the 74X application
   int nHitsAboveThreshold_;
   float eThreshold_;
 };


### PR DESCRIPTION
####PR description:
This PR updates the mustache supercluster energy regression for incoming UL regression.

The 2017 regression will be coming soon to a global tag and then 2016/2018 will follow in a few weeks.

This PR is backwards compatible with the existing supercluster regression, as in it will work just fine with what is in the global tag right now. There are two changes

seed eta is added to the endcap as an input variable to help the regression be more stable with high eta. This is the last variable the regression and the current 74X regressions simply ignore it.

a bug was fixed in the calculation of sigmaIEtaIPhi, it was always not set as sigmaIPhiIPhi was always set to std::numeric_limits::max() when it was being constructed. The option to reapply that bug is available.

#### if this PR is a backport please specify the original PR:

backport  of : https://github.com/cms-sw/cmssw/pull/26763