### PR TITLE
Remove obsolete DataFormats headers

### DIFF
--- a/DataFormats/BTauReco/interface/JetTracksAssociation.h
+++ b/DataFormats/BTauReco/interface/JetTracksAssociation.h
@@ -1,7 +1,0 @@
-#ifndef BTauReco_JetTracksAssociation_h
-#define BTauReco_JetTracksAssociation_h
-
-#warning "Including DF/BTau/JTA is deprecated, please include DataFormats/JetReco/interface/JetTracksAssociation.h"
-#include "DataFormats/JetReco/interface/JetTracksAssociation.h"
-
-#endif

--- a/DataFormats/JetReco/interface/BasicJetfwd.h
+++ b/DataFormats/JetReco/interface/BasicJetfwd.h
@@ -1,2 +1,0 @@
-#warning BasicJetfwd.h is deprecated, use #include "DataFormats/JetReco/interface/BasicJetCollection.h" instead
-#include "DataFormats/JetReco/interface/BasicJetCollection.h"

--- a/DataFormats/JetReco/interface/CaloJetfwd.h
+++ b/DataFormats/JetReco/interface/CaloJetfwd.h
@@ -1,2 +1,0 @@
-#warning CaloJetfwd.h is deprecated, use #include "DataFormats/JetReco/interface/CaloJetCollection.h" instead
-#include "DataFormats/JetReco/interface/CaloJetCollection.h"

--- a/DataFormats/JetReco/interface/GenJetfwd.h
+++ b/DataFormats/JetReco/interface/GenJetfwd.h
@@ -1,2 +1,0 @@
-#warning "GenJetfwd.h is deprecated, use #include DataFormats/JetReco/interface/GenJetCollection.h instead"
-#include "DataFormats/JetReco/interface/GenJetCollection.h"

--- a/DataFormats/JetReco/interface/GenericJetfwd.h
+++ b/DataFormats/JetReco/interface/GenericJetfwd.h
@@ -1,2 +1,0 @@
-#warning "GenericJetfwd.h is deprecated, use #include DataFormats/JetReco/interface/GenericJetCollection.h instead"
-#include "DataFormats/JetReco/interface/GenericJetCollection.h"

--- a/DataFormats/JetReco/interface/PFJetfwd.h
+++ b/DataFormats/JetReco/interface/PFJetfwd.h
@@ -1,2 +1,0 @@
-#warning "PFJetfwd.h is deprecated, use #include DataFormats/JetReco/interface/PFJetCollection.h instead")
-#include "DataFormats/JetReco/interface/PFJetCollection.h"


### PR DESCRIPTION
#### PR description:

The following DataFormats headers are already marked as obsolete, and since a while never included in CMSSW code:
```C++
DataFormats/BTauReco/interface/JetTracksAssociation.h
DataFormats/JetReco/interface/BasicJetfwd.h
DataFormats/JetReco/interface/CaloJetfwd.h
DataFormats/JetReco/interface/GenJetfwd.h
DataFormats/JetReco/interface/GenericJetfwd.h
DataFormats/JetReco/interface/PFJetfwd.h
```
They are also giving header inconsistency warnings in the code checks: removing them will silence those warnings

#### PR validation:

It builds