### PR TITLE
Running code-format for alca-db

### DIFF
--- a/CondFormats/BTauObjects/interface/BTagCalibration.h
+++ b/CondFormats/BTauObjects/interface/BTagCalibration.h
@@ -24,18 +24,17 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include "CondFormats/BTauObjects/interface/BTagEntry.h"
 
-class BTagCalibration
-{
+class BTagCalibration {
 public:
   BTagCalibration() {}
   BTagCalibration(const std::string &tagger);
   BTagCalibration(const std::string &tagger, const std::string &filename);
   ~BTagCalibration() {}
 
-  std::string tagger() const {return tagger_;}
+  std::string tagger() const { return tagger_; }
 
   void addEntry(const BTagEntry &entry);
-  const std::vector<BTagEntry>& getEntries(const BTagEntry::Parameters &par) const;
+  const std::vector<BTagEntry> &getEntries(const BTagEntry::Parameters &par) const;
 
   void readCSV(std::istream &s);
   void readCSV(const std::string &s);

--- a/CondFormats/BTauObjects/interface/BTagEntry.h
+++ b/CondFormats/BTauObjects/interface/BTagEntry.h
@@ -21,19 +21,18 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-class BTagEntry
-{
+class BTagEntry {
 public:
   enum OperatingPoint {
-    OP_LOOSE=0,
-    OP_MEDIUM=1,
-    OP_TIGHT=2,
-    OP_RESHAPING=3,
+    OP_LOOSE = 0,
+    OP_MEDIUM = 1,
+    OP_TIGHT = 2,
+    OP_RESHAPING = 3,
   };
   enum JetFlavor {
-    FLAV_B=0,
-    FLAV_C=1,
-    FLAV_UDSG=2,
+    FLAV_B = 0,
+    FLAV_C = 1,
+    FLAV_UDSG = 2,
   };
   struct Parameters {
     OperatingPoint operatingPoint;
@@ -48,25 +47,23 @@ public:
     float discrMax;
 
     // default constructor
-    Parameters(
-      OperatingPoint op=OP_TIGHT,
-      std::string measurement_type="comb",
-      std::string sys_type="central",
-      JetFlavor jf=FLAV_B,
-      float eta_min=-99999.,
-      float eta_max=99999.,
-      float pt_min=0.,
-      float pt_max=99999.,
-      float discr_min=0.,
-      float discr_max=99999.
-    );
+    Parameters(OperatingPoint op = OP_TIGHT,
+               std::string measurement_type = "comb",
+               std::string sys_type = "central",
+               JetFlavor jf = FLAV_B,
+               float eta_min = -99999.,
+               float eta_max = 99999.,
+               float pt_min = 0.,
+               float pt_max = 99999.,
+               float discr_min = 0.,
+               float discr_max = 99999.);
 
     COND_SERIALIZABLE;
   };
 
   BTagEntry() {}
-  BTagEntry(const std::string &csvLine);
-  BTagEntry(const std::string &func, Parameters p);
+  BTagEntry(const std::string& csvLine);
+  BTagEntry(const std::string& func, Parameters p);
   BTagEntry(const TF1* func, Parameters p);
   BTagEntry(const TH1* histo, Parameters p);
   ~BTagEntry() {}

--- a/CondFormats/BTauObjects/interface/CombinedSVCalibration.h
+++ b/CondFormats/BTauObjects/interface/CombinedSVCalibration.h
@@ -7,22 +7,17 @@
 #include "CondFormats/BTauObjects/interface/CalibratedHistogram.h"
 #include <vector>
 
-struct CombinedSVCalibration
-{
-  struct Entry
-  {
+struct CombinedSVCalibration {
+  struct Entry {
     CombinedSVCategoryData category;
     CalibratedHistogram histogram;
-  
+
+    COND_SERIALIZABLE;
+  };
+
+  std::vector<Entry> data;
+
   COND_SERIALIZABLE;
 };
 
- std::vector<Entry> data;
-  
-
- COND_SERIALIZABLE;
-};
-
-#endif //CombinedSVCalibration_h
-
-
+#endif  //CombinedSVCalibration_h

--- a/CondFormats/BTauObjects/interface/CombinedTauTagCalibration.h
+++ b/CondFormats/BTauObjects/interface/CombinedTauTagCalibration.h
@@ -7,21 +7,16 @@
 #include "CondFormats/BTauObjects/interface/CalibratedHistogram.h"
 #include <vector>
 
-struct CombinedTauTagCalibration
-{
-  struct Entry
-  {
-   CombinedTauTagCategoryData category;
-   CalibratedHistogram histogram;
-  
+struct CombinedTauTagCalibration {
+  struct Entry {
+    CombinedTauTagCategoryData category;
+    CalibratedHistogram histogram;
+
+    COND_SERIALIZABLE;
+  };
+
+  std::vector<Entry> data;
+
   COND_SERIALIZABLE;
 };
-
- std::vector<Entry> data;
-  
-
- COND_SERIALIZABLE;
-};
-#endif //CombinedTauTagCalibration_h
-
-
+#endif  //CombinedTauTagCalibration_h

--- a/CondFormats/BTauObjects/interface/CombinedTauTagCategoryData.h
+++ b/CondFormats/BTauObjects/interface/CombinedTauTagCategoryData.h
@@ -4,8 +4,8 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 struct CombinedTauTagCategoryData {
-  int truthmatched1orfake0candidates,theTagVar,signaltks_n;
-  float EtMin,EtMax;
+  int truthmatched1orfake0candidates, theTagVar, signaltks_n;
+  float EtMin, EtMax;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/BTauObjects/interface/TrackProbabilityCalibration.h
+++ b/CondFormats/BTauObjects/interface/TrackProbabilityCalibration.h
@@ -8,22 +8,17 @@
 
 #include <vector>
 
-struct TrackProbabilityCalibration
-{
-  struct Entry
-  {
-   TrackProbabilityCategoryData category;
+struct TrackProbabilityCalibration {
+  struct Entry {
+    TrackProbabilityCategoryData category;
     PhysicsTools::Calibration::HistogramF histogram;
-  
+
+    COND_SERIALIZABLE;
+  };
+
+  std::vector<Entry> data;
+
   COND_SERIALIZABLE;
 };
 
- std::vector<Entry> data;
-  
-
- COND_SERIALIZABLE;
-};
-
-#endif //TrackProbabilityCalibration_h
-
-
+#endif  //TrackProbabilityCalibration_h

--- a/CondFormats/BTauObjects/interface/TrackProbabilityCategoryData.h
+++ b/CondFormats/BTauObjects/interface/TrackProbabilityCategoryData.h
@@ -3,24 +3,14 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-
 struct TrackProbabilityCategoryData {
   float pMin, pMax, etaMin, etaMax;
-  int   nHitsMin, nHitsMax, nPixelHitsMin, nPixelHitsMax;
-  float chiMin,chiMax;
+  int nHitsMin, nHitsMax, nPixelHitsMin, nPixelHitsMax;
+  float chiMin, chiMax;
   float withFirstPixel;
   signed short trackQuality;
 
   COND_SERIALIZABLE;
 };
 
-
 #endif
-
-
-
-
-
-
-
-

--- a/CondFormats/BTauObjects/src/BTagCalibration.cc
+++ b/CondFormats/BTauObjects/src/BTagCalibration.cc
@@ -4,59 +4,42 @@
 #include "CondFormats/BTauObjects/interface/BTagCalibration.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+BTagCalibration::BTagCalibration(const std::string &taggr) : tagger_(taggr) {}
 
-BTagCalibration::BTagCalibration(const std::string &taggr):
-  tagger_(taggr)
-{}
-
-BTagCalibration::BTagCalibration(const std::string &taggr,
-                                 const std::string &filename):
-  tagger_(taggr)
-{
+BTagCalibration::BTagCalibration(const std::string &taggr, const std::string &filename) : tagger_(taggr) {
   std::ifstream ifs(filename);
   if (!ifs.good()) {
-    throw cms::Exception("BTagCalibration")
-          << "input file not available: "
-          << filename;
+    throw cms::Exception("BTagCalibration") << "input file not available: " << filename;
   }
   readCSV(ifs);
   ifs.close();
 }
 
-void BTagCalibration::addEntry(const BTagEntry &entry)
-{
-  data_[token(entry.params)].push_back(entry);
-}
+void BTagCalibration::addEntry(const BTagEntry &entry) { data_[token(entry.params)].push_back(entry); }
 
-const std::vector<BTagEntry>& BTagCalibration::getEntries(
-  const BTagEntry::Parameters &par) const
-{
+const std::vector<BTagEntry> &BTagCalibration::getEntries(const BTagEntry::Parameters &par) const {
   std::string tok = token(par);
   if (!data_.count(tok)) {
-    throw cms::Exception("BTagCalibration")
-          << "(OperatingPoint, measurementType, sysType) not available: "
-          << tok;
+    throw cms::Exception("BTagCalibration") << "(OperatingPoint, measurementType, sysType) not available: " << tok;
   }
   return data_.at(tok);
 }
 
-void BTagCalibration::readCSV(const std::string &s)
-{
+void BTagCalibration::readCSV(const std::string &s) {
   std::stringstream buff(s);
   readCSV(buff);
 }
 
-void BTagCalibration::readCSV(std::istream &s)
-{
+void BTagCalibration::readCSV(std::istream &s) {
   std::string line;
 
   // firstline might be the header
-  getline(s,line);
+  getline(s, line);
   if (line.find("OperatingPoint") == std::string::npos) {
     addEntry(BTagEntry(line));
   }
 
-  while (getline(s,line)) {
+  while (getline(s, line)) {
     line = BTagEntry::trimStr(line);
     if (line.empty()) {  // skip empty lines
       continue;
@@ -65,31 +48,24 @@ void BTagCalibration::readCSV(std::istream &s)
   }
 }
 
-void BTagCalibration::makeCSV(std::ostream &s) const
-{
+void BTagCalibration::makeCSV(std::ostream &s) const {
   s << tagger_ << ";" << BTagEntry::makeCSVHeader();
-  for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i
-           = data_.cbegin(); i != data_.cend(); ++i) {
+  for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i = data_.cbegin(); i != data_.cend(); ++i) {
     const std::vector<BTagEntry> &vec = i->second;
-    for (std::vector<BTagEntry>::const_iterator j
-             = vec.cbegin(); j != vec.cend(); ++j) {
+    for (std::vector<BTagEntry>::const_iterator j = vec.cbegin(); j != vec.cend(); ++j) {
       s << j->makeCSVLine();
     }
   }
 }
 
-std::string BTagCalibration::makeCSV() const
-{
+std::string BTagCalibration::makeCSV() const {
   std::stringstream buff;
   makeCSV(buff);
   return buff.str();
 }
 
-std::string BTagCalibration::token(const BTagEntry::Parameters &par)
-{
+std::string BTagCalibration::token(const BTagEntry::Parameters &par) {
   std::stringstream buff;
-  buff << par.operatingPoint << ", "
-       << par.measurementType << ", "
-       << par.sysType;
+  buff << par.operatingPoint << ", " << par.measurementType << ", " << par.sysType;
   return buff.str();
 }

--- a/CondFormats/BTauObjects/src/BTagEntry.cc
+++ b/CondFormats/BTauObjects/src/BTagEntry.cc
@@ -4,37 +4,31 @@
 #include "CondFormats/BTauObjects/interface/BTagEntry.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-BTagEntry::Parameters::Parameters(
-  OperatingPoint op,
-  std::string measurement_type,
-  std::string sys_type,
-  JetFlavor jf,
-  float eta_min,
-  float eta_max,
-  float pt_min,
-  float pt_max,
-  float discr_min,
-  float discr_max
-):
-  operatingPoint(op),
-  measurementType(measurement_type),
-  sysType(sys_type),
-  jetFlavor(jf),
-  etaMin(eta_min),
-  etaMax(eta_max),
-  ptMin(pt_min),
-  ptMax(pt_max),
-  discrMin(discr_min),
-  discrMax(discr_max)
-{
-  std::transform(measurementType.begin(), measurementType.end(),
-                 measurementType.begin(), ::tolower);
-  std::transform(sysType.begin(), sysType.end(),
-                 sysType.begin(), ::tolower);
+BTagEntry::Parameters::Parameters(OperatingPoint op,
+                                  std::string measurement_type,
+                                  std::string sys_type,
+                                  JetFlavor jf,
+                                  float eta_min,
+                                  float eta_max,
+                                  float pt_min,
+                                  float pt_max,
+                                  float discr_min,
+                                  float discr_max)
+    : operatingPoint(op),
+      measurementType(measurement_type),
+      sysType(sys_type),
+      jetFlavor(jf),
+      etaMin(eta_min),
+      etaMax(eta_max),
+      ptMin(pt_min),
+      ptMax(pt_max),
+      discrMin(discr_min),
+      discrMax(discr_max) {
+  std::transform(measurementType.begin(), measurementType.end(), measurementType.begin(), ::tolower);
+  std::transform(sysType.begin(), sysType.end(), sysType.begin(), ::tolower);
 }
 
-BTagEntry::BTagEntry(const std::string &csvLine)
-{
+BTagEntry::BTagEntry(const std::string& csvLine) {
   // make tokens
   std::stringstream buff(csvLine);
   std::vector<std::string> vec;
@@ -47,75 +41,56 @@ BTagEntry::BTagEntry(const std::string &csvLine)
     vec.push_back(token);
   }
   if (vec.size() != 11) {
-    throw cms::Exception("BTagCalibration")
-          << "Invalid csv line; num tokens != 11: "
-          << csvLine;
+    throw cms::Exception("BTagCalibration") << "Invalid csv line; num tokens != 11: " << csvLine;
   }
 
   // clean string values
   char chars[] = " \"\n";
   for (unsigned int i = 0; i < strlen(chars); ++i) {
-    vec[1].erase(remove(vec[1].begin(),vec[1].end(),chars[i]),vec[1].end());
-    vec[2].erase(remove(vec[2].begin(),vec[2].end(),chars[i]),vec[2].end());
-    vec[10].erase(remove(vec[10].begin(),vec[10].end(),chars[i]),vec[10].end());
+    vec[1].erase(remove(vec[1].begin(), vec[1].end(), chars[i]), vec[1].end());
+    vec[2].erase(remove(vec[2].begin(), vec[2].end(), chars[i]), vec[2].end());
+    vec[10].erase(remove(vec[10].begin(), vec[10].end(), chars[i]), vec[10].end());
   }
 
   // make formula
   formula = vec[10];
   TF1 f1("", formula.c_str());  // compile formula to check validity
   if (f1.IsZombie()) {
-    throw cms::Exception("BTagCalibration")
-          << "Invalid csv line; formula does not compile: "
-          << csvLine;
+    throw cms::Exception("BTagCalibration") << "Invalid csv line; formula does not compile: " << csvLine;
   }
 
   // make parameters
   unsigned op = stoi(vec[0]);
   if (op > 3) {
-    throw cms::Exception("BTagCalibration")
-          << "Invalid csv line; OperatingPoint > 3: "
-          << csvLine;
+    throw cms::Exception("BTagCalibration") << "Invalid csv line; OperatingPoint > 3: " << csvLine;
   }
   unsigned jf = stoi(vec[3]);
   if (jf > 2) {
-    throw cms::Exception("BTagCalibration")
-          << "Invalid csv line; JetFlavor > 2: "
-          << csvLine;
+    throw cms::Exception("BTagCalibration") << "Invalid csv line; JetFlavor > 2: " << csvLine;
   }
-  params = BTagEntry::Parameters(
-    BTagEntry::OperatingPoint(op),
-    vec[1],
-    vec[2],
-    BTagEntry::JetFlavor(jf),
-    stof(vec[4]),
-    stof(vec[5]),
-    stof(vec[6]),
-    stof(vec[7]),
-    stof(vec[8]),
-    stof(vec[9])
-  );
+  params = BTagEntry::Parameters(BTagEntry::OperatingPoint(op),
+                                 vec[1],
+                                 vec[2],
+                                 BTagEntry::JetFlavor(jf),
+                                 stof(vec[4]),
+                                 stof(vec[5]),
+                                 stof(vec[6]),
+                                 stof(vec[7]),
+                                 stof(vec[8]),
+                                 stof(vec[9]));
 }
 
-BTagEntry::BTagEntry(const std::string &func, BTagEntry::Parameters p):
-  formula(func),
-  params(p)
-{
+BTagEntry::BTagEntry(const std::string& func, BTagEntry::Parameters p) : formula(func), params(p) {
   TF1 f1("", formula.c_str());  // compile formula to check validity
   if (f1.IsZombie()) {
-    throw cms::Exception("BTagCalibration")
-          << "Invalid func string; formula does not compile: "
-          << func;
+    throw cms::Exception("BTagCalibration") << "Invalid func string; formula does not compile: " << func;
   }
 }
 
-BTagEntry::BTagEntry(const TF1* func, BTagEntry::Parameters p):
-  formula(std::string(func->GetExpFormula("p").Data())),
-  params(p)
-{
+BTagEntry::BTagEntry(const TF1* func, BTagEntry::Parameters p)
+    : formula(std::string(func->GetExpFormula("p").Data())), params(p) {
   if (func->IsZombie()) {
-    throw cms::Exception("BTagCalibration")
-          << "Invalid TF1 function; function is zombie: "
-          << func->GetName();
+    throw cms::Exception("BTagCalibration") << "Invalid TF1 function; function is zombie: " << func->GetName();
   }
 }
 
@@ -127,7 +102,7 @@ std::string th1ToFormulaLin(const TH1* hist) {
   TAxis const* axis = hist->GetXaxis();
   std::stringstream buff;
   buff << "x<" << axis->GetBinLowEdge(1) << " ? 0. : ";  // default value
-  for (int i=1; i<nbins+1; ++i) {
+  for (int i = 1; i < nbins + 1; ++i) {
     char tmp_buff[50];
     sprintf(tmp_buff,
             "x<%g ? %g : ",  // %g is the smaller one of %e or %f
@@ -142,23 +117,23 @@ std::string th1ToFormulaLin(const TH1* hist) {
 // Creates step functions making a binary search tree:
 // "x<mid_bin_bound ? (<left side tree>) : (<right side tree>)"
 // e.g. "x<2 ? (x<1 ? (x<0 ? 0:0.1) : (1)) : (x<4 ? (x<3 ? 2:3) : (0))"
-std::string th1ToFormulaBinTree(const TH1* hist, int start=0, int end=-1) {
-  if (end == -1) {                      // initialize
+std::string th1ToFormulaBinTree(const TH1* hist, int start = 0, int end = -1) {
+  if (end == -1) {  // initialize
     start = 0.;
-    end = hist->GetNbinsX()+1;
-    TH1* h2 = (TH1*) hist->Clone();
+    end = hist->GetNbinsX() + 1;
+    TH1* h2 = (TH1*)hist->Clone();
     h2->SetBinContent(start, 0);  // kill underflow
     h2->SetBinContent(end, 0);    // kill overflow
     std::string res = th1ToFormulaBinTree(h2, start, end);
     delete h2;
     return res;
   }
-  if (start == end) {                   // leave is reached
+  if (start == end) {  // leave is reached
     char tmp_buff[20];
     sprintf(tmp_buff, "%g", hist->GetBinContent(start));
     return std::string(tmp_buff);
   }
-  if (start == end - 1) {               // no parenthesis for neighbors
+  if (start == end - 1) {  // no parenthesis for neighbors
     char tmp_buff[70];
     sprintf(tmp_buff,
             "x<%g ? %g:%g",
@@ -170,22 +145,15 @@ std::string th1ToFormulaBinTree(const TH1* hist, int start=0, int end=-1) {
 
   // top-down recursion
   std::stringstream buff;
-  int mid = (end-start)/2 + start;
+  int mid = (end - start) / 2 + start;
   char tmp_buff[25];
-  sprintf(tmp_buff,
-          "x<%g ? (",
-          hist->GetXaxis()->GetBinUpEdge(mid));
-  buff << tmp_buff
-       << th1ToFormulaBinTree(hist, start, mid)
-       << ") : ("
-       << th1ToFormulaBinTree(hist, mid+1, end)
+  sprintf(tmp_buff, "x<%g ? (", hist->GetXaxis()->GetBinUpEdge(mid));
+  buff << tmp_buff << th1ToFormulaBinTree(hist, start, mid) << ") : (" << th1ToFormulaBinTree(hist, mid + 1, end)
        << ")";
   return buff.str();
 }
 
-BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
-  params(p)
-{
+BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p) : params(p) {
   int nbins = hist->GetNbinsX();
   TAxis const* axis = hist->GetXaxis();
 
@@ -210,13 +178,11 @@ BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
   TF1 f1("", formula.c_str());
   if (f1.IsZombie()) {
     throw cms::Exception("BTagCalibration")
-          << "Invalid histogram; formula does not compile (>150 bins?): "
-          << hist->GetName();
+        << "Invalid histogram; formula does not compile (>150 bins?): " << hist->GetName();
   }
 }
 
-std::string BTagEntry::makeCSVHeader()
-{
+std::string BTagEntry::makeCSVHeader() {
   return "OperatingPoint, "
          "measurementType, "
          "sysType, "
@@ -230,30 +196,20 @@ std::string BTagEntry::makeCSVHeader()
          "formula \n";
 }
 
-std::string BTagEntry::makeCSVLine() const
-{
+std::string BTagEntry::makeCSVLine() const {
   std::stringstream buff;
-  buff << params.operatingPoint
-       << ", " << params.measurementType
-       << ", " << params.sysType
-       << ", " << params.jetFlavor
-       << ", " << params.etaMin
-       << ", " << params.etaMax
-       << ", " << params.ptMin
-       << ", " << params.ptMax
-       << ", " << params.discrMin
-       << ", " << params.discrMax
-       << ", \"" << formula
-       << "\" \n";
+  buff << params.operatingPoint << ", " << params.measurementType << ", " << params.sysType << ", " << params.jetFlavor
+       << ", " << params.etaMin << ", " << params.etaMax << ", " << params.ptMin << ", " << params.ptMax << ", "
+       << params.discrMin << ", " << params.discrMax << ", \"" << formula << "\" \n";
   return buff.str();
 }
 
 std::string BTagEntry::trimStr(std::string str) {
   size_t s = str.find_first_not_of(" \n\r\t");
-  size_t e = str.find_last_not_of (" \n\r\t");
+  size_t e = str.find_last_not_of(" \n\r\t");
 
-  if((std::string::npos == s) || (std::string::npos == e))
+  if ((std::string::npos == s) || (std::string::npos == e))
     return "";
   else
-    return str.substr(s, e-s+1);
+    return str.substr(s, e - s + 1);
 }

--- a/CondFormats/BTauObjects/src/classes.h
+++ b/CondFormats/BTauObjects/src/classes.h
@@ -1,7 +1,5 @@
 #include "CondFormats/BTauObjects/src/headers.h"
 
-
-
 namespace CondFormats_BTauObjects {
   struct dictionary {
     std::vector<float> b1;
@@ -29,4 +27,4 @@ namespace CondFormats_BTauObjects {
     std::map<std::string, std::vector<BTagEntry> > mv_bte1;
     BTagCalibration btc1;
   };
-}
+}  // namespace CondFormats_BTauObjects

--- a/CondFormats/BTauObjects/test/testBTagCalibration.cpp
+++ b/CondFormats/BTauObjects/test/testBTagCalibration.cpp
@@ -5,36 +5,28 @@
 
 #include "CondFormats/BTauObjects/src/headers.h"
 
-int main()
-{
+int main() {
   using namespace std;
 
   string csv1(
-    "0, comb, up, 0, 1, 2, 3, 4, 5, 6, \"2*x\" \n"
-    "0, comb, central, 0, 1, 2, 3, 4, 5, 6, \"2*x\" \n"
-    "0, comb, central, 0, 1, 2, 3, 4, 6, 7, \"2*x\" \n"
-    " \n \t    \t"
-    "0, ttbar, central, 0, 1, 2, 3, 4, 6, 7, \"2*x\" \n"
-    "1, comb, central, 0, 1, 2, 3, 4, 6, 7, \"2*x\" \n"
-    "0, comb, down, 0, 1, 2, 3, 4, 5, 6, \"2*x\" \n"
-  );
+      "0, comb, up, 0, 1, 2, 3, 4, 5, 6, \"2*x\" \n"
+      "0, comb, central, 0, 1, 2, 3, 4, 5, 6, \"2*x\" \n"
+      "0, comb, central, 0, 1, 2, 3, 4, 6, 7, \"2*x\" \n"
+      " \n \t    \t"
+      "0, ttbar, central, 0, 1, 2, 3, 4, 6, 7, \"2*x\" \n"
+      "1, comb, central, 0, 1, 2, 3, 4, 6, 7, \"2*x\" \n"
+      "0, comb, down, 0, 1, 2, 3, 4, 5, 6, \"2*x\" \n");
   stringstream csv1Stream(csv1);
   BTagCalibration b1("csv");
   b1.readCSV(csv1Stream);
 
   // assert correct length of vectors
-  auto e1 = b1.getEntries(
-    BTagEntry::Parameters(BTagEntry::OP_LOOSE, "comb", "central")
-  );
-  assert (e1.size() == 2);
-  auto e2 = b1.getEntries(
-    BTagEntry::Parameters(BTagEntry::OP_LOOSE, "comb", "up")
-  );
-  assert (e2.size() == 1);
-  auto e3 = b1.getEntries(
-    BTagEntry::Parameters(BTagEntry::OP_MEDIUM, "comb", "central")
-  );
-  assert (e3.size() == 1);
+  auto e1 = b1.getEntries(BTagEntry::Parameters(BTagEntry::OP_LOOSE, "comb", "central"));
+  assert(e1.size() == 2);
+  auto e2 = b1.getEntries(BTagEntry::Parameters(BTagEntry::OP_LOOSE, "comb", "up"));
+  assert(e2.size() == 1);
+  auto e3 = b1.getEntries(BTagEntry::Parameters(BTagEntry::OP_MEDIUM, "comb", "central"));
+  assert(e3.size() == 1);
 
   // check csv output (ordering arbitrary)
   string tggr = "testTagger";
@@ -49,11 +41,7 @@ int main()
 
   stringstream csv3Stream;
   b2.makeCSV(csv3Stream);
-  assert (
-    csv2Stream1.str() == csv3Stream.str() ||
-    csv2Stream2.str() == csv3Stream.str()
-  );
+  assert(csv2Stream1.str() == csv3Stream.str() || csv2Stream2.str() == csv3Stream.str());
 
   return 0;
 }
-

--- a/CondFormats/BTauObjects/test/testBTagEntry.cpp
+++ b/CondFormats/BTauObjects/test/testBTagEntry.cpp
@@ -6,13 +6,12 @@
 
 #include "CondFormats/BTauObjects/src/headers.h"
 
-int main()
-{
+int main() {
   using namespace std;
 
   auto par1 = BTagEntry::Parameters(BTagEntry::OP_TIGHT, "CoMb", "cEnTrAl_");
-  assert (par1.measurementType == std::string("comb"));
-  assert (par1.sysType == string("central_"));
+  assert(par1.measurementType == std::string("comb"));
+  assert(par1.sysType == string("central_"));
 
   // default constructor
   auto b1 = BTagEntry();
@@ -20,39 +19,35 @@ int main()
   // function constructor
   auto f1 = TF1("", "[0]*x");
   f1.SetParameter(0, 2);
-  auto b2 = BTagEntry(
-    &f1,
-    BTagEntry::Parameters(BTagEntry::OP_TIGHT, "comb", "up", BTagEntry::FLAV_C)
-  );
-  assert (b2.formula == string("2*x"));
+  auto b2 = BTagEntry(&f1, BTagEntry::Parameters(BTagEntry::OP_TIGHT, "comb", "up", BTagEntry::FLAV_C));
+  assert(b2.formula == string("2*x"));
 
   // histo constructor
-  auto h1 = TH1F("h1", "", 3, 0., 1.);  // lin.
+  auto h1 = TH1F("h1", "", 3, 0., 1.);    // lin.
   auto h2 = TH1F("h2", "", 100, 0., 1.);  // bin. tree
   auto sin = TF1("sin", "sin(x)");
-  for (float f=0.01f; f<1.f; f+=.01f) {
-    h1.Fill(f, sin.Eval(f)/30.);
+  for (float f = 0.01f; f < 1.f; f += .01f) {
+    h1.Fill(f, sin.Eval(f) / 30.);
     h2.Fill(f, sin.Eval(f));
   }
   auto f3_1 = TF1("", BTagEntry(&h1, par1).formula.c_str());
   auto f3_2 = TF1("", BTagEntry(&h2, par1).formula.c_str());
-  for (float f=0.01f; f<1.f; f+=.01f) {
-    assert (fabs(h1.GetBinContent(h1.FindBin(f)) - f3_1.Eval(f)) < 1e-5);
-    assert (fabs(h2.GetBinContent(h2.FindBin(f)) - f3_2.Eval(f)) < 1e-5);
+  for (float f = 0.01f; f < 1.f; f += .01f) {
+    assert(fabs(h1.GetBinContent(h1.FindBin(f)) - f3_1.Eval(f)) < 1e-5);
+    assert(fabs(h2.GetBinContent(h2.FindBin(f)) - f3_2.Eval(f)) < 1e-5);
   }
 
   // csv constructor
   string csv = "0, comb, up, 0, 1, 2, 3, 4, 5, 6, \"2*x\" \n";
   auto b4 = BTagEntry(csv);
   auto csv2 = b4.makeCSVLine();
-  assert (b4.params.etaMin == 1);
-  assert (b4.params.etaMax == 2);
-  assert (b4.params.ptMin == 3);
-  assert (b4.params.ptMax == 4);
-  assert (b4.params.discrMin == 5);
-  assert (b4.params.discrMax == 6);
-  assert (csv == csv2);
+  assert(b4.params.etaMin == 1);
+  assert(b4.params.etaMax == 2);
+  assert(b4.params.ptMin == 3);
+  assert(b4.params.ptMax == 4);
+  assert(b4.params.discrMin == 5);
+  assert(b4.params.discrMax == 6);
+  assert(csv == csv2);
 
   return 0;
 }
-

--- a/CondFormats/BTauObjects/test/testSerializationBTauObjects.cpp
+++ b/CondFormats/BTauObjects/test/testSerializationBTauObjects.cpp
@@ -2,24 +2,23 @@
 
 #include "CondFormats/BTauObjects/src/headers.h"
 
-int main()
-{
-    testSerialization<CombinedSVCalibration>();
-    testSerialization<CombinedSVCalibration::Entry>();
-    testSerialization<CombinedSVCategoryData>();
-    testSerialization<CombinedTauTagCalibration>();
-    testSerialization<CombinedTauTagCalibration::Entry>();
-    testSerialization<CombinedTauTagCategoryData>();
-    testSerialization<TrackProbabilityCalibration>();
-    testSerialization<TrackProbabilityCalibration::Entry>();
-    testSerialization<TrackProbabilityCategoryData>();
-    testSerialization<std::vector<CombinedSVCalibration::Entry>>();
-    testSerialization<std::vector<CombinedTauTagCalibration::Entry>>();
-    testSerialization<std::vector<TrackProbabilityCalibration::Entry>>();
+int main() {
+  testSerialization<CombinedSVCalibration>();
+  testSerialization<CombinedSVCalibration::Entry>();
+  testSerialization<CombinedSVCategoryData>();
+  testSerialization<CombinedTauTagCalibration>();
+  testSerialization<CombinedTauTagCalibration::Entry>();
+  testSerialization<CombinedTauTagCategoryData>();
+  testSerialization<TrackProbabilityCalibration>();
+  testSerialization<TrackProbabilityCalibration::Entry>();
+  testSerialization<TrackProbabilityCategoryData>();
+  testSerialization<std::vector<CombinedSVCalibration::Entry>>();
+  testSerialization<std::vector<CombinedTauTagCalibration::Entry>>();
+  testSerialization<std::vector<TrackProbabilityCalibration::Entry>>();
 
-    testSerialization<BTagEntry>();
-    testSerialization<BTagEntry::Parameters>();
-    testSerialization<BTagCalibration>();
+  testSerialization<BTagEntry>();
+  testSerialization<BTagEntry::Parameters>();
+  testSerialization<BTagCalibration>();
 
-    return 0;
+  return 0;
 }

--- a/CondFormats/CastorObjects/interface/CastorCalibrationQIECoder.h
+++ b/CondFormats/CastorObjects/interface/CastorCalibrationQIECoder.h
@@ -15,21 +15,22 @@ $Id
 #include <boost/cstdint.hpp>
 
 class CastorCalibrationQIECoder {
- public:
-  CastorCalibrationQIECoder (unsigned long fId = 0) : mId (fId) {}
+public:
+  CastorCalibrationQIECoder(unsigned long fId = 0) : mId(fId) {}
   /// ADC [0..31] -> fC conversion
-  float charge (const unsigned fAdc) const;
+  float charge(const unsigned fAdc) const;
   /// fC -> ADC conversion
-  unsigned adc (const float fCharge) const;
+  unsigned adc(const float fCharge) const;
 
   // following methods are not for use by consumers
-  float minCharge (unsigned fBin) const;
-  // 32 values 
-  const float* minCharges () const;
-  void setMinCharge (unsigned fBin, float fValue);
-  void setMinCharges (const float fValue [32]);
-  uint32_t rawId () const {return mId;}
- private:
+  float minCharge(unsigned fBin) const;
+  // 32 values
+  const float* minCharges() const;
+  void setMinCharge(unsigned fBin, float fValue);
+  void setMinCharges(const float fValue[32]);
+  uint32_t rawId() const { return mId; }
+
+private:
   uint32_t mId;
   float bin0;
   float bin1;
@@ -63,10 +64,10 @@ class CastorCalibrationQIECoder {
   float bin29;
   float bin30;
   float bin31;
-  const float* base () const {return &bin0;}
-  float* base () {return &bin0;}
+  const float* base() const { return &bin0; }
+  float* base() { return &bin0; }
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorCalibrationQIEData.h
+++ b/CondFormats/CastorObjects/interface/CastorCalibrationQIEData.h
@@ -21,22 +21,18 @@ $Id
 #include "CondFormats/CastorObjects/interface/CastorCalibrationQIECoder.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-
-class CastorCalibrationQIEData: public CastorCondObjectContainer<CastorCalibrationQIECoder>
-{
- public:
-   
+class CastorCalibrationQIEData : public CastorCondObjectContainer<CastorCalibrationQIECoder> {
+public:
   /// get QIE parameters
-  const CastorCalibrationQIECoder* getCoder (DetId fId) const { return getValues(fId); }
+  const CastorCalibrationQIECoder* getCoder(DetId fId) const { return getValues(fId); }
   // check if data are sorted
-  bool sorted () const {return true;}
+  bool sorted() const { return true; }
   // fill values [capid][range]
-  bool addCoder (const CastorCalibrationQIECoder& fCoder) { return addValues(fCoder); }
-   // sort values by channelId  
-  void sort () {}
+  bool addCoder(const CastorCalibrationQIECoder& fCoder) { return addValues(fCoder); }
+  // sort values by channelId
+  void sort() {}
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorChannelQuality.h
+++ b/CondFormats/CastorObjects/interface/CastorChannelQuality.h
@@ -14,18 +14,14 @@ POOL object to store CastorChannelStatus
 
 //typedef CastorCondObjectContainer<CastorChannelStatus> CastorChannelQuality;
 
-class CastorChannelQuality: public CastorCondObjectContainer<CastorChannelStatus>
-{
- public:
-  CastorChannelQuality():CastorCondObjectContainer<CastorChannelStatus>() {}
+class CastorChannelQuality : public CastorCondObjectContainer<CastorChannelStatus> {
+public:
+  CastorChannelQuality() : CastorCondObjectContainer<CastorChannelStatus>() {}
 
-  std::string myname() const {return (std::string)"CastorChannelQuality";}
+  std::string myname() const { return (std::string) "CastorChannelQuality"; }
 
- private:
-
- COND_SERIALIZABLE;
+private:
+  COND_SERIALIZABLE;
 };
 
-
 #endif
-

--- a/CondFormats/CastorObjects/interface/CastorChannelStatus.h
+++ b/CondFormats/CastorObjects/interface/CastorChannelStatus.h
@@ -12,9 +12,8 @@ contains one channel status and corresponding DetId
 #include <boost/cstdint.hpp>
 #include <string>
 
-class CastorChannelStatus
-{
- public:
+class CastorChannelStatus {
+public:
   // contains the defined bits for easy access, see https://twiki.cern.ch/twiki/bin/view/CMS/CastorDataValidationWorkflow
   /* Original Hcal stuff
   enum StatusBit {       
@@ -25,59 +24,53 @@ class CastorChannelStatus
     HcalCellStabErr=7,  // 1=Hcal cell has stability error
     HcalCellTimErr=8    // 1=Hcal cell has timing error
   };*/
-  enum StatusBit {
-    UNKNOWN = 0,
-    BAD = 1,
-    GOOD = 2,
-    HOT = 3,
-    DEAD = 4,
-    END = 5
-  };
+  enum StatusBit { UNKNOWN = 0, BAD = 1, GOOD = 2, HOT = 3, DEAD = 4, END = 5 };
 
-  CastorChannelStatus(): mId(0), mStatus(0) {}
-  CastorChannelStatus(unsigned long fid, uint32_t status): mId(fid), mStatus(status) {}
-  CastorChannelStatus(unsigned long fid, std::string status): mId(fid)
-                     {
-                        if      (status=="BAD")    mStatus = BAD;
-                        else if (status=="GOOD")   mStatus = GOOD;
-                        else if (status=="HOT")    mStatus = HOT;
-                        else if (status=="DEAD")   mStatus = DEAD;
-                        else if (status=="END")    mStatus = END;
-                        else                       mStatus = UNKNOWN;
-                     }
+  CastorChannelStatus() : mId(0), mStatus(0) {}
+  CastorChannelStatus(unsigned long fid, uint32_t status) : mId(fid), mStatus(status) {}
+  CastorChannelStatus(unsigned long fid, std::string status) : mId(fid) {
+    if (status == "BAD")
+      mStatus = BAD;
+    else if (status == "GOOD")
+      mStatus = GOOD;
+    else if (status == "HOT")
+      mStatus = HOT;
+    else if (status == "DEAD")
+      mStatus = DEAD;
+    else if (status == "END")
+      mStatus = END;
+    else
+      mStatus = UNKNOWN;
+  }
 
   //  void setDetId(unsigned long fid) {mId = fid;}
-  void setValue(uint32_t value) {mStatus = value;}
+  void setValue(uint32_t value) { mStatus = value; }
 
   // for the following, one can use unsigned int values or CastorChannelStatus::StatusBit values
   //   e.g. 4 or CastorChannelStatus::DEAD
-  void setBit(unsigned int bitnumber) 
-  {
-    uint32_t statadd = 0x1<<(bitnumber);
-    mStatus = mStatus|statadd;
+  void setBit(unsigned int bitnumber) {
+    uint32_t statadd = 0x1 << (bitnumber);
+    mStatus = mStatus | statadd;
   }
-  void unsetBit(unsigned int bitnumber) 
-  {
-    uint32_t statadd = 0x1<<(bitnumber);
+  void unsetBit(unsigned int bitnumber) {
+    uint32_t statadd = 0x1 << (bitnumber);
     statadd = ~statadd;
-    mStatus = mStatus&statadd;
+    mStatus = mStatus & statadd;
   }
-  
-  bool isBitSet(unsigned int bitnumber) const
-  {
-    uint32_t statadd = 0x1<<(bitnumber);
-    return (mStatus&statadd)?(true):(false);
+
+  bool isBitSet(unsigned int bitnumber) const {
+    uint32_t statadd = 0x1 << (bitnumber);
+    return (mStatus & statadd) ? (true) : (false);
   }
-  
-  uint32_t rawId() const {return mId;}
-  
-  uint32_t getValue() const {return mStatus;}
-  
- private:
+
+  uint32_t rawId() const { return mId; }
+
+  uint32_t getValue() const { return mStatus; }
+
+private:
   uint32_t mId;
   uint32_t mStatus;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 #endif

--- a/CondFormats/CastorObjects/interface/CastorElectronicsMap.h
+++ b/CondFormats/CastorObjects/interface/CastorElectronicsMap.h
@@ -26,9 +26,9 @@ Modified for CASTOR by L. Mundim
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "DataFormats/HcalDetId/interface/CastorElectronicsId.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
-// 
+//
 class CastorElectronicsMap {
- public:
+public:
   CastorElectronicsMap();
   ~CastorElectronicsMap();
 
@@ -63,46 +63,45 @@ class CastorElectronicsMap {
   /// brief lookup the DetId and full electronics id associated with this partial (dcc/spigot/slb/slbchan) id
   bool lookup(const CastorElectronicsId pId, CastorElectronicsId& eid, HcalTrigTowerDetId& did) const;
 
-  std::vector <CastorElectronicsId> allElectronicsId () const;
-  std::vector <CastorElectronicsId> allElectronicsIdPrecision() const;
-  std::vector <CastorElectronicsId> allElectronicsIdTrigger() const;
-  std::vector <HcalGenericDetId> allPrecisionId () const;
-  std::vector <HcalTrigTowerDetId> allTriggerId () const;
+  std::vector<CastorElectronicsId> allElectronicsId() const;
+  std::vector<CastorElectronicsId> allElectronicsIdPrecision() const;
+  std::vector<CastorElectronicsId> allElectronicsIdTrigger() const;
+  std::vector<HcalGenericDetId> allPrecisionId() const;
+  std::vector<HcalTrigTowerDetId> allTriggerId() const;
 
   // map channels
-  bool mapEId2tId (CastorElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId);
-  bool mapEId2chId (CastorElectronicsId fElectronicsId, DetId fId);
+  bool mapEId2tId(CastorElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId);
+  bool mapEId2chId(CastorElectronicsId fElectronicsId, DetId fId);
   // sorting
-  void sortById () const;
-  void sortByTriggerId () const;
+  void sortById() const;
+  void sortByTriggerId() const;
   void sort() {}
 
-  class PrecisionItem { 
+  class PrecisionItem {
   public:
-    PrecisionItem () {mId = mElId = 0;}
-    PrecisionItem (uint32_t fId, uint32_t fElId) 
-      : mId (fId), mElId (fElId) {}
+    PrecisionItem() { mId = mElId = 0; }
+    PrecisionItem(uint32_t fId, uint32_t fElId) : mId(fId), mElId(fElId) {}
     uint32_t mId;
     uint32_t mElId;
-  
-  COND_SERIALIZABLE;
-};
-  class TriggerItem { 
+
+    COND_SERIALIZABLE;
+  };
+  class TriggerItem {
   public:
-    TriggerItem () {mElId = mTrigId = 0;}
-    TriggerItem (uint32_t fTrigId, uint32_t fElId) 
-      : mTrigId (fTrigId), mElId (fElId) { }
+    TriggerItem() { mElId = mTrigId = 0; }
+    TriggerItem(uint32_t fTrigId, uint32_t fElId) : mTrigId(fTrigId), mElId(fElId) {}
     uint32_t mTrigId;
     uint32_t mElId;
-  
-  COND_SERIALIZABLE;
-};
- protected:
-  const PrecisionItem* findById (unsigned long fId) const;
-  const PrecisionItem* findPByElId (unsigned long fElId) const;
-  const TriggerItem* findTByElId (unsigned long fElId) const;
-  const TriggerItem* findByTrigId (unsigned long fTrigId) const;
-  
+
+    COND_SERIALIZABLE;
+  };
+
+protected:
+  const PrecisionItem* findById(unsigned long fId) const;
+  const PrecisionItem* findPByElId(unsigned long fElId) const;
+  const TriggerItem* findTByElId(unsigned long fElId) const;
+  const TriggerItem* findByTrigId(unsigned long fTrigId) const;
+
   std::vector<PrecisionItem> mPItems;
   std::vector<TriggerItem> mTItems;
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
@@ -113,7 +112,7 @@ class CastorElectronicsMap {
   mutable std::vector<const TriggerItem*>* mTItemsByTrigId COND_TRANSIENT;
 #endif
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorGain.h
+++ b/CondFormats/CastorObjects/interface/CastorGain.h
@@ -12,33 +12,29 @@ POOL object to store Gain values 4xCapId
 #include <boost/cstdint.hpp>
 
 class CastorGain {
- public:
+public:
   /// get value for all capId = 0..3
-  const float* getValues () const {return &mValue0;}
+  const float* getValues() const { return &mValue0; }
   /// get value for capId = 0..3
-  float getValue (int fCapId) const {return *(getValues () + fCapId);}
+  float getValue(int fCapId) const { return *(getValues() + fCapId); }
 
   // functions below are not supposed to be used by consumer applications
 
-  CastorGain () : mId (0), mValue0 (0), mValue1 (0), mValue2 (0), mValue3 (0) {}
-  
-  CastorGain (unsigned long fId, float fCap0, float fCap1, float fCap2, float fCap3) :
-    mId (fId),
-    mValue0 (fCap0),
-    mValue1 (fCap1),
-    mValue2 (fCap2),
-    mValue3 (fCap3) {}
+  CastorGain() : mId(0), mValue0(0), mValue1(0), mValue2(0), mValue3(0) {}
 
-  uint32_t rawId () const {return mId;}
+  CastorGain(unsigned long fId, float fCap0, float fCap1, float fCap2, float fCap3)
+      : mId(fId), mValue0(fCap0), mValue1(fCap1), mValue2(fCap2), mValue3(fCap3) {}
 
- private:
+  uint32_t rawId() const { return mId; }
+
+private:
   uint32_t mId;
   float mValue0;
   float mValue1;
   float mValue2;
   float mValue3;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorGainWidth.h
+++ b/CondFormats/CastorObjects/interface/CastorGainWidth.h
@@ -11,33 +11,29 @@ POOL object to store GainWidth values 4xCapId
 #include <boost/cstdint.hpp>
 
 class CastorGainWidth {
- public:
+public:
   /// get value for all capId = 0..3
-  const float* getValues () const {return &mValue0;}
+  const float* getValues() const { return &mValue0; }
   /// get value for capId = 0..3
-  float getValue (int fCapId) const {return *(getValues () + fCapId);}
+  float getValue(int fCapId) const { return *(getValues() + fCapId); }
 
   // functions below are not supposed to be used by consumer applications
 
-  CastorGainWidth () : mId (0), mValue0 (0), mValue1 (0), mValue2 (0), mValue3 (0) {}
-  
-  CastorGainWidth (unsigned long fId, float fCap0, float fCap1, float fCap2, float fCap3) :
-    mId (fId),
-    mValue0 (fCap0),
-    mValue1 (fCap1),
-    mValue2 (fCap2),
-    mValue3 (fCap3) {}
+  CastorGainWidth() : mId(0), mValue0(0), mValue1(0), mValue2(0), mValue3(0) {}
 
-  uint32_t rawId () const {return mId;}
+  CastorGainWidth(unsigned long fId, float fCap0, float fCap1, float fCap2, float fCap3)
+      : mId(fId), mValue0(fCap0), mValue1(fCap1), mValue2(fCap2), mValue3(fCap3) {}
 
- private:
+  uint32_t rawId() const { return mId; }
+
+private:
   uint32_t mId;
   float mValue0;
   float mValue1;
   float mValue2;
   float mValue3;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorGainWidths.h
+++ b/CondFormats/CastorObjects/interface/CastorGainWidths.h
@@ -15,16 +15,14 @@ POOL container to store GainWidth values 4xCapId
 
 //typedef CastorCondObjectContainer<CastorGainWidth> CastorGainWidths;
 
-class CastorGainWidths: public CastorCondObjectContainer<CastorGainWidth>
-{
- public:
-  CastorGainWidths():CastorCondObjectContainer<CastorGainWidth>() {}
+class CastorGainWidths : public CastorCondObjectContainer<CastorGainWidth> {
+public:
+  CastorGainWidths() : CastorCondObjectContainer<CastorGainWidth>() {}
 
-  std::string myname() const {return (std::string)"CastorGainWidths";}
+  std::string myname() const { return (std::string) "CastorGainWidths"; }
 
- private:
-
- COND_SERIALIZABLE;
+private:
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorGains.h
+++ b/CondFormats/CastorObjects/interface/CastorGains.h
@@ -15,16 +15,14 @@ POOL container to store Gain values 4xCapId
 
 //typedef CastorCondObjectContainer<CastorGain> CastorGains;
 
-class CastorGains: public CastorCondObjectContainer<CastorGain>
-{
- public:
-  CastorGains():CastorCondObjectContainer<CastorGain>() {}
+class CastorGains : public CastorCondObjectContainer<CastorGain> {
+public:
+  CastorGains() : CastorCondObjectContainer<CastorGain>() {}
 
-  std::string myname() const {return (std::string)"CastorGains";}
+  std::string myname() const { return (std::string) "CastorGains"; }
 
- private:
-
- COND_SERIALIZABLE;
+private:
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorPedestal.h
+++ b/CondFormats/CastorObjects/interface/CastorPedestal.h
@@ -15,29 +15,44 @@ Adapted for CASTOR by L. Mundim (26/03/2009)
 #include <boost/cstdint.hpp>
 
 class CastorPedestal {
- public:
+public:
   /// get value for all capId = 0..3
-  const float* getValues () const {return &mValue0;}
+  const float* getValues() const { return &mValue0; }
   /// get value for capId = 0..3
-  float getValue (int fCapId) const {return *(getValues () + fCapId);}
+  float getValue(int fCapId) const { return *(getValues() + fCapId); }
 
   /// get width for all capId = 0..3
-  const float* getWidths () const {return &mWidth0;}
+  const float* getWidths() const { return &mWidth0; }
   /// get width for capId = 0..3
-  float getWidth (int fCapId) const {return *(getWidths () + fCapId);}
+  float getWidth(int fCapId) const { return *(getWidths() + fCapId); }
 
   // functions below are not supposed to be used by consumer applications
 
-  CastorPedestal () : mId (0), mValue0 (0), mValue1 (0), mValue2 (0), mValue3 (0), 
-    mWidth0 (0), mWidth1 (0), mWidth2 (0), mWidth3 (0) {}
-  
-  CastorPedestal (unsigned long fId, float fCap0, float fCap1, float fCap2, float fCap3,
-		float wCap0 = 0, float wCap1 = 0, float wCap2 = 0, float wCap3 = 0) :
-  mId (fId), mValue0 (fCap0), mValue1 (fCap1), mValue2 (fCap2), mValue3 (fCap3),
-    mWidth0 (wCap0), mWidth1 (wCap1), mWidth2 (wCap2), mWidth3 (wCap3) {}
+  CastorPedestal()
+      : mId(0), mValue0(0), mValue1(0), mValue2(0), mValue3(0), mWidth0(0), mWidth1(0), mWidth2(0), mWidth3(0) {}
 
-    uint32_t rawId () const {return mId;}
- private:
+  CastorPedestal(unsigned long fId,
+                 float fCap0,
+                 float fCap1,
+                 float fCap2,
+                 float fCap3,
+                 float wCap0 = 0,
+                 float wCap1 = 0,
+                 float wCap2 = 0,
+                 float wCap3 = 0)
+      : mId(fId),
+        mValue0(fCap0),
+        mValue1(fCap1),
+        mValue2(fCap2),
+        mValue3(fCap3),
+        mWidth0(wCap0),
+        mWidth1(wCap1),
+        mWidth2(wCap2),
+        mWidth3(wCap3) {}
+
+  uint32_t rawId() const { return mId; }
+
+private:
   uint32_t mId;
   float mValue0;
   float mValue1;
@@ -48,7 +63,7 @@ class CastorPedestal {
   float mWidth2;
   float mWidth3;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorPedestalWidth.h
+++ b/CondFormats/CastorObjects/interface/CastorPedestalWidth.h
@@ -15,26 +15,26 @@ Adapted for CASTOR by L. Mundim
 #include <boost/cstdint.hpp>
 
 class CastorPedestalWidth {
- public:
+public:
   /// get value for all capId = 0..3, 10 values in total
-  const float* getValues () const {return &mSigma00;}
+  const float* getValues() const { return &mSigma00; }
 
   /// get width (sqrt(sigma_i_i)) for capId = 0..3
-  float getWidth (int fCapId) const;
+  float getWidth(int fCapId) const;
 
   /// get correlation element for capId1/2 = 0..3
-  float getSigma (int fCapId1, int fCapId2) const;
+  float getSigma(int fCapId1, int fCapId2) const;
 
   // functions below are not supposed to be used by consumer applications
-  CastorPedestalWidth (int fId = 0);
-  void setSigma (int fCapId1, int fCapId2, float fSigma);
+  CastorPedestalWidth(int fId = 0);
+  void setSigma(int fCapId1, int fCapId2, float fSigma);
 
-  uint32_t rawId () const {return mId;}
+  uint32_t rawId() const { return mId; }
 
   // produces pedestal noise in assumption of near correlations and small variations
-  void makeNoise (unsigned fFrames, const double* fGauss, double* fNoise) const;
+  void makeNoise(unsigned fFrames, const double* fGauss, double* fNoise) const;
 
- private:
+private:
   uint32_t mId;
   float mSigma00;
   float mSigma01;
@@ -53,7 +53,7 @@ class CastorPedestalWidth {
   float mSigma32;
   float mSigma33;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorPedestalWidths.h
+++ b/CondFormats/CastorObjects/interface/CastorPedestalWidths.h
@@ -15,25 +15,23 @@ POOL container to store PedestalWidth values 4xCapId, using template
 
 //typedef CastorCondObjectContainer<CastorPedestalWidth> CastorPedestalWidths;
 
-class CastorPedestalWidths: public CastorCondObjectContainer<CastorPedestalWidth>
-{
- public:
-  //constructor definition: has to contain 
-  CastorPedestalWidths():CastorCondObjectContainer<CastorPedestalWidth>(), unitIsADC(false) {}
-  CastorPedestalWidths(bool isADC):CastorCondObjectContainer<CastorPedestalWidth>(), unitIsADC(isADC) {}
+class CastorPedestalWidths : public CastorCondObjectContainer<CastorPedestalWidth> {
+public:
+  //constructor definition: has to contain
+  CastorPedestalWidths() : CastorCondObjectContainer<CastorPedestalWidth>(), unitIsADC(false) {}
+  CastorPedestalWidths(bool isADC) : CastorCondObjectContainer<CastorPedestalWidth>(), unitIsADC(isADC) {}
 
   // are the units ADC ? (true=ADC, false=fC)
-  bool isADC() const {return unitIsADC;}
+  bool isADC() const { return unitIsADC; }
   // set unit boolean
-  void setUnitADC(bool isADC) {unitIsADC = isADC;}
+  void setUnitADC(bool isADC) { unitIsADC = isADC; }
 
-  std::string const myname() {return (std::string)"CastorPedestalWidths";}
+  std::string const myname() { return (std::string) "CastorPedestalWidths"; }
 
- private:
+private:
   bool unitIsADC;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorPedestals.h
+++ b/CondFormats/CastorObjects/interface/CastorPedestals.h
@@ -15,23 +15,21 @@ $Author: katsas
 
 //typedef CastorCondObjectContainer<CastorPedestal> CastorPedestals;
 
-class CastorPedestals: public CastorCondObjectContainer<CastorPedestal>
-{
- public:
-  //constructor definition: has to contain 
-  CastorPedestals():CastorCondObjectContainer<CastorPedestal>(), unitIsADC(false) {}
-  CastorPedestals(bool isADC):CastorCondObjectContainer<CastorPedestal>(), unitIsADC(isADC) {}
+class CastorPedestals : public CastorCondObjectContainer<CastorPedestal> {
+public:
+  //constructor definition: has to contain
+  CastorPedestals() : CastorCondObjectContainer<CastorPedestal>(), unitIsADC(false) {}
+  CastorPedestals(bool isADC) : CastorCondObjectContainer<CastorPedestal>(), unitIsADC(isADC) {}
 
   // are the units ADC ? (true=ADC, false=fC)
-  bool isADC() const {return unitIsADC;} 
+  bool isADC() const { return unitIsADC; }
   // set unit boolean
-  void setUnitADC(bool isADC) {unitIsADC = isADC;}
+  void setUnitADC(bool isADC) { unitIsADC = isADC; }
 
- private:
+private:
   bool unitIsADC;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorQIECoder.h
+++ b/CondFormats/CastorObjects/interface/CastorQIECoder.h
@@ -20,49 +20,76 @@ Modified for CASTOR by L. Mundim
 class CastorQIEShape;
 
 class CastorQIECoder {
- public:
-  CastorQIECoder (unsigned long fId = 0) : mId (fId), mOffset00(0),   mOffset01(0),  mOffset02(0),
-                 mOffset03(0),  mOffset10(0),  mOffset11(0),  mOffset12(0),  mOffset13(0),
-                 mOffset20(0),  mOffset21(0),  mOffset22(0),  mOffset23(0),  mOffset30(0),
-                 mOffset31(0),  mOffset32(0),  mOffset33(0),  mSlope00(0),  mSlope01(0),  
-                 mSlope02(0),  mSlope03(0),  mSlope10(0),  mSlope11(0),  mSlope12(0),  
-                 mSlope13(0),  mSlope20(0),  mSlope21(0),  mSlope22(0),  mSlope23(0), 
-                 mSlope30(0),  mSlope31(0),  mSlope32(0),  mSlope33(0) {};
+public:
+  CastorQIECoder(unsigned long fId = 0)
+      : mId(fId),
+        mOffset00(0),
+        mOffset01(0),
+        mOffset02(0),
+        mOffset03(0),
+        mOffset10(0),
+        mOffset11(0),
+        mOffset12(0),
+        mOffset13(0),
+        mOffset20(0),
+        mOffset21(0),
+        mOffset22(0),
+        mOffset23(0),
+        mOffset30(0),
+        mOffset31(0),
+        mOffset32(0),
+        mOffset33(0),
+        mSlope00(0),
+        mSlope01(0),
+        mSlope02(0),
+        mSlope03(0),
+        mSlope10(0),
+        mSlope11(0),
+        mSlope12(0),
+        mSlope13(0),
+        mSlope20(0),
+        mSlope21(0),
+        mSlope22(0),
+        mSlope23(0),
+        mSlope30(0),
+        mSlope31(0),
+        mSlope32(0),
+        mSlope33(0){};
 
   /// ADC [0..127] + capid [0..3] -> fC conversion
-  float charge (const CastorQIEShape& fShape, unsigned fAdc, unsigned fCapId) const;
+  float charge(const CastorQIEShape& fShape, unsigned fAdc, unsigned fCapId) const;
   /// fC + capid [0..3] -> ADC conversion
-  unsigned adc (const CastorQIEShape& fShape, float fCharge, unsigned fCapId) const;
+  unsigned adc(const CastorQIEShape& fShape, float fCharge, unsigned fCapId) const;
 
   // following methods are not for use by consumers
-  float offset (unsigned fCapId, unsigned fRange) const;
-  float slope (unsigned fCapId, unsigned fRange) const;
-  
-  void setOffset (unsigned fCapId, unsigned fRange, float fValue);
-  void setSlope (unsigned fCapId, unsigned fRange, float fValue);
+  float offset(unsigned fCapId, unsigned fRange) const;
+  float slope(unsigned fCapId, unsigned fRange) const;
 
-  uint32_t rawId () const {return mId;}
+  void setOffset(unsigned fCapId, unsigned fRange, float fValue);
+  void setSlope(unsigned fCapId, unsigned fRange, float fValue);
 
- private:
+  uint32_t rawId() const { return mId; }
+
+private:
   uint32_t mId;
   float mOffset00;
-  float mOffset01; 
-  float mOffset02; 
-  float mOffset03; 
-  float mOffset10; 
-  float mOffset11; 
-  float mOffset12; 
-  float mOffset13; 
-  float mOffset20; 
-  float mOffset21; 
-  float mOffset22; 
-  float mOffset23; 
-  float mOffset30; 
-  float mOffset31; 
-  float mOffset32; 
-  float mOffset33; 
-  float mSlope00; 
-  float mSlope01; 
+  float mOffset01;
+  float mOffset02;
+  float mOffset03;
+  float mOffset10;
+  float mOffset11;
+  float mOffset12;
+  float mOffset13;
+  float mOffset20;
+  float mOffset21;
+  float mOffset22;
+  float mOffset23;
+  float mOffset30;
+  float mOffset31;
+  float mOffset32;
+  float mOffset33;
+  float mSlope00;
+  float mSlope01;
   float mSlope02;
   float mSlope03;
   float mSlope10;
@@ -78,7 +105,7 @@ class CastorQIECoder {
   float mSlope32;
   float mSlope33;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorQIEData.h
+++ b/CondFormats/CastorObjects/interface/CastorQIEData.h
@@ -22,34 +22,32 @@ $Revision: 1.9 $
 #include "CondFormats/CastorObjects/interface/CastorQIECoder.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-class CastorQIEData: public CastorCondObjectContainer<CastorQIECoder>
-{
- private:
+class CastorQIEData : public CastorCondObjectContainer<CastorQIECoder> {
+private:
   static const CastorQIEShape shape_;
- public:
 
+public:
   // constructor, destructor, and all methods stay the same
- CastorQIEData():CastorCondObjectContainer<CastorQIECoder>() {}
+  CastorQIEData() : CastorCondObjectContainer<CastorQIECoder>() {}
   /// get basic shape
   //   const CastorQIEShape& getShape () const {return mShape;}
 
-  const CastorQIEShape& getShape () const { return shape_;}
+  const CastorQIEShape& getShape() const { return shape_; }
   /// get QIE parameters
-  const CastorQIECoder* getCoder (DetId fId) const { return getValues(fId); }
+  const CastorQIECoder* getCoder(DetId fId) const { return getValues(fId); }
   // check if data are sorted - remove in the next version
-  bool sorted () const { return true; }
+  bool sorted() const { return true; }
   // fill values [capid][range]
   //bool addCoder (const CastorQIECoder& fCoder, bool h2mode_ = false) { return addValues(fCoder, h2mode_); }
-  bool addCoder (const CastorQIECoder& fCoder) { return addValues(fCoder); }
-  // sort values by channelId - remove in the next version  
-  void sort () {}
-  
-  std::string myname() const {return (std::string)"CastorQIEData";}
+  bool addCoder(const CastorQIECoder& fCoder) { return addValues(fCoder); }
+  // sort values by channelId - remove in the next version
+  void sort() {}
+
+  std::string myname() const { return (std::string) "CastorQIEData"; }
 
   //not needed/not used  CastorQIEData(const CastorQIEData&);
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorQIEShape.h
+++ b/CondFormats/CastorObjects/interface/CastorQIEShape.h
@@ -12,20 +12,21 @@ POOL object to store QIE basic shape
 
 // 128 QIE channels
 class CastorQIEShape {
- public:
+public:
   CastorQIEShape();
   ~CastorQIEShape();
-  float lowEdge (unsigned fAdc) const;
-  float highEdge (unsigned fAdc) const;
-  float center (unsigned fAdc) const;
-  bool setLowEdges (const float fValue [32]);
-  unsigned range (unsigned fAdc) const {return (fAdc >> 5) & 0x3;}
-  unsigned local (unsigned fAdc) const {return fAdc & 0x1f;}
- protected:
- private:
-  void expand ();
-  bool setLowEdge (float fValue, unsigned fAdc);
-  float mValues [129];
+  float lowEdge(unsigned fAdc) const;
+  float highEdge(unsigned fAdc) const;
+  float center(unsigned fAdc) const;
+  bool setLowEdges(const float fValue[32]);
+  unsigned range(unsigned fAdc) const { return (fAdc >> 5) & 0x3; }
+  unsigned local(unsigned fAdc) const { return fAdc & 0x1f; }
+
+protected:
+private:
+  void expand();
+  bool setLowEdge(float fValue, unsigned fAdc);
+  float mValues[129];
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorRawGain.h
+++ b/CondFormats/CastorObjects/interface/CastorRawGain.h
@@ -10,27 +10,22 @@ POOL object to store raw Gain values
 #include <string>
 
 class CastorRawGain {
- public:
-  enum Status {GOOD = 0, BAD = 1};
-  float getValue () const {return mValue;}
-  float getError  () const {return mError;}
-  float getVoltage () const {return mVoltage;}
-  Status getStatus () const {return Status (mStatus);}
-  std::string strStatus () const {return getStatus () == GOOD ? "GOOD" : "BAD";}
-  
+public:
+  enum Status { GOOD = 0, BAD = 1 };
+  float getValue() const { return mValue; }
+  float getError() const { return mError; }
+  float getVoltage() const { return mVoltage; }
+  Status getStatus() const { return Status(mStatus); }
+  std::string strStatus() const { return getStatus() == GOOD ? "GOOD" : "BAD"; }
 
-  CastorRawGain (unsigned long fId = 0) : mId (fId), mValue (0), mError (0), mVoltage (0), mStatus (int (BAD)) {}
-  
-  CastorRawGain (unsigned long fId, float fValue, float fError, float fVoltage, Status fStatus) :
-    mId (fId),
-    mValue (fValue),
-    mError (fError),
-    mVoltage (fVoltage),
-    mStatus (int (fStatus)) {}
+  CastorRawGain(unsigned long fId = 0) : mId(fId), mValue(0), mError(0), mVoltage(0), mStatus(int(BAD)) {}
 
-  uint32_t rawId () const {return mId;}
+  CastorRawGain(unsigned long fId, float fValue, float fError, float fVoltage, Status fStatus)
+      : mId(fId), mValue(fValue), mError(fError), mVoltage(fVoltage), mStatus(int(fStatus)) {}
 
- private:
+  uint32_t rawId() const { return mId; }
+
+private:
   uint32_t mId;
   float mValue;
   float mError;

--- a/CondFormats/CastorObjects/interface/CastorRawGains.h
+++ b/CondFormats/CastorObjects/interface/CastorRawGains.h
@@ -13,27 +13,28 @@ POOL container to store Gain values 4xCapId
 #include "CondFormats/CastorObjects/interface/CastorRawGain.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-// 
+//
 class CastorRawGains {
- public:
+public:
   CastorRawGains();
   ~CastorRawGains();
-  /// get value 
-  const CastorRawGain* getValues (DetId fId) const;
+  /// get value
+  const CastorRawGain* getValues(DetId fId) const;
   /// get list of all available channels
-  std::vector<DetId> getAllChannels () const;
+  std::vector<DetId> getAllChannels() const;
   /// check if data are sorted
-  bool sorted () const {return mSorted;}
+  bool sorted() const { return mSorted; }
   /// add new (empty) item
-  CastorRawGain* addItem (DetId fId);
+  CastorRawGain* addItem(DetId fId);
   /// fill values
-  void addValues (DetId fId, const CastorRawGain& fValues);
-  /// sort values by channelId  
-  void sort ();
+  void addValues(DetId fId, const CastorRawGain& fValues);
+  /// sort values by channelId
+  void sort();
   // helper typedefs
   typedef CastorRawGain Item;
-  typedef std::vector <Item> Container;
- private:
+  typedef std::vector<Item> Container;
+
+private:
   Container mItems;
   bool mSorted;
 };

--- a/CondFormats/CastorObjects/interface/CastorRecoParam.h
+++ b/CondFormats/CastorObjects/interface/CastorRecoParam.h
@@ -12,23 +12,23 @@ POOL object to store timeslice reco values
 #include <boost/cstdint.hpp>
 
 class CastorRecoParam {
- public:
-  CastorRecoParam():mId(0), mFirstSample(0), mSamplesToAdd(0) {}
+public:
+  CastorRecoParam() : mId(0), mFirstSample(0), mSamplesToAdd(0) {}
 
-  CastorRecoParam(unsigned long fId, unsigned int fFirstSample, unsigned int fSamplesToAdd):
-    mId(fId), mFirstSample(fFirstSample), mSamplesToAdd(fSamplesToAdd) {}
+  CastorRecoParam(unsigned long fId, unsigned int fFirstSample, unsigned int fSamplesToAdd)
+      : mId(fId), mFirstSample(fFirstSample), mSamplesToAdd(fSamplesToAdd) {}
 
-  uint32_t rawId () const {return mId;}
+  uint32_t rawId() const { return mId; }
 
-  unsigned int firstSample() const {return mFirstSample;}
-  unsigned int samplesToAdd() const {return mSamplesToAdd;}
+  unsigned int firstSample() const { return mFirstSample; }
+  unsigned int samplesToAdd() const { return mSamplesToAdd; }
 
- private:
+private:
   uint32_t mId;
   uint32_t mFirstSample;
   uint32_t mSamplesToAdd;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorRecoParams.h
+++ b/CondFormats/CastorObjects/interface/CastorRecoParams.h
@@ -1,23 +1,18 @@
 #ifndef CastorRecoParams_h
 #define CastorRecoParams_h
 
-
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "CondFormats/CastorObjects/interface/CastorRecoParam.h"
 #include "CondFormats/CastorObjects/interface/CastorCondObjectContainer.h"
 
+class CastorRecoParams : public CastorCondObjectContainer<CastorRecoParam> {
+public:
+  CastorRecoParams() : CastorCondObjectContainer<CastorRecoParam>() {}
 
-class CastorRecoParams: public CastorCondObjectContainer<CastorRecoParam>
-{
- public:
-  CastorRecoParams():CastorCondObjectContainer<CastorRecoParam>() {}
+  std::string myname() const { return (std::string) "CastorRecoParams"; }
 
-  std::string myname() const {return (std::string)"CastorRecoParams";}
-
- private:
-
-
- COND_SERIALIZABLE;
+private:
+  COND_SERIALIZABLE;
 };
 #endif

--- a/CondFormats/CastorObjects/interface/CastorSaturationCorr.h
+++ b/CondFormats/CastorObjects/interface/CastorSaturationCorr.h
@@ -12,21 +12,20 @@ POOL object to store saturation correction values
 #include <boost/cstdint.hpp>
 
 class CastorSaturationCorr {
- public:
-  CastorSaturationCorr():mId(0), mSatCorr(0) {}
+public:
+  CastorSaturationCorr() : mId(0), mSatCorr(0) {}
 
-  CastorSaturationCorr(unsigned long fId, float fSatCorr):
-    mId(fId), mSatCorr(fSatCorr) {}
+  CastorSaturationCorr(unsigned long fId, float fSatCorr) : mId(fId), mSatCorr(fSatCorr) {}
 
-  uint32_t rawId () const {return mId;}
+  uint32_t rawId() const { return mId; }
 
-  float getValue() const {return mSatCorr;}
+  float getValue() const { return mSatCorr; }
 
- private:
+private:
   uint32_t mId;
   float mSatCorr;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/CastorObjects/interface/CastorSaturationCorrs.h
+++ b/CondFormats/CastorObjects/interface/CastorSaturationCorrs.h
@@ -1,23 +1,18 @@
 #ifndef CastorSaturationCorrs_h
 #define CastorSaturationCorrs_h
 
-
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "CondFormats/CastorObjects/interface/CastorSaturationCorr.h"
 #include "CondFormats/CastorObjects/interface/CastorCondObjectContainer.h"
 
+class CastorSaturationCorrs : public CastorCondObjectContainer<CastorSaturationCorr> {
+public:
+  CastorSaturationCorrs() : CastorCondObjectContainer<CastorSaturationCorr>() {}
 
-class CastorSaturationCorrs: public CastorCondObjectContainer<CastorSaturationCorr>
-{
- public:
-  CastorSaturationCorrs():CastorCondObjectContainer<CastorSaturationCorr>() {}
+  std::string myname() const { return (std::string) "CastorSaturationCorrs"; }
 
-  std::string myname() const {return (std::string)"CastorSaturationCorrs";}
-
- private:
-
-
- COND_SERIALIZABLE;
+private:
+  COND_SERIALIZABLE;
 };
 #endif

--- a/CondFormats/CastorObjects/src/CastorCalibrationQIECoder.cc
+++ b/CondFormats/CastorObjects/src/CastorCalibrationQIECoder.cc
@@ -10,38 +10,41 @@ $Id
 #include "CondFormats/CastorObjects/interface/CastorQIEShape.h"
 #include "CondFormats/CastorObjects/interface/CastorCalibrationQIECoder.h"
 
-float CastorCalibrationQIECoder::charge (unsigned fAdc) const {
-  const float* data = base ();
-  if (fAdc >= 31) return (3*data[31]-data[30])/2.; // extrapolation
-  return (data[fAdc]+data[fAdc+1])/2;
+float CastorCalibrationQIECoder::charge(unsigned fAdc) const {
+  const float* data = base();
+  if (fAdc >= 31)
+    return (3 * data[31] - data[30]) / 2.;  // extrapolation
+  return (data[fAdc] + data[fAdc + 1]) / 2;
 }
 
-unsigned CastorCalibrationQIECoder::adc (float fCharge) const {
-  const float* data = base ();
+unsigned CastorCalibrationQIECoder::adc(float fCharge) const {
+  const float* data = base();
   unsigned adc = 1;
   for (; adc < 32; adc++) {
-    if (fCharge < data[adc]) return adc-1;
+    if (fCharge < data[adc])
+      return adc - 1;
   }
-  return 31; // overflow
+  return 31;  // overflow
 }
 
-float CastorCalibrationQIECoder::minCharge (unsigned fBin) const {
-  const float* data = base ();
+float CastorCalibrationQIECoder::minCharge(unsigned fBin) const {
+  const float* data = base();
   return fBin < 32 ? data[fBin] : data[31];
 }
 
-const float* CastorCalibrationQIECoder::minCharges () const {
-  const float* data = base ();
+const float* CastorCalibrationQIECoder::minCharges() const {
+  const float* data = base();
   return data;
 }
 
-
-void CastorCalibrationQIECoder::setMinCharge (unsigned fBin, float fValue) {
-  float* data = base ();
-  if (fBin < 32) data [fBin] = fValue;
+void CastorCalibrationQIECoder::setMinCharge(unsigned fBin, float fValue) {
+  float* data = base();
+  if (fBin < 32)
+    data[fBin] = fValue;
 }
 
-void CastorCalibrationQIECoder::setMinCharges (const float fValue [32]) {
-  float* data = base ();
-  for (int i = 0; i < 32; i++) data[i] = fValue[i];
+void CastorCalibrationQIECoder::setMinCharges(const float fValue[32]) {
+  float* data = base();
+  for (int i = 0; i < 32; i++)
+    data[i] = fValue[i];
 }

--- a/CondFormats/CastorObjects/src/CastorChannelQuality.cc
+++ b/CondFormats/CastorObjects/src/CastorChannelQuality.cc
@@ -1,4 +1,3 @@
 // to see it compile
 
 #include "CondFormats/CastorObjects/interface/CastorChannelQuality.h"
-

--- a/CondFormats/CastorObjects/src/CastorElectronicsMap.cc
+++ b/CondFormats/CastorObjects/src/CastorElectronicsMap.cc
@@ -14,231 +14,252 @@ Adapted for CASTOR by L. Mundim
 #include "CondFormats/CastorObjects/interface/CastorElectronicsMap.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-CastorElectronicsMap::CastorElectronicsMap() :
-  mPItems(CastorElectronicsId::maxLinearIndex+1),
-  mTItems(CastorElectronicsId::maxLinearIndex+1),
-  mPItemsById(nullptr), mTItemsByTrigId(nullptr)
-{}
+CastorElectronicsMap::CastorElectronicsMap()
+    : mPItems(CastorElectronicsId::maxLinearIndex + 1),
+      mTItems(CastorElectronicsId::maxLinearIndex + 1),
+      mPItemsById(nullptr),
+      mTItemsByTrigId(nullptr) {}
 
 namespace castor_impl {
-  class LessById {public: bool operator () (const CastorElectronicsMap::PrecisionItem* a, const CastorElectronicsMap::PrecisionItem* b) {return a->mId < b->mId;}};
-  class LessByTrigId {public: bool operator () (const CastorElectronicsMap::TriggerItem* a, const CastorElectronicsMap::TriggerItem* b) {return a->mTrigId < b->mTrigId;}};
-}
+  class LessById {
+  public:
+    bool operator()(const CastorElectronicsMap::PrecisionItem* a, const CastorElectronicsMap::PrecisionItem* b) {
+      return a->mId < b->mId;
+    }
+  };
+  class LessByTrigId {
+  public:
+    bool operator()(const CastorElectronicsMap::TriggerItem* a, const CastorElectronicsMap::TriggerItem* b) {
+      return a->mTrigId < b->mTrigId;
+    }
+  };
+}  // namespace castor_impl
 
 CastorElectronicsMap::~CastorElectronicsMap() {
-	delete mPItemsById.load();
-	delete mTItemsByTrigId.load();
+  delete mPItemsById.load();
+  delete mTItemsByTrigId.load();
 }
 // copy-ctor
 CastorElectronicsMap::CastorElectronicsMap(const CastorElectronicsMap& src)
-    : mPItems(src.mPItems), mTItems(src.mTItems),
-      mPItemsById(nullptr), mTItemsByTrigId(nullptr) {}
+    : mPItems(src.mPItems), mTItems(src.mTItems), mPItemsById(nullptr), mTItemsByTrigId(nullptr) {}
 // copy assignment operator
-CastorElectronicsMap&
-CastorElectronicsMap::operator=(const CastorElectronicsMap& rhs) {
-    CastorElectronicsMap temp(rhs);
-    temp.swap(*this);
-    return *this;
+CastorElectronicsMap& CastorElectronicsMap::operator=(const CastorElectronicsMap& rhs) {
+  CastorElectronicsMap temp(rhs);
+  temp.swap(*this);
+  return *this;
 }
 // public swap function
 void CastorElectronicsMap::swap(CastorElectronicsMap& other) {
-    std::swap(mPItems, other.mPItems);
-    std::swap(mTItems, other.mTItems);
-    other.mTItemsByTrigId.exchange(mTItemsByTrigId.exchange(other.mTItemsByTrigId));
-    other.mPItemsById.exchange(mPItemsById.exchange(other.mPItemsById));
+  std::swap(mPItems, other.mPItems);
+  std::swap(mTItems, other.mTItems);
+  other.mTItemsByTrigId.exchange(mTItemsByTrigId.exchange(other.mTItemsByTrigId));
+  other.mPItemsById.exchange(mPItemsById.exchange(other.mPItemsById));
 }
 // move constructor
-CastorElectronicsMap::CastorElectronicsMap(CastorElectronicsMap&& other)
-    : CastorElectronicsMap() {
-    other.swap(*this);
-}
+CastorElectronicsMap::CastorElectronicsMap(CastorElectronicsMap&& other) : CastorElectronicsMap() { other.swap(*this); }
 
-const CastorElectronicsMap::PrecisionItem* CastorElectronicsMap::findById (unsigned long fId) const {
-  PrecisionItem target (fId, 0);
+const CastorElectronicsMap::PrecisionItem* CastorElectronicsMap::findById(unsigned long fId) const {
+  PrecisionItem target(fId, 0);
   std::vector<const CastorElectronicsMap::PrecisionItem*>::const_iterator item;
 
   sortById();
-  
-  item = std::lower_bound ((*mPItemsById).begin(), (*mPItemsById).end(), &target, castor_impl::LessById());
-  if (item == (*mPItemsById).end() || (*item)->mId != fId) 
+
+  item = std::lower_bound((*mPItemsById).begin(), (*mPItemsById).end(), &target, castor_impl::LessById());
+  if (item == (*mPItemsById).end() || (*item)->mId != fId)
     //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
     return nullptr;
   return *item;
 }
 
-const CastorElectronicsMap::PrecisionItem* CastorElectronicsMap::findPByElId (unsigned long fElId) const {
+const CastorElectronicsMap::PrecisionItem* CastorElectronicsMap::findPByElId(unsigned long fElId) const {
   CastorElectronicsId eid(fElId);
-  const PrecisionItem* i=&(mPItems[eid.linearIndex()]);
-  
-  if (i!=nullptr && i->mElId!=fElId) i=nullptr;
+  const PrecisionItem* i = &(mPItems[eid.linearIndex()]);
+
+  if (i != nullptr && i->mElId != fElId)
+    i = nullptr;
   return i;
 }
 
-const CastorElectronicsMap::TriggerItem* CastorElectronicsMap::findTByElId (unsigned long fElId) const {
+const CastorElectronicsMap::TriggerItem* CastorElectronicsMap::findTByElId(unsigned long fElId) const {
   CastorElectronicsId eid(fElId);
-  const TriggerItem* i=&(mTItems[eid.linearIndex()]);
-  
-  if (i!=nullptr && i->mElId!=fElId) i=nullptr;
+  const TriggerItem* i = &(mTItems[eid.linearIndex()]);
+
+  if (i != nullptr && i->mElId != fElId)
+    i = nullptr;
   return i;
 }
 
-
-const CastorElectronicsMap::TriggerItem* CastorElectronicsMap::findByTrigId (unsigned long fTrigId) const {
-  TriggerItem target (fTrigId,0);
+const CastorElectronicsMap::TriggerItem* CastorElectronicsMap::findByTrigId(unsigned long fTrigId) const {
+  TriggerItem target(fTrigId, 0);
   std::vector<const CastorElectronicsMap::TriggerItem*>::const_iterator item;
 
   sortByTriggerId();
-  
-  item = std::lower_bound ((*mTItemsByTrigId).begin(), (*mTItemsByTrigId).end(), &target, castor_impl::LessByTrigId());
-  if (item == (*mTItemsByTrigId).end() || (*item)->mTrigId != fTrigId) 
+
+  item = std::lower_bound((*mTItemsByTrigId).begin(), (*mTItemsByTrigId).end(), &target, castor_impl::LessByTrigId());
+  if (item == (*mTItemsByTrigId).end() || (*item)->mTrigId != fTrigId)
     //    throw cms::Exception ("Conditions not found") << "Unavailable Electronics map for cell " << fId;
     return nullptr;
   return *item;
 }
 
-const DetId CastorElectronicsMap::lookup(CastorElectronicsId fId ) const {
-  const PrecisionItem* item = findPByElId (fId.rawId ());
-  return DetId (item ? item->mId : 0);
+const DetId CastorElectronicsMap::lookup(CastorElectronicsId fId) const {
+  const PrecisionItem* item = findPByElId(fId.rawId());
+  return DetId(item ? item->mId : 0);
 }
 
 const CastorElectronicsId CastorElectronicsMap::lookup(DetId fId) const {
-  const PrecisionItem* item = findById (fId.rawId ());
-  return CastorElectronicsId (item ? item->mElId : 0);
+  const PrecisionItem* item = findById(fId.rawId());
+  return CastorElectronicsId(item ? item->mElId : 0);
 }
 
 const DetId CastorElectronicsMap::lookupTrigger(CastorElectronicsId fId) const {
-  const TriggerItem* item = findTByElId (fId.rawId ());
-  return DetId (item ? item->mTrigId : 0);
+  const TriggerItem* item = findTByElId(fId.rawId());
+  return DetId(item ? item->mTrigId : 0);
 }
 
 const CastorElectronicsId CastorElectronicsMap::lookupTrigger(DetId fId) const {
-  const TriggerItem* item = findByTrigId (fId.rawId ());
-  return CastorElectronicsId (item ? item->mElId : 0);
+  const TriggerItem* item = findByTrigId(fId.rawId());
+  return CastorElectronicsId(item ? item->mElId : 0);
 }
 
-bool CastorElectronicsMap::lookup(const CastorElectronicsId pid, CastorElectronicsId& eid, HcalGenericDetId& did) const {
-  const PrecisionItem* i=&(mPItems[pid.linearIndex()]);
-  if (i!=nullptr && i->mId!=0) {
-    eid=CastorElectronicsId(i->mElId);
-    did=HcalGenericDetId(i->mId);
+bool CastorElectronicsMap::lookup(const CastorElectronicsId pid,
+                                  CastorElectronicsId& eid,
+                                  HcalGenericDetId& did) const {
+  const PrecisionItem* i = &(mPItems[pid.linearIndex()]);
+  if (i != nullptr && i->mId != 0) {
+    eid = CastorElectronicsId(i->mElId);
+    did = HcalGenericDetId(i->mId);
     return true;
-  } else return false;
+  } else
+    return false;
 }
 
-bool CastorElectronicsMap::lookup(const CastorElectronicsId pid, CastorElectronicsId& eid, HcalTrigTowerDetId& did) const {
-  const TriggerItem* i=&(mTItems[pid.linearIndex()]);
-  if (i!=nullptr && i->mTrigId!=0) {
-    eid=CastorElectronicsId(i->mElId);
-    did=HcalGenericDetId(i->mTrigId);
+bool CastorElectronicsMap::lookup(const CastorElectronicsId pid,
+                                  CastorElectronicsId& eid,
+                                  HcalTrigTowerDetId& did) const {
+  const TriggerItem* i = &(mTItems[pid.linearIndex()]);
+  if (i != nullptr && i->mTrigId != 0) {
+    eid = CastorElectronicsId(i->mElId);
+    did = HcalGenericDetId(i->mTrigId);
     return true;
-  } else return false;  
+  } else
+    return false;
 }
 
-
-std::vector <CastorElectronicsId> CastorElectronicsMap::allElectronicsId () const {
-  std::vector <CastorElectronicsId> result;
-  for (std::vector<PrecisionItem>::const_iterator item = mPItems.begin (); item != mPItems.end (); item++) 
-    if (item->mElId) result.push_back(CastorElectronicsId(item->mElId));
-  for (std::vector<TriggerItem>::const_iterator item = mTItems.begin (); item != mTItems.end (); item++) 
-    if (item->mElId) result.push_back(CastorElectronicsId(item->mElId));
+std::vector<CastorElectronicsId> CastorElectronicsMap::allElectronicsId() const {
+  std::vector<CastorElectronicsId> result;
+  for (std::vector<PrecisionItem>::const_iterator item = mPItems.begin(); item != mPItems.end(); item++)
+    if (item->mElId)
+      result.push_back(CastorElectronicsId(item->mElId));
+  for (std::vector<TriggerItem>::const_iterator item = mTItems.begin(); item != mTItems.end(); item++)
+    if (item->mElId)
+      result.push_back(CastorElectronicsId(item->mElId));
 
   return result;
 }
 
-std::vector <CastorElectronicsId> CastorElectronicsMap::allElectronicsIdPrecision() const {
-  std::vector <CastorElectronicsId> result;
-  for (std::vector<PrecisionItem>::const_iterator item = mPItems.begin (); item != mPItems.end (); item++) 
-    if (item->mElId) result.push_back(CastorElectronicsId(item->mElId));
+std::vector<CastorElectronicsId> CastorElectronicsMap::allElectronicsIdPrecision() const {
+  std::vector<CastorElectronicsId> result;
+  for (std::vector<PrecisionItem>::const_iterator item = mPItems.begin(); item != mPItems.end(); item++)
+    if (item->mElId)
+      result.push_back(CastorElectronicsId(item->mElId));
   return result;
 }
 
-std::vector <CastorElectronicsId> CastorElectronicsMap::allElectronicsIdTrigger() const {
-  std::vector <CastorElectronicsId> result;
-  for (std::vector<TriggerItem>::const_iterator item = mTItems.begin (); item != mTItems.end (); item++) 
-    if (item->mElId) result.push_back(CastorElectronicsId(item->mElId));
+std::vector<CastorElectronicsId> CastorElectronicsMap::allElectronicsIdTrigger() const {
+  std::vector<CastorElectronicsId> result;
+  for (std::vector<TriggerItem>::const_iterator item = mTItems.begin(); item != mTItems.end(); item++)
+    if (item->mElId)
+      result.push_back(CastorElectronicsId(item->mElId));
 
   return result;
 }
 
-std::vector <HcalGenericDetId> CastorElectronicsMap::allPrecisionId () const {
-  std::vector <HcalGenericDetId> result;
-  std::set <unsigned long> allIds;
-  for (std::vector<PrecisionItem>::const_iterator item = mPItems.begin (); item != mPItems.end (); item++)  
-    if (item->mId) allIds.insert (item->mId);
-  for (std::set <unsigned long>::const_iterator channel = allIds.begin (); channel != allIds.end (); channel++) {
-      result.push_back (HcalGenericDetId (*channel));
+std::vector<HcalGenericDetId> CastorElectronicsMap::allPrecisionId() const {
+  std::vector<HcalGenericDetId> result;
+  std::set<unsigned long> allIds;
+  for (std::vector<PrecisionItem>::const_iterator item = mPItems.begin(); item != mPItems.end(); item++)
+    if (item->mId)
+      allIds.insert(item->mId);
+  for (std::set<unsigned long>::const_iterator channel = allIds.begin(); channel != allIds.end(); channel++) {
+    result.push_back(HcalGenericDetId(*channel));
   }
   return result;
 }
 
-std::vector <HcalTrigTowerDetId> CastorElectronicsMap::allTriggerId () const {
-  std::vector <HcalTrigTowerDetId> result;
-  std::set <unsigned long> allIds;
-  for (std::vector<TriggerItem>::const_iterator item = mTItems.begin (); item != mTItems.end (); item++)  
-    if (item->mTrigId) allIds.insert (item->mTrigId);
-  for (std::set <unsigned long>::const_iterator channel = allIds.begin (); channel != allIds.end (); channel++)
-    result.push_back (HcalTrigTowerDetId (*channel));
+std::vector<HcalTrigTowerDetId> CastorElectronicsMap::allTriggerId() const {
+  std::vector<HcalTrigTowerDetId> result;
+  std::set<unsigned long> allIds;
+  for (std::vector<TriggerItem>::const_iterator item = mTItems.begin(); item != mTItems.end(); item++)
+    if (item->mTrigId)
+      allIds.insert(item->mTrigId);
+  for (std::set<unsigned long>::const_iterator channel = allIds.begin(); channel != allIds.end(); channel++)
+    result.push_back(HcalTrigTowerDetId(*channel));
   return result;
 }
 
-bool CastorElectronicsMap::mapEId2tId (CastorElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId) {
+bool CastorElectronicsMap::mapEId2tId(CastorElectronicsId fElectronicsId, HcalTrigTowerDetId fTriggerId) {
   TriggerItem& item = mTItems[fElectronicsId.linearIndex()];
-  if (item.mElId==0) item.mElId=fElectronicsId.rawId();
+  if (item.mElId == 0)
+    item.mElId = fElectronicsId.rawId();
   if (item.mTrigId == 0) {
-    item.mTrigId = fTriggerId.rawId (); // just cast avoiding long machinery
-  } 
-  else if (item.mTrigId != fTriggerId.rawId ()) {
-    edm::LogWarning("CASTOR") << "CastorElectronicsMap::mapEId2tId-> Electronics channel " <<  fElectronicsId  << " already mapped to trigger channel " 
-	      << (HcalTrigTowerDetId(item.mTrigId)) << ". New value " << fTriggerId << " is ignored" ;
+    item.mTrigId = fTriggerId.rawId();  // just cast avoiding long machinery
+  } else if (item.mTrigId != fTriggerId.rawId()) {
+    edm::LogWarning("CASTOR") << "CastorElectronicsMap::mapEId2tId-> Electronics channel " << fElectronicsId
+                              << " already mapped to trigger channel " << (HcalTrigTowerDetId(item.mTrigId))
+                              << ". New value " << fTriggerId << " is ignored";
     return false;
   }
   return true;
 }
 
-bool CastorElectronicsMap::mapEId2chId (CastorElectronicsId fElectronicsId, DetId fId) {
+bool CastorElectronicsMap::mapEId2chId(CastorElectronicsId fElectronicsId, DetId fId) {
   PrecisionItem& item = mPItems[fElectronicsId.linearIndex()];
 
-  if (item.mElId==0) item.mElId=fElectronicsId.rawId();
+  if (item.mElId == 0)
+    item.mElId = fElectronicsId.rawId();
   if (item.mId == 0) {
-    item.mId = fId.rawId ();
-  } 
-  else if (item.mId != fId.rawId ()) {
-     edm::LogWarning("CASTOR") << "CastorElectronicsMap::mapEId2tId-> Electronics channel " <<  fElectronicsId << " already mapped to channel " 
-			     << HcalGenericDetId(item.mId) << ". New value " << HcalGenericDetId(fId) << " is ignored" ;
-       return false;
+    item.mId = fId.rawId();
+  } else if (item.mId != fId.rawId()) {
+    edm::LogWarning("CASTOR") << "CastorElectronicsMap::mapEId2tId-> Electronics channel " << fElectronicsId
+                              << " already mapped to channel " << HcalGenericDetId(item.mId) << ". New value "
+                              << HcalGenericDetId(fId) << " is ignored";
+    return false;
   }
   return true;
 }
 
-void CastorElectronicsMap::sortById () const {
+void CastorElectronicsMap::sortById() const {
   if (!mPItemsById) {
-      auto ptr = new std::vector<const PrecisionItem*>;
-      for (auto i=mPItems.begin(); i!=mPItems.end(); ++i) {
-          if (i->mElId) (*ptr).push_back(&(*i));
-      }
-      std::sort ((*ptr).begin(), (*ptr).end(), castor_impl::LessById ());
-      //atomically try to swap this to become mPItemsById
-      std::vector<const PrecisionItem*>* expect = nullptr;
-      bool exchanged = mPItemsById.compare_exchange_strong(expect, ptr);
-      if(!exchanged) {
-          delete ptr;
-      }
+    auto ptr = new std::vector<const PrecisionItem*>;
+    for (auto i = mPItems.begin(); i != mPItems.end(); ++i) {
+      if (i->mElId)
+        (*ptr).push_back(&(*i));
+    }
+    std::sort((*ptr).begin(), (*ptr).end(), castor_impl::LessById());
+    //atomically try to swap this to become mPItemsById
+    std::vector<const PrecisionItem*>* expect = nullptr;
+    bool exchanged = mPItemsById.compare_exchange_strong(expect, ptr);
+    if (!exchanged) {
+      delete ptr;
+    }
   }
 }
 
-void CastorElectronicsMap::sortByTriggerId () const {
+void CastorElectronicsMap::sortByTriggerId() const {
   if (!mTItemsByTrigId) {
-      auto ptr = new std::vector<const TriggerItem*>;
-      for (auto i=mTItems.begin(); i!=mTItems.end(); ++i) {
-          if (i->mElId) (*ptr).push_back(&(*i));
-      }
+    auto ptr = new std::vector<const TriggerItem*>;
+    for (auto i = mTItems.begin(); i != mTItems.end(); ++i) {
+      if (i->mElId)
+        (*ptr).push_back(&(*i));
+    }
 
-      std::sort ((*ptr).begin(), (*ptr).end(), castor_impl::LessByTrigId ());
-      //atomically try to swap this to become mTItemsByTrigId
-      std::vector<const TriggerItem*>* expect = nullptr;
-      bool exchanged = mTItemsByTrigId.compare_exchange_strong(expect, ptr);
-      if(!exchanged) {
-          delete ptr;
-      }
+    std::sort((*ptr).begin(), (*ptr).end(), castor_impl::LessByTrigId());
+    //atomically try to swap this to become mTItemsByTrigId
+    std::vector<const TriggerItem*>* expect = nullptr;
+    bool exchanged = mTItemsByTrigId.compare_exchange_strong(expect, ptr);
+    if (!exchanged) {
+      delete ptr;
+    }
   }
 }

--- a/CondFormats/CastorObjects/src/CastorGains.cc
+++ b/CondFormats/CastorObjects/src/CastorGains.cc
@@ -1,4 +1,3 @@
 // to see it compile
 
 #include "CondFormats/CastorObjects/interface/CastorGains.h"
-

--- a/CondFormats/CastorObjects/src/CastorPedestalWidth.cc
+++ b/CondFormats/CastorObjects/src/CastorPedestalWidth.cc
@@ -14,41 +14,42 @@ Adapted for CASTOR by L. Mundim
 #include "CondFormats/CastorObjects/interface/CastorPedestalWidth.h"
 
 namespace {
-  int offset (int fCapId1, int fCapId2) {
+  int offset(int fCapId1, int fCapId2) {
     //    static int offsets [4] = {0, 1, 3, 6};
     //    if (fCapId1 < fCapId2) { // swap
     //      int tmp = fCapId1; fCapId1 = fCapId2; fCapId2 = tmp;
     //    }
     //    return offsets [fCapId1] + fCapId2;
-    return fCapId1*4 + fCapId2;
+    return fCapId1 * 4 + fCapId2;
+  }
+}  // namespace
+
+CastorPedestalWidth::CastorPedestalWidth(int fId) : mId(fId) {
+  for (int i = 16; --i >= 0; *(&mSigma00 + i) = 0) {
   }
 }
 
-CastorPedestalWidth::CastorPedestalWidth (int fId) : mId (fId) {
-  for (int i = 16; --i >= 0; *(&mSigma00 + i) = 0) {}
+float CastorPedestalWidth::getWidth(int fCapId) const { return sqrt(*(getValues() + offset(fCapId, fCapId))); }
+
+float CastorPedestalWidth::getSigma(int fCapId1, int fCapId2) const {
+  return *(getValues() + offset(fCapId1, fCapId2));
 }
 
-float CastorPedestalWidth::getWidth (int fCapId) const {
-  return sqrt (*(getValues () + offset (fCapId, fCapId)));
-}
-
-float CastorPedestalWidth::getSigma (int fCapId1, int fCapId2) const {
-  return *(getValues () + offset (fCapId1, fCapId2));
-}
-
-void CastorPedestalWidth::setSigma (int fCapId1, int fCapId2, float fSigma) {
-  *(&mSigma00 + offset (fCapId1, fCapId2)) = fSigma;
+void CastorPedestalWidth::setSigma(int fCapId1, int fCapId2, float fSigma) {
+  *(&mSigma00 + offset(fCapId1, fCapId2)) = fSigma;
 }
 
 // produces pedestal noise in assumption of near correlations and small variations
-void CastorPedestalWidth::makeNoise (unsigned fFrames, const double* fGauss, double* fNoise) const {
-  double s_xx_mean = (getSigma (0,0) + getSigma (1,1) + getSigma (2,2) + getSigma (3,3)) / 4;
-  double s_xy_mean = (getSigma (1,0) + getSigma (2,1) + getSigma (3,2) + getSigma (3,0)) / 4;
-  double sigma = sqrt (0.5 * (s_xx_mean + sqrt (s_xx_mean*s_xx_mean - 2*s_xy_mean*s_xy_mean)));
-  double corr = sigma == 0 ? 0 : 0.5*s_xy_mean / sigma;
+void CastorPedestalWidth::makeNoise(unsigned fFrames, const double* fGauss, double* fNoise) const {
+  double s_xx_mean = (getSigma(0, 0) + getSigma(1, 1) + getSigma(2, 2) + getSigma(3, 3)) / 4;
+  double s_xy_mean = (getSigma(1, 0) + getSigma(2, 1) + getSigma(3, 2) + getSigma(3, 0)) / 4;
+  double sigma = sqrt(0.5 * (s_xx_mean + sqrt(s_xx_mean * s_xx_mean - 2 * s_xy_mean * s_xy_mean)));
+  double corr = sigma == 0 ? 0 : 0.5 * s_xy_mean / sigma;
   for (unsigned i = 0; i < fFrames; i++) {
-    fNoise [i] = fGauss[i]*sigma;
-    if (i > 0) fNoise [i] += fGauss[i-1]*corr;
-    if (i < fFrames-1) fNoise [i] += fGauss[i+1]*corr;
+    fNoise[i] = fGauss[i] * sigma;
+    if (i > 0)
+      fNoise[i] += fGauss[i - 1] * corr;
+    if (i < fFrames - 1)
+      fNoise[i] += fGauss[i + 1] * corr;
   }
 }

--- a/CondFormats/CastorObjects/src/CastorQIECoder.cc
+++ b/CondFormats/CastorObjects/src/CastorQIECoder.cc
@@ -11,58 +11,50 @@ POOL object to store QIE coder parameters for one channel
 
 namespace {
   // pack range/capId in the plain index
-  unsigned index (unsigned fRange, unsigned fCapId) {return fCapId * 4 + fRange;}
+  unsigned index(unsigned fRange, unsigned fCapId) { return fCapId * 4 + fRange; }
+}  // namespace
+
+float CastorQIECoder::charge(const CastorQIEShape& fShape, unsigned fAdc, unsigned fCapId) const {
+  unsigned range = fShape.range(fAdc);
+  return (fShape.center(fAdc) - offset(fCapId, range)) / slope(fCapId, range);
 }
 
-float CastorQIECoder::charge (const CastorQIEShape& fShape, unsigned fAdc, unsigned fCapId) const {
-  unsigned range = fShape.range (fAdc);
-  return (fShape.center (fAdc) - offset (fCapId, range)) / slope (fCapId, range);
-}
-
-unsigned CastorQIECoder::adc (const CastorQIEShape& fShape, float fCharge, unsigned fCapId) const {
+unsigned CastorQIECoder::adc(const CastorQIEShape& fShape, float fCharge, unsigned fCapId) const {
   // search for the range
   for (unsigned range = 0; range < 4; range++) {
-    float qieCharge = fCharge * slope (fCapId, range) + offset (fCapId, range);
-    unsigned minBin = 32*range;
-    float qieChargeMax = fShape.highEdge (minBin + 31);
+    float qieCharge = fCharge * slope(fCapId, range) + offset(fCapId, range);
+    unsigned minBin = 32 * range;
+    float qieChargeMax = fShape.highEdge(minBin + 31);
     if (qieCharge <= qieChargeMax) {
       for (unsigned bin = minBin; bin <= minBin + 31; bin++) {
-	if (qieCharge < fShape.highEdge (bin)) {
-	  return bin;
-	}
+        if (qieCharge < fShape.highEdge(bin)) {
+          return bin;
+        }
       }
-      return minBin; // underflow
-    }
-    else if (range == 3) {
-      return 127; // overflow
+      return minBin;  // underflow
+    } else if (range == 3) {
+      return 127;  // overflow
     }
   }
-  return 0; //should never get here
+  return 0;  //should never get here
 }
 
-float CastorQIECoder::offset (unsigned fCapId, unsigned fRange) const {
-  return *((&mOffset00) + index (fRange, fCapId));
-}
+float CastorQIECoder::offset(unsigned fCapId, unsigned fRange) const { return *((&mOffset00) + index(fRange, fCapId)); }
 
-float CastorQIECoder::slope (unsigned fCapId, unsigned fRange) const {
-  return *((&mSlope00) + index (fRange, fCapId));
-}
-  
-void CastorQIECoder::setOffset (unsigned fCapId, unsigned fRange, float fValue) {
-  if (fCapId < 4U && fRange < 4U) { // fCapId >= 0 and fRange >= 0, since fCapId and fRange are unsigned
-     *((&mOffset00) + index (fRange, fCapId)) = fValue;
-  }
-  else {
+float CastorQIECoder::slope(unsigned fCapId, unsigned fRange) const { return *((&mSlope00) + index(fRange, fCapId)); }
+
+void CastorQIECoder::setOffset(unsigned fCapId, unsigned fRange, float fValue) {
+  if (fCapId < 4U && fRange < 4U) {  // fCapId >= 0 and fRange >= 0, since fCapId and fRange are unsigned
+    *((&mOffset00) + index(fRange, fCapId)) = fValue;
+  } else {
     std::cerr << "CastorQIECoder::setOffset-> Wrong parameters capid/range: " << fCapId << '/' << fRange << std::endl;
   }
 }
 
-void CastorQIECoder::setSlope (unsigned fCapId, unsigned fRange, float fValue) {
-  if (fCapId < 4U && fRange < 4U) { // fCapId >= 0 and fRange >= 0, since fCapId and fRange are unsigned
-    *((&mSlope00) + index (fRange, fCapId)) = fValue;
-  }
-  else {
+void CastorQIECoder::setSlope(unsigned fCapId, unsigned fRange, float fValue) {
+  if (fCapId < 4U && fRange < 4U) {  // fCapId >= 0 and fRange >= 0, since fCapId and fRange are unsigned
+    *((&mSlope00) + index(fRange, fCapId)) = fValue;
+  } else {
     std::cerr << "CastorQIECoder::setSlope-> Wrong parameters capid/range: " << fCapId << '/' << fRange << std::endl;
   }
 }
-

--- a/CondFormats/CastorObjects/src/CastorQIEShape.cc
+++ b/CondFormats/CastorObjects/src/CastorQIEShape.cc
@@ -6,62 +6,68 @@ POOL object to store pedestal values 4xCapId
 #include "CondFormats/CastorObjects/interface/CastorQIEShape.h"
 
 namespace {
-  const float binMin [32] = {-1,  0,  1,  2,  3,  4,  5,  6,  7,  8,
-			     9, 10, 11, 12, 13, 14, 16, 18, 20, 22,
-			     24, 26, 28, 31, 34, 37, 40, 44, 48, 52,
-			     57, 62};
+  const float binMin[32] = {-1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
+                            16, 18, 20, 22, 24, 26, 28, 31, 34, 37, 40, 44, 48, 52, 57, 62};
 }
 
-CastorQIEShape::CastorQIEShape() 
-{
-  for (int i = 0; i < 32; i++) mValues [i] = binMin [i];
-  expand ();
+CastorQIEShape::CastorQIEShape() {
+  for (int i = 0; i < 32; i++)
+    mValues[i] = binMin[i];
+  expand();
 }
 
 CastorQIEShape::~CastorQIEShape() {}
 
-void CastorQIEShape::expand () {
+void CastorQIEShape::expand() {
   int scale = 1;
   for (unsigned range = 1; range < 4; range++) {
     scale = scale * 5;
     unsigned index = range * 32;
-    mValues [index] = mValues [index - 2]; // link to previous range
+    mValues[index] = mValues[index - 2];  // link to previous range
     for (unsigned i = 1; i < 32; i++) {
-      mValues [index + i] =  mValues [index + i - 1] + scale * (mValues [i] - mValues [i - 1]);
+      mValues[index + i] = mValues[index + i - 1] + scale * (mValues[i] - mValues[i - 1]);
     }
   }
-  mValues [128] = 2 * mValues [127] - mValues [126]; // extrapolate
+  mValues[128] = 2 * mValues[127] - mValues[126];  // extrapolate
 }
 
-float CastorQIEShape::lowEdge (unsigned fAdc) const {
-  if (fAdc < 128) return mValues [fAdc];
+float CastorQIEShape::lowEdge(unsigned fAdc) const {
+  if (fAdc < 128)
+    return mValues[fAdc];
   return 0.;
 }
 
-float CastorQIEShape::center (unsigned fAdc) const {
+float CastorQIEShape::center(unsigned fAdc) const {
   if (fAdc < 128) {
-    if (fAdc % 32 == 31) return 0.5 * (3 * mValues [fAdc] - mValues [fAdc - 1]); // extrapolate
-    else       return 0.5 * (mValues [fAdc] + mValues [fAdc + 1]); // interpolate
+    if (fAdc % 32 == 31)
+      return 0.5 * (3 * mValues[fAdc] - mValues[fAdc - 1]);  // extrapolate
+    else
+      return 0.5 * (mValues[fAdc] + mValues[fAdc + 1]);  // interpolate
   }
   return 0.;
 }
 
-float CastorQIEShape::highEdge (unsigned fAdc) const {
-  if (fAdc >= 128 ) return 0;
-  if (fAdc == 127 ) return mValues [fAdc+1];
-  if (fAdc % 32 == 31) return mValues [fAdc+3];
-  return mValues [fAdc+1];
+float CastorQIEShape::highEdge(unsigned fAdc) const {
+  if (fAdc >= 128)
+    return 0;
+  if (fAdc == 127)
+    return mValues[fAdc + 1];
+  if (fAdc % 32 == 31)
+    return mValues[fAdc + 3];
+  return mValues[fAdc + 1];
 }
 
-bool CastorQIEShape::setLowEdge (float fValue, unsigned fAdc) {
-  if (fAdc >= 32) return false; 
-  mValues [fAdc] = fValue;
+bool CastorQIEShape::setLowEdge(float fValue, unsigned fAdc) {
+  if (fAdc >= 32)
+    return false;
+  mValues[fAdc] = fValue;
   return true;
 }
 
-bool CastorQIEShape::setLowEdges (const float fValue [32]) {
+bool CastorQIEShape::setLowEdges(const float fValue[32]) {
   bool result = true;
-  for (int adc = 0; adc < 32; adc++) result = result && setLowEdge (fValue [adc], adc);
-  expand ();
+  for (int adc = 0; adc < 32; adc++)
+    result = result && setLowEdge(fValue[adc], adc);
+  expand();
   return result;
 }

--- a/CondFormats/CastorObjects/src/CastorRawGains.cc
+++ b/CondFormats/CastorObjects/src/CastorRawGains.cc
@@ -13,67 +13,65 @@ POOL object to store Gain values 4xCapId
 namespace {
   class compareItems {
   public:
-    bool operator () (const CastorRawGains::Item& first, const CastorRawGains::Item& second) const {
-      return first.rawId () < second.rawId ();
+    bool operator()(const CastorRawGains::Item& first, const CastorRawGains::Item& second) const {
+      return first.rawId() < second.rawId();
     }
   };
 
-  CastorRawGains::Container::const_iterator 
-  find (const CastorRawGains::Container& container, unsigned long id) {
-    CastorRawGains::Container::const_iterator result = container.begin ();
-    for (; result != container.end (); result++) {
-      if (result->rawId () == id) break; // found
+  CastorRawGains::Container::const_iterator find(const CastorRawGains::Container& container, unsigned long id) {
+    CastorRawGains::Container::const_iterator result = container.begin();
+    for (; result != container.end(); result++) {
+      if (result->rawId() == id)
+        break;  // found
     }
     return result;
   }
-}
+}  // namespace
 
-CastorRawGains::CastorRawGains() 
-  : mSorted (false) {}
+CastorRawGains::CastorRawGains() : mSorted(false) {}
 
-CastorRawGains::~CastorRawGains(){}
+CastorRawGains::~CastorRawGains() {}
 
-const CastorRawGain* CastorRawGains::getValues (DetId fId) const {
-  Item target (fId.rawId (), 0, 0, 0, CastorRawGain::BAD);
+const CastorRawGain* CastorRawGains::getValues(DetId fId) const {
+  Item target(fId.rawId(), 0, 0, 0, CastorRawGain::BAD);
   std::vector<Item>::const_iterator cell;
-  if (sorted ()) {
-    cell = std::lower_bound (mItems.begin(), mItems.end(), target, compareItems ());
+  if (sorted()) {
+    cell = std::lower_bound(mItems.begin(), mItems.end(), target, compareItems());
+  } else {
+    std::cerr << "CastorRawGains::getValues-> container is not sorted. Please sort it to search effectively"
+              << std::endl;
+    cell = find(mItems, fId.rawId());
   }
-  else {
-    std::cerr << "CastorRawGains::getValues-> container is not sorted. Please sort it to search effectively" << std::endl;
-    cell = find (mItems, fId.rawId ());
-  }
-  if (cell == mItems.end() || cell->rawId () != target.rawId ())
-    throw cms::Exception ("Conditions not found") << "Unavailable Raw Gains for cell " << HcalGenericDetId(target.rawId());
+  if (cell == mItems.end() || cell->rawId() != target.rawId())
+    throw cms::Exception("Conditions not found")
+        << "Unavailable Raw Gains for cell " << HcalGenericDetId(target.rawId());
   return &(*cell);
 }
 
-std::vector<DetId> CastorRawGains::getAllChannels () const {
+std::vector<DetId> CastorRawGains::getAllChannels() const {
   std::vector<DetId> result;
-  for (std::vector<Item>::const_iterator item = mItems.begin (); item != mItems.end (); item++) {
-    result.push_back (DetId (item->rawId ()));
+  for (std::vector<Item>::const_iterator item = mItems.begin(); item != mItems.end(); item++) {
+    result.push_back(DetId(item->rawId()));
   }
   return result;
 }
 
-
-CastorRawGain* CastorRawGains::addItem (DetId fId) {
-  CastorRawGain item (fId.rawId ());
-  mItems.push_back (item);
+CastorRawGain* CastorRawGains::addItem(DetId fId) {
+  CastorRawGain item(fId.rawId());
+  mItems.push_back(item);
   mSorted = false;
-  return &(mItems.back ());
+  return &(mItems.back());
 }
 
-void CastorRawGains::addValues (DetId fId, const CastorRawGain& fValues) {
-  Item item (fId.rawId (), fValues.getValue(), fValues.getError(), fValues.getVoltage(), fValues.getStatus());
-  mItems.push_back (item);
+void CastorRawGains::addValues(DetId fId, const CastorRawGain& fValues) {
+  Item item(fId.rawId(), fValues.getValue(), fValues.getError(), fValues.getVoltage(), fValues.getStatus());
+  mItems.push_back(item);
   mSorted = false;
 }
 
-
-void CastorRawGains::sort () {
+void CastorRawGains::sort() {
   if (!mSorted) {
-    std::sort (mItems.begin(), mItems.end(), compareItems ());
+    std::sort(mItems.begin(), mItems.end(), compareItems());
     mSorted = true;
   }
 }

--- a/CondFormats/CastorObjects/src/classes.h
+++ b/CondFormats/CastorObjects/src/classes.h
@@ -1,40 +1,38 @@
 #include "CondFormats/CastorObjects/src/headers.h"
 
-
 namespace CondFormats_CastorObjects {
   struct dictionary {
     CastorPedestals mypeds;
     std::vector<CastorPedestal> mypedsVec;
- 
+
     CastorPedestalWidths mywidths;
     std::vector<CastorPedestalWidth> mywidthsVec;
- 
+
     CastorGains mygains;
     std::vector<CastorGain> mygainsVec;
- 
+
     CastorGainWidths mygwidths;
     std::vector<CastorGainWidth> mygwidthsVec;
- 
+
     CastorQIEData myqie;
     std::vector<CastorQIECoder> myqievec;
- 
+
     CastorCalibrationQIEData mycalqie;
     std::vector<CastorCalibrationQIECoder> mycalqieVec;
- 
+
     CastorElectronicsMap mymap;
     std::vector<CastorElectronicsMap::PrecisionItem> mymap2;
     std::vector<CastorElectronicsMap::TriggerItem> mymap3;
- 
+
     CastorChannelQuality myquality;
     std::vector<CastorChannelStatus> myqualityVec;
 
     CastorRecoParam myrecoparam;
     std::vector<CastorRecoParam> myrecoparamVec;
     CastorRecoParams myrecoparams;
-    
+
     CastorSaturationCorr mysatcorr;
     std::vector<CastorSaturationCorr> mysatcorrVec;
     CastorSaturationCorrs mysatcorrs;
   };
-}
-
+}  // namespace CondFormats_CastorObjects

--- a/CondFormats/CastorObjects/test/testSerializationCastorObjects.cpp
+++ b/CondFormats/CastorObjects/test/testSerializationCastorObjects.cpp
@@ -2,41 +2,40 @@
 
 #include "CondFormats/CastorObjects/src/headers.h"
 
-int main()
-{
-    testSerialization<CastorCalibrationQIECoder>();
-    testSerialization<CastorCalibrationQIEData>();
-    testSerialization<CastorChannelQuality>();
-    testSerialization<CastorChannelStatus>();
-    //testSerialization<CastorCondObjectContainer>(); missing arguments
-    testSerialization<CastorElectronicsMap>();
-    testSerialization<CastorElectronicsMap::PrecisionItem>();
-    testSerialization<CastorElectronicsMap::TriggerItem>();
-    testSerialization<CastorGain>();
-    testSerialization<CastorGainWidth>();
-    testSerialization<CastorGainWidths>();
-    testSerialization<CastorGains>();
-    testSerialization<CastorPedestal>();
-    testSerialization<CastorPedestalWidth>();
-    testSerialization<CastorPedestalWidths>();
-    testSerialization<CastorPedestals>();
-    testSerialization<CastorQIECoder>();
-    testSerialization<CastorQIEData>();
-    testSerialization<CastorRecoParam>();
-    testSerialization<CastorRecoParams>();
-    testSerialization<CastorSaturationCorr>();
-    testSerialization<CastorSaturationCorrs>();
-    testSerialization<std::vector<CastorCalibrationQIECoder>>();
-    testSerialization<std::vector<CastorChannelStatus>>();
-    testSerialization<std::vector<CastorElectronicsMap::PrecisionItem>>();
-    testSerialization<std::vector<CastorElectronicsMap::TriggerItem>>();
-    testSerialization<std::vector<CastorGain>>();
-    testSerialization<std::vector<CastorGainWidth>>();
-    testSerialization<std::vector<CastorPedestal>>();
-    testSerialization<std::vector<CastorPedestalWidth>>();
-    testSerialization<std::vector<CastorQIECoder>>();
-    testSerialization<std::vector<CastorRecoParam>>();
-    testSerialization<std::vector<CastorSaturationCorr>>();
+int main() {
+  testSerialization<CastorCalibrationQIECoder>();
+  testSerialization<CastorCalibrationQIEData>();
+  testSerialization<CastorChannelQuality>();
+  testSerialization<CastorChannelStatus>();
+  //testSerialization<CastorCondObjectContainer>(); missing arguments
+  testSerialization<CastorElectronicsMap>();
+  testSerialization<CastorElectronicsMap::PrecisionItem>();
+  testSerialization<CastorElectronicsMap::TriggerItem>();
+  testSerialization<CastorGain>();
+  testSerialization<CastorGainWidth>();
+  testSerialization<CastorGainWidths>();
+  testSerialization<CastorGains>();
+  testSerialization<CastorPedestal>();
+  testSerialization<CastorPedestalWidth>();
+  testSerialization<CastorPedestalWidths>();
+  testSerialization<CastorPedestals>();
+  testSerialization<CastorQIECoder>();
+  testSerialization<CastorQIEData>();
+  testSerialization<CastorRecoParam>();
+  testSerialization<CastorRecoParams>();
+  testSerialization<CastorSaturationCorr>();
+  testSerialization<CastorSaturationCorrs>();
+  testSerialization<std::vector<CastorCalibrationQIECoder>>();
+  testSerialization<std::vector<CastorChannelStatus>>();
+  testSerialization<std::vector<CastorElectronicsMap::PrecisionItem>>();
+  testSerialization<std::vector<CastorElectronicsMap::TriggerItem>>();
+  testSerialization<std::vector<CastorGain>>();
+  testSerialization<std::vector<CastorGainWidth>>();
+  testSerialization<std::vector<CastorPedestal>>();
+  testSerialization<std::vector<CastorPedestalWidth>>();
+  testSerialization<std::vector<CastorQIECoder>>();
+  testSerialization<std::vector<CastorRecoParam>>();
+  testSerialization<std::vector<CastorSaturationCorr>>();
 
-    return 0;
+  return 0;
 }

--- a/CondFormats/ESObjects/interface/ESADCToGeVConstant.h
+++ b/CondFormats/ESObjects/interface/ESADCToGeVConstant.h
@@ -5,23 +5,23 @@
 #include <iostream>
 
 class ESADCToGeVConstant {
-  public:
-    ESADCToGeVConstant();
-    ESADCToGeVConstant(const float & ESvaluelow, const float & ESvaluehigh);
-    ~ESADCToGeVConstant();
-    void  setESValueLow(const float& value) { ESvaluelow_ = value; }
-    float getESValueLow() const { return ESvaluelow_; }
-    void  setESValueHigh(const float& value) { ESvaluehigh_ = value; }
-    float getESValueHigh() const { return ESvaluehigh_; }
-    void print(std::ostream& s) const {
-      s << "ESADCToGeVConstant: ES low/high " << ESvaluelow_ << " / " << ESvaluehigh_ <<" [GeV/ADC count]";
-    }
-  private:
-    float ESvaluelow_;
-    float ESvaluehigh_;
+public:
+  ESADCToGeVConstant();
+  ESADCToGeVConstant(const float& ESvaluelow, const float& ESvaluehigh);
+  ~ESADCToGeVConstant();
+  void setESValueLow(const float& value) { ESvaluelow_ = value; }
+  float getESValueLow() const { return ESvaluelow_; }
+  void setESValueHigh(const float& value) { ESvaluehigh_ = value; }
+  float getESValueHigh() const { return ESvaluehigh_; }
+  void print(std::ostream& s) const {
+    s << "ESADCToGeVConstant: ES low/high " << ESvaluelow_ << " / " << ESvaluehigh_ << " [GeV/ADC count]";
+  }
+
+private:
+  float ESvaluelow_;
+  float ESvaluehigh_;
 
   COND_SERIALIZABLE;
 };
-
 
 #endif

--- a/CondFormats/ESObjects/interface/ESChannelStatusCode.h
+++ b/CondFormats/ESObjects/interface/ESChannelStatusCode.h
@@ -7,21 +7,21 @@
 #include <boost/cstdint.hpp>
 
 class ESChannelStatusCode {
-  public:
-    ESChannelStatusCode();
-    ESChannelStatusCode(const ESChannelStatusCode & codeStatus);
-    ESChannelStatusCode(const uint16_t& encodedStatus) : status_(encodedStatus) {};
-    ~ESChannelStatusCode();
+public:
+  ESChannelStatusCode();
+  ESChannelStatusCode(const ESChannelStatusCode& codeStatus);
+  ESChannelStatusCode(const uint16_t& encodedStatus) : status_(encodedStatus){};
+  ~ESChannelStatusCode();
 
-    //get Methods to be defined according to the final definition
+  //get Methods to be defined according to the final definition
 
-    void print(std::ostream& s) const { s << "status is: " << status_; }
+  void print(std::ostream& s) const { s << "status is: " << status_; }
 
-    ESChannelStatusCode& operator=(const ESChannelStatusCode& rhs);
-    uint16_t getStatusCode() const { return status_; }
+  ESChannelStatusCode& operator=(const ESChannelStatusCode& rhs);
+  uint16_t getStatusCode() const { return status_; }
 
-  private:
-    uint16_t status_;
+private:
+  uint16_t status_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/ESObjects/interface/ESCondObjectContainer.h
+++ b/CondFormats/ESObjects/interface/ESCondObjectContainer.h
@@ -7,79 +7,50 @@
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-template < typename T >
+template <typename T>
 class ESCondObjectContainer {
-        public:
-                typedef T Item;
-                typedef Item value_type;
-                typedef ESCondObjectContainer<T> self;
-                typedef typename std::vector<Item> Items;
-                typedef typename std::vector<Item>::const_iterator const_iterator; 
-                typedef typename std::vector<Item>::iterator iterator;
+public:
+  typedef T Item;
+  typedef Item value_type;
+  typedef ESCondObjectContainer<T> self;
+  typedef typename std::vector<Item> Items;
+  typedef typename std::vector<Item>::const_iterator const_iterator;
+  typedef typename std::vector<Item>::iterator iterator;
 
-                ESCondObjectContainer() {};
-                ~ESCondObjectContainer() {};
+  ESCondObjectContainer(){};
+  ~ESCondObjectContainer(){};
 
-                inline
-                const Items & preshowerItems() const { return es_.items(); };
+  inline const Items &preshowerItems() const { return es_.items(); };
 
-                inline
-                const Item & preshower( size_t hashedIndex ) const {
-                        return es_.item(hashedIndex);
-                }
-                
-                inline
-                void insert( std::pair<uint32_t, Item> const &a ) {
-                        if (DetId(a.first).subdetId() == EcalPreshower) {
-				es_.insert(a);
-                        }
-                }
-                
-                inline
-                const_iterator find( uint32_t rawId ) const {
-			return es_.find(rawId);
-                }
+  inline const Item &preshower(size_t hashedIndex) const { return es_.item(hashedIndex); }
 
-                inline
-                const_iterator begin() const {
-                        return es_.begin();
-                }
+  inline void insert(std::pair<uint32_t, Item> const &a) {
+    if (DetId(a.first).subdetId() == EcalPreshower) {
+      es_.insert(a);
+    }
+  }
 
-                inline
-                const_iterator end() const {
-                        return es_.end();
-                }
+  inline const_iterator find(uint32_t rawId) const { return es_.find(rawId); }
 
-                inline
-                void setValue(const uint32_t id, const Item &item) {
-                        (*this)[id] = item;
-                }
+  inline const_iterator begin() const { return es_.begin(); }
 
-                inline
-                const self & getMap() const {
-                        return *this;
-                }
+  inline const_iterator end() const { return es_.end(); }
 
-                inline
-                size_t size() const {
-                        return es_.size() ;
-                }
-                // add coherent operator++, not needed now -- FIXME
+  inline void setValue(const uint32_t id, const Item &item) { (*this)[id] = item; }
 
-                inline
-                Item & operator[]( uint32_t rawId ) {
-			return es_[rawId];
-                }
-                
-                inline
-                Item const & operator[]( uint32_t rawId ) const {
-			return es_[rawId];
-                }
-                
-        private:
-                EcalContainer< ESDetId, Item > es_;
+  inline const self &getMap() const { return *this; }
 
-      COND_SERIALIZABLE;
+  inline size_t size() const { return es_.size(); }
+  // add coherent operator++, not needed now -- FIXME
+
+  inline Item &operator[](uint32_t rawId) { return es_[rawId]; }
+
+  inline Item const &operator[](uint32_t rawId) const { return es_[rawId]; }
+
+private:
+  EcalContainer<ESDetId, Item> es_;
+
+  COND_SERIALIZABLE;
 };
 
 typedef ESCondObjectContainer<float> ESFloatCondObjectContainer;

--- a/CondFormats/ESObjects/interface/ESEEIntercalibConstants.h
+++ b/CondFormats/ESObjects/interface/ESEEIntercalibConstants.h
@@ -5,86 +5,95 @@
 #include <iostream>
 
 class ESEEIntercalibConstants {
+public:
+  ESEEIntercalibConstants();
+  ESEEIntercalibConstants(const float& gammaLow0,
+                          const float& alphaLow0,
+                          const float& gammaHigh0,
+                          const float& alphaHigh0,
+                          const float& gammaLow1,
+                          const float& alphaLow1,
+                          const float& gammaHigh1,
+                          const float& alphaHigh1,
+                          const float& gammaLow2,
+                          const float& alphaLow2,
+                          const float& gammaHigh2,
+                          const float& alphaHigh2,
+                          const float& gammaLow3,
+                          const float& alphaLow3,
+                          const float& gammaHigh3,
+                          const float& alphaHigh3);
+  ~ESEEIntercalibConstants();
 
-  public:
+  void setGammaLow0(const float& value) { gammaLow0_ = value; }
+  float getGammaLow0() const { return gammaLow0_; }
+  void setAlphaLow0(const float& value) { alphaLow0_ = value; }
+  float getAlphaLow0() const { return alphaLow0_; }
 
-    ESEEIntercalibConstants();
-    ESEEIntercalibConstants(const float & gammaLow0, const float & alphaLow0, const float & gammaHigh0, const float & alphaHigh0,
-			    const float & gammaLow1, const float & alphaLow1, const float & gammaHigh1, const float & alphaHigh1,
-			    const float & gammaLow2, const float & alphaLow2, const float & gammaHigh2, const float & alphaHigh2,
-			    const float & gammaLow3, const float & alphaLow3, const float & gammaHigh3, const float & alphaHigh3
-			    );
-    ~ESEEIntercalibConstants();
+  void setGammaLow1(const float& value) { gammaLow1_ = value; }
+  float getGammaLow1() const { return gammaLow1_; }
+  void setAlphaLow1(const float& value) { alphaLow1_ = value; }
+  float getAlphaLow1() const { return alphaLow1_; }
 
-    void  setGammaLow0(const float& value) { gammaLow0_ = value; }
-    float getGammaLow0() const { return gammaLow0_; }
-    void  setAlphaLow0(const float& value) { alphaLow0_ = value; }
-    float getAlphaLow0() const { return alphaLow0_; }
+  void setGammaLow2(const float& value) { gammaLow2_ = value; }
+  float getGammaLow2() const { return gammaLow2_; }
+  void setAlphaLow2(const float& value) { alphaLow2_ = value; }
+  float getAlphaLow2() const { return alphaLow2_; }
 
-    void  setGammaLow1(const float& value) { gammaLow1_ = value; }
-    float getGammaLow1() const { return gammaLow1_; }
-    void  setAlphaLow1(const float& value) { alphaLow1_ = value; }
-    float getAlphaLow1() const { return alphaLow1_; }
+  void setGammaLow3(const float& value) { gammaLow3_ = value; }
+  float getGammaLow3() const { return gammaLow3_; }
+  void setAlphaLow3(const float& value) { alphaLow3_ = value; }
+  float getAlphaLow3() const { return alphaLow3_; }
 
-    void  setGammaLow2(const float& value) { gammaLow2_ = value; }
-    float getGammaLow2() const { return gammaLow2_; }
-    void  setAlphaLow2(const float& value) { alphaLow2_ = value; }
-    float getAlphaLow2() const { return alphaLow2_; }
+  void setGammaHigh0(const float& value) { gammaHigh0_ = value; }
+  float getGammaHigh0() const { return gammaHigh0_; }
+  void setAlphaHigh0(const float& value) { alphaHigh0_ = value; }
+  float getAlphaHigh0() const { return alphaHigh0_; }
 
-    void  setGammaLow3(const float& value) { gammaLow3_ = value; }
-    float getGammaLow3() const { return gammaLow3_; }
-    void  setAlphaLow3(const float& value) { alphaLow3_ = value; }
-    float getAlphaLow3() const { return alphaLow3_; }
+  void setGammaHigh1(const float& value) { gammaHigh1_ = value; }
+  float getGammaHigh1() const { return gammaHigh1_; }
+  void setAlphaHigh1(const float& value) { alphaHigh1_ = value; }
+  float getAlphaHigh1() const { return alphaHigh1_; }
 
-    void  setGammaHigh0(const float& value) { gammaHigh0_ = value; }
-    float getGammaHigh0() const { return gammaHigh0_; }
-    void  setAlphaHigh0(const float& value) { alphaHigh0_ = value; }
-    float getAlphaHigh0() const { return alphaHigh0_; }
+  void setGammaHigh2(const float& value) { gammaHigh2_ = value; }
+  float getGammaHigh2() const { return gammaHigh2_; }
+  void setAlphaHigh2(const float& value) { alphaHigh2_ = value; }
+  float getAlphaHigh2() const { return alphaHigh2_; }
 
-    void  setGammaHigh1(const float& value) { gammaHigh1_ = value; }
-    float getGammaHigh1() const { return gammaHigh1_; }
-    void  setAlphaHigh1(const float& value) { alphaHigh1_ = value; }
-    float getAlphaHigh1() const { return alphaHigh1_; }
+  void setGammaHigh3(const float& value) { gammaHigh3_ = value; }
+  float getGammaHigh3() const { return gammaHigh3_; }
+  void setAlphaHigh3(const float& value) { alphaHigh3_ = value; }
+  float getAlphaHigh3() const { return alphaHigh3_; }
 
-    void  setGammaHigh2(const float& value) { gammaHigh2_ = value; }
-    float getGammaHigh2() const { return gammaHigh2_; }
-    void  setAlphaHigh2(const float& value) { alphaHigh2_ = value; }
-    float getAlphaHigh2() const { return alphaHigh2_; }
+  void print(std::ostream& s) const {
+    s << "ESEEIntercalibConstants: ES low gain (gamma, alpha) / high gain (gamma, alpha)" << gammaLow0_ << " "
+      << alphaLow0_ << " / " << gammaHigh0_ << " " << alphaHigh0_;
+  }
 
-    void  setGammaHigh3(const float& value) { gammaHigh3_ = value; }
-    float getGammaHigh3() const { return gammaHigh3_; }
-    void  setAlphaHigh3(const float& value) { alphaHigh3_ = value; }
-    float getAlphaHigh3() const { return alphaHigh3_; }
+private:
+  // both planes work perfectly
+  float gammaLow0_;
+  float alphaLow0_;
+  float gammaHigh0_;
+  float alphaHigh0_;
 
-    void print(std::ostream& s) const {
-      s << "ESEEIntercalibConstants: ES low gain (gamma, alpha) / high gain (gamma, alpha)" << gammaLow0_ << " " << alphaLow0_<< " / " << gammaHigh0_ <<" "<<alphaHigh0_;
-    }
+  // both planes do not work at all
+  float gammaLow1_;
+  float alphaLow1_;
+  float gammaHigh1_;
+  float alphaHigh1_;
 
-  private:
+  // only the first plane works
+  float gammaLow2_;
+  float alphaLow2_;
+  float gammaHigh2_;
+  float alphaHigh2_;
 
-    // both planes work perfectly
-    float gammaLow0_;
-    float alphaLow0_;
-    float gammaHigh0_;
-    float alphaHigh0_;
-
-    // both planes do not work at all
-    float gammaLow1_;
-    float alphaLow1_;
-    float gammaHigh1_;
-    float alphaHigh1_;
-
-    // only the first plane works
-    float gammaLow2_;
-    float alphaLow2_;
-    float gammaHigh2_;
-    float alphaHigh2_;
-
-    // only the second plane works
-    float gammaLow3_;
-    float alphaLow3_;
-    float gammaHigh3_;
-    float alphaHigh3_;
+  // only the second plane works
+  float gammaLow3_;
+  float alphaLow3_;
+  float gammaHigh3_;
+  float alphaHigh3_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/ESObjects/interface/ESGain.h
+++ b/CondFormats/ESObjects/interface/ESGain.h
@@ -5,20 +5,18 @@
 #include <iostream>
 
 class ESGain {
-  public:
-    ESGain();
-    ESGain(const float & gain);
-    ~ESGain();
-    void  setESGain(const float& value) { gain_ = value; }
-    float getESGain() const { return gain_; }
-    void print(std::ostream& s) const {
-      s << "ESGain: " << gain_; 
-    }
-  private:
-    float gain_;
+public:
+  ESGain();
+  ESGain(const float& gain);
+  ~ESGain();
+  void setESGain(const float& value) { gain_ = value; }
+  float getESGain() const { return gain_; }
+  void print(std::ostream& s) const { s << "ESGain: " << gain_; }
+
+private:
+  float gain_;
 
   COND_SERIALIZABLE;
 };
-
 
 #endif

--- a/CondFormats/ESObjects/interface/ESIntercalibConstants.h
+++ b/CondFormats/ESObjects/interface/ESIntercalibConstants.h
@@ -6,5 +6,4 @@ typedef float ESIntercalibConstant;
 typedef ESFloatCondObjectContainer ESIntercalibConstantMap;
 typedef ESIntercalibConstantMap ESIntercalibConstants;
 
-
 #endif

--- a/CondFormats/ESObjects/interface/ESMIPToGeVConstant.h
+++ b/CondFormats/ESObjects/interface/ESMIPToGeVConstant.h
@@ -5,24 +5,21 @@
 #include <iostream>
 
 class ESMIPToGeVConstant {
+public:
+  ESMIPToGeVConstant();
+  ESMIPToGeVConstant(const float& ESvaluelow, const float& ESvaluehigh);
+  ~ESMIPToGeVConstant();
+  void setESValueLow(const float& value) { ESvaluelow_ = value; }
+  float getESValueLow() const { return ESvaluelow_; }
+  void setESValueHigh(const float& value) { ESvaluehigh_ = value; }
+  float getESValueHigh() const { return ESvaluehigh_; }
+  void print(std::ostream& s) const {
+    s << "ESMIPToGeVConstant: ES low/high " << ESvaluelow_ << " / " << ESvaluehigh_ << " [GeV/MIP count]";
+  }
 
-  public:
-
-    ESMIPToGeVConstant();
-    ESMIPToGeVConstant(const float & ESvaluelow, const float & ESvaluehigh);
-    ~ESMIPToGeVConstant();
-    void  setESValueLow(const float& value) { ESvaluelow_ = value; }
-    float getESValueLow() const { return ESvaluelow_; }
-    void  setESValueHigh(const float& value) { ESvaluehigh_ = value; }
-    float getESValueHigh() const { return ESvaluehigh_; }
-    void print(std::ostream& s) const {
-      s << "ESMIPToGeVConstant: ES low/high " << ESvaluelow_ << " / " << ESvaluehigh_ <<" [GeV/MIP count]";
-    }
-
-  private:
-
-    float ESvaluelow_;
-    float ESvaluehigh_;
+private:
+  float ESvaluelow_;
+  float ESvaluehigh_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/ESObjects/interface/ESMissingEnergyCalibration.h
+++ b/CondFormats/ESObjects/interface/ESMissingEnergyCalibration.h
@@ -5,56 +5,55 @@
 #include <iostream>
 
 class ESMissingEnergyCalibration {
+public:
+  ESMissingEnergyCalibration();
+  ESMissingEnergyCalibration(const float& ConstAEta0,
+                             const float& ConstBEta0,
+                             const float& ConstAEta1,
+                             const float& ConstBEta1,
+                             const float& ConstAEta2,
+                             const float& ConstBEta2,
+                             const float& ConstAEta3,
+                             const float& ConstBEta3);
+  ~ESMissingEnergyCalibration();
 
-  public:
+  void setConstAEta0(const float& value) { ConstAEta0_ = value; }
+  float getConstAEta0() const { return ConstAEta0_; }
+  void setConstBEta0(const float& value) { ConstBEta0_ = value; }
+  float getConstBEta0() const { return ConstBEta0_; }
 
-    ESMissingEnergyCalibration();
-    ESMissingEnergyCalibration(const float & ConstAEta0, const float & ConstBEta0, 
-			       const float & ConstAEta1, const float & ConstBEta1,
-			       const float & ConstAEta2, const float & ConstBEta2,
-			       const float & ConstAEta3, const float & ConstBEta3
-			       );
-    ~ESMissingEnergyCalibration();
+  void setConstAEta1(const float& value) { ConstAEta1_ = value; }
+  float getConstAEta1() const { return ConstAEta1_; }
+  void setConstBEta1(const float& value) { ConstBEta1_ = value; }
+  float getConstBEta1() const { return ConstBEta1_; }
 
-    void  setConstAEta0(const float& value) { ConstAEta0_ = value; }
-    float getConstAEta0() const { return ConstAEta0_; }
-    void  setConstBEta0(const float& value) { ConstBEta0_ = value; }
-    float getConstBEta0() const { return ConstBEta0_; }
+  void setConstAEta2(const float& value) { ConstAEta2_ = value; }
+  float getConstAEta2() const { return ConstAEta2_; }
+  void setConstBEta2(const float& value) { ConstBEta2_ = value; }
+  float getConstBEta2() const { return ConstBEta2_; }
 
-    void  setConstAEta1(const float& value) { ConstAEta1_ = value; }
-    float getConstAEta1() const { return ConstAEta1_; }
-    void  setConstBEta1(const float& value) { ConstBEta1_ = value; }
-    float getConstBEta1() const { return ConstBEta1_; }
+  void setConstAEta3(const float& value) { ConstAEta3_ = value; }
+  float getConstAEta3() const { return ConstAEta3_; }
+  void setConstBEta3(const float& value) { ConstBEta3_ = value; }
+  float getConstBEta3() const { return ConstBEta3_; }
 
-    void  setConstAEta2(const float& value) { ConstAEta2_ = value; }
-    float getConstAEta2() const { return ConstAEta2_; }
-    void  setConstBEta2(const float& value) { ConstBEta2_ = value; }
-    float getConstBEta2() const { return ConstBEta2_; }
+  void print(std::ostream& s) const {
+    s << "ESMissingEnergyCalibration: ES low eta constants" << ConstAEta0_ << " " << ConstBEta0_ << " / " << ConstAEta1_
+      << " " << ConstBEta1_;
+  }
 
-    void  setConstAEta3(const float& value) { ConstAEta3_ = value; }
-    float getConstAEta3() const { return ConstAEta3_; }
-    void  setConstBEta3(const float& value) { ConstBEta3_ = value; }
-    float getConstBEta3() const { return ConstBEta3_; }
+private:
+  float ConstAEta0_;
+  float ConstBEta0_;
 
-    void print(std::ostream& s) const {
-      s << "ESMissingEnergyCalibration: ES low eta constants" << ConstAEta0_ << " " << ConstBEta0_<< " / " << ConstAEta1_ << " " << ConstBEta1_;
-    }
+  float ConstAEta1_;
+  float ConstBEta1_;
 
-  private:
+  float ConstAEta2_;
+  float ConstBEta2_;
 
-
-    float ConstAEta0_;
-    float ConstBEta0_;
-
-    float ConstAEta1_;
-    float ConstBEta1_;
-
-    float ConstAEta2_;
-    float ConstBEta2_;
-
-    float ConstAEta3_;
-    float ConstBEta3_;
-
+  float ConstAEta3_;
+  float ConstBEta3_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/ESObjects/interface/ESPedestals.h
+++ b/CondFormats/ESObjects/interface/ESPedestals.h
@@ -1,30 +1,27 @@
 #ifndef ESPedestals_h
 #define ESPedestals_h
 
-
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include "CondFormats/ESObjects/interface/ESCondObjectContainer.h"
 
 struct ESPedestal {
-        struct Zero { float z1; float z2;};
+  struct Zero {
+    float z1;
+    float z2;
+  };
 
-        static const Zero zero;
+  static const Zero zero;
 
-        float mean;
-        float rms;
+  float mean;
+  float rms;
 
-        public:
+public:
+  float getMean() const { return mean; }
 
-        float getMean() const {
-                return mean;
-        }
+  float getRms() const { return rms; }
 
-        float getRms() const {
-                return rms;
-        }
-
-        COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 typedef ESCondObjectContainer<ESPedestal> ESPedestalsMap;

--- a/CondFormats/ESObjects/interface/ESRecHitRatioCuts.h
+++ b/CondFormats/ESObjects/interface/ESRecHitRatioCuts.h
@@ -5,34 +5,31 @@
 #include <iostream>
 
 class ESRecHitRatioCuts {
+public:
+  ESRecHitRatioCuts();
+  ESRecHitRatioCuts(const float& r12Low, const float& r23Low, const float& r12High, const float& r23High);
+  ~ESRecHitRatioCuts();
 
-  public:
+  void setR12Low(const float& value) { r12Low_ = value; }
+  float getR12Low() const { return r12Low_; }
+  void setR23Low(const float& value) { r23Low_ = value; }
+  float getR23Low() const { return r23Low_; }
 
-    ESRecHitRatioCuts();
-    ESRecHitRatioCuts(const float & r12Low, const float & r23Low, 
-		      const float & r12High, const float & r23High);
-    ~ESRecHitRatioCuts();
+  void setR12High(const float& value) { r12High_ = value; }
+  float getR12High() const { return r12High_; }
+  void setR23High(const float& value) { r23High_ = value; }
+  float getR23High() const { return r23High_; }
 
-    void  setR12Low(const float& value) { r12Low_ = value; }
-    float getR12Low() const { return r12Low_; }
-    void  setR23Low(const float& value) { r23Low_ = value; }
-    float getR23Low() const { return r23Low_; }
+  void print(std::ostream& s) const {
+    s << "ESRecHitRatioCuts: ES low cut (r12, r23) / high cut (r12, r23)" << r12Low_ << " " << r23Low_ << " / "
+      << r12High_ << " " << r23High_;
+  }
 
-    void  setR12High(const float& value) { r12High_ = value; }
-    float getR12High() const { return r12High_; }
-    void  setR23High(const float& value) { r23High_ = value; }
-    float getR23High() const { return r23High_; }
-
-    void print(std::ostream& s) const {
-      s << "ESRecHitRatioCuts: ES low cut (r12, r23) / high cut (r12, r23)" << r12Low_ << " " << r23Low_<< " / " << r12High_ <<" "<< r23High_;
-    }
-
-  private:
-
-    float r12Low_;
-    float r23Low_;
-    float r12High_;
-    float r23High_;
+private:
+  float r12Low_;
+  float r23Low_;
+  float r12High_;
+  float r23High_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/ESObjects/interface/ESStripGroupId.h
+++ b/CondFormats/ESObjects/interface/ESStripGroupId.h
@@ -5,20 +5,19 @@
 
 class ESStripGroupId {
 public:
-  ESStripGroupId()  : id_(0){}
-  ESStripGroupId(const unsigned int& id)  : id_(id){}
+  ESStripGroupId() : id_(0) {}
+  ESStripGroupId(const unsigned int& id) : id_(id) {}
 
-  bool operator>(const ESStripGroupId& rhs) const{ return ( id_>rhs.id() ); }
-  bool operator>=(const ESStripGroupId& rhs) const { return ( id_>=rhs.id() ); }
-  bool operator==(const ESStripGroupId& rhs) const { return ( id_==rhs.id() ); }
-  bool operator<(const ESStripGroupId& rhs) const { return ( id_<rhs.id() ); }
-  bool operator<=(const ESStripGroupId& rhs) const { return ( id_<=rhs.id() ); }
-    
+  bool operator>(const ESStripGroupId& rhs) const { return (id_ > rhs.id()); }
+  bool operator>=(const ESStripGroupId& rhs) const { return (id_ >= rhs.id()); }
+  bool operator==(const ESStripGroupId& rhs) const { return (id_ == rhs.id()); }
+  bool operator<(const ESStripGroupId& rhs) const { return (id_ < rhs.id()); }
+  bool operator<=(const ESStripGroupId& rhs) const { return (id_ <= rhs.id()); }
+
   const unsigned int id() const { return id_; }
 
 private:
   unsigned int id_;
-  
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/ESObjects/interface/ESTBWeights.h
+++ b/CondFormats/ESObjects/interface/ESTBWeights.h
@@ -8,22 +8,21 @@
 #include "CondFormats/ESObjects/interface/ESStripGroupId.h"
 #include "CondFormats/ESObjects/interface/ESWeightSet.h"
 
-
 class ESTBWeights {
-  public:
-   typedef std::map< ESStripGroupId,  ESWeightSet > ESTBWeightMap;
+public:
+  typedef std::map<ESStripGroupId, ESWeightSet> ESTBWeightMap;
 
-    ESTBWeights();
-    ~ESTBWeights();
+  ESTBWeights();
+  ~ESTBWeights();
 
-    // modifiers
-    void setValue(const ESStripGroupId& groupId, const ESWeightSet& weight);
+  // modifiers
+  void setValue(const ESStripGroupId& groupId, const ESWeightSet& weight);
 
-    // accessors
-    const ESTBWeightMap& getMap() const { return map_; }
+  // accessors
+  const ESTBWeightMap& getMap() const { return map_; }
 
-  private:
-    ESTBWeightMap map_;
+private:
+  ESTBWeightMap map_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/ESObjects/interface/ESThresholds.h
+++ b/CondFormats/ESObjects/interface/ESThresholds.h
@@ -5,29 +5,25 @@
 #include <iostream>
 
 class ESThresholds {
+public:
+  ESThresholds();
+  ESThresholds(const float& ts2, const float& zs);
+  ~ESThresholds();
 
-  public:
+  void setTS2Threshold(const float& value) { ts2_ = value; }
+  float getTS2Threshold() const { return ts2_; }
+  void setZSThreshold(const float& value) { zs_ = value; }
+  float getZSThreshold() const { return zs_; }
 
-    ESThresholds();
-    ESThresholds(const float & ts2, const float & zs);
-    ~ESThresholds();
+  void print(std::ostream& s) const {
+    s << "ESThresholds: 2nd time sample / ZS threshold" << ts2_ << " / " << zs_ << " [ADC count]";
+  }
 
-    void  setTS2Threshold(const float& value) { ts2_ = value; }
-    float getTS2Threshold() const { return ts2_; }
-    void  setZSThreshold(const float& value) { zs_ = value; }
-    float getZSThreshold() const { return zs_; }
-
-    void print(std::ostream& s) const {
-      s << "ESThresholds: 2nd time sample / ZS threshold" << ts2_ << " / " << zs_ <<" [ADC count]";
-    }
-
-  private:
-
-    float ts2_;
-    float zs_;
+private:
+  float ts2_;
+  float zs_;
 
   COND_SERIALIZABLE;
 };
-
 
 #endif

--- a/CondFormats/ESObjects/interface/ESTimeSampleWeights.h
+++ b/CondFormats/ESObjects/interface/ESTimeSampleWeights.h
@@ -5,32 +5,26 @@
 #include <iostream>
 
 class ESTimeSampleWeights {
+public:
+  ESTimeSampleWeights();
+  ESTimeSampleWeights(const float& w0, const float& w1, const float& w2);
+  ~ESTimeSampleWeights();
 
-  public:
+  void setWeightForTS0(const float& value) { w0_ = value; }
+  float getWeightForTS0() const { return w0_; }
+  void setWeightForTS1(const float& value) { w1_ = value; }
+  float getWeightForTS1() const { return w1_; }
+  void setWeightForTS2(const float& value) { w2_ = value; }
+  float getWeightForTS2() const { return w2_; }
 
-    ESTimeSampleWeights();
-    ESTimeSampleWeights(const float & w0, const float & w1, const float & w2);
-    ~ESTimeSampleWeights();
+  void print(std::ostream& s) const { s << "ESTimeSampleWeights: " << w0_ << " " << w1_ << " " << w2_; }
 
-    void  setWeightForTS0(const float& value) { w0_ = value; }
-    float getWeightForTS0() const { return w0_; }
-    void  setWeightForTS1(const float& value) { w1_ = value; }
-    float getWeightForTS1() const { return w1_; }
-    void  setWeightForTS2(const float& value) { w2_ = value; }
-    float getWeightForTS2() const { return w2_; }
-
-    void print(std::ostream& s) const {
-      s<<"ESTimeSampleWeights: "<<w0_<<" "<<w1_<<" "<<w2_;
-    }
-
-  private:
-
-    float w0_; 
-    float w1_;
-    float w2_;
+private:
+  float w0_;
+  float w1_;
+  float w2_;
 
   COND_SERIALIZABLE;
 };
-
 
 #endif

--- a/CondFormats/ESObjects/interface/ESWeight.h
+++ b/CondFormats/ESObjects/interface/ESWeight.h
@@ -12,24 +12,24 @@
 #include <iostream>
 
 class ESWeight {
- public:
+public:
   ESWeight();
   ESWeight(const double& awgt);
   ESWeight(const ESWeight& awgt);
-  ESWeight& operator=(const ESWeight&rhs);
+  ESWeight& operator=(const ESWeight& rhs);
 
   double value() const { return wgt_; }
   double operator()() const { return wgt_; }
 
   void setValue(const double& awgt) { wgt_ = awgt; }
-  bool operator ==(const ESWeight&rhs) const { return (wgt_ == rhs.wgt_); }
-  bool operator !=(const ESWeight&rhs) const { return (wgt_ != rhs.wgt_); }
-  bool operator <(const ESWeight&rhs) const { return (wgt_ < rhs.wgt_); }
-  bool operator >(const ESWeight&rhs) const { return (wgt_ > rhs.wgt_); }
-  bool operator <=(const ESWeight&rhs) const { return (wgt_ <= rhs.wgt_); }
-  bool operator >=(const ESWeight&rhs) const { return (wgt_ >= rhs.wgt_); }
+  bool operator==(const ESWeight& rhs) const { return (wgt_ == rhs.wgt_); }
+  bool operator!=(const ESWeight& rhs) const { return (wgt_ != rhs.wgt_); }
+  bool operator<(const ESWeight& rhs) const { return (wgt_ < rhs.wgt_); }
+  bool operator>(const ESWeight& rhs) const { return (wgt_ > rhs.wgt_); }
+  bool operator<=(const ESWeight& rhs) const { return (wgt_ <= rhs.wgt_); }
+  bool operator>=(const ESWeight& rhs) const { return (wgt_ >= rhs.wgt_); }
 
- private:
+private:
   double wgt_;
 };
 

--- a/CondFormats/ESObjects/interface/ESWeightSet.h
+++ b/CondFormats/ESObjects/interface/ESWeightSet.h
@@ -8,33 +8,29 @@
 #include <iostream>
 
 class ESWeightSet {
+public:
+  typedef math::Matrix<2, 3>::type ESWeightMatrix;
 
-  public:
-  
-  typedef math::Matrix<2,3>::type ESWeightMatrix;
-  
   ESWeightSet();
   ESWeightSet(const ESWeightSet& aset);
   ESWeightSet(ESWeightMatrix& amat);
   ~ESWeightSet();
-  
+
   ESWeightMatrix& getWeights() { return wgtBeforeSwitch_; }
-  
+
   const ESWeightMatrix& getWeights() const { return wgtBeforeSwitch_; }
-  
+
   ESWeightSet& operator=(const ESWeightSet& rhs);
-  
+
   void print(std::ostream& o) const {
     using namespace std;
-    o << "wgtBeforeSwitch_.: " << wgtBeforeSwitch_
-      << endl;
+    o << "wgtBeforeSwitch_.: " << wgtBeforeSwitch_ << endl;
   }
-  
-  
- private:
+
+private:
   ESWeightMatrix wgtBeforeSwitch_;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/ESObjects/src/ESADCToGeVConstant.cc
+++ b/CondFormats/ESObjects/src/ESADCToGeVConstant.cc
@@ -1,17 +1,13 @@
 #include "CondFormats/ESObjects/interface/ESADCToGeVConstant.h"
 
-ESADCToGeVConstant::ESADCToGeVConstant() 
-{
-  ESvaluelow_=0.;
-  ESvaluehigh_=0.;
+ESADCToGeVConstant::ESADCToGeVConstant() {
+  ESvaluelow_ = 0.;
+  ESvaluehigh_ = 0.;
 }
 
-ESADCToGeVConstant::ESADCToGeVConstant(const float & ESvaluelow, const float & ESvaluehigh) {
+ESADCToGeVConstant::ESADCToGeVConstant(const float& ESvaluelow, const float& ESvaluehigh) {
   ESvaluelow_ = ESvaluelow;
   ESvaluehigh_ = ESvaluehigh;
-
 }
 
-ESADCToGeVConstant::~ESADCToGeVConstant() {
-
-}
+ESADCToGeVConstant::~ESADCToGeVConstant() {}

--- a/CondFormats/ESObjects/src/ESChannelStatus.cc
+++ b/CondFormats/ESObjects/src/ESChannelStatus.cc
@@ -1,2 +1,1 @@
 #include "CondFormats/ESObjects/interface/ESChannelStatus.h"
-

--- a/CondFormats/ESObjects/src/ESChannelStatusCode.cc
+++ b/CondFormats/ESObjects/src/ESChannelStatusCode.cc
@@ -1,15 +1,10 @@
 #include "CondFormats/ESObjects/interface/ESChannelStatusCode.h"
 
-ESChannelStatusCode::ESChannelStatusCode() {
-  status_ = 0;
-}
+ESChannelStatusCode::ESChannelStatusCode() { status_ = 0; }
 
-ESChannelStatusCode::ESChannelStatusCode(const ESChannelStatusCode & ratio) {
-  status_ = ratio.status_;
-}
+ESChannelStatusCode::ESChannelStatusCode(const ESChannelStatusCode& ratio) { status_ = ratio.status_; }
 
-ESChannelStatusCode::~ESChannelStatusCode() {
-}
+ESChannelStatusCode::~ESChannelStatusCode() {}
 
 ESChannelStatusCode& ESChannelStatusCode::operator=(const ESChannelStatusCode& rhs) {
   status_ = rhs.status_;

--- a/CondFormats/ESObjects/src/ESCondObjectContainer.cc
+++ b/CondFormats/ESObjects/src/ESCondObjectContainer.cc
@@ -1,2 +1,1 @@
 #include "CondFormats/ESObjects/interface/ESCondObjectContainer.h"
-

--- a/CondFormats/ESObjects/src/ESEEIntercalibConstants.cc
+++ b/CondFormats/ESObjects/src/ESEEIntercalibConstants.cc
@@ -1,56 +1,62 @@
 #include "CondFormats/ESObjects/interface/ESEEIntercalibConstants.h"
 
-ESEEIntercalibConstants::ESEEIntercalibConstants() 
-{
-  gammaLow0_  = 0.;
+ESEEIntercalibConstants::ESEEIntercalibConstants() {
+  gammaLow0_ = 0.;
   gammaHigh0_ = 0.;
-  alphaLow0_  = 0.;
+  alphaLow0_ = 0.;
   alphaHigh0_ = 0.;
 
-  gammaLow1_  = 0.;
+  gammaLow1_ = 0.;
   gammaHigh1_ = 0.;
-  alphaLow1_  = 0.;
+  alphaLow1_ = 0.;
   alphaHigh1_ = 0.;
 
-  gammaLow2_  = 0.;
+  gammaLow2_ = 0.;
   gammaHigh2_ = 0.;
-  alphaLow2_  = 0.;
+  alphaLow2_ = 0.;
   alphaHigh2_ = 0.;
 
-  gammaLow3_  = 0.;
+  gammaLow3_ = 0.;
   gammaHigh3_ = 0.;
-  alphaLow3_  = 0.;
+  alphaLow3_ = 0.;
   alphaHigh3_ = 0.;
 }
 
-ESEEIntercalibConstants::ESEEIntercalibConstants(
-  const float & gammaLow0, const float & alphaLow0, const float & gammaHigh0, const float & alphaHigh0, 
-  const float & gammaLow1, const float & alphaLow1, const float & gammaHigh1, const float & alphaHigh1, 
-  const float & gammaLow2, const float & alphaLow2, const float & gammaHigh2, const float & alphaHigh2, 
-  const float & gammaLow3, const float & alphaLow3, const float & gammaHigh3, const float & alphaHigh3 
-  ) 
-{
-  gammaLow0_  = gammaLow0;
+ESEEIntercalibConstants::ESEEIntercalibConstants(const float& gammaLow0,
+                                                 const float& alphaLow0,
+                                                 const float& gammaHigh0,
+                                                 const float& alphaHigh0,
+                                                 const float& gammaLow1,
+                                                 const float& alphaLow1,
+                                                 const float& gammaHigh1,
+                                                 const float& alphaHigh1,
+                                                 const float& gammaLow2,
+                                                 const float& alphaLow2,
+                                                 const float& gammaHigh2,
+                                                 const float& alphaHigh2,
+                                                 const float& gammaLow3,
+                                                 const float& alphaLow3,
+                                                 const float& gammaHigh3,
+                                                 const float& alphaHigh3) {
+  gammaLow0_ = gammaLow0;
   gammaHigh0_ = gammaHigh0;
-  alphaLow0_  = alphaLow0;
+  alphaLow0_ = alphaLow0;
   alphaHigh0_ = alphaHigh0;
 
-  gammaLow1_  = gammaLow1;
+  gammaLow1_ = gammaLow1;
   gammaHigh1_ = gammaHigh1;
-  alphaLow1_  = alphaLow1;
+  alphaLow1_ = alphaLow1;
   alphaHigh1_ = alphaHigh1;
 
-  gammaLow2_  = gammaLow2;
+  gammaLow2_ = gammaLow2;
   gammaHigh2_ = gammaHigh2;
-  alphaLow2_  = alphaLow2;
+  alphaLow2_ = alphaLow2;
   alphaHigh2_ = alphaHigh2;
 
-  gammaLow3_  = gammaLow3;
+  gammaLow3_ = gammaLow3;
   gammaHigh3_ = gammaHigh3;
-  alphaLow3_  = alphaLow3;
+  alphaLow3_ = alphaLow3;
   alphaHigh3_ = alphaHigh3;
 }
 
-ESEEIntercalibConstants::~ESEEIntercalibConstants() {
-
-}
+ESEEIntercalibConstants::~ESEEIntercalibConstants() {}

--- a/CondFormats/ESObjects/src/ESGain.cc
+++ b/CondFormats/ESObjects/src/ESGain.cc
@@ -1,14 +1,7 @@
 #include "CondFormats/ESObjects/interface/ESGain.h"
 
-ESGain::ESGain() 
-{
-  gain_=0.;
-}
+ESGain::ESGain() { gain_ = 0.; }
 
-ESGain::ESGain(const float & gain) {
-  gain_ = gain;
-}
+ESGain::ESGain(const float& gain) { gain_ = gain; }
 
-ESGain::~ESGain() {
-
-}
+ESGain::~ESGain() {}

--- a/CondFormats/ESObjects/src/ESMIPToGeVConstant.cc
+++ b/CondFormats/ESObjects/src/ESMIPToGeVConstant.cc
@@ -1,17 +1,13 @@
 #include "CondFormats/ESObjects/interface/ESMIPToGeVConstant.h"
 
-ESMIPToGeVConstant::ESMIPToGeVConstant() 
-{
-  ESvaluelow_=0.;
-  ESvaluehigh_=0.;
+ESMIPToGeVConstant::ESMIPToGeVConstant() {
+  ESvaluelow_ = 0.;
+  ESvaluehigh_ = 0.;
 }
 
-ESMIPToGeVConstant::ESMIPToGeVConstant(const float & ESvaluelow, const float & ESvaluehigh) {
+ESMIPToGeVConstant::ESMIPToGeVConstant(const float& ESvaluelow, const float& ESvaluehigh) {
   ESvaluelow_ = ESvaluelow;
   ESvaluehigh_ = ESvaluehigh;
-
 }
 
-ESMIPToGeVConstant::~ESMIPToGeVConstant() {
-
-}
+ESMIPToGeVConstant::~ESMIPToGeVConstant() {}

--- a/CondFormats/ESObjects/src/ESMissingEnergyCalibration.cc
+++ b/CondFormats/ESObjects/src/ESMissingEnergyCalibration.cc
@@ -1,40 +1,38 @@
 #include "CondFormats/ESObjects/interface/ESMissingEnergyCalibration.h"
 
-ESMissingEnergyCalibration::ESMissingEnergyCalibration() 
-{
-  ConstAEta0_  = 0.;
-  ConstBEta0_  = 0.;
+ESMissingEnergyCalibration::ESMissingEnergyCalibration() {
+  ConstAEta0_ = 0.;
+  ConstBEta0_ = 0.;
 
-  ConstAEta1_  = 0.;
-  ConstBEta1_  = 0.;
+  ConstAEta1_ = 0.;
+  ConstBEta1_ = 0.;
 
-  ConstAEta2_  = 0.;
-  ConstBEta2_  = 0.;
+  ConstAEta2_ = 0.;
+  ConstBEta2_ = 0.;
 
-  ConstAEta3_  = 0.;
-  ConstBEta3_  = 0.;
+  ConstAEta3_ = 0.;
+  ConstBEta3_ = 0.;
 }
 
-ESMissingEnergyCalibration::ESMissingEnergyCalibration(
-  const float & ConstAEta0, const float & ConstBEta0, 
-  const float & ConstAEta1, const float & ConstBEta1, 
-  const float & ConstAEta2, const float & ConstBEta2, 
-  const float & ConstAEta3, const float & ConstBEta3
-  ) 
-{
-  ConstAEta0_  = ConstAEta0;
-  ConstBEta0_  = ConstBEta0;
+ESMissingEnergyCalibration::ESMissingEnergyCalibration(const float& ConstAEta0,
+                                                       const float& ConstBEta0,
+                                                       const float& ConstAEta1,
+                                                       const float& ConstBEta1,
+                                                       const float& ConstAEta2,
+                                                       const float& ConstBEta2,
+                                                       const float& ConstAEta3,
+                                                       const float& ConstBEta3) {
+  ConstAEta0_ = ConstAEta0;
+  ConstBEta0_ = ConstBEta0;
 
-  ConstAEta1_  = ConstAEta1;
-  ConstBEta1_  = ConstBEta1;
+  ConstAEta1_ = ConstAEta1;
+  ConstBEta1_ = ConstBEta1;
 
-  ConstAEta2_  = ConstAEta2;
-  ConstBEta2_  = ConstBEta2;
+  ConstAEta2_ = ConstAEta2;
+  ConstBEta2_ = ConstBEta2;
 
-  ConstAEta3_  = ConstAEta3;
-  ConstBEta3_  = ConstBEta3;
+  ConstAEta3_ = ConstAEta3;
+  ConstBEta3_ = ConstBEta3;
 }
 
-ESMissingEnergyCalibration::~ESMissingEnergyCalibration() {
-
-}
+ESMissingEnergyCalibration::~ESMissingEnergyCalibration() {}

--- a/CondFormats/ESObjects/src/ESPedestals.cc
+++ b/CondFormats/ESObjects/src/ESPedestals.cc
@@ -1,3 +1,3 @@
 #include "CondFormats/ESObjects/interface/ESPedestals.h"
 
-const ESPedestal::Zero ESPedestal::zero = {0.,0.};
+const ESPedestal::Zero ESPedestal::zero = {0., 0.};

--- a/CondFormats/ESObjects/src/ESRecHitRatioCuts.cc
+++ b/CondFormats/ESObjects/src/ESRecHitRatioCuts.cc
@@ -1,19 +1,20 @@
 #include "CondFormats/ESObjects/interface/ESRecHitRatioCuts.h"
 
 ESRecHitRatioCuts::ESRecHitRatioCuts() {
-  r12Low_=0.;
-  r12High_=0.;
-  r23Low_=0.;
-  r23High_=0.;
+  r12Low_ = 0.;
+  r12High_ = 0.;
+  r23Low_ = 0.;
+  r23High_ = 0.;
 }
 
-ESRecHitRatioCuts::ESRecHitRatioCuts(const float & r12Low, const float & r23Low, const float & r12High, const float & r23High) {
-  r12Low_  = r12Low;
+ESRecHitRatioCuts::ESRecHitRatioCuts(const float& r12Low,
+                                     const float& r23Low,
+                                     const float& r12High,
+                                     const float& r23High) {
+  r12Low_ = r12Low;
   r12High_ = r12High;
-  r23Low_  = r23Low;
+  r23Low_ = r23Low;
   r23High_ = r23High;
 }
 
-ESRecHitRatioCuts::~ESRecHitRatioCuts() {
-
-}
+ESRecHitRatioCuts::~ESRecHitRatioCuts() {}

--- a/CondFormats/ESObjects/src/ESStripGroupId.cc
+++ b/CondFormats/ESObjects/src/ESStripGroupId.cc
@@ -1,2 +1,1 @@
 #include "CondFormats/ESObjects/interface/ESStripGroupId.h"
-

--- a/CondFormats/ESObjects/src/ESTBWeights.cc
+++ b/CondFormats/ESObjects/src/ESTBWeights.cc
@@ -2,17 +2,10 @@
 //
 // defualt ctor creates vectors of length EBDataFrame::MAXSAMPLES==10
 //
-ESTBWeights::ESTBWeights() {
+ESTBWeights::ESTBWeights() {}
 
+ESTBWeights::~ESTBWeights() {}
+
+void ESTBWeights::setValue(const ESStripGroupId& groupId, const ESWeightSet& weight) {
+  map_.insert(std::make_pair(groupId, weight));
 }
-
-ESTBWeights::~ESTBWeights() {
-}
-
-void
-ESTBWeights::setValue(const ESStripGroupId& groupId,
-                        const ESWeightSet& weight) {
-  map_.insert( std::make_pair(groupId ,weight) );
-}
-
-

--- a/CondFormats/ESObjects/src/ESThresholds.cc
+++ b/CondFormats/ESObjects/src/ESThresholds.cc
@@ -1,16 +1,13 @@
 #include "CondFormats/ESObjects/interface/ESThresholds.h"
 
-ESThresholds::ESThresholds() 
-{
-  ts2_=0.;
-  zs_=0.;
+ESThresholds::ESThresholds() {
+  ts2_ = 0.;
+  zs_ = 0.;
 }
 
-ESThresholds::ESThresholds(const float & ts2, const float & zs) {
+ESThresholds::ESThresholds(const float& ts2, const float& zs) {
   ts2_ = ts2;
   zs_ = zs;
 }
 
-ESThresholds::~ESThresholds() {
-
-}
+ESThresholds::~ESThresholds() {}

--- a/CondFormats/ESObjects/src/ESTimeSampleWeights.cc
+++ b/CondFormats/ESObjects/src/ESTimeSampleWeights.cc
@@ -1,18 +1,15 @@
 #include "CondFormats/ESObjects/interface/ESTimeSampleWeights.h"
 
-ESTimeSampleWeights::ESTimeSampleWeights() 
-{
+ESTimeSampleWeights::ESTimeSampleWeights() {
   w0_ = 0.;
   w1_ = 0.;
   w2_ = 0.;
 }
 
-ESTimeSampleWeights::ESTimeSampleWeights(const float & w0, const float & w1, const float & w2) {
+ESTimeSampleWeights::ESTimeSampleWeights(const float& w0, const float& w1, const float& w2) {
   w0_ = w0;
   w1_ = w1;
   w2_ = w2;
 }
 
-ESTimeSampleWeights::~ESTimeSampleWeights() {
-
-}
+ESTimeSampleWeights::~ESTimeSampleWeights() {}

--- a/CondFormats/ESObjects/src/ESWeight.cc
+++ b/CondFormats/ESObjects/src/ESWeight.cc
@@ -1,18 +1,12 @@
 #include "CondFormats/ESObjects/interface/ESWeight.h"
 
-ESWeight::ESWeight() {
-  wgt_ = 0.0;
-}
+ESWeight::ESWeight() { wgt_ = 0.0; }
 
-ESWeight::ESWeight(const double& awgt) {
-  wgt_ = awgt;
-}
+ESWeight::ESWeight(const double& awgt) { wgt_ = awgt; }
 
-ESWeight::ESWeight(const ESWeight& awgt) {
-  wgt_ = awgt.wgt_;
-}
+ESWeight::ESWeight(const ESWeight& awgt) { wgt_ = awgt.wgt_; }
 
-ESWeight& ESWeight::operator=(const ESWeight&rhs) {
-   wgt_ = rhs.wgt_;
-   return *this;
+ESWeight& ESWeight::operator=(const ESWeight& rhs) {
+  wgt_ = rhs.wgt_;
+  return *this;
 }

--- a/CondFormats/ESObjects/src/ESWeightSet.cc
+++ b/CondFormats/ESObjects/src/ESWeightSet.cc
@@ -1,20 +1,13 @@
 #include "CondFormats/ESObjects/interface/ESWeightSet.h"
-ESWeightSet::ESWeightSet() {
+ESWeightSet::ESWeightSet() {}
 
-}
+ESWeightSet::ESWeightSet(const ESWeightSet& rhs) { wgtBeforeSwitch_ = rhs.wgtBeforeSwitch_; }
 
-ESWeightSet::ESWeightSet(const ESWeightSet& rhs) {
-  wgtBeforeSwitch_ = rhs.wgtBeforeSwitch_;
-}
-
-ESWeightSet::ESWeightSet(ESWeightMatrix& rhs) {
-  wgtBeforeSwitch_ = rhs ;
-}
+ESWeightSet::ESWeightSet(ESWeightMatrix& rhs) { wgtBeforeSwitch_ = rhs; }
 
 ESWeightSet& ESWeightSet::operator=(const ESWeightSet& rhs) {
   wgtBeforeSwitch_ = rhs.wgtBeforeSwitch_;
   return *this;
 }
 
-ESWeightSet::~ESWeightSet() {
-}
+ESWeightSet::~ESWeightSet() {}

--- a/CondFormats/ESObjects/src/T_EventSetup_ESCondObjectContainer_Float.cc
+++ b/CondFormats/ESObjects/src/T_EventSetup_ESCondObjectContainer_Float.cc
@@ -3,4 +3,3 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(ESFloatCondObjectContainer);
-

--- a/CondFormats/ESObjects/src/T_EventSetup_ESPedestals.cc
+++ b/CondFormats/ESObjects/src/T_EventSetup_ESPedestals.cc
@@ -2,7 +2,7 @@
 //
 // Package:     EDMProto
 // Class  :     T_Context_Pedestals
-// 
+//
 // Implementation:
 //     create all the 'infrastructure' needed to get into the Context
 //

--- a/CondFormats/ESObjects/src/classes.h
+++ b/CondFormats/ESObjects/src/classes.h
@@ -12,7 +12,7 @@
 #include "CondFormats/ESObjects/interface/ESAngleCorrectionFactors.h"
 #include "CondFormats/ESObjects/interface/ESEEIntercalibConstants.h"
 #include "CondFormats/ESObjects/interface/ESMissingEnergyCalibration.h"
-#include "CondFormats/ESObjects/interface/ESChannelStatus.h" 
+#include "CondFormats/ESObjects/interface/ESChannelStatus.h"
 #include "CondFormats/ESObjects/interface/ESChannelStatusCode.h"
 #include "CondFormats/ESObjects/interface/ESThresholds.h"
 #include "CondFormats/ESObjects/interface/ESGain.h"
@@ -21,27 +21,26 @@
 
 namespace CondFormats_ESObjects {
   struct dictionary {
-
     ESCondObjectContainer<ESPedestal> ESPedestalsMap;
     ESPedestalsMap::const_iterator ESPedestalsMapIterator;
 
     ESPedestals pedmap;
 
     ESWeightStripGroups gg;
- 
+
     ESTBWeights tbwgt;
     ESWeightSet wset;
-    std::map<  ESStripGroupId,  ESWeightSet > wgmap;
-    std::pair< ESStripGroupId,  ESWeightSet > wgmapvalue;
- 
+    std::map<ESStripGroupId, ESWeightSet> wgmap;
+    std::pair<ESStripGroupId, ESWeightSet> wgmapvalue;
+
     ESADCToGeVConstant adcfactor;
 
     ESMIPToGeVConstant mipfactor;
- 
+
     ESIntercalibConstants intercalib;
 
     ESAngleCorrectionFactors anglecorrection;
- 
+
     ESEEIntercalibConstants eseeintercalib;
 
     ESMissingEnergyCalibration esmissingecalib;
@@ -50,10 +49,10 @@ namespace CondFormats_ESObjects {
 
     ESChannelStatus channelStatus;
 
-    ESThresholds threshold; 
+    ESThresholds threshold;
 
     ESGain gain;
 
     ESTimeSampleWeights tsweights;
   };
-}
+}  // namespace CondFormats_ESObjects

--- a/CondFormats/ESObjects/src/headers.h
+++ b/CondFormats/ESObjects/src/headers.h
@@ -3,4 +3,3 @@
 
 #include "CondFormats/External/interface/EcalDetID.h"
 #include "CondFormats/External/interface/SMatrix.h"
-

--- a/CondFormats/ESObjects/test/testSerializationESObjects.cpp
+++ b/CondFormats/ESObjects/test/testSerializationESObjects.cpp
@@ -2,35 +2,34 @@
 
 #include "CondFormats/ESObjects/src/headers.h"
 
-int main()
-{
-    testSerialization<ESADCToGeVConstant>();
-    testSerialization<ESAngleCorrectionFactors>();
-    testSerialization<ESChannelStatus>();
-    testSerialization<ESChannelStatusCode>();
-    testSerialization<ESEEIntercalibConstants>();
-    testSerialization<ESGain>();
-    testSerialization<ESIntercalibConstants>();
-    testSerialization<ESMIPToGeVConstant>();
-    testSerialization<ESMissingEnergyCalibration>();
-    testSerialization<ESPedestal>();
-    testSerialization<ESPedestals>();
-    testSerialization<ESRecHitRatioCuts>();
-    testSerialization<ESStripGroupId>();
-    testSerialization<ESTBWeights>();
-    testSerialization<ESThresholds>();
-    testSerialization<ESTimeSampleWeights>();
-    testSerialization<ESWeightSet>();
-    testSerialization<ESWeightStripGroups>();
-    testSerialization<EcalContainer<ESDetId,ESChannelStatusCode>>();
-    testSerialization<EcalContainer<ESDetId,ESPedestal>>();
-    testSerialization<EcalContainer<ESDetId,ESStripGroupId>>();
-    testSerialization<EcalContainer<ESDetId,float>>();
-    testSerialization<std::map<ESStripGroupId ,ESWeightSet>>();
-    testSerialization<std::pair<ESStripGroupId, ESWeightSet>>();
-    testSerialization<std::vector<ESChannelStatusCode>>();
-    testSerialization<std::vector<ESPedestal>>();
-    testSerialization<std::vector<ESStripGroupId>>();
+int main() {
+  testSerialization<ESADCToGeVConstant>();
+  testSerialization<ESAngleCorrectionFactors>();
+  testSerialization<ESChannelStatus>();
+  testSerialization<ESChannelStatusCode>();
+  testSerialization<ESEEIntercalibConstants>();
+  testSerialization<ESGain>();
+  testSerialization<ESIntercalibConstants>();
+  testSerialization<ESMIPToGeVConstant>();
+  testSerialization<ESMissingEnergyCalibration>();
+  testSerialization<ESPedestal>();
+  testSerialization<ESPedestals>();
+  testSerialization<ESRecHitRatioCuts>();
+  testSerialization<ESStripGroupId>();
+  testSerialization<ESTBWeights>();
+  testSerialization<ESThresholds>();
+  testSerialization<ESTimeSampleWeights>();
+  testSerialization<ESWeightSet>();
+  testSerialization<ESWeightStripGroups>();
+  testSerialization<EcalContainer<ESDetId, ESChannelStatusCode>>();
+  testSerialization<EcalContainer<ESDetId, ESPedestal>>();
+  testSerialization<EcalContainer<ESDetId, ESStripGroupId>>();
+  testSerialization<EcalContainer<ESDetId, float>>();
+  testSerialization<std::map<ESStripGroupId, ESWeightSet>>();
+  testSerialization<std::pair<ESStripGroupId, ESWeightSet>>();
+  testSerialization<std::vector<ESChannelStatusCode>>();
+  testSerialization<std::vector<ESPedestal>>();
+  testSerialization<std::vector<ESStripGroupId>>();
 
-    return 0;
+  return 0;
 }

--- a/CondFormats/EcalCorrections/interface/EcalGlobalShowerContainmentCorrectionsVsEta.h
+++ b/CondFormats/EcalCorrections/interface/EcalGlobalShowerContainmentCorrectionsVsEta.h
@@ -4,7 +4,7 @@
 //
 // Package:     CondFormats
 // Class  :     EcalGlobalShowerContainmentCorrectionsVsEta
-// 
+//
 /**\class EcalGlobalShowerContainmentCorrectionsVsEta EcalGlobalShowerContainmentCorrectionsVsEta.h src/CondFormats/interface/EcalGlobalShowerContainmentCorrectionsVsEta.h
 
  * Description: Holds the coefficients of a polynomial that describes variation of the global containment effect as afunction of eta
@@ -35,42 +35,37 @@
 class DetId;
 
 class EcalGlobalShowerContainmentCorrectionsVsEta {
-
- public:
-  
+public:
   /// Structure defining the container for correction coefficients
   /**  data[0-2]    : 3x3
    *   data[3-5]    : 5x5
    */
 
-  struct Coefficients{
-
-    Coefficients(){for(unsigned int i=0; i<Coefficients::kSize; ++i) data[i]=0;}
-    Coefficients(const Coefficients& coeff){
-      std::copy(coeff.data,
-		coeff.data+Coefficients::kSize,
-		data);
+  struct Coefficients {
+    Coefficients() {
+      for (unsigned int i = 0; i < Coefficients::kSize; ++i)
+        data[i] = 0;
     }
- 
-    Coefficients& operator=(const Coefficients& coeff){
-      if (this == &coeff) return *this; 
-      std::copy(coeff.data,coeff.data+Coefficients::kSize,data);
+    Coefficients(const Coefficients& coeff) { std::copy(coeff.data, coeff.data + Coefficients::kSize, data); }
+
+    Coefficients& operator=(const Coefficients& coeff) {
+      if (this == &coeff)
+        return *this;
+      std::copy(coeff.data, coeff.data + Coefficients::kSize, data);
       return *this;
     }
-    
+
     ///The degree of the polynomial used as correction function plus one
     static const int kCoefficients = 3;
-    
+
     ///Number of types of correction:  3x3, 5x5
-    static const int kNTypes           = 2; 
-    static const unsigned int kSize    = kCoefficients * kNTypes  ;
+    static const int kNTypes = 2;
+    static const unsigned int kSize = kCoefficients * kNTypes;
 
     double data[kSize];
 
-  
- COND_SERIALIZABLE;
-};
-
+    COND_SERIALIZABLE;
+  };
 
   /// The correction factor for 3x3 matrix
   /** @param pos is the distance in cm from the center of the xtal
@@ -80,8 +75,7 @@ class EcalGlobalShowerContainmentCorrectionsVsEta {
    *  Returns -1 if correction is not avaiable for that xtal*/
   const double correction3x3(const DetId& xtal) const;
 
-
- /// The correction factor for 5x5 matrix
+  /// The correction factor for 5x5 matrix
   /** @param pos is the distance in cm from the center of the xtal
    *  as calculated in RecoEcal/EgammaCoreTools/interface/PositionCalc.h 
    *  The return value is in the range (0,1] (divide by this
@@ -92,22 +86,19 @@ class EcalGlobalShowerContainmentCorrectionsVsEta {
   /// Get the correction coefficients for the given xtal
   const Coefficients correctionCoefficients() const;
 
-  /// Fill the correction coefficients 
-  void fillCorrectionCoefficients(const Coefficients&  coefficients);
-  
+  /// Fill the correction coefficients
+  void fillCorrectionCoefficients(const Coefficients& coefficients);
 
- private:
-  enum  Type{e3x3,e5x5};
-  
+private:
+  enum Type { e3x3, e5x5 };
+
   /** Calculate the correction for the given direction and type  */
-  const double correction(const DetId& xtal, 
-			  Type type) const ;
-  
-  /// Holds the coeffiecients. The index corresponds to the group
-  Coefficients coefficients_;  
-  
+  const double correction(const DetId& xtal, Type type) const;
 
- COND_SERIALIZABLE;
+  /// Holds the coeffiecients. The index corresponds to the group
+  Coefficients coefficients_;
+
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/EcalCorrections/interface/EcalShowerContainmentCorrections.h
+++ b/CondFormats/EcalCorrections/interface/EcalShowerContainmentCorrections.h
@@ -4,7 +4,7 @@
 //
 // Package:     CondFormats
 // Class  :     EcalShowerContainmentCorrections
-// 
+//
 /**\class EcalShowerContainmentCorrections EcalShowerContainmentCorrections.h src/CondFormats/interface/EcalShowerContainmentCorrections.h
 
  * Description: Holds the coefficients of a polynomial that describes
@@ -44,9 +44,7 @@
 class EBDetId;
 
 class EcalShowerContainmentCorrections {
-
- public:
-
+public:
   /// Structure defining the container for correction coefficients
   /**  data[0-3]    : 3x3, x, right
    *   data[4-7]    : 3x3, x, left
@@ -58,18 +56,17 @@ class EcalShowerContainmentCorrections {
    *   data[28-31]  : 5x5, y, left
    */
 
-  struct Coefficients{
-
-    Coefficients(){for(unsigned int i=0; i<Coefficients::kSize; ++i) data[i]=0;}
-    Coefficients(const Coefficients& coeff){
-      std::copy(coeff.data,
-		coeff.data+Coefficients::kSize,
-		data);
+  struct Coefficients {
+    Coefficients() {
+      for (unsigned int i = 0; i < Coefficients::kSize; ++i)
+        data[i] = 0;
     }
- 
-    Coefficients& operator=(const Coefficients& coeff){
-      if (this == &coeff) return *this; 
-      std::copy(coeff.data,coeff.data+Coefficients::kSize,data);
+    Coefficients(const Coefficients& coeff) { std::copy(coeff.data, coeff.data + Coefficients::kSize, data); }
+
+    Coefficients& operator=(const Coefficients& coeff) {
+      if (this == &coeff)
+        return *this;
+      std::copy(coeff.data, coeff.data + Coefficients::kSize, data);
       return *this;
     }
 
@@ -77,15 +74,13 @@ class EcalShowerContainmentCorrections {
     static const int kPolynomialDegree = 4;
 
     ///Number of types of correction:  Left, right, 3x3, 5x5, x, y
-    static const int kNTypes           = 8; 
-    static const unsigned int kSize    = kPolynomialDegree* kNTypes  ;
+    static const int kNTypes = 8;
+    static const unsigned int kSize = kPolynomialDegree * kNTypes;
 
     double data[kSize];
 
-  
- COND_SERIALIZABLE;
-};
-
+    COND_SERIALIZABLE;
+  };
 
   /// Get the correction coefficients for the given xtal
   /** Return zero coefficients in case the correction is not available
@@ -94,16 +89,12 @@ class EcalShowerContainmentCorrections {
 
   /// Fill the correction coefficients for a given xtal, part of group @group
   /** Do not replace if xtal is already there*/
-  void fillCorrectionCoefficients(const EBDetId& xtal, 
-                                  int   group, 
-				  const Coefficients&  coefficients);
+  void fillCorrectionCoefficients(const EBDetId& xtal, int group, const Coefficients& coefficients);
 
   /// Fill the correction coefficients for a given Ecal module
   /** Assume that corresponding  modules in different supermodules use
       the same coefficients*/
-  void fillCorrectionCoefficients(const int supermodule, const int module, 
-				  const Coefficients&  coefficients);
-
+  void fillCorrectionCoefficients(const int supermodule, const int module, const Coefficients& coefficients);
 
   /// The correction factor for 3x3 matrix
   /** @param pos is the distance in cm from the center of the xtal
@@ -111,43 +102,32 @@ class EcalShowerContainmentCorrections {
    *  The valid return value is in the range (0,1] (divide by this
    *  value to apply the correction)
    *  Returns -1 if correction is not avaiable for that xtal*/
-  const double correction3x3(const EBDetId& xtal, 
-			     const  math::XYZPoint& pos) const;
+  const double correction3x3(const EBDetId& xtal, const math::XYZPoint& pos) const;
 
-
- /// The correction factor for 5x5 matrix
+  /// The correction factor for 5x5 matrix
   /** @param pos is the distance in cm from the center of the xtal
    *  as calculated in RecoEcal/EgammaCoreTools/interface/PositionCalc.h 
    *  The return value is in the range (0,1] (divide by this
    *  value to apply the correction)
    *  Returns -1 if correction is not avaiable for that xtal*/
-  const double correction5x5(const EBDetId& xtal, 
-			     const  math::XYZPoint& pos) const;
+  const double correction5x5(const EBDetId& xtal, const math::XYZPoint& pos) const;
 
-
-
- private:
-  enum  Direction{eX,eY};
-  enum  Type{e3x3,e5x5};
+private:
+  enum Direction { eX, eY };
+  enum Type { e3x3, e5x5 };
 
   /** Calculate the correction for the given direction and type  */
-  const double correctionXY(const EBDetId& xtal, 
-			    double position, 
-			    Direction dir,
-			    Type type) const ;
+  const double correctionXY(const EBDetId& xtal, double position, Direction dir, Type type) const;
 
-
-  typedef std::map<EBDetId,int> GroupMap;
+  typedef std::map<EBDetId, int> GroupMap;
 
   /// Maps in which group a particular xtal has been placed
-  GroupMap     groupmap_;
-
+  GroupMap groupmap_;
 
   /// Holds the coeffiecients. The index corresponds to the group
-  std::vector<Coefficients> coefficients_;  
+  std::vector<Coefficients> coefficients_;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/EcalCorrections/src/EcalGlobalShowerContainmentCorrectionsVsEta.cc
+++ b/CondFormats/EcalCorrections/src/EcalGlobalShowerContainmentCorrectionsVsEta.cc
@@ -8,60 +8,44 @@
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 //#include <iostream>
 
-
 const EcalGlobalShowerContainmentCorrectionsVsEta::Coefficients
 EcalGlobalShowerContainmentCorrectionsVsEta::correctionCoefficients() const {
   return coefficients_;
 }
 
-
-void 
-EcalGlobalShowerContainmentCorrectionsVsEta::fillCorrectionCoefficients(const Coefficients&  coefficients)
-{
-  coefficients_=coefficients;
+void EcalGlobalShowerContainmentCorrectionsVsEta::fillCorrectionCoefficients(const Coefficients& coefficients) {
+  coefficients_ = coefficients;
 }
 
 /** Calculate the correction for the given direction and type  */
-const double 
-EcalGlobalShowerContainmentCorrectionsVsEta::correction(const DetId& xtal, 
-							EcalGlobalShowerContainmentCorrectionsVsEta::Type type
-							  ) const
-{
-  if (xtal.det() == DetId::Ecal && xtal.subdetId() == EcalBarrel )
-    {
-      int offset=0;
-      
-      if (type==e5x5) offset+= Coefficients::kCoefficients;
-      
-      double corr=0;
-      
-      if (EBDetId(xtal).ieta() < coefficients_.data[0])
-	corr=coefficients_.data[1];
-      else
-	corr=coefficients_.data[1] + coefficients_.data[2] * pow ( EBDetId(xtal).ieta() - coefficients_.data[0] , 2);
-      
-      return corr;
-    }
-  else if (xtal.det() == DetId::Ecal && xtal.subdetId() == EcalEndcap )
+const double EcalGlobalShowerContainmentCorrectionsVsEta::correction(
+    const DetId& xtal, EcalGlobalShowerContainmentCorrectionsVsEta::Type type) const {
+  if (xtal.det() == DetId::Ecal && xtal.subdetId() == EcalBarrel) {
+    int offset = 0;
+
+    if (type == e5x5)
+      offset += Coefficients::kCoefficients;
+
+    double corr = 0;
+
+    if (EBDetId(xtal).ieta() < coefficients_.data[0])
+      corr = coefficients_.data[1];
+    else
+      corr = coefficients_.data[1] + coefficients_.data[2] * pow(EBDetId(xtal).ieta() - coefficients_.data[0], 2);
+
+    return corr;
+  } else if (xtal.det() == DetId::Ecal && xtal.subdetId() == EcalEndcap)
     return 1.;
   else
     return -1;
 }
 
-const double 
-EcalGlobalShowerContainmentCorrectionsVsEta::correction3x3(const DetId& xtal) const 
-{
-  double corr = correction(xtal,e3x3);
+const double EcalGlobalShowerContainmentCorrectionsVsEta::correction3x3(const DetId& xtal) const {
+  double corr = correction(xtal, e3x3);
   return corr;
 }
 
-
-
-
-const double 
-EcalGlobalShowerContainmentCorrectionsVsEta::correction5x5(const DetId& xtal) const 
-{ 
-  double corr = correction(xtal,e5x5);
+const double EcalGlobalShowerContainmentCorrectionsVsEta::correction5x5(const DetId& xtal) const {
+  double corr = correction(xtal, e5x5);
   return corr;
 }
-

--- a/CondFormats/EcalCorrections/src/EcalShowerContainmentCorrections.cc
+++ b/CondFormats/EcalCorrections/src/EcalShowerContainmentCorrections.cc
@@ -10,120 +10,99 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 #include "CondFormats/External/interface/EcalDetID.h"
 
-const EcalShowerContainmentCorrections::Coefficients
-EcalShowerContainmentCorrections::correctionCoefficients(const EBDetId& centerxtal) const 
-{
+const EcalShowerContainmentCorrections::Coefficients EcalShowerContainmentCorrections::correctionCoefficients(
+    const EBDetId& centerxtal) const {
   GroupMap::const_iterator iter = groupmap_.find(centerxtal.rawId());
 
-  if (iter!=groupmap_.end()) {
-    int group =iter->second;
-    return coefficients_[group-1];
+  if (iter != groupmap_.end()) {
+    int group = iter->second;
+    return coefficients_[group - 1];
   }
 
   edm::LogError("ShowerContaiment Correction not found");
   return Coefficients();
-
 }
 
-
-void 
-EcalShowerContainmentCorrections::fillCorrectionCoefficients(const EBDetId& xtal, int group,const Coefficients&  coefficients){
-
+void EcalShowerContainmentCorrections::fillCorrectionCoefficients(const EBDetId& xtal,
+                                                                  int group,
+                                                                  const Coefficients& coefficients) {
   // do not replace if we already have the xtal
-  if (groupmap_.find(xtal)!=groupmap_.end()) return;
-  groupmap_[xtal]=group;
+  if (groupmap_.find(xtal) != groupmap_.end())
+    return;
+  groupmap_[xtal] = group;
 
-
-  if (coefficients_.size()<(unsigned int)(group)) {
+  if (coefficients_.size() < (unsigned int)(group)) {
     coefficients_.resize(group);
-    coefficients_[group-1]=coefficients;
+    coefficients_[group - 1] = coefficients;
   }
 
   // we don't need to fill coefficients if the group has already been inserted
-
-
 }
 
-
-void 
-EcalShowerContainmentCorrections::fillCorrectionCoefficients(const int supermodule, const int module, 
-					    const Coefficients&  coefficients){
-
-
-  if (module>EBDetId::kModulesPerSM) {
+void EcalShowerContainmentCorrections::fillCorrectionCoefficients(const int supermodule,
+                                                                  const int module,
+                                                                  const Coefficients& coefficients) {
+  if (module > EBDetId::kModulesPerSM) {
     edm::LogError("Invalid Module Number");
     return;
   }
 
-
   // what is EBDetID::kModuleBoundaries ? we better redefine them here ...
-  const int kModuleLow[]={1,501,901,1301};
-  const int kModuleHigh[]={500,900,1300,1700};
+  const int kModuleLow[] = {1, 501, 901, 1301};
+  const int kModuleHigh[] = {500, 900, 1300, 1700};
 
-  for (int xtal =kModuleLow[module-1] ; xtal <= kModuleHigh[module-1];++xtal){
-    EBDetId detid(supermodule,xtal,EBDetId::SMCRYSTALMODE);
-    fillCorrectionCoefficients(detid,module,coefficients);
+  for (int xtal = kModuleLow[module - 1]; xtal <= kModuleHigh[module - 1]; ++xtal) {
+    EBDetId detid(supermodule, xtal, EBDetId::SMCRYSTALMODE);
+    fillCorrectionCoefficients(detid, module, coefficients);
   }
-  
 }
 
 /** Calculate the correction for the given direction and type  */
-const double 
-EcalShowerContainmentCorrections::correctionXY(const EBDetId& xtal, 
-				double position,  
-			        EcalShowerContainmentCorrections::Direction dir,
-				EcalShowerContainmentCorrections::Type type
-                                ) const{
-  
-  GroupMap::const_iterator iter=groupmap_.find(xtal);
-  if (iter==groupmap_.end()) return -1;
+const double EcalShowerContainmentCorrections::correctionXY(const EBDetId& xtal,
+                                                            double position,
+                                                            EcalShowerContainmentCorrections::Direction dir,
+                                                            EcalShowerContainmentCorrections::Type type) const {
+  GroupMap::const_iterator iter = groupmap_.find(xtal);
+  if (iter == groupmap_.end())
+    return -1;
 
-  int group=iter->second;
-  EcalShowerContainmentCorrections::Coefficients coeff=coefficients_[group-1];
+  int group = iter->second;
+  EcalShowerContainmentCorrections::Coefficients coeff = coefficients_[group - 1];
 
-  int offset=0;
-  
-  if (dir==eY)    offset+=  2* Coefficients::kPolynomialDegree;
-  if (position<0) offset+=     Coefficients::kPolynomialDegree;
-  if (type==e5x5) offset+=  4* Coefficients::kPolynomialDegree;
+  int offset = 0;
 
-  double corr=0;
+  if (dir == eY)
+    offset += 2 * Coefficients::kPolynomialDegree;
+  if (position < 0)
+    offset += Coefficients::kPolynomialDegree;
+  if (type == e5x5)
+    offset += 4 * Coefficients::kPolynomialDegree;
 
-  for (  int i=offset; 
-	 i<offset+Coefficients::kPolynomialDegree; 
-	 ++i){  
-    corr+= coeff.data[i] * pow( position ,i-offset) ;    
+  double corr = 0;
+
+  for (int i = offset; i < offset + Coefficients::kPolynomialDegree; ++i) {
+    corr += coeff.data[i] * pow(position, i - offset);
   }
 
-  return corr;  
+  return corr;
 }
 
-const double 
-EcalShowerContainmentCorrections::correction3x3(const EBDetId& xtal, 
-					     const  math::XYZPoint& pos) const {
-    
-  double x= pos.X()*10; // correction functions use mm
-  double y= pos.Y()*10;
+const double EcalShowerContainmentCorrections::correction3x3(const EBDetId& xtal, const math::XYZPoint& pos) const {
+  double x = pos.X() * 10;  // correction functions use mm
+  double y = pos.Y() * 10;
 
-  double corrx = correctionXY(xtal,x,eX,e3x3);
-  double corry = correctionXY(xtal,y,eY,e3x3);
-  
-  return corrx*corry;
+  double corrx = correctionXY(xtal, x, eX, e3x3);
+  double corry = correctionXY(xtal, y, eY, e3x3);
+
+  return corrx * corry;
 }
 
+const double EcalShowerContainmentCorrections::correction5x5(const EBDetId& xtal, const math::XYZPoint& pos) const {
+  double x = pos.X() * 10;  // correction functions use mm
+  double y = pos.Y() * 10;
 
+  double corrx = correctionXY(xtal, x, eX, e5x5);
+  double corry = correctionXY(xtal, y, eY, e5x5);
 
-
-const double 
-EcalShowerContainmentCorrections::correction5x5(const EBDetId& xtal, 
-					     const  math::XYZPoint& pos) const {
-    
-  double x= pos.X()*10; // correction functions use mm
-  double y= pos.Y()*10;
-
-  double corrx = correctionXY(xtal,x,eX,e5x5);
-  double corry = correctionXY(xtal,y,eY,e5x5);
-  
-  return corrx*corry;
+  return corrx * corry;
 }
-

--- a/CondFormats/EcalCorrections/src/classes.h
+++ b/CondFormats/EcalCorrections/src/classes.h
@@ -1,4 +1,3 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "CondFormats/EcalCorrections/interface/EcalShowerContainmentCorrections.h"
 #include "CondFormats/EcalCorrections/interface/EcalGlobalShowerContainmentCorrectionsVsEta.h"
-

--- a/CondFormats/EcalCorrections/test/testEcalShowerContaimentCorrections.cc
+++ b/CondFormats/EcalCorrections/test/testEcalShowerContaimentCorrections.cc
@@ -11,90 +11,67 @@
 #include "CondFormats/EcalCorrections/interface/EcalShowerContainmentCorrections.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 class testEcalShowerContainmentCorrections : public CppUnit::TestFixture {
-
   CPPUNIT_TEST_SUITE(testEcalShowerContainmentCorrections);
 
   CPPUNIT_TEST(testFillandReadBack1);
   CPPUNIT_TEST(testFillandReadBack2);
- 
+
   CPPUNIT_TEST_SUITE_END();
 
 public:
-
-
   void setUp();
-  void tearDown();  
+  void tearDown();
   void testFillandReadBack1();
-  void testFillandReadBack2(); 
- 
-  double * testdata_;
-}; 
+  void testFillandReadBack2();
+
+  double* testdata_;
+};
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testEcalShowerContainmentCorrections);
 
-void testEcalShowerContainmentCorrections::setUp(){
-
+void testEcalShowerContainmentCorrections::setUp() {
   testdata_ = new double[EcalShowerContainmentCorrections::Coefficients::kSize];
 
-  for (unsigned int i=0; i<EcalShowerContainmentCorrections::Coefficients::kSize;
-       ++i) testdata_[i]=i;
+  for (unsigned int i = 0; i < EcalShowerContainmentCorrections::Coefficients::kSize; ++i)
+    testdata_[i] = i;
 }
 
-void testEcalShowerContainmentCorrections::tearDown(){
-  delete[] testdata_;
-}
+void testEcalShowerContainmentCorrections::tearDown() { delete[] testdata_; }
 
-void testEcalShowerContainmentCorrections::testFillandReadBack1(){
-  
+void testEcalShowerContainmentCorrections::testFillandReadBack1() {
   EcalShowerContainmentCorrections::Coefficients coeff;
-  std::copy(testdata_, 
-	    testdata_+EcalShowerContainmentCorrections::Coefficients::kSize,
-	    coeff.data);
-  
+  std::copy(testdata_, testdata_ + EcalShowerContainmentCorrections::Coefficients::kSize, coeff.data);
+
   // fill a random xtal
-  EBDetId xtal(5,550,EBDetId::SMCRYSTALMODE);
+  EBDetId xtal(5, 550, EBDetId::SMCRYSTALMODE);
 
   EcalShowerContainmentCorrections correction;
-  
-  correction.fillCorrectionCoefficients(xtal,3,coeff);
 
+  correction.fillCorrectionCoefficients(xtal, 3, coeff);
 
-  
-  EcalShowerContainmentCorrections::Coefficients correction_readback=
-    correction.correctionCoefficients(xtal);
-  
-  for (unsigned int i=0; i<EcalShowerContainmentCorrections::Coefficients::kSize;
-       ++i) 
-    CPPUNIT_ASSERT(testdata_[i]==correction_readback.data[i]);  
+  EcalShowerContainmentCorrections::Coefficients correction_readback = correction.correctionCoefficients(xtal);
 
+  for (unsigned int i = 0; i < EcalShowerContainmentCorrections::Coefficients::kSize; ++i)
+    CPPUNIT_ASSERT(testdata_[i] == correction_readback.data[i]);
 }
 
-
-void testEcalShowerContainmentCorrections::testFillandReadBack2(){
-  
+void testEcalShowerContainmentCorrections::testFillandReadBack2() {
   EcalShowerContainmentCorrections::Coefficients coeff;
-  std::copy(testdata_, 
-	    testdata_+EcalShowerContainmentCorrections::Coefficients::kSize,
-	    coeff.data);
-  
- 
+  std::copy(testdata_, testdata_ + EcalShowerContainmentCorrections::Coefficients::kSize, coeff.data);
+
   EcalShowerContainmentCorrections correction;
 
   // use filling by module
-  correction.fillCorrectionCoefficients(3,2,coeff);
+  correction.fillCorrectionCoefficients(3, 2, coeff);
 
   // this is a xtal in SM3 , module 2
   EBDetId xtal(3, 550, EBDetId::SMCRYSTALMODE);
 
-  EcalShowerContainmentCorrections::Coefficients correction_readback=
-    correction.correctionCoefficients(xtal);
-  
-  for (unsigned int i=0; i<EcalShowerContainmentCorrections::Coefficients::kSize;
-       ++i) 
-    CPPUNIT_ASSERT(testdata_[i]==correction_readback.data[i]);  
+  EcalShowerContainmentCorrections::Coefficients correction_readback = correction.correctionCoefficients(xtal);
 
+  for (unsigned int i = 0; i < EcalShowerContainmentCorrections::Coefficients::kSize; ++i)
+    CPPUNIT_ASSERT(testdata_[i] == correction_readback.data[i]);
 }
-
 
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>

--- a/CondFormats/EcalCorrections/test/testSerializationEcalCorrections.cpp
+++ b/CondFormats/EcalCorrections/test/testSerializationEcalCorrections.cpp
@@ -2,12 +2,11 @@
 
 #include "CondFormats/EcalCorrections/src/headers.h"
 
-int main()
-{
-    testSerialization<EcalGlobalShowerContainmentCorrectionsVsEta>();
-    testSerialization<EcalGlobalShowerContainmentCorrectionsVsEta::Coefficients>();
-    testSerialization<EcalShowerContainmentCorrections>();
-    testSerialization<EcalShowerContainmentCorrections::Coefficients>();
+int main() {
+  testSerialization<EcalGlobalShowerContainmentCorrectionsVsEta>();
+  testSerialization<EcalGlobalShowerContainmentCorrectionsVsEta::Coefficients>();
+  testSerialization<EcalShowerContainmentCorrections>();
+  testSerialization<EcalShowerContainmentCorrections::Coefficients>();
 
-    return 0;
+  return 0;
 }

--- a/CondFormats/HIObjects/interface/CentralityTable.h
+++ b/CondFormats/HIObjects/interface/CentralityTable.h
@@ -5,15 +5,13 @@
 
 #include <vector>
 class CentralityTable {
-  
-  public:
-
-  struct BinValues{
+public:
+  struct BinValues {
     float mean;
     float var;
-  
-  COND_SERIALIZABLE;
-};
+
+    COND_SERIALIZABLE;
+  };
 
   struct CBin {
     float bin_edge;
@@ -33,15 +31,14 @@ class CentralityTable {
     BinValues var0;
     BinValues var1;
     BinValues var2;
-  
-  COND_SERIALIZABLE;
-};
-    
-  CentralityTable(){}
+
+    COND_SERIALIZABLE;
+  };
+
+  CentralityTable() {}
   std::vector<CBin> m_table;
 
   COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/HIObjects/interface/RPFlatParams.h
+++ b/CondFormats/HIObjects/interface/RPFlatParams.h
@@ -4,8 +4,8 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <vector>
-class RPFlatParams{
- public:
+class RPFlatParams {
+public:
   struct EP {
     float x[50];
     float y[50];
@@ -14,15 +14,14 @@ class RPFlatParams{
     float xSub2[50];
     float ySub2[50];
     int RPNameIndx[50];
-  
-  COND_SERIALIZABLE;
-};
-  RPFlatParams(){}
-  virtual ~RPFlatParams(){}
+
+    COND_SERIALIZABLE;
+  };
+  RPFlatParams() {}
+  virtual ~RPFlatParams() {}
   std::vector<EP> m_table;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/HIObjects/interface/UETable.h
+++ b/CondFormats/HIObjects/interface/UETable.h
@@ -4,23 +4,22 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 #include <vector>
 
-class UETable{
- public:
+class UETable {
+public:
   UETable(){};
-  float getUE(int i){return values[i];}
-  unsigned int getNp(int i){return np[i];}
-  unsigned int getNi0(int i){return ni0[i];}
-  unsigned int getNi1(int i){return ni1[i];}
-  unsigned int getNi2(int i){return ni2[i];}
-  float getEtaEdge(int i){return edgeEta[i];}
+  float getUE(int i) { return values[i]; }
+  unsigned int getNp(int i) { return np[i]; }
+  unsigned int getNi0(int i) { return ni0[i]; }
+  unsigned int getNi1(int i) { return ni1[i]; }
+  unsigned int getNi2(int i) { return ni2[i]; }
+  float getEtaEdge(int i) { return edgeEta[i]; }
 
-
-  void pushUE(float v){values.push_back(v);}
-  void pushNp(unsigned int v){np.push_back(v);}
-  void pushNi0(unsigned int v){ni0.push_back(v);}
-  void pushNi1(unsigned int v){ni1.push_back(v);}
-  void pushNi2(unsigned int v){ni2.push_back(v);}
-  void pushEtaEdge(float v){edgeEta.push_back(v);}
+  void pushUE(float v) { values.push_back(v); }
+  void pushNp(unsigned int v) { np.push_back(v); }
+  void pushNi0(unsigned int v) { ni0.push_back(v); }
+  void pushNi1(unsigned int v) { ni1.push_back(v); }
+  void pushNi2(unsigned int v) { ni2.push_back(v); }
+  void pushEtaEdge(float v) { edgeEta.push_back(v); }
 
   std::vector<float> values;
   std::vector<unsigned int> np;

--- a/CondFormats/HIObjects/src/T_EventSetup_CentralityCuts.cc
+++ b/CondFormats/HIObjects/src/T_EventSetup_CentralityCuts.cc
@@ -1,4 +1,4 @@
-#include "CondFormats/HIObjects/interface/CentralityTable.h" 
+#include "CondFormats/HIObjects/interface/CentralityTable.h"
 #include "CondFormats/HIObjects/interface/RPFlatParams.h"
 #include "CondFormats/HIObjects/interface/UETable.h"
 
@@ -7,5 +7,3 @@
 TYPELOOKUP_DATA_REG(CentralityTable);
 TYPELOOKUP_DATA_REG(RPFlatParams);
 TYPELOOKUP_DATA_REG(UETable);
-
-

--- a/CondFormats/HIObjects/src/classes.h
+++ b/CondFormats/HIObjects/src/classes.h
@@ -1,10 +1,9 @@
 #include "CondFormats/HIObjects/src/headers.h"
 
 namespace CondFormats_HIObjects {
-  struct dictionary{
+  struct dictionary {
     std::vector<CentralityTable::CBin> dummy;
     std::vector<RPFlatParams::EP> yummy;
     UETable pred;
   };
-}
-
+}  // namespace CondFormats_HIObjects

--- a/CondFormats/HIObjects/test/testSerializationHIObjects.cpp
+++ b/CondFormats/HIObjects/test/testSerializationHIObjects.cpp
@@ -2,15 +2,14 @@
 
 #include "CondFormats/HIObjects/src/headers.h"
 
-int main()
-{
-    testSerialization<CentralityTable>();
-    testSerialization<CentralityTable::BinValues>();
-    testSerialization<CentralityTable::CBin>();
-    testSerialization<RPFlatParams>();
-    testSerialization<RPFlatParams::EP>();
-    testSerialization<std::vector<CentralityTable::CBin>>();
-    testSerialization<std::vector<RPFlatParams::EP>>();
+int main() {
+  testSerialization<CentralityTable>();
+  testSerialization<CentralityTable::BinValues>();
+  testSerialization<CentralityTable::CBin>();
+  testSerialization<RPFlatParams>();
+  testSerialization<RPFlatParams::EP>();
+  testSerialization<std::vector<CentralityTable::CBin>>();
+  testSerialization<std::vector<RPFlatParams::EP>>();
 
-    return 0;
+  return 0;
 }

--- a/CondFormats/Luminosity/interface/LumiCorrections.h
+++ b/CondFormats/Luminosity/interface/LumiCorrections.h
@@ -13,7 +13,6 @@
  *  m_overallCorrection as well.  
  */
 
-
 #include <sstream>
 #include <cstring>
 #include <vector>
@@ -21,24 +20,25 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 class LumiCorrections {
-    public:
-        void  setOverallCorrection(float overallCorrection){m_overallCorrection=overallCorrection;}
-        void  setType1Fraction(float type1frac){m_type1Fraction=type1frac;}
-        void  setType1Residual(float type1res){m_type1Residual=type1res;}
-        void  setType2Residual(float type2res){m_type2Residual=type2res;}
-        void  setCorrectionsBX(std::vector<float>& correctBX){m_correctionsBX.assign(correctBX.begin(),correctBX.end());} 
-        float getOverallCorrection(){return m_overallCorrection;}
-        float getCorrectionAtBX(float bx){return m_correctionsBX[bx];}
-        float getType1Fraction(){return m_type1Fraction;}
-        float getType1Residual(){return m_type1Residual;}
-        float getType2Residual(){return m_type2Residual;}
-        const std::vector<float>& getCorrectionsBX() const{return m_correctionsBX;} 
-    private:
-        float m_overallCorrection;
-        float m_type1Fraction;
-        float m_type1Residual;
-        float m_type2Residual;
-        std::vector<float> m_correctionsBX;
-        COND_SERIALIZABLE; 
+public:
+  void setOverallCorrection(float overallCorrection) { m_overallCorrection = overallCorrection; }
+  void setType1Fraction(float type1frac) { m_type1Fraction = type1frac; }
+  void setType1Residual(float type1res) { m_type1Residual = type1res; }
+  void setType2Residual(float type2res) { m_type2Residual = type2res; }
+  void setCorrectionsBX(std::vector<float>& correctBX) { m_correctionsBX.assign(correctBX.begin(), correctBX.end()); }
+  float getOverallCorrection() { return m_overallCorrection; }
+  float getCorrectionAtBX(float bx) { return m_correctionsBX[bx]; }
+  float getType1Fraction() { return m_type1Fraction; }
+  float getType1Residual() { return m_type1Residual; }
+  float getType2Residual() { return m_type2Residual; }
+  const std::vector<float>& getCorrectionsBX() const { return m_correctionsBX; }
+
+private:
+  float m_overallCorrection;
+  float m_type1Fraction;
+  float m_type1Residual;
+  float m_type2Residual;
+  std::vector<float> m_correctionsBX;
+  COND_SERIALIZABLE;
 };
-#endif 
+#endif

--- a/CondFormats/Luminosity/interface/LumiSectionData.h
+++ b/CondFormats/Luminosity/interface/LumiSectionData.h
@@ -11,101 +11,101 @@
  * $Id: LumiSectionData.h,v 1.2 2009/10/07 14:33:02 xiezhen Exp $
  *
  ************************************************************/
- 
+
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <vector>
 #include <string>
 
-namespace lumi{
-  static const int BXMIN=1;
-  static const int BXMAX=3564;
-  static const int LUMIALGOMAX=3;
-  
-  typedef enum { ET=0,OCCD1=1,OCCD2=2 } LumiAlgoType;
-  typedef enum { ALGO=0,TECH=1 } TriggerType;
+namespace lumi {
+  static const int BXMIN = 1;
+  static const int BXMAX = 3564;
+  static const int LUMIALGOMAX = 3;
 
-  struct HLTInfo{
-    HLTInfo():pathname(""),inputcount(-99),acceptcount(-99),prescale(-99){}
-    HLTInfo(const std::string& pathnameIN, int i,int a,int p):
-      pathname(pathnameIN),inputcount(i),acceptcount(a),prescale(p){}
+  typedef enum { ET = 0, OCCD1 = 1, OCCD2 = 2 } LumiAlgoType;
+  typedef enum { ALGO = 0, TECH = 1 } TriggerType;
+
+  struct HLTInfo {
+    HLTInfo() : pathname(""), inputcount(-99), acceptcount(-99), prescale(-99) {}
+    HLTInfo(const std::string& pathnameIN, int i, int a, int p)
+        : pathname(pathnameIN), inputcount(i), acceptcount(a), prescale(p) {}
     std::string pathname;
     int inputcount;
     int acceptcount;
     int prescale;
-  
-  COND_SERIALIZABLE;
-};
 
-  struct TriggerInfo{
-    TriggerInfo():name(""),triggercount(-99),deadtimecount(-99),prescale(-99){}
-    TriggerInfo(const std::string& trgname,int trgcount,int deadcount,int p):name(trgname),triggercount(trgcount),deadtimecount(deadcount),prescale(p){}
+    COND_SERIALIZABLE;
+  };
+
+  struct TriggerInfo {
+    TriggerInfo() : name(""), triggercount(-99), deadtimecount(-99), prescale(-99) {}
+    TriggerInfo(const std::string& trgname, int trgcount, int deadcount, int p)
+        : name(trgname), triggercount(trgcount), deadtimecount(deadcount), prescale(p) {}
     std::string name;
     int triggercount;
-    int deadtimecount;//max 2**20*3564=3737124864, so wrong type
-    int prescale; 
-  
-  COND_SERIALIZABLE;
-};
+    int deadtimecount;  //max 2**20*3564=3737124864, so wrong type
+    int prescale;
+
+    COND_SERIALIZABLE;
+  };
 
   struct BunchCrossingInfo {
-    BunchCrossingInfo(){}
-    BunchCrossingInfo(int idx,float value,float err,int quality):
-      BXIdx(idx),lumivalue(value),lumierr(err),lumiquality(quality){}
-    int BXIdx;//starting from 1
-    float lumivalue; 
+    BunchCrossingInfo() {}
+    BunchCrossingInfo(int idx, float value, float err, int quality)
+        : BXIdx(idx), lumivalue(value), lumierr(err), lumiquality(quality) {}
+    int BXIdx;  //starting from 1
+    float lumivalue;
     float lumierr;
     int lumiquality;
-  
-  COND_SERIALIZABLE;
-};
 
-  static const BunchCrossingInfo BXNULL=BunchCrossingInfo(-99,-99.0,-99.0,-99);
+    COND_SERIALIZABLE;
+  };
+
+  static const BunchCrossingInfo BXNULL = BunchCrossingInfo(-99, -99.0, -99.0, -99);
   typedef std::vector<BunchCrossingInfo>::const_iterator BunchCrossingIterator;
-  typedef std::vector< HLTInfo >::const_iterator HLTIterator;  
-  typedef std::vector< TriggerInfo >::const_iterator TriggerIterator;
+  typedef std::vector<HLTInfo>::const_iterator HLTIterator;
+  typedef std::vector<TriggerInfo>::const_iterator TriggerIterator;
 
-  class LumiSectionData{
+  class LumiSectionData {
   public:
     LumiSectionData();
-    ~LumiSectionData(){}
+    ~LumiSectionData() {}
+
   public:
     ///
     ///getter methods
     ///
-    std::string lumiVersion()const;
-    int lumisectionID()const;
-    size_t nBunchCrossing()const;
-    //radom access to instant LumiAverage 
-    float lumiAverage()const;
-    float lumiError()const;
-    float deadFraction()const;
-    int lumiquality()const;
-    unsigned long long startorbit()const;
+    std::string lumiVersion() const;
+    int lumisectionID() const;
+    size_t nBunchCrossing() const;
+    //radom access to instant LumiAverage
+    float lumiAverage() const;
+    float lumiError() const;
+    float deadFraction() const;
+    int lumiquality() const;
+    unsigned long long startorbit() const;
     //get bunchCrossingInfo by algorithm
-    void bunchCrossingInfo(  const LumiAlgoType lumialgotype, 
-			     std::vector<BunchCrossingInfo>& result )const ;
+    void bunchCrossingInfo(const LumiAlgoType lumialgotype, std::vector<BunchCrossingInfo>& result) const;
     //random access to bunchCrossingInfo by bunchcrossing index
-    const BunchCrossingInfo bunchCrossingInfo( const int BXIndex,
-					 const LumiAlgoType lumialgotype )const;
+    const BunchCrossingInfo bunchCrossingInfo(const int BXIndex, const LumiAlgoType lumialgotype) const;
     //sequential access to bunchCrossingInfo
-    BunchCrossingIterator bunchCrossingBegin( const LumiAlgoType lumialgotype )const;
-    BunchCrossingIterator bunchCrossingEnd( const LumiAlgoType lumialgotype )const;
+    BunchCrossingIterator bunchCrossingBegin(const LumiAlgoType lumialgotype) const;
+    BunchCrossingIterator bunchCrossingEnd(const LumiAlgoType lumialgotype) const;
     //total number of HLT paths
-    size_t nHLTPath()const;
-    bool HLThasData()const;
-    HLTIterator hltBegin()const;
-    HLTIterator hltEnd()const;
+    size_t nHLTPath() const;
+    bool HLThasData() const;
+    HLTIterator hltBegin() const;
+    HLTIterator hltEnd() const;
 
-    bool TriggerhasData()const;
-    TriggerIterator trgBegin()const;
-    TriggerIterator trgEnd()const;
+    bool TriggerhasData() const;
+    TriggerIterator trgBegin() const;
+    TriggerIterator trgEnd() const;
 
-    short qualityFlag()const;
+    short qualityFlag() const;
     ///
-    ///setter methods. 
+    ///setter methods.
     ///
-    void setLumiNull(); //set versionid number to -99, signal no lumi data written.
+    void setLumiNull();  //set versionid number to -99, signal no lumi data written.
     void setLumiVersion(const std::string& versionid);
     void setLumiSectionId(int sectionid);
     void setLumiAverage(float lumiavg);
@@ -113,25 +113,25 @@ namespace lumi{
     void setDeadFraction(float deadfrac);
     void setLumiError(float lumierr);
     void setStartOrbit(unsigned long long orbtnumber);
-    void setBunchCrossingData(const std::vector<BunchCrossingInfo>& BXs,
-			      const LumiAlgoType algotype);
+    void setBunchCrossingData(const std::vector<BunchCrossingInfo>& BXs, const LumiAlgoType algotype);
     void setHLTData(const std::vector<HLTInfo>& hltdetail);
     void setTriggerData(const std::vector<TriggerInfo>& triggerinfo);
     void setQualityFlag(short qualityflag);
-    void print( std::ostream& s )const;
+    void print(std::ostream& s) const;
+
   private:
-    std::vector<BunchCrossingInfo> m_bx;//Lumi detail info sorted by algoright+BX number stored as blob
-    int m_sectionid; //LS id counting from 1 as required by evt. Instead from 0
-    std::string m_versionid; //Lumi version
-    float m_lumiavg; //instant lumi , selected from best algo
-    float m_lumierror; //instant lumi err, 
-    short m_quality; //use 7 bits PIXEL,STRIP,MUON,HCAL,ECAL,HF,HLX
-    float m_deadfrac; //deadtime fraction
-    unsigned long long m_startorbit; //first orbit number of this LS    
-    std::vector< HLTInfo > m_hlt; //hlt scaler information sorted by hltpath independent of lumiversion
-    std::vector< TriggerInfo > m_trigger; //trigger scaler sorted by bit number 128algo+64tech independent of lumiversion
-  
-  COND_SERIALIZABLE;
-}; 
-}//ns lumi
-#endif 
+    std::vector<BunchCrossingInfo> m_bx;  //Lumi detail info sorted by algoright+BX number stored as blob
+    int m_sectionid;                      //LS id counting from 1 as required by evt. Instead from 0
+    std::string m_versionid;              //Lumi version
+    float m_lumiavg;                      //instant lumi , selected from best algo
+    float m_lumierror;                    //instant lumi err,
+    short m_quality;                      //use 7 bits PIXEL,STRIP,MUON,HCAL,ECAL,HF,HLX
+    float m_deadfrac;                     //deadtime fraction
+    unsigned long long m_startorbit;      //first orbit number of this LS
+    std::vector<HLTInfo> m_hlt;           //hlt scaler information sorted by hltpath independent of lumiversion
+    std::vector<TriggerInfo> m_trigger;  //trigger scaler sorted by bit number 128algo+64tech independent of lumiversion
+
+    COND_SERIALIZABLE;
+  };
+}  // namespace lumi
+#endif

--- a/CondFormats/Luminosity/src/LumiSectionData.cc
+++ b/CondFormats/Luminosity/src/LumiSectionData.cc
@@ -1,155 +1,75 @@
 #include "CondFormats/Luminosity/interface/LumiSectionData.h"
 #include <iostream>
-lumi::LumiSectionData::LumiSectionData(): m_sectionid(0),m_versionid("-1"){
-  m_bx.reserve(lumi::BXMAX*LUMIALGOMAX);
+lumi::LumiSectionData::LumiSectionData() : m_sectionid(0), m_versionid("-1") {
+  m_bx.reserve(lumi::BXMAX * LUMIALGOMAX);
 }
-std::string
-lumi::LumiSectionData::lumiVersion()const{
-  return m_versionid; 
-}
-int
-lumi::LumiSectionData::lumisectionID()const{
-  return m_sectionid;
-}
-size_t
-lumi::LumiSectionData::nBunchCrossing()const{
-  return m_bx.size()/lumi::LUMIALGOMAX;
-}
-float
-lumi::LumiSectionData::lumiAverage()const{
-  return m_lumiavg;
-}
-float 
-lumi::LumiSectionData::lumiError()const{
-  return  m_lumierror;
-}
-float 
-lumi::LumiSectionData::deadFraction()const{
-  return m_deadfrac;
-}
-unsigned long long
-lumi::LumiSectionData::startorbit()const{
-  return m_startorbit;
-}
-int 
-lumi::LumiSectionData::lumiquality()const{
-  return m_quality;
-}
-void 
-lumi::LumiSectionData::bunchCrossingInfo(  const lumi::LumiAlgoType lumialgotype,std::vector<lumi::BunchCrossingInfo>& result )const {
+std::string lumi::LumiSectionData::lumiVersion() const { return m_versionid; }
+int lumi::LumiSectionData::lumisectionID() const { return m_sectionid; }
+size_t lumi::LumiSectionData::nBunchCrossing() const { return m_bx.size() / lumi::LUMIALGOMAX; }
+float lumi::LumiSectionData::lumiAverage() const { return m_lumiavg; }
+float lumi::LumiSectionData::lumiError() const { return m_lumierror; }
+float lumi::LumiSectionData::deadFraction() const { return m_deadfrac; }
+unsigned long long lumi::LumiSectionData::startorbit() const { return m_startorbit; }
+int lumi::LumiSectionData::lumiquality() const { return m_quality; }
+void lumi::LumiSectionData::bunchCrossingInfo(const lumi::LumiAlgoType lumialgotype,
+                                              std::vector<lumi::BunchCrossingInfo>& result) const {
   result.clear();
-  size_t offset=lumialgotype*lumi::BXMAX;
-  std::copy(m_bx.begin()+offset,m_bx.begin()+offset+lumi::BXMAX,std::back_inserter(result));
+  size_t offset = lumialgotype * lumi::BXMAX;
+  std::copy(m_bx.begin() + offset, m_bx.begin() + offset + lumi::BXMAX, std::back_inserter(result));
 }
 
-const lumi::BunchCrossingInfo 
-lumi::LumiSectionData::bunchCrossingInfo( const int BXIndex,
-				  const LumiAlgoType lumialgotype )const{
-  int realIdx=BXIndex-lumi::BXMIN+lumialgotype*lumi::BXMAX;
+const lumi::BunchCrossingInfo lumi::LumiSectionData::bunchCrossingInfo(const int BXIndex,
+                                                                       const LumiAlgoType lumialgotype) const {
+  int realIdx = BXIndex - lumi::BXMIN + lumialgotype * lumi::BXMAX;
   return m_bx.at(realIdx);
 }
-lumi::BunchCrossingIterator 
-lumi::LumiSectionData::bunchCrossingBegin( const LumiAlgoType lumialgotype )const{
-  return m_bx.begin()+lumialgotype*BXMAX;
+lumi::BunchCrossingIterator lumi::LumiSectionData::bunchCrossingBegin(const LumiAlgoType lumialgotype) const {
+  return m_bx.begin() + lumialgotype * BXMAX;
 }
-lumi::BunchCrossingIterator 
-lumi::LumiSectionData::bunchCrossingEnd( const LumiAlgoType lumialgotype )const{
-  return m_bx.end()-(lumi::BXMAX)*lumialgotype;
+lumi::BunchCrossingIterator lumi::LumiSectionData::bunchCrossingEnd(const LumiAlgoType lumialgotype) const {
+  return m_bx.end() - (lumi::BXMAX)*lumialgotype;
 }
-size_t
-lumi::LumiSectionData::nHLTPath()const{
-  return  m_hlt.size();
+size_t lumi::LumiSectionData::nHLTPath() const { return m_hlt.size(); }
+bool lumi::LumiSectionData::HLThasData() const { return !m_hlt.empty(); }
+lumi::HLTIterator lumi::LumiSectionData::hltBegin() const { return m_hlt.begin(); }
+lumi::HLTIterator lumi::LumiSectionData::hltEnd() const { return m_hlt.end(); }
+bool lumi::LumiSectionData::TriggerhasData() const { return !m_trigger.empty(); }
+lumi::TriggerIterator lumi::LumiSectionData::trgBegin() const { return m_trigger.begin(); }
+lumi::TriggerIterator lumi::LumiSectionData::trgEnd() const { return m_trigger.end(); }
+short lumi::LumiSectionData::qualityFlag() const { return m_quality; }
+void lumi::LumiSectionData::setLumiNull() { m_versionid = -99; }
+void lumi::LumiSectionData::setLumiVersion(const std::string& versionid) { m_versionid = versionid; }
+void lumi::LumiSectionData::setLumiSectionId(int sectionid) { m_sectionid = sectionid; }
+void lumi::LumiSectionData::setLumiAverage(float avg) { m_lumiavg = avg; }
+void lumi::LumiSectionData::setLumiQuality(int lumiquality) { m_quality = lumiquality; }
+void lumi::LumiSectionData::setDeadFraction(float deadfrac) { m_deadfrac = deadfrac; }
+void lumi::LumiSectionData::setLumiError(float lumierr) { m_lumierror = lumierr; }
+void lumi::LumiSectionData::setStartOrbit(unsigned long long orbtnumber) { m_startorbit = orbtnumber; }
+void lumi::LumiSectionData::setBunchCrossingData(const std::vector<BunchCrossingInfo>& BXs,
+                                                 const LumiAlgoType algotype) {
+  std::copy(BXs.begin(), BXs.begin() + lumi::BXMAX, std::back_inserter(m_bx));
 }
-bool 
-lumi::LumiSectionData::HLThasData()const{
-  return !m_hlt.empty();
+void lumi::LumiSectionData::setHLTData(const std::vector<HLTInfo>& hltdetail) {
+  std::copy(hltdetail.begin(), hltdetail.end(), std::back_inserter(m_hlt));
 }
-lumi::HLTIterator
-lumi::LumiSectionData::hltBegin()const{
-  return m_hlt.begin();
+void lumi::LumiSectionData::setTriggerData(const std::vector<TriggerInfo>& triggerinfo) {
+  std::copy(triggerinfo.begin(), triggerinfo.end(), std::back_inserter(m_trigger));
 }
-lumi::HLTIterator
-lumi::LumiSectionData::hltEnd()const{
-  return m_hlt.end();
-}
-bool
-lumi::LumiSectionData::TriggerhasData()const{
-  return !m_trigger.empty();
-}
-lumi::TriggerIterator
-lumi::LumiSectionData::trgBegin()const{
-  return m_trigger.begin();
-}
-lumi::TriggerIterator
-lumi::LumiSectionData::trgEnd()const{
-  return m_trigger.end();
-}
-short
-lumi::LumiSectionData::qualityFlag()const{
-  return m_quality;
-}
-void
-lumi::LumiSectionData::setLumiNull(){
-  m_versionid=-99;
-}
-void 
-lumi::LumiSectionData::setLumiVersion(const std::string& versionid){
-  m_versionid=versionid;
-}
-void
-lumi::LumiSectionData::setLumiSectionId(int sectionid){
-  m_sectionid=sectionid;
-}
-void
-lumi::LumiSectionData::setLumiAverage(float avg){
-  m_lumiavg=avg;
-}
-void 
-lumi::LumiSectionData::setLumiQuality(int lumiquality){
-  m_quality=lumiquality;
-}
-void 
-lumi::LumiSectionData::setDeadFraction(float deadfrac){
-  m_deadfrac=deadfrac;
-}
-void 
-lumi::LumiSectionData::setLumiError(float lumierr){
-  m_lumierror=lumierr;
-}
-void
-lumi::LumiSectionData::setStartOrbit(unsigned long long orbtnumber){
-  m_startorbit=orbtnumber;
-}
-void 
-lumi::LumiSectionData::setBunchCrossingData(const std::vector<BunchCrossingInfo>& BXs,const LumiAlgoType algotype){
-  std::copy(BXs.begin(),BXs.begin()+lumi::BXMAX,std::back_inserter(m_bx));
-}
-void 
-lumi::LumiSectionData::setHLTData(const std::vector<HLTInfo>& hltdetail){
-  std::copy(hltdetail.begin(),hltdetail.end(),std::back_inserter(m_hlt));
-}
-void
-lumi::LumiSectionData::setTriggerData(const std::vector<TriggerInfo>& triggerinfo){
-  std::copy(triggerinfo.begin(),triggerinfo.end(),std::back_inserter(m_trigger));
-}
-void 
-lumi::LumiSectionData::setQualityFlag(short qualityflag){
-  m_quality=qualityflag;
-}
-void
-lumi::LumiSectionData::print( std::ostream& s ) const{
-  s<<"lumi section id :"<<m_sectionid <<", ";
-  s<<"lumi data version : "<<m_versionid<<", ";
-  s<<"lumi average : "<<m_lumiavg<<", ";
-  s<<"lumi error : "<<m_lumierror<<", ";
-  s<<"lumi quality : "<<m_quality<<", ";
-  s<<"lumi deadfrac : "<<m_deadfrac<<std::endl;
+void lumi::LumiSectionData::setQualityFlag(short qualityflag) { m_quality = qualityflag; }
+void lumi::LumiSectionData::print(std::ostream& s) const {
+  s << "lumi section id :" << m_sectionid << ", ";
+  s << "lumi data version : " << m_versionid << ", ";
+  s << "lumi average : " << m_lumiavg << ", ";
+  s << "lumi error : " << m_lumierror << ", ";
+  s << "lumi quality : " << m_quality << ", ";
+  s << "lumi deadfrac : " << m_deadfrac << std::endl;
   std::vector<lumi::TriggerInfo>::const_iterator trgit;
-  std::vector<lumi::TriggerInfo>::const_iterator trgitBeg=m_trigger.begin();
-  std::vector<lumi::TriggerInfo>::const_iterator trgitEnd=m_trigger.end();
-  unsigned int i=0;
-  for(trgit=trgitBeg;trgit!=trgitEnd;++trgit){
-    std::cout<<"  trg "<<i<<" : name : "<<trgit->name<<" : count : "<<trgit->triggercount<<" : deadtime : "<< trgit->deadtimecount<<" : prescale : "<<trgit->prescale<<std::endl;
+  std::vector<lumi::TriggerInfo>::const_iterator trgitBeg = m_trigger.begin();
+  std::vector<lumi::TriggerInfo>::const_iterator trgitEnd = m_trigger.end();
+  unsigned int i = 0;
+  for (trgit = trgitBeg; trgit != trgitEnd; ++trgit) {
+    std::cout << "  trg " << i << " : name : " << trgit->name << " : count : " << trgit->triggercount
+              << " : deadtime : " << trgit->deadtimecount << " : prescale : " << trgit->prescale << std::endl;
     ++i;
   }
 }

--- a/CondFormats/Luminosity/src/classes.h
+++ b/CondFormats/Luminosity/src/classes.h
@@ -1,8 +1,7 @@
 #include "CondFormats/Luminosity/src/headers.h"
 
 namespace {
-    std::vector<lumi::BunchCrossingInfo>::iterator tmp1;
-    std::vector<lumi::HLTInfo>::iterator tmp2;
-    std::vector<lumi::TriggerInfo>::iterator tmp3;
-  };
-
+  std::vector<lumi::BunchCrossingInfo>::iterator tmp1;
+  std::vector<lumi::HLTInfo>::iterator tmp2;
+  std::vector<lumi::TriggerInfo>::iterator tmp3;
+};  // namespace

--- a/CondFormats/Luminosity/test/testSerializationLumiCorrections.cpp
+++ b/CondFormats/Luminosity/test/testSerializationLumiCorrections.cpp
@@ -1,7 +1,4 @@
 #include "CondFormats/Serialization/interface/Test.h"
 #include "CondFormats/Luminosity/interface/LumiCorrections.h"
 
-int main()
-{
-    testSerialization<LumiCorrections>();
-}
+int main() { testSerialization<LumiCorrections>(); }

--- a/CondFormats/Luminosity/test/testSerializationLuminosity.cpp
+++ b/CondFormats/Luminosity/test/testSerializationLuminosity.cpp
@@ -2,15 +2,14 @@
 
 #include "CondFormats/Luminosity/src/headers.h"
 
-int main()
-{
-    testSerialization<lumi::BunchCrossingInfo>();
-    testSerialization<lumi::HLTInfo>();
-    testSerialization<lumi::LumiSectionData>();
-    testSerialization<lumi::TriggerInfo>();
-    testSerialization<std::vector<lumi::BunchCrossingInfo>>();
-    testSerialization<std::vector<lumi::HLTInfo>>();
-    testSerialization<std::vector<lumi::TriggerInfo>>();
+int main() {
+  testSerialization<lumi::BunchCrossingInfo>();
+  testSerialization<lumi::HLTInfo>();
+  testSerialization<lumi::LumiSectionData>();
+  testSerialization<lumi::TriggerInfo>();
+  testSerialization<std::vector<lumi::BunchCrossingInfo>>();
+  testSerialization<std::vector<lumi::HLTInfo>>();
+  testSerialization<std::vector<lumi::TriggerInfo>>();
 
-    return 0;
+  return 0;
 }

--- a/CondFormats/PCLConfig/interface/AlignPCLThreshold.h
+++ b/CondFormats/PCLConfig/interface/AlignPCLThreshold.h
@@ -1,27 +1,26 @@
-#ifndef CondFormats_PCLConfig_AlignPCLThreshold_h 
+#ifndef CondFormats_PCLConfig_AlignPCLThreshold_h
 #define CondFormats_PCLConfig_AlignPCLThreshold_h
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-class AlignPCLThreshold
-{
+class AlignPCLThreshold {
 public:
-  
-  struct coordThresholds{
-    coordThresholds(){
-      m_Cut=5.;
-      m_sigCut=2.5;
-      m_errorCut=10.;
-      m_maxMoveCut=200;
-      m_label="default";
+  struct coordThresholds {
+    coordThresholds() {
+      m_Cut = 5.;
+      m_sigCut = 2.5;
+      m_errorCut = 10.;
+      m_maxMoveCut = 200;
+      m_label = "default";
     }
-    ~coordThresholds(){}
-    void setThresholds(float theCut,float theSigCut,float theErrorCut,float theMaxMoveCut,const std::string &theLabel){
-      m_Cut=theCut;
-      m_sigCut=theSigCut;
-      m_errorCut=theErrorCut;
-      m_maxMoveCut=theMaxMoveCut;
-      m_label=theLabel;
+    ~coordThresholds() {}
+    void setThresholds(
+        float theCut, float theSigCut, float theErrorCut, float theMaxMoveCut, const std::string &theLabel) {
+      m_Cut = theCut;
+      m_sigCut = theSigCut;
+      m_errorCut = theErrorCut;
+      m_maxMoveCut = theMaxMoveCut;
+      m_label = theLabel;
     }
 
     float m_Cut;
@@ -31,62 +30,61 @@ public:
     std::string m_label;
 
     COND_SERIALIZABLE;
-    
   };
-  
-  virtual ~AlignPCLThreshold(){}
-  
-  AlignPCLThreshold(coordThresholds X=coordThresholds(),coordThresholds tX=coordThresholds(),
-		    coordThresholds Y=coordThresholds(),coordThresholds tY=coordThresholds(),
-		    coordThresholds Z=coordThresholds(),coordThresholds tZ=coordThresholds(),
-		    std::vector< coordThresholds > extraDOF=std::vector< coordThresholds >()
-		    );
-  
-  float getXcut()              const {return m_xCoord.m_Cut;}
-  float getYcut()              const {return m_yCoord.m_Cut;}
-  float getZcut()              const {return m_zCoord.m_Cut;}
-  float getThetaXcut()         const {return m_thetaXCoord.m_Cut;}
-  float getThetaYcut()         const {return m_thetaYCoord.m_Cut;}
-  float getThetaZcut()         const {return m_thetaZCoord.m_Cut;}
 
-  float getSigXcut()           const {return m_xCoord.m_sigCut;}
-  float getSigYcut()           const {return m_yCoord.m_sigCut;}
-  float getSigZcut()           const {return m_zCoord.m_sigCut;}
-  float getSigThetaXcut()      const {return m_thetaXCoord.m_sigCut;}
-  float getSigThetaYcut()      const {return m_thetaYCoord.m_sigCut;}
-  float getSigThetaZcut()      const {return m_thetaZCoord.m_sigCut;}
+  virtual ~AlignPCLThreshold() {}
 
-  float getErrorXcut()         const {return m_xCoord.m_errorCut;}
-  float getErrorYcut()         const {return m_yCoord.m_errorCut;}
-  float getErrorZcut()         const {return m_zCoord.m_errorCut;}
-  float getErrorThetaXcut()    const {return m_thetaXCoord.m_errorCut;}
-  float getErrorThetaYcut()    const {return m_thetaYCoord.m_errorCut;}
-  float getErrorThetaZcut()    const {return m_thetaZCoord.m_errorCut;}
+  AlignPCLThreshold(coordThresholds X = coordThresholds(),
+                    coordThresholds tX = coordThresholds(),
+                    coordThresholds Y = coordThresholds(),
+                    coordThresholds tY = coordThresholds(),
+                    coordThresholds Z = coordThresholds(),
+                    coordThresholds tZ = coordThresholds(),
+                    std::vector<coordThresholds> extraDOF = std::vector<coordThresholds>());
 
-  float getMaxMoveXcut()       const {return m_xCoord.m_maxMoveCut;}
-  float getMaxMoveYcut()       const {return m_yCoord.m_maxMoveCut;}
-  float getMaxMoveZcut()       const {return m_zCoord.m_maxMoveCut;}
-  float getMaxMoveThetaXcut()  const {return m_thetaXCoord.m_maxMoveCut;}
-  float getMaxMoveThetaYcut()  const {return m_thetaYCoord.m_maxMoveCut;}
-  float getMaxMoveThetaZcut()  const {return m_thetaZCoord.m_maxMoveCut;}
+  float getXcut() const { return m_xCoord.m_Cut; }
+  float getYcut() const { return m_yCoord.m_Cut; }
+  float getZcut() const { return m_zCoord.m_Cut; }
+  float getThetaXcut() const { return m_thetaXCoord.m_Cut; }
+  float getThetaYcut() const { return m_thetaYCoord.m_Cut; }
+  float getThetaZcut() const { return m_thetaZCoord.m_Cut; }
 
-  bool hasExtraDOF()           const {return (!m_extraDOF.empty());}
-  unsigned int extraDOFSize()  const {return m_extraDOF.size();}
-  std::array<float,4> getExtraDOFCuts(const unsigned int i) const;
+  float getSigXcut() const { return m_xCoord.m_sigCut; }
+  float getSigYcut() const { return m_yCoord.m_sigCut; }
+  float getSigZcut() const { return m_zCoord.m_sigCut; }
+  float getSigThetaXcut() const { return m_thetaXCoord.m_sigCut; }
+  float getSigThetaYcut() const { return m_thetaYCoord.m_sigCut; }
+  float getSigThetaZcut() const { return m_thetaZCoord.m_sigCut; }
+
+  float getErrorXcut() const { return m_xCoord.m_errorCut; }
+  float getErrorYcut() const { return m_yCoord.m_errorCut; }
+  float getErrorZcut() const { return m_zCoord.m_errorCut; }
+  float getErrorThetaXcut() const { return m_thetaXCoord.m_errorCut; }
+  float getErrorThetaYcut() const { return m_thetaYCoord.m_errorCut; }
+  float getErrorThetaZcut() const { return m_thetaZCoord.m_errorCut; }
+
+  float getMaxMoveXcut() const { return m_xCoord.m_maxMoveCut; }
+  float getMaxMoveYcut() const { return m_yCoord.m_maxMoveCut; }
+  float getMaxMoveZcut() const { return m_zCoord.m_maxMoveCut; }
+  float getMaxMoveThetaXcut() const { return m_thetaXCoord.m_maxMoveCut; }
+  float getMaxMoveThetaYcut() const { return m_thetaYCoord.m_maxMoveCut; }
+  float getMaxMoveThetaZcut() const { return m_thetaZCoord.m_maxMoveCut; }
+
+  bool hasExtraDOF() const { return (!m_extraDOF.empty()); }
+  unsigned int extraDOFSize() const { return m_extraDOF.size(); }
+  std::array<float, 4> getExtraDOFCuts(const unsigned int i) const;
   std::string getExtraDOFLabel(const unsigned int i) const;
 
 private:
-
-  coordThresholds  m_xCoord;
-  coordThresholds  m_yCoord;
-  coordThresholds  m_zCoord;
-  coordThresholds  m_thetaXCoord;
-  coordThresholds  m_thetaYCoord;
-  coordThresholds  m_thetaZCoord;
-  std::vector< coordThresholds > m_extraDOF;
+  coordThresholds m_xCoord;
+  coordThresholds m_yCoord;
+  coordThresholds m_zCoord;
+  coordThresholds m_thetaXCoord;
+  coordThresholds m_thetaYCoord;
+  coordThresholds m_thetaZCoord;
+  std::vector<coordThresholds> m_extraDOF;
 
   COND_SERIALIZABLE;
-
 };
 
 #endif

--- a/CondFormats/PCLConfig/interface/AlignPCLThresholds.h
+++ b/CondFormats/PCLConfig/interface/AlignPCLThresholds.h
@@ -8,50 +8,48 @@
 #include <string>
 #include <vector>
 
-class AlignPCLThresholds{
- public:
-  typedef std::map<std::string,AlignPCLThreshold> threshold_map;
-  enum coordType {X, Y, Z, theta_X, theta_Y, theta_Z, extra_DOF, endOfTypes}; 
+class AlignPCLThresholds {
+public:
+  typedef std::map<std::string, AlignPCLThreshold> threshold_map;
+  enum coordType { X, Y, Z, theta_X, theta_Y, theta_Z, extra_DOF, endOfTypes };
 
-  AlignPCLThresholds(){}
-  virtual ~AlignPCLThresholds(){}
+  AlignPCLThresholds() {}
+  virtual ~AlignPCLThresholds() {}
 
   void setAlignPCLThreshold(const std::string &AlignableId, const AlignPCLThreshold &Threshold);
-  void setAlignPCLThresholds(const int &Nrecords,const threshold_map &Thresholds);
+  void setAlignPCLThresholds(const int &Nrecords, const threshold_map &Thresholds);
   void setNRecords(const int &Nrecords);
-                  
-  const threshold_map& getThreshold_Map () const  {return m_thresholds;}
-  const int& getNrecords() const {return m_nrecords;}
 
-  AlignPCLThreshold   getAlignPCLThreshold(const std::string &AlignableId) const;
-  AlignPCLThreshold & getAlignPCLThreshold(const std::string &AlignableId);
-  
-  float getSigCut     (const std::string &AlignableId,const coordType &type) const;
-  float getCut        (const std::string &AlignableId,const coordType &type) const;
-  float getMaxMoveCut (const std::string &AlignableId,const coordType &type) const; 
-  float getMaxErrorCut(const std::string &AlignableId,const coordType &type) const;                     
+  const threshold_map &getThreshold_Map() const { return m_thresholds; }
+  const int &getNrecords() const { return m_nrecords; }
+
+  AlignPCLThreshold getAlignPCLThreshold(const std::string &AlignableId) const;
+  AlignPCLThreshold &getAlignPCLThreshold(const std::string &AlignableId);
+
+  float getSigCut(const std::string &AlignableId, const coordType &type) const;
+  float getCut(const std::string &AlignableId, const coordType &type) const;
+  float getMaxMoveCut(const std::string &AlignableId, const coordType &type) const;
+  float getMaxErrorCut(const std::string &AlignableId, const coordType &type) const;
 
   // overloaded methods to get all the coordinates
-  std::array<float,6> getSigCut     (const std::string &AlignableId) const;
-  std::array<float,6> getCut        (const std::string &AlignableId) const;
-  std::array<float,6> getMaxMoveCut (const std::string &AlignableId) const; 
-  std::array<float,6> getMaxErrorCut(const std::string &AlignableId) const;
-  
-  std::array<float,4> getExtraDOFCutsForAlignable(const std::string &AlignableId,const unsigned int i) const;
-  std::string getExtraDOFLabelForAlignable(const std::string &AlignableId,const unsigned int i) const;
+  std::array<float, 6> getSigCut(const std::string &AlignableId) const;
+  std::array<float, 6> getCut(const std::string &AlignableId) const;
+  std::array<float, 6> getMaxMoveCut(const std::string &AlignableId) const;
+  std::array<float, 6> getMaxErrorCut(const std::string &AlignableId) const;
 
-  double size()const {return m_thresholds.size();}
+  std::array<float, 4> getExtraDOFCutsForAlignable(const std::string &AlignableId, const unsigned int i) const;
+  std::string getExtraDOFLabelForAlignable(const std::string &AlignableId, const unsigned int i) const;
+
+  double size() const { return m_thresholds.size(); }
   std::vector<std::string> getAlignableList() const;
 
   void printAll() const;
 
- private:
-
+private:
   threshold_map m_thresholds;
   int m_nrecords;
 
   COND_SERIALIZABLE;
-
 };
 
 #endif

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -73,7 +73,7 @@ namespace edmtest
     }
  
     FILE* pFile=nullptr;
-    if(formatedOutput_!="")pFile=fopen(formatedOutput_.c_str(), "w");
+    if(!formatedOutput_.empty())pFile=fopen(formatedOutput_.c_str(), "w");
     if(pFile){
 
       fprintf(pFile,"AlignPCLThresholds::printAll() \n");

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -9,136 +9,134 @@
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
 #include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
 
-namespace edmtest
-{
+namespace edmtest {
   class AlignPCLThresholdsReader : public edm::one::EDAnalyzer<> {
   public:
-    explicit AlignPCLThresholdsReader(edm::ParameterSet const& p); 
-    ~AlignPCLThresholdsReader() override; 
+    explicit AlignPCLThresholdsReader(edm::ParameterSet const& p);
+    ~AlignPCLThresholdsReader() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
   private:
-    
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
     // ----------member data ---------------------------
     const bool printdebug_;
     const std::string formatedOutput_;
-
   };
-  
-  AlignPCLThresholdsReader::AlignPCLThresholdsReader(edm::ParameterSet const& p):
-    printdebug_(p.getUntrackedParameter<bool>("printDebug",true)),
-    formatedOutput_(p.getUntrackedParameter<std::string>("outputFile",""))
-  { 
-    edm::LogInfo("AlignPCLThresholdsReader")<<"AlignPCLThresholdsReader"<<std::endl;
+
+  AlignPCLThresholdsReader::AlignPCLThresholdsReader(edm::ParameterSet const& p)
+      : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
+        formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")) {
+    edm::LogInfo("AlignPCLThresholdsReader") << "AlignPCLThresholdsReader" << std::endl;
   }
 
-  AlignPCLThresholdsReader::~AlignPCLThresholdsReader() {  
-    edm::LogInfo("AlignPCLThresholdsReader")<<"~AlignPCLThresholdsReader "<<std::endl;
+  AlignPCLThresholdsReader::~AlignPCLThresholdsReader() {
+    edm::LogInfo("AlignPCLThresholdsReader") << "~AlignPCLThresholdsReader " << std::endl;
   }
 
-  void
-  AlignPCLThresholdsReader::analyze(const edm::Event& e, const edm::EventSetup& context){
+  void AlignPCLThresholdsReader::analyze(const edm::Event& e, const edm::EventSetup& context) {
+    edm::LogInfo("AlignPCLThresholdsReader") << "### AlignPCLThresholdsReader::analyze  ###" << std::endl;
+    edm::LogInfo("AlignPCLThresholdsReader") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
+    edm::LogInfo("AlignPCLThresholdsReader") << " ---EVENT NUMBER " << e.id().event() << std::endl;
 
-    edm::LogInfo("AlignPCLThresholdsReader") <<"### AlignPCLThresholdsReader::analyze  ###"<<std::endl;
-    edm::LogInfo("AlignPCLThresholdsReader") <<" I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
-    edm::LogInfo("AlignPCLThresholdsReader") <<" ---EVENT NUMBER "<<e.id().event() <<std::endl;
-    
-    edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("AlignPCLThresholdsRcd"));
-    
-    if( recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+    edm::eventsetup::EventSetupRecordKey recordKey(
+        edm::eventsetup::EventSetupRecordKey::TypeTag::findType("AlignPCLThresholdsRcd"));
+
+    if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      edm::LogInfo("AlignPCLThresholdsReader") <<"Record \"AlignPCLThresholdsRcd"<<"\" does not exist "<<std::endl;
+      edm::LogInfo("AlignPCLThresholdsReader") << "Record \"AlignPCLThresholdsRcd"
+                                               << "\" does not exist " << std::endl;
     }
-    
+
     //this part gets the handle of the event source and the record (i.e. the Database)
     edm::ESHandle<AlignPCLThresholds> thresholdHandle;
-    edm::LogInfo("AlignPCLThresholdsReader") <<"got eshandle"<<std::endl;
+    edm::LogInfo("AlignPCLThresholdsReader") << "got eshandle" << std::endl;
 
     context.get<AlignPCLThresholdsRcd>().get(thresholdHandle);
-    edm::LogInfo("AlignPCLThresholdsReader") <<"got context"<<std::endl;
+    edm::LogInfo("AlignPCLThresholdsReader") << "got context" << std::endl;
 
-    const AlignPCLThresholds* thresholds=thresholdHandle.product();
-    edm::LogInfo("AlignPCLThresholdsReader") <<"got AlignPCLThresholds* "<< std::endl;
-    edm::LogInfo("AlignPCLThresholdsReader") << "print  pointer address : " ;
+    const AlignPCLThresholds* thresholds = thresholdHandle.product();
+    edm::LogInfo("AlignPCLThresholdsReader") << "got AlignPCLThresholds* " << std::endl;
+    edm::LogInfo("AlignPCLThresholdsReader") << "print  pointer address : ";
     edm::LogInfo("AlignPCLThresholdsReader") << thresholds << std::endl;
 
-    edm::LogInfo("AlignPCLThresholdsReader") << "Size "  <<  thresholds->size() << std::endl;     
-    edm::LogInfo("AlignPCLThresholdsReader") <<"Content of myThresholds "<<std::endl;
+    edm::LogInfo("AlignPCLThresholdsReader") << "Size " << thresholds->size() << std::endl;
+    edm::LogInfo("AlignPCLThresholdsReader") << "Content of myThresholds " << std::endl;
     // use built-in method in the CondFormat to print the content
-    if(printdebug_){
+    if (printdebug_) {
       thresholds->printAll();
     }
- 
-    FILE* pFile=nullptr;
-    if(!formatedOutput_.empty())pFile=fopen(formatedOutput_.c_str(), "w");
-    if(pFile){
 
-      fprintf(pFile,"AlignPCLThresholds::printAll() \n");
-      fprintf(pFile," =================================================================================================================== \n"); 
-      fprintf(pFile,"N records cut: %i \n",thresholds->getNrecords());    
+    FILE* pFile = nullptr;
+    if (!formatedOutput_.empty())
+      pFile = fopen(formatedOutput_.c_str(), "w");
+    if (pFile) {
+      fprintf(pFile, "AlignPCLThresholds::printAll() \n");
+      fprintf(pFile,
+              " ======================================================================================================="
+              "============ \n");
+      fprintf(pFile, "N records cut: %i \n", thresholds->getNrecords());
 
       AlignPCLThresholds::threshold_map m_thresholds = thresholds->getThreshold_Map();
-      
-      for(auto it = m_thresholds.begin(); it != m_thresholds.end() ; ++it){
-	fprintf(pFile," =================================================================================================================== \n");
-	fprintf(pFile,"key : %s \n ",(it->first).c_str());
-	fprintf(pFile,"- Xcut             : %8.3f   um   ",(it->second).getXcut()            );
-	fprintf(pFile,"| sigXcut          : %8.3f        ",(it->second).getSigXcut()         );
-	fprintf(pFile,"| maxMoveXcut      : %8.3f   um   ",(it->second).getMaxMoveXcut()     );
-	fprintf(pFile,"| ErrorXcut        : %8.3f   um\n ",(it->second).getErrorXcut()       );
-					           
-	fprintf(pFile,"- thetaXcut        : %8.3f urad   ",(it->second).getThetaXcut()       ); 
-	fprintf(pFile,"| sigThetaXcut     : %8.3f        ",(it->second).getSigThetaXcut()    );
-	fprintf(pFile,"| maxMoveThetaXcut : %8.3f urad   ",(it->second).getMaxMoveThetaXcut());
-	fprintf(pFile,"| ErrorThetaXcut   : %8.3f urad\n ",(it->second).getErrorThetaXcut()  ); 
-					           
-	fprintf(pFile,"- Ycut             : %8.3f   um   ",(it->second).getYcut()            ); 
-	fprintf(pFile,"| sigYcut          : %8.3f        ",(it->second).getSigXcut()         );
-	fprintf(pFile,"| maxMoveYcut      : %8.3f   um   ",(it->second).getMaxMoveYcut()     );
-	fprintf(pFile,"| ErrorYcut        : %8.3f   um\n ",(it->second).getErrorYcut()       ); 
-	    				           
-	fprintf(pFile,"- thetaYcut        : %8.3f urad   ",(it->second).getThetaYcut()       ); 
-	fprintf(pFile,"| sigThetaYcut     : %8.3f        ",(it->second).getSigThetaYcut()    );
-	fprintf(pFile,"| maxMoveThetaYcut : %8.3f urad   ",(it->second).getMaxMoveThetaYcut());
-	fprintf(pFile,"| ErrorThetaYcut   : %8.3f urad\n ",(it->second).getErrorThetaYcut()  ); 
-	    				           
-	fprintf(pFile,"- Zcut             : %8.3f   um   ",(it->second).getZcut()            );	     
-	fprintf(pFile,"| sigZcut          : %8.3f        ",(it->second).getSigZcut()         );	     
-	fprintf(pFile,"| maxMoveZcut      : %8.3f   um   ",(it->second).getMaxMoveZcut()     );	     
-	fprintf(pFile,"| ErrorZcut        : %8.3f   um\n ",(it->second).getErrorZcut()       ); 
-	    				           
-	fprintf(pFile,"- thetaZcut        : %8.3f urad   ",(it->second).getThetaZcut()       ); 
-	fprintf(pFile,"| sigThetaZcut     : %8.3f        ",(it->second).getSigThetaZcut()    );
-	fprintf(pFile,"| maxMoveThetaZcut : %8.3f urad   ",(it->second).getMaxMoveThetaZcut());
-	fprintf(pFile,"| ErrorThetaZcut   : %8.3f urad\n ",(it->second).getErrorThetaZcut()  );
-		
-	if((it->second).hasExtraDOF()){
-	  for (unsigned int j=0; j<(it->second).extraDOFSize(); j++){
-	    std::array<float,4> extraDOFCuts = thresholds->getExtraDOFCutsForAlignable(it->first,j);
-	    const char* theLabel =  (thresholds->getExtraDOFLabelForAlignable(it->first,j)).c_str();
-	    fprintf(pFile,"Extra DOF: %i with label %s \n ",j,theLabel);	  
-	    fprintf(pFile,"- cut              : %8.3f        " ,extraDOFCuts.at(0));
-	    fprintf(pFile,"| sigCut           : %8.3f        " ,extraDOFCuts.at(1)); 
-	    fprintf(pFile,"| maxMoveCut       : %8.3f        " ,extraDOFCuts.at(2)); 
-	    fprintf(pFile,"| maxErrorCut      : %8.3f     \n " ,extraDOFCuts.at(3)); 
-	  }
-	}
+
+      for (auto it = m_thresholds.begin(); it != m_thresholds.end(); ++it) {
+        fprintf(pFile,
+                " ====================================================================================================="
+                "============== \n");
+        fprintf(pFile, "key : %s \n ", (it->first).c_str());
+        fprintf(pFile, "- Xcut             : %8.3f   um   ", (it->second).getXcut());
+        fprintf(pFile, "| sigXcut          : %8.3f        ", (it->second).getSigXcut());
+        fprintf(pFile, "| maxMoveXcut      : %8.3f   um   ", (it->second).getMaxMoveXcut());
+        fprintf(pFile, "| ErrorXcut        : %8.3f   um\n ", (it->second).getErrorXcut());
+
+        fprintf(pFile, "- thetaXcut        : %8.3f urad   ", (it->second).getThetaXcut());
+        fprintf(pFile, "| sigThetaXcut     : %8.3f        ", (it->second).getSigThetaXcut());
+        fprintf(pFile, "| maxMoveThetaXcut : %8.3f urad   ", (it->second).getMaxMoveThetaXcut());
+        fprintf(pFile, "| ErrorThetaXcut   : %8.3f urad\n ", (it->second).getErrorThetaXcut());
+
+        fprintf(pFile, "- Ycut             : %8.3f   um   ", (it->second).getYcut());
+        fprintf(pFile, "| sigYcut          : %8.3f        ", (it->second).getSigXcut());
+        fprintf(pFile, "| maxMoveYcut      : %8.3f   um   ", (it->second).getMaxMoveYcut());
+        fprintf(pFile, "| ErrorYcut        : %8.3f   um\n ", (it->second).getErrorYcut());
+
+        fprintf(pFile, "- thetaYcut        : %8.3f urad   ", (it->second).getThetaYcut());
+        fprintf(pFile, "| sigThetaYcut     : %8.3f        ", (it->second).getSigThetaYcut());
+        fprintf(pFile, "| maxMoveThetaYcut : %8.3f urad   ", (it->second).getMaxMoveThetaYcut());
+        fprintf(pFile, "| ErrorThetaYcut   : %8.3f urad\n ", (it->second).getErrorThetaYcut());
+
+        fprintf(pFile, "- Zcut             : %8.3f   um   ", (it->second).getZcut());
+        fprintf(pFile, "| sigZcut          : %8.3f        ", (it->second).getSigZcut());
+        fprintf(pFile, "| maxMoveZcut      : %8.3f   um   ", (it->second).getMaxMoveZcut());
+        fprintf(pFile, "| ErrorZcut        : %8.3f   um\n ", (it->second).getErrorZcut());
+
+        fprintf(pFile, "- thetaZcut        : %8.3f urad   ", (it->second).getThetaZcut());
+        fprintf(pFile, "| sigThetaZcut     : %8.3f        ", (it->second).getSigThetaZcut());
+        fprintf(pFile, "| maxMoveThetaZcut : %8.3f urad   ", (it->second).getMaxMoveThetaZcut());
+        fprintf(pFile, "| ErrorThetaZcut   : %8.3f urad\n ", (it->second).getErrorThetaZcut());
+
+        if ((it->second).hasExtraDOF()) {
+          for (unsigned int j = 0; j < (it->second).extraDOFSize(); j++) {
+            std::array<float, 4> extraDOFCuts = thresholds->getExtraDOFCutsForAlignable(it->first, j);
+            const char* theLabel = (thresholds->getExtraDOFLabelForAlignable(it->first, j)).c_str();
+            fprintf(pFile, "Extra DOF: %i with label %s \n ", j, theLabel);
+            fprintf(pFile, "- cut              : %8.3f        ", extraDOFCuts.at(0));
+            fprintf(pFile, "| sigCut           : %8.3f        ", extraDOFCuts.at(1));
+            fprintf(pFile, "| maxMoveCut       : %8.3f        ", extraDOFCuts.at(2));
+            fprintf(pFile, "| maxErrorCut      : %8.3f     \n ", extraDOFCuts.at(3));
+          }
+        }
       }
     }
-   
   }
 
-  void
-  AlignPCLThresholdsReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  void AlignPCLThresholdsReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.setComment("Reads payloads of type AlignPCLThresholds");
-    desc.addUntracked<bool>("printDebug",true);
-    desc.addUntracked<std::string>("outputFile","");
-    descriptions.add("AlignPCLThresholdsReader",desc);
+    desc.addUntracked<bool>("printDebug", true);
+    desc.addUntracked<std::string>("outputFile", "");
+    descriptions.add("AlignPCLThresholdsReader", desc);
   }
 
   DEFINE_FWK_MODULE(AlignPCLThresholdsReader);
-}
+}  // namespace edmtest

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CondFormats/PCLConfig
 // Class:      AlignPCLThresholdsWriter
-// 
+//
 /**\class AlignPCLThresholdsWriter AlignPCLThresholdsWriter.cc CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
 
  Description: class to build the SiPixelAli PCL thresholds
@@ -34,211 +34,181 @@
 //
 
 namespace DOFs {
-  enum dof{
-    X,
-    Y,
-    Z,
-    thetaX,
-    thetaY,
-    thetaZ,
-    extraDOF
-  };
+  enum dof { X, Y, Z, thetaX, thetaY, thetaZ, extraDOF };
 }
 
-class AlignPCLThresholdsWriter : public edm::one::EDAnalyzer<>  {
-   public:
-      explicit AlignPCLThresholdsWriter(const edm::ParameterSet&);
-      ~AlignPCLThresholdsWriter() override;
+class AlignPCLThresholdsWriter : public edm::one::EDAnalyzer<> {
+public:
+  explicit AlignPCLThresholdsWriter(const edm::ParameterSet&);
+  ~AlignPCLThresholdsWriter() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+  DOFs::dof mapOntoEnum(std::string coord);
 
-   private:
-      void beginJob() override;
-      void analyze(const edm::Event&, const edm::EventSetup&) override;
-      void endJob() override;
-      DOFs::dof mapOntoEnum(std::string coord);
-
-      // ----------member data ---------------------------
-      const std::string m_record;
-      const unsigned int m_minNrecords;
-      const std::vector<edm::ParameterSet> m_parameters;
-      AlignPCLThresholds* myThresholds;
-
+  // ----------member data ---------------------------
+  const std::string m_record;
+  const unsigned int m_minNrecords;
+  const std::vector<edm::ParameterSet> m_parameters;
+  AlignPCLThresholds* myThresholds;
 };
 
 //
 // constructors and destructor
 //
-AlignPCLThresholdsWriter::AlignPCLThresholdsWriter(const edm::ParameterSet& iConfig):
-  m_record(iConfig.getParameter<std::string>("record")),
-  m_minNrecords(iConfig.getParameter<unsigned int>("minNRecords")),
-  m_parameters(iConfig.getParameter<std::vector<edm::ParameterSet> >("thresholds"))
-{
+AlignPCLThresholdsWriter::AlignPCLThresholdsWriter(const edm::ParameterSet& iConfig)
+    : m_record(iConfig.getParameter<std::string>("record")),
+      m_minNrecords(iConfig.getParameter<unsigned int>("minNRecords")),
+      m_parameters(iConfig.getParameter<std::vector<edm::ParameterSet> >("thresholds")) {
   //now do what ever initialization is needed
   myThresholds = new AlignPCLThresholds();
 }
 
-
-AlignPCLThresholdsWriter::~AlignPCLThresholdsWriter()
-{
-  delete myThresholds;
-}
+AlignPCLThresholdsWriter::~AlignPCLThresholdsWriter() { delete myThresholds; }
 
 //
 // member functions
 //
 
 // ------------ method called for each event  ------------
-void
-AlignPCLThresholdsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-  
-   edm::LogInfo("AlignPCLThresholdsWriter")<<"Size of AlignPCLThresholds object "<< myThresholds->size() <<std::endl<<std::endl;
-   
-   // loop on the PSet and insert the conditions 
+void AlignPCLThresholdsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   std::array<std::string,6> mandatories = {{"X","Y","Z","thetaX","thetaY","thetaZ"}};
-   std::vector<std::string> alignables;
+  edm::LogInfo("AlignPCLThresholdsWriter") << "Size of AlignPCLThresholds object " << myThresholds->size() << std::endl
+                                           << std::endl;
 
-   // fill the list of alignables
-   for(auto& thePSet : m_parameters){
-     const std::string alignableId(thePSet.getParameter<std::string>("alignableId"));
-     // only if it is not yet in the list
-     if(std::find(alignables.begin(), alignables.end(), alignableId) == alignables.end()) {
-       alignables.push_back(alignableId);
-     }
-   }
+  // loop on the PSet and insert the conditions
 
-   for (auto& alignable : alignables){
-     
-     AlignPCLThreshold::coordThresholds my_X;
-     AlignPCLThreshold::coordThresholds my_Y;
-     AlignPCLThreshold::coordThresholds my_Z;
-     AlignPCLThreshold::coordThresholds my_tX;
-     AlignPCLThreshold::coordThresholds my_tY;
-     AlignPCLThreshold::coordThresholds my_tZ;
-   
-     std::vector<std::string> presentDOF;
+  std::array<std::string, 6> mandatories = {{"X", "Y", "Z", "thetaX", "thetaY", "thetaZ"}};
+  std::vector<std::string> alignables;
 
-     // extra degrees of freedom
-     std::vector< AlignPCLThreshold::coordThresholds > extraDOFs = std::vector< AlignPCLThreshold::coordThresholds >();
+  // fill the list of alignables
+  for (auto& thePSet : m_parameters) {
+    const std::string alignableId(thePSet.getParameter<std::string>("alignableId"));
+    // only if it is not yet in the list
+    if (std::find(alignables.begin(), alignables.end(), alignableId) == alignables.end()) {
+      alignables.push_back(alignableId);
+    }
+  }
 
-     for(auto& thePSet : m_parameters){
-     
-       const std::string alignableId(thePSet.getParameter<std::string>("alignableId"));
-       const std::string DOF(thePSet.getParameter<std::string>("DOF"));
-       
-       const double cutoff(thePSet.getParameter<double>("cut"));
-       const double sigCut(thePSet.getParameter<double>("sigCut"));
-       const double maxMoveCut(thePSet.getParameter<double>("maxMoveCut"));
-       const double maxErrorCut(thePSet.getParameter<double>("maxErrorCut"));
-       
-       if (alignableId == alignable){
-	 presentDOF.push_back(DOF);
-	 // create the objects 
-  
-	 switch( mapOntoEnum(DOF) )
-	   {
-	   case DOFs::X:
-	     my_X.setThresholds(cutoff,sigCut,maxErrorCut,maxMoveCut,DOF);
-	     break;			                  
-	   case DOFs::Y:		                  
-	     my_Y.setThresholds(cutoff,sigCut,maxErrorCut,maxMoveCut,DOF);
-	     break;			                  
-	   case DOFs::Z:		                  
-	     my_Z.setThresholds(cutoff,sigCut,maxErrorCut,maxMoveCut,DOF);
-	     break;			                  
-	   case DOFs::thetaX:		                  
-	     my_tX.setThresholds(cutoff,sigCut,maxErrorCut,maxMoveCut,DOF);
-	     break;			                  
-	   case DOFs::thetaY:		                  
-	     my_tY.setThresholds(cutoff,sigCut,maxErrorCut,maxMoveCut,DOF);
-	     break;			                  
-	   case DOFs::thetaZ:		                  
-	     my_tZ.setThresholds(cutoff,sigCut,maxErrorCut,maxMoveCut,DOF);
-	     break;	    
-	   default:
-	     edm::LogInfo("AlignPCLThresholdsWriter")<<"Appending Extra degree of freeedom: "<< DOF <<" " << mapOntoEnum(DOF) << std::endl;
-	     AlignPCLThreshold::coordThresholds ExtraDOF;
-	     ExtraDOF.setThresholds(cutoff,sigCut,maxErrorCut,maxMoveCut,DOF);
-	     extraDOFs.push_back(ExtraDOF);
-	   }
-	 
-	 AlignPCLThreshold a(my_X,my_tX,my_Y,my_tY,my_Z,my_tZ,extraDOFs);
-	 myThresholds->setAlignPCLThreshold(alignableId,a);
-	 
-       } // if alignable is found in the PSet
-     } // loop on the PSets
+  for (auto& alignable : alignables) {
+    AlignPCLThreshold::coordThresholds my_X;
+    AlignPCLThreshold::coordThresholds my_Y;
+    AlignPCLThreshold::coordThresholds my_Z;
+    AlignPCLThreshold::coordThresholds my_tX;
+    AlignPCLThreshold::coordThresholds my_tY;
+    AlignPCLThreshold::coordThresholds my_tZ;
 
-     // checks if all mandatories are present
-     edm::LogInfo("AlignPCLThresholdsWriter")<<"Size of AlignPCLThresholds object  "<<myThresholds->size() <<std::endl;
-     for(auto& mandatory : mandatories){
-       if(std::find(presentDOF.begin(), presentDOF.end(), mandatory) == presentDOF.end()) {
-	 edm::LogWarning("AlignPCLThresholdsWriter")<<"Configuration for DOF: "<<mandatory<<" for alignable "<< alignable <<"is not present \n" 
-						    <<"Will build object with defaults!" <<std::endl;
-       }
-     }
+    std::vector<std::string> presentDOF;
 
-   } // ends loop on the alignable units
-   
-   // set the minimum number of records to be used in pede
-   myThresholds->setNRecords(m_minNrecords);
-   edm::LogInfo("AlignPCLThresholdsWriter")<<"Content of AlignPCLThresholds "<<std::endl;
+    // extra degrees of freedom
+    std::vector<AlignPCLThreshold::coordThresholds> extraDOFs = std::vector<AlignPCLThreshold::coordThresholds>();
 
-   // use buil-in method in the CondFormat
-   myThresholds->printAll();
+    for (auto& thePSet : m_parameters) {
+      const std::string alignableId(thePSet.getParameter<std::string>("alignableId"));
+      const std::string DOF(thePSet.getParameter<std::string>("DOF"));
 
-   // Form the data here
-   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-   if( poolDbService.isAvailable() ){
-     cond::Time_t valid_time = poolDbService->currentTime(); 
-     // this writes the payload to begin in current run defined in cfg
-     poolDbService->writeOne(myThresholds,valid_time, m_record);
-   }
+      const double cutoff(thePSet.getParameter<double>("cut"));
+      const double sigCut(thePSet.getParameter<double>("sigCut"));
+      const double maxMoveCut(thePSet.getParameter<double>("maxMoveCut"));
+      const double maxErrorCut(thePSet.getParameter<double>("maxErrorCut"));
+
+      if (alignableId == alignable) {
+        presentDOF.push_back(DOF);
+        // create the objects
+
+        switch (mapOntoEnum(DOF)) {
+          case DOFs::X:
+            my_X.setThresholds(cutoff, sigCut, maxErrorCut, maxMoveCut, DOF);
+            break;
+          case DOFs::Y:
+            my_Y.setThresholds(cutoff, sigCut, maxErrorCut, maxMoveCut, DOF);
+            break;
+          case DOFs::Z:
+            my_Z.setThresholds(cutoff, sigCut, maxErrorCut, maxMoveCut, DOF);
+            break;
+          case DOFs::thetaX:
+            my_tX.setThresholds(cutoff, sigCut, maxErrorCut, maxMoveCut, DOF);
+            break;
+          case DOFs::thetaY:
+            my_tY.setThresholds(cutoff, sigCut, maxErrorCut, maxMoveCut, DOF);
+            break;
+          case DOFs::thetaZ:
+            my_tZ.setThresholds(cutoff, sigCut, maxErrorCut, maxMoveCut, DOF);
+            break;
+          default:
+            edm::LogInfo("AlignPCLThresholdsWriter")
+                << "Appending Extra degree of freeedom: " << DOF << " " << mapOntoEnum(DOF) << std::endl;
+            AlignPCLThreshold::coordThresholds ExtraDOF;
+            ExtraDOF.setThresholds(cutoff, sigCut, maxErrorCut, maxMoveCut, DOF);
+            extraDOFs.push_back(ExtraDOF);
+        }
+
+        AlignPCLThreshold a(my_X, my_tX, my_Y, my_tY, my_Z, my_tZ, extraDOFs);
+        myThresholds->setAlignPCLThreshold(alignableId, a);
+
+      }  // if alignable is found in the PSet
+    }    // loop on the PSets
+
+    // checks if all mandatories are present
+    edm::LogInfo("AlignPCLThresholdsWriter")
+        << "Size of AlignPCLThresholds object  " << myThresholds->size() << std::endl;
+    for (auto& mandatory : mandatories) {
+      if (std::find(presentDOF.begin(), presentDOF.end(), mandatory) == presentDOF.end()) {
+        edm::LogWarning("AlignPCLThresholdsWriter")
+            << "Configuration for DOF: " << mandatory << " for alignable " << alignable << "is not present \n"
+            << "Will build object with defaults!" << std::endl;
+      }
+    }
+
+  }  // ends loop on the alignable units
+
+  // set the minimum number of records to be used in pede
+  myThresholds->setNRecords(m_minNrecords);
+  edm::LogInfo("AlignPCLThresholdsWriter") << "Content of AlignPCLThresholds " << std::endl;
+
+  // use buil-in method in the CondFormat
+  myThresholds->printAll();
+
+  // Form the data here
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  if (poolDbService.isAvailable()) {
+    cond::Time_t valid_time = poolDbService->currentTime();
+    // this writes the payload to begin in current run defined in cfg
+    poolDbService->writeOne(myThresholds, valid_time, m_record);
+  }
 }
-   
+
 // ------------ method called once each job just before starting event loop  ------------
-void 
-AlignPCLThresholdsWriter::beginJob()
-{
-}
+void AlignPCLThresholdsWriter::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-AlignPCLThresholdsWriter::endJob() 
-{
-}
+void AlignPCLThresholdsWriter::endJob() {}
 
-DOFs::dof AlignPCLThresholdsWriter::mapOntoEnum(std::string coord){
-  if( coord=="X" ){
+DOFs::dof AlignPCLThresholdsWriter::mapOntoEnum(std::string coord) {
+  if (coord == "X") {
     return DOFs::X;
-  } 
-  else if ( coord=="Y" ){
+  } else if (coord == "Y") {
     return DOFs::Y;
-  }
-  else if ( coord=="Z" ){
+  } else if (coord == "Z") {
     return DOFs::Z;
-  }
-  else if ( coord=="thetaX" ){
+  } else if (coord == "thetaX") {
     return DOFs::thetaX;
-  }
-  else if ( coord=="thetaY" ){
+  } else if (coord == "thetaY") {
     return DOFs::thetaY;
-  }
-  else if ( coord=="thetaZ" ){
+  } else if (coord == "thetaZ") {
     return DOFs::thetaZ;
-  } 
-  else {
+  } else {
     return DOFs::extraDOF;
   }
-  
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-AlignPCLThresholdsWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void AlignPCLThresholdsWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);

--- a/CondFormats/PCLConfig/src/AlignPCLThreshold.cc
+++ b/CondFormats/PCLConfig/src/AlignPCLThreshold.cc
@@ -1,40 +1,36 @@
 #include "CondFormats/PCLConfig/interface/AlignPCLThreshold.h"
-#include "FWCore/Utilities/interface/Exception.h" 
+#include "FWCore/Utilities/interface/Exception.h"
 
-AlignPCLThreshold:: AlignPCLThreshold(coordThresholds X,
-				      coordThresholds tX,
-				      coordThresholds Y,
-				      coordThresholds tY,
-				      coordThresholds Z, 
-				      coordThresholds tZ,
-				      std::vector< coordThresholds > extraDOF
-				      ){
-  m_xCoord      = X;	 
-  m_yCoord      = Y;
-  m_zCoord      = Z;	 
+AlignPCLThreshold::AlignPCLThreshold(coordThresholds X,
+                                     coordThresholds tX,
+                                     coordThresholds Y,
+                                     coordThresholds tY,
+                                     coordThresholds Z,
+                                     coordThresholds tZ,
+                                     std::vector<coordThresholds> extraDOF) {
+  m_xCoord = X;
+  m_yCoord = Y;
+  m_zCoord = Z;
   m_thetaXCoord = tX;
   m_thetaYCoord = tY;
   m_thetaZCoord = tZ;
-  m_extraDOF    = extraDOF;
-
+  m_extraDOF = extraDOF;
 };
 
 //****************************************************************************//
-std::array<float,4> AlignPCLThreshold::getExtraDOFCuts(const unsigned int i) const  { 
-  
-  if(i<m_extraDOF.size()){
-    return {{m_extraDOF[i].m_Cut,m_extraDOF[i].m_sigCut,m_extraDOF[i].m_errorCut,m_extraDOF[i].m_maxMoveCut}}; 
+std::array<float, 4> AlignPCLThreshold::getExtraDOFCuts(const unsigned int i) const {
+  if (i < m_extraDOF.size()) {
+    return {{m_extraDOF[i].m_Cut, m_extraDOF[i].m_sigCut, m_extraDOF[i].m_errorCut, m_extraDOF[i].m_maxMoveCut}};
   } else {
-    throw cms::Exception("AlignPCLThreshold")<< "No extra DOF thresholds defined for index" << i << "\n";
+    throw cms::Exception("AlignPCLThreshold") << "No extra DOF thresholds defined for index" << i << "\n";
   }
-}   
+}
 
 //****************************************************************************//
-std::string AlignPCLThreshold::getExtraDOFLabel(const unsigned int i) const  { 
-  
-  if(i<m_extraDOF.size()){
-    return m_extraDOF[i].m_label; 
+std::string AlignPCLThreshold::getExtraDOFLabel(const unsigned int i) const {
+  if (i < m_extraDOF.size()) {
+    return m_extraDOF[i].m_label;
   } else {
-    throw cms::Exception("AlignPCLThreshold")<< "No extra DOF label defined for index" << i << "\n";
+    throw cms::Exception("AlignPCLThreshold") << "No extra DOF label defined for index" << i << "\n";
   }
-}   
+}

--- a/CondFormats/PCLConfig/src/AlignPCLThresholds.cc
+++ b/CondFormats/PCLConfig/src/AlignPCLThresholds.cc
@@ -1,219 +1,237 @@
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
 #include "CondFormats/PCLConfig/interface/AlignPCLThreshold.h"
-#include "FWCore/Utilities/interface/Exception.h" 
+#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
-#include <iomanip>      // std::setw
+#include <iomanip>  // std::setw
 
 //****************************************************************************//
-void AlignPCLThresholds::setAlignPCLThreshold(const std::string &AlignableId, const AlignPCLThreshold & Threshold) {
-  m_thresholds[AlignableId]=Threshold;
+void AlignPCLThresholds::setAlignPCLThreshold(const std::string &AlignableId, const AlignPCLThreshold &Threshold) {
+  m_thresholds[AlignableId] = Threshold;
 }
 
 //****************************************************************************//
-void AlignPCLThresholds::setAlignPCLThresholds(const int & Nrecords,const threshold_map & AlignPCLThresholds){
-  m_nrecords=Nrecords;
-  m_thresholds=AlignPCLThresholds;
+void AlignPCLThresholds::setAlignPCLThresholds(const int &Nrecords, const threshold_map &AlignPCLThresholds) {
+  m_nrecords = Nrecords;
+  m_thresholds = AlignPCLThresholds;
 }
 
 //****************************************************************************//
-void AlignPCLThresholds::setNRecords(const int &Nrecords){
-  m_nrecords=Nrecords;
-}
+void AlignPCLThresholds::setNRecords(const int &Nrecords) { m_nrecords = Nrecords; }
 
 //****************************************************************************//
 AlignPCLThreshold AlignPCLThresholds::getAlignPCLThreshold(const std::string &AlignableId) const {
   threshold_map::const_iterator it = m_thresholds.find(AlignableId);
 
-  if (it != m_thresholds.end()){
+  if (it != m_thresholds.end()) {
     return it->second;
   } else {
-    throw cms::Exception("AlignPCLThresholds")<< "No Thresholds defined for Alignable id " << AlignableId << "\n";
+    throw cms::Exception("AlignPCLThresholds") << "No Thresholds defined for Alignable id " << AlignableId << "\n";
   }
 }
 
 //****************************************************************************//
-AlignPCLThreshold& AlignPCLThresholds::getAlignPCLThreshold(const std::string &AlignableId) {
+AlignPCLThreshold &AlignPCLThresholds::getAlignPCLThreshold(const std::string &AlignableId) {
   return m_thresholds[AlignableId];
 }
 
-float AlignPCLThresholds::getSigCut(const std::string &AlignableId,const coordType &type) const {
+float AlignPCLThresholds::getSigCut(const std::string &AlignableId, const coordType &type) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
-  switch(type){
-  case X:
-    return a.getSigXcut();
-  case Y:
-    return a.getSigYcut();
-  case Z:
-    return a.getSigZcut();
-  case theta_X:
-    return a.getSigThetaXcut();
-  case theta_Y:
-    return a.getSigThetaYcut();
-  case theta_Z:
-    return a.getSigThetaZcut();
-  default:
-    throw cms::Exception("AlignPCLThresholds")<<"Requested significance threshold for undefined coordinate"<< type << "\n";
+  switch (type) {
+    case X:
+      return a.getSigXcut();
+    case Y:
+      return a.getSigYcut();
+    case Z:
+      return a.getSigZcut();
+    case theta_X:
+      return a.getSigThetaXcut();
+    case theta_Y:
+      return a.getSigThetaYcut();
+    case theta_Z:
+      return a.getSigThetaZcut();
+    default:
+      throw cms::Exception("AlignPCLThresholds")
+          << "Requested significance threshold for undefined coordinate" << type << "\n";
   }
 }
 
 //****************************************************************************//
 // overloaded method
 //****************************************************************************//
-std::array<float,6> AlignPCLThresholds::getSigCut(const std::string &AlignableId) const {
+std::array<float, 6> AlignPCLThresholds::getSigCut(const std::string &AlignableId) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
-  return {{a.getSigXcut(),a.getSigYcut(), a.getSigZcut(), a.getSigThetaXcut(), a.getSigThetaYcut(),a.getSigThetaZcut()}};
+  return {
+      {a.getSigXcut(), a.getSigYcut(), a.getSigZcut(), a.getSigThetaXcut(), a.getSigThetaYcut(), a.getSigThetaZcut()}};
 }
 
-float AlignPCLThresholds::getCut(const std::string &AlignableId,const coordType &type) const {
+float AlignPCLThresholds::getCut(const std::string &AlignableId, const coordType &type) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
-  switch(type){
-  case X:
-    return a.getXcut();
-  case Y:
-    return a.getYcut();
-  case Z:
-    return a.getZcut();
-  case theta_X:
-    return a.getThetaXcut();
-  case theta_Y:
-    return a.getThetaYcut();
-  case theta_Z:
-    return a.getThetaZcut();
-  default:
-    throw cms::Exception("AlignPCLThresholds")<<"Requested significance threshold for undefined coordinate"<< type << "\n";
+  switch (type) {
+    case X:
+      return a.getXcut();
+    case Y:
+      return a.getYcut();
+    case Z:
+      return a.getZcut();
+    case theta_X:
+      return a.getThetaXcut();
+    case theta_Y:
+      return a.getThetaYcut();
+    case theta_Z:
+      return a.getThetaZcut();
+    default:
+      throw cms::Exception("AlignPCLThresholds")
+          << "Requested significance threshold for undefined coordinate" << type << "\n";
   }
 }
 
 //****************************************************************************//
 // overloaded method
 //****************************************************************************//
-std::array<float,6> AlignPCLThresholds::getCut(const std::string &AlignableId) const {
+std::array<float, 6> AlignPCLThresholds::getCut(const std::string &AlignableId) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
-  return {{a.getXcut(),a.getYcut(), a.getZcut(), a.getThetaXcut(), a.getThetaYcut(),a.getThetaZcut()}};
+  return {{a.getXcut(), a.getYcut(), a.getZcut(), a.getThetaXcut(), a.getThetaYcut(), a.getThetaZcut()}};
 }
 
 //****************************************************************************//
-float AlignPCLThresholds::getMaxMoveCut(const std::string &AlignableId,const coordType &type) const {
+float AlignPCLThresholds::getMaxMoveCut(const std::string &AlignableId, const coordType &type) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
-  switch(type){
-  case X:
-    return a.getMaxMoveXcut();
-  case Y:
-    return a.getMaxMoveYcut();
-  case Z:
-    return a.getMaxMoveZcut();
-  case theta_X:
-    return a.getMaxMoveThetaXcut();
-  case theta_Y:
-    return a.getMaxMoveThetaYcut();
-  case theta_Z:
-    return a.getMaxMoveThetaZcut();
-  default:
-    throw cms::Exception("AlignPCLThresholds")<<"Requested significance threshold for undefined coordinate"<< type << "\n";
+  switch (type) {
+    case X:
+      return a.getMaxMoveXcut();
+    case Y:
+      return a.getMaxMoveYcut();
+    case Z:
+      return a.getMaxMoveZcut();
+    case theta_X:
+      return a.getMaxMoveThetaXcut();
+    case theta_Y:
+      return a.getMaxMoveThetaYcut();
+    case theta_Z:
+      return a.getMaxMoveThetaZcut();
+    default:
+      throw cms::Exception("AlignPCLThresholds")
+          << "Requested significance threshold for undefined coordinate" << type << "\n";
   }
 }
 
 //****************************************************************************//
 // overloaded method
 //****************************************************************************//
-std::array<float,6> AlignPCLThresholds::getMaxMoveCut(const std::string &AlignableId) const {
+std::array<float, 6> AlignPCLThresholds::getMaxMoveCut(const std::string &AlignableId) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
-  return {{a.getMaxMoveXcut(),a.getMaxMoveYcut(), a.getMaxMoveZcut(), a.getMaxMoveThetaXcut(), a.getMaxMoveThetaYcut(),a.getMaxMoveThetaZcut()}};
+  return {{a.getMaxMoveXcut(),
+           a.getMaxMoveYcut(),
+           a.getMaxMoveZcut(),
+           a.getMaxMoveThetaXcut(),
+           a.getMaxMoveThetaYcut(),
+           a.getMaxMoveThetaZcut()}};
 }
 
 //****************************************************************************//
-float AlignPCLThresholds::getMaxErrorCut(const std::string &AlignableId,const coordType &type) const {
+float AlignPCLThresholds::getMaxErrorCut(const std::string &AlignableId, const coordType &type) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
-   switch(type){
-   case X:
-     return a.getErrorXcut();
-   case Y:
-     return a.getErrorYcut();
-   case Z:
-     return a.getErrorZcut();
-   case theta_X:
-     return a.getErrorThetaXcut();
-   case theta_Y:
-     return a.getErrorThetaYcut();
-   case theta_Z:
-     return a.getErrorThetaZcut();
-   default:
-     throw cms::Exception("AlignPCLThresholds")<<"Requested significance threshold for undefined coordinate"<< type << "\n";
-   }
+  switch (type) {
+    case X:
+      return a.getErrorXcut();
+    case Y:
+      return a.getErrorYcut();
+    case Z:
+      return a.getErrorZcut();
+    case theta_X:
+      return a.getErrorThetaXcut();
+    case theta_Y:
+      return a.getErrorThetaYcut();
+    case theta_Z:
+      return a.getErrorThetaZcut();
+    default:
+      throw cms::Exception("AlignPCLThresholds")
+          << "Requested significance threshold for undefined coordinate" << type << "\n";
+  }
 }
 
 //****************************************************************************//
 // overloaded method
 //****************************************************************************//
-std::array<float,6> AlignPCLThresholds::getMaxErrorCut(const std::string &AlignableId) const {
+std::array<float, 6> AlignPCLThresholds::getMaxErrorCut(const std::string &AlignableId) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
-  return {{a.getErrorXcut(),a.getErrorYcut(), a.getErrorZcut(), a.getErrorThetaXcut(), a.getErrorThetaYcut(),a.getErrorThetaZcut()}};
+  return {{a.getErrorXcut(),
+           a.getErrorYcut(),
+           a.getErrorZcut(),
+           a.getErrorThetaXcut(),
+           a.getErrorThetaYcut(),
+           a.getErrorThetaZcut()}};
 }
 
 //****************************************************************************//
-std::array<float,4> AlignPCLThresholds::getExtraDOFCutsForAlignable(const std::string &AlignableId,const unsigned int i) const {
+std::array<float, 4> AlignPCLThresholds::getExtraDOFCutsForAlignable(const std::string &AlignableId,
+                                                                     const unsigned int i) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
   return a.getExtraDOFCuts(i);
 }
 
 //****************************************************************************//
-std::string AlignPCLThresholds::getExtraDOFLabelForAlignable(const std::string &AlignableId,const unsigned int i) const
-{
+std::string AlignPCLThresholds::getExtraDOFLabelForAlignable(const std::string &AlignableId,
+                                                             const unsigned int i) const {
   AlignPCLThreshold a = getAlignPCLThreshold(AlignableId);
   return a.getExtraDOFLabel(i);
 }
 
 //****************************************************************************//
 void AlignPCLThresholds::printAll() const {
-  
-  edm::LogVerbatim("AlignPCLThresholds")<<"AlignPCLThresholds::printAll()";
-  edm::LogVerbatim("AlignPCLThresholds")<<" ===================================================================================================================";
-  edm::LogVerbatim("AlignPCLThresholds")<<"N records cut: "<<this->getNrecords();    
-  for(auto it = m_thresholds.begin(); it != m_thresholds.end() ; ++it){
-    edm::LogVerbatim("AlignPCLThresholds")<<" ===================================================================================================================";
-    edm::LogVerbatim("AlignPCLThresholds")<<"key : " << it->first <<" \n"
-					  <<"- Xcut             : " <<std::setw(4)<< (it->second).getXcut()            <<std::setw(5)<<"   um" 
-					  <<"| sigXcut          : " <<std::setw(4)<< (it->second).getSigXcut()         <<std::setw(1)<<" "
-					  <<"| maxMoveXcut      : " <<std::setw(4)<< (it->second).getMaxMoveXcut()     <<std::setw(5)<<"   um"
-					  <<"| ErrorXcut        : " <<std::setw(4)<< (it->second).getErrorXcut()       <<std::setw(5)<<"   um\n" 
-      
-					  <<"- thetaXcut        : " <<std::setw(4)<< (it->second).getThetaXcut()       <<std::setw(5)<<" urad" 
-					  <<"| sigThetaXcut     : " <<std::setw(4)<< (it->second).getSigThetaXcut()    <<std::setw(1)<<" "
-					  <<"| maxMoveThetaXcut : " <<std::setw(4)<< (it->second).getMaxMoveThetaXcut()<<std::setw(5)<<" urad"
-					  <<"| ErrorThetaXcut   : " <<std::setw(4)<< (it->second).getErrorThetaXcut()  <<std::setw(5)<<" urad\n" 
-      
-					  <<"- Ycut             : " <<std::setw(4)<< (it->second).getYcut()            <<std::setw(5)<<"   um"  
-					  <<"| sigYcut          : " <<std::setw(4)<< (it->second).getSigXcut()         <<std::setw(1)<<" "
-					  <<"| maxMoveYcut      : " <<std::setw(4)<< (it->second).getMaxMoveYcut()     <<std::setw(5)<<"   um"
-					  <<"| ErrorYcut        : " <<std::setw(4)<< (it->second).getErrorYcut()       <<std::setw(5)<<"   um\n" 
-      
-					  <<"- thetaYcut        : " <<std::setw(4)<< (it->second).getThetaYcut()       <<std::setw(5)<<" urad" 
-					  <<"| sigThetaYcut     : " <<std::setw(4)<< (it->second).getSigThetaYcut()    <<std::setw(1)<<" "
-					  <<"| maxMoveThetaYcut : " <<std::setw(4)<< (it->second).getMaxMoveThetaYcut()<<std::setw(5)<<" urad"
-					  <<"| ErrorThetaYcut   : " <<std::setw(4)<< (it->second).getErrorThetaYcut()  <<std::setw(5)<<" urad\n" 
-      
-					  <<"- Zcut             : " <<std::setw(4)<< (it->second).getZcut()            <<std::setw(5)<<"   um"	     
-					  <<"| sigZcut          : " <<std::setw(4)<< (it->second).getSigZcut()         <<std::setw(1)<<" "	     
-					  <<"| maxMoveZcut      : " <<std::setw(4)<< (it->second).getMaxMoveZcut()     <<std::setw(5)<<"   um"	     
-					  <<"| ErrorZcut        : " <<std::setw(4)<< (it->second).getErrorZcut()       <<std::setw(5)<<"   um\n" 
-      
-					  <<"- thetaZcut        : " <<std::setw(4)<< (it->second).getThetaZcut()       <<std::setw(5)<<" urad" 
-					  <<"| sigThetaZcut     : " <<std::setw(4)<< (it->second).getSigThetaZcut()    <<std::setw(1)<<" "
-					  <<"| maxMoveThetaZcut : " <<std::setw(4)<< (it->second).getMaxMoveThetaZcut()<<std::setw(5)<<" urad"
-					  <<"| ErrorThetaZcut   : " <<std::setw(4)<< (it->second).getErrorThetaZcut()  <<std::setw(5)<<" urad";
-    
-    if((it->second).hasExtraDOF()){
-      for (unsigned int j=0; j<(it->second).extraDOFSize(); j++){
-	std::array<float,4> extraDOFCuts = getExtraDOFCutsForAlignable(it->first,j);
-	
-	edm::LogVerbatim("AlignPCLThresholds")<<"Extra DOF " << j << " with label: "<<getExtraDOFLabelForAlignable(it->first,j);	  
-	edm::LogVerbatim("AlignPCLThresholds") <<"- cut              : " << std::setw(4) << extraDOFCuts.at(0) << std::setw(5)<<"    "
-					       <<"| sigCut           : " << std::setw(4) << extraDOFCuts.at(1) << std::setw(1)<<" "
-					       <<"| maxMoveCut       : " << std::setw(4) << extraDOFCuts.at(2) << std::setw(5)<<"    "
-					       <<"| maxErrorCut      : " << std::setw(4) << extraDOFCuts.at(3) << std::setw(5)<<"    ";
+  edm::LogVerbatim("AlignPCLThresholds") << "AlignPCLThresholds::printAll()";
+  edm::LogVerbatim("AlignPCLThresholds") << " ========================================================================="
+                                            "==========================================";
+  edm::LogVerbatim("AlignPCLThresholds") << "N records cut: " << this->getNrecords();
+  for (auto it = m_thresholds.begin(); it != m_thresholds.end(); ++it) {
+    edm::LogVerbatim("AlignPCLThresholds") << " ======================================================================="
+                                              "============================================";
+    edm::LogVerbatim("AlignPCLThresholds")
+        << "key : " << it->first << " \n"
+        << "- Xcut             : " << std::setw(4) << (it->second).getXcut() << std::setw(5) << "   um"
+        << "| sigXcut          : " << std::setw(4) << (it->second).getSigXcut() << std::setw(1) << " "
+        << "| maxMoveXcut      : " << std::setw(4) << (it->second).getMaxMoveXcut() << std::setw(5) << "   um"
+        << "| ErrorXcut        : " << std::setw(4) << (it->second).getErrorXcut() << std::setw(5) << "   um\n"
+
+        << "- thetaXcut        : " << std::setw(4) << (it->second).getThetaXcut() << std::setw(5) << " urad"
+        << "| sigThetaXcut     : " << std::setw(4) << (it->second).getSigThetaXcut() << std::setw(1) << " "
+        << "| maxMoveThetaXcut : " << std::setw(4) << (it->second).getMaxMoveThetaXcut() << std::setw(5) << " urad"
+        << "| ErrorThetaXcut   : " << std::setw(4) << (it->second).getErrorThetaXcut() << std::setw(5) << " urad\n"
+
+        << "- Ycut             : " << std::setw(4) << (it->second).getYcut() << std::setw(5) << "   um"
+        << "| sigYcut          : " << std::setw(4) << (it->second).getSigXcut() << std::setw(1) << " "
+        << "| maxMoveYcut      : " << std::setw(4) << (it->second).getMaxMoveYcut() << std::setw(5) << "   um"
+        << "| ErrorYcut        : " << std::setw(4) << (it->second).getErrorYcut() << std::setw(5) << "   um\n"
+
+        << "- thetaYcut        : " << std::setw(4) << (it->second).getThetaYcut() << std::setw(5) << " urad"
+        << "| sigThetaYcut     : " << std::setw(4) << (it->second).getSigThetaYcut() << std::setw(1) << " "
+        << "| maxMoveThetaYcut : " << std::setw(4) << (it->second).getMaxMoveThetaYcut() << std::setw(5) << " urad"
+        << "| ErrorThetaYcut   : " << std::setw(4) << (it->second).getErrorThetaYcut() << std::setw(5) << " urad\n"
+
+        << "- Zcut             : " << std::setw(4) << (it->second).getZcut() << std::setw(5) << "   um"
+        << "| sigZcut          : " << std::setw(4) << (it->second).getSigZcut() << std::setw(1) << " "
+        << "| maxMoveZcut      : " << std::setw(4) << (it->second).getMaxMoveZcut() << std::setw(5) << "   um"
+        << "| ErrorZcut        : " << std::setw(4) << (it->second).getErrorZcut() << std::setw(5) << "   um\n"
+
+        << "- thetaZcut        : " << std::setw(4) << (it->second).getThetaZcut() << std::setw(5) << " urad"
+        << "| sigThetaZcut     : " << std::setw(4) << (it->second).getSigThetaZcut() << std::setw(1) << " "
+        << "| maxMoveThetaZcut : " << std::setw(4) << (it->second).getMaxMoveThetaZcut() << std::setw(5) << " urad"
+        << "| ErrorThetaZcut   : " << std::setw(4) << (it->second).getErrorThetaZcut() << std::setw(5) << " urad";
+
+    if ((it->second).hasExtraDOF()) {
+      for (unsigned int j = 0; j < (it->second).extraDOFSize(); j++) {
+        std::array<float, 4> extraDOFCuts = getExtraDOFCutsForAlignable(it->first, j);
+
+        edm::LogVerbatim("AlignPCLThresholds")
+            << "Extra DOF " << j << " with label: " << getExtraDOFLabelForAlignable(it->first, j);
+        edm::LogVerbatim("AlignPCLThresholds")
+            << "- cut              : " << std::setw(4) << extraDOFCuts.at(0) << std::setw(5) << "    "
+            << "| sigCut           : " << std::setw(4) << extraDOFCuts.at(1) << std::setw(1) << " "
+            << "| maxMoveCut       : " << std::setw(4) << extraDOFCuts.at(2) << std::setw(5) << "    "
+            << "| maxErrorCut      : " << std::setw(4) << extraDOFCuts.at(3) << std::setw(5) << "    ";
       }
-    }	
+    }
   }
 }
 
@@ -222,7 +240,7 @@ std::vector<std::string> AlignPCLThresholds::getAlignableList() const {
   std::vector<std::string> alignables_;
   alignables_.reserve(m_thresholds.size());
 
-  for(auto it = m_thresholds.begin(); it != m_thresholds.end() ; ++it){
+  for (auto it = m_thresholds.begin(); it != m_thresholds.end(); ++it) {
     alignables_.push_back(it->first);
   }
   return alignables_;

--- a/CondFormats/PCLConfig/src/classes.h
+++ b/CondFormats/PCLConfig/src/classes.h
@@ -1,7 +1,7 @@
 #include "CondFormats/PCLConfig/src/headers.h"
 
-namespace CondFormats_AlignPCLThresholds{
+namespace CondFormats_AlignPCLThresholds {
   struct dictionary {
-    std::map<unsigned int,AlignPCLThreshold> mythresholdmap;
-  };  
-}
+    std::map<unsigned int, AlignPCLThreshold> mythresholdmap;
+  };
+}  // namespace CondFormats_AlignPCLThresholds

--- a/CondFormats/PCLConfig/src/headers.h
+++ b/CondFormats/PCLConfig/src/headers.h
@@ -1,1 +1,1 @@
-#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h" 
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"

--- a/CondFormats/PCLConfig/test/testSerializationPCLConfig.cpp
+++ b/CondFormats/PCLConfig/test/testSerializationPCLConfig.cpp
@@ -2,8 +2,7 @@
 
 #include "CondFormats/PCLConfig/src/headers.h"
 
-int main()
-{
+int main() {
   testSerialization<AlignPCLThresholds>();
   testSerialization<std::vector<AlignPCLThreshold>>();
   //testSerialization<std::vector<AlignPCLThreshold::coordThresholds>>();

--- a/CondFormats/RecoMuonObjects/interface/DYTParamObject.h
+++ b/CondFormats/RecoMuonObjects/interface/DYTParamObject.h
@@ -1,34 +1,30 @@
 #ifndef DytParamObject_h
 #define DytParamObject_h
 
-#include<vector>
+#include <vector>
 #include "DataFormats/DetId/interface/DetId.h"
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 class DYTParamObject {
- public:
-  
-  DYTParamObject() { };
-  DYTParamObject(uint32_t id, std::vector<double> & params) 
-    : m_id(id) , m_params(params) { };
+public:
+  DYTParamObject(){};
+  DYTParamObject(uint32_t id, std::vector<double>& params) : m_id(id), m_params(params){};
   ~DYTParamObject() { m_params.clear(); };
-  
+
   // Return raw id
-  uint32_t id() const {return m_id;};
+  uint32_t id() const { return m_id; };
 
   // Return param i (i from 0 to size-1)
   double parameter(unsigned int iParam) const;
-  
+
   // Return param vector size (i from 0 to size-1)
   unsigned int paramSize() const { return m_params.size(); };
-  
- private:
 
+private:
   uint32_t m_id;
   std::vector<double> m_params;
 
   COND_SERIALIZABLE;
-
 };
 
 #endif

--- a/CondFormats/RecoMuonObjects/interface/DYTParamsObject.h
+++ b/CondFormats/RecoMuonObjects/interface/DYTParamsObject.h
@@ -6,25 +6,23 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 class DYTParamsObject {
- public:
-
-  DYTParamsObject() {};
+public:
+  DYTParamsObject(){};
   ~DYTParamsObject() { m_paramObjs.clear(); };
 
   // Add a parameter to the vector of parameters
-  void addParamObject(const DYTParamObject & obj) { m_paramObjs.push_back(obj); };
+  void addParamObject(const DYTParamObject& obj) { m_paramObjs.push_back(obj); };
 
-  // Set the parametrized formula                                                                                                                                                                            
-  void  setFormula(std::string formula) { m_formula = formula; };
+  // Set the parametrized formula
+  void setFormula(std::string formula) { m_formula = formula; };
 
   // Get the list of parameters
-  const std::vector<DYTParamObject> & getParamObjs() const { return m_paramObjs; };
+  const std::vector<DYTParamObject>& getParamObjs() const { return m_paramObjs; };
 
-  // Get the functional parametrization                                                                                                                                                                    
-  const std::string & formula() const { return m_formula; };
+  // Get the functional parametrization
+  const std::string& formula() const { return m_formula; };
 
- private:
-  
+private:
   std::vector<DYTParamObject> m_paramObjs;
 
   std::string m_formula;

--- a/CondFormats/RecoMuonObjects/interface/DYTThrObject.h
+++ b/CondFormats/RecoMuonObjects/interface/DYTThrObject.h
@@ -3,17 +3,16 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 class DYTThrObject {
- public:
-
+public:
   struct DytThrStruct {
-    DetId  id;
+    DetId id;
     double thr;
 
     COND_SERIALIZABLE;
   };
 
-  DYTThrObject(){}
-  ~DYTThrObject(){}
+  DYTThrObject() {}
+  ~DYTThrObject() {}
   std::vector<DytThrStruct> thrsVec;
 
   COND_SERIALIZABLE;

--- a/CondFormats/RecoMuonObjects/interface/MuScleFitDBobject.h
+++ b/CondFormats/RecoMuonObjects/interface/MuScleFitDBobject.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-struct MuScleFitDBobject
-{
+struct MuScleFitDBobject {
   std::vector<int> identifiers;
   std::vector<double> parameters;
   std::vector<double> fitQuality;
@@ -14,4 +13,4 @@ struct MuScleFitDBobject
   COND_SERIALIZABLE;
 };
 
-#endif // MuScleFitDBobject
+#endif  // MuScleFitDBobject

--- a/CondFormats/RecoMuonObjects/interface/MuonSystemAging.h
+++ b/CondFormats/RecoMuonObjects/interface/MuonSystemAging.h
@@ -2,36 +2,27 @@
 #define MuonSystemAging_H
 
 #include "CondFormats/Serialization/interface/Serializable.h"
-#include<cmath>
-#include<iostream>
+#include <cmath>
+#include <iostream>
 #include <vector>
 #include <regex>
 #include <map>
 
-enum CSCInefficiencyType 
-  { 
-    EFF_CHAMBER=0, 
-    EFF_STRIPS=1,
-    EFF_WIRES=2 
-  };
+enum CSCInefficiencyType { EFF_CHAMBER = 0, EFF_STRIPS = 1, EFF_WIRES = 2 };
 
-class MuonSystemAging 
-{
+class MuonSystemAging {
+public:
+  MuonSystemAging(){};
+  ~MuonSystemAging(){};
 
- public:
+  std::map<unsigned int, float> m_RPCChambEffs;
+  std::map<unsigned int, float> m_DTChambEffs;
+  std::map<unsigned int, std::pair<unsigned int, float> > m_CSCChambEffs;
 
-  MuonSystemAging() { };
-  ~MuonSystemAging() { };
+  std::map<unsigned int, float> m_GEMChambEffs;
+  std::map<unsigned int, float> m_ME0ChambEffs;
 
-  std::map<unsigned int, float>  m_RPCChambEffs;
-  std::map<unsigned int, float>  m_DTChambEffs;
-  std::map<unsigned int, std::pair<unsigned int, float> >  m_CSCChambEffs;
-
-  std::map<unsigned int, float>  m_GEMChambEffs;
-  std::map<unsigned int, float>  m_ME0ChambEffs;
-  
   COND_SERIALIZABLE;
-
 };
 
 #endif

--- a/CondFormats/RecoMuonObjects/src/DYTParamObject.cc
+++ b/CondFormats/RecoMuonObjects/src/DYTParamObject.cc
@@ -1,17 +1,12 @@
 #include "CondFormats/RecoMuonObjects/interface/DYTParamObject.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-double DYTParamObject::parameter(unsigned int iParam) const
-{
-  
-  if (iParam >= paramSize())
-    {
-      edm::LogWarning("DYTParamObject") 
-	<< "The requested parameter (" << (iParam + 1) 
-	<< ") is outside size range (" << paramSize() << ").";
-      return 0.;
-    }
+double DYTParamObject::parameter(unsigned int iParam) const {
+  if (iParam >= paramSize()) {
+    edm::LogWarning("DYTParamObject") << "The requested parameter (" << (iParam + 1) << ") is outside size range ("
+                                      << paramSize() << ").";
+    return 0.;
+  }
 
   return m_params.at(iParam);
-
 }

--- a/CondFormats/RecoMuonObjects/src/T_EventSetup_DYTParamsObject.cc
+++ b/CondFormats/RecoMuonObjects/src/T_EventSetup_DYTParamsObject.cc
@@ -2,4 +2,3 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(DYTParamsObject);
-

--- a/CondFormats/RecoMuonObjects/src/T_EventSetup_DYTThrObject.cc
+++ b/CondFormats/RecoMuonObjects/src/T_EventSetup_DYTThrObject.cc
@@ -1,4 +1,3 @@
 #include "CondFormats/RecoMuonObjects/interface/DYTThrObject.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 TYPELOOKUP_DATA_REG(DYTThrObject);
-

--- a/CondFormats/RecoMuonObjects/src/classes.h
+++ b/CondFormats/RecoMuonObjects/src/classes.h
@@ -6,4 +6,4 @@ namespace CondFormats_RecoMuonObjects {
     MuScleFitDBobject e;
     DYTParamsObject g;
   };
-}
+}  // namespace CondFormats_RecoMuonObjects

--- a/CondFormats/RunInfo/interface/FillInfo.h
+++ b/CondFormats/RunInfo/interface/FillInfo.h
@@ -11,141 +11,141 @@
 #include <vector>
 
 class FillInfo {
- public:
+public:
   enum FillType { UNKNOWN = 0, PROTONS = 1, IONS = 2, COSMICS = 3, GAP = 4 };
   enum ParticleType { NONE = 0, PROTON = 1, PB82 = 2, AR18 = 3, D = 4, XE54 = 5 };
   typedef FillType FillTypeId;
   typedef ParticleType ParticleTypeId;
   FillInfo();
-  FillInfo( unsigned short const & lhcFill, bool const & fromData = true );
+  FillInfo(unsigned short const &lhcFill, bool const &fromData = true);
   ~FillInfo();
-  
+
   //constant static unsigned integer hosting the maximum number of LHC bunch slots
   static size_t const bunchSlots = 3564;
-  
+
   //constant static unsigned integer hosting the available number of LHC bunch slots
   static size_t const availableBunchSlots = 2808;
-  
+
   //reset instance
-  void setFill( unsigned short const & lhcFill, bool const & fromData = true );
-  
+  void setFill(unsigned short const &lhcFill, bool const &fromData = true);
+
   //getters
   unsigned short const fillNumber() const;
-  
+
   bool const isData() const;
-  
+
   unsigned short const bunchesInBeam1() const;
-  
+
   unsigned short const bunchesInBeam2() const;
-  
+
   unsigned short const collidingBunches() const;
-  
+
   unsigned short const targetBunches() const;
-  
+
   FillTypeId const fillType() const;
-  
+
   ParticleTypeId const particleTypeForBeam1() const;
-  
+
   ParticleTypeId const particleTypeForBeam2() const;
-  
+
   float const crossingAngle() const;
 
   float const betaStar() const;
-  
+
   float const intensityForBeam1() const;
-  
+
   float const intensityForBeam2() const;
-  
+
   float const energy() const;
-  
+
   cond::Time_t const createTime() const;
-  
+
   cond::Time_t const beginTime() const;
-  
+
   cond::Time_t const endTime() const;
-  
-  std::string const & injectionScheme() const;
+
+  std::string const &injectionScheme() const;
 
   //returns a boolean, true if the injection scheme has a leading 25ns
   //TODO: parse the circulating bunch configuration, instead of the string.
   bool is25nsBunchSpacing() const;
 
   //returns a boolean, true if the bunch slot number is in the circulating bunch configuration
-  bool isBunchInBeam1( size_t const & bunch ) const;
-  
-  bool isBunchInBeam2( size_t const & bunch ) const;
-  
+  bool isBunchInBeam1(size_t const &bunch) const;
+
+  bool isBunchInBeam2(size_t const &bunch) const;
+
   //member functions returning *by value* a vector with all filled bunch slots
   std::vector<unsigned short> bunchConfigurationForBeam1() const;
-  
+
   std::vector<unsigned short> bunchConfigurationForBeam2() const;
-  
+
   //setters
-  void setBunchesInBeam1( unsigned short const & bunches );
-  
-  void setBunchesInBeam2( unsigned short const & bunches );
-  
-  void setCollidingBunches( unsigned short const & collidingBunches );
-  
-  void setTargetBunches( unsigned short const & targetBunches );
-  
-  void setFillType( FillTypeId const & fillType );
-  
-  void setParticleTypeForBeam1( ParticleTypeId const & particleType );
-  
-  void setParticleTypeForBeam2( ParticleTypeId const & particleType );
-  
-  void setCrossingAngle( float const & angle );
-  
-  void setBetaStar( float const & betaStar );
-  
-  void setIntensityForBeam1( float const & intensity );
-  
-  void setIntensityForBeam2( float const & intensity );
-  
-  void setEnergy( float const & energy );
-  
-  void setCreationTime( cond::Time_t const & createTime );
-  
-  void setBeginTime( cond::Time_t const & beginTime );
-  
-  void setEndTime( cond::Time_t const & endTime );
-  
-  void setInjectionScheme( std::string const & injectionScheme );
-  
+  void setBunchesInBeam1(unsigned short const &bunches);
+
+  void setBunchesInBeam2(unsigned short const &bunches);
+
+  void setCollidingBunches(unsigned short const &collidingBunches);
+
+  void setTargetBunches(unsigned short const &targetBunches);
+
+  void setFillType(FillTypeId const &fillType);
+
+  void setParticleTypeForBeam1(ParticleTypeId const &particleType);
+
+  void setParticleTypeForBeam2(ParticleTypeId const &particleType);
+
+  void setCrossingAngle(float const &angle);
+
+  void setBetaStar(float const &betaStar);
+
+  void setIntensityForBeam1(float const &intensity);
+
+  void setIntensityForBeam2(float const &intensity);
+
+  void setEnergy(float const &energy);
+
+  void setCreationTime(cond::Time_t const &createTime);
+
+  void setBeginTime(cond::Time_t const &beginTime);
+
+  void setEndTime(cond::Time_t const &endTime);
+
+  void setInjectionScheme(std::string const &injectionScheme);
+
   //sets all values in one go
-  void setBeamInfo( unsigned short const & bunches1
-		    ,unsigned short const & bunches2
-		    ,unsigned short const & collidingBunches
-		    ,unsigned short const & targetBunches
-		    ,FillTypeId const & fillType
-		    ,ParticleTypeId const & particleType1
-		    ,ParticleTypeId const & particleType2
-		    ,float const & angle
-		    ,float const & beta
-		    ,float const & intensity1
-		    ,float const & intensity2
-		    ,float const & energy
-		    ,cond::Time_t const & createTime
-		    ,cond::Time_t const & beginTime
-		    ,cond::Time_t const & endTime
-		    ,std::string const & scheme
-		    ,std::bitset<bunchSlots+1> const & bunchConf1 
-		    ,std::bitset<bunchSlots+1> const & bunchConf2 );
-  
+  void setBeamInfo(unsigned short const &bunches1,
+                   unsigned short const &bunches2,
+                   unsigned short const &collidingBunches,
+                   unsigned short const &targetBunches,
+                   FillTypeId const &fillType,
+                   ParticleTypeId const &particleType1,
+                   ParticleTypeId const &particleType2,
+                   float const &angle,
+                   float const &beta,
+                   float const &intensity1,
+                   float const &intensity2,
+                   float const &energy,
+                   cond::Time_t const &createTime,
+                   cond::Time_t const &beginTime,
+                   cond::Time_t const &endTime,
+                   std::string const &scheme,
+                   std::bitset<bunchSlots + 1> const &bunchConf1,
+                   std::bitset<bunchSlots + 1> const &bunchConf2);
+
   //dumping values on output stream
-  void print(std::stringstream & ss) const;
-  
- protected:
-  std::bitset<bunchSlots+1> const & bunchBitsetForBeam1() const;
-  
-  std::bitset<bunchSlots+1> const & bunchBitsetForBeam2() const;
-  
-  void setBunchBitsetForBeam1( std::bitset<bunchSlots+1> const & bunchConfiguration );
-  
-  void setBunchBitsetForBeam2( std::bitset<bunchSlots+1> const & bunchConfiguration );
-  
- private:
+  void print(std::stringstream &ss) const;
+
+protected:
+  std::bitset<bunchSlots + 1> const &bunchBitsetForBeam1() const;
+
+  std::bitset<bunchSlots + 1> const &bunchBitsetForBeam2() const;
+
+  void setBunchBitsetForBeam1(std::bitset<bunchSlots + 1> const &bunchConfiguration);
+
+  void setBunchBitsetForBeam2(std::bitset<bunchSlots + 1> const &bunchConfiguration);
+
+private:
   bool m_isData;
   unsigned short m_lhcFill;
   unsigned short m_bunches1, m_bunches2, m_collidingBunches, m_targetBunches;
@@ -157,11 +157,11 @@ class FillInfo {
   //BEWARE: since CMS counts bunches starting from one,
   //the size of the bitset must be incremented by one,
   //in order to avoid off-by-one
-  std::bitset<bunchSlots+1> m_bunchConfiguration1, m_bunchConfiguration2;
+  std::bitset<bunchSlots + 1> m_bunchConfiguration1, m_bunchConfiguration2;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
-std::ostream & operator<<( std::ostream &, FillInfo fillInfo );
+std::ostream &operator<<(std::ostream &, FillInfo fillInfo);
 
-#endif // CondFormats_RunInfo_FillInfo_H
+#endif  // CondFormats_RunInfo_FillInfo_H

--- a/CondFormats/RunInfo/interface/L1TriggerScaler.h
+++ b/CondFormats/RunInfo/interface/L1TriggerScaler.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <iostream>
-#include<vector>
+#include <vector>
 
 /*
  *  \class L1TriggerScaler
@@ -15,64 +15,58 @@
  *
 */
 
-
 class L1TriggerScaler {
 public:
   // a struct with the information for each lumi
 
-  struct Lumi{
-    Lumi(){}
-    ~Lumi(){}
+  struct Lumi {
+    Lumi() {}
+    ~Lumi() {}
     int m_runnumber;
     long long m_lumi_id;
-    std::string m_start_time; 
+    std::string m_start_time;
     // std::string m_date_str;
     //std::string  m_string_value;
-    std::string  m_string_format;
+    std::string m_string_format;
     long m_rn;
     int m_lumisegment;
     // std::string m_version;
     //std::string m_context;
-    std::string m_date; 
-   
-    
-   
-    
-    std::vector<int> m_GTAlgoCounts;   
+    std::string m_date;
+
+    std::vector<int> m_GTAlgoCounts;
     // m_GTAlgoCounts.reserve(128);
-    
+
     std::vector<float> m_GTAlgoRates;
-    
+
     std::vector<int> m_GTAlgoPrescaling;
-   
+
     std::vector<int> m_GTTechCounts;
-   
+
     std::vector<float> m_GTTechRates;
-   
+
     std::vector<int> m_GTTechPrescaling;
-   
+
     std::vector<int> m_GTPartition0TriggerCounts;
-   
+
     std::vector<float> m_GTPartition0TriggerRates;
-    
+
     std::vector<int> m_GTPartition0DeadTime;
-    
+
     std::vector<float> m_GTPartition0DeadTimeRatio;
-    
-   
-   COND_SERIALIZABLE;
-};
-   
-// the fondamental object is a vector of struct Lumi   
+
+    COND_SERIALIZABLE;
+  };
+
+  // the fondamental object is a vector of struct Lumi
   L1TriggerScaler();
-  virtual ~L1TriggerScaler(){}
-  // fondamental object   
+  virtual ~L1TriggerScaler() {}
+  // fondamental object
   std::vector<Lumi> m_run;
-    
- 
-   // printing everything
+
+  // printing everything
   void printAllValues() const;
-  void printRunValue()const;
+  void printRunValue() const;
   void printLumiSegmentValues() const;
   void printFormat() const;
   void printGTAlgoCounts() const;
@@ -84,30 +78,19 @@ public:
   void printGTPartition0TriggerCounts() const;
   void printGTPartition0TriggerRates() const;
   void printGTPartition0DeadTime() const;
-  void printGTPartition0DeadTimeRatio() const;  
+  void printGTPartition0DeadTimeRatio() const;
 
   typedef std::vector<Lumi>::const_iterator LumiIterator;
- 
 
+  void SetRunNumber(int n) { m_runnumber = n; }
 
- 
- 
+private:
+  int m_lumisegment;
+  int m_runnumber;
+  // std::string  m_string_value;
+  //std::vector<int>  m_GTAlgoCounts;
 
-
- 
-
-void SetRunNumber(int n) {
-    m_runnumber= n;
-  }
-
-
- private:
- int  m_lumisegment; 
- int m_runnumber;
- // std::string  m_string_value;
- //std::vector<int>  m_GTAlgoCounts;
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/RunInfo/interface/LHCInfo.h
+++ b/CondFormats/RunInfo/interface/LHCInfo.h
@@ -10,91 +10,118 @@
 #include <vector>
 
 class LHCInfo {
- public:
+public:
   enum FillType { UNKNOWN = 0, PROTONS = 1, IONS = 2, COSMICS = 3, GAP = 4 };
   enum ParticleType { NONE = 0, PROTON = 1, PB82 = 2, AR18 = 3, D = 4, XE54 = 5 };
 
-  enum IntParamIndex { LHC_FILL = 0, BUNCHES_1 = 1, BUNCHES_2 = 2, COLLIDING_BUNCHES = 3, TARGET_BUNCHES = 4, FILL_TYPE = 5, PARTICLES_1 = 6, PARTICLES_2 = 7, LUMI_SECTION = 8, ISIZE = 9 };
-  enum FloatParamIndex { CROSSING_ANGLE = 0, BETA_STAR = 1, INTENSITY_1 = 2, INTENSITY_2 = 3, ENERGY = 4, DELIV_LUMI = 5, REC_LUMI = 7, LUMI_PER_B = 8, BEAM1_VC = 9, BEAM2_VC = 10, BEAM1_RF = 11, BEAM2_RF = 12, INST_LUMI = 13, INST_LUMI_ERR = 14, FSIZE = 15};
-  enum TimeParamIndex { CREATE_TIME = 0, BEGIN_TIME = 1, END_TIME = 2, TSIZE =3};
-  enum StringParamIndex { INJECTION_SCHEME = 0, LHC_STATE = 1, LHC_COMMENT = 2, CTPPS_STATUS = 3, SSIZE =4};
+  enum IntParamIndex {
+    LHC_FILL = 0,
+    BUNCHES_1 = 1,
+    BUNCHES_2 = 2,
+    COLLIDING_BUNCHES = 3,
+    TARGET_BUNCHES = 4,
+    FILL_TYPE = 5,
+    PARTICLES_1 = 6,
+    PARTICLES_2 = 7,
+    LUMI_SECTION = 8,
+    ISIZE = 9
+  };
+  enum FloatParamIndex {
+    CROSSING_ANGLE = 0,
+    BETA_STAR = 1,
+    INTENSITY_1 = 2,
+    INTENSITY_2 = 3,
+    ENERGY = 4,
+    DELIV_LUMI = 5,
+    REC_LUMI = 7,
+    LUMI_PER_B = 8,
+    BEAM1_VC = 9,
+    BEAM2_VC = 10,
+    BEAM1_RF = 11,
+    BEAM2_RF = 12,
+    INST_LUMI = 13,
+    INST_LUMI_ERR = 14,
+    FSIZE = 15
+  };
+  enum TimeParamIndex { CREATE_TIME = 0, BEGIN_TIME = 1, END_TIME = 2, TSIZE = 3 };
+  enum StringParamIndex { INJECTION_SCHEME = 0, LHC_STATE = 1, LHC_COMMENT = 2, CTPPS_STATUS = 3, SSIZE = 4 };
 
   typedef FillType FillTypeId;
   typedef ParticleType ParticleTypeId;
   LHCInfo();
-  LHCInfo( const LHCInfo& rhs );
+  LHCInfo(const LHCInfo& rhs);
   ~LHCInfo();
 
   LHCInfo* cloneFill() const;
-  
+
   //constant static unsigned integer hosting the maximum number of LHC bunch slots
   static size_t const bunchSlots = 3564;
-  
+
   //constant static unsigned integer hosting the available number of LHC bunch slots
   static size_t const availableBunchSlots = 2808;
-  
-  void setFillNumber( unsigned short lhcFill );
-  
+
+  void setFillNumber(unsigned short lhcFill);
+
   //getters
   unsigned short const fillNumber() const;
-  
+
   unsigned short const bunchesInBeam1() const;
-  
+
   unsigned short const bunchesInBeam2() const;
-  
+
   unsigned short const collidingBunches() const;
-  
+
   unsigned short const targetBunches() const;
-  
+
   FillTypeId const fillType() const;
-  
+
   ParticleTypeId const particleTypeForBeam1() const;
-  
+
   ParticleTypeId const particleTypeForBeam2() const;
-  
+
   float const crossingAngle() const;
 
   float const betaStar() const;
-  
+
   float const intensityForBeam1() const;
-  
+
   float const intensityForBeam2() const;
-  
+
   float const energy() const;
-  
+
   float const delivLumi() const;
-  
+
   float const recLumi() const;
 
   float const instLumi() const;
 
   float const instLumiError() const;
-  
+
   cond::Time_t const createTime() const;
-  
+
   cond::Time_t const beginTime() const;
-  
+
   cond::Time_t const endTime() const;
-  
-  std::string const & injectionScheme() const;
-  
-  std::vector<float> const & lumiPerBX() const;
-  
-  std::string const & lhcState() const;
-  
-  std::string const & lhcComment() const;
-  
-  std::string const & ctppsStatus() const;
-  
-  unsigned int const & lumiSection() const;
-  
-  std::vector<float> const & beam1VC() const;
 
-  std::vector<float> const & beam2VC() const;
+  std::string const& injectionScheme() const;
 
-  std::vector<float> const & beam1RF() const;
+  std::vector<float> const& lumiPerBX() const;
 
-  std::vector<float> const & beam2RF() const;
+  std::string const& lhcState() const;
+
+  std::string const& lhcComment() const;
+
+  std::string const& ctppsStatus() const;
+
+  unsigned int const& lumiSection() const;
+
+  std::vector<float> const& beam1VC() const;
+
+  std::vector<float> const& beam2VC() const;
+
+  std::vector<float> const& beam1RF() const;
+
+  std::vector<float> const& beam2RF() const;
 
   std::vector<float>& beam1VC();
 
@@ -109,133 +136,133 @@ class LHCInfo {
   bool is25nsBunchSpacing() const;
 
   //returns a boolean, true if the bunch slot number is in the circulating bunch configuration
-  bool isBunchInBeam1( size_t const & bunch ) const;
-  
-  bool isBunchInBeam2( size_t const & bunch ) const;
-  
+  bool isBunchInBeam1(size_t const& bunch) const;
+
+  bool isBunchInBeam2(size_t const& bunch) const;
+
   //member functions returning *by value* a vector with all filled bunch slots
   std::vector<unsigned short> bunchConfigurationForBeam1() const;
-  
+
   std::vector<unsigned short> bunchConfigurationForBeam2() const;
-  
+
   //setters
-  void setBunchesInBeam1( unsigned short const & bunches );
-  
-  void setBunchesInBeam2( unsigned short const & bunches );
-  
-  void setCollidingBunches( unsigned short const & collidingBunches );
-  
-  void setTargetBunches( unsigned short const & targetBunches );
-  
-  void setFillType( FillTypeId const & fillType );
-  
-  void setParticleTypeForBeam1( ParticleTypeId const & particleType );
-  
-  void setParticleTypeForBeam2( ParticleTypeId const & particleType );
-  
-  void setCrossingAngle( float const & angle );
-  
-  void setBetaStar( float const & betaStar );
-  
-  void setIntensityForBeam1( float const & intensity );
-  
-  void setIntensityForBeam2( float const & intensity );
-  
-  void setEnergy( float const & energy );
-  
-  void setDelivLumi( float const & delivLumi );
+  void setBunchesInBeam1(unsigned short const& bunches);
 
-  void setRecLumi( float const & recLumi );
+  void setBunchesInBeam2(unsigned short const& bunches);
 
-  void setInstLumi( float const& instLumi );
+  void setCollidingBunches(unsigned short const& collidingBunches);
 
-  void setInstLumiError( float const& instLumiError );
+  void setTargetBunches(unsigned short const& targetBunches);
 
-  void setCreationTime( cond::Time_t const & createTime );
-  
-  void setBeginTime( cond::Time_t const & beginTime );
-  
-  void setEndTime( cond::Time_t const & endTime );
-  
-  void setInjectionScheme( std::string const & injectionScheme );
-  
-  void setLumiPerBX( std::vector<float> const & lumiPerBX);
-  
-  void setLhcState( std::string const & lhcState);
-  
-  void setLhcComment( std::string const & lhcComment);
+  void setFillType(FillTypeId const& fillType);
 
-  void setCtppsStatus( std::string const & ctppsStatus);
-  
-  void setLumiSection( unsigned int const & lumiSection);
-  
-  void setBeam1VC( std::vector<float> const & beam1VC);
-  
-  void setBeam2VC( std::vector<float> const & beam2VC);
-  
-  void setBeam1RF( std::vector<float> const & beam1RF);
-  
-  void setBeam2RF( std::vector<float> const & beam2RF);
-  
+  void setParticleTypeForBeam1(ParticleTypeId const& particleType);
+
+  void setParticleTypeForBeam2(ParticleTypeId const& particleType);
+
+  void setCrossingAngle(float const& angle);
+
+  void setBetaStar(float const& betaStar);
+
+  void setIntensityForBeam1(float const& intensity);
+
+  void setIntensityForBeam2(float const& intensity);
+
+  void setEnergy(float const& energy);
+
+  void setDelivLumi(float const& delivLumi);
+
+  void setRecLumi(float const& recLumi);
+
+  void setInstLumi(float const& instLumi);
+
+  void setInstLumiError(float const& instLumiError);
+
+  void setCreationTime(cond::Time_t const& createTime);
+
+  void setBeginTime(cond::Time_t const& beginTime);
+
+  void setEndTime(cond::Time_t const& endTime);
+
+  void setInjectionScheme(std::string const& injectionScheme);
+
+  void setLumiPerBX(std::vector<float> const& lumiPerBX);
+
+  void setLhcState(std::string const& lhcState);
+
+  void setLhcComment(std::string const& lhcComment);
+
+  void setCtppsStatus(std::string const& ctppsStatus);
+
+  void setLumiSection(unsigned int const& lumiSection);
+
+  void setBeam1VC(std::vector<float> const& beam1VC);
+
+  void setBeam2VC(std::vector<float> const& beam2VC);
+
+  void setBeam1RF(std::vector<float> const& beam1RF);
+
+  void setBeam2RF(std::vector<float> const& beam2RF);
+
   //sets all values in one go
-  void setInfo( unsigned short const & bunches1
-	,unsigned short const & bunches2
-	,unsigned short const & collidingBunches
-	,unsigned short const & targetBunches
-	,FillTypeId const & fillType
-	,ParticleTypeId const & particleType1
-	,ParticleTypeId const & particleType2
-	,float const & angle
-	,float const & beta
-	,float const & intensity1
-	,float const & intensity2
-	,float const & energy
-	,float const & delivLumi
-	,float const & recLumi
-	,float const & instLumi
-	,float const & instLumiError
-	,cond::Time_t const & createTime
-	,cond::Time_t const & beginTime
-	,cond::Time_t const & endTime
-	,std::string const & scheme
-	,std::vector<float> const & lumiPerBX
-	,std::string const & lhcState
-	,std::string const & lhcComment
-	,std::string const & ctppsStatus
-	,unsigned int const & lumiSection
-	,std::vector<float> const & beam1VC
-	,std::vector<float> const & beam2VC
-	,std::vector<float> const & beam1RF
-	,std::vector<float> const & beam2RF
-	,std::bitset<bunchSlots+1> const & bunchConf1 
-	,std::bitset<bunchSlots+1> const & bunchConf2 );
+  void setInfo(unsigned short const& bunches1,
+               unsigned short const& bunches2,
+               unsigned short const& collidingBunches,
+               unsigned short const& targetBunches,
+               FillTypeId const& fillType,
+               ParticleTypeId const& particleType1,
+               ParticleTypeId const& particleType2,
+               float const& angle,
+               float const& beta,
+               float const& intensity1,
+               float const& intensity2,
+               float const& energy,
+               float const& delivLumi,
+               float const& recLumi,
+               float const& instLumi,
+               float const& instLumiError,
+               cond::Time_t const& createTime,
+               cond::Time_t const& beginTime,
+               cond::Time_t const& endTime,
+               std::string const& scheme,
+               std::vector<float> const& lumiPerBX,
+               std::string const& lhcState,
+               std::string const& lhcComment,
+               std::string const& ctppsStatus,
+               unsigned int const& lumiSection,
+               std::vector<float> const& beam1VC,
+               std::vector<float> const& beam2VC,
+               std::vector<float> const& beam1RF,
+               std::vector<float> const& beam2RF,
+               std::bitset<bunchSlots + 1> const& bunchConf1,
+               std::bitset<bunchSlots + 1> const& bunchConf2);
 
-  bool equals( const LHCInfo& rhs ) const;
+  bool equals(const LHCInfo& rhs) const;
 
   bool empty() const;
 
   //dumping values on output stream
-  void print(std::stringstream & ss) const;
-  
-  std::bitset<bunchSlots+1> const & bunchBitsetForBeam1() const;
-  
-  std::bitset<bunchSlots+1> const & bunchBitsetForBeam2() const;
-  
-  void setBunchBitsetForBeam1( std::bitset<bunchSlots+1> const & bunchConfiguration );
-  
-  void setBunchBitsetForBeam2( std::bitset<bunchSlots+1> const & bunchConfiguration );
-  
- private:
+  void print(std::stringstream& ss) const;
+
+  std::bitset<bunchSlots + 1> const& bunchBitsetForBeam1() const;
+
+  std::bitset<bunchSlots + 1> const& bunchBitsetForBeam2() const;
+
+  void setBunchBitsetForBeam1(std::bitset<bunchSlots + 1> const& bunchConfiguration);
+
+  void setBunchBitsetForBeam2(std::bitset<bunchSlots + 1> const& bunchConfiguration);
+
+private:
   bool m_isData = false;
   std::vector<std::vector<unsigned int> > m_intParams;
   std::vector<std::vector<float> > m_floatParams;
   std::vector<std::vector<unsigned long long> > m_timeParams;
   std::vector<std::vector<std::string> > m_stringParams;
-  std::bitset<bunchSlots+1> m_bunchConfiguration1, m_bunchConfiguration2;
+  std::bitset<bunchSlots + 1> m_bunchConfiguration1, m_bunchConfiguration2;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
-std::ostream & operator<<( std::ostream &, LHCInfo lhcInfo );
+std::ostream& operator<<(std::ostream&, LHCInfo lhcInfo);
 
-#endif // CondFormats_RunInfo_LHCInfo_H
+#endif  // CondFormats_RunInfo_LHCInfo_H

--- a/CondFormats/RunInfo/interface/MixingModuleConfig.h
+++ b/CondFormats/RunInfo/interface/MixingModuleConfig.h
@@ -7,84 +7,91 @@
 #include <string>
 #include <iostream>
 
-namespace edm{
+namespace edm {
   class ParameterSet;
 }
 
 class MixingInputConfig {
- public:
+public:
   MixingInputConfig();
   virtual ~MixingInputConfig(){};
 
-  const int itype() const {return t_;}
-  std::string type() const { 
-    switch(t_){
-    case 0:      return "none";
-    case 1:      return "fixed";
-    case 2:      return "poisson";
-    case 3:      return "histo";
-    case 4:      return "probFunction";
-      // FIX ME: add default 
+  const int itype() const { return t_; }
+  std::string type() const {
+    switch (t_) {
+      case 0:
+        return "none";
+      case 1:
+        return "fixed";
+      case 2:
+        return "poisson";
+      case 3:
+        return "histo";
+      case 4:
+        return "probFunction";
+        // FIX ME: add default
     }
     return "";
   }
-  int itype(std::string s)const {
-    if (s=="none")      return 0;
-    if (s=="fixed")      return 1;
-    if (s=="poisson")      return 2;
-    if (s=="histo")      return 3;
-    if (s=="probFunction")      return 4;
+  int itype(std::string s) const {
+    if (s == "none")
+      return 0;
+    if (s == "fixed")
+      return 1;
+    if (s == "poisson")
+      return 2;
+    if (s == "histo")
+      return 3;
+    if (s == "probFunction")
+      return 4;
     return 0;
   }
 
-  const double averageNumber() const { return an_;}
+  const double averageNumber() const { return an_; }
   //  const int intAverage() const { return ia_;}
-  const std::vector<int> & probFunctionVariable() const { return dpfv_;}
-  const std::vector<double> & probValue() const { return dp_;}
-  const int outOfTime() const { return moot_;}
-  const int fixedOutOfTime() const { return ioot_;}
+  const std::vector<int>& probFunctionVariable() const { return dpfv_; }
+  const std::vector<double>& probValue() const { return dp_; }
+  const int outOfTime() const { return moot_; }
+  const int fixedOutOfTime() const { return ioot_; }
 
-  void read(edm::ParameterSet & pset);
+  void read(edm::ParameterSet& pset);
 
- private:
+private:
   int t_;
   double an_;
   //  int ia_;
   std::vector<int> dpfv_;
-  std::vector<double>dp_;
+  std::vector<double> dp_;
   int moot_;
   int ioot_;
-  
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 class MixingModuleConfig {
- public:
+public:
   MixingModuleConfig();
   virtual ~MixingModuleConfig(){};
 
-  const MixingInputConfig & config (unsigned int i=0) const { return configs_[i];}
-  
-  const int & bunchSpace() const { return bs_;}
-  const int & minBunch() const { return minb_;}
-  const int & maxBunch() const { return maxb_;}
+  const MixingInputConfig& config(unsigned int i = 0) const { return configs_[i]; }
 
-  void read(edm::ParameterSet & pset);
-  
- private:
+  const int& bunchSpace() const { return bs_; }
+  const int& minBunch() const { return minb_; }
+  const int& maxBunch() const { return maxb_; }
+
+  void read(edm::ParameterSet& pset);
+
+private:
   std::vector<MixingInputConfig> configs_;
-  
+
   int minb_;
   int maxb_;
   int bs_;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
-
-
-std::ostream& operator<< ( std::ostream&, const MixingModuleConfig & beam );
-std::ostream& operator<< ( std::ostream&, const MixingInputConfig & beam );
+std::ostream& operator<<(std::ostream&, const MixingModuleConfig& beam);
+std::ostream& operator<<(std::ostream&, const MixingInputConfig& beam);
 
 #endif

--- a/CondFormats/RunInfo/interface/RunInfo.h
+++ b/CondFormats/RunInfo/interface/RunInfo.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <iostream>
-#include<vector>
+#include <vector>
 
 /*
  *  \class RunInfo
@@ -17,7 +17,6 @@
 
 class RunInfo {
 public:
-  
   int m_run;
   long long m_start_time_ll;
   std::string m_start_time_str;
@@ -32,17 +31,14 @@ public:
   float m_run_intervall_micros;
   std::vector<float> m_current;
   std::vector<float> m_times_of_currents;
-    
+
   RunInfo();
   virtual ~RunInfo(){};
   static RunInfo* Fake_RunInfo();
-    
-  void printAllValues() const;
 
-  
+  void printAllValues() const;
 
   COND_SERIALIZABLE;
 };
-
 
 #endif

--- a/CondFormats/RunInfo/interface/RunNumber.h
+++ b/CondFormats/RunInfo/interface/RunNumber.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <iostream>
-#include<vector>
+#include <vector>
 
 /*
  *  \class RunNumber
@@ -15,38 +15,36 @@
  *
 */
 
-namespace runinfo_test{
-class RunNumber {
-public:
-  struct Item {
-    Item(){}
-    ~Item(){}
-    int m_run;
-    long long  m_id_start;
-    long long  m_id_stop;
-    std::string m_number;
-    std::string m_name;
-    signed long long m_start_time_sll;
-    std::string m_start_time_str;
-    signed long long m_stop_time_sll;
-    std::string m_stop_time_str;
-    int  m_lumisections;
-    std::vector<std::string> m_subdt_joined;
-    std::vector<int> m_subdt_in;
-    enum subdet { PIXEL, TRACKER, ECAL, HCAL, DT, CSC,RPC };  
-  
-  COND_SERIALIZABLE;
-};
+namespace runinfo_test {
+  class RunNumber {
+  public:
+    struct Item {
+      Item() {}
+      ~Item() {}
+      int m_run;
+      long long m_id_start;
+      long long m_id_stop;
+      std::string m_number;
+      std::string m_name;
+      signed long long m_start_time_sll;
+      std::string m_start_time_str;
+      signed long long m_stop_time_sll;
+      std::string m_stop_time_str;
+      int m_lumisections;
+      std::vector<std::string> m_subdt_joined;
+      std::vector<int> m_subdt_in;
+      enum subdet { PIXEL, TRACKER, ECAL, HCAL, DT, CSC, RPC };
 
- 
- 
-  RunNumber();
-  virtual ~RunNumber(){}
-  typedef std::vector<Item>::const_iterator ItemIterator;
-  std::vector<Item>  m_runnumber;
+      COND_SERIALIZABLE;
+    };
 
- COND_SERIALIZABLE;
-};
+    RunNumber();
+    virtual ~RunNumber() {}
+    typedef std::vector<Item>::const_iterator ItemIterator;
+    std::vector<Item> m_runnumber;
 
-}
+    COND_SERIALIZABLE;
+  };
+
+}  // namespace runinfo_test
 #endif

--- a/CondFormats/RunInfo/interface/RunSummary.h
+++ b/CondFormats/RunInfo/interface/RunSummary.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 #include <iostream>
-#include<vector>
+#include <vector>
 
 /*
  *  \class RunSummary
@@ -17,31 +17,28 @@
 
 class RunSummary {
 public:
-  
   int m_run;
   std::string m_name;
   long long m_start_time_ll;
   std::string m_start_time_str;
   long long m_stop_time_ll;
   std::string m_stop_time_str;
-  int  m_lumisections;
+  int m_lumisections;
   std::vector<int> m_subdt_in;
   std::string m_hltkey;
   long long m_nevents;
   float m_rate;
-    
-  enum subdet { PIXEL, TRACKER, ECAL, HCAL, DT, CSC,RPC };  
-  
+
+  enum subdet { PIXEL, TRACKER, ECAL, HCAL, DT, CSC, RPC };
+
   RunSummary();
   virtual ~RunSummary(){};
   static RunSummary* Fake_RunSummary();
-    
+
   void printAllValues() const;
   std::vector<std::string> getSubdtIn() const;
-  
 
   COND_SERIALIZABLE;
 };
-
 
 #endif

--- a/CondFormats/RunInfo/src/FillInfo.cc
+++ b/CondFormats/RunInfo/src/FillInfo.cc
@@ -5,114 +5,114 @@
 #include <stdexcept>
 
 //helper function: returns the positions of the bits in the bitset that are set (i.e., have a value of 1).
-static std::vector<unsigned short> bitsetToVector( std::bitset<FillInfo::bunchSlots+1> const & bs ) {
+static std::vector<unsigned short> bitsetToVector(std::bitset<FillInfo::bunchSlots + 1> const& bs) {
   std::vector<unsigned short> vec;
   //reserve space only for the bits in the bitset that are set
-  vec.reserve( bs.count() );
-  for( size_t i = 0; i < bs.size(); ++i ) {
-    if( bs.test( i ) )
-      vec.push_back( (unsigned short)i );
+  vec.reserve(bs.count());
+  for (size_t i = 0; i < bs.size(); ++i) {
+    if (bs.test(i))
+      vec.push_back((unsigned short)i);
   }
   return vec;
 }
 
 //helper function: returns the enum for fill types in string type
-static std::string fillTypeToString( FillInfo::FillTypeId const & fillType ) {
-  std::string s_fillType( "UNKNOWN" );
-  switch( fillType ) {
-  case FillInfo::UNKNOWN :
-    s_fillType = std::string( "UNKNOWN" );
-    break;
-  case FillInfo::PROTONS :
-    s_fillType = std::string( "PROTONS" );
-    break;
-  case FillInfo::IONS :
-    s_fillType = std::string( "IONS" );
-    break;
-  case FillInfo::COSMICS :
-    s_fillType = std::string( "COSMICS" );
-    break;
-  case FillInfo::GAP :
-    s_fillType = std::string( "GAP" );
-    break;
-  default :
-    s_fillType = std::string( "UNKNOWN" );
+static std::string fillTypeToString(FillInfo::FillTypeId const& fillType) {
+  std::string s_fillType("UNKNOWN");
+  switch (fillType) {
+    case FillInfo::UNKNOWN:
+      s_fillType = std::string("UNKNOWN");
+      break;
+    case FillInfo::PROTONS:
+      s_fillType = std::string("PROTONS");
+      break;
+    case FillInfo::IONS:
+      s_fillType = std::string("IONS");
+      break;
+    case FillInfo::COSMICS:
+      s_fillType = std::string("COSMICS");
+      break;
+    case FillInfo::GAP:
+      s_fillType = std::string("GAP");
+      break;
+    default:
+      s_fillType = std::string("UNKNOWN");
   }
   return s_fillType;
 }
 
 //helper function: returns the enum for particle types in string type
-static std::string particleTypeToString( FillInfo::ParticleTypeId const & particleType ) {
-  std::string s_particleType( "NONE" );
-  switch( particleType ) {
-  case FillInfo::NONE :
-    s_particleType = std::string( "NONE" );
-    break;
-  case FillInfo::PROTON :
-    s_particleType = std::string( "PROTON" );
-    break;
-  case FillInfo::PB82 :
-    s_particleType = std::string( "PB82" );
-    break;
-  case FillInfo::AR18 :
-    s_particleType = std::string( "AR18" );
-    break;
-  case FillInfo::D :
-    s_particleType = std::string( "D" );
-    break;
-  case FillInfo::XE54 :
-    s_particleType = std::string( "XE54" );
-    break;
-  default :
-    s_particleType = std::string( "NONE" );
+static std::string particleTypeToString(FillInfo::ParticleTypeId const& particleType) {
+  std::string s_particleType("NONE");
+  switch (particleType) {
+    case FillInfo::NONE:
+      s_particleType = std::string("NONE");
+      break;
+    case FillInfo::PROTON:
+      s_particleType = std::string("PROTON");
+      break;
+    case FillInfo::PB82:
+      s_particleType = std::string("PB82");
+      break;
+    case FillInfo::AR18:
+      s_particleType = std::string("AR18");
+      break;
+    case FillInfo::D:
+      s_particleType = std::string("D");
+      break;
+    case FillInfo::XE54:
+      s_particleType = std::string("XE54");
+      break;
+    default:
+      s_particleType = std::string("NONE");
   }
   return s_particleType;
 }
 
-FillInfo::FillInfo(): m_isData( false )
-		    , m_lhcFill( 0 )
-		    , m_bunches1( 0 )
-		    , m_bunches2( 0 )
-		    , m_collidingBunches( 0 )
-		    , m_targetBunches( 0 )
-		    , m_fillType( FillTypeId::UNKNOWN )
-		    , m_particles1( ParticleTypeId::NONE )
-		    , m_particles2( ParticleTypeId::NONE )
-		    , m_crossingAngle( 0. )
-		    , m_betastar( 0. )
-		    , m_intensity1( 0. )
-		    , m_intensity2( 0. )
-		    , m_energy( 0. )
-		    , m_createTime( 0 )
-		    , m_beginTime( 0 )
-		    , m_endTime( 0 )
-		    , m_injectionScheme( "None" )
-{}
+FillInfo::FillInfo()
+    : m_isData(false),
+      m_lhcFill(0),
+      m_bunches1(0),
+      m_bunches2(0),
+      m_collidingBunches(0),
+      m_targetBunches(0),
+      m_fillType(FillTypeId::UNKNOWN),
+      m_particles1(ParticleTypeId::NONE),
+      m_particles2(ParticleTypeId::NONE),
+      m_crossingAngle(0.),
+      m_betastar(0.),
+      m_intensity1(0.),
+      m_intensity2(0.),
+      m_energy(0.),
+      m_createTime(0),
+      m_beginTime(0),
+      m_endTime(0),
+      m_injectionScheme("None") {}
 
-FillInfo::FillInfo( unsigned short const & lhcFill, bool const & fromData ): m_isData( fromData )
-									   , m_lhcFill( lhcFill )
-									   , m_bunches1( 0 )
-									   , m_bunches2( 0 )
-									   , m_collidingBunches( 0 )
-									   , m_targetBunches( 0 )
-									   , m_fillType( FillTypeId::UNKNOWN )
-									   , m_particles1( ParticleTypeId::NONE )
-									   , m_particles2( ParticleTypeId::NONE )
-									   , m_crossingAngle( 0. )
-									   , m_betastar( 0. )
-									   , m_intensity1( 0. )
-									   , m_intensity2( 0. )
-									   , m_energy( 0. )
-									   , m_createTime( 0 )
-									   , m_beginTime( 0 )
-									   , m_endTime( 0 )
-									   , m_injectionScheme( "None" )
-{}
+FillInfo::FillInfo(unsigned short const& lhcFill, bool const& fromData)
+    : m_isData(fromData),
+      m_lhcFill(lhcFill),
+      m_bunches1(0),
+      m_bunches2(0),
+      m_collidingBunches(0),
+      m_targetBunches(0),
+      m_fillType(FillTypeId::UNKNOWN),
+      m_particles1(ParticleTypeId::NONE),
+      m_particles2(ParticleTypeId::NONE),
+      m_crossingAngle(0.),
+      m_betastar(0.),
+      m_intensity1(0.),
+      m_intensity2(0.),
+      m_energy(0.),
+      m_createTime(0),
+      m_beginTime(0),
+      m_endTime(0),
+      m_injectionScheme("None") {}
 
 FillInfo::~FillInfo() {}
 
 //reset instance
-void FillInfo::setFill( unsigned short const & lhcFill, bool const & fromData ) {
+void FillInfo::setFill(unsigned short const& lhcFill, bool const& fromData) {
   m_isData = fromData;
   m_lhcFill = lhcFill;
   m_bunches1 = 0;
@@ -136,260 +136,191 @@ void FillInfo::setFill( unsigned short const & lhcFill, bool const & fromData ) 
 }
 
 //getters
-unsigned short const FillInfo::fillNumber() const {
-  return m_lhcFill;
-}
+unsigned short const FillInfo::fillNumber() const { return m_lhcFill; }
 
-bool const FillInfo::isData() const {
-  return m_isData;
-}
+bool const FillInfo::isData() const { return m_isData; }
 
-unsigned short const FillInfo::bunchesInBeam1() const {
-  return m_bunches1;
-}
+unsigned short const FillInfo::bunchesInBeam1() const { return m_bunches1; }
 
-unsigned short const FillInfo::bunchesInBeam2() const {
-  return m_bunches2;
-}
+unsigned short const FillInfo::bunchesInBeam2() const { return m_bunches2; }
 
-unsigned short const FillInfo::collidingBunches() const {
-  return m_collidingBunches;
-}
+unsigned short const FillInfo::collidingBunches() const { return m_collidingBunches; }
 
-unsigned short const FillInfo::targetBunches() const {
-  return m_targetBunches;
-}
+unsigned short const FillInfo::targetBunches() const { return m_targetBunches; }
 
-FillInfo::FillTypeId const FillInfo::fillType() const {
-  return m_fillType;
-}
+FillInfo::FillTypeId const FillInfo::fillType() const { return m_fillType; }
 
-FillInfo::ParticleTypeId const FillInfo::particleTypeForBeam1() const {
-  return m_particles1;
-}
+FillInfo::ParticleTypeId const FillInfo::particleTypeForBeam1() const { return m_particles1; }
 
-FillInfo::ParticleTypeId const FillInfo::particleTypeForBeam2() const {
-  return m_particles2;
-}
+FillInfo::ParticleTypeId const FillInfo::particleTypeForBeam2() const { return m_particles2; }
 
-float const FillInfo::crossingAngle() const {
-  return m_crossingAngle;
-}
+float const FillInfo::crossingAngle() const { return m_crossingAngle; }
 
-float const FillInfo::betaStar() const {
-  return m_betastar;
-}
+float const FillInfo::betaStar() const { return m_betastar; }
 
-float const FillInfo::intensityForBeam1() const {
-  return m_intensity1;
-}
+float const FillInfo::intensityForBeam1() const { return m_intensity1; }
 
-float const FillInfo::intensityForBeam2() const {
-  return m_intensity2;
-}
+float const FillInfo::intensityForBeam2() const { return m_intensity2; }
 
-float const FillInfo::energy() const {
-  return m_energy;
-}
+float const FillInfo::energy() const { return m_energy; }
 
-cond::Time_t const FillInfo::createTime() const {
-  return m_createTime;
-}
+cond::Time_t const FillInfo::createTime() const { return m_createTime; }
 
-cond::Time_t const FillInfo::beginTime() const {
-  return m_beginTime;
-}
+cond::Time_t const FillInfo::beginTime() const { return m_beginTime; }
 
-cond::Time_t const FillInfo::endTime() const {
-  return m_endTime;
-}
+cond::Time_t const FillInfo::endTime() const { return m_endTime; }
 
-std::string const & FillInfo::injectionScheme() const {
-  return m_injectionScheme;
-}
+std::string const& FillInfo::injectionScheme() const { return m_injectionScheme; }
 
 //returns a boolean, true if the injection scheme has a leading 25ns
 //TODO: parse the circulating bunch configuration, instead of the string.
 bool FillInfo::is25nsBunchSpacing() const {
-  const std::string prefix( "25ns" );
-  return std::equal( prefix.begin(), prefix.end(), m_injectionScheme.begin() );
+  const std::string prefix("25ns");
+  return std::equal(prefix.begin(), prefix.end(), m_injectionScheme.begin());
 }
 
 //returns a boolean, true if the bunch slot number is in the circulating bunch configuration
-bool FillInfo::isBunchInBeam1( size_t const & bunch ) const {
-  if( bunch == 0 )
-    throw std::out_of_range( "0 not allowed" ); //CMS starts counting bunch crossing from 1!
-  return m_bunchConfiguration1.test( bunch );
+bool FillInfo::isBunchInBeam1(size_t const& bunch) const {
+  if (bunch == 0)
+    throw std::out_of_range("0 not allowed");  //CMS starts counting bunch crossing from 1!
+  return m_bunchConfiguration1.test(bunch);
 }
 
-bool FillInfo::isBunchInBeam2( size_t const & bunch ) const {
-  if( bunch == 0 )
-    throw std::out_of_range( "0 not allowed" ); //CMS starts counting bunch crossing from 1!
-  return m_bunchConfiguration2.test( bunch );
+bool FillInfo::isBunchInBeam2(size_t const& bunch) const {
+  if (bunch == 0)
+    throw std::out_of_range("0 not allowed");  //CMS starts counting bunch crossing from 1!
+  return m_bunchConfiguration2.test(bunch);
 }
 
 //member functions returning *by value* a vector with all filled bunch slots
 std::vector<unsigned short> FillInfo::bunchConfigurationForBeam1() const {
-  return bitsetToVector( m_bunchConfiguration1 );
+  return bitsetToVector(m_bunchConfiguration1);
 }
 
 std::vector<unsigned short> FillInfo::bunchConfigurationForBeam2() const {
-  return bitsetToVector( m_bunchConfiguration2 );
+  return bitsetToVector(m_bunchConfiguration2);
 }
 
 //setters
-void FillInfo::setBunchesInBeam1( unsigned short const & bunches ) {
-  m_bunches1 = bunches;
-}
+void FillInfo::setBunchesInBeam1(unsigned short const& bunches) { m_bunches1 = bunches; }
 
-void FillInfo::setBunchesInBeam2( unsigned short const & bunches ) {
-  m_bunches2 = bunches;
-}
+void FillInfo::setBunchesInBeam2(unsigned short const& bunches) { m_bunches2 = bunches; }
 
-void FillInfo::setCollidingBunches( unsigned short const & collidingBunches ) {
-  m_collidingBunches = collidingBunches;
-}
+void FillInfo::setCollidingBunches(unsigned short const& collidingBunches) { m_collidingBunches = collidingBunches; }
 
-void FillInfo::setTargetBunches( unsigned short const & targetBunches ) {
-  m_targetBunches = targetBunches;
-}
+void FillInfo::setTargetBunches(unsigned short const& targetBunches) { m_targetBunches = targetBunches; }
 
-void FillInfo::setFillType( FillInfo::FillTypeId const & fillType ) {
-  m_fillType = fillType;
-}
+void FillInfo::setFillType(FillInfo::FillTypeId const& fillType) { m_fillType = fillType; }
 
-void FillInfo::setParticleTypeForBeam1( FillInfo::ParticleTypeId const & particleType ) {
-  m_particles1 = particleType;
-}
+void FillInfo::setParticleTypeForBeam1(FillInfo::ParticleTypeId const& particleType) { m_particles1 = particleType; }
 
-void FillInfo::setParticleTypeForBeam2( FillInfo::ParticleTypeId const & particleType ) {
-  m_particles2 = particleType;
-}
+void FillInfo::setParticleTypeForBeam2(FillInfo::ParticleTypeId const& particleType) { m_particles2 = particleType; }
 
-void FillInfo::setCrossingAngle( float const & angle ) {
-  m_crossingAngle = angle;
-}
-  
-void FillInfo::setBetaStar( float const & betaStar ) {
-  m_betastar = betaStar;
-}
+void FillInfo::setCrossingAngle(float const& angle) { m_crossingAngle = angle; }
 
-void FillInfo::setIntensityForBeam1( float const & intensity ) {
-  m_intensity1 = intensity;
-}
+void FillInfo::setBetaStar(float const& betaStar) { m_betastar = betaStar; }
 
-void FillInfo::setIntensityForBeam2( float const & intensity ) {
-  m_intensity2 = intensity;
-}
+void FillInfo::setIntensityForBeam1(float const& intensity) { m_intensity1 = intensity; }
 
-void FillInfo::setEnergy( float const & energy ) {
-  m_energy = energy;
-}
+void FillInfo::setIntensityForBeam2(float const& intensity) { m_intensity2 = intensity; }
 
-void FillInfo::setCreationTime( cond::Time_t const & createTime ) {
-  m_createTime = createTime;
-}
+void FillInfo::setEnergy(float const& energy) { m_energy = energy; }
 
-void FillInfo::setBeginTime( cond::Time_t const & beginTime ) {
-  m_beginTime = beginTime;
-}
+void FillInfo::setCreationTime(cond::Time_t const& createTime) { m_createTime = createTime; }
 
-void FillInfo::setEndTime( cond::Time_t const & endTime ) {
-  m_endTime = endTime;
-}
+void FillInfo::setBeginTime(cond::Time_t const& beginTime) { m_beginTime = beginTime; }
 
-void FillInfo::setInjectionScheme( std::string const & injectionScheme ) {
-  m_injectionScheme = injectionScheme;
-}
+void FillInfo::setEndTime(cond::Time_t const& endTime) { m_endTime = endTime; }
+
+void FillInfo::setInjectionScheme(std::string const& injectionScheme) { m_injectionScheme = injectionScheme; }
 
 //sets all values in one go
-void FillInfo::setBeamInfo( unsigned short const & bunches1
-			    ,unsigned short const & bunches2
-			    ,unsigned short const & collidingBunches
-			    ,unsigned short const & targetBunches
-			    ,FillTypeId const & fillType
-			    ,ParticleTypeId const & particleType1
-			    ,ParticleTypeId const & particleType2
-			    ,float const & angle
-			    ,float const & beta
-			    ,float const & intensity1
-			    ,float const & intensity2
-			    ,float const & energy
-			    ,cond::Time_t const & createTime
-			    ,cond::Time_t const & beginTime
-			    ,cond::Time_t const & endTime
-			    ,std::string const & scheme
-			    ,std::bitset<bunchSlots+1> const & bunchConf1
-			    ,std::bitset<bunchSlots+1> const & bunchConf2 ) {
-  this->setBunchesInBeam1( bunches1 );
-  this->setBunchesInBeam2( bunches2 );
-  this->setCollidingBunches( collidingBunches );
-  this->setTargetBunches( targetBunches );
-  this->setFillType( fillType );
-  this->setParticleTypeForBeam1( particleType1 );
-  this->setParticleTypeForBeam2( particleType2 );
-  this->setCrossingAngle( angle );
-  this->setBetaStar( beta );
-  this->setIntensityForBeam1( intensity1 );
-  this->setIntensityForBeam2( intensity2 );
-  this->setEnergy( energy );
-  this->setCreationTime( createTime );
-  this->setBeginTime( beginTime );
-  this->setEndTime( endTime );
-  this->setInjectionScheme( scheme );
-  this->setBunchBitsetForBeam1( bunchConf1 );
-  this->setBunchBitsetForBeam2( bunchConf2 );
+void FillInfo::setBeamInfo(unsigned short const& bunches1,
+                           unsigned short const& bunches2,
+                           unsigned short const& collidingBunches,
+                           unsigned short const& targetBunches,
+                           FillTypeId const& fillType,
+                           ParticleTypeId const& particleType1,
+                           ParticleTypeId const& particleType2,
+                           float const& angle,
+                           float const& beta,
+                           float const& intensity1,
+                           float const& intensity2,
+                           float const& energy,
+                           cond::Time_t const& createTime,
+                           cond::Time_t const& beginTime,
+                           cond::Time_t const& endTime,
+                           std::string const& scheme,
+                           std::bitset<bunchSlots + 1> const& bunchConf1,
+                           std::bitset<bunchSlots + 1> const& bunchConf2) {
+  this->setBunchesInBeam1(bunches1);
+  this->setBunchesInBeam2(bunches2);
+  this->setCollidingBunches(collidingBunches);
+  this->setTargetBunches(targetBunches);
+  this->setFillType(fillType);
+  this->setParticleTypeForBeam1(particleType1);
+  this->setParticleTypeForBeam2(particleType2);
+  this->setCrossingAngle(angle);
+  this->setBetaStar(beta);
+  this->setIntensityForBeam1(intensity1);
+  this->setIntensityForBeam2(intensity2);
+  this->setEnergy(energy);
+  this->setCreationTime(createTime);
+  this->setBeginTime(beginTime);
+  this->setEndTime(endTime);
+  this->setInjectionScheme(scheme);
+  this->setBunchBitsetForBeam1(bunchConf1);
+  this->setBunchBitsetForBeam2(bunchConf2);
 }
 
-void FillInfo::print( std::stringstream & ss ) const {
+void FillInfo::print(std::stringstream& ss) const {
   ss << "LHC fill: " << m_lhcFill << std::endl
      << "Bunches in Beam 1: " << m_bunches1 << std::endl
      << "Bunches in Beam 2: " << m_bunches2 << std::endl
      << "Colliding bunches at IP5: " << m_collidingBunches << std::endl
      << "Target bunches at IP5: " << m_targetBunches << std::endl
-     << "Fill type: " << fillTypeToString( m_fillType ) << std::endl
-     << "Particle type for Beam 1: " << particleTypeToString( m_particles1 ) << std::endl
-     << "Particle type for Beam 2: " << particleTypeToString( m_particles2 ) << std::endl
+     << "Fill type: " << fillTypeToString(m_fillType) << std::endl
+     << "Particle type for Beam 1: " << particleTypeToString(m_particles1) << std::endl
+     << "Particle type for Beam 2: " << particleTypeToString(m_particles2) << std::endl
      << "Crossing angle (urad): " << m_crossingAngle << std::endl
      << "Beta star (cm): " << m_betastar << std::endl
      << "Average Intensity for Beam 1 (number of charges): " << m_intensity1 << std::endl
      << "Average Intensity for Beam 2 (number of charges): " << m_intensity2 << std::endl
      << "Energy (GeV): " << m_energy << std::endl
-     << "Creation time of the fill: " << boost::posix_time::to_iso_extended_string( cond::time::to_boost( m_createTime ) ) << std::endl
-     << "Begin time of Stable Beam flag: " << boost::posix_time::to_iso_extended_string( cond::time::to_boost( m_beginTime ) ) << std::endl
-     << "End time of the fill: " << boost::posix_time::to_iso_extended_string( cond::time::to_boost( m_endTime ) ) << std::endl
+     << "Creation time of the fill: " << boost::posix_time::to_iso_extended_string(cond::time::to_boost(m_createTime))
+     << std::endl
+     << "Begin time of Stable Beam flag: "
+     << boost::posix_time::to_iso_extended_string(cond::time::to_boost(m_beginTime)) << std::endl
+     << "End time of the fill: " << boost::posix_time::to_iso_extended_string(cond::time::to_boost(m_endTime))
+     << std::endl
      << "Injection scheme as given by LPC: " << m_injectionScheme << std::endl;
   std::vector<unsigned short> bunchVector1 = this->bunchConfigurationForBeam1();
   std::vector<unsigned short> bunchVector2 = this->bunchConfigurationForBeam2();
   ss << "Bunches filled for Beam 1 (total " << bunchVector1.size() << "): ";
-  std::copy( bunchVector1.begin(), bunchVector1.end(), std::ostream_iterator<unsigned short>( ss, ", " ) );
+  std::copy(bunchVector1.begin(), bunchVector1.end(), std::ostream_iterator<unsigned short>(ss, ", "));
   ss << std::endl;
   ss << "Bunches filled for Beam 2 (total " << bunchVector2.size() << "): ";
-  std::copy( bunchVector2.begin(), bunchVector2.end(), std::ostream_iterator<unsigned short>( ss, ", " ) );
+  std::copy(bunchVector2.begin(), bunchVector2.end(), std::ostream_iterator<unsigned short>(ss, ", "));
   ss << std::endl;
 }
 
 //protected getters
-std::bitset<FillInfo::bunchSlots+1> const & FillInfo::bunchBitsetForBeam1() const {
-  return m_bunchConfiguration1;  
-}
+std::bitset<FillInfo::bunchSlots + 1> const& FillInfo::bunchBitsetForBeam1() const { return m_bunchConfiguration1; }
 
-std::bitset<FillInfo::bunchSlots+1> const & FillInfo::bunchBitsetForBeam2() const {
-  return m_bunchConfiguration2;  
-}
+std::bitset<FillInfo::bunchSlots + 1> const& FillInfo::bunchBitsetForBeam2() const { return m_bunchConfiguration2; }
 
 //protected setters
-void FillInfo::setBunchBitsetForBeam1( std::bitset<FillInfo::bunchSlots+1> const & bunchConfiguration ) {
+void FillInfo::setBunchBitsetForBeam1(std::bitset<FillInfo::bunchSlots + 1> const& bunchConfiguration) {
   m_bunchConfiguration1 = bunchConfiguration;
 }
 
-void FillInfo::setBunchBitsetForBeam2( std::bitset<FillInfo::bunchSlots+1> const & bunchConfiguration ) {
+void FillInfo::setBunchBitsetForBeam2(std::bitset<FillInfo::bunchSlots + 1> const& bunchConfiguration) {
   m_bunchConfiguration2 = bunchConfiguration;
 }
 
-std::ostream & operator<<( std::ostream & os, FillInfo fillInfo ) {
+std::ostream& operator<<(std::ostream& os, FillInfo fillInfo) {
   std::stringstream ss;
-  fillInfo.print( ss );
+  fillInfo.print(ss);
   os << ss.str();
   return os;
 }

--- a/CondFormats/RunInfo/src/L1TriggerScaler.cc
+++ b/CondFormats/RunInfo/src/L1TriggerScaler.cc
@@ -1,160 +1,144 @@
 #include "CondFormats/RunInfo/interface/L1TriggerScaler.h"
-L1TriggerScaler::L1TriggerScaler(){
-   m_run.reserve(10000); 
-  
- }
-void L1TriggerScaler::printAllValues() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\n lumisegment: "  << it->m_lumisegment<<
-      "\n start_time: "  << it->m_start_time <<std::endl;    
+L1TriggerScaler::L1TriggerScaler() { m_run.reserve(10000); }
+void L1TriggerScaler::printAllValues() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\n lumisegment: " << it->m_lumisegment
+              << "\n start_time: " << it->m_start_time << std::endl;
 
-    for(size_t i=0; i<it->m_GTAlgoRates.size(); i++ ){ 
-      std::cout << "m_GTAlgoRates["<<i<<"] = "<< it->m_GTAlgoRates[i]<<std::endl;  
+    for (size_t i = 0; i < it->m_GTAlgoRates.size(); i++) {
+      std::cout << "m_GTAlgoRates[" << i << "] = " << it->m_GTAlgoRates[i] << std::endl;
     }
-    for(size_t i=0; i<it->m_GTAlgoPrescaling.size(); i++ ){ 
-      std::cout << "m_GTAlgoPrescaling["<<i<<"] = "<< it->m_GTAlgoPrescaling[i]<<std::endl;  
-    } 
-    for(size_t i=0; i<it->m_GTTechCounts.size(); i++ ){ 
-      std::cout << " m_GTTechCounts["<<i<<"] = "<< it->m_GTTechCounts[i]<<std::endl;  
-    } 
-    for(size_t i=0; i<it->m_GTTechRates.size(); i++ ){ 
-      std::cout << " m_GTTechRates["<<i<<"] = "<< it->m_GTTechRates[i]<<std::endl;  
-    } 
-    for(size_t i=0; i<it->m_GTTechPrescaling.size(); i++ ){ 
-      std::cout << " m_GTTechPrescaling["<<i<<"] = "<< it->m_GTTechPrescaling[i]<<std::endl;  
-    } 
-    for(size_t i=0; i<it->m_GTPartition0TriggerCounts.size(); i++ ){ 
-      std::cout << " m_GTPartition0TriggerCounts["<<i<<"] = "<< it->m_GTPartition0TriggerCounts[i]<<std::endl;  
-    } 
-    for(size_t i=0; i<it->m_GTPartition0TriggerRates.size(); i++ ){ 
-      std::cout << " m_GTPartition0TriggerRates["<<i<<"] = "<< it->m_GTPartition0TriggerRates[i]<<std::endl;  
-    } 
-    for(size_t i=0; i<it->m_GTPartition0DeadTime.size(); i++ ){ 
-      std::cout << " m_GTPartition0DeadTime["<<i<<"] = "<< it->m_GTPartition0DeadTime[i]<<std::endl;  
+    for (size_t i = 0; i < it->m_GTAlgoPrescaling.size(); i++) {
+      std::cout << "m_GTAlgoPrescaling[" << i << "] = " << it->m_GTAlgoPrescaling[i] << std::endl;
     }
-    for(size_t i=0; i<it->m_GTPartition0DeadTimeRatio.size(); i++ ){ 
-      std::cout << " m_GTPartition0DeadTimeRatio["<<i<<"] = "<< it->m_GTPartition0DeadTimeRatio[i]<<std::endl;  
-    } 
-  }
-} 
-
-void L1TriggerScaler::printRunValue() const{
-  LumiIterator it=m_run.begin();
-  std::cout<<it->m_rn<<std::endl;
-}
-
-void  L1TriggerScaler::printLumiSegmentValues() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\n lumisegment: "  << it->m_lumisegment<<
-    "\n start_time: "  << it->m_start_time <<std::endl;   
- }
-}
-
-void L1TriggerScaler::printFormat() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\n lumisegment: "  << it->m_lumisegment<<std::endl;  
-    std::cout<< "format :" << it->m_string_format <<std::endl;
-  } 
-}
-
-void  L1TriggerScaler::printGTAlgoCounts() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\n lumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTAlgoCounts.size(); i++ ){ 
-      std::cout << "m_GTAlgoCounts["<<i<<"] = "<< it->m_GTAlgoCounts[i]<<std::endl;  
+    for (size_t i = 0; i < it->m_GTTechCounts.size(); i++) {
+      std::cout << " m_GTTechCounts[" << i << "] = " << it->m_GTTechCounts[i] << std::endl;
+    }
+    for (size_t i = 0; i < it->m_GTTechRates.size(); i++) {
+      std::cout << " m_GTTechRates[" << i << "] = " << it->m_GTTechRates[i] << std::endl;
+    }
+    for (size_t i = 0; i < it->m_GTTechPrescaling.size(); i++) {
+      std::cout << " m_GTTechPrescaling[" << i << "] = " << it->m_GTTechPrescaling[i] << std::endl;
+    }
+    for (size_t i = 0; i < it->m_GTPartition0TriggerCounts.size(); i++) {
+      std::cout << " m_GTPartition0TriggerCounts[" << i << "] = " << it->m_GTPartition0TriggerCounts[i] << std::endl;
+    }
+    for (size_t i = 0; i < it->m_GTPartition0TriggerRates.size(); i++) {
+      std::cout << " m_GTPartition0TriggerRates[" << i << "] = " << it->m_GTPartition0TriggerRates[i] << std::endl;
+    }
+    for (size_t i = 0; i < it->m_GTPartition0DeadTime.size(); i++) {
+      std::cout << " m_GTPartition0DeadTime[" << i << "] = " << it->m_GTPartition0DeadTime[i] << std::endl;
+    }
+    for (size_t i = 0; i < it->m_GTPartition0DeadTimeRatio.size(); i++) {
+      std::cout << " m_GTPartition0DeadTimeRatio[" << i << "] = " << it->m_GTPartition0DeadTimeRatio[i] << std::endl;
     }
   }
 }
 
-void  L1TriggerScaler::printGTAlgoRates() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\n lumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTAlgoRates.size(); i++ ){ 
-      std::cout << "m_GTAlgoRates["<<i<<"] = "<< it->m_GTAlgoRates[i]<<std::endl;  
+void L1TriggerScaler::printRunValue() const {
+  LumiIterator it = m_run.begin();
+  std::cout << it->m_rn << std::endl;
+}
+
+void L1TriggerScaler::printLumiSegmentValues() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\n lumisegment: " << it->m_lumisegment
+              << "\n start_time: " << it->m_start_time << std::endl;
+  }
+}
+
+void L1TriggerScaler::printFormat() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\n lumisegment: " << it->m_lumisegment << std::endl;
+    std::cout << "format :" << it->m_string_format << std::endl;
+  }
+}
+
+void L1TriggerScaler::printGTAlgoCounts() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\n lumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTAlgoCounts.size(); i++) {
+      std::cout << "m_GTAlgoCounts[" << i << "] = " << it->m_GTAlgoCounts[i] << std::endl;
     }
   }
 }
 
-void  L1TriggerScaler::printGTAlgoPrescaling() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\n lumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTAlgoPrescaling.size(); i++ ){ 
-      std::cout << "m_GTAlgoPrescaling["<<i<<"] = "<< it->m_GTAlgoPrescaling[i]<<std::endl;  
-    }
-  }
-}
-void  L1TriggerScaler::printGTTechCounts() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\nlumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTTechCounts.size(); i++ ){ 
-      std::cout << "m_GTTechCounts["<<i<<"] = "<< it->m_GTTechCounts[i]<<std::endl;  
+void L1TriggerScaler::printGTAlgoRates() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\n lumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTAlgoRates.size(); i++) {
+      std::cout << "m_GTAlgoRates[" << i << "] = " << it->m_GTAlgoRates[i] << std::endl;
     }
   }
 }
 
-void  L1TriggerScaler::printGTTechRates() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\nlumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTTechRates.size(); i++ ){ 
-      std::cout << "m_GTTechRates["<<i<<"] = "<< it->m_GTTechRates[i]<<std::endl;  
+void L1TriggerScaler::printGTAlgoPrescaling() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\n lumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTAlgoPrescaling.size(); i++) {
+      std::cout << "m_GTAlgoPrescaling[" << i << "] = " << it->m_GTAlgoPrescaling[i] << std::endl;
+    }
+  }
+}
+void L1TriggerScaler::printGTTechCounts() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\nlumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTTechCounts.size(); i++) {
+      std::cout << "m_GTTechCounts[" << i << "] = " << it->m_GTTechCounts[i] << std::endl;
     }
   }
 }
 
-void  L1TriggerScaler::printGTTechPrescaling() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\nlumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTTechPrescaling.size(); i++ ){ 
-      std::cout << "m_GTTechPrescaling["<<i<<"] = "<< it->m_GTTechPrescaling[i]<<std::endl;  
+void L1TriggerScaler::printGTTechRates() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\nlumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTTechRates.size(); i++) {
+      std::cout << "m_GTTechRates[" << i << "] = " << it->m_GTTechRates[i] << std::endl;
     }
   }
 }
 
-void  L1TriggerScaler::printGTPartition0TriggerCounts() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\nlumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTPartition0TriggerCounts.size(); i++ ){ 
-      std::cout << "m_GTPartition0TriggerCounts["<<i<<"] = "<< it->m_GTPartition0TriggerCounts[i]<<std::endl;  
+void L1TriggerScaler::printGTTechPrescaling() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\nlumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTTechPrescaling.size(); i++) {
+      std::cout << "m_GTTechPrescaling[" << i << "] = " << it->m_GTTechPrescaling[i] << std::endl;
     }
   }
 }
 
-void  L1TriggerScaler::printGTPartition0TriggerRates() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\nlumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTPartition0TriggerRates.size(); i++ ){ 
-      std::cout << "m_GTPartition0TriggerRates["<<i<<"] = "<< it->m_GTPartition0TriggerRates[i]<<std::endl;  
-    }
-  }
-}
- 
-void  L1TriggerScaler::printGTPartition0DeadTime() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\nlumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTPartition0DeadTime.size(); i++ ){ 
-      std::cout << "m_GTPartition0DeadTime["<<i<<"] = "<< it->m_GTPartition0DeadTime[i]<<std::endl;  
+void L1TriggerScaler::printGTPartition0TriggerCounts() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\nlumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTPartition0TriggerCounts.size(); i++) {
+      std::cout << "m_GTPartition0TriggerCounts[" << i << "] = " << it->m_GTPartition0TriggerCounts[i] << std::endl;
     }
   }
 }
 
-void  L1TriggerScaler::printGTPartition0DeadTimeRatio() const{
-  for(LumiIterator it=m_run.begin(); it!=m_run.end(); ++it){
-    std::cout << "  run:  " <<it->m_rn<<
-      "\nlumisegment: "  << it->m_lumisegment<<std::endl;  
-    for(size_t i=0; i<it->m_GTPartition0DeadTimeRatio.size(); i++ ){ 
-      std::cout << "m_GTPartition0DeadTimeRatio["<<i<<"] = "<< it->m_GTPartition0DeadTimeRatio[i]<<std::endl;  
+void L1TriggerScaler::printGTPartition0TriggerRates() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\nlumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTPartition0TriggerRates.size(); i++) {
+      std::cout << "m_GTPartition0TriggerRates[" << i << "] = " << it->m_GTPartition0TriggerRates[i] << std::endl;
+    }
+  }
+}
+
+void L1TriggerScaler::printGTPartition0DeadTime() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\nlumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTPartition0DeadTime.size(); i++) {
+      std::cout << "m_GTPartition0DeadTime[" << i << "] = " << it->m_GTPartition0DeadTime[i] << std::endl;
+    }
+  }
+}
+
+void L1TriggerScaler::printGTPartition0DeadTimeRatio() const {
+  for (LumiIterator it = m_run.begin(); it != m_run.end(); ++it) {
+    std::cout << "  run:  " << it->m_rn << "\nlumisegment: " << it->m_lumisegment << std::endl;
+    for (size_t i = 0; i < it->m_GTPartition0DeadTimeRatio.size(); i++) {
+      std::cout << "m_GTPartition0DeadTimeRatio[" << i << "] = " << it->m_GTPartition0DeadTimeRatio[i] << std::endl;
     }
   }
 }

--- a/CondFormats/RunInfo/src/LHCInfo.cc
+++ b/CondFormats/RunInfo/src/LHCInfo.cc
@@ -6,501 +6,445 @@
 #include <stdexcept>
 
 //helper function: returns the positions of the bits in the bitset that are set (i.e., have a value of 1).
-static std::vector<unsigned short> bitsetToVector( std::bitset<LHCInfo::bunchSlots+1> const & bs ) {
+static std::vector<unsigned short> bitsetToVector(std::bitset<LHCInfo::bunchSlots + 1> const& bs) {
   std::vector<unsigned short> vec;
   //reserve space only for the bits in the bitset that are set
-  vec.reserve( bs.count() );
-  for( size_t i = 0; i < bs.size(); ++i ) {
-    if( bs.test( i ) )
-      vec.push_back( (unsigned short) i );
+  vec.reserve(bs.count());
+  for (size_t i = 0; i < bs.size(); ++i) {
+    if (bs.test(i))
+      vec.push_back((unsigned short)i);
   }
   return vec;
 }
 
 //helper function: returns the enum for fill types in string type
-static std::string fillTypeToString( LHCInfo::FillTypeId const & fillType ) {
-  std::string s_fillType( "UNKNOWN" );
-  switch( fillType ) {
-  case LHCInfo::UNKNOWN :
-    s_fillType = std::string( "UNKNOWN" );
-    break;
-  case LHCInfo::PROTONS :
-    s_fillType = std::string( "PROTONS" );
-    break;
-  case LHCInfo::IONS :
-    s_fillType = std::string( "IONS" );
-    break;
-  case LHCInfo::COSMICS :
-    s_fillType = std::string( "COSMICS" );
-    break;
-  case LHCInfo::GAP :
-    s_fillType = std::string( "GAP" );
-    break;
-  default :
-    s_fillType = std::string( "UNKNOWN" );
+static std::string fillTypeToString(LHCInfo::FillTypeId const& fillType) {
+  std::string s_fillType("UNKNOWN");
+  switch (fillType) {
+    case LHCInfo::UNKNOWN:
+      s_fillType = std::string("UNKNOWN");
+      break;
+    case LHCInfo::PROTONS:
+      s_fillType = std::string("PROTONS");
+      break;
+    case LHCInfo::IONS:
+      s_fillType = std::string("IONS");
+      break;
+    case LHCInfo::COSMICS:
+      s_fillType = std::string("COSMICS");
+      break;
+    case LHCInfo::GAP:
+      s_fillType = std::string("GAP");
+      break;
+    default:
+      s_fillType = std::string("UNKNOWN");
   }
   return s_fillType;
 }
 
 //helper function: returns the enum for particle types in string type
-static std::string particleTypeToString( LHCInfo::ParticleTypeId const & particleType ) {
-  std::string s_particleType( "NONE" );
-  switch( particleType ) {
-  case LHCInfo::NONE :
-    s_particleType = std::string( "NONE" );
-    break;
-  case LHCInfo::PROTON :
-    s_particleType = std::string( "PROTON" );
-    break;
-  case LHCInfo::PB82 :
-    s_particleType = std::string( "PB82" );
-    break;
-  case LHCInfo::AR18 :
-    s_particleType = std::string( "AR18" );
-    break;
-  case LHCInfo::D :
-    s_particleType = std::string( "D" );
-    break;
-  case LHCInfo::XE54 :
-    s_particleType = std::string( "XE54" );
-    break;
-  default :
-    s_particleType = std::string( "NONE" );
+static std::string particleTypeToString(LHCInfo::ParticleTypeId const& particleType) {
+  std::string s_particleType("NONE");
+  switch (particleType) {
+    case LHCInfo::NONE:
+      s_particleType = std::string("NONE");
+      break;
+    case LHCInfo::PROTON:
+      s_particleType = std::string("PROTON");
+      break;
+    case LHCInfo::PB82:
+      s_particleType = std::string("PB82");
+      break;
+    case LHCInfo::AR18:
+      s_particleType = std::string("AR18");
+      break;
+    case LHCInfo::D:
+      s_particleType = std::string("D");
+      break;
+    case LHCInfo::XE54:
+      s_particleType = std::string("XE54");
+      break;
+    default:
+      s_particleType = std::string("NONE");
   }
   return s_particleType;
 }
 
-LHCInfo::LHCInfo(){
-  m_intParams.resize( ISIZE, std::vector<unsigned int>(1,0) );
-  m_floatParams.resize( FSIZE, std::vector<float>(1, 0.) );
-  m_floatParams[ LUMI_PER_B ] = std::vector<float>();
-  m_floatParams[ BEAM1_VC ] = std::vector<float>();
-  m_floatParams[ BEAM2_VC ] = std::vector<float>();
-  m_floatParams[ BEAM1_RF ] = std::vector<float>();
-  m_floatParams[ BEAM2_RF ] = std::vector<float>();
-  m_timeParams.resize( TSIZE, std::vector<unsigned long long>(1,0ULL) );
-  m_stringParams.resize( SSIZE, std::vector<std::string>(1, "") );
-  m_stringParams[ INJECTION_SCHEME ].push_back( std::string("None") );
+LHCInfo::LHCInfo() {
+  m_intParams.resize(ISIZE, std::vector<unsigned int>(1, 0));
+  m_floatParams.resize(FSIZE, std::vector<float>(1, 0.));
+  m_floatParams[LUMI_PER_B] = std::vector<float>();
+  m_floatParams[BEAM1_VC] = std::vector<float>();
+  m_floatParams[BEAM2_VC] = std::vector<float>();
+  m_floatParams[BEAM1_RF] = std::vector<float>();
+  m_floatParams[BEAM2_RF] = std::vector<float>();
+  m_timeParams.resize(TSIZE, std::vector<unsigned long long>(1, 0ULL));
+  m_stringParams.resize(SSIZE, std::vector<std::string>(1, ""));
+  m_stringParams[INJECTION_SCHEME].push_back(std::string("None"));
 }
 
-LHCInfo::LHCInfo( const LHCInfo& rhs ):
-  m_intParams( rhs.m_intParams ),
-  m_floatParams( rhs.m_floatParams ),
-  m_timeParams( rhs.m_timeParams ),
-  m_stringParams( rhs.m_stringParams ),
-  m_bunchConfiguration1( rhs.m_bunchConfiguration1), 
-  m_bunchConfiguration2( rhs.m_bunchConfiguration2){
-}
+LHCInfo::LHCInfo(const LHCInfo& rhs)
+    : m_intParams(rhs.m_intParams),
+      m_floatParams(rhs.m_floatParams),
+      m_timeParams(rhs.m_timeParams),
+      m_stringParams(rhs.m_stringParams),
+      m_bunchConfiguration1(rhs.m_bunchConfiguration1),
+      m_bunchConfiguration2(rhs.m_bunchConfiguration2) {}
 
-LHCInfo::~LHCInfo() {
-}
+LHCInfo::~LHCInfo() {}
 
 LHCInfo* LHCInfo::cloneFill() const {
   LHCInfo* ret = new LHCInfo();
   ret->m_isData = m_isData;
-  if( !m_intParams[0].empty()){
-    for(size_t i=0;i<LUMI_SECTION; i++) ret->m_intParams[i]=m_intParams[i];
-    for(size_t i=0;i<DELIV_LUMI; i++) ret->m_floatParams[i]=m_floatParams[i];
+  if (!m_intParams[0].empty()) {
+    for (size_t i = 0; i < LUMI_SECTION; i++)
+      ret->m_intParams[i] = m_intParams[i];
+    for (size_t i = 0; i < DELIV_LUMI; i++)
+      ret->m_floatParams[i] = m_floatParams[i];
     ret->m_floatParams[LUMI_PER_B] = m_floatParams[LUMI_PER_B];
-    for(size_t i=0;i<TSIZE; i++) ret->m_timeParams[i]=m_timeParams[i];
-    for(size_t i=0;i<LHC_STATE; i++) ret->m_stringParams[i]=m_stringParams[i];
-    ret->m_bunchConfiguration1=m_bunchConfiguration1;
-    ret->m_bunchConfiguration2=m_bunchConfiguration2;
+    for (size_t i = 0; i < TSIZE; i++)
+      ret->m_timeParams[i] = m_timeParams[i];
+    for (size_t i = 0; i < LHC_STATE; i++)
+      ret->m_stringParams[i] = m_stringParams[i];
+    ret->m_bunchConfiguration1 = m_bunchConfiguration1;
+    ret->m_bunchConfiguration2 = m_bunchConfiguration2;
   }
   return ret;
 }
 
 namespace LHCInfoImpl {
-  template <typename T> const T& getParams( const std::vector<T>& params, size_t index ){
-    if( index >= params.size() ) throw std::out_of_range("Parameter with index "+std::to_string(index)+" is out of range.");
-    return params[index];
-  }  
-
-  template <typename T> T& accessParams( std::vector<T>& params, size_t index ){
-    if( index >= params.size() ) throw std::out_of_range("Parameter with index "+std::to_string(index)+" is out of range.");
+  template <typename T>
+  const T& getParams(const std::vector<T>& params, size_t index) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
     return params[index];
   }
 
-  template <typename T> const T& getOneParam( const std::vector< std::vector<T> >& params, size_t index ){
-    if( index >= params.size() ) throw std::out_of_range("Parameter with index "+std::to_string(index)+" is out of range.");
+  template <typename T>
+  T& accessParams(std::vector<T>& params, size_t index) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    return params[index];
+  }
+
+  template <typename T>
+  const T& getOneParam(const std::vector<std::vector<T> >& params, size_t index) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
     const std::vector<T>& inner = params[index];
-    if( inner.empty() ) throw std::out_of_range("Parameter with index "+std::to_string(index)+" type="+typeid(T).name()+" has no value stored.");
-    return inner[ 0 ];
+    if (inner.empty())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " type=" + typeid(T).name() +
+                              " has no value stored.");
+    return inner[0];
   }
 
-  template <typename T> void setOneParam( std::vector< std::vector<T> >& params, size_t index, const T& value ){
-    if( index >= params.size() ) throw std::out_of_range("Parameter with index "+std::to_string(index)+" is out of range.");
-    params[ index ] = std::vector<T>(1,value);
+  template <typename T>
+  void setOneParam(std::vector<std::vector<T> >& params, size_t index, const T& value) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    params[index] = std::vector<T>(1, value);
   }
 
-  template <typename T> void setParams( std::vector<T>& params, size_t index, const T& value ){
-    if( index >= params.size() ) throw std::out_of_range("Parameter with index "+std::to_string(index)+" is out of range.");
-    params[ index ] = value;
+  template <typename T>
+  void setParams(std::vector<T>& params, size_t index, const T& value) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    params[index] = value;
   }
 
-}
+}  // namespace LHCInfoImpl
 
 //getters
-unsigned short const LHCInfo::fillNumber() const {
-  return LHCInfoImpl::getOneParam( m_intParams, LHC_FILL );
-}
+unsigned short const LHCInfo::fillNumber() const { return LHCInfoImpl::getOneParam(m_intParams, LHC_FILL); }
 
-unsigned short const LHCInfo::bunchesInBeam1() const {
-  return LHCInfoImpl::getOneParam( m_intParams, BUNCHES_1 );
-}
+unsigned short const LHCInfo::bunchesInBeam1() const { return LHCInfoImpl::getOneParam(m_intParams, BUNCHES_1); }
 
-unsigned short const LHCInfo::bunchesInBeam2() const {
-  return LHCInfoImpl::getOneParam( m_intParams, BUNCHES_2 );
-}
+unsigned short const LHCInfo::bunchesInBeam2() const { return LHCInfoImpl::getOneParam(m_intParams, BUNCHES_2); }
 
 unsigned short const LHCInfo::collidingBunches() const {
-  return LHCInfoImpl::getOneParam( m_intParams, COLLIDING_BUNCHES );
+  return LHCInfoImpl::getOneParam(m_intParams, COLLIDING_BUNCHES);
 }
 
-unsigned short const LHCInfo::targetBunches() const {
-  return LHCInfoImpl::getOneParam( m_intParams, TARGET_BUNCHES );
-}
+unsigned short const LHCInfo::targetBunches() const { return LHCInfoImpl::getOneParam(m_intParams, TARGET_BUNCHES); }
 
 LHCInfo::FillTypeId const LHCInfo::fillType() const {
-  return static_cast<FillTypeId>(LHCInfoImpl::getOneParam( m_intParams, FILL_TYPE ));
+  return static_cast<FillTypeId>(LHCInfoImpl::getOneParam(m_intParams, FILL_TYPE));
 }
 
 LHCInfo::ParticleTypeId const LHCInfo::particleTypeForBeam1() const {
-  return static_cast<ParticleTypeId>(LHCInfoImpl::getOneParam( m_intParams, PARTICLES_1 ));
+  return static_cast<ParticleTypeId>(LHCInfoImpl::getOneParam(m_intParams, PARTICLES_1));
 }
 
 LHCInfo::ParticleTypeId const LHCInfo::particleTypeForBeam2() const {
-  return static_cast<ParticleTypeId>(LHCInfoImpl::getOneParam( m_intParams, PARTICLES_2 ));
+  return static_cast<ParticleTypeId>(LHCInfoImpl::getOneParam(m_intParams, PARTICLES_2));
 }
 
-float const LHCInfo::crossingAngle() const {
-  return LHCInfoImpl::getOneParam( m_floatParams, CROSSING_ANGLE );
+float const LHCInfo::crossingAngle() const { return LHCInfoImpl::getOneParam(m_floatParams, CROSSING_ANGLE); }
+
+float const LHCInfo::betaStar() const { return LHCInfoImpl::getOneParam(m_floatParams, BETA_STAR); }
+
+float const LHCInfo::intensityForBeam1() const { return LHCInfoImpl::getOneParam(m_floatParams, INTENSITY_1); }
+
+float const LHCInfo::intensityForBeam2() const { return LHCInfoImpl::getOneParam(m_floatParams, INTENSITY_2); }
+
+float const LHCInfo::energy() const { return LHCInfoImpl::getOneParam(m_floatParams, ENERGY); }
+
+float const LHCInfo::delivLumi() const { return LHCInfoImpl::getOneParam(m_floatParams, DELIV_LUMI); }
+
+float const LHCInfo::recLumi() const { return LHCInfoImpl::getOneParam(m_floatParams, REC_LUMI); }
+
+float const LHCInfo::instLumi() const { return LHCInfoImpl::getOneParam(m_floatParams, INST_LUMI); }
+
+float const LHCInfo::instLumiError() const { return LHCInfoImpl::getOneParam(m_floatParams, INST_LUMI_ERR); }
+
+cond::Time_t const LHCInfo::createTime() const { return LHCInfoImpl::getOneParam(m_timeParams, CREATE_TIME); }
+
+cond::Time_t const LHCInfo::beginTime() const { return LHCInfoImpl::getOneParam(m_timeParams, BEGIN_TIME); }
+
+cond::Time_t const LHCInfo::endTime() const { return LHCInfoImpl::getOneParam(m_timeParams, END_TIME); }
+
+std::string const& LHCInfo::injectionScheme() const {
+  return LHCInfoImpl::getOneParam(m_stringParams, INJECTION_SCHEME);
 }
 
-float const LHCInfo::betaStar() const {
-  return LHCInfoImpl::getOneParam( m_floatParams, BETA_STAR );
-}
+std::vector<float> const& LHCInfo::lumiPerBX() const { return LHCInfoImpl::getParams(m_floatParams, LUMI_PER_B); }
 
-float const LHCInfo::intensityForBeam1() const {
-  return LHCInfoImpl::getOneParam( m_floatParams, INTENSITY_1 );
-}
+std::string const& LHCInfo::lhcState() const { return LHCInfoImpl::getOneParam(m_stringParams, LHC_STATE); }
 
-float const LHCInfo::intensityForBeam2() const {
-  return LHCInfoImpl::getOneParam( m_floatParams, INTENSITY_2 );
-}
+std::string const& LHCInfo::lhcComment() const { return LHCInfoImpl::getOneParam(m_stringParams, LHC_COMMENT); }
 
-float const LHCInfo::energy() const {
-  return LHCInfoImpl::getOneParam( m_floatParams, ENERGY );
-}
+std::string const& LHCInfo::ctppsStatus() const { return LHCInfoImpl::getOneParam(m_stringParams, CTPPS_STATUS); }
 
-float const LHCInfo::delivLumi() const {
-  return LHCInfoImpl::getOneParam( m_floatParams, DELIV_LUMI );
-}
+unsigned int const& LHCInfo::lumiSection() const { return LHCInfoImpl::getOneParam(m_intParams, LUMI_SECTION); }
 
-float const LHCInfo::recLumi() const {
-  return LHCInfoImpl::getOneParam( m_floatParams, REC_LUMI );
-}
+std::vector<float> const& LHCInfo::beam1VC() const { return LHCInfoImpl::getParams(m_floatParams, BEAM1_VC); }
 
-float const LHCInfo::instLumi() const {
-  return LHCInfoImpl::getOneParam( m_floatParams, INST_LUMI );
-}
+std::vector<float> const& LHCInfo::beam2VC() const { return LHCInfoImpl::getParams(m_floatParams, BEAM2_VC); }
 
-float const LHCInfo::instLumiError() const {
-  return LHCInfoImpl::getOneParam( m_floatParams, INST_LUMI_ERR );
-}
+std::vector<float> const& LHCInfo::beam1RF() const { return LHCInfoImpl::getParams(m_floatParams, BEAM1_RF); }
 
-cond::Time_t const LHCInfo::createTime() const {
-  return LHCInfoImpl::getOneParam( m_timeParams, CREATE_TIME );
-}
+std::vector<float> const& LHCInfo::beam2RF() const { return LHCInfoImpl::getParams(m_floatParams, BEAM2_RF); }
 
-cond::Time_t const LHCInfo::beginTime() const {
-  return LHCInfoImpl::getOneParam(m_timeParams, BEGIN_TIME );
-}
+std::vector<float>& LHCInfo::beam1VC() { return LHCInfoImpl::accessParams(m_floatParams, BEAM1_VC); }
 
-cond::Time_t const LHCInfo::endTime() const {
-  return LHCInfoImpl::getOneParam(m_timeParams, END_TIME );
-}
+std::vector<float>& LHCInfo::beam2VC() { return LHCInfoImpl::accessParams(m_floatParams, BEAM2_VC); }
 
-std::string const & LHCInfo::injectionScheme() const {
-  return LHCInfoImpl::getOneParam(m_stringParams, INJECTION_SCHEME );
-}
+std::vector<float>& LHCInfo::beam1RF() { return LHCInfoImpl::accessParams(m_floatParams, BEAM1_RF); }
 
-std::vector<float> const & LHCInfo::lumiPerBX() const {
-  return LHCInfoImpl::getParams(m_floatParams, LUMI_PER_B );
-}
-
-std::string const & LHCInfo::lhcState() const {
-  return LHCInfoImpl::getOneParam(m_stringParams, LHC_STATE );
-}
-
-std::string const & LHCInfo::lhcComment() const {
-  return LHCInfoImpl::getOneParam(m_stringParams, LHC_COMMENT );
-}
-
-std::string const & LHCInfo::ctppsStatus() const {
-  return LHCInfoImpl::getOneParam(m_stringParams, CTPPS_STATUS );
-}
-
-unsigned int const & LHCInfo::lumiSection() const {
-  return LHCInfoImpl::getOneParam(m_intParams, LUMI_SECTION );
-}
-
-std::vector<float> const & LHCInfo::beam1VC() const {
-  return LHCInfoImpl::getParams(m_floatParams, BEAM1_VC );
-}
-
-std::vector<float> const & LHCInfo::beam2VC() const {
-  return LHCInfoImpl::getParams(m_floatParams, BEAM2_VC );
-}
-
-std::vector<float> const & LHCInfo::beam1RF() const {
-  return LHCInfoImpl::getParams(m_floatParams, BEAM1_RF );
-}
-
-std::vector<float> const & LHCInfo::beam2RF() const {
-  return LHCInfoImpl::getParams(m_floatParams, BEAM2_RF );
-}
-
-std::vector<float>& LHCInfo::beam1VC(){
-  return LHCInfoImpl::accessParams(m_floatParams, BEAM1_VC );
-}
-
-std::vector<float>& LHCInfo::beam2VC(){
-  return LHCInfoImpl::accessParams(m_floatParams, BEAM2_VC );
-}
-
-std::vector<float>& LHCInfo::beam1RF(){
-  return LHCInfoImpl::accessParams(m_floatParams, BEAM1_RF );
-}
-
-std::vector<float>& LHCInfo::beam2RF(){
-  return LHCInfoImpl::accessParams(m_floatParams, BEAM2_RF );
-}
+std::vector<float>& LHCInfo::beam2RF() { return LHCInfoImpl::accessParams(m_floatParams, BEAM2_RF); }
 
 //returns a boolean, true if the injection scheme has a leading 25ns
 //TODO: parse the circulating bunch configuration, instead of the string.
 bool LHCInfo::is25nsBunchSpacing() const {
-  const std::string prefix( "25ns" );
-  return std::equal( prefix.begin(), prefix.end(), injectionScheme().begin() );
+  const std::string prefix("25ns");
+  return std::equal(prefix.begin(), prefix.end(), injectionScheme().begin());
 }
 
 //returns a boolean, true if the bunch slot number is in the circulating bunch configuration
-bool LHCInfo::isBunchInBeam1( size_t const & bunch ) const {
-  if( bunch == 0 )
-    throw std::out_of_range( "0 not allowed" ); //CMS starts counting bunch crossing from 1!
-  return m_bunchConfiguration1.test( bunch );
+bool LHCInfo::isBunchInBeam1(size_t const& bunch) const {
+  if (bunch == 0)
+    throw std::out_of_range("0 not allowed");  //CMS starts counting bunch crossing from 1!
+  return m_bunchConfiguration1.test(bunch);
 }
 
-bool LHCInfo::isBunchInBeam2( size_t const & bunch ) const {
-  if( bunch == 0 )
-    throw std::out_of_range( "0 not allowed" ); //CMS starts counting bunch crossing from 1!
-  return m_bunchConfiguration2.test( bunch );
+bool LHCInfo::isBunchInBeam2(size_t const& bunch) const {
+  if (bunch == 0)
+    throw std::out_of_range("0 not allowed");  //CMS starts counting bunch crossing from 1!
+  return m_bunchConfiguration2.test(bunch);
 }
 
 //member functions returning *by value* a vector with all filled bunch slots
 std::vector<unsigned short> LHCInfo::bunchConfigurationForBeam1() const {
-  return bitsetToVector( m_bunchConfiguration1 );
+  return bitsetToVector(m_bunchConfiguration1);
 }
 
 std::vector<unsigned short> LHCInfo::bunchConfigurationForBeam2() const {
-  return bitsetToVector( m_bunchConfiguration2 );
+  return bitsetToVector(m_bunchConfiguration2);
 }
 
-void LHCInfo::setFillNumber( unsigned short lhcFill ) {
-  LHCInfoImpl::setOneParam( m_intParams, LHC_FILL, static_cast<unsigned int>(lhcFill) );
+void LHCInfo::setFillNumber(unsigned short lhcFill) {
+  LHCInfoImpl::setOneParam(m_intParams, LHC_FILL, static_cast<unsigned int>(lhcFill));
 }
 
 //setters
-void LHCInfo::setBunchesInBeam1( unsigned short const & bunches ) {
-  LHCInfoImpl::setOneParam( m_intParams, BUNCHES_1, static_cast<unsigned int>(bunches) );
+void LHCInfo::setBunchesInBeam1(unsigned short const& bunches) {
+  LHCInfoImpl::setOneParam(m_intParams, BUNCHES_1, static_cast<unsigned int>(bunches));
 }
 
-void LHCInfo::setBunchesInBeam2( unsigned short const & bunches ) {
-  LHCInfoImpl::setOneParam( m_intParams, BUNCHES_2, static_cast<unsigned int>(bunches) );
+void LHCInfo::setBunchesInBeam2(unsigned short const& bunches) {
+  LHCInfoImpl::setOneParam(m_intParams, BUNCHES_2, static_cast<unsigned int>(bunches));
 }
 
-void LHCInfo::setCollidingBunches( unsigned short const & collidingBunches ) {
-  LHCInfoImpl::setOneParam( m_intParams, COLLIDING_BUNCHES, static_cast<unsigned int>(collidingBunches) );
+void LHCInfo::setCollidingBunches(unsigned short const& collidingBunches) {
+  LHCInfoImpl::setOneParam(m_intParams, COLLIDING_BUNCHES, static_cast<unsigned int>(collidingBunches));
 }
 
-void LHCInfo::setTargetBunches( unsigned short const & targetBunches ) {
-  LHCInfoImpl::setOneParam( m_intParams, TARGET_BUNCHES, static_cast<unsigned int>(targetBunches) );  
+void LHCInfo::setTargetBunches(unsigned short const& targetBunches) {
+  LHCInfoImpl::setOneParam(m_intParams, TARGET_BUNCHES, static_cast<unsigned int>(targetBunches));
 }
 
-void LHCInfo::setFillType( LHCInfo::FillTypeId const & fillType ) {
-  LHCInfoImpl::setOneParam( m_intParams, FILL_TYPE, static_cast<unsigned int>(fillType) );
+void LHCInfo::setFillType(LHCInfo::FillTypeId const& fillType) {
+  LHCInfoImpl::setOneParam(m_intParams, FILL_TYPE, static_cast<unsigned int>(fillType));
 }
 
-void LHCInfo::setParticleTypeForBeam1( LHCInfo::ParticleTypeId const & particleType ) {
-  LHCInfoImpl::setOneParam( m_intParams, PARTICLES_1, static_cast<unsigned int>(particleType) );
+void LHCInfo::setParticleTypeForBeam1(LHCInfo::ParticleTypeId const& particleType) {
+  LHCInfoImpl::setOneParam(m_intParams, PARTICLES_1, static_cast<unsigned int>(particleType));
 }
 
-void LHCInfo::setParticleTypeForBeam2( LHCInfo::ParticleTypeId const & particleType ) {
-  LHCInfoImpl::setOneParam( m_intParams, PARTICLES_2, static_cast<unsigned int>(particleType) );
+void LHCInfo::setParticleTypeForBeam2(LHCInfo::ParticleTypeId const& particleType) {
+  LHCInfoImpl::setOneParam(m_intParams, PARTICLES_2, static_cast<unsigned int>(particleType));
 }
 
-void LHCInfo::setCrossingAngle( float const & angle ) {
-  LHCInfoImpl::setOneParam( m_floatParams, CROSSING_ANGLE, angle );
-}
-  
-void LHCInfo::setBetaStar( float const & betaStar ) {
-  LHCInfoImpl::setOneParam( m_floatParams, BETA_STAR, betaStar );
+void LHCInfo::setCrossingAngle(float const& angle) { LHCInfoImpl::setOneParam(m_floatParams, CROSSING_ANGLE, angle); }
+
+void LHCInfo::setBetaStar(float const& betaStar) { LHCInfoImpl::setOneParam(m_floatParams, BETA_STAR, betaStar); }
+
+void LHCInfo::setIntensityForBeam1(float const& intensity) {
+  LHCInfoImpl::setOneParam(m_floatParams, INTENSITY_1, intensity);
 }
 
-void LHCInfo::setIntensityForBeam1( float const & intensity ) {
-  LHCInfoImpl::setOneParam( m_floatParams, INTENSITY_1, intensity );
+void LHCInfo::setIntensityForBeam2(float const& intensity) {
+  LHCInfoImpl::setOneParam(m_floatParams, INTENSITY_2, intensity);
 }
 
-void LHCInfo::setIntensityForBeam2( float const & intensity ) {
-  LHCInfoImpl::setOneParam( m_floatParams, INTENSITY_2, intensity );
+void LHCInfo::setEnergy(float const& energy) { LHCInfoImpl::setOneParam(m_floatParams, ENERGY, energy); }
+
+void LHCInfo::setDelivLumi(float const& delivLumi) { LHCInfoImpl::setOneParam(m_floatParams, DELIV_LUMI, delivLumi); }
+
+void LHCInfo::setRecLumi(float const& recLumi) { LHCInfoImpl::setOneParam(m_floatParams, REC_LUMI, recLumi); }
+
+void LHCInfo::setInstLumi(float const& instLumi) { LHCInfoImpl::setOneParam(m_floatParams, INST_LUMI, instLumi); }
+
+void LHCInfo::setInstLumiError(float const& instLumiError) {
+  LHCInfoImpl::setOneParam(m_floatParams, INST_LUMI_ERR, instLumiError);
 }
 
-void LHCInfo::setEnergy( float const & energy ) {
-  LHCInfoImpl::setOneParam( m_floatParams, ENERGY, energy );
+void LHCInfo::setCreationTime(cond::Time_t const& createTime) {
+  LHCInfoImpl::setOneParam(m_timeParams, CREATE_TIME, createTime);
 }
 
-void LHCInfo::setDelivLumi( float const & delivLumi ) {
-  LHCInfoImpl::setOneParam( m_floatParams, DELIV_LUMI, delivLumi );
+void LHCInfo::setBeginTime(cond::Time_t const& beginTime) {
+  LHCInfoImpl::setOneParam(m_timeParams, BEGIN_TIME, beginTime);
 }
 
-void LHCInfo::setRecLumi( float const & recLumi ) {
-  LHCInfoImpl::setOneParam( m_floatParams, REC_LUMI, recLumi );
+void LHCInfo::setEndTime(cond::Time_t const& endTime) { LHCInfoImpl::setOneParam(m_timeParams, END_TIME, endTime); }
+
+void LHCInfo::setInjectionScheme(std::string const& injectionScheme) {
+  LHCInfoImpl::setOneParam(m_stringParams, INJECTION_SCHEME, injectionScheme);
 }
 
-void LHCInfo::setInstLumi( float const & instLumi ) {
-  LHCInfoImpl::setOneParam( m_floatParams, INST_LUMI, instLumi );
+void LHCInfo::setLumiPerBX(std::vector<float> const& lumiPerBX) {
+  LHCInfoImpl::setParams(m_floatParams, LUMI_PER_B, lumiPerBX);
 }
 
-void LHCInfo::setInstLumiError( float const & instLumiError ) {
-  LHCInfoImpl::setOneParam( m_floatParams, INST_LUMI_ERR, instLumiError );
+void LHCInfo::setLhcState(std::string const& lhcState) {
+  LHCInfoImpl::setOneParam(m_stringParams, LHC_STATE, lhcState);
 }
 
-void LHCInfo::setCreationTime( cond::Time_t const & createTime ) {
-  LHCInfoImpl::setOneParam( m_timeParams, CREATE_TIME, createTime );
+void LHCInfo::setLhcComment(std::string const& lhcComment) {
+  LHCInfoImpl::setOneParam(m_stringParams, LHC_COMMENT, lhcComment);
 }
 
-void LHCInfo::setBeginTime( cond::Time_t const & beginTime ) {
-  LHCInfoImpl::setOneParam( m_timeParams, BEGIN_TIME, beginTime );
+void LHCInfo::setCtppsStatus(std::string const& ctppsStatus) {
+  LHCInfoImpl::setOneParam(m_stringParams, CTPPS_STATUS, ctppsStatus);
 }
 
-void LHCInfo::setEndTime( cond::Time_t const & endTime ) {
-  LHCInfoImpl::setOneParam( m_timeParams, END_TIME, endTime );
+void LHCInfo::setLumiSection(unsigned int const& lumiSection) {
+  LHCInfoImpl::setOneParam(m_intParams, LUMI_SECTION, lumiSection);
 }
 
-void LHCInfo::setInjectionScheme( std::string const & injectionScheme ) {
-  LHCInfoImpl::setOneParam( m_stringParams, INJECTION_SCHEME, injectionScheme );
+void LHCInfo::setBeam1VC(std::vector<float> const& beam1VC) {
+  LHCInfoImpl::setParams(m_floatParams, BEAM1_VC, beam1VC);
 }
 
-void LHCInfo::setLumiPerBX( std::vector<float> const & lumiPerBX) {
-  LHCInfoImpl::setParams( m_floatParams, LUMI_PER_B, lumiPerBX );
+void LHCInfo::setBeam2VC(std::vector<float> const& beam2VC) {
+  LHCInfoImpl::setParams(m_floatParams, BEAM2_VC, beam2VC);
 }
 
-void LHCInfo::setLhcState( std::string const & lhcState) {
-  LHCInfoImpl::setOneParam( m_stringParams, LHC_STATE, lhcState );
+void LHCInfo::setBeam1RF(std::vector<float> const& beam1RF) {
+  LHCInfoImpl::setParams(m_floatParams, BEAM1_RF, beam1RF);
 }
 
-void LHCInfo::setLhcComment( std::string const & lhcComment) {
-  LHCInfoImpl::setOneParam( m_stringParams, LHC_COMMENT, lhcComment );
-}
-
-void LHCInfo::setCtppsStatus( std::string const & ctppsStatus) {
-  LHCInfoImpl::setOneParam( m_stringParams, CTPPS_STATUS, ctppsStatus );
-}
-
-void LHCInfo::setLumiSection( unsigned int const & lumiSection) {
-  LHCInfoImpl::setOneParam( m_intParams, LUMI_SECTION, lumiSection );
-}
-
-void LHCInfo::setBeam1VC( std::vector<float> const & beam1VC) {
-  LHCInfoImpl::setParams( m_floatParams, BEAM1_VC, beam1VC );
-}
-
-void LHCInfo::setBeam2VC( std::vector<float> const & beam2VC) {
-  LHCInfoImpl::setParams( m_floatParams, BEAM2_VC, beam2VC );
-}
-
-void LHCInfo::setBeam1RF( std::vector<float> const & beam1RF) {
-  LHCInfoImpl::setParams( m_floatParams, BEAM1_RF, beam1RF );
-}
-
-void LHCInfo::setBeam2RF( std::vector<float> const & beam2RF) {
-  LHCInfoImpl::setParams( m_floatParams, BEAM2_RF, beam2RF );
+void LHCInfo::setBeam2RF(std::vector<float> const& beam2RF) {
+  LHCInfoImpl::setParams(m_floatParams, BEAM2_RF, beam2RF);
 }
 
 //sets all values in one go
-void LHCInfo::setInfo( unsigned short const & bunches1
-			    ,unsigned short const & bunches2
-			    ,unsigned short const & collidingBunches
-			    ,unsigned short const & targetBunches
-			    ,FillTypeId const & fillType
-			    ,ParticleTypeId const & particleType1
-			    ,ParticleTypeId const & particleType2
-			    ,float const & angle
-			    ,float const & beta
-			    ,float const & intensity1
-			    ,float const & intensity2
-			    ,float const & energy
-			    ,float const & delivLumi
-			    ,float const & recLumi
-		            ,float const & instLumi
-		            ,float const & instLumiError
-			    ,cond::Time_t const & createTime
-			    ,cond::Time_t const & beginTime
-			    ,cond::Time_t const & endTime
-			    ,std::string const & scheme
-			    ,std::vector<float> const & lumiPerBX
-			    ,std::string const & lhcState
-			    ,std::string const & lhcComment
-			    ,std::string const & ctppsStatus
-			    ,unsigned int const & lumiSection
-			    ,std::vector<float> const & beam1VC
-			    ,std::vector<float> const & beam2VC
-			    ,std::vector<float> const & beam1RF
-			    ,std::vector<float> const & beam2RF
-			    ,std::bitset<bunchSlots+1> const & bunchConf1
-			    ,std::bitset<bunchSlots+1> const & bunchConf2 ) {
-  this->setBunchesInBeam1( bunches1 );
-  this->setBunchesInBeam2( bunches2 );
-  this->setCollidingBunches( collidingBunches );
-  this->setTargetBunches( targetBunches );
-  this->setFillType( fillType );
-  this->setParticleTypeForBeam1( particleType1 );
-  this->setParticleTypeForBeam2( particleType2 );
-  this->setCrossingAngle( angle );
-  this->setBetaStar( beta );
-  this->setIntensityForBeam1( intensity1 );
-  this->setIntensityForBeam2( intensity2 );
-  this->setEnergy( energy );
-  this->setDelivLumi( delivLumi );
-  this->setRecLumi( recLumi );
-  this->setInstLumi( instLumi );
-  this->setInstLumiError( instLumiError );
-  this->setCreationTime( createTime );
-  this->setBeginTime( beginTime );
-  this->setEndTime( endTime );
-  this->setInjectionScheme( scheme );
-  this->setLumiPerBX( lumiPerBX );
-  this->setLhcState( lhcState );
-  this->setLhcComment( lhcComment );
-  this->setCtppsStatus( ctppsStatus );
-  this->setLumiSection( lumiSection );
-  this->setBeam1VC( beam1VC );
-  this->setBeam2VC( beam2VC );
-  this->setBeam1RF( beam1RF );
-  this->setBeam2RF( beam2RF );
-  this->setBunchBitsetForBeam1( bunchConf1 );
-  this->setBunchBitsetForBeam2( bunchConf2 );
+void LHCInfo::setInfo(unsigned short const& bunches1,
+                      unsigned short const& bunches2,
+                      unsigned short const& collidingBunches,
+                      unsigned short const& targetBunches,
+                      FillTypeId const& fillType,
+                      ParticleTypeId const& particleType1,
+                      ParticleTypeId const& particleType2,
+                      float const& angle,
+                      float const& beta,
+                      float const& intensity1,
+                      float const& intensity2,
+                      float const& energy,
+                      float const& delivLumi,
+                      float const& recLumi,
+                      float const& instLumi,
+                      float const& instLumiError,
+                      cond::Time_t const& createTime,
+                      cond::Time_t const& beginTime,
+                      cond::Time_t const& endTime,
+                      std::string const& scheme,
+                      std::vector<float> const& lumiPerBX,
+                      std::string const& lhcState,
+                      std::string const& lhcComment,
+                      std::string const& ctppsStatus,
+                      unsigned int const& lumiSection,
+                      std::vector<float> const& beam1VC,
+                      std::vector<float> const& beam2VC,
+                      std::vector<float> const& beam1RF,
+                      std::vector<float> const& beam2RF,
+                      std::bitset<bunchSlots + 1> const& bunchConf1,
+                      std::bitset<bunchSlots + 1> const& bunchConf2) {
+  this->setBunchesInBeam1(bunches1);
+  this->setBunchesInBeam2(bunches2);
+  this->setCollidingBunches(collidingBunches);
+  this->setTargetBunches(targetBunches);
+  this->setFillType(fillType);
+  this->setParticleTypeForBeam1(particleType1);
+  this->setParticleTypeForBeam2(particleType2);
+  this->setCrossingAngle(angle);
+  this->setBetaStar(beta);
+  this->setIntensityForBeam1(intensity1);
+  this->setIntensityForBeam2(intensity2);
+  this->setEnergy(energy);
+  this->setDelivLumi(delivLumi);
+  this->setRecLumi(recLumi);
+  this->setInstLumi(instLumi);
+  this->setInstLumiError(instLumiError);
+  this->setCreationTime(createTime);
+  this->setBeginTime(beginTime);
+  this->setEndTime(endTime);
+  this->setInjectionScheme(scheme);
+  this->setLumiPerBX(lumiPerBX);
+  this->setLhcState(lhcState);
+  this->setLhcComment(lhcComment);
+  this->setCtppsStatus(ctppsStatus);
+  this->setLumiSection(lumiSection);
+  this->setBeam1VC(beam1VC);
+  this->setBeam2VC(beam2VC);
+  this->setBeam1RF(beam1RF);
+  this->setBeam2RF(beam2RF);
+  this->setBunchBitsetForBeam1(bunchConf1);
+  this->setBunchBitsetForBeam2(bunchConf2);
 }
 
-void LHCInfo::print( std::stringstream & ss ) const {
+void LHCInfo::print(std::stringstream& ss) const {
   ss << "LHC fill: " << this->fillNumber() << std::endl
      << "Bunches in Beam 1: " << this->bunchesInBeam1() << std::endl
      << "Bunches in Beam 2: " << this->bunchesInBeam2() << std::endl
      << "Colliding bunches at IP5: " << this->collidingBunches() << std::endl
-     << "Target bunches at IP5: " <<this->targetBunches() << std::endl
-     << "Fill type: " << fillTypeToString( static_cast<FillTypeId> (this->fillType() ) ) << std::endl
-     << "Particle type for Beam 1: " << particleTypeToString( static_cast<ParticleTypeId>( this->particleTypeForBeam1() ) ) << std::endl
-     << "Particle type for Beam 2: " << particleTypeToString( static_cast<ParticleTypeId>( this->particleTypeForBeam2() ) ) << std::endl
+     << "Target bunches at IP5: " << this->targetBunches() << std::endl
+     << "Fill type: " << fillTypeToString(static_cast<FillTypeId>(this->fillType())) << std::endl
+     << "Particle type for Beam 1: " << particleTypeToString(static_cast<ParticleTypeId>(this->particleTypeForBeam1()))
+     << std::endl
+     << "Particle type for Beam 2: " << particleTypeToString(static_cast<ParticleTypeId>(this->particleTypeForBeam2()))
+     << std::endl
      << "Crossing angle (urad): " << this->crossingAngle() << std::endl
      << "Beta star (cm): " << this->betaStar() << std::endl
      << "Average Intensity for Beam 1 (number of charges): " << this->intensityForBeam1() << std::endl
@@ -510,81 +454,85 @@ void LHCInfo::print( std::stringstream & ss ) const {
      << "Recorded Luminosity (max): " << this->recLumi() << std::endl
      << "Instantaneous Luminosity: " << this->instLumi() << std::endl
      << "Instantaneous Luminosity Error: " << this->instLumiError() << std::endl
-     << "Creation time of the fill: " << boost::posix_time::to_iso_extended_string( cond::time::to_boost( this->createTime() ) ) << std::endl
-     << "Begin time of Stable Beam flag: " << boost::posix_time::to_iso_extended_string( cond::time::to_boost( this->beginTime() ) ) << std::endl
-     << "End time of the fill: " << boost::posix_time::to_iso_extended_string( cond::time::to_boost( this->endTime() ) ) << std::endl
+     << "Creation time of the fill: "
+     << boost::posix_time::to_iso_extended_string(cond::time::to_boost(this->createTime())) << std::endl
+     << "Begin time of Stable Beam flag: "
+     << boost::posix_time::to_iso_extended_string(cond::time::to_boost(this->beginTime())) << std::endl
+     << "End time of the fill: " << boost::posix_time::to_iso_extended_string(cond::time::to_boost(this->endTime()))
+     << std::endl
      << "Injection scheme as given by LPC: " << this->injectionScheme() << std::endl
      << "LHC State: " << this->lhcState() << std::endl
      << "LHC Comments: " << this->lhcComment() << std::endl
      << "CTPPS Status: " << this->ctppsStatus() << std::endl
      << "Lumi section: " << this->lumiSection() << std::endl;
-     
+
   ss << "Luminosity per bunch  (total " << this->lumiPerBX().size() << "): ";
-  std::copy( this->lumiPerBX().begin(), this->lumiPerBX().end(), std::ostream_iterator<float>( ss, ", " ) );
+  std::copy(this->lumiPerBX().begin(), this->lumiPerBX().end(), std::ostream_iterator<float>(ss, ", "));
   ss << std::endl;
-    
+
   ss << "Beam 1 VC  (total " << this->beam1VC().size() << "): ";
-  std::copy( this->beam1VC().begin(), this->beam1VC().end(), std::ostream_iterator<float>( ss, "\t" ) );
+  std::copy(this->beam1VC().begin(), this->beam1VC().end(), std::ostream_iterator<float>(ss, "\t"));
   ss << std::endl;
-  
+
   ss << "Beam 2 VC  (total " << beam2VC().size() << "): ";
-  std::copy( beam2VC().begin(), beam2VC().end(), std::ostream_iterator<float>( ss, "\t" ) );
+  std::copy(beam2VC().begin(), beam2VC().end(), std::ostream_iterator<float>(ss, "\t"));
   ss << std::endl;
-  
+
   ss << "Beam 1 RF  (total " << beam1RF().size() << "): ";
-  std::copy( beam1RF().begin(), beam1RF().end(), std::ostream_iterator<float>( ss, "\t" ) );
+  std::copy(beam1RF().begin(), beam1RF().end(), std::ostream_iterator<float>(ss, "\t"));
   ss << std::endl;
-  
+
   ss << "Beam 2 RF  (total " << beam2RF().size() << "): ";
-  std::copy( beam2RF().begin(), beam2RF().end(), std::ostream_iterator<float>( ss, "\t" ) );
+  std::copy(beam2RF().begin(), beam2RF().end(), std::ostream_iterator<float>(ss, "\t"));
   ss << std::endl;
-  
+
   std::vector<unsigned short> bunchVector1 = this->bunchConfigurationForBeam1();
   std::vector<unsigned short> bunchVector2 = this->bunchConfigurationForBeam2();
   ss << "Bunches filled for Beam 1 (total " << bunchVector1.size() << "): ";
-  std::copy( bunchVector1.begin(), bunchVector1.end(), std::ostream_iterator<unsigned short>( ss, ", " ) );
+  std::copy(bunchVector1.begin(), bunchVector1.end(), std::ostream_iterator<unsigned short>(ss, ", "));
   ss << std::endl;
   ss << "Bunches filled for Beam 2 (total " << bunchVector2.size() << "): ";
-  std::copy( bunchVector2.begin(), bunchVector2.end(), std::ostream_iterator<unsigned short>( ss, ", " ) );
+  std::copy(bunchVector2.begin(), bunchVector2.end(), std::ostream_iterator<unsigned short>(ss, ", "));
   ss << std::endl;
 }
 
 //protected getters
-std::bitset<LHCInfo::bunchSlots+1> const & LHCInfo::bunchBitsetForBeam1() const {
-  return m_bunchConfiguration1;  
-}
+std::bitset<LHCInfo::bunchSlots + 1> const& LHCInfo::bunchBitsetForBeam1() const { return m_bunchConfiguration1; }
 
-std::bitset<LHCInfo::bunchSlots+1> const & LHCInfo::bunchBitsetForBeam2() const {
-  return m_bunchConfiguration2;  
-}
+std::bitset<LHCInfo::bunchSlots + 1> const& LHCInfo::bunchBitsetForBeam2() const { return m_bunchConfiguration2; }
 
 //protected setters
-void LHCInfo::setBunchBitsetForBeam1( std::bitset<LHCInfo::bunchSlots+1> const & bunchConfiguration ) {
+void LHCInfo::setBunchBitsetForBeam1(std::bitset<LHCInfo::bunchSlots + 1> const& bunchConfiguration) {
   m_bunchConfiguration1 = bunchConfiguration;
 }
 
-void LHCInfo::setBunchBitsetForBeam2( std::bitset<LHCInfo::bunchSlots+1> const & bunchConfiguration ) {
+void LHCInfo::setBunchBitsetForBeam2(std::bitset<LHCInfo::bunchSlots + 1> const& bunchConfiguration) {
   m_bunchConfiguration2 = bunchConfiguration;
 }
 
-std::ostream & operator<<( std::ostream & os, LHCInfo beamInfo ) {
+std::ostream& operator<<(std::ostream& os, LHCInfo beamInfo) {
   std::stringstream ss;
-  beamInfo.print( ss );
+  beamInfo.print(ss);
   os << ss.str();
   return os;
 }
 
-bool LHCInfo::equals( const LHCInfo& rhs ) const {
-  if( m_isData != rhs.m_isData ) return false;
-  if( m_intParams != rhs.m_intParams  ) return false;
-  if( m_floatParams != rhs.m_floatParams  ) return false;
-  if( m_timeParams != rhs.m_timeParams  ) return false;
-  if( m_stringParams != rhs.m_stringParams  ) return false;
-  if( m_bunchConfiguration1 != rhs.m_bunchConfiguration1 ) return false;
-  if( m_bunchConfiguration2 != rhs.m_bunchConfiguration2 ) return false;
+bool LHCInfo::equals(const LHCInfo& rhs) const {
+  if (m_isData != rhs.m_isData)
+    return false;
+  if (m_intParams != rhs.m_intParams)
+    return false;
+  if (m_floatParams != rhs.m_floatParams)
+    return false;
+  if (m_timeParams != rhs.m_timeParams)
+    return false;
+  if (m_stringParams != rhs.m_stringParams)
+    return false;
+  if (m_bunchConfiguration1 != rhs.m_bunchConfiguration1)
+    return false;
+  if (m_bunchConfiguration2 != rhs.m_bunchConfiguration2)
+    return false;
   return true;
 }
 
-bool LHCInfo::empty() const {
-  return m_intParams[0].empty();
-}
+bool LHCInfo::empty() const { return m_intParams[0].empty(); }

--- a/CondFormats/RunInfo/src/MixingModuleConfig.cc
+++ b/CondFormats/RunInfo/src/MixingModuleConfig.cc
@@ -3,67 +3,63 @@
 
 #include <sstream>
 
-MixingModuleConfig::MixingModuleConfig(){
-  configs_.resize(4);
-}
-MixingInputConfig::MixingInputConfig(){}
+MixingModuleConfig::MixingModuleConfig() { configs_.resize(4); }
+MixingInputConfig::MixingInputConfig() {}
 
-std::ostream& operator<< ( std::ostream& os, const MixingModuleConfig & c) {
+std::ostream& operator<<(std::ostream& os, const MixingModuleConfig& c) {
   std::stringstream ss;
-  os <<c.bunchSpace()<<"\n"<<c.config();
+  os << c.bunchSpace() << "\n" << c.config();
   return os;
 }
-std::ostream& operator<< ( std::ostream& os, const MixingInputConfig & c) {
+std::ostream& operator<<(std::ostream& os, const MixingInputConfig& c) {
   std::stringstream ss;
-  os <<c.type();
+  os << c.type();
   return os;
 }
 
-void MixingModuleConfig::read(edm::ParameterSet & pset){
-  
-  bs_=pset.getParameter<int>("bunchspace");
-  minb_=(pset.getParameter<int>("minBunch")*25)/pset.getParameter<int>("bunchspace");
-  maxb_=(pset.getParameter<int>("maxBunch")*25)/pset.getParameter<int>("bunchspace");
+void MixingModuleConfig::read(edm::ParameterSet& pset) {
+  bs_ = pset.getParameter<int>("bunchspace");
+  minb_ = (pset.getParameter<int>("minBunch") * 25) / pset.getParameter<int>("bunchspace");
+  maxb_ = (pset.getParameter<int>("maxBunch") * 25) / pset.getParameter<int>("bunchspace");
 
   //FIXME. not covering all possible cases (not used anyways)
-  edm::ParameterSet p0=pset.getParameter<edm::ParameterSet>("input");
+  edm::ParameterSet p0 = pset.getParameter<edm::ParameterSet>("input");
   configs_[0].read(p0);
 }
 
-
-void MixingInputConfig::read(edm::ParameterSet & pset){
-  t_=itype(pset.getParameter<std::string>("type"));
-  an_=0;
+void MixingInputConfig::read(edm::ParameterSet& pset) {
+  t_ = itype(pset.getParameter<std::string>("type"));
+  an_ = 0;
   //  ia_=0;
   dpfv_.clear();
   dp_.clear();
-  moot_=0;
-  ioot_=0;
+  moot_ = 0;
+  ioot_ = 0;
 
-  switch(t_){
-  case 1:
-    an_=pset.getParameter<double>("averageNumber");
-    break;
-  case 2:
-    an_=pset.getParameter<double>("averageNumber");
-    break;
-  case 3:
-    //not supposed to be valid
-  case 4:
-    dpfv_=pset.getParameter<edm::ParameterSet>("nbPileupEvents").getParameter<std::vector<int> >("probFunctionVariable");
-    dp_=pset.getParameter<edm::ParameterSet>("nbPileupEvents").getParameter<std::vector<double> >("probValue");
-    break;
+  switch (t_) {
+    case 1:
+      an_ = pset.getParameter<double>("averageNumber");
+      break;
+    case 2:
+      an_ = pset.getParameter<double>("averageNumber");
+      break;
+    case 3:
+      //not supposed to be valid
+    case 4:
+      dpfv_ = pset.getParameter<edm::ParameterSet>("nbPileupEvents")
+                  .getParameter<std::vector<int> >("probFunctionVariable");
+      dp_ = pset.getParameter<edm::ParameterSet>("nbPileupEvents").getParameter<std::vector<double> >("probValue");
+      break;
   }
 
-  if (pset.getUntrackedParameter<bool>("manage_OOT"))
-    {
-      std::string OOT_type = pset.getUntrackedParameter<std::string>("OOT_type");
+  if (pset.getUntrackedParameter<bool>("manage_OOT")) {
+    std::string OOT_type = pset.getUntrackedParameter<std::string>("OOT_type");
 
-      if(OOT_type == "Poisson" || OOT_type == "poisson")
-	moot_=2;
-      else if (OOT_type == "Fixed" || OOT_type == "fixed") {
-	moot_=1;
-	ioot_=pset.getUntrackedParameter<int>("intFixed_OOT", -1);
-      }
+    if (OOT_type == "Poisson" || OOT_type == "poisson")
+      moot_ = 2;
+    else if (OOT_type == "Fixed" || OOT_type == "fixed") {
+      moot_ = 1;
+      ioot_ = pset.getUntrackedParameter<int>("intFixed_OOT", -1);
     }
+  }
 }

--- a/CondFormats/RunInfo/src/RunInfo.cc
+++ b/CondFormats/RunInfo/src/RunInfo.cc
@@ -1,23 +1,21 @@
 #include "CondFormats/RunInfo/interface/RunInfo.h"
-RunInfo::RunInfo(){}
+RunInfo::RunInfo() {}
 
-RunInfo * RunInfo::Fake_RunInfo(){
-  RunInfo * sum = new RunInfo();
-  sum->m_run=-1;
-  sum->m_start_time_ll=-1;
-  sum->m_start_time_str="null";
-  sum->m_stop_time_ll=-1;
-  sum->m_stop_time_str="null";
-  sum->m_start_current=-1; 
-  sum->m_stop_current=-1;
-  sum->m_avg_current=-1;
-  sum->m_max_current=-1;
-  sum->m_min_current=-1;
-  sum->m_run_intervall_micros=0;
-  return sum; 
+RunInfo* RunInfo::Fake_RunInfo() {
+  RunInfo* sum = new RunInfo();
+  sum->m_run = -1;
+  sum->m_start_time_ll = -1;
+  sum->m_start_time_str = "null";
+  sum->m_stop_time_ll = -1;
+  sum->m_stop_time_str = "null";
+  sum->m_start_current = -1;
+  sum->m_stop_current = -1;
+  sum->m_avg_current = -1;
+  sum->m_max_current = -1;
+  sum->m_min_current = -1;
+  sum->m_run_intervall_micros = 0;
+  return sum;
 }
-
-
 
 void RunInfo::printAllValues() const {
   std::cout << "run number: " << m_run << std::endl;
@@ -32,17 +30,15 @@ void RunInfo::printAllValues() const {
   std::cout << "maximum current " << m_max_current << std::endl;
   std::cout << "run time in microseconds " << m_run_intervall_micros << std::endl;
   std::cout << "ids of fed in run: " << std::endl;
-  for(size_t i = 0; i < m_fed_in.size(); i++) {
+  for (size_t i = 0; i < m_fed_in.size(); i++) {
     std::cout << "---> " << m_fed_in[i] << std::endl;
   }
   std::cout << "B current in run: " << std::endl;
-  for(size_t i = 0; i < m_current.size(); i++) {
+  for (size_t i = 0; i < m_current.size(); i++) {
     std::cout << "---> " << m_current[i] << std::endl;
   }
   std::cout << "correspondent time (from run start) in microseconds for B currents in run: " << std::endl;
-  for(size_t i = 0; i < m_times_of_currents.size(); i++) {
+  for (size_t i = 0; i < m_times_of_currents.size(); i++) {
     std::cout << "---> " << m_times_of_currents[i] << std::endl;
   }
 }
-
-

--- a/CondFormats/RunInfo/src/RunNumber.cc
+++ b/CondFormats/RunInfo/src/RunNumber.cc
@@ -1,4 +1,2 @@
 #include "CondFormats/RunInfo/interface/RunNumber.h"
-runinfo_test::RunNumber::RunNumber(){
-  m_runnumber.reserve(600000);
-}
+runinfo_test::RunNumber::RunNumber() { m_runnumber.reserve(600000); }

--- a/CondFormats/RunInfo/src/RunSummary.cc
+++ b/CondFormats/RunInfo/src/RunSummary.cc
@@ -1,60 +1,58 @@
 #include "CondFormats/RunInfo/interface/RunSummary.h"
-RunSummary::RunSummary(){}
+RunSummary::RunSummary() {}
 
-RunSummary * RunSummary::Fake_RunSummary(){
-  RunSummary * sum = new RunSummary();
-  sum->m_run=-1;
-  sum->m_hltkey="null";
-  sum->m_start_time_str="null";
-  sum->m_stop_time_str="null";
-  sum->m_name="null";
-  return sum; 
+RunSummary* RunSummary::Fake_RunSummary() {
+  RunSummary* sum = new RunSummary();
+  sum->m_run = -1;
+  sum->m_hltkey = "null";
+  sum->m_start_time_str = "null";
+  sum->m_stop_time_str = "null";
+  sum->m_name = "null";
+  return sum;
 }
 
-
-
-void RunSummary::printAllValues() const{
-    std::cout<<"run number: " <<m_run << std::endl;
-    std::cout<<"run name: " <<m_name << std::endl;
-    std::cout<<"run start time as timestamp: "<<m_start_time_ll<<std::endl;
-    std::cout<<"run start time as date: "<<m_start_time_str<<std::endl;
-    std::cout<<"run stop time as timestamp: "<<m_stop_time_ll<< std::endl;
-    std::cout<<"run stop time as date: "<<m_stop_time_str<<std::endl;
-    std::cout<<"lumisection in the run: "<<m_lumisections<<std::endl;
-    std::cout<<"run hltkey: "<<m_hltkey<<std::endl;
-    std::cout<<"run number of events according hlt: "<<m_nevents<<std::endl;
-    std::cout<<"hlt rate: "<<m_rate<<std::endl;
-    std::cout<<"ids of subdetectors in run: "<<std::endl;
-for (size_t i =0; i<m_subdt_in.size(); i++){
-  std::cout<<"---> "<<m_subdt_in[i]<<std::endl;
+void RunSummary::printAllValues() const {
+  std::cout << "run number: " << m_run << std::endl;
+  std::cout << "run name: " << m_name << std::endl;
+  std::cout << "run start time as timestamp: " << m_start_time_ll << std::endl;
+  std::cout << "run start time as date: " << m_start_time_str << std::endl;
+  std::cout << "run stop time as timestamp: " << m_stop_time_ll << std::endl;
+  std::cout << "run stop time as date: " << m_stop_time_str << std::endl;
+  std::cout << "lumisection in the run: " << m_lumisections << std::endl;
+  std::cout << "run hltkey: " << m_hltkey << std::endl;
+  std::cout << "run number of events according hlt: " << m_nevents << std::endl;
+  std::cout << "hlt rate: " << m_rate << std::endl;
+  std::cout << "ids of subdetectors in run: " << std::endl;
+  for (size_t i = 0; i < m_subdt_in.size(); i++) {
+    std::cout << "---> " << m_subdt_in[i] << std::endl;
   }
-  }
+}
 
-std::vector<std::string> RunSummary::getSubdtIn() const{
-  std::vector<std::string> v; 
-  for (size_t i =0; i<m_subdt_in.size(); i++){
-    if (m_subdt_in[i]==0) {
+std::vector<std::string> RunSummary::getSubdtIn() const {
+  std::vector<std::string> v;
+  for (size_t i = 0; i < m_subdt_in.size(); i++) {
+    if (m_subdt_in[i] == 0) {
       v.push_back("PIXEL");
     }
-    if (m_subdt_in[i]==1) {
+    if (m_subdt_in[i] == 1) {
       v.push_back("TRACKER");
     }
-    if (m_subdt_in[i]==2) {
+    if (m_subdt_in[i] == 2) {
       v.push_back("ECAL");
     }
-    if (m_subdt_in[i]==3) {
+    if (m_subdt_in[i] == 3) {
       v.push_back("HCAL");
     }
-    
-    if (m_subdt_in[i]==4) {
+
+    if (m_subdt_in[i] == 4) {
       v.push_back("DT");
-    }  
-    if (m_subdt_in[i]==5) {
+    }
+    if (m_subdt_in[i] == 5) {
       v.push_back("CSC");
-    }   
-    if (m_subdt_in[i]==6) {
+    }
+    if (m_subdt_in[i] == 6) {
       v.push_back("RPC");
-    }  
+    }
   }
   return v;
 }

--- a/CondFormats/RunInfo/src/T_EventSetup_L1TriggerScaler.cc
+++ b/CondFormats/RunInfo/src/T_EventSetup_L1TriggerScaler.cc
@@ -2,5 +2,4 @@
 #include "CondFormats/RunInfo/interface/L1TriggerScaler.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
-
 TYPELOOKUP_DATA_REG(L1TriggerScaler);

--- a/CondFormats/RunInfo/src/classes.h
+++ b/CondFormats/RunInfo/src/classes.h
@@ -9,4 +9,4 @@ namespace CondFormats_RunInfo {
     MixingModuleConfig mmc;
     MixingInputConfig mic;
   };
-}
+}  // namespace CondFormats_RunInfo

--- a/CondFormats/RunInfo/test/fromXML.cpp
+++ b/CondFormats/RunInfo/test/fromXML.cpp
@@ -16,10 +16,8 @@
 // may not be initialized when we serialize them.
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 
-
 template <typename T>
-void toXML( std::string filename="" )
-{
+void toXML(std::string filename = "") {
   if (filename == "") {
     filename = std::string(typeid(T).name()) + ".xml";
   }
@@ -29,20 +27,18 @@ void toXML( std::string filename="" )
   // (since it would be uninitialized), so we always create
   // a non-const object.
   T originalObject;
-  const T & originalObjectRef = originalObject;
+  const T& originalObjectRef = originalObject;
   {
     std::ofstream ofs(filename);
     //cond::serialization::OutputArchiveXML oa(ofs);
-    boost::archive::xml_oarchive oa( ofs );
+    boost::archive::xml_oarchive oa(ofs);
     std::cout << "Serializing " << typeid(T).name() << " ..." << std::endl;
-    oa & boost::serialization::make_nvp( "cmsCondPayload", originalObjectRef );
+    oa& boost::serialization::make_nvp("cmsCondPayload", originalObjectRef);
   }
-
 }
 
 template <typename T>
-T fromXML( std::string filename="" )
-{
+T fromXML(std::string filename = "") {
   if (filename == "") {
     filename = std::string(typeid(T).name()) + ".xml";
   }
@@ -57,44 +53,39 @@ T fromXML( std::string filename="" )
     std::ifstream ifs(filename);
     try {
       // cond::serialization::InputArchiveXML ia( ifs );
-      boost::archive::xml_iarchive ia( ifs );
+      boost::archive::xml_iarchive ia(ifs);
       std::cout << "Deserializing " << typeid(T).name() << " ..." << std::endl;
-      ia & boost::serialization::make_nvp( "cmsCondPayload", originalObject );
-    } catch (const boost::archive::archive_exception& ae) { 
-	std::cout << "** boost::archive load exception" 
-		  << ": " << __FILE__ << ":" << __LINE__ << ":" << __func__ 
-		  << ": " << ae.what() << "\n" 
-		  << std::endl; 
+      ia& boost::serialization::make_nvp("cmsCondPayload", originalObject);
+    } catch (const boost::archive::archive_exception& ae) {
+      std::cout << "** boost::archive load exception"
+                << ": " << __FILE__ << ":" << __LINE__ << ":" << __func__ << ": " << ae.what() << "\n"
+                << std::endl;
     }
   }
   return originalObject;
 }
 
-
 class Simple {
-
 public:
-  Simple() : my_i(42), my_f(42.) { /* nop */ }
+  Simple() : my_i(42), my_f(42.) { /* nop */
+  }
 
   // COND_SERIALIZABLE;
-  template <class Archive> void serialize(Archive & ar, const unsigned int version);
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version);
 
 private:
   int my_i;
   float my_f;
-
 };
 
-template <class Archive> void Simple::serialize(Archive & ar, const unsigned int version)
-{
-  ar & BOOST_SERIALIZATION_NVP(my_i);
-  ar & BOOST_SERIALIZATION_NVP(my_f);
+template <class Archive>
+void Simple::serialize(Archive& ar, const unsigned int version) {
+  ar& BOOST_SERIALIZATION_NVP(my_i);
+  ar& BOOST_SERIALIZATION_NVP(my_f);
 }
 
-
-int main(int, char**)
-{
-
+int main(int, char**) {
   toXML<Simple>();
   fromXML<Simple>();
 
@@ -103,7 +94,6 @@ int main(int, char**)
   RunInfo ri = fromXML<RunInfo>("src/CondFormats/RunInfo/test/RunInfo-000fe8.xml");
   std::cout << "Found info for run " << ri.m_run << std::endl;
   std::cout << "        started at " << ri.m_start_time_str << std::endl;
-
 
   return 0;
 }

--- a/CondFormats/RunInfo/test/testSerializationRunInfo.cpp
+++ b/CondFormats/RunInfo/test/testSerializationRunInfo.cpp
@@ -2,22 +2,21 @@
 
 #include "CondFormats/RunInfo/src/headers.h"
 
-int main()
-{
-    testSerialization<FillInfo>();
-    testSerialization<LHCInfo>();
-    testSerialization<L1TriggerScaler>();
-    testSerialization<L1TriggerScaler::Lumi>();
-    testSerialization<MixingInputConfig>();
-    testSerialization<MixingModuleConfig>();
-    testSerialization<RunInfo>();
-    testSerialization<RunSummary>();
-    testSerialization<runinfo_test::RunNumber>();
-    testSerialization<runinfo_test::RunNumber::Item>();
-    testSerialization<std::bitset<3565>>();
-    testSerialization<std::vector<L1TriggerScaler::Lumi>>();
-    testSerialization<std::vector<MixingInputConfig>>();
-    testSerialization<std::vector<runinfo_test::RunNumber::Item>>();
+int main() {
+  testSerialization<FillInfo>();
+  testSerialization<LHCInfo>();
+  testSerialization<L1TriggerScaler>();
+  testSerialization<L1TriggerScaler::Lumi>();
+  testSerialization<MixingInputConfig>();
+  testSerialization<MixingModuleConfig>();
+  testSerialization<RunInfo>();
+  testSerialization<RunSummary>();
+  testSerialization<runinfo_test::RunNumber>();
+  testSerialization<runinfo_test::RunNumber::Item>();
+  testSerialization<std::bitset<3565>>();
+  testSerialization<std::vector<L1TriggerScaler::Lumi>>();
+  testSerialization<std::vector<MixingInputConfig>>();
+  testSerialization<std::vector<runinfo_test::RunNumber::Item>>();
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION

Applying code-format for CMSSW category alca,db.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/231//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


