### PR TITLE
refactored first part of PFAlgo::processBlock

### DIFF
--- a/RecoParticleFlow/PFProducer/interface/PFAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFAlgo.h
@@ -38,6 +38,19 @@ class PFSCEnergyCalibration;
 class PFEnergyCalibrationHF;
 class PFMuonAlgo;
 
+class ElementIndices {
+public:
+  std::vector<unsigned> hcalIs;
+  std::vector<unsigned> hoIs;
+  std::vector<unsigned> ecalIs;
+  std::vector<unsigned> trackIs;
+  std::vector<unsigned> ps1Is;
+  std::vector<unsigned> ps2Is;
+
+  std::vector<unsigned> hfEmIs;
+  std::vector<unsigned> hfHadIs;
+};
+
 class PFAlgo {
 
  public:
@@ -129,6 +142,12 @@ class PFAlgo {
 
   /// process one block. can be reimplemented in more sophisticated 
   /// algorithms
+  
+  void egammaFilters(const reco::PFBlockRef &blockref, std::vector<bool>& active, PFEGammaFilters const* pfegamma);
+  void conversionAlgo(const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active);
+  void elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea);
+  int decideType(const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockElement::Type type, std::vector<bool>& active, ElementIndices& inds, std::vector<bool> &deadArea, unsigned int iEle);
+
   void processBlock( const reco::PFBlockRef& blockref,
                              std::list<reco::PFBlockRef>& hcalBlockRefs, 
                              std::list<reco::PFBlockRef>& ecalBlockRefs, PFEGammaFilters const* pfegamma );

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -446,7 +446,9 @@ void PFAlgo::conversionAlgo(const edm::OwnVector<reco::PFBlockElement> &elements
   }
 }
 
-void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea) {
+void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData,
+  const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active,
+  const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea) {
   for(unsigned iEle=0; iEle<elements.size(); iEle++) {
     PFBlockElement::Type type = elements[iEle].type();
 
@@ -495,7 +497,9 @@ void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& li
     assert( !trackRef.isNull() );
 
     if (debug_ ) {
-      cout <<"PFAlgo:processBlock "<<" "<< inds.trackIs.size()<<" "<< inds.ecalIs.size()<<" "<< inds.hcalIs.size()<<" "<< inds.hoIs.size()<<endl;
+      cout <<"PFAlgo:processBlock "<<" "<< inds.trackIs.size()<<" "
+        << inds.ecalIs.size()<<" "<< inds.hcalIs.size()<<" "
+        << inds.hoIs.size()<<endl;
     }
 
     // look for associated elements of all types
@@ -1211,7 +1215,9 @@ void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& li
   } // end of loop 1 on elements iEle of any type
 }
 
-int PFAlgo::decideType(const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockElement::Type type, std::vector<bool>& active, ElementIndices& inds, std::vector<bool> &deadArea, unsigned int iEle) {
+int PFAlgo::decideType(const edm::OwnVector<reco::PFBlockElement> &elements,
+  const reco::PFBlockElement::Type type, std::vector<bool>& active,
+  ElementIndices& inds, std::vector<bool> &deadArea, unsigned int iEle) {
   switch( type ) {
   case PFBlockElement::TRACK:
     if ( active[iEle] ) {

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -267,39 +267,7 @@ void PFAlgo::reconstructParticles( const reco::PFBlockHandle& blockHandle, PFEGa
 }
 
 
-void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
-                           std::list<reco::PFBlockRef>& hcalBlockRefs,
-                           std::list<reco::PFBlockRef>& ecalBlockRefs, PFEGammaFilters const* pfegamma  ) {
-
-  // debug_ = false;
-  assert(!blockref.isNull() );
-  const reco::PFBlock& block = *blockref;
-
-  if(debug_) {
-    cout<<"#########################################################"<<endl;
-    cout<<"#####           Process Block:                      #####"<<endl;
-    cout<<"#########################################################"<<endl;
-    cout<<block<<endl;
-  }
-
-
-  const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();
-  // make a copy of the link data, which will be edited.
-  PFBlock::LinkData linkData =  block.linkData();
-
-  // keep track of the elements which are still active.
-  vector<bool>   active( elements.size(), true );
-
-
-  // //PFElectrons:
-  // usePFElectrons_ external configurable parameter to set the usage of pf electron
-  std::vector<reco::PFCandidate> tempElectronCandidates;
-  tempElectronCandidates.clear();
-
-
-  // New EGamma Reconstruction 10/10/2013
-  if(useEGammaFilters_) {
-
+void PFAlgo::egammaFilters(const reco::PFBlockRef &blockref, std::vector<bool>& active, PFEGammaFilters const* pfegamma) {
     // const edm::ValueMap<reco::GsfElectronRef> & myGedElectronValMap(*valueMapGedElectrons_);
     bool egmLocalDebug = debug_;
     bool egmLocalBlockDebug = false;
@@ -461,122 +429,30 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	} // end isSafe
       } // end isGoodPhoton
     } // end loop on EGM candidates
-  } // end if use EGammaFilters
+}
 
-
-
-  //Lock extra conversion tracks not used by Photon Algo
-  if (usePFConversions_  )
-    {
-      for(unsigned iEle=0; iEle<elements.size(); iEle++) {
-	PFBlockElement::Type type = elements[iEle].type();
-	if(type==PFBlockElement::TRACK)
-	  {
-	    if(elements[iEle].trackRef()->algo() == reco::TrackBase::conversionStep)
-	      active[iEle]=false;
-	    if(elements[iEle].trackRef()->quality(reco::TrackBase::highPurity))continue;
-	    const auto* trackRef = dynamic_cast<const reco::PFBlockElementTrack*>((&elements[iEle]));
-	    if(!(trackRef->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)))continue;
-	    if(!elements[iEle].convRefs().empty())active[iEle]=false;
-	  }
+void PFAlgo::conversionAlgo(const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active) {
+  for(unsigned iEle=0; iEle<elements.size(); iEle++) {
+    PFBlockElement::Type type = elements[iEle].type();
+    if(type==PFBlockElement::TRACK)
+      {
+        if(elements[iEle].trackRef()->algo() == reco::TrackBase::conversionStep)
+          active[iEle]=false;
+        if(elements[iEle].trackRef()->quality(reco::TrackBase::highPurity))continue;
+        const auto* trackRef = dynamic_cast<const reco::PFBlockElementTrack*>((&elements[iEle]));
+        if(!(trackRef->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)))continue;
+        if(!elements[iEle].convRefs().empty())active[iEle]=false;
       }
-    }
+  }
+}
 
-
-
-
-
-  if(debug_)
-    cout<<endl<<"--------------- loop 1 ------------------"<<endl;
-
-  //COLINFEB16
-  // In loop 1, we loop on all elements.
-
-  // The primary goal is to deal with tracks that are:
-  // - not associated to an HCAL cluster
-  // - not identified as an electron.
-  // Those tracks should be predominantly relatively low energy charged
-  // hadrons which are not detected in the ECAL.
-
-  // The secondary goal is to prepare for the next loops
-  // - The ecal and hcal elements are sorted in separate vectors
-  // which will be used as a base for the corresponding loops.
-  // - For tracks which are connected to more than one HCAL cluster,
-  // the links between the track and the cluster are cut for all clusters
-  // but the closest one.
-  // - HF only blocks ( HFEM, HFHAD, HFEM+HFAD) are identified
-
-  // obsolete comments?
-  // loop1:
-  // - sort ecal and hcal elements in separate vectors
-  // - for tracks:
-  //       - lock closest ecal cluster
-  //       - cut link to farthest hcal cluster, if more than 1.
-
-  // vectors to store indices to ho, hcal and ecal elements
-  vector<unsigned> hcalIs;
-  vector<unsigned> hoIs;
-  vector<unsigned> ecalIs;
-  vector<unsigned> trackIs;
-  vector<unsigned> ps1Is;
-  vector<unsigned> ps2Is;
-
-  vector<unsigned> hfEmIs;
-  vector<unsigned> hfHadIs;
-
-  vector<bool> deadArea(elements.size(), false);
-
+void PFAlgo::elementLoop(const reco::PFBlock &block, reco::PFBlock::LinkData& linkData, const edm::OwnVector<reco::PFBlockElement> &elements, std::vector<bool>& active, const reco::PFBlockRef &blockref, ElementIndices& inds, std::vector<bool> &deadArea) {
   for(unsigned iEle=0; iEle<elements.size(); iEle++) {
     PFBlockElement::Type type = elements[iEle].type();
 
     if(debug_ && type != PFBlockElement::BREM ) cout<<endl<<elements[iEle];
-
-    switch( type ) {
-    case PFBlockElement::TRACK:
-      if ( active[iEle] ) {
-	trackIs.push_back( iEle );
-	if(debug_) cout<<"TRACK, stored index, continue"<<endl;
-      }
-      break;
-    case PFBlockElement::ECAL:
-      if ( active[iEle]  ) {
-	ecalIs.push_back( iEle );
-	if(debug_) cout<<"ECAL, stored index, continue"<<endl;
-      }
-      continue;
-    case PFBlockElement::HCAL:
-      if ( active[iEle] ) {
-	if (elements[iEle].clusterRef()->flags() & reco::CaloCluster::badHcalMarker) {
-	  if(debug_) cout<<"HCAL DEAD AREA: remember and skip."<<endl;
-	  active[iEle] = false;
-	  deadArea[iEle] = true;
-	  continue;
-	}
-	hcalIs.push_back( iEle );
-	if(debug_) cout<<"HCAL, stored index, continue"<<endl;
-      }
-      continue;
-    case PFBlockElement::HO:
-      if (useHO_) {
-	if ( active[iEle] ) {
-	  hoIs.push_back( iEle );
-	  if(debug_) cout<<"HO, stored index, continue"<<endl;
-	}
-      }
-      continue;
-    case PFBlockElement::HFEM:
-      if ( active[iEle] ) {
-	hfEmIs.push_back( iEle );
-	if(debug_) cout<<"HFEM, stored index, continue"<<endl;
-      }
-      continue;
-    case PFBlockElement::HFHAD:
-      if ( active[iEle] ) {
-	hfHadIs.push_back( iEle );
-	if(debug_) cout<<"HFHAD, stored index, continue"<<endl;
-      }
-      continue;
-    default:
+    auto ret_decideType = decideType(elements, type, active, inds, deadArea, iEle);
+    if (ret_decideType == 1) {
       continue;
     }
 
@@ -619,7 +495,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
     assert( !trackRef.isNull() );
 
     if (debug_ ) {
-      cout <<"PFAlgo:processBlock "<<" "<<trackIs.size()<<" "<<ecalIs.size()<<" "<<hcalIs.size()<<" "<<hoIs.size()<<endl;
+      cout <<"PFAlgo:processBlock "<<" "<< inds.trackIs.size()<<" "<< inds.ecalIs.size()<<" "<< inds.hcalIs.size()<<" "<< inds.hoIs.size()<<endl;
     }
 
     // look for associated elements of all types
@@ -1333,14 +1209,145 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
       }
     } //loop hcal elements
   } // end of loop 1 on elements iEle of any type
+}
+
+int PFAlgo::decideType(const edm::OwnVector<reco::PFBlockElement> &elements, const reco::PFBlockElement::Type type, std::vector<bool>& active, ElementIndices& inds, std::vector<bool> &deadArea, unsigned int iEle) {
+  switch( type ) {
+  case PFBlockElement::TRACK:
+    if ( active[iEle] ) {
+      inds.trackIs.push_back( iEle );
+      if(debug_) cout<<"TRACK, stored index, continue"<<endl;
+    }
+    break;
+  case PFBlockElement::ECAL:
+    if ( active[iEle]  ) {
+      inds.ecalIs.push_back( iEle );
+      if(debug_) cout<<"ECAL, stored index, continue"<<endl;
+    }
+    return 1; //continue
+  case PFBlockElement::HCAL:
+    if ( active[iEle] ) {
+      if (elements[iEle].clusterRef()->flags() & reco::CaloCluster::badHcalMarker) {
+        if(debug_) cout<<"HCAL DEAD AREA: remember and skip."<<endl;
+        active[iEle] = false;
+        deadArea[iEle] = true;
+        return 1; //continue
+      }
+      inds.hcalIs.push_back( iEle );
+      if(debug_) cout<<"HCAL, stored index, continue"<<endl;
+    }
+    return 1; //continue
+  case PFBlockElement::HO:
+    if (useHO_) {
+      if ( active[iEle] ) {
+        inds.hoIs.push_back( iEle );
+        if(debug_) cout<<"HO, stored index, continue"<<endl;
+      }
+    }
+    return 1; //continue
+  case PFBlockElement::HFEM:
+    if ( active[iEle] ) {
+      inds.hfEmIs.push_back( iEle );
+      if(debug_) cout<<"HFEM, stored index, continue"<<endl;
+    }
+    return 1; //continue
+  case PFBlockElement::HFHAD:
+    if ( active[iEle] ) {
+      inds.hfHadIs.push_back( iEle );
+      if(debug_) cout<<"HFHAD, stored index, continue"<<endl;
+    }
+    return 1; //continue
+  default:
+    return 1; //continue
+  }
+  return 0;
+}
+
+void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
+                           std::list<reco::PFBlockRef>& hcalBlockRefs,
+                           std::list<reco::PFBlockRef>& ecalBlockRefs, PFEGammaFilters const* pfegamma  ) {
+
+  // debug_ = false;
+  assert(!blockref.isNull() );
+  const reco::PFBlock& block = *blockref;
+
+  if(debug_) {
+    cout<<"#########################################################"<<endl;
+    cout<<"#####           Process Block:                      #####"<<endl;
+    cout<<"#########################################################"<<endl;
+    cout<<block<<endl;
+  }
 
 
+  const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();
+  // make a copy of the link data, which will be edited.
+  PFBlock::LinkData linkData =  block.linkData();
+
+  // keep track of the elements which are still active.
+  vector<bool>   active( elements.size(), true );
+
+
+  // //PFElectrons:
+  // usePFElectrons_ external configurable parameter to set the usage of pf electron
+  std::vector<reco::PFCandidate> tempElectronCandidates;
+  tempElectronCandidates.clear();
+
+
+  // New EGamma Reconstruction 10/10/2013
+  if(useEGammaFilters_) {
+    egammaFilters(blockref, active, pfegamma);
+  } // end if use EGammaFilters
+
+
+
+  //Lock extra conversion tracks not used by Photon Algo
+  if (usePFConversions_  ) {
+    conversionAlgo(elements, active);
+  }
+
+
+
+
+
+  if(debug_)
+    cout<<endl<<"--------------- loop 1 ------------------"<<endl;
+
+  //COLINFEB16
+  // In loop 1, we loop on all elements.
+
+  // The primary goal is to deal with tracks that are:
+  // - not associated to an HCAL cluster
+  // - not identified as an electron.
+  // Those tracks should be predominantly relatively low energy charged
+  // hadrons which are not detected in the ECAL.
+
+  // The secondary goal is to prepare for the next loops
+  // - The ecal and hcal elements are sorted in separate vectors
+  // which will be used as a base for the corresponding loops.
+  // - For tracks which are connected to more than one HCAL cluster,
+  // the links between the track and the cluster are cut for all clusters
+  // but the closest one.
+  // - HF only blocks ( HFEM, HFHAD, HFEM+HFAD) are identified
+
+  // obsolete comments?
+  // loop1:
+  // - sort ecal and hcal elements in separate vectors
+  // - for tracks:
+  //       - lock closest ecal cluster
+  //       - cut link to farthest hcal cluster, if more than 1.
+
+  vector<bool> deadArea(elements.size(), false);
+  
+  // vectors to store indices to ho, hcal and ecal elements
+  ElementIndices inds;
+
+  elementLoop(block, linkData, elements, active, blockref, inds, deadArea);
 
   // deal with HF.
-  if( !(hfEmIs.empty() &&  hfHadIs.empty() ) ) {
+  if( !(inds.hfEmIs.empty() &&  inds.hfHadIs.empty() ) ) {
     // there is at least one HF element in this block.
     // so all elements must be HF.
-    assert( hfEmIs.size() + hfHadIs.size() == elements.size() );
+    assert( inds.hfEmIs.size() + inds.hfHadIs.size() == elements.size() );
 
     if( elements.size() == 1 ) {
       //Auguste: HAD-only calibration here
@@ -1364,7 +1371,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	(*pfCandidates_)[tmpi].setHoEnergy( 0., 0.);
 	(*pfCandidates_)[tmpi].setPs1Energy( 0. );
 	(*pfCandidates_)[tmpi].setPs2Energy( 0. );
-	(*pfCandidates_)[tmpi].addElementInBlock( blockref, hfEmIs[0] );
+	(*pfCandidates_)[tmpi].addElementInBlock( blockref, inds.hfEmIs[0] );
 	//std::cout << "HF EM alone ! " << energyHF << std::endl;
 	break;
       case PFLayer::HF_HAD:
@@ -1382,7 +1389,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	(*pfCandidates_)[tmpi].setHoEnergy( 0., 0.);
 	(*pfCandidates_)[tmpi].setPs1Energy( 0. );
 	(*pfCandidates_)[tmpi].setPs2Energy( 0. );
-	(*pfCandidates_)[tmpi].addElementInBlock( blockref, hfHadIs[0] );
+	(*pfCandidates_)[tmpi].addElementInBlock( blockref, inds.hfHadIs[0] );
 	//std::cout << "HF Had alone ! " << energyHF << std::endl;
 	break;
       default:
@@ -1426,8 +1433,8 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
       cand.setHoEnergy( 0., 0.);
       cand.setPs1Energy( 0. );
       cand.setPs2Energy( 0. );
-      cand.addElementInBlock( blockref, hfEmIs[0] );
-      cand.addElementInBlock( blockref, hfHadIs[0] );
+      cand.addElementInBlock( blockref, inds.hfEmIs[0] );
+      cand.addElementInBlock( blockref, inds.hfHadIs[0] );
       //std::cout << "HF EM+HAD found ! " << energyHfEm << " " << energyHfHad << std::endl;
     }
     else {
@@ -1453,7 +1460,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
   // hcal energy
   // rescale
 
-  for(unsigned iHcal : hcalIs) {
+  for(unsigned iHcal : inds.hcalIs) {
     PFBlockElement::Type type = elements[iHcal].type();
 
     assert( type == PFBlockElement::HCAL );
@@ -2617,7 +2624,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 
   //COLINFEB16
   // now dealing with the HCAL elements that are not linked to any track
-  for(unsigned iHcal : hcalIs) {
+  for(unsigned iHcal : inds.hcalIs) {
 
     // Keep ECAL and HO elements for reference in the PFCandidate
     std::vector<unsigned> ecalRefs;
@@ -2837,8 +2844,8 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 
   // for each ecal element iEcal = ecalIs[i] in turn:
 
-  for(unsigned i=0; i<ecalIs.size(); i++) {
-    unsigned iEcal = ecalIs[i];
+  for(unsigned i=0; i<inds.ecalIs.size(); i++) {
+    unsigned iEcal = inds.ecalIs[i];
 
     if(debug_)
       cout<<endl<<elements[iEcal]<<" ";


### PR DESCRIPTION
#### PR description:

Proposal to start refactoring the PFAlgo::processBlock, which is a single function of several thousand lines, into smaller independent subfunctions based on physics functionality. As the original code is laid out quite clearly, simply in a long stream of consciousness, it is easy to factorize.

At this stage, we tackle a part of the `PFAlgo::processBlock`, introducing the following factorizations:

-  `egammaFilters`: code in `PFAlgo::processblock { if(useEGammaFilters_) { ... } }`
-  `conversionAlgo`: code in `PFAlgo::processblock { if(usePFConversions_) { ... } }`
-  `elementLoop`: big loop in PF code ([line in code](https://github.com/cms-sw/cmssw/blob/master/RecoParticleFlow/PFProducer/src/PFAlgo.cc#L493)) that does multiple things:
  o Deals with tracks that are not associated to electrons or HCAL clusters
  o Sorts the ECAL and HCAL elements in separate vectors
  o For tracks which are connected to more than one HCAL cluster, cuts the links between the track and the cluster for all clusters but the closest one

This is meant as an inital PR to start clearing up the PFAlgo code, for which I imagine the path could be something like the following:

- [x] Factorize `PFAlgo::processBlock` to smaller subfunctions (this PR, partly)
- [ ] Sanitize the inputs and outputs of the functions and making sure they rely less on the PFAlgo state
- [ ] Given the cleaned-up implementation from above, revisit the logic/physics of the algo to rewrite it from with Run3/HL-LHC in mind
- [ ] Compare to an eventual ML PF algo that arrives in CMS

#### PR validation:

We do not change the functionality of the PFAlgo, hence the output should not change at all and timing performance should change only in as much as the C++ compiler is able to optimize the code better. We have checked this in a previous version of this PR, see [here](https://github.com/jpata/cmssw/pull/44). Nevertheless, I'm running the following comparisons:
- `runTheMatrix -l 38.0` between 43fd1cfad0b8e9e9a6abd0d1c049a1e860993887 and 3b1ae0778119c710e7bd3428e68a33b8d1fce84b: exactly the same reconstruction output on 10 events, output files have the same number of bytes.

#### if this PR is a backport please specify the original PR:

- Complete implementation in 10_5_X: https://github.com/jpata/cmssw/pull/44.
- First cms-sw PR for the now obsolete `usePFPhotons_`: https://github.com/cms-sw/cmssw/pull/26825.

cc PF group: @hatakeyamak @bendavid 