### PR TITLE
[CXXMODULE][CORE] added missing dependency on DataFormats/Common

### DIFF
--- a/FWCore/Common/BuildFile.xml
+++ b/FWCore/Common/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Provenance"/>
+<use   name="DataFormats/Common"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
 <export>


### PR DESCRIPTION
Added the missing dependency on DataFormats/Common
```
>grep DataFormats/Common -R FWCore/Common
FWCore/Common/interface/EventBase.h:#include "DataFormats/Common/interface/BasicHandle.h"
FWCore/Common/interface/EventBase.h:#include "DataFormats/Common/interface/ConvertHandle.h"
FWCore/Common/interface/EventBase.h:#include "DataFormats/Common/interface/Handle.h"
FWCore/Common/interface/TriggerResultsByName.h:#include "DataFormats/Common/interface/HLTenums.h"
FWCore/Common/interface/LuminosityBlockBase.h:#include "DataFormats/Common/interface/BasicHandle.h"
FWCore/Common/interface/LuminosityBlockBase.h:#include "DataFormats/Common/interface/ConvertHandle.h"
FWCore/Common/interface/LuminosityBlockBase.h:#include "DataFormats/Common/interface/Handle.h"
FWCore/Common/interface/RunBase.h:#include "DataFormats/Common/interface/BasicHandle.h"
FWCore/Common/interface/RunBase.h:#include "DataFormats/Common/interface/ConvertHandle.h"
FWCore/Common/interface/RunBase.h:#include "DataFormats/Common/interface/Handle.h"
FWCore/Common/src/EventBase.cc:#include "DataFormats/Common/interface/TriggerResults.h"
FWCore/Common/src/TriggerResultsByName.cc:#include "DataFormats/Common/interface/TriggerResults.h"
```