### PR TITLE
add more options which can trigger isMC

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -206,6 +206,8 @@ def OptionsFromItems(items):
 
     # if not specified by user try to guess whether MC or DATA
     if not options.isData and not options.isMC:
+        if 'GEN' in options.trimmedStep:
+            options.isMC=True
         if 'SIM' in options.trimmedStep:
             options.isMC=True
         if 'CFWRITER' in options.trimmedStep:
@@ -215,6 +217,10 @@ def OptionsFromItems(items):
         if 'DIGI2RAW' in options.trimmedStep:
             options.isMC=True
         if (not (options.eventcontent == None)) and 'SIM' in options.eventcontent:
+            options.isMC=True
+        if 'LHE' in options.datatier:
+            options.isMC=True
+        if 'GEN' in options.datatier:
             options.isMC=True
         if 'SIM' in options.datatier:
             options.isMC=True


### PR DESCRIPTION
#### PR description:
This PR is to add more options which can trigger isMC automatically. The issue is described in https://github.com/cms-sw/cmssw/issues/26812

#### PR validation:
`cmsDriver.py ZEE_13TeV_TuneCUETP8M1_cfi --conditions auto:phase1_2017_realistic -n 10 --era Run2_2017 --eventcontent FEVTDEBUG --relval 9000,50 --step GEN --datatier GEN --beamspot Realistic25ns13TeVEarly2017Collision --io ZEE_13GENUP17.io --python ZEE_13GENUP17.py --no_exec --fileout file:step1.root --nThreads 4`
can run fine without --mc with this PR

#### if this PR is a backport please specify the original PR:

