### PR TITLE
backport of updated monopole skim

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
@@ -7,11 +7,13 @@ hltMonopole.TriggerResultsTag = cms.InputTag( "TriggerResults", "", "HLT" )
 hltMonopole.HLTPaths = cms.vstring(
     #2016
     "HLT_Photon175_v*",
+    "HLT_DoublePhoton60_v*",
     "HLT_PFMET300_v*",
     "HLT_PFMET170_HBHE_BeamHaloCleaned_v*",
-    #2017
+    #2017 and 2018
     "HLT_Photon200_v*",
     "HLT_Photon300_NoHE_v*",
+    "HLT_DoublePhoton70_v*",
     "HLT_PFMET140_PFMHT140_IDTight_v*",
     "HLT_PFMET250_HBHECleaned_v*",
     "HLT_PFMET300_HBHECleaned_v*"


### PR DESCRIPTION
#### PR description:
This PR is to update the trigger used for whole Run2 skim for monopole analysis.

#### PR validation:
Skim was run already. This is to update the trigger name only. Note that 2017/2018 triggers are the same.

#### if this PR is a backport please specify the original PR:
Backport of https://github.com/cms-sw/cmssw/pull/26785

