### PR TITLE
updating GT and BeamSpot for 2021 relvals

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,11 +64,11 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '106X_postLS2_design_v4', # GT containing design conditions for postLS2
+    'phase1_2021_design'       : '106X_upgrade2021_design_v1', # GT containing design conditions for postLS2
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_postLS2_realistic_v4', # GT containing realistic conditions for postLS2
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v4', # GT containing realistic conditions for postLS2
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v1',
+    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2 2023
     'phase2_realistic'         : '106X_upgrade2023_realistic_v2'
 }

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -281,6 +281,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2021_realistic',
         'HLTmenu': '@relval2017',
         'Era' : 'Run3',
+        'BeamSpot': 'Run3RoundOptics25ns13TeVHighSigmaZ',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
     },
     '2021Design' : {


### PR DESCRIPTION
This PR cherry-pick the autocond GTs from AlCa PR@26773 and add proper BS for the 2021 relvals.

Local tests without errors.

FYI @zhenhu @pgunnell @boudoul @christopheralanwest @tocheng

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, what changes are expected in the output if any, what other PRs or externals it depends upon if any -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
