### PR TITLE
[CXXModule] Removed struct dictionary from classes.h + included L1GtObject.h

### DIFF
--- a/CondFormats/L1TObjects/src/classes.h
+++ b/CondFormats/L1TObjects/src/classes.h
@@ -1,3 +1,4 @@
+#include "DataFormats/L1GlobalTrigger/interface/L1GtObject.h"
 #include "CondFormats/L1TObjects/interface/L1MuScale.h"
 #include "CondFormats/L1TObjects/interface/L1MuTriggerScales.h"
 #include "CondFormats/L1TObjects/interface/L1MuTriggerPtScale.h"
@@ -67,64 +68,3 @@
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 
 #include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetos.h"
-
-namespace CondFormats_L1TObjects {
-  struct dictionary {
-    
-    std::vector<l1t::CaloParams::Node> dummy1a;
-    l1t::CaloParams dummy1b;
-    l1t::LUT dummy1c;
-
-    l1t::CaloConfig dummy2;
-
-    std::vector<L1MuDTExtLut::LUT> dummy3 ;
-    std::vector<L1GtMuonTemplate> dummy4 ;
-    std::vector<L1GtCaloTemplate> dummy5 ;
-    std::vector<L1GtEnergySumTemplate> dummy6 ;
-    std::vector<L1GtJetCountsTemplate> dummy7 ;
-    std::vector<L1GtCorrelationTemplate> dummy8 ;
-    std::vector<L1GtCastorTemplate> dummy8a ;
-    std::vector<L1GtHfBitCountsTemplate> dummy8b ;
-    std::vector<L1GtHfRingEtSumsTemplate> dummy8c ;
-    std::vector<L1GtBptxTemplate> dummy8d ;
-    std::vector<L1GtExternalTemplate> dummy8e ;
-    std::map< std::string, L1GtAlgorithm > dummy9 ;
-    std::pair< std::string, L1GtAlgorithm > dummy9a ;
-    std::pair<short,L1MuDTEtaPattern> dummy11 ;
-    std::pair<int, std::vector<L1GtObject> > dummy13 ;
-//    std::vector<L1RPCConeDefinition::TLPSize> dummy15;
-//    std::vector<L1RPCConeDefinition::TRingToTower> dummy15a;
-//    std::vector<L1RPCConeDefinition::TRingToLP> dummy15b;
-    L1TMuonGlobalParams dummy16;
-    std::vector<L1TMuonGlobalParams::Node> dummy16a;
-
-
-    L1TMuonOverlapParams dummy17;
-    std::vector< L1TMuonOverlapParams::Node> dummy17a;
-
-    L1TMuonBarrelParams dummy18;
-    std::vector<L1TMuonBarrelParams::Node> dummy18a;
-
-    L1TMuonEndCapParams dummy19;
-
-    L1TMuonEndCapForest dummy20a;
-    L1TMuonEndCapForest::DTree dummy20b;
-    L1TMuonEndCapForest::DForest dummy20c;
-    L1TMuonEndCapForest::DForestColl dummy20d;
-    L1TMuonEndCapForest::DForestMap dummy20e;
-
-    L1TUtmAlgorithm dummy21a;
-    L1TUtmBin dummy21b;
-    L1TUtmCondition dummy21c;
-    L1TUtmCut dummy21d;
-    L1TUtmCutValue dummy21e;
-    L1TUtmObject dummy21f;
-    L1TUtmScale dummy21g;
-    L1TUtmTriggerMenu dummy21h;
-
-    L1TGlobalPrescalesVetos dummy22;
-
-    L1TGlobalParameters dummy23;
-
-  };
-}


### PR DESCRIPTION
- Removed struct dictionary from classes.h
- Included `DataFormats/L1GlobalTrigger/interface/L1GtObject.h` in classes.h to avoid build errors with new cxxmodules changes
```
CondFormatsL1TObjects_xr dictionary forward declarations' payload:8:192: 
error: enumeration previously declared with nonfixed underlying type
enum __attribute__((annotate("$clingAutoload$DataFormats/L1GlobalTrigger/interface/L1GtObject.h"))) __attribute__((annotate("$clingAutoload$CondFormats/L1TObjects/interface/L1GtBoard.h"))) L1GtObject : unsigned int;
^
DataFormats/L1GlobalTrigger/interface/L1GtObject.h:28:6: note: previous declaration is here
enum L1GtObject
python:root-6.17.01/core/metacling/src/TCling.cxx:1901: virtual void TCling::RegisterModule(const char*, const char**, const char**, const char*, co
nst char*, void (*)(), const FwdDeclArgsToKeepCollection_t&, const char**, Bool_t, Bool_t): Assertion `cling::Interpreter::kSuccess == compRes && "The forward declarations could not be compiled"' failed.
```