### PR TITLE
Herwig7 fix seg fault master

### DIFF
--- a/Configuration/Generator/python/Herwig7Settings/Herwig7LHECommonSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7LHECommonSettings_cfi.py
@@ -12,6 +12,7 @@ herwig7LHECommonSettingsBlock = cms.PSet(
         'set LesHouchesHandler:DecayHandler /Herwig/Decays/DecayHandler',
         'set LesHouchesHandler:HadronizationHandler /Herwig/Hadronization/ClusterHadHandler',
         'set LesHouchesHandler:WeightOption VarNegWeight',
+        'set LesHouchesHandler:Weighted On',
         'set /Herwig/Generators/EventGenerator:EventHandler /Herwig/EventHandlers/LesHouchesHandler',
         'create ThePEG::Cuts /Herwig/Cuts/NoCuts',
         'create ThePEG::LHAPDF /Herwig/Partons/LHAPDF ThePEGLHAPDF.so',

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7PSWeightsSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7PSWeightsSettings_cfi.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+herwig7PSWeightsSettingsBlock = cms.PSet(
+    hw_PSWeights_settings = cms.vstring(
+        'cd /',
+        'cd /Herwig/Shower',
+        'do ShowerHandler:AddVariation RedHighAll 1.141 1.141  All',
+        'do ShowerHandler:AddVariation RedLowAll 0.707 0.707 All',
+        'do ShowerHandler:AddVariation DefHighAll 2 2 All',
+        'do ShowerHandler:AddVariation DefLowAll 0.5 0.5 All',
+        'do ShowerHandler:AddVariation ConHighAll 4 4 All',
+        'do ShowerHandler:AddVariation ConLowAll 0.25 0.25 All',
+        'do ShowerHandler:AddVariation RedHighHard 1.141 1.141  Hard',
+        'do ShowerHandler:AddVariation RedLowHard 0.707 0.707 Hard',
+        'do ShowerHandler:AddVariation DefHighHard 2 2 Hard',
+        'do ShowerHandler:AddVariation DefLowHard 0.5 0.5 Hard',
+        'do ShowerHandler:AddVariation ConHighHard 4 4 Hard',
+        'do ShowerHandler:AddVariation ConLowHard 0.25 0.25 Hard',
+        'do ShowerHandler:AddVariation RedHighSecondary 1.141 1.141  Secondary',
+        'do ShowerHandler:AddVariation RedLowSecondary 0.707 0.707 Secondary',
+        'do ShowerHandler:AddVariation DefHighSecondary 2 2 Secondary',
+        'do ShowerHandler:AddVariation DefLowSecondary 0.5 0.5 Secondary',
+        'do ShowerHandler:AddVariation ConHighSecondary 4 4 Secondary',
+        'do ShowerHandler:AddVariation ConLowSecondary 0.25 0.25 Secondary',
+        'set SplittingGenerator:Detuning 2.0',
+        'cd /',
+    )
+)

--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -2,8 +2,11 @@
 Marco A. Harrendorf
 **/
 
+
 #ifndef GeneratorInterface_Herwig7Interface_Herwig7Interface_h
 #define GeneratorInterface_Herwig7Interface_Herwig7Interface_h
+
+
 
 #include <memory>
 #include <string>
@@ -25,60 +28,76 @@ Marco A. Harrendorf
 
 namespace ThePEG {
 
-  template <>
-  struct HepMCTraits<HepMC::GenEvent>
-      : public HepMCTraitsBase<HepMC::GenEvent, HepMC::GenParticle, HepMC::GenVertex, HepMC::Polarization, HepMC::PdfInfo> {
-  };
+  template<> struct HepMCTraits<HepMC::GenEvent> :
+                public HepMCTraitsBase<
+    HepMC::GenEvent, HepMC::GenParticle,
+    HepMC::GenVertex, HepMC::Polarization,
+    HepMC::PdfInfo> {};
 
-}  // namespace ThePEG
+}
 
 namespace CLHEP {
   class HepRandomEngine;
 }
 
 class Herwig7Interface {
-public:
-  Herwig7Interface(const edm::ParameterSet &params);
-  ~Herwig7Interface() noexcept;
+    public:
+	Herwig7Interface(const edm::ParameterSet &params);
+	~Herwig7Interface() noexcept;
 
-  void setPEGRandomEngine(CLHEP::HepRandomEngine *);
+        void setPEGRandomEngine(CLHEP::HepRandomEngine*);
 
-  ThePEG::EGPtr eg_;
+	ThePEG::EGPtr				eg_;
 
-protected:
-  void initRepository(const edm::ParameterSet &params);
-  bool initGenerator();
-  void flushRandomNumberGenerator();
 
-  static std::unique_ptr<HepMC::GenEvent> convert(const ThePEG::EventPtr &event);
 
-  static double pthat(const ThePEG::EventPtr &event);
+    protected:
+	void initRepository(const edm::ParameterSet &params);
+	bool initGenerator();
+	void flushRandomNumberGenerator();
 
-  std::unique_ptr<HepMC::IO_BaseClass> iobc_;
+	static std::auto_ptr<HepMC::GenEvent>
+				convert(const ThePEG::EventPtr &event);
 
-  // HerwigUi contains settings piped to Herwig7
-  Herwig::HerwigUIProvider *HwUI_;
+	static double pthat(const ThePEG::EventPtr &event);
 
-  /**
+	
+
+	std::auto_ptr<HepMC::IO_BaseClass>	iobc_;
+
+	// HerwigUi contains settings piped to Herwig7
+	std::shared_ptr<Herwig::HerwigUIProvider> HwUI_;
+
+	/**
         * Function calls Herwig event generator via API
 	*
 	* According to the run mode different steps of event generation are done
 	**/
-  void callHerwigGenerator();
+	void callHerwigGenerator();
 
-  // The Inputfile ist created according to the parameter set
-  void createInputFile(const edm::ParameterSet &params);
 
-private:
-  boost::shared_ptr<ThePEG::RandomEngineGlue::Proxy> randomEngineGlueProxy_;
+	// The Inputfile ist created according to the parameter set
+	void createInputFile(const edm::ParameterSet &params);
 
-  const std::string dataLocation_;
-  const std::string generator_;
-  const std::string run_;
-  // File name containing Herwig input config
-  std::string dumpConfig_;
-  const unsigned int skipEvents_;
-  CLHEP::HepRandomEngine *randomEngine;
+
+
+    private:
+	boost::shared_ptr<ThePEG::RandomEngineGlue::Proxy>
+						randomEngineGlueProxy_;
+
+	const std::string			dataLocation_;
+	const std::string			generator_;
+	const std::string			run_;
+	// File name containing Herwig input config 
+	std::string				dumpConfig_;
+	const unsigned int			skipEvents_;
+    CLHEP::HepRandomEngine* randomEngine;
 };
 
-#endif  // GeneratorInterface_Herwig7Interface_Herwig7Interface_h
+
+
+
+
+
+
+#endif // GeneratorInterface_Herwig7Interface_Herwig7Interface_h

--- a/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
+++ b/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
@@ -10,6 +10,8 @@
 #include <ThePEG/Config/ThePEG.h>
 #include <ThePEG/LesHouches/LesHouchesReader.h>
 
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
@@ -24,135 +26,202 @@
 
 #include "GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h"
 
+#include <Herwig/API/HerwigAPI.h>
+#include "CLHEP/Random/RandomEngine.h"
+
 namespace CLHEP {
   class HepRandomEngine;
 }
 
 class Herwig7Hadronizer : public Herwig7Interface, public gen::BaseHadronizer {
-public:
-  Herwig7Hadronizer(const edm::ParameterSet &params);
-  ~Herwig7Hadronizer() override;
+    public:
+	Herwig7Hadronizer(const edm::ParameterSet &params);
+	~Herwig7Hadronizer() override;
 
-  bool readSettings(int) { return true; }
-  bool initializeForInternalPartons();
-  bool initializeForExternalPartons();
-  bool declareStableParticles(const std::vector<int> &pdgIds);
-  bool declareSpecialSettings(const std::vector<std::string>) { return true; }
+	bool readSettings( int ) { return true; }
+	bool initializeForInternalPartons();
+	bool initializeForExternalPartons();
+	bool declareStableParticles(const std::vector<int> &pdgIds);
+	bool declareSpecialSettings( const std::vector<std::string> ) { return true; }
 
-  void statistics();
+	void statistics();
 
-  bool generatePartonsAndHadronize();
-  bool hadronize();
-  bool decay();
-  bool residualDecay();
-  void finalizeEvent();
+	bool generatePartonsAndHadronize();
+	bool hadronize();
+	bool decay();
+	bool residualDecay();
+	void finalizeEvent();
 
-  const char *classname() const { return "Herwig7Hadronizer"; }
+	const char *classname() const { return "Herwig7Hadronizer"; }
+	GenLumiInfoHeader *getGenLumiInfoHeader() const override;
+ 	void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+ 	void randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine);
 
-private:
-  void doSetRandomEngine(CLHEP::HepRandomEngine *v) override { setPEGRandomEngine(v); }
 
-  unsigned int eventsToPrint;
+    private:
 
-  ThePEG::EventPtr thepegEvent;
+        void doSetRandomEngine(CLHEP::HepRandomEngine* v) override { setPEGRandomEngine(v); }
 
-  boost::shared_ptr<lhef::LHEProxy> proxy_;
-  const std::string handlerDirectory_;
-  edm::ParameterSet paramSettings;
-  const std::string runFileName;
+	unsigned int			eventsToPrint;
+
+	ThePEG::EventPtr		thepegEvent;
+	
+	std::shared_ptr<lhef::LHEProxy> proxy_;
+	const std::string		handlerDirectory_;
+	edm::ParameterSet 	paramSettings;
+	const std::string runFileName;
+
+	unsigned int firstLumiBlock=0;
+	unsigned int currentLumiBlock=0;
 };
 
-Herwig7Hadronizer::Herwig7Hadronizer(const edm::ParameterSet &pset)
-    : Herwig7Interface(pset),
-      BaseHadronizer(pset),
-      eventsToPrint(pset.getUntrackedParameter<unsigned int>("eventsToPrint", 0)),
-      handlerDirectory_(pset.getParameter<std::string>("eventHandlers")),
-      runFileName(pset.getParameter<std::string>("run")) {
-  initRepository(pset);
-  paramSettings = pset;
+Herwig7Hadronizer::Herwig7Hadronizer(const edm::ParameterSet &pset) :
+	Herwig7Interface(pset),
+	BaseHadronizer(pset),
+	eventsToPrint(pset.getUntrackedParameter<unsigned int>("eventsToPrint", 0)),
+	handlerDirectory_(pset.getParameter<std::string>("eventHandlers")),
+	runFileName(pset.getParameter<std::string>("run"))
+{  
+	initRepository(pset);
+	paramSettings = pset;
 }
 
-Herwig7Hadronizer::~Herwig7Hadronizer() {}
+Herwig7Hadronizer::~Herwig7Hadronizer()
+{
+}
 
-bool Herwig7Hadronizer::initializeForInternalPartons() {
-  std::ifstream runFile(runFileName + ".run");
-  if (runFile.fail())  //required for showering of LHE files
+bool Herwig7Hadronizer::initializeForInternalPartons()
+{
+
+	if (currentLumiBlock==firstLumiBlock)
+	{
+		std::ifstream runFile(runFileName+".run");
+		if (runFile.fail()) //required for showering of LHE files
+		{
+			initRepository(paramSettings);
+		}
+		if (!initGenerator())
+		{
+			edm::LogInfo("Generator|Herwig7Hadronizer") << "No run step for Herwig chosen. Program will be aborted.";
+			exit(0);
+		}
+	}
+	return true;
+}
+
+bool Herwig7Hadronizer::initializeForExternalPartons()
+{
+	edm::LogError("Herwig7 interface") << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
+	return false;
+}
+
+bool Herwig7Hadronizer::declareStableParticles(const std::vector<int> &pdgIds)
+{
+	return false;
+}
+
+void Herwig7Hadronizer::statistics()
+{
+	if(eg_){
+		runInfo().setInternalXSec(GenRunInfoProduct::XSec(
+			eg_->integratedXSec() / ThePEG::picobarn,
+			eg_->integratedXSecErr() / ThePEG::picobarn));
+	}
+}
+
+bool Herwig7Hadronizer::generatePartonsAndHadronize()
+{
+	edm::LogInfo("Generator|Herwig7Hadronizer") << "Start production";
+
+
+        try {
+                thepegEvent = eg_->shoot();
+        } catch (std::exception& exc) {
+                edm::LogWarning("Generator|Herwig7Hadronizer") << "EGPtr::shoot() thrown an exception, event skipped: " << exc.what();
+                return false;
+        }
+
+        if (!thepegEvent) {
+                edm::LogWarning("Generator|Herwig7Hadronizer") << "thepegEvent not initialized";
+                return false;
+        }
+
+        event() = convert(thepegEvent);
+        if (!event().get()) {
+                edm::LogWarning("Generator|Herwig7Hadronizer") << "genEvent not initialized";
+                return false;
+        }
+
+        return true;
+}
+
+bool Herwig7Hadronizer::hadronize()
+{
+
+	edm::LogError("Herwig7 interface") << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
+	return false;
+}
+
+void Herwig7Hadronizer::finalizeEvent()
+{
+	eventInfo().reset(new GenEventInfoProduct(event().get()));
+	eventInfo()->setBinningValues(
+			std::vector<double>(1, pthat(thepegEvent)));
+
+	if (eventsToPrint) {
+		eventsToPrint--;
+		event()->print();
+	}
+
+	if (iobc_.get())
+		iobc_->write_event(event().get());
+
+	edm::LogInfo("Generator|Herwig7Hadronizer") << "Event produced";
+}
+
+bool Herwig7Hadronizer::decay()
+{
+	return true;
+}
+
+bool Herwig7Hadronizer::residualDecay()
+{
+	return true;
+}
+
+GenLumiInfoHeader *Herwig7Hadronizer::getGenLumiInfoHeader() const {
+  GenLumiInfoHeader *genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
+
+  if (thepegEvent)
   {
-    initRepository(paramSettings);
+  	int weights_number = thepegEvent->optionalWeights().size();
+
+	  if(weights_number > 1){
+	    genLumiInfoHeader->weightNames().reserve(weights_number + 1);
+	    genLumiInfoHeader->weightNames().push_back("nominal");
+	    std::map<std::string,double> weights_map = thepegEvent->optionalWeights();
+		for (std::map<std::string,double>::iterator it = weights_map.begin(); it != weights_map.end(); it++)
+		{
+		  	genLumiInfoHeader->weightNames().push_back(it->first);
+		}
+ 	 }
   }
-  if (!initGenerator()) {
-    edm::LogInfo("Generator|Herwig7Hadronizer") << "No run step for Herwig chosen. Program will be aborted.";
-    exit(0);
-  }
-  return true;
+
+  return genLumiInfoHeader;
 }
 
-bool Herwig7Hadronizer::initializeForExternalPartons() {
-  edm::LogError("Herwig7 interface")
-      << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
-  return false;
+void Herwig7Hadronizer::randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine)
+{
+	BaseHadronizer::randomizeIndex(lumi, rengine);
+	
+	if (firstLumiBlock==0)
+	{
+		firstLumiBlock=lumi.id().luminosityBlock();
+	}
+	currentLumiBlock=lumi.id().luminosityBlock();
+
 }
 
-bool Herwig7Hadronizer::declareStableParticles(const std::vector<int> &pdgIds) { return false; }
-
-void Herwig7Hadronizer::statistics() {
-  if (eg_) {
-    runInfo().setInternalXSec(
-        GenRunInfoProduct::XSec(eg_->integratedXSec() / ThePEG::picobarn, eg_->integratedXSecErr() / ThePEG::picobarn));
-  }
-}
-
-bool Herwig7Hadronizer::generatePartonsAndHadronize() {
-  edm::LogInfo("Generator|Herwig7Hadronizer") << "Start production";
-
-  flushRandomNumberGenerator();
-
-  try {
-    thepegEvent = eg_->shoot();
-  } catch (std::exception &exc) {
-    edm::LogWarning("Generator|Herwig7Hadronizer")
-        << "EGPtr::shoot() thrown an exception, event skipped: " << exc.what();
-    return false;
-  }
-
-  if (!thepegEvent) {
-    edm::LogWarning("Generator|Herwig7Hadronizer") << "thepegEvent not initialized";
-    return false;
-  }
-
-  event() = convert(thepegEvent);
-  if (!event().get()) {
-    edm::LogWarning("Generator|Herwig7Hadronizer") << "genEvent not initialized";
-    return false;
-  }
-
-  return true;
-}
-
-bool Herwig7Hadronizer::hadronize() {
-  edm::LogError("Herwig7 interface")
-      << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
-  return false;
-}
-
-void Herwig7Hadronizer::finalizeEvent() {
-  eventInfo().reset(new GenEventInfoProduct(event().get()));
-  eventInfo()->setBinningValues(std::vector<double>(1, pthat(thepegEvent)));
-
-  if (eventsToPrint) {
-    eventsToPrint--;
-    event()->print();
-  }
-
-  if (iobc_.get())
-    iobc_->write_event(event().get());
-
-  edm::LogInfo("Generator|Herwig7Hadronizer") << "Event produced";
-}
-
-bool Herwig7Hadronizer::decay() { return true; }
-
-bool Herwig7Hadronizer::residualDecay() { return true; }
 
 #include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
 

--- a/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
+++ b/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
@@ -53,7 +53,7 @@ class Herwig7Hadronizer : public Herwig7Interface, public gen::BaseHadronizer {
 	void finalizeEvent();
 
 	const char *classname() const { return "Herwig7Hadronizer"; }
-	GenLumiInfoHeader *getGenLumiInfoHeader() const override;
+	std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const override;
  	void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
  	void randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine);
 
@@ -189,8 +189,8 @@ bool Herwig7Hadronizer::residualDecay()
 	return true;
 }
 
-GenLumiInfoHeader *Herwig7Hadronizer::getGenLumiInfoHeader() const {
-  GenLumiInfoHeader *genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
+std::unique_ptr<GenLumiInfoHeader> Herwig7Hadronizer::getGenLumiInfoHeader() const {
+  auto genLumiInfoHeader = BaseHadronizer::getGenLumiInfoHeader();
 
   if (thepegEvent)
   {

--- a/GeneratorInterface/Herwig7Interface/python/Herwig7_loadCommonSettings_cff.py
+++ b/GeneratorInterface/Herwig7Interface/python/Herwig7_loadCommonSettings_cff.py
@@ -12,10 +12,13 @@ from Configuration.Generator.Herwig7Settings.Herwig7LHECommonSettings_cfi import
 from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_cfi import *
 from Configuration.Generator.Herwig7Settings.Herwig7CH3TuneSettings_cfi import *
 from Configuration.Generator.Herwig7Settings.Herwig7LHEPowhegSettings_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7PSWeightsSettings_cfi import *
+
 
 generator = cms.EDFilter("Herwig7GeneratorFilter",
     herwig7LHECommonSettingsBlock,
     herwig7LHEPowhegSettingsBlock,
+    herwig7PSWeightsSettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7CH3SettingsBlock,
     configFiles = cms.vstring(),
@@ -37,6 +40,7 @@ generator = cms.EDFilter("Herwig7GeneratorFilter",
         'herwig7CH3AlphaS', 
         'herwig7CH3MPISettings', 
         'herwig7StableParticlesForDetector',
+        'hw_PSWeights_settings',
         'hw_user_settings'
     ),
     repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
@@ -62,7 +62,7 @@ Herwig7Interface::Herwig7Interface(const edm::ParameterSet &pset) :
 	// Write events in hepmc ascii format for debugging purposes
 	string dumpEvents = pset.getUntrackedParameter<string>("dumpEvents", "");
 	if (!dumpEvents.empty()) {
-		iobc_.reset(new HepMC::IO_GenEvent(dumpEvents.c_str(), ios::out));
+		iobc_.reset(new HepMC::IO_GenEvent(dumpEvents, ios::out));
 		edm::LogInfo("ThePEGSource") << "Event logging switched on (=> " << dumpEvents << ")";
 	}
 	// Clear dumpConfig target

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
@@ -28,7 +28,7 @@
 #include <ThePEG/Handlers/EventHandler.h>
 #include <ThePEG/Handlers/XComb.h>
 #include <ThePEG/EventRecord/Event.h>
-#include <ThePEG/EventRecord/Particle.h>
+#include <ThePEG/EventRecord/Particle.h> 
 #include <ThePEG/EventRecord/Collision.h>
 #include <ThePEG/EventRecord/TmpTransform.h>
 #include <ThePEG/Config/ThePEG.h>
@@ -36,6 +36,7 @@
 #include <ThePEG/PDF/PDFBase.h>
 #include <ThePEG/Utilities/UtilityBase.h>
 #include <ThePEG/Vectors/HepMCConverter.h>
+
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -50,174 +51,188 @@
 using namespace std;
 using namespace gen;
 
-Herwig7Interface::Herwig7Interface(const edm::ParameterSet &pset)
-    : randomEngineGlueProxy_(ThePEG::RandomEngineGlue::Proxy::create()),
-      dataLocation_(ParameterCollector::resolve(pset.getParameter<string>("dataLocation"))),
-      generator_(pset.getParameter<string>("generatorModule")),
-      run_(pset.getParameter<string>("run")),
-      dumpConfig_(pset.getUntrackedParameter<string>("dumpConfig", "HerwigConfig.in")),
-      skipEvents_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0)) {
-  // Write events in hepmc ascii format for debugging purposes
-  string dumpEvents = pset.getUntrackedParameter<string>("dumpEvents", "");
-  if (!dumpEvents.empty()) {
-    iobc_.reset(new HepMC::IO_GenEvent(dumpEvents, ios::out));
-    edm::LogInfo("ThePEGSource") << "Event logging switched on (=> " << dumpEvents << ")";
-  }
-  // Clear dumpConfig target
-  if (!dumpConfig_.empty())
-    ofstream cfgDump(dumpConfig_.c_str(), ios_base::trunc);
+Herwig7Interface::Herwig7Interface(const edm::ParameterSet &pset) :
+	randomEngineGlueProxy_(ThePEG::RandomEngineGlue::Proxy::create()),
+	dataLocation_(ParameterCollector::resolve(pset.getParameter<string>("dataLocation"))),
+	generator_(pset.getParameter<string>("generatorModule")),
+	run_(pset.getParameter<string>("run")),
+	dumpConfig_(pset.getUntrackedParameter<string>("dumpConfig", "HerwigConfig.in")),
+	skipEvents_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0))
+{
+	// Write events in hepmc ascii format for debugging purposes
+	string dumpEvents = pset.getUntrackedParameter<string>("dumpEvents", "");
+	if (!dumpEvents.empty()) {
+		iobc_.reset(new HepMC::IO_GenEvent(dumpEvents.c_str(), ios::out));
+		edm::LogInfo("ThePEGSource") << "Event logging switched on (=> " << dumpEvents << ")";
+	}
+	// Clear dumpConfig target
+	if (!dumpConfig_.empty())
+		ofstream cfgDump(dumpConfig_.c_str(), ios_base::trunc);
 }
 
-Herwig7Interface::~Herwig7Interface() noexcept {
-  if (eg_)
-    eg_->finalize();
-  edm::LogInfo("Herwig7Interface") << "Event generator finalized";
+Herwig7Interface::~Herwig7Interface () noexcept
+{
+	if (eg_)
+		eg_->finalize();
+	edm::LogInfo("Herwig7Interface") << "Event generator finalized";
 }
 
-void Herwig7Interface::setPEGRandomEngine(CLHEP::HepRandomEngine *v) {
-  randomEngineGlueProxy_->setRandomEngine(v);
-  randomEngine = v;
-  ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
-  if (rnd) {
-    rnd->setRandomEngine(v);
-  }
+void Herwig7Interface::setPEGRandomEngine(CLHEP::HepRandomEngine* v) {
+    
+        randomEngineGlueProxy_->setRandomEngine(v);
+        randomEngine = v;
+        ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
+        if(rnd) {
+            rnd->setRandomEngine(v);
+        }
 }
 
-void Herwig7Interface::initRepository(const edm::ParameterSet &pset) {
-  std::string runModeTemp = pset.getUntrackedParameter<string>("runModeList", "read,run");
 
-  // To Lower
-  std::transform(runModeTemp.begin(), runModeTemp.end(), runModeTemp.begin(), ::tolower);
+void Herwig7Interface::initRepository(const edm::ParameterSet &pset)
+{
+	std::string runModeTemp = pset.getUntrackedParameter<string>("runModeList","read,run");
 
-  while (!runModeTemp.empty()) {
-    // Split first part of List
-    std::string choice;
-    size_t pos = runModeTemp.find(",");
-    if (std::string::npos == pos)
-      choice = runModeTemp;
-    else
-      choice = runModeTemp.substr(0, pos);
+	// To Lower
+	std::transform(runModeTemp.begin(), runModeTemp.end(), runModeTemp.begin(), ::tolower);
 
-    if (pos == std::string::npos)
-      runModeTemp.erase();
-    else
-      runModeTemp.erase(0, pos + 1);
 
-    // construct HerwigUIProvider object and return it as global object
-    HwUI_ = new Herwig::HerwigUIProvider(pset, dumpConfig_, Herwig::RunMode::READ);
-    edm::LogInfo("Herwig7Interface") << "HerwigUIProvider object with run mode " << HwUI_->runMode() << " created.\n";
 
-    // Chose run mode
-    if (choice == "read") {
-      createInputFile(pset);
-      HwUI_->setRunMode(Herwig::RunMode::READ, pset, dumpConfig_);
-      edm::LogInfo("Herwig7Interface") << "Input file " << dumpConfig_
-                                       << " will be passed to Herwig for the read step.\n";
-      callHerwigGenerator();
-    } else if (choice == "build") {
-      createInputFile(pset);
-      HwUI_->setRunMode(Herwig::RunMode::BUILD, pset, dumpConfig_);
-      edm::LogInfo("Herwig7Interface") << "Input file " << dumpConfig_
-                                       << " will be passed to Herwig for the build step.\n";
-      callHerwigGenerator();
+	while(!runModeTemp.empty())
+	{
+		// Split first part of List
+		std::string choice;
+		size_t pos = runModeTemp.find(",");
+        if (std::string::npos == pos)
+            choice=runModeTemp;
+        else
+		    choice = runModeTemp.substr(0, pos);
+        
+		if (pos == std::string::npos)
+			runModeTemp.erase();
+        else
+            runModeTemp.erase(0, pos+1);
 
-    } else if (choice == "integrate") {
-      std::string runFileName = run_ + ".run";
-      edm::LogInfo("Herwig7Interface") << "Run file " << runFileName
-                                       << " will be passed to Herwig for the integrate step.\n";
-      HwUI_->setRunMode(Herwig::RunMode::INTEGRATE, pset, runFileName);
-      callHerwigGenerator();
+		HwUI_.reset(new Herwig::HerwigUIProvider(pset, dumpConfig_, Herwig::RunMode::READ));
+		edm::LogInfo("Herwig7Interface") << "HerwigUIProvider object with run mode " << HwUI_->runMode() << " created.\n";
 
-    } else if (choice == "run") {
-      std::string runFileName = run_ + ".run";
-      edm::LogInfo("Herwig7Interface") << "Run file " << runFileName << " will be passed to Herwig for the run step.\n";
-      HwUI_->setRunMode(Herwig::RunMode::RUN, pset, runFileName);
-    } else {
-      edm::LogInfo("Herwig7Interface") << "Cannot recognize \"" << choice << "\".\n"
-                                       << "Trying to skip step.\n";
-      continue;
-    }
-  }
+
+		// Chose run mode
+		if	( choice == "read" )
+		{
+			createInputFile(pset);
+			HwUI_->setRunMode(Herwig::RunMode::READ, pset, dumpConfig_);
+			edm::LogInfo("Herwig7Interface") << "Input file " << dumpConfig_ << " will be passed to Herwig for the read step.\n";
+			callHerwigGenerator();
+		}
+		else if	( choice == "build" )
+		{
+			createInputFile(pset);
+			HwUI_->setRunMode(Herwig::RunMode::BUILD, pset, dumpConfig_);
+			edm::LogInfo("Herwig7Interface") << "Input file " << dumpConfig_ << " will be passed to Herwig for the build step.\n";
+			callHerwigGenerator();
+
+		}
+		else if	( choice == "integrate" )
+		{
+			std::string runFileName = run_ + ".run";
+			edm::LogInfo("Herwig7Interface") << "Run file " << runFileName << " will be passed to Herwig for the integrate step.\n";
+			HwUI_->setRunMode(Herwig::RunMode::INTEGRATE, pset, runFileName);
+			callHerwigGenerator();
+
+		}
+		else if	( choice == "run" )
+		{
+			std::string runFileName = run_ + ".run";
+			edm::LogInfo("Herwig7Interface") << "Run file " << runFileName << " will be passed to Herwig for the run step.\n";
+			HwUI_->setRunMode(Herwig::RunMode::RUN, pset, runFileName);
+		}
+		else
+		{
+			edm::LogInfo("Herwig7Interface") << "Cannot recognize \"" << choice << "\".\n"
+							 << "Trying to skip step.\n";
+			continue;
+		}
+
+	}
+
 }
 
-void Herwig7Interface::callHerwigGenerator() {
+void Herwig7Interface::callHerwigGenerator()
+{
   try {
-    edm::LogInfo("Herwig7Interface") << "callHerwigGenerator function invoked with run mode " << HwUI_->runMode()
-                                     << ".\n";
+
+    edm::LogInfo("Herwig7Interface") << "callHerwigGenerator function invoked with run mode " << HwUI_->runMode() << ".\n";
 
     // Call program switches according to runMode
-    switch (HwUI_->runMode()) {
-      case Herwig::RunMode::INIT:
-        Herwig::API::init(*HwUI_);
-        break;
-      case Herwig::RunMode::READ:
-        Herwig::API::read(*HwUI_);
-        break;
-      case Herwig::RunMode::BUILD:
-        Herwig::API::build(*HwUI_);
-        break;
-      case Herwig::RunMode::INTEGRATE:
-        Herwig::API::integrate(*HwUI_);
-        break;
-      case Herwig::RunMode::MERGEGRIDS:
-        Herwig::API::mergegrids(*HwUI_);
-        break;
-      case Herwig::RunMode::RUN: {
-        HwUI_->setSeed(randomEngine->getSeed());
-        eg_ = Herwig::API::prepareRun(*HwUI_);
-        break;
-      }
-      case Herwig::RunMode::ERROR:
-        edm::LogError("Herwig7Interface") << "Error during read in of command line parameters.\n"
-                                          << "Program execution will stop now.";
-        return;
-      default:
-        HwUI_->quitWithHelp();
+    switch ( HwUI_->runMode() ) {
+    case Herwig::RunMode::INIT:        Herwig::API::init(*HwUI_);       break;
+    case Herwig::RunMode::READ:        Herwig::API::read(*HwUI_);       break;
+    case Herwig::RunMode::BUILD:       Herwig::API::build(*HwUI_);      break;
+    case Herwig::RunMode::INTEGRATE:   Herwig::API::integrate(*HwUI_);  break;
+    case Herwig::RunMode::MERGEGRIDS:  Herwig::API::mergegrids(*HwUI_); break;
+    case Herwig::RunMode::RUN:         {    
+                                            HwUI_->setSeed(randomEngine->getSeed());
+                                            eg_ =  Herwig::API::prepareRun(*HwUI_); break;}
+    case Herwig::RunMode::ERROR:       
+      edm::LogError("Herwig7Interface") << "Error during read in of command line parameters.\n"
+                << "Program execution will stop now."; 
+      return;
+    default:          		     
+      HwUI_->quitWithHelp();
     }
 
     return;
 
-  } catch (ThePEG::Exception &e) {
+  }
+  catch ( ThePEG::Exception & e ) {
     edm::LogError("Herwig7Interface") << ": ThePEG::Exception caught.\n"
-                                      << e.what() << '\n'
-                                      << "See logfile for details.\n";
-    return;
-  } catch (std::exception &e) {
-    edm::LogError("Herwig7Interface") << ": " << e.what() << '\n';
-    return;
-  } catch (const char *what) {
-    edm::LogError("Herwig7Interface") << ": caught exception: " << what << "\n";
+              << e.what() << '\n'
+      	      << "See logfile for details.\n";
     return;
   }
+  catch ( std::exception & e ) {
+    edm::LogError("Herwig7Interface") << ": " << e.what() << '\n';
+    return;
+  }
+  catch ( const char* what ) {
+    edm::LogError("Herwig7Interface") << ": caught exception: "
+	      << what << "\n";
+    return;
+  }
+
 }
 
-bool Herwig7Interface::initGenerator() {
-  if (HwUI_->runMode() == Herwig::RunMode::RUN) {
-    edm::LogInfo("Herwig7Interface") << "Starting EventGenerator initialization";
-    callHerwigGenerator();
-    edm::LogInfo("Herwig7Interface") << "EventGenerator initialized";
 
-    // Skip events
-    for (unsigned int i = 0; i < skipEvents_; i++) {
-      flushRandomNumberGenerator();
-      eg_->shoot();
-      edm::LogInfo("Herwig7Interface") << "Event discarded";
-    }
+bool Herwig7Interface::initGenerator()
+{
+	if ( HwUI_->runMode() == Herwig::RunMode::RUN) {
+		edm::LogInfo("Herwig7Interface") << "Starting EventGenerator initialization";
+		callHerwigGenerator();
+		edm::LogInfo("Herwig7Interface") << "EventGenerator initialized";
 
-    return true;
+		// Skip events
+		for (unsigned int i = 0; i < skipEvents_; i++) {
+			flushRandomNumberGenerator();
+			eg_->shoot();
+			edm::LogInfo("Herwig7Interface") << "Event discarded";
+		}
 
-  } else {
-    edm::LogInfo("Herwig7Interface") << "Stopped EventGenerator due to missing run mode.";
-    return false;
-    /*
+		return true;
+
+	} else {
+		edm::LogInfo("Herwig7Interface") << "Stopped EventGenerator due to missing run mode.";
+		return false;
+/*
 		throw cms::Exception("Herwig7Interface")
 			<< "EventGenerator could not be initialized due to wrong run mode!" << endl;
 */
-  }
+	}
+
 }
 
-void Herwig7Interface::flushRandomNumberGenerator() {
-  /*ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
+void Herwig7Interface::flushRandomNumberGenerator()
+{
+	/*ThePEG::RandomEngineGlue *rnd = randomEngineGlueProxy_->getInstance();
 
 	if (!rnd)
 		edm::LogWarning("ProxyMissing")
@@ -227,89 +242,105 @@ void Herwig7Interface::flushRandomNumberGenerator() {
       */
 }
 
-unique_ptr<HepMC::GenEvent> Herwig7Interface::convert(const ThePEG::EventPtr &event) {
-  return std::unique_ptr<HepMC::GenEvent>(ThePEG::HepMCConverter<HepMC::GenEvent>::convert(*event));
+auto_ptr<HepMC::GenEvent> Herwig7Interface::convert(
+					const ThePEG::EventPtr &event)
+{
+	return std::auto_ptr<HepMC::GenEvent>(
+		ThePEG::HepMCConverter<HepMC::GenEvent>::convert(*event));
 }
 
-double Herwig7Interface::pthat(const ThePEG::EventPtr &event) {
-  using namespace ThePEG;
 
-  if (!event->primaryCollision())
-    return -1.0;
 
-  tSubProPtr sub = event->primaryCollision()->primarySubProcess();
-  TmpTransform<tSubProPtr> tmp(sub, Utilities::getBoostToCM(sub->incoming()));
 
-  double pthat = (*sub->outgoing().begin())->momentum().perp() / ThePEG::GeV;
-  for (PVector::const_iterator it = sub->outgoing().begin(); it != sub->outgoing().end(); ++it)
-    pthat = std::min<double>(pthat, (*it)->momentum().perp() / ThePEG::GeV);
+double Herwig7Interface::pthat(const ThePEG::EventPtr &event)
+{
+	using namespace ThePEG;
 
-  return pthat;
+	if (!event->primaryCollision())
+		return -1.0;
+
+	tSubProPtr sub = event->primaryCollision()->primarySubProcess();
+	TmpTransform<tSubProPtr> tmp(sub, Utilities::getBoostToCM(
+							sub->incoming()));
+
+	double pthat = (*sub->outgoing().begin())->momentum().perp() / ThePEG::GeV;
+	for(PVector::const_iterator it = sub->outgoing().begin();
+	    it != sub->outgoing().end(); ++it)
+		pthat = std::min<double>(pthat, (*it)->momentum().perp() / ThePEG::GeV);
+
+	return pthat;
 }
 
-void Herwig7Interface::createInputFile(const edm::ParameterSet &pset) {
-  /* Initialize the input config for Herwig from
+
+
+
+void Herwig7Interface::createInputFile(const edm::ParameterSet &pset)
+{
+	/* Initialize the input config for Herwig from
 	 * 1. the Herwig7 config files
 	 * 2. the CMSSW config blocks
 	 * Writes them to an output file which is read by Herwig
 	*/
 
-  stringstream logstream;
+	stringstream logstream;
 
-  // Contains input config passed to Herwig
-  stringstream herwiginputconfig;
 
-  // Define output file to which input config is written, too, if dumpConfig parameter is set.
-  // Otherwise use default file HerwigConfig.in which is read in by Herwig
-  ofstream cfgDump;
-  cfgDump.open(dumpConfig_.c_str(), ios_base::app);
+	// Contains input config passed to Herwig
+	stringstream herwiginputconfig;
 
-  // Read Herwig config files as input
-  vector<string> configFiles = pset.getParameter<vector<string> >("configFiles");
-  // Loop over the config files
-  for (const auto &iter : configFiles) {
-    // Open external config file
-    ifstream externalConfigFile(iter);
-    if (externalConfigFile.is_open()) {
-      edm::LogInfo("Herwig7Interface") << "Reading config file (" << iter << ")" << endl;
-      stringstream configFileStream;
-      configFileStream << externalConfigFile.rdbuf();
-      string configFileContent = configFileStream.str();
+	// Define output file to which input config is written, too, if dumpConfig parameter is set. 
+	// Otherwise use default file HerwigConfig.in which is read in by Herwig
+	ofstream cfgDump;
+	cfgDump.open(dumpConfig_.c_str(), ios_base::app);
+	
 
-      // Comment out occurence of saverun in config file since it is set later considering run and generator option
-      string searchKeyword("saverun");
-      if (configFileContent.find(searchKeyword) != std::string::npos) {
-        edm::LogInfo("Herwig7Interface") << "Commented out saverun command in external input config file(" << iter
-                                         << ")" << endl;
-        configFileContent.insert(configFileContent.find(searchKeyword), "#");
-      }
-      herwiginputconfig << "# Begin Config file input" << endl
-                        << configFileContent << endl
-                        << "# End Config file input";
-      edm::LogInfo("Herwig7Interface") << "Finished reading config file (" << iter << ")" << endl;
-    } else {
-      edm::LogWarning("Herwig7Interface") << "Could not read config file (" << iter << ")" << endl;
-    }
-  }
 
-  edm::LogInfo("Herwig7Interface") << "Start with processing CMSSW config" << endl;
-  // Read CMSSW config file parameter sets starting from "parameterSets"
-  ParameterCollector collector(pset);
-  ParameterCollector::const_iterator iter;
-  iter = collector.begin();
-  herwiginputconfig << endl << "# Begin Parameter set input\n" << endl;
-  for (; iter != collector.end(); ++iter) {
-    herwiginputconfig << *iter << endl;
-  }
+	// Read Herwig config files as input
+	vector<string> configFiles = pset.getParameter<vector<string> >("configFiles");
+	// Loop over the config files
+	for ( const auto & iter : configFiles ) {
+		// Open external config file
+		ifstream externalConfigFile (iter);
+		if (externalConfigFile.is_open()) {
+			edm::LogInfo("Herwig7Interface") << "Reading config file (" << iter << ")" << endl;
+			stringstream configFileStream;
+			configFileStream << externalConfigFile.rdbuf();
+			string configFileContent = configFileStream.str();
+			
+			// Comment out occurence of saverun in config file since it is set later considering run and generator option
+			string searchKeyword("saverun");
+   			if(configFileContent.find(searchKeyword) !=std::string::npos) {
+				edm::LogInfo("Herwig7Interface") << "Commented out saverun command in external input config file(" << iter << ")" << endl;
+				configFileContent.insert(configFileContent.find(searchKeyword),"#");
+			}
+			herwiginputconfig << "# Begin Config file input" << endl  << configFileContent << endl << "# End Config file input";
+			edm::LogInfo("Herwig7Interface") << "Finished reading config file (" << iter << ")" << endl;
+		}
+		else {
+			edm::LogWarning("Herwig7Interface") << "Could not read config file (" << iter << ")" << endl;
+		}
+	}
 
-  // Add some additional necessary lines to the Herwig input config
-  herwiginputconfig << "saverun " << run_ << " " << generator_ << endl;
-  // write the ProxyID for the RandomEngineGlue to fill its pointer in
-  ostringstream ss;
-  ss << randomEngineGlueProxy_->getID();
-  //herwiginputconfig << "set " << generator_ << ":RandomNumberGenerator:ProxyID " << ss.str() << endl;
+	edm::LogInfo("Herwig7Interface") << "Start with processing CMSSW config" << endl;
+	// Read CMSSW config file parameter sets starting from "parameterSets"
+	ParameterCollector collector(pset);
+	ParameterCollector::const_iterator iter;
+	iter = collector.begin();
+	herwiginputconfig << endl << "# Begin Parameter set input\n" << endl;
+	for(; iter != collector.end(); ++iter) {
+		herwiginputconfig << *iter << endl;
+	}
 
-  // Dump Herwig input config to file, so that it can be read by Herwig
-  cfgDump << herwiginputconfig.str() << endl;
-  cfgDump.close();
+	// Add some additional necessary lines to the Herwig input config
+	herwiginputconfig << "saverun " << run_ << " " << generator_ << endl;
+	// write the ProxyID for the RandomEngineGlue to fill its pointer in
+	ostringstream ss;
+	ss << randomEngineGlueProxy_->getID();
+	//herwiginputconfig << "set " << generator_ << ":RandomNumberGenerator:ProxyID " << ss.str() << endl;
+
+
+	// Dump Herwig input config to file, so that it can be read by Herwig
+	cfgDump << herwiginputconfig.str() << endl;
+	cfgDump.close();
 }
+


### PR DESCRIPTION
#### PR description:
Dear all, 
this is a PR to fix the crash in official production with Herwig7 when the luminosityBlock changed.
Additionally, the PR adds parton shower weights for Herwig 7 as well as a corresponding configs that can be used in production.
Kind regards,
Andrej

#### PR validation:

To simulate the official production, the code was run on crab, which had the same issue. Just to be sure, we still need to test it in official production that the issue is indeed fully solved.
Output of an example job:
https://cmsweb.cern.ch/scheddmon/0197/cms1305/190523_121600:asaibel_crab_Generator_InitializeOnlyFirstLumi/job_out.3.0.txt

Before the changes, the jobs always failed after the change in luminosity block after 100events. You can see in the job that 350 events (two lumiBlock changes) are produced without failing.

The content of the PS weights was checked by checking the number of weights for each event in the GenEventInfoProduct
