### PR TITLE
cleanup of some static analyzer issues in isolation-related code

### DIFF
--- a/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.cc
+++ b/CommonTools/ParticleFlow/plugins/PFCandIsolatorFromDeposit.cc
@@ -21,7 +21,7 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <string>
-#include <boost/regex.hpp>
+#include <regex>
 
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositVetoFactory.h"
 
@@ -30,7 +30,7 @@ using namespace reco;
 using namespace reco::isodeposit;
 
 bool PFCandIsolatorFromDeposits::SingleDeposit::isNumber(const std::string &str) const {
-   static boost::regex re("^[+-]?(\\d+\\.?|\\d*\\.\\d*)$");
+   static const std::regex re("^[+-]?(\\d+\\.?|\\d*\\.\\d*)$");
    return regex_match(str.c_str(), re);
 }
 double PFCandIsolatorFromDeposits::SingleDeposit::toNumber(const std::string &str) const {
@@ -61,10 +61,10 @@ PFCandIsolatorFromDeposits::SingleDeposit::SingleDeposit(const edm::ParameterSet
   typedef std::vector<std::string> vstring;
   vstring vetos = iConfig.getParameter< vstring >("vetos");
   reco::isodeposit::EventDependentAbsVeto *evdep=nullptr;
-  static boost::regex ecalSwitch("^Ecal(Barrel|Endcaps):(.*)");
+  static const std::regex ecalSwitch("^Ecal(Barrel|Endcaps):(.*)");
 
   for (vstring::const_iterator it = vetos.begin(), ed = vetos.end(); it != ed; ++it) {
-    boost::cmatch match;
+    std::cmatch match;
     // in that case, make two series of vetoes
     if( usePivotForBarrelEndcaps_) {
       if (regex_match(it->c_str(), match, ecalSwitch))

--- a/PhysicsTools/IsolationAlgos/plugins/CandIsolatorFromDeposits.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CandIsolatorFromDeposits.cc
@@ -19,7 +19,7 @@
 #include "DataFormats/Candidate/interface/CandAssociation.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <string>
-#include <boost/regex.hpp>
+#include <regex>
 
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositVetoFactory.h"
 
@@ -28,7 +28,7 @@ using namespace reco;
 using namespace reco::isodeposit;
 
 bool isNumber(const std::string &str) {
-   static boost::regex re("^[+-]?(\\d+\\.?|\\d*\\.\\d*)$");
+   static const std::regex re("^[+-]?(\\d+\\.?|\\d*\\.\\d*)$");
    return regex_match(str.c_str(), re);
 }
 double toNumber(const std::string &str) {

--- a/PhysicsTools/IsolationAlgos/plugins/CandViewExtractor.icc
+++ b/PhysicsTools/IsolationAlgos/plugins/CandViewExtractor.icc
@@ -1,7 +1,7 @@
 template<typename T>
 IsoDeposit CandViewExtractor::depositFromObject(const Event & event, const EventSetup & eventSetup, const T & cand) const
 {
-    static std::string metname = "MuonIsolation|CandViewExtractor";
+    static const std::string metname = "MuonIsolation|CandViewExtractor";
 
     reco::isodeposit::Direction candDir(cand.eta(), cand.phi());
     IsoDeposit deposit(candDir );

--- a/PhysicsTools/IsolationAlgos/src/IsoDepositVetoFactory.cc
+++ b/PhysicsTools/IsolationAlgos/src/IsoDepositVetoFactory.cc
@@ -2,7 +2,7 @@
 
 #include "DataFormats/RecoCandidate/interface/IsoDepositVetos.h"
 #include "PhysicsTools/IsolationAlgos/interface/EventDependentAbsVetos.h"
-#include <boost/regex.hpp>
+#include <regex>
 
 // ---------- FIRST DEFINE NEW VETOS ------------
 namespace reco { namespace isodeposit {
@@ -83,7 +83,7 @@ IsoDepositVetoFactory::make(const char *string, edm::ConsumesCollector& iC) {
 reco::isodeposit::AbsVeto *
 IsoDepositVetoFactory::make(const char *string, reco::isodeposit::EventDependentAbsVeto *&evdep, edm::ConsumesCollector& iC) {
     using namespace reco::isodeposit;
-    static boost::regex
+    static const std::regex
         ecalSwitch("^Ecal(Barrel|Endcaps):(.*)"),
         threshold("Threshold\\((\\d+\\.\\d+)\\)"),
         thresholdtransverse("ThresholdFromTransverse\\((\\d+\\.\\d+)\\)"),
@@ -99,10 +99,7 @@ IsoDepositVetoFactory::make(const char *string, reco::isodeposit::EventDependent
         otherJetConstituentsDR("OtherJetConstituentsDeltaRVeto\\((\\w+:?\\w*:?\\w*),\\s*(\\d+\\.?|\\d*\\.\\d*),\\s*(\\w+:?\\w*:?\\w*),\\s*(\\d+\\.?|\\d*\\.\\d*)\\)"),
         otherCand("^(.*?):(.*)"),
         number("^(\\d+\\.?|\\d*\\.\\d*)$");
-    boost::cmatch match;
-
-    //std::cout << "<IsoDepositVetoFactory::make>:" << std::endl;
-    //std::cout << " string = " << string << std::endl;
+    std::cmatch match;
 
     evdep = nullptr; // by default it does not depend on this
     if (regex_match(string, match, ecalSwitch)) {

--- a/PhysicsTools/PatAlgos/src/IsoDepositIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/IsoDepositIsolator.cc
@@ -55,16 +55,16 @@ IsoDepositIsolator::IsoDepositIsolator(const edm::ParameterSet &conf, edm::Consu
 }
 
 IsoDepositIsolator::~IsoDepositIsolator() {
-    for (AbsVetos::iterator it = vetos_.begin(), ed = vetos_.end(); it != ed; ++it) {
-        delete *it;
+    for (auto veto : vetos_){
+        delete veto;
     }
 }
 
 void
 IsoDepositIsolator::beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) {
     event.getByToken(inputIsoDepositToken_, handle_);
-    for (EventDependentAbsVetos::iterator it = evdepVetos_.begin(), ed = evdepVetos_.end(); it != ed; ++it) {
-        (*it)->setEvent(event,eventSetup);
+    for (auto veto :  evdepVetos_) {
+        veto->setEvent(event,eventSetup);
     }
 }
 
@@ -86,8 +86,8 @@ IsoDepositIsolator::getValue(const edm::ProductID &id, size_t index) const {
     const reco::IsoDeposit &dep = handle_->get(id, index);
 
     double eta = dep.eta(), phi = dep.phi(); // better to center on the deposit direction that could be, e.g., the impact point at calo
-    for (AbsVetos::const_iterator it = vetos_.begin(), ed = vetos_.end(); it != ed; ++it) {
-        (const_cast<AbsVeto *>(*it))->centerOn(eta, phi); // I need the const_cast to be able to 'move' the veto
+    for (auto veto : vetos_) {
+        veto->centerOn(eta, phi);
     }
     switch (mode_) {
         case Count:        return dep.countWithin(deltaR_, vetos_, skipDefaultVeto_);

--- a/PhysicsTools/PatAlgos/src/IsoDepositIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/IsoDepositIsolator.cc
@@ -4,8 +4,6 @@
 #include "DataFormats/RecoCandidate/interface/IsoDepositVetos.h"
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositVetoFactory.h"
 
-#include <boost/regex.hpp>
-
 using pat::helper::IsoDepositIsolator;
 using pat::helper::BaseIsolator;
 using namespace reco::isodeposit;

--- a/RecoMuon/MuonIsolation/src/NominalEfficiencyThresholds.cc
+++ b/RecoMuon/MuonIsolation/src/NominalEfficiencyThresholds.cc
@@ -74,6 +74,7 @@ NominalEfficiencyThresholds::NominalEfficiencyThresholds(const string & infile)
   }
   ThresholdLocation location;
   EfficiencyBin eb;
+  eb.eff = 0;
   float thr_val;
   while (fgets(buffer,80,INFILE)) {
     sscanf(buffer,"%4s",tag);


### PR DESCRIPTION
this clears a few 
- non-const statics
- a const cast
- possibly thread unsafe mutable members
- possibly uninitialized case
- also, some replacement of boost::regex with std::regex
