### PR TITLE
Follow up on "Remove PFElectronAlgo and PFPhotonAlgo used back in Run 1"

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -46,7 +46,6 @@ class PFAlgo {
   PFAlgo(bool debug);
 
   void setHOTag(bool ho) { useHO_ = ho;}
-  void setPFMuonAlgo(PFMuonAlgo* algo) {pfmu_ =algo;}
   void setMuonHandle(const edm::Handle<reco::MuonCollection>&);
 
   void setParameters(double nSigmaECAL,
@@ -103,18 +102,18 @@ class PFAlgo {
   void setEGElectronCollection(const reco::GsfElectronCollection & egelectrons);
 
   /// reconstruct particles 
-  void reconstructParticles( const reco::PFBlockHandle& blockHandle, PFEGammaFilters const* pfegamma );
+  void reconstructParticles(const reco::PFBlockHandle& blockHandle, PFEGammaFilters const* pfegamma);
 
   /// Check HF Cleaning
   void checkCleaning( const reco::PFRecHitCollection& cleanedHF );
 
   /// \return collection of cleaned HF candidates
-  std::unique_ptr<reco::PFCandidateCollection> transferCleanedCandidates() {
-    return std::move(pfCleanedCandidates_);
+  reco::PFCandidateCollection& getCleanedCandidates() {
+    return pfCleanedCandidates_;
   }
-  
+
   /// \return the collection of candidates
-  reco::PFCandidateCollection transferCandidates() {
+  reco::PFCandidateCollection makeConnectedCandidates() {
     return connector_.connect(*pfCandidates_);
   }
   
@@ -163,7 +162,7 @@ class PFAlgo {
 
   std::unique_ptr<reco::PFCandidateCollection>    pfCandidates_;
   // the post-HF-cleaned candidates
-  std::unique_ptr<reco::PFCandidateCollection>    pfCleanedCandidates_;
+  reco::PFCandidateCollection pfCleanedCandidates_;
 
   /// Associate PS clusters to a given ECAL cluster, and return their energy
   void associatePSClusters(unsigned iEcal,
@@ -180,14 +179,6 @@ class PFAlgo {
   // Post HF Cleaning
   void postCleaning();
 
-  /// create a reference to a block, transient or persistent 
-  /// depending on the needs
-  reco::PFBlockRef createBlockRef( const reco::PFBlockCollection& blocks, 
-				   unsigned bi );
-    
-  /// input block handle (full framework case)
-  reco::PFBlockHandle    blockHandle_;
-
   /// number of sigma to judge energy excess in ECAL
   double             nSigmaECAL_;
   
@@ -201,7 +192,7 @@ class PFAlgo {
   bool               useHO_;
   const bool         debug_;
 
-  PFMuonAlgo *pfmu_;
+  std::unique_ptr<PFMuonAlgo> pfmu_;
 
 
   /// Variables for NEW EGAMMA selection


### PR DESCRIPTION
#### PR description:

I think I made a little mistake in #26813, more precisely here: https://github.com/cms-sw/cmssw/pull/26813/files#diff-7eb5532b1cb65bc84e460aeaebc307c1R170. Should be `auto const& blocks` to not copy them. Also, somewhere on the way I accidentally removed the destructor for the muon algo, therefore I wrap it into a std::unique_pointer now to fix a memory leak. Also, some other minor tweaks to make up for the mistakes:

* EDPutToken for pfCleanedCandidates
* Avoid temporary unique pointers to muon output collections 

I meant to amend this to #26813 but it was already signed off, so I didn't want to stop it.
That's my last PF PR now. @jpata, now it's all yours :)

#### PR validation:

Code compiles and matrix tests pass.

#### if this PR is a backport please specify the original PR:

No backport intended.