### PR TITLE
Adding Sistrip DQM Cluster Maps

### DIFF
--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -44,9 +44,9 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 
-//******** Single include for the TkMap *************
+//******** Single include for the TkMap *************/
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"
-//***************************************************
+//***************************************************/
 
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
@@ -122,7 +122,9 @@ private:
                     const TrackerTopology* tTopo,
                     const SiStripGain* stripGain,
                     const SiStripQuality* stripQuality,
-                    const edm::DetSetVector<SiStripDigi>& digilist);
+                    const edm::DetSetVector<SiStripDigi>& digilist,
+		    float clustZ,
+		    float clustPhi);
   template <class T>
   void RecHitInfo(const T* tkrecHit,
                   LocalVector LV,
@@ -166,13 +168,13 @@ private:
 
   std::string topFolderName_;
 
-  //******* TkHistoMaps
+  //******* TkHistoMaps*/
   std::unique_ptr<TkHistoMap> tkhisto_StoNCorrOnTrack, tkhisto_NumOnTrack, tkhisto_NumOffTrack;
   std::unique_ptr<TkHistoMap> tkhisto_ClChPerCMfromOrigin, tkhisto_ClChPerCMfromTrack;
   std::unique_ptr<TkHistoMap> tkhisto_NumMissingHits, tkhisto_NumberInactiveHits, tkhisto_NumberValidHits;
   std::unique_ptr<TkHistoMap> tkhisto_NoiseOnTrack, tkhisto_NoiseOffTrack, tkhisto_ClusterWidthOnTrack,
       tkhisto_ClusterWidthOffTrack;
-  //******** TkHistoMaps
+  //******** TkHistoMaps*/
   int numTracks;
 
   struct ModMEs {
@@ -201,6 +203,7 @@ private:
     MonitorElement* ClusterWidthOnTrack = nullptr;
     MonitorElement* ClusterWidthOffTrack = nullptr;
     MonitorElement* ClusterPosOnTrack = nullptr;
+    MonitorElement* ClusterPosOnTrack2D = nullptr;
     MonitorElement* ClusterPosOffTrack = nullptr;
     MonitorElement* ClusterChargePerCMfromTrack = nullptr;
     MonitorElement* ClusterChargePerCMfromOriginOnTrack = nullptr;
@@ -219,6 +222,7 @@ private:
     MonitorElement* ClusterWidthOnTrack = nullptr;
     MonitorElement* ClusterWidthOffTrack = nullptr;
     MonitorElement* ClusterPosOnTrack = nullptr;
+    MonitorElement* ClusterPosOnTrack2D = nullptr;
     MonitorElement* ClusterPosOffTrack = nullptr;
     MonitorElement* ClusterChargePerCMfromTrack = nullptr;
     MonitorElement* ClusterChargePerCMfromOriginOnTrack = nullptr;

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -557,9 +557,9 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker& ibooker, const uint32_
   hpar = "TH2ClusterPosTEC";
   if ( layer_id.find("TEC") != std::string::npos ){ 
     
-    int nbinR = 8;
-    float rval[9]= {0, 21.2, 30.8, 40.4, 50.0, 60.0, 75.0, 90.0, 110.0};
-    int nmodulesPhi = 40*6; //max number of APV  for a ring
+    static constexpr int   nbinR = 8;
+    static constexpr float rval[9]= {0, 21.2, 30.8, 40.4, 50.0, 60.0, 75.0, 90.0, 110.0};
+    static constexpr int   nmodulesPhi = 40*6; //max number of APV  for a ring
     float phival[nmodulesPhi];
     for(int i=0; i<nmodulesPhi; i++) phival[i] = -3.2+2*i*3.2/nmodulesPhi;
     
@@ -570,9 +570,9 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker& ibooker, const uint32_
   hname = hidmanager.createHistoLayer("Summary_ClusterPosition2D", name, layer_id, "OnTrack");
   hpar = "TH2ClusterPosTID";
   if ( layer_id.find("TID") != std::string::npos ){
-    int nbinR = 4;
-    float rval[5]= {0, 21.2, 30.8, 40.4, 50.0};
-    int nmodulesPhi = 80*4;//max number of APV  for a ring
+    static constexpr int   nbinR = 4;
+    static constexpr float rval[5]= {0, 21.2, 30.8, 40.4, 50.0};
+    static constexpr int   nmodulesPhi = 80*4;//max number of APV  for a ring
     float phival[nmodulesPhi];
     for(int i=0; i<nmodulesPhi; i++) phival[i] = -3.2+i*2*3.2/nmodulesPhi;
     


### PR DESCRIPTION
#### PR description:

Addition of TH2F plots showing the z-phi (r-phi) position of on track hits for the SiStrip barrel (endcaps). The plots are made per layer (per disk).

#### PR validation:

Compiles with CMSSW_11_0_X_2019-05-20-2300, tested with "runTheMatrix.py -l 10024 " and for 100 events.
