### PR TITLE
Use unique_ptr constructor for PluginFactory plugin in HGCalLayerClusterProducer

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterProducer.cc
@@ -83,7 +83,7 @@ HGCalLayerClusterProducer::HGCalLayerClusterProducer(const edm::ParameterSet &ps
 
 
   auto pluginPSet = ps.getParameter<edm::ParameterSet>("plugin");
-  algo.reset(HGCalLayerClusterAlgoFactory::get()->create(pluginPSet.getParameter<std::string>("type"), pluginPSet));
+  algo = std::unique_ptr<HGCalClusteringAlgoBase>{HGCalLayerClusterAlgoFactory::get()->create(pluginPSet.getParameter<std::string>("type"), pluginPSet)};
   algo->setAlgoId(algoId);
 
   produces<std::vector<reco::BasicCluster> >();


### PR DESCRIPTION
#### PR description:

This PR is a preparatory step to change PluginFactory to return `std::unique_ptr`.

#### PR validation:

Code compiles.