### PR TITLE
Fix HGCal KDTreeLinkerAlgoT.h: in the non-leaf case both left and right sons must exist

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/KDTreeLinkerAlgoT.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/KDTreeLinkerAlgoT.h
@@ -171,7 +171,7 @@ KDTreeLinkerAlgo<DATA,DIM>::recSearch(const KDTreeNodeT<DATA,DIM> *current,
 	    ((current->left != 0) && (current->right == 0))));
   */
     
-  if ((current->left == nullptr) && (current->right == nullptr)) {//leaf case
+  if ((current->left == nullptr) || (current->right == nullptr)) {//leaf case
   
     // If point inside the rectangle/area
     bool isInside = true;


### PR DESCRIPTION
#### PR description:

As pointed out by the static analyzer, there was the possibility (which shouldn't never happen by construction but still possible in practice) that the code tries to access a null pointer.
This can be avoided by enforcing the check that both pointers that the code tries to access are non-null.

#### PR validation:

The code compiles correctly

@felicepantaleo @rovere 