### PR TITLE
Run3-hcx203 Add detId2denseId for some new calibration channels

### DIFF
--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalCalibDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/HcalCommonData/interface/HcalTopologyMode.h"
@@ -54,6 +55,7 @@ public:
   bool validHcal(const HcalDetId& id) const;
   bool validDetId(HcalSubdetector subdet, int ieta, int iphi, int depth) const;
   bool validHT(const HcalTrigTowerDetId& id) const;
+  bool validCalib(const HcalCalibDetId& id) const;
   /** Is this a valid cell in context of Plan1 */
   bool validHcal(const HcalDetId& id, const unsigned int flag) const;
   /** Flag=0 for unmerged Id's; =1 for for merged Id's; =2 for either */
@@ -161,6 +163,8 @@ public:
   unsigned int detId2denseIdHT(const DetId& id) const;
   /// return a linear packed id from CALIB
   unsigned int detId2denseIdCALIB(const DetId& id) const;
+  /// return a Calib DetId from linear packed id
+  HcalCalibDetId denseId2detIdCALIB(const unsigned int& id) const;
 
   unsigned int getNumberOfShapes() const { return numberOfShapes_; }
   bool isBH() const { return ((hcons_ == nullptr) ? false : hcons_->isBH()); }
@@ -211,7 +215,6 @@ private:
   int maxDepthHB_, maxDepthHE_, maxDepthHF_;
   int etaHE2HF_, etaHF2HE_;
   int maxEta_, maxPhiHE_;
-  static const int minMaxDepth_ = 4;
 
   unsigned int HBSize_;
   unsigned int HESize_;
@@ -250,7 +253,60 @@ private:
   enum { kHTSizePreLS1 = 2*kHThalf } ;
   enum { kHTSizePhase1 = 2*kHThalfPhase1 } ;
   enum { kCALIBSizePreLS1 = 2*kCALIBhalf };
+  static const int minMaxDepth_ = 4;
+  static const unsigned int minPhi_=1, maxPhi_=72;
+  static const unsigned int nchanCalibHB_=3, nchanCalibHE_=6;
+  static const unsigned int nchanCalibHF_=3, nchanCalibHO_=2, chanCalibHOs_=7;
+  static constexpr int chanCalibHB_[nchanCalibHB_] = {0,1,2};
+  static constexpr int chanCalibHE_[nchanCalibHE_] = {0,1,3,4,5,6};
+  static constexpr int chanCalibHF_[nchanCalibHF_] = {0,1,8};
+  static constexpr int chanCalibHO_[nchanCalibHO_] = {0,1};
+  static const unsigned int nEtaCalibHBHEHF_=2, nEtaCalibHO_=5;
+  static constexpr int etaCalibHBHEHF_[nEtaCalibHBHEHF_] = {-1,1};
+  static constexpr int etaCalibHO_[nEtaCalibHO_] = {-2,-1,0,1,2};
+  static constexpr int phiCalibHO_[nEtaCalibHO_] = {59,47,53,47,47};
+  static const unsigned int mPhiCalibHBHE_=4, mPhiCalibHF_=18;
+  static const unsigned int mPhiCalibHO1_=12, mPhiCalibHO0_=mPhiCalibHO1_/2;
+  static const unsigned int kPhiCalibHBHE_=maxPhi_/mPhiCalibHBHE_;
+  static const unsigned int kchanCalibHB_=nchanCalibHB_*kPhiCalibHBHE_/2;
+  static const unsigned int kchanCalibHE_=nchanCalibHE_*kPhiCalibHBHE_/2;
+  static const unsigned int nCalibHB_=kPhiCalibHBHE_*nchanCalibHB_*nEtaCalibHBHEHF_;
+  static const unsigned int nCalibHE_=kPhiCalibHBHE_*nchanCalibHE_*nEtaCalibHBHEHF_;
+  static const unsigned int kPhiCalibHF_=maxPhi_/mPhiCalibHF_;
+  static const unsigned int kchanCalibHF_=nchanCalibHF_*kPhiCalibHF_/2;
+  static const unsigned int nCalibHF_=kPhiCalibHF_*nchanCalibHF_*nEtaCalibHBHEHF_;
+  static const unsigned int kPhiCalibHO0_=maxPhi_/mPhiCalibHO0_;
+  static const unsigned int kPhiCalibHO1_=maxPhi_/mPhiCalibHO1_;
+  static const unsigned int kPhiCalibHO2_=(3*kPhiCalibHO1_+kPhiCalibHO0_);
+  static const unsigned int kchanCalibHO_=nchanCalibHO_*kPhiCalibHO1_/2;
+  static const unsigned int kchanCalibHO1_=maxPhi_/2;
+  static const unsigned int kEtaPhiCalibHO_=kPhiCalibHO1_*(1+nEtaCalibHO_);
+  static const unsigned int nCalibHO0_=kEtaPhiCalibHO_*nchanCalibHO_;
+  static const unsigned int nCalibHO_=(nEtaCalibHO_+nCalibHO0_);
+  static const unsigned int kOffCalibHB_=0, kOffCalibHE_=(kOffCalibHB_+nCalibHB_);
+  static const unsigned int kOffCalibHF_=(kOffCalibHE_+nCalibHE_);
+  static const unsigned int kOffCalibHO0_=(kOffCalibHF_+nCalibHF_);
+  static const unsigned int kOffCalibHO_=(kOffCalibHO0_+nCalibHO0_);
+  static const unsigned int kOffCalibHOX_=(kOffCalibHO0_+nCalibHO_);
+  static const unsigned int nEtaCalibHOX_=2, ctypeHX_=-999;
+  static constexpr unsigned int etaCalibHOX_[nEtaCalibHOX_]={4,15};
+  static constexpr unsigned int mPhiCalibHOX_[nEtaCalibHOX_]={2,1};
+  static constexpr unsigned int nPhiCalibHOX_[nEtaCalibHOX_]={36,72};
+  static const int nCalibHOX_=(2*(nPhiCalibHOX_[0]+nPhiCalibHOX_[1]));
+  static constexpr int phiCalibHOX_[37]= {36, 1,38, 3,40,41, 6,43, 8,45,10,47,
+					  12,49,14,51,16,17,54,19,56,21,58,23,
+					  60,25,62,27,64,65,30,67,32,69,34,71,
+					  36};
+  static const unsigned int kOffCalibHBX_=(kOffCalibHOX_+nCalibHOX_);
+  static const unsigned int nEtaCalibHBX_=1,  etaCalibHBX_=16;
+  static const unsigned int mPhiCalibHBX_=1,  nPhiCalibHBX_=maxPhi_/mPhiCalibHBX_;
+  static const unsigned int nCalibHBX_=(2*nPhiCalibHBX_*nEtaCalibHBX_);
+  static const unsigned int kOffCalibHEX_=(kOffCalibHBX_+nCalibHBX_);
+  static const unsigned int nEtaCalibHEX_=2;
+  static constexpr int etaCalibHEX_[nEtaCalibHEX_]={25,27};
+  static const unsigned int mPhiCalibHEX_=2,  nPhiCalibHEX_=maxPhi_/mPhiCalibHEX_;
+  static const unsigned int nCalibHEX_=(2*nPhiCalibHEX_*nEtaCalibHEX_);
+  static const unsigned int kOffCalibHFX_=(kOffCalibHEX_+nCalibHEX_);
 };
-
 
 #endif

--- a/Geometry/CaloTopology/test/BuildFile.xml
+++ b/Geometry/CaloTopology/test/BuildFile.xml
@@ -7,8 +7,4 @@
 <use   name="Geometry/HcalTowerAlgo"/>
 
 <flags   EDM_PLUGIN="1"/>
-<library   file="HcalTopologyTester.cc" name="testGeometryHcalTopology"> </library>
-<library   file="HGCalTopologyTester.cc" name="testGeometryHGCalTopology"> </library>
-<library   file="CaloTowerTopologyTester.cc" name="testGeometryCaloTowerTopology"> </library>
-<library   file="FastTimeTopologyTester.cc" name="testGeometryFastTimeTopology"> </library>
-<library   file="CaloTowerMapTester.cc" name="testGeometryCaloTowerMap"> </library>
+<library   file="*.cc" name="testGeometryCaloTopology"> </library>

--- a/Geometry/CaloTopology/test/HcalDetId2DenseTester.cc
+++ b/Geometry/CaloTopology/test/HcalDetId2DenseTester.cc
@@ -1,0 +1,320 @@
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalCalibDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+
+class HcalDetId2DenseTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+
+public:
+  explicit HcalDetId2DenseTester(const edm::ParameterSet& );
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void beginJob() override {}
+  void beginRun(edm::Run const&, edm::EventSetup const&) override {}
+  void endRun(edm::Run const&, edm::EventSetup const&) override {}
+  void doTestFile(const HcalTopology& topology);
+  void doTestHcalDetId(const HcalTopology& topology);
+  void doTestHcalCalibDetId(const HcalTopology& topology);
+  std::vector<std::string> splitString (const std::string& fLine);
+  // ----------member data ---------------------------
+  const std::string     fileName_;
+};
+
+HcalDetId2DenseTester::HcalDetId2DenseTester(const edm::ParameterSet& iC) :
+  fileName_(iC.getUntrackedParameter<std::string>("fileName","")) {}
+
+void HcalDetId2DenseTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("fileName","");
+  descriptions.add("hcalDetId2DenseTester",desc);
+}
+
+void HcalDetId2DenseTester::analyze(edm::Event const&, edm::EventSetup const& iSetup ) {
+
+  edm::ESHandle<HcalTopology> topo;
+  iSetup.get<HcalRecNumberingRecord>().get(topo);
+  if (topo.isValid()) {
+    doTestFile(*topo);
+    doTestHcalDetId(*topo);
+    doTestHcalCalibDetId(*topo);
+  } else {
+    std::cout << "Cannot get a valid HcalTopology Object\n";
+  }
+}
+
+void HcalDetId2DenseTester::doTestFile(const HcalTopology& topology) {
+
+  if (!fileName_.empty()) {
+    std::ifstream fInput(fileName_);
+    if (!fInput.good()) {
+      std::cout << "Cannot open file " << fileName_ << std::endl;
+    } else {
+     char buffer [1024];
+     unsigned int all(0), total(0), good(0), ok(0), bad(0);
+     while (fInput.getline(buffer, 1024)) {
+        ++all;
+        if (buffer [0] == '#') continue; //ignore comment
+	std::vector <std::string> items = splitString (std::string(buffer));
+        if (items.size () != 4) {
+	  std::cout << "Ignore  line: " << buffer << std::endl;
+        } else {
+          ++total;
+	  int ieta = std::atoi (items[1].c_str());;
+	  int iphi = std::atoi (items[2].c_str());;
+	  std::string error;
+	  if ((items[0]=="HB") || (items[0]=="HE") || (items[0]=="HF") ||
+	      (items[0]=="HO")) {
+	    HcalSubdetector sd(HcalBarrel);
+	    if (items[0] == "HE") {
+	      sd = HcalEndcap;
+	    } else if (items[0] == "HF") {
+	      sd = HcalForward;
+	    } else if (items[0] == "HO") {
+	      sd = HcalOuter;
+	    }
+	    int depth = std::atoi (items[3].c_str());
+	    HcalDetId cell(sd,ieta,iphi,depth);
+	    if (topology.valid(cell)) {
+	      ++ok;
+	      unsigned int dense = topology.detId2denseId(DetId(cell));
+	      DetId        id    = topology.denseId2detId(dense);
+	      if (cell == HcalDetId(id)) {
+		error = ""; ++good;
+	      } else {
+		error =  "***ERROR***"; ++bad;
+	      }
+	      std::cout << total << " " << cell << " Dense Index " << dense
+			<< " gives back " << HcalDetId(id) << " " << error 
+			<< std::endl;
+	    }
+	 
+	  } else if (items[0].find ("CALIB_") == 0) {
+	    HcalSubdetector sd = HcalOther;
+	    if      (items[0].find("HB")!=std::string::npos) sd=HcalBarrel;
+	    else if (items[0].find("HE")!=std::string::npos) sd=HcalEndcap;
+	    else if (items[0].find("HO")!=std::string::npos) sd=HcalOuter;
+	    else if (items[0].find("HF")!=std::string::npos) sd=HcalForward;
+	    int channel = std::atoi (items[3].c_str());
+	    HcalCalibDetId cell(sd, ieta,iphi,channel);
+	    if (topology.validCalib(cell)) {
+	      ++ok;
+	      unsigned int dense = topology.detId2denseIdCALIB(DetId(cell));
+	      DetId        id    = topology.denseId2detIdCALIB(dense);
+	      if (cell == HcalCalibDetId(id)) {
+		error = ""; ++good;
+	      } else {
+		error =  "***ERROR***"; ++bad;
+	      }
+	      std::cout << total << " " << cell << " Dense Index " << dense
+			<< " gives back "  << HcalCalibDetId(id) << " " 
+			<< error << std::endl;
+	    }
+	  } else if ((items[0]=="HOX") || (items[0]=="HBX") || 
+		     (items[0]=="HEX")) {
+	    HcalCalibDetId cell = ((items[0]=="HOX") ?
+				   (HcalCalibDetId(HcalCalibDetId::HOCrosstalk,ieta,iphi)) :
+				   ((items[0]=="HBX") ? (HcalCalibDetId(HcalCalibDetId::HBX,ieta,iphi)) :
+				    (HcalCalibDetId(HcalCalibDetId::HEX,ieta,iphi))));
+	    if (topology.validCalib(cell)) {
+	      ++ok;
+	      unsigned int dense = topology.detId2denseIdCALIB(DetId(cell));
+	      DetId        id    = topology.denseId2detIdCALIB(dense);
+	      if (cell == HcalCalibDetId(id)) {
+		error = ""; ++good;
+	      } else {
+		error =  "***ERROR***"; ++bad;
+	      }
+	      std::cout << good << " " << cell << " Dense Index " << dense 
+			<< " gives back " << HcalCalibDetId(id) << " " 
+			<< error << std::endl;
+	    }
+	  }
+	}
+     }
+     fInput.close();
+     std::cout << "Reads total of " << all << ":" << total << " records with "
+	       << good << ":" << ok << " good and " << bad << " bad DetId's" 
+	       << std::endl;
+    }
+  }    
+}
+
+void HcalDetId2DenseTester::doTestHcalDetId(const HcalTopology& topology) {
+  const int n=48;
+  HcalSubdetector sds[n] = {HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
+			    HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
+			    HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
+			    HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
+			    HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
+			    HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
+			    HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
+			    HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
+			    HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
+			    HcalForward,HcalForward,HcalForward,HcalForward,
+			    HcalForward,HcalForward,HcalForward,HcalForward,
+			    HcalForward,HcalForward,HcalForward,HcalForward};
+  int ietas[n] = {  1,  5,  9, 12, 14, 16, -2, -4, -8,-11,-13,-16,
+		   18, 21, 23, 25, 27, 29,-19,-20,-22,-24,-26,-28,
+		    1,  3,  5,  9, 11, 13, -2, -4, -6,-10,-12,-14,
+                   30, 32, 34, 36, 38, 40,-31,-33,-35,-37,-39,-41};
+  int iphis[n] = {11,21,31,41,51,61, 5,15,25,35,45,65,
+		  11,23,35,47,59,71, 3,15,27,39,51,63,
+		  11,21,31,41,51,61, 5,15,25,35,45,65,
+		  11,23,35,47,59,71, 3,15,27,39,51,63};
+  int depth[n] = {1,1,1,1,1,1,1,1,1,1,1,1,
+		  2,2,2,2,2,2,2,2,2,2,2,2,
+		  4,4,4,4,4,4,4,4,4,4,4,4,
+		  1,1,1,1,1,1,2,2,2,2,2,2};
+
+  // Check on Dense Index
+  std::cout << "\nCheck on Dense Index for DetId's" << std::endl
+	    << "==================================" << std::endl;
+  int total(0), good(0), bad(0);
+  std::string error;
+  for (int i = 0; i < n; ++i) {
+    HcalDetId cell(sds[i], ietas[i], iphis[i], depth[i]);
+    if (topology.valid(cell)) {
+      ++total;
+      unsigned int dense = topology.detId2denseId(DetId(cell));
+      DetId        id    = topology.denseId2detId(dense);
+      if (cell == HcalDetId(id)) {
+	++good; error = "";
+      } else {
+	++bad; error = "**** ERROR *****"; 
+      }
+      std::cout << "[" << total << "] " << cell << " Dense " << dense 
+		<< " o/p " << HcalDetId(id) << " " << error << std::endl;
+    }
+  }
+
+  std::cout << "Analyzes total of " << n << ":" << total <<" HcalDetIds with "
+	    << good << " good and " << bad << " bad DetId's" << std::endl;
+}
+
+
+void HcalDetId2DenseTester::doTestHcalCalibDetId(const HcalTopology& topology) {
+
+  const int n=48;
+  HcalCalibDetId::CalibDetType dets[n] =
+    {HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::CalibrationBox,HcalCalibDetId::CalibrationBox,
+     HcalCalibDetId::HOCrosstalk,   HcalCalibDetId::HOCrosstalk,
+     HcalCalibDetId::HOCrosstalk,   HcalCalibDetId::HOCrosstalk,
+     HcalCalibDetId::HOCrosstalk,   HcalCalibDetId::HOCrosstalk,
+     HcalCalibDetId::HOCrosstalk,   HcalCalibDetId::HOCrosstalk,
+     HcalCalibDetId::HBX,           HcalCalibDetId::HBX,
+     HcalCalibDetId::HBX,           HcalCalibDetId::HBX,
+     HcalCalibDetId::HBX,           HcalCalibDetId::HBX,
+     HcalCalibDetId::HBX,           HcalCalibDetId::HBX,
+     HcalCalibDetId::HEX,           HcalCalibDetId::HEX,
+     HcalCalibDetId::HEX,           HcalCalibDetId::HEX,
+     HcalCalibDetId::HEX,           HcalCalibDetId::HEX,
+     HcalCalibDetId::HEX,           HcalCalibDetId::HEX};
+  HcalSubdetector sds[n] = 
+    {HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
+     HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
+     HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
+     HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
+     HcalOuter,  HcalOuter,  HcalForward,HcalForward,
+     HcalForward,HcalForward,HcalForward,HcalForward,
+     HcalBarrel, HcalBarrel, HcalBarrel, HcalBarrel,
+     HcalBarrel, HcalBarrel, HcalEndcap, HcalEndcap,
+     HcalEndcap, HcalEndcap, HcalEndcap, HcalEndcap,
+     HcalOuter,  HcalOuter,  HcalOuter,  HcalOuter,
+     HcalOuter,  HcalOuter,  HcalForward,HcalForward,
+     HcalForward,HcalForward,HcalForward,HcalForward};
+  int ietas[n] = { 1,  1,  1, -1, -1, -1,  1,  1,  1, -1, -1, -1,
+		   1, -1,  0,  2, -1, -2,  1,  1, -1, -1,  1, -1,
+		   4,  4, -4, -4, 15, 15,-15,-15,-16,-16,-16,-16,
+                  16, 16, 16, 16, 25, 25, 27, 27,-25,-25,-27,-27};
+  int iphis[n] = {11,23,35,47,59,71, 3,15,27,39,51,65,
+		  22,11,35,71,47,59,19,37,55, 1,19,37,
+		  47,36,36,41,51,61, 5,15,25,35,45,65,
+		  11, 1,35,47,59,71, 3,15,27,39,51,63};
+  int depth[n] = {0,1,2,0,1,2,0,1,3,4,5,6,
+		  0,1,0,1,7,7,0,1,0,1,0,1,
+		  4,4,4,4,4,4,4,4,4,4,4,4,
+		  1,1,1,1,1,1,2,2,2,2,2,2};
+
+  // Check on Dense Index
+  std::cout << "\nCheck on Dense Index for CalibDetId's" << std::endl
+	    << "=======================================" << std::endl;
+  int total(0), good(0), bad(0);
+  std::string error;
+  for (int i = 0; i < n; ++i) {
+    HcalCalibDetId cell;
+    if (dets[i] == HcalCalibDetId::CalibrationBox) {
+      cell = HcalCalibDetId(sds[i], ietas[i], iphis[i], depth[i]);
+    } else {
+      cell = HcalCalibDetId(dets[i], ietas[i], iphis[i]);
+    }
+    if (topology.validCalib(cell)) {
+      ++total;
+      unsigned int dense = topology.detId2denseIdCALIB(DetId(cell));
+      DetId        id    = topology.denseId2detIdCALIB(dense);
+      if (cell == HcalCalibDetId(id)) {
+	++good; error = "";
+      } else {
+	++bad; error = "**** ERROR *****"; 
+      }
+      std::cout << "[" << total << "] " << cell << " Dense " << dense 
+		<< " o/p " << HcalCalibDetId(id) << " " << error << std::endl;
+    }
+  }
+  std::cout << "Analyzes total of " << n << ":" << total << " CalibIds with "
+	    << good << " good and " << bad << " bad DetId's" << std::endl;
+}
+
+std::vector<std::string> HcalDetId2DenseTester::splitString (const std::string& fLine) {
+  std::vector <std::string> result;
+  int start = 0;
+  bool empty = true;
+  for (unsigned i = 0; i <= fLine.size (); i++) {
+    if (fLine [i] == ' ' || i == fLine.size ()) {
+      if (!empty) {
+	std::string item (fLine, start, i-start);
+        result.push_back (item);
+        empty = true;
+      }
+      start = i+1;
+    } else {
+      if (empty) empty = false;
+    }
+  }
+  return result;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HcalDetId2DenseTester);

--- a/Geometry/CaloTopology/test/hcaldetid2dense.txt
+++ b/Geometry/CaloTopology/test/hcaldetid2dense.txt
@@ -1,0 +1,91 @@
+      HB   -10    14      4
+      HB    -9    14      4
+      HB   -12    14      4
+      HB   -11    14      4
+      HB     4    11      1
+      HB     3    11      1
+      HB     2    11      1
+      HB     1    11      1
+      HB     7    14      1
+      HB     6    14      3
+      HB     5    14      3
+      HB     8    14      3
+      HE   -29    13      1
+      HE   -18    14      2
+      HE   -17    14      2
+      HE   -24    15      3
+      HE   -26    15      2
+      HE    29    11      1
+      HE    28    11      1
+      HE    18    11      2
+      HE    26    11      7
+      HE    28    11      6
+      HE    18    11      3
+      HE    28    11      4
+      HF   -34     5      1
+      HF   -34     5      4
+      HF   -32     5      1
+      HF   -32     5      4
+      HF   -30     5      1
+      HF   -30     5      4
+      HF    38     5      3
+      HF    36     5      3
+      HF    39     5      2
+      HF    39     5      3
+      HF    37     5      2
+      HF    37     5      3
+      HO    15     4      4
+      HO    14     4      4
+      HO    12     2      4
+      HO    11     3      4
+      HO    10    71      4
+      HO     9    72      4
+      HO     4    71      4
+      HO   -15     3      4
+      HO    -2     6      4
+      HO     1     5      4
+      HO   -10    11      4
+      HO    -9    12      4
+CALIB_HB    -1    11      0
+CALIB_HB    -1    11      1
+CALIB_HB     1    15      2
+CALIB_HB    -1    19      0
+CALIB_HB     1     7      1
+CALIB_HB     1     7      2
+CALIB_HE    -1    11      6
+CALIB_HE    -1    15      0
+CALIB_HE     1    15      1
+CALIB_HE    -1     7      3
+CALIB_HE     1    27      5
+CALIB_HE     1    27      6
+CALIB_HO     0    47      0
+CALIB_HO     1    47      1
+CALIB_HO     1    47      7
+CALIB_HO    -2    59      1
+CALIB_HO     2    71      0
+CALIB_HO    -1    11      1
+CALIB_HF     1    55      1
+CALIB_HF     1     1      0
+CALIB_HF    -1     1      8
+CALIB_HF    -1     1      1
+CALIB_HF    -1    19      8
+CALIB_HF    -1    19      0
+     HOX     4    71   -999
+     HOX   -15     4   -999
+     HOX   -15     3   -999
+     HOX    -4    19   -999
+     HOX    -4    17   -999
+     HOX    15    51   -999
+     HBX   -16    16   -999
+     HBX   -16    15   -999
+     HBX    16    11   -999
+     HBX    16    12   -999
+     HBX    16    34   -999
+     HBX   -16    70   -999
+     HEX    27    13   -999
+     HEX    25    15   -999
+     HEX    27    15   -999
+     HEX    25    17   -999
+     HEX    27    17   -999
+     HEX   -25    21   -999
+

--- a/Geometry/CaloTopology/test/testHcalDetId2DenseTester_cfg.py
+++ b/Geometry/CaloTopology/test/testHcalDetId2DenseTester_cfg.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+process.load("SimGeneral.HepPDTESSource.pdt_cfi")
+
+#process.load("Geometry.HcalCommonData.testGeometry17bXML_cfi")
+#process.load("Geometry.HcalCommonData.hcalDDConstants_cff")
+#process.load("Geometry.HcalEventSetup.hcalTopologyIdeal_cfi")
+process.load('Configuration.Geometry.GeometryExtended2023D41Reco_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.categories.append('HcalGeom')
+    process.MessageLogger.categories.append('CaloTopology')
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.generator.initialSeed = 456789
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDProducer("FlatRandomEGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32(14),
+        MinEta = cms.double(-3.5),
+        MaxEta = cms.double(3.5),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinE   = cms.double(9.99),
+        MaxE   = cms.double(10.01)
+    ),
+    AddAntiParticle = cms.bool(False),
+    Verbosity       = cms.untracked.int32(0),
+    firstRun        = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.load("Geometry.CaloTopology.hcalDetId2DenseTester_cfi")
+process.hcalDetId2DenseTester.fileName = "hcaldetid2dense.txt"
+
+process.p1 = cms.Path(process.generator*process.hcalDetId2DenseTester)


### PR DESCRIPTION
#### PR description:

Extend detId2denseId for new calibration types HBX and HEX and also provide the corresponding dense index to hcalcalibdetid 

#### PR validation:

Made a test with runTheMatrix.py and also added a private test to verify the two added methods

#### if this PR is a backport please specify the original PR:

No back porting is required