### PR TITLE
Add in cmsDriver LHE and GEN as steps defining the isMC option

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -206,9 +206,9 @@ def OptionsFromItems(items):
 
     # if not specified by user try to guess whether MC or DATA
     if not options.isData and not options.isMC:
-        if 'LHE' in options.trimmedStep:
+        if 'LHE' in options.trimmedStep or 'LHE' in options.datatier:
             options.isMC=True
-        if 'GEN' in options.trimmedStep:
+        if 'GEN' in options.trimmedStep or 'GEN' in options.datatier:
             options.isMC=True
         if 'SIM' in options.trimmedStep:
             options.isMC=True

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -206,6 +206,10 @@ def OptionsFromItems(items):
 
     # if not specified by user try to guess whether MC or DATA
     if not options.isData and not options.isMC:
+        if 'LHE' in options.trimmedStep:
+            options.isMC=True
+        if 'GEN' in options.trimmedStep:
+            options.isMC=True
         if 'SIM' in options.trimmedStep:
             options.isMC=True
         if 'CFWRITER' in options.trimmedStep:


### PR DESCRIPTION
#### PR description:

Following #26812 I realize that within cmsDriver the ```isMC``` options is set according to the step content for several MC-related steps but for the ```LHE``` and ```GEN``` steps. I guess this has only historical reasons, without any explicit desire. This PR just sets the isMC option to True even in the case at least one of these additional steps is required.

#### PR validation:

The output configurations for test wf 503.0 (GEN only) and 521.0 (LHE only) are unchanged. The failing test reported by @srimanob now succeed even without specifying the ```--mc``` command line option.