### PR TITLE
Skip tensorflow test that doesnt build on ppc64

### DIFF
--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -22,10 +22,10 @@
     <use name="PhysicsTools/TensorFlow" />
 </bin>
 
-
+<architecture name="!_ppc64le_.*">
 <bin file="tfadd_t.cpp">
   <flags DNN_NAME="test_graph_tfadd"/>
   <use name="tensorflow-runtime"/>
   <use name="tensorflow-xla_compiled_cpu_function"/> 
 </bin>
-
+</architecture>


### PR DESCRIPTION
- Fixes build failures in the powerpc build
- Should solve this : https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_ppc64le_gcc700/CMSSW_11_0_X_2019-05-22-2300/PhysicsTools/TensorFlow so that we don't rebuild full IB every time
- Check if builds on intel and arm: builds
- Try the test on powerpc to check if cmssw PRs can be tested with different archs