### PR TITLE
backport python3 fixes to pileup scripts

### DIFF
--- a/RecoLuminosity/LumiDB/scripts/pileupCalc.py
+++ b/RecoLuminosity/LumiDB/scripts/pileupCalc.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 VERSION='1.00'
 import os,sys,time
 import optparse
@@ -128,9 +129,9 @@ def fillPileupHistogram (lumiInfo, calcOption, hist, minbXsec, Nbins):
                 hist.Fill (val, prob * LSintLumi)
                 
             if 1.0-totalProb > 0.01:
-                print "Significant probability density outside of your histogram"
-                print "Consider using a higher value of --maxPileupBin"
-                print "Mean %f, RMS %f, Integrated probability %f" % (AveNumInt,RMSInt,totalProb)
+                print("Significant probability density outside of your histogram")
+                print("Consider using a higher value of --maxPileupBin")
+                print("Mean %f, RMS %f, Integrated probability %f" % (AveNumInt,RMSInt,totalProb))
             #    hist.Fill (val, (1 - totalProb) * LSintLumi)
         else:
             hist.Fill(AveNumInt,LSintLumi)
@@ -148,8 +149,8 @@ def fillPileupHistogram (lumiInfo, calcOption, hist, minbXsec, Nbins):
                 hist.Fill (val, prob * LSintLumi * RMSWeight)
 
         if 1.0-totalProb > 0.01:
-            print "Significant probability density outside of your histogram"
-            print "Consider using a higher value of --maxPileupBin"
+            print("Significant probability density outside of your histogram")
+            print("Consider using a higher value of --maxPileupBin")
 
 
     return hist
@@ -210,7 +211,7 @@ if __name__ == '__main__':
     try:
         (options, args) = parser.parse_args()
     except Exception as e:
-        print e
+        print(e)
     if not args:
         parser.print_usage()
         sys.exit()
@@ -222,13 +223,13 @@ if __name__ == '__main__':
 #    options=parser.parse_args()
 
     if options.verbose:
-        print 'General configuration'
-        print '\toutputfile: ',options.outputfile
-        print '\tAction: ',options.calcMode, 'luminosity distribution will be calculated'
-        print '\tinput selection file: ',options.inputfile
-        print '\tMinBiasXsec: ',options.minBiasXsec
-        print '\tmaxPileupBin: ',options.maxPileupBin
-        print '\tnumPileupBins: ',options.numPileupBins
+        print('General configuration')
+        print('\toutputfile: ',options.outputfile)
+        print('\tAction: ',options.calcMode, 'luminosity distribution will be calculated')
+        print('\tinput selection file: ',options.inputfile)
+        print('\tMinBiasXsec: ',options.minBiasXsec)
+        print('\tmaxPileupBin: ',options.maxPileupBin)
+        print('\tnumPileupBins: ',options.numPileupBins)
 
     import ROOT 
     pileupHist = ROOT.TH1D (options.pileupHistName,options.pileupHistName,
@@ -250,7 +251,7 @@ if __name__ == '__main__':
         # now, we have to find the information for the input runs and LumiSections 
         # in the Lumi/Pileup list. First, loop over inputs
 
-        for (run, lslist) in sorted (six.iteritems(inputRange)) ):
+        for (run, lslist) in sorted (six.iteritems(inputRange)):
             # now, look for matching run, then match lumi sections
             # print "searching for run %d" % (run)
             if run in inputPileupRange.keys():
@@ -265,11 +266,11 @@ if __name__ == '__main__':
                         fillPileupHistogram (lumiInfo, options.calcMode,
                                 pileupHist, options.minBiasXsec, nbins)
                     else: # trouble
-                        print "Run %d, LumiSection %d not found in Lumi/Pileup input file. Check your files!" \
-                                % (run,LSnumber)
+                        print("Run %d, LumiSection %d not found in Lumi/Pileup input file. Check your files!" \
+                                % (run,LSnumber))
 
             else:  # trouble
-                print "Run %d not found in Lumi/Pileup input file.  Check your files!" % (run)
+                print("Run %d not found in Lumi/Pileup input file.  Check your files!" % (run))
 
 
 
@@ -286,5 +287,5 @@ if __name__ == '__main__':
         sys.exit()
 
     else:
-        print "must specify a pileup calculation mode via --calcMode true or --calcMode observed"
+        print("must specify a pileup calculation mode via --calcMode true or --calcMode observed")
         sys.exit()

--- a/RecoLuminosity/LumiDB/scripts/pileupReCalc_HLTpaths.py
+++ b/RecoLuminosity/LumiDB/scripts/pileupReCalc_HLTpaths.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 VERSION='1.00'
 import os,sys,time
 import optparse
@@ -60,7 +61,7 @@ if __name__ == '__main__':
     try:
         (options, args) = parser.parse_args()
     except Exception as e:
-        print e
+        print(e)
 #    if not args:
 #        parser.print_usage()
 #        sys.exit()
@@ -72,9 +73,9 @@ if __name__ == '__main__':
 #    options=parser.parse_args()
 
     if options.verbose:
-        print 'General configuration'
-        print '\toutputfile: ',options.outputfile
-        print '\tinput selection file: ',options.inputfile
+        print('General configuration')
+        print('\toutputfile: ',options.outputfile)
+        print('\tinput selection file: ',options.inputfile)
 
     #print options.runperiod
     #inpf = open (options.inputfile, 'r')
@@ -95,7 +96,7 @@ if __name__ == '__main__':
     OUTPUTLINE = ""
     OUTPUTLINE+='{'
 
-    for (run, lslist) in sorted (six.iteritems(inputRange)) ):
+    for (run, lslist) in sorted (six.iteritems(inputRange)):
         # now, look for matching run, then match lumi sections
         #print "searching for run %d" % (run)
         if run in inputPileupRange.keys():
@@ -115,7 +116,7 @@ if __name__ == '__main__':
                         scale=HLTlumiInfo[1]/PUlumiInfo[0] # rescale to HLT recorded Lumi
 
                     if scale > 1.001:
-                        print 'Run %d, LS %d, HLT Scale (%f), HLTL (%f), PUL (%f) larger than one - please check!' % (run, LSnumber, scale, HLTlumiInfo[1],PUlumiInfo[0])
+                        print('Run %d, LS %d, HLT Scale (%f), HLTL (%f), PUL (%f) larger than one - please check!' % (run, LSnumber, scale, HLTlumiInfo[1],PUlumiInfo[0]))
                         scale=1.01  # HLT integrated values are wrong, punt                        
 
                     newIntLumi = scale*PUlumiInfo[0]
@@ -145,7 +146,7 @@ if __name__ == '__main__':
             OUTPUTLINE += '], '
 
         else:  # trouble
-            print "Run %d not found in Lumi/Pileup input file.  Check your files!" % (run)
+            print("Run %d not found in Lumi/Pileup input file.  Check your files!" % (run))
 
 
 #            print run

--- a/RecoLuminosity/LumiDB/scripts/pileupReCalc_Lumis.py
+++ b/RecoLuminosity/LumiDB/scripts/pileupReCalc_Lumis.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 VERSION='1.00'
 import os,sys,time
 import optparse
@@ -60,7 +61,7 @@ if __name__ == '__main__':
     try:
         (options, args) = parser.parse_args()
     except Exception as e:
-        print e
+        print(e)
 #    if not args:
 #        parser.print_usage()
 #        sys.exit()
@@ -72,9 +73,9 @@ if __name__ == '__main__':
 #    options=parser.parse_args()
 
     if options.verbose:
-        print 'General configuration'
-        print '\toutputfile: ',options.outputfile
-        print '\tinput selection file: ',options.inputfile
+        print('General configuration')
+        print('\toutputfile: ',options.outputfile)
+        print('\tinput selection file: ',options.inputfile)
 
 
     #inpf = open (options.inputfile, 'r')
@@ -96,7 +97,7 @@ if __name__ == '__main__':
 
     # loop over pileup JSON as source, since it should have more lumi sections
 
-    for (run, LSPUlist) in sorted (six.iteritems(inputPileupRange)) ):
+    for (run, LSPUlist) in sorted (six.iteritems(inputPileupRange)):
         # now, look for matching run, then match lumi sections
         #print "searching for run %d" % (run)
         if run in inputRange.keys():
@@ -116,7 +117,7 @@ if __name__ == '__main__':
                         scale=PixlumiInfo[1]/PUlumiInfo[0] # rescale to HLT recorded Lumi
 
                     if scale !=0 and (scale < 0.2 or scale > 5.0):
-                        print 'Run %d, LS %d, Scale (%f), PixL (%f), PUL (%f) big change - please check!' % (run, LSnumber, scale, PixlumiInfo[1],PUlumiInfo[0])
+                        print('Run %d, LS %d, Scale (%f), PixL (%f), PUL (%f) big change - please check!' % (run, LSnumber, scale, PixlumiInfo[1],PUlumiInfo[0]))
                     #    scale=1.01  # HLT integrated values are wrong, punt                        
 
                     newIntLumi = scale*PUlumiInfo[0]
@@ -127,7 +128,7 @@ if __name__ == '__main__':
                         newRmsLumi = PUlumiInfo[1]
                         newInstLumi = PUlumiInfo[2]
                                                      
-                        print 'Run %d, LS %d, Scale (%f), PixL (%f), PUL (%f) - 0 please check!' % (run, LSnumber, scale, PixlumiInfo[1],PUlumiInfo[0])
+                        print('Run %d, LS %d, Scale (%f), PixL (%f), PUL (%f) - 0 please check!' % (run, LSnumber, scale, PixlumiInfo[1],PUlumiInfo[0]))
                     LumiString = "[%d,%2.4e,%2.4e,%2.4e]," % (LSnumber, newIntLumi, newRmsLumi ,newInstLumi)
                     OUTPUTLINE += LumiString
 
@@ -150,7 +151,7 @@ if __name__ == '__main__':
             OUTPUTLINE += '], '
 
         else:  # trouble
-            print "Run %d not found in Lumi/Pileup input file.  Check your files!" % (run)
+            print("Run %d not found in Lumi/Pileup input file.  Check your files!" % (run))
 
 
 #            print run


### PR DESCRIPTION
#### PR description:

`pileupCalc.py` is broken in 10_2_X. Since this is the analysis release, this important script should be usable. I backported the fix that entered 10_3_X, as well as fixes to other scripts from the package  `RecoLuminosity/LumiDB`.

#### PR validation:

Modified package compiles and `pileupCalc.py` runs successfully.

#### if this PR is a backport please specify the original PR:

Partial backport of #24301