### PR TITLE
Running code-format for hlt-reconstruction

### DIFF
--- a/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.cc
+++ b/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.cc
@@ -33,10 +33,9 @@ using namespace reco;
 using namespace muonisolation;
 
 /// constructor with config
-L2MuonIsolationProducer::L2MuonIsolationProducer(const ParameterSet& par) :
-  theSACollectionLabel(par.getParameter<edm::InputTag>("StandAloneCollectionLabel"))
-{
-  LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")<<" L2MuonIsolationProducer constructor called";
+L2MuonIsolationProducer::L2MuonIsolationProducer(const ParameterSet& par)
+    : theSACollectionLabel(par.getParameter<edm::InputTag>("StandAloneCollectionLabel")) {
+  LogDebug("Muon|RecoMuon|L2MuonIsolationProducer") << " L2MuonIsolationProducer constructor called";
 
   theSACollectionToken = consumes<RecoChargedCandidateCollection>(theSACollectionLabel);
 
@@ -45,91 +44,93 @@ L2MuonIsolationProducer::L2MuonIsolationProducer(const ParameterSet& par) :
   //
   edm::ParameterSet extractorPSet = par.getParameter<edm::ParameterSet>("ExtractorPSet");
   std::string extractorName = extractorPSet.getParameter<std::string>("ComponentName");
-  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector())};
-
+  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{
+      IsoDepositExtractorFactory::get()->create(extractorName, extractorPSet, consumesCollector())};
 
   edm::ParameterSet isolatorPSet = par.getParameter<edm::ParameterSet>("IsolatorPSet");
   bool haveIsolator = !isolatorPSet.empty();
   optOutputDecision = haveIsolator;
-  if (optOutputDecision){
+  if (optOutputDecision) {
     std::string type = isolatorPSet.getParameter<std::string>("ComponentName");
-    theDepositIsolator = std::unique_ptr<muonisolation::MuIsoBaseIsolator>{MuonIsolatorFactory::get()->create(type, isolatorPSet, consumesCollector())};
+    theDepositIsolator = std::unique_ptr<muonisolation::MuIsoBaseIsolator>{
+        MuonIsolatorFactory::get()->create(type, isolatorPSet, consumesCollector())};
   }
-  if (optOutputDecision) produces<edm::ValueMap<bool> >();
+  if (optOutputDecision)
+    produces<edm::ValueMap<bool>>();
   produces<reco::IsoDepositMap>();
 
   optOutputIsolatorFloat = par.getParameter<bool>("WriteIsolatorFloat");
-  if (optOutputIsolatorFloat && haveIsolator){
-    produces<edm::ValueMap<float> >();
+  if (optOutputIsolatorFloat && haveIsolator) {
+    produces<edm::ValueMap<float>>();
   }
 }
 
 /// destructor
-L2MuonIsolationProducer::~L2MuonIsolationProducer(){
-  LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")<<" L2MuonIsolationProducer destructor called";
+L2MuonIsolationProducer::~L2MuonIsolationProducer() {
+  LogDebug("Muon|RecoMuon|L2MuonIsolationProducer") << " L2MuonIsolationProducer destructor called";
 }
 
 /// ParameterSet descriptions
 void L2MuonIsolationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("StandAloneCollectionLabel",edm::InputTag("hltL2MuonCandidates"));
+  desc.add<edm::InputTag>("StandAloneCollectionLabel", edm::InputTag("hltL2MuonCandidates"));
   edm::ParameterSetDescription extractorPSet;
   {
-    extractorPSet.add<double>("DR_Veto_H",0.1);
-    extractorPSet.add<bool>("Vertex_Constraint_Z",false);
-    extractorPSet.add<double>("Threshold_H",0.5);
-    extractorPSet.add<std::string>("ComponentName","CaloExtractor");
-    extractorPSet.add<double>("Threshold_E",0.2);
-    extractorPSet.add<double>("DR_Max",1.0);
-    extractorPSet.add<double>("DR_Veto_E",0.07);
-    extractorPSet.add<double>("Weight_E",1.5);
-    extractorPSet.add<bool>("Vertex_Constraint_XY",false);
-    extractorPSet.addUntracked<std::string>("DepositLabel","EcalPlusHcal");
-    extractorPSet.add<edm::InputTag>("CaloTowerCollectionLabel",edm::InputTag("towerMaker"));
-    extractorPSet.add<double>("Weight_H",1.0);
+    extractorPSet.add<double>("DR_Veto_H", 0.1);
+    extractorPSet.add<bool>("Vertex_Constraint_Z", false);
+    extractorPSet.add<double>("Threshold_H", 0.5);
+    extractorPSet.add<std::string>("ComponentName", "CaloExtractor");
+    extractorPSet.add<double>("Threshold_E", 0.2);
+    extractorPSet.add<double>("DR_Max", 1.0);
+    extractorPSet.add<double>("DR_Veto_E", 0.07);
+    extractorPSet.add<double>("Weight_E", 1.5);
+    extractorPSet.add<bool>("Vertex_Constraint_XY", false);
+    extractorPSet.addUntracked<std::string>("DepositLabel", "EcalPlusHcal");
+    extractorPSet.add<edm::InputTag>("CaloTowerCollectionLabel", edm::InputTag("towerMaker"));
+    extractorPSet.add<double>("Weight_H", 1.0);
   }
-  desc.add<edm::ParameterSetDescription>("ExtractorPSet",extractorPSet);
+  desc.add<edm::ParameterSetDescription>("ExtractorPSet", extractorPSet);
   edm::ParameterSetDescription isolatorPSet;
   {
     std::vector<double> temp;
-    isolatorPSet.add<std::vector<double> >("ConeSizesRel",std::vector<double>(1, 0.3));
-    isolatorPSet.add<double>("EffAreaSFEndcap",1.0);
-    isolatorPSet.add<bool>("CutAbsoluteIso",true);
-    isolatorPSet.add<bool>("AndOrCuts",true);
-    isolatorPSet.add<edm::InputTag>("RhoSrc",edm::InputTag("hltKT6CaloJetsForMuons","rho"));
-    isolatorPSet.add<std::vector<double> >("ConeSizes",std::vector<double>(1, 0.3));
-    isolatorPSet.add<std::string>("ComponentName","CutsIsolatorWithCorrection");
-    isolatorPSet.add<bool>("ReturnRelativeSum",false);
-    isolatorPSet.add<double>("RhoScaleBarrel",1.0);
-    isolatorPSet.add<double>("EffAreaSFBarrel",1.0);
-    isolatorPSet.add<bool>("CutRelativeIso",false);
-    isolatorPSet.add<std::vector<double> >("EtaBounds",std::vector<double>(1, 2.411));
-    isolatorPSet.add<std::vector<double> >("Thresholds",std::vector<double>(1, 9.9999999E7));
-    isolatorPSet.add<bool>("ReturnAbsoluteSum",true);
-    isolatorPSet.add<std::vector<double> >("EtaBoundsRel",std::vector<double>(1, 2.411));
-    isolatorPSet.add<std::vector<double> >("ThresholdsRel",std::vector<double>(1, 9.9999999E7));
-    isolatorPSet.add<double>("RhoScaleEndcap",1.0);
-    isolatorPSet.add<double>("RhoMax",9.9999999E7);
-    isolatorPSet.add<bool>("UseRhoCorrection",true);
+    isolatorPSet.add<std::vector<double>>("ConeSizesRel", std::vector<double>(1, 0.3));
+    isolatorPSet.add<double>("EffAreaSFEndcap", 1.0);
+    isolatorPSet.add<bool>("CutAbsoluteIso", true);
+    isolatorPSet.add<bool>("AndOrCuts", true);
+    isolatorPSet.add<edm::InputTag>("RhoSrc", edm::InputTag("hltKT6CaloJetsForMuons", "rho"));
+    isolatorPSet.add<std::vector<double>>("ConeSizes", std::vector<double>(1, 0.3));
+    isolatorPSet.add<std::string>("ComponentName", "CutsIsolatorWithCorrection");
+    isolatorPSet.add<bool>("ReturnRelativeSum", false);
+    isolatorPSet.add<double>("RhoScaleBarrel", 1.0);
+    isolatorPSet.add<double>("EffAreaSFBarrel", 1.0);
+    isolatorPSet.add<bool>("CutRelativeIso", false);
+    isolatorPSet.add<std::vector<double>>("EtaBounds", std::vector<double>(1, 2.411));
+    isolatorPSet.add<std::vector<double>>("Thresholds", std::vector<double>(1, 9.9999999E7));
+    isolatorPSet.add<bool>("ReturnAbsoluteSum", true);
+    isolatorPSet.add<std::vector<double>>("EtaBoundsRel", std::vector<double>(1, 2.411));
+    isolatorPSet.add<std::vector<double>>("ThresholdsRel", std::vector<double>(1, 9.9999999E7));
+    isolatorPSet.add<double>("RhoScaleEndcap", 1.0);
+    isolatorPSet.add<double>("RhoMax", 9.9999999E7);
+    isolatorPSet.add<bool>("UseRhoCorrection", true);
   }
-  desc.add<edm::ParameterSetDescription>("IsolatorPSet",isolatorPSet);
-  desc.add<bool>("WriteIsolatorFloat",false);
+  desc.add<edm::ParameterSetDescription>("IsolatorPSet", isolatorPSet);
+  desc.add<bool>("WriteIsolatorFloat", false);
   descriptions.add("hltL2MuonIsolations", desc);
 }
 
 /// build deposits
-void L2MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup){
+void L2MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup) {
   std::string metname = "Muon|RecoMuon|L2MuonIsolationProducer";
 
-  LogDebug(metname)<<" L2 Muon Isolation producing...";
+  LogDebug(metname) << " L2 Muon Isolation producing...";
 
   // Take the SA container
-  LogDebug(metname)<<" Taking the StandAlone muons: "<<theSACollectionLabel;
+  LogDebug(metname) << " Taking the StandAlone muons: " << theSACollectionLabel;
   Handle<RecoChargedCandidateCollection> muons;
-  event.getByToken(theSACollectionToken,muons);
+  event.getByToken(theSACollectionToken, muons);
 
   // Find deposits and load into event
-  LogDebug(metname)<<" Get energy around";
+  LogDebug(metname) << " Get energy around";
   auto depMap = std::make_unique<reco::IsoDepositMap>();
   auto isoMap = std::make_unique<edm::ValueMap<bool>>();
   auto isoFloatMap = std::make_unique<edm::ValueMap<float>>();
@@ -141,27 +142,26 @@ void L2MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup
 
   // fill track collection to use for vetos calculation
   TrackCollection muonTracks;
-  for (unsigned int i=0; i<nMuons; i++) {
+  for (unsigned int i = 0; i < nMuons; i++) {
     TrackRef tk = (*muons)[i].track();
     muonTracks.push_back(*tk);
   }
 
-  theExtractor->fillVetos(event,eventSetup,muonTracks);
+  theExtractor->fillVetos(event, eventSetup, muonTracks);
 
-  for (unsigned int i=0; i<nMuons; i++) {
+  for (unsigned int i = 0; i < nMuons; i++) {
     TrackRef tk = (*muons)[i].track();
 
-      deps[i] = theExtractor->deposit(event, eventSetup, *tk);
+    deps[i] = theExtractor->deposit(event, eventSetup, *tk);
 
-      if (optOutputDecision){
-	muonisolation::MuIsoBaseIsolator::DepositContainer isoContainer(1,muonisolation::MuIsoBaseIsolator::DepositAndVetos(&deps[i]));
-	muonisolation::MuIsoBaseIsolator::Result isoResult = theDepositIsolator->result( isoContainer, *tk, &event );
-	isos[i] = isoResult.valBool;
-	isoFloats[i] = isoResult.valFloat;
-      }
+    if (optOutputDecision) {
+      muonisolation::MuIsoBaseIsolator::DepositContainer isoContainer(
+          1, muonisolation::MuIsoBaseIsolator::DepositAndVetos(&deps[i]));
+      muonisolation::MuIsoBaseIsolator::Result isoResult = theDepositIsolator->result(isoContainer, *tk, &event);
+      isos[i] = isoResult.valBool;
+      isoFloats[i] = isoResult.valFloat;
+    }
   }
-
-
 
   //!do the business of filling iso map
   reco::IsoDepositMap::Filler depFiller(*depMap);
@@ -169,20 +169,20 @@ void L2MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup
   depFiller.fill();
   event.put(std::move(depMap));
 
-  if (optOutputDecision){
-    edm::ValueMap<bool> ::Filler isoFiller(*isoMap);
+  if (optOutputDecision) {
+    edm::ValueMap<bool>::Filler isoFiller(*isoMap);
     isoFiller.insert(muons, isos.begin(), isos.end());
-    isoFiller.fill();//! annoying -- I will forget it at some point
+    isoFiller.fill();  //! annoying -- I will forget it at some point
     event.put(std::move(isoMap));
 
-    if (optOutputIsolatorFloat){
-      edm::ValueMap<float> ::Filler isoFloatFiller(*isoFloatMap);
+    if (optOutputIsolatorFloat) {
+      edm::ValueMap<float>::Filler isoFloatFiller(*isoFloatMap);
       isoFloatFiller.insert(muons, isoFloats.begin(), isoFloats.end());
-      isoFloatFiller.fill();//! annoying -- I will forget it at some point
+      isoFloatFiller.fill();  //! annoying -- I will forget it at some point
       event.put(std::move(isoFloatMap));
     }
   }
 
-  LogDebug(metname) <<" Event loaded"
-		    <<"================================";
+  LogDebug(metname) << " Event loaded"
+                    << "================================";
 }

--- a/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.h
+++ b/RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.h
@@ -20,24 +20,21 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 
 class L2MuonIsolationProducer : public edm::stream::EDProducer<> {
-
- public:
-
+public:
   /// constructor with config
   L2MuonIsolationProducer(const edm::ParameterSet&);
-  
+
   /// destructor
-  ~L2MuonIsolationProducer() override; 
+  ~L2MuonIsolationProducer() override;
 
   /// ParameterSet descriptions
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   /// Produce isolation maps
   void produce(edm::Event&, const edm::EventSetup&) override;
   // ex virtual void reconstruct();
 
- private:
-  
+private:
   // Muon track Collection Label
   edm::InputTag theSACollectionLabel;
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> theSACollectionToken;
@@ -51,9 +48,8 @@ class L2MuonIsolationProducer : public edm::stream::EDProducer<> {
   // MuIsoExtractor
   std::unique_ptr<reco::isodeposit::IsoDepositExtractor> theExtractor;
 
-  // muon isolator 
+  // muon isolator
   std::unique_ptr<muonisolation::MuIsoBaseIsolator> theDepositIsolator;
-
 };
 
 #endif

--- a/RecoMuon/L2MuonIsolationProducer/src/SealModule.cc
+++ b/RecoMuon/L2MuonIsolationProducer/src/SealModule.cc
@@ -4,5 +4,4 @@
 
 #include "RecoMuon/L2MuonIsolationProducer/src/L2MuonIsolationProducer.h"
 
-
 DEFINE_FWK_MODULE(L2MuonIsolationProducer);

--- a/RecoMuon/L2MuonIsolationProducer/test/L2MuonIsolationAnalyzer.cc
+++ b/RecoMuon/L2MuonIsolationProducer/test/L2MuonIsolationAnalyzer.cc
@@ -27,28 +27,24 @@ using namespace edm;
 using namespace reco;
 
 /// Constructor
-L2MuonIsolationAnalyzer::L2MuonIsolationAnalyzer(const ParameterSet& pset) :
-  theIsolationLabel(pset.getUntrackedParameter<edm::InputTag>("IsolationCollectionLabel")),
-  theConeCases(pset.getParameter<std::vector<double> > ("ConeCases")),
-  theEtMin(pset.getParameter<double> ("EtMin")),
-  theEtMax(pset.getParameter<double> ("EtMax")),
-  theEtBins(pset.getParameter<unsigned int> ("EtBins")),
-  theCuts(pset.getParameter<std::vector<double> > ("EtaBounds"),
-          pset.getParameter<std::vector<double> > ("ConeSizes"),
-          pset.getParameter<std::vector<double> > ("Thresholds")),
-  theRootFileName(pset.getUntrackedParameter<string>("rootFileName")),
-  theTxtFileName(pset.getUntrackedParameter<string>("txtFileName"))
-{
-  LogDebug("Muon|RecoMuon|L2MuonIsolationTest")<<" L2MuonIsolationTest constructor called";
-
-
+L2MuonIsolationAnalyzer::L2MuonIsolationAnalyzer(const ParameterSet& pset)
+    : theIsolationLabel(pset.getUntrackedParameter<edm::InputTag>("IsolationCollectionLabel")),
+      theConeCases(pset.getParameter<std::vector<double> >("ConeCases")),
+      theEtMin(pset.getParameter<double>("EtMin")),
+      theEtMax(pset.getParameter<double>("EtMax")),
+      theEtBins(pset.getParameter<unsigned int>("EtBins")),
+      theCuts(pset.getParameter<std::vector<double> >("EtaBounds"),
+              pset.getParameter<std::vector<double> >("ConeSizes"),
+              pset.getParameter<std::vector<double> >("Thresholds")),
+      theRootFileName(pset.getUntrackedParameter<string>("rootFileName")),
+      theTxtFileName(pset.getUntrackedParameter<string>("txtFileName")) {
+  LogDebug("Muon|RecoMuon|L2MuonIsolationTest") << " L2MuonIsolationTest constructor called";
 }
 
 /// Destructor
-L2MuonIsolationAnalyzer::~L2MuonIsolationAnalyzer(){
-}
+L2MuonIsolationAnalyzer::~L2MuonIsolationAnalyzer() {}
 
-void L2MuonIsolationAnalyzer::beginJob(){
+void L2MuonIsolationAnalyzer::beginJob() {
   // Create output files
   theTxtFile = fopen(theTxtFileName.data(), "w");
 
@@ -58,32 +54,32 @@ void L2MuonIsolationAnalyzer::beginJob(){
   numberOfEvents = 0;
   numberOfMuons = 0;
 
-  hEtSum = new TH1F("etSum","Sum E_{T}^{weighted} (GeV)",100,0,50);
-  hEffVsCone = new TH1F("effVsCone","Efficiency(%) vs Cone Set"
-      , theConeCases.size(), 0.5, theConeCases.size()+0.5);
-  hEffVsEt = new TH1F("effVsEt","Efficiency(%) vs E_{T}^{weighted} (GeV)"
-      , theEtBins, theEtMin, theEtMax);
+  hEtSum = new TH1F("etSum", "Sum E_{T}^{weighted} (GeV)", 100, 0, 50);
+  hEffVsCone = new TH1F("effVsCone", "Efficiency(%) vs Cone Set", theConeCases.size(), 0.5, theConeCases.size() + 0.5);
+  hEffVsEt = new TH1F("effVsEt", "Efficiency(%) vs E_{T}^{weighted} (GeV)", theEtBins, theEtMin, theEtMax);
 
   hEffVsEtArray.clear();
   char chnam[256];
   char chtit[1000];
-  for (unsigned int j=0; j<theConeCases.size() ; j++) {
-      for (unsigned int k=0; k<theCuts.size() ; k++) {
-            snprintf(chnam,sizeof(chnam),"effVsEt-%.2d-%.2d", j, k);
-            snprintf(chtit,sizeof(chtit),"Eff(%%) vs E_{T}(GeV), cone size %.4f, eta in [%.4f,%.4f]"
-               , theConeCases[j], theCuts[k].etaRange.min(), theCuts[k].etaRange.max());
-            hEffVsEtArray.push_back(new TH1F(chnam, chtit
-                  , theEtBins,theEtMin,theEtMax));
-      }
+  for (unsigned int j = 0; j < theConeCases.size(); j++) {
+    for (unsigned int k = 0; k < theCuts.size(); k++) {
+      snprintf(chnam, sizeof(chnam), "effVsEt-%.2d-%.2d", j, k);
+      snprintf(chtit,
+               sizeof(chtit),
+               "Eff(%%) vs E_{T}(GeV), cone size %.4f, eta in [%.4f,%.4f]",
+               theConeCases[j],
+               theCuts[k].etaRange.min(),
+               theCuts[k].etaRange.max());
+      hEffVsEtArray.push_back(new TH1F(chnam, chtit, theEtBins, theEtMin, theEtMax));
+    }
   }
-
 }
 
-void L2MuonIsolationAnalyzer::endJob(){
+void L2MuonIsolationAnalyzer::endJob() {
   Puts("L2MuonIsolationAnalyzer>>> FINAL PRINTOUTS -> BEGIN");
   Puts("L2MuonIsolationAnalyzer>>> Number of analyzed events= %d", numberOfEvents);
   Puts("L2MuonIsolationAnalyzer>>> Number of analyzed muons= %d", numberOfMuons);
-    
+
   // Write the histos to file
   theRootFile->cd();
 
@@ -92,48 +88,50 @@ void L2MuonIsolationAnalyzer::endJob(){
   unsigned int overflow_bin;
   float norm;
 
-  overflow_bin = hEffVsCone->GetNbinsX()+1;
+  overflow_bin = hEffVsCone->GetNbinsX() + 1;
   norm = hEffVsCone->GetBinContent(overflow_bin);
-  if (norm<=0.) norm = 1.;
+  if (norm <= 0.)
+    norm = 1.;
   Puts("EffVsCone Normalization= %f", norm);
-  for (unsigned int k=1; k<overflow_bin; k++) {
-            float aux = hEffVsCone->GetBinContent(k);
-            float eff = 100*aux/norm;
-            hEffVsCone->SetBinContent(k,eff);
-            Puts("\tEfficiency in cone index= %d (size=%f): %f"
-                        , k, theConeCases[k-1], eff);
+  for (unsigned int k = 1; k < overflow_bin; k++) {
+    float aux = hEffVsCone->GetBinContent(k);
+    float eff = 100 * aux / norm;
+    hEffVsCone->SetBinContent(k, eff);
+    Puts("\tEfficiency in cone index= %d (size=%f): %f", k, theConeCases[k - 1], eff);
   }
   hEffVsCone->Write();
 
   Puts("");
-  overflow_bin = hEffVsEt->GetNbinsX()+1;
+  overflow_bin = hEffVsEt->GetNbinsX() + 1;
   norm = hEffVsEt->GetBinContent(overflow_bin);
-  if (norm<=0.) norm = 1.;
+  if (norm <= 0.)
+    norm = 1.;
   Puts("EffVsEt Normalization= %f", norm);
-  for (unsigned int k=1; k<overflow_bin; k++) {
-            float aux = hEffVsEt->GetBinContent(k);
-            float eff = 100*aux/norm;
-            hEffVsEt->SetBinContent(k,eff);
-            float et = theEtMin + (k-0.5)/theEtBins*(theEtMax-theEtMin);
-            Puts("\tEfficiency for Et threshold cut %f: %f", et, eff);
+  for (unsigned int k = 1; k < overflow_bin; k++) {
+    float aux = hEffVsEt->GetBinContent(k);
+    float eff = 100 * aux / norm;
+    hEffVsEt->SetBinContent(k, eff);
+    float et = theEtMin + (k - 0.5) / theEtBins * (theEtMax - theEtMin);
+    Puts("\tEfficiency for Et threshold cut %f: %f", et, eff);
   }
   hEffVsEt->Write();
 
-  for (unsigned int j=0; j<hEffVsEtArray.size(); j++) {
-      overflow_bin = hEffVsEtArray[j]->GetNbinsX()+1;
-      norm = hEffVsEtArray[j]->GetBinContent(overflow_bin);
-      if (norm<=0.) norm = 1.;
-      Puts("EffVsEt[%d] Normalization= %f", j, norm);
-      fprintf(theTxtFile, "%s\n", hEffVsEtArray[j]->GetTitle());
-      fprintf(theTxtFile, "%s\n", "ET threshold(GeV), efficiency(%): ");
-      for (unsigned int k=1; k<overflow_bin; k++) {
-            float aux = hEffVsEtArray[j]->GetBinContent(k);
-            float eff = 100*aux/norm;
-            hEffVsEtArray[j]->SetBinContent(k,eff);
-            float etthr = hEffVsEtArray[j]->GetXaxis()->GetBinCenter(k);
-            fprintf(theTxtFile, "%6.2f %8.3f\n", etthr, eff);
-      }
-      hEffVsEtArray[j]->Write();
+  for (unsigned int j = 0; j < hEffVsEtArray.size(); j++) {
+    overflow_bin = hEffVsEtArray[j]->GetNbinsX() + 1;
+    norm = hEffVsEtArray[j]->GetBinContent(overflow_bin);
+    if (norm <= 0.)
+      norm = 1.;
+    Puts("EffVsEt[%d] Normalization= %f", j, norm);
+    fprintf(theTxtFile, "%s\n", hEffVsEtArray[j]->GetTitle());
+    fprintf(theTxtFile, "%s\n", "ET threshold(GeV), efficiency(%): ");
+    for (unsigned int k = 1; k < overflow_bin; k++) {
+      float aux = hEffVsEtArray[j]->GetBinContent(k);
+      float eff = 100 * aux / norm;
+      hEffVsEtArray[j]->SetBinContent(k, eff);
+      float etthr = hEffVsEtArray[j]->GetXaxis()->GetBinCenter(k);
+      fprintf(theTxtFile, "%6.2f %8.3f\n", etthr, eff);
+    }
+    hEffVsEtArray[j]->Write();
   }
 
   theRootFile->Close();
@@ -142,31 +140,30 @@ void L2MuonIsolationAnalyzer::endJob(){
   Puts("L2MuonIsolationAnalyzer>>> FINAL PRINTOUTS -> END");
 }
 
-void L2MuonIsolationAnalyzer::analyze(const Event & event, const EventSetup& eventSetup){
+void L2MuonIsolationAnalyzer::analyze(const Event& event, const EventSetup& eventSetup) {
   static const string metname = "L3MuonIsolation";
-  
+
   numberOfEvents++;
-  
+
   // Get the isolation information from the event
   Handle<reco::IsoDepositMap> depMap;
   event.getByLabel(theIsolationLabel, depMap);
 
   //! How do I know it's made for tracks? Just guessing
-  typedef edm::View<reco::Track>  tracks_type;
-  Handle<tracks_type > tracksH;
-
+  typedef edm::View<reco::Track> tracks_type;
+  Handle<tracks_type> tracksH;
 
   typedef reco::IsoDepositMap::const_iterator depmap_iterator;
   depmap_iterator depMI = depMap->begin();
   depmap_iterator depMEnd = depMap->end();
 
   for (; depMI != depMEnd; ++depMI) {
-    if (depMI.id() != tracksH.id()){
-      LogTrace(metname)<<"Getting tracks with id "<<depMI.id();
+    if (depMI.id() != tracksH.id()) {
+      LogTrace(metname) << "Getting tracks with id " << depMI.id();
       event.get(depMI.id(), tracksH);
     }
-    
-    typedef reco::IsoDepositMap::container::const_iterator dep_iterator;    
+
+    typedef reco::IsoDepositMap::container::const_iterator dep_iterator;
     dep_iterator depI = depMI.begin();
     dep_iterator depEnd = depMI.end();
 
@@ -174,59 +171,64 @@ void L2MuonIsolationAnalyzer::analyze(const Event & event, const EventSetup& eve
     tk_iterator tkI = tracksH->begin();
     tk_iterator tkEnd = tracksH->end();
 
-    for (;tkI != tkEnd && depI != depEnd; ++tkI, ++depI){    
-      
+    for (; tkI != tkEnd && depI != depEnd; ++tkI, ++depI) {
       numberOfMuons++;
       tracks_type::const_pointer tk = &*tkI;
       const IsoDeposit& dep = *depI;
       //Puts("L2MuonIsolationAnalyzer>>> Track pt: %f, Deposit eta%f", tk->pt(), dep.eta());
-      
+
       muonisolation::Cuts::CutSpec cuts_here = theCuts(tk->eta());
       double conesize = cuts_here.conesize;
       float etsum = dep.depositWithin(conesize);
       hEtSum->Fill(etsum);
-      
-      hEffVsCone->Fill(theConeCases.size()+999.);
-      for (unsigned int j=0; j<theConeCases.size(); j++) {
-	if (dep.depositWithin(theConeCases[j])<cuts_here.threshold) 
-	  hEffVsCone->Fill(j+1.0);
+
+      hEffVsCone->Fill(theConeCases.size() + 999.);
+      for (unsigned int j = 0; j < theConeCases.size(); j++) {
+        if (dep.depositWithin(theConeCases[j]) < cuts_here.threshold)
+          hEffVsCone->Fill(j + 1.0);
       }
-      
-      hEffVsEt->Fill(theEtMax+999.);
-      for (unsigned int j=0; j<theEtBins; j++) {
-	float etthr = theEtMin + (j+0.5)/theEtBins*(theEtMax-theEtMin);
-	if (etsum<etthr) hEffVsEt->Fill(etthr);
+
+      hEffVsEt->Fill(theEtMax + 999.);
+      for (unsigned int j = 0; j < theEtBins; j++) {
+        float etthr = theEtMin + (j + 0.5) / theEtBins * (theEtMax - theEtMin);
+        if (etsum < etthr)
+          hEffVsEt->Fill(etthr);
       }
-      
-      for (unsigned int j=0; j<theConeCases.size() ; j++) {
-	float etsum = dep.depositWithin(theConeCases[j]);
-	for (unsigned int k=0; k<theCuts.size() ; k++) {
-	  unsigned int n = theCuts.size()*j + k;
-	  if (fabs(tk->eta())<theCuts[k].etaRange.min()) continue;
-	  if (fabs(tk->eta())>theCuts[k].etaRange.max()) continue;
-	  hEffVsEtArray[n]->Fill(theEtMax+999.);
-	  for (unsigned int l=0; l<theEtBins; l++) {
-	    float etthr = theEtMin + (l+0.5)/theEtBins*(theEtMax-theEtMin);
-	    if (etsum<etthr) hEffVsEtArray[n]->Fill(etthr);
-	  }
-	}
+
+      for (unsigned int j = 0; j < theConeCases.size(); j++) {
+        float etsum = dep.depositWithin(theConeCases[j]);
+        for (unsigned int k = 0; k < theCuts.size(); k++) {
+          unsigned int n = theCuts.size() * j + k;
+          if (fabs(tk->eta()) < theCuts[k].etaRange.min())
+            continue;
+          if (fabs(tk->eta()) > theCuts[k].etaRange.max())
+            continue;
+          hEffVsEtArray[n]->Fill(theEtMax + 999.);
+          for (unsigned int l = 0; l < theEtBins; l++) {
+            float etthr = theEtMin + (l + 0.5) / theEtBins * (theEtMax - theEtMin);
+            if (etsum < etthr)
+              hEffVsEtArray[n]->Fill(etthr);
+          }
+        }
       }
     }
   }
-  Puts("L2MuonIsolationAnalyzer>>> Run: %llu, Event %llu, number of muons %d"
-       , event.id().run(), event.id().event(), depMap->size());
+  Puts("L2MuonIsolationAnalyzer>>> Run: %llu, Event %llu, number of muons %d",
+       event.id().run(),
+       event.id().event(),
+       depMap->size());
 }
 
 void L2MuonIsolationAnalyzer::Puts(const char* va_(fmt), ...) {
-      // Do not write more than 256 characters
-      const unsigned int bufsize = 256; 
-      char chout[bufsize] = "";
-      va_list ap;
-      va_start(ap, va_(fmt));
-      vsnprintf(chout, bufsize, va_(fmt), ap);
-      va_end(ap);
-      LogVerbatim("") << chout;
-      //LogError("") << chout;
+  // Do not write more than 256 characters
+  const unsigned int bufsize = 256;
+  char chout[bufsize] = "";
+  va_list ap;
+  va_start(ap, va_(fmt));
+  vsnprintf(chout, bufsize, va_(fmt), ap);
+  va_end(ap);
+  LogVerbatim("") << chout;
+  //LogError("") << chout;
 }
 
 DEFINE_FWK_MODULE(L2MuonIsolationAnalyzer);

--- a/RecoMuon/L2MuonIsolationProducer/test/L2MuonIsolationAnalyzer.h
+++ b/RecoMuon/L2MuonIsolationProducer/test/L2MuonIsolationAnalyzer.h
@@ -15,13 +15,13 @@ namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class TFile;
 class TH1F;
 class TH2F;
 
-class L2MuonIsolationAnalyzer: public edm::EDAnalyzer {
+class L2MuonIsolationAnalyzer : public edm::EDAnalyzer {
 public:
   /// Constructor
   L2MuonIsolationAnalyzer(const edm::ParameterSet& pset);
@@ -30,10 +30,10 @@ public:
   virtual ~L2MuonIsolationAnalyzer();
 
   // Operations
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
 
-  virtual void beginJob() ;
-  virtual void endJob() ;
+  virtual void beginJob();
+  virtual void endJob();
 
 private:
   void Puts(const char* fmt, ...);
@@ -59,15 +59,13 @@ private:
   FILE* theTxtFile;
 
   // Histograms
-  TH1F *hEtSum;
-  TH1F *hEffVsCone;
-  TH1F *hEffVsEt;
+  TH1F* hEtSum;
+  TH1F* hEffVsCone;
+  TH1F* hEffVsEt;
   std::vector<TH1F*> hEffVsEtArray;
 
   // Counters and vectors
   unsigned int numberOfEvents;
   unsigned int numberOfMuons;
-  
 };
 #endif
-

--- a/RecoMuon/L2MuonProducer/src/L2MuonCandidateProducer.cc
+++ b/RecoMuon/L2MuonProducer/src/L2MuonCandidateProducer.cc
@@ -35,49 +35,50 @@ using namespace std;
 using namespace reco;
 
 /// constructor with config
-L2MuonCandidateProducer::L2MuonCandidateProducer(const ParameterSet& parameterSet){
-  LogTrace("Muon|RecoMuon|L2MuonCandidateProducer")<<" constructor called";
+L2MuonCandidateProducer::L2MuonCandidateProducer(const ParameterSet& parameterSet) {
+  LogTrace("Muon|RecoMuon|L2MuonCandidateProducer") << " constructor called";
 
   // StandAlone Collection Label
   theSACollectionLabel = parameterSet.getParameter<InputTag>("InputObjects");
   tracksToken = consumes<reco::TrackCollection>(theSACollectionLabel);
   produces<RecoChargedCandidateCollection>();
 }
-  
-/// destructor
-L2MuonCandidateProducer::~L2MuonCandidateProducer(){
-  LogTrace("Muon|RecoMuon|L2MuonCandidateProducer")<<" L2MuonCandidateProducer destructor called";
-}
 
+/// destructor
+L2MuonCandidateProducer::~L2MuonCandidateProducer() {
+  LogTrace("Muon|RecoMuon|L2MuonCandidateProducer") << " L2MuonCandidateProducer destructor called";
+}
 
 /// reconstruct muons
 void L2MuonCandidateProducer::produce(edm::StreamID sid, Event& event, const EventSetup& eventSetup) const {
   const string metname = "Muon|RecoMuon|L2MuonCandidateProducer";
-  
+
   // Take the SA container
-  LogTrace(metname)<<" Taking the StandAlone muons: "<<theSACollectionLabel;
-  Handle<TrackCollection> tracks; 
-  event.getByToken(tracksToken,tracks);
+  LogTrace(metname) << " Taking the StandAlone muons: " << theSACollectionLabel;
+  Handle<TrackCollection> tracks;
+  event.getByToken(tracksToken, tracks);
 
   // Create a RecoChargedCandidate collection
-  LogTrace(metname)<<" Creating the RecoChargedCandidate collection";
+  LogTrace(metname) << " Creating the RecoChargedCandidate collection";
   auto candidates = std::make_unique<RecoChargedCandidateCollection>();
 
-  for (unsigned int i=0; i<tracks->size(); i++) {
-      TrackRef tkref(tracks,i);
-      Particle::Charge q = tkref->charge();
-      Particle::LorentzVector p4(tkref->px(), tkref->py(), tkref->pz(), tkref->p());
-      Particle::Point vtx(tkref->vx(),tkref->vy(), tkref->vz());
-      int pid = 13;
-      if(abs(q)==1) pid = q < 0 ? 13 : -13;
-      else LogWarning(metname) << "L2MuonCandidate has charge = "<<q;
-      RecoChargedCandidate cand(q, p4, vtx, pid);
-      cand.setTrack(tkref);
-      candidates->push_back(cand);
+  for (unsigned int i = 0; i < tracks->size(); i++) {
+    TrackRef tkref(tracks, i);
+    Particle::Charge q = tkref->charge();
+    Particle::LorentzVector p4(tkref->px(), tkref->py(), tkref->pz(), tkref->p());
+    Particle::Point vtx(tkref->vx(), tkref->vy(), tkref->vz());
+    int pid = 13;
+    if (abs(q) == 1)
+      pid = q < 0 ? 13 : -13;
+    else
+      LogWarning(metname) << "L2MuonCandidate has charge = " << q;
+    RecoChargedCandidate cand(q, p4, vtx, pid);
+    cand.setTrack(tkref);
+    candidates->push_back(cand);
   }
-  
+
   event.put(std::move(candidates));
- 
-  LogTrace(metname)<<" Event loaded"
-		   <<"================================";
+
+  LogTrace(metname) << " Event loaded"
+                    << "================================";
 }

--- a/RecoMuon/L2MuonProducer/src/L2MuonCandidateProducer.h
+++ b/RecoMuon/L2MuonProducer/src/L2MuonCandidateProducer.h
@@ -23,25 +23,26 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class L2MuonCandidateProducer : public edm::global::EDProducer<> {
-
- public:
-
+public:
   /// constructor with config
   L2MuonCandidateProducer(const edm::ParameterSet&);
-  
+
   /// destructor
-  ~L2MuonCandidateProducer() override; 
-  
+  ~L2MuonCandidateProducer() override;
+
   /// produce candidates
   void produce(edm::StreamID sid, edm::Event& event, const edm::EventSetup&) const override;
-  
- private:
-  
+
+private:
   // StandAlone Collection Label
-  edm::InputTag theSACollectionLabel; 
+  edm::InputTag theSACollectionLabel;
   edm::EDGetTokenT<reco::TrackCollection> tracksToken;
 };
 

--- a/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
+++ b/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
@@ -46,15 +46,15 @@ using namespace edm;
 using namespace std;
 
 /// constructor with config
-L2MuonProducer::L2MuonProducer(const ParameterSet& parameterSet){
-  LogTrace("Muon|RecoMuon|L2MuonProducer")<<"constructor called"<<endl;
+L2MuonProducer::L2MuonProducer(const ParameterSet& parameterSet) {
+  LogTrace("Muon|RecoMuon|L2MuonProducer") << "constructor called" << endl;
 
   // Parameter set for the Builder
   ParameterSet trajectoryBuilderParameters = parameterSet.getParameter<ParameterSet>("L2TrajBuilderParameters");
 
   // MuonSeed Collection Label
   theSeedCollectionLabel = parameterSet.getParameter<InputTag>("InputObjects");
-  seedsToken = consumes<edm::View<TrajectorySeed> >(theSeedCollectionLabel);
+  seedsToken = consumes<edm::View<TrajectorySeed>>(theSeedCollectionLabel);
   // service parameters
   ParameterSet serviceParameters = parameterSet.getParameter<ParameterSet>("ServiceParameters");
 
@@ -64,199 +64,200 @@ L2MuonProducer::L2MuonProducer(const ParameterSet& parameterSet){
   // the services
   theService = new MuonServiceProxy(serviceParameters);
 
-  MuonTrajectoryBuilder * trajectoryBuilder = nullptr;
+  MuonTrajectoryBuilder* trajectoryBuilder = nullptr;
   // instantiate the concrete trajectory builder in the Track Finder
 
-  edm::ConsumesCollector  iC = consumesCollector();
-  string typeOfBuilder = parameterSet.existsAs<string>("MuonTrajectoryBuilder") ? 
-    parameterSet.getParameter<string>("MuonTrajectoryBuilder") : "StandAloneMuonTrajectoryBuilder";
-  if(typeOfBuilder == "StandAloneMuonTrajectoryBuilder" || typeOfBuilder.empty())
-    trajectoryBuilder = new StandAloneMuonTrajectoryBuilder(trajectoryBuilderParameters,theService,iC);
-  else if(typeOfBuilder == "Exhaustive")
-    trajectoryBuilder = new ExhaustiveMuonTrajectoryBuilder(trajectoryBuilderParameters,theService,iC);
-  else{
-    LogWarning("Muon|RecoMuon|StandAloneMuonProducer") << "No Trajectory builder associated with "<<typeOfBuilder
-    						       << ". Falling down to the default (StandAloneMuonTrajectoryBuilder)";
-    trajectoryBuilder = new StandAloneMuonTrajectoryBuilder(trajectoryBuilderParameters,theService,iC);
+  edm::ConsumesCollector iC = consumesCollector();
+  string typeOfBuilder = parameterSet.existsAs<string>("MuonTrajectoryBuilder")
+                             ? parameterSet.getParameter<string>("MuonTrajectoryBuilder")
+                             : "StandAloneMuonTrajectoryBuilder";
+  if (typeOfBuilder == "StandAloneMuonTrajectoryBuilder" || typeOfBuilder.empty())
+    trajectoryBuilder = new StandAloneMuonTrajectoryBuilder(trajectoryBuilderParameters, theService, iC);
+  else if (typeOfBuilder == "Exhaustive")
+    trajectoryBuilder = new ExhaustiveMuonTrajectoryBuilder(trajectoryBuilderParameters, theService, iC);
+  else {
+    LogWarning("Muon|RecoMuon|StandAloneMuonProducer")
+        << "No Trajectory builder associated with " << typeOfBuilder
+        << ". Falling down to the default (StandAloneMuonTrajectoryBuilder)";
+    trajectoryBuilder = new StandAloneMuonTrajectoryBuilder(trajectoryBuilderParameters, theService, iC);
   }
-  theTrackFinder = new MuonTrackFinder(trajectoryBuilder,
-				       new MuonTrackLoader(trackLoaderParameters, iC, theService),
-				       new MuonTrajectoryCleaner(true));
-  
+  theTrackFinder = new MuonTrackFinder(
+      trajectoryBuilder, new MuonTrackLoader(trackLoaderParameters, iC, theService), new MuonTrajectoryCleaner(true));
+
   produces<reco::TrackCollection>();
   produces<reco::TrackCollection>("UpdatedAtVtx");
   produces<TrackingRecHitCollection>();
   produces<reco::TrackExtraCollection>();
   produces<reco::TrackToTrackMap>();
 
-  produces<std::vector<Trajectory> >();
+  produces<std::vector<Trajectory>>();
   produces<TrajTrackAssociationCollection>();
 
-  produces<edm::AssociationMap<edm::OneToMany<std::vector<L2MuonTrajectorySeed>, std::vector<L2MuonTrajectorySeed> > > >();
+  produces<edm::AssociationMap<edm::OneToMany<std::vector<L2MuonTrajectorySeed>, std::vector<L2MuonTrajectorySeed>>>>();
 }
-  
+
 /// destructor
-L2MuonProducer::~L2MuonProducer(){
-  LogTrace("Muon|RecoMuon|L2eMuonProducer")<<"L2MuonProducer destructor called"<<endl;
+L2MuonProducer::~L2MuonProducer() {
+  LogTrace("Muon|RecoMuon|L2eMuonProducer") << "L2MuonProducer destructor called" << endl;
   delete theService;
   delete theTrackFinder;
 }
 
-
 /// reconstruct muons
-void L2MuonProducer::produce(Event& event, const EventSetup& eventSetup){
-  
- const std::string metname = "Muon|RecoMuon|L2MuonProducer";
-  
-  LogTrace(metname)<<endl<<endl<<endl;
-  LogTrace(metname)<<"L2 Muon Reconstruction Started"<<endl;
-  
+void L2MuonProducer::produce(Event& event, const EventSetup& eventSetup) {
+  const std::string metname = "Muon|RecoMuon|L2MuonProducer";
+
+  LogTrace(metname) << endl << endl << endl;
+  LogTrace(metname) << "L2 Muon Reconstruction Started" << endl;
+
   // Take the seeds container
-  LogTrace(metname)<<"Taking the seeds: "<<theSeedCollectionLabel.label()<<endl;
-  Handle<View<TrajectorySeed> > seeds; 
-  event.getByToken(seedsToken,seeds);
+  LogTrace(metname) << "Taking the seeds: " << theSeedCollectionLabel.label() << endl;
+  Handle<View<TrajectorySeed>> seeds;
+  event.getByToken(seedsToken, seeds);
 
   // Update the services
   theService->update(eventSetup);
-  
-  // Reconstruct 
-  LogTrace(metname)<<"Track Reconstruction"<<endl;
-  theTrackFinder->reconstruct(seeds,event, eventSetup);
-  
-  LogTrace(metname)<<"Event loaded"
-		   <<"================================"
-		   <<endl<<endl;
+
+  // Reconstruct
+  LogTrace(metname) << "Track Reconstruction" << endl;
+  theTrackFinder->reconstruct(seeds, event, eventSetup);
+
+  LogTrace(metname) << "Event loaded"
+                    << "================================" << endl
+                    << endl;
 }
 
 void L2MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-    edm::ParameterSetDescription desc;
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.addUntracked<std::vector<std::string>>("Propagators",
+                                                {
+                                                    "hltESPFastSteppingHelixPropagatorAny"
+                                                    "hltESPFastSteppingHelixPropagatorOpposite",
+                                                });
+    psd0.add<bool>("RPCLayers", true);
+    psd0.addUntracked<bool>("UseMuonNavigation", true);
+    desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
+  }
+
+  desc.add<edm::InputTag>("InputObjects", edm::InputTag("hltL2MuonSeeds"));
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("Fitter", "hltESPKFFittingSmootherForL2Muon");
+    psd0.add<std::string>("MuonRecHitBuilder", "hltESPMuonTransientTrackingRecHitBuilder");
+    psd0.add<unsigned int>("NMinRecHits", 2);
+    psd0.add<bool>("UseSubRecHits", false);
+    psd0.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorAny");
+    psd0.add<double>("RescaleError", 100.0);
+    desc.add<edm::ParameterSetDescription>("SeedTransformerParameters", psd0);
+  }
+
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<bool>("DoRefit", false);
+    psd0.add<std::string>("SeedPropagator", "hltESPFastSteppingHelixPropagatorAny");
     {
-        edm::ParameterSetDescription psd0;
-        psd0.addUntracked<std::vector<std::string>>("Propagators", {
-            "hltESPFastSteppingHelixPropagatorAny"
-            "hltESPFastSteppingHelixPropagatorOpposite",
-        });
-        psd0.add<bool>("RPCLayers", true);
-        psd0.addUntracked<bool>("UseMuonNavigation", true);
-        desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
+      edm::ParameterSetDescription psd1;
+      psd1.add<double>("NumberOfSigma", 3.0);
+      psd1.add<std::string>("FitDirection", "insideOut");
+      psd1.add<edm::InputTag>("DTRecSegmentLabel", edm::InputTag("hltDt4DSegments"));
+      psd1.add<double>("MaxChi2", 1000.0);
+      {
+        edm::ParameterSetDescription psd2;
+        psd2.add<double>("MaxChi2", 25.0);
+        psd2.add<double>("RescaleErrorFactor", 100.0);
+        psd2.add<int>("Granularity", 0);
+        psd2.add<bool>("ExcludeRPCFromFit", false);
+        psd2.add<bool>("UseInvalidHits", true);
+        psd2.add<bool>("RescaleError", false);
+        psd1.add<edm::ParameterSetDescription>("MuonTrajectoryUpdatorParameters", psd2);
+      }
+      psd1.add<bool>("EnableRPCMeasurement", true);
+      psd1.add<edm::InputTag>("CSCRecSegmentLabel", edm::InputTag("hltCscSegments"));
+      psd1.add<bool>("EnableDTMeasurement", true);
+      psd1.add<edm::InputTag>("RPCRecSegmentLabel", edm::InputTag("hltRpcRecHits"));
+      psd1.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorAny");
+      psd1.add<bool>("EnableGEMMeasurement", false);
+      psd1.add<edm::InputTag>("GEMRecSegmentLabel", edm::InputTag("gemRecHits"));
+      psd1.add<bool>("EnableME0Measurement", false);
+      psd1.add<edm::InputTag>("ME0RecSegmentLabel", edm::InputTag("me0Segments"));
+      psd1.add<bool>("EnableCSCMeasurement", true);
+      psd0.add<edm::ParameterSetDescription>("FilterParameters", psd1);
     }
-    
-    
-    desc.add<edm::InputTag>("InputObjects", edm::InputTag("hltL2MuonSeeds"));
+    psd0.add<std::string>("NavigationType", "Standard");
     {
-        edm::ParameterSetDescription psd0;
-        psd0.add<std::string>("Fitter", "hltESPKFFittingSmootherForL2Muon");
-        psd0.add<std::string>("MuonRecHitBuilder", "hltESPMuonTransientTrackingRecHitBuilder");
-        psd0.add<unsigned int>("NMinRecHits",2);
-        psd0.add<bool>("UseSubRecHits", false);
-        psd0.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorAny");
-        psd0.add<double>("RescaleError", 100.0);
-        desc.add<edm::ParameterSetDescription>("SeedTransformerParameters", psd0);
+      edm::ParameterSetDescription psd1;
+      psd1.add<std::string>("Fitter", "hltESPKFFittingSmootherForL2Muon");
+      psd1.add<std::string>("MuonRecHitBuilder", "hltESPMuonTransientTrackingRecHitBuilder");
+      psd1.add<unsigned int>("NMinRecHits", 2);
+      psd1.add<bool>("UseSubRecHits", false);
+      psd1.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorAny");
+      psd1.add<double>("RescaleError", 100.0);
+      psd0.add<edm::ParameterSetDescription>("SeedTransformerParameters", psd1);
     }
-    
+    psd0.add<bool>("DoBackwardFilter", true);
+    psd0.add<std::string>("SeedPosition", "in");
     {
-        edm::ParameterSetDescription psd0;
-        psd0.add<bool>("DoRefit", false);
-        psd0.add<std::string>("SeedPropagator", "hltESPFastSteppingHelixPropagatorAny");
-        {
-            edm::ParameterSetDescription psd1;
-            psd1.add<double>("NumberOfSigma", 3.0);
-            psd1.add<std::string>("FitDirection", "insideOut");
-            psd1.add<edm::InputTag>("DTRecSegmentLabel", edm::InputTag("hltDt4DSegments"));
-            psd1.add<double>("MaxChi2", 1000.0);
-            {
-                edm::ParameterSetDescription psd2;
-                psd2.add<double>("MaxChi2", 25.0);
-                psd2.add<double>("RescaleErrorFactor", 100.0);
-                psd2.add<int>("Granularity", 0);
-                psd2.add<bool>("ExcludeRPCFromFit", false);
-                psd2.add<bool>("UseInvalidHits", true);
-                psd2.add<bool>("RescaleError", false);
-                psd1.add<edm::ParameterSetDescription>("MuonTrajectoryUpdatorParameters", psd2);
-            }
-            psd1.add<bool>("EnableRPCMeasurement", true);
-            psd1.add<edm::InputTag>("CSCRecSegmentLabel", edm::InputTag("hltCscSegments"));
-            psd1.add<bool>("EnableDTMeasurement", true);
-            psd1.add<edm::InputTag>("RPCRecSegmentLabel", edm::InputTag("hltRpcRecHits"));
-            psd1.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorAny");
-            psd1.add<bool>("EnableGEMMeasurement", false);
-            psd1.add<edm::InputTag>("GEMRecSegmentLabel", edm::InputTag("gemRecHits"));
-            psd1.add<bool>("EnableME0Measurement", false);
-            psd1.add<edm::InputTag>("ME0RecSegmentLabel", edm::InputTag("me0Segments"));
-            psd1.add<bool>("EnableCSCMeasurement", true);
-            psd0.add<edm::ParameterSetDescription>("FilterParameters", psd1);
-        }
-        psd0.add<std::string>("NavigationType", "Standard");
-        {
-            edm::ParameterSetDescription psd1;
-            psd1.add<std::string>("Fitter", "hltESPKFFittingSmootherForL2Muon");
-            psd1.add<std::string>("MuonRecHitBuilder", "hltESPMuonTransientTrackingRecHitBuilder");
-            psd1.add<unsigned int>("NMinRecHits",2);
-            psd1.add<bool>("UseSubRecHits", false);
-            psd1.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorAny");
-            psd1.add<double>("RescaleError", 100.0);
-            psd0.add<edm::ParameterSetDescription>("SeedTransformerParameters", psd1);
-        }
-        psd0.add<bool>("DoBackwardFilter", true);
-        psd0.add<std::string>("SeedPosition", "in");
-        {
-            edm::ParameterSetDescription psd1;
-            psd1.add<double>("NumberOfSigma", 3.0);
-            psd1.add<edm::InputTag>("CSCRecSegmentLabel", edm::InputTag("hltCscSegments"));
-            psd1.add<std::string>("FitDirection", "outsideIn");
-            psd1.add<edm::InputTag>("DTRecSegmentLabel", edm::InputTag("hltDt4DSegments"));
-            psd1.add<double>("MaxChi2", 100.0);
-            {
-                edm::ParameterSetDescription psd2;
-                psd2.add<double>("MaxChi2", 25.0);
-                psd2.add<double>("RescaleErrorFactor", 100.0);
-                psd2.add<int>("Granularity", 0);
-                psd2.add<bool>("ExcludeRPCFromFit", false);
-                psd2.add<bool>("UseInvalidHits", true);
-                psd2.add<bool>("RescaleError", false);
-                psd1.add<edm::ParameterSetDescription>("MuonTrajectoryUpdatorParameters", psd2);
-            }
-            psd1.add<bool>("EnableRPCMeasurement", true);
-            psd1.add<std::string>("BWSeedType", "fromGenerator");
-            psd1.add<bool>("EnableDTMeasurement", true);
-            psd1.add<edm::InputTag>("RPCRecSegmentLabel", edm::InputTag("hltRpcRecHits"));
-            psd1.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorAny");
-            psd1.add<bool>("EnableGEMMeasurement", false);
-            psd1.add<edm::InputTag>("GEMRecSegmentLabel", edm::InputTag("gemRecHits"));
-            psd1.add<bool>("EnableME0Measurement", false);
-            psd1.add<edm::InputTag>("ME0RecSegmentLabel", edm::InputTag("me0Segments"));
-            psd1.add<bool>("EnableCSCMeasurement", true);
-            psd0.add<edm::ParameterSetDescription>("BWFilterParameters", psd1);
-        }
-        psd0.add<bool>("DoSeedRefit", false);
-        desc.add<edm::ParameterSetDescription>("L2TrajBuilderParameters", psd0);
+      edm::ParameterSetDescription psd1;
+      psd1.add<double>("NumberOfSigma", 3.0);
+      psd1.add<edm::InputTag>("CSCRecSegmentLabel", edm::InputTag("hltCscSegments"));
+      psd1.add<std::string>("FitDirection", "outsideIn");
+      psd1.add<edm::InputTag>("DTRecSegmentLabel", edm::InputTag("hltDt4DSegments"));
+      psd1.add<double>("MaxChi2", 100.0);
+      {
+        edm::ParameterSetDescription psd2;
+        psd2.add<double>("MaxChi2", 25.0);
+        psd2.add<double>("RescaleErrorFactor", 100.0);
+        psd2.add<int>("Granularity", 0);
+        psd2.add<bool>("ExcludeRPCFromFit", false);
+        psd2.add<bool>("UseInvalidHits", true);
+        psd2.add<bool>("RescaleError", false);
+        psd1.add<edm::ParameterSetDescription>("MuonTrajectoryUpdatorParameters", psd2);
+      }
+      psd1.add<bool>("EnableRPCMeasurement", true);
+      psd1.add<std::string>("BWSeedType", "fromGenerator");
+      psd1.add<bool>("EnableDTMeasurement", true);
+      psd1.add<edm::InputTag>("RPCRecSegmentLabel", edm::InputTag("hltRpcRecHits"));
+      psd1.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorAny");
+      psd1.add<bool>("EnableGEMMeasurement", false);
+      psd1.add<edm::InputTag>("GEMRecSegmentLabel", edm::InputTag("gemRecHits"));
+      psd1.add<bool>("EnableME0Measurement", false);
+      psd1.add<edm::InputTag>("ME0RecSegmentLabel", edm::InputTag("me0Segments"));
+      psd1.add<bool>("EnableCSCMeasurement", true);
+      psd0.add<edm::ParameterSetDescription>("BWFilterParameters", psd1);
     }
-    desc.add<bool>("DoSeedRefit", false);
+    psd0.add<bool>("DoSeedRefit", false);
+    desc.add<edm::ParameterSetDescription>("L2TrajBuilderParameters", psd0);
+  }
+  desc.add<bool>("DoSeedRefit", false);
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("Smoother", "hltESPKFTrajectorySmootherForMuonTrackLoader");
+    psd0.add<bool>("DoSmoothing", false);
+    psd0.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"));
     {
-        edm::ParameterSetDescription psd0;
-        psd0.add<std::string>("Smoother", "hltESPKFTrajectorySmootherForMuonTrackLoader");
-        psd0.add<bool>("DoSmoothing", false);
-        psd0.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"));
-        {
-            edm::ParameterSetDescription psd1;
-            psd1.add<double>("MaxChi2", 1000000.0);
-            psd1.add<std::vector<double>>("BeamSpotPosition", {
-                0.0,
-                0.0,
-                0.0,
-            });
-            psd1.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorOpposite");
-            psd1.add<std::vector<double>>("BeamSpotPositionErrors", {
-                0.1,
-                0.1,
-                5.3,
-            });
-            psd0.add<edm::ParameterSetDescription>("MuonUpdatorAtVertexParameters", psd1);
-        }
-        psd0.add<bool>("VertexConstraint", true);
-        psd0.add<std::string>("TTRHBuilder", "hltESPTTRHBWithTrackAngle");
-        desc.add<edm::ParameterSetDescription>("TrackLoaderParameters", psd0);
+      edm::ParameterSetDescription psd1;
+      psd1.add<double>("MaxChi2", 1000000.0);
+      psd1.add<std::vector<double>>("BeamSpotPosition",
+                                    {
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                    });
+      psd1.add<std::string>("Propagator", "hltESPFastSteppingHelixPropagatorOpposite");
+      psd1.add<std::vector<double>>("BeamSpotPositionErrors",
+                                    {
+                                        0.1,
+                                        0.1,
+                                        5.3,
+                                    });
+      psd0.add<edm::ParameterSetDescription>("MuonUpdatorAtVertexParameters", psd1);
     }
-    desc.add<std::string>("MuonTrajectoryBuilder", "Exhaustive");
-    descriptions.add("L2MuonProducer", desc);
+    psd0.add<bool>("VertexConstraint", true);
+    psd0.add<std::string>("TTRHBuilder", "hltESPTTRHBWithTrackAngle");
+    desc.add<edm::ParameterSetDescription>("TrackLoaderParameters", psd0);
+  }
+  desc.add<std::string>("MuonTrajectoryBuilder", "Exhaustive");
+  descriptions.add("L2MuonProducer", desc);
 }

--- a/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
+++ b/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
@@ -70,7 +70,7 @@ L2MuonProducer::L2MuonProducer(const ParameterSet& parameterSet){
   edm::ConsumesCollector  iC = consumesCollector();
   string typeOfBuilder = parameterSet.existsAs<string>("MuonTrajectoryBuilder") ? 
     parameterSet.getParameter<string>("MuonTrajectoryBuilder") : "StandAloneMuonTrajectoryBuilder";
-  if(typeOfBuilder == "StandAloneMuonTrajectoryBuilder" || typeOfBuilder == "")
+  if(typeOfBuilder == "StandAloneMuonTrajectoryBuilder" || typeOfBuilder.empty())
     trajectoryBuilder = new StandAloneMuonTrajectoryBuilder(trajectoryBuilderParameters,theService,iC);
   else if(typeOfBuilder == "Exhaustive")
     trajectoryBuilder = new ExhaustiveMuonTrajectoryBuilder(trajectoryBuilderParameters,theService,iC);

--- a/RecoMuon/L2MuonProducer/src/L2MuonProducer.h
+++ b/RecoMuon/L2MuonProducer/src/L2MuonProducer.h
@@ -25,37 +25,38 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class MuonTrackFinder;
 class MuonServiceProxy;
 
 class L2MuonProducer : public edm::stream::EDProducer<> {
-
-  public:
-
+public:
   /// constructor with config
   L2MuonProducer(const edm::ParameterSet&);
-  
+
   /// destructor
-  ~L2MuonProducer() override; 
-  
+  ~L2MuonProducer() override;
+
   /// reconstruct muons
   void produce(edm::Event&, const edm::EventSetup&) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);   
- private:
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+private:
   // MuonSeed Collection Label
   edm::InputTag theSeedCollectionLabel;
 
   /// the track finder
-  MuonTrackFinder* theTrackFinder; //It isn't the same as in ORCA
+  MuonTrackFinder* theTrackFinder;  //It isn't the same as in ORCA
 
   /// the event setup proxy, it takes care the services update
-  MuonServiceProxy *theService;
-  
-  edm::EDGetTokenT<edm::View<TrajectorySeed> > seedsToken;
+  MuonServiceProxy* theService;
 
+  edm::EDGetTokenT<edm::View<TrajectorySeed> > seedsToken;
 };
 
 #endif

--- a/RecoMuon/L2MuonProducer/src/SealModule.cc
+++ b/RecoMuon/L2MuonProducer/src/SealModule.cc
@@ -5,6 +5,5 @@
 #include "RecoMuon/L2MuonProducer/src/L2MuonProducer.h"
 #include "RecoMuon/L2MuonProducer/src/L2MuonCandidateProducer.h"
 
-
 DEFINE_FWK_MODULE(L2MuonProducer);
 DEFINE_FWK_MODULE(L2MuonCandidateProducer);

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.cc
@@ -18,7 +18,6 @@
 // Class Header
 #include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.h"
 
-
 // Framework
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -41,54 +40,53 @@ using namespace edm;
 using namespace l1extra;
 
 // constructors
-L2MuonSeedGenerator::L2MuonSeedGenerator(const edm::ParameterSet& iConfig) : 
-  theSource(iConfig.getParameter<InputTag>("InputObjects")),
-  theL1GMTReadoutCollection(iConfig.getParameter<InputTag>("GMTReadoutCollection")),
-  thePropagatorName(iConfig.getParameter<string>("Propagator")),
-  theL1MinPt(iConfig.getParameter<double>("L1MinPt")),
-  theL1MaxEta(iConfig.getParameter<double>("L1MaxEta")),
-  theL1MinQuality(iConfig.getParameter<unsigned int>("L1MinQuality")),
-  useOfflineSeed(iConfig.getUntrackedParameter<bool>("UseOfflineSeed", false)),
-  useUnassociatedL1(iConfig.existsAs<bool>("UseUnassociatedL1") ? 
-		    iConfig.getParameter<bool>("UseUnassociatedL1") : true){
-
+L2MuonSeedGenerator::L2MuonSeedGenerator(const edm::ParameterSet& iConfig)
+    : theSource(iConfig.getParameter<InputTag>("InputObjects")),
+      theL1GMTReadoutCollection(iConfig.getParameter<InputTag>("GMTReadoutCollection")),
+      thePropagatorName(iConfig.getParameter<string>("Propagator")),
+      theL1MinPt(iConfig.getParameter<double>("L1MinPt")),
+      theL1MaxEta(iConfig.getParameter<double>("L1MaxEta")),
+      theL1MinQuality(iConfig.getParameter<unsigned int>("L1MinQuality")),
+      useOfflineSeed(iConfig.getUntrackedParameter<bool>("UseOfflineSeed", false)),
+      useUnassociatedL1(iConfig.existsAs<bool>("UseUnassociatedL1") ? iConfig.getParameter<bool>("UseUnassociatedL1")
+                                                                    : true) {
   gmtToken_ = consumes<L1MuGMTReadoutCollection>(theL1GMTReadoutCollection);
   muCollToken_ = consumes<L1MuonParticleCollection>(theSource);
 
-  if(useOfflineSeed) {
+  if (useOfflineSeed) {
     theOfflineSeedLabel = iConfig.getUntrackedParameter<InputTag>("OfflineSeedLabel");
     offlineSeedToken_ = consumes<edm::View<TrajectorySeed> >(theOfflineSeedLabel);
   }
-  
+
   // service parameters
   ParameterSet serviceParameters = iConfig.getParameter<ParameterSet>("ServiceParameters");
-  
+
   // the services
   theService = new MuonServiceProxy(serviceParameters);
 
   // the estimator
   theEstimator = new Chi2MeasurementEstimator(10000.);
 
-
-  produces<L2MuonTrajectorySeedCollection>(); 
+  produces<L2MuonTrajectorySeedCollection>();
 }
 
 // destructor
-L2MuonSeedGenerator::~L2MuonSeedGenerator(){
-  if (theService) delete theService;
-  if (theEstimator) delete theEstimator;
+L2MuonSeedGenerator::~L2MuonSeedGenerator() {
+  if (theService)
+    delete theService;
+  if (theEstimator)
+    delete theEstimator;
 }
 
-void L2MuonSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void L2MuonSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const std::string metname = "Muon|RecoMuon|L2MuonSeedGenerator";
   MuonPatternRecoDumper debug;
 
   auto output = std::make_unique<L2MuonTrajectorySeedCollection>();
-  
+
   // Muon particles and GMT readout collection
   edm::Handle<L1MuGMTReadoutCollection> gmtrc_handle;
-  iEvent.getByToken(gmtToken_,gmtrc_handle);
+  iEvent.getByToken(gmtToken_, gmtrc_handle);
   L1MuGMTReadoutRecord const& gmtrr = gmtrc_handle.product()->getRecord(0);
 
   edm::Handle<L1MuonParticleCollection> muColl;
@@ -97,7 +95,7 @@ void L2MuonSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   edm::Handle<edm::View<TrajectorySeed> > offlineSeedHandle;
   vector<int> offlineSeedMap;
-  if(useOfflineSeed) {
+  if (useOfflineSeed) {
     iEvent.getByToken(offlineSeedToken_, offlineSeedHandle);
     LogTrace(metname) << "Number of offline seeds " << offlineSeedHandle->size() << endl;
     offlineSeedMap = vector<int>(offlineSeedHandle->size(), 0);
@@ -106,279 +104,298 @@ void L2MuonSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   L1MuonParticleCollection::const_iterator it;
   L1MuonParticleRef::key_type l1ParticleIndex = 0;
 
-  for(it = muColl->begin(); it != muColl->end(); ++it,++l1ParticleIndex) {
-    
+  for (it = muColl->begin(); it != muColl->end(); ++it, ++l1ParticleIndex) {
     const L1MuGMTExtendedCand muonCand = (*it).gmtMuonCand();
     unsigned int quality = 0;
-    bool valid_charge = false;;
+    bool valid_charge = false;
+    ;
 
-    if ( muonCand.empty() ) {
+    if (muonCand.empty()) {
       LogWarning(metname) << "L2MuonSeedGenerator: WARNING, no L1MuGMTCand! " << endl;
       LogWarning(metname) << "L2MuonSeedGenerator:   this should make sense only within MC tests" << endl;
       // FIXME! Temporary to handle the MC input
       quality = 7;
       valid_charge = true;
-    }
-    else {
-      quality =  muonCand.quality();
+    } else {
+      quality = muonCand.quality();
       valid_charge = muonCand.charge_valid();
     }
-    
-    float pt    =  (*it).pt();
-    float eta   =  (*it).eta();
-    float theta =  2*atan(exp(-eta));
-    float phi   =  (*it).phi();      
-    int charge  =  (*it).charge();
+
+    float pt = (*it).pt();
+    float eta = (*it).eta();
+    float theta = 2 * atan(exp(-eta));
+    float phi = (*it).phi();
+    int charge = (*it).charge();
     // Set charge=0 for the time being if the valid charge bit is zero
-    if (!valid_charge) charge = 0;
+    if (!valid_charge)
+      charge = 0;
     bool barrel = !(*it).isForward();
 
     // Get a better eta and charge from regional information
     // Phi has the same resolution in GMT than regionally, is not it?
-    if ( !(muonCand.empty()) ) {
+    if (!(muonCand.empty())) {
       int idx = -1;
       vector<L1MuRegionalCand> rmc;
-      if ( !muonCand.isRPC() ) {
-            idx = muonCand.getDTCSCIndex();
-            if (muonCand.isFwd()) rmc = gmtrr.getCSCCands();
-            else rmc = gmtrr.getDTBXCands();
+      if (!muonCand.isRPC()) {
+        idx = muonCand.getDTCSCIndex();
+        if (muonCand.isFwd())
+          rmc = gmtrr.getCSCCands();
+        else
+          rmc = gmtrr.getDTBXCands();
       } else {
-            idx = muonCand.getRPCIndex();
-            if (muonCand.isFwd()) rmc = gmtrr.getFwdRPCCands();
-            else rmc = gmtrr.getBrlRPCCands();
+        idx = muonCand.getRPCIndex();
+        if (muonCand.isFwd())
+          rmc = gmtrr.getFwdRPCCands();
+        else
+          rmc = gmtrr.getBrlRPCCands();
       }
-      if (idx>=0) {
-            eta = rmc[idx].etaValue();
-            //phi = rmc[idx].phiValue();
-            // Use this charge if the valid charge bit is zero
-            if (!valid_charge) charge = rmc[idx].chargeValue();
+      if (idx >= 0) {
+        eta = rmc[idx].etaValue();
+        //phi = rmc[idx].phiValue();
+        // Use this charge if the valid charge bit is zero
+        if (!valid_charge)
+          charge = rmc[idx].chargeValue();
       }
     }
 
-    if ( pt < theL1MinPt || fabs(eta) > theL1MaxEta ) continue;
-    
+    if (pt < theL1MinPt || fabs(eta) > theL1MaxEta)
+      continue;
+
     LogTrace(metname) << "New L2 Muon Seed";
     LogTrace(metname) << "Pt = " << pt << " GeV/c";
     LogTrace(metname) << "eta = " << eta;
     LogTrace(metname) << "theta = " << theta << " rad";
     LogTrace(metname) << "phi = " << phi << " rad";
-    LogTrace(metname) << "charge = "<< charge;
-    LogTrace(metname) << "In Barrel? = "<< barrel;
-    
-    if ( quality <= theL1MinQuality ) continue;
-    LogTrace(metname) << "quality = "<< quality; 
-    
+    LogTrace(metname) << "charge = " << charge;
+    LogTrace(metname) << "In Barrel? = " << barrel;
+
+    if (quality <= theL1MinQuality)
+      continue;
+    LogTrace(metname) << "quality = " << quality;
+
     // Update the services
     theService->update(iSetup);
 
-    const DetLayer *detLayer = nullptr;
+    const DetLayer* detLayer = nullptr;
     float radius = 0.;
-  
-    CLHEP::Hep3Vector vec(0.,1.,0.);
+
+    CLHEP::Hep3Vector vec(0., 1., 0.);
     vec.setTheta(theta);
     vec.setPhi(phi);
-	
+
     // Get the det layer on which the state should be put
-    if ( barrel ){
+    if (barrel) {
       LogTrace(metname) << "The seed is in the barrel";
-      
+
       // MB2
-      DetId id = DTChamberId(0,2,0);
+      DetId id = DTChamberId(0, 2, 0);
       detLayer = theService->detLayerGeometry()->idToLayer(id);
       LogTrace(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
-      
+
       const BoundSurface* sur = &(detLayer->surface());
       const BoundCylinder* bc = dynamic_cast<const BoundCylinder*>(sur);
 
-      radius = fabs(bc->radius()/sin(theta));
+      radius = fabs(bc->radius() / sin(theta));
 
-      LogTrace(metname) << "radius "<<radius;
+      LogTrace(metname) << "radius " << radius;
 
-      if ( pt < 3.5 ) pt = 3.5;
-    }
-    else { 
+      if (pt < 3.5)
+        pt = 3.5;
+    } else {
       LogTrace(metname) << "The seed is in the endcap";
-      
+
       DetId id;
       // ME2
-      if ( theta < Geom::pi()/2. )
-	id = CSCDetId(1,2,0,0,0); 
+      if (theta < Geom::pi() / 2.)
+        id = CSCDetId(1, 2, 0, 0, 0);
       else
-	id = CSCDetId(2,2,0,0,0); 
-      
+        id = CSCDetId(2, 2, 0, 0, 0);
+
       detLayer = theService->detLayerGeometry()->idToLayer(id);
       LogTrace(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
 
-      radius = fabs(detLayer->position().z()/cos(theta));      
-      
-      if( pt < 1.0) pt = 1.0;
-    }
-        
-    vec.setMag(radius);
-    
-    GlobalPoint pos(vec.x(),vec.y(),vec.z());
-      
-    GlobalVector mom(pt*cos(phi), pt*sin(phi), pt*cos(theta)/sin(theta));
+      radius = fabs(detLayer->position().z() / cos(theta));
 
-    GlobalTrajectoryParameters param(pos,mom,charge,&*theService->magneticField());
+      if (pt < 1.0)
+        pt = 1.0;
+    }
+
+    vec.setMag(radius);
+
+    GlobalPoint pos(vec.x(), vec.y(), vec.z());
+
+    GlobalVector mom(pt * cos(phi), pt * sin(phi), pt * cos(theta) / sin(theta));
+
+    GlobalTrajectoryParameters param(pos, mom, charge, &*theService->magneticField());
     AlgebraicSymMatrix55 mat;
-    
-    mat[0][0] = (0.25/pt)*(0.25/pt);  // sigma^2(charge/abs_momentum)
-    if ( !barrel ) mat[0][0] = (0.4/pt)*(0.4/pt);
+
+    mat[0][0] = (0.25 / pt) * (0.25 / pt);  // sigma^2(charge/abs_momentum)
+    if (!barrel)
+      mat[0][0] = (0.4 / pt) * (0.4 / pt);
 
     //Assign q/pt = 0 +- 1/pt if charge has been declared invalid
-    if (!valid_charge) mat[0][0] = (1./pt)*(1./pt);
-    
-    mat[1][1] = 0.05*0.05;        // sigma^2(lambda)
-    mat[2][2] = 0.2*0.2;          // sigma^2(phi)
-    mat[3][3] = 20.*20.;          // sigma^2(x_transverse))
-    mat[4][4] = 20.*20.;          // sigma^2(y_transverse))
-    
+    if (!valid_charge)
+      mat[0][0] = (1. / pt) * (1. / pt);
+
+    mat[1][1] = 0.05 * 0.05;  // sigma^2(lambda)
+    mat[2][2] = 0.2 * 0.2;    // sigma^2(phi)
+    mat[3][3] = 20. * 20.;    // sigma^2(x_transverse))
+    mat[4][4] = 20. * 20.;    // sigma^2(y_transverse))
+
     CurvilinearTrajectoryError error(mat);
 
-    const FreeTrajectoryState state(param,error);
-   
+    const FreeTrajectoryState state(param, error);
+
     LogTrace(metname) << "Free trajectory State from the parameters";
     LogTrace(metname) << debug.dumpFTS(state);
 
     // Propagate the state on the MB2/ME2 surface
     TrajectoryStateOnSurface tsos = theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
-   
+
     LogTrace(metname) << "State after the propagation on the layer";
     LogTrace(metname) << debug.dumpLayer(detLayer);
     LogTrace(metname) << debug.dumpFTS(state);
 
     if (tsos.isValid()) {
       // Get the compatible dets on the layer
-      std::vector< pair<const GeomDet*,TrajectoryStateOnSurface> > 
-	detsWithStates = detLayer->compatibleDets(tsos, 
-						  *theService->propagator(thePropagatorName), 
-						  *theEstimator);   
-      if (!detsWithStates.empty()){
+      std::vector<pair<const GeomDet*, TrajectoryStateOnSurface> > detsWithStates =
+          detLayer->compatibleDets(tsos, *theService->propagator(thePropagatorName), *theEstimator);
+      if (!detsWithStates.empty()) {
+        TrajectoryStateOnSurface newTSOS = detsWithStates.front().second;
+        const GeomDet* newTSOSDet = detsWithStates.front().first;
 
-	TrajectoryStateOnSurface newTSOS = detsWithStates.front().second;
-	const GeomDet *newTSOSDet = detsWithStates.front().first;
-	
-	LogTrace(metname) << "Most compatible det";
-	LogTrace(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
+        LogTrace(metname) << "Most compatible det";
+        LogTrace(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
 
-	LogDebug(metname) << "L1 info: Det and State:";
-	LogDebug(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
+        LogDebug(metname) << "L1 info: Det and State:";
+        LogDebug(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
 
-	if (newTSOS.isValid()){
+        if (newTSOS.isValid()) {
+          //LogDebug(metname) << "(x, y, z) = (" << newTSOS.globalPosition().x() << ", "
+          //	              << newTSOS.globalPosition().y() << ", " << newTSOS.globalPosition().z() << ")";
+          LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag()
+                            << ", phi=" << newTSOS.globalPosition().phi() << ", eta=" << newTSOS.globalPosition().eta()
+                            << ")";
+          LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge() * newTSOS.globalMomentum().perp()
+                            << ", phi=" << newTSOS.globalMomentum().phi() << ", eta=" << newTSOS.globalMomentum().eta()
+                            << ")";
 
-	  //LogDebug(metname) << "(x, y, z) = (" << newTSOS.globalPosition().x() << ", " 
-	  //	              << newTSOS.globalPosition().y() << ", " << newTSOS.globalPosition().z() << ")";
-	  LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag() << ", phi=" 
-			    << newTSOS.globalPosition().phi() << ", eta=" << newTSOS.globalPosition().eta() << ")";
-	  LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge()*newTSOS.globalMomentum().perp() << ", phi=" 
-			    << newTSOS.globalMomentum().phi() << ", eta=" << newTSOS.globalMomentum().eta() << ")";
+          //LogDebug(metname) << "State on it";
+          //LogDebug(metname) << debug.dumpTSOS(newTSOS);
 
-	  //LogDebug(metname) << "State on it";
-	  //LogDebug(metname) << debug.dumpTSOS(newTSOS);
+          //PTrajectoryStateOnDet seedTSOS;
+          edm::OwnVector<TrackingRecHit> container;
 
-	  //PTrajectoryStateOnDet seedTSOS;
-	  edm::OwnVector<TrackingRecHit> container;
+          if (useOfflineSeed) {
+            const TrajectorySeed* assoOffseed = associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, newTSOS);
 
-	  if(useOfflineSeed) {
-	    const TrajectorySeed *assoOffseed = 
-	      associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, newTSOS);
-
-	    if(assoOffseed!=nullptr) {
-	      PTrajectoryStateOnDet const & seedTSOS = assoOffseed->startingState();
-	      TrajectorySeed::const_iterator 
-		tsci  = assoOffseed->recHits().first,
-		tscie = assoOffseed->recHits().second;
-	      for(; tsci!=tscie; ++tsci) {
-		container.push_back(*tsci);
-	      }
-	      output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-						     L1MuonParticleRef(muColl,l1ParticleIndex)));
-	    }
-	    else {
-	      if(useUnassociatedL1) {
-		// convert the TSOS into a PTSOD
-		PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( newTSOS,newTSOSDet->geographicalId().rawId());
-		output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-						       L1MuonParticleRef(muColl,l1ParticleIndex)));
-	      }
-	    }
-	  }
-	  else {
-	    // convert the TSOS into a PTSOD
-	    PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( newTSOS,newTSOSDet->geographicalId().rawId());
-	    output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-						   L1MuonParticleRef(muColl,l1ParticleIndex)));
-	  }
-	}
+            if (assoOffseed != nullptr) {
+              PTrajectoryStateOnDet const& seedTSOS = assoOffseed->startingState();
+              TrajectorySeed::const_iterator tsci = assoOffseed->recHits().first, tscie = assoOffseed->recHits().second;
+              for (; tsci != tscie; ++tsci) {
+                container.push_back(*tsci);
+              }
+              output->push_back(
+                  L2MuonTrajectorySeed(seedTSOS, container, alongMomentum, L1MuonParticleRef(muColl, l1ParticleIndex)));
+            } else {
+              if (useUnassociatedL1) {
+                // convert the TSOS into a PTSOD
+                PTrajectoryStateOnDet const& seedTSOS =
+                    trajectoryStateTransform::persistentState(newTSOS, newTSOSDet->geographicalId().rawId());
+                output->push_back(L2MuonTrajectorySeed(
+                    seedTSOS, container, alongMomentum, L1MuonParticleRef(muColl, l1ParticleIndex)));
+              }
+            }
+          } else {
+            // convert the TSOS into a PTSOD
+            PTrajectoryStateOnDet const& seedTSOS =
+                trajectoryStateTransform::persistentState(newTSOS, newTSOSDet->geographicalId().rawId());
+            output->push_back(
+                L2MuonTrajectorySeed(seedTSOS, container, alongMomentum, L1MuonParticleRef(muColl, l1ParticleIndex)));
+          }
+        }
       }
     }
   }
-  
+
   iEvent.put(std::move(output));
 }
 
-
-// FIXME: does not resolve ambiguities yet! 
-const TrajectorySeed* L2MuonSeedGenerator::associateOfflineSeedToL1( edm::Handle<edm::View<TrajectorySeed> > & offseeds, 
-								     std::vector<int> & offseedMap, 
-								     TrajectoryStateOnSurface & newTsos) {
-
+// FIXME: does not resolve ambiguities yet!
+const TrajectorySeed* L2MuonSeedGenerator::associateOfflineSeedToL1(edm::Handle<edm::View<TrajectorySeed> >& offseeds,
+                                                                    std::vector<int>& offseedMap,
+                                                                    TrajectoryStateOnSurface& newTsos) {
   const std::string metlabel = "Muon|RecoMuon|L2MuonSeedGenerator";
   MuonPatternRecoDumper debugtmp;
 
   edm::View<TrajectorySeed>::const_iterator offseed, endOffseed = offseeds->end();
-  const TrajectorySeed *selOffseed = nullptr;
+  const TrajectorySeed* selOffseed = nullptr;
   double bestDr = 99999.;
   unsigned int nOffseed(0);
   int lastOffseed(-1);
 
-  for(offseed=offseeds->begin(); offseed!=endOffseed; ++offseed, ++nOffseed) {
-    if(offseedMap[nOffseed]!=0) continue;
-    GlobalPoint glbPos = theService->trackingGeometry()->idToDet(offseed->startingState().detId())->surface().toGlobal(offseed->startingState().parameters().position());
-    GlobalVector glbMom = theService->trackingGeometry()->idToDet(offseed->startingState().detId())->surface().toGlobal(offseed->startingState().parameters().momentum());
+  for (offseed = offseeds->begin(); offseed != endOffseed; ++offseed, ++nOffseed) {
+    if (offseedMap[nOffseed] != 0)
+      continue;
+    GlobalPoint glbPos = theService->trackingGeometry()
+                             ->idToDet(offseed->startingState().detId())
+                             ->surface()
+                             .toGlobal(offseed->startingState().parameters().position());
+    GlobalVector glbMom = theService->trackingGeometry()
+                              ->idToDet(offseed->startingState().detId())
+                              ->surface()
+                              .toGlobal(offseed->startingState().parameters().momentum());
 
     // Preliminary check
-    double preDr = deltaR( newTsos.globalPosition().eta(), newTsos.globalPosition().phi(), glbPos.eta(), glbPos.phi() );
-    if(preDr > 1.0) continue;
+    double preDr = deltaR(newTsos.globalPosition().eta(), newTsos.globalPosition().phi(), glbPos.eta(), glbPos.phi());
+    if (preDr > 1.0)
+      continue;
 
-    const FreeTrajectoryState offseedFTS(glbPos, glbMom, offseed->startingState().parameters().charge(), &*theService->magneticField()); 
-    TrajectoryStateOnSurface offseedTsos = theService->propagator(thePropagatorName)->propagate(offseedFTS, newTsos.surface());
+    const FreeTrajectoryState offseedFTS(
+        glbPos, glbMom, offseed->startingState().parameters().charge(), &*theService->magneticField());
+    TrajectoryStateOnSurface offseedTsos =
+        theService->propagator(thePropagatorName)->propagate(offseedFTS, newTsos.surface());
     LogDebug(metlabel) << "Offline seed info: Det and State" << std::endl;
     LogDebug(metlabel) << debugtmp.dumpMuonId(offseed->startingState().detId()) << std::endl;
-    //LogDebug(metlabel) << "(x, y, z) = (" << newTSOS.globalPosition().x() << ", " 
+    //LogDebug(metlabel) << "(x, y, z) = (" << newTSOS.globalPosition().x() << ", "
     //	                 << newTSOS.globalPosition().y() << ", " << newTSOS.globalPosition().z() << ")" << std::endl;
-    LogDebug(metlabel) << "pos: (r=" << offseedFTS.position().mag() << ", phi=" 
-		       << offseedFTS.position().phi() << ", eta=" << offseedFTS.position().eta() << ")" << std::endl;
-    LogDebug(metlabel) << "mom: (q*pt=" << offseedFTS.charge()*offseedFTS.momentum().perp() << ", phi=" 
-		       << offseedFTS.momentum().phi() << ", eta=" << offseedFTS.momentum().eta() << ")" << std::endl << std::endl;
+    LogDebug(metlabel) << "pos: (r=" << offseedFTS.position().mag() << ", phi=" << offseedFTS.position().phi()
+                       << ", eta=" << offseedFTS.position().eta() << ")" << std::endl;
+    LogDebug(metlabel) << "mom: (q*pt=" << offseedFTS.charge() * offseedFTS.momentum().perp()
+                       << ", phi=" << offseedFTS.momentum().phi() << ", eta=" << offseedFTS.momentum().eta() << ")"
+                       << std::endl
+                       << std::endl;
     //LogDebug(metlabel) << debugtmp.dumpFTS(offseedFTS) << std::endl;
 
-    if(offseedTsos.isValid()) {
+    if (offseedTsos.isValid()) {
       LogDebug(metlabel) << "Offline seed info after propagation to L1 layer:" << std::endl;
-      //LogDebug(metlabel) << "(x, y, z) = (" << offseedTsos.globalPosition().x() << ", " 
+      //LogDebug(metlabel) << "(x, y, z) = (" << offseedTsos.globalPosition().x() << ", "
       //                   << offseedTsos.globalPosition().y() << ", " << offseedTsos.globalPosition().z() << ")" << std::endl;
-      LogDebug(metlabel) << "pos: (r=" << offseedTsos.globalPosition().mag() << ", phi=" 
-			 << offseedTsos.globalPosition().phi() << ", eta=" << offseedTsos.globalPosition().eta() << ")" << std::endl;
-      LogDebug(metlabel) << "mom: (q*pt=" << offseedTsos.charge()*offseedTsos.globalMomentum().perp() << ", phi=" 
-			 << offseedTsos.globalMomentum().phi() << ", eta=" << offseedTsos.globalMomentum().eta() << ")" << std::endl << std::endl;
+      LogDebug(metlabel) << "pos: (r=" << offseedTsos.globalPosition().mag()
+                         << ", phi=" << offseedTsos.globalPosition().phi()
+                         << ", eta=" << offseedTsos.globalPosition().eta() << ")" << std::endl;
+      LogDebug(metlabel) << "mom: (q*pt=" << offseedTsos.charge() * offseedTsos.globalMomentum().perp()
+                         << ", phi=" << offseedTsos.globalMomentum().phi()
+                         << ", eta=" << offseedTsos.globalMomentum().eta() << ")" << std::endl
+                         << std::endl;
       //LogDebug(metlabel) << debugtmp.dumpTSOS(offseedTsos) << std::endl;
-      double newDr = deltaR( newTsos.globalPosition().eta(),     newTsos.globalPosition().phi(), 
-			     offseedTsos.globalPosition().eta(), offseedTsos.globalPosition().phi() );
+      double newDr = deltaR(newTsos.globalPosition().eta(),
+                            newTsos.globalPosition().phi(),
+                            offseedTsos.globalPosition().eta(),
+                            offseedTsos.globalPosition().phi());
       LogDebug(metlabel) << "   -- DR = " << newDr << std::endl;
-      if( newDr<0.3 && newDr<bestDr ) {
-	LogDebug(metlabel) << "          --> OK! " << newDr << std::endl << std::endl;
-	selOffseed = &*offseed;
-	bestDr = newDr;
-	offseedMap[nOffseed] = 1;
-	if(lastOffseed>-1) offseedMap[lastOffseed] = 0;
-	lastOffseed = nOffseed;
+      if (newDr < 0.3 && newDr < bestDr) {
+        LogDebug(metlabel) << "          --> OK! " << newDr << std::endl << std::endl;
+        selOffseed = &*offseed;
+        bestDr = newDr;
+        offseedMap[nOffseed] = 1;
+        if (lastOffseed > -1)
+          offseedMap[lastOffseed] = 0;
+        lastOffseed = nOffseed;
+      } else {
+        LogDebug(metlabel) << "          --> Rejected. " << newDr << std::endl << std::endl;
       }
-      else {
-	LogDebug(metlabel) << "          --> Rejected. " << newDr << std::endl << std::endl;
-      }
-    }
-    else {
+    } else {
       LogDebug(metlabel) << "Invalid offline seed TSOS after propagation!" << std::endl << std::endl;
     }
   }

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.h
@@ -21,7 +21,7 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-// Data Formats 
+// Data Formats
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h"
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
 #include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
@@ -45,26 +45,27 @@ class MeasurementEstimator;
 class TrajectorySeed;
 class TrajectoryStateOnSurface;
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class L2MuonSeedGenerator : public edm::stream::EDProducer<> {
- 
- public:
-  
+public:
   /// Constructor
-  explicit L2MuonSeedGenerator(const edm::ParameterSet&);
+  explicit L2MuonSeedGenerator(const edm::ParameterSet &);
 
   /// Destructor
   ~L2MuonSeedGenerator() override;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  
- private:
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
+private:
   edm::InputTag theSource;
   edm::InputTag theL1GMTReadoutCollection;
   edm::InputTag theOfflineSeedLabel;
-  std::string   thePropagatorName;
+  std::string thePropagatorName;
 
   edm::EDGetTokenT<L1MuGMTReadoutCollection> gmtToken_;
   edm::EDGetTokenT<l1extra::L1MuonParticleCollection> muCollToken_;
@@ -77,14 +78,13 @@ class L2MuonSeedGenerator : public edm::stream::EDProducer<> {
   const bool useUnassociatedL1;
 
   /// the event setup proxy, it takes care the services update
-  MuonServiceProxy *theService;  
+  MuonServiceProxy *theService;
 
   MeasurementEstimator *theEstimator;
 
-  const TrajectorySeed* associateOfflineSeedToL1( edm::Handle<edm::View<TrajectorySeed> > &, 
-						  std::vector<int> &, 
-						  TrajectoryStateOnSurface &);
-
+  const TrajectorySeed *associateOfflineSeedToL1(edm::Handle<edm::View<TrajectorySeed> > &,
+                                                 std::vector<int> &,
+                                                 TrajectoryStateOnSurface &);
 };
 
 #endif

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.cc
@@ -20,7 +20,6 @@
 // Class Header
 #include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h"
 
-
 // Framework
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -55,156 +54,155 @@ bool sortByL1QandPt(L2MuonTrajectorySeed &A, L2MuonTrajectorySeed &B) {
   l1t::MuonRef Ref_L1B = B.l1tParticle();
 
   // Compare quality first
-  if (Ref_L1A->hwQual() > Ref_L1B->hwQual())  return true;
-  if (Ref_L1A->hwQual() < Ref_L1B->hwQual())  return false;
+  if (Ref_L1A->hwQual() > Ref_L1B->hwQual())
+    return true;
+  if (Ref_L1A->hwQual() < Ref_L1B->hwQual())
+    return false;
 
   // For same quality L1s compare pT
   return (Ref_L1A->pt() > Ref_L1B->pt());
 };
 
 // constructors
-L2MuonSeedGeneratorFromL1T::L2MuonSeedGeneratorFromL1T(const edm::ParameterSet& iConfig) : 
-  theSource(iConfig.getParameter<InputTag>("InputObjects")),
-  theL1GMTReadoutCollection(iConfig.getParameter<InputTag>("GMTReadoutCollection")), // to be removed
-  thePropagatorName(iConfig.getParameter<string>("Propagator")),
-  theL1MinPt(iConfig.getParameter<double>("L1MinPt")),
-  theL1MaxEta(iConfig.getParameter<double>("L1MaxEta")),
-  theL1MinQuality(iConfig.getParameter<unsigned int>("L1MinQuality")),
-  theMinPtBarrel(iConfig.getParameter<double>("SetMinPtBarrelTo")),
-  theMinPtEndcap(iConfig.getParameter<double>("SetMinPtEndcapTo")),
-  useOfflineSeed(iConfig.getUntrackedParameter<bool>("UseOfflineSeed", false)),
-  useUnassociatedL1(iConfig.getParameter<bool>("UseUnassociatedL1")),
-  matchingDR(iConfig.getParameter<std::vector<double> >("MatchDR")),          
-  etaBins(iConfig.getParameter<std::vector<double> >("EtaMatchingBins")),          
-  centralBxOnly_( iConfig.getParameter<bool>("CentralBxOnly") ),
-  matchType( iConfig.getParameter<unsigned int>("MatchType") ),
-  sortType( iConfig.getParameter<unsigned int>("SortType") )
-  {
-
+L2MuonSeedGeneratorFromL1T::L2MuonSeedGeneratorFromL1T(const edm::ParameterSet &iConfig)
+    : theSource(iConfig.getParameter<InputTag>("InputObjects")),
+      theL1GMTReadoutCollection(iConfig.getParameter<InputTag>("GMTReadoutCollection")),  // to be removed
+      thePropagatorName(iConfig.getParameter<string>("Propagator")),
+      theL1MinPt(iConfig.getParameter<double>("L1MinPt")),
+      theL1MaxEta(iConfig.getParameter<double>("L1MaxEta")),
+      theL1MinQuality(iConfig.getParameter<unsigned int>("L1MinQuality")),
+      theMinPtBarrel(iConfig.getParameter<double>("SetMinPtBarrelTo")),
+      theMinPtEndcap(iConfig.getParameter<double>("SetMinPtEndcapTo")),
+      useOfflineSeed(iConfig.getUntrackedParameter<bool>("UseOfflineSeed", false)),
+      useUnassociatedL1(iConfig.getParameter<bool>("UseUnassociatedL1")),
+      matchingDR(iConfig.getParameter<std::vector<double>>("MatchDR")),
+      etaBins(iConfig.getParameter<std::vector<double>>("EtaMatchingBins")),
+      centralBxOnly_(iConfig.getParameter<bool>("CentralBxOnly")),
+      matchType(iConfig.getParameter<unsigned int>("MatchType")),
+      sortType(iConfig.getParameter<unsigned int>("SortType")) {
   muCollToken_ = consumes<MuonBxCollection>(theSource);
 
-  if(useOfflineSeed) {
+  if (useOfflineSeed) {
     theOfflineSeedLabel = iConfig.getUntrackedParameter<InputTag>("OfflineSeedLabel");
-    offlineSeedToken_ = consumes<edm::View<TrajectorySeed> >(theOfflineSeedLabel);
-  
-  // check that number of eta bins -1 matches number of dR cones
-  if( matchingDR.size()!=etaBins.size() - 1  ) {
-    throw cms::Exception("Configuration") << "Size of MatchDR "
-					  << "does not match number of eta bins." << endl;
+    offlineSeedToken_ = consumes<edm::View<TrajectorySeed>>(theOfflineSeedLabel);
+
+    // check that number of eta bins -1 matches number of dR cones
+    if (matchingDR.size() != etaBins.size() - 1) {
+      throw cms::Exception("Configuration") << "Size of MatchDR "
+                                            << "does not match number of eta bins." << endl;
+    }
   }
 
-  
-  }
-  
-  if(matchType>4 || sortType>3) {
+  if (matchType > 4 || sortType > 3) {
     throw cms::Exception("Configuration") << "Wrong MatchType or SortType" << endl;
   }
 
   // service parameters
   ParameterSet serviceParameters = iConfig.getParameter<ParameterSet>("ServiceParameters");
-  
+
   // the services
   theService = new MuonServiceProxy(serviceParameters);
 
   // the estimator
   theEstimator = new Chi2MeasurementEstimator(10000.);
 
-
-  produces<L2MuonTrajectorySeedCollection>(); 
+  produces<L2MuonTrajectorySeedCollection>();
 }
 
 // destructor
-L2MuonSeedGeneratorFromL1T::~L2MuonSeedGeneratorFromL1T(){
-  if (theService)   delete theService;
-  if (theEstimator) delete theEstimator;
+L2MuonSeedGeneratorFromL1T::~L2MuonSeedGeneratorFromL1T() {
+  if (theService)
+    delete theService;
+  if (theEstimator)
+    delete theEstimator;
 }
 
-void
-L2MuonSeedGeneratorFromL1T::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void L2MuonSeedGeneratorFromL1T::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("GMTReadoutCollection", edm::InputTag("")); // to be removed
-  desc.add<edm::InputTag>("InputObjects",edm::InputTag("hltGmtStage2Digis"));
+  desc.add<edm::InputTag>("GMTReadoutCollection", edm::InputTag(""));  // to be removed
+  desc.add<edm::InputTag>("InputObjects", edm::InputTag("hltGmtStage2Digis"));
   desc.add<string>("Propagator", "");
-  desc.add<double>("L1MinPt",-1.);
-  desc.add<double>("L1MaxEta",5.0);
-  desc.add<unsigned int>("L1MinQuality",0);   
-  desc.add<double>("SetMinPtBarrelTo",3.5);
-  desc.add<double>("SetMinPtEndcapTo",1.0);
-  desc.addUntracked<bool>("UseOfflineSeed",false);
+  desc.add<double>("L1MinPt", -1.);
+  desc.add<double>("L1MaxEta", 5.0);
+  desc.add<unsigned int>("L1MinQuality", 0);
+  desc.add<double>("SetMinPtBarrelTo", 3.5);
+  desc.add<double>("SetMinPtEndcapTo", 1.0);
+  desc.addUntracked<bool>("UseOfflineSeed", false);
   desc.add<bool>("UseUnassociatedL1", true);
   desc.add<std::vector<double>>("MatchDR", {0.3});
   desc.add<std::vector<double>>("EtaMatchingBins", {0., 2.5});
   desc.add<bool>("CentralBxOnly", true);
-  desc.add<unsigned int>("MatchType", 0)->setComment("MatchType : 0 Old matching,   1 L1 Order(1to1), 2 Min dR(1to1), 3 Higher Q(1to1), 4 All matched L1");
+  desc.add<unsigned int>("MatchType", 0)
+      ->setComment(
+          "MatchType : 0 Old matching,   1 L1 Order(1to1), 2 Min dR(1to1), 3 Higher Q(1to1), 4 All matched L1");
   desc.add<unsigned int>("SortType", 0)->setComment("SortType :  0 not sort,       1 Pt, 2 Q and Pt");
   desc.addUntracked<edm::InputTag>("OfflineSeedLabel", edm::InputTag(""));
 
   edm::ParameterSetDescription psd0;
-  psd0.addUntracked<std::vector<std::string>>("Propagators", {
-      "SteppingHelixPropagatorAny"
-  });
+  psd0.addUntracked<std::vector<std::string>>("Propagators", {"SteppingHelixPropagatorAny"});
   psd0.add<bool>("RPCLayers", true);
   psd0.addUntracked<bool>("UseMuonNavigation", true);
   desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
-  descriptions.add("L2MuonSeedGeneratorFromL1T",desc);
+  descriptions.add("L2MuonSeedGeneratorFromL1T", desc);
 }
 
-void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void L2MuonSeedGeneratorFromL1T::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   const std::string metname = "Muon|RecoMuon|L2MuonSeedGeneratorFromL1T";
   MuonPatternRecoDumper debug;
 
   auto output = std::make_unique<L2MuonTrajectorySeedCollection>();
-  
+
   edm::Handle<MuonBxCollection> muColl;
   iEvent.getByToken(muCollToken_, muColl);
   LogDebug(metname) << "Number of muons " << muColl->size() << endl;
 
-
   //--- matchType 0 : Old logic
-  if(matchType == 0) {
-
-    edm::Handle<edm::View<TrajectorySeed> > offlineSeedHandle;
+  if (matchType == 0) {
+    edm::Handle<edm::View<TrajectorySeed>> offlineSeedHandle;
     vector<int> offlineSeedMap;
-    if(useOfflineSeed) {
+    if (useOfflineSeed) {
       iEvent.getByToken(offlineSeedToken_, offlineSeedHandle);
       LogDebug(metname) << "Number of offline seeds " << offlineSeedHandle->size() << endl;
       offlineSeedMap = vector<int>(offlineSeedHandle->size(), 0);
     }
 
     for (int ibx = muColl->getFirstBX(); ibx <= muColl->getLastBX(); ++ibx) {
-      if (centralBxOnly_ && (ibx != 0)) continue;
-      for (auto it = muColl->begin(ibx); it != muColl->end(ibx); it++){
-
+      if (centralBxOnly_ && (ibx != 0))
+        continue;
+      for (auto it = muColl->begin(ibx); it != muColl->end(ibx); it++) {
         unsigned int quality = it->hwQual();
         int valid_charge = it->hwChargeValid();
 
-        float pt    =  it->pt();
-        float eta   =  it->eta();
-        float theta =  2*atan(exp(-eta));
-        float phi   =  it->phi();      
-        int charge  =  it->charge();
+        float pt = it->pt();
+        float eta = it->eta();
+        float theta = 2 * atan(exp(-eta));
+        float phi = it->phi();
+        int charge = it->charge();
         // Set charge=0 for the time being if the valid charge bit is zero
-        if (!valid_charge) charge = 0;
+        if (!valid_charge)
+          charge = 0;
 
         // link number indices of the optical fibres that connect the uGMT with the track finders
         //EMTF+ : 36-41, OMTF+ : 42-47, BMTF : 48-59, OMTF- : 60-65, EMTF- : 66-71
-        int link = 36 + (int)(it -> tfMuonIndex() / 3.);
+        int link = 36 + (int)(it->tfMuonIndex() / 3.);
         bool barrel = true;
-        if ( (link >= 36 && link <= 41) || (link >= 66 && link <= 71)) barrel = false;
+        if ((link >= 36 && link <= 41) || (link >= 66 && link <= 71))
+          barrel = false;
 
-        if ( pt < theL1MinPt || fabs(eta) > theL1MaxEta ) continue;
+        if (pt < theL1MinPt || fabs(eta) > theL1MaxEta)
+          continue;
 
-        LogDebug(metname) << "New L2 Muon Seed" ;
-        LogDebug(metname) << "Pt = "         << pt     << " GeV/c";
-        LogDebug(metname) << "eta = "        << eta; 
-        LogDebug(metname) << "theta = "      << theta  << " rad";
-        LogDebug(metname) << "phi = "        << phi    << " rad";
-        LogDebug(metname) << "charge = "     << charge;
+        LogDebug(metname) << "New L2 Muon Seed";
+        LogDebug(metname) << "Pt = " << pt << " GeV/c";
+        LogDebug(metname) << "eta = " << eta;
+        LogDebug(metname) << "theta = " << theta << " rad";
+        LogDebug(metname) << "phi = " << phi << " rad";
+        LogDebug(metname) << "charge = " << charge;
         LogDebug(metname) << "In Barrel? = " << barrel;
 
-        if ( quality <= theL1MinQuality ) continue;
-        LogDebug(metname) << "quality = "<< quality; 
+        if (quality <= theL1MinQuality)
+          continue;
+        LogDebug(metname) << "quality = " << quality;
 
         // Update the services
         theService->update(iSetup);
@@ -212,200 +210,205 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
         const DetLayer *detLayer = nullptr;
         float radius = 0.;
 
-        CLHEP::Hep3Vector vec(0.,1.,0.);
+        CLHEP::Hep3Vector vec(0., 1., 0.);
         vec.setTheta(theta);
         vec.setPhi(phi);
 
-        DetId theid; 
+        DetId theid;
         // Get the det layer on which the state should be put
-        if ( barrel ){
+        if (barrel) {
           LogDebug(metname) << "The seed is in the barrel";
 
           // MB2
-          theid = DTChamberId(0,2,0);
+          theid = DTChamberId(0, 2, 0);
           detLayer = theService->detLayerGeometry()->idToLayer(theid);
           LogDebug(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
 
-          const BoundSurface* sur = &(detLayer->surface());
-          const BoundCylinder* bc = dynamic_cast<const BoundCylinder*>(sur);
+          const BoundSurface *sur = &(detLayer->surface());
+          const BoundCylinder *bc = dynamic_cast<const BoundCylinder *>(sur);
 
-          radius = fabs(bc->radius()/sin(theta));
+          radius = fabs(bc->radius() / sin(theta));
 
-          LogDebug(metname) << "radius "<<radius;
+          LogDebug(metname) << "radius " << radius;
 
-          if ( pt < theMinPtBarrel ) pt = theMinPtBarrel;
-        }
-        else {
+          if (pt < theMinPtBarrel)
+            pt = theMinPtBarrel;
+        } else {
           LogDebug(metname) << "The seed is in the endcap";
 
           // ME2
-          theid = theta < Geom::pi()/2. ? CSCDetId(1,2,0,0,0) : CSCDetId(2,2,0,0,0);
+          theid = theta < Geom::pi() / 2. ? CSCDetId(1, 2, 0, 0, 0) : CSCDetId(2, 2, 0, 0, 0);
 
           detLayer = theService->detLayerGeometry()->idToLayer(theid);
           LogDebug(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
 
-          radius = fabs(detLayer->position().z()/cos(theta));      
+          radius = fabs(detLayer->position().z() / cos(theta));
 
-          if( pt < theMinPtEndcap) pt = theMinPtEndcap;
+          if (pt < theMinPtEndcap)
+            pt = theMinPtEndcap;
         }
 
         vec.setMag(radius);
 
-        GlobalPoint pos(vec.x(),vec.y(),vec.z());
+        GlobalPoint pos(vec.x(), vec.y(), vec.z());
 
-        GlobalVector mom(pt*cos(phi), pt*sin(phi), pt*cos(theta)/sin(theta));
+        GlobalVector mom(pt * cos(phi), pt * sin(phi), pt * cos(theta) / sin(theta));
 
-        GlobalTrajectoryParameters param(pos,mom,charge,&*theService->magneticField());
+        GlobalTrajectoryParameters param(pos, mom, charge, &*theService->magneticField());
         AlgebraicSymMatrix55 mat;
 
-        mat[0][0] = (0.25/pt)*(0.25/pt);  // sigma^2(charge/abs_momentum)
-        if ( !barrel ) mat[0][0] = (0.4/pt)*(0.4/pt);
+        mat[0][0] = (0.25 / pt) * (0.25 / pt);  // sigma^2(charge/abs_momentum)
+        if (!barrel)
+          mat[0][0] = (0.4 / pt) * (0.4 / pt);
 
         //Assign q/pt = 0 +- 1/pt if charge has been declared invalid
-        if (!valid_charge) mat[0][0] = (1./pt)*(1./pt);
+        if (!valid_charge)
+          mat[0][0] = (1. / pt) * (1. / pt);
 
-        mat[1][1] = 0.05*0.05;        // sigma^2(lambda)
-        mat[2][2] = 0.2*0.2;          // sigma^2(phi)
-        mat[3][3] = 20.*20.;          // sigma^2(x_transverse))
-        mat[4][4] = 20.*20.;          // sigma^2(y_transverse))
+        mat[1][1] = 0.05 * 0.05;  // sigma^2(lambda)
+        mat[2][2] = 0.2 * 0.2;    // sigma^2(phi)
+        mat[3][3] = 20. * 20.;    // sigma^2(x_transverse))
+        mat[4][4] = 20. * 20.;    // sigma^2(y_transverse))
 
         CurvilinearTrajectoryError error(mat);
 
-        const FreeTrajectoryState state(param,error);
+        const FreeTrajectoryState state(param, error);
 
         LogDebug(metname) << "Free trajectory State from the parameters";
         LogDebug(metname) << debug.dumpFTS(state);
 
         // Propagate the state on the MB2/ME2 surface
-        TrajectoryStateOnSurface tsos = theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
+        TrajectoryStateOnSurface tsos =
+            theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
 
         LogDebug(metname) << "State after the propagation on the layer";
         LogDebug(metname) << debug.dumpLayer(detLayer);
         LogDebug(metname) << debug.dumpTSOS(tsos);
 
-      double dRcone = matchingDR[0];
-      if ( fabs(eta) < etaBins.back() ){
-      std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(eta));
-      dRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);   
-      }
+        double dRcone = matchingDR[0];
+        if (fabs(eta) < etaBins.back()) {
+          std::vector<double>::iterator lowEdge = std::upper_bound(etaBins.begin(), etaBins.end(), fabs(eta));
+          dRcone = matchingDR.at(lowEdge - etaBins.begin() - 1);
+        }
 
         if (tsos.isValid()) {
-
           edm::OwnVector<TrackingRecHit> container;
 
-          if(useOfflineSeed && ( !valid_charge || charge == 0) ) {
+          if (useOfflineSeed && (!valid_charge || charge == 0)) {
+            const TrajectorySeed *assoOffseed =
+                associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, tsos, dRcone);
 
-            const TrajectorySeed *assoOffseed = 
-              associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, tsos, dRcone );
-
-            if(assoOffseed!=nullptr) {
-              PTrajectoryStateOnDet const & seedTSOS = assoOffseed->startingState();
-              TrajectorySeed::const_iterator 
-              tsci  = assoOffseed->recHits().first,
-              tscie = assoOffseed->recHits().second;
-              for(; tsci!=tscie; ++tsci) {
+            if (assoOffseed != nullptr) {
+              PTrajectoryStateOnDet const &seedTSOS = assoOffseed->startingState();
+              TrajectorySeed::const_iterator tsci = assoOffseed->recHits().first, tscie = assoOffseed->recHits().second;
+              for (; tsci != tscie; ++tsci) {
                 container.push_back(*tsci);
               }
-              output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                                MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
-            }
-            else {
-              if(useUnassociatedL1) {
+              output->push_back(
+                  L2MuonTrajectorySeed(seedTSOS,
+                                       container,
+                                       alongMomentum,
+                                       MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
+            } else {
+              if (useUnassociatedL1) {
                 // convert the TSOS into a PTSOD
-                PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
-                output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                                  MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+                PTrajectoryStateOnDet const &seedTSOS = trajectoryStateTransform::persistentState(tsos, theid.rawId());
+                output->push_back(
+                    L2MuonTrajectorySeed(seedTSOS,
+                                         container,
+                                         alongMomentum,
+                                         MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
               }
             }
-          }
-          else if (useOfflineSeed && valid_charge){
+          } else if (useOfflineSeed && valid_charge) {
             // Get the compatible dets on the layer
-            std::vector< pair<const GeomDet*,TrajectoryStateOnSurface> > 
-              detsWithStates = detLayer->compatibleDets(tsos, 
-                                *theService->propagator(thePropagatorName), 
-                                *theEstimator);   
+            std::vector<pair<const GeomDet *, TrajectoryStateOnSurface>> detsWithStates =
+                detLayer->compatibleDets(tsos, *theService->propagator(thePropagatorName), *theEstimator);
 
-            if (detsWithStates.empty() && barrel ) {
+            if (detsWithStates.empty() && barrel) {
               // Fallback solution using ME2, try again to propagate but using ME2 as reference
               DetId fallback_id;
-              theta < Geom::pi()/2. ? fallback_id = CSCDetId(1,2,0,0,0) : fallback_id = CSCDetId(2,2,0,0,0); 
-              const DetLayer* ME2DetLayer = theService->detLayerGeometry()->idToLayer(fallback_id);
+              theta < Geom::pi() / 2. ? fallback_id = CSCDetId(1, 2, 0, 0, 0) : fallback_id = CSCDetId(2, 2, 0, 0, 0);
+              const DetLayer *ME2DetLayer = theService->detLayerGeometry()->idToLayer(fallback_id);
 
               tsos = theService->propagator(thePropagatorName)->propagate(state, ME2DetLayer->surface());
-              detsWithStates = ME2DetLayer->compatibleDets(tsos, 
-                                             *theService->propagator(thePropagatorName), 
-                                             *theEstimator);   
+              detsWithStates =
+                  ME2DetLayer->compatibleDets(tsos, *theService->propagator(thePropagatorName), *theEstimator);
             }
 
-            if (!detsWithStates.empty()){
-
+            if (!detsWithStates.empty()) {
               TrajectoryStateOnSurface newTSOS = detsWithStates.front().second;
               const GeomDet *newTSOSDet = detsWithStates.front().first;
 
               LogDebug(metname) << "Most compatible det";
               LogDebug(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
 
-              if (newTSOS.isValid()){
-
-                LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag() << ", phi="
-                                  << newTSOS.globalPosition().phi() << ", eta=" << newTSOS.globalPosition().eta() << ")";
-                LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge()*newTSOS.globalMomentum().perp() << ", phi="
-                                  << newTSOS.globalMomentum().phi() << ", eta=" << newTSOS.globalMomentum().eta() << ")";
+              if (newTSOS.isValid()) {
+                LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag()
+                                  << ", phi=" << newTSOS.globalPosition().phi()
+                                  << ", eta=" << newTSOS.globalPosition().eta() << ")";
+                LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge() * newTSOS.globalMomentum().perp()
+                                  << ", phi=" << newTSOS.globalMomentum().phi()
+                                  << ", eta=" << newTSOS.globalMomentum().eta() << ")";
 
                 const TrajectorySeed *assoOffseed =
-                  associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, newTSOS, dRcone);
+                    associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, newTSOS, dRcone);
 
-                if(assoOffseed!=nullptr) {
-                  PTrajectoryStateOnDet const & seedTSOS = assoOffseed->startingState();
-                  TrajectorySeed::const_iterator
-                    tsci  = assoOffseed->recHits().first,
-                    tscie = assoOffseed->recHits().second;
-                  for(; tsci!=tscie; ++tsci) {
+                if (assoOffseed != nullptr) {
+                  PTrajectoryStateOnDet const &seedTSOS = assoOffseed->startingState();
+                  TrajectorySeed::const_iterator tsci = assoOffseed->recHits().first,
+                                                 tscie = assoOffseed->recHits().second;
+                  for (; tsci != tscie; ++tsci) {
                     container.push_back(*tsci);
                   }
-                  output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                                    MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
-                }
-                else {
-                  if(useUnassociatedL1) {
+                  output->push_back(
+                      L2MuonTrajectorySeed(seedTSOS,
+                                           container,
+                                           alongMomentum,
+                                           MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
+                } else {
+                  if (useUnassociatedL1) {
                     // convert the TSOS into a PTSOD
-                    PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( newTSOS,newTSOSDet->geographicalId().rawId());
-                    output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                                      MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+                    PTrajectoryStateOnDet const &seedTSOS =
+                        trajectoryStateTransform::persistentState(newTSOS, newTSOSDet->geographicalId().rawId());
+                    output->push_back(
+                        L2MuonTrajectorySeed(seedTSOS,
+                                             container,
+                                             alongMomentum,
+                                             MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
                   }
-                } 
+                }
               }
-            } 
-          }
-          else {
+            }
+          } else {
             // convert the TSOS into a PTSOD
-            PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
-            output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                              MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
-          }      
-        }  
+            PTrajectoryStateOnDet const &seedTSOS = trajectoryStateTransform::persistentState(tsos, theid.rawId());
+            output->push_back(L2MuonTrajectorySeed(
+                seedTSOS, container, alongMomentum, MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
+          }
+        }
       }
     }
 
-  } // End of matchType 0
+  }  // End of matchType 0
 
   //--- matchType > 0 : Updated logics
-  else if(matchType > 0) {
-
+  else if (matchType > 0) {
     unsigned int nMuColl = muColl->size();
 
-    vector< vector<double> > dRmtx;
-    vector< vector<const TrajectorySeed *> > selOffseeds;
+    vector<vector<double>> dRmtx;
+    vector<vector<const TrajectorySeed *>> selOffseeds;
 
-    edm::Handle<edm::View<TrajectorySeed> > offlineSeedHandle;
-    if(useOfflineSeed) {
+    edm::Handle<edm::View<TrajectorySeed>> offlineSeedHandle;
+    if (useOfflineSeed) {
       iEvent.getByToken(offlineSeedToken_, offlineSeedHandle);
       unsigned int nOfflineSeed = offlineSeedHandle->size();
       LogDebug(metname) << "Number of offline seeds " << nOfflineSeed << endl;
 
       // Initialize dRmtx and selOffseeds
-      dRmtx = vector< vector<double> >(nMuColl, vector<double>(nOfflineSeed, 999.0));
-      selOffseeds = vector< vector <const TrajectorySeed *> >(nMuColl, vector<const TrajectorySeed *>(nOfflineSeed, nullptr));
+      dRmtx = vector<vector<double>>(nMuColl, vector<double>(nOfflineSeed, 999.0));
+      selOffseeds =
+          vector<vector<const TrajectorySeed *>>(nMuColl, vector<const TrajectorySeed *>(nOfflineSeed, nullptr));
     }
 
     // At least one L1 muons are associated with offSeed
@@ -413,41 +416,45 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
 
     //--- Fill dR matrix
     for (int ibx = muColl->getFirstBX(); ibx <= muColl->getLastBX(); ++ibx) {
-      if (centralBxOnly_ && (ibx != 0)) continue;
-      for (auto it = muColl->begin(ibx); it != muColl->end(ibx); it++){
-
+      if (centralBxOnly_ && (ibx != 0))
+        continue;
+      for (auto it = muColl->begin(ibx); it != muColl->end(ibx); it++) {
         //Position of given L1mu
-        unsigned int imu = distance(muColl->begin(muColl->getFirstBX()),it);
+        unsigned int imu = distance(muColl->begin(muColl->getFirstBX()), it);
 
         unsigned int quality = it->hwQual();
         int valid_charge = it->hwChargeValid();
 
-        float pt    =  it->pt();
-        float eta   =  it->eta();
-        float theta =  2*atan(exp(-eta));
-        float phi   =  it->phi();
-        int charge  =  it->charge();
+        float pt = it->pt();
+        float eta = it->eta();
+        float theta = 2 * atan(exp(-eta));
+        float phi = it->phi();
+        int charge = it->charge();
         // Set charge=0 for the time being if the valid charge bit is zero
-        if (!valid_charge) charge = 0;
+        if (!valid_charge)
+          charge = 0;
 
         // link number indices of the optical fibres that connect the uGMT with the track finders
         //EMTF+ : 36-41, OMTF+ : 42-47, BMTF : 48-59, OMTF- : 60-65, EMTF- : 66-71
-        int link = 36 + (int)(it -> tfMuonIndex() / 3.);
+        int link = 36 + (int)(it->tfMuonIndex() / 3.);
         bool barrel = true;
-        if ( (link >= 36 && link <= 41) || (link >= 66 && link <= 71)) barrel = false;
+        if ((link >= 36 && link <= 41) || (link >= 66 && link <= 71))
+          barrel = false;
 
-        if ( pt < theL1MinPt || fabs(eta) > theL1MaxEta ) continue;
+        if (pt < theL1MinPt || fabs(eta) > theL1MaxEta)
+          continue;
 
-        LogDebug(metname) << "New L2 Muon Seed" ;
-        LogDebug(metname) << "Pt = "         << pt     << " GeV/c";
-        LogDebug(metname) << "eta = "        << eta;
-        LogDebug(metname) << "theta = "      << theta  << " rad";
-        LogDebug(metname) << "phi = "        << phi    << " rad";
-        LogDebug(metname) << "charge = "     << charge;
+        LogDebug(metname) << "New L2 Muon Seed";
+        LogDebug(metname) << "Pt = " << pt << " GeV/c";
+        LogDebug(metname) << "eta = " << eta;
+        LogDebug(metname) << "theta = " << theta << " rad";
+        LogDebug(metname) << "phi = " << phi << " rad";
+        LogDebug(metname) << "charge = " << charge;
         LogDebug(metname) << "In Barrel? = " << barrel;
 
-        if ( quality <= theL1MinQuality ) continue;
-        LogDebug(metname) << "quality = "<< quality;
+        if (quality <= theL1MinQuality)
+          continue;
+        LogDebug(metname) << "quality = " << quality;
 
         // Update the services
         theService->update(iSetup);
@@ -455,192 +462,197 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
         const DetLayer *detLayer = nullptr;
         float radius = 0.;
 
-        CLHEP::Hep3Vector vec(0.,1.,0.);
+        CLHEP::Hep3Vector vec(0., 1., 0.);
         vec.setTheta(theta);
         vec.setPhi(phi);
 
         DetId theid;
         // Get the det layer on which the state should be put
-        if ( barrel ){
+        if (barrel) {
           LogDebug(metname) << "The seed is in the barrel";
 
           // MB2
-          theid = DTChamberId(0,2,0);
+          theid = DTChamberId(0, 2, 0);
           detLayer = theService->detLayerGeometry()->idToLayer(theid);
           LogDebug(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
 
-          const BoundSurface* sur = &(detLayer->surface());
-          const BoundCylinder* bc = dynamic_cast<const BoundCylinder*>(sur);
+          const BoundSurface *sur = &(detLayer->surface());
+          const BoundCylinder *bc = dynamic_cast<const BoundCylinder *>(sur);
 
-          radius = fabs(bc->radius()/sin(theta));
+          radius = fabs(bc->radius() / sin(theta));
 
-          LogDebug(metname) << "radius "<<radius;
+          LogDebug(metname) << "radius " << radius;
 
-          if ( pt < theMinPtBarrel ) pt = theMinPtBarrel;
-        }
-        else {
+          if (pt < theMinPtBarrel)
+            pt = theMinPtBarrel;
+        } else {
           LogDebug(metname) << "The seed is in the endcap";
 
           // ME2
-          theid = theta < Geom::pi()/2. ? CSCDetId(1,2,0,0,0) : CSCDetId(2,2,0,0,0);
+          theid = theta < Geom::pi() / 2. ? CSCDetId(1, 2, 0, 0, 0) : CSCDetId(2, 2, 0, 0, 0);
 
           detLayer = theService->detLayerGeometry()->idToLayer(theid);
           LogDebug(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
 
-          radius = fabs(detLayer->position().z()/cos(theta));
+          radius = fabs(detLayer->position().z() / cos(theta));
 
-          if( pt < theMinPtEndcap) pt = theMinPtEndcap;
+          if (pt < theMinPtEndcap)
+            pt = theMinPtEndcap;
         }
 
         vec.setMag(radius);
 
-        GlobalPoint pos(vec.x(),vec.y(),vec.z());
+        GlobalPoint pos(vec.x(), vec.y(), vec.z());
 
-        GlobalVector mom(pt*cos(phi), pt*sin(phi), pt*cos(theta)/sin(theta));
+        GlobalVector mom(pt * cos(phi), pt * sin(phi), pt * cos(theta) / sin(theta));
 
-        GlobalTrajectoryParameters param(pos,mom,charge,&*theService->magneticField());
+        GlobalTrajectoryParameters param(pos, mom, charge, &*theService->magneticField());
         AlgebraicSymMatrix55 mat;
 
-        mat[0][0] = (0.25/pt)*(0.25/pt);  // sigma^2(charge/abs_momentum)
-        if ( !barrel ) mat[0][0] = (0.4/pt)*(0.4/pt);
+        mat[0][0] = (0.25 / pt) * (0.25 / pt);  // sigma^2(charge/abs_momentum)
+        if (!barrel)
+          mat[0][0] = (0.4 / pt) * (0.4 / pt);
 
         //Assign q/pt = 0 +- 1/pt if charge has been declared invalid
-        if (!valid_charge) mat[0][0] = (1./pt)*(1./pt);
+        if (!valid_charge)
+          mat[0][0] = (1. / pt) * (1. / pt);
 
-        mat[1][1] = 0.05*0.05;        // sigma^2(lambda)
-        mat[2][2] = 0.2*0.2;          // sigma^2(phi)
-        mat[3][3] = 20.*20.;          // sigma^2(x_transverse))
-        mat[4][4] = 20.*20.;          // sigma^2(y_transverse))
+        mat[1][1] = 0.05 * 0.05;  // sigma^2(lambda)
+        mat[2][2] = 0.2 * 0.2;    // sigma^2(phi)
+        mat[3][3] = 20. * 20.;    // sigma^2(x_transverse))
+        mat[4][4] = 20. * 20.;    // sigma^2(y_transverse))
 
         CurvilinearTrajectoryError error(mat);
 
-        const FreeTrajectoryState state(param,error);
+        const FreeTrajectoryState state(param, error);
 
         LogDebug(metname) << "Free trajectory State from the parameters";
         LogDebug(metname) << debug.dumpFTS(state);
 
         // Propagate the state on the MB2/ME2 surface
-        TrajectoryStateOnSurface tsos = theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
+        TrajectoryStateOnSurface tsos =
+            theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
 
         LogDebug(metname) << "State after the propagation on the layer";
         LogDebug(metname) << debug.dumpLayer(detLayer);
         LogDebug(metname) << debug.dumpTSOS(tsos);
 
         double dRcone = matchingDR[0];
-        if ( fabs(eta) < etaBins.back() ){
-          std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(eta));
-          dRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+        if (fabs(eta) < etaBins.back()) {
+          std::vector<double>::iterator lowEdge = std::upper_bound(etaBins.begin(), etaBins.end(), fabs(eta));
+          dRcone = matchingDR.at(lowEdge - etaBins.begin() - 1);
         }
 
         if (tsos.isValid()) {
-
           edm::OwnVector<TrackingRecHit> container;
 
-          if(useOfflineSeed) {
+          if (useOfflineSeed) {
+            if ((!valid_charge || charge == 0)) {
+              bool isAssoOffseed = isAssociateOfflineSeedToL1(offlineSeedHandle, dRmtx, tsos, imu, selOffseeds, dRcone);
 
-            if( ( !valid_charge || charge == 0 ) ) {
-
-              bool isAssoOffseed = isAssociateOfflineSeedToL1(offlineSeedHandle, dRmtx, tsos, imu, selOffseeds, dRcone );
-
-              if(isAssoOffseed) {
+              if (isAssoOffseed) {
                 isAsso = true;
               }
 
               // Using old way
               else {
-                if(useUnassociatedL1) {
+                if (useUnassociatedL1) {
                   // convert the TSOS into a PTSOD
-                  PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
-                  output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                                    MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+                  PTrajectoryStateOnDet const &seedTSOS =
+                      trajectoryStateTransform::persistentState(tsos, theid.rawId());
+                  output->push_back(
+                      L2MuonTrajectorySeed(seedTSOS,
+                                           container,
+                                           alongMomentum,
+                                           MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
                 }
               }
 
             }
 
-            else if( valid_charge ) {
-
+            else if (valid_charge) {
               // Get the compatible dets on the layer
-              std::vector< pair<const GeomDet*,TrajectoryStateOnSurface> >
-                detsWithStates = detLayer->compatibleDets(tsos,
-                                  *theService->propagator(thePropagatorName),
-                                  *theEstimator);
+              std::vector<pair<const GeomDet *, TrajectoryStateOnSurface>> detsWithStates =
+                  detLayer->compatibleDets(tsos, *theService->propagator(thePropagatorName), *theEstimator);
 
-              if (detsWithStates.empty() && barrel ) {
+              if (detsWithStates.empty() && barrel) {
                 // Fallback solution using ME2, try again to propagate but using ME2 as reference
                 DetId fallback_id;
-                theta < Geom::pi()/2. ? fallback_id = CSCDetId(1,2,0,0,0) : fallback_id = CSCDetId(2,2,0,0,0); 
-                const DetLayer* ME2DetLayer = theService->detLayerGeometry()->idToLayer(fallback_id);
+                theta < Geom::pi() / 2. ? fallback_id = CSCDetId(1, 2, 0, 0, 0) : fallback_id = CSCDetId(2, 2, 0, 0, 0);
+                const DetLayer *ME2DetLayer = theService->detLayerGeometry()->idToLayer(fallback_id);
 
                 tsos = theService->propagator(thePropagatorName)->propagate(state, ME2DetLayer->surface());
-                detsWithStates = ME2DetLayer->compatibleDets(tsos,
-                                               *theService->propagator(thePropagatorName),
-                                               *theEstimator);
+                detsWithStates =
+                    ME2DetLayer->compatibleDets(tsos, *theService->propagator(thePropagatorName), *theEstimator);
               }
 
-              if (!detsWithStates.empty()){
-
+              if (!detsWithStates.empty()) {
                 TrajectoryStateOnSurface newTSOS = detsWithStates.front().second;
                 const GeomDet *newTSOSDet = detsWithStates.front().first;
 
                 LogDebug(metname) << "Most compatible det";
                 LogDebug(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
 
-                if (newTSOS.isValid()){
+                if (newTSOS.isValid()) {
+                  LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag()
+                                    << ", phi=" << newTSOS.globalPosition().phi()
+                                    << ", eta=" << newTSOS.globalPosition().eta() << ")";
+                  LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge() * newTSOS.globalMomentum().perp()
+                                    << ", phi=" << newTSOS.globalMomentum().phi()
+                                    << ", eta=" << newTSOS.globalMomentum().eta() << ")";
 
-                  LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag() << ", phi="
-                                    << newTSOS.globalPosition().phi() << ", eta=" << newTSOS.globalPosition().eta() << ")";
-                  LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge()*newTSOS.globalMomentum().perp() << ", phi="
-                                    << newTSOS.globalMomentum().phi() << ", eta=" << newTSOS.globalMomentum().eta() << ")";
+                  bool isAssoOffseed =
+                      isAssociateOfflineSeedToL1(offlineSeedHandle, dRmtx, newTSOS, imu, selOffseeds, dRcone);
 
-                  bool isAssoOffseed = isAssociateOfflineSeedToL1(offlineSeedHandle, dRmtx, newTSOS, imu, selOffseeds, dRcone );
-
-                  if(isAssoOffseed) {
+                  if (isAssoOffseed) {
                     isAsso = true;
                   }
 
                   // Using old way
                   else {
-                    if(useUnassociatedL1) {
+                    if (useUnassociatedL1) {
                       // convert the TSOS into a PTSOD
-                      PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( newTSOS,newTSOSDet->geographicalId().rawId());
-                      output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                                        MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+                      PTrajectoryStateOnDet const &seedTSOS =
+                          trajectoryStateTransform::persistentState(newTSOS, newTSOSDet->geographicalId().rawId());
+                      output->push_back(
+                          L2MuonTrajectorySeed(seedTSOS,
+                                               container,
+                                               alongMomentum,
+                                               MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
                     }
                   }
-
                 }
               }
             }
-          } // useOfflineSeed
+          }  // useOfflineSeed
 
           else {
             // convert the TSOS into a PTSOD
-            PTrajectoryStateOnDet const & seedTSOS = trajectoryStateTransform::persistentState( tsos, theid.rawId());
-            output->push_back(L2MuonTrajectorySeed(seedTSOS,container,alongMomentum,
-                              MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+            PTrajectoryStateOnDet const &seedTSOS = trajectoryStateTransform::persistentState(tsos, theid.rawId());
+            output->push_back(L2MuonTrajectorySeed(
+                seedTSOS, container, alongMomentum, MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
           }
-
         }
       }
     }
 
     // MatchType : 0 Old matching,   1 L1 Order(1to1), 2 Min dR(1to1), 3 Higher Q(1to1), 4 All matched L1
-    if(useOfflineSeed && isAsso) {
+    if (useOfflineSeed && isAsso) {
       unsigned int nOfflineSeed1 = offlineSeedHandle->size();
       unsigned int nL1;
-      unsigned int i, j; // for the matrix element
+      unsigned int i, j;  // for the matrix element
 
-      if(matchType==1) {
+      if (matchType == 1) {
         vector<bool> removed_col = vector<bool>(nOfflineSeed1, false);
 
-        for(nL1=0; nL1 < nMuColl; ++nL1) {
+        for (nL1 = 0; nL1 < nMuColl; ++nL1) {
           double tempDR = 99.;
           unsigned int theOffs = 0;
 
-          for(j=0; j<nOfflineSeed1; ++j) {
-            if(removed_col[j]) continue;
-            if( tempDR > dRmtx[nL1][j] ) {
+          for (j = 0; j < nOfflineSeed1; ++j) {
+            if (removed_col[j])
+              continue;
+            if (tempDR > dRmtx[nL1][j]) {
               tempDR = dRmtx[nL1][j];
               theOffs = j;
             }
@@ -649,47 +661,51 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
           auto it = muColl->begin(muColl->getFirstBX()) + nL1;
 
           double newDRcone = matchingDR[0];
-          if ( fabs(it->eta()) < etaBins.back() ){
-            std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(it->eta()));
-            newDRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+          if (fabs(it->eta()) < etaBins.back()) {
+            std::vector<double>::iterator lowEdge = std::upper_bound(etaBins.begin(), etaBins.end(), fabs(it->eta()));
+            newDRcone = matchingDR.at(lowEdge - etaBins.begin() - 1);
           }
 
-          if( !(tempDR < newDRcone) )  continue;
+          if (!(tempDR < newDRcone))
+            continue;
 
           // Remove column for given offSeed
           removed_col[theOffs] = true;
 
-          if( selOffseeds[nL1][theOffs] != nullptr ) {
+          if (selOffseeds[nL1][theOffs] != nullptr) {
             //put given L1mu and offSeed to output
             edm::OwnVector<TrackingRecHit> newContainer;
 
-            PTrajectoryStateOnDet const & seedTSOS = selOffseeds[nL1][theOffs] ->startingState();
-                          TrajectorySeed::const_iterator
-                          tsci  = selOffseeds[nL1][theOffs]->recHits().first,
-                          tscie = selOffseeds[nL1][theOffs]->recHits().second;
-                          for(; tsci!=tscie; ++tsci) {
-                            newContainer.push_back(*tsci);
-                          }
-                          output->push_back(L2MuonTrajectorySeed(seedTSOS,newContainer,alongMomentum,
-                                            MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+            PTrajectoryStateOnDet const &seedTSOS = selOffseeds[nL1][theOffs]->startingState();
+            TrajectorySeed::const_iterator tsci = selOffseeds[nL1][theOffs]->recHits().first,
+                                           tscie = selOffseeds[nL1][theOffs]->recHits().second;
+            for (; tsci != tscie; ++tsci) {
+              newContainer.push_back(*tsci);
+            }
+            output->push_back(L2MuonTrajectorySeed(seedTSOS,
+                                                   newContainer,
+                                                   alongMomentum,
+                                                   MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
           }
         }
       }
 
-      else if(matchType==2) {
+      else if (matchType == 2) {
         vector<bool> removed_row = vector<bool>(nMuColl, false);
         vector<bool> removed_col = vector<bool>(nOfflineSeed1, false);
 
-        for(nL1=0; nL1 < nMuColl; ++nL1) {
+        for (nL1 = 0; nL1 < nMuColl; ++nL1) {
           double tempDR = 99.;
           unsigned int theL1 = 0;
           unsigned int theOffs = 0;
 
-          for(i=0; i<nMuColl; ++i) {
-            if(removed_row[i]) continue;
-            for(j=0; j<nOfflineSeed1; ++j) {
-              if(removed_col[j]) continue;
-              if(tempDR > dRmtx[i][j]) {
+          for (i = 0; i < nMuColl; ++i) {
+            if (removed_row[i])
+              continue;
+            for (j = 0; j < nOfflineSeed1; ++j) {
+              if (removed_col[j])
+                continue;
+              if (tempDR > dRmtx[i][j]) {
                 tempDR = dRmtx[i][j];
                 theL1 = i;
                 theOffs = j;
@@ -700,52 +716,56 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
           auto it = muColl->begin(muColl->getFirstBX()) + theL1;
 
           double newDRcone = matchingDR[0];
-          if ( fabs(it->eta()) < etaBins.back() ){
-            std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(it->eta()));
-            newDRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+          if (fabs(it->eta()) < etaBins.back()) {
+            std::vector<double>::iterator lowEdge = std::upper_bound(etaBins.begin(), etaBins.end(), fabs(it->eta()));
+            newDRcone = matchingDR.at(lowEdge - etaBins.begin() - 1);
           }
 
-          if( !(tempDR < newDRcone) )  continue;
+          if (!(tempDR < newDRcone))
+            continue;
 
           // Remove row and column for given (L1mu, offSeed)
           removed_col[theOffs] = true;
           removed_row[theL1] = true;
 
-          if( selOffseeds[theL1][theOffs] != nullptr ) {
+          if (selOffseeds[theL1][theOffs] != nullptr) {
             //put given L1mu and offSeed to output
             edm::OwnVector<TrackingRecHit> newContainer;
 
-            PTrajectoryStateOnDet const & seedTSOS = selOffseeds[theL1][theOffs] ->startingState();
-                          TrajectorySeed::const_iterator
-                          tsci  = selOffseeds[theL1][theOffs]->recHits().first,
-                          tscie = selOffseeds[theL1][theOffs]->recHits().second;
-                          for(; tsci!=tscie; ++tsci) {
-                            newContainer.push_back(*tsci);
-                          }
-                          output->push_back(L2MuonTrajectorySeed(seedTSOS,newContainer,alongMomentum,
-                                            MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+            PTrajectoryStateOnDet const &seedTSOS = selOffseeds[theL1][theOffs]->startingState();
+            TrajectorySeed::const_iterator tsci = selOffseeds[theL1][theOffs]->recHits().first,
+                                           tscie = selOffseeds[theL1][theOffs]->recHits().second;
+            for (; tsci != tscie; ++tsci) {
+              newContainer.push_back(*tsci);
+            }
+            output->push_back(L2MuonTrajectorySeed(seedTSOS,
+                                                   newContainer,
+                                                   alongMomentum,
+                                                   MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
           }
         }
       }
 
-      else if(matchType==3) {
+      else if (matchType == 3) {
         vector<bool> removed_row = vector<bool>(nMuColl, false);
         vector<bool> removed_col = vector<bool>(nOfflineSeed1, false);
 
-        for(nL1=0; nL1 < nMuColl; ++nL1) {
+        for (nL1 = 0; nL1 < nMuColl; ++nL1) {
           double tempDR = 99.;
           unsigned int theL1 = 0;
           unsigned int theOffs = 0;
           auto theit = muColl->begin(muColl->getFirstBX());
 
           // L1Q > 10 (L1Q = 12)
-          for(i=0; i<nMuColl; ++i) {
-            if(removed_row[i]) continue;
+          for (i = 0; i < nMuColl; ++i) {
+            if (removed_row[i])
+              continue;
             theit = muColl->begin(muColl->getFirstBX()) + i;
             if (theit->hwQual() > 10) {
-              for(j=0; j<nOfflineSeed1; ++j) {
-                if(removed_col[j]) continue;
-                if(tempDR > dRmtx[i][j]) {
+              for (j = 0; j < nOfflineSeed1; ++j) {
+                if (removed_col[j])
+                  continue;
+                if (tempDR > dRmtx[i][j]) {
                   tempDR = dRmtx[i][j];
                   theL1 = i;
                   theOffs = j;
@@ -756,13 +776,15 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
 
           // 6 < L1Q <= 10 (L1Q = 8)
           if (tempDR == 99.) {
-            for(i=0; i<nMuColl; ++i) {
-              if(removed_row[i]) continue;
+            for (i = 0; i < nMuColl; ++i) {
+              if (removed_row[i])
+                continue;
               theit = muColl->begin(muColl->getFirstBX()) + i;
-              if ( (theit->hwQual() <= 10) && (theit->hwQual() > 6) ) {
-                for(j=0; j<nOfflineSeed1; ++j) {
-                  if(removed_col[j]) continue;
-                  if(tempDR > dRmtx[i][j]) {
+              if ((theit->hwQual() <= 10) && (theit->hwQual() > 6)) {
+                for (j = 0; j < nOfflineSeed1; ++j) {
+                  if (removed_col[j])
+                    continue;
+                  if (tempDR > dRmtx[i][j]) {
                     tempDR = dRmtx[i][j];
                     theL1 = i;
                     theOffs = j;
@@ -774,13 +796,15 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
 
           // L1Q <= 6 (L1Q = 4)
           if (tempDR == 99.) {
-            for(i=0; i<nMuColl; ++i) {
-              if(removed_row[i]) continue;
+            for (i = 0; i < nMuColl; ++i) {
+              if (removed_row[i])
+                continue;
               theit = muColl->begin(muColl->getFirstBX()) + i;
               if (theit->hwQual() <= 6) {
-                for(j=0; j<nOfflineSeed1; ++j) {
-                  if(removed_col[j]) continue;
-                  if(tempDR > dRmtx[i][j]) {
+                for (j = 0; j < nOfflineSeed1; ++j) {
+                  if (removed_col[j])
+                    continue;
+                  if (tempDR > dRmtx[i][j]) {
                     tempDR = dRmtx[i][j];
                     theL1 = i;
                     theOffs = j;
@@ -793,100 +817,100 @@ void L2MuonSeedGeneratorFromL1T::produce(edm::Event& iEvent, const edm::EventSet
           auto it = muColl->begin(muColl->getFirstBX()) + theL1;
 
           double newDRcone = matchingDR[0];
-          if ( fabs(it->eta()) < etaBins.back() ){
-            std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(it->eta()));
-            newDRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+          if (fabs(it->eta()) < etaBins.back()) {
+            std::vector<double>::iterator lowEdge = std::upper_bound(etaBins.begin(), etaBins.end(), fabs(it->eta()));
+            newDRcone = matchingDR.at(lowEdge - etaBins.begin() - 1);
           }
 
-          if( !(tempDR < newDRcone) )  continue;
+          if (!(tempDR < newDRcone))
+            continue;
 
           // Remove row and column for given (L1mu, offSeed)
           removed_col[theOffs] = true;
           removed_row[theL1] = true;
 
-          if( selOffseeds[theL1][theOffs] != nullptr ) {
+          if (selOffseeds[theL1][theOffs] != nullptr) {
             //put given L1mu and offSeed to output
             edm::OwnVector<TrackingRecHit> newContainer;
 
-            PTrajectoryStateOnDet const & seedTSOS = selOffseeds[theL1][theOffs] ->startingState();
-                          TrajectorySeed::const_iterator
-                          tsci  = selOffseeds[theL1][theOffs]->recHits().first,
-                          tscie = selOffseeds[theL1][theOffs]->recHits().second;
-                          for(; tsci!=tscie; ++tsci) {
-                            newContainer.push_back(*tsci);
-                          }
-                          output->push_back(L2MuonTrajectorySeed(seedTSOS,newContainer,alongMomentum,
-                                            MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+            PTrajectoryStateOnDet const &seedTSOS = selOffseeds[theL1][theOffs]->startingState();
+            TrajectorySeed::const_iterator tsci = selOffseeds[theL1][theOffs]->recHits().first,
+                                           tscie = selOffseeds[theL1][theOffs]->recHits().second;
+            for (; tsci != tscie; ++tsci) {
+              newContainer.push_back(*tsci);
+            }
+            output->push_back(L2MuonTrajectorySeed(seedTSOS,
+                                                   newContainer,
+                                                   alongMomentum,
+                                                   MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
           }
         }
       }
 
-      else if(matchType==4) {
-
-        for(i=0; i<nMuColl; ++i) {
-
+      else if (matchType == 4) {
+        for (i = 0; i < nMuColl; ++i) {
           auto it = muColl->begin(muColl->getFirstBX()) + i;
 
           double tempDR = 99.;
           unsigned int theOffs = 0;
 
           double newDRcone = matchingDR[0];
-          if ( fabs(it->eta()) < etaBins.back() ){
-            std::vector<double>::iterator lowEdge = std::upper_bound (etaBins.begin(), etaBins.end(), fabs(it->eta()));
-            newDRcone    =  matchingDR.at( lowEdge - etaBins.begin() - 1);
+          if (fabs(it->eta()) < etaBins.back()) {
+            std::vector<double>::iterator lowEdge = std::upper_bound(etaBins.begin(), etaBins.end(), fabs(it->eta()));
+            newDRcone = matchingDR.at(lowEdge - etaBins.begin() - 1);
           }
 
-          for(j=0; j<nOfflineSeed1; ++j) {
-            if( tempDR > dRmtx[i][j] ) {
+          for (j = 0; j < nOfflineSeed1; ++j) {
+            if (tempDR > dRmtx[i][j]) {
               tempDR = dRmtx[i][j];
               theOffs = j;
             }
           }
 
-          if( !(tempDR < newDRcone) )  continue;
+          if (!(tempDR < newDRcone))
+            continue;
 
-          if( selOffseeds[i][theOffs] != nullptr ) {
+          if (selOffseeds[i][theOffs] != nullptr) {
             //put given L1mu and offSeed to output
             edm::OwnVector<TrackingRecHit> newContainer;
 
-            PTrajectoryStateOnDet const & seedTSOS = selOffseeds[i][theOffs] ->startingState();
-                          TrajectorySeed::const_iterator
-                          tsci  = selOffseeds[i][theOffs]->recHits().first,
-                          tscie = selOffseeds[i][theOffs]->recHits().second;
-                          for(; tsci!=tscie; ++tsci) {
-                            newContainer.push_back(*tsci);
-                          }
-                          output->push_back(L2MuonTrajectorySeed(seedTSOS,newContainer,alongMomentum,
-                                            MuonRef(muColl,  distance(muColl->begin(muColl->getFirstBX()),it)  )));
+            PTrajectoryStateOnDet const &seedTSOS = selOffseeds[i][theOffs]->startingState();
+            TrajectorySeed::const_iterator tsci = selOffseeds[i][theOffs]->recHits().first,
+                                           tscie = selOffseeds[i][theOffs]->recHits().second;
+            for (; tsci != tscie; ++tsci) {
+              newContainer.push_back(*tsci);
+            }
+            output->push_back(L2MuonTrajectorySeed(seedTSOS,
+                                                   newContainer,
+                                                   alongMomentum,
+                                                   MuonRef(muColl, distance(muColl->begin(muColl->getFirstBX()), it))));
           }
         }
       }
 
-    } // useOfflineSeed && isAsso
+    }  // useOfflineSeed && isAsso
 
-  } // matchType > 0
+  }  // matchType > 0
 
   //--- SortType 1 : by L1 pT
-  if(sortType == 1) {
-    sort(output->begin(),output->end(),sortByL1Pt);
+  if (sortType == 1) {
+    sort(output->begin(), output->end(), sortByL1Pt);
   }
 
   //--- SortType 2 : by L1 quality and pT
-  else if(sortType == 2) {
-    sort(output->begin(),output->end(),sortByL1QandPt);
+  else if (sortType == 2) {
+    sort(output->begin(), output->end(), sortByL1QandPt);
   }
-
 
   iEvent.put(std::move(output));
 }
 
-
-// FIXME: does not resolve ambiguities yet! 
-const TrajectorySeed* L2MuonSeedGeneratorFromL1T::associateOfflineSeedToL1( edm::Handle<edm::View<TrajectorySeed> > & offseeds, 
-                                     std::vector<int> & offseedMap, 
-                                     TrajectoryStateOnSurface & newTsos,
-                                     double dRcone ) {
-
+// FIXME: does not resolve ambiguities yet!
+const TrajectorySeed *L2MuonSeedGeneratorFromL1T::associateOfflineSeedToL1(
+    edm::Handle<edm::View<TrajectorySeed>> &offseeds,
+    std::vector<int> &offseedMap,
+    TrajectoryStateOnSurface &newTsos,
+    double dRcone) {
   const std::string metlabel = "Muon|RecoMuon|L2MuonSeedGeneratorFromL1T";
   MuonPatternRecoDumper debugtmp;
 
@@ -896,46 +920,62 @@ const TrajectorySeed* L2MuonSeedGeneratorFromL1T::associateOfflineSeedToL1( edm:
   unsigned int nOffseed(0);
   int lastOffseed(-1);
 
-  for(offseed=offseeds->begin(); offseed!=endOffseed; ++offseed, ++nOffseed) {
-    if(offseedMap[nOffseed]!=0) continue;
-    GlobalPoint  glbPos = theService->trackingGeometry()->idToDet(offseed->startingState().detId())->surface().toGlobal(offseed->startingState().parameters().position());
-    GlobalVector glbMom = theService->trackingGeometry()->idToDet(offseed->startingState().detId())->surface().toGlobal(offseed->startingState().parameters().momentum());
+  for (offseed = offseeds->begin(); offseed != endOffseed; ++offseed, ++nOffseed) {
+    if (offseedMap[nOffseed] != 0)
+      continue;
+    GlobalPoint glbPos = theService->trackingGeometry()
+                             ->idToDet(offseed->startingState().detId())
+                             ->surface()
+                             .toGlobal(offseed->startingState().parameters().position());
+    GlobalVector glbMom = theService->trackingGeometry()
+                              ->idToDet(offseed->startingState().detId())
+                              ->surface()
+                              .toGlobal(offseed->startingState().parameters().momentum());
 
     // Preliminary check
-    double preDr = deltaR( newTsos.globalPosition().eta(), newTsos.globalPosition().phi(), glbPos.eta(), glbPos.phi() );
-    if(preDr > 1.0) continue;
+    double preDr = deltaR(newTsos.globalPosition().eta(), newTsos.globalPosition().phi(), glbPos.eta(), glbPos.phi());
+    if (preDr > 1.0)
+      continue;
 
-    const FreeTrajectoryState offseedFTS(glbPos, glbMom, offseed->startingState().parameters().charge(), &*theService->magneticField()); 
-    TrajectoryStateOnSurface offseedTsos = theService->propagator(thePropagatorName)->propagate(offseedFTS, newTsos.surface());
+    const FreeTrajectoryState offseedFTS(
+        glbPos, glbMom, offseed->startingState().parameters().charge(), &*theService->magneticField());
+    TrajectoryStateOnSurface offseedTsos =
+        theService->propagator(thePropagatorName)->propagate(offseedFTS, newTsos.surface());
     LogDebug(metlabel) << "Offline seed info: Det and State" << std::endl;
     LogDebug(metlabel) << debugtmp.dumpMuonId(offseed->startingState().detId()) << std::endl;
-    LogDebug(metlabel) << "pos: (r=" << offseedFTS.position().mag() << ", phi=" 
-               << offseedFTS.position().phi() << ", eta=" << offseedFTS.position().eta() << ")" << std::endl;
-    LogDebug(metlabel) << "mom: (q*pt=" << offseedFTS.charge()*offseedFTS.momentum().perp() << ", phi=" 
-               << offseedFTS.momentum().phi() << ", eta=" << offseedFTS.momentum().eta() << ")" << std::endl << std::endl;
+    LogDebug(metlabel) << "pos: (r=" << offseedFTS.position().mag() << ", phi=" << offseedFTS.position().phi()
+                       << ", eta=" << offseedFTS.position().eta() << ")" << std::endl;
+    LogDebug(metlabel) << "mom: (q*pt=" << offseedFTS.charge() * offseedFTS.momentum().perp()
+                       << ", phi=" << offseedFTS.momentum().phi() << ", eta=" << offseedFTS.momentum().eta() << ")"
+                       << std::endl
+                       << std::endl;
 
-    if(offseedTsos.isValid()) {
+    if (offseedTsos.isValid()) {
       LogDebug(metlabel) << "Offline seed info after propagation to L1 layer:" << std::endl;
-      LogDebug(metlabel) << "pos: (r=" << offseedTsos.globalPosition().mag() << ", phi=" 
-             << offseedTsos.globalPosition().phi() << ", eta=" << offseedTsos.globalPosition().eta() << ")" << std::endl;
-      LogDebug(metlabel) << "mom: (q*pt=" << offseedTsos.charge()*offseedTsos.globalMomentum().perp() << ", phi=" 
-             << offseedTsos.globalMomentum().phi() << ", eta=" << offseedTsos.globalMomentum().eta() << ")" << std::endl << std::endl;
-      double newDr = deltaR( newTsos.globalPosition().eta(),     newTsos.globalPosition().phi(), 
-                 offseedTsos.globalPosition().eta(), offseedTsos.globalPosition().phi() );
+      LogDebug(metlabel) << "pos: (r=" << offseedTsos.globalPosition().mag()
+                         << ", phi=" << offseedTsos.globalPosition().phi()
+                         << ", eta=" << offseedTsos.globalPosition().eta() << ")" << std::endl;
+      LogDebug(metlabel) << "mom: (q*pt=" << offseedTsos.charge() * offseedTsos.globalMomentum().perp()
+                         << ", phi=" << offseedTsos.globalMomentum().phi()
+                         << ", eta=" << offseedTsos.globalMomentum().eta() << ")" << std::endl
+                         << std::endl;
+      double newDr = deltaR(newTsos.globalPosition().eta(),
+                            newTsos.globalPosition().phi(),
+                            offseedTsos.globalPosition().eta(),
+                            offseedTsos.globalPosition().phi());
       LogDebug(metlabel) << "   -- DR = " << newDr << std::endl;
-      if( newDr < dRcone && newDr<bestDr ) {  
+      if (newDr < dRcone && newDr < bestDr) {
         LogDebug(metlabel) << "          --> OK! " << newDr << std::endl << std::endl;
         selOffseed = &*offseed;
         bestDr = newDr;
         offseedMap[nOffseed] = 1;
-        if(lastOffseed>-1) offseedMap[lastOffseed] = 0;
+        if (lastOffseed > -1)
+          offseedMap[lastOffseed] = 0;
         lastOffseed = nOffseed;
-      }
-      else {
+      } else {
         LogDebug(metlabel) << "          --> Rejected. " << newDr << std::endl << std::endl;
       }
-    }
-    else {
+    } else {
       LogDebug(metlabel) << "Invalid offline seed TSOS after propagation!" << std::endl << std::endl;
     }
   }
@@ -943,14 +983,13 @@ const TrajectorySeed* L2MuonSeedGeneratorFromL1T::associateOfflineSeedToL1( edm:
   return selOffseed;
 }
 
-
-bool L2MuonSeedGeneratorFromL1T::isAssociateOfflineSeedToL1( edm::Handle<edm::View<TrajectorySeed> > & offseeds,
-                                     std::vector< std::vector<double> > & dRmtx,
-                                     TrajectoryStateOnSurface & newTsos,
-                                     unsigned int imu,
-                                     std::vector< std::vector<const TrajectorySeed *> > & selOffseeds,
-                                     double dRcone ) {
-
+bool L2MuonSeedGeneratorFromL1T::isAssociateOfflineSeedToL1(
+    edm::Handle<edm::View<TrajectorySeed>> &offseeds,
+    std::vector<std::vector<double>> &dRmtx,
+    TrajectoryStateOnSurface &newTsos,
+    unsigned int imu,
+    std::vector<std::vector<const TrajectorySeed *>> &selOffseeds,
+    double dRcone) {
   const std::string metlabel = "Muon|RecoMuon|L2MuonSeedGeneratorFromL1T";
   bool isAssociated = false;
   MuonPatternRecoDumper debugtmp;
@@ -958,51 +997,60 @@ bool L2MuonSeedGeneratorFromL1T::isAssociateOfflineSeedToL1( edm::Handle<edm::Vi
   edm::View<TrajectorySeed>::const_iterator offseed, endOffseed = offseeds->end();
   unsigned int nOffseed(0);
 
-  for(offseed=offseeds->begin(); offseed!=endOffseed; ++offseed, ++nOffseed) {
-    GlobalPoint  glbPos = theService->trackingGeometry()->idToDet(offseed->startingState().detId())->surface().toGlobal(offseed->startingState().parameters().position());
-    GlobalVector glbMom = theService->trackingGeometry()->idToDet(offseed->startingState().detId())->surface().toGlobal(offseed->startingState().parameters().momentum());
+  for (offseed = offseeds->begin(); offseed != endOffseed; ++offseed, ++nOffseed) {
+    GlobalPoint glbPos = theService->trackingGeometry()
+                             ->idToDet(offseed->startingState().detId())
+                             ->surface()
+                             .toGlobal(offseed->startingState().parameters().position());
+    GlobalVector glbMom = theService->trackingGeometry()
+                              ->idToDet(offseed->startingState().detId())
+                              ->surface()
+                              .toGlobal(offseed->startingState().parameters().momentum());
 
     // Preliminary check
-    double preDr = deltaR( newTsos.globalPosition().eta(), newTsos.globalPosition().phi(), glbPos.eta(), glbPos.phi() );
-    if(preDr > 1.0) continue;
+    double preDr = deltaR(newTsos.globalPosition().eta(), newTsos.globalPosition().phi(), glbPos.eta(), glbPos.phi());
+    if (preDr > 1.0)
+      continue;
 
-    const FreeTrajectoryState offseedFTS(glbPos, glbMom, offseed->startingState().parameters().charge(), &*theService->magneticField());
-    TrajectoryStateOnSurface offseedTsos = theService->propagator(thePropagatorName)->propagate(offseedFTS, newTsos.surface());
+    const FreeTrajectoryState offseedFTS(
+        glbPos, glbMom, offseed->startingState().parameters().charge(), &*theService->magneticField());
+    TrajectoryStateOnSurface offseedTsos =
+        theService->propagator(thePropagatorName)->propagate(offseedFTS, newTsos.surface());
     LogDebug(metlabel) << "Offline seed info: Det and State" << std::endl;
     LogDebug(metlabel) << debugtmp.dumpMuonId(offseed->startingState().detId()) << std::endl;
-    LogDebug(metlabel) << "pos: (r=" << offseedFTS.position().mag() <<
-                              ", phi=" << offseedFTS.position().phi() <<
-                              ", eta=" << offseedFTS.position().eta() << ")" << std::endl;
-    LogDebug(metlabel) << "mom: (q*pt=" << offseedFTS.charge()*offseedFTS.momentum().perp() <<
-                              ", phi=" << offseedFTS.momentum().phi() <<
-                              ", eta=" << offseedFTS.momentum().eta() << ")" << std::endl << std::endl;
+    LogDebug(metlabel) << "pos: (r=" << offseedFTS.position().mag() << ", phi=" << offseedFTS.position().phi()
+                       << ", eta=" << offseedFTS.position().eta() << ")" << std::endl;
+    LogDebug(metlabel) << "mom: (q*pt=" << offseedFTS.charge() * offseedFTS.momentum().perp()
+                       << ", phi=" << offseedFTS.momentum().phi() << ", eta=" << offseedFTS.momentum().eta() << ")"
+                       << std::endl
+                       << std::endl;
 
-    if(offseedTsos.isValid()) {
+    if (offseedTsos.isValid()) {
       LogDebug(metlabel) << "Offline seed info after propagation to L1 layer:" << std::endl;
-      LogDebug(metlabel) << "pos: (r=" << offseedTsos.globalPosition().mag() <<
-                                ", phi=" << offseedTsos.globalPosition().phi() <<
-                                ", eta=" << offseedTsos.globalPosition().eta() << ")" << std::endl;
-      LogDebug(metlabel) << "mom: (q*pt=" << offseedTsos.charge()*offseedTsos.globalMomentum().perp() <<
-                                ", phi=" << offseedTsos.globalMomentum().phi() <<
-                                ", eta=" << offseedTsos.globalMomentum().eta() << ")" << std::endl << std::endl;
-      double newDr = deltaR( newTsos.globalPosition().eta(),     newTsos.globalPosition().phi(),
-                             offseedTsos.globalPosition().eta(), offseedTsos.globalPosition().phi() );
-
+      LogDebug(metlabel) << "pos: (r=" << offseedTsos.globalPosition().mag()
+                         << ", phi=" << offseedTsos.globalPosition().phi()
+                         << ", eta=" << offseedTsos.globalPosition().eta() << ")" << std::endl;
+      LogDebug(metlabel) << "mom: (q*pt=" << offseedTsos.charge() * offseedTsos.globalMomentum().perp()
+                         << ", phi=" << offseedTsos.globalMomentum().phi()
+                         << ", eta=" << offseedTsos.globalMomentum().eta() << ")" << std::endl
+                         << std::endl;
+      double newDr = deltaR(newTsos.globalPosition().eta(),
+                            newTsos.globalPosition().phi(),
+                            offseedTsos.globalPosition().eta(),
+                            offseedTsos.globalPosition().phi());
 
       LogDebug(metlabel) << "   -- DR = " << newDr << std::endl;
-      if( newDr < dRcone ) {
+      if (newDr < dRcone) {
         LogDebug(metlabel) << "          --> OK! " << newDr << std::endl << std::endl;
 
         dRmtx[imu][nOffseed] = newDr;
         selOffseeds[imu][nOffseed] = &*offseed;
 
         isAssociated = true;
-      }
-      else {
+      } else {
         LogDebug(metlabel) << "          --> Rejected. " << newDr << std::endl << std::endl;
       }
-    }
-    else {
+    } else {
       LogDebug(metlabel) << "Invalid offline seed TSOS after propagation!" << std::endl << std::endl;
     }
   }

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h
@@ -23,7 +23,7 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-// Data Formats 
+// Data Formats
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h"
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
 #include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
@@ -43,27 +43,28 @@ class MeasurementEstimator;
 class TrajectorySeed;
 class TrajectoryStateOnSurface;
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class L2MuonSeedGeneratorFromL1T : public edm::stream::EDProducer<> {
- 
- public:
-  
+public:
   /// Constructor
-  explicit L2MuonSeedGeneratorFromL1T(const edm::ParameterSet&);
+  explicit L2MuonSeedGeneratorFromL1T(const edm::ParameterSet &);
 
   /// Destructor
   ~L2MuonSeedGeneratorFromL1T() override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  
- private:
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
+private:
   edm::InputTag theSource;
   edm::InputTag theL1GMTReadoutCollection;
   edm::InputTag theOfflineSeedLabel;
-  std::string   thePropagatorName;
+  std::string thePropagatorName;
 
   edm::EDGetTokenT<l1t::MuonBxCollection> muCollToken_;
   edm::EDGetTokenT<edm::View<TrajectorySeed> > offlineSeedToken_;
@@ -84,22 +85,21 @@ class L2MuonSeedGeneratorFromL1T : public edm::stream::EDProducer<> {
   const unsigned sortType;
 
   /// the event setup proxy, it takes care the services update
-  MuonServiceProxy *theService;  
+  MuonServiceProxy *theService;
 
   MeasurementEstimator *theEstimator;
 
-  const TrajectorySeed* associateOfflineSeedToL1( edm::Handle<edm::View<TrajectorySeed> > &, 
-						  std::vector<int> &, 
-						  TrajectoryStateOnSurface &,
-						  double );
+  const TrajectorySeed *associateOfflineSeedToL1(edm::Handle<edm::View<TrajectorySeed> > &,
+                                                 std::vector<int> &,
+                                                 TrajectoryStateOnSurface &,
+                                                 double);
 
-  bool isAssociateOfflineSeedToL1( edm::Handle<edm::View<TrajectorySeed> > &,
-              std::vector< std::vector<double> > &,
-              TrajectoryStateOnSurface &,
-              unsigned int,
-              std::vector< std::vector<const TrajectorySeed *> > &,
-              double );
-
+  bool isAssociateOfflineSeedToL1(edm::Handle<edm::View<TrajectorySeed> > &,
+                                  std::vector<std::vector<double> > &,
+                                  TrajectoryStateOnSurface &,
+                                  unsigned int,
+                                  std::vector<std::vector<const TrajectorySeed *> > &,
+                                  double);
 };
 
 #endif

--- a/RecoMuon/L2MuonSeedGenerator/src/SealModule.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/SealModule.cc
@@ -5,6 +5,5 @@
 #include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.h"
 #include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h"
 
-
 DEFINE_FWK_MODULE(L2MuonSeedGenerator);
 DEFINE_FWK_MODULE(L2MuonSeedGeneratorFromL1T);

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.cc
@@ -35,44 +35,43 @@ using namespace reco;
 using namespace muonisolation;
 
 /// constructor with config
-L3MuonCombinedRelativeIsolationProducer::L3MuonCombinedRelativeIsolationProducer(const ParameterSet& par) :
-  theConfig(par),
-  theMuonCollectionLabel(par.getParameter<InputTag>("inputMuonCollection")),
-  optOutputIsoDeposits(par.getParameter<bool>("OutputMuIsoDeposits")),
-  useCaloIso(par.existsAs<bool>("UseCaloIso") ?
-	     par.getParameter<bool>("UseCaloIso") : true),
-  useRhoCorrectedCaloDeps(par.existsAs<bool>("UseRhoCorrectedCaloDeposits") ?
-			  par.getParameter<bool>("UseRhoCorrectedCaloDeposits") : false),
-  theCaloDepsLabel(par.existsAs<InputTag>("CaloDepositsLabel") ?
-                   par.getParameter<InputTag>("CaloDepositsLabel") :
-                   InputTag("hltL3CaloMuonCorrectedIsolations")),
-  theTrackPt_Min(-1),
-  printDebug (par.getParameter<bool>("printDebug"))
-  {
-  LogDebug("RecoMuon|L3MuonCombinedRelativeIsolationProducer")<<" L3MuonCombinedRelativeIsolationProducer CTOR";
+L3MuonCombinedRelativeIsolationProducer::L3MuonCombinedRelativeIsolationProducer(const ParameterSet& par)
+    : theConfig(par),
+      theMuonCollectionLabel(par.getParameter<InputTag>("inputMuonCollection")),
+      optOutputIsoDeposits(par.getParameter<bool>("OutputMuIsoDeposits")),
+      useCaloIso(par.existsAs<bool>("UseCaloIso") ? par.getParameter<bool>("UseCaloIso") : true),
+      useRhoCorrectedCaloDeps(par.existsAs<bool>("UseRhoCorrectedCaloDeposits")
+                                  ? par.getParameter<bool>("UseRhoCorrectedCaloDeposits")
+                                  : false),
+      theCaloDepsLabel(par.existsAs<InputTag>("CaloDepositsLabel") ? par.getParameter<InputTag>("CaloDepositsLabel")
+                                                                   : InputTag("hltL3CaloMuonCorrectedIsolations")),
+      theTrackPt_Min(-1),
+      printDebug(par.getParameter<bool>("printDebug")) {
+  LogDebug("RecoMuon|L3MuonCombinedRelativeIsolationProducer") << " L3MuonCombinedRelativeIsolationProducer CTOR";
 
   theMuonCollectionToken = consumes<RecoChargedCandidateCollection>(theMuonCollectionLabel);
-  theCaloDepsToken = consumes<edm::ValueMap<float> >(theCaloDepsLabel);
+  theCaloDepsToken = consumes<edm::ValueMap<float>>(theCaloDepsLabel);
 
   if (optOutputIsoDeposits) {
     produces<reco::IsoDepositMap>("trkIsoDeposits");
-    if( useRhoCorrectedCaloDeps==false ) // otherwise, calo deposits have been previously computed
+    if (useRhoCorrectedCaloDeps == false)  // otherwise, calo deposits have been previously computed
       produces<reco::IsoDepositMap>("caloIsoDeposits");
     //produces<std::vector<double> >("combinedRelativeIsoDeposits");
-    produces<edm::ValueMap<double> >("combinedRelativeIsoDeposits");
+    produces<edm::ValueMap<double>>("combinedRelativeIsoDeposits");
   }
-  produces<edm::ValueMap<bool> >();
+  produces<edm::ValueMap<bool>>();
 
   //
   // Extractor
   //
   // Calorimeters (ONLY if not previously computed)
   //
-  if( useCaloIso && (useRhoCorrectedCaloDeps==false) ) {
+  if (useCaloIso && (useRhoCorrectedCaloDeps == false)) {
     edm::ParameterSet caloExtractorPSet = theConfig.getParameter<edm::ParameterSet>("CaloExtractorPSet");
 
     std::string caloExtractorName = caloExtractorPSet.getParameter<std::string>("ComponentName");
-    caloExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( caloExtractorName, caloExtractorPSet, consumesCollector())};
+    caloExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{
+        IsoDepositExtractorFactory::get()->create(caloExtractorName, caloExtractorPSet, consumesCollector())};
     //std::string caloDepositType = caloExtractorPSet.getUntrackedParameter<std::string>("DepositLabel"); // N.B. Not used in the following!
   }
 
@@ -82,7 +81,8 @@ L3MuonCombinedRelativeIsolationProducer::L3MuonCombinedRelativeIsolationProducer
 
   theTrackPt_Min = theConfig.getParameter<double>("TrackPt_Min");
   std::string trkExtractorName = trkExtractorPSet.getParameter<std::string>("ComponentName");
-  trkExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( trkExtractorName, trkExtractorPSet, consumesCollector())};
+  trkExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{
+      IsoDepositExtractorFactory::get()->create(trkExtractorName, trkExtractorPSet, consumesCollector())};
   //std::string trkDepositType = trkExtractorPSet.getUntrackedParameter<std::string>("DepositLabel"); // N.B. Not used in the following!
 
   //
@@ -92,109 +92,106 @@ L3MuonCombinedRelativeIsolationProducer::L3MuonCombinedRelativeIsolationProducer
   std::string cutsName = cutsPSet.getParameter<std::string>("ComponentName");
   if (cutsName == "SimpleCuts") {
     theCuts = Cuts(cutsPSet);
-  }
-  else if (
-	   //        (cutsName== "L3NominalEfficiencyCuts_PXLS" && depositType=="PXLS")
-	   //     || (cutsName== "L3NominalEfficiencyCuts_TRKS" && depositType=="TRKS")
-	   //! test cutsName only. The depositType is informational only (has not been used so far) [VK]
-	   (cutsName== "L3NominalEfficiencyCuts_PXLS" )
-	   || (cutsName== "L3NominalEfficiencyCuts_TRKS") ) {
+  } else if (
+      //        (cutsName== "L3NominalEfficiencyCuts_PXLS" && depositType=="PXLS")
+      //     || (cutsName== "L3NominalEfficiencyCuts_TRKS" && depositType=="TRKS")
+      //! test cutsName only. The depositType is informational only (has not been used so far) [VK]
+      (cutsName == "L3NominalEfficiencyCuts_PXLS") || (cutsName == "L3NominalEfficiencyCuts_TRKS")) {
     theCuts = L3NominalEfficiencyConfigurator(cutsPSet).cuts();
+  } else {
+    LogError("L3MuonCombinedRelativeIsolationProducer::beginJob") << "cutsName: " << cutsPSet << " is not recognized:"
+                                                                  << " theCuts not set!";
   }
-  else {
-    LogError("L3MuonCombinedRelativeIsolationProducer::beginJob")
-      <<"cutsName: "<<cutsPSet<<" is not recognized:"
-      <<" theCuts not set!";
-  }
-  LogTrace("")<< theCuts.print();
+  LogTrace("") << theCuts.print();
 
   // (kludge) additional cut on the number of tracks
   theMaxNTracks = cutsPSet.getParameter<int>("maxNTracks");
   theApplyCutsORmaxNTracks = cutsPSet.getParameter<bool>("applyCutsORmaxNTracks");
-
 }
 
 /// destructor
-L3MuonCombinedRelativeIsolationProducer::~L3MuonCombinedRelativeIsolationProducer(){
-  LogDebug("RecoMuon|L3MuonCombinedRelativeIsolationProducer")<<" L3MuonCombinedRelativeIsolationProducer DTOR";
+L3MuonCombinedRelativeIsolationProducer::~L3MuonCombinedRelativeIsolationProducer() {
+  LogDebug("RecoMuon|L3MuonCombinedRelativeIsolationProducer") << " L3MuonCombinedRelativeIsolationProducer DTOR";
 }
 
 /// ParameterSet descriptions
 void L3MuonCombinedRelativeIsolationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<bool>("UseRhoCorrectedCaloDeposits",false);
-  desc.add<bool>("UseCaloIso",true);
-  desc.add<edm::InputTag>("CaloDepositsLabel",edm::InputTag("hltL3CaloMuonCorrectedIsolations"));
-  desc.add<edm::InputTag>("inputMuonCollection",edm::InputTag("hltL3MuonCandidates"));
-  desc.add<bool>("OutputMuIsoDeposits",true);
-  desc.add<double>("TrackPt_Min",-1.0);
-  desc.add<bool>("printDebug",false);
+  desc.add<bool>("UseRhoCorrectedCaloDeposits", false);
+  desc.add<bool>("UseCaloIso", true);
+  desc.add<edm::InputTag>("CaloDepositsLabel", edm::InputTag("hltL3CaloMuonCorrectedIsolations"));
+  desc.add<edm::InputTag>("inputMuonCollection", edm::InputTag("hltL3MuonCandidates"));
+  desc.add<bool>("OutputMuIsoDeposits", true);
+  desc.add<double>("TrackPt_Min", -1.0);
+  desc.add<bool>("printDebug", false);
   edm::ParameterSetDescription cutsPSet;
   {
-    cutsPSet.add<std::vector<double> >("ConeSizes",std::vector<double>(1, 0.24));
-    cutsPSet.add<std::string>("ComponentName","SimpleCuts");
-    cutsPSet.add<std::vector<double> >("Thresholds",std::vector<double>(1, 0.1));
-    cutsPSet.add<int>("maxNTracks",-1);
-    cutsPSet.add<std::vector<double> >("EtaBounds",std::vector<double>(1, 2.411));
-    cutsPSet.add<bool>("applyCutsORmaxNTracks",false);
+    cutsPSet.add<std::vector<double>>("ConeSizes", std::vector<double>(1, 0.24));
+    cutsPSet.add<std::string>("ComponentName", "SimpleCuts");
+    cutsPSet.add<std::vector<double>>("Thresholds", std::vector<double>(1, 0.1));
+    cutsPSet.add<int>("maxNTracks", -1);
+    cutsPSet.add<std::vector<double>>("EtaBounds", std::vector<double>(1, 2.411));
+    cutsPSet.add<bool>("applyCutsORmaxNTracks", false);
   }
-  desc.add<edm::ParameterSetDescription>("CutsPSet",cutsPSet);
+  desc.add<edm::ParameterSetDescription>("CutsPSet", cutsPSet);
   edm::ParameterSetDescription trkExtractorPSet;
   {
     trkExtractorPSet.add<double>("Chi2Prob_Min", -1.0);
     trkExtractorPSet.add<double>("Chi2Ndof_Max", 1.0E64);
-    trkExtractorPSet.add<double>("Diff_z",0.2);
-    trkExtractorPSet.add<edm::InputTag>("inputTrackCollection",edm::InputTag("hltPixelTracks"));
-    trkExtractorPSet.add<double>("ReferenceRadius",6.0);
-    trkExtractorPSet.add<edm::InputTag>("BeamSpotLabel",edm::InputTag("hltOnlineBeamSpot"));
-    trkExtractorPSet.add<std::string>("ComponentName","PixelTrackExtractor");
-    trkExtractorPSet.add<double>("DR_Max",0.24);
-    trkExtractorPSet.add<double>("Diff_r",0.1);
-    trkExtractorPSet.add<bool>("VetoLeadingTrack",true);
-    trkExtractorPSet.add<double>("DR_VetoPt",0.025);
-    trkExtractorPSet.add<double>("DR_Veto",0.01);
-    trkExtractorPSet.add<unsigned int>("NHits_Min",0);
-    trkExtractorPSet.add<double>("Pt_Min",-1.0);
-    trkExtractorPSet.addUntracked<std::string>("DepositLabel","PXLS");
-    trkExtractorPSet.add<std::string>("BeamlineOption","BeamSpotFromEvent");
-    trkExtractorPSet.add<bool>("PropagateTracksToRadius",true);
-    trkExtractorPSet.add<double>("PtVeto_Min",2.0);
+    trkExtractorPSet.add<double>("Diff_z", 0.2);
+    trkExtractorPSet.add<edm::InputTag>("inputTrackCollection", edm::InputTag("hltPixelTracks"));
+    trkExtractorPSet.add<double>("ReferenceRadius", 6.0);
+    trkExtractorPSet.add<edm::InputTag>("BeamSpotLabel", edm::InputTag("hltOnlineBeamSpot"));
+    trkExtractorPSet.add<std::string>("ComponentName", "PixelTrackExtractor");
+    trkExtractorPSet.add<double>("DR_Max", 0.24);
+    trkExtractorPSet.add<double>("Diff_r", 0.1);
+    trkExtractorPSet.add<bool>("VetoLeadingTrack", true);
+    trkExtractorPSet.add<double>("DR_VetoPt", 0.025);
+    trkExtractorPSet.add<double>("DR_Veto", 0.01);
+    trkExtractorPSet.add<unsigned int>("NHits_Min", 0);
+    trkExtractorPSet.add<double>("Pt_Min", -1.0);
+    trkExtractorPSet.addUntracked<std::string>("DepositLabel", "PXLS");
+    trkExtractorPSet.add<std::string>("BeamlineOption", "BeamSpotFromEvent");
+    trkExtractorPSet.add<bool>("PropagateTracksToRadius", true);
+    trkExtractorPSet.add<double>("PtVeto_Min", 2.0);
   }
-  desc.add<edm::ParameterSetDescription>("TrkExtractorPSet",trkExtractorPSet);
+  desc.add<edm::ParameterSetDescription>("TrkExtractorPSet", trkExtractorPSet);
   edm::ParameterSetDescription caloExtractorPSet;
   {
-    caloExtractorPSet.add<double>("DR_Veto_H",0.1);
-    caloExtractorPSet.add<bool>("Vertex_Constraint_Z",false);
-    caloExtractorPSet.add<double>("Threshold_H",0.5);
-    caloExtractorPSet.add<std::string>("ComponentName","CaloExtractor");
-    caloExtractorPSet.add<double>("Threshold_E",0.2);
-    caloExtractorPSet.add<double>("DR_Max",0.24);
-    caloExtractorPSet.add<double>("DR_Veto_E",0.07);
-    caloExtractorPSet.add<double>("Weight_E",1.5);
-    caloExtractorPSet.add<bool>("Vertex_Constraint_XY",false);
-    caloExtractorPSet.addUntracked<std::string>("DepositLabel","EcalPlusHcal");
-    caloExtractorPSet.add<edm::InputTag>("CaloTowerCollectionLabel",edm::InputTag("hltTowerMakerForMuons"));
-    caloExtractorPSet.add<double>("Weight_H",1.0);
+    caloExtractorPSet.add<double>("DR_Veto_H", 0.1);
+    caloExtractorPSet.add<bool>("Vertex_Constraint_Z", false);
+    caloExtractorPSet.add<double>("Threshold_H", 0.5);
+    caloExtractorPSet.add<std::string>("ComponentName", "CaloExtractor");
+    caloExtractorPSet.add<double>("Threshold_E", 0.2);
+    caloExtractorPSet.add<double>("DR_Max", 0.24);
+    caloExtractorPSet.add<double>("DR_Veto_E", 0.07);
+    caloExtractorPSet.add<double>("Weight_E", 1.5);
+    caloExtractorPSet.add<bool>("Vertex_Constraint_XY", false);
+    caloExtractorPSet.addUntracked<std::string>("DepositLabel", "EcalPlusHcal");
+    caloExtractorPSet.add<edm::InputTag>("CaloTowerCollectionLabel", edm::InputTag("hltTowerMakerForMuons"));
+    caloExtractorPSet.add<double>("Weight_H", 1.0);
   }
-  desc.add<edm::ParameterSetDescription>("CaloExtractorPSet",caloExtractorPSet);
+  desc.add<edm::ParameterSetDescription>("CaloExtractorPSet", caloExtractorPSet);
   descriptions.add("hltL3MuonIsolations", desc);
 }
 
-
-void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventSetup& eventSetup){
+void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventSetup& eventSetup) {
   std::string metname = "RecoMuon|L3MuonCombinedRelativeIsolationProducer";
 
-  if (printDebug) std::cout  <<" L3 Muon Isolation producing..."
-            <<" BEGINING OF EVENT " <<"================================" <<std::endl;
+  if (printDebug)
+    std::cout << " L3 Muon Isolation producing..."
+              << " BEGINING OF EVENT "
+              << "================================" << std::endl;
 
   // Take the SA container
-  if (printDebug) std::cout  <<" Taking the muons: "<<theMuonCollectionLabel << std::endl;
+  if (printDebug)
+    std::cout << " Taking the muons: " << theMuonCollectionLabel << std::endl;
   Handle<RecoChargedCandidateCollection> muons;
-  event.getByToken(theMuonCollectionToken,muons);
+  event.getByToken(theMuonCollectionToken, muons);
 
   // Take calo deposits with rho corrections (ONLY if previously computed)
-  Handle< edm::ValueMap<float> > caloDepWithCorrMap;
-  if( useRhoCorrectedCaloDeps )
+  Handle<edm::ValueMap<float>> caloDepWithCorrMap;
+  if (useRhoCorrectedCaloDeps)
     event.getByToken(theCaloDepsToken, caloDepWithCorrMap);
 
   auto caloDepMap = std::make_unique<reco::IsoDepositMap>();
@@ -205,7 +202,6 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
   //auto combinedRelativeDeps = std::make_unique<std::vector<double>>();
   auto combinedRelativeDepMap = std::make_unique<edm::ValueMap<double>>();
 
-
   //
   // get Vetos and deposits
   //
@@ -213,7 +209,6 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
 
   IsoDeposit::Vetos trkVetos(nMuons);
   std::vector<IsoDeposit> trkDeps(nMuons);
-
 
   // IsoDeposit::Vetos caloVetos(nMuons);
   // std::vector<IsoDeposit> caloDeps(nMuons);
@@ -223,10 +218,9 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
   std::vector<IsoDeposit> caloDeps;
   std::vector<float> caloCorrDeps;  // if calo deposits with corrections available
 
-  if(useCaloIso && useRhoCorrectedCaloDeps) {
+  if (useCaloIso && useRhoCorrectedCaloDeps) {
     caloCorrDeps.resize(nMuons, 0.);
-  }
-  else if (useCaloIso) {
+  } else if (useCaloIso) {
     caloVetos.resize(nMuons);
     caloDeps.resize(nMuons);
   }
@@ -234,22 +228,19 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
   std::vector<double> combinedRelativeDeps(nMuons, 0.);
   std::vector<bool> combinedRelativeIsos(nMuons, false);
 
-  for (unsigned int i=0; i<nMuons; i++) {
-
-    RecoChargedCandidateRef candref(muons,i);
+  for (unsigned int i = 0; i < nMuons; i++) {
+    RecoChargedCandidateRef candref(muons, i);
     TrackRef mu = candref->track();
 
     trkDeps[i] = trkExtractor->deposit(event, eventSetup, *mu);
     trkVetos[i] = trkDeps[i].veto();
 
-    if( useCaloIso && useRhoCorrectedCaloDeps ) {
+    if (useCaloIso && useRhoCorrectedCaloDeps) {
       caloCorrDeps[i] = (*caloDepWithCorrMap)[candref];
-    }
-    else if (useCaloIso) {
+    } else if (useCaloIso) {
       caloDeps[i] = caloExtractor->deposit(event, eventSetup, *mu);
       caloVetos[i] = caloDeps[i].veto();
     }
-
   }
 
   //
@@ -261,36 +252,40 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
   // actual cut step
   //
 
-  if (printDebug) std::cout  << "Looping over deposits...." << std::endl;
-  for(unsigned int iMu=0; iMu < nMuons; ++iMu){
-
-    if (printDebug) std::cout  << "Muon number = " << iMu << std::endl;
+  if (printDebug)
+    std::cout << "Looping over deposits...." << std::endl;
+  for (unsigned int iMu = 0; iMu < nMuons; ++iMu) {
+    if (printDebug)
+      std::cout << "Muon number = " << iMu << std::endl;
     TrackRef mu = (*muons)[iMu].track();
 
     // cuts
-    const Cuts::CutSpec & cut = theCuts( mu->eta());
+    const Cuts::CutSpec& cut = theCuts(mu->eta());
 
+    if (printDebug)
+      std::cout << "CUTDEBUG: Muon eta = " << mu->eta() << std::endl
+                << "CUTDEBUG: Muon pt  = " << mu->pt() << std::endl
+                << "CUTDEBUG: minEta   = " << cut.etaRange.min() << std::endl
+                << "CUTDEBUG: maxEta   = " << cut.etaRange.max() << std::endl
+                << "CUTDEBUG: consize  = " << cut.conesize << std::endl
+                << "CUTDEBUG: thresho  = " << cut.threshold << std::endl;
 
-    if (printDebug) std::cout << "CUTDEBUG: Muon eta = " << mu->eta() << std::endl
-                              << "CUTDEBUG: Muon pt  = " <<  mu->pt() << std::endl
-                              << "CUTDEBUG: minEta   = " << cut.etaRange.min() << std::endl
-                              << "CUTDEBUG: maxEta   = " << cut.etaRange.max() << std::endl
-                              << "CUTDEBUG: consize  = " << cut.conesize << std::endl
-                              << "CUTDEBUG: thresho  = " << cut.threshold << std::endl;
-
-    const IsoDeposit & trkDeposit = trkDeps[iMu];
-    if (printDebug) std::cout  << trkDeposit.print();
+    const IsoDeposit& trkDeposit = trkDeps[iMu];
+    if (printDebug)
+      std::cout << trkDeposit.print();
     std::pair<double, int> trkIsoSumAndCount = trkDeposit.depositAndCountWithin(cut.conesize, trkVetos, theTrackPt_Min);
 
     double caloIsoSum = 0.;
-    if( useCaloIso && useRhoCorrectedCaloDeps ) {
+    if (useCaloIso && useRhoCorrectedCaloDeps) {
       caloIsoSum = caloCorrDeps[iMu];
-      if(caloIsoSum<0.) caloIsoSum = 0.;
-      if(printDebug) std::cout << "Rho-corrected calo deposit (min. 0) = " << caloIsoSum << std::endl;
-    }
-    else if (useCaloIso) {
-      const IsoDeposit & caloDeposit = caloDeps[iMu];
-      if (printDebug) std::cout  << caloDeposit.print();
+      if (caloIsoSum < 0.)
+        caloIsoSum = 0.;
+      if (printDebug)
+        std::cout << "Rho-corrected calo deposit (min. 0) = " << caloIsoSum << std::endl;
+    } else if (useCaloIso) {
+      const IsoDeposit& caloDeposit = caloDeps[iMu];
+      if (printDebug)
+        std::cout << caloDeposit.print();
       caloIsoSum = caloDeposit.depositWithin(cut.conesize, caloVetos);
     }
 
@@ -298,15 +293,18 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
     int count = trkIsoSumAndCount.second;
 
     double muPt = mu->pt();
-    if( muPt<1. ) muPt = 1.;
-    double combinedRelativeDeposit = ((trkIsoSum + caloIsoSum ) / muPt);
-    bool result = ( combinedRelativeDeposit < cut.threshold);
-    if (theApplyCutsORmaxNTracks ) result |= count <= theMaxNTracks;
-    if (printDebug) std::cout  <<"  trk dep in cone:  " << trkIsoSum << "  with count "<<count <<std::endl
-              <<"  calo dep in cone: " << caloIsoSum << std::endl
-              <<"  muPt: " << muPt << std::endl
-              <<"  relIso:  " <<combinedRelativeDeposit  << std::endl
-              <<"  is isolated: "<<result << std::endl;
+    if (muPt < 1.)
+      muPt = 1.;
+    double combinedRelativeDeposit = ((trkIsoSum + caloIsoSum) / muPt);
+    bool result = (combinedRelativeDeposit < cut.threshold);
+    if (theApplyCutsORmaxNTracks)
+      result |= count <= theMaxNTracks;
+    if (printDebug)
+      std::cout << "  trk dep in cone:  " << trkIsoSum << "  with count " << count << std::endl
+                << "  calo dep in cone: " << caloIsoSum << std::endl
+                << "  muPt: " << muPt << std::endl
+                << "  relIso:  " << combinedRelativeDeposit << std::endl
+                << "  is isolated: " << result << std::endl;
 
     combinedRelativeIsos[iMu] = result;
     //combinedRelativeDeps->push_back(combinedRelativeDeposit);
@@ -316,14 +314,13 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
   //
   // store
   //
-  if (optOutputIsoDeposits){
-
+  if (optOutputIsoDeposits) {
     reco::IsoDepositMap::Filler depFillerTrk(*trkDepMap);
     depFillerTrk.insert(muons, trkDeps.begin(), trkDeps.end());
     depFillerTrk.fill();
     event.put(std::move(trkDepMap), "trkIsoDeposits");
 
-    if( useCaloIso && (useRhoCorrectedCaloDeps==false) ) {
+    if (useCaloIso && (useRhoCorrectedCaloDeps == false)) {
       reco::IsoDepositMap::Filler depFillerCalo(*caloDepMap);
       depFillerCalo.insert(muons, caloDeps.begin(), caloDeps.end());
       depFillerCalo.fill();
@@ -335,12 +332,13 @@ void L3MuonCombinedRelativeIsolationProducer::produce(Event& event, const EventS
     depFillerCombRel.insert(muons, combinedRelativeDeps.begin(), combinedRelativeDeps.end());
     depFillerCombRel.fill();
     event.put(std::move(combinedRelativeDepMap), "combinedRelativeIsoDeposits");
-
   }
   edm::ValueMap<bool>::Filler isoFiller(*comboIsoDepMap);
   isoFiller.insert(muons, combinedRelativeIsos.begin(), combinedRelativeIsos.end());
   isoFiller.fill();
   event.put(std::move(comboIsoDepMap));
 
-  if (printDebug) std::cout  <<" END OF EVENT " <<"================================";
+  if (printDebug)
+    std::cout << " END OF EVENT "
+              << "================================";
 }

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.h
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonCombinedRelativeIsolationProducer.h
@@ -16,13 +16,15 @@
 
 #include <string>
 
-namespace edm { class Event; }
-namespace edm { class EventSetup; }
+namespace edm {
+  class Event;
+}
+namespace edm {
+  class EventSetup;
+}
 
 class L3MuonCombinedRelativeIsolationProducer : public edm::stream::EDProducer<> {
-
 public:
-
   /// constructor with config
   L3MuonCombinedRelativeIsolationProducer(const edm::ParameterSet&);
 
@@ -30,13 +32,12 @@ public:
   ~L3MuonCombinedRelativeIsolationProducer() override;
 
   /// ParameterSet descriptions
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   /// Produce isolation maps
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-
   edm::ParameterSet theConfig;
 
   // Muon track Collection Label
@@ -75,7 +76,6 @@ private:
   // Print out debug info
 
   bool printDebug;
-
 };
 
 #endif

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.cc
@@ -33,18 +33,18 @@ using namespace reco;
 using namespace muonisolation;
 
 /// constructor with config
-L3MuonIsolationProducer::L3MuonIsolationProducer(const ParameterSet& par) :
-  theConfig(par),
-  theMuonCollectionLabel(par.getParameter<InputTag>("inputMuonCollection")),
-  optOutputIsoDeposits(par.getParameter<bool>("OutputMuIsoDeposits")),
-  theTrackPt_Min(-1)
-  {
-  LogDebug("RecoMuon|L3MuonIsolationProducer")<<" L3MuonIsolationProducer CTOR";
+L3MuonIsolationProducer::L3MuonIsolationProducer(const ParameterSet& par)
+    : theConfig(par),
+      theMuonCollectionLabel(par.getParameter<InputTag>("inputMuonCollection")),
+      optOutputIsoDeposits(par.getParameter<bool>("OutputMuIsoDeposits")),
+      theTrackPt_Min(-1) {
+  LogDebug("RecoMuon|L3MuonIsolationProducer") << " L3MuonIsolationProducer CTOR";
 
   theMuonCollectionToken = consumes<RecoChargedCandidateCollection>(theMuonCollectionLabel);
 
-  if (optOutputIsoDeposits) produces<reco::IsoDepositMap>();
-  produces<edm::ValueMap<bool> >();
+  if (optOutputIsoDeposits)
+    produces<reco::IsoDepositMap>();
+  produces<edm::ValueMap<bool>>();
 
   //
   // Extractor
@@ -53,7 +53,8 @@ L3MuonIsolationProducer::L3MuonIsolationProducer(const ParameterSet& par) :
   //! get min pt for the track to go into sumPt
   theTrackPt_Min = theConfig.getParameter<double>("TrackPt_Min");
   std::string extractorName = extractorPSet.getParameter<std::string>("ComponentName");
-  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( extractorName, extractorPSet, consumesCollector())};
+  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{
+      IsoDepositExtractorFactory::get()->create(extractorName, extractorPSet, consumesCollector())};
   std::string depositType = extractorPSet.getUntrackedParameter<std::string>("DepositLabel");
 
   //
@@ -63,21 +64,17 @@ L3MuonIsolationProducer::L3MuonIsolationProducer(const ParameterSet& par) :
   std::string cutsName = cutsPSet.getParameter<std::string>("ComponentName");
   if (cutsName == "SimpleCuts") {
     theCuts = Cuts(cutsPSet);
-  }
-  else if (
-//        (cutsName== "L3NominalEfficiencyCuts_PXLS" && depositType=="PXLS")
-//     || (cutsName== "L3NominalEfficiencyCuts_TRKS" && depositType=="TRKS")
-//! test cutsName only. The depositType is informational only (has not been used so far) [VK]
-	   (cutsName== "L3NominalEfficiencyCuts_PXLS" )
-	   || (cutsName== "L3NominalEfficiencyCuts_TRKS") ) {
+  } else if (
+      //        (cutsName== "L3NominalEfficiencyCuts_PXLS" && depositType=="PXLS")
+      //     || (cutsName== "L3NominalEfficiencyCuts_TRKS" && depositType=="TRKS")
+      //! test cutsName only. The depositType is informational only (has not been used so far) [VK]
+      (cutsName == "L3NominalEfficiencyCuts_PXLS") || (cutsName == "L3NominalEfficiencyCuts_TRKS")) {
     theCuts = L3NominalEfficiencyConfigurator(cutsPSet).cuts();
+  } else {
+    LogError("L3MuonIsolationProducer::beginJob") << "cutsName: " << cutsPSet << " is not recognized:"
+                                                  << " theCuts not set!";
   }
-  else {
-    LogError("L3MuonIsolationProducer::beginJob")
-      <<"cutsName: "<<cutsPSet<<" is not recognized:"
-      <<" theCuts not set!";
-  }
-  LogTrace("")<< theCuts.print();
+  LogTrace("") << theCuts.print();
 
   // (kludge) additional cut on the number of tracks
   theMaxNTracks = cutsPSet.getParameter<int>("maxNTracks");
@@ -85,24 +82,24 @@ L3MuonIsolationProducer::L3MuonIsolationProducer(const ParameterSet& par) :
 }
 
 /// destructor
-L3MuonIsolationProducer::~L3MuonIsolationProducer(){
-  LogDebug("RecoMuon|L3MuonIsolationProducer")<<" L3MuonIsolationProducer DTOR";
+L3MuonIsolationProducer::~L3MuonIsolationProducer() {
+  LogDebug("RecoMuon|L3MuonIsolationProducer") << " L3MuonIsolationProducer DTOR";
 }
 
-void L3MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup){
+void L3MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup) {
   std::string metname = "RecoMuon|L3MuonIsolationProducer";
 
-  LogDebug(metname)<<" L3 Muon Isolation producing..."
-                    <<" BEGINING OF EVENT " <<"================================";
+  LogDebug(metname) << " L3 Muon Isolation producing..."
+                    << " BEGINING OF EVENT "
+                    << "================================";
 
   // Take the SA container
-  LogTrace(metname)<<" Taking the muons: "<<theMuonCollectionLabel;
+  LogTrace(metname) << " Taking the muons: " << theMuonCollectionLabel;
   Handle<TrackCollection> muons;
-  event.getByToken(theMuonCollectionToken,muons);
+  event.getByToken(theMuonCollectionToken, muons);
 
   auto depMap = std::make_unique<reco::IsoDepositMap>();
   auto isoMap = std::make_unique<edm::ValueMap<bool>>();
-
 
   //
   // get Vetos and deposits
@@ -114,8 +111,8 @@ void L3MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup
   std::vector<IsoDeposit> deps(nMuons);
   std::vector<bool> isos(nMuons, false);
 
-  for (unsigned int i=0; i<nMuons; i++) {
-    TrackRef mu(muons,i);
+  for (unsigned int i = 0; i < nMuons; i++) {
+    TrackRef mu(muons, i);
     deps[i] = theExtractor->deposit(event, eventSetup, *mu);
     vetos[i] = deps[i].veto();
   }
@@ -128,21 +125,22 @@ void L3MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup
   //
   // actual cut step
   //
-  for(unsigned int iMu=0; iMu < nMuons; ++iMu){
+  for (unsigned int iMu = 0; iMu < nMuons; ++iMu) {
     const reco::Track* mu = &(*muons)[iMu];
 
-    const IsoDeposit & deposit = deps[iMu];
-    LogTrace(metname)<< deposit.print();
+    const IsoDeposit& deposit = deps[iMu];
+    LogTrace(metname) << deposit.print();
 
-    const Cuts::CutSpec & cut = theCuts( mu->eta());
+    const Cuts::CutSpec& cut = theCuts(mu->eta());
     std::pair<double, int> sumAndCount = deposit.depositAndCountWithin(cut.conesize, vetos, theTrackPt_Min);
 
     double value = sumAndCount.first;
     int count = sumAndCount.second;
 
     bool result = (value < cut.threshold);
-    if (theApplyCutsORmaxNTracks ) result |= count <= theMaxNTracks;
-    LogTrace(metname)<<"deposit in cone: "<<value<<"with count "<<count<<" is isolated: "<<result;
+    if (theApplyCutsORmaxNTracks)
+      result |= count <= theMaxNTracks;
+    LogTrace(metname) << "deposit in cone: " << value << "with count " << count << " is isolated: " << result;
 
     isos[iMu] = result;
   }
@@ -150,16 +148,17 @@ void L3MuonIsolationProducer::produce(Event& event, const EventSetup& eventSetup
   //
   // store
   //
-  if (optOutputIsoDeposits){
+  if (optOutputIsoDeposits) {
     reco::IsoDepositMap::Filler depFiller(*depMap);
     depFiller.insert(muons, deps.begin(), deps.end());
     depFiller.fill();
     event.put(std::move(depMap));
   }
-  edm::ValueMap<bool> ::Filler isoFiller(*isoMap);
+  edm::ValueMap<bool>::Filler isoFiller(*isoMap);
   isoFiller.insert(muons, isos.begin(), isos.end());
   isoFiller.fill();
   event.put(std::move(isoMap));
 
-  LogTrace(metname) <<" END OF EVENT " <<"================================";
+  LogTrace(metname) << " END OF EVENT "
+                    << "================================";
 }

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.h
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonIsolationProducer.h
@@ -14,13 +14,15 @@
 
 #include <string>
 
-namespace edm { class Event; }
-namespace edm { class EventSetup; }
+namespace edm {
+  class Event;
+}
+namespace edm {
+  class EventSetup;
+}
 
 class L3MuonIsolationProducer : public edm::stream::EDProducer<> {
-
 public:
-
   /// constructor with config
   L3MuonIsolationProducer(const edm::ParameterSet&);
 
@@ -31,7 +33,6 @@ public:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-
   edm::ParameterSet theConfig;
 
   // Muon track Collection Label
@@ -57,7 +58,6 @@ private:
 
   //! apply or not the maxN cut on top of the sumPt (or nominall eff) < cuts
   bool theApplyCutsORmaxNTracks;
-
 };
 
 #endif

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonSumCaloPFIsolationProducer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonSumCaloPFIsolationProducer.cc
@@ -28,53 +28,51 @@ using namespace reco;
 
 /// constructor with config
 L3MuonSumCaloPFIsolationProducer::L3MuonSumCaloPFIsolationProducer(const edm::ParameterSet& config) {
-    
-    recoChargedCandidateProducer_ = consumes<reco::RecoChargedCandidateCollection>(config.getParameter<edm::InputTag>("recoChargedCandidateProducer"));
-    pfEcalClusterProducer_         = consumes<reco::RecoChargedCandidateIsolationMap>(config.getParameter<edm::InputTag>("pfEcalClusterProducer"));
-    pfHcalClusterProducer_         = consumes<reco::RecoChargedCandidateIsolationMap>(config.getParameter<edm::InputTag>("pfHcalClusterProducer"));
-    
-    produces < edm::ValueMap<float> >();
-    
+  recoChargedCandidateProducer_ = consumes<reco::RecoChargedCandidateCollection>(
+      config.getParameter<edm::InputTag>("recoChargedCandidateProducer"));
+  pfEcalClusterProducer_ =
+      consumes<reco::RecoChargedCandidateIsolationMap>(config.getParameter<edm::InputTag>("pfEcalClusterProducer"));
+  pfHcalClusterProducer_ =
+      consumes<reco::RecoChargedCandidateIsolationMap>(config.getParameter<edm::InputTag>("pfHcalClusterProducer"));
+
+  produces<edm::ValueMap<float>>();
 }
 
-L3MuonSumCaloPFIsolationProducer::~L3MuonSumCaloPFIsolationProducer()
-{}
+L3MuonSumCaloPFIsolationProducer::~L3MuonSumCaloPFIsolationProducer() {}
 
 void L3MuonSumCaloPFIsolationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-    edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("recoChargedCandidateProducer", edm::InputTag("hltL1SeededRecoChargedCandidatePF"));
-    desc.add<edm::InputTag>("pfEcalClusterProducer", edm::InputTag("hltParticleFlowClusterECAL"));
-    desc.add<edm::InputTag>("pfHcalClusterProducer", edm::InputTag("hltParticleFlowClusterHCAL"));
-    descriptions.add(("hltL3MuonSumCaloPFIsolationProducer"), desc);
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("recoChargedCandidateProducer", edm::InputTag("hltL1SeededRecoChargedCandidatePF"));
+  desc.add<edm::InputTag>("pfEcalClusterProducer", edm::InputTag("hltParticleFlowClusterECAL"));
+  desc.add<edm::InputTag>("pfHcalClusterProducer", edm::InputTag("hltParticleFlowClusterHCAL"));
+  descriptions.add(("hltL3MuonSumCaloPFIsolationProducer"), desc);
 }
 
-void L3MuonSumCaloPFIsolationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const{
-    
-    edm::Handle<reco::RecoChargedCandidateCollection> recochargedcandHandle;
-    iEvent.getByToken(recoChargedCandidateProducer_,recochargedcandHandle);
-    
-    edm::Handle<reco::RecoChargedCandidateIsolationMap> ecalIsolation;
-    iEvent.getByToken (pfEcalClusterProducer_,ecalIsolation);
-    
-    edm::Handle<reco::RecoChargedCandidateIsolationMap> hcalIsolation;
-    iEvent.getByToken (pfHcalClusterProducer_,hcalIsolation);
-    
-    auto caloIsoMap = std::make_unique<edm::ValueMap<float>>();
-    std::vector<float> isoFloats(recochargedcandHandle->size(), 0);
-    
-    for (unsigned int iReco = 0; iReco < recochargedcandHandle->size(); iReco++) {
-        reco::RecoChargedCandidateRef candRef(recochargedcandHandle, iReco);
-        reco::RecoChargedCandidateIsolationMap::const_iterator mapiECAL = (*ecalIsolation).find( candRef );
-        float valisoECAL = mapiECAL->val;
-        reco::RecoChargedCandidateIsolationMap::const_iterator mapiHCAL = (*hcalIsolation).find( candRef );
-        float valisoHCAL = mapiHCAL->val;
-        float caloIso = valisoECAL + valisoHCAL;
-        isoFloats[iReco] = caloIso;
-    }
-    
-    edm::ValueMap<float> ::Filler isoFloatFiller(*caloIsoMap);
-    isoFloatFiller.insert(recochargedcandHandle, isoFloats.begin(), isoFloats.end());
-    isoFloatFiller.fill();
-    iEvent.put(std::move(caloIsoMap));
+void L3MuonSumCaloPFIsolationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  edm::Handle<reco::RecoChargedCandidateCollection> recochargedcandHandle;
+  iEvent.getByToken(recoChargedCandidateProducer_, recochargedcandHandle);
 
+  edm::Handle<reco::RecoChargedCandidateIsolationMap> ecalIsolation;
+  iEvent.getByToken(pfEcalClusterProducer_, ecalIsolation);
+
+  edm::Handle<reco::RecoChargedCandidateIsolationMap> hcalIsolation;
+  iEvent.getByToken(pfHcalClusterProducer_, hcalIsolation);
+
+  auto caloIsoMap = std::make_unique<edm::ValueMap<float>>();
+  std::vector<float> isoFloats(recochargedcandHandle->size(), 0);
+
+  for (unsigned int iReco = 0; iReco < recochargedcandHandle->size(); iReco++) {
+    reco::RecoChargedCandidateRef candRef(recochargedcandHandle, iReco);
+    reco::RecoChargedCandidateIsolationMap::const_iterator mapiECAL = (*ecalIsolation).find(candRef);
+    float valisoECAL = mapiECAL->val;
+    reco::RecoChargedCandidateIsolationMap::const_iterator mapiHCAL = (*hcalIsolation).find(candRef);
+    float valisoHCAL = mapiHCAL->val;
+    float caloIso = valisoECAL + valisoHCAL;
+    isoFloats[iReco] = caloIso;
+  }
+
+  edm::ValueMap<float>::Filler isoFloatFiller(*caloIsoMap);
+  isoFloatFiller.insert(recochargedcandHandle, isoFloats.begin(), isoFloats.end());
+  isoFloatFiller.fill();
+  iEvent.put(std::move(caloIsoMap));
 }

--- a/RecoMuon/L3MuonIsolationProducer/src/L3MuonSumCaloPFIsolationProducer.h
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3MuonSumCaloPFIsolationProducer.h
@@ -14,27 +14,22 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateIsolation.h"
 
-
-
 namespace edm {
-    class ConfigurationDescriptions;
+  class ConfigurationDescriptions;
 }
 
 class L3MuonSumCaloPFIsolationProducer : public edm::global::EDProducer<> {
 public:
-    explicit L3MuonSumCaloPFIsolationProducer(const edm::ParameterSet&);
-    ~L3MuonSumCaloPFIsolationProducer() override;
-    
-    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-    
-private:
-    
-    edm::EDGetTokenT<reco::RecoChargedCandidateCollection> recoChargedCandidateProducer_;
-    edm::EDGetTokenT<reco::RecoChargedCandidateIsolationMap> pfEcalClusterProducer_;
-    edm::EDGetTokenT<reco::RecoChargedCandidateIsolationMap> pfHcalClusterProducer_;
-    
+  explicit L3MuonSumCaloPFIsolationProducer(const edm::ParameterSet&);
+  ~L3MuonSumCaloPFIsolationProducer() override;
 
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  edm::EDGetTokenT<reco::RecoChargedCandidateCollection> recoChargedCandidateProducer_;
+  edm::EDGetTokenT<reco::RecoChargedCandidateIsolationMap> pfEcalClusterProducer_;
+  edm::EDGetTokenT<reco::RecoChargedCandidateIsolationMap> pfHcalClusterProducer_;
 };
 
 #endif

--- a/RecoMuon/L3MuonIsolationProducer/src/L3NominalEfficiencyConfigurator.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3NominalEfficiencyConfigurator.cc
@@ -3,33 +3,26 @@
 
 using namespace muonisolation;
 
-L3NominalEfficiencyConfigurator::L3NominalEfficiencyConfigurator(const edm::ParameterSet & pset)
-  : theConfig(pset), theWeights(std::vector<double>(1,1.))
-{
+L3NominalEfficiencyConfigurator::L3NominalEfficiencyConfigurator(const edm::ParameterSet& pset)
+    : theConfig(pset), theWeights(std::vector<double>(1, 1.)) {
   std::string name = theConfig.getParameter<std::string>("ComponentName");
-  std::string lumi = theConfig.getParameter<std::string>("LumiOption"); 
+  std::string lumi = theConfig.getParameter<std::string>("LumiOption");
 
-  std::string dir="RecoMuon/L3MuonIsolationProducer/data/";
-  if (name=="L3NominalEfficiencyCuts_PXLS") {
-    if (lumi=="2E33") {
-      theFileName = dir+"L3Pixel_PTDR_2x1033.dat";
-      theBestCones = std::vector<std::string>(1,"8:0.97");
+  std::string dir = "RecoMuon/L3MuonIsolationProducer/data/";
+  if (name == "L3NominalEfficiencyCuts_PXLS") {
+    if (lumi == "2E33") {
+      theFileName = dir + "L3Pixel_PTDR_2x1033.dat";
+      theBestCones = std::vector<std::string>(1, "8:0.97");
     }
-  } 
-  else if ( name=="L3NominalEfficiencyCuts_TRKS") {
-  }
-  else {
-    
+  } else if (name == "L3NominalEfficiencyCuts_TRKS") {
+  } else {
   }
 }
 
 Cuts L3NominalEfficiencyConfigurator::cuts() const
 
 {
-
   IsolatorByNominalEfficiency nomEff(theFileName, theBestCones, theWeights);
-  double threshold = theConfig.getParameter<double>("NominalEfficiency"); 
+  double threshold = theConfig.getParameter<double>("NominalEfficiency");
   return nomEff.cuts(threshold);
-
 }
-

--- a/RecoMuon/L3MuonIsolationProducer/src/L3NominalEfficiencyConfigurator.h
+++ b/RecoMuon/L3MuonIsolationProducer/src/L3NominalEfficiencyConfigurator.h
@@ -8,13 +8,13 @@
 
 class L3NominalEfficiencyConfigurator {
 public:
-  L3NominalEfficiencyConfigurator(const edm::ParameterSet & pset); 
+  L3NominalEfficiencyConfigurator(const edm::ParameterSet& pset);
   muonisolation::Cuts cuts() const;
+
 private:
   edm::ParameterSet theConfig;
   std::vector<std::string> theBestCones;
   std::vector<double> theWeights;
-  std::string theFileName; 
-   
+  std::string theFileName;
 };
 #endif

--- a/RecoMuon/L3MuonIsolationProducer/src/SealModule.cc
+++ b/RecoMuon/L3MuonIsolationProducer/src/SealModule.cc
@@ -2,15 +2,11 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
-
-
 #include "L3MuonIsolationProducer.h"
 DEFINE_FWK_MODULE(L3MuonIsolationProducer);
 
 #include "L3MuonCombinedRelativeIsolationProducer.h"
 DEFINE_FWK_MODULE(L3MuonCombinedRelativeIsolationProducer);
-
 
 #include "RecoMuon/L3MuonIsolationProducer/src/L3MuonSumCaloPFIsolationProducer.h"
 DEFINE_FWK_MODULE(L3MuonSumCaloPFIsolationProducer);

--- a/RecoMuon/L3MuonIsolationProducer/test/L3MuonIsolationAnalyzer.cc
+++ b/RecoMuon/L3MuonIsolationProducer/test/L3MuonIsolationAnalyzer.cc
@@ -27,28 +27,24 @@ using namespace edm;
 using namespace reco;
 
 /// Constructor
-L3MuonIsolationAnalyzer::L3MuonIsolationAnalyzer(const ParameterSet& pset) :
-  theIsolationLabel(pset.getUntrackedParameter<edm::InputTag>("IsolationCollectionLabel")),
-  theConeCases(pset.getParameter<std::vector<double> > ("ConeCases")),
-  thePtMin(pset.getParameter<double> ("PtMin")),
-  thePtMax(pset.getParameter<double> ("PtMax")),
-  thePtBins(pset.getParameter<unsigned int> ("PtBins")),
-  theCuts(pset.getParameter<std::vector<double> > ("EtaBounds"),
-          pset.getParameter<std::vector<double> > ("ConeSizes"),
-          pset.getParameter<std::vector<double> > ("Thresholds")),
-  theRootFileName(pset.getUntrackedParameter<string>("rootFileName")),
-  theTxtFileName(pset.getUntrackedParameter<string>("txtFileName"))
-{
-  LogDebug("Muon|RecoMuon|L3MuonIsolationTest")<<" L3MuonIsolationTest constructor called";
-
-
+L3MuonIsolationAnalyzer::L3MuonIsolationAnalyzer(const ParameterSet& pset)
+    : theIsolationLabel(pset.getUntrackedParameter<edm::InputTag>("IsolationCollectionLabel")),
+      theConeCases(pset.getParameter<std::vector<double> >("ConeCases")),
+      thePtMin(pset.getParameter<double>("PtMin")),
+      thePtMax(pset.getParameter<double>("PtMax")),
+      thePtBins(pset.getParameter<unsigned int>("PtBins")),
+      theCuts(pset.getParameter<std::vector<double> >("EtaBounds"),
+              pset.getParameter<std::vector<double> >("ConeSizes"),
+              pset.getParameter<std::vector<double> >("Thresholds")),
+      theRootFileName(pset.getUntrackedParameter<string>("rootFileName")),
+      theTxtFileName(pset.getUntrackedParameter<string>("txtFileName")) {
+  LogDebug("Muon|RecoMuon|L3MuonIsolationTest") << " L3MuonIsolationTest constructor called";
 }
 
 /// Destructor
-L3MuonIsolationAnalyzer::~L3MuonIsolationAnalyzer(){
-}
+L3MuonIsolationAnalyzer::~L3MuonIsolationAnalyzer() {}
 
-void L3MuonIsolationAnalyzer::beginJob(){
+void L3MuonIsolationAnalyzer::beginJob() {
   // Create output files
   theTxtFile = fopen(theTxtFileName.data(), "w");
 
@@ -58,32 +54,32 @@ void L3MuonIsolationAnalyzer::beginJob(){
   numberOfEvents = 0;
   numberOfMuons = 0;
 
-  hPtSum = new TH1F("ptSum","Sum E_{T}^{weighted} (GeV)",100,0,50);
-  hEffVsCone = new TH1F("effVsCone","Efficiency(%) vs Cone Set"
-      , theConeCases.size(), 0.5, theConeCases.size()+0.5);
-  hEffVsPt = new TH1F("effVsPt","Efficiency(%) vs E_{T}^{weighted} (GeV)"
-      , thePtBins, thePtMin, thePtMax);
+  hPtSum = new TH1F("ptSum", "Sum E_{T}^{weighted} (GeV)", 100, 0, 50);
+  hEffVsCone = new TH1F("effVsCone", "Efficiency(%) vs Cone Set", theConeCases.size(), 0.5, theConeCases.size() + 0.5);
+  hEffVsPt = new TH1F("effVsPt", "Efficiency(%) vs E_{T}^{weighted} (GeV)", thePtBins, thePtMin, thePtMax);
 
   hEffVsPtArray.clear();
   char chnam[256];
   char chtit[1000];
-  for (unsigned int j=0; j<theConeCases.size() ; j++) {
-      for (unsigned int k=0; k<theCuts.size() ; k++) {
-            snprintf(chnam,sizeof(chnam),"effVsPt-%.2d-%.2d", j, k);
-            snprintf(chtit,sizeof(chtit),"Eff(%%) vs P_{T}(GeV), cone size %.4f, eta in [%.4f,%.4f]"
-               , theConeCases[j], theCuts[k].etaRange.min(), theCuts[k].etaRange.max());
-            hEffVsPtArray.push_back(new TH1F(chnam, chtit
-                  , thePtBins,thePtMin,thePtMax));
-      }
+  for (unsigned int j = 0; j < theConeCases.size(); j++) {
+    for (unsigned int k = 0; k < theCuts.size(); k++) {
+      snprintf(chnam, sizeof(chnam), "effVsPt-%.2d-%.2d", j, k);
+      snprintf(chtit,
+               sizeof(chtit),
+               "Eff(%%) vs P_{T}(GeV), cone size %.4f, eta in [%.4f,%.4f]",
+               theConeCases[j],
+               theCuts[k].etaRange.min(),
+               theCuts[k].etaRange.max());
+      hEffVsPtArray.push_back(new TH1F(chnam, chtit, thePtBins, thePtMin, thePtMax));
+    }
   }
-
 }
 
-void L3MuonIsolationAnalyzer::endJob(){
+void L3MuonIsolationAnalyzer::endJob() {
   Puts("L3MuonIsolationAnalyzer>>> FINAL PRINTOUTS -> BEGIN");
   Puts("L3MuonIsolationAnalyzer>>> Number of analyzed events= %d", numberOfEvents);
   Puts("L3MuonIsolationAnalyzer>>> Number of analyzed muons= %d", numberOfMuons);
-    
+
   // Write the histos to file
   theRootFile->cd();
 
@@ -92,46 +88,48 @@ void L3MuonIsolationAnalyzer::endJob(){
   unsigned int overflow_bin;
   float norm;
 
-  overflow_bin = hEffVsCone->GetNbinsX()+1;
+  overflow_bin = hEffVsCone->GetNbinsX() + 1;
   norm = hEffVsCone->GetBinContent(overflow_bin);
-  if (norm<=0.) norm = 1.;
+  if (norm <= 0.)
+    norm = 1.;
   Puts("");
-  for (unsigned int k=1; k<overflow_bin; k++) {
-            float aux = hEffVsCone->GetBinContent(k);
-            float eff = 100*aux/norm;
-            hEffVsCone->SetBinContent(k,eff);
-            Puts("\tEfficiency in cone index= %d (size=%f): %f"
-                        , k, theConeCases[k-1], eff);
+  for (unsigned int k = 1; k < overflow_bin; k++) {
+    float aux = hEffVsCone->GetBinContent(k);
+    float eff = 100 * aux / norm;
+    hEffVsCone->SetBinContent(k, eff);
+    Puts("\tEfficiency in cone index= %d (size=%f): %f", k, theConeCases[k - 1], eff);
   }
   hEffVsCone->Write();
 
   Puts("");
-  overflow_bin = hEffVsPt->GetNbinsX()+1;
+  overflow_bin = hEffVsPt->GetNbinsX() + 1;
   norm = hEffVsPt->GetBinContent(overflow_bin);
-  if (norm<=0.) norm = 1.;
-  for (unsigned int k=1; k<overflow_bin; k++) {
-            float aux = hEffVsPt->GetBinContent(k);
-            float eff = 100*aux/norm;
-            hEffVsPt->SetBinContent(k,eff);
-            float pt = thePtMin + (k-0.5)/thePtBins*(thePtMax-thePtMin);
-            Puts("\tEfficiency for Pt threshold cut %f: %f", pt, eff);
+  if (norm <= 0.)
+    norm = 1.;
+  for (unsigned int k = 1; k < overflow_bin; k++) {
+    float aux = hEffVsPt->GetBinContent(k);
+    float eff = 100 * aux / norm;
+    hEffVsPt->SetBinContent(k, eff);
+    float pt = thePtMin + (k - 0.5) / thePtBins * (thePtMax - thePtMin);
+    Puts("\tEfficiency for Pt threshold cut %f: %f", pt, eff);
   }
   hEffVsPt->Write();
 
-  for (unsigned int j=0; j<hEffVsPtArray.size(); j++) {
-      overflow_bin = hEffVsPtArray[j]->GetNbinsX()+1;
-      norm = hEffVsPtArray[j]->GetBinContent(overflow_bin);
-      if (norm<=0.) norm = 1.;
-      fprintf(theTxtFile, "%s\n", hEffVsPtArray[j]->GetTitle());
-      fprintf(theTxtFile, "%s\n", "PT threshold(GeV), efficiency(%): ");
-      for (unsigned int k=1; k<overflow_bin; k++) {
-            float aux = hEffVsPtArray[j]->GetBinContent(k);
-            float eff = 100*aux/norm;
-            hEffVsPtArray[j]->SetBinContent(k,eff);
-            float ptthr = hEffVsPtArray[j]->GetXaxis()->GetBinCenter(k);
-            fprintf(theTxtFile, "%6.2f %8.3f\n", ptthr, eff);
-      }
-      hEffVsPtArray[j]->Write();
+  for (unsigned int j = 0; j < hEffVsPtArray.size(); j++) {
+    overflow_bin = hEffVsPtArray[j]->GetNbinsX() + 1;
+    norm = hEffVsPtArray[j]->GetBinContent(overflow_bin);
+    if (norm <= 0.)
+      norm = 1.;
+    fprintf(theTxtFile, "%s\n", hEffVsPtArray[j]->GetTitle());
+    fprintf(theTxtFile, "%s\n", "PT threshold(GeV), efficiency(%): ");
+    for (unsigned int k = 1; k < overflow_bin; k++) {
+      float aux = hEffVsPtArray[j]->GetBinContent(k);
+      float eff = 100 * aux / norm;
+      hEffVsPtArray[j]->SetBinContent(k, eff);
+      float ptthr = hEffVsPtArray[j]->GetXaxis()->GetBinCenter(k);
+      fprintf(theTxtFile, "%6.2f %8.3f\n", ptthr, eff);
+    }
+    hEffVsPtArray[j]->Write();
   }
 
   theRootFile->Close();
@@ -139,31 +137,30 @@ void L3MuonIsolationAnalyzer::endJob(){
 
   Puts("L3MuonIsolationAnalyzer>>> FINAL PRINTOUTS -> END");
 }
- 
 
-void L3MuonIsolationAnalyzer::analyze(const Event & event, const EventSetup& eventSetup){
+void L3MuonIsolationAnalyzer::analyze(const Event& event, const EventSetup& eventSetup) {
   static const string metname = "L3MuonIsolation";
-  
+
   numberOfEvents++;
-  
+
   // Get the isolation information from the event
   Handle<reco::IsoDepositMap> depMap;
   event.getByLabel(theIsolationLabel, depMap);
 
   //! How do I know it's made for tracks? Just guessing
-  typedef edm::View<reco::Track>  tracks_type;
-  Handle<tracks_type > tracksH;
+  typedef edm::View<reco::Track> tracks_type;
+  Handle<tracks_type> tracksH;
 
   typedef reco::IsoDepositMap::const_iterator depmap_iterator;
   depmap_iterator depMI = depMap->begin();
   depmap_iterator depMEnd = depMap->end();
 
   for (; depMI != depMEnd; ++depMI) {
-    if (depMI.id() != tracksH.id()){
-      LogTrace(metname)<<"Getting tracks with id "<<depMI.id();
+    if (depMI.id() != tracksH.id()) {
+      LogTrace(metname) << "Getting tracks with id " << depMI.id();
       event.get(depMI.id(), tracksH);
     }
-    
+
     typedef reco::IsoDepositMap::container::const_iterator dep_iterator;
     dep_iterator depI = depMI.begin();
     dep_iterator depEnd = depMI.end();
@@ -172,58 +169,62 @@ void L3MuonIsolationAnalyzer::analyze(const Event & event, const EventSetup& eve
     tk_iterator tkI = tracksH->begin();
     tk_iterator tkEnd = tracksH->end();
 
-    for (;tkI != tkEnd && depI != depEnd; ++tkI, ++depI){    
-      
+    for (; tkI != tkEnd && depI != depEnd; ++tkI, ++depI) {
       numberOfMuons++;
       tracks_type::const_pointer tk = &*tkI;
       const IsoDeposit& dep = *depI;
-      
+
       muonisolation::Cuts::CutSpec cuts_here = theCuts(tk->eta());
       double conesize = cuts_here.conesize;
       float ptsum = dep.depositWithin(conesize);
       hPtSum->Fill(ptsum);
-      
-      hEffVsCone->Fill(theConeCases.size()+999.);
-      for (unsigned int j=0; j<theConeCases.size(); j++) {
-	if (dep.depositWithin(theConeCases[j])<cuts_here.threshold) 
-	  hEffVsCone->Fill(j+1.0);
+
+      hEffVsCone->Fill(theConeCases.size() + 999.);
+      for (unsigned int j = 0; j < theConeCases.size(); j++) {
+        if (dep.depositWithin(theConeCases[j]) < cuts_here.threshold)
+          hEffVsCone->Fill(j + 1.0);
       }
-      
-      hEffVsPt->Fill(thePtMax+999.);
-      for (unsigned int j=0; j<thePtBins; j++) {
-	float ptthr = thePtMin + (j+0.5)/thePtBins*(thePtMax-thePtMin);
-	if (ptsum<ptthr) hEffVsPt->Fill(ptthr);
+
+      hEffVsPt->Fill(thePtMax + 999.);
+      for (unsigned int j = 0; j < thePtBins; j++) {
+        float ptthr = thePtMin + (j + 0.5) / thePtBins * (thePtMax - thePtMin);
+        if (ptsum < ptthr)
+          hEffVsPt->Fill(ptthr);
       }
-      
-      for (unsigned int j=0; j<theConeCases.size() ; j++) {
-	float ptsum = dep.depositWithin(theConeCases[j]);
-	for (unsigned int k=0; k<theCuts.size() ; k++) {
-	  unsigned int n = theCuts.size()*j + k;
-	  if (fabs(tk->eta())<theCuts[k].etaRange.min()) continue;
-	  if (fabs(tk->eta())>theCuts[k].etaRange.max()) continue;
-	  hEffVsPtArray[n]->Fill(thePtMax+999.);
-	  for (unsigned int l=0; l<thePtBins; l++) {
-	    float ptthr = thePtMin + (l+0.5)/thePtBins*(thePtMax-thePtMin);
-	    if (ptsum<ptthr) hEffVsPtArray[n]->Fill(ptthr);
-	  }
-	}
+
+      for (unsigned int j = 0; j < theConeCases.size(); j++) {
+        float ptsum = dep.depositWithin(theConeCases[j]);
+        for (unsigned int k = 0; k < theCuts.size(); k++) {
+          unsigned int n = theCuts.size() * j + k;
+          if (fabs(tk->eta()) < theCuts[k].etaRange.min())
+            continue;
+          if (fabs(tk->eta()) > theCuts[k].etaRange.max())
+            continue;
+          hEffVsPtArray[n]->Fill(thePtMax + 999.);
+          for (unsigned int l = 0; l < thePtBins; l++) {
+            float ptthr = thePtMin + (l + 0.5) / thePtBins * (thePtMax - thePtMin);
+            if (ptsum < ptthr)
+              hEffVsPtArray[n]->Fill(ptthr);
+          }
+        }
       }
     }
-
   }
-  Puts("L3MuonIsolationAnalyzer>>> Run: %llu, Event %llu, number of muons %d"
-                 , event.id().run(), event.id().event(), depMap->size());
+  Puts("L3MuonIsolationAnalyzer>>> Run: %llu, Event %llu, number of muons %d",
+       event.id().run(),
+       event.id().event(),
+       depMap->size());
 }
 
 void L3MuonIsolationAnalyzer::Puts(const char* va_(fmt), ...) {
-      // Do not write more than 256 characters
-      const unsigned int bufsize = 256; 
-      char chout[bufsize] = "";
-      va_list ap;
-      va_start(ap, va_(fmt));
-      vsnprintf(chout, bufsize, va_(fmt), ap);
-      va_end(ap);
-      LogVerbatim("") << chout;
+  // Do not write more than 256 characters
+  const unsigned int bufsize = 256;
+  char chout[bufsize] = "";
+  va_list ap;
+  va_start(ap, va_(fmt));
+  vsnprintf(chout, bufsize, va_(fmt), ap);
+  va_end(ap);
+  LogVerbatim("") << chout;
 }
 
 DEFINE_FWK_MODULE(L3MuonIsolationAnalyzer);

--- a/RecoMuon/L3MuonIsolationProducer/test/L3MuonIsolationAnalyzer.h
+++ b/RecoMuon/L3MuonIsolationProducer/test/L3MuonIsolationAnalyzer.h
@@ -14,13 +14,13 @@ namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class TFile;
 class TH1F;
 class TH2F;
 
-class L3MuonIsolationAnalyzer: public edm::EDAnalyzer {
+class L3MuonIsolationAnalyzer : public edm::EDAnalyzer {
 public:
   /// Constructor
   L3MuonIsolationAnalyzer(const edm::ParameterSet& pset);
@@ -29,10 +29,10 @@ public:
   virtual ~L3MuonIsolationAnalyzer();
 
   // Operations
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
 
-  virtual void beginJob() ;
-  virtual void endJob() ;
+  virtual void beginJob();
+  virtual void endJob();
 
 private:
   void Puts(const char* fmt, ...);
@@ -58,15 +58,13 @@ private:
   FILE* theTxtFile;
 
   // Histograms
-  TH1F *hPtSum;
-  TH1F *hEffVsCone;
-  TH1F *hEffVsPt;
+  TH1F* hPtSum;
+  TH1F* hEffVsCone;
+  TH1F* hEffVsPt;
   std::vector<TH1F*> hEffVsPtArray;
 
   // Counters and vectors
   unsigned int numberOfEvents;
   unsigned int numberOfMuons;
-  
 };
 #endif
-

--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducer.cc
@@ -24,7 +24,6 @@
 
 #include "RecoMuon/L3MuonProducer/src/L3MuonCandidateProducer.h"
 
-
 #include "DataFormats/Math/interface/deltaR.h"
 
 // Input and output collections
@@ -41,13 +40,13 @@ using namespace reco;
 static const char category[] = "Muon|RecoMuon|L3MuonCandidateProducer";
 
 /// constructor with config
-L3MuonCandidateProducer::L3MuonCandidateProducer(const ParameterSet& parameterSet){
-  LogTrace(category)<<" constructor called";
+L3MuonCandidateProducer::L3MuonCandidateProducer(const ParameterSet& parameterSet) {
+  LogTrace(category) << " constructor called";
 
   // StandAlone Collection Label
   theL3CollectionLabel = parameterSet.getParameter<InputTag>("InputObjects");
   trackToken_ = consumes<reco::TrackCollection>(theL3CollectionLabel);
- 
+
   // use links
   theUseLinks = parameterSet.existsAs<InputTag>("InputLinksObjects");
   if (theUseLinks) {
@@ -58,54 +57,59 @@ L3MuonCandidateProducer::L3MuonCandidateProducer(const ParameterSet& parameterSe
   }
 
   // use global, standalone or tracker pT/4-vector assignment
-  const std::string & muon_track_for_momentum = parameterSet.existsAs<std::string>("MuonPtOption") ?  parameterSet.getParameter<std::string>("MuonPtOption") : "Global";
+  const std::string& muon_track_for_momentum = parameterSet.existsAs<std::string>("MuonPtOption")
+                                                   ? parameterSet.getParameter<std::string>("MuonPtOption")
+                                                   : "Global";
   if (muon_track_for_momentum == std::string("Tracker"))
-    theType=InnerTrack;
+    theType = InnerTrack;
   else if (muon_track_for_momentum == std::string("Standalone"))
-    theType=OuterTrack;
+    theType = OuterTrack;
   else if (muon_track_for_momentum == std::string("Global"))
-    theType=CombinedTrack;
+    theType = CombinedTrack;
   else {
-    LogError(category)<<"invalid value for MuonPtOption, please choose among 'Tracker', 'Standalone', 'Global'";
-    theType=CombinedTrack;
+    LogError(category) << "invalid value for MuonPtOption, please choose among 'Tracker', 'Standalone', 'Global'";
+    theType = CombinedTrack;
   }
 
   produces<RecoChargedCandidateCollection>();
 }
 
 /// destructor
-L3MuonCandidateProducer::~L3MuonCandidateProducer(){
-  LogTrace(category)<<" L3MuonCandidateProducer destructor called";
+L3MuonCandidateProducer::~L3MuonCandidateProducer() {
+  LogTrace(category) << " L3MuonCandidateProducer destructor called";
 }
 
-
 /// reconstruct muons
-void L3MuonCandidateProducer::produce(StreamID, Event& event, const EventSetup& eventSetup) const{
+void L3MuonCandidateProducer::produce(StreamID, Event& event, const EventSetup& eventSetup) const {
   // Take the L3 container
-  LogTrace(category)<<" Taking the L3/GLB muons: "<<theL3CollectionLabel.label();
+  LogTrace(category) << " Taking the L3/GLB muons: " << theL3CollectionLabel.label();
   Handle<TrackCollection> tracks;
-  event.getByToken(trackToken_,tracks);
+  event.getByToken(trackToken_, tracks);
 
   edm::Handle<reco::MuonTrackLinksCollection> links;
   if (theUseLinks)
     event.getByToken(linkToken_, links);
 
   // Create a RecoChargedCandidate collection
-  LogTrace(category)<<" Creating the RecoChargedCandidate collection";
+  LogTrace(category) << " Creating the RecoChargedCandidate collection";
   auto candidates = std::make_unique<RecoChargedCandidateCollection>();
   LogDebug(category) << " size = " << tracks->size();
-  for (unsigned int i=0; i<tracks->size(); i++) {
-    TrackRef inRef(tracks,i);
+  for (unsigned int i = 0; i < tracks->size(); i++) {
+    TrackRef inRef(tracks, i);
     TrackRef tkRef = TrackRef();
 
     if (theUseLinks) {
-      for(reco::MuonTrackLinksCollection::const_iterator link = links->begin();
-          link != links->end(); ++link){ LogDebug(category) << " i = " << i;
+      for (reco::MuonTrackLinksCollection::const_iterator link = links->begin(); link != links->end(); ++link) {
+        LogDebug(category) << " i = " << i;
 
-        if (not link->trackerTrack().isNull()) LogTrace(category) << " link tk pt " << link->trackerTrack()->pt();
-        if (not link->standAloneTrack().isNull()) LogTrace(category) << " sta pt " << link->standAloneTrack()->pt();
-        if (not link->globalTrack().isNull()) LogTrace(category) << " global pt " << link->globalTrack()->pt();
-        if (not inRef.isNull()) LogTrace(category) << " inRef pt " << inRef->pt();
+        if (not link->trackerTrack().isNull())
+          LogTrace(category) << " link tk pt " << link->trackerTrack()->pt();
+        if (not link->standAloneTrack().isNull())
+          LogTrace(category) << " sta pt " << link->standAloneTrack()->pt();
+        if (not link->globalTrack().isNull())
+          LogTrace(category) << " global pt " << link->globalTrack()->pt();
+        if (not inRef.isNull())
+          LogTrace(category) << " inRef pt " << inRef->pt();
 
         if (link->globalTrack().isNull()) {
           edm::LogError(category) << "null reference to the global track";
@@ -113,15 +117,23 @@ void L3MuonCandidateProducer::produce(StreamID, Event& event, const EventSetup& 
           continue;
         }
 
-        float dR  = deltaR(inRef->eta(),inRef->phi(),link->globalTrack()->eta(),link->globalTrack()->phi());
-        float dPt = abs(inRef->pt() - link->globalTrack()->pt())/inRef->pt();
+        float dR = deltaR(inRef->eta(), inRef->phi(), link->globalTrack()->eta(), link->globalTrack()->phi());
+        float dPt = abs(inRef->pt() - link->globalTrack()->pt()) / inRef->pt();
         if (dR < 0.02 and dPt < 0.001) {
           LogTrace(category) << " *** pt matches *** ";
-          switch(theType) {
-            case InnerTrack:    tkRef = link->trackerTrack();    break;
-            case OuterTrack:    tkRef = link->standAloneTrack(); break;
-            case CombinedTrack: tkRef = link->globalTrack();     break;
-            default:            tkRef = link->globalTrack();     break;
+          switch (theType) {
+            case InnerTrack:
+              tkRef = link->trackerTrack();
+              break;
+            case OuterTrack:
+              tkRef = link->standAloneTrack();
+              break;
+            case CombinedTrack:
+              tkRef = link->globalTrack();
+              break;
+            default:
+              tkRef = link->globalTrack();
+              break;
           }
         }
       }
@@ -133,15 +145,18 @@ void L3MuonCandidateProducer::produce(StreamID, Event& event, const EventSetup& 
       // theUseLinks is false
       tkRef = inRef;
     }
-    LogDebug(category) << "tkRef Used For Momentum pt " << tkRef->pt() << " inRef from the input collection pt " << inRef->pt();
+    LogDebug(category) << "tkRef Used For Momentum pt " << tkRef->pt() << " inRef from the input collection pt "
+                       << inRef->pt();
 
     Particle::Charge q = tkRef->charge();
     Particle::LorentzVector p4(tkRef->px(), tkRef->py(), tkRef->pz(), tkRef->p());
-    Particle::Point vtx(tkRef->vx(),tkRef->vy(), tkRef->vz());
+    Particle::Point vtx(tkRef->vx(), tkRef->vy(), tkRef->vz());
 
     int pid = 13;
-    if(abs(q)==1) pid = q < 0 ? 13 : -13;
-    else LogWarning(category) << "L3MuonCandidate has charge = "<<q;
+    if (abs(q) == 1)
+      pid = q < 0 ? 13 : -13;
+    else
+      LogWarning(category) << "L3MuonCandidate has charge = " << q;
     RecoChargedCandidate cand(q, p4, vtx, pid);
 
     //set the inRef as the RecoChargedCandidate ref so that the isolation maps
@@ -152,7 +167,6 @@ void L3MuonCandidateProducer::produce(StreamID, Event& event, const EventSetup& 
 
   event.put(std::move(candidates));
 
-  LogTrace(category)<<" Event loaded"
-                   <<"================================";
+  LogTrace(category) << " Event loaded"
+                     << "================================";
 }
-

--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducer.cc
@@ -53,7 +53,7 @@ L3MuonCandidateProducer::L3MuonCandidateProducer(const ParameterSet& parameterSe
   if (theUseLinks) {
     theL3LinksLabel = parameterSet.getParameter<InputTag>("InputLinksObjects");
     linkToken_ = consumes<reco::MuonTrackLinksCollection>(theL3LinksLabel);
-    if (theL3LinksLabel.label() == "" or theL3LinksLabel.label() == "unused")
+    if (theL3LinksLabel.label().empty() or theL3LinksLabel.label() == "unused")
       theUseLinks = false;
   }
 

--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducer.h
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducer.h
@@ -25,33 +25,34 @@
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class L3MuonCandidateProducer : public edm::global::EDProducer<> {
-
- public:
-  enum MuonTrackType {InnerTrack, OuterTrack, CombinedTrack};
+public:
+  enum MuonTrackType { InnerTrack, OuterTrack, CombinedTrack };
 
   /// constructor with config
   L3MuonCandidateProducer(const edm::ParameterSet&);
-  
+
   /// destructor
-  ~L3MuonCandidateProducer() override; 
-  
+  ~L3MuonCandidateProducer() override;
+
   /// produce candidates
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
- private:
+private:
   // L3/GLB Collection Label
-  edm::InputTag theL3CollectionLabel; 
-  edm::InputTag theL3LinksLabel; 
+  edm::InputTag theL3CollectionLabel;
+  edm::InputTag theL3LinksLabel;
   edm::EDGetTokenT<reco::TrackCollection> trackToken_;
   edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;
 
   enum MuonTrackType theType;
   bool theUseLinks;
-
-
 };
 
 #endif

--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.cc
@@ -21,7 +21,6 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 
-
 #include <string>
 
 using namespace edm;
@@ -31,47 +30,45 @@ using namespace reco;
 static const std::string category("Muon|RecoMuon|L3MuonCandidateProducerFromMuons");
 
 /// constructor with config
-L3MuonCandidateProducerFromMuons::L3MuonCandidateProducerFromMuons(const ParameterSet& parameterSet) :
-  m_L3CollectionLabel( parameterSet.getParameter<InputTag>("InputObjects") )       // standAlone Collection Label
+L3MuonCandidateProducerFromMuons::L3MuonCandidateProducerFromMuons(const ParameterSet& parameterSet)
+    : m_L3CollectionLabel(parameterSet.getParameter<InputTag>("InputObjects"))  // standAlone Collection Label
 {
   muonToken_ = consumes<reco::MuonCollection>(m_L3CollectionLabel);
-  LogTrace(category)<<" constructor called";
+  LogTrace(category) << " constructor called";
   produces<RecoChargedCandidateCollection>();
 }
 
 /// destructor
-L3MuonCandidateProducerFromMuons::~L3MuonCandidateProducerFromMuons(){
-  LogTrace(category)<<" L3MuonCandidateProducerFromMuons destructor called";
+L3MuonCandidateProducerFromMuons::~L3MuonCandidateProducerFromMuons() {
+  LogTrace(category) << " L3MuonCandidateProducerFromMuons destructor called";
 }
-
 
 /// reconstruct muons
 void L3MuonCandidateProducerFromMuons::produce(StreamID, Event& event, const EventSetup& eventSetup) const {
   // Create a RecoChargedCandidate collection
-  LogTrace(category)<<" Creating the RecoChargedCandidate collection";
+  LogTrace(category) << " Creating the RecoChargedCandidate collection";
   auto candidates = std::make_unique<RecoChargedCandidateCollection>();
 
   // Take the L3 container
-  LogTrace(category)<<" Taking the L3/GLB muons: "<<m_L3CollectionLabel.label();
+  LogTrace(category) << " Taking the L3/GLB muons: " << m_L3CollectionLabel.label();
   Handle<reco::MuonCollection> muons;
-  event.getByToken(muonToken_,muons);
+  event.getByToken(muonToken_, muons);
 
   if (not muons.isValid()) {
     LogError(category) << muons.whyFailed()->what();
-  } else { 
-    for (unsigned int i=0; i<muons->size(); i++) {
-      
-      // avoids crashing in case the muon is SA only. 
-      TrackRef tkref = ((*muons)[i].innerTrack().isNonnull())? (*muons)[i].innerTrack() : (*muons)[i].muonBestTrack();
-      
+  } else {
+    for (unsigned int i = 0; i < muons->size(); i++) {
+      // avoids crashing in case the muon is SA only.
+      TrackRef tkref = ((*muons)[i].innerTrack().isNonnull()) ? (*muons)[i].innerTrack() : (*muons)[i].muonBestTrack();
+
       Particle::Charge q = tkref->charge();
       Particle::LorentzVector p4(tkref->px(), tkref->py(), tkref->pz(), tkref->p());
-      Particle::Point vtx(tkref->vx(),tkref->vy(), tkref->vz());
+      Particle::Point vtx(tkref->vx(), tkref->vy(), tkref->vz());
 
       int pid = 13;
-      if (abs(q)==1) 
+      if (abs(q) == 1)
         pid = q < 0 ? 13 : -13;
-      else 
+      else
         LogWarning(category) << "L3MuonCandidate has charge = " << q;
       RecoChargedCandidate cand(q, p4, vtx, pid);
 

--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.h
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.h
@@ -15,25 +15,26 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class L3MuonCandidateProducerFromMuons : public edm::global::EDProducer<> {
-
- public:
-
+public:
   /// constructor with config
   L3MuonCandidateProducerFromMuons(const edm::ParameterSet&);
-  
+
   /// destructor
-  ~L3MuonCandidateProducerFromMuons() override; 
-  
+  ~L3MuonCandidateProducerFromMuons() override;
+
   /// produce candidates
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-  
- private:
-  
+
+private:
   // L3/GLB Collection Label
-  edm::InputTag m_L3CollectionLabel; 
+  edm::InputTag m_L3CollectionLabel;
   edm::EDGetTokenT<reco::MuonCollection> muonToken_;
 };
 

--- a/RecoMuon/L3MuonProducer/src/L3MuonCleaner.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCleaner.cc
@@ -12,22 +12,20 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 class L3MuonCleaner : public edm::global::EDProducer<> {
- public:
+public:
   L3MuonCleaner(const edm::ParameterSet&);
-  ~L3MuonCleaner() override{}
+  ~L3MuonCleaner() override {}
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
- private:
-  edm::InputTag m_input; 
+
+private:
+  edm::InputTag m_input;
   int m_minTrkHits;
   int m_minMuonHits;
   double m_maxNormalizedChi2;
   edm::EDGetTokenT<reco::TrackCollection> inputToken_;
-
-
-
 };
 
-L3MuonCleaner::L3MuonCleaner(const edm::ParameterSet& parameterSet){
+L3MuonCleaner::L3MuonCleaner(const edm::ParameterSet& parameterSet) {
   m_input = parameterSet.getParameter<edm::InputTag>("input");
   m_minTrkHits = parameterSet.getParameter<int>("minTrkHits");
   m_minMuonHits = parameterSet.getParameter<int>("minMuonHits");
@@ -37,14 +35,17 @@ L3MuonCleaner::L3MuonCleaner(const edm::ParameterSet& parameterSet){
   produces<reco::TrackCollection>();
 }
 
-void L3MuonCleaner::produce(edm::StreamID, edm::Event& event, const edm::EventSetup&) const{
-  edm::Handle<reco::TrackCollection> tracks; 
-  event.getByToken(inputToken_,tracks);
+void L3MuonCleaner::produce(edm::StreamID, edm::Event& event, const edm::EventSetup&) const {
+  edm::Handle<reco::TrackCollection> tracks;
+  event.getByToken(inputToken_, tracks);
   auto outTracks = std::make_unique<reco::TrackCollection>();
-  for ( reco::TrackCollection::const_iterator trk=tracks->begin(); trk!=tracks->end(); ++trk ){
-    if (trk->normalizedChi2()>m_maxNormalizedChi2) continue;
-    if (trk->hitPattern().numberOfValidTrackerHits()<m_minTrkHits) continue;
-    if (trk->hitPattern().numberOfValidMuonHits()<m_minMuonHits) continue;
+  for (reco::TrackCollection::const_iterator trk = tracks->begin(); trk != tracks->end(); ++trk) {
+    if (trk->normalizedChi2() > m_maxNormalizedChi2)
+      continue;
+    if (trk->hitPattern().numberOfValidTrackerHits() < m_minTrkHits)
+      continue;
+    if (trk->hitPattern().numberOfValidMuonHits() < m_minMuonHits)
+      continue;
     outTracks->push_back(*trk);
   }
   event.put(std::move(outTracks));

--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
@@ -25,7 +25,6 @@
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
 
-
 using namespace edm;
 using namespace std;
 
@@ -33,7 +32,6 @@ using namespace std;
 // constructor with config
 //
 L3MuonProducer::L3MuonProducer(const ParameterSet& parameterSet) {
-
   LogTrace("L3MuonProducer") << "constructor called" << endl;
 
   // Parameter set for the Builder
@@ -42,7 +40,7 @@ L3MuonProducer::L3MuonProducer(const ParameterSet& parameterSet) {
   // L2 Muon Collection Label
   theL2CollectionLabel = parameterSet.getParameter<InputTag>("MuonCollectionLabel");
   l2MuonToken_ = consumes<reco::TrackCollection>(theL2CollectionLabel);
-  l2MuonTrajToken_ = consumes<std::vector<Trajectory> >(theL2CollectionLabel.label());
+  l2MuonTrajToken_ = consumes<std::vector<Trajectory>>(theL2CollectionLabel.label());
   l2AssoMapToken_ = consumes<TrajTrackAssociationCollection>(theL2CollectionLabel.label());
   updatedL2AssoMapToken_ = consumes<reco::TrackToTrackMap>(theL2CollectionLabel.label());
 
@@ -57,48 +55,46 @@ L3MuonProducer::L3MuonProducer(const ParameterSet& parameterSet) {
   ConsumesCollector iC = consumesCollector();
 
   // instantiate the concrete trajectory builder in the Track Finder
-  MuonTrackLoader* mtl = new MuonTrackLoader(trackLoaderParameters,iC,theService);
-  L3MuonTrajectoryBuilder* l3mtb = new L3MuonTrajectoryBuilder(trajectoryBuilderParameters, theService,iC);
+  MuonTrackLoader* mtl = new MuonTrackLoader(trackLoaderParameters, iC, theService);
+  L3MuonTrajectoryBuilder* l3mtb = new L3MuonTrajectoryBuilder(trajectoryBuilderParameters, theService, iC);
   theTrackFinder = new MuonTrackFinder(l3mtb, mtl);
 
-  theL2SeededTkLabel = trackLoaderParameters.getUntrackedParameter<std::string>("MuonSeededTracksInstance",std::string());
+  theL2SeededTkLabel =
+      trackLoaderParameters.getUntrackedParameter<std::string>("MuonSeededTracksInstance", std::string());
 
   produces<reco::TrackCollection>(theL2SeededTkLabel);
   produces<TrackingRecHitCollection>(theL2SeededTkLabel);
   produces<reco::TrackExtraCollection>(theL2SeededTkLabel);
-  produces<vector<Trajectory> >(theL2SeededTkLabel) ;
+  produces<vector<Trajectory>>(theL2SeededTkLabel);
   produces<TrajTrackAssociationCollection>(theL2SeededTkLabel);
 
   produces<reco::TrackCollection>();
   produces<TrackingRecHitCollection>();
   produces<reco::TrackExtraCollection>();
-  produces<vector<Trajectory> >() ;
+  produces<vector<Trajectory>>();
   produces<TrajTrackAssociationCollection>();
 
   produces<reco::MuonTrackLinksCollection>();
-
 }
-
 
 //
 // destructor
 //
 L3MuonProducer::~L3MuonProducer() {
-
   LogTrace("L3MuonProducer") << "destructor called" << endl;
-  if (theService) delete theService;
-  if (theTrackFinder) delete theTrackFinder;
-
+  if (theService)
+    delete theService;
+  if (theTrackFinder)
+    delete theTrackFinder;
 }
-
 
 //
 // reconstruct muons
 //
 void L3MuonProducer::produce(Event& event, const EventSetup& eventSetup) {
   const string metname = "Muon|RecoMuon|L3MuonProducer";
-  LogTrace(metname)<<endl<<endl<<endl;
-  LogTrace(metname)<<"L3 Muon Reconstruction started"<<endl;
+  LogTrace(metname) << endl << endl << endl;
+  LogTrace(metname) << "L3 Muon Reconstruction started" << endl;
 
   typedef vector<Trajectory> TrajColl;
 
@@ -106,68 +102,66 @@ void L3MuonProducer::produce(Event& event, const EventSetup& eventSetup) {
   theService->update(eventSetup);
 
   // Take the L2 muon container(s)
-  LogTrace(metname)<<"Taking the L2 Muons "<<theL2CollectionLabel<<endl;
-
+  LogTrace(metname) << "Taking the L2 Muons " << theL2CollectionLabel << endl;
 
   Handle<reco::TrackCollection> L2Muons;
-  event.getByToken(l2MuonToken_,L2Muons);
+  event.getByToken(l2MuonToken_, L2Muons);
 
-  Handle<vector<Trajectory> > L2MuonsTraj;
+  Handle<vector<Trajectory>> L2MuonsTraj;
   vector<MuonTrajectoryBuilder::TrackCand> L2TrackCands;
-
 
   event.getByToken(l2MuonTrajToken_, L2MuonsTraj);
 
   edm::Handle<TrajTrackAssociationCollection> L2AssoMap;
-  event.getByToken(l2AssoMapToken_,L2AssoMap);
+  event.getByToken(l2AssoMapToken_, L2AssoMap);
 
   edm::Handle<reco::TrackToTrackMap> updatedL2AssoMap;
-  event.getByToken(updatedL2AssoMapToken_,updatedL2AssoMap);
+  event.getByToken(updatedL2AssoMapToken_, updatedL2AssoMap);
 
-
-
-  for(TrajTrackAssociationCollection::const_iterator it = L2AssoMap->begin(); it != L2AssoMap->end(); ++it){
-    const Ref<vector<Trajectory> > traj = it->key;
-    const reco::TrackRef tkRegular  = it->val;
+  for (TrajTrackAssociationCollection::const_iterator it = L2AssoMap->begin(); it != L2AssoMap->end(); ++it) {
+    const Ref<vector<Trajectory>> traj = it->key;
+    const reco::TrackRef tkRegular = it->val;
     reco::TrackRef tkUpdated;
     reco::TrackToTrackMap::const_iterator iEnd;
     reco::TrackToTrackMap::const_iterator iii;
-    if ( theL2CollectionLabel.instance() == "UpdatedAtVtx") {
+    if (theL2CollectionLabel.instance() == "UpdatedAtVtx") {
       iEnd = updatedL2AssoMap->end();
       iii = updatedL2AssoMap->find(it->val);
-      if (iii != iEnd ) tkUpdated = (*updatedL2AssoMap)[it->val] ;
+      if (iii != iEnd)
+        tkUpdated = (*updatedL2AssoMap)[it->val];
     }
 
-    const reco::TrackRef tk = ( tkUpdated.isNonnull() ) ? tkUpdated : tkRegular ;
+    const reco::TrackRef tk = (tkUpdated.isNonnull()) ? tkUpdated : tkRegular;
 
-    MuonTrajectoryBuilder::TrackCand L2Cand = MuonTrajectoryBuilder::TrackCand((Trajectory*)nullptr,tk);
-    if( traj->isValid() ) L2Cand.first = &*traj ;
+    MuonTrajectoryBuilder::TrackCand L2Cand = MuonTrajectoryBuilder::TrackCand((Trajectory*)nullptr, tk);
+    if (traj->isValid())
+      L2Cand.first = &*traj;
     L2TrackCands.push_back(L2Cand);
   }
 
   theTrackFinder->reconstruct(L2TrackCands, event, eventSetup);
 
-  LogTrace(metname)<<"Event loaded"
-                   <<"================================"
-                   <<endl<<endl;
-
+  LogTrace(metname) << "Event loaded"
+                    << "================================" << endl
+                    << endl;
 }
 
 void L3MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   {
     edm::ParameterSetDescription psd0;
-    psd0.addUntracked<std::vector<std::string>>("Propagators", {
-      "hltESPSmartPropagatorAny",
-      "SteppingHelixPropagatorAny",
-      "hltESPSmartPropagator",
-      "hltESPSteppingHelixPropagatorOpposite",
-    });
+    psd0.addUntracked<std::vector<std::string>>("Propagators",
+                                                {
+                                                    "hltESPSmartPropagatorAny",
+                                                    "SteppingHelixPropagatorAny",
+                                                    "hltESPSmartPropagator",
+                                                    "hltESPSteppingHelixPropagatorOpposite",
+                                                });
     psd0.add<bool>("RPCLayers", true);
     psd0.addUntracked<bool>("UseMuonNavigation", true);
     desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
   }
-  desc.add<edm::InputTag>("MuonCollectionLabel", edm::InputTag("hltL2Muons","UpdatedAtVtx"));
+  desc.add<edm::InputTag>("MuonCollectionLabel", edm::InputTag("hltL2Muons", "UpdatedAtVtx"));
   {
     edm::ParameterSetDescription psd0;
     psd0.addUntracked<bool>("PutTkTrackIntoEvent", false);
@@ -180,11 +174,12 @@ void L3MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
       edm::ParameterSetDescription psd1;
       psd1.add<double>("MaxChi2", 1000000.0);
       psd1.add<std::string>("Propagator", "hltESPSteppingHelixPropagatorOpposite");
-      psd1.add<std::vector<double>>("BeamSpotPositionErrors", {
-        0.1,
-        0.1,
-        5.3,
-      });
+      psd1.add<std::vector<double>>("BeamSpotPositionErrors",
+                                    {
+                                        0.1,
+                                        0.1,
+                                        5.3,
+                                    });
       psd0.add<edm::ParameterSetDescription>("MuonUpdatorAtVertexParameters", psd1);
     }
     psd0.add<bool>("VertexConstraint", false);
@@ -213,21 +208,22 @@ void L3MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
       psd1.add<edm::InputTag>("CSCRecSegmentLabel", edm::InputTag("hltCscSegments"));
       psd1.add<edm::InputTag>("GEMRecHitLabel", edm::InputTag("gemRecHits"));
       psd1.add<edm::InputTag>("ME0RecHitLabel", edm::InputTag("me0Segments"));
-      psd1.add<std::vector<int>>("DYTthrs", {
-        30,
-        15,
-      });
-      psd1.add<int>("DYTselector",1);
+      psd1.add<std::vector<int>>("DYTthrs",
+                                 {
+                                     30,
+                                     15,
+                                 });
+      psd1.add<int>("DYTselector", 1);
       psd1.add<bool>("DYTupdator", false);
-      psd1.add<bool>("DYTuseAPE", false );
+      psd1.add<bool>("DYTuseAPE", false);
       psd1.add<bool>("DYTuseThrsParametrization", true);
       {
         edm::ParameterSetDescription psd2;
-        psd2.add<std::vector<double>>("eta0p8", {1,-0.919853, 0.990742});
-        psd2.add<std::vector<double>>("eta1p2", {1,-0.897354, 0.987738});
-        psd2.add<std::vector<double>>("eta2p0", {1,-0.986855, 0.998516});
-        psd2.add<std::vector<double>>("eta2p2", {1,-0.940342, 0.992955});
-        psd2.add<std::vector<double>>("eta2p4", {1,-0.947633, 0.993762});
+        psd2.add<std::vector<double>>("eta0p8", {1, -0.919853, 0.990742});
+        psd2.add<std::vector<double>>("eta1p2", {1, -0.897354, 0.987738});
+        psd2.add<std::vector<double>>("eta2p0", {1, -0.986855, 0.998516});
+        psd2.add<std::vector<double>>("eta2p2", {1, -0.940342, 0.992955});
+        psd2.add<std::vector<double>>("eta2p4", {1, -0.947633, 0.993762});
         psd1.add<edm::ParameterSetDescription>("DYTthrsParameters", psd2);
       }
       psd1.add<double>("Chi2CutCSC", 150.0);
@@ -261,7 +257,7 @@ void L3MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
       psd1.add<double>("PhiR_UpperLimit_Par2", 0.2);
       psd1.add<edm::InputTag>("vertexCollection", edm::InputTag("pixelVertices"));
       psd1.add<bool>("Phi_fixed", true);
-      psd1.add<edm::InputTag>("input", edm::InputTag("hltL2Muons","UpdatedAtVtx"));
+      psd1.add<edm::InputTag>("input", edm::InputTag("hltL2Muons", "UpdatedAtVtx"));
       psd1.add<double>("DeltaR", 0.025);
       psd1.add<int>("OnDemand", -1);
       psd1.add<double>("DeltaZ", 24.2);
@@ -283,15 +279,15 @@ void L3MuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
     {
       edm::ParameterSetDescription psd1;
       TrackTransformer::fillPSetDescription(psd1,
-					    false, // do predictions only
-					    "hltESPL3MuKFTrajectoryFitter", // fitter
-					    "hltESPKFTrajectorySmootherForMuonTrackLoader", // smoother
-					    "hltESPSmartPropagatorAny", // propagator
-					    "insideOut", // refit direction
-					    true, // refit rpc hits
-					    "hltESPTTRHBWithTrackAngle", // tracker rechit builder
-					    "hltESPMuonTransientTrackingRecHitBuilder" // muon rechit builder
-					    );
+                                            false,                                           // do predictions only
+                                            "hltESPL3MuKFTrajectoryFitter",                  // fitter
+                                            "hltESPKFTrajectorySmootherForMuonTrackLoader",  // smoother
+                                            "hltESPSmartPropagatorAny",                      // propagator
+                                            "insideOut",                                     // refit direction
+                                            true,                                            // refit rpc hits
+                                            "hltESPTTRHBWithTrackAngle",                     // tracker rechit builder
+                                            "hltESPMuonTransientTrackingRecHitBuilder"       // muon rechit builder
+      );
       psd0.add<edm::ParameterSetDescription>("TrackTransformer", psd1);
     }
     {

--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.h
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.h
@@ -23,32 +23,33 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class MuonTrackFinder;
 class MuonServiceProxy;
 
 class L3MuonProducer : public edm::stream::EDProducer<> {
-
- public:
-
+public:
   /// constructor with config
   L3MuonProducer(const edm::ParameterSet&);
-  
+
   /// destructor
-  ~L3MuonProducer() override; 
-  
+  ~L3MuonProducer() override;
+
   /// reconstruct muons
   void produce(edm::Event&, const edm::EventSetup&) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
- private:
-    
+
+private:
   /// Seed STA Label
   edm::InputTag theL2CollectionLabel;
-  
+
   /// Label for L2SeededTracks
-  std::string theL2SeededTkLabel; 
+  std::string theL2SeededTkLabel;
 
   edm::EDGetTokenT<reco::TrackCollection> l2MuonToken_;
   edm::EDGetTokenT<std::vector<Trajectory> > l2MuonTrajToken_;
@@ -56,10 +57,9 @@ class L3MuonProducer : public edm::stream::EDProducer<> {
   edm::EDGetTokenT<reco::TrackToTrackMap> updatedL2AssoMapToken_;
 
   MuonTrackFinder* theTrackFinder;
-    
+
   /// the event setup proxy, it takes care the services update
-  MuonServiceProxy *theService;
-    
+  MuonServiceProxy* theService;
 };
 
 #endif

--- a/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
@@ -23,174 +23,192 @@ using namespace std;
 using namespace reco;
 
 /// constructor with config
-L3TkMuonProducer::L3TkMuonProducer(const ParameterSet& parameterSet){
-  LogTrace("Muon|RecoMuon|L3TkMuonProducer")<<" constructor called";
+L3TkMuonProducer::L3TkMuonProducer(const ParameterSet& parameterSet) {
+  LogTrace("Muon|RecoMuon|L3TkMuonProducer") << " constructor called";
 
   // StandAlone Collection Label
   theL3CollectionLabel = parameterSet.getParameter<InputTag>("InputObjects");
-  trackToken_ = consumes<reco::TrackCollection>(theL3CollectionLabel); 
+  trackToken_ = consumes<reco::TrackCollection>(theL3CollectionLabel);
   produces<TrackCollection>();
   produces<TrackExtraCollection>();
   produces<TrackingRecHitCollection>();
 
-
-
-  callWhenNewProductsRegistered( [this](const edm::BranchDescription& iBD) {
-				   edm::TypeID id(typeid(L3MuonTrajectorySeedCollection));
-				   if(iBD.unwrappedTypeID() == id) {
-				     this->mayConsume<L3MuonTrajectorySeedCollection>(edm::InputTag{iBD.moduleLabel(), iBD.productInstanceName(),iBD.processName()} );
-				   }
-				 });
-
-
-
+  callWhenNewProductsRegistered([this](const edm::BranchDescription& iBD) {
+    edm::TypeID id(typeid(L3MuonTrajectorySeedCollection));
+    if (iBD.unwrappedTypeID() == id) {
+      this->mayConsume<L3MuonTrajectorySeedCollection>(
+          edm::InputTag{iBD.moduleLabel(), iBD.productInstanceName(), iBD.processName()});
+    }
+  });
 }
-  
+
 /// destructor
-L3TkMuonProducer::~L3TkMuonProducer(){
-  LogTrace("Muon|RecoMuon|L3TkMuonProducer")<<" L3TkMuonProducer destructor called";
+L3TkMuonProducer::~L3TkMuonProducer() {
+  LogTrace("Muon|RecoMuon|L3TkMuonProducer") << " L3TkMuonProducer destructor called";
 }
 
-bool L3TkMuonProducer::sharedSeed(const L3MuonTrajectorySeed& s1,const L3MuonTrajectorySeed& s2){
+bool L3TkMuonProducer::sharedSeed(const L3MuonTrajectorySeed& s1, const L3MuonTrajectorySeed& s2) {
   //quit right away on nH=0
-  if (s1.nHits()==0 || s2.nHits()==0) return false;
+  if (s1.nHits() == 0 || s2.nHits() == 0)
+    return false;
   //quit right away if not the same number of hits
-  if (s1.nHits()!=s2.nHits()) return false;
-  TrajectorySeed::range r1=s1.recHits();
-  TrajectorySeed::range r2=s2.recHits();
-  TrajectorySeed::const_iterator i1,i2;
-  TrajectorySeed::const_iterator & i1_e=r1.second,&i2_e=r2.second;
-  TrajectorySeed::const_iterator & i1_b=r1.first,&i2_b=r2.first;
+  if (s1.nHits() != s2.nHits())
+    return false;
+  TrajectorySeed::range r1 = s1.recHits();
+  TrajectorySeed::range r2 = s2.recHits();
+  TrajectorySeed::const_iterator i1, i2;
+  TrajectorySeed::const_iterator &i1_e = r1.second, &i2_e = r2.second;
+  TrajectorySeed::const_iterator &i1_b = r1.first, &i2_b = r2.first;
   //quit right away if first detId does not match. front exist because of ==0 ->quit test
-  if(i1_b->geographicalId() != i2_b->geographicalId()) return false;
+  if (i1_b->geographicalId() != i2_b->geographicalId())
+    return false;
   //then check hit by hit if they are the same
-  for (i1=i1_b,i2=i2_b;i1!=i1_e && i2!=i2_e;++i1,++i2){
-    if (!i1->sharesInput(&(*i2),TrackingRecHit::all)) return false;
+  for (i1 = i1_b, i2 = i2_b; i1 != i1_e && i2 != i2_e; ++i1, ++i2) {
+    if (!i1->sharesInput(&(*i2), TrackingRecHit::all))
+      return false;
   }
   return true;
 }
 
-string printvector(const vector<TrackRef> & v){
+string printvector(const vector<TrackRef>& v) {
   std::stringstream ss;
-  for (unsigned int i=0;i!=v.size();++i) {
-    if (i!=0) ss<<"\n";
-    ss<<"track with ref: "<<v[i].id().id()<<":"<<v[i].key()
-      <<" and pT: "<<v[i]->pt()
-      <<" with seedRef: "<<v[i]->seedRef().id().id()<<":"<<v[i]->seedRef().key();
+  for (unsigned int i = 0; i != v.size(); ++i) {
+    if (i != 0)
+      ss << "\n";
+    ss << "track with ref: " << v[i].id().id() << ":" << v[i].key() << " and pT: " << v[i]->pt()
+       << " with seedRef: " << v[i]->seedRef().id().id() << ":" << v[i]->seedRef().key();
   }
   return ss.str();
 }
 
-string printvector(const vector<L3TkMuonProducer::SeedRef> & v){
+string printvector(const vector<L3TkMuonProducer::SeedRef>& v) {
   std::stringstream ss;
-  for (unsigned int i=0;i!=v.size();++i){
-    if (i!=0) ss<<"\n";
-    ss<<"seed ref: "<<v[i].id().id()<<":"<<v[i].key();
+  for (unsigned int i = 0; i != v.size(); ++i) {
+    if (i != 0)
+      ss << "\n";
+    ss << "seed ref: " << v[i].id().id() << ":" << v[i].key();
     if (v[i]->l2Track().isNull())
-      ss<<" and pT: "<<v[i]->l1Particle()->pt()<<" of L1: "<<v[i]->l1Particle().id().id()<<":"<<v[i]->l1Particle().key();
-    else 
-      ss<<" and pT: "<<v[i]->l2Track()->pt()<<" of L2: "<<v[i]->l2Track().id().id()<<":"<<v[i]->l2Track().key();
+      ss << " and pT: " << v[i]->l1Particle()->pt() << " of L1: " << v[i]->l1Particle().id().id() << ":"
+         << v[i]->l1Particle().key();
+    else
+      ss << " and pT: " << v[i]->l2Track()->pt() << " of L2: " << v[i]->l2Track().id().id() << ":"
+         << v[i]->l2Track().key();
   }
   return ss.str();
 }
 
-string printseed(const L3TkMuonProducer::SeedRef & s){
+string printseed(const L3TkMuonProducer::SeedRef& s) {
   std::stringstream ss;
-  ss<<" seed ref: "<<s.id().id()<<":"<<s.key()<<" has "<< s->nHits()<<"rechits";
-  TrajectorySeed::range r=s->recHits();
-  TrajectorySeed::const_iterator it=r.first;
-  for (;it!=r.second;++it)
-    ss<<"\n detId: " << std::hex <<it->geographicalId().rawId() << std::dec <<" position: "<<it->localPosition()<<" and error: "<<it->localPositionError();
+  ss << " seed ref: " << s.id().id() << ":" << s.key() << " has " << s->nHits() << "rechits";
+  TrajectorySeed::range r = s->recHits();
+  TrajectorySeed::const_iterator it = r.first;
+  for (; it != r.second; ++it)
+    ss << "\n detId: " << std::hex << it->geographicalId().rawId() << std::dec << " position: " << it->localPosition()
+       << " and error: " << it->localPositionError();
   return ss.str();
 }
 
 /// reconstruct muons
 void L3TkMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
   const string metname = "Muon|RecoMuon|L3TkMuonProducer";
-  
+
   // Take the L3 container
-  LogDebug(metname)<<" Taking the L3/GLB muons: "<<theL3CollectionLabel.label();
-  Handle<TrackCollection> tracks; 
-  event.getByToken(trackToken_,tracks);
+  LogDebug(metname) << " Taking the L3/GLB muons: " << theL3CollectionLabel.label();
+  Handle<TrackCollection> tracks;
+  event.getByToken(trackToken_, tracks);
 
   //make the LX->L3s pools
   LXtoL3sMap LXtoL3s;
 
   unsigned int maxI = tracks->size();
-  bool gotL3seeds=false;
+  bool gotL3seeds = false;
   edm::Handle<L3MuonTrajectorySeedCollection> l3seeds;
 
   //make a list of reference to tracker tracks
   vector<TrackRef> orderedTrackTracks(maxI);
-  for (unsigned int i=0;i!=maxI;i++) orderedTrackTracks[i]=TrackRef(tracks,i);
-  LogDebug(metname)<<"vector of L3 tracks before ordering:\n"<<printvector(orderedTrackTracks);
+  for (unsigned int i = 0; i != maxI; i++)
+    orderedTrackTracks[i] = TrackRef(tracks, i);
+  LogDebug(metname) << "vector of L3 tracks before ordering:\n" << printvector(orderedTrackTracks);
   //order them in pT
-  sort(orderedTrackTracks.begin(),orderedTrackTracks.end(),trackRefBypT);
-  LogDebug(metname)<<"vector of L3 tracks after ordering:\n"<<printvector(orderedTrackTracks);
+  sort(orderedTrackTracks.begin(), orderedTrackTracks.end(), trackRefBypT);
+  LogDebug(metname) << "vector of L3 tracks after ordering:\n" << printvector(orderedTrackTracks);
   //loop over then
-  for (unsigned int i=0;i!=maxI;i++) {
-    TrackRef & tk=orderedTrackTracks[i];  
+  for (unsigned int i = 0; i != maxI; i++) {
+    TrackRef& tk = orderedTrackTracks[i];
     SeedRef l3seedRef = tk->seedRef().castTo<SeedRef>();
 
-    vector<SeedRef> allPossibleOrderedLx; // with identical hit-set
+    vector<SeedRef> allPossibleOrderedLx;  // with identical hit-set
     //add the direct relation
     allPossibleOrderedLx.push_back(l3seedRef);
-    LogDebug(metname)<<"adding the seed ref: "<<l3seedRef.id().id()<<":"<<l3seedRef.key()<<" for this tracker track: "<<tk.id().id()<<":"<<tk.key();
+    LogDebug(metname) << "adding the seed ref: " << l3seedRef.id().id() << ":" << l3seedRef.key()
+                      << " for this tracker track: " << tk.id().id() << ":" << tk.key();
 
     //add the relations due to shared seeds
     //check whether there is a "shared" seed in addition
-    if (!gotL3seeds){
+    if (!gotL3seeds) {
       //need to fetch the handle from the ref
-      const edm::Provenance & seedsProv=event.getProvenance(l3seedRef.id());
+      const edm::Provenance& seedsProv = event.getProvenance(l3seedRef.id());
       edm::InputTag l3seedsTag(seedsProv.moduleLabel(), seedsProv.productInstanceName(), seedsProv.processName());
       event.getByLabel(l3seedsTag, l3seeds);
-      gotL3seeds=true;
-      LogDebug(metname)<<"got seeds handle from: "<<l3seedsTag;
+      gotL3seeds = true;
+      LogDebug(metname) << "got seeds handle from: " << l3seedsTag;
     }
     //loop the other seeds in the collection
-    for (unsigned int iS=0;iS!=l3seeds->size();++iS){
-      const L3MuonTrajectorySeed & seed = (*l3seeds)[iS];
-      const L3MuonTrajectorySeed & thisSeed = *l3seedRef;
-      if (l3seedRef.key()==iS) continue; //not care about this one
+    for (unsigned int iS = 0; iS != l3seeds->size(); ++iS) {
+      const L3MuonTrajectorySeed& seed = (*l3seeds)[iS];
+      const L3MuonTrajectorySeed& thisSeed = *l3seedRef;
+      if (l3seedRef.key() == iS)
+        continue;  //not care about this one
       //compare this seed with the seed in the collection
-      if (sharedSeed(seed,thisSeed)){
-	SeedRef thisSharedSeedRef(l3seeds,iS);
-	LogDebug(metname)<<"shared seeds: \n"<<printseed(l3seedRef)<<" and: \n"<<printseed(thisSharedSeedRef)
-			 <<"\nadding ANOTHER seed ref: "<<thisSharedSeedRef.id().id()<<":"<<thisSharedSeedRef.key()<<" for this tracker track: "<<tk.id().id()<<":"<<tk.key();
-	//	edm::LogError(metname)<<" we have a shared seed right there.";
-	allPossibleOrderedLx.push_back(thisSharedSeedRef);
-      }//seed is shared
-    }//loop all other existing seed for overlaps
+      if (sharedSeed(seed, thisSeed)) {
+        SeedRef thisSharedSeedRef(l3seeds, iS);
+        LogDebug(metname) << "shared seeds: \n"
+                          << printseed(l3seedRef) << " and: \n"
+                          << printseed(thisSharedSeedRef)
+                          << "\nadding ANOTHER seed ref: " << thisSharedSeedRef.id().id() << ":"
+                          << thisSharedSeedRef.key() << " for this tracker track: " << tk.id().id() << ":" << tk.key();
+        //	edm::LogError(metname)<<" we have a shared seed right there.";
+        allPossibleOrderedLx.push_back(thisSharedSeedRef);
+      }  //seed is shared
+    }    //loop all other existing seed for overlaps
 
     //now you have the full list of Lx objects that have seed this tracker track.
     // order the list in pT of Lx objects
-    LogDebug(metname)<<"list of possible Lx objects for tracker track: "<<tk.id().id()<<":"<<tk.key()<<" before ordering\n"<<printvector(allPossibleOrderedLx);
-    sort(allPossibleOrderedLx.begin(),allPossibleOrderedLx.end(),seedRefBypT);
-    LogDebug(metname)<<"list of possible Lx objects for tracker track: "<<tk.id().id()<<":"<<tk.key()<<" after ordering\n"<<printvector(allPossibleOrderedLx);
+    LogDebug(metname) << "list of possible Lx objects for tracker track: " << tk.id().id() << ":" << tk.key()
+                      << " before ordering\n"
+                      << printvector(allPossibleOrderedLx);
+    sort(allPossibleOrderedLx.begin(), allPossibleOrderedLx.end(), seedRefBypT);
+    LogDebug(metname) << "list of possible Lx objects for tracker track: " << tk.id().id() << ":" << tk.key()
+                      << " after ordering\n"
+                      << printvector(allPossibleOrderedLx);
     // assign this tracker track to the highest pT Lx.
-    for (unsigned int iL=0;iL!=allPossibleOrderedLx.size();++iL){
-      SeedRef thisRef=allPossibleOrderedLx[iL];
+    for (unsigned int iL = 0; iL != allPossibleOrderedLx.size(); ++iL) {
+      SeedRef thisRef = allPossibleOrderedLx[iL];
       pseudoRef ref = makePseudoRef(*thisRef);
-      LogDebug(metname)<<"seed ref: "<<thisRef.id().id()<<":"<<thisRef.key()<<" transcribe to pseudoref: "<<ref.first<<":"<<ref.second;
-      LXtoL3sMap::iterator f=LXtoL3s.find(ref);
-      if (f!=LXtoL3s.end()){
-	//there's already an entry. because of the prior ordering in pT of the tracker track refs
-	// the track ref already there *has* a higher pT: this one cannot compete and should be assigned to the next Lx;
-	LogDebug(metname)<<"this tracker track: "<<tk.id().id()<<":"<<tk.key()<<" ("<< tk->pt()<<")"
-			 <<"\n cannot compete in pT with track: "<<f->second.first.id().id()<<":"<<f->second.first.key()<<" ("<<f->second.first->pt()<<")"
-			 <<"\n already assigned to pseudo ref: "<<ref.first<<":"<<ref.second<<" which corresponds to seedRef: "<<f->second.second.id().id()<<":"<<f->second.second.key();
-	continue;
-      }else{
-	//there was no entry yet. make the assignement
-	LogDebug(metname)<<"this tracker track: "<<tk.id().id()<<":"<<tk.key()
-			 <<" is assigned to pseudo ref: "<<ref.first<<":"<<ref.second<<" which corresponds to seedRef: "<<thisRef.id().id()<<":"<<thisRef.key();
-	LXtoL3s[ref] = std::make_pair(tk,thisRef);
-	//once assigned. break
-	break;
+      LogDebug(metname) << "seed ref: " << thisRef.id().id() << ":" << thisRef.key()
+                        << " transcribe to pseudoref: " << ref.first << ":" << ref.second;
+      LXtoL3sMap::iterator f = LXtoL3s.find(ref);
+      if (f != LXtoL3s.end()) {
+        //there's already an entry. because of the prior ordering in pT of the tracker track refs
+        // the track ref already there *has* a higher pT: this one cannot compete and should be assigned to the next Lx;
+        LogDebug(metname) << "this tracker track: " << tk.id().id() << ":" << tk.key() << " (" << tk->pt() << ")"
+                          << "\n cannot compete in pT with track: " << f->second.first.id().id() << ":"
+                          << f->second.first.key() << " (" << f->second.first->pt() << ")"
+                          << "\n already assigned to pseudo ref: " << ref.first << ":" << ref.second
+                          << " which corresponds to seedRef: " << f->second.second.id().id() << ":"
+                          << f->second.second.key();
+        continue;
+      } else {
+        //there was no entry yet. make the assignement
+        LogDebug(metname) << "this tracker track: " << tk.id().id() << ":" << tk.key()
+                          << " is assigned to pseudo ref: " << ref.first << ":" << ref.second
+                          << " which corresponds to seedRef: " << thisRef.id().id() << ":" << thisRef.key();
+        LXtoL3s[ref] = std::make_pair(tk, thisRef);
+        //once assigned. break
+        break;
       }
-    }//loop possible Lx for possible assignement
-  }//loop over ordered list of tracker track refs
-
+    }  //loop possible Lx for possible assignement
+  }    //loop over ordered list of tracker track refs
 
   //prepare the output
   auto outTracks = std::make_unique<TrackCollection>(LXtoL3s.size());
@@ -199,43 +217,48 @@ void L3TkMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
   auto outRecHits = std::make_unique<TrackingRecHitCollection>();
   TrackingRecHitRefProd rHits = event.getRefBeforePut<TrackingRecHitCollection>();
 
-  LogDebug(metname)<<"reading the map to make "<< LXtoL3s.size()<<"products.";
+  LogDebug(metname) << "reading the map to make " << LXtoL3s.size() << "products.";
   //fill the collection from the map
-  LXtoL3sMap::iterator f=LXtoL3s.begin();
-  unsigned int i=0;
-  for (;f!=LXtoL3s.end();++f,++i){
-
-    LogDebug(metname)<<"copy the track over, and make ref to extra";
-    const Track & trk = *(f->second.first);
+  LXtoL3sMap::iterator f = LXtoL3s.begin();
+  unsigned int i = 0;
+  for (; f != LXtoL3s.end(); ++f, ++i) {
+    LogDebug(metname) << "copy the track over, and make ref to extra";
+    const Track& trk = *(f->second.first);
     (*outTracks)[i] = Track(trk);
-    (*outTracks)[i].setExtra( TrackExtraRef(rTrackExtras,i));
+    (*outTracks)[i].setExtra(TrackExtraRef(rTrackExtras, i));
 
-    LogDebug(metname)<<"copy the trackExtra too, and change the seedref";
+    LogDebug(metname) << "copy the trackExtra too, and change the seedref";
     edm::RefToBase<TrajectorySeed> seedRef(f->second.second);
     //do not use the copy constructor, otherwise the hit Ref are still the same
-    (*outTrackExtras)[i] = TrackExtra(
-				      trk.outerPosition(), trk.outerMomentum(), trk.outerOk(),
-				      trk.innerPosition(), trk.innerMomentum(), trk.innerOk(),
-				      trk.outerStateCovariance(), trk.outerDetId(),
-				      trk.innerStateCovariance(), trk.innerDetId(),
-				      seedRef->direction(),seedRef
-				      );
+    (*outTrackExtras)[i] = TrackExtra(trk.outerPosition(),
+                                      trk.outerMomentum(),
+                                      trk.outerOk(),
+                                      trk.innerPosition(),
+                                      trk.innerMomentum(),
+                                      trk.innerOk(),
+                                      trk.outerStateCovariance(),
+                                      trk.outerDetId(),
+                                      trk.innerStateCovariance(),
+                                      trk.innerDetId(),
+                                      seedRef->direction(),
+                                      seedRef);
 
-    LogDebug(metname)<<"copy the hits too";
-    unsigned int iRH=0;
-    for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit,++iRH ) {
+    LogDebug(metname) << "copy the hits too";
+    unsigned int iRH = 0;
+    for (trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++hit, ++iRH) {
       outRecHits->push_back((*hit)->clone());
     }
-    (*outTrackExtras)[i].setHits( rHits, 0, iRH);
+    (*outTrackExtras)[i].setHits(rHits, 0, iRH);
   }
-  
-  LogDebug(metname)<<"made: "<<outTracks->size()<<" tracks, "<<outTrackExtras->size()<<" extras and "<<outRecHits->size()<<" rechits.";
+
+  LogDebug(metname) << "made: " << outTracks->size() << " tracks, " << outTrackExtras->size() << " extras and "
+                    << outRecHits->size() << " rechits.";
 
   //put the collection in the event
-  LogDebug(metname)<<"loading...";
+  LogDebug(metname) << "loading...";
   event.put(std::move(outTracks));
   event.put(std::move(outTrackExtras));
   event.put(std::move(outRecHits));
-  LogDebug(metname)<<" Event loaded"
-		   <<"================================";
+  LogDebug(metname) << " Event loaded"
+                    << "================================";
 }

--- a/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.h
+++ b/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.h
@@ -9,7 +9,6 @@
  *   \author  J-R Vlimant.
  */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -19,65 +18,62 @@
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
 #include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
 
-
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class L3TkMuonProducer : public edm::stream::EDProducer<> {
-
- public:
-
+public:
   /// constructor with config
   L3TkMuonProducer(const edm::ParameterSet&);
-  
+
   /// destructor
-  ~L3TkMuonProducer() override; 
-  
+  ~L3TkMuonProducer() override;
+
   /// produce candidates
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   typedef edm::Ref<L3MuonTrajectorySeedCollection> SeedRef;
-  
- private:
-  
+
+private:
   // L3/GLB Collection Label
-  edm::InputTag theL3CollectionLabel; 
+  edm::InputTag theL3CollectionLabel;
   edm::EDGetTokenT<reco::TrackCollection> trackToken_;
 
-
-
   //psuedo ref is L2 or L1 ref.
-  typedef std::pair<unsigned int,unsigned int> pseudoRef;
-  typedef std::map<pseudoRef, std::pair<reco::TrackRef,SeedRef> > LXtoL3sMap;
+  typedef std::pair<unsigned int, unsigned int> pseudoRef;
+  typedef std::map<pseudoRef, std::pair<reco::TrackRef, SeedRef> > LXtoL3sMap;
 
-  pseudoRef makePseudoRef(const L3MuonTrajectorySeed& s){
+  pseudoRef makePseudoRef(const L3MuonTrajectorySeed& s) {
     reco::TrackRef l2ref = s.l2Track();
-    if (l2ref.isNull()){
+    if (l2ref.isNull()) {
       l1extra::L1MuonParticleRef l1ref = s.l1Particle();
-      return std::make_pair(l1ref.id().id(),l1ref.key());
-    }else return std::make_pair(l2ref.id().id(),l2ref.key());
+      return std::make_pair(l1ref.id().id(), l1ref.key());
+    } else
+      return std::make_pair(l2ref.id().id(), l2ref.key());
   }
 
-  bool sharedSeed(const L3MuonTrajectorySeed& s1,const L3MuonTrajectorySeed& s2);
-
+  bool sharedSeed(const L3MuonTrajectorySeed& s1, const L3MuonTrajectorySeed& s2);
 
   //ordering functions
-  static  bool seedRefBypT(const SeedRef & s1, const SeedRef & s2){
-    double pt1,pt2;
+  static bool seedRefBypT(const SeedRef& s1, const SeedRef& s2) {
+    double pt1, pt2;
     reco::TrackRef l2ref1 = s1->l2Track();
-    if (l2ref1.isNull()) pt1=s1->l1Particle()->pt();
-    else pt1=l2ref1->pt();
+    if (l2ref1.isNull())
+      pt1 = s1->l1Particle()->pt();
+    else
+      pt1 = l2ref1->pt();
     reco::TrackRef l2ref2 = s2->l2Track();
-    if (l2ref2.isNull()) pt2=s2->l1Particle()->pt();
-    else pt2=l2ref2->pt();
-    return (pt1>pt2);
-  }
-  
-  static bool trackRefBypT(const reco::TrackRef & t1,const reco::TrackRef & t2){
-    return (t1->pt()>t2->pt());
+    if (l2ref2.isNull())
+      pt2 = s2->l1Particle()->pt();
+    else
+      pt2 = l2ref2->pt();
+    return (pt1 > pt2);
   }
 
-
-
+  static bool trackRefBypT(const reco::TrackRef& t1, const reco::TrackRef& t2) { return (t1->pt() > t2->pt()); }
 };
 
 #endif

--- a/RecoMuon/L3MuonProducer/src/QuarkoniaTrackSelector.cc
+++ b/RecoMuon/L3MuonProducer/src/QuarkoniaTrackSelector.cc
@@ -9,54 +9,49 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <memory>
 #include <iostream>
 #include <sstream>
 
-QuarkoniaTrackSelector::QuarkoniaTrackSelector(const edm::ParameterSet& iConfig) :
-  muonTag_(iConfig.getParameter<edm::InputTag>("muonCandidates")),
-  trackTag_(iConfig.getParameter<edm::InputTag>("tracks")),
-  minMasses_(iConfig.getParameter< std::vector<double> >("MinMasses")),
-  maxMasses_(iConfig.getParameter< std::vector<double> >("MaxMasses")),
-  checkCharge_(iConfig.getParameter<bool>("checkCharge")),
-  minTrackPt_(iConfig.getParameter<double>("MinTrackPt")),
-  minTrackP_(iConfig.getParameter<double>("MinTrackP")),
-  maxTrackEta_(iConfig.getParameter<double>("MaxTrackEta"))
-{
-
-
+QuarkoniaTrackSelector::QuarkoniaTrackSelector(const edm::ParameterSet& iConfig)
+    : muonTag_(iConfig.getParameter<edm::InputTag>("muonCandidates")),
+      trackTag_(iConfig.getParameter<edm::InputTag>("tracks")),
+      minMasses_(iConfig.getParameter<std::vector<double> >("MinMasses")),
+      maxMasses_(iConfig.getParameter<std::vector<double> >("MaxMasses")),
+      checkCharge_(iConfig.getParameter<bool>("checkCharge")),
+      minTrackPt_(iConfig.getParameter<double>("MinTrackPt")),
+      minTrackP_(iConfig.getParameter<double>("MinTrackP")),
+      maxTrackEta_(iConfig.getParameter<double>("MaxTrackEta")) {
   muonToken_ = consumes<reco::RecoChargedCandidateCollection>(muonTag_);
   trackToken_ = consumes<reco::TrackCollection>(trackTag_);
-
 
   //register your products
   produces<reco::TrackCollection>();
   //
   // verify mass windows
   //
-  bool massesValid = minMasses_.size()==maxMasses_.size();
-  if ( massesValid ) {
-    for ( size_t i=0; i<minMasses_.size(); ++i ) {
-      if ( minMasses_[i]<0 || maxMasses_[i]<0 || 
-	   minMasses_[i]>maxMasses_[i] )  massesValid = false;
+  bool massesValid = minMasses_.size() == maxMasses_.size();
+  if (massesValid) {
+    for (size_t i = 0; i < minMasses_.size(); ++i) {
+      if (minMasses_[i] < 0 || maxMasses_[i] < 0 || minMasses_[i] > maxMasses_[i])
+        massesValid = false;
     }
   }
-  if ( !massesValid ) {
+  if (!massesValid) {
     edm::LogError("QuarkoniaTrackSelector") << "Inconsistency in definition of mass windows, "
-					    << "no track will be selected";
+                                            << "no track will be selected";
     minMasses_.clear();
     maxMasses_.clear();
   }
 
   std::ostringstream stream;
   stream << "instantiated with parameters\n"
-	 << "  muonTag  = " << muonTag_ << "\n"
-	 << "  trackTag = " << trackTag_ << "\n";
+         << "  muonTag  = " << muonTag_ << "\n"
+         << "  trackTag = " << trackTag_ << "\n";
   stream << "  mass windows =";
-  for ( size_t i=0; i<minMasses_.size(); ++i )  
+  for (size_t i = 0; i < minMasses_.size(); ++i)
     stream << " (" << minMasses_[i] << "," << maxMasses_[i] << ")";
   stream << "\n";
   stream << "  checkCharge  = " << checkCharge_ << "\n";
@@ -66,10 +61,7 @@ QuarkoniaTrackSelector::QuarkoniaTrackSelector(const edm::ParameterSet& iConfig)
   LogDebug("QuarkoniaTrackSelector") << stream.str();
 }
 
-
-void
-QuarkoniaTrackSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
+void QuarkoniaTrackSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   //
   // the product
   //
@@ -78,44 +70,41 @@ QuarkoniaTrackSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
   // Muons
   //
   edm::Handle<reco::RecoChargedCandidateCollection> muonHandle;
-  iEvent.getByToken(muonToken_,muonHandle);
+  iEvent.getByToken(muonToken_, muonHandle);
   //
   // Tracks
   //
   edm::Handle<reco::TrackCollection> trackHandle;
-  iEvent.getByToken(trackToken_,trackHandle);
+  iEvent.getByToken(trackToken_, trackHandle);
   //
   // Verification
   //
-  if ( !muonHandle.isValid() || !trackHandle.isValid() || minMasses_.empty() ) {
+  if (!muonHandle.isValid() || !trackHandle.isValid() || minMasses_.empty()) {
     iEvent.put(std::move(product));
     return;
   }
   //
   // Debug output
   //
-  if ( edm::isDebugEnabled() ) {
+  if (edm::isDebugEnabled()) {
     std::ostringstream stream;
     stream << "\nInput muons: # / q / pt / p / eta\n";
-    for ( size_t im=0; im<muonHandle->size(); ++im ) {
+    for (size_t im = 0; im < muonHandle->size(); ++im) {
       const reco::RecoChargedCandidate& muon = (*muonHandle)[im];
-      stream << "   " << im << " "
-	     << muon.charge() << " " << muon.pt() << " "
-	     << muon.p() << " " << muon.eta() << "\n";
+      stream << "   " << im << " " << muon.charge() << " " << muon.pt() << " " << muon.p() << " " << muon.eta() << "\n";
     }
     stream << "Input tracks: # / q / pt / p / eta\n";
-    for ( size_t it=0; it<trackHandle->size(); ++it ) {
+    for (size_t it = 0; it < trackHandle->size(); ++it) {
       const reco::Track& track = (*trackHandle)[it];
-      stream << "   " << it << " "
-	     << track.charge() << " " << track.pt() << " "
-	     << track.p() << " " << track.eta() << "\n";
+      stream << "   " << it << " " << track.charge() << " " << track.pt() << " " << track.p() << " " << track.eta()
+             << "\n";
     }
     LogDebug("QuarkoniaTrackSelector") << stream.str();
   }
   //
   // combinations
   //
-//   std::ostringstream stream;
+  //   std::ostringstream stream;
   unsigned int nQ(0);
   unsigned int nComb(0);
   std::vector<size_t> selectedTrackIndices;
@@ -123,60 +112,59 @@ QuarkoniaTrackSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
   reco::Particle::LorentzVector p4Muon;
   reco::Particle::LorentzVector p4JPsi;
   // muons
-  for ( size_t im=0; im<muonHandle->size(); ++im ) {
+  for (size_t im = 0; im < muonHandle->size(); ++im) {
     const reco::RecoChargedCandidate& muon = (*muonHandle)[im];
     int qMuon = muon.charge();
     p4Muon = muon.p4();
     // tracks
-    for ( size_t it=0; it<trackHandle->size(); ++it ) {
+    for (size_t it = 0; it < trackHandle->size(); ++it) {
       const reco::Track& track = (*trackHandle)[it];
-      if ( track.pt()<minTrackPt_ || track.p()<minTrackP_ ||
-	   fabs(track.eta())>maxTrackEta_ )  continue;
-      if ( checkCharge_ && track.charge()!=-qMuon )  continue;
+      if (track.pt() < minTrackPt_ || track.p() < minTrackP_ || fabs(track.eta()) > maxTrackEta_)
+        continue;
+      if (checkCharge_ && track.charge() != -qMuon)
+        continue;
       ++nQ;
-      reco::Particle::LorentzVector p4Track(track.px(),track.py(),track.pz(),
-					    sqrt(track.p()*track.p()+0.0111636));
+      reco::Particle::LorentzVector p4Track(
+          track.px(), track.py(), track.pz(), sqrt(track.p() * track.p() + 0.0111636));
       // mass windows
-      double mass = (p4Muon+p4Track).mass();
-//       stream << "Combined mass = " << im << " " << it 
-// 	     << " " << mass 
-// 	     << " phi " << track.phi() << "\n";
-      for ( size_t j=0; j<minMasses_.size(); ++j ) {
-	if ( mass>minMasses_[j] && mass<maxMasses_[j] ) {
-	  ++nComb;
-	  if ( find(selectedTrackIndices.begin(),selectedTrackIndices.end(),it)==
-	       selectedTrackIndices.end() )  selectedTrackIndices.push_back(it);
-// 	  stream << "... adding " << "\n"; 
-	  break;
-	}
+      double mass = (p4Muon + p4Track).mass();
+      //       stream << "Combined mass = " << im << " " << it
+      // 	     << " " << mass
+      // 	     << " phi " << track.phi() << "\n";
+      for (size_t j = 0; j < minMasses_.size(); ++j) {
+        if (mass > minMasses_[j] && mass < maxMasses_[j]) {
+          ++nComb;
+          if (find(selectedTrackIndices.begin(), selectedTrackIndices.end(), it) == selectedTrackIndices.end())
+            selectedTrackIndices.push_back(it);
+          // 	  stream << "... adding " << "\n";
+          break;
+        }
       }
     }
   }
-//   LogDebug("QuarkoniaTrackSelector") << stream.str();
+  //   LogDebug("QuarkoniaTrackSelector") << stream.str();
   //
   // filling of output collection
   //
-  for ( size_t i=0; i<selectedTrackIndices.size(); ++i ) 
+  for (size_t i = 0; i < selectedTrackIndices.size(); ++i)
     product->push_back((*trackHandle)[selectedTrackIndices[i]]);
   //
   // debug output
   //
-  if ( edm::isDebugEnabled() ) {
+  if (edm::isDebugEnabled()) {
     std::ostringstream stream;
-    stream << "Total number of combinations = " << muonHandle->size()*trackHandle->size()
-	   << " , after charge " << nQ << " , after mass " << nComb << std::endl;
+    stream << "Total number of combinations = " << muonHandle->size() * trackHandle->size() << " , after charge " << nQ
+           << " , after mass " << nComb << std::endl;
     stream << "Selected " << product->size() << " tracks with # / q / pt / eta\n";
-    for ( size_t i=0; i<product->size(); ++i ) {
+    for (size_t i = 0; i < product->size(); ++i) {
       const reco::Track& track = (*product)[i];
-      stream << "  " << i << " " << track.charge() << " "
-	     << track.pt() << " " << track.eta() << "\n";
+      stream << "  " << i << " " << track.charge() << " " << track.pt() << " " << track.eta() << "\n";
     }
     LogDebug("QuarkoniaTrackSelector") << stream.str();
   }
   //
   iEvent.put(std::move(product));
 }
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(QuarkoniaTrackSelector);

--- a/RecoMuon/L3MuonProducer/src/QuarkoniaTrackSelector.h
+++ b/RecoMuon/L3MuonProducer/src/QuarkoniaTrackSelector.h
@@ -14,7 +14,6 @@
 
 #include <vector>
 
-
 class QuarkoniaTrackSelector : public edm::global::EDProducer<> {
 public:
   explicit QuarkoniaTrackSelector(const edm::ParameterSet&);
@@ -22,10 +21,10 @@ public:
 
 private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-      
+
 private:
-  edm::InputTag muonTag_;          ///< tag for RecoChargedCandidateCollection
-  edm::InputTag trackTag_;         ///< tag for TrackCollection
+  edm::InputTag muonTag_;   ///< tag for RecoChargedCandidateCollection
+  edm::InputTag trackTag_;  ///< tag for TrackCollection
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> muonToken_;
   edm::EDGetTokenT<reco::TrackCollection> trackToken_;
 

--- a/RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h
+++ b/RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h
@@ -18,29 +18,33 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class HLTMuonL2SelectorForL3IO : public edm::stream::EDProducer<> {
- public:
+public:
   /// constructor with config
   HLTMuonL2SelectorForL3IO(const edm::ParameterSet&);
-  
+
   /// destructor
-  ~HLTMuonL2SelectorForL3IO() override; 
-  
+  ~HLTMuonL2SelectorForL3IO() override;
+
   /// default values
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
   /// select muons
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
- private:
+
+private:
   const edm::EDGetTokenT<reco::TrackCollection> l2Src_;
   const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> l3OISrc_;
   const edm::EDGetTokenT<reco::MuonTrackLinksCollection> l3linkToken_;
   const bool applyL3Filters_;
-  const double max_NormalizedChi2_,max_PtDifference_;
-  const int min_Nhits_,min_NmuonHits_;
+  const double max_NormalizedChi2_, max_PtDifference_;
+  const int min_Nhits_, min_NmuonHits_;
 };
 
 #endif

--- a/RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h
+++ b/RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h
@@ -22,49 +22,50 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class MuonServiceProxy;
 class Trajectory;
 class TrajectoryCleaner;
 
 class L3MuonTrajectoryBuilder : public GlobalTrajectoryBuilderBase {
+public:
+  /// Constructor with Parameter Set and MuonServiceProxy
+  L3MuonTrajectoryBuilder(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
 
-  public:
+  /// Destructor
+  ~L3MuonTrajectoryBuilder() override;
 
-    /// Constructor with Parameter Set and MuonServiceProxy
-	L3MuonTrajectoryBuilder(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
+  /// Reconstruct trajectories from standalone and tracker only Tracks
+  using GlobalTrajectoryBuilderBase::trajectories;
+  MuonTrajectoryBuilder::CandidateContainer trajectories(const TrackCand&) override;
 
-    /// Destructor
-    ~L3MuonTrajectoryBuilder() override;
+  /// Pass the Event to the algo at each event
+  void setEvent(const edm::Event&) override;
 
-    /// Reconstruct trajectories from standalone and tracker only Tracks
-    using GlobalTrajectoryBuilderBase::trajectories;
-    MuonTrajectoryBuilder::CandidateContainer trajectories(const TrackCand&) override;
+  /// Add default values for fillDescriptions
+  static void fillDescriptions(edm::ParameterSetDescription& descriptions);
 
-    /// Pass the Event to the algo at each event
-    void setEvent(const edm::Event&) override;
+private:
+  /// Make a TrackCand collection using tracker Track, Trajectory information
+  std::vector<TrackCand> makeTkCandCollection(const TrackCand&) override;
 
-    /// Add default values for fillDescriptions
-    static void fillDescriptions(edm::ParameterSetDescription& descriptions);
-
-  private:
-
-    /// Make a TrackCand collection using tracker Track, Trajectory information
-    std::vector<TrackCand> makeTkCandCollection(const TrackCand&) override;
-
-    TrajectoryCleaner* theTrajectoryCleaner;
-    edm::InputTag theTkCollName;
-    edm::Handle<reco::TrackCollection> allTrackerTracks;
-    reco::BeamSpot beamSpot;
-    edm::Handle<reco::BeamSpot> beamSpotHandle;
-    edm::InputTag theBeamSpotInputTag;
-    reco::Vertex vtx;
-    edm::Handle<reco::VertexCollection> pvHandle;
-    edm::InputTag theVertexCollInputTag;
-    bool theUseVertex;
-    double theMaxChi2;
-    double theDXYBeamSpot;
-    edm::EDGetTokenT<reco::TrackCollection> theTrackToken;
+  TrajectoryCleaner* theTrajectoryCleaner;
+  edm::InputTag theTkCollName;
+  edm::Handle<reco::TrackCollection> allTrackerTracks;
+  reco::BeamSpot beamSpot;
+  edm::Handle<reco::BeamSpot> beamSpotHandle;
+  edm::InputTag theBeamSpotInputTag;
+  reco::Vertex vtx;
+  edm::Handle<reco::VertexCollection> pvHandle;
+  edm::InputTag theVertexCollInputTag;
+  bool theUseVertex;
+  double theMaxChi2;
+  double theDXYBeamSpot;
+  edm::EDGetTokenT<reco::TrackCollection> theTrackToken;
 };
 #endif

--- a/RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h
+++ b/RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h
@@ -5,28 +5,33 @@
 #include "FWCore/Framework/interface/ESWatcher.h"
 
 class MuonCkfTrajectoryBuilder : public CkfTrajectoryBuilder {
- public:
+public:
   MuonCkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
   ~MuonCkfTrajectoryBuilder() override;
 
- protected:
+protected:
   void setEvent_(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  void collectMeasurement(const DetLayer * layer, const std::vector<const DetLayer*>& nl,const TrajectoryStateOnSurface & currentState, std::vector<TM>& result,int& invalidHits,const Propagator *) const;
+  void collectMeasurement(const DetLayer* layer,
+                          const std::vector<const DetLayer*>& nl,
+                          const TrajectoryStateOnSurface& currentState,
+                          std::vector<TM>& result,
+                          int& invalidHits,
+                          const Propagator*) const;
 
-  void findCompatibleMeasurements(const TrajectorySeed&seed, const TempTrajectory& traj, std::vector<TrajectoryMeasurement> & result) const override;
-  
+  void findCompatibleMeasurements(const TrajectorySeed& seed,
+                                  const TempTrajectory& traj,
+                                  std::vector<TrajectoryMeasurement>& result) const override;
+
   //and other fields
   bool theUseSeedLayer;
   double theRescaleErrorIfFail;
   const double theDeltaEta;
   const double theDeltaPhi;
   const std::string theProximityPropagatorName;
-  const Propagator * theProximityPropagator;
+  const Propagator* theProximityPropagator;
   edm::ESWatcher<BaseCkfTrajectoryBuilder::Chi2MeasurementEstimatorRecord> theEstimatorWatcher;
   std::unique_ptr<Chi2MeasurementEstimatorBase> theEtaPhiEstimator;
-  
 };
-
 
 #endif

--- a/RecoMuon/L3TrackFinder/plugins/SealModules.cc
+++ b/RecoMuon/L3TrackFinder/plugins/SealModules.cc
@@ -6,4 +6,3 @@
 
 DEFINE_EDM_PLUGIN(BaseCkfTrajectoryBuilderFactory, MuonCkfTrajectoryBuilder, "MuonCkfTrajectoryBuilder");
 DEFINE_FWK_MODULE(HLTMuonL2SelectorForL3IO);
-

--- a/RecoMuon/L3TrackFinder/src/EtaPhiEstimator.h
+++ b/RecoMuon/L3TrackFinder/src/EtaPhiEstimator.h
@@ -6,50 +6,43 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 class EtaPhiEstimator : public Chi2MeasurementEstimatorBase {
- public:
-
+public:
   /** Construct with cuts on chi2 and nSigma.
    *  The cut on Chi2 is used to define the acceptance of RecHits.
    *  The errors of the trajectory state are multiplied by nSigma 
    *  to define acceptance of BoundPlane and maximalLocalDisplacement.
    */
-  explicit EtaPhiEstimator(double eta, double phi,
-			   const Chi2MeasurementEstimatorBase * estimator): 
-    Chi2MeasurementEstimatorBase(estimator->chiSquaredCut(),
-				 estimator->nSigmaCut()),
-    estimator_(estimator),
-    thedEta(eta),
-    thedPhi(phi),
-    thedEta2(eta*eta),
-    thedPhi2(phi*phi)
-      { }
+  explicit EtaPhiEstimator(double eta, double phi, const Chi2MeasurementEstimatorBase* estimator)
+      : Chi2MeasurementEstimatorBase(estimator->chiSquaredCut(), estimator->nSigmaCut()),
+        estimator_(estimator),
+        thedEta(eta),
+        thedPhi(phi),
+        thedEta2(eta * eta),
+        thedPhi2(phi * phi) {}
 
-    std::pair<bool,double> estimate(const TrajectoryStateOnSurface& tsos,
-					    const TrackingRecHit& aRecHit) const override{
-      
-      std::pair<bool,double> primaryResult = estimator_->estimate(tsos,aRecHit);
+  std::pair<bool, double> estimate(const TrajectoryStateOnSurface& tsos, const TrackingRecHit& aRecHit) const override {
+    std::pair<bool, double> primaryResult = estimator_->estimate(tsos, aRecHit);
 
-      double dEta = fabs(tsos.globalPosition().eta() - aRecHit.globalPosition().eta());
-      double dPhi = deltaPhi< double > (tsos.globalPosition().phi(), aRecHit.globalPosition().phi());
+    double dEta = fabs(tsos.globalPosition().eta() - aRecHit.globalPosition().eta());
+    double dPhi = deltaPhi<double>(tsos.globalPosition().phi(), aRecHit.globalPosition().phi());
 
-      double check = (dEta*dEta)/(thedEta2) + (dPhi*dPhi)/(thedPhi2);
-      
-      LogDebug("EtaPhiMeasurementEstimator")<< " The state to compare with is \n"<< tsos
-					    << " The hit position is:\n" << aRecHit.globalPosition()
-					    << " deta: "<< dEta<< " dPhi: "<<dPhi<<" check: "<<check<<" primaryly: "<< primaryResult.second;
+    double check = (dEta * dEta) / (thedEta2) + (dPhi * dPhi) / (thedPhi2);
 
-      if (check <= 1)
-	//      if (dEta < thedEta && dPhi <thedPhi)
-	return std::make_pair(true, primaryResult.second);
-      else
-	return std::make_pair(false, primaryResult.second);
-    }
-    
-    EtaPhiEstimator* clone() const override {
-      return new EtaPhiEstimator(*this);
-    }
+    LogDebug("EtaPhiMeasurementEstimator") << " The state to compare with is \n"
+                                           << tsos << " The hit position is:\n"
+                                           << aRecHit.globalPosition() << " deta: " << dEta << " dPhi: " << dPhi
+                                           << " check: " << check << " primaryly: " << primaryResult.second;
 
- private:
-    const Chi2MeasurementEstimatorBase * estimator_;
-    double thedEta,thedPhi,thedEta2,thedPhi2;
+    if (check <= 1)
+      //      if (dEta < thedEta && dPhi <thedPhi)
+      return std::make_pair(true, primaryResult.second);
+    else
+      return std::make_pair(false, primaryResult.second);
+  }
+
+  EtaPhiEstimator* clone() const override { return new EtaPhiEstimator(*this); }
+
+private:
+  const Chi2MeasurementEstimatorBase* estimator_;
+  double thedEta, thedPhi, thedEta2, thedPhi2;
 };

--- a/RecoMuon/L3TrackFinder/src/HLTMuonL2SelectorForL3IO.cc
+++ b/RecoMuon/L3TrackFinder/src/HLTMuonL2SelectorForL3IO.cc
@@ -14,92 +14,98 @@
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
 
 /// constructor with config
-HLTMuonL2SelectorForL3IO::HLTMuonL2SelectorForL3IO(const edm::ParameterSet& iConfig):  
-  l2Src_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l2Src"))),
-  l3OISrc_(consumes<reco::RecoChargedCandidateCollection>(iConfig.getParameter<edm::InputTag>("l3OISrc"))),
-  l3linkToken_(consumes<reco::MuonTrackLinksCollection>(iConfig.getParameter<edm::InputTag>("InputLinks"))),
-  applyL3Filters_(iConfig.getParameter<bool>("applyL3Filters")),
-  max_NormalizedChi2_ (iConfig.getParameter<double> ("MaxNormalizedChi2")),
-  max_PtDifference_ (iConfig.getParameter<double> ("MaxPtDifference")),
-  min_Nhits_ (iConfig.getParameter<int> ("MinNhits")),
-  min_NmuonHits_ (iConfig.getParameter<int> ("MinNmuonHits"))  
-{
-   LogTrace("Muon|RecoMuon|HLTMuonL2SelectorForL3IO")<<"constructor called";
-   produces<reco::TrackCollection>();
+HLTMuonL2SelectorForL3IO::HLTMuonL2SelectorForL3IO(const edm::ParameterSet& iConfig)
+    : l2Src_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l2Src"))),
+      l3OISrc_(consumes<reco::RecoChargedCandidateCollection>(iConfig.getParameter<edm::InputTag>("l3OISrc"))),
+      l3linkToken_(consumes<reco::MuonTrackLinksCollection>(iConfig.getParameter<edm::InputTag>("InputLinks"))),
+      applyL3Filters_(iConfig.getParameter<bool>("applyL3Filters")),
+      max_NormalizedChi2_(iConfig.getParameter<double>("MaxNormalizedChi2")),
+      max_PtDifference_(iConfig.getParameter<double>("MaxPtDifference")),
+      min_Nhits_(iConfig.getParameter<int>("MinNhits")),
+      min_NmuonHits_(iConfig.getParameter<int>("MinNmuonHits")) {
+  LogTrace("Muon|RecoMuon|HLTMuonL2SelectorForL3IO") << "constructor called";
+  produces<reco::TrackCollection>();
 }
 
 /// destructor
-HLTMuonL2SelectorForL3IO::~HLTMuonL2SelectorForL3IO(){}
+HLTMuonL2SelectorForL3IO::~HLTMuonL2SelectorForL3IO() {}
 
 /// create collection of L2 muons not already reconstructed as L3 muons
-void HLTMuonL2SelectorForL3IO::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+void HLTMuonL2SelectorForL3IO::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const std::string metname = "Muon|RecoMuon|HLTMuonL2SelectorForL3IO";
-	
+
   //  IN:
   edm::Handle<reco::TrackCollection> l2muonH;
   iEvent.getByToken(l2Src_, l2muonH);
 
   edm::Handle<reco::RecoChargedCandidateCollection> l3muonH;
-  iEvent.getByToken(l3OISrc_,l3muonH);
+  iEvent.getByToken(l3OISrc_, l3muonH);
 
   // Read Links collection:
   edm::Handle<reco::MuonTrackLinksCollection> links;
-  iEvent.getByToken(l3linkToken_, links);  
-  
+  iEvent.getByToken(l3linkToken_, links);
+
   //	OUT:
-  std::unique_ptr<reco::TrackCollection > result(new reco::TrackCollection());
-    
-  for (unsigned int il2=0; il2 != l2muonH->size(); ++il2){
+  std::unique_ptr<reco::TrackCollection> result(new reco::TrackCollection());
+
+  for (unsigned int il2 = 0; il2 != l2muonH->size(); ++il2) {
     reco::TrackRef l2muRef(l2muonH, il2);
-    bool re_do_this_L2=true;
-    
-    for (unsigned int il3=0; il3 != l3muonH->size(); ++il3){
-      reco::RecoChargedCandidateRef cand(l3muonH,il3);
+    bool re_do_this_L2 = true;
+
+    for (unsigned int il3 = 0; il3 != l3muonH->size(); ++il3) {
+      reco::RecoChargedCandidateRef cand(l3muonH, il3);
       reco::TrackRef tk = cand->track();
-      
+
       bool useThisLink = false;
-      for (unsigned int l(0); l<links->size() && !useThisLink; ++l){
-	const reco::MuonTrackLinks* link = &links->at(l);
-	
-	// Check if the L3 link matches the L3 candidate
-	const reco::Track& globalTrack = *link->globalTrack();
-	float dR2 = deltaR2(tk->eta(),tk->phi(),globalTrack.eta(),globalTrack.phi());
-	if (dR2 < 0.02*0.02 and std::abs(tk->pt() - globalTrack.pt()) < 0.001*tk->pt()) {
-	  useThisLink=true;
-	}
-	
-	if (!useThisLink) continue;
-	
-	// Check whether the stand-alone track matches a L2, if not, we will re-use this L2
-	const reco::TrackRef staTrack = link->standAloneTrack();	
-	if (l2muRef==staTrack) re_do_this_L2=false; 
-      
-	// Check the quality of the reconstructed L3, if poor quality, we will re-use this L2
-	if (staTrack==l2muRef && applyL3Filters_) {
-	  re_do_this_L2 = true;
-	  const reco::Track& globalTrack = *link->globalTrack();
-	  if (globalTrack.numberOfValidHits()< min_Nhits_) continue;  	// cut on number of hits
-	  if (globalTrack.normalizedChi2() > max_NormalizedChi2_ ) continue;		//normalizedChi2 cut
-	  if (globalTrack.hitPattern().numberOfValidMuonHits() < min_NmuonHits_ ) continue;  	//min muon hits cut
-	  if (std::abs(globalTrack.pt()-l2muRef->pt()) > max_PtDifference_*globalTrack.pt()) continue; // pt difference 
-	  re_do_this_L2 = false;
-	}
+      for (unsigned int l(0); l < links->size() && !useThisLink; ++l) {
+        const reco::MuonTrackLinks* link = &links->at(l);
+
+        // Check if the L3 link matches the L3 candidate
+        const reco::Track& globalTrack = *link->globalTrack();
+        float dR2 = deltaR2(tk->eta(), tk->phi(), globalTrack.eta(), globalTrack.phi());
+        if (dR2 < 0.02 * 0.02 and std::abs(tk->pt() - globalTrack.pt()) < 0.001 * tk->pt()) {
+          useThisLink = true;
+        }
+
+        if (!useThisLink)
+          continue;
+
+        // Check whether the stand-alone track matches a L2, if not, we will re-use this L2
+        const reco::TrackRef staTrack = link->standAloneTrack();
+        if (l2muRef == staTrack)
+          re_do_this_L2 = false;
+
+        // Check the quality of the reconstructed L3, if poor quality, we will re-use this L2
+        if (staTrack == l2muRef && applyL3Filters_) {
+          re_do_this_L2 = true;
+          const reco::Track& globalTrack = *link->globalTrack();
+          if (globalTrack.numberOfValidHits() < min_Nhits_)
+            continue;  // cut on number of hits
+          if (globalTrack.normalizedChi2() > max_NormalizedChi2_)
+            continue;  //normalizedChi2 cut
+          if (globalTrack.hitPattern().numberOfValidMuonHits() < min_NmuonHits_)
+            continue;  //min muon hits cut
+          if (std::abs(globalTrack.pt() - l2muRef->pt()) > max_PtDifference_ * globalTrack.pt())
+            continue;  // pt difference
+          re_do_this_L2 = false;
+        }
       }
     }
-    if (re_do_this_L2) result->push_back(*l2muRef);  // used the L2 if no L3 if matched or if the matched L3 has poor quality cuts. 
+    if (re_do_this_L2)
+      result->push_back(*l2muRef);  // used the L2 if no L3 if matched or if the matched L3 has poor quality cuts.
   }
   iEvent.put(std::move(result));
 }
 
 void HLTMuonL2SelectorForL3IO::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("l2Src",edm::InputTag("hltL2Muons","UpdatedAtVtx"));
-  desc.add<edm::InputTag>("l3OISrc",edm::InputTag("hltNewOIL3MuonCandidates"));
-  desc.add<edm::InputTag>("InputLinks",edm::InputTag("hltNewOIL3MuonsLinksCombination"));
-  desc.add<bool>("applyL3Filters",true); 
-  desc.add<int>("MinNhits",1);
-  desc.add<double>("MaxNormalizedChi2",20.0);
-  desc.add<int>("MinNmuonHits",0);
-  desc.add<double>("MaxPtDifference",999.0); //relative difference
-  descriptions.add("HLTMuonL2SelectorForL3IO",desc);
+  desc.add<edm::InputTag>("l2Src", edm::InputTag("hltL2Muons", "UpdatedAtVtx"));
+  desc.add<edm::InputTag>("l3OISrc", edm::InputTag("hltNewOIL3MuonCandidates"));
+  desc.add<edm::InputTag>("InputLinks", edm::InputTag("hltNewOIL3MuonsLinksCombination"));
+  desc.add<bool>("applyL3Filters", true);
+  desc.add<int>("MinNhits", 1);
+  desc.add<double>("MaxNormalizedChi2", 20.0);
+  desc.add<int>("MinNmuonHits", 0);
+  desc.add<double>("MaxPtDifference", 999.0);  //relative difference
+  descriptions.add("HLTMuonL2SelectorForL3IO", desc);
 }

--- a/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
+++ b/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
@@ -15,22 +15,19 @@
 #include "RecoMuon/L3TrackFinder/src/EtaPhiEstimator.h"
 #include <sstream>
 
-MuonCkfTrajectoryBuilder::MuonCkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC):
-  CkfTrajectoryBuilder(conf, iC),
-  theDeltaEta(conf.getParameter<double>("deltaEta")),
-  theDeltaPhi(conf.getParameter<double>("deltaPhi")),
-  theProximityPropagatorName(conf.getParameter<std::string>("propagatorProximity")),
-  theProximityPropagator(nullptr),
-  theEtaPhiEstimator(nullptr)
-{
+MuonCkfTrajectoryBuilder::MuonCkfTrajectoryBuilder(const edm::ParameterSet& conf, edm::ConsumesCollector& iC)
+    : CkfTrajectoryBuilder(conf, iC),
+      theDeltaEta(conf.getParameter<double>("deltaEta")),
+      theDeltaPhi(conf.getParameter<double>("deltaPhi")),
+      theProximityPropagatorName(conf.getParameter<std::string>("propagatorProximity")),
+      theProximityPropagator(nullptr),
+      theEtaPhiEstimator(nullptr) {
   //and something specific to me ?
   theUseSeedLayer = conf.getParameter<bool>("useSeedLayer");
   theRescaleErrorIfFail = conf.getParameter<double>("rescaleErrorIfFail");
 }
 
-MuonCkfTrajectoryBuilder::~MuonCkfTrajectoryBuilder()
-{
-}
+MuonCkfTrajectoryBuilder::~MuonCkfTrajectoryBuilder() {}
 
 void MuonCkfTrajectoryBuilder::setEvent_(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   CkfTrajectoryBuilder::setEvent_(iEvent, iSetup);
@@ -40,10 +37,9 @@ void MuonCkfTrajectoryBuilder::setEvent_(const edm::Event& iEvent, const edm::Ev
   theProximityPropagator = propagatorProximityHandle.product();
 
   // theEstimator is set for this event in the base class
-  if(theEstimatorWatcher.check(iSetup) && theDeltaEta>0 && theDeltaPhi>0)
+  if (theEstimatorWatcher.check(iSetup) && theDeltaEta > 0 && theDeltaPhi > 0)
     theEtaPhiEstimator = std::make_unique<EtaPhiEstimator>(theDeltaEta, theDeltaPhi, theEstimator);
 }
-
 
 /*
 std::string dumpMeasurement(const TrajectoryMeasurement & tm)
@@ -76,164 +72,156 @@ std::string dumpMeasurements(const std::vector<TrajectoryMeasurement> & v)
 */
 
 void MuonCkfTrajectoryBuilder::collectMeasurement(const DetLayer* layer,
-						  const std::vector<const DetLayer*>& nl,
-						  const TrajectoryStateOnSurface & currentState,
-						  std::vector<TM>& result,int& invalidHits,
-						  const Propagator * prop) const{
-  for (std::vector<const DetLayer*>::const_iterator il = nl.begin();
-       il != nl.end(); il++) {
-
+                                                  const std::vector<const DetLayer*>& nl,
+                                                  const TrajectoryStateOnSurface& currentState,
+                                                  std::vector<TM>& result,
+                                                  int& invalidHits,
+                                                  const Propagator* prop) const {
+  for (std::vector<const DetLayer*>::const_iterator il = nl.begin(); il != nl.end(); il++) {
     TSOS stateToUse = currentState;
-    
-    if (layer == (*il)){
-      LogDebug("CkfPattern")<<" self propagating in findCompatibleMeasurements.\n from: \n"<<stateToUse;
+
+    if (layer == (*il)) {
+      LogDebug("CkfPattern") << " self propagating in findCompatibleMeasurements.\n from: \n" << stateToUse;
       //self navigation case
       // go to a middle point first
       TransverseImpactPointExtrapolator middle;
-      GlobalPoint center(0,0,0);
+      GlobalPoint center(0, 0, 0);
       stateToUse = middle.extrapolate(stateToUse, center, *prop);
 
-      if (!stateToUse.isValid()) continue;
-      LogDebug("CkfPattern")<<"to: "<<stateToUse;
+      if (!stateToUse.isValid())
+        continue;
+      LogDebug("CkfPattern") << "to: " << stateToUse;
     }
 
     LayerMeasurements layerMeasurements(theMeasurementTracker->measurementTracker(), *theMeasurementTracker);
-    std::vector<TM> tmp =
-      layerMeasurements.measurements((**il),stateToUse, *prop, *theEstimator);
-    
-    if (tmp.size()==1 && theEtaPhiEstimator){
-      LogDebug("CkfPattern")<<"only an invalid hit is found. trying differently";
-      tmp = layerMeasurements.measurements((**il),stateToUse, *prop, *theEtaPhiEstimator);
+    std::vector<TM> tmp = layerMeasurements.measurements((**il), stateToUse, *prop, *theEstimator);
+
+    if (tmp.size() == 1 && theEtaPhiEstimator) {
+      LogDebug("CkfPattern") << "only an invalid hit is found. trying differently";
+      tmp = layerMeasurements.measurements((**il), stateToUse, *prop, *theEtaPhiEstimator);
     }
-    LogDebug("CkfPattern")<<tmp.size()<<" measurements returned by LayerMeasurements";
-    
-    if ( !tmp.empty()) {
+    LogDebug("CkfPattern") << tmp.size() << " measurements returned by LayerMeasurements";
+
+    if (!tmp.empty()) {
       // FIXME durty-durty-durty cleaning: never do that please !
       /*      for (vector<TM>::iterator it = tmp.begin(); it!=tmp.end(); ++it)
               {if (it->recHit()->det()==0) it=tmp.erase(it)--;}*/
-      
-      if ( result.empty()) result = tmp;
+
+      if (result.empty())
+        result = tmp;
       else {
         // keep one dummy TM at the end, skip the others
-        result.insert( result.end()-invalidHits, tmp.begin(), tmp.end());
+        result.insert(result.end() - invalidHits, tmp.begin(), tmp.end());
       }
       invalidHits++;
     }
   }
-  
-  LogDebug("CkfPattern")<<"starting from:\n"
-                        <<"x: "<<currentState.globalPosition()<<"\n"
-                        <<"p: "<<currentState.globalMomentum()<<"\n"
-                        <<PrintoutHelper::dumpMeasurements(result);
+
+  LogDebug("CkfPattern") << "starting from:\n"
+                         << "x: " << currentState.globalPosition() << "\n"
+                         << "p: " << currentState.globalMomentum() << "\n"
+                         << PrintoutHelper::dumpMeasurements(result);
 }
- 
 
-
-void 
-MuonCkfTrajectoryBuilder::findCompatibleMeasurements(const TrajectorySeed&seed,
-						     const TempTrajectory& traj, 
-						     std::vector<TrajectoryMeasurement> & result) const
-{
+void MuonCkfTrajectoryBuilder::findCompatibleMeasurements(const TrajectorySeed& seed,
+                                                          const TempTrajectory& traj,
+                                                          std::vector<TrajectoryMeasurement>& result) const {
   int invalidHits = 0;
-
 
   std::vector<const DetLayer*> nl;
 
-  if (traj.empty())
-    {
-      LogDebug("CkfPattern")<<"using JR patch for no measurement case";           
-     //what if there are no measurement on the Trajectory
+  if (traj.empty()) {
+    LogDebug("CkfPattern") << "using JR patch for no measurement case";
+    //what if there are no measurement on the Trajectory
 
-      //set the currentState to be the one from the trajectory seed starting point
-      PTrajectoryStateOnDet ptod =seed.startingState();
-      DetId id(ptod.detId());
-      const GeomDet * g = theMeasurementTracker->geomTracker()->idToDet(id);
-      const Surface * surface=&g->surface();
-      
-      TrajectoryStateOnSurface currentState(trajectoryStateTransform::transientState(ptod,surface,forwardPropagator(seed)->magneticField()));
+    //set the currentState to be the one from the trajectory seed starting point
+    PTrajectoryStateOnDet ptod = seed.startingState();
+    DetId id(ptod.detId());
+    const GeomDet* g = theMeasurementTracker->geomTracker()->idToDet(id);
+    const Surface* surface = &g->surface();
 
-      //set the next layers to be that one the state is on
-      const DetLayer * l=theMeasurementTracker->geometricSearchTracker()->detLayer(id);
+    TrajectoryStateOnSurface currentState(
+        trajectoryStateTransform::transientState(ptod, surface, forwardPropagator(seed)->magneticField()));
 
-      if (theUseSeedLayer){
-        {
-	  //get the measurements on the layer first
-	  LogDebug("CkfPattern")<<"using the layer of the seed first.";
-          nl.push_back(l);
-          collectMeasurement(l,nl,currentState,result,invalidHits,theProximityPropagator);
-        }
-	
-        //if fails: try to rescale locally the state to find measurements
-        if ((unsigned int)invalidHits==result.size() && theRescaleErrorIfFail!=1.0 && !result.empty())
-          {
-	    result.clear();
-	    LogDebug("CkfPattern")<<"using a rescale by "<< theRescaleErrorIfFail <<" to find measurements.";
-	    TrajectoryStateOnSurface rescaledCurrentState = currentState;
-	    rescaledCurrentState.rescaleError(theRescaleErrorIfFail);
-	    invalidHits=0;
-	    collectMeasurement(l,nl,rescaledCurrentState,result,invalidHits,theProximityPropagator);
-          }
+    //set the next layers to be that one the state is on
+    const DetLayer* l = theMeasurementTracker->geometricSearchTracker()->detLayer(id);
+
+    if (theUseSeedLayer) {
+      {
+        //get the measurements on the layer first
+        LogDebug("CkfPattern") << "using the layer of the seed first.";
+        nl.push_back(l);
+        collectMeasurement(l, nl, currentState, result, invalidHits, theProximityPropagator);
       }
 
-      //if fails: go to next layers
-      if (result.empty() || (unsigned int)invalidHits==result.size())
-        {
-          result.clear();
-	  LogDebug("CkfPattern")<<"Need to go to next layer to get measurements";
-          //the following will "JUMP" the first layer measurements
-	  nl = theNavigationSchool->nextLayers(*l, *currentState.freeState(), traj.direction());
-	  if (nl.empty()){
-            LogDebug("CkfPattern")<<" there was no next layer with wellInside. Use the next with no check.";
-            //means you did not get any compatible layer on the next 1/2 tracker layer.
-            // use the next layers with no checking
-            nl = theNavigationSchool->nextLayers(*l, ((traj.direction()==alongMomentum)?insideOut:outsideIn));
-          }
-          invalidHits=0;
-          collectMeasurement(l,nl,currentState,result,invalidHits,forwardPropagator(seed));
-        }
-
-      //if fails: this is on the next layers already, try rescaling locally the state
-      if (!result.empty() && (unsigned int)invalidHits==result.size() && theRescaleErrorIfFail!=1.0)
-        {
-          result.clear();
-	  LogDebug("CkfPattern")<<"using a rescale by "<< theRescaleErrorIfFail <<" to find measurements on next layers.";
-          TrajectoryStateOnSurface rescaledCurrentState = currentState;
-          rescaledCurrentState.rescaleError(theRescaleErrorIfFail);
-          invalidHits=0;
-          collectMeasurement(l,nl,rescaledCurrentState, result,invalidHits,forwardPropagator(seed));
-        }
-
-    }
-  else //regular case
-    {
-
-      TSOS currentState( traj.lastMeasurement().updatedState());
-
-      nl = theNavigationSchool->nextLayers(*traj.lastLayer(), *currentState.freeState(), traj.direction());
-      if (nl.empty()){LogDebug("CkfPattern")<<" no next layers... going "<<traj.direction()<<"\n from: \n"<<currentState<<"\n from detId: "<<traj.lastMeasurement().recHit()->geographicalId().rawId(); return ;}
-
-      collectMeasurement(traj.lastLayer(),nl,currentState,result,invalidHits,forwardPropagator(seed));
+      //if fails: try to rescale locally the state to find measurements
+      if ((unsigned int)invalidHits == result.size() && theRescaleErrorIfFail != 1.0 && !result.empty()) {
+        result.clear();
+        LogDebug("CkfPattern") << "using a rescale by " << theRescaleErrorIfFail << " to find measurements.";
+        TrajectoryStateOnSurface rescaledCurrentState = currentState;
+        rescaledCurrentState.rescaleError(theRescaleErrorIfFail);
+        invalidHits = 0;
+        collectMeasurement(l, nl, rescaledCurrentState, result, invalidHits, theProximityPropagator);
+      }
     }
 
+    //if fails: go to next layers
+    if (result.empty() || (unsigned int)invalidHits == result.size()) {
+      result.clear();
+      LogDebug("CkfPattern") << "Need to go to next layer to get measurements";
+      //the following will "JUMP" the first layer measurements
+      nl = theNavigationSchool->nextLayers(*l, *currentState.freeState(), traj.direction());
+      if (nl.empty()) {
+        LogDebug("CkfPattern") << " there was no next layer with wellInside. Use the next with no check.";
+        //means you did not get any compatible layer on the next 1/2 tracker layer.
+        // use the next layers with no checking
+        nl = theNavigationSchool->nextLayers(*l, ((traj.direction() == alongMomentum) ? insideOut : outsideIn));
+      }
+      invalidHits = 0;
+      collectMeasurement(l, nl, currentState, result, invalidHits, forwardPropagator(seed));
+    }
+
+    //if fails: this is on the next layers already, try rescaling locally the state
+    if (!result.empty() && (unsigned int)invalidHits == result.size() && theRescaleErrorIfFail != 1.0) {
+      result.clear();
+      LogDebug("CkfPattern") << "using a rescale by " << theRescaleErrorIfFail
+                             << " to find measurements on next layers.";
+      TrajectoryStateOnSurface rescaledCurrentState = currentState;
+      rescaledCurrentState.rescaleError(theRescaleErrorIfFail);
+      invalidHits = 0;
+      collectMeasurement(l, nl, rescaledCurrentState, result, invalidHits, forwardPropagator(seed));
+    }
+
+  } else  //regular case
+  {
+    TSOS currentState(traj.lastMeasurement().updatedState());
+
+    nl = theNavigationSchool->nextLayers(*traj.lastLayer(), *currentState.freeState(), traj.direction());
+    if (nl.empty()) {
+      LogDebug("CkfPattern") << " no next layers... going " << traj.direction() << "\n from: \n"
+                             << currentState
+                             << "\n from detId: " << traj.lastMeasurement().recHit()->geographicalId().rawId();
+      return;
+    }
+
+    collectMeasurement(traj.lastLayer(), nl, currentState, result, invalidHits, forwardPropagator(seed));
+  }
 
   // sort the final result, keep dummy measurements at the end
-  if ( result.size() > 1) {
-    sort( result.begin(), result.end()-invalidHits, TrajMeasLessEstim());
+  if (result.size() > 1) {
+    sort(result.begin(), result.end() - invalidHits, TrajMeasLessEstim());
   }
 
 #ifdef DEBUG_INVALID
   bool afterInvalid = false;
-  for (std::vector<TM>::const_iterator i=result.begin();
-       i!=result.end(); i++) {
-    if ( ! i->recHit().isValid()) afterInvalid = true;
+  for (std::vector<TM>::const_iterator i = result.begin(); i != result.end(); i++) {
+    if (!i->recHit().isValid())
+      afterInvalid = true;
     if (afterInvalid && i->recHit().isValid()) {
-      edm::LogError("CkfPattern") << "CkfTrajectoryBuilder error: valid hit after invalid!" ;
+      edm::LogError("CkfPattern") << "CkfTrajectoryBuilder error: valid hit after invalid!";
     }
   }
 #endif
 
   //analyseMeasurements( result, traj);
-
 }
-
-


### PR DESCRIPTION

Applying code-format for CMSSW category hlt,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/246//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


