### PR TITLE
[HGCAL] Perform HGCal Calibration only on the hard scatterer event

### DIFF
--- a/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
+++ b/Validation/HGCalValidation/plugins/HGCalHitCalibration.cc
@@ -259,6 +259,13 @@ void HGCalHitCalibration::analyze(const edm::Event& iEvent,
   IfLogTrace(debug_ > 0, "HGCalHitCalibration")
     << "Number of caloParticles: " << caloParticles.size() << std::endl;
   for (const auto& it_caloPart : caloParticles) {
+    if (it_caloPart.g4Tracks()[0].eventId().event() != 0 or it_caloPart.g4Tracks()[0].eventId().bunchCrossing() != 0) {
+      LogDebug("HGCalHitCalibration") << "Excluding CaloParticles from event: "
+        << it_caloPart.g4Tracks()[0].eventId().event()
+        << " with BX: " << it_caloPart.g4Tracks()[0].eventId().bunchCrossing() << std::endl;
+        continue;
+    }
+
     const SimClusterRefVector& simClusterRefVector = it_caloPart.simClusters();
     Energy_layer_calib_.fill(0.);
     Energy_layer_calib_fraction_.fill(0.);


### PR DESCRIPTION
#### PR description:

This PR will limit the HGCal Calibration to CaloParticles coming from the hard scatterer, excluding the PU contribution. This has the effect of making the plots understandable also using PU samples and a side effect of reducing the timing of that module from an average of **14s/event** to **0.2s/event** on a typical TTBar+200PU event.

Incidentally, it would be worth signalling that the current main offender in a typical Relval/runTheMatrix workflow with PU is the **OuterTrackerMonitorTrackingParticles** module, with its 400s/event. I do not know if this is known or, maybe, it is some weird effect that I happened to notice.

#### PR validation:

Run on TTbar and EGun RelVal samples of 10_6_0 with 200PU

