### PR TITLE
Running code-format for geometry

### DIFF
--- a/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.h
+++ b/Geometry/DTGeometryBuilder/plugins/DTGeometryESModule.h
@@ -38,7 +38,7 @@
 class DTGeometryESModule : public edm::ESProducer {
 public:
   /// Constructor
-  DTGeometryESModule(const edm::ParameterSet & p);
+  DTGeometryESModule(const edm::ParameterSet& p);
 
   /// Destructor
   ~DTGeometryESModule() override;
@@ -47,10 +47,7 @@ public:
   std::shared_ptr<DTGeometry> produce(const MuonGeometryRecord& record);
 
 private:
-
-  using HostType = edm::ESProductHost<DTGeometry,
-                                      MuonNumberingRecord,
-                                      DTRecoGeometryRcd>;
+  using HostType = edm::ESProductHost<DTGeometry, MuonNumberingRecord, DTRecoGeometryRcd>;
 
   void setupGeometry(MuonNumberingRecord const&, std::shared_ptr<HostType>&);
   void setupDBGeometry(DTRecoGeometryRcd const&, std::shared_ptr<HostType>&);
@@ -64,7 +61,7 @@ private:
   edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
   edm::ESGetToken<RecoIdealGeometry, DTRecoGeometryRcd> rigToken_;
 
-  bool applyAlignment_; // Switch to apply alignment corrections
+  bool applyAlignment_;  // Switch to apply alignment corrections
   const std::string alignmentsLabel_;
   const std::string myLabel_;
   bool fromDDD_;

--- a/Geometry/DTGeometryBuilder/plugins/DTGeometryValidate.cc
+++ b/Geometry/DTGeometryBuilder/plugins/DTGeometryValidate.cc
@@ -25,36 +25,33 @@
 
 using namespace std;
 
-template<class T>
-typename enable_if<!numeric_limits<T>::is_integer, bool>::type
-    almost_equal(T x, T y, int ulp)
-{
-    // the machine epsilon has to be scaled to the magnitude of the values used
-    // and multiplied by the desired precision in ULPs (units in the last place)
-    return abs(x-y) <= numeric_limits<T>::epsilon() * abs(x+y) * ulp
-        // unless the result is subnormal
-        || abs(x-y) < numeric_limits<T>::min();
+template <class T>
+typename enable_if<!numeric_limits<T>::is_integer, bool>::type almost_equal(T x, T y, int ulp) {
+  // the machine epsilon has to be scaled to the magnitude of the values used
+  // and multiplied by the desired precision in ULPs (units in the last place)
+  return abs(x - y) <= numeric_limits<T>::epsilon() * abs(x + y) * ulp
+         // unless the result is subnormal
+         || abs(x - y) < numeric_limits<T>::min();
 }
 
 using namespace edm;
 
-class DTGeometryValidate : public one::EDAnalyzer<> 
-{
+class DTGeometryValidate : public one::EDAnalyzer<> {
 public:
   explicit DTGeometryValidate(const ParameterSet&);
   ~DTGeometryValidate() override {}
-  
+
 private:
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;  
+  void endJob() override;
 
   void validateDTChamberGeometry();
   void validateDTLayerGeometry();
 
   void compareTransform(const GlobalPoint&, const TGeoMatrix*);
   void compareShape(const GeomDet*, const float*);
-  
+
   float getDistance(const GlobalPoint&, const GlobalPoint&);
   float getDiff(const float, const float);
 
@@ -68,11 +65,11 @@ private:
     lengths_.clear();
     thicknesses_.clear();
   }
-  
+
   edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeometryToken_;
   edm::ESHandle<DTGeometry> dtGeometry_;
-  FWGeometry                fwGeometry_;
-  TFile*                    outFile_;
+  FWGeometry fwGeometry_;
+  TFile* outFile_;
   vector<float> globalDistances_;
   vector<float> topWidths_;
   vector<float> bottomWidths_;
@@ -80,110 +77,96 @@ private:
   vector<float> thicknesses_;
   string infileName_;
   string outfileName_;
-  int    tolerance_;
+  int tolerance_;
 };
 
-
 DTGeometryValidate::DTGeometryValidate(const edm::ParameterSet& iConfig)
-  : dtGeometryToken_{esConsumes<DTGeometry, MuonGeometryRecord>(edm::ESInputTag{})},
-    infileName_(iConfig.getUntrackedParameter<string>("infileName", "cmsGeom10.root")),
-    outfileName_(iConfig.getUntrackedParameter<string>("outfileName", "validateDTGeometry.root")),
-    tolerance_(iConfig.getUntrackedParameter<int>("tolerance", 6))
-{
+    : dtGeometryToken_{esConsumes<DTGeometry, MuonGeometryRecord>(edm::ESInputTag{})},
+      infileName_(iConfig.getUntrackedParameter<string>("infileName", "cmsGeom10.root")),
+      outfileName_(iConfig.getUntrackedParameter<string>("outfileName", "validateDTGeometry.root")),
+      tolerance_(iConfig.getUntrackedParameter<int>("tolerance", 6)) {
   fwGeometry_.loadMap(infileName_.c_str());
   outFile_ = new TFile(outfileName_.c_str(), "RECREATE");
 }
 
-void 
-DTGeometryValidate::analyze(const edm::Event& event, const edm::EventSetup& eventSetup)
-{
+void DTGeometryValidate::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
   dtGeometry_ = eventSetup.getHandle(dtGeometryToken_);
 
-  if(dtGeometry_.isValid()) {
+  if (dtGeometry_.isValid()) {
     LogVerbatim("DTGeometry") << "Validating DT chamber geometry";
     validateDTChamberGeometry();
 
-    LogVerbatim("DTGeometry") <<"Validating DT layer geometry";
+    LogVerbatim("DTGeometry") << "Validating DT layer geometry";
     validateDTLayerGeometry();
-  }
-  else
-    LogVerbatim("DTGeometry") << "Invalid DT geometry"; 
+  } else
+    LogVerbatim("DTGeometry") << "Invalid DT geometry";
 }
 
-void 
-DTGeometryValidate::validateDTChamberGeometry() {
-
+void DTGeometryValidate::validateDTChamberGeometry() {
   clearData();
 
-  for(auto const& it : dtGeometry_->chambers()) {
+  for (auto const& it : dtGeometry_->chambers()) {
     DTChamberId chId = it->id();
-    GlobalPoint gp = it->surface().toGlobal(LocalPoint(0.0, 0.0, 0.0)); 
+    GlobalPoint gp = it->surface().toGlobal(LocalPoint(0.0, 0.0, 0.0));
 
     const TGeoMatrix* matrix = fwGeometry_.getMatrix(chId.rawId());
-    
-    if(!matrix) {
-      LogVerbatim("DTGeometry") << "Failed to get matrix of DT chamber with detid: " 
-                                << chId.rawId();
+
+    if (!matrix) {
+      LogVerbatim("DTGeometry") << "Failed to get matrix of DT chamber with detid: " << chId.rawId();
       continue;
     }
 
     compareTransform(gp, matrix);
-    
+
     auto const& shape = fwGeometry_.getShapePars(chId.rawId());
-    
-    if(!shape) {
-      LogVerbatim("DTGeometry") << "Failed to get shape of DT chamber with detid: "
-                                << chId.rawId();
+
+    if (!shape) {
+      LogVerbatim("DTGeometry") << "Failed to get shape of DT chamber with detid: " << chId.rawId();
       continue;
     }
-    
+
     compareShape(it, shape);
   }
 
   makeHistograms("DT Chamber");
 }
 
-void 
-DTGeometryValidate::validateDTLayerGeometry() {
-
+void DTGeometryValidate::validateDTLayerGeometry() {
   clearData();
-  
+
   vector<float> wire_positions;
 
-  for(auto const& it : dtGeometry_->layers()) {
+  for (auto const& it : dtGeometry_->layers()) {
     DTLayerId layerId = it->id();
-    GlobalPoint gp = it->surface().toGlobal(LocalPoint(0.0, 0.0, 0.0)); 
-     
+    GlobalPoint gp = it->surface().toGlobal(LocalPoint(0.0, 0.0, 0.0));
+
     const TGeoMatrix* matrix = fwGeometry_.getMatrix(layerId.rawId());
- 
-    if (!matrix) {     
-        LogVerbatim("DTGeometry") << "Failed to get matrix of DT layer with detid: " 
-                                  << layerId.rawId();
-        continue;
+
+    if (!matrix) {
+      LogVerbatim("DTGeometry") << "Failed to get matrix of DT layer with detid: " << layerId.rawId();
+      continue;
     }
 
     compareTransform(gp, matrix);
 
     auto const& shape = fwGeometry_.getShapePars(layerId.rawId());
 
-    if(!shape) {
-      LogVerbatim("DTGeometry") << "Failed to get shape of DT layer with detid: "
-                                << layerId.rawId();
+    if (!shape) {
+      LogVerbatim("DTGeometry") << "Failed to get shape of DT layer with detid: " << layerId.rawId();
       continue;
     }
-      
+
     compareShape(it, shape);
-    
+
     auto const& parameters = fwGeometry_.getParameters(layerId.rawId());
-      
-    if(parameters == nullptr) {
-      LogVerbatim("DTGeometry") << "Parameters empty for DT layer with detid: " 
-				<< layerId.rawId();
+
+    if (parameters == nullptr) {
+      LogVerbatim("DTGeometry") << "Parameters empty for DT layer with detid: " << layerId.rawId();
       continue;
     }
-           
+
     float width = it->surface().bounds().width();
-    assert(width == parameters[6]); 
+    assert(width == parameters[6]);
 
     float thickness = it->surface().bounds().thickness();
     assert(thickness == parameters[7]);
@@ -196,24 +179,21 @@ DTGeometryValidate::validateDTLayerGeometry() {
 
     int lastChannel = it->specificTopology().lastChannel();
     int nChannels = parameters[5];
-    assert(nChannels == (lastChannel-firstChannel)+1);
+    assert(nChannels == (lastChannel - firstChannel) + 1);
 
-    for(int wireN = firstChannel; wireN - lastChannel <= 0; ++wireN) {
+    for (int wireN = firstChannel; wireN - lastChannel <= 0; ++wireN) {
       float localX1 = it->specificTopology().wirePosition(wireN);
-      float localX2 = (wireN -(firstChannel-1)-0.5f)*parameters[0] - nChannels/2.0f*parameters[0];
+      float localX2 = (wireN - (firstChannel - 1) - 0.5f) * parameters[0] - nChannels / 2.0f * parameters[0];
       wire_positions.emplace_back(getDiff(localX1, localX2));
     }
   }
-  
+
   makeHistogram("DT Layer Wire localX", wire_positions);
   makeHistograms("DT Layer");
 }
 
-void
-DTGeometryValidate::compareTransform(const GlobalPoint& gp,
-				     const TGeoMatrix* matrix)
-{
-  double local[3] = { 0.0, 0.0, 0.0 };  
+void DTGeometryValidate::compareTransform(const GlobalPoint& gp, const TGeoMatrix* matrix) {
+  double local[3] = {0.0, 0.0, 0.0};
   double global[3];
 
   matrix->LocalToMaster(local, global);
@@ -222,27 +202,23 @@ DTGeometryValidate::compareTransform(const GlobalPoint& gp,
   globalDistances_.push_back(distance);
 }
 
-void 
-DTGeometryValidate::compareShape(const GeomDet* det, const float* shape)
-{
+void DTGeometryValidate::compareShape(const GeomDet* det, const float* shape) {
   float shapeTopWidth;
   float shapeBottomWidth;
   float shapeLength;
   float shapeThickness;
 
-  if(shape[0] == 1) {
+  if (shape[0] == 1) {
     shapeTopWidth = shape[2];
     shapeBottomWidth = shape[1];
     shapeLength = shape[4];
     shapeThickness = shape[3];
-  }
-  else if(shape[0] == 2) {
+  } else if (shape[0] == 2) {
     shapeTopWidth = shape[1];
     shapeBottomWidth = shape[1];
     shapeLength = shape[2];
     shapeThickness = shape[3];
-  }
-  else {
+  } else {
     LogVerbatim("DTGeometry") << "Failed to get box or trapezoid from shape";
     return;
   }
@@ -251,25 +227,22 @@ DTGeometryValidate::compareShape(const GeomDet* det, const float* shape)
   float length, thickness;
 
   const Bounds* bounds = &(det->surface().bounds());
- 
-  if(const TrapezoidalPlaneBounds* tpbs = dynamic_cast<const TrapezoidalPlaneBounds*>(bounds))
-  {
-    array<const float, 4> const & ps = tpbs->parameters();
-    
+
+  if (const TrapezoidalPlaneBounds* tpbs = dynamic_cast<const TrapezoidalPlaneBounds*>(bounds)) {
+    array<const float, 4> const& ps = tpbs->parameters();
+
     assert(ps.size() == 4);
-    
+
     bottomWidth = ps[0];
     topWidth = ps[1];
     thickness = ps[2];
     length = ps[3];
-  }
-  else if((dynamic_cast<const RectangularPlaneBounds*>(bounds))) {
-    length = det->surface().bounds().length()*0.5;
-    topWidth = det->surface().bounds().width()*0.5;
+  } else if ((dynamic_cast<const RectangularPlaneBounds*>(bounds))) {
+    length = det->surface().bounds().length() * 0.5;
+    topWidth = det->surface().bounds().width() * 0.5;
     bottomWidth = topWidth;
-    thickness = det->surface().bounds().thickness()*0.5;
-  }
-  else {
+    thickness = det->surface().bounds().thickness() * 0.5;
+  } else {
     LogVerbatim("DTGeometry") << "Failed to get bounds";
     return;
   }
@@ -279,30 +252,24 @@ DTGeometryValidate::compareShape(const GeomDet* det, const float* shape)
   thicknesses_.push_back(fabs(shapeThickness - thickness));
 }
 
-float
-DTGeometryValidate::getDistance(const GlobalPoint& p1, const GlobalPoint& p2)
-{
-  return sqrt((p1.x()-p2.x())*(p1.x()-p2.x())+
-              (p1.y()-p2.y())*(p1.y()-p2.y())+
-              (p1.z()-p2.z())*(p1.z()-p2.z()));
+float DTGeometryValidate::getDistance(const GlobalPoint& p1, const GlobalPoint& p2) {
+  return sqrt((p1.x() - p2.x()) * (p1.x() - p2.x()) + (p1.y() - p2.y()) * (p1.y() - p2.y()) +
+              (p1.z() - p2.z()) * (p1.z() - p2.z()));
 }
 
-float
-DTGeometryValidate::getDiff(const float val1, const float val2) {
-  if(almost_equal(val1, val2, tolerance_))
+float DTGeometryValidate::getDiff(const float val1, const float val2) {
+  if (almost_equal(val1, val2, tolerance_))
     return 0.0f;
   else
     return (val1 - val2);
 }
 
-void
-DTGeometryValidate::makeHistograms(const char* detector)
-{
+void DTGeometryValidate::makeHistograms(const char* detector) {
   outFile_->cd();
 
   string d(detector);
-  
-  string gdn = d+": distance between points in global coordinates";
+
+  string gdn = d + ": distance between points in global coordinates";
   makeHistogram(gdn, globalDistances_);
 
   string twn = d + ": absolute difference between top widths (along X)";
@@ -318,32 +285,26 @@ DTGeometryValidate::makeHistograms(const char* detector)
   makeHistogram(tn, thicknesses_);
 }
 
-void
-DTGeometryValidate::makeHistogram(const string& name, vector<float>& data)
-{
-  if(data.empty())
+void DTGeometryValidate::makeHistogram(const string& name, vector<float>& data) {
+  if (data.empty())
     return;
 
   const auto [minE, maxE] = minmax_element(begin(data), end(data));
-  
-  TH1D hist(name.c_str(), name.c_str(), 100, *minE*(1+0.10), *maxE*(1+0.10));
 
-  for(auto const& it : data)
+  TH1D hist(name.c_str(), name.c_str(), 100, *minE * (1 + 0.10), *maxE * (1 + 0.10));
+
+  for (auto const& it : data)
     hist.Fill(it);
-  
+
   hist.GetXaxis()->SetTitle("[cm]");
   hist.Write();
 }
 
-void 
-DTGeometryValidate::beginJob() {
-  outFile_->cd();
-}
+void DTGeometryValidate::beginJob() { outFile_->cd(); }
 
-void 
-DTGeometryValidate::endJob() {
+void DTGeometryValidate::endJob() {
   LogVerbatim("DTGeometry") << "Done.";
-  LogVerbatim("DTGeometry") << "Results written to "<< outfileName_;
+  LogVerbatim("DTGeometry") << "Results written to " << outfileName_;
   outFile_->Close();
 }
 

--- a/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryBuilder.cc
+++ b/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryBuilder.cc
@@ -2,7 +2,7 @@
 //
 // Package:    DetectorDescription/DTGeometryBuilder
 // Class:      DTGeometryBuilder
-// 
+//
 /**\class DTGeometryBuilder
 
  Description: DT Geometry builder from DD4hep
@@ -48,140 +48,128 @@ using namespace edm;
 using namespace std;
 using namespace cms;
 
-void
-DTGeometryBuilder::buildGeometry(DDFilteredView& fview,
-				 DTGeometry& geom, const MuonNumbering& num) const {
-
+void DTGeometryBuilder::buildGeometry(DDFilteredView& fview, DTGeometry& geom, const MuonNumbering& num) const {
   bool doChamber = fview.firstChild();
-  
-  while(doChamber) {
+
+  while (doChamber) {
     DTChamber* chamber = buildChamber(fview, num);
 
     // Loop on SLs
     bool doSL = fview.firstSibling();
-    while(doSL) {
+    while (doSL) {
       DTSuperLayer* sl = buildSuperLayer(fview, chamber, num);
 
       // Loop on Layers
       fview.down();
       bool doLayers = fview.sibling();
-      while(doLayers) {
-	DTLayer* l = buildLayer(fview, sl, num);
-	fview.unCheckNode();
-	geom.add(l);
+      while (doLayers) {
+        DTLayer* l = buildLayer(fview, sl, num);
+        fview.unCheckNode();
+        geom.add(l);
 
-	doLayers = fview.sibling(); // go to next Layer
+        doLayers = fview.sibling();  // go to next Layer
       }
       // Done with layers, go up
       fview.up();
 
-      geom.add(sl);     
-      doSL = fview.nextSibling(); // go to next SL
+      geom.add(sl);
+      doSL = fview.nextSibling();  // go to next SL
     }
     geom.add(chamber);
-    
-    fview.parent(); // stop iterating current branch 
-    doChamber = fview.firstChild(); // go to next chamber
+
+    fview.parent();                  // stop iterating current branch
+    doChamber = fview.firstChild();  // go to next chamber
   }
 }
 
-DTGeometryBuilder::RCPPlane
-DTGeometryBuilder::plane(const DDFilteredView& fview,
-			 Bounds* bounds) const {
+DTGeometryBuilder::RCPPlane DTGeometryBuilder::plane(const DDFilteredView& fview, Bounds* bounds) const {
+  const Double_t* tr = fview.trans();
+  const Double_t* rot = fview.rot();
 
-  const Double_t *tr  = fview.trans();
-  const Double_t *rot = fview.rot();
-  
-  return RCPPlane(new Plane(Surface::PositionType(tr[0], tr[1], tr[2]),
-			    Surface::RotationType(rot[0], rot[3], rot[6],
-						  rot[1], rot[4], rot[7],
-						  rot[2], rot[5], rot[8]),
-			    bounds));
+  return RCPPlane(
+      new Plane(Surface::PositionType(tr[0], tr[1], tr[2]),
+                Surface::RotationType(rot[0], rot[3], rot[6], rot[1], rot[4], rot[7], rot[2], rot[5], rot[8]),
+                bounds));
 }
 
-DTChamber*
-DTGeometryBuilder::buildChamber(const DDFilteredView& fview,
-				const MuonNumbering& muonConstants) const {
+DTChamber* DTGeometryBuilder::buildChamber(const DDFilteredView& fview, const MuonNumbering& muonConstants) const {
   int rawid = dtnum_->getDetId(muonConstants.geoHistoryToBaseNumber(fview.history()));
   DTChamberId detId(rawid);
   auto const& par = fview.extractParameters();
   // par[0] r-phi  dimension - different in different chambers
   // par[1] z      dimension - constant 125.55 cm
-  // par[2] radial thickness - almost constant about 18 cm  
+  // par[2] radial thickness - almost constant about 18 cm
 
   RCPPlane surf(plane(fview, new RectangularPlaneBounds(par[0], par[1], par[2])));
-  
+
   DTChamber* chamber = new DTChamber(detId, surf);
-  
+
   return chamber;
 }
 
-DTSuperLayer*
-DTGeometryBuilder::buildSuperLayer(const DDFilteredView& fview,
-				   DTChamber* chamber,
-				   const MuonNumbering& muonConstants) const {
+DTSuperLayer* DTGeometryBuilder::buildSuperLayer(const DDFilteredView& fview,
+                                                 DTChamber* chamber,
+                                                 const MuonNumbering& muonConstants) const {
   int rawid = dtnum_->getDetId(muonConstants.geoHistoryToBaseNumber(fview.history()));
   DTSuperLayerId slId(rawid);
-  
+
   auto const& par = fview.extractParameters();
   // par[0] r-phi  dimension - changes in different chambers
   // par[1] z      dimension - constant 126.8 cm
   // par[2] radial thickness - almost constant about 20 cm
-  
+
   // Ok this is the slayer position...
   RCPPlane surf(plane(fview, new RectangularPlaneBounds(par[0], par[1], par[2])));
-  
+
   DTSuperLayer* slayer = new DTSuperLayer(slId, surf, chamber);
-  
+
   // add to the chamber
   chamber->add(slayer);
-  
+
   return slayer;
 }
 
-DTLayer*
-DTGeometryBuilder::buildLayer(DDFilteredView& fview,
-			      DTSuperLayer* sl,
-			      const MuonNumbering& muonConstants) const {
+DTLayer* DTGeometryBuilder::buildLayer(DDFilteredView& fview,
+                                       DTSuperLayer* sl,
+                                       const MuonNumbering& muonConstants) const {
   int rawid = dtnum_->getDetId(muonConstants.geoHistoryToBaseNumber(fview.history()));
   DTLayerId layId(rawid);
-  
+
   auto const& par = fview.extractParameters();
   // Layer specific parameter (size)
   // par[0] r-phi  dimension - changes in different chambers
   // par[1] z      dimension - constant 126.8 cm
   // par[2] radial thickness - almost constant about 20 cm
   RCPPlane surf(plane(fview, new RectangularPlaneBounds(par[0], par[1], par[2])));
-  
+
   // Loop on wires
   fview.down();
   bool doWire = fview.siblingNoCheck();
-  int firstWire = fview.volume()->GetNumber(); // copy no
+  int firstWire = fview.volume()->GetNumber();  // copy no
   auto const& wpar = fview.extractParameters();
   float wireLength = wpar[1];
-  
+
   int WCounter = 0;
-  while(doWire) {
+  while (doWire) {
     doWire = fview.checkChild();
     WCounter++;
   }
   fview.up();
 
   DTTopology topology(firstWire, WCounter, wireLength);
-  
+
   DTLayerType layerType;
-  
+
   DTLayer* layer = new DTLayer(layId, surf, topology, layerType, sl);
 
   sl->add(layer);
-  return layer;    
+  return layer;
 }
 
-void
-DTGeometryBuilder::build(DTGeometry& geom,
-			 const DDDetector* det,
-			 const MuonNumbering& num,
-			 const DDSpecParRefs& refs) {
+void DTGeometryBuilder::build(DTGeometry& geom,
+                              const DDDetector* det,
+                              const MuonNumbering& num,
+                              const DDSpecParRefs& refs) {
   Volume top = det->worldVolume();
   DDFilteredView fview(det, top);
   fview.mergedSpecifics(refs);

--- a/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryBuilder.h
+++ b/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryBuilder.h
@@ -21,44 +21,35 @@ namespace cms {
   class DDFilteredView;
   class MuonNumbering;
   struct DDSpecPar;
-  
+
   class DTGeometryBuilder {
   public:
     DTGeometryBuilder() {}
     ~DTGeometryBuilder() {}
-    
+
     using Detector = dd4hep::Detector;
     using DDSpecParRefs = std::vector<const DDSpecPar*>;
 
-    void build(DTGeometry&,
-               const DDDetector*, 
-               const MuonNumbering&,
-	       const DDSpecParRefs&);
+    void build(DTGeometry&, const DDDetector*, const MuonNumbering&, const DDSpecParRefs&);
+
   private:
-    void buildGeometry(DDFilteredView&,
-		       DTGeometry&, const MuonNumbering&) const;
+    void buildGeometry(DDFilteredView&, DTGeometry&, const MuonNumbering&) const;
 
     /// create the chamber
-    DTChamber* buildChamber(const DDFilteredView&,
-                            const MuonNumbering&) const;
-    
+    DTChamber* buildChamber(const DDFilteredView&, const MuonNumbering&) const;
+
     /// create the SL
-    DTSuperLayer* buildSuperLayer(const DDFilteredView&,
-				  DTChamber*,
-				  const MuonNumbering&) const;
+    DTSuperLayer* buildSuperLayer(const DDFilteredView&, DTChamber*, const MuonNumbering&) const;
 
     /// create the layer
-    DTLayer* buildLayer(DDFilteredView&,
-			DTSuperLayer*,
-			const MuonNumbering&) const;
+    DTLayer* buildLayer(DDFilteredView&, DTSuperLayer*, const MuonNumbering&) const;
 
     using RCPPlane = ReferenceCountingPointer<Plane>;
 
-    RCPPlane plane(const DDFilteredView&,
-		   Bounds* bounds) const;
+    RCPPlane plane(const DDFilteredView&, Bounds* bounds) const;
 
     std::unique_ptr<cms::DTNumberingScheme> dtnum_ = nullptr;
   };
-}
+}  // namespace cms
 
 #endif

--- a/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryTest.cc
+++ b/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryTest.cc
@@ -21,78 +21,67 @@ public:
   void analyze(Event const& iEvent, EventSetup const&) override;
   void endJob() override {}
 
-private:  
+private:
   const string m_label;
   const edm::ESGetToken<DTGeometry, MuonGeometryRecord> m_token;
 };
 
 DTGeometryTest::DTGeometryTest(const ParameterSet& iConfig)
-  : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", "")),
-    m_token(esConsumes<DTGeometry, MuonGeometryRecord>(edm::ESInputTag{"", m_label}))
-{}
+    : m_label(iConfig.getUntrackedParameter<string>("fromDataLabel", "")),
+      m_token(esConsumes<DTGeometry, MuonGeometryRecord>(edm::ESInputTag{"", m_label})) {}
 
-void
-DTGeometryTest::analyze(const Event&, const EventSetup& iEventSetup)
-{
+void DTGeometryTest::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry") << "DTGeometryTest::analyze: " << m_label;
   ESTransientHandle<DTGeometry> pDD = iEventSetup.getTransientHandle(m_token);
-  
-  LogVerbatim("Geometry") << " Geometry node for DTGeom is  " << &(*pDD);   
-  LogVerbatim("Geometry") << " I have " << pDD->detTypes().size()    << " detTypes";
-  LogVerbatim("Geometry") << " I have " << pDD->detUnits().size()    << " detUnits";
-  LogVerbatim("Geometry") << " I have " << pDD->dets().size()        << " dets";
-  LogVerbatim("Geometry") << " I have " << pDD->layers().size()      << " layers";
+
+  LogVerbatim("Geometry") << " Geometry node for DTGeom is  " << &(*pDD);
+  LogVerbatim("Geometry") << " I have " << pDD->detTypes().size() << " detTypes";
+  LogVerbatim("Geometry") << " I have " << pDD->detUnits().size() << " detUnits";
+  LogVerbatim("Geometry") << " I have " << pDD->dets().size() << " dets";
+  LogVerbatim("Geometry") << " I have " << pDD->layers().size() << " layers";
   LogVerbatim("Geometry") << " I have " << pDD->superLayers().size() << " superlayers";
-  LogVerbatim("Geometry") << " I have " << pDD->chambers().size()    << " chambers";
-  
+  LogVerbatim("Geometry") << " I have " << pDD->chambers().size() << " chambers";
+
   // check chamber
   LogVerbatim("Geometry") << "CHAMBERS " << string(120, '-');
 
   LogVerbatim("Geometry").log([&](auto& log) {
-      for(auto det : pDD->chambers()){
-	const BoundPlane& surf = det->surface();
-	log << "Chamber " << det->id() 
-	    << " Position " << surf.position()
-	    << " normVect " << surf.normalVector() 
-	    << " bounds W/H/L: " << surf.bounds().width() << "/" 
-	    << surf.bounds().thickness() << "/" << surf.bounds().length() << "\n";
-      }
-    });
+    for (auto det : pDD->chambers()) {
+      const BoundPlane& surf = det->surface();
+      log << "Chamber " << det->id() << " Position " << surf.position() << " normVect " << surf.normalVector()
+          << " bounds W/H/L: " << surf.bounds().width() << "/" << surf.bounds().thickness() << "/"
+          << surf.bounds().length() << "\n";
+    }
+  });
   LogVerbatim("Geometry") << "END " << string(120, '-');
-  
+
   // check superlayers
   LogVerbatim("Geometry") << "SUPERLAYERS " << string(120, '-');
   LogVerbatim("Geometry").log([&](auto& log) {
-      for(auto det : pDD->superLayers()) {
-  	const BoundPlane& surf = det->surface();
-  	log << "SuperLayer " << det->id() 
-	    << " chamber " << det->chamber()->id()
-  	    << " Position " << surf.position()
-  	    << " normVect " << surf.normalVector() 
-  	    << " bounds W/H/L: " << surf.bounds().width() << "/" 
-  	    << surf.bounds().thickness() << "/" << surf.bounds().length() << "\n";
-      }
-    });
+    for (auto det : pDD->superLayers()) {
+      const BoundPlane& surf = det->surface();
+      log << "SuperLayer " << det->id() << " chamber " << det->chamber()->id() << " Position " << surf.position()
+          << " normVect " << surf.normalVector() << " bounds W/H/L: " << surf.bounds().width() << "/"
+          << surf.bounds().thickness() << "/" << surf.bounds().length() << "\n";
+    }
+  });
   LogVerbatim("Geometry") << "END " << string(120, '-');
 
   // check layers
   LogVerbatim("Geometry") << "LAYERS " << string(120, '-');
 
   LogVerbatim("Geometry").log([&](auto& log) {
-      for(auto det : pDD->layers()){
-	const DTTopology& topo = det->specificTopology();
-	const BoundPlane& surf=det->surface();
-	log << "Layer " << det->id() << " SL " << det->superLayer()->id() 
-	    << " chamber " << det->chamber()->id() 
-	    << " Topology W/H/L: " 
-	    << topo.cellWidth() << "/" << topo.cellHeight() << "/" << topo.cellLenght() 
-	    << " first/last/# wire " << topo.firstChannel() << "/" << topo.lastChannel() << "/" << topo.channels()
-	    << " Position " << surf.position()
-	    << " normVect " << surf.normalVector() 
-	    << " bounds W/H/L: " << surf.bounds().width() << "/" 
-	    << surf.bounds().thickness() << "/" << surf.bounds().length() << "\n";
-      }
-    });
+    for (auto det : pDD->layers()) {
+      const DTTopology& topo = det->specificTopology();
+      const BoundPlane& surf = det->surface();
+      log << "Layer " << det->id() << " SL " << det->superLayer()->id() << " chamber " << det->chamber()->id()
+          << " Topology W/H/L: " << topo.cellWidth() << "/" << topo.cellHeight() << "/" << topo.cellLenght()
+          << " first/last/# wire " << topo.firstChannel() << "/" << topo.lastChannel() << "/" << topo.channels()
+          << " Position " << surf.position() << " normVect " << surf.normalVector()
+          << " bounds W/H/L: " << surf.bounds().width() << "/" << surf.bounds().thickness() << "/"
+          << surf.bounds().length() << "\n";
+    }
+  });
   LogVerbatim("Geometry") << "END " << string(120, '-');
 }
 

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.cc
@@ -31,18 +31,14 @@ using namespace geant_units::operators;
 
 /* ====================================================================== */
 
-/* Constructor */ 
-DTGeometryBuilderFromCondDB::DTGeometryBuilderFromCondDB() {
-}
+/* Constructor */
+DTGeometryBuilderFromCondDB::DTGeometryBuilderFromCondDB() {}
 
-/* Destructor */ 
-DTGeometryBuilderFromCondDB::~DTGeometryBuilderFromCondDB() {
-}
+/* Destructor */
+DTGeometryBuilderFromCondDB::~DTGeometryBuilderFromCondDB() {}
 
-/* Operations */ 
-void
-DTGeometryBuilderFromCondDB::build(const std::shared_ptr<DTGeometry>& theGeometry,
-                                   const RecoIdealGeometry& rig) {
+/* Operations */
+void DTGeometryBuilderFromCondDB::build(const std::shared_ptr<DTGeometry>& theGeometry, const RecoIdealGeometry& rig) {
   //  cout << "DTGeometryBuilderFromCondDB " << endl;
   const std::vector<DetId>& detids(rig.detIds());
   //  cout << "size " << detids.size() << endl;
@@ -50,24 +46,23 @@ DTGeometryBuilderFromCondDB::build(const std::shared_ptr<DTGeometry>& theGeometr
   size_t idt = 0;
   DTChamber* chamber(nullptr);
   DTSuperLayer* sl(nullptr);
-  while(idt < detids.size()) {
+  while (idt < detids.size()) {
     //copy(par.begin(), par.end(), ostream_iterator<double>(std::cout," "));
-    if (int(*(rig.shapeStart(idt)))==0){ // a Chamber
+    if (int(*(rig.shapeStart(idt))) == 0) {  // a Chamber
       // add the provious chamber which by now has been updated with SL and
       // layers
-      if (chamber) theGeometry->add(chamber);
+      if (chamber)
+        theGeometry->add(chamber);
       // go for the actual one
       DTChamberId chid(detids[idt]);
       //cout << "CH: " <<  chid << endl;
-      chamber = buildChamber(chid, rig, idt); 
-    }
-    else if (int(*(rig.shapeStart(idt)))==1){ // a SL
+      chamber = buildChamber(chid, rig, idt);
+    } else if (int(*(rig.shapeStart(idt))) == 1) {  // a SL
       DTSuperLayerId slid(detids[idt]);
       //cout << "  SL: " <<  slid << endl;
       sl = buildSuperLayer(chamber, slid, rig, idt);
       theGeometry->add(sl);
-    }
-    else if (int(*(rig.shapeStart(idt)))==2){ // a Layer
+    } else if (int(*(rig.shapeStart(idt))) == 2) {  // a Layer
       DTLayerId lid(detids[idt]);
       //cout << "    LAY: " <<  lid << endl;
       DTLayer* lay = buildLayer(sl, lid, rig, idt);
@@ -77,22 +72,20 @@ DTGeometryBuilderFromCondDB::build(const std::shared_ptr<DTGeometry>& theGeometr
     }
     ++idt;
   }
-  if (chamber) theGeometry->add(chamber); // add the last chamber
+  if (chamber)
+    theGeometry->add(chamber);  // add the last chamber
 }
 
 // Calling function has the responsibility to delete the allocated RectangularPlaneBounds object
-RectangularPlaneBounds* dtGeometryBuilder::getRecPlaneBounds( const std::vector<double>::const_iterator &shapeStart ) {
-  float width =     convertMmToCm( *(shapeStart) );     // r-phi  dimension - different in different chambers
-  float length =    convertMmToCm( *(shapeStart + 1) );    // z      dimension - constant
-  float thickness = convertMmToCm( *(shapeStart + 2) );   // radial thickness - almost constant
+RectangularPlaneBounds* dtGeometryBuilder::getRecPlaneBounds(const std::vector<double>::const_iterator& shapeStart) {
+  float width = convertMmToCm(*(shapeStart));          // r-phi  dimension - different in different chambers
+  float length = convertMmToCm(*(shapeStart + 1));     // z      dimension - constant
+  float thickness = convertMmToCm(*(shapeStart + 2));  // radial thickness - almost constant
   return new RectangularPlaneBounds(width, length, thickness);
 }
 
-
-DTChamber* DTGeometryBuilderFromCondDB::buildChamber(const DetId& id,
-                                                     const RecoIdealGeometry& rig,
-						     size_t idt ) const {
-  DTChamberId detId(id);  
+DTChamber* DTGeometryBuilderFromCondDB::buildChamber(const DetId& id, const RecoIdealGeometry& rig, size_t idt) const {
+  DTChamberId detId(id);
 
   ///SL the definition of length, width, thickness depends on the local reference frame of the Det
   // width is along local X
@@ -100,19 +93,18 @@ DTChamber* DTGeometryBuilderFromCondDB::buildChamber(const DetId& id,
   // length z      dimension - constant 125.55 cm
   // thickness is along local Z
   // radial thickness - almost constant about 18 cm
-  RCPPlane surf(plane(rig.tranStart(idt), rig.rotStart(idt), dtGeometryBuilder::getRecPlaneBounds(++rig.shapeStart(idt))));
+  RCPPlane surf(
+      plane(rig.tranStart(idt), rig.rotStart(idt), dtGeometryBuilder::getRecPlaneBounds(++rig.shapeStart(idt))));
 
   DTChamber* chamber = new DTChamber(detId, surf);
 
   return chamber;
 }
 
-DTSuperLayer*
-DTGeometryBuilderFromCondDB::buildSuperLayer(DTChamber* chamber,
-                                             const DetId& id,
-                                             const RecoIdealGeometry& rig,
-					     size_t idt) const {
-
+DTSuperLayer* DTGeometryBuilderFromCondDB::buildSuperLayer(DTChamber* chamber,
+                                                           const DetId& id,
+                                                           const RecoIdealGeometry& rig,
+                                                           size_t idt) const {
   DTSuperLayerId slId(id);
 
   // r-phi  dimension - different in different chambers
@@ -120,7 +112,8 @@ DTGeometryBuilderFromCondDB::buildSuperLayer(DTChamber* chamber,
   // radial thickness - almost constant about 5 cm
 
   // Ok this is the slayer position...
-  RCPPlane surf(plane(rig.tranStart(idt), rig.rotStart(idt), dtGeometryBuilder::getRecPlaneBounds(++rig.shapeStart(idt))));
+  RCPPlane surf(
+      plane(rig.tranStart(idt), rig.rotStart(idt), dtGeometryBuilder::getRecPlaneBounds(++rig.shapeStart(idt))));
 
   DTSuperLayer* slayer = new DTSuperLayer(slId, surf, chamber);
 
@@ -130,12 +123,10 @@ DTGeometryBuilderFromCondDB::buildSuperLayer(DTChamber* chamber,
   return slayer;
 }
 
-DTLayer*
-DTGeometryBuilderFromCondDB::buildLayer(DTSuperLayer* sl,
-                                        const DetId& id,
-                                        const RecoIdealGeometry& rig,
-					size_t idt) const {
-
+DTLayer* DTGeometryBuilderFromCondDB::buildLayer(DTSuperLayer* sl,
+                                                 const DetId& id,
+                                                 const RecoIdealGeometry& rig,
+                                                 size_t idt) const {
   DTLayerId layId(id);
 
   // Layer specific parameter (size)
@@ -143,14 +134,14 @@ DTGeometryBuilderFromCondDB::buildLayer(DTSuperLayer* sl,
   // z      dimension - constant 126.8 cm
   // radial thickness - almost constant about 20 cm
 
-
   auto shapeStartPtr = rig.shapeStart(idt);
-  RCPPlane surf(plane(rig.tranStart(idt), rig.rotStart(idt), dtGeometryBuilder::getRecPlaneBounds((shapeStartPtr + 1))));
+  RCPPlane surf(
+      plane(rig.tranStart(idt), rig.rotStart(idt), dtGeometryBuilder::getRecPlaneBounds((shapeStartPtr + 1))));
 
   // Loop on wires
-  int firstWire = static_cast<int>(*(shapeStartPtr + 4 )); //par[4]);
-  int WCounter = static_cast<int>(*(shapeStartPtr  + 5 )); //par[5]);
-  double sensibleLength = convertMmToCm( *(shapeStartPtr  + 6 ) ); //par[6] in cm;
+  int firstWire = static_cast<int>(*(shapeStartPtr + 4));       //par[4]);
+  int WCounter = static_cast<int>(*(shapeStartPtr + 5));        //par[5]);
+  double sensibleLength = convertMmToCm(*(shapeStartPtr + 6));  //par[6] in cm;
   DTTopology topology(firstWire, WCounter, sensibleLength);
 
   DTLayerType layerType;
@@ -163,16 +154,21 @@ DTGeometryBuilderFromCondDB::buildLayer(DTSuperLayer* sl,
   return layer;
 }
 
-DTGeometryBuilderFromCondDB::RCPPlane 
-DTGeometryBuilderFromCondDB::plane(const vector<double>::const_iterator tranStart,
-                                   const vector<double>::const_iterator rotStart,
-                                   Bounds * bounds) const {
+DTGeometryBuilderFromCondDB::RCPPlane DTGeometryBuilderFromCondDB::plane(const vector<double>::const_iterator tranStart,
+                                                                         const vector<double>::const_iterator rotStart,
+                                                                         Bounds* bounds) const {
   // extract the position
-  const Surface::PositionType posResult(*(tranStart), *(tranStart+1), *(tranStart+2));
+  const Surface::PositionType posResult(*(tranStart), *(tranStart + 1), *(tranStart + 2));
   // now the rotation
-  Surface::RotationType rotResult( *(rotStart+0), *(rotStart+1), *(rotStart+2), 
-                                   *(rotStart+3), *(rotStart+4), *(rotStart+5),
-                                   *(rotStart+6), *(rotStart+7), *(rotStart+8) );
+  Surface::RotationType rotResult(*(rotStart + 0),
+                                  *(rotStart + 1),
+                                  *(rotStart + 2),
+                                  *(rotStart + 3),
+                                  *(rotStart + 4),
+                                  *(rotStart + 5),
+                                  *(rotStart + 6),
+                                  *(rotStart + 7),
+                                  *(rotStart + 8));
 
-  return RCPPlane( new Plane( posResult, rotResult, bounds));
+  return RCPPlane(new Plane(posResult, rotResult, bounds));
 }

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromCondDB.h
@@ -29,55 +29,38 @@ class DetId;
 #include <memory>
 #include <vector>
 
-
 namespace dtGeometryBuilder {
-    RectangularPlaneBounds* getRecPlaneBounds( const std::vector<double>::const_iterator &shapeStart );
+  RectangularPlaneBounds* getRecPlaneBounds(const std::vector<double>::const_iterator& shapeStart);
 }
-
 
 /* ====================================================================== */
 
 /* Class DTGeometryBuilderFromCondDB Interface */
 
-class DTGeometryBuilderFromCondDB{
+class DTGeometryBuilderFromCondDB {
+public:
+  /* Constructor */
+  DTGeometryBuilderFromCondDB();
 
-  public:
+  /* Destructor */
+  virtual ~DTGeometryBuilderFromCondDB();
 
-/* Constructor */ 
-    DTGeometryBuilderFromCondDB() ;
+  /* Operations */
+  void build(const std::shared_ptr<DTGeometry>& theGeometry, const RecoIdealGeometry& rig);
 
-/* Destructor */ 
-    virtual ~DTGeometryBuilderFromCondDB() ;
+private:
+  DTChamber* buildChamber(const DetId& id, const RecoIdealGeometry& rig, size_t idt) const;
 
-/* Operations */ 
-    void build(const std::shared_ptr<DTGeometry>& theGeometry,
-               const RecoIdealGeometry& rig);
+  DTSuperLayer* buildSuperLayer(DTChamber* chamber, const DetId& id, const RecoIdealGeometry& rig, size_t idt) const;
 
+  DTLayer* buildLayer(DTSuperLayer* sl, const DetId& id, const RecoIdealGeometry& rig, size_t idt) const;
 
-  private:
-    DTChamber* buildChamber(const DetId& id,
-                            const RecoIdealGeometry& rig,
-			    size_t idt) const ;
+  typedef ReferenceCountingPointer<Plane> RCPPlane;
 
-    DTSuperLayer* buildSuperLayer(DTChamber* chamber,
-                                  const DetId& id,
-                                  const RecoIdealGeometry& rig,
-				  size_t idt) const ;
+  RCPPlane plane(const std::vector<double>::const_iterator tranStart,
+                 const std::vector<double>::const_iterator rotStart,
+                 Bounds* bounds) const;
 
-    DTLayer* buildLayer(DTSuperLayer* sl,
-                        const DetId& id,
-                        const RecoIdealGeometry& rig,
-			size_t idt) const ;
-
-
-    typedef ReferenceCountingPointer<Plane> RCPPlane;
-
-    RCPPlane plane(const std::vector<double>::const_iterator tranStart,
-                   const std::vector<double>::const_iterator rotStart,
-                   Bounds * bounds) const ;
-
-  protected:
-
+protected:
 };
-#endif // DTGEOMETRYBUILDERFROMCONDDB_H
-
+#endif  // DTGEOMETRYBUILDERFROMCONDDB_H

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
@@ -17,7 +17,6 @@
 #include "Geometry/MuonNumbering/interface/DTNumberingScheme.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 
-
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
 
 #include <string>
@@ -33,26 +32,24 @@ using namespace std;
 
 DTGeometryBuilderFromDDD::DTGeometryBuilderFromDDD() {}
 
-DTGeometryBuilderFromDDD::~DTGeometryBuilderFromDDD(){}
-
+DTGeometryBuilderFromDDD::~DTGeometryBuilderFromDDD() {}
 
 void DTGeometryBuilderFromDDD::build(DTGeometry& theGeometry,
                                      const DDCompactView* cview,
-                                     const MuonDDDConstants& muonConstants){
+                                     const MuonDDDConstants& muonConstants) {
   //  cout << "DTGeometryBuilderFromDDD::build" << endl;
   //   static const string t0 = "DTGeometryBuilderFromDDD::build";
   //   TimeMe timer(t0,true);
 
-  std::string attribute = "MuStructure"; 
-  std::string value     = "MuonBarrelDT";
+  std::string attribute = "MuStructure";
+  std::string value = "MuonBarrelDT";
 
   // Asking only for the Muon DTs
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
 
-  DDFilteredView fview(*cview,filter);
+  DDFilteredView fview(*cview, filter);
   buildGeometry(theGeometry, fview, muonConstants);
 }
-
 
 void DTGeometryBuilderFromDDD::buildGeometry(DTGeometry& theGeometry,
                                              DDFilteredView& fv,
@@ -60,29 +57,31 @@ void DTGeometryBuilderFromDDD::buildGeometry(DTGeometry& theGeometry,
   bool doChamber = fv.firstChild();
 
   // Loop on chambers
-  int ChamCounter=0;
-  while (doChamber){
+  int ChamCounter = 0;
+  while (doChamber) {
     ChamCounter++;
     DDValue val("Type");
     const DDsvalues_type params(fv.mergedSpecifics());
     string type;
-    if (DDfetch(&params,val)) type = val.strings()[0];
+    if (DDfetch(&params, val))
+      type = val.strings()[0];
     // FIXME
-    val=DDValue("FEPos");
+    val = DDValue("FEPos");
     string FEPos;
-    if (DDfetch(&params,val)) FEPos = val.strings()[0];
-    DTChamber* chamber = buildChamber(fv,type, muonConstants);
+    if (DDfetch(&params, val))
+      FEPos = val.strings()[0];
+    DTChamber* chamber = buildChamber(fv, type, muonConstants);
 
     // Loop on SLs
     bool doSL = fv.firstChild();
-    int SLCounter=0;
+    int SLCounter = 0;
     while (doSL) {
       SLCounter++;
       DTSuperLayer* sl = buildSuperLayer(fv, chamber, type, muonConstants);
       theGeometry.add(sl);
 
       bool doL = fv.firstChild();
-      int LCounter=0;
+      int LCounter = 0;
       // Loop on SLs
       while (doL) {
         LCounter++;
@@ -90,27 +89,28 @@ void DTGeometryBuilderFromDDD::buildGeometry(DTGeometry& theGeometry,
         theGeometry.add(layer);
 
         fv.parent();
-        doL = fv.nextSibling(); // go to next layer
-      } // layers
+        doL = fv.nextSibling();  // go to next layer
+      }                          // layers
 
       fv.parent();
-      doSL = fv.nextSibling(); // go to next SL
-    } // sls
+      doSL = fv.nextSibling();  // go to next SL
+    }                           // sls
     theGeometry.add(chamber);
 
     fv.parent();
-    doChamber = fv.nextSibling(); // go to next chamber
-  } // chambers
+    doChamber = fv.nextSibling();  // go to next chamber
+  }                                // chambers
 }
 
 DTChamber* DTGeometryBuilderFromDDD::buildChamber(DDFilteredView& fv,
-                                                  const string& type, const MuonDDDConstants& muonConstants) const {
-  MuonDDDNumbering mdddnum (muonConstants);
-  DTNumberingScheme dtnum (muonConstants);
+                                                  const string& type,
+                                                  const MuonDDDConstants& muonConstants) const {
+  MuonDDDNumbering mdddnum(muonConstants);
+  DTNumberingScheme dtnum(muonConstants);
   int rawid = dtnum.getDetId(mdddnum.geoHistoryToBaseNumber(fv.geoHistory()));
-  DTChamberId detId(rawid);  
+  DTChamberId detId(rawid);
 
-  // Chamber specific parameter (size) 
+  // Chamber specific parameter (size)
   // FIXME: some trouble for boolean solids?
   vector<double> par = extractParameters(fv);
 
@@ -118,7 +118,6 @@ DTChamber* DTGeometryBuilderFromDDD::buildChamber(DDFilteredView& fv,
   // width is along local X. r-phi  dimension - different in different chambers
   // length is along local Y. z      dimension - constant 125.55 cm
   // thickness is long local Z. radial thickness - almost constant about 18 cm
-
 
   RCPPlane surf(plane(fv, dtGeometryBuilder::getRecPlaneBounds(par.begin())));
 
@@ -129,9 +128,8 @@ DTChamber* DTGeometryBuilderFromDDD::buildChamber(DDFilteredView& fv,
 
 DTSuperLayer* DTGeometryBuilderFromDDD::buildSuperLayer(DDFilteredView& fv,
                                                         DTChamber* chamber,
-                                                        const std::string& type, 
-							const MuonDDDConstants& muonConstants) const {
-
+                                                        const std::string& type,
+                                                        const MuonDDDConstants& muonConstants) const {
   MuonDDDNumbering mdddnum(muonConstants);
   DTNumberingScheme dtnum(muonConstants);
   int rawid = dtnum.getDetId(mdddnum.geoHistoryToBaseNumber(fv.geoHistory()));
@@ -157,12 +155,10 @@ DTSuperLayer* DTGeometryBuilderFromDDD::buildSuperLayer(DDFilteredView& fv,
   return slayer;
 }
 
-
 DTLayer* DTGeometryBuilderFromDDD::buildLayer(DDFilteredView& fv,
                                               DTSuperLayer* sl,
                                               const std::string& type,
-					      const MuonDDDConstants& muonConstants) const {
-
+                                              const MuonDDDConstants& muonConstants) const {
   MuonDDDNumbering mdddnum(muonConstants);
   DTNumberingScheme dtnum(muonConstants);
   int rawid = dtnum.getDetId(mdddnum.geoHistoryToBaseNumber(fv.geoHistory()));
@@ -178,13 +174,13 @@ DTLayer* DTGeometryBuilderFromDDD::buildLayer(DDFilteredView& fv,
 
   // Loop on wires
   bool doWire = fv.firstChild();
-  int WCounter=0;
-  int firstWire=fv.copyno();
+  int WCounter = 0;
+  int firstWire = fv.copyno();
   par = extractParameters(fv);
-  float wireLength = convertMmToCm( par[1] );
+  float wireLength = convertMmToCm(par[1]);
   while (doWire) {
     WCounter++;
-    doWire = fv.nextSibling(); // next wire
+    doWire = fv.nextSibling();  // next wire
   }
   //int lastWire=fv.copyno();
   DTTopology topology(firstWire, WCounter, wireLength);
@@ -197,8 +193,7 @@ DTLayer* DTGeometryBuilderFromDDD::buildLayer(DDFilteredView& fv,
   return layer;
 }
 
-vector<double> 
-DTGeometryBuilderFromDDD::extractParameters(DDFilteredView& fv) const {
+vector<double> DTGeometryBuilderFromDDD::extractParameters(DDFilteredView& fv) const {
   vector<double> par;
   if (fv.logicalPart().solid().shape() != DDSolidShape::ddbox) {
     DDBooleanSolid bs(fv.logicalPart().solid());
@@ -207,46 +202,49 @@ DTGeometryBuilderFromDDD::extractParameters(DDFilteredView& fv) const {
       DDBooleanSolid bs(A);
       A = bs.solidA();
     }
-    par=A.parameters();
+    par = A.parameters();
   } else {
     par = fv.logicalPart().solid().parameters();
   }
   return par;
 }
 
-DTGeometryBuilderFromDDD::RCPPlane 
-DTGeometryBuilderFromDDD::plane(const DDFilteredView& fv,
-                                Bounds * bounds) const {
+DTGeometryBuilderFromDDD::RCPPlane DTGeometryBuilderFromDDD::plane(const DDFilteredView& fv, Bounds* bounds) const {
   // extract the position
-  const DDTranslation & trans(fv.translation());
+  const DDTranslation& trans(fv.translation());
 
-  const Surface::PositionType posResult(float(convertMmToCm( trans.x() )), 
-                                        float(convertMmToCm( trans.y() )), 
-                                        float(convertMmToCm( trans.z() ))); 
-  LogTrace("DTGeometryBuilderFromDDD") << "DTGeometryBuilderFromDDD::plane " <<" posResult: "
-		<< posResult << std::endl;
+  const Surface::PositionType posResult(
+      float(convertMmToCm(trans.x())), float(convertMmToCm(trans.y())), float(convertMmToCm(trans.z())));
+  LogTrace("DTGeometryBuilderFromDDD") << "DTGeometryBuilderFromDDD::plane "
+                                       << " posResult: " << posResult << std::endl;
   // now the rotation
   //     'active' and 'passive' rotations are inverse to each other
-  const DDRotationMatrix& rotation = fv.rotation();//REMOVED .Inverse();
+  const DDRotationMatrix& rotation = fv.rotation();  //REMOVED .Inverse();
   DD3Vector x, y, z;
-  rotation.GetComponents(x,y,z);
-//   std::cout << "INVERSE rotation by its own operator: "<< fv.rotation() << std::endl;
-//   std::cout << "INVERSE rotation manually: "
-// 	    << x.X() << ", " << x.Y() << ", " << x.Z() << std::endl
-// 	    << y.X() << ", " << y.Y() << ", " << y.Z() << std::endl
-// 	    << z.X() << ", " << z.Y() << ", " << z.Z() << std::endl;
+  rotation.GetComponents(x, y, z);
+  //   std::cout << "INVERSE rotation by its own operator: "<< fv.rotation() << std::endl;
+  //   std::cout << "INVERSE rotation manually: "
+  // 	    << x.X() << ", " << x.Y() << ", " << x.Z() << std::endl
+  // 	    << y.X() << ", " << y.Y() << ", " << y.Z() << std::endl
+  // 	    << z.X() << ", " << z.Y() << ", " << z.Z() << std::endl;
 
-  Surface::RotationType rotResult(float(x.X()),float(x.Y()),float(x.Z()),
-                                  float(y.X()),float(y.Y()),float(y.Z()),
-                                  float(z.X()),float(z.Y()),float(z.Z())); 
+  Surface::RotationType rotResult(float(x.X()),
+                                  float(x.Y()),
+                                  float(x.Z()),
+                                  float(y.X()),
+                                  float(y.Y()),
+                                  float(y.Z()),
+                                  float(z.X()),
+                                  float(z.Y()),
+                                  float(z.Z()));
 
-//   std::cout << "rotation by its own operator: "<< tmp << std::endl;
-//   DD3Vector tx, ty,tz;
-//   tmp.GetComponents(tx, ty, tz);
-//   std::cout << "rotation manually: "
-// 	    << tx.X() << ", " << tx.Y() << ", " << tx.Z() << std::endl
-// 	    << ty.X() << ", " << ty.Y() << ", " << ty.Z() << std::endl
-// 	    << tz.X() << ", " << tz.Y() << ", " << tz.Z() << std::endl;
+  //   std::cout << "rotation by its own operator: "<< tmp << std::endl;
+  //   DD3Vector tx, ty,tz;
+  //   tmp.GetComponents(tx, ty, tz);
+  //   std::cout << "rotation manually: "
+  // 	    << tx.X() << ", " << tx.Y() << ", " << tx.Z() << std::endl
+  // 	    << ty.X() << ", " << ty.Y() << ", " << ty.Z() << std::endl
+  // 	    << tz.X() << ", " << tz.Y() << ", " << tz.Z() << std::endl;
 
-  return RCPPlane( new Plane( posResult, rotResult, bounds));
+  return RCPPlane(new Plane(posResult, rotResult, bounds));
 }

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.h
@@ -24,53 +24,44 @@ class Bounds;
 class MuonDDDConstants;
 
 namespace dtGeometryBuilder {
-	// Helper function from DTGeometryBuilderFromCondDB.cc
-  RectangularPlaneBounds* getRecPlaneBounds( const std::vector<double>::const_iterator &shapeStart );
-}
+  // Helper function from DTGeometryBuilderFromCondDB.cc
+  RectangularPlaneBounds* getRecPlaneBounds(const std::vector<double>::const_iterator& shapeStart);
+}  // namespace dtGeometryBuilder
 
 class DTGeometryBuilderFromDDD {
-  public:
-    /// Constructor
-    DTGeometryBuilderFromDDD();
+public:
+  /// Constructor
+  DTGeometryBuilderFromDDD();
 
-    /// Destructor
-    virtual ~DTGeometryBuilderFromDDD();
+  /// Destructor
+  virtual ~DTGeometryBuilderFromDDD();
 
-    // Operations
-    void build(DTGeometry& theGeometry,
-               const DDCompactView* cview, 
-               const MuonDDDConstants& muonConstants);
+  // Operations
+  void build(DTGeometry& theGeometry, const DDCompactView* cview, const MuonDDDConstants& muonConstants);
 
-  private:
-    /// create the chamber
-    DTChamber* buildChamber(DDFilteredView& fv, 
-                            const std::string& type, 
-                            const MuonDDDConstants& muonConstants) const;
+private:
+  /// create the chamber
+  DTChamber* buildChamber(DDFilteredView& fv, const std::string& type, const MuonDDDConstants& muonConstants) const;
 
-    /// create the SL
-    DTSuperLayer* buildSuperLayer(DDFilteredView& fv,
-                                  DTChamber* chamber,
-                                  const std::string& type, 
-                                  const MuonDDDConstants& muonConstants) const;
+  /// create the SL
+  DTSuperLayer* buildSuperLayer(DDFilteredView& fv,
+                                DTChamber* chamber,
+                                const std::string& type,
+                                const MuonDDDConstants& muonConstants) const;
 
-    /// create the layer
-    DTLayer* buildLayer(DDFilteredView& fv,
-                        DTSuperLayer* sl,
-                        const std::string& type, 
-                        const MuonDDDConstants& muonConstants) const;
+  /// create the layer
+  DTLayer* buildLayer(DDFilteredView& fv,
+                      DTSuperLayer* sl,
+                      const std::string& type,
+                      const MuonDDDConstants& muonConstants) const;
 
-    /// get parameter also for boolean solid.
-    std::vector<double> extractParameters(DDFilteredView& fv) const ;
+  /// get parameter also for boolean solid.
+  std::vector<double> extractParameters(DDFilteredView& fv) const;
 
-    typedef ReferenceCountingPointer<Plane> RCPPlane;
+  typedef ReferenceCountingPointer<Plane> RCPPlane;
 
-    RCPPlane plane(const DDFilteredView& fv, 
-                   Bounds * bounds) const ;
+  RCPPlane plane(const DDFilteredView& fv, Bounds* bounds) const;
 
-    void buildGeometry(DTGeometry& theGeometry,
-                       DDFilteredView& fv,
-                       const MuonDDDConstants& muonConstants) const;
-
+  void buildGeometry(DTGeometry& theGeometry, DDFilteredView& fv, const MuonDDDConstants& muonConstants) const;
 };
 #endif
-

--- a/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
@@ -28,8 +28,7 @@ using namespace geant_units::operators;
 
 DTGeometryParsFromDD::DTGeometryParsFromDD() {}
 
-DTGeometryParsFromDD::~DTGeometryParsFromDD(){}
-
+DTGeometryParsFromDD::~DTGeometryParsFromDD() {}
 
 void DTGeometryParsFromDD::build(const DDCompactView* cview,
                                  const MuonDDDConstants& muonConstants,
@@ -38,16 +37,15 @@ void DTGeometryParsFromDD::build(const DDCompactView* cview,
   //   static const string t0 = "DTGeometryParsFromDD::build";
   //   TimeMe timer(t0,true);
 
-  std::string attribute = "MuStructure"; 
-  std::string value     = "MuonBarrelDT";
+  std::string attribute = "MuStructure";
+  std::string value = "MuonBarrelDT";
 
   // Asking only for the Muon DTs
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
-  DDFilteredView fview(*cview,filter);
+  DDFilteredView fview(*cview, filter);
   buildGeometry(fview, muonConstants, rig);
   //cout << "RecoIdealGeometry " << rig.size() << endl;
 }
-
 
 void DTGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
                                          const MuonDDDConstants& muonConstants,
@@ -58,60 +56,62 @@ void DTGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
   bool doChamber = fv.firstChild();
 
   // Loop on chambers
-  int ChamCounter=0;
-  while (doChamber){
+  int ChamCounter = 0;
+  while (doChamber) {
     ChamCounter++;
     DDValue val("Type");
     const DDsvalues_type params(fv.mergedSpecifics());
     string type;
-    if (DDfetch(&params,val)) type = val.strings()[0];
+    if (DDfetch(&params, val))
+      type = val.strings()[0];
     // FIXME
-    val=DDValue("FEPos");
+    val = DDValue("FEPos");
     string FEPos;
-    if (DDfetch(&params,val)) FEPos = val.strings()[0];
-    insertChamber(fv,type, muonConstants,rig);
+    if (DDfetch(&params, val))
+      FEPos = val.strings()[0];
+    insertChamber(fv, type, muonConstants, rig);
 
     // Loop on SLs
     bool doSL = fv.firstChild();
-    int SLCounter=0;
+    int SLCounter = 0;
     while (doSL) {
       SLCounter++;
-      insertSuperLayer(fv, type, muonConstants,rig);
+      insertSuperLayer(fv, type, muonConstants, rig);
 
       bool doL = fv.firstChild();
-      int LCounter=0;
+      int LCounter = 0;
       // Loop on SLs
       while (doL) {
         LCounter++;
         insertLayer(fv, type, muonConstants, rig);
 
         // fv.parent();
-        doL = fv.nextSibling(); // go to next layer
-      } // layers
+        doL = fv.nextSibling();  // go to next layer
+      }                          // layers
 
       fv.parent();
-      doSL = fv.nextSibling(); // go to next SL
-    } // sls
+      doSL = fv.nextSibling();  // go to next SL
+    }                           // sls
 
     fv.parent();
-    doChamber = fv.nextSibling(); // go to next chamber
-  } // chambers
+    doChamber = fv.nextSibling();  // go to next chamber
+  }                                // chambers
 }
 
 void DTGeometryParsFromDD::insertChamber(DDFilteredView& fv,
                                          const string& type,
                                          const MuonDDDConstants& muonConstants,
                                          RecoIdealGeometry& rig) const {
-  MuonDDDNumbering mdddnum (muonConstants);
-  DTNumberingScheme dtnum (muonConstants);
+  MuonDDDNumbering mdddnum(muonConstants);
+  DTNumberingScheme dtnum(muonConstants);
   int rawid = dtnum.getDetId(mdddnum.geoHistoryToBaseNumber(fv.geoHistory()));
   DTChamberId detId(rawid);
   //cout << "inserting Chamber " << detId << endl;
 
-  // Chamber specific parameter (size) 
+  // Chamber specific parameter (size)
   vector<double> par;
   par.emplace_back(DTChamberTag);
-  vector<double> size= extractParameters(fv);
+  vector<double> size = extractParameters(fv);
   par.insert(par.end(), size.begin(), size.end());
 
   ///SL the definition of length, width, thickness depends on the local reference frame of the Det
@@ -125,10 +125,9 @@ void DTGeometryParsFromDD::insertChamber(DDFilteredView& fv,
 }
 
 void DTGeometryParsFromDD::insertSuperLayer(DDFilteredView& fv,
-                                            const std::string& type, 
+                                            const std::string& type,
                                             const MuonDDDConstants& muonConstants,
                                             RecoIdealGeometry& rig) const {
-
   MuonDDDNumbering mdddnum(muonConstants);
   DTNumberingScheme dtnum(muonConstants);
   int rawid = dtnum.getDetId(mdddnum.geoHistoryToBaseNumber(fv.geoHistory()));
@@ -138,7 +137,7 @@ void DTGeometryParsFromDD::insertSuperLayer(DDFilteredView& fv,
   // Slayer specific parameter (size)
   vector<double> par;
   par.emplace_back(DTSuperLayerTag);
-  vector<double> size= extractParameters(fv);
+  vector<double> size = extractParameters(fv);
   par.insert(par.end(), size.begin(), size.end());
 
   // Ok this is the slayer position...
@@ -151,7 +150,6 @@ void DTGeometryParsFromDD::insertLayer(DDFilteredView& fv,
                                        const std::string& type,
                                        const MuonDDDConstants& muonConstants,
                                        RecoIdealGeometry& rig) const {
-
   MuonDDDNumbering mdddnum(muonConstants);
   DTNumberingScheme dtnum(muonConstants);
   int rawid = dtnum.getDetId(mdddnum.geoHistoryToBaseNumber(fv.geoHistory()));
@@ -161,19 +159,19 @@ void DTGeometryParsFromDD::insertLayer(DDFilteredView& fv,
   // Layer specific parameter (size)
   vector<double> par;
   par.emplace_back(DTLayerTag);
-  vector<double> size= extractParameters(fv);
+  vector<double> size = extractParameters(fv);
   par.insert(par.end(), size.begin(), size.end());
 
   // Loop on wires
   bool doWire = fv.firstChild();
-  int WCounter=0;
-  int firstWire=fv.copyno();
+  int WCounter = 0;
+  int firstWire = fv.copyno();
   //float wireLength = par[1]/cm;
   while (doWire) {
     WCounter++;
-    doWire = fv.nextSibling(); // next wire
+    doWire = fv.nextSibling();  // next wire
   }
-  vector<double> sensSize= extractParameters(fv);
+  vector<double> sensSize = extractParameters(fv);
   //int lastWire=fv.copyno();
   par.emplace_back(firstWire);
   par.emplace_back(WCounter);
@@ -183,11 +181,9 @@ void DTGeometryParsFromDD::insertLayer(DDFilteredView& fv,
   PosRotPair posRot(plane(fv));
 
   rig.insert(layId, posRot.first, posRot.second, par);
-
 }
 
-vector<double> 
-DTGeometryParsFromDD::extractParameters(DDFilteredView& fv) const {
+vector<double> DTGeometryParsFromDD::extractParameters(DDFilteredView& fv) const {
   vector<double> par;
   if (fv.logicalPart().solid().shape() != DDSolidShape::ddbox) {
     DDBooleanSolid bs(fv.logicalPart().solid());
@@ -196,35 +192,34 @@ DTGeometryParsFromDD::extractParameters(DDFilteredView& fv) const {
       DDBooleanSolid bs(A);
       A = bs.solidA();
     }
-    par=A.parameters();
+    par = A.parameters();
   } else {
     par = fv.logicalPart().solid().parameters();
   }
   return par;
 }
 
-DTGeometryParsFromDD::PosRotPair
-DTGeometryParsFromDD::plane(const DDFilteredView& fv) const {
+DTGeometryParsFromDD::PosRotPair DTGeometryParsFromDD::plane(const DDFilteredView& fv) const {
   // extract the position
-  const DDTranslation & trans(fv.translation());
+  const DDTranslation& trans(fv.translation());
 
-  std::vector<double> gtran( 3 );
-  gtran[0] = convertMmToCm( trans.x() );
-  gtran[1] = convertMmToCm( trans.y() );
-  gtran[2] = convertMmToCm( trans.z() );
+  std::vector<double> gtran(3);
+  gtran[0] = convertMmToCm(trans.x());
+  gtran[1] = convertMmToCm(trans.y());
+  gtran[2] = convertMmToCm(trans.z());
 
   // now the rotation
   //     'active' and 'passive' rotations are inverse to each other
-  const DDRotationMatrix& rotation = fv.rotation();//REMOVED .Inverse();
+  const DDRotationMatrix& rotation = fv.rotation();  //REMOVED .Inverse();
   DD3Vector x, y, z;
-  rotation.GetComponents(x,y,z);
-//   std::cout << "INVERSE rotation by its own operator: "<< fv.rotation() << std::endl;
-//   std::cout << "INVERSE rotation manually: "
-// 	    << x.X() << ", " << x.Y() << ", " << x.Z() << std::endl
-// 	    << y.X() << ", " << y.Y() << ", " << y.Z() << std::endl
-// 	    << z.X() << ", " << z.Y() << ", " << z.Z() << std::endl;
+  rotation.GetComponents(x, y, z);
+  //   std::cout << "INVERSE rotation by its own operator: "<< fv.rotation() << std::endl;
+  //   std::cout << "INVERSE rotation manually: "
+  // 	    << x.X() << ", " << x.Y() << ", " << x.Z() << std::endl
+  // 	    << y.X() << ", " << y.Y() << ", " << y.Z() << std::endl
+  // 	    << z.X() << ", " << z.Y() << ", " << z.Z() << std::endl;
 
-  std::vector<double> grmat( 9 );
+  std::vector<double> grmat(9);
   grmat[0] = x.X();
   grmat[1] = x.Y();
   grmat[2] = x.Z();
@@ -237,13 +232,13 @@ DTGeometryParsFromDD::plane(const DDFilteredView& fv) const {
   grmat[7] = z.Y();
   grmat[8] = z.Z();
 
-//   std::cout << "rotation by its own operator: "<< tmp << std::endl;
-//   DD3Vector tx, ty,tz;
-//   tmp.GetComponents(tx, ty, tz);
-//   std::cout << "rotation manually: "
-// 	    << tx.X() << ", " << tx.Y() << ", " << tx.Z() << std::endl
-// 	    << ty.X() << ", " << ty.Y() << ", " << ty.Z() << std::endl
-// 	    << tz.X() << ", " << tz.Y() << ", " << tz.Z() << std::endl;
+  //   std::cout << "rotation by its own operator: "<< tmp << std::endl;
+  //   DD3Vector tx, ty,tz;
+  //   tmp.GetComponents(tx, ty, tz);
+  //   std::cout << "rotation manually: "
+  // 	    << tx.X() << ", " << tx.Y() << ", " << tx.Z() << std::endl
+  // 	    << ty.X() << ", " << ty.Y() << ", " << ty.Z() << std::endl
+  // 	    << tz.X() << ", " << tz.Y() << ", " << tz.Z() << std::endl;
 
   return pair<std::vector<double>, std::vector<double> >(gtran, grmat);
 }

--- a/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.h
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.h
@@ -22,49 +22,44 @@ class MuonDDDConstants;
 class RecoIdealGeometry;
 
 class DTGeometryParsFromDD {
-  public:
-    /// Constructor
-    DTGeometryParsFromDD();
+public:
+  /// Constructor
+  DTGeometryParsFromDD();
 
-    /// Destructor
-    virtual ~DTGeometryParsFromDD();
+  /// Destructor
+  virtual ~DTGeometryParsFromDD();
 
-    // Operations
-    void build(const DDCompactView* cview, 
-               const MuonDDDConstants& muonConstants,
-               RecoIdealGeometry& rig) ;
+  // Operations
+  void build(const DDCompactView* cview, const MuonDDDConstants& muonConstants, RecoIdealGeometry& rig);
 
-    enum DTDetTag { DTChamberTag, DTSuperLayerTag, DTLayerTag };
-  private:
-    /// create the chamber
-    void insertChamber(DDFilteredView& fv, 
-                       const std::string& type, 
-                       const MuonDDDConstants& muonConstants,
-                       RecoIdealGeometry& rig) const;
+  enum DTDetTag { DTChamberTag, DTSuperLayerTag, DTLayerTag };
 
-    /// create the SL
-    void insertSuperLayer(DDFilteredView& fv,
-                          const std::string& type, 
-                          const MuonDDDConstants& muonConstants,
-                          RecoIdealGeometry& rig) const;
-
-    /// create the layer
-    void insertLayer(DDFilteredView& fv,
-                     const std::string& type, 
+private:
+  /// create the chamber
+  void insertChamber(DDFilteredView& fv,
+                     const std::string& type,
                      const MuonDDDConstants& muonConstants,
                      RecoIdealGeometry& rig) const;
 
-    /// get parameter also for boolean solid.
-    std::vector<double> extractParameters(DDFilteredView& fv) const ;
+  /// create the SL
+  void insertSuperLayer(DDFilteredView& fv,
+                        const std::string& type,
+                        const MuonDDDConstants& muonConstants,
+                        RecoIdealGeometry& rig) const;
 
-    typedef std::pair<std::vector<double>, std::vector<double> > PosRotPair;
+  /// create the layer
+  void insertLayer(DDFilteredView& fv,
+                   const std::string& type,
+                   const MuonDDDConstants& muonConstants,
+                   RecoIdealGeometry& rig) const;
 
-    PosRotPair plane(const DDFilteredView& fv) const ;
+  /// get parameter also for boolean solid.
+  std::vector<double> extractParameters(DDFilteredView& fv) const;
 
-    void buildGeometry(DDFilteredView& fv,
-                       const MuonDDDConstants& muonConstants,
-                       RecoIdealGeometry& rig) const;
+  typedef std::pair<std::vector<double>, std::vector<double> > PosRotPair;
 
+  PosRotPair plane(const DDFilteredView& fv) const;
+
+  void buildGeometry(DDFilteredView& fv, const MuonDDDConstants& muonConstants, RecoIdealGeometry& rig) const;
 };
 #endif
-

--- a/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
@@ -16,126 +16,117 @@
 #include <vector>
 #include <atomic>
 
-class EcalBarrelGeometry final : public CaloSubdetectorGeometry 
-{
-   public:
+class EcalBarrelGeometry final : public CaloSubdetectorGeometry {
+public:
+  typedef std::vector<TruncatedPyramid> CellVec;
 
-      typedef std::vector<TruncatedPyramid> CellVec ;
+  typedef CaloCellGeometry::CCGFloat CCGFloat;
+  typedef CaloCellGeometry::Pt3D Pt3D;
+  typedef CaloCellGeometry::Pt3DVec Pt3DVec;
 
-      typedef CaloCellGeometry::CCGFloat CCGFloat ;
-      typedef CaloCellGeometry::Pt3D     Pt3D     ;
-      typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
+  typedef IdealGeometryRecord IdealRecord;
+  typedef EcalBarrelGeometryRecord AlignedRecord;
+  typedef EBAlignmentRcd AlignmentRecord;
+  typedef PEcalBarrelRcd PGeometryRecord;
 
-      typedef IdealGeometryRecord      IdealRecord   ;
-      typedef EcalBarrelGeometryRecord AlignedRecord ;
-      typedef EBAlignmentRcd           AlignmentRecord ;
-      typedef PEcalBarrelRcd           PGeometryRecord ;
+  typedef EZArrayFL<EEDetId> OrderedListOfEEDetId;  // like an stl vector: begin(), end(), [i]
 
-      typedef EZArrayFL<EEDetId> OrderedListOfEEDetId ; // like an stl vector: begin(), end(), [i]
+  typedef std::vector<OrderedListOfEEDetId*> VecOrdListEEDetIdPtr;
 
-      typedef std::vector<OrderedListOfEEDetId*>  VecOrdListEEDetIdPtr ;
+  typedef EcalBarrelNumberingScheme NumberingScheme;
 
-      typedef EcalBarrelNumberingScheme NumberingScheme ;
+  typedef EBDetId DetIdType;
 
-      typedef EBDetId DetIdType ;
+  enum { k_NumberOfCellsForCorners = EBDetId::kSizeForDenseIndexing };
 
-      enum { k_NumberOfCellsForCorners = EBDetId::kSizeForDenseIndexing } ;
+  enum { k_NumberOfShapes = 17 };
 
-      enum { k_NumberOfShapes = 17 } ;
+  enum { k_NumberOfParametersPerShape = 11 };
 
-      enum { k_NumberOfParametersPerShape = 11 } ;
+  static std::string dbString() { return "PEcalBarrelRcd"; }
 
-      static std::string dbString() { return "PEcalBarrelRcd" ; }
+  unsigned int numberOfShapes() const override { return k_NumberOfShapes; }
+  unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape; }
 
-      unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
-      unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
+  EcalBarrelGeometry();
 
-      EcalBarrelGeometry() ;
-  
-      ~EcalBarrelGeometry() override;
+  ~EcalBarrelGeometry() override;
 
-      int getNumXtalsPhiDirection()           const { return _nnxtalPhi ; }
+  int getNumXtalsPhiDirection() const { return _nnxtalPhi; }
 
-      int getNumXtalsEtaDirection()           const { return _nnxtalEta ; }
+  int getNumXtalsEtaDirection() const { return _nnxtalEta; }
 
-      const std::vector<int>& getEtaBaskets() const { return _EtaBaskets ; }
+  const std::vector<int>& getEtaBaskets() const { return _EtaBaskets; }
 
-      int getBasketSizeInPhi()                const { return _PhiBaskets ; }  
+  int getBasketSizeInPhi() const { return _PhiBaskets; }
 
-      void setNumXtalsPhiDirection( const int& nnxtalPhi )     { _nnxtalPhi=nnxtalPhi ; }
+  void setNumXtalsPhiDirection(const int& nnxtalPhi) { _nnxtalPhi = nnxtalPhi; }
 
-      void setNumXtalsEtaDirection( const int& nnxtalEta )     { _nnxtalEta=nnxtalEta ; }
+  void setNumXtalsEtaDirection(const int& nnxtalEta) { _nnxtalEta = nnxtalEta; }
 
-      void setEtaBaskets( const std::vector<int>& EtaBaskets ) { _EtaBaskets=EtaBaskets ; }
+  void setEtaBaskets(const std::vector<int>& EtaBaskets) { _EtaBaskets = EtaBaskets; }
 
-      void setBasketSizeInPhi( const int& PhiBaskets )         { _PhiBaskets=PhiBaskets ; }
+  void setBasketSizeInPhi(const int& PhiBaskets) { _PhiBaskets = PhiBaskets; }
 
-      const OrderedListOfEEDetId* getClosestEndcapCells( EBDetId id ) const ;
+  const OrderedListOfEEDetId* getClosestEndcapCells(EBDetId id) const;
 
-      // Get closest cell, etc...
+  // Get closest cell, etc...
 
-      DetId getClosestCell( const GlobalPoint& r ) const override ;
+  DetId getClosestCell(const GlobalPoint& r) const override;
 
-      CaloSubdetectorGeometry::DetIdSet getCells( const GlobalPoint& r,
-							  double             dR ) const override ;
+  CaloSubdetectorGeometry::DetIdSet getCells(const GlobalPoint& r, double dR) const override;
 
-      CCGFloat avgRadiusXYFrontFaceCenter() const;
+  CCGFloat avgRadiusXYFrontFaceCenter() const;
 
-      static std::string hitString() { return "EcalHitsEB" ; }
+  static std::string hitString() { return "EcalHitsEB"; }
 
-      static std::string producerTag() { return "EcalBarrel" ; }
+  static std::string producerTag() { return "EcalBarrel"; }
 
-      static unsigned int numberOfAlignments() { return 36 ; }
+  static unsigned int numberOfAlignments() { return 36; }
 
-      static unsigned int alignmentTransformIndexLocal( const DetId& id ) ;
+  static unsigned int alignmentTransformIndexLocal(const DetId& id);
 
-      static unsigned int alignmentTransformIndexGlobal( const DetId& id ) ;
+  static unsigned int alignmentTransformIndexGlobal(const DetId& id);
 
-      static DetId detIdFromLocalAlignmentIndex( unsigned int iLoc ) ;
+  static DetId detIdFromLocalAlignmentIndex(unsigned int iLoc);
 
-      static void localCorners( Pt3DVec&        lc  ,
-				const CCGFloat* pv  , 
-				unsigned int    i   ,
-				Pt3D&           ref   ) ;
+  static void localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int i, Pt3D& ref);
 
-      void newCell( const GlobalPoint& f1 ,
-			    const GlobalPoint& f2 ,
-			    const GlobalPoint& f3 ,
-			    const CCGFloat*    parm ,
-			    const DetId&       detId ) override ;
+  void newCell(const GlobalPoint& f1,
+               const GlobalPoint& f2,
+               const GlobalPoint& f3,
+               const CCGFloat* parm,
+               const DetId& detId) override;
 
-      bool present( const DetId& id ) const override;
+  bool present(const DetId& id) const override;
 
-   protected:
+protected:
+  // Modify the RawPtr class
+  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
 
-      // Modify the RawPtr class
-      const CaloCellGeometry* getGeometryRawPtr (uint32_t index) const override;
+private:
+  /** number of crystals in eta direction */
+  int _nnxtalEta;
 
-   private:
+  /** number of crystals in phi direction */
+  int _nnxtalPhi;
 
-      /** number of crystals in eta direction */
-      int _nnxtalEta;
-  
-      /** number of crystals in phi direction */
-      int _nnxtalPhi;
-  
-      /** size of the baskets in the eta direction. This is needed
+  /** size of the baskets in the eta direction. This is needed
 	  to find out whether two adjacent crystals lie in the same
 	  basked ('module') or not (e.g. this can be used for correcting
 	  cluster energies etc.) */
-      std::vector<int> _EtaBaskets;
-      
-      /** size of one basket in phi */
-      int _PhiBaskets;
+  std::vector<int> _EtaBaskets;
 
-      mutable std::atomic<EZMgrFL<EEDetId>*>     m_borderMgr ;
+  /** size of one basket in phi */
+  int _PhiBaskets;
 
-      mutable std::atomic<VecOrdListEEDetIdPtr*> m_borderPtrVec ;
-      CMS_THREAD_GUARD(m_check) mutable CCGFloat m_radius ; 
-      mutable std::atomic<bool> m_check;
+  mutable std::atomic<EZMgrFL<EEDetId>*> m_borderMgr;
 
-      CellVec m_cellVec ;
+  mutable std::atomic<VecOrdListEEDetIdPtr*> m_borderPtrVec;
+  CMS_THREAD_GUARD(m_check) mutable CCGFloat m_radius;
+  mutable std::atomic<bool> m_check;
+
+  CellVec m_cellVec;
 };
-
 
 #endif

--- a/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
@@ -13,108 +13,94 @@
 #include <vector>
 
 class EcalPreshowerGeometry final : public CaloSubdetectorGeometry {
-
 public:
+  typedef std::vector<PreshowerStrip> CellVec;
 
-  typedef std::vector<PreshowerStrip> CellVec ;
-  
-  typedef CaloCellGeometry::CCGFloat CCGFloat ;
-  typedef CaloCellGeometry::Pt3D     Pt3D     ;
-  typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
-      
-  typedef IdealGeometryRecord         IdealRecord   ;
-  typedef EcalPreshowerGeometryRecord AlignedRecord ;
-  typedef ESAlignmentRcd              AlignmentRecord ;
-  typedef PEcalPreshowerRcd           PGeometryRecord ;
+  typedef CaloCellGeometry::CCGFloat CCGFloat;
+  typedef CaloCellGeometry::Pt3D Pt3D;
+  typedef CaloCellGeometry::Pt3DVec Pt3DVec;
 
-  typedef EcalPreshowerNumberingScheme NumberingScheme ;
-  typedef CaloSubdetectorGeometry::ParVec ParVec ;
-  typedef CaloSubdetectorGeometry::ParVecVec ParVecVec ;
-  typedef ESDetId DetIdType ;
+  typedef IdealGeometryRecord IdealRecord;
+  typedef EcalPreshowerGeometryRecord AlignedRecord;
+  typedef ESAlignmentRcd AlignmentRecord;
+  typedef PEcalPreshowerRcd PGeometryRecord;
 
-  enum { k_NumberOfCellsForCorners = ESDetId::kSizeForDenseIndexing } ;
+  typedef EcalPreshowerNumberingScheme NumberingScheme;
+  typedef CaloSubdetectorGeometry::ParVec ParVec;
+  typedef CaloSubdetectorGeometry::ParVecVec ParVecVec;
+  typedef ESDetId DetIdType;
 
-  enum { k_NumberOfShapes = 4 } ;
+  enum { k_NumberOfCellsForCorners = ESDetId::kSizeForDenseIndexing };
 
-  enum { k_NumberOfParametersPerShape = 4 } ;
+  enum { k_NumberOfShapes = 4 };
 
-  static std::string dbString() { return "PEcalPreshowerRcd" ; }
+  enum { k_NumberOfParametersPerShape = 4 };
 
-  unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
-  unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
+  static std::string dbString() { return "PEcalPreshowerRcd"; }
 
-  EcalPreshowerGeometry() ;
-  
+  unsigned int numberOfShapes() const override { return k_NumberOfShapes; }
+  unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape; }
+
+  EcalPreshowerGeometry();
+
   /// The EcalPreshowerGeometry will delete all its cell geometries at destruction time
   ~EcalPreshowerGeometry() override;
 
-  void setzPlanes( CCGFloat z1minus, 
-		   CCGFloat z2minus,
-		   CCGFloat z1plus, 
-		   CCGFloat z2plus ) ;
-  
+  void setzPlanes(CCGFloat z1minus, CCGFloat z2minus, CCGFloat z1plus, CCGFloat z2plus);
+
   // Get closest cell
-  DetId getClosestCell( const GlobalPoint& r ) const override;
+  DetId getClosestCell(const GlobalPoint& r) const override;
 
   // Get closest cell in arbitrary plane (1 or 2)
-  virtual DetId getClosestCellInPlane( const GlobalPoint& r     ,
-				       int                plane   ) const;
-
+  virtual DetId getClosestCellInPlane(const GlobalPoint& r, int plane) const;
 
   void initializeParms() override;
-  unsigned int numberOfTransformParms() const override { return 3 ; }
+  unsigned int numberOfTransformParms() const override { return 3; }
 
-  static std::string hitString() { return "EcalHitsES" ; }
-  
-  static std::string producerTag() { return "EcalPreshower" ; }
+  static std::string hitString() { return "EcalHitsES"; }
 
-  static unsigned int numberOfAlignments() { return 8 ; }
+  static std::string producerTag() { return "EcalPreshower"; }
 
-  static unsigned int alignmentTransformIndexLocal( const DetId& id ) ;
-  
-  static unsigned int alignmentTransformIndexGlobal( const DetId& id ) ;
+  static unsigned int numberOfAlignments() { return 8; }
 
-  static DetId detIdFromLocalAlignmentIndex( unsigned int iLoc ) ;
-  
-  static void localCorners( Pt3DVec&        lc  ,
-			    const CCGFloat* pv  ,
-			    unsigned int    i   ,
-			    Pt3D&           ref   ) ;
+  static unsigned int alignmentTransformIndexLocal(const DetId& id);
 
-  void newCell( const GlobalPoint& f1 ,
-		const GlobalPoint& f2 ,
-		const GlobalPoint& f3 ,
-		const CCGFloat*    parm ,
-		const DetId&       detId   ) override;
-  
+  static unsigned int alignmentTransformIndexGlobal(const DetId& id);
+
+  static DetId detIdFromLocalAlignmentIndex(unsigned int iLoc);
+
+  static void localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int i, Pt3D& ref);
+
+  void newCell(const GlobalPoint& f1,
+               const GlobalPoint& f2,
+               const GlobalPoint& f3,
+               const CCGFloat* parm,
+               const DetId& detId) override;
 
   /// is this detid present in the geometry?
-  bool present( const DetId& id ) const override {
-    if(id==DetId(0)) return false;
+  bool present(const DetId& id) const override {
+    if (id == DetId(0))
+      return false;
     // not needed???
-    auto index = CaloGenericDetId( id ).denseIndex();
+    auto index = CaloGenericDetId(id).denseIndex();
     return index < m_cellVec.size();
   }
 
 protected:
-
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr (uint32_t index) const override;
+  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
 
 private:
+  const CCGFloat m_xWidWaf;
+  const CCGFloat m_xInterLadGap;
+  const CCGFloat m_xIntraLadGap;
 
-  const CCGFloat m_xWidWaf      ;
-  const CCGFloat m_xInterLadGap ;
-  const CCGFloat m_xIntraLadGap ;
-      
-  const CCGFloat m_yWidAct      ;
-  const CCGFloat m_yCtrOff      ;
+  const CCGFloat m_yWidAct;
+  const CCGFloat m_yCtrOff;
 
   CCGFloat m_zplane[4];
-      
-  CellVec m_cellVec ;
+
+  CellVec m_cellVec;
 };
 
-
 #endif
-

--- a/Geometry/EcalAlgo/interface/WriteESAlignments.h
+++ b/Geometry/EcalAlgo/interface/WriteESAlignments.h
@@ -1,54 +1,49 @@
 #ifndef SOMEPACKAGE_WRITEESALIGNMENTS_H
 #define SOMEPACKAGE_WRITEESALIGNMENTS_H 1
 
-namespace edm
-{
-   class ConsumesCollector;
-   class EventSetup ;
-}
+namespace edm {
+  class ConsumesCollector;
+  class EventSetup;
+}  // namespace edm
 
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
+class WriteESAlignments {
+public:
+  typedef Alignments* AliPtr;
+  typedef std::vector<AlignTransform> AliVec;
 
-class WriteESAlignments
-{
-   public:
+  typedef AlignTransform::Translation Trl;
+  typedef AlignTransform::Rotation Rot;
 
-      typedef Alignments*                  AliPtr ;
-      typedef std::vector<AlignTransform>  AliVec ;
+  typedef std::vector<double> DVec;
 
-      typedef AlignTransform::Translation Trl ;
-      typedef AlignTransform::Rotation    Rot ;
+  static const unsigned int k_nA;
 
-      typedef std::vector<double> DVec ;
+  WriteESAlignments(edm::ConsumesCollector&& cc);
 
-      static const unsigned int k_nA ;
+  void writeAlignments(const edm::EventSetup& eventSetup,
+                       const DVec& alphaVec,
+                       const DVec& betaVec,
+                       const DVec& gammaVec,
+                       const DVec& xtranslVec,
+                       const DVec& ytranslVec,
+                       const DVec& ztranslVec);
 
-      WriteESAlignments(edm::ConsumesCollector&& cc);
+private:
+  void convert(const edm::EventSetup& eS,
+               const DVec& a,
+               const DVec& b,
+               const DVec& g,
+               const DVec& x,
+               const DVec& y,
+               const DVec& z,
+               AliVec& va);
 
-      void writeAlignments( const edm::EventSetup& eventSetup ,
-                            const DVec&            alphaVec   ,
-                            const DVec&            betaVec    ,
-                            const DVec&            gammaVec   ,
-                            const DVec&            xtranslVec ,
-                            const DVec&            ytranslVec ,
-                            const DVec&            ztranslVec  ) ;
-
-   private:
-
-      void convert( const edm::EventSetup& eS ,
-		    const DVec&            a  ,
-		    const DVec&            b  ,
-		    const DVec&            g  ,
-		    const DVec&            x  ,
-		    const DVec&            y  ,
-		    const DVec&            z  ,
-		    AliVec&                va  ) ;
-
-      void write( AliPtr aliPtr ) ;
+  void write(AliPtr aliPtr);
 
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   edm::ESGetToken<Alignments, ESAlignmentRcd> alignmentToken_;

--- a/Geometry/EcalAlgo/plugins/EcalBarrelGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalAlgo/plugins/EcalBarrelGeometryLoaderFromDDD.cc
@@ -3,151 +3,108 @@
 #include "Geometry/CaloEventSetup/interface/CaloGeometryLoader.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 
-typedef CaloGeometryLoader< EcalBarrelGeometry > EcalBGL ;
+typedef CaloGeometryLoader<EcalBarrelGeometry> EcalBGL;
 
 template <>
-void 
-EcalBGL::fillGeom( EcalBarrelGeometry*         geom,
-		   const EcalBGL::ParmVec&     vv,
-		   const HepGeom::Transform3D& tr,
-		   const DetId&                id );
+void EcalBGL::fillGeom(EcalBarrelGeometry* geom,
+                       const EcalBGL::ParmVec& vv,
+                       const HepGeom::Transform3D& tr,
+                       const DetId& id);
 template <>
-void 
-EcalBGL::fillNamedParams(const  DDFilteredView&      fv,
-			  EcalBarrelGeometry* geom );
+void EcalBGL::fillNamedParams(const DDFilteredView& fv, EcalBarrelGeometry* geom);
 
 #include "Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc"
 
-template class CaloGeometryLoader< EcalBarrelGeometry > ;
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
+template class CaloGeometryLoader<EcalBarrelGeometry>;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
 
 template <>
-void 
-EcalBGL::fillGeom( EcalBarrelGeometry*         geom,
-		   const EcalBGL::ParmVec&     vv,
-		   const HepGeom::Transform3D& tr,
-		   const DetId&                id )
-{
-   std::vector<CCGFloat> pv ;
-   pv.reserve( vv.size() ) ;
-   for( unsigned int i ( 0 ) ; i != vv.size() ; ++i )
-   {
-      const CCGFloat factor ( 1==i || 2==i || 6==i || 10==i ? 1 : 
-			      (CCGFloat)k_ScaleFromDDDtoGeant ) ;
+void EcalBGL::fillGeom(EcalBarrelGeometry* geom,
+                       const EcalBGL::ParmVec& vv,
+                       const HepGeom::Transform3D& tr,
+                       const DetId& id) {
+  std::vector<CCGFloat> pv;
+  pv.reserve(vv.size());
+  for (unsigned int i(0); i != vv.size(); ++i) {
+    const CCGFloat factor(1 == i || 2 == i || 6 == i || 10 == i ? 1 : (CCGFloat)k_ScaleFromDDDtoGeant);
 
-      pv.emplace_back( factor*vv[i] ) ;
-   }
+    pv.emplace_back(factor * vv[i]);
+  }
 
-   std::vector<GlobalPoint> corners (8);
+  std::vector<GlobalPoint> corners(8);
 
-   TruncatedPyramid::createCorners( pv, tr, corners ) ;
+  TruncatedPyramid::createCorners(pv, tr, corners);
 
-   const CCGFloat* parmPtr ( CaloCellGeometry::getParmPtr( pv, 
-							   geom->parMgr(), 
-							   geom->parVecVec() ) ) ;
+  const CCGFloat* parmPtr(CaloCellGeometry::getParmPtr(pv, geom->parMgr(), geom->parVecVec()));
 
-   const GlobalPoint front ( 0.25*( corners[0].x() + 
-				    corners[1].x() + 
-				    corners[2].x() + 
-				    corners[3].x()   ),
-			     0.25*( corners[0].y() + 
-				    corners[1].y() + 
-				    corners[2].y() + 
-				    corners[3].y()   ),
-			     0.25*( corners[0].z() + 
-				    corners[1].z() + 
-				    corners[2].z() + 
-				    corners[3].z()   ) ) ;
-   
-   const GlobalPoint back  ( 0.25*( corners[4].x() + 
-				    corners[5].x() + 
-				    corners[6].x() + 
-				    corners[7].x()   ),
-			     0.25*( corners[4].y() + 
-				    corners[5].y() + 
-				    corners[6].y() + 
-				    corners[7].y()   ),
-			     0.25*( corners[4].z() + 
-				    corners[5].z() + 
-				    corners[6].z() + 
-				    corners[7].z()   ) ) ;
+  const GlobalPoint front(0.25 * (corners[0].x() + corners[1].x() + corners[2].x() + corners[3].x()),
+                          0.25 * (corners[0].y() + corners[1].y() + corners[2].y() + corners[3].y()),
+                          0.25 * (corners[0].z() + corners[1].z() + corners[2].z() + corners[3].z()));
 
-   geom->newCell( front, back, corners[0],
-		  parmPtr, 
-		  id ) ;
+  const GlobalPoint back(0.25 * (corners[4].x() + corners[5].x() + corners[6].x() + corners[7].x()),
+                         0.25 * (corners[4].y() + corners[5].y() + corners[6].y() + corners[7].y()),
+                         0.25 * (corners[4].z() + corners[5].z() + corners[6].z() + corners[7].z()));
+
+  geom->newCell(front, back, corners[0], parmPtr, id);
 }
 
 template <>
-void 
-EcalBGL::fillNamedParams(const DDFilteredView&      _fv,
-			  EcalBarrelGeometry* geom )
-{
-   DDFilteredView fv = _fv;
-   bool doSubDets = fv.firstChild();
+void EcalBGL::fillNamedParams(const DDFilteredView& _fv, EcalBarrelGeometry* geom) {
+  DDFilteredView fv = _fv;
+  bool doSubDets = fv.firstChild();
 
-   while( doSubDets )
-   {
-      DDsvalues_type sv(fv.mergedSpecifics());
-        
-      //nxtalPhi
-      DDValue valnPhi("nxtalPhi");
-      if( DDfetch( &sv, valnPhi ) )
-      {
-	 const std::vector<double>& fvec = valnPhi.doubles();
+  while (doSubDets) {
+    DDsvalues_type sv(fv.mergedSpecifics());
 
-	 // this parameter can only appear once
-	 assert(fvec.size() == 1);
-	 geom->setNumXtalsPhiDirection((int)fvec[0]);
-      }
-      else
-	 continue;
-          
+    //nxtalPhi
+    DDValue valnPhi("nxtalPhi");
+    if (DDfetch(&sv, valnPhi)) {
+      const std::vector<double>& fvec = valnPhi.doubles();
 
-      DDValue valnEta("nxtalEta");
-      if( DDfetch( &sv, valnEta ) ) 
-      {
-	 const std::vector<double>& fmvec = valnEta.doubles();
+      // this parameter can only appear once
+      assert(fvec.size() == 1);
+      geom->setNumXtalsPhiDirection((int)fvec[0]);
+    } else
+      continue;
 
-	 // there can only be one such value
-	 assert(fmvec.size() == 1);
-            
-	 geom->setNumXtalsEtaDirection((int)fmvec[0]);
-      }
-      else
-	 // once we find nxtalPhi, the rest must also be defined
-	 assert( 1 == 0 );
+    DDValue valnEta("nxtalEta");
+    if (DDfetch(&sv, valnEta)) {
+      const std::vector<double>& fmvec = valnEta.doubles();
 
-      //EtaBaskets
-      DDValue valEtaB("EtaBaskets");
-      if( DDfetch( &sv, valEtaB ) ) 
-      {
-	 const std::vector<double>& ebvec = valEtaB.doubles();
-	 assert(!ebvec.empty());
-	 std::vector<int> EtaBaskets;
-	 EtaBaskets.resize(ebvec.size());
-	 for (unsigned i = 0; i<ebvec.size(); ++i) 
-	    EtaBaskets[i] = (int) ebvec[i];
-	 geom->setEtaBaskets(EtaBaskets);
-      }
-      else
-	 // once we find nxtalPhi, the rest must also be defined
-	 assert( 1 == 0 );
+      // there can only be one such value
+      assert(fmvec.size() == 1);
 
-      //PhiBaskets
-      DDValue valPhi("PhiBaskets");
-      if (DDfetch(&sv,valPhi)) 
-      {
-	 const std::vector<double> & pvec = valPhi.doubles();
-	 assert(!pvec.empty());
-	 geom->setBasketSizeInPhi((int)pvec[0]);
-      }
-      else
-	 // once we find nxtalPhi, the rest must also be defined
-	 assert( 1 == 0 );
+      geom->setNumXtalsEtaDirection((int)fmvec[0]);
+    } else
+      // once we find nxtalPhi, the rest must also be defined
+      assert(1 == 0);
 
-      break;
-    
-      doSubDets = fv.nextSibling(); // go to next layer
-   }
+    //EtaBaskets
+    DDValue valEtaB("EtaBaskets");
+    if (DDfetch(&sv, valEtaB)) {
+      const std::vector<double>& ebvec = valEtaB.doubles();
+      assert(!ebvec.empty());
+      std::vector<int> EtaBaskets;
+      EtaBaskets.resize(ebvec.size());
+      for (unsigned i = 0; i < ebvec.size(); ++i)
+        EtaBaskets[i] = (int)ebvec[i];
+      geom->setEtaBaskets(EtaBaskets);
+    } else
+      // once we find nxtalPhi, the rest must also be defined
+      assert(1 == 0);
+
+    //PhiBaskets
+    DDValue valPhi("PhiBaskets");
+    if (DDfetch(&sv, valPhi)) {
+      const std::vector<double>& pvec = valPhi.doubles();
+      assert(!pvec.empty());
+      geom->setBasketSizeInPhi((int)pvec[0]);
+    } else
+      // once we find nxtalPhi, the rest must also be defined
+      assert(1 == 0);
+
+    break;
+
+    doSubDets = fv.nextSibling();  // go to next layer
+  }
 }
-

--- a/Geometry/EcalAlgo/plugins/EcalEndcapGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalAlgo/plugins/EcalEndcapGeometryLoaderFromDDD.cc
@@ -3,115 +3,80 @@
 #include "Geometry/CaloEventSetup/interface/CaloGeometryLoader.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 
-typedef CaloGeometryLoader< EcalEndcapGeometry > EcalEGL ;
+typedef CaloGeometryLoader<EcalEndcapGeometry> EcalEGL;
 
 template <>
-void 
-EcalEGL::fillGeom( EcalEndcapGeometry*         geom,
-		   const EcalEGL::ParmVec&     vv,
-		   const HepGeom::Transform3D& tr,
-		   const DetId&                id );
+void EcalEGL::fillGeom(EcalEndcapGeometry* geom,
+                       const EcalEGL::ParmVec& vv,
+                       const HepGeom::Transform3D& tr,
+                       const DetId& id);
 template <>
-void 
-EcalEGL::fillNamedParams( const DDFilteredView&      fv,
-			  EcalEndcapGeometry* geom );
+void EcalEGL::fillNamedParams(const DDFilteredView& fv, EcalEndcapGeometry* geom);
 
 #include "Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc"
 
-template class CaloGeometryLoader< EcalEndcapGeometry > ;
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
+template class CaloGeometryLoader<EcalEndcapGeometry>;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
 
 template <>
-void 
-EcalEGL::fillGeom( EcalEndcapGeometry*         geom,
-		   const EcalEGL::ParmVec&     vv,
-		   const HepGeom::Transform3D& tr,
-		   const DetId&                id )
-{
-   std::vector<CCGFloat> pv ;
-   pv.reserve( vv.size() ) ;
-   for( unsigned int i ( 0 ) ; i != vv.size() ; ++i )
-   {
-      const CCGFloat factor ( 1==i || 2==i || 6==i || 10==i ? 1 : k_ScaleFromDDDtoGeant ) ;
-      pv.emplace_back( factor*vv[i] ) ;
-   }
+void EcalEGL::fillGeom(EcalEndcapGeometry* geom,
+                       const EcalEGL::ParmVec& vv,
+                       const HepGeom::Transform3D& tr,
+                       const DetId& id) {
+  std::vector<CCGFloat> pv;
+  pv.reserve(vv.size());
+  for (unsigned int i(0); i != vv.size(); ++i) {
+    const CCGFloat factor(1 == i || 2 == i || 6 == i || 10 == i ? 1 : k_ScaleFromDDDtoGeant);
+    pv.emplace_back(factor * vv[i]);
+  }
 
-   std::vector<GlobalPoint> corners (8);
+  std::vector<GlobalPoint> corners(8);
 
-   TruncatedPyramid::createCorners( pv, tr, corners ) ;
+  TruncatedPyramid::createCorners(pv, tr, corners);
 
-   const CCGFloat* parmPtr ( CaloCellGeometry::getParmPtr( pv, 
-							   geom->parMgr(), 
-							   geom->parVecVec() ) ) ;
+  const CCGFloat* parmPtr(CaloCellGeometry::getParmPtr(pv, geom->parMgr(), geom->parVecVec()));
 
-   const GlobalPoint front ( 0.25*( corners[0].x() + 
-				    corners[1].x() + 
-				    corners[2].x() + 
-				    corners[3].x()   ),
-			     0.25*( corners[0].y() + 
-				    corners[1].y() + 
-				    corners[2].y() + 
-				    corners[3].y()   ),
-			     0.25*( corners[0].z() + 
-				    corners[1].z() + 
-				    corners[2].z() + 
-				    corners[3].z()   ) ) ;
-   
-   const GlobalPoint back  ( 0.25*( corners[4].x() + 
-				    corners[5].x() + 
-				    corners[6].x() + 
-				    corners[7].x()   ),
-			     0.25*( corners[4].y() + 
-				    corners[5].y() + 
-				    corners[6].y() + 
-				    corners[7].y()   ),
-			     0.25*( corners[4].z() + 
-				    corners[5].z() + 
-				    corners[6].z() + 
-				    corners[7].z()   ) ) ;
+  const GlobalPoint front(0.25 * (corners[0].x() + corners[1].x() + corners[2].x() + corners[3].x()),
+                          0.25 * (corners[0].y() + corners[1].y() + corners[2].y() + corners[3].y()),
+                          0.25 * (corners[0].z() + corners[1].z() + corners[2].z() + corners[3].z()));
 
-   geom->newCell( front, back, corners[0],
-		  parmPtr, 
-		  id ) ;
+  const GlobalPoint back(0.25 * (corners[4].x() + corners[5].x() + corners[6].x() + corners[7].x()),
+                         0.25 * (corners[4].y() + corners[5].y() + corners[6].y() + corners[7].y()),
+                         0.25 * (corners[4].z() + corners[5].z() + corners[6].z() + corners[7].z()));
+
+  geom->newCell(front, back, corners[0], parmPtr, id);
 }
 
 template <>
-void 
-EcalEGL::fillNamedParams(const DDFilteredView&      _fv,
-			  EcalEndcapGeometry* geom )
-{
-   DDFilteredView fv = _fv;
-   bool doSubDets = fv.firstChild();
-   while (doSubDets)
-   {
-      DDsvalues_type sv ( fv.mergedSpecifics() ) ;
-	    
-      //ncrys
-      DDValue valNcrys("ncrys");
-      if( DDfetch( &sv, valNcrys ) ) 
-      {
-	 const std::vector<double>& fvec = valNcrys.doubles();
+void EcalEGL::fillNamedParams(const DDFilteredView& _fv, EcalEndcapGeometry* geom) {
+  DDFilteredView fv = _fv;
+  bool doSubDets = fv.firstChild();
+  while (doSubDets) {
+    DDsvalues_type sv(fv.mergedSpecifics());
 
-	 // this parameter can only appear once
-	 assert(fvec.size() == 1);
-	 geom->setNumberOfCrystalPerModule((int)fvec[0]);
-      }
-      else 
-	 continue;
+    //ncrys
+    DDValue valNcrys("ncrys");
+    if (DDfetch(&sv, valNcrys)) {
+      const std::vector<double>& fvec = valNcrys.doubles();
 
-      //nmods
-      DDValue valNmods("nmods");
-      if( DDfetch( &sv, valNmods ) ) 
-      {
-	 const std::vector<double>& fmvec = valNmods.doubles() ;
+      // this parameter can only appear once
+      assert(fvec.size() == 1);
+      geom->setNumberOfCrystalPerModule((int)fvec[0]);
+    } else
+      continue;
 
-	 // there can only be one such value
-	 assert(fmvec.size() == 1);
-	 geom->setNumberOfModules((int)fmvec[0]);
-      }
-	    
-      break;
+    //nmods
+    DDValue valNmods("nmods");
+    if (DDfetch(&sv, valNmods)) {
+      const std::vector<double>& fmvec = valNmods.doubles();
 
-      doSubDets = fv.nextSibling(); // go to next layer
-   }
+      // there can only be one such value
+      assert(fmvec.size() == 1);
+      geom->setNumberOfModules((int)fmvec[0]);
+    }
+
+    break;
+
+    doSubDets = fv.nextSibling();  // go to next layer
+  }
 }

--- a/Geometry/EcalAlgo/plugins/EcalPreshowerGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalAlgo/plugins/EcalPreshowerGeometryLoaderFromDDD.cc
@@ -2,79 +2,64 @@
 #include "Geometry/CaloEventSetup/interface/CaloGeometryLoader.h"
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 
-typedef CaloGeometryLoader< EcalPreshowerGeometry > EcalPGL ;
+typedef CaloGeometryLoader<EcalPreshowerGeometry> EcalPGL;
 
 template <>
-void 
-EcalPGL::fillGeom( EcalPreshowerGeometry*      geom ,
-		   const EcalPGL::ParmVec&     pv ,
-		   const HepGeom::Transform3D& tr ,
-		   const DetId&                id     );
+void EcalPGL::fillGeom(EcalPreshowerGeometry* geom,
+                       const EcalPGL::ParmVec& pv,
+                       const HepGeom::Transform3D& tr,
+                       const DetId& id);
 template <>
-void 
-EcalPGL::fillNamedParams(const DDFilteredView&         /*fv*/   ,
-			  EcalPreshowerGeometry* /*geom*/  );
+void EcalPGL::fillNamedParams(const DDFilteredView& /*fv*/, EcalPreshowerGeometry* /*geom*/);
 
 #include "Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc"
 
-template class CaloGeometryLoader< EcalPreshowerGeometry > ;
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
-typedef CaloCellGeometry::Pt3D     Pt3D     ;
+template class CaloGeometryLoader<EcalPreshowerGeometry>;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
+typedef CaloCellGeometry::Pt3D Pt3D;
 
 template <>
-void 
-EcalPGL::fillGeom( EcalPreshowerGeometry*      geom ,
-		   const EcalPGL::ParmVec&     pv ,
-		   const HepGeom::Transform3D& tr ,
-		   const DetId&                id     )
-{
-   std::vector<CCGFloat> vv ;
-   vv.reserve( pv.size() + 1 ) ;
-   for( unsigned int i ( 0 ) ; i != pv.size() ; ++i )
-   {
-      vv.emplace_back( k_ScaleFromDDDtoGeant*pv[i] ) ;
-   }
+void EcalPGL::fillGeom(EcalPreshowerGeometry* geom,
+                       const EcalPGL::ParmVec& pv,
+                       const HepGeom::Transform3D& tr,
+                       const DetId& id) {
+  std::vector<CCGFloat> vv;
+  vv.reserve(pv.size() + 1);
+  for (unsigned int i(0); i != pv.size(); ++i) {
+    vv.emplace_back(k_ScaleFromDDDtoGeant * pv[i]);
+  }
 
-   const Pt3D cor1 (  vv[0],  vv[1], vv[2] ) ;
-   const Pt3D cor2 ( -vv[0],  vv[1], vv[2] ) ;
-   const Pt3D cor3 (  vv[0], -vv[1], vv[2] ) ;
+  const Pt3D cor1(vv[0], vv[1], vv[2]);
+  const Pt3D cor2(-vv[0], vv[1], vv[2]);
+  const Pt3D cor3(vv[0], -vv[1], vv[2]);
 
-   const CCGFloat z1 ( Pt3D( tr*cor1 ).z() ) ;
-   const CCGFloat z2 ( Pt3D( tr*cor2 ).z() ) ;
-   const CCGFloat z3 ( Pt3D( tr*cor3 ).z() ) ;
+  const CCGFloat z1(Pt3D(tr * cor1).z());
+  const CCGFloat z2(Pt3D(tr * cor2).z());
+  const CCGFloat z3(Pt3D(tr * cor3).z());
 
-   const CCGFloat y1 ( Pt3D( tr*cor3 ).y() ) ;
-//   const CCGFloat y3 ( Pt3D( tr*cor3 ).y() ) ;
+  const CCGFloat y1(Pt3D(tr * cor3).y());
+  //   const CCGFloat y3 ( Pt3D( tr*cor3 ).y() ) ;
 
-   const CCGFloat x1 ( Pt3D( tr*cor3 ).x() ) ;
-//   const CCGFloat x2 ( Pt3D( tr*cor3 ).x() ) ;
+  const CCGFloat x1(Pt3D(tr * cor3).x());
+  //   const CCGFloat x2 ( Pt3D( tr*cor3 ).x() ) ;
 
-   const CCGFloat zdif ( 0.00001 > fabs( z1 - z2 ) ? 
-		       ( y1>0 ? +1.0 : -1.0 )*( z1 - z3 ) : 
-		       ( x1>0 ? +1.0 : -1.0 )*( z1 - z2 ) ) ;
+  const CCGFloat zdif(0.00001 > fabs(z1 - z2) ? (y1 > 0 ? +1.0 : -1.0) * (z1 - z3)
+                                              : (x1 > 0 ? +1.0 : -1.0) * (z1 - z2));
 
-   const CCGFloat tilt ( asin( 0.5*zdif/( vv[1]>vv[0] ? vv[1] : vv[0] ) ) ) ;
+  const CCGFloat tilt(asin(0.5 * zdif / (vv[1] > vv[0] ? vv[1] : vv[0])));
 
-   vv.emplace_back( tilt ) ;
+  vv.emplace_back(tilt);
 
-   const CCGFloat* pP ( CaloCellGeometry::getParmPtr( vv, 
-						      geom->parMgr(), 
-						      geom->parVecVec() ) ) ;
-   
-   const Pt3D ctr ( tr*Pt3D(0,0,0) ) ;
+  const CCGFloat* pP(CaloCellGeometry::getParmPtr(vv, geom->parMgr(), geom->parVecVec()));
 
-   const GlobalPoint refPoint ( ctr.x(), ctr.y(), ctr.z() ) ;
+  const Pt3D ctr(tr * Pt3D(0, 0, 0));
 
-   geom->newCell( refPoint, refPoint, refPoint,
-		  pP,
-		  id );
+  const GlobalPoint refPoint(ctr.x(), ctr.y(), ctr.z());
+
+  geom->newCell(refPoint, refPoint, refPoint, pP, id);
 }
 
 template <>
-void 
-EcalPGL::fillNamedParams(const DDFilteredView&         /*fv*/   ,
-			  EcalPreshowerGeometry* /*geom*/  )
-{
-   // nothing yet for preshower
+void EcalPGL::fillNamedParams(const DDFilteredView& /*fv*/, EcalPreshowerGeometry* /*geom*/) {
+  // nothing yet for preshower
 }
-

--- a/Geometry/EcalAlgo/plugins/module.cc
+++ b/Geometry/EcalAlgo/plugins/module.cc
@@ -3,38 +3,34 @@
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 #include "Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h"
 
-template class CaloGeometryEP< EcalBarrelGeometry    > ;
-template class CaloGeometryEP< EcalEndcapGeometry    > ;
-template class CaloGeometryEP< EcalPreshowerGeometry > ;
+template class CaloGeometryEP<EcalBarrelGeometry>;
+template class CaloGeometryEP<EcalEndcapGeometry>;
+template class CaloGeometryEP<EcalPreshowerGeometry>;
 
-typedef CaloGeometryEP< EcalBarrelGeometry > EcalBarrelGeometryEP ;
+typedef CaloGeometryEP<EcalBarrelGeometry> EcalBarrelGeometryEP;
 DEFINE_FWK_EVENTSETUP_MODULE(EcalBarrelGeometryEP);
 
-typedef CaloGeometryEP< EcalEndcapGeometry > EcalEndcapGeometryEP ;
+typedef CaloGeometryEP<EcalEndcapGeometry> EcalEndcapGeometryEP;
 DEFINE_FWK_EVENTSETUP_MODULE(EcalEndcapGeometryEP);
 
-typedef CaloGeometryEP< EcalPreshowerGeometry > EcalPreshowerGeometryEP ;
+typedef CaloGeometryEP<EcalPreshowerGeometry> EcalPreshowerGeometryEP;
 DEFINE_FWK_EVENTSETUP_MODULE(EcalPreshowerGeometryEP);
 
 #include "Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h"
 #include "Geometry/CaloEventSetup/interface/CaloGeometryDBReader.h"
 
+template class CaloGeometryDBEP<EcalBarrelGeometry, CaloGeometryDBReader>;
+template class CaloGeometryDBEP<EcalEndcapGeometry, CaloGeometryDBReader>;
+template class CaloGeometryDBEP<EcalPreshowerGeometry, CaloGeometryDBReader>;
 
-template class CaloGeometryDBEP< EcalBarrelGeometry    , CaloGeometryDBReader> ;
-template class CaloGeometryDBEP< EcalEndcapGeometry    , CaloGeometryDBReader> ;
-template class CaloGeometryDBEP< EcalPreshowerGeometry , CaloGeometryDBReader> ;
-
-typedef CaloGeometryDBEP< EcalBarrelGeometry , CaloGeometryDBReader> 
-EcalBarrelGeometryFromDBEP ;
+typedef CaloGeometryDBEP<EcalBarrelGeometry, CaloGeometryDBReader> EcalBarrelGeometryFromDBEP;
 
 DEFINE_FWK_EVENTSETUP_MODULE(EcalBarrelGeometryFromDBEP);
 
-typedef CaloGeometryDBEP< EcalEndcapGeometry , CaloGeometryDBReader> 
-EcalEndcapGeometryFromDBEP ;
+typedef CaloGeometryDBEP<EcalEndcapGeometry, CaloGeometryDBReader> EcalEndcapGeometryFromDBEP;
 
 DEFINE_FWK_EVENTSETUP_MODULE(EcalEndcapGeometryFromDBEP);
 
-typedef CaloGeometryDBEP< EcalPreshowerGeometry , CaloGeometryDBReader> 
-EcalPreshowerGeometryFromDBEP ;
+typedef CaloGeometryDBEP<EcalPreshowerGeometry, CaloGeometryDBReader> EcalPreshowerGeometryFromDBEP;
 
 DEFINE_FWK_EVENTSETUP_MODULE(EcalPreshowerGeometryFromDBEP);

--- a/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
@@ -12,501 +12,437 @@
 #include <iomanip>
 #include <iostream>
 
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
-typedef CaloCellGeometry::Pt3D     Pt3D     ;
-typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
-typedef HepGeom::Plane3D<CCGFloat> Pl3D     ;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
+typedef CaloCellGeometry::Pt3D Pt3D;
+typedef CaloCellGeometry::Pt3DVec Pt3DVec;
+typedef HepGeom::Plane3D<CCGFloat> Pl3D;
 
-EcalBarrelGeometry::EcalBarrelGeometry() :
-   _nnxtalEta     ( 85 ) ,
-   _nnxtalPhi     ( 360 ) ,
-   _PhiBaskets    ( 18 ) ,
-   m_borderMgr    ( nullptr ),
-   m_borderPtrVec ( nullptr ) ,
-   m_radius       ( -1. ),
-   m_check        ( false ),
-   m_cellVec      ( k_NumberOfCellsForCorners )
-{
-   const int neba[] = {25,45,65,85} ;
-   _EtaBaskets = std::vector<int>( neba, neba+4 ) ;
+EcalBarrelGeometry::EcalBarrelGeometry()
+    : _nnxtalEta(85),
+      _nnxtalPhi(360),
+      _PhiBaskets(18),
+      m_borderMgr(nullptr),
+      m_borderPtrVec(nullptr),
+      m_radius(-1.),
+      m_check(false),
+      m_cellVec(k_NumberOfCellsForCorners) {
+  const int neba[] = {25, 45, 65, 85};
+  _EtaBaskets = std::vector<int>(neba, neba + 4);
 }
 
-
-EcalBarrelGeometry::~EcalBarrelGeometry() 
-{
-  if(m_borderPtrVec)
-  {
+EcalBarrelGeometry::~EcalBarrelGeometry() {
+  if (m_borderPtrVec) {
     auto ptr = m_borderPtrVec.load(std::memory_order_acquire);
-    for(auto& v: (*ptr)) {
-        delete v;
-        v = nullptr;
+    for (auto& v : (*ptr)) {
+      delete v;
+      v = nullptr;
     }
-    delete m_borderPtrVec.load() ;
+    delete m_borderPtrVec.load();
   }
-  delete m_borderMgr.load() ;
+  delete m_borderMgr.load();
 }
 
+unsigned int EcalBarrelGeometry::alignmentTransformIndexLocal(const DetId& id) {
+  const CaloGenericDetId gid(id);
 
-unsigned int
-EcalBarrelGeometry::alignmentTransformIndexLocal( const DetId& id )
-{
-   const CaloGenericDetId gid ( id ) ;
+  assert(gid.isEB());
 
-   assert( gid.isEB() ) ;
+  unsigned int index(EBDetId(id).ism() - 1);
 
-   unsigned int index ( EBDetId(id).ism() - 1 ) ;
-
-   return index ;
+  return index;
 }
 
-DetId 
-EcalBarrelGeometry::detIdFromLocalAlignmentIndex( unsigned int iLoc )
-{
-   return EBDetId( iLoc + 1, 1, EBDetId::SMCRYSTALMODE ) ;
+DetId EcalBarrelGeometry::detIdFromLocalAlignmentIndex(unsigned int iLoc) {
+  return EBDetId(iLoc + 1, 1, EBDetId::SMCRYSTALMODE);
 }
 
-unsigned int
-EcalBarrelGeometry::alignmentTransformIndexGlobal( const DetId& /*id*/ )
-{
-   return (unsigned int)DetId::Ecal - 1 ;
+unsigned int EcalBarrelGeometry::alignmentTransformIndexGlobal(const DetId& /*id*/) {
+  return (unsigned int)DetId::Ecal - 1;
 }
 // Get closest cell, etc...
-DetId 
-EcalBarrelGeometry::getClosestCell(const GlobalPoint& r) const
-{
-
+DetId EcalBarrelGeometry::getClosestCell(const GlobalPoint& r) const {
   // z is the easy one
   int leverx = 1;
   int levery = 1;
   CCGFloat pointz = r.z();
-  int zbin=1;
-  if(pointz<0)
-    zbin=-1;
+  int zbin = 1;
+  if (pointz < 0)
+    zbin = -1;
 
   // Now find the closest eta
   CCGFloat pointeta = r.eta();
   //  double eta;
-  CCGFloat deta=999.;
-  int etabin=1;
-  
-  int guessed_eta = (int)( fabs(pointeta) / 0.0174)+1;
-  int guessed_eta_begin = guessed_eta-1;
-  int guessed_eta_end   = guessed_eta+1;
-  if (guessed_eta_begin < 1) guessed_eta_begin = 1;
-  if (guessed_eta_end > 85) guessed_eta_end = 85;
+  CCGFloat deta = 999.;
+  int etabin = 1;
 
-    for(int bin=guessed_eta_begin; bin<= guessed_eta_end; bin++)
-      {
-	try
-	  {
-	    if (!present(EBDetId(zbin*bin,1,EBDetId::ETAPHIMODE)))
-	      continue;
+  int guessed_eta = (int)(fabs(pointeta) / 0.0174) + 1;
+  int guessed_eta_begin = guessed_eta - 1;
+  int guessed_eta_end = guessed_eta + 1;
+  if (guessed_eta_begin < 1)
+    guessed_eta_begin = 1;
+  if (guessed_eta_end > 85)
+    guessed_eta_end = 85;
 
-	    CCGFloat eta = getGeometry(EBDetId(zbin*bin,1,EBDetId::ETAPHIMODE))->etaPos();
+  for (int bin = guessed_eta_begin; bin <= guessed_eta_end; bin++) {
+    try {
+      if (!present(EBDetId(zbin * bin, 1, EBDetId::ETAPHIMODE)))
+        continue;
 
-	    if(fabs(pointeta-eta)<deta)
-	      {
-		deta=fabs(pointeta-eta);
-		etabin=bin;
-	      }
-	    else break;
-	  }
-	catch ( cms::Exception &e ) 
-	  {
-	  }
-      }
-    
+      CCGFloat eta = getGeometry(EBDetId(zbin * bin, 1, EBDetId::ETAPHIMODE))->etaPos();
+
+      if (fabs(pointeta - eta) < deta) {
+        deta = fabs(pointeta - eta);
+        etabin = bin;
+      } else
+        break;
+    } catch (cms::Exception& e) {
+    }
+  }
 
   // Now the closest phi. always same number of phi bins(!?)
-  constexpr CCGFloat twopi = M_PI+M_PI;
+  constexpr CCGFloat twopi = M_PI + M_PI;
   // 10 degree tilt
-  constexpr CCGFloat tilt=twopi/36.;
+  constexpr CCGFloat tilt = twopi / 36.;
 
-  CCGFloat pointphi = r.phi()+tilt;
+  CCGFloat pointphi = r.phi() + tilt;
 
   // put phi in correct range (0->2pi)
-  if(pointphi > twopi)
+  if (pointphi > twopi)
     pointphi -= twopi;
-  if(pointphi < 0)
+  if (pointphi < 0)
     pointphi += twopi;
 
   //calculate phi bin, distinguish + and - eta
-  int phibin = static_cast<int>(pointphi / (twopi/_nnxtalPhi)) + 1;
+  int phibin = static_cast<int>(pointphi / (twopi / _nnxtalPhi)) + 1;
   //   if(point.z()<0.0)
   //     {
   //       phibin = nxtalPhi/2 - 1 - phibin;
   //       if(phibin<0)
   //         phibin += nxtalPhi;
   //     }
-  try
-    {
-      EBDetId myCell(zbin*etabin,phibin,EBDetId::ETAPHIMODE);
+  try {
+    EBDetId myCell(zbin * etabin, phibin, EBDetId::ETAPHIMODE);
 
-      if (!present(myCell))
-	return DetId(0);
-      
-      Pt3D A;
-      Pt3D B;
-      Pt3D C;
-      Pt3D point(r.x(),r.y(),r.z());
-
-      // D.K. : equation of plane : AA*x+BB*y+CC*z+DD=0;
-      // finding equation for each edge
-
-      // Since the point can lie between crystals, it is necessary to keep track of the movements
-      // to avoid infinite loops
-      CCGFloat history[4]{0.f};
-
-      //
-      // stop movement in eta direction when closest cell was found (point between crystals)
-      int start = 1;
-      int counter = 0;
-      // Moving until find closest crystal in eta and phi directions (leverx and levery)
-      while  (leverx==1 || levery == 1)
-	{
-	  leverx = 0;
-	  levery = 0;
-	  const CaloCellGeometry::CornersVec& corners 
-	     ( getGeometry(myCell)->getCorners() ) ;
-	  CCGFloat SS[4];
-
-	  // compute the distance of the point with respect of the 4 crystal lateral planes
-	  for (short i=0; i < 4 ; ++i)
-	    {
-	      A = Pt3D(corners[i%4].x(),corners[i%4].y(),corners[i%4].z());
-	      B = Pt3D(corners[(i+1)%4].x(),corners[(i+1)%4].y(),corners[(i+1)%4].z());
-	      C = Pt3D(corners[4+(i+1)%4].x(),corners[4+(i+1)%4].y(),corners[4+(i+1)%4].z());
-	      Pl3D plane(A,B,C);
-	      plane.normalize();
-	      CCGFloat distance = plane.distance(point);
-	      if(plane.d()>0.) distance=-distance;
-	      if (corners[0].z()<0.) distance=-distance;
-	      SS[i] = distance;
-	    }
-
-	  // SS's - normals
-	  // check position of the point with respect to opposite side of crystal
-	  // if SS's have opposite sign, the  point lies inside that crystal
-
-	  if ( ( SS[0]>0.&&SS[2]>0. )||( SS[0]<0.&&SS[2]<0. ) )
-	    {
-	      levery = 1;
-	      if ( history[0]>0. && history[2]>0. && SS[0]<0 && SS[2]<0 &&
-		   (fabs(SS[0])+fabs(SS[2]))> (fabs(history[0])+fabs(history[2]))) levery = 0  ;
-	      if ( history[0]<0. && history[2]<0. && SS[0]>0 && SS[2]>0 &&
-		   (fabs(SS[0])+fabs(SS[2]))> (fabs(history[0])+fabs(history[2]))) levery = 0  ;
-
-
-	      if (SS[0]>0. )
-		{
-		  EBDetId nextPoint;
-		  if (myCell.iphi()==EBDetId::MIN_IPHI) 
-		    nextPoint=EBDetId(myCell.ieta(),EBDetId::MAX_IPHI);
-		  else 
-		    nextPoint=EBDetId(myCell.ieta(),myCell.iphi()-1);
-		  if (present(nextPoint))
-		    myCell=nextPoint;
-		  else
-		    levery=0;		  
-		}
-	      else
-		{
-		  EBDetId nextPoint;
-		  if (myCell.iphi()==EBDetId::MAX_IPHI)
-		    nextPoint=EBDetId(myCell.ieta(),EBDetId::MIN_IPHI);
-		  else
-		    nextPoint=EBDetId(myCell.ieta(),myCell.iphi()+1);
-		  if (present(nextPoint))
-		    myCell=nextPoint;
-		  else
-		    levery=0;
-		}
-	    }
-
-
-	  if ( ( ( SS[1]>0.&&SS[3]>0. )||( SS[1]<0.&&SS[3]<0. )) && start==1  )
-	    {
-	      leverx = 1;
-
-	      if ( history[1]>0. && history[3]>0. && SS[1]<0 && SS[3]<0 &&
-		   (fabs(SS[1])+fabs(SS[3]))> (fabs(history[1])+fabs(history[3])) )
-		{
-		  leverx = 0;
-		  start = 0;
-		}
-
-	      if ( history[1]<0. && history[3]<0. && SS[1]>0 && SS[3]>0 &&
-		   (fabs(SS[1])+fabs(SS[3]))> (fabs(history[1])+fabs(history[3])) )
-		{
-		  leverx = 0;
-		  start = 0;
-		}
-
-
-	      if (SS[1]>0.)
-		{
-		  EBDetId nextPoint;
-		  if (myCell.ieta()==-1) 
-		    nextPoint=EBDetId (1,myCell.iphi());
-		  else 
-		    {
-		      int nieta= myCell.ieta()+1;
-		      if(nieta==86) nieta=85;
-		      nextPoint=EBDetId(nieta,myCell.iphi());
-		    }
-		  if (present(nextPoint))
-		    myCell = nextPoint;
-		  else
-		    leverx = 0;
-		}
-	      else
-		{
-		  EBDetId nextPoint;
-		  if (myCell.ieta()==1) 
-		    nextPoint=EBDetId(-1,myCell.iphi());
-		  else 
-		    {
-		      int nieta=myCell.ieta()-1;
-		      if(nieta==-86) nieta=-85;
-		      nextPoint=EBDetId(nieta,myCell.iphi());
-		    }
-		  if (present(nextPoint))
-		    myCell = nextPoint;
-		  else
-		    leverx = 0;
-		}
-	    }
-	  
-	  // Update the history. If the point lies between crystals, the closest one
-	  // is returned
-	  std::copy(SS,SS+4,history);
-	  
-	  counter++;
-	  if (counter == 10)
-	    {
-	      leverx=0;
-	      levery=0;
-	    }
-	}
-      // D.K. if point lies netween cells, take a closest cell.
-      return DetId(myCell);
-    }
-  catch ( cms::Exception &e ) 
-    { 
+    if (!present(myCell))
       return DetId(0);
+
+    Pt3D A;
+    Pt3D B;
+    Pt3D C;
+    Pt3D point(r.x(), r.y(), r.z());
+
+    // D.K. : equation of plane : AA*x+BB*y+CC*z+DD=0;
+    // finding equation for each edge
+
+    // Since the point can lie between crystals, it is necessary to keep track of the movements
+    // to avoid infinite loops
+    CCGFloat history[4]{0.f};
+
+    //
+    // stop movement in eta direction when closest cell was found (point between crystals)
+    int start = 1;
+    int counter = 0;
+    // Moving until find closest crystal in eta and phi directions (leverx and levery)
+    while (leverx == 1 || levery == 1) {
+      leverx = 0;
+      levery = 0;
+      const CaloCellGeometry::CornersVec& corners(getGeometry(myCell)->getCorners());
+      CCGFloat SS[4];
+
+      // compute the distance of the point with respect of the 4 crystal lateral planes
+      for (short i = 0; i < 4; ++i) {
+        A = Pt3D(corners[i % 4].x(), corners[i % 4].y(), corners[i % 4].z());
+        B = Pt3D(corners[(i + 1) % 4].x(), corners[(i + 1) % 4].y(), corners[(i + 1) % 4].z());
+        C = Pt3D(corners[4 + (i + 1) % 4].x(), corners[4 + (i + 1) % 4].y(), corners[4 + (i + 1) % 4].z());
+        Pl3D plane(A, B, C);
+        plane.normalize();
+        CCGFloat distance = plane.distance(point);
+        if (plane.d() > 0.)
+          distance = -distance;
+        if (corners[0].z() < 0.)
+          distance = -distance;
+        SS[i] = distance;
+      }
+
+      // SS's - normals
+      // check position of the point with respect to opposite side of crystal
+      // if SS's have opposite sign, the  point lies inside that crystal
+
+      if ((SS[0] > 0. && SS[2] > 0.) || (SS[0] < 0. && SS[2] < 0.)) {
+        levery = 1;
+        if (history[0] > 0. && history[2] > 0. && SS[0] < 0 && SS[2] < 0 &&
+            (fabs(SS[0]) + fabs(SS[2])) > (fabs(history[0]) + fabs(history[2])))
+          levery = 0;
+        if (history[0] < 0. && history[2] < 0. && SS[0] > 0 && SS[2] > 0 &&
+            (fabs(SS[0]) + fabs(SS[2])) > (fabs(history[0]) + fabs(history[2])))
+          levery = 0;
+
+        if (SS[0] > 0.) {
+          EBDetId nextPoint;
+          if (myCell.iphi() == EBDetId::MIN_IPHI)
+            nextPoint = EBDetId(myCell.ieta(), EBDetId::MAX_IPHI);
+          else
+            nextPoint = EBDetId(myCell.ieta(), myCell.iphi() - 1);
+          if (present(nextPoint))
+            myCell = nextPoint;
+          else
+            levery = 0;
+        } else {
+          EBDetId nextPoint;
+          if (myCell.iphi() == EBDetId::MAX_IPHI)
+            nextPoint = EBDetId(myCell.ieta(), EBDetId::MIN_IPHI);
+          else
+            nextPoint = EBDetId(myCell.ieta(), myCell.iphi() + 1);
+          if (present(nextPoint))
+            myCell = nextPoint;
+          else
+            levery = 0;
+        }
+      }
+
+      if (((SS[1] > 0. && SS[3] > 0.) || (SS[1] < 0. && SS[3] < 0.)) && start == 1) {
+        leverx = 1;
+
+        if (history[1] > 0. && history[3] > 0. && SS[1] < 0 && SS[3] < 0 &&
+            (fabs(SS[1]) + fabs(SS[3])) > (fabs(history[1]) + fabs(history[3]))) {
+          leverx = 0;
+          start = 0;
+        }
+
+        if (history[1] < 0. && history[3] < 0. && SS[1] > 0 && SS[3] > 0 &&
+            (fabs(SS[1]) + fabs(SS[3])) > (fabs(history[1]) + fabs(history[3]))) {
+          leverx = 0;
+          start = 0;
+        }
+
+        if (SS[1] > 0.) {
+          EBDetId nextPoint;
+          if (myCell.ieta() == -1)
+            nextPoint = EBDetId(1, myCell.iphi());
+          else {
+            int nieta = myCell.ieta() + 1;
+            if (nieta == 86)
+              nieta = 85;
+            nextPoint = EBDetId(nieta, myCell.iphi());
+          }
+          if (present(nextPoint))
+            myCell = nextPoint;
+          else
+            leverx = 0;
+        } else {
+          EBDetId nextPoint;
+          if (myCell.ieta() == 1)
+            nextPoint = EBDetId(-1, myCell.iphi());
+          else {
+            int nieta = myCell.ieta() - 1;
+            if (nieta == -86)
+              nieta = -85;
+            nextPoint = EBDetId(nieta, myCell.iphi());
+          }
+          if (present(nextPoint))
+            myCell = nextPoint;
+          else
+            leverx = 0;
+        }
+      }
+
+      // Update the history. If the point lies between crystals, the closest one
+      // is returned
+      std::copy(SS, SS + 4, history);
+
+      counter++;
+      if (counter == 10) {
+        leverx = 0;
+        levery = 0;
+      }
     }
-
+    // D.K. if point lies netween cells, take a closest cell.
+    return DetId(myCell);
+  } catch (cms::Exception& e) {
+    return DetId(0);
+  }
 }
 
-CaloSubdetectorGeometry::DetIdSet 
-EcalBarrelGeometry::getCells( const GlobalPoint& r, 
-			      double             dR ) const
-{
-   constexpr int maxphi ( EBDetId::MAX_IPHI ) ;
-   constexpr int maxeta ( EBDetId::MAX_IETA ) ;
-   constexpr float scale( maxphi/(2*M_PI) ) ; // angle to index
+CaloSubdetectorGeometry::DetIdSet EcalBarrelGeometry::getCells(const GlobalPoint& r, double dR) const {
+  constexpr int maxphi(EBDetId::MAX_IPHI);
+  constexpr int maxeta(EBDetId::MAX_IETA);
+  constexpr float scale(maxphi / (2 * M_PI));  // angle to index
 
-   CaloSubdetectorGeometry::DetIdSet dis;  // this is the return object
+  CaloSubdetectorGeometry::DetIdSet dis;  // this is the return object
 
-   if( 0.000001 < dR )
-   {
-      if( dR > M_PI/2. ) // this version needs "small" dR
+  if (0.000001 < dR) {
+    if (dR > M_PI / 2.)  // this version needs "small" dR
+    {
+      dis = CaloSubdetectorGeometry::getCells(r, dR);  // base class version
+    } else {
+      const float dR2(dR * dR);
+      const float reta(r.eta());
+      const float rz(r.z());
+      const float rphi(r.phi());
+      const float lowEta(reta - dR);
+      const float highEta(reta + dR);
+
+      if (highEta > -1.5 && lowEta < 1.5)  // in barrel
       {
-	 dis = CaloSubdetectorGeometry::getCells( r, dR ) ; // base class version
-      }
-      else
-      {
-	 const float dR2     ( dR*dR ) ;
-	 const float reta    ( r.eta() ) ;
-	 const float rz      ( r.z()   ) ;
-	 const float rphi    ( r.phi() ) ;
-	 const float lowEta  ( reta - dR ) ;
-	 const float highEta ( reta + dR ) ;
-	 
-	 if( highEta > -1.5 &&
-	     lowEta  <  1.5    ) // in barrel
-	 {
-	   const int    ieta_center ( int( reta*scale + ((rz<0)?(-1):(1))) ) ;
-	   const float phi         ( rphi<0 ? rphi + float(2*M_PI) : rphi ) ;
-	   const int    iphi_center ( int( phi*scale + 11.f ) ) ; // phi=-9.4deg is iphi=1
+        const int ieta_center(int(reta * scale + ((rz < 0) ? (-1) : (1))));
+        const float phi(rphi < 0 ? rphi + float(2 * M_PI) : rphi);
+        const int iphi_center(int(phi * scale + 11.f));  // phi=-9.4deg is iphi=1
 
-	   const float fr    ( dR*scale    ) ; // # crystal widths in dR
-	   const float frp   ( 1.08f*fr + 1.f ) ; // conservatively above fr 
-	   const float frm   ( 0.92f*fr - 1.f ) ; // conservatively below fr
-	   const int    idr   ( (int)frp        ) ; // integerize
-	   const int    idr2p ( (int)(frp*frp)     ) ;
-	   const int    idr2m ( frm > 0 ? int(frm*frm) : 0 ) ;
-	   
-	   for( int de ( -idr ) ; de <= idr ; ++de ) // over eta limits
-	     {
-	       int ieta ( de + ieta_center ) ;
-	       
-	       if( std::abs(ieta) <= maxeta &&
-		   ieta      != 0         ) // eta is in EB
-		 {
-		   const int de2 ( de*de ) ;
-		   for( int dp ( -idr ) ; dp <= idr ; ++dp )  // over phi limits
-		     {
-		       const int irange2 ( dp*dp + de2 ) ;
-		       
-		       if( irange2 <= idr2p ) // cut off corners that must be too far away
-			 {
-			   const int iphi ( ( iphi_center + dp + maxphi - 1 )%maxphi + 1 ) ;
-			   
-			   if( iphi != 0 )
-			     {
-			       const EBDetId id ( ieta, iphi ) ;
-			       
-			       bool ok ( irange2 < idr2m ) ;  // no more calculation necessary if inside this radius
-			   
-			       if( !ok ) // if not ok, then we have to test this cell for being inside cone
-				 {
-				   const CaloCellGeometry* cell(&m_cellVec[ id.denseIndex()]);
-				   const float       eta ( cell->etaPos() ) ;
-				   const float       phi ( cell->phiPos() ) ;
-				   ok = ( reco::deltaR2( eta, phi, reta, rphi ) < dR2 ) ;
-			   }
-			       if( ok ) dis.insert( id ) ;
-			     }
-			 }
-		     }
-		 }
-	     }
-	 }
-      }
-   }
-   return dis;
-}
+        const float fr(dR * scale);         // # crystal widths in dR
+        const float frp(1.08f * fr + 1.f);  // conservatively above fr
+        const float frm(0.92f * fr - 1.f);  // conservatively below fr
+        const int idr((int)frp);            // integerize
+        const int idr2p((int)(frp * frp));
+        const int idr2m(frm > 0 ? int(frm * frm) : 0);
 
-const EcalBarrelGeometry::OrderedListOfEEDetId* 
-EcalBarrelGeometry::getClosestEndcapCells( EBDetId id ) const
-{
-   OrderedListOfEEDetId* ptr ( nullptr ) ;
-   auto ptrVec = m_borderPtrVec.load(std::memory_order_acquire);
-   if(!ptrVec) {
-       if( 0 != id.rawId() ) {
-          const int iPhi     ( id.iphi() ) ;
-          const int iz       ( id.ieta()>0 ? 1 : -1 ) ;
-          const EEDetId eeid ( EEDetId::idOuterRing( iPhi, iz ) ) ;
-          const int iq ( eeid.iquadrant() ) ;
-          const int xout ( 1==iq || 4==iq ? 1 : -1 ) ;
-          const int yout ( 1==iq || 2==iq ? 1 : -1 ) ;
-          if (!m_borderMgr.load(std::memory_order_acquire)) {
-              EZMgrFL<EEDetId>* expect = nullptr;
-              auto ptrMgr = new EZMgrFL<EEDetId>( 720*9, 9 ) ;
-              bool exchanged = m_borderMgr.compare_exchange_strong(expect, ptrMgr, std::memory_order_acq_rel);
-              if(!exchanged) delete ptrMgr;
-          }
-          VecOrdListEEDetIdPtr* expect = nullptr;
-          auto ptrVec = new VecOrdListEEDetIdPtr();
-          ptrVec->reserve(720);
-          for( unsigned int i ( 0 ) ; i != 720 ; ++i )
+        for (int de(-idr); de <= idr; ++de)  // over eta limits
+        {
+          int ieta(de + ieta_center);
+
+          if (std::abs(ieta) <= maxeta && ieta != 0)  // eta is in EB
           {
-              const int kz ( 360>i ? -1 : 1 ) ;
-              const EEDetId eeid ( EEDetId::idOuterRing( i%360+1, kz ) ) ;
+            const int de2(de * de);
+            for (int dp(-idr); dp <= idr; ++dp)  // over phi limits
+            {
+              const int irange2(dp * dp + de2);
 
-              const int jx ( eeid.ix() ) ;
-              const int jy ( eeid.iy() ) ;
-
-              OrderedListOfEEDetId& olist ( *new OrderedListOfEEDetId( m_borderMgr.load(std::memory_order_acquire) ) );
-              int il ( 0 ) ;
-
-              for( unsigned int k ( 1 ) ; k <= 25 ; ++k )
+              if (irange2 <= idr2p)  // cut off corners that must be too far away
               {
-                 const int kx ( 1==k || 2==k || 3==k || 12==k || 13==k ? 0 :
-                        ( 4==k || 6==k || 8==k || 15==k || 20==k ? 1 :
-                      ( 5==k || 7==k || 9==k || 16==k || 19==k ? -1 :
-                        ( 10==k || 14==k || 21==k || 22==k || 25==k ? 2 : -2 )))) ;
-                 const int ky ( 1==k || 4==k || 5==k || 10==k || 11==k ? 0 :
-                        ( 2==k || 6==k || 7==k || 14==k || 17==k ? 1 :
-                      ( 3==k || 8==k || 9==k || 18==k || 21==k ? -1 :
-                        ( 12==k || 15==k || 16==k || 22==k || 23==k ? 2 : -2 )))) ;
+                const int iphi((iphi_center + dp + maxphi - 1) % maxphi + 1);
 
-                 if( 8>=il && EEDetId::validDetId( jx + kx*xout ,
-                               jy + ky*yout , kz ) )
-                 {
-                    olist[il++]=EEDetId( jx + kx*xout, jy + ky*yout, kz ) ;
-                 }
+                if (iphi != 0) {
+                  const EBDetId id(ieta, iphi);
+
+                  bool ok(irange2 < idr2m);  // no more calculation necessary if inside this radius
+
+                  if (!ok)  // if not ok, then we have to test this cell for being inside cone
+                  {
+                    const CaloCellGeometry* cell(&m_cellVec[id.denseIndex()]);
+                    const float eta(cell->etaPos());
+                    const float phi(cell->phiPos());
+                    ok = (reco::deltaR2(eta, phi, reta, rphi) < dR2);
+                  }
+                  if (ok)
+                    dis.insert(id);
+                }
               }
-              ptrVec->emplace_back( &olist ) ;
+            }
           }
-          bool exchanged = m_borderPtrVec.compare_exchange_strong(expect, ptrVec, std::memory_order_acq_rel);
-          if(!exchanged) delete ptrVec;
-          ptrVec = m_borderPtrVec.load(std::memory_order_acquire);
-          ptr = (*ptrVec)[iPhi - 1 + ( 0>iz ? 0 : 360 )];
-       }
-   }
-   return ptr;
-}
-
-void
-EcalBarrelGeometry::localCorners( Pt3DVec&        lc  ,
-				  const CCGFloat* pv  , 
-				  unsigned int    i   ,
-				  Pt3D&           ref   )
-{
-   const bool negz ( EBDetId::kSizeForDenseIndexing/2 >  i ) ;
-   const bool odd  ( 1 == i%2 ) ;
-
-   if( ( ( negz  && !odd ) ||
-	 ( !negz && odd  )    ) )
-   {
-      TruncatedPyramid::localCornersReflection( lc, pv, ref ) ;
-   }
-   else
-   {
-      TruncatedPyramid::localCornersSwap( lc, pv, ref ) ;
-   }
-}
-
-void
-EcalBarrelGeometry::newCell( const GlobalPoint& f1 ,
-			     const GlobalPoint& f2 ,
-			     const GlobalPoint& f3 ,
-			     const CCGFloat*    parm ,
-			     const DetId&       detId   ) 
-{
-   const unsigned int cellIndex ( EBDetId( detId ).denseIndex() ) ;
-   m_cellVec[ cellIndex ] =
-      TruncatedPyramid( cornersMgr(), f1, f2, f3, parm ) ;
-   addValidID( detId ) ;
-}
-
-CCGFloat 
-EcalBarrelGeometry::avgRadiusXYFrontFaceCenter() const
-{
-   if(!m_check.load(std::memory_order_acquire))
-   {
-      CCGFloat sum ( 0 ) ;
-      for( uint32_t i ( 0 ) ; i != m_cellVec.size() ; ++i )
-      {
-	 auto cell ( cellGeomPtr(i) ) ;
-	 if( nullptr != cell )
-	 {
-	    const GlobalPoint& pos ( cell->getPosition() ) ;
-	    sum += pos.perp() ;
-	 }
+        }
       }
-      m_radius = sum/m_cellVec.size() ;
-      m_check.store(true, std::memory_order_release);
-   }
-   return m_radius ;
+    }
+  }
+  return dis;
 }
 
-const CaloCellGeometry* EcalBarrelGeometry::getGeometryRawPtr (uint32_t index) const {
+const EcalBarrelGeometry::OrderedListOfEEDetId* EcalBarrelGeometry::getClosestEndcapCells(EBDetId id) const {
+  OrderedListOfEEDetId* ptr(nullptr);
+  auto ptrVec = m_borderPtrVec.load(std::memory_order_acquire);
+  if (!ptrVec) {
+    if (0 != id.rawId()) {
+      const int iPhi(id.iphi());
+      const int iz(id.ieta() > 0 ? 1 : -1);
+      const EEDetId eeid(EEDetId::idOuterRing(iPhi, iz));
+      const int iq(eeid.iquadrant());
+      const int xout(1 == iq || 4 == iq ? 1 : -1);
+      const int yout(1 == iq || 2 == iq ? 1 : -1);
+      if (!m_borderMgr.load(std::memory_order_acquire)) {
+        EZMgrFL<EEDetId>* expect = nullptr;
+        auto ptrMgr = new EZMgrFL<EEDetId>(720 * 9, 9);
+        bool exchanged = m_borderMgr.compare_exchange_strong(expect, ptrMgr, std::memory_order_acq_rel);
+        if (!exchanged)
+          delete ptrMgr;
+      }
+      VecOrdListEEDetIdPtr* expect = nullptr;
+      auto ptrVec = new VecOrdListEEDetIdPtr();
+      ptrVec->reserve(720);
+      for (unsigned int i(0); i != 720; ++i) {
+        const int kz(360 > i ? -1 : 1);
+        const EEDetId eeid(EEDetId::idOuterRing(i % 360 + 1, kz));
+
+        const int jx(eeid.ix());
+        const int jy(eeid.iy());
+
+        OrderedListOfEEDetId& olist(*new OrderedListOfEEDetId(m_borderMgr.load(std::memory_order_acquire)));
+        int il(0);
+
+        for (unsigned int k(1); k <= 25; ++k) {
+          const int kx(1 == k || 2 == k || 3 == k || 12 == k || 13 == k
+                           ? 0
+                           : (4 == k || 6 == k || 8 == k || 15 == k || 20 == k
+                                  ? 1
+                                  : (5 == k || 7 == k || 9 == k || 16 == k || 19 == k
+                                         ? -1
+                                         : (10 == k || 14 == k || 21 == k || 22 == k || 25 == k ? 2 : -2))));
+          const int ky(1 == k || 4 == k || 5 == k || 10 == k || 11 == k
+                           ? 0
+                           : (2 == k || 6 == k || 7 == k || 14 == k || 17 == k
+                                  ? 1
+                                  : (3 == k || 8 == k || 9 == k || 18 == k || 21 == k
+                                         ? -1
+                                         : (12 == k || 15 == k || 16 == k || 22 == k || 23 == k ? 2 : -2))));
+
+          if (8 >= il && EEDetId::validDetId(jx + kx * xout, jy + ky * yout, kz)) {
+            olist[il++] = EEDetId(jx + kx * xout, jy + ky * yout, kz);
+          }
+        }
+        ptrVec->emplace_back(&olist);
+      }
+      bool exchanged = m_borderPtrVec.compare_exchange_strong(expect, ptrVec, std::memory_order_acq_rel);
+      if (!exchanged)
+        delete ptrVec;
+      ptrVec = m_borderPtrVec.load(std::memory_order_acquire);
+      ptr = (*ptrVec)[iPhi - 1 + (0 > iz ? 0 : 360)];
+    }
+  }
+  return ptr;
+}
+
+void EcalBarrelGeometry::localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int i, Pt3D& ref) {
+  const bool negz(EBDetId::kSizeForDenseIndexing / 2 > i);
+  const bool odd(1 == i % 2);
+
+  if (((negz && !odd) || (!negz && odd))) {
+    TruncatedPyramid::localCornersReflection(lc, pv, ref);
+  } else {
+    TruncatedPyramid::localCornersSwap(lc, pv, ref);
+  }
+}
+
+void EcalBarrelGeometry::newCell(
+    const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId) {
+  const unsigned int cellIndex(EBDetId(detId).denseIndex());
+  m_cellVec[cellIndex] = TruncatedPyramid(cornersMgr(), f1, f2, f3, parm);
+  addValidID(detId);
+}
+
+CCGFloat EcalBarrelGeometry::avgRadiusXYFrontFaceCenter() const {
+  if (!m_check.load(std::memory_order_acquire)) {
+    CCGFloat sum(0);
+    for (uint32_t i(0); i != m_cellVec.size(); ++i) {
+      auto cell(cellGeomPtr(i));
+      if (nullptr != cell) {
+        const GlobalPoint& pos(cell->getPosition());
+        sum += pos.perp();
+      }
+    }
+    m_radius = sum / m_cellVec.size();
+    m_check.store(true, std::memory_order_release);
+  }
+  return m_radius;
+}
+
+const CaloCellGeometry* EcalBarrelGeometry::getGeometryRawPtr(uint32_t index) const {
   // Modify the RawPtr class
   const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index ||
-	  nullptr == cell->param() ? nullptr : cell);
+  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
 }
 
-bool EcalBarrelGeometry::present( const DetId& id ) const
-{
-  if(id.det()==DetId::Ecal && id.subdetId()==EcalBarrel){
+bool EcalBarrelGeometry::present(const DetId& id) const {
+  if (id.det() == DetId::Ecal && id.subdetId() == EcalBarrel) {
     EBDetId ebId(id);
-    if(EBDetId::validDetId(ebId.ieta(),ebId.iphi())) return true;
+    if (EBDetId::validDetId(ebId.ieta(), ebId.iphi()))
+      return true;
   }
   return false;
-
 }
- 

--- a/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
@@ -6,25 +6,24 @@
 #include <CLHEP/Geometry/Point3D.h>
 #include <CLHEP/Geometry/Plane3D.h>
 
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
-typedef CaloCellGeometry::Pt3D     Pt3D     ;
-typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
-typedef HepGeom::Plane3D<CCGFloat> Pl3D     ;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
+typedef CaloCellGeometry::Pt3D Pt3D;
+typedef CaloCellGeometry::Pt3DVec Pt3DVec;
+typedef HepGeom::Plane3D<CCGFloat> Pl3D;
 
-EcalEndcapGeometry::EcalEndcapGeometry( void )
-  : _nnmods( 316 ),
-    _nncrys( 25 ),
-    zeP( 0. ),
-    zeN( 0. ),
-    m_wref( 0. ),
-    m_del( 0. ),
-    m_nref( 0 ),
-    m_borderMgr( nullptr ),
-    m_borderPtrVec( nullptr ),
-    m_avgZ( -1 ),
-    m_check( false ),
-    m_cellVec( k_NumberOfCellsForCorners )
-{
+EcalEndcapGeometry::EcalEndcapGeometry(void)
+    : _nnmods(316),
+      _nncrys(25),
+      zeP(0.),
+      zeN(0.),
+      m_wref(0.),
+      m_del(0.),
+      m_nref(0),
+      m_borderMgr(nullptr),
+      m_borderPtrVec(nullptr),
+      m_avgZ(-1),
+      m_check(false),
+      m_cellVec(k_NumberOfCellsForCorners) {
   m_xlo[0] = 999.;
   m_xlo[1] = 999.;
   m_xhi[0] = -999.;
@@ -39,131 +38,126 @@ EcalEndcapGeometry::EcalEndcapGeometry( void )
   m_yoff[1] = 0.;
 }
 
-EcalEndcapGeometry::~EcalEndcapGeometry() 
-{
-  if(m_borderPtrVec)
-  {
+EcalEndcapGeometry::~EcalEndcapGeometry() {
+  if (m_borderPtrVec) {
     auto ptr = m_borderPtrVec.load(std::memory_order_acquire);
-    for(auto& v: (*ptr)) {
-        delete v;
-        v = nullptr;
+    for (auto& v : (*ptr)) {
+      delete v;
+      v = nullptr;
     }
-    delete m_borderPtrVec.load() ;
+    delete m_borderPtrVec.load();
   }
-  delete m_borderMgr.load() ;
+  delete m_borderMgr.load();
 }
 
-unsigned int
-EcalEndcapGeometry::alignmentTransformIndexLocal( const DetId& id )
-{
-   const CaloGenericDetId gid ( id ) ;
+unsigned int EcalEndcapGeometry::alignmentTransformIndexLocal(const DetId& id) {
+  const CaloGenericDetId gid(id);
 
-   assert( gid.isEE() ) ;
-   unsigned int index ( EEDetId(id).ix()/51 + ( EEDetId(id).zside()<0 ? 0 : 2 ) ) ;
+  assert(gid.isEE());
+  unsigned int index(EEDetId(id).ix() / 51 + (EEDetId(id).zside() < 0 ? 0 : 2));
 
-   return index ;
+  return index;
 }
 
-DetId 
-EcalEndcapGeometry::detIdFromLocalAlignmentIndex( unsigned int iLoc )
-{
-   return EEDetId( 20 + 50*( iLoc%2 ), 50, 2*( iLoc/2 ) - 1 ) ;
+DetId EcalEndcapGeometry::detIdFromLocalAlignmentIndex(unsigned int iLoc) {
+  return EEDetId(20 + 50 * (iLoc % 2), 50, 2 * (iLoc / 2) - 1);
 }
 
-unsigned int
-EcalEndcapGeometry::alignmentTransformIndexGlobal( const DetId& /*id*/ )
-{
-   return (unsigned int)DetId::Ecal - 1 ;
+unsigned int EcalEndcapGeometry::alignmentTransformIndexGlobal(const DetId& /*id*/) {
+  return (unsigned int)DetId::Ecal - 1;
 }
 
-void 
-EcalEndcapGeometry::initializeParms()
-{
-  zeP=0.;
-  zeN=0.;
-  unsigned nP=0;
-  unsigned nN=0;
-  m_nref = 0 ;
+void EcalEndcapGeometry::initializeParms() {
+  zeP = 0.;
+  zeN = 0.;
+  unsigned nP = 0;
+  unsigned nN = 0;
+  m_nref = 0;
 
-  for( uint32_t i ( 0 ) ; i != m_cellVec.size() ; ++i )
-  {
-     auto cell = cellGeomPtr(i);
-     if( nullptr != cell )
-     {
-	const CCGFloat z ( cell->getPosition().z() ) ;
-	if(z>0.)
-	{
-	   zeP+=z;
-	   ++nP;
-	}
-	else
-	{
-	   zeN+=z;
-	   ++nN;
-	}
-	const EEDetId myId ( EEDetId::detIdFromDenseIndex(i) ) ;
-	const unsigned int ix ( myId.ix() ) ;
-	const unsigned int iy ( myId.iy() ) ;
-	if( ix > m_nref ) m_nref = ix ;
-	if( iy > m_nref ) m_nref = iy ;
-     }
+  for (uint32_t i(0); i != m_cellVec.size(); ++i) {
+    auto cell = cellGeomPtr(i);
+    if (nullptr != cell) {
+      const CCGFloat z(cell->getPosition().z());
+      if (z > 0.) {
+        zeP += z;
+        ++nP;
+      } else {
+        zeN += z;
+        ++nN;
+      }
+      const EEDetId myId(EEDetId::detIdFromDenseIndex(i));
+      const unsigned int ix(myId.ix());
+      const unsigned int iy(myId.iy());
+      if (ix > m_nref)
+        m_nref = ix;
+      if (iy > m_nref)
+        m_nref = iy;
+    }
   }
-  if( 0 < nP ) zeP/=(CCGFloat)nP;
-  if( 0 < nN ) zeN/=(CCGFloat)nN;
+  if (0 < nP)
+    zeP /= (CCGFloat)nP;
+  if (0 < nN)
+    zeN /= (CCGFloat)nN;
 
-  m_xlo[0] =  999 ;
-  m_xhi[0] = -999 ;
-  m_ylo[0] =  999 ;
-  m_yhi[0] = -999 ;
-  m_xlo[1] =  999 ;
-  m_xhi[1] = -999 ;
-  m_ylo[1] =  999 ;
-  m_yhi[1] = -999 ;
-  for( uint32_t i ( 0 ) ; i != m_cellVec.size() ; ++i )
-  {
-     auto cell = cellGeomPtr(i);
-     if( nullptr != cell )
-     {
-	const GlobalPoint& p ( cell->getPosition()  ) ;
-	const CCGFloat z ( p.z() ) ;
-	const CCGFloat zz ( 0 > z ? zeN : zeP ) ;
-	const CCGFloat x ( p.x()*zz/z ) ;
-	const CCGFloat y ( p.y()*zz/z ) ;
+  m_xlo[0] = 999;
+  m_xhi[0] = -999;
+  m_ylo[0] = 999;
+  m_yhi[0] = -999;
+  m_xlo[1] = 999;
+  m_xhi[1] = -999;
+  m_ylo[1] = 999;
+  m_yhi[1] = -999;
+  for (uint32_t i(0); i != m_cellVec.size(); ++i) {
+    auto cell = cellGeomPtr(i);
+    if (nullptr != cell) {
+      const GlobalPoint& p(cell->getPosition());
+      const CCGFloat z(p.z());
+      const CCGFloat zz(0 > z ? zeN : zeP);
+      const CCGFloat x(p.x() * zz / z);
+      const CCGFloat y(p.y() * zz / z);
 
-	if( 0 > z && x < m_xlo[0] ) m_xlo[0] = x ;
-	if( 0 < z && x < m_xlo[1] ) m_xlo[1] = x ;
-	if( 0 > z && y < m_ylo[0] ) m_ylo[0] = y ;
-	if( 0 < z && y < m_ylo[1] ) m_ylo[1] = y ;
-     
-	if( 0 > z && x > m_xhi[0] ) m_xhi[0] = x ;
-	if( 0 < z && x > m_xhi[1] ) m_xhi[1] = x ;
-	if( 0 > z && y > m_yhi[0] ) m_yhi[0] = y ;
-	if( 0 < z && y > m_yhi[1] ) m_yhi[1] = y ;
-     }
+      if (0 > z && x < m_xlo[0])
+        m_xlo[0] = x;
+      if (0 < z && x < m_xlo[1])
+        m_xlo[1] = x;
+      if (0 > z && y < m_ylo[0])
+        m_ylo[0] = y;
+      if (0 < z && y < m_ylo[1])
+        m_ylo[1] = y;
+
+      if (0 > z && x > m_xhi[0])
+        m_xhi[0] = x;
+      if (0 < z && x > m_xhi[1])
+        m_xhi[1] = x;
+      if (0 > z && y > m_yhi[0])
+        m_yhi[0] = y;
+      if (0 < z && y > m_yhi[1])
+        m_yhi[1] = y;
+    }
   }
 
-  m_xoff[0] = ( m_xhi[0] + m_xlo[0] )/2. ;
-  m_xoff[1] = ( m_xhi[1] + m_xlo[1] )/2. ;
-  m_yoff[0] = ( m_yhi[0] + m_ylo[0] )/2. ;
-  m_yoff[1] = ( m_yhi[1] + m_ylo[1] )/2. ;
+  m_xoff[0] = (m_xhi[0] + m_xlo[0]) / 2.;
+  m_xoff[1] = (m_xhi[1] + m_xlo[1]) / 2.;
+  m_yoff[0] = (m_yhi[0] + m_ylo[0]) / 2.;
+  m_yoff[1] = (m_yhi[1] + m_ylo[1]) / 2.;
 
-  m_del = ( m_xhi[0] - m_xlo[0] + m_xhi[1] - m_xlo[1] +
-	    m_yhi[0] - m_ylo[0] + m_yhi[1] - m_ylo[1]   ) ;
+  m_del = (m_xhi[0] - m_xlo[0] + m_xhi[1] - m_xlo[1] + m_yhi[0] - m_ylo[0] + m_yhi[1] - m_ylo[1]);
 
-  if( 1 != m_nref ) m_wref = m_del/(4.*(m_nref-1)) ;
+  if (1 != m_nref)
+    m_wref = m_del / (4. * (m_nref - 1));
 
-  m_xlo[0] -= m_wref/2 ;
-  m_xlo[1] -= m_wref/2 ;
-  m_xhi[0] += m_wref/2 ;
-  m_xhi[1] += m_wref/2 ;
+  m_xlo[0] -= m_wref / 2;
+  m_xlo[1] -= m_wref / 2;
+  m_xhi[0] += m_wref / 2;
+  m_xhi[1] += m_wref / 2;
 
-  m_ylo[0] -= m_wref/2 ;
-  m_ylo[1] -= m_wref/2 ;
-  m_yhi[0] += m_wref/2 ;
-  m_yhi[1] += m_wref/2 ;
+  m_ylo[0] -= m_wref / 2;
+  m_ylo[1] -= m_wref / 2;
+  m_yhi[0] += m_wref / 2;
+  m_yhi[1] += m_wref / 2;
 
-  m_del += m_wref ;
-/*
+  m_del += m_wref;
+  /*
   std::cout<<"zeP="<<zeP<<", zeN="<<zeN<<", nP="<<nP<<", nN="<<nN<<std::endl ;
 
   std::cout<<"xlo[0]="<<m_xlo[0]<<", xlo[1]="<<m_xlo[1]<<", xhi[0]="<<m_xhi[0]<<", xhi[1]="<<m_xhi[1]
@@ -172,362 +166,292 @@ EcalEndcapGeometry::initializeParms()
   std::cout<<"xoff[0]="<<m_xoff[0]<<", xoff[1]"<<m_xoff[1]<<", yoff[0]="<<m_yoff[0]<<", yoff[1]"<<m_yoff[1]<<std::endl ;
 
   std::cout<<"nref="<<m_nref<<", m_wref="<<m_wref<<std::endl ;
-*/  
+*/
 }
 
+unsigned int EcalEndcapGeometry::xindex(CCGFloat x, CCGFloat z) const {
+  const CCGFloat xlo(0 > z ? m_xlo[0] : m_xlo[1]);
+  const int i(1 + int((x - xlo) / m_wref));
 
-unsigned int 
-EcalEndcapGeometry::xindex( CCGFloat x,
-			    CCGFloat z ) const
-{
-   const CCGFloat xlo ( 0 > z ? m_xlo[0]  : m_xlo[1]  ) ;
-   const int i ( 1 + int( ( x - xlo )/m_wref ) ) ;
-
-   return ( 1 > i ? 1 :
-	    ( m_nref < (unsigned int) i ? m_nref : (unsigned int) i ) ) ;
-
+  return (1 > i ? 1 : (m_nref < (unsigned int)i ? m_nref : (unsigned int)i));
 }
 
-unsigned int 
-EcalEndcapGeometry::yindex( CCGFloat y,
-			    CCGFloat z  ) const
-{
-   const CCGFloat ylo ( 0 > z ? m_ylo[0]  : m_ylo[1]  ) ;
-   const int i ( 1 + int( ( y - ylo )/m_wref ) ) ;
+unsigned int EcalEndcapGeometry::yindex(CCGFloat y, CCGFloat z) const {
+  const CCGFloat ylo(0 > z ? m_ylo[0] : m_ylo[1]);
+  const int i(1 + int((y - ylo) / m_wref));
 
-   return ( 1 > i ? 1 :
-	    ( m_nref < (unsigned int) i ? m_nref : (unsigned int) i ) ) ;
+  return (1 > i ? 1 : (m_nref < (unsigned int)i ? m_nref : (unsigned int)i));
 }
 
-EEDetId 
-EcalEndcapGeometry::gId( float x, 
-			 float y, 
-			 float z ) const
-{
-   const CCGFloat     fac ( fabs( ( 0 > z ? zeN : zeP )/z ) ) ;
-   const unsigned int ix  ( xindex( x*fac, z ) ) ; 
-   const unsigned int iy  ( yindex( y*fac, z ) ) ; 
-   const unsigned int iz  ( z>0 ? 1 : -1 ) ;
+EEDetId EcalEndcapGeometry::gId(float x, float y, float z) const {
+  const CCGFloat fac(fabs((0 > z ? zeN : zeP) / z));
+  const unsigned int ix(xindex(x * fac, z));
+  const unsigned int iy(yindex(y * fac, z));
+  const unsigned int iz(z > 0 ? 1 : -1);
 
-   if( EEDetId::validDetId( ix, iy, iz ) ) 
-   {
-      return EEDetId( ix, iy, iz ) ; // first try is on target
-   }
-   else // try nearby coordinates, spiraling out from center
-   {
-      for( unsigned int i ( 1 ) ; i != 6 ; ++i )
-      {
-	 for( unsigned int k ( 0 ) ; k != 8 ; ++k )
-	 {
-	    const int jx ( 0 == k || 4 == k || 5 == k ? +i :
-			   ( 1 == k || 5 < k ? -i : 0 ) ) ;
-	    const int jy ( 2 == k || 4 == k || 6 == k ? +i :
-			   ( 3 == k || 5 == k || 7 == k ? -i : 0 ) ) ;
-	    if( EEDetId::validDetId( ix + jx, iy + jy, iz ) ) 
-	    {
-	       return EEDetId( ix + jx, iy + jy, iz ) ;
-	    }
-	 }
+  if (EEDetId::validDetId(ix, iy, iz)) {
+    return EEDetId(ix, iy, iz);  // first try is on target
+  } else                         // try nearby coordinates, spiraling out from center
+  {
+    for (unsigned int i(1); i != 6; ++i) {
+      for (unsigned int k(0); k != 8; ++k) {
+        const int jx(0 == k || 4 == k || 5 == k ? +i : (1 == k || 5 < k ? -i : 0));
+        const int jy(2 == k || 4 == k || 6 == k ? +i : (3 == k || 5 == k || 7 == k ? -i : 0));
+        if (EEDetId::validDetId(ix + jx, iy + jy, iz)) {
+          return EEDetId(ix + jx, iy + jy, iz);
+        }
       }
-   }
-   return EEDetId() ; // nowhere near any crystal
+    }
+  }
+  return EEDetId();  // nowhere near any crystal
 }
-
 
 // Get closest cell, etc...
-DetId 
-EcalEndcapGeometry::getClosestCell( const GlobalPoint& r ) const
-{
-   try
-   {
-      EEDetId mycellID ( gId( r.x(), r.y(), r.z() ) ) ; // educated guess
+DetId EcalEndcapGeometry::getClosestCell(const GlobalPoint& r) const {
+  try {
+    EEDetId mycellID(gId(r.x(), r.y(), r.z()));  // educated guess
 
-      if( EEDetId::validDetId( mycellID.ix(), 
-			       mycellID.iy(),
-			       mycellID.zside() ) )
-      {
-	 // now get points in convenient ordering
+    if (EEDetId::validDetId(mycellID.ix(), mycellID.iy(), mycellID.zside())) {
+      // now get points in convenient ordering
 
-	 Pt3D A;
-	 Pt3D B;
-	 Pt3D C;
-	 Pt3D point(r.x(),r.y(),r.z());
-	 // D.K. : equation of plane : AA*x+BB*y+CC*z+DD=0;
-	 // finding equation for each edge
-	 
-	 // ================================================================
-	 CCGFloat x,y,z;
-	 unsigned offset=0;
-	 int zsign=1;
-	 //================================================================
-      
-	 // compute the distance of the point with respect of the 4 crystal lateral planes
+      Pt3D A;
+      Pt3D B;
+      Pt3D C;
+      Pt3D point(r.x(), r.y(), r.z());
+      // D.K. : equation of plane : AA*x+BB*y+CC*z+DD=0;
+      // finding equation for each edge
 
-	 
-	 if( nullptr != getGeometry(mycellID) )
-	 {
-	    const GlobalPoint& myPosition=getGeometry(mycellID)->getPosition();
-	 
-	    x=myPosition.x();
-	    y=myPosition.y();
-	    z=myPosition.z();
-	 
-	    offset=0;
-	    // This will disappear when Andre has applied his fix
-	 
-	    if(z>0)
-	    {
-	       if(x>0&&y>0)
-		  offset=1;
-	       else  if(x<0&&y>0)
-		  offset=2;
-	       else if(x>0&&y<0)
-		  offset=0;
-	       else if (x<0&&y<0)
-		  offset=3;
-	       zsign=1;
-	    }
-	    else
-	    {
-	       if(x>0&&y>0)
-		  offset=3;
-	       else if(x<0&&y>0)
-		  offset=2;
-	       else if(x>0&&y<0)
-		  offset=0;
-	       else if(x<0&&y<0)
-		  offset=1;
-	       zsign=-1;
-	    }
-	    GlobalPoint corners[8];
-	    for(unsigned ic=0;ic<4;++ic)
-	    {
-	       corners[ic]=getGeometry(mycellID)->getCorners()[(unsigned)((zsign*ic+offset)%4)];
-	       corners[4+ic]=getGeometry(mycellID)->getCorners()[(unsigned)(4+(zsign*ic+offset)%4)];
-	    }
+      // ================================================================
+      CCGFloat x, y, z;
+      unsigned offset = 0;
+      int zsign = 1;
+      //================================================================
 
-	    CCGFloat SS[4];
-	    for (short i=0; i < 4 ; ++i)
-	    {
-	       A = Pt3D(corners[i%4].x(),corners[i%4].y(),corners[i%4].z());
-	       B = Pt3D(corners[(i+1)%4].x(),corners[(i+1)%4].y(),corners[(i+1)%4].z());
-	       C = Pt3D(corners[4+(i+1)%4].x(),corners[4+(i+1)%4].y(),corners[4+(i+1)%4].z());
-	       Pl3D plane(A,B,C);
-	       plane.normalize();
-	       CCGFloat distance = plane.distance(point);
-	       if (corners[0].z()<0.) distance=-distance;
-	       SS[i] = distance;
-	    }
-	 
-	    // Only one move in necessary direction
-	 
-	    const bool yout ( 0 > SS[0]*SS[2] ) ;
-	    const bool xout ( 0 > SS[1]*SS[3] ) ;
-	 
-	    if( yout || xout )
-	    {
-	       const int ydel ( !yout ? 0 :  ( 0 < SS[0] ? -1 : 1 ) ) ;
-	       const int xdel ( !xout ? 0 :  ( 0 < SS[1] ? -1 : 1 ) ) ;
-	       const unsigned int ix ( mycellID.ix() + xdel ) ;
-	       const unsigned int iy ( mycellID.iy() + ydel ) ;
-	       const unsigned int iz ( mycellID.zside()     ) ;
-	       if( EEDetId::validDetId( ix, iy, iz ) ) 
-		  mycellID = EEDetId( ix, iy, iz ) ;
-	    }
-  
-	    return mycellID;
-	 }
-	 return DetId(0);
+      // compute the distance of the point with respect of the 4 crystal lateral planes
+
+      if (nullptr != getGeometry(mycellID)) {
+        const GlobalPoint& myPosition = getGeometry(mycellID)->getPosition();
+
+        x = myPosition.x();
+        y = myPosition.y();
+        z = myPosition.z();
+
+        offset = 0;
+        // This will disappear when Andre has applied his fix
+
+        if (z > 0) {
+          if (x > 0 && y > 0)
+            offset = 1;
+          else if (x < 0 && y > 0)
+            offset = 2;
+          else if (x > 0 && y < 0)
+            offset = 0;
+          else if (x < 0 && y < 0)
+            offset = 3;
+          zsign = 1;
+        } else {
+          if (x > 0 && y > 0)
+            offset = 3;
+          else if (x < 0 && y > 0)
+            offset = 2;
+          else if (x > 0 && y < 0)
+            offset = 0;
+          else if (x < 0 && y < 0)
+            offset = 1;
+          zsign = -1;
+        }
+        GlobalPoint corners[8];
+        for (unsigned ic = 0; ic < 4; ++ic) {
+          corners[ic] = getGeometry(mycellID)->getCorners()[(unsigned)((zsign * ic + offset) % 4)];
+          corners[4 + ic] = getGeometry(mycellID)->getCorners()[(unsigned)(4 + (zsign * ic + offset) % 4)];
+        }
+
+        CCGFloat SS[4];
+        for (short i = 0; i < 4; ++i) {
+          A = Pt3D(corners[i % 4].x(), corners[i % 4].y(), corners[i % 4].z());
+          B = Pt3D(corners[(i + 1) % 4].x(), corners[(i + 1) % 4].y(), corners[(i + 1) % 4].z());
+          C = Pt3D(corners[4 + (i + 1) % 4].x(), corners[4 + (i + 1) % 4].y(), corners[4 + (i + 1) % 4].z());
+          Pl3D plane(A, B, C);
+          plane.normalize();
+          CCGFloat distance = plane.distance(point);
+          if (corners[0].z() < 0.)
+            distance = -distance;
+          SS[i] = distance;
+        }
+
+        // Only one move in necessary direction
+
+        const bool yout(0 > SS[0] * SS[2]);
+        const bool xout(0 > SS[1] * SS[3]);
+
+        if (yout || xout) {
+          const int ydel(!yout ? 0 : (0 < SS[0] ? -1 : 1));
+          const int xdel(!xout ? 0 : (0 < SS[1] ? -1 : 1));
+          const unsigned int ix(mycellID.ix() + xdel);
+          const unsigned int iy(mycellID.iy() + ydel);
+          const unsigned int iz(mycellID.zside());
+          if (EEDetId::validDetId(ix, iy, iz))
+            mycellID = EEDetId(ix, iy, iz);
+        }
+
+        return mycellID;
       }
-   }
-   catch ( cms::Exception &e ) 
-   { 
       return DetId(0);
-   }
-   return DetId(0);
+    }
+  } catch (cms::Exception& e) {
+    return DetId(0);
+  }
+  return DetId(0);
 }
 
-CaloSubdetectorGeometry::DetIdSet 
-EcalEndcapGeometry::getCells( const GlobalPoint& r, 
-			      double             dR ) const
-{
-   CaloSubdetectorGeometry::DetIdSet dis ; // return object
-   if( 0.000001 < dR )
-   {
-     if( dR > M_PI/2. ) // this code assumes small dR
-      {
-	 dis = CaloSubdetectorGeometry::getCells( r, dR ) ; // base class version
+CaloSubdetectorGeometry::DetIdSet EcalEndcapGeometry::getCells(const GlobalPoint& r, double dR) const {
+  CaloSubdetectorGeometry::DetIdSet dis;  // return object
+  if (0.000001 < dR) {
+    if (dR > M_PI / 2.)  // this code assumes small dR
+    {
+      dis = CaloSubdetectorGeometry::getCells(r, dR);  // base class version
+    } else {
+      const float dR2(dR * dR);
+      const float reta(r.eta());
+      const float rphi(r.phi());
+      const float rx(r.x());
+      const float ry(r.y());
+      const float rz(r.z());
+      const float fac(std::abs(zeP / rz));
+      const float xx(rx * fac);  // xyz at endcap z
+      const float yy(ry * fac);
+      const float zz(rz * fac);
+
+      const float xang(std::atan(xx / zz));
+      const float lowX(zz > 0 ? zz * std::tan(xang - dR) : zz * std::tan(xang + dR));
+      const float highX(zz > 0 ? zz * std::tan(xang + dR) : zz * std::tan(xang - dR));
+      const float yang(std::atan(yy / zz));
+      const float lowY(zz > 0 ? zz * std::tan(yang - dR) : zz * std::tan(yang + dR));
+      const float highY(zz > 0 ? zz * std::tan(yang + dR) : zz * std::tan(yang - dR));
+
+      const float refxlo(0 > rz ? m_xlo[0] : m_xlo[1]);
+      const float refxhi(0 > rz ? m_xhi[0] : m_xhi[1]);
+      const float refylo(0 > rz ? m_ylo[0] : m_ylo[1]);
+      const float refyhi(0 > rz ? m_yhi[0] : m_yhi[1]);
+
+      if (lowX < refxhi &&  // proceed if any possible overlap with the endcap
+          lowY < refyhi && highX > refxlo && highY > refylo) {
+        const int ix_ctr(xindex(xx, rz));
+        const int iy_ctr(yindex(yy, rz));
+        const int iz(rz > 0 ? 1 : -1);
+
+        const int ix_hi(ix_ctr + int((highX - xx) / m_wref) + 2);
+        const int ix_lo(ix_ctr - int((xx - lowX) / m_wref) - 2);
+
+        const int iy_hi(iy_ctr + int((highY - yy) / m_wref) + 2);
+        const int iy_lo(iy_ctr - int((yy - lowY) / m_wref) - 2);
+
+        for (int kx(ix_lo); kx <= ix_hi; ++kx) {
+          if (kx > 0 && kx <= (int)m_nref) {
+            for (int ky(iy_lo); ky <= iy_hi; ++ky) {
+              if (ky > 0 && ky <= (int)m_nref) {
+                if (EEDetId::validDetId(kx, ky, iz))  // reject invalid ids
+                {
+                  const EEDetId id(kx, ky, iz);
+                  const CaloCellGeometry* cell(&m_cellVec[id.denseIndex()]);
+                  const float eta(cell->etaPos());
+                  const float phi(cell->phiPos());
+                  if (reco::deltaR2(eta, phi, reta, rphi) < dR2)
+                    dis.insert(id);
+                }
+              }
+            }
+          }
+        }
       }
-      else
-      {
-	 const float dR2  ( dR*dR ) ;
-	 const float reta ( r.eta() ) ;
-	 const float rphi ( r.phi() ) ;
-	 const float rx   ( r.x() ) ;
-	 const float ry   ( r.y() ) ;
-	 const float rz   ( r.z() ) ;
-	 const float fac  ( std::abs( zeP/rz ) ) ;
-	 const float xx   ( rx*fac ) ; // xyz at endcap z
-	 const float yy   ( ry*fac ) ; 
-	 const float zz   ( rz*fac ) ; 
+    }
+  }
+  return dis;
+}
 
-	 const float xang  ( std::atan( xx/zz ) ) ;
-	 const float lowX  ( zz>0 ? zz*std::tan( xang - dR ) : zz*std::tan( xang + dR ) ) ;
-	 const float highX ( zz>0 ? zz*std::tan( xang + dR ) : zz*std::tan( xang - dR ) ) ;
-	 const float yang  ( std::atan( yy/zz ) ) ;
-	 const float lowY  ( zz>0 ? zz*std::tan( yang - dR ) : zz*std::tan( yang + dR ) ) ;
-	 const float highY ( zz>0 ? zz*std::tan( yang + dR ) : zz*std::tan( yang - dR ) ) ;
-
-	 const float refxlo ( 0 > rz ? m_xlo[0] : m_xlo[1] ) ;
-	 const float refxhi ( 0 > rz ? m_xhi[0] : m_xhi[1] ) ;
-	 const float refylo ( 0 > rz ? m_ylo[0] : m_ylo[1] ) ;
-	 const float refyhi ( 0 > rz ? m_yhi[0] : m_yhi[1] ) ;
-
-	 if( lowX  <  refxhi &&   // proceed if any possible overlap with the endcap
-	     lowY  <  refyhi &&
-	     highX >  refxlo &&
-	     highY >  refylo    )
-	 {
-	    const int ix_ctr ( xindex( xx, rz ) ) ;
-	    const int iy_ctr ( yindex( yy, rz ) ) ;
-	    const int iz     ( rz>0 ? 1 : -1 ) ;
-	    
-	    const int ix_hi  ( ix_ctr + int( ( highX - xx )/m_wref ) + 2 ) ;
-	    const int ix_lo  ( ix_ctr - int( ( xx - lowX  )/m_wref ) - 2 ) ;
-	    
-	    const int iy_hi  ( iy_ctr + int( ( highY - yy )/m_wref ) + 2 ) ;
-	    const int iy_lo  ( iy_ctr - int( ( yy - lowY  )/m_wref ) - 2 ) ;
-	    
-	    for( int kx ( ix_lo ) ; kx <= ix_hi ; ++kx ) 
-	    {
-	       if( kx >  0      && 
-		   kx <= (int) m_nref    )
-	       {
-		  for( int ky ( iy_lo ) ; ky <= iy_hi ; ++ky ) 
-		  {
-		     if( ky >  0      && 
-			 ky <= (int) m_nref    )
-		     {
-			if( EEDetId::validDetId( kx, ky, iz ) ) // reject invalid ids
-			{
-			  const EEDetId id ( kx, ky, iz ) ;
-			  const CaloCellGeometry* cell(&m_cellVec[id.denseIndex()]);
-			  const float       eta  (cell->etaPos() ) ;
-			  const float       phi  (cell->phiPos() ) ;
-			  if( reco::deltaR2( eta, phi, reta, rphi ) < dR2 ) dis.insert( id ) ;
-			}
-		     }
-		  }
-	       }
-	    }
-	 }
+const EcalEndcapGeometry::OrderedListOfEBDetId* EcalEndcapGeometry::getClosestBarrelCells(EEDetId id) const {
+  OrderedListOfEBDetId* ptr(nullptr);
+  auto ptrVec = m_borderPtrVec.load(std::memory_order_acquire);
+  if (!ptrVec) {
+    if (0 != id.rawId() && nullptr != getGeometry(id)) {
+      const float phi(370. + getGeometry(id)->getPosition().phi().degrees());
+      const int iPhi(1 + int(phi) % 360);
+      const int iz(id.zside());
+      if (!m_borderMgr.load(std::memory_order_acquire)) {
+        EZMgrFL<EBDetId>* expect = nullptr;
+        auto ptrMgr = new EZMgrFL<EBDetId>(720 * 9, 9);
+        bool exchanged = m_borderMgr.compare_exchange_strong(expect, ptrMgr, std::memory_order_acq_rel);
+        if (!exchanged)
+          delete ptrMgr;
       }
-   }
-   return dis;
-}
-
-const EcalEndcapGeometry::OrderedListOfEBDetId*
-EcalEndcapGeometry::getClosestBarrelCells( EEDetId id ) const
-{
-   OrderedListOfEBDetId* ptr ( nullptr ) ;
-   auto ptrVec = m_borderPtrVec.load(std::memory_order_acquire);
-   if(!ptrVec) {
-       if(0 != id.rawId() && nullptr != getGeometry(id)) {
-           const float phi(370.+getGeometry(id)->getPosition().phi().degrees());
-           const int iPhi(1+int(phi)%360) ;
-           const int iz(id.zside()) ;
-           if (!m_borderMgr.load(std::memory_order_acquire)) {
-               EZMgrFL<EBDetId>* expect = nullptr;
-               auto ptrMgr = new EZMgrFL<EBDetId>( 720*9, 9 );
-               bool exchanged = m_borderMgr.compare_exchange_strong(expect, ptrMgr, std::memory_order_acq_rel);
-               if(!exchanged) delete ptrMgr;
-           }
-           VecOrdListEBDetIdPtr* expect = nullptr;
-           auto ptrVec = new VecOrdListEBDetIdPtr();
-           ptrVec->reserve(720);
-           for( unsigned int i ( 0 ) ; i != 720 ; ++i )
-           {
-               const int kz     ( 360>i ? -1 : 1 ) ;
-               const int iEta   ( kz*85 ) ;
-               const int iEtam1 ( kz*84 ) ;
-               const int iEtam2 ( kz*83 ) ;
-               const int jPhi   ( i%360 + 1 ) ;
-               OrderedListOfEBDetId& olist ( *new OrderedListOfEBDetId( m_borderMgr.load(std::memory_order_acquire) ) );
-               olist[0]=EBDetId( iEta  ,        jPhi     ) ;
-               olist[1]=EBDetId( iEta  , myPhi( jPhi+1 ) ) ;
-               olist[2]=EBDetId( iEta  , myPhi( jPhi-1 ) ) ;
-               olist[3]=EBDetId( iEtam1,        jPhi     ) ;
-               olist[4]=EBDetId( iEtam1, myPhi( jPhi+1 ) ) ;
-               olist[5]=EBDetId( iEtam1, myPhi( jPhi-1 ) ) ;
-               olist[6]=EBDetId( iEta  , myPhi( jPhi+2 ) ) ;
-               olist[7]=EBDetId( iEta  , myPhi( jPhi-2 ) ) ;
-               olist[8]=EBDetId( iEtam2,        jPhi     ) ;
-               ptrVec->emplace_back( &olist ) ;
-           }
-           bool exchanged = m_borderPtrVec.compare_exchange_strong(expect, ptrVec, std::memory_order_acq_rel);
-           if(!exchanged) delete ptrVec;
-           ptrVec = m_borderPtrVec.load(std::memory_order_acquire);
-           ptr = (*ptrVec)[ ( iPhi - 1 ) + ( 0>iz ? 0 : 360 ) ] ;
-       }
-   }
-   return ptr;
-}
-
-void
-EcalEndcapGeometry::localCorners( Pt3DVec&        lc  ,
-				  const CCGFloat* pv  ,
-				  unsigned int   /*i*/,
-				  Pt3D&           ref   )
-{
-   TruncatedPyramid::localCorners( lc, pv, ref ) ;
-}
-
-void
-EcalEndcapGeometry::newCell( const GlobalPoint& f1 ,
-			     const GlobalPoint& f2 ,
-			     const GlobalPoint& f3 ,
-			     const CCGFloat*    parm ,
-			     const DetId&       detId   ) 
-{
-   const unsigned int cellIndex ( EEDetId( detId ).denseIndex() ) ;
-   m_cellVec[ cellIndex ] =
-      TruncatedPyramid( cornersMgr(), f1, f2, f3, parm ) ;
-   addValidID( detId ) ;
-}
-
-
-CCGFloat 
-EcalEndcapGeometry::avgAbsZFrontFaceCenter() const
-{
-   if(!m_check.load(std::memory_order_acquire))
-   {
-      CCGFloat sum ( 0 ) ;
-      for( unsigned int i ( 0 ) ; i != m_cellVec.size() ; ++i )
-      {
-	 auto cell = cellGeomPtr(i);
-	 if( nullptr != cell )
-	 {
-	    sum += fabs( cell->getPosition().z() ) ;
-	 }
+      VecOrdListEBDetIdPtr* expect = nullptr;
+      auto ptrVec = new VecOrdListEBDetIdPtr();
+      ptrVec->reserve(720);
+      for (unsigned int i(0); i != 720; ++i) {
+        const int kz(360 > i ? -1 : 1);
+        const int iEta(kz * 85);
+        const int iEtam1(kz * 84);
+        const int iEtam2(kz * 83);
+        const int jPhi(i % 360 + 1);
+        OrderedListOfEBDetId& olist(*new OrderedListOfEBDetId(m_borderMgr.load(std::memory_order_acquire)));
+        olist[0] = EBDetId(iEta, jPhi);
+        olist[1] = EBDetId(iEta, myPhi(jPhi + 1));
+        olist[2] = EBDetId(iEta, myPhi(jPhi - 1));
+        olist[3] = EBDetId(iEtam1, jPhi);
+        olist[4] = EBDetId(iEtam1, myPhi(jPhi + 1));
+        olist[5] = EBDetId(iEtam1, myPhi(jPhi - 1));
+        olist[6] = EBDetId(iEta, myPhi(jPhi + 2));
+        olist[7] = EBDetId(iEta, myPhi(jPhi - 2));
+        olist[8] = EBDetId(iEtam2, jPhi);
+        ptrVec->emplace_back(&olist);
       }
-      m_avgZ = sum/m_cellVec.size();
-      m_check.store(true, std::memory_order_release);
-   }
-   return m_avgZ;
+      bool exchanged = m_borderPtrVec.compare_exchange_strong(expect, ptrVec, std::memory_order_acq_rel);
+      if (!exchanged)
+        delete ptrVec;
+      ptrVec = m_borderPtrVec.load(std::memory_order_acquire);
+      ptr = (*ptrVec)[(iPhi - 1) + (0 > iz ? 0 : 360)];
+    }
+  }
+  return ptr;
+}
+
+void EcalEndcapGeometry::localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int /*i*/, Pt3D& ref) {
+  TruncatedPyramid::localCorners(lc, pv, ref);
+}
+
+void EcalEndcapGeometry::newCell(
+    const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId) {
+  const unsigned int cellIndex(EEDetId(detId).denseIndex());
+  m_cellVec[cellIndex] = TruncatedPyramid(cornersMgr(), f1, f2, f3, parm);
+  addValidID(detId);
+}
+
+CCGFloat EcalEndcapGeometry::avgAbsZFrontFaceCenter() const {
+  if (!m_check.load(std::memory_order_acquire)) {
+    CCGFloat sum(0);
+    for (unsigned int i(0); i != m_cellVec.size(); ++i) {
+      auto cell = cellGeomPtr(i);
+      if (nullptr != cell) {
+        sum += fabs(cell->getPosition().z());
+      }
+    }
+    m_avgZ = sum / m_cellVec.size();
+    m_check.store(true, std::memory_order_release);
+  }
+  return m_avgZ;
 }
 
 const CaloCellGeometry* EcalEndcapGeometry::getGeometryRawPtr(uint32_t index) const {
   // Modify the RawPtr class
   const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index ||
-	  nullptr == cell->param() ? nullptr : cell);
+  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
 }
 
-bool EcalEndcapGeometry::present( const DetId& id ) const
-{
-  if(id.det()==DetId::Ecal && id.subdetId()==EcalEndcap){
+bool EcalEndcapGeometry::present(const DetId& id) const {
+  if (id.det() == DetId::Ecal && id.subdetId() == EcalEndcap) {
     EEDetId eeId(id);
-    if(EEDetId::validDetId(eeId.ix(),eeId.iy(),eeId.zside())) return true;
+    if (EEDetId::validDetId(eeId.ix(), eeId.iy(), eeId.zside()))
+      return true;
   }
   return false;
 }

--- a/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
@@ -5,260 +5,198 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include <iostream>
 
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
-typedef CaloCellGeometry::Pt3D     Pt3D     ;
-typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
-typedef HepGeom::Plane3D<CCGFloat> Pl3D     ;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
+typedef CaloCellGeometry::Pt3D Pt3D;
+typedef CaloCellGeometry::Pt3DVec Pt3DVec;
+typedef HepGeom::Plane3D<CCGFloat> Pl3D;
 
-EcalPreshowerGeometry::EcalPreshowerGeometry() :
-   m_xWidWaf      ( 6.3  ) ,
-   m_xInterLadGap ( 0.05 ) , // additional gap between wafers in adj ladders
-   m_xIntraLadGap ( 0.04 ) , // gap between wafers in same ladder
-   m_yWidAct      ( 6.1  ) ,
-   m_yCtrOff      ( 0.05 ) ,  // gap at center
-   m_cellVec      ( k_NumberOfCellsForCorners )
-{
-  m_zplane[0] = 0. ;
-  m_zplane[1] = 0. ;
-  m_zplane[2] = 0. ;
-  m_zplane[3] = 0. ;
+EcalPreshowerGeometry::EcalPreshowerGeometry()
+    : m_xWidWaf(6.3),
+      m_xInterLadGap(0.05),  // additional gap between wafers in adj ladders
+      m_xIntraLadGap(0.04),  // gap between wafers in same ladder
+      m_yWidAct(6.1),
+      m_yCtrOff(0.05),  // gap at center
+      m_cellVec(k_NumberOfCellsForCorners) {
+  m_zplane[0] = 0.;
+  m_zplane[1] = 0.;
+  m_zplane[2] = 0.;
+  m_zplane[3] = 0.;
 }
 
+EcalPreshowerGeometry::~EcalPreshowerGeometry() {}
 
-EcalPreshowerGeometry::~EcalPreshowerGeometry()
-{
+unsigned int EcalPreshowerGeometry::alignmentTransformIndexLocal(const DetId& id) {
+  const CaloGenericDetId gid(id);
+
+  assert(gid.isES());
+
+  // plane 2 is split into 2 dees along x=0 for both signs of z
+
+  // plane 1 at zsign=-1 is split into 2 dees between six=19 and six=20 for siy<=20,
+  //                                             and six=21 and 22 for siy>=21
+
+  // plane 1 at zsign=+1 is split into 2 dees between six=20 and six=21 for siy<=20,
+  //                                             and six=19 and 20 for siy>=21
+
+  // Desired numbering
+  //                LEFT    RIGHT (as one faces the Dee from the IP)
+  //  ES-  pl=2     0       1
+  //       pl=1     2       3    the reversal of pl=2 and pl=1 is intentional here (CM Kuo)
+  //  ES+  pl=1     4       5
+  //       pl=2     6       7
+
+  const ESDetId esid(id);
+  const int jx(esid.six() - 1);
+  const int jy(esid.siy() - 1);
+  const int jz(esid.zside() + 1);
+  const int pl(esid.plane() - 1);
+  const bool second(1 == pl);
+  const bool top(19 < jy);
+  const bool negz(0 == jz);
+  const int lrl(19 > jx ? 0 : 1);
+  const int lrr(21 > jx ? 0 : 1);
+
+  return (second ? jx / 20 + 3 * jz :        // 2nd plane split along middle
+              (negz && !top ? lrl + 2 :      // 1st plane at neg z and bottom half split at six=19&20
+                   (negz && top ? lrr + 2 :  // 1st plane at neg z and top half split at six=21&22
+                        (!negz && !top ? lrr + 4 : lrl + 4))));  // opposite at positive z
 }
 
-unsigned int
-EcalPreshowerGeometry::alignmentTransformIndexLocal( const DetId& id )
-{
-   const CaloGenericDetId gid ( id ) ;
-
-   assert( gid.isES() ) ;
-
-// plane 2 is split into 2 dees along x=0 for both signs of z
-
-// plane 1 at zsign=-1 is split into 2 dees between six=19 and six=20 for siy<=20,
-//                                             and six=21 and 22 for siy>=21
-
-// plane 1 at zsign=+1 is split into 2 dees between six=20 and six=21 for siy<=20,
-//                                             and six=19 and 20 for siy>=21
-
-
-// Desired numbering 
-//                LEFT    RIGHT (as one faces the Dee from the IP)
-//  ES-  pl=2     0       1
-//       pl=1     2       3    the reversal of pl=2 and pl=1 is intentional here (CM Kuo)
-//  ES+  pl=1     4       5
-//       pl=2     6       7
-
-   const ESDetId esid ( id ) ;
-   const int jx ( esid.six() - 1 ) ;
-   const int jy ( esid.siy() - 1 ) ;
-   const int jz ( esid.zside() + 1 ) ;
-   const int pl ( esid.plane() - 1 ) ;
-   const bool second ( 1 == pl ) ;
-   const bool top   ( 19 < jy ) ;
-   const bool negz  ( 0 == jz ) ;
-   const int lrl    ( 19>jx ? 0 : 1 ) ;
-   const int lrr    ( 21>jx ? 0 : 1 ) ;
-
-   return ( second ? jx/20 + 3*jz :  // 2nd plane split along middle
-	    ( negz && !top ? lrl + 2 :  // 1st plane at neg z and bottom half split at six=19&20
-	      ( negz && top ? lrr + 2 : // 1st plane at neg z and top half split at six=21&22
-		( !negz && !top ? lrr + 4 : lrl + 4 ) ) ) ) ; // opposite at positive z
+DetId EcalPreshowerGeometry::detIdFromLocalAlignmentIndex(unsigned int iLoc) {
+  return ESDetId(1, 10 + 20 * (iLoc % 2), 10, 2 > iLoc || 5 < iLoc ? 2 : 1, 2 * (iLoc / 4) - 1);
 }
 
-DetId 
-EcalPreshowerGeometry::detIdFromLocalAlignmentIndex( unsigned int iLoc )
-{
-   return ESDetId( 1, 10 + 20*( iLoc%2 ), 10, 2>iLoc || 5<iLoc ? 2 : 1, 2*( iLoc/4 ) - 1 ) ;
+unsigned int EcalPreshowerGeometry::alignmentTransformIndexGlobal(const DetId& /*id*/) {
+  return (unsigned int)DetId::Ecal - 1;
 }
 
-unsigned int
-EcalPreshowerGeometry::alignmentTransformIndexGlobal( const DetId& /*id*/ )
-{
-   return (unsigned int)DetId::Ecal - 1 ;
-}
+void EcalPreshowerGeometry::initializeParms() {
+  unsigned int n1minus(0);
+  unsigned int n2minus(0);
+  unsigned int n1plus(0);
+  unsigned int n2plus(0);
+  CCGFloat z1minus(0);
+  CCGFloat z2minus(0);
+  CCGFloat z1plus(0);
+  CCGFloat z2plus(0);
+  const std::vector<DetId>& esDetIds(getValidDetIds());
 
-
-void 
-EcalPreshowerGeometry::initializeParms() 
-{
-   unsigned int n1minus ( 0 ) ;
-   unsigned int n2minus ( 0 ) ;
-   unsigned int n1plus ( 0 ) ;
-   unsigned int n2plus ( 0 ) ;
-   CCGFloat z1minus ( 0 ) ;
-   CCGFloat z2minus ( 0 ) ;
-   CCGFloat z1plus ( 0 ) ;
-   CCGFloat z2plus ( 0 ) ;
-   const std::vector<DetId>& esDetIds ( getValidDetIds() ) ;
-
-   for( unsigned int i ( 0 ) ; i != esDetIds.size() ; ++i )
-   {
-      const ESDetId esid ( esDetIds[i] ) ;
-      auto cell = getGeometry( esid ) ;
-      if( nullptr != cell )
-      {
-	 const CCGFloat zz ( cell->getPosition().z() ) ; 
-	 if( 1 == esid.plane() )
-	 {
-	    if( 0 > esid.zside() )
-	    {
-	       z1minus += zz ;
-	       ++n1minus ;
-	    }
-	    else
-	    {
-	       z1plus += zz ;
-	       ++n1plus ;
-	    }
-	 }
-	 if( 2 == esid.plane() )
-	 {
-	    if( 0 > esid.zside() )
-	    {
-	       z2minus += zz ;
-	       ++n2minus ;
-	    }
-	    else
-	    {
-	       z2plus += zz ;
-	       ++n2plus ;
-	    }
-	 }
+  for (unsigned int i(0); i != esDetIds.size(); ++i) {
+    const ESDetId esid(esDetIds[i]);
+    auto cell = getGeometry(esid);
+    if (nullptr != cell) {
+      const CCGFloat zz(cell->getPosition().z());
+      if (1 == esid.plane()) {
+        if (0 > esid.zside()) {
+          z1minus += zz;
+          ++n1minus;
+        } else {
+          z1plus += zz;
+          ++n1plus;
+        }
       }
-   }
-   assert( 0 != n1minus &&
-	   0 != n2minus &&
-	   0 != n1plus  &&
-	   0 != n2plus     ) ;
-   z1minus /= (1.*n1minus) ;
-   z2minus /= (1.*n2minus) ;
-   z1plus /= (1.*n1plus) ;
-   z2plus /= (1.*n2plus) ;
-   assert( 0 != z1minus &&
-	   0 != z2minus &&
-	   0 != z1plus  &&
-	   0 != z2plus     ) ;
-   setzPlanes( z1minus, z2minus, z1plus, z2plus ) ;
+      if (2 == esid.plane()) {
+        if (0 > esid.zside()) {
+          z2minus += zz;
+          ++n2minus;
+        } else {
+          z2plus += zz;
+          ++n2plus;
+        }
+      }
+    }
+  }
+  assert(0 != n1minus && 0 != n2minus && 0 != n1plus && 0 != n2plus);
+  z1minus /= (1. * n1minus);
+  z2minus /= (1. * n2minus);
+  z1plus /= (1. * n1plus);
+  z2plus /= (1. * n2plus);
+  assert(0 != z1minus && 0 != z2minus && 0 != z1plus && 0 != z2plus);
+  setzPlanes(z1minus, z2minus, z1plus, z2plus);
 }
 
+void EcalPreshowerGeometry::setzPlanes(CCGFloat z1minus, CCGFloat z2minus, CCGFloat z1plus, CCGFloat z2plus) {
+  assert(0 > z1minus && 0 > z2minus && 0 < z1plus && 0 < z2plus);
 
-void 
-EcalPreshowerGeometry::setzPlanes( CCGFloat z1minus, 
-				   CCGFloat z2minus,
-				   CCGFloat z1plus, 
-				   CCGFloat z2plus ) 
-{
-   assert( 0 > z1minus &&
-	   0 > z2minus &&
-	   0 < z1plus  &&
-	   0 < z2plus     ) ;
-
-   m_zplane[0] = z1minus ;
-   m_zplane[1] = z2minus ;
-   m_zplane[2] = z1plus ;
-   m_zplane[3] = z2plus ;
+  m_zplane[0] = z1minus;
+  m_zplane[1] = z2minus;
+  m_zplane[2] = z1plus;
+  m_zplane[3] = z2plus;
 }
-
 
 // Get closest cell, etc...
-DetId 
-EcalPreshowerGeometry::getClosestCell( const GlobalPoint& point ) const
-{
-  return getClosestCellInPlane( point, 2 );
-} 
+DetId EcalPreshowerGeometry::getClosestCell(const GlobalPoint& point) const { return getClosestCellInPlane(point, 2); }
 
-DetId 
-EcalPreshowerGeometry::getClosestCellInPlane( const GlobalPoint& point,
-					      int                plane          ) const
-{
-   const CCGFloat x ( point.x() ) ;
-   const CCGFloat y ( point.y() ) ;
-   const CCGFloat z ( point.z() ) ;
+DetId EcalPreshowerGeometry::getClosestCellInPlane(const GlobalPoint& point, int plane) const {
+  const CCGFloat x(point.x());
+  const CCGFloat y(point.y());
+  const CCGFloat z(point.z());
 
-   if( 0 == z    ||
-       1 > plane ||
-       2 < plane    ) return DetId( 0 ) ;
+  if (0 == z || 1 > plane || 2 < plane)
+    return DetId(0);
 
-   const unsigned int iz ( ( 0>z ? 0 : 2 ) + plane - 1 ) ;
+  const unsigned int iz((0 > z ? 0 : 2) + plane - 1);
 
-   const CCGFloat ze ( m_zplane[iz] ) ;
-   const CCGFloat xe ( x * ze/z ) ;
-   const CCGFloat ye ( y * ze/z ) ;
+  const CCGFloat ze(m_zplane[iz]);
+  const CCGFloat xe(x * ze / z);
+  const CCGFloat ye(y * ze / z);
 
-   const CCGFloat x0 ( 1 == plane ? xe : ye ) ;
-   const CCGFloat y0 ( 1 == plane ? ye : xe ) ;
+  const CCGFloat x0(1 == plane ? xe : ye);
+  const CCGFloat y0(1 == plane ? ye : xe);
 
-   static const CCGFloat xWid ( m_xWidWaf + m_xIntraLadGap + m_xInterLadGap ) ;
+  static const CCGFloat xWid(m_xWidWaf + m_xIntraLadGap + m_xInterLadGap);
 
-   const int row ( 1 + int( y0 + 20.*m_yWidAct - m_yCtrOff )/m_yWidAct ) ;
-   const int col ( 1 + int( ( x0 + 20.*xWid )/xWid ) ) ;
+  const int row(1 + int(y0 + 20. * m_yWidAct - m_yCtrOff) / m_yWidAct);
+  const int col(1 + int((x0 + 20. * xWid) / xWid));
 
-   CCGFloat closest ( 1e9 ) ; 
+  CCGFloat closest(1e9);
 
-   DetId detId ( 0 ) ;
+  DetId detId(0);
 
-   const int jz ( 0 > ze ? -1 : 1 ) ;
+  const int jz(0 > ze ? -1 : 1);
 
+  //   std::cout<<"** p="<<point<<", ("<<xe<<", "<<ye<<", "<<ze<<"), row="<<row<<", col="<<col<<std::endl;
 
-//   std::cout<<"** p="<<point<<", ("<<xe<<", "<<ye<<", "<<ze<<"), row="<<row<<", col="<<col<<std::endl;
-
-   for( int ix ( -1 ); ix != 2 ; ++ix ) // search within +-1 in row and col
-   {
-      for( int iy ( -1 ); iy != 2 ; ++iy )
-      {
-	 for( int jstrip ( ESDetId::ISTRIP_MIN ) ; jstrip <= ESDetId::ISTRIP_MAX ; ++jstrip )
-	 {
-	    const int jx ( 1 == plane ? col + ix : row + iy ) ;
-	    const int jy ( 1 == plane ? row + iy : col + ix ) ;
-	    if( ESDetId::validDetId( jstrip, jx, jy, plane, jz ) )
-	    {
-	       const ESDetId esId ( jstrip, jx, jy, plane, jz ) ;
-	       auto cell = getGeometry( esId );
-	       if( nullptr != cell )
-	       {
-		  const GlobalPoint& p ( cell->getPosition() ) ;
-		  const CCGFloat dist2 ( (p.x()-xe)*(p.x()-xe) + (p.y()-ye)*(p.y()-ye) ) ;
-		  if( dist2 < closest && present( esId ) )
-		  {
-		     closest = dist2 ;
-		     detId   = esId  ;
-		  }
-	       }
-	    }
-	 }
+  for (int ix(-1); ix != 2; ++ix)  // search within +-1 in row and col
+  {
+    for (int iy(-1); iy != 2; ++iy) {
+      for (int jstrip(ESDetId::ISTRIP_MIN); jstrip <= ESDetId::ISTRIP_MAX; ++jstrip) {
+        const int jx(1 == plane ? col + ix : row + iy);
+        const int jy(1 == plane ? row + iy : col + ix);
+        if (ESDetId::validDetId(jstrip, jx, jy, plane, jz)) {
+          const ESDetId esId(jstrip, jx, jy, plane, jz);
+          auto cell = getGeometry(esId);
+          if (nullptr != cell) {
+            const GlobalPoint& p(cell->getPosition());
+            const CCGFloat dist2((p.x() - xe) * (p.x() - xe) + (p.y() - ye) * (p.y() - ye));
+            if (dist2 < closest && present(esId)) {
+              closest = dist2;
+              detId = esId;
+            }
+          }
+        }
       }
-   }
-   return detId ;
+    }
+  }
+  return detId;
 }
 
-void
-EcalPreshowerGeometry::localCorners( Pt3DVec&        lc  ,
-				     const CCGFloat* pv  ,
-				     unsigned int    /*i*/   ,
-				     Pt3D&           ref   )
-{
-   PreshowerStrip::localCorners( lc, pv, ref ) ;
+void EcalPreshowerGeometry::localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int /*i*/, Pt3D& ref) {
+  PreshowerStrip::localCorners(lc, pv, ref);
 }
 
-void
-EcalPreshowerGeometry::newCell( const GlobalPoint& f1 ,
-				const GlobalPoint& /*f2*/ ,
-				const GlobalPoint& /*f3*/ ,
-				const CCGFloat*    parm ,
-				const DetId&       detId    ) 
-{
-   const unsigned int cellIndex ( ESDetId( detId ).denseIndex() ) ;
-   m_cellVec[ cellIndex ] = PreshowerStrip( f1, cornersMgr(), parm ) ;
-   addValidID( detId ) ;
+void EcalPreshowerGeometry::newCell(const GlobalPoint& f1,
+                                    const GlobalPoint& /*f2*/,
+                                    const GlobalPoint& /*f3*/,
+                                    const CCGFloat* parm,
+                                    const DetId& detId) {
+  const unsigned int cellIndex(ESDetId(detId).denseIndex());
+  m_cellVec[cellIndex] = PreshowerStrip(f1, cornersMgr(), parm);
+  addValidID(detId);
 }
 
 const CaloCellGeometry* EcalPreshowerGeometry::getGeometryRawPtr(uint32_t index) const {
   // Modify the RawPtr class
   const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index ||
-	  nullptr == cell->param() ? nullptr : cell);
+  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
 }

--- a/Geometry/EcalAlgo/src/WriteESAlignments.cc
+++ b/Geometry/EcalAlgo/src/WriteESAlignments.cc
@@ -9,122 +9,104 @@
 
 #include "Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h"
 
-typedef WriteESAlignments WEA ;
+typedef WriteESAlignments WEA;
 
-const unsigned int WEA::k_nA = EcalPreshowerGeometry::numberOfAlignments() ;
+const unsigned int WEA::k_nA = EcalPreshowerGeometry::numberOfAlignments();
 
-WEA::WriteESAlignments(edm::ConsumesCollector&& cc):
-  geometryToken_{cc.esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})},
-  alignmentToken_{cc.esConsumes<Alignments, ESAlignmentRcd>(edm::ESInputTag{})}
-{}
+WEA::WriteESAlignments(edm::ConsumesCollector&& cc)
+    : geometryToken_{cc.esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})},
+      alignmentToken_{cc.esConsumes<Alignments, ESAlignmentRcd>(edm::ESInputTag{})} {}
 
-void WEA::writeAlignments( const edm::EventSetup& eventSetup ,
-                           const WEA::DVec&       alphaVec   ,
-                           const WEA::DVec&       betaVec    ,
-                           const WEA::DVec&       gammaVec   ,
-                           const WEA::DVec&       xtranslVec ,
-                           const WEA::DVec&       ytranslVec ,
-                           const WEA::DVec&       ztranslVec  )
-{
-   assert( alphaVec.size()   == k_nA ) ;
-   assert( betaVec.size()    == k_nA ) ;
-   assert( gammaVec.size()   == k_nA ) ;
-   assert( xtranslVec.size() == k_nA ) ;
-   assert( ytranslVec.size() == k_nA ) ;
-   assert( ztranslVec.size() == k_nA ) ;
+void WEA::writeAlignments(const edm::EventSetup& eventSetup,
+                          const WEA::DVec& alphaVec,
+                          const WEA::DVec& betaVec,
+                          const WEA::DVec& gammaVec,
+                          const WEA::DVec& xtranslVec,
+                          const WEA::DVec& ytranslVec,
+                          const WEA::DVec& ztranslVec) {
+  assert(alphaVec.size() == k_nA);
+  assert(betaVec.size() == k_nA);
+  assert(gammaVec.size() == k_nA);
+  assert(xtranslVec.size() == k_nA);
+  assert(ytranslVec.size() == k_nA);
+  assert(ztranslVec.size() == k_nA);
 
-   AliPtr  aliPtr ( new Alignments  ) ;// writeOne will take ownership!
-   AliVec& vali   ( aliPtr->m_align ) ;
+  AliPtr aliPtr(new Alignments);  // writeOne will take ownership!
+  AliVec& vali(aliPtr->m_align);
 
-   convert( eventSetup , 
-	    alphaVec   ,
-	    betaVec    , 
-	    gammaVec   ,
-	    xtranslVec , 
-	    ytranslVec , 
-	    ztranslVec ,
-	    vali         ) ;
+  convert(eventSetup, alphaVec, betaVec, gammaVec, xtranslVec, ytranslVec, ztranslVec, vali);
 
-   write( aliPtr ) ;
+  write(aliPtr);
 }
 
-void 
-WEA::write( WEA::AliPtr aliPtr ) 
-{
-   std::cout << "Uploading ES alignments to the database" << std::endl ;
+void WEA::write(WEA::AliPtr aliPtr) {
+  std::cout << "Uploading ES alignments to the database" << std::endl;
 
-   edm::Service<cond::service::PoolDBOutputService> poolDbService ;
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
-   if (!poolDbService.isAvailable()) throw cms::Exception("NotAvailable") 
-      << "PoolDBOutputService not available";
+  if (!poolDbService.isAvailable())
+    throw cms::Exception("NotAvailable") << "PoolDBOutputService not available";
 
-   poolDbService->writeOne<Alignments>(&(*aliPtr), 
-				       poolDbService->currentTime(),
-				       "ESAlignmentRcd" ) ;
+  poolDbService->writeOne<Alignments>(&(*aliPtr), poolDbService->currentTime(), "ESAlignmentRcd");
 }
 
-void 
-WEA::convert( const edm::EventSetup& eS ,
-	      const WEA::DVec&       a  ,
-	      const WEA::DVec&       b  ,
-	      const WEA::DVec&       g  ,
-	      const WEA::DVec&       x  ,
-	      const WEA::DVec&       y  ,
-	      const WEA::DVec&       z  ,
-	      WEA::AliVec&           va   ) 
-{
-   const auto& pG = eS.getData(geometryToken_);
+void WEA::convert(const edm::EventSetup& eS,
+                  const WEA::DVec& a,
+                  const WEA::DVec& b,
+                  const WEA::DVec& g,
+                  const WEA::DVec& x,
+                  const WEA::DVec& y,
+                  const WEA::DVec& z,
+                  WEA::AliVec& va) {
+  const auto& pG = eS.getData(geometryToken_);
 
-   const CaloSubdetectorGeometry* geom(pG.getSubdetectorGeometry( DetId::Ecal, EcalPreshower) ) ;
+  const CaloSubdetectorGeometry* geom(pG.getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
 
-   const auto& pA = eS.getData(alignmentToken_);
-   const AliVec& vaPrev ( pA.m_align ) ;
+  const auto& pA = eS.getData(alignmentToken_);
+  const AliVec& vaPrev(pA.m_align);
 
-   va.reserve( k_nA ) ;
-   for( unsigned int i ( 0 ) ; i != k_nA ; ++i )
-   {
-      // ordering of i is: left, right, left, right,...
-      // starting at ES- rear, then ES- front, 
-      // then ES+ front, then ES+ rear
+  va.reserve(k_nA);
+  for (unsigned int i(0); i != k_nA; ++i) {
+    // ordering of i is: left, right, left, right,...
+    // starting at ES- rear, then ES- front,
+    // then ES+ front, then ES+ rear
 
-      const ESDetId id ( EcalPreshowerGeometry::detIdFromLocalAlignmentIndex( i ) ) ;
+    const ESDetId id(EcalPreshowerGeometry::detIdFromLocalAlignmentIndex(i));
 
-      double zPlanePrev ( geom->getGeometry( id )->getPosition().z() ) ;
-      const double zAlignPrev ( vaPrev[i].translation().z() ) ;
-      const Trl    q_I ( 0, 0, zPlanePrev - zAlignPrev ) ;
-      const Trl&   s_p ( vaPrev[i].translation() ) ;
-      const Trl    t_n ( x[i], y[i], z[i] ) ;
-      const Rot    G_p ( vaPrev[i].rotation() ) ;
-      const double gamma ( g[i] ) ;
-      const double alpha ( a[i] ) ;
-      const double beta  ( b[i] ) ;
+    double zPlanePrev(geom->getGeometry(id)->getPosition().z());
+    const double zAlignPrev(vaPrev[i].translation().z());
+    const Trl q_I(0, 0, zPlanePrev - zAlignPrev);
+    const Trl& s_p(vaPrev[i].translation());
+    const Trl t_n(x[i], y[i], z[i]);
+    const Rot G_p(vaPrev[i].rotation());
+    const double gamma(g[i]);
+    const double alpha(a[i]);
+    const double beta(b[i]);
 
-      const Rot L_n ( // New rotation in local frame!
-	 Rot( Rot( Rot().rotateZ( -gamma ) ).rotateX( -alpha ) ).rotateY( -beta ) ) ;
+    const Rot L_n(  // New rotation in local frame!
+        Rot(Rot(Rot().rotateZ(-gamma)).rotateX(-alpha)).rotateY(-beta));
 
-      const Rot InvL_n ( L_n.inverse() ) ;
+    const Rot InvL_n(L_n.inverse());
 
-      const Rot G_n ( InvL_n * G_p ) ;
+    const Rot G_n(InvL_n * G_p);
 
-      const Trl s_n ( t_n + s_p + q_I - InvL_n*q_I ) ;
+    const Trl s_n(t_n + s_p + q_I - InvL_n * q_I);
 
-      std::cout<<"For i = "<<i<<", q_I="<<q_I<<std::endl ;
-      std::cout<<"For i = "<<i<<", s_p="<<s_p<<std::endl ;
-      std::cout<<"For i = "<<i<<", alpha = "<<1000.*alpha<<" mr"<<std::endl;
-      std::cout<<"For i = "<<i<<", beta  = "<<1000.*beta <<" mr"<<std::endl;
-      std::cout<<"For i = "<<i<<", gamma = "<<1000.*gamma<<" mr"<<std::endl;
-      std::cout<<" For i = "<<i<<", L_n = "<< L_n
-	       <<"   Euler angles="<<InvL_n.eulerAngles()<<"\n"<<std::endl;
-      std::cout<<"For i = "<<i<<", t_n="<<t_n<<std::endl ;
-      std::cout<<"For i = "<<i<<", G_p="<<G_p
-	       <<"   Euler angles="<<G_p.eulerAngles()<<"\n"<<std::endl ;
-      std::cout<<" For i = "<<i<<", InvL_n = "<< InvL_n
-	       <<"   Euler angles="<<InvL_n.eulerAngles()<<"\n"<<std::endl;
-      std::cout<<" For i ="<<i<<", G_n = "<< G_n
-	       <<"    Euler angles="<<G_n.eulerAngles()<<"\n"<<std::endl;
-      std::cout<<" For i ="<<i<<", s_n = "<< s_n<<std::endl;
-      std::cout<<"++++++++++++++++++++++++++\n\n"<<std::endl;
+    std::cout << "For i = " << i << ", q_I=" << q_I << std::endl;
+    std::cout << "For i = " << i << ", s_p=" << s_p << std::endl;
+    std::cout << "For i = " << i << ", alpha = " << 1000. * alpha << " mr" << std::endl;
+    std::cout << "For i = " << i << ", beta  = " << 1000. * beta << " mr" << std::endl;
+    std::cout << "For i = " << i << ", gamma = " << 1000. * gamma << " mr" << std::endl;
+    std::cout << " For i = " << i << ", L_n = " << L_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n"
+              << std::endl;
+    std::cout << "For i = " << i << ", t_n=" << t_n << std::endl;
+    std::cout << "For i = " << i << ", G_p=" << G_p << "   Euler angles=" << G_p.eulerAngles() << "\n" << std::endl;
+    std::cout << " For i = " << i << ", InvL_n = " << InvL_n << "   Euler angles=" << InvL_n.eulerAngles() << "\n"
+              << std::endl;
+    std::cout << " For i =" << i << ", G_n = " << G_n << "    Euler angles=" << G_n.eulerAngles() << "\n" << std::endl;
+    std::cout << " For i =" << i << ", s_n = " << s_n << std::endl;
+    std::cout << "++++++++++++++++++++++++++\n\n" << std::endl;
 
-      va.emplace_back( AlignTransform( s_n, G_n, id ) ) ;
-   }
+    va.emplace_back(AlignTransform(s_n, G_n, id));
+  }
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalAngular.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // File: DDHCalAngular.cc
-// Description: Position inside the mother according to (eta,phi) 
+// Description: Position inside the mother according to (eta,phi)
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <cmath>
@@ -13,7 +13,7 @@
 #include "DetectorDescription/Core/interface/DDTypes.h"
 #include "Geometry/HcalAlgo/plugins/DDHCalAngular.h"
 
-//#define EDM_ML_DEBUG                                                         
+//#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
 DDHCalAngular::DDHCalAngular() {
@@ -24,82 +24,70 @@ DDHCalAngular::DDHCalAngular() {
 
 DDHCalAngular::~DDHCalAngular() {}
 
-void DDHCalAngular::initialize(const DDNumericArguments & nArgs,
-			       const DDVectorArguments & ,
-			       const DDMapArguments & ,
-			       const DDStringArguments & sArgs,
-			       const DDStringVectorArguments & ) {
-
-  startAngle  = nArgs["startAngle"];
-  rangeAngle  = nArgs["rangeAngle"];
-  shiftX      = nArgs["shiftX"];
-  shiftY      = nArgs["shiftY"];
-  zoffset     = nArgs["zoffset"];
-  n           = int (nArgs["n"]);
-  startCopyNo = int (nArgs["startCopyNo"]);
-  incrCopyNo  = int (nArgs["incrCopyNo"]);
+void DDHCalAngular::initialize(const DDNumericArguments& nArgs,
+                               const DDVectorArguments&,
+                               const DDMapArguments&,
+                               const DDStringArguments& sArgs,
+                               const DDStringVectorArguments&) {
+  startAngle = nArgs["startAngle"];
+  rangeAngle = nArgs["rangeAngle"];
+  shiftX = nArgs["shiftX"];
+  shiftY = nArgs["shiftY"];
+  zoffset = nArgs["zoffset"];
+  n = int(nArgs["n"]);
+  startCopyNo = int(nArgs["startCopyNo"]);
+  incrCopyNo = int(nArgs["incrCopyNo"]);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Parameters for positioning "
-			       << "-- " << n << " copies in " 
-			       << convertRadToDeg(rangeAngle) << " from " 
-			       << convertRadToDeg(startAngle) << "\tShifts " 
-			       << shiftX << ", " << shiftY 
-			       << " along x, y axes; \tZoffest " << zoffset
-			       << "\tStart and inremental copy nos " 
-			       << startCopyNo << ", " << incrCopyNo;
+                               << "-- " << n << " copies in " << convertRadToDeg(rangeAngle) << " from "
+                               << convertRadToDeg(startAngle) << "\tShifts " << shiftX << ", " << shiftY
+                               << " along x, y axes; \tZoffest " << zoffset << "\tStart and inremental copy nos "
+                               << startCopyNo << ", " << incrCopyNo;
 #endif
-  rotns       = sArgs["RotNameSpace"];
+  rotns = sArgs["RotNameSpace"];
   idNameSpace = DDCurrentNamespace::ns();
-  childName   = sArgs["ChildName"]; 
+  childName = sArgs["ChildName"];
 #ifdef EDM_ML_DEBUG
-  DDName parentName = parent().name(); 
-  edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Parent " << parentName 
-			       << "\tChild " << childName << "\tNameSpace "
-			       << idNameSpace << "\tRotation Namespace "
-			       << rotns;
+  DDName parentName = parent().name();
+  edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Parent " << parentName << "\tChild " << childName << "\tNameSpace "
+                               << idNameSpace << "\tRotation Namespace " << rotns;
 #endif
 }
 
 void DDHCalAngular::execute(DDCompactView& cpv) {
-
-  double dphi   = rangeAngle/n;
-  double phix   = startAngle;
-  int    copyNo = startCopyNo;
-  double theta  = 90._deg;
-  for (int ii=0; ii<n; ii++) {
-    double phiy   = phix + 90._deg;
+  double dphi = rangeAngle / n;
+  double phix = startAngle;
+  int copyNo = startCopyNo;
+  double theta = 90._deg;
+  for (int ii = 0; ii < n; ii++) {
+    double phiy = phix + 90._deg;
     DDRotation rotation;
     std::string rotstr("NULL");
- 
+
     static const double tol = 0.1;
     if (std::abs(phix) > tol) {
       rotstr = "R" + formatAsDegreesInInteger(phix);
-      rotation = DDRotation(DDName(rotstr, rotns)); 
+      rotation = DDRotation(DDName(rotstr, rotns));
       if (!rotation) {
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Creating a rotation "
-				     << DDName(rotstr, idNameSpace) << "\t90, "
-				     << convertRadToDeg(phix) << ", 90, " 
-				     << (90+convertRadToDeg(phix)) << ", 0, 0";
+        edm::LogVerbatim("HCalGeom") << "DDHCalAngular: Creating a rotation " << DDName(rotstr, idNameSpace) << "\t90, "
+                                     << convertRadToDeg(phix) << ", 90, " << (90 + convertRadToDeg(phix)) << ", 0, 0";
 #endif
-        rotation = DDrot(DDName(rotstr, rotns), theta, phix, theta, phiy, 0,0);
-      } 
+        rotation = DDrot(DDName(rotstr, rotns), theta, phix, theta, phiy, 0, 0);
+      }
     }
-    
-    double xpos = shiftX*cos(phix) - shiftY*sin(phix);
-    double ypos = shiftX*sin(phix) + shiftY*cos(phix);
+
+    double xpos = shiftX * cos(phix) - shiftY * sin(phix);
+    double ypos = shiftX * sin(phix) + shiftY * cos(phix);
     DDTranslation tran(xpos, ypos, zoffset);
-  
-    DDName parentName = parent().name(); 
-    cpv.position(DDName(childName,idNameSpace),parentName,copyNo,tran,rotation);
+
+    DDName parentName = parent().name();
+    cpv.position(DDName(childName, idNameSpace), parentName, copyNo, tran, rotation);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalAngular: " 
-				 << DDName(childName, idNameSpace) 
-				 << " number " << copyNo << " positioned in "
-				 << parentName << " at " << tran << " with "
-				 << rotation;
+    edm::LogVerbatim("HCalGeom") << "DDHCalAngular: " << DDName(childName, idNameSpace) << " number " << copyNo
+                                 << " positioned in " << parentName << " at " << tran << " with " << rotation;
 #endif
-    phix   += dphi;
+    phix += dphi;
     copyNo += incrCopyNo;
   }
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalAngular.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalAngular.h
@@ -8,33 +8,32 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalAngular : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDHCalAngular(); 
+  DDHCalAngular();
   ~DDHCalAngular() override;
-  
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
+  double startAngle;  //Start angle
+  double rangeAngle;  //Range angle
+  double shiftY;      //Shift along Y
+  double shiftX;      //Shift along X
+  double zoffset;     //Offset in z
+  int n;              //Mumber of copies
+  int startCopyNo;    //Start copy Number
+  int incrCopyNo;     //Increment copy Number
 
-  double        startAngle;   //Start angle 
-  double        rangeAngle;   //Range angle
-  double        shiftY;       //Shift along Y
-  double        shiftX;       //Shift along X
-  double        zoffset;      //Offset in z
-  int           n;            //Mumber of copies
-  int           startCopyNo;  //Start copy Number
-  int           incrCopyNo;   //Increment copy Number
-
-  std::string   rotns;        //Namespace for rotation matrix
-  std::string   idNameSpace;  //Namespace of this and ALL sub-parts
-  std::string   childName;    //Children name
+  std::string rotns;        //Namespace for rotation matrix
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  std::string childName;    //Children name
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.cc
@@ -17,17 +17,50 @@
 #include "DetectorDescription/Core/interface/DDSplit.h"
 #include "Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.h"
 
-//#define EDM_ML_DEBUG                                                         
+//#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-DDHCalBarrelAlgo::DDHCalBarrelAlgo():
-  theta(0),rmax(0),zoff(0),ttheta(0),layerId(0),layerLabel(0),layerMat(0),
-  layerWidth(0),layerD1(0),layerD2(0),layerAlpha(0),layerT1(0),layerT2(0),
-  layerAbsorb(0),layerGap(0),absorbName(0),absorbMat(0),absorbD(0),absorbT(0),
-  midName(0),midMat(0),midW(0),midT(0),sideMat(0),sideD(0),sideT(0),
-  sideAbsName(0),sideAbsMat(0),sideAbsW(0),detType(0),detdP1(0),detdP2(0),
-  detT11(0),detT12(0),detTsc(0),detT21(0),detT22(0),detWidth1(0),detWidth2(0),
-  detPosY(0) {
+DDHCalBarrelAlgo::DDHCalBarrelAlgo()
+    : theta(0),
+      rmax(0),
+      zoff(0),
+      ttheta(0),
+      layerId(0),
+      layerLabel(0),
+      layerMat(0),
+      layerWidth(0),
+      layerD1(0),
+      layerD2(0),
+      layerAlpha(0),
+      layerT1(0),
+      layerT2(0),
+      layerAbsorb(0),
+      layerGap(0),
+      absorbName(0),
+      absorbMat(0),
+      absorbD(0),
+      absorbT(0),
+      midName(0),
+      midMat(0),
+      midW(0),
+      midT(0),
+      sideMat(0),
+      sideD(0),
+      sideT(0),
+      sideAbsName(0),
+      sideAbsMat(0),
+      sideAbsW(0),
+      detType(0),
+      detdP1(0),
+      detdP2(0),
+      detT11(0),
+      detT12(0),
+      detTsc(0),
+      detT21(0),
+      detT22(0),
+      detWidth1(0),
+      detWidth2(0),
+      detPosY(0) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Creating an instance";
 #endif
@@ -35,42 +68,37 @@ DDHCalBarrelAlgo::DDHCalBarrelAlgo():
 
 DDHCalBarrelAlgo::~DDHCalBarrelAlgo() {}
 
-void DDHCalBarrelAlgo::initialize(const DDNumericArguments & nArgs,
-				  const DDVectorArguments & vArgs,
-				  const DDMapArguments & ,
-				  const DDStringArguments & sArgs,
-				  const DDStringVectorArguments & vsArgs) {
-
+void DDHCalBarrelAlgo::initialize(const DDNumericArguments& nArgs,
+                                  const DDVectorArguments& vArgs,
+                                  const DDMapArguments&,
+                                  const DDStringArguments& sArgs,
+                                  const DDStringVectorArguments& vsArgs) {
   genMaterial = sArgs["MaterialName"];
-  nsectors    = int (nArgs["NSector"]);
-  nsectortot  = int (nArgs["NSectorTot"]);
-  nhalf       = int (nArgs["NHalf"]);
-  rin         = nArgs["RIn"];
-  rout        = nArgs["ROut"];
-  rzones      = int (nArgs["RZones"]);
-  rotHalf     = sArgs["RotHalf"];
-  rotns       = sArgs["RotNameSpace"];
+  nsectors = int(nArgs["NSector"]);
+  nsectortot = int(nArgs["NSectorTot"]);
+  nhalf = int(nArgs["NHalf"]);
+  rin = nArgs["RIn"];
+  rout = nArgs["ROut"];
+  rzones = int(nArgs["RZones"]);
+  rotHalf = sArgs["RotHalf"];
+  rotns = sArgs["RotNameSpace"];
 
-  theta       = vArgs["Theta"];
-  rmax        = vArgs["RMax"];
-  zoff        = vArgs["ZOff"];
+  theta = vArgs["Theta"];
+  rmax = vArgs["RMax"];
+  zoff = vArgs["ZOff"];
   for (int i = 0; i < rzones; i++) {
-    ttheta.emplace_back(tan(theta[i])); //*deg already done in XML
+    ttheta.emplace_back(tan(theta[i]));  //*deg already done in XML
   }
   if (rzones > 3)
     rmax[2] = (zoff[3] - zoff[2]) / ttheta[2];
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: General material " 
-			       << genMaterial << "\tSectors " << nsectors
-			       << ", "  << nsectortot <<"\tHalves "
-			       << nhalf << "\tRotation matrix " << rotns 
-			       << ":" << rotHalf << "\n\t\t" << rin << "\t" 
-			       << rout << "\t" << rzones;
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: General material " << genMaterial << "\tSectors " << nsectors
+                               << ", " << nsectortot << "\tHalves " << nhalf << "\tRotation matrix " << rotns << ":"
+                               << rotHalf << "\n\t\t" << rin << "\t" << rout << "\t" << rzones;
   for (int i = 0; i < rzones; i++)
-    edm::LogVerbatim("HCalGeom") << "\tTheta[" << i << "] = " << theta[i] 
-				 << "\trmax[" << i << "] = " << rmax[i]
-				 << "\tzoff[" << i << "] = " << zoff[i];
+    edm::LogVerbatim("HCalGeom") << "\tTheta[" << i << "] = " << theta[i] << "\trmax[" << i << "] = " << rmax[i]
+                                 << "\tzoff[" << i << "] = " << zoff[i];
 #endif
   ///////////////////////////////////////////////////////////////
   //Layers
@@ -78,123 +106,109 @@ void DDHCalBarrelAlgo::initialize(const DDNumericArguments & nArgs,
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Layer\t" << nLayers;
 #endif
-  layerId     = dbl_to_int (vArgs["Id"]);
-  layerLabel  = vsArgs["LayerLabel"];
-  layerMat    = vsArgs["LayerMat"];
-  layerWidth  = vArgs["LayerWidth"];
-  layerD1     = vArgs["D1"];
-  layerD2     = vArgs["D2"];
-  layerAlpha  = vArgs["Alpha2"]; 
-  layerT1     = vArgs["T1"];
-  layerT2     = vArgs["T2"];
+  layerId = dbl_to_int(vArgs["Id"]);
+  layerLabel = vsArgs["LayerLabel"];
+  layerMat = vsArgs["LayerMat"];
+  layerWidth = vArgs["LayerWidth"];
+  layerD1 = vArgs["D1"];
+  layerD2 = vArgs["D2"];
+  layerAlpha = vArgs["Alpha2"];
+  layerT1 = vArgs["T1"];
+  layerT2 = vArgs["T2"];
   layerAbsorb = dbl_to_int(vArgs["AbsL"]);
-  layerGap    = vArgs["Gap"];
+  layerGap = vArgs["Gap"];
 #ifdef EDM_ML_DEBUG
   for (int i = 0; i < nLayers; i++)
-    edm::LogVerbatim("HCalGeom") << layerLabel[i] << "\t" << layerId[i] << "\t"
-				 << layerMat[i] << "\t" << layerWidth[i] 
-				 << "\t" << layerD1[i] << "\t" << layerD2[i]
-				 << "\t" << layerAlpha[i] << "\t" << layerT1[i]
-				 << "\t" << layerT2[i] << "\t" 
-				 << layerAbsorb[i] << "\t" << layerGap[i];
+    edm::LogVerbatim("HCalGeom") << layerLabel[i] << "\t" << layerId[i] << "\t" << layerMat[i] << "\t" << layerWidth[i]
+                                 << "\t" << layerD1[i] << "\t" << layerD2[i] << "\t" << layerAlpha[i] << "\t"
+                                 << layerT1[i] << "\t" << layerT2[i] << "\t" << layerAbsorb[i] << "\t" << layerGap[i];
 #endif
-  
+
   ///////////////////////////////////////////////////////////////
   //Absorber Layers and middle part
-  absorbName  = vsArgs["AbsorbName"];
-  absorbMat   = vsArgs["AbsorbMat"];
-  absorbD     = vArgs["AbsorbD"];
-  absorbT     = vArgs["AbsorbT"];
-  nAbsorber   = absorbName.size();
+  absorbName = vsArgs["AbsorbName"];
+  absorbMat = vsArgs["AbsorbMat"];
+  absorbD = vArgs["AbsorbD"];
+  absorbT = vArgs["AbsorbT"];
+  nAbsorber = absorbName.size();
 #ifdef EDM_ML_DEBUG
   for (int i = 0; i < nAbsorber; i++)
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << absorbName[i]
-				 <<" Material " <<  absorbMat[i] << " d "
-				 << absorbD[i] << " t " <<absorbT[i];
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << absorbName[i] << " Material " << absorbMat[i] << " d "
+                                 << absorbD[i] << " t " << absorbT[i];
 #endif
-  middleMat   = sArgs["MiddleMat"];
-  middleD     = nArgs["MiddleD"];
-  middleW     = nArgs["MiddleW"];
+  middleMat = sArgs["MiddleMat"];
+  middleD = nArgs["MiddleD"];
+  middleW = nArgs["MiddleW"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Middle material " 
-			       << middleMat << " d " << middleD << " w "
-			       << middleW;
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Middle material " << middleMat << " d " << middleD << " w "
+                               << middleW;
 #endif
-  midName     = vsArgs["MidAbsName"];
-  midMat      = vsArgs["MidAbsMat"];
-  midW        = vArgs["MidAbsW"];
-  midT        = vArgs["MidAbsT"];
-  nMidAbs     = midName.size();
+  midName = vsArgs["MidAbsName"];
+  midMat = vsArgs["MidAbsMat"];
+  midW = vArgs["MidAbsW"];
+  midT = vArgs["MidAbsT"];
+  nMidAbs = midName.size();
 #ifdef EDM_ML_DEBUG
   for (int i = 0; i < nMidAbs; i++)
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << midName[i]
-				 << " Material " <<  midMat[i] << " W " 
-				 << midW[i] << " T " << midT[i];
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << midName[i] << " Material " << midMat[i] << " W " << midW[i]
+                                 << " T " << midT[i];
 #endif
 
   //Absorber layers in the side part
-  sideMat     = vsArgs["SideMat"];
-  sideD       = vArgs["SideD"];
-  sideT       = vArgs["SideT"];
+  sideMat = vsArgs["SideMat"];
+  sideD = vArgs["SideD"];
+  sideT = vArgs["SideT"];
 #ifdef EDM_ML_DEBUG
   for (unsigned int i = 0; i < sideMat.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Side material " 
-				 << sideMat[i] << " d " << sideD[i] << " t "
-				 << sideT[i];
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Side material " << sideMat[i] << " d " << sideD[i] << " t "
+                                 << sideT[i];
 #endif
   sideAbsName = vsArgs["SideAbsName"];
-  sideAbsMat  = vsArgs["SideAbsMat"];
-  sideAbsW    = vArgs["SideAbsW"];
-  nSideAbs    = sideAbsName.size();
+  sideAbsMat = vsArgs["SideAbsMat"];
+  sideAbsW = vArgs["SideAbsW"];
+  nSideAbs = sideAbsName.size();
 #ifdef EDM_ML_DEBUG
   for (int i = 0; i < nSideAbs; i++)
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << sideAbsName[i]
-				 <<" Material " <<  sideAbsMat[i] << " W "
-				 << sideAbsW[i];
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << sideAbsName[i] << " Material " << sideAbsMat[i] << " W "
+                                 << sideAbsW[i];
 #endif
 
   ///////////////////////////////////////////////////////////////
   // Detectors
 
-  detMat   = sArgs["DetMat"];
-  detRot   = sArgs["DetRot"];
+  detMat = sArgs["DetMat"];
+  detRot = sArgs["DetRot"];
   detMatPl = sArgs["DetMatPl"];
   detMatSc = sArgs["DetMatSc"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Detector (" <<  nLayers 
-			       << ") Rotation matrix " << rotns << ":" 
-			       << detRot << "\n\t\t" << detMat << "\t" 
-			       << detMatPl  << "\t" << detMatSc;
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Detector (" << nLayers << ") Rotation matrix " << rotns << ":"
+                               << detRot << "\n\t\t" << detMat << "\t" << detMatPl << "\t" << detMatSc;
 #endif
-  detType   = dbl_to_int(vArgs["DetType"]);
-  detdP1    = vArgs["DetdP1"];
-  detdP2    = vArgs["DetdP2"];
-  detT11    = vArgs["DetT11"];
-  detT12    = vArgs["DetT12"];
-  detTsc    = vArgs["DetTsc"];
-  detT21    = vArgs["DetT21"];
-  detT22    = vArgs["DetT22"];
+  detType = dbl_to_int(vArgs["DetType"]);
+  detdP1 = vArgs["DetdP1"];
+  detdP2 = vArgs["DetdP2"];
+  detT11 = vArgs["DetT11"];
+  detT12 = vArgs["DetT12"];
+  detTsc = vArgs["DetTsc"];
+  detT21 = vArgs["DetT21"];
+  detT22 = vArgs["DetT22"];
   detWidth1 = vArgs["DetWidth1"];
   detWidth2 = vArgs["DetWidth2"];
-  detPosY   = dbl_to_int(vArgs["DetPosY"]);
+  detPosY = dbl_to_int(vArgs["DetPosY"]);
 #ifdef EDM_ML_DEBUG
-  for (int i = 0; i < nLayers; i ++) 
-    edm::LogVerbatim("HCalGeom") << i+1 << "\t" << detType[i] << "\t"
-				 << detdP1[i] << ", "  << detdP2[i] << "\t" 
-				 << detT11[i] << ", " << detT12[i] << "\t" 
-				 << detTsc[i] << "\t" << detT21[i] << ", "
-				 << detT22[i] << "\t" << detWidth1[i] << "\t" 
-				 << detWidth2[i] << "\t" << detPosY[i];
+  for (int i = 0; i < nLayers; i++)
+    edm::LogVerbatim("HCalGeom") << i + 1 << "\t" << detType[i] << "\t" << detdP1[i] << ", " << detdP2[i] << "\t"
+                                 << detT11[i] << ", " << detT12[i] << "\t" << detTsc[i] << "\t" << detT21[i] << ", "
+                                 << detT22[i] << "\t" << detWidth1[i] << "\t" << detWidth2[i] << "\t" << detPosY[i];
 #endif
 
   //  idName = parentName.name();
-  idName      = sArgs["MotherName"];
+  idName = sArgs["MotherName"];
   idNameSpace = DDCurrentNamespace::ns();
-  idOffset = int (nArgs["IdOffset"]); 
+  idOffset = int(nArgs["IdOffset"]);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Parent " <<parent().name()
-			       <<" idName " << idName << " NameSpace "
-			       << idNameSpace << " Offset " << idOffset;
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Parent " << parent().name() << " idName " << idName
+                               << " NameSpace " << idNameSpace << " Offset " << idOffset;
 #endif
 }
 
@@ -203,7 +217,6 @@ void DDHCalBarrelAlgo::initialize(const DDNumericArguments & nArgs,
 ////////////////////////////////////////////////////////////////////
 
 void DDHCalBarrelAlgo::execute(DDCompactView& cpv) {
-
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "==>> Constructing DDHCalBarrelAlgo...";
 #endif
@@ -216,16 +229,15 @@ void DDHCalBarrelAlgo::execute(DDCompactView& cpv) {
 //----------------------start here for DDD work!!! ---------------
 
 void DDHCalBarrelAlgo::constructGeneralVolume(DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: General volume...";
 #endif
 
   DDRotation rot = DDRotation();
 
-  double alpha = (1._pi)/getNsectors();
-  double dphi  = getNsectortot()*(2._pi)/getNsectors();
-  int nsec, ntot=15;
+  double alpha = (1._pi) / getNsectors();
+  double dphi = getNsectortot() * (2._pi) / getNsectors();
+  int nsec, ntot = 15;
   if (getNhalf() == 1)
     nsec = 8;
   else
@@ -234,326 +246,305 @@ void DDHCalBarrelAlgo::constructGeneralVolume(DDCompactView& cpv) {
 
   //Calculate zmin... see HCalBarrel.hh picture. For polyhedra
   //Rmin and Rmax are distances to vertex
-  double zmax   = getZoff(3);
+  double zmax = getZoff(3);
   double zstep5 = getZoff(4);
-  double zstep4 =(getZoff(1) + getRmax(1)*getTanTheta(1));
-  if ((getZoff(2)+getRmax(1)*getTanTheta(2)) > zstep4)
-    zstep4 = (getZoff(2)+getRmax(1)*getTanTheta(2));
-  double zstep3 =(getZoff(1) + getRmax(0)*getTanTheta(1));
-  double zstep2 =(getZoff(0) + getRmax(0)*getTanTheta(0));
-  double zstep1 =(getZoff(0) + getRin()  *getTanTheta(0));
-  double rout   = getRout();
-  double rout1  = getRmax(3);
-  double rin    = getRin();
-  double rmid1  = getRmax(0);
-  double rmid2  = getRmax(1);
-  double rmid3  =(getZoff(4) - getZoff(2))/getTanTheta(2);
-  double rmid4  = getRmax(2);
+  double zstep4 = (getZoff(1) + getRmax(1) * getTanTheta(1));
+  if ((getZoff(2) + getRmax(1) * getTanTheta(2)) > zstep4)
+    zstep4 = (getZoff(2) + getRmax(1) * getTanTheta(2));
+  double zstep3 = (getZoff(1) + getRmax(0) * getTanTheta(1));
+  double zstep2 = (getZoff(0) + getRmax(0) * getTanTheta(0));
+  double zstep1 = (getZoff(0) + getRin() * getTanTheta(0));
+  double rout = getRout();
+  double rout1 = getRmax(3);
+  double rin = getRin();
+  double rmid1 = getRmax(0);
+  double rmid2 = getRmax(1);
+  double rmid3 = (getZoff(4) - getZoff(2)) / getTanTheta(2);
+  double rmid4 = getRmax(2);
 
-  std::vector<double> pgonZ = {-zmax,  -zstep5,-zstep5,-zstep4,-zstep3,
-			       -zstep2,-zstep1,      0, zstep1, zstep2, 
-			        zstep3, zstep4, zstep5, zstep5,   zmax};
+  std::vector<double> pgonZ = {-zmax,
+                               -zstep5,
+                               -zstep5,
+                               -zstep4,
+                               -zstep3,
+                               -zstep2,
+                               -zstep1,
+                               0,
+                               zstep1,
+                               zstep2,
+                               zstep3,
+                               zstep4,
+                               zstep5,
+                               zstep5,
+                               zmax};
 
-  std::vector<double> pgonRmin = {rmid4,rmid3,rmid3,rmid2,rmid1, 
-				  rmid1,  rin,  rin,  rin,rmid1, 
-				  rmid1,rmid2,rmid3,rmid3,rmid4};
+  std::vector<double> pgonRmin = {
+      rmid4, rmid3, rmid3, rmid2, rmid1, rmid1, rin, rin, rin, rmid1, rmid1, rmid2, rmid3, rmid3, rmid4};
 
-  std::vector<double> pgonRmax = {rout1,rout1,rout, rout, rout, rout, 
-				  rout, rout, rout, rout, rout, rout, 
-				  rout, rout1,rout1};
+  std::vector<double> pgonRmax = {
+      rout1, rout1, rout, rout, rout, rout, rout, rout, rout, rout, rout, rout, rout, rout1, rout1};
 
-  std::vector<double> pgonZHalf = {0,     zstep1,zstep2,zstep3,zstep4,zstep5, 
-				   zstep5,zmax};
+  std::vector<double> pgonZHalf = {0, zstep1, zstep2, zstep3, zstep4, zstep5, zstep5, zmax};
 
-  std::vector<double> pgonRminHalf = {rin,  rin,rmid1,rmid1,rmid2,rmid3, 
-				      rmid3,rmid4};
+  std::vector<double> pgonRminHalf = {rin, rin, rmid1, rmid1, rmid2, rmid3, rmid3, rmid4};
 
-  std::vector<double> pgonRmaxHalf = {rout, rout, rout, rout, rout, rout, 
-				      rout1,rout1};
+  std::vector<double> pgonRmaxHalf = {rout, rout, rout, rout, rout, rout, rout1, rout1};
 
   std::string name("Null");
   DDSolid solid;
-  if (nf == 0) { 
-    solid = DDSolidFactory::polyhedra(DDName(idName, idNameSpace),
-				      getNsectortot(), -alpha, dphi, pgonZ, 
-				      pgonRmin, pgonRmax);
+  if (nf == 0) {
+    solid = DDSolidFactory::polyhedra(
+        DDName(idName, idNameSpace), getNsectortot(), -alpha, dphi, pgonZ, pgonRmin, pgonRmax);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: "
-				 << DDName(idName, idNameSpace)
-				 << " Polyhedra made of " << getGenMaterial()
-				 << " with " << getNsectortot()
-				 << " sectors from " << convertRadToDeg(-alpha)
-				 << " to " << convertRadToDeg(-alpha+dphi)
-				 << " and with " << nsec << " sections ";
-    for (unsigned int i = 0; i <pgonZ.size(); i++)
-      edm::LogVerbatim("HCalGeom") << "\t" << "\tZ = " << pgonZ[i]
-				   << "\tRmin = " << pgonRmin[i] << "\tRmax = "
-				   << pgonRmax[i];
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << DDName(idName, idNameSpace) << " Polyhedra made of "
+                                 << getGenMaterial() << " with " << getNsectortot() << " sectors from "
+                                 << convertRadToDeg(-alpha) << " to " << convertRadToDeg(-alpha + dphi) << " and with "
+                                 << nsec << " sections ";
+    for (unsigned int i = 0; i < pgonZ.size(); i++)
+      edm::LogVerbatim("HCalGeom") << "\t"
+                                   << "\tZ = " << pgonZ[i] << "\tRmin = " << pgonRmin[i] << "\tRmax = " << pgonRmax[i];
 #endif
   } else {
-    solid = DDSolidFactory::polyhedra(DDName(idName, idNameSpace),
-				      getNsectortot(), -alpha, dphi, pgonZHalf,
-				      pgonRminHalf, pgonRmaxHalf);
+    solid = DDSolidFactory::polyhedra(
+        DDName(idName, idNameSpace), getNsectortot(), -alpha, dphi, pgonZHalf, pgonRminHalf, pgonRmaxHalf);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " 
-				 << DDName(idName, idNameSpace) 
-				 << " Polyhedra made of " << getGenMaterial()
-				 << " with " << getNsectortot()
-				 << " sectors from " << convertRadToDeg(-alpha)
-				 << " to " << convertRadToDeg(-alpha+dphi)
-				 << " and with " << nsec << " sections ";
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << DDName(idName, idNameSpace) << " Polyhedra made of "
+                                 << getGenMaterial() << " with " << getNsectortot() << " sectors from "
+                                 << convertRadToDeg(-alpha) << " to " << convertRadToDeg(-alpha + dphi) << " and with "
+                                 << nsec << " sections ";
     for (unsigned int i = 0; i < pgonZHalf.size(); i++)
-      edm::LogVerbatim("HCalGeom") << "\t" << "\tZ = " << pgonZHalf[i]
-				   << "\tRmin = " << pgonRminHalf[i] 
-				   << "\tRmax = " << pgonRmaxHalf[i];
+      edm::LogVerbatim("HCalGeom") << "\t"
+                                   << "\tZ = " << pgonZHalf[i] << "\tRmin = " << pgonRminHalf[i]
+                                   << "\tRmax = " << pgonRmaxHalf[i];
 #endif
-  }  
-  
+  }
 
   DDName matname(DDSplit(getGenMaterial()).first, DDSplit(getGenMaterial()).second);
   DDMaterial matter(matname);
   DDLogicalPart genlogic(DDName(idName, idNameSpace), matter, solid);
 
-  DDName parentName = parent().name(); 
-  DDTranslation r0(0,0,0);
+  DDName parentName = parent().name();
+  DDTranslation r0(0, 0, 0);
   cpv.position(DDName(idName, idNameSpace), parentName, 1, r0, rot);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " 
-			       << DDName(idName, idNameSpace)
-			       << " number 1 positioned in " << parentName 
-			       << " at " << r0 << " with " << rot;
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << DDName(idName, idNameSpace) << " number 1 positioned in "
+                               << parentName << " at " << r0 << " with " << rot;
 #endif
   //Forward and backwards halfs
   name = idName + "Half";
-  nf   = (ntot+1)/2;
+  nf = (ntot + 1) / 2;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: "
-			       << DDName(name,idNameSpace)
-			       << " Polyhedra made of " << getGenMaterial()
-			       << " with " << getNsectortot() 
-			       << " sectors from " << convertRadToDeg(-alpha)
-			       << " to " << convertRadToDeg(-alpha+dphi) 
-			       << " and with " << nf << " sections "; 
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << DDName(name, idNameSpace) << " Polyhedra made of "
+                               << getGenMaterial() << " with " << getNsectortot() << " sectors from "
+                               << convertRadToDeg(-alpha) << " to " << convertRadToDeg(-alpha + dphi) << " and with "
+                               << nf << " sections ";
   for (unsigned int i = 0; i < pgonZHalf.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t" << "\tZ = " << pgonZHalf[i] 
-				 << "\tRmin = " << pgonRminHalf[i]
-				 << "\tRmax = " << pgonRmaxHalf[i];
+    edm::LogVerbatim("HCalGeom") << "\t"
+                                 << "\tZ = " << pgonZHalf[i] << "\tRmin = " << pgonRminHalf[i]
+                                 << "\tRmax = " << pgonRmaxHalf[i];
 #endif
 
-  solid =   DDSolidFactory::polyhedra(DDName(name, idNameSpace),
-				      getNsectortot(), -alpha, dphi, pgonZHalf,
-				      pgonRminHalf, pgonRmaxHalf);
+  solid = DDSolidFactory::polyhedra(
+      DDName(name, idNameSpace), getNsectortot(), -alpha, dphi, pgonZHalf, pgonRminHalf, pgonRmaxHalf);
   DDLogicalPart genlogich(DDName(name, idNameSpace), matter, solid);
 
   cpv.position(genlogich, genlogic, 1, r0, rot);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: "  << genlogich.name() 
-			       << " number 1 positioned in " << genlogic.name()
-			       << " at " << r0 << " with " << rot;
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << genlogich.name() << " number 1 positioned in "
+                               << genlogic.name() << " at " << r0 << " with " << rot;
 #endif
   if (getNhalf() != 1) {
     rot = DDRotation(DDName(rotHalf, rotns));
     cpv.position(genlogich, genlogic, 2, r0, rot);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << genlogich.name()
-				 << " number 2 positioned in " 
-				 << genlogic.name() << " at " << r0 
-				 << " with " << rot;
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << genlogich.name() << " number 2 positioned in "
+                                 << genlogic.name() << " at " << r0 << " with " << rot;
 #endif
-  } //end if (getNhalf...
-  
+  }  //end if (getNhalf...
+
   //Construct sector (from -alpha to +alpha)
   name = idName + "Module";
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: "
-			       << DDName(name,idNameSpace)
-			       << " Polyhedra made of " << getGenMaterial() 
-			       << " with 1 sector from "
-			       << convertRadToDeg(-alpha) << " to "
-			       << convertRadToDeg(alpha) << " and with " 
-			       << nf <<" sections";
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << DDName(name, idNameSpace) << " Polyhedra made of "
+                               << getGenMaterial() << " with 1 sector from " << convertRadToDeg(-alpha) << " to "
+                               << convertRadToDeg(alpha) << " and with " << nf << " sections";
   for (unsigned int i = 0; i < pgonZHalf.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t" << "\tZ = " << pgonZHalf[i]
-				 << "\tRmin = " << pgonRminHalf[i]
-				 << "\tRmax = " << pgonRmaxHalf[i];
+    edm::LogVerbatim("HCalGeom") << "\t"
+                                 << "\tZ = " << pgonZHalf[i] << "\tRmin = " << pgonRminHalf[i]
+                                 << "\tRmax = " << pgonRmaxHalf[i];
 #endif
 
-  solid =   DDSolidFactory::polyhedra(DDName(name, idNameSpace),
-				      1, -alpha, 2*alpha, pgonZHalf,
-				      pgonRminHalf, pgonRmaxHalf);
+  solid =
+      DDSolidFactory::polyhedra(DDName(name, idNameSpace), 1, -alpha, 2 * alpha, pgonZHalf, pgonRminHalf, pgonRmaxHalf);
   DDLogicalPart seclogic(DDName(name, idNameSpace), matter, solid);
-  
+
   double theta = 90._deg;
-  for (int ii=0; ii<getNsectortot(); ii++) {
-    double phi    = ii*2*alpha;
-    double phiy   = phi + 90._deg;
-    
+  for (int ii = 0; ii < getNsectortot(); ii++) {
+    double phi = ii * 2 * alpha;
+    double phiy = phi + 90._deg;
+
     DDRotation rotation;
     std::string rotstr("NULL");
     if (phi != 0) {
       rotstr = "R" + formatAsDegreesInInteger(phi);
-      rotation = DDRotation(DDName(rotstr, rotns)); 
+      rotation = DDRotation(DDName(rotstr, rotns));
       if (!rotation) {
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Creating a new "
-				     << "rotation " << rotstr << "\t 90," 
-				     << convertRadToDeg(phi) << ",90," 
-				     << (90+convertRadToDeg(phi)) << ", 0, 0";
+        edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Creating a new "
+                                     << "rotation " << rotstr << "\t 90," << convertRadToDeg(phi) << ",90,"
+                                     << (90 + convertRadToDeg(phi)) << ", 0, 0";
 #endif
-	rotation = DDrot(DDName(rotstr, rotns), theta, phi, theta, phiy, 0, 0);
-      } //if !rotation
-    } //if phideg!=0
-  
-    cpv.position(seclogic, genlogich, ii+1, r0, rotation);
+        rotation = DDrot(DDName(rotstr, rotns), theta, phi, theta, phiy, 0, 0);
+      }  //if !rotation
+    }    //if phideg!=0
+
+    cpv.position(seclogic, genlogich, ii + 1, r0, rotation);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << seclogic.name() 
-				 << " number " << ii+1 << " positioned in " 
-				 << genlogich.name() << " at " << r0 
-				 << " with " << rotation;
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << seclogic.name() << " number " << ii + 1 << " positioned in "
+                                 << genlogich.name() << " at " << r0 << " with " << rotation;
 #endif
   }
-  
+
   //Construct the things inside the sector
   constructInsideSector(seclogic, cpv);
 }
 
-
 void DDHCalBarrelAlgo::constructInsideSector(const DDLogicalPart& sector, DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Layers (" << getNLayers()
-			       << ") ...";
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: Layers (" << getNLayers() << ") ...";
 #endif
-  double alpha = (1._pi)/getNsectors();
-  double rin   = getRin();
+  double alpha = (1._pi) / getNsectors();
+  double rin = getRin();
   for (int i = 0; i < getNLayers(); i++) {
-    std::string  name   = idName + getLayerLabel(i);
-    DDName matname(DDSplit(getLayerMaterial(i)).first, 
-		   DDSplit(getLayerMaterial(i)).second); //idNameSpace);
+    std::string name = idName + getLayerLabel(i);
+    DDName matname(DDSplit(getLayerMaterial(i)).first,
+                   DDSplit(getLayerMaterial(i)).second);  //idNameSpace);
     DDMaterial matter(matname);
 
     double width = getLayerWidth(i);
-    double rout  = rin + width;
+    double rout = rin + width;
 
-    int    in = 0, out = 0;
-    for (int j = 0; j < getRzones()-1; j++) {
-      if (rin >= getRmax(j)) in = j+1;
-      if (rout>  getRmax(j)) out= j+1;
+    int in = 0, out = 0;
+    for (int j = 0; j < getRzones() - 1; j++) {
+      if (rin >= getRmax(j))
+        in = j + 1;
+      if (rout > getRmax(j))
+        out = j + 1;
     }
-    double zout  = getZoff(in) + rin*getTanTheta(in);
+    double zout = getZoff(in) + rin * getTanTheta(in);
 
     //!!!!!!!!!!!!!!!!!Should be zero. And removed as soon as
     //vertical walls are allowed in SolidPolyhedra
     double deltaz = 0;
-    int    nsec=2;
+    int nsec = 2;
     std::vector<double> pgonZ, pgonRmin, pgonRmax;
     // index 0
     pgonZ.emplace_back(0);
-    pgonRmin.emplace_back(rin); 
+    pgonRmin.emplace_back(rin);
     pgonRmax.emplace_back(rout);
     // index 1
-    pgonZ.emplace_back(zout);  
-    pgonRmin.emplace_back(rin); 
+    pgonZ.emplace_back(zout);
+    pgonRmin.emplace_back(rin);
     pgonRmax.emplace_back(rout);
     if (in == out) {
       if (in <= 3) {
-	//index 2
-	pgonZ.emplace_back(getZoff(in) + rout*getTanTheta(in));
-	pgonRmin.emplace_back(pgonRmax[1]);
-	pgonRmax.emplace_back(pgonRmax[1]);
-	nsec++;
+        //index 2
+        pgonZ.emplace_back(getZoff(in) + rout * getTanTheta(in));
+        pgonRmin.emplace_back(pgonRmax[1]);
+        pgonRmax.emplace_back(pgonRmax[1]);
+        nsec++;
       }
     } else {
       if (in == 3) {
-	//redo index 1, add index 2
-	pgonZ[1]    =(getZoff(out) + getRmax(out)*getTanTheta(out));
-	pgonZ.emplace_back(pgonZ[1] + deltaz);
-	pgonRmin.emplace_back(pgonRmin[1]); 
-	pgonRmax.emplace_back(getRmax(in));
-	//index 3 
-	pgonZ.emplace_back(getZoff(in) + getRmax(in)*getTanTheta(in));
-	pgonRmin.emplace_back(pgonRmin[2]); 
-	pgonRmax.emplace_back(pgonRmax[2]);
-        nsec       += 2;
+        //redo index 1, add index 2
+        pgonZ[1] = (getZoff(out) + getRmax(out) * getTanTheta(out));
+        pgonZ.emplace_back(pgonZ[1] + deltaz);
+        pgonRmin.emplace_back(pgonRmin[1]);
+        pgonRmax.emplace_back(getRmax(in));
+        //index 3
+        pgonZ.emplace_back(getZoff(in) + getRmax(in) * getTanTheta(in));
+        pgonRmin.emplace_back(pgonRmin[2]);
+        pgonRmax.emplace_back(pgonRmax[2]);
+        nsec += 2;
       } else {
-	//index 2
-	pgonZ.emplace_back(getZoff(in) + getRmax(in)*getTanTheta(in));
-	pgonRmin.emplace_back(getRmax(in)); 
-	pgonRmax.emplace_back(pgonRmax[1]); 
-	nsec++;
-	if (in == 0) {
-	  pgonZ.emplace_back(getZoff(out) + getRmax(in)*getTanTheta(out));
-          pgonRmin.emplace_back(pgonRmin[2]); 
-	  pgonRmax.emplace_back(pgonRmax[2]);
-	  nsec++;
-	}
-	if (in <= 1) {
-	  pgonZ.emplace_back(getZoff(out) + rout*getTanTheta(out));
-	  pgonRmin.emplace_back(rout);
-	  pgonRmax.emplace_back(rout);
-	  nsec++;
-	}
+        //index 2
+        pgonZ.emplace_back(getZoff(in) + getRmax(in) * getTanTheta(in));
+        pgonRmin.emplace_back(getRmax(in));
+        pgonRmax.emplace_back(pgonRmax[1]);
+        nsec++;
+        if (in == 0) {
+          pgonZ.emplace_back(getZoff(out) + getRmax(in) * getTanTheta(out));
+          pgonRmin.emplace_back(pgonRmin[2]);
+          pgonRmax.emplace_back(pgonRmax[2]);
+          nsec++;
+        }
+        if (in <= 1) {
+          pgonZ.emplace_back(getZoff(out) + rout * getTanTheta(out));
+          pgonRmin.emplace_back(rout);
+          pgonRmax.emplace_back(rout);
+          nsec++;
+        }
       }
     }
     //Solid & volume
     DDSolid solid;
-    double  alpha1 = alpha;
-    if (getLayerGap(i)>1.e-6) {
-      double rmid  = 0.5*(rin+rout);
-      double width = rmid*tan(alpha) - getLayerGap(i);
-      alpha1 = atan(width/rmid);
+    double alpha1 = alpha;
+    if (getLayerGap(i) > 1.e-6) {
+      double rmid = 0.5 * (rin + rout);
+      double width = rmid * tan(alpha) - getLayerGap(i);
+      alpha1 = atan(width / rmid);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "\t" << "Alpha_1 modified from " 
-				   << convertRadToDeg(alpha) << " to " 
-				   << convertRadToDeg(alpha1) 
-				   << " Rmid " << rmid << " Reduced width "
-				   << width;
+      edm::LogVerbatim("HCalGeom") << "\t"
+                                   << "Alpha_1 modified from " << convertRadToDeg(alpha) << " to "
+                                   << convertRadToDeg(alpha1) << " Rmid " << rmid << " Reduced width " << width;
 #endif
     }
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << name << " (Layer " 
-				 << i << ") Polyhedra made of " 
-				 << getLayerMaterial(i)
-				 << " with 1 sector from "
-				 << convertRadToDeg(-alpha1) << " to " 
-				 << convertRadToDeg(alpha1) << " and with " 
-				 << nsec << " sections";
-    for (unsigned int k=0; k<pgonZ.size(); k++)
-      edm::LogVerbatim("HCalGeom") << "\t" << "\t" << pgonZ[k] << "\t"
-				   << pgonRmin[k] << "\t" << pgonRmax[k];
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << name << " (Layer " << i << ") Polyhedra made of "
+                                 << getLayerMaterial(i) << " with 1 sector from " << convertRadToDeg(-alpha1) << " to "
+                                 << convertRadToDeg(alpha1) << " and with " << nsec << " sections";
+    for (unsigned int k = 0; k < pgonZ.size(); k++)
+      edm::LogVerbatim("HCalGeom") << "\t"
+                                   << "\t" << pgonZ[k] << "\t" << pgonRmin[k] << "\t" << pgonRmax[k];
 #endif
-    solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 
-				      1, -alpha1, 2*alpha1,
-				      pgonZ, pgonRmin, pgonRmax);
+    solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 1, -alpha1, 2 * alpha1, pgonZ, pgonRmin, pgonRmax);
     DDLogicalPart glog(DDName(name, idNameSpace), matter, solid);
 
-   cpv.position(glog, sector, getLayerId(i), DDTranslation(0.0, 0.0, 0.0), 
-		DDRotation());
+    cpv.position(glog, sector, getLayerId(i), DDTranslation(0.0, 0.0, 0.0), DDRotation());
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() 
-				 << " number " << getLayerId(i)
-				 << " positioned in " << sector.name()
-				 << " at (0,0,0) with no rotation";
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() << " number " << getLayerId(i)
+                                 << " positioned in " << sector.name() << " at (0,0,0) with no rotation";
 #endif
-    constructInsideLayers(glog, getLayerLabel(i), getLayerId(i), 
-			  getLayerAbsorb(i), rin,  getLayerD1(i), alpha1, 
-			  getLayerD2(i), getLayerAlpha(i), getLayerT1(i),
-			  getLayerT2(i), cpv);
+    constructInsideLayers(glog,
+                          getLayerLabel(i),
+                          getLayerId(i),
+                          getLayerAbsorb(i),
+                          rin,
+                          getLayerD1(i),
+                          alpha1,
+                          getLayerD2(i),
+                          getLayerAlpha(i),
+                          getLayerT1(i),
+                          getLayerT2(i),
+                          cpv);
     rin = rout;
   }
-  
 }
 
 void DDHCalBarrelAlgo::constructInsideLayers(const DDLogicalPart& laylog,
-					     const std::string& nm, int id,
-					     int nAbs, double rin, double d1, 
-					     double alpha1, double d2, 
-					     double alpha2, double t1,
-					     double t2, DDCompactView& cpv) {
-  
+                                             const std::string& nm,
+                                             int id,
+                                             int nAbs,
+                                             double rin,
+                                             double d1,
+                                             double alpha1,
+                                             double d2,
+                                             double alpha2,
+                                             double t1,
+                                             double t2,
+                                             DDCompactView& cpv) {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: \t\tInside layer " << id 
-			       << "...";
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: \t\tInside layer " << id << "...";
 #endif
   ///////////////////////////////////////////////////////////////
   //Pointers to the Rotation Matrices and to the Materials
@@ -562,33 +553,32 @@ void DDHCalBarrelAlgo::constructInsideLayers(const DDLogicalPart& laylog,
   std::string nam0 = nm + "In";
   std::string name = idName + nam0;
   DDName matName(DDSplit(getDetMat()).first, DDSplit(getDetMat()).second);
-  DDMaterial matter (matName);
+  DDMaterial matter(matName);
 
-  DDSolid        solid;
-  DDLogicalPart  glog, mother;
-  double         rsi, dx, dy, dz, x, y;
-  int            i, in;
+  DDSolid solid;
+  DDLogicalPart glog, mother;
+  double rsi, dx, dy, dz, x, y;
+  int i, in;
   //Two lower volumes
   if (alpha1 > 0) {
     rsi = rin + d1;
-    in  = 0;
-    for (i = 0; i < getRzones()-1; i++) {
-      if (rsi >= getRmax(i)) in = i+1;
+    in = 0;
+    for (i = 0; i < getRzones() - 1; i++) {
+      if (rsi >= getRmax(i))
+        in = i + 1;
     }
-    dx = 0.5*t1;
-    dy = 0.5*rsi*(tan(alpha1)-tan(alpha2));
-    dz = 0.5*(getZoff(in) + rsi*getTanTheta(in));
-    x  = rsi + dx;
-    y  = 0.5*rsi*(tan(alpha1)+tan(alpha2));
+    dx = 0.5 * t1;
+    dy = 0.5 * rsi * (tan(alpha1) - tan(alpha2));
+    dz = 0.5 * (getZoff(in) + rsi * getTanTheta(in));
+    x = rsi + dx;
+    y = 0.5 * rsi * (tan(alpha1) + tan(alpha2));
     DDTranslation r11(x, y, dz);
     DDTranslation r12(x, -y, dz);
 
-    solid = DDSolidFactory::box(DDName(name+"1", idNameSpace), dx, dy, dz);
+    solid = DDSolidFactory::box(DDName(name + "1", idNameSpace), dx, dy, dz);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-				 <<" Box made of " << getDetMat()
-				 << " of dimensions " << dx << ", " << dy 
-				 << ", " << dz;
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Box made of " << getDetMat()
+                                 << " of dimensions " << dx << ", " << dy << ", " << dz;
 #endif
     glog = DDLogicalPart(solid.ddname(), matter, solid);
 
@@ -597,41 +587,36 @@ void DDHCalBarrelAlgo::constructInsideLayers(const DDLogicalPart& laylog,
     } else {
       mother = laylog;
     }
-    cpv.position(glog, mother, idOffset+1, r11, DDRotation());
-    cpv.position(glog, mother, idOffset+2, r12, rot);
+    cpv.position(glog, mother, idOffset + 1, r11, DDRotation());
+    cpv.position(glog, mother, idOffset + 2, r12, rot);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() 
-				 << " Number " << idOffset+1 
-				 << " positioned in " << mother.name() 
-				 << " at " << r11 << " with no rotation\n"
-				 << "DDHCalBarrelAlgo: " << glog.name() 
-				 << " Number " << idOffset+2 
-				 << " positioned in " << mother.name() 
-				 << " at " << r12 << " with " << rot;
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() << " Number " << idOffset + 1
+                                 << " positioned in " << mother.name() << " at " << r11 << " with no rotation\n"
+                                 << "DDHCalBarrelAlgo: " << glog.name() << " Number " << idOffset + 2
+                                 << " positioned in " << mother.name() << " at " << r12 << " with " << rot;
 #endif
     //Constructin the plastics and scintillators inside
-    constructInsideDetectors(glog, nam0+"1", id, dx, dy, dz, 1, cpv);
+    constructInsideDetectors(glog, nam0 + "1", id, dx, dy, dz, 1, cpv);
   }
 
   //Upper volume
   rsi = rin + d2;
-  in  = 0;
-  for (i = 0; i < getRzones()-1; i++) {
-    if (rsi >= getRmax(i)) in = i+1;
+  in = 0;
+  for (i = 0; i < getRzones() - 1; i++) {
+    if (rsi >= getRmax(i))
+      in = i + 1;
   }
-  dx  = 0.5*t2;
-  dy  = 0.5*rsi*tan(alpha2);
-  dz  = 0.5*(getZoff(in) + rsi*getTanTheta(in));
-  x   = rsi + dx;
+  dx = 0.5 * t2;
+  dy = 0.5 * rsi * tan(alpha2);
+  dz = 0.5 * (getZoff(in) + rsi * getTanTheta(in));
+  x = rsi + dx;
   DDTranslation r21(x, dy, dz);
   DDTranslation r22(x, -dy, dz);
-  
-  solid = DDSolidFactory::box(DDName(name+"2", idNameSpace), dx, dy, dz);
+
+  solid = DDSolidFactory::box(DDName(name + "2", idNameSpace), dx, dy, dz);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-			       << " Box made of " << getDetMat()
-			       << " of dimensions " << dx << ", " << dy 
-			       << ", " << dz;
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Box made of " << getDetMat()
+                               << " of dimensions " << dx << ", " << dy << ", " << dz;
 #endif
   glog = DDLogicalPart(solid.ddname(), matter, solid);
 
@@ -640,61 +625,51 @@ void DDHCalBarrelAlgo::constructInsideLayers(const DDLogicalPart& laylog,
   } else {
     mother = laylog;
   }
-  cpv.position(glog, mother, idOffset+3, r21, DDRotation());
-  cpv.position(glog, mother, idOffset+4, r22, rot);
+  cpv.position(glog, mother, idOffset + 3, r21, DDRotation());
+  cpv.position(glog, mother, idOffset + 4, r22, rot);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() 
-			       << " Number " << idOffset+3 << " positioned in "
-			       << mother.name() << " at " << r21 
-			       << " with no rotation\nDDHCalBarrelAlgo: "
-			       << glog.name() << " Number " << idOffset+4 
-			       << " positioned in " << mother.name() << " at " 
-			       << r22 << " with " << rot;
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() << " Number " << idOffset + 3 << " positioned in "
+                               << mother.name() << " at " << r21
+                               << " with no rotation\nDDHCalBarrelAlgo: " << glog.name() << " Number " << idOffset + 4
+                               << " positioned in " << mother.name() << " at " << r22 << " with " << rot;
 #endif
   //Constructin the plastics and scintillators inside
-  constructInsideDetectors(glog, nam0+"2", id, dx, dy, dz, 2, cpv);
+  constructInsideDetectors(glog, nam0 + "2", id, dx, dy, dz, 2, cpv);
 }
 
-DDLogicalPart DDHCalBarrelAlgo::constructSideLayer(const DDLogicalPart& laylog,
-						   const std::string& nm,
-						   int nAbs,  double rin,
-						   double alpha,
-						   DDCompactView& cpv) {
-
+DDLogicalPart DDHCalBarrelAlgo::constructSideLayer(
+    const DDLogicalPart& laylog, const std::string& nm, int nAbs, double rin, double alpha, DDCompactView& cpv) {
   //Extra absorber layer
   int k = abs(nAbs) - 1;
   std::string namek = nm + "Side";
-  double rsi   = rin + getSideD(k);
-  int    in  = 0;
-  for (int i = 0; i < getRzones()-1; i++) {
-    if (rsi >= getRmax(i)) in = i+1;
+  double rsi = rin + getSideD(k);
+  int in = 0;
+  for (int i = 0; i < getRzones() - 1; i++) {
+    if (rsi >= getRmax(i))
+      in = i + 1;
   }
   std::vector<double> pgonZ, pgonRmin, pgonRmax;
   // index 0
-  pgonZ.emplace_back(0.0);     
-  pgonRmin.emplace_back(rsi); 
-  pgonRmax.emplace_back(rsi+getSideT(k));
+  pgonZ.emplace_back(0.0);
+  pgonRmin.emplace_back(rsi);
+  pgonRmax.emplace_back(rsi + getSideT(k));
   // index 1
-  pgonZ.emplace_back(getZoff(in) + rsi*getTanTheta(in));  
-  pgonRmin.emplace_back(rsi); 
+  pgonZ.emplace_back(getZoff(in) + rsi * getTanTheta(in));
+  pgonRmin.emplace_back(rsi);
   pgonRmax.emplace_back(pgonRmax[0]);
   // index 2
-  pgonZ.emplace_back(getZoff(in) + pgonRmax[0]*getTanTheta(in));
+  pgonZ.emplace_back(getZoff(in) + pgonRmax[0] * getTanTheta(in));
   pgonRmin.emplace_back(pgonRmax[1]);
   pgonRmax.emplace_back(pgonRmax[1]);
-  DDSolid solid = DDSolidFactory::polyhedra(DDName(namek, idNameSpace), 1, 
-					    -alpha, 2*alpha, pgonZ, pgonRmin, 
-					    pgonRmax);
+  DDSolid solid =
+      DDSolidFactory::polyhedra(DDName(namek, idNameSpace), 1, -alpha, 2 * alpha, pgonZ, pgonRmin, pgonRmax);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-			       << " Polyhedra made of " << getSideMat(k) 
-			       << " with 1 sector from "
-			       << convertRadToDeg(-alpha) << " to "
-			       << convertRadToDeg(alpha) << " and with "
-			       << pgonZ.size() << " sections";
-  for (unsigned int ii=0; ii<pgonZ.size(); ii++) 
-    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] << "\tRmin = " 
-				 << pgonRmin[ii] << "\tRmax = " <<pgonRmax[ii];
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Polyhedra made of " << getSideMat(k)
+                               << " with 1 sector from " << convertRadToDeg(-alpha) << " to " << convertRadToDeg(alpha)
+                               << " and with " << pgonZ.size() << " sections";
+  for (unsigned int ii = 0; ii < pgonZ.size(); ii++)
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] << "\tRmin = " << pgonRmin[ii]
+                                 << "\tRmax = " << pgonRmax[ii];
 #endif
 
   DDName matName(DDSplit(getSideMat(k)).first, DDSplit(getSideMat(k)).second);
@@ -703,94 +678,76 @@ DDLogicalPart DDHCalBarrelAlgo::constructSideLayer(const DDLogicalPart& laylog,
 
   cpv.position(glog, laylog, 1, DDTranslation(), DDRotation());
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() 
-			       << " Number 1 positioned in " << laylog.name()
-			       << " at (0,0,0) with no rotation";
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() << " Number 1 positioned in " << laylog.name()
+                               << " at (0,0,0) with no rotation";
 #endif
   if (nAbs < 0) {
     DDLogicalPart mother = glog;
-    double rmid  = pgonRmax[0];
+    double rmid = pgonRmax[0];
     for (int i = 0; i < getSideAbsorber(); i++) {
-      double alpha1 = atan(getSideAbsW(i)/rmid);  
+      double alpha1 = atan(getSideAbsW(i) / rmid);
       if (alpha1 > 0) {
-	std::string name   = namek + getSideAbsName(i);
-	solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 1, 
-					  -alpha1, 2*alpha1, pgonZ, pgonRmin, 
-					  pgonRmax);
+        std::string name = namek + getSideAbsName(i);
+        solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 1, -alpha1, 2 * alpha1, pgonZ, pgonRmin, pgonRmax);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-				     << " Polyhedra made of " 
-				     << getSideAbsMat(i) 
-				     << " with 1 sector from " 
-				     << convertRadToDeg(-alpha1) << " to "
-				     << convertRadToDeg(alpha1) << " and with "
-				     << pgonZ.size() << " sections";
-	for (unsigned int ii=0; ii<pgonZ.size(); ii++)
-	  edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii]
-				       << "\tRmin = " << pgonRmin[ii]
-				       << "\tRmax = " << pgonRmax[ii];
+        edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Polyhedra made of "
+                                     << getSideAbsMat(i) << " with 1 sector from " << convertRadToDeg(-alpha1) << " to "
+                                     << convertRadToDeg(alpha1) << " and with " << pgonZ.size() << " sections";
+        for (unsigned int ii = 0; ii < pgonZ.size(); ii++)
+          edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] << "\tRmin = " << pgonRmin[ii]
+                                       << "\tRmax = " << pgonRmax[ii];
 #endif
 
-	DDName matName(DDSplit(getSideAbsMat(i)).first, 
-		       DDSplit(getSideAbsMat(i)).second);
-	DDMaterial matter(matName);
-	DDLogicalPart log = DDLogicalPart(solid.ddname(), matter, solid);
+        DDName matName(DDSplit(getSideAbsMat(i)).first, DDSplit(getSideAbsMat(i)).second);
+        DDMaterial matter(matName);
+        DDLogicalPart log = DDLogicalPart(solid.ddname(), matter, solid);
 
-	cpv.position(log, mother, 1, DDTranslation(), DDRotation());
+        cpv.position(log, mother, 1, DDTranslation(), DDRotation());
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << log.name() 
-				     << " Number 1 positioned in " 
-				     << mother.name()
-				     << " at (0,0,0) with no rotation";
+        edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << log.name() << " Number 1 positioned in "
+                                     << mother.name() << " at (0,0,0) with no rotation";
 #endif
-	mother = log;
+        mother = log;
       }
     }
   }
   return glog;
 }
 
-DDLogicalPart DDHCalBarrelAlgo::constructMidLayer(const DDLogicalPart& laylog,
-						  const std::string& nm,
-						  double rin, double alpha,
-						  DDCompactView& cpv) {
-
-  DDSolid       solid;
+DDLogicalPart DDHCalBarrelAlgo::constructMidLayer(
+    const DDLogicalPart& laylog, const std::string& nm, double rin, double alpha, DDCompactView& cpv) {
+  DDSolid solid;
   DDLogicalPart log, glog;
   std::string name = nm + "Mid";
-  for (int k=0; k < getAbsorberN(); k++) {
+  for (int k = 0; k < getAbsorberN(); k++) {
     std::string namek = name + getAbsorbName(k);
-    double rsi   = rin + getAbsorbD(k);
-    int    in  = 0;
-    for (int i = 0; i < getRzones()-1; i++) {
-      if (rsi >= getRmax(i)) in = i+1;
+    double rsi = rin + getAbsorbD(k);
+    int in = 0;
+    for (int i = 0; i < getRzones() - 1; i++) {
+      if (rsi >= getRmax(i))
+        in = i + 1;
     }
     std::vector<double> pgonZ, pgonRmin, pgonRmax;
     // index 0
-    pgonZ.emplace_back(0.0);     
-    pgonRmin.emplace_back(rsi); 
-    pgonRmax.emplace_back(rsi+getAbsorbT(k));
+    pgonZ.emplace_back(0.0);
+    pgonRmin.emplace_back(rsi);
+    pgonRmax.emplace_back(rsi + getAbsorbT(k));
     // index 1
-    pgonZ.emplace_back(getZoff(in) + rsi*getTanTheta(in));  
-    pgonRmin.emplace_back(rsi); 
+    pgonZ.emplace_back(getZoff(in) + rsi * getTanTheta(in));
+    pgonRmin.emplace_back(rsi);
     pgonRmax.emplace_back(pgonRmax[0]);
     // index 2
-    pgonZ.emplace_back(getZoff(in) + pgonRmax[0]*getTanTheta(in));
+    pgonZ.emplace_back(getZoff(in) + pgonRmax[0] * getTanTheta(in));
     pgonRmin.emplace_back(pgonRmax[1]);
     pgonRmax.emplace_back(pgonRmax[1]);
-    solid = DDSolidFactory::polyhedra(DDName(namek, idNameSpace), 1, -alpha, 
-				      2*alpha, pgonZ, pgonRmin, pgonRmax);
+    solid = DDSolidFactory::polyhedra(DDName(namek, idNameSpace), 1, -alpha, 2 * alpha, pgonZ, pgonRmin, pgonRmax);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-				 << " Polyhedra made of " << getAbsorbMat(k) 
-				 << " with 1 sector from " 
-				 << convertRadToDeg(-alpha) << " to "
-				 << convertRadToDeg(alpha) << " and with "
-				 << pgonZ.size() << " sections";
-    for (unsigned int ii=0; ii<pgonZ.size(); ii++)
-      edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] << "\tRmin = " 
-				   << pgonRmin[ii] << "\tRmax = "
-				   << pgonRmax[ii];
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Polyhedra made of " << getAbsorbMat(k)
+                                 << " with 1 sector from " << convertRadToDeg(-alpha) << " to "
+                                 << convertRadToDeg(alpha) << " and with " << pgonZ.size() << " sections";
+    for (unsigned int ii = 0; ii < pgonZ.size(); ii++)
+      edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] << "\tRmin = " << pgonRmin[ii]
+                                   << "\tRmax = " << pgonRmax[ii];
 #endif
 
     DDName matName(DDSplit(getAbsorbMat(k)).first, DDSplit(getAbsorbMat(k)).second);
@@ -799,215 +756,188 @@ DDLogicalPart DDHCalBarrelAlgo::constructMidLayer(const DDLogicalPart& laylog,
 
     cpv.position(log, laylog, 1, DDTranslation(), DDRotation());
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << log.name() 
-				 << " Number 1 positioned in " << laylog.name()
-				 << " at (0,0,0) with no rotation";
+    edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << log.name() << " Number 1 positioned in " << laylog.name()
+                                 << " at (0,0,0) with no rotation";
 #endif
-    if (k==0) {
-      double rmin   = pgonRmin[0];
-      double rmax   = pgonRmax[0];
+    if (k == 0) {
+      double rmin = pgonRmin[0];
+      double rmax = pgonRmax[0];
       DDLogicalPart mother = log;
-      for (int i=0; i<1; i++) {
-	double alpha1 = atan(getMidAbsW(i)/rmin);
-	std::string namek  = name + getMidAbsName(i);
-	solid = DDSolidFactory::polyhedra(DDName(namek, idNameSpace), 1, 
-					  -alpha1, 2*alpha1, pgonZ, pgonRmin, 
-					  pgonRmax);
+      for (int i = 0; i < 1; i++) {
+        double alpha1 = atan(getMidAbsW(i) / rmin);
+        std::string namek = name + getMidAbsName(i);
+        solid =
+            DDSolidFactory::polyhedra(DDName(namek, idNameSpace), 1, -alpha1, 2 * alpha1, pgonZ, pgonRmin, pgonRmax);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-				     << " Polyhedra made of " <<getMidAbsMat(i)
-				     << " with 1 sector from " 
-				     << convertRadToDeg(-alpha1) << " to " 
-				     << convertRadToDeg(alpha1) << " and with "
-				     << pgonZ.size() << " sections";
-	for (unsigned int ii=0; ii<pgonZ.size(); ii++)
-	  edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii]
-				       << "\tRmin = " << pgonRmin[ii] 
-				       << "\tRmax = " << pgonRmax[ii];
+        edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Polyhedra made of " << getMidAbsMat(i)
+                                     << " with 1 sector from " << convertRadToDeg(-alpha1) << " to "
+                                     << convertRadToDeg(alpha1) << " and with " << pgonZ.size() << " sections";
+        for (unsigned int ii = 0; ii < pgonZ.size(); ii++)
+          edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] << "\tRmin = " << pgonRmin[ii]
+                                       << "\tRmax = " << pgonRmax[ii];
 #endif
 
-	DDName matNam1(DDSplit(getMidAbsMat(i)).first, 
-		       DDSplit(getMidAbsMat(i)).second);
-	DDMaterial matter1(matNam1);
-	log = DDLogicalPart(solid.ddname(), matter1, solid);
+        DDName matNam1(DDSplit(getMidAbsMat(i)).first, DDSplit(getMidAbsMat(i)).second);
+        DDMaterial matter1(matNam1);
+        log = DDLogicalPart(solid.ddname(), matter1, solid);
 
-	cpv.position(log, mother, 1, DDTranslation(), DDRotation());
+        cpv.position(log, mother, 1, DDTranslation(), DDRotation());
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << log.name() 
-				     << " Number 1 positioned in "
-				     << mother.name()
-				     << " at (0,0,0) with no rotation";
+        edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << log.name() << " Number 1 positioned in "
+                                     << mother.name() << " at (0,0,0) with no rotation";
 #endif
-	mother = log;
+        mother = log;
       }
 
       // Now the layer with detectors
       double rmid = rmin + getMiddleD();
-      pgonRmin[0] = rmid; pgonRmax[0] = rmax;
-      pgonRmin[1] = rmid; pgonRmax[1] = rmax; pgonZ[1] = getZoff(in) + rmid*getTanTheta(in);
-      pgonRmin[2] = rmax; pgonRmax[2] = rmax; pgonZ[2] = getZoff(in) + rmax*getTanTheta(in);
-      double alpha1 = atan(getMiddleW()/rmin);
-      solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 1, 
-					-alpha1, 2*alpha1, pgonZ, pgonRmin, 
-					pgonRmax);
+      pgonRmin[0] = rmid;
+      pgonRmax[0] = rmax;
+      pgonRmin[1] = rmid;
+      pgonRmax[1] = rmax;
+      pgonZ[1] = getZoff(in) + rmid * getTanTheta(in);
+      pgonRmin[2] = rmax;
+      pgonRmax[2] = rmax;
+      pgonZ[2] = getZoff(in) + rmax * getTanTheta(in);
+      double alpha1 = atan(getMiddleW() / rmin);
+      solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 1, -alpha1, 2 * alpha1, pgonZ, pgonRmin, pgonRmax);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-				   << " Polyhedra made of " << getMiddleMat() 
-				   << " with 1 sector from " 
-				   << convertRadToDeg(-alpha1) << " to "
-				   << convertRadToDeg(alpha1) << " and with "
-				   << pgonZ.size() << " sections";
-      for (unsigned int ii=0; ii<pgonZ.size(); ii++)
-	edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] << "\tRmin = " 
-				     << pgonRmin[ii] << "\tRmax = "
-				     << pgonRmax[ii];
+      edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Polyhedra made of " << getMiddleMat()
+                                   << " with 1 sector from " << convertRadToDeg(-alpha1) << " to "
+                                   << convertRadToDeg(alpha1) << " and with " << pgonZ.size() << " sections";
+      for (unsigned int ii = 0; ii < pgonZ.size(); ii++)
+        edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] << "\tRmin = " << pgonRmin[ii]
+                                     << "\tRmax = " << pgonRmax[ii];
 #endif
 
-      DDName matNam1(DDSplit(getMiddleMat()).first, 
-		     DDSplit(getMiddleMat()).second);
+      DDName matNam1(DDSplit(getMiddleMat()).first, DDSplit(getMiddleMat()).second);
       DDMaterial matter1(matNam1);
       glog = DDLogicalPart(solid.ddname(), matter1, solid);
 
       cpv.position(glog, mother, 1, DDTranslation(), DDRotation());
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() 
-				   << " Number 1 positioned in "
-				   << mother.name()
-				   << " at (0,0,0) with no rotation";
+      edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() << " Number 1 positioned in " << mother.name()
+                                   << " at (0,0,0) with no rotation";
 #endif
       // Now the remaining absorber layers
       for (int i = 1; i < getMidAbsorber(); i++) {
-	namek  = name + getMidAbsName(i);
-	rmid   = rmin + getMidAbsT(i);
-	pgonRmin[0] = rmin; pgonRmax[0] = rmid;
-	pgonRmin[1] = rmin; pgonRmax[1] = rmid; pgonZ[1] = getZoff(in) + rmin*getTanTheta(in);
-	pgonRmin[2] = rmid; pgonRmax[2] = rmid; pgonZ[2] = getZoff(in) + rmid*getTanTheta(in);
-	alpha1 = atan(getMidAbsW(i)/rmin);
-	solid = DDSolidFactory::polyhedra(DDName(namek, idNameSpace), 1, 
-					  -alpha1, 2*alpha1, pgonZ, pgonRmin, 
-					  pgonRmax);
+        namek = name + getMidAbsName(i);
+        rmid = rmin + getMidAbsT(i);
+        pgonRmin[0] = rmin;
+        pgonRmax[0] = rmid;
+        pgonRmin[1] = rmin;
+        pgonRmax[1] = rmid;
+        pgonZ[1] = getZoff(in) + rmin * getTanTheta(in);
+        pgonRmin[2] = rmid;
+        pgonRmax[2] = rmid;
+        pgonZ[2] = getZoff(in) + rmid * getTanTheta(in);
+        alpha1 = atan(getMidAbsW(i) / rmin);
+        solid =
+            DDSolidFactory::polyhedra(DDName(namek, idNameSpace), 1, -alpha1, 2 * alpha1, pgonZ, pgonRmin, pgonRmax);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-				     << " Polyhedra made of " 
-				     << getMidAbsMat(i) 
-				     << " with 1 sector from " 
-				     << convertRadToDeg(-alpha1) << " to "
-				     << convertRadToDeg(alpha1) << " and with "
-				     << pgonZ.size() << " sections";
-	for (unsigned int ii=0; ii<pgonZ.size(); ii++)
-	  edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] 
-				       << "\tRmin = " << pgonRmin[ii]
-				       << "\tRmax = " << pgonRmax[ii];
+        edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Polyhedra made of " << getMidAbsMat(i)
+                                     << " with 1 sector from " << convertRadToDeg(-alpha1) << " to "
+                                     << convertRadToDeg(alpha1) << " and with " << pgonZ.size() << " sections";
+        for (unsigned int ii = 0; ii < pgonZ.size(); ii++)
+          edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[ii] << "\tRmin = " << pgonRmin[ii]
+                                       << "\tRmax = " << pgonRmax[ii];
 #endif
 
-	DDName matName2(DDSplit(getMidAbsMat(i)).first, 
-			DDSplit(getMidAbsMat(i)).second);
-	DDMaterial matter2(matName2);
-	log = DDLogicalPart(solid.ddname(), matter2, solid);
+        DDName matName2(DDSplit(getMidAbsMat(i)).first, DDSplit(getMidAbsMat(i)).second);
+        DDMaterial matter2(matName2);
+        log = DDLogicalPart(solid.ddname(), matter2, solid);
 
-	cpv.position(log, mother, i, DDTranslation(), DDRotation());
+        cpv.position(log, mother, i, DDTranslation(), DDRotation());
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << log.name() 
-				     << " Number " << i << " positioned in " 
-				     << mother.name() << " at (0,0,0) with no "
-				     << "rotation";
+        edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << log.name() << " Number " << i << " positioned in "
+                                     << mother.name() << " at (0,0,0) with no "
+                                     << "rotation";
 #endif
-	mother = log;
+        mother = log;
       }
     }
   }
   return glog;
 }
- 
-void DDHCalBarrelAlgo::constructInsideDetectors(const DDLogicalPart& detector,
-						const std::string& name,
-						int id, double dx,
-						double dy, double dz,
-						int type, DDCompactView& cpv) {
 
+void DDHCalBarrelAlgo::constructInsideDetectors(const DDLogicalPart& detector,
+                                                const std::string& name,
+                                                int id,
+                                                double dx,
+                                                double dy,
+                                                double dz,
+                                                int type,
+                                                DDCompactView& cpv) {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: \t\tInside detector " 
-			       << id << "...";
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: \t\tInside detector " << id << "...";
 #endif
-  
+
   DDName plmatname(DDSplit(getDetMatPl()).first, DDSplit(getDetMatPl()).second);
   DDMaterial plmatter(plmatname);
   DDName scmatname(DDSplit(getDetMatSc()).first, DDSplit(getDetMatSc()).second);
   DDMaterial scmatter(scmatname);
-  
-  std::string plname = detector.name().name()+"Plastic_";
-  std::string scname = idName+"Scintillator"+name;
-  
+
+  std::string plname = detector.name().name() + "Plastic_";
+  std::string scname = idName + "Scintillator" + name;
+
   id--;
   DDSolid solid;
   DDLogicalPart glog;
-  double  wid, y=0;
-  double  dx1, dx2, shiftX;
+  double wid, y = 0;
+  double dx1, dx2, shiftX;
 
   if (type == 1) {
-    wid = 0.5*getDetWidth1(id);
-    if (getDetPosY(id)>0) y =-dy+wid;
-    dx1    = 0.5*getDetT11(id);
-    dx2    = 0.5*getDetT21(id);
+    wid = 0.5 * getDetWidth1(id);
+    if (getDetPosY(id) > 0)
+      y = -dy + wid;
+    dx1 = 0.5 * getDetT11(id);
+    dx2 = 0.5 * getDetT21(id);
     shiftX = getDetdP1(id);
   } else {
-    wid = 0.5*getDetWidth2(id);
-    dx1    = 0.5*getDetT12(id);
-    dx2    = 0.5*getDetT22(id);
+    wid = 0.5 * getDetWidth2(id);
+    dx1 = 0.5 * getDetT12(id);
+    dx2 = 0.5 * getDetT22(id);
     shiftX = getDetdP2(id);
   }
 
-  solid = DDSolidFactory::box(DDName(plname+"1", idNameSpace), dx1, wid, dz);
+  solid = DDSolidFactory::box(DDName(plname + "1", idNameSpace), dx1, wid, dz);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-			       << " Box made of " << getDetMatPl() 
-			       << " of dimensions " << dx1 <<", " << wid 
-			       << ", "  << dz;
-#endif
-  glog = DDLogicalPart(solid.ddname(), plmatter, solid); 
-
-  double x = shiftX + dx1 - dx;
-  cpv.position(glog, detector, 1, DDTranslation(x,y,0), DDRotation());
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() 
-			       << " Number 1 positioned in " << detector.name()
-			       << " at (" << x << "," << y
-			       << ",0) with no rotation";
-#endif
-  solid = DDSolidFactory::box(DDName(scname, idNameSpace), 
-			      0.5*getDetTsc(id), wid, dz);
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-			       << " Box made of " << getDetMatSc()
-			       << " of dimensions " << 0.5*getDetTsc(id)
-			       << ", " << wid << ", " << dz;
-#endif
-  glog = DDLogicalPart(solid.ddname(), scmatter, solid);
-
-  x += dx1 + 0.5*getDetTsc(id);
-  int copyNo = id*10 + getDetType(id);
-  cpv.position(glog, detector, copyNo, DDTranslation(x, y, 0), DDRotation());
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name()
-			       << " Number " << copyNo << " positioned in "
-			       << detector.name() << " at (" << x << "," << y 
-			       << ",0) with no rotation";
-#endif
-  solid = DDSolidFactory::box(DDName(plname+"2", idNameSpace), dx2, wid, dz);
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() 
-			       << " Box made of " << getDetMatPl() 
-			       << " of dimensions " << dx2 <<", " << wid 
-			       << ", "  << dz;
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Box made of " << getDetMatPl()
+                               << " of dimensions " << dx1 << ", " << wid << ", " << dz;
 #endif
   glog = DDLogicalPart(solid.ddname(), plmatter, solid);
 
-  x+=0.5*getDetTsc(id) + dx2;
+  double x = shiftX + dx1 - dx;
   cpv.position(glog, detector, 1, DDTranslation(x, y, 0), DDRotation());
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() 
-			       << " Number 1 positioned in " << detector.name()
-			       << " at (" << x << "," << y 
-			       << ",0) with no rotation";
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() << " Number 1 positioned in " << detector.name()
+                               << " at (" << x << "," << y << ",0) with no rotation";
+#endif
+  solid = DDSolidFactory::box(DDName(scname, idNameSpace), 0.5 * getDetTsc(id), wid, dz);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Box made of " << getDetMatSc()
+                               << " of dimensions " << 0.5 * getDetTsc(id) << ", " << wid << ", " << dz;
+#endif
+  glog = DDLogicalPart(solid.ddname(), scmatter, solid);
+
+  x += dx1 + 0.5 * getDetTsc(id);
+  int copyNo = id * 10 + getDetType(id);
+  cpv.position(glog, detector, copyNo, DDTranslation(x, y, 0), DDRotation());
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() << " Number " << copyNo << " positioned in "
+                               << detector.name() << " at (" << x << "," << y << ",0) with no rotation";
+#endif
+  solid = DDSolidFactory::box(DDName(plname + "2", idNameSpace), dx2, wid, dz);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << solid.name() << " Box made of " << getDetMatPl()
+                               << " of dimensions " << dx2 << ", " << wid << ", " << dz;
+#endif
+  glog = DDLogicalPart(solid.ddname(), plmatter, solid);
+
+  x += 0.5 * getDetTsc(id) + dx2;
+  cpv.position(glog, detector, 1, DDTranslation(x, y, 0), DDRotation());
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalBarrelAlgo: " << glog.name() << " Number 1 positioned in " << detector.name()
+                               << " at (" << x << "," << y << ",0) with no rotation";
 #endif
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalBarrelAlgo.h
@@ -8,96 +8,109 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalBarrelAlgo : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDHCalBarrelAlgo(); //const std::string & name);
+  DDHCalBarrelAlgo();  //const std::string & name);
   ~DDHCalBarrelAlgo() override;
-  
+
   //Get Methods
-  std::string getGenMaterial()                const {return genMaterial;}
-  int         getNsectors()                   const {return nsectors;}
-  int         getNsectortot()                 const {return nsectortot;}
-  int         getNhalf()                      const {return nhalf;}
-  double      getRin()                        const {return rin;}
-  double      getRout()                       const {return rout;}
-  int         getRzones()                     const {return rzones;}
-  double      getTanTheta(unsigned int i)     const {return ttheta[i];}
-  double      getTheta(unsigned int i)        const {return theta[i];}
-  double      getRmax(unsigned int i)         const {return rmax[i];}
-  double      getZoff(unsigned int i)         const {return zoff[i];}
-  
-  int         getNLayers()                    const {return nLayers;}
-  int         getLayerId(unsigned i)          const {return layerId[i];}
-  std::string getLayerLabel(unsigned i)       const {return layerLabel[i];}
-  std::string getLayerMaterial(unsigned i)    const {return layerMat[i];}
-  double      getLayerWidth(unsigned i)       const {return layerWidth[i];}
-  double      getLayerD1(unsigned i)          const {return layerD1[i];}
-  double      getLayerD2(unsigned i)          const {return layerD2[i];}
-  double      getLayerAlpha(unsigned i)       const {return layerAlpha[i];}
-  double      getLayerT1(unsigned i)          const {return layerT1[i];}
-  double      getLayerT2(unsigned i)          const {return layerT2[i];}
-  int         getLayerAbsorb(unsigned int i)  const {return layerAbsorb[i];}
-  double      getLayerGap(unsigned int i)     const {return layerGap[i];}
+  std::string getGenMaterial() const { return genMaterial; }
+  int getNsectors() const { return nsectors; }
+  int getNsectortot() const { return nsectortot; }
+  int getNhalf() const { return nhalf; }
+  double getRin() const { return rin; }
+  double getRout() const { return rout; }
+  int getRzones() const { return rzones; }
+  double getTanTheta(unsigned int i) const { return ttheta[i]; }
+  double getTheta(unsigned int i) const { return theta[i]; }
+  double getRmax(unsigned int i) const { return rmax[i]; }
+  double getZoff(unsigned int i) const { return zoff[i]; }
 
-  std::string getSideMat(unsigned int i)      const {return sideMat[i];}
-  double      getSideD(unsigned int i)        const {return sideD[i];}
-  double      getSideT(unsigned int i)        const {return sideT[i];}
-  int         getSideAbsorber()               const {return nSideAbs;}
-  std::string getSideAbsName(unsigned int i)  const {return sideAbsName[i];}
-  std::string getSideAbsMat(unsigned int i)   const {return sideAbsMat[i];}
-  double      getSideAbsW(unsigned int i)     const {return sideAbsW[i];}
+  int getNLayers() const { return nLayers; }
+  int getLayerId(unsigned i) const { return layerId[i]; }
+  std::string getLayerLabel(unsigned i) const { return layerLabel[i]; }
+  std::string getLayerMaterial(unsigned i) const { return layerMat[i]; }
+  double getLayerWidth(unsigned i) const { return layerWidth[i]; }
+  double getLayerD1(unsigned i) const { return layerD1[i]; }
+  double getLayerD2(unsigned i) const { return layerD2[i]; }
+  double getLayerAlpha(unsigned i) const { return layerAlpha[i]; }
+  double getLayerT1(unsigned i) const { return layerT1[i]; }
+  double getLayerT2(unsigned i) const { return layerT2[i]; }
+  int getLayerAbsorb(unsigned int i) const { return layerAbsorb[i]; }
+  double getLayerGap(unsigned int i) const { return layerGap[i]; }
 
-  int         getAbsorberN()                  const {return nAbsorber;}
-  std::string getAbsorbName(unsigned int i)   const {return absorbName[i];}
-  std::string getAbsorbMat(unsigned int i)    const {return absorbMat[i];}
-  double      getAbsorbD(unsigned int i)      const {return absorbD[i];}
-  double      getAbsorbT(unsigned int i)      const {return absorbT[i];}
-  std::string getMiddleMat()                  const {return middleMat;}
-  double      getMiddleD()                    const {return middleD;}
-  double      getMiddleW()                    const {return middleW;}
-  int         getMidAbsorber()                const {return nMidAbs;}
-  std::string getMidAbsName(unsigned int i)   const {return midName[i];}
-  std::string getMidAbsMat(unsigned int i)    const {return midMat[i];}
-  double      getMidAbsW(unsigned int i)      const {return midW[i];}
-  double      getMidAbsT(unsigned int i)      const {return midT[i];}
+  std::string getSideMat(unsigned int i) const { return sideMat[i]; }
+  double getSideD(unsigned int i) const { return sideD[i]; }
+  double getSideT(unsigned int i) const { return sideT[i]; }
+  int getSideAbsorber() const { return nSideAbs; }
+  std::string getSideAbsName(unsigned int i) const { return sideAbsName[i]; }
+  std::string getSideAbsMat(unsigned int i) const { return sideAbsMat[i]; }
+  double getSideAbsW(unsigned int i) const { return sideAbsW[i]; }
 
-  std::string getDetMat()                     const {return detMat;}
-  std::string getDetMatPl()                   const {return detMatPl;}
-  std::string getDetMatSc()                   const {return detMatSc;}
-  int         getDetType(unsigned int i)      const {return detType[i];}
-  double      getDetdP1(unsigned int i)       const {return detdP1[i];}
-  double      getDetdP2(unsigned int i)       const {return detdP2[i];}
-  double      getDetT11(unsigned int i)       const {return detT11[i];}
-  double      getDetT12(unsigned int i)       const {return detT12[i];}
-  double      getDetTsc(unsigned int i)       const {return detTsc[i];}
-  double      getDetT21(unsigned int i)       const {return detT21[i];}
-  double      getDetT22(unsigned int i)       const {return detT22[i];}
-  double      getDetWidth1(unsigned int i)    const {return detWidth1[i];}
-  double      getDetWidth2(unsigned int i)    const {return detWidth2[i];}
-  int         getDetPosY(unsigned int i)      const {return detPosY[i];}
+  int getAbsorberN() const { return nAbsorber; }
+  std::string getAbsorbName(unsigned int i) const { return absorbName[i]; }
+  std::string getAbsorbMat(unsigned int i) const { return absorbMat[i]; }
+  double getAbsorbD(unsigned int i) const { return absorbD[i]; }
+  double getAbsorbT(unsigned int i) const { return absorbT[i]; }
+  std::string getMiddleMat() const { return middleMat; }
+  double getMiddleD() const { return middleD; }
+  double getMiddleW() const { return middleW; }
+  int getMidAbsorber() const { return nMidAbs; }
+  std::string getMidAbsName(unsigned int i) const { return midName[i]; }
+  std::string getMidAbsMat(unsigned int i) const { return midMat[i]; }
+  double getMidAbsW(unsigned int i) const { return midW[i]; }
+  double getMidAbsT(unsigned int i) const { return midT[i]; }
 
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+  std::string getDetMat() const { return detMat; }
+  std::string getDetMatPl() const { return detMatPl; }
+  std::string getDetMatSc() const { return detMatSc; }
+  int getDetType(unsigned int i) const { return detType[i]; }
+  double getDetdP1(unsigned int i) const { return detdP1[i]; }
+  double getDetdP2(unsigned int i) const { return detdP2[i]; }
+  double getDetT11(unsigned int i) const { return detT11[i]; }
+  double getDetT12(unsigned int i) const { return detT12[i]; }
+  double getDetTsc(unsigned int i) const { return detTsc[i]; }
+  double getDetT21(unsigned int i) const { return detT21[i]; }
+  double getDetT22(unsigned int i) const { return detT22[i]; }
+  double getDetWidth1(unsigned int i) const { return detWidth1[i]; }
+  double getDetWidth2(unsigned int i) const { return detWidth2[i]; }
+  int getDetPosY(unsigned int i) const { return detPosY[i]; }
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 protected:
-
   void constructGeneralVolume(DDCompactView& cpv);
   void constructInsideSector(const DDLogicalPart& sector, DDCompactView& cpv);
-  void constructInsideLayers(const DDLogicalPart& laylog, const std::string& name, int id, 
-			     int nAbs, double rin, double d1, double alpha1, 
-			     double d2, double alpha2, double t1, double t2, DDCompactView& cpv);
-  DDLogicalPart constructSideLayer(const DDLogicalPart& laylog, const std::string& nm,
-				   int nAbs, double rin, double alpha, DDCompactView& cpv);
-  DDLogicalPart constructMidLayer(const DDLogicalPart& laylog, const std::string& nm,
-				  double rin, double alpha, DDCompactView& cpv);
+  void constructInsideLayers(const DDLogicalPart& laylog,
+                             const std::string& name,
+                             int id,
+                             int nAbs,
+                             double rin,
+                             double d1,
+                             double alpha1,
+                             double d2,
+                             double alpha2,
+                             double t1,
+                             double t2,
+                             DDCompactView& cpv);
+  DDLogicalPart constructSideLayer(
+      const DDLogicalPart& laylog, const std::string& nm, int nAbs, double rin, double alpha, DDCompactView& cpv);
+  DDLogicalPart constructMidLayer(
+      const DDLogicalPart& laylog, const std::string& nm, double rin, double alpha, DDCompactView& cpv);
   void constructInsideDetectors(const DDLogicalPart& detector,
-				const std::string& name, int id, double dx, 
-				double dy, double dz, int type, DDCompactView& cpv);
+                                const std::string& name,
+                                int id,
+                                double dx,
+                                double dy,
+                                double dz,
+                                int type,
+                                DDCompactView& cpv);
 
 private:
   //General Volume
@@ -111,18 +124,18 @@ private:
   //                        *Theta[0] Rmax[0]|  |
   // Rin  *****************----------------------
 
-  std::string  genMaterial;         //General material
-  int       nsectors;               //Number of potenital straight edges
-  int       nsectortot;             //Number of straight edges (actual)
-  int       nhalf;                  //Number of half modules
-  double    rin, rout;              //See picture
-  int       rzones;                 //  ....
-  std::vector<double>   theta;      //  .... (in degrees)
-  std::vector<double>   rmax;       //  .... 
-  std::vector<double>   zoff;       //  ....
-  std::vector<double>   ttheta;     //tan(theta)
-  std::string rotHalf;              //Rotation matrix of the second half
-  std::string rotns;                //Name space for Rotation matrices
+  std::string genMaterial;     //General material
+  int nsectors;                //Number of potenital straight edges
+  int nsectortot;              //Number of straight edges (actual)
+  int nhalf;                   //Number of half modules
+  double rin, rout;            //See picture
+  int rzones;                  //  ....
+  std::vector<double> theta;   //  .... (in degrees)
+  std::vector<double> rmax;    //  ....
+  std::vector<double> zoff;    //  ....
+  std::vector<double> ttheta;  //tan(theta)
+  std::string rotHalf;         //Rotation matrix of the second half
+  std::string rotns;           //Name space for Rotation matrices
 
   //Upper layers inside general volume
   //     <---- Zout ---->
@@ -150,72 +163,72 @@ private:
   //  |  ****************--------
   //     <--- Zin ------>
 
-  int                      nLayers;     //Number of layers
-  std::vector<int>         layerId;     //Number identification
+  int nLayers;                          //Number of layers
+  std::vector<int> layerId;             //Number identification
   std::vector<std::string> layerLabel;  //String identification
   std::vector<std::string> layerMat;    //Material
-  std::vector<double>      layerWidth;  //W in picture
-  std::vector<double>      layerD1;     //d1 in front picture
-  std::vector<double>      layerD2;     //d2 in front picture
-  std::vector<double>      layerAlpha;  //Angular width of the middle tiles
-  std::vector<double>      layerT1;     //t in front picture (side)
-  std::vector<double>      layerT2;     //t in front picture (front)
-  std::vector<int>         layerAbsorb; //Absorber flag
-  std::vector<double>      layerGap;    //Gap at the edge
+  std::vector<double> layerWidth;       //W in picture
+  std::vector<double> layerD1;          //d1 in front picture
+  std::vector<double> layerD2;          //d2 in front picture
+  std::vector<double> layerAlpha;       //Angular width of the middle tiles
+  std::vector<double> layerT1;          //t in front picture (side)
+  std::vector<double> layerT2;          //t in front picture (front)
+  std::vector<int> layerAbsorb;         //Absorber flag
+  std::vector<double> layerGap;         //Gap at the edge
 
-  int                      nAbsorber;   //Number of absorber layers in middle
+  int nAbsorber;                        //Number of absorber layers in middle
   std::vector<std::string> absorbName;  //Absorber name
   std::vector<std::string> absorbMat;   //Absorber material
-  std::vector<double>      absorbD;     //Distance from the bottom surface
-  std::vector<double>      absorbT;     //Thickness
-  std::string              middleMat;   //Material of the detector layer
-  double                   middleD;     //Distance from the bottom surface
-  double                   middleW;     //Half width
-  int                      nMidAbs;     //Number of absorbers in front part
+  std::vector<double> absorbD;          //Distance from the bottom surface
+  std::vector<double> absorbT;          //Thickness
+  std::string middleMat;                //Material of the detector layer
+  double middleD;                       //Distance from the bottom surface
+  double middleW;                       //Half width
+  int nMidAbs;                          //Number of absorbers in front part
   std::vector<std::string> midName;     //Absorber names in the front part
   std::vector<std::string> midMat;      //Absorber material
-  std::vector<double>      midW;        //Half width
-  std::vector<double>      midT;        //Thickness
+  std::vector<double> midW;             //Half width
+  std::vector<double> midT;             //Thickness
 
-  std::vector<std::string> sideMat;     //Material for special side layers
-  std::vector<double>      sideD;       //Depth from bottom surface
-  std::vector<double>      sideT;       //Thickness
-  int                      nSideAbs;    //Number of absorbers in special side
-  std::vector<std::string> sideAbsName; //Absorber name
-  std::vector<std::string> sideAbsMat;  //Absorber material
-  std::vector<double>      sideAbsW;    //Half width
+  std::vector<std::string> sideMat;      //Material for special side layers
+  std::vector<double> sideD;             //Depth from bottom surface
+  std::vector<double> sideT;             //Thickness
+  int nSideAbs;                          //Number of absorbers in special side
+  std::vector<std::string> sideAbsName;  //Absorber name
+  std::vector<std::string> sideAbsMat;   //Absorber material
+  std::vector<double> sideAbsW;          //Half width
 
   // Detectors. Each volume inside the layer has the shape:
   //
   // ******************************* |
   // *\\\\\\\Plastic\\\\\\\\\\\\\\\* T2
-  // ******************************* |        
-  // *////Scintillator/////////////* Tsc      
-  // ******************************* |        
-  // *\\\\\\\Plastic\\\\\\\\\\\\\\\* T1       
-  // ******************************* |   |    
-  // *         Air                 *     dP1  
-  // *******************************     |    
-  // 
-  std::string         detMat;                 //fill material
-  std::string         detRot;                 //Rotation matrix for the 2nd
-  std::string         detMatPl;               //Plastic material
-  std::string         detMatSc;               //Scintillator material
-  std::vector<int>    detType;       
-  std::vector<double> detdP1;                 //Air gap (side)
-  std::vector<double> detdP2;                 //Air gap (centre)
-  std::vector<double> detT11;                 //Back plastic thickness (side)
-  std::vector<double> detT12;                 //Back plastic thickness (centre)
-  std::vector<double> detTsc;                 //Scintillator
-  std::vector<double> detT21;                 //Front plastic thickness (side)
-  std::vector<double> detT22;                 //Front plastic thickness (centre)
-  std::vector<double> detWidth1;              //Width of phi(1,4) megatiles
-  std::vector<double> detWidth2;              //Width of phi(2,3) megatiles
-  std::vector<int>    detPosY;                //Positioning of phi(1,4) tiles - 0 centre
+  // ******************************* |
+  // *////Scintillator/////////////* Tsc
+  // ******************************* |
+  // *\\\\\\\Plastic\\\\\\\\\\\\\\\* T1
+  // ******************************* |   |
+  // *         Air                 *     dP1
+  // *******************************     |
+  //
+  std::string detMat;    //fill material
+  std::string detRot;    //Rotation matrix for the 2nd
+  std::string detMatPl;  //Plastic material
+  std::string detMatSc;  //Scintillator material
+  std::vector<int> detType;
+  std::vector<double> detdP1;     //Air gap (side)
+  std::vector<double> detdP2;     //Air gap (centre)
+  std::vector<double> detT11;     //Back plastic thickness (side)
+  std::vector<double> detT12;     //Back plastic thickness (centre)
+  std::vector<double> detTsc;     //Scintillator
+  std::vector<double> detT21;     //Front plastic thickness (side)
+  std::vector<double> detT22;     //Front plastic thickness (centre)
+  std::vector<double> detWidth1;  //Width of phi(1,4) megatiles
+  std::vector<double> detWidth2;  //Width of phi(2,3) megatiles
+  std::vector<int> detPosY;       //Positioning of phi(1,4) tiles - 0 centre
 
-  std::string         idName;                 //Name of the "parent" volume.  
-  std::string         idNameSpace;            //Namespace of this and ALL sub-parts
-  int                 idOffset;               // Geant4 ID's...    = 3000;
+  std::string idName;       //Name of the "parent" volume.
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  int idOffset;             // Geant4 ID's...    = 3000;
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.cc
@@ -20,12 +20,29 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-DDHCalEndcapAlgo::DDHCalEndcapAlgo():
-  modMat(0),modType(0),sectionModule(0),layerN(0),layerN0(0),layerN1(0),
-  layerN2(0),layerN3(0),layerN4(0),layerN5(0),thick(0),trimLeft(0),
-  trimRight(0),zminBlock(0),zmaxBlock(0),rinBlock1(0),routBlock1(0),
-  rinBlock2(0),routBlock2(0),layerType(0),layerT(0),scintT(0) {
-
+DDHCalEndcapAlgo::DDHCalEndcapAlgo()
+    : modMat(0),
+      modType(0),
+      sectionModule(0),
+      layerN(0),
+      layerN0(0),
+      layerN1(0),
+      layerN2(0),
+      layerN3(0),
+      layerN4(0),
+      layerN5(0),
+      thick(0),
+      trimLeft(0),
+      trimRight(0),
+      zminBlock(0),
+      zmaxBlock(0),
+      rinBlock1(0),
+      routBlock1(0),
+      rinBlock2(0),
+      routBlock2(0),
+      layerType(0),
+      layerT(0),
+      scintT(0) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Creating an instance";
 #endif
@@ -34,212 +51,197 @@ DDHCalEndcapAlgo::DDHCalEndcapAlgo():
 DDHCalEndcapAlgo::~DDHCalEndcapAlgo() {}
 
 int DDHCalEndcapAlgo::getLayer(unsigned int i, unsigned int j) const {
-
   switch (i) {
-  case 0: 
-    return layerN0[j];
-    break;
+    case 0:
+      return layerN0[j];
+      break;
 
-  case 1: 
-    return layerN1[j];
-    break;
+    case 1:
+      return layerN1[j];
+      break;
 
-  case 2: 
-    return layerN2[j];
-    break;
+    case 2:
+      return layerN2[j];
+      break;
 
-  case 3: 
-    return layerN3[j];
-    break;
+    case 3:
+      return layerN3[j];
+      break;
 
-  case 4: 
-    return layerN4[j];
-    break;
+    case 4:
+      return layerN4[j];
+      break;
 
-  case 5: 
-    return layerN5[j];
-    break;
+    case 5:
+      return layerN5[j];
+      break;
 
-  default:
-    return 0;
+    default:
+      return 0;
   }
 }
 
 double DDHCalEndcapAlgo::getTrim(unsigned int i, unsigned int j) const {
- 
- if (j == 0)
+  if (j == 0)
     return trimLeft[i];
   else
     return trimRight[j];
 }
 
-void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
-				  const DDVectorArguments & vArgs,
-				  const DDMapArguments & ,
-				  const DDStringArguments & sArgs,
-				  const DDStringVectorArguments & vsArgs) {
+void DDHCalEndcapAlgo::initialize(const DDNumericArguments& nArgs,
+                                  const DDVectorArguments& vArgs,
+                                  const DDMapArguments&,
+                                  const DDStringArguments& sArgs,
+                                  const DDStringVectorArguments& vsArgs) {
+  genMaterial = sArgs["MaterialName"];
+  rotation = sArgs["Rotation"];
+  nsectors = int(nArgs["Sector"]);
+  nsectortot = int(nArgs["SectorTot"]);
+  nEndcap = int(nArgs["Endcap"]);
+  rotHalf = sArgs["RotHalf"];
+  rotns = sArgs["RotNameSpace"];
+  zShift = nArgs["ZShift"];
 
-  genMaterial   = sArgs["MaterialName"];
-  rotation      = sArgs["Rotation"];
-  nsectors      = int (nArgs["Sector"]);
-  nsectortot    = int (nArgs["SectorTot"]);
-  nEndcap       = int (nArgs["Endcap"]);
-  rotHalf       = sArgs["RotHalf"];
-  rotns         = sArgs["RotNameSpace"];
-  zShift        = nArgs["ZShift"];
-
-  zFront        = nArgs["ZFront"];
-  zEnd          = nArgs["ZEnd"];
-  ziNose        = nArgs["ZiNose"];
-  ziL0Nose      = nArgs["ZiL0Nose"];
-  ziBody        = nArgs["ZiBody"];
-  ziL0Body      = nArgs["ZiL0Body"];
-  z0Beam        = nArgs["Z0Beam"];
-  ziDip         = nArgs["ZiDip"];
-  dzStep        = nArgs["DzStep"];
-  zShiftHac2    = nArgs["ZShiftHac2"];
-  double gap    = nArgs["Gap"];
-  double z1     = nArgs["Z1"];
-  double r1     = nArgs["R1"];
-  rout          = nArgs["Rout"];
-  heboxDepth    = nArgs["HEboxDepth"];
-  drEnd         = nArgs["DrEnd"];
+  zFront = nArgs["ZFront"];
+  zEnd = nArgs["ZEnd"];
+  ziNose = nArgs["ZiNose"];
+  ziL0Nose = nArgs["ZiL0Nose"];
+  ziBody = nArgs["ZiBody"];
+  ziL0Body = nArgs["ZiL0Body"];
+  z0Beam = nArgs["Z0Beam"];
+  ziDip = nArgs["ZiDip"];
+  dzStep = nArgs["DzStep"];
+  zShiftHac2 = nArgs["ZShiftHac2"];
+  double gap = nArgs["Gap"];
+  double z1 = nArgs["Z1"];
+  double r1 = nArgs["R1"];
+  rout = nArgs["Rout"];
+  heboxDepth = nArgs["HEboxDepth"];
+  drEnd = nArgs["DrEnd"];
   double etamin = nArgs["Etamin"];
-  angBot        = nArgs["AngBot"];
-  angGap        = nArgs["AngGap"];
+  angBot = nArgs["AngBot"];
+  angGap = nArgs["AngGap"];
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom")
-    << "DDHCalEndcapAlgo: General material " << genMaterial << "\tSectors "  
-    << nsectors << ",  " << nsectortot << "\tEndcaps " << nEndcap  
-    << "\tRotation matrix for half " << rotns << ":" << rotHalf << "\n\tzFront "
-    << zFront << " zEnd " << zEnd << " ziNose " << ziNose << " ziL0Nose " 
-    << ziL0Nose << " ziBody " << ziBody << " ziL0Body " << ziL0Body << " z0Beam "
-    << z0Beam << " ziDip " << ziDip << " dzStep " << dzStep << " Gap " << gap 
-    << " z1 " << z1 << "\n\tr1 " << r1 << " rout " << rout << " HeboxDepth " 
-    << heboxDepth << " drEnd " << drEnd << "\tetamin " << etamin 
-    << " Bottom angle " << angBot << " Gap angle " << angGap << " Z-Shift "
-    << zShift << " " << zShiftHac2;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: General material " << genMaterial << "\tSectors " << nsectors
+                               << ",  " << nsectortot << "\tEndcaps " << nEndcap << "\tRotation matrix for half "
+                               << rotns << ":" << rotHalf << "\n\tzFront " << zFront << " zEnd " << zEnd << " ziNose "
+                               << ziNose << " ziL0Nose " << ziL0Nose << " ziBody " << ziBody << " ziL0Body " << ziL0Body
+                               << " z0Beam " << z0Beam << " ziDip " << ziDip << " dzStep " << dzStep << " Gap " << gap
+                               << " z1 " << z1 << "\n\tr1 " << r1 << " rout " << rout << " HeboxDepth " << heboxDepth
+                               << " drEnd " << drEnd << "\tetamin " << etamin << " Bottom angle " << angBot
+                               << " Gap angle " << angGap << " Z-Shift " << zShift << " " << zShiftHac2;
 #endif
-  
+
   //Derived quantities
-  angTop   = 2.0 * atan (exp(-etamin));
-  slope    = tan(angGap);
-  z1Beam   = z1 - r1/slope;
-  ziKink   = z1Beam + rout/slope;
-  riKink   = ziKink*tan(angBot);
-  riDip    = ziDip*tan(angBot);
-  roDip    = rout - heboxDepth;
-  dzShift  = (z1Beam - z0Beam) - gap/sin(angGap);
+  angTop = 2.0 * atan(exp(-etamin));
+  slope = tan(angGap);
+  z1Beam = z1 - r1 / slope;
+  ziKink = z1Beam + rout / slope;
+  riKink = ziKink * tan(angBot);
+  riDip = ziDip * tan(angBot);
+  roDip = rout - heboxDepth;
+  dzShift = (z1Beam - z0Beam) - gap / sin(angGap);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: angTop " << convertRadToDeg(angTop)  <<"\tSlope " 
-    << slope << "\tDzShift " << dzShift << "\n\tz1Beam " << z1Beam
-    << "\tziKink" << ziKink << "\triKink " << riKink << "\triDip " << riDip 
-    << "\n\troDip " << roDip << "\tRotation " << rotation;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: angTop " << convertRadToDeg(angTop) << "\tSlope " << slope
+                               << "\tDzShift " << dzShift << "\n\tz1Beam " << z1Beam << "\tziKink" << ziKink
+                               << "\triKink " << riKink << "\triDip " << riDip << "\n\troDip " << roDip << "\tRotation "
+                               << rotation;
 #endif
-  
+
   ///////////////////////////////////////////////////////////////
   //Modules
-  absMat        = sArgs["AbsMat"];
-  modules       = int(nArgs["Modules"]);
+  absMat = sArgs["AbsMat"];
+  modules = int(nArgs["Modules"]);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom")
-    << "DDHCalEndcapAlgo: Number of modules " << modules 
-    << " and absorber material " << absMat;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Number of modules " << modules << " and absorber material "
+                               << absMat;
 #endif
-  
-  modName       = vsArgs["ModuleName"];
-  modMat        = vsArgs["ModuleMat"];
-  modType       = dbl_to_int(vArgs["ModuleType"]);
+
+  modName = vsArgs["ModuleName"];
+  modMat = vsArgs["ModuleMat"];
+  modType = dbl_to_int(vArgs["ModuleType"]);
   sectionModule = dbl_to_int(vArgs["SectionModule"]);
-  thick         = vArgs["ModuleThick"];
-  trimLeft      = vArgs["TrimLeft"]; 
-  trimRight     = vArgs["TrimRight"]; 
-  eModule       = dbl_to_int(vArgs["EquipModule"]);
-  layerN        = dbl_to_int(vArgs["LayerN"]);
-  layerN0       = dbl_to_int(vArgs["LayerN0"]);
-  layerN1       = dbl_to_int(vArgs["LayerN1"]);
-  layerN2       = dbl_to_int(vArgs["LayerN2"]);
-  layerN3       = dbl_to_int(vArgs["LayerN3"]);
-  layerN4       = dbl_to_int(vArgs["LayerN4"]);
-  layerN5       = dbl_to_int(vArgs["LayerN5"]);
+  thick = vArgs["ModuleThick"];
+  trimLeft = vArgs["TrimLeft"];
+  trimRight = vArgs["TrimRight"];
+  eModule = dbl_to_int(vArgs["EquipModule"]);
+  layerN = dbl_to_int(vArgs["LayerN"]);
+  layerN0 = dbl_to_int(vArgs["LayerN0"]);
+  layerN1 = dbl_to_int(vArgs["LayerN1"]);
+  layerN2 = dbl_to_int(vArgs["LayerN2"]);
+  layerN3 = dbl_to_int(vArgs["LayerN3"]);
+  layerN4 = dbl_to_int(vArgs["LayerN4"]);
+  layerN5 = dbl_to_int(vArgs["LayerN5"]);
 
 #ifdef EDM_ML_DEBUG
   for (int i = 0; i < modules; i++) {
-    edm::LogVerbatim("HCalGeom") 
-      << "DDHCalEndcapAlgo: " << modName[i] << " type " << modType[i]
-      << " Sections "  << sectionModule[i] <<" thickness of absorber/air "
-      << thick[i] << " trim " << trimLeft[i] << ", " << trimRight[i] 
-      << " equip module " << eModule[i] << " with " << layerN[i] << " layers";
+    edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << modName[i] << " type " << modType[i] << " Sections "
+                                 << sectionModule[i] << " thickness of absorber/air " << thick[i] << " trim "
+                                 << trimLeft[i] << ", " << trimRight[i] << " equip module " << eModule[i] << " with "
+                                 << layerN[i] << " layers";
     if (i == 0) {
       for (int j = 0; j < layerN[i]; j++) {
-	edm::LogVerbatim("HCalGeom") 
-	  << "\t " << layerN0[j] << "/" << layerN0[j+1];
+        edm::LogVerbatim("HCalGeom") << "\t " << layerN0[j] << "/" << layerN0[j + 1];
       }
     } else if (i == 1) {
       for (int j = 0; j < layerN[i]; j++) {
-	edm::LogVerbatim("HCalGeom") 
-	  << "\t " << layerN1[j] << "/" << layerN1[j+1];
+        edm::LogVerbatim("HCalGeom") << "\t " << layerN1[j] << "/" << layerN1[j + 1];
       }
     } else if (i == 2) {
       for (int j = 0; j < layerN[i]; j++) {
-	edm::LogVerbatim("HCalGeom") << "\t " << layerN2[j];
+        edm::LogVerbatim("HCalGeom") << "\t " << layerN2[j];
       }
     } else if (i == 3) {
       for (int j = 0; j < layerN[i]; j++) {
-	edm::LogVerbatim("HCalGeom") << "\t " << layerN3[j];
+        edm::LogVerbatim("HCalGeom") << "\t " << layerN3[j];
       }
     } else if (i == 4) {
       for (int j = 0; j < layerN[i]; j++) {
-	edm::LogVerbatim("HCalGeom") << "\t " << layerN4[j];
+        edm::LogVerbatim("HCalGeom") << "\t " << layerN4[j];
       }
     } else if (i == 5) {
       for (int j = 0; j < layerN[i]; j++) {
-	edm::LogVerbatim("HCalGeom") << "\t " << layerN5[j];
+        edm::LogVerbatim("HCalGeom") << "\t " << layerN5[j];
       }
     }
   }
 #endif
-  
+
   ///////////////////////////////////////////////////////////////
   //Layers
   phiSections = int(nArgs["PhiSections"]);
-  phiName     = vsArgs["PhiName"];
-  layers      = int(nArgs["Layers"]);
-  layerName   = vsArgs["LayerName"];
-  layerType   = dbl_to_int(vArgs["LayerType"]);
-  layerT      = vArgs["LayerT"];
-  scintT      = vArgs["ScintT"];
-  scintMat    = sArgs["ScintMat"];
-  plastMat    = sArgs["PlastMat"];
-  rotmat      = sArgs["RotMat"];
+  phiName = vsArgs["PhiName"];
+  layers = int(nArgs["Layers"]);
+  layerName = vsArgs["LayerName"];
+  layerType = dbl_to_int(vArgs["LayerType"]);
+  layerT = vArgs["LayerT"];
+  scintT = vArgs["ScintT"];
+  scintMat = sArgs["ScintMat"];
+  plastMat = sArgs["PlastMat"];
+  rotmat = sArgs["RotMat"];
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: Phi Sections " << phiSections;
-  for (int i = 0; i < phiSections; i++) 
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Phi Sections " << phiSections;
+  for (int i = 0; i < phiSections; i++)
     edm::LogVerbatim("HCalGeom") << "\tName[" << i << "] : " << phiName[i];
-  edm::LogVerbatim("HCalGeom") 
-    << "\tPlastic: " << plastMat << "\tScintillator: " << scintMat 
-    << "\tRotation matrix " << rotns << ":"  << rotmat << "\n\tNumber of layers "
-    << layers;
+  edm::LogVerbatim("HCalGeom") << "\tPlastic: " << plastMat << "\tScintillator: " << scintMat << "\tRotation matrix "
+                               << rotns << ":" << rotmat << "\n\tNumber of layers " << layers;
   for (int i = 0; i < layers; i++) {
-    edm::LogVerbatim("HCalGeom") 
-      << "\t" << layerName[i] << "\tType " << layerType[i] << "\tThickness " 
-      << layerT[i] << "\tScint.Thick " << scintT[i];
+    edm::LogVerbatim("HCalGeom") << "\t" << layerName[i] << "\tType " << layerType[i] << "\tThickness " << layerT[i]
+                                 << "\tScint.Thick " << scintT[i];
   }
 #endif
-  
+
   ///////////////////////////////////////////////////////////////
   // Derive bounding of the modules
   int module = 0;
   // Layer 0 (Nose)
   if (modules > 0) {
     zminBlock.emplace_back(ziL0Nose);
-    zmaxBlock.emplace_back(zminBlock[module] + layerT[0] + 0.5*dzStep);
+    zmaxBlock.emplace_back(zminBlock[module] + layerT[0] + 0.5 * dzStep);
     rinBlock1.emplace_back(zminBlock[module] * tan(angTop));
     rinBlock2.emplace_back(zmaxBlock[module] * tan(angTop));
     routBlock1.emplace_back((zminBlock[module] - z1Beam) * slope);
@@ -250,7 +252,7 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
   // Layer 0 (Body)
   if (modules > 1) {
     zminBlock.emplace_back(ziL0Body);
-    zmaxBlock.emplace_back(zminBlock[module] + layerT[0] + 0.5*dzStep);
+    zmaxBlock.emplace_back(zminBlock[module] + layerT[0] + 0.5 * dzStep);
     rinBlock1.emplace_back(zminBlock[module] * tan(angBot));
     rinBlock2.emplace_back(zmaxBlock[module] * tan(angBot));
     routBlock1.emplace_back(zminBlock[module] * tan(angTop));
@@ -272,18 +274,18 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
   // Hac2
   if (modules > 3) {
     zminBlock.emplace_back(ziBody);
-    zmaxBlock.emplace_back(zminBlock[module] + layerN[3]*dzStep);
+    zmaxBlock.emplace_back(zminBlock[module] + layerN[3] * dzStep);
     rinBlock1.emplace_back(zminBlock[module] * tan(angBot));
     rinBlock2.emplace_back(zmaxBlock[module] * tan(angBot));
-    routBlock1.emplace_back((zmaxBlock[module-1] - z1Beam) * slope);
+    routBlock1.emplace_back((zmaxBlock[module - 1] - z1Beam) * slope);
     routBlock2.emplace_back(rout);
     module++;
   }
 
   // Hac3
   if (modules > 4) {
-    zminBlock.emplace_back(zmaxBlock[module-1]);
-    zmaxBlock.emplace_back(zminBlock[module] + layerN[4]*dzStep);
+    zminBlock.emplace_back(zmaxBlock[module - 1]);
+    zmaxBlock.emplace_back(zminBlock[module] + layerN[4] * dzStep);
     rinBlock1.emplace_back(zminBlock[module] * tan(angBot));
     rinBlock2.emplace_back(zmaxBlock[module] * tan(angBot));
     routBlock1.emplace_back(rout);
@@ -293,8 +295,8 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
 
   // Hac4
   if (modules > 5) {
-    zminBlock.emplace_back(zmaxBlock[module-1]);
-    zmaxBlock.emplace_back(zminBlock[module] + layerN[5]*dzStep);
+    zminBlock.emplace_back(zmaxBlock[module - 1]);
+    zmaxBlock.emplace_back(zminBlock[module] + layerN[5] * dzStep);
     rinBlock1.emplace_back(zminBlock[module] * tan(angBot));
     rinBlock2.emplace_back(zmaxBlock[module] * tan(angBot));
     routBlock1.emplace_back(rout);
@@ -304,29 +306,25 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
 
 #ifdef EDM_ML_DEBUG
   for (int i = 0; i < module; i++)
-    edm::LogVerbatim("HCalGeom") 
-      << "DDHCalEndcapAlgo: Module " << i << "\tZ/Rin/Rout " << zminBlock[i] 
-      << ", " << zmaxBlock[i] << "/ " << rinBlock1[i] << ", " << rinBlock2[i] 
-      << "/ " << routBlock1[i] << ", " << routBlock2[i];
+    edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Module " << i << "\tZ/Rin/Rout " << zminBlock[i] << ", "
+                                 << zmaxBlock[i] << "/ " << rinBlock1[i] << ", " << rinBlock2[i] << "/ "
+                                 << routBlock1[i] << ", " << routBlock2[i];
 #endif
 
-  idName      = sArgs["MotherName"];
+  idName = sArgs["MotherName"];
   idNameSpace = DDCurrentNamespace::ns();
-  idOffset = int (nArgs["IdOffset"]); 
+  idOffset = int(nArgs["IdOffset"]);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: Parent " << parent().name() << " idName " << idName 
-    << " NameSpace " << idNameSpace << " Offset " << idOffset;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Parent " << parent().name() << " idName " << idName
+                               << " NameSpace " << idNameSpace << " Offset " << idOffset;
 #endif
 
-  tolPos      = nArgs["TolPos"];
-  tolAbs      = nArgs["TolAbs"];
+  tolPos = nArgs["TolPos"];
+  tolAbs = nArgs["TolAbs"];
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    <<"DDHCalEndcapAlgo: Tolerances - Positioning " << tolPos << " Absorber " 
-    << tolAbs;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Tolerances - Positioning " << tolPos << " Absorber " << tolAbs;
 #endif
 }
 
@@ -335,7 +333,6 @@ void DDHCalEndcapAlgo::initialize(const DDNumericArguments & nArgs,
 ////////////////////////////////////////////////////////////////////
 
 void DDHCalEndcapAlgo::execute(DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "==>> Constructing DDHCalEndcapAlgo...";
 #endif
@@ -350,28 +347,29 @@ void DDHCalEndcapAlgo::execute(DDCompactView& cpv) {
 //----------------------start here for DDD work!!! ---------------
 
 void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: General volume...";
 #endif
 
   bool proto = true;
-  for (int i=0; i<3; i++) 
-    if (equipModule(i) > 0) proto = false;
+  for (int i = 0; i < 3; i++)
+    if (equipModule(i) > 0)
+      proto = false;
 
-  DDRotation    rot;
-  if (DDSplit(getRotation()).first == "NULL") rot = DDRotation();
-  else rot = DDRotation(DDName(DDSplit(getRotation()).first,DDSplit(getRotation()).second));
+  DDRotation rot;
+  if (DDSplit(getRotation()).first == "NULL")
+    rot = DDRotation();
+  else
+    rot = DDRotation(DDName(DDSplit(getRotation()).first, DDSplit(getRotation()).second));
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << " First " << DDSplit(getRotation()).first << " Second " 
-    << DDSplit(getRotation()).second << " Rotation " << rot;
+  edm::LogVerbatim("HCalGeom") << " First " << DDSplit(getRotation()).first << " Second "
+                               << DDSplit(getRotation()).second << " Rotation " << rot;
 #endif
-  
-  DDTranslation r0(0,0,getZShift());
-  double alpha = (1._pi)/getNsectors();
-  double dphi  = getNsectortot()*(2._pi)/getNsectors();
+
+  DDTranslation r0(0, 0, getZShift());
+  double alpha = (1._pi) / getNsectors();
+  double dphi = getNsectortot() * (2._pi) / getNsectors();
 
   //!!!!!!!!!!!!!!!!!Should be zero. And removed as soon as
   //vertical walls are allowed in SolidPolyhedra
@@ -380,300 +378,271 @@ void DDHCalEndcapAlgo::constructGeneralVolume(DDCompactView& cpv) {
   std::vector<double> pgonZ, pgonRmin, pgonRmax;
   if (proto) {
     double zf = getZiBody() + getZShiftHac2();
-    pgonZ.emplace_back(zf - getDzShift()); 
-    pgonRmin.emplace_back(zf * tan(getAngBot())); 
-    pgonRmax.emplace_back((zf - getZ1Beam())*getSlope()); 
+    pgonZ.emplace_back(zf - getDzShift());
+    pgonRmin.emplace_back(zf * tan(getAngBot()));
+    pgonRmax.emplace_back((zf - getZ1Beam()) * getSlope());
   } else {
-    pgonZ.emplace_back(getZFront()   - getDzShift()); 
-    pgonRmin.emplace_back(getZFront()   * tan(getAngTop())); 
-    pgonRmax.emplace_back((getZFront()   - getZ1Beam())*getSlope()); 
-    pgonZ.emplace_back(getZiL0Body() - getDzShift()); 
-    pgonRmin.emplace_back(getZiL0Body() * tan(getAngTop())); 
-    pgonRmax.emplace_back((getZiL0Body() - getZ1Beam())*getSlope()); 
-    pgonZ.emplace_back(getZiL0Body() - getDzShift()); 
-    pgonRmin.emplace_back(getZiL0Body() * tan(getAngBot())); 
-    pgonRmax.emplace_back((getZiL0Body() - getZ1Beam())*getSlope()); 
+    pgonZ.emplace_back(getZFront() - getDzShift());
+    pgonRmin.emplace_back(getZFront() * tan(getAngTop()));
+    pgonRmax.emplace_back((getZFront() - getZ1Beam()) * getSlope());
+    pgonZ.emplace_back(getZiL0Body() - getDzShift());
+    pgonRmin.emplace_back(getZiL0Body() * tan(getAngTop()));
+    pgonRmax.emplace_back((getZiL0Body() - getZ1Beam()) * getSlope());
+    pgonZ.emplace_back(getZiL0Body() - getDzShift());
+    pgonRmin.emplace_back(getZiL0Body() * tan(getAngBot()));
+    pgonRmax.emplace_back((getZiL0Body() - getZ1Beam()) * getSlope());
   }
-  pgonZ.emplace_back(getZiKink()   - getDzShift()); 
-  pgonRmin.emplace_back(getRinKink()); 
-  pgonRmax.emplace_back(getRout()); 
-  pgonZ.emplace_back(getZiDip()    - getDzShift()); 
-  pgonRmin.emplace_back(getRinDip()); 
-  pgonRmax.emplace_back(getRout()); 
-  pgonZ.emplace_back(getZiDip()    - getDzShift() + delz); 
-  pgonRmin.emplace_back(getRinDip()); 
-  pgonRmax.emplace_back(getRoutDip()); 
-  pgonZ.emplace_back(getZEnd()     - getDzShift()); 
-  pgonRmin.emplace_back(getZEnd() * tan(getAngBot())); 
-  pgonRmax.emplace_back(getRoutDip()); 
-  pgonZ.emplace_back(getZEnd()); 
-  pgonRmin.emplace_back(getZEnd() * tan(getAngBot())); 
-  pgonRmax.emplace_back(getRoutDip()); 
+  pgonZ.emplace_back(getZiKink() - getDzShift());
+  pgonRmin.emplace_back(getRinKink());
+  pgonRmax.emplace_back(getRout());
+  pgonZ.emplace_back(getZiDip() - getDzShift());
+  pgonRmin.emplace_back(getRinDip());
+  pgonRmax.emplace_back(getRout());
+  pgonZ.emplace_back(getZiDip() - getDzShift() + delz);
+  pgonRmin.emplace_back(getRinDip());
+  pgonRmax.emplace_back(getRoutDip());
+  pgonZ.emplace_back(getZEnd() - getDzShift());
+  pgonRmin.emplace_back(getZEnd() * tan(getAngBot()));
+  pgonRmax.emplace_back(getRoutDip());
+  pgonZ.emplace_back(getZEnd());
+  pgonRmin.emplace_back(getZEnd() * tan(getAngBot()));
+  pgonRmax.emplace_back(getRoutDip());
 
   std::string name("Null");
   DDSolid solid;
-  solid = DDSolidFactory::polyhedra(DDName(idName, idNameSpace),
-				    getNsectortot(), -alpha, dphi, pgonZ, 
-				    pgonRmin, pgonRmax);
+  solid =
+      DDSolidFactory::polyhedra(DDName(idName, idNameSpace), getNsectortot(), -alpha, dphi, pgonZ, pgonRmin, pgonRmax);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: " << DDName(idName, idNameSpace) 
-    << " Polyhedra made of " << getGenMat() << " with " << getNsectortot() 
-    << " sectors from " << convertRadToDeg(-alpha) << " to " 
-    << convertRadToDeg(-alpha+dphi) << " and with " << pgonZ.size() <<" sections";
-  for (unsigned int i = 0; i <pgonZ.size(); i++) 
-    edm::LogVerbatim("HCalGeom") 
-      << "\t\tZ = " << pgonZ[i] << "\tRmin = " << pgonRmin[i] << "\tRmax = " 
-      << pgonRmax[i];
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << DDName(idName, idNameSpace) << " Polyhedra made of "
+                               << getGenMat() << " with " << getNsectortot() << " sectors from "
+                               << convertRadToDeg(-alpha) << " to " << convertRadToDeg(-alpha + dphi) << " and with "
+                               << pgonZ.size() << " sections";
+  for (unsigned int i = 0; i < pgonZ.size(); i++)
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[i] << "\tRmin = " << pgonRmin[i] << "\tRmax = " << pgonRmax[i];
 #endif
 
-  DDName matname(DDSplit(getGenMat()).first, DDSplit(getGenMat()).second); 
+  DDName matname(DDSplit(getGenMat()).first, DDSplit(getGenMat()).second);
   DDMaterial matter(matname);
   DDLogicalPart genlogic(DDName(idName, idNameSpace), matter, solid);
 
-  DDName parentName = parent().name(); 
+  DDName parentName = parent().name();
   cpv.position(DDName(idName, idNameSpace), parentName, 1, r0, rot);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: " << DDName(idName, idNameSpace)
-    << " number 1 positioned in " << parentName << " at " << r0 << " with " <<rot;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << DDName(idName, idNameSpace) << " number 1 positioned in "
+                               << parentName << " at " << r0 << " with " << rot;
 #endif
-  
+
   if (getEndcaps() != 1) {
-    rot = DDRotation(DDName(rotHalf,rotns));
+    rot = DDRotation(DDName(rotHalf, rotns));
     cpv.position(DDName(idName, idNameSpace), parentName, 2, r0, rot);
 
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") 
-      << "DDHCalEndcapAlgo: " << DDName(idName, idNameSpace) << " number 2 "
-      << "positioned in " << parentName  << " at " << r0 << " with " << rot;
+    edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << DDName(idName, idNameSpace) << " number 2 "
+                                 << "positioned in " << parentName << " at " << r0 << " with " << rot;
 #endif
-
   }
 
   //Forward half
-  name  = idName + "Front";
+  name = idName + "Front";
   std::vector<double> pgonZMod, pgonRminMod, pgonRmaxMod;
-  for (unsigned int i=0; i < (pgonZ.size()-1); i++) {
-    pgonZMod.emplace_back(pgonZ[i] + getDzShift()); 
-    pgonRminMod.emplace_back(pgonRmin[i]); 
-    pgonRmaxMod.emplace_back(pgonRmax[i]); 
+  for (unsigned int i = 0; i < (pgonZ.size() - 1); i++) {
+    pgonZMod.emplace_back(pgonZ[i] + getDzShift());
+    pgonRminMod.emplace_back(pgonRmin[i]);
+    pgonRmaxMod.emplace_back(pgonRmax[i]);
   }
-  solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace),
-				    getNsectortot(), -alpha, dphi, pgonZMod,
-				    pgonRminMod, pgonRmaxMod);
+  solid = DDSolidFactory::polyhedra(
+      DDName(name, idNameSpace), getNsectortot(), -alpha, dphi, pgonZMod, pgonRminMod, pgonRmaxMod);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom")
-    << "DDHCalEndcapAlgo: " << DDName(name,idNameSpace) << " Polyhedra made of "
-    << getGenMat() << " with " << getNsectortot() << " sectors from " 
-    << convertRadToDeg(-alpha) << " to " << convertRadToDeg(-alpha+dphi)
-    << " and with " << pgonZMod.size() << " sections ";
-  for (unsigned int i = 0; i < pgonZMod.size(); i++) 
-    edm::LogVerbatim("HCalGeom") 
-      << "\t\tZ = " << pgonZMod[i] << "\tRmin = " << pgonRminMod[i] << "\tRmax = "
-      << pgonRmaxMod[i];
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << DDName(name, idNameSpace) << " Polyhedra made of "
+                               << getGenMat() << " with " << getNsectortot() << " sectors from "
+                               << convertRadToDeg(-alpha) << " to " << convertRadToDeg(-alpha + dphi) << " and with "
+                               << pgonZMod.size() << " sections ";
+  for (unsigned int i = 0; i < pgonZMod.size(); i++)
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZMod[i] << "\tRmin = " << pgonRminMod[i]
+                                 << "\tRmax = " << pgonRmaxMod[i];
 #endif
-  
+
   DDLogicalPart genlogich(DDName(name, idNameSpace), matter, solid);
 
-  cpv.position(genlogich, genlogic, 1, DDTranslation(0.0, 0.0, -getDzShift()),
-	DDRotation());
+  cpv.position(genlogich, genlogic, 1, DDTranslation(0.0, 0.0, -getDzShift()), DDRotation());
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: " << genlogich.name() << " number 1 positioned in " 
-    << genlogic.name() << " at (0,0," << -getDzShift()<< ") with no rotation";
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << genlogich.name() << " number 1 positioned in "
+                               << genlogic.name() << " at (0,0," << -getDzShift() << ") with no rotation";
 #endif
-  
+
   //Construct sector (from -alpha to +alpha)
-  name  = idName + "Module";
-  solid =   DDSolidFactory::polyhedra(DDName(name, idNameSpace),
-				      1, -alpha, 2*alpha, pgonZMod,
-				      pgonRminMod, pgonRmaxMod);
+  name = idName + "Module";
+  solid =
+      DDSolidFactory::polyhedra(DDName(name, idNameSpace), 1, -alpha, 2 * alpha, pgonZMod, pgonRminMod, pgonRmaxMod);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: " << DDName(name,idNameSpace)<< " Polyhedra made of "
-    << getGenMat() <<" with 1 sector from " << convertRadToDeg(-alpha) << " to " 
-    << convertRadToDeg(alpha) << " and with " << pgonZMod.size() << " sections";
-  for (unsigned int i = 0; i < pgonZMod.size(); i++) 
-    edm::LogVerbatim("HCalGeom")
-      << "\t\tZ = " << pgonZMod[i] << "\tRmin = " << pgonRminMod[i] << "\tRmax = "
-      << pgonRmaxMod[i];
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << DDName(name, idNameSpace) << " Polyhedra made of "
+                               << getGenMat() << " with 1 sector from " << convertRadToDeg(-alpha) << " to "
+                               << convertRadToDeg(alpha) << " and with " << pgonZMod.size() << " sections";
+  for (unsigned int i = 0; i < pgonZMod.size(); i++)
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZMod[i] << "\tRmin = " << pgonRminMod[i]
+                                 << "\tRmax = " << pgonRmaxMod[i];
 #endif
-  
+
   DDLogicalPart seclogic(DDName(name, idNameSpace), matter, solid);
-  
-  for (int ii=0; ii<getNsectortot(); ii++) {
-    double phi    = ii*2*alpha;
+
+  for (int ii = 0; ii < getNsectortot(); ii++) {
+    double phi = ii * 2 * alpha;
     DDRotation rotation;
     std::string rotstr("NULL");
     if (phi != 0) {
       rotstr = "R" + formatAsDegreesInInteger(phi);
-      rotation = DDRotation(DDName(rotstr, rotns)); 
+      rotation = DDRotation(DDName(rotstr, rotns));
       if (!rotation) {
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom")
-	  << "DDHCalEndcapAlgo: Creating a new rotation " << rotstr 
-	  << "\t 90," << convertRadToDeg(phi) << ", 90," 
-	  << convertRadToDeg(phi+90._deg) << ", 0, 0";
+        edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Creating a new rotation " << rotstr << "\t 90,"
+                                     << convertRadToDeg(phi) << ", 90," << convertRadToDeg(phi + 90._deg) << ", 0, 0";
 #endif
-	rotation = DDrot(DDName(rotstr, rotns), 90._deg, phi, 90._deg,
-			 (90._deg+phi), 0,  0);
-      } //if !rotation
-    } //if phi!=0
-  
-   cpv.position(seclogic, genlogich, ii+1, DDTranslation(0.0, 0.0, 0.0), rotation);
+        rotation = DDrot(DDName(rotstr, rotns), 90._deg, phi, 90._deg, (90._deg + phi), 0, 0);
+      }  //if !rotation
+    }    //if phi!=0
+
+    cpv.position(seclogic, genlogich, ii + 1, DDTranslation(0.0, 0.0, 0.0), rotation);
 
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") 
-      << "DDHCalEndcapAlgo: " << seclogic.name() << " number " << ii+1 
-      << " positioned in " << genlogich.name() << " at (0,0,0) with " << rotation;
+    edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << seclogic.name() << " number " << ii + 1 << " positioned in "
+                                 << genlogich.name() << " at (0,0,0) with " << rotation;
 #endif
-    
   }
-  
+
   //Construct the things inside the sector
   constructInsideSector(seclogic, cpv);
 
   //Backward half
-  name  = idName + "Back";
+  name = idName + "Back";
   std::vector<double> pgonZBack, pgonRminBack, pgonRmaxBack;
-  pgonZBack.emplace_back(getZEnd() - getDzShift()); 
-  pgonRminBack.emplace_back(pgonZBack[0]*tan(getAngBot()) + getDrEnd()); 
-  pgonRmaxBack.emplace_back(getRoutDip()); 
-  pgonZBack.emplace_back(getZEnd()); 
-  pgonRminBack.emplace_back(pgonZBack[1]*tan(getAngBot()) + getDrEnd()); 
-  pgonRmaxBack.emplace_back(getRoutDip()); 
-  solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace),
-				    getNsectortot(), -alpha, dphi, pgonZBack,
-				    pgonRminBack, pgonRmaxBack);
+  pgonZBack.emplace_back(getZEnd() - getDzShift());
+  pgonRminBack.emplace_back(pgonZBack[0] * tan(getAngBot()) + getDrEnd());
+  pgonRmaxBack.emplace_back(getRoutDip());
+  pgonZBack.emplace_back(getZEnd());
+  pgonRminBack.emplace_back(pgonZBack[1] * tan(getAngBot()) + getDrEnd());
+  pgonRmaxBack.emplace_back(getRoutDip());
+  solid = DDSolidFactory::polyhedra(
+      DDName(name, idNameSpace), getNsectortot(), -alpha, dphi, pgonZBack, pgonRminBack, pgonRmaxBack);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: " << DDName(name,idNameSpace) << " Polyhedra made of " 
-    << getAbsMat() << " with " << getNsectortot() << " sectors from " 
-    << convertRadToDeg(-alpha) << " to " << convertRadToDeg(-alpha+dphi)
-    << " and with "  << pgonZBack.size() << " sections";
-  for (unsigned int i = 0; i < pgonZBack.size(); i++) 
-    edm::LogVerbatim("HCalGeom") 
-      << "\t\tZ = " << pgonZBack[i] << "\tRmin = " << pgonRminBack[i] 
-      << "\tRmax = " << pgonRmaxBack[i];
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << DDName(name, idNameSpace) << " Polyhedra made of "
+                               << getAbsMat() << " with " << getNsectortot() << " sectors from "
+                               << convertRadToDeg(-alpha) << " to " << convertRadToDeg(-alpha + dphi) << " and with "
+                               << pgonZBack.size() << " sections";
+  for (unsigned int i = 0; i < pgonZBack.size(); i++)
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZBack[i] << "\tRmin = " << pgonRminBack[i]
+                                 << "\tRmax = " << pgonRmaxBack[i];
 #endif
-  
-  DDName absMatname(DDSplit(getAbsMat()).first, DDSplit(getAbsMat()).second); 
+
+  DDName absMatname(DDSplit(getAbsMat()).first, DDSplit(getAbsMat()).second);
   DDMaterial absMatter(absMatname);
   DDLogicalPart glog(DDName(name, idNameSpace), absMatter, solid);
 
   cpv.position(glog, genlogic, 1, DDTranslation(0.0, 0.0, 0.0), DDRotation());
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: " << glog.name() << " number 1 positioned in "
-    << genlogic.name() << " at (0,0,0) with no rotation";
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << glog.name() << " number 1 positioned in " << genlogic.name()
+                               << " at (0,0,0) with no rotation";
 #endif
 }
 
-
 void DDHCalEndcapAlgo::constructInsideSector(const DDLogicalPart& sector, DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: Modules (" << getModules() << ") ...";
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Modules (" << getModules() << ") ...";
 #endif
 
-  double alpha = (1._pi)/getNsectors();
+  double alpha = (1._pi) / getNsectors();
 
   for (int i = 0; i < getModules(); i++) {
-    std::string  name   = idName + getModName(i);
-    DDName matname(DDSplit(getModMat(i)).first, DDSplit(getModMat(i)).second); 
+    std::string name = idName + getModName(i);
+    DDName matname(DDSplit(getModMat(i)).first, DDSplit(getModMat(i)).second);
     DDMaterial matter(matname);
-    
-    if (equipModule(i)>0) {
+
+    if (equipModule(i) > 0) {
       int nsec = getSectionModule(i);
 
       //!!!!!!!!!!!!!!!!!Should be zero. And removed as soon as
       //vertical walls are allowed in SolidPolyhedra
       double deltaz = 0;
-    
+
       std::vector<double> pgonZ, pgonRmin, pgonRmax;
       if (nsec == 3) {
-	double zf = getZminBlock(i) + getZShiftHac2();
-	pgonZ.emplace_back(zf);
-	pgonRmin.emplace_back(zf*tan(getAngBot())); 
-	pgonRmax.emplace_back((zf-getZ1Beam())*getSlope());
-	pgonZ.emplace_back(getZiKink());  
-	pgonRmin.emplace_back(getRinKink()); 
-	pgonRmax.emplace_back(getRout());
+        double zf = getZminBlock(i) + getZShiftHac2();
+        pgonZ.emplace_back(zf);
+        pgonRmin.emplace_back(zf * tan(getAngBot()));
+        pgonRmax.emplace_back((zf - getZ1Beam()) * getSlope());
+        pgonZ.emplace_back(getZiKink());
+        pgonRmin.emplace_back(getRinKink());
+        pgonRmax.emplace_back(getRout());
       } else {
-	pgonZ.emplace_back(getZminBlock(i));
-	pgonRmin.emplace_back(getRinBlock1(i)); 
-	pgonRmax.emplace_back(getRoutBlock1(i));
+        pgonZ.emplace_back(getZminBlock(i));
+        pgonRmin.emplace_back(getRinBlock1(i));
+        pgonRmax.emplace_back(getRoutBlock1(i));
       }
       if (nsec == 4) {
-	pgonZ.emplace_back(getZiDip());
-	pgonRmin.emplace_back(getRinDip());
-	pgonRmax.emplace_back(getRout());
-	pgonZ.emplace_back(pgonZ[1] + deltaz);
-	pgonRmin.emplace_back(pgonRmin[1]); 
-	pgonRmax.emplace_back(getRoutDip());
+        pgonZ.emplace_back(getZiDip());
+        pgonRmin.emplace_back(getRinDip());
+        pgonRmax.emplace_back(getRout());
+        pgonZ.emplace_back(pgonZ[1] + deltaz);
+        pgonRmin.emplace_back(pgonRmin[1]);
+        pgonRmax.emplace_back(getRoutDip());
       }
       pgonZ.emplace_back(getZmaxBlock(i));
-      pgonRmin.emplace_back(getRinBlock2(i)); 
+      pgonRmin.emplace_back(getRinBlock2(i));
       pgonRmax.emplace_back(getRoutBlock2(i));
 
       //Solid & volume
       DDSolid solid;
-      solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 
-					1, -alpha, 2*alpha,
-					pgonZ, pgonRmin, pgonRmax);
+      solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 1, -alpha, 2 * alpha, pgonZ, pgonRmin, pgonRmax);
 
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapAlgo: " << DDName(name,idNameSpace) 
-	<< " Polyhedra made of " << getModMat(i) << " with 1 sector from " 
-	<< convertRadToDeg(-alpha) << " to " << convertRadToDeg(alpha)
-	<< " and with " << nsec << " sections";
-      for (unsigned int k=0; k<pgonZ.size(); k++)
-	edm::LogVerbatim("HCalGeom")
-	  << "\t\tZ = " << pgonZ[k] << "\tRmin = " << pgonRmin[k] << "\tRmax = "
-	  << pgonRmax[k];
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << DDName(name, idNameSpace) << " Polyhedra made of "
+                                   << getModMat(i) << " with 1 sector from " << convertRadToDeg(-alpha) << " to "
+                                   << convertRadToDeg(alpha) << " and with " << nsec << " sections";
+      for (unsigned int k = 0; k < pgonZ.size(); k++)
+        edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[k] << "\tRmin = " << pgonRmin[k]
+                                     << "\tRmax = " << pgonRmax[k];
 #endif
-      
+
       DDLogicalPart glog(DDName(name, idNameSpace), matter, solid);
 
-      cpv.position(glog, sector, i+1, DDTranslation(0.0, 0.0, 0.0), DDRotation());
+      cpv.position(glog, sector, i + 1, DDTranslation(0.0, 0.0, 0.0), DDRotation());
 
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapAlgo: " << glog.name() << " number " << i+1 
-	<< " positioned in " << sector.name() <<" at (0,0,0) with no rotation";
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << glog.name() << " number " << i + 1 << " positioned in "
+                                   << sector.name() << " at (0,0,0) with no rotation";
 #endif
-      
-      if (getModType(i) == 0) 
-	constructInsideModule0 (glog, i, cpv);
+
+      if (getModType(i) == 0)
+        constructInsideModule0(glog, i, cpv);
       else
-	constructInsideModule  (glog, i, cpv);
+        constructInsideModule(glog, i, cpv);
     }
-  } 
+  }
 }
 
-void DDHCalEndcapAlgo::parameterLayer0(int mod, int layer, int iphi, 
-				       double& yh, double& bl, double& tl, 
-				       double& alp, double& xpos, double& ypos,
+void DDHCalEndcapAlgo::parameterLayer0(int mod,
+                                       int layer,
+                                       int iphi,
+                                       double& yh,
+                                       double& bl,
+                                       double& tl,
+                                       double& alp,
+                                       double& xpos,
+                                       double& ypos,
                                        double& zpos) {
-
   //Given module and layer number compute parameters of trapezoid
   //and positioning parameters
-  double alpha = (1._pi)/getNsectors();
+  double alpha = (1._pi) / getNsectors();
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "Input " << iphi << " " << layer << " " << iphi << " Alpha " 
-    << convertRadToDeg(alpha);
+  edm::LogVerbatim("HCalGeom") << "Input " << iphi << " " << layer << " " << iphi << " Alpha "
+                               << convertRadToDeg(alpha);
 #endif
-  
+
   double zi, zo;
   if (iphi == 0) {
     zi = getZminBlock(mod);
@@ -684,94 +653,97 @@ void DDHCalEndcapAlgo::parameterLayer0(int mod, int layer, int iphi,
   }
   double rin, rout;
   if (mod == 0) {
-    rin  = zo * tan(getAngTop());
+    rin = zo * tan(getAngTop());
     rout = (zi - getZ1Beam()) * getSlope();
   } else {
-    rin  = zo * tan(getAngBot());
+    rin = zo * tan(getAngBot());
     rout = zi * tan(getAngTop());
   }
-  yh   = 0.5 * (rout - rin);
-  bl   = 0.5 * rin * tan (alpha);
-  tl   = 0.5 * rout * tan(alpha);
+  yh = 0.5 * (rout - rin);
+  bl = 0.5 * rin * tan(alpha);
+  tl = 0.5 * rout * tan(alpha);
   xpos = 0.5 * (rin + rout);
   ypos = 0.5 * (bl + tl);
   zpos = 0.5 * (zi + zo);
-  yh  -= getTrim(mod,iphi);
-  bl  -= getTrim(mod,iphi);
-  tl  -= getTrim(mod,iphi);
-  alp  = atan(0.5 * tan(alpha));
+  yh -= getTrim(mod, iphi);
+  bl -= getTrim(mod, iphi);
+  tl -= getTrim(mod, iphi);
+  alp = atan(0.5 * tan(alpha));
   if (iphi == 0) {
-    ypos  = -ypos;
+    ypos = -ypos;
   } else {
-    alp  = -alp;
+    alp = -alp;
   }
-  
+
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "Output Dimensions " << yh << " " << bl << " " << tl << " " 
-    << convertRadToDeg(alp) << " Position " << xpos << " " << ypos << " " << zpos;
+  edm::LogVerbatim("HCalGeom") << "Output Dimensions " << yh << " " << bl << " " << tl << " " << convertRadToDeg(alp)
+                               << " Position " << xpos << " " << ypos << " " << zpos;
 #endif
 }
 
-void DDHCalEndcapAlgo::parameterLayer(int iphi, double rinF, double routF,
-				      double rinB, double routB, double zi,
-				      double zo, double& yh1, double& bl1,
-				      double& tl1, double& yh2, double& bl2,
-				      double& tl2, double& alp, double& theta,
-				      double& phi, double& xpos, double& ypos,
-				      double& zpos) {
-
-  //Given rin, rout compute parameters of the trapezoid and 
+void DDHCalEndcapAlgo::parameterLayer(int iphi,
+                                      double rinF,
+                                      double routF,
+                                      double rinB,
+                                      double routB,
+                                      double zi,
+                                      double zo,
+                                      double& yh1,
+                                      double& bl1,
+                                      double& tl1,
+                                      double& yh2,
+                                      double& bl2,
+                                      double& tl2,
+                                      double& alp,
+                                      double& theta,
+                                      double& phi,
+                                      double& xpos,
+                                      double& ypos,
+                                      double& zpos) {
+  //Given rin, rout compute parameters of the trapezoid and
   //position of the trapezoid for a standrd layer
-  double alpha = (1._pi)/getNsectors();
+  double alpha = (1._pi) / getNsectors();
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "Input " << iphi << " Front " << rinF << " " << routF << " " << zi 
-    << " Back " << rinB << " " << routB << " " << zo << " Alpha " 
-    << convertRadToDeg(alpha);
+  edm::LogVerbatim("HCalGeom") << "Input " << iphi << " Front " << rinF << " " << routF << " " << zi << " Back " << rinB
+                               << " " << routB << " " << zo << " Alpha " << convertRadToDeg(alpha);
 #endif
-  
+
   yh1 = 0.5 * (routF - rinB);
-  bl1 = 0.5 * rinB  * tan(alpha);
+  bl1 = 0.5 * rinB * tan(alpha);
   tl1 = 0.5 * routF * tan(alpha);
   yh2 = 0.5 * (routF - rinB);
-  bl2 = 0.5 * rinB  * tan(alpha);
+  bl2 = 0.5 * rinB * tan(alpha);
   tl2 = 0.5 * routF * tan(alpha);
-  double dx  = 0.25* (bl2+tl2-bl1-tl1);
-  double dy  = 0.5 * (rinB+routF-rinB-routF);
-  xpos = 0.25*(rinB+routF+rinB+routF);
-  ypos = 0.25*(bl2+tl2+bl1+tl1);
-  zpos = 0.5*(zi+zo);
-  alp  = atan(0.5 * tan(alpha));
+  double dx = 0.25 * (bl2 + tl2 - bl1 - tl1);
+  double dy = 0.5 * (rinB + routF - rinB - routF);
+  xpos = 0.25 * (rinB + routF + rinB + routF);
+  ypos = 0.25 * (bl2 + tl2 + bl1 + tl1);
+  zpos = 0.5 * (zi + zo);
+  alp = atan(0.5 * tan(alpha));
   //  ypos-= getTolPos();
   if (iphi == 0) {
-    ypos  = -ypos;
+    ypos = -ypos;
   } else {
-    alp  = -alp;
-    dx   = -dx;
+    alp = -alp;
+    dx = -dx;
   }
-  double r   = sqrt (dx*dx + dy*dy);
-  theta= atan (r/(zo-zi));
-  phi  = atan2 (dy, dx);
+  double r = sqrt(dx * dx + dy * dy);
+  theta = atan(r / (zo - zi));
+  phi = atan2(dy, dx);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "Output Dimensions " << yh1 << " " << bl1 << " " << tl1 << " " << yh2 
-    << " " << bl2 << " " << tl2 << " " << convertRadToDeg(alp) << " " 
-    << convertRadToDeg(theta) << " " << convertRadToDeg(phi) << " Position "
-    << xpos << " " << ypos << " " << zpos;
+  edm::LogVerbatim("HCalGeom") << "Output Dimensions " << yh1 << " " << bl1 << " " << tl1 << " " << yh2 << " " << bl2
+                               << " " << tl2 << " " << convertRadToDeg(alp) << " " << convertRadToDeg(theta) << " "
+                               << convertRadToDeg(phi) << " Position " << xpos << " " << ypos << " " << zpos;
 #endif
 }
 
-
 void DDHCalEndcapAlgo::constructInsideModule0(const DDLogicalPart& module, int mod, DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: \t\tInside module0 ..." << mod;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: \t\tInside module0 ..." << mod;
 #endif
-  
+
   ///////////////////////////////////////////////////////////////
   //Pointers to the Rotation Matrices and to the Materials
   std::string rotstr = getRotMat();
@@ -781,116 +753,104 @@ void DDHCalEndcapAlgo::constructInsideModule0(const DDLogicalPart& module, int m
   DDName plasName(DDSplit(getPlastMat()).first, DDSplit(getPlastMat()).second);
   DDMaterial matplastic(plasName);
 
-  int     layer  = getLayer(mod,0);
-  int     layer0 = getLayer(mod,1);
-  std::string  name;
-  double  xpos, ypos, zpos;
+  int layer = getLayer(mod, 0);
+  int layer0 = getLayer(mod, 1);
+  std::string name;
+  double xpos, ypos, zpos;
   DDSolid solid;
   DDLogicalPart glog, plog;
   for (int iphi = 0; iphi < getPhi(); iphi++) {
     double yh, bl, tl, alp;
     parameterLayer0(mod, layer, iphi, yh, bl, tl, alp, xpos, ypos, zpos);
-    name = module.name().name()+getLayerName(layer)+getPhiName(iphi);
-    solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
-				 0.5*getLayerT(layer), 0, 0, yh,
-				 bl, tl, alp, yh, bl, tl, alp);
+    name = module.name().name() + getLayerName(layer) + getPhiName(iphi);
+    solid =
+        DDSolidFactory::trap(DDName(name, idNameSpace), 0.5 * getLayerT(layer), 0, 0, yh, bl, tl, alp, yh, bl, tl, alp);
 
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") 
-      << "DDHCalEndcapAlgo: " << solid.name() << " Trap made of " << getPlastMat()
-      << " of dimensions " << 0.5*getLayerT(layer) << ", 0, 0, " << yh << ", "
-      << bl << ", " << tl << ", " << convertRadToDeg(alp) << ", " << yh << ", " 
-      << bl << ", " << tl << ", " << convertRadToDeg(alp);
+    edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << solid.name() << " Trap made of " << getPlastMat()
+                                 << " of dimensions " << 0.5 * getLayerT(layer) << ", 0, 0, " << yh << ", " << bl
+                                 << ", " << tl << ", " << convertRadToDeg(alp) << ", " << yh << ", " << bl << ", " << tl
+                                 << ", " << convertRadToDeg(alp);
 #endif
 
     glog = DDLogicalPart(solid.ddname(), matplastic, solid);
 
     DDTranslation r1(xpos, ypos, zpos);
-    cpv.position(glog, module, idOffset+layer+1, r1, rot);
+    cpv.position(glog, module, idOffset + layer + 1, r1, rot);
 
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") 
-      << "DDHCalEndcapAlgo: " << glog.name() << " number " << idOffset+layer+1 
-      << " positioned in " << module.name() << " at " << r1 << " with " << rot;
+    edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << glog.name() << " number " << idOffset + layer + 1
+                                 << " positioned in " << module.name() << " at " << r1 << " with " << rot;
 #endif
 
     //Now construct the layer of scintillator inside this
-    int copyNo = layer0*10 + getLayerType(layer);
-    name = getModName(mod)+getLayerName(layer)+getPhiName(iphi);
-    constructScintLayer (glog, getScintT(layer), yh, bl, tl, alp, name, copyNo, cpv);
+    int copyNo = layer0 * 10 + getLayerType(layer);
+    name = getModName(mod) + getLayerName(layer) + getPhiName(iphi);
+    constructScintLayer(glog, getScintT(layer), yh, bl, tl, alp, name, copyNo, cpv);
   }
 
   //Now the absorber layer
   double zi = getZminBlock(mod) + getLayerT(layer);
-  double zo = zi + 0.5*getDzStep();
+  double zo = zi + 0.5 * getDzStep();
   double rinF, routF, rinB, routB;
   if (mod == 0) {
-    rinF  = zi * tan(getAngTop());
-    routF =(zi - getZ1Beam()) * getSlope();
-    rinB  = zo * tan(getAngTop());
-    routB =(zo - getZ1Beam()) * getSlope();
+    rinF = zi * tan(getAngTop());
+    routF = (zi - getZ1Beam()) * getSlope();
+    rinB = zo * tan(getAngTop());
+    routB = (zo - getZ1Beam()) * getSlope();
   } else {
-    rinF  = zi * tan(getAngBot());
+    rinF = zi * tan(getAngBot());
     routF = zi * tan(getAngTop());
-    rinB  = zo * tan(getAngBot());
+    rinB = zo * tan(getAngBot());
     routB = zo * tan(getAngTop());
   }
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: Module " << mod << " Front " << zi << ", " << rinF
-    << ", " << routF << " Back " << zo << ", " << rinB << ", " << routB;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Module " << mod << " Front " << zi << ", " << rinF << ", " << routF
+                               << " Back " << zo << ", " << rinB << ", " << routB;
 #endif
-  
+
   double yh1, bl1, tl1, yh2, bl2, tl2, theta, phi, alp;
-  parameterLayer(0, rinF, routF, rinB, routB, zi, zo, yh1, bl1, tl1, yh2, bl2, 
-                 tl2, alp, theta, phi, xpos, ypos, zpos);
+  parameterLayer(0, rinF, routF, rinB, routB, zi, zo, yh1, bl1, tl1, yh2, bl2, tl2, alp, theta, phi, xpos, ypos, zpos);
   double fact = getTolAbs();
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: Trim " << fact << " Param " << yh1 << ", " << bl1 
-    << ", " << tl1 << ", " << yh2 << ", " << bl2 << ", " << tl2;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Trim " << fact << " Param " << yh1 << ", " << bl1 << ", " << tl1
+                               << ", " << yh2 << ", " << bl2 << ", " << tl2;
 #endif
-  
+
   bl1 -= fact;
   tl1 -= fact;
   bl2 -= fact;
   tl2 -= fact;
 
-  name = module.name().name()+"Absorber";
-  solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
-			       0.5*getThick(mod), theta, phi, yh1,
-			       bl1, tl1, alp, yh2, bl2, tl2, alp);
+  name = module.name().name() + "Absorber";
+  solid = DDSolidFactory::trap(
+      DDName(name, idNameSpace), 0.5 * getThick(mod), theta, phi, yh1, bl1, tl1, alp, yh2, bl2, tl2, alp);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: " << solid.name() << " Trap made of " << getAbsMat() 
-    << " of dimensions " << 0.5*getThick(mod) << ", " << convertRadToDeg(theta)
-    << ", " << convertRadToDeg(phi) << ", " << yh1 << ", " << bl1 << ", " << tl1
-    << ", " << convertRadToDeg(alp) << ", " << yh2 << ", " << bl2 << ", " << tl2
-    << ", " << convertRadToDeg(alp);
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << solid.name() << " Trap made of " << getAbsMat()
+                               << " of dimensions " << 0.5 * getThick(mod) << ", " << convertRadToDeg(theta) << ", "
+                               << convertRadToDeg(phi) << ", " << yh1 << ", " << bl1 << ", " << tl1 << ", "
+                               << convertRadToDeg(alp) << ", " << yh2 << ", " << bl2 << ", " << tl2 << ", "
+                               << convertRadToDeg(alp);
 #endif
-  
+
   glog = DDLogicalPart(solid.ddname(), matabsorbr, solid);
 
   DDTranslation r2(xpos, ypos, zpos);
   cpv.position(glog, module, 1, r2, rot);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom")
-    << "DDHCalEndcapAlgo: " << glog.name() << " number 1 positioned in " 
-    << module.name() << " at " << r2 << " with " << rot;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << glog.name() << " number 1 positioned in " << module.name()
+                               << " at " << r2 << " with " << rot;
 #endif
 }
 
-
 void DDHCalEndcapAlgo::constructInsideModule(const DDLogicalPart& module, int mod, DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: \t\tInside module ..." << mod;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: \t\tInside module ..." << mod;
 #endif
-  
+
   ///////////////////////////////////////////////////////////////
   //Pointers to the Rotation Matrices and to the Materials
   std::string rotstr = getRotMat();
@@ -900,137 +860,129 @@ void DDHCalEndcapAlgo::constructInsideModule(const DDLogicalPart& module, int mo
   DDName plasName(DDSplit(getPlastMat()).first, DDSplit(getPlastMat()).second);
   DDMaterial matplastic(plasName);
 
-  double  alpha = (1._pi)/getNsectors();
-  double  zi    = getZminBlock(mod);
+  double alpha = (1._pi) / getNsectors();
+  double zi = getZminBlock(mod);
 
   for (int i = 0; i < getLayerN(mod); i++) {
     std::string name;
     DDSolid solid;
     DDLogicalPart glog, plog;
-    int     layer  = getLayer(mod,i);
-    double  zo     = zi + 0.5*getDzStep();
+    int layer = getLayer(mod, i);
+    double zo = zi + 0.5 * getDzStep();
 
     for (int iphi = 0; iphi < getPhi(); iphi++) {
-      double  ziAir = zo - getThick(mod);
-      double  rinF, rinB;
+      double ziAir = zo - getThick(mod);
+      double rinF, rinB;
       if (layer == 1) {
-        rinF  = ziAir * tan(getAngTop());
-        rinB  = zo    * tan(getAngTop());
+        rinF = ziAir * tan(getAngTop());
+        rinB = zo * tan(getAngTop());
       } else {
-        rinF  = ziAir * tan(getAngBot());
-        rinB  = zo    * tan(getAngBot());
+        rinF = ziAir * tan(getAngBot());
+        rinB = zo * tan(getAngBot());
       }
       double routF = (ziAir - getZ1Beam()) * getSlope();
-      double routB = (zo    - getZ1Beam()) * getSlope();
-      if (routF > getRoutBlock2(mod)) routF =  getRoutBlock2(mod);
-      if (routB > getRoutBlock2(mod)) routB =  getRoutBlock2(mod);
+      double routB = (zo - getZ1Beam()) * getSlope();
+      if (routF > getRoutBlock2(mod))
+        routF = getRoutBlock2(mod);
+      if (routB > getRoutBlock2(mod))
+        routB = getRoutBlock2(mod);
 
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapAlgo: Layer " << i <<" Phi " << iphi << " Front " 
-	<< ziAir << ", " << rinF << ", " << routF << " Back " << zo << ", "
-	<< rinB << ", " << routB;
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: Layer " << i << " Phi " << iphi << " Front " << ziAir << ", "
+                                   << rinF << ", " << routF << " Back " << zo << ", " << rinB << ", " << routB;
 #endif
 
       double yh1, bl1, tl1, yh2, bl2, tl2, theta, phi, alp;
       double xpos, ypos, zpos;
-      parameterLayer(iphi, rinF, routF, rinB, routB, ziAir, zo, yh1, bl1, tl1, 
-                     yh2, bl2, tl2, alp, theta, phi, xpos, ypos, zpos);
-      
-      name = module.name().name()+getLayerName(layer)+getPhiName(iphi)+"Air";
-      solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
-				   0.5*getThick(mod), theta, phi, yh1,
-				   bl1, tl1, alp, yh2, bl2, tl2, alp);
+      parameterLayer(
+          iphi, rinF, routF, rinB, routB, ziAir, zo, yh1, bl1, tl1, yh2, bl2, tl2, alp, theta, phi, xpos, ypos, zpos);
+
+      name = module.name().name() + getLayerName(layer) + getPhiName(iphi) + "Air";
+      solid = DDSolidFactory::trap(
+          DDName(name, idNameSpace), 0.5 * getThick(mod), theta, phi, yh1, bl1, tl1, alp, yh2, bl2, tl2, alp);
 
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom")
-	<< "DDHCalEndcapAlgo: " << solid.name() << " Trap made of " << getGenMat()
-	<< " of dimensions " << 0.5*getThick(mod) << ", "<< convertRadToDeg(theta)
-	<< ", " << convertRadToDeg(phi) << ", " << yh1 << ", " << bl1 << ", " 
-	<< tl1 << ", " << convertRadToDeg(alp) << ", " << yh2 << ", " << bl2 
-	<< ", " << tl2 << ", " << convertRadToDeg(alp);
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << solid.name() << " Trap made of " << getGenMat()
+                                   << " of dimensions " << 0.5 * getThick(mod) << ", " << convertRadToDeg(theta) << ", "
+                                   << convertRadToDeg(phi) << ", " << yh1 << ", " << bl1 << ", " << tl1 << ", "
+                                   << convertRadToDeg(alp) << ", " << yh2 << ", " << bl2 << ", " << tl2 << ", "
+                                   << convertRadToDeg(alp);
 #endif
 
       glog = DDLogicalPart(solid.ddname(), matter, solid);
 
       DDTranslation r1(xpos, ypos, zpos);
-      cpv.position(glog, module, layer+1, r1, rot);
+      cpv.position(glog, module, layer + 1, r1, rot);
 
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapAlgo: " << glog.name() << " number " << layer+1 
-	<< " positioned in " << module.name() << " at " << r1 << " with " << rot;
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << glog.name() << " number " << layer + 1
+                                   << " positioned in " << module.name() << " at " << r1 << " with " << rot;
 #endif
-      
+
       //Now the plastic with scintillators
-      double yh = 0.5 * (routF - rinB) - getTrim(mod,iphi);
-      double bl = 0.5 * rinB  * tan(alpha) - getTrim(mod,iphi);
-      double tl = 0.5 * routF * tan(alpha) - getTrim(mod,iphi);
-      name = module.name().name()+getLayerName(layer)+getPhiName(iphi);
-      solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
-				   0.5*getLayerT(layer), 0, 0, yh,
-				   bl, tl, alp, yh, bl, tl, alp);
+      double yh = 0.5 * (routF - rinB) - getTrim(mod, iphi);
+      double bl = 0.5 * rinB * tan(alpha) - getTrim(mod, iphi);
+      double tl = 0.5 * routF * tan(alpha) - getTrim(mod, iphi);
+      name = module.name().name() + getLayerName(layer) + getPhiName(iphi);
+      solid = DDSolidFactory::trap(
+          DDName(name, idNameSpace), 0.5 * getLayerT(layer), 0, 0, yh, bl, tl, alp, yh, bl, tl, alp);
 
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapAlgo: " << solid.name() << " Trap made of " 
-	<< getPlastMat() << " of dimensions " << 0.5*getLayerT(layer) 
-	<< ", 0, 0, " << yh << ", " << bl << ", " << tl  << ", " 
-	<< convertRadToDeg(alp) << ", " << yh << ", " << bl << ", " << tl << ", " 
-	<< convertRadToDeg(alp);
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << solid.name() << " Trap made of " << getPlastMat()
+                                   << " of dimensions " << 0.5 * getLayerT(layer) << ", 0, 0, " << yh << ", " << bl
+                                   << ", " << tl << ", " << convertRadToDeg(alp) << ", " << yh << ", " << bl << ", "
+                                   << tl << ", " << convertRadToDeg(alp);
 #endif
 
       plog = DDLogicalPart(solid.ddname(), matplastic, solid);
 
-      ypos = 0.5*(routF+rinB) - xpos;
+      ypos = 0.5 * (routF + rinB) - xpos;
       DDTranslation r2(0., ypos, 0.);
-      cpv.position(plog, glog, idOffset+layer+1, r2, DDRotation());
+      cpv.position(plog, glog, idOffset + layer + 1, r2, DDRotation());
 
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapAlgo: " << plog.name() << " number " << idOffset+layer+1 
-	<< " positioned in " << glog.name() << " at " << r2 <<" with no rotation";
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << plog.name() << " number " << idOffset + layer + 1
+                                   << " positioned in " << glog.name() << " at " << r2 << " with no rotation";
 #endif
-      
+
       //Constructin the scintillators inside
-      int copyNo = layer*10 + getLayerType(layer);
-      name = getModName(mod)+getLayerName(layer)+getPhiName(iphi);
-      constructScintLayer (plog, getScintT(layer), yh,bl,tl, alp,name,copyNo, cpv);
-      zo += 0.5*getDzStep();
-    } // End of loop over phi indices
-    zi = zo - 0.5*getDzStep();
-  }   // End of loop on layers
+      int copyNo = layer * 10 + getLayerType(layer);
+      name = getModName(mod) + getLayerName(layer) + getPhiName(iphi);
+      constructScintLayer(plog, getScintT(layer), yh, bl, tl, alp, name, copyNo, cpv);
+      zo += 0.5 * getDzStep();
+    }  // End of loop over phi indices
+    zi = zo - 0.5 * getDzStep();
+  }  // End of loop on layers
 }
 
- 
 void DDHCalEndcapAlgo::constructScintLayer(const DDLogicalPart& detector,
-					   double dz, double yh, double bl, 
-					   double tl, double alp, 
-					   const std::string& nm, int id, 
-					   DDCompactView& cpv) {
-
+                                           double dz,
+                                           double yh,
+                                           double bl,
+                                           double tl,
+                                           double alp,
+                                           const std::string& nm,
+                                           int id,
+                                           DDCompactView& cpv) {
   DDName matname(DDSplit(getScintMat()).first, DDSplit(getScintMat()).second);
   DDMaterial matter(matname);
-  std::string name = idName+"Scintillator"+nm;
+  std::string name = idName + "Scintillator" + nm;
 
-  DDSolid solid = DDSolidFactory::trap(DDName(name, idNameSpace), 0.5*dz, 0, 0,
-				       yh, bl, tl, alp, yh, bl, tl, alp);
+  DDSolid solid = DDSolidFactory::trap(DDName(name, idNameSpace), 0.5 * dz, 0, 0, yh, bl, tl, alp, yh, bl, tl, alp);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: " << DDName(name,idNameSpace) << " Trap made of " 
-    << getScintMat() <<" of dimensions " << 0.5*dz << ", 0, 0, " << yh << ", "
-    << bl << ", "  << tl  << ", " << convertRadToDeg(alp) << ", " << yh << ", " 
-    << bl << ", " << tl << ", " << convertRadToDeg(alp);
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << DDName(name, idNameSpace) << " Trap made of " << getScintMat()
+                               << " of dimensions " << 0.5 * dz << ", 0, 0, " << yh << ", " << bl << ", " << tl << ", "
+                               << convertRadToDeg(alp) << ", " << yh << ", " << bl << ", " << tl << ", "
+                               << convertRadToDeg(alp);
 #endif
-  
-  DDLogicalPart glog(solid.ddname(), matter, solid); 
 
-  cpv.position(glog, detector, id, DDTranslation(0,0,0), DDRotation());
+  DDLogicalPart glog(solid.ddname(), matter, solid);
+
+  cpv.position(glog, detector, id, DDTranslation(0, 0, 0), DDRotation());
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapAlgo: " << glog.name() << " number " << id 
-    << " positioned in " << detector.name() << " at (0,0,0) with no rotation";
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapAlgo: " << glog.name() << " number " << id << " positioned in "
+                               << detector.name() << " at (0,0,0) with no rotation";
 #endif
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalEndcapAlgo.h
@@ -8,178 +8,203 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalEndcapAlgo : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDHCalEndcapAlgo(); //const std::string & name);
+  DDHCalEndcapAlgo();  //const std::string & name);
   ~DDHCalEndcapAlgo() override;
-  
+
   //Get Methods
-  std::string getGenMat()                  const {return genMaterial;}
-  std::string getRotation()                const {return rotation;}
-  int         getNsectors()                const {return nsectors;}
-  int         getNsectortot()              const {return nsectortot;}
-  int         getEndcaps()                 const {return nEndcap;}
-  int         equipModule(unsigned int i)  const {return eModule[i];}
-  double      getZShift()                  const {return zShift;}
+  std::string getGenMat() const { return genMaterial; }
+  std::string getRotation() const { return rotation; }
+  int getNsectors() const { return nsectors; }
+  int getNsectortot() const { return nsectortot; }
+  int getEndcaps() const { return nEndcap; }
+  int equipModule(unsigned int i) const { return eModule[i]; }
+  double getZShift() const { return zShift; }
 
-  double      getZFront()                  const {return zFront;}
-  double      getZEnd()                    const {return zEnd;}
-  double      getZiNose()                  const {return ziNose;}
-  double      getZiL0Nose()                const {return ziL0Nose;}
-  double      getZiBody()                  const {return ziBody;}
-  double      getZiL0Body()                const {return ziL0Body;}
-  double      getZiKink()                  const {return ziKink;}
-  double      getZ0Beam()                  const {return z0Beam;}
-  double      getZ1Beam()                  const {return z1Beam;}
-  double      getZiDip()                   const {return ziDip;}
-  double      getDzStep()                  const {return dzStep;}
-  double      getDzShift()                 const {return dzShift;}
-  double      getZShiftHac2()              const {return zShiftHac2;}
+  double getZFront() const { return zFront; }
+  double getZEnd() const { return zEnd; }
+  double getZiNose() const { return ziNose; }
+  double getZiL0Nose() const { return ziL0Nose; }
+  double getZiBody() const { return ziBody; }
+  double getZiL0Body() const { return ziL0Body; }
+  double getZiKink() const { return ziKink; }
+  double getZ0Beam() const { return z0Beam; }
+  double getZ1Beam() const { return z1Beam; }
+  double getZiDip() const { return ziDip; }
+  double getDzStep() const { return dzStep; }
+  double getDzShift() const { return dzShift; }
+  double getZShiftHac2() const { return zShiftHac2; }
 
-  double      getRout()                    const {return rout;}
-  double      getRinKink()                 const {return riKink;}
-  double      getRinDip()                  const {return riDip;}
-  double      getRoutDip()                 const {return roDip;}
-  double      getHeboxDepth()              const {return heboxDepth;}
-  double      getDrEnd()                   const {return drEnd;}
-  double      getAngTop()                  const {return angTop;}
-  double      getAngBot()                  const {return angBot;}
-  double      getAngGap()                  const {return angGap;}
-  double      getSlope()                   const {return slope;}
+  double getRout() const { return rout; }
+  double getRinKink() const { return riKink; }
+  double getRinDip() const { return riDip; }
+  double getRoutDip() const { return roDip; }
+  double getHeboxDepth() const { return heboxDepth; }
+  double getDrEnd() const { return drEnd; }
+  double getAngTop() const { return angTop; }
+  double getAngBot() const { return angBot; }
+  double getAngGap() const { return angGap; }
+  double getSlope() const { return slope; }
 
-  std::string getAbsMat()                  const {return absMat;}
-  int         getModules()                 const {return modules;}
-  std::string getModName(unsigned int i)   const {return modName[i];}
-  std::string getModMat(unsigned int i)    const {return modMat[i];}
-  int         getModType(unsigned int i)   const {return modType[i];}
-  int         getSectionModule(unsigned i) const {return sectionModule[i];}
-  int         getLayerN(unsigned int i)    const {return layerN[i];}
-  int         getLayer(unsigned int i, unsigned int j) const;
-  double      getThick(unsigned int i)     const {return thick[i];}
-  double      getTrim(unsigned int i, unsigned int j) const;
-  double      getZminBlock(unsigned i)     const {return zminBlock[i];}
-  double      getZmaxBlock(unsigned i)     const {return zmaxBlock[i];}
-  double      getRinBlock1(unsigned i)     const {return rinBlock1[i];}
-  double      getRinBlock2(unsigned i)     const {return rinBlock2[i];}
-  double      getRoutBlock1(unsigned i)    const {return routBlock1[i];}
-  double      getRoutBlock2(unsigned i)    const {return routBlock2[i];}
+  std::string getAbsMat() const { return absMat; }
+  int getModules() const { return modules; }
+  std::string getModName(unsigned int i) const { return modName[i]; }
+  std::string getModMat(unsigned int i) const { return modMat[i]; }
+  int getModType(unsigned int i) const { return modType[i]; }
+  int getSectionModule(unsigned i) const { return sectionModule[i]; }
+  int getLayerN(unsigned int i) const { return layerN[i]; }
+  int getLayer(unsigned int i, unsigned int j) const;
+  double getThick(unsigned int i) const { return thick[i]; }
+  double getTrim(unsigned int i, unsigned int j) const;
+  double getZminBlock(unsigned i) const { return zminBlock[i]; }
+  double getZmaxBlock(unsigned i) const { return zmaxBlock[i]; }
+  double getRinBlock1(unsigned i) const { return rinBlock1[i]; }
+  double getRinBlock2(unsigned i) const { return rinBlock2[i]; }
+  double getRoutBlock1(unsigned i) const { return routBlock1[i]; }
+  double getRoutBlock2(unsigned i) const { return routBlock2[i]; }
 
-  int         getPhi()                     const {return phiSections;}
-  std::string getPhiName(unsigned int i)   const {return phiName[i];}
-  int         getLayers()                  const {return layers;}
-  std::string getLayerName(unsigned int i) const {return layerName[i];}
-  int         getLayerType(unsigned int i) const {return layerType[i];}
-  double      getLayerT(unsigned int i)    const {return layerT[i];}
-  double      getScintT(unsigned int i)    const {return scintT[i];}
-  std::string getPlastMat()                const {return plastMat;}
-  std::string getScintMat()                const {return scintMat;}
-  std::string getRotMat()                  const {return rotmat;}
-  double      getTolPos()                  const {return tolPos;}
-  double      getTolAbs()                  const {return tolAbs;}
+  int getPhi() const { return phiSections; }
+  std::string getPhiName(unsigned int i) const { return phiName[i]; }
+  int getLayers() const { return layers; }
+  std::string getLayerName(unsigned int i) const { return layerName[i]; }
+  int getLayerType(unsigned int i) const { return layerType[i]; }
+  double getLayerT(unsigned int i) const { return layerT[i]; }
+  double getScintT(unsigned int i) const { return scintT[i]; }
+  std::string getPlastMat() const { return plastMat; }
+  std::string getScintMat() const { return scintMat; }
+  std::string getRotMat() const { return rotmat; }
+  double getTolPos() const { return tolPos; }
+  double getTolAbs() const { return tolAbs; }
 
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 protected:
-
   void constructGeneralVolume(DDCompactView& cpv);
   void constructInsideSector(const DDLogicalPart& sector, DDCompactView& cpv);
-  void parameterLayer (int iphi, double rinF, double routF, double rinB, 
-		       double routB, double zi, double zo, double& yh1, 
-		       double& bl1, double& tl1, double& yh2, double& bl2,
-		       double& tl2, double& alp, double& theta, double& phi,
-		       double& xpos, double& ypos, double& zcpv);
-  void parameterLayer0(int mod, int layer, int iphi, double& yh, double& bl, 
-		       double& tl, double& alp, double& xpos, double& ypos, 
-		       double& zcpv);
+  void parameterLayer(int iphi,
+                      double rinF,
+                      double routF,
+                      double rinB,
+                      double routB,
+                      double zi,
+                      double zo,
+                      double& yh1,
+                      double& bl1,
+                      double& tl1,
+                      double& yh2,
+                      double& bl2,
+                      double& tl2,
+                      double& alp,
+                      double& theta,
+                      double& phi,
+                      double& xpos,
+                      double& ypos,
+                      double& zcpv);
+  void parameterLayer0(int mod,
+                       int layer,
+                       int iphi,
+                       double& yh,
+                       double& bl,
+                       double& tl,
+                       double& alp,
+                       double& xpos,
+                       double& ypos,
+                       double& zcpv);
   void constructInsideModule0(const DDLogicalPart& module, int mod, DDCompactView& cpv);
-  void constructInsideModule (const DDLogicalPart& module, int mod, DDCompactView& cpv);
-  void constructScintLayer   (const DDLogicalPart& glog, double pDz, double yh, 
-			      double bl, double tl, double alp, 
-			      const std::string& name, int id, DDCompactView& cpv);
+  void constructInsideModule(const DDLogicalPart& module, int mod, DDCompactView& cpv);
+  void constructScintLayer(const DDLogicalPart& glog,
+                           double pDz,
+                           double yh,
+                           double bl,
+                           double tl,
+                           double alp,
+                           const std::string& name,
+                           int id,
+                           DDCompactView& cpv);
 
 private:
+  std::string genMaterial;   //General material
+  int nsectors;              //Number of potenital straight edges
+  int nsectortot;            //Number of straight edges (actual)
+  int nEndcap;               //Number of endcaps
+  std::vector<int> eModule;  //Modules to be present in part i (?)
+  std::string rotHalf;       //Rotation matrix for half
+  std::string rotns;         //Name space for rotation
+  std::string rotation;      //Rotation matrix to place in mother
+  double zShift;             //needed for TB setup (move HE)
 
-  std::string              genMaterial;   //General material
-  int                      nsectors;      //Number of potenital straight edges
-  int                      nsectortot;    //Number of straight edges (actual)
-  int                      nEndcap;       //Number of endcaps
-  std::vector<int>         eModule;       //Modules to be present in part i (?)
-  std::string              rotHalf;       //Rotation matrix for half
-  std::string              rotns;         //Name space for rotation
-  std::string              rotation;      //Rotation matrix to place in mother
-  double                   zShift;        //needed for TB setup (move HE)
+  double zFront;      //Z of the front section
+  double zEnd;        //Outer Z of the HE
+  double ziNose;      //Starting Z of the nose
+  double ziL0Nose;    //Starting Z of layer 0 at nose
+  double ziBody;      //Starting Z of the body
+  double ziL0Body;    //Starting Z of layer 0 at body
+  double ziKink;      //Position of the kink point
+  double z0Beam;      //Position of gap front along z-axis
+  double z1Beam;      //Position of gap end   along z-axis
+  double ziDip;       //Starting Z of dipped part of body
+  double dzStep;      //Width in Z of a layer
+  double dzShift;     //Shift in Z for HE
+  double zShiftHac2;  //needed for TB (remove part Hac2)
 
-  double                   zFront;        //Z of the front section
-  double                   zEnd;          //Outer Z of the HE
-  double                   ziNose;        //Starting Z of the nose
-  double                   ziL0Nose;      //Starting Z of layer 0 at nose
-  double                   ziBody;        //Starting Z of the body
-  double                   ziL0Body;      //Starting Z of layer 0 at body
-  double                   ziKink;        //Position of the kink point
-  double                   z0Beam;        //Position of gap front along z-axis
-  double                   z1Beam;        //Position of gap end   along z-axis
-  double                   ziDip;         //Starting Z of dipped part of body
-  double                   dzStep;        //Width in Z of a layer
-  double                   dzShift;       //Shift in Z for HE
-  double                   zShiftHac2;    //needed for TB (remove part Hac2)
+  double rout;        //Outer R of the HE
+  double riKink;      //Inner radius at kink point
+  double riDip;       //Inner radius at the dip point
+  double roDip;       //Outer radius at the dip point
+  double heboxDepth;  //Depth of the HE box
+  double drEnd;       //Shift in R for the end absorber
 
-  double                   rout;          //Outer R of the HE
-  double                   riKink;        //Inner radius at kink point
-  double                   riDip;         //Inner radius at the dip point
-  double                   roDip;         //Outer radius at the dip point
-  double                   heboxDepth;    //Depth of the HE box
-  double                   drEnd;         //Shift in R for the end absorber
+  double angTop;  //Angle of top end of HE
+  double angBot;  //Angle of the bottom end of HE
+  double angGap;  //Gap angle (in degrees)
+  double slope;   //Slope of the gap on HE side
 
-  double                   angTop;        //Angle of top end of HE
-  double                   angBot;        //Angle of the bottom end of HE
-  double                   angGap;        //Gap angle (in degrees)
-  double                   slope;         //Slope of the gap on HE side
+  std::string absMat;                //Absorber     material
+  int modules;                       //Number of modules
+  std::vector<std::string> modName;  //Name
+  std::vector<std::string> modMat;   //Material
+  std::vector<int> modType;          //Type (0/1 for front/standard)
+  std::vector<int> sectionModule;    //Number of sections in a module
+  std::vector<int> layerN;           //Number of layers
+  std::vector<int> layerN0;          //Layer numbers in section 0
+  std::vector<int> layerN1;          //Layer numbers in section 1
+  std::vector<int> layerN2;          //Layer numbers in section 2
+  std::vector<int> layerN3;          //Layer numbers in section 3
+  std::vector<int> layerN4;          //Layer numbers in section 4
+  std::vector<int> layerN5;          //Layer numbers in section 5
+  std::vector<double> thick;         //Thickness of absorber/air
+  std::vector<double> trimLeft;      //Trimming of left  layers in module
+  std::vector<double> trimRight;     //Trimming of right layers in module
+  std::vector<double> zminBlock;     //Minimum Z
+  std::vector<double> zmaxBlock;     //Maximum Z
+  std::vector<double> rinBlock1;     //Inner Radius
+  std::vector<double> routBlock1;    //Outer Radius at zmin
+  std::vector<double> rinBlock2;     //Inner Radius
+  std::vector<double> routBlock2;    //Outer Radius at zmax
 
-  std::string              absMat;        //Absorber     material
-  int                      modules;       //Number of modules
-  std::vector<std::string> modName;       //Name
-  std::vector<std::string> modMat;        //Material
-  std::vector<int>         modType;       //Type (0/1 for front/standard)
-  std::vector<int>         sectionModule; //Number of sections in a module
-  std::vector<int>         layerN;        //Number of layers
-  std::vector<int>         layerN0;       //Layer numbers in section 0
-  std::vector<int>         layerN1;       //Layer numbers in section 1
-  std::vector<int>         layerN2;       //Layer numbers in section 2
-  std::vector<int>         layerN3;       //Layer numbers in section 3
-  std::vector<int>         layerN4;       //Layer numbers in section 4
-  std::vector<int>         layerN5;       //Layer numbers in section 5
-  std::vector<double>      thick;         //Thickness of absorber/air
-  std::vector<double>      trimLeft;      //Trimming of left  layers in module
-  std::vector<double>      trimRight;     //Trimming of right layers in module
-  std::vector<double>      zminBlock;     //Minimum Z
-  std::vector<double>      zmaxBlock;     //Maximum Z
-  std::vector<double>      rinBlock1;     //Inner Radius
-  std::vector<double>      routBlock1;    //Outer Radius at zmin
-  std::vector<double>      rinBlock2;     //Inner Radius
-  std::vector<double>      routBlock2;    //Outer Radius at zmax
-  
-  int                      phiSections;   //Number of phi sections
-  std::vector<std::string> phiName;       //Name of Phi sections
-  int                      layers;        //Number of layers
-  std::vector<std::string> layerName;     //Layer Names
-  std::vector<int>         layerType;     //Detector type in each layer
-  std::vector<double>      layerT;        //Layer thickness (plastic + scint.)
-  std::vector<double>      scintT;        //Scintillator thickness
-  std::string              plastMat;      //Plastic      material
-  std::string              scintMat;      //Scintillator material
-  std::string              rotmat;        //Rotation matrix for positioning
+  int phiSections;                     //Number of phi sections
+  std::vector<std::string> phiName;    //Name of Phi sections
+  int layers;                          //Number of layers
+  std::vector<std::string> layerName;  //Layer Names
+  std::vector<int> layerType;          //Detector type in each layer
+  std::vector<double> layerT;          //Layer thickness (plastic + scint.)
+  std::vector<double> scintT;          //Scintillator thickness
+  std::string plastMat;                //Plastic      material
+  std::string scintMat;                //Scintillator material
+  std::string rotmat;                  //Rotation matrix for positioning
 
-  std::string              idName;        //Name of the "parent" volume.  
-  std::string              idNameSpace;   //Namespace of this and ALL sub-parts
-  int                      idOffset;      // Geant4 ID's...    = 4000;
+  std::string idName;       //Name of the "parent" volume.
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  int idOffset;             // Geant4 ID's...    = 4000;
 
-  double                   tolPos, tolAbs; //Tolerances
+  double tolPos, tolAbs;  //Tolerances
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalEndcapModuleAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalEndcapModuleAlgo.cc
@@ -28,93 +28,80 @@ DDHCalEndcapModuleAlgo::DDHCalEndcapModuleAlgo() {
 
 DDHCalEndcapModuleAlgo::~DDHCalEndcapModuleAlgo() {}
 
-void DDHCalEndcapModuleAlgo::initialize(const DDNumericArguments & nArgs,
-					const DDVectorArguments & vArgs,
-					const DDMapArguments & ,
-					const DDStringArguments & sArgs,
-					const DDStringVectorArguments &vsArgs){
-
-  genMaterial   = sArgs["MaterialName"];
-  absorberMat   = sArgs["AbsorberMat"];
-  plasticMat    = sArgs["PlasticMat"];
-  scintMat      = sArgs["ScintMat"];
-  rotstr        = sArgs["Rotation"];
-  sectors       = int (nArgs["Sectors"]);
+void DDHCalEndcapModuleAlgo::initialize(const DDNumericArguments& nArgs,
+                                        const DDVectorArguments& vArgs,
+                                        const DDMapArguments&,
+                                        const DDStringArguments& sArgs,
+                                        const DDStringVectorArguments& vsArgs) {
+  genMaterial = sArgs["MaterialName"];
+  absorberMat = sArgs["AbsorberMat"];
+  plasticMat = sArgs["PlasticMat"];
+  scintMat = sArgs["ScintMat"];
+  rotstr = sArgs["Rotation"];
+  sectors = int(nArgs["Sectors"]);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: General material " << genMaterial << "\tAbsorber "
-    << absorberMat << "\tPlastic " << plasticMat << "\tScintillator "
-    << scintMat << "\tRotation " << rotstr << "\tSectors "  << sectors;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: General material " << genMaterial << "\tAbsorber "
+                               << absorberMat << "\tPlastic " << plasticMat << "\tScintillator " << scintMat
+                               << "\tRotation " << rotstr << "\tSectors " << sectors;
 #endif
-  zMinBlock     = nArgs["ZMinBlock"];
-  zMaxBlock     = nArgs["ZMaxBlock"];
-  z1Beam        = nArgs["Z1Beam"];
-  ziDip         = nArgs["ZiDip"];
-  dzStep        = nArgs["DzStep"];
-  moduleThick   = nArgs["ModuleThick"];
-  layerThick    = nArgs["LayerThick"];
-  scintThick    = nArgs["ScintThick"];
+  zMinBlock = nArgs["ZMinBlock"];
+  zMaxBlock = nArgs["ZMaxBlock"];
+  z1Beam = nArgs["Z1Beam"];
+  ziDip = nArgs["ZiDip"];
+  dzStep = nArgs["DzStep"];
+  moduleThick = nArgs["ModuleThick"];
+  layerThick = nArgs["LayerThick"];
+  scintThick = nArgs["ScintThick"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: Zmin " << zMinBlock << "\tZmax " << zMaxBlock 
-    << "\tZ1Beam " << z1Beam << "\tZiDip " << ziDip << "\tDzStep " << dzStep
-    << "\tModuleThick " << moduleThick <<"\tLayerThick " << layerThick 
-    << "\tScintThick " << scintThick;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: Zmin " << zMinBlock << "\tZmax " << zMaxBlock << "\tZ1Beam "
+                               << z1Beam << "\tZiDip " << ziDip << "\tDzStep " << dzStep << "\tModuleThick "
+                               << moduleThick << "\tLayerThick " << layerThick << "\tScintThick " << scintThick;
 #endif
-  rMaxFront     = nArgs["RMaxFront"];
-  rMaxBack      = nArgs["RMaxBack"];
-  trimLeft      = nArgs["TrimLeft"];
-  trimRight     = nArgs["TrimRight"];
-  tolAbs        = nArgs["TolAbs"];
+  rMaxFront = nArgs["RMaxFront"];
+  rMaxBack = nArgs["RMaxBack"];
+  trimLeft = nArgs["TrimLeft"];
+  trimRight = nArgs["TrimRight"];
+  tolAbs = nArgs["TolAbs"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: RMaxFront " << rMaxFront <<"\tRmaxBack " 
-    << rMaxBack << "\tTrims " <<trimLeft << ":" << trimRight << "\tTolAbs "
-    << tolAbs;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: RMaxFront " << rMaxFront << "\tRmaxBack " << rMaxBack
+                               << "\tTrims " << trimLeft << ":" << trimRight << "\tTolAbs " << tolAbs;
 #endif
-  slopeBot      = nArgs["SlopeBottom"];
-  slopeTop      = nArgs["SlopeTop"];
-  slopeTopF     = nArgs["SlopeTopFront"];
-  modType       = (int)(nArgs["ModType"]);
-  modNumber     = (int)(nArgs["ModNumber"]);
-  layerType     = (int)(nArgs["LayerType"]);
+  slopeBot = nArgs["SlopeBottom"];
+  slopeTop = nArgs["SlopeTop"];
+  slopeTopF = nArgs["SlopeTopFront"];
+  modType = (int)(nArgs["ModType"]);
+  modNumber = (int)(nArgs["ModNumber"]);
+  layerType = (int)(nArgs["LayerType"]);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: slopeBot " << slopeBot << "\tslopeTop " 
-    << slopeTop << "\tslopeTopF " << slopeTopF << "\tmodType " << modType
-    << "\tmodNumber " << modNumber << "\tlayerType " << layerType;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: slopeBot " << slopeBot << "\tslopeTop " << slopeTop
+                               << "\tslopeTopF " << slopeTopF << "\tmodType " << modType << "\tmodNumber " << modNumber
+                               << "\tlayerType " << layerType;
 #endif
-  layerNumber   = dbl_to_int(vArgs["LayerNumber"]);
+  layerNumber = dbl_to_int(vArgs["LayerNumber"]);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: " << layerNumber.size() << " layer Numbers";
-  for (unsigned int i=0; i<layerNumber.size(); ++i)
-    edm::LogVerbatim("HCalGeom") 
-      << "LayerNumber[" << i << "] = " <<layerNumber[i];
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << layerNumber.size() << " layer Numbers";
+  for (unsigned int i = 0; i < layerNumber.size(); ++i)
+    edm::LogVerbatim("HCalGeom") << "LayerNumber[" << i << "] = " << layerNumber[i];
 #endif
-  phiName       = vsArgs["PhiName"];
+  phiName = vsArgs["PhiName"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: " << phiName.size() << " phi sectors";
-  for (unsigned int i=0; i<phiName.size(); ++i)
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << phiName.size() << " phi sectors";
+  for (unsigned int i = 0; i < phiName.size(); ++i)
     edm::LogVerbatim("HCalGeom") << "PhiName[" << i << "] = " << phiName[i];
 #endif
-  layerName     = vsArgs["LayerName"];
+  layerName = vsArgs["LayerName"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: " << layerName.size() << " layers";
-  for (unsigned int i=0; i<layerName.size(); ++i)
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << layerName.size() << " layers";
+  for (unsigned int i = 0; i < layerName.size(); ++i)
     edm::LogVerbatim("HCalGeom") << "LayerName[" << i << "] = " << layerName[i];
 #endif
-  idName      = sArgs["MotherName"];
+  idName = sArgs["MotherName"];
   idNameSpace = DDCurrentNamespace::ns();
-  idOffset    = int (nArgs["IdOffset"]); 
-  modName     = sArgs["ModName"];
+  idOffset = int(nArgs["IdOffset"]);
+  modName = sArgs["ModName"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: Parent " << parent().name() << "   " << modName
-    << " idName " << idName << " NameSpace " << idNameSpace << " Offset " 
-    << idOffset;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: Parent " << parent().name() << "   " << modName << " idName "
+                               << idName << " NameSpace " << idNameSpace << " Offset " << idOffset;
 #endif
 }
 
@@ -123,23 +110,19 @@ void DDHCalEndcapModuleAlgo::initialize(const DDNumericArguments & nArgs,
 ////////////////////////////////////////////////////////////////////
 
 void DDHCalEndcapModuleAlgo::execute(DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "==>> Constructing DDHCalEndcapModuleAlgo...";
 #endif
-  if (modType == 0) 
-    constructInsideModule0 (parent(), cpv);
+  if (modType == 0)
+    constructInsideModule0(parent(), cpv);
   else
-    constructInsideModule  (parent(), cpv);
+    constructInsideModule(parent(), cpv);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "<<== End of DDHCalEndcapModuleAlgo construction ...";
+  edm::LogVerbatim("HCalGeom") << "<<== End of DDHCalEndcapModuleAlgo construction ...";
 #endif
 }
 
-
 void DDHCalEndcapModuleAlgo::constructInsideModule0(const DDLogicalPart& module, DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: \t\tInside module0";
 #endif
@@ -151,107 +134,111 @@ void DDHCalEndcapModuleAlgo::constructInsideModule0(const DDLogicalPart& module,
   DDName plasName(DDSplit(plasticMat).first, DDSplit(plasticMat).second);
   DDMaterial matplastic(plasName);
 
-  int           layer  = layerNumber[0];
-  int           layer0 = layerNumber[1];
-  std::string   name;
-  DDSolid       solid;
+  int layer = layerNumber[0];
+  int layer0 = layerNumber[1];
+  std::string name;
+  DDSolid solid;
   DDLogicalPart glog, plog;
-  for (unsigned int iphi=0; iphi<phiName.size(); iphi++) {
+  for (unsigned int iphi = 0; iphi < phiName.size(); iphi++) {
     DDHCalEndcapModuleAlgo::HcalEndcapPar parm = parameterLayer0(iphi);
-    name  = idName+modName+layerName[0]+phiName[iphi];
-    solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
-				 0.5*layerThick, 0, 0, parm.yh1, parm.bl1, 
-				 parm.tl1, parm.alp, parm.yh2, parm.bl1, 
-				 parm.tl2, parm.alp);
+    name = idName + modName + layerName[0] + phiName[iphi];
+    solid = DDSolidFactory::trap(DDName(name, idNameSpace),
+                                 0.5 * layerThick,
+                                 0,
+                                 0,
+                                 parm.yh1,
+                                 parm.bl1,
+                                 parm.tl1,
+                                 parm.alp,
+                                 parm.yh2,
+                                 parm.bl1,
+                                 parm.tl2,
+                                 parm.alp);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") 
-      << "DDHCalEndcapModuleAlgo: " << solid.name() << " Trap made of " 
-      << plasName << " of dimensions " << 0.5*layerThick << ", 0, 0, " 
-      << parm.yh1 << ", " << parm.bl1 << ", " << parm.tl1 << ", " 
-      << convertRadToDeg(parm.alp) << ", " << parm.yh2 << ", " << parm.bl2 
-      << ", " << parm.tl2 << ", " << convertRadToDeg(parm.alp);
+    edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << solid.name() << " Trap made of " << plasName
+                                 << " of dimensions " << 0.5 * layerThick << ", 0, 0, " << parm.yh1 << ", " << parm.bl1
+                                 << ", " << parm.tl1 << ", " << convertRadToDeg(parm.alp) << ", " << parm.yh2 << ", "
+                                 << parm.bl2 << ", " << parm.tl2 << ", " << convertRadToDeg(parm.alp);
 #endif
     glog = DDLogicalPart(solid.ddname(), matplastic, solid);
 
     DDTranslation r1(parm.xpos, parm.ypos, parm.zpos);
-    cpv.position(glog, module, idOffset+layer+1, r1, rot);
+    cpv.position(glog, module, idOffset + layer + 1, r1, rot);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") 
-      << "DDHCalEndcapModuleAlgo: " << glog.name() << " number " 
-      << idOffset+layer+1 << " positioned in " << module.name() << " at " << r1
-      << " with " << rot;
+    edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << glog.name() << " number " << idOffset + layer + 1
+                                 << " positioned in " << module.name() << " at " << r1 << " with " << rot;
 #endif
     //Now construct the layer of scintillator inside this
-    int copyNo = layer0*10 + layerType;
-    name = modName+layerName[0]+phiName[iphi];
-    constructScintLayer (glog, scintThick, parm, name, copyNo, cpv);
+    int copyNo = layer0 * 10 + layerType;
+    name = modName + layerName[0] + phiName[iphi];
+    constructScintLayer(glog, scintThick, parm, name, copyNo, cpv);
   }
 
   //Now the absorber layer
   double zi = zMinBlock + layerThick;
-  double zo = zi + 0.5*dzStep;
+  double zo = zi + 0.5 * dzStep;
   double rinF, routF, rinB, routB;
   if (modNumber == 0) {
-    rinF  = zi * slopeTopF;
+    rinF = zi * slopeTopF;
     routF = (zi - z1Beam) * slopeTop;
-    rinB  = zo * slopeTopF;
+    rinB = zo * slopeTopF;
     routB = (zo - z1Beam) * slopeTop;
   } else if (modNumber > 0) {
-    rinF  = zi * slopeBot;
+    rinF = zi * slopeBot;
     routF = zi * slopeTopF;
-    rinB  = zo * slopeBot;
+    rinB = zo * slopeBot;
     routB = zo * slopeTopF;
   } else {
-    rinF  = zi * slopeBot;
+    rinF = zi * slopeBot;
     routF = (zi - z1Beam) * slopeTop;
-    rinB  = zo * slopeBot;
+    rinB = zo * slopeBot;
     routB = (zo - z1Beam) * slopeTop;
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: Front " << zi << ", " << rinF << ", " << routF 
-    << " Back " << zo << ", " << rinB << ", " << routB;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: Front " << zi << ", " << rinF << ", " << routF << " Back "
+                               << zo << ", " << rinB << ", " << routB;
 #endif
-  DDHCalEndcapModuleAlgo::HcalEndcapPar parm = parameterLayer(0, rinF, routF, 
-							      rinB, routB, zi,zo);
+  DDHCalEndcapModuleAlgo::HcalEndcapPar parm = parameterLayer(0, rinF, routF, rinB, routB, zi, zo);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: Trim " << tolAbs << " Param " << parm.yh1 << ", "
-    << parm.bl1 << ", " << parm.tl1 << ", " << parm.yh2 << ", " << parm.bl2 
-    << ", " << parm.tl2;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: Trim " << tolAbs << " Param " << parm.yh1 << ", " << parm.bl1
+                               << ", " << parm.tl1 << ", " << parm.yh2 << ", " << parm.bl2 << ", " << parm.tl2;
 #endif
   parm.bl1 -= tolAbs;
   parm.tl1 -= tolAbs;
   parm.bl2 -= tolAbs;
   parm.tl2 -= tolAbs;
 
-  name  = idName+modName+layerName[0]+"Absorber";
-  solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
-			       0.5*moduleThick, parm.theta, parm.phi, parm.yh1,
-			       parm.bl1, parm.tl1, parm.alp, parm.yh2, 
-			       parm.bl2, parm.tl2, parm.alp);
+  name = idName + modName + layerName[0] + "Absorber";
+  solid = DDSolidFactory::trap(DDName(name, idNameSpace),
+                               0.5 * moduleThick,
+                               parm.theta,
+                               parm.phi,
+                               parm.yh1,
+                               parm.bl1,
+                               parm.tl1,
+                               parm.alp,
+                               parm.yh2,
+                               parm.bl2,
+                               parm.tl2,
+                               parm.alp);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: " << solid.name() << " Trap made of " << matName 
-    << " of dimensions " << 0.5*moduleThick << ", " << convertRadToDeg(parm.theta)
-    << ", " << convertRadToDeg(parm.phi) << ", " << parm.yh1 << ", " << parm.bl1
-    << ", "  << parm.tl1 << ", " << convertRadToDeg(parm.alp) << ", " << parm.yh2
-    << ", " << parm.bl2 << ", " << parm.tl2 << ", " << convertRadToDeg(parm.alp);
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << solid.name() << " Trap made of " << matName
+                               << " of dimensions " << 0.5 * moduleThick << ", " << convertRadToDeg(parm.theta) << ", "
+                               << convertRadToDeg(parm.phi) << ", " << parm.yh1 << ", " << parm.bl1 << ", " << parm.tl1
+                               << ", " << convertRadToDeg(parm.alp) << ", " << parm.yh2 << ", " << parm.bl2 << ", "
+                               << parm.tl2 << ", " << convertRadToDeg(parm.alp);
 #endif
   glog = DDLogicalPart(solid.ddname(), matabsorbr, solid);
 
   DDTranslation r2(parm.xpos, parm.ypos, parm.zpos);
   cpv.position(glog, module, 1, r2, rot);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom")
-    << "DDHCalEndcapModuleAlgo: " << glog.name() << " number 1 positioned in " 
-    << module.name() << " at " << r2 << " with " << rot;
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << glog.name() << " number 1 positioned in "
+                               << module.name() << " at " << r2 << " with " << rot;
 #endif
 }
 
-
 void DDHCalEndcapModuleAlgo::constructInsideModule(const DDLogicalPart& module, DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: \t\tInside module";
 #endif
@@ -263,111 +250,112 @@ void DDHCalEndcapModuleAlgo::constructInsideModule(const DDLogicalPart& module, 
   DDName plasName(DDSplit(plasticMat).first, DDSplit(plasticMat).second);
   DDMaterial matplastic(plasName);
 
-  double  alpha = (1._pi)/sectors;
-  double  zi    = zMinBlock;
+  double alpha = (1._pi) / sectors;
+  double zi = zMinBlock;
 
-  for (unsigned int i=0; i<layerName.size(); i++) {
+  for (unsigned int i = 0; i < layerName.size(); i++) {
     std::string name;
     DDSolid solid;
     DDLogicalPart glog, plog;
-    int     layer  = layerNumber[i];
-    double  zo     = zi + 0.5*dzStep;
+    int layer = layerNumber[i];
+    double zo = zi + 0.5 * dzStep;
 
-    for (unsigned int iphi=0; iphi<phiName.size(); iphi++) {
+    for (unsigned int iphi = 0; iphi < phiName.size(); iphi++) {
       double ziAir = zo - moduleThick;
       double rinF, rinB;
       if (modNumber == 0) {
-	rinF  = ziAir * slopeTopF;
-	rinB  = zo    * slopeTopF;
+        rinF = ziAir * slopeTopF;
+        rinB = zo * slopeTopF;
       } else {
-	rinF  = ziAir * slopeBot;
-	rinB  = zo    * slopeBot;
+        rinF = ziAir * slopeBot;
+        rinB = zo * slopeBot;
       }
       double routF = getRout(ziAir);
       double routB = getRout(zo);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapModuleAlgo: Layer " << i << " Phi "  << iphi << " Front "
-	<< ziAir <<", " << rinF << ", " << routF << " Back " << zo << ", " << rinB
-	<< ", " << routB;
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: Layer " << i << " Phi " << iphi << " Front " << ziAir
+                                   << ", " << rinF << ", " << routF << " Back " << zo << ", " << rinB << ", " << routB;
 #endif
-      DDHCalEndcapModuleAlgo::HcalEndcapPar parm = parameterLayer(iphi, rinF, 
-								  routF, rinB, 
-								  routB, ziAir,
-								  zo);
-      
-      name  = idName+modName+layerName[i]+phiName[iphi]+"Air";
-      solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
-				   0.5*moduleThick, parm.theta, parm.phi, 
-				   parm.yh1, parm.bl1, parm.tl1, parm.alp, 
-				   parm.yh2, parm.bl2, parm.tl2, parm.alp);
+      DDHCalEndcapModuleAlgo::HcalEndcapPar parm = parameterLayer(iphi, rinF, routF, rinB, routB, ziAir, zo);
+
+      name = idName + modName + layerName[i] + phiName[iphi] + "Air";
+      solid = DDSolidFactory::trap(DDName(name, idNameSpace),
+                                   0.5 * moduleThick,
+                                   parm.theta,
+                                   parm.phi,
+                                   parm.yh1,
+                                   parm.bl1,
+                                   parm.tl1,
+                                   parm.alp,
+                                   parm.yh2,
+                                   parm.bl2,
+                                   parm.tl2,
+                                   parm.alp);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapModuleAlgo: " << solid.name() << " Trap made of " 
-	<< matName << " of dimensions " << 0.5*moduleThick << ", "
-	<< convertRadToDeg(parm.theta) << ", " << convertRadToDeg(parm.phi) 
-	<< ", " << parm.yh1 << ", " << parm.bl1 << ", " << parm.tl1 << ", "
-	<< convertRadToDeg(parm.alp) << ", " << parm.yh2 << ", " << parm.bl2 
-	<< ", " << parm.tl2 << ", " << convertRadToDeg(parm.alp);
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << solid.name() << " Trap made of " << matName
+                                   << " of dimensions " << 0.5 * moduleThick << ", " << convertRadToDeg(parm.theta)
+                                   << ", " << convertRadToDeg(parm.phi) << ", " << parm.yh1 << ", " << parm.bl1 << ", "
+                                   << parm.tl1 << ", " << convertRadToDeg(parm.alp) << ", " << parm.yh2 << ", "
+                                   << parm.bl2 << ", " << parm.tl2 << ", " << convertRadToDeg(parm.alp);
 #endif
       glog = DDLogicalPart(solid.ddname(), matter, solid);
 
       DDTranslation r1(parm.xpos, parm.ypos, parm.zpos);
-      cpv.position(glog, module, layer+1, r1, rot);
+      cpv.position(glog, module, layer + 1, r1, rot);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapModuleAlgo: " <<glog.name() << " number " << layer+1 
-	<< " positioned in " << module.name() << " at " << r1 << " with " << rot;
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << glog.name() << " number " << layer + 1
+                                   << " positioned in " << module.name() << " at " << r1 << " with " << rot;
 #endif
       //Now the plastic with scintillators
       parm.yh1 = 0.5 * (routF - rinB) - getTrim(iphi);
-      parm.bl1 = 0.5 * rinB  * tan(alpha) - getTrim(iphi);
+      parm.bl1 = 0.5 * rinB * tan(alpha) - getTrim(iphi);
       parm.tl1 = 0.5 * routF * tan(alpha) - getTrim(iphi);
-      name  = idName+modName+layerName[i]+phiName[iphi];
-      solid = DDSolidFactory::trap(DDName(name, idNameSpace), 
-				   0.5*layerThick, 0, 0, parm.yh1,
-				   parm.bl1, parm.tl1, parm.alp, parm.yh1, 
-				   parm.bl1, parm.tl1, parm.alp);
+      name = idName + modName + layerName[i] + phiName[iphi];
+      solid = DDSolidFactory::trap(DDName(name, idNameSpace),
+                                   0.5 * layerThick,
+                                   0,
+                                   0,
+                                   parm.yh1,
+                                   parm.bl1,
+                                   parm.tl1,
+                                   parm.alp,
+                                   parm.yh1,
+                                   parm.bl1,
+                                   parm.tl1,
+                                   parm.alp);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapModuleAlgo: "<< solid.name() << " Trap made of " 
-	<< plasName << " of dimensions " << 0.5*layerThick << ", 0, 0, " 
-	<< parm.yh1 << ", " << parm.bl1 << ", " << parm.tl1 <<", "
-	<< convertRadToDeg(parm.alp) << ", " << parm.yh1 << ", " << parm.bl1 
-	<< ", " << parm.tl1 << ", " << convertRadToDeg(parm.alp);
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << solid.name() << " Trap made of " << plasName
+                                   << " of dimensions " << 0.5 * layerThick << ", 0, 0, " << parm.yh1 << ", "
+                                   << parm.bl1 << ", " << parm.tl1 << ", " << convertRadToDeg(parm.alp) << ", "
+                                   << parm.yh1 << ", " << parm.bl1 << ", " << parm.tl1 << ", "
+                                   << convertRadToDeg(parm.alp);
 #endif
       plog = DDLogicalPart(solid.ddname(), matplastic, solid);
 
-      double ypos = 0.5*(routF+rinB) - parm.xpos;
+      double ypos = 0.5 * (routF + rinB) - parm.xpos;
       DDTranslation r2(0., ypos, 0.);
-      cpv.position(plog, glog, idOffset+layer+1, r2, DDRotation());
+      cpv.position(plog, glog, idOffset + layer + 1, r2, DDRotation());
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") 
-	<< "DDHCalEndcapModuleAlgo: " << plog.name() << " number " 
-	<< idOffset+layer+1 << " positioned in " << glog.name() << " at " 
-	<< r2 << " with no rotation";
+      edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << plog.name() << " number " << idOffset + layer + 1
+                                   << " positioned in " << glog.name() << " at " << r2 << " with no rotation";
 #endif
       //Constructin the scintillators inside
-      int copyNo = layer*10 + layerType;
-      name = modName+layerName[i]+phiName[iphi];
-      constructScintLayer (plog, scintThick, parm, name, copyNo, cpv);
-      zo += 0.5*dzStep;
-    } // End of loop over phi indices
-    zi = zo - 0.5*dzStep;
-  }   // End of loop on layers
+      int copyNo = layer * 10 + layerType;
+      name = modName + layerName[i] + phiName[iphi];
+      constructScintLayer(plog, scintThick, parm, name, copyNo, cpv);
+      zo += 0.5 * dzStep;
+    }  // End of loop over phi indices
+    zi = zo - 0.5 * dzStep;
+  }  // End of loop on layers
 }
 
-
-DDHCalEndcapModuleAlgo::HcalEndcapPar 
-DDHCalEndcapModuleAlgo::parameterLayer0(unsigned int iphi) {
-
+DDHCalEndcapModuleAlgo::HcalEndcapPar DDHCalEndcapModuleAlgo::parameterLayer0(unsigned int iphi) {
   DDHCalEndcapModuleAlgo::HcalEndcapPar parm;
   //Given module and layer number compute parameters of trapezoid
   //and positioning parameters
-  double alpha = (1._pi)/sectors;
+  double alpha = (1._pi) / sectors;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "Input " << iphi << " Alpha " << convertRadToDeg(alpha);
+  edm::LogVerbatim("HCalGeom") << "Input " << iphi << " Alpha " << convertRadToDeg(alpha);
 #endif
   double zi, zo;
   if (iphi == 0) {
@@ -379,139 +367,141 @@ DDHCalEndcapModuleAlgo::parameterLayer0(unsigned int iphi) {
   }
   double rin, rout;
   if (modNumber == 0) {
-    rin  = zo * slopeTopF;
+    rin = zo * slopeTopF;
     rout = (zi - z1Beam) * slopeTop;
   } else if (modNumber > 0) {
-    rin  = zo * slopeBot;
+    rin = zo * slopeBot;
     rout = zi * slopeTopF;
   } else {
-    rin  = zo * slopeBot;
+    rin = zo * slopeBot;
     rout = (zi - z1Beam) * slopeTop;
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "ModNumber " << modNumber << " " << zi << " " << zo << " " << slopeTopF 
-    << " " << slopeTop << " " << slopeBot << " " << rin << " " << rout << " " 
-    << getTrim(iphi);
+  edm::LogVerbatim("HCalGeom") << "ModNumber " << modNumber << " " << zi << " " << zo << " " << slopeTopF << " "
+                               << slopeTop << " " << slopeBot << " " << rin << " " << rout << " " << getTrim(iphi);
 #endif
-  double yh   = 0.5 * (rout - rin);
-  double bl   = 0.5 * rin * tan (alpha);
-  double tl   = 0.5 * rout * tan(alpha);
+  double yh = 0.5 * (rout - rin);
+  double bl = 0.5 * rin * tan(alpha);
+  double tl = 0.5 * rout * tan(alpha);
   parm.xpos = 0.5 * (rin + rout);
   parm.ypos = 0.5 * (bl + tl);
   parm.zpos = 0.5 * (zi + zo);
-  parm.yh1  = parm.yh2 = yh - getTrim(iphi);
-  parm.bl1  = parm.bl2 = bl - getTrim(iphi);
-  parm.tl1  = parm.tl2 = tl - getTrim(iphi);
-  parm.alp  = atan(0.5 * tan(alpha));
+  parm.yh1 = parm.yh2 = yh - getTrim(iphi);
+  parm.bl1 = parm.bl2 = bl - getTrim(iphi);
+  parm.tl1 = parm.tl2 = tl - getTrim(iphi);
+  parm.alp = atan(0.5 * tan(alpha));
   if (iphi == 0) {
     parm.ypos = -parm.ypos;
   } else {
-    parm.alp  = -parm.alp;
+    parm.alp = -parm.alp;
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "Output Dimensions " << parm.yh1 << " " << parm.bl1 << " " << parm.tl1 
-    << " " << convertRadToDeg(parm.alp) << " Position " << parm.xpos << " "
-    << parm.ypos << " " << parm.zpos;
+  edm::LogVerbatim("HCalGeom") << "Output Dimensions " << parm.yh1 << " " << parm.bl1 << " " << parm.tl1 << " "
+                               << convertRadToDeg(parm.alp) << " Position " << parm.xpos << " " << parm.ypos << " "
+                               << parm.zpos;
 #endif
   return parm;
 }
 
-DDHCalEndcapModuleAlgo::HcalEndcapPar 
-DDHCalEndcapModuleAlgo::parameterLayer(unsigned int iphi, double rinF, 
-				       double routF, double rinB, double routB,
-				       double zi, double zo) {
-
+DDHCalEndcapModuleAlgo::HcalEndcapPar DDHCalEndcapModuleAlgo::parameterLayer(
+    unsigned int iphi, double rinF, double routF, double rinB, double routB, double zi, double zo) {
   DDHCalEndcapModuleAlgo::HcalEndcapPar parm;
-  //Given rin, rout compute parameters of the trapezoid and 
+  //Given rin, rout compute parameters of the trapezoid and
   //position of the trapezoid for a standrd layer
-  double alpha = (1._pi)/sectors;
+  double alpha = (1._pi) / sectors;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "Input " << iphi << " Front " << rinF << " " << routF << " " << zi 
-    << " Back " << rinB << " " << routB << " " << zo << " Alpha " 
-    << convertRadToDeg(alpha);
+  edm::LogVerbatim("HCalGeom") << "Input " << iphi << " Front " << rinF << " " << routF << " " << zi << " Back " << rinB
+                               << " " << routB << " " << zo << " Alpha " << convertRadToDeg(alpha);
 #endif
-  parm.yh1    = 0.5 * (routF - rinB);
-  parm.bl1    = 0.5 * rinB  * tan(alpha);
-  parm.tl1    = 0.5 * routF * tan(alpha);
-  parm.yh2    = 0.5 * (routF - rinB);
-  parm.bl2    = 0.5 * rinB  * tan(alpha);
-  parm.tl2    = 0.5 * routF * tan(alpha);
-  double dx   = 0.25* (parm.bl2+parm.tl2-parm.bl1-parm.tl1);
-  double dy   = 0.5 * (rinB+routF-rinB-routF);
-  parm.xpos   = 0.25*(rinB+routF+rinB+routF);
-  parm.ypos   = 0.25*(parm.bl2+parm.tl2+parm.bl1+parm.tl1);
-  parm.zpos   = 0.5*(zi+zo);
-  parm.alp    = atan(0.5 * tan(alpha));
+  parm.yh1 = 0.5 * (routF - rinB);
+  parm.bl1 = 0.5 * rinB * tan(alpha);
+  parm.tl1 = 0.5 * routF * tan(alpha);
+  parm.yh2 = 0.5 * (routF - rinB);
+  parm.bl2 = 0.5 * rinB * tan(alpha);
+  parm.tl2 = 0.5 * routF * tan(alpha);
+  double dx = 0.25 * (parm.bl2 + parm.tl2 - parm.bl1 - parm.tl1);
+  double dy = 0.5 * (rinB + routF - rinB - routF);
+  parm.xpos = 0.25 * (rinB + routF + rinB + routF);
+  parm.ypos = 0.25 * (parm.bl2 + parm.tl2 + parm.bl1 + parm.tl1);
+  parm.zpos = 0.5 * (zi + zo);
+  parm.alp = atan(0.5 * tan(alpha));
   if (iphi == 0) {
     parm.ypos = -parm.ypos;
   } else {
-    parm.alp  = -parm.alp;
-    dx        = -dx;
+    parm.alp = -parm.alp;
+    dx = -dx;
   }
-  double r    = sqrt (dx*dx + dy*dy);
+  double r = sqrt(dx * dx + dy * dy);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "dx|dy|r " << dx << ":" << dy << ":" << r;
 #endif
   if (r > 1.0e-8) {
-    parm.theta  = atan (r/(zo-zi));
-    parm.phi    = atan2 (dy, dx);
+    parm.theta = atan(r / (zo - zi));
+    parm.phi = atan2(dy, dx);
   } else {
-    parm.theta  = parm.phi = 0;
+    parm.theta = parm.phi = 0;
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "Output Dimensions " << parm.yh1 << " " << parm.bl1 << " " << parm.tl1 
-    << " " << parm.yh2 << " " << parm.bl2 << " " << parm.tl2 << " " 
-    << convertRadToDeg(parm.alp) <<" " << convertRadToDeg(parm.theta) << " " 
-    << convertRadToDeg(parm.phi) << " Position " << parm.xpos << " " << parm.ypos
-    << " " <<parm.zpos;
+  edm::LogVerbatim("HCalGeom") << "Output Dimensions " << parm.yh1 << " " << parm.bl1 << " " << parm.tl1 << " "
+                               << parm.yh2 << " " << parm.bl2 << " " << parm.tl2 << " " << convertRadToDeg(parm.alp)
+                               << " " << convertRadToDeg(parm.theta) << " " << convertRadToDeg(parm.phi) << " Position "
+                               << parm.xpos << " " << parm.ypos << " " << parm.zpos;
 #endif
   return parm;
 }
- 
-void DDHCalEndcapModuleAlgo::constructScintLayer(const DDLogicalPart& detector, double dz,
-						 DDHCalEndcapModuleAlgo::HcalEndcapPar parm,
-						 const std::string& nm, int id, DDCompactView& cpv) {
 
+void DDHCalEndcapModuleAlgo::constructScintLayer(const DDLogicalPart& detector,
+                                                 double dz,
+                                                 DDHCalEndcapModuleAlgo::HcalEndcapPar parm,
+                                                 const std::string& nm,
+                                                 int id,
+                                                 DDCompactView& cpv) {
   DDName matname(DDSplit(scintMat).first, DDSplit(scintMat).second);
   DDMaterial matter(matname);
-  std::string name = idName+"Scintillator"+nm;
+  std::string name = idName + "Scintillator" + nm;
 
-  DDSolid solid = DDSolidFactory::trap(DDName(name, idNameSpace), 0.5*dz, 0, 0,
-				       parm.yh1, parm.bl1, parm.tl1, parm.alp, 
-				       parm.yh1, parm.bl1, parm.tl1, parm.alp);
+  DDSolid solid = DDSolidFactory::trap(DDName(name, idNameSpace),
+                                       0.5 * dz,
+                                       0,
+                                       0,
+                                       parm.yh1,
+                                       parm.bl1,
+                                       parm.tl1,
+                                       parm.alp,
+                                       parm.yh1,
+                                       parm.bl1,
+                                       parm.tl1,
+                                       parm.alp);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: " << solid.name() << " Trap made of " << scintMat
-    << " of dimensions " << 0.5*dz << ", 0, 0, " << parm.yh1 << ", " << parm.bl1 
-    << ", " << parm.tl1 << ", " << convertRadToDeg(parm.alp) << ", " << parm.yh1 
-    << ", " << parm.bl1 << ", " << parm.tl1 << ", " << convertRadToDeg(parm.alp);
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << solid.name() << " Trap made of " << scintMat
+                               << " of dimensions " << 0.5 * dz << ", 0, 0, " << parm.yh1 << ", " << parm.bl1 << ", "
+                               << parm.tl1 << ", " << convertRadToDeg(parm.alp) << ", " << parm.yh1 << ", " << parm.bl1
+                               << ", " << parm.tl1 << ", " << convertRadToDeg(parm.alp);
 #endif
-  DDLogicalPart glog(solid.ddname(), matter, solid); 
+  DDLogicalPart glog(solid.ddname(), matter, solid);
 
-  cpv.position(glog, detector, id, DDTranslation(0,0,0), DDRotation());
+  cpv.position(glog, detector, id, DDTranslation(0, 0, 0), DDRotation());
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") 
-    << "DDHCalEndcapModuleAlgo: " << glog.name() << " number " << id 
-    << " positioned in " << detector.name() <<" at (0,0,0) with no rotation";
+  edm::LogVerbatim("HCalGeom") << "DDHCalEndcapModuleAlgo: " << glog.name() << " number " << id << " positioned in "
+                               << detector.name() << " at (0,0,0) with no rotation";
 #endif
 }
 
 double DDHCalEndcapModuleAlgo::getTrim(unsigned int j) const {
- 
- if (j == 0) return trimLeft;
- else        return trimRight;
+  if (j == 0)
+    return trimLeft;
+  else
+    return trimRight;
 }
 
 double DDHCalEndcapModuleAlgo::getRout(double z) const {
   double r = (modNumber >= 0) ? ((z - z1Beam) * slopeTop) : z * slopeTopF;
   if (z > ziDip) {
-    if (r > rMaxBack)  r = rMaxBack;
+    if (r > rMaxBack)
+      r = rMaxBack;
   } else {
-    if (r > rMaxFront) r = rMaxFront;
+    if (r > rMaxFront)
+      r = rMaxFront;
   }
   return r;
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalEndcapModuleAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalEndcapModuleAlgo.h
@@ -8,75 +8,94 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalEndcapModuleAlgo : public DDAlgorithm {
- 
 public:
   //Constructor and Destructor
-  DDHCalEndcapModuleAlgo(); //const std::string & name);
+  DDHCalEndcapModuleAlgo();  //const std::string & name);
   ~DDHCalEndcapModuleAlgo() override;
-  
+
   struct HcalEndcapPar {
     double yh1, bl1, tl1, yh2, bl2, tl2, alp, theta, phi, xpos, ypos, zpos;
-    HcalEndcapPar(double yh1v=0, double bl1v=0, double tl1v=0, double yh2v=0, 
-		  double bl2v=0, double tl2v=0, double alpv=0, double thv=0,
-		  double fiv=0, double x=0, double y=0, double z=0) :
-      yh1(yh1v), bl1(bl1v), tl1(tl1v), yh2(yh2v), bl2(bl2v), tl2(tl2v),
-      alp(alpv), theta(thv), phi(fiv), xpos(x), ypos(y), zpos(z) {}
-  }; 
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+    HcalEndcapPar(double yh1v = 0,
+                  double bl1v = 0,
+                  double tl1v = 0,
+                  double yh2v = 0,
+                  double bl2v = 0,
+                  double tl2v = 0,
+                  double alpv = 0,
+                  double thv = 0,
+                  double fiv = 0,
+                  double x = 0,
+                  double y = 0,
+                  double z = 0)
+        : yh1(yh1v),
+          bl1(bl1v),
+          tl1(tl1v),
+          yh2(yh2v),
+          bl2(bl2v),
+          tl2(tl2v),
+          alp(alpv),
+          theta(thv),
+          phi(fiv),
+          xpos(x),
+          ypos(y),
+          zpos(z) {}
+  };
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
   void execute(DDCompactView& cpv) override;
 
 protected:
-
   void constructInsideModule0(const DDLogicalPart& module, DDCompactView& cpv);
-  void constructInsideModule (const DDLogicalPart& module, DDCompactView& cpv);
+  void constructInsideModule(const DDLogicalPart& module, DDCompactView& cpv);
   HcalEndcapPar parameterLayer0(unsigned int iphi);
-  HcalEndcapPar parameterLayer(unsigned int iphi, double rinF, double routF, 
-			       double rinB, double routB, double zi,double zo);
-  void constructScintLayer(const DDLogicalPart& detector, double dz,
-			   DDHCalEndcapModuleAlgo::HcalEndcapPar parm,
-			   const std::string& nm, int id, DDCompactView& cpv);
+  HcalEndcapPar parameterLayer(
+      unsigned int iphi, double rinF, double routF, double rinB, double routB, double zi, double zo);
+  void constructScintLayer(const DDLogicalPart& detector,
+                           double dz,
+                           DDHCalEndcapModuleAlgo::HcalEndcapPar parm,
+                           const std::string& nm,
+                           int id,
+                           DDCompactView& cpv);
   double getTrim(unsigned int j) const;
   double getRout(double z) const;
 
 private:
+  std::string genMaterial;             //General material
+  std::string absorberMat;             //Absorber material
+  std::string plasticMat;              //Plastic material cover
+  std::string scintMat;                //Scintillator material
+  std::string rotstr;                  //Rotation matrix to place in mother
+  int sectors;                         //Number of potenital straight edges
+  double zMinBlock;                    //Minimum z extent of the block
+  double zMaxBlock;                    //Maximum
+  double z1Beam;                       //Position of gap end   along z-axis
+  double ziDip;                        //Starting Z of dipped part of body
+  double dzStep;                       //Width in Z of a layer
+  double moduleThick;                  //Thickness of a layer (air/absorber)
+  double layerThick;                   //Thickness of a layer (plastic)
+  double scintThick;                   //Thickness of scinitllator
+  double rMaxBack;                     //Maximum R after  the dip
+  double rMaxFront;                    //Maximum R before the dip
+  double slopeBot;                     //Slope of the bottom edge
+  double slopeTop;                     //Slope of the top edge
+  double slopeTopF;                    //Slope of the top front edge
+  double trimLeft;                     //Trim of the left edge
+  double trimRight;                    //Trim of the right edge
+  double tolAbs;                       //Tolerance for absorber
+  int modType;                         //Type of module
+  int modNumber;                       //Module number
+  int layerType;                       //Layer type
+  std::vector<int> layerNumber;        //layer numbers
+  std::vector<std::string> phiName;    //Name of Phi sections
+  std::vector<std::string> layerName;  //Layer Names
 
-  std::string              genMaterial;   //General material
-  std::string              absorberMat;   //Absorber material
-  std::string              plasticMat;    //Plastic material cover
-  std::string              scintMat;      //Scintillator material
-  std::string              rotstr;        //Rotation matrix to place in mother
-  int                      sectors;       //Number of potenital straight edges
-  double                   zMinBlock;     //Minimum z extent of the block 
-  double                   zMaxBlock;     //Maximum
-  double                   z1Beam;        //Position of gap end   along z-axis
-  double                   ziDip;         //Starting Z of dipped part of body
-  double                   dzStep;        //Width in Z of a layer
-  double                   moduleThick;   //Thickness of a layer (air/absorber)
-  double                   layerThick;    //Thickness of a layer (plastic)
-  double                   scintThick;    //Thickness of scinitllator
-  double                   rMaxBack;      //Maximum R after  the dip
-  double                   rMaxFront;     //Maximum R before the dip
-  double                   slopeBot;      //Slope of the bottom edge
-  double                   slopeTop;      //Slope of the top edge
-  double                   slopeTopF;     //Slope of the top front edge
-  double                   trimLeft;      //Trim of the left edge
-  double                   trimRight;     //Trim of the right edge
-  double                   tolAbs;        //Tolerance for absorber
-  int                      modType;       //Type of module
-  int                      modNumber;     //Module number
-  int                      layerType;     //Layer type
-  std::vector<int>         layerNumber;   //layer numbers
-  std::vector<std::string> phiName;       //Name of Phi sections
-  std::vector<std::string> layerName;     //Layer Names
-
-  std::string              idName;        //Name of the "parent" volume.  
-  std::string              idNameSpace;   //Namespace of this and ALL sub-parts
-  std::string              modName;       //Module Name
-  int                      idOffset;      // Geant4 ID's...    = 4000;
+  std::string idName;       //Name of the "parent" volume.
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  std::string modName;      //Module Name
+  int idOffset;             // Geant4 ID's...    = 4000;
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalFibreBundle.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalFibreBundle.cc
@@ -27,116 +27,105 @@ DDHCalFibreBundle::DDHCalFibreBundle() {
 
 DDHCalFibreBundle::~DDHCalFibreBundle() {}
 
-void DDHCalFibreBundle::initialize(const DDNumericArguments & nArgs,
-				   const DDVectorArguments & vArgs,
-				   const DDMapArguments & ,
-				   const DDStringArguments & sArgs,
-				   const DDStringVectorArguments & ) {
-
-  deltaPhi    = nArgs["DeltaPhi"];
-  deltaZ      = nArgs["DeltaZ"];
-  numberPhi   = int(nArgs["NumberPhi"]);
-  material    = sArgs["Material"];
+void DDHCalFibreBundle::initialize(const DDNumericArguments& nArgs,
+                                   const DDVectorArguments& vArgs,
+                                   const DDMapArguments&,
+                                   const DDStringArguments& sArgs,
+                                   const DDStringVectorArguments&) {
+  deltaPhi = nArgs["DeltaPhi"];
+  deltaZ = nArgs["DeltaZ"];
+  numberPhi = int(nArgs["NumberPhi"]);
+  material = sArgs["Material"];
   areaSection = vArgs["AreaSection"];
-  rStart      = vArgs["RadiusStart"];
-  rEnd        = vArgs["RadiusEnd"];
-  bundle      = dbl_to_int(vArgs["Bundles"]);
-  tilt        = nArgs["TiltAngle"];
-  
+  rStart = vArgs["RadiusStart"];
+  rEnd = vArgs["RadiusEnd"];
+  bundle = dbl_to_int(vArgs["Bundles"]);
+  tilt = nArgs["TiltAngle"];
+
   idNameSpace = DDCurrentNamespace::ns();
-  childPrefix = sArgs["Child"]; 
+  childPrefix = sArgs["Child"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Parent " 
-			       << parent().name() << " with " << bundle.size()
-			       << " children with prefix " << childPrefix 
-			       << ", material " << material << " with "
-			       << numberPhi << " bundles along phi; width of"
-			       << " mother " << deltaZ << " along Z, " 
-			       << convertRadToDeg(deltaPhi) 
-			       << " along phi and with " << rStart.size()
-			       << " different bundle types";
-  for (unsigned int i=0; i<areaSection.size(); ++i) 
-    edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Child[" << i 
-				 << "] Area " << areaSection[i] 
-				 << " R at Start " << rStart[i]
-				 << " R at End " << rEnd[i];
-  edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: NameSpace " 
-			       << idNameSpace << " Tilt Angle " 
-			       << convertRadToDeg(tilt)
-			       << " Bundle type at different positions";
-  for (unsigned int i=0; i<bundle.size(); ++i) {
+  edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Parent " << parent().name() << " with " << bundle.size()
+                               << " children with prefix " << childPrefix << ", material " << material << " with "
+                               << numberPhi << " bundles along phi; width of"
+                               << " mother " << deltaZ << " along Z, " << convertRadToDeg(deltaPhi)
+                               << " along phi and with " << rStart.size() << " different bundle types";
+  for (unsigned int i = 0; i < areaSection.size(); ++i)
+    edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Child[" << i << "] Area " << areaSection[i] << " R at Start "
+                                 << rStart[i] << " R at End " << rEnd[i];
+  edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: NameSpace " << idNameSpace << " Tilt Angle "
+                               << convertRadToDeg(tilt) << " Bundle type at different positions";
+  for (unsigned int i = 0; i < bundle.size(); ++i) {
     edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Position[" << i << "] "
-				 << " with Type " << bundle[i];
+                                 << " with Type " << bundle[i];
   }
 #endif
 }
 
 void DDHCalFibreBundle::execute(DDCompactView& cpv) {
-
   DDName mother = parent().name();
   DDName matname(DDSplit(material).first, DDSplit(material).second);
   DDMaterial matter(matname);
 
   // Create the rotation matrices
-  double dPhi = deltaPhi/numberPhi;
+  double dPhi = deltaPhi / numberPhi;
   std::vector<DDRotation> rotation;
-  for (int i=0; i<numberPhi; ++i) {
-    double phi    = -0.5*deltaPhi+(i+0.5)*dPhi;
+  for (int i = 0; i < numberPhi; ++i) {
+    double phi = -0.5 * deltaPhi + (i + 0.5) * dPhi;
     double phideg = convertRadToDeg(phi);
-    std::string rotstr = "R0"+ std::to_string(phideg);
-    DDRotation  rot = DDRotation(DDName(rotstr, idNameSpace));
+    std::string rotstr = "R0" + std::to_string(phideg);
+    DDRotation rot = DDRotation(DDName(rotstr, idNameSpace));
     if (!rot) {
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Creating a new "
-				   << "rotation " << rotstr << "\t" << 90 
-				   << ","  << phideg << ","  << 90 << ","
-				   << (phideg+90) << ", 0, 0";
+                                   << "rotation " << rotstr << "\t" << 90 << "," << phideg << "," << 90 << ","
+                                   << (phideg + 90) << ", 0, 0";
 #endif
-      rot = DDrot(DDName(rotstr, idNameSpace), 90._deg, phi, 
-		  90._deg, (90._deg+phi), 0,  0);
+      rot = DDrot(DDName(rotstr, idNameSpace), 90._deg, phi, 90._deg, (90._deg + phi), 0, 0);
     }
     rotation.emplace_back(rot);
   }
 
   // Create the solids and logical parts
   std::vector<DDLogicalPart> logs;
-  for (unsigned int i=0; i<areaSection.size(); ++i) {
-    double r0     = rEnd[i]/std::cos(tilt);
-    double dStart = areaSection[i]/(2*dPhi*rStart[i]);
-    double dEnd   = areaSection[i]/(2*dPhi*r0);
+  for (unsigned int i = 0; i < areaSection.size(); ++i) {
+    double r0 = rEnd[i] / std::cos(tilt);
+    double dStart = areaSection[i] / (2 * dPhi * rStart[i]);
+    double dEnd = areaSection[i] / (2 * dPhi * r0);
     std::string name = childPrefix + std::to_string(i);
-    DDSolid solid = DDSolidFactory::cons(DDName(name, idNameSpace), 0.5*deltaZ,
-					 rStart[i]-dStart, rStart[i]+dStart,
-					 r0-dEnd, r0+dEnd, -0.5*dPhi, dPhi);
+    DDSolid solid = DDSolidFactory::cons(DDName(name, idNameSpace),
+                                         0.5 * deltaZ,
+                                         rStart[i] - dStart,
+                                         rStart[i] + dStart,
+                                         r0 - dEnd,
+                                         r0 + dEnd,
+                                         -0.5 * dPhi,
+                                         dPhi);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Creating a new solid "
-				 << name << " a cons with dZ " << deltaZ 
-				 << " rStart " << rStart[i]-dStart << ":"
-				 << rStart[i]+dStart << " rEnd " << r0-dEnd 
-				 << ":" << r0+dEnd << " Phi " 
-				 << convertRadToDeg(-0.5*dPhi) << ":" 
-				 << convertRadToDeg(0.5*dPhi);
+    edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: Creating a new solid " << name << " a cons with dZ " << deltaZ
+                                 << " rStart " << rStart[i] - dStart << ":" << rStart[i] + dStart << " rEnd "
+                                 << r0 - dEnd << ":" << r0 + dEnd << " Phi " << convertRadToDeg(-0.5 * dPhi) << ":"
+                                 << convertRadToDeg(0.5 * dPhi);
 #endif
     DDLogicalPart log(DDName(name, idNameSpace), matter, solid);
     logs.emplace_back(log);
   }
 
   // Now posiiton them
-  int    copy = 0;
-  int    nY   = (int)(bundle.size())/numberPhi;
-  for (unsigned int i=0; i<bundle.size(); i++) {
-    DDTranslation tran(0,0,0);
-    int ir = (int)(i)/nY;
-    if (ir >= numberPhi) ir = numberPhi-1;
+  int copy = 0;
+  int nY = (int)(bundle.size()) / numberPhi;
+  for (unsigned int i = 0; i < bundle.size(); i++) {
+    DDTranslation tran(0, 0, 0);
+    int ir = (int)(i) / nY;
+    if (ir >= numberPhi)
+      ir = numberPhi - 1;
     int ib = bundle[i];
     copy++;
-    if (ib>=0 && ib<(int)(logs.size())) {
+    if (ib >= 0 && ib < (int)(logs.size())) {
       cpv.position(logs[ib], mother, copy, tran, rotation[ir]);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: " << logs[ib].name() 
-				   << " number " << copy << " positioned in "
-				   << mother << " at " << tran << " with " 
-				   << rotation[ir];
+      edm::LogVerbatim("HCalGeom") << "DDHCalFibreBundle: " << logs[ib].name() << " number " << copy
+                                   << " positioned in " << mother << " at " << tran << " with " << rotation[ir];
 #endif
     }
   }

--- a/Geometry/HcalAlgo/plugins/DDHCalFibreBundle.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalFibreBundle.h
@@ -8,33 +8,31 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalFibreBundle : public DDAlgorithm {
-
 public:
   //Constructor and Destructor
-  DDHCalFibreBundle(); 
+  DDHCalFibreBundle();
   ~DDHCalFibreBundle() override;
-  
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
-
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
-  std::string              childPrefix; //Prefix to child name
-  std::string              material;    //Name of the material for bundles
-  double                   deltaZ;      //Width in  Z  for mother
-  double                   deltaPhi;    //Width in phi for mother
-  int                      numberPhi;   //Number of sections in phi
-  double                   tilt;        //Tilt angle of the readout box
-  std::vector<double>      areaSection; //Area of a bundle
-  std::vector<double>      rStart;      //Radius at start
-  std::vector<double>      rEnd;        //Radius at End
-  std::vector<int>         bundle;      //Bundle to be positioned 
+  std::string idNameSpace;          //Namespace of this and ALL sub-parts
+  std::string childPrefix;          //Prefix to child name
+  std::string material;             //Name of the material for bundles
+  double deltaZ;                    //Width in  Z  for mother
+  double deltaPhi;                  //Width in phi for mother
+  int numberPhi;                    //Number of sections in phi
+  double tilt;                      //Tilt angle of the readout box
+  std::vector<double> areaSection;  //Area of a bundle
+  std::vector<double> rStart;       //Radius at start
+  std::vector<double> rEnd;         //Radius at End
+  std::vector<int> bundle;          //Bundle to be positioned
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalForwardAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalForwardAlgo.cc
@@ -17,7 +17,7 @@
 
 //#define EDM_ML_DEBUG
 
-DDHCalForwardAlgo::DDHCalForwardAlgo(): number(0),size(0),type(0) {
+DDHCalForwardAlgo::DDHCalForwardAlgo() : number(0), size(0), type(0) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo: Creating an instance";
 #endif
@@ -25,68 +25,57 @@ DDHCalForwardAlgo::DDHCalForwardAlgo(): number(0),size(0),type(0) {
 
 DDHCalForwardAlgo::~DDHCalForwardAlgo() {}
 
-void DDHCalForwardAlgo::initialize(const DDNumericArguments & nArgs,
-				   const DDVectorArguments & vArgs,
-				   const DDMapArguments & ,
-				   const DDStringArguments & sArgs,
-				   const DDStringVectorArguments & vsArgs) {
+void DDHCalForwardAlgo::initialize(const DDNumericArguments& nArgs,
+                                   const DDVectorArguments& vArgs,
+                                   const DDMapArguments&,
+                                   const DDStringArguments& sArgs,
+                                   const DDStringVectorArguments& vsArgs) {
+  cellMat = sArgs["CellMaterial"];
+  cellDx = nArgs["CellDx"];
+  cellDy = nArgs["CellDy"];
+  cellDz = nArgs["CellDz"];
+  startY = nArgs["StartY"];
 
-  cellMat     = sArgs["CellMaterial"];
-  cellDx      = nArgs["CellDx"];
-  cellDy      = nArgs["CellDy"];
-  cellDz      = nArgs["CellDz"];
-  startY      = nArgs["StartY"];
-
-  childName   = vsArgs["Child"];
-  number      = dbl_to_int(vArgs["Number"]);
-  size        = dbl_to_int(vArgs["Size"]);
-  type        = dbl_to_int(vArgs["Type"]);
+  childName = vsArgs["Child"];
+  number = dbl_to_int(vArgs["Number"]);
+  size = dbl_to_int(vArgs["Size"]);
+  type = dbl_to_int(vArgs["Type"]);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo: Cell material "
-			       << cellMat << "\tCell Size "  << cellDx << ", "
-			       << cellDy << ", " << cellDz << "\tStarting Y " 
-			       << startY << "\tChildren " << childName[0] 
-			       << ", " << childName[1] << "\n               "
-			       << "          Cell positioning done for "
-			       << number.size() << " times";
+  edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo: Cell material " << cellMat << "\tCell Size " << cellDx << ", "
+                               << cellDy << ", " << cellDz << "\tStarting Y " << startY << "\tChildren " << childName[0]
+                               << ", " << childName[1] << "\n               "
+                               << "          Cell positioning done for " << number.size() << " times";
   for (unsigned int i = 0; i < number.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t" << i << " Number of children " 
-				 << size[i] << " occurence " << number[i] 
-				 << " first child index " << type[i];
+    edm::LogVerbatim("HCalGeom") << "\t" << i << " Number of children " << size[i] << " occurence " << number[i]
+                                 << " first child index " << type[i];
 #endif
   idNameSpace = DDCurrentNamespace::ns();
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo debug: Parent " 
-			       << parent().name() << " NameSpace " 
-			       << idNameSpace;
+  edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo debug: Parent " << parent().name() << " NameSpace " << idNameSpace;
 #endif
 }
 
 void DDHCalForwardAlgo::execute(DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "==>> Constructing DDHCalForwardAlgo...";
 #endif
-  DDName parentName = parent().name(); 
-  double ypos       = startY;
-  int    box        = 0;
+  DDName parentName = parent().name();
+  double ypos = startY;
+  int box = 0;
 
-  for (unsigned int i=0; i<number.size(); i++) {
-    double dx   = cellDx*size[i];
-    int    indx = type[i];
-    for (int j=0; j<number[i]; j++) {
+  for (unsigned int i = 0; i < number.size(); i++) {
+    double dx = cellDx * size[i];
+    int indx = type[i];
+    for (int j = 0; j < number[i]; j++) {
       box++;
       std::string name = parentName.name() + std::to_string(box);
-      DDSolid solid = DDSolidFactory::box(DDName(name, idNameSpace),
-					  dx, cellDy, cellDz);
+      DDSolid solid = DDSolidFactory::box(DDName(name, idNameSpace), dx, cellDy, cellDz);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo: " 
-				   << DDName(name, idNameSpace) 
-				   << " Box made of " << cellMat << " of Size "
-				   << dx << ", " << cellDy << ", " << cellDz;
+      edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo: " << DDName(name, idNameSpace) << " Box made of " << cellMat
+                                   << " of Size " << dx << ", " << cellDy << ", " << cellDz;
 #endif
-      DDName matname(DDSplit(cellMat).first, DDSplit(cellMat).second); 
+      DDName matname(DDSplit(cellMat).first, DDSplit(cellMat).second);
       DDMaterial matter(matname);
       DDLogicalPart genlogic(solid.ddname(), matter, solid);
 
@@ -94,29 +83,24 @@ void DDHCalForwardAlgo::execute(DDCompactView& cpv) {
       DDRotation rot;
       cpv.position(solid.ddname(), parentName, box, r0, rot);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo: " << solid.ddname() 
-				   << " number " << box << " positioned in " 
-				   << parentName << " at " << r0 << " with " 
-				   << rot;
+      edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo: " << solid.ddname() << " number " << box << " positioned in "
+                                   << parentName << " at " << r0 << " with " << rot;
 #endif
-      DDName child(DDSplit(childName[indx]).first, 
-		   DDSplit(childName[indx]).second); 
+      DDName child(DDSplit(childName[indx]).first, DDSplit(childName[indx]).second);
       double xpos = -dx + cellDx;
-      ypos       += 2*cellDy;
-      indx        = 1 - indx;
+      ypos += 2 * cellDy;
+      indx = 1 - indx;
 
-      for (int k=0; k<size[i]; k++) {
-	DDTranslation r1(xpos, 0.0, 0.0);
-	cpv.position(child, solid.ddname(), k+1, r1, rot);
+      for (int k = 0; k < size[i]; k++) {
+        DDTranslation r1(xpos, 0.0, 0.0);
+        cpv.position(child, solid.ddname(), k + 1, r1, rot);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo: " << child 
-				     << " number " << k+1 << " positioned in " 
-				     << solid.ddname() << " at " << r1 
-				     << " with " << rot;
+        edm::LogVerbatim("HCalGeom") << "DDHCalForwardAlgo: " << child << " number " << k + 1 << " positioned in "
+                                     << solid.ddname() << " at " << r1 << " with " << rot;
 #endif
-	xpos += 2*cellDx;
+        xpos += 2 * cellDx;
       }
-    }  
+    }
   }
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "<<== End of DDHCalForwardAlgo construction";

--- a/Geometry/HcalAlgo/plugins/DDHCalForwardAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalForwardAlgo.h
@@ -8,30 +8,29 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalForwardAlgo : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDHCalForwardAlgo(); //const std::string & name);
+  DDHCalForwardAlgo();  //const std::string & name);
   ~DDHCalForwardAlgo() override;
 
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
+  std::string cellMat;                 //Cell material
+  double cellDx, cellDy, cellDz;       //Cell size
+  double startY;                       //Starting Y for Cell
+  std::vector<std::string> childName;  //Children name
+  std::vector<int> number;             //Number of cells
+  std::vector<int> size;               //Number of children
+  std::vector<int> type;               //First child
 
-  std::string              cellMat;                 //Cell material 
-  double                   cellDx, cellDy, cellDz;  //Cell size
-  double                   startY;                  //Starting Y for Cell
-  std::vector<std::string> childName;               //Children name
-  std::vector<int>         number;                  //Number of cells
-  std::vector<int>         size;                    //Number of children
-  std::vector<int>         type;                    //First child
-
-  std::string              idNameSpace;     //Namespace for aLL sub-parts
+  std::string idNameSpace;  //Namespace for aLL sub-parts
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalLinearXY.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalLinearXY.cc
@@ -21,69 +21,60 @@ DDHCalLinearXY::DDHCalLinearXY() {
 
 DDHCalLinearXY::~DDHCalLinearXY() {}
 
-void DDHCalLinearXY::initialize(const DDNumericArguments & nArgs,
-				const DDVectorArguments & vArgs,
-				const DDMapArguments & ,
-				const DDStringArguments & sArgs,
-				const DDStringVectorArguments & vsArgs) {
+void DDHCalLinearXY::initialize(const DDNumericArguments& nArgs,
+                                const DDVectorArguments& vArgs,
+                                const DDMapArguments&,
+                                const DDStringArguments& sArgs,
+                                const DDStringVectorArguments& vsArgs) {
+  numberX = int(nArgs["NumberX"]);
+  deltaX = nArgs["DeltaX"];
+  numberY = int(nArgs["NumberY"]);
+  deltaY = nArgs["DeltaY"];
+  centre = vArgs["Center"];
 
-  numberX   = int(nArgs["NumberX"]);
-  deltaX    = nArgs["DeltaX"];
-  numberY   = int(nArgs["NumberY"]);
-  deltaY    = nArgs["DeltaY"];
-  centre    = vArgs["Center"];
-  
   idNameSpace = DDCurrentNamespace::ns();
-  childName   = vsArgs["Child"]; 
+  childName = vsArgs["Child"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: Parent " << parent().name()
-			       << "\twith " << childName.size() << " children";
-  for (unsigned int i=0; i<childName.size(); ++i) 
-    edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: Child[" << i << "] = "
-				 << childName[i];
-  edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: NameSpace " << idNameSpace
-			       << "\tNumber along X/Y " << numberX << "/" 
-			       << numberY << "\tDelta along X/Y " << deltaX
-			       << "/" << deltaY << "\tCentre " << centre[0] 
-			       << ", " << centre[1] << ", " << centre[2];
+  edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: Parent " << parent().name() << "\twith " << childName.size()
+                               << " children";
+  for (unsigned int i = 0; i < childName.size(); ++i)
+    edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: Child[" << i << "] = " << childName[i];
+  edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: NameSpace " << idNameSpace << "\tNumber along X/Y " << numberX << "/"
+                               << numberY << "\tDelta along X/Y " << deltaX << "/" << deltaY << "\tCentre " << centre[0]
+                               << ", " << centre[1] << ", " << centre[2];
 #endif
 }
 
 void DDHCalLinearXY::execute(DDCompactView& cpv) {
-
   DDName mother = parent().name();
   DDName child;
   DDRotation rot;
-  double xoff = centre[0] - (numberX-1)*deltaX/2.;
-  double yoff = centre[1] - (numberY-1)*deltaY/2.;
-  int    copy = 0;
+  double xoff = centre[0] - (numberX - 1) * deltaX / 2.;
+  double yoff = centre[1] - (numberY - 1) * deltaY / 2.;
+  int copy = 0;
 
-  for (int i=0; i<numberX; i++) {
-    for (int j=0; j<numberY; j++) {
-	
-      DDTranslation tran(xoff+i*deltaX,yoff+j*deltaY,centre[2]);
-      bool     place = true;
+  for (int i = 0; i < numberX; i++) {
+    for (int j = 0; j < numberY; j++) {
+      DDTranslation tran(xoff + i * deltaX, yoff + j * deltaY, centre[2]);
+      bool place = true;
       unsigned int k = copy;
-      if (childName.size() == 1) k = 0;
-      if (k < childName.size() && (childName[k] != " " && 
-				   childName[k] != "Null")) {
-	child = DDName(DDSplit(childName[k]).first, DDSplit(childName[k]).second);
+      if (childName.size() == 1)
+        k = 0;
+      if (k < childName.size() && (childName[k] != " " && childName[k] != "Null")) {
+        child = DDName(DDSplit(childName[k]).first, DDSplit(childName[k]).second);
       } else {
-	place = false;
+        place = false;
       }
       copy++;
       if (place) {
-	cpv.position(child, mother, copy, tran, rot);
+        cpv.position(child, mother, copy, tran, rot);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: " << child 
-				     << " number " << copy << " positioned in "
-				     << mother << " at " << tran << " with "
-				     << rot;
+        edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: " << child << " number " << copy << " positioned in " << mother
+                                     << " at " << tran << " with " << rot;
 #endif
       } else {
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: No child placed for ["
-				     << copy << "]";
+        edm::LogVerbatim("HCalGeom") << "DDHCalLinearXY: No child placed for [" << copy << "]";
 #endif
       }
     }

--- a/Geometry/HcalAlgo/plugins/DDHCalLinearXY.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalLinearXY.h
@@ -8,29 +8,27 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalLinearXY : public DDAlgorithm {
-
 public:
   //Constructor and Destructor
-  DDHCalLinearXY(); 
+  DDHCalLinearXY();
   ~DDHCalLinearXY() override;
-  
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
-
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
-  std::vector<std::string> childName;   //Child name
-  int                      numberX;     //Number of positioning along X-axis
-  double                   deltaX;      //Increment               .........
-  int                      numberY;     //Number of positioning along Y-axis
-  double                   deltaY;      //Increment               .........
-  std::vector<double>      centre;      //Centre
+  std::string idNameSpace;             //Namespace of this and ALL sub-parts
+  std::vector<std::string> childName;  //Child name
+  int numberX;                         //Number of positioning along X-axis
+  double deltaX;                       //Increment               .........
+  int numberY;                         //Number of positioning along Y-axis
+  double deltaY;                       //Increment               .........
+  std::vector<double> centre;          //Centre
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.cc
@@ -18,7 +18,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-DDHCalTBCableAlgo::DDHCalTBCableAlgo(): theta(0),rmax(0),zoff(0) {
+DDHCalTBCableAlgo::DDHCalTBCableAlgo() : theta(0), rmax(0), zoff(0) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating an instance";
 #endif
@@ -26,278 +26,220 @@ DDHCalTBCableAlgo::DDHCalTBCableAlgo(): theta(0),rmax(0),zoff(0) {
 
 DDHCalTBCableAlgo::~DDHCalTBCableAlgo() {}
 
+void DDHCalTBCableAlgo::initialize(const DDNumericArguments& nArgs,
+                                   const DDVectorArguments& vArgs,
+                                   const DDMapArguments&,
+                                   const DDStringArguments& sArgs,
+                                   const DDStringVectorArguments&) {
+  genMat = sArgs["MaterialName"];
+  nsectors = int(nArgs["NSector"]);
+  nsectortot = int(nArgs["NSectorTot"]);
+  nhalf = int(nArgs["NHalf"]);
+  rin = nArgs["RIn"];
+  theta = vArgs["Theta"];
+  rmax = vArgs["RMax"];
+  zoff = vArgs["ZOff"];
 
-void DDHCalTBCableAlgo::initialize(const DDNumericArguments & nArgs,
-				   const DDVectorArguments & vArgs,
-				   const DDMapArguments & ,
-				   const DDStringArguments & sArgs,
-				   const DDStringVectorArguments & ) {
-
-  genMat      = sArgs["MaterialName"];
-  nsectors    = int (nArgs["NSector"]);
-  nsectortot  = int (nArgs["NSectorTot"]);
-  nhalf       = int (nArgs["NHalf"]);
-  rin         = nArgs["RIn"];
-  theta       = vArgs["Theta"];
-  rmax        = vArgs["RMax"];
-  zoff        = vArgs["ZOff"];
-
-  absMat      = sArgs["AbsMatName"];
-  thick       = nArgs["Thickness"];
-  width1      = nArgs["Width1"];
-  length1     = nArgs["Length1"];
-  width2      = nArgs["Width2"];
-  length2     = nArgs["Length2"];
-  gap2        = nArgs["Gap2"];
+  absMat = sArgs["AbsMatName"];
+  thick = nArgs["Thickness"];
+  width1 = nArgs["Width1"];
+  length1 = nArgs["Length1"];
+  width2 = nArgs["Width2"];
+  length2 = nArgs["Length2"];
+  gap2 = nArgs["Gap2"];
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: General material " 
-			       << genMat << "\tSectors "  << nsectors << ", " 
-			       << nsectortot << "\tHalves " << nhalf 
-			       << "\tRin " << rin;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: General material " << genMat << "\tSectors " << nsectors << ", "
+                               << nsectortot << "\tHalves " << nhalf << "\tRin " << rin;
   for (unsigned int i = 0; i < theta.size(); i++)
-    edm::LogVerbatim("HCalGeom") << "\t" << i << " Theta " << theta[i] 
-				 << " rmax " << rmax[i] << " zoff " << zoff[i];
-  edm::LogVerbatim("HCalGeom") << "\tCable mockup made of " << absMat
-			       << "\tThick " << thick << "\tLength and width "
-			       << length1 << ", " << width1 <<" and "
-			       << length2 << ", " << width2 << " Gap " << gap2;
+    edm::LogVerbatim("HCalGeom") << "\t" << i << " Theta " << theta[i] << " rmax " << rmax[i] << " zoff " << zoff[i];
+  edm::LogVerbatim("HCalGeom") << "\tCable mockup made of " << absMat << "\tThick " << thick << "\tLength and width "
+                               << length1 << ", " << width1 << " and " << length2 << ", " << width2 << " Gap " << gap2;
 #endif
-  idName      = sArgs["MotherName"];
+  idName = sArgs["MotherName"];
   idNameSpace = DDCurrentNamespace::ns();
-  rotns       = sArgs["RotNameSpace"];
+  rotns = sArgs["RotNameSpace"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Parent " 
-			       << parent().name() << " idName " << idName 
-			       << " NameSpace " << idNameSpace
-			       << " for solids etc. and " << rotns 
-			       << " for rotations";
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Parent " << parent().name() << " idName " << idName
+                               << " NameSpace " << idNameSpace << " for solids etc. and " << rotns << " for rotations";
 #endif
 }
 
 void DDHCalTBCableAlgo::execute(DDCompactView& cpv) {
-  
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "==>> Constructing DDHCalTBCableAlgo...";
 #endif
 
-  double alpha = 1._pi/nsectors;
-  double dphi  = nsectortot*2._pi/nsectors;
-  
-  double zstep0 = zoff[1]+rmax[1]*tan(theta[1])+(rin-rmax[1])*tan(theta[2]);
-  double zstep1 = zstep0+thick/cos(theta[2]);
-  double zstep2 = zoff[3];
- 
-  double rstep0 = rin + (zstep2-zstep1)/tan(theta[2]);
-  double rstep1 = rin + (zstep1-zstep0)/tan(theta[2]);
+  double alpha = 1._pi / nsectors;
+  double dphi = nsectortot * 2._pi / nsectors;
 
-  std::vector<double> pgonZ = {zstep0, zstep1, zstep2, 
-			       zstep2+thick/cos(theta[2])}; 
-  
+  double zstep0 = zoff[1] + rmax[1] * tan(theta[1]) + (rin - rmax[1]) * tan(theta[2]);
+  double zstep1 = zstep0 + thick / cos(theta[2]);
+  double zstep2 = zoff[3];
+
+  double rstep0 = rin + (zstep2 - zstep1) / tan(theta[2]);
+  double rstep1 = rin + (zstep1 - zstep0) / tan(theta[2]);
+
+  std::vector<double> pgonZ = {zstep0, zstep1, zstep2, zstep2 + thick / cos(theta[2])};
+
   std::vector<double> pgonRmin = {rin, rin, rstep0, rmax[2]};
-  std::vector<double> pgonRmax = {rin, rstep1, rmax[2], rmax[2]}; 
+  std::vector<double> pgonRmax = {rin, rstep1, rmax[2], rmax[2]};
 
   std::string name("Null");
   DDSolid solid;
-  solid = DDSolidFactory::polyhedra(DDName(idName, idNameSpace),
-				    nsectortot, -alpha, dphi, pgonZ, 
-				    pgonRmin, pgonRmax);
+  solid = DDSolidFactory::polyhedra(DDName(idName, idNameSpace), nsectortot, -alpha, dphi, pgonZ, pgonRmin, pgonRmax);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " 
-			       << DDName(idName,idNameSpace) 
-			       << " Polyhedra made of " << genMat << " with " 
-			       << nsectortot << " sectors from "
-			       << convertRadToDeg(-alpha) << " to " 
-			       << convertRadToDeg(-alpha+dphi) << " and with " 
-			       << pgonZ.size() << " sections";
-  for (unsigned int i = 0; i <pgonZ.size(); i++) 
-    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[i] << "\tRmin = " 
-				 << pgonRmin[i] << "\tRmax = " << pgonRmax[i];
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << DDName(idName, idNameSpace) << " Polyhedra made of "
+                               << genMat << " with " << nsectortot << " sectors from " << convertRadToDeg(-alpha)
+                               << " to " << convertRadToDeg(-alpha + dphi) << " and with " << pgonZ.size()
+                               << " sections";
+  for (unsigned int i = 0; i < pgonZ.size(); i++)
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[i] << "\tRmin = " << pgonRmin[i] << "\tRmax = " << pgonRmax[i];
 #endif
-  DDName matname(DDSplit(genMat).first, DDSplit(genMat).second); 
+  DDName matname(DDSplit(genMat).first, DDSplit(genMat).second);
   DDMaterial matter(matname);
   DDLogicalPart genlogic(solid.ddname(), matter, solid);
 
-  DDName parentName = parent().name(); 
+  DDName parentName = parent().name();
   DDTranslation r0(0.0, 0.0, 0.0);
   DDRotation rot;
   cpv.position(DDName(idName, idNameSpace), parentName, 1, r0, rot);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " 
-			       << DDName(idName,idNameSpace) 
-			       << " number 1 positioned in " << parentName 
-			       << " at " << r0 << " with "<<rot;
-#endif  
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << DDName(idName, idNameSpace) << " number 1 positioned in "
+                               << parentName << " at " << r0 << " with " << rot;
+#endif
   if (nhalf != 1) {
     rot = DDRotation(DDName("180D", rotns));
     cpv.position(DDName(idName, idNameSpace), parentName, 2, r0, rot);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " 
-				 << DDName(idName,idNameSpace) 
-				 <<" number 2 positioned in " << parentName
-				 << " at " << r0 << " with " << rot;
+    edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << DDName(idName, idNameSpace) << " number 2 positioned in "
+                                 << parentName << " at " << r0 << " with " << rot;
 #endif
-  } 
-  
+  }
+
   //Construct sector (from -alpha to +alpha)
   name = idName + "Module";
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " 
-			       << DDName(name,idNameSpace) 
-			       << " Polyhedra made of " << genMat 
-			       << " with 1 sector from " 
-			       << convertRadToDeg(-alpha) << " to " 
-			       << convertRadToDeg(alpha) << " and with " 
-			       << pgonZ.size() << " sections";
-  for (unsigned int i = 0; i < pgonZ.size(); i++) 
-    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[i] << "\tRmin = " 
-				 << pgonRmin[i] << "\tRmax = " << pgonRmax[i];
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << DDName(name, idNameSpace) << " Polyhedra made of " << genMat
+                               << " with 1 sector from " << convertRadToDeg(-alpha) << " to " << convertRadToDeg(alpha)
+                               << " and with " << pgonZ.size() << " sections";
+  for (unsigned int i = 0; i < pgonZ.size(); i++)
+    edm::LogVerbatim("HCalGeom") << "\t\tZ = " << pgonZ[i] << "\tRmin = " << pgonRmin[i] << "\tRmax = " << pgonRmax[i];
 #endif
-  solid =   DDSolidFactory::polyhedra(DDName(name, idNameSpace),
-				      1, -alpha, 2*alpha, pgonZ,
-				      pgonRmin, pgonRmax);
+  solid = DDSolidFactory::polyhedra(DDName(name, idNameSpace), 1, -alpha, 2 * alpha, pgonZ, pgonRmin, pgonRmax);
   DDLogicalPart seclogic(solid.ddname(), matter, solid);
-  
-  for (int ii=0; ii<nsectortot; ii++) {
-    double phi    = ii*2*alpha;
+
+  for (int ii = 0; ii < nsectortot; ii++) {
+    double phi = ii * 2 * alpha;
     DDRotation rotation;
     std::string rotstr("NULL");
     if (phi != 0) {
       rotstr = "R" + formatAsDegreesInInteger(phi);
-      rotation = DDRotation(DDName(rotstr, rotns)); 
+      rotation = DDRotation(DDName(rotstr, rotns));
       if (!rotation) {
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a new "
-				     << "rotation " << rotstr << "\t90," 
-                                     << convertRadToDeg(phi) << ",90,"
-                                     << (90+convertRadToDeg(phi)) << ", 0, 0";
+        edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a new "
+                                     << "rotation " << rotstr << "\t90," << convertRadToDeg(phi) << ",90,"
+                                     << (90 + convertRadToDeg(phi)) << ", 0, 0";
 #endif
-	rotation = DDrot(DDName(rotstr, idNameSpace), 90._deg, phi, 90._deg, 
-			 (90._deg+phi), 0,  0);
+        rotation = DDrot(DDName(rotstr, idNameSpace), 90._deg, phi, 90._deg, (90._deg + phi), 0, 0);
       }
-    } 
-  
-    cpv.position(seclogic, genlogic, ii+1, DDTranslation(0.0, 0.0, 0.0), 
-		 rotation);
+    }
+
+    cpv.position(seclogic, genlogic, ii + 1, DDTranslation(0.0, 0.0, 0.0), rotation);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << seclogic.name() 
-				 << " number " << ii+1 << " positioned in " 
-				 << genlogic.name() << " at (0,0,0) with " 
-				 << rotation;
+    edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << seclogic.name() << " number " << ii + 1
+                                 << " positioned in " << genlogic.name() << " at (0,0,0) with " << rotation;
 #endif
   }
-  
+
   //Now a trapezoid of air
-  double rinl  = pgonRmin[0] + thick * sin(theta[2]);
+  double rinl = pgonRmin[0] + thick * sin(theta[2]);
   double routl = pgonRmax[2] - thick * sin(theta[2]);
-  double dx1   = rinl * tan(alpha);
-  double dx2   = 0.90 * routl * tan(alpha);
-  double dy    = 0.50 * thick;
-  double dz    = 0.50 * (routl -rinl);
-  name  = idName + "Trap";
-  solid = DDSolidFactory::trap(DDName(name, idNameSpace), dz, 0, 0, dy, dx1, 
-			       dx1, 0, dy, dx2, dx2, 0);
+  double dx1 = rinl * tan(alpha);
+  double dx2 = 0.90 * routl * tan(alpha);
+  double dy = 0.50 * thick;
+  double dz = 0.50 * (routl - rinl);
+  name = idName + "Trap";
+  solid = DDSolidFactory::trap(DDName(name, idNameSpace), dz, 0, 0, dy, dx1, dx1, 0, dy, dx2, dx2, 0);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() 
-			       << " Trap made of " << genMat 
-			       << " of dimensions " << dz << ", 0, 0, " 
-			       << dy << ", " << dx1 << ", " << dx1 
-			       << ", 0, " << dy << ", " << dx2 << ", " << dx2
-			       <<", 0";
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Trap made of " << genMat
+                               << " of dimensions " << dz << ", 0, 0, " << dy << ", " << dx1 << ", " << dx1 << ", 0, "
+                               << dy << ", " << dx2 << ", " << dx2 << ", 0";
 #endif
   DDLogicalPart glog(solid.ddname(), matter, solid);
 
   std::string rotstr = name;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a rotation: " 
-			       << rotstr << "\t90, 270, " 
-			       << (180-convertRadToDeg(theta[2]))
-			       << ", 0, " << (90-convertRadToDeg(theta[2])) 
-			       << ", 0";
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a rotation: " << rotstr << "\t90, 270, "
+                               << (180 - convertRadToDeg(theta[2])) << ", 0, " << (90 - convertRadToDeg(theta[2]))
+                               << ", 0";
 #endif
-  rot = DDrot(DDName(rotstr, idNameSpace), 90._deg, 270._deg, 
-	      (180._deg-theta[2]), 0, (90._deg-theta[2]), 0);
-  DDTranslation r1(0.5*(rinl+routl), 0, 0.5*(pgonZ[1]+pgonZ[2]));
+  rot = DDrot(DDName(rotstr, idNameSpace), 90._deg, 270._deg, (180._deg - theta[2]), 0, (90._deg - theta[2]), 0);
+  DDTranslation r1(0.5 * (rinl + routl), 0, 0.5 * (pgonZ[1] + pgonZ[2]));
   cpv.position(glog, seclogic, 1, r1, rot);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << glog.name() 
-			       << " number 1 positioned in " << seclogic.name()
-			       << " at " << r1 << " with " << rot;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << glog.name() << " number 1 positioned in " << seclogic.name()
+                               << " at " << r1 << " with " << rot;
 #endif
   //Now the cable of type 1
   name = idName + "Cable1";
-  double phi  = atan((dx2-dx1)/(2*dz));
-  double xmid = 0.5*(dx1+dx2)-1.0;
-  solid = DDSolidFactory::box(DDName(name, idNameSpace), 0.5*width1,
-			      0.5*thick, 0.5*length1);
+  double phi = atan((dx2 - dx1) / (2 * dz));
+  double xmid = 0.5 * (dx1 + dx2) - 1.0;
+  solid = DDSolidFactory::box(DDName(name, idNameSpace), 0.5 * width1, 0.5 * thick, 0.5 * length1);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() 
-			       << " Box made of " << absMat << " of dimension "
-			       << 0.5*width1 << ", " << 0.5*thick << ", " 
-			       << 0.5*length1;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Box made of " << absMat << " of dimension "
+                               << 0.5 * width1 << ", " << 0.5 * thick << ", " << 0.5 * length1;
 #endif
-  DDName absname(DDSplit(absMat).first, DDSplit(absMat).second); 
+  DDName absname(DDSplit(absMat).first, DDSplit(absMat).second);
   DDMaterial absmatter(absname);
   DDLogicalPart cablog1(solid.ddname(), absmatter, solid);
 
   rotstr = idName + "Left";
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a rotation " 
-			       << rotstr << "\t"  << (90+convertRadToDeg(phi))
-			       << ", 0, 90, 90, " << convertRadToDeg(phi) 
-			       << ", 0";
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a rotation " << rotstr << "\t"
+                               << (90 + convertRadToDeg(phi)) << ", 0, 90, 90, " << convertRadToDeg(phi) << ", 0";
 #endif
-  DDRotation rot2 = DDrot(DDName(rotstr, idNameSpace), (90._deg+phi), 0.0, 
-			  90._deg, 90._deg, phi, 0.0);
-  DDTranslation r2((xmid-0.5*width1*cos(phi)), 0, 0);
+  DDRotation rot2 = DDrot(DDName(rotstr, idNameSpace), (90._deg + phi), 0.0, 90._deg, 90._deg, phi, 0.0);
+  DDTranslation r2((xmid - 0.5 * width1 * cos(phi)), 0, 0);
   cpv.position(cablog1, glog, 1, r2, rot2);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog1.name() 
-			       << " number 1 positioned in " << glog.name() 
-			       << " at " << r2 << " with " << rot2;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog1.name() << " number 1 positioned in " << glog.name()
+                               << " at " << r2 << " with " << rot2;
 #endif
   rotstr = idName + "Right";
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a rotation " 
-			       << rotstr << "\t"  << (90-convertRadToDeg(phi))
-			       << ", 0, 90, 90, " << convertRadToDeg(-phi)
-			       << ", 0";
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: Creating a rotation " << rotstr << "\t"
+                               << (90 - convertRadToDeg(phi)) << ", 0, 90, 90, " << convertRadToDeg(-phi) << ", 0";
 #endif
-  DDRotation rot3 = DDrot(DDName(rotstr, idNameSpace), (90._deg-phi), 0,
-			  90._deg, 90._deg, -phi, 0);
-  DDTranslation r3(-(xmid-0.5*width1*cos(phi)), 0, 0);
+  DDRotation rot3 = DDrot(DDName(rotstr, idNameSpace), (90._deg - phi), 0, 90._deg, 90._deg, -phi, 0);
+  DDTranslation r3(-(xmid - 0.5 * width1 * cos(phi)), 0, 0);
   cpv.position(cablog1, glog, 2, r3, rot3);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog1.name() 
-			       << " number 2 positioned in "  << glog.name()
-			       << " at " << r3 << " with " << rot3;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog1.name() << " number 2 positioned in " << glog.name()
+                               << " at " << r3 << " with " << rot3;
 #endif
   //Now the cable of type 2
   name = idName + "Cable2";
-  solid = DDSolidFactory::box(DDName(name, idNameSpace), 0.5*width2,
-			      0.5*thick, 0.5*length2);
+  solid = DDSolidFactory::box(DDName(name, idNameSpace), 0.5 * width2, 0.5 * thick, 0.5 * length2);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() 
-			       << " Box made of " << absMat << " of dimension "
-			       << 0.5*width2 << ", " << 0.5*thick << ", "
-			       << 0.5*length2;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << solid.name() << " Box made of " << absMat << " of dimension "
+                               << 0.5 * width2 << ", " << 0.5 * thick << ", " << 0.5 * length2;
 #endif
   DDLogicalPart cablog2(solid.ddname(), absmatter, solid);
 
-  double xpos = 0.5*(width2+gap2);
+  double xpos = 0.5 * (width2 + gap2);
   cpv.position(cablog2, glog, 1, DDTranslation(xpos, 0.0, 0.0), DDRotation());
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog2.name() 
-			       << " number 1 positioned in "  << glog.name() 
-			       << " at (" << xpos << ",  0, 0) with no "
-			       << "rotation";
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog2.name() << " number 1 positioned in " << glog.name()
+                               << " at (" << xpos << ",  0, 0) with no "
+                               << "rotation";
 #endif
   cpv.position(cablog2, glog, 2, DDTranslation(-xpos, 0.0, 0.0), DDRotation());
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog2.name() 
-			       << " number 2 positioned in "  << glog.name()
-			       << " at ("  <<-xpos << ", 0, 0) with no "
-			       << "rotation";
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBCableAlgo: " << cablog2.name() << " number 2 positioned in " << glog.name()
+                               << " at (" << -xpos << ", 0, 0) with no "
+                               << "rotation";
 
   edm::LogVerbatim("HCalGeom") << "<<== End of DDHCalTBCableAlgo construction";
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBCableAlgo.h
@@ -8,38 +8,37 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalTBCableAlgo : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDHCalTBCableAlgo(); //const std::string & name);
+  DDHCalTBCableAlgo();  //const std::string & name);
   ~DDHCalTBCableAlgo() override;
 
-  void initialize(const DDNumericArguments & nArgs,
-			  const DDVectorArguments & vArgs,
-			  const DDMapArguments & mArgs,
-			  const DDStringArguments & sArgs,
-			  const DDStringVectorArguments & vsArgs) override;
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
+  std::string genMat;         //General material
+  int nsectors;               //Number of potenital straight edges
+  int nsectortot;             //Number of straight edges (actual)
+  int nhalf;                  //Number of half modules
+  double rin;                 //(see Figure of hcalbarrel)
+  std::vector<double> theta;  //  .... (in degrees)
+  std::vector<double> rmax;   //  ....
+  std::vector<double> zoff;   //  ....
+  std::string absMat;         //Absorber material
+  double thick;               //Thickness of absorber
+  double width1, length1;     //Width, length of absorber type 1
+  double width2, length2;     //Width, length of absorber type 2
+  double gap2;                //Gap between abosrbers of type 2
 
-  std::string           genMat;          //General material
-  int                   nsectors;        //Number of potenital straight edges
-  int                   nsectortot;      //Number of straight edges (actual)
-  int                   nhalf;           //Number of half modules
-  double                rin;             //(see Figure of hcalbarrel)
-  std::vector<double>   theta;           //  .... (in degrees)
-  std::vector<double>   rmax;            //  .... 
-  std::vector<double>   zoff;            //  ....
-  std::string           absMat;          //Absorber material
-  double                thick;           //Thickness of absorber
-  double                width1, length1; //Width, length of absorber type 1
-  double                width2, length2; //Width, length of absorber type 2
-  double                gap2;            //Gap between abosrbers of type 2
-
-  std::string           idName;          //Name of the "parent" volume.  
-  std::string           idNameSpace;     //Namespace of this and ALL sub-parts
-  std::string           rotns;           //Namespace for rotation matrix
+  std::string idName;       //Name of the "parent" volume.
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  std::string rotns;        //Namespace for rotation matrix
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.cc
@@ -24,67 +24,58 @@ DDHCalTBZposAlgo::DDHCalTBZposAlgo() {
 
 DDHCalTBZposAlgo::~DDHCalTBZposAlgo() {}
 
-void DDHCalTBZposAlgo::initialize(const DDNumericArguments & nArgs,
-				  const DDVectorArguments & ,
-				  const DDMapArguments & ,
-				  const DDStringArguments & sArgs,
-				  const DDStringVectorArguments & ) {
-
-  eta        = nArgs["Eta"];
-  theta      = 2.0*atan(exp(-eta));
-  shiftX     = nArgs["ShiftX"];
-  shiftY     = nArgs["ShiftY"];
-  zoffset    = nArgs["Zoffset"];
-  dist       = nArgs["Distance"];
-  tilt       = nArgs["TiltAngle"];
-  copyNumber = int (nArgs["Number"]);
+void DDHCalTBZposAlgo::initialize(const DDNumericArguments& nArgs,
+                                  const DDVectorArguments&,
+                                  const DDMapArguments&,
+                                  const DDStringArguments& sArgs,
+                                  const DDStringVectorArguments&) {
+  eta = nArgs["Eta"];
+  theta = 2.0 * atan(exp(-eta));
+  shiftX = nArgs["ShiftX"];
+  shiftY = nArgs["ShiftY"];
+  zoffset = nArgs["Zoffset"];
+  dist = nArgs["Distance"];
+  tilt = nArgs["TiltAngle"];
+  copyNumber = int(nArgs["Number"]);
   edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Parameters for position"
-			       << "ing--" << " Eta " << eta << "\tTheta " 
-			       << convertRadToDeg(theta) << "\tShifts " 
-			       << shiftX << ", " << shiftY  << " along x, y "
-			       << "axes; \tZoffest " << zoffset
-			       << "\tRadial Distance " << dist 
-			       << "\tTilt angle " << convertRadToDeg(tilt)
-			       << "\tcopyNumber " << copyNumber;
+                               << "ing--"
+                               << " Eta " << eta << "\tTheta " << convertRadToDeg(theta) << "\tShifts " << shiftX
+                               << ", " << shiftY << " along x, y "
+                               << "axes; \tZoffest " << zoffset << "\tRadial Distance " << dist << "\tTilt angle "
+                               << convertRadToDeg(tilt) << "\tcopyNumber " << copyNumber;
 
   idNameSpace = DDCurrentNamespace::ns();
-  childName   = sArgs["ChildName"]; 
+  childName = sArgs["ChildName"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Parent " <<parent().name()
-			       << "\tChild " << childName << " NameSpace "
-			       << idNameSpace;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: Parent " << parent().name() << "\tChild " << childName
+                               << " NameSpace " << idNameSpace;
 #endif
 }
 
 void DDHCalTBZposAlgo::execute(DDCompactView& cpv) {
-
   DDName mother = parent().name();
   DDName child(DDSplit(childName).first, DDSplit(childName).second);
- 
+
   double thetax = 90._deg - theta;
-  double z      = zoffset + dist*tan(thetax);
-  double x      = shiftX - shiftY*sin(tilt);
-  double y      = shiftY*cos(tilt);
-  DDTranslation tran(x,y,z);
+  double z = zoffset + dist * tan(thetax);
+  double x = shiftX - shiftY * sin(tilt);
+  double y = shiftY * cos(tilt);
+  DDTranslation tran(x, y, z);
   DDRotation rot;
   if (tilt != 0) {
     std::string rotstr = "R" + formatAsDegrees(tilt);
-    rot    = DDRotation(DDName(rotstr, idNameSpace)); 
+    rot = DDRotation(DDName(rotstr, idNameSpace));
     if (!rot) {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "DDHCalZposAlgo: Creating a rotation "
-				   << DDName(rotstr,idNameSpace) << "\t90, "
-				   << convertRadToDeg(tilt) << ",90,"
-				   << (90+convertRadToDeg(tilt)) << ", 0, 0";
+      edm::LogVerbatim("HCalGeom") << "DDHCalZposAlgo: Creating a rotation " << DDName(rotstr, idNameSpace) << "\t90, "
+                                   << convertRadToDeg(tilt) << ",90," << (90 + convertRadToDeg(tilt)) << ", 0, 0";
 #endif
-      rot = DDrot(DDName(rotstr, idNameSpace), 90._deg, tilt, 
-		  90._deg, (90._deg+tilt), 0.0,  0.0);
+      rot = DDrot(DDName(rotstr, idNameSpace), 90._deg, tilt, 90._deg, (90._deg + tilt), 0.0, 0.0);
     }
   }
   cpv.position(child, mother, copyNumber, tran, rot);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: " << child << " number " 
-			       << copyNumber << " positioned in " << mother
-			       << " at " << tran << " with " << rot;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTBZposAlgo: " << child << " number " << copyNumber << " positioned in "
+                               << mother << " at " << tran << " with " << rot;
 #endif
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalTBZposAlgo.h
@@ -8,32 +8,31 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalTBZposAlgo : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDHCalTBZposAlgo(); 
+  DDHCalTBZposAlgo();
   ~DDHCalTBZposAlgo() override;
-  
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
+  double eta;      //Eta at which beam is focussed
+  double theta;    //Corresponding theta value
+  double shiftY;   //Shift along Y
+  double shiftX;   //Shift along X
+  double zoffset;  //Offset in z
+  double dist;     //Radial distance
+  double tilt;     //Tilt with respect to y-axis
+  int copyNumber;  //Copy Number
 
-  double        eta;         //Eta at which beam is focussed
-  double        theta;       //Corresponding theta value
-  double        shiftY;      //Shift along Y
-  double        shiftX;      //Shift along X
-  double        zoffset;     //Offset in z
-  double        dist;        //Radial distance
-  double        tilt;        //Tilt with respect to y-axis
-  int           copyNumber;  //Copy Number
-
-  std::string   idNameSpace; //Namespace of this and ALL sub-parts
-  std::string   childName;   //Children name
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  std::string childName;    //Children name
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.cc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // File: DDHCalTestBeamAlgo.cc
-// Description: Position inside the mother according to (eta,phi) 
+// Description: Position inside the mother according to (eta,phi)
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <cmath>
@@ -16,93 +16,82 @@
 using namespace geant_units::operators;
 
 DDHCalTestBeamAlgo::DDHCalTestBeamAlgo() {
-#ifdef  EDM_ML_DEBUG
+#ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: Creating an instance";
 #endif
 }
 
 DDHCalTestBeamAlgo::~DDHCalTestBeamAlgo() {}
 
-void DDHCalTestBeamAlgo::initialize(const DDNumericArguments & nArgs,
-				    const DDVectorArguments & ,
-				    const DDMapArguments & ,
-				    const DDStringArguments & sArgs,
-				    const DDStringVectorArguments & ) {
-
-  eta        = nArgs["Eta"];
-  theta      = 2.0*atan(exp(-eta));
-  phi        = nArgs["Phi"];
-  distance   = nArgs["Dist"];
-  distanceZ  = nArgs["DistZ"];
-  dz         = nArgs["Dz"];
-  copyNumber = int (nArgs["Number"]);
-  dist       = (distance+distanceZ/sin(theta));
+void DDHCalTestBeamAlgo::initialize(const DDNumericArguments& nArgs,
+                                    const DDVectorArguments&,
+                                    const DDMapArguments&,
+                                    const DDStringArguments& sArgs,
+                                    const DDStringVectorArguments&) {
+  eta = nArgs["Eta"];
+  theta = 2.0 * atan(exp(-eta));
+  phi = nArgs["Phi"];
+  distance = nArgs["Dist"];
+  distanceZ = nArgs["DistZ"];
+  dz = nArgs["Dz"];
+  copyNumber = int(nArgs["Number"]);
+  dist = (distance + distanceZ / sin(theta));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: Parameters for position"
-			       << "ing--" << " Eta " << eta << "\tPhi " 
-			       << convertRadToDeg(phi) << "\tTheta " 
-			       << convertRadToDeg(theta) << "\tDistance "
-			       << distance << "/" << distanceZ << "/"
-			       << dist <<"\tDz " << dz <<"\tcopyNumber "
-			       << copyNumber;
+                               << "ing--"
+                               << " Eta " << eta << "\tPhi " << convertRadToDeg(phi) << "\tTheta "
+                               << convertRadToDeg(theta) << "\tDistance " << distance << "/" << distanceZ << "/" << dist
+                               << "\tDz " << dz << "\tcopyNumber " << copyNumber;
 #endif
   idNameSpace = DDCurrentNamespace::ns();
-  childName   = sArgs["ChildName"]; 
+  childName = sArgs["ChildName"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo:Parent " 
-			       << parent().name() << "\tChild " << childName 
-			       << " NameSpace " << idNameSpace;
+  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo:Parent " << parent().name() << "\tChild " << childName
+                               << " NameSpace " << idNameSpace;
 #endif
 }
 
 void DDHCalTestBeamAlgo::execute(DDCompactView& cpv) {
-
   double thetax = 90._deg + theta;
-  double sthx   = sin(thetax);
-  if (std::abs(sthx)>1.e-12) sthx = 1./sthx;
-  else                       sthx = 1.;
-  double phix   = atan2(sthx*cos(theta)*sin(phi),sthx*cos(theta)*cos(phi));
+  double sthx = sin(thetax);
+  if (std::abs(sthx) > 1.e-12)
+    sthx = 1. / sthx;
+  else
+    sthx = 1.;
+  double phix = atan2(sthx * cos(theta) * sin(phi), sthx * cos(theta) * cos(phi));
   double thetay = 90._deg;
-  double phiy   = 90._deg + phi;
+  double phiy = 90._deg + phi;
   double thetaz = theta;
-  double phiz   = phi;
-  
+  double phiz = phi;
+
   DDRotation rotation;
   std::string rotstr = childName;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: Creating a rotation "
-			       << rotstr << "\t" << convertRadToDeg(thetax)
-			       << "," << convertRadToDeg(phix) << "," 
-			       << convertRadToDeg(thetay) << "," 
-			       << convertRadToDeg(phiy) << "," 
-			       << convertRadToDeg(thetaz) <<"," 
-			       << convertRadToDeg(phiz);
+  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: Creating a rotation " << rotstr << "\t"
+                               << convertRadToDeg(thetax) << "," << convertRadToDeg(phix) << ","
+                               << convertRadToDeg(thetay) << "," << convertRadToDeg(phiy) << ","
+                               << convertRadToDeg(thetaz) << "," << convertRadToDeg(phiz);
 #endif
-  rotation = DDrot(DDName(rotstr, idNameSpace), thetax, phix, thetay, phiy,
-		   thetaz, phiz);
-	
-  double r    = dist*sin(theta);
-  double xpos = r*cos(phi);
-  double ypos = r*sin(phi);
-  double zpos = dist*cos(theta);
-  DDTranslation tran(xpos, ypos, zpos);
-  
-  DDName parentName = parent().name(); 
-  cpv.position(DDName(childName,idNameSpace), parentName, copyNumber, tran,
-	       rotation);
-#ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: " 
-			       << DDName(childName, idNameSpace) << " number " 
-			       << copyNumber << " positioned in " << parentName
-			       << " at " << tran << " with " << rotation;
+  rotation = DDrot(DDName(rotstr, idNameSpace), thetax, phix, thetay, phiy, thetaz, phiz);
 
-  xpos = (dist-dz)*sin(theta)*cos(phi);
-  ypos = (dist-dz)*sin(theta)*sin(phi);
-  zpos = (dist-dz)*cos(theta);
+  double r = dist * sin(theta);
+  double xpos = r * cos(phi);
+  double ypos = r * sin(phi);
+  double zpos = dist * cos(theta);
+  DDTranslation tran(xpos, ypos, zpos);
+
+  DDName parentName = parent().name();
+  cpv.position(DDName(childName, idNameSpace), parentName, copyNumber, tran, rotation);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "DDHCalTestBeamAlgo: " << DDName(childName, idNameSpace) << " number " << copyNumber
+                               << " positioned in " << parentName << " at " << tran << " with " << rotation;
+
+  xpos = (dist - dz) * sin(theta) * cos(phi);
+  ypos = (dist - dz) * sin(theta) * sin(phi);
+  zpos = (dist - dz) * cos(theta);
 
   edm::LogInfo("HCalGeom") << "DDHCalTestBeamAlgo: Suggested Beam position "
-			   << "(" << xpos << ", " << ypos << ", " << zpos 
-			   << ") and (dist, eta, phi) = (" << (dist-dz) << ", "
-			   << eta << ", " << phi << ")";
+                           << "(" << xpos << ", " << ypos << ", " << zpos << ") and (dist, eta, phi) = (" << (dist - dz)
+                           << ", " << eta << ", " << phi << ")";
 #endif
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalTestBeamAlgo.h
@@ -8,32 +8,31 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalTestBeamAlgo : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDHCalTestBeamAlgo(); 
+  DDHCalTestBeamAlgo();
   ~DDHCalTestBeamAlgo() override;
-  
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
+  double eta;        //Eta at which beam is focussed
+  double phi;        //Phi    ................
+  double theta;      //Corresponding theta value
+  double distance;   //Distance of the centre of rotation
+  double distanceZ;  //Distance along x-axis of the centre of rotation
+  double dist;       //Overall distance
+  double dz;         //Half length along z of the volume to be placed
+  int copyNumber;    //Copy Number
 
-  double        eta;         //Eta at which beam is focussed
-  double        phi;         //Phi    ................
-  double        theta;       //Corresponding theta value
-  double        distance;    //Distance of the centre of rotation
-  double        distanceZ;   //Distance along x-axis of the centre of rotation
-  double        dist;        //Overall distance
-  double        dz;          //Half length along z of the volume to be placed
-  int           copyNumber;  //Copy Number
-
-  std::string   idNameSpace; //Namespace of this and ALL sub-parts
-  std::string   childName;   //Children name
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  std::string childName;    //Children name
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.cc
@@ -23,86 +23,74 @@ DDHCalXtalAlgo::DDHCalXtalAlgo() {
 
 DDHCalXtalAlgo::~DDHCalXtalAlgo() {}
 
-void DDHCalXtalAlgo::initialize(const DDNumericArguments & nArgs,
-				const DDVectorArguments & ,
-				const DDMapArguments & ,
-				const DDStringArguments & sArgs,
-				const DDStringVectorArguments & vsArgs) {
-
-  radius     = nArgs["Radius"];
-  offset     = nArgs["Offset"];
-  dx         = nArgs["Dx"];
-  dz         = nArgs["Dz"];
-  angwidth   = nArgs["AngWidth"];
-  iaxis      = int (nArgs["Axis"]);
-  names      = vsArgs["Names"];
+void DDHCalXtalAlgo::initialize(const DDNumericArguments& nArgs,
+                                const DDVectorArguments&,
+                                const DDMapArguments&,
+                                const DDStringArguments& sArgs,
+                                const DDStringVectorArguments& vsArgs) {
+  radius = nArgs["Radius"];
+  offset = nArgs["Offset"];
+  dx = nArgs["Dx"];
+  dz = nArgs["Dz"];
+  angwidth = nArgs["AngWidth"];
+  iaxis = int(nArgs["Axis"]);
+  names = vsArgs["Names"];
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo::Parameters for positioning:"
-			       << " Axis " << iaxis << "\tRadius " << radius 
-			       << "\tOffset " << offset << "\tDx " << dx
-			       << "\tDz " << dz << "\tAngWidth " 
-			       << convertRadToDeg(angwidth) << "\tNumbers "
-			       << names.size();
+                               << " Axis " << iaxis << "\tRadius " << radius << "\tOffset " << offset << "\tDx " << dx
+                               << "\tDz " << dz << "\tAngWidth " << convertRadToDeg(angwidth) << "\tNumbers "
+                               << names.size();
   for (unsigned int i = 0; i < names.size(); i++)
     edm::LogVerbatim("HCalGeom") << "\tnames[" << i << "] = " << names[i];
 #endif
   idNameSpace = DDCurrentNamespace::ns();
-  idName      = sArgs["ChildName"]; 
+  idName = sArgs["ChildName"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: Parent " << parent().name()
-			       << "\tChild " << idName << " NameSpace "
-			       << idNameSpace;
+  edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: Parent " << parent().name() << "\tChild " << idName << " NameSpace "
+                               << idNameSpace;
 #endif
 }
 
 void DDHCalXtalAlgo::execute(DDCompactView& cpv) {
-
   double theta[3], phi[3], pos[3];
   phi[0] = 0;
   phi[1] = 90._deg;
-  theta[1-iaxis] = 90._deg;
-  pos[1-iaxis]   = 0;
+  theta[1 - iaxis] = 90._deg;
+  pos[1 - iaxis] = 0;
   int number = (int)(names.size());
-  for (int i=0; i<number; i++) {
-    double angle = 0.5*angwidth*(2*i+1-number);
+  for (int i = 0; i < number; i++) {
+    double angle = 0.5 * angwidth * (2 * i + 1 - number);
     theta[iaxis] = 90._deg + angle;
-    if (angle>0) {
-      theta[2]   = angle;
-      phi[2]     = iaxis*90._deg;
+    if (angle > 0) {
+      theta[2] = angle;
+      phi[2] = iaxis * 90._deg;
     } else {
-      theta[2]   =-angle;
-      phi[2]     = (2-3*iaxis)*90._deg;
+      theta[2] = -angle;
+      phi[2] = (2 - 3 * iaxis) * 90._deg;
     }
-    pos[iaxis]   = angle*(dz+radius);
-    pos[2]       = dx*std::abs(sin(angle)) + offset;
-  
+    pos[iaxis] = angle * (dz + radius);
+    pos[2] = dx * std::abs(sin(angle)) + offset;
+
     DDRotation rotation;
     std::string rotstr = names[i];
     DDTranslation tran(pos[0], pos[1], pos[2]);
-    DDName parentName = parent().name(); 
+    DDName parentName = parent().name();
 
-    static const double tol = 0.01_deg; // 0.01 degree
+    static const double tol = 0.01_deg;  // 0.01 degree
     if (std::abs(angle) > tol) {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: Creating a rotation " 
-				   << rotstr << "\t" 
-				   << convertRadToDeg(theta[0]) << "," 
-				   << convertRadToDeg(phi[0]) << "," 
-				   << convertRadToDeg(theta[1]) << "," 
-				   << convertRadToDeg(phi[1]) << "," 
-				   << convertRadToDeg(theta[2]) << ","
-				   << convertRadToDeg(phi[2]);
+      edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: Creating a rotation " << rotstr << "\t"
+                                   << convertRadToDeg(theta[0]) << "," << convertRadToDeg(phi[0]) << ","
+                                   << convertRadToDeg(theta[1]) << "," << convertRadToDeg(phi[1]) << ","
+                                   << convertRadToDeg(theta[2]) << "," << convertRadToDeg(phi[2]);
 #endif
-      rotation = DDrot(DDName(rotstr, idNameSpace), theta[0], phi[0], theta[1],
-		       phi[1], theta[2], phi[2]);
+      rotation = DDrot(DDName(rotstr, idNameSpace), theta[0], phi[0], theta[1], phi[1], theta[2], phi[2]);
     }
-    cpv.position(DDName(idName, idNameSpace), parentName, i+1, tran, rotation);
+    cpv.position(DDName(idName, idNameSpace), parentName, i + 1, tran, rotation);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: "
-				 << DDName(idName,idNameSpace) << " number "
-				 << i+1 << " positioned in " << parentName
-				 << " at " << tran << " with " << rotation;
+    edm::LogVerbatim("HCalGeom") << "DDHCalXtalAlgo: " << DDName(idName, idNameSpace) << " number " << i + 1
+                                 << " positioned in " << parentName << " at " << tran << " with " << rotation;
 #endif
   }
 }

--- a/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.h
+++ b/Geometry/HcalAlgo/plugins/DDHCalXtalAlgo.h
@@ -8,31 +8,30 @@
 #include "DetectorDescription/Core/interface/DDAlgorithm.h"
 
 class DDHCalXtalAlgo : public DDAlgorithm {
- public:
+public:
   //Constructor and Destructor
-  DDHCalXtalAlgo(); 
+  DDHCalXtalAlgo();
   ~DDHCalXtalAlgo() override;
-  
-  void initialize(const DDNumericArguments & nArgs,
-		  const DDVectorArguments & vArgs,
-		  const DDMapArguments & mArgs,
-		  const DDStringArguments & sArgs,
-		  const DDStringVectorArguments & vsArgs) override;
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
 
   void execute(DDCompactView& cpv) override;
 
 private:
+  double radius;                   //Pointing distance from front surface
+  double offset;                   //Offset along Z
+  double dx;                       //Half size along x
+  double dz;                       //Half size along z
+  double angwidth;                 //Angular width
+  int iaxis;                       //Axis of rotation
+  std::vector<std::string> names;  //Names for rotation matrices
 
-  double                   radius;      //Pointing distance from front surface 
-  double                   offset;      //Offset along Z
-  double                   dx;          //Half size along x
-  double                   dz;          //Half size along z
-  double                   angwidth;    //Angular width
-  int                      iaxis;       //Axis of rotation
-  std::vector<std::string> names;       //Names for rotation matrices
-
-  std::string              idNameSpace; //Namespace of this and ALL sub-parts
-  std::string              idName;      //Children name
+  std::string idNameSpace;  //Namespace of this and ALL sub-parts
+  std::string idName;       //Children name
 };
 
 #endif

--- a/Geometry/HcalAlgo/plugins/module.cc
+++ b/Geometry/HcalAlgo/plugins/module.cc
@@ -14,14 +14,14 @@
 #include "DetectorDescription/Core/interface/DDAlgorithmFactory.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalAngular,      "hcal:DDHCalAngular");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalBarrelAlgo,   "hcal:DDHCalBarrelAlgo");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalEndcapAlgo,   "hcal:DDHCalEndcapAlgo");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalEndcapModuleAlgo,"hcal:DDHCalEndcapModuleAlgo");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalForwardAlgo,  "hcal:DDHCalForwardAlgo");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalFibreBundle,  "hcal:DDHCalFibreBundle");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalLinearXY,     "hcal:DDHCalLinearXY");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalTBCableAlgo,  "hcal:DDHCalTBCableAlgo");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalTBZposAlgo,   "hcal:DDHCalTBZposAlgo");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalTestBeamAlgo, "hcal:DDHCalTestBeamAlgo");
-DEFINE_EDM_PLUGIN (DDAlgorithmFactory, DDHCalXtalAlgo,     "hcal:DDHCalXtalAlgo");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalAngular, "hcal:DDHCalAngular");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalBarrelAlgo, "hcal:DDHCalBarrelAlgo");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalEndcapAlgo, "hcal:DDHCalEndcapAlgo");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalEndcapModuleAlgo, "hcal:DDHCalEndcapModuleAlgo");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalForwardAlgo, "hcal:DDHCalForwardAlgo");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalFibreBundle, "hcal:DDHCalFibreBundle");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalLinearXY, "hcal:DDHCalLinearXY");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalTBCableAlgo, "hcal:DDHCalTBCableAlgo");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalTBZposAlgo, "hcal:DDHCalTBZposAlgo");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalTestBeamAlgo, "hcal:DDHCalTestBeamAlgo");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHCalXtalAlgo, "hcal:DDHCalXtalAlgo");

--- a/Geometry/HcalCommonData/interface/HcalBadLaserChannels.h
+++ b/Geometry/HcalCommonData/interface/HcalBadLaserChannels.h
@@ -5,20 +5,21 @@
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 class HcalBadLaserChannels {
-
 public:
   HcalBadLaserChannels() {}
 
-  static int badChannelsHBHE () { return 72*3; }
-  static int badChannelsHF()    { return 0; }
+  static int badChannelsHBHE() { return 72 * 3; }
+  static int badChannelsHF() { return 0; }
   static bool badChannelHBHE(HcalDetId id) {
     bool isbad(false);
     // Three RBX's in HB do not receive any laser light (HBM5, HBM8, HBM9)
     // They correspond to iphi = 15:18, 27:30, 31:34 respectively and
     // ieta < 0
-    if (id.subdet()==HcalBarrel && id.ieta()<0) {
-      if      (id.iphi()>=15 && id.iphi()<=18) isbad = true;
-      else if (id.iphi()>=27 && id.iphi()<=34) isbad = true;
+    if (id.subdet() == HcalBarrel && id.ieta() < 0) {
+      if (id.iphi() >= 15 && id.iphi() <= 18)
+        isbad = true;
+      else if (id.iphi() >= 27 && id.iphi() <= 34)
+        isbad = true;
     }
     return isbad;
   }

--- a/Geometry/HcalCommonData/interface/HcalCellType.h
+++ b/Geometry/HcalCommonData/interface/HcalCellType.h
@@ -11,104 +11,112 @@
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
 class HcalCellType {
-
 public:
-
   struct HcalCell {
-    bool   ok;
+    bool ok;
     double eta, deta, phi, dphi, rz, drz;
-    bool   flagrz;
-    HcalCell(bool fl=false, double et=0, double det=0, double fi=0,
-             double dfi=0, double rzv=0, double drzv=0, bool frz=true) :
-      ok(fl), eta(et), deta(det), phi(fi), dphi(dfi), rz(rzv), drz(drzv),
-         flagrz(frz) {}
+    bool flagrz;
+    HcalCell(bool fl = false,
+             double et = 0,
+             double det = 0,
+             double fi = 0,
+             double dfi = 0,
+             double rzv = 0,
+             double drzv = 0,
+             bool frz = true)
+        : ok(fl), eta(et), deta(det), phi(fi), dphi(dfi), rz(rzv), drz(drzv), flagrz(frz) {}
   };
 
-  HcalCellType(HcalSubdetector detType, int etaBin, int zside,
-	       int depthSegment, const HcalCell& cell, int readoutDirection=0,
-	       double samplingFactor=0, double halfSize=0);
-  HcalCellType(const HcalCellType &right);
-  const HcalCellType& operator=(const HcalCellType &right);
+  HcalCellType(HcalSubdetector detType,
+               int etaBin,
+               int zside,
+               int depthSegment,
+               const HcalCell& cell,
+               int readoutDirection = 0,
+               double samplingFactor = 0,
+               double halfSize = 0);
+  HcalCellType(const HcalCellType& right);
+  const HcalCellType& operator=(const HcalCellType& right);
   ~HcalCellType();
 
   /// 1=HB, 2=HE, 3=HO, 4=HF (sub detector type)
   /// as in DataFormats/HcalDetId/interface/HcalSubdetector.h
-  HcalSubdetector detType() const {return theDetType;}
-                                                                               
+  HcalSubdetector detType() const { return theDetType; }
+
   /// which eta ring it belongs to, starting from one
-  int etaBin() const {return theEtaBin;}
-  int zside()  const {return theSide;}
+  int etaBin() const { return theEtaBin; }
+  int zside() const { return theSide; }
   void setEta(int bin, double etamin, double etamax);
-                                                                               
+
   /// which depth segment it is, starting from 1
   /// absolute within the tower, so HE depth of the
   /// overlap doesn't start at 1.
-  int depthSegment() const {return theDepthSegment;}
+  int depthSegment() const { return theDepthSegment; }
   void setDepth(int bin, double dmin, double dmax);
 
   /// the number of these cells in a ring
-  int nPhiBins() const {return (int)(thePhis.size());}
-  int nPhiModule() const {return static_cast<int>(20.*CLHEP::deg/thePhiBinWidth);}
-                                                                               
+  int nPhiBins() const { return (int)(thePhis.size()); }
+  int nPhiModule() const { return static_cast<int>(20. * CLHEP::deg / thePhiBinWidth); }
+
   /// phi bin width
-  double phiBinWidth() const {return thePhiBinWidth;}
-  double phiOffset() const {return thePhiOffset;}
-  int    unitPhi() const {return theUnitPhi;}
-  void   setPhi(const std::vector<std::pair<int,double>>& phis,
-		const std::vector<int>& iphiMiss, double foff, double dphi,
-		int unit);
-  void   setPhi(const std::vector<std::pair<int,double>>& phis) {thePhis = phis;}
-                                                                               
+  double phiBinWidth() const { return thePhiBinWidth; }
+  double phiOffset() const { return thePhiOffset; }
+  int unitPhi() const { return theUnitPhi; }
+  void setPhi(const std::vector<std::pair<int, double>>& phis,
+              const std::vector<int>& iphiMiss,
+              double foff,
+              double dphi,
+              int unit);
+  void setPhi(const std::vector<std::pair<int, double>>& phis) { thePhis = phis; }
+
   /// which cell will actually do the readout for this cell
   /// 1 means move hits in this cell up, and -1 means down
   /// 0 means do nothing
-  int actualReadoutDirection() const {return theActualReadoutDirection;}
-                                                                               
+  int actualReadoutDirection() const { return theActualReadoutDirection; }
+
   /// lower cell edge.  Always positive
-  double etaMin() const {return theEtaMin;}
-                                                                               
+  double etaMin() const { return theEtaMin; }
+
   /// cell edge, always positive & greater than etaMin
-  double etaMax() const {return theEtaMax;}
+  double etaMax() const { return theEtaMax; }
 
   /// Phi modules and the central phi values
-  std::vector<std::pair<int,double>> phis() const {return thePhis;}
+  std::vector<std::pair<int, double>> phis() const { return thePhis; }
 
   /// z or r position, depending on whether it's barrel or endcap
-  double depth() const {return (theDepthMin+theDepthMax)/2;}
-  double depthMin() const {return theDepthMin;}
-  double depthMax() const {return theDepthMax;}
-  bool   depthType() const {return theRzFlag;}
-  double halfSize() const {return theHalfSize;}
-                                                                               
+  double depth() const { return (theDepthMin + theDepthMax) / 2; }
+  double depthMin() const { return theDepthMin; }
+  double depthMax() const { return theDepthMax; }
+  bool depthType() const { return theRzFlag; }
+  double halfSize() const { return theHalfSize; }
+
   /// ratio of real particle energy to deposited energy in the SimHi
-  double samplingFactor() const {return theSamplingFactor;}
+  double samplingFactor() const { return theSamplingFactor; }
 
 protected:
- 
   HcalCellType();
-                                                                               
+
 private:
+  HcalSubdetector theDetType;
+  int theEtaBin;
+  int theSide;
+  int theDepthSegment;
+  int theUnitPhi;
+  int theActualReadoutDirection;
 
-  HcalSubdetector  theDetType;
-  int              theEtaBin;
-  int              theSide;
-  int              theDepthSegment;
-  int              theUnitPhi;
-  int              theActualReadoutDirection;
+  bool theRzFlag;
 
-  bool             theRzFlag;
-                                                                               
-  double           theEtaMin;
-  double           theEtaMax;
-  double           theDepthMin;
-  double           theDepthMax;
-  double           thePhiOffset;
-  double           thePhiBinWidth;
-  double           theHalfSize;
-  double           theSamplingFactor;
+  double theEtaMin;
+  double theEtaMax;
+  double theDepthMin;
+  double theDepthMax;
+  double thePhiOffset;
+  double thePhiBinWidth;
+  double theHalfSize;
+  double theSamplingFactor;
 
-  std::vector<std::pair<int,double> > thePhis;
+  std::vector<std::pair<int, double>> thePhis;
 };
-                                                                               
+
 std::ostream& operator<<(std::ostream&, const HcalCellType&);
 #endif

--- a/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDRecConstants.h
@@ -10,10 +10,10 @@
  *
  */
 
-#include<map>
-#include<string>
-#include<vector>
-#include<iostream>
+#include <map>
+#include <string>
+#include <vector>
+#include <iostream>
 
 #include "CondFormats/GeometryObjects/interface/HcalParameters.h"
 #include "Geometry/HcalCommonData/interface/HcalCellType.h"
@@ -21,146 +21,140 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 class HcalDDDRecConstants {
-
 public:
-
   HcalDDDRecConstants(const HcalParameters* hp, const HcalDDDSimConstants& hc);
   ~HcalDDDRecConstants();
 
   struct HcalID {
-    int    subdet, eta, phi, depth;
-    HcalID(int sub=0, int et=0, int fi=0, int d=0) : subdet(sub), eta(et),
-						     phi(fi), depth(d) {}
+    int subdet, eta, phi, depth;
+    HcalID(int sub = 0, int et = 0, int fi = 0, int d = 0) : subdet(sub), eta(et), phi(fi), depth(d) {}
   };
   struct HcalEtaBin {
-    int    ieta, zside, depthStart;
+    int ieta, zside, depthStart;
     double dphi, etaMin, etaMax;
-    std::vector<std::pair<int, int> > layer;
-    std::vector<std::pair<int,double> > phis;
-    HcalEtaBin(int eta=0, int zs=1, double dfi=0, double et1=0, 
-  	       double et2=0) : ieta(eta), zside(zs), depthStart(0), dphi(dfi), 
-                               etaMin(et1), etaMax(et2) {}
+    std::vector<std::pair<int, int>> layer;
+    std::vector<std::pair<int, double>> phis;
+    HcalEtaBin(int eta = 0, int zs = 1, double dfi = 0, double et1 = 0, double et2 = 0)
+        : ieta(eta), zside(zs), depthStart(0), dphi(dfi), etaMin(et1), etaMax(et2) {}
   };
   struct HcalActiveLength {
-    int    ieta, depth, zside, stype;
+    int ieta, depth, zside, stype;
     double eta, thick;
     std::vector<int> iphis;
-    HcalActiveLength(int ie=0, int d=0, int z=0, int s=0, double et=0, 
-		     double t=0) : ieta(ie), depth(d), zside(z), stype(s),
-                                   eta(et), thick(t) {}
+    HcalActiveLength(int ie = 0, int d = 0, int z = 0, int s = 0, double et = 0, double t = 0)
+        : ieta(ie), depth(d), zside(z), stype(s), eta(et), thick(t) {}
   };
   struct HFCellParameters {
-    int    ieta, depth, firstPhi, stepPhi, nPhi;
+    int ieta, depth, firstPhi, stepPhi, nPhi;
     double rMin, rMax;
-    HFCellParameters(int ie=0, int d=1, int ffi=1, int sfi=2, int nfi=36,
-		     double r1=0, double r2=0) : ieta(ie), depth(d), 
-                                                 firstPhi(ffi), stepPhi(sfi),
-                                                 nPhi(nfi), rMin(r1), rMax(r2) {}
+    HFCellParameters(int ie = 0, int d = 1, int ffi = 1, int sfi = 2, int nfi = 36, double r1 = 0, double r2 = 0)
+        : ieta(ie), depth(d), firstPhi(ffi), stepPhi(sfi), nPhi(nfi), rMin(r1), rMax(r2) {}
   };
 
-  std::vector<std::pair<double,double> > getConstHBHE(const int& type) const {
-    if      (type == 0) return gconsHB;
-    else if (type == 1) return gconsHE;
-    else {std::vector<std::pair<double,double> > gcons; return gcons;}
+  std::vector<std::pair<double, double>> getConstHBHE(const int& type) const {
+    if (type == 0)
+      return gconsHB;
+    else if (type == 1)
+      return gconsHE;
+    else {
+      std::vector<std::pair<double, double>> gcons;
+      return gcons;
+    }
   }
-  std::vector<int>          getDepth(const int& det, const int& phi, 
-				     const int& zside, const unsigned int& eta) const;
-  std::vector<int>          getDepth(const unsigned int& eta, const bool& extra) const;
-  int                       getDepthEta16(const int& det, const int& iphi, 
-					  const int& zside) const {return hcons.getDepthEta16(det,iphi,zside);}
-  int                       getDepthEta29(const int& iphi, const int& zside, 
-					  const int& type) const {return hcons.getDepthEta29(iphi,zside,type);}
-  std::vector<HcalEtaBin>   getEtaBins(const int& itype) const;
-  std::pair<double,double>  getEtaPhi(const int& subdet, const int& ieta, const int& iphi) const;
-  std::pair<int,int>        getEtaRange(const int& i) const
-    {return std::pair<int,int>(iEtaMin[i],iEtaMax[i]);}
-  const std::vector<double> &      getEtaTable()   const {return etaTable;}
-  const std::vector<double> &      getEtaTableHF() const {return hpar->etaTableHF;}
-  std::pair<double,double>  getEtaLimit(const int& i) const 
-    {return std::pair<double,double>(etaTable[i],etaTable[i+1]);}
-  HcalID                    getHCID(int subdet, int ieta, int iphi, int lay, int idepth) const;
-  std::vector<HFCellParameters>    getHFCellParameters() const;
-  void                      getLayerDepth(const int& ieta, std::map<int,int>& layers) const;
-  int                       getLayerBack(const int& det, const int& eta, const int& phi,
-					 const int& depth) const;
-  int                       getLayerFront(const int& det, const int& eta, const int& phi,
-					  const int& depth) const;
-  double                    getLayer0Wt(const int& det, const int& phi,
-					const int& zside) const {return hcons.getLayer0Wt(det,phi,zside);}
-  int                       getMaxDepth(const int& type) const {return maxDepth[type];}
-  int                       getMaxDepth(const int& itype, const int& ieta,
-					const int& iphi,  const int& zside) const;
-  int                       getMinDepth(const int& itype, const int& ieta,
-					const int& iphi,  const int& zside) const;
-  int                       getNEta() const {return hpar->etagroup.size();}
-  int                       getNoff(const int& i) const {return hpar->noff[i];}
-  int                       getNPhi(const int& type) const {return nPhiBins[type];}
-  double                    getPhiBin(const int& i) const {return phibin[i];}
-  double                    getPhiOff(const int& i) const {return hpar->phioff[i];}
-  const std::vector<double> &      getPhiOffs()    const {return hpar->phioff;}
-  std::vector<std::pair<int,double> > getPhis(const int& subdet, const int& ieta) const;
-  const std::vector<double> &      getPhiTable()   const {return phibin;}
-  const std::vector<double> &      getPhiTableHF() const {return hpar->phitable;}
-  int                       getPhiZOne(std::vector<std::pair<int,int> >& phiz) const;
-  double                    getRZ(const int& subdet, const int& ieta, const int& depth) const;
-  double                    getRZ(const int& subdet, const int& ieta, const int& iphi,
-				  const int& depth) const;
-  double                    getRZ(const int& subdet, const int& layer) const;
-  std::pair<double,double>  getRZ(const HcalDetId& id) const;
-  std::vector<HcalActiveLength>    getThickActive(const int& type) const;
-  int                       getTopoMode() const {return ((hpar->topologyMode)&0xFF);}
-  int                       getTriggerMode() const {return (((hpar->topologyMode)>>8)&0xFF);}
+  std::vector<int> getDepth(const int& det, const int& phi, const int& zside, const unsigned int& eta) const;
+  std::vector<int> getDepth(const unsigned int& eta, const bool& extra) const;
+  int getDepthEta16(const int& det, const int& iphi, const int& zside) const {
+    return hcons.getDepthEta16(det, iphi, zside);
+  }
+  int getDepthEta29(const int& iphi, const int& zside, const int& type) const {
+    return hcons.getDepthEta29(iphi, zside, type);
+  }
+  std::vector<HcalEtaBin> getEtaBins(const int& itype) const;
+  std::pair<double, double> getEtaPhi(const int& subdet, const int& ieta, const int& iphi) const;
+  std::pair<int, int> getEtaRange(const int& i) const { return std::pair<int, int>(iEtaMin[i], iEtaMax[i]); }
+  const std::vector<double>& getEtaTable() const { return etaTable; }
+  const std::vector<double>& getEtaTableHF() const { return hpar->etaTableHF; }
+  std::pair<double, double> getEtaLimit(const int& i) const {
+    return std::pair<double, double>(etaTable[i], etaTable[i + 1]);
+  }
+  HcalID getHCID(int subdet, int ieta, int iphi, int lay, int idepth) const;
+  std::vector<HFCellParameters> getHFCellParameters() const;
+  void getLayerDepth(const int& ieta, std::map<int, int>& layers) const;
+  int getLayerBack(const int& det, const int& eta, const int& phi, const int& depth) const;
+  int getLayerFront(const int& det, const int& eta, const int& phi, const int& depth) const;
+  double getLayer0Wt(const int& det, const int& phi, const int& zside) const {
+    return hcons.getLayer0Wt(det, phi, zside);
+  }
+  int getMaxDepth(const int& type) const { return maxDepth[type]; }
+  int getMaxDepth(const int& itype, const int& ieta, const int& iphi, const int& zside) const;
+  int getMinDepth(const int& itype, const int& ieta, const int& iphi, const int& zside) const;
+  int getNEta() const { return hpar->etagroup.size(); }
+  int getNoff(const int& i) const { return hpar->noff[i]; }
+  int getNPhi(const int& type) const { return nPhiBins[type]; }
+  double getPhiBin(const int& i) const { return phibin[i]; }
+  double getPhiOff(const int& i) const { return hpar->phioff[i]; }
+  const std::vector<double>& getPhiOffs() const { return hpar->phioff; }
+  std::vector<std::pair<int, double>> getPhis(const int& subdet, const int& ieta) const;
+  const std::vector<double>& getPhiTable() const { return phibin; }
+  const std::vector<double>& getPhiTableHF() const { return hpar->phitable; }
+  int getPhiZOne(std::vector<std::pair<int, int>>& phiz) const;
+  double getRZ(const int& subdet, const int& ieta, const int& depth) const;
+  double getRZ(const int& subdet, const int& ieta, const int& iphi, const int& depth) const;
+  double getRZ(const int& subdet, const int& layer) const;
+  std::pair<double, double> getRZ(const HcalDetId& id) const;
+  std::vector<HcalActiveLength> getThickActive(const int& type) const;
+  int getTopoMode() const { return ((hpar->topologyMode) & 0xFF); }
+  int getTriggerMode() const { return (((hpar->topologyMode) >> 8) & 0xFF); }
   std::vector<HcalCellType> HcalCellTypes(HcalSubdetector) const;
-  bool                      isBH() const {return hcons.isBH();}
-  bool                      isPlan1(const HcalDetId& id) const { return detIdSp_.find(id) != detIdSp_.end(); };
-  int                       maxHFDepth(int ieta, int iphi) const {return hcons.maxHFDepth(ieta,iphi);}
-  bool                      mergedDepthList29(int ieta, int iphi, int depth) const;
-  std::vector<int>          mergedDepthList29(int ieta, int iphi) const;
-  unsigned int              numberOfCells(HcalSubdetector) const;
-  unsigned int              nCells(HcalSubdetector) const;
-  unsigned int              nCells() const;
-  HcalDetId                 mergedDepthDetId(const HcalDetId& id) const;
-  HcalDetId                 idFront(const HcalDetId& id) const;
-  HcalDetId                 idBack (const HcalDetId& id) const;
-  void                      unmergeDepthDetId(const HcalDetId& id,
-					      std::vector<HcalDetId>& ids) const;
-  void                      specialRBXHBHE(const std::vector<HcalDetId>&,
-					   std::vector<HcalDetId> &) const;
-  bool                      specialRBXHBHE(bool flag,
-					   std::vector<HcalDetId> &) const;
-  bool                      withSpecialRBXHBHE() const {return (hcons.ldMap()->getSubdet() != 0);}
-  bool                      isPlan1ToBeMergedId(const HcalDetId& id) const { return detIdSp_.find(id) != detIdSp_.end(); };
-  bool                      isPlan1MergedId(const HcalDetId& id) const { return detIdSpR_.find(id) != detIdSpR_.end(); };
-  const HcalDDDSimConstants* dddConstants() const {return &hcons;}
-       
+  bool isBH() const { return hcons.isBH(); }
+  bool isPlan1(const HcalDetId& id) const { return detIdSp_.find(id) != detIdSp_.end(); };
+  int maxHFDepth(int ieta, int iphi) const { return hcons.maxHFDepth(ieta, iphi); }
+  bool mergedDepthList29(int ieta, int iphi, int depth) const;
+  std::vector<int> mergedDepthList29(int ieta, int iphi) const;
+  unsigned int numberOfCells(HcalSubdetector) const;
+  unsigned int nCells(HcalSubdetector) const;
+  unsigned int nCells() const;
+  HcalDetId mergedDepthDetId(const HcalDetId& id) const;
+  HcalDetId idFront(const HcalDetId& id) const;
+  HcalDetId idBack(const HcalDetId& id) const;
+  void unmergeDepthDetId(const HcalDetId& id, std::vector<HcalDetId>& ids) const;
+  void specialRBXHBHE(const std::vector<HcalDetId>&, std::vector<HcalDetId>&) const;
+  bool specialRBXHBHE(bool flag, std::vector<HcalDetId>&) const;
+  bool withSpecialRBXHBHE() const { return (hcons.ldMap()->getSubdet() != 0); }
+  bool isPlan1ToBeMergedId(const HcalDetId& id) const { return detIdSp_.find(id) != detIdSp_.end(); };
+  bool isPlan1MergedId(const HcalDetId& id) const { return detIdSpR_.find(id) != detIdSpR_.end(); };
+  const HcalDDDSimConstants* dddConstants() const { return &hcons; }
+
 private:
+  void getOneEtaBin(HcalSubdetector subdet,
+                    int ieta,
+                    int zside,
+                    std::vector<std::pair<int, double>>& phis,
+                    std::map<int, int>& layers,
+                    bool planOne,
+                    std::vector<HcalDDDRecConstants::HcalEtaBin>& bins) const;
+  void initialize(void);
+  unsigned int layerGroupSize(int eta) const;
+  unsigned int layerGroup(int eta, int i) const;
 
-  void                      getOneEtaBin(HcalSubdetector subdet, int ieta, int zside,
-					 std::vector<std::pair<int,double>>& phis,
-					 std::map<int,int>& layers, bool planOne,
-					 std::vector<HcalDDDRecConstants::HcalEtaBin>& bins) const;
-  void                      initialize(void);
-  unsigned int              layerGroupSize(int eta) const;
-  unsigned int              layerGroup(int eta, int i) const;
-
-  static const int           maxLayer_=18;
-  static const int           maxLayerHB_=16;
-  const HcalParameters      *hpar;
-  const HcalDDDSimConstants &hcons;
-  std::vector<std::pair<int,int> > etaSimValu; // eta ranges at Sim stage
-  std::vector<double> etaTable;   // Eta table (HB+HE)
-  std::vector<int>    ietaMap;    // Map Sim level ieta to Rec level ieta
-  std::vector<int>    iEtaMin, iEtaMax; // Minimum and maximum eta
-  std::vector<int>    maxDepth;   // Maximum depth in HB/HE/HF/HO 
-  std::vector<int>    nPhiBins;   // Number of phi bis for HB/HE/HF/HO
-  std::vector<double> phibin;     // Phi step for all eta bins (HB, HE, HO)
-  std::vector<int>    phiUnitS;   // Phi unit at SIM stage
-  std::vector<std::pair<double,double> > gconsHB; // Geometry constatnts HB
-  std::vector<std::pair<double,double> > gconsHE; // Geometry constatnts HE
-  int                 nModule[2], nHalves[2];     // Modules, Halves for HB/HE
-  std::pair<int,int>  depthMaxDf_, depthMaxSp_; // (subdet,maximum depth) default,special
-  std::map<HcalDetId,HcalDetId> detIdSp_;       // Map of Id's for special RBX
-  std::map<HcalDetId,std::vector<HcalDetId>> detIdSpR_; // Reverse map for RBX
+  static const int maxLayer_ = 18;
+  static const int maxLayerHB_ = 16;
+  const HcalParameters* hpar;
+  const HcalDDDSimConstants& hcons;
+  std::vector<std::pair<int, int>> etaSimValu;            // eta ranges at Sim stage
+  std::vector<double> etaTable;                           // Eta table (HB+HE)
+  std::vector<int> ietaMap;                               // Map Sim level ieta to Rec level ieta
+  std::vector<int> iEtaMin, iEtaMax;                      // Minimum and maximum eta
+  std::vector<int> maxDepth;                              // Maximum depth in HB/HE/HF/HO
+  std::vector<int> nPhiBins;                              // Number of phi bis for HB/HE/HF/HO
+  std::vector<double> phibin;                             // Phi step for all eta bins (HB, HE, HO)
+  std::vector<int> phiUnitS;                              // Phi unit at SIM stage
+  std::vector<std::pair<double, double>> gconsHB;         // Geometry constatnts HB
+  std::vector<std::pair<double, double>> gconsHE;         // Geometry constatnts HE
+  int nModule[2], nHalves[2];                             // Modules, Halves for HB/HE
+  std::pair<int, int> depthMaxDf_, depthMaxSp_;           // (subdet,maximum depth) default,special
+  std::map<HcalDetId, HcalDetId> detIdSp_;                // Map of Id's for special RBX
+  std::map<HcalDetId, std::vector<HcalDetId>> detIdSpR_;  // Reverse map for RBX
 };
 
 #endif

--- a/Geometry/HcalCommonData/interface/HcalDDDSimConstants.h
+++ b/Geometry/HcalCommonData/interface/HcalDDDSimConstants.h
@@ -10,10 +10,10 @@
  *
  */
 
-#include<string>
-#include<vector>
-#include<iostream>
-#include<iomanip>
+#include <string>
+#include <vector>
+#include <iostream>
+#include <iomanip>
 
 #include "CondFormats/GeometryObjects/interface/HcalParameters.h"
 #include "Geometry/HcalCommonData/interface/HcalCellType.h"
@@ -22,117 +22,95 @@
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 
 class HcalDDDSimConstants {
-
 public:
-
   HcalDDDSimConstants(const HcalParameters* hp);
   ~HcalDDDSimConstants();
 
-  HcalCellType::HcalCell    cell(const int& det,  const int& zside, const int& depth,
-				 const int& etaR, const int& iphi) const;
-  int                       findDepth(const int& det,   const int& eta, const int& phi,
-				      const int& zside, const int& lay) const;
-  unsigned int              findLayer(const int& layer, const std::vector<HcalParameters::LayerItem>& layerGroup) const;
-  std::vector<std::pair<double,double> > getConstHBHE(const int& type) const;
-  int                       getDepthEta16(const int& det, const int& phi, 
-					  const int& zside) const;
-  int                       getDepthEta16M(const int& det) const;
-  int                       getDepthEta29(const int& phi, const int& zside, const int& i) const;
-  int                       getDepthEta29M(const int& i, const bool& planOne) const;
-  std::pair<int,double>     getDetEta(const double& eta, const int& depth) const;
-  int                       getEta(const int& det, const int& lay, const double& hetaR) const;
-  std::pair<int,int>        getEtaDepth(const int& det, int etaR, 
-					const int& phi,	const int& zside, 
-					int depth, const int& lay) const;
-  double                    getEtaHO(const double& etaR, const double& x, 
-				     const double& y, const double& z) const;
-  std::pair<int,int>        getiEtaRange(const int& i) const {return std::pair<int,int>(hpar->etaMin[i],hpar->etaMax[i]);}
-  const std::vector<double> &  getEtaTableHF() const {return hpar->etaTableHF;}
-  const std::vector<double> &  getGparHF() const {return hpar->gparHF;}
-  const std::vector<HcalDetId> & getIdHF2QIE() const {return idHF2QIE;}
-  double                    getLayer0Wt(const int& det, const int& phi, 
-					const int& zside) const;
-  int                       getFrontLayer(const int& det, const int& eta) const;
-  int                       getLastLayer(const int& det, const int& eta) const;
-  int                       getLayerFront(const int& det, const int& eta, 
-					  const int& phi, const int& zside,
-					  const int& depth) const;
-  int                       getLayerBack(const int& det, const int& eta, 
-					 const int& phi, const int& zside,
-					 const int& depth) const;
-  int                       getLayerMax(const int& eta, const int& depth) const;
-  int                       getMaxDepth(const int& type) const {return maxDepth[type];}
-  int                       getMaxDepth(const int& det, const int& eta, 
-					const int& phi, const int& zside,
-					const bool& partialOnly) const;
-  std::pair<int,int>        getMaxDepthDet(const int& i) const {return ((i==1) ? depthMaxDf_ : depthMaxSp_);}
-  int                       getMinDepth(const int& det, const int& eta, 
-					const int& phi, const int& zside,
-					const bool& partialOnly) const;
-  std::pair<int,int>        getModHalfHBHE(const int& type) const;
-  std::pair<double,double>  getPhiCons(const int& det, const int& ieta) const;
-  std::vector<std::pair<int,double> > getPhis(const int& subdet, const int& ieta) const;
-  const std::vector<double> &  getPhiTableHF() const {return hpar->phitable;}
-  const std::vector<double> &  getRTableHF()   const {return hpar->rTable;}
-  std::vector<HcalCellType> HcalCellTypes()    const;
-  std::vector<HcalCellType> HcalCellTypes(const HcalSubdetector&, int ieta=-1,
-					  int depth=-1) const;
-  bool                      isBH() const {return isBH_;}
-  const HcalLayerDepthMap*  ldMap() const {return &ldmap_;}
-  int                       maxHFDepth(const int& ieta, const int& iphi) const;
-  unsigned int              numberOfCells(const HcalSubdetector&) const;
-  int                       phiNumber(const int& phi, const int& unit) const;
-  void                      printTiles() const;
-  int                       unitPhi(const int& det, const int& etaR) const;
-  int                       unitPhi(const double& dphi) const; 
-       
+  HcalCellType::HcalCell cell(
+      const int& det, const int& zside, const int& depth, const int& etaR, const int& iphi) const;
+  int findDepth(const int& det, const int& eta, const int& phi, const int& zside, const int& lay) const;
+  unsigned int findLayer(const int& layer, const std::vector<HcalParameters::LayerItem>& layerGroup) const;
+  std::vector<std::pair<double, double> > getConstHBHE(const int& type) const;
+  int getDepthEta16(const int& det, const int& phi, const int& zside) const;
+  int getDepthEta16M(const int& det) const;
+  int getDepthEta29(const int& phi, const int& zside, const int& i) const;
+  int getDepthEta29M(const int& i, const bool& planOne) const;
+  std::pair<int, double> getDetEta(const double& eta, const int& depth) const;
+  int getEta(const int& det, const int& lay, const double& hetaR) const;
+  std::pair<int, int> getEtaDepth(
+      const int& det, int etaR, const int& phi, const int& zside, int depth, const int& lay) const;
+  double getEtaHO(const double& etaR, const double& x, const double& y, const double& z) const;
+  std::pair<int, int> getiEtaRange(const int& i) const { return std::pair<int, int>(hpar->etaMin[i], hpar->etaMax[i]); }
+  const std::vector<double>& getEtaTableHF() const { return hpar->etaTableHF; }
+  const std::vector<double>& getGparHF() const { return hpar->gparHF; }
+  const std::vector<HcalDetId>& getIdHF2QIE() const { return idHF2QIE; }
+  double getLayer0Wt(const int& det, const int& phi, const int& zside) const;
+  int getFrontLayer(const int& det, const int& eta) const;
+  int getLastLayer(const int& det, const int& eta) const;
+  int getLayerFront(const int& det, const int& eta, const int& phi, const int& zside, const int& depth) const;
+  int getLayerBack(const int& det, const int& eta, const int& phi, const int& zside, const int& depth) const;
+  int getLayerMax(const int& eta, const int& depth) const;
+  int getMaxDepth(const int& type) const { return maxDepth[type]; }
+  int getMaxDepth(const int& det, const int& eta, const int& phi, const int& zside, const bool& partialOnly) const;
+  std::pair<int, int> getMaxDepthDet(const int& i) const { return ((i == 1) ? depthMaxDf_ : depthMaxSp_); }
+  int getMinDepth(const int& det, const int& eta, const int& phi, const int& zside, const bool& partialOnly) const;
+  std::pair<int, int> getModHalfHBHE(const int& type) const;
+  std::pair<double, double> getPhiCons(const int& det, const int& ieta) const;
+  std::vector<std::pair<int, double> > getPhis(const int& subdet, const int& ieta) const;
+  const std::vector<double>& getPhiTableHF() const { return hpar->phitable; }
+  const std::vector<double>& getRTableHF() const { return hpar->rTable; }
+  std::vector<HcalCellType> HcalCellTypes() const;
+  std::vector<HcalCellType> HcalCellTypes(const HcalSubdetector&, int ieta = -1, int depth = -1) const;
+  bool isBH() const { return isBH_; }
+  const HcalLayerDepthMap* ldMap() const { return &ldmap_; }
+  int maxHFDepth(const int& ieta, const int& iphi) const;
+  unsigned int numberOfCells(const HcalSubdetector&) const;
+  int phiNumber(const int& phi, const int& unit) const;
+  void printTiles() const;
+  int unitPhi(const int& det, const int& etaR) const;
+  int unitPhi(const double& dphi) const;
+
 private:
+  static const int nDepthMax = 9;
+  static const int maxLayer_ = 18;
+  static const int maxLayerHB_ = 16;
 
-  static const int          nDepthMax=9;
-  static const int          maxLayer_=18;
-  static const int          maxLayerHB_=16;
-
-  void                      initialize();
-  double                    deltaEta(const int& det, const int& eta, const int& depth) const;
-  double                    getEta(const int& det, const int& etaR,
-				   const int& zside, int depth=1) const;
-  double                    getEta(const double& r, const double& z) const;
-  int                       getShift(const HcalSubdetector& subdet, const int& depth) const;
-  double                    getGain (const HcalSubdetector& subdet, const int& depth) const;
-  void                      printTileHB(const int& eta,   const int& phi,
-					const int& zside, const int& depth) const;
-  void                      printTileHE(const int& eta,   const int& phi, 
-					const int& zside, const int& depth) const;
-  unsigned int              layerGroupSize(int eta) const;
-  unsigned int              layerGroup(int eta, int i) const;
-  unsigned int              layerGroup(int det, int eta,
-				       int phi, int zside,
-				       int i) const;
+  void initialize();
+  double deltaEta(const int& det, const int& eta, const int& depth) const;
+  double getEta(const int& det, const int& etaR, const int& zside, int depth = 1) const;
+  double getEta(const double& r, const double& z) const;
+  int getShift(const HcalSubdetector& subdet, const int& depth) const;
+  double getGain(const HcalSubdetector& subdet, const int& depth) const;
+  void printTileHB(const int& eta, const int& phi, const int& zside, const int& depth) const;
+  void printTileHE(const int& eta, const int& phi, const int& zside, const int& depth) const;
+  unsigned int layerGroupSize(int eta) const;
+  unsigned int layerGroup(int eta, int i) const;
+  unsigned int layerGroup(int det, int eta, int phi, int zside, int i) const;
 
   const HcalParameters* hpar;
-  HcalLayerDepthMap     ldmap_;
+  HcalLayerDepthMap ldmap_;
 
-  std::vector<int>    maxDepth; // Maximum depths in HB/HE/HF/HO
-  int                 nEta;     // Number of bins in eta for HB and HE
-  int                 nR;       // Number of bins in r
-  int                 nPhiF;    // Number of bins in phitable
-  std::vector<int>    depths[nDepthMax];   // Maximum layer number for a depth 
-  int                 nDepth;   // Number of bins in depth0
-  int                 nzHB, nmodHB;     // Number of halves and modules in HB
-  int                 nzHE, nmodHE;     // Number of halves and modules in HE
-  double              etaHO[4], rminHO; // eta in HO ring boundaries
-  double              zVcal;    // Z-position  of the front of HF
-  double              dzVcal;   // Half length of the HF
-  double              dlShort;  // Diference of length between long and short
-  int                 depthEta16[2]; // depth index of ieta=16 for HBmax, HEMin
-  int                 depthEta29[2]; // maximum depth index for ieta=29
-  int                 layFHB[2]; // first layers in HB (normal, special 16)
-  int                 layFHE[3]; // first layers in HE (normal, special 16, 18)
-  int                 layBHB[3]; // last layers in HB (normal, special 15, 16)
-  int                 layBHE[4]; // last layers in HE (normal, special 16, 17, 18)
-  bool                isBH_;         // if HE is BH
-  std::vector<HcalDetId> idHF2QIE;   // DetId's of HF modules with 2 QIE's
-  std::pair<int,int>  depthMaxDf_, depthMaxSp_; // (subdet,maximum depth) default,special
+  std::vector<int> maxDepth;                     // Maximum depths in HB/HE/HF/HO
+  int nEta;                                      // Number of bins in eta for HB and HE
+  int nR;                                        // Number of bins in r
+  int nPhiF;                                     // Number of bins in phitable
+  std::vector<int> depths[nDepthMax];            // Maximum layer number for a depth
+  int nDepth;                                    // Number of bins in depth0
+  int nzHB, nmodHB;                              // Number of halves and modules in HB
+  int nzHE, nmodHE;                              // Number of halves and modules in HE
+  double etaHO[4], rminHO;                       // eta in HO ring boundaries
+  double zVcal;                                  // Z-position  of the front of HF
+  double dzVcal;                                 // Half length of the HF
+  double dlShort;                                // Diference of length between long and short
+  int depthEta16[2];                             // depth index of ieta=16 for HBmax, HEMin
+  int depthEta29[2];                             // maximum depth index for ieta=29
+  int layFHB[2];                                 // first layers in HB (normal, special 16)
+  int layFHE[3];                                 // first layers in HE (normal, special 16, 18)
+  int layBHB[3];                                 // last layers in HB (normal, special 15, 16)
+  int layBHE[4];                                 // last layers in HE (normal, special 16, 17, 18)
+  bool isBH_;                                    // if HE is BH
+  std::vector<HcalDetId> idHF2QIE;               // DetId's of HF modules with 2 QIE's
+  std::pair<int, int> depthMaxDf_, depthMaxSp_;  // (subdet,maximum depth) default,special
 };
 
 #endif

--- a/Geometry/HcalCommonData/interface/HcalGeomParameters.h
+++ b/Geometry/HcalCommonData/interface/HcalGeomParameters.h
@@ -11,41 +11,38 @@
  *
  */
 
-#include<string>
-#include<vector>
-#include<iostream>
+#include <string>
+#include <vector>
+#include <iostream>
 
 #include "DetectorDescription/Core/interface/DDsvalues.h"
 #include "Geometry/HcalCommonData/interface/HcalCellType.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
-class DDCompactView;    
+class DDCompactView;
 class DDFilteredView;
 class HcalParameters;
 
 class HcalGeomParameters {
-
 public:
-
   HcalGeomParameters();
   ~HcalGeomParameters();
 
-  double              getConstDzHF()   const {return dzVcal;}
-  void                getConstRHO( std::vector<double> & ) const;
-  std::vector<int>    getModHalfHBHE(const int type) const;
-  void                loadGeometry(const DDFilteredView& _fv, 
-				   HcalParameters& php);
+  double getConstDzHF() const { return dzVcal; }
+  void getConstRHO(std::vector<double>&) const;
+  std::vector<int> getModHalfHBHE(const int type) const;
+  void loadGeometry(const DDFilteredView& _fv, HcalParameters& php);
 
 private:
-  unsigned            find (int element, std::vector<int>& array) const;
-  double              getEta (double r, double z) const;
+  unsigned find(int element, std::vector<int>& array) const;
+  double getEta(double r, double z) const;
 
-  int                 nzHB, nmodHB;     // Number of halves and modules in HB
-  int                 nzHE, nmodHE;     // Number of halves and modules in HE
-  double              etaHO[4], rminHO; // eta in HO ring boundaries
-  double              zVcal;    // Z-position  of the front of HF
-  double              dzVcal;   // Half length of the HF
-  double              dlShort;  // Diference of length between long and short
+  int nzHB, nmodHB;         // Number of halves and modules in HB
+  int nzHE, nmodHE;         // Number of halves and modules in HE
+  double etaHO[4], rminHO;  // eta in HO ring boundaries
+  double zVcal;             // Z-position  of the front of HF
+  double dzVcal;            // Half length of the HF
+  double dlShort;           // Diference of length between long and short
 };
 
 #endif

--- a/Geometry/HcalCommonData/interface/HcalHitRelabeller.h
+++ b/Geometry/HcalCommonData/interface/HcalHitRelabeller.h
@@ -9,16 +9,16 @@
 
 class HcalHitRelabeller {
 public:
-  HcalHitRelabeller(bool nd=false);
-  void process(std::vector<PCaloHit> & hcalHits);
-  void setGeometry(const HcalDDDRecConstants *&);
+  HcalHitRelabeller(bool nd = false);
+  void process(std::vector<PCaloHit>& hcalHits);
+  void setGeometry(const HcalDDDRecConstants*&);
   DetId relabel(const uint32_t testId) const;
-  static DetId relabel(const uint32_t testId, const HcalDDDRecConstants * theRecNumber);
+  static DetId relabel(const uint32_t testId, const HcalDDDRecConstants* theRecNumber);
 
 private:
   double energyWt(const uint32_t testId) const;
 
   const HcalDDDRecConstants* theRecNumber;
-  bool                       neutralDensity_;
+  bool neutralDensity_;
 };
 #endif

--- a/Geometry/HcalCommonData/interface/HcalLayerDepthMap.h
+++ b/Geometry/HcalCommonData/interface/HcalLayerDepthMap.h
@@ -9,61 +9,59 @@
  *
  */
 
-#include<iostream>
-#include<iomanip>
-#include<map>
-#include<string>
-#include<vector>
+#include <iostream>
+#include <iomanip>
+#include <map>
+#include <string>
+#include <vector>
 
 class HcalLayerDepthMap {
-
 public:
-
   HcalLayerDepthMap();
   ~HcalLayerDepthMap();
-  void initialize(const int subdet, const int ietaMax, const int dep16C, 
-		  const int dep29C, const double wtl0C,
-		  std::vector<int> const& iphi, std::vector<int> const& ieta,
-		  std::vector<int> const& layer,std::vector<int> const& depth);
-  int    getSubdet() const {return subdet_;}
-  int    getDepth(const int subdet, const int ieta, const int iphi, 
-		  const int zside, const int layer) const;
-  int    getDepth16(const int subdet, const int iphi, const int zside) const;
-  int    getDepthMin(const int subdet, const int iphi, const int zside) const;
-  int    getDepthMax(const int subdet, const int iphi, const int zside) const;
-  int    getDepthMax(const int subdet, const int ieta, const int iphi, 
-		     const int zside) const;
-  std::pair<int,int> getDepths(const int eta) const;
-  int    getLayerFront(const int subdet, const int ieta, const int iphi,
-		       const int zside, const int depth) const;
-  int    getLayerBack(const int subdet, const int ieta, const int iphi,
-		      const int zside, const int depth) const;
-  void   getLayerDepth(const int subdet, const int ieta, const int iphi,
-		       const int zside, std::map<int,int>& layers) const;
-  void   getLayerDepth(const int ieta, std::map<int,int>& layers) const;
+  void initialize(const int subdet,
+                  const int ietaMax,
+                  const int dep16C,
+                  const int dep29C,
+                  const double wtl0C,
+                  std::vector<int> const& iphi,
+                  std::vector<int> const& ieta,
+                  std::vector<int> const& layer,
+                  std::vector<int> const& depth);
+  int getSubdet() const { return subdet_; }
+  int getDepth(const int subdet, const int ieta, const int iphi, const int zside, const int layer) const;
+  int getDepth16(const int subdet, const int iphi, const int zside) const;
+  int getDepthMin(const int subdet, const int iphi, const int zside) const;
+  int getDepthMax(const int subdet, const int iphi, const int zside) const;
+  int getDepthMax(const int subdet, const int ieta, const int iphi, const int zside) const;
+  std::pair<int, int> getDepths(const int eta) const;
+  int getLayerFront(const int subdet, const int ieta, const int iphi, const int zside, const int depth) const;
+  int getLayerBack(const int subdet, const int ieta, const int iphi, const int zside, const int depth) const;
+  void getLayerDepth(
+      const int subdet, const int ieta, const int iphi, const int zside, std::map<int, int>& layers) const;
+  void getLayerDepth(const int ieta, std::map<int, int>& layers) const;
   double getLayer0Wt(const int subdet, const int iphi, const int zside) const;
-  int    getMaxDepthLastHE(const int subdet, const int iphi,
-			   const int zside) const;
-  const std::vector<int> & getPhis() const {return iphi_;}
-  bool   isValid(const int det, const int phi, const int zside) const;
-  int    validDet(std::vector<int>& phis) const;
-  std::pair<int,int> validEta() const {return std::pair<int,int>(ietaMin_,ietaMax_);}
-       
+  int getMaxDepthLastHE(const int subdet, const int iphi, const int zside) const;
+  const std::vector<int>& getPhis() const { return iphi_; }
+  bool isValid(const int det, const int phi, const int zside) const;
+  int validDet(std::vector<int>& phis) const;
+  std::pair<int, int> validEta() const { return std::pair<int, int>(ietaMin_, ietaMax_); }
+
 private:
-  static const int                 maxLayers_ = 18;
-  int                              subdet_;       // Subdet (HB=1, HE=2)
-  int                              ietaMin_;      // Minimum eta value
-  int                              ietaMax_;      // Maximum eta value
-  int                              depthMin_;     // Minimum depth
-  int                              depthMax_;     // Maximum depth
-  int                              dep16C_;       // Max/Min layer # for HB/HE (ieta=16)
-  int                              dep29C_;       // Max Depth of the last HE
-  double                           wtl0C_;        // Layer 0 weight   
-  std::vector<int>                 iphi_;         // phi*zside values
-  std::map<std::pair<int,int>,int> layer2Depth_;  // Layer to depth map
-  std::map<std::pair<int,int>,int> depth2LayerF_; // Depth to front layer map
-  std::map<std::pair<int,int>,int> depth2LayerB_; // Depth to back  layer map
-  std::map<int,std::pair<int,int>> depthsEta_;    // Depth range for each eta
+  static const int maxLayers_ = 18;
+  int subdet_;                                       // Subdet (HB=1, HE=2)
+  int ietaMin_;                                      // Minimum eta value
+  int ietaMax_;                                      // Maximum eta value
+  int depthMin_;                                     // Minimum depth
+  int depthMax_;                                     // Maximum depth
+  int dep16C_;                                       // Max/Min layer # for HB/HE (ieta=16)
+  int dep29C_;                                       // Max Depth of the last HE
+  double wtl0C_;                                     // Layer 0 weight
+  std::vector<int> iphi_;                            // phi*zside values
+  std::map<std::pair<int, int>, int> layer2Depth_;   // Layer to depth map
+  std::map<std::pair<int, int>, int> depth2LayerF_;  // Depth to front layer map
+  std::map<std::pair<int, int>, int> depth2LayerB_;  // Depth to back  layer map
+  std::map<int, std::pair<int, int>> depthsEta_;     // Depth range for each eta
 };
 
 #endif

--- a/Geometry/HcalCommonData/interface/HcalNumberingFromDDD.h
+++ b/Geometry/HcalCommonData/interface/HcalNumberingFromDDD.h
@@ -14,28 +14,23 @@
 #include <string>
 
 class HcalNumberingFromDDD {
-
 public:
-
-  HcalNumberingFromDDD(const HcalDDDSimConstants * hcons);
+  HcalNumberingFromDDD(const HcalDDDSimConstants* hcons);
   ~HcalNumberingFromDDD();
-	 
+
   struct HcalID {
     int subdet, zside, depth, etaR, phi, phis, lay;
-    HcalID(int det=0, int zs=0, int d=0, int et=0, int fi=0, int phiskip=0, int ly=-1) :
-      subdet(det), zside(zs), depth(d), etaR(et), phi(fi), phis(phiskip), lay(ly) {}
+    HcalID(int det = 0, int zs = 0, int d = 0, int et = 0, int fi = 0, int phiskip = 0, int ly = -1)
+        : subdet(det), zside(zs), depth(d), etaR(et), phi(fi), phis(phiskip), lay(ly) {}
   };
 
-  HcalID         unitID(int det, const math::XYZVectorD& pos, int depth, int lay=-1) const;
-  HcalID         unitID(double eta, double phi, int depth=1, int lay=-1) const;
-  HcalID         unitID(int det, double etaR, double phi, int depth,
-			int lay=-1) const;
-  HcalID         unitID(int det, int zside, int depth, int etaR, int phi, 
-			int lay=-1) const;
+  HcalID unitID(int det, const math::XYZVectorD& pos, int depth, int lay = -1) const;
+  HcalID unitID(double eta, double phi, int depth = 1, int lay = -1) const;
+  HcalID unitID(int det, double etaR, double phi, int depth, int lay = -1) const;
+  HcalID unitID(int det, int zside, int depth, int etaR, int phi, int lay = -1) const;
 
 private:
-
-  const HcalDDDSimConstants *hcalConstants;
+  const HcalDDDSimConstants* hcalConstants;
 };
 
 #endif

--- a/Geometry/HcalCommonData/interface/HcalParametersFromDD.h
+++ b/Geometry/HcalCommonData/interface/HcalParametersFromDD.h
@@ -9,7 +9,7 @@ public:
   HcalParametersFromDD() {}
   virtual ~HcalParametersFromDD() {}
 
-  bool build(const DDCompactView*,  HcalParameters& );
+  bool build(const DDCompactView*, HcalParameters&);
 };
 
 #endif

--- a/Geometry/HcalCommonData/interface/HcalTopologyMode.h
+++ b/Geometry/HcalCommonData/interface/HcalTopologyMode.h
@@ -6,35 +6,34 @@
 #include <string>
 #include <algorithm>
 
-template< typename T >
+template <typename T>
 class StringToEnumParser {
-  std::map< std::string, T > enumMap;
-public:
-    
-  StringToEnumParser( void );
+  std::map<std::string, T> enumMap;
 
-  T parseString( const std::string &value )  { 
-    typename std::map<std::string, T>::const_iterator iValue = enumMap.find( value );
-    if (iValue  == enumMap.end())
-      throw cms::Exception( "Configuration" )
-	<< "the value " << value << " is not defined.";
-	    
+public:
+  StringToEnumParser(void);
+
+  T parseString(const std::string &value) {
+    typename std::map<std::string, T>::const_iterator iValue = enumMap.find(value);
+    if (iValue == enumMap.end())
+      throw cms::Exception("Configuration") << "the value " << value << " is not defined.";
+
     return iValue->second;
   }
 };
 
 namespace HcalTopologyMode {
-  enum Mode { LHC=0, H2=1, SLHC=2, H2HE=3 };
+  enum Mode { LHC = 0, H2 = 1, SLHC = 2, H2HE = 3 };
 
   enum TriggerMode {
-    TriggerMode_2009=0,         // HF is summed in 3x2 regions
-    TriggerMode_2016=1,         // HF is summed in both 3x2 and 1x1 regions
-    TriggerMode_2018legacy=2,   // For the database, before 2017 and 2017plan1 was introduced
-    TriggerMode_2017=3,         // HF upgraded to QIE10
-    TriggerMode_2017plan1=4,    // HF upgraded to QIE10, 1 RBX of HE to QIE11
-    TriggerMode_2018=5,         // HF upgraded to QIE10, HE to QIE11
-    TriggerMode_2021=6          // HF upgraded to QIE10, HBHE to QIE11
+    TriggerMode_2009 = 0,        // HF is summed in 3x2 regions
+    TriggerMode_2016 = 1,        // HF is summed in both 3x2 and 1x1 regions
+    TriggerMode_2018legacy = 2,  // For the database, before 2017 and 2017plan1 was introduced
+    TriggerMode_2017 = 3,        // HF upgraded to QIE10
+    TriggerMode_2017plan1 = 4,   // HF upgraded to QIE10, 1 RBX of HE to QIE11
+    TriggerMode_2018 = 5,        // HF upgraded to QIE10, HE to QIE11
+    TriggerMode_2021 = 6         // HF upgraded to QIE10, HBHE to QIE11
   };
-}
+}  // namespace HcalTopologyMode
 
-#endif // Geometry_HcalCommonData_HcalTopologyMode_H
+#endif  // Geometry_HcalCommonData_HcalTopologyMode_H

--- a/Geometry/HcalCommonData/plugins/HcalDDDRecConstantsESMoudle.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDRecConstantsESMoudle.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HcalDDDRecConstantsESModule
 // Class:      HcalDDDRecConstantsESModule
-// 
+//
 /**\class HcalDDDRecConstantsESModule HcalDDDRecConstantsESModule.h Geometry/HcalCommonData/interface/HcalDDDRecConstantsESModule.h
 
  Description: <one line class summary>
@@ -16,7 +16,6 @@
 // $Id: HcalDDDRecConstantsESModule.cc,v 1.0 2013/12/24 12:47:41 sunanda Exp $
 //
 //
-
 
 // system include files
 #include <memory>
@@ -34,14 +33,13 @@
 //#define EDM_ML_DEBUG
 
 class HcalDDDRecConstantsESModule : public edm::ESProducer {
-
 public:
   HcalDDDRecConstantsESModule(const edm::ParameterSet&);
   ~HcalDDDRecConstantsESModule() override;
 
   using ReturnType = std::unique_ptr<HcalDDDRecConstants>;
 
-  static void fillDescriptions( edm::ConfigurationDescriptions & );
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
   ReturnType produce(const HcalRecNumberingRecord&);
 
@@ -52,7 +50,7 @@ private:
 
 HcalDDDRecConstantsESModule::HcalDDDRecConstantsESModule(const edm::ParameterSet& iConfig) {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") <<"constructing HcalDDDRecConstantsESModule";
+  edm::LogVerbatim("HcalGeom") << "constructing HcalDDDRecConstantsESModule";
 #endif
   auto cc = setWhatProduced(this);
   parToken_ = cc.consumesFrom<HcalParameters, HcalParametersRcd>(edm::ESInputTag{});
@@ -61,14 +59,13 @@ HcalDDDRecConstantsESModule::HcalDDDRecConstantsESModule(const edm::ParameterSet
 
 HcalDDDRecConstantsESModule::~HcalDDDRecConstantsESModule() {}
 
-void HcalDDDRecConstantsESModule::fillDescriptions( edm::ConfigurationDescriptions & descriptions ) {
+void HcalDDDRecConstantsESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  descriptions.add( "hcalDDDRecConstants", desc );
+  descriptions.add("hcalDDDRecConstants", desc);
 }
 
 // ------------ method called to produce the data  ------------
-HcalDDDRecConstantsESModule::ReturnType
-HcalDDDRecConstantsESModule::produce(const HcalRecNumberingRecord& iRecord) {
+HcalDDDRecConstantsESModule::ReturnType HcalDDDRecConstantsESModule::produce(const HcalRecNumberingRecord& iRecord) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HcalGeom") << "in HcalDDDRecConstantsESModule::produce";
 #endif

--- a/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalDDDSimConstantsESModule.cc
@@ -25,13 +25,12 @@
 #include <Geometry/Records/interface/HcalSimNumberingRecord.h>
 
 class HcalDDDSimConstantsESModule : public edm::ESProducer {
-
 public:
   HcalDDDSimConstantsESModule(const edm::ParameterSet&);
 
   using ReturnType = std::unique_ptr<HcalDDDSimConstants>;
 
-  static void fillDescriptions( edm::ConfigurationDescriptions & );
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
   ReturnType produce(const HcalSimNumberingRecord&);
 
@@ -42,9 +41,9 @@ private:
 HcalDDDSimConstantsESModule::HcalDDDSimConstantsESModule(const edm::ParameterSet&)
     : parToken_{setWhatProduced(this).consumesFrom<HcalParameters, HcalParametersRcd>(edm::ESInputTag{})} {}
 
-void HcalDDDSimConstantsESModule::fillDescriptions( edm::ConfigurationDescriptions & descriptions ) {
+void HcalDDDSimConstantsESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  descriptions.add( "hcalDDDSimConstants", desc );
+  descriptions.add("hcalDDDSimConstants", desc);
 }
 
 // ------------ method called to produce the data  ------------

--- a/Geometry/HcalCommonData/plugins/HcalParametersESModule.cc
+++ b/Geometry/HcalCommonData/plugins/HcalParametersESModule.cc
@@ -10,46 +10,43 @@
 #include "Geometry/HcalCommonData/interface/HcalParametersFromDD.h"
 
 #include <memory>
- 
 
-class  HcalParametersESModule : public edm::ESProducer {
+class HcalParametersESModule : public edm::ESProducer {
 public:
-  HcalParametersESModule( const edm::ParameterSet & );
-  ~HcalParametersESModule( void ) override;
-  
+  HcalParametersESModule(const edm::ParameterSet&);
+  ~HcalParametersESModule(void) override;
+
   using ReturnType = std::unique_ptr<HcalParameters>;
 
-  static void fillDescriptions( edm::ConfigurationDescriptions & );
-  
-  ReturnType produce( const HcalParametersRcd & );
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  ReturnType produce(const HcalParametersRcd&);
 
 private:
   edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvToken_;
 };
 
-HcalParametersESModule::HcalParametersESModule( const edm::ParameterSet& )
+HcalParametersESModule::HcalParametersESModule(const edm::ParameterSet&)
     : cpvToken_{setWhatProduced(this).consumesFrom<DDCompactView, IdealGeometryRecord>(edm::ESInputTag{})} {
   edm::LogInfo("HCAL") << "HcalParametersESModule::HcalParametersESModule";
 }
 
 HcalParametersESModule::~HcalParametersESModule() {}
 
-void HcalParametersESModule::fillDescriptions( edm::ConfigurationDescriptions & descriptions ) {
+void HcalParametersESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  descriptions.add( "hcalParameters", desc );
+  descriptions.add("hcalParameters", desc);
 }
 
-HcalParametersESModule::ReturnType
-HcalParametersESModule::produce( const HcalParametersRcd& iRecord ) {
-  edm::LogInfo("HcalESModule")
-    <<  "HcalParametersESModule::produce(const HcalParametersRcd& iRecord)";
+HcalParametersESModule::ReturnType HcalParametersESModule::produce(const HcalParametersRcd& iRecord) {
+  edm::LogInfo("HcalESModule") << "HcalParametersESModule::produce(const HcalParametersRcd& iRecord)";
   edm::ESTransientHandle<DDCompactView> cpv = iRecord.getTransientHandle(cpvToken_);
-  
+
   auto ptp = std::make_unique<HcalParameters>();
   HcalParametersFromDD builder;
-  builder.build( &(*cpv), *ptp );
-  
+  builder.build(&(*cpv), *ptp);
+
   return ptp;
 }
 
-DEFINE_FWK_EVENTSETUP_MODULE( HcalParametersESModule);
+DEFINE_FWK_EVENTSETUP_MODULE(HcalParametersESModule);

--- a/Geometry/HcalCommonData/src/HcalCellType.cc
+++ b/Geometry/HcalCommonData/src/HcalCellType.cc
@@ -9,63 +9,67 @@
 #include <algorithm>
 #include <iomanip>
 
-HcalCellType::HcalCellType(HcalSubdetector detType, int etaBin, int zside,
-			   int depthSegment,const HcalCellType::HcalCell& cell,
-			   int readoutDirection, double samplingFactor,
-			   double halfSize) :
-  theDetType(detType), theEtaBin(etaBin), theSide(zside),
-  theDepthSegment(depthSegment), theActualReadoutDirection(readoutDirection), 
-  theSamplingFactor(samplingFactor) {
-
-  theEtaMin   = cell.eta - cell.deta;
-  theEtaMax   = cell.eta + cell.deta;
-  theRzFlag   = cell.flagrz;
-  theDepthMin = (cell.rz  - cell.drz)/CLHEP::cm;
-  theDepthMax = (cell.rz  + cell.drz)/CLHEP::cm;
-  thePhiBinWidth     = 2*(cell.dphi)/CLHEP::deg;
-  thePhiOffset       = 0;
-  theUnitPhi         = 1;
-  theHalfSize        = halfSize/CLHEP::cm;
+HcalCellType::HcalCellType(HcalSubdetector detType,
+                           int etaBin,
+                           int zside,
+                           int depthSegment,
+                           const HcalCellType::HcalCell& cell,
+                           int readoutDirection,
+                           double samplingFactor,
+                           double halfSize)
+    : theDetType(detType),
+      theEtaBin(etaBin),
+      theSide(zside),
+      theDepthSegment(depthSegment),
+      theActualReadoutDirection(readoutDirection),
+      theSamplingFactor(samplingFactor) {
+  theEtaMin = cell.eta - cell.deta;
+  theEtaMax = cell.eta + cell.deta;
+  theRzFlag = cell.flagrz;
+  theDepthMin = (cell.rz - cell.drz) / CLHEP::cm;
+  theDepthMax = (cell.rz + cell.drz) / CLHEP::cm;
+  thePhiBinWidth = 2 * (cell.dphi) / CLHEP::deg;
+  thePhiOffset = 0;
+  theUnitPhi = 1;
+  theHalfSize = halfSize / CLHEP::cm;
 }
 
-HcalCellType::HcalCellType(const HcalCellType &right) {
-
-  theDetType                = right.theDetType;
-  theEtaBin                 = right.theEtaBin;
-  theSide                   = right.theSide;
-  theUnitPhi                = right.theUnitPhi;
-  theDepthSegment           = right.theDepthSegment;
+HcalCellType::HcalCellType(const HcalCellType& right) {
+  theDetType = right.theDetType;
+  theEtaBin = right.theEtaBin;
+  theSide = right.theSide;
+  theUnitPhi = right.theUnitPhi;
+  theDepthSegment = right.theDepthSegment;
   theActualReadoutDirection = right.theActualReadoutDirection;
-  theRzFlag                 = right.theRzFlag;
-  theEtaMin                 = right.theEtaMin;
-  theEtaMax                 = right.theEtaMax;
-  theDepthMin               = right.theDepthMin;
-  theDepthMax               = right.theDepthMax;
-  thePhiBinWidth            = right.thePhiBinWidth;
-  thePhiOffset              = right.thePhiOffset;
-  theHalfSize               = right.theHalfSize;
-  theSamplingFactor         = right.theSamplingFactor;
-  thePhis                   = right.thePhis;
+  theRzFlag = right.theRzFlag;
+  theEtaMin = right.theEtaMin;
+  theEtaMax = right.theEtaMax;
+  theDepthMin = right.theDepthMin;
+  theDepthMax = right.theDepthMax;
+  thePhiBinWidth = right.thePhiBinWidth;
+  thePhiOffset = right.thePhiOffset;
+  theHalfSize = right.theHalfSize;
+  theSamplingFactor = right.theSamplingFactor;
+  thePhis = right.thePhis;
 }
 
-const HcalCellType& HcalCellType::operator=(const HcalCellType &right) {
-
-  theDetType                = right.theDetType;
-  theEtaBin                 = right.theEtaBin;
-  theSide                   = right.theSide;
-  theUnitPhi                = right.theUnitPhi;
-  theDepthSegment           = right.theDepthSegment;
+const HcalCellType& HcalCellType::operator=(const HcalCellType& right) {
+  theDetType = right.theDetType;
+  theEtaBin = right.theEtaBin;
+  theSide = right.theSide;
+  theUnitPhi = right.theUnitPhi;
+  theDepthSegment = right.theDepthSegment;
   theActualReadoutDirection = right.theActualReadoutDirection;
-  theRzFlag                 = right.theRzFlag;
-  theEtaMin                 = right.theEtaMin;
-  theEtaMax                 = right.theEtaMax;
-  theDepthMin               = right.theDepthMin;
-  theDepthMax               = right.theDepthMax;
-  thePhiBinWidth            = right.thePhiBinWidth;
-  thePhiOffset              = right.thePhiOffset;
-  theHalfSize               = right.theHalfSize;
-  theSamplingFactor         = right.theSamplingFactor;
-  thePhis                   = right.thePhis;
+  theRzFlag = right.theRzFlag;
+  theEtaMin = right.theEtaMin;
+  theEtaMax = right.theEtaMax;
+  theDepthMin = right.theDepthMin;
+  theDepthMax = right.theDepthMax;
+  thePhiBinWidth = right.thePhiBinWidth;
+  thePhiOffset = right.thePhiOffset;
+  theHalfSize = right.theHalfSize;
+  theSamplingFactor = right.theSamplingFactor;
+  thePhis = right.thePhis;
 
   return *this;
 }
@@ -80,33 +84,32 @@ void HcalCellType::setEta(int bin, double etamin, double etamax) {
 
 void HcalCellType::setDepth(int bin, double dmin, double dmax) {
   theDepthSegment = bin;
-  theDepthMin     = dmin;
-  theDepthMax     = dmax;
+  theDepthMin = dmin;
+  theDepthMax = dmax;
 }
 
-void HcalCellType::setPhi(const std::vector<std::pair<int,double> >& phis,
-			  const std::vector<int>& iphiMiss, double foff, 
-			  double dphi, int unit) {
+void HcalCellType::setPhi(const std::vector<std::pair<int, double> >& phis,
+                          const std::vector<int>& iphiMiss,
+                          double foff,
+                          double dphi,
+                          int unit) {
   thePhiBinWidth = dphi;
-  thePhiOffset   = foff;
-  theUnitPhi     = unit;
+  thePhiOffset = foff;
+  theUnitPhi = unit;
   thePhis.clear();
-  for (const auto & phi : phis) {
-    if (std::find(iphiMiss.begin(),iphiMiss.end(),phi.first) == iphiMiss.end()) {
+  for (const auto& phi : phis) {
+    if (std::find(iphiMiss.begin(), iphiMiss.end(), phi.first) == iphiMiss.end()) {
       thePhis.emplace_back(phi);
     }
   }
 }
 
 std::ostream& operator<<(std::ostream& os, const HcalCellType& cell) {
-  os << "Detector " << cell.detType() << " Eta " << cell.etaBin() << " (" 
-     << cell.etaMin() << ":" << cell.etaMax() << ") Zside " << cell.zside()
-     << " Depth " << cell.depthSegment() << " (" << cell.depthMin() << ":" 
-     << cell.depthMax() << "; " << cell.depthType() << ") Phi " 
-     << cell.nPhiBins() << " ("	<< cell.phiOffset()/CLHEP::deg << ", " 
-     << cell.phiBinWidth()/CLHEP::deg << ", " << cell.unitPhi() << ", "
-     << cell.nPhiModule() << ")  Direction " 
-     << cell.actualReadoutDirection() << " Half size " << cell.halfSize() 
+  os << "Detector " << cell.detType() << " Eta " << cell.etaBin() << " (" << cell.etaMin() << ":" << cell.etaMax()
+     << ") Zside " << cell.zside() << " Depth " << cell.depthSegment() << " (" << cell.depthMin() << ":"
+     << cell.depthMax() << "; " << cell.depthType() << ") Phi " << cell.nPhiBins() << " ("
+     << cell.phiOffset() / CLHEP::deg << ", " << cell.phiBinWidth() / CLHEP::deg << ", " << cell.unitPhi() << ", "
+     << cell.nPhiModule() << ")  Direction " << cell.actualReadoutDirection() << " Half size " << cell.halfSize()
      << " Sampling Factor " << cell.samplingFactor();
   return os;
 }

--- a/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
@@ -8,7 +8,6 @@
 using namespace geant_units::operators;
 
 HcalDDDSimConstants::HcalDDDSimConstants(const HcalParameters* hp) : hpar(hp) {
-
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "HcalDDDSimConstants::HcalDDDSimConstants (const HcalParameter* hp) constructor\n";
 #endif
@@ -16,120 +15,116 @@ HcalDDDSimConstants::HcalDDDSimConstants(const HcalParameters* hp) : hpar(hp) {
   initialize();
 #ifdef EDM_ML_DEBUG
   std::vector<HcalCellType> cellTypes = HcalCellTypes();
-  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants: " << cellTypes.size()
-			       << " cells of type HCal (All)\n";
+  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants: " << cellTypes.size() << " cells of type HCal (All)\n";
 #endif
 }
 
-HcalDDDSimConstants::~HcalDDDSimConstants() { 
+HcalDDDSimConstants::~HcalDDDSimConstants() {
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo ("HCalGeom") << "HcalDDDSimConstants::destructed!!!\n";
+  edm::LogInfo("HCalGeom") << "HcalDDDSimConstants::destructed!!!\n";
 #endif
 }
 
-HcalCellType::HcalCell HcalDDDSimConstants::cell(const int& idet,  const int& zside, 
-						 const int& depth, const int& etaR,
-						 const int& iphi) const {
-
+HcalCellType::HcalCell HcalDDDSimConstants::cell(
+    const int& idet, const int& zside, const int& depth, const int& etaR, const int& iphi) const {
   double etaMn = hpar->etaMin[0];
   double etaMx = hpar->etaMax[0];
-  if (idet==static_cast<int>(HcalEndcap)) {
-    etaMn = hpar->etaMin[1]; etaMx = hpar->etaMax[1];
-  } else if (idet==static_cast<int>(HcalForward)) {
-    etaMn = hpar->etaMin[2]; etaMx = hpar->etaMax[2];
+  if (idet == static_cast<int>(HcalEndcap)) {
+    etaMn = hpar->etaMin[1];
+    etaMx = hpar->etaMax[1];
+  } else if (idet == static_cast<int>(HcalForward)) {
+    etaMn = hpar->etaMin[2];
+    etaMx = hpar->etaMax[2];
   }
   double eta = 0, deta = 0, phi = 0, dphi = 0, rz = 0, drz = 0;
-  bool   ok = false, flagrz = true;
-  if ((idet==static_cast<int>(HcalBarrel)||idet==static_cast<int>(HcalEndcap)||
-       idet==static_cast<int>(HcalOuter)||idet==static_cast<int>(HcalForward))
-      && etaR >=etaMn && etaR <= etaMx && depth > 0)    ok = true;
-  if (idet == static_cast<int>(HcalEndcap) && depth>(int)(hpar->zHE.size()))ok=false;
-  else if (idet == static_cast<int>(HcalBarrel) && depth > maxLayerHB_+1)   ok=false;
-  else if (idet == static_cast<int>(HcalOuter) && depth != 4)               ok=false;
-  else if (idet == static_cast<int>(HcalForward) && depth > maxDepth[2])    ok=false;
+  bool ok = false, flagrz = true;
+  if ((idet == static_cast<int>(HcalBarrel) || idet == static_cast<int>(HcalEndcap) ||
+       idet == static_cast<int>(HcalOuter) || idet == static_cast<int>(HcalForward)) &&
+      etaR >= etaMn && etaR <= etaMx && depth > 0)
+    ok = true;
+  if (idet == static_cast<int>(HcalEndcap) && depth > (int)(hpar->zHE.size()))
+    ok = false;
+  else if (idet == static_cast<int>(HcalBarrel) && depth > maxLayerHB_ + 1)
+    ok = false;
+  else if (idet == static_cast<int>(HcalOuter) && depth != 4)
+    ok = false;
+  else if (idet == static_cast<int>(HcalForward) && depth > maxDepth[2])
+    ok = false;
   if (ok) {
-    eta  = getEta(idet, etaR, zside, depth);
+    eta = getEta(idet, etaR, zside, depth);
     deta = deltaEta(idet, etaR, depth);
     double fibin, fioff;
-    if      (idet == static_cast<int>(HcalBarrel)||
-	     idet == static_cast<int>(HcalOuter)) {
+    if (idet == static_cast<int>(HcalBarrel) || idet == static_cast<int>(HcalOuter)) {
       fioff = hpar->phioff[0];
-      fibin = hpar->phibin[etaR-1];
+      fibin = hpar->phibin[etaR - 1];
     } else if (idet == static_cast<int>(HcalEndcap)) {
       fioff = hpar->phioff[1];
-      fibin = hpar->phibin[etaR-1];
+      fibin = hpar->phibin[etaR - 1];
     } else {
       fioff = hpar->phioff[2];
-      fibin = hpar->phitable[etaR-hpar->etaMin[2]];
-      if (unitPhi(fibin) > 2) fioff = hpar->phioff[4];
+      fibin = hpar->phitable[etaR - hpar->etaMin[2]];
+      if (unitPhi(fibin) > 2)
+        fioff = hpar->phioff[4];
     }
-    phi  =-fioff + (iphi - 0.5)*fibin;
-    dphi = 0.5*fibin;
+    phi = -fioff + (iphi - 0.5) * fibin;
+    dphi = 0.5 * fibin;
     if (idet == static_cast<int>(HcalForward)) {
       int ir = nR + hpar->etaMin[2] - etaR - 1;
       if (ir > 0 && ir < nR) {
-	rz     = 0.5*(hpar->rTable[ir]+hpar->rTable[ir-1]);
-	drz    = 0.5*(hpar->rTable[ir]-hpar->rTable[ir-1]);
+        rz = 0.5 * (hpar->rTable[ir] + hpar->rTable[ir - 1]);
+        drz = 0.5 * (hpar->rTable[ir] - hpar->rTable[ir - 1]);
       } else {
-	ok     = false;
+        ok = false;
 #ifdef EDM_ML_DEBUG
-	edm::LogInfo("HCalGeom") << "HcalDDDSimConstants: wrong eta " << etaR 
-				 << " ("  << ir << "/" << nR << ") Detector "
-				 << idet << std::endl;
+        edm::LogInfo("HCalGeom") << "HcalDDDSimConstants: wrong eta " << etaR << " (" << ir << "/" << nR
+                                 << ") Detector " << idet << std::endl;
 #endif
       }
     } else if (etaR <= nEta) {
       int laymin(depth), laymax(depth);
       if (idet == static_cast<int>(HcalOuter)) {
-	laymin = (etaR > hpar->noff[2]) ? ((int)(hpar->zHE.size())) : ((int)(hpar->zHE.size()))-1;
-	laymax = ((int)(hpar->zHE.size()));
+        laymin = (etaR > hpar->noff[2]) ? ((int)(hpar->zHE.size())) : ((int)(hpar->zHE.size())) - 1;
+        laymax = ((int)(hpar->zHE.size()));
       }
-      double d1=0, d2=0;
+      double d1 = 0, d2 = 0;
       if (idet == static_cast<int>(HcalEndcap)) {
-	flagrz = false;
-	d1     = hpar->zHE[laymin-1] - hpar->dzHE[laymin-1];
-	d2     = hpar->zHE[laymax-1] + hpar->dzHE[laymax-1];
+        flagrz = false;
+        d1 = hpar->zHE[laymin - 1] - hpar->dzHE[laymin - 1];
+        d2 = hpar->zHE[laymax - 1] + hpar->dzHE[laymax - 1];
       } else {
-	d1     = hpar->rHB[laymin-1] - hpar->drHB[laymin-1];
-	d2     = hpar->rHB[laymax-1] + hpar->drHB[laymax-1];
+        d1 = hpar->rHB[laymin - 1] - hpar->drHB[laymin - 1];
+        d2 = hpar->rHB[laymax - 1] + hpar->drHB[laymax - 1];
       }
-      rz     = 0.5*(d2+d1);
-      drz    = 0.5*(d2-d1);
+      rz = 0.5 * (d2 + d1);
+      drz = 0.5 * (d2 - d1);
     } else {
       ok = false;
-      edm::LogWarning("HCalGeom") << "HcalDDDSimConstants: wrong depth " 
-				  << depth << " or etaR " << etaR 
-				  << " for detector " << idet;
+      edm::LogWarning("HCalGeom") << "HcalDDDSimConstants: wrong depth " << depth << " or etaR " << etaR
+                                  << " for detector " << idet;
     }
   } else {
     ok = false;
-    edm::LogWarning("HCalGeom") << "HcalDDDSimConstants: wrong depth " << depth
-				<< " det " << idet;
+    edm::LogWarning("HCalGeom") << "HcalDDDSimConstants: wrong depth " << depth << " det " << idet;
   }
-  HcalCellType::HcalCell tmp(ok,eta,deta,phi,dphi,rz,drz,flagrz);
+  HcalCellType::HcalCell tmp(ok, eta, deta, phi, dphi, rz, drz, flagrz);
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants: det/side/depth/etaR/"
-			       << "phi " << idet  << "/" << zside << "/" 
-			       << depth << "/" << etaR << "/" << iphi 
-			       << " Cell Flag " << tmp.ok << " "  << tmp.eta 
-			       << " " << tmp.deta << " phi " << tmp.phi << " "
-			       << tmp.dphi << " r(z) " << tmp.rz << " "  
-			       << tmp.drz << " " << tmp.flagrz;
+                               << "phi " << idet << "/" << zside << "/" << depth << "/" << etaR << "/" << iphi
+                               << " Cell Flag " << tmp.ok << " " << tmp.eta << " " << tmp.deta << " phi " << tmp.phi
+                               << " " << tmp.dphi << " r(z) " << tmp.rz << " " << tmp.drz << " " << tmp.flagrz;
 #endif
   return tmp;
 }
 
-int HcalDDDSimConstants::findDepth(const int& det, const int& eta, 
-				   const int& phi, const int& zside,
-				   const int& lay) const {
-
-  int depth = (ldmap_.isValid(det,phi,zside)) ? ldmap_.getDepth(det,eta,phi,zside,lay) : -1;
+int HcalDDDSimConstants::findDepth(
+    const int& det, const int& eta, const int& phi, const int& zside, const int& lay) const {
+  int depth = (ldmap_.isValid(det, phi, zside)) ? ldmap_.getDepth(det, eta, phi, zside, lay) : -1;
   return depth;
 }
 
-unsigned int HcalDDDSimConstants::findLayer(const int& layer, const std::vector<HcalParameters::LayerItem>& layerGroup) const {
-  
+unsigned int HcalDDDSimConstants::findLayer(const int& layer,
+                                            const std::vector<HcalParameters::LayerItem>& layerGroup) const {
   unsigned int id = layerGroup.size();
   for (unsigned int i = 0; i < layerGroup.size(); i++) {
     if (layer == (int)(layerGroup[i].layer)) {
@@ -140,26 +135,24 @@ unsigned int HcalDDDSimConstants::findLayer(const int& layer, const std::vector<
   return id;
 }
 
-std::vector<std::pair<double,double> > HcalDDDSimConstants::getConstHBHE(const int& type) const {
-
-  std::vector<std::pair<double,double> > gcons;
+std::vector<std::pair<double, double> > HcalDDDSimConstants::getConstHBHE(const int& type) const {
+  std::vector<std::pair<double, double> > gcons;
   if (type == 0) {
-    for (unsigned int i=0; i<hpar->rHB.size(); ++i) {
-      gcons.emplace_back(std::pair<double,double>(hpar->rHB[i],hpar->drHB[i]));
+    for (unsigned int i = 0; i < hpar->rHB.size(); ++i) {
+      gcons.emplace_back(std::pair<double, double>(hpar->rHB[i], hpar->drHB[i]));
     }
   } else {
-    for (unsigned int i=0; i<hpar->zHE.size(); ++i) {
-      gcons.emplace_back(std::pair<double,double>(hpar->zHE[i],hpar->dzHE[i]));
+    for (unsigned int i = 0; i < hpar->zHE.size(); ++i) {
+      gcons.emplace_back(std::pair<double, double>(hpar->zHE[i], hpar->dzHE[i]));
     }
   }
   return gcons;
 }
 
-int HcalDDDSimConstants::getDepthEta16(const int& det, const int& phi, 
-				       const int& zside) const {
-
-  int depth = ldmap_.getDepth16(det,phi,zside);
-  if (depth < 0) depth = (det == 2) ? depthEta16[1] : depthEta16[0];
+int HcalDDDSimConstants::getDepthEta16(const int& det, const int& phi, const int& zside) const {
+  int depth = ldmap_.getDepth16(det, phi, zside);
+  if (depth < 0)
+    depth = (det == 2) ? depthEta16[1] : depthEta16[0];
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HcalGeom") << "getDepthEta16: " << det << ":" << depth;
 #endif
@@ -172,155 +165,152 @@ int HcalDDDSimConstants::getDepthEta16M(const int& det) const {
   int detsp = ldmap_.validDet(phis);
   if (detsp == det) {
     int zside = (phis[0] > 0) ? 1 : -1;
-    int iphi  = (phis[0] > 0) ? phis[0] : -phis[0];
-    int depthsp = ldmap_.getDepth16(det,iphi,zside);
-    if (det == 1 && depthsp > depth) depth = depthsp;
-    if (det == 2 && depthsp < depth) depth = depthsp;
+    int iphi = (phis[0] > 0) ? phis[0] : -phis[0];
+    int depthsp = ldmap_.getDepth16(det, iphi, zside);
+    if (det == 1 && depthsp > depth)
+      depth = depthsp;
+    if (det == 2 && depthsp < depth)
+      depth = depthsp;
   }
   return depth;
 }
 
-int HcalDDDSimConstants::getDepthEta29(const int& phi, const int& zside, 
-				       const int& i) const {
-
-  int depth = (i == 0) ? ldmap_.getMaxDepthLastHE(2,phi,zside) : -1;
-  if (depth < 0) depth = (i == 1) ? depthEta29[1] : depthEta29[0];
+int HcalDDDSimConstants::getDepthEta29(const int& phi, const int& zside, const int& i) const {
+  int depth = (i == 0) ? ldmap_.getMaxDepthLastHE(2, phi, zside) : -1;
+  if (depth < 0)
+    depth = (i == 1) ? depthEta29[1] : depthEta29[0];
   return depth;
 }
 
-int HcalDDDSimConstants::getDepthEta29M(const int& i, 
-					const bool& planOne) const {
+int HcalDDDSimConstants::getDepthEta29M(const int& i, const bool& planOne) const {
   int depth = (i == 1) ? depthEta29[1] : depthEta29[0];
   if (i == 0 && planOne) {
     std::vector<int> phis;
     int detsp = ldmap_.validDet(phis);
     if (detsp == 2) {
       int zside = (phis[0] > 0) ? 1 : -1;
-      int iphi  = (phis[0] > 0) ? phis[0] : -phis[0];
-      int depthsp = ldmap_.getMaxDepthLastHE(2,iphi,zside);
-      if (depthsp > depth) depth = depthsp;
+      int iphi = (phis[0] > 0) ? phis[0] : -phis[0];
+      int depthsp = ldmap_.getMaxDepthLastHE(2, iphi, zside);
+      if (depthsp > depth)
+        depth = depthsp;
     }
   }
   return depth;
 }
 
-std::pair<int,double> HcalDDDSimConstants::getDetEta(const double& eta, 
-						     const int& depth) const {
-
-  int    hsubdet(0), ieta(0);
+std::pair<int, double> HcalDDDSimConstants::getDetEta(const double& eta, const int& depth) const {
+  int hsubdet(0), ieta(0);
   double etaR(0);
   double heta = fabs(eta);
   for (int i = 0; i < nEta; i++)
-    if (heta > hpar->etaTable[i]) ieta = i + 1;
+    if (heta > hpar->etaTable[i])
+      ieta = i + 1;
   if (heta <= hpar->etaRange[1]) {
-    if (((ieta == hpar->etaMin[1] && depth==depthEta16[1]) ||
-	 (ieta > hpar->etaMax[0])) && (ieta <= hpar->etaMax[1])) {
+    if (((ieta == hpar->etaMin[1] && depth == depthEta16[1]) || (ieta > hpar->etaMax[0])) &&
+        (ieta <= hpar->etaMax[1])) {
       hsubdet = static_cast<int>(HcalEndcap);
     } else {
       hsubdet = static_cast<int>(HcalBarrel);
     }
-    etaR    = eta;
+    etaR = eta;
   } else {
     hsubdet = static_cast<int>(HcalForward);
-    double theta = 2.*atan(exp(-heta));
-    double hR    = zVcal*tan(theta);
-    etaR    = (eta >= 0. ? hR : -hR);
+    double theta = 2. * atan(exp(-heta));
+    double hR = zVcal * tan(theta);
+    etaR = (eta >= 0. ? hR : -hR);
   }
-  return std::pair<int,double>(hsubdet,etaR);
+  return std::pair<int, double>(hsubdet, etaR);
 }
 
-int HcalDDDSimConstants::getEta(const int& det, const int& lay, 
-				const double& hetaR) const {
-
-  int    ieta(0);
-  if (det == static_cast<int>(HcalForward)) { // Forward HCal
-    ieta    = hpar->etaMax[2];
-    for (int i = nR-1; i > 0; i--)
-      if (hetaR < hpar->rTable[i]) ieta = hpar->etaMin[2] + nR - i - 1;
-  } else { // Barrel or Endcap
-    ieta  = 1;
-    for (int i = 0; i < nEta-1; i++)
-      if (hetaR > hpar->etaTable[i]) ieta = i + 1;
+int HcalDDDSimConstants::getEta(const int& det, const int& lay, const double& hetaR) const {
+  int ieta(0);
+  if (det == static_cast<int>(HcalForward)) {  // Forward HCal
+    ieta = hpar->etaMax[2];
+    for (int i = nR - 1; i > 0; i--)
+      if (hetaR < hpar->rTable[i])
+        ieta = hpar->etaMin[2] + nR - i - 1;
+  } else {  // Barrel or Endcap
+    ieta = 1;
+    for (int i = 0; i < nEta - 1; i++)
+      if (hetaR > hpar->etaTable[i])
+        ieta = i + 1;
     if (det == static_cast<int>(HcalBarrel)) {
-      if (ieta > hpar->etaMax[0])  ieta = hpar->etaMax[0];
+      if (ieta > hpar->etaMax[0])
+        ieta = hpar->etaMax[0];
       if (lay == maxLayer_) {
-	if (hetaR > etaHO[1] && ieta == hpar->noff[2]) ieta++;
+        if (hetaR > etaHO[1] && ieta == hpar->noff[2])
+          ieta++;
       }
     } else if (det == static_cast<int>(HcalEndcap)) {
-      if (ieta <= hpar->etaMin[1]) ieta = hpar->etaMin[1];
+      if (ieta <= hpar->etaMin[1])
+        ieta = hpar->etaMin[1];
     }
   }
   return ieta;
 }
 
-std::pair<int,int> HcalDDDSimConstants::getEtaDepth(const int& det, int etaR, 
-						    const int& phi, 
-						    const int& zside, 
-						    int depth, 
-						    const int& lay) const {
-
+std::pair<int, int> HcalDDDSimConstants::getEtaDepth(
+    const int& det, int etaR, const int& phi, const int& zside, int depth, const int& lay) const {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "HcalDDDEsimConstants:getEtaDepth: I/P " 
-			       << det << ":" << etaR << ":" << phi << ":" 
-			       << zside << ":" << depth << ":" << lay;
+  edm::LogVerbatim("HcalGeom") << "HcalDDDEsimConstants:getEtaDepth: I/P " << det << ":" << etaR << ":" << phi << ":"
+                               << zside << ":" << depth << ":" << lay;
 #endif
   //Modify the depth index
   if ((det == static_cast<int>(HcalEndcap)) && (etaR == 17) && (lay == 1))
     etaR = 18;
-  if (det == static_cast<int>(HcalForward)) { // Forward HCal
+  if (det == static_cast<int>(HcalForward)) {  // Forward HCal
   } else if (det == static_cast<int>(HcalOuter)) {
     depth = 4;
   } else {
     if (lay >= 0) {
-      depth = layerGroup(det, etaR, phi, zside, lay-1);
+      depth = layerGroup(det, etaR, phi, zside, lay - 1);
       if (etaR == hpar->noff[0] && lay > 1) {
-	int   kphi   = phi + int((hpar->phioff[3]+0.1)/hpar->phibin[etaR-1]);
-	kphi         = (kphi-1)%4 + 1;
-	if (kphi == 2 || kphi == 3)
-	  depth = layerGroup(det, etaR, phi, zside, lay-2);
+        int kphi = phi + int((hpar->phioff[3] + 0.1) / hpar->phibin[etaR - 1]);
+        kphi = (kphi - 1) % 4 + 1;
+        if (kphi == 2 || kphi == 3)
+          depth = layerGroup(det, etaR, phi, zside, lay - 2);
       }
     } else if (det == static_cast<int>(HcalBarrel)) {
-      if (depth>getMaxDepth(det,etaR,phi,zside,false)) 
-	depth = getMaxDepth(det,etaR,phi,zside,false);
+      if (depth > getMaxDepth(det, etaR, phi, zside, false))
+        depth = getMaxDepth(det, etaR, phi, zside, false);
     }
-    if (etaR >= hpar->noff[1] && depth > getDepthEta29(phi,zside,0)) {
-      etaR -= getDepthEta29(phi,zside,1);
+    if (etaR >= hpar->noff[1] && depth > getDepthEta29(phi, zside, 0)) {
+      etaR -= getDepthEta29(phi, zside, 1);
     } else if (etaR == hpar->etaMin[1]) {
       if (det == static_cast<int>(HcalBarrel)) {
-	if (depth > getDepthEta16(det, phi, zside)) 
-	  depth = getDepthEta16(det, phi, zside);
+        if (depth > getDepthEta16(det, phi, zside))
+          depth = getDepthEta16(det, phi, zside);
       } else {
-	if (depth < getDepthEta16(det, phi, zside)) 
-	  depth = getDepthEta16(det, phi, zside);
+        if (depth < getDepthEta16(det, phi, zside))
+          depth = getDepthEta16(det, phi, zside);
       }
     }
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "HcalDDDEsimConstants:getEtaDepth: O/P " 
-			       << etaR << ":" << depth;
+  edm::LogVerbatim("HcalGeom") << "HcalDDDEsimConstants:getEtaDepth: O/P " << etaR << ":" << depth;
 #endif
-  return std::pair<int,int>(etaR,depth);
+  return std::pair<int, int>(etaR, depth);
 }
 
-double HcalDDDSimConstants::getEtaHO(const double& etaR, const double& x, 
-				     const double& y, const double& z) const {
-
+double HcalDDDSimConstants::getEtaHO(const double& etaR, const double& x, const double& y, const double& z) const {
   if (hpar->zHO.size() > 4) {
-    double eta  = fabs(etaR);
-    double r    = std::sqrt(x*x+y*y);
+    double eta = fabs(etaR);
+    double r = std::sqrt(x * x + y * y);
     if (r > rminHO) {
       double zz = fabs(z);
       if (zz > hpar->zHO[3]) {
-	if (eta <= hpar->etaTable[10]) eta = hpar->etaTable[10]+0.001;
+        if (eta <= hpar->etaTable[10])
+          eta = hpar->etaTable[10] + 0.001;
       } else if (zz > hpar->zHO[1]) {
-	if (eta <= hpar->etaTable[4])  eta = hpar->etaTable[4]+0.001;
+        if (eta <= hpar->etaTable[4])
+          eta = hpar->etaTable[4] + 0.001;
       }
     }
     eta = (z >= 0. ? eta : -eta);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HcalGeom") << "R " << r << " Z " << z << " eta " << etaR 
-				 << ":" << eta;
-    if (eta != etaR) edm::LogInfo ("HCalGeom") << "**** Check *****";
+    edm::LogVerbatim("HcalGeom") << "R " << r << " Z " << z << " eta " << etaR << ":" << eta;
+    if (eta != etaR)
+      edm::LogInfo("HCalGeom") << "**** Check *****";
 #endif
     return eta;
   } else {
@@ -329,71 +319,77 @@ double HcalDDDSimConstants::getEtaHO(const double& etaR, const double& x,
 }
 
 int HcalDDDSimConstants::getFrontLayer(const int& det, const int& eta) const {
-
-  int lay=0;
+  int lay = 0;
   if (det == 1) {
-    if      (std::abs(eta) == 16) lay = layFHB[1];
-    else                          lay = layFHB[0];
+    if (std::abs(eta) == 16)
+      lay = layFHB[1];
+    else
+      lay = layFHB[0];
   } else {
-    if      (std::abs(eta) == 16) lay = layFHE[1];
-    else if (std::abs(eta) == 18) lay = layFHE[2];
-    else                          lay = layFHE[0];
+    if (std::abs(eta) == 16)
+      lay = layFHE[1];
+    else if (std::abs(eta) == 18)
+      lay = layFHE[2];
+    else
+      lay = layFHE[0];
   }
   return lay;
 }
 
 int HcalDDDSimConstants::getLastLayer(const int& det, const int& eta) const {
-
-  int lay=0;
+  int lay = 0;
   if (det == 1) {
-    if      (std::abs(eta) == 15) lay = layBHB[1];
-    else if (std::abs(eta) == 16) lay = layBHB[2];
-    else                          lay = layBHB[0];
+    if (std::abs(eta) == 15)
+      lay = layBHB[1];
+    else if (std::abs(eta) == 16)
+      lay = layBHB[2];
+    else
+      lay = layBHB[0];
   } else {
-    if      (std::abs(eta) == 16) lay = layBHE[1];
-    else if (std::abs(eta) == 17) lay = layBHE[2];
-    else if (std::abs(eta) == 18) lay = layBHE[3];
-    else                          lay = layBHE[0];
+    if (std::abs(eta) == 16)
+      lay = layBHE[1];
+    else if (std::abs(eta) == 17)
+      lay = layBHE[2];
+    else if (std::abs(eta) == 18)
+      lay = layBHE[3];
+    else
+      lay = layBHE[0];
   }
   return lay;
 }
 
-double HcalDDDSimConstants::getLayer0Wt(const int& det, const int& phi, 
-					const int& zside) const {
-
+double HcalDDDSimConstants::getLayer0Wt(const int& det, const int& phi, const int& zside) const {
   double wt = ldmap_.getLayer0Wt(det, phi, zside);
-  if (wt < 0) wt = (det == 2) ? hpar->Layer0Wt[1] :  hpar->Layer0Wt[0];
+  if (wt < 0)
+    wt = (det == 2) ? hpar->Layer0Wt[1] : hpar->Layer0Wt[0];
   return wt;
 }
 
-int HcalDDDSimConstants::getLayerFront(const int& det, const int& eta, 
-				       const int& phi, const int& zside,
-				       const int& depth) const {
-
+int HcalDDDSimConstants::getLayerFront(
+    const int& det, const int& eta, const int& phi, const int& zside, const int& depth) const {
   int layer = ldmap_.getLayerFront(det, eta, phi, zside, depth);
   if (layer < 0) {
     if (det == 1 || det == 2) {
       layer = 1;
-      for (int l=0; l<getLayerMax(eta,depth); ++l) {
-	if ((int)(layerGroup(eta-1,l)) == depth) {
-	  layer = l+1; break;
-	}
+      for (int l = 0; l < getLayerMax(eta, depth); ++l) {
+        if ((int)(layerGroup(eta - 1, l)) == depth) {
+          layer = l + 1;
+          break;
+        }
       }
     } else {
-      layer = (eta > hpar->noff[2]) ? maxLayerHB_+1 : maxLayer_;
+      layer = (eta > hpar->noff[2]) ? maxLayerHB_ + 1 : maxLayer_;
     }
   }
   return layer;
 }
 
-int HcalDDDSimConstants::getLayerBack(const int& det, const int& eta, 
-				      const int& phi, const int& zside,
-				      const int& depth) const {
-
+int HcalDDDSimConstants::getLayerBack(
+    const int& det, const int& eta, const int& phi, const int& zside, const int& depth) const {
   int layer = ldmap_.getLayerBack(det, eta, phi, zside, depth);
   if (layer < 0) {
-    if (det == 1 || det ==2) {
-      layer = depths[depth-1][eta-1];
+    if (det == 1 || det == 2) {
+      layer = depths[depth - 1][eta - 1];
     } else {
       layer = maxLayer_;
     }
@@ -402,32 +398,29 @@ int HcalDDDSimConstants::getLayerBack(const int& det, const int& eta,
 }
 
 int HcalDDDSimConstants::getLayerMax(const int& eta, const int& depth) const {
-
-  int layermx =  ((eta < hpar->etaMin[1]) && depth-1 < maxDepth[0]) ? maxLayerHB_+1 : (int)layerGroupSize(eta-1);
+  int layermx = ((eta < hpar->etaMin[1]) && depth - 1 < maxDepth[0]) ? maxLayerHB_ + 1 : (int)layerGroupSize(eta - 1);
   return layermx;
 }
 
-int HcalDDDSimConstants::getMaxDepth(const int& det, const int& eta, 
-				     const int& phi, const int& zside,
-				     const bool& partialDetOnly) const {
-
+int HcalDDDSimConstants::getMaxDepth(
+    const int& det, const int& eta, const int& phi, const int& zside, const bool& partialDetOnly) const {
   int dmax(-1);
   if (partialDetOnly) {
-    if (ldmap_.isValid(det,phi,zside)) {
+    if (ldmap_.isValid(det, phi, zside)) {
       dmax = ldmap_.getDepths(eta).second;
     }
   } else if (det == 1 || det == 2) {
-    if (ldmap_.isValid(det,phi,zside))
+    if (ldmap_.isValid(det, phi, zside))
       dmax = ldmap_.getDepths(eta).second;
-    else if (det == 2)               
-      dmax = (maxDepth[1] > 0) ? layerGroup(eta-1,maxLayer_) : 0;
-    else if (eta == hpar->etaMax[0]) 
-      dmax = getDepthEta16(det,phi,zside);
-    else                             
-      dmax = layerGroup(eta-1,maxLayerHB_);
-  } else if (det == 3) { // HF
-    dmax = maxHFDepth(zside*eta,phi);
-  } else if (det == 4) { // HO
+    else if (det == 2)
+      dmax = (maxDepth[1] > 0) ? layerGroup(eta - 1, maxLayer_) : 0;
+    else if (eta == hpar->etaMax[0])
+      dmax = getDepthEta16(det, phi, zside);
+    else
+      dmax = layerGroup(eta - 1, maxLayerHB_);
+  } else if (det == 3) {  // HF
+    dmax = maxHFDepth(zside * eta, phi);
+  } else if (det == 4) {  // HO
     dmax = maxDepth[3];
   } else {
     dmax = -1;
@@ -435,27 +428,25 @@ int HcalDDDSimConstants::getMaxDepth(const int& det, const int& eta,
   return dmax;
 }
 
-int HcalDDDSimConstants::getMinDepth(const int& det, const int& eta, 
-				     const int& phi, const int& zside,
-				     const bool& partialDetOnly) const {
-
+int HcalDDDSimConstants::getMinDepth(
+    const int& det, const int& eta, const int& phi, const int& zside, const bool& partialDetOnly) const {
   int lmin(-1);
   if (partialDetOnly) {
-    if (ldmap_.isValid(det,phi,zside)) {
+    if (ldmap_.isValid(det, phi, zside)) {
       lmin = ldmap_.getDepths(eta).first;
     }
-  } else if (det == 3) { // HF
+  } else if (det == 3) {  // HF
     lmin = 1;
-  } else if (det == 4) { // HO
+  } else if (det == 4) {  // HO
     lmin = maxDepth[3];
   } else {
-    if (ldmap_.isValid(det,phi,zside)) {
+    if (ldmap_.isValid(det, phi, zside)) {
       lmin = ldmap_.getDepths(eta).first;
-    } else if (layerGroupSize(eta-1) > 0) {
-      lmin = (int)(layerGroup(eta-1, 0));
-      unsigned int type  = (det == 1) ? 0 : 1;
-      if (type == 1 && eta == hpar->etaMin[1]) 
-	lmin = getDepthEta16(det, phi, zside);
+    } else if (layerGroupSize(eta - 1) > 0) {
+      lmin = (int)(layerGroup(eta - 1, 0));
+      unsigned int type = (det == 1) ? 0 : 1;
+      if (type == 1 && eta == hpar->etaMin[1])
+        lmin = getDepthEta16(det, phi, zside);
     } else {
       lmin = 1;
     }
@@ -463,194 +454,198 @@ int HcalDDDSimConstants::getMinDepth(const int& det, const int& eta,
   return lmin;
 }
 
-std::pair<int,int> HcalDDDSimConstants::getModHalfHBHE(const int& type) const {
-
+std::pair<int, int> HcalDDDSimConstants::getModHalfHBHE(const int& type) const {
   if (type == 0) {
-    return std::pair<int,int>(nmodHB,nzHB);
+    return std::pair<int, int>(nmodHB, nzHB);
   } else {
-    return std::pair<int,int>(nmodHE,nzHE);
+    return std::pair<int, int>(nmodHE, nzHE);
   }
 }
 
-std::pair<double,double> HcalDDDSimConstants::getPhiCons(const int& det, 
-							 const int& ieta) const {
-  
+std::pair<double, double> HcalDDDSimConstants::getPhiCons(const int& det, const int& ieta) const {
   double fioff(0), fibin(0);
-  if (det == static_cast<int>(HcalForward)) { // Forward HCal
-    fioff   = hpar->phioff[2];
-    fibin   = hpar->phitable[ieta-hpar->etaMin[2]];
-    if  (unitPhi(fibin) > 2) {   // HF double-phi  
+  if (det == static_cast<int>(HcalForward)) {  // Forward HCal
+    fioff = hpar->phioff[2];
+    fibin = hpar->phitable[ieta - hpar->etaMin[2]];
+    if (unitPhi(fibin) > 2) {  // HF double-phi
       fioff = hpar->phioff[4];
     }
-  } else { // Barrel or Endcap
+  } else {  // Barrel or Endcap
     if (det == static_cast<int>(HcalEndcap)) {
-      fioff   = hpar->phioff[1];
+      fioff = hpar->phioff[1];
     } else {
-      fioff   = hpar->phioff[0];
+      fioff = hpar->phioff[0];
     }
-    fibin = hpar->phibin[ieta-1];
+    fibin = hpar->phibin[ieta - 1];
   }
-  return std::pair<double,double>(fioff,fibin);
+  return std::pair<double, double>(fioff, fibin);
 }
 
-std::vector<std::pair<int,double> >
-HcalDDDSimConstants::getPhis(const int& subdet, const int& ieta) const {
-
-  std::vector<std::pair<int,double> > phis;
+std::vector<std::pair<int, double> > HcalDDDSimConstants::getPhis(const int& subdet, const int& ieta) const {
+  std::vector<std::pair<int, double> > phis;
   int ietaAbs = (ieta > 0) ? ieta : -ieta;
-  std::pair<double,double> ficons = getPhiCons(subdet, ietaAbs);
-  int nphi    = int((2._pi+0.1*ficons.second)/ficons.second);
-  int units   = unitPhi(subdet, ietaAbs);
+  std::pair<double, double> ficons = getPhiCons(subdet, ietaAbs);
+  int nphi = int((2._pi + 0.1 * ficons.second) / ficons.second);
+  int units = unitPhi(subdet, ietaAbs);
   for (int ifi = 0; ifi < nphi; ++ifi) {
-    double phi =-ficons.first + (ifi+0.5)*ficons.second;
-    int iphi   = phiNumber(ifi+1,units);
-    phis.emplace_back(std::pair<int,double>(iphi,phi));
+    double phi = -ficons.first + (ifi + 0.5) * ficons.second;
+    int iphi = phiNumber(ifi + 1, units);
+    phis.emplace_back(std::pair<int, double>(iphi, phi));
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "getPhis: subdet|ieta|iphi " << subdet << "|"
-			       << ieta << " with " << phis.size() 
-			       << " phi bins";
-  for (unsigned int k=0; k<phis.size(); ++k)
-    edm::LogVerbatim("HcalGeom") << "[" << k << "] iphi " << phis[k].first 
-				 << " phi " << convertRadToDeg(phis[k].second);
+  edm::LogVerbatim("HcalGeom") << "getPhis: subdet|ieta|iphi " << subdet << "|" << ieta << " with " << phis.size()
+                               << " phi bins";
+  for (unsigned int k = 0; k < phis.size(); ++k)
+    edm::LogVerbatim("HcalGeom") << "[" << k << "] iphi " << phis[k].first << " phi "
+                                 << convertRadToDeg(phis[k].second);
 #endif
   return phis;
 }
 
-std::vector<HcalCellType> HcalDDDSimConstants::HcalCellTypes() const{
-
+std::vector<HcalCellType> HcalDDDSimConstants::HcalCellTypes() const {
   std::vector<HcalCellType> cellTypes = HcalCellTypes(HcalBarrel);
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo ("HCalGeom") << "HcalDDDSimConstants: " << cellTypes.size()
-			    << " cells of type HCal Barrel\n";
-  for (unsigned int i=0; i<cellTypes.size(); i++)
-    edm::LogInfo ("HCalGeom") << "Cell " << i << " " << cellTypes[i] << "\n";
+  edm::LogInfo("HCalGeom") << "HcalDDDSimConstants: " << cellTypes.size() << " cells of type HCal Barrel\n";
+  for (unsigned int i = 0; i < cellTypes.size(); i++)
+    edm::LogInfo("HCalGeom") << "Cell " << i << " " << cellTypes[i] << "\n";
 #endif
 
-  std::vector<HcalCellType> hoCells   = HcalCellTypes(HcalOuter);
+  std::vector<HcalCellType> hoCells = HcalCellTypes(HcalOuter);
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo ("HCalGeom") << "HcalDDDSimConstants: " << hoCells.size()
-			    << " cells of type HCal Outer\n";
-  for (unsigned int i=0; i<hoCells.size(); i++)
-    edm::LogInfo ("HCalGeom") << "Cell " << i << " " << hoCells[i] << "\n";
+  edm::LogInfo("HCalGeom") << "HcalDDDSimConstants: " << hoCells.size() << " cells of type HCal Outer\n";
+  for (unsigned int i = 0; i < hoCells.size(); i++)
+    edm::LogInfo("HCalGeom") << "Cell " << i << " " << hoCells[i] << "\n";
 #endif
   cellTypes.insert(cellTypes.end(), hoCells.begin(), hoCells.end());
 
-  std::vector<HcalCellType> heCells   = HcalCellTypes(HcalEndcap);
+  std::vector<HcalCellType> heCells = HcalCellTypes(HcalEndcap);
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo ("HCalGeom") << "HcalDDDSimConstants: " << heCells.size()
-			    << " cells of type HCal Endcap\n";
-  for (unsigned int i=0; i<heCells.size(); i++)
-    edm::LogInfo ("HCalGeom") << "Cell " << i << " " << heCells[i] << "\n";
+  edm::LogInfo("HCalGeom") << "HcalDDDSimConstants: " << heCells.size() << " cells of type HCal Endcap\n";
+  for (unsigned int i = 0; i < heCells.size(); i++)
+    edm::LogInfo("HCalGeom") << "Cell " << i << " " << heCells[i] << "\n";
 #endif
   cellTypes.insert(cellTypes.end(), heCells.begin(), heCells.end());
 
-  std::vector<HcalCellType> hfCells   = HcalCellTypes(HcalForward);
+  std::vector<HcalCellType> hfCells = HcalCellTypes(HcalForward);
 #ifdef EDM_ML_DEBUG
-  edm::LogInfo ("HCalGeom") << "HcalDDDSimConstants: " << hfCells.size()
-			    << " cells of type HCal Forward\n";
-  for (unsigned int i=0; i<hfCells.size(); i++)
-    edm::LogInfo ("HCalGeom") << "Cell " << i << " " << hfCells[i] << "\n";
+  edm::LogInfo("HCalGeom") << "HcalDDDSimConstants: " << hfCells.size() << " cells of type HCal Forward\n";
+  for (unsigned int i = 0; i < hfCells.size(); i++)
+    edm::LogInfo("HCalGeom") << "Cell " << i << " " << hfCells[i] << "\n";
 #endif
   cellTypes.insert(cellTypes.end(), hfCells.begin(), hfCells.end());
 
   return cellTypes;
 }
 
-std::vector<HcalCellType> HcalDDDSimConstants::HcalCellTypes(const HcalSubdetector& subdet, 
-							     int ieta, int depthl) const {
-
+std::vector<HcalCellType> HcalDDDSimConstants::HcalCellTypes(const HcalSubdetector& subdet,
+                                                             int ieta,
+                                                             int depthl) const {
   std::vector<HcalCellType> cellTypes;
   if (subdet == HcalForward) {
-    if (dzVcal < 0) return cellTypes;
+    if (dzVcal < 0)
+      return cellTypes;
   }
 
-  int    dmin, dmax, indx, nz;
+  int dmin, dmax, indx, nz;
   double hsize = 0;
-  switch(subdet) {
-  case HcalEndcap:
-    dmin = 1; dmax = (maxDepth[1] > 0) ? maxLayer_+1 : 0; indx = 1; nz = nzHE;
-    break;
-  case HcalForward:
-    dmin = 1; dmax = (!idHF2QIE.empty()) ? 2 : maxDepth[2]; indx = 2; nz = 2;
-    break;
-  case HcalOuter:
-    dmin = 4; dmax = 4; indx = 0; nz = nzHB;
-    break;
-  default:
-    dmin = 1; dmax = maxLayerHB_+1; indx = 0; nz = nzHB;
-    break;
+  switch (subdet) {
+    case HcalEndcap:
+      dmin = 1;
+      dmax = (maxDepth[1] > 0) ? maxLayer_ + 1 : 0;
+      indx = 1;
+      nz = nzHE;
+      break;
+    case HcalForward:
+      dmin = 1;
+      dmax = (!idHF2QIE.empty()) ? 2 : maxDepth[2];
+      indx = 2;
+      nz = 2;
+      break;
+    case HcalOuter:
+      dmin = 4;
+      dmax = 4;
+      indx = 0;
+      nz = nzHB;
+      break;
+    default:
+      dmin = 1;
+      dmax = maxLayerHB_ + 1;
+      indx = 0;
+      nz = nzHB;
+      break;
   }
-  if (depthl > 0) dmin = dmax = depthl;
-  int ietamin = (ieta>0) ? ieta : hpar->etaMin[indx];
-  int ietamax = (ieta>0) ? ieta : hpar->etaMax[indx];
-  int phi     = (indx == 2) ? 3 : 1;
+  if (depthl > 0)
+    dmin = dmax = depthl;
+  int ietamin = (ieta > 0) ? ieta : hpar->etaMin[indx];
+  int ietamax = (ieta > 0) ? ieta : hpar->etaMax[indx];
+  int phi = (indx == 2) ? 3 : 1;
 
-  // Get the Cells 
+  // Get the Cells
   int subdet0 = static_cast<int>(subdet);
-  for (int depth=dmin; depth<=dmax; depth++) {
-    int    shift = getShift(subdet, depth);
-    double gain  = getGain (subdet, depth);
+  for (int depth = dmin; depth <= dmax; depth++) {
+    int shift = getShift(subdet, depth);
+    double gain = getGain(subdet, depth);
     if (subdet == HcalForward) {
-      if (depth%2 == 1) hsize = dzVcal;
-      else              hsize = dzVcal-0.5*dlShort;
-    } 
-    for (int eta=ietamin; eta<=ietamax; eta++) {
-      for (int iz=0; iz<nz; ++iz) {
-	int zside = -2*iz + 1;
-	HcalCellType::HcalCell temp1 = cell(subdet0,zside,depth,eta,phi);
-	if (temp1.ok) {
-	  std::vector<std::pair<int,double> > phis = getPhis(subdet0,eta);
-	  HcalCellType temp2(subdet, eta, zside, depth, temp1,
-			     shift, gain, hsize);
-	  double dphi, fioff;
-	  std::vector<int> phiMiss2;
-	  if      ((subdet == HcalBarrel) || (subdet == HcalOuter)) {
-	    fioff = hpar->phioff[0];
-	    dphi  = hpar->phibin[eta-1];
-	    if (subdet == HcalOuter) {
-	      if (eta == hpar->noff[4]) {
-		int kk = (iz == 0) ? 7 : (7+hpar->noff[5]);
-		for (int miss=0; miss<hpar->noff[5+iz]; miss++) {
-		  phiMiss2.emplace_back(hpar->noff[kk]);
-		  kk++;
-		}
-	      }
-	    }
-	  } else if (subdet == HcalEndcap) {
-	    fioff = hpar->phioff[1];
-	    dphi  = hpar->phibin[eta-1];
-	  } else {
-	    fioff = hpar->phioff[2];
-	    dphi  = hpar->phitable[eta-hpar->etaMin[2]];
-	    if (unitPhi(dphi) > 2) fioff = hpar->phioff[4];
-	  }
-	  int unit  = unitPhi(dphi);
-	  temp2.setPhi(phis,phiMiss2,fioff,dphi,unit);
-	  cellTypes.emplace_back(temp2);
-	  // For HF look at extra cells
-	  if ((subdet == HcalForward) && (!idHF2QIE.empty())) {
-	    HcalCellType temp3(subdet, eta, zside+2, depth, temp1,
-			       shift, gain, hsize);
-	    std::vector<int> phiMiss3;
-	    for (auto & phi : phis) {
-	      bool ok(false);
-	      for (auto l : idHF2QIE) {
-		if ((eta*zside     == l.ieta()) && 
-		    (phi.first == l.iphi())) {
-		  ok = true;
-		  break;
-		}
-	      }
-	      if (!ok) phiMiss3.emplace_back(phi.first);
-	    }
-	    dphi  = hpar->phitable[eta-hpar->etaMin[2]];
-	    unit  = unitPhi(dphi);
-	    fioff = (unit > 2) ? hpar->phioff[4] : hpar->phioff[2];
-	    temp3.setPhi(phis,phiMiss2,fioff,dphi,unit);
-	    cellTypes.emplace_back(temp3);
-	  }
-	}
+      if (depth % 2 == 1)
+        hsize = dzVcal;
+      else
+        hsize = dzVcal - 0.5 * dlShort;
+    }
+    for (int eta = ietamin; eta <= ietamax; eta++) {
+      for (int iz = 0; iz < nz; ++iz) {
+        int zside = -2 * iz + 1;
+        HcalCellType::HcalCell temp1 = cell(subdet0, zside, depth, eta, phi);
+        if (temp1.ok) {
+          std::vector<std::pair<int, double> > phis = getPhis(subdet0, eta);
+          HcalCellType temp2(subdet, eta, zside, depth, temp1, shift, gain, hsize);
+          double dphi, fioff;
+          std::vector<int> phiMiss2;
+          if ((subdet == HcalBarrel) || (subdet == HcalOuter)) {
+            fioff = hpar->phioff[0];
+            dphi = hpar->phibin[eta - 1];
+            if (subdet == HcalOuter) {
+              if (eta == hpar->noff[4]) {
+                int kk = (iz == 0) ? 7 : (7 + hpar->noff[5]);
+                for (int miss = 0; miss < hpar->noff[5 + iz]; miss++) {
+                  phiMiss2.emplace_back(hpar->noff[kk]);
+                  kk++;
+                }
+              }
+            }
+          } else if (subdet == HcalEndcap) {
+            fioff = hpar->phioff[1];
+            dphi = hpar->phibin[eta - 1];
+          } else {
+            fioff = hpar->phioff[2];
+            dphi = hpar->phitable[eta - hpar->etaMin[2]];
+            if (unitPhi(dphi) > 2)
+              fioff = hpar->phioff[4];
+          }
+          int unit = unitPhi(dphi);
+          temp2.setPhi(phis, phiMiss2, fioff, dphi, unit);
+          cellTypes.emplace_back(temp2);
+          // For HF look at extra cells
+          if ((subdet == HcalForward) && (!idHF2QIE.empty())) {
+            HcalCellType temp3(subdet, eta, zside + 2, depth, temp1, shift, gain, hsize);
+            std::vector<int> phiMiss3;
+            for (auto& phi : phis) {
+              bool ok(false);
+              for (auto l : idHF2QIE) {
+                if ((eta * zside == l.ieta()) && (phi.first == l.iphi())) {
+                  ok = true;
+                  break;
+                }
+              }
+              if (!ok)
+                phiMiss3.emplace_back(phi.first);
+            }
+            dphi = hpar->phitable[eta - hpar->etaMin[2]];
+            unit = unitPhi(dphi);
+            fioff = (unit > 2) ? hpar->phioff[4] : hpar->phioff[2];
+            temp3.setPhi(phis, phiMiss2, fioff, dphi, unit);
+            cellTypes.emplace_back(temp3);
+          }
+        }
       }
     }
   }
@@ -663,200 +658,197 @@ int HcalDDDSimConstants::maxHFDepth(const int& eta, const int& iphi) const {
     bool ok(false);
     for (auto k : idHF2QIE) {
       if ((eta == k.ieta()) && (iphi == k.iphi())) {
-	ok = true; break;
+        ok = true;
+        break;
       }
     }
-    if (!ok) mxdepth = 2;
+    if (!ok)
+      mxdepth = 2;
   }
   return mxdepth;
 }
 
-unsigned int HcalDDDSimConstants::numberOfCells(const HcalSubdetector& subdet) const{
-
+unsigned int HcalDDDSimConstants::numberOfCells(const HcalSubdetector& subdet) const {
   unsigned int num = 0;
   std::vector<HcalCellType> cellTypes = HcalCellTypes(subdet);
-  for (auto & cellType : cellTypes) {
+  for (auto& cellType : cellTypes) {
     num += (unsigned int)(cellType.nPhiBins());
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants:numberOfCells " 
-			       << cellTypes.size()  << " " << num 
-			       << " for subdetector " << subdet;
+  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants:numberOfCells " << cellTypes.size() << " " << num
+                               << " for subdetector " << subdet;
 #endif
   return num;
 }
 
 int HcalDDDSimConstants::phiNumber(const int& phi, const int& units) const {
-
   int iphi_skip = phi;
-  if      (units==2) iphi_skip  = (phi-1)*2+1;
-  else if (units==4) iphi_skip  = (phi-1)*4-1;
-  if (iphi_skip < 0) iphi_skip += 72;
+  if (units == 2)
+    iphi_skip = (phi - 1) * 2 + 1;
+  else if (units == 4)
+    iphi_skip = (phi - 1) * 4 - 1;
+  if (iphi_skip < 0)
+    iphi_skip += 72;
   return iphi_skip;
 }
 
 void HcalDDDSimConstants::printTiles() const {
- 
   std::vector<int> phis;
   int detsp = ldmap_.validDet(phis);
-  int kphi  = (detsp > 0) ? phis[0] : 1;
+  int kphi = (detsp > 0) ? phis[0] : 1;
   int zside = (kphi > 0) ? 1 : -1;
-  int iphi  = (kphi > 0) ? kphi : -kphi;
-  edm::LogVerbatim("HcalGeom") << "Tile Information for HB from " 
-			       << hpar->etaMin[0] << " to " << hpar->etaMax[0]
-			       << "\n";
-  for (int eta=hpar->etaMin[0]; eta<= hpar->etaMax[0]; eta++) {
-    int dmax = getMaxDepth(1,eta,iphi,-zside,false);
-    for (int depth=1; depth<=dmax; depth++) 
+  int iphi = (kphi > 0) ? kphi : -kphi;
+  edm::LogVerbatim("HcalGeom") << "Tile Information for HB from " << hpar->etaMin[0] << " to " << hpar->etaMax[0]
+                               << "\n";
+  for (int eta = hpar->etaMin[0]; eta <= hpar->etaMax[0]; eta++) {
+    int dmax = getMaxDepth(1, eta, iphi, -zside, false);
+    for (int depth = 1; depth <= dmax; depth++)
       printTileHB(eta, iphi, -zside, depth);
     if (detsp == 1) {
-      int dmax = getMaxDepth(1,eta,iphi,zside,false);
-      for (int depth=1; depth<=dmax; depth++) 
-	printTileHB(eta, iphi, zside, depth);
+      int dmax = getMaxDepth(1, eta, iphi, zside, false);
+      for (int depth = 1; depth <= dmax; depth++)
+        printTileHB(eta, iphi, zside, depth);
     }
   }
 
-  edm::LogVerbatim("HcalGeom") << "\nTile Information for HE from " 
-			       << hpar->etaMin[1] << " to " << hpar->etaMax[1]
-			       << "\n";
-  for (int eta=hpar->etaMin[1]; eta<= hpar->etaMax[1]; eta++) {
-    int dmin = (eta == hpar->etaMin[1]) ? getDepthEta16(2,iphi,-zside) : 1;
-    int dmax = getMaxDepth(2,eta,iphi,-zside,false);
-    for (int depth=dmin; depth<=dmax; depth++)
+  edm::LogVerbatim("HcalGeom") << "\nTile Information for HE from " << hpar->etaMin[1] << " to " << hpar->etaMax[1]
+                               << "\n";
+  for (int eta = hpar->etaMin[1]; eta <= hpar->etaMax[1]; eta++) {
+    int dmin = (eta == hpar->etaMin[1]) ? getDepthEta16(2, iphi, -zside) : 1;
+    int dmax = getMaxDepth(2, eta, iphi, -zside, false);
+    for (int depth = dmin; depth <= dmax; depth++)
       printTileHE(eta, iphi, -zside, depth);
     if (detsp == 2) {
-      int dmax = getMaxDepth(2,eta,iphi,zside,false);
-      for (int depth=1; depth<=dmax; depth++) 
-	printTileHE(eta, iphi, zside, depth);
+      int dmax = getMaxDepth(2, eta, iphi, zside, false);
+      for (int depth = 1; depth <= dmax; depth++)
+        printTileHE(eta, iphi, zside, depth);
     }
   }
 }
 
 int HcalDDDSimConstants::unitPhi(const int& det, const int& etaR) const {
-
-  double dphi = (det == static_cast<int>(HcalForward)) ? hpar->phitable[etaR-hpar->etaMin[2]] : hpar->phibin[etaR-1];
+  double dphi =
+      (det == static_cast<int>(HcalForward)) ? hpar->phitable[etaR - hpar->etaMin[2]] : hpar->phibin[etaR - 1];
   return unitPhi(dphi);
 }
 
 int HcalDDDSimConstants::unitPhi(const double& dphi) const {
-
-  const double fiveDegInRad = 2*M_PI/72;
-  int units = int(dphi/fiveDegInRad+0.5);
-  if (units < 1) units = 1;
+  const double fiveDegInRad = 2 * M_PI / 72;
+  int units = int(dphi / fiveDegInRad + 0.5);
+  if (units < 1)
+    units = 1;
   return units;
 }
 
-void HcalDDDSimConstants::initialize( void ) {
-
-  nEta      = hpar->etaTable.size();
-  nR        = hpar->rTable.size();
-  nPhiF     = nR - 1;
-  isBH_     = false;
+void HcalDDDSimConstants::initialize(void) {
+  nEta = hpar->etaTable.size();
+  nR = hpar->rTable.size();
+  nPhiF = nR - 1;
+  isBH_ = false;
 
 #ifdef EDM_ML_DEBUG
-  for (int i=0; i<nEta-1; ++i) {
-    edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants:Read LayerGroup" 
-				 << i << ":";
-    for (unsigned int k=0; k<layerGroupSize( i ); k++) 
+  for (int i = 0; i < nEta - 1; ++i) {
+    edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants:Read LayerGroup" << i << ":";
+    for (unsigned int k = 0; k < layerGroupSize(i); k++)
       edm::LogVerbatim("HcalGeom") << " [" << k << "] = " << layerGroup(i, k);
   }
 #endif
 
   // Geometry parameters for HF
-  dlShort   = hpar->gparHF[0];
-  zVcal     = hpar->gparHF[4];
-  dzVcal    = hpar->dzVcal;
+  dlShort = hpar->gparHF[0];
+  zVcal = hpar->gparHF[4];
+  dzVcal = hpar->dzVcal;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants: dlShort " << dlShort
-			       << " zVcal " << zVcal << " and dzVcal " 
-			       << dzVcal;
+  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants: dlShort " << dlShort << " zVcal " << zVcal << " and dzVcal "
+                               << dzVcal;
 #endif
 
   //Transform some of the parameters
   maxDepth = hpar->maxDepth;
   maxDepth[0] = maxDepth[1] = 0;
-  for (int i=0; i<nEta-1; ++i) {
-    unsigned int imx = layerGroupSize( i );
-    int laymax = (imx > 0) ? layerGroup( i, imx-1 ) : 0;
+  for (int i = 0; i < nEta - 1; ++i) {
+    unsigned int imx = layerGroupSize(i);
+    int laymax = (imx > 0) ? layerGroup(i, imx - 1) : 0;
     if (i < hpar->etaMax[0]) {
       int laymax0 = (imx > 16) ? layerGroup(i, 16) : laymax;
-      if (i+1 == hpar->etaMax[0] && laymax0 > 2) laymax0 = 2;
-      if (maxDepth[0] < laymax0) maxDepth[0] = laymax0;
+      if (i + 1 == hpar->etaMax[0] && laymax0 > 2)
+        laymax0 = 2;
+      if (maxDepth[0] < laymax0)
+        maxDepth[0] = laymax0;
     }
-    if (i >= hpar->etaMin[1]-1 && i < hpar->etaMax[1]) {
-      if (maxDepth[1] < laymax) maxDepth[1] = laymax;
+    if (i >= hpar->etaMin[1] - 1 && i < hpar->etaMax[1]) {
+      if (maxDepth[1] < laymax)
+        maxDepth[1] = laymax;
     }
   }
 #ifdef EDM_ML_DEBUG
-  for (int i=0; i<4; ++i)
-    edm::LogVerbatim("HcalGeom") << "Detector Type [" << i << "] iEta " 
-				 << hpar->etaMin[i] << ":" << hpar->etaMax[i] 
-				 << " MaxDepth " << maxDepth[i];
+  for (int i = 0; i < 4; ++i)
+    edm::LogVerbatim("HcalGeom") << "Detector Type [" << i << "] iEta " << hpar->etaMin[i] << ":" << hpar->etaMax[i]
+                                 << " MaxDepth " << maxDepth[i];
 #endif
 
-  int maxdepth = (maxDepth[1]>maxDepth[0]) ? maxDepth[1] : maxDepth[0];
-  for (int i=0; i<maxdepth; ++i) {
-    for (int k=0; k<nEta-1; ++k) {
-      int layermx = getLayerMax(k+1,i+1);
-      int ll      = layermx;
-      for (int l=layermx-1; l >= 0; --l) {
-	if ((int)layerGroup( k, l ) == i+1) {
-	  ll = l+1; break;
-	}
+  int maxdepth = (maxDepth[1] > maxDepth[0]) ? maxDepth[1] : maxDepth[0];
+  for (int i = 0; i < maxdepth; ++i) {
+    for (int k = 0; k < nEta - 1; ++k) {
+      int layermx = getLayerMax(k + 1, i + 1);
+      int ll = layermx;
+      for (int l = layermx - 1; l >= 0; --l) {
+        if ((int)layerGroup(k, l) == i + 1) {
+          ll = l + 1;
+          break;
+        }
       }
       depths[i].emplace_back(ll);
     }
 
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HcalGeom") << "Depth " << i+1 << " with " 
-				 << depths[i].size() << " etas:";
-    for (int k=0; k<nEta-1; ++k) 
+    edm::LogVerbatim("HcalGeom") << "Depth " << i + 1 << " with " << depths[i].size() << " etas:";
+    for (int k = 0; k < nEta - 1; ++k)
       edm::LogVerbatim("HcalGeom") << " [" << k << "] " << depths[i][k];
 #endif
   }
 
-  nzHB   = hpar->modHB[1];
+  nzHB = hpar->modHB[1];
   nmodHB = hpar->modHB[0];
-  nzHE   = hpar->modHE[1];
+  nzHE = hpar->modHE[1];
   nmodHE = hpar->modHE[0];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants:: " << nzHB << ":" 
-			       << nmodHB << " barrel and " << nzHE << ":" 
-			       << nmodHE << " endcap half-sectors";
+  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants:: " << nzHB << ":" << nmodHB << " barrel and " << nzHE << ":"
+                               << nmodHE << " endcap half-sectors";
 #endif
 
-  if (hpar->rHB.size() > maxLayerHB_+1 && hpar->zHO.size() > 4) {
-    rminHO   = hpar->rHO[0];
-    for (int k=0; k<4; ++k) etaHO[k] = hpar->rHO[k+1];
+  if (hpar->rHB.size() > maxLayerHB_ + 1 && hpar->zHO.size() > 4) {
+    rminHO = hpar->rHO[0];
+    for (int k = 0; k < 4; ++k)
+      etaHO[k] = hpar->rHO[k + 1];
   } else {
-    rminHO   =-1.0;
+    rminHO = -1.0;
     etaHO[0] = hpar->etaTable[4];
     etaHO[1] = hpar->etaTable[4];
     etaHO[2] = hpar->etaTable[10];
     etaHO[3] = hpar->etaTable[10];
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "HO Eta boundaries " << etaHO[0] << " " 
-			       << etaHO[1] << " " << etaHO[2] << " " 
-			       << etaHO[3];
-  edm::LogVerbatim("HcalGeom") << "HO Parameters " << rminHO << " " 
-			       << hpar->zHO.size();
-  for (int i=0; i<4; ++i) 
+  edm::LogVerbatim("HcalGeom") << "HO Eta boundaries " << etaHO[0] << " " << etaHO[1] << " " << etaHO[2] << " "
+                               << etaHO[3];
+  edm::LogVerbatim("HcalGeom") << "HO Parameters " << rminHO << " " << hpar->zHO.size();
+  for (int i = 0; i < 4; ++i)
     edm::LogVerbatim("HcalGeom") << " eta[" << i << "] = " << etaHO[i];
-  for (unsigned int i=0; i<hpar->zHO.size(); ++i) 
+  for (unsigned int i = 0; i < hpar->zHO.size(); ++i)
     edm::LogVerbatim("HcalGeom") << " zHO[" << i << "] = " << hpar->zHO[i];
 #endif
 
   int noffsize = 7 + hpar->noff[5] + hpar->noff[6];
-  int noffl(noffsize+5);
-  if ((int)(hpar->noff.size()) > (noffsize+3)) {
+  int noffl(noffsize + 5);
+  if ((int)(hpar->noff.size()) > (noffsize + 3)) {
     depthEta16[0] = hpar->noff[noffsize];
-    depthEta16[1] = hpar->noff[noffsize+1];
-    depthEta29[0] = hpar->noff[noffsize+2];
-    depthEta29[1] = hpar->noff[noffsize+3];
-    if ((int)(hpar->noff.size()) > (noffsize+4)) {
-      noffl += (2*hpar->noff[noffsize+4]);
-      if ((int)(hpar->noff.size()) > noffl) isBH_ = (hpar->noff[noffl] > 0);
+    depthEta16[1] = hpar->noff[noffsize + 1];
+    depthEta29[0] = hpar->noff[noffsize + 2];
+    depthEta29[1] = hpar->noff[noffsize + 3];
+    if ((int)(hpar->noff.size()) > (noffsize + 4)) {
+      noffl += (2 * hpar->noff[noffsize + 4]);
+      if ((int)(hpar->noff.size()) > noffl)
+        isBH_ = (hpar->noff[noffl] > 0);
     }
   } else {
     depthEta16[0] = 2;
@@ -865,361 +857,344 @@ void HcalDDDSimConstants::initialize( void ) {
     depthEta29[1] = 1;
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "isBH_ " << hpar->noff.size() << ":" 
-			       << noffsize << ":" << noffl << ":" << isBH_;
-  edm::LogVerbatim("HcalGeom") << "Depth index at ieta = 16 for HB (max) " 
-			       << depthEta16[0] << " HE (min) " <<depthEta16[1]
-			       << "; max depth for itea = 29 : ("
-			       << depthEta29[0] << ":" << depthEta29[1] << ")";
+  edm::LogVerbatim("HcalGeom") << "isBH_ " << hpar->noff.size() << ":" << noffsize << ":" << noffl << ":" << isBH_;
+  edm::LogVerbatim("HcalGeom") << "Depth index at ieta = 16 for HB (max) " << depthEta16[0] << " HE (min) "
+                               << depthEta16[1] << "; max depth for itea = 29 : (" << depthEta29[0] << ":"
+                               << depthEta29[1] << ")";
 #endif
-  
-  if ((int)(hpar->noff.size()) > (noffsize+4)) {
-    int npair = hpar->noff[noffsize+4];
-    int kk    = noffsize+4;
-    for (int k=0; k<npair; ++k) {
-      idHF2QIE.emplace_back(HcalDetId(HcalForward,hpar->noff[kk+1],hpar->noff[kk+2],1));
+
+  if ((int)(hpar->noff.size()) > (noffsize + 4)) {
+    int npair = hpar->noff[noffsize + 4];
+    int kk = noffsize + 4;
+    for (int k = 0; k < npair; ++k) {
+      idHF2QIE.emplace_back(HcalDetId(HcalForward, hpar->noff[kk + 1], hpar->noff[kk + 2], 1));
       kk += 2;
     }
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << idHF2QIE.size() 
-			       << " detector channels having 2 QIE cards:";
-  for (unsigned int k=0; k<idHF2QIE.size(); ++k) 
+  edm::LogVerbatim("HcalGeom") << idHF2QIE.size() << " detector channels having 2 QIE cards:";
+  for (unsigned int k = 0; k < idHF2QIE.size(); ++k)
     edm::LogVerbatim("HcalGeom") << " [" << k << "] " << idHF2QIE[k];
 #endif
 
-  layFHB[0] = 0;  layFHB[1] = 1;
-  layBHB[0] = 16; layBHB[1] = 15; layBHB[2] = 8;
+  layFHB[0] = 0;
+  layFHB[1] = 1;
+  layBHB[0] = 16;
+  layBHB[1] = 15;
+  layBHB[2] = 8;
   if (maxDepth[1] == 0) {
     layFHE[0] = layFHE[1] = layFHE[2] = 0;
     layBHE[0] = layBHE[1] = layBHE[2] = layBHE[3] = 0;
   } else {
-    layFHE[0] = 1;  layFHE[1] = 4;  layFHE[2] = 0;
-    layBHE[0] = 18; layBHE[1] = 9;  layBHE[2] = 14; layBHE[3] = 16;
+    layFHE[0] = 1;
+    layFHE[1] = 4;
+    layFHE[2] = 0;
+    layBHE[0] = 18;
+    layBHE[1] = 9;
+    layBHE[2] = 14;
+    layBHE[3] = 16;
   }
-  depthMaxSp_ = std::pair<int,int>(0,0);
-  int noffk(noffsize+5);
-  if ((int)(hpar->noff.size()) > (noffsize+5)) {
-    noffk += (2*hpar->noff[noffsize+4]);
-    if ((int)(hpar->noff.size()) >= noffk+7) {
-      int dtype = hpar->noff[noffk+1];
-      int nphi  = hpar->noff[noffk+2];
-      int ndeps = hpar->noff[noffk+3];
-      int ndp16 = hpar->noff[noffk+4];
-      int ndp29 = hpar->noff[noffk+5];
-      double wt = 0.1*(hpar->noff[noffk+6]);
-      if ((int)(hpar->noff.size()) >= (noffk+7+nphi+3*ndeps)) {
-	if (dtype == 1 || dtype == 2) {
-	  std::vector<int> ifi, iet, ily, idp;
-	  for (int i=0; i<nphi; ++i) ifi.emplace_back(hpar->noff[noffk+7+i]);
-	  for (int i=0; i<ndeps;++i) {
-	    iet.emplace_back(hpar->noff[noffk+7+nphi+3*i]);
-	    ily.emplace_back(hpar->noff[noffk+7+nphi+3*i+1]);
-	    idp.emplace_back(hpar->noff[noffk+7+nphi+3*i+2]);
-	  }
+  depthMaxSp_ = std::pair<int, int>(0, 0);
+  int noffk(noffsize + 5);
+  if ((int)(hpar->noff.size()) > (noffsize + 5)) {
+    noffk += (2 * hpar->noff[noffsize + 4]);
+    if ((int)(hpar->noff.size()) >= noffk + 7) {
+      int dtype = hpar->noff[noffk + 1];
+      int nphi = hpar->noff[noffk + 2];
+      int ndeps = hpar->noff[noffk + 3];
+      int ndp16 = hpar->noff[noffk + 4];
+      int ndp29 = hpar->noff[noffk + 5];
+      double wt = 0.1 * (hpar->noff[noffk + 6]);
+      if ((int)(hpar->noff.size()) >= (noffk + 7 + nphi + 3 * ndeps)) {
+        if (dtype == 1 || dtype == 2) {
+          std::vector<int> ifi, iet, ily, idp;
+          for (int i = 0; i < nphi; ++i)
+            ifi.emplace_back(hpar->noff[noffk + 7 + i]);
+          for (int i = 0; i < ndeps; ++i) {
+            iet.emplace_back(hpar->noff[noffk + 7 + nphi + 3 * i]);
+            ily.emplace_back(hpar->noff[noffk + 7 + nphi + 3 * i + 1]);
+            idp.emplace_back(hpar->noff[noffk + 7 + nphi + 3 * i + 2]);
+          }
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("HcalGeom") << "Initialize HcalLayerDepthMap for "
-				       << "Detector " << dtype << " etaMax "
-				       << hpar->etaMax[dtype] << " with " 
-				       << nphi << " sectors";
-	  for (int i=0; i<nphi; ++i) 
-	    edm::LogVerbatim("HcalGeom") << " [" << i << "] " << ifi[i];
-	  edm::LogVerbatim("HcalGeom") << "And " << ndeps << " depth sections";
-	  for (int i=0; i<ndeps;++i)
-	    edm::LogVerbatim("HcalGeom") << " [" << i << "] " << iet[i] << "  "
-					 << ily[i] << "  " << idp[i];
-	  edm::LogVerbatim("HcalGeom") <<"Maximum depth for last HE Eta tower "
-				       << depthEta29[0] << ":" << ndp16 << ":"
-				       << ndp29 << " L0 Wt " 
-				       << hpar->Layer0Wt[dtype-1] << ":" << wt;
+          edm::LogVerbatim("HcalGeom") << "Initialize HcalLayerDepthMap for "
+                                       << "Detector " << dtype << " etaMax " << hpar->etaMax[dtype] << " with " << nphi
+                                       << " sectors";
+          for (int i = 0; i < nphi; ++i)
+            edm::LogVerbatim("HcalGeom") << " [" << i << "] " << ifi[i];
+          edm::LogVerbatim("HcalGeom") << "And " << ndeps << " depth sections";
+          for (int i = 0; i < ndeps; ++i)
+            edm::LogVerbatim("HcalGeom") << " [" << i << "] " << iet[i] << "  " << ily[i] << "  " << idp[i];
+          edm::LogVerbatim("HcalGeom") << "Maximum depth for last HE Eta tower " << depthEta29[0] << ":" << ndp16 << ":"
+                                       << ndp29 << " L0 Wt " << hpar->Layer0Wt[dtype - 1] << ":" << wt;
 #endif
-	  ldmap_.initialize(dtype,hpar->etaMax[dtype-1],ndp16,ndp29,wt,ifi,iet,
-			    ily,idp);
-	  int zside   = (ifi[0]>0) ? 1 : -1;
-	  int iphi    = (ifi[0]>0) ? ifi[0] : -ifi[0];
-	  depthMaxSp_ = std::pair<int,int>(dtype,ldmap_.getDepthMax(dtype,iphi,zside));
-	}
+          ldmap_.initialize(dtype, hpar->etaMax[dtype - 1], ndp16, ndp29, wt, ifi, iet, ily, idp);
+          int zside = (ifi[0] > 0) ? 1 : -1;
+          int iphi = (ifi[0] > 0) ? ifi[0] : -ifi[0];
+          depthMaxSp_ = std::pair<int, int>(dtype, ldmap_.getDepthMax(dtype, iphi, zside));
+        }
       }
-      int noffm = (noffk+7+nphi+3*ndeps);
+      int noffm = (noffk + 7 + nphi + 3 * ndeps);
       if ((int)(hpar->noff.size()) > noffm) {
-	int ndnext = hpar->noff[noffm];
-	if (ndnext > 4 && (int)(hpar->noff.size()) >= noffm+ndnext) {
-	  for (int i=0; i<2; ++i) layFHB[i] = hpar->noff[noffm+i+1];
-	  for (int i=0; i<3; ++i) layFHE[i] = hpar->noff[noffm+i+3];
-	}
-	if (ndnext > 11 && (int)(hpar->noff.size()) >= noffm+ndnext) {
-	  for (int i=0; i<3; ++i) layBHB[i] = hpar->noff[noffm+i+6];
-	  for (int i=0; i<4; ++i) layBHE[i] = hpar->noff[noffm+i+9];
-	}
+        int ndnext = hpar->noff[noffm];
+        if (ndnext > 4 && (int)(hpar->noff.size()) >= noffm + ndnext) {
+          for (int i = 0; i < 2; ++i)
+            layFHB[i] = hpar->noff[noffm + i + 1];
+          for (int i = 0; i < 3; ++i)
+            layFHE[i] = hpar->noff[noffm + i + 3];
+        }
+        if (ndnext > 11 && (int)(hpar->noff.size()) >= noffm + ndnext) {
+          for (int i = 0; i < 3; ++i)
+            layBHB[i] = hpar->noff[noffm + i + 6];
+          for (int i = 0; i < 4; ++i)
+            layBHE[i] = hpar->noff[noffm + i + 9];
+        }
       }
     }
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "Front Layer Definition for HB: " 
-			       << layFHB[0] << ":" << layFHB[1] 
-			       << " and for HE: " << layFHE[0] << ":" 
-			       << layFHE[1] << ":" << layFHE[2];
-  edm::LogVerbatim("HcalGeom") << "Last Layer Definition for HB: " << layBHB[0]
-			       << ":" << layBHB[1] << ":" << layBHB[2]
-			       << " and for HE: " << layBHE[0] << ":" 
-			       << layBHE[1] << ":" << layBHE[2] << ":" 
-			       << layBHE[3];
+  edm::LogVerbatim("HcalGeom") << "Front Layer Definition for HB: " << layFHB[0] << ":" << layFHB[1]
+                               << " and for HE: " << layFHE[0] << ":" << layFHE[1] << ":" << layFHE[2];
+  edm::LogVerbatim("HcalGeom") << "Last Layer Definition for HB: " << layBHB[0] << ":" << layBHB[1] << ":" << layBHB[2]
+                               << " and for HE: " << layBHE[0] << ":" << layBHE[1] << ":" << layBHE[2] << ":"
+                               << layBHE[3];
 #endif
   if (depthMaxSp_.first == 0) {
-    depthMaxSp_ = depthMaxDf_ = std::pair<int,int>(2,maxDepth[1]);
+    depthMaxSp_ = depthMaxDf_ = std::pair<int, int>(2, maxDepth[1]);
   } else if (depthMaxSp_.first == 1) {
-    depthMaxDf_ = std::pair<int,int>(1,maxDepth[0]);
-    if (depthMaxSp_.second > maxDepth[0]) maxDepth[0] = depthMaxSp_.second;
+    depthMaxDf_ = std::pair<int, int>(1, maxDepth[0]);
+    if (depthMaxSp_.second > maxDepth[0])
+      maxDepth[0] = depthMaxSp_.second;
   } else {
-    depthMaxDf_ = std::pair<int,int>(2,maxDepth[1]);
-    if (depthMaxSp_.second > maxDepth[1]) maxDepth[1] = depthMaxSp_.second;
+    depthMaxDf_ = std::pair<int, int>(2, maxDepth[1]);
+    if (depthMaxSp_.second > maxDepth[1])
+      maxDepth[1] = depthMaxSp_.second;
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") <<"Detector type and maximum depth for all RBX "
-			       << depthMaxDf_.first << ":" <<depthMaxDf_.second
-			       << " and for special RBX " << depthMaxSp_.first
-			       << ":" << depthMaxSp_.second;
+  edm::LogVerbatim("HcalGeom") << "Detector type and maximum depth for all RBX " << depthMaxDf_.first << ":"
+                               << depthMaxDf_.second << " and for special RBX " << depthMaxSp_.first << ":"
+                               << depthMaxSp_.second;
 #endif
 }
 
-double HcalDDDSimConstants::deltaEta(const int& det, const int& etaR,
-				     const int& depth) const {
-
+double HcalDDDSimConstants::deltaEta(const int& det, const int& etaR, const int& depth) const {
   double tmp = 0;
   if (det == static_cast<int>(HcalForward)) {
     int ir = nR + hpar->etaMin[2] - etaR - 1;
     if (ir > 0 && ir < nR) {
       double z = zVcal;
-      if (depth%2 != 1) z += dlShort;
-      tmp = 0.5*(getEta(hpar->rTable[ir-1],z)-getEta(hpar->rTable[ir],z));
+      if (depth % 2 != 1)
+        z += dlShort;
+      tmp = 0.5 * (getEta(hpar->rTable[ir - 1], z) - getEta(hpar->rTable[ir], z));
     }
   } else {
     if (etaR > 0 && etaR < nEta) {
-      if (etaR == hpar->noff[1]-1 && depth > depthEta29[0]) {
-	tmp = 0.5*(hpar->etaTable[etaR+1]-hpar->etaTable[etaR-1]);
+      if (etaR == hpar->noff[1] - 1 && depth > depthEta29[0]) {
+        tmp = 0.5 * (hpar->etaTable[etaR + 1] - hpar->etaTable[etaR - 1]);
       } else if (det == static_cast<int>(HcalOuter)) {
-	if (etaR == hpar->noff[2]) {
-	  tmp = 0.5*(etaHO[0]-hpar->etaTable[etaR-1]);
-	} else if (etaR == hpar->noff[2]+1) {
-	  tmp = 0.5*(hpar->etaTable[etaR]-etaHO[1]);
-	} else if (etaR == hpar->noff[3]) {
-	  tmp = 0.5*(etaHO[2]-hpar->etaTable[etaR-1]);
-	} else if (etaR == hpar->noff[3]+1) {
-	  tmp = 0.5*(hpar->etaTable[etaR]-etaHO[3]);
-	} else {
-	  tmp = 0.5*(hpar->etaTable[etaR]-hpar->etaTable[etaR-1]);
-	}
+        if (etaR == hpar->noff[2]) {
+          tmp = 0.5 * (etaHO[0] - hpar->etaTable[etaR - 1]);
+        } else if (etaR == hpar->noff[2] + 1) {
+          tmp = 0.5 * (hpar->etaTable[etaR] - etaHO[1]);
+        } else if (etaR == hpar->noff[3]) {
+          tmp = 0.5 * (etaHO[2] - hpar->etaTable[etaR - 1]);
+        } else if (etaR == hpar->noff[3] + 1) {
+          tmp = 0.5 * (hpar->etaTable[etaR] - etaHO[3]);
+        } else {
+          tmp = 0.5 * (hpar->etaTable[etaR] - hpar->etaTable[etaR - 1]);
+        }
       } else {
-	tmp = 0.5*(hpar->etaTable[etaR]-hpar->etaTable[etaR-1]);
+        tmp = 0.5 * (hpar->etaTable[etaR] - hpar->etaTable[etaR - 1]);
       }
-    } 
+    }
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants::deltaEta " << etaR 
-			       << " " << depth << " ==> " << tmp;
+  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants::deltaEta " << etaR << " " << depth << " ==> " << tmp;
 #endif
   return tmp;
 }
 
-double HcalDDDSimConstants::getEta(const int& det,   const int& etaR,
-				   const int& zside, int depth) const {
-
+double HcalDDDSimConstants::getEta(const int& det, const int& etaR, const int& zside, int depth) const {
   double tmp = 0;
   if (det == static_cast<int>(HcalForward)) {
     int ir = nR + hpar->etaMin[2] - etaR - 1;
     if (ir > 0 && ir < nR) {
       double z = zVcal;
-      if (depth%2 != 1) z += dlShort;
-      tmp = 0.5*(getEta(hpar->rTable[ir-1],z)+getEta(hpar->rTable[ir],z));
+      if (depth % 2 != 1)
+        z += dlShort;
+      tmp = 0.5 * (getEta(hpar->rTable[ir - 1], z) + getEta(hpar->rTable[ir], z));
     }
   } else {
     if (etaR > 0 && etaR < nEta) {
-      if (etaR == hpar->noff[1]-1 && depth > depthEta29[0]) {
-	tmp = 0.5*(hpar->etaTable[etaR+1]+hpar->etaTable[etaR-1]);
+      if (etaR == hpar->noff[1] - 1 && depth > depthEta29[0]) {
+        tmp = 0.5 * (hpar->etaTable[etaR + 1] + hpar->etaTable[etaR - 1]);
       } else if (det == static_cast<int>(HcalOuter)) {
-	if (etaR == hpar->noff[2]) {
-	  tmp = 0.5*(etaHO[0]+hpar->etaTable[etaR-1]);
-	} else if (etaR == hpar->noff[2]+1) {
-	  tmp = 0.5*(hpar->etaTable[etaR]+etaHO[1]);
-	} else if (etaR == hpar->noff[3]) {
-	  tmp = 0.5*(etaHO[2]+hpar->etaTable[etaR-1]);
-	} else if (etaR == hpar->noff[3]+1) {
-	  tmp = 0.5*(hpar->etaTable[etaR]+etaHO[3]);
-	} else {
-	  tmp = 0.5*(hpar->etaTable[etaR]+hpar->etaTable[etaR-1]);
-	}
+        if (etaR == hpar->noff[2]) {
+          tmp = 0.5 * (etaHO[0] + hpar->etaTable[etaR - 1]);
+        } else if (etaR == hpar->noff[2] + 1) {
+          tmp = 0.5 * (hpar->etaTable[etaR] + etaHO[1]);
+        } else if (etaR == hpar->noff[3]) {
+          tmp = 0.5 * (etaHO[2] + hpar->etaTable[etaR - 1]);
+        } else if (etaR == hpar->noff[3] + 1) {
+          tmp = 0.5 * (hpar->etaTable[etaR] + etaHO[3]);
+        } else {
+          tmp = 0.5 * (hpar->etaTable[etaR] + hpar->etaTable[etaR - 1]);
+        }
       } else {
-	tmp = 0.5*(hpar->etaTable[etaR]+hpar->etaTable[etaR-1]);
+        tmp = 0.5 * (hpar->etaTable[etaR] + hpar->etaTable[etaR - 1]);
       }
     }
-  } 
-  if (zside == 0) tmp = -tmp;
+  }
+  if (zside == 0)
+    tmp = -tmp;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants::getEta " << etaR << " "
-			       << zside << " " << depth << " ==> " << tmp;
+  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants::getEta " << etaR << " " << zside << " " << depth << " ==> "
+                               << tmp;
 #endif
   return tmp;
 }
- 
+
 double HcalDDDSimConstants::getEta(const double& r, const double& z) const {
-
   double tmp = 0;
-  if (z != 0) tmp = -log(tan(0.5*atan(r/z)));
+  if (z != 0)
+    tmp = -log(tan(0.5 * atan(r / z)));
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants::getEta " << r << " "
-			       << z << " ==> " << tmp;
+  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants::getEta " << r << " " << z << " ==> " << tmp;
 #endif
   return tmp;
 }
 
-int HcalDDDSimConstants::getShift(const HcalSubdetector& subdet,
-				  const int& depth) const {
-
+int HcalDDDSimConstants::getShift(const HcalSubdetector& subdet, const int& depth) const {
   int shift;
-  switch(subdet) {
-  case HcalEndcap:
-    shift = hpar->HEShift[0];
-    break;
-  case HcalForward:
-    shift = hpar->HFShift[(depth-1)%2];
-    break;
-  case HcalOuter:
-    shift = hpar->HBShift[3];
-    break;
-  default:
-    shift = hpar->HBShift[0];
-    break;
+  switch (subdet) {
+    case HcalEndcap:
+      shift = hpar->HEShift[0];
+      break;
+    case HcalForward:
+      shift = hpar->HFShift[(depth - 1) % 2];
+      break;
+    case HcalOuter:
+      shift = hpar->HBShift[3];
+      break;
+    default:
+      shift = hpar->HBShift[0];
+      break;
   }
   return shift;
 }
 
-double HcalDDDSimConstants::getGain(const HcalSubdetector& subdet, 
-				    const int& depth) const {
-
+double HcalDDDSimConstants::getGain(const HcalSubdetector& subdet, const int& depth) const {
   double gain;
-  switch(subdet) {
-  case HcalEndcap:
-    gain = hpar->HEGains[0];
-    break;
-  case HcalForward:
-    gain = hpar->HFGains[(depth-1)%2];
-    break;
-  case HcalOuter:
-    gain = hpar->HBGains[3];
-    break;
-  default:
-    gain = hpar->HBGains[0];
-    break;
+  switch (subdet) {
+    case HcalEndcap:
+      gain = hpar->HEGains[0];
+      break;
+    case HcalForward:
+      gain = hpar->HFGains[(depth - 1) % 2];
+      break;
+    case HcalOuter:
+      gain = hpar->HBGains[3];
+      break;
+    default:
+      gain = hpar->HBGains[0];
+      break;
   }
   return gain;
 }
 
-void HcalDDDSimConstants::printTileHB(const int& eta,   const int& phi,
-				      const int& zside, const int& depth) const {
-  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants::printTileHB for eta " 
-			       << eta << " and depth " << depth;
-  
-  double etaL   = hpar->etaTable.at(eta-1);
-  double thetaL = 2.*atan(exp(-etaL));
-  double etaH   = hpar->etaTable.at(eta);
-  double thetaH = 2.*atan(exp(-etaH));
-  int    layL   = getLayerFront(1,eta,phi,zside,depth);
-  int    layH   = getLayerBack(1,eta,phi,zside,depth);
-  edm::LogVerbatim("HcalGeom") << "\ntileHB:: eta|depth " << zside*eta << "|" 
-			       << depth << " theta " << convertRadToDeg(thetaH)
-			       << ":" << convertRadToDeg(thetaL) << " Layer " 
-			       << layL-1 << ":" << layH-1;
-  for (int lay=layL-1; lay<layH; ++lay) {
-    std::vector<double> area(2,0);
-    int    kk(0);
+void HcalDDDSimConstants::printTileHB(const int& eta, const int& phi, const int& zside, const int& depth) const {
+  edm::LogVerbatim("HcalGeom") << "HcalDDDSimConstants::printTileHB for eta " << eta << " and depth " << depth;
+
+  double etaL = hpar->etaTable.at(eta - 1);
+  double thetaL = 2. * atan(exp(-etaL));
+  double etaH = hpar->etaTable.at(eta);
+  double thetaH = 2. * atan(exp(-etaH));
+  int layL = getLayerFront(1, eta, phi, zside, depth);
+  int layH = getLayerBack(1, eta, phi, zside, depth);
+  edm::LogVerbatim("HcalGeom") << "\ntileHB:: eta|depth " << zside * eta << "|" << depth << " theta "
+                               << convertRadToDeg(thetaH) << ":" << convertRadToDeg(thetaL) << " Layer " << layL - 1
+                               << ":" << layH - 1;
+  for (int lay = layL - 1; lay < layH; ++lay) {
+    std::vector<double> area(2, 0);
+    int kk(0);
     double mean(0);
-    for (unsigned int k=0; k<hpar->layHB.size(); ++k) {
+    for (unsigned int k = 0; k < hpar->layHB.size(); ++k) {
       if (lay == hpar->layHB[k]) {
-	double zmin = hpar->rhoxHB[k]*std::cos(thetaL)/std::sin(thetaL);
-	double zmax = hpar->rhoxHB[k]*std::cos(thetaH)/std::sin(thetaH);
-	double dz   = (std::min(zmax,hpar->dxHB[k]) - zmin);
-	if (dz > 0) {
-	  area[kk] = dz*hpar->dyHB[k];
-	  mean    += area[kk];
-	  kk++;
-	}
+        double zmin = hpar->rhoxHB[k] * std::cos(thetaL) / std::sin(thetaL);
+        double zmax = hpar->rhoxHB[k] * std::cos(thetaH) / std::sin(thetaH);
+        double dz = (std::min(zmax, hpar->dxHB[k]) - zmin);
+        if (dz > 0) {
+          area[kk] = dz * hpar->dyHB[k];
+          mean += area[kk];
+          kk++;
+        }
       }
     }
     if (area[0] > 0) {
-      mean /= (kk*100);
-      edm::LogVerbatim("HcalGeom") << std::setw(2) << lay << " Area " 
-				   << std::setw(8) << area[0] << " " 
-				   << std::setw(8) << area[1] << " Mean " 
-				   << mean;
+      mean /= (kk * 100);
+      edm::LogVerbatim("HcalGeom") << std::setw(2) << lay << " Area " << std::setw(8) << area[0] << " " << std::setw(8)
+                                   << area[1] << " Mean " << mean;
     }
   }
 }
-  
-void HcalDDDSimConstants::printTileHE(const int& eta,   const int& phi,
-				      const int& zside, const int& depth) const {
 
-  double etaL   = hpar->etaTable[eta-1];
-  double thetaL = 2.*atan(exp(-etaL));
-  double etaH   = hpar->etaTable[eta];
-  double thetaH = 2.*atan(exp(-etaH));
-  int    layL   = getLayerFront(2,eta,phi,zside,depth);
-  int    layH   = getLayerBack(2,eta,phi,zside,depth);
-  double phib  = hpar->phibin[eta-1];
+void HcalDDDSimConstants::printTileHE(const int& eta, const int& phi, const int& zside, const int& depth) const {
+  double etaL = hpar->etaTable[eta - 1];
+  double thetaL = 2. * atan(exp(-etaL));
+  double etaH = hpar->etaTable[eta];
+  double thetaH = 2. * atan(exp(-etaH));
+  int layL = getLayerFront(2, eta, phi, zside, depth);
+  int layH = getLayerBack(2, eta, phi, zside, depth);
+  double phib = hpar->phibin[eta - 1];
   int nphi = 2;
-  if (phib > 6._deg) nphi = 1;
-  edm::LogVerbatim("HcalGeom") << "\ntileHE:: Eta/depth " << zside*eta << "|" 
-			       << depth << " theta " << convertRadToDeg(thetaH)
-			       << ":" << convertRadToDeg(thetaL) << " Layer " 
-			       << layL-1 << ":" << layH-1 << " phi " << nphi;
-  for (int lay=layL-1; lay<layH; ++lay) {
-    std::vector<double> area(4,0);
-    int    kk(0);
+  if (phib > 6._deg)
+    nphi = 1;
+  edm::LogVerbatim("HcalGeom") << "\ntileHE:: Eta/depth " << zside * eta << "|" << depth << " theta "
+                               << convertRadToDeg(thetaH) << ":" << convertRadToDeg(thetaL) << " Layer " << layL - 1
+                               << ":" << layH - 1 << " phi " << nphi;
+  for (int lay = layL - 1; lay < layH; ++lay) {
+    std::vector<double> area(4, 0);
+    int kk(0);
     double mean(0);
-    for (unsigned int k=0; k<hpar->layHE.size(); ++k) {
+    for (unsigned int k = 0; k < hpar->layHE.size(); ++k) {
       if (lay == hpar->layHE[k]) {
-	double rmin = hpar->zxHE[k]*std::tan(thetaH);
-	double rmax = hpar->zxHE[k]*std::tan(thetaL);
-	if ((lay != 0 || eta == 18) && 
-	    (lay != 1 || (eta == 18 && hpar->rhoxHE[k]-hpar->dyHE[k] > 1000) ||
-	     (eta != 18 && hpar->rhoxHE[k]-hpar->dyHE[k] < 1000)) &&
-	    rmin+30 < hpar->rhoxHE[k]+hpar->dyHE[k] && 
-	    rmax > hpar->rhoxHE[k]-hpar->dyHE[k]) {
-	  rmin = std::max(rmin,hpar->rhoxHE[k]-hpar->dyHE[k]);
-	  rmax = std::min(rmax,hpar->rhoxHE[k]+hpar->dyHE[k]);
-	  double dx1 = rmin*std::tan(phib);
-	  double dx2 = rmax*std::tan(phib);
-	  double ar1=0, ar2=0;
-	  if (nphi == 1) {
-	    ar1 = 0.5*(rmax-rmin)*(dx1+dx2-4.*hpar->dx1HE[k]);
-	    mean += ar1;
-	  } else {
-	    ar1 = 0.5*(rmax-rmin)*(dx1+dx2-2.*hpar->dx1HE[k]);
-	    ar2 = 0.5*(rmax-rmin)*((rmax+rmin)*tan(10._deg)-4*hpar->dx1HE[k])-ar1;
-	    mean += (ar1+ar2);
-	  }
-	  area[kk]   = ar1;
-	  area[kk+2] = ar2;
-	  kk++;
-	}
+        double rmin = hpar->zxHE[k] * std::tan(thetaH);
+        double rmax = hpar->zxHE[k] * std::tan(thetaL);
+        if ((lay != 0 || eta == 18) &&
+            (lay != 1 || (eta == 18 && hpar->rhoxHE[k] - hpar->dyHE[k] > 1000) ||
+             (eta != 18 && hpar->rhoxHE[k] - hpar->dyHE[k] < 1000)) &&
+            rmin + 30 < hpar->rhoxHE[k] + hpar->dyHE[k] && rmax > hpar->rhoxHE[k] - hpar->dyHE[k]) {
+          rmin = std::max(rmin, hpar->rhoxHE[k] - hpar->dyHE[k]);
+          rmax = std::min(rmax, hpar->rhoxHE[k] + hpar->dyHE[k]);
+          double dx1 = rmin * std::tan(phib);
+          double dx2 = rmax * std::tan(phib);
+          double ar1 = 0, ar2 = 0;
+          if (nphi == 1) {
+            ar1 = 0.5 * (rmax - rmin) * (dx1 + dx2 - 4. * hpar->dx1HE[k]);
+            mean += ar1;
+          } else {
+            ar1 = 0.5 * (rmax - rmin) * (dx1 + dx2 - 2. * hpar->dx1HE[k]);
+            ar2 = 0.5 * (rmax - rmin) * ((rmax + rmin) * tan(10._deg) - 4 * hpar->dx1HE[k]) - ar1;
+            mean += (ar1 + ar2);
+          }
+          area[kk] = ar1;
+          area[kk + 2] = ar2;
+          kk++;
+        }
       }
     }
     if (area[0] > 0 && area[1] > 0) {
-      int lay0 = lay-1;
-      if (eta == 18) lay0++;
+      int lay0 = lay - 1;
+      if (eta == 18)
+        lay0++;
       if (nphi == 1) {
-	mean /= (kk*100);
-	edm::LogVerbatim("HcalGeom") << std::setw(2) << lay0 << " Area " 
-				     << std::setw(8) << area[0] << " " 
-				     << std::setw(8) << area[1] << " Mean "
-				     << mean;
+        mean /= (kk * 100);
+        edm::LogVerbatim("HcalGeom") << std::setw(2) << lay0 << " Area " << std::setw(8) << area[0] << " "
+                                     << std::setw(8) << area[1] << " Mean " << mean;
       } else {
-	mean /= (kk*200);
-	edm::LogVerbatim("HcalGeom") << std::setw(2) << lay0 << " Area " 
-				     << std::setw(8) << area[0] << " " 
-				     << std::setw(8) << area[1] << ":" 
-				     << std::setw(8) << area[2] << " " 
-				     << std::setw(8) << area[3] << " Mean "
-				     << mean;
+        mean /= (kk * 200);
+        edm::LogVerbatim("HcalGeom") << std::setw(2) << lay0 << " Area " << std::setw(8) << area[0] << " "
+                                     << std::setw(8) << area[1] << ":" << std::setw(8) << area[2] << " " << std::setw(8)
+                                     << area[3] << " Mean " << mean;
       }
     }
   }
@@ -1227,11 +1202,12 @@ void HcalDDDSimConstants::printTileHE(const int& eta,   const int& phi,
 
 unsigned int HcalDDDSimConstants::layerGroupSize(int eta) const {
   unsigned int k = 0;
-  for (auto const & it : hpar->layerGroupEtaSim) {
+  for (auto const& it : hpar->layerGroupEtaSim) {
     if (it.layer == (unsigned int)(eta + 1)) {
       return it.layerGroup.size();
     }
-    if (it.layer > (unsigned int)(eta + 1)) break;
+    if (it.layer > (unsigned int)(eta + 1))
+      break;
     k = it.layerGroup.size();
   }
   return k;
@@ -1239,21 +1215,19 @@ unsigned int HcalDDDSimConstants::layerGroupSize(int eta) const {
 
 unsigned int HcalDDDSimConstants::layerGroup(int eta, int i) const {
   unsigned int k = 0;
-  for (auto const & it :  hpar->layerGroupEtaSim) {
+  for (auto const& it : hpar->layerGroupEtaSim) {
     if (it.layer == (unsigned int)(eta + 1)) {
       return it.layerGroup.at(i);
     }
-    if (it.layer > (unsigned int)(eta + 1)) break;
+    if (it.layer > (unsigned int)(eta + 1))
+      break;
     k = it.layerGroup.at(i);
   }
   return k;
 }
- 
-unsigned int HcalDDDSimConstants::layerGroup(int det, int eta,
-					     int phi, int zside,
-					     int lay) const {
 
-  int depth0 = findDepth(det,eta,phi,zside,lay);
-  unsigned int depth = (depth0 > 0) ? (unsigned int)(depth0) : layerGroup(eta-1,lay);
+unsigned int HcalDDDSimConstants::layerGroup(int det, int eta, int phi, int zside, int lay) const {
+  int depth0 = findDepth(det, eta, phi, zside, lay);
+  unsigned int depth = (depth0 > 0) ? (unsigned int)(depth0) : layerGroup(eta - 1, lay);
   return depth;
 }

--- a/Geometry/HcalCommonData/src/HcalGeomParameters.cc
+++ b/Geometry/HcalCommonData/src/HcalGeomParameters.cc
@@ -23,31 +23,31 @@ HcalGeomParameters::HcalGeomParameters() {
 #endif
 }
 
-HcalGeomParameters::~HcalGeomParameters() { 
+HcalGeomParameters::~HcalGeomParameters() {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::destructed!!!";
 #endif
 }
 
-void HcalGeomParameters::getConstRHO( std::vector<double>& rHO ) const {
-
+void HcalGeomParameters::getConstRHO(std::vector<double>& rHO) const {
   rHO.emplace_back(rminHO);
-  for (double i : etaHO) rHO.emplace_back(i);
+  for (double i : etaHO)
+    rHO.emplace_back(i);
 }
 
 std::vector<int> HcalGeomParameters::getModHalfHBHE(const int type) const {
-
   std::vector<int> modHalf;
   if (type == 0) {
-    modHalf.emplace_back(nmodHB); modHalf.emplace_back(nzHB);
+    modHalf.emplace_back(nmodHB);
+    modHalf.emplace_back(nzHB);
   } else {
-    modHalf.emplace_back(nmodHE); modHalf.emplace_back(nzHE);
+    modHalf.emplace_back(nmodHE);
+    modHalf.emplace_back(nzHE);
   }
   return modHalf;
 }
 
-unsigned int HcalGeomParameters::find(int element, 
-				      std::vector<int>& array) const {
+unsigned int HcalGeomParameters::find(int element, std::vector<int>& array) const {
   unsigned int id = array.size();
   for (unsigned int i = 0; i < array.size(); i++) {
     if (element == array[i]) {
@@ -57,64 +57,71 @@ unsigned int HcalGeomParameters::find(int element,
   }
   return id;
 }
- 
-double HcalGeomParameters::getEta(double r, double z) const {
 
+double HcalGeomParameters::getEta(double r, double z) const {
   double tmp = 0;
-  if (z != 0) tmp = -log(tan(0.5*atan(r/z)));
+  if (z != 0)
+    tmp = -log(tan(0.5 * atan(r / z)));
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::getEta " << r << " " 
-			       << z  << " ==> " << tmp;
+  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::getEta " << r << " " << z << " ==> " << tmp;
 #endif
   return tmp;
 }
 
-void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv,  
-				      HcalParameters& php) {
-
+void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv, HcalParameters& php) {
   DDFilteredView fv = _fv;
-  bool dodet=true, hf=false;
-  std::vector<double> rb(20,0.0), ze(20,0.0), thkb(20,-1.0), thke(20,-1.0);
-  std::vector<int>    ib(20,0),   ie(20,0);
-  std::vector<int>    izb, phib, ize, phie;
+  bool dodet = true, hf = false;
+  std::vector<double> rb(20, 0.0), ze(20, 0.0), thkb(20, -1.0), thke(20, -1.0);
+  std::vector<int> ib(20, 0), ie(20, 0);
+  std::vector<int> izb, phib, ize, phie;
   std::vector<double> rxb;
 #ifdef EDM_ML_DEBUG
-  std::vector<double> rminHE(20,0.0), rmaxHE(20,0.0);
+  std::vector<double> rminHE(20, 0.0), rmaxHE(20, 0.0);
 #endif
-  php.rhoxHB.clear(); php.zxHB.clear(); php.dyHB.clear(); php.dxHB.clear();
-  php.layHB.clear(); php.layHE.clear();
-  php.zxHE.clear(); php.rhoxHE.clear(); php.dyHE.clear(); php.dx1HE.clear(); php.dx2HE.clear();
-  dzVcal    = -1.;
+  php.rhoxHB.clear();
+  php.zxHB.clear();
+  php.dyHB.clear();
+  php.dxHB.clear();
+  php.layHB.clear();
+  php.layHE.clear();
+  php.zxHE.clear();
+  php.rhoxHE.clear();
+  php.dyHE.clear();
+  php.dx1HE.clear();
+  php.dx2HE.clear();
+  dzVcal = -1.;
 
   while (dodet) {
-    DDTranslation    t    = fv.translation();
+    DDTranslation t = fv.translation();
     std::vector<int> copy = fv.copyNumbers();
-    const DDSolid & sol  = fv.logicalPart().solid();
+    const DDSolid& sol = fv.logicalPart().solid();
     int idet = 0, lay = -1;
     int nsiz = (int)(copy.size());
-    if (nsiz>0) lay  = copy[nsiz-1]/10;
-    if (nsiz>1) idet = copy[nsiz-2]/1000;
-    double dx=0, dy=0, dz=0, dx1=0, dx2=0;
+    if (nsiz > 0)
+      lay = copy[nsiz - 1] / 10;
+    if (nsiz > 1)
+      idet = copy[nsiz - 2] / 1000;
+    double dx = 0, dy = 0, dz = 0, dx1 = 0, dx2 = 0;
 #ifdef EDM_ML_DEBUG
     double alp(0);
 #endif
     if (sol.shape() == DDSolidShape::ddbox) {
-      const DDBox & box = static_cast<DDBox>(fv.logicalPart().solid());
+      const DDBox& box = static_cast<DDBox>(fv.logicalPart().solid());
       dx = box.halfX();
       dy = box.halfY();
       dz = box.halfZ();
     } else if (sol.shape() == DDSolidShape::ddtrap) {
-      const DDTrap & trp = static_cast<DDTrap>(fv.logicalPart().solid());
-      dx1= trp.x1();
-      dx2= trp.x2();
-      dx = 0.25*(trp.x1()+trp.x2()+trp.x3()+trp.x4());
-      dy = 0.5*(trp.y1()+trp.y2());
+      const DDTrap& trp = static_cast<DDTrap>(fv.logicalPart().solid());
+      dx1 = trp.x1();
+      dx2 = trp.x2();
+      dx = 0.25 * (trp.x1() + trp.x2() + trp.x3() + trp.x4());
+      dy = 0.5 * (trp.y1() + trp.y2());
       dz = trp.halfZ();
 #ifdef EDM_ML_DEBUG
-      alp= 0.5*(trp.alpha1()+trp.alpha2());
+      alp = 0.5 * (trp.alpha1() + trp.alpha2());
 #endif
     } else if (sol.shape() == DDSolidShape::ddtubs) {
-      const DDTubs & tub = static_cast<DDTubs>(fv.logicalPart().solid());
+      const DDTubs& tub = static_cast<DDTubs>(fv.logicalPart().solid());
       dx = tub.rIn();
       dy = tub.rOut();
       dz = tub.zhalf();
@@ -122,154 +129,157 @@ void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv,
     if (idet == 3) {
       // HB
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "HB " << sol.name() << " Shape " 
-				   << sol.shape() << " Layer " << lay << " R "
-				   << t.Rho();
+      edm::LogVerbatim("HCalGeom") << "HB " << sol.name() << " Shape " << sol.shape() << " Layer " << lay << " R "
+                                   << t.Rho();
 #endif
-      if (lay >=0 && lay < 20) {
-	ib[lay]++;
-	rb[lay] += t.Rho();
-	if (thkb[lay] <= 0) {
-	  if (lay < 17) thkb[lay] = dx;
-	  else          thkb[lay] = std::min(dx,dy);
-	}
-	if (lay < 17) {
-	  bool found = false;
-	  for (double k : rxb) {
-	    if (std::abs(k-t.Rho()) < 0.01) {
-	      found = true;
-	      break;
-	    }
-	  }
-	  if (!found) {
-	    rxb.emplace_back(t.Rho());
-	    php.rhoxHB.emplace_back(t.Rho()*std::cos(t.phi()));
-	    php.zxHB.emplace_back(std::abs(t.z()));
-	    php.dyHB.emplace_back(2.*dy);
-	    php.dxHB.emplace_back(2.*dz);
-	    php.layHB.emplace_back(lay);
-	  }
-	}
+      if (lay >= 0 && lay < 20) {
+        ib[lay]++;
+        rb[lay] += t.Rho();
+        if (thkb[lay] <= 0) {
+          if (lay < 17)
+            thkb[lay] = dx;
+          else
+            thkb[lay] = std::min(dx, dy);
+        }
+        if (lay < 17) {
+          bool found = false;
+          for (double k : rxb) {
+            if (std::abs(k - t.Rho()) < 0.01) {
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            rxb.emplace_back(t.Rho());
+            php.rhoxHB.emplace_back(t.Rho() * std::cos(t.phi()));
+            php.zxHB.emplace_back(std::abs(t.z()));
+            php.dyHB.emplace_back(2. * dy);
+            php.dxHB.emplace_back(2. * dz);
+            php.layHB.emplace_back(lay);
+          }
+        }
       }
       if (lay == 2) {
-	int iz = copy[nsiz-5];
-	int fi = copy[nsiz-4];
-	unsigned int it1 = find(iz, izb);
-	if (it1 == izb.size())  izb.emplace_back(iz);
-	unsigned int it2 = find(fi, phib);
-	if (it2 == phib.size()) phib.emplace_back(fi);
+        int iz = copy[nsiz - 5];
+        int fi = copy[nsiz - 4];
+        unsigned int it1 = find(iz, izb);
+        if (it1 == izb.size())
+          izb.emplace_back(iz);
+        unsigned int it2 = find(fi, phib);
+        if (it2 == phib.size())
+          phib.emplace_back(fi);
       }
       if (lay == 18) {
-	int ifi=-1, ich=-1;
-	if (nsiz>2) ifi = copy[nsiz-3];
-	if (nsiz>3) ich = copy[nsiz-4];
-	double z1 = std::abs((t.z()) + dz);
-	double z2 = std::abs((t.z()) - dz);
-	if (std::abs(z1-z2) < 0.01) z1 = 0;
+        int ifi = -1, ich = -1;
+        if (nsiz > 2)
+          ifi = copy[nsiz - 3];
+        if (nsiz > 3)
+          ich = copy[nsiz - 4];
+        double z1 = std::abs((t.z()) + dz);
+        double z2 = std::abs((t.z()) - dz);
+        if (std::abs(z1 - z2) < 0.01)
+          z1 = 0;
         if (ifi == 1 && ich == 4) {
-	  if (z1 > z2) {
-	    double tmp = z1;
-	    z1 = z2;
-	    z2 = tmp;
-	  }
-	  bool sok = true;
-	  for (unsigned int kk=0; kk<php.zHO.size(); kk++) {
-	    if (std::abs(z2-php.zHO[kk]) < 0.01) {
-	      sok = false;
-	      break;
-	    }	else if (z2 < php.zHO[kk]) {
-	      php.zHO.resize(php.zHO.size()+2);
-	      for (unsigned int kz=php.zHO.size()-1; kz>kk+1; kz=kz-2) {
-		php.zHO[kz]   = php.zHO[kz-2];
-		php.zHO[kz-1] = php.zHO[kz-3];
-	      }
-	      php.zHO[kk+1] = z2;
-	      php.zHO[kk]   = z1;
-	      sok = false;
-	      break;
-	    }
-	  }
-	  if (sok) {
-	    php.zHO.emplace_back(z1);
-	    php.zHO.emplace_back(z2);
-	  }
+          if (z1 > z2) {
+            double tmp = z1;
+            z1 = z2;
+            z2 = tmp;
+          }
+          bool sok = true;
+          for (unsigned int kk = 0; kk < php.zHO.size(); kk++) {
+            if (std::abs(z2 - php.zHO[kk]) < 0.01) {
+              sok = false;
+              break;
+            } else if (z2 < php.zHO[kk]) {
+              php.zHO.resize(php.zHO.size() + 2);
+              for (unsigned int kz = php.zHO.size() - 1; kz > kk + 1; kz = kz - 2) {
+                php.zHO[kz] = php.zHO[kz - 2];
+                php.zHO[kz - 1] = php.zHO[kz - 3];
+              }
+              php.zHO[kk + 1] = z2;
+              php.zHO[kk] = z1;
+              sok = false;
+              break;
+            }
+          }
+          if (sok) {
+            php.zHO.emplace_back(z1);
+            php.zHO.emplace_back(z2);
+          }
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("HCalGeom") << "Detector " << idet << " Lay " 
-				       << lay << " fi " << ifi << " " << ich
-				       << " z " << z1 << " " << z2;
+          edm::LogVerbatim("HCalGeom") << "Detector " << idet << " Lay " << lay << " fi " << ifi << " " << ich << " z "
+                                       << z1 << " " << z2;
 #endif
-	}
+        }
       }
     } else if (idet == 4) {
       // HE
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "HE " << sol.name() << " Shape " 
-				   << sol.shape() << " Layer " << lay << " Z "
-				   << t.z();
+      edm::LogVerbatim("HCalGeom") << "HE " << sol.name() << " Shape " << sol.shape() << " Layer " << lay << " Z "
+                                   << t.z();
 #endif
-      if (lay >=0 && lay < 20) {
-	ie[lay]++;
-	ze[lay] += std::abs(t.z());
-	if (thke[lay] <= 0) thke[lay] = dz;
+      if (lay >= 0 && lay < 20) {
+        ie[lay]++;
+        ze[lay] += std::abs(t.z());
+        if (thke[lay] <= 0)
+          thke[lay] = dz;
 #ifdef EDM_ML_DEBUG
-	double rinHE  = t.Rho()*cos(alp) - dy;
-	double routHE = t.Rho()*cos(alp) + dy;
-	rminHE[lay] += rinHE;
-	rmaxHE[lay] += routHE;
+        double rinHE = t.Rho() * cos(alp) - dy;
+        double routHE = t.Rho() * cos(alp) + dy;
+        rminHE[lay] += rinHE;
+        rmaxHE[lay] += routHE;
 #endif
-	bool found = false;
-	for (double k : php.zxHE) {
-	  if (std::abs(k-std::abs(t.z())) < 0.01) {
-	    found = true;
-	    break;
-	  }
-	}
-	if (!found) {
-	  php.zxHE.emplace_back(std::abs(t.z()));
-	  php.rhoxHE.emplace_back(t.Rho()*std::cos(t.phi()));
-	  php.dyHE.emplace_back(dy*std::cos(t.phi()));
-	  dx1 -= 0.5*(t.rho()-dy)*std::cos(t.phi())*std::tan(10*CLHEP::deg);
-	  dx2 -= 0.5*(t.rho()+dy)*std::cos(t.phi())*std::tan(10*CLHEP::deg);
-	  php.dx1HE.emplace_back(-dx1);
-	  php.dx2HE.emplace_back(-dx2);
-	  php.layHE.emplace_back(lay);
-	}
+        bool found = false;
+        for (double k : php.zxHE) {
+          if (std::abs(k - std::abs(t.z())) < 0.01) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          php.zxHE.emplace_back(std::abs(t.z()));
+          php.rhoxHE.emplace_back(t.Rho() * std::cos(t.phi()));
+          php.dyHE.emplace_back(dy * std::cos(t.phi()));
+          dx1 -= 0.5 * (t.rho() - dy) * std::cos(t.phi()) * std::tan(10 * CLHEP::deg);
+          dx2 -= 0.5 * (t.rho() + dy) * std::cos(t.phi()) * std::tan(10 * CLHEP::deg);
+          php.dx1HE.emplace_back(-dx1);
+          php.dx2HE.emplace_back(-dx2);
+          php.layHE.emplace_back(lay);
+        }
       }
-      if (copy[nsiz-1] == 21 || copy[nsiz-1] == 71) {
-	int iz = copy[nsiz-7];
-	int fi = copy[nsiz-5];
-	unsigned int it1 = find(iz, ize);
-	if (it1 == ize.size())  ize.emplace_back(iz);
-	unsigned int it2 = find(fi, phie);
-	if (it2 == phie.size()) phie.emplace_back(fi);
+      if (copy[nsiz - 1] == 21 || copy[nsiz - 1] == 71) {
+        int iz = copy[nsiz - 7];
+        int fi = copy[nsiz - 5];
+        unsigned int it1 = find(iz, ize);
+        if (it1 == ize.size())
+          ize.emplace_back(iz);
+        unsigned int it2 = find(fi, phie);
+        if (it2 == phie.size())
+          phie.emplace_back(fi);
       }
     } else if (idet == 5) {
       // HF
       if (!hf) {
-	const std::vector<double> & paras = sol.parameters();
+        const std::vector<double>& paras = sol.parameters();
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HCalGeom") << "HF " << sol.name() << " Shape "
-				     << sol.shape() << " Z " << t.z() 
-				     << " with " << paras.size()
-				     << " Parameters";
-	for (unsigned j=0; j<paras.size(); j++)
-	  edm::LogVerbatim("HCalGeom") << "HF Parameter[" << j << "] = "
-				       << paras[j];
+        edm::LogVerbatim("HCalGeom") << "HF " << sol.name() << " Shape " << sol.shape() << " Z " << t.z() << " with "
+                                     << paras.size() << " Parameters";
+        for (unsigned j = 0; j < paras.size(); j++)
+          edm::LogVerbatim("HCalGeom") << "HF Parameter[" << j << "] = " << paras[j];
 #endif
-	if (sol.shape() == DDSolidShape::ddpolycone_rrz) {
-	  int nz  = (int)(paras.size())-3;
-	  dzVcal  = 0.5*(paras[nz]-paras[3]);
-	  hf      = true;
-	} else if (sol.shape() == DDSolidShape::ddtubs || sol.shape() == DDSolidShape::ddcons) {
-	  dzVcal  = paras[0];
-	  hf      = true;
-	}
+        if (sol.shape() == DDSolidShape::ddpolycone_rrz) {
+          int nz = (int)(paras.size()) - 3;
+          dzVcal = 0.5 * (paras[nz] - paras[3]);
+          hf = true;
+        } else if (sol.shape() == DDSolidShape::ddtubs || sol.shape() == DDSolidShape::ddcons) {
+          dzVcal = paras[0];
+          hf = true;
+        }
       }
 #ifdef EDM_ML_DEBUG
     } else {
-      edm::LogVerbatim("HCalGeom") << "Unknown Detector " << idet << " for "
-				   << sol.name() << " Shape " << sol.shape() 
-				   << " R " << t.Rho() << " Z " << t.z();
+      edm::LogVerbatim("HCalGeom") << "Unknown Detector " << idet << " for " << sol.name() << " Shape " << sol.shape()
+                                   << " R " << t.Rho() << " Z " << t.z();
 #endif
     }
     dodet = fv.next();
@@ -277,131 +287,117 @@ void HcalGeomParameters::loadGeometry(const DDFilteredView& _fv,
 
   int ibmx = 0, iemx = 0;
   for (int i = 0; i < 20; i++) {
-    if (ib[i]>0) {
+    if (ib[i] > 0) {
       rb[i] /= (double)(ib[i]);
-      ibmx   = i+1;
+      ibmx = i + 1;
     }
-    if (ie[i]>0) {
+    if (ie[i] > 0) {
       ze[i] /= (double)(ie[i]);
-      iemx   = i+1;
+      iemx = i + 1;
     }
 #ifdef EDM_ML_DEBUG
-    if (ie[i]> 0) {
+    if (ie[i] > 0) {
       rminHE[i] /= (double)(ie[i]);
       rmaxHE[i] /= (double)(ie[i]);
     }
-    edm::LogVerbatim("HCalGeom") << "Index " << i << " Barrel " << ib[i] << " "
-				 << rb[i] << " Endcap " << ie[i] << " " 
-				 << ze[i] << ":" << rminHE[i] << ":"
-				 << rmaxHE[i];
+    edm::LogVerbatim("HCalGeom") << "Index " << i << " Barrel " << ib[i] << " " << rb[i] << " Endcap " << ie[i] << " "
+                                 << ze[i] << ":" << rminHE[i] << ":" << rmaxHE[i];
 #endif
   }
   for (int i = 4; i >= 0; i--) {
-    if (ib[i] == 0) {rb[i] = rb[i+1]; thkb[i] = thkb[i+1];}
-    if (ie[i] == 0) {ze[i] = ze[i+1]; thke[i] = thke[i+1];}
+    if (ib[i] == 0) {
+      rb[i] = rb[i + 1];
+      thkb[i] = thkb[i + 1];
+    }
+    if (ie[i] == 0) {
+      ze[i] = ze[i + 1];
+      thke[i] = thke[i + 1];
+    }
 #ifdef EDM_ML_DEBUG
     if (ib[i] == 0 || ie[i] == 0)
-      edm::LogVerbatim("HCalGeom") << "Index " << i << " Barrel " << ib[i] 
-				   << " " << rb[i] << " Endcap " << ie[i]
-				   << " " << ze[i];
+      edm::LogVerbatim("HCalGeom") << "Index " << i << " Barrel " << ib[i] << " " << rb[i] << " Endcap " << ie[i] << " "
+                                   << ze[i];
 #endif
   }
 
 #ifdef EDM_ML_DEBUG
-  for (unsigned int k=0; k<php.layHB.size(); ++k)
-    edm::LogVerbatim("HCalGeom") << "HB: " << php.layHB[k] << " R " << rxb[k]
-				 << " " << php.rhoxHB[k] << " Z " 
-				 << php.zxHB[k] << " DY " << php.dyHB[k]
-				 << " DZ " << php.dxHB[k];
-  for (unsigned int k=0; k<php.layHE.size(); ++k) 
-    edm::LogVerbatim("HCalGeom") << "HE: " << php.layHE[k] << " R "
-				 << php.rhoxHE[k] << " Z " << php.zxHE[k]
-				 << " X1|X2 " << php.dx1HE[k] << "|"
-				 << php.dx2HE[k] << " DY " << php.dyHE[k];
-  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters: Maximum Layer for HB "
-			       << ibmx << " for HE " << iemx << " extent "
-			       << dzVcal;
+  for (unsigned int k = 0; k < php.layHB.size(); ++k)
+    edm::LogVerbatim("HCalGeom") << "HB: " << php.layHB[k] << " R " << rxb[k] << " " << php.rhoxHB[k] << " Z "
+                                 << php.zxHB[k] << " DY " << php.dyHB[k] << " DZ " << php.dxHB[k];
+  for (unsigned int k = 0; k < php.layHE.size(); ++k)
+    edm::LogVerbatim("HCalGeom") << "HE: " << php.layHE[k] << " R " << php.rhoxHE[k] << " Z " << php.zxHE[k]
+                                 << " X1|X2 " << php.dx1HE[k] << "|" << php.dx2HE[k] << " DY " << php.dyHE[k];
+  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters: Maximum Layer for HB " << ibmx << " for HE " << iemx
+                               << " extent " << dzVcal;
 #endif
 
   if (ibmx > 0) {
     php.rHB.resize(ibmx);
     php.drHB.resize(ibmx);
-    for (int i=0; i<ibmx; i++) {
-      php.rHB[i]  = rb[i];
+    for (int i = 0; i < ibmx; i++) {
+      php.rHB[i] = rb[i];
       php.drHB[i] = thkb[i];
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "HcalGeomParameters: php.rHB[" << i 
-				   << "] = " << php.rHB[i] << " php.drHB["
-				   << i << "] = " << php.drHB[i];
+      edm::LogVerbatim("HCalGeom") << "HcalGeomParameters: php.rHB[" << i << "] = " << php.rHB[i] << " php.drHB[" << i
+                                   << "] = " << php.drHB[i];
 #endif
     }
   }
   if (iemx > 0) {
     php.zHE.resize(iemx);
     php.dzHE.resize(iemx);
-    for (int i=0; i<iemx; i++) {
-      php.zHE[i]  = ze[i];
+    for (int i = 0; i < iemx; i++) {
+      php.zHE[i] = ze[i];
       php.dzHE[i] = thke[i];
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HCalGeom") << "HcalGeomParameters: php.zHE[" << i 
-				   << "] = " << php.zHE[i] << " php.dzHE["
-				   << i << "] = " << php.dzHE[i];
+      edm::LogVerbatim("HCalGeom") << "HcalGeomParameters: php.zHE[" << i << "] = " << php.zHE[i] << " php.dzHE[" << i
+                                   << "] = " << php.dzHE[i];
 #endif
     }
   }
 
-  nzHB   = (int)(izb.size());
+  nzHB = (int)(izb.size());
   nmodHB = (int)(phib.size());
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::loadGeometry: " << nzHB
-			       << " barrel half-sectors";
-  for (int i=0; i<nzHB; i++)
-    edm::LogVerbatim("HCalGeom") << "Section " << i << " Copy number " 
-				 << izb[i];
-  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::loadGeometry: " 
-			       << nmodHB << " barrel modules";
-  for (int i=0; i<nmodHB; i++)
-    edm::LogVerbatim("HCalGeom") << "Module " << i << " Copy number " 
-				 << phib[i];
+  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::loadGeometry: " << nzHB << " barrel half-sectors";
+  for (int i = 0; i < nzHB; i++)
+    edm::LogVerbatim("HCalGeom") << "Section " << i << " Copy number " << izb[i];
+  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::loadGeometry: " << nmodHB << " barrel modules";
+  for (int i = 0; i < nmodHB; i++)
+    edm::LogVerbatim("HCalGeom") << "Module " << i << " Copy number " << phib[i];
 #endif
 
-  nzHE   = (int)(ize.size());
+  nzHE = (int)(ize.size());
   nmodHE = (int)(phie.size());
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::loadGeometry: " << nzHE
-			       << " endcap half-sectors";
-  for (int i=0; i<nzHE; i++)
-    edm::LogVerbatim("HCalGeom") << "Section " << i << " Copy number " 
-				 << ize[i];
-  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::loadGeometry: " 
-			       << nmodHE << " endcap modules";
-  for (int i=0; i<nmodHE; i++)
-    edm::LogVerbatim("HCalGeom") << "Module " << i << " Copy number " 
-				 << phie[i];
+  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::loadGeometry: " << nzHE << " endcap half-sectors";
+  for (int i = 0; i < nzHE; i++)
+    edm::LogVerbatim("HCalGeom") << "Section " << i << " Copy number " << ize[i];
+  edm::LogVerbatim("HCalGeom") << "HcalGeomParameters::loadGeometry: " << nmodHE << " endcap modules";
+  for (int i = 0; i < nmodHE; i++)
+    edm::LogVerbatim("HCalGeom") << "Module " << i << " Copy number " << phie[i];
 #endif
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "HO has Z of size " << php.zHO.size();
-  for (unsigned int kk=0; kk<php.zHO.size(); kk++)
+  for (unsigned int kk = 0; kk < php.zHO.size(); kk++)
     edm::LogVerbatim("HCalGeom") << "ZHO[" << kk << "] = " << php.zHO[kk];
 #endif
   if (ibmx > 17 && php.zHO.size() > 4) {
-    rminHO   = php.rHB[17]-100.0;
-    etaHO[0] = getEta(0.5*(php.rHB[17]+php.rHB[18]), php.zHO[1]);
-    etaHO[1] = getEta(php.rHB[18]+php.drHB[18], php.zHO[2]);
-    etaHO[2] = getEta(php.rHB[18]-php.drHB[18], php.zHO[3]);
-    etaHO[3] = getEta(php.rHB[18]+php.drHB[18], php.zHO[4]);
+    rminHO = php.rHB[17] - 100.0;
+    etaHO[0] = getEta(0.5 * (php.rHB[17] + php.rHB[18]), php.zHO[1]);
+    etaHO[1] = getEta(php.rHB[18] + php.drHB[18], php.zHO[2]);
+    etaHO[2] = getEta(php.rHB[18] - php.drHB[18], php.zHO[3]);
+    etaHO[3] = getEta(php.rHB[18] + php.drHB[18], php.zHO[4]);
   } else {
-    rminHO   =-1.0;
+    rminHO = -1.0;
     etaHO[0] = etaHO[1] = etaHO[2] = etaHO[3] = 0;
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HO Eta boundaries " << etaHO[0] << " " 
-			       << etaHO[1] << " " << etaHO[2] << " " 
-			       << etaHO[3];
-  edm::LogVerbatim("HCalGeom") << "HO Parameters " << rminHO << " " 
-			       << php.zHO.size();
-  for (unsigned int i=0; i<php.zHO.size(); ++i) 
+  edm::LogVerbatim("HCalGeom") << "HO Eta boundaries " << etaHO[0] << " " << etaHO[1] << " " << etaHO[2] << " "
+                               << etaHO[3];
+  edm::LogVerbatim("HCalGeom") << "HO Parameters " << rminHO << " " << php.zHO.size();
+  for (unsigned int i = 0; i < php.zHO.size(); ++i)
     edm::LogVerbatim("HCalGeom") << " zho[" << i << "] = " << php.zHO[i];
 #endif
 }

--- a/Geometry/HcalCommonData/src/HcalHitRelabeller.cc
+++ b/Geometry/HcalCommonData/src/HcalHitRelabeller.cc
@@ -6,110 +6,93 @@
 
 //#define EDM_ML_DEBUG
 
-HcalHitRelabeller::HcalHitRelabeller(bool nd) : 
-  theRecNumber(nullptr),
-  neutralDensity_(nd) { 
+HcalHitRelabeller::HcalHitRelabeller(bool nd) : theRecNumber(nullptr), neutralDensity_(nd) {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HcalSim") << "HcalHitRelabeller initialized with" 
-				  << " neutralDensity " << neutralDensity_;
+  edm::LogVerbatim("HcalSim") << "HcalHitRelabeller initialized with"
+                              << " neutralDensity " << neutralDensity_;
 #endif
 }
 
 void HcalHitRelabeller::process(std::vector<PCaloHit>& hcalHits) {
-
   if (theRecNumber) {
 #ifdef EDM_ML_DEBUG
     int ii(0);
 #endif
-    for (auto & hcalHit : hcalHits) {
+    for (auto& hcalHit : hcalHits) {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HcalSim") << "Hit[" << ii << "] " << std::hex 
-				  << hcalHit.id() << std::dec 
-				  << " Neutral density " << neutralDensity_;
+      edm::LogVerbatim("HcalSim") << "Hit[" << ii << "] " << std::hex << hcalHit.id() << std::dec << " Neutral density "
+                                  << neutralDensity_;
 #endif
       double energy = (hcalHit.energy());
       if (neutralDensity_) {
-	energy *= (energyWt(hcalHit.id()));
-	hcalHit.setEnergy(energy);
+        energy *= (energyWt(hcalHit.id()));
+        hcalHit.setEnergy(energy);
       }
       DetId newid = relabel(hcalHit.id());
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HcalSim") << "Hit " << ii << " out of " 
-				  << hcalHits.size() << " " << std::hex 
-				  << newid.rawId() << std::dec << " E " 
-				  << energy;
+      edm::LogVerbatim("HcalSim") << "Hit " << ii << " out of " << hcalHits.size() << " " << std::hex << newid.rawId()
+                                  << std::dec << " E " << energy;
 #endif
       hcalHit.setID(newid.rawId());
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HcalSim") << "Modified Hit " 
-				  << HcalDetId(hcalHit.id());
+      edm::LogVerbatim("HcalSim") << "Modified Hit " << HcalDetId(hcalHit.id());
       ++ii;
 #endif
     }
   } else {
     edm::LogWarning("HcalSim") << "HcalHitRelabeller: no valid HcalDDDRecConstants";
   }
-  
 }
 
-void HcalHitRelabeller::setGeometry(const HcalDDDRecConstants *& recNum) {
-  theRecNumber = recNum;
-}
+void HcalHitRelabeller::setGeometry(const HcalDDDRecConstants*& recNum) { theRecNumber = recNum; }
 
 DetId HcalHitRelabeller::relabel(const uint32_t testId) const {
   return HcalHitRelabeller::relabel(testId, theRecNumber);
 }
 
-DetId HcalHitRelabeller::relabel(const uint32_t testId, const HcalDDDRecConstants * theRecNumber) {
-
+DetId HcalHitRelabeller::relabel(const uint32_t testId, const HcalDDDRecConstants* theRecNumber) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HcalSim") << "Enter HcalHitRelabeller::relabel";
 #endif
   HcalDetId hid;
-  int       det, z, depth, eta, phi, layer, sign;
-  HcalTestNumbering::unpackHcalIndex(testId,det,z,depth,eta,phi,layer);
+  int det, z, depth, eta, phi, layer, sign;
+  HcalTestNumbering::unpackHcalIndex(testId, det, z, depth, eta, phi, layer);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HcalSim") << "det: " << det << " "
-			      << "z: " << z << " "
-			      << "depth: " << depth << " "
-			      << "ieta: " << eta << " "
-			      << "iphi: " << phi << " "
-			      << "layer: " << layer;
+                              << "z: " << z << " "
+                              << "depth: " << depth << " "
+                              << "ieta: " << eta << " "
+                              << "iphi: " << phi << " "
+                              << "layer: " << layer;
 #endif
-  sign=(z==0)?(-1):(1);
-  HcalDDDRecConstants::HcalID id = theRecNumber->getHCID(det,sign*eta,phi,layer,depth);
+  sign = (z == 0) ? (-1) : (1);
+  HcalDDDRecConstants::HcalID id = theRecNumber->getHCID(det, sign * eta, phi, layer, depth);
 
-  if (id.subdet==int(HcalBarrel)) {
-    hid=HcalDetId(HcalBarrel,sign*id.eta,id.phi,id.depth);        
-  } else if (id.subdet==int(HcalEndcap)) {
-    hid=HcalDetId(HcalEndcap,sign*id.eta,id.phi,id.depth);    
-  } else if (id.subdet==int(HcalOuter)) {
-    hid=HcalDetId(HcalOuter,sign*id.eta,id.phi,id.depth);    
-  } else if (id.subdet==int(HcalForward)) {
-    hid=HcalDetId(HcalForward,sign*id.eta,id.phi,id.depth);
+  if (id.subdet == int(HcalBarrel)) {
+    hid = HcalDetId(HcalBarrel, sign * id.eta, id.phi, id.depth);
+  } else if (id.subdet == int(HcalEndcap)) {
+    hid = HcalDetId(HcalEndcap, sign * id.eta, id.phi, id.depth);
+  } else if (id.subdet == int(HcalOuter)) {
+    hid = HcalDetId(HcalOuter, sign * id.eta, id.phi, id.depth);
+  } else if (id.subdet == int(HcalForward)) {
+    hid = HcalDetId(HcalForward, sign * id.eta, id.phi, id.depth);
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalSim") << " new HcalDetId -> hex.RawID = "
-			      << std::hex << hid.rawId() << std::dec
-			      << " det, z, depth, eta, phi = " << det << " "
-			      << z << " "<< id.depth << " " << id.eta << " "
-			      << id.phi << " ---> " << hid;  
+  edm::LogVerbatim("HcalSim") << " new HcalDetId -> hex.RawID = " << std::hex << hid.rawId() << std::dec
+                              << " det, z, depth, eta, phi = " << det << " " << z << " " << id.depth << " " << id.eta
+                              << " " << id.phi << " ---> " << hid;
 #endif
   return hid;
 }
 
 double HcalHitRelabeller::energyWt(const uint32_t testId) const {
-
-  int       det, z, depth, eta, phi, layer;
-  HcalTestNumbering::unpackHcalIndex(testId,det,z,depth,eta,phi,layer);
-  int       zside = (z==0) ? (-1) : (1);
-  double    wt    = (((det==1) || (det==2)) && (depth == 1)) ? 
-    theRecNumber->getLayer0Wt(det,phi,zside) : 1.0;
+  int det, z, depth, eta, phi, layer;
+  HcalTestNumbering::unpackHcalIndex(testId, det, z, depth, eta, phi, layer);
+  int zside = (z == 0) ? (-1) : (1);
+  double wt = (((det == 1) || (det == 2)) && (depth == 1)) ? theRecNumber->getLayer0Wt(det, phi, zside) : 1.0;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HcalSim") << "EnergyWT::det: " << det << " z: " << z  
-			      << ":" << zside << " depth: " << depth 
-			      << " ieta: " << eta << " iphi: " << phi
-			      << " layer: " << layer << " wt " << wt;
+  edm::LogVerbatim("HcalSim") << "EnergyWT::det: " << det << " z: " << z << ":" << zside << " depth: " << depth
+                              << " ieta: " << eta << " iphi: " << phi << " layer: " << layer << " wt " << wt;
 #endif
   return wt;
 }

--- a/Geometry/HcalCommonData/src/HcalLayerDepthMap.cc
+++ b/Geometry/HcalCommonData/src/HcalLayerDepthMap.cc
@@ -2,273 +2,260 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include<algorithm>
+#include <algorithm>
 
 //#define EDM_ML_DEBUG
 
 HcalLayerDepthMap::HcalLayerDepthMap() {
-  subdet_  = 0;
+  subdet_ = 0;
   ietaMin_ = ietaMax_ = 0;
-  depthMin_= 99;
-  depthMax_=-1;
-  dep29C_  = 2;
-  wtl0C_   = 1.;
+  depthMin_ = 99;
+  depthMax_ = -1;
+  dep29C_ = 2;
+  wtl0C_ = 1.;
 }
 
 HcalLayerDepthMap::~HcalLayerDepthMap() {}
 
-void HcalLayerDepthMap::initialize(const int subdet, const int ietaMax, 
-				   const int dep16C, const int dep29C, 
-				   const double wtl0C, 
-				   std::vector<int> const& iphi,
-				   std::vector<int> const& ieta,
-				   std::vector<int> const& layer,
-				   std::vector<int> const& depth) {
-  
-  subdet_  = subdet;
+void HcalLayerDepthMap::initialize(const int subdet,
+                                   const int ietaMax,
+                                   const int dep16C,
+                                   const int dep29C,
+                                   const double wtl0C,
+                                   std::vector<int> const& iphi,
+                                   std::vector<int> const& ieta,
+                                   std::vector<int> const& layer,
+                                   std::vector<int> const& depth) {
+  subdet_ = subdet;
   ietaMin_ = ietaMax_ = ietaMax;
-  dep16C_  = dep16C;
-  dep29C_  = dep29C;
-  wtl0C_   = wtl0C;
-  iphi_.insert(iphi_.end(),iphi.begin(),iphi.end());
-  layer2Depth_.clear(); depth2LayerF_.clear(); depth2LayerB_.clear();
-  depthMin_= 99;
-  depthMax_=-1;
-  for (unsigned int k=0; k<ieta.size(); ++k) {
-    if (ieta[k]  < ietaMin_)  ietaMin_  = ieta[k];
-    if (depth[k] < depthMin_) depthMin_ = depth[k];
-    if (depth[k] > depthMax_) depthMax_ = depth[k];
+  dep16C_ = dep16C;
+  dep29C_ = dep29C;
+  wtl0C_ = wtl0C;
+  iphi_.insert(iphi_.end(), iphi.begin(), iphi.end());
+  layer2Depth_.clear();
+  depth2LayerF_.clear();
+  depth2LayerB_.clear();
+  depthMin_ = 99;
+  depthMax_ = -1;
+  for (unsigned int k = 0; k < ieta.size(); ++k) {
+    if (ieta[k] < ietaMin_)
+      ietaMin_ = ieta[k];
+    if (depth[k] < depthMin_)
+      depthMin_ = depth[k];
+    if (depth[k] > depthMax_)
+      depthMax_ = depth[k];
   }
   //Assume ieta, layer, depth are in increasing order of ieta and depth
-  for (unsigned int k1=0; k1<ieta.size(); ++k1) {
+  for (unsigned int k1 = 0; k1 < ieta.size(); ++k1) {
     int ietaMin = ieta[k1];
     int ietaMax = ietaMax_;
-    int layMin  = layer[k1];
-    int layMax  = (k1+1 < ieta.size()) ? (layer[k1+1]-1) : maxLayers_;
-    for (unsigned int k2=k1+1; k2<ieta.size(); ++k2) {
+    int layMin = layer[k1];
+    int layMax = (k1 + 1 < ieta.size()) ? (layer[k1 + 1] - 1) : maxLayers_;
+    for (unsigned int k2 = k1 + 1; k2 < ieta.size(); ++k2) {
       if (ieta[k2] > ieta[k1]) {
-	ietaMax = ieta[k2] - 1;
-	if (k2 == k1+1) layMax = maxLayers_;
-	break;
+        ietaMax = ieta[k2] - 1;
+        if (k2 == k1 + 1)
+          layMax = maxLayers_;
+        break;
       }
     }
-    for (int eta=ietaMin; eta<=ietaMax; ++eta) {
-      depth2LayerF_[std::pair<int,int>(eta,depth[k1])] = layMin;
-      depth2LayerB_[std::pair<int,int>(eta,depth[k1])] = layMax;
-      for (int lay=layMin; lay<=layMax; ++lay)
-	layer2Depth_[std::pair<int,int>(eta,lay)] = depth[k1];
+    for (int eta = ietaMin; eta <= ietaMax; ++eta) {
+      depth2LayerF_[std::pair<int, int>(eta, depth[k1])] = layMin;
+      depth2LayerB_[std::pair<int, int>(eta, depth[k1])] = layMax;
+      for (int lay = layMin; lay <= layMax; ++lay)
+        layer2Depth_[std::pair<int, int>(eta, lay)] = depth[k1];
     }
   }
-  for (int eta=ietaMin_; eta<=ietaMax_; ++eta) {
+  for (int eta = ietaMin_; eta <= ietaMax_; ++eta) {
     int dmin(99), dmax(-1);
-    for (auto & itr : layer2Depth_) {
+    for (auto& itr : layer2Depth_) {
       if ((itr.first).first == eta) {
-	if ((itr.second) < dmin) dmin = (itr.second);
-	if ((itr.second) > dmax) dmax = (itr.second);
+        if ((itr.second) < dmin)
+          dmin = (itr.second);
+        if ((itr.second) > dmax)
+          dmax = (itr.second);
       }
     }
     if (subdet == 2) {
-      if      (eta == ietaMin_) dmin = dep16C_;
-      else if (eta == ietaMax_) dmax = dep29C_;
+      if (eta == ietaMin_)
+        dmin = dep16C_;
+      else if (eta == ietaMax_)
+        dmax = dep29C_;
     }
-    depthsEta_[eta] = std::pair<int,int>(dmin,dmax);
+    depthsEta_[eta] = std::pair<int, int>(dmin, dmax);
   }
 #ifdef EDM_ML_DEBUG
-  std::cout << "HcalLayerDepthMap: Subdet " << subdet_ << " iEta " << ietaMin_
-	    << ":" << ietaMax_ << " depth " << depthMin_ << ":" << depthMax_
-	    << "\nMaximum Depth for last HE towers " << dep29C_  
-	    << " Layer 0 Weight " << wtl0C_ << " iPhi";
-  for (unsigned int k=0; k<iphi_.size(); ++k) std::cout << ":" << iphi_[k];
-  std::cout << std::endl << "Layer2Depth_ with " << layer2Depth_.size()
-	    << " elements" << std::endl;
-  for (std::map<std::pair<int,int>,int>::iterator itr=layer2Depth_.begin();
-       itr != layer2Depth_.end(); ++itr)
-    std::cout << "iEta " << (itr->first).first << " Layer " 
-	      << (itr->first).second << " Depth " << itr->second << std::endl;
-  std::cout << "Depth2LayerFront with " << depth2LayerF_.size() 
-	    << " elemsts" << std::endl;
-  for (std::map<std::pair<int,int>,int>::iterator itr=depth2LayerF_.begin();
-       itr != depth2LayerF_.end(); ++itr)
-    std::cout << "iEta " << (itr->first).first << " Depth " 
-	      << (itr->first).second << " Layer " << itr->second << std::endl;
-  std::cout << "Depth2LayerBack with " << depth2LayerB_.size()
-	    << " elemets" << std::endl;
-  for (std::map<std::pair<int,int>,int>::iterator itr=depth2LayerB_.begin();
-       itr != depth2LayerB_.end(); ++itr)
-    std::cout << "iEta " << (itr->first).first << " Depth " 
-	      << (itr->first).second << " Layer " << itr->second << std::endl;
+  std::cout << "HcalLayerDepthMap: Subdet " << subdet_ << " iEta " << ietaMin_ << ":" << ietaMax_ << " depth "
+            << depthMin_ << ":" << depthMax_ << "\nMaximum Depth for last HE towers " << dep29C_ << " Layer 0 Weight "
+            << wtl0C_ << " iPhi";
+  for (unsigned int k = 0; k < iphi_.size(); ++k)
+    std::cout << ":" << iphi_[k];
+  std::cout << std::endl << "Layer2Depth_ with " << layer2Depth_.size() << " elements" << std::endl;
+  for (std::map<std::pair<int, int>, int>::iterator itr = layer2Depth_.begin(); itr != layer2Depth_.end(); ++itr)
+    std::cout << "iEta " << (itr->first).first << " Layer " << (itr->first).second << " Depth " << itr->second
+              << std::endl;
+  std::cout << "Depth2LayerFront with " << depth2LayerF_.size() << " elemsts" << std::endl;
+  for (std::map<std::pair<int, int>, int>::iterator itr = depth2LayerF_.begin(); itr != depth2LayerF_.end(); ++itr)
+    std::cout << "iEta " << (itr->first).first << " Depth " << (itr->first).second << " Layer " << itr->second
+              << std::endl;
+  std::cout << "Depth2LayerBack with " << depth2LayerB_.size() << " elemets" << std::endl;
+  for (std::map<std::pair<int, int>, int>::iterator itr = depth2LayerB_.begin(); itr != depth2LayerB_.end(); ++itr)
+    std::cout << "iEta " << (itr->first).first << " Depth " << (itr->first).second << " Layer " << itr->second
+              << std::endl;
   std::cout << "DepthsEta_ with " << depthsEta_.size() << " elements\n";
-  for (std::map<int,std::pair<int,int> >::iterator itr=depthsEta_.begin();
-       itr != depthsEta_.end(); ++itr)
-    std::cout << "iEta " << itr->first << " Depths " 
-	      << (itr->second).first << ":" << (itr->second).second 
-	      << std::endl;
+  for (std::map<int, std::pair<int, int> >::iterator itr = depthsEta_.begin(); itr != depthsEta_.end(); ++itr)
+    std::cout << "iEta " << itr->first << " Depths " << (itr->second).first << ":" << (itr->second).second << std::endl;
 #endif
 }
 
-int HcalLayerDepthMap::getDepth(const int subdet, const int ieta, 
-				const int iphi, const int zside,
-				const int layer) const {
+int HcalLayerDepthMap::getDepth(
+    const int subdet, const int ieta, const int iphi, const int zside, const int layer) const {
   int depth(-1);
-  if (isValid(subdet,iphi,zside)) {
-    std::map<std::pair<int,int>,int>::const_iterator itr = layer2Depth_.find(std::pair<int,int>(ieta,layer));
-    if (itr != layer2Depth_.end()) depth = itr->second;
+  if (isValid(subdet, iphi, zside)) {
+    std::map<std::pair<int, int>, int>::const_iterator itr = layer2Depth_.find(std::pair<int, int>(ieta, layer));
+    if (itr != layer2Depth_.end())
+      depth = itr->second;
   }
 #ifdef EDM_ML_DEBUG
-  std::cout << "getDepth::Input " << subdet << ":" << ieta << ":" << iphi 
-	    << ":" << zside << ":" << layer << " Output " << depth <<std::endl;
+  std::cout << "getDepth::Input " << subdet << ":" << ieta << ":" << iphi << ":" << zside << ":" << layer << " Output "
+            << depth << std::endl;
 #endif
   return depth;
 }
 
-int HcalLayerDepthMap::getDepth16(const int subdet, const int iphi, 
-				  const int zside) const {
+int HcalLayerDepthMap::getDepth16(const int subdet, const int iphi, const int zside) const {
   int depth(-1);
-  if (isValid(subdet,iphi,zside)) depth = dep16C_;
+  if (isValid(subdet, iphi, zside))
+    depth = dep16C_;
 #ifdef EDM_ML_DEBUG
-  std::cout << "getDepth16::Input " << subdet << ":" << iphi << ":" << zside
-	    << " Output "  << depth << std::endl;
+  std::cout << "getDepth16::Input " << subdet << ":" << iphi << ":" << zside << " Output " << depth << std::endl;
 #endif
   return depth;
 }
 
-int HcalLayerDepthMap::getDepthMin(const int subdet, const int iphi,
-				   const int zside) const {
-  int depth = (isValid(subdet,iphi,zside)) ? depthMin_ : -1;
+int HcalLayerDepthMap::getDepthMin(const int subdet, const int iphi, const int zside) const {
+  int depth = (isValid(subdet, iphi, zside)) ? depthMin_ : -1;
 #ifdef EDM_ML_DEBUG
-  std::cout << "getDepthMin::Input " << subdet << ":" << iphi << ":" << zside
-	    << " Output " << depth << std::endl;
+  std::cout << "getDepthMin::Input " << subdet << ":" << iphi << ":" << zside << " Output " << depth << std::endl;
 #endif
   return depth;
 }
 
-int HcalLayerDepthMap::getDepthMax(const int subdet, const int iphi,
-				   const int zside) const {
-  int depth = (isValid(subdet,iphi,zside)) ? depthMax_ : -1;
+int HcalLayerDepthMap::getDepthMax(const int subdet, const int iphi, const int zside) const {
+  int depth = (isValid(subdet, iphi, zside)) ? depthMax_ : -1;
 #ifdef EDM_ML_DEBUG
-  std::cout << "getDepthMax::Input " << subdet << ":" << iphi << ":" << zside
-	    << " Output " << depth << std::endl;
+  std::cout << "getDepthMax::Input " << subdet << ":" << iphi << ":" << zside << " Output " << depth << std::endl;
 #endif
   return depth;
 }
 
-int HcalLayerDepthMap::getDepthMax(const int subdet, const int ieta,
-				   const int iphi, const int zside) const {
-  int depth = (isValid(subdet,iphi,zside)) ? getDepth(subdet,ieta,iphi,zside,maxLayers_) : -1;
+int HcalLayerDepthMap::getDepthMax(const int subdet, const int ieta, const int iphi, const int zside) const {
+  int depth = (isValid(subdet, iphi, zside)) ? getDepth(subdet, ieta, iphi, zside, maxLayers_) : -1;
 #ifdef EDM_ML_DEBUG
-  std::cout << "getDepthMax::Input " << subdet << ":" << iphi << ":" << zside
-	    << " Output " << depth << std::endl;
+  std::cout << "getDepthMax::Input " << subdet << ":" << iphi << ":" << zside << " Output " << depth << std::endl;
 #endif
   return depth;
 }
 
-std::pair<int,int> HcalLayerDepthMap::getDepths(const int eta) const {
-
-  std::map<int,std::pair<int,int> >::const_iterator itr = depthsEta_.find(eta);
-  if (itr == depthsEta_.end()) return std::pair<int,int>(-1,-1);
-  else                         return itr->second;
+std::pair<int, int> HcalLayerDepthMap::getDepths(const int eta) const {
+  std::map<int, std::pair<int, int> >::const_iterator itr = depthsEta_.find(eta);
+  if (itr == depthsEta_.end())
+    return std::pair<int, int>(-1, -1);
+  else
+    return itr->second;
 }
 
-int HcalLayerDepthMap::getLayerFront(const int subdet, const int ieta,
-				     const int iphi, const int zside,
-				     const int depth) const {
+int HcalLayerDepthMap::getLayerFront(
+    const int subdet, const int ieta, const int iphi, const int zside, const int depth) const {
   int layer(-1);
-  if (isValid(subdet,iphi,zside)) {
-    std::map<std::pair<int,int>,int>::const_iterator itr = depth2LayerF_.find(std::pair<int,int>(ieta,depth));
-    if (itr != depth2LayerF_.end()) layer = itr->second;
+  if (isValid(subdet, iphi, zside)) {
+    std::map<std::pair<int, int>, int>::const_iterator itr = depth2LayerF_.find(std::pair<int, int>(ieta, depth));
+    if (itr != depth2LayerF_.end())
+      layer = itr->second;
   }
 #ifdef EDM_ML_DEBUG
-  std::cout << "getLayerFront::Input " << subdet << ":" << ieta << ":" << iphi 
-	    << ":" << zside << ":" << depth << " Output " << layer <<std::endl;
+  std::cout << "getLayerFront::Input " << subdet << ":" << ieta << ":" << iphi << ":" << zside << ":" << depth
+            << " Output " << layer << std::endl;
 #endif
   return layer;
 }
 
-int HcalLayerDepthMap::getLayerBack(const int subdet, const int ieta, 
-				    const int iphi, const int zside,
-				    const int depth) const {
+int HcalLayerDepthMap::getLayerBack(
+    const int subdet, const int ieta, const int iphi, const int zside, const int depth) const {
   int layer(-1);
-  if (isValid(subdet,iphi,zside)) {
-    std::map<std::pair<int,int>,int>::const_iterator itr = depth2LayerB_.find(std::pair<int,int>(ieta,depth));
-    if (itr != depth2LayerB_.end()) layer = itr->second;
+  if (isValid(subdet, iphi, zside)) {
+    std::map<std::pair<int, int>, int>::const_iterator itr = depth2LayerB_.find(std::pair<int, int>(ieta, depth));
+    if (itr != depth2LayerB_.end())
+      layer = itr->second;
   }
 #ifdef EDM_ML_DEBUG
-  std::cout << "getLayerBack::Input " << subdet << ":" << ieta << ":" << iphi 
-	    << ":" << zside << ":" << depth << " Output " << layer <<std::endl;
+  std::cout << "getLayerBack::Input " << subdet << ":" << ieta << ":" << iphi << ":" << zside << ":" << depth
+            << " Output " << layer << std::endl;
 #endif
   return layer;
 }
 
-void HcalLayerDepthMap::getLayerDepth(const int subdet, const int eta, 
-				      const int phi, const int zside,
-				      std::map<int,int>& layers) const {
+void HcalLayerDepthMap::getLayerDepth(
+    const int subdet, const int eta, const int phi, const int zside, std::map<int, int>& layers) const {
   layers.clear();
-  if (isValid(subdet,phi,zside)) {
-    for (const auto & itr : layer2Depth_) {
+  if (isValid(subdet, phi, zside)) {
+    for (const auto& itr : layer2Depth_) {
       if ((itr.first).first == eta) {
-	layers[((itr.first).second)+1] = (itr.second);
+        layers[((itr.first).second) + 1] = (itr.second);
       }
     }
   }
 #ifdef EDM_ML_DEBUG
-  std::cout << "getLayerDepth::Input " << subdet << ":" << eta << ":" << phi
-	    << ":" << zside << " Output " << layers.size() << " entries\n";
-  for (std::map<int,int>::iterator itr=layers.begin(); itr != layers.end();
-       ++itr) std::cout << " [" << itr->first << "] " << itr->second;
+  std::cout << "getLayerDepth::Input " << subdet << ":" << eta << ":" << phi << ":" << zside << " Output "
+            << layers.size() << " entries\n";
+  for (std::map<int, int>::iterator itr = layers.begin(); itr != layers.end(); ++itr)
+    std::cout << " [" << itr->first << "] " << itr->second;
   std::cout << std::endl;
 #endif
 }
 
-void HcalLayerDepthMap::getLayerDepth(const int eta, 
-				      std::map<int,int>& layers) const {
+void HcalLayerDepthMap::getLayerDepth(const int eta, std::map<int, int>& layers) const {
   layers.clear();
   if (subdet_ > 0) {
-    for (const auto & itr : layer2Depth_) {
+    for (const auto& itr : layer2Depth_) {
       if ((itr.first).first == eta) {
-	layers[((itr.first).second)+1] = (itr.second);
+        layers[((itr.first).second) + 1] = (itr.second);
       }
     }
   }
 #ifdef EDM_ML_DEBUG
-  std::cout << "getLayerDepth::Input " << eta << " Output " << layers.size()
-	    << " entries\n";
-  for (std::map<int,int>::iterator itr=layers.begin(); itr != layers.end();
-       ++itr) std::cout << " [" << itr->first << "] " << itr->second;
+  std::cout << "getLayerDepth::Input " << eta << " Output " << layers.size() << " entries\n";
+  for (std::map<int, int>::iterator itr = layers.begin(); itr != layers.end(); ++itr)
+    std::cout << " [" << itr->first << "] " << itr->second;
   std::cout << std::endl;
 #endif
 }
 
-int HcalLayerDepthMap::getMaxDepthLastHE(const int subdet, const int iphi,
-					 const int zside) const {
-  int depth = isValid(subdet,iphi,zside) ? dep29C_ : -1;
+int HcalLayerDepthMap::getMaxDepthLastHE(const int subdet, const int iphi, const int zside) const {
+  int depth = isValid(subdet, iphi, zside) ? dep29C_ : -1;
 #ifdef EDM_ML_DEBUG
-  std::cout << "getMaxDepthLastHE::Input " << subdet << ":" << iphi << ":"
-	    << zside << " Output " << depth << std::endl;
+  std::cout << "getMaxDepthLastHE::Input " << subdet << ":" << iphi << ":" << zside << " Output " << depth << std::endl;
 #endif
   return depth;
 }
 
-double HcalLayerDepthMap::getLayer0Wt(const int subdet, const int iphi,
-				      const int zside) const {
-  double wt = isValid(subdet,iphi,zside) ? wtl0C_ : -1.0;
+double HcalLayerDepthMap::getLayer0Wt(const int subdet, const int iphi, const int zside) const {
+  double wt = isValid(subdet, iphi, zside) ? wtl0C_ : -1.0;
 #ifdef EDM_ML_DEBUG
-  std::cout << "getLayer0Wt::Input " << subdet << ":" << iphi << ":" << zside 
-	    << " Output " << wt << std::endl;
+  std::cout << "getLayer0Wt::Input " << subdet << ":" << iphi << ":" << zside << " Output " << wt << std::endl;
 #endif
   return wt;
 }
 
-bool HcalLayerDepthMap::isValid(const int subdet, const int iphi,
-				const int zside) const {
+bool HcalLayerDepthMap::isValid(const int subdet, const int iphi, const int zside) const {
   bool flag(false);
-  int  kphi = (zside > 0) ? iphi : -iphi;
+  int kphi = (zside > 0) ? iphi : -iphi;
   if (subdet == subdet_)
-    flag = (std::find(iphi_.begin(),iphi_.end(),kphi) != iphi_.end());
+    flag = (std::find(iphi_.begin(), iphi_.end(), kphi) != iphi_.end());
   return flag;
 }
 
 int HcalLayerDepthMap::validDet(std::vector<int>& phi) const {
-
-  phi.insert(phi.end(),iphi_.begin(),iphi_.end());
+  phi.insert(phi.end(), iphi_.begin(), iphi_.end());
   return subdet_;
 }

--- a/Geometry/HcalCommonData/src/HcalNumberingFromDDD.cc
+++ b/Geometry/HcalCommonData/src/HcalNumberingFromDDD.cc
@@ -15,8 +15,7 @@
 using namespace geant_units;
 using namespace geant_units::operators;
 
-HcalNumberingFromDDD::HcalNumberingFromDDD(const HcalDDDSimConstants *hcons) :
-  hcalConstants(hcons) {
+HcalNumberingFromDDD::HcalNumberingFromDDD(const HcalDDDSimConstants* hcons) : hcalConstants(hcons) {
 #ifdef EDM_ML_DEBUG
   edm::LogInfo("HCalGeom") << "Creating HcalNumberingFromDDD\n";
 #endif
@@ -29,106 +28,88 @@ HcalNumberingFromDDD::~HcalNumberingFromDDD() {
 }
 
 HcalNumberingFromDDD::HcalID HcalNumberingFromDDD::unitID(int det,
-							  const math::XYZVectorD& point,
-							  int depth,
-							  int lay) const {
-
-
-  double hx  = point.x();
-  double hy  = point.y();
-  double hz  = point.z();
-  double hR  = sqrt(hx*hx+hy*hy+hz*hz);
-  double htheta = (hR == 0. ? 0. : acos(std::max(std::min(hz/hR,1.0),-1.0)));
+                                                          const math::XYZVectorD& point,
+                                                          int depth,
+                                                          int lay) const {
+  double hx = point.x();
+  double hy = point.y();
+  double hz = point.z();
+  double hR = sqrt(hx * hx + hy * hy + hz * hz);
+  double htheta = (hR == 0. ? 0. : acos(std::max(std::min(hz / hR, 1.0), -1.0)));
   double hsintheta = sin(htheta);
-  double hphi = (hR*hsintheta == 0. ? 0. :atan2(hy,hx));
-  double heta = (fabs(hsintheta) == 1.? 0. : -log(fabs(tan(htheta/2.))) );
+  double hphi = (hR * hsintheta == 0. ? 0. : atan2(hy, hx));
+  double heta = (fabs(hsintheta) == 1. ? 0. : -log(fabs(tan(htheta / 2.))));
 
-  int    hsubdet=0;
+  int hsubdet = 0;
   double etaR;
 
   //First eta index
-  if (det == 5) { // Forward HCal
+  if (det == 5) {  // Forward HCal
     hsubdet = static_cast<int>(HcalForward);
-    hR      = sqrt(hx*hx+hy*hy);
-    etaR    = (heta >= 0. ? hR : -hR);
-  } else { // Barrel or Endcap
-    etaR    = heta;
+    hR = sqrt(hx * hx + hy * hy);
+    etaR = (heta >= 0. ? hR : -hR);
+  } else {  // Barrel or Endcap
+    etaR = heta;
     if (det == 3) {
       hsubdet = static_cast<int>(HcalBarrel);
-      etaR    = hcalConstants->getEtaHO(heta,hx,hy,hz);
+      etaR = hcalConstants->getEtaHO(heta, hx, hy, hz);
     } else {
       hsubdet = static_cast<int>(HcalEndcap);
     }
   }
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalNumberingFromDDD: point = " << point
-			       << " det " << det << ":" << hsubdet << " eta/R "
-			       << etaR << " phi " << hphi << " depth " << depth
-			       << " layer " << lay;
+  edm::LogVerbatim("HCalGeom") << "HcalNumberingFromDDD: point = " << point << " det " << det << ":" << hsubdet
+                               << " eta/R " << etaR << " phi " << hphi << " depth " << depth << " layer " << lay;
 #endif
-  return unitID(hsubdet,etaR,hphi,depth,lay);
+  return unitID(hsubdet, etaR, hphi, depth, lay);
 }
 
-HcalNumberingFromDDD::HcalID HcalNumberingFromDDD::unitID(double eta,double fi,
-							  int depth, 
-							  int lay) const {
-  std::pair<int,double> detEta = hcalConstants->getDetEta(eta, depth);
-  return unitID(detEta.first,detEta.second,fi,depth,lay);
+HcalNumberingFromDDD::HcalID HcalNumberingFromDDD::unitID(double eta, double fi, int depth, int lay) const {
+  std::pair<int, double> detEta = hcalConstants->getDetEta(eta, depth);
+  return unitID(detEta.first, detEta.second, fi, depth, lay);
 }
 
-
-HcalNumberingFromDDD::HcalID HcalNumberingFromDDD::unitID(int det,
-							  double etaR,
-							  double phi,
-							  int depth,
-							  int lay) const {
-
+HcalNumberingFromDDD::HcalID HcalNumberingFromDDD::unitID(int det, double etaR, double phi, int depth, int lay) const {
   double hetaR = fabs(etaR);
-  int    ieta  = hcalConstants->getEta(det, lay, hetaR);
-  std::pair<double,double> ficons = hcalConstants->getPhiCons(det, ieta);
+  int ieta = hcalConstants->getEta(det, lay, hetaR);
+  std::pair<double, double> ficons = hcalConstants->getPhiCons(det, ieta);
 
-  int    nphi  = int((2._pi+0.1*ficons.second)/ficons.second);
-  int    zside = etaR>0 ? 1: 0;
-  double hphi  = phi+ficons.first;
-  if (hphi < 0)    hphi += (2._pi);
-  int    iphi  = int(hphi/ficons.second) + 1;
-  if (iphi > nphi) iphi = 1;
+  int nphi = int((2._pi + 0.1 * ficons.second) / ficons.second);
+  int zside = etaR > 0 ? 1 : 0;
+  double hphi = phi + ficons.first;
+  if (hphi < 0)
+    hphi += (2._pi);
+  int iphi = int(hphi / ficons.second) + 1;
+  if (iphi > nphi)
+    iphi = 1;
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalNumberingFromDDD: etaR = " << etaR 
-			       << " : " << zside << "/" << ieta << " phi "
-			       << hphi << " : " << iphi << std::endl;
+  edm::LogVerbatim("HCalGeom") << "HcalNumberingFromDDD: etaR = " << etaR << " : " << zside << "/" << ieta << " phi "
+                               << hphi << " : " << iphi << std::endl;
 #endif
-  return unitID(det,zside,depth,ieta,iphi,lay);
+  return unitID(det, zside, depth, ieta, iphi, lay);
 }
 
-HcalNumberingFromDDD::HcalID HcalNumberingFromDDD::unitID(int det, int zside,
-							  int depth, int etaR,
-							  int phi, 
-							  int lay) const {
-
-
+HcalNumberingFromDDD::HcalID HcalNumberingFromDDD::unitID(
+    int det, int zside, int depth, int etaR, int phi, int lay) const {
   if (det == static_cast<int>(HcalBarrel) && lay > 17)
     det = static_cast<int>(HcalOuter);
 
-  int units     = hcalConstants->unitPhi(det, etaR);
+  int units = hcalConstants->unitPhi(det, etaR);
   int iphi_skip = hcalConstants->phiNumber(phi, units);
 
-  std::pair<int,int> etaDepth = hcalConstants->getEtaDepth(det, etaR, iphi_skip, zside, depth, lay);
+  std::pair<int, int> etaDepth = hcalConstants->getEtaDepth(det, etaR, iphi_skip, zside, depth, lay);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalNumberingFromDDD: phi units= " << units
-			       << "  iphi_skip= " << iphi_skip; 
+  edm::LogVerbatim("HCalGeom") << "HcalNumberingFromDDD: phi units= " << units << "  iphi_skip= " << iphi_skip;
 #endif
-  HcalNumberingFromDDD::HcalID tmp(det,zside,etaDepth.second,etaDepth.first,phi,iphi_skip,lay);
+  HcalNumberingFromDDD::HcalID tmp(det, zside, etaDepth.second, etaDepth.first, phi, iphi_skip, lay);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HCalGeom") << "HcalNumberingFromDDD: det = " << det << " " 
-			       << tmp.subdet << " zside = " << tmp.zside 
-			       << " depth = " << tmp.depth << " eta/R = " 
-			       << tmp.etaR << " phi = "   << tmp.phi 
-			       << " layer = " << tmp.lay;
+  edm::LogVerbatim("HCalGeom") << "HcalNumberingFromDDD: det = " << det << " " << tmp.subdet << " zside = " << tmp.zside
+                               << " depth = " << tmp.depth << " eta/R = " << tmp.etaR << " phi = " << tmp.phi
+                               << " layer = " << tmp.lay;
 #endif
   return tmp;
 }

--- a/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
@@ -15,211 +15,211 @@
 //#define EDM_ML_DEBUG
 
 namespace {
-  int getTopologyMode(const char* s, const DDsvalues_type & sv, bool type) {
-    DDValue val( s );
-    if (DDfetch( &sv, val )) {
-      const std::vector<std::string> & fvec = val.strings();
+  int getTopologyMode(const char* s, const DDsvalues_type& sv, bool type) {
+    DDValue val(s);
+    if (DDfetch(&sv, val)) {
+      const std::vector<std::string>& fvec = val.strings();
       if (fvec.empty()) {
-	throw cms::Exception( "HcalParametersFromDD" ) << "Failed to get " << s << " tag.";
+        throw cms::Exception("HcalParametersFromDD") << "Failed to get " << s << " tag.";
       }
 
       int result(-1);
       if (type) {
-	StringToEnumParser<HcalTopologyMode::Mode> eparser;
-	HcalTopologyMode::Mode mode = (HcalTopologyMode::Mode) eparser.parseString(fvec[0]);
-	result = (int)(mode);
+        StringToEnumParser<HcalTopologyMode::Mode> eparser;
+        HcalTopologyMode::Mode mode = (HcalTopologyMode::Mode)eparser.parseString(fvec[0]);
+        result = (int)(mode);
       } else {
-	StringToEnumParser<HcalTopologyMode::TriggerMode> eparser;
-	HcalTopologyMode::TriggerMode mode = (HcalTopologyMode::TriggerMode) eparser.parseString(fvec[0]);
-	result = (int)(mode);
+        StringToEnumParser<HcalTopologyMode::TriggerMode> eparser;
+        HcalTopologyMode::TriggerMode mode = (HcalTopologyMode::TriggerMode)eparser.parseString(fvec[0]);
+        result = (int)(mode);
       }
       return result;
     } else {
-      throw cms::Exception( "HcalParametersFromDD" ) << "Failed to get "<< s << " tag.";
+      throw cms::Exception("HcalParametersFromDD") << "Failed to get " << s << " tag.";
     }
   }
-}
+}  // namespace
 
-bool HcalParametersFromDD::build(const DDCompactView* cpv,
-				 HcalParameters& php) {
-
+bool HcalParametersFromDD::build(const DDCompactView* cpv, HcalParameters& php) {
   //Special parameters at simulation level
-  std::string attribute = "OnlyForHcalSimNumbering"; 
+  std::string attribute = "OnlyForHcalSimNumbering";
   DDSpecificsHasNamedValueFilter filter1{attribute};
-  DDFilteredView fv1(*cpv,filter1);
+  DDFilteredView fv1(*cpv, filter1);
   bool ok = fv1.firstChild();
 
-  const int nEtaMax=100;
+  const int nEtaMax = 100;
 
   if (ok) {
-    HcalGeomParameters *geom = new HcalGeomParameters();
-    geom->loadGeometry( fv1, php );
-    php.modHB  = geom->getModHalfHBHE(0);
-    php.modHE  = geom->getModHalfHBHE(1);
+    HcalGeomParameters* geom = new HcalGeomParameters();
+    geom->loadGeometry(fv1, php);
+    php.modHB = geom->getModHalfHBHE(0);
+    php.modHE = geom->getModHalfHBHE(1);
     php.dzVcal = geom->getConstDzHF();
     geom->getConstRHO(php.rHO);
 
-    php.phioff   = DDVectorGetter::get( "phioff" );
-    php.etaTable = DDVectorGetter::get( "etaTable" );
-    php.rTable   = DDVectorGetter::get( "rTable" );
-    php.phibin   = DDVectorGetter::get( "phibin" );
-    php.phitable = DDVectorGetter::get( "phitable" );  
-    for (unsigned int i = 1; i<=nEtaMax; ++i) {
+    php.phioff = DDVectorGetter::get("phioff");
+    php.etaTable = DDVectorGetter::get("etaTable");
+    php.rTable = DDVectorGetter::get("rTable");
+    php.phibin = DDVectorGetter::get("phibin");
+    php.phitable = DDVectorGetter::get("phitable");
+    for (unsigned int i = 1; i <= nEtaMax; ++i) {
       std::stringstream sstm;
       sstm << "layerGroupSimEta" << i;
       std::string tempName = sstm.str();
       if (DDVectorGetter::check(tempName)) {
-	HcalParameters::LayerItem layerGroupEta;
-	layerGroupEta.layer = i;
-	layerGroupEta.layerGroup = dbl_to_int(DDVectorGetter::get(tempName));
-	php.layerGroupEtaSim.emplace_back(layerGroupEta);
+        HcalParameters::LayerItem layerGroupEta;
+        layerGroupEta.layer = i;
+        layerGroupEta.layerGroup = dbl_to_int(DDVectorGetter::get(tempName));
+        php.layerGroupEtaSim.emplace_back(layerGroupEta);
       }
     }
-    php.etaMin   = dbl_to_int( DDVectorGetter::get( "etaMin" ));
-    php.etaMax   = dbl_to_int( DDVectorGetter::get( "etaMax" ));
+    php.etaMin = dbl_to_int(DDVectorGetter::get("etaMin"));
+    php.etaMax = dbl_to_int(DDVectorGetter::get("etaMax"));
     php.etaMin[0] = 1;
     if (php.etaMax[1] >= php.etaMin[1])
-      php.etaMax[1] = static_cast<int>(php.etaTable.size())-1;
-    php.etaMax[2] = php.etaMin[2]+(int)(php.rTable.size())-2;
-    php.etaRange = DDVectorGetter::get( "etaRange" );
-    php.gparHF   = DDVectorGetter::get( "gparHF" );
-    php.noff     = dbl_to_int( DDVectorGetter::get( "noff" ));
-    php.Layer0Wt = DDVectorGetter::get( "Layer0Wt" );  
-    php.HBGains  = DDVectorGetter::get( "HBGains" );
-    php.HBShift  = dbl_to_int( DDVectorGetter::get( "HBShift" ));
-    php.HEGains  = DDVectorGetter::get( "HEGains" );
-    php.HEShift  = dbl_to_int( DDVectorGetter::get( "HEShift" ));
-    php.HFGains  = DDVectorGetter::get( "HFGains" );
-    php.HFShift  = dbl_to_int( DDVectorGetter::get( "HFShift" ));
-    php.maxDepth = dbl_to_int( DDVectorGetter::get( "MaxDepth" ));
+      php.etaMax[1] = static_cast<int>(php.etaTable.size()) - 1;
+    php.etaMax[2] = php.etaMin[2] + (int)(php.rTable.size()) - 2;
+    php.etaRange = DDVectorGetter::get("etaRange");
+    php.gparHF = DDVectorGetter::get("gparHF");
+    php.noff = dbl_to_int(DDVectorGetter::get("noff"));
+    php.Layer0Wt = DDVectorGetter::get("Layer0Wt");
+    php.HBGains = DDVectorGetter::get("HBGains");
+    php.HBShift = dbl_to_int(DDVectorGetter::get("HBShift"));
+    php.HEGains = DDVectorGetter::get("HEGains");
+    php.HEShift = dbl_to_int(DDVectorGetter::get("HEShift"));
+    php.HFGains = DDVectorGetter::get("HFGains");
+    php.HFShift = dbl_to_int(DDVectorGetter::get("HFShift"));
+    php.maxDepth = dbl_to_int(DDVectorGetter::get("MaxDepth"));
   } else {
-    throw cms::Exception("HcalParametersFromDD") << "Not found "<< attribute.c_str() << " but needed.";
+    throw cms::Exception("HcalParametersFromDD") << "Not found " << attribute.c_str() << " but needed.";
   }
-  for( unsigned int i = 0; i < php.rTable.size(); ++i ) {
+  for (unsigned int i = 0; i < php.rTable.size(); ++i) {
     unsigned int k = php.rTable.size() - i - 1;
-    php.etaTableHF.emplace_back( -log( tan( 0.5 * atan( php.rTable[k] / php.gparHF[4] ))));
+    php.etaTableHF.emplace_back(-log(tan(0.5 * atan(php.rTable[k] / php.gparHF[4]))));
   }
   //Special parameters at reconstruction level
-  attribute = "OnlyForHcalRecNumbering"; 
+  attribute = "OnlyForHcalRecNumbering";
   DDSpecificsHasNamedValueFilter filter2{attribute};
-  DDFilteredView fv2(*cpv,filter2);
+  DDFilteredView fv2(*cpv, filter2);
   ok = fv2.firstChild();
   if (ok) {
     DDsvalues_type sv(fv2.mergedSpecifics());
     int topoMode = getTopologyMode("TopologyMode", sv, true);
     int trigMode = getTopologyMode("TriggerMode", sv, false);
-    php.topologyMode = ((trigMode&0xFF)<<8) | (topoMode&0xFF);
-    php.etagroup = dbl_to_int( DDVectorGetter::get( "etagroup" ));
-    php.phigroup = dbl_to_int( DDVectorGetter::get( "phigroup" ));
-    for (unsigned int i = 1; i<=nEtaMax; ++i) {
+    php.topologyMode = ((trigMode & 0xFF) << 8) | (topoMode & 0xFF);
+    php.etagroup = dbl_to_int(DDVectorGetter::get("etagroup"));
+    php.phigroup = dbl_to_int(DDVectorGetter::get("phigroup"));
+    for (unsigned int i = 1; i <= nEtaMax; ++i) {
       std::stringstream sstm;
       sstm << "layerGroupRecEta" << i;
       std::string tempName = sstm.str();
       if (DDVectorGetter::check(tempName)) {
-	HcalParameters::LayerItem layerGroupEta;
-	layerGroupEta.layer = i;
-	layerGroupEta.layerGroup = dbl_to_int(DDVectorGetter::get(tempName));
-	php.layerGroupEtaRec.emplace_back(layerGroupEta);
+        HcalParameters::LayerItem layerGroupEta;
+        layerGroupEta.layer = i;
+        layerGroupEta.layerGroup = dbl_to_int(DDVectorGetter::get(tempName));
+        php.layerGroupEtaRec.emplace_back(layerGroupEta);
       }
     }
-  } else {			      
-    throw cms::Exception( "HcalParametersFromDD" ) << "Not found "<< attribute.c_str() << " but needed.";
+  } else {
+    throw cms::Exception("HcalParametersFromDD") << "Not found " << attribute.c_str() << " but needed.";
   }
 
 #ifdef EDM_ML_DEBUG
   int i(0);
   std::cout << "HcalParametersFromDD: MaxDepth: ";
-  for (const auto& it : php.maxDepth) std::cout << it << ", ";
+  for (const auto& it : php.maxDepth)
+    std::cout << it << ", ";
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: ModHB [" << php.modHB.size() << "]: ";
-  for (const auto& it : php.modHB) std::cout << it << ", ";
+  for (const auto& it : php.modHB)
+    std::cout << it << ", ";
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: ModHE [" << php.modHE.size() << "]: ";
-  for (const auto& it : php.modHE) std::cout << it << ", ";
+  for (const auto& it : php.modHE)
+    std::cout << it << ", ";
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.phioff.size() << " phioff values";
   std::vector<double>::const_iterator it;
-  for (it=php.phioff.begin(), i=0; it!=php.phioff.end(); ++it) 
-    std::cout << " [" << ++i << "] = " << (*it)/CLHEP::deg;
+  for (it = php.phioff.begin(), i = 0; it != php.phioff.end(); ++it)
+    std::cout << " [" << ++i << "] = " << (*it) / CLHEP::deg;
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.etaTable.size() << " entries for etaTable";
-  for (it=php.etaTable.begin(), i=0; it!=php.etaTable.end(); ++it) 
+  for (it = php.etaTable.begin(), i = 0; it != php.etaTable.end(); ++it)
     std::cout << " [" << ++i << "] = " << (*it);
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.rTable.size() << " entries for rTable";
-  for (it=php.rTable.begin(), i=0; it!=php.rTable.end(); ++it) 
-    std::cout << " [" << ++i << "] = " << (*it)/CLHEP::cm;
+  for (it = php.rTable.begin(), i = 0; it != php.rTable.end(); ++it)
+    std::cout << " [" << ++i << "] = " << (*it) / CLHEP::cm;
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.phibin.size() << " phibin values";
-  for (it=php.phibin.begin(), i=0; it!=php.phibin.end(); ++it) 
-    std::cout << " [" << ++i << "] = " << (*it)/CLHEP::deg;
+  for (it = php.phibin.begin(), i = 0; it != php.phibin.end(); ++it)
+    std::cout << " [" << ++i << "] = " << (*it) / CLHEP::deg;
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.phitable.size() << " phitable values";
-  for (it=php.phitable.begin(), i=0; it!=php.phitable.end(); ++it) 
-    std::cout << " [" << ++i << "] = " << (*it)/CLHEP::deg;
+  for (it = php.phitable.begin(), i = 0; it != php.phitable.end(); ++it)
+    std::cout << " [" << ++i << "] = " << (*it) / CLHEP::deg;
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.layerGroupEtaSim.size() << " layerGroupEtaSim blocks" << std::endl;
   std::vector<HcalParameters::LayerItem>::const_iterator jt;
   std::vector<int>::const_iterator kt;
-  for (unsigned int k=0; k < php.layerGroupEtaSim.size(); ++k) {
+  for (unsigned int k = 0; k < php.layerGroupEtaSim.size(); ++k) {
     std::cout << "layerGroupEtaSim[" << k << "] Layer " << php.layerGroupEtaSim[k].layer;
-    for (kt=php.layerGroupEtaSim[k].layerGroup.begin(), i=0; kt!=php.layerGroupEtaSim[k].layerGroup.end(); ++kt)
+    for (kt = php.layerGroupEtaSim[k].layerGroup.begin(), i = 0; kt != php.layerGroupEtaSim[k].layerGroup.end(); ++kt)
       std::cout << " " << ++i << ":" << (*kt);
     std::cout << std::endl;
   }
   std::cout << "HcalParametersFromDD: " << php.etaMin.size() << " etaMin values";
-  for (kt=php.etaMin.begin(), i=0; kt!=php.etaMin.end(); ++kt) 
+  for (kt = php.etaMin.begin(), i = 0; kt != php.etaMin.end(); ++kt)
     std::cout << " [" << ++i << "] = " << (*kt);
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.etaMax.size() << " etaMax values";
-  for (kt=php.etaMax.begin(), i=0; kt!=php.etaMax.end(); ++kt) 
+  for (kt = php.etaMax.begin(), i = 0; kt != php.etaMax.end(); ++kt)
     std::cout << " [" << ++i << "] = " << (*kt);
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.etaRange.size() << " etaRange values";
-  for (it=php.etaRange.begin(), i=0; it!=php.etaRange.end(); ++it) 
+  for (it = php.etaRange.begin(), i = 0; it != php.etaRange.end(); ++it)
     std::cout << " [" << ++i << "] = " << (*it);
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.gparHF.size() << " gparHF values";
-  for (it=php.gparHF.begin(), i=0; it!=php.gparHF.end(); ++it) 
-    std::cout << " [" << ++i << "] = " << (*it)/CLHEP::cm;
+  for (it = php.gparHF.begin(), i = 0; it != php.gparHF.end(); ++it)
+    std::cout << " [" << ++i << "] = " << (*it) / CLHEP::cm;
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.noff.size() << " noff values";
-  for (kt=php.noff.begin(), i=0; kt!=php.noff.end(); ++kt) 
+  for (kt = php.noff.begin(), i = 0; kt != php.noff.end(); ++kt)
     std::cout << " [" << ++i << "] = " << (*kt);
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.Layer0Wt.size() << " Layer0Wt values";
-  for (it=php.Layer0Wt.begin(), i=0; it!=php.Layer0Wt.end(); ++it) 
+  for (it = php.Layer0Wt.begin(), i = 0; it != php.Layer0Wt.end(); ++it)
     std::cout << " [" << ++i << "] = " << (*it);
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.HBGains.size() << " Shift/Gains values for HB";
-  for (unsigned k=0; k<php.HBGains.size(); ++k)
+  for (unsigned k = 0; k < php.HBGains.size(); ++k)
     std::cout << " [" << k << "] = " << php.HBShift[k] << ":" << php.HBGains[k];
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.HEGains.size() << " Shift/Gains values for HE";
-  for (unsigned k=0; k<php.HEGains.size(); ++k)
+  for (unsigned k = 0; k < php.HEGains.size(); ++k)
     std::cout << " [" << k << "] = " << php.HEShift[k] << ":" << php.HEGains[k];
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.HFGains.size() << " Shift/Gains values for HF";
-  for (unsigned k=0; k<php.HFGains.size(); ++k)
+  for (unsigned k = 0; k < php.HFGains.size(); ++k)
     std::cout << " [" << k << "] = " << php.HFShift[k] << ":" << php.HFGains[k];
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.etagroup.size() << " etagroup values";
-  for (kt=php.etagroup.begin(), i=0; kt!=php.etagroup.end(); ++kt) 
+  for (kt = php.etagroup.begin(), i = 0; kt != php.etagroup.end(); ++kt)
     std::cout << " [" << ++i << "] = " << (*kt);
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.phigroup.size() << " phigroup values";
-  for (kt=php.phigroup.begin(), i=0; kt!=php.phigroup.end(); ++kt) 
+  for (kt = php.phigroup.begin(), i = 0; kt != php.phigroup.end(); ++kt)
     std::cout << " [" << ++i << "] = " << (*kt);
   std::cout << std::endl;
   std::cout << "HcalParametersFromDD: " << php.layerGroupEtaRec.size() << " layerGroupEtaRec blocks" << std::endl;
-  for (unsigned int k=0; k < php.layerGroupEtaRec.size(); ++k) {
+  for (unsigned int k = 0; k < php.layerGroupEtaRec.size(); ++k) {
     std::cout << "layerGroupEtaRec[" << k << "] Layer " << php.layerGroupEtaRec[k].layer;
-    for (kt=php.layerGroupEtaRec[k].layerGroup.begin(), i=0; kt!=php.layerGroupEtaRec[k].layerGroup.end(); ++kt)
+    for (kt = php.layerGroupEtaRec[k].layerGroup.begin(), i = 0; kt != php.layerGroupEtaRec[k].layerGroup.end(); ++kt)
       std::cout << " " << ++i << ":" << (*kt);
     std::cout << std::endl;
   }
-  std::cout << "HcalParametersFromDD: (topology|trigger)Mode " << std::hex
-	    << php.topologyMode << std::dec << std::endl;
+  std::cout << "HcalParametersFromDD: (topology|trigger)Mode " << std::hex << php.topologyMode << std::dec << std::endl;
 #endif
 
   return true;

--- a/Geometry/HcalCommonData/src/HcalTopologyMode.cc
+++ b/Geometry/HcalCommonData/src/HcalTopologyMode.cc
@@ -1,6 +1,6 @@
 #include "Geometry/HcalCommonData/interface/HcalTopologyMode.h"
 
-template<>
+template <>
 StringToEnumParser<HcalTopologyMode::Mode>::StringToEnumParser() {
   enumMap["HcalTopologyMode::LHC"] = HcalTopologyMode::LHC;
   enumMap["HcalTopologyMode::H2"] = HcalTopologyMode::H2;
@@ -8,7 +8,7 @@ StringToEnumParser<HcalTopologyMode::Mode>::StringToEnumParser() {
   enumMap["HcalTopologyMode::H2HE"] = HcalTopologyMode::H2HE;
 }
 
-template<>
+template <>
 StringToEnumParser<HcalTopologyMode::TriggerMode>::StringToEnumParser() {
   enumMap["HcalTopologyMode::TriggerMode_2009"] = HcalTopologyMode::TriggerMode_2009;
   enumMap["HcalTopologyMode::TriggerMode_2016"] = HcalTopologyMode::TriggerMode_2016;

--- a/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
+++ b/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
@@ -7,199 +7,198 @@
 
 class HcalParametersAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit HcalParametersAnalyzer( const edm::ParameterSet& );
-  ~HcalParametersAnalyzer( void ) override;
-  
+  explicit HcalParametersAnalyzer(const edm::ParameterSet&);
+  ~HcalParametersAnalyzer(void) override;
+
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
 
 private:
   edm::ESGetToken<HcalParameters, HcalParametersRcd> parToken_;
 };
 
-HcalParametersAnalyzer::HcalParametersAnalyzer( const edm::ParameterSet& )
-  : parToken_{esConsumes<HcalParameters, HcalParametersRcd>(edm::ESInputTag{})} {}
+HcalParametersAnalyzer::HcalParametersAnalyzer(const edm::ParameterSet&)
+    : parToken_{esConsumes<HcalParameters, HcalParametersRcd>(edm::ESInputTag{})} {}
 
-HcalParametersAnalyzer::~HcalParametersAnalyzer( void ) {}
+HcalParametersAnalyzer::~HcalParametersAnalyzer(void) {}
 
-void HcalParametersAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup ) {
+void HcalParametersAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
   const auto& parR = iSetup.getData(parToken_);
   const HcalParameters* pars = &parR;
 
   std::cout << "rHB: ";
-  for( const auto& it : pars->rHB ) {
+  for (const auto& it : pars->rHB) {
     std::cout << it << ", ";
   }
   std::cout << "\ndrHB: ";
-  for( const auto& it : pars->drHB ) {
+  for (const auto& it : pars->drHB) {
     std::cout << it << ", ";
   }
   std::cout << "\nzHE: ";
-  for( const auto& it : pars->zHE ) {
+  for (const auto& it : pars->zHE) {
     std::cout << it << ", ";
   }
   std::cout << "\ndzHE: ";
-  for( const auto& it : pars->dzHE ) {
+  for (const auto& it : pars->dzHE) {
     std::cout << it << ", ";
   }
   std::cout << "\nzHO: ";
-  for( const auto& it : pars->zHO ) {
+  for (const auto& it : pars->zHO) {
     std::cout << it << ", ";
   }
   std::cout << "\nrHO: ";
-  for( const auto& it : pars->rHO ) {
-      std::cout << it << ", ";
+  for (const auto& it : pars->rHO) {
+    std::cout << it << ", ";
   }
   std::cout << "\nrhoxHB: ";
-  for( const auto& it : pars->rhoxHB ) {
+  for (const auto& it : pars->rhoxHB) {
     std::cout << it << ", ";
   }
   std::cout << "\nzxHB: ";
-  for( const auto& it : pars->zxHB ) {
+  for (const auto& it : pars->zxHB) {
     std::cout << it << ", ";
   }
   std::cout << "\ndyHB: ";
-  for( const auto& it : pars->dyHB ) {
+  for (const auto& it : pars->dyHB) {
     std::cout << it << ", ";
   }
   std::cout << "\ndxHB: ";
-  for( const auto& it : pars->dxHB ) {
+  for (const auto& it : pars->dxHB) {
     std::cout << it << ", ";
   }
   std::cout << "\nrhoxHE: ";
-  for( const auto& it : pars->rhoxHE ) {
+  for (const auto& it : pars->rhoxHE) {
     std::cout << it << ", ";
   }
   std::cout << "\nzxHE: ";
-  for( const auto& it : pars->zxHE ) {
+  for (const auto& it : pars->zxHE) {
     std::cout << it << ", ";
   }
   std::cout << "\ndyHE: ";
-  for( const auto& it : pars->dyHE ) {
+  for (const auto& it : pars->dyHE) {
     std::cout << it << ", ";
   }
   std::cout << "\ndx1HE: ";
-  for( const auto& it : pars->dx1HE ) {
+  for (const auto& it : pars->dx1HE) {
     std::cout << it << ", ";
   }
   std::cout << "\ndx2HE: ";
-  for( const auto& it : pars->dx2HE ) {
+  for (const auto& it : pars->dx2HE) {
     std::cout << it << ", ";
   }
   std::cout << "\nphioff: ";
-  for( const auto& it : pars->phioff ) {
+  for (const auto& it : pars->phioff) {
     std::cout << it << ", ";
   }
   std::cout << "\netaTable: ";
-  for( const auto& it : pars->etaTable ) {
+  for (const auto& it : pars->etaTable) {
     std::cout << it << ", ";
   }
   std::cout << "\nrTable: ";
-  for( const auto& it : pars->rTable ) {
+  for (const auto& it : pars->rTable) {
     std::cout << it << ", ";
   }
   std::cout << "\nphibin: ";
-  for( const auto& it : pars->phibin ) {
+  for (const auto& it : pars->phibin) {
     std::cout << it << ", ";
   }
   std::cout << "\nphitable: ";
-  for( const auto& it : pars->phitable ) {
+  for (const auto& it : pars->phitable) {
     std::cout << it << ", ";
   }
   std::cout << "\netaRange: ";
-  for( const auto& it : pars->etaRange ) {
+  for (const auto& it : pars->etaRange) {
     std::cout << it << ", ";
   }
   std::cout << "\ngparHF: ";
-  for( const auto& it : pars->gparHF ) {
+  for (const auto& it : pars->gparHF) {
     std::cout << it << ", ";
   }
   std::cout << "\nLayer0Wt: ";
-  for( const auto& it : pars->Layer0Wt ) {
+  for (const auto& it : pars->Layer0Wt) {
     std::cout << it << ", ";
   }
   std::cout << "\nHBGains: ";
-  for( const auto& it : pars->HBGains ) {
+  for (const auto& it : pars->HBGains) {
     std::cout << it << ", ";
   }
   std::cout << "\nHEGains: ";
-  for( const auto& it : pars->HEGains ) {
+  for (const auto& it : pars->HEGains) {
     std::cout << it << ", ";
   }
   std::cout << "\nHFGains: ";
-  for( const auto& it : pars->HFGains ) {
+  for (const auto& it : pars->HFGains) {
     std::cout << it << ", ";
   }
   std::cout << "\netaTableHF: ";
-  for( const auto& it : pars->etaTableHF ) {
+  for (const auto& it : pars->etaTableHF) {
     std::cout << it << ", ";
   }
   std::cout << "\nmodHB: ";
-  for( const auto& it : pars->modHB ) {
+  for (const auto& it : pars->modHB) {
     std::cout << it << ", ";
   }
   std::cout << "\nmodHE: ";
-  for( const auto& it : pars->modHE ) {
+  for (const auto& it : pars->modHE) {
     std::cout << it << ", ";
   }
   std::cout << "\nmaxDepth: ";
-  for( const auto& it : pars->maxDepth ) {
+  for (const auto& it : pars->maxDepth) {
     std::cout << it << ", ";
   }
   std::cout << "\nlayHB: ";
-  for( const auto& it : pars->layHB ) {
+  for (const auto& it : pars->layHB) {
     std::cout << it << ", ";
   }
   std::cout << "\nlayHE: ";
-  for( const auto& it : pars->layHE ) {
+  for (const auto& it : pars->layHE) {
     std::cout << it << ", ";
   }
   std::cout << "\netaMin: ";
-  for( const auto& it : pars->etaMin ) {
+  for (const auto& it : pars->etaMin) {
     std::cout << it << ", ";
   }
   std::cout << "\netaMax: ";
-  for( const auto& it : pars->etaMax ) {
+  for (const auto& it : pars->etaMax) {
     std::cout << it << ", ";
   }
   std::cout << "\nnoff: ";
-  for( const auto& it :  pars->noff ) {
+  for (const auto& it : pars->noff) {
     std::cout << it << ", ";
-  }      
+  }
   std::cout << "\nHBShift: ";
-  for( const auto& it : pars->HBShift ) {
+  for (const auto& it : pars->HBShift) {
     std::cout << it << ", ";
   }
   std::cout << "\nHEShift: ";
-  for( const auto& it : pars->HEShift ) {
-    std::cout << it << ", ";
-    }
-  std::cout << "\nHFShift: ";
-  for( const auto& it : pars->HFShift ) {
+  for (const auto& it : pars->HEShift) {
     std::cout << it << ", ";
   }
-  for( const auto& it : pars->layerGroupEtaSim ) {
+  std::cout << "\nHFShift: ";
+  for (const auto& it : pars->HFShift) {
+    std::cout << it << ", ";
+  }
+  for (const auto& it : pars->layerGroupEtaSim) {
     std::cout << "\nlayerGroupEtaSim" << it.layer << ": ";
-    for( const auto& iit : it.layerGroup )  {
+    for (const auto& iit : it.layerGroup) {
       std::cout << iit << ", ";
     }
   }
   std::cout << "\netagroup: ";
-  for( const auto& it : pars->etagroup )  {
+  for (const auto& it : pars->etagroup) {
     std::cout << it << ", ";
   }
   std::cout << "\nphigroup: ";
-  for( const auto& it : pars->phigroup ) {
+  for (const auto& it : pars->phigroup) {
     std::cout << it << ", ";
   }
-  for( const auto& it : pars->layerGroupEtaRec ) {
+  for (const auto& it : pars->layerGroupEtaRec) {
     std::cout << "\nlayerGroupEtaRec" << it.layer << ": ";
-    for( const auto& iit : it.layerGroup )  {
+    for (const auto& iit : it.layerGroup) {
       std::cout << iit << ", ";
     }
   }
-  std::cout << "\ndzVcal: " << pars->dzVcal
-	    << "\n(Topology|Trigger)Mode: " << std::hex << pars->topologyMode 
-	    << std::dec << std::endl;
+  std::cout << "\ndzVcal: " << pars->dzVcal << "\n(Topology|Trigger)Mode: " << std::hex << pars->topologyMode
+            << std::dec << std::endl;
 }
 
 DEFINE_FWK_MODULE(HcalParametersAnalyzer);

--- a/Geometry/HcalCommonData/test/HcalRecNumberingTester.cc
+++ b/Geometry/HcalCommonData/test/HcalRecNumberingTester.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HcalRecNumberingTester
 // Class:      HcalRecNumberingTester
-// 
+//
 /**\class HcalRecNumberingTester HcalRecNumberingTester.cc test/HcalRecNumberingTester.cc
 
  Description: <one line class summary>
@@ -14,7 +14,6 @@
 // Original Author:  Sunanda Banerjee
 //         Created:  Mon 2013/12/26
 //
-
 
 // system include files
 #include <memory>
@@ -42,7 +41,7 @@
 
 class HcalRecNumberingTester : public edm::one::EDAnalyzer<> {
 public:
-  explicit HcalRecNumberingTester( const edm::ParameterSet& );
+  explicit HcalRecNumberingTester(const edm::ParameterSet&);
   ~HcalRecNumberingTester() override;
 
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
@@ -51,211 +50,164 @@ private:
   edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> token_;
 };
 
-HcalRecNumberingTester::HcalRecNumberingTester(const edm::ParameterSet& ):
-  token_{esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord>(edm::ESInputTag{})} {}
+HcalRecNumberingTester::HcalRecNumberingTester(const edm::ParameterSet&)
+    : token_{esConsumes<HcalDDDRecConstants, HcalRecNumberingRecord>(edm::ESInputTag{})} {}
 
 HcalRecNumberingTester::~HcalRecNumberingTester() {}
 
 // ------------ method called to produce the data  ------------
-void HcalRecNumberingTester::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
-
+void HcalRecNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   if (auto pHSNDC = iSetup.getHandle(token_)) {
     edm::LogVerbatim("HcalGeom") << "about to de-reference the edm::ESHandle<HcalDDDRecConstants> pHSNDC";
-    const HcalDDDRecConstants& hdc (*pHSNDC);
-    for (int i=0; i<4; ++i) 
-      edm::LogVerbatim("HcalGeom") << "MaxDepth[" << i << "] = "
-				   << hdc.getMaxDepth(i);
+    const HcalDDDRecConstants& hdc(*pHSNDC);
+    for (int i = 0; i < 4; ++i)
+      edm::LogVerbatim("HcalGeom") << "MaxDepth[" << i << "] = " << hdc.getMaxDepth(i);
     edm::LogVerbatim("HcalGeom") << "about to getPhiOff and getPhiBin for 0..2";
     int neta = hdc.getNEta();
     edm::LogVerbatim("HcalGeom") << neta << " eta bins with phi off set for "
-				 << "barrel = " << hdc.getPhiOff(0) 
-				 << ", endcap = " << hdc.getPhiOff(1);
-    for (int i=0; i<neta; ++i) {
-      std::pair<double,double> etas   = hdc.getEtaLimit(i);
-      double                   fbin   = hdc.getPhiBin(i);
-      std::vector<int>         depths = hdc.getDepth(i,false);
-      edm::LogVerbatim("HcalGeom") << "EtaBin[" << i << "]: EtaLimit = (" 
-				   << etas.first << ":" << etas.second 
-				   << ")  phiBin = " << fbin << " and " 
-				   << depths.size() << " depths";
-      for (unsigned int k=0; k<depths.size(); ++k) {
-	edm::LogVerbatim("HcalGeom") << "[" << k << "] " << depths[k];
+                                 << "barrel = " << hdc.getPhiOff(0) << ", endcap = " << hdc.getPhiOff(1);
+    for (int i = 0; i < neta; ++i) {
+      std::pair<double, double> etas = hdc.getEtaLimit(i);
+      double fbin = hdc.getPhiBin(i);
+      std::vector<int> depths = hdc.getDepth(i, false);
+      edm::LogVerbatim("HcalGeom") << "EtaBin[" << i << "]: EtaLimit = (" << etas.first << ":" << etas.second
+                                   << ")  phiBin = " << fbin << " and " << depths.size() << " depths";
+      for (unsigned int k = 0; k < depths.size(); ++k) {
+        edm::LogVerbatim("HcalGeom") << "[" << k << "] " << depths[k];
       }
     }
-    for (int type=0; type<2; ++type) {
-      std::pair<int,int> etar = hdc.getEtaRange(type);
-      edm::LogVerbatim("HcalGeom") << "Detector type: " << type 
-				   << " with eta ranges " << etar.first << ":" 
-				   << etar.second;
-      for (int eta=etar.first; eta<=etar.second; ++eta) {
-	std::vector<std::pair<int,double> > phis = hdc.getPhis(type+1, eta);
-	for (auto & phi : phis) {
-	  edm::LogVerbatim("HcalGeom") << "Type:Eta:phi " << type << ":" << eta 
-				       << ":" << phi.first <<" Depth range (+z) "
-				       << hdc.getMinDepth(type,eta,phi.first,1) 
-<< ":" 
-				       << hdc.getMaxDepth(type,eta,phi.first,1) << " (-z) "
-				       << hdc.getMinDepth(type,eta,phi.first,-1) << ":" 
-				       << hdc.getMaxDepth(type,eta,phi.first,-1);
-	}
+    for (int type = 0; type < 2; ++type) {
+      std::pair<int, int> etar = hdc.getEtaRange(type);
+      edm::LogVerbatim("HcalGeom") << "Detector type: " << type << " with eta ranges " << etar.first << ":"
+                                   << etar.second;
+      for (int eta = etar.first; eta <= etar.second; ++eta) {
+        std::vector<std::pair<int, double>> phis = hdc.getPhis(type + 1, eta);
+        for (auto& phi : phis) {
+          edm::LogVerbatim("HcalGeom") << "Type:Eta:phi " << type << ":" << eta << ":" << phi.first
+                                       << " Depth range (+z) " << hdc.getMinDepth(type, eta, phi.first, 1) << ":"
+                                       << hdc.getMaxDepth(type, eta, phi.first, 1) << " (-z) "
+                                       << hdc.getMinDepth(type, eta, phi.first, -1) << ":"
+                                       << hdc.getMaxDepth(type, eta, phi.first, -1);
+        }
       }
     }
     std::vector<HcalDDDRecConstants::HcalEtaBin> hbar = hdc.getEtaBins(0);
     std::vector<HcalDDDRecConstants::HcalEtaBin> hcap = hdc.getEtaBins(1);
-    edm::LogVerbatim("HcalGeom") << "Topology Mode " << hdc.getTopoMode() 
-				 << " HB with " << hbar.size() 
-				 << " eta sectors and HE with "
-				 << hcap.size() << " eta sectors";
+    edm::LogVerbatim("HcalGeom") << "Topology Mode " << hdc.getTopoMode() << " HB with " << hbar.size()
+                                 << " eta sectors and HE with " << hcap.size() << " eta sectors";
     std::vector<HcalCellType> hbcell = hdc.HcalCellTypes(HcalBarrel);
     edm::LogVerbatim("HcalGeom") << "HB with " << hbcell.size() << " cells";
     unsigned int i1(0), i2(0), i3(0), i4(0);
     for (const auto& cell : hbcell) {
-      edm::LogVerbatim("HcalGeom") << "HB[" << i1 << "] det " << cell.detType() 
-				   << " zside "	<< cell.zside() << ":" 
-				   << cell.halfSize() << " RO " 
-				   << cell.actualReadoutDirection()
-				   << " eta " << cell.etaBin() << ":"
-				   << cell.etaMin() << ":" << cell.etaMax() 
-				   << " phi " << cell.nPhiBins() << ":" 
-				   << cell.nPhiModule() << ":" <<cell.phiOffset()
-				   << ":" << cell.phiBinWidth() << ":"
-				   << cell.unitPhi() << " depth " 
-				   << cell.depthSegment() << ":" << cell.depth()
-				   << ":" << cell.depthMin() << ":" 
-				   << cell.depthMax() << ":" << cell.depthType();
+      edm::LogVerbatim("HcalGeom") << "HB[" << i1 << "] det " << cell.detType() << " zside " << cell.zside() << ":"
+                                   << cell.halfSize() << " RO " << cell.actualReadoutDirection() << " eta "
+                                   << cell.etaBin() << ":" << cell.etaMin() << ":" << cell.etaMax() << " phi "
+                                   << cell.nPhiBins() << ":" << cell.nPhiModule() << ":" << cell.phiOffset() << ":"
+                                   << cell.phiBinWidth() << ":" << cell.unitPhi() << " depth " << cell.depthSegment()
+                                   << ":" << cell.depth() << ":" << cell.depthMin() << ":" << cell.depthMax() << ":"
+                                   << cell.depthType();
       ++i1;
-      std::vector<std::pair<int,double>>phis = cell.phis();
+      std::vector<std::pair<int, double>> phis = cell.phis();
       edm::LogVerbatim("HcalGeom") << "Phis (" << phis.size() << ") :";
-      for (const auto& phi : phis) 
-	edm::LogVerbatim("HcalGeom") << " [" << phi.first << ", " << phi.second 
-				     << "]";
+      for (const auto& phi : phis)
+        edm::LogVerbatim("HcalGeom") << " [" << phi.first << ", " << phi.second << "]";
     }
     std::vector<HcalCellType> hecell = hdc.HcalCellTypes(HcalEndcap);
     edm::LogVerbatim("HcalGeom") << "HE with " << hecell.size() << " cells";
     for (const auto& cell : hecell) {
-      edm::LogVerbatim("HcalGeom") << "HE[" << i2 << "] det " << cell.detType() 
-				   << " zside "	<< cell.zside() << ":" 
-				   << cell.halfSize() << " RO " 
-				   << cell.actualReadoutDirection() << " eta " 
-				   << cell.etaBin() << ":" << cell.etaMin()<< ":"
-				   << cell.etaMax() << " phi " << cell.nPhiBins()
-				   << ":" << cell.nPhiModule() << ":" 
-				   << cell.phiOffset() << ":" 
-				   << cell.phiBinWidth() << ":" << cell.unitPhi()
-				   << " depth " << cell.depthSegment() << ":" 
-				   << cell.depth() << ":" << cell.depthMin()
-				   << ":" << cell.depthMax() << ":" 
-				   << cell.depthType();
+      edm::LogVerbatim("HcalGeom") << "HE[" << i2 << "] det " << cell.detType() << " zside " << cell.zside() << ":"
+                                   << cell.halfSize() << " RO " << cell.actualReadoutDirection() << " eta "
+                                   << cell.etaBin() << ":" << cell.etaMin() << ":" << cell.etaMax() << " phi "
+                                   << cell.nPhiBins() << ":" << cell.nPhiModule() << ":" << cell.phiOffset() << ":"
+                                   << cell.phiBinWidth() << ":" << cell.unitPhi() << " depth " << cell.depthSegment()
+                                   << ":" << cell.depth() << ":" << cell.depthMin() << ":" << cell.depthMax() << ":"
+                                   << cell.depthType();
       ++i2;
-      std::vector<std::pair<int,double>>phis = cell.phis();
+      std::vector<std::pair<int, double>> phis = cell.phis();
       edm::LogVerbatim("HcalGeom") << "Phis (" << phis.size() << ") :";
-      for (const auto& phi : phis) 
-	edm::LogVerbatim("HcalGeom") << " [" << phi.first << ", " 
-				     << phi.second << "]";
+      for (const auto& phi : phis)
+        edm::LogVerbatim("HcalGeom") << " [" << phi.first << ", " << phi.second << "]";
     }
     std::vector<HcalCellType> hfcell = hdc.HcalCellTypes(HcalForward);
     edm::LogVerbatim("HcalGeom") << "HF with " << hfcell.size() << " cells";
     for (const auto& cell : hfcell) {
-      edm::LogVerbatim("HcalGeom") << "HF[" << i3 << "] det " << cell.detType() 
-				   << " zside "	<< cell.zside() << ":" 
-				   << cell.halfSize() << " RO " 
-				   << cell.actualReadoutDirection() << " eta "
-				   << cell.etaBin() << ":" << cell.etaMin() <<":"
-				   << cell.etaMax() << " phi " << cell.nPhiBins()
-				   << ":" << cell.nPhiModule() << ":" 
-				   << cell.phiOffset() << ":" 
-				   << cell.phiBinWidth() << ":" << cell.unitPhi()
-				   << " depth " << cell.depthSegment() << ":"
-				   << cell.depth() << ":" << cell.depthMin()
-				   << ":" << cell.depthMax() << ":" 
-				   << cell.depthType();
+      edm::LogVerbatim("HcalGeom") << "HF[" << i3 << "] det " << cell.detType() << " zside " << cell.zside() << ":"
+                                   << cell.halfSize() << " RO " << cell.actualReadoutDirection() << " eta "
+                                   << cell.etaBin() << ":" << cell.etaMin() << ":" << cell.etaMax() << " phi "
+                                   << cell.nPhiBins() << ":" << cell.nPhiModule() << ":" << cell.phiOffset() << ":"
+                                   << cell.phiBinWidth() << ":" << cell.unitPhi() << " depth " << cell.depthSegment()
+                                   << ":" << cell.depth() << ":" << cell.depthMin() << ":" << cell.depthMax() << ":"
+                                   << cell.depthType();
       ++i3;
     }
     std::vector<HcalCellType> hocell = hdc.HcalCellTypes(HcalOuter);
     edm::LogVerbatim("HcalGeom") << "HO with " << hocell.size() << " cells";
     for (const auto& cell : hocell) {
-      edm::LogVerbatim("HcalGeom") << "HO[" << i4 << "] det " << cell.detType()
-				   << " zside "	<< cell.zside() << ":" 
-				   << cell.halfSize() << " RO "
-				   << cell.actualReadoutDirection() << " eta "
-				   << cell.etaBin() << ":" << cell.etaMin()<< ":"
-				   << cell.etaMax() << " phi " << cell.nPhiBins()
-				   << ":" << cell.nPhiModule() << ":" 
-				   << cell.phiOffset() << ":" 
-				   << cell.phiBinWidth() << ":" << cell.unitPhi()
-				   << " depth " << cell.depthSegment() << ":" 
-				   << cell.depth() << ":" << cell.depthMin()
-				   << ":" << cell.depthMax() << ":"
-				   << cell.depthType();
+      edm::LogVerbatim("HcalGeom") << "HO[" << i4 << "] det " << cell.detType() << " zside " << cell.zside() << ":"
+                                   << cell.halfSize() << " RO " << cell.actualReadoutDirection() << " eta "
+                                   << cell.etaBin() << ":" << cell.etaMin() << ":" << cell.etaMax() << " phi "
+                                   << cell.nPhiBins() << ":" << cell.nPhiModule() << ":" << cell.phiOffset() << ":"
+                                   << cell.phiBinWidth() << ":" << cell.unitPhi() << " depth " << cell.depthSegment()
+                                   << ":" << cell.depth() << ":" << cell.depthMin() << ":" << cell.depthMax() << ":"
+                                   << cell.depthType();
       ++i4;
     }
-    for (int type=0; type <= 1; ++type ) {
+    for (int type = 0; type <= 1; ++type) {
       std::vector<HcalDDDRecConstants::HcalActiveLength> act = hdc.getThickActive(type);
-      edm::LogVerbatim("HcalGeom") << "Hcal type " << type << " has " 
-				   << act.size() << " eta/depth segments";
+      edm::LogVerbatim("HcalGeom") << "Hcal type " << type << " has " << act.size() << " eta/depth segments";
       for (const auto& active : act) {
-	edm::LogVerbatim("HcalGeom") << "zside " << active.zside << " ieta " 
-				     << active.ieta << " depth " << active.depth
-				     << " type " << active.stype << " eta "
-				     << active.eta  << " active thickness " 
-				     << active.thick;
+        edm::LogVerbatim("HcalGeom") << "zside " << active.zside << " ieta " << active.ieta << " depth " << active.depth
+                                     << " type " << active.stype << " eta " << active.eta << " active thickness "
+                                     << active.thick;
       }
     }
 
     // Test merging
     std::vector<int> phiSp;
-    HcalSubdetector  subdet = HcalSubdetector(hdc.dddConstants()->ldMap()->validDet(phiSp));
+    HcalSubdetector subdet = HcalSubdetector(hdc.dddConstants()->ldMap()->validDet(phiSp));
     if (subdet == HcalBarrel || subdet == HcalEndcap) {
-      int type = (int)(subdet-1);
-      std::pair<int,int> etas = hdc.getEtaRange(type);
-      for (int eta=etas.first; eta<=etas.second; ++eta) {
-	for (int k : phiSp) {
-	  int zside = (k>0) ? 1 : -1;
-	  int iphi  = (k>0) ? k : -k;
+      int type = (int)(subdet - 1);
+      std::pair<int, int> etas = hdc.getEtaRange(type);
+      for (int eta = etas.first; eta <= etas.second; ++eta) {
+        for (int k : phiSp) {
+          int zside = (k > 0) ? 1 : -1;
+          int iphi = (k > 0) ? k : -k;
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("HcalGeom") << "Look for Subdet " << subdet 
-				       << " Zside " << zside << " Eta " << eta 
-				       << " Phi " << iphi << " depths "
-				       << hdc.getMinDepth(type,eta,iphi,zside) << ":"
-				       << hdc.getMaxDepth(type,eta,iphi,zside);
+          edm::LogVerbatim("HcalGeom") << "Look for Subdet " << subdet << " Zside " << zside << " Eta " << eta
+                                       << " Phi " << iphi << " depths " << hdc.getMinDepth(type, eta, iphi, zside)
+                                       << ":" << hdc.getMaxDepth(type, eta, iphi, zside);
 #endif
-	  std::vector<HcalDetId> ids;
-	  for (int depth=hdc.getMinDepth(type,eta,iphi,zside);
-	       depth <= hdc.getMaxDepth(type,eta,iphi,zside); ++depth) {
-	    HcalDetId id(subdet,zside*eta,iphi,depth);
-	    HcalDetId hid = hdc.mergedDepthDetId(id);
-	    hdc.unmergeDepthDetId(hid,ids);
-	    edm::LogVerbatim("HcalGeom") << "Input ID " << id << " Merged ID "
-					 << hid << " containing " << ids.size() 
-					 << " IDS:";
-	    for (auto id : ids) 
-	      edm::LogVerbatim("HcalGeom") << " " << id;
-	  }
-	}
+          std::vector<HcalDetId> ids;
+          for (int depth = hdc.getMinDepth(type, eta, iphi, zside); depth <= hdc.getMaxDepth(type, eta, iphi, zside);
+               ++depth) {
+            HcalDetId id(subdet, zside * eta, iphi, depth);
+            HcalDetId hid = hdc.mergedDepthDetId(id);
+            hdc.unmergeDepthDetId(hid, ids);
+            edm::LogVerbatim("HcalGeom") << "Input ID " << id << " Merged ID " << hid << " containing " << ids.size()
+                                         << " IDS:";
+            for (auto id : ids)
+              edm::LogVerbatim("HcalGeom") << " " << id;
+          }
+        }
       }
     }
     // R,Z of cells
     for (const auto& cell : hbcell) {
-      int ieta  = cell.etaBin()*cell.zside();
-      double rz = hdc.getRZ(HcalBarrel,ieta,cell.phis()[0].first,
-			    cell.depthSegment());
-      edm::LogVerbatim("HcalGeom") << "HB (eta=" << ieta << ", phi=" 
-				   << cell.phis()[0].first << ", depth=" 
-				   << cell.depthSegment() << ") r/z = " << rz ;
+      int ieta = cell.etaBin() * cell.zside();
+      double rz = hdc.getRZ(HcalBarrel, ieta, cell.phis()[0].first, cell.depthSegment());
+      edm::LogVerbatim("HcalGeom") << "HB (eta=" << ieta << ", phi=" << cell.phis()[0].first
+                                   << ", depth=" << cell.depthSegment() << ") r/z = " << rz;
     }
     for (const auto& cell : hecell) {
-      int ieta  = cell.etaBin()*cell.zside();
-      double rz = hdc.getRZ(HcalEndcap,ieta,cell.phis()[0].first,
-			    cell.depthSegment());
-      edm::LogVerbatim("HcalGeom") << "HE (eta=" << ieta << ", phi=" 
-				   << cell.phis()[0].first << ", depth=" 
-				   << cell.depthSegment() << ") r/z = " << rz; 
+      int ieta = cell.etaBin() * cell.zside();
+      double rz = hdc.getRZ(HcalEndcap, ieta, cell.phis()[0].first, cell.depthSegment());
+      edm::LogVerbatim("HcalGeom") << "HE (eta=" << ieta << ", phi=" << cell.phis()[0].first
+                                   << ", depth=" << cell.depthSegment() << ") r/z = " << rz;
     }
   } else {
     edm::LogVerbatim("HcalGeom") << "No record found with HcalDDDRecConstants";
   }
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(HcalRecNumberingTester);

--- a/Geometry/HcalCommonData/test/HcalSimNumberingTester.cc
+++ b/Geometry/HcalCommonData/test/HcalSimNumberingTester.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HcalSimNumberingTester
 // Class:      HcalSimNumberingTester
-// 
+//
 /**\class HcalSimNumberingTester HcalSimNumberingTester.cc test/HcalSimNumberingTester.cc
 
  Description: <one line class summary>
@@ -14,7 +14,6 @@
 // Original Author:  Sunanda Banerjee
 //         Created:  Mon 2013/12/26
 //
-
 
 // system include files
 #include <memory>
@@ -38,10 +37,9 @@
 #include "Geometry/Records/interface/HcalSimNumberingRecord.h"
 #include "Geometry/HcalCommonData/interface/HcalDDDSimConstants.h"
 
-
 class HcalSimNumberingTester : public edm::one::EDAnalyzer<> {
 public:
-  explicit HcalSimNumberingTester( const edm::ParameterSet& );
+  explicit HcalSimNumberingTester(const edm::ParameterSet&);
   ~HcalSimNumberingTester() override;
 
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
@@ -50,37 +48,30 @@ private:
   edm::ESGetToken<HcalDDDSimConstants, HcalSimNumberingRecord> token_;
 };
 
-HcalSimNumberingTester::HcalSimNumberingTester(const edm::ParameterSet& )
-  : token_{esConsumes<HcalDDDSimConstants, HcalSimNumberingRecord>(edm::ESInputTag{})} {}
-
+HcalSimNumberingTester::HcalSimNumberingTester(const edm::ParameterSet&)
+    : token_{esConsumes<HcalDDDSimConstants, HcalSimNumberingRecord>(edm::ESInputTag{})} {}
 
 HcalSimNumberingTester::~HcalSimNumberingTester() {}
 
 // ------------ method called to produce the data  ------------
-void HcalSimNumberingTester::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
-
+void HcalSimNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   if (auto pHSNDC = iSetup.getHandle(token_)) {
     edm::LogVerbatim("HcalGeom") << "about to de-reference the edm::ESHandle<HcalDDDSimConstants> pHSNDC";
-    const HcalDDDSimConstants hdc (*pHSNDC);
+    const HcalDDDSimConstants hdc(*pHSNDC);
     edm::LogVerbatim("HcalGeom") << "about to getConst for 0..1";
-    for (int i=0; i<=1; ++i) {
-      std::vector<std::pair<double,double> > gcons = hdc.getConstHBHE(i);
-      edm::LogVerbatim("HcalGeom") << "Geometry Constants for [" << i 
-				   << "] with " << gcons.size() << "  elements";
-      for (unsigned int k=0; k<gcons.size(); ++k)
-	edm::LogVerbatim("HcalGeom") << "Element[" << k << "] = " 
-				     << gcons[k].first << " : "
-				     << gcons[k].second;
+    for (int i = 0; i <= 1; ++i) {
+      std::vector<std::pair<double, double> > gcons = hdc.getConstHBHE(i);
+      edm::LogVerbatim("HcalGeom") << "Geometry Constants for [" << i << "] with " << gcons.size() << "  elements";
+      for (unsigned int k = 0; k < gcons.size(); ++k)
+        edm::LogVerbatim("HcalGeom") << "Element[" << k << "] = " << gcons[k].first << " : " << gcons[k].second;
     }
-    for (int i=0; i<4; ++i) 
-      edm::LogVerbatim("HcalGeom") << "MaxDepth[" << i << "] = "
-				   << hdc.getMaxDepth(i);
+    for (int i = 0; i < 4; ++i)
+      edm::LogVerbatim("HcalGeom") << "MaxDepth[" << i << "] = " << hdc.getMaxDepth(i);
     hdc.printTiles();
   } else {
     edm::LogVerbatim("HcalGeom") << "No record found with HcalDDDSimConstants";
   }
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(HcalSimNumberingTester);

--- a/Geometry/HcalTowerAlgo/interface/CaloGeometryDBCaloTower.h
+++ b/Geometry/HcalTowerAlgo/interface/CaloGeometryDBCaloTower.h
@@ -12,6 +12,6 @@ namespace calogeometryDBEPimpl {
     }
     edm::ESGetToken<CaloTowerTopology, HcalRecNumberingRecord> topology;
   };
-}
+}  // namespace calogeometryDBEPimpl
 
 #endif

--- a/Geometry/HcalTowerAlgo/interface/CaloGeometryDBHcal.h
+++ b/Geometry/HcalTowerAlgo/interface/CaloGeometryDBHcal.h
@@ -12,6 +12,6 @@ namespace calogeometryDBEPimpl {
     }
     edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topology;
   };
-}
+}  // namespace calogeometryDBEPimpl
 
 #endif

--- a/Geometry/HcalTowerAlgo/interface/CaloTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/CaloTowerGeometry.h
@@ -14,71 +14,64 @@
   * \author J. Mans - Minnesota
   */
 class CaloTowerGeometry : public CaloSubdetectorGeometry {
-
 public:
+  typedef std::vector<IdealObliquePrism> CellVec;
 
-  typedef std::vector<IdealObliquePrism> CellVec ;
+  typedef CaloCellGeometry::CCGFloat CCGFloat;
+  typedef CaloCellGeometry::Pt3D Pt3D;
+  typedef CaloCellGeometry::Pt3DVec Pt3DVec;
 
-  typedef CaloCellGeometry::CCGFloat CCGFloat ;
-  typedef CaloCellGeometry::Pt3D     Pt3D     ;
-  typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
+  typedef CaloTowerAlignmentRcd AlignmentRecord;
+  typedef CaloTowerGeometryRecord AlignedRecord;
+  typedef PCaloTowerRcd PGeometryRecord;
+  typedef CaloTowerDetId DetIdType;
 
-  typedef CaloTowerAlignmentRcd    AlignmentRecord ;
-  typedef CaloTowerGeometryRecord  AlignedRecord   ;
-  typedef PCaloTowerRcd            PGeometryRecord ;
-  typedef CaloTowerDetId           DetIdType       ;
+  enum { k_NumberOfParametersPerShape = 5 };
 
-  enum { k_NumberOfParametersPerShape = 5 } ;
+  static std::string dbString() { return "PCaloTowerRcd"; }
 
-  static std::string dbString() { return "PCaloTowerRcd" ; }
+  unsigned int numberOfShapes() const override { return k_NumberOfShapes; }
+  unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape; }
+  virtual unsigned int numberOfCellsForCorners() const { return k_NumberOfCellsForCorners; }
 
-  unsigned int numberOfShapes() const override { return k_NumberOfShapes ; }
-  unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
-  virtual unsigned int numberOfCellsForCorners() const { return k_NumberOfCellsForCorners ; }
+  CaloTowerGeometry(const CaloTowerTopology* cttopo);
+  ~CaloTowerGeometry() override;
 
+  static std::string producerTag() { return "TOWER"; }
 
-  CaloTowerGeometry(const CaloTowerTopology *cttopo);
-  ~CaloTowerGeometry() override;  
+  static unsigned int numberOfAlignments() { return 0; }
+  unsigned int alignmentTransformIndexLocal(const DetId& id);
+  unsigned int alignmentTransformIndexGlobal(const DetId& id);
 
-  static std::string producerTag() { return "TOWER" ; }
+  static void localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int i, Pt3D& ref);
 
-  static unsigned int numberOfAlignments() { return 0 ; }
-  unsigned int alignmentTransformIndexLocal( const DetId& id ) ;
-  unsigned int alignmentTransformIndexGlobal( const DetId& id ) ;
+  void newCell(const GlobalPoint& f1,
+               const GlobalPoint& f2,
+               const GlobalPoint& f3,
+               const CCGFloat* parm,
+               const DetId& detId) override;
 
-  static void localCorners( Pt3DVec&        lc  ,
-			    const CCGFloat* pv  , 
-			    unsigned int    i   ,
-			    Pt3D&           ref   ) ;
-  
-  void newCell( const GlobalPoint& f1 ,
-		const GlobalPoint& f2 ,
-		const GlobalPoint& f3 ,
-		const CCGFloat*    parm,
-		const DetId&       detId     ) override ;
-				
-  std::shared_ptr<const CaloCellGeometry> getGeometry( const DetId& id ) const override {
-    return cellGeomPtr( m_cttopo->denseIndex(id) ) ;
+  std::shared_ptr<const CaloCellGeometry> getGeometry(const DetId& id) const override {
+    return cellGeomPtr(m_cttopo->denseIndex(id));
   }
 
-  void getSummary( CaloSubdetectorGeometry::TrVec&  trVector,
-		   CaloSubdetectorGeometry::IVec&   iVector,
-		   CaloSubdetectorGeometry::DimVec& dimVector,
-		   CaloSubdetectorGeometry::IVec& dinsVector ) const override ;
+  void getSummary(CaloSubdetectorGeometry::TrVec& trVector,
+                  CaloSubdetectorGeometry::IVec& iVector,
+                  CaloSubdetectorGeometry::DimVec& dimVector,
+                  CaloSubdetectorGeometry::IVec& dinsVector) const override;
 
 protected:
-
-  unsigned int indexFor(const DetId& id) const override { return  m_cttopo->denseIndex(id); }
+  unsigned int indexFor(const DetId& id) const override { return m_cttopo->denseIndex(id); }
   unsigned int sizeForDenseIndex(const DetId& id) const override { return m_cttopo->sizeForDenseIndexing(); }
 
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr (uint32_t index) const override;
+  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
 
 private:
   const CaloTowerTopology* m_cttopo;
   int k_NumberOfCellsForCorners;
   int k_NumberOfShapes;
-  CellVec m_cellVec ;
+  CellVec m_cellVec;
   CaloSubdetectorGeometry::IVec m_dins;
 };
 

--- a/Geometry/HcalTowerAlgo/interface/CaloTowerHardcodeGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/CaloTowerHardcodeGeometryLoader.h
@@ -14,15 +14,16 @@
   */
 class CaloTowerHardcodeGeometryLoader {
 public:
-  std::unique_ptr<CaloSubdetectorGeometry> load(const CaloTowerTopology *limits, const HcalTopology *hcaltopo, const HcalDDDRecConstants* hcons);
+  std::unique_ptr<CaloSubdetectorGeometry> load(const CaloTowerTopology *limits,
+                                                const HcalTopology *hcaltopo,
+                                                const HcalDDDRecConstants *hcons);
+
 private:
-  void makeCell(uint32_t din, CaloSubdetectorGeometry* geom) const;
+  void makeCell(uint32_t din, CaloSubdetectorGeometry *geom) const;
   const CaloTowerTopology *m_limits;
   const HcalTopology *m_hcaltopo;
   const HcalDDDRecConstants *m_hcons;
   std::vector<double> theHBHEEtaBounds, theHFEtaBounds;
-
-
 };
 
 #endif

--- a/Geometry/HcalTowerAlgo/interface/HcalDDDGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalDDDGeometry.h
@@ -15,74 +15,62 @@
 class HcalDDDGeometryLoader;
 
 class HcalDDDGeometry : public CaloSubdetectorGeometry {
-
 public:
-
   friend class HcalDDDGeometryLoader;
 
-  typedef std::vector<IdealObliquePrism> HBCellVec ;
-  typedef std::vector<IdealObliquePrism> HECellVec ;
-  typedef std::vector<IdealObliquePrism> HOCellVec ;
-  typedef std::vector<IdealZPrism>       HFCellVec ;
+  typedef std::vector<IdealObliquePrism> HBCellVec;
+  typedef std::vector<IdealObliquePrism> HECellVec;
+  typedef std::vector<IdealObliquePrism> HOCellVec;
+  typedef std::vector<IdealZPrism> HFCellVec;
 
   explicit HcalDDDGeometry(const HcalTopology& theTopo);
   /// The HcalDDDGeometry will delete all its cell geometries at destruction time
   ~HcalDDDGeometry() override;
-  
-  const std::vector<DetId>& getValidDetIds( DetId::Detector det    = DetId::Detector ( 0 ) , 
-						    int             subdet = 0   ) const override;
 
-  DetId getClosestCell(const GlobalPoint& r) const override ;
+  const std::vector<DetId>& getValidDetIds(DetId::Detector det = DetId::Detector(0), int subdet = 0) const override;
 
-  int insertCell (std::vector<HcalCellType> const & );
+  DetId getClosestCell(const GlobalPoint& r) const override;
 
-  void newCell( const GlobalPoint& f1 ,
-			const GlobalPoint& f2 ,
-			const GlobalPoint& f3 ,
-			const CCGFloat*    parm,
-			const DetId&       detId     ) override ;
+  int insertCell(std::vector<HcalCellType> const&);
+
+  void newCell(const GlobalPoint& f1,
+               const GlobalPoint& f2,
+               const GlobalPoint& f3,
+               const CCGFloat* parm,
+               const DetId& detId) override;
 
 protected:
-
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr (uint32_t index) const override;
+  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
 
 private:
+  void newCellImpl(
+      const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId);
 
-  void newCellImpl( const GlobalPoint& f1 ,
-		    const GlobalPoint& f2 ,
-		    const GlobalPoint& f3 ,
-		    const CCGFloat*    parm,
-		    const DetId&       detId     ) ;
-
-  //can only be used by friend classes, to ensure sorting is done at the end					
-  void newCellFast( const GlobalPoint& f1 ,
-		    const GlobalPoint& f2 ,
-		    const GlobalPoint& f3 ,
-		    const CCGFloat*    parm,
-		    const DetId&       detId     ) ;
+  //can only be used by friend classes, to ensure sorting is done at the end
+  void newCellFast(
+      const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId);
 
   void increaseReserve(unsigned int extra);
   void sortValidIds();
 
-  void fillDetIds() const ;
+  void fillDetIds() const;
 
   std::vector<HcalCellType> hcalCells_;
-  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_hbIds ;
-  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_heIds ;
-  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_hoIds ;
-  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_hfIds ;
-  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_emptyIds ;
+  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_hbIds;
+  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_heIds;
+  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_hoIds;
+  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_hfIds;
+  CMS_THREAD_GUARD(m_filledDetIds) mutable std::vector<DetId> m_emptyIds;
 
   const HcalTopology& topo_;
-  double              etaMax_;
+  double etaMax_;
 
-  HBCellVec m_hbCellVec ;
-  HECellVec m_heCellVec ;
-  HOCellVec m_hoCellVec ;
-  HFCellVec m_hfCellVec ;
+  HBCellVec m_hbCellVec;
+  HECellVec m_heCellVec;
+  HOCellVec m_hoCellVec;
+  HFCellVec m_hfCellVec;
   mutable std::atomic<bool> m_filledDetIds;
 };
 
 #endif
-

--- a/Geometry/HcalTowerAlgo/interface/HcalDDDGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalDDDGeometryLoader.h
@@ -19,32 +19,27 @@ class HcalDDDGeometry;
 */
 
 class HcalDDDGeometryLoader {
-
 public:
-
-  explicit HcalDDDGeometryLoader(const HcalDDDRecConstants * hcons);
+  explicit HcalDDDGeometryLoader(const HcalDDDRecConstants* hcons);
   virtual ~HcalDDDGeometryLoader();
-  
-  typedef CaloSubdetectorGeometry* ReturnType ;
-  ReturnType load(const HcalTopology& topo, DetId::Detector , int );
+
+  typedef CaloSubdetectorGeometry* ReturnType;
+  ReturnType load(const HcalTopology& topo, DetId::Detector, int);
   /// Load all of HCAL
   ReturnType load(const HcalTopology& topo);
 
   HcalDDDGeometryLoader() = delete;
 
- private:
-
+private:
   /// helper functions to make all the ids and cells, and put them into the
   /// vectors and mpas passed in.
   void fill(HcalSubdetector, HcalDDDGeometry*);
-  
-  void makeCell( const HcalDetId &, 
-		 const HcalCellType& , double, 
-		 double, HcalDDDGeometry* geom) const;
-  
+
+  void makeCell(const HcalDetId&, const HcalCellType&, double, double, HcalDDDGeometry* geom) const;
+
   const HcalDDDRecConstants* hcalConstants_;
 
-  bool          isBH_;
+  bool isBH_;
 };
 
 #endif

--- a/Geometry/HcalTowerAlgo/interface/HcalFlexiHardcodeGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalFlexiHardcodeGeometryLoader.h
@@ -16,18 +16,31 @@ class HcalDDDRecConstants;
 class HcalGeometry;
 
 class HcalFlexiHardcodeGeometryLoader {
-
 public:
   HcalFlexiHardcodeGeometryLoader();
 
   CaloSubdetectorGeometry* load(const HcalTopology& fTopology, const HcalDDDRecConstants& hcons);
 
 private:
-
   struct HBHOCellParameters {
-    HBHOCellParameters (int f_eta, int f_depth, int f_phi, double f_phi0, double f_dPhi, double f_rMin, double f_rMax, double f_etaMin, double f_etaMax)
-    : ieta(f_eta), depth(f_depth), iphi(f_phi), phi(f_phi0), dphi(f_dPhi), rMin(f_rMin), rMax(f_rMax), etaMin(f_etaMin), etaMax(f_etaMax)
-    {}
+    HBHOCellParameters(int f_eta,
+                       int f_depth,
+                       int f_phi,
+                       double f_phi0,
+                       double f_dPhi,
+                       double f_rMin,
+                       double f_rMax,
+                       double f_etaMin,
+                       double f_etaMax)
+        : ieta(f_eta),
+          depth(f_depth),
+          iphi(f_phi),
+          phi(f_phi0),
+          dphi(f_dPhi),
+          rMin(f_rMin),
+          rMax(f_rMax),
+          etaMin(f_etaMin),
+          etaMax(f_etaMax) {}
 
     int ieta;
     int depth;
@@ -41,9 +54,24 @@ private:
   };
 
   struct HECellParameters {
-    HECellParameters (int f_eta, int f_depth, int f_phi, double f_phi0, double f_dPhi, double f_zMin, double f_zMax, double f_etaMin, double f_etaMax)
-    : ieta(f_eta), depth(f_depth), iphi(f_phi), phi(f_phi0), dphi(f_dPhi), zMin(f_zMin), zMax(f_zMax), etaMin(f_etaMin), etaMax(f_etaMax)
-    {}
+    HECellParameters(int f_eta,
+                     int f_depth,
+                     int f_phi,
+                     double f_phi0,
+                     double f_dPhi,
+                     double f_zMin,
+                     double f_zMax,
+                     double f_etaMin,
+                     double f_etaMax)
+        : ieta(f_eta),
+          depth(f_depth),
+          iphi(f_phi),
+          phi(f_phi0),
+          dphi(f_dPhi),
+          zMin(f_zMin),
+          zMax(f_zMax),
+          etaMin(f_etaMin),
+          etaMax(f_etaMax) {}
 
     int ieta;
     int depth;
@@ -57,9 +85,26 @@ private:
   };
 
   struct HFCellParameters {
-    HFCellParameters (int f_eta, int f_depth, int f_phiFirst, int f_phiStep, int f_nPhi, int f_dPhi, float f_zMin, float f_zMax, float f_rMin, float f_rMax)
-    : eta(f_eta), depth(f_depth), phiFirst(f_phiFirst), phiStep(f_phiStep), nPhi(f_nPhi), dphi(f_dPhi), zMin(f_zMin), zMax(f_zMax), rMin(f_rMin), rMax(f_rMax)
-    {}
+    HFCellParameters(int f_eta,
+                     int f_depth,
+                     int f_phiFirst,
+                     int f_phiStep,
+                     int f_nPhi,
+                     int f_dPhi,
+                     float f_zMin,
+                     float f_zMax,
+                     float f_rMin,
+                     float f_rMax)
+        : eta(f_eta),
+          depth(f_depth),
+          phiFirst(f_phiFirst),
+          phiStep(f_phiStep),
+          nPhi(f_nPhi),
+          dphi(f_dPhi),
+          zMin(f_zMin),
+          zMax(f_zMax),
+          rMin(f_rMin),
+          rMax(f_rMax) {}
 
     int eta;
     int depth;
@@ -73,19 +118,19 @@ private:
     float rMax;
   };
 
-  std::vector <HBHOCellParameters> makeHBCells (const HcalDDDRecConstants& hcons);
-  std::vector <HBHOCellParameters> makeHOCells ();
-  std::vector <HECellParameters> makeHECells (const HcalDDDRecConstants& hcons);
-  std::vector <HECellParameters> makeHECells_H2 ();
-  std::vector <HFCellParameters> makeHFCells (const HcalDDDRecConstants& hcons);
+  std::vector<HBHOCellParameters> makeHBCells(const HcalDDDRecConstants& hcons);
+  std::vector<HBHOCellParameters> makeHOCells();
+  std::vector<HECellParameters> makeHECells(const HcalDDDRecConstants& hcons);
+  std::vector<HECellParameters> makeHECells_H2();
+  std::vector<HFCellParameters> makeHFCells(const HcalDDDRecConstants& hcons);
 
-  void fillHBHO (HcalGeometry* fGeometry, const std::vector <HBHOCellParameters>& fCells, bool fHB);
-  void fillHE (HcalGeometry* fGeometry, const std::vector <HECellParameters>& fCells);
-  void fillHF (HcalGeometry* fGeometry, const std::vector <HFCellParameters>& fCells);
+  void fillHBHO(HcalGeometry* fGeometry, const std::vector<HBHOCellParameters>& fCells, bool fHB);
+  void fillHE(HcalGeometry* fGeometry, const std::vector<HECellParameters>& fCells);
+  void fillHF(HcalGeometry* fGeometry, const std::vector<HFCellParameters>& fCells);
 
-  int    MAX_HCAL_PHI;
+  int MAX_HCAL_PHI;
   double DEGREE2RAD;
-  bool   isBH_;
+  bool isBH_;
 };
 
 #endif

--- a/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
@@ -15,164 +15,146 @@ class HcalFlexiHardcodeGeometryLoader;
 class HcalHardcodeGeometryLoader;
 
 class HcalGeometry : public CaloSubdetectorGeometry {
-
   friend class HcalGeometryPlan1Tester;
 
 public:
-
   friend class HcalFlexiHardcodeGeometryLoader;
   friend class HcalHardcodeGeometryLoader;
-  
-  typedef std::vector<IdealObliquePrism> HBCellVec ;
-  typedef std::vector<IdealObliquePrism> HECellVec ;
-  typedef std::vector<IdealObliquePrism> HOCellVec ;
-  typedef std::vector<IdealZPrism>       HFCellVec ;
 
-  typedef CaloCellGeometry::CCGFloat CCGFloat ;
-  typedef CaloCellGeometry::Pt3D     Pt3D     ;
-  typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
+  typedef std::vector<IdealObliquePrism> HBCellVec;
+  typedef std::vector<IdealObliquePrism> HECellVec;
+  typedef std::vector<IdealObliquePrism> HOCellVec;
+  typedef std::vector<IdealZPrism> HFCellVec;
 
-  typedef HcalAlignmentRcd   AlignmentRecord ;
-  typedef HcalGeometryRecord AlignedRecord   ;
-  typedef PHcalRcd           PGeometryRecord ;
-  typedef HcalDetId          DetIdType       ;
+  typedef CaloCellGeometry::CCGFloat CCGFloat;
+  typedef CaloCellGeometry::Pt3D Pt3D;
+  typedef CaloCellGeometry::Pt3DVec Pt3DVec;
 
-    
-  enum { k_NumberOfParametersPerShape = 5 } ;
+  typedef HcalAlignmentRcd AlignmentRecord;
+  typedef HcalGeometryRecord AlignedRecord;
+  typedef PHcalRcd PGeometryRecord;
+  typedef HcalDetId DetIdType;
 
-  static std::string dbString() { return "PHcalRcd" ; }
+  enum { k_NumberOfParametersPerShape = 5 };
 
-  unsigned int numberOfShapes() const override { return m_topology.getNumberOfShapes() ; }
-  unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape ; }
-  
+  static std::string dbString() { return "PHcalRcd"; }
+
+  unsigned int numberOfShapes() const override { return m_topology.getNumberOfShapes(); }
+  unsigned int numberOfParametersPerShape() const override { return k_NumberOfParametersPerShape; }
+
   explicit HcalGeometry(const HcalTopology& topology);
-  
+
   /// The HcalGeometry will delete all its cell geometries at destruction time
   ~HcalGeometry() override;
-  
-  const std::vector<DetId>& getValidDetIds(DetId::Detector det    = DetId::Detector ( 0 ), 
-					   int             subdet = 0 ) const override;
 
-  std::shared_ptr<const CaloCellGeometry> getGeometry( const DetId& id ) const override ;
-  
-  DetId getClosestCell(const GlobalPoint& r) const override ;
+  const std::vector<DetId>& getValidDetIds(DetId::Detector det = DetId::Detector(0), int subdet = 0) const override;
+
+  std::shared_ptr<const CaloCellGeometry> getGeometry(const DetId& id) const override;
+
+  DetId getClosestCell(const GlobalPoint& r) const override;
   DetId getClosestCell(const GlobalPoint& r, bool ignoreCorrect) const;
-  
-  CaloSubdetectorGeometry::DetIdSet getCells(const GlobalPoint& r, double dR) const override ;
 
-  GlobalPoint                   getPosition(const DetId& id) const;
-  GlobalPoint                   getBackPosition(const DetId& id) const;
-  CaloCellGeometry::CornersVec  getCorners(const DetId& id) const;
+  CaloSubdetectorGeometry::DetIdSet getCells(const GlobalPoint& r, double dR) const override;
 
-  static std::string producerTag() { return "HCAL" ; }
-  
-  static unsigned int numberOfBarrelAlignments() { return 36 ; }
+  GlobalPoint getPosition(const DetId& id) const;
+  GlobalPoint getBackPosition(const DetId& id) const;
+  CaloCellGeometry::CornersVec getCorners(const DetId& id) const;
 
-  static unsigned int numberOfEndcapAlignments() { return 36 ; }
-  
-  static unsigned int numberOfForwardAlignments() { return 36 ; }
+  static std::string producerTag() { return "HCAL"; }
 
-  static unsigned int numberOfOuterAlignments() { return 60 ; }
+  static unsigned int numberOfBarrelAlignments() { return 36; }
+
+  static unsigned int numberOfEndcapAlignments() { return 36; }
+
+  static unsigned int numberOfForwardAlignments() { return 36; }
+
+  static unsigned int numberOfOuterAlignments() { return 60; }
 
   unsigned int getHxSize(const int type) const;
 
-  static unsigned int numberOfAlignments() { 
-    return ( numberOfBarrelAlignments() +
-	     numberOfEndcapAlignments() +
-	     numberOfOuterAlignments() +
-	     numberOfForwardAlignments() ) ; }
+  static unsigned int numberOfAlignments() {
+    return (numberOfBarrelAlignments() + numberOfEndcapAlignments() + numberOfOuterAlignments() +
+            numberOfForwardAlignments());
+  }
 
-  static unsigned int alignmentBarrelIndexLocal(    const DetId& id ) ;
-  static unsigned int alignmentEndcapIndexLocal(    const DetId& id ) ;
-  static unsigned int alignmentForwardIndexLocal(   const DetId& id ) ;
-  static unsigned int alignmentOuterIndexLocal(     const DetId& id ) ;
-  static unsigned int alignmentTransformIndexLocal( const DetId& id ) ;
+  static unsigned int alignmentBarrelIndexLocal(const DetId& id);
+  static unsigned int alignmentEndcapIndexLocal(const DetId& id);
+  static unsigned int alignmentForwardIndexLocal(const DetId& id);
+  static unsigned int alignmentOuterIndexLocal(const DetId& id);
+  static unsigned int alignmentTransformIndexLocal(const DetId& id);
 
-  static unsigned int alignmentBarEndForIndexLocal( const DetId& id,unsigned int nD ) ;
+  static unsigned int alignmentBarEndForIndexLocal(const DetId& id, unsigned int nD);
 
-  static unsigned int alignmentTransformIndexGlobal( const DetId& id ) ;
+  static unsigned int alignmentTransformIndexGlobal(const DetId& id);
 
-  static DetId detIdFromLocalAlignmentIndex(   unsigned int i ) ;
-  static DetId detIdFromBarrelAlignmentIndex(  unsigned int i ) ;
-  static DetId detIdFromEndcapAlignmentIndex(  unsigned int i ) ;
-  static DetId detIdFromForwardAlignmentIndex( unsigned int i ) ;
-  static DetId detIdFromOuterAlignmentIndex(   unsigned int i ) ;
+  static DetId detIdFromLocalAlignmentIndex(unsigned int i);
+  static DetId detIdFromBarrelAlignmentIndex(unsigned int i);
+  static DetId detIdFromEndcapAlignmentIndex(unsigned int i);
+  static DetId detIdFromForwardAlignmentIndex(unsigned int i);
+  static DetId detIdFromOuterAlignmentIndex(unsigned int i);
 
-  void localCorners( Pt3DVec&        lc  ,
-		     const CCGFloat* pv  , 
-		     unsigned int    i   ,
-		     Pt3D&           ref   ) ;
-  
-  void newCell( const GlobalPoint& f1 ,
-		const GlobalPoint& f2 ,
-		const GlobalPoint& f3 ,
-		const CCGFloat*    parm,
-		const DetId&       detId     ) override ;
+  void localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int i, Pt3D& ref);
 
-  void getSummary( CaloSubdetectorGeometry::TrVec&  trVector,
-		   CaloSubdetectorGeometry::IVec&   iVector,
-		   CaloSubdetectorGeometry::DimVec& dimVector,
-		   CaloSubdetectorGeometry::IVec& dinsVector ) const override ;
+  void newCell(const GlobalPoint& f1,
+               const GlobalPoint& f2,
+               const GlobalPoint& f3,
+               const CCGFloat* parm,
+               const DetId& detId) override;
+
+  void getSummary(CaloSubdetectorGeometry::TrVec& trVector,
+                  CaloSubdetectorGeometry::IVec& iVector,
+                  CaloSubdetectorGeometry::DimVec& dimVector,
+                  CaloSubdetectorGeometry::IVec& dinsVector) const override;
 
   const HcalTopology& topology() const { return m_topology; }
 
 protected:
-
-  unsigned int indexFor(const DetId& id) const override { return  m_topology.detId2denseId(id); }
+  unsigned int indexFor(const DetId& id) const override { return m_topology.detId2denseId(id); }
   unsigned int sizeForDenseIndex(const DetId& id) const override { return m_topology.ncells(); }
 
   // Modify the RawPtr class
-  const CaloCellGeometry* getGeometryRawPtr (uint32_t index) const override;
+  const CaloCellGeometry* getGeometryRawPtr(uint32_t index) const override;
 
 private:
-
   // Base clas for getting geometry
-  std::shared_ptr<const CaloCellGeometry> getGeometryBase( const DetId& id ) const {
-    return cellGeomPtr( m_topology.detId2denseId( id ) ) ;
+  std::shared_ptr<const CaloCellGeometry> getGeometryBase(const DetId& id) const {
+    return cellGeomPtr(m_topology.detId2denseId(id));
   }
 
   //returns din
-  unsigned int newCellImpl( const GlobalPoint& f1 ,
-			    const GlobalPoint& f2 ,
-			    const GlobalPoint& f3 ,
-			    const CCGFloat*    parm,
-			    const DetId&       detId     ) ;
+  unsigned int newCellImpl(
+      const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId);
 
   //can only be used by friend classes, to ensure sorting is done at the end
-  void newCellFast( const GlobalPoint& f1 ,
-		    const GlobalPoint& f2 ,
-		    const GlobalPoint& f3 ,
-		    const CCGFloat*    parm,
-		    const DetId&       detId     ) ;
+  void newCellFast(
+      const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId);
 
   void increaseReserve(unsigned int extra);
   void sortValidIds();
 
-  void fillDetIds() const ;
+  void fillDetIds() const;
 
-  void init() ;
+  void init();
 
   /// helper methods for getClosestCell
   int etaRing(HcalSubdetector bc, double abseta) const;
   int phiBin(HcalSubdetector bc, int etaring, double phi) const;
-  DetId correctId(const DetId& id) const ;
+  DetId correctId(const DetId& id) const;
 
   const HcalTopology& m_topology;
-  bool                m_mergePosition;
-  
-  mutable edm::AtomicPtrCache<std::vector<DetId>> m_hbIds ;
-  mutable edm::AtomicPtrCache<std::vector<DetId>> m_heIds ;
-  mutable edm::AtomicPtrCache<std::vector<DetId>> m_hoIds ;
-  mutable edm::AtomicPtrCache<std::vector<DetId>> m_hfIds ;
-  mutable edm::AtomicPtrCache<std::vector<DetId>> m_emptyIds ;
+  bool m_mergePosition;
+
+  mutable edm::AtomicPtrCache<std::vector<DetId>> m_hbIds;
+  mutable edm::AtomicPtrCache<std::vector<DetId>> m_heIds;
+  mutable edm::AtomicPtrCache<std::vector<DetId>> m_hoIds;
+  mutable edm::AtomicPtrCache<std::vector<DetId>> m_hfIds;
+  mutable edm::AtomicPtrCache<std::vector<DetId>> m_emptyIds;
   CaloSubdetectorGeometry::IVec m_dins;
 
-  HBCellVec m_hbCellVec ;
-  HECellVec m_heCellVec ;
-  HOCellVec m_hoCellVec ;
-  HFCellVec m_hfCellVec ;
+  HBCellVec m_hbCellVec;
+  HECellVec m_heCellVec;
+  HOCellVec m_hoCellVec;
+  HFCellVec m_hfCellVec;
 };
 
-
 #endif
-

--- a/Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalHardcodeGeometryLoader.h
@@ -15,18 +15,31 @@ class HcalTopology;
 class HcalGeometry;
 
 class HcalHardcodeGeometryLoader {
-
 public:
   HcalHardcodeGeometryLoader();
 
   CaloSubdetectorGeometry* load(const HcalTopology& fTopology);
 
 private:
-
   struct HBHOCellParameters {
-    HBHOCellParameters (int f_eta, int f_depth, int f_phiFirst, int f_phiStep, int f_dPhi, float f_rMin, float f_rMax, float f_etaMin, float f_etaMax)
-      : eta(f_eta), depth(f_depth), phiFirst(f_phiFirst), phiStep(f_phiStep), dphi(f_dPhi), rMin(f_rMin), rMax(f_rMax), etaMin(f_etaMin), etaMax(f_etaMax)
-    {}
+    HBHOCellParameters(int f_eta,
+                       int f_depth,
+                       int f_phiFirst,
+                       int f_phiStep,
+                       int f_dPhi,
+                       float f_rMin,
+                       float f_rMax,
+                       float f_etaMin,
+                       float f_etaMax)
+        : eta(f_eta),
+          depth(f_depth),
+          phiFirst(f_phiFirst),
+          phiStep(f_phiStep),
+          dphi(f_dPhi),
+          rMin(f_rMin),
+          rMax(f_rMax),
+          etaMin(f_etaMin),
+          etaMax(f_etaMax) {}
 
     int eta;
     int depth;
@@ -40,9 +53,24 @@ private:
   };
 
   struct HECellParameters {
-    HECellParameters (int f_eta, int f_depth, int f_phiFirst, int f_phiStep, int f_dPhi, float f_zMin, float f_zMax, float f_etaMin, float f_etaMax)
-      : eta(f_eta), depth(f_depth), phiFirst(f_phiFirst), phiStep(f_phiStep), dphi(f_dPhi), zMin(f_zMin), zMax(f_zMax), etaMin(f_etaMin), etaMax(f_etaMax)
-    {}
+    HECellParameters(int f_eta,
+                     int f_depth,
+                     int f_phiFirst,
+                     int f_phiStep,
+                     int f_dPhi,
+                     float f_zMin,
+                     float f_zMax,
+                     float f_etaMin,
+                     float f_etaMax)
+        : eta(f_eta),
+          depth(f_depth),
+          phiFirst(f_phiFirst),
+          phiStep(f_phiStep),
+          dphi(f_dPhi),
+          zMin(f_zMin),
+          zMax(f_zMax),
+          etaMin(f_etaMin),
+          etaMax(f_etaMax) {}
 
     int eta;
     int depth;
@@ -56,9 +84,24 @@ private:
   };
 
   struct HFCellParameters {
-    HFCellParameters (int f_eta, int f_depth, int f_phiFirst, int f_phiStep, int f_dPhi, float f_zMin, float f_zMax, float f_rMin, float f_rMax)
-      : eta(f_eta), depth(f_depth), phiFirst(f_phiFirst), phiStep(f_phiStep), dphi(f_dPhi), zMin(f_zMin), zMax(f_zMax), rMin(f_rMin), rMax(f_rMax)
-    {}
+    HFCellParameters(int f_eta,
+                     int f_depth,
+                     int f_phiFirst,
+                     int f_phiStep,
+                     int f_dPhi,
+                     float f_zMin,
+                     float f_zMax,
+                     float f_rMin,
+                     float f_rMax)
+        : eta(f_eta),
+          depth(f_depth),
+          phiFirst(f_phiFirst),
+          phiStep(f_phiStep),
+          dphi(f_dPhi),
+          zMin(f_zMin),
+          zMax(f_zMax),
+          rMin(f_rMin),
+          rMax(f_rMax) {}
 
     int eta;
     int depth;
@@ -71,21 +114,20 @@ private:
     float rMax;
   };
 
-  std::vector <HBHOCellParameters> makeHBCells (const HcalTopology & topology);
-  std::vector <HBHOCellParameters> makeHOCells ();
-  std::vector <HECellParameters> makeHECells (const HcalTopology & topology);
-  std::vector <HECellParameters> makeHECells_H2 ();
-  std::vector <HFCellParameters> makeHFCells ();
+  std::vector<HBHOCellParameters> makeHBCells(const HcalTopology& topology);
+  std::vector<HBHOCellParameters> makeHOCells();
+  std::vector<HECellParameters> makeHECells(const HcalTopology& topology);
+  std::vector<HECellParameters> makeHECells_H2();
+  std::vector<HFCellParameters> makeHFCells();
 
-  void fillHBHO (HcalGeometry* fGeometry, const std::vector <HBHOCellParameters>& fCells, bool fHB);
-  void fillHE (HcalGeometry* fGeometry, const std::vector <HECellParameters>& fCells);
-  void fillHF (HcalGeometry* fGeometry, const std::vector <HFCellParameters>& fCells);
+  void fillHBHO(HcalGeometry* fGeometry, const std::vector<HBHOCellParameters>& fCells, bool fHB);
+  void fillHE(HcalGeometry* fGeometry, const std::vector<HECellParameters>& fCells);
+  void fillHF(HcalGeometry* fGeometry, const std::vector<HFCellParameters>& fCells);
 
-  int    MAX_HCAL_PHI;
+  int MAX_HCAL_PHI;
   double DEGREE2RAD;
 
   std::vector<std::vector<int> > m_segmentation;
-
 };
 
 #endif

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -9,20 +9,19 @@ class HcalDetId;
 
 class HcalTrigTowerGeometry {
 public:
-
-  HcalTrigTowerGeometry( const HcalTopology* topology );
+  HcalTrigTowerGeometry(const HcalTopology* topology);
 
   /// the mapping to and from DetIds
-  std::vector<HcalTrigTowerDetId> towerIds(const HcalDetId & cellId) const;
-  std::vector<HcalDetId> detIds(const HcalTrigTowerDetId &) const;
+  std::vector<HcalTrigTowerDetId> towerIds(const HcalDetId& cellId) const;
+  std::vector<HcalDetId> detIds(const HcalTrigTowerDetId&) const;
 
-  int firstHFTower(int version) const {return (version==0)?(29):(30);} 
+  int firstHFTower(int version) const { return (version == 0) ? (29) : (30); }
 
   /// where this tower begins and ends in eta
-  void towerEtaBounds(int ieta, int version, double & eta1, double & eta2) const;
+  void towerEtaBounds(int ieta, int version, double& eta1, double& eta2) const;
 
   /// number of towers (version dependent)
-  int nTowers(int version) const {return (version==0)?(32):(41);}
+  int nTowers(int version) const { return (version == 0) ? (32) : (41); }
 
   // get the topology pointer
   const HcalTopology& topology() const { return *theTopology; }
@@ -31,11 +30,10 @@ public:
   bool useRCT() const { return useRCT_; }
   bool use1x1() const { return use1x1_; }
 
- private:
-
+private:
   /// the number of phi bins in this eta ring
   int nPhiBins(int ieta, int version) const {
-    int nPhiBinsHF = ( 18 );   
+    int nPhiBinsHF = (18);
     return (abs(ieta) < firstHFTower(version)) ? 72 : nPhiBinsHF;
   }
 
@@ -46,7 +44,7 @@ public:
   /// since the towers are irregular in eta in HF
   int firstHFRingInTower(int ietaTower) const;
 
- private:
+private:
   const HcalTopology* theTopology;
 
   bool useRCT_;
@@ -55,4 +53,3 @@ public:
 };
 
 #endif
-

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
@@ -3,23 +3,19 @@
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include <memory>
 
-HcalTrigTowerGeometryESProducer::HcalTrigTowerGeometryESProducer( const edm::ParameterSet & config )
-  : topologyToken_{setWhatProduced( this ).consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{})}
-{}
+HcalTrigTowerGeometryESProducer::HcalTrigTowerGeometryESProducer(const edm::ParameterSet& config)
+    : topologyToken_{setWhatProduced(this).consumesFrom<HcalTopology, HcalRecNumberingRecord>(edm::ESInputTag{})} {}
 
-HcalTrigTowerGeometryESProducer::~HcalTrigTowerGeometryESProducer( void ) 
-{}
+HcalTrigTowerGeometryESProducer::~HcalTrigTowerGeometryESProducer(void) {}
 
-std::unique_ptr<HcalTrigTowerGeometry>
-HcalTrigTowerGeometryESProducer::produce( const CaloGeometryRecord & iRecord )
-{
+std::unique_ptr<HcalTrigTowerGeometry> HcalTrigTowerGeometryESProducer::produce(const CaloGeometryRecord& iRecord) {
   const auto& hcalTopology = iRecord.get(topologyToken_);
   return std::make_unique<HcalTrigTowerGeometry>(&hcalTopology);
 }
 
-void HcalTrigTowerGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-   edm::ParameterSetDescription desc;
-   descriptions.add("HcalTrigTowerGeometryESProducer", desc);
+void HcalTrigTowerGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.add("HcalTrigTowerGeometryESProducer", desc);
 }
 
-DEFINE_FWK_EVENTSETUP_MODULE( HcalTrigTowerGeometryESProducer );
+DEFINE_FWK_EVENTSETUP_MODULE(HcalTrigTowerGeometryESProducer);

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
@@ -1,29 +1,28 @@
 #ifndef HCAL_TOWER_ALGO_HCAL_TRIG_TOWER_GEOMETRY_ES_PRODUCER_H
-# define HCAL_TOWER_ALGO_HCAL_TRIG_TOWER_GEOMETRY_ES_PRODUCER_H
+#define HCAL_TOWER_ALGO_HCAL_TRIG_TOWER_GEOMETRY_ES_PRODUCER_H
 
-# include <memory>
+#include <memory>
 
-# include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
-# include "Geometry/Records/interface/CaloGeometryRecord.h"
-# include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 
 namespace edm {
   class ConfigurationDescriptions;
 }
 
-class HcalTrigTowerGeometryESProducer : public edm::ESProducer
-{
+class HcalTrigTowerGeometryESProducer : public edm::ESProducer {
 public:
-  HcalTrigTowerGeometryESProducer( const edm::ParameterSet & conf );
-  ~HcalTrigTowerGeometryESProducer( void ) override;
+  HcalTrigTowerGeometryESProducer(const edm::ParameterSet& conf);
+  ~HcalTrigTowerGeometryESProducer(void) override;
 
-  std::unique_ptr<HcalTrigTowerGeometry> produce( const CaloGeometryRecord & );
+  std::unique_ptr<HcalTrigTowerGeometry> produce(const CaloGeometryRecord&);
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
 };
 
-#endif // HCAL_TOWER_ALGO_HCAL_TRIG_TOWER_GEOMETRY_ES_PRODUCER_H
+#endif  // HCAL_TOWER_ALGO_HCAL_TRIG_TOWER_GEOMETRY_ES_PRODUCER_H

--- a/Geometry/HcalTowerAlgo/src/CaloTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/CaloTowerGeometry.cc
@@ -4,143 +4,123 @@
 #include <Math/Transform3D.h>
 #include <Math/EulerAngles.h>
 
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
-typedef CaloCellGeometry::Pt3D     Pt3D     ;
-typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
-typedef CaloCellGeometry::Tr3D Tr3D ;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
+typedef CaloCellGeometry::Pt3D Pt3D;
+typedef CaloCellGeometry::Pt3DVec Pt3DVec;
+typedef CaloCellGeometry::Tr3D Tr3D;
 
-CaloTowerGeometry::CaloTowerGeometry(const CaloTowerTopology *cttopo) :
-  m_cttopo(cttopo), 
-  k_NumberOfCellsForCorners(m_cttopo->sizeForDenseIndexing()), 
-  k_NumberOfShapes(m_cttopo->lastHFRing()), 
-  m_cellVec ( k_NumberOfCellsForCorners ) 
-{
-}
-  
+CaloTowerGeometry::CaloTowerGeometry(const CaloTowerTopology* cttopo)
+    : m_cttopo(cttopo),
+      k_NumberOfCellsForCorners(m_cttopo->sizeForDenseIndexing()),
+      k_NumberOfShapes(m_cttopo->lastHFRing()),
+      m_cellVec(k_NumberOfCellsForCorners) {}
 
-CaloTowerGeometry::~CaloTowerGeometry() { }
+CaloTowerGeometry::~CaloTowerGeometry() {}
 
+unsigned int CaloTowerGeometry::alignmentTransformIndexLocal(const DetId& id) {
+  const CaloGenericDetId gid(id);
+  assert(gid.isCaloTower());
 
-unsigned int 
-CaloTowerGeometry::alignmentTransformIndexLocal( const DetId& id ) {
-  
-  const CaloGenericDetId gid ( id ) ;
-  assert( gid.isCaloTower() ) ;
+  const CaloTowerDetId cid(id);
+  const int iea(cid.ietaAbs());
+  const unsigned int ip((cid.iphi() - 1) / 4);
+  const int izoff((cid.zside() + 1) / 2);
+  const unsigned int offset(izoff * 3 * 18);
 
-  const CaloTowerDetId cid ( id ) ;
-  const int iea ( cid.ietaAbs() ) ;
-  const unsigned int ip ( ( cid.iphi() - 1 )/4 ) ;
-  const int izoff ( ( cid.zside() + 1 )/2 ) ;
-  const unsigned int offset ( izoff*3*18) ;
-
-  return ( offset + ip + 
-	   ( m_cttopo->firstHFQuadPhiRing() <= iea ? 36 :
-	     ( m_cttopo->firstHEDoublePhiRing() <= iea ? 18 : 0 ) ) ) ;
+  return (offset + ip +
+          (m_cttopo->firstHFQuadPhiRing() <= iea ? 36 : (m_cttopo->firstHEDoublePhiRing() <= iea ? 18 : 0)));
 }
 
-unsigned int
-CaloTowerGeometry::alignmentTransformIndexGlobal( const DetId& id ) {
-  return (unsigned int) DetId::Calo - 1 ;
+unsigned int CaloTowerGeometry::alignmentTransformIndexGlobal(const DetId& id) { return (unsigned int)DetId::Calo - 1; }
+
+void CaloTowerGeometry::localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int i, Pt3D& ref) {
+  IdealObliquePrism::localCorners(lc, pv, ref);
 }
 
-void
-CaloTowerGeometry::localCorners( Pt3DVec&        lc  ,
-				 const CCGFloat* pv  ,
-				 unsigned int    i   ,
-				 Pt3D&           ref  ) {
-  IdealObliquePrism::localCorners( lc, pv, ref ) ;
-}
+void CaloTowerGeometry::newCell(
+    const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId) {
+  const CaloGenericDetId cgid(detId);
 
-void
-CaloTowerGeometry::newCell( const GlobalPoint& f1 ,
-			    const GlobalPoint& f2 ,
-			    const GlobalPoint& f3 ,
-			    const CCGFloat*    parm ,
-			    const DetId&       detId   ) {
-  const CaloGenericDetId cgid ( detId ) ;
+  assert(cgid.isCaloTower());
 
-  assert( cgid.isCaloTower() ) ;
-   
-  const CaloTowerDetId cid ( detId ) ;
+  const CaloTowerDetId cid(detId);
 
-  const unsigned int di ( m_cttopo->denseIndex(cid) ) ;
+  const unsigned int di(m_cttopo->denseIndex(cid));
 
-   m_cellVec[ di ] = IdealObliquePrism( f1, cornersMgr(), parm ) ;
-   addValidID( detId ) ;
-   m_dins.emplace_back( di );
+  m_cellVec[di] = IdealObliquePrism(f1, cornersMgr(), parm);
+  addValidID(detId);
+  m_dins.emplace_back(di);
 }
 
 const CaloCellGeometry* CaloTowerGeometry::getGeometryRawPtr(uint32_t index) const {
   // Modify the RawPtr class
   const CaloCellGeometry* cell(&m_cellVec[index]);
-  return (m_cellVec.size() < index ||
-	  nullptr == cell->param() ? nullptr : cell);
+  return (m_cellVec.size() < index || nullptr == cell->param() ? nullptr : cell);
 }
 
-void
-CaloTowerGeometry::getSummary(CaloSubdetectorGeometry::TrVec&  tVec,
-                              CaloSubdetectorGeometry::IVec&   iVec,
-                              CaloSubdetectorGeometry::DimVec& dVec,
-                              CaloSubdetectorGeometry::IVec& dinsVec ) const {
-  tVec.reserve( numberOfCellsForCorners()*numberOfTransformParms() ) ;
-  iVec.reserve( numberOfShapes()==1 ? 1 : numberOfCellsForCorners() ) ;
-  dVec.reserve( numberOfShapes()*numberOfParametersPerShape() ) ;
+void CaloTowerGeometry::getSummary(CaloSubdetectorGeometry::TrVec& tVec,
+                                   CaloSubdetectorGeometry::IVec& iVec,
+                                   CaloSubdetectorGeometry::DimVec& dVec,
+                                   CaloSubdetectorGeometry::IVec& dinsVec) const {
+  tVec.reserve(numberOfCellsForCorners() * numberOfTransformParms());
+  iVec.reserve(numberOfShapes() == 1 ? 1 : numberOfCellsForCorners());
+  dVec.reserve(numberOfShapes() * numberOfParametersPerShape());
   dinsVec.reserve(numberOfCellsForCorners());
-   
-  for (const auto & pv : parVecVec()) {
+
+  for (const auto& pv : parVecVec()) {
     for (float iv : pv) {
-      dVec.emplace_back( iv ) ;
+      dVec.emplace_back(iv);
     }
   }
-   
-  for (unsigned int i ( 0 ) ; i < numberOfCellsForCorners() ; ++i) {
-    Tr3D tr ;
-    auto ptr (cellGeomPtr( i ));
-       
+
+  for (unsigned int i(0); i < numberOfCellsForCorners(); ++i) {
+    Tr3D tr;
+    auto ptr(cellGeomPtr(i));
+
     if (nullptr != ptr) {
-      dinsVec.emplace_back( i );
+      dinsVec.emplace_back(i);
 
-      ptr->getTransform( tr, ( Pt3DVec* ) nullptr ) ;
+      ptr->getTransform(tr, (Pt3DVec*)nullptr);
 
-      if( Tr3D() == tr ) { // for preshower there is no rotation
-         const GlobalPoint& gp ( ptr->getPosition() ) ; 
-         tr = HepGeom::Translate3D( gp.x(), gp.y(), gp.z() ) ;
+      if (Tr3D() == tr) {  // for preshower there is no rotation
+        const GlobalPoint& gp(ptr->getPosition());
+        tr = HepGeom::Translate3D(gp.x(), gp.y(), gp.z());
       }
 
-      const CLHEP::Hep3Vector  tt ( tr.getTranslation() ) ;
-      tVec.emplace_back( tt.x() ) ;
-      tVec.emplace_back( tt.y() ) ;
-      tVec.emplace_back( tt.z() ) ;
+      const CLHEP::Hep3Vector tt(tr.getTranslation());
+      tVec.emplace_back(tt.x());
+      tVec.emplace_back(tt.y());
+      tVec.emplace_back(tt.z());
       if (6 == numberOfTransformParms()) {
-         const CLHEP::HepRotation rr ( tr.getRotation() ) ;
-         const ROOT::Math::Transform3D rtr (rr.xx(), rr.xy(), rr.xz(), tt.x(),
-                                            rr.yx(), rr.yy(), rr.yz(), tt.y(),
-                                            rr.zx(), rr.zy(), rr.zz(), tt.z());
-         ROOT::Math::EulerAngles ea ;
-         rtr.GetRotation( ea ) ;
-         tVec.emplace_back( ea.Phi() ) ;
-         tVec.emplace_back( ea.Theta() ) ;
-         tVec.emplace_back( ea.Psi() ) ;
+        const CLHEP::HepRotation rr(tr.getRotation());
+        const ROOT::Math::Transform3D rtr(
+            rr.xx(), rr.xy(), rr.xz(), tt.x(), rr.yx(), rr.yy(), rr.yz(), tt.y(), rr.zx(), rr.zy(), rr.zz(), tt.z());
+        ROOT::Math::EulerAngles ea;
+        rtr.GetRotation(ea);
+        tVec.emplace_back(ea.Phi());
+        tVec.emplace_back(ea.Theta());
+        tVec.emplace_back(ea.Psi());
       }
 
-      const CCGFloat* par ( ptr->param() ) ;
+      const CCGFloat* par(ptr->param());
 
-      unsigned int ishape ( 9999 ) ;
-      for( unsigned int ivv ( 0 ) ; ivv != parVecVec().size() ; ++ivv ) {
-         bool ok ( true ) ;
-         const CCGFloat* pv ( &(*parVecVec()[ivv].begin() ) ) ;
-         for( unsigned int k ( 0 ) ; k != numberOfParametersPerShape() ; ++k ) {
-            ok = ok && ( fabs( par[k] - pv[k] ) < 1.e-6 ) ;
-         }
-         if( ok ) {
-            ishape = ivv ;
-            break ;
-         }
+      unsigned int ishape(9999);
+      for (unsigned int ivv(0); ivv != parVecVec().size(); ++ivv) {
+        bool ok(true);
+        const CCGFloat* pv(&(*parVecVec()[ivv].begin()));
+        for (unsigned int k(0); k != numberOfParametersPerShape(); ++k) {
+          ok = ok && (fabs(par[k] - pv[k]) < 1.e-6);
+        }
+        if (ok) {
+          ishape = ivv;
+          break;
+        }
       }
-      assert( 9999 != ishape ) ;
-      
-      const unsigned int nn (( numberOfShapes()==1) ? (unsigned int)1 : m_dins.size() ) ; 
-      if( iVec.size() < nn ) iVec.emplace_back( ishape ) ;
+      assert(9999 != ishape);
+
+      const unsigned int nn((numberOfShapes() == 1) ? (unsigned int)1 : m_dins.size());
+      if (iVec.size() < nn)
+        iVec.emplace_back(ishape);
     }
   }
 }

--- a/Geometry/HcalTowerAlgo/src/CaloTowerHardcodeGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/CaloTowerHardcodeGeometryLoader.cc
@@ -9,16 +9,17 @@
 
 //#define DebugLog
 
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
 
-std::unique_ptr<CaloSubdetectorGeometry> CaloTowerHardcodeGeometryLoader::load(const CaloTowerTopology *limits, const HcalTopology *hcaltopo, const HcalDDDRecConstants* hcons) {
-
+std::unique_ptr<CaloSubdetectorGeometry> CaloTowerHardcodeGeometryLoader::load(const CaloTowerTopology* limits,
+                                                                               const HcalTopology* hcaltopo,
+                                                                               const HcalDDDRecConstants* hcons) {
   m_limits = limits;
   m_hcaltopo = hcaltopo;
   m_hcons = hcons;
 
   //get eta limits from hcal rec constants
-  theHFEtaBounds   = m_hcons->getEtaTableHF();
+  theHFEtaBounds = m_hcons->getEtaTableHF();
   theHBHEEtaBounds = m_hcons->getEtaTable();
 
 #ifdef DebugLog
@@ -26,33 +27,34 @@ std::unique_ptr<CaloSubdetectorGeometry> CaloTowerHardcodeGeometryLoader::load(c
   std::copy(theHBHEEtaBounds.begin(), theHBHEEtaBounds.end(), std::ostream_iterator<double>(std::cout, ","));
   std::cout << std::endl;
 
-  std::cout << "CaloTowerHardcodeGeometryLoader: lastHBRing = " << m_limits->lastHBRing() << ", lastHERing = " << m_limits->lastHERing() << std::endl;
-  std::cout << "CaloTowerHardcodeGeometryLoader: HcalTopology: firstHBRing = " << hcaltopo->firstHBRing() << ", lastHBRing = " << hcaltopo->lastHBRing() << ", firstHERing = " << hcaltopo->firstHERing() << ", lastHERing = " << hcaltopo->lastHERing() << ", firstHFRing = " << hcaltopo->firstHFRing() << ", lastHFRing = " << hcaltopo->lastHFRing() << std::endl;
+  std::cout << "CaloTowerHardcodeGeometryLoader: lastHBRing = " << m_limits->lastHBRing()
+            << ", lastHERing = " << m_limits->lastHERing() << std::endl;
+  std::cout << "CaloTowerHardcodeGeometryLoader: HcalTopology: firstHBRing = " << hcaltopo->firstHBRing()
+            << ", lastHBRing = " << hcaltopo->lastHBRing() << ", firstHERing = " << hcaltopo->firstHERing()
+            << ", lastHERing = " << hcaltopo->lastHERing() << ", firstHFRing = " << hcaltopo->firstHFRing()
+            << ", lastHFRing = " << hcaltopo->lastHFRing() << std::endl;
 #endif
 
-  CaloTowerGeometry* geom=new CaloTowerGeometry(m_limits);
+  CaloTowerGeometry* geom = new CaloTowerGeometry(m_limits);
 
-  if( nullptr == geom->cornersMgr() ) geom->allocateCorners ( 
-     geom->numberOfCellsForCorners() ) ;
-  if( nullptr == geom->parMgr() ) geom->allocatePar (
-     geom->numberOfParametersPerShape()*geom->numberOfShapes(),
-     geom->numberOfParametersPerShape() ) ;
+  if (nullptr == geom->cornersMgr())
+    geom->allocateCorners(geom->numberOfCellsForCorners());
+  if (nullptr == geom->parMgr())
+    geom->allocatePar(geom->numberOfParametersPerShape() * geom->numberOfShapes(), geom->numberOfParametersPerShape());
 
   // simple loop
   for (uint32_t din = 0; din < m_limits->sizeForDenseIndexing(); ++din) {
     makeCell(din, geom);
   }
   edm::LogInfo("Geometry") << "CaloTowersHardcodeGeometry made " << m_limits->sizeForDenseIndexing() << " towers.";
-  return std::unique_ptr<CaloSubdetectorGeometry>(geom); 
+  return std::unique_ptr<CaloSubdetectorGeometry>(geom);
 }
 
-void
-CaloTowerHardcodeGeometryLoader::makeCell( uint32_t din,
-					   CaloSubdetectorGeometry* geom ) const {
-  const double EBradius = 143.0; // cm
-  const double HOradius = 406.0+1.0;
-  const double EEz = 320.0; // rough (cm)
-  const double HEz = 568.0; // back (cm)
+void CaloTowerHardcodeGeometryLoader::makeCell(uint32_t din, CaloSubdetectorGeometry* geom) const {
+  const double EBradius = 143.0;  // cm
+  const double HOradius = 406.0 + 1.0;
+  const double EEz = 320.0;  // rough (cm)
+  const double HEz = 568.0;  // back (cm)
   const double HFz = 1100.0;
   const double HFthick = 165;
   // Tower 17 is the last EB tower
@@ -61,79 +63,78 @@ CaloTowerHardcodeGeometryLoader::makeCell( uint32_t din,
   CaloTowerDetId id = m_limits->detIdFromDenseIndex(din);
   int ieta = id.ieta();
   int iphi = id.iphi();
-  
+
   //use CT topology to get proper ieta for hcal
-  int etaRing=m_limits->convertCTtoHcal(abs(ieta));
-  int sign=(ieta>0)?(1):(-1);
+  int etaRing = m_limits->convertCTtoHcal(abs(ieta));
+  int sign = (ieta > 0) ? (1) : (-1);
   double eta1, eta2;
 
 #ifdef DebugLog
-  std::cout << "CaloTowerHardcodeGeometryLoader: ieta = " << ieta << ", iphi = " << iphi << ", etaRing = " << etaRing << std::endl;
+  std::cout << "CaloTowerHardcodeGeometryLoader: ieta = " << ieta << ", iphi = " << iphi << ", etaRing = " << etaRing
+            << std::endl;
 #endif
 
-  if (abs(ieta)>m_limits->lastHERing()) {
-    eta1 = theHFEtaBounds.at(etaRing-m_hcaltopo->firstHFRing());
-    eta2 = theHFEtaBounds.at(etaRing-m_hcaltopo->firstHFRing()+1);
+  if (abs(ieta) > m_limits->lastHERing()) {
+    eta1 = theHFEtaBounds.at(etaRing - m_hcaltopo->firstHFRing());
+    eta2 = theHFEtaBounds.at(etaRing - m_hcaltopo->firstHFRing() + 1);
   } else {
-    eta1 = theHBHEEtaBounds.at(etaRing-1);
+    eta1 = theHBHEEtaBounds.at(etaRing - 1);
     eta2 = theHBHEEtaBounds.at(etaRing);
   }
-  double eta = 0.5*(eta1+eta2);
-  double deta = (eta2-eta1);  
+  double eta = 0.5 * (eta1 + eta2);
+  double deta = (eta2 - eta1);
 
   // in radians
-  double dphi_nominal = 2.0*M_PI / m_hcaltopo->nPhiBins(1); // always the same
-  double dphi_half = M_PI / m_hcaltopo->nPhiBins(etaRing); // half-width
-  
-  double phi_low = dphi_nominal*(iphi-1); // low-edge boundaries are constant...
-  double phi = phi_low+dphi_half;
+  double dphi_nominal = 2.0 * M_PI / m_hcaltopo->nPhiBins(1);  // always the same
+  double dphi_half = M_PI / m_hcaltopo->nPhiBins(etaRing);     // half-width
+
+  double phi_low = dphi_nominal * (iphi - 1);  // low-edge boundaries are constant...
+  double phi = phi_low + dphi_half;
 
 #ifdef DebugLog
-  std::cout << "CaloTowerHardcodeGeometryLoader: eta1 = " << eta1 << ", eta2 = " << eta2 <<", eta = " << eta << ", phi = " << phi << std::endl;
+  std::cout << "CaloTowerHardcodeGeometryLoader: eta1 = " << eta1 << ", eta2 = " << eta2 << ", eta = " << eta
+            << ", phi = " << phi << std::endl;
 #endif
 
-  double x,y,z,thickness;
-  bool alongZ=true;
-  if (abs(ieta)>m_limits->lastHERing()) { // forward
-    z=HFz;
-    double r=z/sinh(eta);
-    x=r * cos(phi);
-    y=r * sin(phi);
-    thickness=HFthick/tanh(eta);
-  } else if (abs(ieta)>m_limits->firstHERing()+1) { // EE-containing
-    z=EEz;
-    double r=z/sinh(eta);
-    x=r * cos(phi);
-    y=r * sin(phi);
-    thickness=(HEz-EEz)/tanh(eta);
-  } else { // EB-containing
-    x=EBradius * cos(phi);
-    y=EBradius * sin(phi);
-    alongZ=false;
-    z=EBradius * sinh(eta);
-    thickness=(HOradius-EBradius) * cosh(eta);
+  double x, y, z, thickness;
+  bool alongZ = true;
+  if (abs(ieta) > m_limits->lastHERing()) {  // forward
+    z = HFz;
+    double r = z / sinh(eta);
+    x = r * cos(phi);
+    y = r * sin(phi);
+    thickness = HFthick / tanh(eta);
+  } else if (abs(ieta) > m_limits->firstHERing() + 1) {  // EE-containing
+    z = EEz;
+    double r = z / sinh(eta);
+    x = r * cos(phi);
+    y = r * sin(phi);
+    thickness = (HEz - EEz) / tanh(eta);
+  } else {  // EB-containing
+    x = EBradius * cos(phi);
+    y = EBradius * sin(phi);
+    alongZ = false;
+    z = EBradius * sinh(eta);
+    thickness = (HOradius - EBradius) * cosh(eta);
   }
 
-  z*=sign;
-  GlobalPoint point(x,y,z);
+  z *= sign;
+  GlobalPoint point(x, y, z);
 
-  const double mysign ( !alongZ ? 1 : -1 ) ;
-  std::vector<CCGFloat> hh ;
-  hh.reserve(5) ;
-  hh.emplace_back( deta/2 ) ;
-  hh.emplace_back( dphi_half ) ;
-  hh.emplace_back( mysign*thickness/2. ) ;
+  const double mysign(!alongZ ? 1 : -1);
+  std::vector<CCGFloat> hh;
+  hh.reserve(5);
+  hh.emplace_back(deta / 2);
+  hh.emplace_back(dphi_half);
+  hh.emplace_back(mysign * thickness / 2.);
 
-  hh.emplace_back( fabs( eta ) ) ;
-  hh.emplace_back( fabs( z ) ) ;
+  hh.emplace_back(fabs(eta));
+  hh.emplace_back(fabs(z));
 
 #ifdef DebugLog
-  std::cout << "CaloTowerHardcodeGeometryLoader: x = " << x << ", y = " << y << ", z = " << z << ", thickness = " << thickness << std::endl;
+  std::cout << "CaloTowerHardcodeGeometryLoader: x = " << x << ", y = " << y << ", z = " << z
+            << ", thickness = " << thickness << std::endl;
 #endif
 
-  geom->newCell( point, point, point,
-		 CaloCellGeometry::getParmPtr( hh, 
-					       geom->parMgr(), 
-					       geom->parVecVec() ),
-		 id ) ;
+  geom->newCell(point, point, point, CaloCellGeometry::getParmPtr(hh, geom->parMgr(), geom->parVecVec()), id);
 }

--- a/Geometry/HcalTowerAlgo/src/HcalDDDGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalDDDGeometry.cc
@@ -8,134 +8,115 @@
 static std::mutex s_fillLock;
 
 HcalDDDGeometry::HcalDDDGeometry(const HcalTopology& topo)
-  : topo_(topo),
-    etaMax_(0),
-    m_hbCellVec ( topo.getHBSize() ) ,
-    m_heCellVec ( topo.getHESize() ) ,
-    m_hoCellVec ( topo.getHOSize() ) ,
-    m_hfCellVec ( topo.getHFSize() ) ,
-    m_filledDetIds(false)
-{
-}
+    : topo_(topo),
+      etaMax_(0),
+      m_hbCellVec(topo.getHBSize()),
+      m_heCellVec(topo.getHESize()),
+      m_hoCellVec(topo.getHOSize()),
+      m_hfCellVec(topo.getHFSize()),
+      m_filledDetIds(false) {}
 
-HcalDDDGeometry::~HcalDDDGeometry()
-{
-}
+HcalDDDGeometry::~HcalDDDGeometry() {}
 
-void
-HcalDDDGeometry::fillDetIds() const
-{
-   std::lock_guard<std::mutex> guard(s_fillLock);
-   if (m_filledDetIds) {
-     //another thread already did the work
-     return;
-   }
-   const std::vector<DetId>& baseIds ( CaloSubdetectorGeometry::getValidDetIds() ) ;
-   for( unsigned int i ( 0 ) ; i != baseIds.size() ; ++i ) 
-   {
-      const DetId id ( baseIds[i] );
-      if( id.subdetId() == HcalBarrel )
-      { 
-	 m_hbIds.emplace_back( id ) ;
+void HcalDDDGeometry::fillDetIds() const {
+  std::lock_guard<std::mutex> guard(s_fillLock);
+  if (m_filledDetIds) {
+    //another thread already did the work
+    return;
+  }
+  const std::vector<DetId>& baseIds(CaloSubdetectorGeometry::getValidDetIds());
+  for (unsigned int i(0); i != baseIds.size(); ++i) {
+    const DetId id(baseIds[i]);
+    if (id.subdetId() == HcalBarrel) {
+      m_hbIds.emplace_back(id);
+    } else {
+      if (id.subdetId() == HcalEndcap) {
+        m_heIds.emplace_back(id);
+      } else {
+        if (id.subdetId() == HcalOuter) {
+          m_hoIds.emplace_back(id);
+        } else {
+          if (id.subdetId() == HcalForward) {
+            m_hfIds.emplace_back(id);
+          }
+        }
       }
-      else
-      {
-	 if( id.subdetId() == HcalEndcap )
-	 { 
-	    m_heIds.emplace_back( id ) ;
-	 }
-	 else
-	 {
-	    if( id.subdetId() == HcalOuter )
-	    { 
-	       m_hoIds.emplace_back( id ) ;
-	    }
-	    else
-	    {
-	       if( id.subdetId() == HcalForward )
-	       { 
-		  m_hfIds.emplace_back( id ) ;
-	       }
-	    }
-	 }
-      }
-   }
-   std::sort( m_hbIds.begin(), m_hbIds.end() ) ;
-   std::sort( m_heIds.begin(), m_heIds.end() ) ;
-   std::sort( m_hoIds.begin(), m_hoIds.end() ) ;
-   std::sort( m_hfIds.begin(), m_hfIds.end() ) ;
-       
-   m_emptyIds.resize( 0 ) ;
-   m_filledDetIds = true;
+    }
+  }
+  std::sort(m_hbIds.begin(), m_hbIds.end());
+  std::sort(m_heIds.begin(), m_heIds.end());
+  std::sort(m_hoIds.begin(), m_hoIds.end());
+  std::sort(m_hfIds.begin(), m_hfIds.end());
+
+  m_emptyIds.resize(0);
+  m_filledDetIds = true;
 }
 
-std::vector<DetId> const &
-HcalDDDGeometry::getValidDetIds(DetId::Detector det,
-				int subdet) const
-{
-  if( 0 != subdet &&
-      not m_filledDetIds ) fillDetIds() ;
-  return ( 0 == subdet ? CaloSubdetectorGeometry::getValidDetIds() :
-	   ( HcalBarrel == subdet ? m_hbIds :
-	     ( HcalEndcap == subdet ? m_heIds :
-	       ( HcalOuter == subdet ? m_hoIds :
-		 ( HcalForward == subdet ? m_hfIds : m_emptyIds ) ) ) ) ) ;
+std::vector<DetId> const& HcalDDDGeometry::getValidDetIds(DetId::Detector det, int subdet) const {
+  if (0 != subdet && not m_filledDetIds)
+    fillDetIds();
+  return (0 == subdet
+              ? CaloSubdetectorGeometry::getValidDetIds()
+              : (HcalBarrel == subdet
+                     ? m_hbIds
+                     : (HcalEndcap == subdet
+                            ? m_heIds
+                            : (HcalOuter == subdet ? m_hoIds : (HcalForward == subdet ? m_hfIds : m_emptyIds)))));
 }
 
-DetId
-HcalDDDGeometry::getClosestCell(const GlobalPoint& r) const {
-  constexpr double twopi = M_PI+M_PI;
-  constexpr double deg   = M_PI/180.;
+DetId HcalDDDGeometry::getClosestCell(const GlobalPoint& r) const {
+  constexpr double twopi = M_PI + M_PI;
+  constexpr double deg = M_PI / 180.;
 
   // Now find the closest eta_bin, eta value of a bin i is average
   // of eta[i] and eta[i-1]
   double abseta = fabs(r.eta());
-  double phi    = r.phi();
-  if (phi < 0) phi += twopi;
+  double phi = r.phi();
+  if (phi < 0)
+    phi += twopi;
   double radius = r.mag();
-  double z      = fabs(r.z());
+  double z = fabs(r.z());
 
-  LogDebug("HCalGeom") << "HcalDDDGeometry::getClosestCell for eta "
-		       << r.eta() << " phi " << phi/deg << " z " << r.z()
-		       << " radius " << radius;
+  LogDebug("HCalGeom") << "HcalDDDGeometry::getClosestCell for eta " << r.eta() << " phi " << phi / deg << " z "
+                       << r.z() << " radius " << radius;
   HcalDetId bestId;
   if (abseta <= etaMax_) {
-    for (const auto & hcalCell : hcalCells_) {
-      if (abseta >=hcalCell.etaMin() && abseta <=hcalCell.etaMax()) {
-	HcalSubdetector bc = hcalCell.detType();
-	int etaring = hcalCell.etaBin();
-	int phibin  = 0;
-	if (hcalCell.unitPhi() == 4) {
-	  // rings 40 and 41 are offset wrt the other phi numbering
-	  //  1        1         1         2
-	  //  ------------------------------
-	  //  72       36        36        1
-	  phibin = static_cast<int>((phi+hcalCell.phiOffset()+
-				     0.5*hcalCell.phiBinWidth())/
-				    hcalCell.phiBinWidth());
-	  if (phibin == 0) phibin = hcalCell.nPhiBins();
-	  phibin = phibin*4 - 1; 
-	} else {
-	  phibin = static_cast<int>((phi+hcalCell.phiOffset())/
-				    hcalCell.phiBinWidth()) + 1;
-	  // convert to the convention of numbering 1,3,5, in 36 phi bins
-	  phibin = (phibin-1)*(hcalCell.unitPhi()) + 1;
-	}
+    for (const auto& hcalCell : hcalCells_) {
+      if (abseta >= hcalCell.etaMin() && abseta <= hcalCell.etaMax()) {
+        HcalSubdetector bc = hcalCell.detType();
+        int etaring = hcalCell.etaBin();
+        int phibin = 0;
+        if (hcalCell.unitPhi() == 4) {
+          // rings 40 and 41 are offset wrt the other phi numbering
+          //  1        1         1         2
+          //  ------------------------------
+          //  72       36        36        1
+          phibin =
+              static_cast<int>((phi + hcalCell.phiOffset() + 0.5 * hcalCell.phiBinWidth()) / hcalCell.phiBinWidth());
+          if (phibin == 0)
+            phibin = hcalCell.nPhiBins();
+          phibin = phibin * 4 - 1;
+        } else {
+          phibin = static_cast<int>((phi + hcalCell.phiOffset()) / hcalCell.phiBinWidth()) + 1;
+          // convert to the convention of numbering 1,3,5, in 36 phi bins
+          phibin = (phibin - 1) * (hcalCell.unitPhi()) + 1;
+        }
 
-	int dbin   = 1;
-	int etabin = (r.z() > 0) ? etaring : -etaring;
-	if (bc == HcalForward) {
-	  bestId   = HcalDetId(bc, etabin, phibin, dbin);
-	  break;
-	} else {
-	  double rz = z;
-	  if (hcalCell.depthType()) rz = radius;
-	  if (rz < hcalCell.depthMax()) {
-	    dbin   = hcalCell.depthSegment();
-	    bestId = HcalDetId(bc, etabin, phibin, dbin);
-	    break;
-	  }
-	}
+        int dbin = 1;
+        int etabin = (r.z() > 0) ? etaring : -etaring;
+        if (bc == HcalForward) {
+          bestId = HcalDetId(bc, etabin, phibin, dbin);
+          break;
+        } else {
+          double rz = z;
+          if (hcalCell.depthType())
+            rz = radius;
+          if (rz < hcalCell.depthMax()) {
+            dbin = hcalCell.depthSegment();
+            bestId = HcalDetId(bc, etabin, phibin, dbin);
+            break;
+          }
+        }
       }
     }
   }
@@ -145,105 +126,77 @@ HcalDDDGeometry::getClosestCell(const GlobalPoint& r) const {
   return bestId;
 }
 
-int
-HcalDDDGeometry::insertCell(std::vector<HcalCellType> const & cells) {
-
+int HcalDDDGeometry::insertCell(std::vector<HcalCellType> const& cells) {
   hcalCells_.insert(hcalCells_.end(), cells.begin(), cells.end());
   int num = static_cast<int>(hcalCells_.size());
-  for (const auto & cell : cells) {
-    if (cell.etaMax() > etaMax_ ) etaMax_ = cell.etaMax();
+  for (const auto& cell : cells) {
+    if (cell.etaMax() > etaMax_)
+      etaMax_ = cell.etaMax();
   }
 
-  LogDebug("HCalGeom") << "HcalDDDGeometry::insertCell " << cells.size()
-		       << " cells inserted == Total " << num
-		       << " EtaMax = " << etaMax_;
+  LogDebug("HCalGeom") << "HcalDDDGeometry::insertCell " << cells.size() << " cells inserted == Total " << num
+                       << " EtaMax = " << etaMax_;
   return num;
 }
 
-void
-HcalDDDGeometry::newCellImpl( const GlobalPoint& f1 ,
-			      const GlobalPoint& f2 ,
-			      const GlobalPoint& f3 ,
-			      const CCGFloat*    parm ,
-			      const DetId&       detId   ) 
-{
+void HcalDDDGeometry::newCellImpl(
+    const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId) {
+  assert(detId.det() == DetId::Hcal);
 
-  assert( detId.det()==DetId::Hcal );
-  
   const unsigned int din(topo_.detId2denseId(detId));
 
   HcalDetId hId(detId);
 
-  if( hId.subdet()==HcalBarrel ) {
-    m_hbCellVec[ din ] = IdealObliquePrism( f1, cornersMgr(), parm ) ;
+  if (hId.subdet() == HcalBarrel) {
+    m_hbCellVec[din] = IdealObliquePrism(f1, cornersMgr(), parm);
   } else {
-    if( hId.subdet()==HcalEndcap ) {
-      const unsigned int index ( din - m_hbCellVec.size() ) ;
-      m_heCellVec[ index ] = IdealObliquePrism( f1, cornersMgr(), parm ) ;
-    } else  {
-      if( hId.subdet()==HcalOuter )  {
-	const unsigned int index ( din 
-				   - m_hbCellVec.size() 
-				   - m_heCellVec.size() ) ;
-	m_hoCellVec[ index ] = IdealObliquePrism( f1, cornersMgr(), parm ) ;
-      } else { // assuming HcalForward here!
-	const unsigned int index ( din 
-				   - m_hbCellVec.size() 
-				   - m_heCellVec.size() 
-				   - m_hoCellVec.size() ) ;
-	m_hfCellVec[ index ] = IdealZPrism( f1, cornersMgr(), parm, hId.depth()==1 ? IdealZPrism::EM : IdealZPrism::HADR ) ;
+    if (hId.subdet() == HcalEndcap) {
+      const unsigned int index(din - m_hbCellVec.size());
+      m_heCellVec[index] = IdealObliquePrism(f1, cornersMgr(), parm);
+    } else {
+      if (hId.subdet() == HcalOuter) {
+        const unsigned int index(din - m_hbCellVec.size() - m_heCellVec.size());
+        m_hoCellVec[index] = IdealObliquePrism(f1, cornersMgr(), parm);
+      } else {  // assuming HcalForward here!
+        const unsigned int index(din - m_hbCellVec.size() - m_heCellVec.size() - m_hoCellVec.size());
+        m_hfCellVec[index] =
+            IdealZPrism(f1, cornersMgr(), parm, hId.depth() == 1 ? IdealZPrism::EM : IdealZPrism::HADR);
       }
     }
   }
 }
 
-void
-HcalDDDGeometry::newCell( const GlobalPoint& f1 ,
-			  const GlobalPoint& f2 ,
-			  const GlobalPoint& f3 ,
-			  const CCGFloat*    parm ,
-			  const DetId&       detId   )
-{
-  newCellImpl(f1,f2,f3,parm,detId);
-  addValidID( detId );
+void HcalDDDGeometry::newCell(
+    const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId) {
+  newCellImpl(f1, f2, f3, parm, detId);
+  addValidID(detId);
 }
 
-void
-HcalDDDGeometry::newCellFast( const GlobalPoint& f1 ,
-			      const GlobalPoint& f2 ,
-			      const GlobalPoint& f3 ,
-			      const CCGFloat*    parm ,
-			      const DetId&       detId   )
-{
-  newCellImpl(f1,f2,f3,parm,detId);
+void HcalDDDGeometry::newCellFast(
+    const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId) {
+  newCellImpl(f1, f2, f3, parm, detId);
   m_validIds.emplace_back(detId);
 }
 
-const CaloCellGeometry* HcalDDDGeometry::getGeometryRawPtr (uint32_t din) const {
+const CaloCellGeometry* HcalDDDGeometry::getGeometryRawPtr(uint32_t din) const {
   // Modify the RawPtr class
   const CaloCellGeometry* cell(nullptr);
   if (m_hbCellVec.size() > din) {
     cell = (&m_hbCellVec[din]);
-  } else if (m_hbCellVec.size()+m_heCellVec.size() > din) {
-    const unsigned int ind (din - m_hbCellVec.size() ) ;
+  } else if (m_hbCellVec.size() + m_heCellVec.size() > din) {
+    const unsigned int ind(din - m_hbCellVec.size());
     cell = (&m_heCellVec[ind]);
-  } else if (m_hbCellVec.size()+m_heCellVec.size()+m_hoCellVec.size() > din) {
-    const unsigned int ind (din - m_hbCellVec.size() - m_heCellVec.size());
+  } else if (m_hbCellVec.size() + m_heCellVec.size() + m_hoCellVec.size() > din) {
+    const unsigned int ind(din - m_hbCellVec.size() - m_heCellVec.size());
     cell = (&m_hoCellVec[ind]);
-  } else if (m_hbCellVec.size()+m_heCellVec.size()+m_hoCellVec.size()+
-	     m_hfCellVec.size() > din) {
-    const unsigned int ind (din - m_hbCellVec.size() - m_heCellVec.size() -
-			    m_hoCellVec.size() ) ;
+  } else if (m_hbCellVec.size() + m_heCellVec.size() + m_hoCellVec.size() + m_hfCellVec.size() > din) {
+    const unsigned int ind(din - m_hbCellVec.size() - m_heCellVec.size() - m_hoCellVec.size());
     cell = (&m_hfCellVec[ind]);
   }
-  
-  return (( nullptr == cell || nullptr == cell->param()) ? nullptr : cell ) ;
+
+  return ((nullptr == cell || nullptr == cell->param()) ? nullptr : cell);
 }
 
-void HcalDDDGeometry::increaseReserve(unsigned int extra) {
-  m_validIds.reserve(m_validIds.size()+extra);
-}
+void HcalDDDGeometry::increaseReserve(unsigned int extra) { m_validIds.reserve(m_validIds.size() + extra); }
 
-void HcalDDDGeometry::sortValidIds() {
-  std::sort(m_validIds.begin(),m_validIds.end());
-}
+void HcalDDDGeometry::sortValidIds() { std::sort(m_validIds.begin(), m_validIds.end()); }

--- a/Geometry/HcalTowerAlgo/src/HcalDDDGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalDDDGeometryLoader.cc
@@ -6,204 +6,182 @@
 #include "Geometry/CaloGeometry/interface/IdealZPrism.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include<string>
+#include <string>
 
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
 
 //#define EDM_ML_DEBUG
 
-HcalDDDGeometryLoader::HcalDDDGeometryLoader(const HcalDDDRecConstants* hcons)
-  : hcalConstants_(hcons)
-{ 
+HcalDDDGeometryLoader::HcalDDDGeometryLoader(const HcalDDDRecConstants* hcons) : hcalConstants_(hcons) {
   isBH_ = hcalConstants_->isBH();
 }
 
-HcalDDDGeometryLoader::~HcalDDDGeometryLoader() {
-}
+HcalDDDGeometryLoader::~HcalDDDGeometryLoader() {}
 
-HcalDDDGeometryLoader::ReturnType 
-HcalDDDGeometryLoader::load(const HcalTopology& topo, DetId::Detector det, int subdet) {
+HcalDDDGeometryLoader::ReturnType HcalDDDGeometryLoader::load(const HcalTopology& topo,
+                                                              DetId::Detector det,
+                                                              int subdet) {
+  HcalSubdetector hsub = static_cast<HcalSubdetector>(subdet);
 
-  HcalSubdetector  hsub        = static_cast<HcalSubdetector>(subdet);
+  HcalDDDGeometry* geom(new HcalDDDGeometry(topo));
 
-
-  HcalDDDGeometry* geom ( new HcalDDDGeometry(topo) );
-
-  if ( geom->cornersMgr() == nullptr ) {
-     const unsigned int count (hcalConstants_->numberOfCells(HcalBarrel ) +
-			       hcalConstants_->numberOfCells(HcalEndcap ) +
-			       2*hcalConstants_->numberOfCells(HcalForward) +
-			       hcalConstants_->numberOfCells(HcalOuter  ) );
-     geom->allocateCorners( count ) ;
+  if (geom->cornersMgr() == nullptr) {
+    const unsigned int count(hcalConstants_->numberOfCells(HcalBarrel) + hcalConstants_->numberOfCells(HcalEndcap) +
+                             2 * hcalConstants_->numberOfCells(HcalForward) + hcalConstants_->numberOfCells(HcalOuter));
+    geom->allocateCorners(count);
   }
 
   //  if( geom->cornersMgr() == 0 )  geom->allocateCorners( 2592 ) ;
 
-  if ( geom->parMgr()     == nullptr ) geom->allocatePar( 500, 3 ) ;
+  if (geom->parMgr() == nullptr)
+    geom->allocatePar(500, 3);
 
-  fill (hsub, geom );
+  fill(hsub, geom);
   //fast insertion of valid ids requires sort at end
   geom->sortValidIds();
-  return geom ;
+  return geom;
 }
 
-HcalDDDGeometryLoader::ReturnType 
-HcalDDDGeometryLoader::load(const HcalTopology& topo) {
+HcalDDDGeometryLoader::ReturnType HcalDDDGeometryLoader::load(const HcalTopology& topo) {
+  HcalDDDGeometry* geom(new HcalDDDGeometry(topo));
 
-  HcalDDDGeometry* geom ( new HcalDDDGeometry(topo) );
-
-  if( geom->cornersMgr() == nullptr ) {
-    const unsigned int count (hcalConstants_->numberOfCells(HcalBarrel ) +
-			      hcalConstants_->numberOfCells(HcalEndcap ) +
-			      2*hcalConstants_->numberOfCells(HcalForward) +
-			      hcalConstants_->numberOfCells(HcalOuter  ) );
-    geom->allocateCorners( count ) ;
+  if (geom->cornersMgr() == nullptr) {
+    const unsigned int count(hcalConstants_->numberOfCells(HcalBarrel) + hcalConstants_->numberOfCells(HcalEndcap) +
+                             2 * hcalConstants_->numberOfCells(HcalForward) + hcalConstants_->numberOfCells(HcalOuter));
+    geom->allocateCorners(count);
   }
-  if( geom->parMgr()     == nullptr ) geom->allocatePar( 500, 3 ) ;
-  
-  fill(HcalBarrel,  geom); 
-  fill(HcalEndcap,  geom); 
-  fill(HcalForward, geom); 
-  fill(HcalOuter,   geom);
+  if (geom->parMgr() == nullptr)
+    geom->allocatePar(500, 3);
+
+  fill(HcalBarrel, geom);
+  fill(HcalEndcap, geom);
+  fill(HcalForward, geom);
+  fill(HcalOuter, geom);
   //fast insertion of valid ids requires sort at end
   geom->sortValidIds();
-  return geom ;
+  return geom;
 }
 
-void HcalDDDGeometryLoader::fill(HcalSubdetector          subdet, 
-				 HcalDDDGeometry*         geom ) {
-
+void HcalDDDGeometryLoader::fill(HcalSubdetector subdet, HcalDDDGeometry* geom) {
   // start by making the new HcalDetIds
   std::vector<HcalCellType> hcalCells = hcalConstants_->HcalCellTypes(subdet);
   geom->insertCell(hcalCells);
 #ifdef EDM_ML_DEBUG
-  std::cout << "HcalDDDGeometryLoader::fill gets " << hcalCells.size() 
-	    << " cells for subdetector " << subdet << std::endl;
-#endif			 
+  std::cout << "HcalDDDGeometryLoader::fill gets " << hcalCells.size() << " cells for subdetector " << subdet
+            << std::endl;
+#endif
   // Make the new HcalDetIds and the cells
 
   std::vector<HcalDetId> hcalIds;
-  for (auto & hcalCell : hcalCells) {
-    int etaRing  = hcalCell.etaBin();
-    int iside    = hcalCell.zside();
+  for (auto& hcalCell : hcalCells) {
+    int etaRing = hcalCell.etaBin();
+    int iside = hcalCell.zside();
     int depthBin = hcalCell.depthSegment();
-    double dphi  = hcalCell.phiBinWidth();
-    std::vector<std::pair<int,double> > phis = hcalCell.phis();
+    double dphi = hcalCell.phiBinWidth();
+    std::vector<std::pair<int, double> > phis = hcalCell.phis();
 #ifdef EDM_ML_DEBUG
-    std::cout << "HcalDDDGeometryLoader: Subdet " << subdet << " side "
-	      << iside << " eta " << etaRing << " depth " << depthBin 
-	      << " with " << phis.size() << "modules:" << std::endl;
+    std::cout << "HcalDDDGeometryLoader: Subdet " << subdet << " side " << iside << " eta " << etaRing << " depth "
+              << depthBin << " with " << phis.size() << "modules:" << std::endl;
 #endif
     geom->increaseReserve(phis.size());
-    for (auto & phi : phis) {
+    for (auto& phi : phis) {
 #ifdef EDM_ML_DEBUG
-      std::cout << "HcalDDDGeometryLoader::fill Cell " << i << " eta " 
-		<< iside*etaRing << " phi " << phis[k].first << "("
-		<< phis[k].second/CLHEP::deg << ", " << dphi/CLHEP::deg 
-		<< ") depth " << depthBin << std::endl;
+      std::cout << "HcalDDDGeometryLoader::fill Cell " << i << " eta " << iside * etaRing << " phi " << phis[k].first
+                << "(" << phis[k].second / CLHEP::deg << ", " << dphi / CLHEP::deg << ") depth " << depthBin
+                << std::endl;
 #endif
-      HcalDetId id(subdet, iside*etaRing, phi.first, depthBin);
+      HcalDetId id(subdet, iside * etaRing, phi.first, depthBin);
       hcalIds.emplace_back(id);
-      makeCell(id,hcalCell,phi.second,dphi,geom) ;
+      makeCell(id, hcalCell, phi.second, dphi, geom);
     }
   }
-  
-  edm::LogInfo("HCalGeom") << "Number of HCAL DetIds made for " << subdet
-			   << " is " << hcalIds.size();
+
+  edm::LogInfo("HCalGeom") << "Number of HCAL DetIds made for " << subdet << " is " << hcalIds.size();
 }
 
-void HcalDDDGeometryLoader::makeCell(const HcalDetId& detId,
-				     const HcalCellType& hcalCell,
-				     double phi, double dphi,
-				     HcalDDDGeometry* geom) const {
-
+void HcalDDDGeometryLoader::makeCell(
+    const HcalDetId& detId, const HcalCellType& hcalCell, double phi, double dphi, HcalDDDGeometry* geom) const {
   // the two eta boundaries of the cell
-  double          eta1   = hcalCell.etaMin();
-  double          eta2   = hcalCell.etaMax();
+  double eta1 = hcalCell.etaMin();
+  double eta2 = hcalCell.etaMax();
   HcalSubdetector subdet = detId.subdet();
-  double          eta    = 0.5*(eta1+eta2) * detId.zside();
-  double          deta   = (eta2-eta1);
-  double          theta  = 2.0*atan(exp(-eta));
+  double eta = 0.5 * (eta1 + eta2) * detId.zside();
+  double deta = (eta2 - eta1);
+  double theta = 2.0 * atan(exp(-eta));
 
   // barrel vs forward
-  bool rzType   = hcalCell.depthType();
+  bool rzType = hcalCell.depthType();
   bool isBarrel = (subdet == HcalBarrel || subdet == HcalOuter);
 
-  double          z, r, thickness;
+  double z, r, thickness;
 #ifdef EDM_ML_DEBUG
-  double          r0, r1, r2;
+  double r0, r1, r2;
 #endif
   if (rzType) {
-    r          = hcalCell.depthMin();
+    r = hcalCell.depthMin();
     if (isBarrel) {
-      z         = r * sinh(eta); // sinh(eta) == 1/tan(theta)
-      thickness = (hcalCell.depthMax() - r) * cosh(eta); // cosh(eta) == 1/sin(theta)
+      z = r * sinh(eta);                                  // sinh(eta) == 1/tan(theta)
+      thickness = (hcalCell.depthMax() - r) * cosh(eta);  // cosh(eta) == 1/sin(theta)
 #ifdef EDM_ML_DEBUG
-      r1        = r;
-      r2        = hcalCell.depthMax();
-      r0        = 0.5*(r1+r2);
+      r1 = r;
+      r2 = hcalCell.depthMax();
+      r0 = 0.5 * (r1 + r2);
 #endif
     } else {
-      z         = r * sinh(eta2);
+      z = r * sinh(eta2);
       thickness = 2. * hcalCell.halfSize();
-      r         = z/sinh(std::abs(eta));
+      r = z / sinh(std::abs(eta));
 #ifdef EDM_ML_DEBUG
-      r0        = z/sinh(std::abs(eta));
-      r1        = z/sinh(std::abs(eta)+0.5*deta);
-      r2        = z/sinh(std::abs(eta)-0.5*deta);
+      r0 = z / sinh(std::abs(eta));
+      r1 = z / sinh(std::abs(eta) + 0.5 * deta);
+      r2 = z / sinh(std::abs(eta) - 0.5 * deta);
 #endif
     }
 #ifdef EDM_ML_DEBUG
-    std::cout << "HcalDDDGeometryLoader::makeCell SubDet " << subdet
-	      << " eta = " << eta << " theta = " << theta << " r = " << r 
-	      << " thickness = " << thickness << " r0-r2 (" << r0 << ":" 
-	      << r1 << ":" << r2 << ")" << std::endl;
+    std::cout << "HcalDDDGeometryLoader::makeCell SubDet " << subdet << " eta = " << eta << " theta = " << theta
+              << " r = " << r << " thickness = " << thickness << " r0-r2 (" << r0 << ":" << r1 << ":" << r2 << ")"
+              << std::endl;
 #endif
   } else {
-    z          = hcalCell.depthMin();
-    thickness  = hcalCell.depthMax() - z;
-    if (isBH_) z += (0.5*thickness);
-    z         *= detId.zside(); // get the sign right.
-    r          = z * tan(theta);
+    z = hcalCell.depthMin();
+    thickness = hcalCell.depthMax() - z;
+    if (isBH_)
+      z += (0.5 * thickness);
+    z *= detId.zside();  // get the sign right.
+    r = z * tan(theta);
     thickness /= std::abs(cos(theta));
 #ifdef EDM_ML_DEBUG
-    r0         = z/sinh(std::abs(eta));
-    r1         = z/sinh(std::abs(eta)+0.5*deta);
-    r2         = z/sinh(std::abs(eta)-0.5*deta);
-    std::cout << "HcalDDDGeometryLoader::makeCell SubDet " << subdet
-	      << " eta = " << eta << " theta = " << theta << " z = " << z 
-	      << " r = " << r << " thickness = " << thickness << " r0-r2 (" 
-	      << r0 << ":" << r1 << ":" << r2 << ")" << std::endl;    
+    r0 = z / sinh(std::abs(eta));
+    r1 = z / sinh(std::abs(eta) + 0.5 * deta);
+    r2 = z / sinh(std::abs(eta) - 0.5 * deta);
+    std::cout << "HcalDDDGeometryLoader::makeCell SubDet " << subdet << " eta = " << eta << " theta = " << theta
+              << " z = " << z << " r = " << r << " thickness = " << thickness << " r0-r2 (" << r0 << ":" << r1 << ":"
+              << r2 << ")" << std::endl;
 #endif
   }
 
   double x = r * cos(phi);
   double y = r * sin(phi);
-  GlobalPoint point(x,y,z);
+  GlobalPoint point(x, y, z);
 
 #ifdef EDM_ML_DEBUG
-  std::cout << "HcalDDDGeometryLoader::makeCell for " << detId << " Point " 
-	    << point << " deta = " << deta << " dphi = " << dphi 
-	    << " thickness = " << thickness << " isBarrel = " << isBarrel 
-	    << " " << rzType << std::endl;
+  std::cout << "HcalDDDGeometryLoader::makeCell for " << detId << " Point " << point << " deta = " << deta
+            << " dphi = " << dphi << " thickness = " << thickness << " isBarrel = " << isBarrel << " " << rzType
+            << std::endl;
 #endif
 
-  std::vector<CCGFloat> hp ;
-  hp.reserve(3) ;
-  
-  if (subdet==HcalForward) {
-    hp.emplace_back(deta/2.) ;
-    hp.emplace_back(dphi/2.) ;
-    hp.emplace_back(thickness/2.) ;
-  } else { 
-    const double sign ( isBarrel ? 1 : -1 ) ;
-    hp.emplace_back(deta/2.) ;
-    hp.emplace_back(dphi/2.) ;
-    hp.emplace_back(sign*thickness/2.) ;
+  std::vector<CCGFloat> hp;
+  hp.reserve(3);
+
+  if (subdet == HcalForward) {
+    hp.emplace_back(deta / 2.);
+    hp.emplace_back(dphi / 2.);
+    hp.emplace_back(thickness / 2.);
+  } else {
+    const double sign(isBarrel ? 1 : -1);
+    hp.emplace_back(deta / 2.);
+    hp.emplace_back(dphi / 2.);
+    hp.emplace_back(sign * thickness / 2.);
   }
-  geom->newCellFast( point, point, point,
-		 CaloCellGeometry::getParmPtr( hp, 
-					       geom->parMgr(), 
-					       geom->parVecVec() ),
-		 detId ) ;
+  geom->newCellFast(point, point, point, CaloCellGeometry::getParmPtr(hp, geom->parMgr(), geom->parVecVec()), detId);
 }

--- a/Geometry/HcalTowerAlgo/src/HcalFlexiHardcodeGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalFlexiHardcodeGeometryLoader.cc
@@ -17,76 +17,70 @@ using CCGFloat = CaloCellGeometry::CCGFloat;
 // ==============> Loader Itself <==========================
 
 HcalFlexiHardcodeGeometryLoader::HcalFlexiHardcodeGeometryLoader() {
-
   MAX_HCAL_PHI = 72;
   DEGREE2RAD = M_PI / 180.;
 }
 
-CaloSubdetectorGeometry* HcalFlexiHardcodeGeometryLoader::load(const HcalTopology& fTopology, const HcalDDDRecConstants& hcons) {
-  HcalGeometry* hcalGeometry = new HcalGeometry (fTopology);
-  if( nullptr == hcalGeometry->cornersMgr() ) hcalGeometry->allocateCorners ( fTopology.ncells()+fTopology.getHFSize() );
-  if( nullptr == hcalGeometry->parMgr() ) hcalGeometry->allocatePar (hcalGeometry->numberOfShapes(),
-							       HcalGeometry::k_NumberOfParametersPerShape ) ;
+CaloSubdetectorGeometry* HcalFlexiHardcodeGeometryLoader::load(const HcalTopology& fTopology,
+                                                               const HcalDDDRecConstants& hcons) {
+  HcalGeometry* hcalGeometry = new HcalGeometry(fTopology);
+  if (nullptr == hcalGeometry->cornersMgr())
+    hcalGeometry->allocateCorners(fTopology.ncells() + fTopology.getHFSize());
+  if (nullptr == hcalGeometry->parMgr())
+    hcalGeometry->allocatePar(hcalGeometry->numberOfShapes(), HcalGeometry::k_NumberOfParametersPerShape);
   isBH_ = hcons.isBH();
 #ifdef EDM_ML_DEBUG
-  std::cout << "FlexiGeometryLoader initialize with ncells "
-	    << fTopology.ncells() << " and shapes "
-	    << hcalGeometry->numberOfShapes() << ":"
-	    << HcalGeometry::k_NumberOfParametersPerShape
-	    << " with BH Flag " << isBH_ << std::endl;
+  std::cout << "FlexiGeometryLoader initialize with ncells " << fTopology.ncells() << " and shapes "
+            << hcalGeometry->numberOfShapes() << ":" << HcalGeometry::k_NumberOfParametersPerShape << " with BH Flag "
+            << isBH_ << std::endl;
 #endif
   if (fTopology.mode() == HcalTopologyMode::H2) {  // TB geometry
-    fillHBHO (hcalGeometry, makeHBCells(hcons), true);
-    fillHBHO (hcalGeometry, makeHOCells(), false);
-    fillHE (hcalGeometry, makeHECells_H2());
-  } else { // regular geometry
-    fillHBHO (hcalGeometry, makeHBCells(hcons), true);
-    fillHBHO (hcalGeometry, makeHOCells(), false);
-    fillHF (hcalGeometry, makeHFCells(hcons));
-    fillHE (hcalGeometry, makeHECells(hcons));
+    fillHBHO(hcalGeometry, makeHBCells(hcons), true);
+    fillHBHO(hcalGeometry, makeHOCells(), false);
+    fillHE(hcalGeometry, makeHECells_H2());
+  } else {  // regular geometry
+    fillHBHO(hcalGeometry, makeHBCells(hcons), true);
+    fillHBHO(hcalGeometry, makeHOCells(), false);
+    fillHF(hcalGeometry, makeHFCells(hcons));
+    fillHE(hcalGeometry, makeHECells(hcons));
   }
   //fast insertion of valid ids requires sort at end
   hcalGeometry->sortValidIds();
   return hcalGeometry;
 }
 
-
 // ----------> HB <-----------
-std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> HcalFlexiHardcodeGeometryLoader::makeHBCells (const HcalDDDRecConstants& hcons) {
-
+std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> HcalFlexiHardcodeGeometryLoader::makeHBCells(
+    const HcalDDDRecConstants& hcons) {
   std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> result;
-  std::vector<std::pair<double,double> > gconsHB = hcons.getConstHBHE(0);
+  std::vector<std::pair<double, double> > gconsHB = hcons.getConstHBHE(0);
   std::vector<HcalDDDRecConstants::HcalEtaBin> etabins = hcons.getEtaBins(0);
 
 #ifdef EDM_ML_DEBUG
-  std::cout << "FlexiGeometryLoader called for " << etabins.size()
-	    << " Eta Bins" << std::endl;
-  for (unsigned int k=0; k<gconsHB.size(); ++k) {
-    std::cout << "gconsHB[" << k << "] = " << gconsHB[k].first << " +- "
-	      << gconsHB[k].second << std::endl;
+  std::cout << "FlexiGeometryLoader called for " << etabins.size() << " Eta Bins" << std::endl;
+  for (unsigned int k = 0; k < gconsHB.size(); ++k) {
+    std::cout << "gconsHB[" << k << "] = " << gconsHB[k].first << " +- " << gconsHB[k].second << std::endl;
   }
 #endif
-  for (auto & etabin : etabins) {
+  for (auto& etabin : etabins) {
     int iring = (etabin.zside >= 0) ? etabin.ieta : -etabin.ieta;
     int depth = etabin.depthStart;
-    double dphi = (etabin.phis.size() > 1) ?
-      (etabin.phis[1].second-etabin.phis[0].second) :
-      ((2.0*M_PI)/MAX_HCAL_PHI);
-    for (unsigned int k=0; k<etabin.layer.size(); ++k) {
-      int layf = etabin.layer[k].first-1;
-      int layl = etabin.layer[k].second-1;
-      double rmin = gconsHB[layf].first-gconsHB[layf].second;
-      double rmax = gconsHB[layl].first+gconsHB[layl].second;
-      for (unsigned int j=0; j<etabin.phis.size(); ++j) {
+    double dphi =
+        (etabin.phis.size() > 1) ? (etabin.phis[1].second - etabin.phis[0].second) : ((2.0 * M_PI) / MAX_HCAL_PHI);
+    for (unsigned int k = 0; k < etabin.layer.size(); ++k) {
+      int layf = etabin.layer[k].first - 1;
+      int layl = etabin.layer[k].second - 1;
+      double rmin = gconsHB[layf].first - gconsHB[layf].second;
+      double rmax = gconsHB[layl].first + gconsHB[layl].second;
+      for (unsigned int j = 0; j < etabin.phis.size(); ++j) {
 #ifdef EDM_ML_DEBUG
-	std::cout << "HBRing " << iring << " eta " << etabin.etaMin << ":"
-		  << etabin.etaMax << " depth " << depth << " R " << rmin
-		  << ":" << rmax << " Phi " << etabin.phis[j].first << ":"
-		  << etabin.phis[j].second << ":" << dphi << " layer[" << k
-		  << "]: " << etabin.layer[k].first-1 << ":"
-		  << etabin.layer[k].second << std::endl;
+        std::cout << "HBRing " << iring << " eta " << etabin.etaMin << ":" << etabin.etaMax << " depth " << depth
+                  << " R " << rmin << ":" << rmax << " Phi " << etabin.phis[j].first << ":" << etabin.phis[j].second
+                  << ":" << dphi << " layer[" << k << "]: " << etabin.layer[k].first - 1 << ":"
+                  << etabin.layer[k].second << std::endl;
 #endif
-	result.emplace_back (HcalFlexiHardcodeGeometryLoader::HBHOCellParameters(iring, depth, etabin.phis[j].first, etabin.phis[j].second, dphi, rmin, rmax, etabin.etaMin, etabin.etaMax));
+        result.emplace_back(HcalFlexiHardcodeGeometryLoader::HBHOCellParameters(
+            iring, depth, etabin.phis[j].first, etabin.phis[j].second, dphi, rmin, rmax, etabin.etaMin, etabin.etaMax));
       }
       depth++;
     }
@@ -94,178 +88,159 @@ std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> HcalFlexiHardco
   return result;
 }
 
-
 // ----------> HO <-----------
-std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> HcalFlexiHardcodeGeometryLoader::makeHOCells () {
+std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> HcalFlexiHardcodeGeometryLoader::makeHOCells() {
   const double HORMIN0 = 390.0;
   const double HORMIN1 = 412.6;
-  const double HORMAX  = 413.6;
-  const int    nCells  = 15;
-  const int    nPhi    = 72;
-  const double etamin[nCells] = {0.000,0.087,0.174, 0.261, 0.3395,0.435,0.522,
-				 0.609,0.696,0.783, 0.873, 0.957, 1.044,1.131,
-				 1.218};
-  const double etamax[nCells] = {0.087,0.174,0.261, 0.3075,0.435, 0.522,0.609,
-				 0.696,0.783,0.8494,0.957, 1.044, 1.131,1.218,
-				 1.305};
+  const double HORMAX = 413.6;
+  const int nCells = 15;
+  const int nPhi = 72;
+  const double etamin[nCells] = {
+      0.000, 0.087, 0.174, 0.261, 0.3395, 0.435, 0.522, 0.609, 0.696, 0.783, 0.873, 0.957, 1.044, 1.131, 1.218};
+  const double etamax[nCells] = {
+      0.087, 0.174, 0.261, 0.3075, 0.435, 0.522, 0.609, 0.696, 0.783, 0.8494, 0.957, 1.044, 1.131, 1.218, 1.305};
   std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters> result;
-  result.reserve (nCells*nPhi);
-  double dphi = ((2.0*M_PI)/nPhi);
+  result.reserve(nCells * nPhi);
+  double dphi = ((2.0 * M_PI) / nPhi);
   for (int i = 0; i < nCells; ++i) {
     double rmin = ((i < 4) ? HORMIN0 : HORMIN1);
     for (int iside = -1; iside <= 1; iside += 2) {
-      for (int j=0; j < nPhi; ++j) {
-	double phi = (j+0.5)*dphi;
-	// eta, depth, phi, phi0, deltaPhi, rMin, rMax, etaMin, etaMax
-	result.emplace_back (HcalFlexiHardcodeGeometryLoader::HBHOCellParameters(iside*(i+1), 4, j+1, phi, dphi, rmin, HORMAX, etamin[i], etamax[i]));
+      for (int j = 0; j < nPhi; ++j) {
+        double phi = (j + 0.5) * dphi;
+        // eta, depth, phi, phi0, deltaPhi, rMin, rMax, etaMin, etaMax
+        result.emplace_back(HcalFlexiHardcodeGeometryLoader::HBHOCellParameters(
+            iside * (i + 1), 4, j + 1, phi, dphi, rmin, HORMAX, etamin[i], etamax[i]));
       }
     }
   }
   return result;
 }
 
-
 //
 // Convert constants to appropriate cells
 //
-void HcalFlexiHardcodeGeometryLoader::fillHBHO (HcalGeometry* fGeometry, const std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters>& fCells, bool fHB) {
-
+void HcalFlexiHardcodeGeometryLoader::fillHBHO(
+    HcalGeometry* fGeometry, const std::vector<HcalFlexiHardcodeGeometryLoader::HBHOCellParameters>& fCells, bool fHB) {
   fGeometry->increaseReserve(fCells.size());
-  for (const auto & param : fCells) {
-    HcalDetId hid (fHB ? HcalBarrel : HcalOuter, param.ieta, param.iphi, param.depth);
-    float phiCenter = param.phi; // middle of the cell
-    float etaCenter = 0.5*(param.etaMin + param.etaMax);
-    float x = param.rMin* cos (phiCenter);
-    float y = param.rMin* sin (phiCenter);
-    float z = (param.ieta < 0) ? -(param.rMin*sinh(etaCenter)) : (param.rMin*sinh(etaCenter));
+  for (const auto& param : fCells) {
+    HcalDetId hid(fHB ? HcalBarrel : HcalOuter, param.ieta, param.iphi, param.depth);
+    float phiCenter = param.phi;  // middle of the cell
+    float etaCenter = 0.5 * (param.etaMin + param.etaMax);
+    float x = param.rMin * cos(phiCenter);
+    float y = param.rMin * sin(phiCenter);
+    float z = (param.ieta < 0) ? -(param.rMin * sinh(etaCenter)) : (param.rMin * sinh(etaCenter));
     // make cell geometry
-    GlobalPoint refPoint (x,y,z); // center of the cell's face
+    GlobalPoint refPoint(x, y, z);  // center of the cell's face
     std::vector<CCGFloat> cellParams;
-    cellParams.reserve (5);
-    cellParams.emplace_back (0.5 * (param.etaMax - param.etaMin)); // deta_half
-    cellParams.emplace_back (0.5 * param.dphi);                    // dphi_half
-    cellParams.emplace_back (0.5 * (param.rMax - param.rMin) * cosh (etaCenter)); // dr_half
-    cellParams.emplace_back ( fabs( refPoint.eta() ) ) ;
-    cellParams.emplace_back ( fabs( refPoint.z() ) ) ;
+    cellParams.reserve(5);
+    cellParams.emplace_back(0.5 * (param.etaMax - param.etaMin));                // deta_half
+    cellParams.emplace_back(0.5 * param.dphi);                                   // dphi_half
+    cellParams.emplace_back(0.5 * (param.rMax - param.rMin) * cosh(etaCenter));  // dr_half
+    cellParams.emplace_back(fabs(refPoint.eta()));
+    cellParams.emplace_back(fabs(refPoint.z()));
 #ifdef EDM_ML_DEBUG
-    std::cout << "HcalFlexiHardcodeGeometryLoader::fillHBHO-> " << hid
-	      << " " << hid.rawId() << " " << std::hex << hid.rawId()
-	      << std::dec << " " << hid << " " << refPoint << '/'
-	      << cellParams [0] << '/' << cellParams [1] << '/'
-	      << cellParams [2] << std::endl;
+    std::cout << "HcalFlexiHardcodeGeometryLoader::fillHBHO-> " << hid << " " << hid.rawId() << " " << std::hex
+              << hid.rawId() << std::dec << " " << hid << " " << refPoint << '/' << cellParams[0] << '/'
+              << cellParams[1] << '/' << cellParams[2] << std::endl;
 #endif
-    fGeometry->newCellFast(refPoint,  refPoint,  refPoint,
-		       CaloCellGeometry::getParmPtr(cellParams,
-						    fGeometry->parMgr(),
-						    fGeometry->parVecVec()),
-		       hid ) ;
+    fGeometry->newCellFast(refPoint,
+                           refPoint,
+                           refPoint,
+                           CaloCellGeometry::getParmPtr(cellParams, fGeometry->parMgr(), fGeometry->parVecVec()),
+                           hid);
   }
 }
 
-
 // ----------> HE <-----------
-std::vector<HcalFlexiHardcodeGeometryLoader::HECellParameters> HcalFlexiHardcodeGeometryLoader::makeHECells (const HcalDDDRecConstants& hcons) {
-
+std::vector<HcalFlexiHardcodeGeometryLoader::HECellParameters> HcalFlexiHardcodeGeometryLoader::makeHECells(
+    const HcalDDDRecConstants& hcons) {
   std::vector<HcalFlexiHardcodeGeometryLoader::HECellParameters> result;
-  std::vector<std::pair<double,double> > gconsHE = hcons.getConstHBHE(1);
+  std::vector<std::pair<double, double> > gconsHE = hcons.getConstHBHE(1);
 #ifdef EDM_ML_DEBUG
-  std::cout << "HcalFlexiHardcodeGeometryLoader:HE with " << gconsHE.size()
-	    << " cells" << std::endl;
+  std::cout << "HcalFlexiHardcodeGeometryLoader:HE with " << gconsHE.size() << " cells" << std::endl;
 #endif
   if (!gconsHE.empty()) {
     std::vector<HcalDDDRecConstants::HcalEtaBin> etabins = hcons.getEtaBins(1);
 
 #ifdef EDM_ML_DEBUG
-    std::cout << "FlexiGeometryLoader called for HE with " << etabins.size()
-	      << " Eta Bins and " << gconsHE.size() << " depths"
-	      << std::endl;
-    for (unsigned int i=0; i<gconsHE.size(); ++i)
-      std::cout << " Depth[" << i << "] = " << gconsHE[i].first << " +- "
-		<< gconsHE[i].second;
+    std::cout << "FlexiGeometryLoader called for HE with " << etabins.size() << " Eta Bins and " << gconsHE.size()
+              << " depths" << std::endl;
+    for (unsigned int i = 0; i < gconsHE.size(); ++i)
+      std::cout << " Depth[" << i << "] = " << gconsHE[i].first << " +- " << gconsHE[i].second;
     std::cout << std::endl;
 #endif
-    for (auto & etabin : etabins) {
-      int    iring = (etabin.zside >= 0) ? etabin.ieta : -etabin.ieta;
-      int    depth = etabin.depthStart;
-      double dphi = (etabin.phis.size() > 1) ?
-	(etabin.phis[1].second-etabin.phis[0].second) :
-	((2.0*M_PI)/MAX_HCAL_PHI);
+    for (auto& etabin : etabins) {
+      int iring = (etabin.zside >= 0) ? etabin.ieta : -etabin.ieta;
+      int depth = etabin.depthStart;
+      double dphi =
+          (etabin.phis.size() > 1) ? (etabin.phis[1].second - etabin.phis[0].second) : ((2.0 * M_PI) / MAX_HCAL_PHI);
 #ifdef EDM_ML_DEBUG
-      std::cout << "FlexiGeometryLoader::Ring " << iring << " nphi "
-		<< etabin.phis.size() << " dstart " << depth << " dphi "
-		<< dphi << " layers "<< etabin.layer.size() << std::endl;
-      for (unsigned int j=0; j<etabin.phis.size(); ++j)
-	std::cout << " [" << j << "] " << etabin.phis[j].first << ":"
-		  << etabin.phis[j].second;
+      std::cout << "FlexiGeometryLoader::Ring " << iring << " nphi " << etabin.phis.size() << " dstart " << depth
+                << " dphi " << dphi << " layers " << etabin.layer.size() << std::endl;
+      for (unsigned int j = 0; j < etabin.phis.size(); ++j)
+        std::cout << " [" << j << "] " << etabin.phis[j].first << ":" << etabin.phis[j].second;
       std::cout << std::endl;
 #endif
-      for (unsigned int k=0; k<etabin.layer.size(); ++k) {
-	int layf = etabin.layer[k].first-1;
-	int layl = etabin.layer[k].second-1;
-	double zmin = gconsHE[layf].first-gconsHE[layf].second;
-	double zmax = gconsHE[layl].first+gconsHE[layl].second;
-	if (zmin < 1.0) {
-	  for (int k2=layf; k2<=layl; ++k2) {
-	    if (gconsHE[k2].first > 10) {
-	      zmin = gconsHE[k2].first-gconsHE[k2].second;
-	      break;
-	    }
-	  }
-	}
-	if (zmin >= zmax) zmax = zmin+10.;
-	for (unsigned int j=0; j<etabin.phis.size(); ++j) {
+      for (unsigned int k = 0; k < etabin.layer.size(); ++k) {
+        int layf = etabin.layer[k].first - 1;
+        int layl = etabin.layer[k].second - 1;
+        double zmin = gconsHE[layf].first - gconsHE[layf].second;
+        double zmax = gconsHE[layl].first + gconsHE[layl].second;
+        if (zmin < 1.0) {
+          for (int k2 = layf; k2 <= layl; ++k2) {
+            if (gconsHE[k2].first > 10) {
+              zmin = gconsHE[k2].first - gconsHE[k2].second;
+              break;
+            }
+          }
+        }
+        if (zmin >= zmax)
+          zmax = zmin + 10.;
+        for (unsigned int j = 0; j < etabin.phis.size(); ++j) {
 #ifdef EDM_ML_DEBUG
-	  std::cout << "HERing " << iring << " eta " << etabin.etaMin << ":"
-		    << etabin.etaMax << " depth " << depth << " Z " << zmin
-		    << ":" << zmax << " Phi :" << etabin.phis[j].first
-		    << ":" << etabin.phis[j].second << ":" << dphi
-		    << " layer[" << k << "]: " << etabin.layer[k].first-1
-		    << ":" << etabin.layer[k].second-1 << std::endl;
+          std::cout << "HERing " << iring << " eta " << etabin.etaMin << ":" << etabin.etaMax << " depth " << depth
+                    << " Z " << zmin << ":" << zmax << " Phi :" << etabin.phis[j].first << ":" << etabin.phis[j].second
+                    << ":" << dphi << " layer[" << k << "]: " << etabin.layer[k].first - 1 << ":"
+                    << etabin.layer[k].second - 1 << std::endl;
 #endif
-	  result.emplace_back(HcalFlexiHardcodeGeometryLoader::HECellParameters(iring, depth, etabin.phis[j].first, etabin.phis[j].second, dphi, zmin, zmax, etabin.etaMin, etabin.etaMax));
-	}
-	depth++;
+          result.emplace_back(HcalFlexiHardcodeGeometryLoader::HECellParameters(
+              iring, depth, etabin.phis[j].first, etabin.phis[j].second, dphi, zmin, zmax, etabin.etaMin, etabin.etaMax));
+        }
+        depth++;
       }
     }
   }
   return result;
 }
 
-
 // ----------> HE @ H2 <-----------
-std::vector <HcalFlexiHardcodeGeometryLoader::HECellParameters> HcalFlexiHardcodeGeometryLoader::makeHECells_H2 () {
-
+std::vector<HcalFlexiHardcodeGeometryLoader::HECellParameters> HcalFlexiHardcodeGeometryLoader::makeHECells_H2() {
   const double HEZMIN_H2 = 400.715;
   const double HEZMID_H2 = 436.285;
   const double HEZMAX_H2 = 541.885;
-  const int    nEtas = 10;
-  const int    nDepth[nEtas] = {1,2,2,2,2,2,2,2,3,3};
-  const int    dStart[nEtas] = {3,1,1,1,1,1,1,1,1,1};
-  const int    nPhis[nEtas]  = {8,8,8,8,8,8,4,4,4,4};
-  const double etas[nEtas+1] = {1.305,1.373,1.444,1.521,1.603,1.693,1.790,
-				1.880,1.980,2.090,2.210};
-  const double zval[4*nEtas] = {409.885,462.685,0.,0.,
-				HEZMIN_H2,427.485,506.685,0.0,
-				HEZMIN_H2,HEZMID_H2,524.285,0.,
-				HEZMIN_H2,HEZMID_H2,HEZMAX_H2,0.,
-				HEZMIN_H2,HEZMID_H2,HEZMAX_H2,0.,
-				HEZMIN_H2,HEZMID_H2,HEZMAX_H2,0.,
-				HEZMIN_H2,HEZMID_H2,HEZMAX_H2,0.,
-				HEZMIN_H2,HEZMID_H2,HEZMAX_H2,0.,
-				HEZMIN_H2,418.685,HEZMID_H2,HEZMAX_H2,
-				HEZMIN_H2,418.685,HEZMID_H2,HEZMAX_H2};
+  const int nEtas = 10;
+  const int nDepth[nEtas] = {1, 2, 2, 2, 2, 2, 2, 2, 3, 3};
+  const int dStart[nEtas] = {3, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  const int nPhis[nEtas] = {8, 8, 8, 8, 8, 8, 4, 4, 4, 4};
+  const double etas[nEtas + 1] = {1.305, 1.373, 1.444, 1.521, 1.603, 1.693, 1.790, 1.880, 1.980, 2.090, 2.210};
+  const double zval[4 * nEtas] = {
+      409.885,   462.685,   0.,        0.,        HEZMIN_H2, 427.485,   506.685,   0.0,       HEZMIN_H2, HEZMID_H2,
+      524.285,   0.,        HEZMIN_H2, HEZMID_H2, HEZMAX_H2, 0.,        HEZMIN_H2, HEZMID_H2, HEZMAX_H2, 0.,
+      HEZMIN_H2, HEZMID_H2, HEZMAX_H2, 0.,        HEZMIN_H2, HEZMID_H2, HEZMAX_H2, 0.,        HEZMIN_H2, HEZMID_H2,
+      HEZMAX_H2, 0.,        HEZMIN_H2, 418.685,   HEZMID_H2, HEZMAX_H2, HEZMIN_H2, 418.685,   HEZMID_H2, HEZMAX_H2};
   std::vector<HcalFlexiHardcodeGeometryLoader::HECellParameters> result;
 
   for (int i = 0; i < nEtas; ++i) {
-    int ieta = 16+i;
-    for (int k=0; k<nDepth[i]; ++k) {
-      int depth = dStart[i]+k;
-      for (int j=0; j < nPhis[i]; ++j) {
-	int    iphi = (nPhis[i] == 8) ? (j+1) : (2*j+1);
-	double dphi = (40.0*DEGREE2RAD)/nPhis[i];
-	double phi0 = (j+0.5)*dphi;
-	// ieta, depth, iphi, phi0, deltaPhi, zMin, zMax, etaMin, etaMax
-	result.emplace_back (HcalFlexiHardcodeGeometryLoader::HECellParameters(ieta, depth, iphi, phi0, dphi, zval[4*i+k+1], zval[4*i+k+2], etas[i], etas[i+1]));
+    int ieta = 16 + i;
+    for (int k = 0; k < nDepth[i]; ++k) {
+      int depth = dStart[i] + k;
+      for (int j = 0; j < nPhis[i]; ++j) {
+        int iphi = (nPhis[i] == 8) ? (j + 1) : (2 * j + 1);
+        double dphi = (40.0 * DEGREE2RAD) / nPhis[i];
+        double phi0 = (j + 0.5) * dphi;
+        // ieta, depth, iphi, phi0, deltaPhi, zMin, zMax, etaMin, etaMax
+        result.emplace_back(HcalFlexiHardcodeGeometryLoader::HECellParameters(
+            ieta, depth, iphi, phi0, dphi, zval[4 * i + k + 1], zval[4 * i + k + 2], etas[i], etas[i + 1]));
       }
     }
   }
@@ -273,98 +248,114 @@ std::vector <HcalFlexiHardcodeGeometryLoader::HECellParameters> HcalFlexiHardcod
 }
 
 // ----------> HF <-----------
-std::vector <HcalFlexiHardcodeGeometryLoader::HFCellParameters> HcalFlexiHardcodeGeometryLoader::makeHFCells (const HcalDDDRecConstants& hcons) {
-
+std::vector<HcalFlexiHardcodeGeometryLoader::HFCellParameters> HcalFlexiHardcodeGeometryLoader::makeHFCells(
+    const HcalDDDRecConstants& hcons) {
   const float HFZMIN1 = 1115.;
   const float HFZMIN2 = 1137.;
   const float HFZMAX = 1280.1;
   std::vector<HcalDDDRecConstants::HFCellParameters> cells = hcons.getHFCellParameters();
   unsigned int nCells = cells.size();
-  std::vector <HcalFlexiHardcodeGeometryLoader::HFCellParameters> result;
-  result.reserve (nCells);
+  std::vector<HcalFlexiHardcodeGeometryLoader::HFCellParameters> result;
+  result.reserve(nCells);
   for (unsigned int i = 0; i < nCells; ++i) {
-    HcalFlexiHardcodeGeometryLoader::HFCellParameters cell1(cells[i].ieta,cells[i].depth,cells[i].firstPhi,cells[i].stepPhi,cells[i].nPhi,5*cells[i].stepPhi,HFZMIN1,HFZMAX,cells[i].rMin,cells[i].rMax);
-    result.emplace_back (cell1);
-    HcalFlexiHardcodeGeometryLoader::HFCellParameters cell2(cells[i].ieta,1+cells[i].depth,cells[i].firstPhi,cells[i].stepPhi,cells[i].nPhi,5*cells[i].stepPhi,HFZMIN2,HFZMAX,cells[i].rMin,cells[i].rMax);
-    result.emplace_back (cell2);
+    HcalFlexiHardcodeGeometryLoader::HFCellParameters cell1(cells[i].ieta,
+                                                            cells[i].depth,
+                                                            cells[i].firstPhi,
+                                                            cells[i].stepPhi,
+                                                            cells[i].nPhi,
+                                                            5 * cells[i].stepPhi,
+                                                            HFZMIN1,
+                                                            HFZMAX,
+                                                            cells[i].rMin,
+                                                            cells[i].rMax);
+    result.emplace_back(cell1);
+    HcalFlexiHardcodeGeometryLoader::HFCellParameters cell2(cells[i].ieta,
+                                                            1 + cells[i].depth,
+                                                            cells[i].firstPhi,
+                                                            cells[i].stepPhi,
+                                                            cells[i].nPhi,
+                                                            5 * cells[i].stepPhi,
+                                                            HFZMIN2,
+                                                            HFZMAX,
+                                                            cells[i].rMin,
+                                                            cells[i].rMax);
+    result.emplace_back(cell2);
   }
   return result;
 }
 
-void HcalFlexiHardcodeGeometryLoader::fillHE (HcalGeometry* fGeometry, const std::vector <HcalFlexiHardcodeGeometryLoader::HECellParameters>& fCells) {
-
+void HcalFlexiHardcodeGeometryLoader::fillHE(
+    HcalGeometry* fGeometry, const std::vector<HcalFlexiHardcodeGeometryLoader::HECellParameters>& fCells) {
   fGeometry->increaseReserve(fCells.size());
-  for (const auto & param : fCells) {
-    HcalDetId hid (HcalEndcap, param.ieta, param.iphi, param.depth);
-    float phiCenter = param.phi; // middle of the cell
+  for (const auto& param : fCells) {
+    HcalDetId hid(HcalEndcap, param.ieta, param.iphi, param.depth);
+    float phiCenter = param.phi;  // middle of the cell
     float etaCenter = 0.5 * (param.etaMin + param.etaMax);
-    int   iside     = (param.ieta >= 0) ? 1 : -1;
-    float z = (isBH_) ? (iside*0.5*(param.zMin+param.zMax)) : (iside*param.zMin);
-    float perp = std::abs(z) / sinh (etaCenter);
-    float x = perp * cos (phiCenter);
-    float y = perp * sin (phiCenter);
+    int iside = (param.ieta >= 0) ? 1 : -1;
+    float z = (isBH_) ? (iside * 0.5 * (param.zMin + param.zMax)) : (iside * param.zMin);
+    float perp = std::abs(z) / sinh(etaCenter);
+    float x = perp * cos(phiCenter);
+    float y = perp * sin(phiCenter);
     // make cell geometry
-    GlobalPoint refPoint (x,y,z); // center of the cell's face
+    GlobalPoint refPoint(x, y, z);  // center of the cell's face
     std::vector<CCGFloat> cellParams;
-    cellParams.reserve (5);
-    cellParams.emplace_back (0.5 * (param.etaMax - param.etaMin)); //deta_half
-    cellParams.emplace_back (0.5 * param.dphi);  // dphi_half
-    cellParams.emplace_back (-0.5 * (param.zMax - param.zMin) / tanh (etaCenter)); // dz_half, "-" means edges in Z
-    cellParams.emplace_back ( fabs( refPoint.eta() ) ) ;
-    cellParams.emplace_back ( fabs( refPoint.z() ) ) ;
+    cellParams.reserve(5);
+    cellParams.emplace_back(0.5 * (param.etaMax - param.etaMin));                 //deta_half
+    cellParams.emplace_back(0.5 * param.dphi);                                    // dphi_half
+    cellParams.emplace_back(-0.5 * (param.zMax - param.zMin) / tanh(etaCenter));  // dz_half, "-" means edges in Z
+    cellParams.emplace_back(fabs(refPoint.eta()));
+    cellParams.emplace_back(fabs(refPoint.z()));
 #ifdef EDM_ML_DEBUG
-    std::cout << "HcalFlexiHardcodeGeometryLoader::fillHE-> " << hid << " "
-	      << hid.rawId() << " " << std::hex << hid.rawId() << std::dec
-	      << " " << hid << refPoint << '/' << cellParams [0] << '/'
-	      << cellParams [1] << '/' << cellParams [2] << std::endl;
+    std::cout << "HcalFlexiHardcodeGeometryLoader::fillHE-> " << hid << " " << hid.rawId() << " " << std::hex
+              << hid.rawId() << std::dec << " " << hid << refPoint << '/' << cellParams[0] << '/' << cellParams[1]
+              << '/' << cellParams[2] << std::endl;
 #endif
-    fGeometry->newCellFast(refPoint,  refPoint,  refPoint,
-		       CaloCellGeometry::getParmPtr(cellParams,
-						    fGeometry->parMgr(),
-						    fGeometry->parVecVec()),
-		       hid ) ;
+    fGeometry->newCellFast(refPoint,
+                           refPoint,
+                           refPoint,
+                           CaloCellGeometry::getParmPtr(cellParams, fGeometry->parMgr(), fGeometry->parVecVec()),
+                           hid);
   }
 }
 
-void HcalFlexiHardcodeGeometryLoader::fillHF (HcalGeometry* fGeometry, const std::vector <HcalFlexiHardcodeGeometryLoader::HFCellParameters>& fCells) {
-
+void HcalFlexiHardcodeGeometryLoader::fillHF(
+    HcalGeometry* fGeometry, const std::vector<HcalFlexiHardcodeGeometryLoader::HFCellParameters>& fCells) {
   fGeometry->increaseReserve(fCells.size());
-  for (const auto & param : fCells) {
+  for (const auto& param : fCells) {
     for (int kPhi = 0; kPhi < param.nPhi; ++kPhi) {
-      int iPhi = param.phiFirst + kPhi*param.phiStep;
-      HcalDetId hid (HcalForward, param.eta, iPhi, param.depth);
+      int iPhi = param.phiFirst + kPhi * param.phiStep;
+      HcalDetId hid(HcalForward, param.eta, iPhi, param.depth);
       // middle of the cell
-      float phiCenter = ((iPhi-1)*360./MAX_HCAL_PHI + 0.5*param.dphi) * DEGREE2RAD;
-      GlobalPoint inner (param.rMin, 0, param.zMin);
-      GlobalPoint outer (param.rMax, 0, param.zMin);
+      float phiCenter = ((iPhi - 1) * 360. / MAX_HCAL_PHI + 0.5 * param.dphi) * DEGREE2RAD;
+      GlobalPoint inner(param.rMin, 0, param.zMin);
+      GlobalPoint outer(param.rMax, 0, param.zMin);
       float iEta = inner.eta();
       float oEta = outer.eta();
-      float etaCenter = 0.5 * ( iEta + oEta );
+      float etaCenter = 0.5 * (iEta + oEta);
 
-      float perp = param.zMin / sinh (etaCenter);
-      float x = perp * cos (phiCenter);
-      float y = perp * sin (phiCenter);
+      float perp = param.zMin / sinh(etaCenter);
+      float x = perp * cos(phiCenter);
+      float y = perp * sin(phiCenter);
       float z = (param.eta > 0) ? param.zMin : -param.zMin;
       // make cell geometry
-      GlobalPoint refPoint (x,y,z); // center of the cell's face
+      GlobalPoint refPoint(x, y, z);  // center of the cell's face
       std::vector<CCGFloat> cellParams;
-      cellParams.reserve (5);
-      cellParams.emplace_back (0.5 * ( iEta - oEta )); // deta_half
-      cellParams.emplace_back (0.5 * param.dphi * DEGREE2RAD);  // dphi_half
-      cellParams.emplace_back (0.5 * (param.zMax - param.zMin)); // dz_half
-      cellParams.emplace_back ( fabs( refPoint.eta()));
-      cellParams.emplace_back ( fabs( refPoint.z() ) ) ;
+      cellParams.reserve(5);
+      cellParams.emplace_back(0.5 * (iEta - oEta));              // deta_half
+      cellParams.emplace_back(0.5 * param.dphi * DEGREE2RAD);    // dphi_half
+      cellParams.emplace_back(0.5 * (param.zMax - param.zMin));  // dz_half
+      cellParams.emplace_back(fabs(refPoint.eta()));
+      cellParams.emplace_back(fabs(refPoint.z()));
 #ifdef EDM_ML_DEBUG
-      std::cout << "HcalFlexiHardcodeGeometryLoader::fillHF-> " << hid << " "
-		<< hid.rawId() << " " << std::hex << hid.rawId() << std::dec
-		<< " " << hid << " " << refPoint << '/' << cellParams [0]
-		<< '/' << cellParams [1] << '/' << cellParams [2] << std::endl;
+      std::cout << "HcalFlexiHardcodeGeometryLoader::fillHF-> " << hid << " " << hid.rawId() << " " << std::hex
+                << hid.rawId() << std::dec << " " << hid << " " << refPoint << '/' << cellParams[0] << '/'
+                << cellParams[1] << '/' << cellParams[2] << std::endl;
 #endif
-      fGeometry->newCellFast(refPoint,  refPoint,  refPoint,
-			 CaloCellGeometry::getParmPtr(cellParams,
-						      fGeometry->parMgr(),
-						      fGeometry->parVecVec()),
-			 hid ) ;
+      fGeometry->newCellFast(refPoint,
+                             refPoint,
+                             refPoint,
+                             CaloCellGeometry::getParmPtr(cellParams, fGeometry->parMgr(), fGeometry->parVecVec()),
+                             hid);
     }
   }
 }

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -6,63 +6,63 @@
 #include <Math/Transform3D.h>
 #include <Math/EulerAngles.h>
 
-typedef CaloCellGeometry::CCGFloat CCGFloat ;
-typedef CaloCellGeometry::Pt3D     Pt3D     ;
-typedef CaloCellGeometry::Pt3DVec  Pt3DVec  ;
-typedef CaloCellGeometry::Tr3D     Tr3D     ;
+typedef CaloCellGeometry::CCGFloat CCGFloat;
+typedef CaloCellGeometry::Pt3D Pt3D;
+typedef CaloCellGeometry::Pt3DVec Pt3DVec;
+typedef CaloCellGeometry::Tr3D Tr3D;
 
 //#define EDM_ML_DEBUG
 
-HcalGeometry::HcalGeometry(const HcalTopology& topology) :
-  m_topology(topology), m_mergePosition(topology.getMergePositionFlag()) {
+HcalGeometry::HcalGeometry(const HcalTopology& topology)
+    : m_topology(topology), m_mergePosition(topology.getMergePositionFlag()) {
   init();
 }
-  
+
 HcalGeometry::~HcalGeometry() {}
 
 void HcalGeometry::init() {
-  if (!m_topology.getMergePositionFlag()) m_mergePosition = false;
+  if (!m_topology.getMergePositionFlag())
+    m_mergePosition = false;
 #ifdef EDM_ML_DEBUG
-  std::cout << "HcalGeometry: " << "HcalGeometry::init() "
-			       << " HBSize " << m_topology.getHBSize() 
-			       << " HESize " << m_topology.getHESize() 
-			       << " HOSize " << m_topology.getHOSize() 
-			       << " HFSize " << m_topology.getHFSize() << std::endl;
+  std::cout << "HcalGeometry: "
+            << "HcalGeometry::init() "
+            << " HBSize " << m_topology.getHBSize() << " HESize " << m_topology.getHESize() << " HOSize "
+            << m_topology.getHOSize() << " HFSize " << m_topology.getHFSize() << std::endl;
 #endif
 
-  m_hbCellVec = HBCellVec( m_topology.getHBSize() ) ;
-  m_heCellVec = HECellVec( m_topology.getHESize() ) ;
-  m_hoCellVec = HOCellVec( m_topology.getHOSize() ) ;
-  m_hfCellVec = HFCellVec( m_topology.getHFSize() ) ;
+  m_hbCellVec = HBCellVec(m_topology.getHBSize());
+  m_heCellVec = HECellVec(m_topology.getHESize());
+  m_hoCellVec = HOCellVec(m_topology.getHOSize());
+  m_hfCellVec = HFCellVec(m_topology.getHFSize());
 }
 
 void HcalGeometry::fillDetIds() const {
   // this must test the last record filled to avoid a race condition
-  if(!m_emptyIds.isSet()) {
+  if (!m_emptyIds.isSet()) {
     std::unique_ptr<std::vector<DetId>> p_hbIds{new std::vector<DetId>};
     std::unique_ptr<std::vector<DetId>> p_heIds{new std::vector<DetId>};
     std::unique_ptr<std::vector<DetId>> p_hoIds{new std::vector<DetId>};
     std::unique_ptr<std::vector<DetId>> p_hfIds{new std::vector<DetId>};
     std::unique_ptr<std::vector<DetId>> p_emptyIds{new std::vector<DetId>};
-    
-    const std::vector<DetId>& baseIds (CaloSubdetectorGeometry::getValidDetIds());
-    for (unsigned int i ( 0 ) ; i != baseIds.size() ; ++i) {
-      const DetId id ( baseIds[i] );
+
+    const std::vector<DetId>& baseIds(CaloSubdetectorGeometry::getValidDetIds());
+    for (unsigned int i(0); i != baseIds.size(); ++i) {
+      const DetId id(baseIds[i]);
       if (id.subdetId() == HcalBarrel) {
-	p_hbIds->emplace_back( id ) ;
+        p_hbIds->emplace_back(id);
       } else if (id.subdetId() == HcalEndcap) {
-	p_heIds->emplace_back( id ) ;
-      } else if (id.subdetId() == HcalOuter)  {
-	p_hoIds->emplace_back( id ) ;
+        p_heIds->emplace_back(id);
+      } else if (id.subdetId() == HcalOuter) {
+        p_hoIds->emplace_back(id);
       } else if (id.subdetId() == HcalForward) {
-	p_hfIds->emplace_back( id ) ;
+        p_hfIds->emplace_back(id);
       }
     }
-    std::sort( p_hbIds->begin(), p_hbIds->end() ) ;
-    std::sort( p_heIds->begin(), p_heIds->end() ) ;
-    std::sort( p_hoIds->begin(), p_hoIds->end() ) ;
-    std::sort( p_hfIds->begin(), p_hfIds->end() ) ;
-    p_emptyIds->resize( 0 ) ;
+    std::sort(p_hbIds->begin(), p_hbIds->end());
+    std::sort(p_heIds->begin(), p_heIds->end());
+    std::sort(p_hoIds->begin(), p_hoIds->end());
+    std::sort(p_hfIds->begin(), p_hfIds->end());
+    p_emptyIds->resize(0);
 
     m_hbIds.set(std::move(p_hbIds));
     m_heIds.set(std::move(p_heIds));
@@ -72,57 +72,53 @@ void HcalGeometry::fillDetIds() const {
   }
 }
 
-const std::vector<DetId>& 
-HcalGeometry::getValidDetIds( DetId::Detector det,
-			      int             subdet ) const {
-  if( 0 != subdet ) fillDetIds() ;
-  return ( 0 == subdet ? CaloSubdetectorGeometry::getValidDetIds() :
-	   ( HcalBarrel == subdet ? *m_hbIds.load() :
-	     ( HcalEndcap == subdet ? *m_heIds.load() :
-	       ( HcalOuter == subdet ? *m_hoIds.load() :
-		 ( HcalForward == subdet ? *m_hfIds.load() : *m_emptyIds.load() ) ) ) ) ) ;
+const std::vector<DetId>& HcalGeometry::getValidDetIds(DetId::Detector det, int subdet) const {
+  if (0 != subdet)
+    fillDetIds();
+  return (0 == subdet
+              ? CaloSubdetectorGeometry::getValidDetIds()
+              : (HcalBarrel == subdet
+                     ? *m_hbIds.load()
+                     : (HcalEndcap == subdet
+                            ? *m_heIds.load()
+                            : (HcalOuter == subdet ? *m_hoIds.load()
+                                                   : (HcalForward == subdet ? *m_hfIds.load() : *m_emptyIds.load())))));
 }
 
 std::shared_ptr<const CaloCellGeometry> HcalGeometry::getGeometry(const DetId& id) const {
 #ifdef EDM_ML_DEBUG
-  std::cout << "HcalGeometry::getGeometry for " << HcalDetId(id) << "  " 
-	    << m_mergePosition << " ";
+  std::cout << "HcalGeometry::getGeometry for " << HcalDetId(id) << "  " << m_mergePosition << " ";
 #endif
   if (!m_mergePosition) {
 #ifdef EDM_ML_DEBUG
-    std::cout << m_topology.detId2denseId(id) << " " << getGeometryBase(id) 
-	      << "\n";
+    std::cout << m_topology.detId2denseId(id) << " " << getGeometryBase(id) << "\n";
 #endif
     return getGeometryBase(id);
   } else {
 #ifdef EDM_ML_DEBUG
-    std:: cout << m_topology.detId2denseId(m_topology.idFront(id)) << " " 
-	       << getGeometryBase(m_topology.idFront(id)) << "\n";
+    std::cout << m_topology.detId2denseId(m_topology.idFront(id)) << " " << getGeometryBase(m_topology.idFront(id))
+              << "\n";
 #endif
     return getGeometryBase(m_topology.idFront(id));
   }
 }
 
-DetId HcalGeometry::getClosestCell(const GlobalPoint& r) const {
-  return getClosestCell(r,false);
-}
+DetId HcalGeometry::getClosestCell(const GlobalPoint& r) const { return getClosestCell(r, false); }
 
-DetId HcalGeometry::getClosestCell(const GlobalPoint& r,
-				   bool ignoreCorrect) const {
-
+DetId HcalGeometry::getClosestCell(const GlobalPoint& r, bool ignoreCorrect) const {
   // Now find the closest eta_bin, eta value of a bin i is average
   // of eta[i] and eta[i-1]
-  static const double z_long=1100.0;
+  static const double z_long = 1100.0;
   double abseta = fabs(r.eta());
-  double absz   = fabs(r.z());
-  
+  double absz = fabs(r.z());
+
   // figure out subdetector, giving preference to HE in HE/HF overlap region
-  HcalSubdetector bc= HcalEmpty;
-  if (abseta <= m_topology.etaMax(HcalBarrel) ) {
+  HcalSubdetector bc = HcalEmpty;
+  if (abseta <= m_topology.etaMax(HcalBarrel)) {
     bc = HcalBarrel;
   } else if (absz >= z_long) {
     bc = HcalForward;
-  } else if (abseta <= m_topology.etaMax(HcalEndcap) ) {
+  } else if (abseta <= m_topology.etaMax(HcalEndcap)) {
     bc = HcalEndcap;
   } else {
     bc = HcalForward;
@@ -137,40 +133,42 @@ DetId HcalGeometry::getClosestCell(const GlobalPoint& r,
   int etabin = (r.z() > 0) ? etaring : -etaring;
 
   if (bc == HcalForward) {
-    static const double z_short=1137.0;
+    static const double z_short = 1137.0;
     // Next line is premature depth 1 and 2 can coexist for large z-extent
     //    HcalDetId bestId(bc,etabin,phibin,((fabs(r.z())>=z_short)?(2):(1)));
     // above line is no good with finite precision
-    HcalDetId bestId(bc,etabin,phibin,((fabs(r.z()) - z_short >-0.1)?(2):(1)));
+    HcalDetId bestId(bc, etabin, phibin, ((fabs(r.z()) - z_short > -0.1) ? (2) : (1)));
     return correctId(bestId);
   } else {
-
     //Now do depth if required
     int zside = (r.z() > 0) ? 1 : -1;
-    int dbin  = m_topology.dddConstants()->getMinDepth(((int)(bc)-1),etaring,phibin,zside);
+    int dbin = m_topology.dddConstants()->getMinDepth(((int)(bc)-1), etaring, phibin, zside);
     double pointrz(0), drz(99999.);
     HcalDetId currentId(bc, etabin, phibin, dbin);
-    if (bc == HcalBarrel) pointrz = r.mag();
-    else                  pointrz = std::abs(r.z());
+    if (bc == HcalBarrel)
+      pointrz = r.mag();
+    else
+      pointrz = std::abs(r.z());
     HcalDetId bestId;
-    for ( ; currentId != HcalDetId(); m_topology.incrementDepth(currentId)) {
+    for (; currentId != HcalDetId(); m_topology.incrementDepth(currentId)) {
       std::shared_ptr<const CaloCellGeometry> cell = getGeometry(currentId);
       if (cell == nullptr) {
-        assert (bestId != HcalDetId());
+        assert(bestId != HcalDetId());
         break;
       } else {
         double rz;
-        if (bc == HcalEndcap) rz = std::abs(cell->getPosition().z());
-        else                  rz = cell->getPosition().mag();
-        if (std::abs(pointrz-rz)<drz) {
+        if (bc == HcalEndcap)
+          rz = std::abs(cell->getPosition().z());
+        else
+          rz = cell->getPosition().mag();
+        if (std::abs(pointrz - rz) < drz) {
           bestId = currentId;
-          drz    = std::abs(pointrz-rz);
+          drz = std::abs(pointrz - rz);
         }
       }
     }
 #ifdef EDM_ML_DEBUG
-    std::cout << bestId << " Corrected to " << HcalDetId(correctId(bestId)) 
-	      << std::endl;
+    std::cout << bestId << " Corrected to " << HcalDetId(correctId(bestId)) << std::endl;
 #endif
 
     return (ignoreCorrect ? bestId : correctId(bestId));
@@ -190,7 +188,7 @@ GlobalPoint HcalGeometry::getBackPosition(const DetId& id) const {
     return (getGeometryBase(id)->getBackPoint());
   } else {
     std::vector<HcalDetId> ids;
-    m_topology.unmergeDepthDetId(HcalDetId(id),ids);
+    m_topology.unmergeDepthDetId(HcalDetId(id), ids);
     return (getGeometryBase(ids.back())->getBackPoint());
   }
 }
@@ -200,375 +198,343 @@ CaloCellGeometry::CornersVec HcalGeometry::getCorners(const DetId& id) const {
     return (getGeometryBase(id)->getCorners());
   } else {
     std::vector<HcalDetId> ids;
-    m_topology.unmergeDepthDetId(HcalDetId(id),ids);
+    m_topology.unmergeDepthDetId(HcalDetId(id), ids);
     CaloCellGeometry::CornersVec mcorners;
     CaloCellGeometry::CornersVec mcf = getGeometryBase(ids.front())->getCorners();
     CaloCellGeometry::CornersVec mcb = getGeometryBase(ids.back())->getCorners();
-    for (unsigned int k=0; k<4; ++k) {
-      mcorners[k]   = mcf[k];
-      mcorners[k+4] = mcb[k+4];
+    for (unsigned int k = 0; k < 4; ++k) {
+      mcorners[k] = mcf[k];
+      mcorners[k + 4] = mcb[k + 4];
     }
     return mcorners;
   }
 }
 
-int HcalGeometry::etaRing(HcalSubdetector bc, double abseta) const {
-  return m_topology.etaRing(bc, abseta);
-}
+int HcalGeometry::etaRing(HcalSubdetector bc, double abseta) const { return m_topology.etaRing(bc, abseta); }
 
 int HcalGeometry::phiBin(HcalSubdetector bc, int etaring, double phi) const {
   return m_topology.phiBin(bc, etaring, phi);
 }
 
-CaloSubdetectorGeometry::DetIdSet HcalGeometry::getCells(const GlobalPoint& r, 
-							 double dR ) const {
+CaloSubdetectorGeometry::DetIdSet HcalGeometry::getCells(const GlobalPoint& r, double dR) const {
   CaloSubdetectorGeometry::DetIdSet dis;  // this is the return object
 
   if (0.000001 < dR) {
-    if (dR > M_PI/2.) {// this version needs "small" dR
-      dis = CaloSubdetectorGeometry::getCells(r, dR); // base class version
+    if (dR > M_PI / 2.) {                              // this version needs "small" dR
+      dis = CaloSubdetectorGeometry::getCells(r, dR);  // base class version
     } else {
-      const double dR2     ( dR*dR ) ;
-      const double reta    ( r.eta() ) ;
-      const double rphi    ( r.phi() ) ;
-      const double lowEta  ( reta - dR ) ;
-      const double highEta ( reta + dR ) ;
-      const double lowPhi  ( rphi - dR ) ;
-      const double highPhi ( rphi + dR ) ;
-       
-      const double hfEtaHi (m_topology.etaMax(HcalForward));
-	 
-      if (highEta > -hfEtaHi &&
-	  lowEta  <  hfEtaHi    ) { // in hcal
-	const HcalSubdetector hs[] = {HcalBarrel, HcalOuter, HcalEndcap, HcalForward } ;
+      const double dR2(dR * dR);
+      const double reta(r.eta());
+      const double rphi(r.phi());
+      const double lowEta(reta - dR);
+      const double highEta(reta + dR);
+      const double lowPhi(rphi - dR);
+      const double highPhi(rphi + dR);
 
-	for (unsigned int is ( 0 ) ; is != 4 ; ++is ) {
-	  const int sign        (  reta>0 ? 1 : -1 ) ;
-	  const int ieta_center ( sign*etaRing( hs[is], fabs( reta ) ) ) ;
-	  const int ieta_lo     ( ( 0 < lowEta*sign ? sign : -sign )*etaRing( hs[is], fabs( lowEta ) ) ) ;
-	  const int ieta_hi     ( ( 0 < highEta*sign ? sign : -sign )*etaRing( hs[is], fabs( highEta ) ) ) ;
-          const int iphi_lo     ( phiBin( hs[is], ieta_center, lowPhi  ) ) ;
-          const int iphi_hi     ( phiBin( hs[is], ieta_center, highPhi ) ) ;
-	  const int jphi_lo     ( iphi_lo>iphi_hi ? iphi_lo - 72 : iphi_lo ) ;
-	  const int jphi_hi     ( iphi_hi ) ;
+      const double hfEtaHi(m_topology.etaMax(HcalForward));
 
-	   const int idep_lo     ( 1 == is ? 4 : 1 ) ;
-	   const int idep_hi     ( m_topology.maxDepth(hs[is]) );
-	   for (int ieta ( ieta_lo ) ; ieta <= ieta_hi ; ++ieta) {// over eta limits
-	     if (ieta != 0) {
-	       for (int jphi ( jphi_lo ) ; jphi <= jphi_hi ; ++jphi) { // over phi limits
-		 const int iphi ( 1 > jphi ? jphi+72 : jphi ) ;
-		 for (int idep ( idep_lo ) ; idep <= idep_hi ; ++idep ) {
-		   const HcalDetId did ( hs[is], ieta, iphi, idep ) ;
-		   if (m_topology.valid(did)) {
-		     std::shared_ptr<const CaloCellGeometry> cell ( getGeometryBase( did ) );
-		     if (nullptr != cell ) {
-		       const GlobalPoint& p   ( cell->getPosition() ) ;
-		       const double       eta ( p.eta() ) ;
-		       const double       phi ( p.phi() ) ;
-		       if (reco::deltaR2(eta, phi, reta, rphi ) < dR2) dis.insert( did ) ;
-		     }
-		   }
-		 }
-	       }
-	     }
-	   }
-	 }
-       }
-     }
-   }
-   return dis;
+      if (highEta > -hfEtaHi && lowEta < hfEtaHi) {  // in hcal
+        const HcalSubdetector hs[] = {HcalBarrel, HcalOuter, HcalEndcap, HcalForward};
+
+        for (unsigned int is(0); is != 4; ++is) {
+          const int sign(reta > 0 ? 1 : -1);
+          const int ieta_center(sign * etaRing(hs[is], fabs(reta)));
+          const int ieta_lo((0 < lowEta * sign ? sign : -sign) * etaRing(hs[is], fabs(lowEta)));
+          const int ieta_hi((0 < highEta * sign ? sign : -sign) * etaRing(hs[is], fabs(highEta)));
+          const int iphi_lo(phiBin(hs[is], ieta_center, lowPhi));
+          const int iphi_hi(phiBin(hs[is], ieta_center, highPhi));
+          const int jphi_lo(iphi_lo > iphi_hi ? iphi_lo - 72 : iphi_lo);
+          const int jphi_hi(iphi_hi);
+
+          const int idep_lo(1 == is ? 4 : 1);
+          const int idep_hi(m_topology.maxDepth(hs[is]));
+          for (int ieta(ieta_lo); ieta <= ieta_hi; ++ieta) {  // over eta limits
+            if (ieta != 0) {
+              for (int jphi(jphi_lo); jphi <= jphi_hi; ++jphi) {  // over phi limits
+                const int iphi(1 > jphi ? jphi + 72 : jphi);
+                for (int idep(idep_lo); idep <= idep_hi; ++idep) {
+                  const HcalDetId did(hs[is], ieta, iphi, idep);
+                  if (m_topology.valid(did)) {
+                    std::shared_ptr<const CaloCellGeometry> cell(getGeometryBase(did));
+                    if (nullptr != cell) {
+                      const GlobalPoint& p(cell->getPosition());
+                      const double eta(p.eta());
+                      const double phi(p.phi());
+                      if (reco::deltaR2(eta, phi, reta, rphi) < dR2)
+                        dis.insert(did);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return dis;
 }
 
 unsigned int HcalGeometry::getHxSize(const int type) const {
-   unsigned int hxsize(0);
-   if (!m_hbIds.isSet()) fillDetIds();
-   if (type == 1)       hxsize = (m_hbIds.isSet()) ? m_hbIds->size() : 0;
-   else if (type == 2)  hxsize = (m_heIds.isSet()) ? m_heIds->size() : 0;
-   else if (type == 3)  hxsize = (m_hoIds.isSet()) ? m_hoIds->size() : 0;
-   else if (type == 4)  hxsize = (m_hfIds.isSet()) ? m_hfIds->size() : 0;
-   else if (type == 0)  hxsize = (m_emptyIds.isSet()) ? m_emptyIds->size() : 0;
-   return hxsize;
+  unsigned int hxsize(0);
+  if (!m_hbIds.isSet())
+    fillDetIds();
+  if (type == 1)
+    hxsize = (m_hbIds.isSet()) ? m_hbIds->size() : 0;
+  else if (type == 2)
+    hxsize = (m_heIds.isSet()) ? m_heIds->size() : 0;
+  else if (type == 3)
+    hxsize = (m_hoIds.isSet()) ? m_hoIds->size() : 0;
+  else if (type == 4)
+    hxsize = (m_hfIds.isSet()) ? m_hfIds->size() : 0;
+  else if (type == 0)
+    hxsize = (m_emptyIds.isSet()) ? m_emptyIds->size() : 0;
+  return hxsize;
 }
 
 DetId HcalGeometry::detIdFromBarrelAlignmentIndex(unsigned int i) {
-   assert( i < numberOfBarrelAlignments() ) ;
-   const int ieta  ( i < numberOfBarrelAlignments()/2 ? -1 : 1 ) ;
-   const int iphi ( 1 + (4*i)%72 ) ;
-   return HcalDetId( HcalBarrel, ieta, iphi, 1 ) ;
+  assert(i < numberOfBarrelAlignments());
+  const int ieta(i < numberOfBarrelAlignments() / 2 ? -1 : 1);
+  const int iphi(1 + (4 * i) % 72);
+  return HcalDetId(HcalBarrel, ieta, iphi, 1);
 }
 
 DetId HcalGeometry::detIdFromEndcapAlignmentIndex(unsigned int i) {
-   assert( i < numberOfEndcapAlignments() ) ;
-   const int ieta  ( i < numberOfEndcapAlignments()/2 ? -16 : 16 ) ;
-   const int iphi ( 1 + (4*i)%72 ) ;
-   return HcalDetId( HcalEndcap, ieta, iphi, 1 ) ;
+  assert(i < numberOfEndcapAlignments());
+  const int ieta(i < numberOfEndcapAlignments() / 2 ? -16 : 16);
+  const int iphi(1 + (4 * i) % 72);
+  return HcalDetId(HcalEndcap, ieta, iphi, 1);
 }
 
 DetId HcalGeometry::detIdFromForwardAlignmentIndex(unsigned int i) {
-   assert( i < numberOfForwardAlignments() ) ;
-   const int ieta ( i < numberOfForwardAlignments()/2 ? -29 : 29 ) ;
-   const int iphi ( 1 + (4*i)%72 ) ;
-   return HcalDetId( HcalForward, ieta, iphi, 1 ) ;
+  assert(i < numberOfForwardAlignments());
+  const int ieta(i < numberOfForwardAlignments() / 2 ? -29 : 29);
+  const int iphi(1 + (4 * i) % 72);
+  return HcalDetId(HcalForward, ieta, iphi, 1);
 }
 
 DetId HcalGeometry::detIdFromOuterAlignmentIndex(unsigned int i) {
-   assert( i < numberOfOuterAlignments() ) ;
-   const int ring ( i/12 ) ;
-   const int ieta ( 0 == ring ? -11 :
-		    1 == ring ? -5  :
-		    2 == ring ?  1  :
-		    3 == ring ?  5  : 11 ) ;
-   const int iphi ( 1 + ( i - ring*12 )*6 ) ;
-   return HcalDetId( HcalOuter, ieta, iphi, 4 ) ;
+  assert(i < numberOfOuterAlignments());
+  const int ring(i / 12);
+  const int ieta(0 == ring ? -11 : 1 == ring ? -5 : 2 == ring ? 1 : 3 == ring ? 5 : 11);
+  const int iphi(1 + (i - ring * 12) * 6);
+  return HcalDetId(HcalOuter, ieta, iphi, 4);
 }
 
 DetId HcalGeometry::detIdFromLocalAlignmentIndex(unsigned int i) {
-   assert( i < numberOfAlignments() ) ;
+  assert(i < numberOfAlignments());
 
-   const unsigned int nB ( numberOfBarrelAlignments()  ) ;
-   const unsigned int nE ( numberOfEndcapAlignments()  ) ;
-   const unsigned int nF ( numberOfForwardAlignments() ) ;
-//   const unsigned int nO ( numberOfOuterAlignments()   ) ;
+  const unsigned int nB(numberOfBarrelAlignments());
+  const unsigned int nE(numberOfEndcapAlignments());
+  const unsigned int nF(numberOfForwardAlignments());
+  //   const unsigned int nO ( numberOfOuterAlignments()   ) ;
 
-   return (  i < nB       ? detIdFromBarrelAlignmentIndex( i ) :
-	     i < nB+nE    ? detIdFromEndcapAlignmentIndex( i - nB ) :
-	     i < nB+nE+nF ? detIdFromForwardAlignmentIndex( i - nB - nE ) :
-	     detIdFromOuterAlignmentIndex( i - nB - nE - nF ) ) ;
+  return (i < nB ? detIdFromBarrelAlignmentIndex(i)
+                 : i < nB + nE ? detIdFromEndcapAlignmentIndex(i - nB)
+                               : i < nB + nE + nF ? detIdFromForwardAlignmentIndex(i - nB - nE)
+                                                  : detIdFromOuterAlignmentIndex(i - nB - nE - nF));
 }
 
-unsigned int HcalGeometry::alignmentBarEndForIndexLocal(const DetId& id ,
-							unsigned int nD) {
-   const HcalDetId hid ( id ) ;
-   const unsigned int iphi ( hid.iphi() ) ;
-   const int ieta ( hid.ieta() ) ;
-   const unsigned int index ( ( 0 < ieta ? nD/2 : 0 ) + ( iphi + 1 )%72/4 ) ;
-   assert( index < nD ) ;
-   return index ;
+unsigned int HcalGeometry::alignmentBarEndForIndexLocal(const DetId& id, unsigned int nD) {
+  const HcalDetId hid(id);
+  const unsigned int iphi(hid.iphi());
+  const int ieta(hid.ieta());
+  const unsigned int index((0 < ieta ? nD / 2 : 0) + (iphi + 1) % 72 / 4);
+  assert(index < nD);
+  return index;
 }
 
 unsigned int HcalGeometry::alignmentBarrelIndexLocal(const DetId& id) {
-  return alignmentBarEndForIndexLocal( id, numberOfBarrelAlignments() ) ;
+  return alignmentBarEndForIndexLocal(id, numberOfBarrelAlignments());
 }
 
 unsigned int HcalGeometry::alignmentEndcapIndexLocal(const DetId& id) {
-  return alignmentBarEndForIndexLocal( id, numberOfEndcapAlignments() ) ;
+  return alignmentBarEndForIndexLocal(id, numberOfEndcapAlignments());
 }
 
 unsigned int HcalGeometry::alignmentForwardIndexLocal(const DetId& id) {
-   return alignmentBarEndForIndexLocal( id, numberOfForwardAlignments() ) ;
+  return alignmentBarEndForIndexLocal(id, numberOfForwardAlignments());
 }
 
 unsigned int HcalGeometry::alignmentOuterIndexLocal(const DetId& id) {
-   const HcalDetId hid ( id ) ;
-   const int ieta ( hid.ieta() ) ;
-   const int iphi ( hid.iphi() ) ;
-   const int ring ( ieta < -10 ? 0 :
-		    ( ieta < -4 ? 1 :
-		      ( ieta < 5 ? 2 :
-			( ieta < 11 ? 3 : 4 ) ) ) ) ;
+  const HcalDetId hid(id);
+  const int ieta(hid.ieta());
+  const int iphi(hid.iphi());
+  const int ring(ieta < -10 ? 0 : (ieta < -4 ? 1 : (ieta < 5 ? 2 : (ieta < 11 ? 3 : 4))));
 
-   const unsigned int index ( 12*ring + ( iphi - 1 )/6 ) ;
-   assert( index < numberOfOuterAlignments() ) ;
-   return index ;
+  const unsigned int index(12 * ring + (iphi - 1) / 6);
+  assert(index < numberOfOuterAlignments());
+  return index;
 }
 
 unsigned int HcalGeometry::alignmentTransformIndexLocal(const DetId& id) {
-   assert(id.det() == DetId::Hcal) ;
+  assert(id.det() == DetId::Hcal);
 
-   const HcalDetId hid ( id ) ;
-   bool isHB = (hid.subdet() == HcalBarrel);
-   bool isHE = (hid.subdet() == HcalEndcap);
-   bool isHF = (hid.subdet() == HcalForward);
-   // bool isHO = (hid.subdet() == HcalOuter);
+  const HcalDetId hid(id);
+  bool isHB = (hid.subdet() == HcalBarrel);
+  bool isHE = (hid.subdet() == HcalEndcap);
+  bool isHF = (hid.subdet() == HcalForward);
+  // bool isHO = (hid.subdet() == HcalOuter);
 
-   const unsigned int nB ( numberOfBarrelAlignments()  ) ;
-   const unsigned int nE ( numberOfEndcapAlignments()  ) ;
-   const unsigned int nF ( numberOfForwardAlignments() ) ;
-   // const unsigned int nO ( numberOfOuterAlignments()   ) ;
+  const unsigned int nB(numberOfBarrelAlignments());
+  const unsigned int nE(numberOfEndcapAlignments());
+  const unsigned int nF(numberOfForwardAlignments());
+  // const unsigned int nO ( numberOfOuterAlignments()   ) ;
 
-   const unsigned int index (isHB ? alignmentBarrelIndexLocal(id) :
-			     isHE ? alignmentEndcapIndexLocal(id) + nB :
-			     isHF ? alignmentForwardIndexLocal( id ) + nB + nE :
-			     alignmentOuterIndexLocal(id) + nB + nE + nF
-			     );
+  const unsigned int index(isHB ? alignmentBarrelIndexLocal(id)
+                                : isHE ? alignmentEndcapIndexLocal(id) + nB
+                                       : isHF ? alignmentForwardIndexLocal(id) + nB + nE
+                                              : alignmentOuterIndexLocal(id) + nB + nE + nF);
 
-   assert( index < numberOfAlignments() ) ;
-   return index ;
+  assert(index < numberOfAlignments());
+  return index;
 }
 
-unsigned int HcalGeometry::alignmentTransformIndexGlobal( const DetId& id ) {
-  return (unsigned int)DetId::Hcal - 1 ;
+unsigned int HcalGeometry::alignmentTransformIndexGlobal(const DetId& id) { return (unsigned int)DetId::Hcal - 1; }
+
+void HcalGeometry::localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int i, Pt3D& ref) {
+  HcalDetId hid = HcalDetId(m_topology.denseId2detId(i));
+
+  if (hid.subdet() == HcalForward) {
+    IdealZPrism::localCorners(lc, pv, ref);
+  } else {
+    IdealObliquePrism::localCorners(lc, pv, ref);
+  }
 }
 
-void HcalGeometry::localCorners(Pt3DVec&        lc,
-				const CCGFloat* pv,
-				unsigned int    i,
-				Pt3D&           ref) {
-  HcalDetId hid=HcalDetId(m_topology.denseId2detId(i));
+unsigned int HcalGeometry::newCellImpl(
+    const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId) {
+  assert(detId.det() == DetId::Hcal);
 
-   if (hid.subdet() == HcalForward ) {
-      IdealZPrism::localCorners( lc, pv, ref ) ;
-   } else {
-     IdealObliquePrism::localCorners( lc, pv, ref ) ;
-   }
-}
-
-unsigned int HcalGeometry::newCellImpl(const GlobalPoint& f1 ,
-			   const GlobalPoint& f2 ,
-			   const GlobalPoint& f3 ,
-			   const CCGFloat*    parm ,
-			   const DetId&       detId) {
-
-  assert (detId.det()==DetId::Hcal);
-    
-  const HcalDetId hid ( detId ) ;
-  unsigned int din=m_topology.detId2denseId(detId);
+  const HcalDetId hid(detId);
+  unsigned int din = m_topology.detId2denseId(detId);
 
 #ifdef EDM_ML_DEBUG
-  std::cout << "HcalGeometry: " << " newCell subdet "
- 	    << detId.subdetId() << ", raw ID " 
- 	    << detId.rawId() << ", hid " << hid << ", din " 
- 	    << din << ", index " << std::endl;
+  std::cout << "HcalGeometry: "
+            << " newCell subdet " << detId.subdetId() << ", raw ID " << detId.rawId() << ", hid " << hid << ", din "
+            << din << ", index " << std::endl;
 #endif
 
-  if (hid.subdet()==HcalBarrel) {
-    m_hbCellVec.at( din ) = IdealObliquePrism( f1, cornersMgr(), parm ) ;
-  } else if (hid.subdet()==HcalEndcap) {
-    const unsigned int index ( din - m_hbCellVec.size() ) ;
-    m_heCellVec.at( index ) = IdealObliquePrism( f1, cornersMgr(), parm ) ;
-  } else if (hid.subdet()==HcalOuter) {
-    const unsigned int index ( din 
-			       - m_hbCellVec.size()
-			       - m_heCellVec.size() ) ;
-    m_hoCellVec.at( index ) = IdealObliquePrism( f1, cornersMgr(), parm ) ;
+  if (hid.subdet() == HcalBarrel) {
+    m_hbCellVec.at(din) = IdealObliquePrism(f1, cornersMgr(), parm);
+  } else if (hid.subdet() == HcalEndcap) {
+    const unsigned int index(din - m_hbCellVec.size());
+    m_heCellVec.at(index) = IdealObliquePrism(f1, cornersMgr(), parm);
+  } else if (hid.subdet() == HcalOuter) {
+    const unsigned int index(din - m_hbCellVec.size() - m_heCellVec.size());
+    m_hoCellVec.at(index) = IdealObliquePrism(f1, cornersMgr(), parm);
   } else {
-    const unsigned int index ( din 
-			       - m_hbCellVec.size()
-			       - m_heCellVec.size()
-			       - m_hoCellVec.size() ) ;
-    m_hfCellVec.at( index ) = IdealZPrism( f1, cornersMgr(), parm,  hid.depth()==1 ? IdealZPrism::EM : IdealZPrism::HADR ) ;
+    const unsigned int index(din - m_hbCellVec.size() - m_heCellVec.size() - m_hoCellVec.size());
+    m_hfCellVec.at(index) = IdealZPrism(f1, cornersMgr(), parm, hid.depth() == 1 ? IdealZPrism::EM : IdealZPrism::HADR);
   }
 
   return din;
 }
 
-void HcalGeometry::newCell(const GlobalPoint& f1 ,
-			   const GlobalPoint& f2 ,
-			   const GlobalPoint& f3 ,
-			   const CCGFloat*    parm ,
-			   const DetId&       detId) {
+void HcalGeometry::newCell(
+    const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId) {
+  unsigned int din = newCellImpl(f1, f2, f3, parm, detId);
 
-  unsigned int din = newCellImpl(f1,f2,f3,parm,detId);
-
-  addValidID( detId ) ;
-  m_dins.emplace_back( din );
+  addValidID(detId);
+  m_dins.emplace_back(din);
 }
 
-void HcalGeometry::newCellFast(const GlobalPoint& f1 ,
-			       const GlobalPoint& f2 ,
-			       const GlobalPoint& f3 ,
-			       const CCGFloat*    parm ,
-			       const DetId&       detId) {
+void HcalGeometry::newCellFast(
+    const GlobalPoint& f1, const GlobalPoint& f2, const GlobalPoint& f3, const CCGFloat* parm, const DetId& detId) {
+  unsigned int din = newCellImpl(f1, f2, f3, parm, detId);
 
-  unsigned int din = newCellImpl(f1,f2,f3,parm,detId);
-
-  m_validIds.emplace_back( detId ) ;
-  m_dins.emplace_back( din );
+  m_validIds.emplace_back(detId);
+  m_dins.emplace_back(din);
 }
 
-const CaloCellGeometry* HcalGeometry::getGeometryRawPtr (uint32_t din) const {
+const CaloCellGeometry* HcalGeometry::getGeometryRawPtr(uint32_t din) const {
   // Modify the RawPtr class
   const CaloCellGeometry* cell(nullptr);
   if (m_hbCellVec.size() > din) {
     cell = (&m_hbCellVec[din]);
-  } else if (m_hbCellVec.size()+m_heCellVec.size() > din) {
-    const unsigned int ind (din - m_hbCellVec.size() ) ;
+  } else if (m_hbCellVec.size() + m_heCellVec.size() > din) {
+    const unsigned int ind(din - m_hbCellVec.size());
     cell = (&m_heCellVec[ind]);
-  } else if (m_hbCellVec.size()+m_heCellVec.size()+m_hoCellVec.size() > din) {
-    const unsigned int ind (din - m_hbCellVec.size() - m_heCellVec.size());
+  } else if (m_hbCellVec.size() + m_heCellVec.size() + m_hoCellVec.size() > din) {
+    const unsigned int ind(din - m_hbCellVec.size() - m_heCellVec.size());
     cell = (&m_hoCellVec[ind]);
-  } else if (m_hbCellVec.size()+m_heCellVec.size()+m_hoCellVec.size()+
-	     m_hfCellVec.size() > din) {
-    const unsigned int ind (din - m_hbCellVec.size() - m_heCellVec.size() -
-			    m_hoCellVec.size() ) ;
+  } else if (m_hbCellVec.size() + m_heCellVec.size() + m_hoCellVec.size() + m_hfCellVec.size() > din) {
+    const unsigned int ind(din - m_hbCellVec.size() - m_heCellVec.size() - m_hoCellVec.size());
     cell = (&m_hfCellVec[ind]);
   }
-  
-  return (( nullptr == cell || nullptr == cell->param()) ? nullptr : cell ) ;
+
+  return ((nullptr == cell || nullptr == cell->param()) ? nullptr : cell);
 }
 
-void HcalGeometry::getSummary( CaloSubdetectorGeometry::TrVec&  tVec,
-			       CaloSubdetectorGeometry::IVec&   iVec,
-			       CaloSubdetectorGeometry::DimVec& dVec,
-			       CaloSubdetectorGeometry::IVec& dinsVec ) const {
+void HcalGeometry::getSummary(CaloSubdetectorGeometry::TrVec& tVec,
+                              CaloSubdetectorGeometry::IVec& iVec,
+                              CaloSubdetectorGeometry::DimVec& dVec,
+                              CaloSubdetectorGeometry::IVec& dinsVec) const {
+  tVec.reserve(m_topology.ncells() * numberOfTransformParms());
+  iVec.reserve(numberOfShapes() == 1 ? 1 : m_topology.ncells());
+  dVec.reserve(numberOfShapes() * numberOfParametersPerShape());
+  dinsVec.reserve(m_topology.ncells());
 
-  tVec.reserve( m_topology.ncells()*numberOfTransformParms());
-  iVec.reserve( numberOfShapes()==1 ? 1 : m_topology.ncells());
-  dVec.reserve( numberOfShapes()*numberOfParametersPerShape());
-  dinsVec.reserve( m_topology.ncells());
-   
-  for (const auto & pv : parVecVec()) {
+  for (const auto& pv : parVecVec()) {
     for (float iv : pv) {
-      dVec.emplace_back( iv ) ;
+      dVec.emplace_back(iv);
     }
   }
-   
-  for( auto i : m_dins ) {
-    Tr3D tr ;
-    auto ptr = cellGeomPtr( i );
-       
+
+  for (auto i : m_dins) {
+    Tr3D tr;
+    auto ptr = cellGeomPtr(i);
+
     if (nullptr != ptr) {
-      dinsVec.emplace_back( i );
+      dinsVec.emplace_back(i);
 
-      const CCGFloat* par ( ptr->param() ) ;
+      const CCGFloat* par(ptr->param());
 
-      unsigned int ishape ( 9999 ) ;
+      unsigned int ishape(9999);
 
-      for( unsigned int ivv ( 0 ) ; ivv != parVecVec().size() ; ++ivv ) {
-	bool ok ( true ) ;
-	const CCGFloat* pv ( &(*parVecVec()[ivv].begin() ) ) ;
-	for( unsigned int k ( 0 ) ; k != numberOfParametersPerShape() ; ++k ) {
-	  ok = ok && ( fabs( par[k] - pv[k] ) < 1.e-6 ) ;
-	}
-	if( ok ) {
-	  ishape = ivv;
-	  break ;
-	}
+      for (unsigned int ivv(0); ivv != parVecVec().size(); ++ivv) {
+        bool ok(true);
+        const CCGFloat* pv(&(*parVecVec()[ivv].begin()));
+        for (unsigned int k(0); k != numberOfParametersPerShape(); ++k) {
+          ok = ok && (fabs(par[k] - pv[k]) < 1.e-6);
+        }
+        if (ok) {
+          ishape = ivv;
+          break;
+        }
       }
-      assert( 9999 != ishape ) ;
-      
-      const unsigned int nn (( numberOfShapes()==1) ? (unsigned int)1 : m_dins.size() ) ; 
-      if( iVec.size() < nn ) iVec.emplace_back( ishape ) ;
+      assert(9999 != ishape);
 
-      ptr->getTransform( tr, ( Pt3DVec* ) nullptr ) ;
+      const unsigned int nn((numberOfShapes() == 1) ? (unsigned int)1 : m_dins.size());
+      if (iVec.size() < nn)
+        iVec.emplace_back(ishape);
 
-      if( Tr3D() == tr ) { // for preshower there is no rotation
-	const GlobalPoint& gp ( ptr->getPosition() ) ; 
-	tr = HepGeom::Translate3D( gp.x(), gp.y(), gp.z() ) ;
+      ptr->getTransform(tr, (Pt3DVec*)nullptr);
+
+      if (Tr3D() == tr) {  // for preshower there is no rotation
+        const GlobalPoint& gp(ptr->getPosition());
+        tr = HepGeom::Translate3D(gp.x(), gp.y(), gp.z());
       }
 
-      const CLHEP::Hep3Vector  tt ( tr.getTranslation() ) ;
-      tVec.emplace_back( tt.x() ) ;
-      tVec.emplace_back( tt.y() ) ;
-      tVec.emplace_back( tt.z() ) ;
+      const CLHEP::Hep3Vector tt(tr.getTranslation());
+      tVec.emplace_back(tt.x());
+      tVec.emplace_back(tt.y());
+      tVec.emplace_back(tt.z());
       if (6 == numberOfTransformParms()) {
-	const CLHEP::HepRotation rr ( tr.getRotation() ) ;
-	const ROOT::Math::Transform3D rtr (rr.xx(), rr.xy(), rr.xz(), tt.x(),
-					   rr.yx(), rr.yy(), rr.yz(), tt.y(),
-					   rr.zx(), rr.zy(), rr.zz(), tt.z());
-	ROOT::Math::EulerAngles ea ;
-	rtr.GetRotation( ea ) ;
-	tVec.emplace_back( ea.Phi() ) ;
-	tVec.emplace_back( ea.Theta() ) ;
-	tVec.emplace_back( ea.Psi() ) ;
+        const CLHEP::HepRotation rr(tr.getRotation());
+        const ROOT::Math::Transform3D rtr(
+            rr.xx(), rr.xy(), rr.xz(), tt.x(), rr.yx(), rr.yy(), rr.yz(), tt.y(), rr.zx(), rr.zy(), rr.zz(), tt.z());
+        ROOT::Math::EulerAngles ea;
+        rtr.GetRotation(ea);
+        tVec.emplace_back(ea.Phi());
+        tVec.emplace_back(ea.Theta());
+        tVec.emplace_back(ea.Psi());
       }
     }
   }
 }
 
 DetId HcalGeometry::correctId(const DetId& id) const {
-
   if (m_mergePosition) {
     HcalDetId hid(id);
     return ((DetId)(m_topology.mergedDepthDetId(hid)));
@@ -577,11 +543,6 @@ DetId HcalGeometry::correctId(const DetId& id) const {
   }
 }
 
-void HcalGeometry::increaseReserve(unsigned int extra) {
-  m_validIds.reserve(m_validIds.size()+extra);
-}
+void HcalGeometry::increaseReserve(unsigned int extra) { m_validIds.reserve(m_validIds.size() + extra); }
 
-void HcalGeometry::sortValidIds() {
-  std::sort(m_validIds.begin(),m_validIds.end());
-}
-
+void HcalGeometry::sortValidIds() { std::sort(m_validIds.begin(), m_validIds.end()); }

--- a/Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryLoader.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalHardcodeGeometryLoader.cc
@@ -13,7 +13,6 @@ using CCGFloat = CaloCellGeometry::CCGFloat;
 // ==============> Loader Itself <==========================
 
 HcalHardcodeGeometryLoader::HcalHardcodeGeometryLoader() {
-
   MAX_HCAL_PHI = 72;
   DEGREE2RAD = M_PI / 180.;
 #ifdef DebugLog
@@ -22,284 +21,359 @@ HcalHardcodeGeometryLoader::HcalHardcodeGeometryLoader() {
 }
 
 CaloSubdetectorGeometry* HcalHardcodeGeometryLoader::load(const HcalTopology& fTopology) {
-
   int maxEta = fTopology.lastHERing();
   m_segmentation.resize(maxEta);
   for (int i = 0; i < maxEta; i++) {
-    fTopology.getDepthSegmentation(i+1,m_segmentation[i]);
+    fTopology.getDepthSegmentation(i + 1, m_segmentation[i]);
 #ifdef DebugLog
-    std::cout << "Eta" << i+1;
-    for (unsigned int k=0; k<m_segmentation[i].size(); ++k) {
+    std::cout << "Eta" << i + 1;
+    for (unsigned int k = 0; k < m_segmentation[i].size(); ++k) {
       std::cout << " [" << k << "] " << m_segmentation[i][k];
     }
     std::cout << std::endl;
 #endif
   }
-  HcalGeometry* hcalGeometry = new HcalGeometry (fTopology);
-  if( nullptr == hcalGeometry->cornersMgr() ) hcalGeometry->allocateCorners ( fTopology.ncells()+fTopology.getHFSize() );
-  if( nullptr == hcalGeometry->parMgr() ) hcalGeometry->allocatePar (hcalGeometry->numberOfShapes(),
-							       HcalGeometry::k_NumberOfParametersPerShape ) ;
+  HcalGeometry* hcalGeometry = new HcalGeometry(fTopology);
+  if (nullptr == hcalGeometry->cornersMgr())
+    hcalGeometry->allocateCorners(fTopology.ncells() + fTopology.getHFSize());
+  if (nullptr == hcalGeometry->parMgr())
+    hcalGeometry->allocatePar(hcalGeometry->numberOfShapes(), HcalGeometry::k_NumberOfParametersPerShape);
   if (fTopology.mode() == HcalTopologyMode::H2) {  // TB geometry
-    fillHBHO (hcalGeometry, makeHBCells(fTopology), true);
-    fillHBHO (hcalGeometry, makeHOCells(), false);
-    fillHE (hcalGeometry, makeHECells_H2());
- } else { // regular geometry
-    fillHBHO (hcalGeometry, makeHBCells(fTopology), true);
-    fillHBHO (hcalGeometry, makeHOCells(), false);
-    fillHF (hcalGeometry, makeHFCells());
-    fillHE (hcalGeometry, makeHECells(fTopology));
+    fillHBHO(hcalGeometry, makeHBCells(fTopology), true);
+    fillHBHO(hcalGeometry, makeHOCells(), false);
+    fillHE(hcalGeometry, makeHECells_H2());
+  } else {  // regular geometry
+    fillHBHO(hcalGeometry, makeHBCells(fTopology), true);
+    fillHBHO(hcalGeometry, makeHOCells(), false);
+    fillHF(hcalGeometry, makeHFCells());
+    fillHE(hcalGeometry, makeHECells(fTopology));
   }
   //fast insertion of valid ids requires sort at end
   hcalGeometry->sortValidIds();
   return hcalGeometry;
 }
 
-
 // ----------> HB <-----------
-std::vector <HcalHardcodeGeometryLoader::HBHOCellParameters> HcalHardcodeGeometryLoader::makeHBCells (const HcalTopology & topology) {
-
+std::vector<HcalHardcodeGeometryLoader::HBHOCellParameters> HcalHardcodeGeometryLoader::makeHBCells(
+    const HcalTopology& topology) {
   const float HBRMIN = 181.1;
   const float HBRMAX = 288.8;
-    
+
   float normalDepths[2] = {HBRMIN, HBRMAX};
   float ring15Depths[3] = {HBRMIN, 258.4, HBRMAX};
   float ring16Depths[3] = {HBRMIN, 190.4, 232.6};
-  float layerDepths[18] = {HBRMIN, 188.7, 194.7, 200.7, 206.7, 212.7, 218.7,
-			   224.7, 230.7, 236.7, 242.7, 249.3, 255.9, 262.5,
-			   269.1, 275.7, 282.3, HBRMAX};
-  float slhcDepths[4]   = {HBRMIN, 214., 239., HBRMAX};
+  float layerDepths[18] = {HBRMIN,
+                           188.7,
+                           194.7,
+                           200.7,
+                           206.7,
+                           212.7,
+                           218.7,
+                           224.7,
+                           230.7,
+                           236.7,
+                           242.7,
+                           249.3,
+                           255.9,
+                           262.5,
+                           269.1,
+                           275.7,
+                           282.3,
+                           HBRMAX};
+  float slhcDepths[4] = {HBRMIN, 214., 239., HBRMAX};
 #ifdef DebugLog
-  std::cout <<"FlexiGeometryLoader called for "<< topology.mode() << ":" << HcalTopologyMode::SLHC << std::endl;
+  std::cout << "FlexiGeometryLoader called for " << topology.mode() << ":" << HcalTopologyMode::SLHC << std::endl;
 #endif
-  std::vector <HcalHardcodeGeometryLoader::HBHOCellParameters> result;
-  for(int iring = 1; iring <= 16; ++iring) {
+  std::vector<HcalHardcodeGeometryLoader::HBHOCellParameters> result;
+  for (int iring = 1; iring <= 16; ++iring) {
     std::vector<float> depths;
     if (topology.mode() != HcalTopologyMode::SLHC) {
       if (iring == 15) {
-	for (float ring15Depth : ring15Depths) depths.emplace_back(ring15Depth);
+        for (float ring15Depth : ring15Depths)
+          depths.emplace_back(ring15Depth);
       } else if (iring == 16) {
-	for (float ring16Depth : ring16Depths) depths.emplace_back(ring16Depth);
+        for (float ring16Depth : ring16Depths)
+          depths.emplace_back(ring16Depth);
       } else {
-	for (float normalDepth : normalDepths) depths.emplace_back(normalDepth);
+        for (float normalDepth : normalDepths)
+          depths.emplace_back(normalDepth);
       }
     } else {
       if (m_segmentation.size() >= (unsigned int)(iring)) {
-	int depth = m_segmentation[iring-1][0];
-	depths.emplace_back(layerDepths[depth]);
-	int layer = 1;
-	for (unsigned int i=1; i<m_segmentation[iring-1].size(); ++i) {
-	  if (depth != m_segmentation[iring-1][i]) {
-	    depth = m_segmentation[iring-1][i];
-	    layer = i;
-	    if (iring != 16 || depth < 3)
-	      depths.emplace_back(layerDepths[depth]);
-	  }
-	  if (i >= 17) break;
-	}
-	if (layer <= 17) depths.emplace_back(HBRMAX);
+        int depth = m_segmentation[iring - 1][0];
+        depths.emplace_back(layerDepths[depth]);
+        int layer = 1;
+        for (unsigned int i = 1; i < m_segmentation[iring - 1].size(); ++i) {
+          if (depth != m_segmentation[iring - 1][i]) {
+            depth = m_segmentation[iring - 1][i];
+            layer = i;
+            if (iring != 16 || depth < 3)
+              depths.emplace_back(layerDepths[depth]);
+          }
+          if (i >= 17)
+            break;
+        }
+        if (layer <= 17)
+          depths.emplace_back(HBRMAX);
       } else {
-	for (int i=0; i<4; ++i) {
-	  if (iring != 16 || i < 3) {
-	    depths.emplace_back(slhcDepths[i]);
-	  }
-	}
+        for (int i = 0; i < 4; ++i) {
+          if (iring != 16 || i < 3) {
+            depths.emplace_back(slhcDepths[i]);
+          }
+        }
       }
     }
-    unsigned int ndepth=depths.size()-1;
-    unsigned int startingDepth=1;
-    float etaMin=(iring-1)*0.087;
-    float etaMax=iring*0.087;
+    unsigned int ndepth = depths.size() - 1;
+    unsigned int startingDepth = 1;
+    float etaMin = (iring - 1) * 0.087;
+    float etaMax = iring * 0.087;
     // topology.depthBinInformation(HcalBarrel, iring, ndepth, startingDepth);
 #ifdef DebugLog
-    std::cout << "HBRing " << iring << " eta " << etaMin << ":" << etaMax << " depths " << ndepth << ":" << startingDepth;
-    for (unsigned int i=0; i<depths.size(); ++i) std::cout << ":" << depths[i];
+    std::cout << "HBRing " << iring << " eta " << etaMin << ":" << etaMax << " depths " << ndepth << ":"
+              << startingDepth;
+    for (unsigned int i = 0; i < depths.size(); ++i)
+      std::cout << ":" << depths[i];
     std::cout << "\n";
 #endif
     for (unsigned int idepth = startingDepth; idepth <= ndepth; ++idepth) {
-      float rmin = depths[idepth-1];
+      float rmin = depths[idepth - 1];
       float rmax = depths[idepth];
 #ifdef DebugLog
       std::cout << "HB " << idepth << " R " << rmin << ":" << rmax << "\n";
 #endif
-      result.emplace_back(HcalHardcodeGeometryLoader::HBHOCellParameters(iring, (int)idepth, 1, 1, 5, rmin, rmax, etaMin, etaMax));
+      result.emplace_back(
+          HcalHardcodeGeometryLoader::HBHOCellParameters(iring, (int)idepth, 1, 1, 5, rmin, rmax, etaMin, etaMax));
     }
   }
   return result;
 }
 
-
-
 // ----------> HO <-----------
-std::vector <HcalHardcodeGeometryLoader::HBHOCellParameters> HcalHardcodeGeometryLoader::makeHOCells () {
+std::vector<HcalHardcodeGeometryLoader::HBHOCellParameters> HcalHardcodeGeometryLoader::makeHOCells() {
   const float HORMIN0 = 390.0;
   const float HORMIN1 = 412.6;
   const float HORMAX = 413.6;
-  
-  HcalHardcodeGeometryLoader::HBHOCellParameters cells [] = {
-    // eta, depth, firstPhi, stepPhi, deltaPhi, rMin, rMax, etaMin, etaMax
-    HcalHardcodeGeometryLoader::HBHOCellParameters ( 1, 4, 1, 1, 5, HORMIN0, HORMAX, 0.087*0, 0.087*1),
-    HcalHardcodeGeometryLoader::HBHOCellParameters ( 2, 4, 1, 1, 5, HORMIN0, HORMAX, 0.087*1, 0.087*2),
-    HcalHardcodeGeometryLoader::HBHOCellParameters ( 3, 4, 1, 1, 5, HORMIN0, HORMAX, 0.087*2, 0.087*3),
-    HcalHardcodeGeometryLoader::HBHOCellParameters ( 4, 4, 1, 1, 5, HORMIN0, HORMAX, 0.087*3, 0.3075),
-    HcalHardcodeGeometryLoader::HBHOCellParameters ( 5, 4, 1, 1, 5, HORMIN1, HORMAX, 0.3395,  0.087*5),
-    HcalHardcodeGeometryLoader::HBHOCellParameters ( 6, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087*5, 0.087*6),
-    HcalHardcodeGeometryLoader::HBHOCellParameters ( 7, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087*6, 0.087*7),
-    HcalHardcodeGeometryLoader::HBHOCellParameters ( 8, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087*7, 0.087*8),
-    HcalHardcodeGeometryLoader::HBHOCellParameters ( 9, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087*8, 0.087*9),
-    HcalHardcodeGeometryLoader::HBHOCellParameters (10, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087*9,  0.8494),
-    HcalHardcodeGeometryLoader::HBHOCellParameters (11, 4, 1, 1, 5, HORMIN1, HORMAX, 0.873, 0.087*11),
-    HcalHardcodeGeometryLoader::HBHOCellParameters (12, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087*11, 0.087*12),
-    HcalHardcodeGeometryLoader::HBHOCellParameters (13, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087*12, 0.087*13),
-    HcalHardcodeGeometryLoader::HBHOCellParameters (14, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087*13, 0.087*14),
-    HcalHardcodeGeometryLoader::HBHOCellParameters (15, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087*14, 0.087*15)
-  };
-  int nCells = sizeof(cells)/sizeof(HcalHardcodeGeometryLoader::HBHOCellParameters);
-  std::vector <HcalHardcodeGeometryLoader::HBHOCellParameters> result;
-  result.reserve (nCells);
-  for (int i = 0; i < nCells; ++i) result.emplace_back (cells[i]);
+
+  HcalHardcodeGeometryLoader::HBHOCellParameters cells[] = {
+      // eta, depth, firstPhi, stepPhi, deltaPhi, rMin, rMax, etaMin, etaMax
+      HcalHardcodeGeometryLoader::HBHOCellParameters(1, 4, 1, 1, 5, HORMIN0, HORMAX, 0.087 * 0, 0.087 * 1),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(2, 4, 1, 1, 5, HORMIN0, HORMAX, 0.087 * 1, 0.087 * 2),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(3, 4, 1, 1, 5, HORMIN0, HORMAX, 0.087 * 2, 0.087 * 3),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(4, 4, 1, 1, 5, HORMIN0, HORMAX, 0.087 * 3, 0.3075),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(5, 4, 1, 1, 5, HORMIN1, HORMAX, 0.3395, 0.087 * 5),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(6, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087 * 5, 0.087 * 6),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(7, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087 * 6, 0.087 * 7),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(8, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087 * 7, 0.087 * 8),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(9, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087 * 8, 0.087 * 9),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(10, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087 * 9, 0.8494),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(11, 4, 1, 1, 5, HORMIN1, HORMAX, 0.873, 0.087 * 11),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(12, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087 * 11, 0.087 * 12),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(13, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087 * 12, 0.087 * 13),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(14, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087 * 13, 0.087 * 14),
+      HcalHardcodeGeometryLoader::HBHOCellParameters(15, 4, 1, 1, 5, HORMIN1, HORMAX, 0.087 * 14, 0.087 * 15)};
+  int nCells = sizeof(cells) / sizeof(HcalHardcodeGeometryLoader::HBHOCellParameters);
+  std::vector<HcalHardcodeGeometryLoader::HBHOCellParameters> result;
+  result.reserve(nCells);
+  for (int i = 0; i < nCells; ++i)
+    result.emplace_back(cells[i]);
   return result;
 }
-
 
 //
 // Convert constants to appropriate cells
 //
-void HcalHardcodeGeometryLoader::fillHBHO (HcalGeometry* fGeometry, const std::vector <HcalHardcodeGeometryLoader::HBHOCellParameters>& fCells, bool fHB) {
-
+void HcalHardcodeGeometryLoader::fillHBHO(HcalGeometry* fGeometry,
+                                          const std::vector<HcalHardcodeGeometryLoader::HBHOCellParameters>& fCells,
+                                          bool fHB) {
   fGeometry->increaseReserve(fCells.size());
-  for (const auto & param : fCells) {
+  for (const auto& param : fCells) {
     for (int iPhi = param.phiFirst; iPhi <= MAX_HCAL_PHI; iPhi += param.phiStep) {
-      for (int iside = -1; iside <= 1; iside += 2) { // both detector sides are identical
-	HcalDetId hid (fHB ? HcalBarrel : HcalOuter, param.eta*iside, iPhi, param.depth);
-	float phiCenter = ((iPhi-1)*360./MAX_HCAL_PHI + 0.5*param.dphi) * DEGREE2RAD; // middle of the cell
-	float etaCenter = 0.5*(param.etaMin + param.etaMax);
-	float x = param.rMin* cos (phiCenter);
-	float y = param.rMin* sin (phiCenter);
-	float z = iside * param.rMin * sinh(etaCenter);
-	// make cell geometry
-	GlobalPoint refPoint (x,y,z); // center of the cell's face
-	std::vector<CCGFloat> cellParams;
-	cellParams.reserve (5);
-	cellParams.emplace_back (0.5 * (param.etaMax - param.etaMin)); // deta_half
-	cellParams.emplace_back (0.5 * param.dphi * DEGREE2RAD);  // dphi_half
-	cellParams.emplace_back (0.5 * (param.rMax - param.rMin) * cosh (etaCenter)); // dr_half
-	cellParams.emplace_back ( fabs( refPoint.eta() ) ) ;
-	cellParams.emplace_back ( fabs( refPoint.z() ) ) ;
+      for (int iside = -1; iside <= 1; iside += 2) {  // both detector sides are identical
+        HcalDetId hid(fHB ? HcalBarrel : HcalOuter, param.eta * iside, iPhi, param.depth);
+        float phiCenter = ((iPhi - 1) * 360. / MAX_HCAL_PHI + 0.5 * param.dphi) * DEGREE2RAD;  // middle of the cell
+        float etaCenter = 0.5 * (param.etaMin + param.etaMax);
+        float x = param.rMin * cos(phiCenter);
+        float y = param.rMin * sin(phiCenter);
+        float z = iside * param.rMin * sinh(etaCenter);
+        // make cell geometry
+        GlobalPoint refPoint(x, y, z);  // center of the cell's face
+        std::vector<CCGFloat> cellParams;
+        cellParams.reserve(5);
+        cellParams.emplace_back(0.5 * (param.etaMax - param.etaMin));                // deta_half
+        cellParams.emplace_back(0.5 * param.dphi * DEGREE2RAD);                      // dphi_half
+        cellParams.emplace_back(0.5 * (param.rMax - param.rMin) * cosh(etaCenter));  // dr_half
+        cellParams.emplace_back(fabs(refPoint.eta()));
+        cellParams.emplace_back(fabs(refPoint.z()));
 #ifdef DebugLog
-	std::cout << "HcalHardcodeGeometryLoader::fillHBHO-> " << hid << hid.ieta() << '/' << hid.iphi() << '/' << hid.depth() << refPoint << '/' << cellParams [0] << '/' << cellParams [1] << '/' << cellParams [2] << std::endl;
+        std::cout << "HcalHardcodeGeometryLoader::fillHBHO-> " << hid << hid.ieta() << '/' << hid.iphi() << '/'
+                  << hid.depth() << refPoint << '/' << cellParams[0] << '/' << cellParams[1] << '/' << cellParams[2]
+                  << std::endl;
 #endif
-	fGeometry->newCellFast(refPoint,  refPoint,  refPoint, 
-			   CaloCellGeometry::getParmPtr(cellParams, 
-							fGeometry->parMgr(), 
-							fGeometry->parVecVec()),
-			   hid ) ;
+        fGeometry->newCellFast(refPoint,
+                               refPoint,
+                               refPoint,
+                               CaloCellGeometry::getParmPtr(cellParams, fGeometry->parMgr(), fGeometry->parVecVec()),
+                               hid);
       }
     }
   }
 }
 
-
 // ----------> HE <-----------
-std::vector<HcalHardcodeGeometryLoader::HECellParameters> HcalHardcodeGeometryLoader::makeHECells (const HcalTopology & topology) {
-
-  std::vector <HcalHardcodeGeometryLoader::HECellParameters> result;
+std::vector<HcalHardcodeGeometryLoader::HECellParameters> HcalHardcodeGeometryLoader::makeHECells(
+    const HcalTopology& topology) {
+  std::vector<HcalHardcodeGeometryLoader::HECellParameters> result;
   const float HEZMIN = 400.458;
   const float HEZMID = 436.168;
   const float HEZMAX = 549.268;
   float normalDepths[3] = {HEZMIN, HEZMID, HEZMAX};
   float tripleDepths[4] = {HEZMIN, 418.768, HEZMID, HEZMAX};
-  float slhcDepths[5]   = {HEZMIN, 418.768, HEZMID, 493., HEZMAX};
-  float ring16Depths[2] = {418.768,470.968};
+  float slhcDepths[5] = {HEZMIN, 418.768, HEZMID, 493., HEZMAX};
+  float ring16Depths[2] = {418.768, 470.968};
   float ring16slhcDepths[3] = {418.768, 450., 470.968};
-  float ring17Depths[2] = {409.698,514.468};
+  float ring17Depths[2] = {409.698, 514.468};
   float ring17slhcDepths[5] = {409.698, 435., 460., 495., 514.468};
-  float ring18Depths[3] = {391.883,427.468,540.568};
-  float ring18slhcDepths[5] = {391.883, 439.,  467., 504. , 540.568};
-  float etaBounds[] = {0.087*15, 0.087*16, 0.087*17, 0.087*18,  0.087*19,
-		       1.74, 1.83,  1.93, 2.043, 2.172, 2.322, 2.500,
-		       2.650, 2.868, 3.000};
-  float layerDepths[19] = {HEZMIN, 408.718, 416.978, 425.248, 433.508, 441.768,
-			   450.038,458.298, 466.558, 474.828, 483.088, 491.348,
-			   499.618,507.878, 516.138, 524.398, 532.668, 540.928,
-			   HEZMAX};
+  float ring18Depths[3] = {391.883, 427.468, 540.568};
+  float ring18slhcDepths[5] = {391.883, 439., 467., 504., 540.568};
+  float etaBounds[] = {0.087 * 15,
+                       0.087 * 16,
+                       0.087 * 17,
+                       0.087 * 18,
+                       0.087 * 19,
+                       1.74,
+                       1.83,
+                       1.93,
+                       2.043,
+                       2.172,
+                       2.322,
+                       2.500,
+                       2.650,
+                       2.868,
+                       3.000};
+  float layerDepths[19] = {HEZMIN,
+                           408.718,
+                           416.978,
+                           425.248,
+                           433.508,
+                           441.768,
+                           450.038,
+                           458.298,
+                           466.558,
+                           474.828,
+                           483.088,
+                           491.348,
+                           499.618,
+                           507.878,
+                           516.138,
+                           524.398,
+                           532.668,
+                           540.928,
+                           HEZMAX};
 
   // count by ring - 16
-  for(int iringm16=0; iringm16 <= 13; ++iringm16) {
+  for (int iringm16 = 0; iringm16 <= 13; ++iringm16) {
     int iring = iringm16 + 16;
     std::vector<float> depths;
     unsigned int startingDepth = 1;
     if (topology.mode() != HcalTopologyMode::SLHC) {
-      if (iring == 16)     
-	{for (float ring16Depth : ring16Depths) depths.emplace_back(ring16Depth); startingDepth = 3;}
-      else if (iring == 17) 
-	for (float ring17Depth : ring17Depths) depths.emplace_back(ring17Depth);
-      else if (iring == 18) 
-	for (float ring18Depth : ring18Depths) depths.emplace_back(ring18Depth);
-      else if (iring == topology.lastHERing()) 
-	for (int i=0; i<3; ++i) depths.emplace_back(tripleDepths[i]);
+      if (iring == 16) {
+        for (float ring16Depth : ring16Depths)
+          depths.emplace_back(ring16Depth);
+        startingDepth = 3;
+      } else if (iring == 17)
+        for (float ring17Depth : ring17Depths)
+          depths.emplace_back(ring17Depth);
+      else if (iring == 18)
+        for (float ring18Depth : ring18Depths)
+          depths.emplace_back(ring18Depth);
+      else if (iring == topology.lastHERing())
+        for (int i = 0; i < 3; ++i)
+          depths.emplace_back(tripleDepths[i]);
       else if (iring >= topology.firstHETripleDepthRing())
-	for (float tripleDepth : tripleDepths) depths.emplace_back(tripleDepth);
+        for (float tripleDepth : tripleDepths)
+          depths.emplace_back(tripleDepth);
       else
-	for (float normalDepth : normalDepths) depths.emplace_back(normalDepth);
+        for (float normalDepth : normalDepths)
+          depths.emplace_back(normalDepth);
     } else {
       if (m_segmentation.size() >= (unsigned int)(iring)) {
-	int depth = m_segmentation[iring-1][0];
-	if (iring == 16)      depths.emplace_back(ring16Depths[0]);
-	else if (iring == 17) depths.emplace_back(ring17Depths[0]);
-	else if (iring == 18) depths.emplace_back(ring18Depths[0]);
-	else                  depths.emplace_back(layerDepths[depth]);
-	int layer = 1;
-	float lastDepth = depths[0];
-	for (unsigned int i=1; i<m_segmentation[iring-1].size(); ++i) {
-	  if (depth != m_segmentation[iring-1][i]) {
-	    depth = m_segmentation[iring-1][i];
-	    layer = i;
-	    if (layerDepths[depth] > lastDepth && (iring != 16 || depth > 3)) {
-	      depths.emplace_back(layerDepths[depth]);
-	      lastDepth = layerDepths[depth];
-	    }
-	  }
-	}
-	if (layer <= 17) depths.emplace_back(HEZMAX);
-	if (iring == 16) startingDepth = 3;
+        int depth = m_segmentation[iring - 1][0];
+        if (iring == 16)
+          depths.emplace_back(ring16Depths[0]);
+        else if (iring == 17)
+          depths.emplace_back(ring17Depths[0]);
+        else if (iring == 18)
+          depths.emplace_back(ring18Depths[0]);
+        else
+          depths.emplace_back(layerDepths[depth]);
+        int layer = 1;
+        float lastDepth = depths[0];
+        for (unsigned int i = 1; i < m_segmentation[iring - 1].size(); ++i) {
+          if (depth != m_segmentation[iring - 1][i]) {
+            depth = m_segmentation[iring - 1][i];
+            layer = i;
+            if (layerDepths[depth] > lastDepth && (iring != 16 || depth > 3)) {
+              depths.emplace_back(layerDepths[depth]);
+              lastDepth = layerDepths[depth];
+            }
+          }
+        }
+        if (layer <= 17)
+          depths.emplace_back(HEZMAX);
+        if (iring == 16)
+          startingDepth = 3;
       } else {
-	if (iring == 16)     {for (float ring16slhcDepth : ring16slhcDepths) depths.emplace_back(ring16slhcDepth); startingDepth = 3;}
-	else if (iring == 17) for (float ring17slhcDepth : ring17slhcDepths) depths.emplace_back(ring17slhcDepth);
-	else if (iring == 18) for (float ring18slhcDepth : ring18slhcDepths) depths.emplace_back(ring18slhcDepth);
-	else                  for (float slhcDepth : slhcDepths) depths.emplace_back(slhcDepth);
+        if (iring == 16) {
+          for (float ring16slhcDepth : ring16slhcDepths)
+            depths.emplace_back(ring16slhcDepth);
+          startingDepth = 3;
+        } else if (iring == 17)
+          for (float ring17slhcDepth : ring17slhcDepths)
+            depths.emplace_back(ring17slhcDepth);
+        else if (iring == 18)
+          for (float ring18slhcDepth : ring18slhcDepths)
+            depths.emplace_back(ring18slhcDepth);
+        else
+          for (float slhcDepth : slhcDepths)
+            depths.emplace_back(slhcDepth);
       }
     }
     float etamin = etaBounds[iringm16];
-    float etamax = etaBounds[iringm16+1];
-    unsigned int ndepth = depths.size()-1;
+    float etamax = etaBounds[iringm16 + 1];
+    unsigned int ndepth = depths.size() - 1;
     //    topology.depthBinInformation(HcalEndcap, iring, ndepth, startingDepth);
 #ifdef DebugLog
-    std::cout << "HERing " << iring << " eta " << etamin << ":" << etamax << " depths " << ndepth << ":" << startingDepth;
-    for (unsigned int i=0; i<depths.size(); ++i) std::cout << ":" << depths[i];
+    std::cout << "HERing " << iring << " eta " << etamin << ":" << etamax << " depths " << ndepth << ":"
+              << startingDepth;
+    for (unsigned int i = 0; i < depths.size(); ++i)
+      std::cout << ":" << depths[i];
     std::cout << "\n";
 #endif
     for (unsigned int idepth = 0; idepth < ndepth; ++idepth) {
       int depthIndex = (int)(idepth + startingDepth);
       float zmin = depths[idepth];
-      float zmax = depths[idepth+1];
+      float zmax = depths[idepth + 1];
       if (depthIndex <= 7) {
 #ifdef DebugLog
-	std::cout << "HE Depth " << idepth << ":" << depthIndex << " Z " << zmin << ":" << zmax << "\n";
+        std::cout << "HE Depth " << idepth << ":" << depthIndex << " Z " << zmin << ":" << zmax << "\n";
 #endif
-	int stepPhi = (iring >= topology.firstHEDoublePhiRing() ? 2 : 1);
-	int deltaPhi =  (iring >= topology.firstHEDoublePhiRing() ? 10 : 5);
-	if (topology.mode() != HcalTopologyMode::SLHC &&
-	    iring == topology.lastHERing()-1 && idepth == ndepth-1) {
+        int stepPhi = (iring >= topology.firstHEDoublePhiRing() ? 2 : 1);
+        int deltaPhi = (iring >= topology.firstHEDoublePhiRing() ? 10 : 5);
+        if (topology.mode() != HcalTopologyMode::SLHC && iring == topology.lastHERing() - 1 && idepth == ndepth - 1) {
 #ifdef DebugLog
-	  std::cout << "HE iEta " << iring << " Depth " << depthIndex << " Eta " << etamin << ":" << etaBounds[iringm16+2] << std::endl;
+          std::cout << "HE iEta " << iring << " Depth " << depthIndex << " Eta " << etamin << ":"
+                    << etaBounds[iringm16 + 2] << std::endl;
 #endif
-	  result.emplace_back(HcalHardcodeGeometryLoader::HECellParameters(iring, depthIndex, 1, stepPhi, deltaPhi, zmin, zmax, etamin, etaBounds[iringm16+2]));
-	} else {
+          result.emplace_back(HcalHardcodeGeometryLoader::HECellParameters(
+              iring, depthIndex, 1, stepPhi, deltaPhi, zmin, zmax, etamin, etaBounds[iringm16 + 2]));
+        } else {
 #ifdef DebugLog
-	  std::cout << "HE iEta " << iring << " Depth " << depthIndex << " Eta " << etamin << ":" << etamax << std::endl;
+          std::cout << "HE iEta " << iring << " Depth " << depthIndex << " Eta " << etamin << ":" << etamax
+                    << std::endl;
 #endif
-	  result.emplace_back(HcalHardcodeGeometryLoader::HECellParameters(iring, depthIndex, 1, stepPhi, deltaPhi, zmin, zmax, etamin, etamax));
-	}
+          result.emplace_back(HcalHardcodeGeometryLoader::HECellParameters(
+              iring, depthIndex, 1, stepPhi, deltaPhi, zmin, zmax, etamin, etamax));
+        }
       }
     }
   }
@@ -307,159 +381,158 @@ std::vector<HcalHardcodeGeometryLoader::HECellParameters> HcalHardcodeGeometryLo
   return result;
 }
 
-
 // ----------> HE @ H2 <-----------
-std::vector <HcalHardcodeGeometryLoader::HECellParameters> HcalHardcodeGeometryLoader::makeHECells_H2 () {
-
+std::vector<HcalHardcodeGeometryLoader::HECellParameters> HcalHardcodeGeometryLoader::makeHECells_H2() {
   const float HEZMIN_H2 = 400.715;
   const float HEZMID_H2 = 436.285;
   const float HEZMAX_H2 = 541.885;
-    
-  HcalHardcodeGeometryLoader::HECellParameters cells [] = {
-    // eta, depth, firstPhi, stepPhi, deltaPhi, zMin, zMax, etaMin, etaMax
-    HcalHardcodeGeometryLoader::HECellParameters ( 16, 3, 1, 1, 5, 409.885,   462.685,   1.305, 1.373),
-    HcalHardcodeGeometryLoader::HECellParameters ( 17, 1, 1, 1, 5, HEZMIN_H2, 427.485,   1.373, 1.444),
-    HcalHardcodeGeometryLoader::HECellParameters ( 17, 2, 1, 1, 5, 427.485,   506.685,   1.373, 1.444),
-    HcalHardcodeGeometryLoader::HECellParameters ( 18, 1, 1, 1, 5, HEZMIN_H2, HEZMID_H2, 1.444, 1.521),
-    HcalHardcodeGeometryLoader::HECellParameters ( 18, 2, 1, 1, 5, HEZMID_H2, 524.285,   1.444, 1.521),
-    HcalHardcodeGeometryLoader::HECellParameters ( 19, 1, 1, 1, 5, HEZMIN_H2, HEZMID_H2, 1.521, 1.603),
-    HcalHardcodeGeometryLoader::HECellParameters ( 19, 2, 1, 1, 5, HEZMID_H2, HEZMAX_H2, 1.521, 1.603),
-    HcalHardcodeGeometryLoader::HECellParameters ( 20, 1, 1, 1, 5, HEZMIN_H2, HEZMID_H2, 1.603, 1.693),
-    HcalHardcodeGeometryLoader::HECellParameters ( 20, 2, 1, 1, 5, HEZMID_H2, HEZMAX_H2, 1.603, 1.693),
-    HcalHardcodeGeometryLoader::HECellParameters ( 21, 1, 1, 2, 5, HEZMIN_H2, HEZMID_H2, 1.693, 1.79),
-    HcalHardcodeGeometryLoader::HECellParameters ( 21, 2, 1, 2, 5, HEZMID_H2, HEZMAX_H2, 1.693, 1.79),
-    HcalHardcodeGeometryLoader::HECellParameters ( 22, 1, 1, 2,10, HEZMIN_H2, HEZMID_H2, 1.79, 1.88),
-    HcalHardcodeGeometryLoader::HECellParameters ( 22, 2, 1, 2,10, HEZMID_H2, HEZMAX_H2, 1.79, 1.88),
-    HcalHardcodeGeometryLoader::HECellParameters ( 23, 1, 1, 2,10, HEZMIN_H2, HEZMID_H2, 1.88, 1.98),
-    HcalHardcodeGeometryLoader::HECellParameters ( 23, 2, 1, 2,10, HEZMID_H2, HEZMAX_H2, 1.88, 1.98),
-    HcalHardcodeGeometryLoader::HECellParameters ( 24, 1, 1, 2,10, HEZMIN_H2, 418.685,   1.98, 2.09),
-    HcalHardcodeGeometryLoader::HECellParameters ( 24, 2, 1, 2,10, 418.685,   HEZMID_H2, 1.98, 2.09),
-    HcalHardcodeGeometryLoader::HECellParameters ( 24, 3, 1, 2,10, HEZMID_H2, HEZMAX_H2, 1.98, 2.09),
-    HcalHardcodeGeometryLoader::HECellParameters ( 25, 1, 1, 2,10, HEZMIN_H2, 418.685,   2.09, 2.21),
-    HcalHardcodeGeometryLoader::HECellParameters ( 25, 2, 1, 2,10, 418.685,   HEZMID_H2, 2.09, 2.21),
-    HcalHardcodeGeometryLoader::HECellParameters ( 25, 3, 1, 2,10, HEZMID_H2, HEZMAX_H2, 2.09, 2.21)
-  };
-  int nCells = sizeof(cells)/sizeof(HcalHardcodeGeometryLoader::HECellParameters);
-  std::vector <HcalHardcodeGeometryLoader::HECellParameters> result;
-  result.reserve (nCells);
-  for (int i = 0; i < nCells; ++i) result.emplace_back (cells[i]);
+
+  HcalHardcodeGeometryLoader::HECellParameters cells[] = {
+      // eta, depth, firstPhi, stepPhi, deltaPhi, zMin, zMax, etaMin, etaMax
+      HcalHardcodeGeometryLoader::HECellParameters(16, 3, 1, 1, 5, 409.885, 462.685, 1.305, 1.373),
+      HcalHardcodeGeometryLoader::HECellParameters(17, 1, 1, 1, 5, HEZMIN_H2, 427.485, 1.373, 1.444),
+      HcalHardcodeGeometryLoader::HECellParameters(17, 2, 1, 1, 5, 427.485, 506.685, 1.373, 1.444),
+      HcalHardcodeGeometryLoader::HECellParameters(18, 1, 1, 1, 5, HEZMIN_H2, HEZMID_H2, 1.444, 1.521),
+      HcalHardcodeGeometryLoader::HECellParameters(18, 2, 1, 1, 5, HEZMID_H2, 524.285, 1.444, 1.521),
+      HcalHardcodeGeometryLoader::HECellParameters(19, 1, 1, 1, 5, HEZMIN_H2, HEZMID_H2, 1.521, 1.603),
+      HcalHardcodeGeometryLoader::HECellParameters(19, 2, 1, 1, 5, HEZMID_H2, HEZMAX_H2, 1.521, 1.603),
+      HcalHardcodeGeometryLoader::HECellParameters(20, 1, 1, 1, 5, HEZMIN_H2, HEZMID_H2, 1.603, 1.693),
+      HcalHardcodeGeometryLoader::HECellParameters(20, 2, 1, 1, 5, HEZMID_H2, HEZMAX_H2, 1.603, 1.693),
+      HcalHardcodeGeometryLoader::HECellParameters(21, 1, 1, 2, 5, HEZMIN_H2, HEZMID_H2, 1.693, 1.79),
+      HcalHardcodeGeometryLoader::HECellParameters(21, 2, 1, 2, 5, HEZMID_H2, HEZMAX_H2, 1.693, 1.79),
+      HcalHardcodeGeometryLoader::HECellParameters(22, 1, 1, 2, 10, HEZMIN_H2, HEZMID_H2, 1.79, 1.88),
+      HcalHardcodeGeometryLoader::HECellParameters(22, 2, 1, 2, 10, HEZMID_H2, HEZMAX_H2, 1.79, 1.88),
+      HcalHardcodeGeometryLoader::HECellParameters(23, 1, 1, 2, 10, HEZMIN_H2, HEZMID_H2, 1.88, 1.98),
+      HcalHardcodeGeometryLoader::HECellParameters(23, 2, 1, 2, 10, HEZMID_H2, HEZMAX_H2, 1.88, 1.98),
+      HcalHardcodeGeometryLoader::HECellParameters(24, 1, 1, 2, 10, HEZMIN_H2, 418.685, 1.98, 2.09),
+      HcalHardcodeGeometryLoader::HECellParameters(24, 2, 1, 2, 10, 418.685, HEZMID_H2, 1.98, 2.09),
+      HcalHardcodeGeometryLoader::HECellParameters(24, 3, 1, 2, 10, HEZMID_H2, HEZMAX_H2, 1.98, 2.09),
+      HcalHardcodeGeometryLoader::HECellParameters(25, 1, 1, 2, 10, HEZMIN_H2, 418.685, 2.09, 2.21),
+      HcalHardcodeGeometryLoader::HECellParameters(25, 2, 1, 2, 10, 418.685, HEZMID_H2, 2.09, 2.21),
+      HcalHardcodeGeometryLoader::HECellParameters(25, 3, 1, 2, 10, HEZMID_H2, HEZMAX_H2, 2.09, 2.21)};
+  int nCells = sizeof(cells) / sizeof(HcalHardcodeGeometryLoader::HECellParameters);
+  std::vector<HcalHardcodeGeometryLoader::HECellParameters> result;
+  result.reserve(nCells);
+  for (int i = 0; i < nCells; ++i)
+    result.emplace_back(cells[i]);
   return result;
 }
 
 // ----------> HF <-----------
-std::vector <HcalHardcodeGeometryLoader::HFCellParameters> HcalHardcodeGeometryLoader::makeHFCells () {
-
+std::vector<HcalHardcodeGeometryLoader::HFCellParameters> HcalHardcodeGeometryLoader::makeHFCells() {
   const float HFZMIN1 = 1115.;
   const float HFZMIN2 = 1137.;
   const float HFZMAX = 1280.1;
-    
-  HcalHardcodeGeometryLoader::HFCellParameters cells [] = {
-    // eta, depth, firstPhi, stepPhi, deltaPhi, zMin, zMax, rMin, rMax
-    HcalHardcodeGeometryLoader::HFCellParameters (29, 1, 1, 2, 10, HFZMIN1, HFZMAX,116.2,130.0),
-    HcalHardcodeGeometryLoader::HFCellParameters (29, 2, 1, 2, 10, HFZMIN2, HFZMAX,116.2,130.0),
-    HcalHardcodeGeometryLoader::HFCellParameters (30, 1, 1, 2, 10, HFZMIN1, HFZMAX, 97.5,116.2),
-    HcalHardcodeGeometryLoader::HFCellParameters (30, 2, 1, 2, 10, HFZMIN2, HFZMAX, 97.5,116.2),
-    HcalHardcodeGeometryLoader::HFCellParameters (31, 1, 1, 2, 10, HFZMIN1, HFZMAX, 81.8, 97.5),
-    HcalHardcodeGeometryLoader::HFCellParameters (31, 2, 1, 2, 10, HFZMIN2, HFZMAX, 81.8, 97.5),
-    HcalHardcodeGeometryLoader::HFCellParameters (32, 1, 1, 2, 10, HFZMIN1, HFZMAX, 68.6, 81.8),
-    HcalHardcodeGeometryLoader::HFCellParameters (32, 2, 1, 2, 10, HFZMIN2, HFZMAX, 68.6, 81.8),
-    HcalHardcodeGeometryLoader::HFCellParameters (33, 1, 1, 2, 10, HFZMIN1, HFZMAX, 57.6, 68.6),
-    HcalHardcodeGeometryLoader::HFCellParameters (33, 2, 1, 2, 10, HFZMIN2, HFZMAX, 57.6, 68.6),
-    HcalHardcodeGeometryLoader::HFCellParameters (34, 1, 1, 2, 10, HFZMIN1, HFZMAX, 48.3, 57.6),
-    HcalHardcodeGeometryLoader::HFCellParameters (34, 2, 1, 2, 10, HFZMIN2, HFZMAX, 48.3, 57.6),
-    HcalHardcodeGeometryLoader::HFCellParameters (35, 1, 1, 2, 10, HFZMIN1, HFZMAX, 40.6, 48.3),
-    HcalHardcodeGeometryLoader::HFCellParameters (35, 2, 1, 2, 10, HFZMIN2, HFZMAX, 40.6, 48.3),
-    HcalHardcodeGeometryLoader::HFCellParameters (36, 1, 1, 2, 10, HFZMIN1, HFZMAX, 34.0, 40.6),
-    HcalHardcodeGeometryLoader::HFCellParameters (36, 2, 1, 2, 10, HFZMIN2, HFZMAX, 34.0, 40.6),
-    HcalHardcodeGeometryLoader::HFCellParameters (37, 1, 1, 2, 10, HFZMIN1, HFZMAX, 28.6, 34.0),
-    HcalHardcodeGeometryLoader::HFCellParameters (37, 2, 1, 2, 10, HFZMIN2, HFZMAX, 28.6, 34.0),
-    HcalHardcodeGeometryLoader::HFCellParameters (38, 1, 1, 2, 10, HFZMIN1, HFZMAX, 24.0, 28.6),
-    HcalHardcodeGeometryLoader::HFCellParameters (38, 2, 1, 2, 10, HFZMIN2, HFZMAX, 24.0, 28.6),
-    HcalHardcodeGeometryLoader::HFCellParameters (39, 1, 1, 2, 10, HFZMIN1, HFZMAX, 20.1, 24.0),
-    HcalHardcodeGeometryLoader::HFCellParameters (39, 2, 1, 2, 10, HFZMIN2, HFZMAX, 20.1, 24.0),
-    HcalHardcodeGeometryLoader::HFCellParameters (40, 1, 3, 4, 20, HFZMIN1, HFZMAX, 16.9, 20.1),
-    HcalHardcodeGeometryLoader::HFCellParameters (40, 2, 3, 4, 20, HFZMIN2, HFZMAX, 16.9, 20.1),
-    HcalHardcodeGeometryLoader::HFCellParameters (41, 1, 3, 4, 20, HFZMIN1, HFZMAX, 12.5, 16.9),
-    HcalHardcodeGeometryLoader::HFCellParameters (41, 2, 3, 4, 20, HFZMIN2, HFZMAX, 12.5, 16.9)
-  };
-  int nCells = sizeof(cells)/sizeof(HcalHardcodeGeometryLoader::HFCellParameters);
-  std::vector <HcalHardcodeGeometryLoader::HFCellParameters> result;
-  result.reserve (nCells);
-  for (int i = 0; i < nCells; ++i) result.emplace_back (cells[i]);
+
+  HcalHardcodeGeometryLoader::HFCellParameters cells[] = {
+      // eta, depth, firstPhi, stepPhi, deltaPhi, zMin, zMax, rMin, rMax
+      HcalHardcodeGeometryLoader::HFCellParameters(29, 1, 1, 2, 10, HFZMIN1, HFZMAX, 116.2, 130.0),
+      HcalHardcodeGeometryLoader::HFCellParameters(29, 2, 1, 2, 10, HFZMIN2, HFZMAX, 116.2, 130.0),
+      HcalHardcodeGeometryLoader::HFCellParameters(30, 1, 1, 2, 10, HFZMIN1, HFZMAX, 97.5, 116.2),
+      HcalHardcodeGeometryLoader::HFCellParameters(30, 2, 1, 2, 10, HFZMIN2, HFZMAX, 97.5, 116.2),
+      HcalHardcodeGeometryLoader::HFCellParameters(31, 1, 1, 2, 10, HFZMIN1, HFZMAX, 81.8, 97.5),
+      HcalHardcodeGeometryLoader::HFCellParameters(31, 2, 1, 2, 10, HFZMIN2, HFZMAX, 81.8, 97.5),
+      HcalHardcodeGeometryLoader::HFCellParameters(32, 1, 1, 2, 10, HFZMIN1, HFZMAX, 68.6, 81.8),
+      HcalHardcodeGeometryLoader::HFCellParameters(32, 2, 1, 2, 10, HFZMIN2, HFZMAX, 68.6, 81.8),
+      HcalHardcodeGeometryLoader::HFCellParameters(33, 1, 1, 2, 10, HFZMIN1, HFZMAX, 57.6, 68.6),
+      HcalHardcodeGeometryLoader::HFCellParameters(33, 2, 1, 2, 10, HFZMIN2, HFZMAX, 57.6, 68.6),
+      HcalHardcodeGeometryLoader::HFCellParameters(34, 1, 1, 2, 10, HFZMIN1, HFZMAX, 48.3, 57.6),
+      HcalHardcodeGeometryLoader::HFCellParameters(34, 2, 1, 2, 10, HFZMIN2, HFZMAX, 48.3, 57.6),
+      HcalHardcodeGeometryLoader::HFCellParameters(35, 1, 1, 2, 10, HFZMIN1, HFZMAX, 40.6, 48.3),
+      HcalHardcodeGeometryLoader::HFCellParameters(35, 2, 1, 2, 10, HFZMIN2, HFZMAX, 40.6, 48.3),
+      HcalHardcodeGeometryLoader::HFCellParameters(36, 1, 1, 2, 10, HFZMIN1, HFZMAX, 34.0, 40.6),
+      HcalHardcodeGeometryLoader::HFCellParameters(36, 2, 1, 2, 10, HFZMIN2, HFZMAX, 34.0, 40.6),
+      HcalHardcodeGeometryLoader::HFCellParameters(37, 1, 1, 2, 10, HFZMIN1, HFZMAX, 28.6, 34.0),
+      HcalHardcodeGeometryLoader::HFCellParameters(37, 2, 1, 2, 10, HFZMIN2, HFZMAX, 28.6, 34.0),
+      HcalHardcodeGeometryLoader::HFCellParameters(38, 1, 1, 2, 10, HFZMIN1, HFZMAX, 24.0, 28.6),
+      HcalHardcodeGeometryLoader::HFCellParameters(38, 2, 1, 2, 10, HFZMIN2, HFZMAX, 24.0, 28.6),
+      HcalHardcodeGeometryLoader::HFCellParameters(39, 1, 1, 2, 10, HFZMIN1, HFZMAX, 20.1, 24.0),
+      HcalHardcodeGeometryLoader::HFCellParameters(39, 2, 1, 2, 10, HFZMIN2, HFZMAX, 20.1, 24.0),
+      HcalHardcodeGeometryLoader::HFCellParameters(40, 1, 3, 4, 20, HFZMIN1, HFZMAX, 16.9, 20.1),
+      HcalHardcodeGeometryLoader::HFCellParameters(40, 2, 3, 4, 20, HFZMIN2, HFZMAX, 16.9, 20.1),
+      HcalHardcodeGeometryLoader::HFCellParameters(41, 1, 3, 4, 20, HFZMIN1, HFZMAX, 12.5, 16.9),
+      HcalHardcodeGeometryLoader::HFCellParameters(41, 2, 3, 4, 20, HFZMIN2, HFZMAX, 12.5, 16.9)};
+  int nCells = sizeof(cells) / sizeof(HcalHardcodeGeometryLoader::HFCellParameters);
+  std::vector<HcalHardcodeGeometryLoader::HFCellParameters> result;
+  result.reserve(nCells);
+  for (int i = 0; i < nCells; ++i)
+    result.emplace_back(cells[i]);
   return result;
 }
-  
-void HcalHardcodeGeometryLoader::fillHE (HcalGeometry* fGeometry, const std::vector <HcalHardcodeGeometryLoader::HECellParameters>& fCells) {
 
+void HcalHardcodeGeometryLoader::fillHE(HcalGeometry* fGeometry,
+                                        const std::vector<HcalHardcodeGeometryLoader::HECellParameters>& fCells) {
   fGeometry->increaseReserve(fCells.size());
-  for (const auto & param : fCells) {
+  for (const auto& param : fCells) {
     for (int iPhi = param.phiFirst; iPhi <= MAX_HCAL_PHI; iPhi += param.phiStep) {
-      for (int iside = -1; iside <= 1; iside += 2) { // both detector sides are identical
-	HcalDetId hid (HcalEndcap, param.eta*iside, iPhi, param.depth);
-	float phiCenter = ((iPhi-1)*360./MAX_HCAL_PHI + 0.5*param.dphi) * DEGREE2RAD; // middle of the cell
-	float etaCenter = 0.5 * (param.etaMin + param.etaMax);
+      for (int iside = -1; iside <= 1; iside += 2) {  // both detector sides are identical
+        HcalDetId hid(HcalEndcap, param.eta * iside, iPhi, param.depth);
+        float phiCenter = ((iPhi - 1) * 360. / MAX_HCAL_PHI + 0.5 * param.dphi) * DEGREE2RAD;  // middle of the cell
+        float etaCenter = 0.5 * (param.etaMin + param.etaMax);
 
-	float perp = param.zMin / sinh (etaCenter);
-	float x = perp * cos (phiCenter);
-	float y = perp * sin (phiCenter);
-	float z = iside * param.zMin;
-	// make cell geometry
-	GlobalPoint refPoint (x,y,z); // center of the cell's face
-	std::vector<CCGFloat> cellParams;
-	cellParams.reserve (5);
-	cellParams.emplace_back (0.5 * (param.etaMax - param.etaMin)); //deta_half
-	cellParams.emplace_back (0.5 * param.dphi * DEGREE2RAD);  // dphi_half
-	cellParams.emplace_back (-0.5 * (param.zMax - param.zMin) / tanh (etaCenter)); // dz_half, "-" means edges in Z
-	cellParams.emplace_back ( fabs( refPoint.eta() ) ) ;
-	cellParams.emplace_back ( fabs( refPoint.z() ) ) ;
+        float perp = param.zMin / sinh(etaCenter);
+        float x = perp * cos(phiCenter);
+        float y = perp * sin(phiCenter);
+        float z = iside * param.zMin;
+        // make cell geometry
+        GlobalPoint refPoint(x, y, z);  // center of the cell's face
+        std::vector<CCGFloat> cellParams;
+        cellParams.reserve(5);
+        cellParams.emplace_back(0.5 * (param.etaMax - param.etaMin));                 //deta_half
+        cellParams.emplace_back(0.5 * param.dphi * DEGREE2RAD);                       // dphi_half
+        cellParams.emplace_back(-0.5 * (param.zMax - param.zMin) / tanh(etaCenter));  // dz_half, "-" means edges in Z
+        cellParams.emplace_back(fabs(refPoint.eta()));
+        cellParams.emplace_back(fabs(refPoint.z()));
 #ifdef DebugLog
-	std::cout << "HcalHardcodeGeometryLoader::fillHE-> " << hid << refPoint << '/' << cellParams [0] << '/' << cellParams [1] << '/' << cellParams [2] << std::endl;
+        std::cout << "HcalHardcodeGeometryLoader::fillHE-> " << hid << refPoint << '/' << cellParams[0] << '/'
+                  << cellParams[1] << '/' << cellParams[2] << std::endl;
 #endif
-	fGeometry->newCellFast(refPoint,  refPoint,  refPoint, 
-			   CaloCellGeometry::getParmPtr(cellParams, 
-							fGeometry->parMgr(), 
-							fGeometry->parVecVec()),
-			   hid ) ;
+        fGeometry->newCellFast(refPoint,
+                               refPoint,
+                               refPoint,
+                               CaloCellGeometry::getParmPtr(cellParams, fGeometry->parMgr(), fGeometry->parVecVec()),
+                               hid);
       }
     }
   }
 }
 
-void HcalHardcodeGeometryLoader::fillHF (HcalGeometry* fGeometry, const std::vector <HcalHardcodeGeometryLoader::HFCellParameters>& fCells) {
-
+void HcalHardcodeGeometryLoader::fillHF(HcalGeometry* fGeometry,
+                                        const std::vector<HcalHardcodeGeometryLoader::HFCellParameters>& fCells) {
   fGeometry->increaseReserve(fCells.size());
-  for (const auto & param : fCells) {
+  for (const auto& param : fCells) {
     for (int iPhi = param.phiFirst; iPhi <= MAX_HCAL_PHI; iPhi += param.phiStep) {
-      for (int iside = -1; iside <= 1; iside += 2) { // both detector sides are identical
-	HcalDetId hid (HcalForward, param.eta*iside, iPhi, param.depth);
-	float phiCenter = ((iPhi-1)*360./MAX_HCAL_PHI + 0.5*param.dphi) * DEGREE2RAD; // middle of the cell
-	GlobalPoint inner (param.rMin, 0, param.zMin);
-	GlobalPoint outer (param.rMax, 0, param.zMin);
-	float iEta = inner.eta();
-	float oEta = outer.eta();
-	float etaCenter = 0.5 * ( iEta + oEta );
-	
-	float perp = param.zMin / sinh (etaCenter);
-	float x = perp * cos (phiCenter);
-	float y = perp * sin (phiCenter);
-	float z = iside * param.zMin;
-	// make cell geometry
-	GlobalPoint refPoint (x,y,z); // center of the cell's face
-	std::vector<CCGFloat> cellParams;
-	cellParams.reserve (5);
-	cellParams.emplace_back (0.5 * ( iEta - oEta )); // deta_half
-	cellParams.emplace_back (0.5 * param.dphi * DEGREE2RAD);  // dphi_half
-	cellParams.emplace_back (0.5 * (param.zMax - param.zMin)); // dz_half
-	cellParams.emplace_back ( fabs( refPoint.eta()));
-	cellParams.emplace_back ( fabs( refPoint.z() ) ) ;
+      for (int iside = -1; iside <= 1; iside += 2) {  // both detector sides are identical
+        HcalDetId hid(HcalForward, param.eta * iside, iPhi, param.depth);
+        float phiCenter = ((iPhi - 1) * 360. / MAX_HCAL_PHI + 0.5 * param.dphi) * DEGREE2RAD;  // middle of the cell
+        GlobalPoint inner(param.rMin, 0, param.zMin);
+        GlobalPoint outer(param.rMax, 0, param.zMin);
+        float iEta = inner.eta();
+        float oEta = outer.eta();
+        float etaCenter = 0.5 * (iEta + oEta);
+
+        float perp = param.zMin / sinh(etaCenter);
+        float x = perp * cos(phiCenter);
+        float y = perp * sin(phiCenter);
+        float z = iside * param.zMin;
+        // make cell geometry
+        GlobalPoint refPoint(x, y, z);  // center of the cell's face
+        std::vector<CCGFloat> cellParams;
+        cellParams.reserve(5);
+        cellParams.emplace_back(0.5 * (iEta - oEta));              // deta_half
+        cellParams.emplace_back(0.5 * param.dphi * DEGREE2RAD);    // dphi_half
+        cellParams.emplace_back(0.5 * (param.zMax - param.zMin));  // dz_half
+        cellParams.emplace_back(fabs(refPoint.eta()));
+        cellParams.emplace_back(fabs(refPoint.z()));
 #ifdef DebugLog
-	std::cout << "HcalHardcodeGeometryLoader::fillHF-> " << hid << refPoint << '/' << cellParams [0] << '/' << cellParams [1] << '/' << cellParams [2] << std::endl;
-#endif	
-	fGeometry->newCellFast(refPoint,  refPoint,  refPoint, 
-			   CaloCellGeometry::getParmPtr(cellParams, 
-							fGeometry->parMgr(), 
-							fGeometry->parVecVec()),
-			   hid ) ;
+        std::cout << "HcalHardcodeGeometryLoader::fillHF-> " << hid << refPoint << '/' << cellParams[0] << '/'
+                  << cellParams[1] << '/' << cellParams[2] << std::endl;
+#endif
+        fGeometry->newCellFast(refPoint,
+                               refPoint,
+                               refPoint,
+                               CaloCellGeometry::getParmPtr(cellParams, fGeometry->parMgr(), fGeometry->parVecVec()),
+                               hid);
       }
     }
   }

--- a/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
@@ -5,88 +5,83 @@
 #include <iostream>
 #include <cassert>
 
-HcalTrigTowerGeometry::HcalTrigTowerGeometry( const HcalTopology* topology )
-   : theTopology(topology)
-{
-   auto tmode = theTopology->triggerMode();
-   useRCT_ = tmode <= HcalTopologyMode::TriggerMode_2016;
-   use1x1_ = tmode >= HcalTopologyMode::TriggerMode_2016;
-   use2017_ = tmode >= HcalTopologyMode::TriggerMode_2017 or
-              tmode == HcalTopologyMode::TriggerMode_2018legacy;
+HcalTrigTowerGeometry::HcalTrigTowerGeometry(const HcalTopology* topology) : theTopology(topology) {
+  auto tmode = theTopology->triggerMode();
+  useRCT_ = tmode <= HcalTopologyMode::TriggerMode_2016;
+  use1x1_ = tmode >= HcalTopologyMode::TriggerMode_2016;
+  use2017_ = tmode >= HcalTopologyMode::TriggerMode_2017 or tmode == HcalTopologyMode::TriggerMode_2018legacy;
 }
 
-std::vector<HcalTrigTowerDetId> 
-HcalTrigTowerGeometry::towerIds(const HcalDetId & cellId) const {
-
+std::vector<HcalTrigTowerDetId> HcalTrigTowerGeometry::towerIds(const HcalDetId& cellId) const {
   std::vector<HcalTrigTowerDetId> results;
 
-  if(cellId.subdet() == HcalForward) {
-
-    if (useRCT_) { 
+  if (cellId.subdet() == HcalForward) {
+    if (useRCT_) {
       // first do eta
       int hfRing = cellId.ietaAbs();
-      int ieta = firstHFTower(0); 
+      int ieta = firstHFTower(0);
       // find the tower that contains this ring
-      while(hfRing >= firstHFRingInTower(ieta+1)) {
-	++ieta;
+      while (hfRing >= firstHFRingInTower(ieta + 1)) {
+        ++ieta;
       }
-      
+
       ieta *= cellId.zside();
-      
+
       // now for phi
       // HF towers are quad, 18 in phi.
       // go two cells per trigger tower.
-      
-      int iphi = (((cellId.iphi()+1)/4) * 4 + 1)%72; // 71+1 --> 1, 3+5 --> 5
-      results.emplace_back( HcalTrigTowerDetId(ieta, iphi) );
-    } 
+
+      int iphi = (((cellId.iphi() + 1) / 4) * 4 + 1) % 72;  // 71+1 --> 1, 3+5 --> 5
+      results.emplace_back(HcalTrigTowerDetId(ieta, iphi));
+    }
     if (use1x1_) {
       int hfRing = cellId.ietaAbs();
-      if (hfRing==29) hfRing=30; // sum 29 into 30.
+      if (hfRing == 29)
+        hfRing = 30;  // sum 29 into 30.
 
-      int ieta = hfRing*cellId.zside();      
+      int ieta = hfRing * cellId.zside();
       int iphi = cellId.iphi();
 
-      HcalTrigTowerDetId id(ieta,iphi);
-      id.setVersion(1); // version 1 for 1x1 HF granularity
+      HcalTrigTowerDetId id(ieta, iphi);
+      id.setVersion(1);  // version 1 for 1x1 HF granularity
       results.emplace_back(id);
     }
-      
+
   } else {
     // the first twenty rings are one-to-one
-    if (cellId.ietaAbs() <= theTopology->lastHBRing()) {    
-      results.emplace_back( HcalTrigTowerDetId(cellId.ieta(), cellId.iphi()) );
+    if (cellId.ietaAbs() <= theTopology->lastHBRing()) {
+      results.emplace_back(HcalTrigTowerDetId(cellId.ieta(), cellId.iphi()));
     } else if (theTopology->maxDepthHE() == 0) {
-      // Ignore these    
-    } else if (cellId.ietaAbs() < theTopology->firstHEDoublePhiRing()) {    
-      results.emplace_back( HcalTrigTowerDetId(cellId.ieta(), cellId.iphi()) );
+      // Ignore these
+    } else if (cellId.ietaAbs() < theTopology->firstHEDoublePhiRing()) {
+      results.emplace_back(HcalTrigTowerDetId(cellId.ieta(), cellId.iphi()));
     } else {
       // the remaining rings are two-to-one in phi
       int iphi1 = cellId.iphi();
       int ieta = cellId.ieta();
       int depth = cellId.depth();
       // the last eta ring in HE is split.  Recombine.
-      if(ieta == theTopology->lastHERing()) --ieta;
-      if(ieta == -theTopology->lastHERing()) ++ieta;
+      if (ieta == theTopology->lastHERing())
+        --ieta;
+      if (ieta == -theTopology->lastHERing())
+        ++ieta;
 
       if (use2017_) {
-         if (ieta == 26 and depth == 7)
-            ++ieta;
-         if (ieta == -26 and depth == 7)
-            --ieta;
+        if (ieta == 26 and depth == 7)
+          ++ieta;
+        if (ieta == -26 and depth == 7)
+          --ieta;
       }
 
-      results.emplace_back( HcalTrigTowerDetId(ieta, iphi1) );
-      results.emplace_back( HcalTrigTowerDetId(ieta, iphi1+1) );
+      results.emplace_back(HcalTrigTowerDetId(ieta, iphi1));
+      results.emplace_back(HcalTrigTowerDetId(ieta, iphi1 + 1));
     }
   }
 
   return results;
 }
 
-
-std::vector<HcalDetId>
-HcalTrigTowerGeometry::detIds(const HcalTrigTowerDetId & hcalTrigTowerDetId) const {
+std::vector<HcalDetId> HcalTrigTowerGeometry::detIds(const HcalTrigTowerDetId& hcalTrigTowerDetId) const {
   // Written, tested by E. Berry (Princeton)
   std::vector<HcalDetId> results;
 
@@ -99,153 +94,155 @@ HcalTrigTowerGeometry::detIds(const HcalTrigTowerDetId & hcalTrigTowerDetId) con
   int min_depth, n_depths;
 
   // HB
-  
-  if (abs(cell_ieta) <= theTopology->lastHBRing()){
-    theTopology->depthBinInformation(HcalBarrel, abs(tower_ieta), tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
+
+  if (abs(cell_ieta) <= theTopology->lastHBRing()) {
+    theTopology->depthBinInformation(
+        HcalBarrel, abs(tower_ieta), tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
     for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
-      results.emplace_back(HcalDetId(HcalBarrel,cell_ieta,cell_iphi,cell_depth));
+      results.emplace_back(HcalDetId(HcalBarrel, cell_ieta, cell_iphi, cell_depth));
   }
 
   // HO
-  
-  if (abs(cell_ieta) <= theTopology->lastHORing()){ 
-    theTopology->depthBinInformation(HcalOuter , abs(tower_ieta), tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);  
+
+  if (abs(cell_ieta) <= theTopology->lastHORing()) {
+    theTopology->depthBinInformation(
+        HcalOuter, abs(tower_ieta), tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
     for (int ho_depth = min_depth; ho_depth <= min_depth + n_depths - 1; ho_depth++)
-      results.emplace_back(HcalDetId(HcalOuter, cell_ieta,cell_iphi,ho_depth));
+      results.emplace_back(HcalDetId(HcalOuter, cell_ieta, cell_iphi, ho_depth));
   }
 
-  // HE 
+  // HE
 
-  if (abs(cell_ieta) >= theTopology->firstHERing() && 
-      abs(cell_ieta) <  theTopology->lastHERing()){   
+  if (abs(cell_ieta) >= theTopology->firstHERing() && abs(cell_ieta) < theTopology->lastHERing()) {
+    theTopology->depthBinInformation(
+        HcalEndcap, abs(tower_ieta), tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
 
-    theTopology->depthBinInformation(HcalEndcap, abs(tower_ieta), tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
-    
     // Special for double-phi cells
     if (abs(cell_ieta) >= theTopology->firstHEDoublePhiRing())
-      if (tower_iphi%2 == 0) cell_iphi = tower_iphi - 1;
+      if (tower_iphi % 2 == 0)
+        cell_iphi = tower_iphi - 1;
 
     if (use2017_) {
-         if (abs(tower_ieta) == 26)
-            --n_depths;
-         if (tower_ieta == 27)
-            results.emplace_back(HcalDetId(HcalEndcap, cell_ieta - 1, cell_iphi, 7));
-         if (tower_ieta == -27)
-            results.emplace_back(HcalDetId(HcalEndcap, cell_ieta + 1, cell_iphi, 7));
+      if (abs(tower_ieta) == 26)
+        --n_depths;
+      if (tower_ieta == 27)
+        results.emplace_back(HcalDetId(HcalEndcap, cell_ieta - 1, cell_iphi, 7));
+      if (tower_ieta == -27)
+        results.emplace_back(HcalDetId(HcalEndcap, cell_ieta + 1, cell_iphi, 7));
     }
-    
+
     for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
       results.emplace_back(HcalDetId(HcalEndcap, cell_ieta, cell_iphi, cell_depth));
-    
+
     // Special for split-eta cells
-    if (abs(tower_ieta) == 28){
-      theTopology->depthBinInformation(HcalEndcap, abs(tower_ieta)+1, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
-      for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++){
-	if (tower_ieta < 0) results.emplace_back(HcalDetId(HcalEndcap, tower_ieta - 1, cell_iphi, cell_depth));
-	if (tower_ieta > 0) results.emplace_back(HcalDetId(HcalEndcap, tower_ieta + 1, cell_iphi, cell_depth));
+    if (abs(tower_ieta) == 28) {
+      theTopology->depthBinInformation(
+          HcalEndcap, abs(tower_ieta) + 1, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
+      for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++) {
+        if (tower_ieta < 0)
+          results.emplace_back(HcalDetId(HcalEndcap, tower_ieta - 1, cell_iphi, cell_depth));
+        if (tower_ieta > 0)
+          results.emplace_back(HcalDetId(HcalEndcap, tower_ieta + 1, cell_iphi, cell_depth));
       }
     }
-    
   }
-    
-  // HF 
 
-  if (abs(cell_ieta) >= theTopology->firstHFRing()){  
+  // HF
 
-    if (hcalTrigTowerDetId.version()==0) {
-    
-      int HfTowerPhiSize =  72 / nPhiBins(tower_ieta,0);
+  if (abs(cell_ieta) >= theTopology->firstHFRing()) {
+    if (hcalTrigTowerDetId.version() == 0) {
+      int HfTowerPhiSize = 72 / nPhiBins(tower_ieta, 0);
 
-      int HfTowerEtaSize     = hfTowerEtaSize(tower_ieta);
+      int HfTowerEtaSize = hfTowerEtaSize(tower_ieta);
       int FirstHFRingInTower = firstHFRingInTower(abs(tower_ieta));
 
-      for (int iHFTowerPhiSegment = 0; iHFTowerPhiSegment < HfTowerPhiSize; iHFTowerPhiSegment++){      
-            
-	cell_iphi =  (tower_iphi / HfTowerPhiSize) * HfTowerPhiSize; // Find the minimum phi segment
-	cell_iphi -= 2; // The first trigger tower starts at HCAL iphi = 71, not HCAL iphi = 1
-	cell_iphi += iHFTowerPhiSegment;       // Get all of the HCAL iphi values in this trigger tower
-	cell_iphi += 72;                       // Don't want to take the mod of a negative number
-	cell_iphi =  cell_iphi % 72;           // There are, at most, 72 cells.
-	cell_iphi += 1;// There is no cell at iphi = 0
-      
-	if (cell_iphi%2 == 0) continue;        // These cells don't exist.
+      for (int iHFTowerPhiSegment = 0; iHFTowerPhiSegment < HfTowerPhiSize; iHFTowerPhiSegment++) {
+        cell_iphi = (tower_iphi / HfTowerPhiSize) * HfTowerPhiSize;  // Find the minimum phi segment
+        cell_iphi -= 2;                   // The first trigger tower starts at HCAL iphi = 71, not HCAL iphi = 1
+        cell_iphi += iHFTowerPhiSegment;  // Get all of the HCAL iphi values in this trigger tower
+        cell_iphi += 72;                  // Don't want to take the mod of a negative number
+        cell_iphi = cell_iphi % 72;       // There are, at most, 72 cells.
+        cell_iphi += 1;                   // There is no cell at iphi = 0
 
-	for (int iHFTowerEtaSegment = 0; iHFTowerEtaSegment < HfTowerEtaSize; iHFTowerEtaSegment++){
-		
-	  cell_ieta = FirstHFRingInTower + iHFTowerEtaSegment;
+        if (cell_iphi % 2 == 0)
+          continue;  // These cells don't exist.
 
-	  if (cell_ieta >= 40 && cell_iphi%4 == 1) continue;  // These cells don't exist.
+        for (int iHFTowerEtaSegment = 0; iHFTowerEtaSegment < HfTowerEtaSize; iHFTowerEtaSegment++) {
+          cell_ieta = FirstHFRingInTower + iHFTowerEtaSegment;
 
-	  theTopology->depthBinInformation(HcalForward, cell_ieta, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);  
-	  
-	  // Negative tower_ieta -> negative cell_ieta
-	  int zside = 1;
-	  if (tower_ieta < 0) zside = -1;
+          if (cell_ieta >= 40 && cell_iphi % 4 == 1)
+            continue;  // These cells don't exist.
 
-	  cell_ieta *= zside;	       
+          theTopology->depthBinInformation(
+              HcalForward, cell_ieta, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
 
-	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
-	    results.emplace_back(HcalDetId(HcalForward, cell_ieta, cell_iphi, cell_depth));
-	
-	  if ( zside * cell_ieta == 30 ) {
-	    theTopology->depthBinInformation(HcalForward, 29 * zside, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);  
-	    for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++) 
-	      results.emplace_back(HcalDetId(HcalForward, 29 * zside , cell_iphi, cell_depth));
-	  }
-	}
-      }  
-    } else if (hcalTrigTowerDetId.version()==1) {
-      theTopology->depthBinInformation(HcalForward, tower_ieta, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);  
+          // Negative tower_ieta -> negative cell_ieta
+          int zside = 1;
+          if (tower_ieta < 0)
+            zside = -1;
+
+          cell_ieta *= zside;
+
+          for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+            results.emplace_back(HcalDetId(HcalForward, cell_ieta, cell_iphi, cell_depth));
+
+          if (zside * cell_ieta == 30) {
+            theTopology->depthBinInformation(
+                HcalForward, 29 * zside, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
+            for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+              results.emplace_back(HcalDetId(HcalForward, 29 * zside, cell_iphi, cell_depth));
+          }
+        }
+      }
+    } else if (hcalTrigTowerDetId.version() == 1) {
+      theTopology->depthBinInformation(
+          HcalForward, tower_ieta, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
       for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
-	results.emplace_back(HcalDetId(HcalForward, tower_ieta, tower_iphi, cell_depth));      
-      if (abs(tower_ieta)==30) {
-	int i29 = 29;
-	  if (tower_ieta < 0) i29 = -29;
-	  theTopology->depthBinInformation(HcalForward, i29, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);  
-	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
-	    results.emplace_back(HcalDetId(HcalForward, i29, tower_iphi, cell_depth));      
+        results.emplace_back(HcalDetId(HcalForward, tower_ieta, tower_iphi, cell_depth));
+      if (abs(tower_ieta) == 30) {
+        int i29 = 29;
+        if (tower_ieta < 0)
+          i29 = -29;
+        theTopology->depthBinInformation(HcalForward, i29, tower_iphi, hcalTrigTowerDetId.zside(), n_depths, min_depth);
+        for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+          results.emplace_back(HcalDetId(HcalForward, i29, tower_iphi, cell_depth));
       }
     }
   }
-  
+
   return results;
 }
 
-
 int HcalTrigTowerGeometry::hfTowerEtaSize(int ieta) const {
-  
-  int ietaAbs = abs(ieta); 
+  int ietaAbs = abs(ieta);
   assert(ietaAbs >= firstHFTower(0) && ietaAbs <= nTowers(0));
   // the first three come from rings 29-31, 32-34, 35-37. The last has 4 rings: 38-41
   return (ietaAbs == nTowers(0)) ? 4 : 3;
-  
 }
-
 
 int HcalTrigTowerGeometry::firstHFRingInTower(int ietaTower) const {
   // count up to the correct HF ring
   int inputTower = abs(ietaTower);
   int result = theTopology->firstHFRing();
-  for(int iTower = firstHFTower(0); iTower != inputTower; ++iTower) {
+  for (int iTower = firstHFTower(0); iTower != inputTower; ++iTower) {
     result += hfTowerEtaSize(iTower);
   }
-  
+
   // negative in, negative out.
-  if(ietaTower < 0) result *= -1;
+  if (ietaTower < 0)
+    result *= -1;
   return result;
 }
 
-
-void HcalTrigTowerGeometry::towerEtaBounds(int ieta, int version, double & eta1, double & eta2) const {
+void HcalTrigTowerGeometry::towerEtaBounds(int ieta, int version, double& eta1, double& eta2) const {
   int ietaAbs = abs(ieta);
-  std::pair<double,double> etas = 
-    (ietaAbs < firstHFTower(version)) ? theTopology->etaRange(HcalBarrel,ietaAbs) : 
-    theTopology->etaRange(HcalForward,ietaAbs);
+  std::pair<double, double> etas = (ietaAbs < firstHFTower(version)) ? theTopology->etaRange(HcalBarrel, ietaAbs)
+                                                                     : theTopology->etaRange(HcalForward, ietaAbs);
   eta1 = etas.first;
   eta2 = etas.second;
-  
+
   // get the signs and order right
-  if(ieta < 0) {
+  if (ieta < 0) {
     double tmp = eta1;
     eta1 = -eta2;
     eta2 = -tmp;

--- a/Geometry/HcalTowerAlgo/test/CaloTowerGeometryAnalyzer.cc
+++ b/Geometry/HcalTowerAlgo/test/CaloTowerGeometryAnalyzer.cc
@@ -14,13 +14,8 @@
 #include <iostream>
 #include <cmath>
 
-namespace 
-{
-  bool
-  AreSame( double a, double b, double epsilon )
-  {
-    return std::fabs( a - b ) < epsilon;
-  }
+namespace {
+  bool AreSame(double a, double b, double epsilon) { return std::fabs(a - b) < epsilon; }
 
   /*
   inline double
@@ -30,23 +25,16 @@ namespace
     return floor( n * mult ) / mult;
   }
   */
-  
-  std::map<int, std::string> hcalmapping = {{1, "HB"},
-					    {2, "HE"},
-					    {3, "HO"},
-					    {4, "HF"},
-					    {5, "HT"},
-					    {6, "ZDC"},
-					    {0, "Empty"}
-  };
-}
 
-class CaloTowerGeometryAnalyzer : public edm::one::EDAnalyzer<> 
-{
+  std::map<int, std::string> hcalmapping = {
+      {1, "HB"}, {2, "HE"}, {3, "HO"}, {4, "HF"}, {5, "HT"}, {6, "ZDC"}, {0, "Empty"}};
+}  // namespace
+
+class CaloTowerGeometryAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit CaloTowerGeometryAnalyzer( const edm::ParameterSet& );
-  ~CaloTowerGeometryAnalyzer( void ) override;
-    
+  explicit CaloTowerGeometryAnalyzer(const edm::ParameterSet&);
+  ~CaloTowerGeometryAnalyzer(void) override;
+
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
@@ -56,167 +44,129 @@ private:
   double m_epsilon;
 };
 
-CaloTowerGeometryAnalyzer::CaloTowerGeometryAnalyzer( const edm::ParameterSet& iConfig )
-  : m_fname( "CaloTower.cells" ),
-    m_epsilon( 0.004 )
-{
-  m_fname = iConfig.getParameter<std::string>( "FileName" );
-  m_epsilon = iConfig.getParameter<double>( "Epsilon" );
+CaloTowerGeometryAnalyzer::CaloTowerGeometryAnalyzer(const edm::ParameterSet& iConfig)
+    : m_fname("CaloTower.cells"), m_epsilon(0.004) {
+  m_fname = iConfig.getParameter<std::string>("FileName");
+  m_epsilon = iConfig.getParameter<double>("Epsilon");
 }
 
-CaloTowerGeometryAnalyzer::~CaloTowerGeometryAnalyzer( void )
-{
-}
+CaloTowerGeometryAnalyzer::~CaloTowerGeometryAnalyzer(void) {}
 
-void
-CaloTowerGeometryAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup )
-{
-  std::fstream fAll( std::string( m_fname + ".all" ).c_str(), std::ios_base::out );
-  std::fstream f( std::string( m_fname + ".diff" ).c_str(), std::ios_base::out );
+void CaloTowerGeometryAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
+  std::fstream fAll(std::string(m_fname + ".all").c_str(), std::ios_base::out);
+  std::fstream f(std::string(m_fname + ".diff").c_str(), std::ios_base::out);
 
   edm::ESHandle<CaloGeometry> caloGeomHandle;
   iSetup.get<CaloGeometryRecord>().get(caloGeomHandle);
   const CaloGeometry* caloGeom = caloGeomHandle.product();
 
-  const std::vector<DetId>& dha( caloGeom->getSubdetectorGeometry( DetId::Hcal, 1 )->getValidDetIds());
+  const std::vector<DetId>& dha(caloGeom->getSubdetectorGeometry(DetId::Hcal, 1)->getValidDetIds());
 
-  const std::vector< DetId >& ids (caloGeom->getValidDetIds());
+  const std::vector<DetId>& ids(caloGeom->getValidDetIds());
 
-  fAll << std::setw( 4 ) << "iEta"
-       << std::setw( 4 ) << "iPhi"
-       << std::setw( 4 ) << "Z"
-       << std::setw( 10 ) << "Sub:Depth"
-       << std::setw( 6 ) << "Eta"
-       << std::setw( 13 ) << "Phi"
-       << std::setw( 18 ) << "Corners in Eta\n";
-  
-  f << std::setw( 4 ) << "iEta"
-    << std::setw( 4 ) << "iPhi"
-    << std::setw( 4 ) << "Z"
-    << std::setw( 10 ) << "Sub:Depth"
-    << std::setw( 6 ) << "Eta"
-    << std::setw( 13 ) << "Phi"
-    << std::setw( 18 ) << "Corners in Eta\n";
+  fAll << std::setw(4) << "iEta" << std::setw(4) << "iPhi" << std::setw(4) << "Z" << std::setw(10) << "Sub:Depth"
+       << std::setw(6) << "Eta" << std::setw(13) << "Phi" << std::setw(18) << "Corners in Eta\n";
 
-  for(auto id : ids)
-  {    
-    const CaloGenericDetId cgid( id );
-    if( cgid.isCaloTower()) 
-    {
-      const CaloTowerDetId cid( id );
-      const int ie( cid.ieta());
-      const int ip( cid.iphi());
-      const int iz( cid.zside());
-      
-      fAll << std::setw( 4 ) << ie
-	   << std::setw( 4 ) << ip
-	   << std::setw( 4 ) << iz
-	   << std::setw( 6 ) << "-";
-      
-      auto cell = caloGeom->getGeometry( id );
-      assert( cell );
+  f << std::setw(4) << "iEta" << std::setw(4) << "iPhi" << std::setw(4) << "Z" << std::setw(10) << "Sub:Depth"
+    << std::setw(6) << "Eta" << std::setw(13) << "Phi" << std::setw(18) << "Corners in Eta\n";
+
+  for (auto id : ids) {
+    const CaloGenericDetId cgid(id);
+    if (cgid.isCaloTower()) {
+      const CaloTowerDetId cid(id);
+      const int ie(cid.ieta());
+      const int ip(cid.iphi());
+      const int iz(cid.zside());
+
+      fAll << std::setw(4) << ie << std::setw(4) << ip << std::setw(4) << iz << std::setw(6) << "-";
+
+      auto cell = caloGeom->getGeometry(id);
+      assert(cell);
       const GlobalPoint& pos = cell->getPosition();
       double eta = pos.eta();
       double phi = pos.phi();
-      fAll << std::setw( 10 ) << eta << std::setw( 13 ) << phi;
+      fAll << std::setw(10) << eta << std::setw(13) << phi;
 
       const CaloCellGeometry::CornersVec& corners(cell->getCorners());
-      for( unsigned int i( 0 ); i != corners.size() ; ++i ) 
-      {
-	const GlobalPoint& cpos = corners[ i ];
-	double ceta = cpos.eta();
+      for (unsigned int i(0); i != corners.size(); ++i) {
+        const GlobalPoint& cpos = corners[i];
+        double ceta = cpos.eta();
 
-	fAll << std::setw( 13 ) << ceta;
+        fAll << std::setw(13) << ceta;
       }
       fAll << "\n";
-      
-      for(auto ii : dha)
-      {
-	const HcalDetId hid( ii );
-	const int iie( hid.ieta());
-	const int iip( hid.iphi());
-	const int iiz( hid.zside());
-	const int iid( hid.depth());
 
-	if( ie == iie && ip == iip && iz == iiz ) 
-	{
-	  fAll << std::setw( 4 ) << iie
-	       << std::setw( 4 ) << iip
-	       << std::setw( 4 ) << iiz;
+      for (auto ii : dha) {
+        const HcalDetId hid(ii);
+        const int iie(hid.ieta());
+        const int iip(hid.iphi());
+        const int iiz(hid.zside());
+        const int iid(hid.depth());
 
-	  std::map<int, std::string>::const_iterator iter = hcalmapping.find( hid.subdet());
-	  if( iter != hcalmapping.end())
-	  {
-	    fAll << std::setw( 4 ) << iter->second.c_str() << ":" << iid;
-	  }
-	  
-	  auto hcell = caloGeom->getGeometry( ii );
-	  assert( hcell );
-	  const GlobalPoint& hpos = hcell->getPosition();
-	  double heta = hpos.eta();
-	  double hphi = hpos.phi();
-	  
-	  fAll << std::setw( 10 ) << heta << std::setw( 13 ) << hphi;
+        if (ie == iie && ip == iip && iz == iiz) {
+          fAll << std::setw(4) << iie << std::setw(4) << iip << std::setw(4) << iiz;
 
-	  const CaloCellGeometry::CornersVec& hcorners(hcell->getCorners());
-	  for( unsigned int i( 0 ) ; i != hcorners.size() ; ++i ) 
-	  {
-	    const GlobalPoint& hcpos = hcorners[ i ];
-	    double hceta = hcpos.eta();
+          std::map<int, std::string>::const_iterator iter = hcalmapping.find(hid.subdet());
+          if (iter != hcalmapping.end()) {
+            fAll << std::setw(4) << iter->second.c_str() << ":" << iid;
+          }
 
-	    fAll << std::setw( 13 ) << hceta;
-	  }
+          auto hcell = caloGeom->getGeometry(ii);
+          assert(hcell);
+          const GlobalPoint& hpos = hcell->getPosition();
+          double heta = hpos.eta();
+          double hphi = hpos.phi();
 
-	  if( !AreSame( eta, heta, m_epsilon ))
-	  {
-	    
-	    fAll << "*DIFFER in Eta*";
-	    
-	    f << std::setw( 4 ) << ie
-	      << std::setw( 4 ) << ip
-	      << std::setw( 4 ) << iz
-	      << std::setw( 6 ) << "-";
-	    
-	    f << std::setw( 10 ) << eta << std::setw( 13 ) << phi;
-	    
-	    for( unsigned int i( 0 ) ; i != corners.size() ; ++i ) 
-	    {
-	      const GlobalPoint& cpos = corners[ i ];
-	      double ceta = cpos.eta();
+          fAll << std::setw(10) << heta << std::setw(13) << hphi;
 
-	      f << std::setw( 9 ) << ceta;
-	    }
-	    f << "\n";
-	    
-	    f << std::setw( 4 ) << iie
-	      << std::setw( 4 ) << iip
-	      << std::setw( 4 ) << iiz;
-	    
-	    if( iter != hcalmapping.end())
-	    {
-	      f << std::setw( 4 ) << iter->second.c_str() << ":" << iid;
-	    }
+          const CaloCellGeometry::CornersVec& hcorners(hcell->getCorners());
+          for (unsigned int i(0); i != hcorners.size(); ++i) {
+            const GlobalPoint& hcpos = hcorners[i];
+            double hceta = hcpos.eta();
 
-	    f << std::setw( 10 ) << heta << std::setw( 13 ) << hphi;
+            fAll << std::setw(13) << hceta;
+          }
 
-	    for( unsigned int i( 0 ) ; i != hcorners.size() ; ++i ) 
-	    {
-	      const GlobalPoint& hcpos = hcorners[ i ];
-	      double hceta = hcpos.eta();
+          if (!AreSame(eta, heta, m_epsilon)) {
+            fAll << "*DIFFER in Eta*";
 
-	      f << std::setw( 9 ) << hceta;
-	    }
-	    f << "\n\n";
-	  }
-	  
-	  if( !AreSame( phi, hphi, m_epsilon ))
-	    fAll << " *DIFFER in Phi*";
-	  fAll << "\n";
-	}
+            f << std::setw(4) << ie << std::setw(4) << ip << std::setw(4) << iz << std::setw(6) << "-";
+
+            f << std::setw(10) << eta << std::setw(13) << phi;
+
+            for (unsigned int i(0); i != corners.size(); ++i) {
+              const GlobalPoint& cpos = corners[i];
+              double ceta = cpos.eta();
+
+              f << std::setw(9) << ceta;
+            }
+            f << "\n";
+
+            f << std::setw(4) << iie << std::setw(4) << iip << std::setw(4) << iiz;
+
+            if (iter != hcalmapping.end()) {
+              f << std::setw(4) << iter->second.c_str() << ":" << iid;
+            }
+
+            f << std::setw(10) << heta << std::setw(13) << hphi;
+
+            for (unsigned int i(0); i != hcorners.size(); ++i) {
+              const GlobalPoint& hcpos = hcorners[i];
+              double hceta = hcpos.eta();
+
+              f << std::setw(9) << hceta;
+            }
+            f << "\n\n";
+          }
+
+          if (!AreSame(phi, hphi, m_epsilon))
+            fAll << " *DIFFER in Phi*";
+          fAll << "\n";
+        }
       }
     }
   }
-  
+
   fAll.close();
   f.close();
 }

--- a/Geometry/HcalTowerAlgo/test/HcalCellSizeCheck.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalCellSizeCheck.cc
@@ -15,21 +15,18 @@
 #include <string>
 
 class HcalCellSizeCheck : public edm::one::EDAnalyzer<> {
-
 public:
-  explicit HcalCellSizeCheck(const edm::ParameterSet& );
-  ~HcalCellSizeCheck( void ) override {}
+  explicit HcalCellSizeCheck(const edm::ParameterSet&);
+  ~HcalCellSizeCheck(void) override {}
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endJob() override {}
 };
 
-HcalCellSizeCheck::HcalCellSizeCheck( const edm::ParameterSet& iConfig ) { }
+HcalCellSizeCheck::HcalCellSizeCheck(const edm::ParameterSet& iConfig) {}
 
-void HcalCellSizeCheck::analyze(const edm::Event& /*iEvent*/,
-				 const edm::EventSetup& iSetup) {
-
+void HcalCellSizeCheck::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
   iSetup.get<HcalRecNumberingRecord>().get(hDRCons);
   const HcalDDDRecConstants hcons = (*hDRCons);
@@ -39,19 +36,19 @@ void HcalCellSizeCheck::analyze(const edm::Event& /*iEvent*/,
   const HcalTopology topology = (*topologyHandle);
 
   HcalFlexiHardcodeGeometryLoader m_loader;
-  CaloSubdetectorGeometry*  geom = m_loader.load(topology, hcons);
+  CaloSubdetectorGeometry* geom = m_loader.load(topology, hcons);
 
-  const std::vector<DetId>& idsb=geom->getValidDetIds(DetId::Hcal,HcalBarrel);
+  const std::vector<DetId>& idsb = geom->getValidDetIds(DetId::Hcal, HcalBarrel);
   for (auto id : idsb) {
     HcalDetId hid(id.rawId());
-    std::pair<double,double> rz = hcons.getRZ(hid);
+    std::pair<double, double> rz = hcons.getRZ(hid);
     std::cout << hid << " Front " << rz.first << " Back " << rz.second << "\n";
   }
 
-  const std::vector<DetId>& idse=geom->getValidDetIds(DetId::Hcal,HcalEndcap);
+  const std::vector<DetId>& idse = geom->getValidDetIds(DetId::Hcal, HcalEndcap);
   for (auto id : idse) {
     HcalDetId hid(id.rawId());
-    std::pair<double,double> rz = hcons.getRZ(hid);
+    std::pair<double, double> rz = hcons.getRZ(hid);
     std::cout << hid << " Front " << rz.first << " Back " << rz.second << "\n";
   }
 }

--- a/Geometry/HcalTowerAlgo/test/HcalDetIdTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalDetIdTester.cc
@@ -11,34 +11,30 @@
 #include <iostream>
 
 class HcalDetIdTester : public edm::one::EDAnalyzer<> {
-
 public:
-  explicit HcalDetIdTester( const edm::ParameterSet& );
-  ~HcalDetIdTester( void ) override;
+  explicit HcalDetIdTester(const edm::ParameterSet&);
+  ~HcalDetIdTester(void) override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  bool              geomDB_;
+  bool geomDB_;
 };
 
-HcalDetIdTester::HcalDetIdTester( const edm::ParameterSet& iConfig ) {
+HcalDetIdTester::HcalDetIdTester(const edm::ParameterSet& iConfig) {
   geomDB_ = iConfig.getParameter<bool>("GeometryFromDB");
 }
 
-HcalDetIdTester::~HcalDetIdTester( void ) {}
+HcalDetIdTester::~HcalDetIdTester(void) {}
 
-void
-HcalDetIdTester::analyze(const edm::Event& /*iEvent*/,
-			 const edm::EventSetup& iSetup ) {
-
+void HcalDetIdTester::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
   iSetup.get<HcalRecNumberingRecord>().get(hDRCons);
   const HcalDDDRecConstants hcons = (*hDRCons);
   edm::ESHandle<HcalTopology> topologyHandle;
-  iSetup.get<HcalRecNumberingRecord>().get( topologyHandle );
+  iSetup.get<HcalRecNumberingRecord>().get(topologyHandle);
   const HcalTopology topology = (*topologyHandle);
 
   CaloSubdetectorGeometry* caloGeom(nullptr);
@@ -46,48 +42,46 @@ HcalDetIdTester::analyze(const edm::Event& /*iEvent*/,
     edm::ESHandle<CaloGeometry> pG;
     iSetup.get<CaloGeometryRecord>().get(pG);
     const CaloGeometry* geo = pG.product();
-    caloGeom = (CaloSubdetectorGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
+    caloGeom = (CaloSubdetectorGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
   } else {
     HcalFlexiHardcodeGeometryLoader m_loader;
     caloGeom = m_loader.load(topology, hcons);
   }
 
-  int maxDepth = (topology.maxDepthHB() > topology.maxDepthHE()) ?
-    topology.maxDepthHB() : topology.maxDepthHE();
+  int maxDepth = (topology.maxDepthHB() > topology.maxDepthHE()) ? topology.maxDepthHB() : topology.maxDepthHE();
 
   int nfail0(0);
   for (int det = 1; det <= HcalForward; det++) {
-    for (int eta = -HcalDetId::kHcalEtaMask2;
-	 eta <= (int)(HcalDetId::kHcalEtaMask2); eta++) {
+    for (int eta = -HcalDetId::kHcalEtaMask2; eta <= (int)(HcalDetId::kHcalEtaMask2); eta++) {
       for (int depth = 1; depth <= maxDepth; depth++) {
-	for (unsigned int phi = 0; phi <= HcalDetId::kHcalPhiMask2; phi++) {
-	  HcalDetId detId ((HcalSubdetector) det, eta, phi, depth);
-	  if (topology.valid(detId)) {
-	    auto cell = caloGeom->getGeometry((DetId)(detId));
-	    if (cell) {
-	      std::cout << detId << " " << cell->getPosition() << std::endl;
-	    } else {
-	      std::cout << detId << " position not found" << std::endl;
-	      ++nfail0;
-	    }
-	  }
-	}
+        for (unsigned int phi = 0; phi <= HcalDetId::kHcalPhiMask2; phi++) {
+          HcalDetId detId((HcalSubdetector)det, eta, phi, depth);
+          if (topology.valid(detId)) {
+            auto cell = caloGeom->getGeometry((DetId)(detId));
+            if (cell) {
+              std::cout << detId << " " << cell->getPosition() << std::endl;
+            } else {
+              std::cout << detId << " position not found" << std::endl;
+              ++nfail0;
+            }
+          }
+        }
       }
     }
   }
 
   int nfail1(0);
   const std::vector<DetId>& ids = caloGeom->getValidDetIds();
-  for (auto id : ids)  {
+  for (auto id : ids) {
     if (!topology.valid(id)) {
       std::cout << HcalDetId(id) << " declared as invalid == ERROR\n";
       ++nfail1;
     }
   }
 
-  std::cout << "\nNumber of failures:\nTopology certifies but geometry fails "
-	    << nfail0 << "\nGeometry certifies but Topology fails " << nfail1
-	    << std::endl << std::endl;
+  std::cout << "\nNumber of failures:\nTopology certifies but geometry fails " << nfail0
+            << "\nGeometry certifies but Topology fails " << nfail1 << std::endl
+            << std::endl;
 }
 
 DEFINE_FWK_MODULE(HcalDetIdTester);

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryAnalyzer.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryAnalyzer.cc
@@ -12,36 +12,32 @@
 #include <iostream>
 
 class HcalGeometryAnalyzer : public edm::one::EDAnalyzer<> {
-
 public:
-  explicit HcalGeometryAnalyzer( const edm::ParameterSet& );
-  ~HcalGeometryAnalyzer( void ) override;
-    
+  explicit HcalGeometryAnalyzer(const edm::ParameterSet&);
+  ~HcalGeometryAnalyzer(void) override;
+
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-
-  bool              useOld_;
-  bool              geomDB_;
+  bool useOld_;
+  bool geomDB_;
 };
 
-HcalGeometryAnalyzer::HcalGeometryAnalyzer( const edm::ParameterSet& iConfig ) {
+HcalGeometryAnalyzer::HcalGeometryAnalyzer(const edm::ParameterSet& iConfig) {
   useOld_ = iConfig.getParameter<bool>("UseOldLoader");
   geomDB_ = iConfig.getParameter<bool>("GeometryFromDB");
 }
 
-HcalGeometryAnalyzer::~HcalGeometryAnalyzer( void ) {}
+HcalGeometryAnalyzer::~HcalGeometryAnalyzer(void) {}
 
-void
-HcalGeometryAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup ) {
-
+void HcalGeometryAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
   iSetup.get<HcalRecNumberingRecord>().get(hDRCons);
   const HcalDDDRecConstants hcons = (*hDRCons);
   edm::ESHandle<HcalTopology> topologyHandle;
-  iSetup.get<HcalRecNumberingRecord>().get( topologyHandle );
+  iSetup.get<HcalRecNumberingRecord>().get(topologyHandle);
   const HcalTopology topology = (*topologyHandle);
 
   CaloSubdetectorGeometry* caloGeom(nullptr);
@@ -49,7 +45,7 @@ HcalGeometryAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::EventSet
     edm::ESHandle<CaloGeometry> pG;
     iSetup.get<CaloGeometryRecord>().get(pG);
     const CaloGeometry* geo = pG.product();
-    caloGeom = (CaloSubdetectorGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
+    caloGeom = (CaloSubdetectorGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
   } else if (useOld_) {
     HcalHardcodeGeometryLoader m_loader;
     caloGeom = m_loader.load(topology);
@@ -61,29 +57,26 @@ HcalGeometryAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::EventSet
 
   std::vector<int> dins;
   int counter = 0;
-  for( std::vector<DetId>::const_iterator i = ids.begin(), iEnd = ids.end(); i != iEnd; ++i, ++counter )  {
+  for (std::vector<DetId>::const_iterator i = ids.begin(), iEnd = ids.end(); i != iEnd; ++i, ++counter) {
     HcalDetId hid = (*i);
     std::cout << counter << ": din " << topology.detId2denseId(*i) << ":" << hid;
-    dins.emplace_back( topology.detId2denseId(*i));
-	
+    dins.emplace_back(topology.detId2denseId(*i));
+
     auto cell = caloGeom->getGeometry(*i);
     std::cout << *cell << std::endl;
   }
 
-  std::sort( dins.begin(), dins.end());
+  std::sort(dins.begin(), dins.end());
   std::cout << "=== Total " << counter << " cells in HCAL."
-	    << " from HcalTopology ncells " << topology.ncells() << std::endl;
+            << " from HcalTopology ncells " << topology.ncells() << std::endl;
 
   // HB : 6911: din 16123
-  std::cout << "HB Size " << topology.getHBSize()
-	    << "\nHE Size " << topology.getHESize()
-	    << "\nHO Size " << topology.getHOSize()
-	    << "\nHF Size " << topology.getHFSize()
-	    << "\nTotal " << topology.getHBSize() + topology.getHESize() + topology.getHOSize() + topology.getHFSize() 
-	    << "\n";
-    
+  std::cout << "HB Size " << topology.getHBSize() << "\nHE Size " << topology.getHESize() << "\nHO Size "
+            << topology.getHOSize() << "\nHF Size " << topology.getHFSize() << "\nTotal "
+            << topology.getHBSize() + topology.getHESize() + topology.getHOSize() + topology.getHFSize() << "\n";
+
   counter = 0;
-  for (std::vector<int>::const_iterator i=dins.begin(); i != dins.end(); ++i, ++counter) {
+  for (std::vector<int>::const_iterator i = dins.begin(); i != dins.end(); ++i, ++counter) {
     HcalDetId hid = (topology.denseId2detId(*i));
     HcalDetId ihid = (topology.denseId2detId(dins[counter]));
     std::cout << counter << ": din " << (*i) << " :" << hid << " == " << ihid << std::endl;

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdAnalyzer.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryDetIdAnalyzer.cc
@@ -12,31 +12,29 @@
 
 class HcalGeometryDetIdAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  explicit HcalGeometryDetIdAnalyzer( const edm::ParameterSet& );
-  ~HcalGeometryDetIdAnalyzer( void ) override;
+  explicit HcalGeometryDetIdAnalyzer(const edm::ParameterSet&);
+  ~HcalGeometryDetIdAnalyzer(void) override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-
-  bool              useOld_;
+  bool useOld_;
 };
 
-HcalGeometryDetIdAnalyzer::HcalGeometryDetIdAnalyzer(const edm::ParameterSet& iConfig ) {
+HcalGeometryDetIdAnalyzer::HcalGeometryDetIdAnalyzer(const edm::ParameterSet& iConfig) {
   useOld_ = iConfig.getParameter<bool>("UseOldLoader");
 }
 
-HcalGeometryDetIdAnalyzer::~HcalGeometryDetIdAnalyzer( void ) {}
+HcalGeometryDetIdAnalyzer::~HcalGeometryDetIdAnalyzer(void) {}
 
-void
-HcalGeometryDetIdAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup ) {
+void HcalGeometryDetIdAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
   iSetup.get<HcalRecNumberingRecord>().get(hDRCons);
   const HcalDDDRecConstants hcons = (*hDRCons);
   edm::ESHandle<HcalTopology> topologyHandle;
-  iSetup.get<HcalRecNumberingRecord>().get( topologyHandle );
+  iSetup.get<HcalRecNumberingRecord>().get(topologyHandle);
   const HcalTopology topology = (*topologyHandle);
 
   CaloSubdetectorGeometry* caloGeom(nullptr);
@@ -50,14 +48,12 @@ HcalGeometryDetIdAnalyzer::analyze( const edm::Event& /*iEvent*/, const edm::Eve
   const std::vector<DetId>& ids = caloGeom->getValidDetIds();
 
   int counter = 0;
-  for (std::vector<DetId>::const_iterator i = ids.begin(), iEnd = ids.end();
-       i != iEnd; ++i, ++counter )  {
+  for (std::vector<DetId>::const_iterator i = ids.begin(), iEnd = ids.end(); i != iEnd; ++i, ++counter) {
     HcalDetId hid = (*i);
     unsigned int did = topology.detId2denseId(*i);
     HcalDetId rhid = topology.denseId2detId(did);
 
-    std::cout << counter << ": din " << std::hex << did << std::dec << ": "
-	      << hid << " == " << rhid << std::endl;
+    std::cout << counter << ": din " << std::hex << did << std::dec << ": " << hid << " == " << rhid << std::endl;
     assert(hid == rhid);
   }
   std::cout << "No error found among " << counter << " HCAL valid ID's\n";

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryDump.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryDump.cc
@@ -11,34 +11,30 @@
 #include <iostream>
 
 class HcalGeometryDump : public edm::one::EDAnalyzer<> {
-
 public:
-  explicit HcalGeometryDump( const edm::ParameterSet& );
-  ~HcalGeometryDump( void ) override;
+  explicit HcalGeometryDump(const edm::ParameterSet&);
+  ~HcalGeometryDump(void) override;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  bool              geomDB_;
+  bool geomDB_;
 };
 
-HcalGeometryDump::HcalGeometryDump( const edm::ParameterSet& iConfig ) {
+HcalGeometryDump::HcalGeometryDump(const edm::ParameterSet& iConfig) {
   geomDB_ = iConfig.getParameter<bool>("GeometryFromDB");
 }
 
-HcalGeometryDump::~HcalGeometryDump( void ) {}
+HcalGeometryDump::~HcalGeometryDump(void) {}
 
-void
-HcalGeometryDump::analyze(const edm::Event& /*iEvent*/,
-			  const edm::EventSetup& iSetup ) {
-
+void HcalGeometryDump::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
   iSetup.get<HcalRecNumberingRecord>().get(hDRCons);
   const HcalDDDRecConstants hcons = (*hDRCons);
   edm::ESHandle<HcalTopology> topologyHandle;
-  iSetup.get<HcalRecNumberingRecord>().get( topologyHandle );
+  iSetup.get<HcalRecNumberingRecord>().get(topologyHandle);
   const HcalTopology topology = (*topologyHandle);
 
   HcalGeometry* caloGeom(nullptr);
@@ -46,7 +42,7 @@ HcalGeometryDump::analyze(const edm::Event& /*iEvent*/,
     edm::ESHandle<CaloGeometry> pG;
     iSetup.get<CaloGeometryRecord>().get(pG);
     const CaloGeometry* geo = pG.product();
-    caloGeom = (HcalGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
+    caloGeom = (HcalGeometry*)(geo->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
   } else {
     HcalFlexiHardcodeGeometryLoader m_loader;
     caloGeom = (HcalGeometry*)(m_loader.load(topology, hcons));
@@ -54,25 +50,22 @@ HcalGeometryDump::analyze(const edm::Event& /*iEvent*/,
 
   const std::vector<DetId>& ids = caloGeom->getValidDetIds();
 
-  for (int subdet=1; subdet<= 4; ++subdet) {
+  for (int subdet = 1; subdet <= 4; ++subdet) {
     std::vector<unsigned int> detIds;
-    for (auto id : ids)  {
+    for (auto id : ids) {
       DetId hid = id;
       if (hid.subdetId() == subdet) {
-	detIds.emplace_back(hid.rawId());
+        detIds.emplace_back(hid.rawId());
       }
     }
-    std::cout << detIds.size() << " valid Ids for subdetector " << subdet
-	      << std::endl;
+    std::cout << detIds.size() << " valid Ids for subdetector " << subdet << std::endl;
     std::sort(detIds.begin(), detIds.end());
     int counter = 0;
-    for (std::vector<unsigned int>::const_iterator i = detIds.begin();
-	 i != detIds.end(); ++i, ++counter)  {
+    for (std::vector<unsigned int>::const_iterator i = detIds.begin(); i != detIds.end(); ++i, ++counter) {
       HcalDetId hid = HcalDetId(*i);
       auto cell = caloGeom->getGeometry(*i);
-      std::cout << hid << "\tCaloCellGeometry " << cell->getPosition()
-		<< "\tHcalGeometry " << caloGeom->getPosition(hid)
-		<< std::endl;
+      std::cout << hid << "\tCaloCellGeometry " << cell->getPosition() << "\tHcalGeometry "
+                << caloGeom->getPosition(hid) << std::endl;
     }
   }
 }

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryPlan1Tester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryPlan1Tester.cc
@@ -13,26 +13,23 @@
 #include <string>
 
 class HcalGeometryPlan1Tester : public edm::one::EDAnalyzer<> {
-
 public:
-  explicit HcalGeometryPlan1Tester( const edm::ParameterSet& );
-  ~HcalGeometryPlan1Tester( void ) override {}
+  explicit HcalGeometryPlan1Tester(const edm::ParameterSet&);
+  ~HcalGeometryPlan1Tester(void) override {}
 
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  bool              geomES_;
+  bool geomES_;
 };
 
-HcalGeometryPlan1Tester::HcalGeometryPlan1Tester( const edm::ParameterSet& iConfig ) {
+HcalGeometryPlan1Tester::HcalGeometryPlan1Tester(const edm::ParameterSet& iConfig) {
   geomES_ = iConfig.getParameter<bool>("GeometryFromES");
 }
 
-void HcalGeometryPlan1Tester::analyze(const edm::Event& /*iEvent*/,
-				      const edm::EventSetup& iSetup) {
-
+void HcalGeometryPlan1Tester::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
   iSetup.get<HcalRecNumberingRecord>().get(hDRCons);
   const HcalDDDRecConstants hcons = (*hDRCons);
@@ -45,7 +42,7 @@ void HcalGeometryPlan1Tester::analyze(const edm::Event& /*iEvent*/,
     edm::ESHandle<CaloGeometry> pG;
     iSetup.get<CaloGeometryRecord>().get(pG);
     const CaloGeometry* geo = pG.product();
-    geom = (geo->getSubdetectorGeometry(DetId::Hcal,HcalBarrel));
+    geom = (geo->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
   } else {
     HcalFlexiHardcodeGeometryLoader m_loader;
     geom = (m_loader.load(topology, hcons));
@@ -53,34 +50,35 @@ void HcalGeometryPlan1Tester::analyze(const edm::Event& /*iEvent*/,
   //  geom  = (HcalGeometry*)(geom0);
 
   std::vector<HcalDetId> idsp;
-  bool ok = hcons.specialRBXHBHE(true,idsp);
-  std::cout << "Special RBX Flag " << ok << " with " << idsp.size()
-	    << " ID's" << std::endl;
+  bool ok = hcons.specialRBXHBHE(true, idsp);
+  std::cout << "Special RBX Flag " << ok << " with " << idsp.size() << " ID's" << std::endl;
   int nall(0), ngood(0);
-  for (std::vector<HcalDetId>::const_iterator itr=idsp.begin();
-       itr != idsp.end(); ++itr) {
+  for (std::vector<HcalDetId>::const_iterator itr = idsp.begin(); itr != idsp.end(); ++itr) {
     if (topology.valid(*itr)) {
       ++nall;
       HcalDetId idnew = hcons.mergedDepthDetId(*itr);
       GlobalPoint pt1 = (dynamic_cast<const HcalGeometry*>(geom))->getGeometryBase(*itr)->getPosition();
-      auto        ptr = geom->getGeometry(idnew);
+      auto ptr = geom->getGeometry(idnew);
       GlobalPoint pt2 = ptr->getPosition();
       GlobalPoint pt0 = (dynamic_cast<const HcalGeometry*>(geom))->getPosition(idnew);
-      double     deta = std::abs(pt1.eta() - pt2.eta());
-      double     dphi = std::abs(pt1.phi() - pt2.phi());
-      if (dphi > M_PI) dphi -= (2*M_PI);
-      ok              = (deta<0.00001) && (dphi<0.00001);
+      double deta = std::abs(pt1.eta() - pt2.eta());
+      double dphi = std::abs(pt1.phi() - pt2.phi());
+      if (dphi > M_PI)
+        dphi -= (2 * M_PI);
+      ok = (deta < 0.00001) && (dphi < 0.00001);
       deta = std::abs(pt0.eta() - pt2.eta());
       dphi = std::abs(pt0.phi() - pt2.phi());
-      if (dphi > M_PI) dphi -= (2*M_PI);
-      if ((deta>0.00001) || (dphi>0.00001)) ok = false;
-      std::cout << "Unmerged ID " << (*itr) << " (" << pt1.eta() << ", "
-		<< pt1.phi() << ", " << pt1.z() << ") Merged ID " << idnew
-		<< " (" << pt2.eta() << ", " << pt2.phi() << ", " << pt2.z()
-		<< ") or (" << pt0.eta() << ", " << pt0.phi() << ", "
-		<< pt0.z() << ")";
-      if (ok) ++ngood;
-      else    std::cout << " ***** ERROR *****";
+      if (dphi > M_PI)
+        dphi -= (2 * M_PI);
+      if ((deta > 0.00001) || (dphi > 0.00001))
+        ok = false;
+      std::cout << "Unmerged ID " << (*itr) << " (" << pt1.eta() << ", " << pt1.phi() << ", " << pt1.z()
+                << ") Merged ID " << idnew << " (" << pt2.eta() << ", " << pt2.phi() << ", " << pt2.z() << ") or ("
+                << pt0.eta() << ", " << pt0.phi() << ", " << pt0.z() << ")";
+      if (ok)
+        ++ngood;
+      else
+        std::cout << " ***** ERROR *****";
       std::cout << std::endl;
     }
   }

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTester.cc
@@ -15,37 +15,39 @@
 #include <string>
 
 class HcalGeometryTester : public edm::one::EDAnalyzer<> {
-
 public:
-  explicit HcalGeometryTester( const edm::ParameterSet& );
-  ~HcalGeometryTester( void ) override {}
-    
+  explicit HcalGeometryTester(const edm::ParameterSet&);
+  ~HcalGeometryTester(void) override {}
+
   void beginJob() override {}
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  void testValidDetIds(CaloSubdetectorGeometry* geom, const HcalTopology& topo, 
-		       DetId::Detector det, int subdet, const std::string& label);
+  void testValidDetIds(CaloSubdetectorGeometry* geom,
+                       const HcalTopology& topo,
+                       DetId::Detector det,
+                       int subdet,
+                       const std::string& label);
   void testClosestCells(CaloSubdetectorGeometry* geom, const HcalTopology& top);
-  void testClosestCell(const HcalDetId & detId, CaloSubdetectorGeometry * geom);
+  void testClosestCell(const HcalDetId& detId, CaloSubdetectorGeometry* geom);
   void testTriggerGeometry(const HcalTopology& topology);
-  void testFlexiValidDetIds(CaloSubdetectorGeometry* geom, 
-			    const HcalTopology& topology, DetId::Detector det, 
-			    int subdet, const std::string& label, 
-			    std::vector<int> &dins);
+  void testFlexiValidDetIds(CaloSubdetectorGeometry* geom,
+                            const HcalTopology& topology,
+                            DetId::Detector det,
+                            int subdet,
+                            const std::string& label,
+                            std::vector<int>& dins);
   void testFlexiGeomHF(CaloSubdetectorGeometry* geom);
 
-  bool              useOld_;
+  bool useOld_;
 };
 
-HcalGeometryTester::HcalGeometryTester( const edm::ParameterSet& iConfig ) {
-  useOld_ = iConfig.getParameter<bool>( "UseOldLoader" );
+HcalGeometryTester::HcalGeometryTester(const edm::ParameterSet& iConfig) {
+  useOld_ = iConfig.getParameter<bool>("UseOldLoader");
 }
 
-void HcalGeometryTester::analyze(const edm::Event& /*iEvent*/, 
-				 const edm::EventSetup& iSetup) {
-
+void HcalGeometryTester::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
   edm::ESHandle<HcalDDDRecConstants> hDRCons;
   iSetup.get<HcalRecNumberingRecord>().get(hDRCons);
   const HcalDDDRecConstants hcons = (*hDRCons);
@@ -61,9 +63,9 @@ void HcalGeometryTester::analyze(const edm::Event& /*iEvent*/,
     geom = m_loader.load(topology, hcons);
   }
 
-  testValidDetIds(geom, topology, DetId::Hcal, HcalBarrel,  " BARREL ");
-  testValidDetIds(geom, topology, DetId::Hcal, HcalEndcap,  " ENDCAP ");
-  testValidDetIds(geom, topology, DetId::Hcal, HcalOuter,   " OUTER ");
+  testValidDetIds(geom, topology, DetId::Hcal, HcalBarrel, " BARREL ");
+  testValidDetIds(geom, topology, DetId::Hcal, HcalEndcap, " ENDCAP ");
+  testValidDetIds(geom, topology, DetId::Hcal, HcalOuter, " OUTER ");
   testValidDetIds(geom, topology, DetId::Hcal, HcalForward, " FORWARD ");
 
   testTriggerGeometry(topology);
@@ -73,41 +75,36 @@ void HcalGeometryTester::analyze(const edm::Event& /*iEvent*/,
   std::cout << "HcalGeometryTester::Test SLHC Hcal Geometry" << std::endl;
   std::vector<int> dins;
 
-  testFlexiValidDetIds(geom, topology, DetId::Hcal, HcalBarrel, " BARREL ",  dins );
-  testFlexiValidDetIds(geom, topology, DetId::Hcal, HcalEndcap, " ENDCAP ",  dins );
-  testFlexiValidDetIds(geom, topology, DetId::Hcal, HcalOuter,  " OUTER ",   dins );
-  testFlexiValidDetIds(geom, topology, DetId::Hcal, HcalForward," FORWARD ", dins );
+  testFlexiValidDetIds(geom, topology, DetId::Hcal, HcalBarrel, " BARREL ", dins);
+  testFlexiValidDetIds(geom, topology, DetId::Hcal, HcalEndcap, " ENDCAP ", dins);
+  testFlexiValidDetIds(geom, topology, DetId::Hcal, HcalOuter, " OUTER ", dins);
+  testFlexiValidDetIds(geom, topology, DetId::Hcal, HcalForward, " FORWARD ", dins);
 
   testFlexiGeomHF(geom);
-
 }
 
 void HcalGeometryTester::testValidDetIds(CaloSubdetectorGeometry* caloGeom,
-					 const HcalTopology& topology, 
-					 DetId::Detector det, int subdet, 
-					 const std::string& label) {
-
+                                         const HcalTopology& topology,
+                                         DetId::Detector det,
+                                         int subdet,
+                                         const std::string& label) {
   std::stringstream s;
   s << label << " : " << std::endl;
   const std::vector<DetId>& idshb = caloGeom->getValidDetIds(det, subdet);
- 
+
   int counter = 0;
-  for (std::vector<DetId>::const_iterator i=idshb.begin(); i!=idshb.end(); 
-       i++, ++counter) {
-    HcalDetId hid=(*i);
-    s << counter << ": din " << topology.detId2denseId(*i) << ":" 
-	      << hid;
+  for (std::vector<DetId>::const_iterator i = idshb.begin(); i != idshb.end(); i++, ++counter) {
+    HcalDetId hid = (*i);
+    s << counter << ": din " << topology.detId2denseId(*i) << ":" << hid;
     auto cell = caloGeom->getGeometry(*i);
     s << *cell << std::endl;
   }
- 
+
   s << "=== Total " << counter << " cells in " << label << std::endl;
   std::cout << s.str();
 }
 
-void HcalGeometryTester::testClosestCells(CaloSubdetectorGeometry* g,
-					  const HcalTopology& topology ) {
-  
+void HcalGeometryTester::testClosestCells(CaloSubdetectorGeometry* g, const HcalTopology& topology) {
   // make sure each cell is its own closest cell
   HcalDetId barrelDet1(HcalBarrel, 1, 1, 1);
   HcalDetId barrelDet2(HcalBarrel, 16, 50, 1);
@@ -119,52 +116,57 @@ void HcalGeometryTester::testClosestCells(CaloSubdetectorGeometry* g,
   HcalDetId endcapDet4(HcalEndcap, -24, 63, 5);
   HcalDetId forwardDet1(HcalForward, 30, 71, 1);
   HcalDetId forwardDet3(HcalForward, -40, 71, 1);
-  
-  if (topology.valid(barrelDet1))  testClosestCell(barrelDet1 , g);
-  if (topology.valid(barrelDet2))  testClosestCell(barrelDet2 , g);
-  if (topology.valid(barrelDet3))  testClosestCell(barrelDet3 , g);
-  if (topology.valid(barrelDet4))  testClosestCell(barrelDet4 , g);
-  if (topology.valid(endcapDet1))  testClosestCell(endcapDet1 , g);
-  if (topology.valid(endcapDet2))  testClosestCell(endcapDet2 , g);
-  if (topology.valid(endcapDet3))  testClosestCell(endcapDet3 , g);
-  if (topology.valid(endcapDet4))  testClosestCell(endcapDet4 , g);
-  if (topology.valid(forwardDet1)) testClosestCell(forwardDet1, g);
-  if (topology.valid(forwardDet3)) testClosestCell(forwardDet3, g);
-  
-  const std::vector<DetId>& idsb=g->getValidDetIds(DetId::Hcal,HcalBarrel);
+
+  if (topology.valid(barrelDet1))
+    testClosestCell(barrelDet1, g);
+  if (topology.valid(barrelDet2))
+    testClosestCell(barrelDet2, g);
+  if (topology.valid(barrelDet3))
+    testClosestCell(barrelDet3, g);
+  if (topology.valid(barrelDet4))
+    testClosestCell(barrelDet4, g);
+  if (topology.valid(endcapDet1))
+    testClosestCell(endcapDet1, g);
+  if (topology.valid(endcapDet2))
+    testClosestCell(endcapDet2, g);
+  if (topology.valid(endcapDet3))
+    testClosestCell(endcapDet3, g);
+  if (topology.valid(endcapDet4))
+    testClosestCell(endcapDet4, g);
+  if (topology.valid(forwardDet1))
+    testClosestCell(forwardDet1, g);
+  if (topology.valid(forwardDet3))
+    testClosestCell(forwardDet3, g);
+
+  const std::vector<DetId>& idsb = g->getValidDetIds(DetId::Hcal, HcalBarrel);
   for (auto id : idsb) {
     testClosestCell(HcalDetId(id), g);
   }
-  
-  const std::vector<DetId>& idse=g->getValidDetIds(DetId::Hcal,HcalEndcap);
+
+  const std::vector<DetId>& idse = g->getValidDetIds(DetId::Hcal, HcalEndcap);
   for (auto id : idse) {
     testClosestCell(HcalDetId(id), g);
   }
 }
 
-void HcalGeometryTester::testClosestCell(const HcalDetId & detId, 
-					 CaloSubdetectorGeometry *geom) {
-
+void HcalGeometryTester::testClosestCell(const HcalDetId& detId, CaloSubdetectorGeometry* geom) {
   auto cell = geom->getGeometry(detId);
   HcalDetId closest = geom->getClosestCell(cell->getPosition());
-  std::cout << "i/p " << detId << " position " << cell->getPosition() 
-	    << " closest " << closest << std::endl;
+  std::cout << "i/p " << detId << " position " << cell->getPosition() << " closest " << closest << std::endl;
 
-  if(closest != detId) {
-    std::cout << "HcalGeometryTester::Mismatch.  Original HCAL cell is "
-	      << detId << " while nearest is " << closest << " ***ERROR***"
-	      << std::endl;
+  if (closest != detId) {
+    std::cout << "HcalGeometryTester::Mismatch.  Original HCAL cell is " << detId << " while nearest is " << closest
+              << " ***ERROR***" << std::endl;
   }
 }
 
 void HcalGeometryTester::testTriggerGeometry(const HcalTopology& topology) {
-
-  HcalTrigTowerGeometry trigTowers( &topology );
+  HcalTrigTowerGeometry trigTowers(&topology);
   std::cout << "HCAL trigger tower eta bounds:" << std::endl;
-  for(int ieta = 1; ieta <= 32; ++ieta) {
+  for (int ieta = 1; ieta <= 32; ++ieta) {
     double eta1, eta2;
     trigTowers.towerEtaBounds(ieta, 0, eta1, eta2);
-    std::cout << "[" << ieta << "] "  << eta1 << " " << eta2 << std::endl;
+    std::cout << "[" << ieta << "] " << eta1 << " " << eta2 << std::endl;
   }
 
   // now test some cell mappings
@@ -177,72 +179,65 @@ void HcalGeometryTester::testTriggerGeometry(const HcalTopology& topology) {
   using TowerDets = std::vector<HcalTrigTowerDetId>;
   if (topology.valid(barrelDet)) {
     TowerDets barrelTowers = trigTowers.towerIds(barrelDet);
-    std::cout << "Trigger Tower Size: Barrel " << barrelTowers.size()
-	       << std::endl;
-    assert(barrelTowers.size() ==1);
+    std::cout << "Trigger Tower Size: Barrel " << barrelTowers.size() << std::endl;
+    assert(barrelTowers.size() == 1);
     std::cout << "Tower[0] " << barrelTowers[0] << std::endl;
-  } 
+  }
   if (topology.valid(endcapDet)) {
     TowerDets endcapTowers = trigTowers.towerIds(endcapDet);
-    std::cout << "Trigger Tower Size: Endcap " << endcapTowers.size() 
-	      << std::endl;
+    std::cout << "Trigger Tower Size: Endcap " << endcapTowers.size() << std::endl;
     assert(!endcapTowers.empty());
-    for (unsigned int k=0; k<endcapTowers.size(); ++k)
+    for (unsigned int k = 0; k < endcapTowers.size(); ++k)
       std::cout << "Tower[" << k << "] " << endcapTowers[k] << std::endl;
   }
   if (topology.valid(forwardDet1)) {
     TowerDets forwardTowers1 = trigTowers.towerIds(forwardDet1);
-    std::cout << "Trigger Tower Size: Forward1 " << forwardTowers1.size()
-	      << std::endl;
+    std::cout << "Trigger Tower Size: Forward1 " << forwardTowers1.size() << std::endl;
     assert(!forwardTowers1.empty());
-    for (unsigned int k=0; k<forwardTowers1.size(); ++k)
+    for (unsigned int k = 0; k < forwardTowers1.size(); ++k)
       std::cout << "Tower[" << k << "] " << forwardTowers1[k] << std::endl;
   }
   if (topology.valid(forwardDet2)) {
     TowerDets forwardTowers2 = trigTowers.towerIds(forwardDet2);
-    std::cout << "Trigger Tower Size: Forward2 " << forwardTowers2.size()
-	      << std::endl;
+    std::cout << "Trigger Tower Size: Forward2 " << forwardTowers2.size() << std::endl;
     assert(!forwardTowers2.empty());
-    for (unsigned int k=0; k<forwardTowers2.size(); ++k)
+    for (unsigned int k = 0; k < forwardTowers2.size(); ++k)
       std::cout << "Tower[" << k << "] " << forwardTowers2[k] << std::endl;
   }
   if (topology.valid(forwardDet3)) {
     TowerDets forwardTowers3 = trigTowers.towerIds(forwardDet3);
-    std::cout << "Trigger Tower Size: Forward3 " << forwardTowers3.size()
-	      << std::endl;
+    std::cout << "Trigger Tower Size: Forward3 " << forwardTowers3.size() << std::endl;
     assert(!forwardTowers3.empty());
-    for (unsigned int k=0; k<forwardTowers3.size(); ++k)
+    for (unsigned int k = 0; k < forwardTowers3.size(); ++k)
       std::cout << "Tower[" << k << "] " << forwardTowers3[k] << std::endl;
   }
 }
 
 void HcalGeometryTester::testFlexiValidDetIds(CaloSubdetectorGeometry* caloGeom,
-					      const HcalTopology& topology, 
-					      DetId::Detector det, int subdet, 
-					      const std::string& label, 
-					      std::vector<int> &dins) {
-
+                                              const HcalTopology& topology,
+                                              DetId::Detector det,
+                                              int subdet,
+                                              const std::string& label,
+                                              std::vector<int>& dins) {
   std::stringstream s;
   s << label << " : " << std::endl;
   const std::vector<DetId>& idshb = caloGeom->getValidDetIds(det, subdet);
-    
+
   int counter = 0;
-  for (std::vector<DetId>::const_iterator i=idshb.begin(); i!=idshb.end(); 
-       i++, ++counter) {
-    HcalDetId hid=(*i);
+  for (std::vector<DetId>::const_iterator i = idshb.begin(); i != idshb.end(); i++, ++counter) {
+    HcalDetId hid = (*i);
     s << counter << ": din " << topology.detId2denseId(*i) << ":" << hid;
-    dins.emplace_back( topology.detId2denseId(*i));
-	
+    dins.emplace_back(topology.detId2denseId(*i));
+
     auto cell = caloGeom->getGeometry(*i);
     s << *cell << std::endl;
   }
 
-  std::sort( dins.begin(), dins.end());
+  std::sort(dins.begin(), dins.end());
   s << "=== Total " << counter << " cells in " << label << std::endl;
 
   counter = 0;
-  for (std::vector<int>::const_iterator i=dins.begin(); i != dins.end(); 
-       ++i, ++counter) {
+  for (std::vector<int>::const_iterator i = dins.begin(); i != dins.end(); ++i, ++counter) {
     HcalDetId hid = (topology.denseId2detId(*i));
     HcalDetId ihid = (topology.denseId2detId(dins[counter]));
     s << counter << ": din " << (*i) << " :" << hid << " == " << ihid << std::endl;
@@ -251,21 +246,17 @@ void HcalGeometryTester::testFlexiValidDetIds(CaloSubdetectorGeometry* caloGeom,
 }
 
 void HcalGeometryTester::testFlexiGeomHF(CaloSubdetectorGeometry* caloGeom) {
-
   std::stringstream s;
   s << "Test HF Geometry : " << std::endl;
-  for (int ieta = 29; ieta <=41; ++ieta) {
-    HcalDetId cell3 (HcalForward, ieta, 3, 1);
-    auto cellGeometry3 = caloGeom->getGeometry (cell3);
+  for (int ieta = 29; ieta <= 41; ++ieta) {
+    HcalDetId cell3(HcalForward, ieta, 3, 1);
+    auto cellGeometry3 = caloGeom->getGeometry(cell3);
     if (cellGeometry3) {
-      s << "cell geometry iphi=3 -> ieta=" << ieta
-	<< " eta " << cellGeometry3->getPosition().eta () << "+-" 
-	<< std::abs(cellGeometry3->getCorners()[0].eta() -
-		    cellGeometry3->getCorners()[2].eta())/2
-	<< " phi " << cellGeometry3->getPosition().phi ()/3.1415*180 
-	<<  "+-" << std::abs(cellGeometry3->getCorners()[0].phi() -
-			     cellGeometry3->getCorners()[2].phi())/3.1415*180/2.
-	<< std::endl;
+      s << "cell geometry iphi=3 -> ieta=" << ieta << " eta " << cellGeometry3->getPosition().eta() << "+-"
+        << std::abs(cellGeometry3->getCorners()[0].eta() - cellGeometry3->getCorners()[2].eta()) / 2 << " phi "
+        << cellGeometry3->getPosition().phi() / 3.1415 * 180 << "+-"
+        << std::abs(cellGeometry3->getCorners()[0].phi() - cellGeometry3->getCorners()[2].phi()) / 3.1415 * 180 / 2.
+        << std::endl;
     }
   }
   std::cout << s.str();

--- a/Geometry/Records/interface/CaloGeometryRecord.h
+++ b/Geometry/Records/interface/CaloGeometryRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Records
 // Class  :     CaloGeometryRecord
-// 
+//
 //
 // Author:      Brian Heltsley
 // Created:     Tue April 1, 2008
@@ -27,24 +27,20 @@
 #include "Geometry/Records/interface/FastTimeGeometryRecord.h"
 #include "boost/mpl/vector.hpp"
 
-
-class CaloGeometryRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   CaloGeometryRecord,
-		boost::mpl::vector<
-                IdealGeometryRecord,
-		EcalBarrelGeometryRecord,
-		EcalEndcapGeometryRecord,
-		EcalPreshowerGeometryRecord,
-                HcalParametersRcd,
-                HcalSimNumberingRecord,
-                HcalRecNumberingRecord,
-		HcalGeometryRecord,
-                HGCalGeometryRecord, 
-                FastTimeGeometryRecord,
-		CaloTowerGeometryRecord,
-		CastorGeometryRecord,
-		ZDCGeometryRecord> > {};
+class CaloGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<CaloGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               EcalBarrelGeometryRecord,
+                                                                               EcalEndcapGeometryRecord,
+                                                                               EcalPreshowerGeometryRecord,
+                                                                               HcalParametersRcd,
+                                                                               HcalSimNumberingRecord,
+                                                                               HcalRecNumberingRecord,
+                                                                               HcalGeometryRecord,
+                                                                               HGCalGeometryRecord,
+                                                                               FastTimeGeometryRecord,
+                                                                               CaloTowerGeometryRecord,
+                                                                               CastorGeometryRecord,
+                                                                               ZDCGeometryRecord> > {};
 
 #endif /* RECORDS_CALOGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/CaloTopologyRecord.h
+++ b/Geometry/Records/interface/CaloTopologyRecord.h
@@ -7,11 +7,8 @@
 
 #include "boost/mpl/vector.hpp"
 
+class CaloTopologyRecord
+    : public edm::eventsetup::DependentRecordImplementation<CaloTopologyRecord, boost::mpl::vector<CaloGeometryRecord> > {
+};
 
-class CaloTopologyRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   CaloTopologyRecord,
-                     boost::mpl::vector<
-                     CaloGeometryRecord> > {};
-
-#endif 
+#endif

--- a/Geometry/Records/interface/CaloTowerGeometryRecord.h
+++ b/Geometry/Records/interface/CaloTowerGeometryRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Records
 // Class  :     CaloTowerGeometryRecord
-// 
+//
 //
 // Author:      Brian Heltsley
 // Created:     Tue April 1, 2008
@@ -21,18 +21,14 @@
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "boost/mpl/vector.hpp"
 
-
-class CaloTowerGeometryRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   CaloTowerGeometryRecord,
-		boost::mpl::vector<
-                IdealGeometryRecord,
-                HcalRecNumberingRecord,
-		CaloTowerAlignmentRcd, 
-		CaloTowerAlignmentErrorRcd,
-                CaloTowerAlignmentErrorExtendedRcd,
-		GlobalPositionRcd,
-                PCaloTowerRcd               > > {};
+class CaloTowerGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<CaloTowerGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               HcalRecNumberingRecord,
+                                                                               CaloTowerAlignmentRcd,
+                                                                               CaloTowerAlignmentErrorRcd,
+                                                                               CaloTowerAlignmentErrorExtendedRcd,
+                                                                               GlobalPositionRcd,
+                                                                               PCaloTowerRcd> > {};
 
 #endif /* RECORDS_CALOTOWERGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/CastorGeometryRecord.h
+++ b/Geometry/Records/interface/CastorGeometryRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Records
 // Class  :     CastorGeometryRecord
-// 
+//
 //
 // Author:      Brian Heltsley
 // Created:     Tue April 1, 2008
@@ -20,18 +20,13 @@
 #include "Geometry/Records/interface/PCastorRcd.h"
 #include "boost/mpl/vector.hpp"
 
-
-class CastorGeometryRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   CastorGeometryRecord,
-		boost::mpl::vector<
-                IdealGeometryRecord,
-		CastorAlignmentRcd, 
-		CastorAlignmentErrorRcd,
-                CastorAlignmentErrorExtendedRcd,
-		GlobalPositionRcd,
-		PCastorRcd
-		> > {};
+class CastorGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<CastorGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               CastorAlignmentRcd,
+                                                                               CastorAlignmentErrorRcd,
+                                                                               CastorAlignmentErrorExtendedRcd,
+                                                                               GlobalPositionRcd,
+                                                                               PCastorRcd> > {};
 
 #endif /* RECORDS_CastorGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/DDSpecParRegistryRcd.h
+++ b/Geometry/Records/interface/DDSpecParRegistryRcd.h
@@ -5,7 +5,8 @@
 #include "Geometry/Records/interface/GeometryFileRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class DDSpecParRegistryRcd : public edm::eventsetup::DependentRecordImplementation<
-DDSpecParRegistryRcd, boost::mpl::vector<GeometryFileRcd>> {};
+class DDSpecParRegistryRcd
+    : public edm::eventsetup::DependentRecordImplementation<DDSpecParRegistryRcd, boost::mpl::vector<GeometryFileRcd>> {
+};
 
 #endif

--- a/Geometry/Records/interface/DDVectorRegistryRcd.h
+++ b/Geometry/Records/interface/DDVectorRegistryRcd.h
@@ -5,7 +5,8 @@
 #include "Geometry/Records/interface/GeometryFileRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class DDVectorRegistryRcd : public edm::eventsetup::DependentRecordImplementation<
-DDVectorRegistryRcd, boost::mpl::vector<GeometryFileRcd>> {};
+class DDVectorRegistryRcd
+    : public edm::eventsetup::DependentRecordImplementation<DDVectorRegistryRcd, boost::mpl::vector<GeometryFileRcd>> {
+};
 
 #endif

--- a/Geometry/Records/interface/EcalBarrelGeometryRecord.h
+++ b/Geometry/Records/interface/EcalBarrelGeometryRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Records
 // Class  :     EcalBarrelGeometryRecord
-// 
+//
 //
 // Author:      Brian Heltsley
 // Created:     Tue April 1, 2008
@@ -20,18 +20,13 @@
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "boost/mpl/vector.hpp"
 
-
-class EcalBarrelGeometryRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   EcalBarrelGeometryRecord,
-		boost::mpl::vector<
-                IdealGeometryRecord,
-		EBAlignmentRcd, 
-		EBAlignmentErrorRcd,
-                EBAlignmentErrorExtendedRcd,
-		GlobalPositionRcd,
-                PEcalBarrelRcd
-		> > {};
+class EcalBarrelGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<EcalBarrelGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               EBAlignmentRcd,
+                                                                               EBAlignmentErrorRcd,
+                                                                               EBAlignmentErrorExtendedRcd,
+                                                                               GlobalPositionRcd,
+                                                                               PEcalBarrelRcd> > {};
 
 #endif /* RECORDS_ECALBARRELGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/EcalEndcapGeometryRecord.h
+++ b/Geometry/Records/interface/EcalEndcapGeometryRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Records
 // Class  :     EcalEndcapGeometryRecord
-// 
+//
 //
 // Author:      Brian Heltsley
 // Created:     Tue April 1, 2008
@@ -20,18 +20,13 @@
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "boost/mpl/vector.hpp"
 
-
-class EcalEndcapGeometryRecord : 
-  public edm::eventsetup::DependentRecordImplementation<
-   EcalEndcapGeometryRecord,
-		boost::mpl::vector<
-                IdealGeometryRecord,
-		EEAlignmentRcd, 
-		EEAlignmentErrorRcd,
-                EEAlignmentErrorExtendedRcd, 
-		GlobalPositionRcd,
-                PEcalEndcapRcd
-		> > {};
+class EcalEndcapGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<EcalEndcapGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               EEAlignmentRcd,
+                                                                               EEAlignmentErrorRcd,
+                                                                               EEAlignmentErrorExtendedRcd,
+                                                                               GlobalPositionRcd,
+                                                                               PEcalEndcapRcd> > {};
 
 #endif /* RECORDS_ECALENDCAPGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/EcalGeometryDescriptionRcd.h
+++ b/Geometry/Records/interface/EcalGeometryDescriptionRcd.h
@@ -2,5 +2,6 @@
 #define ECALGEOMETRYDESCRIPTIONRCD_H
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
-class EcalGeometryDescriptionRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalGeometryDescriptionRcd> {};
+class EcalGeometryDescriptionRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalGeometryDescriptionRcd> {
+};
 #endif

--- a/Geometry/Records/interface/EcalPreshowerGeometryRecord.h
+++ b/Geometry/Records/interface/EcalPreshowerGeometryRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Records
 // Class  :     EcalPreshowerGeometryRecord
-// 
+//
 //
 // Author:      Brian Heltsley
 // Created:     Tue April 1, 2008
@@ -20,18 +20,13 @@
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "boost/mpl/vector.hpp"
 
-
-class EcalPreshowerGeometryRecord : 
-  public edm::eventsetup::DependentRecordImplementation<
-   EcalPreshowerGeometryRecord,
-		boost::mpl::vector<
-                IdealGeometryRecord,
-		ESAlignmentRcd, 
-		ESAlignmentErrorRcd,
-                ESAlignmentErrorExtendedRcd,
-		GlobalPositionRcd,
-                PEcalPreshowerRcd
-		> > {};
+class EcalPreshowerGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<EcalPreshowerGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               ESAlignmentRcd,
+                                                                               ESAlignmentErrorRcd,
+                                                                               ESAlignmentErrorExtendedRcd,
+                                                                               GlobalPositionRcd,
+                                                                               PEcalPreshowerRcd> > {};
 
 #endif /* RECORDS_ECALPRESHOWERGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/FastTimeGeometryRecord.h
+++ b/Geometry/Records/interface/FastTimeGeometryRecord.h
@@ -8,13 +8,8 @@
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class FastTimeGeometryRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   FastTimeGeometryRecord,
-     boost::mpl::vector<
-     IdealGeometryRecord,
-     GlobalPositionRcd,
-     PFastTimeRcd               > > {};
+class FastTimeGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
+                                   FastTimeGeometryRecord,
+                                   boost::mpl::vector<IdealGeometryRecord, GlobalPositionRcd, PFastTimeRcd> > {};
 
 #endif /* Records_FastTimeGeometryRecord_h */
-

--- a/Geometry/Records/interface/GlobalTrackingGeometryRecord.h
+++ b/Geometry/Records/interface/GlobalTrackingGeometryRecord.h
@@ -14,8 +14,9 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "boost/mpl/vector.hpp"
 
-
-class GlobalTrackingGeometryRecord : public edm::eventsetup::DependentRecordImplementation<GlobalTrackingGeometryRecord,boost::mpl::vector<TrackerDigiGeometryRecord,MTDDigiGeometryRecord,MuonGeometryRecord> > {};
+class GlobalTrackingGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          GlobalTrackingGeometryRecord,
+          boost::mpl::vector<TrackerDigiGeometryRecord, MTDDigiGeometryRecord, MuonGeometryRecord> > {};
 
 #endif
-

--- a/Geometry/Records/interface/HGCalGeometryRecord.h
+++ b/Geometry/Records/interface/HGCalGeometryRecord.h
@@ -8,13 +8,8 @@
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class HGCalGeometryRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   HGCalGeometryRecord,
-     boost::mpl::vector<
-     IdealGeometryRecord,
-     GlobalPositionRcd,
-     PHGCalRcd               > > {};
+class HGCalGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
+                                HGCalGeometryRecord,
+                                boost::mpl::vector<IdealGeometryRecord, GlobalPositionRcd, PHGCalRcd> > {};
 
 #endif /* RECORDS_HGCALGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/HcalGeometryRecord.h
+++ b/Geometry/Records/interface/HcalGeometryRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Records
 // Class  :     HcalGeometryRecord
-// 
+//
 //
 // Author:      Brian Heltsley
 // Created:     Tue April 1, 2008
@@ -20,20 +20,16 @@
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "boost/mpl/vector.hpp"
 
-
-class HcalGeometryRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   HcalGeometryRecord,
-     boost::mpl::vector<
-     IdealGeometryRecord,
-     HcalParametersRcd,
-     HcalSimNumberingRecord,
-     HcalRecNumberingRecord,
-     HcalAlignmentRcd, 
-     HcalAlignmentErrorRcd,
-     HcalAlignmentErrorExtendedRcd,
-     GlobalPositionRcd,
-     PHcalRcd               > > {};
+class HcalGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<HcalGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               HcalParametersRcd,
+                                                                               HcalSimNumberingRecord,
+                                                                               HcalRecNumberingRecord,
+                                                                               HcalAlignmentRcd,
+                                                                               HcalAlignmentErrorRcd,
+                                                                               HcalAlignmentErrorExtendedRcd,
+                                                                               GlobalPositionRcd,
+                                                                               PHcalRcd> > {};
 
 #endif /* RECORDS_HCALGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/HcalParametersRcd.h
+++ b/Geometry/Records/interface/HcalParametersRcd.h
@@ -5,7 +5,8 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "boost/mpl/vector.hpp"
 
-class HcalParametersRcd : public edm::eventsetup::DependentRecordImplementation<HcalParametersRcd,
-  boost::mpl::vector<IdealGeometryRecord> > {};
+class HcalParametersRcd
+    : public edm::eventsetup::DependentRecordImplementation<HcalParametersRcd, boost::mpl::vector<IdealGeometryRecord> > {
+};
 
-#endif // Geometry_Records_HcalParameters_H
+#endif  // Geometry_Records_HcalParameters_H

--- a/Geometry/Records/interface/HcalRecNumberingRecord.h
+++ b/Geometry/Records/interface/HcalRecNumberingRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Record
 // Class  :     HcalRecNumberingRecord
-// 
+//
 /**\class HcalRecNumberingRecord HcalRecNumberingRecord.h Geometry/Record/interface/HcalRecNumberingRecord.h
 
  Description: <one line class summary>
@@ -14,12 +14,15 @@
 
 */
 //
-// Author:      
+// Author:
 // Created:     Thu Dec 24 16:41:02 PDT 2013
 //
 #include <boost/mpl/vector.hpp>
 #include "Geometry/Records/interface/HcalSimNumberingRecord.h"
 
-class HcalRecNumberingRecord : public edm::eventsetup::DependentRecordImplementation<HcalRecNumberingRecord, boost::mpl::vector<IdealGeometryRecord, HcalParametersRcd, HcalSimNumberingRecord> > {};
+class HcalRecNumberingRecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          HcalRecNumberingRecord,
+          boost::mpl::vector<IdealGeometryRecord, HcalParametersRcd, HcalSimNumberingRecord> > {};
 
 #endif

--- a/Geometry/Records/interface/HcalSimNumberingRecord.h
+++ b/Geometry/Records/interface/HcalSimNumberingRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Record
 // Class  :     HcalSimNumberingRecord
-// 
+//
 /**\class HcalSimNumberingRecord HcalSimNumberingRecord.h Geometry/Record/interface/HcalSimNumberingRecord.h
 
  Description: <one line class summary>
@@ -14,7 +14,7 @@
 
 */
 //
-// Author:      
+// Author:
 // Created:     Thu Dec 24 16:41:02 PDT 2013
 //
 
@@ -22,6 +22,9 @@
 #include "Geometry/Records/interface/HcalParametersRcd.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
-class HcalSimNumberingRecord : public edm::eventsetup::DependentRecordImplementation<HcalSimNumberingRecord, boost::mpl::vector<IdealGeometryRecord, HcalParametersRcd> > {};
+class HcalSimNumberingRecord
+    : public edm::eventsetup::DependentRecordImplementation<HcalSimNumberingRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord, HcalParametersRcd> > {
+};
 
 #endif

--- a/Geometry/Records/interface/IdealGeometryRecord.h
+++ b/Geometry/Records/interface/IdealGeometryRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Records
 // Class  :     IdealGeometryRecord
-// 
+//
 /**\class IdealGeometryRecord IdealGeometryRecord.h Geometry/Records/interface/IdealGeometryRecord.h
 
  Description: <one line class summary>
@@ -14,7 +14,7 @@
 
 */
 //
-// Author:      
+// Author:
 // Created:     Mon Jul 25 11:05:09 EDT 2005
 //
 
@@ -24,8 +24,9 @@
 #include "Geometry/Records/interface/PGeometricTimingDetExtraRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class IdealGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
-IdealGeometryRecord, boost::mpl::vector<GeometryFileRcd, PGeometricDetExtraRcd, PGeometricTimingDetExtraRcd> > { };
+class IdealGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          IdealGeometryRecord,
+          boost::mpl::vector<GeometryFileRcd, PGeometricDetExtraRcd, PGeometricTimingDetExtraRcd> > {};
 
 #endif /* RECORDS_IDEALGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/MTDDigiGeometryRecord.h
+++ b/Geometry/Records/interface/MTDDigiGeometryRecord.h
@@ -12,14 +12,14 @@
 #include "Geometry/Records/interface/PMTDParametersRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class MTDDigiGeometryRecord : 
-  public edm::eventsetup::DependentRecordImplementation<MTDDigiGeometryRecord,
-                boost::mpl::vector<IdealGeometryRecord,
-                MTDAlignmentRcd, 
-                MTDAlignmentErrorExtendedRcd,
-                MTDSurfaceDeformationRcd,
-                GlobalPositionRcd,
-                MTDTopologyRcd,
-                PMTDParametersRcd> > {};
+class MTDDigiGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<MTDDigiGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               MTDAlignmentRcd,
+                                                                               MTDAlignmentErrorExtendedRcd,
+                                                                               MTDSurfaceDeformationRcd,
+                                                                               GlobalPositionRcd,
+                                                                               MTDTopologyRcd,
+                                                                               PMTDParametersRcd> > {};
 
 #endif /* RECORDS_MTDDIGIGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/MTDGeometryRecord.h
+++ b/Geometry/Records/interface/MTDGeometryRecord.h
@@ -10,15 +10,9 @@
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class MTDGeometryRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   MTDGeometryRecord,
-     boost::mpl::vector<
-     IdealGeometryRecord,
-     BTLGeometryRcd,
-     ETLGeometryRcd,
-     GlobalPositionRcd,
-     PFastTimeRcd                 > > {};
+class MTDGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          MTDGeometryRecord,
+          boost::mpl::vector<IdealGeometryRecord, BTLGeometryRcd, ETLGeometryRcd, GlobalPositionRcd, PFastTimeRcd> > {};
 
 #endif /* RECORDS_MTDGEOMETRYRECORD_H */
-

--- a/Geometry/Records/interface/MTDTopologyRcd.h
+++ b/Geometry/Records/interface/MTDTopologyRcd.h
@@ -7,8 +7,9 @@
 #include "Geometry/Records/interface/PMTDParametersRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class MTDTopologyRcd :
-public edm::eventsetup::DependentRecordImplementation<MTDTopologyRcd,
-  boost::mpl::vector<IdealGeometryRecord, PMTDParametersRcd> > {};
+class MTDTopologyRcd
+    : public edm::eventsetup::DependentRecordImplementation<MTDTopologyRcd,
+                                                            boost::mpl::vector<IdealGeometryRecord, PMTDParametersRcd> > {
+};
 
 #endif

--- a/Geometry/Records/interface/MuonGeometryRcd.h
+++ b/Geometry/Records/interface/MuonGeometryRcd.h
@@ -12,7 +12,14 @@
 #include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class MuonGeometryRcd : public edm::eventsetup::DependentRecordImplementation<
-MuonGeometryRcd, boost::mpl::vector<MuonNumberingRcd, DDSpecParRegistryRcd, DetectorDescriptionRcd,
-  GlobalPositionRcd, DTAlignmentRcd, DTAlignmentErrorRcd, DTAlignmentErrorExtendedRcd, DTRecoGeometryRcd>> {};
+class MuonGeometryRcd
+    : public edm::eventsetup::DependentRecordImplementation<MuonGeometryRcd,
+                                                            boost::mpl::vector<MuonNumberingRcd,
+                                                                               DDSpecParRegistryRcd,
+                                                                               DetectorDescriptionRcd,
+                                                                               GlobalPositionRcd,
+                                                                               DTAlignmentRcd,
+                                                                               DTAlignmentErrorRcd,
+                                                                               DTAlignmentErrorExtendedRcd,
+                                                                               DTRecoGeometryRcd>> {};
 #endif

--- a/Geometry/Records/interface/MuonGeometryRecord.h
+++ b/Geometry/Records/interface/MuonGeometryRecord.h
@@ -31,6 +31,27 @@
 #include "CondFormats/AlignmentRecord/interface/GEMAlignmentErrorExtendedRcd.h"
 #include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
 
-class MuonGeometryRecord : public edm::eventsetup::DependentRecordImplementation<MuonGeometryRecord,boost::mpl::vector<IdealGeometryRecord, DDSpecParRegistryRcd, GeometryFileRcd, MuonNumberingRecord, DTAlignmentRcd, DTAlignmentErrorRcd, DTAlignmentErrorExtendedRcd, CSCAlignmentRcd, CSCAlignmentErrorRcd, CSCAlignmentErrorExtendedRcd, GEMAlignmentRcd, GEMAlignmentErrorRcd, GEMAlignmentErrorExtendedRcd, GlobalPositionRcd, ME0RecoGeometryRcd, GEMRecoGeometryRcd, RPCRecoGeometryRcd, DTRecoGeometryRcd, CSCRecoGeometryRcd, CSCRecoDigiParametersRcd> > {};
+class MuonGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<MuonGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               DDSpecParRegistryRcd,
+                                                                               GeometryFileRcd,
+                                                                               MuonNumberingRecord,
+                                                                               DTAlignmentRcd,
+                                                                               DTAlignmentErrorRcd,
+                                                                               DTAlignmentErrorExtendedRcd,
+                                                                               CSCAlignmentRcd,
+                                                                               CSCAlignmentErrorRcd,
+                                                                               CSCAlignmentErrorExtendedRcd,
+                                                                               GEMAlignmentRcd,
+                                                                               GEMAlignmentErrorRcd,
+                                                                               GEMAlignmentErrorExtendedRcd,
+                                                                               GlobalPositionRcd,
+                                                                               ME0RecoGeometryRcd,
+                                                                               GEMRecoGeometryRcd,
+                                                                               RPCRecoGeometryRcd,
+                                                                               DTRecoGeometryRcd,
+                                                                               CSCRecoGeometryRcd,
+                                                                               CSCRecoDigiParametersRcd> > {};
 
 #endif

--- a/Geometry/Records/interface/MuonNumberingRcd.h
+++ b/Geometry/Records/interface/MuonNumberingRcd.h
@@ -7,5 +7,6 @@
 #include "boost/mpl/vector.hpp"
 
 class MuonNumberingRcd : public edm::eventsetup::DependentRecordImplementation<
-MuonNumberingRcd, boost::mpl::vector<DDSpecParRegistryRcd, DetectorDescriptionRcd>> {};
+                             MuonNumberingRcd,
+                             boost::mpl::vector<DDSpecParRegistryRcd, DetectorDescriptionRcd>> {};
 #endif

--- a/Geometry/Records/interface/MuonNumberingRecord.h
+++ b/Geometry/Records/interface/MuonNumberingRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     MuonNumberingInitialization
 // Class  :     MuonNumberingRecord
-// 
+//
 /**\class MuonNumberingRecord MuonNumberingRecord.h Geometry/MuonNumberingInitialization/interface/MuonNumberingRecord.h
 
  Description: <one line class summary>
@@ -14,7 +14,7 @@
 
 */
 //
-// Author:      
+// Author:
 // Created:     Thu Sep 28 16:41:02 PDT 2006
 //
 
@@ -27,6 +27,13 @@
 #include "Geometry/Records/interface/CSCRecoGeometryRcd.h"
 #include "Geometry/Records/interface/DTRecoGeometryRcd.h"
 
-class MuonNumberingRecord : public edm::eventsetup::DependentRecordImplementation<MuonNumberingRecord, boost::mpl::vector<IdealGeometryRecord, CSCRecoDigiParametersRcd, CSCRecoGeometryRcd, DTRecoGeometryRcd, DDSpecParRegistryRcd, GeometryFileRcd> > {};
+class MuonNumberingRecord
+    : public edm::eventsetup::DependentRecordImplementation<MuonNumberingRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               CSCRecoDigiParametersRcd,
+                                                                               CSCRecoGeometryRcd,
+                                                                               DTRecoGeometryRcd,
+                                                                               DDSpecParRegistryRcd,
+                                                                               GeometryFileRcd> > {};
 
 #endif

--- a/Geometry/Records/interface/PFastTimeParametersRcd.h
+++ b/Geometry/Records/interface/PFastTimeParametersRcd.h
@@ -6,7 +6,8 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "boost/mpl/vector.hpp"
 
-class PFastTimeParametersRcd : public edm::eventsetup::DependentRecordImplementation<PFastTimeParametersRcd,
-  boost::mpl::vector<IdealGeometryRecord> > {};
+class PFastTimeParametersRcd
+    : public edm::eventsetup::DependentRecordImplementation<PFastTimeParametersRcd,
+                                                            boost::mpl::vector<IdealGeometryRecord> > {};
 
-#endif // PFastTimeParameters_H
+#endif  // PFastTimeParameters_H

--- a/Geometry/Records/interface/PGeometricTimingDetExtraRcd.h
+++ b/Geometry/Records/interface/PGeometricTimingDetExtraRcd.h
@@ -2,5 +2,6 @@
 #define PGeometricTimingDetExtraRcd_H
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
-class PGeometricTimingDetExtraRcd : public edm::eventsetup::EventSetupRecordImplementation<PGeometricTimingDetExtraRcd> {};
+class PGeometricTimingDetExtraRcd
+    : public edm::eventsetup::EventSetupRecordImplementation<PGeometricTimingDetExtraRcd> {};
 #endif

--- a/Geometry/Records/interface/PHGCalParametersRcd.h
+++ b/Geometry/Records/interface/PHGCalParametersRcd.h
@@ -6,7 +6,8 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "boost/mpl/vector.hpp"
 
-class PHGCalParametersRcd : public edm::eventsetup::DependentRecordImplementation<PHGCalParametersRcd,
-  boost::mpl::vector<IdealGeometryRecord> > {};
+class PHGCalParametersRcd
+    : public edm::eventsetup::DependentRecordImplementation<PHGCalParametersRcd,
+                                                            boost::mpl::vector<IdealGeometryRecord> > {};
 
-#endif // PHGCalParameters_H
+#endif  // PHGCalParameters_H

--- a/Geometry/Records/interface/PMTDParametersRcd.h
+++ b/Geometry/Records/interface/PMTDParametersRcd.h
@@ -6,7 +6,8 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "boost/mpl/vector.hpp"
 
-class PMTDParametersRcd : public edm::eventsetup::DependentRecordImplementation<PMTDParametersRcd,
-  boost::mpl::vector<IdealGeometryRecord> > {};
+class PMTDParametersRcd
+    : public edm::eventsetup::DependentRecordImplementation<PMTDParametersRcd, boost::mpl::vector<IdealGeometryRecord> > {
+};
 
-#endif // PMTDParameters_H
+#endif  // PMTDParameters_H

--- a/Geometry/Records/interface/PTrackerParametersRcd.h
+++ b/Geometry/Records/interface/PTrackerParametersRcd.h
@@ -6,7 +6,8 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "boost/mpl/vector.hpp"
 
-class PTrackerParametersRcd : public edm::eventsetup::DependentRecordImplementation<PTrackerParametersRcd,
-  boost::mpl::vector<IdealGeometryRecord> > {};
+class PTrackerParametersRcd
+    : public edm::eventsetup::DependentRecordImplementation<PTrackerParametersRcd,
+                                                            boost::mpl::vector<IdealGeometryRecord> > {};
 
-#endif // PTrackerParameters_H
+#endif  // PTrackerParameters_H

--- a/Geometry/Records/interface/StackedTrackerGeometryRecord.h
+++ b/Geometry/Records/interface/StackedTrackerGeometryRecord.h
@@ -17,10 +17,10 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "boost/mpl/vector.hpp"
 
-class StackedTrackerGeometryRecord : public edm::eventsetup::DependentRecordImplementation< StackedTrackerGeometryRecord , boost::mpl::vector<TrackerDigiGeometryRecord> > {};
+class StackedTrackerGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<StackedTrackerGeometryRecord,
+                                                            boost::mpl::vector<TrackerDigiGeometryRecord> > {};
 
-#endif 
+#endif
 
 /* RECORDS_StackedTrackerGEOMETRYRECORD_H */
-
-

--- a/Geometry/Records/interface/TrackerDigiGeometryRecord.h
+++ b/Geometry/Records/interface/TrackerDigiGeometryRecord.h
@@ -12,14 +12,14 @@
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class TrackerDigiGeometryRecord : 
-  public edm::eventsetup::DependentRecordImplementation<TrackerDigiGeometryRecord,
-                boost::mpl::vector<IdealGeometryRecord,
-                TrackerAlignmentRcd, 
-                TrackerAlignmentErrorExtendedRcd,
-                TrackerSurfaceDeformationRcd,
-                GlobalPositionRcd,
-                TrackerTopologyRcd,
-                PTrackerParametersRcd> > {};
+class TrackerDigiGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<TrackerDigiGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               TrackerAlignmentRcd,
+                                                                               TrackerAlignmentErrorExtendedRcd,
+                                                                               TrackerSurfaceDeformationRcd,
+                                                                               GlobalPositionRcd,
+                                                                               TrackerTopologyRcd,
+                                                                               PTrackerParametersRcd> > {};
 
 #endif /* RECORDS_TRACKERDIGIGEOMETRYRECORD_H */

--- a/Geometry/Records/interface/TrackerTopologyRcd.h
+++ b/Geometry/Records/interface/TrackerTopologyRcd.h
@@ -7,8 +7,8 @@
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class TrackerTopologyRcd :
-public edm::eventsetup::DependentRecordImplementation<TrackerTopologyRcd,
-  boost::mpl::vector<IdealGeometryRecord, PTrackerParametersRcd> > {};
+class TrackerTopologyRcd : public edm::eventsetup::DependentRecordImplementation<
+                               TrackerTopologyRcd,
+                               boost::mpl::vector<IdealGeometryRecord, PTrackerParametersRcd> > {};
 
 #endif

--- a/Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h
+++ b/Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h
@@ -21,10 +21,9 @@
  * \brief Event setup record containing the misaligned geometry information. It is used for 
  * alignment studies only.
  **/
-class VeryForwardMisalignedGeometryRecord : public edm::eventsetup::DependentRecordImplementation
-						   <VeryForwardMisalignedGeometryRecord, boost::mpl::vector<IdealGeometryRecord, RPMisalignedAlignmentRecord /*, ... */> >
-{
-};
+class VeryForwardMisalignedGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          VeryForwardMisalignedGeometryRecord,
+          boost::mpl::vector<IdealGeometryRecord, RPMisalignedAlignmentRecord /*, ... */> > {};
 
 #endif
-

--- a/Geometry/Records/interface/VeryForwardRealGeometryRecord.h
+++ b/Geometry/Records/interface/VeryForwardRealGeometryRecord.h
@@ -20,10 +20,9 @@
  * \ingroup TotemRPGeometry
  * \brief Event setup record containing the real (actual) geometry information.
  **/
-class VeryForwardRealGeometryRecord : public edm::eventsetup::DependentRecordImplementation
-						   <VeryForwardRealGeometryRecord, boost::mpl::vector<IdealGeometryRecord, RPRealAlignmentRecord /*, ... */> >
-{
+class VeryForwardRealGeometryRecord : public edm::eventsetup::DependentRecordImplementation<
+                                          VeryForwardRealGeometryRecord,
+                                          boost::mpl::vector<IdealGeometryRecord, RPRealAlignmentRecord /*, ... */> > {
 };
 
 #endif
-

--- a/Geometry/Records/interface/ZDCGeometryRecord.h
+++ b/Geometry/Records/interface/ZDCGeometryRecord.h
@@ -4,7 +4,7 @@
 //
 // Package:     Records
 // Class  :     ZDCGeometryRecord
-// 
+//
 //
 // Author:      Brian Heltsley
 // Created:     Tue April 1, 2008
@@ -20,17 +20,13 @@
 #include "Geometry/Records/interface/PZdcRcd.h"
 #include "boost/mpl/vector.hpp"
 
-
-class ZDCGeometryRecord : 
-   public edm::eventsetup::DependentRecordImplementation<
-   ZDCGeometryRecord,
-		boost::mpl::vector<
-                IdealGeometryRecord,
-		ZDCAlignmentRcd, 
-		ZDCAlignmentErrorRcd,
-                ZDCAlignmentErrorExtendedRcd,
-		GlobalPositionRcd,
-		PZdcRcd         	> > {};
+class ZDCGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<ZDCGeometryRecord,
+                                                            boost::mpl::vector<IdealGeometryRecord,
+                                                                               ZDCAlignmentRcd,
+                                                                               ZDCAlignmentErrorRcd,
+                                                                               ZDCAlignmentErrorExtendedRcd,
+                                                                               GlobalPositionRcd,
+                                                                               PZdcRcd> > {};
 
 #endif /* RECORDS_ZDCGEOMETRYRECORD_H */
-

--- a/Geometry/Records/src/CaloGeometryRecord.cc
+++ b/Geometry/Records/src/CaloGeometryRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Records
 // Class  :     CaloGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //

--- a/Geometry/Records/src/CaloTowerGeometryRecord.cc
+++ b/Geometry/Records/src/CaloTowerGeometryRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Records
 // Class  :     CaloTowerGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //

--- a/Geometry/Records/src/CastorGeometryRecord.cc
+++ b/Geometry/Records/src/CastorGeometryRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Records
 // Class  :     CastorGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //

--- a/Geometry/Records/src/EcalBarrelGeometryRecord.cc
+++ b/Geometry/Records/src/EcalBarrelGeometryRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Records
 // Class  :     EcalBarrelGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //

--- a/Geometry/Records/src/EcalEndcapGeometryRecord.cc
+++ b/Geometry/Records/src/EcalEndcapGeometryRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Records
 // Class  :     EcalEndcapGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //

--- a/Geometry/Records/src/EcalPreshowerGeometryRecord.cc
+++ b/Geometry/Records/src/EcalPreshowerGeometryRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Records
 // Class  :     EcalPreshowerGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //

--- a/Geometry/Records/src/HcalGeometryRecord.cc
+++ b/Geometry/Records/src/HcalGeometryRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Records
 // Class  :     HcalGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //

--- a/Geometry/Records/src/HcalRecNumberingRecord.cc
+++ b/Geometry/Records/src/HcalRecNumberingRecord.cc
@@ -2,11 +2,11 @@
 //
 // Package:     Record
 // Class  :     HcalRecNumberingRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Author:      
+// Author:
 // Created:     Thu Dec 24 16:41:02 PDT 2013
 
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"

--- a/Geometry/Records/src/HcalSimNumberingRecord.cc
+++ b/Geometry/Records/src/HcalSimNumberingRecord.cc
@@ -2,11 +2,11 @@
 //
 // Package:     Record
 // Class  :     HcalSimNumberingRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Author:      
+// Author:
 // Created:     Thu Dec 24 16:41:02 PDT 2013
 
 #include "Geometry/Records/interface/HcalSimNumberingRecord.h"

--- a/Geometry/Records/src/IdealGeometryRecord.cc
+++ b/Geometry/Records/src/IdealGeometryRecord.cc
@@ -2,11 +2,11 @@
 //
 // Package:     Records
 // Class  :     IdealGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Author:      
+// Author:
 // Created:     Mon Jul 25 11:05:09 EDT 2005
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"

--- a/Geometry/Records/src/MTDDigiGeometryRecord.cc
+++ b/Geometry/Records/src/MTDDigiGeometryRecord.cc
@@ -2,11 +2,11 @@
 //
 // Package:     Records
 // Class  :     IdealGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Author:      
+// Author:
 // Created:     Mon Jul 25 11:05:09 EDT 2005
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"

--- a/Geometry/Records/src/MuonNumberingRecord.cc
+++ b/Geometry/Records/src/MuonNumberingRecord.cc
@@ -2,11 +2,11 @@
 //
 // Package:     MuonNumberingInitialization
 // Class  :     MuonNumberingRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Author:      
+// Author:
 // Created:     Thu Sep 28 16:41:02 PDT 2006
 
 #include "Geometry/Records/interface/MuonNumberingRecord.h"

--- a/Geometry/Records/src/StackedTrackerGeometryRecord.cc
+++ b/Geometry/Records/src/StackedTrackerGeometryRecord.cc
@@ -9,4 +9,3 @@
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 
 EVENTSETUP_RECORD_REG(StackedTrackerGeometryRecord);
-

--- a/Geometry/Records/src/TrackerDigiGeometryRecord.cc
+++ b/Geometry/Records/src/TrackerDigiGeometryRecord.cc
@@ -2,11 +2,11 @@
 //
 // Package:     Records
 // Class  :     IdealGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
-// Author:      
+// Author:
 // Created:     Mon Jul 25 11:05:09 EDT 2005
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/Geometry/Records/src/ZDCGeometryRecord.cc
+++ b/Geometry/Records/src/ZDCGeometryRecord.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Records
 // Class  :     ZDCGeometryRecord
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //


### PR DESCRIPTION

Applying code-format for CMSSW category geometry.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/244//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


