### PR TITLE
Running code-format for geometry

### DIFF
--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
@@ -37,7 +37,8 @@ namespace calogeometryDBEPimpl {
     using TokenType = edm::ESGetToken<CaloSubdetectorGeometry, typename T::AlignedRecord>;
 
     static TokenType makeToken(edm::ESConsumesCollectorT<typename T::AlignedRecord>& cc) {
-      return cc.template consumes<CaloSubdetectorGeometry>(edm::ESInputTag{"", T::producerTag() + std::string("_master")});
+      return cc.template consumes<CaloSubdetectorGeometry>(
+          edm::ESInputTag{"", T::producerTag() + std::string("_master")});
     }
   };
 
@@ -54,14 +55,15 @@ namespace calogeometryDBEPimpl {
   //
   // SFINAE tricks to detect if T::AlignmentRecord exists. Note that
   // the declarations of the following are sufficient.
-  template <typename T> std::false_type has_AlignmentRecord(...);
-  template <typename T> std::true_type has_AlignmentRecord(typename T::AlignmentRecord *);
+  template <typename T>
+  std::false_type has_AlignmentRecord(...);
+  template <typename T>
+  std::true_type has_AlignmentRecord(typename T::AlignmentRecord*);
 
   template <typename T>
   struct HasAlignmentRecord {
     static constexpr bool value = std::is_same<decltype(has_AlignmentRecord<T>(nullptr)), std::true_type>::value;
   };
-
 
   // Then define tokens from alignment record
   template <typename T, bool = HasAlignmentRecord<T>::value>
@@ -72,200 +74,177 @@ namespace calogeometryDBEPimpl {
   template <typename T>
   struct AlignmentTokens<T, false> {};
 
-
   // Some partial specializations need additional tokens...
   template <typename T>
   struct AdditionalTokens {
     void makeTokens(edm::ESConsumesCollectorT<typename T::AlignedRecord>& cc) {}
   };
-}
+}  // namespace calogeometryDBEPimpl
 
 template <class T, class U>
-class CaloGeometryDBEP : public edm::ESProducer 
-{
-   public:
+class CaloGeometryDBEP : public edm::ESProducer {
+public:
+  typedef CaloCellGeometry::CCGFloat CCGFloat;
+  typedef CaloCellGeometry::Pt3D Pt3D;
+  typedef CaloCellGeometry::Pt3DVec Pt3DVec;
+  typedef CaloCellGeometry::Tr3D Tr3D;
 
-      typedef CaloCellGeometry::CCGFloat CCGFloat ;
-      typedef CaloCellGeometry::Pt3D     Pt3D     ;
-      typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
-      typedef CaloCellGeometry::Tr3D     Tr3D     ;
+  using PtrType = std::unique_ptr<CaloSubdetectorGeometry>;
+  typedef CaloSubdetectorGeometry::TrVec TrVec;
+  typedef CaloSubdetectorGeometry::DimVec DimVec;
+  typedef CaloSubdetectorGeometry::IVec IVec;
 
-      using PtrType = std::unique_ptr<CaloSubdetectorGeometry >;
-      typedef CaloSubdetectorGeometry::TrVec  TrVec      ;
-      typedef CaloSubdetectorGeometry::DimVec DimVec     ;
-      typedef CaloSubdetectorGeometry::IVec   IVec       ;
-      
-      CaloGeometryDBEP<T,U>( const edm::ParameterSet& ps ) :
-	  applyAlignment_ ( ps.getParameter<bool>("applyAlignment") )
-      {
-         auto cc = setWhatProduced( this,
-                                    &CaloGeometryDBEP<T,U>::produceAligned,
-                                    edm::es::Label( T::producerTag() ) ) ;//+std::string("TEST") ) ) ;
+  CaloGeometryDBEP<T, U>(const edm::ParameterSet& ps) : applyAlignment_(ps.getParameter<bool>("applyAlignment")) {
+    auto cc = setWhatProduced(this,
+                              &CaloGeometryDBEP<T, U>::produceAligned,
+                              edm::es::Label(T::producerTag()));  //+std::string("TEST") ) ) ;
 
-         if constexpr (calogeometryDBEPimpl::HasAlignmentRecord<T>::value) {
-           if( applyAlignment_ ) {
-             alignmentTokens_.alignments = cc.template consumesFrom<Alignments, typename T::AlignmentRecord>(edm::ESInputTag{});
-             alignmentTokens_.globals = cc.template consumesFrom<Alignments, GlobalPositionRcd>(edm::ESInputTag{});
-           }
-         }
-         geometryToken_ = calogeometryDBEPimpl::GeometryTraits<T, U::writeFlag()>::makeToken(cc);
+    if constexpr (calogeometryDBEPimpl::HasAlignmentRecord<T>::value) {
+      if (applyAlignment_) {
+        alignmentTokens_.alignments =
+            cc.template consumesFrom<Alignments, typename T::AlignmentRecord>(edm::ESInputTag{});
+        alignmentTokens_.globals = cc.template consumesFrom<Alignments, GlobalPositionRcd>(edm::ESInputTag{});
+      }
+    }
+    geometryToken_ = calogeometryDBEPimpl::GeometryTraits<T, U::writeFlag()>::makeToken(cc);
 
-         additionalTokens_.makeTokens(cc);
+    additionalTokens_.makeTokens(cc);
+  }
+
+  ~CaloGeometryDBEP<T, U>() override {}
+
+  PtrType produceAligned(const typename T::AlignedRecord& iRecord) {
+    const auto [alignPtr, globalPtr] = getAlignGlobal(iRecord);
+
+    TrVec tvec;
+    DimVec dvec;
+    IVec ivec;
+    std::vector<uint32_t> dins;
+
+    if constexpr (U::writeFlag()) {
+      const auto& pG = iRecord.get(geometryToken_);
+
+      pG.getSummary(tvec, ivec, dvec, dins);
+
+      U::write(tvec, dvec, ivec, T::dbString());
+    } else {
+      const auto& pG = iRecord.get(geometryToken_);
+
+      tvec = pG.getTranslation();
+      dvec = pG.getDimension();
+      ivec = pG.getIndexes();
+    }
+    //*********************************************************************************************
+
+    const unsigned int nTrParm(tvec.size() / T::k_NumberOfCellsForCorners);
+
+    assert(dvec.size() == T::k_NumberOfShapes * T::k_NumberOfParametersPerShape);
+
+    PtrType ptr = std::make_unique<T>();
+
+    ptr->fillDefaultNamedParameters();
+
+    ptr->allocateCorners(T::k_NumberOfCellsForCorners);
+
+    ptr->allocatePar(dvec.size(), T::k_NumberOfParametersPerShape);
+
+    for (unsigned int i(0); i != T::k_NumberOfCellsForCorners; ++i) {
+      const unsigned int nPerShape(T::k_NumberOfParametersPerShape);
+      DimVec dims;
+      dims.reserve(nPerShape);
+
+      const unsigned int indx(ivec.size() == 1 ? 0 : i);
+
+      DimVec::const_iterator dsrc(dvec.begin() + ivec[indx] * nPerShape);
+
+      for (unsigned int j(0); j != nPerShape; ++j) {
+        dims.emplace_back(*dsrc);
+        ++dsrc;
       }
 
-      ~CaloGeometryDBEP<T,U>() override {}
-    
-      PtrType produceAligned( const typename T::AlignedRecord& iRecord ) 
-      {
-	 const auto [alignPtr, globalPtr] = getAlignGlobal(iRecord);
+      const CCGFloat* myParm(CaloCellGeometry::getParmPtr(dims, ptr->parMgr(), ptr->parVecVec()));
 
-	 TrVec  tvec ;
-	 DimVec dvec ;
-	 IVec   ivec ;
-	 std::vector<uint32_t> dins;
+      const DetId id(T::DetIdType::detIdFromDenseIndex(i));
 
-	 if constexpr ( U::writeFlag() )
-	 {
-	    const auto& pG = iRecord.get( geometryToken_ ) ;
+      const unsigned int iGlob(nullptr == globalPtr ? 0 : T::alignmentTransformIndexGlobal(id));
 
-	    pG.getSummary( tvec, ivec, dvec, dins ) ;
+      assert(nullptr == globalPtr || iGlob < globalPtr->m_align.size());
 
-	    U::write( tvec, dvec, ivec, T::dbString() ) ;
-	 }
-	 else
-	 {
-	    const auto& pG = iRecord.get( geometryToken_ ) ;
+      const AlignTransform* gt(nullptr == globalPtr ? nullptr : &globalPtr->m_align[iGlob]);
 
-	    tvec = pG.getTranslation() ;
-	    dvec = pG.getDimension() ;
-	    ivec = pG.getIndexes() ;
-	 }	 
-//*********************************************************************************************
+      assert(nullptr == gt || iGlob == T::alignmentTransformIndexGlobal(DetId(gt->rawId())));
 
-	 const unsigned int nTrParm ( tvec.size()/T::k_NumberOfCellsForCorners ) ;
+      const unsigned int iLoc(nullptr == alignPtr ? 0 : T::alignmentTransformIndexLocal(id));
 
-	 assert( dvec.size() == T::k_NumberOfShapes * T::k_NumberOfParametersPerShape ) ;
+      assert(nullptr == alignPtr || iLoc < alignPtr->m_align.size());
 
-	 PtrType ptr = std::make_unique<T>();
+      const AlignTransform* at(nullptr == alignPtr ? nullptr : &alignPtr->m_align[iLoc]);
 
-	 ptr->fillDefaultNamedParameters() ;
+      assert(nullptr == at || (T::alignmentTransformIndexLocal(DetId(at->rawId())) == iLoc));
 
-	 ptr->allocateCorners( T::k_NumberOfCellsForCorners ) ;
+      const CaloGenericDetId gId(id);
 
-	 ptr->allocatePar(    dvec.size() ,
-			      T::k_NumberOfParametersPerShape ) ;
+      Pt3D lRef;
+      Pt3DVec lc(8, Pt3D(0, 0, 0));
+      T::localCorners(lc, &dims.front(), i, lRef);
 
-	 for( unsigned int i ( 0 ) ; i != T::k_NumberOfCellsForCorners ; ++i )
-	 {
-	    const unsigned int nPerShape ( T::k_NumberOfParametersPerShape ) ;
-	    DimVec dims ;
-	    dims.reserve( nPerShape ) ;
+      const Pt3D lBck(0.25 * (lc[4] + lc[5] + lc[6] + lc[7]));  // ctr rear  face in local
+      const Pt3D lCor(lc[0]);
 
-	    const unsigned int indx ( ivec.size()==1 ? 0 : i ) ;
+      //----------------------------------- create transform from 6 numbers ---
+      const unsigned int jj(i * nTrParm);
+      Tr3D tr;
+      const ROOT::Math::Translation3D tl(tvec[jj], tvec[jj + 1], tvec[jj + 2]);
+      const ROOT::Math::EulerAngles ea(6 == nTrParm ? ROOT::Math::EulerAngles(tvec[jj + 3], tvec[jj + 4], tvec[jj + 5])
+                                                    : ROOT::Math::EulerAngles());
+      const ROOT::Math::Transform3D rt(ea, tl);
+      double xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz;
+      rt.GetComponents(xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz);
+      tr = Tr3D(CLHEP::HepRep3x3(xx, xy, xz, yx, yy, yz, zx, zy, zz), CLHEP::Hep3Vector(dx, dy, dz));
 
-	    DimVec::const_iterator dsrc ( dvec.begin() + ivec[indx]*nPerShape ) ;
+      // now prepend alignment(s) for final transform
+      const Tr3D atr(nullptr == at ? tr
+                                   : (nullptr == gt ? at->transform() * tr : at->transform() * gt->transform() * tr));
+      //--------------------------------- done making transform  ---------------
 
-	    for( unsigned int j ( 0 ) ; j != nPerShape ; ++j )
-	    {
-	       dims.emplace_back( *dsrc ) ;
-	       ++dsrc ;
-	    }
+      const Pt3D gRef(atr * lRef);
+      const GlobalPoint fCtr(gRef.x(), gRef.y(), gRef.z());
+      const Pt3D gBck(atr * lBck);
+      const GlobalPoint fBck(gBck.x(), gBck.y(), gBck.z());
+      const Pt3D gCor(atr * lCor);
+      const GlobalPoint fCor(gCor.x(), gCor.y(), gCor.z());
 
-	    const CCGFloat* myParm ( CaloCellGeometry::getParmPtr( dims, 
-								   ptr->parMgr(), 
-								   ptr->parVecVec() ) ) ;
+      ptr->newCell(fCtr, fBck, fCor, myParm, id);
+    }
 
+    ptr->initializeParms();  // initializations; must happen after cells filled
 
-	    const DetId id ( T::DetIdType::detIdFromDenseIndex( i ) ) ;
-    
-	    const unsigned int iGlob ( nullptr == globalPtr ? 0 :
-				       T::alignmentTransformIndexGlobal( id ) ) ;
+    return ptr;
+  }
 
-	    assert( nullptr == globalPtr || iGlob < globalPtr->m_align.size() ) ;
-
-	    const AlignTransform* gt ( nullptr == globalPtr ? nullptr : &globalPtr->m_align[ iGlob ] ) ;
-
-	    assert( nullptr == gt || iGlob == T::alignmentTransformIndexGlobal( DetId( gt->rawId() ) ) ) ;
-
-	    const unsigned int iLoc ( nullptr == alignPtr ? 0 :
-				      T::alignmentTransformIndexLocal( id ) ) ;
-
-	    assert( nullptr == alignPtr || iLoc < alignPtr->m_align.size() ) ;
-
-	    const AlignTransform* at ( nullptr == alignPtr ? nullptr :
-				       &alignPtr->m_align[ iLoc ] ) ;
-
-	    assert( nullptr == at || ( T::alignmentTransformIndexLocal( DetId( at->rawId() ) ) == iLoc ) ) ;
-
-	    const CaloGenericDetId gId ( id ) ;
-
-	    Pt3D  lRef ;
-	    Pt3DVec lc ( 8, Pt3D(0,0,0) ) ;
-	    T::localCorners( lc, &dims.front(), i, lRef ) ;
-
-	    const Pt3D lBck ( 0.25*(lc[4]+lc[5]+lc[6]+lc[7] ) ) ; // ctr rear  face in local
-	    const Pt3D lCor ( lc[0] ) ;
-
-	    //----------------------------------- create transform from 6 numbers ---
-	    const unsigned int jj ( i*nTrParm ) ;
-	    Tr3D tr ;
-	    const ROOT::Math::Translation3D tl ( tvec[jj], tvec[jj+1], tvec[jj+2] ) ;
-	    const ROOT::Math::EulerAngles ea (
-	       6==nTrParm ?
-	       ROOT::Math::EulerAngles( tvec[jj+3], tvec[jj+4], tvec[jj+5] ) :
-	       ROOT::Math::EulerAngles() ) ;
-	    const ROOT::Math::Transform3D rt ( ea, tl ) ;
-	    double xx,xy,xz,dx,yx,yy,yz,dy,zx,zy,zz,dz;
-	    rt.GetComponents(xx,xy,xz,dx,yx,yy,yz,dy,zx,zy,zz,dz) ;
-	    tr = Tr3D( CLHEP::HepRep3x3( xx, xy, xz,
-					 yx, yy, yz,
-					 zx, zy, zz ), 
-		       CLHEP::Hep3Vector(dx,dy,dz)     );
-
-	    // now prepend alignment(s) for final transform
-	    const Tr3D atr ( nullptr == at ? tr :
-			     ( nullptr == gt ? at->transform()*tr :
-			       at->transform()*gt->transform()*tr ) ) ;
-	    //--------------------------------- done making transform  ---------------
-
-	    const Pt3D        gRef ( atr*lRef ) ;
-	    const GlobalPoint fCtr ( gRef.x(), gRef.y(), gRef.z() ) ;
-	    const Pt3D        gBck ( atr*lBck ) ;
-	    const GlobalPoint fBck ( gBck.x(), gBck.y(), gBck.z() ) ;
-	    const Pt3D        gCor ( atr*lCor ) ;
-	    const GlobalPoint fCor ( gCor.x(), gCor.y(), gCor.z() ) ;
-
-	    ptr->newCell(  fCtr, fBck, fCor, myParm, id ) ;
-	 }
-
-	 ptr->initializeParms() ; // initializations; must happen after cells filled
-
-	 return ptr ; 
-      }
-    
 private:
-      std::tuple<const Alignments *, const Alignments *> getAlignGlobal(const typename T::AlignedRecord& iRecord) const {
-	 const Alignments* alignPtr  ( nullptr ) ;
-	 const Alignments* globalPtr ( nullptr ) ;
-         if constexpr (calogeometryDBEPimpl::HasAlignmentRecord<T>::value) {
-	    if( applyAlignment_ ) // get ptr if necessary
-	    {
-	       const auto& alignments = iRecord.get( alignmentTokens_.alignments ) ;
-	       // require expected size
-	       assert( alignments.m_align.size() == T::numberOfAlignments() ) ;
-	       alignPtr = &alignments ;
+  std::tuple<const Alignments*, const Alignments*> getAlignGlobal(const typename T::AlignedRecord& iRecord) const {
+    const Alignments* alignPtr(nullptr);
+    const Alignments* globalPtr(nullptr);
+    if constexpr (calogeometryDBEPimpl::HasAlignmentRecord<T>::value) {
+      if (applyAlignment_)  // get ptr if necessary
+      {
+        const auto& alignments = iRecord.get(alignmentTokens_.alignments);
+        // require expected size
+        assert(alignments.m_align.size() == T::numberOfAlignments());
+        alignPtr = &alignments;
 
-	       const auto& globals = iRecord.get( alignmentTokens_.globals ) ;
-	       globalPtr = &globals ;
-	    }
-	 }
-         return std::make_tuple(alignPtr, globalPtr);
+        const auto& globals = iRecord.get(alignmentTokens_.globals);
+        globalPtr = &globals;
       }
+    }
+    return std::make_tuple(alignPtr, globalPtr);
+  }
 
-    typename calogeometryDBEPimpl::AlignmentTokens<T> alignmentTokens_;
-    typename calogeometryDBEPimpl::GeometryTraits<T, U::writeFlag()>::TokenType geometryToken_;
-    typename calogeometryDBEPimpl::AdditionalTokens<T> additionalTokens_;
-    bool        applyAlignment_ ;
+  typename calogeometryDBEPimpl::AlignmentTokens<T> alignmentTokens_;
+  typename calogeometryDBEPimpl::GeometryTraits<T, U::writeFlag()>::TokenType geometryToken_;
+  typename calogeometryDBEPimpl::AdditionalTokens<T> additionalTokens_;
+  bool applyAlignment_;
 };
 
 #endif

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBReader.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBReader.h
@@ -3,26 +3,21 @@
 
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 
-class CaloGeometryDBReader
-{
+class CaloGeometryDBReader {
 public:
+  typedef CaloSubdetectorGeometry::TrVec TrVec;
+  typedef CaloSubdetectorGeometry::DimVec DimVec;
+  typedef CaloSubdetectorGeometry::IVec IVec;
 
-  typedef CaloSubdetectorGeometry::TrVec  TrVec      ;
-  typedef CaloSubdetectorGeometry::DimVec DimVec     ;
-  typedef CaloSubdetectorGeometry::IVec   IVec       ;
+  static void write(TrVec& /*tvec*/, DimVec& /*dvec*/, IVec& /*ivec*/, const std::string& /*str*/) {}
 
-  static void write( TrVec&      /*tvec*/, 
-		     DimVec&     /*dvec*/, 
-		     IVec&       /*ivec*/,
-		     const std::string& /*str*/   ) {}
+  static void writeIndexed(const TrVec& /*tvec*/,
+                           const DimVec& /*dvec*/,
+                           const IVec& /*ivec*/,
+                           const std::vector<uint32_t>& /*dins*/,
+                           const std::string& /*tag*/) {}
 
-  static void writeIndexed( const TrVec&  /*tvec*/, 
-			    const DimVec& /*dvec*/, 
-			    const IVec&   /*ivec*/,
-			    const std::vector<uint32_t>& /*dins*/,
-			    const std::string&   /*tag*/   ) {}
-
-  static constexpr bool writeFlag() { return false ; }
+  static constexpr bool writeFlag() { return false; }
 
   CaloGeometryDBReader() {}
   virtual ~CaloGeometryDBReader() {}

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBWriter.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBWriter.h
@@ -7,84 +7,48 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-class CaloGeometryDBWriter
-{
-   public:
+class CaloGeometryDBWriter {
+public:
+  typedef CaloSubdetectorGeometry::TrVec TrVec;
+  typedef CaloSubdetectorGeometry::DimVec DimVec;
+  typedef CaloSubdetectorGeometry::IVec IVec;
 
-      typedef CaloSubdetectorGeometry::TrVec  TrVec      ;
-      typedef CaloSubdetectorGeometry::DimVec DimVec     ;
-      typedef CaloSubdetectorGeometry::IVec   IVec       ;
+  static constexpr bool writeFlag() { return true; }
 
-      static constexpr bool writeFlag() { return true ; }
+  static void write(const TrVec& tvec, const DimVec& dvec, const IVec& ivec, const std::string& tag) {
+    const IVec dins;
+    PCaloGeometry* peg = new PCaloGeometry(tvec, dvec, ivec, dins);
 
-      static void write( const TrVec&  tvec, 
-			 const DimVec& dvec, 
-			 const IVec&   ivec,
-			 const std::string&   tag   )
-      {
-	 const IVec dins;
-	 PCaloGeometry* peg = new PCaloGeometry( tvec, dvec, ivec, dins );  
-  
-	 edm::Service<cond::service::PoolDBOutputService> mydbservice;
-	 if( !mydbservice.isAvailable() )
-	 {
-	    edm::LogError("PCaloDBGeometryBuilder")<<"PoolDBOutputService unavailable";
-	 }
-	 else
-	 {
-	    if ( mydbservice->isNewTagRequest( tag ) ) 
-	    {
-	       mydbservice->createNewIOV<PCaloGeometry>( 
-		  peg,
-		  mydbservice->beginOfTime(),
-		  mydbservice->endOfTime(),
-		  tag ) ;
-	    }
-	    else 
-	    {
-	       mydbservice->appendSinceTime<PCaloGeometry>(
-		  peg,
-		  mydbservice->currentTime(),
-		  tag ) ;
-	    }
-	 }
+    edm::Service<cond::service::PoolDBOutputService> mydbservice;
+    if (!mydbservice.isAvailable()) {
+      edm::LogError("PCaloDBGeometryBuilder") << "PoolDBOutputService unavailable";
+    } else {
+      if (mydbservice->isNewTagRequest(tag)) {
+        mydbservice->createNewIOV<PCaloGeometry>(peg, mydbservice->beginOfTime(), mydbservice->endOfTime(), tag);
+      } else {
+        mydbservice->appendSinceTime<PCaloGeometry>(peg, mydbservice->currentTime(), tag);
       }
-    
-      static void writeIndexed( const TrVec&  tvec, 
-				const DimVec& dvec, 
-				const IVec&   ivec,
-				const IVec&   dins,
-				const std::string&   tag   )
-      {
-	 PCaloGeometry* peg = new PCaloGeometry( tvec, dvec, ivec, dins );  
-  
-	 edm::Service<cond::service::PoolDBOutputService> mydbservice;
-	 if( !mydbservice.isAvailable() )
-	 {
-	    edm::LogError("PCaloDBGeometryBuilder")<<"PoolDBOutputService unavailable";
-	 }
-	 else
-	 {
-	    if ( mydbservice->isNewTagRequest( tag ) ) 
-	    {
-	       mydbservice->createNewIOV<PCaloGeometry>( 
-		  peg,
-		  mydbservice->beginOfTime(),
-		  mydbservice->endOfTime(),
-		  tag ) ;
-	    }
-	    else 
-	    {
-	       mydbservice->appendSinceTime<PCaloGeometry>(
-		  peg,
-		  mydbservice->currentTime(),
-		  tag ) ;
-	    }
-	 }
-      }
+    }
+  }
 
-      CaloGeometryDBWriter() {}
-      virtual ~CaloGeometryDBWriter() {}
+  static void writeIndexed(
+      const TrVec& tvec, const DimVec& dvec, const IVec& ivec, const IVec& dins, const std::string& tag) {
+    PCaloGeometry* peg = new PCaloGeometry(tvec, dvec, ivec, dins);
+
+    edm::Service<cond::service::PoolDBOutputService> mydbservice;
+    if (!mydbservice.isAvailable()) {
+      edm::LogError("PCaloDBGeometryBuilder") << "PoolDBOutputService unavailable";
+    } else {
+      if (mydbservice->isNewTagRequest(tag)) {
+        mydbservice->createNewIOV<PCaloGeometry>(peg, mydbservice->beginOfTime(), mydbservice->endOfTime(), tag);
+      } else {
+        mydbservice->appendSinceTime<PCaloGeometry>(peg, mydbservice->currentTime(), tag);
+      }
+    }
+  }
+
+  CaloGeometryDBWriter() {}
+  virtual ~CaloGeometryDBWriter() {}
 };
 
 #endif

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.h
@@ -20,48 +20,35 @@
 
 class DDCompactView;
 
-template < class T >
-class CaloGeometryLoader
-{
+template <class T>
+class CaloGeometryLoader {
 public:
-
-  typedef std::vector< double > ParmVec ;
+  typedef std::vector<double> ParmVec;
 
   using PtrType = std::unique_ptr<CaloSubdetectorGeometry>;
 
-  typedef CaloSubdetectorGeometry::ParVec    ParVec ;
-  typedef CaloSubdetectorGeometry::ParVecVec ParVecVec ;
+  typedef CaloSubdetectorGeometry::ParVec ParVec;
+  typedef CaloSubdetectorGeometry::ParVecVec ParVecVec;
 
-  static const double k_ScaleFromDDDtoGeant ;
+  static const double k_ScaleFromDDDtoGeant;
 
-  CaloGeometryLoader< T >() ;
+  CaloGeometryLoader<T>();
 
-  virtual ~CaloGeometryLoader< T >() {}
- 
-  PtrType load( const DDCompactView* cpv,
-		const Alignments*    alignments = nullptr ,
-		const Alignments*    globals    = nullptr  ) ;  
+  virtual ~CaloGeometryLoader<T>() {}
+
+  PtrType load(const DDCompactView* cpv, const Alignments* alignments = nullptr, const Alignments* globals = nullptr);
 
 private:
+  void makeGeometry(const DDCompactView* cpv, T* geom, const Alignments* alignments, const Alignments* globals);
 
-  void makeGeometry( const DDCompactView*  cpv        , 
-		     T*                    geom       ,
-		     const Alignments*     alignments ,
-		     const Alignments*     globals       ) ;
-      
-  void fillNamedParams( const DDFilteredView& fv,
-			T*             geom ) ;
-      
-  void fillGeom( T*                    geom ,
-		 const ParmVec&        pv ,
-		 const HepGeom::Transform3D& tr ,
-		 const DetId&          id    ) ;
+  void fillNamedParams(const DDFilteredView& fv, T* geom);
 
-  unsigned int getDetIdForDDDNode( const DDFilteredView& fv ) ;
+  void fillGeom(T* geom, const ParmVec& pv, const HepGeom::Transform3D& tr, const DetId& id);
+
+  unsigned int getDetIdForDDDNode(const DDFilteredView& fv);
 
   typename T::NumberingScheme m_scheme;
-  DDAndFilter<DDSpecificsMatchesValueFilter,
-              DDSpecificsMatchesValueFilter> m_filter;
+  DDAndFilter<DDSpecificsMatchesValueFilter, DDSpecificsMatchesValueFilter> m_filter;
 };
 
 #endif

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
@@ -30,128 +30,99 @@
 #include <vector>
 
 template <class T>
-const double 
-CaloGeometryLoader<T>::k_ScaleFromDDDtoGeant ( 0.1 ) ;
+const double CaloGeometryLoader<T>::k_ScaleFromDDDtoGeant(0.1);
 
 template <class T>
-CaloGeometryLoader<T>::CaloGeometryLoader() :
-m_filter(DDSpecificsMatchesValueFilter{DDValue( "SensitiveDetector",
-                                                "EcalSensitiveDetector",
-				                0                        )},
-         DDSpecificsMatchesValueFilter{DDValue( "ReadOutName",
-   				                T::hitString(),
-				                0              )})
-{
+CaloGeometryLoader<T>::CaloGeometryLoader()
+    : m_filter(DDSpecificsMatchesValueFilter{DDValue("SensitiveDetector", "EcalSensitiveDetector", 0)},
+               DDSpecificsMatchesValueFilter{DDValue("ReadOutName", T::hitString(), 0)}) {}
+
+template <class T>
+typename CaloGeometryLoader<T>::PtrType CaloGeometryLoader<T>::load(const DDCompactView* cpv,
+                                                                    const Alignments* alignments,
+                                                                    const Alignments* globals) {
+  PtrType geom = std::make_unique<T>();
+
+  makeGeometry(cpv, dynamic_cast<T*>(geom.get()), alignments, globals);
+
+  return geom;
 }
 
 template <class T>
-typename CaloGeometryLoader<T>::PtrType
-CaloGeometryLoader<T>::load( const DDCompactView*  cpv        ,
-			     const Alignments*     alignments ,
-			     const Alignments*     globals       ) 
-{
-   PtrType geom = std::make_unique<T>();
+void CaloGeometryLoader<T>::makeGeometry(const DDCompactView* cpv,
+                                         T* geom,
+                                         const Alignments* alignments,
+                                         const Alignments* globals) {
+  DDFilteredView fv0(*cpv, m_filter);
 
-   makeGeometry( cpv,
-		 dynamic_cast<T*>( geom.get() ),
-		 alignments,
-		 globals ) ;
+  fillNamedParams(fv0, geom);
 
-   return geom ;
+  geom->allocateCorners(T::k_NumberOfCellsForCorners);
+  geom->allocatePar(T::k_NumberOfParametersPerShape * T::k_NumberOfShapes, T::k_NumberOfParametersPerShape);
+
+  DDFilteredView fv(*cpv, m_filter);
+
+  unsigned int counter(0);
+  for (bool doSubDets = fv.firstChild(); doSubDets; doSubDets = fv.nextSibling()) {
+    const DDSolid& solid(fv.logicalPart().solid());
+    if (boost::starts_with(solid.name().name(), "EA")) {
+      continue;
+    }
+    ++counter;
+
+    const ParmVec& parameters(solid.parameters());
+
+    DD3Vector x, y, z;
+    fv.rotation().GetComponents(x, y, z);
+    const CLHEP::HepRep3x3 temp(x.X(), y.X(), z.X(), x.Y(), y.Y(), z.Y(), x.Z(), y.Z(), z.Z());
+    const CLHEP::HepRotation hr(temp);
+    const CLHEP::Hep3Vector h3v(fv.translation().X(), fv.translation().Y(), fv.translation().Z());
+    const HepGeom::Transform3D ht3d(hr,  // only scale translation
+                                    k_ScaleFromDDDtoGeant * h3v);
+
+    const DetId id(getDetIdForDDDNode(fv));
+
+    const unsigned int which(geom->alignmentTransformIndexLocal(id));
+
+    assert(nullptr == alignments || which < alignments->m_align.size());
+
+    const AlignTransform* at(nullptr == alignments ? nullptr : &alignments->m_align[which]);
+
+    assert(nullptr == at || (geom->alignmentTransformIndexLocal(DetId(at->rawId())) == which));
+
+    const unsigned int gIndex(geom->alignmentTransformIndexGlobal(id));
+
+    const AlignTransform* globalT(
+        nullptr == globals ? nullptr : (globals->m_align.size() > gIndex ? &globals->m_align[gIndex] : nullptr));
+
+    const HepGeom::Transform3D atr(
+        nullptr == at ? ht3d
+                      : (nullptr == globalT ? at->transform() * ht3d : at->transform() * globalT->transform() * ht3d));
+
+    fillGeom(geom, parameters, atr, id);
+  }
+
+  assert(counter <= T::k_NumberOfCellsForCorners);
+
+  geom->initializeParms();
 }
 
 template <class T>
-void 
-CaloGeometryLoader<T>::makeGeometry( const DDCompactView*  cpv        ,
-				     T*                    geom       ,
-				     const Alignments*     alignments ,
-				     const Alignments*     globals      )
-{
-   DDFilteredView fv0 ( *cpv, m_filter ) ;
-
-   fillNamedParams( fv0, geom ) ;
-
-   geom->allocateCorners( T::k_NumberOfCellsForCorners ) ;
-   geom->allocatePar( T::k_NumberOfParametersPerShape*T::k_NumberOfShapes,
-		      T::k_NumberOfParametersPerShape ) ;
-
-   DDFilteredView fv( *cpv, m_filter ) ;
- 
-   unsigned int counter ( 0 ) ;
-   for( bool doSubDets = fv.firstChild(); doSubDets ; doSubDets = fv.nextSibling() )
-   {
-      const DDSolid& solid ( fv.logicalPart().solid() ) ;
-      if (boost::starts_with(solid.name().name(), "EA")) 
-      {
-	 continue;
-      }      
-      ++counter ;
-
-      const ParmVec& parameters ( solid.parameters() ) ;
-
-      DD3Vector x, y, z;
-      fv.rotation().GetComponents( x, y, z ) ;
-      const CLHEP::HepRep3x3 temp( x.X(), y.X(), z.X(),
-				   x.Y(), y.Y(), z.Y(),
-			           x.Z(), y.Z(), z.Z() );
-      const CLHEP::HepRotation hr ( temp );
-      const CLHEP::Hep3Vector h3v ( fv.translation().X(),
-		 		    fv.translation().Y(),
-				    fv.translation().Z()  ) ;
-      const HepGeom::Transform3D ht3d ( hr,          // only scale translation
-	 	 		        k_ScaleFromDDDtoGeant*h3v ) ;    
-
-      const DetId id ( getDetIdForDDDNode( fv ) ) ;
-
-      const unsigned int which ( geom->alignmentTransformIndexLocal( id ) ) ;
-
-      assert( nullptr == alignments ||
-	      which < alignments->m_align.size() ) ;
-
-      const AlignTransform* at ( nullptr == alignments ? nullptr :
-				 &alignments->m_align[ which ] ) ;
-
-      assert( nullptr == at || ( geom->alignmentTransformIndexLocal( DetId( at->rawId() ) ) == which ) ) ;
-
-      const unsigned int gIndex ( geom->alignmentTransformIndexGlobal( id ) ) ;
-
-      const AlignTransform* globalT ( nullptr == globals ? nullptr :
-				      ( globals->m_align.size() > gIndex ? 
-					&globals->m_align[ gIndex ] : nullptr ) ) ;
-
-      const HepGeom::Transform3D atr ( nullptr == at ? ht3d :
-				 ( nullptr == globalT ? at->transform()*ht3d :
-				   at->transform()*globalT->transform()*ht3d ) ) ;
-
-      fillGeom( geom, parameters, atr, id ) ;
-   }
-
-   assert( counter <= T::k_NumberOfCellsForCorners ) ;
-
-   geom->initializeParms() ;
-}
-
-template <class T>
-unsigned int 
-CaloGeometryLoader<T>::getDetIdForDDDNode( const DDFilteredView& fv )
-{
+unsigned int CaloGeometryLoader<T>::getDetIdForDDDNode(const DDFilteredView& fv) {
   // perform some consistency checks
   // get the parents and grandparents of this node
 
-  const DDGeoHistory& parents ( fv.geoHistory() ) ;
-  const DDGeoHistory::size_type psize ( parents.size() ) ;
+  const DDGeoHistory& parents(fv.geoHistory());
+  const DDGeoHistory::size_type psize(parents.size());
 
-  EcalBaseNumber baseNumber ;
-  baseNumber.setSize( psize ) ;
+  EcalBaseNumber baseNumber;
+  baseNumber.setSize(psize);
 
-  for( unsigned int i=1 ; i<=psize ; ++i )
-  {
-     baseNumber.addLevel( parents[psize-i].logicalPart().name().name(),
-			  parents[psize-i].copyno() ) ;
+  for (unsigned int i = 1; i <= psize; ++i) {
+    baseNumber.addLevel(parents[psize - i].logicalPart().name().name(), parents[psize - i].copyno());
   }
 
-  return m_scheme.getUnitID( baseNumber );  
+  return m_scheme.getUnitID(baseNumber);
 }
-
 
 #endif

--- a/Geometry/CaloEventSetup/interface/CaloTopologyRecord.h
+++ b/Geometry/CaloEventSetup/interface/CaloTopologyRecord.h
@@ -5,4 +5,4 @@
 
 #include "Geometry/Records/interface/CaloTopologyRecord.h"
 
-#endif 
+#endif

--- a/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CaloGeometryBuilder
 // Class:      CaloGeometryBuilder
-// 
+//
 /**\class CaloGeometryBuilder CaloGeometryBuilder.h tmp/CaloGeometryBuilder/interface/CaloGeometryBuilder.h
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Mon Oct  3 11:35:27 CDT 2005
 //
 //
-
 
 // user include files
 #include "Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h"
@@ -34,123 +33,122 @@
 
 namespace {
   template <typename Record>
-  void makeToken(edm::ESConsumesCollector& cc, std::vector<std::string>& list, std::string const& tag, edm::ESGetToken<CaloSubdetectorGeometry, Record>& token) {
+  void makeToken(edm::ESConsumesCollector& cc,
+                 std::vector<std::string>& list,
+                 std::string const& tag,
+                 edm::ESGetToken<CaloSubdetectorGeometry, Record>& token) {
     auto found = std::find(list.begin(), list.end(), tag);
-    if(found != list.end()) {
+    if (found != list.end()) {
       token = cc.consumesFrom<CaloSubdetectorGeometry, Record>(edm::ESInputTag{"", *found});
       list.erase(found);
     }
   }
-}
+}  // namespace
 
 //
 // member functions
 //
-CaloGeometryBuilder::CaloGeometryBuilder( const edm::ParameterSet& iConfig )
-{
-   //the following line is needed to tell the framework what
-   // data is being produced
-   auto cc = setWhatProduced( this,
-                              &CaloGeometryBuilder::produceAligned );
+CaloGeometryBuilder::CaloGeometryBuilder(const edm::ParameterSet& iConfig) {
+  //the following line is needed to tell the framework what
+  // data is being produced
+  auto cc = setWhatProduced(this, &CaloGeometryBuilder::produceAligned);
 
-   //now do what ever other initialization is needed
-   auto caloList = iConfig.getParameter< std::vector<std::string> >("SelectedCalos");
-   if ( caloList.empty() ) throw cms::Exception("Configuration")
-      << "No calorimeter specified for geometry, aborting";
+  //now do what ever other initialization is needed
+  auto caloList = iConfig.getParameter<std::vector<std::string> >("SelectedCalos");
+  if (caloList.empty())
+    throw cms::Exception("Configuration") << "No calorimeter specified for geometry, aborting";
 
-   makeToken(cc, caloList, HcalGeometry::producerTag(), hcalToken_);
-   makeToken(cc, caloList, ZdcGeometry::producerTag(), zdcToken_);
-   makeToken(cc, caloList, CastorGeometry::producerTag(), castorToken_);
-   makeToken(cc, caloList, EcalBarrelGeometry::producerTag(), ecalBarrelToken_);
-   makeToken(cc, caloList, EcalEndcapGeometry::producerTag(), ecalEndcapToken_);
-   makeToken(cc, caloList, EcalPreshowerGeometry::producerTag(), ecalPreshowerToken_);
-   makeToken(cc, caloList, CaloTowerGeometry::producerTag(), caloTowerToken_);
+  makeToken(cc, caloList, HcalGeometry::producerTag(), hcalToken_);
+  makeToken(cc, caloList, ZdcGeometry::producerTag(), zdcToken_);
+  makeToken(cc, caloList, CastorGeometry::producerTag(), castorToken_);
+  makeToken(cc, caloList, EcalBarrelGeometry::producerTag(), ecalBarrelToken_);
+  makeToken(cc, caloList, EcalEndcapGeometry::producerTag(), ecalEndcapToken_);
+  makeToken(cc, caloList, EcalPreshowerGeometry::producerTag(), ecalPreshowerToken_);
+  makeToken(cc, caloList, CaloTowerGeometry::producerTag(), caloTowerToken_);
 
-   // Move HGC elements to the end
-   auto hgcBegin = std::partition(caloList.begin(), caloList.end(), [](std::string const& elem) {
-       return elem.find(HGCalGeometry::producerTag()) == std::string::npos;
-     });
-   // Process HGC elements
-   for(auto iter = hgcBegin; iter != caloList.end(); ++iter) {
-     hgcalTokens_.emplace_back(cc.consumesFrom<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", *iter}), *iter);
-   }
-   // Erase HGC elements
-   caloList.erase(hgcBegin, caloList.end());
+  // Move HGC elements to the end
+  auto hgcBegin = std::partition(caloList.begin(), caloList.end(), [](std::string const& elem) {
+    return elem.find(HGCalGeometry::producerTag()) == std::string::npos;
+  });
+  // Process HGC elements
+  for (auto iter = hgcBegin; iter != caloList.end(); ++iter) {
+    hgcalTokens_.emplace_back(cc.consumesFrom<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", *iter}), *iter);
+  }
+  // Erase HGC elements
+  caloList.erase(hgcBegin, caloList.end());
 
-   // Throw if any elements are left
-   if(not caloList.empty()) {
-     cms::Exception ex{"Configuration"};
-     ex << "Reconstruction geometry requested for a not implemented sub-detectors:";
-     for(auto const& elem: caloList) {
-       ex << " " << elem;
-     }
-     throw ex;
-   }
+  // Throw if any elements are left
+  if (not caloList.empty()) {
+    cms::Exception ex{"Configuration"};
+    ex << "Reconstruction geometry requested for a not implemented sub-detectors:";
+    for (auto const& elem : caloList) {
+      ex << " " << elem;
+    }
+    throw ex;
+  }
 }
 
 // ------------ method called to produce the data  ------------
 
-CaloGeometryBuilder::ReturnType
-CaloGeometryBuilder::produceAligned( const CaloGeometryRecord& iRecord )
-{
-   edm::ESHandle< CaloSubdetectorGeometry > pG;
+CaloGeometryBuilder::ReturnType CaloGeometryBuilder::produceAligned(const CaloGeometryRecord& iRecord) {
+  edm::ESHandle<CaloSubdetectorGeometry> pG;
 
-   ReturnType pCalo  = std::make_unique<CaloGeometry>();
+  ReturnType pCalo = std::make_unique<CaloGeometry>();
 
-   // look for HCAL parts
-   // assume 'HCAL' for all of HCAL.
-   if(hcalToken_.isInitialized()) {
-     edm::LogInfo("CaloGeometryBuilder") << "Building HCAL reconstruction geometry";
+  // look for HCAL parts
+  // assume 'HCAL' for all of HCAL.
+  if (hcalToken_.isInitialized()) {
+    edm::LogInfo("CaloGeometryBuilder") << "Building HCAL reconstruction geometry";
 
-     auto const& pG = iRecord.get(hcalToken_);
-     pCalo->setSubdetGeometry( DetId::Hcal, HcalBarrel , &pG );
-     pCalo->setSubdetGeometry( DetId::Hcal, HcalEndcap , &pG );
-     pCalo->setSubdetGeometry( DetId::Hcal, HcalOuter  , &pG );
-     pCalo->setSubdetGeometry( DetId::Hcal, HcalForward, &pG );
-   }
-   if(zdcToken_.isInitialized()) {
-     edm::LogInfo("CaloGeometryBuilder") << "Building ZDC reconstruction geometry";
-     auto const& pG = iRecord.get( zdcToken_ );
-     pCalo->setSubdetGeometry( DetId::Calo, HcalZDCDetId::SubdetectorId, &pG);
-   }
-   if(castorToken_.isInitialized()) {
-     edm::LogInfo("CaloGeometryBuilder") << "Building CASTOR reconstruction geometry";
-     auto const& pG = iRecord.get( castorToken_ );
-     pCalo->setSubdetGeometry( DetId::Calo, HcalCastorDetId::SubdetectorId, &pG);
-   }
+    auto const& pG = iRecord.get(hcalToken_);
+    pCalo->setSubdetGeometry(DetId::Hcal, HcalBarrel, &pG);
+    pCalo->setSubdetGeometry(DetId::Hcal, HcalEndcap, &pG);
+    pCalo->setSubdetGeometry(DetId::Hcal, HcalOuter, &pG);
+    pCalo->setSubdetGeometry(DetId::Hcal, HcalForward, &pG);
+  }
+  if (zdcToken_.isInitialized()) {
+    edm::LogInfo("CaloGeometryBuilder") << "Building ZDC reconstruction geometry";
+    auto const& pG = iRecord.get(zdcToken_);
+    pCalo->setSubdetGeometry(DetId::Calo, HcalZDCDetId::SubdetectorId, &pG);
+  }
+  if (castorToken_.isInitialized()) {
+    edm::LogInfo("CaloGeometryBuilder") << "Building CASTOR reconstruction geometry";
+    auto const& pG = iRecord.get(castorToken_);
+    pCalo->setSubdetGeometry(DetId::Calo, HcalCastorDetId::SubdetectorId, &pG);
+  }
 
-   // look for Ecal Barrel
-   if(ecalBarrelToken_.isInitialized()) {
-     edm::LogInfo("CaloGeometryBuilder") << "Building EcalBarrel reconstruction geometry";
-     auto const& pG = iRecord.get( ecalBarrelToken_ );
-     pCalo->setSubdetGeometry(DetId::Ecal, EcalBarrel, &pG);
-   }
-   // look for Ecal Endcap
-   if(ecalEndcapToken_.isInitialized()) {
-     edm::LogInfo("CaloGeometryBuilder") << "Building EcalEndcap reconstruction geometry";
-     auto const& pG = iRecord.get( ecalEndcapToken_ );
-     pCalo->setSubdetGeometry(DetId::Ecal, EcalEndcap, &pG);
-   }
-   // look for Ecal Preshower
-   if(ecalPreshowerToken_.isInitialized()) {
-     edm::LogInfo("CaloGeometryBuilder") << "Building EcalPreshower reconstruction geometry";
-     const auto& pG = iRecord.get(ecalPreshowerToken_);
-     pCalo->setSubdetGeometry(DetId::Ecal, EcalPreshower, &pG);
-   }
+  // look for Ecal Barrel
+  if (ecalBarrelToken_.isInitialized()) {
+    edm::LogInfo("CaloGeometryBuilder") << "Building EcalBarrel reconstruction geometry";
+    auto const& pG = iRecord.get(ecalBarrelToken_);
+    pCalo->setSubdetGeometry(DetId::Ecal, EcalBarrel, &pG);
+  }
+  // look for Ecal Endcap
+  if (ecalEndcapToken_.isInitialized()) {
+    edm::LogInfo("CaloGeometryBuilder") << "Building EcalEndcap reconstruction geometry";
+    auto const& pG = iRecord.get(ecalEndcapToken_);
+    pCalo->setSubdetGeometry(DetId::Ecal, EcalEndcap, &pG);
+  }
+  // look for Ecal Preshower
+  if (ecalPreshowerToken_.isInitialized()) {
+    edm::LogInfo("CaloGeometryBuilder") << "Building EcalPreshower reconstruction geometry";
+    const auto& pG = iRecord.get(ecalPreshowerToken_);
+    pCalo->setSubdetGeometry(DetId::Ecal, EcalPreshower, &pG);
+  }
 
-   // look for TOWER parts
-   if(caloTowerToken_.isInitialized()) {
-     edm::LogInfo("CaloGeometryBuilder") << "Building TOWER reconstruction geometry";
-     const auto& pG = iRecord.get(caloTowerToken_);
-     pCalo->setSubdetGeometry(DetId::Calo, 1, &pG);
-   }
+  // look for TOWER parts
+  if (caloTowerToken_.isInitialized()) {
+    edm::LogInfo("CaloGeometryBuilder") << "Building TOWER reconstruction geometry";
+    const auto& pG = iRecord.get(caloTowerToken_);
+    pCalo->setSubdetGeometry(DetId::Calo, 1, &pG);
+  }
 
-   for(auto const& hgcTokenLabel: hgcalTokens_) {
-     edm::LogInfo("CaloGeometryBuilder") << "Building " << hgcTokenLabel.second << " reconstruction geometry";
-     auto const& pHG = iRecord.get(hgcTokenLabel.first);
-     const auto& topo = pHG.topology();
-     pCalo->setSubdetGeometry(topo.detector(), topo.subDetector(), &pHG);
-   }
+  for (auto const& hgcTokenLabel : hgcalTokens_) {
+    edm::LogInfo("CaloGeometryBuilder") << "Building " << hgcTokenLabel.second << " reconstruction geometry";
+    auto const& pHG = iRecord.get(hgcTokenLabel.first);
+    const auto& topo = pHG.topology();
+    pCalo->setSubdetGeometry(topo.detector(), topo.subDetector(), &pHG);
+  }
 
-   return pCalo ;
+  return pCalo;
 }

--- a/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloGeometryBuilder.h
@@ -2,7 +2,7 @@
 //
 // Package:    CaloGeometryBuilder
 // Class:      CaloGeometryBuilder
-// 
+//
 /**\class CaloGeometryBuilder CaloGeometryBuilder.h tmp/CaloGeometryBuilder/interface/CaloGeometryBuilder.h
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Mon Oct  3 11:35:27 CDT 2005
 //
 //
-
 
 // system include files
 #include <memory>
@@ -36,28 +35,25 @@
 // class decleration
 //
 
-class CaloGeometryBuilder : public edm::ESProducer 
-{
-   public:
+class CaloGeometryBuilder : public edm::ESProducer {
+public:
+  using ReturnType = std::unique_ptr<CaloGeometry>;
 
-      using ReturnType = std::unique_ptr<CaloGeometry>;
+  CaloGeometryBuilder(const edm::ParameterSet& iConfig);
 
-      CaloGeometryBuilder( const edm::ParameterSet& iConfig ) ;
+  ~CaloGeometryBuilder() override{};
 
-      ~CaloGeometryBuilder() override {} ;
+  ReturnType produceAligned(const CaloGeometryRecord& iRecord);
 
-      ReturnType produceAligned( const CaloGeometryRecord&  iRecord ) ;
+private:
+  // ----------member data ---------------------------
 
-   private:
-      // ----------member data ---------------------------
-      
-      edm::ESGetToken<CaloSubdetectorGeometry, HcalGeometryRecord> hcalToken_;
-      edm::ESGetToken<CaloSubdetectorGeometry, ZDCGeometryRecord> zdcToken_;
-      edm::ESGetToken<CaloSubdetectorGeometry, CastorGeometryRecord> castorToken_;
-      edm::ESGetToken<CaloSubdetectorGeometry, EcalBarrelGeometryRecord> ecalBarrelToken_;
-      edm::ESGetToken<CaloSubdetectorGeometry, EcalEndcapGeometryRecord> ecalEndcapToken_;
-      edm::ESGetToken<CaloSubdetectorGeometry, EcalPreshowerGeometryRecord> ecalPreshowerToken_;
-      edm::ESGetToken<CaloSubdetectorGeometry, CaloTowerGeometryRecord> caloTowerToken_;
-      std::vector<std::pair<edm::ESGetToken<HGCalGeometry, IdealGeometryRecord>, std::string>> hgcalTokens_;
+  edm::ESGetToken<CaloSubdetectorGeometry, HcalGeometryRecord> hcalToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, ZDCGeometryRecord> zdcToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, CastorGeometryRecord> castorToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, EcalBarrelGeometryRecord> ecalBarrelToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, EcalEndcapGeometryRecord> ecalEndcapToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, EcalPreshowerGeometryRecord> ecalPreshowerToken_;
+  edm::ESGetToken<CaloSubdetectorGeometry, CaloTowerGeometryRecord> caloTowerToken_;
+  std::vector<std::pair<edm::ESGetToken<HGCalGeometry, IdealGeometryRecord>, std::string>> hgcalTokens_;
 };
-

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.cc
@@ -5,36 +5,24 @@
 #include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
+CaloTopologyBuilder::CaloTopologyBuilder(const edm::ParameterSet& /*iConfig*/)
+    : geometryToken_{setWhatProduced(this, &CaloTopologyBuilder::produceCalo)
+                         .consumesFrom<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})} {}
 
-CaloTopologyBuilder::CaloTopologyBuilder( const edm::ParameterSet& /*iConfig*/ ):
-  geometryToken_{setWhatProduced(this, &CaloTopologyBuilder::produceCalo).consumesFrom<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})}
-{}
-
-CaloTopologyBuilder::~CaloTopologyBuilder()
-{ 
-}
-
+CaloTopologyBuilder::~CaloTopologyBuilder() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-CaloTopologyBuilder::ReturnType
-CaloTopologyBuilder::produceCalo( const CaloTopologyRecord& iRecord )
-{
-   const auto& geometry = iRecord.get(geometryToken_);
+CaloTopologyBuilder::ReturnType CaloTopologyBuilder::produceCalo(const CaloTopologyRecord& iRecord) {
+  const auto& geometry = iRecord.get(geometryToken_);
 
-   ReturnType ct = std::make_unique<CaloTopology>();
-   //ECAL parts      
-   ct->setSubdetTopology( DetId::Ecal,
-			  EcalBarrel,
-			  std::make_unique<EcalBarrelTopology>( geometry ) ) ;
-   ct->setSubdetTopology( DetId::Ecal,
-			  EcalEndcap,
-			  std::make_unique<EcalEndcapTopology>( geometry ) ) ;
-   ct->setSubdetTopology( DetId::Ecal,
-			  EcalPreshower,
-			  std::make_unique<EcalPreshowerTopology>());
-   return ct ;
+  ReturnType ct = std::make_unique<CaloTopology>();
+  //ECAL parts
+  ct->setSubdetTopology(DetId::Ecal, EcalBarrel, std::make_unique<EcalBarrelTopology>(geometry));
+  ct->setSubdetTopology(DetId::Ecal, EcalEndcap, std::make_unique<EcalEndcapTopology>(geometry));
+  ct->setSubdetTopology(DetId::Ecal, EcalPreshower, std::make_unique<EcalPreshowerTopology>());
+  return ct;
 }

--- a/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTopologyBuilder.h
@@ -2,7 +2,7 @@
 //
 // Package:    CaloTopologyBuilder
 // Class:      CaloTopologyBuilder
-// 
+//
 /**\class CaloTopologyBuilder CaloTopologyBuilder.h 
 
  Description: <one line class summary>
@@ -14,7 +14,6 @@
 // Original Author:  Paolo Meridiani
 //
 //
-
 
 // system include files
 #include <memory>
@@ -32,18 +31,16 @@
 // class decleration
 //
 
-class CaloTopologyBuilder : public edm::ESProducer 
-{
-   public:
-      CaloTopologyBuilder( const edm::ParameterSet& iP );
-      ~CaloTopologyBuilder() override ;
+class CaloTopologyBuilder : public edm::ESProducer {
+public:
+  CaloTopologyBuilder(const edm::ParameterSet& iP);
+  ~CaloTopologyBuilder() override;
 
-      using ReturnType = std::unique_ptr<CaloTopology>;
+  using ReturnType = std::unique_ptr<CaloTopology>;
 
-      ReturnType produceCalo(  const CaloTopologyRecord&  );
+  ReturnType produceCalo(const CaloTopologyRecord&);
 
-   private:
-      // ----------member data ---------------------------
-      edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+private:
+  // ----------member data ---------------------------
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
 };
-

--- a/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/CaloTowerConstituentsMapBuilder.h
@@ -2,7 +2,7 @@
 //
 // Package:    CaloTowerConstituentsMapBuilder
 // Class:      CaloTowerConstituentsMapBuilder
-// 
+//
 /**\class CaloTowerConstituentsMapBuilder CaloTowerConstituentsMapBuilder.h tmp/CaloTowerConstituentsMapBuilder/interface/CaloTowerConstituentsMapBuilder.h
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Mon Oct  3 11:35:27 CDT 2005
 //
 //
-
 
 // system include files
 #include <memory>
@@ -48,15 +47,14 @@ public:
   typedef std::unique_ptr<CaloTowerConstituentsMap> ReturnType;
 
   ReturnType produce(const CaloGeometryRecord&);
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void parseTextMap(const std::string& filename,CaloTowerConstituentsMap& theMap);
-  void assignEEtoHE(const CaloGeometry* geometry, CaloTowerConstituentsMap& theMap, const CaloTowerTopology * cttopo);
+  void parseTextMap(const std::string& filename, CaloTowerConstituentsMap& theMap);
+  void assignEEtoHE(const CaloGeometry* geometry, CaloTowerConstituentsMap& theMap, const CaloTowerTopology* cttopo);
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcaltopoToken_;
   edm::ESGetToken<CaloTowerTopology, HcalRecNumberingRecord> cttopoToken_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   std::string mapFile_;
   bool mapAuto_, skipHE_;
 };
-

--- a/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EcalTrigTowerConstituentsMapBuilder
 // Class:      EcalTrigTowerConstituentsMapBuilder
-// 
+//
 /**\class EcalTrigTowerConstituentsMapBuilder EcalTrigTowerConstituentsMapBuilder.h tmp/EcalTrigTowerConstituentsMapBuilder/interface/EcalTrigTowerConstituentsMapBuilder.h
 
  Description: <one line class summary>
@@ -23,57 +23,53 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-EcalTrigTowerConstituentsMapBuilder::EcalTrigTowerConstituentsMapBuilder(const edm::ParameterSet& iConfig) :
-  mapFile_(iConfig.getUntrackedParameter<std::string>("MapFile",""))
-{
+EcalTrigTowerConstituentsMapBuilder::EcalTrigTowerConstituentsMapBuilder(const edm::ParameterSet& iConfig)
+    : mapFile_(iConfig.getUntrackedParameter<std::string>("MapFile", "")) {
   setWhatProduced(this);
 }
 
-EcalTrigTowerConstituentsMapBuilder::~EcalTrigTowerConstituentsMapBuilder()
-{ 
+EcalTrigTowerConstituentsMapBuilder::~EcalTrigTowerConstituentsMapBuilder() {}
+
+EcalTrigTowerConstituentsMapBuilder::ReturnType EcalTrigTowerConstituentsMapBuilder::produce(
+    const IdealGeometryRecord& iRecord) {
+  auto prod = std::make_unique<EcalTrigTowerConstituentsMap>();
+
+  if (!mapFile_.empty()) {
+    parseTextMap(mapFile_, *prod);
+  }
+  return prod;
 }
 
-EcalTrigTowerConstituentsMapBuilder::ReturnType
-EcalTrigTowerConstituentsMapBuilder::produce(const IdealGeometryRecord& iRecord)
-{
-   auto prod = std::make_unique<EcalTrigTowerConstituentsMap>();
-
-   if (!mapFile_.empty()) {
-     parseTextMap(mapFile_,*prod);
-   }
-   return prod;
-}
-
-void EcalTrigTowerConstituentsMapBuilder::parseTextMap(const std::string& filename, EcalTrigTowerConstituentsMap& theMap) {
+void EcalTrigTowerConstituentsMapBuilder::parseTextMap(const std::string& filename,
+                                                       EcalTrigTowerConstituentsMap& theMap) {
   edm::FileInPath eff(filename);
-  
+
   std::ifstream f(eff.fullPath().c_str());
   if (!f.good())
-    return; 
-  
-  int ietaTower,iphiTower;
-  int ix,iy,iz;
+    return;
+
+  int ietaTower, iphiTower;
+  int ix, iy, iz;
   char line[80];  // a buffer for the line to read
   char ch;        // a temporary for holding the end of line
   while ((ch = f.peek()) != '-') {
-    f.get(line,80,'\n');            // read 80 characters to end of line
-    f.get(ch);                      // eat out the '\n'
+    f.get(line, 80, '\n');  // read 80 characters to end of line
+    f.get(ch);              // eat out the '\n'
     // extract the numbers
 
-    int nread = sscanf (line, " %d %d %d %d %d",&ix,&iy,&iz,&ietaTower, &iphiTower);
+    int nread = sscanf(line, " %d %d %d %d %d", &ix, &iy, &iz, &ietaTower, &iphiTower);
     if (nread == 5) {
-      EEDetId eeid(ix,iy,iz,0);
-      EcalTrigTowerDetId etid(iz,EcalEndcap,ietaTower,iphiTower);
-      theMap.assign(DetId(eeid),etid);
+      EEDetId eeid(ix, iy, iz, 0);
+      EcalTrigTowerDetId etid(iz, EcalEndcap, ietaTower, iphiTower);
+      theMap.assign(DetId(eeid), etid);
     }
-    
   }
   // Pass comment line
-  f.get(line,80,'\n');            // read 80 characters to end of line
-  f.get(ch);                      // eat out the '\n'
+  f.get(line, 80, '\n');  // read 80 characters to end of line
+  f.get(ch);              // eat out the '\n'
   // Next info line
-  f.get(line,80,'\n');            // read 80 characters to end of line
-  f.get(ch);                      // eat out the '\n'
+  f.get(line, 80, '\n');  // read 80 characters to end of line
+  f.get(ch);              // eat out the '\n'
   f.close();
   return;
 }

--- a/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
+++ b/Geometry/CaloEventSetup/plugins/EcalTrigTowerConstituentsMapBuilder.h
@@ -2,7 +2,7 @@
 //
 // Package:    EcalTrigTowerConstituentsMapBuilder
 // Class:      EcalTrigTowerConstituentsMapBuilder
-// 
+//
 /**\class EcalTrigTowerConstituentsMapBuilder EcalTrigTowerConstituentsMapBuilder.h tmp/EcalTrigTowerConstituentsMapBuilder/interface/EcalTrigTowerConstituentsMapBuilder.h
 
  Description: <one line class summary>
@@ -33,7 +33,7 @@
 //
 
 class EcalTrigTowerConstituentsMapBuilder : public edm::ESProducer {
-   public:
+public:
   EcalTrigTowerConstituentsMapBuilder(const edm::ParameterSet&);
   ~EcalTrigTowerConstituentsMapBuilder() override;
 
@@ -42,9 +42,9 @@ class EcalTrigTowerConstituentsMapBuilder : public edm::ESProducer {
   ReturnType produce(const IdealGeometryRecord&);
 
 private:
-  void parseTextMap(const std::string& filename,EcalTrigTowerConstituentsMap& theMap);
+  void parseTextMap(const std::string& filename, EcalTrigTowerConstituentsMap& theMap);
   std::string mapFile_;
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 #endif

--- a/Geometry/CaloEventSetup/plugins/FakeCaloAlignmentEP.cc
+++ b/Geometry/CaloEventSetup/plugins/FakeCaloAlignmentEP.cc
@@ -2,7 +2,7 @@
 //
 // Package:    FakeCaloAlignmentEP
 // Class:      FakeCaloAlignmentEP
-// 
+//
 /**\class FakeCaloAlignmentEP FakeCaloAlignmentEP.h Alignment/FakeCaloAlignmentEP/interface/FakeCaloAlignmentEP.h
 
 Description: Producer of fake alignment data for calo geometries
@@ -15,7 +15,6 @@ The alignment objects are filled with fixed alignments.
 //
 //
 
-
 // System
 #include <memory>
 
@@ -23,8 +22,6 @@ The alignment objects are filled with fixed alignments.
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-
 
 // Alignment
 #include "CondFormats/Alignment/interface/Alignments.h"
@@ -57,241 +54,194 @@ The alignment objects are filled with fixed alignments.
 #include "CondFormats/AlignmentRecord/interface/CastorAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/CastorAlignmentErrorExtendedRcd.h"
 
-class FakeCaloAlignmentEP : public edm::ESProducer 
-{
-   public:
+class FakeCaloAlignmentEP : public edm::ESProducer {
+public:
+  using ReturnAli = std::unique_ptr<Alignments>;
+  using ReturnAliErr = std::unique_ptr<AlignmentErrors>;
 
-      using ReturnAli = std::unique_ptr<Alignments>;
-      using ReturnAliErr = std::unique_ptr<AlignmentErrors>;
+  typedef AlignTransform::Translation Trl;
+  typedef AlignTransform::Rotation Rot;
 
-      typedef AlignTransform::Translation Trl ;
-      typedef AlignTransform::Rotation    Rot ;
+  FakeCaloAlignmentEP(const edm::ParameterSet&) {
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceEBAli);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceEBAliErr);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceEEAli);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceEEAliErr);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceESAli);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceESAliErr);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceHBAli);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceHBAliErr);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceHEAli);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceHEAliErr);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceHOAli);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceHOAliErr);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceHFAli);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceHFAliErr);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceZdcAli);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceZdcAliErr);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceCastorAli);
+    setWhatProduced(this, &FakeCaloAlignmentEP::produceCastorAliErr);
+  }
 
-      FakeCaloAlignmentEP(const edm::ParameterSet&)
-      {
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceEBAli    ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceEBAliErr ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceEEAli    ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceEEAliErr ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceESAli    ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceESAliErr ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceHBAli    ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceHBAliErr ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceHEAli    ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceHEAliErr ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceHOAli    ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceHOAliErr ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceHFAli    ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceHFAliErr ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceZdcAli    ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceZdcAliErr ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceCastorAli    ) ;
-	 setWhatProduced( this, &FakeCaloAlignmentEP::produceCastorAliErr ) ;
-      }
+  ~FakeCaloAlignmentEP() override {}
 
-      ~FakeCaloAlignmentEP() override {}
+  //-------------------------------------------------------------------
 
-//-------------------------------------------------------------------
- 
-      ReturnAli    produceEBAli( const EBAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( EcalBarrelGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const EBDetId id ( EcalBarrelGeometry::detIdFromLocalAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( ( 1==id.ism() ? Trl( 0, 0, 0 ) : //-0.3 ) :
-					     Trl(0,0,0) ) , 
-					   Rot(),
-					   id              ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceEBAli(const EBAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(EcalBarrelGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const EBDetId id(EcalBarrelGeometry::detIdFromLocalAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform((1 == id.ism() ? Trl(0, 0, 0) :  //-0.3 ) :
+                                           Trl(0, 0, 0)),
+                                      Rot(),
+                                      id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceEBAliErr( const EBAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceEBAliErr(const EBAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceEEAli( const EEAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( EcalEndcapGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const EEDetId id (  EcalEndcapGeometry::detIdFromLocalAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id              ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceEEAli(const EEAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(EcalEndcapGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const EEDetId id(EcalEndcapGeometry::detIdFromLocalAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceEEAliErr( const EEAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceEEAliErr(const EEAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceESAli( const ESAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( EcalPreshowerGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const ESDetId id ( EcalPreshowerGeometry::detIdFromLocalAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceESAli(const ESAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(EcalPreshowerGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const ESDetId id(EcalPreshowerGeometry::detIdFromLocalAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceESAliErr( const ESAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceESAliErr(const ESAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceHBAli( const HBAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( HcalGeometry::numberOfBarrelAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalDetId id ( HcalGeometry::detIdFromBarrelAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceHBAli(const HBAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(HcalGeometry::numberOfBarrelAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalDetId id(HcalGeometry::detIdFromBarrelAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceHBAliErr( const HBAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      {
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceHBAliErr(const HBAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceHEAli( const HEAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( HcalGeometry::numberOfEndcapAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalDetId id ( HcalGeometry::detIdFromEndcapAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceHEAli(const HEAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(HcalGeometry::numberOfEndcapAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalDetId id(HcalGeometry::detIdFromEndcapAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceHEAliErr( const HEAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      {
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceHEAliErr(const HEAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceHOAli( const HOAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( HcalGeometry::numberOfOuterAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalDetId id ( HcalGeometry::detIdFromOuterAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceHOAli(const HOAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(HcalGeometry::numberOfOuterAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalDetId id(HcalGeometry::detIdFromOuterAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceHOAliErr( const HOAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      {
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceHOAliErr(const HOAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceHFAli( const HFAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( HcalGeometry::numberOfForwardAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalDetId id ( HcalGeometry::detIdFromForwardAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceHFAli(const HFAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(HcalGeometry::numberOfForwardAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalDetId id(HcalGeometry::detIdFromForwardAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceHFAliErr( const HFAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceHFAliErr(const HFAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceZdcAli( const ZDCAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( ZdcGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalZDCDetId id ( HcalZDCDetId::EM, false, 1 ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceZdcAli(const ZDCAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(ZdcGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalZDCDetId id(HcalZDCDetId::EM, false, 1);
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceZdcAliErr( const ZDCAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceZdcAliErr(const ZDCAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceCastorAli( const CastorAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( CastorGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalCastorDetId id ( HcalCastorDetId::EM, false, 1, 1 ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceCastorAli(const CastorAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(CastorGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalCastorDetId id(HcalCastorDetId::EM, false, 1, 1);
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceCastorAliErr( const CastorAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
+  ReturnAliErr produceCastorAliErr(const CastorAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
 };
-
 
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(FakeCaloAlignmentEP);

--- a/Geometry/CaloEventSetup/plugins/FastTimeTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/FastTimeTopologyBuilder.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CaloEventSetup
 // Class:      FastTimeTopologyBuilder
-// 
+//
 /**\class FastTimeTopologyBuilder FastTimeTopologyBuilder.h 
 
  Description: <one line class summary>
@@ -14,7 +14,6 @@
 // Original Author:  Sunanda Banerjee
 //
 //
-
 
 // system include files
 #include <memory>
@@ -39,10 +38,9 @@
 //
 
 class FastTimeTopologyBuilder : public edm::ESProducer {
-
 public:
-  FastTimeTopologyBuilder( const edm::ParameterSet& iP );
-  ~FastTimeTopologyBuilder() override ;
+  FastTimeTopologyBuilder(const edm::ParameterSet& iP);
+  ~FastTimeTopologyBuilder() override;
 
   using ReturnType = std::unique_ptr<FastTimeTopology>;
 
@@ -51,36 +49,29 @@ public:
 private:
   // ----------member data ---------------------------
   edm::ESGetToken<FastTimeDDDConstants, IdealGeometryRecord> ftlToken_;
-  int                type_;
+  int type_;
   ForwardSubdetector subdet_;
 };
 
-
 FastTimeTopologyBuilder::FastTimeTopologyBuilder(const edm::ParameterSet& iConfig) {
-
   auto name = iConfig.getUntrackedParameter<std::string>("Name");
-  type_     = iConfig.getUntrackedParameter<int>("Type");
-  subdet_   = FastTime;
+  type_ = iConfig.getUntrackedParameter<int>("Type");
+  subdet_ = FastTime;
 #ifdef EDM_ML_DEBUG
-  std::cout <<"constructing FastTimeTopology for " << name << " Type "
-	    << type_ << std::endl;
+  std::cout << "constructing FastTimeTopology for " << name << " Type " << type_ << std::endl;
 #endif
   ftlToken_ = setWhatProduced(this, name).consumes<FastTimeDDDConstants>(edm::ESInputTag{"", name});
 }
 
-
-FastTimeTopologyBuilder::~FastTimeTopologyBuilder() { }
-
+FastTimeTopologyBuilder::~FastTimeTopologyBuilder() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-FastTimeTopologyBuilder::ReturnType
-FastTimeTopologyBuilder::produce(const IdealGeometryRecord& iRecord ) {
-
-  const FastTimeDDDConstants & hgdc = iRecord.get(ftlToken_);
+FastTimeTopologyBuilder::ReturnType FastTimeTopologyBuilder::produce(const IdealGeometryRecord& iRecord) {
+  const FastTimeDDDConstants& hgdc = iRecord.get(ftlToken_);
 
 #ifdef EDM_ML_DEBUG
   std::cout << "Create FastTimeTopology(hgdc,subdet,type)" << std::endl;

--- a/Geometry/CaloEventSetup/plugins/HGCalTopologyBuilder.cc
+++ b/Geometry/CaloEventSetup/plugins/HGCalTopologyBuilder.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CaloEventSetup
 // Class:      HGCalTopologyBuilder
-// 
+//
 /**\class HGCalTopologyBuilder HGCalTopologyBuilder.h 
 
  Description: <one line class summary>
@@ -14,7 +14,6 @@
 // Original Author:  Sunanda Banerjee
 //
 //
-
 
 // system include files
 #include <memory>
@@ -41,10 +40,9 @@
 //
 
 class HGCalTopologyBuilder : public edm::ESProducer {
-
 public:
-  HGCalTopologyBuilder( const edm::ParameterSet& iP );
-  ~HGCalTopologyBuilder() override ;
+  HGCalTopologyBuilder(const edm::ParameterSet& iP);
+  ~HGCalTopologyBuilder() override;
 
   using ReturnType = std::unique_ptr<HGCalTopology>;
 
@@ -53,33 +51,27 @@ public:
 private:
   // ----------member data ---------------------------
   edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord> hgcToken_;
-  int                det_;
+  int det_;
 };
 
-
 HGCalTopologyBuilder::HGCalTopologyBuilder(const edm::ParameterSet& iConfig) {
-
   auto name = iConfig.getParameter<std::string>("Name");
-  det_      = iConfig.getParameter<int>("Type");
+  det_ = iConfig.getParameter<int>("Type");
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "constructing HGCalTopology for " << name
-				<< " and det " << det_;
+  edm::LogVerbatim("HGCalGeom") << "constructing HGCalTopology for " << name << " and det " << det_;
 #endif
   hgcToken_ = setWhatProduced(this, name).consumes<HGCalDDDConstants>(edm::ESInputTag{"", name});
 }
 
-
-HGCalTopologyBuilder::~HGCalTopologyBuilder() { }
+HGCalTopologyBuilder::~HGCalTopologyBuilder() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-HGCalTopologyBuilder::ReturnType
-HGCalTopologyBuilder::produce(const IdealGeometryRecord& iRecord ) {
-
-  const HGCalDDDConstants & hgdc = iRecord.get(hgcToken_);
+HGCalTopologyBuilder::ReturnType HGCalTopologyBuilder::produce(const IdealGeometryRecord& iRecord) {
+  const HGCalDDDConstants& hgdc = iRecord.get(hgcToken_);
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "Create HGCalTopology(hgdc,det)";

--- a/Geometry/CaloEventSetup/plugins/TestCaloAlignmentEP.cc
+++ b/Geometry/CaloEventSetup/plugins/TestCaloAlignmentEP.cc
@@ -2,7 +2,7 @@
 //
 // Package:    TestCaloAlignmentEP
 // Class:      TestCaloAlignmentEP
-// 
+//
 /**\class TestCaloAlignmentEP TestCaloAlignmentEP.h Alignment/TestCaloAlignmentEP/interface/TestCaloAlignmentEP.h
 
 Description: Producer of fake alignment data for calo geometries
@@ -15,7 +15,6 @@ The alignment objects are filled with fixed alignments.
 //
 //
 
-
 // System
 #include <memory>
 
@@ -23,8 +22,6 @@ The alignment objects are filled with fixed alignments.
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-
 
 // Alignment
 #include "CondFormats/Alignment/interface/Alignments.h"
@@ -57,243 +54,194 @@ The alignment objects are filled with fixed alignments.
 #include "CondFormats/AlignmentRecord/interface/CastorAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/CastorAlignmentErrorExtendedRcd.h"
 
-class TestCaloAlignmentEP : public edm::ESProducer 
-{
-   public:
+class TestCaloAlignmentEP : public edm::ESProducer {
+public:
+  using ReturnAli = std::unique_ptr<Alignments>;
+  using ReturnAliErr = std::unique_ptr<AlignmentErrors>;
 
-      using ReturnAli = std::unique_ptr<Alignments>;
-      using ReturnAliErr = std::unique_ptr<AlignmentErrors>;
+  typedef AlignTransform::Translation Trl;
+  typedef AlignTransform::Rotation Rot;
 
-      typedef AlignTransform::Translation Trl ;
-      typedef AlignTransform::Rotation    Rot ;
+  TestCaloAlignmentEP(const edm::ParameterSet&) {
+    setWhatProduced(this, &TestCaloAlignmentEP::produceEBAli);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceEBAliErr);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceEEAli);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceEEAliErr);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceESAli);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceESAliErr);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceHBAli);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceHBAliErr);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceHEAli);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceHEAliErr);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceHOAli);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceHOAliErr);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceHFAli);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceHFAliErr);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceZdcAli);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceZdcAliErr);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceCastorAli);
+    setWhatProduced(this, &TestCaloAlignmentEP::produceCastorAliErr);
+  }
 
-      TestCaloAlignmentEP(const edm::ParameterSet&)
-      {
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceEBAli    ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceEBAliErr ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceEEAli    ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceEEAliErr ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceESAli    ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceESAliErr ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceHBAli    ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceHBAliErr ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceHEAli    ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceHEAliErr ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceHOAli    ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceHOAliErr ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceHFAli    ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceHFAliErr ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceZdcAli    ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceZdcAliErr ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceCastorAli    ) ;
-	 setWhatProduced( this, &TestCaloAlignmentEP::produceCastorAliErr ) ;
-      }
+  ~TestCaloAlignmentEP() override {}
 
-      ~TestCaloAlignmentEP() override {}
+  //-------------------------------------------------------------------
 
-//-------------------------------------------------------------------
- 
-      ReturnAli    produceEBAli( const EBAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( EcalBarrelGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const EBDetId id ( EcalBarrelGeometry::detIdFromLocalAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( ( 1==id.ism() ? Trl( 0, 0, 0 ) : //-0.3 ) :
-					     Trl(0,0,0 ) ) , 
-					   Rot(),
-					   id              ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceEBAli(const EBAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(EcalBarrelGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const EBDetId id(EcalBarrelGeometry::detIdFromLocalAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform((1 == id.ism() ? Trl(0, 0, 0) :  //-0.3 ) :
+                                           Trl(0, 0, 0)),
+                                      Rot(),
+                                      id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceEBAliErr( const EBAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceEBAliErr(const EBAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceEEAli( const EEAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( EcalEndcapGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const EEDetId id (  EcalEndcapGeometry::detIdFromLocalAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform(  ( 2 > i ? Trl( -0.02, -0.81, -0.94 ) :
-					      Trl( +0.52, -0.81, +0.81 ) ) ,
-					   Rot(),
-					   id              ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceEEAli(const EEAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(EcalEndcapGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const EEDetId id(EcalEndcapGeometry::detIdFromLocalAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform((2 > i ? Trl(-0.02, -0.81, -0.94) : Trl(+0.52, -0.81, +0.81)), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceEEAliErr( const EEAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceEEAliErr(const EEAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceESAli( const ESAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( EcalPreshowerGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const ESDetId id ( EcalPreshowerGeometry::detIdFromLocalAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( ( 4 > i ? Trl( -0.02, -0.81, -0.94 ) :
-					     Trl( +0.52, -0.81, +0.81 ) ) ,  
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceESAli(const ESAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(EcalPreshowerGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const ESDetId id(EcalPreshowerGeometry::detIdFromLocalAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform((4 > i ? Trl(-0.02, -0.81, -0.94) : Trl(+0.52, -0.81, +0.81)), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceESAliErr( const ESAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceESAliErr(const ESAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceHBAli( const HBAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( HcalGeometry::numberOfBarrelAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalDetId id ( HcalGeometry::detIdFromBarrelAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceHBAli(const HBAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(HcalGeometry::numberOfBarrelAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalDetId id(HcalGeometry::detIdFromBarrelAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceHBAliErr( const HBAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceHBAliErr(const HBAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceHEAli( const HEAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( HcalGeometry::numberOfEndcapAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalDetId id ( HcalGeometry::detIdFromEndcapAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceHEAli(const HEAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(HcalGeometry::numberOfEndcapAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalDetId id(HcalGeometry::detIdFromEndcapAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceHEAliErr( const HEAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceHEAliErr(const HEAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceHOAli( const HOAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( HcalGeometry::numberOfOuterAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalDetId id ( HcalGeometry::detIdFromOuterAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceHOAli(const HOAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(HcalGeometry::numberOfOuterAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalDetId id(HcalGeometry::detIdFromOuterAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceHOAliErr( const HOAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceHOAliErr(const HOAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceHFAli( const HFAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( HcalGeometry::numberOfForwardAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalDetId id ( HcalGeometry::detIdFromForwardAlignmentIndex( i ) ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceHFAli(const HFAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(HcalGeometry::numberOfForwardAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalDetId id(HcalGeometry::detIdFromForwardAlignmentIndex(i));
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceHFAliErr( const HFAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceHFAliErr(const HFAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceZdcAli( const ZDCAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( ZdcGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalZDCDetId id ( HcalZDCDetId::EM, false, 1 ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceZdcAli(const ZDCAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(ZdcGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalZDCDetId id(HcalZDCDetId::EM, false, 1);
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceZdcAliErr( const ZDCAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
-//-------------------------------------------------------------------
+  ReturnAliErr produceZdcAliErr(const ZDCAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
+  //-------------------------------------------------------------------
 
-      ReturnAli    produceCastorAli( const CastorAlignmentRcd& /*iRecord*/ ) 
-      {
-	 ReturnAli ali = std::make_unique<Alignments>();
-	 std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-	 const unsigned int nA ( CastorGeometry::numberOfAlignments() ) ; 
-	 vtr.reserve( nA ) ;
-	 for( unsigned int i ( 0 ) ; i != nA ; ++i )
-	 {
-	    const HcalCastorDetId id ( HcalCastorDetId::EM, false, 1, 1 ) ;
-	    vtr.emplace_back( AlignTransform( Trl( 0, 0, 0 ), 
-					   Rot(),
-					   id           ) ) ;
-	 }
-	 return ali ;
-      }
+  ReturnAli produceCastorAli(const CastorAlignmentRcd& /*iRecord*/) {
+    ReturnAli ali = std::make_unique<Alignments>();
+    std::vector<AlignTransform>& vtr(ali->m_align);
+    const unsigned int nA(CastorGeometry::numberOfAlignments());
+    vtr.reserve(nA);
+    for (unsigned int i(0); i != nA; ++i) {
+      const HcalCastorDetId id(HcalCastorDetId::EM, false, 1, 1);
+      vtr.emplace_back(AlignTransform(Trl(0, 0, 0), Rot(), id));
+    }
+    return ali;
+  }
 
-      ReturnAliErr produceCastorAliErr( const CastorAlignmentErrorExtendedRcd& /*iRecord*/ ) 
-      { 
-         return std::make_unique<AlignmentErrors>();
-      }
+  ReturnAliErr produceCastorAliErr(const CastorAlignmentErrorExtendedRcd& /*iRecord*/) {
+    return std::make_unique<AlignmentErrors>();
+  }
 };
-
 
 //define this as a plug-in
 DEFINE_FWK_EVENTSETUP_MODULE(TestCaloAlignmentEP);

--- a/Geometry/CaloEventSetup/test/CaloAlignmentRcdRead.cc
+++ b/Geometry/CaloEventSetup/test/CaloAlignmentRcdRead.cc
@@ -13,25 +13,22 @@
 #include "CondFormats/AlignmentRecord/interface/EEAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/ESAlignmentRcd.h"
 
-class CaloAlignmentRcdRead : public edm::one::EDAnalyzer<>
-{
+class CaloAlignmentRcdRead : public edm::one::EDAnalyzer<> {
 public:
-
-  explicit CaloAlignmentRcdRead( const edm::ParameterSet& /*iConfig*/ )
-    :ebToken_{esConsumes<Alignments, EBAlignmentRcd>(edm::ESInputTag{})},
-     eeToken_{esConsumes<Alignments, EEAlignmentRcd>(edm::ESInputTag{})},
-     esToken_{esConsumes<Alignments, ESAlignmentRcd>(edm::ESInputTag{})},
-     nEventCalls_(0)
-  {}
+  explicit CaloAlignmentRcdRead(const edm::ParameterSet& /*iConfig*/)
+      : ebToken_{esConsumes<Alignments, EBAlignmentRcd>(edm::ESInputTag{})},
+        eeToken_{esConsumes<Alignments, EEAlignmentRcd>(edm::ESInputTag{})},
+        esToken_{esConsumes<Alignments, ESAlignmentRcd>(edm::ESInputTag{})},
+        nEventCalls_(0) {}
   ~CaloAlignmentRcdRead() override {}
-  
-  template<typename T>
+
+  template <typename T>
   void dumpAlignments(const edm::EventSetup& evtSetup, edm::ESGetToken<Alignments, T>& token);
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
-  
+
 private:
   edm::ESGetToken<Alignments, EBAlignmentRcd> ebToken_;
   edm::ESGetToken<Alignments, EEAlignmentRcd> eeToken_;
@@ -40,33 +37,30 @@ private:
   unsigned int nEventCalls_;
 };
 
-template<typename T>
-void CaloAlignmentRcdRead::dumpAlignments(const edm::EventSetup& evtSetup, edm::ESGetToken<Alignments, T>& token)
-{
+template <typename T>
+void CaloAlignmentRcdRead::dumpAlignments(const edm::EventSetup& evtSetup, edm::ESGetToken<Alignments, T>& token) {
   const auto& alignments = evtSetup.getData(token);
-  
+
   std::string recordName = Demangle(typeid(T).name())();
 
   LogDebug("CaloAlignmentRcdRead") << "Dumping alignments: " << recordName;
 
-  for (const auto & i : alignments.m_align) {
-    LogDebug("CaloAlignmentRcdRead") << "entry " << i.rawId() 
-	      << " translation " << i.translation() 
-	      << " angles " << i.rotation().eulerAngles();
+  for (const auto& i : alignments.m_align) {
+    LogDebug("CaloAlignmentRcdRead") << "entry " << i.rawId() << " translation " << i.translation() << " angles "
+                                     << i.rotation().eulerAngles();
   }
 }
 
-void CaloAlignmentRcdRead::analyze(const edm::Event& /*evt*/, const edm::EventSetup& evtSetup)
-{
-  if (nEventCalls_>0) {
+void CaloAlignmentRcdRead::analyze(const edm::Event& /*evt*/, const edm::EventSetup& evtSetup) {
+  if (nEventCalls_ > 0) {
     edm::LogWarning("CaloAlignmentRcdRead") << "Reading from DB to be done only once, "
-	      << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'.";
+                                            << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'.";
 
     return;
   }
 
   LogDebug("CaloAlignmentRcdRead") << "Reading from database in CaloAlignmentRcdRead::analyze...";
-  
+
   dumpAlignments(evtSetup, ebToken_);
   dumpAlignments(evtSetup, eeToken_);
   dumpAlignments(evtSetup, esToken_);

--- a/Geometry/CaloEventSetup/test/CaloAlignmentRcdWrite.cc
+++ b/Geometry/CaloEventSetup/test/CaloAlignmentRcdWrite.cc
@@ -17,18 +17,16 @@
 #include "CondFormats/AlignmentRecord/interface/EEAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/ESAlignmentRcd.h"
 
-class CaloAlignmentRcdWrite : public edm::one::EDAnalyzer<>
-{
+class CaloAlignmentRcdWrite : public edm::one::EDAnalyzer<> {
 public:
-
   explicit CaloAlignmentRcdWrite(const edm::ParameterSet& /*iConfig*/)
-    :ebToken_{esConsumes<Alignments, EBAlignmentRcd>(edm::ESInputTag{})},
-     eeToken_{esConsumes<Alignments, EEAlignmentRcd>(edm::ESInputTag{})},
-     esToken_{esConsumes<Alignments, ESAlignmentRcd>(edm::ESInputTag{})},
-     nEventCalls_(0) {}
+      : ebToken_{esConsumes<Alignments, EBAlignmentRcd>(edm::ESInputTag{})},
+        eeToken_{esConsumes<Alignments, EEAlignmentRcd>(edm::ESInputTag{})},
+        esToken_{esConsumes<Alignments, ESAlignmentRcd>(edm::ESInputTag{})},
+        nEventCalls_(0) {}
   ~CaloAlignmentRcdWrite() override {}
-  
-  template<typename T>
+
+  template <typename T>
   void writeAlignments(const edm::EventSetup& evtSetup, edm::ESGetToken<Alignments, T>& token);
 
   void beginJob() override {}
@@ -39,15 +37,14 @@ private:
   edm::ESGetToken<Alignments, EBAlignmentRcd> ebToken_;
   edm::ESGetToken<Alignments, EEAlignmentRcd> eeToken_;
   edm::ESGetToken<Alignments, ESAlignmentRcd> esToken_;
-  
+
   unsigned int nEventCalls_;
 };
 
-template<typename T>
-void CaloAlignmentRcdWrite::writeAlignments(const edm::EventSetup& evtSetup, edm::ESGetToken<Alignments, T>& token)
-{
+template <typename T>
+void CaloAlignmentRcdWrite::writeAlignments(const edm::EventSetup& evtSetup, edm::ESGetToken<Alignments, T>& token) {
   const auto& alignmentsES = evtSetup.getData(token);
-  
+
   std::string recordName = Demangle(typeid(T).name())();
 
   std::cout << "Uploading alignments to the database: " << recordName << std::endl;
@@ -56,29 +53,26 @@ void CaloAlignmentRcdWrite::writeAlignments(const edm::EventSetup& evtSetup, edm
 
   if (!poolDbService.isAvailable())
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
-  
-  Alignments * alignments = new Alignments(alignmentsES);
 
-  poolDbService->writeOne<Alignments>(&(*alignments), 
-				      poolDbService->currentTime(),
-				      recordName);
+  Alignments* alignments = new Alignments(alignmentsES);
+
+  poolDbService->writeOne<Alignments>(&(*alignments), poolDbService->currentTime(), recordName);
 }
-  
-void CaloAlignmentRcdWrite::analyze(const edm::Event& /*evt*/, const edm::EventSetup& evtSetup)
-{
-   if (nEventCalls_ > 0) {
-     std::cout << "Writing to DB to be done only once, "
-	       << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
-	       << "(Your writing should be fine.)" << std::endl;
-     return;
-   }
 
-   writeAlignments<EBAlignmentRcd>(evtSetup, ebToken_);
-   writeAlignments<EEAlignmentRcd>(evtSetup, eeToken_);
-   writeAlignments<ESAlignmentRcd>(evtSetup, esToken_);
-   
-   std::cout << "done!" << std::endl;
-   nEventCalls_++;
+void CaloAlignmentRcdWrite::analyze(const edm::Event& /*evt*/, const edm::EventSetup& evtSetup) {
+  if (nEventCalls_ > 0) {
+    std::cout << "Writing to DB to be done only once, "
+              << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
+              << "(Your writing should be fine.)" << std::endl;
+    return;
+  }
+
+  writeAlignments<EBAlignmentRcd>(evtSetup, ebToken_);
+  writeAlignments<EEAlignmentRcd>(evtSetup, eeToken_);
+  writeAlignments<ESAlignmentRcd>(evtSetup, esToken_);
+
+  std::cout << "done!" << std::endl;
+  nEventCalls_++;
 }
 
 DEFINE_FWK_MODULE(CaloAlignmentRcdWrite);

--- a/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
+++ b/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
@@ -38,185 +38,153 @@
 using namespace geant_units;
 using namespace geant_units::operators;
 
-
 class CaloGeometryAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
-  enum CenterOrCorner { kCenter , kCorner } ;
-  enum XorYorZ { kX, kY, kZ } ;
+  enum CenterOrCorner { kCenter, kCorner };
+  enum XorYorZ { kX, kY, kZ };
 
 public:
-
-  explicit CaloGeometryAnalyzer( const edm::ParameterSet& );
+  explicit CaloGeometryAnalyzer(const edm::ParameterSet&);
   ~CaloGeometryAnalyzer() override;
-  
+
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
   // ----------member data ---------------------------
-  void build( const CaloGeometry* cg , const HcalTopology& ht,
-	      DetId::Detector     det, 
-	      int                 subdetn, 
-	      const char*         name,
-	      unsigned int        histi   );
+  void build(const CaloGeometry* cg,
+             const HcalTopology& ht,
+             DetId::Detector det,
+             int subdetn,
+             const char* name,
+             unsigned int histi);
 
-  void buildHcal( const CaloGeometry* cg , const HcalTopology& ht,
-		  DetId::Detector     det, 
-		  int                 subdetn, 
-		  const char*         name,
-		  unsigned int        histi   );
+  void buildHcal(const CaloGeometry* cg,
+                 const HcalTopology& ht,
+                 DetId::Detector det,
+                 int subdetn,
+                 const char* name,
+                 unsigned int histi);
 
-  void ctrcor( const DetId&            did     ,
-	       const CaloCellGeometry& cell ,
-	       std::fstream&           fCtr    ,
-	       std::fstream&           fCor    ,  
-	       std::fstream&           oldCtr    ,
-	       std::fstream&           oldCor   ,
-	       unsigned int            histi        );
+  void ctrcor(const DetId& did,
+              const CaloCellGeometry& cell,
+              std::fstream& fCtr,
+              std::fstream& fCor,
+              std::fstream& oldCtr,
+              std::fstream& oldCor,
+              unsigned int histi);
 
-  void checkDiff( int            i1,
-		  int            i2,
-		  int            i3,
-		  CenterOrCorner iCtrCor ,
-		  XorYorZ        iXYZ    ,
-		  double         diff      ) ;
+  void checkDiff(int i1, int i2, int i3, CenterOrCorner iCtrCor, XorYorZ iXYZ, double diff);
   int pass_;
 
-  EEDetId gid( unsigned int ix, 
-	       unsigned int iy,
-	       unsigned int iz,
-	       const EEDetId& did ) const ;
+  EEDetId gid(unsigned int ix, unsigned int iy, unsigned int iz, const EEDetId& did) const;
 
-  void cmpset( const CaloSubdetectorGeometry*       geom ,
-	       const GlobalPoint&             gp   ,
-	       const double                   dR     ) ;
+  void cmpset(const CaloSubdetectorGeometry* geom, const GlobalPoint& gp, const double dR);
 
-  void ovrTst( const CaloGeometry* cg      , 
-	       const CaloSubdetectorGeometry* geom ,
-	       const EEDetId&   id   , 
-	       std::fstream&    fOvr  );
+  void ovrTst(const CaloGeometry* cg, const CaloSubdetectorGeometry* geom, const EEDetId& id, std::fstream& fOvr);
 
-  void ovrTst( const CaloGeometry* cg      , 
-	       const CaloSubdetectorGeometry* geom ,
-	       const EBDetId&   id   , 
-	       std::fstream&    fOvr  );
+  void ovrTst(const CaloGeometry* cg, const CaloSubdetectorGeometry* geom, const EBDetId& id, std::fstream& fOvr);
 
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
 
   edm::Service<TFileService> h_fs;
 
+  TProfile* h_dPhi[7];
+  TProfile* h_dPhiR[7];
 
-  TProfile* h_dPhi[7] ;
-  TProfile* h_dPhiR[7] ;
+  TProfile* h_dEta[7];
+  TProfile* h_dEtaR[7];
 
-  TProfile* h_dEta[7] ;
-  TProfile* h_dEtaR[7] ;
-
-  TProfile* h_eta ;
+  TProfile* h_eta;
   TProfile* h_phi;
 
-  TH1D* h_diffs[10][12] ;
+  TH1D* h_diffs[10][12];
 
-  TH1D* h_scindex ;
+  TH1D* h_scindex;
 
-  bool m_allOK ;
+  bool m_allOK;
 };
 
-CaloGeometryAnalyzer::CaloGeometryAnalyzer( const edm::ParameterSet& /*iConfig*/ ):
-  geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})},
-  topologyToken_{esConsumes<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{})}
-{
-
+CaloGeometryAnalyzer::CaloGeometryAnalyzer(const edm::ParameterSet& /*iConfig*/)
+    : geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})},
+      topologyToken_{esConsumes<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{})} {
   usesResource("TFileService");
-  
-  pass_=0;
 
-  h_dPhi[0] = h_fs->make<TProfile>("dPhi:EB:index", "EB: dPhi vs index", 61200, -0.5, 61199.5, " " ) ;
-  h_dPhiR[0]= h_fs->make<TProfile>("dPhi:EB:R", "EB: dPhi vs R", 100, 125, 135, " " ) ;
+  pass_ = 0;
 
-  h_dEta[0] = h_fs->make<TProfile>("dEta:EB:index", "EB: dEta vs index", 61200, -0.5, 61199.5, " " ) ;
-  h_dEtaR[0]= h_fs->make<TProfile>("dEta:EB:R", "EB: dEta vs R", 100, 125, 135, " " ) ;
+  h_dPhi[0] = h_fs->make<TProfile>("dPhi:EB:index", "EB: dPhi vs index", 61200, -0.5, 61199.5, " ");
+  h_dPhiR[0] = h_fs->make<TProfile>("dPhi:EB:R", "EB: dPhi vs R", 100, 125, 135, " ");
 
-  h_dPhi[1] = h_fs->make<TProfile>("dPhi:EE:index", "EE: dPhi vs index", 14648, -0.5, 14647.5, " " ) ;
-  h_dPhiR[1]= h_fs->make<TProfile>("dPhi:EE:R", "EE: dPhi vs R", 130, 30, 160, " " ) ;
+  h_dEta[0] = h_fs->make<TProfile>("dEta:EB:index", "EB: dEta vs index", 61200, -0.5, 61199.5, " ");
+  h_dEtaR[0] = h_fs->make<TProfile>("dEta:EB:R", "EB: dEta vs R", 100, 125, 135, " ");
 
-  h_dEta[1] = h_fs->make<TProfile>("dEta:EE:index", "EE: dEta vs index", 14648, -0.5, 14647.5, " " ) ;
-  h_dEtaR[1]= h_fs->make<TProfile>("dEta:EE:R", "EE: dEta vs R", 130, 30, 160, " " ) ;
+  h_dPhi[1] = h_fs->make<TProfile>("dPhi:EE:index", "EE: dPhi vs index", 14648, -0.5, 14647.5, " ");
+  h_dPhiR[1] = h_fs->make<TProfile>("dPhi:EE:R", "EE: dPhi vs R", 130, 30, 160, " ");
 
-  h_dPhi[2] = h_fs->make<TProfile>("dPhi:ES:index", "ES: dPhi vs index", 137216, -0.5, 137215.5, " " ) ;
-  h_dPhiR[2]= h_fs->make<TProfile>("dPhi:ES:R", "ES: dPhi vs R", 90, 40, 130, " " ) ;
+  h_dEta[1] = h_fs->make<TProfile>("dEta:EE:index", "EE: dEta vs index", 14648, -0.5, 14647.5, " ");
+  h_dEtaR[1] = h_fs->make<TProfile>("dEta:EE:R", "EE: dEta vs R", 130, 30, 160, " ");
 
-  h_dEta[2] = h_fs->make<TProfile>("dEta:ES:index", "ES: dEta vs index", 137216, -0.5, 137215.5, " " ) ;
-  h_dEtaR[2]= h_fs->make<TProfile>("dEta:ES:R", "ES: dEta vs R", 90, 40, 130, " " ) ;
+  h_dPhi[2] = h_fs->make<TProfile>("dPhi:ES:index", "ES: dPhi vs index", 137216, -0.5, 137215.5, " ");
+  h_dPhiR[2] = h_fs->make<TProfile>("dPhi:ES:R", "ES: dPhi vs R", 90, 40, 130, " ");
 
-  h_dPhi[3] = h_fs->make<TProfile>("dPhi:HC:index", "HC: dPhi vs index", 9072, -0.5, 9071.5, " " ) ;
-  h_dPhiR[3]= h_fs->make<TProfile>("dPhi:HC:R", "HC: dPhi vs R", 400, 0, 400, " " ) ;
+  h_dEta[2] = h_fs->make<TProfile>("dEta:ES:index", "ES: dEta vs index", 137216, -0.5, 137215.5, " ");
+  h_dEtaR[2] = h_fs->make<TProfile>("dEta:ES:R", "ES: dEta vs R", 90, 40, 130, " ");
 
-  h_dEta[3] = h_fs->make<TProfile>("dEta:HC:index", "HC: dEta vs index", 9072, -0.5, 9071.5, " " ) ;
-  h_dEtaR[3]= h_fs->make<TProfile>("dEta:HC:R", "HC: dEta vs R", 400, 0, 400, " " ) ;
+  h_dPhi[3] = h_fs->make<TProfile>("dPhi:HC:index", "HC: dPhi vs index", 9072, -0.5, 9071.5, " ");
+  h_dPhiR[3] = h_fs->make<TProfile>("dPhi:HC:R", "HC: dPhi vs R", 400, 0, 400, " ");
 
-  h_dPhi[4] = h_fs->make<TProfile>("dPhi:ZD:index", "ZD: dPhi vs index", 22, -0.5, 21.5, " " ) ;
-  h_dPhiR[4]= h_fs->make<TProfile>("dPhi:ZD:R", "ZD: dPhi vs R", 100, 0, 10, " " ) ;
+  h_dEta[3] = h_fs->make<TProfile>("dEta:HC:index", "HC: dEta vs index", 9072, -0.5, 9071.5, " ");
+  h_dEtaR[3] = h_fs->make<TProfile>("dEta:HC:R", "HC: dEta vs R", 400, 0, 400, " ");
 
-  h_dEta[4] = h_fs->make<TProfile>("dEta:ZD:index", "ZD: dEta vs index", 22, -0.5, 21.5, " " ) ;
-  h_dEtaR[4]= h_fs->make<TProfile>("dEta:ZD:R", "ZD: dEta vs R", 100, 0, 10, " " ) ;
+  h_dPhi[4] = h_fs->make<TProfile>("dPhi:ZD:index", "ZD: dPhi vs index", 22, -0.5, 21.5, " ");
+  h_dPhiR[4] = h_fs->make<TProfile>("dPhi:ZD:R", "ZD: dPhi vs R", 100, 0, 10, " ");
 
-  h_dPhi[5] = h_fs->make<TProfile>("dPhi:CA:index", "CA: dPhi vs index", 224, -0.5, 223.5, " " ) ;
-  h_dPhiR[5]= h_fs->make<TProfile>("dPhi:CA:R", "CA: dPhi vs R", 100, 0, 20, " " ) ;
+  h_dEta[4] = h_fs->make<TProfile>("dEta:ZD:index", "ZD: dEta vs index", 22, -0.5, 21.5, " ");
+  h_dEtaR[4] = h_fs->make<TProfile>("dEta:ZD:R", "ZD: dEta vs R", 100, 0, 10, " ");
 
-  h_dEta[5] = h_fs->make<TProfile>("dEta:CA:index", "CA: dEta vs index", 224, -0.5, 223.5, " " ) ;
-  h_dEtaR[5]= h_fs->make<TProfile>("dEta:CA:R", "CA: dEta vs R", 100, 0, 20, " " ) ;
+  h_dPhi[5] = h_fs->make<TProfile>("dPhi:CA:index", "CA: dPhi vs index", 224, -0.5, 223.5, " ");
+  h_dPhiR[5] = h_fs->make<TProfile>("dPhi:CA:R", "CA: dPhi vs R", 100, 0, 20, " ");
 
-  h_dPhi[6] = h_fs->make<TProfile>("dPhi:CT:index", "CT: dPhi vs index", 4320, -0.5, 4319.5, " " ) ;
-  h_dPhiR[6]= h_fs->make<TProfile>("dPhi:CT:R", "CT: dPhi vs R", 150, 0, 150, " " ) ;
+  h_dEta[5] = h_fs->make<TProfile>("dEta:CA:index", "CA: dEta vs index", 224, -0.5, 223.5, " ");
+  h_dEtaR[5] = h_fs->make<TProfile>("dEta:CA:R", "CA: dEta vs R", 100, 0, 20, " ");
 
-  h_dEta[6] = h_fs->make<TProfile>("dEta:CT:index", "CT: dEta vs index", 4320, -0.5, 4319.5, " " ) ;
-  h_dEtaR[6]= h_fs->make<TProfile>("dEta:CT:R", "CT: dEta vs R", 150, 0, 150, " " ) ;
+  h_dPhi[6] = h_fs->make<TProfile>("dPhi:CT:index", "CT: dPhi vs index", 4320, -0.5, 4319.5, " ");
+  h_dPhiR[6] = h_fs->make<TProfile>("dPhi:CT:R", "CT: dPhi vs R", 150, 0, 150, " ");
 
-  h_eta = h_fs->make<TProfile>("iEta", "Eta vs iEta", 86*2*4, -86, 86, " " ) ;
-  h_phi = h_fs->make<TProfile>("iPhi", "Phi vs iPhi", 360*4, 1, 361, " " ) ;
+  h_dEta[6] = h_fs->make<TProfile>("dEta:CT:index", "CT: dEta vs index", 4320, -0.5, 4319.5, " ");
+  h_dEtaR[6] = h_fs->make<TProfile>("dEta:CT:R", "CT: dEta vs R", 150, 0, 150, " ");
 
-  const std::string hname[10] = { "EB", "EE", "ES", "HB", "HO", "HE", "HF", "CT", "ZD", "CA" } ;
-  const std::string cname[12] = { "XCtr", "YCtr", "ZCtr",
-				  "XCor0", "YCor0", "ZCor0",
-				  "XCor3", "YCor3", "ZCor3",
-				  "XCor6", "YCor6", "ZCor6" } ;
+  h_eta = h_fs->make<TProfile>("iEta", "Eta vs iEta", 86 * 2 * 4, -86, 86, " ");
+  h_phi = h_fs->make<TProfile>("iPhi", "Phi vs iPhi", 360 * 4, 1, 361, " ");
 
-  for( unsigned int i ( 0 ) ; i != 10 ; ++i )
-  {
-     for( unsigned int j ( 0 ) ; j != 12 ; ++j )
-     {
-	h_diffs[i][j] = h_fs->make<TH1D>( std::string( hname[i] + cname[j] +
-						       std::string("Diff (microns)") ).c_str(), 
-					  std::string( hname[i] +
-						       std::string(": New-Nom(")
-						       + cname[j] + std::string(")") ).c_str(), 
-					  200, -200., 200. ) ;
-     }
+  const std::string hname[10] = {"EB", "EE", "ES", "HB", "HO", "HE", "HF", "CT", "ZD", "CA"};
+  const std::string cname[12] = {
+      "XCtr", "YCtr", "ZCtr", "XCor0", "YCor0", "ZCor0", "XCor3", "YCor3", "ZCor3", "XCor6", "YCor6", "ZCor6"};
+
+  for (unsigned int i(0); i != 10; ++i) {
+    for (unsigned int j(0); j != 12; ++j) {
+      h_diffs[i][j] =
+          h_fs->make<TH1D>(std::string(hname[i] + cname[j] + std::string("Diff (microns)")).c_str(),
+                           std::string(hname[i] + std::string(": New-Nom(") + cname[j] + std::string(")")).c_str(),
+                           200,
+                           -200.,
+                           200.);
+    }
   }
-  h_scindex = h_fs->make<TH1D>( std::string( "Supercrystal Hashed Index").c_str(), 
-				std::string( "SC Hashed Index").c_str(), 
-				632, -0.5, 631.5 ) ;
+  h_scindex = h_fs->make<TH1D>(
+      std::string("Supercrystal Hashed Index").c_str(), std::string("SC Hashed Index").c_str(), 632, -0.5, 631.5);
 }
 
+CaloGeometryAnalyzer::~CaloGeometryAnalyzer() {}
 
-CaloGeometryAnalyzer::~CaloGeometryAnalyzer()
-{
-}
+void CaloGeometryAnalyzer::cmpset(const CaloSubdetectorGeometry* geom, const GlobalPoint& gp, const double dR) {
+  typedef CaloSubdetectorGeometry::DetIdSet DetSet;
 
-void 
-CaloGeometryAnalyzer::cmpset( const CaloSubdetectorGeometry* geom ,
-			      const GlobalPoint&             gp   ,
-			      const double                   dR     ) 
-{
-   typedef CaloSubdetectorGeometry::DetIdSet DetSet ;
-
-   DetSet base = geom->CaloSubdetectorGeometry::getCells( gp, dR ) ;
-   DetSet over = geom->getCells( gp, dR ) ;
-   if( over == base )
-   {
-/*
+  DetSet base = geom->CaloSubdetectorGeometry::getCells(gp, dR);
+  DetSet over = geom->getCells(gp, dR);
+  if (over == base) {
+    /*
       std::cout << "getCells Test dR="
 		<< dR
 		<< ", gp=" << gp 
@@ -225,1013 +193,836 @@ CaloGeometryAnalyzer::cmpset( const CaloSubdetectorGeometry* geom ,
 		<< ": base and over are equal!\n ***************************\n " 
 		<< std::endl ;
 */
-   }
-   else
-   {
-      if( 2 < std::abs( (int)(base.size()) - (int)(over.size()) ) ) 
-      {
-      DetSet inBaseNotOver ;
-      DetSet inOverNotBase ;
-      std::set_difference( base.begin(), base.end(), 
-			   over.begin(), over.end(),
-			   std::inserter( inBaseNotOver,
-					  inBaseNotOver.begin() )  ) ;
+  } else {
+    if (2 < std::abs((int)(base.size()) - (int)(over.size()))) {
+      DetSet inBaseNotOver;
+      DetSet inOverNotBase;
+      std::set_difference(
+          base.begin(), base.end(), over.begin(), over.end(), std::inserter(inBaseNotOver, inBaseNotOver.begin()));
 
-      if( inBaseNotOver.empty() )
-      {
-	 std::cout << "getCells Test dR="
-		   << dR
-		   << ", gp=" << gp 
-		   << ", gp.eta=" << gp.eta() 
-		   << ", gp.phi=" << gp.phi() 
-		   << ": No elements in base but not overload " 
-		   << std::endl ;
-      }
-      else
-      {
-	 std::cout << "Length of Base is "<<base.size() <<std::endl ;
-	 std::cout << "Length of Over is "<<over.size() <<std::endl ;
-	 std::cout << "There are "<<inBaseNotOver.size()
-		   << " items in Base but not in Overload"
-		   << std::endl ;
+      if (inBaseNotOver.empty()) {
+        std::cout << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi()
+                  << ": No elements in base but not overload " << std::endl;
+      } else {
+        std::cout << "Length of Base is " << base.size() << std::endl;
+        std::cout << "Length of Over is " << over.size() << std::endl;
+        std::cout << "There are " << inBaseNotOver.size() << " items in Base but not in Overload" << std::endl;
 
-	 for(const auto & iS : inBaseNotOver)
-	 {
-	    std::cout<<"getCells Test dR="
-		     <<dR
-		     << ", gp=" << gp 
-		     << ": cell in base but not overload = " ;
-	    if( iS.det() == DetId::Ecal &&
-		iS.subdetId() == EcalBarrel ) std::cout << EBDetId( iS ) ;
-	    if( iS.det() == DetId::Ecal &&
-		iS.subdetId() == EcalEndcap ) std::cout << EEDetId( iS ) ;
-	    if( iS.det() == DetId::Hcal ) std::cout << HcalDetId( iS ) ;
-	    std::cout<< std::endl ;
-	 }
-      }
-
-      std::set_difference( over.begin(), over.end(),
-			   base.begin(), base.end(), 
-			   std::inserter( inOverNotBase,
-					  inOverNotBase.begin() ) ) ;
-
-      if( inOverNotBase.empty() )
-      {
-	 std::cout << "getCells Test dR="
-		   << dR
-		   << ", gp=" << gp 
-		   << ", gp.eta=" << gp.eta() 
-		   << ", gp.phi=" << gp.phi() 
-		   << ": No elements in overload but not base " 
-		   << std::endl ;
-      }
-      else
-      {
-	 std::cout << "Length of Base is "<<base.size() <<std::endl ;
-	 std::cout << "Length of Over is "<<over.size() <<std::endl ;
-	 std::cout << "There are "<< inOverNotBase.size()
-		   << " items in Overload but not in Base"
-		   << std::endl ;
-
-	 for(const auto & iS : inOverNotBase)
-	 {
-	    std::cout<<"getCells Test dR="
-		     <<dR
-		     << ", gp=" << gp 
-		     << ": cell in overload but not base = " ;
-	    if( iS.det() == DetId::Ecal &&
-		iS.subdetId() == EcalBarrel ) std::cout << EBDetId( iS ) ;
-	    if( iS.det() == DetId::Ecal &&
-		iS.subdetId() == EcalEndcap ) std::cout << EEDetId( iS ) ;
-	    if( iS.det() == DetId::Hcal ) std::cout << HcalDetId( iS ) ;
-	    std::cout << std::endl ;
-	 }
-      }
-      std::cout<<"------------- done with mismatch printout ---------------"<<std::endl ;
-      }
-   }
-}
-
-EEDetId
-CaloGeometryAnalyzer::gid( unsigned int ix, 
-			   unsigned int iy,
-			   unsigned int iz,
-			   const EEDetId& did ) const
-{
-   return ( EEDetId::validDetId( ix, iy, iz ) ? 
-	    EEDetId( ix, iy, iz ) : 
-	    ( EEDetId::validDetId( ix+1, iy  , iz ) ? 
-	      EEDetId( ix+1, iy  , iz ) :
-	      ( EEDetId::validDetId( ix-1 , iy, iz ) ? 
-		EEDetId( ix-1  , iy, iz ) :
-		( EEDetId::validDetId( ix , iy+1, iz ) ? 
-		  EEDetId( ix  , iy+1, iz ) :
-		  ( EEDetId::validDetId( ix , iy-1, iz ) ? 
-		    EEDetId( ix, iy-1, iz ) :
-		    ( EEDetId::validDetId( ix+1, iy+1, iz ) ? 
-		      EEDetId( ix+1, iy+1, iz ) :
-		      ( EEDetId::validDetId( ix+1 , iy-1, iz ) ? 
-			EEDetId( ix+1, iy-1, iz ) :
-			( EEDetId::validDetId( ix-1, iy+1, iz ) ? 
-			  EEDetId( ix-1, iy+1, iz ) :
-			  ( EEDetId::validDetId( ix-1, iy-1, iz ) ? 
-			    EEDetId( ix-1, iy-1, iz ) : did )  ) ) ) ) ) ) ) ) ;
-}
-
-void 
-CaloGeometryAnalyzer::ovrTst( const CaloGeometry* cg      , 
-			      const CaloSubdetectorGeometry* geom ,
-			      const EEDetId&   id   , 
-			      std::fstream&    fOvr   )
-{
-   static const GlobalPoint origin (0,0,0) ;
-   const int iphi ( id.iPhiOuterRing() ) ;
-   if( iphi != 0 )
-   {
-      fOvr << "Barrel Neighbors of Endcap id = " << id << std::endl ;
-      const EcalEndcapGeometry* eeG (dynamic_cast<const EcalEndcapGeometry*>( geom ) );
-      auto cell ( geom->getGeometry(id) ) ;
-      const CaloSubdetectorGeometry* bar(cg->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
-      const EcalEndcapGeometry::OrderedListOfEBDetId* ol ( eeG->getClosestBarrelCells( id ) ) ;
-      // assert ( nullptr != ol ) ;
-      if (ol != nullptr) {
-        for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
-        {
-         fOvr << "           " << i << "  " << (*ol)[i] ;
-         auto  other ( bar->getGeometry((*ol)[i]) ) ;
-         const GlobalVector cv ( cell->getPosition()-origin ) ;
-         const GlobalVector ov ( other->getPosition()-origin ) ;
-         const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
-         const double angle ( convertRadToDeg( acos( std::abs(cosang) < 1. ? cosang : 1. ) ) ) ;
-         fOvr << ", angle = "<<angle<< std::endl ;
+        for (const auto& iS : inBaseNotOver) {
+          std::cout << "getCells Test dR=" << dR << ", gp=" << gp << ": cell in base but not overload = ";
+          if (iS.det() == DetId::Ecal && iS.subdetId() == EcalBarrel)
+            std::cout << EBDetId(iS);
+          if (iS.det() == DetId::Ecal && iS.subdetId() == EcalEndcap)
+            std::cout << EEDetId(iS);
+          if (iS.det() == DetId::Hcal)
+            std::cout << HcalDetId(iS);
+          std::cout << std::endl;
         }
       }
-   }
-}
 
-void 
-CaloGeometryAnalyzer::ovrTst( const CaloGeometry* cg      , 
-			      const CaloSubdetectorGeometry* geom ,
-			      const EBDetId&   id   , 
-			      std::fstream&    fOvr   )
-{
-   static const GlobalPoint origin (0,0,0) ;
-   const int ieta ( id.ieta() ) ;
-   if( 85 == std::abs( ieta ) )
-   {
-      const EcalBarrelGeometry* ebG ( dynamic_cast<const EcalBarrelGeometry*>( geom ) );
-      auto cell ( geom->getGeometry(id) ) ;
-      const CaloSubdetectorGeometry* ecap(cg->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
-      fOvr << "Endcap Neighbors of Barrel id = " << id << std::endl ;
-      const EcalBarrelGeometry::OrderedListOfEEDetId* ol ( ebG->getClosestEndcapCells( id ) ) ;
-      // assert ( nullptr != ol ) ;
-      if (ol != nullptr) {
-        for( unsigned int i ( 0 ) ; i != ol->size() ; ++i )
-        {
-         fOvr << "           " << i << "  " << (*ol)[i] ;
-         auto  other ( ecap->getGeometry((*ol)[i]) ) ;
-         const GlobalVector cv ( cell->getPosition()-origin ) ;
-         const GlobalVector ov ( other->getPosition()-origin ) ;
-         const double cosang ( cv.dot(ov)/(cv.mag()*ov.mag() ) ) ;
-         const double angle ( convertRadToDeg( acos( std::abs(cosang) < 1. ? cosang : 1. ) ) ) ;
-         fOvr << ", angle = "<<angle<< std::endl ;
+      std::set_difference(
+          over.begin(), over.end(), base.begin(), base.end(), std::inserter(inOverNotBase, inOverNotBase.begin()));
+
+      if (inOverNotBase.empty()) {
+        std::cout << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi()
+                  << ": No elements in overload but not base " << std::endl;
+      } else {
+        std::cout << "Length of Base is " << base.size() << std::endl;
+        std::cout << "Length of Over is " << over.size() << std::endl;
+        std::cout << "There are " << inOverNotBase.size() << " items in Overload but not in Base" << std::endl;
+
+        for (const auto& iS : inOverNotBase) {
+          std::cout << "getCells Test dR=" << dR << ", gp=" << gp << ": cell in overload but not base = ";
+          if (iS.det() == DetId::Ecal && iS.subdetId() == EcalBarrel)
+            std::cout << EBDetId(iS);
+          if (iS.det() == DetId::Ecal && iS.subdetId() == EcalEndcap)
+            std::cout << EEDetId(iS);
+          if (iS.det() == DetId::Hcal)
+            std::cout << HcalDetId(iS);
+          std::cout << std::endl;
         }
-      } else { fOvr << "endcap ecal ptr is null " << std::endl; }
-   }      
-}
-
-
-void 
-CaloGeometryAnalyzer::checkDiff( int            i1      ,
-				 int            i2      ,
-				 int            i3      ,
-				 CenterOrCorner iCtrCor ,
-				 XorYorZ        iXYZ    ,
-				 double         diff      )
-{
-   if( 3.5 < fabs( diff ) ) 
-   {
-      std::cout<<"For a volume "<<( kCenter==iCtrCor ? "CENTER" : "CORNER" )
-	       <<", & "
-	       <<"i1="<<i1<<" & i2="<<i2<<" & i3="<<i3
-	       <<", ***BIG DISAGREEMENT FOUND. D"
-	       <<( kX == iXYZ ? "X" : ( kY == iXYZ ? "Y" : "Z" ) )
-	       <<"=" << diff
-	       <<" microns"<<std::endl ;
-      m_allOK = false ;
-   }
-}
-
-
-void 
-CaloGeometryAnalyzer::ctrcor( const DetId&            did     ,
-			      const CaloCellGeometry& cell    ,
-			      std::fstream&           fCtr    ,
-			      std::fstream&           fCor    , 
-			      std::fstream&           oldCtr    ,
-			      std::fstream&           oldCor    ,
-			      unsigned int            histi         )
-{
-   int oldie ( 0 ) ;
-   int oldip ( 0 ) ;
-   oldCtr>>oldie>>oldip ;
-   oldCor>>oldie>>oldip ;
-   const CaloGenericDetId cgid ( did ) ;
-   if( cgid.isEB() )
-   {
-      const EBDetId ebid ( did ) ;
-      const int ie  ( ebid.ieta() ) ;
-      const int ip  ( ebid.iphi() ) ;
-      fCtr << std::setw(4) << ie
-	   << std::setw(4) << ip ;
-      fCor << std::setw(4) << ie
-	   << std::setw(4) << ip ;
-   }
-   if( cgid.isEE() )
-   {
-      const EEDetId eeid ( did ) ;
-      const int ix ( eeid.ix() ) ;
-      const int iy ( eeid.iy() ) ;
-
-      fCtr << std::setw(4) << ix
-	   << std::setw(4) << iy ;
-      fCor << std::setw(4) << ix
-	   << std::setw(4) << iy ;
-   }
-   if( cgid.isES() )
-   {
-      const ESDetId esid ( did ) ;
-      const int pl ( esid.plane() ) ;
-      const int ix ( esid.six() ) ;
-      const int iy ( esid.siy() ) ;
-      const int st ( esid.strip() ) ;
-      fCtr << std::setw(4) << pl
-	   << std::setw(4) << ix
-	   << std::setw(4) << iy
-	   << std::setw(4) << st ;
-      fCor << std::setw(4) << pl
-	   << std::setw(4) << ix
-	   << std::setw(4) << iy
-	   << std::setw(4) << st ;
-      int oldiy, oldst ;
-      oldCtr>>oldiy>>oldst ;
-      oldCor>>oldip>>oldst ;
-   }
-   int depth = 0;
-   if( cgid.det() == DetId::Hcal) 
-   {
-      const HcalDetId hcid ( did ) ;
-      const int ie ( hcid.ieta() ) ;
-      const int ip ( hcid.iphi() ) ;
-      const int de ( hcid.depth() ) ;
-      fCtr << std::setw(4) << ie
-	   << std::setw(4) << ip
-	   << std::setw(4) << de ;
-      fCor << std::setw(4) << ie
-	   << std::setw(4) << ip
-	   << std::setw(4) << de ;
-      int  oldde ;
-      oldCtr>>oldde ;
-      oldCor>>oldde ;
-      depth = de; 
-   }
-   if( cgid.isZDC() ) 
-   {
-      const HcalZDCDetId zcid ( did ) ;
-      const int is ( zcid.section() ) ;
-      const int ic ( zcid.channel() ) ;
-      fCtr << std::setw(4) << is
-	   << std::setw(4) << ic ;
-      fCor << std::setw(4) << is
-	   << std::setw(4) << ic ;
-   }
-   if( cgid.isCastor() ) 
-   {
-      const HcalCastorDetId cid ( did ) ;
-      const int is ( cid.sector() ) ;
-      const int im ( cid.module() ) ;
-      fCtr << std::setw(4) << is
-	   << std::setw(4) << im ;
-      fCor << std::setw(4) << is
-	   << std::setw(4) << im ;
-   }
-   if( cgid.isCaloTower() ) 
-   {
-      const CaloTowerDetId cid ( did ) ;
-      const int ie ( cid.ieta() ) ;
-      const int ip ( cid.iphi() ) ;
-      fCtr << std::setw(4) << ie
-	   << std::setw(4) << ip ;
-      fCor << std::setw(4) << ie
-	   << std::setw(4) << ip ;
-   }
-
-   const double x ( cell.getPosition().x() ) ;
-   const double y ( cell.getPosition().y() ) ;
-   const double z ( cell.getPosition().z() ) ;
-
-   double oldx,oldy,oldz;
-
-   oldCtr >> oldx >> oldy >> oldz;
-
-   const double dx ( 1.e4*(x - oldx) ) ;
-   const double dy ( 1.e4*(y - oldy) ) ;
-   const double dz ( 1.e4*(z - oldz) ) ;
-
-   h_diffs[histi][0]->Fill( dx ) ;
-   h_diffs[histi][1]->Fill( dy ) ;
-   h_diffs[histi][2]->Fill( dz ) ;
-
-   checkDiff( oldie, oldip, depth, kCenter, kX, dx ) ;
-   checkDiff( oldie, oldip, depth, kCenter, kY, dy ) ;
-   checkDiff( oldie, oldip, depth, kCenter, kZ, dz ) ;
-
-   fCtr << std::fixed << std::setw(12) << std::setprecision(4)
-	<< x
-	<< std::fixed << std::setw(12) << std::setprecision(4)
-	<< y
-	<< std::fixed << std::setw(12) << std::setprecision(4)
-	<< z
-	<< std::endl ;
-
-   const CaloCellGeometry::CornersVec& co ( cell.getCorners() ) ;
-
-   for( unsigned int j ( 0 ) ; j < co.size() ; ++(++(++j)) )
-   {
-      const double x ( co[j].x() ) ;
-      const double y ( co[j].y() ) ;
-      const double z ( co[j].z() ) ;
-
-      double oldx,oldy,oldz;
-
-      oldCor >> oldx >> oldy >> oldz;
-
-      const double dx ( 1.e4*(x - oldx) ) ;
-      const double dy ( 1.e4*(y - oldy) ) ;
-      const double dz ( 1.e4*(z - oldz) ) ;
-
-      h_diffs[histi][j+3]->Fill( dx ) ;
-      h_diffs[histi][j+4]->Fill( dy ) ;
-      h_diffs[histi][j+5]->Fill( dz ) ;
-
-      checkDiff( oldie, oldip, j, kCorner, kX, dx ) ;
-      checkDiff( oldie, oldip, j, kCorner, kY, dy ) ;
-      checkDiff( oldie, oldip, j, kCorner, kZ, dz ) ;
-
-      fCor << std::fixed << std::setw(12) << std::setprecision(4)
-	   << x
-	   << std::fixed << std::setw(12) << std::setprecision(4)
-	   << y
-	   << std::fixed << std::setw(12) << std::setprecision(4)
-	   << z ;
-   }
-   fCor << std::endl ;
-}
-
-void 
-CaloGeometryAnalyzer::buildHcal( const CaloGeometry*       cg      , 
-				 const HcalTopology& ht      ,
-				 DetId::Detector     det     , 
-				 int                 subdetn , 
-				 const char*         name    ,
-				 unsigned int        histi     ) 
-{
-    std::cout<<"Now checking detector "<<name<<std::endl ;
-    const std::string oldnameCtr  ( "old" + std::string( name ) + ".ctr" ) ;
-    const std::string oldnameCor  ( "old" + std::string( name ) + ".cor" ) ;
-    const std::string fnameCtr  ( std::string( name ) + ".ctr" ) ;
-    const std::string fnameCor  ( std::string( name ) + ".cor" ) ;
-    const std::string fnameOvr  ( std::string( name ) + ".ovr" ) ;
-    const std::string fnameRoot ( std::string( name ) + ".C" ) ;
-    std::fstream oldCtr(oldnameCtr.c_str() ,std::ios_base::in);
-    std::fstream oldCor(oldnameCor.c_str() ,std::ios_base::in);
-    std::fstream fCtr(fnameCtr.c_str() ,std::ios_base::out);
-    std::fstream fCor(fnameCor.c_str() ,std::ios_base::out);
-    std::fstream fOvr(fnameOvr.c_str() ,std::ios_base::out);
-    std::fstream f   (fnameRoot.c_str(),std::ios_base::out);
-
-    const CaloSubdetectorGeometry* geom(cg->getSubdetectorGeometry(det,subdetn));
-
-    f << "{" << std::endl;
-    f << "  TGeoManager* geoManager = new TGeoManager(\"ROOT\", \"" << name << "\");" << std::endl;
-    f << "  TGeoMaterial* dummyMaterial = new TGeoMaterial(\"Vacuum\", 0,0,0); " << std::endl;
-    f << "  TGeoMedium* dummyMedium =  new TGeoMedium(\"Vacuum\",1,dummyMaterial);" << std::endl;
-    f << "  TGeoVolume* world=geoManager->MakeBox(\"world\",dummyMedium, 8000.0, 8000.0, 14000.0); " << std::endl;
-    f << "  geoManager->SetTopVolume(world); " << std::endl;
-    f << "  TGeoVolume* box; " << std::endl;
-    int n=0;
-    const std::vector< DetId >& ids ( geom->getValidDetIds( det, subdetn ) ) ;
-
-    const std::vector< DetId >& ids2 ( cg->getValidDetIds( det, subdetn ) ) ;
-
-    if( ids != ids2 )
-    {
-	std::cout<<"Methods differ! One gives size "
-		 << ids.size()
-		 <<" and the other gives size "
-		 << ids2.size()
-		 << std::endl ;
+      }
+      std::cout << "------------- done with mismatch printout ---------------" << std::endl;
     }
-    assert( ids == ids2 ) ;
+  }
+}
 
-    for(const auto & i : ids) 
-    {
-	++n;
-	auto cell = ( geom->getGeometry(i) ) ;
+EEDetId CaloGeometryAnalyzer::gid(unsigned int ix, unsigned int iy, unsigned int iz, const EEDetId& did) const {
+  return (EEDetId::validDetId(ix, iy, iz)
+              ? EEDetId(ix, iy, iz)
+              : (EEDetId::validDetId(ix + 1, iy, iz)
+                     ? EEDetId(ix + 1, iy, iz)
+                     : (EEDetId::validDetId(ix - 1, iy, iz)
+                            ? EEDetId(ix - 1, iy, iz)
+                            : (EEDetId::validDetId(ix, iy + 1, iz)
+                                   ? EEDetId(ix, iy + 1, iz)
+                                   : (EEDetId::validDetId(ix, iy - 1, iz)
+                                          ? EEDetId(ix, iy - 1, iz)
+                                          : (EEDetId::validDetId(ix + 1, iy + 1, iz)
+                                                 ? EEDetId(ix + 1, iy + 1, iz)
+                                                 : (EEDetId::validDetId(ix + 1, iy - 1, iz)
+                                                        ? EEDetId(ix + 1, iy - 1, iz)
+                                                        : (EEDetId::validDetId(ix - 1, iy + 1, iz)
+                                                               ? EEDetId(ix - 1, iy + 1, iz)
+                                                               : (EEDetId::validDetId(ix - 1, iy - 1, iz)
+                                                                      ? EEDetId(ix - 1, iy - 1, iz)
+                                                                      : did)))))))));
+}
 
-	assert( cg->present( i ) ) ;
-
-	ctrcor( i,
-		*cell,
-		fCtr,
-		fCor,
-		oldCtr,
-		oldCor,
-		histi ) ;
-
-	const DetId      id ( i ) ;
-
-	const HcalDetId hcId ( i ) ;
-
-	const GlobalPoint pos ( cell->getPosition() ) ; 
-	const double posmag ( pos.mag() ) ;
-
-	const double disin ( DetId::Ecal   == det     &&
-			     EcalPreshower == subdetn     ? 0.000001 : 0.001 ) ;
-
-	const GlobalPoint pointIn ( pos.x() + disin*pos.x()/posmag ,
-				    pos.y() + disin*pos.y()/posmag ,
-				    pos.z() + disin*pos.z()/posmag   ) ;
-	const GlobalPoint pointFr ( pos.x() - 0.1*pos.x()/posmag ,
-				    pos.y() - 0.1*pos.y()/posmag ,
-				    pos.z() - 0.1*pos.z()/posmag   ) ;
-
-	if( cell->inside( pointFr ) ) std::cout<<"Bad outside: "<<pointIn<<", " <<pointFr<<std::endl ;
-	assert( cell->inside( pointIn ) ) ;
-	assert( !cell->inside( pointFr ) ) ;
-
-	const double deltaPhi ( geom->deltaPhi( id ) ) ;
-      
-	const double deltaEta ( geom->deltaEta( id ) ) ;
-
-	const unsigned int detIndex (3);
-	const GlobalPoint ggp ( cell->getPosition() ) ;
-						
-	h_dPhi [detIndex]->Fill( ht.detId2denseId(hcId), deltaPhi ) ;
-	h_dPhiR[detIndex]->Fill( ggp.perp(), deltaPhi ) ;
-
-	h_dEta [detIndex]->Fill( ht.detId2denseId(hcId), deltaEta ) ;
-	h_dEtaR[detIndex]->Fill( ggp.perp(), deltaEta ) ;
-      
-	const unsigned int i1 ( HcalGeometry::alignmentTransformIndexLocal( hcId ) ) ;
-
-	const DetId d1 ( HcalGeometry::detIdFromLocalAlignmentIndex( i1 ) ) ;
-
-	const unsigned int i2 ( HcalGeometry::alignmentTransformIndexLocal( d1 ) ) ;
-
-	assert( i1 == i2 ) ;
-
-	f << "  // " << HcalDetId(i) << std::endl;
-	    
-	const GlobalPoint gp ( cell->getPosition() ) ;
-	f << "  // Checking getClosestCell for position " 
-	  << gp
-	  << std::endl;
-
-	HcalDetId closestCell ( geom->getClosestCell( gp ) ) ;
-
-	f << "  // Return position is " << closestCell << std::endl;
-	if( closestCell != HcalDetId(i) ) {
-	  const double rr ( reco::deltaR( gp.eta(), gp.phi(), 
-					  geom->getGeometry( closestCell )->getPosition().eta(),
-					  geom->getGeometry( closestCell )->getPosition().phi()   ) ) ; 
-	    if( rr> 1.e-5 ) std::cout<<"For "<<HcalDetId(i)<<" closest is "<<closestCell
-				     << " HCAL dR=" << rr <<std::endl ;
-	}
-	// test getCells against base class version every so often
-	if( 0 == ht.detId2denseId(closestCell)%30)
-	{
-	    cmpset( geom, gp,  2._deg ) ;
-	    cmpset( geom, gp,  5._deg ) ;
-	    cmpset( geom, gp,  7._deg ) ;
-	    cmpset( geom, gp, 25._deg ) ;
-	    cmpset( geom, gp, 45._deg ) ;
-	}
-    
-	if (det == DetId::Hcal && subdetn==HcalForward) 
-	    f << "  box=geoManager->MakeBox(\"point\",dummyMedium,1.0,1.0,1.0);" << std::endl;
-	else
-	    f << "  box=geoManager->MakeBox(\"point\",dummyMedium,3.0,3.0,3.0);" << std::endl;
-	f << "  world->AddNode(box,"<< n << ",new TGeoHMatrix(TGeoTranslation(" << 
-	    cell->getPosition().x() << "," << cell->getPosition().y() << "," << cell->getPosition().z() << ")));" << std::endl;
+void CaloGeometryAnalyzer::ovrTst(const CaloGeometry* cg,
+                                  const CaloSubdetectorGeometry* geom,
+                                  const EEDetId& id,
+                                  std::fstream& fOvr) {
+  static const GlobalPoint origin(0, 0, 0);
+  const int iphi(id.iPhiOuterRing());
+  if (iphi != 0) {
+    fOvr << "Barrel Neighbors of Endcap id = " << id << std::endl;
+    const EcalEndcapGeometry* eeG(dynamic_cast<const EcalEndcapGeometry*>(geom));
+    auto cell(geom->getGeometry(id));
+    const CaloSubdetectorGeometry* bar(cg->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
+    const EcalEndcapGeometry::OrderedListOfEBDetId* ol(eeG->getClosestBarrelCells(id));
+    // assert ( nullptr != ol ) ;
+    if (ol != nullptr) {
+      for (unsigned int i(0); i != ol->size(); ++i) {
+        fOvr << "           " << i << "  " << (*ol)[i];
+        auto other(bar->getGeometry((*ol)[i]));
+        const GlobalVector cv(cell->getPosition() - origin);
+        const GlobalVector ov(other->getPosition() - origin);
+        const double cosang(cv.dot(ov) / (cv.mag() * ov.mag()));
+        const double angle(convertRadToDeg(acos(std::abs(cosang) < 1. ? cosang : 1.)));
+        fOvr << ", angle = " << angle << std::endl;
+      }
     }
-    
-    f << "  geoManager->CloseGeometry();" << std::endl;
-    f << "world->Voxelize(\"\"); // now the new geometry is valid for tracking, so you can do \n // even raytracing \n //  if (!canvas) { \n    TCanvas* canvas=new TCanvas(\"EvtDisp\",\"EvtDisp\",500,500); \n //  } \n  canvas->Modified(); \n  canvas->Update();      \n  world->Draw(); \n";
-    f << "}" << std::endl;
-    f.close();
-    fCtr.close();
-    fCor.close();
-}
-   
-
-
-void 
-CaloGeometryAnalyzer::build( const CaloGeometry* cg      , 
-			     const HcalTopology& ht      ,
-			     DetId::Detector     det     , 
-			     int                 subdetn , 
-			     const char*         name    ,
-			     unsigned int        histi     ) 
-{
-   std::cout<<"Now checking detector "<<name<<std::endl ;
-
-   const std::string oldnameCtr  ( "old" + std::string( name ) + ".ctr" ) ;
-   const std::string oldnameCor  ( "old" + std::string( name ) + ".cor" ) ;
-   const std::string fnameCtr  ( std::string( name ) + ".ctr" ) ;
-   const std::string fnameCor  ( std::string( name ) + ".cor" ) ;
-   const std::string fnameOvr  ( std::string( name ) + ".ovr" ) ;
-   const std::string fnameRoot ( std::string( name ) + ".C" ) ;
-   std::fstream oldCtr(oldnameCtr.c_str() ,std::ios_base::in);
-   std::fstream oldCor(oldnameCor.c_str() ,std::ios_base::in);
-   std::fstream fCtr(fnameCtr.c_str() ,std::ios_base::out);
-   std::fstream fCor(fnameCor.c_str() ,std::ios_base::out);
-   std::fstream fOvr(fnameOvr.c_str() ,std::ios_base::out);
-   std::fstream f   (fnameRoot.c_str(),std::ios_base::out);
-
-   const CaloSubdetectorGeometry* geom(cg->getSubdetectorGeometry(det,subdetn));
-
-   f << "{" << std::endl;
-   f << "  TGeoManager* geoManager = new TGeoManager(\"ROOT\", \"" << name << "\");" << std::endl;
-   f << "  TGeoMaterial* dummyMaterial = new TGeoMaterial(\"Vacuum\", 0,0,0); " << std::endl;
-   f << "  TGeoMedium* dummyMedium =  new TGeoMedium(\"Vacuum\",1,dummyMaterial);" << std::endl;
-   f << "  TGeoVolume* world=geoManager->MakeBox(\"world\",dummyMedium, 8000.0, 8000.0, 14000.0); " << std::endl;
-   f << "  geoManager->SetTopVolume(world); " << std::endl;
-   f << "  TGeoVolume* box; " << std::endl;
-   int n=0;
-   const std::vector< DetId >& ids ( geom->getValidDetIds( det, subdetn ) ) ;
-
-   const std::vector< DetId >& ids2 ( cg->getValidDetIds( det, subdetn ) ) ;
-   
-   if( ids != ids2 )
-   {
-      std::cout<<"Methods differ! One gives size "
-	       << ids.size()
-	       <<" and the other gives size "
-	       << ids2.size()
-	       << std::endl ;
-   }
-
-   assert( ids == ids2 ) ;
-
-   for(const auto & i : ids) 
-   {
-      ++n;
-      auto cell ( geom->getGeometry(i) ) ;
-
-      assert( cg->present( i ) ) ;
-
-      ctrcor( i,
-	      *cell,
-	      fCtr,
-	      fCor,
-	      oldCtr,
-	      oldCor,
-	      histi ) ;
-
-      const DetId      id ( i ) ;
-
-      const CaloGenericDetId cid ( id ) ;
-
-      assert( cid.validDetId() ) ;
-
-      assert( CaloGenericDetId( id.det(),
-				id.subdetId(),
-				cid.denseIndex() ) == id ) ;
-      
-      const GlobalPoint pos ( cell->getPosition() ) ; 
-      const double posmag ( pos.mag() ) ;
-
-      const double disin ( DetId::Ecal   == det     &&
-			   EcalPreshower == subdetn     ? 0.000001 : 0.001 ) ;
-
-      const GlobalPoint pointIn ( pos.x() + disin*pos.x()/posmag ,
-				  pos.y() + disin*pos.y()/posmag ,
-				  pos.z() + disin*pos.z()/posmag   ) ;
-      const GlobalPoint pointFr ( pos.x() - 0.1*pos.x()/posmag ,
-				  pos.y() - 0.1*pos.y()/posmag ,
-				  pos.z() - 0.1*pos.z()/posmag   ) ;
-
-      if( cell->inside( pointFr ) ) std::cout<<"Bad outside: "<<pointIn<<", " <<pointFr<<std::endl ;
-      assert( cell->inside( pointIn ) ) ;
-      assert( !cell->inside( pointFr ) ) ;
-
-      const double deltaPhi ( geom->deltaPhi( id ) ) ;
-      
-      const double deltaEta ( geom->deltaEta( id ) ) ;
-
-      const unsigned int detIndex ( DetId::Ecal == det  && EcalBarrel == subdetn ? 0 :
-				    ( DetId::Ecal == det  && EcalEndcap == subdetn ? 1 :
-				      ( DetId::Ecal == det  && EcalPreshower == subdetn ? 2 :
-					( DetId::Hcal == det                          ? 3 :
-					  ( DetId::Calo == det && HcalZDCDetId::SubdetectorId == subdetn ? 4 :
-					    ( DetId::Calo == det && HcalCastorDetId::SubdetectorId == subdetn ?
-					      5 : 6 )
-					     )
-					   )
-					 )
-				       )
-	 ) ;
-
-      const CaloGenericDetId cgid ( id ) ;
-
-      const GlobalPoint ggp ( cell->getPosition() ) ;
-						
-      h_dPhi [detIndex]->Fill( cgid.denseIndex(), deltaPhi ) ;
-      h_dPhiR[detIndex]->Fill( ggp.perp(), deltaPhi ) ;
-
-      h_dEta [detIndex]->Fill( cgid.denseIndex(), deltaEta ) ;
-      h_dEtaR[detIndex]->Fill( ggp.perp(), deltaEta ) ;
-
-      if( det == DetId::Ecal )
-      {
-	 if (subdetn == EcalBarrel )
-	 {
-	    f << "  // " << EBDetId(i) << std::endl;
-	    
-	    const GlobalPoint gp ( cell->getPosition(0.) ) ;
-
-	    f << "  // Checking getClosestCell for position " 
-	      << gp
-	      << std::endl;
-
-	    const EBDetId ebid ( id ) ;
-	    for(unsigned int j ( 0 ) ; j !=4 ; ++j )
-	    {
-	       const CaloCellGeometry::CornersVec& corn ( cell->getCorners() ) ;
-	       h_eta->Fill( ebid.ieta()*1. + 0.25*j, corn[j].eta() ) ;
-	       if( ebid.ieta()>0) h_phi->Fill( ebid.iphi()*1. + 0.25*j, corn[j].phi() ) ;
-	    }
-
-	    EBDetId closestCell ( geom->getClosestCell( gp ) ) ;
-
-	    f << "  // Return position is " << closestCell << std::endl;
-	    assert( closestCell == EBDetId(i) );
-	    // test getCells against base class version every so often
-	    if( 0 == closestCell.hashedIndex()%100 )
-	    {
-	       cmpset( geom, gp,  2._deg ) ;
-	       cmpset( geom, gp,  5._deg ) ;
-	       cmpset( geom, gp, 25._deg ) ;
-	       cmpset( geom, gp, 45._deg ) ;
-	    }
-
-	    ovrTst( cg, geom, EBDetId(i) , fOvr ) ;
-
-	    const unsigned int i1 ( EcalBarrelGeometry::alignmentTransformIndexLocal( ebid ) ) ;
-
-	    const DetId d1 ( EcalBarrelGeometry::detIdFromLocalAlignmentIndex( i1 ) ) ;
-
-	    const unsigned int i2 ( EcalBarrelGeometry::alignmentTransformIndexLocal( d1 ) ) ;
-
-	    assert( i1 == i2 ) ;
-	 }
-	 if (subdetn == EcalEndcap)
-	 {
-	    const EEDetId did ( i ) ;
-	    const int ix ( did.ix() ) ;
-	    const int iy ( did.iy() ) ;
-	    const int iz ( did.zside() ) ;
-
-	    const unsigned int i1 ( EcalEndcapGeometry::alignmentTransformIndexLocal( did ) ) ;
-
-	    const DetId d1 ( EcalEndcapGeometry::detIdFromLocalAlignmentIndex( i1 ) ) ;
-
-	    const unsigned int i2 ( EcalEndcapGeometry::alignmentTransformIndexLocal( d1 ) ) ;
-
-	    assert( i1 == i2 ) ;
-
-	    f << "  // Checking getClosestCell for position " << cell->getPosition(0.) << std::endl;
-
-	    const GlobalPoint gp ( cell->getPosition(0.) ) ;
-
-	    const EEDetId closestCell ( geom->getClosestCell( gp ) ) ;
-	    f << "  // Return position is " << closestCell << std::endl;
-
-	    assert( closestCell == did ) ;
-	    // test getCells against base class version every so often
-	    if( 0 == closestCell.hashedIndex()%10 )
-	    {
-	       cmpset( geom, gp,  2._deg ) ;
-	       cmpset( geom, gp,  5._deg ) ;
-	       cmpset( geom, gp, 25._deg ) ;
-	       cmpset( geom, gp, 45._deg ) ;
-	    }
-
-	    const GlobalVector xx ( 2.5,   0, 0 ) ;
-	    const GlobalVector yy (   0, 2.5, 0 ) ;
-	    const GlobalVector zz (   0,   0, 1 ) ;
-	    const GlobalPoint pointIn ( cell->getPosition(  1.) ) ; 
-	    const GlobalPoint pointFr ( cell->getPosition( -1.) ) ; 
-	    const GlobalPoint pointBk ( cell->getPosition( 24.) ) ; 
-	    const GlobalPoint pointXP ( cell->getPosition(1.) + xx ) ; 
-	    const GlobalPoint pointXM ( cell->getPosition(1.) - xx ) ; 
-	    const GlobalPoint pointYP ( cell->getPosition(1.) + yy ) ; 
-	    const GlobalPoint pointYM ( cell->getPosition(1.) - yy ) ; 
-	    const GlobalPoint pointPP ( cell->getPosition(1.) + xx + yy ) ; 
-	    const GlobalPoint pointPM ( cell->getPosition(1.) + xx - yy ) ; 
-	    const GlobalPoint pointMP ( cell->getPosition(1.) - xx + yy ) ; 
-	    const GlobalPoint pointMM ( cell->getPosition(1.) - xx - yy ) ; 
-	    const EEDetId didXP ( gid( ix+1, iy  , iz, did ) ) ;
-	    const EEDetId didXM ( gid( ix-1, iy  , iz, did ) ) ;
-	    const EEDetId didYP ( gid( ix  , iy+1, iz, did ) ) ;
-	    const EEDetId didYM ( gid( ix  , iy-1, iz, did ) ) ;
-	    const EEDetId didPP ( gid( ix+1, iy+1, iz, did ) ) ;
-	    const EEDetId didPM ( gid( ix+1, iy-1, iz, did ) ) ;
-	    const EEDetId didMP ( gid( ix-1, iy+1, iz, did ) ) ;
-	    const EEDetId didMM ( gid( ix-1, iy-1, iz, did ) ) ;
-
-	    assert(  cell->inside( pointIn ) ) ;
-	    assert( !cell->inside( pointFr ) ) ;
-	    assert( !cell->inside( pointBk ) ) ;
-	    assert( !cell->inside( pointXP ) ) ;
-	    assert( !cell->inside( pointXM ) ) ;
-	    assert( !cell->inside( pointYP ) ) ;
-	    assert( !cell->inside( pointYM ) ) ;
-	    assert( !cell->inside( pointPP ) ) ;
-	    assert( !cell->inside( pointPM ) ) ;
-	    assert( !cell->inside( pointMP ) ) ;
-	    assert( !cell->inside( pointMM ) ) ;
-
-	    const EEDetId ccBk ( geom->getClosestCell( pointBk ) ) ;
-	    const EEDetId ccIn ( geom->getClosestCell( pointIn ) ) ;
-	    const EEDetId ccFr ( geom->getClosestCell( pointFr ) ) ;
-	    const EEDetId ccXP ( geom->getClosestCell( pointXP ) ) ;
-	    const EEDetId ccXM ( geom->getClosestCell( pointXM ) ) ;
-	    const EEDetId ccYP ( geom->getClosestCell( pointYP ) ) ;
-	    const EEDetId ccYM ( geom->getClosestCell( pointYM ) ) ;
-	    const EEDetId ccPP ( geom->getClosestCell( pointPP ) ) ;
-	    const EEDetId ccPM ( geom->getClosestCell( pointPM ) ) ;
-	    const EEDetId ccMP ( geom->getClosestCell( pointMP ) ) ;
-	    const EEDetId ccMM ( geom->getClosestCell( pointMM ) ) ;
-
-	    assert( ccIn == did ) ;
-	    assert( ccFr == did ) ;
-	    assert( ccBk == did ) ;
-	    assert( ccXP == didXP ||
-		    !geom->getGeometry(didXP)->inside( pointXP ) ) ;
-	    assert( ccXM == didXM ||
-		    !geom->getGeometry(didXM)->inside( pointXM ) ) ;
-	    assert( ccYP == didYP  ||
-		    !geom->getGeometry(didYP)->inside( pointYP ) ) ;
-	    assert( ccYM == didYM  ||
-		    !geom->getGeometry(didYM)->inside( pointYM )) ;
-	    assert( ccPP == didPP  ||
-		    !geom->getGeometry(didPP)->inside( pointPP ) ) ;
-	    assert( ccPM == didPM ||
-		    !geom->getGeometry(didPM)->inside( pointPM ) ) ;
-	    assert( ccMP == didMP ||
-		    !geom->getGeometry(didMP)->inside( pointMP ) ) ;
-	    assert( ccMM == didMM ||
-		    !geom->getGeometry(didMM)->inside( pointMM ) ) ;
-
-	    ovrTst( cg, geom, EEDetId(i) , fOvr ) ;
-	 }
-	 if (subdetn == EcalPreshower) 
-	 {
-	    const ESDetId esid ( i ) ;
-
-	    f << "  // " << esid << std::endl;
-	    f << "  // Checking getClosestCell for position " << cell->getPosition() << " in plane " << esid.plane() << std::endl;
-	    ESDetId closestCell=ESDetId((dynamic_cast<const EcalPreshowerGeometry*>(geom))->getClosestCellInPlane(cell->getPosition(),esid.plane()));
-	    f << "  // Return position is " << closestCell << std::endl;
-	    //sanity checks
-            int o_zside = esid.zside();
-
-            assert ((o_zside < 0 && cell->getPosition().z() < 0.) ||
-		    (o_zside > 0 && cell->getPosition().z() > 0.)        );
-
-	    if( closestCell != esid ) std::cout<<"** esid="<<esid<<", closest="<<closestCell<<std::endl ;
-
-	    const unsigned int i1 ( EcalPreshowerGeometry::alignmentTransformIndexLocal( esid ) ) ;
-
-	    const DetId d1 ( EcalPreshowerGeometry::detIdFromLocalAlignmentIndex( i1 ) ) ;
-
-	    const unsigned int i2 ( EcalPreshowerGeometry::alignmentTransformIndexLocal( d1 ) ) ;
-
-	    assert( i1 == i2 ) ;
-	 }
-      }
-      else if (det == DetId::Hcal)
-      {
-	 const HcalDetId hcId ( i ) ;
-
-	 const unsigned int i1 ( HcalGeometry::alignmentTransformIndexLocal( hcId ) ) ;
-
-	 const DetId d1 ( HcalGeometry::detIdFromLocalAlignmentIndex( i1 ) ) ;
-
-	 const unsigned int i2 ( HcalGeometry::alignmentTransformIndexLocal( d1 ) ) ;
-
-	 assert( i1 == i2 ) ;
-
-	 f << "  // " << HcalDetId(i) << std::endl;
-	    
-	 const GlobalPoint& gp ( cell->getPosition() ) ;
-
-	 f << "  // Checking getClosestCell for position " 
-	   << gp
-	   << std::endl;
-
-	 const HcalDetId closestCell ( geom->getClosestCell( gp ) ) ;
-
-	 f << "  // Return position is " << closestCell << std::endl;
-	 if( closestCell != HcalDetId(i) )
-	 {
-	    const double rr ( reco::deltaR( gp.eta(), gp.phi(), 
-					    geom->getGeometry( closestCell )->getPosition().eta(),
-					    geom->getGeometry( closestCell )->getPosition().phi()   ) ) ; 
-	    if( rr> 1.e-5 ) std::cout<<"For "<<HcalDetId(i)<<" closest is "<<closestCell
-				     << " HCAL dR=" << rr <<std::endl ;
-	 }
-	 // test getCells against base class version every so often
-	 if( 0 == ht.detId2denseId(closestCell)%30)
-	 {
-	    cmpset( geom, gp,  2._deg ) ;
-	    cmpset( geom, gp,  5._deg ) ;
-	    cmpset( geom, gp,  7._deg ) ;
-	    cmpset( geom, gp, 25._deg ) ;
-	    cmpset( geom, gp, 45._deg ) ;
-	 }
-      }
-      else if (det == DetId::Calo &&
-	       subdetn == HcalCastorDetId::SubdetectorId )
-      {
-	 f << "  // " << HcalCastorDetId(i) << std::endl;
-	    
-	 const GlobalPoint gp ( cell->getPosition().x(),
-				cell->getPosition().y(),
-				cell->getPosition().z() - 0.1 ) ;
-
-	 f << "  // Checking getClosestCell for position " 
-	   << gp
-	   << std::endl;
-
-	 const DetId closestCell ( geom->getClosestCell( gp ) ) ;
-
-	 if( closestCell != DetId(0) )
-	 {
-	    f << "  // Return position is " << HcalCastorDetId(closestCell) << std::endl;
-	    if( closestCell != HcalCastorDetId(i) )
-	    {
-	       const double rr ( reco::deltaR( gp.eta(), gp.phi(), 
-					       geom->getGeometry( closestCell )->getPosition().eta(),
-					       geom->getGeometry( closestCell )->getPosition().phi()   ) ) ; 
-	       if( rr> 1.e-5 ) std::cout<<"For "<<HcalCastorDetId(i)<<" closest is "<<HcalCastorDetId(closestCell)
-					<< " dR=" << rr <<std::endl ;
-	    }
-	 }
-	 // test getCells against base class version every so often
-	 // if( 0 == closestCell.denseIndex()%30 )
-	 {
-	    cmpset( geom, gp,  2._deg ) ;
-	    cmpset( geom, gp,  5._deg ) ;
-	    cmpset( geom, gp,  7._deg ) ;
-	    cmpset( geom, gp, 25._deg ) ;
-	    cmpset( geom, gp, 45._deg ) ;
-	 }
-      }
-      else if (det == DetId::Calo &&
-	       subdetn == HcalZDCDetId::SubdetectorId )
-      {
-	 f << "  // " << HcalZDCDetId(i) << std::endl;
-	 const double sign ( HcalZDCDetId(i).zside() ) ;
-	 const GlobalPoint gp ( cell->getPosition().x(),
-				cell->getPosition().y(),
-				cell->getPosition().z() + sign*0.1 ) ;
-
-	 f << "  // Checking getClosestCell for position " 
-	   << gp
-	   << std::endl;
-
-	 const DetId closestCell ( geom->getClosestCell( gp ) ) ;
-
-	 if( closestCell != DetId(0) )
-	 {
-	    f << "  // Return position is " << HcalZDCDetId(closestCell) << std::endl;
-	    if( closestCell != HcalZDCDetId(i) )
-	    {
-	       const double rr ( reco::deltaR( gp.eta(), gp.phi(), 
-					       geom->getGeometry( closestCell )->getPosition().eta(),
-					       geom->getGeometry( closestCell )->getPosition().phi()   ) ) ; 
-	       if( rr> 1.e-5 ) std::cout<<"For "<<HcalZDCDetId(i)<<" closest is "<<HcalZDCDetId(closestCell)
-					<< " dR=" << rr <<std::endl ;
-	    }
-	 }
-	 // test getCells against base class version every so often
-	 // if( 0 == closestCell.denseIndex()%30 )
-	 {
-	    cmpset( geom, gp,  2._deg ) ;
-	    cmpset( geom, gp,  5._deg ) ;
-	    cmpset( geom, gp,  7._deg ) ;
-	    cmpset( geom, gp, 25._deg ) ;
-	    cmpset( geom, gp, 45._deg ) ;
-	 }
-      }
-    
-      if (det == DetId::Hcal && subdetn==HcalForward) 
-	 f << "  box=geoManager->MakeBox(\"point\",dummyMedium,1.0,1.0,1.0);" << std::endl;
-      else
-	 f << "  box=geoManager->MakeBox(\"point\",dummyMedium,3.0,3.0,3.0);" << std::endl;
-      f << "  world->AddNode(box,"<< n << ",new TGeoHMatrix(TGeoTranslation(" << 
-	 cell->getPosition().x() << "," << cell->getPosition().y() << "," << cell->getPosition().z() << ")));" << std::endl;
-   }
-   f << "  geoManager->CloseGeometry();" << std::endl;
-   f << "world->Voxelize(\"\"); // now the new geometry is valid for tracking, so you can do \n // even raytracing \n //  if (!canvas) { \n    TCanvas* canvas=new TCanvas(\"EvtDisp\",\"EvtDisp\",500,500); \n //  } \n  canvas->Modified(); \n  canvas->Update();      \n  world->Draw(); \n";
-   f << "}" << std::endl;
-   f.close();
-   fCtr.close();
-   fCor.close();
+  }
 }
 
-void
-CaloGeometryAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup )
-{
+void CaloGeometryAnalyzer::ovrTst(const CaloGeometry* cg,
+                                  const CaloSubdetectorGeometry* geom,
+                                  const EBDetId& id,
+                                  std::fstream& fOvr) {
+  static const GlobalPoint origin(0, 0, 0);
+  const int ieta(id.ieta());
+  if (85 == std::abs(ieta)) {
+    const EcalBarrelGeometry* ebG(dynamic_cast<const EcalBarrelGeometry*>(geom));
+    auto cell(geom->getGeometry(id));
+    const CaloSubdetectorGeometry* ecap(cg->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
+    fOvr << "Endcap Neighbors of Barrel id = " << id << std::endl;
+    const EcalBarrelGeometry::OrderedListOfEEDetId* ol(ebG->getClosestEndcapCells(id));
+    // assert ( nullptr != ol ) ;
+    if (ol != nullptr) {
+      for (unsigned int i(0); i != ol->size(); ++i) {
+        fOvr << "           " << i << "  " << (*ol)[i];
+        auto other(ecap->getGeometry((*ol)[i]));
+        const GlobalVector cv(cell->getPosition() - origin);
+        const GlobalVector ov(other->getPosition() - origin);
+        const double cosang(cv.dot(ov) / (cv.mag() * ov.mag()));
+        const double angle(convertRadToDeg(acos(std::abs(cosang) < 1. ? cosang : 1.)));
+        fOvr << ", angle = " << angle << std::endl;
+      }
+    } else {
+      fOvr << "endcap ecal ptr is null " << std::endl;
+    }
+  }
+}
 
-   const auto& pG = iSetup.getData(geometryToken_);
-   const CaloGeometry* cG = &pG;
-   const auto& pT = iSetup.getData(topologyToken_);
+void CaloGeometryAnalyzer::checkDiff(int i1, int i2, int i3, CenterOrCorner iCtrCor, XorYorZ iXYZ, double diff) {
+  if (3.5 < fabs(diff)) {
+    std::cout << "For a volume " << (kCenter == iCtrCor ? "CENTER" : "CORNER") << ", & "
+              << "i1=" << i1 << " & i2=" << i2 << " & i3=" << i3 << ", ***BIG DISAGREEMENT FOUND. D"
+              << (kX == iXYZ ? "X" : (kY == iXYZ ? "Y" : "Z")) << "=" << diff << " microns" << std::endl;
+    m_allOK = false;
+  }
+}
 
-   const std::vector<DetId> allDetId ( pG.getValidDetIds() ) ;
+void CaloGeometryAnalyzer::ctrcor(const DetId& did,
+                                  const CaloCellGeometry& cell,
+                                  std::fstream& fCtr,
+                                  std::fstream& fCor,
+                                  std::fstream& oldCtr,
+                                  std::fstream& oldCor,
+                                  unsigned int histi) {
+  int oldie(0);
+  int oldip(0);
+  oldCtr >> oldie >> oldip;
+  oldCor >> oldie >> oldip;
+  const CaloGenericDetId cgid(did);
+  if (cgid.isEB()) {
+    const EBDetId ebid(did);
+    const int ie(ebid.ieta());
+    const int ip(ebid.iphi());
+    fCtr << std::setw(4) << ie << std::setw(4) << ip;
+    fCor << std::setw(4) << ie << std::setw(4) << ip;
+  }
+  if (cgid.isEE()) {
+    const EEDetId eeid(did);
+    const int ix(eeid.ix());
+    const int iy(eeid.iy());
 
-   const std::vector<DetId>& deb ( pG.getValidDetIds(DetId::Ecal,EcalBarrel                     ));
-   const std::vector<DetId>& dee ( pG.getValidDetIds(DetId::Ecal,EcalEndcap                     ));
-   const std::vector<DetId>& des ( pG.getValidDetIds(DetId::Ecal,EcalPreshower                  ));
-   const std::vector<DetId>& dhb ( pG.getValidDetIds(DetId::Hcal,HcalBarrel                     ));
-   const std::vector<DetId>& dhe ( pG.getValidDetIds(DetId::Hcal,HcalEndcap                     ));
-   const std::vector<DetId>& dho ( pG.getValidDetIds(DetId::Hcal,HcalOuter                      ));
-   const std::vector<DetId>& dhf ( pG.getValidDetIds(DetId::Hcal,HcalForward                    ));
-   const std::vector<DetId>& dct ( pG.getValidDetIds(DetId::Calo,CaloTowerDetId::SubdetId       ));
-   const std::vector<DetId>& dca ( pG.getValidDetIds(DetId::Calo,HcalCastorDetId::SubdetectorId ));
-   const std::vector<DetId>& dzd ( pG.getValidDetIds(DetId::Calo,HcalZDCDetId::SubdetectorId    ));
+    fCtr << std::setw(4) << ix << std::setw(4) << iy;
+    fCor << std::setw(4) << ix << std::setw(4) << iy;
+  }
+  if (cgid.isES()) {
+    const ESDetId esid(did);
+    const int pl(esid.plane());
+    const int ix(esid.six());
+    const int iy(esid.siy());
+    const int st(esid.strip());
+    fCtr << std::setw(4) << pl << std::setw(4) << ix << std::setw(4) << iy << std::setw(4) << st;
+    fCor << std::setw(4) << pl << std::setw(4) << ix << std::setw(4) << iy << std::setw(4) << st;
+    int oldiy, oldst;
+    oldCtr >> oldiy >> oldst;
+    oldCor >> oldip >> oldst;
+  }
+  int depth = 0;
+  if (cgid.det() == DetId::Hcal) {
+    const HcalDetId hcid(did);
+    const int ie(hcid.ieta());
+    const int ip(hcid.iphi());
+    const int de(hcid.depth());
+    fCtr << std::setw(4) << ie << std::setw(4) << ip << std::setw(4) << de;
+    fCor << std::setw(4) << ie << std::setw(4) << ip << std::setw(4) << de;
+    int oldde;
+    oldCtr >> oldde;
+    oldCor >> oldde;
+    depth = de;
+  }
+  if (cgid.isZDC()) {
+    const HcalZDCDetId zcid(did);
+    const int is(zcid.section());
+    const int ic(zcid.channel());
+    fCtr << std::setw(4) << is << std::setw(4) << ic;
+    fCor << std::setw(4) << is << std::setw(4) << ic;
+  }
+  if (cgid.isCastor()) {
+    const HcalCastorDetId cid(did);
+    const int is(cid.sector());
+    const int im(cid.module());
+    fCtr << std::setw(4) << is << std::setw(4) << im;
+    fCor << std::setw(4) << is << std::setw(4) << im;
+  }
+  if (cgid.isCaloTower()) {
+    const CaloTowerDetId cid(did);
+    const int ie(cid.ieta());
+    const int ip(cid.iphi());
+    fCtr << std::setw(4) << ie << std::setw(4) << ip;
+    fCor << std::setw(4) << ie << std::setw(4) << ip;
+  }
 
-   const std::vector<DetId>& dha ( pG.getSubdetectorGeometry(DetId::Hcal,1)->getValidDetIds());
+  const double x(cell.getPosition().x());
+  const double y(cell.getPosition().y());
+  const double z(cell.getPosition().z());
 
+  double oldx, oldy, oldz;
 
-   const unsigned int sum ( deb.size() +
-			    dee.size() +
-			    des.size() +
-			    dhb.size() +
-			    dhe.size() +
-			    dho.size() +
-			    dhf.size() +
-			    dct.size() +
-			    dca.size() +
-			    dzd.size()   ) ;
+  oldCtr >> oldx >> oldy >> oldz;
 
-   if( sum != allDetId.size() ) 
-   {
-      std::cout<<"Sums differ! One is "<<allDetId.size()
-	       <<" and the other is "<<sum
-	       <<std::endl ;
-   }
+  const double dx(1.e4 * (x - oldx));
+  const double dy(1.e4 * (y - oldy));
+  const double dz(1.e4 * (z - oldz));
 
-   assert( sum == allDetId.size() ) ;
+  h_diffs[histi][0]->Fill(dx);
+  h_diffs[histi][1]->Fill(dy);
+  h_diffs[histi][2]->Fill(dz);
 
-   assert( dha.size() == dhb.size()+dhe.size()+dho.size()+dhf.size() ) ;
-   //
-   // get the ecal & hcal geometry
-   //
-   if (pass_==0) 
-   {
+  checkDiff(oldie, oldip, depth, kCenter, kX, dx);
+  checkDiff(oldie, oldip, depth, kCenter, kY, dy);
+  checkDiff(oldie, oldip, depth, kCenter, kZ, dz);
 
-      std::cout<<"**Ecal Barrel avg Radius = "
-	       << dynamic_cast<const EcalBarrelGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalBarrel))->avgRadiusXYFrontFaceCenter()
-	       << std::endl ;
+  fCtr << std::fixed << std::setw(12) << std::setprecision(4) << x << std::fixed << std::setw(12)
+       << std::setprecision(4) << y << std::fixed << std::setw(12) << std::setprecision(4) << z << std::endl;
 
-      std::cout<<"**Ecal Endcap avg Zabs = "
-	       << dynamic_cast<const EcalEndcapGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalEndcap))->avgAbsZFrontFaceCenter()
-	       << std::endl ;
+  const CaloCellGeometry::CornersVec& co(cell.getCorners());
 
-      m_allOK = true ;
+  for (unsigned int j(0); j < co.size(); ++(++(++j))) {
+    const double x(co[j].x());
+    const double y(co[j].y());
+    const double z(co[j].z());
 
-      build(cG,pT,DetId::Ecal,EcalBarrel                     ,"eb",0);
-      build(cG,pT,DetId::Ecal,EcalEndcap                     ,"ee",1);
-      build(cG,pT,DetId::Ecal,EcalPreshower                  ,"es",2);
-      buildHcal(cG,pT,DetId::Hcal,HcalBarrel                 ,"hb",3);
-      buildHcal(cG,pT,DetId::Hcal,HcalEndcap                 ,"he",4);
-      buildHcal(cG,pT,DetId::Hcal,HcalOuter                  ,"ho",5);
-      buildHcal(cG,pT,DetId::Hcal,HcalForward                ,"hf",6);
-      build(cG,pT,DetId::Calo,CaloTowerDetId::SubdetId       ,"ct",7);
-      build(cG,pT,DetId::Calo,HcalCastorDetId::SubdetectorId ,"ca",8);
-      build(cG,pT,DetId::Calo,HcalZDCDetId::SubdetectorId    ,"zd",9);
+    double oldx, oldy, oldz;
 
-      std::cout<<"\n\n*********** Validation of cell centers and corners "
-	       <<( m_allOK ? "SUCCEEDS!! " : "FAILS!! ")
-	       <<"**********************\n\n\n" 
-	       <<std::endl ;
-   }
+    oldCor >> oldx >> oldy >> oldz;
 
-   pass_++;
+    const double dx(1.e4 * (x - oldx));
+    const double dy(1.e4 * (y - oldy));
+    const double dz(1.e4 * (z - oldz));
+
+    h_diffs[histi][j + 3]->Fill(dx);
+    h_diffs[histi][j + 4]->Fill(dy);
+    h_diffs[histi][j + 5]->Fill(dz);
+
+    checkDiff(oldie, oldip, j, kCorner, kX, dx);
+    checkDiff(oldie, oldip, j, kCorner, kY, dy);
+    checkDiff(oldie, oldip, j, kCorner, kZ, dz);
+
+    fCor << std::fixed << std::setw(12) << std::setprecision(4) << x << std::fixed << std::setw(12)
+         << std::setprecision(4) << y << std::fixed << std::setw(12) << std::setprecision(4) << z;
+  }
+  fCor << std::endl;
+}
+
+void CaloGeometryAnalyzer::buildHcal(const CaloGeometry* cg,
+                                     const HcalTopology& ht,
+                                     DetId::Detector det,
+                                     int subdetn,
+                                     const char* name,
+                                     unsigned int histi) {
+  std::cout << "Now checking detector " << name << std::endl;
+  const std::string oldnameCtr("old" + std::string(name) + ".ctr");
+  const std::string oldnameCor("old" + std::string(name) + ".cor");
+  const std::string fnameCtr(std::string(name) + ".ctr");
+  const std::string fnameCor(std::string(name) + ".cor");
+  const std::string fnameOvr(std::string(name) + ".ovr");
+  const std::string fnameRoot(std::string(name) + ".C");
+  std::fstream oldCtr(oldnameCtr.c_str(), std::ios_base::in);
+  std::fstream oldCor(oldnameCor.c_str(), std::ios_base::in);
+  std::fstream fCtr(fnameCtr.c_str(), std::ios_base::out);
+  std::fstream fCor(fnameCor.c_str(), std::ios_base::out);
+  std::fstream fOvr(fnameOvr.c_str(), std::ios_base::out);
+  std::fstream f(fnameRoot.c_str(), std::ios_base::out);
+
+  const CaloSubdetectorGeometry* geom(cg->getSubdetectorGeometry(det, subdetn));
+
+  f << "{" << std::endl;
+  f << "  TGeoManager* geoManager = new TGeoManager(\"ROOT\", \"" << name << "\");" << std::endl;
+  f << "  TGeoMaterial* dummyMaterial = new TGeoMaterial(\"Vacuum\", 0,0,0); " << std::endl;
+  f << "  TGeoMedium* dummyMedium =  new TGeoMedium(\"Vacuum\",1,dummyMaterial);" << std::endl;
+  f << "  TGeoVolume* world=geoManager->MakeBox(\"world\",dummyMedium, 8000.0, 8000.0, 14000.0); " << std::endl;
+  f << "  geoManager->SetTopVolume(world); " << std::endl;
+  f << "  TGeoVolume* box; " << std::endl;
+  int n = 0;
+  const std::vector<DetId>& ids(geom->getValidDetIds(det, subdetn));
+
+  const std::vector<DetId>& ids2(cg->getValidDetIds(det, subdetn));
+
+  if (ids != ids2) {
+    std::cout << "Methods differ! One gives size " << ids.size() << " and the other gives size " << ids2.size()
+              << std::endl;
+  }
+  assert(ids == ids2);
+
+  for (const auto& i : ids) {
+    ++n;
+    auto cell = (geom->getGeometry(i));
+
+    assert(cg->present(i));
+
+    ctrcor(i, *cell, fCtr, fCor, oldCtr, oldCor, histi);
+
+    const DetId id(i);
+
+    const HcalDetId hcId(i);
+
+    const GlobalPoint pos(cell->getPosition());
+    const double posmag(pos.mag());
+
+    const double disin(DetId::Ecal == det && EcalPreshower == subdetn ? 0.000001 : 0.001);
+
+    const GlobalPoint pointIn(
+        pos.x() + disin * pos.x() / posmag, pos.y() + disin * pos.y() / posmag, pos.z() + disin * pos.z() / posmag);
+    const GlobalPoint pointFr(
+        pos.x() - 0.1 * pos.x() / posmag, pos.y() - 0.1 * pos.y() / posmag, pos.z() - 0.1 * pos.z() / posmag);
+
+    if (cell->inside(pointFr))
+      std::cout << "Bad outside: " << pointIn << ", " << pointFr << std::endl;
+    assert(cell->inside(pointIn));
+    assert(!cell->inside(pointFr));
+
+    const double deltaPhi(geom->deltaPhi(id));
+
+    const double deltaEta(geom->deltaEta(id));
+
+    const unsigned int detIndex(3);
+    const GlobalPoint ggp(cell->getPosition());
+
+    h_dPhi[detIndex]->Fill(ht.detId2denseId(hcId), deltaPhi);
+    h_dPhiR[detIndex]->Fill(ggp.perp(), deltaPhi);
+
+    h_dEta[detIndex]->Fill(ht.detId2denseId(hcId), deltaEta);
+    h_dEtaR[detIndex]->Fill(ggp.perp(), deltaEta);
+
+    const unsigned int i1(HcalGeometry::alignmentTransformIndexLocal(hcId));
+
+    const DetId d1(HcalGeometry::detIdFromLocalAlignmentIndex(i1));
+
+    const unsigned int i2(HcalGeometry::alignmentTransformIndexLocal(d1));
+
+    assert(i1 == i2);
+
+    f << "  // " << HcalDetId(i) << std::endl;
+
+    const GlobalPoint gp(cell->getPosition());
+    f << "  // Checking getClosestCell for position " << gp << std::endl;
+
+    HcalDetId closestCell(geom->getClosestCell(gp));
+
+    f << "  // Return position is " << closestCell << std::endl;
+    if (closestCell != HcalDetId(i)) {
+      const double rr(reco::deltaR(gp.eta(),
+                                   gp.phi(),
+                                   geom->getGeometry(closestCell)->getPosition().eta(),
+                                   geom->getGeometry(closestCell)->getPosition().phi()));
+      if (rr > 1.e-5)
+        std::cout << "For " << HcalDetId(i) << " closest is " << closestCell << " HCAL dR=" << rr << std::endl;
+    }
+    // test getCells against base class version every so often
+    if (0 == ht.detId2denseId(closestCell) % 30) {
+      cmpset(geom, gp, 2._deg);
+      cmpset(geom, gp, 5._deg);
+      cmpset(geom, gp, 7._deg);
+      cmpset(geom, gp, 25._deg);
+      cmpset(geom, gp, 45._deg);
+    }
+
+    if (det == DetId::Hcal && subdetn == HcalForward)
+      f << "  box=geoManager->MakeBox(\"point\",dummyMedium,1.0,1.0,1.0);" << std::endl;
+    else
+      f << "  box=geoManager->MakeBox(\"point\",dummyMedium,3.0,3.0,3.0);" << std::endl;
+    f << "  world->AddNode(box," << n << ",new TGeoHMatrix(TGeoTranslation(" << cell->getPosition().x() << ","
+      << cell->getPosition().y() << "," << cell->getPosition().z() << ")));" << std::endl;
+  }
+
+  f << "  geoManager->CloseGeometry();" << std::endl;
+  f << "world->Voxelize(\"\"); // now the new geometry is valid for tracking, so you can do \n // even raytracing \n "
+       "//  if (!canvas) { \n    TCanvas* canvas=new TCanvas(\"EvtDisp\",\"EvtDisp\",500,500); \n //  } \n  "
+       "canvas->Modified(); \n  canvas->Update();      \n  world->Draw(); \n";
+  f << "}" << std::endl;
+  f.close();
+  fCtr.close();
+  fCor.close();
+}
+
+void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
+                                 const HcalTopology& ht,
+                                 DetId::Detector det,
+                                 int subdetn,
+                                 const char* name,
+                                 unsigned int histi) {
+  std::cout << "Now checking detector " << name << std::endl;
+
+  const std::string oldnameCtr("old" + std::string(name) + ".ctr");
+  const std::string oldnameCor("old" + std::string(name) + ".cor");
+  const std::string fnameCtr(std::string(name) + ".ctr");
+  const std::string fnameCor(std::string(name) + ".cor");
+  const std::string fnameOvr(std::string(name) + ".ovr");
+  const std::string fnameRoot(std::string(name) + ".C");
+  std::fstream oldCtr(oldnameCtr.c_str(), std::ios_base::in);
+  std::fstream oldCor(oldnameCor.c_str(), std::ios_base::in);
+  std::fstream fCtr(fnameCtr.c_str(), std::ios_base::out);
+  std::fstream fCor(fnameCor.c_str(), std::ios_base::out);
+  std::fstream fOvr(fnameOvr.c_str(), std::ios_base::out);
+  std::fstream f(fnameRoot.c_str(), std::ios_base::out);
+
+  const CaloSubdetectorGeometry* geom(cg->getSubdetectorGeometry(det, subdetn));
+
+  f << "{" << std::endl;
+  f << "  TGeoManager* geoManager = new TGeoManager(\"ROOT\", \"" << name << "\");" << std::endl;
+  f << "  TGeoMaterial* dummyMaterial = new TGeoMaterial(\"Vacuum\", 0,0,0); " << std::endl;
+  f << "  TGeoMedium* dummyMedium =  new TGeoMedium(\"Vacuum\",1,dummyMaterial);" << std::endl;
+  f << "  TGeoVolume* world=geoManager->MakeBox(\"world\",dummyMedium, 8000.0, 8000.0, 14000.0); " << std::endl;
+  f << "  geoManager->SetTopVolume(world); " << std::endl;
+  f << "  TGeoVolume* box; " << std::endl;
+  int n = 0;
+  const std::vector<DetId>& ids(geom->getValidDetIds(det, subdetn));
+
+  const std::vector<DetId>& ids2(cg->getValidDetIds(det, subdetn));
+
+  if (ids != ids2) {
+    std::cout << "Methods differ! One gives size " << ids.size() << " and the other gives size " << ids2.size()
+              << std::endl;
+  }
+
+  assert(ids == ids2);
+
+  for (const auto& i : ids) {
+    ++n;
+    auto cell(geom->getGeometry(i));
+
+    assert(cg->present(i));
+
+    ctrcor(i, *cell, fCtr, fCor, oldCtr, oldCor, histi);
+
+    const DetId id(i);
+
+    const CaloGenericDetId cid(id);
+
+    assert(cid.validDetId());
+
+    assert(CaloGenericDetId(id.det(), id.subdetId(), cid.denseIndex()) == id);
+
+    const GlobalPoint pos(cell->getPosition());
+    const double posmag(pos.mag());
+
+    const double disin(DetId::Ecal == det && EcalPreshower == subdetn ? 0.000001 : 0.001);
+
+    const GlobalPoint pointIn(
+        pos.x() + disin * pos.x() / posmag, pos.y() + disin * pos.y() / posmag, pos.z() + disin * pos.z() / posmag);
+    const GlobalPoint pointFr(
+        pos.x() - 0.1 * pos.x() / posmag, pos.y() - 0.1 * pos.y() / posmag, pos.z() - 0.1 * pos.z() / posmag);
+
+    if (cell->inside(pointFr))
+      std::cout << "Bad outside: " << pointIn << ", " << pointFr << std::endl;
+    assert(cell->inside(pointIn));
+    assert(!cell->inside(pointFr));
+
+    const double deltaPhi(geom->deltaPhi(id));
+
+    const double deltaEta(geom->deltaEta(id));
+
+    const unsigned int detIndex(
+        DetId::Ecal == det && EcalBarrel == subdetn
+            ? 0
+            : (DetId::Ecal == det && EcalEndcap == subdetn
+                   ? 1
+                   : (DetId::Ecal == det && EcalPreshower == subdetn
+                          ? 2
+                          : (DetId::Hcal == det
+                                 ? 3
+                                 : (DetId::Calo == det && HcalZDCDetId::SubdetectorId == subdetn
+                                        ? 4
+                                        : (DetId::Calo == det && HcalCastorDetId::SubdetectorId == subdetn ? 5 : 6))))));
+
+    const CaloGenericDetId cgid(id);
+
+    const GlobalPoint ggp(cell->getPosition());
+
+    h_dPhi[detIndex]->Fill(cgid.denseIndex(), deltaPhi);
+    h_dPhiR[detIndex]->Fill(ggp.perp(), deltaPhi);
+
+    h_dEta[detIndex]->Fill(cgid.denseIndex(), deltaEta);
+    h_dEtaR[detIndex]->Fill(ggp.perp(), deltaEta);
+
+    if (det == DetId::Ecal) {
+      if (subdetn == EcalBarrel) {
+        f << "  // " << EBDetId(i) << std::endl;
+
+        const GlobalPoint gp(cell->getPosition(0.));
+
+        f << "  // Checking getClosestCell for position " << gp << std::endl;
+
+        const EBDetId ebid(id);
+        for (unsigned int j(0); j != 4; ++j) {
+          const CaloCellGeometry::CornersVec& corn(cell->getCorners());
+          h_eta->Fill(ebid.ieta() * 1. + 0.25 * j, corn[j].eta());
+          if (ebid.ieta() > 0)
+            h_phi->Fill(ebid.iphi() * 1. + 0.25 * j, corn[j].phi());
+        }
+
+        EBDetId closestCell(geom->getClosestCell(gp));
+
+        f << "  // Return position is " << closestCell << std::endl;
+        assert(closestCell == EBDetId(i));
+        // test getCells against base class version every so often
+        if (0 == closestCell.hashedIndex() % 100) {
+          cmpset(geom, gp, 2._deg);
+          cmpset(geom, gp, 5._deg);
+          cmpset(geom, gp, 25._deg);
+          cmpset(geom, gp, 45._deg);
+        }
+
+        ovrTst(cg, geom, EBDetId(i), fOvr);
+
+        const unsigned int i1(EcalBarrelGeometry::alignmentTransformIndexLocal(ebid));
+
+        const DetId d1(EcalBarrelGeometry::detIdFromLocalAlignmentIndex(i1));
+
+        const unsigned int i2(EcalBarrelGeometry::alignmentTransformIndexLocal(d1));
+
+        assert(i1 == i2);
+      }
+      if (subdetn == EcalEndcap) {
+        const EEDetId did(i);
+        const int ix(did.ix());
+        const int iy(did.iy());
+        const int iz(did.zside());
+
+        const unsigned int i1(EcalEndcapGeometry::alignmentTransformIndexLocal(did));
+
+        const DetId d1(EcalEndcapGeometry::detIdFromLocalAlignmentIndex(i1));
+
+        const unsigned int i2(EcalEndcapGeometry::alignmentTransformIndexLocal(d1));
+
+        assert(i1 == i2);
+
+        f << "  // Checking getClosestCell for position " << cell->getPosition(0.) << std::endl;
+
+        const GlobalPoint gp(cell->getPosition(0.));
+
+        const EEDetId closestCell(geom->getClosestCell(gp));
+        f << "  // Return position is " << closestCell << std::endl;
+
+        assert(closestCell == did);
+        // test getCells against base class version every so often
+        if (0 == closestCell.hashedIndex() % 10) {
+          cmpset(geom, gp, 2._deg);
+          cmpset(geom, gp, 5._deg);
+          cmpset(geom, gp, 25._deg);
+          cmpset(geom, gp, 45._deg);
+        }
+
+        const GlobalVector xx(2.5, 0, 0);
+        const GlobalVector yy(0, 2.5, 0);
+        const GlobalVector zz(0, 0, 1);
+        const GlobalPoint pointIn(cell->getPosition(1.));
+        const GlobalPoint pointFr(cell->getPosition(-1.));
+        const GlobalPoint pointBk(cell->getPosition(24.));
+        const GlobalPoint pointXP(cell->getPosition(1.) + xx);
+        const GlobalPoint pointXM(cell->getPosition(1.) - xx);
+        const GlobalPoint pointYP(cell->getPosition(1.) + yy);
+        const GlobalPoint pointYM(cell->getPosition(1.) - yy);
+        const GlobalPoint pointPP(cell->getPosition(1.) + xx + yy);
+        const GlobalPoint pointPM(cell->getPosition(1.) + xx - yy);
+        const GlobalPoint pointMP(cell->getPosition(1.) - xx + yy);
+        const GlobalPoint pointMM(cell->getPosition(1.) - xx - yy);
+        const EEDetId didXP(gid(ix + 1, iy, iz, did));
+        const EEDetId didXM(gid(ix - 1, iy, iz, did));
+        const EEDetId didYP(gid(ix, iy + 1, iz, did));
+        const EEDetId didYM(gid(ix, iy - 1, iz, did));
+        const EEDetId didPP(gid(ix + 1, iy + 1, iz, did));
+        const EEDetId didPM(gid(ix + 1, iy - 1, iz, did));
+        const EEDetId didMP(gid(ix - 1, iy + 1, iz, did));
+        const EEDetId didMM(gid(ix - 1, iy - 1, iz, did));
+
+        assert(cell->inside(pointIn));
+        assert(!cell->inside(pointFr));
+        assert(!cell->inside(pointBk));
+        assert(!cell->inside(pointXP));
+        assert(!cell->inside(pointXM));
+        assert(!cell->inside(pointYP));
+        assert(!cell->inside(pointYM));
+        assert(!cell->inside(pointPP));
+        assert(!cell->inside(pointPM));
+        assert(!cell->inside(pointMP));
+        assert(!cell->inside(pointMM));
+
+        const EEDetId ccBk(geom->getClosestCell(pointBk));
+        const EEDetId ccIn(geom->getClosestCell(pointIn));
+        const EEDetId ccFr(geom->getClosestCell(pointFr));
+        const EEDetId ccXP(geom->getClosestCell(pointXP));
+        const EEDetId ccXM(geom->getClosestCell(pointXM));
+        const EEDetId ccYP(geom->getClosestCell(pointYP));
+        const EEDetId ccYM(geom->getClosestCell(pointYM));
+        const EEDetId ccPP(geom->getClosestCell(pointPP));
+        const EEDetId ccPM(geom->getClosestCell(pointPM));
+        const EEDetId ccMP(geom->getClosestCell(pointMP));
+        const EEDetId ccMM(geom->getClosestCell(pointMM));
+
+        assert(ccIn == did);
+        assert(ccFr == did);
+        assert(ccBk == did);
+        assert(ccXP == didXP || !geom->getGeometry(didXP)->inside(pointXP));
+        assert(ccXM == didXM || !geom->getGeometry(didXM)->inside(pointXM));
+        assert(ccYP == didYP || !geom->getGeometry(didYP)->inside(pointYP));
+        assert(ccYM == didYM || !geom->getGeometry(didYM)->inside(pointYM));
+        assert(ccPP == didPP || !geom->getGeometry(didPP)->inside(pointPP));
+        assert(ccPM == didPM || !geom->getGeometry(didPM)->inside(pointPM));
+        assert(ccMP == didMP || !geom->getGeometry(didMP)->inside(pointMP));
+        assert(ccMM == didMM || !geom->getGeometry(didMM)->inside(pointMM));
+
+        ovrTst(cg, geom, EEDetId(i), fOvr);
+      }
+      if (subdetn == EcalPreshower) {
+        const ESDetId esid(i);
+
+        f << "  // " << esid << std::endl;
+        f << "  // Checking getClosestCell for position " << cell->getPosition() << " in plane " << esid.plane()
+          << std::endl;
+        ESDetId closestCell = ESDetId((dynamic_cast<const EcalPreshowerGeometry*>(geom))
+                                          ->getClosestCellInPlane(cell->getPosition(), esid.plane()));
+        f << "  // Return position is " << closestCell << std::endl;
+        //sanity checks
+        int o_zside = esid.zside();
+
+        assert((o_zside < 0 && cell->getPosition().z() < 0.) || (o_zside > 0 && cell->getPosition().z() > 0.));
+
+        if (closestCell != esid)
+          std::cout << "** esid=" << esid << ", closest=" << closestCell << std::endl;
+
+        const unsigned int i1(EcalPreshowerGeometry::alignmentTransformIndexLocal(esid));
+
+        const DetId d1(EcalPreshowerGeometry::detIdFromLocalAlignmentIndex(i1));
+
+        const unsigned int i2(EcalPreshowerGeometry::alignmentTransformIndexLocal(d1));
+
+        assert(i1 == i2);
+      }
+    } else if (det == DetId::Hcal) {
+      const HcalDetId hcId(i);
+
+      const unsigned int i1(HcalGeometry::alignmentTransformIndexLocal(hcId));
+
+      const DetId d1(HcalGeometry::detIdFromLocalAlignmentIndex(i1));
+
+      const unsigned int i2(HcalGeometry::alignmentTransformIndexLocal(d1));
+
+      assert(i1 == i2);
+
+      f << "  // " << HcalDetId(i) << std::endl;
+
+      const GlobalPoint& gp(cell->getPosition());
+
+      f << "  // Checking getClosestCell for position " << gp << std::endl;
+
+      const HcalDetId closestCell(geom->getClosestCell(gp));
+
+      f << "  // Return position is " << closestCell << std::endl;
+      if (closestCell != HcalDetId(i)) {
+        const double rr(reco::deltaR(gp.eta(),
+                                     gp.phi(),
+                                     geom->getGeometry(closestCell)->getPosition().eta(),
+                                     geom->getGeometry(closestCell)->getPosition().phi()));
+        if (rr > 1.e-5)
+          std::cout << "For " << HcalDetId(i) << " closest is " << closestCell << " HCAL dR=" << rr << std::endl;
+      }
+      // test getCells against base class version every so often
+      if (0 == ht.detId2denseId(closestCell) % 30) {
+        cmpset(geom, gp, 2._deg);
+        cmpset(geom, gp, 5._deg);
+        cmpset(geom, gp, 7._deg);
+        cmpset(geom, gp, 25._deg);
+        cmpset(geom, gp, 45._deg);
+      }
+    } else if (det == DetId::Calo && subdetn == HcalCastorDetId::SubdetectorId) {
+      f << "  // " << HcalCastorDetId(i) << std::endl;
+
+      const GlobalPoint gp(cell->getPosition().x(), cell->getPosition().y(), cell->getPosition().z() - 0.1);
+
+      f << "  // Checking getClosestCell for position " << gp << std::endl;
+
+      const DetId closestCell(geom->getClosestCell(gp));
+
+      if (closestCell != DetId(0)) {
+        f << "  // Return position is " << HcalCastorDetId(closestCell) << std::endl;
+        if (closestCell != HcalCastorDetId(i)) {
+          const double rr(reco::deltaR(gp.eta(),
+                                       gp.phi(),
+                                       geom->getGeometry(closestCell)->getPosition().eta(),
+                                       geom->getGeometry(closestCell)->getPosition().phi()));
+          if (rr > 1.e-5)
+            std::cout << "For " << HcalCastorDetId(i) << " closest is " << HcalCastorDetId(closestCell) << " dR=" << rr
+                      << std::endl;
+        }
+      }
+      // test getCells against base class version every so often
+      // if( 0 == closestCell.denseIndex()%30 )
+      {
+        cmpset(geom, gp, 2._deg);
+        cmpset(geom, gp, 5._deg);
+        cmpset(geom, gp, 7._deg);
+        cmpset(geom, gp, 25._deg);
+        cmpset(geom, gp, 45._deg);
+      }
+    } else if (det == DetId::Calo && subdetn == HcalZDCDetId::SubdetectorId) {
+      f << "  // " << HcalZDCDetId(i) << std::endl;
+      const double sign(HcalZDCDetId(i).zside());
+      const GlobalPoint gp(cell->getPosition().x(), cell->getPosition().y(), cell->getPosition().z() + sign * 0.1);
+
+      f << "  // Checking getClosestCell for position " << gp << std::endl;
+
+      const DetId closestCell(geom->getClosestCell(gp));
+
+      if (closestCell != DetId(0)) {
+        f << "  // Return position is " << HcalZDCDetId(closestCell) << std::endl;
+        if (closestCell != HcalZDCDetId(i)) {
+          const double rr(reco::deltaR(gp.eta(),
+                                       gp.phi(),
+                                       geom->getGeometry(closestCell)->getPosition().eta(),
+                                       geom->getGeometry(closestCell)->getPosition().phi()));
+          if (rr > 1.e-5)
+            std::cout << "For " << HcalZDCDetId(i) << " closest is " << HcalZDCDetId(closestCell) << " dR=" << rr
+                      << std::endl;
+        }
+      }
+      // test getCells against base class version every so often
+      // if( 0 == closestCell.denseIndex()%30 )
+      {
+        cmpset(geom, gp, 2._deg);
+        cmpset(geom, gp, 5._deg);
+        cmpset(geom, gp, 7._deg);
+        cmpset(geom, gp, 25._deg);
+        cmpset(geom, gp, 45._deg);
+      }
+    }
+
+    if (det == DetId::Hcal && subdetn == HcalForward)
+      f << "  box=geoManager->MakeBox(\"point\",dummyMedium,1.0,1.0,1.0);" << std::endl;
+    else
+      f << "  box=geoManager->MakeBox(\"point\",dummyMedium,3.0,3.0,3.0);" << std::endl;
+    f << "  world->AddNode(box," << n << ",new TGeoHMatrix(TGeoTranslation(" << cell->getPosition().x() << ","
+      << cell->getPosition().y() << "," << cell->getPosition().z() << ")));" << std::endl;
+  }
+  f << "  geoManager->CloseGeometry();" << std::endl;
+  f << "world->Voxelize(\"\"); // now the new geometry is valid for tracking, so you can do \n // even raytracing \n "
+       "//  if (!canvas) { \n    TCanvas* canvas=new TCanvas(\"EvtDisp\",\"EvtDisp\",500,500); \n //  } \n  "
+       "canvas->Modified(); \n  canvas->Update();      \n  world->Draw(); \n";
+  f << "}" << std::endl;
+  f.close();
+  fCtr.close();
+  fCor.close();
+}
+
+void CaloGeometryAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
+  const auto& pG = iSetup.getData(geometryToken_);
+  const CaloGeometry* cG = &pG;
+  const auto& pT = iSetup.getData(topologyToken_);
+
+  const std::vector<DetId> allDetId(pG.getValidDetIds());
+
+  const std::vector<DetId>& deb(pG.getValidDetIds(DetId::Ecal, EcalBarrel));
+  const std::vector<DetId>& dee(pG.getValidDetIds(DetId::Ecal, EcalEndcap));
+  const std::vector<DetId>& des(pG.getValidDetIds(DetId::Ecal, EcalPreshower));
+  const std::vector<DetId>& dhb(pG.getValidDetIds(DetId::Hcal, HcalBarrel));
+  const std::vector<DetId>& dhe(pG.getValidDetIds(DetId::Hcal, HcalEndcap));
+  const std::vector<DetId>& dho(pG.getValidDetIds(DetId::Hcal, HcalOuter));
+  const std::vector<DetId>& dhf(pG.getValidDetIds(DetId::Hcal, HcalForward));
+  const std::vector<DetId>& dct(pG.getValidDetIds(DetId::Calo, CaloTowerDetId::SubdetId));
+  const std::vector<DetId>& dca(pG.getValidDetIds(DetId::Calo, HcalCastorDetId::SubdetectorId));
+  const std::vector<DetId>& dzd(pG.getValidDetIds(DetId::Calo, HcalZDCDetId::SubdetectorId));
+
+  const std::vector<DetId>& dha(pG.getSubdetectorGeometry(DetId::Hcal, 1)->getValidDetIds());
+
+  const unsigned int sum(deb.size() + dee.size() + des.size() + dhb.size() + dhe.size() + dho.size() + dhf.size() +
+                         dct.size() + dca.size() + dzd.size());
+
+  if (sum != allDetId.size()) {
+    std::cout << "Sums differ! One is " << allDetId.size() << " and the other is " << sum << std::endl;
+  }
+
+  assert(sum == allDetId.size());
+
+  assert(dha.size() == dhb.size() + dhe.size() + dho.size() + dhf.size());
+  //
+  // get the ecal & hcal geometry
+  //
+  if (pass_ == 0) {
+    std::cout << "**Ecal Barrel avg Radius = "
+              << dynamic_cast<const EcalBarrelGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalBarrel))
+                     ->avgRadiusXYFrontFaceCenter()
+              << std::endl;
+
+    std::cout << "**Ecal Endcap avg Zabs = "
+              << dynamic_cast<const EcalEndcapGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalEndcap))
+                     ->avgAbsZFrontFaceCenter()
+              << std::endl;
+
+    m_allOK = true;
+
+    build(cG, pT, DetId::Ecal, EcalBarrel, "eb", 0);
+    build(cG, pT, DetId::Ecal, EcalEndcap, "ee", 1);
+    build(cG, pT, DetId::Ecal, EcalPreshower, "es", 2);
+    buildHcal(cG, pT, DetId::Hcal, HcalBarrel, "hb", 3);
+    buildHcal(cG, pT, DetId::Hcal, HcalEndcap, "he", 4);
+    buildHcal(cG, pT, DetId::Hcal, HcalOuter, "ho", 5);
+    buildHcal(cG, pT, DetId::Hcal, HcalForward, "hf", 6);
+    build(cG, pT, DetId::Calo, CaloTowerDetId::SubdetId, "ct", 7);
+    build(cG, pT, DetId::Calo, HcalCastorDetId::SubdetectorId, "ca", 8);
+    build(cG, pT, DetId::Calo, HcalZDCDetId::SubdetectorId, "zd", 9);
+
+    std::cout << "\n\n*********** Validation of cell centers and corners " << (m_allOK ? "SUCCEEDS!! " : "FAILS!! ")
+              << "**********************\n\n\n"
+              << std::endl;
+  }
+
+  pass_++;
 }
 
 DEFINE_FWK_MODULE(CaloGeometryAnalyzer);

--- a/Geometry/CaloEventSetup/test/DumpEcalTrigTowerMapping.cc
+++ b/Geometry/CaloEventSetup/test/DumpEcalTrigTowerMapping.cc
@@ -25,15 +25,19 @@
 
 class DumpEcalTrigTowerMapping : public edm::one::EDAnalyzer<> {
 public:
-  explicit DumpEcalTrigTowerMapping( const edm::ParameterSet& );
+  explicit DumpEcalTrigTowerMapping(const edm::ParameterSet&);
   ~DumpEcalTrigTowerMapping() override;
-    
+
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  void build(const CaloGeometry& cg, const EcalTrigTowerConstituentsMap& etmap, DetId::Detector det, int subdetn, const char* name);
+  void build(const CaloGeometry& cg,
+             const EcalTrigTowerConstituentsMap& etmap,
+             DetId::Detector det,
+             int subdetn,
+             const char* name);
   int towerColor(const EcalTrigTowerDetId& theTower);
 
   edm::ESGetToken<EcalTrigTowerConstituentsMap, IdealGeometryRecord> eTTmapToken_;
@@ -42,175 +46,161 @@ private:
   int pass_;
 };
 
-DumpEcalTrigTowerMapping::DumpEcalTrigTowerMapping( const edm::ParameterSet& /*iConfig*/ ):
-  eTTmapToken_{esConsumes<EcalTrigTowerConstituentsMap, IdealGeometryRecord>(edm::ESInputTag{})},
-  geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})}
-{
+DumpEcalTrigTowerMapping::DumpEcalTrigTowerMapping(const edm::ParameterSet& /*iConfig*/)
+    : eTTmapToken_{esConsumes<EcalTrigTowerConstituentsMap, IdealGeometryRecord>(edm::ESInputTag{})},
+      geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})} {
   //now do what ever initialization is needed
-  pass_=0;
+  pass_ = 0;
   // some setup for root
-  gROOT->SetStyle("Plain");          // white fill colors etc.
+  gROOT->SetStyle("Plain");  // white fill colors etc.
   gStyle->SetPaperSize(TStyle::kA4);
 }
 
-DumpEcalTrigTowerMapping::~DumpEcalTrigTowerMapping()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+DumpEcalTrigTowerMapping::~DumpEcalTrigTowerMapping() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
 
-int DumpEcalTrigTowerMapping::towerColor(const EcalTrigTowerDetId& theTower)
-{
-  int iEtaColorIndex=(theTower.ietaAbs()-1)%2;
+int DumpEcalTrigTowerMapping::towerColor(const EcalTrigTowerDetId& theTower) {
+  int iEtaColorIndex = (theTower.ietaAbs() - 1) % 2;
   int iPhiColorIndex = 0;
-  if (theTower.ietaAbs() < 26 )
-    iPhiColorIndex=(theTower.iphi()-1)%2;
+  if (theTower.ietaAbs() < 26)
+    iPhiColorIndex = (theTower.iphi() - 1) % 2;
   else
-    iPhiColorIndex=((theTower.iphi()-1)%4)/2;
+    iPhiColorIndex = ((theTower.iphi() - 1) % 4) / 2;
 
-  return iEtaColorIndex*2+iPhiColorIndex+1;
+  return iEtaColorIndex * 2 + iPhiColorIndex + 1;
 }
 
-void DumpEcalTrigTowerMapping::build(const CaloGeometry& cg, const EcalTrigTowerConstituentsMap& etmap, DetId::Detector det, int subdetn, const char* name) 
-{
-  if (det == DetId::Ecal && subdetn == EcalEndcap) 
-    {
-      TCanvas *canv = new TCanvas("c","",1000,1000);
-      canv->SetLeftMargin(0.15);
-      canv->SetBottomMargin(0.15);
-      
-      gStyle->SetOptStat(0);
-      TH2F *h = new TH2F("","",
-			 10,0.5, 100.5,
-			 10,0.5, 100.5);
-      
-      h->Draw();
-      //gPad->SetGridx();
-      //gPad->SetGridy();
-      gPad->Update();
-      
-      h->SetXTitle("x index");
-      h->SetYTitle("y index");
-      
-      h->GetXaxis()->SetTickLength(-0.03);
-      h->GetYaxis()->SetTickLength(-0.03);
-      
-      h->GetXaxis()->SetLabelOffset(0.03);
-      h->GetYaxis()->SetLabelOffset(0.03);
-      
-      h->GetXaxis()->SetLabelSize(0.04);
-      h->GetYaxis()->SetLabelSize(0.04);
-      
-      // axis titles
-      h->GetXaxis()->SetTitleSize(0.04);
-      h->GetYaxis()->SetTitleSize(0.04);
-      
-      h->GetXaxis()->SetTitleOffset(1.8);
-      h->GetYaxis()->SetTitleOffset(1.9);
-      
-      h->GetXaxis()->CenterTitle(true);
-      h->GetYaxis()->CenterTitle(true);  
-      const std::vector<DetId>& eeDetIds= cg.getValidDetIds(det,subdetn);
+void DumpEcalTrigTowerMapping::build(const CaloGeometry& cg,
+                                     const EcalTrigTowerConstituentsMap& etmap,
+                                     DetId::Detector det,
+                                     int subdetn,
+                                     const char* name) {
+  if (det == DetId::Ecal && subdetn == EcalEndcap) {
+    TCanvas* canv = new TCanvas("c", "", 1000, 1000);
+    canv->SetLeftMargin(0.15);
+    canv->SetBottomMargin(0.15);
 
-      std::cout<<"*** testing endcap trig tower mapping **"<<std::endl;
-      for (const auto & eeDetId : eeDetIds)
-	{
-	  EEDetId myId(eeDetId);
-	  EcalTrigTowerDetId myTower=etmap.towerOf(eeDetId);      
+    gStyle->SetOptStat(0);
+    TH2F* h = new TH2F("", "", 10, 0.5, 100.5, 10, 0.5, 100.5);
 
-//	  std::cout<<"eedetid="<<EEDetId(eeDetIds[i])<<", myTower="<<myTower<<std::endl;
+    h->Draw();
+    //gPad->SetGridx();
+    //gPad->SetGridy();
+    gPad->Update();
 
-	  assert( myTower == EcalTrigTowerDetId::detIdFromDenseIndex( myTower.denseIndex() ) ) ;
+    h->SetXTitle("x index");
+    h->SetYTitle("y index");
 
-	  if (myId.zside()==1)
-	    continue;
+    h->GetXaxis()->SetTickLength(-0.03);
+    h->GetYaxis()->SetTickLength(-0.03);
 
-	  TBox *box = new TBox(myId.ix()-0.5,myId.iy()-0.5,myId.ix()+0.5,myId.iy()+0.5);
-	  box->SetFillColor(towerColor(myTower));
-	  box->Draw();
-	}
-      gPad->SaveAs(name);
-      delete canv;
-      delete h;
+    h->GetXaxis()->SetLabelOffset(0.03);
+    h->GetYaxis()->SetLabelOffset(0.03);
+
+    h->GetXaxis()->SetLabelSize(0.04);
+    h->GetYaxis()->SetLabelSize(0.04);
+
+    // axis titles
+    h->GetXaxis()->SetTitleSize(0.04);
+    h->GetYaxis()->SetTitleSize(0.04);
+
+    h->GetXaxis()->SetTitleOffset(1.8);
+    h->GetYaxis()->SetTitleOffset(1.9);
+
+    h->GetXaxis()->CenterTitle(true);
+    h->GetYaxis()->CenterTitle(true);
+    const std::vector<DetId>& eeDetIds = cg.getValidDetIds(det, subdetn);
+
+    std::cout << "*** testing endcap trig tower mapping **" << std::endl;
+    for (const auto& eeDetId : eeDetIds) {
+      EEDetId myId(eeDetId);
+      EcalTrigTowerDetId myTower = etmap.towerOf(eeDetId);
+
+      //	  std::cout<<"eedetid="<<EEDetId(eeDetIds[i])<<", myTower="<<myTower<<std::endl;
+
+      assert(myTower == EcalTrigTowerDetId::detIdFromDenseIndex(myTower.denseIndex()));
+
+      if (myId.zside() == 1)
+        continue;
+
+      TBox* box = new TBox(myId.ix() - 0.5, myId.iy() - 0.5, myId.ix() + 0.5, myId.iy() + 0.5);
+      box->SetFillColor(towerColor(myTower));
+      box->Draw();
     }
+    gPad->SaveAs(name);
+    delete canv;
+    delete h;
+  }
 
-  if (det == DetId::Ecal && subdetn == EcalBarrel) 
-    {
-      TCanvas *canv = new TCanvas("c","",1000,1000);
-      canv->SetLeftMargin(0.15);
-      canv->SetBottomMargin(0.15);
-      
-      gStyle->SetOptStat(0);
-      TH2F *h = new TH2F("","",
-			 10,-85.5, 85.5,
-			 10,0.5, 360.5);
-      
-      h->Draw();
-      //gPad->SetGridx();
-      //gPad->SetGridy();
-      gPad->Update();
-      
-      h->SetXTitle("eta index");
-      h->SetYTitle("phi index");
-      
-      h->GetXaxis()->SetTickLength(-0.03);
-      h->GetYaxis()->SetTickLength(-0.03);
-      
-      h->GetXaxis()->SetLabelOffset(0.03);
-      h->GetYaxis()->SetLabelOffset(0.03);
-      
-      h->GetXaxis()->SetLabelSize(0.04);
-      h->GetYaxis()->SetLabelSize(0.04);
-      
-      // axis titles
-      h->GetXaxis()->SetTitleSize(0.04);
-      h->GetYaxis()->SetTitleSize(0.04);
-      
-      h->GetXaxis()->SetTitleOffset(1.8);
-      h->GetYaxis()->SetTitleOffset(1.9);
-      
-      h->GetXaxis()->CenterTitle(true);
-      h->GetYaxis()->CenterTitle(true);  
-      const std::vector<DetId>& ebDetIds= cg.getValidDetIds(det,subdetn);
+  if (det == DetId::Ecal && subdetn == EcalBarrel) {
+    TCanvas* canv = new TCanvas("c", "", 1000, 1000);
+    canv->SetLeftMargin(0.15);
+    canv->SetBottomMargin(0.15);
 
-      std::cout<<"*** testing barrel trig tower mapping **"<<std::endl;
-      for (const auto & ebDetId : ebDetIds)
-	{
-	  EBDetId myId(ebDetId);
-	  EcalTrigTowerDetId myTower=etmap.towerOf(ebDetId);      
+    gStyle->SetOptStat(0);
+    TH2F* h = new TH2F("", "", 10, -85.5, 85.5, 10, 0.5, 360.5);
 
-	  assert( myTower == EcalTrigTowerDetId::detIdFromDenseIndex( myTower.denseIndex() ) ) ;
+    h->Draw();
+    //gPad->SetGridx();
+    //gPad->SetGridy();
+    gPad->Update();
 
-	  TBox *box = new TBox(myId.ieta()-0.5,myId.iphi()-0.5,myId.ieta()+0.5,myId.iphi()+0.5);
-	  box->SetFillColor(towerColor(myTower));
-	  box->Draw();
-	}
-      gPad->SaveAs(name);
-      delete canv;
-      delete h;
+    h->SetXTitle("eta index");
+    h->SetYTitle("phi index");
+
+    h->GetXaxis()->SetTickLength(-0.03);
+    h->GetYaxis()->SetTickLength(-0.03);
+
+    h->GetXaxis()->SetLabelOffset(0.03);
+    h->GetYaxis()->SetLabelOffset(0.03);
+
+    h->GetXaxis()->SetLabelSize(0.04);
+    h->GetYaxis()->SetLabelSize(0.04);
+
+    // axis titles
+    h->GetXaxis()->SetTitleSize(0.04);
+    h->GetYaxis()->SetTitleSize(0.04);
+
+    h->GetXaxis()->SetTitleOffset(1.8);
+    h->GetYaxis()->SetTitleOffset(1.9);
+
+    h->GetXaxis()->CenterTitle(true);
+    h->GetYaxis()->CenterTitle(true);
+    const std::vector<DetId>& ebDetIds = cg.getValidDetIds(det, subdetn);
+
+    std::cout << "*** testing barrel trig tower mapping **" << std::endl;
+    for (const auto& ebDetId : ebDetIds) {
+      EBDetId myId(ebDetId);
+      EcalTrigTowerDetId myTower = etmap.towerOf(ebDetId);
+
+      assert(myTower == EcalTrigTowerDetId::detIdFromDenseIndex(myTower.denseIndex()));
+
+      TBox* box = new TBox(myId.ieta() - 0.5, myId.iphi() - 0.5, myId.ieta() + 0.5, myId.iphi() + 0.5);
+      box->SetFillColor(towerColor(myTower));
+      box->Draw();
     }
+    gPad->SaveAs(name);
+    delete canv;
+    delete h;
+  }
 }
 
-void
-DumpEcalTrigTowerMapping::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup )
-{
-   
-   std::cout << "Here I am " << std::endl;
+void DumpEcalTrigTowerMapping::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
+  std::cout << "Here I am " << std::endl;
 
-   const auto& eTTmap = iSetup.getData(eTTmapToken_);
-   const auto& pG = iSetup.getData(geometryToken_);
+  const auto& eTTmap = iSetup.getData(eTTmapToken_);
+  const auto& pG = iSetup.getData(geometryToken_);
 
-   if (pass_==1) {
-     build(pG,eTTmap,DetId::Ecal,EcalBarrel,"EBTTmapping.eps");
-   }
-   if (pass_==2) {
-     build(pG,eTTmap,DetId::Ecal,EcalEndcap,"EETTmapping.eps");
-   }
-   
-   pass_++;
-      
+  if (pass_ == 1) {
+    build(pG, eTTmap, DetId::Ecal, EcalBarrel, "EBTTmapping.eps");
+  }
+  if (pass_ == 2) {
+    build(pG, eTTmap, DetId::Ecal, EcalEndcap, "EETTmapping.eps");
+  }
+
+  pass_++;
 }
 
 //define this as a plug-in

--- a/Geometry/CaloEventSetup/test/TestEcalGetWindow.cc
+++ b/Geometry/CaloEventSetup/test/TestEcalGetWindow.cc
@@ -26,15 +26,14 @@
 
 class TestEcalGetWindow : public edm::one::EDAnalyzer<> {
 public:
-  explicit TestEcalGetWindow( const edm::ParameterSet& );
+  explicit TestEcalGetWindow(const edm::ParameterSet&);
   ~TestEcalGetWindow() override;
-  
+
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-
   void build(const CaloGeometry& cg, const CaloTopology& etmap, DetId::Detector det, int subdetn, const char* name);
   int towerColor(const EcalTrigTowerDetId& theTower);
 
@@ -44,167 +43,149 @@ private:
   int pass_;
 };
 
-TestEcalGetWindow::TestEcalGetWindow( const edm::ParameterSet& /*iConfig*/ ):
-  topologyToken_{esConsumes<CaloTopology, CaloTopologyRecord>(edm::ESInputTag{})},
-  geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})}
-{
-   //now do what ever initialization is needed
-  pass_=0;
+TestEcalGetWindow::TestEcalGetWindow(const edm::ParameterSet& /*iConfig*/)
+    : topologyToken_{esConsumes<CaloTopology, CaloTopologyRecord>(edm::ESInputTag{})},
+      geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})} {
+  //now do what ever initialization is needed
+  pass_ = 0;
   // some setup for root
-  gROOT->SetStyle("Plain");          // white fill colors etc.
+  gROOT->SetStyle("Plain");  // white fill colors etc.
   gStyle->SetPaperSize(TStyle::kA4);
 }
 
-TestEcalGetWindow::~TestEcalGetWindow()
-{}
+TestEcalGetWindow::~TestEcalGetWindow() {}
 
-void TestEcalGetWindow::build(const CaloGeometry& /*cg*/, const CaloTopology& ct, DetId::Detector det, int subdetn, const char* name) 
-{
-  if (det == DetId::Ecal && subdetn == EcalEndcap) 
-    {
-      TCanvas *canv = new TCanvas("c","",1000,1000);
-      canv->SetLeftMargin(0.15);
-      canv->SetBottomMargin(0.15);
-      
-      gStyle->SetOptStat(0);
-      TH2F *h = new TH2F("","",
-			 10,0.5, 100.5,
-			 10,0.5, 100.5);
-      
-      h->Draw();
-      //gPad->SetGridx();
-      //gPad->SetGridy();
-      gPad->Update();
-      
-      h->SetXTitle("x index");
-      h->SetYTitle("y index");
-      
-      h->GetXaxis()->SetTickLength(-0.03);
-      h->GetYaxis()->SetTickLength(-0.03);
-      
-      h->GetXaxis()->SetLabelOffset(0.03);
-      h->GetYaxis()->SetLabelOffset(0.03);
-      
-      h->GetXaxis()->SetLabelSize(0.04);
-      h->GetYaxis()->SetLabelSize(0.04);
-      
-      // axis titles
-      h->GetXaxis()->SetTitleSize(0.04);
-      h->GetYaxis()->SetTitleSize(0.04);
-      
-      h->GetXaxis()->SetTitleOffset(1.8);
-      h->GetYaxis()->SetTitleOffset(1.9);
-      
-      h->GetXaxis()->CenterTitle(true);
-      h->GetYaxis()->CenterTitle(true);  
-      const CaloSubdetectorTopology* topology=ct.getSubdetectorTopology(det,subdetn);
+void TestEcalGetWindow::build(
+    const CaloGeometry& /*cg*/, const CaloTopology& ct, DetId::Detector det, int subdetn, const char* name) {
+  if (det == DetId::Ecal && subdetn == EcalEndcap) {
+    TCanvas* canv = new TCanvas("c", "", 1000, 1000);
+    canv->SetLeftMargin(0.15);
+    canv->SetBottomMargin(0.15);
 
-      std::vector<DetId> eeDetIds;
-      eeDetIds.emplace_back(EEDetId(1,50,1,EEDetId::XYMODE));
-      eeDetIds.emplace_back(EEDetId(25,50,1,EEDetId::XYMODE));
-      eeDetIds.emplace_back(EEDetId(50,1,1,EEDetId::XYMODE));
-      eeDetIds.emplace_back(EEDetId(50,25,1,EEDetId::XYMODE));
-      eeDetIds.emplace_back(EEDetId(3,60,1,EEDetId::XYMODE));
-      for (const auto & eeDetId : eeDetIds)
-	{
+    gStyle->SetOptStat(0);
+    TH2F* h = new TH2F("", "", 10, 0.5, 100.5, 10, 0.5, 100.5);
 
-	  EEDetId myId(eeDetId);
-	  if (myId.zside()==-1)
-	    continue;
-	  std::vector<DetId> myNeighbours=topology->getWindow(myId,13,13);
-	  for (const auto & myNeighbour : myNeighbours)
-	    {
-	      EEDetId myEEId(myNeighbour);
-	      TBox *box = new TBox(myEEId.ix()-0.5,myEEId.iy()-0.5,myEEId.ix()+0.5,myEEId.iy()+0.5);
-	      box->SetFillColor(1);
-	      box->Draw();
-	    }
+    h->Draw();
+    //gPad->SetGridx();
+    //gPad->SetGridy();
+    gPad->Update();
 
-	}
-      gPad->SaveAs(name);
-      delete canv;
-      delete h;
+    h->SetXTitle("x index");
+    h->SetYTitle("y index");
+
+    h->GetXaxis()->SetTickLength(-0.03);
+    h->GetYaxis()->SetTickLength(-0.03);
+
+    h->GetXaxis()->SetLabelOffset(0.03);
+    h->GetYaxis()->SetLabelOffset(0.03);
+
+    h->GetXaxis()->SetLabelSize(0.04);
+    h->GetYaxis()->SetLabelSize(0.04);
+
+    // axis titles
+    h->GetXaxis()->SetTitleSize(0.04);
+    h->GetYaxis()->SetTitleSize(0.04);
+
+    h->GetXaxis()->SetTitleOffset(1.8);
+    h->GetYaxis()->SetTitleOffset(1.9);
+
+    h->GetXaxis()->CenterTitle(true);
+    h->GetYaxis()->CenterTitle(true);
+    const CaloSubdetectorTopology* topology = ct.getSubdetectorTopology(det, subdetn);
+
+    std::vector<DetId> eeDetIds;
+    eeDetIds.emplace_back(EEDetId(1, 50, 1, EEDetId::XYMODE));
+    eeDetIds.emplace_back(EEDetId(25, 50, 1, EEDetId::XYMODE));
+    eeDetIds.emplace_back(EEDetId(50, 1, 1, EEDetId::XYMODE));
+    eeDetIds.emplace_back(EEDetId(50, 25, 1, EEDetId::XYMODE));
+    eeDetIds.emplace_back(EEDetId(3, 60, 1, EEDetId::XYMODE));
+    for (const auto& eeDetId : eeDetIds) {
+      EEDetId myId(eeDetId);
+      if (myId.zside() == -1)
+        continue;
+      std::vector<DetId> myNeighbours = topology->getWindow(myId, 13, 13);
+      for (const auto& myNeighbour : myNeighbours) {
+        EEDetId myEEId(myNeighbour);
+        TBox* box = new TBox(myEEId.ix() - 0.5, myEEId.iy() - 0.5, myEEId.ix() + 0.5, myEEId.iy() + 0.5);
+        box->SetFillColor(1);
+        box->Draw();
+      }
     }
+    gPad->SaveAs(name);
+    delete canv;
+    delete h;
+  }
 
-  if (det == DetId::Ecal && subdetn == EcalBarrel) 
-    {
-      TCanvas *canv = new TCanvas("c","",1000,1000);
-      canv->SetLeftMargin(0.15);
-      canv->SetBottomMargin(0.15);
-      
-      gStyle->SetOptStat(0);
-      TH2F *h = new TH2F("","",
-			 10,-85.5, 85.5,
-			 10,0.5, 360.5);
-      
-      h->Draw();
-      //gPad->SetGridx();
-      //gPad->SetGridy();
-      gPad->Update();
-      
-      h->SetXTitle("eta index");
-      h->SetYTitle("phi index");
-      
-      h->GetXaxis()->SetTickLength(-0.03);
-      h->GetYaxis()->SetTickLength(-0.03);
-      
-      h->GetXaxis()->SetLabelOffset(0.03);
-      h->GetYaxis()->SetLabelOffset(0.03);
-      
-      h->GetXaxis()->SetLabelSize(0.04);
-      h->GetYaxis()->SetLabelSize(0.04);
-      
-      // axis titles
-      h->GetXaxis()->SetTitleSize(0.04);
-      h->GetYaxis()->SetTitleSize(0.04);
-      
-      h->GetXaxis()->SetTitleOffset(1.8);
-      h->GetYaxis()->SetTitleOffset(1.9);
-      
-      h->GetXaxis()->CenterTitle(true);
-      h->GetYaxis()->CenterTitle(true);  
-      const CaloSubdetectorTopology* topology=ct.getSubdetectorTopology(det,subdetn);
-      std::vector<DetId> ebDetIds;
-      ebDetIds.emplace_back(EBDetId(1,1));
-      ebDetIds.emplace_back(EBDetId(30,30));
-      ebDetIds.emplace_back(EBDetId(-1,120));
-      ebDetIds.emplace_back(EBDetId(85,1));
-      for (const auto & ebDetId : ebDetIds)
-	{
-	  EBDetId myId(ebDetId);
-	  std::vector<DetId> myNeighbours=topology->getWindow(myId,13,13);
-	  for (const auto & myNeighbour : myNeighbours)
-	    {
-	      EBDetId myEBId(myNeighbour);
-	      TBox *box = new TBox(myEBId.ieta()-0.5,myEBId.iphi()-0.5,myEBId.ieta()+0.5,myEBId.iphi()+0.5);
-	      box->SetFillColor(1);
-	      box->Draw();
-	    }
-	}
-      gPad->SaveAs(name);
-      delete canv;
-      delete h;
+  if (det == DetId::Ecal && subdetn == EcalBarrel) {
+    TCanvas* canv = new TCanvas("c", "", 1000, 1000);
+    canv->SetLeftMargin(0.15);
+    canv->SetBottomMargin(0.15);
+
+    gStyle->SetOptStat(0);
+    TH2F* h = new TH2F("", "", 10, -85.5, 85.5, 10, 0.5, 360.5);
+
+    h->Draw();
+    //gPad->SetGridx();
+    //gPad->SetGridy();
+    gPad->Update();
+
+    h->SetXTitle("eta index");
+    h->SetYTitle("phi index");
+
+    h->GetXaxis()->SetTickLength(-0.03);
+    h->GetYaxis()->SetTickLength(-0.03);
+
+    h->GetXaxis()->SetLabelOffset(0.03);
+    h->GetYaxis()->SetLabelOffset(0.03);
+
+    h->GetXaxis()->SetLabelSize(0.04);
+    h->GetYaxis()->SetLabelSize(0.04);
+
+    // axis titles
+    h->GetXaxis()->SetTitleSize(0.04);
+    h->GetYaxis()->SetTitleSize(0.04);
+
+    h->GetXaxis()->SetTitleOffset(1.8);
+    h->GetYaxis()->SetTitleOffset(1.9);
+
+    h->GetXaxis()->CenterTitle(true);
+    h->GetYaxis()->CenterTitle(true);
+    const CaloSubdetectorTopology* topology = ct.getSubdetectorTopology(det, subdetn);
+    std::vector<DetId> ebDetIds;
+    ebDetIds.emplace_back(EBDetId(1, 1));
+    ebDetIds.emplace_back(EBDetId(30, 30));
+    ebDetIds.emplace_back(EBDetId(-1, 120));
+    ebDetIds.emplace_back(EBDetId(85, 1));
+    for (const auto& ebDetId : ebDetIds) {
+      EBDetId myId(ebDetId);
+      std::vector<DetId> myNeighbours = topology->getWindow(myId, 13, 13);
+      for (const auto& myNeighbour : myNeighbours) {
+        EBDetId myEBId(myNeighbour);
+        TBox* box = new TBox(myEBId.ieta() - 0.5, myEBId.iphi() - 0.5, myEBId.ieta() + 0.5, myEBId.iphi() + 0.5);
+        box->SetFillColor(1);
+        box->Draw();
+      }
     }
+    gPad->SaveAs(name);
+    delete canv;
+    delete h;
+  }
 }
 // ------------ method called to produce the data  ------------
-void
-TestEcalGetWindow::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup )
-{
-   
-   std::cout << "Here I am " << std::endl;
+void TestEcalGetWindow::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
+  std::cout << "Here I am " << std::endl;
 
-   const auto& theCaloTopology = iSetup.getData(topologyToken_);
-   const auto& pG = iSetup.getData(geometryToken_);
+  const auto& theCaloTopology = iSetup.getData(topologyToken_);
+  const auto& pG = iSetup.getData(geometryToken_);
 
-   if (pass_==1) {
-     build(pG,theCaloTopology,DetId::Ecal,EcalBarrel,"EBGetWindowTest.eps");
-   }
-   if (pass_==2) {
-     build(pG,theCaloTopology,DetId::Ecal,EcalEndcap,"EEGetWindowTest.eps");
-   }
-   
-   pass_++;
-      
+  if (pass_ == 1) {
+    build(pG, theCaloTopology, DetId::Ecal, EcalBarrel, "EBGetWindowTest.eps");
+  }
+  if (pass_ == 2) {
+    build(pG, theCaloTopology, DetId::Ecal, EcalEndcap, "EEGetWindowTest.eps");
+  }
+
+  pass_++;
 }
 
 //define this as a plug-in

--- a/Geometry/CaloEventSetup/test/TestWriteESAlignments.cc
+++ b/Geometry/CaloEventSetup/test/TestWriteESAlignments.cc
@@ -9,16 +9,14 @@
 #include "Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h"
 #include "Geometry/EcalAlgo/interface/WriteESAlignments.h"
 
-typedef WriteESAlignments WEA ;
+typedef WriteESAlignments WEA;
 
-class TestWriteESAlignments : public edm::one::EDAnalyzer<>
-{
+class TestWriteESAlignments : public edm::one::EDAnalyzer<> {
 public:
-
   explicit TestWriteESAlignments(const edm::ParameterSet& /*iConfig*/)
-    : writer_{consumesCollector()}, nEventCalls_{0} {}
+      : writer_{consumesCollector()}, nEventCalls_{0} {}
   ~TestWriteESAlignments() override {}
-  
+
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
@@ -27,38 +25,30 @@ private:
   WriteESAlignments writer_;
   unsigned int nEventCalls_;
 };
-  
-void TestWriteESAlignments::analyze(const edm::Event& /*evt*/, const edm::EventSetup& evtSetup)
-{
-   if (nEventCalls_ > 0) {
-     edm::LogInfo("TestWriteESAlignments") << "Writing to DB to be done only once, "
-	       << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
-	       << "(Your writing should be fine.)";
-     return;
-   }
 
+void TestWriteESAlignments::analyze(const edm::Event& /*evt*/, const edm::EventSetup& evtSetup) {
+  if (nEventCalls_ > 0) {
+    edm::LogInfo("TestWriteESAlignments") << "Writing to DB to be done only once, "
+                                          << "set 'untracked PSet maxEvents = {untracked int32 input = 1}'."
+                                          << "(Your writing should be fine.)";
+    return;
+  }
 
-   static const unsigned int nA ( EcalPreshowerGeometry::numberOfAlignments() ) ;
+  static const unsigned int nA(EcalPreshowerGeometry::numberOfAlignments());
 
-   typedef std::vector<double> DVec ;
+  typedef std::vector<double> DVec;
 
-   DVec alphaVec   ( nA, 0 ) ;
-   DVec betaVec    ( nA, 0 ) ;
-   DVec gammaVec   ( nA, 0 ) ;
-   DVec xtranslVec ( nA, 0 ) ;
-   DVec ytranslVec ( nA, 0 ) ;
-   DVec ztranslVec ( nA, 0 ) ;
+  DVec alphaVec(nA, 0);
+  DVec betaVec(nA, 0);
+  DVec gammaVec(nA, 0);
+  DVec xtranslVec(nA, 0);
+  DVec ytranslVec(nA, 0);
+  DVec ztranslVec(nA, 0);
 
-   writer_.writeAlignments( evtSetup   ,
-                            alphaVec   ,
-                            betaVec    ,
-                            gammaVec   ,
-                            xtranslVec ,
-                            ytranslVec ,
-                            ztranslVec  ) ;
+  writer_.writeAlignments(evtSetup, alphaVec, betaVec, gammaVec, xtranslVec, ytranslVec, ztranslVec);
 
-   edm::LogInfo("TestWriteESAlignments") << "Done!";
-   nEventCalls_++;
+  edm::LogInfo("TestWriteESAlignments") << "Done!";
+  nEventCalls_++;
 }
 
 DEFINE_FWK_MODULE(TestWriteESAlignments);

--- a/Geometry/HcalEventSetup/interface/CaloTowerTopologyEP.h
+++ b/Geometry/HcalEventSetup/interface/CaloTowerTopologyEP.h
@@ -1,7 +1,6 @@
 #ifndef GEOMETRY_HCALEVENTSETUP_CaloTowerTopologyEP_H
 #define GEOMETRY_HCALEVENTSETUP_CaloTowerTopologyEP_H 1
 
-
 // system include files
 #include <memory>
 
@@ -23,15 +22,14 @@ namespace edm {
 //
 
 class CaloTowerTopologyEP : public edm::ESProducer {
-
 public:
   CaloTowerTopologyEP(const edm::ParameterSet&);
   ~CaloTowerTopologyEP() override;
 
   using ReturnType = std::unique_ptr<CaloTowerTopology>;
 
-  static void fillDescriptions( edm::ConfigurationDescriptions & descriptions );
-    
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   ReturnType produce(const HcalRecNumberingRecord&);
 
 private:

--- a/Geometry/HcalEventSetup/interface/HcalAlignmentEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalAlignmentEP.h
@@ -17,20 +17,18 @@
 #include "CondFormats/AlignmentRecord/interface/HcalAlignmentErrorExtendedRcd.h"
 
 class HcalAlignmentEP : public edm::ESProducer {
-
 public:
-
   using ReturnAli = std::unique_ptr<Alignments>;
 
-  typedef AlignTransform::Translation Trl ;
-  typedef AlignTransform::Rotation    Rot ;
+  typedef AlignTransform::Translation Trl;
+  typedef AlignTransform::Rotation Rot;
 
   HcalAlignmentEP(const edm::ParameterSet&);
   ~HcalAlignmentEP() override;
 
-//-------------------------------------------------------------------
- 
-  ReturnAli    produceHcalAli( const HcalAlignmentRcd& iRecord );
+  //-------------------------------------------------------------------
+
+  ReturnAli produceHcalAli(const HcalAlignmentRcd& iRecord);
 
 private:
   edm::ESGetToken<Alignments, HBAlignmentRcd> hbToken_;

--- a/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalDDDGeometryEP.h
@@ -12,9 +12,7 @@
 #include "Geometry/HcalTowerAlgo/interface/HcalDDDGeometryLoader.h"
 
 class HcalDDDGeometryEP : public edm::ESProducer {
-
 public:
-
   HcalDDDGeometryEP(const edm::ParameterSet&);
 
   using ReturnType = std::unique_ptr<CaloSubdetectorGeometry>;

--- a/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalHardcodeGeometryEP.h
@@ -14,17 +14,16 @@ class HcalDDDRecConstants;
 class HcalTopology;
 
 class HcalHardcodeGeometryEP : public edm::ESProducer {
-
 public:
   HcalHardcodeGeometryEP(const edm::ParameterSet&);
 
   using ReturnType = std::unique_ptr<CaloSubdetectorGeometry>;
 
-  ReturnType produceAligned(const HcalGeometryRecord& );
+  ReturnType produceAligned(const HcalGeometryRecord&);
 
 private:
   edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> consToken_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
-  bool              useOld_;
+  bool useOld_;
 };
 #endif

--- a/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
+++ b/Geometry/HcalEventSetup/interface/HcalTopologyIdealEP.h
@@ -15,13 +15,12 @@ namespace edm {
 }
 
 class HcalTopologyIdealEP : public edm::ESProducer {
-
 public:
   HcalTopologyIdealEP(const edm::ParameterSet&);
 
   using ReturnType = std::unique_ptr<HcalTopology>;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   ReturnType produce(const HcalRecNumberingRecord&);
 
@@ -29,6 +28,6 @@ private:
   // ----------member data ---------------------------
   edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> m_hdcToken;
   std::string m_restrictions;
-  bool        m_mergePosition;
+  bool m_mergePosition;
 };
 #endif

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.cc
@@ -22,24 +22,20 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
 
-CaloTowerHardcodeGeometryEP::CaloTowerHardcodeGeometryEP(const edm::ParameterSet& iConfig)
-{
-   //the following line is needed to tell the framework what
-   // data is being produced
-  auto cc = setWhatProduced(this,
-                            &CaloTowerHardcodeGeometryEP::produce,
-                            edm::es::Label("TOWER"));
+CaloTowerHardcodeGeometryEP::CaloTowerHardcodeGeometryEP(const edm::ParameterSet& iConfig) {
+  //the following line is needed to tell the framework what
+  // data is being produced
+  auto cc = setWhatProduced(this, &CaloTowerHardcodeGeometryEP::produce, edm::es::Label("TOWER"));
   cttopoToken_ = cc.consumesFrom<CaloTowerTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
   hcaltopoToken_ = cc.consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
   consToken_ = cc.consumesFrom<HcalDDDRecConstants, HcalRecNumberingRecord>(edm::ESInputTag{});
 }
 
 // ------------ method called to produce the data  ------------
-CaloTowerHardcodeGeometryEP::ReturnType
-CaloTowerHardcodeGeometryEP::produce(const CaloTowerGeometryRecord& iRecord) {
+CaloTowerHardcodeGeometryEP::ReturnType CaloTowerHardcodeGeometryEP::produce(const CaloTowerGeometryRecord& iRecord) {
   const auto& cttopo = iRecord.get(cttopoToken_);
   const auto& hcaltopo = iRecord.get(hcaltopoToken_);
   const auto& cons = iRecord.get(consToken_);
 
-  return std::unique_ptr<CaloSubdetectorGeometry>( loader_.load( &cttopo, &hcaltopo, &cons ));
+  return std::unique_ptr<CaloSubdetectorGeometry>(loader_.load(&cttopo, &hcaltopo, &cons));
 }

--- a/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
+++ b/Geometry/HcalEventSetup/src/CaloTowerHardcodeGeometryEP.h
@@ -13,7 +13,6 @@
 class HcalRecNumberingRecord;
 class IdealGeometryRecord;
 
-
 class CaloTowerHardcodeGeometryEP : public edm::ESProducer {
 public:
   CaloTowerHardcodeGeometryEP(const edm::ParameterSet&);

--- a/Geometry/HcalEventSetup/src/CaloTowerTopologyEP.cc
+++ b/Geometry/HcalEventSetup/src/CaloTowerTopologyEP.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CaloTowerTopologyEP
 // Class:      CaloTowerTopologyEP
-// 
+//
 /**\class CaloTowerTopologyEP CaloTowerTopologyEP.h tmp/CaloTowerTopologyEP/interface/CaloTowerTopologyEP.h
 
  Description: <one line class summary>
@@ -29,18 +29,15 @@
 // constructors and destructor
 //
 CaloTowerTopologyEP::CaloTowerTopologyEP(const edm::ParameterSet& conf)
-  : topoToken_{setWhatProduced(this).consumes<HcalTopology>(edm::ESInputTag{})}
-{
+    : topoToken_{setWhatProduced(this).consumes<HcalTopology>(edm::ESInputTag{})} {
   edm::LogInfo("HCAL") << "CaloTowerTopologyEP::CaloTowerTopologyEP";
 }
 
+CaloTowerTopologyEP::~CaloTowerTopologyEP() {}
 
-CaloTowerTopologyEP::~CaloTowerTopologyEP() { 
-}
-
-void CaloTowerTopologyEP::fillDescriptions( edm::ConfigurationDescriptions & descriptions ) {
+void CaloTowerTopologyEP::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  descriptions.add( "CaloTowerTopology", desc );
+  descriptions.add("CaloTowerTopology", desc);
 }
 
 //
@@ -48,13 +45,10 @@ void CaloTowerTopologyEP::fillDescriptions( edm::ConfigurationDescriptions & des
 //
 
 // ------------ method called to produce the data  ------------
-CaloTowerTopologyEP::ReturnType
-CaloTowerTopologyEP::produce(const HcalRecNumberingRecord& iRecord) {
+CaloTowerTopologyEP::ReturnType CaloTowerTopologyEP::produce(const HcalRecNumberingRecord& iRecord) {
   const auto& hcaltopo = iRecord.get(topoToken_);
 
   edm::LogInfo("HCAL") << "CaloTowerTopologyEP::produce(const HcalRecNumberingRecord& iRecord)";
 
   return std::make_unique<CaloTowerTopology>(&hcaltopo);
 }
-
-

--- a/Geometry/HcalEventSetup/src/HcalAlignmentEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalAlignmentEP.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HcalAlignmentEP
 // Class:      HcalAlignmentEP
-// 
+//
 //
 // Original Author:  Brian Heltsley
 //
@@ -11,7 +11,7 @@
 #include "Geometry/HcalEventSetup/interface/HcalAlignmentEP.h"
 
 HcalAlignmentEP::HcalAlignmentEP(const edm::ParameterSet&) {
-  auto cc = setWhatProduced( this, &HcalAlignmentEP::produceHcalAli    ) ;
+  auto cc = setWhatProduced(this, &HcalAlignmentEP::produceHcalAli);
   hbToken_ = cc.consumesFrom<Alignments, HBAlignmentRcd>(edm::ESInputTag{});
   heToken_ = cc.consumesFrom<Alignments, HEAlignmentRcd>(edm::ESInputTag{});
   hfToken_ = cc.consumesFrom<Alignments, HFAlignmentRcd>(edm::ESInputTag{});
@@ -19,14 +19,13 @@ HcalAlignmentEP::HcalAlignmentEP(const edm::ParameterSet&) {
 }
 
 HcalAlignmentEP::~HcalAlignmentEP() {}
- 
-HcalAlignmentEP::ReturnAli HcalAlignmentEP::produceHcalAli( const HcalAlignmentRcd& iRecord ) {
 
+HcalAlignmentEP::ReturnAli HcalAlignmentEP::produceHcalAli(const HcalAlignmentRcd& iRecord) {
   auto ali = std::make_unique<Alignments>();
 
-  std::vector<AlignTransform>& vtr ( ali->m_align ) ;
-  const unsigned int nA ( HcalGeometry::numberOfAlignments() ) ; 
-  vtr.resize( nA ) ;
+  std::vector<AlignTransform>& vtr(ali->m_align);
+  const unsigned int nA(HcalGeometry::numberOfAlignments());
+  vtr.resize(nA);
 
   const auto& hb = iRecord.get(hbToken_);
   const auto& he = iRecord.get(heToken_);
@@ -34,19 +33,19 @@ HcalAlignmentEP::ReturnAli HcalAlignmentEP::produceHcalAli( const HcalAlignmentR
   const auto& ho = iRecord.get(hoToken_);
 
   // require valid alignments and expected size
-  assert( hb.m_align.size() == HcalGeometry::numberOfBarrelAlignments() ) ;
-  assert( he.m_align.size() == HcalGeometry::numberOfEndcapAlignments() ) ;
-  assert( hf.m_align.size() == HcalGeometry::numberOfForwardAlignments() ) ;
-  assert( ho.m_align.size() == HcalGeometry::numberOfOuterAlignments() ) ;
-  const std::vector<AlignTransform>& hbt = hb.m_align ;
-  const std::vector<AlignTransform>& het = he.m_align ;
-  const std::vector<AlignTransform>& hft = hf.m_align ;
-  const std::vector<AlignTransform>& hot = ho.m_align ;
+  assert(hb.m_align.size() == HcalGeometry::numberOfBarrelAlignments());
+  assert(he.m_align.size() == HcalGeometry::numberOfEndcapAlignments());
+  assert(hf.m_align.size() == HcalGeometry::numberOfForwardAlignments());
+  assert(ho.m_align.size() == HcalGeometry::numberOfOuterAlignments());
+  const std::vector<AlignTransform>& hbt = hb.m_align;
+  const std::vector<AlignTransform>& het = he.m_align;
+  const std::vector<AlignTransform>& hft = hf.m_align;
+  const std::vector<AlignTransform>& hot = ho.m_align;
 
-  copy( hbt.begin(), hbt.end(), vtr.begin() ) ;
-  copy( het.begin(), het.end(), vtr.begin()+hbt.size() ) ;
-  copy( hft.begin(), hft.end(), vtr.begin()+hbt.size()+het.size() ) ;
-  copy( hot.begin(), hot.end(), vtr.begin()+hbt.size()+het.size()+hft.size() ) ;
-  
-  return ali ;
+  copy(hbt.begin(), hbt.end(), vtr.begin());
+  copy(het.begin(), het.end(), vtr.begin() + hbt.size());
+  copy(hft.begin(), hft.end(), vtr.begin() + hbt.size() + het.size());
+  copy(hot.begin(), hot.end(), vtr.begin() + hbt.size() + het.size() + hft.size());
+
+  return ali;
 }

--- a/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalDDDGeometryEP.cc
@@ -20,21 +20,17 @@
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-HcalDDDGeometryEP::HcalDDDGeometryEP(const edm::ParameterSet& ps ){
-
+HcalDDDGeometryEP::HcalDDDGeometryEP(const edm::ParameterSet& ps) {
   //the following line is needed to tell the framework what
   // data is being produced
-  auto cc = setWhatProduced( this,
-                             &HcalDDDGeometryEP::produceAligned,
-                             edm::es::Label("HCAL"));
+  auto cc = setWhatProduced(this, &HcalDDDGeometryEP::produceAligned, edm::es::Label("HCAL"));
   consToken_ = cc.consumesFrom<HcalDDDRecConstants, HcalRecNumberingRecord>(edm::ESInputTag{});
   topologyToken_ = cc.consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
 }
 
 // ------------ method called to produce the data  ------------
-HcalDDDGeometryEP::ReturnType
-HcalDDDGeometryEP::produceAligned(const HcalGeometryRecord& iRecord) {
-  edm::LogInfo("HCAL") << "Using default HCAL topology" ;
+HcalDDDGeometryEP::ReturnType HcalDDDGeometryEP::produceAligned(const HcalGeometryRecord& iRecord) {
+  edm::LogInfo("HCAL") << "Using default HCAL topology";
   const auto& cons = iRecord.get(consToken_);
   const auto& topology = iRecord.get(topologyToken_);
 

--- a/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalHardcodeGeometryEP.cc
@@ -29,29 +29,26 @@
 
 class HcalTopology;
 
-HcalHardcodeGeometryEP::HcalHardcodeGeometryEP( const edm::ParameterSet& ps ) {
+HcalHardcodeGeometryEP::HcalHardcodeGeometryEP(const edm::ParameterSet& ps) {
   useOld_ = ps.getParameter<bool>("UseOldLoader");
   //the following line is needed to tell the framework what
   // data is being produced
-  auto cc = setWhatProduced( this,
-                             &HcalHardcodeGeometryEP::produceAligned,
-                             edm::es::Label(HcalGeometry::producerTag()));
-  if(not useOld_) {
+  auto cc = setWhatProduced(this, &HcalHardcodeGeometryEP::produceAligned, edm::es::Label(HcalGeometry::producerTag()));
+  if (not useOld_) {
     consToken_ = cc.consumesFrom<HcalDDDRecConstants, HcalRecNumberingRecord>(edm::ESInputTag{});
   }
   topologyToken_ = cc.consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{});
 }
 
-HcalHardcodeGeometryEP::ReturnType
-HcalHardcodeGeometryEP::produceAligned( const HcalGeometryRecord& iRecord ) {
-  edm::LogInfo("HCAL") << "Using default HCAL topology" ;
+HcalHardcodeGeometryEP::ReturnType HcalHardcodeGeometryEP::produceAligned(const HcalGeometryRecord& iRecord) {
+  edm::LogInfo("HCAL") << "Using default HCAL topology";
   const auto& topology = iRecord.get(topologyToken_);
   if (useOld_) {
     HcalHardcodeGeometryLoader loader;
-    return ReturnType (loader.load (topology));
+    return ReturnType(loader.load(topology));
   } else {
     const auto& cons = iRecord.get(consToken_);
     HcalFlexiHardcodeGeometryLoader loader;
-    return ReturnType (loader.load (topology, cons));
+    return ReturnType(loader.load(topology, cons));
   }
 }

--- a/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
@@ -27,28 +27,25 @@
 //#define DebugLog
 
 HcalTopologyIdealEP::HcalTopologyIdealEP(const edm::ParameterSet& conf)
-  : m_hdcToken{setWhatProduced(this, &HcalTopologyIdealEP::produce).consumes<HcalDDDRecConstants>(edm::ESInputTag{})},
-    m_restrictions(conf.getUntrackedParameter<std::string>("Exclude")),
-    m_mergePosition(conf.getUntrackedParameter<bool>("MergePosition")) {
+    : m_hdcToken{setWhatProduced(this, &HcalTopologyIdealEP::produce).consumes<HcalDDDRecConstants>(edm::ESInputTag{})},
+      m_restrictions(conf.getUntrackedParameter<std::string>("Exclude")),
+      m_mergePosition(conf.getUntrackedParameter<bool>("MergePosition")) {
 #ifdef DebugLog
-  std::cout << "HcalTopologyIdealEP::HcalTopologyIdealEP with Exclude: "
-	    << m_restrictions << " MergePosition: " << m_mergePosition
-	    << std::endl;
+  std::cout << "HcalTopologyIdealEP::HcalTopologyIdealEP with Exclude: " << m_restrictions
+            << " MergePosition: " << m_mergePosition << std::endl;
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::HcalTopologyIdealEP";
 #endif
 }
 
-void HcalTopologyIdealEP::fillDescriptions( edm::ConfigurationDescriptions & descriptions ) {
-
+void HcalTopologyIdealEP::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.addUntracked<std::string>( "Exclude", "" );
+  desc.addUntracked<std::string>("Exclude", "");
   desc.addUntracked<bool>("MergePosition", false);
-  descriptions.add( "hcalTopologyIdealBase", desc );
+  descriptions.add("hcalTopologyIdealBase", desc);
 }
 
 // ------------ method called to produce the data  ------------
-HcalTopologyIdealEP::ReturnType
-HcalTopologyIdealEP::produce(const HcalRecNumberingRecord& iRecord) {
+HcalTopologyIdealEP::ReturnType HcalTopologyIdealEP::produce(const HcalRecNumberingRecord& iRecord) {
 #ifdef DebugLog
   std::cout << "HcalTopologyIdealEP::produce(const IdealGeometryRecord& iRecord)" << std::endl;
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::produce(const HcalGeometryRecord& iRecord)";
@@ -56,22 +53,19 @@ HcalTopologyIdealEP::produce(const HcalRecNumberingRecord& iRecord) {
   const HcalDDDRecConstants& hdc = iRecord.get(m_hdcToken);
 
 #ifdef DebugLog
-  std::cout << "mode = " << hdc.getTopoMode() << ", maxDepthHB = "
-	    << hdc.getMaxDepth(0) << ", maxDepthHE = " << hdc.getMaxDepth(1)
-	    << ", maxDepthHF = " << hdc.getMaxDepth(2) << std::endl;
-  edm::LogInfo("HCAL") << "mode = " << hdc.getTopoMode() << ", maxDepthHB = "
-		       << hdc.getMaxDepth(0) << ", maxDepthHE = "
-		       << hdc.getMaxDepth(1) << ", maxDepthHF = "
-		       << hdc.getMaxDepth(2);
+  std::cout << "mode = " << hdc.getTopoMode() << ", maxDepthHB = " << hdc.getMaxDepth(0)
+            << ", maxDepthHE = " << hdc.getMaxDepth(1) << ", maxDepthHF = " << hdc.getMaxDepth(2) << std::endl;
+  edm::LogInfo("HCAL") << "mode = " << hdc.getTopoMode() << ", maxDepthHB = " << hdc.getMaxDepth(0)
+                       << ", maxDepthHE = " << hdc.getMaxDepth(1) << ", maxDepthHF = " << hdc.getMaxDepth(2);
 #endif
-  ReturnType myTopo(new HcalTopology(&hdc,m_mergePosition));
+  ReturnType myTopo(new HcalTopology(&hdc, m_mergePosition));
 
   HcalTopologyRestrictionParser parser(*myTopo);
   if (!m_restrictions.empty()) {
-    std::string error=parser.parse(m_restrictions);
+    std::string error = parser.parse(m_restrictions);
     if (!error.empty()) {
-      throw cms::Exception("Parse Error","Parse error on Exclude "+error);
+      throw cms::Exception("Parse Error", "Parse error on Exclude " + error);
     }
   }
-  return myTopo ;
+  return myTopo;
 }

--- a/Geometry/HcalEventSetup/src/moduleDB.cc
+++ b/Geometry/HcalEventSetup/src/moduleDB.cc
@@ -7,268 +7,239 @@
 #include "Geometry/CaloEventSetup/interface/CaloGeometryDBReader.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
-template<>
+template <>
 CaloGeometryDBEP<HcalGeometry, CaloGeometryDBReader>::PtrType
-CaloGeometryDBEP<HcalGeometry, CaloGeometryDBReader>::produceAligned( const typename HcalGeometry::AlignedRecord& iRecord ) {
+CaloGeometryDBEP<HcalGeometry, CaloGeometryDBReader>::produceAligned(
+    const typename HcalGeometry::AlignedRecord& iRecord) {
   const auto [alignPtr, globalPtr] = getAlignGlobal(iRecord);
 
-  TrVec  tvec ;
-  DimVec dvec ;
-  IVec   ivec ;
-  IVec   dins ;
+  TrVec tvec;
+  DimVec dvec;
+  IVec ivec;
+  IVec dins;
 
-  const auto& pG = iRecord.get( geometryToken_ ) ;
+  const auto& pG = iRecord.get(geometryToken_);
 
-  tvec = pG.getTranslation() ;
-  dvec = pG.getDimension() ;
-  ivec = pG.getIndexes() ;
+  tvec = pG.getTranslation();
+  dvec = pG.getDimension();
+  ivec = pG.getIndexes();
   dins = pG.getDenseIndices();
   //*********************************************************************************************
 
-  const auto& hcalTopology = iRecord.get( additionalTokens_.topology );
+  const auto& hcalTopology = iRecord.get(additionalTokens_.topology);
 
   // We know that the numer of shapes chanes with changing depth
   // so, this check is temporary disabled. We need to implement
   // a way either to store or calculate the number of shapes or be able
   // to deal with only max numer of shapes.
   // assert( dvec.size() == hcalTopology.getNumberOfShapes() * HcalGeometry::k_NumberOfParametersPerShape ) ;
-  assert( dvec.size() <= hcalTopology.getNumberOfShapes() * HcalGeometry::k_NumberOfParametersPerShape ) ;
-  HcalGeometry* hcg = new HcalGeometry( hcalTopology );
-    
-  PtrType ptr ( hcg );
- 
-  const unsigned int nTrParm( hcg->numberOfTransformParms());
-   
+  assert(dvec.size() <= hcalTopology.getNumberOfShapes() * HcalGeometry::k_NumberOfParametersPerShape);
+  HcalGeometry* hcg = new HcalGeometry(hcalTopology);
+
+  PtrType ptr(hcg);
+
+  const unsigned int nTrParm(hcg->numberOfTransformParms());
+
   ptr->fillDefaultNamedParameters();
-  ptr->allocateCorners( hcalTopology.ncells()+hcalTopology.getHFSize());
-  ptr->allocatePar( dvec.size() ,
-		    HcalGeometry::k_NumberOfParametersPerShape );
+  ptr->allocateCorners(hcalTopology.ncells() + hcalTopology.getHFSize());
+  ptr->allocatePar(dvec.size(), HcalGeometry::k_NumberOfParametersPerShape);
 
-  for( unsigned int i ( 0 ) ; i < dins.size() ; ++i ) {
-    const unsigned int nPerShape ( HcalGeometry::k_NumberOfParametersPerShape );
+  for (unsigned int i(0); i < dins.size(); ++i) {
+    const unsigned int nPerShape(HcalGeometry::k_NumberOfParametersPerShape);
     DimVec dims;
-    dims.reserve( nPerShape );
+    dims.reserve(nPerShape);
 
-    const unsigned int indx( ivec.size() == 1 ? 0 : i );
+    const unsigned int indx(ivec.size() == 1 ? 0 : i);
 
-    DimVec::const_iterator dsrc( dvec.begin() + ivec[indx]*nPerShape );
+    DimVec::const_iterator dsrc(dvec.begin() + ivec[indx] * nPerShape);
 
-    for( unsigned int j ( 0 ) ; j != nPerShape ; ++j ) {
-      dims.emplace_back( *dsrc ) ;
-      ++dsrc ;
+    for (unsigned int j(0); j != nPerShape; ++j) {
+      dims.emplace_back(*dsrc);
+      ++dsrc;
     }
 
-    const CCGFloat* myParm( CaloCellGeometry::getParmPtr( dims, 
-							  ptr->parMgr(), 
-							  ptr->parVecVec()));
+    const CCGFloat* myParm(CaloCellGeometry::getParmPtr(dims, ptr->parMgr(), ptr->parVecVec()));
 
-    const DetId id( hcalTopology.denseId2detId( dins[i]));
-    
-    const unsigned int iGlob( nullptr == globalPtr ? 0 :
-			      HcalGeometry::alignmentTransformIndexGlobal( id ));
+    const DetId id(hcalTopology.denseId2detId(dins[i]));
 
-    assert( nullptr == globalPtr || iGlob < globalPtr->m_align.size());
+    const unsigned int iGlob(nullptr == globalPtr ? 0 : HcalGeometry::alignmentTransformIndexGlobal(id));
 
-    const AlignTransform* gt ( nullptr == globalPtr ? nullptr : &globalPtr->m_align[ iGlob ] );
+    assert(nullptr == globalPtr || iGlob < globalPtr->m_align.size());
 
-    assert( nullptr == gt || iGlob == HcalGeometry::alignmentTransformIndexGlobal( DetId( gt->rawId())));
+    const AlignTransform* gt(nullptr == globalPtr ? nullptr : &globalPtr->m_align[iGlob]);
 
-    const unsigned int iLoc( nullptr == alignPtr ? 0 :
-			     HcalGeometry::alignmentTransformIndexLocal( id ));
+    assert(nullptr == gt || iGlob == HcalGeometry::alignmentTransformIndexGlobal(DetId(gt->rawId())));
 
-    assert( nullptr == alignPtr || iLoc < alignPtr->m_align.size());
+    const unsigned int iLoc(nullptr == alignPtr ? 0 : HcalGeometry::alignmentTransformIndexLocal(id));
 
-    const AlignTransform* at( nullptr == alignPtr ? nullptr :
-			      &alignPtr->m_align[ iLoc ]);
+    assert(nullptr == alignPtr || iLoc < alignPtr->m_align.size());
 
-    assert( nullptr == at || ( HcalGeometry::alignmentTransformIndexLocal( DetId( at->rawId())) == iLoc ));
+    const AlignTransform* at(nullptr == alignPtr ? nullptr : &alignPtr->m_align[iLoc]);
 
-    Pt3D  lRef ;
-    Pt3DVec lc( 8, Pt3D( 0, 0, 0 ));
-    hcg->localCorners( lc, &dims.front(), dins[i], lRef );
+    assert(nullptr == at || (HcalGeometry::alignmentTransformIndexLocal(DetId(at->rawId())) == iLoc));
 
-    const Pt3D lBck( 0.25*(lc[4]+lc[5]+lc[6]+lc[7] )); // ctr rear  face in local
-    const Pt3D lCor( lc[0] );
+    Pt3D lRef;
+    Pt3DVec lc(8, Pt3D(0, 0, 0));
+    hcg->localCorners(lc, &dims.front(), dins[i], lRef);
+
+    const Pt3D lBck(0.25 * (lc[4] + lc[5] + lc[6] + lc[7]));  // ctr rear  face in local
+    const Pt3D lCor(lc[0]);
 
     //----------------------------------- create transform from 6 numbers ---
-    const unsigned int jj( i * nTrParm ); // Note: Dence indices are not sorted and
-                                          // parameters stored according to order of a cell creation
+    const unsigned int jj(i * nTrParm);  // Note: Dence indices are not sorted and
+                                         // parameters stored according to order of a cell creation
     Tr3D tr;
-    const ROOT::Math::Translation3D tl( tvec[jj], tvec[jj+1], tvec[jj+2] );
-    const ROOT::Math::EulerAngles ea( 6 == nTrParm ?
-				      ROOT::Math::EulerAngles( tvec[jj+3], tvec[jj+4], tvec[jj+5] ) :
-				      ROOT::Math::EulerAngles());
-    const ROOT::Math::Transform3D rt( ea, tl );
+    const ROOT::Math::Translation3D tl(tvec[jj], tvec[jj + 1], tvec[jj + 2]);
+    const ROOT::Math::EulerAngles ea(6 == nTrParm ? ROOT::Math::EulerAngles(tvec[jj + 3], tvec[jj + 4], tvec[jj + 5])
+                                                  : ROOT::Math::EulerAngles());
+    const ROOT::Math::Transform3D rt(ea, tl);
     double xx, xy, xz, dx;
     double yx, yy, yz, dy;
     double zx, zy, zz, dz;
-    rt.GetComponents( xx, xy, xz, dx,
-		      yx, yy, yz, dy,
-		      zx, zy, zz, dz );
-    tr = Tr3D( CLHEP::HepRep3x3( xx, xy, xz,
-				 yx, yy, yz,
-				 zx, zy, zz ), 
-	       CLHEP::Hep3Vector( dx, dy, dz));
+    rt.GetComponents(xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz);
+    tr = Tr3D(CLHEP::HepRep3x3(xx, xy, xz, yx, yy, yz, zx, zy, zz), CLHEP::Hep3Vector(dx, dy, dz));
 
     // now prepend alignment(s) for final transform
-    const Tr3D atr( nullptr == at ? tr :
-		    ( nullptr == gt ? at->transform() * tr :
-		      at->transform() * gt->transform() * tr ));
+    const Tr3D atr(nullptr == at ? tr
+                                 : (nullptr == gt ? at->transform() * tr : at->transform() * gt->transform() * tr));
     //--------------------------------- done making transform  ---------------
 
-    const Pt3D        gRef( atr*lRef ) ;
-    const GlobalPoint fCtr( gRef.x(), gRef.y(), gRef.z() ) ;
-    const Pt3D        gBck( atr*lBck ) ;
-    const GlobalPoint fBck( gBck.x(), gBck.y(), gBck.z() ) ;
-    const Pt3D        gCor( atr*lCor ) ;
-    const GlobalPoint fCor( gCor.x(), gCor.y(), gCor.z() ) ;
+    const Pt3D gRef(atr * lRef);
+    const GlobalPoint fCtr(gRef.x(), gRef.y(), gRef.z());
+    const Pt3D gBck(atr * lBck);
+    const GlobalPoint fBck(gBck.x(), gBck.y(), gBck.z());
+    const Pt3D gCor(atr * lCor);
+    const GlobalPoint fCor(gCor.x(), gCor.y(), gCor.z());
 
-    assert( hcalTopology.detId2denseId(id) == dins[i] );
+    assert(hcalTopology.detId2denseId(id) == dins[i]);
 
-    ptr->newCell( fCtr, fBck, fCor, myParm, id ) ;
+    ptr->newCell(fCtr, fBck, fCor, myParm, id);
   }
 
-  ptr->initializeParms(); // initializations; must happen after cells filled
+  ptr->initializeParms();  // initializations; must happen after cells filled
 
-  return ptr; 
+  return ptr;
 }
 
-template<>
+template <>
 CaloGeometryDBEP<CaloTowerGeometry, CaloGeometryDBReader>::PtrType
-CaloGeometryDBEP<CaloTowerGeometry, CaloGeometryDBReader>::produceAligned( const typename CaloTowerGeometry::AlignedRecord& iRecord ) {
-
+CaloGeometryDBEP<CaloTowerGeometry, CaloGeometryDBReader>::produceAligned(
+    const typename CaloTowerGeometry::AlignedRecord& iRecord) {
   const auto [alignPtr, globalPtr] = getAlignGlobal(iRecord);
 
-  TrVec  tvec ;
-  DimVec dvec ;
-  IVec   ivec ;
-  IVec   dins ;
-  
-  const auto& pG = iRecord.get( geometryToken_ ) ;
+  TrVec tvec;
+  DimVec dvec;
+  IVec ivec;
+  IVec dins;
 
-  tvec = pG.getTranslation() ;
-  dvec = pG.getDimension() ;
-  ivec = pG.getIndexes() ;
+  const auto& pG = iRecord.get(geometryToken_);
+
+  tvec = pG.getTranslation();
+  dvec = pG.getDimension();
+  ivec = pG.getIndexes();
   dins = pG.getDenseIndices();
-//*********************************************************************************************
+  //*********************************************************************************************
 
-  const auto& caloTopology = iRecord.get( additionalTokens_.topology );
+  const auto& caloTopology = iRecord.get(additionalTokens_.topology);
 
+  CaloTowerGeometry* ctg = new CaloTowerGeometry(&caloTopology);
 
-  CaloTowerGeometry* ctg=new CaloTowerGeometry( &caloTopology );
+  const unsigned int nTrParm(tvec.size() / ctg->numberOfCellsForCorners());
 
-  const unsigned int nTrParm ( tvec.size()/ctg->numberOfCellsForCorners() ) ;
+  assert(dvec.size() == ctg->numberOfShapes() * CaloTowerGeometry::k_NumberOfParametersPerShape);
 
-  assert( dvec.size() == ctg->numberOfShapes() * CaloTowerGeometry::k_NumberOfParametersPerShape ) ;
+  PtrType ptr(ctg);
 
+  ptr->fillDefaultNamedParameters();
 
-  PtrType ptr ( ctg ) ;
+  ptr->allocateCorners(ctg->numberOfCellsForCorners());
 
-  ptr->fillDefaultNamedParameters() ;
+  ptr->allocatePar(dvec.size(), CaloTowerGeometry::k_NumberOfParametersPerShape);
 
-  ptr->allocateCorners( ctg->numberOfCellsForCorners() ) ;
+  for (unsigned int i(0); i < dins.size(); ++i) {
+    const unsigned int nPerShape(ctg->numberOfParametersPerShape());
+    DimVec dims;
+    dims.reserve(nPerShape);
 
-  ptr->allocatePar(    dvec.size() ,
-		       CaloTowerGeometry::k_NumberOfParametersPerShape ) ;
+    const unsigned int indx(ivec.size() == 1 ? 0 : i);
 
-  for( unsigned int i ( 0 ) ;  i < dins.size() ; ++i ) {
-    const unsigned int nPerShape ( ctg->numberOfParametersPerShape() ) ;
-    DimVec dims ;
-    dims.reserve( nPerShape ) ;
-    
-    const unsigned int indx ( ivec.size()==1 ? 0 : i ) ;
-	    
-    DimVec::const_iterator dsrc ( dvec.begin() + ivec[indx]*nPerShape ) ;
+    DimVec::const_iterator dsrc(dvec.begin() + ivec[indx] * nPerShape);
 
-    for( unsigned int j ( 0 ) ; j != nPerShape ; ++j )  {
-      dims.emplace_back( *dsrc ) ;
-      ++dsrc ;
+    for (unsigned int j(0); j != nPerShape; ++j) {
+      dims.emplace_back(*dsrc);
+      ++dsrc;
     }
 
-    const CCGFloat* myParm ( CaloCellGeometry::getParmPtr( dims, 
-							   ptr->parMgr(), 
-							   ptr->parVecVec() ));
+    const CCGFloat* myParm(CaloCellGeometry::getParmPtr(dims, ptr->parMgr(), ptr->parVecVec()));
 
+    const DetId id(caloTopology.detIdFromDenseIndex(dins[i]));
 
-    const DetId id ( caloTopology.detIdFromDenseIndex(dins[i]) ) ;
-    
-    const unsigned int iGlob ( nullptr == globalPtr ? 0 :
-			       ctg->alignmentTransformIndexGlobal( id ) ) ;
+    const unsigned int iGlob(nullptr == globalPtr ? 0 : ctg->alignmentTransformIndexGlobal(id));
 
-    assert( nullptr == globalPtr || iGlob < globalPtr->m_align.size() ) ;
+    assert(nullptr == globalPtr || iGlob < globalPtr->m_align.size());
 
-    const AlignTransform* gt ( nullptr == globalPtr ? nullptr : &globalPtr->m_align[ iGlob ] ) ;
+    const AlignTransform* gt(nullptr == globalPtr ? nullptr : &globalPtr->m_align[iGlob]);
 
-    assert( nullptr == gt || iGlob == ctg->alignmentTransformIndexGlobal( DetId( gt->rawId() ) ) ) ;
+    assert(nullptr == gt || iGlob == ctg->alignmentTransformIndexGlobal(DetId(gt->rawId())));
 
-    const unsigned int iLoc ( nullptr == alignPtr ? 0 :
-			      ctg->alignmentTransformIndexLocal( id ) ) ;
+    const unsigned int iLoc(nullptr == alignPtr ? 0 : ctg->alignmentTransformIndexLocal(id));
 
-    assert( nullptr == alignPtr || iLoc < alignPtr->m_align.size() ) ;
+    assert(nullptr == alignPtr || iLoc < alignPtr->m_align.size());
 
-    const AlignTransform* at ( nullptr == alignPtr ? nullptr :
-			       &alignPtr->m_align[ iLoc ] ) ;
+    const AlignTransform* at(nullptr == alignPtr ? nullptr : &alignPtr->m_align[iLoc]);
 
-    assert( nullptr == at || ( ctg->alignmentTransformIndexLocal( DetId( at->rawId() ) ) == iLoc ) ) ;
+    assert(nullptr == at || (ctg->alignmentTransformIndexLocal(DetId(at->rawId())) == iLoc));
 
-    const CaloGenericDetId gId ( id ) ;
+    const CaloGenericDetId gId(id);
 
-    Pt3D  lRef ;
-    Pt3DVec lc ( 8, Pt3D(0,0,0) ) ;
-    ctg->localCorners( lc, &dims.front(), dins[i], lRef ) ;
+    Pt3D lRef;
+    Pt3DVec lc(8, Pt3D(0, 0, 0));
+    ctg->localCorners(lc, &dims.front(), dins[i], lRef);
 
-    const Pt3D lBck ( 0.25*(lc[4]+lc[5]+lc[6]+lc[7] ) ) ; // ctr rear  face in local
-    const Pt3D lCor ( lc[0] ) ;
+    const Pt3D lBck(0.25 * (lc[4] + lc[5] + lc[6] + lc[7]));  // ctr rear  face in local
+    const Pt3D lCor(lc[0]);
 
     //----------------------------------- create transform from 6 numbers ---
-    const unsigned int jj ( i*nTrParm ) ;
-    Tr3D tr ;
-    const ROOT::Math::Translation3D tl ( tvec[jj], tvec[jj+1], tvec[jj+2] ) ;
-    const ROOT::Math::EulerAngles ea (
-				      6==nTrParm ?
-				      ROOT::Math::EulerAngles( tvec[jj+3], tvec[jj+4], tvec[jj+5] ) :
-				      ROOT::Math::EulerAngles() ) ;
-    const ROOT::Math::Transform3D rt ( ea, tl ) ;
-    double xx,xy,xz,dx,yx,yy,yz,dy,zx,zy,zz,dz;
-    rt.GetComponents(xx,xy,xz,dx,yx,yy,yz,dy,zx,zy,zz,dz) ;
-    tr = Tr3D( CLHEP::HepRep3x3( xx, xy, xz,
-				 yx, yy, yz,
-				 zx, zy, zz ), 
-	       CLHEP::Hep3Vector(dx,dy,dz)     );
+    const unsigned int jj(i * nTrParm);
+    Tr3D tr;
+    const ROOT::Math::Translation3D tl(tvec[jj], tvec[jj + 1], tvec[jj + 2]);
+    const ROOT::Math::EulerAngles ea(6 == nTrParm ? ROOT::Math::EulerAngles(tvec[jj + 3], tvec[jj + 4], tvec[jj + 5])
+                                                  : ROOT::Math::EulerAngles());
+    const ROOT::Math::Transform3D rt(ea, tl);
+    double xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz;
+    rt.GetComponents(xx, xy, xz, dx, yx, yy, yz, dy, zx, zy, zz, dz);
+    tr = Tr3D(CLHEP::HepRep3x3(xx, xy, xz, yx, yy, yz, zx, zy, zz), CLHEP::Hep3Vector(dx, dy, dz));
 
     // now prepend alignment(s) for final transform
-    const Tr3D atr ( nullptr == at ? tr :
-		     ( nullptr == gt ? at->transform()*tr :
-		       at->transform()*gt->transform()*tr ) ) ;
+    const Tr3D atr(nullptr == at ? tr
+                                 : (nullptr == gt ? at->transform() * tr : at->transform() * gt->transform() * tr));
     //--------------------------------- done making transform  ---------------
 
-    const Pt3D        gRef ( atr*lRef ) ;
-    const GlobalPoint fCtr ( gRef.x(), gRef.y(), gRef.z() ) ;
-    const Pt3D        gBck ( atr*lBck ) ;
-    const GlobalPoint fBck ( gBck.x(), gBck.y(), gBck.z() ) ;
-    const Pt3D        gCor ( atr*lCor ) ;
-    const GlobalPoint fCor ( gCor.x(), gCor.y(), gCor.z() ) ;
+    const Pt3D gRef(atr * lRef);
+    const GlobalPoint fCtr(gRef.x(), gRef.y(), gRef.z());
+    const Pt3D gBck(atr * lBck);
+    const GlobalPoint fBck(gBck.x(), gBck.y(), gBck.z());
+    const Pt3D gCor(atr * lCor);
+    const GlobalPoint fCor(gCor.x(), gCor.y(), gCor.z());
 
-    assert( caloTopology.denseIndex(id) == dins[i] );
+    assert(caloTopology.denseIndex(id) == dins[i]);
 
-    ptr->newCell(  fCtr, fBck, fCor, myParm, id ) ;
+    ptr->newCell(fCtr, fBck, fCor, myParm, id);
   }
 
-  ptr->initializeParms() ; // initializations; must happen after cells filled
+  ptr->initializeParms();  // initializations; must happen after cells filled
 
-  return ptr ; 
+  return ptr;
 }
 
-template class CaloGeometryDBEP< HcalGeometry , CaloGeometryDBReader> ;
+template class CaloGeometryDBEP<HcalGeometry, CaloGeometryDBReader>;
 
-typedef CaloGeometryDBEP< HcalGeometry , CaloGeometryDBReader> 
-HcalGeometryFromDBEP ;
+typedef CaloGeometryDBEP<HcalGeometry, CaloGeometryDBReader> HcalGeometryFromDBEP;
 
 DEFINE_FWK_EVENTSETUP_MODULE(HcalGeometryFromDBEP);
 
-template class CaloGeometryDBEP< CaloTowerGeometry , CaloGeometryDBReader> ;
+template class CaloGeometryDBEP<CaloTowerGeometry, CaloGeometryDBReader>;
 
-typedef CaloGeometryDBEP< CaloTowerGeometry , CaloGeometryDBReader> 
-CaloTowerGeometryFromDBEP ;
+typedef CaloGeometryDBEP<CaloTowerGeometry, CaloGeometryDBReader> CaloTowerGeometryFromDBEP;
 
 DEFINE_FWK_EVENTSETUP_MODULE(CaloTowerGeometryFromDBEP);

--- a/Geometry/HcalEventSetup/test/HcalDDDGeometryAnalyzer.cc
+++ b/Geometry/HcalEventSetup/test/HcalDDDGeometryAnalyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HcalDDDGeometryAnalyzer
 // Class:      HcalDDDGeometryAnalyzer
-// 
+//
 /**\class HcalDDDGeometryAnalyzer HcalDDDGeometryAnalyzer.cc test/HcalDDDGeometryAnalyzer/src/HcalDDDGeometryAnalyzer.cc
 
  Description: <one line class summary>
@@ -11,8 +11,6 @@
      <Notes on implementation>
 */
 //
-
-
 
 // system include files
 #include <memory>
@@ -41,11 +39,9 @@
 // class decleration
 //
 
-class HcalDDDGeometryAnalyzer : public edm::one::EDAnalyzer<>
-{
+class HcalDDDGeometryAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-
-  explicit HcalDDDGeometryAnalyzer( const edm::ParameterSet& );
+  explicit HcalDDDGeometryAnalyzer(const edm::ParameterSet&);
   ~HcalDDDGeometryAnalyzer() override;
 
   void beginJob() override {}
@@ -57,18 +53,15 @@ private:
   int pass_;
 };
 
-HcalDDDGeometryAnalyzer::HcalDDDGeometryAnalyzer(const edm::ParameterSet& )
-  : geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})}
-{
-  pass_=0;
+HcalDDDGeometryAnalyzer::HcalDDDGeometryAnalyzer(const edm::ParameterSet&)
+    : geometryToken_{esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})} {
+  pass_ = 0;
 }
 
 HcalDDDGeometryAnalyzer::~HcalDDDGeometryAnalyzer() {}
 
 // ------------ method called to produce the data  ------------
-void HcalDDDGeometryAnalyzer::analyze(const edm::Event& , 
-				      const edm::EventSetup& iSetup) {
-
+void HcalDDDGeometryAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup) {
   LogDebug("HCalGeom") << "HcalDDDGeometryAnalyzer::analyze at pass " << pass_;
 
   const auto& geometryR = iSetup.getData(geometryToken_);
@@ -76,27 +69,20 @@ void HcalDDDGeometryAnalyzer::analyze(const edm::Event& ,
   //
   // get the ecal & hcal geometry
   //
-  if (pass_==0) {
-     const std::vector<DetId>& hbCells = geometry->getValidDetIds(DetId::Hcal, 
-								  HcalBarrel);
-     const std::vector<DetId>& heCells = geometry->getValidDetIds(DetId::Hcal, 
-								  HcalEndcap);
-     const std::vector<DetId>& hoCells = geometry->getValidDetIds(DetId::Hcal,
-								  HcalOuter);
-     const std::vector<DetId>& hfCells = geometry->getValidDetIds(DetId::Hcal,
-								  HcalForward);
-    LogDebug("HCalGeom") << "HcalDDDGeometryAnalyzer:: Hcal Barrel ("
-			 << HcalBarrel << ") with " << hbCells.size() 
-			 << " valid cells; Hcal Endcap (" << HcalEndcap
-			 << ") with " << heCells.size() << " valid cells; "
-			 << "Hcal Outer (" << HcalOuter << ") with "
-			 << hoCells.size() << " valid cells; and Hcal Forward"
-			 << " (" << HcalForward << ") with " << hfCells.size() 
-			 << " valid cells";
+  if (pass_ == 0) {
+    const std::vector<DetId>& hbCells = geometry->getValidDetIds(DetId::Hcal, HcalBarrel);
+    const std::vector<DetId>& heCells = geometry->getValidDetIds(DetId::Hcal, HcalEndcap);
+    const std::vector<DetId>& hoCells = geometry->getValidDetIds(DetId::Hcal, HcalOuter);
+    const std::vector<DetId>& hfCells = geometry->getValidDetIds(DetId::Hcal, HcalForward);
+    LogDebug("HCalGeom") << "HcalDDDGeometryAnalyzer:: Hcal Barrel (" << HcalBarrel << ") with " << hbCells.size()
+                         << " valid cells; Hcal Endcap (" << HcalEndcap << ") with " << heCells.size()
+                         << " valid cells; "
+                         << "Hcal Outer (" << HcalOuter << ") with " << hoCells.size()
+                         << " valid cells; and Hcal Forward"
+                         << " (" << HcalForward << ") with " << hfCells.size() << " valid cells";
   }
 
   pass_++;
-      
 }
 
 //define this as a plug-in

--- a/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
+++ b/Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h
@@ -4,10 +4,9 @@
 #include "TMath.h"
 #include "Geometry/VeryForwardGeometry/interface/CTPPSPixelTopology.h"
 
-class CTPPSPixelSimTopology : public CTPPSPixelTopology
-{
-  public:
-    /* simX and simY are the coordinates as in the simulation:
+class CTPPSPixelSimTopology : public CTPPSPixelTopology {
+public:
+  /* simX and simY are the coordinates as in the simulation:
         _________
        |         |
        |         |  y
@@ -15,198 +14,212 @@ class CTPPSPixelSimTopology : public CTPPSPixelTopology
 
        x
     */
-    class PixelInfo
-    {
-      public:
-        PixelInfo( double lower_simX_border, double higher_simX_border, double lower_simY_border, double higher_simY_border, double eff_factor, unsigned short pixel_row_no, unsigned short pixel_col_no ) :
-          lower_simX_border_( lower_simX_border ), higher_simX_border_( higher_simX_border ),
-          lower_simY_border_( lower_simY_border ), higher_simY_border_( higher_simY_border ),
-          eff_factor_( eff_factor ),
-          pixel_row_no_( pixel_row_no ), pixel_col_no_( pixel_col_no ),
-          pixel_index_( pixel_col_no*CTPPSPixelTopology::no_of_pixels_simX_+pixel_row_no )
-        {}
-
-        inline double higherSimXBorder() const { return higher_simX_border_; }
-        inline double lowerSimXBorder() const { return lower_simX_border_; }
-        inline double higherSimYBorder() const { return higher_simY_border_; }
-        inline double lowerSimYBorder() const { return lower_simY_border_; }
-        inline double effFactor() const { return eff_factor_; }
-        inline unsigned short pixelRowNo() const { return pixel_row_no_; }
-        inline unsigned short pixelColNo() const { return pixel_col_no_; }
-        inline unsigned short pixelIndex() const { return pixel_index_; }
-
-      private:
-        double lower_simX_border_;
-        double higher_simX_border_;
-        double lower_simY_border_;
-        double higher_simY_border_;
-        double eff_factor_;
-        unsigned short pixel_row_no_;
-        unsigned short pixel_col_no_;
-        unsigned short pixel_index_;
-    };
-
+  class PixelInfo {
   public:
-    CTPPSPixelSimTopology();
-    ~CTPPSPixelSimTopology() {}
+    PixelInfo(double lower_simX_border,
+              double higher_simX_border,
+              double lower_simY_border,
+              double higher_simY_border,
+              double eff_factor,
+              unsigned short pixel_row_no,
+              unsigned short pixel_col_no)
+        : lower_simX_border_(lower_simX_border),
+          higher_simX_border_(higher_simX_border),
+          lower_simY_border_(lower_simY_border),
+          higher_simY_border_(higher_simY_border),
+          eff_factor_(eff_factor),
+          pixel_row_no_(pixel_row_no),
+          pixel_col_no_(pixel_col_no),
+          pixel_index_(pixel_col_no * CTPPSPixelTopology::no_of_pixels_simX_ + pixel_row_no) {}
 
-    PixelInfo getPixelsInvolved( double x, double y, double sigma, double& hit_pos_x, double& hit_pos_y ) const;
-
-    inline void pixelRange( unsigned int arow, unsigned int acol, double& lower_x, double& higher_x, double& lower_y, double& higher_y ) const {
-      // x and y in the system  of Geant4 SIMULATION
-      arow = 159 - arow;
-      if ( arow > 159 || acol > 155 )
-        throw cms::Exception("CTPPSPixelSimTopology")<< "rows or columns exceeding limits";
-
-      // rows (x segmentation)
-      if ( arow == 0 ) {
-        lower_x = dead_edge_width_ - phys_active_edge_dist_; // 50 um
-        higher_x = dead_edge_width_ + pitch_simX_; // 300 um
-      }
-      else if ( arow <= 78 ) {
-        lower_x =  dead_edge_width_ + arow*pitch_simX_;
-        higher_x = dead_edge_width_ +   ( arow+1 )*pitch_simX_;
-      }
-      else if ( arow == 79 ) {
-        lower_x =  dead_edge_width_ + arow*pitch_simX_;
-        higher_x = dead_edge_width_ + ( arow+2 )*pitch_simX_;
-      }
-      else if ( arow == 80 ) {
-        lower_x =  dead_edge_width_ + ( arow+1 )*pitch_simX_;
-        higher_x = dead_edge_width_ + ( arow+3 )*pitch_simX_;
-      }
-      else if ( arow <= 158 ) {
-        lower_x =  dead_edge_width_ + ( arow+2 )*pitch_simX_;
-        higher_x = dead_edge_width_ + ( arow+3 )*pitch_simX_;
-      }
-      else if ( arow == 159) {
-        lower_x =  dead_edge_width_ + ( arow+2 )*pitch_simX_;
-        higher_x = dead_edge_width_ + ( arow+3 )*pitch_simX_ + phys_active_edge_dist_ ;
-      }
-
-      // columns (y segmentation)
-      if( acol == 0 ) {
-        lower_y = dead_edge_width_ - phys_active_edge_dist_; // 50 um
-        higher_y = dead_edge_width_ + pitch_simY_; // 350 um
-      }
-      else if ( acol <= 50 ) {
-        lower_y =  dead_edge_width_ + acol*pitch_simY_;
-        higher_y = dead_edge_width_ +  ( acol+1 )*pitch_simY_;
-      }
-      else if ( acol == 51 ) {
-        lower_y =  dead_edge_width_ + acol*pitch_simY_;
-        higher_y = dead_edge_width_ + ( acol+2 )*pitch_simY_;
-      }
-      else if ( acol == 52 ) {
-        lower_y =  dead_edge_width_ + ( acol+1 )*pitch_simY_;
-        higher_y = dead_edge_width_ + ( acol+3 )*pitch_simY_;
-      }
-      else if ( acol <= 102 ) {
-        lower_y =  dead_edge_width_ + ( acol+2 )*pitch_simY_;
-        higher_y = dead_edge_width_ + ( acol+3 )*pitch_simY_;
-      }
-      else if ( acol == 103 ) {
-        lower_y =  dead_edge_width_ + ( acol+2 )*pitch_simY_;
-        higher_y = dead_edge_width_ + ( acol+4 )*pitch_simY_;
-      }
-      else if ( acol == 104) {
-        lower_y =  dead_edge_width_ + ( acol+3 )*pitch_simY_;
-        higher_y = dead_edge_width_ + ( acol+5 )*pitch_simY_;
-      }
-      else if ( acol <= 154 ) {
-        lower_y =  dead_edge_width_ + ( acol+4 )*pitch_simY_;
-        higher_y = dead_edge_width_ + ( acol+5 )*pitch_simY_;
-      }
-      else if ( acol == 155 ) {
-        lower_y =  dead_edge_width_ + ( acol+4 )*pitch_simY_;
-        higher_y = dead_edge_width_ + ( acol+5 )*pitch_simY_ + phys_active_edge_dist_ ;
-      }
-
-      lower_x = lower_x - simX_width_/2.;
-      lower_y = lower_y - simY_width_/2.;
-      higher_x = higher_x - simX_width_/2.;
-      higher_y = higher_y - simY_width_/2.;
-    }
+    inline double higherSimXBorder() const { return higher_simX_border_; }
+    inline double lowerSimXBorder() const { return lower_simX_border_; }
+    inline double higherSimYBorder() const { return higher_simY_border_; }
+    inline double lowerSimYBorder() const { return lower_simY_border_; }
+    inline double effFactor() const { return eff_factor_; }
+    inline unsigned short pixelRowNo() const { return pixel_row_no_; }
+    inline unsigned short pixelColNo() const { return pixel_col_no_; }
+    inline unsigned short pixelIndex() const { return pixel_index_; }
 
   private:
-    double active_edge_x_;
-    double active_edge_y_;
-    
-    inline double activeEdgeFactor( double x, double y ) const {
-      const double inv_sigma = 1./active_edge_sigma_; // precaching
-      const double topEdgeFactor =    TMath::Erf( -distanceFromTopActiveEdge( x, y )   *inv_sigma )*0.5 + 0.5;
-      const double bottomEdgeFactor = TMath::Erf( -distanceFromBottomActiveEdge( x, y )*inv_sigma )*0.5 + 0.5;
-      const double rightEdgeFactor =  TMath::Erf( -distanceFromRightActiveEdge( x, y ) *inv_sigma )*0.5 + 0.5;
-      const double leftEdgeFactor =   TMath::Erf( -distanceFromLeftActiveEdge( x, y )  *inv_sigma )*0.5 + 0.5;
+    double lower_simX_border_;
+    double higher_simX_border_;
+    double lower_simY_border_;
+    double higher_simY_border_;
+    double eff_factor_;
+    unsigned short pixel_row_no_;
+    unsigned short pixel_col_no_;
+    unsigned short pixel_index_;
+  };
 
-      const double aEF = topEdgeFactor*bottomEdgeFactor*rightEdgeFactor*leftEdgeFactor;
+public:
+  CTPPSPixelSimTopology();
+  ~CTPPSPixelSimTopology() {}
 
-      if ( aEF > 1. )
-        throw cms::Exception("CTPPSPixelSimTopology")<< " active edge factor > 1";
+  PixelInfo getPixelsInvolved(double x, double y, double sigma, double& hit_pos_x, double& hit_pos_y) const;
 
-      return aEF;
+  inline void pixelRange(unsigned int arow,
+                         unsigned int acol,
+                         double& lower_x,
+                         double& higher_x,
+                         double& lower_y,
+                         double& higher_y) const {
+    // x and y in the system  of Geant4 SIMULATION
+    arow = 159 - arow;
+    if (arow > 159 || acol > 155)
+      throw cms::Exception("CTPPSPixelSimTopology") << "rows or columns exceeding limits";
+
+    // rows (x segmentation)
+    if (arow == 0) {
+      lower_x = dead_edge_width_ - phys_active_edge_dist_;  // 50 um
+      higher_x = dead_edge_width_ + pitch_simX_;            // 300 um
+    } else if (arow <= 78) {
+      lower_x = dead_edge_width_ + arow * pitch_simX_;
+      higher_x = dead_edge_width_ + (arow + 1) * pitch_simX_;
+    } else if (arow == 79) {
+      lower_x = dead_edge_width_ + arow * pitch_simX_;
+      higher_x = dead_edge_width_ + (arow + 2) * pitch_simX_;
+    } else if (arow == 80) {
+      lower_x = dead_edge_width_ + (arow + 1) * pitch_simX_;
+      higher_x = dead_edge_width_ + (arow + 3) * pitch_simX_;
+    } else if (arow <= 158) {
+      lower_x = dead_edge_width_ + (arow + 2) * pitch_simX_;
+      higher_x = dead_edge_width_ + (arow + 3) * pitch_simX_;
+    } else if (arow == 159) {
+      lower_x = dead_edge_width_ + (arow + 2) * pitch_simX_;
+      higher_x = dead_edge_width_ + (arow + 3) * pitch_simX_ + phys_active_edge_dist_;
     }
 
-    inline double distanceFromTopActiveEdge( double x, double y ) const { return ( y-active_edge_y_ ); }
-    inline double distanceFromBottomActiveEdge( double x, double y ) const { return ( -y-active_edge_y_ ); }
-    inline double distanceFromRightActiveEdge( double x, double y ) const { return ( x-active_edge_x_ ); }
-    inline double distanceFromLeftActiveEdge( double x, double y ) const { return ( -x-active_edge_x_ ); }
-
-    inline unsigned int row( double x ) const {
-      // x in the G4 simulation system
-      x = x + simX_width_/2.;
- 
-      // now x in the system centered in the bottom left corner of the sensor (sensor view, rocs behind)
-      if ( x < 0. || x > simX_width_ )
-        throw cms::Exception("CTPPSPixelSimTopology")<< "out of reference frame";
-
-      // rows (x segmentation)
-      unsigned int arow;
-      if      ( x <= ( dead_edge_width_+    pitch_simX_ ) ) arow = 0;
-      else if ( x <= ( dead_edge_width_+ 79*pitch_simX_ ) ) arow = int( ( x-dead_edge_width_-pitch_simX_ )/pitch_simX_ )+1;
-      else if ( x <= ( dead_edge_width_+ 81*pitch_simX_ ) ) arow = 79;
-      else if ( x <= ( dead_edge_width_+ 83*pitch_simX_ ) ) arow = 80;
-      else if ( x <= ( dead_edge_width_+162*pitch_simX_ ) ) arow = int( ( x-dead_edge_width_-pitch_simX_ )/pitch_simX_ )-1;
-      else arow = 159;
-
-      arow = 159-arow;
-      if ( arow>159 )
-        throw cms::Exception("CTPPSPixelSimTopology")<< "row number exceeding limit";
-
-      return arow;
+    // columns (y segmentation)
+    if (acol == 0) {
+      lower_y = dead_edge_width_ - phys_active_edge_dist_;  // 50 um
+      higher_y = dead_edge_width_ + pitch_simY_;            // 350 um
+    } else if (acol <= 50) {
+      lower_y = dead_edge_width_ + acol * pitch_simY_;
+      higher_y = dead_edge_width_ + (acol + 1) * pitch_simY_;
+    } else if (acol == 51) {
+      lower_y = dead_edge_width_ + acol * pitch_simY_;
+      higher_y = dead_edge_width_ + (acol + 2) * pitch_simY_;
+    } else if (acol == 52) {
+      lower_y = dead_edge_width_ + (acol + 1) * pitch_simY_;
+      higher_y = dead_edge_width_ + (acol + 3) * pitch_simY_;
+    } else if (acol <= 102) {
+      lower_y = dead_edge_width_ + (acol + 2) * pitch_simY_;
+      higher_y = dead_edge_width_ + (acol + 3) * pitch_simY_;
+    } else if (acol == 103) {
+      lower_y = dead_edge_width_ + (acol + 2) * pitch_simY_;
+      higher_y = dead_edge_width_ + (acol + 4) * pitch_simY_;
+    } else if (acol == 104) {
+      lower_y = dead_edge_width_ + (acol + 3) * pitch_simY_;
+      higher_y = dead_edge_width_ + (acol + 5) * pitch_simY_;
+    } else if (acol <= 154) {
+      lower_y = dead_edge_width_ + (acol + 4) * pitch_simY_;
+      higher_y = dead_edge_width_ + (acol + 5) * pitch_simY_;
+    } else if (acol == 155) {
+      lower_y = dead_edge_width_ + (acol + 4) * pitch_simY_;
+      higher_y = dead_edge_width_ + (acol + 5) * pitch_simY_ + phys_active_edge_dist_;
     }
 
-    inline unsigned int col( double y ) const {
-      // y in the G4 simulation system
-      unsigned int column;
+    lower_x = lower_x - simX_width_ / 2.;
+    lower_y = lower_y - simY_width_ / 2.;
+    higher_x = higher_x - simX_width_ / 2.;
+    higher_y = higher_y - simY_width_ / 2.;
+  }
 
-      // columns (y segmentation)
-      // now y in the system centered in the bottom left corner of the sensor (sensor view, rocs behind)
-      y = y + simY_width_/2.;
-      if ( y < 0. || y > simY_width_ )
-        throw cms::Exception("CTPPSPixelSimTopology")<< " out of reference frame";
+private:
+  double active_edge_x_;
+  double active_edge_y_;
 
-      if      ( y <= ( dead_edge_width_+    pitch_simY_ ) ) column = 0;
-      else if ( y <= ( dead_edge_width_+ 51*pitch_simY_ ) ) column = int( ( y-dead_edge_width_-pitch_simY_ )/pitch_simY_ )+1;
-      else if ( y <= ( dead_edge_width_+ 53*pitch_simY_ ) ) column = 51;
-      else if ( y <= ( dead_edge_width_+ 55*pitch_simY_ ) ) column = 52;
-      else if ( y <= ( dead_edge_width_+105*pitch_simY_ ) ) column = int( ( y-dead_edge_width_-pitch_simY_ )/pitch_simY_ )-1;
-      else if ( y <= ( dead_edge_width_+107*pitch_simY_ ) ) column = 103;
-      else if ( y <= ( dead_edge_width_+109*pitch_simY_ ) ) column = 104;
-      else if ( y <= ( dead_edge_width_+159*pitch_simY_ ) ) column = int( ( y-dead_edge_width_-pitch_simY_ )/pitch_simY_ )-3;
-      else column = 155;
+  inline double activeEdgeFactor(double x, double y) const {
+    const double inv_sigma = 1. / active_edge_sigma_;  // precaching
+    const double topEdgeFactor = TMath::Erf(-distanceFromTopActiveEdge(x, y) * inv_sigma) * 0.5 + 0.5;
+    const double bottomEdgeFactor = TMath::Erf(-distanceFromBottomActiveEdge(x, y) * inv_sigma) * 0.5 + 0.5;
+    const double rightEdgeFactor = TMath::Erf(-distanceFromRightActiveEdge(x, y) * inv_sigma) * 0.5 + 0.5;
+    const double leftEdgeFactor = TMath::Erf(-distanceFromLeftActiveEdge(x, y) * inv_sigma) * 0.5 + 0.5;
 
-      return column;
-    }
+    const double aEF = topEdgeFactor * bottomEdgeFactor * rightEdgeFactor * leftEdgeFactor;
 
-    inline void rowCol2Index( unsigned int arow, unsigned int acol, unsigned int& index ) const {
-      index = acol*no_of_pixels_simX_+arow;
-    }
+    if (aEF > 1.)
+      throw cms::Exception("CTPPSPixelSimTopology") << " active edge factor > 1";
 
-    inline void index2RowCol( unsigned int& arow, unsigned int& acol, unsigned int index ) const {
-      acol = index / no_of_pixels_simX_;
-      arow = index % no_of_pixels_simX_;
-    }
+    return aEF;
+  }
+
+  inline double distanceFromTopActiveEdge(double x, double y) const { return (y - active_edge_y_); }
+  inline double distanceFromBottomActiveEdge(double x, double y) const { return (-y - active_edge_y_); }
+  inline double distanceFromRightActiveEdge(double x, double y) const { return (x - active_edge_x_); }
+  inline double distanceFromLeftActiveEdge(double x, double y) const { return (-x - active_edge_x_); }
+
+  inline unsigned int row(double x) const {
+    // x in the G4 simulation system
+    x = x + simX_width_ / 2.;
+
+    // now x in the system centered in the bottom left corner of the sensor (sensor view, rocs behind)
+    if (x < 0. || x > simX_width_)
+      throw cms::Exception("CTPPSPixelSimTopology") << "out of reference frame";
+
+    // rows (x segmentation)
+    unsigned int arow;
+    if (x <= (dead_edge_width_ + pitch_simX_))
+      arow = 0;
+    else if (x <= (dead_edge_width_ + 79 * pitch_simX_))
+      arow = int((x - dead_edge_width_ - pitch_simX_) / pitch_simX_) + 1;
+    else if (x <= (dead_edge_width_ + 81 * pitch_simX_))
+      arow = 79;
+    else if (x <= (dead_edge_width_ + 83 * pitch_simX_))
+      arow = 80;
+    else if (x <= (dead_edge_width_ + 162 * pitch_simX_))
+      arow = int((x - dead_edge_width_ - pitch_simX_) / pitch_simX_) - 1;
+    else
+      arow = 159;
+
+    arow = 159 - arow;
+    if (arow > 159)
+      throw cms::Exception("CTPPSPixelSimTopology") << "row number exceeding limit";
+
+    return arow;
+  }
+
+  inline unsigned int col(double y) const {
+    // y in the G4 simulation system
+    unsigned int column;
+
+    // columns (y segmentation)
+    // now y in the system centered in the bottom left corner of the sensor (sensor view, rocs behind)
+    y = y + simY_width_ / 2.;
+    if (y < 0. || y > simY_width_)
+      throw cms::Exception("CTPPSPixelSimTopology") << " out of reference frame";
+
+    if (y <= (dead_edge_width_ + pitch_simY_))
+      column = 0;
+    else if (y <= (dead_edge_width_ + 51 * pitch_simY_))
+      column = int((y - dead_edge_width_ - pitch_simY_) / pitch_simY_) + 1;
+    else if (y <= (dead_edge_width_ + 53 * pitch_simY_))
+      column = 51;
+    else if (y <= (dead_edge_width_ + 55 * pitch_simY_))
+      column = 52;
+    else if (y <= (dead_edge_width_ + 105 * pitch_simY_))
+      column = int((y - dead_edge_width_ - pitch_simY_) / pitch_simY_) - 1;
+    else if (y <= (dead_edge_width_ + 107 * pitch_simY_))
+      column = 103;
+    else if (y <= (dead_edge_width_ + 109 * pitch_simY_))
+      column = 104;
+    else if (y <= (dead_edge_width_ + 159 * pitch_simY_))
+      column = int((y - dead_edge_width_ - pitch_simY_) / pitch_simY_) - 3;
+    else
+      column = 155;
+
+    return column;
+  }
+
+  inline void rowCol2Index(unsigned int arow, unsigned int acol, unsigned int& index) const {
+    index = acol * no_of_pixels_simX_ + arow;
+  }
+
+  inline void index2RowCol(unsigned int& arow, unsigned int& acol, unsigned int index) const {
+    acol = index / no_of_pixels_simX_;
+    arow = index % no_of_pixels_simX_;
+  }
 };
 
 #endif

--- a/Geometry/VeryForwardGeometry/interface/CTPPSPixelTopology.h
+++ b/Geometry/VeryForwardGeometry/interface/CTPPSPixelTopology.h
@@ -8,57 +8,53 @@
  *\brief Geometrical and topological information on RPix silicon detector.
  * Uses coordinate a frame with origin in the center of the wafer.
  **/
-class CTPPSPixelTopology
-{
-  public:
-    CTPPSPixelTopology();
-    ~CTPPSPixelTopology();
+class CTPPSPixelTopology {
+public:
+  CTPPSPixelTopology();
+  ~CTPPSPixelTopology();
 
-    static constexpr double pitch_simY_ = 150E-3;
-    static constexpr double pitch_simX_ = 100E-3;
-    static constexpr double thickness_ = 0.23;
-    static constexpr unsigned short no_of_pixels_simX_ = 160;
-    static constexpr unsigned short no_of_pixels_simY_ = 156;
-    static constexpr unsigned short no_of_pixels_ = 160*156;
-    static constexpr double simX_width_ = 16.6;
-    static constexpr double simY_width_ = 24.4;
-    static constexpr double dead_edge_width_ = 200E-3;
-    static constexpr double active_edge_sigma_ = 0.02;
-    static constexpr double phys_active_edge_dist_ = 0.150;
+  static constexpr double pitch_simY_ = 150E-3;
+  static constexpr double pitch_simX_ = 100E-3;
+  static constexpr double thickness_ = 0.23;
+  static constexpr unsigned short no_of_pixels_simX_ = 160;
+  static constexpr unsigned short no_of_pixels_simY_ = 156;
+  static constexpr unsigned short no_of_pixels_ = 160 * 156;
+  static constexpr double simX_width_ = 16.6;
+  static constexpr double simY_width_ = 24.4;
+  static constexpr double dead_edge_width_ = 200E-3;
+  static constexpr double active_edge_sigma_ = 0.02;
+  static constexpr double phys_active_edge_dist_ = 0.150;
 
-    inline double detPitchSimX() const { return pitch_simX_; }
-    inline double detPitchSimY() const { return pitch_simY_; }
-    inline double detThickness() const { return thickness_; }
-    inline unsigned short detPixelSimXNo() const { return no_of_pixels_simX_; }
-    inline unsigned short detPixelSimYNo() const { return no_of_pixels_simY_; }
-    inline unsigned short detPixelNo() const { return no_of_pixels_; }
-    inline double detXWidth() const { return simX_width_; }
-    inline double detYWidth() const { return simY_width_; }
-    inline double detDeadEdgeWidth() const { return dead_edge_width_; }
-    inline double activeEdgeSigma() const { return active_edge_sigma_; }
-    inline double physActiveEdgeDist() const { return phys_active_edge_dist_; }
+  inline double detPitchSimX() const { return pitch_simX_; }
+  inline double detPitchSimY() const { return pitch_simY_; }
+  inline double detThickness() const { return thickness_; }
+  inline unsigned short detPixelSimXNo() const { return no_of_pixels_simX_; }
+  inline unsigned short detPixelSimYNo() const { return no_of_pixels_simY_; }
+  inline unsigned short detPixelNo() const { return no_of_pixels_; }
+  inline double detXWidth() const { return simX_width_; }
+  inline double detYWidth() const { return simY_width_; }
+  inline double detDeadEdgeWidth() const { return dead_edge_width_; }
+  inline double activeEdgeSigma() const { return active_edge_sigma_; }
+  inline double physActiveEdgeDist() const { return phys_active_edge_dist_; }
 
+  static bool isPixelHit(float xLocalCoordinate, float yLocalCoordinate, bool is3x2 = true) {
+    // check hit fiducial boundaries
+    double xModuleSize = 2 * ((no_of_pixels_simX_ / 2. + 1) * pitch_simX_ + dead_edge_width_);
+    if (xLocalCoordinate < -xModuleSize / 2. || xLocalCoordinate > xModuleSize / 2.)
+      return false;
 
-    static bool isPixelHit(float xLocalCoordinate, float yLocalCoordinate, bool is3x2 = true)
-    {
-// check hit fiducial boundaries
-      double xModuleSize = 2*((no_of_pixels_simX_/2. + 1)*pitch_simX_ + dead_edge_width_);
-      if(xLocalCoordinate < -xModuleSize/2. || xLocalCoordinate > xModuleSize/2.)
-	return false;
-      
-      double yModuleSize = (no_of_pixels_simY_ + 4.)*pitch_simY_ + 2.*dead_edge_width_;
-      double y2x2top = no_of_pixels_simY_/6.*pitch_simY_ + dead_edge_width_;
-      if(is3x2 && (yLocalCoordinate < -yModuleSize/2. || yLocalCoordinate > yModuleSize/2.))
-	return false;
-      
-      if(!is3x2 && (yLocalCoordinate < -yModuleSize/2. || yLocalCoordinate > y2x2top))
-	return false;
-         
-      return true;
-      
-    }
-    
-    CTPPSPixelIndices indices_;
+    double yModuleSize = (no_of_pixels_simY_ + 4.) * pitch_simY_ + 2. * dead_edge_width_;
+    double y2x2top = no_of_pixels_simY_ / 6. * pitch_simY_ + dead_edge_width_;
+    if (is3x2 && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > yModuleSize / 2.))
+      return false;
+
+    if (!is3x2 && (yLocalCoordinate < -yModuleSize / 2. || yLocalCoordinate > y2x2top))
+      return false;
+
+    return true;
+  }
+
+  CTPPSPixelIndices indices_;
 };
 
-#endif 
+#endif

--- a/Geometry/VeryForwardGeometry/src/CTPPSPixelSimTopology.cc
+++ b/Geometry/VeryForwardGeometry/src/CTPPSPixelSimTopology.cc
@@ -1,26 +1,31 @@
 #include "Geometry/VeryForwardGeometry/interface/CTPPSPixelSimTopology.h"
 
-CTPPSPixelSimTopology::CTPPSPixelSimTopology()
-{
-  active_edge_x_ = simX_width_*0.5 - phys_active_edge_dist_;
-  active_edge_y_ = simY_width_*0.5 - phys_active_edge_dist_;
+CTPPSPixelSimTopology::CTPPSPixelSimTopology() {
+  active_edge_x_ = simX_width_ * 0.5 - phys_active_edge_dist_;
+  active_edge_y_ = simY_width_ * 0.5 - phys_active_edge_dist_;
 }
 
-CTPPSPixelSimTopology::PixelInfo
-CTPPSPixelSimTopology::getPixelsInvolved( double x, double y, double sigma, double& hit_pos_x, double& hit_pos_y ) const
-{
+CTPPSPixelSimTopology::PixelInfo CTPPSPixelSimTopology::getPixelsInvolved(
+    double x, double y, double sigma, double& hit_pos_x, double& hit_pos_y) const {
   //hit position wrt the bottom left corner of the sensor (-8.3, -12.2) in sensor view, rocs behind
-  hit_pos_x = x + simX_width_/2.;
-  hit_pos_y = y + simY_width_/2.;
-  if( !( hit_pos_x*hit_pos_y > 0 ) )
+  hit_pos_x = x + simX_width_ / 2.;
+  hit_pos_y = y + simY_width_ / 2.;
+  if (!(hit_pos_x * hit_pos_y > 0))
     throw cms::Exception("CTPPSPixelSimTopology") << "out of reference frame";
 
-  double hit_factor = activeEdgeFactor( x, y );
+  double hit_factor = activeEdgeFactor(x, y);
 
-  unsigned int interested_row = row( x );
-  unsigned int interested_col = col( y );
+  unsigned int interested_row = row(x);
+  unsigned int interested_col = col(y);
   double low_pixel_range_x, high_pixel_range_x, low_pixel_range_y, high_pixel_range_y;
-  pixelRange( interested_row, interested_col, low_pixel_range_x, high_pixel_range_x, low_pixel_range_y, high_pixel_range_y );
+  pixelRange(
+      interested_row, interested_col, low_pixel_range_x, high_pixel_range_x, low_pixel_range_y, high_pixel_range_y);
 
-  return CTPPSPixelSimTopology::PixelInfo( low_pixel_range_x, high_pixel_range_x, low_pixel_range_y, high_pixel_range_y, hit_factor, interested_row, interested_col );
+  return CTPPSPixelSimTopology::PixelInfo(low_pixel_range_x,
+                                          high_pixel_range_x,
+                                          low_pixel_range_y,
+                                          high_pixel_range_y,
+                                          hit_factor,
+                                          interested_row,
+                                          interested_col);
 }

--- a/Geometry/VeryForwardGeometry/src/CTPPSPixelTopology.cc
+++ b/Geometry/VeryForwardGeometry/src/CTPPSPixelTopology.cc
@@ -1,8 +1,5 @@
 #include "Geometry/VeryForwardGeometry/interface/CTPPSPixelTopology.h"
 
-CTPPSPixelTopology::CTPPSPixelTopology()
-{}
+CTPPSPixelTopology::CTPPSPixelTopology() {}
 
-CTPPSPixelTopology::~CTPPSPixelTopology()
-{}
-
+CTPPSPixelTopology::~CTPPSPixelTopology() {}


### PR DESCRIPTION

Applying code-format for CMSSW category geometry.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/224//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


