### PR TITLE
Manage plugin factory plugins with unique_ptr in Alignment

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 #include <utility>
+#include <memory>
 
 class AlignableTracker;
 class AlignableMuon;
@@ -49,6 +50,9 @@ namespace reco {
 /*** Global typedefs part I (see EOF for part II) ***/
 typedef std::pair<const Trajectory *, const reco::Track *> ConstTrajTrackPair;
 typedef std::vector<ConstTrajTrackPair> ConstTrajTrackPairs;
+
+typedef std::vector<IntegratedCalibrationBase *> Calibrations;
+typedef std::vector<std::unique_ptr<IntegratedCalibrationBase>> CalibrationsOwner;
 
 typedef std::vector<IntegratedCalibrationBase *> Calibrations;
 
@@ -125,6 +129,15 @@ public:
   /// Pass integrated calibrations to algorithm, to be called after initialize()
   /// Calibrations' ownership is NOT passed to algorithm
   virtual bool addCalibrations(const Calibrations &) { return false; }
+  // Overloading for the owning vector
+  bool addCalibrations(const CalibrationsOwner &cals) {
+    Calibrations tmp;
+    tmp.reserve(cals.size());
+    for (const auto &ptr : cals) {
+      tmp.push_back(ptr.get());
+    }
+    return addCalibrations(tmp);
+  }
 
   /// Returns whether algorithm proccesses events in current configuration
   virtual bool processesEvents() { return true; }

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -216,10 +216,10 @@ private:
   CalibrationsOwner calibrations_;
   AlignmentMonitors monitors_;
 
-  AlignmentParameterStore* alignmentParameterStore_{nullptr};
-  AlignableTracker* alignableTracker_{nullptr};
-  AlignableMuon* alignableMuon_{nullptr};
-  AlignableExtras* alignableExtras_{nullptr};
+  std::unique_ptr<AlignmentParameterStore> alignmentParameterStore_;
+  std::unique_ptr<AlignableTracker> alignableTracker_;
+  std::unique_ptr<AlignableMuon> alignableMuon_;
+  std::unique_ptr<AlignableExtras> alignableExtras_;
 
   edm::Handle<reco::BeamSpot> beamSpot_;
   /// GlobalPositions that might be read from DB, nullptr otherwise

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -213,7 +213,7 @@ private:
   /*** Alignment data ***/
 
   std::unique_ptr<AlignmentAlgorithmBase> alignmentAlgo_;
-  Calibrations calibrations_;
+  CalibrationsOwner calibrations_;
   AlignmentMonitors monitors_;
 
   AlignmentParameterStore* alignmentParameterStore_{nullptr};

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -81,9 +81,6 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config)
 
 //------------------------------------------------------------------------------
 AlignmentProducerBase::~AlignmentProducerBase() noexcept(false) {
-  for (auto& iCal : calibrations_)
-    delete iCal;
-
   delete alignmentParameterStore_;
   delete alignableExtras_;
   delete alignableTracker_;
@@ -301,7 +298,7 @@ void AlignmentProducerBase::createMonitors() {
 void AlignmentProducerBase::createCalibrations() {
   const auto& calibrations = config_.getParameter<edm::VParameterSet>("calibrations");
   for (const auto& iCalib : calibrations) {
-    calibrations_.push_back(
+    calibrations_.emplace_back(
         IntegratedCalibrationPluginFactory::get()->create(iCalib.getParameter<std::string>("calibrationName"), iCalib));
   }
 }

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -80,12 +80,7 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config)
 }
 
 //------------------------------------------------------------------------------
-AlignmentProducerBase::~AlignmentProducerBase() noexcept(false) {
-  delete alignmentParameterStore_;
-  delete alignableExtras_;
-  delete alignableTracker_;
-  delete alignableMuon_;
-}
+AlignmentProducerBase::~AlignmentProducerBase() noexcept(false) {}
 
 //------------------------------------------------------------------------------
 void AlignmentProducerBase::startProcessing() {
@@ -379,7 +374,8 @@ void AlignmentProducerBase::initAlignmentAlgorithm(const edm::EventSetup& setup,
   // latter to algorithm
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::initAlignmentAlgorithm"
                             << "Initializing alignment algorithm.";
-  alignmentAlgo_->initialize(setup, alignableTracker_, alignableMuon_, alignableExtras_, alignmentParameterStore_);
+  alignmentAlgo_->initialize(
+      setup, alignableTracker_.get(), alignableMuon_.get(), alignableExtras_.get(), alignmentParameterStore_.get());
 
   // Not all algorithms support calibrations - so do not pass empty vector
   // and throw if non-empty and not supported:
@@ -399,10 +395,10 @@ void AlignmentProducerBase::initAlignmentAlgorithm(const edm::EventSetup& setup,
 
   if (!isTrueUpdate) {  // only needed the first time
     for (const auto& iCal : calibrations_) {
-      iCal->beginOfJob(alignableTracker_, alignableMuon_, alignableExtras_);
+      iCal->beginOfJob(alignableTracker_.get(), alignableMuon_.get(), alignableExtras_.get());
     }
     for (const auto& monitor : monitors_) {
-      monitor->beginOfJob(alignableTracker_, alignableMuon_, alignmentParameterStore_);
+      monitor->beginOfJob(alignableTracker_.get(), alignableMuon_.get(), alignmentParameterStore_.get());
     }
   }
   startProcessing();  // needed if derived class is non-EDLooper-based
@@ -487,7 +483,7 @@ void AlignmentProducerBase::createAlignables(const TrackerTopology* tTopo, bool 
     if (update) {
       alignableTracker_->update(trackerGeometry_.get(), tTopo);
     } else {
-      alignableTracker_ = new AlignableTracker(trackerGeometry_.get(), tTopo);
+      alignableTracker_ = std::make_unique<AlignableTracker>(trackerGeometry_.get(), tTopo);
     }
   }
 
@@ -495,7 +491,7 @@ void AlignmentProducerBase::createAlignables(const TrackerTopology* tTopo, bool 
     if (update) {
       alignableMuon_->update(muonDTGeometry_.get(), muonCSCGeometry_.get());
     } else {
-      alignableMuon_ = new AlignableMuon(muonDTGeometry_.get(), muonCSCGeometry_.get());
+      alignableMuon_ = std::make_unique<AlignableMuon>(muonDTGeometry_.get(), muonCSCGeometry_.get());
     }
   }
 
@@ -503,7 +499,7 @@ void AlignmentProducerBase::createAlignables(const TrackerTopology* tTopo, bool 
     if (update) {
       // FIXME: Requires further code changes to track beam spot condition changes
     } else {
-      alignableExtras_ = new AlignableExtras();
+      alignableExtras_ = std::make_unique<AlignableExtras>();
     }
   }
 }
@@ -518,7 +514,7 @@ void AlignmentProducerBase::buildParameterStore() {
   const auto& alParamStoreCfg = config_.getParameter<edm::ParameterSet>("ParameterStore");
 
   AlignmentParameterBuilder alignmentParameterBuilder{
-      alignableTracker_, alignableMuon_, alignableExtras_, alParamBuildCfg};
+      alignableTracker_.get(), alignableMuon_.get(), alignableExtras_.get(), alParamBuildCfg};
 
   // Fix alignables if requested
   if (stNFixAlignables_ > 0) {
@@ -531,7 +527,7 @@ void AlignmentProducerBase::buildParameterStore() {
                             << "got " << alignables.size() << " alignables";
 
   // Create AlignmentParameterStore
-  alignmentParameterStore_ = new AlignmentParameterStore(alignables, alParamStoreCfg);
+  alignmentParameterStore_ = std::make_unique<AlignmentParameterStore>(alignables, alParamStoreCfg);
   edm::LogInfo("Alignment") << "@SUB=AlignmentProducerBase::buildParameterStore"
                             << "AlignmentParameterStore created!";
 }
@@ -549,11 +545,11 @@ void AlignmentProducerBase::applyMisalignment() {
     const auto& scenarioConfig = config_.getParameterSet("MisalignmentScenario");
 
     if (doTracker_) {
-      TrackerScenarioBuilder scenarioBuilder(alignableTracker_);
+      TrackerScenarioBuilder scenarioBuilder(alignableTracker_.get());
       scenarioBuilder.applyScenario(scenarioConfig);
     }
     if (doMuon_) {
-      MuonScenarioBuilder muonScenarioBuilder(alignableMuon_);
+      MuonScenarioBuilder muonScenarioBuilder(alignableMuon_.get());
       muonScenarioBuilder.applyScenario(scenarioConfig);
     }
 
@@ -699,7 +695,7 @@ void AlignmentProducerBase::readInSurveyRcds(const edm::EventSetup& iSetup) {
       surveyIndex_ = 0;
       surveyValues_ = &*surveys;
       surveyErrors_ = &*surveyErrors;
-      addSurveyInfo(alignableTracker_);
+      addSurveyInfo(alignableTracker_.get());
     }
   }
 

--- a/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
@@ -59,7 +59,6 @@ using namespace std;
 CombinedTrajectoryFactory::CombinedTrajectoryFactory(const edm::ParameterSet &config)
     : TrajectoryFactoryBase(config), theUseAllFactories(config.getParameter<bool>("useAllFactories")) {
   vector<string> factoryNames = config.getParameter<vector<string>>("TrajectoryFactoryNames");
-  vector<string>::iterator itFactoryName;
   for (auto const &factoryName : factoryNames) {
     // auto_ptr to avoid missing a delete due to throw...
     std::unique_ptr<TObjArray> namePset(TString(factoryName.c_str()).Tokenize(","));

--- a/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
+++ b/Alignment/ReferenceTrajectories/plugins/CombinedTrajectoryFactory.cc
@@ -38,7 +38,15 @@ public:
   CombinedTrajectoryFactory *clone() const override { return new CombinedTrajectoryFactory(*this); }
 
 private:
-  std::vector<TrajectoryFactoryBase *> theFactories;
+  CombinedTrajectoryFactory(const CombinedTrajectoryFactory &other)
+      : TrajectoryFactoryBase(other), theUseAllFactories{other.theUseAllFactories} {
+    theFactories.reserve(other.theFactories.size());
+    for (const auto &f : other.theFactories) {
+      theFactories.emplace_back(f->clone());
+    }
+  }
+
+  std::vector<std::unique_ptr<TrajectoryFactoryBase>> theFactories;
   bool theUseAllFactories;  /// use not only the first 'successful'?
 };
 
@@ -50,18 +58,18 @@ using namespace std;
 
 CombinedTrajectoryFactory::CombinedTrajectoryFactory(const edm::ParameterSet &config)
     : TrajectoryFactoryBase(config), theUseAllFactories(config.getParameter<bool>("useAllFactories")) {
-  vector<string> factoryNames = config.getParameter<vector<string> >("TrajectoryFactoryNames");
+  vector<string> factoryNames = config.getParameter<vector<string>>("TrajectoryFactoryNames");
   vector<string>::iterator itFactoryName;
-  for (itFactoryName = factoryNames.begin(); itFactoryName != factoryNames.end(); ++itFactoryName) {
+  for (auto const &factoryName : factoryNames) {
     // auto_ptr to avoid missing a delete due to throw...
-    std::unique_ptr<TObjArray> namePset(TString((*itFactoryName).c_str()).Tokenize(","));
+    std::unique_ptr<TObjArray> namePset(TString(factoryName.c_str()).Tokenize(","));
     if (namePset->GetEntriesFast() != 2) {
       throw cms::Exception("BadConfig") << "@SUB=CombinedTrajectoryFactory"
                                         << "TrajectoryFactoryNames must contain 2 comma "
-                                        << "separated strings, but is '" << *itFactoryName << "'";
+                                        << "separated strings, but is '" << factoryName << "'";
     }
     const edm::ParameterSet factoryCfg = config.getParameter<edm::ParameterSet>(namePset->At(1)->GetName());
-    theFactories.push_back(TrajectoryFactoryPlugin::get()->create(namePset->At(0)->GetName(), factoryCfg));
+    theFactories.emplace_back(TrajectoryFactoryPlugin::get()->create(namePset->At(0)->GetName(), factoryCfg));
   }
 }
 
@@ -72,9 +80,8 @@ const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajector
   ReferenceTrajectoryCollection trajectories;
   ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 
-  vector<TrajectoryFactoryBase *>::const_iterator itFactory;
-  for (itFactory = theFactories.begin(); itFactory != theFactories.end(); ++itFactory) {
-    tmpTrajectories = (*itFactory)->trajectories(setup, tracks, beamSpot);
+  for (auto const &factory : theFactories) {
+    tmpTrajectories = factory->trajectories(setup, tracks, beamSpot);
     trajectories.insert(trajectories.end(), tmpTrajectories.begin(), tmpTrajectories.end());
 
     if (!theUseAllFactories && !trajectories.empty())
@@ -92,9 +99,8 @@ const CombinedTrajectoryFactory::ReferenceTrajectoryCollection CombinedTrajector
   ReferenceTrajectoryCollection trajectories;
   ReferenceTrajectoryCollection tmpTrajectories;  // outside loop for efficiency
 
-  vector<TrajectoryFactoryBase *>::const_iterator itFactory;
-  for (itFactory = theFactories.begin(); itFactory != theFactories.end(); ++itFactory) {
-    tmpTrajectories = (*itFactory)->trajectories(setup, tracks, external, beamSpot);
+  for (auto const &factory : theFactories) {
+    tmpTrajectories = factory->trajectories(setup, tracks, external, beamSpot);
     trajectories.insert(trajectories.end(), tmpTrajectories.begin(), tmpTrajectories.end());
 
     if (!theUseAllFactories && !trajectories.empty())


### PR DESCRIPTION
#### PR description:

This PR is a preparatory step to change PluginFactory to return `std::unique_ptr`.

In addition use range-for, and more `unique_ptr` in AlignmentProducerBase.

#### PR validation:

Code compiles.