### PR TITLE
Move strip tracker partition and ModuleGeometry enums to TrackerTopology.h

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
@@ -6,6 +6,7 @@
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 #include "Alignment/CommonAlignment/interface/Alignable.h"
 #include "Alignment/CommonAlignment/interface/Utilities.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"

--- a/Alignment/SurveyAnalysis/src/SurveyDataReader.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyDataReader.cc
@@ -6,7 +6,7 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-// #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include "Alignment/SurveyAnalysis/interface/SurveyDataReader.h"
 

--- a/Alignment/TrackerAlignment/plugins/MCMisalignmentScaler.cc
+++ b/Alignment/TrackerAlignment/plugins/MCMisalignmentScaler.cc
@@ -46,6 +46,7 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"

--- a/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
+++ b/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
@@ -11,6 +11,7 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/TrackReco/interface/Track.h"

--- a/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
@@ -14,6 +14,7 @@
 #include "Alignment/TrackerAlignment/interface/AlignableSiStripDet.h"
 #include "Alignment/TrackerAlignment/interface/TrackerAlignableIndexer.h"
 
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 
 //=============================================================================

--- a/Alignment/TrackerAlignment/src/TrackerAlignmentLevelBuilder.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignmentLevelBuilder.cc
@@ -7,6 +7,7 @@
 // topology and geometry
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 
 

--- a/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
+++ b/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
@@ -13,6 +13,8 @@
 // for creation of TrackerTopology
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+
 // tracker-alignables aka AlignableTracker
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 #include "Alignment/TrackerAlignment/interface/AlignableSiStripDet.h"

--- a/CalibFormats/SiStripObjects/src/SiStripDetCabling.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripDetCabling.cc
@@ -5,6 +5,7 @@
 //         Created:  Wed Mar 22 12:24:33 CET 2006
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 

--- a/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
+++ b/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
@@ -583,19 +583,19 @@ void SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup&
 
       //enum ModuleGeometry {UNKNOWNGEOMETRY, IB1, IB2, OB1, OB2, W1A, W2A, W3A, W1B, W2B, W3B, W4, W5, W6, W7};
 
-      if (si_strip_det_id.moduleGeometry() == 1) {
+      if (si_strip_det_id.moduleGeometry() == SiStripModuleGeometry::IB1) {
         detector_type = 1;
         //cout << "si_strip_det_id.moduleGeometry() = IB1" << endl;
         //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
-      } else if (si_strip_det_id.moduleGeometry() == 2) {
+      } else if (si_strip_det_id.moduleGeometry() == SiStripModuleGeometry::IB2) {
         detector_type = 2;
         //cout << "si_strip_det_id.moduleGeometry() = IB2" << endl;
         //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
-      } else if (si_strip_det_id.moduleGeometry() == 3) {
+      } else if (si_strip_det_id.moduleGeometry() == SiStripModuleGeometry::OB1) {
         detector_type = 3;
         //cout << "si_strip_det_id.moduleGeometry() = OB1" << endl;
         //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;
-      } else if (si_strip_det_id.moduleGeometry() == 4) {
+      } else if (si_strip_det_id.moduleGeometry() == SiStripModuleGeometry::OB2) {
         detector_type = 4;
         //cout << "si_strip_det_id.moduleGeometry() = OB2" << endl;
         //cout << "si_strip_det_id.moduleGeometry() = " << si_strip_det_id.moduleGeometry() << endl;

--- a/CalibTracker/SiStripCommon/plugins/ShallowClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowClustersProducer.cc
@@ -8,6 +8,7 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 ShallowClustersProducer::ShallowClustersProducer(const edm::ParameterSet& iConfig) 
   : Prefix(iConfig.getParameter<std::string>("Prefix") )

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
@@ -69,7 +69,7 @@ SiStripBackPlaneCorrectionFakeESSource::produce(const SiStripBackPlaneCorrection
 
   const edm::Service<SiStripDetInfoFileReader> reader;
   for ( const auto& detId : reader->getAllDetIds() ) {
-    unsigned int moduleGeometry = tTopo->moduleGeometry(DetId(detId))-1;
+    const auto moduleGeometry = static_cast<unsigned int>(tTopo->moduleGeometry(DetId(detId)))-1;
     if ( moduleGeometry > m_valuePerModuleGeometry.size() ) {
       edm::LogError("SiStripBackPlaneCorrectionGenerator") << " BackPlaneCorrection_PerModuleGeometry only contains " << m_valuePerModuleGeometry.size() << "elements and module is out of range";
     }

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
@@ -20,6 +20,7 @@
 
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
@@ -30,6 +30,8 @@
 #include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 class SiStripLorentzAngleFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
 public:

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -17,6 +17,7 @@
 
 #include "CalibTracker/SiStripHitEfficiency/interface/HitEff.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"

--- a/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
+++ b/CalibTracker/SiStripLorentzAngle/src/LA_Filler.cc
@@ -1,5 +1,6 @@
 #include "CalibTracker/SiStripLorentzAngle/interface/LA_Filler_Fitter.h"
 #include "CalibTracker/SiStripCommon/interface/TTREE_FOREACH_ENTRY.hh"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include <cmath>
 #include <boost/lexical_cast.hpp>

--- a/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripQualityStatistics.cc
@@ -21,6 +21,7 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include <iostream>
 #include <iomanip>

--- a/CalibTracker/SiStripQuality/src/SiStripBadAPVAlgorithmFromClusterOccupancy.cc
+++ b/CalibTracker/SiStripQuality/src/SiStripBadAPVAlgorithmFromClusterOccupancy.cc
@@ -3,6 +3,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"

--- a/CalibTracker/SiStripQuality/src/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.cc
+++ b/CalibTracker/SiStripQuality/src/SiStripBadAPVandHotStripAlgorithmFromClusterOccupancy.cc
@@ -4,6 +4,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"

--- a/CalibTracker/SiStripQuality/src/SiStripHotStripAlgorithmFromClusterOccupancy.cc
+++ b/CalibTracker/SiStripQuality/src/SiStripHotStripAlgorithmFromClusterOccupancy.cc
@@ -1,5 +1,6 @@
 #include "CalibTracker/SiStripQuality/interface/SiStripHotStripAlgorithmFromClusterOccupancy.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 SiStripHotStripAlgorithmFromClusterOccupancy::SiStripHotStripAlgorithmFromClusterOccupancy(
     const edm::ParameterSet& iConfig, const TrackerTopology* theTopo)

--- a/CalibTracker/StandaloneTrackerTopology/src/StandaloneTrackerTopology.cc
+++ b/CalibTracker/StandaloneTrackerTopology/src/StandaloneTrackerTopology.cc
@@ -2,6 +2,7 @@
 
 #include "tinyxml2.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 namespace {
   // split into tokens and convert them to uint32_t

--- a/CondFormats/SiStripObjects/src/SiStripBackPlaneCorrection.cc
+++ b/CondFormats/SiStripObjects/src/SiStripBackPlaneCorrection.cc
@@ -28,7 +28,7 @@ void SiStripBackPlaneCorrection::printDebug(std::stringstream& ss, const Tracker
   ss << "SiStripBackPlaneCorrectionReader:" << std::endl;
   ss << "detid \t Geometry \t Back Plane Corrections" << std::endl;
   for( it=detid_la.begin(); it!=detid_la.end(); ++it ) {
-    ss << it->first << "\t" << trackerTopo->moduleGeometry(it->first) << "\t" << it->second << std::endl;
+    ss << it->first << "\t" << static_cast<int>(trackerTopo->moduleGeometry(it->first)) << "\t" << it->second << std::endl;
     ++count;
   }
 }

--- a/CondFormats/SiStripObjects/src/SiStripDetSummary.cc
+++ b/CondFormats/SiStripObjects/src/SiStripDetSummary.cc
@@ -1,4 +1,5 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
 

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayHit.cc
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayHit.cc
@@ -139,6 +139,7 @@ SiStripFineDelayHit::DeviceMask SiStripFineDelayHit::deviceMask(const StripSubde
       maskDetId = tkrTopo->tecDetId(3, 15, 0, 0, 0, 0, 0).rawId();
       break;
     }
+    default: break;
   }
   return std::make_pair(maskDetId, rootDetId);
 }

--- a/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.cc
@@ -10,6 +10,8 @@
 #include "DQM/SiStripMonitorClient/interface/SiStripUtility.h"
 #include "DQM/SiStripMonitorClient/plugins/SiStripBadComponentInfo.h"
 
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+
 #include <cmath>
 #include <cstdio>
 #include <iomanip>

--- a/DQM/SiStripMonitorSummary/plugins/SiStripCorrelateBadStripAndNoise.cc
+++ b/DQM/SiStripMonitorSummary/plugins/SiStripCorrelateBadStripAndNoise.cc
@@ -2,6 +2,7 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 SiStripCorrelateBadStripAndNoise::SiStripCorrelateBadStripAndNoise(const edm::ParameterSet &iConfig)
     : cacheID_quality(0xFFFFFFFF), cacheID_noise(0xFFFFFFFF) {

--- a/DQM/SiStripMonitorSummary/plugins/SiStripCorrelateNoise.cc
+++ b/DQM/SiStripMonitorSummary/plugins/SiStripCorrelateNoise.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "TCanvas.h"
 
 SiStripCorrelateNoise::SiStripCorrelateNoise(const edm::ParameterSet &iConfig)

--- a/DQM/SiStripMonitorSummary/plugins/SiStripPlotGain.cc
+++ b/DQM/SiStripMonitorSummary/plugins/SiStripPlotGain.cc
@@ -2,6 +2,7 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 SiStripPlotGain::SiStripPlotGain(const edm::ParameterSet &iConfig) : cacheID(0xFFFFFFFF) {
   // now do what ever initialization is needed

--- a/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
@@ -1,4 +1,5 @@
 #include "DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 

--- a/DQM/SiStripMonitorSummary/src/SiStripCablingDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripCablingDQM.cc
@@ -1,6 +1,7 @@
 #include "DQM/SiStripMonitorSummary/interface/SiStripCablingDQM.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "TCanvas.h"
 using namespace std;
 // -----

--- a/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripLorentzAngleDQM.cc
@@ -1,5 +1,6 @@
 #include "DQM/SiStripMonitorSummary/interface/SiStripLorentzAngleDQM.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/SiStripSubStructure.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "TCanvas.h"

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -1655,9 +1655,9 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster,
         fillME(MEs.iSubdet->ClusterChargePerCMfromTrack, dQdx_fromTrack);
       if (track_ok)
         fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
-      if (tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W5 ||
-          tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W6 ||
-          tTopo->moduleGeometry(detid) == SiStripDetId::ModuleGeometry::W7) {
+      if (tTopo->moduleGeometry(detid) == SiStripModuleGeometry::W5 ||
+          tTopo->moduleGeometry(detid) == SiStripModuleGeometry::W6 ||
+          tTopo->moduleGeometry(detid) == SiStripModuleGeometry::W7) {
         if (noise > 0.0)
           fillME(MEs.iSubdet->ClusterStoNCorrThickOnTrack, StoN * cosRZ);
         fillME(MEs.iSubdet->ClusterChargeCorrThickOnTrack, charge * cosRZ);

--- a/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
+++ b/DQM/TrackingMonitor/src/TrackingRecoMaterialAnalyser.cc
@@ -1,6 +1,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -17,6 +17,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 
 template< typename T >

--- a/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
+++ b/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
@@ -14,8 +14,8 @@ namespace siStripClusterTools {
     if (detid.subdetId()>=SiStripDetId::TIB) {
       SiStripDetId siStripDetId = detid(); 
       if (siStripDetId.subdetId()==SiStripDetId::TOB) return 1.f/0.047f;
-      if (siStripDetId.moduleGeometry()==SiStripDetId::W5 || siStripDetId.moduleGeometry()==SiStripDetId::W6 ||
-          siStripDetId.moduleGeometry()==SiStripDetId::W7)
+      if (siStripDetId.moduleGeometry()==SiStripModuleGeometry::W5 || siStripDetId.moduleGeometry()==SiStripModuleGeometry::W6 ||
+          siStripDetId.moduleGeometry()==SiStripModuleGeometry::W7)
 	  return 1.f/0.047f;
       return 1.f/0.029f; // so it is TEC ring 1-4 or TIB or TOB;
     } else if (detid.subdetId()==1) return 1.f/0.0285f;

--- a/DataFormats/SiStripDetId/interface/SiStripDetId.h
+++ b/DataFormats/SiStripDetId/interface/SiStripDetId.h
@@ -2,6 +2,7 @@
 #define DataFormats_SiStripDetId_SiStripDetId_h
 
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/TrackerCommon/interface/SiStripEnums.h"
 #include <ostream>
 
 class SiStripDetId;
@@ -31,10 +32,12 @@ public:
   SiStripDetId(Detector det, int subdet) : DetId(det, subdet) { ; }
 
   /** Enumerated type for tracker sub-deteector systems. */
-  enum SubDetector { UNKNOWN = 0, TIB = 3, TID = 4, TOB = 5, TEC = 6 };
-
-  /** Enumerated type for tracker module geometries. */
-  enum ModuleGeometry { UNKNOWNGEOMETRY, IB1, IB2, OB1, OB2, W1A, W2A, W3A, W1B, W2B, W3B, W4, W5, W6, W7 };
+  using SubDetector = SiStripSubdetector::Subdetector;
+  static constexpr auto UNKNOWN = SiStripSubdetector::UNKNOWN;
+  static constexpr auto TIB = SiStripSubdetector::TIB;
+  static constexpr auto TID = SiStripSubdetector::TID;
+  static constexpr auto TOB = SiStripSubdetector::TOB;
+  static constexpr auto TEC = SiStripSubdetector::TEC;
 
   // ---------- Common methods ----------
 
@@ -42,7 +45,7 @@ public:
   inline SubDetector subDetector() const;
 
   /** Returns enumerated type specifying sub-detector. */
-  inline ModuleGeometry moduleGeometry() const;
+  inline SiStripModuleGeometry moduleGeometry() const;
 
   /** A non-zero value means a glued module, null means not glued. */
   inline uint32_t glued() const;
@@ -103,50 +106,50 @@ SiStripDetId::SubDetector SiStripDetId::subDetector() const {
   return static_cast<SiStripDetId::SubDetector>(subdetId());
 }
 
-SiStripDetId::ModuleGeometry SiStripDetId::moduleGeometry() const {
-  SiStripDetId::ModuleGeometry geometry = UNKNOWNGEOMETRY;
+SiStripModuleGeometry SiStripDetId::moduleGeometry() const {
+  auto geometry = SiStripModuleGeometry::UNKNOWNGEOMETRY;
   switch (subDetector()) {
     case TIB:
-      geometry = int((id_ >> layerStartBit_) & layerMask_) < 3 ? IB1 : IB2;
+      geometry = int((id_ >> layerStartBit_) & layerMask_) < 3 ? SiStripModuleGeometry::IB1 : SiStripModuleGeometry::IB2;
       break;
     case TOB:
-      geometry = int((id_ >> layerStartBit_) & layerMask_) < 5 ? OB2 : OB1;
+      geometry = int((id_ >> layerStartBit_) & layerMask_) < 5 ? SiStripModuleGeometry::OB2 : SiStripModuleGeometry::OB1;
       break;
     case TID:
       switch ((id_ >> ringStartBitTID_) & ringMaskTID_) {
         case 1:
-          geometry = W1A;
+          geometry = SiStripModuleGeometry::W1A;
           break;
         case 2:
-          geometry = W2A;
+          geometry = SiStripModuleGeometry::W2A;
           break;
         case 3:
-          geometry = W3A;
+          geometry = SiStripModuleGeometry::W3A;
           break;
       }
       break;
     case TEC:
       switch ((id_ >> ringStartBitTEC_) & ringMaskTEC_) {
         case 1:
-          geometry = W1B;
+          geometry = SiStripModuleGeometry::W1B;
           break;
         case 2:
-          geometry = W2B;
+          geometry = SiStripModuleGeometry::W2B;
           break;
         case 3:
-          geometry = W3B;
+          geometry = SiStripModuleGeometry::W3B;
           break;
         case 4:
-          geometry = W4;
+          geometry = SiStripModuleGeometry::W4;
           break;
         case 5:
-          geometry = W5;
+          geometry = SiStripModuleGeometry::W5;
           break;
         case 6:
-          geometry = W6;
+          geometry = SiStripModuleGeometry::W6;
           break;
         case 7:
-          geometry = W7;
+          geometry = SiStripModuleGeometry::W7;
           break;
       }
     case UNKNOWN:

--- a/DataFormats/SiStripDetId/interface/StripSubdetector.h
+++ b/DataFormats/SiStripDetId/interface/StripSubdetector.h
@@ -7,10 +7,16 @@
  */
 
 #include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/TrackerCommon/interface/SiStripEnums.h"
 
 class StripSubdetector : public DetId {
 public:
-  enum SubDetector { TIB = 3, TID = 4, TOB = 5, TEC = 6 };
+  using SubDetector = SiStripSubdetector::Subdetector;
+  static constexpr auto UNKNOWN = SiStripSubdetector::UNKNOWN;
+  static constexpr auto TIB = SiStripSubdetector::TIB;
+  static constexpr auto TID = SiStripSubdetector::TID;
+  static constexpr auto TOB = SiStripSubdetector::TOB;
+  static constexpr auto TEC = SiStripSubdetector::TEC;
 
   /** Constructor from a raw value */
   StripSubdetector(uint32_t rawid) : DetId(rawid) {}

--- a/DataFormats/TrackerCommon/interface/SiStripEnums.h
+++ b/DataFormats/TrackerCommon/interface/SiStripEnums.h
@@ -1,0 +1,10 @@
+#ifndef SISTRIPENUMS_H
+#define SISTRIPENUMS_H
+
+namespace SiStripSubdetector {
+  enum Subdetector { UNKNOWN = 0, TIB = 3, TID = 4, TOB = 5, TEC = 6 };
+}
+
+enum class SiStripModuleGeometry { UNKNOWNGEOMETRY, IB1 , IB2, OB1, OB2, W1A, W2A, W3A, W1B, W2B, W3B, W4, W5, W6, W7 };
+
+#endif

--- a/DataFormats/TrackerCommon/interface/TrackerTopology.h
+++ b/DataFormats/TrackerCommon/interface/TrackerTopology.h
@@ -2,9 +2,8 @@
 #define TRACKERTOPOLOGY_H
 
 #include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/SiStripEnums.h"
 
 #include <vector>
 #include <string>
@@ -13,7 +12,6 @@
 //flexible replacement for PXBDetId and friends
 //to implement
 // endcap pixel
-
 
 class TrackerTopology {
 
@@ -494,7 +492,7 @@ class TrackerTopology {
 		 uint32_t petal_fw_bw, uint32_t petal,
 		 uint32_t ring, uint32_t module, uint32_t ster) const {  
 
-    DetId id=SiStripDetId(DetId::Tracker,StripSubdetector::TEC);
+    DetId id=DetId(DetId::Tracker,SiStripSubdetector::TEC);
     uint32_t rawid=id.rawId();
 
     rawid |= (side& tecVals_.sideMask_)         << tecVals_.sideStartBit_ |
@@ -513,7 +511,7 @@ class TrackerTopology {
 		 uint32_t str,
 		 uint32_t module,
 		 uint32_t ster) const {
-    DetId id=SiStripDetId(DetId::Tracker,StripSubdetector::TIB);
+    DetId id=DetId(DetId::Tracker,SiStripSubdetector::TIB);
     uint32_t rawid=id.rawId();
     rawid |= (layer& tibVals_.layerMask_) << tibVals_.layerStartBit_ |
       (str_fw_bw& tibVals_.str_fw_bwMask_) << tibVals_.str_fw_bwStartBit_ |
@@ -530,7 +528,7 @@ class TrackerTopology {
 		 uint32_t module_fw_bw,
 		 uint32_t module,
 		 uint32_t ster) const { 
-    DetId id=SiStripDetId(DetId::Tracker,StripSubdetector::TID);
+    DetId id=DetId(DetId::Tracker,SiStripSubdetector::TID);
     uint32_t rawid=id.rawId();
     rawid |= (side& tidVals_.sideMask_)      << tidVals_.sideStartBit_    |
       (wheel& tidVals_.wheelMask_)          << tidVals_.wheelStartBit_      |
@@ -546,7 +544,7 @@ class TrackerTopology {
 		 uint32_t rod,
 		 uint32_t module,
 		 uint32_t ster) const {
-    DetId id=SiStripDetId(DetId::Tracker,StripSubdetector::TOB);
+    DetId id=DetId(DetId::Tracker,SiStripSubdetector::TOB);
     uint32_t rawid=id.rawId();
     rawid |= (layer& tobVals_.layerMask_) << tobVals_.layerStartBit_ |
       (rod_fw_bw& tobVals_.rod_fw_bwMask_) << tobVals_.rod_fw_bwStartBit_ |
@@ -582,7 +580,7 @@ class TrackerTopology {
 
   std::string print(DetId detid) const;
 
-  SiStripDetId::ModuleGeometry moduleGeometry(const DetId &id) const; 
+  SiStripModuleGeometry moduleGeometry(const DetId &id) const;
   
   int getOTLayerNumber(const DetId &id)const;
   int getITPixelLayerNumber(const DetId &id)const;

--- a/DataFormats/TrackerCommon/src/TrackerTopology.cc
+++ b/DataFormats/TrackerCommon/src/TrackerTopology.cc
@@ -1,7 +1,6 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <sstream>
 
@@ -34,13 +33,13 @@ unsigned int TrackerTopology::side(const DetId &id) const {
     return 0;
   if ( subdet == PixelSubdetector::PixelEndcap )
     return pxfSide(id);
-  if ( subdet == StripSubdetector::TIB )
+  if ( subdet == SiStripSubdetector::TIB )
     return 0;
-  if ( subdet == StripSubdetector::TID )
+  if ( subdet == SiStripSubdetector::TID )
     return tidSide(id);
-  if ( subdet == StripSubdetector::TOB )
+  if ( subdet == SiStripSubdetector::TOB )
     return 0;
-  if ( subdet == StripSubdetector::TEC )
+  if ( subdet == SiStripSubdetector::TEC )
     return tecSide(id);
 
   throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::side";
@@ -53,13 +52,13 @@ unsigned int TrackerTopology::layer(const DetId &id) const {
     return pxbLayer(id);
   if ( subdet == PixelSubdetector::PixelEndcap )
     return pxfDisk(id);
-  if ( subdet == StripSubdetector::TIB )
+  if ( subdet == SiStripSubdetector::TIB )
     return tibLayer(id);
-  if ( subdet == StripSubdetector::TID )
+  if ( subdet == SiStripSubdetector::TID )
     return tidWheel(id);
-  if ( subdet == StripSubdetector::TOB )
+  if ( subdet == SiStripSubdetector::TOB )
     return tobLayer(id);
-  if ( subdet == StripSubdetector::TEC )
+  if ( subdet == SiStripSubdetector::TEC )
     return tecWheel(id);
 
   throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::layer";
@@ -72,13 +71,13 @@ unsigned int TrackerTopology::module(const DetId &id) const {
     return pxbModule(id);
   if ( subdet == PixelSubdetector::PixelEndcap )
     return pxfModule(id);
-  if ( subdet == StripSubdetector::TIB )
+  if ( subdet == SiStripSubdetector::TIB )
     return tibModule(id);
-  if ( subdet == StripSubdetector::TID )
+  if ( subdet == SiStripSubdetector::TID )
     return tidModule(id);
-  if ( subdet == StripSubdetector::TOB )
+  if ( subdet == SiStripSubdetector::TOB )
     return tobModule(id);
-  if ( subdet == StripSubdetector::TEC )
+  if ( subdet == SiStripSubdetector::TEC )
     return tecModule(id);
 
   throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::module";
@@ -92,13 +91,13 @@ uint32_t TrackerTopology::glued(const DetId &id) const {
       return 0;
     if ( subdet == PixelSubdetector::PixelEndcap )
       return 0;
-    if ( subdet == StripSubdetector::TIB )
+    if ( subdet == SiStripSubdetector::TIB )
       return tibGlued(id);
-    if ( subdet == StripSubdetector::TID )
+    if ( subdet == SiStripSubdetector::TID )
       return tidGlued(id);
-    if ( subdet == StripSubdetector::TOB )
+    if ( subdet == SiStripSubdetector::TOB )
       return tobGlued(id);
-    if ( subdet == StripSubdetector::TEC )
+    if ( subdet == SiStripSubdetector::TEC )
       return tecGlued(id);
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::glued";
@@ -112,13 +111,13 @@ uint32_t TrackerTopology::stack(const DetId &id) const {
       return 0;
     if ( subdet == PixelSubdetector::PixelEndcap )
       return 0;
-    if ( subdet == StripSubdetector::TIB )
+    if ( subdet == SiStripSubdetector::TIB )
       return tibStack(id);
-    if ( subdet == StripSubdetector::TID )
+    if ( subdet == SiStripSubdetector::TID )
       return tidStack(id);
-    if ( subdet == StripSubdetector::TOB )
+    if ( subdet == SiStripSubdetector::TOB )
       return tobStack(id);
-    if ( subdet == StripSubdetector::TEC )
+    if ( subdet == SiStripSubdetector::TEC )
       return tecStack(id);
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::stack";
@@ -131,13 +130,13 @@ uint32_t TrackerTopology::lower(const DetId &id) const {
       return 0;
     if ( subdet == PixelSubdetector::PixelEndcap )
       return 0;
-    if ( subdet == StripSubdetector::TIB )
+    if ( subdet == SiStripSubdetector::TIB )
       return tibLower(id);
-    if ( subdet == StripSubdetector::TID )
+    if ( subdet == SiStripSubdetector::TID )
       return tidLower(id);
-    if ( subdet == StripSubdetector::TOB )
+    if ( subdet == SiStripSubdetector::TOB )
       return tobLower(id);
-    if ( subdet == StripSubdetector::TEC )
+    if ( subdet == SiStripSubdetector::TEC )
       return tecLower(id);
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::lower";
@@ -150,13 +149,13 @@ uint32_t TrackerTopology::upper(const DetId &id) const {
       return 0;
     if ( subdet == PixelSubdetector::PixelEndcap )
       return 0;
-    if ( subdet == StripSubdetector::TIB )
+    if ( subdet == SiStripSubdetector::TIB )
       return tibUpper(id);
-    if ( subdet == StripSubdetector::TID )
+    if ( subdet == SiStripSubdetector::TID )
       return tidUpper(id);
-    if ( subdet == StripSubdetector::TOB )
+    if ( subdet == SiStripSubdetector::TOB )
       return tobUpper(id);
-    if ( subdet == StripSubdetector::TEC )
+    if ( subdet == SiStripSubdetector::TEC )
       return tecUpper(id);
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::upper";
@@ -170,13 +169,13 @@ bool TrackerTopology::isStereo(const DetId &id) const {
       return false;
     if ( subdet == PixelSubdetector::PixelEndcap )
       return false;
-    if ( subdet == StripSubdetector::TIB )
+    if ( subdet == SiStripSubdetector::TIB )
       return tibStereo(id)!=0;
-    if ( subdet == StripSubdetector::TID )
+    if ( subdet == SiStripSubdetector::TID )
       return tidStereo(id)!=0;
-    if ( subdet == StripSubdetector::TOB )
+    if ( subdet == SiStripSubdetector::TOB )
       return tobStereo(id)!=0;
-    if ( subdet == StripSubdetector::TEC )
+    if ( subdet == SiStripSubdetector::TEC )
       return tecStereo(id)!=0;
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::isStereo";
@@ -190,13 +189,13 @@ bool TrackerTopology::isRPhi(const DetId &id) const {
       return false;
     if ( subdet == PixelSubdetector::PixelEndcap )
       return false;
-    if ( subdet == StripSubdetector::TIB )
+    if ( subdet == SiStripSubdetector::TIB )
       return tibRPhi(id)!=0;
-    if ( subdet == StripSubdetector::TID )
+    if ( subdet == SiStripSubdetector::TID )
       return tidRPhi(id)!=0;
-    if ( subdet == StripSubdetector::TOB )
+    if ( subdet == SiStripSubdetector::TOB )
       return tobRPhi(id)!=0;
-    if ( subdet == StripSubdetector::TEC )
+    if ( subdet == SiStripSubdetector::TEC )
       return tecRPhi(id)!=0;
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::isRPhi";
@@ -209,13 +208,13 @@ bool TrackerTopology::isLower(const DetId &id) const {
       return false;
     if ( subdet == PixelSubdetector::PixelEndcap )
       return false;
-    if ( subdet == StripSubdetector::TIB )
+    if ( subdet == SiStripSubdetector::TIB )
       return tibLower(id)!=0;
-    if ( subdet == StripSubdetector::TID )
+    if ( subdet == SiStripSubdetector::TID )
       return tidLower(id)!=0;
-    if ( subdet == StripSubdetector::TOB )
+    if ( subdet == SiStripSubdetector::TOB )
       return tobLower(id)!=0;
-    if ( subdet == StripSubdetector::TEC )
+    if ( subdet == SiStripSubdetector::TEC )
       return tecLower(id)!=0;
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::isLower";
@@ -230,13 +229,13 @@ bool TrackerTopology::isUpper(const DetId &id) const {
       return false;
     if ( subdet == PixelSubdetector::PixelEndcap )
       return false;
-    if ( subdet == StripSubdetector::TIB )
+    if ( subdet == SiStripSubdetector::TIB )
       return tibUpper(id)!=0;
-    if ( subdet == StripSubdetector::TID )
+    if ( subdet == SiStripSubdetector::TID )
       return tidUpper(id)!=0;
-    if ( subdet == StripSubdetector::TOB )
+    if ( subdet == SiStripSubdetector::TOB )
       return tobUpper(id)!=0;
-    if ( subdet == StripSubdetector::TEC )
+    if ( subdet == SiStripSubdetector::TEC )
       return tecUpper(id)!=0;
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::isUpper";
@@ -250,13 +249,13 @@ DetId TrackerTopology::partnerDetId(const DetId &id) const {
       return 0;
     if ( subdet == PixelSubdetector::PixelEndcap )
       return 0;
-    if ( subdet == StripSubdetector::TIB )
+    if ( subdet == SiStripSubdetector::TIB )
       return tibPartnerDetId(id);
-    if ( subdet == StripSubdetector::TID )
+    if ( subdet == SiStripSubdetector::TID )
       return tidPartnerDetId(id);
-    if ( subdet == StripSubdetector::TOB )
+    if ( subdet == SiStripSubdetector::TOB )
       return tobPartnerDetId(id);
-    if ( subdet == StripSubdetector::TEC )
+    if ( subdet == SiStripSubdetector::TEC )
       return tecPartnerDetId(id);
 
     throw cms::Exception("Invalid DetId") << "Unsupported DetId in TrackerTopology::partnerDetId";
@@ -296,7 +295,7 @@ std::string TrackerTopology::print(DetId id) const {
     return strstr.str();
   }
 
-  if ( subdet == StripSubdetector::TIB ) {
+  if ( subdet == SiStripSubdetector::TIB ) {
     unsigned int              theLayer  = tibLayer(id);
     std::vector<unsigned int> theString = tibStringInfo(id);
     unsigned int              theModule = tibModule(id);
@@ -321,7 +320,7 @@ std::string TrackerTopology::print(DetId id) const {
     return strstr.str();
   }
 
-  if ( subdet == StripSubdetector::TID ) {
+  if ( subdet == SiStripSubdetector::TID ) {
     unsigned int 	 theSide   = tidSide(id);
     unsigned int         theWheel  = tidWheel(id);
     unsigned int         theRing   = tidRing(id);
@@ -348,7 +347,7 @@ std::string TrackerTopology::print(DetId id) const {
     return strstr.str();
   }
 
-  if ( subdet == StripSubdetector::TOB ) {
+  if ( subdet == SiStripSubdetector::TOB ) {
     unsigned int              theLayer  = tobLayer(id);
     std::vector<unsigned int> theRod    = tobRodInfo(id);
     unsigned int              theModule = tobModule(id);
@@ -374,7 +373,7 @@ std::string TrackerTopology::print(DetId id) const {
     return strstr.str();
   }
 
-  if ( subdet == StripSubdetector::TEC ) {
+  if ( subdet == SiStripSubdetector::TEC ) {
     unsigned int 	      theSide   = tecSide(id);
     unsigned int              theWheel  = tecWheel(id);
     unsigned int              theModule = tecModule(id);
@@ -410,35 +409,35 @@ std::string TrackerTopology::print(DetId id) const {
 }
 
 
-SiStripDetId::ModuleGeometry TrackerTopology::moduleGeometry(const DetId &id) const {
+SiStripModuleGeometry TrackerTopology::moduleGeometry(const DetId &id) const {
   switch(id.subdetId()) {
-  case StripSubdetector::TIB: return tibLayer(id)<3? SiStripDetId::IB1 : SiStripDetId::IB2;
-  case StripSubdetector::TOB: return tobLayer(id)<5? SiStripDetId::OB2 : SiStripDetId::OB1;
-  case StripSubdetector::TID: switch (tidRing(id)) {
-    case 1: return SiStripDetId::W1A;
-    case 2: return SiStripDetId::W2A;
-    case 3: return SiStripDetId::W3A;
+  case SiStripSubdetector::TIB: return tibLayer(id)<3? SiStripModuleGeometry::IB1 : SiStripModuleGeometry::IB2;
+  case SiStripSubdetector::TOB: return tobLayer(id)<5? SiStripModuleGeometry::OB2 : SiStripModuleGeometry::OB1;
+  case SiStripSubdetector::TID: switch (tidRing(id)) {
+    case 1: return SiStripModuleGeometry::W1A;
+    case 2: return SiStripModuleGeometry::W2A;
+    case 3: return SiStripModuleGeometry::W3A;
     }
-  case StripSubdetector::TEC: switch (tecRing(id)) {
-    case 1: return SiStripDetId::W1B;
-    case 2: return SiStripDetId::W2B;
-    case 3: return SiStripDetId::W3B;
-    case 4: return SiStripDetId::W4;
+  case SiStripSubdetector::TEC: switch (tecRing(id)) {
+    case 1: return SiStripModuleGeometry::W1B;
+    case 2: return SiStripModuleGeometry::W2B;
+    case 3: return SiStripModuleGeometry::W3B;
+    case 4: return SiStripModuleGeometry::W4;
   //generic function to return DetIds and boolean factors
-    case 5: return SiStripDetId::W5;
-    case 6: return SiStripDetId::W6;
-    case 7: return SiStripDetId::W7;
+    case 5: return SiStripModuleGeometry::W5;
+    case 6: return SiStripModuleGeometry::W6;
+    case 7: return SiStripModuleGeometry::W7;
     }
   }
-  return SiStripDetId::UNKNOWNGEOMETRY;
+  return SiStripModuleGeometry::UNKNOWNGEOMETRY;
 }
 int TrackerTopology::getOTLayerNumber(const DetId &id) const {
     int layer = -1;
     
     if (id.det() == DetId::Tracker) {
-      if (id.subdetId() == StripSubdetector::TOB) {
+      if (id.subdetId() == SiStripSubdetector::TOB) {
 	layer = tobLayer(id);
-      } else if (id.subdetId() == StripSubdetector::TID) {
+      } else if (id.subdetId() == SiStripSubdetector::TID) {
 	layer = 100 * tidSide(id)  + tidWheel(id);
       } else {
 	edm::LogInfo("TrackerTopology") << ">>> Invalid subdetId()  " ;

--- a/FastSimulation/Tracking/src/TrackingLayer.cc
+++ b/FastSimulation/Tracking/src/TrackingLayer.cc
@@ -1,5 +1,6 @@
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 const TrackingLayer::eqfct TrackingLayer::_eqfct;
 

--- a/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
@@ -1,5 +1,7 @@
 #include "FastSimulation/TrackingRecHitProducer/interface/TrackerDetIdSelector.h"
 
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+
 #define DETIDFCT(NAME) NAME, [](const TrackerTopology& trackerTopology, const DetId& detId) -> int
 
 #define TOPOFCT(NAME) \

--- a/Geometry/TrackerGeometryBuilder/src/trackerHierarchy.cc
+++ b/Geometry/TrackerGeometryBuilder/src/trackerHierarchy.cc
@@ -1,4 +1,5 @@
 #include "Geometry/TrackerGeometryBuilder/interface/trackerHierarchy.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include<string>
 #include<vector>

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h
@@ -37,7 +37,7 @@ public:
     float thickness, invThickness, pitch_rel_err2, maxLength;
     int nstrips;
     float backplanecorrection;
-    SiStripDetId::ModuleGeometry moduleGeom;
+    SiStripModuleGeometry moduleGeom;
     float coveredStrips(const LocalVector&, const LocalPoint&) const;
   };
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPE.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPE.cc
@@ -20,28 +20,28 @@ StripCPE::StripCPE(edm::ParameterSet& conf,
       magfield_(mag),
       LorentzAngleMap_(LorentzAngle),
       BackPlaneCorrectionMap_(BackPlaneCorrection) {
-  typedef std::map<std::string, SiStripDetId::ModuleGeometry> map_t;
+  typedef std::map<std::string, SiStripModuleGeometry> map_t;
   map_t modules;
-  modules["IB1"] = SiStripDetId::IB1;
-  modules["IB2"] = SiStripDetId::IB2;
-  modules["OB1"] = SiStripDetId::OB1;
-  modules["OB2"] = SiStripDetId::OB2;
-  modules["W1A"] = SiStripDetId::W1A;
-  modules["W2A"] = SiStripDetId::W2A;
-  modules["W3A"] = SiStripDetId::W3A;
-  modules["W1B"] = SiStripDetId::W1B;
-  modules["W2B"] = SiStripDetId::W2B;
-  modules["W3B"] = SiStripDetId::W3B;
-  modules["W4"] = SiStripDetId::W4;
-  modules["W5"] = SiStripDetId::W5;
-  modules["W6"] = SiStripDetId::W6;
-  modules["W7"] = SiStripDetId::W7;
+  modules["IB1"] = SiStripModuleGeometry::IB1;
+  modules["IB2"] = SiStripModuleGeometry::IB2;
+  modules["OB1"] = SiStripModuleGeometry::OB1;
+  modules["OB2"] = SiStripModuleGeometry::OB2;
+  modules["W1A"] = SiStripModuleGeometry::W1A;
+  modules["W2A"] = SiStripModuleGeometry::W2A;
+  modules["W3A"] = SiStripModuleGeometry::W3A;
+  modules["W1B"] = SiStripModuleGeometry::W1B;
+  modules["W2B"] = SiStripModuleGeometry::W2B;
+  modules["W3B"] = SiStripModuleGeometry::W3B;
+  modules["W4"] = SiStripModuleGeometry::W4;
+  modules["W5"] = SiStripModuleGeometry::W5;
+  modules["W6"] = SiStripModuleGeometry::W6;
+  modules["W7"] = SiStripModuleGeometry::W7;
 
-  const unsigned size = max_element(modules.begin(),
+  const unsigned size = static_cast<unsigned int>(max_element(modules.begin(),
                                     modules.end(),
                                     boost::bind(&map_t::value_type::second, boost::lambda::_1) <
                                         boost::bind(&map_t::value_type::second, boost::lambda::_2))
-                            ->second +
+                            ->second) +
                         1;
   xtalk1.resize(size);
   xtalk2.resize(size);
@@ -55,8 +55,8 @@ StripCPE::StripCPE(edm::ParameterSet& conf,
     if (!confObj.isParameter(xtalk2S))
       throw cms::Exception("SiStripConfObject does not contain: ") << xtalk2S;
 
-    xtalk1[it->second] = confObj.get<double>(xtalk1S);
-    xtalk2[it->second] = confObj.get<double>(xtalk2S);
+    xtalk1[static_cast<int>(it->second)] = confObj.get<double>(xtalk1S);
+    xtalk2[static_cast<int>(it->second)] = confObj.get<double>(xtalk2S);
   }
 
   fillParams();

--- a/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEgeometric.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/StripCPEgeometric.cc
@@ -21,7 +21,7 @@ StripClusterParameterEstimator::LocalValues StripCPEgeometric::localParameters(
     projection = stats_t<float>::from_relative_uncertainty2(std::max(absProj, minProj), projection_rel_err2);
   }
 
-  const std::vector<stats_t<float> > Q = reco::InverseCrosstalkMatrix::unfold(cluster, xtalk1[p.moduleGeom]);
+  const std::vector<stats_t<float> > Q = reco::InverseCrosstalkMatrix::unfold(cluster, xtalk1[static_cast<int>(p.moduleGeom)]);
   const stats_t<float> strip = cluster.firstStrip() + offset_from_firstStrip(Q, projection);
 
   const float corrected =

--- a/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
@@ -147,7 +147,7 @@ HITrackClusterRemover::HITrackClusterRemover(const ParameterSet& iConfig):
     stripRecHits_(doStripChargeCheck_ ? iConfig.getParameter<std::string>("stripRecHits") : std::string("siStripMatchedRecHits")),
     pixelRecHits_(doPixelChargeCheck_ ? iConfig.getParameter<std::string>("pixelRecHits") : std::string("siPixelRecHits"))
 {
-  mergeOld_ = mergeOld_ && iConfig.getParameter<InputTag>("oldClusterRemovalInfo").label()!="";
+  mergeOld_ = mergeOld_ && !iConfig.getParameter<InputTag>("oldClusterRemovalInfo").label().empty();
   if (iConfig.exists("overrideTrkQuals"))
     overrideTrkQuals_.push_back(consumes<edm::ValueMap<int> >(iConfig.getParameter<InputTag>("overrideTrkQuals")));
   if (iConfig.exists("clusterLessSolution"))

--- a/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HITrackClusterRemover.cc
@@ -278,8 +278,8 @@ float HITrackClusterRemover::sensorThickness (const SiStripDetId& detid) const
 {
   if (detid.subdetId()>=SiStripDetId::TIB) {
     if (detid.subdetId()==SiStripDetId::TOB) return 0.047;
-    if (detid.moduleGeometry()==SiStripDetId::W5 || detid.moduleGeometry()==SiStripDetId::W6 ||
-        detid.moduleGeometry()==SiStripDetId::W7)
+    if (detid.moduleGeometry()==SiStripModuleGeometry::W5 || detid.moduleGeometry()==SiStripModuleGeometry::W6 ||
+        detid.moduleGeometry()==SiStripModuleGeometry::W7)
 	return 0.047;
     return 0.029; // so it is TEC ring 1-4 or TIB or TOB;
   } else if (detid.subdetId()==PixelSubdetector::PixelBarrel) return 0.0285;

--- a/RecoLocalTracker/SubCollectionProducers/test/ClusterMCsplitStrips.cc
+++ b/RecoLocalTracker/SubCollectionProducers/test/ClusterMCsplitStrips.cc
@@ -45,7 +45,7 @@ private:
   edm::ESHandle<TrackerTopology> tTopoHandle_;
 
   std::vector<std::string> moduleTypeStrings_;
-  std::vector<int> moduleTypeCodes_;
+  std::vector<SiStripModuleGeometry> moduleTypeCodes_;
 
 };
 
@@ -61,20 +61,20 @@ ClusterMCsplitStrips(const edm::ParameterSet& conf)
   stripdigisimlinkToken = consumes< edm::DetSetVector<StripDigiSimLink> >(edm::InputTag("simSiStripDigis"));
   moduleTypeStrings_ = confClusterRefiner_.getParameter<std::vector<std::string> >("moduleTypes");
   for (auto mod = moduleTypeStrings_.begin(); mod != moduleTypeStrings_.end(); ++mod) {
-    if (*mod == "IB1") moduleTypeCodes_.push_back(SiStripDetId::IB1);
-    if (*mod == "IB2") moduleTypeCodes_.push_back(SiStripDetId::IB2);
-    if (*mod == "OB1") moduleTypeCodes_.push_back(SiStripDetId::OB1);
-    if (*mod == "OB2") moduleTypeCodes_.push_back(SiStripDetId::OB2);
-    if (*mod == "W1A") moduleTypeCodes_.push_back(SiStripDetId::W1A);
-    if (*mod == "W2A") moduleTypeCodes_.push_back(SiStripDetId::W2A);
-    if (*mod == "W3A") moduleTypeCodes_.push_back(SiStripDetId::W3A);
-    if (*mod == "W1B") moduleTypeCodes_.push_back(SiStripDetId::W1B);
-    if (*mod == "W2B") moduleTypeCodes_.push_back(SiStripDetId::W2B);
-    if (*mod == "W3B") moduleTypeCodes_.push_back(SiStripDetId::W3B);
-    if (*mod == "W4") moduleTypeCodes_.push_back(SiStripDetId::W4);
-    if (*mod == "W5") moduleTypeCodes_.push_back(SiStripDetId::W5);
-    if (*mod == "W6") moduleTypeCodes_.push_back(SiStripDetId::W6);
-    if (*mod == "W7") moduleTypeCodes_.push_back(SiStripDetId::W7);
+    if (*mod == "IB1") moduleTypeCodes_.push_back(SiStripModuleGeometry::IB1);
+    if (*mod == "IB2") moduleTypeCodes_.push_back(SiStripModuleGeometry::IB2);
+    if (*mod == "OB1") moduleTypeCodes_.push_back(SiStripModuleGeometry::OB1);
+    if (*mod == "OB2") moduleTypeCodes_.push_back(SiStripModuleGeometry::OB2);
+    if (*mod == "W1A") moduleTypeCodes_.push_back(SiStripModuleGeometry::W1A);
+    if (*mod == "W2A") moduleTypeCodes_.push_back(SiStripModuleGeometry::W2A);
+    if (*mod == "W3A") moduleTypeCodes_.push_back(SiStripModuleGeometry::W3A);
+    if (*mod == "W1B") moduleTypeCodes_.push_back(SiStripModuleGeometry::W1B);
+    if (*mod == "W2B") moduleTypeCodes_.push_back(SiStripModuleGeometry::W2B);
+    if (*mod == "W3B") moduleTypeCodes_.push_back(SiStripModuleGeometry::W3B);
+    if (*mod == "W4") moduleTypeCodes_.push_back(SiStripModuleGeometry::W4);
+    if (*mod == "W5") moduleTypeCodes_.push_back(SiStripModuleGeometry::W5);
+    if (*mod == "W6") moduleTypeCodes_.push_back(SiStripModuleGeometry::W6);
+    if (*mod == "W7") moduleTypeCodes_.push_back(SiStripModuleGeometry::W7);
   }
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/MatchedHitRZCorrectionFromBending.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/MatchedHitRZCorrectionFromBending.cc
@@ -2,6 +2,7 @@
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -22,6 +22,7 @@
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 //for S/N cut
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"

--- a/SimGeneral/TrackingAnalysis/src/TrackingParticleNumberOfLayers.cc
+++ b/SimGeneral/TrackingAnalysis/src/TrackingParticleNumberOfLayers.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 

--- a/SimTracker/SiPhase2Digitizer/test/TBeamTest.cc
+++ b/SimTracker/SiPhase2Digitizer/test/TBeamTest.cc
@@ -35,6 +35,7 @@
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h" 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -16,6 +16,7 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
 #include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
 #include "CondFormats/SiStripObjects/interface/SiStripPedestals.h"

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.cc
@@ -21,7 +21,7 @@
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 


### PR DESCRIPTION
#### PR description:

This implements the solution proposed in https://github.com/cms-sw/cmssw/issues/26776#issuecomment-492536913 to solve the cyclic dependency between TrackerTopology.h and SiStripDetId.h/StripSubstructure.h. I changed to the TrackerTopology version in the uses that picked up SiStripDetId.h or StripSubdetector.h through TrackerTopology.h (since the latter is preferred), but added a SiStripDetId include for the few nontrivial ones (except one where the code could easily be simplified, https://github.com/cms-sw/cmssw/compare/master...pieterdavid:removecyclictrackercommonsistripdetid?expand=1#diff-efb246c04e3568bf8622531fd4ea48d9).
The other uses of these enums should also be changed (and use of SiStripDetId reduced in favour of TrackerTopology, where possible). I could add that here, but maybe it is better to leave that for a separate PR, after all code formatting changes have landed?

#### PR validation:

Compiled on top of CMSSW_10_6_0 before rebasing to master (to solve a conflict with formatting changes in DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc).