### PR TITLE
DD4hep: Add a Relaxed Condition on Filtering

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDSpecParRegistry.h
+++ b/DetectorDescription/DDCMS/interface/DDSpecParRegistry.h
@@ -26,7 +26,8 @@ namespace cms {
 
   struct DDSpecParRegistry {
     void filter(DDSpecParRefs&, std::string_view, std::string_view) const;
-
+    void filter(DDSpecParRefs&, std::string_view) const;
+    
     DDSpecParMap specpars;
   };
 }

--- a/DetectorDescription/DDCMS/plugins/DDTestSpecParsFilter.cc
+++ b/DetectorDescription/DDCMS/plugins/DDTestSpecParsFilter.cc
@@ -42,21 +42,24 @@ DDTestSpecParsFilter::analyze(const Event&, const EventSetup& iEventSetup)
   LogVerbatim("Geometry") << "DD SpecPar Registry size: " << registry->specpars.size();
 
   DDSpecParRefs myReg;
-  registry->filter(myReg, m_attribute, m_value);
-
+  if(m_value.empty())
+    registry->filter(myReg, m_attribute);
+  else
+    registry->filter(myReg, m_attribute, m_value);
+  
   LogVerbatim("Geometry").log([&myReg](auto& log) {
-      log << "Filtered DD SpecPar Registry size: " << myReg.size();
+      log << "Filtered DD SpecPar Registry size: " << myReg.size() << "\n";
       for(const auto& t: myReg) {
-	log << " = { ";
+	log << "\nRegExps { ";
 	for(const auto& ki : t->paths)
-	  log << ki << ", ";
-	log << " };\n ";
+	  log << ki << " ";
+	log << "};\n ";
 	for(const auto& kl : t->spars) {
-	  log << kl.first << " = { ";
+	  log << kl.first << " = ";
 	  for(const auto& kil : kl.second) {
-	    log << kil << ", ";
+	    log << kil << " ";
 	  }
-	log << " };\n ";
+	log << "\n ";
 	}
       }
     });

--- a/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
+++ b/DetectorDescription/DDCMS/src/DDSpecparRegistry.cc
@@ -53,3 +53,22 @@ DDSpecParRegistry::filter(DDSpecParRefs& refs,
     }
   });
 }
+
+void
+DDSpecParRegistry::filter(DDSpecParRefs& refs,
+			  string_view attribute) const {
+
+  bool found(false);
+  for_each(begin(specpars), end(specpars), [&refs, &attribute,
+					    &found](const auto& k) {
+    found = false;
+    for_each(begin(k.second.spars), end(k.second.spars), [&](const auto& l) {
+	if(l.first == attribute) {
+	  found = true;
+	}
+      });
+    if(found) {
+      refs.emplace_back(&k.second);
+    }
+  });
+}


### PR DESCRIPTION
#### PR description:

* Allow selection on attributes without specified value

#### PR validation:

The DDSpecParRegistry tests are part of the package and run automatically.

#### if this PR is a backport please specify the original PR:

no back-port is needed
