### PR TITLE
MTD geometry: material budget validation

### DIFF
--- a/Validation/Geometry/data/mtdMaterials.l0
+++ b/Validation/Geometry/data/mtdMaterials.l0
@@ -1,0 +1,46 @@
+#Categories:SUP-SEN-CAB-COL-ELE 0 0 0 0 0
+
+
+
+#CommonMaterials 0 0 0 0 0
+
+tkLayout_SenLYSO                                         0.000 1.000 0.000 0.000 0.000
+                                                                                      
+LYSO                                                     0.000 1.000 0.000 0.000 0.000
+                                                                                      
+tkLayout_SenSi                                           0.000 1.000 0.000 0.000 0.000
+                                                                                      
+tkLayout_Al                                              0.000 0.000 0.000 1.000 0.000
+
+hybridcompositeBModule1Layer1PositiveZFSide              0.000 0.000 0.000 0.000 1.000
+
+hybridcompositeBModule1Layer1PositiveZSupportPlate       0.000 0.000 0.000 1.000 0.000
+
+hybridcompositeEModule1Disc1Between                      0.000 0.000 0.000 0.000 1.000    
+
+hybridcompositeEModule1Disc1BSide                        0.000 0.000 0.000 0.000 1.000
+
+hybridcompositeEModule1Disc1FSide                        0.000 0.000 0.000 0.000 1.000
+
+hybridcompositeEModule1Disc1LSide                        0.000 0.000 0.000 0.000 1.000
+
+hybridcompositeEModule1Disc1SupportPlate                 0.000 0.000 0.000 0.000 1.000
+
+servicecompositeR1038Z2666                               0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR323Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR420Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR511Z2666                                0.000 0.000 1.000 0.000 0.000 
+
+servicecompositeR596Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR688Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR772Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR864Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR946Z2666                                0.000 0.000 1.000 0.000 0.000
+

--- a/Validation/Geometry/data/mtdMaterials.l0
+++ b/Validation/Geometry/data/mtdMaterials.l0
@@ -26,40 +26,40 @@ hybridcompositeEModule1Disc1LSide                        0.000 0.000 0.000 0.000
 
 hybridcompositeEModule1Disc1SupportPlate                 0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR1038Z2666                               0.000 0.000 1.000 0.000 0.000
+servicecompositeR1038Z2666                               0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR323Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR323Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR420Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR420Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR511Z2666                                0.000 0.000 1.000 0.000 0.000 
+servicecompositeR511Z2666                                0.000 0.000 0.000 0.000 1.000 
 
-servicecompositeR596Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR596Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR688Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR688Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR772Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR772Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR864Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR864Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR946Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR946Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR1059Z2666                               0.000 0.000 1.000 0.000 0.000
+servicecompositeR1059Z2666                               0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR264Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR264Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR361Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR361Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR452Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR452Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR537Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR537Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR629Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR629Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR713Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR713Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR805Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR805Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR887Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR887Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR979Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR979Z2666                                0.000 0.000 0.000 0.000 1.000

--- a/Validation/Geometry/data/mtdMaterials.l0
+++ b/Validation/Geometry/data/mtdMaterials.l0
@@ -44,3 +44,22 @@ servicecompositeR864Z2666                                0.000 0.000 1.000 0.000
                                                                                       
 servicecompositeR946Z2666                                0.000 0.000 1.000 0.000 0.000
 
+servicecompositeR1059Z2666                               0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR264Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR361Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR452Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR537Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR629Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR713Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR805Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR887Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR979Z2666                                0.000 0.000 1.000 0.000 0.000

--- a/Validation/Geometry/data/mtdMaterials.x0
+++ b/Validation/Geometry/data/mtdMaterials.x0
@@ -1,0 +1,46 @@
+#Categories:SUP-SEN-CAB-COL-ELE 0 0 0 0 0
+
+
+
+#CommonMaterials 0 0 0 0 0
+
+tkLayout_SenLYSO                                         0.000 1.000 0.000 0.000 0.000
+                                                                                      
+LYSO                                                     0.000 1.000 0.000 0.000 0.000
+                                                                                      
+tkLayout_SenSi                                           0.000 1.000 0.000 0.000 0.000
+                                                                                      
+tkLayout_Al                                              0.000 0.000 0.000 1.000 0.000
+
+hybridcompositeBModule1Layer1PositiveZFSide              0.000 0.000 0.000 0.000 1.000
+
+hybridcompositeBModule1Layer1PositiveZSupportPlate       0.000 0.000 0.000 1.000 0.000
+
+hybridcompositeEModule1Disc1Between                      0.000 0.000 0.000 0.000 1.000    
+
+hybridcompositeEModule1Disc1BSide                        0.000 0.000 0.000 0.000 1.000
+
+hybridcompositeEModule1Disc1FSide                        0.000 0.000 0.000 0.000 1.000
+
+hybridcompositeEModule1Disc1LSide                        0.000 0.000 0.000 0.000 1.000
+
+hybridcompositeEModule1Disc1SupportPlate                 0.000 0.000 0.000 0.000 1.000
+
+servicecompositeR1038Z2666                               0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR323Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR420Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR511Z2666                                0.000 0.000 1.000 0.000 0.000 
+
+servicecompositeR596Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR688Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR772Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR864Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR946Z2666                                0.000 0.000 1.000 0.000 0.000
+

--- a/Validation/Geometry/data/mtdMaterials.x0
+++ b/Validation/Geometry/data/mtdMaterials.x0
@@ -26,40 +26,40 @@ hybridcompositeEModule1Disc1LSide                        0.000 0.000 0.000 0.000
 
 hybridcompositeEModule1Disc1SupportPlate                 0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR1038Z2666                               0.000 0.000 1.000 0.000 0.000
+servicecompositeR1038Z2666                               0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR323Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR323Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR420Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR420Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR511Z2666                                0.000 0.000 1.000 0.000 0.000 
+servicecompositeR511Z2666                                0.000 0.000 0.000 0.000 1.000 
 
-servicecompositeR596Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR596Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR688Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR688Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR772Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR772Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR864Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR864Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR946Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR946Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR1059Z2666                               0.000 0.000 1.000 0.000 0.000
+servicecompositeR1059Z2666                               0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR264Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR264Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR361Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR361Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR452Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR452Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR537Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR537Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR629Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR629Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR713Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR713Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR805Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR805Z2666                                0.000 0.000 0.000 0.000 1.000
                                                                                       
-servicecompositeR887Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR887Z2666                                0.000 0.000 0.000 0.000 1.000
 
-servicecompositeR979Z2666                                0.000 0.000 1.000 0.000 0.000
+servicecompositeR979Z2666                                0.000 0.000 0.000 0.000 1.000

--- a/Validation/Geometry/data/mtdMaterials.x0
+++ b/Validation/Geometry/data/mtdMaterials.x0
@@ -44,3 +44,22 @@ servicecompositeR864Z2666                                0.000 0.000 1.000 0.000
                                                                                       
 servicecompositeR946Z2666                                0.000 0.000 1.000 0.000 0.000
 
+servicecompositeR1059Z2666                               0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR264Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR361Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR452Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR537Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR629Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR713Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR805Z2666                                0.000 0.000 1.000 0.000 0.000
+                                                                                      
+servicecompositeR887Z2666                                0.000 0.000 1.000 0.000 0.000
+
+servicecompositeR979Z2666                                0.000 0.000 1.000 0.000 0.000

--- a/Validation/Geometry/interface/MaterialBudget.h
+++ b/Validation/Geometry/interface/MaterialBudget.h
@@ -28,11 +28,12 @@ class MaterialBudget : public SimWatcher,
                        public Observer<const EndOfTrack*> {
 public:
   MaterialBudget(const edm::ParameterSet&);
+  MaterialBudget(const MaterialBudget&) = delete;                   // stop default
   ~MaterialBudget() override;
 
-private:
-  MaterialBudget(const MaterialBudget&) = delete;                   // stop default
   const MaterialBudget& operator=(const MaterialBudget&) = delete;  // ...
+
+private:
 
   void update(const BeginOfRun*) override;
   void update(const BeginOfTrack*) override;
@@ -48,7 +49,7 @@ private:
   std::vector<G4LogicalVolume*> logVolumes;
   std::vector<TProfile*> me100, me200, me300, me400, me500, me600;
   std::vector<double> stepLen, radLen, intLen;
-  double eta, phi, stepT;
+  double eta_, phi_, stepT;
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudget.h
+++ b/Validation/Geometry/interface/MaterialBudget.h
@@ -21,22 +21,19 @@ class EndOfTrack;
 #include <string>
 #include <vector>
 
-class MaterialBudget : public SimWatcher, 
+class MaterialBudget : public SimWatcher,
                        public Observer<const BeginOfRun*>,
                        public Observer<const BeginOfTrack*>,
-		       public Observer<const G4Step*>,
+                       public Observer<const G4Step*>,
                        public Observer<const EndOfTrack*> {
-
 public:
-
   MaterialBudget(const edm::ParameterSet&);
   ~MaterialBudget() override;
-  
-private:
 
-  MaterialBudget(const MaterialBudget&) = delete;          // stop default
-  const MaterialBudget& operator=(const MaterialBudget&) = delete; // ...
-  
+private:
+  MaterialBudget(const MaterialBudget&) = delete;                   // stop default
+  const MaterialBudget& operator=(const MaterialBudget&) = delete;  // ...
+
   void update(const BeginOfRun*) override;
   void update(const BeginOfTrack*) override;
   void update(const G4Step*) override;
@@ -44,14 +41,14 @@ private:
 
   void book(const edm::ParameterSet&);
   bool stopAfter(const G4Step*);
-  
-  std::vector<std::string>      detTypes, detNames;
-  std::vector<int>              constituents, detLevels,regionTypes,stackOrder;
-  std::vector<double>           etaRegions, boundaries;
+
+  std::vector<std::string> detTypes, detNames;
+  std::vector<int> constituents, detLevels, regionTypes, stackOrder;
+  std::vector<double> etaRegions, boundaries;
   std::vector<G4LogicalVolume*> logVolumes;
-  std::vector<TProfile*>        me100, me200, me300, me400, me500, me600;
-  std::vector<double>           stepLen, radLen, intLen;
-  double                        eta, phi, stepT;
+  std::vector<TProfile*> me100, me200, me300, me400, me500, me600;
+  std::vector<double> stepLen, radLen, intLen;
+  double eta, phi, stepT;
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetAction.h
+++ b/Validation/Geometry/interface/MaterialBudgetAction.h
@@ -9,6 +9,7 @@
 #include "Validation/Geometry/interface/MaterialBudgetHistos.h"
 #include "Validation/Geometry/interface/MaterialBudgetTrackerHistos.h"
 #include "Validation/Geometry/interface/MaterialBudgetEcalHistos.h"
+#include "Validation/Geometry/interface/MaterialBudgetMtdHistos.h"
 #include "Validation/Geometry/interface/MaterialBudgetHGCalHistos.h"
 #include "Validation/Geometry/interface/MaterialBudgetTxt.h"
 #include "Validation/Geometry/interface/TestHistoMgr.h"

--- a/Validation/Geometry/interface/MaterialBudgetAction.h
+++ b/Validation/Geometry/interface/MaterialBudgetAction.h
@@ -29,34 +29,33 @@ class EndOfRun;
 class G4StepPoint;
 class G4VTouchable;
 
-class MaterialBudgetAction : public SimWatcher, 
+class MaterialBudgetAction : public SimWatcher,
                              public Observer<const BeginOfRun*>,
-			     public Observer<const BeginOfTrack*>,
-			     public Observer<const G4Step*>,
+                             public Observer<const BeginOfTrack*>,
+                             public Observer<const G4Step*>,
                              public Observer<const EndOfTrack*>,
-			     public Observer<const EndOfRun*>
-{
- public:
+                             public Observer<const EndOfRun*> {
+public:
   MaterialBudgetAction(const edm::ParameterSet&);
   ~MaterialBudgetAction() override;
-  
- private:
-  MaterialBudgetAction(const MaterialBudgetAction&); // stop default
-  
-  const MaterialBudgetAction& operator=(const MaterialBudgetAction&); // stop default
-  
+
+private:
+  MaterialBudgetAction(const MaterialBudgetAction&);  // stop default
+
+  const MaterialBudgetAction& operator=(const MaterialBudgetAction&);  // stop default
+
   void update(const BeginOfRun*) override;
   void update(const BeginOfTrack*) override;
   void update(const G4Step*) override;
   void update(const EndOfTrack*) override;
   void update(const EndOfRun*) override;
-  
-  bool CheckTouchableInSelectedVolumes( const G4VTouchable* touch );
-  bool StopAfterProcess( const G4Step* aStep );
 
-  void save( const G4Step* aStep );
-  std::string getSubDetectorName( G4StepPoint* aStepPoint );
-  std::string getPartName( G4StepPoint* aStepPoint );
+  bool CheckTouchableInSelectedVolumes(const G4VTouchable* touch);
+  bool StopAfterProcess(const G4Step* aStep);
+
+  void save(const G4Step* aStep);
+  std::string getSubDetectorName(G4StepPoint* aStepPoint);
+  std::string getPartName(G4StepPoint* aStepPoint);
 
   std::shared_ptr<MaterialBudgetData> theData;
   std::shared_ptr<MaterialBudgetTree> theTree;
@@ -68,8 +67,8 @@ class MaterialBudgetAction : public SimWatcher,
   bool storeDecay;
   double Ekin;
   bool firstParticle;
-  
-  std::vector<G4String> theVolumeList; 
+
+  std::vector<G4String> theVolumeList;
   G4String theProcessToStop;
   std::string theHistoList;
 };

--- a/Validation/Geometry/interface/MaterialBudgetCastorHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetCastorHistos.h
@@ -15,38 +15,33 @@
 #include <vector>
 
 class MaterialBudgetCastorHistos {
-
 public:
-  
   MaterialBudgetCastorHistos(const edm::ParameterSet &p);
   virtual ~MaterialBudgetCastorHistos();
-  
-  void fillStartTrack(const G4Track*);
+
+  void fillStartTrack(const G4Track *);
   void fillPerStep(const G4Step *);
   void fillEndTrack();
-  
+
 private:
-  
-  void book(); 
+  void book();
   void fillHisto(int id, int ix);
-  
+
 private:
-
-  static const int         maxSet = 20;
-  bool                     fillHistos, printSum;
-  int                      binEta, binPhi;
-  double                   etaLow, etaHigh;
+  static const int maxSet = 20;
+  bool fillHistos, printSum;
+  int binEta, binPhi;
+  double etaLow, etaHigh;
   std::vector<std::string> matList;
-  std::vector<double>      stepLength, radLength, intLength;
-  TH1F                     *me400[maxSet], *me800[maxSet];
-  TH2F                     *me1200[maxSet];
-  TProfile                 *me100[maxSet], *me200[maxSet], *me300[maxSet];
-  TProfile                 *me500[maxSet], *me600[maxSet], *me700[maxSet];
-  TProfile2D               *me900[maxSet], *me1000[maxSet],*me1100[maxSet];
-  int                      id1, id2, steps;
-  double                   radLen, intLen, stepLen;
-  double                   eta, phi;
+  std::vector<double> stepLength, radLength, intLength;
+  TH1F *me400[maxSet], *me800[maxSet];
+  TH2F *me1200[maxSet];
+  TProfile *me100[maxSet], *me200[maxSet], *me300[maxSet];
+  TProfile *me500[maxSet], *me600[maxSet], *me700[maxSet];
+  TProfile2D *me900[maxSet], *me1000[maxSet], *me1100[maxSet];
+  int id1, id2, steps;
+  double radLen, intLen, stepLen;
+  double eta, phi;
 };
-
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetCastorHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetCastorHistos.h
@@ -41,7 +41,7 @@ private:
   TProfile2D *me900[maxSet], *me1000[maxSet], *me1100[maxSet];
   int id1, id2, steps;
   double radLen, intLen, stepLen;
-  double eta, phi;
+  double eta_, phi_;
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetCategorizer.h
+++ b/Validation/Geometry/interface/MaterialBudgetCategorizer.h
@@ -8,40 +8,36 @@
 #ifndef MaterialBudgetCategorizer_h
 #define MaterialBudgetCategorizer_h 1
 
-#include<string>
-#include<map>
-#include<vector>
+#include <string>
+#include <map>
+#include <vector>
 
-class  MaterialBudgetCategorizer {
-
- public:
+class MaterialBudgetCategorizer {
+public:
   MaterialBudgetCategorizer(std::string mode);
-  
-  int volume(std::string s){return theVolumeMap[s];}
-  int material(std::string s){return theMaterialMap[s];}
+
+  int volume(std::string s) { return theVolumeMap[s]; }
+  int material(std::string s) { return theMaterialMap[s]; }
   // rr
-  const std::vector<float> & x0fraction(std::string s){return theX0Map[s];}
-  const std::vector<float> & l0fraction(std::string s){return theL0Map[s];}
+  const std::vector<float>& x0fraction(std::string s) { return theX0Map[s]; }
+  const std::vector<float>& l0fraction(std::string s) { return theL0Map[s]; }
   // rr
   //HGCal
-  const std::vector<float> & HGCalx0fraction(std::string s){return theHGCalX0Map[s];}
-  const std::vector<float> & HGCall0fraction(std::string s){return theHGCalL0Map[s];}
+  const std::vector<float>& HGCalx0fraction(std::string s) { return theHGCalX0Map[s]; }
+  const std::vector<float>& HGCall0fraction(std::string s) { return theHGCalL0Map[s]; }
 
- private:
+private:
   void buildMaps();
-  void buildCategoryMap(std::string theMaterialFileName, std::map<std::string,std::vector<float> >& theMap);
-  void buildHGCalCategoryMap(std::string theMaterialFileName, std::map<std::string,std::vector<float> >& theMap);
-  std::map<std::string,int> theVolumeMap, theMaterialMap;
+  void buildCategoryMap(std::string theMaterialFileName, std::map<std::string, std::vector<float> >& theMap);
+  void buildHGCalCategoryMap(std::string theMaterialFileName, std::map<std::string, std::vector<float> >& theMap);
+  std::map<std::string, int> theVolumeMap, theMaterialMap;
   // rr
-  std::map<std::string,std::vector<float> > theX0Map;
-  std::map<std::string,std::vector<float> > theL0Map;
+  std::map<std::string, std::vector<float> > theX0Map;
+  std::map<std::string, std::vector<float> > theL0Map;
   // rr
   //HGCal
-  std::map<std::string,std::vector<float> > theHGCalX0Map;
-  std::map<std::string,std::vector<float> > theHGCalL0Map;
-
+  std::map<std::string, std::vector<float> > theHGCalX0Map;
+  std::map<std::string, std::vector<float> > theHGCalL0Map;
 };
 
 #endif
-
-    

--- a/Validation/Geometry/interface/MaterialBudgetData.h
+++ b/Validation/Geometry/interface/MaterialBudgetData.h
@@ -215,6 +215,7 @@ public:
 
   inline bool getHGCalmode(void) { return isHGCal; }
   inline void setHGCalmode(bool t) { isHGCal = t; }
+  inline void setMtdmode(bool t) { isMtd = t; }
 
 private:
   static constexpr int MAXNUMBERSTEPS = 10000;
@@ -407,6 +408,7 @@ private:
   int stepN;
   bool allStepsToTree;
   bool isHGCal;  //HGCal mode
+  bool isMtd;    //Mtd mode
 
   double densityConvertionFactor;
 };

--- a/Validation/Geometry/interface/MaterialBudgetData.h
+++ b/Validation/Geometry/interface/MaterialBudgetData.h
@@ -2,7 +2,6 @@
 #ifndef MaterialBudgetData_h
 #define MaterialBudgetData_h 1
 
-
 #include "Validation/Geometry/interface/MaterialBudgetCategorizer.h"
 
 #include "G4ThreeVector.hh"
@@ -17,422 +16,215 @@ class MaterialBudgetData;
 class G4Step;
 class G4Track;
 
-
-typedef std::map< std::string, float > msf;
+typedef std::map<std::string, float> msf;
 
 class MaterialBudgetData {
 public:
-
   MaterialBudgetData();
   ~MaterialBudgetData();
 
-  void dataStartTrack( const G4Track* aTrack );
-  void dataEndTrack( const G4Track* aTrack );
-  void dataPerStep( const G4Step* aStep );
+  void dataStartTrack(const G4Track* aTrack);
+  void dataEndTrack(const G4Track* aTrack);
+  void dataPerStep(const G4Step* aStep);
 
   void SetAllStepsToTree();
- public:
-  float getTotalMB() const {
-    return theTotalMB; }
-  
-  float getSupportFractionMB() const {
-    return theSupportFractionMB; }
-  float getSensitiveFractionMB() const {
-    return theSensitiveFractionMB; }
-  float getCablesFractionMB() const {
-    return theCablesFractionMB; }
-  float getCoolingFractionMB() const {
-    return theCoolingFractionMB; }
-  float getElectronicsFractionMB() const {
-    return theElectronicsFractionMB; }
-  float getOtherFractionMB() const {
-    return theOtherFractionMB; }
-  float getAirFractionMB() const {
-    return theAirFractionMB; }
+
+public:
+  float getTotalMB() const { return theTotalMB; }
+
+  float getSupportFractionMB() const { return theSupportFractionMB; }
+  float getSensitiveFractionMB() const { return theSensitiveFractionMB; }
+  float getCablesFractionMB() const { return theCablesFractionMB; }
+  float getCoolingFractionMB() const { return theCoolingFractionMB; }
+  float getElectronicsFractionMB() const { return theElectronicsFractionMB; }
+  float getOtherFractionMB() const { return theOtherFractionMB; }
+  float getAirFractionMB() const { return theAirFractionMB; }
   //HGCal
-  float getCopperFractionMB() const {             
-    return theCopperFractionMB; }
-  float getH_ScintillatorFractionMB() const {     
-    return theH_ScintillatorFractionMB; }
-  float getLeadFractionMB() const {                    
-    return theLeadFractionMB; }
-  float getEpoxyFractionMB() const {                    
-    return theEpoxyFractionMB; }
-  float getKaptonFractionMB() const {                    
-    return theKaptonFractionMB; }
-  float getAluminiumFractionMB() const {                    
-    return theAluminiumFractionMB; }
-  float getHGC_G10_FR4FractionMB() const {
-    return theHGC_G10_FR4FractionMB; }
-  float getSiliconFractionMB() const {                 
-    return theSiliconFractionMB; }
-  float getStainlessSteelFractionMB() const {  
-    return theStainlessSteelFractionMB; }
-  float getWCuFractionMB() const {         
-    return theWCuFractionMB; }
+  float getCopperFractionMB() const { return theCopperFractionMB; }
+  float getH_ScintillatorFractionMB() const { return theH_ScintillatorFractionMB; }
+  float getLeadFractionMB() const { return theLeadFractionMB; }
+  float getEpoxyFractionMB() const { return theEpoxyFractionMB; }
+  float getKaptonFractionMB() const { return theKaptonFractionMB; }
+  float getAluminiumFractionMB() const { return theAluminiumFractionMB; }
+  float getHGC_G10_FR4FractionMB() const { return theHGC_G10_FR4FractionMB; }
+  float getSiliconFractionMB() const { return theSiliconFractionMB; }
+  float getStainlessSteelFractionMB() const { return theStainlessSteelFractionMB; }
+  float getWCuFractionMB() const { return theWCuFractionMB; }
 
-  float getSupportMB() const {
-    return theSupportMB; }
-  float getSensitiveMB() const {
-    return theSensitiveMB; }
-  float getCablesMB() const {
-    return theCablesMB; }
-  float getCoolingMB() const {
-    return theCoolingMB; }
-  float getElectronicsMB() const {
-    return theElectronicsMB; }
-  float getOtherMB() const {
-    return theOtherMB; }
-  float getAirMB() const {
-    return theAirMB; }
+  float getSupportMB() const { return theSupportMB; }
+  float getSensitiveMB() const { return theSensitiveMB; }
+  float getCablesMB() const { return theCablesMB; }
+  float getCoolingMB() const { return theCoolingMB; }
+  float getElectronicsMB() const { return theElectronicsMB; }
+  float getOtherMB() const { return theOtherMB; }
+  float getAirMB() const { return theAirMB; }
   //HGCal
-  float getCopperMB() const {                    
-    return theCopperMB; }
-  float getH_ScintillatorMB() const {     
-    return theH_ScintillatorMB; }
-  float getLeadMB() const {                    
-    return theLeadMB; }
-  float getEpoxyMB() const {                    
-    return theEpoxyMB; }
-  float getKaptonMB() const {                    
-    return theKaptonMB; }
-  float getAluminiumMB() const {                    
-    return theAluminiumMB; }
-  float getHGC_G10_FR4MB() const {
-    return theHGC_G10_FR4MB; }
-  float getSiliconMB() const {                 
-    return theSiliconMB; }
-  float getStainlessSteelMB() const {  
-    return theStainlessSteelMB; }
-  float getWCuMB() const {         
-    return theWCuMB; }
+  float getCopperMB() const { return theCopperMB; }
+  float getH_ScintillatorMB() const { return theH_ScintillatorMB; }
+  float getLeadMB() const { return theLeadMB; }
+  float getEpoxyMB() const { return theEpoxyMB; }
+  float getKaptonMB() const { return theKaptonMB; }
+  float getAluminiumMB() const { return theAluminiumMB; }
+  float getHGC_G10_FR4MB() const { return theHGC_G10_FR4MB; }
+  float getSiliconMB() const { return theSiliconMB; }
+  float getStainlessSteelMB() const { return theStainlessSteelMB; }
+  float getWCuMB() const { return theWCuMB; }
 
-  float getSupportFractionIL() const {
-    return theSupportFractionIL; }
-  float getSensitiveFractionIL() const {
-    return theSensitiveFractionIL; }
-  float getCablesFractionIL() const {
-    return theCablesFractionIL; }
-  float getCoolingFractionIL() const {
-    return theCoolingFractionIL; }
-  float getElectronicsFractionIL() const {
-    return theElectronicsFractionIL; }
-  float getOtherFractionIL() const {
-    return theOtherFractionIL; }
-  float getAirFractionIL() const {
-    return theAirFractionIL; }
-  float getCopperFractionIL() const {                    
-    return theCopperFractionIL; }
-  float getH_ScintillatorFractionIL() const {     
-    return theH_ScintillatorFractionIL; }
-  float getLeadFractionIL() const {                    
-    return theLeadFractionIL; }
-  float getEpoxyFractionIL() const {                    
-    return theEpoxyFractionIL; }
-  float getKaptonFractionIL() const {                    
-    return theKaptonFractionIL; }
-  float getAluminiumFractionIL() const {                    
-    return theAluminiumFractionIL; }
-  float getHGC_G10_FR4FractionIL() const {
-    return theHGC_G10_FR4FractionIL; }
-  float getSiliconFractionIL() const {                 
-    return theSiliconFractionIL; }
-  float getStainlessSteelFractionIL() const {  
-    return theStainlessSteelFractionIL; }
-  float getWCuFractionIL() const {         
-    return theWCuFractionIL; }
-  float getTotalIL() const {
-    return theTotalIL; }
-  float getSupportIL() const {
-    return theSupportIL; }
-  float getSensitiveIL() const {
-    return theSensitiveIL; }
-  float getCablesIL() const {
-    return theCablesIL; }
-  float getCoolingIL() const {
-    return theCoolingIL; }
-  float getElectronicsIL() const {
-    return theElectronicsIL; }
-  float getOtherIL() const {
-    return theOtherIL; }
-  float getAirIL() const {
-    return theAirIL; }
-  float getCopperIL() const {                    
-    return theCopperIL; }
-  float getH_ScintillatorIL() const {     
-    return theH_ScintillatorIL; }
-  float getLeadIL() const {                    
-    return theLeadIL; }
-  float getEpoxyIL() const {                    
-    return theEpoxyIL; }
-  float getKaptonIL() const {                    
-    return theKaptonIL; }
-  float getAluminiumIL() const {                    
-    return theAluminiumIL; }
-  float getHGC_G10_FR4IL() const {
-    return theHGC_G10_FR4IL; }
-  float getSiliconIL() const {                 
-    return theSiliconIL; }
-  float getStainlessSteelIL() const {  
-    return theStainlessSteelIL; }
-  float getWCuIL() const {         
-    return theWCuIL; }
+  float getSupportFractionIL() const { return theSupportFractionIL; }
+  float getSensitiveFractionIL() const { return theSensitiveFractionIL; }
+  float getCablesFractionIL() const { return theCablesFractionIL; }
+  float getCoolingFractionIL() const { return theCoolingFractionIL; }
+  float getElectronicsFractionIL() const { return theElectronicsFractionIL; }
+  float getOtherFractionIL() const { return theOtherFractionIL; }
+  float getAirFractionIL() const { return theAirFractionIL; }
+  float getCopperFractionIL() const { return theCopperFractionIL; }
+  float getH_ScintillatorFractionIL() const { return theH_ScintillatorFractionIL; }
+  float getLeadFractionIL() const { return theLeadFractionIL; }
+  float getEpoxyFractionIL() const { return theEpoxyFractionIL; }
+  float getKaptonFractionIL() const { return theKaptonFractionIL; }
+  float getAluminiumFractionIL() const { return theAluminiumFractionIL; }
+  float getHGC_G10_FR4FractionIL() const { return theHGC_G10_FR4FractionIL; }
+  float getSiliconFractionIL() const { return theSiliconFractionIL; }
+  float getStainlessSteelFractionIL() const { return theStainlessSteelFractionIL; }
+  float getWCuFractionIL() const { return theWCuFractionIL; }
+  float getTotalIL() const { return theTotalIL; }
+  float getSupportIL() const { return theSupportIL; }
+  float getSensitiveIL() const { return theSensitiveIL; }
+  float getCablesIL() const { return theCablesIL; }
+  float getCoolingIL() const { return theCoolingIL; }
+  float getElectronicsIL() const { return theElectronicsIL; }
+  float getOtherIL() const { return theOtherIL; }
+  float getAirIL() const { return theAirIL; }
+  float getCopperIL() const { return theCopperIL; }
+  float getH_ScintillatorIL() const { return theH_ScintillatorIL; }
+  float getLeadIL() const { return theLeadIL; }
+  float getEpoxyIL() const { return theEpoxyIL; }
+  float getKaptonIL() const { return theKaptonIL; }
+  float getAluminiumIL() const { return theAluminiumIL; }
+  float getHGC_G10_FR4IL() const { return theHGC_G10_FR4IL; }
+  float getSiliconIL() const { return theSiliconIL; }
+  float getStainlessSteelIL() const { return theStainlessSteelIL; }
+  float getWCuIL() const { return theWCuIL; }
 
-  
-  float getEta() const {
-    return theEta; }
-  float getPhi() const {
-    return thePhi; }
-  
-  int getID() const {
-    return theID; }
-  float getPt() const {
-    return thePt; }
-  float getEnergy() const {
-    return theEnergy; }
-  float getMass() const {
-    return theMass; }
-  
-  
-  int getNumberOfSteps() const {
-    return theStepN; }
+  float getEta() const { return theEta; }
+  float getPhi() const { return thePhi; }
 
-  float getTrkLen() const {
-    return theTrkLen; }
-  std::string getPVname() const {
-    return thePVname; }
-  int getPVcopyNo() const {
-    return thePVcopyNo; }
-  float getRadLen() const {
-    return theRadLen; }
-  float getIntLen() const {
-    return theIntLen; }
-  
-  float getStepDmb( int is ) {
-    return theDmb[is];
-  }
-  float getSupportDmb( int is ) const {
-    return theSupportDmb[is]; }
-  float getSensitiveDmb( int is ) const {
-    return theSensitiveDmb[is]; }
-  float getCablesDmb( int is ) const {
-    return theCablesDmb[is]; }
-  float getCoolingDmb( int is ) const {
-    return theCoolingDmb[is]; }
-  float getElectronicsDmb( int is ) const {
-    return theElectronicsDmb[is]; }
-  float getOtherDmb( int is ) const {
-    return theOtherDmb[is]; }
-  float getAirDmb( int is ) const {
-    return theAirDmb[is]; }
-  float getCopperDmb( int is ) const {        
-    return theCopperDmb[is]; }
-  float getH_ScintillatorDmb( int is ) const {  
-    return theH_ScintillatorDmb[is]; }
-  float getLeadDmb( int is ) const {       
-    return theLeadDmb[is]; }
-  float getEpoxyDmb( int is ) const {       
-    return theEpoxyDmb[is]; }
-  float getKaptonDmb( int is ) const {       
-    return theKaptonDmb[is]; }
-  float getAluminiumDmb( int is ) const {       
-    return theAluminiumDmb[is]; }
-  float getHGC_G10_FR4Dmb( int is ) const {
-    return theHGC_G10_FR4Dmb[is]; }
-  float getSiliconDmb( int is ) const {        
-    return theSiliconDmb[is]; }
-  float getStainlessSteelDmb( int is ) const {
-    return theStainlessSteelDmb[is]; }
-  float getWCuDmb( int is ) const {          
-    return theWCuDmb[is]; }
+  int getID() const { return theID; }
+  float getPt() const { return thePt; }
+  float getEnergy() const { return theEnergy; }
+  float getMass() const { return theMass; }
 
+  int getNumberOfSteps() const { return theStepN; }
 
-  float getStepDil( int is ) {
-    return theDil[is];
-  }
-  float getSupportDil( int is ) const {
-    return theSupportDil[is]; }
-  float getSensitiveDil( int is ) const {
-    return theSensitiveDil[is]; }
-  float getCablesDil( int is ) const {
-    return theCablesDil[is]; }
-  float getCoolingDil( int is ) const {
-    return theCoolingDil[is]; }
-  float getElectronicsDil( int is ) const {
-    return theElectronicsDil[is]; }
-  float getOtherDil( int is ) const {
-    return theOtherDil[is]; }
-  float getAirDil( int is ) const {
-    return theAirDil[is]; }
-  float getCopperDil( int is ) const {        
-    return theCopperDil[is]; }
-  float getH_ScintillatorDil( int is ) const {  
-    return theH_ScintillatorDil[is]; }
-  float getLeadDil( int is ) const {       
-    return theLeadDil[is]; }
-  float getEpoxyDil( int is ) const {       
-    return theEpoxyDil[is]; }
-  float getKaptonDil( int is ) const {       
-    return theKaptonDil[is]; }
-  float getAluminiumDil( int is ) const {       
-    return theAluminiumDil[is]; }
-  float getHGC_G10_FR4Dil( int is ) const {
-    return theHGC_G10_FR4Dil[is]; }
-  float getSiliconDil( int is ) const {        
-    return theSiliconDil[is]; }
-  float getStainlessSteelDil( int is ) const {
-    return theStainlessSteelDil[is]; }
-  float getWCuDil( int is ) const {          
-    return theWCuDil[is]; }
-  
-  double getStepInitialX( int is ) {
-    return theInitialX[is];
-  }
-  double getStepInitialY( int is ) {
-    return theInitialY[is];
-  }
-  double getStepInitialZ( int is ) {
-    return theInitialZ[is];
-  }
-  double getStepFinalX( int is ) {
-    return theFinalX[is];
-  }
-  double getStepFinalY( int is ) {
-    return theFinalY[is];
-  }
-  double getStepFinalZ( int is ) {
-    return theFinalZ[is];
-  }
-  int getStepID( int is) {
-    return theStepID[is];
-  }
-  float getStepInitialPt( int is) {
-    return theStepInitialPt[is];
-  }
-  float getStepInitialEta( int is) {
-    return theStepInitialEta[is];
-  }
-  float getStepInitialPhi( int is) {
-    return theStepInitialPhi[is];
-  }
-  float getStepInitialEnergy( int is) {
-    return theStepInitialEnergy[is];
-  }
-  float getStepInitialPx( int is) {
-    return theStepInitialPx[is];
-  }
-  float getStepInitialPy( int is) {
-    return theStepInitialPy[is];
-  }
-  float getStepInitialPz( int is) {
-    return theStepInitialPz[is];
-  }
-  float getStepInitialBeta( int is) {
-    return theStepInitialBeta[is];
-  }
-  float getStepInitialGamma( int is) {
-    return theStepInitialGamma[is];
-  }
-  float getStepInitialMass( int is) {
-    return theStepInitialMass[is];
-  }
-  float getStepFinalPt( int is) {
-    return theStepFinalPt[is];
-  }
-  float getStepFinalEta( int is) {
-    return theStepFinalEta[is];
-  }
-  float getStepFinalPhi( int is) {
-    return theStepFinalPhi[is];
-  }
-  float getStepFinalEnergy( int is) {
-    return theStepFinalEnergy[is];
-  }
-  float getStepFinalPx( int is) {
-    return theStepFinalPx[is];
-  }
-  float getStepFinalPy( int is) {
-    return theStepFinalPy[is];
-  }
-  float getStepFinalPz( int is) {
-    return theStepFinalPz[is];
-  }
-  float getStepFinalBeta( int is) {
-    return theStepFinalBeta[is];
-  }
-  float getStepFinalGamma( int is) {
-    return theStepFinalGamma[is];
-  }
-  float getStepFinalMass( int is) {
-    return theStepFinalMass[is];
-  }
-  int getStepPreProcess( int is) {
-    return theStepPreProcess[is];
-  }
-  int getStepPostProcess( int is) {
-    return theStepPostProcess[is];
-  }
-  
-  int getStepVolumeID( int is ) {
-    return theVolumeID[is];
-  }
-  std::string getStepVolumeName( int is ) {
-    return theVolumeName[is];
-  }
-  int getStepVolumeCopy( int is ) {
-    return theVolumeCopy[is];
-  }
-  float getStepVolumeX( int is ) {
-    return theVolumeX[is];
-  }
-  float getStepVolumeY( int is ) {
-    return theVolumeY[is];
-  }
-  float getStepVolumeZ( int is ) {
-    return theVolumeZ[is];
-  }
-  CLHEP::HepLorentzVector getStepVolumeXaxis( int is ) {
-    return CLHEP::HepLorentzVector(theVolumeXaxis1[is],theVolumeXaxis2[is],theVolumeXaxis3[is]);
-  }
-  CLHEP::HepLorentzVector getStepVolumeYaxis( int is ) {
-    return CLHEP::HepLorentzVector(theVolumeYaxis1[is],theVolumeYaxis2[is],theVolumeYaxis3[is]);
-  }
-  CLHEP::HepLorentzVector getStepVolumeZaxis( int is ) {
-    return CLHEP::HepLorentzVector(theVolumeZaxis1[is],theVolumeZaxis2[is],theVolumeZaxis3[is]);
-  }
-  int getStepMaterialID( int is ) {
-    return theMaterialID[is];
-  }
-  std::string getStepMaterialName( int is ) {
-    return theMaterialName[is];
-  }
-  float getStepMaterialX0( int is ) {
-    return theMaterialX0[is];
-  }
-  float getStepMaterialLambda0( int is ) {
-    return theMaterialLambda0[is];
-  }
-  float getStepMaterialDensity( int is ) {
-    return theMaterialDensity[is];
-  }
-  
-  bool allStepsON() {
-    return allStepsToTree;
-  }
+  float getTrkLen() const { return theTrkLen; }
+  std::string getPVname() const { return thePVname; }
+  int getPVcopyNo() const { return thePVcopyNo; }
+  float getRadLen() const { return theRadLen; }
+  float getIntLen() const { return theIntLen; }
 
-  inline bool getHGCalmode(void) {return isHGCal;}
-  inline void setHGCalmode(bool t) {isHGCal=t;}
- 
- private:
-  
+  float getStepDmb(int is) { return theDmb[is]; }
+  float getSupportDmb(int is) const { return theSupportDmb[is]; }
+  float getSensitiveDmb(int is) const { return theSensitiveDmb[is]; }
+  float getCablesDmb(int is) const { return theCablesDmb[is]; }
+  float getCoolingDmb(int is) const { return theCoolingDmb[is]; }
+  float getElectronicsDmb(int is) const { return theElectronicsDmb[is]; }
+  float getOtherDmb(int is) const { return theOtherDmb[is]; }
+  float getAirDmb(int is) const { return theAirDmb[is]; }
+  float getCopperDmb(int is) const { return theCopperDmb[is]; }
+  float getH_ScintillatorDmb(int is) const { return theH_ScintillatorDmb[is]; }
+  float getLeadDmb(int is) const { return theLeadDmb[is]; }
+  float getEpoxyDmb(int is) const { return theEpoxyDmb[is]; }
+  float getKaptonDmb(int is) const { return theKaptonDmb[is]; }
+  float getAluminiumDmb(int is) const { return theAluminiumDmb[is]; }
+  float getHGC_G10_FR4Dmb(int is) const { return theHGC_G10_FR4Dmb[is]; }
+  float getSiliconDmb(int is) const { return theSiliconDmb[is]; }
+  float getStainlessSteelDmb(int is) const { return theStainlessSteelDmb[is]; }
+  float getWCuDmb(int is) const { return theWCuDmb[is]; }
+
+  float getStepDil(int is) { return theDil[is]; }
+  float getSupportDil(int is) const { return theSupportDil[is]; }
+  float getSensitiveDil(int is) const { return theSensitiveDil[is]; }
+  float getCablesDil(int is) const { return theCablesDil[is]; }
+  float getCoolingDil(int is) const { return theCoolingDil[is]; }
+  float getElectronicsDil(int is) const { return theElectronicsDil[is]; }
+  float getOtherDil(int is) const { return theOtherDil[is]; }
+  float getAirDil(int is) const { return theAirDil[is]; }
+  float getCopperDil(int is) const { return theCopperDil[is]; }
+  float getH_ScintillatorDil(int is) const { return theH_ScintillatorDil[is]; }
+  float getLeadDil(int is) const { return theLeadDil[is]; }
+  float getEpoxyDil(int is) const { return theEpoxyDil[is]; }
+  float getKaptonDil(int is) const { return theKaptonDil[is]; }
+  float getAluminiumDil(int is) const { return theAluminiumDil[is]; }
+  float getHGC_G10_FR4Dil(int is) const { return theHGC_G10_FR4Dil[is]; }
+  float getSiliconDil(int is) const { return theSiliconDil[is]; }
+  float getStainlessSteelDil(int is) const { return theStainlessSteelDil[is]; }
+  float getWCuDil(int is) const { return theWCuDil[is]; }
+
+  double getStepInitialX(int is) { return theInitialX[is]; }
+  double getStepInitialY(int is) { return theInitialY[is]; }
+  double getStepInitialZ(int is) { return theInitialZ[is]; }
+  double getStepFinalX(int is) { return theFinalX[is]; }
+  double getStepFinalY(int is) { return theFinalY[is]; }
+  double getStepFinalZ(int is) { return theFinalZ[is]; }
+  int getStepID(int is) { return theStepID[is]; }
+  float getStepInitialPt(int is) { return theStepInitialPt[is]; }
+  float getStepInitialEta(int is) { return theStepInitialEta[is]; }
+  float getStepInitialPhi(int is) { return theStepInitialPhi[is]; }
+  float getStepInitialEnergy(int is) { return theStepInitialEnergy[is]; }
+  float getStepInitialPx(int is) { return theStepInitialPx[is]; }
+  float getStepInitialPy(int is) { return theStepInitialPy[is]; }
+  float getStepInitialPz(int is) { return theStepInitialPz[is]; }
+  float getStepInitialBeta(int is) { return theStepInitialBeta[is]; }
+  float getStepInitialGamma(int is) { return theStepInitialGamma[is]; }
+  float getStepInitialMass(int is) { return theStepInitialMass[is]; }
+  float getStepFinalPt(int is) { return theStepFinalPt[is]; }
+  float getStepFinalEta(int is) { return theStepFinalEta[is]; }
+  float getStepFinalPhi(int is) { return theStepFinalPhi[is]; }
+  float getStepFinalEnergy(int is) { return theStepFinalEnergy[is]; }
+  float getStepFinalPx(int is) { return theStepFinalPx[is]; }
+  float getStepFinalPy(int is) { return theStepFinalPy[is]; }
+  float getStepFinalPz(int is) { return theStepFinalPz[is]; }
+  float getStepFinalBeta(int is) { return theStepFinalBeta[is]; }
+  float getStepFinalGamma(int is) { return theStepFinalGamma[is]; }
+  float getStepFinalMass(int is) { return theStepFinalMass[is]; }
+  int getStepPreProcess(int is) { return theStepPreProcess[is]; }
+  int getStepPostProcess(int is) { return theStepPostProcess[is]; }
+
+  int getStepVolumeID(int is) { return theVolumeID[is]; }
+  std::string getStepVolumeName(int is) { return theVolumeName[is]; }
+  int getStepVolumeCopy(int is) { return theVolumeCopy[is]; }
+  float getStepVolumeX(int is) { return theVolumeX[is]; }
+  float getStepVolumeY(int is) { return theVolumeY[is]; }
+  float getStepVolumeZ(int is) { return theVolumeZ[is]; }
+  CLHEP::HepLorentzVector getStepVolumeXaxis(int is) {
+    return CLHEP::HepLorentzVector(theVolumeXaxis1[is], theVolumeXaxis2[is], theVolumeXaxis3[is]);
+  }
+  CLHEP::HepLorentzVector getStepVolumeYaxis(int is) {
+    return CLHEP::HepLorentzVector(theVolumeYaxis1[is], theVolumeYaxis2[is], theVolumeYaxis3[is]);
+  }
+  CLHEP::HepLorentzVector getStepVolumeZaxis(int is) {
+    return CLHEP::HepLorentzVector(theVolumeZaxis1[is], theVolumeZaxis2[is], theVolumeZaxis3[is]);
+  }
+  int getStepMaterialID(int is) { return theMaterialID[is]; }
+  std::string getStepMaterialName(int is) { return theMaterialName[is]; }
+  float getStepMaterialX0(int is) { return theMaterialX0[is]; }
+  float getStepMaterialLambda0(int is) { return theMaterialLambda0[is]; }
+  float getStepMaterialDensity(int is) { return theMaterialDensity[is]; }
+
+  bool allStepsON() { return allStepsToTree; }
+
+  inline bool getHGCalmode(void) { return isHGCal; }
+  inline void setHGCalmode(bool t) { isHGCal = t; }
+
+private:
   static constexpr int MAXNUMBERSTEPS = 10000;
 
   float theTotalMB;
   float theEta;
-  float thePhi; 
+  float thePhi;
 
   float thePt;
-  int   theID;
+  int theID;
   float theEnergy;
   float theMass;
   float theSupportFractionMB;
@@ -510,97 +302,97 @@ public:
   float theWCuIL;
 
   int theStepN;
-  std::array<double,MAXNUMBERSTEPS> theInitialX; 
-  std::array<double,MAXNUMBERSTEPS> theInitialY;
-  std::array<double,MAXNUMBERSTEPS> theInitialZ;
+  std::array<double, MAXNUMBERSTEPS> theInitialX;
+  std::array<double, MAXNUMBERSTEPS> theInitialY;
+  std::array<double, MAXNUMBERSTEPS> theInitialZ;
 
-  std::array<double,MAXNUMBERSTEPS> theFinalX;
-  std::array<double,MAXNUMBERSTEPS> theFinalY;
-  std::array<double,MAXNUMBERSTEPS> theFinalZ;
+  std::array<double, MAXNUMBERSTEPS> theFinalX;
+  std::array<double, MAXNUMBERSTEPS> theFinalY;
+  std::array<double, MAXNUMBERSTEPS> theFinalZ;
 
-  std::array<float,MAXNUMBERSTEPS> theDmb;
-  std::array<float,MAXNUMBERSTEPS> theSupportDmb;
-  std::array<float,MAXNUMBERSTEPS> theSensitiveDmb;
-  std::array<float,MAXNUMBERSTEPS> theCablesDmb;
-  std::array<float,MAXNUMBERSTEPS> theCoolingDmb;
-  std::array<float,MAXNUMBERSTEPS> theElectronicsDmb;
-  std::array<float,MAXNUMBERSTEPS> theOtherDmb;
-  std::array<float,MAXNUMBERSTEPS> theAirDmb;
-  std::array<float,MAXNUMBERSTEPS> theCopperDmb;
-  std::array<float,MAXNUMBERSTEPS> theH_ScintillatorDmb;
-  std::array<float,MAXNUMBERSTEPS> theLeadDmb;
-  std::array<float,MAXNUMBERSTEPS> theEpoxyDmb;
-  std::array<float,MAXNUMBERSTEPS> theKaptonDmb;
-  std::array<float,MAXNUMBERSTEPS> theAluminiumDmb;
-  std::array<float,MAXNUMBERSTEPS> theHGC_G10_FR4Dmb;
-  std::array<float,MAXNUMBERSTEPS> theSiliconDmb;
-  std::array<float,MAXNUMBERSTEPS> theStainlessSteelDmb;
-  std::array<float,MAXNUMBERSTEPS> theWCuDmb;
+  std::array<float, MAXNUMBERSTEPS> theDmb;
+  std::array<float, MAXNUMBERSTEPS> theSupportDmb;
+  std::array<float, MAXNUMBERSTEPS> theSensitiveDmb;
+  std::array<float, MAXNUMBERSTEPS> theCablesDmb;
+  std::array<float, MAXNUMBERSTEPS> theCoolingDmb;
+  std::array<float, MAXNUMBERSTEPS> theElectronicsDmb;
+  std::array<float, MAXNUMBERSTEPS> theOtherDmb;
+  std::array<float, MAXNUMBERSTEPS> theAirDmb;
+  std::array<float, MAXNUMBERSTEPS> theCopperDmb;
+  std::array<float, MAXNUMBERSTEPS> theH_ScintillatorDmb;
+  std::array<float, MAXNUMBERSTEPS> theLeadDmb;
+  std::array<float, MAXNUMBERSTEPS> theEpoxyDmb;
+  std::array<float, MAXNUMBERSTEPS> theKaptonDmb;
+  std::array<float, MAXNUMBERSTEPS> theAluminiumDmb;
+  std::array<float, MAXNUMBERSTEPS> theHGC_G10_FR4Dmb;
+  std::array<float, MAXNUMBERSTEPS> theSiliconDmb;
+  std::array<float, MAXNUMBERSTEPS> theStainlessSteelDmb;
+  std::array<float, MAXNUMBERSTEPS> theWCuDmb;
 
-  std::array<float,MAXNUMBERSTEPS> theDil;
-  std::array<float,MAXNUMBERSTEPS> theSupportDil;
-  std::array<float,MAXNUMBERSTEPS> theSensitiveDil;
-  std::array<float,MAXNUMBERSTEPS> theCablesDil;
-  std::array<float,MAXNUMBERSTEPS> theCoolingDil;
-  std::array<float,MAXNUMBERSTEPS> theElectronicsDil;
-  std::array<float,MAXNUMBERSTEPS> theOtherDil;
-  std::array<float,MAXNUMBERSTEPS> theAirDil;
-  std::array<float,MAXNUMBERSTEPS> theCopperDil;
-  std::array<float,MAXNUMBERSTEPS> theH_ScintillatorDil;
-  std::array<float,MAXNUMBERSTEPS> theLeadDil;
-  std::array<float,MAXNUMBERSTEPS> theEpoxyDil;
-  std::array<float,MAXNUMBERSTEPS> theKaptonDil;
-  std::array<float,MAXNUMBERSTEPS> theAluminiumDil;
-  std::array<float,MAXNUMBERSTEPS> theHGC_G10_FR4Dil;
-  std::array<float,MAXNUMBERSTEPS> theSiliconDil;
-  std::array<float,MAXNUMBERSTEPS> theStainlessSteelDil;
-  std::array<float,MAXNUMBERSTEPS> theWCuDil;
-  
-  std::array<int,MAXNUMBERSTEPS> theVolumeID;
-  std::array<std::string,MAXNUMBERSTEPS> theVolumeName;
-  std::array<int,MAXNUMBERSTEPS>   theVolumeCopy;
-  std::array<float,MAXNUMBERSTEPS> theVolumeX;
-  std::array<float,MAXNUMBERSTEPS> theVolumeY;
-  std::array<float,MAXNUMBERSTEPS> theVolumeZ;
-  std::array<float,MAXNUMBERSTEPS> theVolumeXaxis1;
-  std::array<float,MAXNUMBERSTEPS> theVolumeXaxis2;
-  std::array<float,MAXNUMBERSTEPS> theVolumeXaxis3;
-  std::array<float,MAXNUMBERSTEPS> theVolumeYaxis1;
-  std::array<float,MAXNUMBERSTEPS> theVolumeYaxis2;
-  std::array<float,MAXNUMBERSTEPS> theVolumeYaxis3;
-  std::array<float,MAXNUMBERSTEPS> theVolumeZaxis1;
-  std::array<float,MAXNUMBERSTEPS> theVolumeZaxis2;
-  std::array<float,MAXNUMBERSTEPS> theVolumeZaxis3;
+  std::array<float, MAXNUMBERSTEPS> theDil;
+  std::array<float, MAXNUMBERSTEPS> theSupportDil;
+  std::array<float, MAXNUMBERSTEPS> theSensitiveDil;
+  std::array<float, MAXNUMBERSTEPS> theCablesDil;
+  std::array<float, MAXNUMBERSTEPS> theCoolingDil;
+  std::array<float, MAXNUMBERSTEPS> theElectronicsDil;
+  std::array<float, MAXNUMBERSTEPS> theOtherDil;
+  std::array<float, MAXNUMBERSTEPS> theAirDil;
+  std::array<float, MAXNUMBERSTEPS> theCopperDil;
+  std::array<float, MAXNUMBERSTEPS> theH_ScintillatorDil;
+  std::array<float, MAXNUMBERSTEPS> theLeadDil;
+  std::array<float, MAXNUMBERSTEPS> theEpoxyDil;
+  std::array<float, MAXNUMBERSTEPS> theKaptonDil;
+  std::array<float, MAXNUMBERSTEPS> theAluminiumDil;
+  std::array<float, MAXNUMBERSTEPS> theHGC_G10_FR4Dil;
+  std::array<float, MAXNUMBERSTEPS> theSiliconDil;
+  std::array<float, MAXNUMBERSTEPS> theStainlessSteelDil;
+  std::array<float, MAXNUMBERSTEPS> theWCuDil;
 
-  std::array<int,MAXNUMBERSTEPS>         theMaterialID;
-  std::array<std::string,MAXNUMBERSTEPS> theMaterialName;
-  std::array<float,MAXNUMBERSTEPS>       theMaterialX0;
-  std::array<float,MAXNUMBERSTEPS>       theMaterialLambda0;
-  std::array<float,MAXNUMBERSTEPS>       theMaterialDensity;
+  std::array<int, MAXNUMBERSTEPS> theVolumeID;
+  std::array<std::string, MAXNUMBERSTEPS> theVolumeName;
+  std::array<int, MAXNUMBERSTEPS> theVolumeCopy;
+  std::array<float, MAXNUMBERSTEPS> theVolumeX;
+  std::array<float, MAXNUMBERSTEPS> theVolumeY;
+  std::array<float, MAXNUMBERSTEPS> theVolumeZ;
+  std::array<float, MAXNUMBERSTEPS> theVolumeXaxis1;
+  std::array<float, MAXNUMBERSTEPS> theVolumeXaxis2;
+  std::array<float, MAXNUMBERSTEPS> theVolumeXaxis3;
+  std::array<float, MAXNUMBERSTEPS> theVolumeYaxis1;
+  std::array<float, MAXNUMBERSTEPS> theVolumeYaxis2;
+  std::array<float, MAXNUMBERSTEPS> theVolumeYaxis3;
+  std::array<float, MAXNUMBERSTEPS> theVolumeZaxis1;
+  std::array<float, MAXNUMBERSTEPS> theVolumeZaxis2;
+  std::array<float, MAXNUMBERSTEPS> theVolumeZaxis3;
 
-  std::array<int,MAXNUMBERSTEPS>   theStepID;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialPt;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialEta;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialPhi;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialEnergy;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialPx;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialPy;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialPz;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialBeta;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialGamma;
-  std::array<float,MAXNUMBERSTEPS> theStepInitialMass;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalPt;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalEta;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalPhi;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalEnergy;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalPx;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalPy;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalPz;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalBeta;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalGamma;
-  std::array<float,MAXNUMBERSTEPS> theStepFinalMass;
-  std::array<int,MAXNUMBERSTEPS>   theStepPreProcess;
-  std::array<int,MAXNUMBERSTEPS>   theStepPostProcess;
+  std::array<int, MAXNUMBERSTEPS> theMaterialID;
+  std::array<std::string, MAXNUMBERSTEPS> theMaterialName;
+  std::array<float, MAXNUMBERSTEPS> theMaterialX0;
+  std::array<float, MAXNUMBERSTEPS> theMaterialLambda0;
+  std::array<float, MAXNUMBERSTEPS> theMaterialDensity;
+
+  std::array<int, MAXNUMBERSTEPS> theStepID;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialPt;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialEta;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialPhi;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialEnergy;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialPx;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialPy;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialPz;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialBeta;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialGamma;
+  std::array<float, MAXNUMBERSTEPS> theStepInitialMass;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalPt;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalEta;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalPhi;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalEnergy;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalPx;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalPy;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalPz;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalBeta;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalGamma;
+  std::array<float, MAXNUMBERSTEPS> theStepFinalMass;
+  std::array<int, MAXNUMBERSTEPS> theStepPreProcess;
+  std::array<int, MAXNUMBERSTEPS> theStepPostProcess;
 
   float theTrkLen;
 
@@ -614,8 +406,8 @@ public:
   float theIntLen;
   int stepN;
   bool allStepsToTree;
-  bool isHGCal;   //HGCal mode
-  
+  bool isHGCal;  //HGCal mode
+
   double densityConvertionFactor;
 };
 

--- a/Validation/Geometry/interface/MaterialBudgetEcalHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetEcalHistos.h
@@ -6,21 +6,19 @@
 
 #include <string>
 
-class MaterialBudgetEcalHistos : public MaterialBudgetFormat
-{
- public:
-  MaterialBudgetEcalHistos( std::shared_ptr<MaterialBudgetData> data, 
-			    std::shared_ptr<TestHistoMgr> mgr,
-			    const std::string& fileName );   
-  ~MaterialBudgetEcalHistos() override { }
+class MaterialBudgetEcalHistos : public MaterialBudgetFormat {
+public:
+  MaterialBudgetEcalHistos(std::shared_ptr<MaterialBudgetData> data,
+                           std::shared_ptr<TestHistoMgr> mgr,
+                           const std::string& fileName);
+  ~MaterialBudgetEcalHistos() override {}
   void fillStartTrack() override;
   void fillPerStep() override;
   void fillEndTrack() override;
   void endOfRun() override;
-  
- private:
-  
-  virtual void book(); 
+
+private:
+  virtual void book();
   double* theDmb;
   double* theX;
   double* theY;
@@ -29,7 +27,6 @@ class MaterialBudgetEcalHistos : public MaterialBudgetFormat
   double* theMateId;
 
   std::shared_ptr<TestHistoMgr> hmgr;
-
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetFormat.h
+++ b/Validation/Geometry/interface/MaterialBudgetFormat.h
@@ -7,20 +7,18 @@
 class MaterialBudgetData;
 
 class MaterialBudgetFormat {
-
- public:
-  MaterialBudgetFormat( std::shared_ptr<MaterialBudgetData> data );
+public:
+  MaterialBudgetFormat(std::shared_ptr<MaterialBudgetData> data);
   virtual ~MaterialBudgetFormat() {}
 
   virtual void fillStartTrack() {}
   virtual void fillPerStep() {}
   virtual void fillEndTrack() {}
   virtual void endOfRun() {}
-  
- protected:
+
+protected:
   std::shared_ptr<MaterialBudgetData> theData;
   std::string theFileName;
-
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetForward.h
+++ b/Validation/Geometry/interface/MaterialBudgetForward.h
@@ -28,11 +28,12 @@ class MaterialBudgetForward : public SimWatcher,
                               public Observer<const EndOfTrack *> {
 public:
   MaterialBudgetForward(const edm::ParameterSet &);
+  MaterialBudgetForward(const MaterialBudgetForward &) = delete;                   // stop default
   ~MaterialBudgetForward() override;
 
-private:
-  MaterialBudgetForward(const MaterialBudgetForward &) = delete;                   // stop default
   const MaterialBudgetForward &operator=(const MaterialBudgetForward &) = delete;  // ...
+
+private:
 
   void update(const BeginOfRun *) override;
   void update(const BeginOfTrack *) override;
@@ -52,7 +53,7 @@ private:
   TProfile *me100[maxSet], *me200[maxSet], *me300[maxSet];
   TProfile2D *me500[maxSet], *me600[maxSet], *me700[maxSet];
   std::vector<double> stepLen, radLen, intLen;
-  double eta, phi, stepT;
+  double eta_, phi_, stepT;
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetForward.h
+++ b/Validation/Geometry/interface/MaterialBudgetForward.h
@@ -21,41 +21,38 @@ class EndOfTrack;
 #include <string>
 #include <vector>
 
-class MaterialBudgetForward : public SimWatcher, 
-                              public Observer<const BeginOfRun*>,
-                              public Observer<const BeginOfTrack*>,
-			      public Observer<const G4Step*>,
-                              public Observer<const EndOfTrack*> {
-
+class MaterialBudgetForward : public SimWatcher,
+                              public Observer<const BeginOfRun *>,
+                              public Observer<const BeginOfTrack *>,
+                              public Observer<const G4Step *>,
+                              public Observer<const EndOfTrack *> {
 public:
-
-  MaterialBudgetForward(const edm::ParameterSet&);
+  MaterialBudgetForward(const edm::ParameterSet &);
   ~MaterialBudgetForward() override;
-  
+
 private:
+  MaterialBudgetForward(const MaterialBudgetForward &) = delete;                   // stop default
+  const MaterialBudgetForward &operator=(const MaterialBudgetForward &) = delete;  // ...
 
-  MaterialBudgetForward(const MaterialBudgetForward&) = delete;          // stop default
-  const MaterialBudgetForward& operator=(const MaterialBudgetForward&) = delete; // ...
-  
-  void update(const BeginOfRun*) override;
-  void update(const BeginOfTrack*) override;
-  void update(const G4Step*) override;
-  void update(const EndOfTrack*) override;
+  void update(const BeginOfRun *) override;
+  void update(const BeginOfTrack *) override;
+  void update(const G4Step *) override;
+  void update(const EndOfTrack *) override;
 
-  void book(const edm::ParameterSet&);
-  bool stopAfter(const G4Step*);
-  
-  std::vector<std::string>      detTypes, detNames;
-  std::vector<int>              constituents, detLevels,regionTypes,stackOrder;
-  std::vector<double>           etaRegions, boundaries;
-  std::vector<G4LogicalVolume*> logVolumes;
-  static const int              maxSet = 25;
-  TH1F                          *me400[maxSet];
-  TH2F                          *me800[maxSet];
-  TProfile                      *me100[maxSet], *me200[maxSet], *me300[maxSet];
-  TProfile2D                    *me500[maxSet], *me600[maxSet], *me700[maxSet];
-  std::vector<double>           stepLen, radLen, intLen;
-  double                        eta, phi, stepT;
+  void book(const edm::ParameterSet &);
+  bool stopAfter(const G4Step *);
+
+  std::vector<std::string> detTypes, detNames;
+  std::vector<int> constituents, detLevels, regionTypes, stackOrder;
+  std::vector<double> etaRegions, boundaries;
+  std::vector<G4LogicalVolume *> logVolumes;
+  static const int maxSet = 25;
+  TH1F *me400[maxSet];
+  TH2F *me800[maxSet];
+  TProfile *me100[maxSet], *me200[maxSet], *me300[maxSet];
+  TProfile2D *me500[maxSet], *me600[maxSet], *me700[maxSet];
+  std::vector<double> stepLen, radLen, intLen;
+  double eta, phi, stepT;
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetHGCalHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetHGCalHistos.h
@@ -4,22 +4,19 @@
 #include "Validation/Geometry/interface/MaterialBudgetFormat.h"
 #include "Validation/Geometry/interface/TestHistoMgr.h"
 
-class MaterialBudgetHGCalHistos : public MaterialBudgetFormat
-{
+class MaterialBudgetHGCalHistos : public MaterialBudgetFormat {
 public:
-  
-  MaterialBudgetHGCalHistos( std::shared_ptr<MaterialBudgetData> data, 
-			     std::shared_ptr<TestHistoMgr> mgr,
-			     const std::string& fileName );   
-  ~MaterialBudgetHGCalHistos() override { }
+  MaterialBudgetHGCalHistos(std::shared_ptr<MaterialBudgetData> data,
+                            std::shared_ptr<TestHistoMgr> mgr,
+                            const std::string& fileName);
+  ~MaterialBudgetHGCalHistos() override {}
   void fillStartTrack() override;
   void fillPerStep() override;
   void fillEndTrack() override;
   void endOfRun() override;
-  
+
 private:
-  
-  virtual void book(); 
+  virtual void book();
   double* theDmb;
   double* theX;
   double* theY;
@@ -28,8 +25,6 @@ private:
   double* theMateId;
 
   std::shared_ptr<TestHistoMgr> hmgr;
-
 };
-
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetHcal.h
+++ b/Validation/Geometry/interface/MaterialBudgetHcal.h
@@ -22,11 +22,12 @@ class MaterialBudgetHcal : public SimWatcher,
                            public Observer<const EndOfTrack*> {
 public:
   MaterialBudgetHcal(const edm::ParameterSet&);
+  MaterialBudgetHcal(const MaterialBudgetHcal&) = delete;                   // stop default
   ~MaterialBudgetHcal() override;
 
-private:
-  MaterialBudgetHcal(const MaterialBudgetHcal&) = delete;                   // stop default
   const MaterialBudgetHcal& operator=(const MaterialBudgetHcal&) = delete;  // stop default
+
+private:
 
   void update(const BeginOfJob*) override;
   void update(const BeginOfTrack*) override;

--- a/Validation/Geometry/interface/MaterialBudgetHcal.h
+++ b/Validation/Geometry/interface/MaterialBudgetHcal.h
@@ -15,32 +15,29 @@ class BeginOfTrack;
 class G4Step;
 class EndOfTrack;
 
-class MaterialBudgetHcal : public SimWatcher, 
+class MaterialBudgetHcal : public SimWatcher,
                            public Observer<const BeginOfJob*>,
-			   public Observer<const BeginOfTrack*>,
-			   public Observer<const G4Step*>,
+                           public Observer<const BeginOfTrack*>,
+                           public Observer<const G4Step*>,
                            public Observer<const EndOfTrack*> {
-
 public:
-
   MaterialBudgetHcal(const edm::ParameterSet&);
   ~MaterialBudgetHcal() override;
-  
-private:
 
-  MaterialBudgetHcal(const MaterialBudgetHcal&) = delete; // stop default
-  const MaterialBudgetHcal& operator=(const MaterialBudgetHcal&) = delete; // stop default
-  
+private:
+  MaterialBudgetHcal(const MaterialBudgetHcal&) = delete;                   // stop default
+  const MaterialBudgetHcal& operator=(const MaterialBudgetHcal&) = delete;  // stop default
+
   void update(const BeginOfJob*) override;
   void update(const BeginOfTrack*) override;
   void update(const G4Step*) override;
   void update(const EndOfTrack*) override;
 
   bool stopAfter(const G4Step*);
-  
-  MaterialBudgetHcalHistos*   theHistoHcal;
+
+  MaterialBudgetHcalHistos* theHistoHcal;
   MaterialBudgetCastorHistos* theHistoCastor;
-  double                      rMax, zMax;
+  double rMax, zMax;
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetHcalHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetHcalHistos.h
@@ -17,51 +17,45 @@
 #include <vector>
 
 class MaterialBudgetHcalHistos {
-
 public:
-  
   MaterialBudgetHcalHistos(const edm::ParameterSet &p);
   virtual ~MaterialBudgetHcalHistos() { hend(); }
-  
+
   void fillBeginJob(const DDCompactView &);
-  void fillStartTrack(const G4Track*);
+  void fillStartTrack(const G4Track *);
   void fillPerStep(const G4Step *);
   void fillEndTrack();
-  
+
 private:
-  
-  void book(); 
+  void book();
   void fillHisto(int ii);
   void fillLayer();
   void hend();
-  std::vector<std::string> getNames(DDFilteredView& fv);
-  std::vector<double>      getDDDArray(const std::string & str,
-				       const DDsvalues_type & sv);
+  std::vector<std::string> getNames(DDFilteredView &fv);
+  std::vector<double> getDDDArray(const std::string &str, const DDsvalues_type &sv);
   bool isSensitive(std::string);
-  bool isItHF(const G4VTouchable*);
+  bool isItHF(const G4VTouchable *);
   bool isItEC(std::string);
-  
+
 private:
-
-  static const int         maxSet = 25, maxSet2 = 9;
+  static const int maxSet = 25, maxSet2 = 9;
   std::vector<std::string> sensitives, hfNames, sensitiveEC;
-  std::vector<int>         hfLevels;
-  bool                     fillHistos, printSum;
-  int                      binEta, binPhi;
-  double                   maxEta, etaLow, etaHigh;
+  std::vector<int> hfLevels;
+  bool fillHistos, printSum;
+  int binEta, binPhi;
+  double maxEta, etaLow, etaHigh;
   std::vector<std::string> matList;
-  std::vector<double>      stepLength, radLength, intLength;
-  TH1F                     *me400[maxSet], *me800[maxSet], *me1300[maxSet2];
-  TH2F                     *me1200[maxSet],*me1400[maxSet2];
-  TProfile                 *me100[maxSet], *me200[maxSet], *me300[maxSet];
-  TProfile                 *me500[maxSet], *me600[maxSet], *me700[maxSet];
-  TProfile                 *me1500[maxSet2];
-  TProfile2D               *me900[maxSet], *me1000[maxSet],*me1100[maxSet];
-  int                      id, layer, steps;
-  double                   radLen, intLen, stepLen;
-  double                   eta, phi;
-  int                      nlayHB, nlayHE, nlayHO, nlayHF;
+  std::vector<double> stepLength, radLength, intLength;
+  TH1F *me400[maxSet], *me800[maxSet], *me1300[maxSet2];
+  TH2F *me1200[maxSet], *me1400[maxSet2];
+  TProfile *me100[maxSet], *me200[maxSet], *me300[maxSet];
+  TProfile *me500[maxSet], *me600[maxSet], *me700[maxSet];
+  TProfile *me1500[maxSet2];
+  TProfile2D *me900[maxSet], *me1000[maxSet], *me1100[maxSet];
+  int id, layer, steps;
+  double radLen, intLen, stepLen;
+  double eta, phi;
+  int nlayHB, nlayHE, nlayHO, nlayHF;
 };
-
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetHistos.h
@@ -4,23 +4,20 @@
 #include "Validation/Geometry/interface/MaterialBudgetFormat.h"
 #include "Validation/Geometry/interface/TestHistoMgr.h"
 
-class MaterialBudgetHistos : public MaterialBudgetFormat
-{
+class MaterialBudgetHistos : public MaterialBudgetFormat {
 public:
-
-  MaterialBudgetHistos( std::shared_ptr<MaterialBudgetData> data, 
-			std::shared_ptr<TestHistoMgr> mgr, 
-			const std::string& fileName );   
-  ~MaterialBudgetHistos() override { }
+  MaterialBudgetHistos(std::shared_ptr<MaterialBudgetData> data,
+                       std::shared_ptr<TestHistoMgr> mgr,
+                       const std::string& fileName);
+  ~MaterialBudgetHistos() override {}
 
   void fillStartTrack() override;
   void fillPerStep() override;
   void fillEndTrack() override;
   void endOfRun() override;
-  
-private:
 
-  virtual void book();   
+private:
+  virtual void book();
 
   double* theDmb;
   double* theX;
@@ -30,8 +27,6 @@ private:
   double* theMateId;
 
   std::shared_ptr<TestHistoMgr> hmgr;
-
 };
-
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetMtdHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetMtdHistos.h
@@ -1,0 +1,30 @@
+#ifndef MaterialBudgetMtdHistos_h
+#define MaterialBudgetMtdHistos_h 1
+
+#include "Validation/Geometry/interface/MaterialBudgetFormat.h"
+#include "Validation/Geometry/interface/TestHistoMgr.h"
+
+class MaterialBudgetMtdHistos : public MaterialBudgetFormat {
+public:
+  MaterialBudgetMtdHistos(std::shared_ptr<MaterialBudgetData> data,
+                          std::shared_ptr<TestHistoMgr> mgr,
+                          const std::string& fileName);
+  ~MaterialBudgetMtdHistos() override {}
+  void fillStartTrack() override;
+  void fillPerStep() override;
+  void fillEndTrack() override;
+  void endOfRun() override;
+
+private:
+  virtual void book();
+  double* theDmb;
+  double* theX;
+  double* theY;
+  double* theZ;
+  double* theVoluId;
+  double* theMateId;
+
+  std::shared_ptr<TestHistoMgr> hmgr;
+};
+
+#endif

--- a/Validation/Geometry/interface/MaterialBudgetTrackerHistos.h
+++ b/Validation/Geometry/interface/MaterialBudgetTrackerHistos.h
@@ -4,22 +4,19 @@
 #include "Validation/Geometry/interface/MaterialBudgetFormat.h"
 #include "Validation/Geometry/interface/TestHistoMgr.h"
 
-class MaterialBudgetTrackerHistos : public MaterialBudgetFormat
-{
- public:
-  
-  MaterialBudgetTrackerHistos( std::shared_ptr<MaterialBudgetData> data, 
-			       std::shared_ptr<TestHistoMgr> mgr,
-			       const std::string& fileName );
+class MaterialBudgetTrackerHistos : public MaterialBudgetFormat {
+public:
+  MaterialBudgetTrackerHistos(std::shared_ptr<MaterialBudgetData> data,
+                              std::shared_ptr<TestHistoMgr> mgr,
+                              const std::string& fileName);
   ~MaterialBudgetTrackerHistos() override {}
   void fillStartTrack() override;
   void fillPerStep() override;
   void fillEndTrack() override;
   void endOfRun() override;
-  
- private:
-  
-  virtual void book(); 
+
+private:
+  virtual void book();
   double* theDmb;
   double* theX;
   double* theY;
@@ -28,7 +25,6 @@ class MaterialBudgetTrackerHistos : public MaterialBudgetFormat
   double* theMateId;
 
   std::shared_ptr<TestHistoMgr> hmgr;
-
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetTree.h
+++ b/Validation/Geometry/interface/MaterialBudgetTree.h
@@ -7,20 +7,17 @@
 
 #include "Validation/Geometry/interface/MaterialBudgetFormat.h"
 
-class MaterialBudgetTree : public MaterialBudgetFormat
-{
+class MaterialBudgetTree : public MaterialBudgetFormat {
 public:
-
-  MaterialBudgetTree( std::shared_ptr<MaterialBudgetData> data, const std::string& fileName );   
-  ~MaterialBudgetTree() override { }
+  MaterialBudgetTree(std::shared_ptr<MaterialBudgetData> data, const std::string& fileName);
+  ~MaterialBudgetTree() override {}
 
   void fillStartTrack() override;
   void fillPerStep() override;
   void fillEndTrack() override;
   void endOfRun() override;
-  
+
 private:
-  
   void book();  // user booking
   std::unique_ptr<TFile> theFile;
   std::unique_ptr<TTree> theTree;
@@ -30,7 +27,7 @@ private:
   float t_MB;
   float t_IL;
 
-  int   t_ParticleID;
+  int t_ParticleID;
   float t_ParticlePt;
   float t_ParticleEta;
   float t_ParticlePhi;
@@ -64,51 +61,50 @@ private:
   double t_FinalY[MAXSTEPS];
   double t_FinalZ[MAXSTEPS];
 
-  int    t_VolumeID[MAXSTEPS];
-  const char*  t_VolumeName[MAXSTEPS];
-  int    t_VolumeCopy[MAXSTEPS];
-  float  t_VolumeX[MAXSTEPS];
-  float  t_VolumeY[MAXSTEPS];
-  float  t_VolumeZ[MAXSTEPS];
-  float  t_VolumeXaxis1[MAXSTEPS];
-  float  t_VolumeXaxis2[MAXSTEPS];
-  float  t_VolumeXaxis3[MAXSTEPS];
-  float  t_VolumeYaxis1[MAXSTEPS];
-  float  t_VolumeYaxis2[MAXSTEPS];
-  float  t_VolumeYaxis3[MAXSTEPS];
-  float  t_VolumeZaxis1[MAXSTEPS];
-  float  t_VolumeZaxis2[MAXSTEPS];
-  float  t_VolumeZaxis3[MAXSTEPS];
+  int t_VolumeID[MAXSTEPS];
+  const char* t_VolumeName[MAXSTEPS];
+  int t_VolumeCopy[MAXSTEPS];
+  float t_VolumeX[MAXSTEPS];
+  float t_VolumeY[MAXSTEPS];
+  float t_VolumeZ[MAXSTEPS];
+  float t_VolumeXaxis1[MAXSTEPS];
+  float t_VolumeXaxis2[MAXSTEPS];
+  float t_VolumeXaxis3[MAXSTEPS];
+  float t_VolumeYaxis1[MAXSTEPS];
+  float t_VolumeYaxis2[MAXSTEPS];
+  float t_VolumeYaxis3[MAXSTEPS];
+  float t_VolumeZaxis1[MAXSTEPS];
+  float t_VolumeZaxis2[MAXSTEPS];
+  float t_VolumeZaxis3[MAXSTEPS];
 
-  int   t_MaterialID[MAXSTEPS];
-  const char* t_MaterialName[MAXSTEPS];  
-  float t_MaterialX0[MAXSTEPS];  
-  float t_MaterialLambda0[MAXSTEPS];  
-  float t_MaterialDensity[MAXSTEPS]; // g/cm3  
-  int   t_ParticleStepID[MAXSTEPS];  
-  float t_ParticleStepInitialPt[MAXSTEPS];  
-  float t_ParticleStepInitialEta[MAXSTEPS];  
-  float t_ParticleStepInitialPhi[MAXSTEPS];  
-  float t_ParticleStepInitialEnergy[MAXSTEPS];  
-  float t_ParticleStepInitialPx[MAXSTEPS];  
-  float t_ParticleStepInitialPy[MAXSTEPS];  
-  float t_ParticleStepInitialPz[MAXSTEPS];  
-  float t_ParticleStepInitialBeta[MAXSTEPS];  
-  float t_ParticleStepInitialGamma[MAXSTEPS];  
-  float t_ParticleStepInitialMass[MAXSTEPS];  
-  float t_ParticleStepFinalPt[MAXSTEPS];  
-  float t_ParticleStepFinalEta[MAXSTEPS];  
-  float t_ParticleStepFinalPhi[MAXSTEPS];  
-  float t_ParticleStepFinalEnergy[MAXSTEPS];  
-  float t_ParticleStepFinalPx[MAXSTEPS];  
-  float t_ParticleStepFinalPy[MAXSTEPS];  
-  float t_ParticleStepFinalPz[MAXSTEPS];  
-  float t_ParticleStepFinalBeta[MAXSTEPS];  
-  float t_ParticleStepFinalGamma[MAXSTEPS];  
-  float t_ParticleStepFinalMass[MAXSTEPS];  
-  int   t_ParticleStepPreInteraction[MAXSTEPS];  
-  int   t_ParticleStepPostInteraction[MAXSTEPS];  
-
+  int t_MaterialID[MAXSTEPS];
+  const char* t_MaterialName[MAXSTEPS];
+  float t_MaterialX0[MAXSTEPS];
+  float t_MaterialLambda0[MAXSTEPS];
+  float t_MaterialDensity[MAXSTEPS];  // g/cm3
+  int t_ParticleStepID[MAXSTEPS];
+  float t_ParticleStepInitialPt[MAXSTEPS];
+  float t_ParticleStepInitialEta[MAXSTEPS];
+  float t_ParticleStepInitialPhi[MAXSTEPS];
+  float t_ParticleStepInitialEnergy[MAXSTEPS];
+  float t_ParticleStepInitialPx[MAXSTEPS];
+  float t_ParticleStepInitialPy[MAXSTEPS];
+  float t_ParticleStepInitialPz[MAXSTEPS];
+  float t_ParticleStepInitialBeta[MAXSTEPS];
+  float t_ParticleStepInitialGamma[MAXSTEPS];
+  float t_ParticleStepInitialMass[MAXSTEPS];
+  float t_ParticleStepFinalPt[MAXSTEPS];
+  float t_ParticleStepFinalEta[MAXSTEPS];
+  float t_ParticleStepFinalPhi[MAXSTEPS];
+  float t_ParticleStepFinalEnergy[MAXSTEPS];
+  float t_ParticleStepFinalPx[MAXSTEPS];
+  float t_ParticleStepFinalPy[MAXSTEPS];
+  float t_ParticleStepFinalPz[MAXSTEPS];
+  float t_ParticleStepFinalBeta[MAXSTEPS];
+  float t_ParticleStepFinalGamma[MAXSTEPS];
+  float t_ParticleStepFinalMass[MAXSTEPS];
+  int t_ParticleStepPreInteraction[MAXSTEPS];
+  int t_ParticleStepPostInteraction[MAXSTEPS];
 };
 
 #endif

--- a/Validation/Geometry/interface/MaterialBudgetTxt.h
+++ b/Validation/Geometry/interface/MaterialBudgetTxt.h
@@ -5,11 +5,9 @@
 
 #include "Validation/Geometry/interface/MaterialBudgetFormat.h"
 
-
-class MaterialBudgetTxt : public MaterialBudgetFormat
-{
- public:
-  MaterialBudgetTxt(std::shared_ptr< MaterialBudgetData> data, const std::string& fileName );   
+class MaterialBudgetTxt : public MaterialBudgetFormat {
+public:
+  MaterialBudgetTxt(std::shared_ptr<MaterialBudgetData> data, const std::string& fileName);
   ~MaterialBudgetTxt() override;
 
   void fillStartTrack() override;
@@ -17,9 +15,8 @@ class MaterialBudgetTxt : public MaterialBudgetFormat
   void fillEndTrack() override;
   void endOfRun() override;
 
- private:
+private:
   std::ofstream* theFile;
-
 };
 
 #endif

--- a/Validation/Geometry/interface/TestHistoMgr.h
+++ b/Validation/Geometry/interface/TestHistoMgr.h
@@ -13,44 +13,39 @@
 #include <string>
 #include <memory>
 
-typedef std::map< int, TH1F* > mih1;
-typedef std::map< int, TH2F* > mih2;
-typedef std::map< int, TProfile* > mihp1;
-typedef std::map< int, TProfile2D* > mihp2;
+typedef std::map<int, TH1F*> mih1;
+typedef std::map<int, TH2F*> mih2;
+typedef std::map<int, TProfile*> mihp1;
+typedef std::map<int, TProfile2D*> mihp2;
 
-
-class TestHistoMgr 
-{
+class TestHistoMgr {
 public:
-
   TestHistoMgr();
   ~TestHistoMgr();
-  void save( const std::string& name );
-  void openSecondFile( const std::string& name );
+  void save(const std::string& name);
+  void openSecondFile(const std::string& name);
 
-  void printComparisonResult( int ih );
+  void printComparisonResult(int ih);
 
-  bool addHisto1( TH1F* ih );
-  bool addHisto2( TH2F* ih );
-  bool addHistoProf1( TProfile* ih );
-  bool addHistoProf2( TProfile2D* ih );
+  bool addHisto1(TH1F* ih);
+  bool addHisto2(TH2F* ih);
+  bool addHistoProf1(TProfile* ih);
+  bool addHistoProf2(TProfile2D* ih);
 
-  TH1F* getHisto1( int ih );
-  TH2F* getHisto2( int ih );
-  TProfile* getHistoProf1( int ih );
-  TProfile2D* getHistoProf2( int ih );
+  TH1F* getHisto1(int ih);
+  TH2F* getHisto2(int ih);
+  TProfile* getHistoProf1(int ih);
+  TProfile2D* getHistoProf2(int ih);
 
-  TH1F* getHisto1FromSecondFile( const char* hnam );
+  TH1F* getHisto1FromSecondFile(const char* hnam);
 
- private:
+private:
   mih1 theHistos1;
   mih2 theHistos2;
   mihp1 theHistoProfs1;
   mihp2 theHistoProfs2;
 
   std::unique_ptr<TFile> theFileRef;
-
 };
-
 
 #endif

--- a/Validation/Geometry/src/MaterialBudget.cc
+++ b/Validation/Geometry/src/MaterialBudget.cc
@@ -17,91 +17,88 @@
 //#define DebugLog
 
 MaterialBudget::MaterialBudget(const edm::ParameterSet& p) {
-  
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("MaterialBudget");
-  detTypes     = m_p.getParameter<std::vector<std::string> >("DetectorTypes");
+  detTypes = m_p.getParameter<std::vector<std::string> >("DetectorTypes");
   constituents = m_p.getParameter<std::vector<int> >("Constituents");
-  stackOrder   = m_p.getParameter<std::vector<int> >("StackOrder");
-  detNames     = m_p.getParameter<std::vector<std::string> >("DetectorNames");
-  detLevels    = m_p.getParameter<std::vector<int> >("DetectorLevels");
-  etaRegions   = m_p.getParameter<std::vector<double> >("EtaBoundaries");
-  regionTypes  = m_p.getParameter<std::vector<int> >("RegionTypes");
-  boundaries   = m_p.getParameter<std::vector<double> >("Boundaries");
-  edm::LogInfo("MaterialBudget") << "MaterialBudget initialized for "
-				 << detTypes.size() << " detector types";
+  stackOrder = m_p.getParameter<std::vector<int> >("StackOrder");
+  detNames = m_p.getParameter<std::vector<std::string> >("DetectorNames");
+  detLevels = m_p.getParameter<std::vector<int> >("DetectorLevels");
+  etaRegions = m_p.getParameter<std::vector<double> >("EtaBoundaries");
+  regionTypes = m_p.getParameter<std::vector<int> >("RegionTypes");
+  boundaries = m_p.getParameter<std::vector<double> >("Boundaries");
+  edm::LogInfo("MaterialBudget") << "MaterialBudget initialized for " << detTypes.size() << " detector types";
   unsigned int nc = 0;
-  for (unsigned int ii=0; ii<detTypes.size(); ++ii) {
-    edm::LogInfo("MaterialBudget") << "Type[" << ii << "] : " << detTypes[ii]
-				   << " with " << constituents[ii] <<", order "
-				   << stackOrder[ii] << " constituents --> ";
-    for (int kk=0; kk<constituents[ii]; ++kk) {
-      std::string name = "Unknown"; int level = -1;
+  for (unsigned int ii = 0; ii < detTypes.size(); ++ii) {
+    edm::LogInfo("MaterialBudget") << "Type[" << ii << "] : " << detTypes[ii] << " with " << constituents[ii]
+                                   << ", order " << stackOrder[ii] << " constituents --> ";
+    for (int kk = 0; kk < constituents[ii]; ++kk) {
+      std::string name = "Unknown";
+      int level = -1;
       if (nc < detNames.size()) {
-	name = detNames[nc]; level = detLevels[nc]; ++nc;
+        name = detNames[nc];
+        level = detLevels[nc];
+        ++nc;
       }
-      edm::LogInfo("MaterialBudget") << "    Constituent[" << kk << "]: "
-				     << name << " at level " << level;
+      edm::LogInfo("MaterialBudget") << "    Constituent[" << kk << "]: " << name << " at level " << level;
     }
   }
-  edm::LogInfo("MaterialBudget") << "MaterialBudget Stop condition for "
-				 << etaRegions.size() << " eta regions";
-  for (unsigned int ii=0; ii<etaRegions.size(); ++ii) {
-    edm::LogInfo("MaterialBudget") << "Region[" << ii << "] : Eta < " 
-				   << etaRegions[ii] << " boundary type "
-				   << regionTypes[ii] << " limit "
-				   << boundaries[ii];
+  edm::LogInfo("MaterialBudget") << "MaterialBudget Stop condition for " << etaRegions.size() << " eta regions";
+  for (unsigned int ii = 0; ii < etaRegions.size(); ++ii) {
+    edm::LogInfo("MaterialBudget") << "Region[" << ii << "] : Eta < " << etaRegions[ii] << " boundary type "
+                                   << regionTypes[ii] << " limit " << boundaries[ii];
   }
   book(m_p);
 }
 
-MaterialBudget::~MaterialBudget() {
-}
+MaterialBudget::~MaterialBudget() {}
 
-void MaterialBudget::update(const BeginOfRun* ) {
+void MaterialBudget::update(const BeginOfRun*) {
+  const G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();
+  std::vector<G4LogicalVolume*>::const_iterator lvcite;
 
-  const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
-  std::vector<G4LogicalVolume *>::const_iterator lvcite;
-
-  unsigned int kount=detNames.size();
-  for (unsigned int ii=0; ii<kount; ++ii) 
+  unsigned int kount = detNames.size();
+  for (unsigned int ii = 0; ii < kount; ++ii)
     logVolumes.push_back(nullptr);
 
   for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) {
-    for (unsigned int ii=0; ii<detNames.size(); ++ii) {
-      if (strcmp(detNames[ii].c_str(),(*lvcite)->GetName().c_str()) == 0) {
-	logVolumes[ii] = (*lvcite);
-	kount--;
-	break;
+    for (unsigned int ii = 0; ii < detNames.size(); ++ii) {
+      if (strcmp(detNames[ii].c_str(), (*lvcite)->GetName().c_str()) == 0) {
+        logVolumes[ii] = (*lvcite);
+        kount--;
+        break;
       }
     }
-    if (kount <= 0) break;
+    if (kount <= 0)
+      break;
   }
-  edm::LogInfo("MaterialBudget") << "MaterialBudget::Finds " 
-				 << detNames.size()-kount << " out of "
-				 << detNames.size() << " LV addresses";
-  for (unsigned int ii=0; ii<detNames.size(); ++ii) {
+  edm::LogInfo("MaterialBudget") << "MaterialBudget::Finds " << detNames.size() - kount << " out of " << detNames.size()
+                                 << " LV addresses";
+  for (unsigned int ii = 0; ii < detNames.size(); ++ii) {
     std::string name("Unknown");
-    if (logVolumes[ii] != nullptr)  name = logVolumes[ii]->GetName();
-    edm::LogInfo("MaterialBudget") << "LV[" << ii << "] : " << detNames[ii]
-				   << " Address " << logVolumes[ii] << " | " 
-				   << name;
+    if (logVolumes[ii] != nullptr)
+      name = logVolumes[ii]->GetName();
+    edm::LogInfo("MaterialBudget") << "LV[" << ii << "] : " << detNames[ii] << " Address " << logVolumes[ii] << " | "
+                                   << name;
   }
 
-  for (unsigned int ii=0; ii<(detTypes.size()+1); ++ii) {
-    stepLen.push_back(0); radLen.push_back(0); intLen.push_back(0);
+  for (unsigned int ii = 0; ii < (detTypes.size() + 1); ++ii) {
+    stepLen.push_back(0);
+    radLen.push_back(0);
+    intLen.push_back(0);
   }
   stackOrder.push_back(0);
 }
 
 void MaterialBudget::update(const BeginOfTrack* trk) {
-
-  for (unsigned int ii=0; ii<(detTypes.size()+1); ++ii) {
-    stepLen[ii] = 0; radLen[ii] = 0; intLen[ii] = 0;
+  for (unsigned int ii = 0; ii < (detTypes.size() + 1); ++ii) {
+    stepLen[ii] = 0;
+    radLen[ii] = 0;
+    intLen[ii] = 0;
   }
 
-  const G4Track * aTrack = (*trk)(); // recover G4 pointer if wanted
-  const G4ThreeVector& mom = aTrack->GetMomentum() ;
-  if (mom.theta() != 0 ) {
+  const G4Track* aTrack = (*trk)();  // recover G4 pointer if wanted
+  const G4ThreeVector& mom = aTrack->GetMomentum();
+  if (mom.theta() != 0) {
     eta = mom.eta();
   } else {
     eta = -99;
@@ -111,89 +108,77 @@ void MaterialBudget::update(const BeginOfTrack* trk) {
 
 #ifdef DebugLog
   double theEnergy = aTrack->GetTotalEnergy();
-  int    theID     = (int)(aTrack->GetDefinition()->GetPDGEncoding());
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Track "
-				 << aTrack->GetTrackID() << " Code " << theID
-				 << " Energy " <<theEnergy/CLHEP::GeV
-				 << " GeV; Eta " << eta << " Phi " 
-				 << phi/CLHEP::deg << " PT "
-				 << mom.perp()/CLHEP::GeV << " GeV *****";
+  int theID = (int)(aTrack->GetDefinition()->GetPDGEncoding());
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Track " << aTrack->GetTrackID() << " Code " << theID
+                                 << " Energy " << theEnergy / CLHEP::GeV << " GeV; Eta " << eta << " Phi "
+                                 << phi / CLHEP::deg << " PT " << mom.perp() / CLHEP::GeV << " GeV *****";
 #endif
 }
- 
-void MaterialBudget::update(const G4Step* aStep) {
 
+void MaterialBudget::update(const G4Step* aStep) {
   //---------- each step
-  G4Material * material = aStep->GetPreStepPoint()->GetMaterial();
-  double step    = aStep->GetStepLength();
-  double radl    = material->GetRadlen();
-  double intl    = material->GetNuclearInterLength();
+  G4Material* material = aStep->GetPreStepPoint()->GetMaterial();
+  double step = aStep->GetStepLength();
+  double radl = material->GetRadlen();
+  double intl = material->GetNuclearInterLength();
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   unsigned int indx = detTypes.size();
   unsigned int nc = 0;
-  for (unsigned int ii=0; ii<detTypes.size(); ++ii) {
-    for (int kk=0; kk<constituents[ii]; ++kk) {
-      if (detLevels[nc+kk] <= (int)((touch->GetHistoryDepth())+1)) {
-	int jj = (int)((touch->GetHistoryDepth())+1)-detLevels[nc+kk];
-        if ((touch->GetVolume(jj)->GetLogicalVolume()) == logVolumes[nc+kk]) {
-	  indx = ii;
-	  break;
-	}
+  for (unsigned int ii = 0; ii < detTypes.size(); ++ii) {
+    for (int kk = 0; kk < constituents[ii]; ++kk) {
+      if (detLevels[nc + kk] <= (int)((touch->GetHistoryDepth()) + 1)) {
+        int jj = (int)((touch->GetHistoryDepth()) + 1) - detLevels[nc + kk];
+        if ((touch->GetVolume(jj)->GetLogicalVolume()) == logVolumes[nc + kk]) {
+          indx = ii;
+          break;
+        }
       }
     }
     nc += (unsigned int)(constituents[ii]);
-    if (indx == ii) break;
+    if (indx == ii)
+      break;
   }
 
-  stepT         += step;
-  stepLen[indx]  = stepT;
-  radLen[indx]  += (step/radl);
-  intLen[indx]  += (step/intl);
+  stepT += step;
+  stepLen[indx] = stepT;
+  radLen[indx] += (step / radl);
+  intLen[indx] += (step / intl);
 #ifdef DebugLog
-  edm::LogInfo("MaterialBudget") << "MaterialBudget::Step in "
-				 << touch->GetVolume(0)->GetLogicalVolume()->GetName()
-				 << " Index " << indx <<" Step " << step 
-				 << " RadL " << step/radl << " IntL " 
-				 << step/intl;
+  edm::LogInfo("MaterialBudget") << "MaterialBudget::Step in " << touch->GetVolume(0)->GetLogicalVolume()->GetName()
+                                 << " Index " << indx << " Step " << step << " RadL " << step / radl << " IntL "
+                                 << step / intl;
 #endif
   //----- Stop tracking after selected position
   if (stopAfter(aStep)) {
     G4Track* track = aStep->GetTrack();
-    track->SetTrackStatus( fStopAndKill );
+    track->SetTrackStatus(fStopAndKill);
   }
 }
 
-
 void MaterialBudget::update(const EndOfTrack* trk) {
-
-  for (unsigned int ii=0; ii<detTypes.size(); ++ii) {
-    for (unsigned int jj=0; jj<=detTypes.size(); ++jj) {
-      if (stackOrder[jj] == (int)(ii+1)) {
-	for (unsigned int kk=0; kk<=detTypes.size(); ++kk) {
-	  if (stackOrder[kk] == (int)(ii)) {
-	    radLen[jj]  += radLen[kk];
-	    intLen[jj]  += intLen[kk];
+  for (unsigned int ii = 0; ii < detTypes.size(); ++ii) {
+    for (unsigned int jj = 0; jj <= detTypes.size(); ++jj) {
+      if (stackOrder[jj] == (int)(ii + 1)) {
+        for (unsigned int kk = 0; kk <= detTypes.size(); ++kk) {
+          if (stackOrder[kk] == (int)(ii)) {
+            radLen[jj] += radLen[kk];
+            intLen[jj] += intLen[kk];
 #ifdef DebugLog
-	    edm::LogInfo("MaterialBudget") << "MaterialBudget::Add " 
-					   << kk << ":" << stackOrder[kk] 
-					   << " to " << jj <<":" 
-					   << stackOrder[jj] <<" RadL "
-					   << radLen[kk] << " : " << radLen[jj]
-					   << " IntL " << intLen[kk] << " : "
-					   << intLen[jj] <<" StepL " 
-					   << stepLen[kk]<< " : " 
-					   << stepLen[jj];
+            edm::LogInfo("MaterialBudget")
+                << "MaterialBudget::Add " << kk << ":" << stackOrder[kk] << " to " << jj << ":" << stackOrder[jj]
+                << " RadL " << radLen[kk] << " : " << radLen[jj] << " IntL " << intLen[kk] << " : " << intLen[jj]
+                << " StepL " << stepLen[kk] << " : " << stepLen[jj];
 #endif
-	    break;
-	  }
-	}
-	break;
+            break;
+          }
+        }
+        break;
       }
     }
   }
 
-  for (unsigned int ii=0; ii<=detTypes.size(); ++ii) {
+  for (unsigned int ii = 0; ii <= detTypes.size(); ++ii) {
     me100[ii]->Fill(eta, radLen[ii]);
     me200[ii]->Fill(eta, intLen[ii]);
     me300[ii]->Fill(eta, stepLen[ii]);
@@ -202,99 +187,93 @@ void MaterialBudget::update(const EndOfTrack* trk) {
     me600[ii]->Fill(phi, stepLen[ii]);
 #ifdef DebugLog
     std::string name("Unknown");
-    if (ii < detTypes.size()) name = detTypes[ii];
-    edm::LogInfo("MaterialBudget") << "MaterialBudget::Volume[" << ii
-				   << "]: " << name << " eta " << eta 
-				   << " == Step " << stepLen[ii] << " RadL " 
-				   << radLen[ii] << " IntL " << intLen[ii];
+    if (ii < detTypes.size())
+      name = detTypes[ii];
+    edm::LogInfo("MaterialBudget") << "MaterialBudget::Volume[" << ii << "]: " << name << " eta " << eta << " == Step "
+                                   << stepLen[ii] << " RadL " << radLen[ii] << " IntL " << intLen[ii];
 #endif
   }
 }
 
 void MaterialBudget::book(const edm::ParameterSet& m_p) {
-
   // Book histograms
   edm::Service<TFileService> tfile;
 
-  if ( !tfile.isAvailable() )
+  if (!tfile.isAvailable())
     throw cms::Exception("BadConfig") << "TFileService unavailable: "
                                       << "please add it to config file";
 
-  int    binEta  = m_p.getUntrackedParameter<int>("NBinEta", 320);
-  int    binPhi  = m_p.getUntrackedParameter<int>("NBinPhi", 180);
-  double minEta  = m_p.getUntrackedParameter<double>("MinEta",-8.0);
-  double maxEta  = m_p.getUntrackedParameter<double>("MaxEta", 8.0);
-  double maxPhi  = CLHEP::pi;
+  int binEta = m_p.getUntrackedParameter<int>("NBinEta", 320);
+  int binPhi = m_p.getUntrackedParameter<int>("NBinPhi", 180);
+  double minEta = m_p.getUntrackedParameter<double>("MinEta", -8.0);
+  double maxEta = m_p.getUntrackedParameter<double>("MaxEta", 8.0);
+  double maxPhi = CLHEP::pi;
   edm::LogInfo("MaterialBudget") << "MaterialBudget: Booking user "
                                  << "histos === with " << binEta << " bins "
-                                 << "in eta from " << minEta << " to "
-                                 << maxEta << " and " << binPhi << " bins "
-                                 << "in phi from " << -maxPhi << " to "
-                                 << maxPhi;
+                                 << "in eta from " << minEta << " to " << maxEta << " and " << binPhi << " bins "
+                                 << "in phi from " << -maxPhi << " to " << maxPhi;
 
-  char  name[20], title[80];
+  char name[20], title[80];
   std::string named;
-  for (unsigned int i=0; i<=detTypes.size(); i++) {
-    if (i >= detTypes.size()) named = "Unknown";
-    else                      named = detTypes[i];
-    sprintf(name, "%d", i+100);
+  for (unsigned int i = 0; i <= detTypes.size(); i++) {
+    if (i >= detTypes.size())
+      named = "Unknown";
+    else
+      named = detTypes[i];
+    sprintf(name, "%d", i + 100);
     sprintf(title, "MB(X0) prof Eta in %s", named.c_str());
-    me100.push_back(tfile->make<TProfile>(name,title, binEta, minEta, maxEta));
-    sprintf(name, "%d", i+200);
+    me100.push_back(tfile->make<TProfile>(name, title, binEta, minEta, maxEta));
+    sprintf(name, "%d", i + 200);
     sprintf(title, "MB(L0) prof Eta in %s", named.c_str());
-    me200.push_back(tfile->make<TProfile>(name,title, binEta, minEta, maxEta));
-    sprintf(name, "%d", i+300);
+    me200.push_back(tfile->make<TProfile>(name, title, binEta, minEta, maxEta));
+    sprintf(name, "%d", i + 300);
     sprintf(title, "MB(Step) prof Eta in %s", named.c_str());
-    me300.push_back(tfile->make<TProfile>(name,title, binEta, minEta, maxEta));
-    sprintf(name, "%d", i+400);
+    me300.push_back(tfile->make<TProfile>(name, title, binEta, minEta, maxEta));
+    sprintf(name, "%d", i + 400);
     sprintf(title, "MB(X0) prof Phi in %s", named.c_str());
-    me400.push_back(tfile->make<TProfile>(name,title, binPhi,-maxPhi, maxPhi));
-    sprintf(name, "%d", i+500);
+    me400.push_back(tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi));
+    sprintf(name, "%d", i + 500);
     sprintf(title, "MB(L0) prof Phi in %s", named.c_str());
-    me500.push_back(tfile->make<TProfile>(name,title, binPhi,-maxPhi, maxPhi));
-    sprintf(name, "%d", i+600);
+    me500.push_back(tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi));
+    sprintf(name, "%d", i + 600);
     sprintf(title, "MB(Step) prof Phi in %s", named.c_str());
-    me600.push_back(tfile->make<TProfile>(name,title, binPhi,-maxPhi, maxPhi));
+    me600.push_back(tfile->make<TProfile>(name, title, binPhi, -maxPhi, maxPhi));
   }
 
   edm::LogInfo("MaterialBudget") << "MaterialBudget: Booking user "
                                  << "histos done ===";
-
 }
 
 bool MaterialBudget::stopAfter(const G4Step* aStep) {
-
-  G4ThreeVector hitPoint    = aStep->GetPreStepPoint()->GetPosition();
-  if (aStep->GetPostStepPoint() != nullptr) 
+  G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
+  if (aStep->GetPostStepPoint() != nullptr)
     hitPoint = aStep->GetPostStepPoint()->GetPosition();
-  double rr    = hitPoint.perp();
-  double zz    = std::abs(hitPoint.z());
+  double rr = hitPoint.perp();
+  double zz = std::abs(hitPoint.z());
 
-  bool   flag(false);
-  for (unsigned int ii=0; ii<etaRegions.size(); ++ii) {
+  bool flag(false);
+  for (unsigned int ii = 0; ii < etaRegions.size(); ++ii) {
 #ifdef DebugLog
-    edm::LogInfo("MaterialBudget") << " MaterialBudget::Eta " << eta 
-				   << " in Region[" << ii << "] with " 
-				   << etaRegions[ii] << " type "   
-				   << regionTypes[ii] << "|" << boundaries[ii];
+    edm::LogInfo("MaterialBudget") << " MaterialBudget::Eta " << eta << " in Region[" << ii << "] with "
+                                   << etaRegions[ii] << " type " << regionTypes[ii] << "|" << boundaries[ii];
 #endif
     if (fabs(eta) < etaRegions[ii]) {
       if (regionTypes[ii] == 0) {
-	if (rr >= boundaries[ii]-0.001) flag = true;
+        if (rr >= boundaries[ii] - 0.001)
+          flag = true;
       } else {
-	if (zz >= boundaries[ii]-0.001) flag = true;
+        if (zz >= boundaries[ii] - 0.001)
+          flag = true;
       }
 #ifdef DebugLog
       if (flag)
-	edm::LogInfo("MaterialBudget") <<" MaterialBudget::Stop after R = " 
-				       << rr << " and Z = " << zz;
+        edm::LogInfo("MaterialBudget") << " MaterialBudget::Stop after R = " << rr << " and Z = " << zz;
 #endif
       break;
     }
   }
 #ifdef DebugLog
-  edm::LogInfo("MaterialBudget") <<" MaterialBudget:: R = " << rr 
-				 << " and Z = "  << zz << " Flag " << flag;
+  edm::LogInfo("MaterialBudget") << " MaterialBudget:: R = " << rr << " and Z = " << zz << " Flag " << flag;
 #endif
   return flag;
 }

--- a/Validation/Geometry/src/MaterialBudget.cc
+++ b/Validation/Geometry/src/MaterialBudget.cc
@@ -99,19 +99,19 @@ void MaterialBudget::update(const BeginOfTrack* trk) {
   const G4Track* aTrack = (*trk)();  // recover G4 pointer if wanted
   const G4ThreeVector& mom = aTrack->GetMomentum();
   if (mom.theta() != 0) {
-    eta = mom.eta();
+    eta_ = mom.eta();
   } else {
-    eta = -99;
+    eta_ = -99;
   }
-  phi = mom.phi();
+  phi_ = mom.phi();
   stepT = 0;
 
 #ifdef DebugLog
   double theEnergy = aTrack->GetTotalEnergy();
   int theID = (int)(aTrack->GetDefinition()->GetPDGEncoding());
   edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Track " << aTrack->GetTrackID() << " Code " << theID
-                                 << " Energy " << theEnergy / CLHEP::GeV << " GeV; Eta " << eta << " Phi "
-                                 << phi / CLHEP::deg << " PT " << mom.perp() / CLHEP::GeV << " GeV *****";
+                                 << " Energy " << theEnergy / CLHEP::GeV << " GeV; Eta " << eta_ << " Phi "
+                                 << phi_ / CLHEP::deg << " PT " << mom.perp() / CLHEP::GeV << " GeV *****";
 #endif
 }
 
@@ -179,17 +179,17 @@ void MaterialBudget::update(const EndOfTrack* trk) {
   }
 
   for (unsigned int ii = 0; ii <= detTypes.size(); ++ii) {
-    me100[ii]->Fill(eta, radLen[ii]);
-    me200[ii]->Fill(eta, intLen[ii]);
-    me300[ii]->Fill(eta, stepLen[ii]);
-    me400[ii]->Fill(phi, radLen[ii]);
-    me500[ii]->Fill(phi, intLen[ii]);
-    me600[ii]->Fill(phi, stepLen[ii]);
+    me100[ii]->Fill(eta_, radLen[ii]);
+    me200[ii]->Fill(eta_, intLen[ii]);
+    me300[ii]->Fill(eta_, stepLen[ii]);
+    me400[ii]->Fill(phi_, radLen[ii]);
+    me500[ii]->Fill(phi_, intLen[ii]);
+    me600[ii]->Fill(phi_, stepLen[ii]);
 #ifdef DebugLog
     std::string name("Unknown");
     if (ii < detTypes.size())
       name = detTypes[ii];
-    edm::LogInfo("MaterialBudget") << "MaterialBudget::Volume[" << ii << "]: " << name << " eta " << eta << " == Step "
+    edm::LogInfo("MaterialBudget") << "MaterialBudget::Volume[" << ii << "]: " << name << " eta " << eta_ << " == Step "
                                    << stepLen[ii] << " RadL " << radLen[ii] << " IntL " << intLen[ii];
 #endif
   }
@@ -254,10 +254,10 @@ bool MaterialBudget::stopAfter(const G4Step* aStep) {
   bool flag(false);
   for (unsigned int ii = 0; ii < etaRegions.size(); ++ii) {
 #ifdef DebugLog
-    edm::LogInfo("MaterialBudget") << " MaterialBudget::Eta " << eta << " in Region[" << ii << "] with "
+    edm::LogInfo("MaterialBudget") << " MaterialBudget::Eta " << eta_ << " in Region[" << ii << "] with "
                                    << etaRegions[ii] << " type " << regionTypes[ii] << "|" << boundaries[ii];
 #endif
-    if (fabs(eta) < etaRegions[ii]) {
+    if (fabs(eta_) < etaRegions[ii]) {
       if (regionTypes[ii] == 0) {
         if (rr >= boundaries[ii] - 0.001)
           flag = true;

--- a/Validation/Geometry/src/MaterialBudgetAction.cc
+++ b/Validation/Geometry/src/MaterialBudgetAction.cc
@@ -29,308 +29,295 @@
 #include <iostream>
 
 //-------------------------------------------------------------------------
-MaterialBudgetAction::MaterialBudgetAction(const edm::ParameterSet& iPSet)
-{
+MaterialBudgetAction::MaterialBudgetAction(const edm::ParameterSet& iPSet) {
   theData = std::make_shared<MaterialBudgetData>();
 
   edm::ParameterSet m_Anal = iPSet.getParameter<edm::ParameterSet>("MaterialBudgetAction");
-  
+
   //---- Accumulate material budget only inside selected volumes
   std::string theHistoList = m_Anal.getParameter<std::string>("HistogramList");
-  std::vector<std::string> volList = m_Anal.getParameter< std::vector<std::string> >("SelectedVolumes");
+  std::vector<std::string> volList = m_Anal.getParameter<std::vector<std::string> >("SelectedVolumes");
 
   edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: List of the selected volumes:";
-  for( const auto& it : volList) {
-    if( it != "None" ) {
+  for (const auto& it : volList) {
+    if (it != "None") {
       theVolumeList.push_back(it);
-      edm::LogInfo("MaterialBudget") << it ;
+      edm::LogInfo("MaterialBudget") << it;
     }
   }
 
   // log
-  if(theHistoList == "Tracker" ) {
+  if (theHistoList == "Tracker") {
     edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: running in Tracker Mode";
-  } 
-  else if(theHistoList == "ECAL" ) {
+  } else if (theHistoList == "ECAL") {
     edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: running in Ecal Mode";
-  } 
-  else if(theHistoList == "HGCal" ) {
+  } else if (theHistoList == "HGCal") {
     edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: running in HGCal Mode";
-  } 
-  else {
+  } else {
     edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: running in General Mode";
   }
-    
+
   //---- Stop track when a process occurs
   theProcessToStop = m_Anal.getParameter<std::string>("StopAfterProcess");
   LogDebug("MaterialBudget") << "MaterialBudgetAction: stop at process " << theProcessToStop;
 
-  //---- Save histos to ROOT file 
+  //---- Save histos to ROOT file
   std::string saveToHistosFile = m_Anal.getParameter<std::string>("HistosFile");
-  if( saveToHistosFile != "None" ) {
+  if (saveToHistosFile != "None") {
     saveToHistos = true;
     edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: saving histograms to " << saveToHistosFile;
     theHistoMgr = std::make_shared<TestHistoMgr>();
-    if(theHistoList == "Tracker" ) {
+    if (theHistoList == "Tracker") {
       theHistos = std::make_shared<MaterialBudgetTrackerHistos>(theData, theHistoMgr, saveToHistosFile);
-    }
-    else if (theHistoList == "ECAL") {
+    } else if (theHistoList == "ECAL") {
       theHistos = std::make_shared<MaterialBudgetEcalHistos>(theData, theHistoMgr, saveToHistosFile);
-    }
-    else if (theHistoList == "HGCal") {
-      theHistos = std::make_shared<MaterialBudgetHGCalHistos>( theData, theHistoMgr, saveToHistosFile );
+    } else if (theHistoList == "HGCal") {
+      theHistos = std::make_shared<MaterialBudgetHGCalHistos>(theData, theHistoMgr, saveToHistosFile);
       //In HGCal mode, so tell data class
       theData->setHGCalmode(true);
-    }
-    else {
-      theHistos = std::make_shared<MaterialBudgetHistos>( theData, theHistoMgr, saveToHistosFile ); 
+    } else {
+      theHistos = std::make_shared<MaterialBudgetHistos>(theData, theHistoMgr, saveToHistosFile);
     }
   } else {
     edm::LogWarning("MaterialBudget") << "MaterialBudgetAction: No histograms file specified";
     saveToHistos = false;
   }
-  
+
   //---- Save material budget info to TEXT file
   std::string saveToTxtFile = m_Anal.getParameter<std::string>("TextFile");
-  if( saveToTxtFile != "None" ) {
+  if (saveToTxtFile != "None") {
     saveToTxt = true;
     edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: saving text info to " << saveToTxtFile;
-    theTxt = std::make_shared<MaterialBudgetTxt>( theData, saveToTxtFile );
+    theTxt = std::make_shared<MaterialBudgetTxt>(theData, saveToTxtFile);
   } else {
     saveToTxt = false;
   }
-  
+
   //---- Compute all the steps even if not stored on file
-  bool allSteps = m_Anal.getParameter<bool>("AllStepsToTree");  
+  bool allSteps = m_Anal.getParameter<bool>("AllStepsToTree");
   edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: all steps are computed " << allSteps;
-  if( allSteps ) theData->SetAllStepsToTree();
-  
+  if (allSteps)
+    theData->SetAllStepsToTree();
+
   //---- Save tree to ROOT file
   std::string saveToTreeFile = m_Anal.getParameter<std::string>("TreeFile");
-  if( saveToTreeFile != "None" ) {
+  if (saveToTreeFile != "None") {
     saveToTree = true;
-    theTree = std::make_shared<MaterialBudgetTree>( theData, saveToTreeFile );
+    theTree = std::make_shared<MaterialBudgetTree>(theData, saveToTreeFile);
   } else {
     saveToTree = false;
   }
   edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: saving ROOT TTree to " << saveToTreeFile;
-  
+
   //---- Track the first decay products of the main particle
   // if their kinetic energy is greater than  Ekin
-  storeDecay = m_Anal.getUntrackedParameter<bool>("storeDecay",false);  
-  Ekin       = m_Anal.getUntrackedParameter<double>("EminDecayProd",1000.0); // MeV
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: decay products steps are stored (" 
-				 << storeDecay << ") if their kinetic energy is greater than " 
-				 << Ekin << " MeV";
+  storeDecay = m_Anal.getUntrackedParameter<bool>("storeDecay", false);
+  Ekin = m_Anal.getUntrackedParameter<double>("EminDecayProd", 1000.0);  // MeV
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: decay products steps are stored (" << storeDecay
+                                 << ") if their kinetic energy is greater than " << Ekin << " MeV";
   firstParticle = false;
 }
 
+//-------------------------------------------------------------------------
+MaterialBudgetAction::~MaterialBudgetAction() {}
 
 //-------------------------------------------------------------------------
-MaterialBudgetAction::~MaterialBudgetAction()
-{
-}
-
-//-------------------------------------------------------------------------
-void MaterialBudgetAction::update(const BeginOfRun* )
-{
+void MaterialBudgetAction::update(const BeginOfRun*) {
   //----- Check that selected volumes are indeed part of the geometry
   const G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();
 
-  for(const auto& volcite: theVolumeList) {
+  for (const auto& volcite : theVolumeList) {
     bool volFound = false;
-    for(const auto& lvcite: *lvs) {
-      if( lvcite->GetName() == volcite )  {
-	volFound = true;
-	break;
+    for (const auto& lvcite : *lvs) {
+      if (lvcite->GetName() == volcite) {
+        volFound = true;
+        break;
       }
     }
-    if( !volFound ) {
-       edm::LogWarning("MaterialBudget") << "MaterialBudgetAction: selected volume not found in geometry " << volcite;
+    if (!volFound) {
+      edm::LogWarning("MaterialBudget") << "MaterialBudgetAction: selected volume not found in geometry " << volcite;
     }
   }
-
 
   //----- Check process selected is one of the available ones
   bool procFound = false;
-  if( theProcessToStop == "None" ) { 
+  if (theProcessToStop == "None") {
     procFound = true;
   } else {
-    G4ParticleTable * partTable = G4ParticleTable::GetParticleTable();
+    G4ParticleTable* partTable = G4ParticleTable::GetParticleTable();
     int siz = partTable->size();
-    for (int ii= 0; ii < siz; ii++) {
-      G4ParticleDefinition * particle = partTable->GetParticle(ii);
-      
-      //--- All processes of this particle 
-      G4ProcessManager * pmanager = particle->GetProcessManager();
-      G4ProcessVector * pvect = pmanager->GetProcessList();
+    for (int ii = 0; ii < siz; ii++) {
+      G4ParticleDefinition* particle = partTable->GetParticle(ii);
+
+      //--- All processes of this particle
+      G4ProcessManager* pmanager = particle->GetProcessManager();
+      G4ProcessVector* pvect = pmanager->GetProcessList();
       int sizproc = pvect->size();
       for (int jj = 0; jj < sizproc; jj++) {
-	if( (*pvect)[jj]->GetProcessName() == theProcessToStop ) {
-	  procFound = true;
-	  break;
-	}
+        if ((*pvect)[jj]->GetProcessName() == theProcessToStop) {
+          procFound = true;
+          break;
+        }
       }
     }
   }
 
-  if( !procFound ) {
-    edm::LogWarning("MaterialBudget") << "MaterialBudgetAction: selected process to stop tracking not found " << theProcessToStop;
+  if (!procFound) {
+    edm::LogWarning("MaterialBudget") << "MaterialBudgetAction: selected process to stop tracking not found "
+                                      << theProcessToStop;
   }
 }
 
 //-------------------------------------------------------------------------
-void MaterialBudgetAction::update(const BeginOfTrack* trk)
-{
-  const G4Track * aTrack = (*trk)(); // recover G4 pointer if wanted
-  
+void MaterialBudgetAction::update(const BeginOfTrack* trk) {
+  const G4Track* aTrack = (*trk)();  // recover G4 pointer if wanted
+
   // that was a temporary action while we're sorting out
   // about # of secondaries (produced if CutsPerRegion=true)
 
-  LogDebug("MaterialBudget") << "MaterialBudgetAction: Track ID " << aTrack->GetTrackID() 
-				  << "Track parent ID " << aTrack->GetParentID() 
-				  << "PDG Id. = " << aTrack->GetDefinition()->GetPDGEncoding()
-				  << "Ekin = " << aTrack->GetKineticEnergy() << " MeV";
+  LogDebug("MaterialBudget") << "MaterialBudgetAction: Track ID " << aTrack->GetTrackID() << "Track parent ID "
+                             << aTrack->GetParentID() << "PDG Id. = " << aTrack->GetDefinition()->GetPDGEncoding()
+                             << "Ekin = " << aTrack->GetKineticEnergy() << " MeV";
 
-  if( aTrack->GetCreatorProcess() ) 
-    LogDebug("MaterialBudget") << "MaterialBudgetAction: produced through " << aTrack->GetCreatorProcess()->GetProcessType();
-  
-  if(aTrack->GetTrackID() == 1) {
+  if (aTrack->GetCreatorProcess())
+    LogDebug("MaterialBudget") << "MaterialBudgetAction: produced through "
+                               << aTrack->GetCreatorProcess()->GetProcessType();
+
+  if (aTrack->GetTrackID() == 1) {
     firstParticle = true;
   } else {
     firstParticle = false;
   }
-  
-  if( storeDecay ) { // if record of the decay is requested
-    if( aTrack->GetCreatorProcess() ) {
-      if (
-	  aTrack->GetParentID() == 1
-	  &&
-	  //	  aTrack->GetCreatorProcess()->GetProcessType() == 6
-	  //	  &&
-	  aTrack->GetKineticEnergy() > Ekin
-	  ) {
-	// continue
+
+  if (storeDecay) {  // if record of the decay is requested
+    if (aTrack->GetCreatorProcess()) {
+      if (aTrack->GetParentID() == 1 &&
+          //	  aTrack->GetCreatorProcess()->GetProcessType() == 6
+          //	  &&
+          aTrack->GetKineticEnergy() > Ekin) {
+        // continue
       } else {
-	G4Track * aTracknc = const_cast<G4Track*>(aTrack);
-	aTracknc->SetTrackStatus(fStopAndKill);
-	return;
+        G4Track* aTracknc = const_cast<G4Track*>(aTrack);
+        aTracknc->SetTrackStatus(fStopAndKill);
+        return;
       }
-    } // particles produced from a decay (type=6) of the main particle (ID=1) with Kinetic Energy [MeV] > Ekin
-  } else { // kill all the other particles (take only the main one until it disappears) if decay not stored
-    if( aTrack->GetParentID() != 0) {
-      G4Track * aTracknc = const_cast<G4Track*>(aTrack);
+    }       // particles produced from a decay (type=6) of the main particle (ID=1) with Kinetic Energy [MeV] > Ekin
+  } else {  // kill all the other particles (take only the main one until it disappears) if decay not stored
+    if (aTrack->GetParentID() != 0) {
+      G4Track* aTracknc = const_cast<G4Track*>(aTrack);
       aTracknc->SetTrackStatus(fStopAndKill);
-      return;  
+      return;
     }
   }
-  
-  theData->dataStartTrack( aTrack );
 
-  if (saveToTree) theTree->fillStartTrack();
-  if (saveToHistos) theHistos->fillStartTrack();
-  if (saveToTxt) theTxt->fillStartTrack();
+  theData->dataStartTrack(aTrack);
+
+  if (saveToTree)
+    theTree->fillStartTrack();
+  if (saveToHistos)
+    theHistos->fillStartTrack();
+  if (saveToTxt)
+    theTxt->fillStartTrack();
 }
- 
+
 //-------------------------------------------------------------------------
-void MaterialBudgetAction::update(const G4Step* aStep)
-{
+void MaterialBudgetAction::update(const G4Step* aStep) {
   //----- Check it is inside one of the volumes selected
-  if( !theVolumeList.empty() ) {
-    if( !CheckTouchableInSelectedVolumes( aStep->GetTrack()->GetTouchable() ) ) return;
+  if (!theVolumeList.empty()) {
+    if (!CheckTouchableInSelectedVolumes(aStep->GetTrack()->GetTouchable()))
+      return;
   }
 
   //---------- each step
-  theData->dataPerStep( aStep );
-  if (saveToTree) theTree->fillPerStep();
-  if (saveToHistos) theHistos->fillPerStep();
-  if (saveToTxt) theTxt->fillPerStep();
+  theData->dataPerStep(aStep);
+  if (saveToTree)
+    theTree->fillPerStep();
+  if (saveToHistos)
+    theHistos->fillPerStep();
+  if (saveToTxt)
+    theTxt->fillPerStep();
 
   //----- Stop tracking after selected process
-  if( StopAfterProcess( aStep ) ) {
+  if (StopAfterProcess(aStep)) {
     G4Track* track = aStep->GetTrack();
-    track->SetTrackStatus( fStopAndKill );
+    track->SetTrackStatus(fStopAndKill);
   }
 
   return;
 }
 
 //-------------------------------------------------------------------------
-std::string MaterialBudgetAction::getSubDetectorName( G4StepPoint* aStepPoint )
-{
-  const G4TouchableHistory* theTouchable
-    = (const G4TouchableHistory*)(aStepPoint->GetTouchable());
+std::string MaterialBudgetAction::getSubDetectorName(G4StepPoint* aStepPoint) {
+  const G4TouchableHistory* theTouchable = (const G4TouchableHistory*)(aStepPoint->GetTouchable());
   G4int num_levels = theTouchable->GetHistoryDepth();
-  
-  if( theTouchable->GetVolume() ) {
-    return theTouchable->GetVolume(num_levels-1)->GetName();
+
+  if (theTouchable->GetVolume()) {
+    return theTouchable->GetVolume(num_levels - 1)->GetName();
   } else {
     return "OutOfWorld";
   }
 }
 
-
 //-------------------------------------------------------------------------
-std::string MaterialBudgetAction::getPartName( G4StepPoint* aStepPoint )
-{
-  const G4TouchableHistory* theTouchable
-    = (const G4TouchableHistory*)(aStepPoint->GetTouchable());
+std::string MaterialBudgetAction::getPartName(G4StepPoint* aStepPoint) {
+  const G4TouchableHistory* theTouchable = (const G4TouchableHistory*)(aStepPoint->GetTouchable());
   G4int num_levels = theTouchable->GetHistoryDepth();
-  
-  if( theTouchable->GetVolume() ) {
-    return theTouchable->GetVolume(num_levels-3)->GetName();
-  } else { 
+
+  if (theTouchable->GetVolume()) {
+    return theTouchable->GetVolume(num_levels - 3)->GetName();
+  } else {
     return "OutOfWorld";
   }
 }
 
 //-------------------------------------------------------------------------
-void MaterialBudgetAction::update(const EndOfTrack* trk)
-{
-  const G4Track * aTrack = (*trk)(); // recover G4 pointer if wanted
-  theData->dataEndTrack( aTrack );
+void MaterialBudgetAction::update(const EndOfTrack* trk) {
+  const G4Track* aTrack = (*trk)();  // recover G4 pointer if wanted
+  theData->dataEndTrack(aTrack);
 
-  if (saveToTree) theTree->fillEndTrack();
-  if (saveToHistos) theHistos->fillEndTrack();
-  if (saveToTxt) theTxt->fillEndTrack();
+  if (saveToTree)
+    theTree->fillEndTrack();
+  if (saveToHistos)
+    theHistos->fillEndTrack();
+  if (saveToTxt)
+    theTxt->fillEndTrack();
 }
 
 //-------------------------------------------------------------------------
-void MaterialBudgetAction::update(const EndOfRun* )
-{
-  // endOfRun calls TestHistoMgr::save() allowing to write 
+void MaterialBudgetAction::update(const EndOfRun*) {
+  // endOfRun calls TestHistoMgr::save() allowing to write
   // the ROOT files containing the histograms
 
-  if (saveToHistos) theHistos->endOfRun();
-  if (saveToTxt) theHistos->endOfRun();
-  if (saveToTree) theTree->endOfRun();
+  if (saveToHistos)
+    theHistos->endOfRun();
+  if (saveToTxt)
+    theHistos->endOfRun();
+  if (saveToTree)
+    theTree->endOfRun();
 
   return;
 }
 
 //-------------------------------------------------------------------------
-bool MaterialBudgetAction::CheckTouchableInSelectedVolumes( const G4VTouchable*  touch ) 
-{
+bool MaterialBudgetAction::CheckTouchableInSelectedVolumes(const G4VTouchable* touch) {
   size_t volh = touch->GetHistoryDepth();
-    for( int ii = volh; ii >= 0; ii-- ){
-      if ( 
-        std::find(theVolumeList.begin(),
-                  theVolumeList.end(),
-                  touch->GetVolume(ii)->GetName()) != theVolumeList.end() )
-          return true;
-    }
+  for (int ii = volh; ii >= 0; ii--) {
+    if (std::find(theVolumeList.begin(), theVolumeList.end(), touch->GetVolume(ii)->GetName()) != theVolumeList.end())
+      return true;
+  }
   return false;
 }
 
 //-------------------------------------------------------------------------
-bool MaterialBudgetAction::StopAfterProcess( const G4Step* aStep )
-{
-  if( theProcessToStop.empty() ) return false;
+bool MaterialBudgetAction::StopAfterProcess(const G4Step* aStep) {
+  if (theProcessToStop.empty())
+    return false;
 
-  if( aStep->GetPostStepPoint()->GetProcessDefinedStep() == nullptr) return false;
-  if( aStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName() == theProcessToStop ) {
-    edm::LogInfo("MaterialBudget" )<< "MaterialBudgetAction :" 
-				   << aStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();
+  if (aStep->GetPostStepPoint()->GetProcessDefinedStep() == nullptr)
+    return false;
+  if (aStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName() == theProcessToStop) {
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetAction :"
+                                   << aStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();
     return true;
   } else {
     return false;

--- a/Validation/Geometry/src/MaterialBudgetAction.cc
+++ b/Validation/Geometry/src/MaterialBudgetAction.cc
@@ -51,6 +51,8 @@ MaterialBudgetAction::MaterialBudgetAction(const edm::ParameterSet& iPSet) {
     edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: running in Tracker Mode";
   } else if (theHistoList == "ECAL") {
     edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: running in Ecal Mode";
+  } else if (theHistoList == "Mtd") {
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: running in Mtd Mode";
   } else if (theHistoList == "HGCal") {
     edm::LogInfo("MaterialBudget") << "MaterialBudgetAction: running in HGCal Mode";
   } else {
@@ -71,6 +73,9 @@ MaterialBudgetAction::MaterialBudgetAction(const edm::ParameterSet& iPSet) {
       theHistos = std::make_shared<MaterialBudgetTrackerHistos>(theData, theHistoMgr, saveToHistosFile);
     } else if (theHistoList == "ECAL") {
       theHistos = std::make_shared<MaterialBudgetEcalHistos>(theData, theHistoMgr, saveToHistosFile);
+    } else if (theHistoList == "Mtd") {
+      theHistos = std::make_shared<MaterialBudgetMtdHistos>(theData, theHistoMgr, saveToHistosFile);
+      theData->setMtdmode(true);
     } else if (theHistoList == "HGCal") {
       theHistos = std::make_shared<MaterialBudgetHGCalHistos>(theData, theHistoMgr, saveToHistosFile);
       //In HGCal mode, so tell data class

--- a/Validation/Geometry/src/MaterialBudgetCastorHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetCastorHistos.cc
@@ -14,45 +14,40 @@
 
 #include <string>
 
-MaterialBudgetCastorHistos::MaterialBudgetCastorHistos(const edm::ParameterSet &p){
-
-  binEta      = p.getUntrackedParameter<int>("NBinEta", 100);
-  binPhi      = p.getUntrackedParameter<int>("NBinPhi", 180);
-  etaLow      = p.getUntrackedParameter<double>("EtaLow",  5.0);
-  etaHigh     = p.getUntrackedParameter<double>("EtaHigh", 7.0);
-  fillHistos  = p.getUntrackedParameter<bool>("FillHisto", true);
-  printSum    = p.getUntrackedParameter<bool>("PrintSummary", false);
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: FillHisto : "
-				 << fillHistos << " PrintSummary " << printSum
-				 << " == Eta plot: NX " << binEta << " Range "
-				 << etaLow << " (" << -etaHigh << ") : " 
-				 << etaHigh << " (" << -etaLow <<") Phi plot: "
-				 << "NX " << binPhi << " Range " << -pi << ":"
-				 << pi  << " (Eta limit " << etaLow << ":" 
-				 << etaHigh <<")";
-  if (fillHistos) book();
-
+MaterialBudgetCastorHistos::MaterialBudgetCastorHistos(const edm::ParameterSet& p) {
+  binEta = p.getUntrackedParameter<int>("NBinEta", 100);
+  binPhi = p.getUntrackedParameter<int>("NBinPhi", 180);
+  etaLow = p.getUntrackedParameter<double>("EtaLow", 5.0);
+  etaHigh = p.getUntrackedParameter<double>("EtaHigh", 7.0);
+  fillHistos = p.getUntrackedParameter<bool>("FillHisto", true);
+  printSum = p.getUntrackedParameter<bool>("PrintSummary", false);
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: FillHisto : " << fillHistos << " PrintSummary "
+                                 << printSum << " == Eta plot: NX " << binEta << " Range " << etaLow << " (" << -etaHigh
+                                 << ") : " << etaHigh << " (" << -etaLow << ") Phi plot: "
+                                 << "NX " << binPhi << " Range " << -pi << ":" << pi << " (Eta limit " << etaLow << ":"
+                                 << etaHigh << ")";
+  if (fillHistos)
+    book();
 }
 
 MaterialBudgetCastorHistos::~MaterialBudgetCastorHistos() {
   edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: Save user "
-				 << "histos ===";
+                                 << "histos ===";
 }
 
 void MaterialBudgetCastorHistos::fillStartTrack(const G4Track* aTrack) {
-
-  id1    = id2    = steps   = 0;
+  id1 = id2 = steps = 0;
   radLen = intLen = stepLen = 0;
 
-  const G4ThreeVector& dir = aTrack->GetMomentum() ;
-  if (dir.theta() != 0 ) {
+  const G4ThreeVector& dir = aTrack->GetMomentum();
+  if (dir.theta() != 0) {
     eta = dir.eta();
   } else {
     eta = -99;
   }
   phi = dir.phi();
   double theEnergy = aTrack->GetTotalEnergy();
-  int    theID     = (int)(aTrack->GetDefinition()->GetPDGEncoding());
+  int theID = (int)(aTrack->GetDefinition()->GetPDGEncoding());
 
   if (printSum) {
     matList.clear();
@@ -61,203 +56,214 @@ void MaterialBudgetCastorHistos::fillStartTrack(const G4Track* aTrack) {
     intLength.clear();
   }
 
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: Track " 
-				 << aTrack->GetTrackID() << " Code " << theID
-				 << " Energy " << theEnergy/GeV << " GeV; Eta "
-				 << eta << " Phi " << phi/deg << " PT "
-				 << dir.perp()/GeV << " GeV *****";
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: Track " << aTrack->GetTrackID() << " Code " << theID
+                                 << " Energy " << theEnergy / GeV << " GeV; Eta " << eta << " Phi " << phi / deg
+                                 << " PT " << dir.perp() / GeV << " GeV *****";
 }
 
-
 void MaterialBudgetCastorHistos::fillPerStep(const G4Step* aStep) {
+  G4Material* material = aStep->GetPreStepPoint()->GetMaterial();
+  double step = aStep->GetStepLength();
+  double radl = material->GetRadlen();
+  double intl = material->GetNuclearInterLength();
+  double density = material->GetDensity() / (g / cm3);
 
-  G4Material * material = aStep->GetPreStepPoint()->GetMaterial();
-  double step    = aStep->GetStepLength();
-  double radl    = material->GetRadlen();
-  double intl    = material->GetNuclearInterLength();
-  double density = material->GetDensity() / (g/cm3);
-
-  int    id1Old   = id1;
-  int    id2Old   = id2;
+  int id1Old = id1;
+  int id2Old = id2;
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-  std::string         name  = touch->GetVolume(0)->GetName();
-  const std::string&         matName = material->GetName();
+  std::string name = touch->GetVolume(0)->GetName();
+  const std::string& matName = material->GetName();
   if (printSum) {
     bool found = false;
-    for (unsigned int ii=0; ii<matList.size(); ii++) {
+    for (unsigned int ii = 0; ii < matList.size(); ii++) {
       if (matList[ii] == matName) {
-	stepLength[ii] += step;
-	radLength[ii]  += (step/radl);
-	intLength[ii]  += (step/intl);
-	found           = true;
-	break;
+        stepLength[ii] += step;
+        radLength[ii] += (step / radl);
+        intLength[ii] += (step / intl);
+        found = true;
+        break;
       }
     }
     if (!found) {
       matList.push_back(matName);
       stepLength.push_back(step);
-      radLength.push_back(step/radl);
-      intLength.push_back(step/intl);
+      radLength.push_back(step / radl);
+      intLength.push_back(step / intl);
     }
-    edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: "
-				   << name << " " << step << " " << matName 
-				   << " " << stepLen << " " << step/radl << " " 
-				   << radLen << " " <<step/intl << " " <<intLen;
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: " << name << " " << step << " " << matName << " "
+                                   << stepLen << " " << step / radl << " " << radLen << " " << step / intl << " "
+                                   << intLen;
   } else {
-    edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: Step at " 
-				   << name << " Length " << step << " in " 
-				   << matName << " of density " << density 
-				   << " g/cc; Radiation Length " <<radl <<" mm;"
-				   << " Interaction Length " << intl << " mm\n"
-				   << "                          Position " 
-				   << aStep->GetPreStepPoint()->GetPosition()
-				   << " Cylindrical R "
-				   <<aStep->GetPreStepPoint()->GetPosition().perp()
-				   << " Length (so far) " << stepLen << " L/X0 "
-				   << step/radl << "/" << radLen << " L/Lambda "
-				   << step/intl << "/" << intLen;
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: Step at " << name << " Length " << step << " in "
+                                   << matName << " of density " << density << " g/cc; Radiation Length " << radl
+                                   << " mm;"
+                                   << " Interaction Length " << intl << " mm\n"
+                                   << "                          Position " << aStep->GetPreStepPoint()->GetPosition()
+                                   << " Cylindrical R " << aStep->GetPreStepPoint()->GetPosition().perp()
+                                   << " Length (so far) " << stepLen << " L/X0 " << step / radl << "/" << radLen
+                                   << " L/Lambda " << step / intl << "/" << intLen;
   }
 
-  int level = ((touch->GetHistoryDepth())+1);
-  std::string name1="XXXX", name2="XXXX";
-  if (level>3) name1 = touch->GetVolume(level-4)->GetName();
-  if (level>4) name2 = touch->GetVolume(level-5)->GetName();
+  int level = ((touch->GetHistoryDepth()) + 1);
+  std::string name1 = "XXXX", name2 = "XXXX";
+  if (level > 3)
+    name1 = touch->GetVolume(level - 4)->GetName();
+  if (level > 4)
+    name2 = touch->GetVolume(level - 5)->GetName();
   if (name1 == "CAST") {
     id1 = 1;
-    if      (name2 == "CAEC") id2 = 2;
-    else if (name2 == "CAHC") id2 = 3;
-    else if (name2 == "CEDC") id2 = 4;
-    else if (name2 == "CHDC") id2 = 5;
-    else                      id2 = 0;
+    if (name2 == "CAEC")
+      id2 = 2;
+    else if (name2 == "CAHC")
+      id2 = 3;
+    else if (name2 == "CEDC")
+      id2 = 4;
+    else if (name2 == "CHDC")
+      id2 = 5;
+    else
+      id2 = 0;
   } else {
     id1 = id2 = 0;
   }
-  LogDebug("MaterialBudget") << "MaterialBudgetCastorHistos: Level " << level
-			     << " Volume " << name1 << " and " << name2
-			     << " ID1 " << id1 << " (" << id1Old << ") ID2 "
-			     << id2 << " (" << id2Old << ")";
+  LogDebug("MaterialBudget") << "MaterialBudgetCastorHistos: Level " << level << " Volume " << name1 << " and " << name2
+                             << " ID1 " << id1 << " (" << id1Old << ") ID2 " << id2 << " (" << id2Old << ")";
 
   if (fillHistos) {
     if (id1 != id1Old) {
-      if (id1 == 0) fillHisto(id1Old, 1);
-      else          fillHisto(id1,    0);
+      if (id1 == 0)
+        fillHisto(id1Old, 1);
+      else
+        fillHisto(id1, 0);
     }
     if (id2 != id2Old) {
-      if (id2 == 0) fillHisto(id2Old, 1);
-      else          fillHisto(id2,    0);
+      if (id2 == 0)
+        fillHisto(id2Old, 1);
+      else
+        fillHisto(id2, 0);
     }
   }
 
   stepLen += step;
-  radLen  += step/radl;
-  intLen  += step/intl;
+  radLen += step / radl;
+  intLen += step / intl;
 }
 
-
 void MaterialBudgetCastorHistos::fillEndTrack() {
-
   if (fillHistos) {
-    if (id1 != 0) fillHisto(id1, 1);
-    if (id2 != 0) fillHisto(id2, 1);
+    if (id1 != 0)
+      fillHisto(id1, 1);
+    if (id2 != 0)
+      fillHisto(id2, 1);
   }
   if (printSum) {
-    for (unsigned int ii=0; ii<matList.size(); ii++) {
-      edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: "
-				     << matList[ii] << "\t" << stepLength[ii]
-				     << "\t" << radLength[ii] << "\t"
-				     << intLength[ii];
+    for (unsigned int ii = 0; ii < matList.size(); ii++) {
+      edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: " << matList[ii] << "\t" << stepLength[ii] << "\t"
+                                     << radLength[ii] << "\t" << intLength[ii];
     }
   }
 }
 
 void MaterialBudgetCastorHistos::book() {
-
   // Book histograms
   edm::Service<TFileService> tfile;
-  
-  if ( !tfile.isAvailable() )
+
+  if (!tfile.isAvailable())
     throw cms::Exception("BadConfig") << "MaterialBudgetCastorHistos: TFileService unavailable: "
                                       << "please add it to config file";
 
-  double maxPhi=pi;
+  double maxPhi = pi;
   edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: Booking user "
-				 << "histos === with " << binEta << " bins "
-				 << "in eta from " << etaLow << " to "
-				 << etaHigh << " and " << binPhi << " bins "
-				 << "in phi from " << -maxPhi << " to " 
-				 << maxPhi;
-  
+                                 << "histos === with " << binEta << " bins "
+                                 << "in eta from " << etaLow << " to " << etaHigh << " and " << binPhi << " bins "
+                                 << "in phi from " << -maxPhi << " to " << maxPhi;
+
   std::string tag1, tag2;
   // total X0
-  for (int i=0; i<maxSet; i++) {
-    double minEta=etaLow;
-    double maxEta=etaHigh;
-    int    ireg = i;
+  for (int i = 0; i < maxSet; i++) {
+    double minEta = etaLow;
+    double maxEta = etaHigh;
+    int ireg = i;
     if (i > 9) {
       minEta = -etaHigh;
       maxEta = -etaLow;
-      ireg  -= 10;
+      ireg -= 10;
       tag2 = " (-ve Eta Side)";
     } else {
       tag2 = " (+ve Eta Side)";
     }
-    if ((i%2) == 0) {
-      ireg  /= 2;
+    if ((i % 2) == 0) {
+      ireg /= 2;
       tag1 = " == Start";
     } else {
-      ireg   = (ireg-1)/2;
+      ireg = (ireg - 1) / 2;
       tag1 = " == End";
     }
     std::string title = std::to_string(ireg) + tag1 + tag2;
-    me100[i] = tfile->make<TProfile>(std::to_string(i + 100).c_str(),
-                  ("MB(X0) prof Eta in region " + title).c_str(), binEta, minEta, maxEta);
-    me200[i] = tfile->make<TProfile>(std::to_string(i + 200).c_str(),
-                  ("MB(L0) prof Eta in region " + title).c_str(), binEta, minEta, maxEta);
-    me300[i] = tfile->make<TProfile>(std::to_string(i + 300).c_str(),
-                  ("MB(Step) prof Eta in region " + title).c_str(), binEta, minEta, maxEta);
-    me400[i] = tfile->make<TH1F>(std::to_string(i + 400).c_str(),
-                  ("Eta in region " + title).c_str(), binEta, minEta, maxEta);
-    me500[i] = tfile->make<TProfile>(std::to_string(i + 500).c_str(),
-                  ("MB(X0) prof Ph in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
-    me600[i] = tfile->make<TProfile>(std::to_string(i + 600).c_str(),
-                  ("MB(L0) prof Ph in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
-    me700[i] = tfile->make<TProfile>(std::to_string(i + 700).c_str(),
-                  ("MB(Step) prof Ph in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
-    me800[i] = tfile->make<TH1F>(std::to_string(i + 800).c_str(),
-                  ("Phi in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
+    me100[i] = tfile->make<TProfile>(
+        std::to_string(i + 100).c_str(), ("MB(X0) prof Eta in region " + title).c_str(), binEta, minEta, maxEta);
+    me200[i] = tfile->make<TProfile>(
+        std::to_string(i + 200).c_str(), ("MB(L0) prof Eta in region " + title).c_str(), binEta, minEta, maxEta);
+    me300[i] = tfile->make<TProfile>(
+        std::to_string(i + 300).c_str(), ("MB(Step) prof Eta in region " + title).c_str(), binEta, minEta, maxEta);
+    me400[i] =
+        tfile->make<TH1F>(std::to_string(i + 400).c_str(), ("Eta in region " + title).c_str(), binEta, minEta, maxEta);
+    me500[i] = tfile->make<TProfile>(
+        std::to_string(i + 500).c_str(), ("MB(X0) prof Ph in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
+    me600[i] = tfile->make<TProfile>(
+        std::to_string(i + 600).c_str(), ("MB(L0) prof Ph in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
+    me700[i] = tfile->make<TProfile>(
+        std::to_string(i + 700).c_str(), ("MB(Step) prof Ph in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
+    me800[i] =
+        tfile->make<TH1F>(std::to_string(i + 800).c_str(), ("Phi in region " + title).c_str(), binPhi, -maxPhi, maxPhi);
     me900[i] = tfile->make<TProfile2D>(std::to_string(i + 900).c_str(),
-                  ("MB(X0) prof Eta Phi in region " + title).c_str(), binEta/2, minEta, maxEta,
-                  binPhi/2, -maxPhi, maxPhi);
-    me1000[i]= tfile->make<TProfile2D>(std::to_string(i + 1000).c_str(),
-                  ("MB(L0) prof Eta Phi in region " + title).c_str(), binEta/2, minEta, maxEta,
-                  binPhi/2, -maxPhi, maxPhi);
-    me1100[i]= tfile->make<TProfile2D>(std::to_string(i + 1100).c_str(),
-                  ("MB(Step) prof Eta Phi in region " + title).c_str(), binEta/2, minEta, maxEta,
-                  binPhi/2, -maxPhi, maxPhi);
-    me1200[i]= tfile->make<TH2F>(std::to_string(i + 1200).c_str(),
-                  ("Eta vs Phi in region " + title).c_str(), binEta/2, minEta, maxEta,
-                  binPhi/2, -maxPhi, maxPhi);
+                                       ("MB(X0) prof Eta Phi in region " + title).c_str(),
+                                       binEta / 2,
+                                       minEta,
+                                       maxEta,
+                                       binPhi / 2,
+                                       -maxPhi,
+                                       maxPhi);
+    me1000[i] = tfile->make<TProfile2D>(std::to_string(i + 1000).c_str(),
+                                        ("MB(L0) prof Eta Phi in region " + title).c_str(),
+                                        binEta / 2,
+                                        minEta,
+                                        maxEta,
+                                        binPhi / 2,
+                                        -maxPhi,
+                                        maxPhi);
+    me1100[i] = tfile->make<TProfile2D>(std::to_string(i + 1100).c_str(),
+                                        ("MB(Step) prof Eta Phi in region " + title).c_str(),
+                                        binEta / 2,
+                                        minEta,
+                                        maxEta,
+                                        binPhi / 2,
+                                        -maxPhi,
+                                        maxPhi);
+    me1200[i] = tfile->make<TH2F>(std::to_string(i + 1200).c_str(),
+                                  ("Eta vs Phi in region " + title).c_str(),
+                                  binEta / 2,
+                                  minEta,
+                                  maxEta,
+                                  binPhi / 2,
+                                  -maxPhi,
+                                  maxPhi);
   }
 
   edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: Booking user "
-				 << "histos done ===";
-
+                                 << "histos done ===";
 }
 
 void MaterialBudgetCastorHistos::fillHisto(int id, int ix) {
-
-  int ii = 2*(id-1) + ix;
+  int ii = 2 * (id - 1) + ix;
   double etaAbs = eta;
   if (eta < 0) {
     etaAbs = -eta;
-    ii    += 10;
+    ii += 10;
   }
   LogDebug("MaterialBudget") << "MaterialBudgetCastorHistos:FillHisto "
-			     << "called with index " << id << ":" << ix 
-			     << ":" << ii << " eta " << etaAbs << " (" 
-			     << eta << ") integrated  step " << stepLen 
-			     << " X0 " << radLen << " Lamda " << intLen;
-  
+                             << "called with index " << id << ":" << ix << ":" << ii << " eta " << etaAbs << " (" << eta
+                             << ") integrated  step " << stepLen << " X0 " << radLen << " Lamda " << intLen;
+
   me100[ii]->Fill(eta, radLen);
   me200[ii]->Fill(eta, intLen);
   me300[ii]->Fill(eta, stepLen);
@@ -274,5 +280,4 @@ void MaterialBudgetCastorHistos::fillHisto(int id, int ix) {
   me1000[ii]->Fill(eta, phi, intLen);
   me1100[ii]->Fill(eta, phi, stepLen);
   me1200[ii]->Fill(eta, phi);
-    
 }

--- a/Validation/Geometry/src/MaterialBudgetCastorHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetCastorHistos.cc
@@ -41,11 +41,11 @@ void MaterialBudgetCastorHistos::fillStartTrack(const G4Track* aTrack) {
 
   const G4ThreeVector& dir = aTrack->GetMomentum();
   if (dir.theta() != 0) {
-    eta = dir.eta();
+    eta_ = dir.eta();
   } else {
-    eta = -99;
+    eta_ = -99;
   }
-  phi = dir.phi();
+  phi_ = dir.phi();
   double theEnergy = aTrack->GetTotalEnergy();
   int theID = (int)(aTrack->GetDefinition()->GetPDGEncoding());
 
@@ -57,7 +57,7 @@ void MaterialBudgetCastorHistos::fillStartTrack(const G4Track* aTrack) {
   }
 
   edm::LogInfo("MaterialBudget") << "MaterialBudgetCastorHistos: Track " << aTrack->GetTrackID() << " Code " << theID
-                                 << " Energy " << theEnergy / GeV << " GeV; Eta " << eta << " Phi " << phi / deg
+                                 << " Energy " << theEnergy / GeV << " GeV; Eta " << eta_ << " Phi " << phi_ / deg
                                  << " PT " << dir.perp() / GeV << " GeV *****";
 }
 
@@ -255,29 +255,29 @@ void MaterialBudgetCastorHistos::book() {
 
 void MaterialBudgetCastorHistos::fillHisto(int id, int ix) {
   int ii = 2 * (id - 1) + ix;
-  double etaAbs = eta;
-  if (eta < 0) {
-    etaAbs = -eta;
+  double etaAbs = eta_;
+  if (eta_ < 0) {
+    etaAbs = -eta_;
     ii += 10;
   }
   LogDebug("MaterialBudget") << "MaterialBudgetCastorHistos:FillHisto "
-                             << "called with index " << id << ":" << ix << ":" << ii << " eta " << etaAbs << " (" << eta
+                             << "called with index " << id << ":" << ix << ":" << ii << " eta " << etaAbs << " (" << eta_
                              << ") integrated  step " << stepLen << " X0 " << radLen << " Lamda " << intLen;
 
-  me100[ii]->Fill(eta, radLen);
-  me200[ii]->Fill(eta, intLen);
-  me300[ii]->Fill(eta, stepLen);
-  me400[ii]->Fill(eta);
+  me100[ii]->Fill(eta_, radLen);
+  me200[ii]->Fill(eta_, intLen);
+  me300[ii]->Fill(eta_, stepLen);
+  me400[ii]->Fill(eta_);
 
   if (etaAbs >= etaLow && etaAbs <= etaHigh) {
-    me500[ii]->Fill(phi, radLen);
-    me600[ii]->Fill(phi, intLen);
-    me700[ii]->Fill(phi, stepLen);
-    me800[ii]->Fill(phi);
+    me500[ii]->Fill(phi_, radLen);
+    me600[ii]->Fill(phi_, intLen);
+    me700[ii]->Fill(phi_, stepLen);
+    me800[ii]->Fill(phi_);
   }
 
-  me900[ii]->Fill(eta, phi, radLen);
-  me1000[ii]->Fill(eta, phi, intLen);
-  me1100[ii]->Fill(eta, phi, stepLen);
-  me1200[ii]->Fill(eta, phi);
+  me900[ii]->Fill(eta_, phi_, radLen);
+  me1000[ii]->Fill(eta_, phi_, intLen);
+  me1100[ii]->Fill(eta_, phi_, stepLen);
+  me1200[ii]->Fill(eta_, phi_);
 }

--- a/Validation/Geometry/src/MaterialBudgetCategorizer.cc
+++ b/Validation/Geometry/src/MaterialBudgetCategorizer.cc
@@ -26,6 +26,11 @@ MaterialBudgetCategorizer::MaterialBudgetCategorizer(std::string mode) {
     buildCategoryMap(theMaterialX0FileName, theX0Map);
     std::string theMaterialL0FileName = edm::FileInPath("Validation/Geometry/data/trackerMaterials.l0").fullPath();
     buildCategoryMap(theMaterialL0FileName, theL0Map);
+  } else if (mode.compare("Mtd") == 0) {
+    std::string theMaterialX0FileName = edm::FileInPath("Validation/Geometry/data/mtdMaterials.x0").fullPath();
+    buildCategoryMap(theMaterialX0FileName, theX0Map);
+    std::string theMaterialL0FileName = edm::FileInPath("Validation/Geometry/data/mtdMaterials.l0").fullPath();
+    buildCategoryMap(theMaterialL0FileName, theL0Map);
   } else if (mode.compare("HGCal") == 0) {
     std::string thehgcalMaterialX0FileName = edm::FileInPath("Validation/Geometry/data/hgcalMaterials.x0").fullPath();
     buildHGCalCategoryMap(thehgcalMaterialX0FileName, theHGCalX0Map);

--- a/Validation/Geometry/src/MaterialBudgetCategorizer.cc
+++ b/Validation/Geometry/src/MaterialBudgetCategorizer.cc
@@ -12,8 +12,7 @@
 #include <fstream>
 #include <vector>
 
-MaterialBudgetCategorizer::MaterialBudgetCategorizer(std::string mode)
-{
+MaterialBudgetCategorizer::MaterialBudgetCategorizer(std::string mode) {
   //----- Build map volume name - volume index
   G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();
   G4LogicalVolumeStore::iterator ite;
@@ -22,115 +21,105 @@ MaterialBudgetCategorizer::MaterialBudgetCategorizer(std::string mode)
     theVolumeMap[(*ite)->GetName()] = ii++;
   }
 
-  if ( mode.compare("Tracker") == 0 ) {
+  if (mode.compare("Tracker") == 0) {
     std::string theMaterialX0FileName = edm::FileInPath("Validation/Geometry/data/trackerMaterials.x0").fullPath();
     buildCategoryMap(theMaterialX0FileName, theX0Map);
     std::string theMaterialL0FileName = edm::FileInPath("Validation/Geometry/data/trackerMaterials.l0").fullPath();
     buildCategoryMap(theMaterialL0FileName, theL0Map);
-  } else if ( mode.compare("HGCal") == 0 ){
-      std::string thehgcalMaterialX0FileName = edm::FileInPath("Validation/Geometry/data/hgcalMaterials.x0").fullPath();
-      buildHGCalCategoryMap(thehgcalMaterialX0FileName, theHGCalX0Map);
-      std::string thehgcalMaterialL0FileName = edm::FileInPath("Validation/Geometry/data/hgcalMaterials.l0").fullPath();
-      buildHGCalCategoryMap(thehgcalMaterialL0FileName, theHGCalL0Map);
+  } else if (mode.compare("HGCal") == 0) {
+    std::string thehgcalMaterialX0FileName = edm::FileInPath("Validation/Geometry/data/hgcalMaterials.x0").fullPath();
+    buildHGCalCategoryMap(thehgcalMaterialX0FileName, theHGCalX0Map);
+    std::string thehgcalMaterialL0FileName = edm::FileInPath("Validation/Geometry/data/hgcalMaterials.l0").fullPath();
+    buildHGCalCategoryMap(thehgcalMaterialL0FileName, theHGCalL0Map);
   }
 }
 
-void MaterialBudgetCategorizer::buildCategoryMap(std::string theMaterialFileName, 
-						 std::map<std::string,std::vector<float> >& theMap) 
-{
-
+void MaterialBudgetCategorizer::buildCategoryMap(std::string theMaterialFileName,
+                                                 std::map<std::string, std::vector<float> >& theMap) {
   std::ifstream theMaterialFile(theMaterialFileName);
 
-  if (!theMaterialFile) 
+  if (!theMaterialFile)
     cms::Exception("LogicError") << " File not found " << theMaterialFileName;
-  
-  float sup,sen,cab,col,ele,oth,air;
-  sup=sen=cab=col=ele=0.;
+
+  float sup, sen, cab, col, ele, oth, air;
+  sup = sen = cab = col = ele = 0.;
 
   std::string materialName;
 
-  while(theMaterialFile) {
+  while (theMaterialFile) {
     theMaterialFile >> materialName;
     theMaterialFile >> sup >> sen >> cab >> col >> ele;
 
-    if (materialName[0] == '#') //Ignore comments
+    if (materialName[0] == '#')  //Ignore comments
       continue;
- 
+
     oth = 0.000;
     air = 0.000;
-    theMap[materialName].clear();        // clear before re-filling
-    theMap[materialName].push_back(sup); // sup
-    theMap[materialName].push_back(sen); // sen
-    theMap[materialName].push_back(cab); // cab
-    theMap[materialName].push_back(col); // col
-    theMap[materialName].push_back(ele); // ele
-    theMap[materialName].push_back(oth); // oth
-    theMap[materialName].push_back(air); // air
-    edm::LogInfo("MaterialBudget") 
-      << "MaterialBudgetCategorizer: Material " << materialName << " filled: " 
-      << "\n\tSUP " << sup 
-      << "\n\tSEN " << sen 
-      << "\n\tCAB " << cab 
-      << "\n\tCOL " << col 
-      << "\n\tELE " << ele 
-      << "\n\tOTH " << oth 
-      << "\n\tAIR " << air
-      << "\n\tAdd up to: " << sup + sen + cab + col + ele + oth + air;
+    theMap[materialName].clear();         // clear before re-filling
+    theMap[materialName].push_back(sup);  // sup
+    theMap[materialName].push_back(sen);  // sen
+    theMap[materialName].push_back(cab);  // cab
+    theMap[materialName].push_back(col);  // col
+    theMap[materialName].push_back(ele);  // ele
+    theMap[materialName].push_back(oth);  // oth
+    theMap[materialName].push_back(air);  // air
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetCategorizer: Material " << materialName << " filled: "
+                                   << "\n\tSUP " << sup << "\n\tSEN " << sen << "\n\tCAB " << cab << "\n\tCOL " << col
+                                   << "\n\tELE " << ele << "\n\tOTH " << oth << "\n\tAIR " << air
+                                   << "\n\tAdd up to: " << sup + sen + cab + col + ele + oth + air;
   }
 }
 
-void MaterialBudgetCategorizer::buildHGCalCategoryMap(std::string theMaterialFileName, 
-						      std::map<std::string,std::vector<float> >& theMap)
-{
-  
+void MaterialBudgetCategorizer::buildHGCalCategoryMap(std::string theMaterialFileName,
+                                                      std::map<std::string, std::vector<float> >& theMap) {
   std::ifstream theMaterialFile(theMaterialFileName);
-  if (!theMaterialFile) 
-    cms::Exception("LogicError") <<" File not found " << theMaterialFileName;
-  
+  if (!theMaterialFile)
+    cms::Exception("LogicError") << " File not found " << theMaterialFileName;
+
   // fill everything as "other"
-  float air,cables,copper,h_scintillator,lead,hgc_g10_fr4,silicon,stainlesssteel,wcu,oth,epoxy,kapton,aluminium; 
-  air=cables=copper=h_scintillator=lead=hgc_g10_fr4=silicon=stainlesssteel=wcu=epoxy=kapton=aluminium=0.;
+  float air, cables, copper, h_scintillator, lead, hgc_g10_fr4, silicon, stainlesssteel, wcu, oth, epoxy, kapton,
+      aluminium;
+  air = cables = copper = h_scintillator = lead = hgc_g10_fr4 = silicon = stainlesssteel = wcu = epoxy = kapton =
+      aluminium = 0.;
 
   std::string materialName;
-  while(theMaterialFile) {
+  while (theMaterialFile) {
     theMaterialFile >> materialName;
-    theMaterialFile >> air >> cables >> copper >> h_scintillator >> lead >> hgc_g10_fr4 >> silicon >> stainlesssteel >> wcu >> epoxy >> kapton >> aluminium;
+    theMaterialFile >> air >> cables >> copper >> h_scintillator >> lead >> hgc_g10_fr4 >> silicon >> stainlesssteel >>
+        wcu >> epoxy >> kapton >> aluminium;
     // Skip comments
     if (materialName[0] == '#')
       continue;
     // Substitute '*' with spaces
     std::replace(materialName.begin(), materialName.end(), '*', ' ');
     oth = 0.000;
-    theMap[materialName].clear();        // clear before re-filling
-    theMap[materialName].push_back(air             ); // air
-    theMap[materialName].push_back(cables          ); // cables          
-    theMap[materialName].push_back(copper          ); // copper          
-    theMap[materialName].push_back(h_scintillator  ); // h_scintillator  
-    theMap[materialName].push_back(lead            ); // lead            
-    theMap[materialName].push_back(hgc_g10_fr4); // hgc_g10_fr4
-    theMap[materialName].push_back(silicon         ); // silicon         
-    theMap[materialName].push_back(stainlesssteel  ); // stainlesssteel
-    theMap[materialName].push_back(wcu             ); // wcu
-    theMap[materialName].push_back(oth             ); // oth
-    theMap[materialName].push_back(epoxy             ); // epoxy
-    theMap[materialName].push_back(kapton             ); // kapton
-    theMap[materialName].push_back(aluminium             ); // aluminium
-    edm::LogInfo("MaterialBudget") 
-      << "MaterialBudgetCategorizer: material " << materialName << " filled " 
-      << std::endl
-      << "\tair              " << air << std::endl
-      << "\tcables           " << cables << std::endl
-      << "\tcopper           " << copper << std::endl
-      << "\th_scintillator   " << h_scintillator << std::endl
-      << "\tlead             " << lead << std::endl
-      << "\thgc_g10_fr4      " << hgc_g10_fr4 << std::endl
-      << "\tsilicon          " << silicon << std::endl
-      << "\tstainlesssteel   " << stainlesssteel << std::endl
-      << "\twcu              " << wcu << std::endl
-      << "\tepoxy              " << epoxy << std::endl
-      << "\tkapton            " << kapton<< std::endl
-      << "\taluminium            " << aluminium<< std::endl
-      << "\tOTH              " << oth;
+    theMap[materialName].clear();                    // clear before re-filling
+    theMap[materialName].push_back(air);             // air
+    theMap[materialName].push_back(cables);          // cables
+    theMap[materialName].push_back(copper);          // copper
+    theMap[materialName].push_back(h_scintillator);  // h_scintillator
+    theMap[materialName].push_back(lead);            // lead
+    theMap[materialName].push_back(hgc_g10_fr4);     // hgc_g10_fr4
+    theMap[materialName].push_back(silicon);         // silicon
+    theMap[materialName].push_back(stainlesssteel);  // stainlesssteel
+    theMap[materialName].push_back(wcu);             // wcu
+    theMap[materialName].push_back(oth);             // oth
+    theMap[materialName].push_back(epoxy);           // epoxy
+    theMap[materialName].push_back(kapton);          // kapton
+    theMap[materialName].push_back(aluminium);       // aluminium
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetCategorizer: material " << materialName << " filled " << std::endl
+                                   << "\tair              " << air << std::endl
+                                   << "\tcables           " << cables << std::endl
+                                   << "\tcopper           " << copper << std::endl
+                                   << "\th_scintillator   " << h_scintillator << std::endl
+                                   << "\tlead             " << lead << std::endl
+                                   << "\thgc_g10_fr4      " << hgc_g10_fr4 << std::endl
+                                   << "\tsilicon          " << silicon << std::endl
+                                   << "\tstainlesssteel   " << stainlesssteel << std::endl
+                                   << "\twcu              " << wcu << std::endl
+                                   << "\tepoxy              " << epoxy << std::endl
+                                   << "\tkapton            " << kapton << std::endl
+                                   << "\taluminium            " << aluminium << std::endl
+                                   << "\tOTH              " << oth;
   }
-
 }

--- a/Validation/Geometry/src/MaterialBudgetData.cc
+++ b/Validation/Geometry/src/MaterialBudgetData.cc
@@ -5,8 +5,7 @@
 #include "G4EventManager.hh"
 #include "G4Event.hh"
 
-MaterialBudgetData::MaterialBudgetData() 
-{
+MaterialBudgetData::MaterialBudgetData() {
   //instantiate categorizer to assign an ID to volumes and materials
   myMaterialBudgetCategorizer = nullptr;
   allStepsToTree = false;
@@ -16,397 +15,367 @@ MaterialBudgetData::MaterialBudgetData()
 
 MaterialBudgetData::~MaterialBudgetData() = default;
 
-void MaterialBudgetData::SetAllStepsToTree()
-{
-  allStepsToTree = true;
-}
+void MaterialBudgetData::SetAllStepsToTree() { allStepsToTree = true; }
 
+void MaterialBudgetData::dataStartTrack(const G4Track* aTrack) {
+  const G4ThreeVector& dir = aTrack->GetMomentum();
 
-void MaterialBudgetData::dataStartTrack( const G4Track* aTrack )
-{
-
-  const G4ThreeVector& dir = aTrack->GetMomentum() ;
-
-  if( myMaterialBudgetCategorizer == nullptr){
-    if(isHGCal){
-      myMaterialBudgetCategorizer = std::make_unique<MaterialBudgetCategorizer>("HGCal"); 
+  if (myMaterialBudgetCategorizer == nullptr) {
+    if (isHGCal) {
+      myMaterialBudgetCategorizer = std::make_unique<MaterialBudgetCategorizer>("HGCal");
     } else {
-      myMaterialBudgetCategorizer = std::make_unique<MaterialBudgetCategorizer>("Tracker"); 
+      myMaterialBudgetCategorizer = std::make_unique<MaterialBudgetCategorizer>("Tracker");
     }
   }
-  
-  theStepN=0;
-  theTotalMB=0;
-  theTotalIL=0;
-  theEta=0;
-  thePhi=0;
-  theID=0;
-  thePt=0;
-  theEnergy=0;
-  theMass=0;
- 
-  theSupportMB     = 0.f;
-  theSensitiveMB   = 0.f;
-  theCoolingMB     = 0.f;
+
+  theStepN = 0;
+  theTotalMB = 0;
+  theTotalIL = 0;
+  theEta = 0;
+  thePhi = 0;
+  theID = 0;
+  thePt = 0;
+  theEnergy = 0;
+  theMass = 0;
+
+  theSupportMB = 0.f;
+  theSensitiveMB = 0.f;
+  theCoolingMB = 0.f;
   theElectronicsMB = 0.f;
-  theOtherMB       = 0.f;
+  theOtherMB = 0.f;
 
   //HGCal
-  theAirMB              = 0.f;
-  theCablesMB           = 0.f;
-  theCopperMB           = 0.f;
-  theH_ScintillatorMB   = 0.f;
-  theLeadMB             = 0.f;
-  theEpoxyMB            = 0.f;
-  theKaptonMB           = 0.f;
-  theAluminiumMB           = 0.f;
+  theAirMB = 0.f;
+  theCablesMB = 0.f;
+  theCopperMB = 0.f;
+  theH_ScintillatorMB = 0.f;
+  theLeadMB = 0.f;
+  theEpoxyMB = 0.f;
+  theKaptonMB = 0.f;
+  theAluminiumMB = 0.f;
   theHGC_G10_FR4MB = 0.f;
-  theSiliconMB          = 0.f;
-  theStainlessSteelMB   = 0.f;
-  theWCuMB              = 0.f;
+  theSiliconMB = 0.f;
+  theStainlessSteelMB = 0.f;
+  theWCuMB = 0.f;
 
-  theSupportIL     = 0.f;
-  theSensitiveIL   = 0.f;
-  theCoolingIL     = 0.f;
+  theSupportIL = 0.f;
+  theSensitiveIL = 0.f;
+  theCoolingIL = 0.f;
   theElectronicsIL = 0.f;
-  theOtherIL       = 0.f;
+  theOtherIL = 0.f;
 
   //HGCal
-  theAirIL              = 0.f;
-  theCablesIL           = 0.f;
-  theCopperIL           = 0.f;
-  theH_ScintillatorIL   = 0.f;
-  theLeadIL             = 0.f;
-  theEpoxyIL            = 0.f;
-  theKaptonIL           = 0.f;
-  theAluminiumIL           = 0.f;
+  theAirIL = 0.f;
+  theCablesIL = 0.f;
+  theCopperIL = 0.f;
+  theH_ScintillatorIL = 0.f;
+  theLeadIL = 0.f;
+  theEpoxyIL = 0.f;
+  theKaptonIL = 0.f;
+  theAluminiumIL = 0.f;
   theHGC_G10_FR4IL = 0.f;
-  theSiliconIL          = 0.f;
-  theStainlessSteelIL   = 0.f;
-  theWCuIL              = 0.f;
-  
-  theSupportFractionMB     = 0.f;
-  theSensitiveFractionMB   = 0.f;
-  theCoolingFractionMB     = 0.f;
-  theElectronicsFractionMB = 0.f;
-  theOtherFractionMB       = 0.f;
-  //HGCal
-  theAirFractionMB               = 0.f;
-  theCablesFractionMB            = 0.f;
-  theCopperFractionMB            = 0.f;
-  theH_ScintillatorFractionMB    = 0.f;
-  theLeadFractionMB              = 0.f;
-  theEpoxyFractionMB             = 0.f;
-  theKaptonFractionMB            = 0.f;
-  theAluminiumFractionMB            = 0.f;
-  theHGC_G10_FR4FractionMB  = 0.f;
-  theSiliconFractionMB           = 0.f;
-  theStainlessSteelFractionMB    = 0.f;
-  theWCuFractionMB               = 0.f;
+  theSiliconIL = 0.f;
+  theStainlessSteelIL = 0.f;
+  theWCuIL = 0.f;
 
-  theSupportFractionIL     = 0.f;
-  theSensitiveFractionIL   = 0.f;
-  theCoolingFractionIL     = 0.f;
-  theElectronicsFractionIL = 0.f;
-  theOtherFractionIL       = 0.f;
+  theSupportFractionMB = 0.f;
+  theSensitiveFractionMB = 0.f;
+  theCoolingFractionMB = 0.f;
+  theElectronicsFractionMB = 0.f;
+  theOtherFractionMB = 0.f;
   //HGCal
-  theAirFractionIL               = 0.f;
-  theCablesFractionIL            = 0.f;
-  theCopperFractionIL            = 0.f;
-  theH_ScintillatorFractionIL    = 0.f;
-  theLeadFractionIL              = 0.f;
-  theEpoxyFractionIL             = 0.f;
-  theKaptonFractionIL            = 0.f;
-  theAluminiumFractionIL            = 0.f;
-  theHGC_G10_FR4FractionIL  = 0.f;
-  theSiliconFractionIL           = 0.f;
-  theStainlessSteelFractionIL    = 0.f;
-  theWCuFractionIL               = 0.f;
-  
+  theAirFractionMB = 0.f;
+  theCablesFractionMB = 0.f;
+  theCopperFractionMB = 0.f;
+  theH_ScintillatorFractionMB = 0.f;
+  theLeadFractionMB = 0.f;
+  theEpoxyFractionMB = 0.f;
+  theKaptonFractionMB = 0.f;
+  theAluminiumFractionMB = 0.f;
+  theHGC_G10_FR4FractionMB = 0.f;
+  theSiliconFractionMB = 0.f;
+  theStainlessSteelFractionMB = 0.f;
+  theWCuFractionMB = 0.f;
+
+  theSupportFractionIL = 0.f;
+  theSensitiveFractionIL = 0.f;
+  theCoolingFractionIL = 0.f;
+  theElectronicsFractionIL = 0.f;
+  theOtherFractionIL = 0.f;
+  //HGCal
+  theAirFractionIL = 0.f;
+  theCablesFractionIL = 0.f;
+  theCopperFractionIL = 0.f;
+  theH_ScintillatorFractionIL = 0.f;
+  theLeadFractionIL = 0.f;
+  theEpoxyFractionIL = 0.f;
+  theKaptonFractionIL = 0.f;
+  theAluminiumFractionIL = 0.f;
+  theHGC_G10_FR4FractionIL = 0.f;
+  theSiliconFractionIL = 0.f;
+  theStainlessSteelFractionIL = 0.f;
+  theWCuFractionIL = 0.f;
+
   theID = (int)(aTrack->GetDefinition()->GetPDGEncoding());
   thePt = dir.perp();
-  if( dir.theta() != 0 ) {
-    theEta = dir.eta(); 
+  if (dir.theta() != 0) {
+    theEta = dir.eta();
   } else {
     theEta = -99;
   }
   thePhi = dir.phi();
   theEnergy = aTrack->GetTotalEnergy();
-  theMass = aTrack->GetDefinition()->GetPDGMass();  
+  theMass = aTrack->GetDefinition()->GetPDGMass();
 }
 
+void MaterialBudgetData::dataEndTrack(const G4Track* aTrack) {
+  LogDebug("MaterialBudget") << "MaterialBudgetData: [OVAL] MaterialBudget "
+                             << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID()
+                             << " Eta:" << theEta << " Phi:" << thePhi << " TotalMB" << theTotalMB;
 
-void MaterialBudgetData::dataEndTrack( const G4Track* aTrack )
-{
-  LogDebug("MaterialBudget") << "MaterialBudgetData: [OVAL] MaterialBudget " 
-			     << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() 
-			     << " Eta:" << theEta << " Phi:" << thePhi << " TotalMB" << theTotalMB;
-  
   LogDebug("MaterialBudget") << "MaterialBudgetData:" << theStepN << "Recorded steps ";
 
-  if (!isHGCal){
-    
-    LogDebug("Material Budget") <<"MaterialBudgetData: Radiation Length " 
-				<< G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() 
-				<< " Eta" << theEta << " Phi" << thePhi 
-				<< " TotalMB" << theTotalMB 
-				<< " SUP " << theSupportMB << " SEN " << theSensitiveMB 
-				<< " CAB " << theCablesMB << " COL " << theCoolingMB 
-				<< " ELE " << theElectronicsMB << " other " << theOtherMB 
-				<< " Air " << theAirMB;
+  if (!isHGCal) {
+    LogDebug("Material Budget") << "MaterialBudgetData: Radiation Length "
+                                << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() << " Eta"
+                                << theEta << " Phi" << thePhi << " TotalMB" << theTotalMB << " SUP " << theSupportMB
+                                << " SEN " << theSensitiveMB << " CAB " << theCablesMB << " COL " << theCoolingMB
+                                << " ELE " << theElectronicsMB << " other " << theOtherMB << " Air " << theAirMB;
 
-    LogDebug("Material Budget") << "MaterialBudgetData: Interaction Length " 
-				<< G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() 
-				<< " Eta " << theEta << " Phi " << thePhi 
-				<< " TotalIL " << theTotalIL
-				<< " SUP " << theSupportIL << " SEN " << theSensitiveIL 
-				<< " CAB " << theCablesIL << " COL " << theCoolingIL 
-				<< " ELE " << theElectronicsIL << " other " << theOtherIL 
-				<< " Air " << theAirIL << std::endl;
+    LogDebug("Material Budget") << "MaterialBudgetData: Interaction Length "
+                                << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() << " Eta "
+                                << theEta << " Phi " << thePhi << " TotalIL " << theTotalIL << " SUP " << theSupportIL
+                                << " SEN " << theSensitiveIL << " CAB " << theCablesIL << " COL " << theCoolingIL
+                                << " ELE " << theElectronicsIL << " other " << theOtherIL << " Air " << theAirIL
+                                << std::endl;
 
   } else {
+    LogDebug("MaterialBudget") << "MaterialBudgetData: HGCal Material Budget: Radiation Length "
+                               << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() << " Eta "
+                               << theEta << " Phi " << thePhi << " TotaLMB" << theTotalMB << " theCopperMB "
+                               << theCopperMB << " theH_ScintillatorMB " << theH_ScintillatorMB << " CAB "
+                               << theCablesMB << " theLeadMB " << theLeadMB << " theEpoxyMB " << theEpoxyMB
+                               << " theKaptonMB " << theKaptonMB << " theAluminiumMB " << theAluminiumMB
+                               << " theHGC_G10_FR4MB " << theHGC_G10_FR4MB << " theSiliconMB " << theSiliconMB
+                               << " theAirMB " << theAirMB << " theStainlessSteelMB " << theStainlessSteelMB
+                               << " theWCuMB " << theWCuMB;
 
-    LogDebug("MaterialBudget") << "MaterialBudgetData: HGCal Material Budget: Radiation Length " 
-			       << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() 
-			       << " Eta " << theEta << " Phi " << thePhi 
-			       << " TotaLMB" << theTotalMB 
-			       << " theCopperMB " << theCopperMB << " theH_ScintillatorMB " << theH_ScintillatorMB 
-			       << " CAB " << theCablesMB << " theLeadMB " << theLeadMB << " theEpoxyMB " << theEpoxyMB << " theKaptonMB " << theKaptonMB << " theAluminiumMB " << theAluminiumMB << " theHGC_G10_FR4MB " 
-			       << theHGC_G10_FR4MB << " theSiliconMB " << theSiliconMB 
-			       << " theAirMB " << theAirMB << " theStainlessSteelMB " << theStainlessSteelMB 
-			       << " theWCuMB " << theWCuMB;
-    
-    LogDebug("MaterialBudget") << "MaterialBudgetData: HGCal Material Budget: Interaction Length " 
-			       << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() 
-			       << " Eta " << theEta << " Phi " << thePhi 
-			       << " TotalIL " << theTotalIL << " theCopperIL " << theCopperIL 
-			       << " theH_ScintillatorIL " << theH_ScintillatorIL 
-			       << " CAB " << theCablesIL << " theLeadIL " << theLeadIL  << " theEpoxyIL " << theEpoxyIL
-			       << " theKaptonIL " << theKaptonIL << " theAluminiumIL " << theAluminiumIL << " theHGC_G10_FR4IL " 
-			       << theHGC_G10_FR4IL << " theSiliconIL " << theSiliconIL << " Air " 
-			       << theAirIL << " theStainlessSteelIL " << theStainlessSteelIL 
-			       << " theWCuIL " << theWCuIL << std::endl;
+    LogDebug("MaterialBudget") << "MaterialBudgetData: HGCal Material Budget: Interaction Length "
+                               << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() << " Eta "
+                               << theEta << " Phi " << thePhi << " TotalIL " << theTotalIL << " theCopperIL "
+                               << theCopperIL << " theH_ScintillatorIL " << theH_ScintillatorIL << " CAB "
+                               << theCablesIL << " theLeadIL " << theLeadIL << " theEpoxyIL " << theEpoxyIL
+                               << " theKaptonIL " << theKaptonIL << " theAluminiumIL " << theAluminiumIL
+                               << " theHGC_G10_FR4IL " << theHGC_G10_FR4IL << " theSiliconIL " << theSiliconIL
+                               << " Air " << theAirIL << " theStainlessSteelIL " << theStainlessSteelIL << " theWCuIL "
+                               << theWCuIL << std::endl;
   }
 }
 
-void MaterialBudgetData::dataPerStep( const G4Step* aStep )
-{
+void MaterialBudgetData::dataPerStep(const G4Step* aStep) {
   assert(aStep);
-  G4StepPoint* prePoint  = aStep->GetPreStepPoint();
+  G4StepPoint* prePoint = aStep->GetPreStepPoint();
   G4StepPoint* postPoint = aStep->GetPostStepPoint();
   assert(prePoint);
   assert(postPoint);
-  G4Material * theMaterialPre = prePoint->GetMaterial();
+  G4Material* theMaterialPre = prePoint->GetMaterial();
   assert(theMaterialPre);
-  
-  CLHEP::Hep3Vector prePos  = prePoint->GetPosition();
+
+  CLHEP::Hep3Vector prePos = prePoint->GetPosition();
   CLHEP::Hep3Vector postPos = postPoint->GetPosition();
 
   G4double steplen = aStep->GetStepLength();
 
   G4double radlen = theMaterialPre->GetRadlen();
   G4double intlen = theMaterialPre->GetNuclearInterLength();
-  G4double density = theMaterialPre->GetDensity() / densityConvertionFactor; // always g/cm3
-  
+  G4double density = theMaterialPre->GetDensity() / densityConvertionFactor;  // always g/cm3
+
   G4String materialName = theMaterialPre->GetName();
-  
-  LogDebug("MaterialBudget") << "MaterialBudgetData: Material " << materialName
-			     << " steplen " << steplen
-			     << " radlen " << radlen 
-			     << " mb " << steplen/radlen;
+
+  LogDebug("MaterialBudget") << "MaterialBudgetData: Material " << materialName << " steplen " << steplen << " radlen "
+                             << radlen << " mb " << steplen / radlen;
 
   G4String volumeName = aStep->GetPreStepPoint()->GetTouchable()->GetVolume(0)->GetLogicalVolume()->GetName();
 
-  LogDebug("MaterialBudget") << "MaterialBudgetData: Volume " << volumeName
-			     << " Material " << materialName;
+  LogDebug("MaterialBudget") << "MaterialBudgetData: Volume " << volumeName << " Material " << materialName;
 
   // instantiate the categorizer
   assert(myMaterialBudgetCategorizer);
-  int volumeID   = myMaterialBudgetCategorizer->volume( volumeName );
-  int materialID = myMaterialBudgetCategorizer->material( materialName );
+  int volumeID = myMaterialBudgetCategorizer->volume(volumeName);
+  int materialID = myMaterialBudgetCategorizer->material(materialName);
 
-  LogDebug("MaterialBudget") << "MaterialBudgetData: Volume ID " << volumeID 
-			     << " Material ID " << materialID;
+  LogDebug("MaterialBudget") << "MaterialBudgetData: Volume ID " << volumeID << " Material ID " << materialID;
 
   // FIXME: Both volume ID and material ID are zeros, so this part is not executed leaving all
-  // values as zeros. 
+  // values as zeros.
 
-  if (!isHGCal){
+  if (!isHGCal) {
+    bool isCtgOk = !myMaterialBudgetCategorizer->x0fraction(materialName).empty() &&
+                   !myMaterialBudgetCategorizer->l0fraction(materialName).empty() &&
+                   (myMaterialBudgetCategorizer->x0fraction(materialName).size() == 7) /*7 Categories*/
+                   && (myMaterialBudgetCategorizer->l0fraction(materialName).size() == 7);
 
-    bool isCtgOk = !myMaterialBudgetCategorizer->x0fraction(materialName).empty()
-      && !myMaterialBudgetCategorizer->l0fraction(materialName).empty()
-      && (myMaterialBudgetCategorizer->x0fraction(materialName).size() == 7) /*7 Categories*/
-      && (myMaterialBudgetCategorizer->l0fraction(materialName).size() == 7);
-   
-    if(!isCtgOk) 
-      {
-	if(materialName.compare("Air") == 0){
-	  theAirFractionMB = 1.f;
-	  theAirFractionIL = 1.f;
-	} else {
-	  theOtherFractionMB = 1.f;
-	  theOtherFractionIL = 1.f;
-	  edm::LogWarning("MaterialBudget")
-	    << "MaterialBudgetData: Material forced to 'Other': " << materialName 
-	    << " in volume " << volumeName << ". Check Categorization.";
-	}
+    if (!isCtgOk) {
+      if (materialName.compare("Air") == 0) {
+        theAirFractionMB = 1.f;
+        theAirFractionIL = 1.f;
+      } else {
+        theOtherFractionMB = 1.f;
+        theOtherFractionIL = 1.f;
+        edm::LogWarning("MaterialBudget") << "MaterialBudgetData: Material forced to 'Other': " << materialName
+                                          << " in volume " << volumeName << ". Check Categorization.";
       }
-    else 
-      {
-	theSupportFractionMB     = myMaterialBudgetCategorizer->x0fraction(materialName)[0];
-	theSensitiveFractionMB   = myMaterialBudgetCategorizer->x0fraction(materialName)[1];
-	theCablesFractionMB      = myMaterialBudgetCategorizer->x0fraction(materialName)[2];
-	theCoolingFractionMB     = myMaterialBudgetCategorizer->x0fraction(materialName)[3];
-	theElectronicsFractionMB = myMaterialBudgetCategorizer->x0fraction(materialName)[4];
-	theOtherFractionMB       = myMaterialBudgetCategorizer->x0fraction(materialName)[5];
-	theAirFractionMB         = myMaterialBudgetCategorizer->x0fraction(materialName)[6];
-      
-	if(theOtherFractionMB > 0.f)
-	  edm::LogWarning("MaterialBudget") << "MaterialBudgetData: Material found with no category: " << materialName 
-					    << " in volume " << volumeName;
+    } else {
+      theSupportFractionMB = myMaterialBudgetCategorizer->x0fraction(materialName)[0];
+      theSensitiveFractionMB = myMaterialBudgetCategorizer->x0fraction(materialName)[1];
+      theCablesFractionMB = myMaterialBudgetCategorizer->x0fraction(materialName)[2];
+      theCoolingFractionMB = myMaterialBudgetCategorizer->x0fraction(materialName)[3];
+      theElectronicsFractionMB = myMaterialBudgetCategorizer->x0fraction(materialName)[4];
+      theOtherFractionMB = myMaterialBudgetCategorizer->x0fraction(materialName)[5];
+      theAirFractionMB = myMaterialBudgetCategorizer->x0fraction(materialName)[6];
 
-	theSupportFractionIL     = myMaterialBudgetCategorizer->l0fraction(materialName)[0];
-	theSensitiveFractionIL   = myMaterialBudgetCategorizer->l0fraction(materialName)[1];
-	theCablesFractionIL      = myMaterialBudgetCategorizer->l0fraction(materialName)[2];
-	theCoolingFractionIL     = myMaterialBudgetCategorizer->l0fraction(materialName)[3];
-	theElectronicsFractionIL = myMaterialBudgetCategorizer->l0fraction(materialName)[4];
-	theOtherFractionIL       = myMaterialBudgetCategorizer->l0fraction(materialName)[5];
-	theAirFractionIL         = myMaterialBudgetCategorizer->l0fraction(materialName)[6];
+      if (theOtherFractionMB > 0.f)
+        edm::LogWarning("MaterialBudget")
+            << "MaterialBudgetData: Material found with no category: " << materialName << " in volume " << volumeName;
 
-	if(theOtherFractionIL > 0.f)
-	  edm::LogWarning("MaterialBudget") << "MaterialBudgetData: Material found with no category: " << materialName 
-					    << " in volume " << volumeName;
-      }
-  }  else { // isHGCal
+      theSupportFractionIL = myMaterialBudgetCategorizer->l0fraction(materialName)[0];
+      theSensitiveFractionIL = myMaterialBudgetCategorizer->l0fraction(materialName)[1];
+      theCablesFractionIL = myMaterialBudgetCategorizer->l0fraction(materialName)[2];
+      theCoolingFractionIL = myMaterialBudgetCategorizer->l0fraction(materialName)[3];
+      theElectronicsFractionIL = myMaterialBudgetCategorizer->l0fraction(materialName)[4];
+      theOtherFractionIL = myMaterialBudgetCategorizer->l0fraction(materialName)[5];
+      theAirFractionIL = myMaterialBudgetCategorizer->l0fraction(materialName)[6];
+
+      if (theOtherFractionIL > 0.f)
+        edm::LogWarning("MaterialBudget")
+            << "MaterialBudgetData: Material found with no category: " << materialName << " in volume " << volumeName;
+    }
+  } else {  // isHGCal
 
     bool isHGCalx0fractionEmpty = myMaterialBudgetCategorizer->HGCalx0fraction(materialName).empty();
     bool isHGCall0fractionEmpty = myMaterialBudgetCategorizer->HGCall0fraction(materialName).empty();
-    
-    if( isHGCalx0fractionEmpty && isHGCall0fractionEmpty ) {
+
+    if (isHGCalx0fractionEmpty && isHGCall0fractionEmpty) {
       theOtherFractionMB = 1.f;
       theOtherFractionIL = 1.f;
 
-      edm::LogWarning("MaterialBudget") << "MaterialBudgetData: Material forced to 'Other': " << materialName 
-					<< " in volume " << volumeName;
-    } else{
-    
-      theAirFractionMB              = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[0];
-      theCablesFractionMB           = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[1];
-      theCopperFractionMB           = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[2];
-      theH_ScintillatorFractionMB   = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[3];
-      theLeadFractionMB             = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[4];
+      edm::LogWarning("MaterialBudget") << "MaterialBudgetData: Material forced to 'Other': " << materialName
+                                        << " in volume " << volumeName;
+    } else {
+      theAirFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[0];
+      theCablesFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[1];
+      theCopperFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[2];
+      theH_ScintillatorFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[3];
+      theLeadFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[4];
       theHGC_G10_FR4FractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[5];
-      theSiliconFractionMB          = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[6];
-      theStainlessSteelFractionMB   = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[7];
-      theWCuFractionMB              = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[8];
-      theOtherFractionMB            = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[9];
-      theEpoxyFractionMB            = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[10];
-      theKaptonFractionMB           = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[11];
-      theAluminiumFractionMB           = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[12];
+      theSiliconFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[6];
+      theStainlessSteelFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[7];
+      theWCuFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[8];
+      theOtherFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[9];
+      theEpoxyFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[10];
+      theKaptonFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[11];
+      theAluminiumFractionMB = myMaterialBudgetCategorizer->HGCalx0fraction(materialName)[12];
 
-    
-      if(theOtherFractionMB!=0) 
-	// edm::LogWarning("MaterialBudget") << "MaterialBudgetData: Material found with no category: " << materialName 
-	// 				  << " in volume " << volumeName << std::endl;
-	std::cout << "MaterialBudgetData: Material found with no category: " << materialName 
-					  << " in volume " << volumeName << std::endl;
+      if (theOtherFractionMB != 0)
+        // edm::LogWarning("MaterialBudget") << "MaterialBudgetData: Material found with no category: " << materialName
+        // 				  << " in volume " << volumeName << std::endl;
+        std::cout << "MaterialBudgetData: Material found with no category: " << materialName << " in volume "
+                  << volumeName << std::endl;
 
-      theAirFractionIL              = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[0];
-      theCablesFractionIL           = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[1];
-      theCopperFractionIL           = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[2];
-      theH_ScintillatorFractionIL   = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[3];
-      theLeadFractionIL             = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[4];
+      theAirFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[0];
+      theCablesFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[1];
+      theCopperFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[2];
+      theH_ScintillatorFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[3];
+      theLeadFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[4];
       theHGC_G10_FR4FractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[5];
-      theSiliconFractionIL          = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[6];
-      theStainlessSteelFractionIL   = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[7];
-      theWCuFractionIL              = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[8];
-      theOtherFractionIL            = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[9];
-      theEpoxyFractionIL            = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[10];
-      theKaptonFractionIL            = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[11];
-      theAluminiumFractionIL            = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[12];
+      theSiliconFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[6];
+      theStainlessSteelFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[7];
+      theWCuFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[8];
+      theOtherFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[9];
+      theEpoxyFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[10];
+      theKaptonFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[11];
+      theAluminiumFractionIL = myMaterialBudgetCategorizer->HGCall0fraction(materialName)[12];
 
-
-      if(theOtherFractionIL!=0) 
-	edm::LogWarning("MaterialBudget") << "MaterialBudgetData: Material found with no category " << materialName 
-					  << " in volume " << volumeName << std::endl;
+      if (theOtherFractionIL != 0)
+        edm::LogWarning("MaterialBudget") << "MaterialBudgetData: Material found with no category " << materialName
+                                          << " in volume " << volumeName << std::endl;
     }
   }
-  
-  float dmb = steplen/radlen;
-  float dil = steplen/intlen;
-  
-  G4VPhysicalVolume*       pv                = aStep->GetPreStepPoint()->GetPhysicalVolume();
-  const G4VTouchable*      t                 = aStep->GetPreStepPoint()->GetTouchable();
-  const G4ThreeVector&            objectTranslation = t->GetTranslation();
-  const G4RotationMatrix*  objectRotation    = t->GetRotation();
-  const G4VProcess*        interactionPre    = prePoint->GetProcessDefinedStep();
-  const G4VProcess*        interactionPost   = postPoint->GetProcessDefinedStep();
-  
+
+  float dmb = steplen / radlen;
+  float dil = steplen / intlen;
+
+  G4VPhysicalVolume* pv = aStep->GetPreStepPoint()->GetPhysicalVolume();
+  const G4VTouchable* t = aStep->GetPreStepPoint()->GetTouchable();
+  const G4ThreeVector& objectTranslation = t->GetTranslation();
+  const G4RotationMatrix* objectRotation = t->GetRotation();
+  const G4VProcess* interactionPre = prePoint->GetProcessDefinedStep();
+  const G4VProcess* interactionPost = postPoint->GetProcessDefinedStep();
+
   G4Track* track = aStep->GetTrack();
-  if(theStepN==0) 
-    LogDebug("MaterialBudget") << "MaterialBudgetData: Simulated Particle " << theID 
-			       << "\tMass " << theMass << " MeV/c2"
-			       << "\tPt = " << thePt  << " MeV/c" 
-			       << "\tEta = " << theEta 
-			       << "\tPhi = " << thePhi 
-			       << "\tEnergy = " << theEnergy << " MeV";
+  if (theStepN == 0)
+    LogDebug("MaterialBudget") << "MaterialBudgetData: Simulated Particle " << theID << "\tMass " << theMass
+                               << " MeV/c2"
+                               << "\tPt = " << thePt << " MeV/c"
+                               << "\tEta = " << theEta << "\tPhi = " << thePhi << "\tEnergy = " << theEnergy << " MeV";
 
   //fill data per step
-  if( allStepsToTree ){
+  if (allStepsToTree) {
     assert(theStepN < MAXNUMBERSTEPS);
-    if( theStepN > MAXNUMBERSTEPS ) theStepN = MAXNUMBERSTEPS - 1;
+    if (theStepN > MAXNUMBERSTEPS)
+      theStepN = MAXNUMBERSTEPS - 1;
     theDmb[theStepN] = dmb;
     theDil[theStepN] = dil;
-    theSupportDmb[theStepN]     = (dmb * theSupportFractionMB);
-    theSensitiveDmb[theStepN]   = (dmb * theSensitiveFractionMB);
-    theCoolingDmb[theStepN]     = (dmb * theCoolingFractionMB);
+    theSupportDmb[theStepN] = (dmb * theSupportFractionMB);
+    theSensitiveDmb[theStepN] = (dmb * theSensitiveFractionMB);
+    theCoolingDmb[theStepN] = (dmb * theCoolingFractionMB);
     theElectronicsDmb[theStepN] = (dmb * theElectronicsFractionMB);
-    theOtherDmb[theStepN]       = (dmb * theOtherFractionMB);
+    theOtherDmb[theStepN] = (dmb * theOtherFractionMB);
     //HGCal
-    theAirDmb[theStepN]                 = (dmb * theAirFractionMB);
-    theCablesDmb[theStepN]              = (dmb * theCablesFractionMB);
-    theCopperDmb[theStepN]              = (dmb * theCopperFractionMB);                       
-    theH_ScintillatorDmb[theStepN]      = (dmb * theH_ScintillatorFractionMB);       
-    theLeadDmb[theStepN]                = (dmb * theLeadFractionMB);                           
-    theEpoxyDmb[theStepN]               = (dmb * theEpoxyFractionMB);                           
-    theKaptonDmb[theStepN]              = (dmb * theKaptonFractionMB);                           
-    theAluminiumDmb[theStepN]           = (dmb * theAluminiumFractionMB);                           
-    theHGC_G10_FR4Dmb[theStepN]    = (dmb * theHGC_G10_FR4FractionMB);   
-    theSiliconDmb[theStepN]             = (dmb * theSiliconFractionMB);                     
-    theStainlessSteelDmb[theStepN]      = (dmb * theStainlessSteelFractionMB);       
-    theWCuDmb[theStepN]                 = (dmb * theWCuFractionMB);                             
+    theAirDmb[theStepN] = (dmb * theAirFractionMB);
+    theCablesDmb[theStepN] = (dmb * theCablesFractionMB);
+    theCopperDmb[theStepN] = (dmb * theCopperFractionMB);
+    theH_ScintillatorDmb[theStepN] = (dmb * theH_ScintillatorFractionMB);
+    theLeadDmb[theStepN] = (dmb * theLeadFractionMB);
+    theEpoxyDmb[theStepN] = (dmb * theEpoxyFractionMB);
+    theKaptonDmb[theStepN] = (dmb * theKaptonFractionMB);
+    theAluminiumDmb[theStepN] = (dmb * theAluminiumFractionMB);
+    theHGC_G10_FR4Dmb[theStepN] = (dmb * theHGC_G10_FR4FractionMB);
+    theSiliconDmb[theStepN] = (dmb * theSiliconFractionMB);
+    theStainlessSteelDmb[theStepN] = (dmb * theStainlessSteelFractionMB);
+    theWCuDmb[theStepN] = (dmb * theWCuFractionMB);
 
-    theSupportDil[theStepN]     = (dil * theSupportFractionIL);
-    theSensitiveDil[theStepN]   = (dil * theSensitiveFractionIL);
-    theCoolingDil[theStepN]     = (dil * theCoolingFractionIL);
+    theSupportDil[theStepN] = (dil * theSupportFractionIL);
+    theSensitiveDil[theStepN] = (dil * theSensitiveFractionIL);
+    theCoolingDil[theStepN] = (dil * theCoolingFractionIL);
     theElectronicsDil[theStepN] = (dil * theElectronicsFractionIL);
-    theOtherDil[theStepN]       = (dil * theOtherFractionIL);
+    theOtherDil[theStepN] = (dil * theOtherFractionIL);
     //HGCal
-    theAirDil[theStepN]                 = (dil * theAirFractionIL);
-    theCablesDil[theStepN]              = (dil * theCablesFractionIL);
-    theCopperDil[theStepN]              = (dil * theCopperFractionIL);                       
-    theH_ScintillatorDil[theStepN]      = (dil * theH_ScintillatorFractionIL);       
-    theLeadDil[theStepN]                = (dil * theLeadFractionIL);                           
-    theEpoxyDil[theStepN]               = (dil * theEpoxyFractionIL);                           
-    theKaptonDil[theStepN]              = (dil * theKaptonFractionIL);                           
-    theAluminiumDil[theStepN]           = (dil * theAluminiumFractionIL);                           
-    theHGC_G10_FR4Dil[theStepN]    = (dil * theHGC_G10_FR4FractionIL);   
-    theSiliconDil[theStepN]             = (dil * theSiliconFractionIL);                     
-    theStainlessSteelDil[theStepN]      = (dil * theStainlessSteelFractionIL);       
-    theWCuDil[theStepN]                 = (dil * theWCuFractionIL);                             
+    theAirDil[theStepN] = (dil * theAirFractionIL);
+    theCablesDil[theStepN] = (dil * theCablesFractionIL);
+    theCopperDil[theStepN] = (dil * theCopperFractionIL);
+    theH_ScintillatorDil[theStepN] = (dil * theH_ScintillatorFractionIL);
+    theLeadDil[theStepN] = (dil * theLeadFractionIL);
+    theEpoxyDil[theStepN] = (dil * theEpoxyFractionIL);
+    theKaptonDil[theStepN] = (dil * theKaptonFractionIL);
+    theAluminiumDil[theStepN] = (dil * theAluminiumFractionIL);
+    theHGC_G10_FR4Dil[theStepN] = (dil * theHGC_G10_FR4FractionIL);
+    theSiliconDil[theStepN] = (dil * theSiliconFractionIL);
+    theStainlessSteelDil[theStepN] = (dil * theStainlessSteelFractionIL);
+    theWCuDil[theStepN] = (dil * theWCuFractionIL);
 
     theInitialX[theStepN] = prePos.x();
     theInitialY[theStepN] = prePos.y();
     theInitialZ[theStepN] = prePos.z();
-    theFinalX[theStepN]   = postPos.x();
-    theFinalY[theStepN]   = postPos.y();
-    theFinalZ[theStepN]   = postPos.z();
-    theVolumeID[theStepN]   = volumeID;
+    theFinalX[theStepN] = postPos.x();
+    theFinalY[theStepN] = postPos.y();
+    theFinalZ[theStepN] = postPos.z();
+    theVolumeID[theStepN] = volumeID;
     theVolumeName[theStepN] = volumeName;
     theVolumeCopy[theStepN] = pv->GetCopyNo();
-    theVolumeX[theStepN]    = objectTranslation.x();
-    theVolumeY[theStepN]    = objectTranslation.y();
-    theVolumeZ[theStepN]    = objectTranslation.z();
+    theVolumeX[theStepN] = objectTranslation.x();
+    theVolumeY[theStepN] = objectTranslation.y();
+    theVolumeZ[theStepN] = objectTranslation.z();
     theVolumeXaxis1[theStepN] = objectRotation->xx();
     theVolumeXaxis2[theStepN] = objectRotation->xy();
     theVolumeXaxis3[theStepN] = objectRotation->xz();
@@ -416,142 +385,105 @@ void MaterialBudgetData::dataPerStep( const G4Step* aStep )
     theVolumeZaxis1[theStepN] = objectRotation->zx();
     theVolumeZaxis2[theStepN] = objectRotation->zy();
     theVolumeZaxis3[theStepN] = objectRotation->zz();
-    theMaterialID[theStepN]      = materialID;
-    theMaterialName[theStepN]    = materialName;
-    theMaterialX0[theStepN]      = radlen;
+    theMaterialID[theStepN] = materialID;
+    theMaterialName[theStepN] = materialName;
+    theMaterialX0[theStepN] = radlen;
     theMaterialLambda0[theStepN] = intlen;
     theMaterialDensity[theStepN] = density;
-    theStepID[theStepN]             = track->GetDefinition()->GetPDGEncoding();
-    theStepInitialPt[theStepN]      = prePoint->GetMomentum().perp();
-    theStepInitialEta[theStepN]     = prePoint->GetMomentum().eta();
-    theStepInitialPhi[theStepN]     = prePoint->GetMomentum().phi();
-    theStepInitialEnergy[theStepN]  = prePoint->GetTotalEnergy();
-    theStepInitialPx[theStepN]      = prePoint->GetMomentum().x();
-    theStepInitialPy[theStepN]      = prePoint->GetMomentum().y();
-    theStepInitialPz[theStepN]      = prePoint->GetMomentum().z();
-    theStepInitialBeta[theStepN]    = prePoint->GetBeta();
-    theStepInitialGamma[theStepN]   = prePoint->GetGamma();
-    theStepInitialMass[theStepN]    = prePoint->GetMass();
-    theStepFinalPt[theStepN]        = postPoint->GetMomentum().perp();
-    theStepFinalEta[theStepN]       = postPoint->GetMomentum().eta();
-    theStepFinalPhi[theStepN]       = postPoint->GetMomentum().phi();
-    theStepFinalEnergy[theStepN]    = postPoint->GetTotalEnergy();
-    theStepFinalPx[theStepN]        = postPoint->GetMomentum().x();
-    theStepFinalPy[theStepN]        = postPoint->GetMomentum().y();
-    theStepFinalPz[theStepN]        = postPoint->GetMomentum().z();
-    theStepFinalBeta[theStepN]      = postPoint->GetBeta();
-    theStepFinalGamma[theStepN]     = postPoint->GetGamma();
-    theStepFinalMass[theStepN]      = postPoint->GetMass();
-    int preProcType  = -99;
+    theStepID[theStepN] = track->GetDefinition()->GetPDGEncoding();
+    theStepInitialPt[theStepN] = prePoint->GetMomentum().perp();
+    theStepInitialEta[theStepN] = prePoint->GetMomentum().eta();
+    theStepInitialPhi[theStepN] = prePoint->GetMomentum().phi();
+    theStepInitialEnergy[theStepN] = prePoint->GetTotalEnergy();
+    theStepInitialPx[theStepN] = prePoint->GetMomentum().x();
+    theStepInitialPy[theStepN] = prePoint->GetMomentum().y();
+    theStepInitialPz[theStepN] = prePoint->GetMomentum().z();
+    theStepInitialBeta[theStepN] = prePoint->GetBeta();
+    theStepInitialGamma[theStepN] = prePoint->GetGamma();
+    theStepInitialMass[theStepN] = prePoint->GetMass();
+    theStepFinalPt[theStepN] = postPoint->GetMomentum().perp();
+    theStepFinalEta[theStepN] = postPoint->GetMomentum().eta();
+    theStepFinalPhi[theStepN] = postPoint->GetMomentum().phi();
+    theStepFinalEnergy[theStepN] = postPoint->GetTotalEnergy();
+    theStepFinalPx[theStepN] = postPoint->GetMomentum().x();
+    theStepFinalPy[theStepN] = postPoint->GetMomentum().y();
+    theStepFinalPz[theStepN] = postPoint->GetMomentum().z();
+    theStepFinalBeta[theStepN] = postPoint->GetBeta();
+    theStepFinalGamma[theStepN] = postPoint->GetGamma();
+    theStepFinalMass[theStepN] = postPoint->GetMass();
+    int preProcType = -99;
     int postProcType = -99;
-    if (interactionPre) preProcType = interactionPre->GetProcessType();
-    theStepPreProcess[theStepN]     = preProcType;
-    if (interactionPost) postProcType = interactionPost->GetProcessType();
-    theStepPostProcess[theStepN]    = postProcType;
-    
-    LogDebug("MaterialBudget") 
-      << "MaterialBudgetData: Step " << theStepN
-      << "\tDelta MB = " << theDmb[theStepN]
-      << std::endl
-      << " Support "  << theSupportDmb[theStepN]
-      << " Sensitive "   << theSensitiveDmb[theStepN]
-      << " Cables "      << theCablesDmb[theStepN]
-      << " Cooling "     << theCoolingDmb[theStepN]
-      << " Electronics " << theElectronicsDmb[theStepN]
-      << " Other "       << theOtherDmb[theStepN]
-      << " Air "         << theAirDmb[theStepN]
-      << std::endl
-      << "\tDelta IL = " << theDil[theStepN]
-      << std::endl
-      << " Support "  << theSupportDil[theStepN]
-      << " Sensitive "   << theSensitiveDil[theStepN]
-      << " Cables "      << theCablesDil[theStepN]
-      << " Cooling "     << theCoolingDil[theStepN]
-      << " Electronics " << theElectronicsDil[theStepN]
-      << " Other "       << theOtherDil[theStepN]
-      << " Air "         << theAirDil[theStepN];
-    
     if (interactionPre)
-      LogDebug("MaterialBudget") 
-	<< "MaterialBudgetData: Process Pre " << interactionPre->GetProcessName()
-	<< " type " << theStepPreProcess[theStepN] 
-	<< " name " << interactionPre->GetProcessTypeName(G4ProcessType(theStepPreProcess[theStepN]));
+      preProcType = interactionPre->GetProcessType();
+    theStepPreProcess[theStepN] = preProcType;
+    if (interactionPost)
+      postProcType = interactionPost->GetProcessType();
+    theStepPostProcess[theStepN] = postProcType;
+
+    LogDebug("MaterialBudget") << "MaterialBudgetData: Step " << theStepN << "\tDelta MB = " << theDmb[theStepN]
+                               << std::endl
+                               << " Support " << theSupportDmb[theStepN] << " Sensitive " << theSensitiveDmb[theStepN]
+                               << " Cables " << theCablesDmb[theStepN] << " Cooling " << theCoolingDmb[theStepN]
+                               << " Electronics " << theElectronicsDmb[theStepN] << " Other " << theOtherDmb[theStepN]
+                               << " Air " << theAirDmb[theStepN] << std::endl
+                               << "\tDelta IL = " << theDil[theStepN] << std::endl
+                               << " Support " << theSupportDil[theStepN] << " Sensitive " << theSensitiveDil[theStepN]
+                               << " Cables " << theCablesDil[theStepN] << " Cooling " << theCoolingDil[theStepN]
+                               << " Electronics " << theElectronicsDil[theStepN] << " Other " << theOtherDil[theStepN]
+                               << " Air " << theAirDil[theStepN];
+
+    if (interactionPre)
+      LogDebug("MaterialBudget") << "MaterialBudgetData: Process Pre " << interactionPre->GetProcessName() << " type "
+                                 << theStepPreProcess[theStepN] << " name "
+                                 << interactionPre->GetProcessTypeName(G4ProcessType(theStepPreProcess[theStepN]));
     if (interactionPost)
       LogDebug("MaterialBudget")
-	<< "MaterialBudgetData: Process Post " << interactionPost->GetProcessName()
-	<< " type " << theStepPostProcess[theStepN] 
-	<< " name "<< interactionPost->GetProcessTypeName(G4ProcessType(theStepPostProcess[theStepN]))
-	<< " Pre x = " << theInitialX[theStepN]
-	<< " y = "     << theInitialY[theStepN]
-	<< " z = "     << theInitialZ[theStepN] 
-	<< " Polar Radius = " << sqrt(prePos.x()*prePos.x()+prePos.y()*prePos.y())
-	<< " Pt = "     << theStepInitialPt[theStepN]
-	<< " Energy = " << theStepInitialEnergy[theStepN]
-	<< " Final: "
-	<< " Post x = " << theFinalX[theStepN]
-	<< " y = "      << theFinalY[theStepN]
-	<< " z = "      << theFinalZ[theStepN] 
-	<< " Polar Radius = " << sqrt(postPos.x()*postPos.x()+postPos.y()*postPos.y())
-	<< " Pt = "     << theStepFinalPt[theStepN]
-	<< " Energy = " << theStepFinalEnergy[theStepN]
-	<< std::endl
-	<< " Volume " << volumeID << " name " << theVolumeName[theStepN] 
-	<< " copy number " << theVolumeCopy[theStepN]
-	<< " material " << theMaterialID[theStepN] << " " << theMaterialName[theStepN]
-	<< " Density = " << theMaterialDensity[theStepN] << " g/cm3"
-	<< " X0 = " << theMaterialX0[theStepN] << " mm"
-	<< " Lambda0 = " << theMaterialLambda0[theStepN] << " mm"
-	<< std::endl
-	<< " Particle "  << theStepID[theStepN] 
-	<< " Initial Pt = " << theStepInitialPt[theStepN]     << " MeV/c"
-	<< " eta = "        << theStepInitialEta[theStepN]
-	<< " phi = "        << theStepInitialPhi[theStepN]
-	<< " Energy = "     << theStepInitialEnergy[theStepN] << " MeV"
-	<< " Mass = "       << theStepInitialMass[theStepN]   << " MeV/c2"
-	<< " Beta = "       << theStepInitialBeta[theStepN]
-	<< " Gamma = "      << theStepInitialGamma[theStepN]
-	<< std::endl
-	<< " Particle "  << theStepID[theStepN]
-	<< " Final Pt = "   << theStepFinalPt[theStepN]       << " MeV/c"
-	<< " eta = "        << theStepFinalEta[theStepN]
-	<< " phi = "        << theStepFinalPhi[theStepN]
-	<< " Energy = "     << theStepFinalEnergy[theStepN]   << " MeV"
-	<< " Mass = "       << theStepFinalMass[theStepN]     << " MeV/c2"
-	<< " Beta = "       << theStepFinalBeta[theStepN]
-	<< " Gamma = "      << theStepFinalGamma[theStepN]
-	<< std::endl
-	<< " Volume Centre x = " << theVolumeX[theStepN]
-	<< " y = "               << theVolumeY[theStepN]
-	<< " z = "               << theVolumeZ[theStepN]
-	<< "Polar Radius = "    << sqrt( theVolumeX[theStepN]*theVolumeX[theStepN] +
-					 theVolumeY[theStepN]*theVolumeY[theStepN] )
-	<< std::endl
-	<< " x axis = (" 
-	<< theVolumeXaxis1[theStepN] << "," 
-	<< theVolumeXaxis2[theStepN] << "," 
-	<< theVolumeXaxis3[theStepN] << ")"
-	<< std::endl
-	<< " y axis = (" 
-	<< theVolumeYaxis1[theStepN] << "," 
-	<< theVolumeYaxis2[theStepN] << "," 
-	<< theVolumeYaxis3[theStepN] << ")"
-	<< std::endl
-	<< " z axis = (" 
-	<< theVolumeZaxis1[theStepN] << "," 
-	<< theVolumeZaxis2[theStepN] << "," 
-	<< theVolumeZaxis3[theStepN] << ")"
-	<< std::endl
-	<< " Secondaries"
-	<< std::endl;
-    
-    for(G4TrackVector::const_iterator iSec = aStep->GetSecondary()->begin(); iSec!=aStep->GetSecondary()->end(); iSec++) {
-      LogDebug("MaterialBudget") 
-	<< "MaterialBudgetData: tid " << (*iSec)->GetDefinition()->GetPDGEncoding()
-	<< " created through process type " << (*iSec)->GetCreatorProcess()->GetProcessType()
-	<< (*iSec)->GetCreatorProcess()->GetProcessTypeName(G4ProcessType((*iSec)->GetCreatorProcess()->GetProcessType()));
+          << "MaterialBudgetData: Process Post " << interactionPost->GetProcessName() << " type "
+          << theStepPostProcess[theStepN] << " name "
+          << interactionPost->GetProcessTypeName(G4ProcessType(theStepPostProcess[theStepN]))
+          << " Pre x = " << theInitialX[theStepN] << " y = " << theInitialY[theStepN]
+          << " z = " << theInitialZ[theStepN]
+          << " Polar Radius = " << sqrt(prePos.x() * prePos.x() + prePos.y() * prePos.y())
+          << " Pt = " << theStepInitialPt[theStepN] << " Energy = " << theStepInitialEnergy[theStepN] << " Final: "
+          << " Post x = " << theFinalX[theStepN] << " y = " << theFinalY[theStepN] << " z = " << theFinalZ[theStepN]
+          << " Polar Radius = " << sqrt(postPos.x() * postPos.x() + postPos.y() * postPos.y())
+          << " Pt = " << theStepFinalPt[theStepN] << " Energy = " << theStepFinalEnergy[theStepN] << std::endl
+          << " Volume " << volumeID << " name " << theVolumeName[theStepN] << " copy number " << theVolumeCopy[theStepN]
+          << " material " << theMaterialID[theStepN] << " " << theMaterialName[theStepN]
+          << " Density = " << theMaterialDensity[theStepN] << " g/cm3"
+          << " X0 = " << theMaterialX0[theStepN] << " mm"
+          << " Lambda0 = " << theMaterialLambda0[theStepN] << " mm" << std::endl
+          << " Particle " << theStepID[theStepN] << " Initial Pt = " << theStepInitialPt[theStepN] << " MeV/c"
+          << " eta = " << theStepInitialEta[theStepN] << " phi = " << theStepInitialPhi[theStepN]
+          << " Energy = " << theStepInitialEnergy[theStepN] << " MeV"
+          << " Mass = " << theStepInitialMass[theStepN] << " MeV/c2"
+          << " Beta = " << theStepInitialBeta[theStepN] << " Gamma = " << theStepInitialGamma[theStepN] << std::endl
+          << " Particle " << theStepID[theStepN] << " Final Pt = " << theStepFinalPt[theStepN] << " MeV/c"
+          << " eta = " << theStepFinalEta[theStepN] << " phi = " << theStepFinalPhi[theStepN]
+          << " Energy = " << theStepFinalEnergy[theStepN] << " MeV"
+          << " Mass = " << theStepFinalMass[theStepN] << " MeV/c2"
+          << " Beta = " << theStepFinalBeta[theStepN] << " Gamma = " << theStepFinalGamma[theStepN] << std::endl
+          << " Volume Centre x = " << theVolumeX[theStepN] << " y = " << theVolumeY[theStepN]
+          << " z = " << theVolumeZ[theStepN] << "Polar Radius = "
+          << sqrt(theVolumeX[theStepN] * theVolumeX[theStepN] + theVolumeY[theStepN] * theVolumeY[theStepN])
+          << std::endl
+          << " x axis = (" << theVolumeXaxis1[theStepN] << "," << theVolumeXaxis2[theStepN] << ","
+          << theVolumeXaxis3[theStepN] << ")" << std::endl
+          << " y axis = (" << theVolumeYaxis1[theStepN] << "," << theVolumeYaxis2[theStepN] << ","
+          << theVolumeYaxis3[theStepN] << ")" << std::endl
+          << " z axis = (" << theVolumeZaxis1[theStepN] << "," << theVolumeZaxis2[theStepN] << ","
+          << theVolumeZaxis3[theStepN] << ")" << std::endl
+          << " Secondaries" << std::endl;
+
+    for (G4TrackVector::const_iterator iSec = aStep->GetSecondary()->begin(); iSec != aStep->GetSecondary()->end();
+         iSec++) {
+      LogDebug("MaterialBudget") << "MaterialBudgetData: tid " << (*iSec)->GetDefinition()->GetPDGEncoding()
+                                 << " created through process type " << (*iSec)->GetCreatorProcess()->GetProcessType()
+                                 << (*iSec)->GetCreatorProcess()->GetProcessTypeName(
+                                        G4ProcessType((*iSec)->GetCreatorProcess()->GetProcessType()));
     }
   }
-  
+
   theTrkLen = aStep->GetTrack()->GetTrackLength();
   thePVname = pv->GetName();
   thePVcopyNo = pv->GetCopyNo();
@@ -559,52 +491,47 @@ void MaterialBudgetData::dataPerStep( const G4Step* aStep )
   theIntLen = intlen;
   theTotalMB += dmb;
   theTotalIL += dil;
-  
-  theSupportMB     += (dmb * theSupportFractionMB);
-  theSensitiveMB   += (dmb * theSensitiveFractionMB);
-  theCoolingMB     += (dmb * theCoolingFractionMB);
+
+  theSupportMB += (dmb * theSupportFractionMB);
+  theSensitiveMB += (dmb * theSensitiveFractionMB);
+  theCoolingMB += (dmb * theCoolingFractionMB);
   theElectronicsMB += (dmb * theElectronicsFractionMB);
-  theOtherMB       += (dmb * theOtherFractionMB);
+  theOtherMB += (dmb * theOtherFractionMB);
 
   //HGCal
-  theAirMB                 += (dmb * theAirFractionMB);
-  theCablesMB              += (dmb * theCablesFractionMB);
-  theCopperMB              += (dmb * theCopperFractionMB);                       
-  theH_ScintillatorMB      += (dmb * theH_ScintillatorFractionMB);       
-  theLeadMB                += (dmb * theLeadFractionMB);                           
-  theEpoxyMB               += (dmb * theEpoxyFractionMB);                           
-  theKaptonMB              += (dmb * theKaptonFractionMB);                           
-  theAluminiumMB           += (dmb * theAluminiumFractionMB);                           
-  theHGC_G10_FR4MB         += (dmb * theHGC_G10_FR4FractionMB);   
-  theSiliconMB             += (dmb * theSiliconFractionMB);                     
-  theStainlessSteelMB      += (dmb * theStainlessSteelFractionMB);       
-  theWCuMB                 += (dmb * theWCuFractionMB);                             
+  theAirMB += (dmb * theAirFractionMB);
+  theCablesMB += (dmb * theCablesFractionMB);
+  theCopperMB += (dmb * theCopperFractionMB);
+  theH_ScintillatorMB += (dmb * theH_ScintillatorFractionMB);
+  theLeadMB += (dmb * theLeadFractionMB);
+  theEpoxyMB += (dmb * theEpoxyFractionMB);
+  theKaptonMB += (dmb * theKaptonFractionMB);
+  theAluminiumMB += (dmb * theAluminiumFractionMB);
+  theHGC_G10_FR4MB += (dmb * theHGC_G10_FR4FractionMB);
+  theSiliconMB += (dmb * theSiliconFractionMB);
+  theStainlessSteelMB += (dmb * theStainlessSteelFractionMB);
+  theWCuMB += (dmb * theWCuFractionMB);
 
-  theSupportIL     += (dil * theSupportFractionIL);
-  theSensitiveIL   += (dil * theSensitiveFractionIL);
-  theCoolingIL     += (dil * theCoolingFractionIL);
+  theSupportIL += (dil * theSupportFractionIL);
+  theSensitiveIL += (dil * theSensitiveFractionIL);
+  theCoolingIL += (dil * theCoolingFractionIL);
   theElectronicsIL += (dil * theElectronicsFractionIL);
-  theOtherIL       += (dil * theOtherFractionIL);
+  theOtherIL += (dil * theOtherFractionIL);
   //HGCal
-  theAirIL                 += (dil * theAirFractionIL);
-  theCablesIL              += (dil * theCablesFractionIL);
-  theCopperIL              += (dil * theCopperFractionIL);                       
-  theH_ScintillatorIL      += (dil * theH_ScintillatorFractionIL);       
-  theLeadIL                += (dil * theLeadFractionIL);                           
-  theEpoxyIL               += (dil * theEpoxyFractionIL);                           
-  theKaptonIL              += (dil * theKaptonFractionIL);                           
-  theAluminiumIL           += (dil * theAluminiumFractionIL);                           
-  theHGC_G10_FR4IL         += (dil * theHGC_G10_FR4FractionIL);   
-  theSiliconIL             += (dil * theSiliconFractionIL);                     
-  theStainlessSteelIL      += (dil * theStainlessSteelFractionIL);       
-  theWCuIL                 += (dil * theWCuFractionIL);                             
-  
-
+  theAirIL += (dil * theAirFractionIL);
+  theCablesIL += (dil * theCablesFractionIL);
+  theCopperIL += (dil * theCopperFractionIL);
+  theH_ScintillatorIL += (dil * theH_ScintillatorFractionIL);
+  theLeadIL += (dil * theLeadFractionIL);
+  theEpoxyIL += (dil * theEpoxyFractionIL);
+  theKaptonIL += (dil * theKaptonFractionIL);
+  theAluminiumIL += (dil * theAluminiumFractionIL);
+  theHGC_G10_FR4IL += (dil * theHGC_G10_FR4FractionIL);
+  theSiliconIL += (dil * theSiliconFractionIL);
+  theStainlessSteelIL += (dil * theStainlessSteelFractionIL);
+  theWCuIL += (dil * theWCuFractionIL);
 
   // rr
-  
+
   theStepN++;
-  
 }
-
-

--- a/Validation/Geometry/src/MaterialBudgetData.cc
+++ b/Validation/Geometry/src/MaterialBudgetData.cc
@@ -10,6 +10,7 @@ MaterialBudgetData::MaterialBudgetData() {
   myMaterialBudgetCategorizer = nullptr;
   allStepsToTree = false;
   isHGCal = false;
+  isMtd = false;
   densityConvertionFactor = 6.24E18;
 }
 
@@ -23,6 +24,8 @@ void MaterialBudgetData::dataStartTrack(const G4Track* aTrack) {
   if (myMaterialBudgetCategorizer == nullptr) {
     if (isHGCal) {
       myMaterialBudgetCategorizer = std::make_unique<MaterialBudgetCategorizer>("HGCal");
+    } else if (isMtd) {
+      myMaterialBudgetCategorizer = std::make_unique<MaterialBudgetCategorizer>("Mtd");
     } else {
       myMaterialBudgetCategorizer = std::make_unique<MaterialBudgetCategorizer>("Tracker");
     }

--- a/Validation/Geometry/src/MaterialBudgetEcalHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetEcalHistos.cc
@@ -1,170 +1,151 @@
 #include "Validation/Geometry/interface/MaterialBudgetEcalHistos.h"
 #include "Validation/Geometry/interface/MaterialBudgetData.h"
 
-
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-MaterialBudgetEcalHistos::MaterialBudgetEcalHistos(std::shared_ptr<MaterialBudgetData> data, 
-						   std::shared_ptr<TestHistoMgr> mgr,
-						   const std::string& fileName ): MaterialBudgetFormat( data ), hmgr(mgr)
-{
+MaterialBudgetEcalHistos::MaterialBudgetEcalHistos(std::shared_ptr<MaterialBudgetData> data,
+                                                   std::shared_ptr<TestHistoMgr> mgr,
+                                                   const std::string& fileName)
+    : MaterialBudgetFormat(data), hmgr(mgr) {
   theFileName = fileName;
   book();
 }
 
-
-void MaterialBudgetEcalHistos::book() 
-{
+void MaterialBudgetEcalHistos::book() {
   edm::LogInfo("MaterialBudget") << "MaterialBudgetEcalHistos: Booking user histos";
-  
+
   // total X0
-  hmgr->addHistoProf1( new TProfile("10", "MB prof Eta ", 250, -5., 5. ) );
-  hmgr->addHisto1( new TH1F("11", "Eta " , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("20", "MB prof Phi ", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("21", "Phi " , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("30", "MB prof Eta  Phi ", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("31", "Eta vs Phi " , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-    
+  hmgr->addHistoProf1(new TProfile("10", "MB prof Eta ", 250, -5., 5.));
+  hmgr->addHisto1(new TH1F("11", "Eta ", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("20", "MB prof Phi ", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("21", "Phi ", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D("30", "MB prof Eta  Phi ", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("31", "Eta vs Phi ", 501, -5., 5., 180, -3.1416, 3.1416));
+
   // Support
-  hmgr->addHistoProf1( new TProfile("110", "MB prof Eta [Support]", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("111", "Eta [Support]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("120", "MB prof Phi [Support]", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("121", "Phi [Support]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("130", "MB prof Eta  Phi [Support]", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("131", "Eta vs Phi [Support]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
+  hmgr->addHistoProf1(new TProfile("110", "MB prof Eta [Support]", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("111", "Eta [Support]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("120", "MB prof Phi [Support]", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("121", "Phi [Support]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D("130", "MB prof Eta  Phi [Support]", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("131", "Eta vs Phi [Support]", 501, -5., 5., 180, -3.1416, 3.1416));
 
   // Sensitive
-  hmgr->addHistoProf1( new TProfile("210", "MB prof Eta [Sensitive]", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("211", "Eta [Sensitive]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("220", "MB prof Phi [Sensitive]", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("221", "Phi [Sensitive]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("230", "MB prof Eta  Phi [Sensitive]", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("231", "Eta vs Phi [Sensitive]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
+  hmgr->addHistoProf1(new TProfile("210", "MB prof Eta [Sensitive]", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("211", "Eta [Sensitive]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("220", "MB prof Phi [Sensitive]", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("221", "Phi [Sensitive]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D("230", "MB prof Eta  Phi [Sensitive]", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("231", "Eta vs Phi [Sensitive]", 501, -5., 5., 180, -3.1416, 3.1416));
 
   // Cables
-  hmgr->addHistoProf1( new TProfile("310", "MB prof Eta [Cables]", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("311", "Eta [Cables]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("320", "MB prof Phi [Cables]", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("321", "Phi [Cables]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("330", "MB prof Eta  Phi [Cables]", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("331", "Eta vs Phi [Cables]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
+  hmgr->addHistoProf1(new TProfile("310", "MB prof Eta [Cables]", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("311", "Eta [Cables]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("320", "MB prof Phi [Cables]", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("321", "Phi [Cables]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D("330", "MB prof Eta  Phi [Cables]", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("331", "Eta vs Phi [Cables]", 501, -5., 5., 180, -3.1416, 3.1416));
 
   // Cooling
-  hmgr->addHistoProf1( new TProfile("410", "MB prof Eta [Cooling]", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("411", "Eta [Cooling]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("420", "MB prof Phi [Cooling]", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("421", "Phi [Cooling]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("430", "MB prof Eta  Phi [Cooling]", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("431", "Eta vs Phi [Cooling]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
+  hmgr->addHistoProf1(new TProfile("410", "MB prof Eta [Cooling]", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("411", "Eta [Cooling]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("420", "MB prof Phi [Cooling]", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("421", "Phi [Cooling]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D("430", "MB prof Eta  Phi [Cooling]", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("431", "Eta vs Phi [Cooling]", 501, -5., 5., 180, -3.1416, 3.1416));
 
   // Electronics
-  hmgr->addHistoProf1( new TProfile("510", "MB prof Eta [Electronics]", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("511", "Eta [Electronics]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("520", "MB prof Phi [Electronics]", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("521", "Phi [Electronics]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("530", "MB prof Eta  Phi [Electronics]", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("531", "Eta vs Phi [Electronics]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
+  hmgr->addHistoProf1(new TProfile("510", "MB prof Eta [Electronics]", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("511", "Eta [Electronics]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("520", "MB prof Phi [Electronics]", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("521", "Phi [Electronics]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D("530", "MB prof Eta  Phi [Electronics]", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("531", "Eta vs Phi [Electronics]", 501, -5., 5., 180, -3.1416, 3.1416));
 
   // Other
-  hmgr->addHistoProf1( new TProfile("610", "MB prof Eta [Other]", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("611", "Eta [Other]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("620", "MB prof Phi [Other]", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("621", "Phi [Other]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("630", "MB prof Eta  Phi [Other]", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("631", "Eta vs Phi [Other]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
+  hmgr->addHistoProf1(new TProfile("610", "MB prof Eta [Other]", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("611", "Eta [Other]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("620", "MB prof Phi [Other]", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("621", "Phi [Other]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D("630", "MB prof Eta  Phi [Other]", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("631", "Eta vs Phi [Other]", 501, -5., 5., 180, -3.1416, 3.1416));
 
   // Air
-  hmgr->addHistoProf1( new TProfile("710", "MB prof Eta [Air]", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("711", "Eta [Air]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("720", "MB prof Phi [Air]", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("721", "Phi [Air]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("730", "MB prof Eta  Phi [Air]", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("731", "Eta vs Phi [Air]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
+  hmgr->addHistoProf1(new TProfile("710", "MB prof Eta [Air]", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("711", "Eta [Air]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("720", "MB prof Phi [Air]", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("721", "Phi [Air]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D("730", "MB prof Eta  Phi [Air]", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("731", "Eta vs Phi [Air]", 501, -5., 5., 180, -3.1416, 3.1416));
 
   // ECAL specific
-  hmgr->addHistoProf1( new TProfile("1001", "MB prof Eta ECAL Barrel", 340, -1.5, 1.5 ) );
-  hmgr->addHistoProf1( new TProfile("1002", "MB prof Phi ECAL Barrel", 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("1003", "MB prof Phi ECAL Barrel SM", 20, 0., 20. ) );
-  hmgr->addHistoProf1( new TProfile("2003", "MB prof Phi ECAL Barrel SM", 10, 0., 20. ) );
-  hmgr->addHistoProf1( new TProfile("1004", "MB prof Phi ECAL Barrel SM module 1", 20, 0., 20. ) );
-  hmgr->addHistoProf1( new TProfile("1005", "MB prof Phi ECAL Barrel SM module 2", 20, 0., 20. ) );
-  hmgr->addHistoProf1( new TProfile("1006", "MB prof Phi ECAL Barrel SM module 3", 20, 0., 20. ) );
-  hmgr->addHistoProf1( new TProfile("1007", "MB prof Phi ECAL Barrel SM module 4", 20, 0., 20. ) );
+  hmgr->addHistoProf1(new TProfile("1001", "MB prof Eta ECAL Barrel", 340, -1.5, 1.5));
+  hmgr->addHistoProf1(new TProfile("1002", "MB prof Phi ECAL Barrel", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1003", "MB prof Phi ECAL Barrel SM", 20, 0., 20.));
+  hmgr->addHistoProf1(new TProfile("2003", "MB prof Phi ECAL Barrel SM", 10, 0., 20.));
+  hmgr->addHistoProf1(new TProfile("1004", "MB prof Phi ECAL Barrel SM module 1", 20, 0., 20.));
+  hmgr->addHistoProf1(new TProfile("1005", "MB prof Phi ECAL Barrel SM module 2", 20, 0., 20.));
+  hmgr->addHistoProf1(new TProfile("1006", "MB prof Phi ECAL Barrel SM module 3", 20, 0., 20.));
+  hmgr->addHistoProf1(new TProfile("1007", "MB prof Phi ECAL Barrel SM module 4", 20, 0., 20.));
 
-  hmgr->addHistoProf1( new TProfile("1011", "MB prof Eta ECAL Preshower +", 100, 1.65, 2.6 ) );
-  hmgr->addHistoProf1( new TProfile("1012", "MB prof Phi ECAL Preshower +", 180, -3.1416, 3.1416 ) );
-  
-  hmgr->addHistoProf1( new TProfile("1013", "MB prof Eta ECAL Preshower -", 100, -2.6, -1.65 ) );
-  hmgr->addHistoProf1( new TProfile("1014", "MB prof Phi ECAL Preshower -", 180, -3.1416, 3.1416 ) );
-  
+  hmgr->addHistoProf1(new TProfile("1011", "MB prof Eta ECAL Preshower +", 100, 1.65, 2.6));
+  hmgr->addHistoProf1(new TProfile("1012", "MB prof Phi ECAL Preshower +", 180, -3.1416, 3.1416));
+
+  hmgr->addHistoProf1(new TProfile("1013", "MB prof Eta ECAL Preshower -", 100, -2.6, -1.65));
+  hmgr->addHistoProf1(new TProfile("1014", "MB prof Phi ECAL Preshower -", 180, -3.1416, 3.1416));
+
   edm::LogInfo("MaterialBudget") << "MaterialBudgetEcalHistos: booking user histos done";
-
 }
 
+void MaterialBudgetEcalHistos::fillStartTrack() {}
 
-void MaterialBudgetEcalHistos::fillStartTrack()
-{
+void MaterialBudgetEcalHistos::fillPerStep() {}
 
-}
-
-
-void MaterialBudgetEcalHistos::fillPerStep()
-{
-
-}
-
-
-void MaterialBudgetEcalHistos::fillEndTrack()
-{
+void MaterialBudgetEcalHistos::fillEndTrack() {
   // Total X0
   hmgr->getHisto1(11)->Fill(theData->getEta());
   hmgr->getHisto1(21)->Fill(theData->getPhi());
-  hmgr->getHisto2(31)->Fill(theData->getEta(),theData->getPhi());
-  
-  hmgr->getHistoProf1(10)->Fill(theData->getEta(),theData->getTotalMB());
-  hmgr->getHistoProf1(20)->Fill(theData->getPhi(),theData->getTotalMB());
-  hmgr->getHistoProf2(30)->Fill(theData->getEta(),theData->getPhi(),theData->getTotalMB());
-  
-  
+  hmgr->getHisto2(31)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(10)->Fill(theData->getEta(), theData->getTotalMB());
+  hmgr->getHistoProf1(20)->Fill(theData->getPhi(), theData->getTotalMB());
+  hmgr->getHistoProf2(30)->Fill(theData->getEta(), theData->getPhi(), theData->getTotalMB());
+
   // ECAL specific
-  if (fabs(theData->getEta()) <= 1.479 ) {
-    static const double twenty ( 20.*degree ) ;
-    const double phi ( theData->getPhi()+M_PI ) ;
-    const double phiModTwenty (( phi - floor(phi/twenty)*twenty )/degree) ;
-    hmgr->getHistoProf1(1001)->Fill(theData->getEta(),theData->getTotalMB());
-    hmgr->getHistoProf1(1002)->Fill(theData->getPhi(),theData->getTotalMB());
-    hmgr->getHistoProf1(1003)->Fill(phiModTwenty,theData->getTotalMB());
-    hmgr->getHistoProf1(2003)->Fill(phiModTwenty,theData->getTotalMB());
-    if (fabs(theData->getEta()) >= 0. && fabs(theData->getEta()) < 0.435 ) {
-      hmgr->getHistoProf1(1004)->Fill(phiModTwenty,theData->getTotalMB());
+  if (fabs(theData->getEta()) <= 1.479) {
+    static const double twenty(20. * degree);
+    const double phi(theData->getPhi() + M_PI);
+    const double phiModTwenty((phi - floor(phi / twenty) * twenty) / degree);
+    hmgr->getHistoProf1(1001)->Fill(theData->getEta(), theData->getTotalMB());
+    hmgr->getHistoProf1(1002)->Fill(theData->getPhi(), theData->getTotalMB());
+    hmgr->getHistoProf1(1003)->Fill(phiModTwenty, theData->getTotalMB());
+    hmgr->getHistoProf1(2003)->Fill(phiModTwenty, theData->getTotalMB());
+    if (fabs(theData->getEta()) >= 0. && fabs(theData->getEta()) < 0.435) {
+      hmgr->getHistoProf1(1004)->Fill(phiModTwenty, theData->getTotalMB());
     }
-    if (fabs(theData->getEta()) >= 0.435 && fabs(theData->getEta()) < 0.783 ) {
-      hmgr->getHistoProf1(1005)->Fill(phiModTwenty,theData->getTotalMB());
+    if (fabs(theData->getEta()) >= 0.435 && fabs(theData->getEta()) < 0.783) {
+      hmgr->getHistoProf1(1005)->Fill(phiModTwenty, theData->getTotalMB());
     }
-    if (fabs(theData->getEta()) > 0.783 && fabs(theData->getEta()) <= 1.131 ) {
-      hmgr->getHistoProf1(1006)->Fill(phiModTwenty,theData->getTotalMB());
+    if (fabs(theData->getEta()) > 0.783 && fabs(theData->getEta()) <= 1.131) {
+      hmgr->getHistoProf1(1006)->Fill(phiModTwenty, theData->getTotalMB());
     }
-    if (fabs(theData->getEta()) > 1.131 && fabs(theData->getEta()) <= 1.479 ) {
-      hmgr->getHistoProf1(1007)->Fill(phiModTwenty,theData->getTotalMB());
+    if (fabs(theData->getEta()) > 1.131 && fabs(theData->getEta()) <= 1.479) {
+      hmgr->getHistoProf1(1007)->Fill(phiModTwenty, theData->getTotalMB());
     }
   }
 
-  if (theData->getEta() >= 1.653 && theData->getEta() <= 2.6 ) {
-    hmgr->getHistoProf1(1011)->Fill(theData->getEta(),theData->getTotalMB());
-    hmgr->getHistoProf1(1012)->Fill(theData->getPhi(),theData->getTotalMB());
+  if (theData->getEta() >= 1.653 && theData->getEta() <= 2.6) {
+    hmgr->getHistoProf1(1011)->Fill(theData->getEta(), theData->getTotalMB());
+    hmgr->getHistoProf1(1012)->Fill(theData->getPhi(), theData->getTotalMB());
   }
 
-  if (theData->getEta() >= -2.6 && theData->getEta() <= -1.653 ) {
-    hmgr->getHistoProf1(1013)->Fill(theData->getEta(),theData->getTotalMB());
-    hmgr->getHistoProf1(1014)->Fill(theData->getPhi(),theData->getTotalMB());
+  if (theData->getEta() >= -2.6 && theData->getEta() <= -1.653) {
+    hmgr->getHistoProf1(1013)->Fill(theData->getEta(), theData->getTotalMB());
+    hmgr->getHistoProf1(1014)->Fill(theData->getPhi(), theData->getTotalMB());
   }
 }
 
-
-void MaterialBudgetEcalHistos::endOfRun() 
-{
+void MaterialBudgetEcalHistos::endOfRun() {
   edm::LogInfo("MaterialBudget") << "MaterialBudgetEcalHistos: Writing histos ROOT file to:" << theFileName;
-  hmgr->save( theFileName );
-
+  hmgr->save(theFileName);
 }
-

--- a/Validation/Geometry/src/MaterialBudgetFormat.cc
+++ b/Validation/Geometry/src/MaterialBudgetFormat.cc
@@ -1,8 +1,4 @@
 #include "Validation/Geometry/interface/MaterialBudgetFormat.h"
 #include "Validation/Geometry/interface/MaterialBudgetData.h"
 
-MaterialBudgetFormat::MaterialBudgetFormat( std::shared_ptr<MaterialBudgetData> data ): 
- theData(data)
-{
-}
-
+MaterialBudgetFormat::MaterialBudgetFormat(std::shared_ptr<MaterialBudgetData> data) : theData(data) {}

--- a/Validation/Geometry/src/MaterialBudgetForward.cc
+++ b/Validation/Geometry/src/MaterialBudgetForward.cc
@@ -18,91 +18,88 @@
 const int MaterialBudgetForward::maxSet;
 
 MaterialBudgetForward::MaterialBudgetForward(const edm::ParameterSet& p) {
-  
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("MaterialBudgetForward");
-  detTypes     = m_p.getParameter<std::vector<std::string> >("DetectorTypes");
+  detTypes = m_p.getParameter<std::vector<std::string> >("DetectorTypes");
   constituents = m_p.getParameter<std::vector<int> >("Constituents");
-  stackOrder   = m_p.getParameter<std::vector<int> >("StackOrder");
-  detNames     = m_p.getParameter<std::vector<std::string> >("DetectorNames");
-  detLevels    = m_p.getParameter<std::vector<int> >("DetectorLevels");
-  etaRegions   = m_p.getParameter<std::vector<double> >("EtaBoundaries");
-  regionTypes  = m_p.getParameter<std::vector<int> >("RegionTypes");
-  boundaries   = m_p.getParameter<std::vector<double> >("Boundaries");
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetForward initialized for "
-				 << detTypes.size() << " detector types";
+  stackOrder = m_p.getParameter<std::vector<int> >("StackOrder");
+  detNames = m_p.getParameter<std::vector<std::string> >("DetectorNames");
+  detLevels = m_p.getParameter<std::vector<int> >("DetectorLevels");
+  etaRegions = m_p.getParameter<std::vector<double> >("EtaBoundaries");
+  regionTypes = m_p.getParameter<std::vector<int> >("RegionTypes");
+  boundaries = m_p.getParameter<std::vector<double> >("Boundaries");
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetForward initialized for " << detTypes.size() << " detector types";
   unsigned int nc = 0;
-  for (unsigned int ii=0; ii<detTypes.size(); ++ii) {
-    edm::LogInfo("MaterialBudget") << "Type[" << ii << "] : " << detTypes[ii]
-				   << " with " << constituents[ii] <<", order "
-				   << stackOrder[ii] << " constituents --> ";
-    for (int kk=0; kk<constituents[ii]; ++kk) {
-      std::string name = "Unknown"; int level = -1;
+  for (unsigned int ii = 0; ii < detTypes.size(); ++ii) {
+    edm::LogInfo("MaterialBudget") << "Type[" << ii << "] : " << detTypes[ii] << " with " << constituents[ii]
+                                   << ", order " << stackOrder[ii] << " constituents --> ";
+    for (int kk = 0; kk < constituents[ii]; ++kk) {
+      std::string name = "Unknown";
+      int level = -1;
       if (nc < detNames.size()) {
-	name = detNames[nc]; level = detLevels[nc]; ++nc;
+        name = detNames[nc];
+        level = detLevels[nc];
+        ++nc;
       }
-      edm::LogInfo("MaterialBudget") << "    Constituent[" << kk << "]: "
-				     << name << " at level " << level;
+      edm::LogInfo("MaterialBudget") << "    Constituent[" << kk << "]: " << name << " at level " << level;
     }
   }
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetForward Stop condition for "
-				 << etaRegions.size() << " eta regions";
-  for (unsigned int ii=0; ii<etaRegions.size(); ++ii) {
-    edm::LogInfo("MaterialBudget") << "Region[" << ii << "] : Eta < " 
-				   << etaRegions[ii] << " boundary type "
-				   << regionTypes[ii] << " limit "
-				   << boundaries[ii];
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetForward Stop condition for " << etaRegions.size() << " eta regions";
+  for (unsigned int ii = 0; ii < etaRegions.size(); ++ii) {
+    edm::LogInfo("MaterialBudget") << "Region[" << ii << "] : Eta < " << etaRegions[ii] << " boundary type "
+                                   << regionTypes[ii] << " limit " << boundaries[ii];
   }
   book(m_p);
 }
 
-MaterialBudgetForward::~MaterialBudgetForward() {
-}
+MaterialBudgetForward::~MaterialBudgetForward() {}
 
-void MaterialBudgetForward::update(const BeginOfRun* ) {
+void MaterialBudgetForward::update(const BeginOfRun*) {
+  const G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();
+  std::vector<G4LogicalVolume*>::const_iterator lvcite;
 
-  const G4LogicalVolumeStore * lvs = G4LogicalVolumeStore::GetInstance();
-  std::vector<G4LogicalVolume *>::const_iterator lvcite;
-
-  unsigned int kount=detNames.size();
-  for (unsigned int ii=0; ii<kount; ++ii) 
+  unsigned int kount = detNames.size();
+  for (unsigned int ii = 0; ii < kount; ++ii)
     logVolumes.push_back(nullptr);
 
   for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++) {
-    for (unsigned int ii=0; ii<detNames.size(); ++ii) {
-      if (strcmp(detNames[ii].c_str(),(*lvcite)->GetName().c_str()) == 0) {
-	logVolumes[ii] = (*lvcite);
-	kount--;
-	break;
+    for (unsigned int ii = 0; ii < detNames.size(); ++ii) {
+      if (strcmp(detNames[ii].c_str(), (*lvcite)->GetName().c_str()) == 0) {
+        logVolumes[ii] = (*lvcite);
+        kount--;
+        break;
       }
     }
-    if (kount <= 0) break;
+    if (kount <= 0)
+      break;
   }
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetForward::Finds " 
-				 << detNames.size()-kount << " out of "
-				 << detNames.size() << " LV addresses";
-  for (unsigned int ii=0; ii<detNames.size(); ++ii) {
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetForward::Finds " << detNames.size() - kount << " out of "
+                                 << detNames.size() << " LV addresses";
+  for (unsigned int ii = 0; ii < detNames.size(); ++ii) {
     std::string name("Unknown");
-    if (logVolumes[ii] != nullptr)  name = logVolumes[ii]->GetName();
-    edm::LogInfo("MaterialBudget") << "LV[" << ii << "] : " << detNames[ii]
-				   << " Address " << logVolumes[ii] << " | " 
-				   << name;
+    if (logVolumes[ii] != nullptr)
+      name = logVolumes[ii]->GetName();
+    edm::LogInfo("MaterialBudget") << "LV[" << ii << "] : " << detNames[ii] << " Address " << logVolumes[ii] << " | "
+                                   << name;
   }
 
-  for (unsigned int ii=0; ii<(detTypes.size()+1); ++ii) {
-    stepLen.push_back(0); radLen.push_back(0); intLen.push_back(0);
+  for (unsigned int ii = 0; ii < (detTypes.size() + 1); ++ii) {
+    stepLen.push_back(0);
+    radLen.push_back(0);
+    intLen.push_back(0);
   }
   stackOrder.push_back(0);
 }
 
 void MaterialBudgetForward::update(const BeginOfTrack* trk) {
-
-  for (unsigned int ii=0; ii<(detTypes.size()+1); ++ii) {
-    stepLen[ii] = 0; radLen[ii] = 0; intLen[ii] = 0;
+  for (unsigned int ii = 0; ii < (detTypes.size() + 1); ++ii) {
+    stepLen[ii] = 0;
+    radLen[ii] = 0;
+    intLen[ii] = 0;
   }
 
-  const G4Track * aTrack = (*trk)(); // recover G4 pointer if wanted
-  const G4ThreeVector& mom = aTrack->GetMomentum() ;
-  if (mom.theta() != 0 ) {
+  const G4Track* aTrack = (*trk)();  // recover G4 pointer if wanted
+  const G4ThreeVector& mom = aTrack->GetMomentum();
+  if (mom.theta() != 0) {
     eta = mom.eta();
   } else {
     eta = -99;
@@ -112,89 +109,77 @@ void MaterialBudgetForward::update(const BeginOfTrack* trk) {
 
 #ifdef DebugLog
   double theEnergy = aTrack->GetTotalEnergy();
-  int    theID     = (int)(aTrack->GetDefinition()->GetPDGEncoding());
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Track "
-				 << aTrack->GetTrackID() << " Code " << theID
-				 << " Energy " <<theEnergy/CLHEP::GeV
-				 << " GeV; Eta " << eta << " Phi " 
-				 << phi/CLHEP::deg << " PT "
-				 << mom.perp()/CLHEP::GeV << " GeV *****";
+  int theID = (int)(aTrack->GetDefinition()->GetPDGEncoding());
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Track " << aTrack->GetTrackID() << " Code " << theID
+                                 << " Energy " << theEnergy / CLHEP::GeV << " GeV; Eta " << eta << " Phi "
+                                 << phi / CLHEP::deg << " PT " << mom.perp() / CLHEP::GeV << " GeV *****";
 #endif
 }
- 
-void MaterialBudgetForward::update(const G4Step* aStep) {
 
+void MaterialBudgetForward::update(const G4Step* aStep) {
   //---------- each step
-  G4Material * material = aStep->GetPreStepPoint()->GetMaterial();
-  double step    = aStep->GetStepLength();
-  double radl    = material->GetRadlen();
-  double intl    = material->GetNuclearInterLength();
+  G4Material* material = aStep->GetPreStepPoint()->GetMaterial();
+  double step = aStep->GetStepLength();
+  double radl = material->GetRadlen();
+  double intl = material->GetNuclearInterLength();
 
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
   unsigned int indx = detTypes.size();
   unsigned int nc = 0;
-  for (unsigned int ii=0; ii<detTypes.size(); ++ii) {
-    for (int kk=0; kk<constituents[ii]; ++kk) {
-      if (detLevels[nc+kk] <= (int)((touch->GetHistoryDepth())+1)) {
-	int jj = (int)((touch->GetHistoryDepth())+1)-detLevels[nc+kk];
-        if ((touch->GetVolume(jj)->GetLogicalVolume()) == logVolumes[nc+kk]) {
-	  indx = ii;
-	  break;
-	}
+  for (unsigned int ii = 0; ii < detTypes.size(); ++ii) {
+    for (int kk = 0; kk < constituents[ii]; ++kk) {
+      if (detLevels[nc + kk] <= (int)((touch->GetHistoryDepth()) + 1)) {
+        int jj = (int)((touch->GetHistoryDepth()) + 1) - detLevels[nc + kk];
+        if ((touch->GetVolume(jj)->GetLogicalVolume()) == logVolumes[nc + kk]) {
+          indx = ii;
+          break;
+        }
       }
     }
     nc += (unsigned int)(constituents[ii]);
-    if (indx == ii) break;
+    if (indx == ii)
+      break;
   }
 
-  stepT         += step;
-  stepLen[indx]  = stepT;
-  radLen[indx]  += (step/radl);
-  intLen[indx]  += (step/intl);
+  stepT += step;
+  stepLen[indx] = stepT;
+  radLen[indx] += (step / radl);
+  intLen[indx] += (step / intl);
 #ifdef DebugLog
   edm::LogInfo("MaterialBudget") << "MaterialBudgetForward::Step in "
-				 << touch->GetVolume(0)->GetLogicalVolume()->GetName()
-				 << " Index " << indx <<" Step " << step 
-				 << " RadL " << step/radl << " IntL " 
-				 << step/intl;
+                                 << touch->GetVolume(0)->GetLogicalVolume()->GetName() << " Index " << indx << " Step "
+                                 << step << " RadL " << step / radl << " IntL " << step / intl;
 #endif
   //----- Stop tracking after selected position
   if (stopAfter(aStep)) {
     G4Track* track = aStep->GetTrack();
-    track->SetTrackStatus( fStopAndKill );
+    track->SetTrackStatus(fStopAndKill);
   }
 }
 
-
 void MaterialBudgetForward::update(const EndOfTrack* trk) {
-
-  for (unsigned int ii=0; ii<detTypes.size(); ++ii) {
-    for (unsigned int jj=0; jj<=detTypes.size(); ++jj) {
-      if (stackOrder[jj] == (int)(ii+1)) {
-	for (unsigned int kk=0; kk<=detTypes.size(); ++kk) {
-	  if (stackOrder[kk] == (int)(ii)) {
-	    radLen[jj]  += radLen[kk];
-	    intLen[jj]  += intLen[kk];
+  for (unsigned int ii = 0; ii < detTypes.size(); ++ii) {
+    for (unsigned int jj = 0; jj <= detTypes.size(); ++jj) {
+      if (stackOrder[jj] == (int)(ii + 1)) {
+        for (unsigned int kk = 0; kk <= detTypes.size(); ++kk) {
+          if (stackOrder[kk] == (int)(ii)) {
+            radLen[jj] += radLen[kk];
+            intLen[jj] += intLen[kk];
 #ifdef DebugLog
-	    edm::LogInfo("MaterialBudget") << "MaterialBudgetForward::Add " 
-					   << kk << ":" << stackOrder[kk] 
-					   << " to " << jj <<":" 
-					   << stackOrder[jj] <<" RadL "
-					   << radLen[kk] << " : " << radLen[jj]
-					   << " IntL " << intLen[kk] << " : "
-					   << intLen[jj] <<" StepL " 
-					   << stepLen[kk]<< " : " 
-					   << stepLen[jj];
+            edm::LogInfo("MaterialBudget")
+                << "MaterialBudgetForward::Add " << kk << ":" << stackOrder[kk] << " to " << jj << ":" << stackOrder[jj]
+                << " RadL " << radLen[kk] << " : " << radLen[jj] << " IntL " << intLen[kk] << " : " << intLen[jj]
+                << " StepL " << stepLen[kk] << " : " << stepLen[jj];
 #endif
-	    break;
-	  }
-	}
-	break;
+            break;
+          }
+        }
+        break;
       }
     }
   }
 
-  for (unsigned int ii=0; ii<=detTypes.size(); ++ii) {
+  for (unsigned int ii = 0; ii <= detTypes.size(); ++ii) {
     me100[ii]->Fill(eta, radLen[ii]);
     me200[ii]->Fill(eta, intLen[ii]);
     me300[ii]->Fill(eta, stepLen[ii]);
@@ -203,112 +188,102 @@ void MaterialBudgetForward::update(const EndOfTrack* trk) {
     me600[ii]->Fill(eta, phi, intLen[ii]);
     me700[ii]->Fill(eta, phi, stepLen[ii]);
     me800[ii]->Fill(eta, phi);
-    
+
     std::string name("Unknown");
-    if (ii < detTypes.size()) name = detTypes[ii];
+    if (ii < detTypes.size())
+      name = detTypes[ii];
 #ifdef DebugLog
-    edm::LogInfo("MaterialBudget") << "MaterialBudgetForward::Volume[" << ii
-				   << "]: " << name << " eta " << eta 
-				   << " == Step " << stepLen[ii] << " RadL " 
-				   << radLen[ii] << " IntL " << intLen[ii];
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetForward::Volume[" << ii << "]: " << name << " eta " << eta
+                                   << " == Step " << stepLen[ii] << " RadL " << radLen[ii] << " IntL " << intLen[ii];
 #endif
   }
 }
 
 void MaterialBudgetForward::book(const edm::ParameterSet& m_p) {
-
   // Book histograms
   edm::Service<TFileService> tfile;
 
-  if ( !tfile.isAvailable() )
+  if (!tfile.isAvailable())
     throw cms::Exception("BadConfig") << "TFileService unavailable: "
                                       << "please add it to config file";
 
-  int    binEta  = m_p.getUntrackedParameter<int>("NBinEta", 320);
-  int    binPhi  = m_p.getUntrackedParameter<int>("NBinPhi", 180);
-  double minEta  = m_p.getUntrackedParameter<double>("MinEta",-8.0);
-  double maxEta  = m_p.getUntrackedParameter<double>("MaxEta", 8.0);
-  double maxPhi  = CLHEP::pi;
+  int binEta = m_p.getUntrackedParameter<int>("NBinEta", 320);
+  int binPhi = m_p.getUntrackedParameter<int>("NBinPhi", 180);
+  double minEta = m_p.getUntrackedParameter<double>("MinEta", -8.0);
+  double maxEta = m_p.getUntrackedParameter<double>("MaxEta", 8.0);
+  double maxPhi = CLHEP::pi;
   edm::LogInfo("MaterialBudget") << "MaterialBudgetForward: Booking user "
                                  << "histos === with " << binEta << " bins "
-                                 << "in eta from " << minEta << " to "
-                                 << maxEta << " and " << binPhi << " bins "
-                                 << "in phi from " << -maxPhi << " to "
-                                 << maxPhi;
+                                 << "in eta from " << minEta << " to " << maxEta << " and " << binPhi << " bins "
+                                 << "in phi from " << -maxPhi << " to " << maxPhi;
 
-  char  name[20], title[80];
+  char name[20], title[80];
   std::string named;
-  for (int i=0; i<std::min((int)(detTypes.size()+1),maxSet); i++) {
-    if (i >= (int)(detTypes.size())) named = "Unknown";
-    else                             named = detTypes[i];
-    sprintf(name, "%d", i+100);
+  for (int i = 0; i < std::min((int)(detTypes.size() + 1), maxSet); i++) {
+    if (i >= (int)(detTypes.size()))
+      named = "Unknown";
+    else
+      named = detTypes[i];
+    sprintf(name, "%d", i + 100);
     sprintf(title, "MB(X0) prof Eta in %s", named.c_str());
-    me100[i] =  tfile->make<TProfile>(name, title, binEta, minEta, maxEta);
-    sprintf(name, "%d", i+200);
+    me100[i] = tfile->make<TProfile>(name, title, binEta, minEta, maxEta);
+    sprintf(name, "%d", i + 200);
     sprintf(title, "MB(L0) prof Eta in %s", named.c_str());
     me200[i] = tfile->make<TProfile>(name, title, binEta, minEta, maxEta);
-    sprintf(name, "%d", i+300);
+    sprintf(name, "%d", i + 300);
     sprintf(title, "MB(Step) prof Eta in %s", named.c_str());
     me300[i] = tfile->make<TProfile>(name, title, binEta, minEta, maxEta);
-    sprintf(name, "%d", i+400);
+    sprintf(name, "%d", i + 400);
     sprintf(title, "Eta in %s", named.c_str());
     me400[i] = tfile->make<TH1F>(name, title, binEta, minEta, maxEta);
-    sprintf(name, "%d", i+500);
+    sprintf(name, "%d", i + 500);
     sprintf(title, "MB(X0) prof Eta Phi in %s", named.c_str());
-    me500[i] = tfile->make<TProfile2D>(name, title, binEta/2, minEta, maxEta,
-                                       binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+600);
+    me500[i] = tfile->make<TProfile2D>(name, title, binEta / 2, minEta, maxEta, binPhi / 2, -maxPhi, maxPhi);
+    sprintf(name, "%d", i + 600);
     sprintf(title, "MB(L0) prof Eta Phi in %s", named.c_str());
-    me600[i]= tfile->make<TProfile2D>(name, title, binEta/2, minEta, maxEta,
-				      binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+700);
+    me600[i] = tfile->make<TProfile2D>(name, title, binEta / 2, minEta, maxEta, binPhi / 2, -maxPhi, maxPhi);
+    sprintf(name, "%d", i + 700);
     sprintf(title, "MB(Step) prof Eta Phi in %s", named.c_str());
-    me700[i]= tfile->make<TProfile2D>(name, title, binEta/2, minEta, maxEta,
-				      binPhi/2, -maxPhi, maxPhi);
-    sprintf(name, "%d", i+800);
+    me700[i] = tfile->make<TProfile2D>(name, title, binEta / 2, minEta, maxEta, binPhi / 2, -maxPhi, maxPhi);
+    sprintf(name, "%d", i + 800);
     sprintf(title, "Eta vs Phi in %s", named.c_str());
-    me800[i]= tfile->make<TH2F>(name, title, binEta/2, minEta, maxEta,
-				binPhi/2, -maxPhi, maxPhi);
+    me800[i] = tfile->make<TH2F>(name, title, binEta / 2, minEta, maxEta, binPhi / 2, -maxPhi, maxPhi);
   }
 
   edm::LogInfo("MaterialBudget") << "MaterialBudgetForward: Booking user "
                                  << "histos done ===";
-
 }
 
 bool MaterialBudgetForward::stopAfter(const G4Step* aStep) {
-
-  G4ThreeVector hitPoint    = aStep->GetPreStepPoint()->GetPosition();
-  if (aStep->GetPostStepPoint() != nullptr) 
+  G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
+  if (aStep->GetPostStepPoint() != nullptr)
     hitPoint = aStep->GetPostStepPoint()->GetPosition();
-  double rr    = hitPoint.perp();
-  double zz    = std::abs(hitPoint.z());
+  double rr = hitPoint.perp();
+  double zz = std::abs(hitPoint.z());
 
-  bool   flag(false);
-  for (unsigned int ii=0; ii<etaRegions.size(); ++ii) {
+  bool flag(false);
+  for (unsigned int ii = 0; ii < etaRegions.size(); ++ii) {
 #ifdef DebugLog
-    edm::LogInfo("MaterialBudget") << " MaterialBudgetForward::Eta " << eta 
-				   << " in Region[" << ii << "] with " 
-				   << etaRegions[ii] << " type "   
-				   << regionTypes[ii] << "|" << boundaries[ii];
+    edm::LogInfo("MaterialBudget") << " MaterialBudgetForward::Eta " << eta << " in Region[" << ii << "] with "
+                                   << etaRegions[ii] << " type " << regionTypes[ii] << "|" << boundaries[ii];
 #endif
     if (fabs(eta) < etaRegions[ii]) {
       if (regionTypes[ii] == 0) {
-	if (rr >= boundaries[ii]-0.001) flag = true;
+        if (rr >= boundaries[ii] - 0.001)
+          flag = true;
       } else {
-	if (zz >= boundaries[ii]-0.001) flag = true;
+        if (zz >= boundaries[ii] - 0.001)
+          flag = true;
       }
 #ifdef DebugLog
       if (flag)
-	edm::LogInfo("MaterialBudget") <<" MaterialBudgetForward::Stop after R = " 
-				       << rr << " and Z = " << zz;
+        edm::LogInfo("MaterialBudget") << " MaterialBudgetForward::Stop after R = " << rr << " and Z = " << zz;
 #endif
       break;
     }
   }
 #ifdef DebugLog
-  edm::LogInfo("MaterialBudget") <<" MaterialBudgetForward:: R = " << rr 
-				 << " and Z = "  << zz << " Flag " << flag;
+  edm::LogInfo("MaterialBudget") << " MaterialBudgetForward:: R = " << rr << " and Z = " << zz << " Flag " << flag;
 #endif
   return flag;
 }

--- a/Validation/Geometry/src/MaterialBudgetForward.cc
+++ b/Validation/Geometry/src/MaterialBudgetForward.cc
@@ -100,19 +100,19 @@ void MaterialBudgetForward::update(const BeginOfTrack* trk) {
   const G4Track* aTrack = (*trk)();  // recover G4 pointer if wanted
   const G4ThreeVector& mom = aTrack->GetMomentum();
   if (mom.theta() != 0) {
-    eta = mom.eta();
+    eta_ = mom.eta();
   } else {
-    eta = -99;
+    eta_ = -99;
   }
-  phi = mom.phi();
+  phi_ = mom.phi();
   stepT = 0;
 
 #ifdef DebugLog
   double theEnergy = aTrack->GetTotalEnergy();
   int theID = (int)(aTrack->GetDefinition()->GetPDGEncoding());
   edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Track " << aTrack->GetTrackID() << " Code " << theID
-                                 << " Energy " << theEnergy / CLHEP::GeV << " GeV; Eta " << eta << " Phi "
-                                 << phi / CLHEP::deg << " PT " << mom.perp() / CLHEP::GeV << " GeV *****";
+                                 << " Energy " << theEnergy / CLHEP::GeV << " GeV; Eta " << eta_ << " Phi "
+                                 << phi_ / CLHEP::deg << " PT " << mom.perp() / CLHEP::GeV << " GeV *****";
 #endif
 }
 
@@ -180,20 +180,20 @@ void MaterialBudgetForward::update(const EndOfTrack* trk) {
   }
 
   for (unsigned int ii = 0; ii <= detTypes.size(); ++ii) {
-    me100[ii]->Fill(eta, radLen[ii]);
-    me200[ii]->Fill(eta, intLen[ii]);
-    me300[ii]->Fill(eta, stepLen[ii]);
-    me400[ii]->Fill(eta);
-    me500[ii]->Fill(eta, phi, radLen[ii]);
-    me600[ii]->Fill(eta, phi, intLen[ii]);
-    me700[ii]->Fill(eta, phi, stepLen[ii]);
-    me800[ii]->Fill(eta, phi);
+    me100[ii]->Fill(eta_, radLen[ii]);
+    me200[ii]->Fill(eta_, intLen[ii]);
+    me300[ii]->Fill(eta_, stepLen[ii]);
+    me400[ii]->Fill(eta_);
+    me500[ii]->Fill(eta_, phi_, radLen[ii]);
+    me600[ii]->Fill(eta_, phi_, intLen[ii]);
+    me700[ii]->Fill(eta_, phi_, stepLen[ii]);
+    me800[ii]->Fill(eta_, phi_);
 
     std::string name("Unknown");
     if (ii < detTypes.size())
       name = detTypes[ii];
 #ifdef DebugLog
-    edm::LogInfo("MaterialBudget") << "MaterialBudgetForward::Volume[" << ii << "]: " << name << " eta " << eta
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetForward::Volume[" << ii << "]: " << name << " eta " << eta_
                                    << " == Step " << stepLen[ii] << " RadL " << radLen[ii] << " IntL " << intLen[ii];
 #endif
   }
@@ -264,10 +264,10 @@ bool MaterialBudgetForward::stopAfter(const G4Step* aStep) {
   bool flag(false);
   for (unsigned int ii = 0; ii < etaRegions.size(); ++ii) {
 #ifdef DebugLog
-    edm::LogInfo("MaterialBudget") << " MaterialBudgetForward::Eta " << eta << " in Region[" << ii << "] with "
+    edm::LogInfo("MaterialBudget") << " MaterialBudgetForward::Eta " << eta_ << " in Region[" << ii << "] with "
                                    << etaRegions[ii] << " type " << regionTypes[ii] << "|" << boundaries[ii];
 #endif
-    if (fabs(eta) < etaRegions[ii]) {
+    if (fabs(eta_) < etaRegions[ii]) {
       if (regionTypes[ii] == 0) {
         if (rr >= boundaries[ii] - 0.001)
           flag = true;

--- a/Validation/Geometry/src/MaterialBudgetHGCalHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetHGCalHistos.cc
@@ -1,32 +1,27 @@
 #include "Validation/Geometry/interface/MaterialBudgetHGCalHistos.h"
 #include "Validation/Geometry/interface/MaterialBudgetData.h"
 
-template <class T> const T& max ( const T& a, const T& b ) {
-  return (b<a)?a:b;     // or: return comp(b,a)?a:b; for the comp version
+template <class T>
+const T& max(const T& a, const T& b) {
+  return (b < a) ? a : b;  // or: return comp(b,a)?a:b; for the comp version
 }
 
-
-
 MaterialBudgetHGCalHistos::MaterialBudgetHGCalHistos(std::shared_ptr<MaterialBudgetData> data,
-						     std::shared_ptr<TestHistoMgr> mgr,
-						     const std::string& fileName )
-  : MaterialBudgetFormat( data ), 
-    hmgr(mgr)
-{
+                                                     std::shared_ptr<TestHistoMgr> mgr,
+                                                     const std::string& fileName)
+    : MaterialBudgetFormat(data), hmgr(mgr) {
   theFileName = fileName;
   book();
 }
 
-
-void MaterialBudgetHGCalHistos::book() 
-{
+void MaterialBudgetHGCalHistos::book() {
   std::cout << "=== booking user histos ===" << std::endl;
 
   // Parameters for 2D histograms
-  // Make z 1mm per bin 
+  // Make z 1mm per bin
   int nzbin = 11000;
-  float zMax = 5500.;//
-  float zMin = -5500.;//
+  float zMax = 5500.;   //
+  float zMin = -5500.;  //
   // Make r 1cm per bin
   int nrbin = 345;
   float rMin = -50.;
@@ -35,7 +30,7 @@ void MaterialBudgetHGCalHistos::book()
   int netabin = 250;
   float etaMin = -5.;
   float etaMax = 5.;
-  // phi 
+  // phi
   int nphibin = 180;
   float phiMin = -3.2;
   float phiMax = 3.2;
@@ -43,426 +38,676 @@ void MaterialBudgetHGCalHistos::book()
   int nRbin = 300;
   float RMin = 0.;
   float RMax = 3000.;
-  
+
   // total X0
-  hmgr->addHistoProf1( new TProfile("10", "MB prof Eta;#eta;x/X_{0} ", netabin, etaMin, etaMax ) );
-  hmgr->addHisto1( new TH1F("11", "Eta " , netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("20", "MB prof Phi;#varphi [rad];x/X_{0} ", nphibin, phiMin, phiMax ) );
-  hmgr->addHisto1( new TH1F("21", "Phi " , nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("30", "MB prof Eta  Phi;#eta;#varphi;x/X_{0} ", netabin, etaMin, etaMax, nphibin, phiMin, phiMax) );
-  hmgr->addHisto2( new TH2F("31", "Eta vs Phi " , netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("40", "MB prof R;R [mm];x/X_{0} ", nRbin, RMin, RMax ) );
-  hmgr->addHisto1( new TH1F("41", "R " , nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("50", "MB prof sum R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("999", "Tot track length for MB", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("51", "R vs z " , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("52", "MB ortho prof sum R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("60", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("70", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("72", "MB ortho prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("10", "MB prof Eta;#eta;x/X_{0} ", netabin, etaMin, etaMax));
+  hmgr->addHisto1(new TH1F("11", "Eta ", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("20", "MB prof Phi;#varphi [rad];x/X_{0} ", nphibin, phiMin, phiMax));
+  hmgr->addHisto1(new TH1F("21", "Phi ", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("30", "MB prof Eta  Phi;#eta;#varphi;x/X_{0} ", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHisto2(new TH2F("31", "Eta vs Phi ", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("40", "MB prof R;R [mm];x/X_{0} ", nRbin, RMin, RMax));
+  hmgr->addHisto1(new TH1F("41", "R ", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("50", "MB prof sum R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("999", "Tot track length for MB", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("51", "R vs z ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("52", "MB ortho prof sum R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("60", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("70", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("72", "MB ortho prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Copper
-  hmgr->addHistoProf1( new TProfile("110", "MB prof Eta [Copper];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("120", "MB prof Phi [Copper];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("130", "MB prof Eta  Phi [Copper];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("140", "MB prof R [Copper];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("150", "MB prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("152", "MB ortho prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("160", "MB prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("170", "MB prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("172", "MB ortho prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("110", "MB prof Eta [Copper];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("120", "MB prof Phi [Copper];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "130", "MB prof Eta  Phi [Copper];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("140", "MB prof R [Copper];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("150", "MB prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "152", "MB ortho prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("160", "MB prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "170", "MB prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "172", "MB ortho prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // H_Scintillator
-  hmgr->addHistoProf1( new TProfile("210", "MB prof Eta [Scintillator];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("220", "MB prof Phi [Scintillator];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("230", "MB prof Eta  Phi [Scintillator];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("240", "MB prof R [Scintillator];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("250", "MB prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("252", "MB ortho prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("260", "MB prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("270", "MB prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("272", "MB ortho prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("210", "MB prof Eta [Scintillator];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("220", "MB prof Phi [Scintillator];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "230", "MB prof Eta  Phi [Scintillator];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("240", "MB prof R [Scintillator];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "250", "MB prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "252", "MB ortho prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F(
+      "260", "MB prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "270", "MB prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "272", "MB ortho prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Cables
-  hmgr->addHistoProf1( new TProfile("310", "MB prof Eta [Cables];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("320", "MB prof Phi [Cables];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("330", "MB prof Eta  Phi [Cables];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("340", "MB prof R [Cables];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("350", "MB prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("352", "MB ortho prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("360", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("370", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("372", "MB ortho prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("310", "MB prof Eta [Cables];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("320", "MB prof Phi [Cables];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "330", "MB prof Eta  Phi [Cables];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("340", "MB prof R [Cables];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("350", "MB prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "352", "MB ortho prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("360", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "370", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "372", "MB ortho prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // HGC_G10_FR4
-  hmgr->addHistoProf1( new TProfile("410", "MB prof Eta [HGC_G10_FR4];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("420", "MB prof Phi [HGC_G10_FR4];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("430", "MB prof Eta  Phi [HGC_G10_FR4];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("440", "MB prof R [HGC_G10_FR4];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("450", "MB prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("452", "MB ortho prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("460", "MB prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("470", "MB prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("472", "MB ortho prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("410", "MB prof Eta [HGC_G10_FR4];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("420", "MB prof Phi [HGC_G10_FR4];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "430", "MB prof Eta  Phi [HGC_G10_FR4];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("440", "MB prof R [HGC_G10_FR4];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "450", "MB prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "452", "MB ortho prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("460", "MB prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "470", "MB prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "472", "MB ortho prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Silicon
-  hmgr->addHistoProf1( new TProfile("510", "MB prof Eta [Silicon];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("520", "MB prof Phi [Silicon];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("530", "MB prof Eta  Phi [Silicon];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("540", "MB prof R [Silicon];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("550", "MB prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("552", "MB ortho prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("560", "MB prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("570", "MB prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("572", "MB ortho prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("510", "MB prof Eta [Silicon];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("520", "MB prof Phi [Silicon];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "530", "MB prof Eta  Phi [Silicon];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("540", "MB prof R [Silicon];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("550", "MB prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "552", "MB ortho prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("560", "MB prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "570", "MB prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "572", "MB ortho prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Other
-  hmgr->addHistoProf1( new TProfile("610", "MB prof Eta [Other];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("620", "MB prof Phi [Other];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("630", "MB prof Eta  Phi [Other];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("640", "MB prof R [Other];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("650", "MB prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("652", "MB ortho prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("660", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("670", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("672", "MB ortho prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("610", "MB prof Eta [Other];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("620", "MB prof Phi [Other];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "630", "MB prof Eta  Phi [Other];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("640", "MB prof R [Other];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("650", "MB prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "652", "MB ortho prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("660", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("670", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "672", "MB ortho prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Air
-  hmgr->addHistoProf1( new TProfile("710", "MB prof Eta [Air];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("720", "MB prof Phi [Air];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("730", "MB prof Eta  Phi [Air];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("740", "MB prof R [Air];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("750", "MB prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("752", "MB ortho prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("760", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("770", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("772", "MB ortho prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("710", "MB prof Eta [Air];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("720", "MB prof Phi [Air];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "730", "MB prof Eta  Phi [Air];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("740", "MB prof R [Air];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("750", "MB prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "752", "MB ortho prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("760", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("770", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "772", "MB ortho prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   //StainlessSteel
-  hmgr->addHistoProf1( new TProfile("810", "MB prof Eta [StainlessSteel];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("820", "MB prof Phi [StainlessSteel];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("830", "MB prof Eta  Phi [StainlessSteel];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("840", "MB prof R [StainlessSteel];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("850", "MB prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("852", "MB ortho prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("860", "MB prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("870", "MB prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("872", "MB ortho prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("810", "MB prof Eta [StainlessSteel];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("820", "MB prof Phi [StainlessSteel];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "830", "MB prof Eta  Phi [StainlessSteel];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("840", "MB prof R [StainlessSteel];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "850", "MB prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "852", "MB ortho prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F(
+      "860", "MB prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "870", "MB prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "872", "MB ortho prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   //WCu
-  hmgr->addHistoProf1( new TProfile("910", "MB prof Eta [WCu];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("920", "MB prof Phi [WCu];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("930", "MB prof Eta  Phi [WCu];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("940", "MB prof R [WCu];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("950", "MB prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("952", "MB ortho prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("960", "MB prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("970", "MB prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("972", "MB ortho prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("910", "MB prof Eta [WCu];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("920", "MB prof Phi [WCu];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "930", "MB prof Eta  Phi [WCu];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("940", "MB prof R [WCu];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("950", "MB prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "952", "MB ortho prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("960", "MB prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("970", "MB prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "972", "MB ortho prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Lead
-  hmgr->addHistoProf1( new TProfile("1010", "MB prof Eta [Lead];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("1020", "MB prof Phi [Lead];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1030", "MB prof Eta  Phi [Lead];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("1040", "MB prof R [Lead];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1050", "MB prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1052", "MB ortho prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1060", "MB prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1070", "MB prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1072", "MB ortho prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1010", "MB prof Eta [Lead];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("1020", "MB prof Phi [Lead];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1030", "MB prof Eta  Phi [Lead];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("1040", "MB prof R [Lead];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("1050", "MB prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1052", "MB ortho prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1060", "MB prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("1070", "MB prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1072", "MB ortho prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Epoxy
-  hmgr->addHistoProf1( new TProfile("1110", "MB prof Eta [Epoxy];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("1120", "MB prof Phi [Epoxy];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1130", "MB prof Eta  Phi [Epoxy];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("1140", "MB prof R [Epoxy];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1150", "MB prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1152", "MB ortho prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1160", "MB prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1170", "MB prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1172", "MB ortho prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1110", "MB prof Eta [Epoxy];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("1120", "MB prof Phi [Epoxy];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1130", "MB prof Eta  Phi [Epoxy];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("1140", "MB prof R [Epoxy];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("1150", "MB prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1152", "MB ortho prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1160", "MB prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1170", "MB prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1172", "MB ortho prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Kapton
-  hmgr->addHistoProf1( new TProfile("1210", "MB prof Eta [Kapton];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("1220", "MB prof Phi [Kapton];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1230", "MB prof Eta  Phi [Kapton];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("1240", "MB prof R [Kapton];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1250", "MB prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1252", "MB ortho prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1260", "MB prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1270", "MB prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1272", "MB ortho prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1210", "MB prof Eta [Kapton];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("1220", "MB prof Phi [Kapton];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1230", "MB prof Eta  Phi [Kapton];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("1240", "MB prof R [Kapton];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("1250", "MB prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1252", "MB ortho prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1260", "MB prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1270", "MB prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1272", "MB ortho prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Aluminium
-  hmgr->addHistoProf1( new TProfile("1310", "MB prof Eta [Aluminium];#eta;x/X_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("1320", "MB prof Phi [Aluminium];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1330", "MB prof Eta  Phi [Aluminium];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("1340", "MB prof R [Aluminium];R [mm];x/X_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1350", "MB prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1352", "MB ortho prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1360", "MB prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1370", "MB prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("1372", "MB ortho prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1310", "MB prof Eta [Aluminium];#eta;x/X_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("1320", "MB prof Phi [Aluminium];#varphi [rad];x/X_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1330", "MB prof Eta  Phi [Aluminium];#eta;#varphi;x/X_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
+  hmgr->addHistoProf1(new TProfile("1340", "MB prof R [Aluminium];R [mm];x/X_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1350", "MB prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1352", "MB ortho prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1360", "MB prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1370", "MB prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1372", "MB ortho prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   //=========================================================================================================
   // total Lambda0
-  hmgr->addHistoProf1( new TProfile("10010", "IL prof Eta;#eta;#lambda/#lambda_{0} ", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10020", "IL prof Phi;#varphi [rad];#lambda/#lambda_{0} ", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10030", "IL prof Eta  Phi;#eta;#varphi;#lambda/#lambda_{0} ", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
+  hmgr->addHistoProf1(new TProfile("10010", "IL prof Eta;#eta;#lambda/#lambda_{0} ", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(new TProfile("10020", "IL prof Phi;#varphi [rad];#lambda/#lambda_{0} ", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10030", "IL prof Eta  Phi;#eta;#varphi;#lambda/#lambda_{0} ", netabin, etaMin, etaMax, nphibin, phiMin, phiMax));
 
   // rr
-  hmgr->addHistoProf1( new TProfile("10040", "IL prof R;R [mm];#lambda/#lambda_{0} ", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10050", "IL prof sum R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10052", "IL ortho prof sum R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1999", "Tot track length for l0", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10060", "IL prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10070", "IL prof local R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10072", "IL ortho prof local R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("10040", "IL prof R;R [mm];#lambda/#lambda_{0} ", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10050", "IL prof sum R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10052", "IL ortho prof sum R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1999", "Tot track length for l0", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("10060", "IL prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10070", "IL prof local R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10072", "IL ortho prof local R  z;z [mm];R [mm];#lambda/#lambda_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Copper
-  hmgr->addHistoProf1( new TProfile("10110", "IL prof Eta [Copper];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10120", "IL prof Phi [Copper];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10130", "IL prof Eta  Phi [Copper];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("10140", "IL prof R [Copper];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10150", "IL prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10152", "IL ortho prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10160", "IL prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10170", "IL prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10172", "IL ortho prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("10110", "IL prof Eta [Copper];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("10120", "IL prof Phi [Copper];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("10130",
+                                     "IL prof Eta  Phi [Copper];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("10140", "IL prof R [Copper];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10150", "IL prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10152", "IL ortho prof sum R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("10160", "IL prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10170", "IL prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10172", "IL ortho prof local R  z [Copper];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // H_Scintillator
-  hmgr->addHistoProf1( new TProfile("10210", "IL prof Eta [Scintillator];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10220", "IL prof Phi [Scintillator];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10230", "IL prof Eta  Phi [Scintillator];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("10240", "IL prof R [Scintillator];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10250", "IL prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10252", "IL ortho prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10260", "IL prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10270", "IL prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10272", "IL ortho prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(
+      new TProfile("10210", "IL prof Eta [Scintillator];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("10220", "IL prof Phi [Scintillator];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("10230",
+                                     "IL prof Eta  Phi [Scintillator];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("10240", "IL prof R [Scintillator];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10250", "IL prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10252", "IL ortho prof sum R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F(
+      "10260", "IL prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10270", "IL prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10272", "IL ortho prof local R  z [Scintillator];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Cables
-  hmgr->addHistoProf1( new TProfile("10310", "IL prof Eta [Cables];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10320", "IL prof Phi [Cables];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10330", "IL prof Eta  Phi [Cables];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("10340", "IL prof R [Cables];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10350", "IL prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10352", "IL ortho prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10360", "IL prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10370", "IL prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10372", "IL ortho prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("10310", "IL prof Eta [Cables];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("10320", "IL prof Phi [Cables];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("10330",
+                                     "IL prof Eta  Phi [Cables];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("10340", "IL prof R [Cables];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10350", "IL prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10352", "IL ortho prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("10360", "IL prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10370", "IL prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10372", "IL ortho prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // HGC_G10_FR4
-  hmgr->addHistoProf1( new TProfile("10410", "IL prof Eta [HGC_G10_FR4];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10420", "IL prof Phi [HGC_G10_FR4];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10430", "IL prof Eta  Phi [HGC_G10_FR4];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("10440", "IL prof R [HGC_G10_FR4];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10450", "IL prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10452", "IL ortho prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10460", "IL prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10470", "IL prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10472", "IL ortho prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(
+      new TProfile("10410", "IL prof Eta [HGC_G10_FR4];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("10420", "IL prof Phi [HGC_G10_FR4];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("10430",
+                                     "IL prof Eta  Phi [HGC_G10_FR4];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("10440", "IL prof R [HGC_G10_FR4];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10450", "IL prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10452", "IL ortho prof sum R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F(
+      "10460", "IL prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10470", "IL prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10472", "IL ortho prof local R  z [HGC_G10_FR4];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Silicon
-  hmgr->addHistoProf1( new TProfile("10510", "IL prof Eta [Silicon];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10520", "IL prof Phi [Silicon];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10530", "IL prof Eta  Phi [Silicon];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("10540", "IL prof R [Silicon];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10550", "IL prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10552", "IL ortho prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10560", "IL prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10570", "IL prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10572", "IL ortho prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("10510", "IL prof Eta [Silicon];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("10520", "IL prof Phi [Silicon];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("10530",
+                                     "IL prof Eta  Phi [Silicon];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("10540", "IL prof R [Silicon];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10550", "IL prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10552", "IL ortho prof sum R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("10560", "IL prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10570", "IL prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10572", "IL ortho prof local R  z [Silicon];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Other
-  hmgr->addHistoProf1( new TProfile("10610", "IL prof Eta [Other];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10620", "IL prof Phi [Other];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10630", "IL prof Eta  Phi [Other];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("10640", "IL prof R [Other];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10650", "IL prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10652", "IL ortho prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10660", "IL prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10670", "IL prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10672", "IL ortho prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("10610", "IL prof Eta [Other];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("10620", "IL prof Phi [Other];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("10630",
+                                     "IL prof Eta  Phi [Other];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("10640", "IL prof R [Other];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("10650", "IL prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10652", "IL ortho prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("10660", "IL prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10670", "IL prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10672", "IL ortho prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Air
-  hmgr->addHistoProf1( new TProfile("10710", "IL prof Eta [Air];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10720", "IL prof Phi [Air];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10730", "IL prof Eta  Phi [Air];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("10740", "IL prof R [Air];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10750", "IL prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10752", "IL ortho prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10760", "IL prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10770", "IL prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10772", "IL ortho prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("10710", "IL prof Eta [Air];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("10720", "IL prof Phi [Air];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("10730",
+                                     "IL prof Eta  Phi [Air];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("10740", "IL prof R [Air];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("10750", "IL prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10752", "IL ortho prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("10760", "IL prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("10770", "IL prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10772", "IL ortho prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   //StainlessSteel
-  hmgr->addHistoProf1( new TProfile("10810", "IL prof Eta [StainlessSteel];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10820", "IL prof Phi [StainlessSteel];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10830", "IL prof Eta  Phi [StainlessSteel];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("10840", "IL prof R [StainlessSteel];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10850", "IL prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10852", "IL ortho prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10860", "IL prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10870", "IL prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10872", "IL ortho prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(
+      new TProfile("10810", "IL prof Eta [StainlessSteel];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("10820", "IL prof Phi [StainlessSteel];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("10830",
+                                     "IL prof Eta  Phi [StainlessSteel];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(
+      new TProfile("10840", "IL prof R [StainlessSteel];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10850", "IL prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10852", "IL ortho prof sum R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F(
+      "10860", "IL prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10870", "IL prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10872", "IL ortho prof local R  z [StainlessSteel];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   //WCu
-  hmgr->addHistoProf1( new TProfile("10910", "IL prof Eta [WCu];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("10920", "IL prof Phi [WCu];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10930", "IL prof Eta  Phi [WCu];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("10940", "IL prof R [WCu];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10950", "IL prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10952", "IL ortho prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("10960", "IL prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10970", "IL prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("10972", "IL ortho prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("10910", "IL prof Eta [WCu];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("10920", "IL prof Phi [WCu];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("10930",
+                                     "IL prof Eta  Phi [WCu];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("10940", "IL prof R [WCu];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("10950", "IL prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10952", "IL ortho prof sum R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("10960", "IL prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("10970", "IL prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "10972", "IL ortho prof local R  z [WCu];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Lead
-  hmgr->addHistoProf1( new TProfile("11010", "IL prof Eta [Lead];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("11020", "IL prof Phi [Lead];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11030", "IL prof Eta  Phi [Lead];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("11040", "IL prof R [Lead];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11050", "IL prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11052", "IL ortho prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("11060", "IL prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11070", "IL prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11072", "IL ortho prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("11010", "IL prof Eta [Lead];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("11020", "IL prof Phi [Lead];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("11030",
+                                     "IL prof Eta  Phi [Lead];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("11040", "IL prof R [Lead];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("11050", "IL prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11052", "IL ortho prof sum R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("11060", "IL prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11070", "IL prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11072", "IL ortho prof local R  z [Lead];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Epoxy
-  hmgr->addHistoProf1( new TProfile("11110", "IL prof Eta [Epoxy];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("11120", "IL prof Phi [Epoxy];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11130", "IL prof Eta  Phi [Epoxy];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("11140", "IL prof R [Epoxy];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11150", "IL prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11152", "IL ortho prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("11160", "IL prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11170", "IL prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11172", "IL ortho prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("11110", "IL prof Eta [Epoxy];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("11120", "IL prof Phi [Epoxy];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("11130",
+                                     "IL prof Eta  Phi [Epoxy];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("11140", "IL prof R [Epoxy];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(
+      new TProfile2D("11150", "IL prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11152", "IL ortho prof sum R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("11160", "IL prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11170", "IL prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11172", "IL ortho prof local R  z [Epoxy];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Kapton
-  hmgr->addHistoProf1( new TProfile("11210", "IL prof Eta [Kapton];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("11220", "IL prof Phi [Kapton];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11230", "IL prof Eta  Phi [Kapton];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("11240", "IL prof R [Kapton];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11250", "IL prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11252", "IL ortho prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("11260", "IL prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11270", "IL prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11272", "IL ortho prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("11210", "IL prof Eta [Kapton];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("11220", "IL prof Phi [Kapton];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("11230",
+                                     "IL prof Eta  Phi [Kapton];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("11240", "IL prof R [Kapton];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11250", "IL prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11252", "IL ortho prof sum R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("11260", "IL prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11270", "IL prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11272", "IL ortho prof local R  z [Kapton];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Aluminium
-  hmgr->addHistoProf1( new TProfile("11310", "IL prof Eta [Aluminium];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax ) );
-  hmgr->addHistoProf1( new TProfile("11320", "IL prof Phi [Aluminium];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11330", "IL prof Eta  Phi [Aluminium];#eta;#varphi;#lambda/#lambda_{0}", netabin, etaMin, etaMax, nphibin, phiMin, phiMax ) );
-  hmgr->addHistoProf1( new TProfile("11340", "IL prof R [Aluminium];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11350", "IL prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11352", "IL ortho prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("11360", "IL prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11370", "IL prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHistoProf2( new TProfile2D("11372", "IL ortho prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(
+      new TProfile("11310", "IL prof Eta [Aluminium];#eta;#lambda/#lambda_{0}", netabin, etaMin, etaMax));
+  hmgr->addHistoProf1(
+      new TProfile("11320", "IL prof Phi [Aluminium];#varphi [rad];#lambda/#lambda_{0}", nphibin, phiMin, phiMax));
+  hmgr->addHistoProf2(new TProfile2D("11330",
+                                     "IL prof Eta  Phi [Aluminium];#eta;#varphi;#lambda/#lambda_{0}",
+                                     netabin,
+                                     etaMin,
+                                     etaMax,
+                                     nphibin,
+                                     phiMin,
+                                     phiMax));
+  hmgr->addHistoProf1(new TProfile("11340", "IL prof R [Aluminium];R [mm];#lambda/#lambda_{0}", nRbin, RMin, RMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11350", "IL prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11352", "IL ortho prof sum R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("11360", "IL prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11370", "IL prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHistoProf2(new TProfile2D(
+      "11372", "IL ortho prof local R  z [Aluminium];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
-  
   std::cout << "=== booking user histos done ===" << std::endl;
-
 }
 
+void MaterialBudgetHGCalHistos::fillStartTrack() {}
 
-void MaterialBudgetHGCalHistos::fillStartTrack()
-{
+void MaterialBudgetHGCalHistos::fillPerStep() {}
 
-}
-
-
-void MaterialBudgetHGCalHistos::fillPerStep()
-{
-
-}
-
-
-void MaterialBudgetHGCalHistos::fillEndTrack()
-{
+void MaterialBudgetHGCalHistos::fillEndTrack() {
   //
   // fill histograms and profiles only if the material has been crossed
   //
-  
-  if( theData->getNumberOfSteps() != 0 ) {
-    
+
+  if (theData->getNumberOfSteps() != 0) {
     // Total X0
     hmgr->getHisto1(11)->Fill(theData->getEta());
     hmgr->getHisto1(21)->Fill(theData->getPhi());
-    hmgr->getHisto2(31)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(10)->Fill(theData->getEta(),theData->getTotalMB());
-    hmgr->getHistoProf1(20)->Fill(theData->getPhi(),theData->getTotalMB());
-    hmgr->getHistoProf2(30)->Fill(theData->getEta(),theData->getPhi(),theData->getTotalMB());
-    
+    hmgr->getHisto2(31)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(10)->Fill(theData->getEta(), theData->getTotalMB());
+    hmgr->getHistoProf1(20)->Fill(theData->getPhi(), theData->getTotalMB());
+    hmgr->getHistoProf2(30)->Fill(theData->getEta(), theData->getPhi(), theData->getTotalMB());
+
     // rr
-    
+
     // Copper
-    hmgr->getHistoProf1(110)->Fill(theData->getEta(),theData->getCopperMB());
-    hmgr->getHistoProf1(120)->Fill(theData->getPhi(),theData->getCopperMB());
-    hmgr->getHistoProf2(130)->Fill(theData->getEta(),theData->getPhi(),theData->getCopperMB());
-    
+    hmgr->getHistoProf1(110)->Fill(theData->getEta(), theData->getCopperMB());
+    hmgr->getHistoProf1(120)->Fill(theData->getPhi(), theData->getCopperMB());
+    hmgr->getHistoProf2(130)->Fill(theData->getEta(), theData->getPhi(), theData->getCopperMB());
+
     // H_Scintillator
-    hmgr->getHistoProf1(210)->Fill(theData->getEta(),theData->getH_ScintillatorMB());
-    hmgr->getHistoProf1(220)->Fill(theData->getPhi(),theData->getH_ScintillatorMB());
-    hmgr->getHistoProf2(230)->Fill(theData->getEta(),theData->getPhi(),theData->getH_ScintillatorMB());
-    
+    hmgr->getHistoProf1(210)->Fill(theData->getEta(), theData->getH_ScintillatorMB());
+    hmgr->getHistoProf1(220)->Fill(theData->getPhi(), theData->getH_ScintillatorMB());
+    hmgr->getHistoProf2(230)->Fill(theData->getEta(), theData->getPhi(), theData->getH_ScintillatorMB());
+
     // Cables
-    hmgr->getHistoProf1(310)->Fill(theData->getEta(),theData->getCablesMB());
-    hmgr->getHistoProf1(320)->Fill(theData->getPhi(),theData->getCablesMB());
-    hmgr->getHistoProf2(330)->Fill(theData->getEta(),theData->getPhi(),theData->getCablesMB());
-    
+    hmgr->getHistoProf1(310)->Fill(theData->getEta(), theData->getCablesMB());
+    hmgr->getHistoProf1(320)->Fill(theData->getPhi(), theData->getCablesMB());
+    hmgr->getHistoProf2(330)->Fill(theData->getEta(), theData->getPhi(), theData->getCablesMB());
+
     // HGC_G10_FR4
-    hmgr->getHistoProf1(410)->Fill(theData->getEta(),theData->getHGC_G10_FR4MB());
-    hmgr->getHistoProf1(420)->Fill(theData->getPhi(),theData->getHGC_G10_FR4MB());
-    hmgr->getHistoProf2(430)->Fill(theData->getEta(),theData->getPhi(),theData->getHGC_G10_FR4MB());
-    
+    hmgr->getHistoProf1(410)->Fill(theData->getEta(), theData->getHGC_G10_FR4MB());
+    hmgr->getHistoProf1(420)->Fill(theData->getPhi(), theData->getHGC_G10_FR4MB());
+    hmgr->getHistoProf2(430)->Fill(theData->getEta(), theData->getPhi(), theData->getHGC_G10_FR4MB());
+
     // Silicon
-    hmgr->getHistoProf1(510)->Fill(theData->getEta(),theData->getSiliconMB());
-    hmgr->getHistoProf1(520)->Fill(theData->getPhi(),theData->getSiliconMB());
-    hmgr->getHistoProf2(530)->Fill(theData->getEta(),theData->getPhi(),theData->getSiliconMB());
-    
+    hmgr->getHistoProf1(510)->Fill(theData->getEta(), theData->getSiliconMB());
+    hmgr->getHistoProf1(520)->Fill(theData->getPhi(), theData->getSiliconMB());
+    hmgr->getHistoProf2(530)->Fill(theData->getEta(), theData->getPhi(), theData->getSiliconMB());
+
     // Other
-    hmgr->getHistoProf1(610)->Fill(theData->getEta(),theData->getOtherMB());
-    hmgr->getHistoProf1(620)->Fill(theData->getPhi(),theData->getOtherMB());
-    hmgr->getHistoProf2(630)->Fill(theData->getEta(),theData->getPhi(),theData->getOtherMB());
-    
+    hmgr->getHistoProf1(610)->Fill(theData->getEta(), theData->getOtherMB());
+    hmgr->getHistoProf1(620)->Fill(theData->getPhi(), theData->getOtherMB());
+    hmgr->getHistoProf2(630)->Fill(theData->getEta(), theData->getPhi(), theData->getOtherMB());
+
     // Air
-    hmgr->getHistoProf1(710)->Fill(theData->getEta(),theData->getAirMB());
-    hmgr->getHistoProf1(720)->Fill(theData->getPhi(),theData->getAirMB());
-    hmgr->getHistoProf2(730)->Fill(theData->getEta(),theData->getPhi(),theData->getAirMB());
-    
+    hmgr->getHistoProf1(710)->Fill(theData->getEta(), theData->getAirMB());
+    hmgr->getHistoProf1(720)->Fill(theData->getPhi(), theData->getAirMB());
+    hmgr->getHistoProf2(730)->Fill(theData->getEta(), theData->getPhi(), theData->getAirMB());
+
     // StainlessSteel
-    hmgr->getHistoProf1(810)->Fill(theData->getEta(),theData->getStainlessSteelMB());
-    hmgr->getHistoProf1(820)->Fill(theData->getPhi(),theData->getStainlessSteelMB());
-    hmgr->getHistoProf2(830)->Fill(theData->getEta(),theData->getPhi(),theData->getStainlessSteelMB());
+    hmgr->getHistoProf1(810)->Fill(theData->getEta(), theData->getStainlessSteelMB());
+    hmgr->getHistoProf1(820)->Fill(theData->getPhi(), theData->getStainlessSteelMB());
+    hmgr->getHistoProf2(830)->Fill(theData->getEta(), theData->getPhi(), theData->getStainlessSteelMB());
 
     // WCu
-    hmgr->getHistoProf1(910)->Fill(theData->getEta(),theData->getWCuMB());
-    hmgr->getHistoProf1(920)->Fill(theData->getPhi(),theData->getWCuMB());
-    hmgr->getHistoProf2(930)->Fill(theData->getEta(),theData->getPhi(),theData->getWCuMB());
+    hmgr->getHistoProf1(910)->Fill(theData->getEta(), theData->getWCuMB());
+    hmgr->getHistoProf1(920)->Fill(theData->getPhi(), theData->getWCuMB());
+    hmgr->getHistoProf2(930)->Fill(theData->getEta(), theData->getPhi(), theData->getWCuMB());
 
     // Lead
-    hmgr->getHistoProf1(1010)->Fill(theData->getEta(),theData->getLeadMB());
-    hmgr->getHistoProf1(1020)->Fill(theData->getPhi(),theData->getLeadMB());
-    hmgr->getHistoProf2(1030)->Fill(theData->getEta(),theData->getPhi(),theData->getLeadMB());
+    hmgr->getHistoProf1(1010)->Fill(theData->getEta(), theData->getLeadMB());
+    hmgr->getHistoProf1(1020)->Fill(theData->getPhi(), theData->getLeadMB());
+    hmgr->getHistoProf2(1030)->Fill(theData->getEta(), theData->getPhi(), theData->getLeadMB());
 
     // Epoxy
-    hmgr->getHistoProf1(1110)->Fill(theData->getEta(),theData->getEpoxyMB());
-    hmgr->getHistoProf1(1120)->Fill(theData->getPhi(),theData->getEpoxyMB());
-    hmgr->getHistoProf2(1130)->Fill(theData->getEta(),theData->getPhi(),theData->getEpoxyMB());
+    hmgr->getHistoProf1(1110)->Fill(theData->getEta(), theData->getEpoxyMB());
+    hmgr->getHistoProf1(1120)->Fill(theData->getPhi(), theData->getEpoxyMB());
+    hmgr->getHistoProf2(1130)->Fill(theData->getEta(), theData->getPhi(), theData->getEpoxyMB());
 
     // Kapton
-    hmgr->getHistoProf1(1210)->Fill(theData->getEta(),theData->getKaptonMB());
-    hmgr->getHistoProf1(1220)->Fill(theData->getPhi(),theData->getKaptonMB());
-    hmgr->getHistoProf2(1230)->Fill(theData->getEta(),theData->getPhi(),theData->getKaptonMB());
+    hmgr->getHistoProf1(1210)->Fill(theData->getEta(), theData->getKaptonMB());
+    hmgr->getHistoProf1(1220)->Fill(theData->getPhi(), theData->getKaptonMB());
+    hmgr->getHistoProf2(1230)->Fill(theData->getEta(), theData->getPhi(), theData->getKaptonMB());
 
     // Kapton
-    hmgr->getHistoProf1(1310)->Fill(theData->getEta(),theData->getAluminiumMB());
-    hmgr->getHistoProf1(1320)->Fill(theData->getPhi(),theData->getAluminiumMB());
-    hmgr->getHistoProf2(1330)->Fill(theData->getEta(),theData->getPhi(),theData->getAluminiumMB());
+    hmgr->getHistoProf1(1310)->Fill(theData->getEta(), theData->getAluminiumMB());
+    hmgr->getHistoProf1(1320)->Fill(theData->getPhi(), theData->getAluminiumMB());
+    hmgr->getHistoProf2(1330)->Fill(theData->getEta(), theData->getPhi(), theData->getAluminiumMB());
     //
     // Compute the total x/X0 crossed at each step radius for each path
     //
@@ -481,7 +726,7 @@ void MaterialBudgetHGCalHistos::fillEndTrack()
     float theTotalMB_EPX = 0.0;
     float theTotalMB_KAP = 0.0;
     float theTotalMB_ALU = 0.0;
-    for(int iStep = 0; iStep < theData->getNumberOfSteps(); iStep++) {
+    for (int iStep = 0; iStep < theData->getNumberOfSteps(); iStep++) {
       theTotalMB_TOT += theData->getStepDmb(iStep);
       theTotalMB_COP += theData->getCopperDmb(iStep);
       theTotalMB_SCI += theData->getH_ScintillatorDmb(iStep);
@@ -489,13 +734,13 @@ void MaterialBudgetHGCalHistos::fillEndTrack()
       theTotalMB_HGF += theData->getHGC_G10_FR4Dmb(iStep);
       theTotalMB_NIM += theData->getSiliconDmb(iStep);
       theTotalMB_OTH += theData->getOtherDmb(iStep);
-      theTotalMB_AIR += theData->getAirDmb(iStep);        
-      theTotalMB_SST += theData->getStainlessSteelDmb(iStep);        
-      theTotalMB_WCU += theData->getWCuDmb(iStep);        
-      theTotalMB_LEA += theData->getLeadDmb(iStep);        
-      theTotalMB_EPX += theData->getEpoxyDmb(iStep);        
-      theTotalMB_KAP += theData->getKaptonDmb(iStep);        
-      theTotalMB_ALU += theData->getAluminiumDmb(iStep);        
+      theTotalMB_AIR += theData->getAirDmb(iStep);
+      theTotalMB_SST += theData->getStainlessSteelDmb(iStep);
+      theTotalMB_WCU += theData->getWCuDmb(iStep);
+      theTotalMB_LEA += theData->getLeadDmb(iStep);
+      theTotalMB_EPX += theData->getEpoxyDmb(iStep);
+      theTotalMB_KAP += theData->getKaptonDmb(iStep);
+      theTotalMB_ALU += theData->getAluminiumDmb(iStep);
 
       int iCop = 0;
       int iSci = 0;
@@ -510,28 +755,51 @@ void MaterialBudgetHGCalHistos::fillEndTrack()
       int iEpx = 0;
       int iKap = 0;
       int iAlu = 0;
-      if(theData->getCopperDmb(iStep)>0.) { iCop = 1; }
-      if(theData->getH_ScintillatorDmb(iStep)>0.) { iSci = 1; }
-      if(theData->getCablesDmb(iStep)>0.) { iCab = 1; }
-      if(theData->getHGC_G10_FR4Dmb(iStep)>0.) { iHgf = 1; }
-      if(theData->getSiliconDmb(iStep)>0.) { iSil = 1; }
-      if(theData->getOtherDmb(iStep)>0.) { iOth = 1; }
-      if(theData->getAirDmb(iStep)>0.) { iAir = 1; }
-      if(theData->getStainlessSteelDmb(iStep)>0.) { iSst = 1; }
-      if(theData->getWCuDmb(iStep)>0.) { iWcu = 1; }
-      if(theData->getLeadDmb(iStep)>0.) { iLea = 1; }
-      if(theData->getEpoxyDmb(iStep)>0.) { iEpx = 1; }
-      if(theData->getKaptonDmb(iStep)>0.) { iKap = 1; }
-      if(theData->getAluminiumDmb(iStep)>0.) { iAlu = 1; }
+      if (theData->getCopperDmb(iStep) > 0.) {
+        iCop = 1;
+      }
+      if (theData->getH_ScintillatorDmb(iStep) > 0.) {
+        iSci = 1;
+      }
+      if (theData->getCablesDmb(iStep) > 0.) {
+        iCab = 1;
+      }
+      if (theData->getHGC_G10_FR4Dmb(iStep) > 0.) {
+        iHgf = 1;
+      }
+      if (theData->getSiliconDmb(iStep) > 0.) {
+        iSil = 1;
+      }
+      if (theData->getOtherDmb(iStep) > 0.) {
+        iOth = 1;
+      }
+      if (theData->getAirDmb(iStep) > 0.) {
+        iAir = 1;
+      }
+      if (theData->getStainlessSteelDmb(iStep) > 0.) {
+        iSst = 1;
+      }
+      if (theData->getWCuDmb(iStep) > 0.) {
+        iWcu = 1;
+      }
+      if (theData->getLeadDmb(iStep) > 0.) {
+        iLea = 1;
+      }
+      if (theData->getEpoxyDmb(iStep) > 0.) {
+        iEpx = 1;
+      }
+      if (theData->getKaptonDmb(iStep) > 0.) {
+        iKap = 1;
+      }
+      if (theData->getAluminiumDmb(iStep) > 0.) {
+        iAlu = 1;
+      }
 
-      float deltaRadius = sqrt(
-			       pow( theData->getStepFinalX(iStep)-theData->getStepInitialX(iStep),2 )
-			       +
-			       pow( theData->getStepFinalY(iStep)-theData->getStepInitialY(iStep),2 )
-			       );
-      float deltaz = theData->getStepFinalZ(iStep)-theData->getStepInitialZ(iStep) ;
-      
-      float deltaeta = theData->getStepFinalEta(iStep)-theData->getStepInitialEta(iStep) ;
+      float deltaRadius = sqrt(pow(theData->getStepFinalX(iStep) - theData->getStepInitialX(iStep), 2) +
+                               pow(theData->getStepFinalY(iStep) - theData->getStepInitialY(iStep), 2));
+      float deltaz = theData->getStepFinalZ(iStep) - theData->getStepInitialZ(iStep);
+
+      float deltaeta = theData->getStepFinalEta(iStep) - theData->getStepInitialEta(iStep);
 
       // float deltaphi = theData->getStepFinalPhi(iStep)-theData->getStepInitialPhi(iStep) ;
 
@@ -539,227 +807,217 @@ void MaterialBudgetHGCalHistos::fillEndTrack()
 
       int nSubStep = 2;
       float boxWidth = 0.1;
-      if( (deltaRadius>boxWidth) || (fabs(deltaz)>boxWidth) ) {
-	nSubStep = static_cast<int>(max(
-		       ceil(deltaRadius/boxWidth/2.)*2,
-		       ceil(fabs(deltaz)/boxWidth/2.)*2
-		       ));
+      if ((deltaRadius > boxWidth) || (fabs(deltaz) > boxWidth)) {
+        nSubStep = static_cast<int>(max(ceil(deltaRadius / boxWidth / 2.) * 2, ceil(fabs(deltaz) / boxWidth / 2.) * 2));
       }
-      
-      for(int iSubStep = 1; iSubStep < nSubStep; iSubStep+=2) {
 
-	float subdeltaRadius = deltaRadius/nSubStep;
-	float polarRadius = sqrt(
-				 pow( theData->getStepInitialX(iStep),2 )
-				 +
-				 pow( theData->getStepInitialY(iStep),2 )
-				 ) + iSubStep*subdeltaRadius;
+      for (int iSubStep = 1; iSubStep < nSubStep; iSubStep += 2) {
+        float subdeltaRadius = deltaRadius / nSubStep;
+        float polarRadius = sqrt(pow(theData->getStepInitialX(iStep), 2) + pow(theData->getStepInitialY(iStep), 2)) +
+                            iSubStep * subdeltaRadius;
 
-	float subdeltaz = deltaz/nSubStep;
-	float z = theData->getStepInitialZ(iStep) + iSubStep*subdeltaz;
+        float subdeltaz = deltaz / nSubStep;
+        float z = theData->getStepInitialZ(iStep) + iSubStep * subdeltaz;
 
-	float subdeltaeta = deltaeta/nSubStep;
-	float eta = theData->getStepInitialEta(iStep) + iSubStep*subdeltaeta;
+        float subdeltaeta = deltaeta / nSubStep;
+        float eta = theData->getStepInitialEta(iStep) + iSubStep * subdeltaeta;
 
-	// float subdeltaphi = deltaphi/nSubStep;
-	// float phi = theData->getStepInitialPhi(iStep) + iSubStep*subdeltaphi;
+        // float subdeltaphi = deltaphi/nSubStep;
+        // float phi = theData->getStepInitialPhi(iStep) + iSubStep*subdeltaphi;
 
-	float subdelta = sqrt(
-			      pow ( subdeltaRadius,2 ) + pow( subdeltaz,2 )
-			      );
+        float subdelta = sqrt(pow(subdeltaRadius, 2) + pow(subdeltaz, 2));
 
-	float fillValue=subdelta/x0;
+        float fillValue = subdelta / x0;
 
-	float costhetacorrection = cos( 2 * atan(exp(-fabs(eta))) );
-	// Average length
-	hmgr->getHisto2(999)->Fill(z,polarRadius,subdelta);
-	// Total
-	hmgr->getHisto1(41)->Fill(polarRadius);
-	hmgr->getHistoProf1(40)->Fill(polarRadius,theTotalMB_TOT);
-	hmgr->getHisto2(51)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(50)->Fill(z,polarRadius,theTotalMB_TOT);
-	hmgr->getHistoProf2(52)->Fill(z,polarRadius, theTotalMB_TOT * costhetacorrection );
-	hmgr->getHisto2(60)->Fill(z,polarRadius,fillValue);
-	hmgr->getHistoProf2(70)->Fill(z,polarRadius,fillValue);
-	hmgr->getHistoProf2(72)->Fill(z,polarRadius, fillValue * costhetacorrection );
+        float costhetacorrection = cos(2 * atan(exp(-fabs(eta))));
+        // Average length
+        hmgr->getHisto2(999)->Fill(z, polarRadius, subdelta);
+        // Total
+        hmgr->getHisto1(41)->Fill(polarRadius);
+        hmgr->getHistoProf1(40)->Fill(polarRadius, theTotalMB_TOT);
+        hmgr->getHisto2(51)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(50)->Fill(z, polarRadius, theTotalMB_TOT);
+        hmgr->getHistoProf2(52)->Fill(z, polarRadius, theTotalMB_TOT * costhetacorrection);
+        hmgr->getHisto2(60)->Fill(z, polarRadius, fillValue);
+        hmgr->getHistoProf2(70)->Fill(z, polarRadius, fillValue);
+        hmgr->getHistoProf2(72)->Fill(z, polarRadius, fillValue * costhetacorrection);
 
-	// Copper
-	hmgr->getHistoProf1(140)->Fill(polarRadius,theTotalMB_COP);
-	hmgr->getHistoProf2(150)->Fill(z,polarRadius,theTotalMB_COP);
-	hmgr->getHistoProf2(152)->Fill(z,polarRadius,theTotalMB_COP * costhetacorrection );
-	hmgr->getHisto2(160)->Fill(z,polarRadius,iCop*fillValue);
-	hmgr->getHistoProf2(170)->Fill(z,polarRadius,iCop*fillValue);
-	hmgr->getHistoProf2(172)->Fill(z,polarRadius, iCop * fillValue * costhetacorrection );
+        // Copper
+        hmgr->getHistoProf1(140)->Fill(polarRadius, theTotalMB_COP);
+        hmgr->getHistoProf2(150)->Fill(z, polarRadius, theTotalMB_COP);
+        hmgr->getHistoProf2(152)->Fill(z, polarRadius, theTotalMB_COP * costhetacorrection);
+        hmgr->getHisto2(160)->Fill(z, polarRadius, iCop * fillValue);
+        hmgr->getHistoProf2(170)->Fill(z, polarRadius, iCop * fillValue);
+        hmgr->getHistoProf2(172)->Fill(z, polarRadius, iCop * fillValue * costhetacorrection);
 
-	// H_Scintillator
-	hmgr->getHistoProf1(240)->Fill(polarRadius,theTotalMB_SCI);
-	hmgr->getHistoProf2(250)->Fill(z,polarRadius,theTotalMB_SCI);
-	hmgr->getHistoProf2(252)->Fill(z,polarRadius,theTotalMB_SCI * costhetacorrection );
-	hmgr->getHisto2(260)->Fill(z,polarRadius,iSci*fillValue);
-	hmgr->getHistoProf2(270)->Fill(z,polarRadius,iSci*fillValue);
-	hmgr->getHistoProf2(272)->Fill(z,polarRadius, iSci * fillValue * costhetacorrection );
+        // H_Scintillator
+        hmgr->getHistoProf1(240)->Fill(polarRadius, theTotalMB_SCI);
+        hmgr->getHistoProf2(250)->Fill(z, polarRadius, theTotalMB_SCI);
+        hmgr->getHistoProf2(252)->Fill(z, polarRadius, theTotalMB_SCI * costhetacorrection);
+        hmgr->getHisto2(260)->Fill(z, polarRadius, iSci * fillValue);
+        hmgr->getHistoProf2(270)->Fill(z, polarRadius, iSci * fillValue);
+        hmgr->getHistoProf2(272)->Fill(z, polarRadius, iSci * fillValue * costhetacorrection);
 
-	// Cables
-	hmgr->getHistoProf1(340)->Fill(polarRadius,theTotalMB_CAB);
-	hmgr->getHistoProf2(350)->Fill(z,polarRadius,theTotalMB_CAB);
-	hmgr->getHistoProf2(352)->Fill(z,polarRadius,theTotalMB_CAB * costhetacorrection );
-	hmgr->getHisto2(360)->Fill(z,polarRadius,iCab*fillValue);
-	hmgr->getHistoProf2(370)->Fill(z,polarRadius,iCab*fillValue);
-	hmgr->getHistoProf2(372)->Fill(z,polarRadius, iCab * fillValue * costhetacorrection );
+        // Cables
+        hmgr->getHistoProf1(340)->Fill(polarRadius, theTotalMB_CAB);
+        hmgr->getHistoProf2(350)->Fill(z, polarRadius, theTotalMB_CAB);
+        hmgr->getHistoProf2(352)->Fill(z, polarRadius, theTotalMB_CAB * costhetacorrection);
+        hmgr->getHisto2(360)->Fill(z, polarRadius, iCab * fillValue);
+        hmgr->getHistoProf2(370)->Fill(z, polarRadius, iCab * fillValue);
+        hmgr->getHistoProf2(372)->Fill(z, polarRadius, iCab * fillValue * costhetacorrection);
 
-	// HGC_G10_FR4
-	hmgr->getHistoProf1(440)->Fill(polarRadius,theTotalMB_HGF);
-	hmgr->getHistoProf2(450)->Fill(z,polarRadius,theTotalMB_HGF);
-	hmgr->getHistoProf2(452)->Fill(z,polarRadius,theTotalMB_HGF * costhetacorrection );
-	hmgr->getHisto2(460)->Fill(z,polarRadius,iHgf*fillValue);
-	hmgr->getHistoProf2(470)->Fill(z,polarRadius,iHgf*fillValue);
-	hmgr->getHistoProf2(472)->Fill(z,polarRadius, iHgf * fillValue * costhetacorrection );
+        // HGC_G10_FR4
+        hmgr->getHistoProf1(440)->Fill(polarRadius, theTotalMB_HGF);
+        hmgr->getHistoProf2(450)->Fill(z, polarRadius, theTotalMB_HGF);
+        hmgr->getHistoProf2(452)->Fill(z, polarRadius, theTotalMB_HGF * costhetacorrection);
+        hmgr->getHisto2(460)->Fill(z, polarRadius, iHgf * fillValue);
+        hmgr->getHistoProf2(470)->Fill(z, polarRadius, iHgf * fillValue);
+        hmgr->getHistoProf2(472)->Fill(z, polarRadius, iHgf * fillValue * costhetacorrection);
 
-	// Silicon
-	hmgr->getHistoProf1(540)->Fill(polarRadius,theTotalMB_NIM);
-	hmgr->getHistoProf2(550)->Fill(z,polarRadius,theTotalMB_NIM);
-	hmgr->getHistoProf2(552)->Fill(z,polarRadius,theTotalMB_NIM * costhetacorrection );
-	hmgr->getHisto2(560)->Fill(z,polarRadius,iSil*fillValue);
-	hmgr->getHistoProf2(570)->Fill(z,polarRadius,iSil*fillValue);
-	hmgr->getHistoProf2(572)->Fill(z,polarRadius, iSil * fillValue * costhetacorrection );
+        // Silicon
+        hmgr->getHistoProf1(540)->Fill(polarRadius, theTotalMB_NIM);
+        hmgr->getHistoProf2(550)->Fill(z, polarRadius, theTotalMB_NIM);
+        hmgr->getHistoProf2(552)->Fill(z, polarRadius, theTotalMB_NIM * costhetacorrection);
+        hmgr->getHisto2(560)->Fill(z, polarRadius, iSil * fillValue);
+        hmgr->getHistoProf2(570)->Fill(z, polarRadius, iSil * fillValue);
+        hmgr->getHistoProf2(572)->Fill(z, polarRadius, iSil * fillValue * costhetacorrection);
 
-	// Other
-	hmgr->getHistoProf1(640)->Fill(polarRadius,theTotalMB_OTH);
-	hmgr->getHistoProf2(650)->Fill(z,polarRadius,theTotalMB_OTH);
-	hmgr->getHistoProf2(652)->Fill(z,polarRadius,theTotalMB_OTH * costhetacorrection );
-	hmgr->getHisto2(660)->Fill(z,polarRadius,iOth*fillValue);
-	hmgr->getHistoProf2(670)->Fill(z,polarRadius,iOth*fillValue);
-	hmgr->getHistoProf2(672)->Fill(z,polarRadius, iOth * fillValue * costhetacorrection );
+        // Other
+        hmgr->getHistoProf1(640)->Fill(polarRadius, theTotalMB_OTH);
+        hmgr->getHistoProf2(650)->Fill(z, polarRadius, theTotalMB_OTH);
+        hmgr->getHistoProf2(652)->Fill(z, polarRadius, theTotalMB_OTH * costhetacorrection);
+        hmgr->getHisto2(660)->Fill(z, polarRadius, iOth * fillValue);
+        hmgr->getHistoProf2(670)->Fill(z, polarRadius, iOth * fillValue);
+        hmgr->getHistoProf2(672)->Fill(z, polarRadius, iOth * fillValue * costhetacorrection);
 
-	// Air
-	hmgr->getHistoProf1(740)->Fill(polarRadius,theTotalMB_AIR);
-	hmgr->getHistoProf2(750)->Fill(z,polarRadius,theTotalMB_AIR);
-	hmgr->getHistoProf2(752)->Fill(z,polarRadius,theTotalMB_AIR * costhetacorrection );
-	hmgr->getHisto2(760)->Fill(z,polarRadius,iAir*fillValue);
-	hmgr->getHistoProf2(770)->Fill(z,polarRadius,iAir*fillValue);
-	hmgr->getHistoProf2(772)->Fill(z,polarRadius, iAir * fillValue * costhetacorrection );
+        // Air
+        hmgr->getHistoProf1(740)->Fill(polarRadius, theTotalMB_AIR);
+        hmgr->getHistoProf2(750)->Fill(z, polarRadius, theTotalMB_AIR);
+        hmgr->getHistoProf2(752)->Fill(z, polarRadius, theTotalMB_AIR * costhetacorrection);
+        hmgr->getHisto2(760)->Fill(z, polarRadius, iAir * fillValue);
+        hmgr->getHistoProf2(770)->Fill(z, polarRadius, iAir * fillValue);
+        hmgr->getHistoProf2(772)->Fill(z, polarRadius, iAir * fillValue * costhetacorrection);
 
-	// StainlessSteel
-	hmgr->getHistoProf1(840)->Fill(polarRadius,theTotalMB_SST);
-	hmgr->getHistoProf2(850)->Fill(z,polarRadius,theTotalMB_SST);
-	hmgr->getHistoProf2(852)->Fill(z,polarRadius,theTotalMB_SST * costhetacorrection );
-	hmgr->getHisto2(860)->Fill(z,polarRadius,iSst*fillValue);
-	hmgr->getHistoProf2(870)->Fill(z,polarRadius,iSst*fillValue);
-	hmgr->getHistoProf2(872)->Fill(z,polarRadius, iSst * fillValue * costhetacorrection );
+        // StainlessSteel
+        hmgr->getHistoProf1(840)->Fill(polarRadius, theTotalMB_SST);
+        hmgr->getHistoProf2(850)->Fill(z, polarRadius, theTotalMB_SST);
+        hmgr->getHistoProf2(852)->Fill(z, polarRadius, theTotalMB_SST * costhetacorrection);
+        hmgr->getHisto2(860)->Fill(z, polarRadius, iSst * fillValue);
+        hmgr->getHistoProf2(870)->Fill(z, polarRadius, iSst * fillValue);
+        hmgr->getHistoProf2(872)->Fill(z, polarRadius, iSst * fillValue * costhetacorrection);
 
-	// WCu
-	hmgr->getHistoProf1(940)->Fill(polarRadius,theTotalMB_WCU);
-	hmgr->getHistoProf2(950)->Fill(z,polarRadius,theTotalMB_WCU);
-	hmgr->getHistoProf2(952)->Fill(z,polarRadius,theTotalMB_WCU * costhetacorrection );
-	hmgr->getHisto2(960)->Fill(z,polarRadius,iWcu*fillValue);
-	hmgr->getHistoProf2(970)->Fill(z,polarRadius,iWcu*fillValue);
-	hmgr->getHistoProf2(972)->Fill(z,polarRadius, iWcu * fillValue * costhetacorrection );
+        // WCu
+        hmgr->getHistoProf1(940)->Fill(polarRadius, theTotalMB_WCU);
+        hmgr->getHistoProf2(950)->Fill(z, polarRadius, theTotalMB_WCU);
+        hmgr->getHistoProf2(952)->Fill(z, polarRadius, theTotalMB_WCU * costhetacorrection);
+        hmgr->getHisto2(960)->Fill(z, polarRadius, iWcu * fillValue);
+        hmgr->getHistoProf2(970)->Fill(z, polarRadius, iWcu * fillValue);
+        hmgr->getHistoProf2(972)->Fill(z, polarRadius, iWcu * fillValue * costhetacorrection);
 
-	// Lead
-	hmgr->getHistoProf1(1040)->Fill(polarRadius,theTotalMB_LEA);
-	hmgr->getHistoProf2(1050)->Fill(z,polarRadius,theTotalMB_LEA);
-	hmgr->getHistoProf2(1052)->Fill(z,polarRadius,theTotalMB_LEA * costhetacorrection );
-	hmgr->getHisto2(1060)->Fill(z,polarRadius,iLea*fillValue);
-	hmgr->getHistoProf2(1070)->Fill(z,polarRadius,iLea*fillValue);
-	hmgr->getHistoProf2(1072)->Fill(z,polarRadius, iLea * fillValue  * costhetacorrection );
+        // Lead
+        hmgr->getHistoProf1(1040)->Fill(polarRadius, theTotalMB_LEA);
+        hmgr->getHistoProf2(1050)->Fill(z, polarRadius, theTotalMB_LEA);
+        hmgr->getHistoProf2(1052)->Fill(z, polarRadius, theTotalMB_LEA * costhetacorrection);
+        hmgr->getHisto2(1060)->Fill(z, polarRadius, iLea * fillValue);
+        hmgr->getHistoProf2(1070)->Fill(z, polarRadius, iLea * fillValue);
+        hmgr->getHistoProf2(1072)->Fill(z, polarRadius, iLea * fillValue * costhetacorrection);
 
-	// Epoxy
-	hmgr->getHistoProf1(1140)->Fill(polarRadius,theTotalMB_EPX);
-	hmgr->getHistoProf2(1150)->Fill(z,polarRadius,theTotalMB_EPX);
-	hmgr->getHistoProf2(1152)->Fill(z,polarRadius,theTotalMB_EPX * costhetacorrection );
-	hmgr->getHisto2(1160)->Fill(z,polarRadius,iEpx*fillValue);
-	hmgr->getHistoProf2(1170)->Fill(z,polarRadius,iEpx*fillValue);
-	hmgr->getHistoProf2(1172)->Fill(z,polarRadius, iEpx * fillValue  * costhetacorrection );
+        // Epoxy
+        hmgr->getHistoProf1(1140)->Fill(polarRadius, theTotalMB_EPX);
+        hmgr->getHistoProf2(1150)->Fill(z, polarRadius, theTotalMB_EPX);
+        hmgr->getHistoProf2(1152)->Fill(z, polarRadius, theTotalMB_EPX * costhetacorrection);
+        hmgr->getHisto2(1160)->Fill(z, polarRadius, iEpx * fillValue);
+        hmgr->getHistoProf2(1170)->Fill(z, polarRadius, iEpx * fillValue);
+        hmgr->getHistoProf2(1172)->Fill(z, polarRadius, iEpx * fillValue * costhetacorrection);
 
-	// Kapton
-	hmgr->getHistoProf1(1240)->Fill(polarRadius,theTotalMB_KAP);
-	hmgr->getHistoProf2(1250)->Fill(z,polarRadius,theTotalMB_KAP);
-	hmgr->getHistoProf2(1252)->Fill(z,polarRadius,theTotalMB_KAP * costhetacorrection );
-	hmgr->getHisto2(1260)->Fill(z,polarRadius,iKap*fillValue);
-	hmgr->getHistoProf2(1270)->Fill(z,polarRadius,iKap*fillValue);
-	hmgr->getHistoProf2(1272)->Fill(z,polarRadius, iKap * fillValue  * costhetacorrection );
+        // Kapton
+        hmgr->getHistoProf1(1240)->Fill(polarRadius, theTotalMB_KAP);
+        hmgr->getHistoProf2(1250)->Fill(z, polarRadius, theTotalMB_KAP);
+        hmgr->getHistoProf2(1252)->Fill(z, polarRadius, theTotalMB_KAP * costhetacorrection);
+        hmgr->getHisto2(1260)->Fill(z, polarRadius, iKap * fillValue);
+        hmgr->getHistoProf2(1270)->Fill(z, polarRadius, iKap * fillValue);
+        hmgr->getHistoProf2(1272)->Fill(z, polarRadius, iKap * fillValue * costhetacorrection);
 
-	// Aluminium
-	hmgr->getHistoProf1(1340)->Fill(polarRadius,theTotalMB_ALU);
-	hmgr->getHistoProf2(1350)->Fill(z,polarRadius,theTotalMB_ALU);
-	hmgr->getHistoProf2(1352)->Fill(z,polarRadius,theTotalMB_ALU * costhetacorrection );
-	hmgr->getHisto2(1360)->Fill(z,polarRadius,iAlu*fillValue);
-	hmgr->getHistoProf2(1370)->Fill(z,polarRadius,iAlu*fillValue);
-	hmgr->getHistoProf2(1372)->Fill(z,polarRadius, iAlu * fillValue  * costhetacorrection );
-
+        // Aluminium
+        hmgr->getHistoProf1(1340)->Fill(polarRadius, theTotalMB_ALU);
+        hmgr->getHistoProf2(1350)->Fill(z, polarRadius, theTotalMB_ALU);
+        hmgr->getHistoProf2(1352)->Fill(z, polarRadius, theTotalMB_ALU * costhetacorrection);
+        hmgr->getHisto2(1360)->Fill(z, polarRadius, iAlu * fillValue);
+        hmgr->getHistoProf2(1370)->Fill(z, polarRadius, iAlu * fillValue);
+        hmgr->getHistoProf2(1372)->Fill(z, polarRadius, iAlu * fillValue * costhetacorrection);
       }
     }
- 
+
     //============================================================================================
     // Total Lambda0
-    hmgr->getHistoProf1(10010)->Fill(theData->getEta(),theData->getTotalIL());
-    hmgr->getHistoProf1(10020)->Fill(theData->getPhi(),theData->getTotalIL());
-    hmgr->getHistoProf2(10030)->Fill(theData->getEta(),theData->getPhi(),theData->getTotalIL());
-    
+    hmgr->getHistoProf1(10010)->Fill(theData->getEta(), theData->getTotalIL());
+    hmgr->getHistoProf1(10020)->Fill(theData->getPhi(), theData->getTotalIL());
+    hmgr->getHistoProf2(10030)->Fill(theData->getEta(), theData->getPhi(), theData->getTotalIL());
+
     // Copper
-    hmgr->getHistoProf1(10110)->Fill(theData->getEta(),theData->getCopperIL());
-    hmgr->getHistoProf1(10120)->Fill(theData->getPhi(),theData->getCopperIL());
-    hmgr->getHistoProf2(10130)->Fill(theData->getEta(),theData->getPhi(),theData->getCopperIL());
-    
+    hmgr->getHistoProf1(10110)->Fill(theData->getEta(), theData->getCopperIL());
+    hmgr->getHistoProf1(10120)->Fill(theData->getPhi(), theData->getCopperIL());
+    hmgr->getHistoProf2(10130)->Fill(theData->getEta(), theData->getPhi(), theData->getCopperIL());
+
     // H_Scintillator
-    hmgr->getHistoProf1(10210)->Fill(theData->getEta(),theData->getH_ScintillatorIL());
-    hmgr->getHistoProf1(10220)->Fill(theData->getPhi(),theData->getH_ScintillatorIL());
-    hmgr->getHistoProf2(10230)->Fill(theData->getEta(),theData->getPhi(),theData->getH_ScintillatorIL());
-    
+    hmgr->getHistoProf1(10210)->Fill(theData->getEta(), theData->getH_ScintillatorIL());
+    hmgr->getHistoProf1(10220)->Fill(theData->getPhi(), theData->getH_ScintillatorIL());
+    hmgr->getHistoProf2(10230)->Fill(theData->getEta(), theData->getPhi(), theData->getH_ScintillatorIL());
+
     // Cables
-    hmgr->getHistoProf1(10310)->Fill(theData->getEta(),theData->getCablesIL());
-    hmgr->getHistoProf1(10320)->Fill(theData->getPhi(),theData->getCablesIL());
-    hmgr->getHistoProf2(10330)->Fill(theData->getEta(),theData->getPhi(),theData->getCablesIL());
-    
+    hmgr->getHistoProf1(10310)->Fill(theData->getEta(), theData->getCablesIL());
+    hmgr->getHistoProf1(10320)->Fill(theData->getPhi(), theData->getCablesIL());
+    hmgr->getHistoProf2(10330)->Fill(theData->getEta(), theData->getPhi(), theData->getCablesIL());
+
     // HGC_G10_FR4
-    hmgr->getHistoProf1(10410)->Fill(theData->getEta(),theData->getHGC_G10_FR4IL());
-    hmgr->getHistoProf1(10420)->Fill(theData->getPhi(),theData->getHGC_G10_FR4IL());
-    hmgr->getHistoProf2(10430)->Fill(theData->getEta(),theData->getPhi(),theData->getHGC_G10_FR4IL());
-    
+    hmgr->getHistoProf1(10410)->Fill(theData->getEta(), theData->getHGC_G10_FR4IL());
+    hmgr->getHistoProf1(10420)->Fill(theData->getPhi(), theData->getHGC_G10_FR4IL());
+    hmgr->getHistoProf2(10430)->Fill(theData->getEta(), theData->getPhi(), theData->getHGC_G10_FR4IL());
+
     // Silicon
-    hmgr->getHistoProf1(10510)->Fill(theData->getEta(),theData->getSiliconIL());
-    hmgr->getHistoProf1(10520)->Fill(theData->getPhi(),theData->getSiliconIL());
-    hmgr->getHistoProf2(10530)->Fill(theData->getEta(),theData->getPhi(),theData->getSiliconIL());
-    
+    hmgr->getHistoProf1(10510)->Fill(theData->getEta(), theData->getSiliconIL());
+    hmgr->getHistoProf1(10520)->Fill(theData->getPhi(), theData->getSiliconIL());
+    hmgr->getHistoProf2(10530)->Fill(theData->getEta(), theData->getPhi(), theData->getSiliconIL());
+
     // Other
-    hmgr->getHistoProf1(10610)->Fill(theData->getEta(),theData->getOtherIL());
-    hmgr->getHistoProf1(10620)->Fill(theData->getPhi(),theData->getOtherIL());
-    hmgr->getHistoProf2(10630)->Fill(theData->getEta(),theData->getPhi(),theData->getOtherIL());
-    
+    hmgr->getHistoProf1(10610)->Fill(theData->getEta(), theData->getOtherIL());
+    hmgr->getHistoProf1(10620)->Fill(theData->getPhi(), theData->getOtherIL());
+    hmgr->getHistoProf2(10630)->Fill(theData->getEta(), theData->getPhi(), theData->getOtherIL());
+
     // Air
-    hmgr->getHistoProf1(10710)->Fill(theData->getEta(),theData->getAirIL());
-    hmgr->getHistoProf1(10720)->Fill(theData->getPhi(),theData->getAirIL());
-    hmgr->getHistoProf2(10730)->Fill(theData->getEta(),theData->getPhi(),theData->getAirIL());
-    
+    hmgr->getHistoProf1(10710)->Fill(theData->getEta(), theData->getAirIL());
+    hmgr->getHistoProf1(10720)->Fill(theData->getPhi(), theData->getAirIL());
+    hmgr->getHistoProf2(10730)->Fill(theData->getEta(), theData->getPhi(), theData->getAirIL());
+
     // StainlessSteel
-    hmgr->getHistoProf1(10810)->Fill(theData->getEta(),theData->getStainlessSteelIL());
-    hmgr->getHistoProf1(10820)->Fill(theData->getPhi(),theData->getStainlessSteelIL());
-    hmgr->getHistoProf2(10830)->Fill(theData->getEta(),theData->getPhi(),theData->getStainlessSteelIL());
+    hmgr->getHistoProf1(10810)->Fill(theData->getEta(), theData->getStainlessSteelIL());
+    hmgr->getHistoProf1(10820)->Fill(theData->getPhi(), theData->getStainlessSteelIL());
+    hmgr->getHistoProf2(10830)->Fill(theData->getEta(), theData->getPhi(), theData->getStainlessSteelIL());
 
     // WCu
-    hmgr->getHistoProf1(10910)->Fill(theData->getEta(),theData->getWCuIL());
-    hmgr->getHistoProf1(10920)->Fill(theData->getPhi(),theData->getWCuIL());
-    hmgr->getHistoProf2(10930)->Fill(theData->getEta(),theData->getPhi(),theData->getWCuIL());
+    hmgr->getHistoProf1(10910)->Fill(theData->getEta(), theData->getWCuIL());
+    hmgr->getHistoProf1(10920)->Fill(theData->getPhi(), theData->getWCuIL());
+    hmgr->getHistoProf2(10930)->Fill(theData->getEta(), theData->getPhi(), theData->getWCuIL());
 
     // Lead
-    hmgr->getHistoProf1(11010)->Fill(theData->getEta(),theData->getLeadIL());
-    hmgr->getHistoProf1(11020)->Fill(theData->getPhi(),theData->getLeadIL());
-    hmgr->getHistoProf2(11030)->Fill(theData->getEta(),theData->getPhi(),theData->getLeadIL());
+    hmgr->getHistoProf1(11010)->Fill(theData->getEta(), theData->getLeadIL());
+    hmgr->getHistoProf1(11020)->Fill(theData->getPhi(), theData->getLeadIL());
+    hmgr->getHistoProf2(11030)->Fill(theData->getEta(), theData->getPhi(), theData->getLeadIL());
 
     // Epoxy
-    hmgr->getHistoProf1(11110)->Fill(theData->getEta(),theData->getEpoxyIL());
-    hmgr->getHistoProf1(11120)->Fill(theData->getPhi(),theData->getEpoxyIL());
-    hmgr->getHistoProf2(11130)->Fill(theData->getEta(),theData->getPhi(),theData->getEpoxyIL());
+    hmgr->getHistoProf1(11110)->Fill(theData->getEta(), theData->getEpoxyIL());
+    hmgr->getHistoProf1(11120)->Fill(theData->getPhi(), theData->getEpoxyIL());
+    hmgr->getHistoProf2(11130)->Fill(theData->getEta(), theData->getPhi(), theData->getEpoxyIL());
 
     // Kapton
-    hmgr->getHistoProf1(11210)->Fill(theData->getEta(),theData->getKaptonIL());
-    hmgr->getHistoProf1(11220)->Fill(theData->getPhi(),theData->getKaptonIL());
-    hmgr->getHistoProf2(11230)->Fill(theData->getEta(),theData->getPhi(),theData->getKaptonIL());
+    hmgr->getHistoProf1(11210)->Fill(theData->getEta(), theData->getKaptonIL());
+    hmgr->getHistoProf1(11220)->Fill(theData->getPhi(), theData->getKaptonIL());
+    hmgr->getHistoProf2(11230)->Fill(theData->getEta(), theData->getPhi(), theData->getKaptonIL());
 
     // Aluminium
-    hmgr->getHistoProf1(11310)->Fill(theData->getEta(),theData->getAluminiumIL());
-    hmgr->getHistoProf1(11320)->Fill(theData->getPhi(),theData->getAluminiumIL());
-    hmgr->getHistoProf2(11330)->Fill(theData->getEta(),theData->getPhi(),theData->getAluminiumIL());
+    hmgr->getHistoProf1(11310)->Fill(theData->getEta(), theData->getAluminiumIL());
+    hmgr->getHistoProf1(11320)->Fill(theData->getPhi(), theData->getAluminiumIL());
+    hmgr->getHistoProf2(11330)->Fill(theData->getEta(), theData->getPhi(), theData->getAluminiumIL());
 
     // Compute the total l/l0 crossed at each step radius for each path
     float theTotalIL_TOT = 0.0;
@@ -776,7 +1034,7 @@ void MaterialBudgetHGCalHistos::fillEndTrack()
     float theTotalIL_EPX = 0.0;
     float theTotalIL_KAP = 0.0;
     float theTotalIL_ALU = 0.0;
-    for(int iStep = 0; iStep < theData->getNumberOfSteps(); iStep++) {
+    for (int iStep = 0; iStep < theData->getNumberOfSteps(); iStep++) {
       theTotalIL_TOT += theData->getStepDil(iStep);
       theTotalIL_COP += theData->getCopperDil(iStep);
       theTotalIL_SCI += theData->getH_ScintillatorDil(iStep);
@@ -806,28 +1064,51 @@ void MaterialBudgetHGCalHistos::fillEndTrack()
       int iKap = 0;
       int iAlu = 0;
 
-      if(theData->getCopperDil(iStep)>0.) { iCop = 1; }
-      if(theData->getH_ScintillatorDil(iStep)>0.) { iSci = 1; }
-      if(theData->getCablesDil(iStep)>0.) { iCab = 1; }
-      if(theData->getHGC_G10_FR4Dil(iStep)>0.) { iHgf = 1; }
-      if(theData->getSiliconDil(iStep)>0.) { iSil = 1; }
-      if(theData->getOtherDil(iStep)>0.) { iOth = 1; }
-      if(theData->getAirDil(iStep)>0.) { iAir = 1; }
-      if(theData->getStainlessSteelDil(iStep)>0.) { iSst = 1; }
-      if(theData->getWCuDil(iStep)>0.) { iWcu = 1; }
-      if(theData->getLeadDil(iStep)>0.) { iLea = 1; }
-      if(theData->getEpoxyDil(iStep)>0.) { iEpx = 1; }
-      if(theData->getKaptonDil(iStep)>0.) { iKap = 1; }
-      if(theData->getAluminiumDil(iStep)>0.) { iAlu = 1; }
+      if (theData->getCopperDil(iStep) > 0.) {
+        iCop = 1;
+      }
+      if (theData->getH_ScintillatorDil(iStep) > 0.) {
+        iSci = 1;
+      }
+      if (theData->getCablesDil(iStep) > 0.) {
+        iCab = 1;
+      }
+      if (theData->getHGC_G10_FR4Dil(iStep) > 0.) {
+        iHgf = 1;
+      }
+      if (theData->getSiliconDil(iStep) > 0.) {
+        iSil = 1;
+      }
+      if (theData->getOtherDil(iStep) > 0.) {
+        iOth = 1;
+      }
+      if (theData->getAirDil(iStep) > 0.) {
+        iAir = 1;
+      }
+      if (theData->getStainlessSteelDil(iStep) > 0.) {
+        iSst = 1;
+      }
+      if (theData->getWCuDil(iStep) > 0.) {
+        iWcu = 1;
+      }
+      if (theData->getLeadDil(iStep) > 0.) {
+        iLea = 1;
+      }
+      if (theData->getEpoxyDil(iStep) > 0.) {
+        iEpx = 1;
+      }
+      if (theData->getKaptonDil(iStep) > 0.) {
+        iKap = 1;
+      }
+      if (theData->getAluminiumDil(iStep) > 0.) {
+        iAlu = 1;
+      }
 
-      float deltaRadius = sqrt(
-			       pow( theData->getStepFinalX(iStep)-theData->getStepInitialX(iStep),2 )
-			       +
-			       pow( theData->getStepFinalY(iStep)-theData->getStepInitialY(iStep),2 )
-			       );
-      float deltaz = theData->getStepFinalZ(iStep)-theData->getStepInitialZ(iStep) ;
-      
-      float deltaeta = theData->getStepFinalEta(iStep)-theData->getStepInitialEta(iStep) ;
+      float deltaRadius = sqrt(pow(theData->getStepFinalX(iStep) - theData->getStepInitialX(iStep), 2) +
+                               pow(theData->getStepFinalY(iStep) - theData->getStepInitialY(iStep), 2));
+      float deltaz = theData->getStepFinalZ(iStep) - theData->getStepInitialZ(iStep);
+
+      float deltaeta = theData->getStepFinalEta(iStep) - theData->getStepInitialEta(iStep);
 
       // float deltaphi = theData->getStepFinalPhi(iStep)-theData->getStepInitialPhi(iStep) ;
 
@@ -835,174 +1116,156 @@ void MaterialBudgetHGCalHistos::fillEndTrack()
 
       int nSubStep = 2;
       float boxWidth = 0.1;
-      if( (deltaRadius>boxWidth) || (fabs(deltaz)>boxWidth) ) {
-	nSubStep = static_cast<int>(max(
-		       ceil(deltaRadius/boxWidth/2.)*2,
-		       ceil(fabs(deltaz)/boxWidth/2.)*2
-		       ));
-      }
-      
-      for(int iSubStep = 1; iSubStep < nSubStep; iSubStep+=2) {
-
-	float subdeltaRadius = deltaRadius/nSubStep;
-	float polarRadius = sqrt(
-				 pow( theData->getStepInitialX(iStep),2 )
-				 +
-				 pow( theData->getStepInitialY(iStep),2 )
-				 ) + iSubStep*subdeltaRadius;
-
-	float subdeltaz = deltaz/nSubStep;
-	float z = theData->getStepInitialZ(iStep) + iSubStep*subdeltaz;
-
-	float subdeltaeta = deltaeta/nSubStep;
-	float eta = theData->getStepInitialEta(iStep) + iSubStep*subdeltaeta;
-
-	// float subdeltaphi = deltaphi/nSubStep;
-	// float phi = theData->getStepInitialPhi(iStep) + iSubStep*subdeltaphi;
-
-	float subdelta = sqrt(
-			      pow ( subdeltaRadius,2 ) + pow( subdeltaz,2 )
-			      );
-
-	float fillValue=subdelta/il;
-
-	float costhetacorrection = cos( 2 * atan(exp(-fabs(eta))) );
-	// Average length
-	hmgr->getHisto2(1999)->Fill(z,polarRadius,subdelta);
-	// Total
-	hmgr->getHistoProf1(10040)->Fill(polarRadius,theTotalIL_TOT);
-	hmgr->getHistoProf2(10050)->Fill(z,polarRadius,theTotalIL_TOT);
-	hmgr->getHistoProf2(10052)->Fill(z,polarRadius,theTotalIL_TOT * costhetacorrection );
-	hmgr->getHisto2(10060)->Fill(z,polarRadius,fillValue);
-	hmgr->getHistoProf2(10070)->Fill(z,polarRadius,fillValue);
-	hmgr->getHistoProf2(10072)->Fill(z,polarRadius, fillValue * costhetacorrection );
-
-	// Copper
-	hmgr->getHistoProf1(10140)->Fill(polarRadius,theTotalIL_COP);
-	hmgr->getHistoProf2(10150)->Fill(z,polarRadius,theTotalIL_COP);
-	hmgr->getHistoProf2(10152)->Fill(z,polarRadius,theTotalIL_COP * costhetacorrection );
-	hmgr->getHisto2(10160)->Fill(z,polarRadius,iCop*fillValue);
-	hmgr->getHistoProf2(10170)->Fill(z,polarRadius,iCop*fillValue);
-	hmgr->getHistoProf2(10172)->Fill(z,polarRadius, iCop * fillValue * costhetacorrection );
-
-	// H_Scintillator
-	hmgr->getHistoProf1(10240)->Fill(polarRadius,theTotalIL_SCI);
-	hmgr->getHistoProf2(10250)->Fill(z,polarRadius,theTotalIL_SCI);
-	hmgr->getHistoProf2(10252)->Fill(z,polarRadius,theTotalIL_SCI * costhetacorrection );
-	hmgr->getHisto2(10260)->Fill(z,polarRadius,iSci*fillValue);
-	hmgr->getHistoProf2(10270)->Fill(z,polarRadius,iSci*fillValue);
-	hmgr->getHistoProf2(10272)->Fill(z,polarRadius, iSci * fillValue * costhetacorrection );
-
-	// Cables
-	hmgr->getHistoProf1(10340)->Fill(polarRadius,theTotalIL_CAB);
-	hmgr->getHistoProf2(10350)->Fill(z,polarRadius,theTotalIL_CAB);
-	hmgr->getHistoProf2(10352)->Fill(z,polarRadius,theTotalIL_CAB * costhetacorrection );
-	hmgr->getHisto2(10360)->Fill(z,polarRadius,iCab*fillValue);
-	hmgr->getHistoProf2(10370)->Fill(z,polarRadius,iCab*fillValue);
-	hmgr->getHistoProf2(10372)->Fill(z,polarRadius, iCab * fillValue * costhetacorrection );
-
-	// HGC_G10_FR4
-	hmgr->getHistoProf1(10440)->Fill(polarRadius,theTotalIL_HGF);
-	hmgr->getHistoProf2(10450)->Fill(z,polarRadius,theTotalIL_HGF);
-	hmgr->getHistoProf2(10452)->Fill(z,polarRadius,theTotalIL_HGF * costhetacorrection );
-	hmgr->getHisto2(10460)->Fill(z,polarRadius,iHgf*fillValue);
-	hmgr->getHistoProf2(10470)->Fill(z,polarRadius,iHgf*fillValue);
-	hmgr->getHistoProf2(10472)->Fill(z,polarRadius, iHgf * fillValue * costhetacorrection );
-
-	// Silicon
-	hmgr->getHistoProf1(10540)->Fill(polarRadius,theTotalIL_NIM);
-	hmgr->getHistoProf2(10550)->Fill(z,polarRadius,theTotalIL_NIM);
-	hmgr->getHistoProf2(10552)->Fill(z,polarRadius,theTotalIL_NIM * costhetacorrection );
-	hmgr->getHisto2(10560)->Fill(z,polarRadius,iSil*fillValue);
-	hmgr->getHistoProf2(10570)->Fill(z,polarRadius,iSil*fillValue);
-	hmgr->getHistoProf2(10572)->Fill(z,polarRadius, iSil * fillValue * costhetacorrection );
-
-	// Other
-	hmgr->getHistoProf1(10640)->Fill(polarRadius,theTotalIL_OTH);
-	hmgr->getHistoProf2(10650)->Fill(z,polarRadius,theTotalIL_OTH);
-	hmgr->getHistoProf2(10652)->Fill(z,polarRadius,theTotalIL_OTH * costhetacorrection );
-	hmgr->getHisto2(10660)->Fill(z,polarRadius,iOth*fillValue);
-	hmgr->getHistoProf2(10670)->Fill(z,polarRadius,iOth*fillValue);
-	hmgr->getHistoProf2(10672)->Fill(z,polarRadius, iOth * fillValue * costhetacorrection );
-
-	// Air
-	hmgr->getHistoProf1(10740)->Fill(polarRadius,theTotalIL_AIR);
-	hmgr->getHistoProf2(10750)->Fill(z,polarRadius,theTotalIL_AIR);
-	hmgr->getHistoProf2(10752)->Fill(z,polarRadius,theTotalIL_AIR * costhetacorrection );
-	hmgr->getHisto2(10760)->Fill(z,polarRadius,iAir*fillValue);
-	hmgr->getHistoProf2(10770)->Fill(z,polarRadius,iAir*fillValue);
-	hmgr->getHistoProf2(10772)->Fill(z,polarRadius, iAir * fillValue * costhetacorrection );
-
-	// StainlessSteel
-	hmgr->getHistoProf1(10840)->Fill(polarRadius,theTotalIL_SST);
-	hmgr->getHistoProf2(10850)->Fill(z,polarRadius,theTotalIL_SST);
-	hmgr->getHistoProf2(10852)->Fill(z,polarRadius,theTotalIL_SST * costhetacorrection );
-	hmgr->getHisto2(10860)->Fill(z,polarRadius,iSst*fillValue);
-	hmgr->getHistoProf2(10870)->Fill(z,polarRadius,iSst*fillValue);
-	hmgr->getHistoProf2(10872)->Fill(z,polarRadius, iSst * fillValue * costhetacorrection );
-
-	// WCu
-	hmgr->getHistoProf1(10940)->Fill(polarRadius,theTotalIL_WCU);
-	hmgr->getHistoProf2(10950)->Fill(z,polarRadius,theTotalIL_WCU);
-	hmgr->getHistoProf2(10952)->Fill(z,polarRadius,theTotalIL_WCU * costhetacorrection );
-	hmgr->getHisto2(10960)->Fill(z,polarRadius,iWcu*fillValue);
-	hmgr->getHistoProf2(10970)->Fill(z,polarRadius,iWcu*fillValue);
-	hmgr->getHistoProf2(10972)->Fill(z,polarRadius, iWcu * fillValue * costhetacorrection );
-
-	// Lead
-	hmgr->getHistoProf1(11040)->Fill(polarRadius,theTotalIL_LEA);
-	hmgr->getHistoProf2(11050)->Fill(z,polarRadius,theTotalIL_LEA);
-	hmgr->getHistoProf2(11052)->Fill(z,polarRadius,theTotalIL_LEA * costhetacorrection );
-	hmgr->getHisto2(11060)->Fill(z,polarRadius,iLea*fillValue);
-	hmgr->getHistoProf2(11070)->Fill(z,polarRadius,iLea*fillValue);
-	hmgr->getHistoProf2(11072)->Fill(z,polarRadius, iLea * fillValue * costhetacorrection );
-
-	// Epoxy
-	hmgr->getHistoProf1(11140)->Fill(polarRadius,theTotalIL_EPX);
-	hmgr->getHistoProf2(11150)->Fill(z,polarRadius,theTotalIL_EPX);
-	hmgr->getHistoProf2(11152)->Fill(z,polarRadius,theTotalIL_EPX * costhetacorrection );
-	hmgr->getHisto2(11160)->Fill(z,polarRadius,iEpx*fillValue);
-	hmgr->getHistoProf2(11170)->Fill(z,polarRadius,iEpx*fillValue);
-	hmgr->getHistoProf2(11172)->Fill(z,polarRadius, iEpx * fillValue * costhetacorrection );
-
-	// Kapton
-	hmgr->getHistoProf1(11240)->Fill(polarRadius,theTotalIL_KAP);
-	hmgr->getHistoProf2(11250)->Fill(z,polarRadius,theTotalIL_KAP);
-	hmgr->getHistoProf2(11252)->Fill(z,polarRadius,theTotalIL_KAP * costhetacorrection );
-	hmgr->getHisto2(11260)->Fill(z,polarRadius,iKap*fillValue);
-	hmgr->getHistoProf2(11270)->Fill(z,polarRadius,iKap*fillValue);
-	hmgr->getHistoProf2(11272)->Fill(z,polarRadius, iKap * fillValue * costhetacorrection );
-
-	// Aluminium
-	hmgr->getHistoProf1(11340)->Fill(polarRadius,theTotalIL_ALU);
-	hmgr->getHistoProf2(11350)->Fill(z,polarRadius,theTotalIL_ALU);
-	hmgr->getHistoProf2(11352)->Fill(z,polarRadius,theTotalIL_ALU * costhetacorrection );
-	hmgr->getHisto2(11360)->Fill(z,polarRadius,iAlu*fillValue);
-	hmgr->getHistoProf2(11370)->Fill(z,polarRadius,iAlu*fillValue);
-	hmgr->getHistoProf2(11372)->Fill(z,polarRadius, iAlu * fillValue * costhetacorrection );
-
+      if ((deltaRadius > boxWidth) || (fabs(deltaz) > boxWidth)) {
+        nSubStep = static_cast<int>(max(ceil(deltaRadius / boxWidth / 2.) * 2, ceil(fabs(deltaz) / boxWidth / 2.) * 2));
       }
 
+      for (int iSubStep = 1; iSubStep < nSubStep; iSubStep += 2) {
+        float subdeltaRadius = deltaRadius / nSubStep;
+        float polarRadius = sqrt(pow(theData->getStepInitialX(iStep), 2) + pow(theData->getStepInitialY(iStep), 2)) +
+                            iSubStep * subdeltaRadius;
+
+        float subdeltaz = deltaz / nSubStep;
+        float z = theData->getStepInitialZ(iStep) + iSubStep * subdeltaz;
+
+        float subdeltaeta = deltaeta / nSubStep;
+        float eta = theData->getStepInitialEta(iStep) + iSubStep * subdeltaeta;
+
+        // float subdeltaphi = deltaphi/nSubStep;
+        // float phi = theData->getStepInitialPhi(iStep) + iSubStep*subdeltaphi;
+
+        float subdelta = sqrt(pow(subdeltaRadius, 2) + pow(subdeltaz, 2));
+
+        float fillValue = subdelta / il;
+
+        float costhetacorrection = cos(2 * atan(exp(-fabs(eta))));
+        // Average length
+        hmgr->getHisto2(1999)->Fill(z, polarRadius, subdelta);
+        // Total
+        hmgr->getHistoProf1(10040)->Fill(polarRadius, theTotalIL_TOT);
+        hmgr->getHistoProf2(10050)->Fill(z, polarRadius, theTotalIL_TOT);
+        hmgr->getHistoProf2(10052)->Fill(z, polarRadius, theTotalIL_TOT * costhetacorrection);
+        hmgr->getHisto2(10060)->Fill(z, polarRadius, fillValue);
+        hmgr->getHistoProf2(10070)->Fill(z, polarRadius, fillValue);
+        hmgr->getHistoProf2(10072)->Fill(z, polarRadius, fillValue * costhetacorrection);
+
+        // Copper
+        hmgr->getHistoProf1(10140)->Fill(polarRadius, theTotalIL_COP);
+        hmgr->getHistoProf2(10150)->Fill(z, polarRadius, theTotalIL_COP);
+        hmgr->getHistoProf2(10152)->Fill(z, polarRadius, theTotalIL_COP * costhetacorrection);
+        hmgr->getHisto2(10160)->Fill(z, polarRadius, iCop * fillValue);
+        hmgr->getHistoProf2(10170)->Fill(z, polarRadius, iCop * fillValue);
+        hmgr->getHistoProf2(10172)->Fill(z, polarRadius, iCop * fillValue * costhetacorrection);
+
+        // H_Scintillator
+        hmgr->getHistoProf1(10240)->Fill(polarRadius, theTotalIL_SCI);
+        hmgr->getHistoProf2(10250)->Fill(z, polarRadius, theTotalIL_SCI);
+        hmgr->getHistoProf2(10252)->Fill(z, polarRadius, theTotalIL_SCI * costhetacorrection);
+        hmgr->getHisto2(10260)->Fill(z, polarRadius, iSci * fillValue);
+        hmgr->getHistoProf2(10270)->Fill(z, polarRadius, iSci * fillValue);
+        hmgr->getHistoProf2(10272)->Fill(z, polarRadius, iSci * fillValue * costhetacorrection);
+
+        // Cables
+        hmgr->getHistoProf1(10340)->Fill(polarRadius, theTotalIL_CAB);
+        hmgr->getHistoProf2(10350)->Fill(z, polarRadius, theTotalIL_CAB);
+        hmgr->getHistoProf2(10352)->Fill(z, polarRadius, theTotalIL_CAB * costhetacorrection);
+        hmgr->getHisto2(10360)->Fill(z, polarRadius, iCab * fillValue);
+        hmgr->getHistoProf2(10370)->Fill(z, polarRadius, iCab * fillValue);
+        hmgr->getHistoProf2(10372)->Fill(z, polarRadius, iCab * fillValue * costhetacorrection);
+
+        // HGC_G10_FR4
+        hmgr->getHistoProf1(10440)->Fill(polarRadius, theTotalIL_HGF);
+        hmgr->getHistoProf2(10450)->Fill(z, polarRadius, theTotalIL_HGF);
+        hmgr->getHistoProf2(10452)->Fill(z, polarRadius, theTotalIL_HGF * costhetacorrection);
+        hmgr->getHisto2(10460)->Fill(z, polarRadius, iHgf * fillValue);
+        hmgr->getHistoProf2(10470)->Fill(z, polarRadius, iHgf * fillValue);
+        hmgr->getHistoProf2(10472)->Fill(z, polarRadius, iHgf * fillValue * costhetacorrection);
+
+        // Silicon
+        hmgr->getHistoProf1(10540)->Fill(polarRadius, theTotalIL_NIM);
+        hmgr->getHistoProf2(10550)->Fill(z, polarRadius, theTotalIL_NIM);
+        hmgr->getHistoProf2(10552)->Fill(z, polarRadius, theTotalIL_NIM * costhetacorrection);
+        hmgr->getHisto2(10560)->Fill(z, polarRadius, iSil * fillValue);
+        hmgr->getHistoProf2(10570)->Fill(z, polarRadius, iSil * fillValue);
+        hmgr->getHistoProf2(10572)->Fill(z, polarRadius, iSil * fillValue * costhetacorrection);
+
+        // Other
+        hmgr->getHistoProf1(10640)->Fill(polarRadius, theTotalIL_OTH);
+        hmgr->getHistoProf2(10650)->Fill(z, polarRadius, theTotalIL_OTH);
+        hmgr->getHistoProf2(10652)->Fill(z, polarRadius, theTotalIL_OTH * costhetacorrection);
+        hmgr->getHisto2(10660)->Fill(z, polarRadius, iOth * fillValue);
+        hmgr->getHistoProf2(10670)->Fill(z, polarRadius, iOth * fillValue);
+        hmgr->getHistoProf2(10672)->Fill(z, polarRadius, iOth * fillValue * costhetacorrection);
+
+        // Air
+        hmgr->getHistoProf1(10740)->Fill(polarRadius, theTotalIL_AIR);
+        hmgr->getHistoProf2(10750)->Fill(z, polarRadius, theTotalIL_AIR);
+        hmgr->getHistoProf2(10752)->Fill(z, polarRadius, theTotalIL_AIR * costhetacorrection);
+        hmgr->getHisto2(10760)->Fill(z, polarRadius, iAir * fillValue);
+        hmgr->getHistoProf2(10770)->Fill(z, polarRadius, iAir * fillValue);
+        hmgr->getHistoProf2(10772)->Fill(z, polarRadius, iAir * fillValue * costhetacorrection);
+
+        // StainlessSteel
+        hmgr->getHistoProf1(10840)->Fill(polarRadius, theTotalIL_SST);
+        hmgr->getHistoProf2(10850)->Fill(z, polarRadius, theTotalIL_SST);
+        hmgr->getHistoProf2(10852)->Fill(z, polarRadius, theTotalIL_SST * costhetacorrection);
+        hmgr->getHisto2(10860)->Fill(z, polarRadius, iSst * fillValue);
+        hmgr->getHistoProf2(10870)->Fill(z, polarRadius, iSst * fillValue);
+        hmgr->getHistoProf2(10872)->Fill(z, polarRadius, iSst * fillValue * costhetacorrection);
+
+        // WCu
+        hmgr->getHistoProf1(10940)->Fill(polarRadius, theTotalIL_WCU);
+        hmgr->getHistoProf2(10950)->Fill(z, polarRadius, theTotalIL_WCU);
+        hmgr->getHistoProf2(10952)->Fill(z, polarRadius, theTotalIL_WCU * costhetacorrection);
+        hmgr->getHisto2(10960)->Fill(z, polarRadius, iWcu * fillValue);
+        hmgr->getHistoProf2(10970)->Fill(z, polarRadius, iWcu * fillValue);
+        hmgr->getHistoProf2(10972)->Fill(z, polarRadius, iWcu * fillValue * costhetacorrection);
+
+        // Lead
+        hmgr->getHistoProf1(11040)->Fill(polarRadius, theTotalIL_LEA);
+        hmgr->getHistoProf2(11050)->Fill(z, polarRadius, theTotalIL_LEA);
+        hmgr->getHistoProf2(11052)->Fill(z, polarRadius, theTotalIL_LEA * costhetacorrection);
+        hmgr->getHisto2(11060)->Fill(z, polarRadius, iLea * fillValue);
+        hmgr->getHistoProf2(11070)->Fill(z, polarRadius, iLea * fillValue);
+        hmgr->getHistoProf2(11072)->Fill(z, polarRadius, iLea * fillValue * costhetacorrection);
+
+        // Epoxy
+        hmgr->getHistoProf1(11140)->Fill(polarRadius, theTotalIL_EPX);
+        hmgr->getHistoProf2(11150)->Fill(z, polarRadius, theTotalIL_EPX);
+        hmgr->getHistoProf2(11152)->Fill(z, polarRadius, theTotalIL_EPX * costhetacorrection);
+        hmgr->getHisto2(11160)->Fill(z, polarRadius, iEpx * fillValue);
+        hmgr->getHistoProf2(11170)->Fill(z, polarRadius, iEpx * fillValue);
+        hmgr->getHistoProf2(11172)->Fill(z, polarRadius, iEpx * fillValue * costhetacorrection);
+
+        // Kapton
+        hmgr->getHistoProf1(11240)->Fill(polarRadius, theTotalIL_KAP);
+        hmgr->getHistoProf2(11250)->Fill(z, polarRadius, theTotalIL_KAP);
+        hmgr->getHistoProf2(11252)->Fill(z, polarRadius, theTotalIL_KAP * costhetacorrection);
+        hmgr->getHisto2(11260)->Fill(z, polarRadius, iKap * fillValue);
+        hmgr->getHistoProf2(11270)->Fill(z, polarRadius, iKap * fillValue);
+        hmgr->getHistoProf2(11272)->Fill(z, polarRadius, iKap * fillValue * costhetacorrection);
+
+        // Aluminium
+        hmgr->getHistoProf1(11340)->Fill(polarRadius, theTotalIL_ALU);
+        hmgr->getHistoProf2(11350)->Fill(z, polarRadius, theTotalIL_ALU);
+        hmgr->getHistoProf2(11352)->Fill(z, polarRadius, theTotalIL_ALU * costhetacorrection);
+        hmgr->getHisto2(11360)->Fill(z, polarRadius, iAlu * fillValue);
+        hmgr->getHistoProf2(11370)->Fill(z, polarRadius, iAlu * fillValue);
+        hmgr->getHistoProf2(11372)->Fill(z, polarRadius, iAlu * fillValue * costhetacorrection);
+      }
     }
-    
+
     // rr
   } else {
     std::cout << "*** WARNING This event is out of the acceptance *** " << std::endl;
-    std::cout << "eta = "      << theData->getEta()
-    	      << "\t phi = "   << theData->getPhi()
-    	      << "\t x/X0 = "  << theData->getTotalMB()
-    	      << "\t l/l0 = "  << theData->getTotalIL()
-    	      << "\t steps = " << theData->getNumberOfSteps()
-    	      << std::endl;
+    std::cout << "eta = " << theData->getEta() << "\t phi = " << theData->getPhi()
+              << "\t x/X0 = " << theData->getTotalMB() << "\t l/l0 = " << theData->getTotalIL()
+              << "\t steps = " << theData->getNumberOfSteps() << std::endl;
     std::cout << "***" << std::endl;
   }
-
- 
 }
 
-void MaterialBudgetHGCalHistos::endOfRun() 
-{
-
+void MaterialBudgetHGCalHistos::endOfRun() {
   hmgr->getHisto2(60)->Divide(hmgr->getHisto2(999));
   hmgr->getHisto2(160)->Divide(hmgr->getHisto2(999));
   hmgr->getHisto2(260)->Divide(hmgr->getHisto2(999));
@@ -1034,8 +1297,5 @@ void MaterialBudgetHGCalHistos::endOfRun()
   hmgr->getHisto2(11360)->Divide(hmgr->getHisto2(1999));
 
   std::cout << "=== save user histos ===" << std::endl;
-  hmgr->save( theFileName );
-
+  hmgr->save(theFileName);
 }
-
-

--- a/Validation/Geometry/src/MaterialBudgetHcal.cc
+++ b/Validation/Geometry/src/MaterialBudgetHcal.cc
@@ -17,23 +17,25 @@
 
 #include <iostream>
 
-MaterialBudgetHcal::MaterialBudgetHcal(const edm::ParameterSet& p): 
-  theHistoHcal(nullptr), theHistoCastor(nullptr) {
-  
+MaterialBudgetHcal::MaterialBudgetHcal(const edm::ParameterSet& p) : theHistoHcal(nullptr), theHistoCastor(nullptr) {
   edm::ParameterSet m_p = p.getParameter<edm::ParameterSet>("MaterialBudgetHcal");
-  rMax        = m_p.getUntrackedParameter<double>("RMax", 4.5)*CLHEP::m;
-  zMax        = m_p.getUntrackedParameter<double>("ZMax", 13.0)*CLHEP::m;
+  rMax = m_p.getUntrackedParameter<double>("RMax", 4.5) * CLHEP::m;
+  zMax = m_p.getUntrackedParameter<double>("ZMax", 13.0) * CLHEP::m;
   bool doHcal = m_p.getUntrackedParameter<bool>("DoHCAL", true);
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcal initialized with rMax "
-				 << rMax << " mm and zMax " << zMax << " mm"
-				 << " doHcal is set to " << doHcal;
-  if (doHcal)   theHistoHcal   = new MaterialBudgetHcalHistos(m_p);
-  else          theHistoCastor = new MaterialBudgetCastorHistos(m_p);
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcal initialized with rMax " << rMax << " mm and zMax " << zMax
+                                 << " mm"
+                                 << " doHcal is set to " << doHcal;
+  if (doHcal)
+    theHistoHcal = new MaterialBudgetHcalHistos(m_p);
+  else
+    theHistoCastor = new MaterialBudgetCastorHistos(m_p);
 }
 
 MaterialBudgetHcal::~MaterialBudgetHcal() {
-  if (theHistoHcal)   delete theHistoHcal;
-  if (theHistoCastor) delete theHistoCastor;
+  if (theHistoHcal)
+    delete theHistoHcal;
+  if (theHistoCastor)
+    delete theHistoCastor;
 }
 
 void MaterialBudgetHcal::update(const BeginOfJob* job) {
@@ -41,46 +43,46 @@ void MaterialBudgetHcal::update(const BeginOfJob* job) {
   // Numbering From DDD
   edm::ESTransientHandle<DDCompactView> pDD;
   (*job)()->get<IdealGeometryRecord>().get(pDD);
-  if (theHistoHcal)   theHistoHcal->fillBeginJob((*pDD));
-
+  if (theHistoHcal)
+    theHistoHcal->fillBeginJob((*pDD));
 }
 
 void MaterialBudgetHcal::update(const BeginOfTrack* trk) {
-
-  const G4Track * aTrack = (*trk)(); // recover G4 pointer if wanted
-  if (theHistoHcal)   theHistoHcal->fillStartTrack(aTrack);
-  if (theHistoCastor) theHistoCastor->fillStartTrack(aTrack);
+  const G4Track* aTrack = (*trk)();  // recover G4 pointer if wanted
+  if (theHistoHcal)
+    theHistoHcal->fillStartTrack(aTrack);
+  if (theHistoCastor)
+    theHistoCastor->fillStartTrack(aTrack);
 }
- 
-void MaterialBudgetHcal::update(const G4Step* aStep) {
 
+void MaterialBudgetHcal::update(const G4Step* aStep) {
   //---------- each step
-  if (theHistoHcal)   theHistoHcal->fillPerStep(aStep);
-  if (theHistoCastor) theHistoCastor->fillPerStep(aStep);
+  if (theHistoHcal)
+    theHistoHcal->fillPerStep(aStep);
+  if (theHistoCastor)
+    theHistoCastor->fillPerStep(aStep);
 
   //----- Stop tracking after selected position
   if (stopAfter(aStep)) {
     G4Track* track = aStep->GetTrack();
-    track->SetTrackStatus( fStopAndKill );
+    track->SetTrackStatus(fStopAndKill);
   }
 }
 
-
 void MaterialBudgetHcal::update(const EndOfTrack* trk) {
-
-  if (theHistoHcal)   theHistoHcal->fillEndTrack();
-  if (theHistoCastor) theHistoCastor->fillEndTrack();
+  if (theHistoHcal)
+    theHistoHcal->fillEndTrack();
+  if (theHistoCastor)
+    theHistoCastor->fillEndTrack();
 }
 
 bool MaterialBudgetHcal::stopAfter(const G4Step* aStep) {
-
-  G4ThreeVector hitPoint    = aStep->GetPreStepPoint()->GetPosition();
-  double        rr = hitPoint.perp();
-  double        zz = std::abs(hitPoint.z());
+  G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
+  double rr = hitPoint.perp();
+  double zz = std::abs(hitPoint.z());
 
   if (rr > rMax || zz > zMax) {
-    LogDebug("MaterialBudget") << " MaterialBudgetHcal::StopAfter R = " << rr
-			       << " and Z = " << zz;
+    LogDebug("MaterialBudget") << " MaterialBudgetHcal::StopAfter R = " << rr << " and Z = " << zz;
     return true;
   } else {
     return false;

--- a/Validation/Geometry/src/MaterialBudgetHcalHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetHcalHistos.cc
@@ -14,97 +14,85 @@
 
 #include <string>
 
-MaterialBudgetHcalHistos::MaterialBudgetHcalHistos(const edm::ParameterSet &p){
-
-  binEta      = p.getUntrackedParameter<int>("NBinEta", 260);
-  binPhi      = p.getUntrackedParameter<int>("NBinPhi", 180);
-  maxEta      = p.getUntrackedParameter<double>("MaxEta", 5.2);
-  etaLow      = p.getUntrackedParameter<double>("EtaLow", -5.2);
-  etaHigh     = p.getUntrackedParameter<double>("EtaHigh", 5.2);
-  fillHistos  = p.getUntrackedParameter<bool>("FillHisto", true);
-  printSum    = p.getUntrackedParameter<bool>("PrintSummary", false);
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: FillHisto : "
-				 << fillHistos << " PrintSummary " << printSum
-				 << " == Eta plot: NX " << binEta << " Range "
-				 << -maxEta << ":" << maxEta <<" Phi plot: NX "
-				 << binPhi << " Range " << -pi << ":" << pi 
-				 << " (Eta limit " << etaLow << ":" << etaHigh 
-				 <<")";
-  if (fillHistos) book();
-
+MaterialBudgetHcalHistos::MaterialBudgetHcalHistos(const edm::ParameterSet& p) {
+  binEta = p.getUntrackedParameter<int>("NBinEta", 260);
+  binPhi = p.getUntrackedParameter<int>("NBinPhi", 180);
+  maxEta = p.getUntrackedParameter<double>("MaxEta", 5.2);
+  etaLow = p.getUntrackedParameter<double>("EtaLow", -5.2);
+  etaHigh = p.getUntrackedParameter<double>("EtaHigh", 5.2);
+  fillHistos = p.getUntrackedParameter<bool>("FillHisto", true);
+  printSum = p.getUntrackedParameter<bool>("PrintSummary", false);
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: FillHisto : " << fillHistos << " PrintSummary "
+                                 << printSum << " == Eta plot: NX " << binEta << " Range " << -maxEta << ":" << maxEta
+                                 << " Phi plot: NX " << binPhi << " Range " << -pi << ":" << pi << " (Eta limit "
+                                 << etaLow << ":" << etaHigh << ")";
+  if (fillHistos)
+    book();
 }
 
-void MaterialBudgetHcalHistos::fillBeginJob(const DDCompactView & cpv) {
-
+void MaterialBudgetHcalHistos::fillBeginJob(const DDCompactView& cpv) {
   if (fillHistos) {
     std::string attribute = "ReadOutName";
-    std::string value     = "HcalHits";
-    DDSpecificsMatchesValueFilter filter1{DDValue(attribute,value,0)};
-    DDFilteredView fv1(cpv,filter1);
+    std::string value = "HcalHits";
+    DDSpecificsMatchesValueFilter filter1{DDValue(attribute, value, 0)};
+    DDFilteredView fv1(cpv, filter1);
     sensitives = getNames(fv1);
     edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Names to be "
-				   << "tested for " << attribute << " = " 
-				   << value << " has " << sensitives.size()
-				   << " elements";
-    for (unsigned int i=0; i<sensitives.size(); i++) 
-      edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: sensitives["
-				     << i << "] = " << sensitives[i];
+                                   << "tested for " << attribute << " = " << value << " has " << sensitives.size()
+                                   << " elements";
+    for (unsigned int i = 0; i < sensitives.size(); i++)
+      edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: sensitives[" << i << "] = " << sensitives[i];
 
     attribute = "Volume";
-    value     = "HF";
-    DDSpecificsMatchesValueFilter filter2{DDValue(attribute,value,0)};
-    DDFilteredView fv2(cpv,filter2);
+    value = "HF";
+    DDSpecificsMatchesValueFilter filter2{DDValue(attribute, value, 0)};
+    DDFilteredView fv2(cpv, filter2);
     hfNames = getNames(fv2);
     fv2.firstChild();
     DDsvalues_type sv(fv2.mergedSpecifics());
-    std::vector<double> temp =  getDDDArray("Levels",sv);
+    std::vector<double> temp = getDDDArray("Levels", sv);
     edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Names to be "
-				   << "tested for " << attribute << " = " 
-				   << value << " has " << hfNames.size()
-				   << " elements";
-    for (unsigned int i=0; i<hfNames.size(); i++) {
+                                   << "tested for " << attribute << " = " << value << " has " << hfNames.size()
+                                   << " elements";
+    for (unsigned int i = 0; i < hfNames.size(); i++) {
       int level = static_cast<int>(temp[i]);
       hfLevels.push_back(level);
-      edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos:  HF[" << i 
-				     << "] = " << hfNames[i] << " at level " 
-				     << hfLevels[i];
+      edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos:  HF[" << i << "] = " << hfNames[i] << " at level "
+                                     << hfLevels[i];
     }
 
     std::string ecalRO[2] = {"EcalHitsEB", "EcalHitsEE"};
     attribute = "ReadOutName";
-    for (int k=0; k<2; k++) {
-      value     = ecalRO[k];
-      DDSpecificsMatchesValueFilter filter3{DDValue(attribute,value,0)};
-      DDFilteredView fv3(cpv,filter3);
+    for (int k = 0; k < 2; k++) {
+      value = ecalRO[k];
+      DDSpecificsMatchesValueFilter filter3{DDValue(attribute, value, 0)};
+      DDFilteredView fv3(cpv, filter3);
       std::vector<std::string> senstmp = getNames(fv3);
       edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Names to be"
-				     << " tested for " << attribute << " = " 
-				     << value << " has " << senstmp.size()
-				     << " elements";
-      for (unsigned int i=0; i<senstmp.size(); i++)
-	sensitiveEC.push_back(senstmp[i]);
+                                     << " tested for " << attribute << " = " << value << " has " << senstmp.size()
+                                     << " elements";
+      for (unsigned int i = 0; i < senstmp.size(); i++)
+        sensitiveEC.push_back(senstmp[i]);
     }
-    for (unsigned int i=0; i<sensitiveEC.size(); i++) 
-      edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos:sensitiveEC["
-				     << i << "] = " << sensitiveEC[i];
+    for (unsigned int i = 0; i < sensitiveEC.size(); i++)
+      edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos:sensitiveEC[" << i << "] = " << sensitiveEC[i];
   }
 }
 
 void MaterialBudgetHcalHistos::fillStartTrack(const G4Track* aTrack) {
-
-  id     = layer  = steps   = 0;
+  id = layer = steps = 0;
   radLen = intLen = stepLen = 0;
-  nlayHB = nlayHE = nlayHF  = nlayHO = 0;
+  nlayHB = nlayHE = nlayHF = nlayHO = 0;
 
-  const G4ThreeVector& dir = aTrack->GetMomentum() ;
-  if (dir.theta() != 0 ) {
+  const G4ThreeVector& dir = aTrack->GetMomentum();
+  if (dir.theta() != 0) {
     eta = dir.eta();
   } else {
     eta = -99;
   }
   phi = dir.phi();
   double theEnergy = aTrack->GetTotalEnergy();
-  int    theID     = (int)(aTrack->GetDefinition()->GetPDGEncoding());
+  int theID = (int)(aTrack->GetDefinition()->GetPDGEncoding());
 
   if (printSum) {
     matList.clear();
@@ -113,217 +101,238 @@ void MaterialBudgetHcalHistos::fillStartTrack(const G4Track* aTrack) {
     intLength.clear();
   }
 
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Track " 
-				 << aTrack->GetTrackID() << " Code " << theID
-				 << " Energy " << theEnergy/GeV << " GeV; Eta "
-				 << eta << " Phi " << phi/deg << " PT "
-				 << dir.perp()/GeV << " GeV *****";
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Track " << aTrack->GetTrackID() << " Code " << theID
+                                 << " Energy " << theEnergy / GeV << " GeV; Eta " << eta << " Phi " << phi / deg
+                                 << " PT " << dir.perp() / GeV << " GeV *****";
 }
 
-
 void MaterialBudgetHcalHistos::fillPerStep(const G4Step* aStep) {
+  G4Material* material = aStep->GetPreStepPoint()->GetMaterial();
+  double step = aStep->GetStepLength();
+  double radl = material->GetRadlen();
+  double intl = material->GetNuclearInterLength();
+  double density = material->GetDensity() / (g / cm3);
 
-  G4Material * material = aStep->GetPreStepPoint()->GetMaterial();
-  double step    = aStep->GetStepLength();
-  double radl    = material->GetRadlen();
-  double intl    = material->GetNuclearInterLength();
-  double density = material->GetDensity() / (g/cm3);
-
-  int    idOld   = id;
+  int idOld = id;
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-  std::string         name  = touch->GetVolume(0)->GetName();
-  const std::string&         matName = material->GetName();
+  std::string name = touch->GetVolume(0)->GetName();
+  const std::string& matName = material->GetName();
   if (printSum) {
     bool found = false;
-    for (unsigned int ii=0; ii<matList.size(); ii++) {
+    for (unsigned int ii = 0; ii < matList.size(); ii++) {
       if (matList[ii] == matName) {
-	stepLength[ii] += step;
-	radLength[ii]  += (step/radl);
-	intLength[ii]  += (step/intl);
-	found           = true;
-	break;
+        stepLength[ii] += step;
+        radLength[ii] += (step / radl);
+        intLength[ii] += (step / intl);
+        found = true;
+        break;
       }
     }
     if (!found) {
       matList.push_back(matName);
       stepLength.push_back(step);
-      radLength.push_back(step/radl);
-      intLength.push_back(step/intl);
+      radLength.push_back(step / radl);
+      intLength.push_back(step / intl);
     }
-    edm::LogInfo("MaterialBudget") << name << " " << step << " " << matName 
-				   << " " << stepLen << " " << step/radl << " " 
-				   << radLen << " " <<step/intl << " " <<intLen;
+    edm::LogInfo("MaterialBudget") << name << " " << step << " " << matName << " " << stepLen << " " << step / radl
+                                   << " " << radLen << " " << step / intl << " " << intLen;
   } else {
-    edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Step at " 
-				   << name << " Length " << step << " in " 
-				   << matName << " of density " << density 
-				   << " g/cc; Radiation Length " <<radl <<" mm;"
-				   << " Interaction Length " << intl << " mm\n"
-				   << "                          Position " 
-				   << aStep->GetPreStepPoint()->GetPosition()
-				   << " Cylindrical R "
-				   <<aStep->GetPreStepPoint()->GetPosition().perp()
-				   << " Length (so far) " << stepLen << " L/X0 "
-				   << step/radl << "/" << radLen << " L/Lambda "
-				   << step/intl << "/" << intLen;
+    edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Step at " << name << " Length " << step << " in "
+                                   << matName << " of density " << density << " g/cc; Radiation Length " << radl
+                                   << " mm;"
+                                   << " Interaction Length " << intl << " mm\n"
+                                   << "                          Position " << aStep->GetPreStepPoint()->GetPosition()
+                                   << " Cylindrical R " << aStep->GetPreStepPoint()->GetPosition().perp()
+                                   << " Length (so far) " << stepLen << " L/X0 " << step / radl << "/" << radLen
+                                   << " L/Lambda " << step / intl << "/" << intLen;
   }
 
-  int det=0, lay=0;
+  int det = 0, lay = 0;
   if (fillHistos) {
     if (isItEC(name)) {
       det = 1;
       lay = 1;
     } else {
       if (isSensitive(name)) {
-	if (isItHF(touch)) {
-	  det = 5;
-	  lay = 21;
-	  if (lay != layer) nlayHF++;
-	} else {
-	  det   = (touch->GetReplicaNumber(1))/1000;
-	  lay   = (touch->GetReplicaNumber(0)/10)%100 + 3;
-	  if (det == 4) {
-	    double abeta = std::abs(eta);
-	    if (abeta < 1.479) lay = layer + 1;
-	    else               lay--;
-	    if (lay < 3) lay = 3;
-	    if (lay == layer) lay++;
-	    if (lay > 20) lay = 20;
-	    if (lay != layer) nlayHE++;
-	  } else if (lay != layer) {
-	    if (lay >= 20) nlayHO++;
-	    else           nlayHB++;
-	  }
-	}
-	LogDebug("MaterialBudget") << "MaterialBudgetHcalHistos: Det " << det
-				   << " Layer " << lay << " Eta " << eta 
-				   << " Phi " << phi/deg;
+        if (isItHF(touch)) {
+          det = 5;
+          lay = 21;
+          if (lay != layer)
+            nlayHF++;
+        } else {
+          det = (touch->GetReplicaNumber(1)) / 1000;
+          lay = (touch->GetReplicaNumber(0) / 10) % 100 + 3;
+          if (det == 4) {
+            double abeta = std::abs(eta);
+            if (abeta < 1.479)
+              lay = layer + 1;
+            else
+              lay--;
+            if (lay < 3)
+              lay = 3;
+            if (lay == layer)
+              lay++;
+            if (lay > 20)
+              lay = 20;
+            if (lay != layer)
+              nlayHE++;
+          } else if (lay != layer) {
+            if (lay >= 20)
+              nlayHO++;
+            else
+              nlayHB++;
+          }
+        }
+        LogDebug("MaterialBudget") << "MaterialBudgetHcalHistos: Det " << det << " Layer " << lay << " Eta " << eta
+                                   << " Phi " << phi / deg;
       } else if (layer == 1) {
-	det = -1;
-	lay = 2;
+        det = -1;
+        lay = 2;
       }
     }
     if (det != 0) {
       if (lay != layer) {
-	id    = lay;
-	layer = lay;
+        id = lay;
+        layer = lay;
       }
     }
 
     if (id > idOld) {
       //    edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Step at " << name;
-      fillHisto(id-1);
+      fillHisto(id - 1);
     }
   }
 
   stepLen += step;
-  radLen  += step/radl;
-  intLen  += step/intl;
+  radLen += step / radl;
+  intLen += step / intl;
   if (fillHistos) {
     if (layer == 21 && det == 5) {
       if (!isItHF(aStep->GetPostStepPoint()->GetTouchable())) {
-	LogDebug("MaterialBudget") << "MaterialBudgetHcalHistos: After HF in " 
-				   << aStep->GetPostStepPoint()->GetTouchable()->GetVolume(0)->GetName();
-	fillHisto(id);
-	id++;
-	layer = 0;
+        LogDebug("MaterialBudget") << "MaterialBudgetHcalHistos: After HF in "
+                                   << aStep->GetPostStepPoint()->GetTouchable()->GetVolume(0)->GetName();
+        fillHisto(id);
+        id++;
+        layer = 0;
       }
     }
   }
 }
 
-
 void MaterialBudgetHcalHistos::fillEndTrack() {
-  edm::LogInfo("MaterialBudget") << "Number of layers hit in HB:" << nlayHB
-				 << " HE:" << nlayHE << " HO:" << nlayHO
-				 << " HF:" << nlayHF;
+  edm::LogInfo("MaterialBudget") << "Number of layers hit in HB:" << nlayHB << " HE:" << nlayHE << " HO:" << nlayHO
+                                 << " HF:" << nlayHF;
   if (fillHistos) {
-    fillHisto(maxSet-1);
+    fillHisto(maxSet - 1);
     fillLayer();
   }
   if (printSum) {
-    for (unsigned int ii=0; ii<matList.size(); ii++) {
-      edm::LogInfo("MaterialBudget") << matList[ii] << "\t" << stepLength[ii]
-				     << "\t" << radLength[ii] << "\t"
-				     << intLength[ii];
+    for (unsigned int ii = 0; ii < matList.size(); ii++) {
+      edm::LogInfo("MaterialBudget") << matList[ii] << "\t" << stepLength[ii] << "\t" << radLength[ii] << "\t"
+                                     << intLength[ii];
     }
   }
 }
 
 void MaterialBudgetHcalHistos::book() {
-
   // Book histograms
   edm::Service<TFileService> tfile;
-  
-  if ( !tfile.isAvailable() )
+
+  if (!tfile.isAvailable())
     throw cms::Exception("BadConfig") << "TFileService unavailable: "
                                       << "please add it to config file";
 
-  double maxPhi=pi;
+  double maxPhi = pi;
   edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Booking user "
-				 << "histos === with " << binEta << " bins "
-				 << "in eta from " << -maxEta << " to "
-				 << maxEta << " and " << binPhi << " bins "
-				 << "in phi from " << -maxPhi << " to " 
-				 << maxPhi;
-  
+                                 << "histos === with " << binEta << " bins "
+                                 << "in eta from " << -maxEta << " to " << maxEta << " and " << binPhi << " bins "
+                                 << "in phi from " << -maxPhi << " to " << maxPhi;
+
   std::string iter;
   // total X0
-  for (int i=0; i<maxSet; i++) {
+  for (int i = 0; i < maxSet; i++) {
     iter = std::to_string(i);
-    me100[i] = tfile->make<TProfile>(std::to_string(i + 100).c_str(),
-                  ("MB(X0) prof Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
-    me200[i] = tfile->make<TProfile>(std::to_string(i + 200).c_str(),
-                  ("MB(L0) prof Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
-    me300[i] = tfile->make<TProfile>(std::to_string(i + 300).c_str(),
-                  ("MB(Step) prof Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
-    me400[i] = tfile->make<TH1F>(std::to_string(i + 400).c_str(),
-                  ("Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
-    me500[i] = tfile->make<TProfile>(std::to_string(i + 500).c_str(),
-                  ("MB(X0) prof Ph in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
-    me600[i] = tfile->make<TProfile>(std::to_string(i + 600).c_str(),
-                  ("MB(L0) prof Ph in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
-    me700[i] = tfile->make<TProfile>(std::to_string(i + 700).c_str(),
-                  ("MB(Step) prof Ph in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
-    me800[i] = tfile->make<TH1F>(std::to_string(i + 800).c_str(),
-                  ("Phi in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
+    me100[i] = tfile->make<TProfile>(
+        std::to_string(i + 100).c_str(), ("MB(X0) prof Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
+    me200[i] = tfile->make<TProfile>(
+        std::to_string(i + 200).c_str(), ("MB(L0) prof Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
+    me300[i] = tfile->make<TProfile>(
+        std::to_string(i + 300).c_str(), ("MB(Step) prof Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
+    me400[i] =
+        tfile->make<TH1F>(std::to_string(i + 400).c_str(), ("Eta in region " + iter).c_str(), binEta, -maxEta, maxEta);
+    me500[i] = tfile->make<TProfile>(
+        std::to_string(i + 500).c_str(), ("MB(X0) prof Ph in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
+    me600[i] = tfile->make<TProfile>(
+        std::to_string(i + 600).c_str(), ("MB(L0) prof Ph in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
+    me700[i] = tfile->make<TProfile>(
+        std::to_string(i + 700).c_str(), ("MB(Step) prof Ph in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
+    me800[i] =
+        tfile->make<TH1F>(std::to_string(i + 800).c_str(), ("Phi in region " + iter).c_str(), binPhi, -maxPhi, maxPhi);
     me900[i] = tfile->make<TProfile2D>(std::to_string(i + 900).c_str(),
-                  ("MB(X0) prof Eta Phi in region " + iter).c_str(), binEta/2, -maxEta, maxEta,
-                  binPhi/2, -maxPhi, maxPhi);
-    me1000[i]= tfile->make<TProfile2D>(std::to_string(i + 1000).c_str(),
-                  ("MB(L0) prof Eta Phi in region " + iter).c_str(), binEta/2, -maxEta, maxEta,
-                  binPhi/2, -maxPhi, maxPhi);
-    me1100[i]= tfile->make<TProfile2D>(std::to_string(i + 1100).c_str(),
-                  ("MB(Step) prof Eta Phi in region " + iter).c_str(), binEta/2, -maxEta, maxEta,
-                  binPhi/2, -maxPhi, maxPhi);
-    me1200[i]= tfile->make<TH2F>(std::to_string(i + 1200).c_str(),
-                  ("Eta vs Phi in region " + iter).c_str(), binEta/2, -maxEta, maxEta,
-                  binPhi/2, -maxPhi, maxPhi);
+                                       ("MB(X0) prof Eta Phi in region " + iter).c_str(),
+                                       binEta / 2,
+                                       -maxEta,
+                                       maxEta,
+                                       binPhi / 2,
+                                       -maxPhi,
+                                       maxPhi);
+    me1000[i] = tfile->make<TProfile2D>(std::to_string(i + 1000).c_str(),
+                                        ("MB(L0) prof Eta Phi in region " + iter).c_str(),
+                                        binEta / 2,
+                                        -maxEta,
+                                        maxEta,
+                                        binPhi / 2,
+                                        -maxPhi,
+                                        maxPhi);
+    me1100[i] = tfile->make<TProfile2D>(std::to_string(i + 1100).c_str(),
+                                        ("MB(Step) prof Eta Phi in region " + iter).c_str(),
+                                        binEta / 2,
+                                        -maxEta,
+                                        maxEta,
+                                        binPhi / 2,
+                                        -maxPhi,
+                                        maxPhi);
+    me1200[i] = tfile->make<TH2F>(std::to_string(i + 1200).c_str(),
+                                  ("Eta vs Phi in region " + iter).c_str(),
+                                  binEta / 2,
+                                  -maxEta,
+                                  maxEta,
+                                  binPhi / 2,
+                                  -maxPhi,
+                                  maxPhi);
   }
-  for (int i=0; i<maxSet2; i++) {
+  for (int i = 0; i < maxSet2; i++) {
     iter = std::to_string(i);
-    me1300[i]= tfile->make<TH1F>(std::to_string(i + 1300).c_str(),
-                  ("Events with layers Hit (0 all, 1 HB, ..) for " + iter).c_str(), binEta, -maxEta, maxEta);
-    me1400[i]= tfile->make<TH2F>(std::to_string(i + 1400).c_str(),
-                  ("Eta vs Phi for layers hit in " + iter).c_str(), binEta/2, -maxEta, maxEta,
-                  binPhi/2, -maxPhi, maxPhi);
-    me1500[i]= tfile->make<TProfile>(std::to_string(i + 1500).c_str(),
-                  ("Number of layers crossed (0 all, 1 HB, ..) for " + iter).c_str(), binEta, -maxEta, maxEta);
+    me1300[i] = tfile->make<TH1F>(std::to_string(i + 1300).c_str(),
+                                  ("Events with layers Hit (0 all, 1 HB, ..) for " + iter).c_str(),
+                                  binEta,
+                                  -maxEta,
+                                  maxEta);
+    me1400[i] = tfile->make<TH2F>(std::to_string(i + 1400).c_str(),
+                                  ("Eta vs Phi for layers hit in " + iter).c_str(),
+                                  binEta / 2,
+                                  -maxEta,
+                                  maxEta,
+                                  binPhi / 2,
+                                  -maxPhi,
+                                  maxPhi);
+    me1500[i] = tfile->make<TProfile>(std::to_string(i + 1500).c_str(),
+                                      ("Number of layers crossed (0 all, 1 HB, ..) for " + iter).c_str(),
+                                      binEta,
+                                      -maxEta,
+                                      maxEta);
   }
 
   edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Booking user "
-				 << "histos done ===";
-
+                                 << "histos done ===";
 }
 
 void MaterialBudgetHcalHistos::fillHisto(int ii) {
-
   LogDebug("MaterialBudget") << "MaterialBudgetHcalHistos:FillHisto called "
-			     << "with index " << ii << " integrated  step "
-			     << stepLen << " X0 " << radLen << " Lamda " 
-			     << intLen;
-  
-  if (ii >=0 && ii < maxSet) {
+                             << "with index " << ii << " integrated  step " << stepLen << " X0 " << radLen << " Lamda "
+                             << intLen;
+
+  if (ii >= 0 && ii < maxSet) {
     me100[ii]->Fill(eta, radLen);
     me200[ii]->Fill(eta, intLen);
     me300[ii]->Fill(eta, stepLen);
@@ -340,128 +349,121 @@ void MaterialBudgetHcalHistos::fillHisto(int ii) {
     me1000[ii]->Fill(eta, phi, intLen);
     me1100[ii]->Fill(eta, phi, stepLen);
     me1200[ii]->Fill(eta, phi);
-    
   }
 }
 
 void MaterialBudgetHcalHistos::fillLayer() {
-
   me1300[0]->Fill(eta);
-  me1400[0]->Fill(eta,phi);
+  me1400[0]->Fill(eta, phi);
   if (nlayHB > 0) {
     me1300[1]->Fill(eta);
-    me1400[1]->Fill(eta,phi);
+    me1400[1]->Fill(eta, phi);
   }
   if (nlayHB >= 16) {
     me1300[2]->Fill(eta);
-    me1400[2]->Fill(eta,phi);
+    me1400[2]->Fill(eta, phi);
   }
   if (nlayHE > 0) {
     me1300[3]->Fill(eta);
-    me1400[3]->Fill(eta,phi);
+    me1400[3]->Fill(eta, phi);
   }
   if (nlayHE >= 16) {
     me1300[4]->Fill(eta);
-    me1400[4]->Fill(eta,phi);
+    me1400[4]->Fill(eta, phi);
   }
   if (nlayHO > 0) {
     me1300[5]->Fill(eta);
-    me1400[5]->Fill(eta,phi);
+    me1400[5]->Fill(eta, phi);
   }
   if (nlayHO >= 2) {
     me1300[6]->Fill(eta);
-    me1400[6]->Fill(eta,phi);
+    me1400[6]->Fill(eta, phi);
   }
   if (nlayHF > 0) {
     me1300[7]->Fill(eta);
-    me1400[7]->Fill(eta,phi);
+    me1400[7]->Fill(eta, phi);
   }
   if (nlayHB > 0 || nlayHE > 0 || (nlayHF > 0 && std::abs(eta) > 3.0)) {
     me1300[8]->Fill(eta);
-    me1400[8]->Fill(eta,phi);
+    me1400[8]->Fill(eta, phi);
   }
-  me1500[0]->Fill(eta,(double)(nlayHB+nlayHO+nlayHE+nlayHF));
-  me1500[1]->Fill(eta,(double)(nlayHB));
-  me1500[2]->Fill(eta,(double)(nlayHE));
-  me1500[4]->Fill(eta,(double)(nlayHF));
+  me1500[0]->Fill(eta, (double)(nlayHB + nlayHO + nlayHE + nlayHF));
+  me1500[1]->Fill(eta, (double)(nlayHB));
+  me1500[2]->Fill(eta, (double)(nlayHE));
+  me1500[4]->Fill(eta, (double)(nlayHF));
 }
 
 void MaterialBudgetHcalHistos::hend() {
   edm::LogInfo("MaterialBudget") << "MaterialBudgetHcalHistos: Save user "
-				 << "histos ===";
+                                 << "histos ===";
 }
 
 std::vector<std::string> MaterialBudgetHcalHistos::getNames(DDFilteredView& fv) {
-
   std::vector<std::string> tmp;
   bool dodet = fv.firstChild();
   while (dodet) {
-    const DDLogicalPart & log = fv.logicalPart();
+    const DDLogicalPart& log = fv.logicalPart();
     std::string namx = log.name().name();
     bool ok = true;
-    for (unsigned int i=0; i<tmp.size(); i++)
-      if (namx == tmp[i]) ok = false;
-    if (ok) tmp.push_back(namx);
+    for (unsigned int i = 0; i < tmp.size(); i++)
+      if (namx == tmp[i])
+        ok = false;
+    if (ok)
+      tmp.push_back(namx);
     dodet = fv.next();
   }
   return tmp;
 }
 
-std::vector<double> MaterialBudgetHcalHistos::getDDDArray(const std::string & str,
-							  const DDsvalues_type & sv) {
-
+std::vector<double> MaterialBudgetHcalHistos::getDDDArray(const std::string& str, const DDsvalues_type& sv) {
   LogDebug("MaterialBudget") << "MaterialBudgetHcalHistos:getDDDArray called "
-			     << "for " << str;
+                             << "for " << str;
   DDValue value(str);
-  if (DDfetch(&sv,value)) {
+  if (DDfetch(&sv, value)) {
     LogDebug("MaterialBudget") << value;
-    const std::vector<double> & fvec = value.doubles();
+    const std::vector<double>& fvec = value.doubles();
     int nval = fvec.size();
     if (nval < 1) {
-      edm::LogError("MaterialBudget") << "MaterialBudgetHcalHistos : # of " 
-				      << str << " bins " << nval
-				      << " < 1 ==> illegal";
-      throw cms::Exception("Unknown", "MaterialBudgetHcalHistos")
-        << "nval < 1 for array " << str << "\n";
+      edm::LogError("MaterialBudget") << "MaterialBudgetHcalHistos : # of " << str << " bins " << nval
+                                      << " < 1 ==> illegal";
+      throw cms::Exception("Unknown", "MaterialBudgetHcalHistos") << "nval < 1 for array " << str << "\n";
     }
 
     return fvec;
   } else {
     edm::LogError("MaterialBudget") << "MaterialBudgetHcalHistos : cannot get "
-				    << "array " << str;
-    throw cms::Exception("Unknown", "MaterialBudgetHcalHistos")
-      << "cannot get array " << str << "\n";
+                                    << "array " << str;
+    throw cms::Exception("Unknown", "MaterialBudgetHcalHistos") << "cannot get array " << str << "\n";
   }
 }
 
-bool MaterialBudgetHcalHistos::isSensitive (std::string name) {
-
+bool MaterialBudgetHcalHistos::isSensitive(std::string name) {
   std::vector<std::string>::const_iterator it = sensitives.begin();
   std::vector<std::string>::const_iterator itEnd = sensitives.end();
   for (; it != itEnd; ++it)
-    if (name == *it) return true;
+    if (name == *it)
+      return true;
   return false;
 }
 
-bool MaterialBudgetHcalHistos::isItHF (const G4VTouchable* touch) {
-
+bool MaterialBudgetHcalHistos::isItHF(const G4VTouchable* touch) {
   // std::vector<std::string>::const_iterator it = hfNames.begin();
-  int levels = ((touch->GetHistoryDepth())+1);
-  for (unsigned int it=0; it < hfNames.size(); it++) {
+  int levels = ((touch->GetHistoryDepth()) + 1);
+  for (unsigned int it = 0; it < hfNames.size(); it++) {
     if (levels >= hfLevels[it]) {
-      std::string name = touch->GetVolume(levels-hfLevels[it])->GetName();
-      if (name == hfNames[it]) return true;
+      std::string name = touch->GetVolume(levels - hfLevels[it])->GetName();
+      if (name == hfNames[it])
+        return true;
     }
   }
   return false;
 }
 
-bool MaterialBudgetHcalHistos::isItEC (std::string name) {
-
+bool MaterialBudgetHcalHistos::isItEC(std::string name) {
   std::vector<std::string>::const_iterator it = sensitiveEC.begin();
   std::vector<std::string>::const_iterator itEnd = sensitiveEC.end();
   for (; it != itEnd; ++it)
-    if (name == *it) return true;
+    if (name == *it)
+      return true;
   return false;
 }
-

--- a/Validation/Geometry/src/MaterialBudgetHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetHistos.cc
@@ -1,58 +1,39 @@
 #include "Validation/Geometry/interface/MaterialBudgetHistos.h"
 #include "Validation/Geometry/interface/MaterialBudgetData.h"
 
-
 MaterialBudgetHistos::MaterialBudgetHistos(std::shared_ptr<MaterialBudgetData> data,
-					   std::shared_ptr<TestHistoMgr> mgr,
-					   const std::string& fileName )
-  : MaterialBudgetFormat( data ), 
-    hmgr(mgr)
-{
+                                           std::shared_ptr<TestHistoMgr> mgr,
+                                           const std::string& fileName)
+    : MaterialBudgetFormat(data), hmgr(mgr) {
   theFileName = fileName;
   book();
 }
 
-
-void MaterialBudgetHistos::book() 
-{
+void MaterialBudgetHistos::book() {
   edm::LogInfo("MaterialBudget") << " MaterialBudgetHistos: Booking Histos";
-  hmgr->addHistoProf1( new TProfile("10", "MB prof Eta ", 250, -5., 5. ) );
-  hmgr->addHisto1( new TH1F("11", "Eta " , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("20", "MB prof Phi ", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("21", "Phi " , 360, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("30", "MB prof Eta  Phi ", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("31", "Eta vs Phi " , 501, -5., 5., 180, -3.1416, 3.1416 ) );
+  hmgr->addHistoProf1(new TProfile("10", "MB prof Eta ", 250, -5., 5.));
+  hmgr->addHisto1(new TH1F("11", "Eta ", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("20", "MB prof Phi ", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("21", "Phi ", 360, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D("30", "MB prof Eta  Phi ", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("31", "Eta vs Phi ", 501, -5., 5., 180, -3.1416, 3.1416));
 }
 
+void MaterialBudgetHistos::fillStartTrack() {}
 
-void MaterialBudgetHistos::fillStartTrack()
-{
+void MaterialBudgetHistos::fillPerStep() {}
 
-}
-
-
-void MaterialBudgetHistos::fillPerStep()
-{
-
-}
-
-
-void MaterialBudgetHistos::fillEndTrack()
-{
+void MaterialBudgetHistos::fillEndTrack() {
   hmgr->getHisto1(11)->Fill(theData->getEta());
   hmgr->getHisto1(21)->Fill(theData->getPhi());
-  hmgr->getHisto2(31)->Fill(theData->getEta(),theData->getPhi());
+  hmgr->getHisto2(31)->Fill(theData->getEta(), theData->getPhi());
 
-  hmgr->getHistoProf1(10)->Fill(theData->getEta(),theData->getTotalMB());
-  hmgr->getHistoProf1(20)->Fill(theData->getPhi(),theData->getTotalMB());
-  hmgr->getHistoProf2(30)->Fill(theData->getEta(),theData->getPhi(),theData->getTotalMB());
-
+  hmgr->getHistoProf1(10)->Fill(theData->getEta(), theData->getTotalMB());
+  hmgr->getHistoProf1(20)->Fill(theData->getPhi(), theData->getTotalMB());
+  hmgr->getHistoProf2(30)->Fill(theData->getEta(), theData->getPhi(), theData->getTotalMB());
 }
 
-
-void MaterialBudgetHistos::endOfRun() 
-{
+void MaterialBudgetHistos::endOfRun() {
   edm::LogInfo("MaterialBudget") << "MaterialBudgetHistos: Writing Histos ROOT file to" << theFileName;
-  hmgr->save( theFileName );
+  hmgr->save(theFileName);
 }
-

--- a/Validation/Geometry/src/MaterialBudgetMtdHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetMtdHistos.cc
@@ -14,146 +14,147 @@ MaterialBudgetMtdHistos::MaterialBudgetMtdHistos(std::shared_ptr<MaterialBudgetD
 void MaterialBudgetMtdHistos::book() {
   edm::LogInfo("MaterialBudget") << "MaterialBudgetMtdHistos: Booking user histos";
 
+  static constexpr double minEta = -5.;
+  static constexpr double maxEta = 5.;
+  static constexpr double minPhi = -3.1416;
+  static constexpr double maxPhi = 3.1416;        
+  static constexpr int nbinEta = 250;
+  static constexpr int nbinPhi = 180;
+
   // Material budget: radiation length
   // total X0
-  hmgr->addHistoProf1(new TProfile("10", "MB prof Eta [Total];#eta;x/X_{0} ", 250, -5., 5.));
-  hmgr->addHisto1(new TH1F("11", "Eta ", 501, -5., 5.));
-  hmgr->addHistoProf1(new TProfile("20", "MB prof Phi [Total];#varphi [rad];x/X_{0} ", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("21", "Phi ", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("10", "MB prof Eta [Total];#eta;x/X_{0} ", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("11", "Eta ", nbinEta, minEta, maxEta));
+  hmgr->addHistoProf1(new TProfile("20", "MB prof Phi [Total];#varphi [rad];x/X_{0} ", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("21", "Phi ", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(
-      new TProfile2D("30", "MB prof Eta  Phi [Total];#eta;#varphi;x/X_{0} ", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("31", "Eta vs Phi ", 501, -5., 5., 180, -3.1416, 3.1416));
+      new TProfile2D("30", "MB prof Eta  Phi [Total];#eta;#varphi;x/X_{0} ", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("31", "Eta vs Phi ", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Support
-  hmgr->addHistoProf1(new TProfile("110", "MB prof Eta [Support];#eta;x/X_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("111", "Eta [Support]", 501, -5., 5.));
-  hmgr->addHistoProf1(new TProfile("120", "MB prof Phi [Support];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("121", "Phi [Support]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("110", "MB prof Eta [Support];#eta;x/X_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("111", "Eta [Support]", nbinEta, minEta, maxEta));
+  hmgr->addHistoProf1(new TProfile("120", "MB prof Phi [Support];#varphi [rad];x/X_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("121", "Phi [Support]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(
-      new TProfile2D("130", "MB prof Eta  Phi [Support];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("131", "Eta vs Phi [Support]", 501, -5., 5., 180, -3.1416, 3.1416));
+      new TProfile2D("130", "MB prof Eta  Phi [Support];#eta;#varphi;x/X_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("131", "Eta vs Phi [Support]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Sensitive
-  hmgr->addHistoProf1(new TProfile("210", "MB prof Eta [Sensitive];#eta;x/X_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("211", "Eta [Sensitive]", 501, -5., 5.));
-  hmgr->addHistoProf1(new TProfile("220", "MB prof Phi [Sensitive];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("221", "Phi [Sensitive]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("210", "MB prof Eta [Sensitive];#eta;x/X_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("211", "Eta [Sensitive]", nbinEta, minEta, maxEta));
+  hmgr->addHistoProf1(new TProfile("220", "MB prof Phi [Sensitive];#varphi [rad];x/X_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("221", "Phi [Sensitive]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(
-      new TProfile2D("230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("231", "Eta vs Phi [Sensitive]", 501, -5., 5., 180, -3.1416, 3.1416));
+      new TProfile2D("230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;x/X_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("231", "Eta vs Phi [Sensitive]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Cables
-  hmgr->addHistoProf1(new TProfile("310", "MB prof Eta [Cables];#eta;x/X_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("311", "Eta [Cables]", 501, -5., 5.));
-  hmgr->addHistoProf1(new TProfile("320", "MB prof Phi [Cables];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("321", "Phi [Cables]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("310", "MB prof Eta [Cables];#eta;x/X_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("311", "Eta [Cables]", nbinEta, minEta, maxEta));
+  hmgr->addHistoProf1(new TProfile("320", "MB prof Phi [Cables];#varphi [rad];x/X_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("321", "Phi [Cables]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(
-      new TProfile2D("330", "MB prof Eta  Phi [Cables];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("331", "Eta vs Phi [Cables]", 501, -5., 5., 180, -3.1416, 3.1416));
+      new TProfile2D("330", "MB prof Eta  Phi [Cables];#eta;#varphi;x/X_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("331", "Eta vs Phi [Cables]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Cooling
-  hmgr->addHistoProf1(new TProfile("410", "MB prof Eta [Cooling];#eta;x/X_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("411", "Eta [Cooling]", 501, -5., 5.));
-  hmgr->addHistoProf1(new TProfile("420", "MB prof Phi [Cooling];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("421", "Phi [Cooling]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("410", "MB prof Eta [Cooling];#eta;x/X_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("411", "Eta [Cooling]", nbinEta, minEta, maxEta));
+  hmgr->addHistoProf1(new TProfile("420", "MB prof Phi [Cooling];#varphi [rad];x/X_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("421", "Phi [Cooling]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(
-      new TProfile2D("430", "MB prof Eta  Phi [Cooling];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("431", "Eta vs Phi [Cooling]", 501, -5., 5., 180, -3.1416, 3.1416));
+      new TProfile2D("430", "MB prof Eta  Phi [Cooling];#eta;#varphi;x/X_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("431", "Eta vs Phi [Cooling]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Electronics
-  hmgr->addHistoProf1(new TProfile("510", "MB prof Eta [Electronics];#eta;x/X_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("511", "Eta [Electronics]", 501, -5., 5.));
-  hmgr->addHistoProf1(new TProfile("520", "MB prof Phi [Electronics];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("521", "Phi [Electronics]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("510", "MB prof Eta [Electronics];#eta;x/X_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("511", "Eta [Electronics]", nbinEta, minEta, maxEta));
+  hmgr->addHistoProf1(new TProfile("520", "MB prof Phi [Electronics];#varphi [rad];x/X_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("521", "Phi [Electronics]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(
-      new TProfile2D("530", "MB prof Eta  Phi [Electronics];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("531", "Eta vs Phi [Electronics]", 501, -5., 5., 180, -3.1416, 3.1416));
+      new TProfile2D("530", "MB prof Eta  Phi [Electronics];#eta;#varphi;x/X_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("531", "Eta vs Phi [Electronics]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Other
-  hmgr->addHistoProf1(new TProfile("610", "MB prof Eta [Other];#eta;x/X_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("611", "Eta [Other]", 501, -5., 5.));
-  hmgr->addHistoProf1(new TProfile("620", "MB prof Phi [Other];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("621", "Phi [Other]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("610", "MB prof Eta [Other];#eta;x/X_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("611", "Eta [Other]", nbinEta, minEta, maxEta));
+  hmgr->addHistoProf1(new TProfile("620", "MB prof Phi [Other];#varphi [rad];x/X_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("621", "Phi [Other]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(
-      new TProfile2D("630", "MB prof Eta  Phi [Other];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("631", "Eta vs Phi [Other]", 501, -5., 5., 180, -3.1416, 3.1416));
+      new TProfile2D("630", "MB prof Eta  Phi [Other];#eta;#varphi;x/X_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("631", "Eta vs Phi [Other]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Material budget: interaction length
   // total Lambda0
-  hmgr->addHistoProf1(new TProfile("1010", "MB prof Eta [Total];#eta;#lambda/#lambda_{0} ", 250, -5., 5.));
-  hmgr->addHisto1(new TH1F("1011", "Eta ", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("1010", "MB prof Eta [Total];#eta;#lambda/#lambda_{0} ", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("1011", "Eta ", nbinEta, minEta, maxEta));
   hmgr->addHistoProf1(
-      new TProfile("1020", "MB prof Phi [Total];#varphi [rad];#lambda/#lambda_{0} ", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("1021", "Phi ", 180, -3.1416, 3.1416));
+      new TProfile("1020", "MB prof Phi [Total];#varphi [rad];#lambda/#lambda_{0} ", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("1021", "Phi ", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(new TProfile2D(
-      "1030", "MB prof Eta  Phi [Total];#eta;#varphi;#lambda/#lambda_{0} ", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("1031", "Eta vs Phi ", 501, -5., 5., 180, -3.1416, 3.1416));
+      "1030", "MB prof Eta  Phi [Total];#eta;#varphi;#lambda/#lambda_{0} ", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("1031", "Eta vs Phi ", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Support
-  hmgr->addHistoProf1(new TProfile("1110", "MB prof Eta [Support];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("1111", "Eta [Support]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("1110", "MB prof Eta [Support];#eta;#lambda/#lambda_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("1111", "Eta [Support]", nbinEta, minEta, maxEta));
   hmgr->addHistoProf1(
-      new TProfile("1120", "MB prof Phi [Support];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("1121", "Phi [Support]", 180, -3.1416, 3.1416));
+      new TProfile("1120", "MB prof Phi [Support];#varphi [rad];#lambda/#lambda_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("1121", "Phi [Support]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(new TProfile2D(
-      "1130", "MB prof Eta  Phi [Support];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("1131", "Eta vs Phi [Support]", 501, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHistoProf1(new TProfile("1140", "MB prof R [Support];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+      "1130", "MB prof Eta  Phi [Support];#eta;#varphi;#lambda/#lambda_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("1131", "Eta vs Phi [Support]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Sensitive
-  hmgr->addHistoProf1(new TProfile("1210", "MB prof Eta [Sensitive];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("1211", "Eta [Sensitive]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("1210", "MB prof Eta [Sensitive];#eta;#lambda/#lambda_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("1211", "Eta [Sensitive]", nbinEta, minEta, maxEta));
   hmgr->addHistoProf1(
-      new TProfile("1220", "MB prof Phi [Sensitive];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("1221", "Phi [Sensitive]", 180, -3.1416, 3.1416));
+      new TProfile("1220", "MB prof Phi [Sensitive];#varphi [rad];#lambda/#lambda_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("1221", "Phi [Sensitive]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(new TProfile2D(
-      "1230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("1231", "Eta vs Phi [Sensitive]", 501, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHistoProf1(new TProfile("1240", "MB prof R [Sensitive];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+      "1230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;#lambda/#lambda_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("1231", "Eta vs Phi [Sensitive]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Cables
-  hmgr->addHistoProf1(new TProfile("1310", "MB prof Eta [Cables];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("1311", "Eta [Cables]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("1310", "MB prof Eta [Cables];#eta;#lambda/#lambda_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("1311", "Eta [Cables]", nbinEta, minEta, maxEta));
   hmgr->addHistoProf1(
-      new TProfile("1320", "MB prof Phi [Cables];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("1321", "Phi [Cables]", 180, -3.1416, 3.1416));
+      new TProfile("1320", "MB prof Phi [Cables];#varphi [rad];#lambda/#lambda_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("1321", "Phi [Cables]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(new TProfile2D(
-      "1330", "MB prof Eta  Phi [Cables];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("1331", "Eta vs Phi [Cables]", 501, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHistoProf1(new TProfile("1340", "MB prof R [Cables];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+      "1330", "MB prof Eta  Phi [Cables];#eta;#varphi;#lambda/#lambda_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("1331", "Eta vs Phi [Cables]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Cooling
-  hmgr->addHistoProf1(new TProfile("1410", "MB prof Eta [Cooling];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("1411", "Eta [Cooling]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("1410", "MB prof Eta [Cooling];#eta;#lambda/#lambda_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("1411", "Eta [Cooling]", nbinEta, minEta, maxEta));
   hmgr->addHistoProf1(
-      new TProfile("1420", "MB prof Phi [Cooling];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("1421", "Phi [Cooling]", 180, -3.1416, 3.1416));
+      new TProfile("1420", "MB prof Phi [Cooling];#varphi [rad];#lambda/#lambda_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("1421", "Phi [Cooling]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(new TProfile2D(
-      "1430", "MB prof Eta  Phi [Cooling];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("1431", "Eta vs Phi [Cooling]", 501, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHistoProf1(new TProfile("1440", "MB prof R [Cooling];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+      "1430", "MB prof Eta  Phi [Cooling];#eta;#varphi;#lambda/#lambda_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("1431", "Eta vs Phi [Cooling]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Electronics
-  hmgr->addHistoProf1(new TProfile("1510", "MB prof Eta [Electronics];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("1511", "Eta [Electronics]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("1510", "MB prof Eta [Electronics];#eta;#lambda/#lambda_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("1511", "Eta [Electronics]", nbinEta, minEta, maxEta));
   hmgr->addHistoProf1(
-      new TProfile("1520", "MB prof Phi [Electronics];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("1521", "Phi [Electronics]", 180, -3.1416, 3.1416));
+      new TProfile("1520", "MB prof Phi [Electronics];#varphi [rad];#lambda/#lambda_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("1521", "Phi [Electronics]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(new TProfile2D(
-      "1530", "MB prof Eta  Phi [Electronics];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("1531", "Eta vs Phi [Electronics]", 501, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHistoProf1(new TProfile("1540", "MB prof R [Electronics];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+      "1530", "MB prof Eta  Phi [Electronics];#eta;#varphi;#lambda/#lambda_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("1531", "Eta vs Phi [Electronics]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   // Other
-  hmgr->addHistoProf1(new TProfile("1610", "MB prof Eta [Other];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
-  hmgr->addHisto1(new TH1F("1611", "Eta [Other]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("1610", "MB prof Eta [Other];#eta;#lambda/#lambda_{0}", nbinEta, minEta, maxEta));
+  hmgr->addHisto1(new TH1F("1611", "Eta [Other]", nbinEta, minEta, maxEta));
   hmgr->addHistoProf1(
-      new TProfile("1620", "MB prof Phi [Other];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
-  hmgr->addHisto1(new TH1F("1621", "Phi [Other]", 180, -3.1416, 3.1416));
+      new TProfile("1620", "MB prof Phi [Other];#varphi [rad];#lambda/#lambda_{0}", nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto1(new TH1F("1621", "Phi [Other]", nbinPhi, minPhi, maxPhi));
   hmgr->addHistoProf2(new TProfile2D(
-      "1630", "MB prof Eta  Phi [Other];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHisto2(new TH2F("1631", "Eta vs Phi [Other]", 501, -5., 5., 180, -3.1416, 3.1416));
-  hmgr->addHistoProf1(new TProfile("1640", "MB prof R [Other];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+      "1630", "MB prof Eta  Phi [Other];#eta;#varphi;#lambda/#lambda_{0}", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
+  hmgr->addHisto2(new TH2F("1631", "Eta vs Phi [Other]", nbinEta, minEta, maxEta, nbinPhi, minPhi, maxPhi));
 
   edm::LogInfo("MaterialBudget") << "MaterialBudgetMtdHistos: booking user histos done";
 }

--- a/Validation/Geometry/src/MaterialBudgetMtdHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetMtdHistos.cc
@@ -1,0 +1,296 @@
+#include "Validation/Geometry/interface/MaterialBudgetMtdHistos.h"
+#include "Validation/Geometry/interface/MaterialBudgetData.h"
+
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+MaterialBudgetMtdHistos::MaterialBudgetMtdHistos(std::shared_ptr<MaterialBudgetData> data,
+                                                 std::shared_ptr<TestHistoMgr> mgr,
+                                                 const std::string& fileName)
+    : MaterialBudgetFormat(data), hmgr(mgr) {
+  theFileName = fileName;
+  book();
+}
+
+void MaterialBudgetMtdHistos::book() {
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetMtdHistos: Booking user histos";
+
+  // Material budget: radiation length
+  // total X0
+  hmgr->addHistoProf1(new TProfile("10", "MB prof Eta [Total];#eta;x/X_{0} ", 250, -5., 5.));
+  hmgr->addHisto1(new TH1F("11", "Eta ", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("20", "MB prof Phi [Total];#varphi [rad];x/X_{0} ", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("21", "Phi ", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("30", "MB prof Eta  Phi [Total];#eta;#varphi;x/X_{0} ", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("31", "Eta vs Phi ", 501, -5., 5., 180, -3.1416, 3.1416));
+
+  // Support
+  hmgr->addHistoProf1(new TProfile("110", "MB prof Eta [Support];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("111", "Eta [Support]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("120", "MB prof Phi [Support];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("121", "Phi [Support]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("130", "MB prof Eta  Phi [Support];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("131", "Eta vs Phi [Support]", 501, -5., 5., 180, -3.1416, 3.1416));
+
+  // Sensitive
+  hmgr->addHistoProf1(new TProfile("210", "MB prof Eta [Sensitive];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("211", "Eta [Sensitive]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("220", "MB prof Phi [Sensitive];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("221", "Phi [Sensitive]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("231", "Eta vs Phi [Sensitive]", 501, -5., 5., 180, -3.1416, 3.1416));
+
+  // Cables
+  hmgr->addHistoProf1(new TProfile("310", "MB prof Eta [Cables];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("311", "Eta [Cables]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("320", "MB prof Phi [Cables];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("321", "Phi [Cables]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("330", "MB prof Eta  Phi [Cables];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("331", "Eta vs Phi [Cables]", 501, -5., 5., 180, -3.1416, 3.1416));
+
+  // Cooling
+  hmgr->addHistoProf1(new TProfile("410", "MB prof Eta [Cooling];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("411", "Eta [Cooling]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("420", "MB prof Phi [Cooling];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("421", "Phi [Cooling]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("430", "MB prof Eta  Phi [Cooling];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("431", "Eta vs Phi [Cooling]", 501, -5., 5., 180, -3.1416, 3.1416));
+
+  // Electronics
+  hmgr->addHistoProf1(new TProfile("510", "MB prof Eta [Electronics];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("511", "Eta [Electronics]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("520", "MB prof Phi [Electronics];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("521", "Phi [Electronics]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("530", "MB prof Eta  Phi [Electronics];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("531", "Eta vs Phi [Electronics]", 501, -5., 5., 180, -3.1416, 3.1416));
+
+  // Other
+  hmgr->addHistoProf1(new TProfile("610", "MB prof Eta [Other];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("611", "Eta [Other]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("620", "MB prof Phi [Other];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("621", "Phi [Other]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("630", "MB prof Eta  Phi [Other];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("631", "Eta vs Phi [Other]", 501, -5., 5., 180, -3.1416, 3.1416));
+
+  // Material budget: interaction length
+  // total Lambda0
+  hmgr->addHistoProf1(new TProfile("1010", "MB prof Eta [Total];#eta;#lambda/#lambda_{0} ", 250, -5., 5.));
+  hmgr->addHisto1(new TH1F("1011", "Eta ", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1020", "MB prof Phi [Total];#varphi [rad];#lambda/#lambda_{0} ", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1021", "Phi ", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1030", "MB prof Eta  Phi [Total];#eta;#varphi;#lambda/#lambda_{0} ", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1031", "Eta vs Phi ", 501, -5., 5., 180, -3.1416, 3.1416));
+
+  // Support
+  hmgr->addHistoProf1(new TProfile("1110", "MB prof Eta [Support];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1111", "Eta [Support]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1120", "MB prof Phi [Support];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1121", "Phi [Support]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1130", "MB prof Eta  Phi [Support];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1131", "Eta vs Phi [Support]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1140", "MB prof R [Support];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+
+  // Sensitive
+  hmgr->addHistoProf1(new TProfile("1210", "MB prof Eta [Sensitive];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1211", "Eta [Sensitive]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1220", "MB prof Phi [Sensitive];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1221", "Phi [Sensitive]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1231", "Eta vs Phi [Sensitive]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1240", "MB prof R [Sensitive];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+
+  // Cables
+  hmgr->addHistoProf1(new TProfile("1310", "MB prof Eta [Cables];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1311", "Eta [Cables]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1320", "MB prof Phi [Cables];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1321", "Phi [Cables]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1330", "MB prof Eta  Phi [Cables];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1331", "Eta vs Phi [Cables]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1340", "MB prof R [Cables];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+
+  // Cooling
+  hmgr->addHistoProf1(new TProfile("1410", "MB prof Eta [Cooling];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1411", "Eta [Cooling]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1420", "MB prof Phi [Cooling];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1421", "Phi [Cooling]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1430", "MB prof Eta  Phi [Cooling];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1431", "Eta vs Phi [Cooling]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1440", "MB prof R [Cooling];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+
+  // Electronics
+  hmgr->addHistoProf1(new TProfile("1510", "MB prof Eta [Electronics];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1511", "Eta [Electronics]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1520", "MB prof Phi [Electronics];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1521", "Phi [Electronics]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1530", "MB prof Eta  Phi [Electronics];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1531", "Eta vs Phi [Electronics]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1540", "MB prof R [Electronics];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+
+  // Other
+  hmgr->addHistoProf1(new TProfile("1610", "MB prof Eta [Other];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1611", "Eta [Other]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1620", "MB prof Phi [Other];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1621", "Phi [Other]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1630", "MB prof Eta  Phi [Other];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1631", "Eta vs Phi [Other]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1640", "MB prof R [Other];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetMtdHistos: booking user histos done";
+}
+
+void MaterialBudgetMtdHistos::fillStartTrack() {}
+
+void MaterialBudgetMtdHistos::fillPerStep() {}
+
+void MaterialBudgetMtdHistos::fillEndTrack() {
+  // Total X0
+  hmgr->getHisto1(11)->Fill(theData->getEta());
+  hmgr->getHisto1(21)->Fill(theData->getPhi());
+  hmgr->getHisto2(31)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(10)->Fill(theData->getEta(), theData->getTotalMB());
+  hmgr->getHistoProf1(20)->Fill(theData->getPhi(), theData->getTotalMB());
+  hmgr->getHistoProf2(30)->Fill(theData->getEta(), theData->getPhi(), theData->getTotalMB());
+
+  // Support
+  hmgr->getHisto1(111)->Fill(theData->getEta());
+  hmgr->getHisto1(121)->Fill(theData->getPhi());
+  hmgr->getHisto2(131)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(110)->Fill(theData->getEta(), theData->getSupportMB());
+  hmgr->getHistoProf1(120)->Fill(theData->getPhi(), theData->getSupportMB());
+  hmgr->getHistoProf2(130)->Fill(theData->getEta(), theData->getPhi(), theData->getSupportMB());
+
+  // Sensitive
+  hmgr->getHisto1(211)->Fill(theData->getEta());
+  hmgr->getHisto1(221)->Fill(theData->getPhi());
+  hmgr->getHisto2(231)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(210)->Fill(theData->getEta(), theData->getSensitiveMB());
+  hmgr->getHistoProf1(220)->Fill(theData->getPhi(), theData->getSensitiveMB());
+  hmgr->getHistoProf2(230)->Fill(theData->getEta(), theData->getPhi(), theData->getSensitiveMB());
+
+  // Cables
+  hmgr->getHisto1(311)->Fill(theData->getEta());
+  hmgr->getHisto1(321)->Fill(theData->getPhi());
+  hmgr->getHisto2(331)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(310)->Fill(theData->getEta(), theData->getCablesMB());
+  hmgr->getHistoProf1(320)->Fill(theData->getPhi(), theData->getCablesMB());
+  hmgr->getHistoProf2(330)->Fill(theData->getEta(), theData->getPhi(), theData->getCablesMB());
+
+  // Cooling
+  hmgr->getHisto1(411)->Fill(theData->getEta());
+  hmgr->getHisto1(421)->Fill(theData->getPhi());
+  hmgr->getHisto2(431)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(410)->Fill(theData->getEta(), theData->getCoolingMB());
+  hmgr->getHistoProf1(420)->Fill(theData->getPhi(), theData->getCoolingMB());
+  hmgr->getHistoProf2(430)->Fill(theData->getEta(), theData->getPhi(), theData->getCoolingMB());
+
+  // Electronics
+  hmgr->getHisto1(511)->Fill(theData->getEta());
+  hmgr->getHisto1(521)->Fill(theData->getPhi());
+  hmgr->getHisto2(531)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(510)->Fill(theData->getEta(), theData->getElectronicsMB());
+  hmgr->getHistoProf1(520)->Fill(theData->getPhi(), theData->getElectronicsMB());
+  hmgr->getHistoProf2(530)->Fill(theData->getEta(), theData->getPhi(), theData->getElectronicsMB());
+
+  // Other
+  hmgr->getHisto1(611)->Fill(theData->getEta());
+  hmgr->getHisto1(621)->Fill(theData->getPhi());
+  hmgr->getHisto2(631)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(610)->Fill(theData->getEta(), theData->getOtherMB());
+  hmgr->getHistoProf1(620)->Fill(theData->getPhi(), theData->getOtherMB());
+  hmgr->getHistoProf2(630)->Fill(theData->getEta(), theData->getPhi(), theData->getOtherMB());
+
+  // Total Lambda0
+  hmgr->getHisto1(1011)->Fill(theData->getEta());
+  hmgr->getHisto1(1021)->Fill(theData->getPhi());
+  hmgr->getHisto2(1031)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(1010)->Fill(theData->getEta(), theData->getTotalIL());
+  hmgr->getHistoProf1(1020)->Fill(theData->getPhi(), theData->getTotalIL());
+  hmgr->getHistoProf2(1030)->Fill(theData->getEta(), theData->getPhi(), theData->getTotalIL());
+
+  // Support
+  hmgr->getHisto1(1111)->Fill(theData->getEta());
+  hmgr->getHisto1(1121)->Fill(theData->getPhi());
+  hmgr->getHisto2(1131)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(1110)->Fill(theData->getEta(), theData->getSupportIL());
+  hmgr->getHistoProf1(1120)->Fill(theData->getPhi(), theData->getSupportIL());
+  hmgr->getHistoProf2(1130)->Fill(theData->getEta(), theData->getPhi(), theData->getSupportIL());
+
+  // Sensitive
+  hmgr->getHisto1(1211)->Fill(theData->getEta());
+  hmgr->getHisto1(1221)->Fill(theData->getPhi());
+  hmgr->getHisto2(1231)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(1210)->Fill(theData->getEta(), theData->getSensitiveIL());
+  hmgr->getHistoProf1(1220)->Fill(theData->getPhi(), theData->getSensitiveIL());
+  hmgr->getHistoProf2(1230)->Fill(theData->getEta(), theData->getPhi(), theData->getSensitiveIL());
+
+  // Cables
+  hmgr->getHisto1(1311)->Fill(theData->getEta());
+  hmgr->getHisto1(1321)->Fill(theData->getPhi());
+  hmgr->getHisto2(1331)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(1310)->Fill(theData->getEta(), theData->getCablesIL());
+  hmgr->getHistoProf1(1320)->Fill(theData->getPhi(), theData->getCablesIL());
+  hmgr->getHistoProf2(1330)->Fill(theData->getEta(), theData->getPhi(), theData->getCablesIL());
+
+  // Cooling
+  hmgr->getHisto1(1411)->Fill(theData->getEta());
+  hmgr->getHisto1(1421)->Fill(theData->getPhi());
+  hmgr->getHisto2(1431)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(1410)->Fill(theData->getEta(), theData->getCoolingIL());
+  hmgr->getHistoProf1(1420)->Fill(theData->getPhi(), theData->getCoolingIL());
+  hmgr->getHistoProf2(1430)->Fill(theData->getEta(), theData->getPhi(), theData->getCoolingIL());
+
+  // Electronics
+  hmgr->getHisto1(1511)->Fill(theData->getEta());
+  hmgr->getHisto1(1521)->Fill(theData->getPhi());
+  hmgr->getHisto2(1531)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(1510)->Fill(theData->getEta(), theData->getElectronicsIL());
+  hmgr->getHistoProf1(1520)->Fill(theData->getPhi(), theData->getElectronicsIL());
+  hmgr->getHistoProf2(1530)->Fill(theData->getEta(), theData->getPhi(), theData->getElectronicsIL());
+
+  // Other
+  hmgr->getHisto1(1611)->Fill(theData->getEta());
+  hmgr->getHisto1(1621)->Fill(theData->getPhi());
+  hmgr->getHisto2(1631)->Fill(theData->getEta(), theData->getPhi());
+
+  hmgr->getHistoProf1(1610)->Fill(theData->getEta(), theData->getOtherIL());
+  hmgr->getHistoProf1(1620)->Fill(theData->getPhi(), theData->getOtherIL());
+  hmgr->getHistoProf2(1630)->Fill(theData->getEta(), theData->getPhi(), theData->getOtherIL());
+}
+
+void MaterialBudgetMtdHistos::endOfRun() {
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetMtdHistos: Writing histos ROOT file to:" << theFileName;
+  hmgr->save(theFileName);
+}

--- a/Validation/Geometry/src/MaterialBudgetTrackerHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetTrackerHistos.cc
@@ -1,23 +1,20 @@
 #include "Validation/Geometry/interface/MaterialBudgetTrackerHistos.h"
 #include "Validation/Geometry/interface/MaterialBudgetData.h"
 
-template <class T> const T& max ( const T& a, const T& b ) {
-  return (b<a)?a:b;     // or: return comp(b,a)?a:b; for the comp version
+template <class T>
+const T& max(const T& a, const T& b) {
+  return (b < a) ? a : b;  // or: return comp(b,a)?a:b; for the comp version
 }
 
 MaterialBudgetTrackerHistos::MaterialBudgetTrackerHistos(std::shared_ptr<MaterialBudgetData> data,
-							 std::shared_ptr<TestHistoMgr> mgr,
-							 const std::string& fileName )
-  : MaterialBudgetFormat( data ), 
-    hmgr(mgr)
-{
+                                                         std::shared_ptr<TestHistoMgr> mgr,
+                                                         const std::string& fileName)
+    : MaterialBudgetFormat(data), hmgr(mgr) {
   theFileName = fileName;
   book();
 }
 
-
-void MaterialBudgetTrackerHistos::book() 
-{
+void MaterialBudgetTrackerHistos::book() {
   edm::LogInfo("MaterialBudget") << " MaterialBudgetTrackerHistos: Booking Histos";
 
   // Parameters for 2D histograms
@@ -27,321 +24,364 @@ void MaterialBudgetTrackerHistos::book()
   int nrbin = 290;
   float rMin = -50.;
   float rMax = 1400.;
-  
+
   // total X0
-  hmgr->addHistoProf1( new TProfile("10", "MB prof Eta [Total];#eta;x/X_{0} ", 250, -5., 5. ) );
-  hmgr->addHisto1( new TH1F("11", "Eta " , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("20", "MB prof Phi [Total];#varphi [rad];x/X_{0} ", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("21", "Phi " , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("30", "MB prof Eta  Phi [Total];#eta;#varphi;x/X_{0} ", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("31", "Eta vs Phi " , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("40", "MB prof R [Total];R [mm];x/X_{0} ", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("41", "R " , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("50", "MB prof sum R  z [Total];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("999", "Tot track length for MB", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("51", "R vs z " , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("60", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("61", "R vs z " , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  
+  hmgr->addHistoProf1(new TProfile("10", "MB prof Eta [Total];#eta;x/X_{0} ", 250, -5., 5.));
+  hmgr->addHisto1(new TH1F("11", "Eta ", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("20", "MB prof Phi [Total];#varphi [rad];x/X_{0} ", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("21", "Phi ", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("30", "MB prof Eta  Phi [Total];#eta;#varphi;x/X_{0} ", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("31", "Eta vs Phi ", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("40", "MB prof R [Total];R [mm];x/X_{0} ", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("41", "R ", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("50", "MB prof sum R  z [Total];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("999", "Tot track length for MB", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("51", "R vs z ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("60", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("61", "R vs z ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+
   // Support
-  hmgr->addHistoProf1( new TProfile("110", "MB prof Eta [Support];#eta;x/X_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("111", "Eta [Support]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("120", "MB prof Phi [Support];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("121", "Phi [Support]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("130", "MB prof Eta  Phi [Support];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("131", "Eta vs Phi [Support]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("140", "MB prof R [Support];R [mm];x/X_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("141", "R [Support]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("150", "MB prof sum R  z [Support];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("151", "R vs z [Support]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("160", "MB prof local R  z [Support];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("161", "R vs z [Support]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("110", "MB prof Eta [Support];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("111", "Eta [Support]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("120", "MB prof Phi [Support];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("121", "Phi [Support]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("130", "MB prof Eta  Phi [Support];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("131", "Eta vs Phi [Support]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("140", "MB prof R [Support];R [mm];x/X_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("141", "R [Support]", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("150", "MB prof sum R  z [Support];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("151", "R vs z [Support]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("160", "MB prof local R  z [Support];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("161", "R vs z [Support]", nzbin, zMin, zMax, nrbin, rMin, rMax));
 
   // Sensitive
-  hmgr->addHistoProf1( new TProfile("210", "MB prof Eta [Sensitive];#eta;x/X_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("211", "Eta [Sensitive]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("220", "MB prof Phi [Sensitive];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("221", "Phi [Sensitive]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("231", "Eta vs Phi [Sensitive]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("240", "MB prof R [Sensitive];R [mm];x/X_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("241", "R [Sensitive]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("250", "MB prof sum R  z [Sensitive];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("251", "R vs z [Sensitive]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("260", "MB prof local R  z [Sensitive];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("261", "R vs z [Sensitive]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("210", "MB prof Eta [Sensitive];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("211", "Eta [Sensitive]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("220", "MB prof Phi [Sensitive];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("221", "Phi [Sensitive]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("231", "Eta vs Phi [Sensitive]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("240", "MB prof R [Sensitive];R [mm];x/X_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("241", "R [Sensitive]", 200, 0., 2000.));
+  hmgr->addHistoProf2(new TProfile2D(
+      "250", "MB prof sum R  z [Sensitive];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("251", "R vs z [Sensitive]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("260", "MB prof local R  z [Sensitive];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("261", "R vs z [Sensitive]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Cables
-  hmgr->addHistoProf1( new TProfile("310", "MB prof Eta [Cables];#eta;x/X_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("311", "Eta [Cables]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("320", "MB prof Phi [Cables];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("321", "Phi [Cables]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("330", "MB prof Eta  Phi [Cables];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("331", "Eta vs Phi [Cables]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("340", "MB prof R [Cables];R [mm];x/X_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("341", "R [Cables]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("350", "MB prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("351", "R vs z [Cables]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("360", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("361", "R vs z [Cables]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("310", "MB prof Eta [Cables];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("311", "Eta [Cables]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("320", "MB prof Phi [Cables];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("321", "Phi [Cables]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("330", "MB prof Eta  Phi [Cables];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("331", "Eta vs Phi [Cables]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("340", "MB prof R [Cables];R [mm];x/X_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("341", "R [Cables]", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("350", "MB prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("351", "R vs z [Cables]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("360", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("361", "R vs z [Cables]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Cooling
-  hmgr->addHistoProf1( new TProfile("410", "MB prof Eta [Cooling];#eta;x/X_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("411", "Eta [Cooling]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("420", "MB prof Phi [Cooling];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("421", "Phi [Cooling]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("430", "MB prof Eta  Phi [Cooling];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("431", "Eta vs Phi [Cooling]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("440", "MB prof R [Cooling];R [mm];x/X_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("441", "R [Cooling]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("450", "MB prof sum R  z [Cooling];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("451", "R vs z [Cooling]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("460", "MB prof local R  z [Cooling];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("461", "R vs z [Cooling]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("410", "MB prof Eta [Cooling];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("411", "Eta [Cooling]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("420", "MB prof Phi [Cooling];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("421", "Phi [Cooling]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("430", "MB prof Eta  Phi [Cooling];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("431", "Eta vs Phi [Cooling]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("440", "MB prof R [Cooling];R [mm];x/X_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("441", "R [Cooling]", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("450", "MB prof sum R  z [Cooling];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("451", "R vs z [Cooling]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("460", "MB prof local R  z [Cooling];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("461", "R vs z [Cooling]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Electronics
-  hmgr->addHistoProf1( new TProfile("510", "MB prof Eta [Electronics];#eta;x/X_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("511", "Eta [Electronics]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("520", "MB prof Phi [Electronics];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("521", "Phi [Electronics]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("530", "MB prof Eta  Phi [Electronics];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("531", "Eta vs Phi [Electronics]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("540", "MB prof R [Electronics];R [mm];x/X_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("541", "R [Electronics]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("550", "MB prof sum R  z [Electronics];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("551", "R vs z [Electronics]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("560", "MB prof local R  z [Electronics];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("561", "R vs z [Electronics]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("510", "MB prof Eta [Electronics];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("511", "Eta [Electronics]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("520", "MB prof Phi [Electronics];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("521", "Phi [Electronics]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("530", "MB prof Eta  Phi [Electronics];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("531", "Eta vs Phi [Electronics]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("540", "MB prof R [Electronics];R [mm];x/X_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("541", "R [Electronics]", 200, 0., 2000.));
+  hmgr->addHistoProf2(new TProfile2D(
+      "550", "MB prof sum R  z [Electronics];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("551", "R vs z [Electronics]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("560", "MB prof local R  z [Electronics];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("561", "R vs z [Electronics]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Other
-  hmgr->addHistoProf1( new TProfile("610", "MB prof Eta [Other];#eta;x/X_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("611", "Eta [Other]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("620", "MB prof Phi [Other];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("621", "Phi [Other]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("630", "MB prof Eta  Phi [Other];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("631", "Eta vs Phi [Other]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("640", "MB prof R [Other];R [mm];x/X_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("641", "R [Other]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("650", "MB prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("651", "R vs z [Other]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("660", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("661", "R vs z [Other]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("610", "MB prof Eta [Other];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("611", "Eta [Other]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("620", "MB prof Phi [Other];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("621", "Phi [Other]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("630", "MB prof Eta  Phi [Other];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("631", "Eta vs Phi [Other]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("640", "MB prof R [Other];R [mm];x/X_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("641", "R [Other]", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("650", "MB prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("651", "R vs z [Other]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("660", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("661", "R vs z [Other]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Air
-  hmgr->addHistoProf1( new TProfile("710", "MB prof Eta [Air];#eta;x/X_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("711", "Eta [Air]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("720", "MB prof Phi [Air];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("721", "Phi [Air]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("730", "MB prof Eta  Phi [Air];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("731", "Eta vs Phi [Air]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("740", "MB prof R [Air];R [mm];x/X_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("741", "R [Air]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("750", "MB prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("751", "R vs z [Air]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("760", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("761", "R vs z [Air]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("710", "MB prof Eta [Air];#eta;x/X_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("711", "Eta [Air]", 501, -5., 5.));
+  hmgr->addHistoProf1(new TProfile("720", "MB prof Phi [Air];#varphi [rad];x/X_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("721", "Phi [Air]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(
+      new TProfile2D("730", "MB prof Eta  Phi [Air];#eta;#varphi;x/X_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("731", "Eta vs Phi [Air]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("740", "MB prof R [Air];R [mm];x/X_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("741", "R [Air]", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("750", "MB prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("751", "R vs z [Air]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("760", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("761", "R vs z [Air]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   //
-  
+
   // total Lambda0
-  hmgr->addHistoProf1( new TProfile("1010", "MB prof Eta [Total];#eta;#lambda/#lambda_{0} ", 250, -5., 5. ) );
-  hmgr->addHisto1( new TH1F("1011", "Eta " , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("1020", "MB prof Phi [Total];#varphi [rad];#lambda/#lambda_{0} ", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("1021", "Phi " , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("1030", "MB prof Eta  Phi [Total];#eta;#varphi;#lambda/#lambda_{0} ", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("1031", "Eta vs Phi " , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  
+  hmgr->addHistoProf1(new TProfile("1010", "MB prof Eta [Total];#eta;#lambda/#lambda_{0} ", 250, -5., 5.));
+  hmgr->addHisto1(new TH1F("1011", "Eta ", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1020", "MB prof Phi [Total];#varphi [rad];#lambda/#lambda_{0} ", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1021", "Phi ", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1030", "MB prof Eta  Phi [Total];#eta;#varphi;#lambda/#lambda_{0} ", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1031", "Eta vs Phi ", 501, -5., 5., 180, -3.1416, 3.1416));
+
   // rr
-  hmgr->addHistoProf1( new TProfile("1040", "MB prof R [Total];R [mm];#lambda/#lambda_{0} ", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("1041", "R " , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("1050", "MB prof sum R  z [Total];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1999", "Tot track length for l0", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1051", "R vs z " , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1060", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1061", "R vs z " , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  
+  hmgr->addHistoProf1(new TProfile("1040", "MB prof R [Total];R [mm];#lambda/#lambda_{0} ", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("1041", "R ", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("1050", "MB prof sum R  z [Total];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1999", "Tot track length for l0", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1051", "R vs z ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1060", "MB prof local R  z;z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1061", "R vs z ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+
   // Support
-  hmgr->addHistoProf1( new TProfile("1110", "MB prof Eta [Support];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("1111", "Eta [Support]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("1120", "MB prof Phi [Support];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("1121", "Phi [Support]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("1130", "MB prof Eta  Phi [Support];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("1131", "Eta vs Phi [Support]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("1140", "MB prof R [Support];R [mm];#lambda/#lambda_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("1141", "R [Support]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("1150", "MB prof sum R  z [Support];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1151", "R vs z [Support]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1160", "MB prof local R  z [Support];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1161", "R vs z [Support]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1110", "MB prof Eta [Support];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1111", "Eta [Support]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1120", "MB prof Phi [Support];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1121", "Phi [Support]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1130", "MB prof Eta  Phi [Support];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1131", "Eta vs Phi [Support]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1140", "MB prof R [Support];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("1141", "R [Support]", 200, 0., 2000.));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1150", "MB prof sum R  z [Support];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1151", "R vs z [Support]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1160", "MB prof local R  z [Support];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1161", "R vs z [Support]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Sensitive
-  hmgr->addHistoProf1( new TProfile("1210", "MB prof Eta [Sensitive];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("1211", "Eta [Sensitive]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("1220", "MB prof Phi [Sensitive];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("1221", "Phi [Sensitive]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("1230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("1231", "Eta vs Phi [Sensitive]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("1240", "MB prof R [Sensitive];R [mm];#lambda/#lambda_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("1241", "R [Sensitive]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("1250", "MB prof sum R  z [Sensitive];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1251", "R vs z [Sensitive]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1260", "MB prof local R  z [Sensitive];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1261", "R vs z [Sensitive]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1210", "MB prof Eta [Sensitive];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1211", "Eta [Sensitive]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1220", "MB prof Phi [Sensitive];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1221", "Phi [Sensitive]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1230", "MB prof Eta  Phi [Sensitive];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1231", "Eta vs Phi [Sensitive]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1240", "MB prof R [Sensitive];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("1241", "R [Sensitive]", 200, 0., 2000.));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1250", "MB prof sum R  z [Sensitive];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1251", "R vs z [Sensitive]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1260", "MB prof local R  z [Sensitive];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1261", "R vs z [Sensitive]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Cables
-  hmgr->addHistoProf1( new TProfile("1310", "MB prof Eta [Cables];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("1311", "Eta [Cables]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("1320", "MB prof Phi [Cables];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("1321", "Phi [Cables]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("1330", "MB prof Eta  Phi [Cables];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("1331", "Eta vs Phi [Cables]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("1340", "MB prof R [Cables];R [mm];#lambda/#lambda_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("1341", "R [Cables]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("1350", "MB prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1351", "R vs z [Cables]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1360", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1361", "R vs z [Cables]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1310", "MB prof Eta [Cables];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1311", "Eta [Cables]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1320", "MB prof Phi [Cables];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1321", "Phi [Cables]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1330", "MB prof Eta  Phi [Cables];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1331", "Eta vs Phi [Cables]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1340", "MB prof R [Cables];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("1341", "R [Cables]", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("1350", "MB prof sum R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1351", "R vs z [Cables]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1360", "MB prof local R  z [Cables];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1361", "R vs z [Cables]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Cooling
-  hmgr->addHistoProf1( new TProfile("1410", "MB prof Eta [Cooling];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("1411", "Eta [Cooling]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("1420", "MB prof Phi [Cooling];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("1421", "Phi [Cooling]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("1430", "MB prof Eta  Phi [Cooling];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("1431", "Eta vs Phi [Cooling]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("1440", "MB prof R [Cooling];R [mm];#lambda/#lambda_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("1441", "R [Cooling]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("1450", "MB prof sum R  z [Cooling];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1451", "R vs z [Cooling]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1460", "MB prof local R  z [Cooling];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1461", "R vs z [Cooling]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1410", "MB prof Eta [Cooling];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1411", "Eta [Cooling]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1420", "MB prof Phi [Cooling];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1421", "Phi [Cooling]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1430", "MB prof Eta  Phi [Cooling];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1431", "Eta vs Phi [Cooling]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1440", "MB prof R [Cooling];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("1441", "R [Cooling]", 200, 0., 2000.));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1450", "MB prof sum R  z [Cooling];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1451", "R vs z [Cooling]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1460", "MB prof local R  z [Cooling];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1461", "R vs z [Cooling]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Electronics
-  hmgr->addHistoProf1( new TProfile("1510", "MB prof Eta [Electronics];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("1511", "Eta [Electronics]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("1520", "MB prof Phi [Electronics];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("1521", "Phi [Electronics]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("1530", "MB prof Eta  Phi [Electronics];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("1531", "Eta vs Phi [Electronics]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("1540", "MB prof R [Electronics];R [mm];#lambda/#lambda_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("1541", "R [Electronics]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("1550", "MB prof sum R  z [Electronics];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1551", "R vs z [Electronics]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1560", "MB prof local R  z [Electronics];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1561", "R vs z [Electronics]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1510", "MB prof Eta [Electronics];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1511", "Eta [Electronics]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1520", "MB prof Phi [Electronics];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1521", "Phi [Electronics]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1530", "MB prof Eta  Phi [Electronics];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1531", "Eta vs Phi [Electronics]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1540", "MB prof R [Electronics];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("1541", "R [Electronics]", 200, 0., 2000.));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1550", "MB prof sum R  z [Electronics];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1551", "R vs z [Electronics]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F(
+      "1560", "MB prof local R  z [Electronics];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1561", "R vs z [Electronics]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Other
-  hmgr->addHistoProf1( new TProfile("1610", "MB prof Eta [Other];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("1611", "Eta [Other]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("1620", "MB prof Phi [Other];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("1621", "Phi [Other]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("1630", "MB prof Eta  Phi [Other];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("1631", "Eta vs Phi [Other]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("1640", "MB prof R [Other];R [mm];#lambda/#lambda_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("1641", "R [Other]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("1650", "MB prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1651", "R vs z [Other]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1660", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1661", "R vs z [Other]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1610", "MB prof Eta [Other];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1611", "Eta [Other]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1620", "MB prof Phi [Other];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1621", "Phi [Other]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1630", "MB prof Eta  Phi [Other];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1631", "Eta vs Phi [Other]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1640", "MB prof R [Other];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("1641", "R [Other]", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("1650", "MB prof sum R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1651", "R vs z [Other]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1660", "MB prof local R  z [Other];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1661", "R vs z [Other]", nzbin, zMin, zMax, nrbin, rMin, rMax));
   // Air
-  hmgr->addHistoProf1( new TProfile("1710", "MB prof Eta [Air];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0 ) );
-  hmgr->addHisto1( new TH1F("1711", "Eta [Air]" , 501, -5., 5. ) );
-  hmgr->addHistoProf1( new TProfile("1720", "MB prof Phi [Air];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto1( new TH1F("1721", "Phi [Air]" , 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf2( new TProfile2D("1730", "MB prof Eta  Phi [Air];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHisto2( new TH2F("1731", "Eta vs Phi [Air]" , 501, -5., 5., 180, -3.1416, 3.1416 ) );
-  hmgr->addHistoProf1( new TProfile("1740", "MB prof R [Air];R [mm];#lambda/#lambda_{0}", 200, 0., 2000. ) );
-  hmgr->addHisto1( new TH1F("1741", "R [Air]" , 200, 0., 2000. ) );
-  hmgr->addHistoProf2( new TProfile2D("1750", "MB prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1751", "R vs z [Air]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1760", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax ) );
-  hmgr->addHisto2( new TH2F("1761", "R vs z [Air]" , nzbin, zMin, zMax, nrbin, rMin, rMax ) );
+  hmgr->addHistoProf1(new TProfile("1710", "MB prof Eta [Air];#eta;#lambda/#lambda_{0}", 250, -5.0, 5.0));
+  hmgr->addHisto1(new TH1F("1711", "Eta [Air]", 501, -5., 5.));
+  hmgr->addHistoProf1(
+      new TProfile("1720", "MB prof Phi [Air];#varphi [rad];#lambda/#lambda_{0}", 180, -3.1416, 3.1416));
+  hmgr->addHisto1(new TH1F("1721", "Phi [Air]", 180, -3.1416, 3.1416));
+  hmgr->addHistoProf2(new TProfile2D(
+      "1730", "MB prof Eta  Phi [Air];#eta;#varphi;#lambda/#lambda_{0}", 250, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHisto2(new TH2F("1731", "Eta vs Phi [Air]", 501, -5., 5., 180, -3.1416, 3.1416));
+  hmgr->addHistoProf1(new TProfile("1740", "MB prof R [Air];R [mm];#lambda/#lambda_{0}", 200, 0., 2000.));
+  hmgr->addHisto1(new TH1F("1741", "R [Air]", 200, 0., 2000.));
+  hmgr->addHistoProf2(
+      new TProfile2D("1750", "MB prof sum R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1751", "R vs z [Air]", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(
+      new TH2F("1760", "MB prof local R  z [Air];z [mm];R [mm];x/X_{0} ", nzbin, zMin, zMax, nrbin, rMin, rMax));
+  hmgr->addHisto2(new TH2F("1761", "R vs z [Air]", nzbin, zMin, zMax, nrbin, rMin, rMax));
 }
 
+void MaterialBudgetTrackerHistos::fillStartTrack() {}
 
-void MaterialBudgetTrackerHistos::fillStartTrack()
-{
+void MaterialBudgetTrackerHistos::fillPerStep() {}
 
-}
-
-
-void MaterialBudgetTrackerHistos::fillPerStep()
-{
-
-}
-
-
-void MaterialBudgetTrackerHistos::fillEndTrack()
-{
+void MaterialBudgetTrackerHistos::fillEndTrack() {
   //
   // fill histograms and profiles only if the material has been crossed
   //
-  
-  if( theData->getNumberOfSteps() != 0 ) {
-    
+
+  if (theData->getNumberOfSteps() != 0) {
     // Total X0
     hmgr->getHisto1(11)->Fill(theData->getEta());
     hmgr->getHisto1(21)->Fill(theData->getPhi());
-    hmgr->getHisto2(31)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(10)->Fill(theData->getEta(),theData->getTotalMB());
-    hmgr->getHistoProf1(20)->Fill(theData->getPhi(),theData->getTotalMB());
-    hmgr->getHistoProf2(30)->Fill(theData->getEta(),theData->getPhi(),theData->getTotalMB());
-    
+    hmgr->getHisto2(31)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(10)->Fill(theData->getEta(), theData->getTotalMB());
+    hmgr->getHistoProf1(20)->Fill(theData->getPhi(), theData->getTotalMB());
+    hmgr->getHistoProf2(30)->Fill(theData->getEta(), theData->getPhi(), theData->getTotalMB());
+
     // rr
-    
+
     // Support
     hmgr->getHisto1(111)->Fill(theData->getEta());
     hmgr->getHisto1(121)->Fill(theData->getPhi());
-    hmgr->getHisto2(131)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(110)->Fill(theData->getEta(),theData->getSupportMB());
-    hmgr->getHistoProf1(120)->Fill(theData->getPhi(),theData->getSupportMB());
-    hmgr->getHistoProf2(130)->Fill(theData->getEta(),theData->getPhi(),theData->getSupportMB());
-    
+    hmgr->getHisto2(131)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(110)->Fill(theData->getEta(), theData->getSupportMB());
+    hmgr->getHistoProf1(120)->Fill(theData->getPhi(), theData->getSupportMB());
+    hmgr->getHistoProf2(130)->Fill(theData->getEta(), theData->getPhi(), theData->getSupportMB());
+
     // Sensitive
     hmgr->getHisto1(211)->Fill(theData->getEta());
     hmgr->getHisto1(221)->Fill(theData->getPhi());
-    hmgr->getHisto2(231)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(210)->Fill(theData->getEta(),theData->getSensitiveMB());
-    hmgr->getHistoProf1(220)->Fill(theData->getPhi(),theData->getSensitiveMB());
-    hmgr->getHistoProf2(230)->Fill(theData->getEta(),theData->getPhi(),theData->getSensitiveMB());
-    
+    hmgr->getHisto2(231)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(210)->Fill(theData->getEta(), theData->getSensitiveMB());
+    hmgr->getHistoProf1(220)->Fill(theData->getPhi(), theData->getSensitiveMB());
+    hmgr->getHistoProf2(230)->Fill(theData->getEta(), theData->getPhi(), theData->getSensitiveMB());
+
     // Cables
     hmgr->getHisto1(311)->Fill(theData->getEta());
     hmgr->getHisto1(321)->Fill(theData->getPhi());
-    hmgr->getHisto2(331)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(310)->Fill(theData->getEta(),theData->getCablesMB());
-    hmgr->getHistoProf1(320)->Fill(theData->getPhi(),theData->getCablesMB());
-    hmgr->getHistoProf2(330)->Fill(theData->getEta(),theData->getPhi(),theData->getCablesMB());
-    
+    hmgr->getHisto2(331)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(310)->Fill(theData->getEta(), theData->getCablesMB());
+    hmgr->getHistoProf1(320)->Fill(theData->getPhi(), theData->getCablesMB());
+    hmgr->getHistoProf2(330)->Fill(theData->getEta(), theData->getPhi(), theData->getCablesMB());
+
     // Cooling
     hmgr->getHisto1(411)->Fill(theData->getEta());
     hmgr->getHisto1(421)->Fill(theData->getPhi());
-    hmgr->getHisto2(431)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(410)->Fill(theData->getEta(),theData->getCoolingMB());
-    hmgr->getHistoProf1(420)->Fill(theData->getPhi(),theData->getCoolingMB());
-    hmgr->getHistoProf2(430)->Fill(theData->getEta(),theData->getPhi(),theData->getCoolingMB());
-    
+    hmgr->getHisto2(431)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(410)->Fill(theData->getEta(), theData->getCoolingMB());
+    hmgr->getHistoProf1(420)->Fill(theData->getPhi(), theData->getCoolingMB());
+    hmgr->getHistoProf2(430)->Fill(theData->getEta(), theData->getPhi(), theData->getCoolingMB());
+
     // Electronics
     hmgr->getHisto1(511)->Fill(theData->getEta());
     hmgr->getHisto1(521)->Fill(theData->getPhi());
-    hmgr->getHisto2(531)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(510)->Fill(theData->getEta(),theData->getElectronicsMB());
-    hmgr->getHistoProf1(520)->Fill(theData->getPhi(),theData->getElectronicsMB());
-    hmgr->getHistoProf2(530)->Fill(theData->getEta(),theData->getPhi(),theData->getElectronicsMB());
-    
+    hmgr->getHisto2(531)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(510)->Fill(theData->getEta(), theData->getElectronicsMB());
+    hmgr->getHistoProf1(520)->Fill(theData->getPhi(), theData->getElectronicsMB());
+    hmgr->getHistoProf2(530)->Fill(theData->getEta(), theData->getPhi(), theData->getElectronicsMB());
+
     // Other
     hmgr->getHisto1(611)->Fill(theData->getEta());
     hmgr->getHisto1(621)->Fill(theData->getPhi());
-    hmgr->getHisto2(631)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(610)->Fill(theData->getEta(),theData->getOtherMB());
-    hmgr->getHistoProf1(620)->Fill(theData->getPhi(),theData->getOtherMB());
-    hmgr->getHistoProf2(630)->Fill(theData->getEta(),theData->getPhi(),theData->getOtherMB());
-    
+    hmgr->getHisto2(631)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(610)->Fill(theData->getEta(), theData->getOtherMB());
+    hmgr->getHistoProf1(620)->Fill(theData->getPhi(), theData->getOtherMB());
+    hmgr->getHistoProf2(630)->Fill(theData->getEta(), theData->getPhi(), theData->getOtherMB());
+
     // Air
     hmgr->getHisto1(711)->Fill(theData->getEta());
     hmgr->getHisto1(721)->Fill(theData->getPhi());
-    hmgr->getHisto2(731)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(710)->Fill(theData->getEta(),theData->getAirMB());
-    hmgr->getHistoProf1(720)->Fill(theData->getPhi(),theData->getAirMB());
-    hmgr->getHistoProf2(730)->Fill(theData->getEta(),theData->getPhi(),theData->getAirMB());
-    
+    hmgr->getHisto2(731)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(710)->Fill(theData->getEta(), theData->getAirMB());
+    hmgr->getHistoProf1(720)->Fill(theData->getPhi(), theData->getAirMB());
+    hmgr->getHistoProf2(730)->Fill(theData->getEta(), theData->getPhi(), theData->getAirMB());
+
     //
     // Compute the total x/X0 crossed at each step radius for each path
     //
@@ -354,7 +394,7 @@ void MaterialBudgetTrackerHistos::fillEndTrack()
     float theTotalMB_ELE = 0.0;
     float theTotalMB_OTH = 0.0;
     float theTotalMB_AIR = 0.0;
-    for(int iStep = 0; iStep < theData->getNumberOfSteps(); iStep++) {
+    for (int iStep = 0; iStep < theData->getNumberOfSteps(); iStep++) {
       theTotalMB_TOT += theData->getStepDmb(iStep);
       theTotalMB_SUP += theData->getSupportDmb(iStep);
       theTotalMB_SEN += theData->getSensitiveDmb(iStep);
@@ -362,7 +402,7 @@ void MaterialBudgetTrackerHistos::fillEndTrack()
       theTotalMB_COL += theData->getCoolingDmb(iStep);
       theTotalMB_ELE += theData->getElectronicsDmb(iStep);
       theTotalMB_OTH += theData->getOtherDmb(iStep);
-      theTotalMB_AIR += theData->getAirDmb(iStep);        
+      theTotalMB_AIR += theData->getAirDmb(iStep);
 
       int iSup = 0;
       int iSen = 0;
@@ -371,110 +411,112 @@ void MaterialBudgetTrackerHistos::fillEndTrack()
       int iEle = 0;
       int iOth = 0;
       int iAir = 0;
-      if( theData->getSupportDmb(iStep)>0.     ) { iSup = 1; }
-      if( theData->getSensitiveDmb(iStep)>0.   ) { iSen = 1; }
-      if( theData->getCablesDmb(iStep)>0.      ) { iCab = 1; }
-      if( theData->getCoolingDmb(iStep)>0.     ) { iCol = 1; }
-      if( theData->getElectronicsDmb(iStep)>0. ) { iEle = 1; }
-      if( theData->getOtherDmb(iStep)>0.       ) { iOth = 1; }
-      if( theData->getAirDmb(iStep)>0.         ) { iAir = 1; }
+      if (theData->getSupportDmb(iStep) > 0.) {
+        iSup = 1;
+      }
+      if (theData->getSensitiveDmb(iStep) > 0.) {
+        iSen = 1;
+      }
+      if (theData->getCablesDmb(iStep) > 0.) {
+        iCab = 1;
+      }
+      if (theData->getCoolingDmb(iStep) > 0.) {
+        iCol = 1;
+      }
+      if (theData->getElectronicsDmb(iStep) > 0.) {
+        iEle = 1;
+      }
+      if (theData->getOtherDmb(iStep) > 0.) {
+        iOth = 1;
+      }
+      if (theData->getAirDmb(iStep) > 0.) {
+        iAir = 1;
+      }
 
-      float deltaRadius = sqrt(
-			       pow( theData->getStepFinalX(iStep)-theData->getStepInitialX(iStep),2 )
-			       +
-			       pow( theData->getStepFinalY(iStep)-theData->getStepInitialY(iStep),2 )
-			       );
-      float deltaz = theData->getStepFinalZ(iStep)-theData->getStepInitialZ(iStep) ;
-      
+      float deltaRadius = sqrt(pow(theData->getStepFinalX(iStep) - theData->getStepInitialX(iStep), 2) +
+                               pow(theData->getStepFinalY(iStep) - theData->getStepInitialY(iStep), 2));
+      float deltaz = theData->getStepFinalZ(iStep) - theData->getStepInitialZ(iStep);
+
       float x0 = theData->getStepMaterialX0(iStep);
 
       int nSubStep = 2;
       float boxWidth = 0.1;
-      if( (deltaRadius>boxWidth) || (fabs(deltaz)>boxWidth) ) {
-	nSubStep = static_cast<int>(max(
-		       ceil(deltaRadius/boxWidth/2.)*2,
-		       ceil(fabs(deltaz)/boxWidth/2.)*2
-		       ));
+      if ((deltaRadius > boxWidth) || (fabs(deltaz) > boxWidth)) {
+        nSubStep = static_cast<int>(max(ceil(deltaRadius / boxWidth / 2.) * 2, ceil(fabs(deltaz) / boxWidth / 2.) * 2));
       }
-      
-      for(int iSubStep = 1; iSubStep < nSubStep; iSubStep+=2) {
 
-	float subdeltaRadius = deltaRadius/nSubStep;
-	float polarRadius = sqrt(
-				 pow( theData->getStepInitialX(iStep),2 )
-				 +
-				 pow( theData->getStepInitialY(iStep),2 )
-				 ) + iSubStep*subdeltaRadius;
+      for (int iSubStep = 1; iSubStep < nSubStep; iSubStep += 2) {
+        float subdeltaRadius = deltaRadius / nSubStep;
+        float polarRadius = sqrt(pow(theData->getStepInitialX(iStep), 2) + pow(theData->getStepInitialY(iStep), 2)) +
+                            iSubStep * subdeltaRadius;
 
-	float subdeltaz = deltaz/nSubStep;
-	float z = theData->getStepInitialZ(iStep) + iSubStep*subdeltaz;
+        float subdeltaz = deltaz / nSubStep;
+        float z = theData->getStepInitialZ(iStep) + iSubStep * subdeltaz;
 
-	float subdelta = sqrt(
-			      pow ( subdeltaRadius,2 ) + pow( subdeltaz,2 )
-			      );
+        float subdelta = sqrt(pow(subdeltaRadius, 2) + pow(subdeltaz, 2));
 
-	float fillValue=subdelta/x0;
+        float fillValue = subdelta / x0;
 
-	//
-	// Average length
-	hmgr->getHisto2(999)->Fill(z,polarRadius,subdelta);
-	// Total
-	hmgr->getHisto1(41)->Fill(polarRadius);
-	hmgr->getHistoProf1(40)->Fill(polarRadius,theTotalMB_TOT);
-	hmgr->getHisto2(51)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(50)->Fill(z,polarRadius,theTotalMB_TOT);
-	hmgr->getHisto2(61)->Fill(z,polarRadius);
-	hmgr->getHisto2(60)->Fill(z,polarRadius,fillValue);
-	// Support
-	hmgr->getHisto1(141)->Fill(polarRadius);
-	hmgr->getHistoProf1(140)->Fill(polarRadius,theTotalMB_SUP);
-	hmgr->getHisto2(151)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(150)->Fill(z,polarRadius,theTotalMB_SUP);
-	hmgr->getHisto2(161)->Fill(z,polarRadius);
-	hmgr->getHisto2(160)->Fill(z,polarRadius,iSup*fillValue);
-	// Sensitive
-	hmgr->getHisto1(241)->Fill(polarRadius);
-	hmgr->getHistoProf1(240)->Fill(polarRadius,theTotalMB_SEN);
-	hmgr->getHisto2(251)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(250)->Fill(z,polarRadius,theTotalMB_SEN);
-	hmgr->getHisto2(261)->Fill(z,polarRadius);
-	hmgr->getHisto2(260)->Fill(z,polarRadius,iSen*fillValue);
-	// Cables
-	hmgr->getHisto1(341)->Fill(polarRadius);
-	hmgr->getHistoProf1(340)->Fill(polarRadius,theTotalMB_CAB);
-	hmgr->getHisto2(351)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(350)->Fill(z,polarRadius,theTotalMB_CAB);
-	hmgr->getHisto2(361)->Fill(z,polarRadius);
-	hmgr->getHisto2(360)->Fill(z,polarRadius,iCab*fillValue);
-	// Cooling
-	hmgr->getHisto1(441)->Fill(polarRadius);
-	hmgr->getHistoProf1(440)->Fill(polarRadius,theTotalMB_COL);
-	hmgr->getHisto2(451)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(450)->Fill(z,polarRadius,theTotalMB_COL);
-	hmgr->getHisto2(461)->Fill(z,polarRadius);
-	hmgr->getHisto2(460)->Fill(z,polarRadius,iCol*fillValue);
-	// Electronics
-	hmgr->getHisto1(541)->Fill(polarRadius);
-	hmgr->getHistoProf1(540)->Fill(polarRadius,theTotalMB_ELE);
-	hmgr->getHisto2(551)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(550)->Fill(z,polarRadius,theTotalMB_ELE);
-	hmgr->getHisto2(561)->Fill(z,polarRadius);
-	hmgr->getHisto2(560)->Fill(z,polarRadius,iEle*fillValue);
-	// Other
-	hmgr->getHisto1(641)->Fill(polarRadius);
-	hmgr->getHistoProf1(640)->Fill(polarRadius,theTotalMB_OTH);
-	hmgr->getHisto2(651)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(650)->Fill(z,polarRadius,theTotalMB_OTH);
-	hmgr->getHisto2(661)->Fill(z,polarRadius);
-	hmgr->getHisto2(660)->Fill(z,polarRadius,iOth*fillValue);
-	// Air
-	hmgr->getHisto1(741)->Fill(polarRadius);
-	hmgr->getHistoProf1(740)->Fill(polarRadius,theTotalMB_AIR);
-	hmgr->getHisto2(751)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(750)->Fill(z,polarRadius,theTotalMB_AIR);
-	hmgr->getHisto2(761)->Fill(z,polarRadius);
-	hmgr->getHisto2(760)->Fill(z,polarRadius,iAir*fillValue);
-	//
+        //
+        // Average length
+        hmgr->getHisto2(999)->Fill(z, polarRadius, subdelta);
+        // Total
+        hmgr->getHisto1(41)->Fill(polarRadius);
+        hmgr->getHistoProf1(40)->Fill(polarRadius, theTotalMB_TOT);
+        hmgr->getHisto2(51)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(50)->Fill(z, polarRadius, theTotalMB_TOT);
+        hmgr->getHisto2(61)->Fill(z, polarRadius);
+        hmgr->getHisto2(60)->Fill(z, polarRadius, fillValue);
+        // Support
+        hmgr->getHisto1(141)->Fill(polarRadius);
+        hmgr->getHistoProf1(140)->Fill(polarRadius, theTotalMB_SUP);
+        hmgr->getHisto2(151)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(150)->Fill(z, polarRadius, theTotalMB_SUP);
+        hmgr->getHisto2(161)->Fill(z, polarRadius);
+        hmgr->getHisto2(160)->Fill(z, polarRadius, iSup * fillValue);
+        // Sensitive
+        hmgr->getHisto1(241)->Fill(polarRadius);
+        hmgr->getHistoProf1(240)->Fill(polarRadius, theTotalMB_SEN);
+        hmgr->getHisto2(251)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(250)->Fill(z, polarRadius, theTotalMB_SEN);
+        hmgr->getHisto2(261)->Fill(z, polarRadius);
+        hmgr->getHisto2(260)->Fill(z, polarRadius, iSen * fillValue);
+        // Cables
+        hmgr->getHisto1(341)->Fill(polarRadius);
+        hmgr->getHistoProf1(340)->Fill(polarRadius, theTotalMB_CAB);
+        hmgr->getHisto2(351)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(350)->Fill(z, polarRadius, theTotalMB_CAB);
+        hmgr->getHisto2(361)->Fill(z, polarRadius);
+        hmgr->getHisto2(360)->Fill(z, polarRadius, iCab * fillValue);
+        // Cooling
+        hmgr->getHisto1(441)->Fill(polarRadius);
+        hmgr->getHistoProf1(440)->Fill(polarRadius, theTotalMB_COL);
+        hmgr->getHisto2(451)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(450)->Fill(z, polarRadius, theTotalMB_COL);
+        hmgr->getHisto2(461)->Fill(z, polarRadius);
+        hmgr->getHisto2(460)->Fill(z, polarRadius, iCol * fillValue);
+        // Electronics
+        hmgr->getHisto1(541)->Fill(polarRadius);
+        hmgr->getHistoProf1(540)->Fill(polarRadius, theTotalMB_ELE);
+        hmgr->getHisto2(551)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(550)->Fill(z, polarRadius, theTotalMB_ELE);
+        hmgr->getHisto2(561)->Fill(z, polarRadius);
+        hmgr->getHisto2(560)->Fill(z, polarRadius, iEle * fillValue);
+        // Other
+        hmgr->getHisto1(641)->Fill(polarRadius);
+        hmgr->getHistoProf1(640)->Fill(polarRadius, theTotalMB_OTH);
+        hmgr->getHisto2(651)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(650)->Fill(z, polarRadius, theTotalMB_OTH);
+        hmgr->getHisto2(661)->Fill(z, polarRadius);
+        hmgr->getHisto2(660)->Fill(z, polarRadius, iOth * fillValue);
+        // Air
+        hmgr->getHisto1(741)->Fill(polarRadius);
+        hmgr->getHistoProf1(740)->Fill(polarRadius, theTotalMB_AIR);
+        hmgr->getHisto2(751)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(750)->Fill(z, polarRadius, theTotalMB_AIR);
+        hmgr->getHisto2(761)->Fill(z, polarRadius);
+        hmgr->getHisto2(760)->Fill(z, polarRadius, iAir * fillValue);
+        //
       }
     }
     //
@@ -484,79 +526,78 @@ void MaterialBudgetTrackerHistos::fillEndTrack()
     //
     //
 
-    
     // Total Lambda0
     hmgr->getHisto1(1011)->Fill(theData->getEta());
     hmgr->getHisto1(1021)->Fill(theData->getPhi());
-    hmgr->getHisto2(1031)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(1010)->Fill(theData->getEta(),theData->getTotalIL());
-    hmgr->getHistoProf1(1020)->Fill(theData->getPhi(),theData->getTotalIL());
-    hmgr->getHistoProf2(1030)->Fill(theData->getEta(),theData->getPhi(),theData->getTotalIL());
-    
+    hmgr->getHisto2(1031)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(1010)->Fill(theData->getEta(), theData->getTotalIL());
+    hmgr->getHistoProf1(1020)->Fill(theData->getPhi(), theData->getTotalIL());
+    hmgr->getHistoProf2(1030)->Fill(theData->getEta(), theData->getPhi(), theData->getTotalIL());
+
     // Support
     hmgr->getHisto1(1111)->Fill(theData->getEta());
     hmgr->getHisto1(1121)->Fill(theData->getPhi());
-    hmgr->getHisto2(1131)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(1110)->Fill(theData->getEta(),theData->getSupportIL());
-    hmgr->getHistoProf1(1120)->Fill(theData->getPhi(),theData->getSupportIL());
-    hmgr->getHistoProf2(1130)->Fill(theData->getEta(),theData->getPhi(),theData->getSupportIL());
-    
+    hmgr->getHisto2(1131)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(1110)->Fill(theData->getEta(), theData->getSupportIL());
+    hmgr->getHistoProf1(1120)->Fill(theData->getPhi(), theData->getSupportIL());
+    hmgr->getHistoProf2(1130)->Fill(theData->getEta(), theData->getPhi(), theData->getSupportIL());
+
     // Sensitive
     hmgr->getHisto1(1211)->Fill(theData->getEta());
     hmgr->getHisto1(1221)->Fill(theData->getPhi());
-    hmgr->getHisto2(1231)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(1210)->Fill(theData->getEta(),theData->getSensitiveIL());
-    hmgr->getHistoProf1(1220)->Fill(theData->getPhi(),theData->getSensitiveIL());
-    hmgr->getHistoProf2(1230)->Fill(theData->getEta(),theData->getPhi(),theData->getSensitiveIL());
-    
+    hmgr->getHisto2(1231)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(1210)->Fill(theData->getEta(), theData->getSensitiveIL());
+    hmgr->getHistoProf1(1220)->Fill(theData->getPhi(), theData->getSensitiveIL());
+    hmgr->getHistoProf2(1230)->Fill(theData->getEta(), theData->getPhi(), theData->getSensitiveIL());
+
     // Cables
     hmgr->getHisto1(1311)->Fill(theData->getEta());
     hmgr->getHisto1(1321)->Fill(theData->getPhi());
-    hmgr->getHisto2(1331)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(1310)->Fill(theData->getEta(),theData->getCablesIL());
-    hmgr->getHistoProf1(1320)->Fill(theData->getPhi(),theData->getCablesIL());
-    hmgr->getHistoProf2(1330)->Fill(theData->getEta(),theData->getPhi(),theData->getCablesIL());
-    
+    hmgr->getHisto2(1331)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(1310)->Fill(theData->getEta(), theData->getCablesIL());
+    hmgr->getHistoProf1(1320)->Fill(theData->getPhi(), theData->getCablesIL());
+    hmgr->getHistoProf2(1330)->Fill(theData->getEta(), theData->getPhi(), theData->getCablesIL());
+
     // Cooling
     hmgr->getHisto1(1411)->Fill(theData->getEta());
     hmgr->getHisto1(1421)->Fill(theData->getPhi());
-    hmgr->getHisto2(1431)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(1410)->Fill(theData->getEta(),theData->getCoolingIL());
-    hmgr->getHistoProf1(1420)->Fill(theData->getPhi(),theData->getCoolingIL());
-    hmgr->getHistoProf2(1430)->Fill(theData->getEta(),theData->getPhi(),theData->getCoolingIL());
-    
+    hmgr->getHisto2(1431)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(1410)->Fill(theData->getEta(), theData->getCoolingIL());
+    hmgr->getHistoProf1(1420)->Fill(theData->getPhi(), theData->getCoolingIL());
+    hmgr->getHistoProf2(1430)->Fill(theData->getEta(), theData->getPhi(), theData->getCoolingIL());
+
     // Electronics
     hmgr->getHisto1(1511)->Fill(theData->getEta());
     hmgr->getHisto1(1521)->Fill(theData->getPhi());
-    hmgr->getHisto2(1531)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(1510)->Fill(theData->getEta(),theData->getElectronicsIL());
-    hmgr->getHistoProf1(1520)->Fill(theData->getPhi(),theData->getElectronicsIL());
-    hmgr->getHistoProf2(1530)->Fill(theData->getEta(),theData->getPhi(),theData->getElectronicsIL());
-    
+    hmgr->getHisto2(1531)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(1510)->Fill(theData->getEta(), theData->getElectronicsIL());
+    hmgr->getHistoProf1(1520)->Fill(theData->getPhi(), theData->getElectronicsIL());
+    hmgr->getHistoProf2(1530)->Fill(theData->getEta(), theData->getPhi(), theData->getElectronicsIL());
+
     // Other
     hmgr->getHisto1(1611)->Fill(theData->getEta());
     hmgr->getHisto1(1621)->Fill(theData->getPhi());
-    hmgr->getHisto2(1631)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(1610)->Fill(theData->getEta(),theData->getOtherIL());
-    hmgr->getHistoProf1(1620)->Fill(theData->getPhi(),theData->getOtherIL());
-    hmgr->getHistoProf2(1630)->Fill(theData->getEta(),theData->getPhi(),theData->getOtherIL());
-    
+    hmgr->getHisto2(1631)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(1610)->Fill(theData->getEta(), theData->getOtherIL());
+    hmgr->getHistoProf1(1620)->Fill(theData->getPhi(), theData->getOtherIL());
+    hmgr->getHistoProf2(1630)->Fill(theData->getEta(), theData->getPhi(), theData->getOtherIL());
+
     // Air
     hmgr->getHisto1(1711)->Fill(theData->getEta());
     hmgr->getHisto1(1721)->Fill(theData->getPhi());
-    hmgr->getHisto2(1731)->Fill(theData->getEta(),theData->getPhi());
-    
-    hmgr->getHistoProf1(1710)->Fill(theData->getEta(),theData->getAirIL());
-    hmgr->getHistoProf1(1720)->Fill(theData->getPhi(),theData->getAirIL());
-    hmgr->getHistoProf2(1730)->Fill(theData->getEta(),theData->getPhi(),theData->getAirIL());
-    
+    hmgr->getHisto2(1731)->Fill(theData->getEta(), theData->getPhi());
+
+    hmgr->getHistoProf1(1710)->Fill(theData->getEta(), theData->getAirIL());
+    hmgr->getHistoProf1(1720)->Fill(theData->getPhi(), theData->getAirIL());
+    hmgr->getHistoProf2(1730)->Fill(theData->getEta(), theData->getPhi(), theData->getAirIL());
+
     // Compute the total l/l0 crossed at each step radius for each path
     float theTotalIL_TOT = 0.0;
     float theTotalIL_SUP = 0.0;
@@ -566,7 +607,7 @@ void MaterialBudgetTrackerHistos::fillEndTrack()
     float theTotalIL_ELE = 0.0;
     float theTotalIL_OTH = 0.0;
     float theTotalIL_AIR = 0.0;
-    for(int iStep = 0; iStep < theData->getNumberOfSteps(); iStep++) {
+    for (int iStep = 0; iStep < theData->getNumberOfSteps(); iStep++) {
       theTotalIL_TOT += theData->getStepDil(iStep);
       theTotalIL_SUP += theData->getSupportDil(iStep);
       theTotalIL_SEN += theData->getSensitiveDil(iStep);
@@ -583,129 +624,125 @@ void MaterialBudgetTrackerHistos::fillEndTrack()
       int iEle = 0;
       int iOth = 0;
       int iAir = 0;
-      if( theData->getSupportDil(iStep)>0.     ) { iSup = 1; }
-      if( theData->getSensitiveDil(iStep)>0.   ) { iSen = 1; }
-      if( theData->getCablesDil(iStep)>0.      ) { iCab = 1; }
-      if( theData->getCoolingDil(iStep)>0.     ) { iCol = 1; }
-      if( theData->getElectronicsDil(iStep)>0. ) { iEle = 1; }
-      if( theData->getOtherDil(iStep)>0.       ) { iOth = 1; }
-      if( theData->getAirDil(iStep)>0.         ) { iAir = 1; }
+      if (theData->getSupportDil(iStep) > 0.) {
+        iSup = 1;
+      }
+      if (theData->getSensitiveDil(iStep) > 0.) {
+        iSen = 1;
+      }
+      if (theData->getCablesDil(iStep) > 0.) {
+        iCab = 1;
+      }
+      if (theData->getCoolingDil(iStep) > 0.) {
+        iCol = 1;
+      }
+      if (theData->getElectronicsDil(iStep) > 0.) {
+        iEle = 1;
+      }
+      if (theData->getOtherDil(iStep) > 0.) {
+        iOth = 1;
+      }
+      if (theData->getAirDil(iStep) > 0.) {
+        iAir = 1;
+      }
 
-      float deltaRadius = sqrt(
-			       pow( theData->getStepFinalX(iStep)-theData->getStepInitialX(iStep),2 )
-			       +
-			       pow( theData->getStepFinalY(iStep)-theData->getStepInitialY(iStep),2 )
-			       );
-      float deltaz = theData->getStepFinalZ(iStep)-theData->getStepInitialZ(iStep) ;
-      
+      float deltaRadius = sqrt(pow(theData->getStepFinalX(iStep) - theData->getStepInitialX(iStep), 2) +
+                               pow(theData->getStepFinalY(iStep) - theData->getStepInitialY(iStep), 2));
+      float deltaz = theData->getStepFinalZ(iStep) - theData->getStepInitialZ(iStep);
+
       float il = theData->getStepMaterialLambda0(iStep);
 
       int nSubStep = 2;
       float boxWidth = 0.1;
-      if( (deltaRadius>boxWidth) || (fabs(deltaz)>boxWidth) ) {
-	nSubStep = static_cast<int>(max(
-		       ceil(deltaRadius/boxWidth/2.)*2,
-		       ceil(fabs(deltaz)/boxWidth/2.)*2
-		       ));
-      }
-      
-      for(int iSubStep = 1; iSubStep < nSubStep; iSubStep+=2) {
-
-	float subdeltaRadius = deltaRadius/nSubStep;
-	float polarRadius = sqrt(
-				 pow( theData->getStepInitialX(iStep),2 )
-				 +
-				 pow( theData->getStepInitialY(iStep),2 )
-				 ) + iSubStep*subdeltaRadius;
-
-	float subdeltaz = deltaz/nSubStep;
-	float z = theData->getStepInitialZ(iStep) + iSubStep*subdeltaz;
-
-	float subdelta = sqrt(
-			      pow ( subdeltaRadius,2 ) + pow( subdeltaz,2 )
-			      );
-
-	float fillValue=subdelta/il;
-
-	//
-	// Average length
-	hmgr->getHisto2(1999)->Fill(z,polarRadius,subdelta);
-	// Total
-	hmgr->getHisto1(1041)->Fill(polarRadius);
-	hmgr->getHistoProf1(1040)->Fill(polarRadius,theTotalIL_TOT);
-	hmgr->getHisto2(1051)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(1050)->Fill(z,polarRadius,theTotalIL_TOT);
-	hmgr->getHisto2(1061)->Fill(z,polarRadius);
-	hmgr->getHisto2(1060)->Fill(z,polarRadius,fillValue);
-	// Support
-	hmgr->getHisto1(1141)->Fill(polarRadius);
-	hmgr->getHistoProf1(1140)->Fill(polarRadius,theTotalIL_SUP);
-	hmgr->getHisto2(1151)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(1150)->Fill(z,polarRadius,theTotalIL_SUP);
-	hmgr->getHisto2(1161)->Fill(z,polarRadius);
-	hmgr->getHisto2(1160)->Fill(z,polarRadius,iSup*fillValue);
-	// Sensitive
-	hmgr->getHisto1(1241)->Fill(polarRadius);
-	hmgr->getHistoProf1(1240)->Fill(polarRadius,theTotalIL_SEN);
-	hmgr->getHisto2(1251)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(1250)->Fill(z,polarRadius,theTotalIL_SEN);
-	hmgr->getHisto2(1261)->Fill(z,polarRadius);
-	hmgr->getHisto2(1260)->Fill(z,polarRadius,iSen*fillValue);
-	// Cables
-	hmgr->getHisto1(1341)->Fill(polarRadius);
-	hmgr->getHistoProf1(1340)->Fill(polarRadius,theTotalIL_CAB);
-	hmgr->getHisto2(1351)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(1350)->Fill(z,polarRadius,theTotalIL_CAB);
-	hmgr->getHisto2(1361)->Fill(z,polarRadius);
-	hmgr->getHisto2(1360)->Fill(z,polarRadius,iCab*fillValue);
-	// Cooling
-	hmgr->getHisto1(1441)->Fill(polarRadius);
-	hmgr->getHistoProf1(1440)->Fill(polarRadius,theTotalIL_COL);
-	hmgr->getHisto2(1451)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(1450)->Fill(z,polarRadius,theTotalIL_COL);
-	hmgr->getHisto2(1461)->Fill(z,polarRadius);
-	hmgr->getHisto2(1460)->Fill(z,polarRadius,iCol*fillValue);
-	// Electronics
-	hmgr->getHisto1(1541)->Fill(polarRadius);
-	hmgr->getHistoProf1(1540)->Fill(polarRadius,theTotalIL_ELE);
-	hmgr->getHisto2(1551)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(1550)->Fill(z,polarRadius,theTotalIL_ELE);
-	hmgr->getHisto2(1561)->Fill(z,polarRadius);
-	hmgr->getHisto2(1560)->Fill(z,polarRadius,iEle*fillValue);
-	// Other
-	hmgr->getHisto1(1641)->Fill(polarRadius);
-	hmgr->getHistoProf1(1640)->Fill(polarRadius,theTotalIL_OTH);
-	hmgr->getHisto2(1651)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(1650)->Fill(z,polarRadius,theTotalIL_OTH);
-	hmgr->getHisto2(1661)->Fill(z,polarRadius);
-	hmgr->getHisto2(1660)->Fill(z,polarRadius,iOth*fillValue);
-	// Air
-	hmgr->getHisto1(1741)->Fill(polarRadius);
-	hmgr->getHistoProf1(1740)->Fill(polarRadius,theTotalIL_AIR);
-	hmgr->getHisto2(1751)->Fill(z,polarRadius);
-	hmgr->getHistoProf2(1750)->Fill(z,polarRadius,theTotalIL_AIR);
-	hmgr->getHisto2(1761)->Fill(z,polarRadius);
-	hmgr->getHisto2(1760)->Fill(z,polarRadius,iAir*fillValue);
-	//
+      if ((deltaRadius > boxWidth) || (fabs(deltaz) > boxWidth)) {
+        nSubStep = static_cast<int>(max(ceil(deltaRadius / boxWidth / 2.) * 2, ceil(fabs(deltaz) / boxWidth / 2.) * 2));
       }
 
+      for (int iSubStep = 1; iSubStep < nSubStep; iSubStep += 2) {
+        float subdeltaRadius = deltaRadius / nSubStep;
+        float polarRadius = sqrt(pow(theData->getStepInitialX(iStep), 2) + pow(theData->getStepInitialY(iStep), 2)) +
+                            iSubStep * subdeltaRadius;
+
+        float subdeltaz = deltaz / nSubStep;
+        float z = theData->getStepInitialZ(iStep) + iSubStep * subdeltaz;
+
+        float subdelta = sqrt(pow(subdeltaRadius, 2) + pow(subdeltaz, 2));
+
+        float fillValue = subdelta / il;
+
+        //
+        // Average length
+        hmgr->getHisto2(1999)->Fill(z, polarRadius, subdelta);
+        // Total
+        hmgr->getHisto1(1041)->Fill(polarRadius);
+        hmgr->getHistoProf1(1040)->Fill(polarRadius, theTotalIL_TOT);
+        hmgr->getHisto2(1051)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(1050)->Fill(z, polarRadius, theTotalIL_TOT);
+        hmgr->getHisto2(1061)->Fill(z, polarRadius);
+        hmgr->getHisto2(1060)->Fill(z, polarRadius, fillValue);
+        // Support
+        hmgr->getHisto1(1141)->Fill(polarRadius);
+        hmgr->getHistoProf1(1140)->Fill(polarRadius, theTotalIL_SUP);
+        hmgr->getHisto2(1151)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(1150)->Fill(z, polarRadius, theTotalIL_SUP);
+        hmgr->getHisto2(1161)->Fill(z, polarRadius);
+        hmgr->getHisto2(1160)->Fill(z, polarRadius, iSup * fillValue);
+        // Sensitive
+        hmgr->getHisto1(1241)->Fill(polarRadius);
+        hmgr->getHistoProf1(1240)->Fill(polarRadius, theTotalIL_SEN);
+        hmgr->getHisto2(1251)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(1250)->Fill(z, polarRadius, theTotalIL_SEN);
+        hmgr->getHisto2(1261)->Fill(z, polarRadius);
+        hmgr->getHisto2(1260)->Fill(z, polarRadius, iSen * fillValue);
+        // Cables
+        hmgr->getHisto1(1341)->Fill(polarRadius);
+        hmgr->getHistoProf1(1340)->Fill(polarRadius, theTotalIL_CAB);
+        hmgr->getHisto2(1351)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(1350)->Fill(z, polarRadius, theTotalIL_CAB);
+        hmgr->getHisto2(1361)->Fill(z, polarRadius);
+        hmgr->getHisto2(1360)->Fill(z, polarRadius, iCab * fillValue);
+        // Cooling
+        hmgr->getHisto1(1441)->Fill(polarRadius);
+        hmgr->getHistoProf1(1440)->Fill(polarRadius, theTotalIL_COL);
+        hmgr->getHisto2(1451)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(1450)->Fill(z, polarRadius, theTotalIL_COL);
+        hmgr->getHisto2(1461)->Fill(z, polarRadius);
+        hmgr->getHisto2(1460)->Fill(z, polarRadius, iCol * fillValue);
+        // Electronics
+        hmgr->getHisto1(1541)->Fill(polarRadius);
+        hmgr->getHistoProf1(1540)->Fill(polarRadius, theTotalIL_ELE);
+        hmgr->getHisto2(1551)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(1550)->Fill(z, polarRadius, theTotalIL_ELE);
+        hmgr->getHisto2(1561)->Fill(z, polarRadius);
+        hmgr->getHisto2(1560)->Fill(z, polarRadius, iEle * fillValue);
+        // Other
+        hmgr->getHisto1(1641)->Fill(polarRadius);
+        hmgr->getHistoProf1(1640)->Fill(polarRadius, theTotalIL_OTH);
+        hmgr->getHisto2(1651)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(1650)->Fill(z, polarRadius, theTotalIL_OTH);
+        hmgr->getHisto2(1661)->Fill(z, polarRadius);
+        hmgr->getHisto2(1660)->Fill(z, polarRadius, iOth * fillValue);
+        // Air
+        hmgr->getHisto1(1741)->Fill(polarRadius);
+        hmgr->getHistoProf1(1740)->Fill(polarRadius, theTotalIL_AIR);
+        hmgr->getHisto2(1751)->Fill(z, polarRadius);
+        hmgr->getHistoProf2(1750)->Fill(z, polarRadius, theTotalIL_AIR);
+        hmgr->getHisto2(1761)->Fill(z, polarRadius);
+        hmgr->getHisto2(1760)->Fill(z, polarRadius, iAir * fillValue);
+        //
+      }
     }
-    
+
     // rr
   } else {
-    edm::LogWarning("MaterialBudget") 
-      << "MaterialBudgetTrackerHistos: This event is out of the acceptance:" 
-      << "eta = "      << theData->getEta()
-      << "\t phi = "   << theData->getPhi()
-      << "\t x/X0 = "  << theData->getTotalMB()
-      << "\t l/l0 = "  << theData->getTotalIL()
-      << "\t steps = " << theData->getNumberOfSteps();
+    edm::LogWarning("MaterialBudget") << "MaterialBudgetTrackerHistos: This event is out of the acceptance:"
+                                      << "eta = " << theData->getEta() << "\t phi = " << theData->getPhi()
+                                      << "\t x/X0 = " << theData->getTotalMB() << "\t l/l0 = " << theData->getTotalIL()
+                                      << "\t steps = " << theData->getNumberOfSteps();
   }
 }
 
-void MaterialBudgetTrackerHistos::endOfRun()
-{
-
+void MaterialBudgetTrackerHistos::endOfRun() {
   // Prefered method to include any instruction
   // once all the tracks are done
 
@@ -717,7 +754,7 @@ void MaterialBudgetTrackerHistos::endOfRun()
   hmgr->getHisto2(560)->Divide(hmgr->getHisto2(999));
   hmgr->getHisto2(660)->Divide(hmgr->getHisto2(999));
   hmgr->getHisto2(760)->Divide(hmgr->getHisto2(999));
-  
+
   hmgr->getHisto2(160)->Divide(hmgr->getHisto2(1999));
   hmgr->getHisto2(1160)->Divide(hmgr->getHisto2(1999));
   hmgr->getHisto2(1260)->Divide(hmgr->getHisto2(1999));
@@ -726,8 +763,7 @@ void MaterialBudgetTrackerHistos::endOfRun()
   hmgr->getHisto2(1560)->Divide(hmgr->getHisto2(1999));
   hmgr->getHisto2(1660)->Divide(hmgr->getHisto2(1999));
   hmgr->getHisto2(1760)->Divide(hmgr->getHisto2(1999));
-  
-  edm::LogInfo("MaterialBudget") << "MaterialBudgetTrackerHistos: Saving Histograms to: " << theFileName;
-  hmgr->save( theFileName );
 
+  edm::LogInfo("MaterialBudget") << "MaterialBudgetTrackerHistos: Saving Histograms to: " << theFileName;
+  hmgr->save(theFileName);
 }

--- a/Validation/Geometry/src/MaterialBudgetTree.cc
+++ b/Validation/Geometry/src/MaterialBudgetTree.cc
@@ -3,35 +3,31 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
-MaterialBudgetTree::MaterialBudgetTree(std::shared_ptr<MaterialBudgetData> data, const std::string& filename )
-  : MaterialBudgetFormat( data )
-{
-  theFile = std::make_unique<TFile>(filename.c_str(),"RECREATE");
+MaterialBudgetTree::MaterialBudgetTree(std::shared_ptr<MaterialBudgetData> data, const std::string& filename)
+    : MaterialBudgetFormat(data) {
+  theFile = std::make_unique<TFile>(filename.c_str(), "RECREATE");
   theFile->cd();
   book();
 }
 
-
-void MaterialBudgetTree::book() 
-{
+void MaterialBudgetTree::book() {
   LogDebug("MaterialBudget") << "MaterialBudgetTree: Booking user TTree";
   // create the TTree
-  theTree = std::make_unique<TTree>("T1","GeometryTest Tree");
+  theTree = std::make_unique<TTree>("T1", "GeometryTest Tree");
 
   // GENERAL block
   theTree->Branch("MB", &t_MB, "MB/F");
   theTree->Branch("IL", &t_IL, "IL/F");
-  
+
   // PARTICLE Block
-  theTree->Branch( "Particle ID",     &t_ParticleID,     "Particle_ID/I"  );
-  theTree->Branch( "Particle Pt",     &t_ParticlePt,     "Particle_Pt/F"  );
-  theTree->Branch( "Particle Eta",    &t_ParticleEta,    "Particle_Eta/F" );
-  theTree->Branch( "Particle Phi",    &t_ParticlePhi,    "Particle_Phi/F" );
-  theTree->Branch( "Particle Energy", &t_ParticleEnergy, "Particle_E/F"   );
-  theTree->Branch( "Particle Mass",   &t_ParticleMass,   "Particle_M/F"   );
-  
-  if( theData->allStepsON() ) {
+  theTree->Branch("Particle ID", &t_ParticleID, "Particle_ID/I");
+  theTree->Branch("Particle Pt", &t_ParticlePt, "Particle_Pt/F");
+  theTree->Branch("Particle Eta", &t_ParticleEta, "Particle_Eta/F");
+  theTree->Branch("Particle Phi", &t_ParticlePhi, "Particle_Phi/F");
+  theTree->Branch("Particle Energy", &t_ParticleEnergy, "Particle_E/F");
+  theTree->Branch("Particle Mass", &t_ParticleMass, "Particle_M/F");
+
+  if (theData->allStepsON()) {
     theTree->Branch("Nsteps", &t_Nsteps, "Nsteps/I");
     theTree->Branch("DeltaMB", t_DeltaMB, "DeltaMB[Nsteps]/F");
     theTree->Branch("DeltaMB_SUP", t_DeltaMB_SUP, "DeltaMB_SUP[Nsteps]/F");
@@ -55,16 +51,16 @@ void MaterialBudgetTree::book()
     theTree->Branch("Initial Y", t_InitialY, "Initial_Y[Nsteps]/D");
     theTree->Branch("Initial Z", t_InitialZ, "Initial_Z[Nsteps]/D");
 
-    theTree->Branch("Final X",   t_FinalX,   "Final_X[Nsteps]/D");
-    theTree->Branch("Final Y",   t_FinalY,   "Final_Y[Nsteps]/D");
-    theTree->Branch("Final Z",   t_FinalZ,   "Final_Z[Nsteps]/D");
+    theTree->Branch("Final X", t_FinalX, "Final_X[Nsteps]/D");
+    theTree->Branch("Final Y", t_FinalY, "Final_Y[Nsteps]/D");
+    theTree->Branch("Final Z", t_FinalZ, "Final_Z[Nsteps]/D");
 
-    theTree->Branch("Volume ID",       t_VolumeID,     "VolumeID[Nsteps]/I");
-    theTree->Branch("Volume Name",     t_VolumeName,   "VolumeName[Nsteps]/C");
-    theTree->Branch("Volume Copy",     t_VolumeCopy,   "VolumeCopy[Nsteps]/I");
-    theTree->Branch("Volume X",        t_VolumeX,      "VolumeX[Nsteps]/F");
-    theTree->Branch("Volume Y",        t_VolumeY,      "VolumeY[Nsteps]/F");
-    theTree->Branch("Volume Z",        t_VolumeZ,      "VolumeZ[Nsteps]/F");
+    theTree->Branch("Volume ID", t_VolumeID, "VolumeID[Nsteps]/I");
+    theTree->Branch("Volume Name", t_VolumeName, "VolumeName[Nsteps]/C");
+    theTree->Branch("Volume Copy", t_VolumeCopy, "VolumeCopy[Nsteps]/I");
+    theTree->Branch("Volume X", t_VolumeX, "VolumeX[Nsteps]/F");
+    theTree->Branch("Volume Y", t_VolumeY, "VolumeY[Nsteps]/F");
+    theTree->Branch("Volume Z", t_VolumeZ, "VolumeZ[Nsteps]/F");
     theTree->Branch("Volume X axis 1", t_VolumeXaxis1, "VolumeXaxis1[Nsteps]/F");
     theTree->Branch("Volume X axis 2", t_VolumeXaxis2, "VolumeXaxis2[Nsteps]/F");
     theTree->Branch("Volume X axis 3", t_VolumeXaxis3, "VolumeXaxis3[Nsteps]/F");
@@ -74,79 +70,67 @@ void MaterialBudgetTree::book()
     theTree->Branch("Volume Z axis 1", t_VolumeZaxis1, "VolumeZaxis1[Nsteps]/F");
     theTree->Branch("Volume Z axis 2", t_VolumeZaxis2, "VolumeZaxis2[Nsteps]/F");
     theTree->Branch("Volume Z axis 3", t_VolumeZaxis3, "VolumeZaxis3[Nsteps]/F");
-    
-    theTree->Branch("Material ID",      t_MaterialID,      "MaterialID[Nsteps]/I");
-    theTree->Branch("Material Name",    t_MaterialName,    "MaterialName[Nsteps]/C");
-    theTree->Branch("Material X0",      t_MaterialX0,      "MaterialX0[Nsteps]/F");
+
+    theTree->Branch("Material ID", t_MaterialID, "MaterialID[Nsteps]/I");
+    theTree->Branch("Material Name", t_MaterialName, "MaterialName[Nsteps]/C");
+    theTree->Branch("Material X0", t_MaterialX0, "MaterialX0[Nsteps]/F");
     theTree->Branch("Material Lambda0", t_MaterialLambda0, "MaterialLambda0[Nsteps]/F");
     theTree->Branch("Material Density", t_MaterialDensity, "MaterialDensity[Nsteps]/F");
-    
-    theTree->Branch("Particle Step ID",               t_ParticleStepID,              "Step_ID[Nsteps]/I");
-    theTree->Branch("Particle Step Initial Pt",       t_ParticleStepInitialPt,       "Step_Initial_Pt[Nsteps]/F");
-    theTree->Branch("Particle Step Initial Eta",      t_ParticleStepInitialEta,      "Step_Initial_Eta[Nsteps]/F");
-    theTree->Branch("Particle Step Initial Phi",      t_ParticleStepInitialPhi,      "Step_Initial_Phi[Nsteps]/F");
-    theTree->Branch("Particle Step Initial Energy",   t_ParticleStepInitialEnergy,   "Step_Initial_E[Nsteps]/F");
-    theTree->Branch("Particle Step Initial Px",       t_ParticleStepInitialPx,       "Step_Initial_Px[Nsteps]/F");
-    theTree->Branch("Particle Step Initial Py",       t_ParticleStepInitialPy,       "Step_Initial_Py[Nsteps]/F");
-    theTree->Branch("Particle Step Initial Pz",       t_ParticleStepInitialPz,       "Step_Initial_Pz[Nsteps]/F");
-    theTree->Branch("Particle Step Initial Beta",     t_ParticleStepInitialBeta,     "Step_Initial_Beta[Nsteps]/F");
-    theTree->Branch("Particle Step Initial Gamma",    t_ParticleStepInitialGamma,    "Step_Initial_Gamma[Nsteps]/F");
-    theTree->Branch("Particle Step Initial Mass",     t_ParticleStepInitialMass,     "Step_Initial_Mass[Nsteps]/F");
-    theTree->Branch("Particle Step Final Pt",         t_ParticleStepFinalPt,         "Step_Final_Pt[Nsteps]/F");
-    theTree->Branch("Particle Step Final Eta",        t_ParticleStepFinalEta,        "Step_Final_Eta[Nsteps]/F");
-    theTree->Branch("Particle Step Final Phi",        t_ParticleStepFinalPhi,        "Step_Final_Phi[Nsteps]/F");
-    theTree->Branch("Particle Step Final Energy",     t_ParticleStepFinalEnergy,     "Step_Final_E[Nsteps]/F");
-    theTree->Branch("Particle Step Final Px",         t_ParticleStepFinalPx,         "Step_Final_Px[Nsteps]/F");
-    theTree->Branch("Particle Step Final Py",         t_ParticleStepFinalPy,         "Step_Final_Py[Nsteps]/F");
-    theTree->Branch("Particle Step Final Pz",         t_ParticleStepFinalPz,         "Step_Final_Pz[Nsteps]/F");
-    theTree->Branch("Particle Step Final Beta",       t_ParticleStepFinalBeta,       "Step_Final_Beta[Nsteps]/F");
-    theTree->Branch("Particle Step Final Gamma",      t_ParticleStepFinalGamma,      "Step_Final_Gamma[Nsteps]/F");
-    theTree->Branch("Particle Step Final Mass",       t_ParticleStepFinalMass,       "Step_Final_Mass[Nsteps]/F");
-    theTree->Branch("Particle Step Pre Interaction",  t_ParticleStepPreInteraction,  "Step_PreInteraction[Nsteps]/I");
-    theTree->Branch("Particle Step Post Interaction", t_ParticleStepPostInteraction, "Step_PostInteraction[Nsteps]/I");
 
+    theTree->Branch("Particle Step ID", t_ParticleStepID, "Step_ID[Nsteps]/I");
+    theTree->Branch("Particle Step Initial Pt", t_ParticleStepInitialPt, "Step_Initial_Pt[Nsteps]/F");
+    theTree->Branch("Particle Step Initial Eta", t_ParticleStepInitialEta, "Step_Initial_Eta[Nsteps]/F");
+    theTree->Branch("Particle Step Initial Phi", t_ParticleStepInitialPhi, "Step_Initial_Phi[Nsteps]/F");
+    theTree->Branch("Particle Step Initial Energy", t_ParticleStepInitialEnergy, "Step_Initial_E[Nsteps]/F");
+    theTree->Branch("Particle Step Initial Px", t_ParticleStepInitialPx, "Step_Initial_Px[Nsteps]/F");
+    theTree->Branch("Particle Step Initial Py", t_ParticleStepInitialPy, "Step_Initial_Py[Nsteps]/F");
+    theTree->Branch("Particle Step Initial Pz", t_ParticleStepInitialPz, "Step_Initial_Pz[Nsteps]/F");
+    theTree->Branch("Particle Step Initial Beta", t_ParticleStepInitialBeta, "Step_Initial_Beta[Nsteps]/F");
+    theTree->Branch("Particle Step Initial Gamma", t_ParticleStepInitialGamma, "Step_Initial_Gamma[Nsteps]/F");
+    theTree->Branch("Particle Step Initial Mass", t_ParticleStepInitialMass, "Step_Initial_Mass[Nsteps]/F");
+    theTree->Branch("Particle Step Final Pt", t_ParticleStepFinalPt, "Step_Final_Pt[Nsteps]/F");
+    theTree->Branch("Particle Step Final Eta", t_ParticleStepFinalEta, "Step_Final_Eta[Nsteps]/F");
+    theTree->Branch("Particle Step Final Phi", t_ParticleStepFinalPhi, "Step_Final_Phi[Nsteps]/F");
+    theTree->Branch("Particle Step Final Energy", t_ParticleStepFinalEnergy, "Step_Final_E[Nsteps]/F");
+    theTree->Branch("Particle Step Final Px", t_ParticleStepFinalPx, "Step_Final_Px[Nsteps]/F");
+    theTree->Branch("Particle Step Final Py", t_ParticleStepFinalPy, "Step_Final_Py[Nsteps]/F");
+    theTree->Branch("Particle Step Final Pz", t_ParticleStepFinalPz, "Step_Final_Pz[Nsteps]/F");
+    theTree->Branch("Particle Step Final Beta", t_ParticleStepFinalBeta, "Step_Final_Beta[Nsteps]/F");
+    theTree->Branch("Particle Step Final Gamma", t_ParticleStepFinalGamma, "Step_Final_Gamma[Nsteps]/F");
+    theTree->Branch("Particle Step Final Mass", t_ParticleStepFinalMass, "Step_Final_Mass[Nsteps]/F");
+    theTree->Branch("Particle Step Pre Interaction", t_ParticleStepPreInteraction, "Step_PreInteraction[Nsteps]/I");
+    theTree->Branch("Particle Step Post Interaction", t_ParticleStepPostInteraction, "Step_PostInteraction[Nsteps]/I");
   }
-  
+
   LogDebug("MaterialBudget") << "MaterialBudgetTree: Booking user TTree done";
 }
 
+void MaterialBudgetTree::fillStartTrack() {}
 
-void MaterialBudgetTree::fillStartTrack()
-{
-  
-}
+void MaterialBudgetTree::fillPerStep() {}
 
-
-void MaterialBudgetTree::fillPerStep()
-{
-
-}
-
-void MaterialBudgetTree::fillEndTrack()
-{
-
-  t_MB  = theData->getTotalMB();
-  t_IL  = theData->getTotalIL();
+void MaterialBudgetTree::fillEndTrack() {
+  t_MB = theData->getTotalMB();
+  t_IL = theData->getTotalIL();
   //  t_Eta = theData->getEta();
   //  t_Phi = theData->getPhi();
 
-  t_ParticleID     = theData->getID();
-  t_ParticlePt     = theData->getPt();
-  t_ParticleEta    = theData->getEta();
-  t_ParticlePhi    = theData->getPhi();
+  t_ParticleID = theData->getID();
+  t_ParticlePt = theData->getPt();
+  t_ParticleEta = theData->getEta();
+  t_ParticlePhi = theData->getPhi();
   t_ParticleEnergy = theData->getEnergy();
-  t_ParticleMass   = theData->getMass();
-  
-  if( theData->allStepsON() ) {
+  t_ParticleMass = theData->getMass();
 
+  if (theData->allStepsON()) {
     t_Nsteps = theData->getNumberOfSteps();
-    
-    if( t_Nsteps > MAXSTEPS ) t_Nsteps = MAXSTEPS;
+
+    if (t_Nsteps > MAXSTEPS)
+      t_Nsteps = MAXSTEPS;
 
     edm::LogInfo("MaterialBudget") << "MaterialBudgetTree: Number of Steps into the tree " << t_Nsteps;
 
-    for(int ii=0;ii<t_Nsteps;ii++) {
-
+    for (int ii = 0; ii < t_Nsteps; ii++) {
       t_DeltaMB[ii] = theData->getStepDmb(ii);
       t_DeltaMB_SUP[ii] = theData->getSupportDmb(ii);
       t_DeltaMB_SEN[ii] = theData->getSensitiveDmb(ii);
@@ -155,7 +139,7 @@ void MaterialBudgetTree::fillEndTrack()
       t_DeltaMB_ELE[ii] = theData->getElectronicsDmb(ii);
       t_DeltaMB_OTH[ii] = theData->getOtherDmb(ii);
       t_DeltaMB_AIR[ii] = theData->getAirDmb(ii);
-      
+
       t_DeltaIL[ii] = theData->getStepDil(ii);
       t_DeltaIL_SUP[ii] = theData->getSupportDil(ii);
       t_DeltaIL_SEN[ii] = theData->getSensitiveDil(ii);
@@ -168,16 +152,16 @@ void MaterialBudgetTree::fillEndTrack()
       t_InitialX[ii] = theData->getStepInitialX(ii);
       t_InitialY[ii] = theData->getStepInitialY(ii);
       t_InitialZ[ii] = theData->getStepInitialZ(ii);
-      t_FinalX[ii]   = theData->getStepFinalX(ii);
-      t_FinalY[ii]   = theData->getStepFinalY(ii);
-      t_FinalZ[ii]   = theData->getStepFinalZ(ii);
-      
-      t_VolumeID[ii]     = theData->getStepVolumeID(ii);
-      t_VolumeName[ii]   = theData->getStepVolumeName(ii).c_str();
-      t_VolumeCopy[ii]   = theData->getStepVolumeCopy(ii);
-      t_VolumeX[ii]      = theData->getStepVolumeX(ii);
-      t_VolumeY[ii]      = theData->getStepVolumeY(ii);
-      t_VolumeZ[ii]      = theData->getStepVolumeZ(ii);
+      t_FinalX[ii] = theData->getStepFinalX(ii);
+      t_FinalY[ii] = theData->getStepFinalY(ii);
+      t_FinalZ[ii] = theData->getStepFinalZ(ii);
+
+      t_VolumeID[ii] = theData->getStepVolumeID(ii);
+      t_VolumeName[ii] = theData->getStepVolumeName(ii).c_str();
+      t_VolumeCopy[ii] = theData->getStepVolumeCopy(ii);
+      t_VolumeX[ii] = theData->getStepVolumeX(ii);
+      t_VolumeY[ii] = theData->getStepVolumeY(ii);
+      t_VolumeZ[ii] = theData->getStepVolumeZ(ii);
       t_VolumeXaxis1[ii] = theData->getStepVolumeXaxis(ii).x();
       t_VolumeXaxis2[ii] = theData->getStepVolumeXaxis(ii).y();
       t_VolumeXaxis3[ii] = theData->getStepVolumeXaxis(ii).z();
@@ -187,47 +171,43 @@ void MaterialBudgetTree::fillEndTrack()
       t_VolumeZaxis1[ii] = theData->getStepVolumeZaxis(ii).x();
       t_VolumeZaxis2[ii] = theData->getStepVolumeZaxis(ii).y();
       t_VolumeZaxis3[ii] = theData->getStepVolumeZaxis(ii).z();
-      
-      t_MaterialID[ii]        = theData->getStepMaterialID(ii);
-      t_MaterialName[ii]      = theData->getStepMaterialName(ii).c_str();
-      t_MaterialX0[ii]        = theData->getStepMaterialX0(ii);
-      t_MaterialLambda0[ii]   = theData->getStepMaterialLambda0(ii);
-      t_MaterialDensity[ii]   = theData->getStepMaterialDensity(ii);
-      
-      t_ParticleStepID[ii]              = theData->getStepID(ii);
-      t_ParticleStepInitialPt[ii]       = theData->getStepInitialPt(ii);
-      t_ParticleStepInitialEta[ii]      = theData->getStepInitialEta(ii);
-      t_ParticleStepInitialPhi[ii]      = theData->getStepInitialPhi(ii);
-      t_ParticleStepInitialEnergy[ii]   = theData->getStepInitialEnergy(ii);
-      t_ParticleStepInitialPx[ii]       = theData->getStepInitialPx(ii);
-      t_ParticleStepInitialPy[ii]       = theData->getStepInitialPy(ii);
-      t_ParticleStepInitialPz[ii]       = theData->getStepInitialPz(ii);
-      t_ParticleStepInitialBeta[ii]     = theData->getStepInitialBeta(ii);
-      t_ParticleStepInitialGamma[ii]    = theData->getStepInitialGamma(ii);
-      t_ParticleStepInitialMass[ii]     = theData->getStepInitialMass(ii);
-      t_ParticleStepFinalPt[ii]         = theData->getStepFinalPt(ii);
-      t_ParticleStepFinalEta[ii]        = theData->getStepFinalEta(ii);
-      t_ParticleStepFinalPhi[ii]        = theData->getStepFinalPhi(ii);
-      t_ParticleStepFinalEnergy[ii]     = theData->getStepFinalEnergy(ii);
-      t_ParticleStepFinalPx[ii]         = theData->getStepFinalPx(ii);
-      t_ParticleStepFinalPy[ii]         = theData->getStepFinalPy(ii);
-      t_ParticleStepFinalPz[ii]         = theData->getStepFinalPz(ii);
-      t_ParticleStepFinalBeta[ii]       = theData->getStepFinalBeta(ii);
-      t_ParticleStepFinalGamma[ii]      = theData->getStepFinalGamma(ii);
-      t_ParticleStepFinalMass[ii]       = theData->getStepFinalMass(ii);
-      t_ParticleStepPreInteraction[ii]  = theData->getStepPreProcess(ii);
+
+      t_MaterialID[ii] = theData->getStepMaterialID(ii);
+      t_MaterialName[ii] = theData->getStepMaterialName(ii).c_str();
+      t_MaterialX0[ii] = theData->getStepMaterialX0(ii);
+      t_MaterialLambda0[ii] = theData->getStepMaterialLambda0(ii);
+      t_MaterialDensity[ii] = theData->getStepMaterialDensity(ii);
+
+      t_ParticleStepID[ii] = theData->getStepID(ii);
+      t_ParticleStepInitialPt[ii] = theData->getStepInitialPt(ii);
+      t_ParticleStepInitialEta[ii] = theData->getStepInitialEta(ii);
+      t_ParticleStepInitialPhi[ii] = theData->getStepInitialPhi(ii);
+      t_ParticleStepInitialEnergy[ii] = theData->getStepInitialEnergy(ii);
+      t_ParticleStepInitialPx[ii] = theData->getStepInitialPx(ii);
+      t_ParticleStepInitialPy[ii] = theData->getStepInitialPy(ii);
+      t_ParticleStepInitialPz[ii] = theData->getStepInitialPz(ii);
+      t_ParticleStepInitialBeta[ii] = theData->getStepInitialBeta(ii);
+      t_ParticleStepInitialGamma[ii] = theData->getStepInitialGamma(ii);
+      t_ParticleStepInitialMass[ii] = theData->getStepInitialMass(ii);
+      t_ParticleStepFinalPt[ii] = theData->getStepFinalPt(ii);
+      t_ParticleStepFinalEta[ii] = theData->getStepFinalEta(ii);
+      t_ParticleStepFinalPhi[ii] = theData->getStepFinalPhi(ii);
+      t_ParticleStepFinalEnergy[ii] = theData->getStepFinalEnergy(ii);
+      t_ParticleStepFinalPx[ii] = theData->getStepFinalPx(ii);
+      t_ParticleStepFinalPy[ii] = theData->getStepFinalPy(ii);
+      t_ParticleStepFinalPz[ii] = theData->getStepFinalPz(ii);
+      t_ParticleStepFinalBeta[ii] = theData->getStepFinalBeta(ii);
+      t_ParticleStepFinalGamma[ii] = theData->getStepFinalGamma(ii);
+      t_ParticleStepFinalMass[ii] = theData->getStepFinalMass(ii);
+      t_ParticleStepPreInteraction[ii] = theData->getStepPreProcess(ii);
       t_ParticleStepPostInteraction[ii] = theData->getStepPostProcess(ii);
-      
     }
   }
 
   theTree->Fill();
 }
 
-
-void MaterialBudgetTree::endOfRun() 
-{
-
+void MaterialBudgetTree::endOfRun() {
   // Prefered method to include any instruction
   // once all the tracks are done
 

--- a/Validation/Geometry/src/MaterialBudgetTxt.cc
+++ b/Validation/Geometry/src/MaterialBudgetTxt.cc
@@ -3,46 +3,33 @@
 #include "G4EventManager.hh"
 #include "G4Event.hh"
 
-
-MaterialBudgetTxt::MaterialBudgetTxt( std::shared_ptr<MaterialBudgetData> data, const std::string& fileName )
-  : MaterialBudgetFormat( data )
-{
-  const char * fnamechar = fileName.c_str();
+MaterialBudgetTxt::MaterialBudgetTxt(std::shared_ptr<MaterialBudgetData> data, const std::string& fileName)
+    : MaterialBudgetFormat(data) {
+  const char* fnamechar = fileName.c_str();
   theFile = new std::ofstream(fnamechar, std::ios::out);
   edm::LogInfo("MaterialBudget") << "MaterialBudgetTxt: Dumping  Material Budget to " << fileName;
-  if (theFile->fail()){
-    edm::LogError("MaterialBudget") <<"MaterialBudgetTxt: Error opening file" << fileName;
+  if (theFile->fail()) {
+    edm::LogError("MaterialBudget") << "MaterialBudgetTxt: Error opening file" << fileName;
   }
 }
 
+MaterialBudgetTxt::~MaterialBudgetTxt() {}
 
-MaterialBudgetTxt::~MaterialBudgetTxt()
-{
-}
-
-
-void MaterialBudgetTxt::fillStartTrack()
-{
-  
-  (*theFile)<< " Track "<< G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() << " " << theData->getEta() << " " << theData->getPhi() << std::endl;
+void MaterialBudgetTxt::fillStartTrack() {
+  (*theFile) << " Track " << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() << " "
+             << theData->getEta() << " " << theData->getPhi() << std::endl;
   // + 1 was GEANT3 notation  (*theFile)<< " Track "<< G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() + 1<< " " << theData->getEta() << " " << theData->getPhi() << std::endl;
 }
 
-
-void MaterialBudgetTxt::fillPerStep()
-{
-  (*theFile) << "step "<< theData->getTrkLen() << " " << theData->getPVname() << " " << theData->getPVcopyNo()  << " " << theData->getTotalMB() << " " << theData->getRadLen() << std::endl;
+void MaterialBudgetTxt::fillPerStep() {
+  (*theFile) << "step " << theData->getTrkLen() << " " << theData->getPVname() << " " << theData->getPVcopyNo() << " "
+             << theData->getTotalMB() << " " << theData->getRadLen() << std::endl;
   //-    std::cout << "step "<< theData->getTrkLen() << " " << theData->getPVname() << " " << theData->getPVcopyNo()  << " " << theData->getTotalMB() << " " << theData->getRadLen() << std::endl;
-
 }
 
-
-void MaterialBudgetTxt::fillEndTrack()
-{
-  (*theFile) << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() << " " << "finalTrkMB " << theData->getTotalMB() << std::endl;
+void MaterialBudgetTxt::fillEndTrack() {
+  (*theFile) << G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID() << " "
+             << "finalTrkMB " << theData->getTotalMB() << std::endl;
 }
 
-void MaterialBudgetTxt::endOfRun() 
-{
-  theFile->close();
-}
+void MaterialBudgetTxt::endOfRun() { theFile->close(); }

--- a/Validation/Geometry/src/TestHistoMgr.cc
+++ b/Validation/Geometry/src/TestHistoMgr.cc
@@ -15,35 +15,31 @@
 #include <cstdlib>
 
 //----------------------------------------------------------------------
-TestHistoMgr::TestHistoMgr()
-{
+TestHistoMgr::TestHistoMgr() {
   //  pi_aida::Proxy_Selector::setHistogramType(pi_aida::Histogram_Native);
 }
 
 //----------------------------------------------------------------------
-TestHistoMgr::~TestHistoMgr()
-{ 
-  for(auto& it: theHistos1){
+TestHistoMgr::~TestHistoMgr() {
+  for (auto& it : theHistos1) {
     delete it.second;
   }
-  for(auto& it: theHistos2){
+  for (auto& it : theHistos2) {
     delete it.second;
   }
-  for(auto& it: theHistoProfs1){
+  for (auto& it : theHistoProfs1) {
     delete it.second;
   }
-  for(auto& it: theHistoProfs2){
+  for (auto& it : theHistoProfs2) {
     delete it.second;
-  } 
+  }
 }
 
 //----------------------------------------------------------------------
-void TestHistoMgr::save( const std::string& name )
-{
-
+void TestHistoMgr::save(const std::string& name) {
   edm::LogInfo("MaterialBudget") << "TestHistoMgr: Save user histos";
 
-  TFile fout(name.c_str(),"recreate");
+  TFile fout(name.c_str(), "recreate");
 
   // write out the histos
   mih1::const_iterator ite1;
@@ -51,50 +47,41 @@ void TestHistoMgr::save( const std::string& name )
   mihp1::const_iterator itep1;
   mihp2::const_iterator itep2;
 
-  for( ite1 = theHistos1.begin(); ite1 != theHistos1.end(); ite1++ ){
+  for (ite1 = theHistos1.begin(); ite1 != theHistos1.end(); ite1++) {
     ((*ite1).second)->Write();
   }
-  for( ite2 = theHistos2.begin(); ite2 != theHistos2.end(); ite2++ ){
+  for (ite2 = theHistos2.begin(); ite2 != theHistos2.end(); ite2++) {
     ((*ite2).second)->Write();
   }
-  for( itep1 = theHistoProfs1.begin(); itep1 != theHistoProfs1.end(); itep1++ ){
+  for (itep1 = theHistoProfs1.begin(); itep1 != theHistoProfs1.end(); itep1++) {
     ((*itep1).second)->Write();
   }
-  for( itep2 = theHistoProfs2.begin(); itep2 != theHistoProfs2.end(); itep2++ ){
+  for (itep2 = theHistoProfs2.begin(); itep2 != theHistoProfs2.end(); itep2++) {
     ((*itep2).second)->Write();
   }
-
 }
 
-void TestHistoMgr::openSecondFile( const std::string& name )
-{
+void TestHistoMgr::openSecondFile(const std::string& name) { theFileRef = std::make_unique<TFile>(name.c_str()); }
 
-  theFileRef = std::make_unique<TFile>(name.c_str());
-
-}
-
-
-void TestHistoMgr::printComparisonResult( int ih )
-{
-  
+void TestHistoMgr::printComparisonResult(int ih) {
 #ifdef StatTesting
 
   TH1F* histo2 = getHisto1FromSecondFile(histo1->GetName());
-  
-  StatisticsTesting::StatisticsComparator< StatisticsTesting::Chi2ComparisonAlgorithm > comparator;
+
+  StatisticsTesting::StatisticsComparator<StatisticsTesting::Chi2ComparisonAlgorithm> comparator;
 
 #ifdef PI121
 
-  qStatisticsTesting::ComparisonResult result = comparator.compare(*histo1, *histo2); 
+  qStatisticsTesting::ComparisonResult result = comparator.compare(*histo1, *histo2);
 
 #else
 
-  double result = comparator.compare(*histo1, *histo2); 
+  double result = comparator.compare(*histo1, *histo2);
 
 #endif
 
   // ---------------------------------------------------------
-  // Do something with (e.g. print out) the result of the test 
+  // Do something with (e.g. print out) the result of the test
   // ---------------------------------------------------------
   edm::LogInfo << "TestHistoMgr: Result of the Chi2 Statistical Test: " << histo1->GetName();
 #ifdef PI121
@@ -102,62 +89,54 @@ void TestHistoMgr::printComparisonResult( int ih )
   << " ndf = " << result.ndf() << std::endl
   << " p-value = " << result.quality() << std::endl
 #else
-            << " p-value = " << result << std::endl
- #endif
-            << "---------------- exampleReadXML  ENDS   ------------------ " 
-	    << std::endl;
+  << " p-value = " << result << std::endl
+#endif
+  << "---------------- exampleReadXML  ENDS   ------------------ " << std::endl;
 #ifdef PI121
-  std::cout << "[OVAL]: HISTO_QUALITY " << histo1->GetName() <<" " << result.quality() << std::endl;
- #else 
-  std::cout << "[OVAL]: HISTO_QUALITY " << histo1->GetName() <<" " << result << std::endl;
- #endif
-  std::cout << std::endl << " mean= " << histo1->GetMean() << " " << histo1->GetName() << " " << histo1->GetTitle() << std::endl;
+  std::cout << "[OVAL]: HISTO_QUALITY " << histo1->GetName() << " " << result.quality() << std::endl;
+#else
+  std::cout << "[OVAL]: HISTO_QUALITY " << histo1->GetName() << " " << result << std::endl;
+#endif
+  std::cout << std::endl
+            << " mean= " << histo1->GetMean() << " " << histo1->GetName() << " " << histo1->GetTitle() << std::endl;
   std::cout << " rms= " << histo1->GetRMS() << " " << histo1->GetName() << " " << histo1->GetTitle() << std::endl;
 
 #else
 #endif
 }
 
-
-bool TestHistoMgr::addHisto1( TH1F* sih )
-{
+bool TestHistoMgr::addHisto1(TH1F* sih) {
   int ih = atoi(sih->GetName());
   theHistos1[ih] = sih;
   edm::LogInfo("MaterialBudget") << "TestHistoMgr: addHisto1: " << ih << " = " << sih->GetTitle();
   return true;
 }
 
-bool TestHistoMgr::addHisto2( TH2F* sih )
-{
+bool TestHistoMgr::addHisto2(TH2F* sih) {
   int ih = atoi(sih->GetName());
   theHistos2[ih] = sih;
   return true;
 }
 
-
-bool TestHistoMgr::addHistoProf1( TProfile* sih )
-{
+bool TestHistoMgr::addHistoProf1(TProfile* sih) {
   int ih = atoi(sih->GetName());
   theHistoProfs1[ih] = sih;
   edm::LogInfo("MaterialBudget") << "TestHistoMgr: addHistoProf1: " << ih << " = " << sih->GetTitle();
   return true;
 }
 
-bool TestHistoMgr::addHistoProf2( TProfile2D* sih )
-{
+bool TestHistoMgr::addHistoProf2(TProfile2D* sih) {
   int ih = atoi(sih->GetName());
   theHistoProfs2[ih] = sih;
   edm::LogInfo("MaterialBudget") << "TestHistoMgr: addHistoProf2: " << ih << " = " << sih->GetTitle();
   return true;
 }
 
-
-TH1F* TestHistoMgr::getHisto1( int ih )
-{
+TH1F* TestHistoMgr::getHisto1(int ih) {
   TH1F* his = nullptr;
 
-  mih1::const_iterator ite = theHistos1.find( ih );
-  if( ite != theHistos1.end() ) {
+  mih1::const_iterator ite = theHistos1.find(ih);
+  if (ite != theHistos1.end()) {
     his = (*ite).second;
   } else {
     edm::LogError("MaterialBudget") << "TestHistoMgr: getHisto1 Histogram does not exist " << ih;
@@ -166,11 +145,10 @@ TH1F* TestHistoMgr::getHisto1( int ih )
   return his;
 }
 
-TH2F* TestHistoMgr::getHisto2( int ih )
-{
+TH2F* TestHistoMgr::getHisto2(int ih) {
   TH2F* his = nullptr;
-  mih2::const_iterator ite = theHistos2.find( ih );
-  if( ite != theHistos2.end() ) {
+  mih2::const_iterator ite = theHistos2.find(ih);
+  if (ite != theHistos2.end()) {
     his = (*ite).second;
   } else {
     edm::LogError("MaterialBudget") << "TestHistoMgr: getHisto2 Histogram does not exist " << ih;
@@ -179,11 +157,10 @@ TH2F* TestHistoMgr::getHisto2( int ih )
   return his;
 }
 
-TProfile* TestHistoMgr::getHistoProf1( int ih )
-{
+TProfile* TestHistoMgr::getHistoProf1(int ih) {
   TProfile* his = nullptr;
-  mihp1::const_iterator ite = theHistoProfs1.find( ih );
-  if( ite != theHistoProfs1.end() ) {
+  mihp1::const_iterator ite = theHistoProfs1.find(ih);
+  if (ite != theHistoProfs1.end()) {
     his = (*ite).second;
   } else {
     edm::LogError("MaterialBudget") << "TestHistoMgr: Profile Histogram 1D does not exist " << ih;
@@ -192,12 +169,10 @@ TProfile* TestHistoMgr::getHistoProf1( int ih )
   return his;
 }
 
-
-TProfile2D* TestHistoMgr::getHistoProf2( int ih )
-{
+TProfile2D* TestHistoMgr::getHistoProf2(int ih) {
   TProfile2D* his = nullptr;
-  mihp2::const_iterator ite = theHistoProfs2.find( ih );
-  if( ite != theHistoProfs2.end() ) {
+  mihp2::const_iterator ite = theHistoProfs2.find(ih);
+  if (ite != theHistoProfs2.end()) {
     his = (*ite).second;
   } else {
     edm::LogError("MaterialBudget") << "TestHistoMgr: Profile Histogram 2D does not exist " << ih;
@@ -205,18 +180,17 @@ TProfile2D* TestHistoMgr::getHistoProf2( int ih )
   }
   return his;
 }
- 
-TH1F* TestHistoMgr::getHisto1FromSecondFile( const char* hnam )
-{
+
+TH1F* TestHistoMgr::getHisto1FromSecondFile(const char* hnam) {
   TH1F* his = new TH1F();
-  if( !theFileRef ){
+  if (!theFileRef) {
     edm::LogError("MaterialBudget") << "TestHistoMgr: Second file not yet opened ";
     std::exception();
-  } else{
+  } else {
     his = (TH1F*)(*theFileRef).Get(hnam);
   }
 
-  if( !his ) {
+  if (!his) {
     edm::LogError("MaterialBudget") << "TestHistoMgr: FATAL ERROR Histogram does not exist in second file " << hnam;
     theFileRef->ls();
     std::exception();

--- a/Validation/Geometry/src/module.cc
+++ b/Validation/Geometry/src/module.cc
@@ -5,8 +5,7 @@
 #include "Validation/Geometry/interface/MaterialBudgetForward.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 
-DEFINE_SIMWATCHER (MaterialBudget);
-DEFINE_SIMWATCHER (MaterialBudgetAction);
-DEFINE_SIMWATCHER (MaterialBudgetHcal);
-DEFINE_SIMWATCHER (MaterialBudgetForward);
-
+DEFINE_SIMWATCHER(MaterialBudget);
+DEFINE_SIMWATCHER(MaterialBudgetAction);
+DEFINE_SIMWATCHER(MaterialBudgetHcal);
+DEFINE_SIMWATCHER(MaterialBudgetForward);

--- a/Validation/Geometry/test/CMS_lumi.C
+++ b/Validation/Geometry/test/CMS_lumi.C
@@ -1,0 +1,163 @@
+#include "CMS_lumi.h"
+#include <iostream>
+
+void 
+CMS_lumi( TPad* pad, int iPeriod, int iPosX )
+{            
+  bool outOfFrame    = false;
+  if( iPosX/10==0 ) 
+    {
+      outOfFrame = true;
+    }
+  int alignY_=3;
+  int alignX_=2;
+  if( iPosX/10==0 ) alignX_=1;
+  if( iPosX==0    ) alignX_=1;
+  if( iPosX==0    ) alignY_=1;
+  if( iPosX/10==1 ) alignX_=1;
+  if( iPosX/10==2 ) alignX_=2;
+  if( iPosX/10==3 ) alignX_=3;
+  if( iPosX == 0  ) relPosX = 0.12;
+  int align_ = 10*alignX_ + alignY_;
+
+  float H = pad->GetWh();
+  float W = pad->GetWw();
+  float l = pad->GetLeftMargin();
+  float t = pad->GetTopMargin();
+  float r = pad->GetRightMargin();
+  float b = pad->GetBottomMargin();
+  //  float e = 0.025;
+
+  pad->cd();
+
+  TString lumiText;
+  if( iPeriod==1 )
+    {
+      lumiText += lumi_7TeV;
+      lumiText += " (7 TeV)";
+    }
+  else if ( iPeriod==2 )
+    {
+      lumiText += lumi_8TeV;
+      lumiText += " (8 TeV)";
+    }
+  else if( iPeriod==3 ) 
+    {
+      lumiText = lumi_8TeV; 
+      lumiText += " (8 TeV)";
+      lumiText += " + ";
+      lumiText += lumi_7TeV;
+      lumiText += " (7 TeV)";
+    }
+  else if ( iPeriod==4 )
+    {
+      lumiText += lumi_13TeV;
+      lumiText += " (13 TeV)";
+    }
+  else if ( iPeriod==7 )
+    { 
+      if( outOfFrame ) lumiText += "#scale[0.85]{";
+      lumiText += lumi_13TeV; 
+      lumiText += " (13 TeV)";
+      lumiText += " + ";
+      lumiText += lumi_8TeV; 
+      lumiText += " (8 TeV)";
+      lumiText += " + ";
+      lumiText += lumi_7TeV;
+      lumiText += " (7 TeV)";
+      if( outOfFrame) lumiText += "}";
+    }
+  else if ( iPeriod==12 )
+    {
+      lumiText += "8 TeV";
+    }
+  else if ( iPeriod==0 )
+    {
+      lumiText += lumi_sqrtS;
+    }
+   
+  std::cout << lumiText << endl;
+
+  TLatex latex;
+  latex.SetNDC();
+  latex.SetTextAngle(0);
+  latex.SetTextColor(kBlack);    
+
+  float extraTextSize = extraOverCmsTextSize*cmsTextSize;
+
+  latex.SetTextFont(42);
+  latex.SetTextAlign(31); 
+  latex.SetTextSize(lumiTextSize*t);    
+  latex.DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  if( outOfFrame )
+    {
+      latex.SetTextFont(cmsTextFont);
+      latex.SetTextAlign(11); 
+      latex.SetTextSize(cmsTextSize*t);    
+      latex.DrawLatex(l,1-t+lumiTextOffset*t,cmsText);
+    }
+  
+  pad->cd();
+
+  float posX_=0;
+  if( iPosX%10<=1 )
+    {
+      posX_ =   l + relPosX*(1-l-r);
+    }
+  else if( iPosX%10==2 )
+    {
+      posX_ =  l + 0.5*(1-l-r);
+    }
+  else if( iPosX%10==3 )
+    {
+      posX_ =  1-r - relPosX*(1-l-r);
+    }
+  float posY_ = 1-t - relPosY*(1-t-b);
+  if( !outOfFrame )
+    {
+      if( drawLogo )
+	{
+	  posX_ =   l + 0.045*(1-l-r)*W/H;
+	  posY_ = 1-t - 0.045*(1-t-b);
+	  float xl_0 = posX_;
+	  float yl_0 = posY_ - 0.15;
+	  float xl_1 = posX_ + 0.15*H/W;
+	  float yl_1 = posY_;
+	  TASImage* CMS_logo = new TASImage("CMS-BW-label.png");
+	  TPad* pad_logo = new TPad("logo","logo", xl_0, yl_0, xl_1, yl_1 );
+	  pad_logo->Draw();
+	  pad_logo->cd();
+	  CMS_logo->Draw("X");
+	  pad_logo->Modified();
+	  pad->cd();
+	}
+      else
+	{
+	  latex.SetTextFont(cmsTextFont);
+	  latex.SetTextSize(cmsTextSize*t);
+	  latex.SetTextAlign(align_);
+	  latex.DrawLatex(posX_, posY_, cmsText);
+	  if( writeExtraText ) 
+	    {
+	      latex.SetTextFont(extraTextFont);
+	      latex.SetTextAlign(align_);
+	      latex.SetTextSize(extraTextSize*t);
+	      latex.DrawLatex(posX_, posY_- relExtraDY*cmsTextSize*t, extraText);
+	    }
+	}
+    }
+  else if( writeExtraText )
+    {
+      if( iPosX==0) 
+	{
+	  posX_ =   l +  relPosX*(1-l-r);
+	  posY_ =   1-t+lumiTextOffset*t;
+	}
+      latex.SetTextFont(extraTextFont);
+      latex.SetTextSize(extraTextSize*t);
+      latex.SetTextAlign(align_);
+      latex.DrawLatex(posX_, posY_, extraText);      
+    }
+  return;
+}

--- a/Validation/Geometry/test/CMS_lumi.h
+++ b/Validation/Geometry/test/CMS_lumi.h
@@ -1,0 +1,39 @@
+#include "TPad.h"
+#include "TLatex.h"
+#include "TLine.h"
+#include "TBox.h"
+#include "TASImage.h"
+
+//
+// Global variables
+//
+
+TString cmsText     = "CMS";
+float cmsTextFont   = 61;  // default is helvetic-bold
+
+bool writeExtraText = false;
+TString extraText   = "Preliminary";
+float extraTextFont = 52;  // default is helvetica-italics
+
+// text sizes and text offsets with respect to the top frame
+// in unit of the top margin size
+float lumiTextSize     = 0.6;
+float lumiTextOffset   = 0.2;
+float cmsTextSize      = 0.75;
+float cmsTextOffset    = 0.1;  // only used in outOfFrame version
+
+float relPosX    = 0.045;
+float relPosY    = 0.035;
+float relExtraDY = 1.2;
+
+// ratio of "CMS" and extra text size
+float extraOverCmsTextSize  = 0.76;
+
+TString lumi_13TeV = "20.1 fb^{-1}";
+TString lumi_8TeV  = "19.7 fb^{-1}";
+TString lumi_7TeV  = "5.1 fb^{-1}";
+TString lumi_sqrtS = "";
+
+bool drawLogo      = false;
+
+void CMS_lumi( TPad* pad, int iPeriod=3, int iPosX=10 );

--- a/Validation/Geometry/test/MaterialBudgetMtd.C
+++ b/Validation/Geometry/test/MaterialBudgetMtd.C
@@ -1,115 +1,13 @@
 // include files
+
+#include "tdrStyle.C"
+#include "CMS_lumi.C"
+
 #include <iostream>
 #include <iomanip>
 #include <fstream>
 #include <cmath>
 #include "TStyle.h"
-
-void setTDRStyle() {
-
-  TStyle *tdrStyle = new TStyle("tdrStyle","Style for P-TDR");
-
-  // For the canvas:
-  tdrStyle->SetCanvasBorderMode(0);
-  tdrStyle->SetCanvasColor(kWhite);
-  tdrStyle->SetCanvasDefH(600); //Height of canvas
-  tdrStyle->SetCanvasDefW(600); //Width of canvas
-  tdrStyle->SetCanvasDefX(0);   //POsition on screen
-  tdrStyle->SetCanvasDefY(0);
-
-  // For the Pad:
-  tdrStyle->SetPadBorderMode(0);
-  tdrStyle->SetPadColor(kWhite);
-  tdrStyle->SetPadGridX(false);
-  tdrStyle->SetPadGridY(false);
-  tdrStyle->SetGridColor(0);
-  tdrStyle->SetGridStyle(3);
-  tdrStyle->SetGridWidth(1);
-
-  // For the frame:
-  tdrStyle->SetFrameBorderMode(0);
-  tdrStyle->SetFrameBorderSize(1);
-  tdrStyle->SetFrameFillColor(0);
-  tdrStyle->SetFrameFillStyle(0);
-  tdrStyle->SetFrameLineColor(1);
-  tdrStyle->SetFrameLineStyle(1);
-  tdrStyle->SetFrameLineWidth(1);
-
-  // For the histo:
-  tdrStyle->SetHistLineColor(1);
-  tdrStyle->SetHistLineStyle(0);
-  tdrStyle->SetHistLineWidth(1);
-  tdrStyle->SetEndErrorSize(2);
-  tdrStyle->SetErrorX(0.);
-  tdrStyle->SetMarkerStyle(20);
-
-  //For the fit/function:
-  tdrStyle->SetOptFit(1);
-  tdrStyle->SetFitFormat("5.4g");
-  tdrStyle->SetFuncColor(2);
-  tdrStyle->SetFuncStyle(1);
-  tdrStyle->SetFuncWidth(1);
-
-  //For the date:
-  tdrStyle->SetOptDate(0);
-
-  // For the statistics box:
-  tdrStyle->SetOptFile(0);
-  tdrStyle->SetOptStat(0); // To display the mean and RMS:   SetOptStat("mr");
-  tdrStyle->SetStatColor(kWhite);
-  tdrStyle->SetStatFont(42);
-  tdrStyle->SetStatFontSize(0.025);
-  tdrStyle->SetStatTextColor(1);
-  tdrStyle->SetStatFormat("6.4g");
-  tdrStyle->SetStatBorderSize(1);
-  tdrStyle->SetStatH(0.1);
-  tdrStyle->SetStatW(0.15);
-
-  // Margins:
-  tdrStyle->SetPadTopMargin(0.05);
-  tdrStyle->SetPadBottomMargin(0.13);
-  tdrStyle->SetPadLeftMargin(0.16);
-  tdrStyle->SetPadRightMargin(0.02);
-
-  // For the Global title:
-  tdrStyle->SetOptTitle(0);
-  tdrStyle->SetTitleFont(42);
-  tdrStyle->SetTitleColor(1);
-  tdrStyle->SetTitleTextColor(1);
-  tdrStyle->SetTitleFillColor(10);
-  tdrStyle->SetTitleFontSize(0.05);
-
-  // For the axis titles:
-  tdrStyle->SetTitleColor(1, "XYZ");
-  tdrStyle->SetTitleFont(42, "XYZ");
-  tdrStyle->SetTitleSize(0.06, "XYZ");
-  tdrStyle->SetTitleXOffset(0.9);
-  tdrStyle->SetTitleYOffset(1.25);
-
-  // For the axis labels:
-  tdrStyle->SetLabelColor(1, "XYZ");
-  tdrStyle->SetLabelFont(42, "XYZ");
-  tdrStyle->SetLabelOffset(0.007, "XYZ");
-  tdrStyle->SetLabelSize(0.05, "XYZ");
-
-  // For the axis:
-  tdrStyle->SetAxisColor(1, "XYZ");
-  tdrStyle->SetStripDecimals(kTRUE);
-  tdrStyle->SetTickLength(0.03, "XYZ");
-  tdrStyle->SetNdivisions(510, "XYZ");
-  tdrStyle->SetPadTickX(1);  // To get tick marks on the opposite side of the frame
-  tdrStyle->SetPadTickY(1);
-
-  // Change for log plots:
-  tdrStyle->SetOptLogx(0);
-  tdrStyle->SetOptLogy(0);
-  tdrStyle->SetOptLogz(0);
-
-  // Postscript options:
-  tdrStyle->SetPaperSize(20.,20.);
-
-  tdrStyle->cd();
-}
 
 // data dirs
 TString theDirName = "Figures";
@@ -278,9 +176,30 @@ void createPlots(TString plot){
   //
   
   // canvas
-  TCanvas can_Materials("can_Materials","can_Materials",800,800);
-  can_Materials.Range(0,0,25,25);
-  can_Materials.SetFillColor(kWhite);
+
+  int W = 800;
+  int H = 600;
+  int H_ref = 600; 
+  int W_ref = 800; 
+
+  // references for T, B, L, R
+  float T = 0.08*H_ref;
+  float B = 0.12*H_ref; 
+  float L = 0.12*W_ref;
+  float R = 0.04*W_ref;
+
+  TCanvas * can_Materials = new TCanvas("can_Materials","can_Materials",50,50,W,H);
+  can_Materials->Range(0,0,25,25);
+  can_Materials->SetFillColor(kWhite);
+  can_Materials->SetBorderMode(0);
+  can_Materials->SetFrameFillStyle(0);
+  can_Materials->SetFrameBorderMode(0);
+  can_Materials->SetLeftMargin( L/W );
+  can_Materials->SetRightMargin( R/W );
+  can_Materials->SetTopMargin( T/H );
+  can_Materials->SetBottomMargin( B/H );
+  can_Materials->SetTickx(0);
+  can_Materials->SetTicky(0);
   gStyle->SetOptStat(0);
   //
   
@@ -292,7 +211,8 @@ void createPlots(TString plot){
   //
   
   // Legenda
-  TLegend* theLegend_Materials = new TLegend(0.180,0.8,0.98,0.92); 
+  TLegend* theLegend_Materials = new TLegend(0.14,0.8,0.96,0.92); 
+  theLegend_Materials->SetTextAlign(22);
   theLegend_Materials->SetNColumns(3); 
   theLegend_Materials->SetFillColor(0); 
   theLegend_Materials->SetFillStyle(0); 
@@ -300,31 +220,39 @@ void createPlots(TString plot){
 
   theLegend_Materials->AddEntry(hist_x0_SEN, "Sensitive material", "f");
   theLegend_Materials->AddEntry(hist_x0_COL, "Support/cooling", "f");
-  theLegend_Materials->AddEntry(hist_x0_ELE, "Electronics", "f");
-
-  theLegend_Materials->AddEntry(hist_x0_CAB, "Services", "f");
+  theLegend_Materials->AddEntry(hist_x0_ELE, "Electronics/services", "f");
+  //  theLegend_Materials->AddEntry(hist_x0_CAB, "Services", "f");
   //  theLegend_Materials->AddEntry(hist_x0_SUP, "Support", "f");
   //  theLegend_Materials->AddEntry(hist_x0_OTH, "Other", "f");
   theLegend_Materials->Draw();
-  //
 
-  // text
-  TPaveText* text_Materials = new TPaveText(0.180,0.727,0.402,0.787,"NDC");
-  text_Materials->SetFillColor(0);
-  text_Materials->SetBorderSize(0);
-  text_Materials->AddText("CMS Simulation");
-  text_Materials->SetTextAlign(11);
-  text_Materials->Draw();
-  //
+  // writing the lumi information and the CMS "logo"
+  int iPeriod = 0;
+  writeExtraText = true;
+  extraText = "Simulation";
+
+  // second parameter in example_plot is iPos, which drives the position of the CMS logo in the plot
+  // iPos=11 : top-left, left-aligned
+  // iPos=33 : top-right, right-aligned
+  // iPos=22 : center, centered
+  // mode generally : 
+  //   iPos = 10*(alignement 1/2/3) + position (1/2/3 = left/center/right)
+  int iPos = 0;
+
+  CMS_lumi( can_Materials, iPeriod, iPos );
   
   // Store
-  can_Materials.Update();
-  // can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.eps",  theDirName.Data(), plot.Data() ) );
-  // can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.gif",  theDirName.Data(), plot.Data() ) );
-  can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.pdf",  theDirName.Data(), plot.Data() ) );
-  // can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.png",  theDirName.Data(), plot.Data() ) );
-  can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.root",  theDirName.Data(), plot.Data() ) );
-  // can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.C",  theDirName.Data(), plot.Data() ) );
+  can_Materials->Update();
+  can_Materials->RedrawAxis();
+  can_Materials->Draw();
+  // can_Materials->SaveAs( Form( "%s/Mtd_Materials_%s.eps",  theDirName.Data(), plot.Data() ) );
+  // can_Materials->SaveAs( Form( "%s/Mtd_Materials_%s.gif",  theDirName.Data(), plot.Data() ) );
+  can_Materials->SaveAs( Form( "%s/Mtd_Materials_%s.pdf",  theDirName.Data(), plot.Data() ) );
+  // can_Materials->SaveAs( Form( "%s/Mtd_Materials_%s.png",  theDirName.Data(), plot.Data() ) );
+  can_Materials->SaveAs( Form( "%s/Mtd_Materials_%s.root",  theDirName.Data(), plot.Data() ) );
+  // can_Materials->SaveAs( Form( "%s/Mtd_Materials_%s.C",  theDirName.Data(), plot.Data() ) );
   //
+
+  delete can_Materials;
   
 }

--- a/Validation/Geometry/test/MaterialBudgetMtd.C
+++ b/Validation/Geometry/test/MaterialBudgetMtd.C
@@ -1,0 +1,330 @@
+// include files
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cmath>
+#include "TStyle.h"
+
+void setTDRStyle() {
+
+  TStyle *tdrStyle = new TStyle("tdrStyle","Style for P-TDR");
+
+  // For the canvas:
+  tdrStyle->SetCanvasBorderMode(0);
+  tdrStyle->SetCanvasColor(kWhite);
+  tdrStyle->SetCanvasDefH(600); //Height of canvas
+  tdrStyle->SetCanvasDefW(600); //Width of canvas
+  tdrStyle->SetCanvasDefX(0);   //POsition on screen
+  tdrStyle->SetCanvasDefY(0);
+
+  // For the Pad:
+  tdrStyle->SetPadBorderMode(0);
+  tdrStyle->SetPadColor(kWhite);
+  tdrStyle->SetPadGridX(false);
+  tdrStyle->SetPadGridY(false);
+  tdrStyle->SetGridColor(0);
+  tdrStyle->SetGridStyle(3);
+  tdrStyle->SetGridWidth(1);
+
+  // For the frame:
+  tdrStyle->SetFrameBorderMode(0);
+  tdrStyle->SetFrameBorderSize(1);
+  tdrStyle->SetFrameFillColor(0);
+  tdrStyle->SetFrameFillStyle(0);
+  tdrStyle->SetFrameLineColor(1);
+  tdrStyle->SetFrameLineStyle(1);
+  tdrStyle->SetFrameLineWidth(1);
+
+  // For the histo:
+  tdrStyle->SetHistLineColor(1);
+  tdrStyle->SetHistLineStyle(0);
+  tdrStyle->SetHistLineWidth(1);
+  tdrStyle->SetEndErrorSize(2);
+  tdrStyle->SetErrorX(0.);
+  tdrStyle->SetMarkerStyle(20);
+
+  //For the fit/function:
+  tdrStyle->SetOptFit(1);
+  tdrStyle->SetFitFormat("5.4g");
+  tdrStyle->SetFuncColor(2);
+  tdrStyle->SetFuncStyle(1);
+  tdrStyle->SetFuncWidth(1);
+
+  //For the date:
+  tdrStyle->SetOptDate(0);
+
+  // For the statistics box:
+  tdrStyle->SetOptFile(0);
+  tdrStyle->SetOptStat(0); // To display the mean and RMS:   SetOptStat("mr");
+  tdrStyle->SetStatColor(kWhite);
+  tdrStyle->SetStatFont(42);
+  tdrStyle->SetStatFontSize(0.025);
+  tdrStyle->SetStatTextColor(1);
+  tdrStyle->SetStatFormat("6.4g");
+  tdrStyle->SetStatBorderSize(1);
+  tdrStyle->SetStatH(0.1);
+  tdrStyle->SetStatW(0.15);
+
+  // Margins:
+  tdrStyle->SetPadTopMargin(0.05);
+  tdrStyle->SetPadBottomMargin(0.13);
+  tdrStyle->SetPadLeftMargin(0.16);
+  tdrStyle->SetPadRightMargin(0.02);
+
+  // For the Global title:
+  tdrStyle->SetOptTitle(0);
+  tdrStyle->SetTitleFont(42);
+  tdrStyle->SetTitleColor(1);
+  tdrStyle->SetTitleTextColor(1);
+  tdrStyle->SetTitleFillColor(10);
+  tdrStyle->SetTitleFontSize(0.05);
+
+  // For the axis titles:
+  tdrStyle->SetTitleColor(1, "XYZ");
+  tdrStyle->SetTitleFont(42, "XYZ");
+  tdrStyle->SetTitleSize(0.06, "XYZ");
+  tdrStyle->SetTitleXOffset(0.9);
+  tdrStyle->SetTitleYOffset(1.25);
+
+  // For the axis labels:
+  tdrStyle->SetLabelColor(1, "XYZ");
+  tdrStyle->SetLabelFont(42, "XYZ");
+  tdrStyle->SetLabelOffset(0.007, "XYZ");
+  tdrStyle->SetLabelSize(0.05, "XYZ");
+
+  // For the axis:
+  tdrStyle->SetAxisColor(1, "XYZ");
+  tdrStyle->SetStripDecimals(kTRUE);
+  tdrStyle->SetTickLength(0.03, "XYZ");
+  tdrStyle->SetNdivisions(510, "XYZ");
+  tdrStyle->SetPadTickX(1);  // To get tick marks on the opposite side of the frame
+  tdrStyle->SetPadTickY(1);
+
+  // Change for log plots:
+  tdrStyle->SetOptLogx(0);
+  tdrStyle->SetOptLogy(0);
+  tdrStyle->SetOptLogz(0);
+
+  // Postscript options:
+  tdrStyle->SetPaperSize(20.,20.);
+
+  tdrStyle->cd();
+}
+
+// data dirs
+TString theDirName = "Figures";
+
+// data files
+// All the rootfiles must be present:
+//  TkStrct PixBar PixFwdPlus PixFwdMinus TIB TIDF TIDB TOB TEC BeamPipe InnerServices
+//
+
+// histograms
+TProfile* prof_x0_BeamPipe;
+TProfile* prof_x0_PixBar;
+TProfile* prof_x0_PixFwdPlus;
+TProfile* prof_x0_PixFwdMinus;
+TProfile* prof_x0_TIB;
+TProfile* prof_x0_TIDF;
+TProfile* prof_x0_TIDB;
+TProfile* prof_x0_InnerServices;
+TProfile* prof_x0_TOB;
+TProfile* prof_x0_TEC;
+TProfile* prof_x0_Outside;
+//
+TProfile* prof_x0_SEN;
+TProfile* prof_x0_SUP;
+TProfile* prof_x0_ELE;
+TProfile* prof_x0_CAB;
+TProfile* prof_x0_COL;
+TProfile* prof_x0_OTH;
+TProfile* prof_x0_AIR;
+//
+TH1D* hist_x0_BeamPipe;
+TH1D* hist_x0_Pixel;
+TH1D* hist_x0_IB;
+TH1D* hist_x0_TOB;
+TH1D* hist_x0_TEC;
+TH1D* hist_x0_Outside;
+//
+TH1D* hist_x0_SEN;
+TH1D* hist_x0_SUP;
+TH1D* hist_x0_ELE;
+TH1D* hist_x0_CAB;
+TH1D* hist_x0_COL;
+TH1D* hist_x0_OTH;
+//
+float xmin;
+float xmax; 
+
+float ymin;
+float ymax;
+//
+void createPlots(TString plot);
+
+using namespace std;
+
+// Main
+void MaterialBudgetMtd() {
+
+  //TDR style
+  setTDRStyle();  
+
+  // plots
+  createPlots("x_vs_eta");
+  createPlots("x_vs_phi");
+  createPlots("l_vs_eta");
+  createPlots("l_vs_phi");
+}
+
+void createPlots(TString plot){
+  unsigned int plotNumber = 0;
+  TString abscissaName = "dummy";
+  TString ordinateName = "dummy";
+  if(plot.CompareTo("x_vs_eta") == 0) {
+    plotNumber = 10;
+    abscissaName = TString("#eta");
+    ordinateName = TString("t/X_{0}");
+    ymin =  0.0;
+    ymax =  0.8;
+    xmin = -4.0;
+    xmax =  4.0;
+  }
+  else if(plot.CompareTo("x_vs_phi") == 0) {
+    plotNumber = 20;
+    abscissaName = TString("#varphi [rad]");
+    ordinateName = TString("t/X_{0}");
+    ymin =  0.0;
+    ymax =  0.8;
+    xmin = -3.2;
+    xmax =  3.2;
+  }
+  else if(plot.CompareTo("l_vs_eta") == 0) {
+    plotNumber = 1010;
+    abscissaName = TString("#eta");
+    ordinateName = TString("t/#lambda_{I}");
+    ymin =  0.0;
+    ymax =  0.08;
+    xmin = -4.0;
+    xmax =  4.0;
+  }
+  else if(plot.CompareTo("l_vs_phi") == 0) {
+    plotNumber = 1020;
+    abscissaName = TString("#varphi [rad]");
+    ordinateName = TString("t/#lambda_{I}");
+    ymin =  0.0;
+    ymax =  0.08;
+    xmin = -3.2;
+    xmax =  3.2;
+  }
+  else {
+    cout << " error: chosen plot name not known " << plot << endl;
+    return;
+  }
+  
+
+  // file name
+  TString subDetectorFileName = "matbdg_Mtd.root";
+
+  // open file
+  TFile* subDetectorFile = new TFile(subDetectorFileName);
+  cout << "*** Open file... " << endl;
+  cout << subDetectorFileName << endl;
+  cout << "***" << endl;
+    
+  TProfile* prof_x0 = (TProfile*)subDetectorFile->Get(Form("%u", plotNumber));
+  TH1D* hist_x0  = (TH1D*)prof_x0->ProjectionX();
+  // category profiles
+  TProfile* prof_x0_SUP   = (TProfile*)subDetectorFile->Get(Form("%u", 100 + plotNumber));
+  TProfile* prof_x0_SEN   = (TProfile*)subDetectorFile->Get(Form("%u", 200 + plotNumber));
+  TProfile* prof_x0_CAB   = (TProfile*)subDetectorFile->Get(Form("%u", 300 + plotNumber));
+  TProfile* prof_x0_COL   = (TProfile*)subDetectorFile->Get(Form("%u", 400 + plotNumber));
+  TProfile* prof_x0_ELE   = (TProfile*)subDetectorFile->Get(Form("%u", 500 + plotNumber));
+  TProfile* prof_x0_OTH   = (TProfile*)subDetectorFile->Get(Form("%u", 600 + plotNumber));
+  // add to summary histogram
+  TH1D* hist_x0_SUP = (TH1D*)prof_x0_SUP->ProjectionX();
+  TH1D* hist_x0_SEN = (TH1D*)prof_x0_SEN->ProjectionX();
+  TH1D* hist_x0_CAB = (TH1D*)prof_x0_CAB->ProjectionX();
+  TH1D* hist_x0_COL = (TH1D*)prof_x0_COL->ProjectionX();
+  TH1D* hist_x0_ELE = (TH1D*)prof_x0_ELE->ProjectionX();
+  TH1D* hist_x0_OTH = (TH1D*)prof_x0_OTH->ProjectionX();
+  
+  // colors
+
+  int ksen = 27;
+  int kele = 46;
+  int kcab = kOrange-8;
+  int kcol = 30;
+  int ksup = 38;
+  int koth = kOrange-2;
+
+  hist_x0_SEN->SetFillColor(ksen); // Sensitive   = brown
+  hist_x0_ELE->SetFillColor(kele); // Electronics = red
+  hist_x0_CAB->SetFillColor(kcab); // Cabling     = dark orange 
+  hist_x0_COL->SetFillColor(kcol); // Cooling     = green
+  hist_x0_SUP->SetFillColor(ksup); // Support     = light blue
+  hist_x0_OTH->SetFillColor(koth); // Other+Air   = light orange
+  //
+  
+  
+  TString stackTitle_Materials = Form( "Mtd Material Budget;%s;%s",abscissaName.Data(),ordinateName.Data() );
+  THStack stack_x0_Materials("stack_x0",stackTitle_Materials);
+  stack_x0_Materials.Add(hist_x0_SEN);
+  stack_x0_Materials.Add(hist_x0_CAB);
+  stack_x0_Materials.Add(hist_x0_COL);
+  stack_x0_Materials.Add(hist_x0_ELE);
+  stack_x0_Materials.Add(hist_x0_OTH);
+  stack_x0_Materials.Add(hist_x0_SUP);
+  //
+  
+  // canvas
+  TCanvas can_Materials("can_Materials","can_Materials",800,800);
+  can_Materials.Range(0,0,25,25);
+  can_Materials.SetFillColor(kWhite);
+  gStyle->SetOptStat(0);
+  //
+  
+  // Draw
+  stack_x0_Materials.SetMinimum(ymin);
+  stack_x0_Materials.SetMaximum(ymax);
+  stack_x0_Materials.Draw("HIST");
+  stack_x0_Materials.GetXaxis()->SetLimits(xmin,xmax);
+  //
+  
+  // Legenda
+  TLegend* theLegend_Materials = new TLegend(0.180,0.8,0.98,0.92); 
+  theLegend_Materials->SetNColumns(3); 
+  theLegend_Materials->SetFillColor(0); 
+  theLegend_Materials->SetFillStyle(0); 
+  theLegend_Materials->SetBorderSize(0); 
+
+  theLegend_Materials->AddEntry(hist_x0_SEN, "Sensitive material", "f");
+  theLegend_Materials->AddEntry(hist_x0_COL, "Support/cooling", "f");
+  theLegend_Materials->AddEntry(hist_x0_ELE, "Electronics", "f");
+
+  theLegend_Materials->AddEntry(hist_x0_CAB, "Services", "f");
+  //  theLegend_Materials->AddEntry(hist_x0_SUP, "Support", "f");
+  //  theLegend_Materials->AddEntry(hist_x0_OTH, "Other", "f");
+  theLegend_Materials->Draw();
+  //
+
+  // text
+  TPaveText* text_Materials = new TPaveText(0.180,0.727,0.402,0.787,"NDC");
+  text_Materials->SetFillColor(0);
+  text_Materials->SetBorderSize(0);
+  text_Materials->AddText("CMS Simulation");
+  text_Materials->SetTextAlign(11);
+  text_Materials->Draw();
+  //
+  
+  // Store
+  can_Materials.Update();
+  // can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.eps",  theDirName.Data(), plot.Data() ) );
+  // can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.gif",  theDirName.Data(), plot.Data() ) );
+  can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.pdf",  theDirName.Data(), plot.Data() ) );
+  // can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.png",  theDirName.Data(), plot.Data() ) );
+  can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.root",  theDirName.Data(), plot.Data() ) );
+  // can_Materials.SaveAs( Form( "%s/Mtd_Materials_%s.C",  theDirName.Data(), plot.Data() ) );
+  //
+  
+}

--- a/Validation/Geometry/test/runP_Mtd_cfg.py
+++ b/Validation/Geometry/test/runP_Mtd_cfg.py
@@ -54,7 +54,7 @@ process.source = cms.Source("PoolSource",
 
 process.maxEvents = cms.untracked.PSet(
 #    input = cms.untracked.int32(-1)
-    input = cms.untracked.int32(10)
+    input = cms.untracked.int32(10000)
 )
 
 process.p1 = cms.Path(process.g4SimHits)

--- a/Validation/Geometry/test/runP_Mtd_cfg.py
+++ b/Validation/Geometry/test/runP_Mtd_cfg.py
@@ -1,0 +1,80 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+
+#Geometry
+#
+process.load("Configuration.Geometry.GeometryExtended2023D38_cff")
+
+#Magnetic Field
+#
+process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+
+# Output of events, etc...
+#
+# Explicit note : since some histos/tree might be dumped directly,
+#                 better NOT use PoolOutputModule !
+# Detector simulation (Geant4-based)
+#
+process.load("SimG4Core.Application.g4SimHits_cfi")
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO'),
+#        threshold = cms.untracked.string('DEBUG'),
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        FwkJob = cms.untracked.PSet( ## but FwkJob category - those unlimitted
+            limit = cms.untracked.int32(-1)
+        ),
+        MaterialBudget = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+        ),
+        G4cout = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+        ),
+        G4cerr = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+        ),
+    ),
+    categories = cms.untracked.vstring('FwkJob','MaterialBudget','G4cout','G4cerr'),
+    debugModules = cms.untracked.vstring('g4SimHits'),
+    destinations = cms.untracked.vstring('cout')
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:single_neutrino_random.root')
+)
+
+process.maxEvents = cms.untracked.PSet(
+#    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(10)
+)
+
+process.p1 = cms.Path(process.g4SimHits)
+process.g4SimHits.StackingAction.TrackNeutrino = cms.bool(True)
+process.g4SimHits.UseMagneticField = False
+process.g4SimHits.Physics.type = 'SimG4Core/Physics/DummyPhysics'
+process.g4SimHits.Physics.DummyEMPhysics = True
+process.g4SimHits.Physics.CutsPerRegion = False
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+    type = cms.string('MaterialBudgetAction'),
+    MaterialBudgetAction = cms.PSet(
+        HistosFile = cms.string('matbdg_Mtd.root'),
+        AllStepsToTree = cms.bool(False),
+        HistogramList = cms.string('Mtd'),
+        SelectedVolumes = cms.vstring('BarrelTimingLayer','EndcapTimingLayer'),
+        # string TextFile = "None"          # "None" means this option 
+        TreeFile = cms.string('None'),
+        StopAfterProcess = cms.string('None'),
+        TextFile = cms.string('None')
+    )
+))
+
+

--- a/Validation/Geometry/test/runP_Mtd_cfg.py
+++ b/Validation/Geometry/test/runP_Mtd_cfg.py
@@ -77,4 +77,4 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
     )
 ))
 
-
+process.g4SimHits.G4Commands = cms.vstring("/material/g4/printMaterial")

--- a/Validation/Geometry/test/tdrStyle.C
+++ b/Validation/Geometry/test/tdrStyle.C
@@ -1,0 +1,148 @@
+#include "TStyle.h"
+
+void setTDRStyle() {
+  TStyle *tdrStyle = new TStyle("tdrStyle","Style for P-TDR");
+
+// For the canvas:
+  tdrStyle->SetCanvasBorderMode(0);
+  tdrStyle->SetCanvasColor(kWhite);
+  tdrStyle->SetCanvasDefH(600); //Height of canvas
+  tdrStyle->SetCanvasDefW(600); //Width of canvas
+  tdrStyle->SetCanvasDefX(0);   //POsition on screen
+  tdrStyle->SetCanvasDefY(0);
+
+// For the Pad:
+  tdrStyle->SetPadBorderMode(0);
+  // tdrStyle->SetPadBorderSize(Width_t size = 1);
+  tdrStyle->SetPadColor(kWhite);
+  tdrStyle->SetPadGridX(false);
+  tdrStyle->SetPadGridY(false);
+  tdrStyle->SetGridColor(0);
+  tdrStyle->SetGridStyle(3);
+  tdrStyle->SetGridWidth(1);
+
+// For the frame:
+  tdrStyle->SetFrameBorderMode(0);
+  tdrStyle->SetFrameBorderSize(1);
+  tdrStyle->SetFrameFillColor(0);
+  tdrStyle->SetFrameFillStyle(0);
+  tdrStyle->SetFrameLineColor(1);
+  tdrStyle->SetFrameLineStyle(1);
+  tdrStyle->SetFrameLineWidth(1);
+  
+// For the histo:
+  // tdrStyle->SetHistFillColor(1);
+  // tdrStyle->SetHistFillStyle(0);
+  tdrStyle->SetHistLineColor(1);
+  tdrStyle->SetHistLineStyle(0);
+  tdrStyle->SetHistLineWidth(1);
+  // tdrStyle->SetLegoInnerR(Float_t rad = 0.5);
+  // tdrStyle->SetNumberContours(Int_t number = 20);
+
+  tdrStyle->SetEndErrorSize(2);
+  // tdrStyle->SetErrorMarker(20);
+  //tdrStyle->SetErrorX(0.);
+  
+  tdrStyle->SetMarkerStyle(20);
+  
+//For the fit/function:
+  tdrStyle->SetOptFit(1);
+  tdrStyle->SetFitFormat("5.4g");
+  tdrStyle->SetFuncColor(2);
+  tdrStyle->SetFuncStyle(1);
+  tdrStyle->SetFuncWidth(1);
+
+//For the date:
+  tdrStyle->SetOptDate(0);
+  // tdrStyle->SetDateX(Float_t x = 0.01);
+  // tdrStyle->SetDateY(Float_t y = 0.01);
+
+// For the statistics box:
+  tdrStyle->SetOptFile(0);
+  tdrStyle->SetOptStat(0); // To display the mean and RMS:   SetOptStat("mr");
+  tdrStyle->SetStatColor(kWhite);
+  tdrStyle->SetStatFont(42);
+  tdrStyle->SetStatFontSize(0.025);
+  tdrStyle->SetStatTextColor(1);
+  tdrStyle->SetStatFormat("6.4g");
+  tdrStyle->SetStatBorderSize(1);
+  tdrStyle->SetStatH(0.1);
+  tdrStyle->SetStatW(0.15);
+  // tdrStyle->SetStatStyle(Style_t style = 1001);
+  // tdrStyle->SetStatX(Float_t x = 0);
+  // tdrStyle->SetStatY(Float_t y = 0);
+
+// Margins:
+  tdrStyle->SetPadTopMargin(0.05);
+  tdrStyle->SetPadBottomMargin(0.13);
+  tdrStyle->SetPadLeftMargin(0.16);
+  tdrStyle->SetPadRightMargin(0.02);
+
+// For the Global title:
+
+  tdrStyle->SetOptTitle(0);
+  tdrStyle->SetTitleFont(42);
+  tdrStyle->SetTitleColor(1);
+  tdrStyle->SetTitleTextColor(1);
+  tdrStyle->SetTitleFillColor(10);
+  tdrStyle->SetTitleFontSize(0.05);
+  // tdrStyle->SetTitleH(0); // Set the height of the title box
+  // tdrStyle->SetTitleW(0); // Set the width of the title box
+  // tdrStyle->SetTitleX(0); // Set the position of the title box
+  // tdrStyle->SetTitleY(0.985); // Set the position of the title box
+  // tdrStyle->SetTitleStyle(Style_t style = 1001);
+  // tdrStyle->SetTitleBorderSize(2);
+
+// For the axis titles:
+
+  tdrStyle->SetTitleColor(1, "XYZ");
+  tdrStyle->SetTitleFont(42, "XYZ");
+  tdrStyle->SetTitleSize(0.06, "XYZ");
+  // tdrStyle->SetTitleXSize(Float_t size = 0.02); // Another way to set the size?
+  // tdrStyle->SetTitleYSize(Float_t size = 0.02);
+  tdrStyle->SetTitleXOffset(0.9);
+  tdrStyle->SetTitleYOffset(1.0);
+  // tdrStyle->SetTitleOffset(1.1, "Y"); // Another way to set the Offset
+
+// For the axis labels:
+
+  tdrStyle->SetLabelColor(1, "XYZ");
+  tdrStyle->SetLabelFont(42, "XYZ");
+  tdrStyle->SetLabelOffset(0.007, "XYZ");
+  tdrStyle->SetLabelSize(0.05, "XYZ");
+
+// For the axis:
+
+  tdrStyle->SetAxisColor(1, "XYZ");
+  tdrStyle->SetStripDecimals(kTRUE);
+  tdrStyle->SetTickLength(0.03, "XYZ");
+  tdrStyle->SetNdivisions(510, "XYZ");
+  tdrStyle->SetPadTickX(1);  // To get tick marks on the opposite side of the frame
+  tdrStyle->SetPadTickY(1);
+
+// Change for log plots:
+  tdrStyle->SetOptLogx(0);
+  tdrStyle->SetOptLogy(0);
+  tdrStyle->SetOptLogz(0);
+
+// Postscript options:
+  tdrStyle->SetPaperSize(20.,20.);
+  // tdrStyle->SetLineScalePS(Float_t scale = 3);
+  // tdrStyle->SetLineStyleString(Int_t i, const char* text);
+  // tdrStyle->SetHeaderPS(const char* header);
+  // tdrStyle->SetTitlePS(const char* pstitle);
+
+  // tdrStyle->SetBarOffset(Float_t baroff = 0.5);
+  // tdrStyle->SetBarWidth(Float_t barwidth = 0.5);
+  // tdrStyle->SetPaintTextFormat(const char* format = "g");
+  // tdrStyle->SetPalette(Int_t ncolors = 0, Int_t* colors = 0);
+  // tdrStyle->SetTimeOffset(Double_t toffset);
+  // tdrStyle->SetHistMinimumZero(kTRUE);
+
+  tdrStyle->SetHatchesLineWidth(5);
+  tdrStyle->SetHatchesSpacing(0.05);
+
+  tdrStyle->cd();
+
+}
+


### PR DESCRIPTION
#### PR description:

This PR updates the Validation/Geometry package by adding a class for the evaluation of the MTD material budget. A macro providing plots is also added. The clang-format cleaning has been applied to the whole package.

#### PR validation:

Results of a 10k neutrinos run on scenario D38:

[Mtd_Materials_l_vs_eta.pdf](https://github.com/cms-sw/cmssw/files/3195412/Mtd_Materials_l_vs_eta.pdf)
[Mtd_Materials_x_vs_eta.pdf](https://github.com/cms-sw/cmssw/files/3195413/Mtd_Materials_x_vs_eta.pdf)
