### PR TITLE
[RECO] Fixes needed for new root cxxmodules

### DIFF
--- a/DataFormats/Math/src/classes_def.xml
+++ b/DataFormats/Math/src/classes_def.xml
@@ -4,7 +4,10 @@
   <class pattern="ROOT::Math::MatRepStd<*>" />
   <class pattern="ROOT::Math::RowOffsets<*>" />
   <class pattern="ROOT::Math::SVector<*>" />
-  <class pattern="std::vector<ROOT::Math::*>" />
+  <class pattern="std::vector<ROOT::Math::SMatrix<*>>" />
+  <class pattern="std::vector<ROOT::Math::MatRepStd<*>>" />
+  <class pattern="std::vector<ROOT::Math::RowOffsets<*>>" />
+  <class pattern="std::vector<ROOT::Math::SVector<*>>" />
   <class pattern="edm::Wrapper<*>" />
   <class pattern="edm::RefVector<*>" />
   <class pattern="edm::ValueMap<*>" />

--- a/DataFormats/SiStripCluster/BuildFile.xml
+++ b/DataFormats/SiStripCluster/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrajectoryState"/>
+<use   name="DataFormats/SiStripDigi"/>
 <use   name="boost"/>
 
 <export>


### PR DESCRIPTION
- Added missing dependency 
```
>grep -R DataFormats/SiStripDigi DataFormats/SiStripCluster
DataFormats/SiStripCluster/interface/SiStripCluster.h:#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
```
- Removed usage of pattern `ROOT::Math::*` from https://github.com/cms-sw/cmssw/blob/c52e2819d7a2bca52273e9c36fc99622313eff71/DataFormats/Math/src/classes_def.xml#L7
