### PR TITLE
refactor PFAlgo::processblock usePFPhotons part

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -223,7 +223,9 @@ class PFAlgo {
   void processBlock( const reco::PFBlockRef& blockref,
                              std::list<reco::PFBlockRef>& hcalBlockRefs, 
                              std::list<reco::PFBlockRef>& ecalBlockRefs, PFEGammaFilters const* pfegamma );
-  
+  void photonAlgo( const reco::PFBlockRef &blockref, std::vector<bool>& active,
+                   std::vector<reco::PFCandidate>& tempElectronCandidates);
+ 
   /// Reconstruct a charged particle from a track
   /// Returns the index of the newly created candidate in pfCandidates_
   /// Michalis added a flag here to treat muons inside jets


### PR DESCRIPTION
#### PR description:

Proposal to start refactoring the `PFAlgo::processBlock`, which is a single function of several thousand lines, into smaller independent subfunctions, based on physics functionality. As the original code is laid out quite clearly, simply in a long stream of consciousness, it is easy to factorize for example the part processing photons into a separate function. In a future iteration, we can factorize also the rest of the `processBlock` function. 
This can be followed by sanitizing the inputs and outputs of the functions and making sure they rely less on a global state.

#### PR validation:

We do not change the functionality of the PFAlgo code, we have validated by re-running the RECO sequence on 10k events and observed exactly the same PF reconstruction output. The full test matrix is running, I will report back with the output, I expect no new failures.

#### if this PR is a backport please specify the original PR:

This is a partial port of the original proposal PR in https://github.com/jpata/cmssw/pull/44.