### PR TITLE
maskCell() bug fix: two masks were swapped

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -15,7 +15,7 @@
 #include <functional>
 #include <numeric>
 
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
 static const int maxType = 2;
@@ -794,7 +794,7 @@ bool HGCalDDDConstants::maskCell(const DetId& detId, int corners) const {
                 break;
               }
               case (2): {
-                mask = (u <= v);
+                mask = (u > v);
                 break;
               }
               case (3): {
@@ -806,7 +806,7 @@ bool HGCalDDDConstants::maskCell(const DetId& detId, int corners) const {
                 break;
               }
               default: {
-                mask = (u > v);
+                mask = (u <= v);
                 break;
               }
             }

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -747,6 +747,12 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(int lay, int irad,
   return std::make_pair(x, y);
 }
 
+/*
+Masks each cell (or not) according to its wafer and cell position (detId) and to the user
+needs (corners).
+Each wafer has k_CornerSize corners which are defined in anti-clockwise order starting from the corner at the top, which is always #0. 'ncor' denotes the number of corners inside the physical region. 'fcor' is the defined to be the first corner that appears inside the detector's physical volume in anti-clockwise order. 
+The argument 'corners' controls the types of wafers the user wants: for instance, corners=3 masks all wafers that have at least 3 corners inside the physical region. 
+ */
 bool HGCalDDDConstants::maskCell(const DetId& detId, int corners) const {
   bool mask(false);
   if (corners > 2 && corners < (int)(HGCalParameters::k_CornerSize)) {

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -15,7 +15,7 @@
 #include <functional>
 #include <numeric>
 
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
 static const int maxType = 2;
@@ -748,8 +748,7 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(int lay, int irad,
 }
 
 /*
-Masks each cell (or not) according to its wafer and cell position (detId) and to the user
-needs (corners).
+Masks each cell (or not) according to its wafer and cell position (detId) and to the user needs (corners).
 Each wafer has k_CornerSize corners which are defined in anti-clockwise order starting from the corner at the top, which is always #0. 'ncor' denotes the number of corners inside the physical region. 'fcor' is the defined to be the first corner that appears inside the detector's physical volume in anti-clockwise order. 
 The argument 'corners' controls the types of wafers the user wants: for instance, corners=3 masks all wafers that have at least 3 corners inside the physical region. 
  */


### PR DESCRIPTION
#### PR description:

A bug was found in the cell masks that will be eventually used to mask some of the virtual wafers (the masks allow the implementation of partial wafers, such as "fives" or "threes"). Two masks were swapped.

#### PR validation:

The new masks were tested using RecHits from a particle gun: [before correcting the bug](https://bfontana.web.cern.ch/bfontana/ncor3_bug/layer1/?match=*2_*2) and [after correcting the bug](https://bfontana.web.cern.ch/bfontana/ncor3/layer1/?match=*2_*2). The wafers (2,2) and (-2,-2) were not being correctly masked.