### PR TITLE
Manage PluginFactory plugins with unique_ptr in RecoEgamma

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -195,8 +195,8 @@ class GsfElectronAlgo {
       const ElectronHcalHelper::Configuration & hcalCfgPflow,
       const IsolationConfiguration &,
       const EcalRecHitsConfiguration &,
-      EcalClusterFunctionBaseClass * superClusterErrorFunction,
-      EcalClusterFunctionBaseClass * crackCorrectionFunction,
+      std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction,
+      std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction,
       const RegressionHelper::Configuration & regCfg,
       const edm::ParameterSet& tkIsol03Cfg,
       const edm::ParameterSet& tkIsol04Cfg,
@@ -233,8 +233,8 @@ class GsfElectronAlgo {
       // additional configuration and helpers
       ElectronHcalHelper hcalHelper;
       ElectronHcalHelper hcalHelperPflow ;
-      EcalClusterFunctionBaseClass * superClusterErrorFunction ;
-      EcalClusterFunctionBaseClass * crackCorrectionFunction ;
+      std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction ;
+      std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction ;
       RegressionHelper regHelper;
      } ;
 

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -302,8 +302,8 @@ GsfElectronAlgo::GsfElectronAlgo
    const ElectronHcalHelper::Configuration & hcalCfgPflow,
    const IsolationConfiguration & isoCfg,
    const EcalRecHitsConfiguration & recHitsCfg,
-   EcalClusterFunctionBaseClass * superClusterErrorFunction,
-   EcalClusterFunctionBaseClass * crackCorrectionFunction,
+   std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction,
+   std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction,
    const RegressionHelper::Configuration & regCfg,
    const edm::ParameterSet& tkIsol03Cfg,
    const edm::ParameterSet& tkIsol04Cfg,
@@ -311,7 +311,7 @@ GsfElectronAlgo::GsfElectronAlgo
    const edm::ParameterSet& tkIsolHEEP04Cfg
 
  )
-: generalData_{inputCfg,strategyCfg,cutsCfg,cutsCfgPflow,isoCfg,recHitsCfg,hcalCfg,hcalCfgPflow,superClusterErrorFunction,crackCorrectionFunction,regCfg},
+: generalData_{inputCfg,strategyCfg,cutsCfg,cutsCfgPflow,isoCfg,recHitsCfg,hcalCfg,hcalCfgPflow,std::move(superClusterErrorFunction),std::move(crackCorrectionFunction),regCfg},
    eventSetupData_{},
    tkIsol03Calc_(tkIsol03Cfg),tkIsol04Calc_(tkIsol04Cfg),
    tkIsolHEEP03Calc_(tkIsolHEEP03Cfg),tkIsolHEEP04Calc_(tkIsolHEEP04Cfg)
@@ -803,7 +803,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection & electrons, El
   theClassifier.classify(ele) ;
   theClassifier.refineWithPflow(ele) ;
   // ecal energy
-  ElectronEnergyCorrector theEnCorrector(generalData_.crackCorrectionFunction) ;
+  ElectronEnergyCorrector theEnCorrector(generalData_.crackCorrectionFunction.get()) ;
   if (generalData_.strategyCfg.useEcalRegression) // new 
     { 
       generalData_.regHelper.applyEcalRegression(ele,

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
@@ -33,12 +33,8 @@ GEDGsfElectronFinalizer::GEDGsfElectronFinalizer( const edm::ParameterSet & cfg 
    if( cfg.existsAs<edm::ParameterSet>("regressionConfig") ) {
      const edm::ParameterSet& iconf = cfg.getParameterSet("regressionConfig");
      const std::string& mname = iconf.getParameter<std::string>("modifierName");
-     edm::ConsumesCollector&& cc = consumesCollector();
-     ModifyObjectValueBase* plugin = 
-       ModifyObjectValueFactory::get()->create(mname,iconf,cc);
-     gedRegression_.reset(plugin);
-   } else {
-     gedRegression_.reset(nullptr);
+     auto cc = consumesCollector();
+     gedRegression_ = std::unique_ptr<ModifyObjectValueBase>{ModifyObjectValueFactory::get()->create(mname,iconf,cc)};
    }
 
    produces<reco::GsfElectronCollection> (outputCollectionLabel_);

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -344,20 +344,15 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg, 
       .combinationRegressionWeightFiles = cfg.getParameter<std::vector<std::string> >("combinationRegressionWeightFile")
   };
 
-  // functions for corrector
-  EcalClusterFunctionBaseClass * const superClusterErrorFunction =
-      EcalClusterFunctionFactory::get()->create(cfg.getParameter<std::string>("superClusterErrorFunction"),cfg);
-  EcalClusterFunctionBaseClass * const crackCorrectionFunction =
-      EcalClusterFunctionFactory::get()->create(cfg.getParameter<std::string>("crackCorrectionFunction"),cfg) ;
 
   // create algo
-  algo_ = new GsfElectronAlgo
+  algo_ = std::make_unique<GsfElectronAlgo>
    ( inputCfg_, strategyCfg_,
      cutsCfg_,cutsCfgPflow_,
      hcalCfg_,hcalCfgPflow_,
      isoCfg,recHitsCfg,
-     superClusterErrorFunction,
-     crackCorrectionFunction,
+     std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create(cfg.getParameter<std::string>("superClusterErrorFunction"),cfg)},
+     std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create(cfg.getParameter<std::string>("crackCorrectionFunction"),cfg)},
      regressionCfg,
      cfg.getParameter<edm::ParameterSet>("trkIsol03Cfg"),
      cfg.getParameter<edm::ParameterSet>("trkIsol04Cfg"),
@@ -366,7 +361,7 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg, 
    ) ;
  }
 
-GsfElectronBaseProducer::~GsfElectronBaseProducer() { delete algo_ ; }
+GsfElectronBaseProducer::~GsfElectronBaseProducer() = default;
 
 void GsfElectronBaseProducer::beginEvent( edm::Event & event, const edm::EventSetup & setup )
  {

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -45,7 +45,7 @@ class GsfElectronBaseProducer : public edm::stream::EDProducer< edm::GlobalCache
 
   protected:
 
-    GsfElectronAlgo * algo_ ;
+    std::unique_ptr<GsfElectronAlgo> algo_ ;
 
     void beginEvent( edm::Event &, const edm::EventSetup & ) ;
     void fillEvent( reco::GsfElectronCollection & electrons, edm::Event & event ) ;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRegionalPixelSeedGeneratorProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRegionalPixelSeedGeneratorProducers.cc
@@ -61,17 +61,15 @@ EgammaHLTRegionalPixelSeedGeneratorProducers::EgammaHLTRegionalPixelSeedGenerato
   edm::ParameterSet hitsfactoryPSet = conf.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
   std::string hitsfactoryName = hitsfactoryPSet.getParameter<std::string>("ComponentName");
 
-  // get orderd hits generator from factory
-  edm::ConsumesCollector iC = consumesCollector();
-  OrderedHitsGenerator*  hitsGenerator = OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC);
-
   // start seed generator
   edm::ParameterSet creatorPSet;
   creatorPSet.addParameter<std::string>("propagator","PropagatorWithMaterial");
 
-  combinatorialSeedGenerator.reset(new SeedGeneratorFromRegionHits( hitsGenerator, nullptr,
-                                                                    SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
-                                                                    ));
+  edm::ConsumesCollector iC = consumesCollector();
+  combinatorialSeedGenerator = std::make_unique<SeedGeneratorFromRegionHits>( OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC),
+                                                                              nullptr,
+                                                                              SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
+                                                                              );
   // setup orderedhits setup (in order to tell seed generator to use pairs/triplets, which layers)
 }
 

--- a/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
@@ -25,36 +25,31 @@ PhotonEnergyCorrector::PhotonEnergyCorrector( const edm::ParameterSet& config, e
 
 
   // function to extract f(eta) correction
-  scEnergyFunction_ = nullptr ;
   std::string superClusterFunctionName = config.getParameter<std::string>("superClusterEnergyCorrFunction") ;
-  scEnergyFunction_.reset(EcalClusterFunctionFactory::get()->create(superClusterFunctionName,config));
+  scEnergyFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create(superClusterFunctionName,config)};
 
 
   // function to extract corrections to cracks
-  scCrackEnergyFunction_ = nullptr ;
   std::string superClusterCrackFunctionName = config.getParameter<std::string>("superClusterCrackEnergyCorrFunction") ;
-  scCrackEnergyFunction_.reset(EcalClusterFunctionFactory::get()->create(superClusterCrackFunctionName,config));
+  scCrackEnergyFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create(superClusterCrackFunctionName,config)};
 
 
   // function to extract the error on the sc ecal correction
-  scEnergyErrorFunction_ = nullptr ;
   std::string superClusterErrorFunctionName = config.getParameter<std::string>("superClusterEnergyErrorFunction") ;
-  scEnergyErrorFunction_.reset(EcalClusterFunctionFactory::get()->create(superClusterErrorFunctionName,config));
+  scEnergyErrorFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create(superClusterErrorFunctionName,config)};
 
 
   // function  to extract the error on the photon ecal correction
-  photonEcalEnergyCorrFunction_=nullptr;
   std::string photonEnergyFunctionName = config.getParameter<std::string>("photonEcalEnergyCorrFunction") ;
-  photonEcalEnergyCorrFunction_.reset(EcalClusterFunctionFactory::get()->create(photonEnergyFunctionName, config));
+  photonEcalEnergyCorrFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create(photonEnergyFunctionName, config)};
   //ingredient for photon uncertainty
-  photonUncertaintyCalculator_.reset(new EnergyUncertaintyPhotonSpecific(config));
+  photonUncertaintyCalculator_ = std::make_unique<EnergyUncertaintyPhotonSpecific>(config);
  
   if( config.existsAs<edm::ParameterSet>("regressionConfig") ) {
     const edm::ParameterSet& regr_conf = 
       config.getParameterSet("regressionConfig");
     const std::string& mname = regr_conf.getParameter<std::string>("modifierName");
-    ModifyObjectValueBase* regr = ModifyObjectValueFactory::get()->create(mname,regr_conf,iC);
-    gedRegression_.reset(regr);
+    gedRegression_ = std::unique_ptr<ModifyObjectValueBase>{ModifyObjectValueFactory::get()->create(mname,regr_conf,iC)};
   }
 
   // ingredient for energy regression
@@ -62,7 +57,7 @@ PhotonEnergyCorrector::PhotonEnergyCorrector( const edm::ParameterSet& config, e
   w_file_ = config.getParameter<std::string>("energyRegressionWeightsFileLocation");
   if (weightsfromDB_) w_db_   = config.getParameter<std::string>("energyRegressionWeightsDBLocation");
   else  w_db_ = "none" ;
-  regressionCorrector_.reset(new EGEnergyCorrector()); 
+  regressionCorrector_ = std::make_unique<EGEnergyCorrector>();
 
 
 }

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
@@ -47,7 +47,7 @@
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
 namespace {
-  BaseCkfTrajectoryBuilder *createBaseCkfTrajectoryBuilder(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC) {
+  auto createBaseCkfTrajectoryBuilder(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC) {
     return BaseCkfTrajectoryBuilderFactory::get()->create(pset.getParameter<std::string>("ComponentType"), pset, iC);
   }
 }


### PR DESCRIPTION
#### PR description:

In addition use `unique_ptr` constructor where needed to prepare for PluginFactory returning `std::unique_ptr`.

#### PR validation:

Code compiles.
