### PR TITLE
Add HTXSFilter

### DIFF
--- a/GeneratorInterface/GenFilters/interface/HTXSFilter.h
+++ b/GeneratorInterface/GenFilters/interface/HTXSFilter.h
@@ -1,0 +1,56 @@
+#ifndef HTXS_FILTER_h
+#define HTXS_FILTER_h
+// -*- C++ -*-
+//
+// Package:    HTXSFilter
+// Class:      HTXSFilter
+// 
+/**\class HTXSFilter HTXSFilter.cc user/HTXSFilter/plugins/HTXSFilter.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Janek Bechtel
+//         Created:  Fri, 10 May 2019 14:30:15 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+//
+// class decleration
+//
+namespace edm {
+  class HiggsClassification;
+}
+
+class HTXSFilter : public edm::global::EDFilter<> {
+   public:
+      explicit HTXSFilter(const edm::ParameterSet&);
+      ~HTXSFilter() override;
+
+
+      bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+   private:
+      // ----------member data ---------------------------
+      
+       const edm::EDGetTokenT<HTXS::HiggsClassification> token_;
+       const std::vector<int> htxs_flags;
+};
+#endif

--- a/GeneratorInterface/GenFilters/src/HTXSFilter.cc
+++ b/GeneratorInterface/GenFilters/src/HTXSFilter.cc
@@ -1,0 +1,75 @@
+// -*- C++ -*-
+//
+// Package:    HTXSFilter
+// Class:      HTXSFilter
+// 
+/**\class HTXSFilter HTXSFilter.cc user/HTXSFilter/plugins/HTXSFilter.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Janek Bechtel
+//         Created:  Fri, 10 May 2019 14:30:15 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include "GeneratorInterface/GenFilters/interface/HTXSFilter.h"
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "SimDataFormats/HTXS/interface/HiggsTemplateCrossSections.h"
+
+
+HTXSFilter::HTXSFilter(const edm::ParameterSet& iConfig) :
+token_(consumes<HTXS::HiggsClassification>(edm::InputTag("rivetProducerHTXS", "HiggsClassification"))),
+htxs_flags(iConfig.getUntrackedParameter("htxs_flags",std::vector <int> ()))
+{
+
+}
+
+
+HTXSFilter::~HTXSFilter()
+{
+ 
+   // do anything here that needs to be done at destruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called on each new Event  ------------
+bool HTXSFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
+{
+   using namespace edm;
+   Handle<HTXS::HiggsClassification> cat;
+   iEvent.getByToken(token_, cat);
+   if(htxs_flags.empty()){
+      edm::LogInfo ("HTXSFilter") << "Selection of HTXS flags to filter is empty. Filtering will not be applied." << std::endl;
+      return true;
+   }
+   if(std::find(htxs_flags.begin(), htxs_flags.end(), cat->stage1_1_cat_pTjet30GeV) != htxs_flags.end()) {
+      return true;
+   } else {
+      return false;
+   }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HTXSFilter);


### PR DESCRIPTION
#### PR description:

This PR adds a new EDFilter to filter events during generation based on their simplified template cross-section classification. It uses the output of the new Stage1.1 HTXS classifier which was merged this morning. This filter will be used for an official MC production to produce only events in weakly populated HTXS to have enough events in these bins for legacy results in the SM H->tautau analysis.

#### PR validation:

The standard tests as well as creation of a GEN-SIM file using this new filter have been run. 

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
