### PR TITLE
Additional Photos options

### DIFF
--- a/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
+++ b/GeneratorInterface/PhotosInterface/plugins/PhotosppInterface.cc
@@ -91,6 +91,12 @@ void PhotosppInterface::init() {
     if (curSet == "suppressAll")
       if (fPSet->getParameter<bool>(curSet) == true)
         Photospp::Photos::suppressAll();
+    if(curSet=="setPairEmission")
+      Photospp::Photos::setPairEmission(fPSet->getParameter<bool>(curSet));
+    if(curSet=="setPhotonEmission")
+      Photospp::Photos::setPhotonEmission(fPSet->getParameter<bool>(curSet));
+    if(curSet=="setStopAtCriticalError")
+      Photospp::Photos::setStopAtCriticalError(fPSet->getParameter<bool>(curSet));
 
     // Now setup more complicated radiation/mass supression and forcing.
     if (curSet == "suppressBremForBranch") {

--- a/GeneratorInterface/PhotosInterface/test/DY_7TeV_pythia8_rivet.py
+++ b/GeneratorInterface/PhotosInterface/test/DY_7TeV_pythia8_rivet.py
@@ -1,0 +1,162 @@
+import FWCore.ParameterSet.Config as cms
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing ('python')
+options.register('outFilename', 'particleLevel.root',  VarParsing.multiplicity.singleton, VarParsing.varType.string, "Output file name")
+options.register('photos', 'off', VarParsing.multiplicity.singleton, VarParsing.varType.string, "ME corrections")
+options.register('lepton', 13, VarParsing.multiplicity.singleton, VarParsing.varType.int, "Lepton ID for Z decays")
+options.setDefault('maxEvents', 10000)
+options.parseArguments()
+print(options)
+
+process = cms.Process("PROD")
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = int(options.maxEvents/100)
+
+from IOMC.RandomEngine.RandomServiceHelper import RandomNumberServiceHelper
+randSvc = RandomNumberServiceHelper(process.RandomNumberGeneratorService)
+randSvc.populate()
+
+# set input to process
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(7000.),
+    PythiaParameters = cms.PSet(
+        processParameters = cms.vstring('WeakSingleBoson:ffbar2gmZ = on',
+                                        'PhaseSpace:mHatMin = 50.',
+                                        '23:onMode = off', 
+                                        '23:onIfAny = %i' % options.lepton,
+                                        #'PartonLevel:MPI = off',
+                                        #'PartonLevel:ISR = off',
+                                        #'PartonLevel:FSR = off',
+                                        #'HadronLevel:all = off',
+                                        ),
+        parameterSets = cms.vstring('processParameters')
+    )
+)
+
+if options.photos == 'exp':
+    process.generator.ExternalDecays = cms.PSet(
+        Photospp = cms.untracked.PSet(
+            parameterSets = cms.vstring("setExponentiation", "setInfraredCutOff", "setMeCorrectionWtForW", "setMeCorrectionWtForZ", "setMomentumConservationThreshold", "setPairEmission", "setPhotonEmission", "setStopAtCriticalError"),
+            setExponentiation = cms.bool(True),
+            setMeCorrectionWtForW = cms.bool(True),
+            setMeCorrectionWtForZ = cms.bool(True),
+            setInfraredCutOff = cms.double(0.00011),
+            setMomentumConservationThreshold = cms.double(0.1),
+            setPairEmission = cms.bool(True),
+            setPhotonEmission = cms.bool(True),
+            setStopAtCriticalError = cms.bool(False),
+        ),
+        parameterSets = cms.vstring("Photospp")
+    )
+    process.generator.PythiaParameters.processParameters += cms.vstring(
+        'ParticleDecays:allowPhotonRadiation = off',
+        'TimeShower:QEDshowerByL = off',
+    )
+
+if options.photos == 'single':
+    process.generator.ExternalDecays = cms.PSet(
+        Photospp = cms.untracked.PSet(
+            parameterSets = cms.vstring("setExponentiation", "setInfraredCutOff", "setMeCorrectionWtForW", "setMeCorrectionWtForZ", "setMomentumConservationThreshold", "setPairEmission", "setPhotonEmission", "setStopAtCriticalError"),
+            setExponentiation = cms.bool(False),
+            setInfraredCutOff = cms.double(0.001),
+            setMeCorrectionWtForW = cms.bool(True),
+            setMeCorrectionWtForZ = cms.bool(True),
+            setMomentumConservationThreshold = cms.double(0.1),
+            setPairEmission = cms.bool(True),
+            setPhotonEmission = cms.bool(True),
+            setStopAtCriticalError = cms.bool(False),
+        ),
+        parameterSets = cms.vstring("Photospp")
+    )
+    process.generator.PythiaParameters.processParameters += cms.vstring(
+        'ParticleDecays:allowPhotonRadiation = off',
+        'TimeShower:QEDshowerByL = off'
+    )
+
+if options.photos == 'double':
+    process.generator.ExternalDecays = cms.PSet(
+        Photospp = cms.untracked.PSet(
+            parameterSets = cms.vstring("setExponentiation", "setDoubleBrem", "setInfraredCutOff", "setMeCorrectionWtForW", "setMeCorrectionWtForZ", "setMomentumConservationThreshold", "setPairEmission", "setPhotonEmission", "setStopAtCriticalError"),
+            setExponentiation = cms.bool(False),
+            setDoubleBrem = cms.bool(True),
+            setInfraredCutOff = cms.double(0.001),
+            setMeCorrectionWtForW = cms.bool(True),
+            setMeCorrectionWtForZ = cms.bool(True),
+            setMomentumConservationThreshold = cms.double(0.1),
+            setPairEmission = cms.bool(True),
+            setPhotonEmission = cms.bool(True),
+            setStopAtCriticalError = cms.bool(False),
+        ),
+        parameterSets = cms.vstring("Photospp")
+    )
+    process.generator.PythiaParameters.processParameters += cms.vstring(
+        'ParticleDecays:allowPhotonRadiation = off',
+        'TimeShower:QEDshowerByL = off'
+    )
+
+if options.photos == 'quatro':
+    process.generator.ExternalDecays = cms.PSet(
+        Photospp = cms.untracked.PSet(
+            parameterSets = cms.vstring("setExponentiation", "setQuatroBrem", "setInfraredCutOff", "setMeCorrectionWtForW", "setMeCorrectionWtForZ", "setMomentumConservationThreshold", "setPairEmission", "setPhotonEmission", "setStopAtCriticalError"),
+            setExponentiation = cms.bool(False),
+            setQuatroBrem = cms.bool(True),
+            setInfraredCutOff = cms.double(0.001),
+            setMeCorrectionWtForW = cms.bool(True),
+            setMeCorrectionWtForZ = cms.bool(True),
+            setMomentumConservationThreshold = cms.double(0.1),
+            setPairEmission = cms.bool(True),
+            setPhotonEmission = cms.bool(True),
+            setStopAtCriticalError = cms.bool(False),
+        ),
+        parameterSets = cms.vstring("Photospp")
+    )
+    process.generator.PythiaParameters.processParameters += cms.vstring(
+        'ParticleDecays:allowPhotonRadiation = off',
+        'TimeShower:QEDshowerByL = off'
+    )
+
+if options.photos == 'nofsr':
+    process.generator.PythiaParameters.processParameters += cms.vstring(
+        'TimeShower:QEDshowerByL = off'
+    )
+
+## configure process options
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True),
+    wantSummary      = cms.untracked.bool(True)
+)
+
+process.genParticles = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator:unsmeared"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+process.printTree1 = cms.EDAnalyzer("ParticleListDrawer",
+    src = cms.InputTag("genParticles"),
+    maxEventsToPrint  = cms.untracked.int32(10)
+)
+
+process.load("GeneratorInterface.RivetInterface.particleLevel_cfi")
+process.particleLevel.src = cms.InputTag("generator:unsmeared")
+process.particleLevel.lepConeSize = 0.1
+
+process.load("GeneratorInterface.RivetInterface.rivetAnalyzer_cfi")
+process.rivetAnalyzer.HepMCCollection = cms.InputTag("generator:unsmeared")
+process.rivetAnalyzer.AnalysisNames = cms.vstring('CMS_2015_I1346843', 'MC_ZINC_MU', 'MC_ZINC_MU_BARE', 'MC_ZINC_EL', 'MC_ZINC_EL_BARE', 'MC_PHOTONS', 'MC_MUONS', 'MC_ELECTRONS')
+process.rivetAnalyzer.OutputFile = cms.string('run.yoda')
+
+process.path = cms.Path(process.generator*process.rivetAnalyzer)#*process.particleLevel*process.genParticles*process.printTree1)
+


### PR DESCRIPTION
#### PR description:

Add additional options for Photos++: Enabling of pair production (`setPairEmission`) and ability to continue after rare erroneus events (`setStopAtCriticalError`) that would halt production otherwise.

#### PR validation:

![d02-x01-y01](https://user-images.githubusercontent.com/1311783/58079537-860df400-7bb1-11e9-854f-f83004661947.png)
![DeltaR_ptweighted](https://user-images.githubusercontent.com/1311783/58079673-d422f780-7bb1-11e9-9b0c-ad86586c630f.png)
![Ptgamma](https://user-images.githubusercontent.com/1311783/58079688-dedd8c80-7bb1-11e9-9dc6-6961f59a746e.png)

> @qliphy Please see here the electron multiplicity in Z->mu+mu- events with pair production on/off. Events with 1/2 electrons (= 1 pair) are suppressed by one order of magnitude if pair production is turned off.
> 
> ![image](https://user-images.githubusercontent.com/1311783/58097171-0bf06600-7bd7-11e9-931f-a3291cc521a2.png)
> 
> It seems Photos creates maximal 1 pair while Pythia can do more.

