### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/EventFilter/ESRawToDigi/interface/ESRawToDigi.h
+++ b/EventFilter/ESRawToDigi/interface/ESRawToDigi.h
@@ -1,5 +1,5 @@
 #ifndef _ESRAWTODIGI_H_
-#define _ESRAWTODIGI_H_ 
+#define _ESRAWTODIGI_H_
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -10,33 +10,25 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/EcalRawData/interface/ESListOfFEDS.h"
 
-
 class ESRawToDigi : public edm::stream::EDProducer<> {
-  
- public:
-  
+public:
   ESRawToDigi(const edm::ParameterSet& ps);
   ~ESRawToDigi() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
- 
+
   void produce(edm::Event& e, const edm::EventSetup& es) override;
-  
- private:
 
-
-
+private:
   std::string ESdigiCollection_;
   edm::EDGetTokenT<FEDRawDataCollection> dataToken_;
-  edm::EDGetTokenT<ESListOfFEDS>         fedsToken_;
-
+  edm::EDGetTokenT<ESListOfFEDS> fedsToken_;
 
   bool regional_;
 
   bool debug_;
 
   ESUnpacker* ESUnpacker_;
-  
 };
 
 #endif

--- a/EventFilter/ESRawToDigi/interface/ESUnpacker.h
+++ b/EventFilter/ESRawToDigi/interface/ESUnpacker.h
@@ -17,34 +17,32 @@
 #include "DataFormats/EcalRawData/interface/ESKCHIPBlock.h"
 #include "DataFormats/EcalRawData/interface/EcalRawDataCollections.h"
 
-
-
-
 class ESDigiToRaw;
 
 class ESUnpacker {
-  
-  public :
-      
+public:
   typedef unsigned int Word32;
   typedef unsigned long long Word64;
 
   ESUnpacker(const edm::ParameterSet& ps);
   ~ESUnpacker();
 
-  void interpretRawData(int fedId, const FEDRawData & rawData, ESRawDataCollection & dccs, ESLocalRawDataCollection & kchips, ESDigiCollection & digis);
-  void word2digi(int kchip, int kPACE[4], const Word64 & word, ESDigiCollection & digis);
+  void interpretRawData(int fedId,
+                        const FEDRawData& rawData,
+                        ESRawDataCollection& dccs,
+                        ESLocalRawDataCollection& kchips,
+                        ESDigiCollection& digis);
+  void word2digi(int kchip, int kPACE[4], const Word64& word, ESDigiCollection& digis);
 
-  void setRunNumber(int i) {run_number_ = i;};
-  void setOrbitNumber(int i) {orbit_number_ = i;};
-  void setBX(int i) {bx_ = i;};
-  void setLV1(int i) {lv1_ = i;};
-  void setTriggerType(int i) {trgtype_ = i;};
+  void setRunNumber(int i) { run_number_ = i; };
+  void setOrbitNumber(int i) { orbit_number_ = i; };
+  void setBX(int i) { bx_ = i; };
+  void setLV1(int i) { lv1_ = i; };
+  void setTriggerType(int i) { trgtype_ = i; };
 
-  private :    
-
+private:
   const edm::ParameterSet pset_;
-    
+
   int fedId_;
   int run_number_;
   int orbit_number_;
@@ -66,14 +64,12 @@ class ESUnpacker {
   bool debug_;
   edm::FileInPath lookup_;
 
-  std::string print(const Word64 & word) const;
+  std::string print(const Word64& word) const;
 
-  protected :
-
+protected:
   Word64 m1, m2, m4, m5, m6, m8, m12, m16, m32;
 
-   int zside_[4288][4], pl_[4288][4], x_[4288][4], y_[4288][4]; 
-
+  int zside_[4288][4], pl_[4288][4], x_[4288][4], y_[4288][4];
 };
 
 #endif

--- a/EventFilter/ESRawToDigi/src/ESRawToDigi.cc
+++ b/EventFilter/ESRawToDigi/src/ESRawToDigi.cc
@@ -6,58 +6,51 @@
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h" 
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalRawData/interface/ESDCCHeaderBlock.h"
 #include "DataFormats/EcalRawData/interface/ESKCHIPBlock.h"
 
 #include <iostream>
 
-ESRawToDigi::ESRawToDigi(edm::ParameterSet const& ps) 
-{
-   
+ESRawToDigi::ESRawToDigi(edm::ParameterSet const& ps) {
   edm::InputTag sourceTag = ps.getParameter<edm::InputTag>("sourceTag");
   ESdigiCollection_ = ps.getParameter<std::string>("ESdigiCollection");
-  regional_         = ps.getUntrackedParameter<bool>("DoRegional",false);
-  edm::InputTag fedsListLabel     
-      = ps.getUntrackedParameter<edm::InputTag>("ESFedsListLabel", edm::InputTag(":esfedslist"));
-  debug_            = ps.getUntrackedParameter<bool>("debugMode", false);
+  regional_ = ps.getUntrackedParameter<bool>("DoRegional", false);
+  edm::InputTag fedsListLabel =
+      ps.getUntrackedParameter<edm::InputTag>("ESFedsListLabel", edm::InputTag(":esfedslist"));
+  debug_ = ps.getUntrackedParameter<bool>("debugMode", false);
 
   ESUnpacker_ = new ESUnpacker(ps);
 
   produces<ESRawDataCollection>();
   produces<ESLocalRawDataCollection>();
   produces<ESDigiCollection>();
-  dataToken_=consumes<FEDRawDataCollection>(sourceTag);
-  if (regional_){
-      fedsToken_=consumes<ESListOfFEDS>(fedsListLabel);
+  dataToken_ = consumes<FEDRawDataCollection>(sourceTag);
+  if (regional_) {
+    fedsToken_ = consumes<ESListOfFEDS>(fedsListLabel);
   }
 }
 
-ESRawToDigi::~ESRawToDigi(){
-
-  delete ESUnpacker_;
-
-}
+ESRawToDigi::~ESRawToDigi() { delete ESUnpacker_; }
 
 void ESRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("sourceTag",edm::InputTag("rawDataCollector"));
-  desc.addUntracked<bool>("debugMode",false);
-  desc.add<std::string>("InstanceES","");
-  desc.add<edm::FileInPath>("LookupTable",edm::FileInPath("EventFilter/ESDigiToRaw/data/ES_lookup_table.dat"));
-  desc.add<std::string>("ESdigiCollection","");
-  descriptions.add("esRawToDigi",desc);
+  desc.add<edm::InputTag>("sourceTag", edm::InputTag("rawDataCollector"));
+  desc.addUntracked<bool>("debugMode", false);
+  desc.add<std::string>("InstanceES", "");
+  desc.add<edm::FileInPath>("LookupTable", edm::FileInPath("EventFilter/ESDigiToRaw/data/ES_lookup_table.dat"));
+  desc.add<std::string>("ESdigiCollection", "");
+  descriptions.add("esRawToDigi", desc);
 }
 
 void ESRawToDigi::produce(edm::Event& e, const edm::EventSetup& es) {
-
   // Input
   edm::Handle<FEDRawDataCollection> rawdata;
   e.getByToken(dataToken_, rawdata);
   if (!rawdata.isValid()) {
     LogDebug("") << "ESRawToDigi : Error! can't get rawdata!" << std::endl;
   }
-  
+
   std::vector<int> esFeds_to_unpack;
   if (regional_) {
     edm::Handle<ESListOfFEDS> fedslist;
@@ -68,30 +61,29 @@ void ESRawToDigi::produce(edm::Event& e, const edm::EventSetup& es) {
   // Output
   auto productDCC = std::make_unique<ESRawDataCollection>();
   auto productKCHIP = std::make_unique<ESLocalRawDataCollection>();
-  auto productDigis = std::make_unique<ESDigiCollection>();  
-  
+  auto productDigis = std::make_unique<ESDigiCollection>();
+
   ESDigiCollection digis;
 
   if (regional_) {
-    for (unsigned int i=0; i<esFeds_to_unpack.size(); ++i) {
-      
+    for (unsigned int i = 0; i < esFeds_to_unpack.size(); ++i) {
       const FEDRawData& fedRawData = rawdata->FEDData(esFeds_to_unpack[i]);
       ESUnpacker_->interpretRawData(esFeds_to_unpack[i], fedRawData, *productDCC, *productKCHIP, *productDigis);
-      
-      if (debug_) std::cout<<"FED : "<<esFeds_to_unpack[i]<<" Data size : "<<fedRawData.size()<<" (Bytes)"<<std::endl;
-    }   
+
+      if (debug_)
+        std::cout << "FED : " << esFeds_to_unpack[i] << " Data size : " << fedRawData.size() << " (Bytes)" << std::endl;
+    }
   } else {
-    for (int fedId=FEDNumbering::MINPreShowerFEDID; fedId<=FEDNumbering::MAXPreShowerFEDID; ++fedId) {
-      
+    for (int fedId = FEDNumbering::MINPreShowerFEDID; fedId <= FEDNumbering::MAXPreShowerFEDID; ++fedId) {
       const FEDRawData& fedRawData = rawdata->FEDData(fedId);
       ESUnpacker_->interpretRawData(fedId, fedRawData, *productDCC, *productKCHIP, *productDigis);
-      
-      if (debug_) std::cout<<"FED : "<<fedId<<" Data size : "<<fedRawData.size()<<" (Bytes)"<<std::endl;
-    }   
+
+      if (debug_)
+        std::cout << "FED : " << fedId << " Data size : " << fedRawData.size() << " (Bytes)" << std::endl;
+    }
   }
 
   e.put(std::move(productDCC));
   e.put(std::move(productKCHIP));
   e.put(std::move(productDigis), ESdigiCollection_);
 }
-

--- a/EventFilter/ESRawToDigi/src/ESUnpacker.cc
+++ b/EventFilter/ESRawToDigi/src/ESUnpacker.cc
@@ -7,19 +7,17 @@
 
 #include <fstream>
 
-ESUnpacker::ESUnpacker(const edm::ParameterSet& ps) 
-  : pset_(ps), fedId_(0), run_number_(0), orbit_number_(0), bx_(0), lv1_(0), trgtype_(0)
-{
-
+ESUnpacker::ESUnpacker(const edm::ParameterSet& ps)
+    : pset_(ps), fedId_(0), run_number_(0), orbit_number_(0), bx_(0), lv1_(0), trgtype_(0) {
   debug_ = pset_.getUntrackedParameter<bool>("debugMode", false);
   lookup_ = ps.getParameter<edm::FileInPath>("LookupTable");
 
-  m1  = ~(~Word64(0) << 1);
-  m2  = ~(~Word64(0) << 2);
-  m4  = ~(~Word64(0) << 4);
-  m5  = ~(~Word64(0) << 5);
-  m6  = ~(~Word64(0) << 6);
-  m8  = ~(~Word64(0) << 8);
+  m1 = ~(~Word64(0) << 1);
+  m2 = ~(~Word64(0) << 2);
+  m4 = ~(~Word64(0) << 4);
+  m5 = ~(~Word64(0) << 5);
+  m6 = ~(~Word64(0) << 6);
+  m8 = ~(~Word64(0) << 8);
   m12 = ~(~Word64(0) << 12);
   m16 = ~(~Word64(0) << 16);
   m32 = ~(~Word64(0) << 32);
@@ -28,32 +26,34 @@ ESUnpacker::ESUnpacker(const edm::ParameterSet& ps)
   int nLines, iz, ip, ix, iy, fed, kchip, pace, bundle, fiber, optorx;
   std::ifstream file;
   file.open(lookup_.fullPath().c_str());
-  if( file.is_open() ) {
-
+  if (file.is_open()) {
     file >> nLines;
 
-    for (int i=0; i<nLines; ++i) {
-      file>> iz >> ip >> ix >> iy >> fed >> kchip >> pace >> bundle >> fiber >> optorx;
+    for (int i = 0; i < nLines; ++i) {
+      file >> iz >> ip >> ix >> iy >> fed >> kchip >> pace >> bundle >> fiber >> optorx;
 
-      zside_[kchip-1][pace-1] = iz;
-      pl_[kchip-1][pace-1] = ip;
-      x_[kchip-1][pace-1] = ix;
-      y_[kchip-1][pace-1] = iy;      
+      zside_[kchip - 1][pace - 1] = iz;
+      pl_[kchip - 1][pace - 1] = ip;
+      x_[kchip - 1][pace - 1] = ix;
+      y_[kchip - 1][pace - 1] = iy;
     }
-    
+
   } else {
-    edm::LogWarning("Invalid Data")<<"ESUnpacker::ESUnpacker : Look up table file can not be found in "<<lookup_.fullPath().c_str();
+    edm::LogWarning("Invalid Data") << "ESUnpacker::ESUnpacker : Look up table file can not be found in "
+                                    << lookup_.fullPath().c_str();
   }
-
 }
 
-ESUnpacker::~ESUnpacker() {
-}
+ESUnpacker::~ESUnpacker() {}
 
-void ESUnpacker::interpretRawData(int fedId, const FEDRawData & rawData, ESRawDataCollection & dccs, ESLocalRawDataCollection & kchips, ESDigiCollection & digis) {
-  
-  unsigned int nWords = rawData.size()/sizeof(Word64);
-  if (nWords==0) return;
+void ESUnpacker::interpretRawData(int fedId,
+                                  const FEDRawData& rawData,
+                                  ESRawDataCollection& dccs,
+                                  ESLocalRawDataCollection& kchips,
+                                  ESDigiCollection& digis) {
+  unsigned int nWords = rawData.size() / sizeof(Word64);
+  if (nWords == 0)
+    return;
   int dccWords = 6;
   int head, kPACE[4], kFlag1, kFlag2, kBC, kEC, optoBC, optoEC;
   int kid = -1;
@@ -62,31 +62,35 @@ void ESUnpacker::interpretRawData(int fedId, const FEDRawData & rawData, ESRawDa
   ESDCCHeader.setFedId(fedId);
 
   // Event header
-  const Word64* header = reinterpret_cast<const Word64* >(rawData.data()); --header;
+  const Word64* header = reinterpret_cast<const Word64*>(rawData.data());
+  --header;
   bool moreHeaders = true;
   while (moreHeaders) {
     ++header;
-    FEDHeader ESHeader( reinterpret_cast<const unsigned char*>(header) );
-    if ( !ESHeader.check() ) {
-      if (debug_) edm::LogWarning("Invalid Data")<<"ES : Failed header check !";
+    FEDHeader ESHeader(reinterpret_cast<const unsigned char*>(header));
+    if (!ESHeader.check()) {
+      if (debug_)
+        edm::LogWarning("Invalid Data") << "ES : Failed header check !";
       return;
     }
 
     fedId_ = ESHeader.sourceID();
-    lv1_   = ESHeader.lvl1ID();
-    bx_    = ESHeader.bxID();
+    lv1_ = ESHeader.lvl1ID();
+    bx_ = ESHeader.bxID();
 
     if (debug_) {
-      LogDebug("ESUnpacker") << "[ESUnpacker]: FED Header candidate. Is header? "<< ESHeader.check();
+      LogDebug("ESUnpacker") << "[ESUnpacker]: FED Header candidate. Is header? " << ESHeader.check();
       if (ESHeader.check())
-	LogDebug("ESUnpacker") << ". BXID: "<<bx_<<" SourceID : "<<fedId_<<" L1ID: "<<lv1_;
-      else LogDebug("ESUnpacker")<<" WARNING!, this is not a ES Header";
+        LogDebug("ESUnpacker") << ". BXID: " << bx_ << " SourceID : " << fedId_ << " L1ID: " << lv1_;
+      else
+        LogDebug("ESUnpacker") << " WARNING!, this is not a ES Header";
     }
-    
+
     moreHeaders = ESHeader.moreHeaders();
   }
-  if ( fedId != fedId_) {
-    if (debug_) edm::LogWarning("Invalid Data")<<"Invalid ES data with source id " <<fedId_;
+  if (fedId != fedId_) {
+    if (debug_)
+      edm::LogWarning("Invalid Data") << "Invalid ES data with source id " << fedId_;
     ESDCCHeader.setDCCErrors(1);
     dccs.push_back(ESDCCHeader);
     return;
@@ -96,34 +100,39 @@ void ESUnpacker::interpretRawData(int fedId, const FEDRawData & rawData, ESRawDa
 
   // Event trailer
   int slinkCRC = 1;
-  const Word64* trailer = reinterpret_cast<const Word64* >(rawData.data())+(nWords-1); ++trailer;
+  const Word64* trailer = reinterpret_cast<const Word64*>(rawData.data()) + (nWords - 1);
+  ++trailer;
   bool moreTrailers = true;
   while (moreTrailers) {
     --trailer;
     FEDTrailer ESTrailer(reinterpret_cast<const unsigned char*>(trailer));
-    if ( !ESTrailer.check()) { 
-      ++trailer; 
-      if (debug_) edm::LogWarning("Invalid Data")<<"ES : Failed trailer check !";
+    if (!ESTrailer.check()) {
+      ++trailer;
+      if (debug_)
+        edm::LogWarning("Invalid Data") << "ES : Failed trailer check !";
       return;
-    } 
-    if ( ESTrailer.fragmentLength() != nWords) {
-      if (debug_) edm::LogWarning("Invalid Data")<<"Invalid ES data : the length is not correct !";
+    }
+    if (ESTrailer.fragmentLength() != nWords) {
+      if (debug_)
+        edm::LogWarning("Invalid Data") << "Invalid ES data : the length is not correct !";
       ESDCCHeader.setDCCErrors(2);
       dccs.push_back(ESDCCHeader);
       return;
     }
-    if ( ESTrailer.fragmentLength() < 8) {
-      if (debug_) edm::LogWarning("Invalid Data")<<"Invalid ES data : the length is not correct !";
+    if (ESTrailer.fragmentLength() < 8) {
+      if (debug_)
+        edm::LogWarning("Invalid Data") << "Invalid ES data : the length is not correct !";
       ESDCCHeader.setDCCErrors(3);
       dccs.push_back(ESDCCHeader);
       return;
     }
-    slinkCRC = (*trailer >> 2 ) & 0x1;
-    if (debug_)  {
-      LogDebug("ESUnpacker")<<"[ESUnpacker]: FED Trailer candidate. Is trailer? "<<ESTrailer.check();
+    slinkCRC = (*trailer >> 2) & 0x1;
+    if (debug_) {
+      LogDebug("ESUnpacker") << "[ESUnpacker]: FED Trailer candidate. Is trailer? " << ESTrailer.check();
       if (ESTrailer.check())
-	LogDebug("ESUnpacker")<<". Length of the ES event: "<<ESTrailer.fragmentLength();
-      else LogDebug("ESUnpacker")<<" WARNING!, this is not a ES Trailer";
+        LogDebug("ESUnpacker") << ". Length of the ES event: " << ESTrailer.fragmentLength();
+      else
+        LogDebug("ESUnpacker") << " WARNING!, this is not a ES Trailer";
     }
 
     moreTrailers = ESTrailer.moreTrailers();
@@ -143,29 +152,32 @@ void ESUnpacker::interpretRawData(int fedId, const FEDRawData & rawData, ESRawDa
   int dccCRC1_ = 0;
   int dccCRC2_ = 0;
   int dccCRC3_ = 0;
-  for (const Word64* word=(header+1); word!=(header+dccWords+1); ++word) {
-    if (debug_) LogDebug("ESUnpacker")<<"DCC   : "<<print(*word);
+  for (const Word64* word = (header + 1); word != (header + dccWords + 1); ++word) {
+    if (debug_)
+      LogDebug("ESUnpacker") << "DCC   : " << print(*word);
     dccHead = (*word >> 60) & m4;
-    if (dccHead == 3) dccHeaderCount++;
+    if (dccHead == 3)
+      dccHeaderCount++;
     dccLine = (*word >> 56) & m4;
     dccLineCount++;
     if (dccLine != dccLineCount) {
-      if (debug_) edm::LogWarning("Invalid Data")<<"Invalid ES data : DCC header order is not correct !";
+      if (debug_)
+        edm::LogWarning("Invalid Data") << "Invalid ES data : DCC header order is not correct !";
       ESDCCHeader.setDCCErrors(4);
       dccs.push_back(ESDCCHeader);
-      return; 
+      return;
     }
     if (dccLineCount == 1) {
-      dccCRC1_ = (*word >> 24) & m1; 
-      dccCRC2_ = (*word >> 25) & m1; 
-      dccCRC3_ = (*word >> 26) & m1; 
+      dccCRC1_ = (*word >> 24) & m1;
+      dccCRC2_ = (*word >> 25) & m1;
+      dccCRC3_ = (*word >> 26) & m1;
     } else if (dccLineCount == 2) {
-      runtype_   = (*word >>  0) & m4;
-      seqtype_   = (*word >>  4) & m4;
-      dac_       = (*word >>  8) & m12; 
-      gain_      = (*word >> 20) & m1;
+      runtype_ = (*word >> 0) & m4;
+      seqtype_ = (*word >> 4) & m4;
+      dac_ = (*word >> 8) & m12;
+      gain_ = (*word >> 20) & m1;
       precision_ = (*word >> 21) & m1;
-      trgtype_   = (*word >> 34) & m6;
+      trgtype_ = (*word >> 34) & m6;
 
       ESDCCHeader.setRunType(runtype_);
       ESDCCHeader.setSeqType(seqtype_);
@@ -175,31 +187,34 @@ void ESUnpacker::interpretRawData(int fedId, const FEDRawData & rawData, ESRawDa
       ESDCCHeader.setPrecision(precision_);
     }
     if (dccLineCount == 3) {
-      orbit_number_ = (*word >>  0) & m32;
-      vminor_       = (*word >> 40) & m8;
-      vmajor_       = (*word >> 48) & m8;
+      orbit_number_ = (*word >> 0) & m32;
+      vminor_ = (*word >> 40) & m8;
+      vmajor_ = (*word >> 48) & m8;
 
       ESDCCHeader.setOrbitNumber(orbit_number_);
       ESDCCHeader.setMajorVersion(vmajor_);
       ESDCCHeader.setMinorVersion(vminor_);
     }
-    if (dccLineCount == 4) optoRX0_  = (*word >> 48) & m8;
-    if (dccLineCount == 5) optoRX1_  = (*word >> 48) & m8;
-    if (dccLineCount == 6) optoRX2_  = (*word >> 48) & m8;
-    if (dccLineCount >=4) {
-      for (unsigned int j=0; j<12; ++j) {
-	FEch_[(dccLineCount-4)*12+j] = (*word >> (j*4)) & m4;
-	FEch_status.push_back(FEch_[(dccLineCount-4)*12+j]);
+    if (dccLineCount == 4)
+      optoRX0_ = (*word >> 48) & m8;
+    if (dccLineCount == 5)
+      optoRX1_ = (*word >> 48) & m8;
+    if (dccLineCount == 6)
+      optoRX2_ = (*word >> 48) & m8;
+    if (dccLineCount >= 4) {
+      for (unsigned int j = 0; j < 12; ++j) {
+        FEch_[(dccLineCount - 4) * 12 + j] = (*word >> (j * 4)) & m4;
+        FEch_status.push_back(FEch_[(dccLineCount - 4) * 12 + j]);
       }
     }
   }
   if (vmajor_ < 4) {
-    if (debug_) 
-      edm::LogWarning("Invalid Data")<<"Invalid ES data format : "<<vmajor_<<" "<<vminor_;
+    if (debug_)
+      edm::LogWarning("Invalid Data") << "Invalid ES data format : " << vmajor_ << " " << vminor_;
     return;
   }
   if (dccHeaderCount != 6) {
-    edm::LogWarning("Invalid Data")<<"Invalid ES data : DCC header lines are "<<dccHeaderCount;
+    edm::LogWarning("Invalid Data") << "Invalid ES data : DCC header lines are " << dccHeaderCount;
     ESDCCHeader.setDCCErrors(5);
     dccs.push_back(ESDCCHeader);
     return;
@@ -209,7 +224,7 @@ void ESUnpacker::interpretRawData(int fedId, const FEDRawData & rawData, ESRawDa
   ESDCCHeader.setOptoRX2(optoRX2_ + dccCRC3_);
   ESDCCHeader.setFEChannelStatus(FEch_status);
   int enableOptoRX[3] = {-1, -1, -1};
-  int NenableOptoRX = 0; 
+  int NenableOptoRX = 0;
   if (optoRX0_ == 128) {
     enableOptoRX[NenableOptoRX] = 0;
     NenableOptoRX++;
@@ -225,24 +240,26 @@ void ESUnpacker::interpretRawData(int fedId, const FEDRawData & rawData, ESRawDa
   // Event data
   int iopto = 0;
   int opto = -1;
-  for (const Word64* word=(header+dccWords+1); word!=trailer; ++word) {
-    if (debug_) LogDebug("ESUnpacker")<<"Event : "<<print(*word);
+  for (const Word64* word = (header + dccWords + 1); word != trailer; ++word) {
+    if (debug_)
+      LogDebug("ESUnpacker") << "Event : " << print(*word);
 
     head = (*word >> 60) & m4;
 
     if (head == 12) {
-      if ((opto==0 && ESDCCHeader.getOptoRX0()==129) || (opto==1 && ESDCCHeader.getOptoRX1()==129) || (opto==2 && ESDCCHeader.getOptoRX2()==129)) 
-	word2digi(kid, kPACE, *word, digis);
+      if ((opto == 0 && ESDCCHeader.getOptoRX0() == 129) || (opto == 1 && ESDCCHeader.getOptoRX1() == 129) ||
+          (opto == 2 && ESDCCHeader.getOptoRX2() == 129))
+        word2digi(kid, kPACE, *word, digis);
     } else if (head == 9) {
-      kid      = (*word >> 2) & 0x07ff;
+      kid = (*word >> 2) & 0x07ff;
       kPACE[0] = (*word >> 16) & m1;
       kPACE[1] = (*word >> 17) & m1;
       kPACE[2] = (*word >> 18) & m1;
       kPACE[3] = (*word >> 19) & m1;
-      kFlag2   = (*word >> 20) & m4;
-      kFlag1   = (*word >> 24) & m8;
-      kBC      = (*word >> 32) & m16;
-      kEC      = (*word >> 48) & m8;
+      kFlag2 = (*word >> 20) & m4;
+      kFlag1 = (*word >> 24) & m8;
+      kBC = (*word >> 32) & m16;
+      kEC = (*word >> 48) & m8;
 
       ESKCHIPBlock ESKCHIP;
       ESKCHIP.setId(kid);
@@ -255,70 +272,79 @@ void ESUnpacker::interpretRawData(int fedId, const FEDRawData & rawData, ESRawDa
       kchips.push_back(ESKCHIP);
     } else if (head == 6) {
       optoBC = (*word >> 32) & m16;
-      optoEC = (*word >> 48) & m8;      
+      optoEC = (*word >> 48) & m8;
 
       opto = enableOptoRX[iopto];
-      if (opto==0) ESDCCHeader.setOptoBC0(optoBC);
-      else if (opto==1) ESDCCHeader.setOptoBC1(optoBC);
-      else if (opto==2) ESDCCHeader.setOptoBC2(optoBC);
-      if (iopto < 2) ++iopto;
+      if (opto == 0)
+        ESDCCHeader.setOptoBC0(optoBC);
+      else if (opto == 1)
+        ESDCCHeader.setOptoBC1(optoBC);
+      else if (opto == 2)
+        ESDCCHeader.setOptoBC2(optoBC);
+      if (iopto < 2)
+        ++iopto;
     }
   }
 
   dccs.push_back(ESDCCHeader);
 }
 
-void ESUnpacker::word2digi(int kid, int kPACE[4], const Word64 & word, ESDigiCollection & digis) 
-{
+void ESUnpacker::word2digi(int kid, int kPACE[4], const Word64& word, ESDigiCollection& digis) {
+  int pace = (word >> 53) & m2;
+  if (kPACE[pace] == 0)
+    return;
+  if (kid > 1511 || kid < 1)
+    return;
 
-  int pace  = (word >> 53) & m2;
-  if (kPACE[pace]==0) return;
-  if (kid > 1511 || kid < 1) return;
-  
   int adc[3];
-  adc[0]    = (word >> 0)  & m16;
-  adc[1]    = (word >> 16) & m16;
-  adc[2]    = (word >> 32) & m16;
+  adc[0] = (word >> 0) & m16;
+  adc[1] = (word >> 16) & m16;
+  adc[2] = (word >> 32) & m16;
   int strip = (word >> 48) & m5;
 
-  if (debug_) LogDebug("ESUnpacker")<<kid<<" "<<strip<<" "<<pace<<" "<<adc[0]<<" "<<adc[1]<<" "<<adc[2];
+  if (debug_)
+    LogDebug("ESUnpacker") << kid << " " << strip << " " << pace << " " << adc[0] << " " << adc[1] << " " << adc[2];
 
   int zside, plane, ix, iy;
-  zside = zside_[kid-1][pace];
-  plane = pl_[kid-1][pace];
-  ix    = x_[kid-1][pace];
-  iy    = y_[kid-1][pace];
-  
+  zside = zside_[kid - 1][pace];
+  plane = pl_[kid - 1][pace];
+  ix = x_[kid - 1][pace];
+  iy = y_[kid - 1][pace];
+
   // convert strip number from electronics id to detector id
-  if (vmajor_ == 4 && (vminor_==2 || vminor_==3)) {
-    if (zside == 1 && plane == 1 && iy <= 20) strip = 31 - strip;
-    if (zside == 1 && plane == 2 && ix > 20) strip = 31 - strip;
-    if (zside == -1 && plane == 1 && iy > 20) strip = 31 - strip;
-    if (zside == -1 && plane == 2 && ix <= 20) strip = 31 - strip;
+  if (vmajor_ == 4 && (vminor_ == 2 || vminor_ == 3)) {
+    if (zside == 1 && plane == 1 && iy <= 20)
+      strip = 31 - strip;
+    if (zside == 1 && plane == 2 && ix > 20)
+      strip = 31 - strip;
+    if (zside == -1 && plane == 1 && iy > 20)
+      strip = 31 - strip;
+    if (zside == -1 && plane == 2 && ix <= 20)
+      strip = 31 - strip;
   }
 
-  if (debug_) LogDebug("ESUnpacker")<<"DetId : "<<zside<<" "<<plane<<" "<<ix<<" "<<iy<<" "<<strip+1;
-  
-  if (ESDetId::validDetId(strip+1, ix, iy, plane, zside)) {
-    
-    ESDetId detId(strip+1, ix, iy, plane, zside);
+  if (debug_)
+    LogDebug("ESUnpacker") << "DetId : " << zside << " " << plane << " " << ix << " " << iy << " " << strip + 1;
+
+  if (ESDetId::validDetId(strip + 1, ix, iy, plane, zside)) {
+    ESDetId detId(strip + 1, ix, iy, plane, zside);
     ESDataFrame df(detId);
     df.setSize(3);
-    
-    for (int i=0; i<3; i++) df.setSample(i, adc[i]);  
-    
-    digis.push_back(df);
-    
-    if (debug_) 
-      LogDebug("ESUnpacker")<<"Si : "<<detId.zside()<<" "<<detId.plane()<<" "<<detId.six()<<" "<<detId.siy()<<" "<<detId.strip()<<" ("<<kid<<","<<pace<<") "<<df.sample(0).adc()<<" "<<df.sample(1).adc()<<" "<<df.sample(2).adc();
-  }
 
+    for (int i = 0; i < 3; i++)
+      df.setSample(i, adc[i]);
+
+    digis.push_back(df);
+
+    if (debug_)
+      LogDebug("ESUnpacker") << "Si : " << detId.zside() << " " << detId.plane() << " " << detId.six() << " "
+                             << detId.siy() << " " << detId.strip() << " (" << kid << "," << pace << ") "
+                             << df.sample(0).adc() << " " << df.sample(1).adc() << " " << df.sample(2).adc();
+  }
 }
 
-std::string ESUnpacker::print(const  Word64 & word) const
-{
+std::string ESUnpacker::print(const Word64& word) const {
   std::ostringstream str;
-  str << "Word64:  " << reinterpret_cast<const std::bitset<64>&> (word);
+  str << "Word64:  " << reinterpret_cast<const std::bitset<64>&>(word);
   return str.str();
 }
-

--- a/EventFilter/ESRawToDigi/src/SealModule.cc
+++ b/EventFilter/ESRawToDigi/src/SealModule.cc
@@ -1,5 +1,4 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "EventFilter/ESRawToDigi/interface/ESRawToDigi.h"
 
-
 DEFINE_FWK_MODULE(ESRawToDigi);

--- a/MagneticField/Engine/interface/MagneticField.h
+++ b/MagneticField/Engine/interface/MagneticField.h
@@ -16,58 +16,50 @@
 #include "FWCore/Utilities/interface/Likely.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
-class MagneticField
-{
- public:
+class MagneticField {
+public:
   MagneticField();
   MagneticField(const MagneticField& orig);
   virtual ~MagneticField();
 
-  /// Derived classes can implement cloning without ownership of the 
+  /// Derived classes can implement cloning without ownership of the
   /// underlying engines.
-  virtual MagneticField* clone() const {
-    return nullptr;
-  }
-  
+  virtual MagneticField* clone() const { return nullptr; }
+
   /// Field value ad specified global point, in Tesla
-  virtual GlobalVector inTesla (const GlobalPoint& gp) const = 0;
+  virtual GlobalVector inTesla(const GlobalPoint& gp) const = 0;
 
   /// Field value ad specified global point, in KGauss
-  GlobalVector inKGauss(const GlobalPoint& gp) const  {
-    return inTesla(gp) * 10.F;
-  }
+  GlobalVector inKGauss(const GlobalPoint& gp) const { return inTesla(gp) * 10.F; }
 
   /// Field value ad specified global point, in 1/Gev
-  GlobalVector inInverseGeV(const GlobalPoint& gp) const {
-    return inTesla(gp) * 2.99792458e-3F;
-  }
+  GlobalVector inInverseGeV(const GlobalPoint& gp) const { return inTesla(gp) * 2.99792458e-3F; }
 
   /// True if the point is within the region where the concrete field
   // engine is defined.
-  virtual bool isDefined(const GlobalPoint& /*gp*/) const {
-    return true;
-  }
-  
+  virtual bool isDefined(const GlobalPoint& /*gp*/) const { return true; }
+
   /// Optional implementation that derived classes can implement to provide faster query
   /// by skipping the check to isDefined.
-  virtual GlobalVector inTeslaUnchecked (const GlobalPoint& gp) const {
+  virtual GlobalVector inTeslaUnchecked(const GlobalPoint& gp) const {
     return inTesla(gp);  // default dummy implementation
   }
-  
+
   /// The nominal field value for this map in kGauss
-  int nominalValue() const {  
-     if(kSet==nominalValueCompiuted.load()) return theNominalValue;
-     return computeNominalValue();
-  }     
+  int nominalValue() const {
+    if (kSet == nominalValueCompiuted.load())
+      return theNominalValue;
+    return computeNominalValue();
+  }
 
 private:
-  //nominal field value 
+  //nominal field value
   virtual int computeNominalValue() const;
   mutable std::atomic<char> nominalValueCompiuted;
-//  CMS_THREAD_GUARD(nominalValueCompiuted) mutable int theNominalValue;
-//  PG temporary fix for clang 3.4 which is not parsing thread_guard correctly
+  //  CMS_THREAD_GUARD(nominalValueCompiuted) mutable int theNominalValue;
+  //  PG temporary fix for clang 3.4 which is not parsing thread_guard correctly
   CMS_THREAD_SAFE mutable int theNominalValue;
-  enum FooStates {kUnset, kSetting, kSet};
+  enum FooStates { kUnset, kSetting, kSet };
 };
 
 #endif

--- a/MagneticField/Engine/src/ES_MagneticField.cc
+++ b/MagneticField/Engine/src/ES_MagneticField.cc
@@ -1,6 +1,5 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
-   
+
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(MagneticField);
-   

--- a/MagneticField/Engine/src/MagneticField.cc
+++ b/MagneticField/Engine/src/MagneticField.cc
@@ -5,28 +5,25 @@
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 
-MagneticField::MagneticField() : nominalValueCompiuted(kUnset), theNominalValue(0)
-{
-}
+MagneticField::MagneticField() : nominalValueCompiuted(kUnset), theNominalValue(0) {}
 
-MagneticField::MagneticField(const MagneticField& orig) : nominalValueCompiuted(kUnset), theNominalValue(0)
-{
-  if(orig.nominalValueCompiuted.load() == kSet) {
+MagneticField::MagneticField(const MagneticField& orig) : nominalValueCompiuted(kUnset), theNominalValue(0) {
+  if (orig.nominalValueCompiuted.load() == kSet) {
     theNominalValue = orig.theNominalValue;
     nominalValueCompiuted.store(kSet);
   }
 }
 
-MagneticField::~MagneticField(){}
+MagneticField::~MagneticField() {}
 
 int MagneticField::computeNominalValue() const {
-  int tmp = int((inTesla(GlobalPoint(0.f,0.f,0.f))).z() * 10.f + 0.5f);
+  int tmp = int((inTesla(GlobalPoint(0.f, 0.f, 0.f))).z() * 10.f + 0.5f);
 
   //Try to cache
   char expected = kUnset;
-  if(nominalValueCompiuted.compare_exchange_strong(expected, kSetting) ) {
+  if (nominalValueCompiuted.compare_exchange_strong(expected, kSetting)) {
     //it is our job to set the value
-    std::swap(theNominalValue,tmp);
+    std::swap(theNominalValue, tmp);
 
     //this must be after the swap
     nominalValueCompiuted.store(kSet);

--- a/MagneticField/Engine/test/queryField.cc
+++ b/MagneticField/Engine/test/queryField.cc
@@ -19,7 +19,6 @@
 //#include "DataFormats/GeometryVector/interface/Pi.h"
 //#include "DataFormats/GeometryVector/interface/CoordinateSets.h"
 
-
 #include <iostream>
 #include <string>
 #include <sstream>
@@ -31,39 +30,35 @@ using namespace Geom;
 using namespace std;
 
 class queryField : public edm::EDAnalyzer {
- public:
-  queryField(const edm::ParameterSet& pset) {    
-  }
+public:
+  queryField(const edm::ParameterSet& pset) {}
 
-  ~queryField(){}
+  ~queryField() {}
 
   virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) {
-   ESHandle<MagneticField> magfield;
-   setup.get<IdealMagneticFieldRecord>().get(magfield);
+    ESHandle<MagneticField> magfield;
+    setup.get<IdealMagneticFieldRecord>().get(magfield);
 
-   field = magfield.product();
+    field = magfield.product();
 
-   cout << "Field Nominal Value: " << field->nominalValue() << endl;
+    cout << "Field Nominal Value: " << field->nominalValue() << endl;
 
-   double x,y,z;
+    double x, y, z;
 
-   while (1) {
-     
-     cout << "Enter X Y Z (cm): ";
+    while (1) {
+      cout << "Enter X Y Z (cm): ";
 
-     if (!(cin >> x >>  y >>  z)) exit(0);
+      if (!(cin >> x >> y >> z))
+        exit(0);
 
-     GlobalPoint g(x,y,z);
-     
-     cout << "At R=" << g.perp() << " phi=" << g.phi()<< " B=" << field->inTesla(g) << endl;
-   }
-   
+      GlobalPoint g(x, y, z);
+
+      cout << "At R=" << g.perp() << " phi=" << g.phi() << " B=" << field->inTesla(g) << endl;
+    }
   }
-   
- private:
+
+private:
   const MagneticField* field;
 };
 
-
 DEFINE_FWK_MODULE(queryField);
-

--- a/MagneticField/Engine/test/testMagneticField.cc
+++ b/MagneticField/Engine/test/testMagneticField.cc
@@ -53,9 +53,8 @@ using namespace std;
 // #include "MagneticField/Layers/interface/MagVerbosity.h"
 
 class testMagneticField : public edm::EDAnalyzer {
- public:
+public:
   testMagneticField(const edm::ParameterSet& pset) {
-
     //    verbose::debugOut = true;
     outputFile = pset.getUntrackedParameter<string>("outputTable", "");
     inputFile = pset.getUntrackedParameter<string>("inputTable", "");
@@ -66,64 +65,61 @@ class testMagneticField : public edm::EDAnalyzer {
     //    number of random points to try
     numberOfPoints = pset.getUntrackedParameter<int>("numberOfPoints", 10000);
     //    outer radius of test cylinder
-    InnerRadius = pset.getUntrackedParameter<double>("InnerRadius",0.);
+    InnerRadius = pset.getUntrackedParameter<double>("InnerRadius", 0.);
     //    half length of test cylinder
-    OuterRadius = pset.getUntrackedParameter<double>("OuterRadius",900);
+    OuterRadius = pset.getUntrackedParameter<double>("OuterRadius", 900);
     //    half length of test cylinder
-    HalfLength = pset.getUntrackedParameter<double>("HalfLength",2400);
-    
+    HalfLength = pset.getUntrackedParameter<double>("HalfLength", 2400);
   }
 
-  ~testMagneticField(){}
+  ~testMagneticField() {}
 
-
-  void go(GlobalPoint g) {
-    std::cout << "At: " << g << " phi=" << g.phi()<< " B= " << field->inTesla(g) << std::endl;
-  }
+  void go(GlobalPoint g) { std::cout << "At: " << g << " phi=" << g.phi() << " B= " << field->inTesla(g) << std::endl; }
 
   virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) {
-   ESHandle<MagneticField> magfield;
-   setup.get<IdealMagneticFieldRecord>().get(magfield);
+    ESHandle<MagneticField> magfield;
+    setup.get<IdealMagneticFieldRecord>().get(magfield);
 
-   field = magfield.product();
+    field = magfield.product();
 
-   std::cout << "Nominal Field " << field->nominalValue() << "\n" << std::endl;
+    std::cout << "Nominal Field " << field->nominalValue() << "\n" << std::endl;
 
-   go(GlobalPoint(0,0,0));
+    go(GlobalPoint(0, 0, 0));
 
-   if (outputFile!="") {
-     writeValidationTable(numberOfPoints,outputFile);
-   }
-   
-   if (inputFileType == "TOSCA") {
-     validateVsTOSCATable(inputFile);
-   } else if (inputFileType == "TOSCAFileList") {
-     ifstream file(inputFile.c_str());
-     string table;
-     while (getline(file,table)) {
-       validateVsTOSCATable(table);
-     }
-   } else if (inputFileType == "TOSCASectorComparison") {
-     ifstream file(inputFile.c_str());
-     string table;
+    if (outputFile != "") {
+      writeValidationTable(numberOfPoints, outputFile);
+    }
 
-     cout << "Vol.      1       2       3       4       5       6       7       8       9      10      11      12" << endl;
+    if (inputFileType == "TOSCA") {
+      validateVsTOSCATable(inputFile);
+    } else if (inputFileType == "TOSCAFileList") {
+      ifstream file(inputFile.c_str());
+      string table;
+      while (getline(file, table)) {
+        validateVsTOSCATable(table);
+      }
+    } else if (inputFileType == "TOSCASectorComparison") {
+      ifstream file(inputFile.c_str());
+      string table;
 
-     while (getline(file,table)) {     
-       compareSectorTables(table);
-     }
-   }   else if (inputFile!="") {
-     validate (inputFile, inputFileType);
-   }
+      cout << "Vol.      1       2       3       4       5       6       7       8       9      10      11      12"
+           << endl;
 
-   // Some ad-hoc test
-//    for (float phi = 0; phi<Geom::twoPi(); phi+=Geom::pi()/48.) {
-//      go(GlobalPoint(Cylindrical2Cartesian<float>(89.,phi,145.892)), magfield.product());
-//   }
+      while (getline(file, table)) {
+        compareSectorTables(table);
+      }
+    } else if (inputFile != "") {
+      validate(inputFile, inputFileType);
+    }
+
+    // Some ad-hoc test
+    //    for (float phi = 0; phi<Geom::twoPi(); phi+=Geom::pi()/48.) {
+    //      go(GlobalPoint(Cylindrical2Cartesian<float>(89.,phi,145.892)), magfield.product());
+    //   }
   }
-  
+
   void writeValidationTable(int npoints, string filename);
-  void validate(string filename, string type="xyz");
+  void validate(string filename, string type = "xyz");
   void validateVsTOSCATable(string filename);
 
   const MagVolume6Faces* findVolume(GlobalPoint& gp);
@@ -133,11 +129,11 @@ class testMagneticField : public edm::EDAnalyzer {
   void fillFromTable(string inputFile, vector<GlobalPoint>& p, vector<GlobalVector>& b, string type);
   void compareSectorTables(string file);
 
- private:
+private:
   const MagneticField* field;
   string inputFile;
   string inputFileType;
-  string outputFile;  
+  string outputFile;
   double reso;
   int numberOfPoints;
   double OuterRadius;
@@ -145,317 +141,307 @@ class testMagneticField : public edm::EDAnalyzer {
   double HalfLength;
 };
 
-
 void testMagneticField::writeValidationTable(int npoints, string filename) {
   GlobalPointProvider p(InnerRadius, OuterRadius, -Geom::pi(), Geom::pi(), -HalfLength, HalfLength);
   ofstream file(filename.c_str());
 
-  for (int i = 0; i<npoints; ++i) {
+  for (int i = 0; i < npoints; ++i) {
     GlobalPoint gp = p.getPoint();
     GlobalVector f = field->inTesla(gp);
-    file << setprecision (9) //<< i << " "
-	 << gp.x() << " " << gp.y() << " " << gp.z() << " "
-	 << f.x() << " " << f.y() << " " << f.z()  << endl;
+    file << setprecision(9)  //<< i << " "
+         << gp.x() << " " << gp.y() << " " << gp.z() << " " << f.x() << " " << f.y() << " " << f.z() << endl;
   }
 }
 
-void testMagneticField::validate(string filename, string type) {  
+void testMagneticField::validate(string filename, string type) {
   ifstream file(filename.c_str());
   string line;
 
   int fail = 0;
   int count = 0;
-  
-  float maxdelta=0.;
 
-  while (getline(file,line) && count < numberOfPoints) {
-    if( line == "" || line[0] == '#' ) continue;
+  float maxdelta = 0.;
+
+  while (getline(file, line) && count < numberOfPoints) {
+    if (line == "" || line[0] == '#')
+      continue;
     stringstream linestr;
     linestr << line;
     float px, py, pz;
     float bx, by, bz;
-    linestr  >> px >> py >> pz >> bx >> by >> bz;
+    linestr >> px >> py >> pz >> bx >> by >> bz;
     GlobalPoint gp;
-    if (type=="rpz_m") { // assume rpz file with units in m.
-      gp = GlobalPoint(GlobalPoint::Cylindrical(px*100.,py,pz*100.));
-    } else if (type=="xyz_m") { // assume xyz file with units in m.
-      gp = GlobalPoint(px*100., py*100., pz*100.);
-    } else { // assume x,y,z with units in cm
-      gp = GlobalPoint(px, py, pz);      
+    if (type == "rpz_m") {  // assume rpz file with units in m.
+      gp = GlobalPoint(GlobalPoint::Cylindrical(px * 100., py, pz * 100.));
+    } else if (type == "xyz_m") {  // assume xyz file with units in m.
+      gp = GlobalPoint(px * 100., py * 100., pz * 100.);
+    } else {  // assume x,y,z with units in cm
+      gp = GlobalPoint(px, py, pz);
     }
 
-    if (gp.perp() < InnerRadius || gp.perp() > OuterRadius || fabs(gp.z()) > HalfLength) continue;
-    
+    if (gp.perp() < InnerRadius || gp.perp() > OuterRadius || fabs(gp.z()) > HalfLength)
+      continue;
+
     GlobalVector oldB(bx, by, bz);
     GlobalVector newB = field->inTesla(gp);
-    if ((newB-oldB).mag() > reso) {
+    if ((newB - oldB).mag() > reso) {
       ++fail;
-      float delta = (newB-oldB).mag();
-      if (delta > maxdelta) maxdelta = delta;
-      cout << " Discrepancy at: # " << count+1 << " " << gp
-	   << " R " << gp.perp() << " Phi " << gp.phi()
-	   << " delta : " << newB-oldB << " " << delta <<  endl;
-      
-      const MagVolume6Faces* vol = findVolume(gp);      
-      if (vol) cout << " volume: " << vol->volumeNo << " " << (int) vol->copyno ;
+      float delta = (newB - oldB).mag();
+      if (delta > maxdelta)
+        maxdelta = delta;
+      cout << " Discrepancy at: # " << count + 1 << " " << gp << " R " << gp.perp() << " Phi " << gp.phi()
+           << " delta : " << newB - oldB << " " << delta << endl;
+
+      const MagVolume6Faces* vol = findVolume(gp);
+      if (vol)
+        cout << " volume: " << vol->volumeNo << " " << (int)vol->copyno;
       cout << " Old: " << oldB << " New: " << newB << endl;
     }
     count++;
   }
-  cout << endl << " testMagneticField::validate: tested " << count
-       << " points " << fail << " failures; max delta = " << maxdelta
-       << endl << endl;
-  
+  cout << endl
+       << " testMagneticField::validate: tested " << count << " points " << fail
+       << " failures; max delta = " << maxdelta << endl
+       << endl;
 }
 
-
-
-void  testMagneticField::parseTOSCATablePath(string filename, int& volNo, int& sector, string& type) {
+void testMagneticField::parseTOSCATablePath(string filename, int& volNo, int& sector, string& type) {
   // Determine volume number, type, and sector from filename, assumed to be like:
   // [path]/s01_1/v-xyz-1156.table
   using boost::lexical_cast;
 
-
   char buf[512];
-  strcpy(buf, filename.c_str());		
+  strcpy(buf, filename.c_str());
   string table = basename(buf);
   string ssector = basename(dirname(buf));
 
-
   // Find type
-  string::size_type ibeg = table.find('-');  // first occurence of "-"
-  string::size_type iend = table.rfind('-'); // last  occurence of "-"
-  type = table.substr(ibeg+1, iend-ibeg-1);
+  string::size_type ibeg = table.find('-');   // first occurence of "-"
+  string::size_type iend = table.rfind('-');  // last  occurence of "-"
+  type = table.substr(ibeg + 1, iend - ibeg - 1);
 
   // Find volume number
-  string::size_type iext = table.rfind('.'); // last  occurence of "."
-  volNo = boost::lexical_cast<int>(table.substr(iend+1, iext-iend-1));
+  string::size_type iext = table.rfind('.');  // last  occurence of "."
+  volNo = boost::lexical_cast<int>(table.substr(iend + 1, iext - iend - 1));
 
   // Find sector number
-  if (ssector[0]=='s') {
-    sector = boost::lexical_cast<int>(ssector.substr(1,2));
+  if (ssector[0] == 's') {
+    sector = boost::lexical_cast<int>(ssector.substr(1, 2));
   } else {
     cout << "Can not determine sector number, assuming 1" << endl;
     sector = 1;
   }
 }
 
-
-
 void testMagneticField::validateVsTOSCATable(string filename) {
-  // The magic here is that we want to check against the result of the master volume only 
+  // The magic here is that we want to check against the result of the master volume only
   // as grid points on the border of volumes can end up in the neighbor volume.
-  
+
   int volNo, sector;
   string type;
-  parseTOSCATablePath(filename,volNo,sector,type);
-
-  
+  parseTOSCATablePath(filename, volNo, sector, type);
 
   const MagVolume6Faces* vol = findMasterVolume(volNo, sector);
-  if (vol==0) {
+  if (vol == 0) {
     cout << "   ERROR: volume " << volNo << ":" << sector << "not found" << endl;
     return;
   }
 
-  cout << "Validate interpolation vs TOSCATable: " << filename << " volume " << volNo << ":[" << sector <<"], type " << type << endl;  
+  cout << "Validate interpolation vs TOSCATable: " << filename << " volume " << volNo << ":[" << sector << "], type "
+       << type << endl;
 
-
-  
   ifstream file(filename.c_str());
   string line;
 
   int fail = 0;
   int count = 0;
-  
-  float maxdelta=0.;
 
+  float maxdelta = 0.;
 
   // Dump table
-//   const MFGrid* interpolator = (const MFGrid*) vol->provider();
-//   Dimensions dim = interpolator->dimensions();
-//   for (int i=0; i<dim.w; ++i){
-//     for (int j=0; j<dim.h; ++j){
-//       for (int k=0; k<dim.d; ++k){
-// 	cout << vol->toGlobal(interpolator->nodePosition(i,j,k)) << " " << vol->toGlobal(interpolator->nodeValue(i,j,k)) <<endl;
-//       }
-//     }
-//   } 
+  //   const MFGrid* interpolator = (const MFGrid*) vol->provider();
+  //   Dimensions dim = interpolator->dimensions();
+  //   for (int i=0; i<dim.w; ++i){
+  //     for (int j=0; j<dim.h; ++j){
+  //       for (int k=0; k<dim.d; ++k){
+  // 	cout << vol->toGlobal(interpolator->nodePosition(i,j,k)) << " " << vol->toGlobal(interpolator->nodeValue(i,j,k)) <<endl;
+  //       }
+  //     }
+  //   }
 
-  while (getline(file,line) && count < numberOfPoints) {
-    if( line == "" || line[0] == '#' ) continue;
+  while (getline(file, line) && count < numberOfPoints) {
+    if (line == "" || line[0] == '#')
+      continue;
     stringstream linestr;
     linestr << line;
     double px, py, pz;
     double bx, by, bz;
-    linestr  >> px >> py >> pz >> bx >> by >> bz;
+    linestr >> px >> py >> pz >> bx >> by >> bz;
     GlobalPoint gp;
-    if (type=="rpz") { // rpz file with units in m.
-      gp = GlobalPoint(GlobalPoint::Cylindrical(px*100.,py,pz*100.));
-    } else if (type=="xyz") { // xyz file with units in m.
-      gp = GlobalPoint(px*100., py*100., pz*100.);
+    if (type == "rpz") {  // rpz file with units in m.
+      gp = GlobalPoint(GlobalPoint::Cylindrical(px * 100., py, pz * 100.));
+    } else if (type == "xyz") {  // xyz file with units in m.
+      gp = GlobalPoint(px * 100., py * 100., pz * 100.);
     } else {
       cout << "validateVsTOSCATable: type " << type << " unknown " << endl;
       return;
     }
 
     //    if (gp.perp() < InnerRadius || gp.perp() > OuterRadius || fabs(gp.z()) > HalfLength) continue;
-    
+
     GlobalVector oldB(bx, by, bz);
-    if (vol->inside(gp,0.03)) {    
+    if (vol->inside(gp, 0.03)) {
       GlobalVector newB = vol->inTesla(gp);
-      if ((newB-oldB).mag() > reso) {
-	++fail;
-	float delta = (newB-oldB).mag();
-	if (delta > maxdelta) maxdelta = delta;
-	cout << " Discrepancy at: # " << count+1 << " " << gp << " delta : " << newB-oldB << " " << delta <<  endl;
-	cout << " Table: " << oldB << " Map: " << newB << endl;
+      if ((newB - oldB).mag() > reso) {
+        ++fail;
+        float delta = (newB - oldB).mag();
+        if (delta > maxdelta)
+          maxdelta = delta;
+        cout << " Discrepancy at: # " << count + 1 << " " << gp << " delta : " << newB - oldB << " " << delta << endl;
+        cout << " Table: " << oldB << " Map: " << newB << endl;
       }
     } else {
-      cout << "ERROR: grid point # "  << count+1 << " " << gp << " is not inside volume " << endl;
+      cout << "ERROR: grid point # " << count + 1 << " " << gp << " is not inside volume " << endl;
     }
-    
+
     count++;
   }
 
-  if (count==0) {
+  if (count == 0) {
     cout << "ERROR: input table not found" << endl;
   } else {
-    cout << endl << " testMagneticField::validateVsTOSCATable: tested " << count
-	 << " points " << fail << " failures; max delta = " << maxdelta
-	 << endl << endl;
+    cout << endl
+         << " testMagneticField::validateVsTOSCATable: tested " << count << " points " << fail
+         << " failures; max delta = " << maxdelta << endl
+         << endl;
   }
-  
 }
 
-// #include <multimap> 
+// #include <multimap>
 // typedef multimap<float, pair<int, int> > VolumesByDiscrepancy ;
 
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-
 // Compare the TOSCA txt table with the corresponding one in other sector.
 void testMagneticField::compareSectorTables(string file1) {
-
-  bool list = false; // true: print one line per volume
-                    // false: print formatted table
+  bool list = false;  // true: print one line per volume
+                      // false: print formatted table
 
   int volNo, sector1;
-  string type;  
-  parseTOSCATablePath(file1,volNo,sector1,type);
+  string type;
+  parseTOSCATablePath(file1, volNo, sector1, type);
 
-  //cout << "Comparing tables for all sectors for volume " << volNo << " with " << file1 << endl;  
-  if (!list) cout << volNo;
+  //cout << "Comparing tables for all sectors for volume " << volNo << " with " << file1 << endl;
+  if (!list)
+    cout << volNo;
 
   float maxmaxdelta = 0.;
-  for (int sector2=1; sector2<=12; ++sector2) {
-    if (sector2==sector1) {
-      if (!list) cout << "   ----";
+  for (int sector2 = 1; sector2 <= 12; ++sector2) {
+    if (sector2 == sector1) {
+      if (!list)
+        cout << "   ----";
       continue;
     }
-    
-    
-//     vols.insert(pair<float,int>());
-    
-    double phi = (sector2-sector1)*Geom::pi()/6.;
+
+    //     vols.insert(pair<float,int>());
+
+    double phi = (sector2 - sector1) * Geom::pi() / 6.;
     double cphi = cos(phi);
     double sphi = sin(phi);
-    
 
     // Path of file for the other sector
-    string file2=file1;
-    string::size_type ss = file2.rfind("/s"); // last  occurence of "-"
+    string file2 = file1;
+    string::size_type ss = file2.rfind("/s");  // last  occurence of "-"
     string ssec = "/s";
-    if (sector2<10) ssec+="0";
-    ssec+=std::to_string(sector2);
-    file2.replace(ss,4,ssec);
- 
-    vector<GlobalPoint>  p1, p2;
+    if (sector2 < 10)
+      ssec += "0";
+    ssec += std::to_string(sector2);
+    file2.replace(ss, 4, ssec);
+
+    vector<GlobalPoint> p1, p2;
     vector<GlobalVector> b1, b2;
-  
+
     fillFromTable(file1, p1, b1, type);
     fillFromTable(file2, p2, b2, type);
 
-
     struct stat theStat;
     //FIXME get table size
-    string binTable = "/data/n/namapane/MagneticField/120812/grid_120812_3_8t_v7_large"; 
-    binTable+=ssec;
-    binTable+="_";
+    string binTable = "/data/n/namapane/MagneticField/120812/grid_120812_3_8t_v7_large";
+    binTable += ssec;
+    binTable += "_";
     string sVolNo = std::to_string(volNo);
-    binTable+=sVolNo[0];
-    binTable+="/grid.";
-    binTable+=sVolNo;
-    binTable+=".bin";
+    binTable += sVolNo[0];
+    binTable += "/grid.";
+    binTable += sVolNo;
+    binTable += ".bin";
     stat(binTable.c_str(), &theStat);
     off_t size = theStat.st_size;
-    
 
-    if (p1.size()!= p2.size() || p1.size()==0) {
-      cout << "ERROR: file size: " <<  p1.size() << " " << p2.size() << endl;
-    }  
+    if (p1.size() != p2.size() || p1.size() == 0) {
+      cout << "ERROR: file size: " << p1.size() << " " << p2.size() << endl;
+    }
 
     float maxdelta = 0;
     float avgdelta = 0;
-//     int imaxdelta = -1;
+    //     int imaxdelta = -1;
     vector<GlobalVector> b12;
-    for (unsigned int i=0; i<p1.size(); ++i){
+    for (unsigned int i = 0; i < p1.size(); ++i) {
       // check positions, need to get appropriate rotation
       //Rotate b1 into sector of b2
-      GlobalPoint p12( cphi*p1[i].x()-sphi*p1[i].y(), sphi*p1[i].x()+cphi*p1[i].y(),   p1[i].z());
-      float pd = (p12-p2[i]).mag();
+      GlobalPoint p12(cphi * p1[i].x() - sphi * p1[i].y(), sphi * p1[i].x() + cphi * p1[i].y(), p1[i].z());
+      float pd = (p12 - p2[i]).mag();
       if (pd > 0.005) {
-	cout << "ERROR: " << p12 << " " << p2[i] << " " << (p12-p2[i]).mag() << endl;      
+        cout << "ERROR: " << p12 << " " << p2[i] << " " << (p12 - p2[i]).mag() << endl;
       }
-      
-      b12.push_back(GlobalVector( cphi*b1[i].x()-sphi*b1[i].y(), sphi*b1[i].x()+cphi*b1[i].y(),   b1[i].z()));
-      GlobalVector delta = (b2[i]-b12[i]);
+
+      b12.push_back(GlobalVector(cphi * b1[i].x() - sphi * b1[i].y(), sphi * b1[i].x() + cphi * b1[i].y(), b1[i].z()));
+      GlobalVector delta = (b2[i] - b12[i]);
       float d = delta.mag();
-      avgdelta+=d;
+      avgdelta += d;
       if (d > maxdelta) {
-// 	imaxdelta=i;
-	maxdelta=d;	
+        // 	imaxdelta=i;
+        maxdelta = d;
       }
     }
 
     if (maxdelta > maxmaxdelta) {
-      maxmaxdelta=maxdelta;	
+      maxmaxdelta = maxdelta;
     }
 
-    avgdelta/=p1.size();
+    avgdelta /= p1.size();
 
     cout << setprecision(3) << fixed;
-    if (list) cout << volNo << " " << sector2 << " " << avgdelta  << " " << maxdelta << " " << size << endl;
+    if (list)
+      cout << volNo << " " << sector2 << " " << avgdelta << " " << maxdelta << " " << size << endl;
     else {
       cout << "   " << maxdelta;
-//      cout << "   " << avgdelta;
+      //      cout << "   " << avgdelta;
     }
-    
+
     cout.unsetf(ios_base::floatfield);
-//     cout << "MAX: " << volNo << " " << sector2 << " " <<  setprecision(3) << maxdelta << endl;
-//     cout << imaxdelta << " " << b2[imaxdelta] << " " << b12[imaxdelta] << " " << (b2[imaxdelta]-b12[imaxdelta]) << endl;
+    //     cout << "MAX: " << volNo << " " << sector2 << " " <<  setprecision(3) << maxdelta << endl;
+    //     cout << imaxdelta << " " << b2[imaxdelta] << " " << b12[imaxdelta] << " " << (b2[imaxdelta]-b12[imaxdelta]) << endl;
   }
   cout << endl;
 }
 
 void testMagneticField::fillFromTable(string inputFile, vector<GlobalPoint>& p, vector<GlobalVector>& b, string type) {
-
   ifstream file(inputFile.c_str());
   string line;
-  while (getline(file,line) ) {
+  while (getline(file, line)) {
     stringstream linestr;
     linestr << line;
     double px, py, pz;
     double bx, by, bz;
-    linestr  >> px >> py >> pz >> bx >> by >> bz;
+    linestr >> px >> py >> pz >> bx >> by >> bz;
     GlobalVector gv(bx, by, bz);
     GlobalPoint gp;
-    if (type=="rpz") { // rpz file with units in m.
-      gp = GlobalPoint(GlobalPoint::Cylindrical(px*100.,py,pz*100.));
-    } else if (type=="xyz") { // xyz file with units in m.
-      gp = GlobalPoint(px*100., py*100., pz*100.);
+    if (type == "rpz") {  // rpz file with units in m.
+      gp = GlobalPoint(GlobalPoint::Cylindrical(px * 100., py, pz * 100.));
+    } else if (type == "xyz") {  // xyz file with units in m.
+      gp = GlobalPoint(px * 100., py * 100., pz * 100.);
     } else {
       cout << "fillFromTable: type " << type << " unknown " << endl;
       return;
@@ -464,7 +450,6 @@ void testMagneticField::fillFromTable(string inputFile, vector<GlobalPoint>& p, 
     b.push_back(gv);
   }
 }
-
 
 #include "MagneticField/VolumeBasedEngine/interface/VolumeBasedMagneticField.h"
 
@@ -477,25 +462,23 @@ const MagVolume6Faces* testMagneticField::findVolume(GlobalPoint& gp) {
   return 0;
 }
 
-
 // Find a specific volume:sector
 const MagVolume6Faces* testMagneticField::findMasterVolume(int volume, int sector) {
   const MagGeometry* vbffield = (dynamic_cast<const VolumeBasedMagneticField*>(field))->field;
 
-  if (vbffield==0) return 0;
+  if (vbffield == 0)
+    return 0;
 
   const vector<MagVolume6Faces const*>& bvol = vbffield->barrelVolumes();
-  for (vector<MagVolume6Faces const*>::const_iterator i=bvol.begin();
-       i!=bvol.end(); i++) {
-    if ((*i)->copyno == sector && (*i)->volumeNo==volume) {
+  for (vector<MagVolume6Faces const*>::const_iterator i = bvol.begin(); i != bvol.end(); i++) {
+    if ((*i)->copyno == sector && (*i)->volumeNo == volume) {
       return (*i);
     }
   }
-  
+
   const vector<MagVolume6Faces const*>& evol = vbffield->endcapVolumes();
-  for (vector<MagVolume6Faces const*>::const_iterator i=evol.begin();
-       i!=evol.end(); i++) {
-    if ((*i)->copyno == sector && (*i)->volumeNo==volume) {
+  for (vector<MagVolume6Faces const*>::const_iterator i = evol.begin(); i != evol.end(); i++) {
+    if ((*i)->copyno == sector && (*i)->volumeNo == volume) {
       return (*i);
     }
   }
@@ -503,8 +486,4 @@ const MagVolume6Faces* testMagneticField::findMasterVolume(int volume, int secto
   return 0;
 }
 
-
- 
-
 DEFINE_FWK_MODULE(testMagneticField);
-

--- a/RecoBTag/Skimming/interface/BTagSkimLeptonJet.h
+++ b/RecoBTag/Skimming/interface/BTagSkimLeptonJet.h
@@ -15,39 +15,37 @@
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"    
+#include "FWCore/Utilities/interface/InputTag.h"
 
 class BTagSkimLeptonJet : public edm::EDFilter {
-	
-  public:
-	explicit BTagSkimLeptonJet( const edm::ParameterSet& );
-	~BTagSkimLeptonJet() override;
-	bool filter( edm::Event&, const edm::EventSetup& ) override;
-	void endJob() override;
-
-  private:
-	edm::InputTag CaloJetInput_;
-	double MinCaloJetPt_;
-	double MaxCaloJetEta_;
-	int MinNLeptonJet_;
-	std::string LeptonType_;
-	edm::InputTag LeptonInput_;
-	double MinLeptonPt_;
-	double MaxLeptonEta_;
-	double MaxDeltaR_;
-	double MinPtRel_;
-	
-	unsigned int nEvents_;
-	unsigned int nAccepted_;
-
-
-class PtSorter {
 public:
-  template <class T> bool operator() ( const T& a, const T& b ) {
-    return ( a.pt() > b.pt() );
-  }
-};
+  explicit BTagSkimLeptonJet(const edm::ParameterSet&);
+  ~BTagSkimLeptonJet() override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
+private:
+  edm::InputTag CaloJetInput_;
+  double MinCaloJetPt_;
+  double MaxCaloJetEta_;
+  int MinNLeptonJet_;
+  std::string LeptonType_;
+  edm::InputTag LeptonInput_;
+  double MinLeptonPt_;
+  double MaxLeptonEta_;
+  double MaxDeltaR_;
+  double MinPtRel_;
+
+  unsigned int nEvents_;
+  unsigned int nAccepted_;
+
+  class PtSorter {
+  public:
+    template <class T>
+    bool operator()(const T& a, const T& b) {
+      return (a.pt() > b.pt());
+    }
+  };
 };
 
 #endif

--- a/RecoBTag/Skimming/interface/BTagSkimMC.h
+++ b/RecoBTag/Skimming/interface/BTagSkimMC.h
@@ -1,12 +1,11 @@
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 class BTagSkimMC : public edm::EDFilter {
 public:
   /// constructor
-  BTagSkimMC( const edm::ParameterSet & );
-  bool filter( edm::Event& evt, const edm::EventSetup& es ) override;
+  BTagSkimMC(const edm::ParameterSet&);
+  bool filter(edm::Event& evt, const edm::EventSetup& es) override;
   void endJob() override;
 
 private:

--- a/RecoBTag/Skimming/src/BTagSkimLeptonJet.cc
+++ b/RecoBTag/Skimming/src/BTagSkimLeptonJet.cc
@@ -9,7 +9,7 @@
 #include <cmath>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/Common/interface/Handle.h"    
+#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/JetReco/interface/CaloJet.h"
@@ -31,149 +31,134 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
+BTagSkimLeptonJet::BTagSkimLeptonJet(const edm::ParameterSet& iConfig) : nEvents_(0), nAccepted_(0) {
+  CaloJetInput_ = iConfig.getParameter<InputTag>("CaloJet");
+  MinCaloJetPt_ = iConfig.getParameter<double>("MinimumCaloJetPt");
+  MaxCaloJetEta_ = iConfig.getParameter<double>("MaximumCaloJetEta");
 
-BTagSkimLeptonJet::BTagSkimLeptonJet( const edm::ParameterSet& iConfig ) :
-  nEvents_(0), nAccepted_(0)
-{
-  CaloJetInput_ = iConfig.getParameter<InputTag>( "CaloJet" );
-  MinCaloJetPt_ = iConfig.getParameter<double>( "MinimumCaloJetPt" );
-  MaxCaloJetEta_ = iConfig.getParameter<double>( "MaximumCaloJetEta" );
-  
   LeptonType_ = iConfig.getParameter<std::string>("LeptonType");
-  if ( LeptonType_ != "electron" && LeptonType_ != "muon" )
-	  edm::LogError( "BTagSkimLeptonJet" )
-		  << "unknown lepton type !!";
-  LeptonInput_ = iConfig.getParameter<InputTag>( "Lepton" );
-  MinLeptonPt_ = iConfig.getParameter<double>( "MinimumLeptonPt" );
-  MaxLeptonEta_ = iConfig.getParameter<double>( "MaximumLeptonEta" );
+  if (LeptonType_ != "electron" && LeptonType_ != "muon")
+    edm::LogError("BTagSkimLeptonJet") << "unknown lepton type !!";
+  LeptonInput_ = iConfig.getParameter<InputTag>("Lepton");
+  MinLeptonPt_ = iConfig.getParameter<double>("MinimumLeptonPt");
+  MaxLeptonEta_ = iConfig.getParameter<double>("MaximumLeptonEta");
   //MinNLepton_ = iConfig.getParameter<int>( "MinimumNLepton" );
 
-  MaxDeltaR_ = iConfig.getParameter<double>( "MaximumDeltaR" );
-  
-  MinPtRel_ = iConfig.getParameter<double>("MinimumPtRel" );
+  MaxDeltaR_ = iConfig.getParameter<double>("MaximumDeltaR");
 
-  MinNLeptonJet_ = iConfig.getParameter<int>( "MinimumNLeptonJet" );
-  if ( MinNLeptonJet_ < 1 ) 
-    edm::LogError( "BTagSkimLeptonJet" ) 
-		<< "MinimunNCaloJet < 1 !!";
+  MinPtRel_ = iConfig.getParameter<double>("MinimumPtRel");
+
+  MinNLeptonJet_ = iConfig.getParameter<int>("MinimumNLeptonJet");
+  if (MinNLeptonJet_ < 1)
+    edm::LogError("BTagSkimLeptonJet") << "MinimunNCaloJet < 1 !!";
 }
 
 /*------------------------------------------------------------------------*/
 
-BTagSkimLeptonJet::~BTagSkimLeptonJet() 
-{}
+BTagSkimLeptonJet::~BTagSkimLeptonJet() {}
 
 /*------------------------------------------------------------------------*/
 
-bool BTagSkimLeptonJet::filter( edm::Event& iEvent, 
-			     const edm::EventSetup& iSetup )
-{
+bool BTagSkimLeptonJet::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   nEvents_++;
 
   Handle<CaloJetCollection> CaloJetsHandle;
   //try {
-    iEvent.getByLabel( CaloJetInput_, CaloJetsHandle );
-    //} 
-    //catch ( cms::Exception& ex ) {
-    //edm::LogError( "BTagSkimLeptonJet" ) 
-    //  << "Unable to get CaloJet collection "
-    //  << CaloJetInput_.label();
-    //return false;
-    //}
-  if ( CaloJetsHandle->empty() ) return false;
+  iEvent.getByLabel(CaloJetInput_, CaloJetsHandle);
+  //}
+  //catch ( cms::Exception& ex ) {
+  //edm::LogError( "BTagSkimLeptonJet" )
+  //  << "Unable to get CaloJet collection "
+  //  << CaloJetInput_.label();
+  //return false;
+  //}
+  if (CaloJetsHandle->empty())
+    return false;
   CaloJetCollection TheCaloJets = *CaloJetsHandle;
-  std::stable_sort( TheCaloJets.begin(), TheCaloJets.end(), PtSorter() );
+  std::stable_sort(TheCaloJets.begin(), TheCaloJets.end(), PtSorter());
 
   //int nLepton = 0;
-  
+
   Handle<MuonCollection> MuonHandle;
   MuonCollection TheMuons;
   if (LeptonType_ == "muon") {
     //try{
-		  iEvent.getByLabel( LeptonInput_, MuonHandle );
-		  //  }
-		  //	  catch ( cms::Exception& ex ) {
-		  //edm::LogError( "BTagSkimLeptonJet" )
-		  //	  << "Unable to get muon collection "
-		  //	  << LeptonInput_.label();
-		  //return false;
-		  //}
-	  TheMuons = *MuonHandle;
-	  std::stable_sort( TheMuons.begin(), TheMuons.end(), PtSorter() );
+    iEvent.getByLabel(LeptonInput_, MuonHandle);
+    //  }
+    //	  catch ( cms::Exception& ex ) {
+    //edm::LogError( "BTagSkimLeptonJet" )
+    //	  << "Unable to get muon collection "
+    //	  << LeptonInput_.label();
+    //return false;
+    //}
+    TheMuons = *MuonHandle;
+    std::stable_sort(TheMuons.begin(), TheMuons.end(), PtSorter());
   }
 
   Handle<GsfElectronCollection> ElectronHandle;
   GsfElectronCollection TheElectrons;
   if (LeptonType_ == "electron") {
     //try{
-		  iEvent.getByLabel( LeptonInput_, ElectronHandle );
-		  //  }
-		  // catch ( cms::Exception& ex ) {
-		  // edm::LogError( "BTagSkimLeptonJet" )
-		  //		  << "Unable to get electron collection "
-		  //		  << LeptonInput_.label();
-		  // return false;
-		  // }
-	  TheElectrons = *ElectronHandle;
-	  std::stable_sort( TheElectrons.begin(), TheElectrons.end(), PtSorter() );
+    iEvent.getByLabel(LeptonInput_, ElectronHandle);
+    //  }
+    // catch ( cms::Exception& ex ) {
+    // edm::LogError( "BTagSkimLeptonJet" )
+    //		  << "Unable to get electron collection "
+    //		  << LeptonInput_.label();
+    // return false;
+    // }
+    TheElectrons = *ElectronHandle;
+    std::stable_sort(TheElectrons.begin(), TheElectrons.end(), PtSorter());
   }
-  
+
   // Jet cuts
   int nJet = 0;
-  for ( CaloJetCollection::const_iterator ajet = TheCaloJets.begin(); ajet != TheCaloJets.end(); ++ajet ) {
-	  
-	  if ( (fabs(ajet->eta()) < MaxCaloJetEta_) && (ajet->pt() > MinCaloJetPt_) ) {
+  for (CaloJetCollection::const_iterator ajet = TheCaloJets.begin(); ajet != TheCaloJets.end(); ++ajet) {
+    if ((fabs(ajet->eta()) < MaxCaloJetEta_) && (ajet->pt() > MinCaloJetPt_)) {
+      if (LeptonType_ == "muon") {
+        for (MuonCollection::const_iterator amuon = TheMuons.begin(); amuon != TheMuons.end(); ++amuon) {
+          // select good muon
+          if ((amuon->pt() > MinLeptonPt_) && (fabs(amuon->eta()) < MaxLeptonEta_)) {
+            double deltar = ROOT::Math::VectorUtil::DeltaR(ajet->p4().Vect(), amuon->momentum());
 
-		  if (LeptonType_ == "muon" ) {
-			  for ( MuonCollection::const_iterator amuon = TheMuons.begin(); amuon != TheMuons.end(); ++amuon ) {
-				  // select good muon
-				  if ( (amuon->pt() > MinLeptonPt_) && (fabs(amuon->eta()) < MaxLeptonEta_) ) {
+            TVector3 jetvec(ajet->p4().Vect().X(), ajet->p4().Vect().Y(), ajet->p4().Vect().Z());
+            TVector3 muvec(amuon->momentum().X(), amuon->momentum().Y(), amuon->momentum().Z());
+            jetvec += muvec;
+            double ptrel = muvec.Perp(jetvec);
 
-					  double deltar = ROOT::Math::VectorUtil::DeltaR(ajet->p4().Vect(),
-																	 amuon->momentum() );
+            if ((deltar < MaxDeltaR_) && (ptrel > MinPtRel_))
+              nJet++;
+            if (nJet >= MinNLeptonJet_)
+              break;
+          }
+        }
+      }
 
-					  TVector3 jetvec(ajet->p4().Vect().X(),
-									  ajet->p4().Vect().Y(),
-									  ajet->p4().Vect().Z() );
-					  TVector3 muvec( amuon->momentum().X(),
-									  amuon->momentum().Y(),
-									  amuon->momentum().Z() );
-					  jetvec += muvec;
-					  double ptrel = muvec.Perp(jetvec);
-				  
-					  if ( ( deltar < MaxDeltaR_ ) && (ptrel > MinPtRel_) ) nJet++;
-					  if ( nJet >= MinNLeptonJet_ ) break;
-				  }
-			  }
-		  }
+      if (LeptonType_ == "electron") {
+        for (GsfElectronCollection::const_iterator anelectron = TheElectrons.begin(); anelectron != TheElectrons.end();
+             anelectron++) {
+          if ((anelectron->pt() > MinLeptonPt_) && (fabs(anelectron->eta()) < MaxLeptonEta_)) {
+            double deltar = ROOT::Math::VectorUtil::DeltaR(ajet->p4().Vect(), anelectron->momentum());
 
-		  if (LeptonType_ == "electron") {
-			  for ( GsfElectronCollection::const_iterator anelectron = TheElectrons.begin(); anelectron != TheElectrons.end(); anelectron++ ) {
-				  if ( (anelectron->pt() > MinLeptonPt_) && (fabs(anelectron->eta()) < MaxLeptonEta_ ) ) {
-					  
-					  double deltar = ROOT::Math::VectorUtil::DeltaR(ajet->p4().Vect(),
-																	 anelectron->momentum() );
+            TVector3 jetvec(ajet->p4().Vect().X(), ajet->p4().Vect().Y(), ajet->p4().Vect().Z());
+            TVector3 evec(anelectron->momentum().X(), anelectron->momentum().Y(), anelectron->momentum().Z());
+            jetvec += evec;
+            double ptrel = evec.Perp(jetvec);
 
-					  TVector3 jetvec(ajet->p4().Vect().X(),
-									  ajet->p4().Vect().Y(),
-									  ajet->p4().Vect().Z() );
-					  TVector3 evec( anelectron->momentum().X(),
-									  anelectron->momentum().Y(),
-									  anelectron->momentum().Z() );
-					  jetvec += evec;
-					  double ptrel = evec.Perp(jetvec);
-				  
-					  if ( ( deltar < MaxDeltaR_ ) && (ptrel > MinPtRel_) ) nJet++;
-					  if ( nJet >= MinNLeptonJet_ ) break;
-				  }
-			  }
-		  }
-		  
-	  }// close jet selection
+            if ((deltar < MaxDeltaR_) && (ptrel > MinPtRel_))
+              nJet++;
+            if (nJet >= MinNLeptonJet_)
+              break;
+          }
+        }
+      }
+
+    }  // close jet selection
   }
-  
-  if ( nJet < MinNLeptonJet_ ) return false;
-  	  
+
+  if (nJet < MinNLeptonJet_)
+    return false;
+
   nAccepted_++;
 
   return true;
@@ -181,15 +166,12 @@ bool BTagSkimLeptonJet::filter( edm::Event& iEvent,
 
 /*------------------------------------------------------------------------*/
 
-void BTagSkimLeptonJet::endJob()
-{
-  edm::LogVerbatim( "BTagSkimLeptonJet" ) 
-    << "=============================================================================\n"
-	<< " Events read: " << nEvents_
-    << "\n Events accepted by (" << LeptonType_ << ") BTagSkimLeptonJet: " << nAccepted_
-    << "\n Efficiency: " << (double)(nAccepted_)/(double)(nEvents_)
-	<< "\n==========================================================================="
-    << endl;
+void BTagSkimLeptonJet::endJob() {
+  edm::LogVerbatim("BTagSkimLeptonJet")
+      << "=============================================================================\n"
+      << " Events read: " << nEvents_ << "\n Events accepted by (" << LeptonType_
+      << ") BTagSkimLeptonJet: " << nAccepted_ << "\n Efficiency: " << (double)(nAccepted_) / (double)(nEvents_)
+      << "\n===========================================================================" << endl;
 }
 
 //define this as a plug-in

--- a/RecoBTag/Skimming/src/BTagSkimMC.cc
+++ b/RecoBTag/Skimming/src/BTagSkimMC.cc
@@ -10,85 +10,81 @@ using namespace std;
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 using namespace reco;
 
-BTagSkimMC::BTagSkimMC( const ParameterSet & p ) :
-  nEvents_(0), nAccepted_(0)
-{
-  verbose = p.getUntrackedParameter<bool> ("verbose", false);
-  pthatMin = p.getParameter<double> ("pthat_min");
-  pthatMax = p.getParameter<double> ("pthat_max");
-  process_ = p.getParameter<string> ("mcProcess");
-  if (verbose) cout << " Requested:  " << process_<<endl;
-
+BTagSkimMC::BTagSkimMC(const ParameterSet& p) : nEvents_(0), nAccepted_(0) {
+  verbose = p.getUntrackedParameter<bool>("verbose", false);
+  pthatMin = p.getParameter<double>("pthat_min");
+  pthatMax = p.getParameter<double>("pthat_max");
+  process_ = p.getParameter<string>("mcProcess");
+  if (verbose)
+    cout << " Requested:  " << process_ << endl;
 }
 
-
-bool BTagSkimMC::filter( Event& evt, const EventSetup& es )
-{
+bool BTagSkimMC::filter(Event& evt, const EventSetup& es) {
   nEvents_++;
 
   Handle<int> genProcessID;
-  evt.getByLabel( "genEventProcID", genProcessID );
+  evt.getByLabel("genEventProcID", genProcessID);
   double processID = *genProcessID;
 
   Handle<double> genEventScale;
-  evt.getByLabel( "genEventScale", genEventScale );
+  evt.getByLabel("genEventScale", genEventScale);
   double pthat = *genEventScale;
 
-  if (verbose) cout << "processID: "<< processID << " - pthat: " << pthat;
-  
-  if  ((processID != 4) && (process_=="QCD")){  // the Pythia events (for ALPGEN see below)
+  if (verbose)
+    cout << "processID: " << processID << " - pthat: " << pthat;
+
+  if ((processID != 4) && (process_ == "QCD")) {  // the Pythia events (for ALPGEN see below)
 
     Handle<double> genFilterEff;
-    evt.getByLabel( "genEventRunInfo", "FilterEfficiency", genFilterEff);
+    evt.getByLabel("genEventRunInfo", "FilterEfficiency", genFilterEff);
     double filter_eff = *genFilterEff;
-    if (verbose) cout << " Is QCD ";
+    if (verbose)
+      cout << " Is QCD ";
     // qcd (including min bias HS)
-    if ((filter_eff == 1. || filter_eff == 0.964) && (processID == 11 || processID == 12 || processID == 13 || processID == 28 || processID == 68 || processID == 53)) {
-
+    if ((filter_eff == 1. || filter_eff == 0.964) && (processID == 11 || processID == 12 || processID == 13 ||
+                                                      processID == 28 || processID == 68 || processID == 53)) {
       if (pthat > pthatMin && pthat < pthatMax) {
-      if (verbose) cout << " ACCEPTED "<<endl;
-	nAccepted_++;
-	return true;
+        if (verbose)
+          cout << " ACCEPTED " << endl;
+        nAccepted_++;
+        return true;
       }
     }
 
-
-  }  // ALPGEN
-  else if(processID == 4) { // this is the number for external ALPGEN events
+  }                           // ALPGEN
+  else if (processID == 4) {  // this is the number for external ALPGEN events
 
     Handle<GenParticleCollection> genParticles;
-    evt.getByLabel( "genParticles", genParticles );
+    evt.getByLabel("genParticles", genParticles);
 
-    for( size_t i = 0; i < genParticles->size(); ++ i ) {
-      const Candidate & p = (*genParticles)[ i ];
+    for (size_t i = 0; i < genParticles->size(); ++i) {
+      const Candidate& p = (*genParticles)[i];
       int id = p.pdgId();
       int st = p.status();
 
       // tt+jets
-      if(st == 3 && (id == 6 || id == -6) ) {
-	if (verbose) cout << "We have a ttbar event"<<endl;
-	nAccepted_++;
-	return true;
+      if (st == 3 && (id == 6 || id == -6)) {
+        if (verbose)
+          cout << "We have a ttbar event" << endl;
+        nAccepted_++;
+        return true;
       }
     }
   }
-  if (verbose) cout << " REJECTED "<<endl;
+  if (verbose)
+    cout << " REJECTED " << endl;
 
   return false;
 }
 
-void BTagSkimMC::endJob()
-{
-  edm::LogVerbatim( "BTagSkimMC" ) 
-    << "=============================================================================\n"
-	<< " Events read: " << nEvents_
-    << "\n Events accepted by BTagSkimMC: " << nAccepted_
-    << "\n Efficiency: " << (double)(nAccepted_)/(double)(nEvents_)
-	<< "\n==========================================================================="
-    << endl;
+void BTagSkimMC::endJob() {
+  edm::LogVerbatim("BTagSkimMC") << "=============================================================================\n"
+                                 << " Events read: " << nEvents_ << "\n Events accepted by BTagSkimMC: " << nAccepted_
+                                 << "\n Efficiency: " << (double)(nAccepted_) / (double)(nEvents_)
+                                 << "\n==========================================================================="
+                                 << endl;
 }
-
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE( BTagSkimMC );
+DEFINE_FWK_MODULE(BTagSkimMC);

--- a/RecoBTag/XMLCalibration/interface/AlgorithmCalibration.h
+++ b/RecoBTag/XMLCalibration/interface/AlgorithmCalibration.h
@@ -16,9 +16,9 @@
 //#include "RecoBTag/TrackProbability/interface/CalibrationInterface.h"
 #include "RecoBTag/XMLCalibration/interface/CalibrationInterface.h"
 
-namespace XERCES_CPP_NAMESPACE { class DOMNode; }
-
-
+namespace XERCES_CPP_NAMESPACE {
+  class DOMNode;
+}
 
 //template <class T,class CO> class   CalibrationInterface;
 /**
@@ -34,115 +34,105 @@ namespace XERCES_CPP_NAMESPACE { class DOMNode; }
 * The class is templated on the Category T and on the CalibratedObject CO
 */
 
-template <class T,class CO> class AlgorithmCalibration : public CalibrationInterface<T,CO>
-{
-// friend class CalibrationInterface<T,CO>; 
-  public:
-    typedef XERCES_CPP_NAMESPACE::DOMElement DOMElement;
-    typedef XERCES_CPP_NAMESPACE::DOMNode DOMNode;
+template <class T, class CO>
+class AlgorithmCalibration : public CalibrationInterface<T, CO> {
+  // friend class CalibrationInterface<T,CO>;
+public:
+  typedef XERCES_CPP_NAMESPACE::DOMElement DOMElement;
+  typedef XERCES_CPP_NAMESPACE::DOMNode DOMNode;
 
   /**
    * Create an AlgorithmCalibration class and load from fileName the
    * cateogries and their objects.
    */
-    AlgorithmCalibration(const std::string & fileName);
-    
-    ~AlgorithmCalibration();
-    
-    /**
+  AlgorithmCalibration(const std::string &fileName);
+
+  ~AlgorithmCalibration();
+
+  /**
      * Prepare for a new calibration run
      */
-    void startCalibration();
+  void startCalibration();
 
-    /**
+  /**
      * Accumulate information to calibrate.
      */
-    void updateCalibration(const typename T::Input & calibrationInput);
-    template <class CI> void updateCalibration(const typename T::Input & calibrationInputForCategory,const CI & inputForCalibration);
+  void updateCalibration(const typename T::Input &calibrationInput);
+  template <class CI>
+  void updateCalibration(const typename T::Input &calibrationInputForCategory, const CI &inputForCalibration);
 
-    /**
+  /**
      * Finalize and save the calibration run to fileName
      */
-    void saveCalibration(const std::string & fileName);
+  void saveCalibration(const std::string &fileName);
 
- protected:
+protected:
+  CO *readObject(DOMNode *);
+  bool readCategories();
 
-    CO* readObject(DOMNode *);
-    bool readCategories();
-    
- protected:
-
-    DOMElement * dom() 
-    {
-      if(m_xml == 0)
-       {
-        m_xml=new CalibrationXML();
-	m_xml->openFile(m_filename);
-	
-       } 
-    return m_xml->calibrationDOM();
+protected:
+  DOMElement *dom() {
+    if (m_xml == 0) {
+      m_xml = new CalibrationXML();
+      m_xml->openFile(m_filename);
     }
+    return m_xml->calibrationDOM();
+  }
 
-  private:
-    std::string m_filename;
-    CalibrationXML *m_xml;
+private:
+  std::string m_filename;
+  CalibrationXML *m_xml;
 };
 
-
-template <class T,class CO> 
-AlgorithmCalibration<T,CO>::AlgorithmCalibration(const std::string & filename) : m_filename(filename), m_xml(0)
-{
- readCategories();
- if(m_xml) {
-  m_xml->closeFile();
- }
+template <class T, class CO>
+AlgorithmCalibration<T, CO>::AlgorithmCalibration(const std::string &filename) : m_filename(filename), m_xml(0) {
+  readCategories();
+  if (m_xml) {
+    m_xml->closeFile();
+  }
 }
 
-template <class T,class CO> 
-AlgorithmCalibration<T,CO>::~AlgorithmCalibration()
-{
-   if(m_xml) delete m_xml;
+template <class T, class CO>
+AlgorithmCalibration<T, CO>::~AlgorithmCalibration() {
+  if (m_xml)
+    delete m_xml;
 }
-    
-template <class T,class CO> 
-bool AlgorithmCalibration<T,CO>::readCategories()
-{
-   if(dom()==0) return false;
-   
-   DOMNode* n1 = dom()->getFirstChild();
-   while(n1)
-    {
-      if (n1->getNodeType() == DOMNode::ELEMENT_NODE   )
-      {
-	  T *cat = new T();
-	  cat->readFromDOM((DOMElement *)n1);
-	  CO * obj =readObject(n1->getFirstChild());
-          if(obj) 
-           {
-                this->addEntry(*cat,*obj);  
-                delete obj;  
-           }
-          delete cat;
+
+template <class T, class CO>
+bool AlgorithmCalibration<T, CO>::readCategories() {
+  if (dom() == 0)
+    return false;
+
+  DOMNode *n1 = dom()->getFirstChild();
+  while (n1) {
+    if (n1->getNodeType() == DOMNode::ELEMENT_NODE) {
+      T *cat = new T();
+      cat->readFromDOM((DOMElement *)n1);
+      CO *obj = readObject(n1->getFirstChild());
+      if (obj) {
+        this->addEntry(*cat, *obj);
+        delete obj;
       }
-      n1 = n1->getNextSibling();
+      delete cat;
     }
-    
- return true;
+    n1 = n1->getNextSibling();
+  }
+
+  return true;
 }
-template <class T,class CO>
-CO * AlgorithmCalibration<T,CO>::readObject(DOMNode * dom)
-{
-  DOMNode* n1 = dom;
-  while(n1)
-    {
-      if (n1->getNodeType() == DOMNode::ELEMENT_NODE   )
-	   break;
-      n1 = n1->getNextSibling();
-    }
-     
-  if(n1==0) return 0; //Cannot find any calibrated objects
-  
-  CO * co = new CO();
+template <class T, class CO>
+CO *AlgorithmCalibration<T, CO>::readObject(DOMNode *dom) {
+  DOMNode *n1 = dom;
+  while (n1) {
+    if (n1->getNodeType() == DOMNode::ELEMENT_NODE)
+      break;
+    n1 = n1->getNextSibling();
+  }
+
+  if (n1 == 0)
+    return 0;  //Cannot find any calibrated objects
+
+  CO *co = new CO();
   co->read((DOMElement *)n1);
   return co;
 }

--- a/RecoBTag/XMLCalibration/interface/CalibratedHistogramXML.h
+++ b/RecoBTag/XMLCalibration/interface/CalibratedHistogramXML.h
@@ -6,7 +6,6 @@
 #include <vector>
 #include <xercesc/dom/DOMNode.hpp>
 
-
 /**
 * This class implements some methods of the CalibratedObject.
 * This class does not provide methdos for calibration, i.e.
@@ -15,27 +14,21 @@
 * implement those methods in a child class.
 */
 
-class CalibratedHistogramXML:public CalibratedHistogram, CalibratedObject
-{
+class CalibratedHistogramXML : public CalibratedHistogram, CalibratedObject {
 public:
   typedef XERCES_CPP_NAMESPACE::DOMElement DOMElement;
   typedef XERCES_CPP_NAMESPACE::DOMNode DOMNode;
 
-  CalibratedHistogramXML() {} 
-  CalibratedHistogramXML(const CalibratedHistogram &h):CalibratedHistogram(h) {} 
-  CalibratedHistogramXML( const std::vector < float > & ulimits ) :
-   CalibratedHistogram ( ulimits) {}
-  ~CalibratedHistogramXML() override {} 
+  CalibratedHistogramXML() {}
+  CalibratedHistogramXML(const CalibratedHistogram &h) : CalibratedHistogram(h) {}
+  CalibratedHistogramXML(const std::vector<float> &ulimits) : CalibratedHistogram(ulimits) {}
+  ~CalibratedHistogramXML() override {}
 
-   
-  void read (DOMElement * dom) override;
-  
-  void write (DOMElement * dom) const override;
+  void read(DOMElement *dom) override;
 
-  std::string name () const override
-  {
-    return "CalibratedHistogramXML";
-  }
+  void write(DOMElement *dom) const override;
+
+  std::string name() const override { return "CalibratedHistogramXML"; }
 };
 
 #endif

--- a/RecoBTag/XMLCalibration/interface/CalibratedObject.h
+++ b/RecoBTag/XMLCalibration/interface/CalibratedObject.h
@@ -1,7 +1,7 @@
 #ifndef CALIBRATED_OBJECT_H
 #define CALIBRATED_OBJECT_H
 #include <string>
-#include <xercesc/dom/DOM.hpp>    
+#include <xercesc/dom/DOM.hpp>
 
 /** CalibratedObject class.
 * This is the abstract class of any object that the calibration framework returns to
@@ -11,39 +11,38 @@
 * Example of "CalibratedObjects" are PDFs,Neural Network set of parameters, ...
 */
 
-class CalibratedObject 
-{
-  public:
-    virtual ~CalibratedObject() = default;
-    /** This function has to be implemented in derived class.
+class CalibratedObject {
+public:
+  virtual ~CalibratedObject() = default;
+  /** This function has to be implemented in derived class.
     * It should read all the information the calibrated objects need to
     * load to be initialized from the xml file.
     * It is possible to use CalibrationXML::readAttribute<type>() to read an
     * attribute from the passed DOMElement.
     */
-    virtual void read( XERCES_CPP_NAMESPACE::DOMElement * dom ) = 0;
+  virtual void read(XERCES_CPP_NAMESPACE::DOMElement* dom) = 0;
 
-    /** This function has to be implemented in derived class.
+  /** This function has to be implemented in derived class.
     * It should write all the information the calibrated objects need to\
     * save/load.
     * It is possible to use CalibrationXML::writeAttribute() to write an
     * attribute in the passed DOMElement.
     */
-    virtual void write( XERCES_CPP_NAMESPACE::DOMElement * dom ) const = 0;
+  virtual void write(XERCES_CPP_NAMESPACE::DOMElement* dom) const = 0;
 
-    /** This function has to be implemented in derived class.
+  /** This function has to be implemented in derived class.
     * Prepare the calibrated object for a calibration run.
     * E.g. clear the right data members.
-    */  
-    virtual void startCalibration() {};
+    */
+  virtual void startCalibration(){};
 
-    /** This function has to be implemented in derived class.
+  /** This function has to be implemented in derived class.
     * Calibration is finished. Prepare for writing.
     * E.g. fit histogram, normalize, compute averages, whatever...
-    */  
-    virtual void finishCalibration() {};
+    */
+  virtual void finishCalibration(){};
 
-    /** 
+  /** 
     * You have to impelement a different updateCalibration(CalibrationInput) in the derived class for each 
     * CalibrationInput you want to be able to calibrate on.
     * So for example you may want to have an updateCalibration(RecTrack) but also a 
@@ -52,11 +51,11 @@ class CalibratedObject
     *
     * This implementation do nothing. 
     */
-    virtual void updateCalibration(){}
-    
-    /** Return a name for your calibrated object. It is used as XML tag name in reading and writing.
+  virtual void updateCalibration() {}
+
+  /** Return a name for your calibrated object. It is used as XML tag name in reading and writing.
     */
-    virtual std::string name() const = 0;     
+  virtual std::string name() const = 0;
 };
 
 #endif

--- a/RecoBTag/XMLCalibration/interface/CalibrationCategory.h
+++ b/RecoBTag/XMLCalibration/interface/CalibrationCategory.h
@@ -7,10 +7,7 @@
 #include <stdlib.h>
 #include "CalibrationXML.h"
 
-
-
-class CalibratedObject ;
-
+class CalibratedObject;
 
 /** This class defines a category.
 * The class is templated on the CI (category input) 
@@ -18,48 +15,38 @@ class CalibratedObject ;
 * virtual functions.
 */
 
-template <class CI> 
-class CalibrationCategory
-{
-  public:
+template <class CI>
+class CalibrationCategory {
+public:
+  typedef XERCES_CPP_NAMESPACE::DOMElement DOMElement;
+  typedef CI Input;
 
-    typedef XERCES_CPP_NAMESPACE::DOMElement DOMElement;
-    typedef  CI Input;
+  CalibrationCategory();
 
-    CalibrationCategory();
-    
-    virtual ~CalibrationCategory();
+  virtual ~CalibrationCategory();
 
-/** 
+  /** 
 * Should returun true if the CI input match that category 
 */
-    virtual bool match(const CI & calibrationInput) const = 0; //Not implemented here
-   
-    virtual std::string name(){return "BaseCalibrationCategory";} //Set it to pure virtual?
-    
-  protected:
-/** Read category parameters from XML
-*/
-    virtual void readFromDOM(DOMElement * dom)=0;  //Not implemented
-/** Save category parameters to XML
-*/
-    virtual void saveToDOM(DOMElement * dom)=0;  //Not implemented
+  virtual bool match(const CI& calibrationInput) const = 0;  //Not implemented here
 
-    virtual void dump() { }
+  virtual std::string name() { return "BaseCalibrationCategory"; }  //Set it to pure virtual?
 
-    
+protected:
+  /** Read category parameters from XML
+*/
+  virtual void readFromDOM(DOMElement* dom) = 0;  //Not implemented
+                                                  /** Save category parameters to XML
+*/
+  virtual void saveToDOM(DOMElement* dom) = 0;    //Not implemented
+
+  virtual void dump() {}
 };
 
+template <class CI>
+CalibrationCategory<CI>::CalibrationCategory() {}
 
-template <class CI> CalibrationCategory<CI>::CalibrationCategory() 
-{
-}
-
-template <class CI>  CalibrationCategory<CI>::~CalibrationCategory()
-{
-}
-
-
-
+template <class CI>
+CalibrationCategory<CI>::~CalibrationCategory() {}
 
 #endif

--- a/RecoBTag/XMLCalibration/interface/CalibrationInterface.h
+++ b/RecoBTag/XMLCalibration/interface/CalibrationInterface.h
@@ -8,115 +8,96 @@
 /**
 
 */
-template <class CategoryT,class CalibDataT> class CalibrationInterface
-{
-  public:
+template <class CategoryT, class CalibDataT>
+class CalibrationInterface {
+public:
+  CalibrationInterface();
+  ~CalibrationInterface();
 
-    CalibrationInterface();
-    ~CalibrationInterface();
-    
-    const CalibDataT* getCalibData(const typename CategoryT::Input & calibrationInput) const 
-     {
-      return(getCalibData(getIndex(calibrationInput)));
-     }
+  const CalibDataT* getCalibData(const typename CategoryT::Input& calibrationInput) const {
+    return (getCalibData(getIndex(calibrationInput)));
+  }
 
-    CalibDataT* getCalibData(const typename CategoryT::Input & calibrationInput) 
-     {
-      return(getCalibData(getIndex(calibrationInput)));
-     }
+  CalibDataT* getCalibData(const typename CategoryT::Input& calibrationInput) {
+    return (getCalibData(getIndex(calibrationInput)));
+  }
 
-    const CalibDataT* getCalibData(int index) const ; 
-    CalibDataT* getCalibData(int index);
+  const CalibDataT* getCalibData(int index) const;
+  CalibDataT* getCalibData(int index);
 
-    const CategoryT* getCategoryDefinition(int index) const ;
+  const CategoryT* getCategoryDefinition(int index) const;
 
-    int getIndex(const typename CategoryT::Input & calibrationInput) const ; 
-    
-  
-    int addCategoryDefinition(const CategoryT & categoryDefinition);
-    int addEntry(const CategoryT & categoryDefinition,const CalibDataT & data);
-    
-    void setCalibData(int index,const CalibDataT & data); 
-   
-    const std::vector<std::pair<CategoryT, CalibDataT> > & categoriesWithData() const  {return m_categoriesWithData; }
-    int size() const {return m_categoriesWithData.size(); }
+  int getIndex(const typename CategoryT::Input& calibrationInput) const;
 
-  private:
-    std::vector<std::pair<CategoryT, CalibDataT> > m_categoriesWithData;
+  int addCategoryDefinition(const CategoryT& categoryDefinition);
+  int addEntry(const CategoryT& categoryDefinition, const CalibDataT& data);
+
+  void setCalibData(int index, const CalibDataT& data);
+
+  const std::vector<std::pair<CategoryT, CalibDataT> >& categoriesWithData() const { return m_categoriesWithData; }
+  int size() const { return m_categoriesWithData.size(); }
+
+private:
+  std::vector<std::pair<CategoryT, CalibDataT> > m_categoriesWithData;
 };
 
+template <class CategoryT, class CalibDataT>
+CalibrationInterface<CategoryT, CalibDataT>::CalibrationInterface() {}
 
-template <class CategoryT,class CalibDataT> 
-CalibrationInterface<CategoryT,CalibDataT>::CalibrationInterface() 
-{
-}
+template <class CategoryT, class CalibDataT>
+CalibrationInterface<CategoryT, CalibDataT>::~CalibrationInterface() {}
 
-template <class CategoryT,class CalibDataT> 
-CalibrationInterface<CategoryT,CalibDataT>::~CalibrationInterface()
-{
-}
-    
-template <class CategoryT,class CalibDataT> 
-int  CalibrationInterface<CategoryT,CalibDataT>::getIndex(const typename CategoryT::Input & calibrationInput) const
-{
-   int i=0;
-   int found=-1;
-   for(typename std::vector<std::pair<CategoryT,CalibDataT> >::const_iterator it = m_categoriesWithData.begin();it!=m_categoriesWithData.end();it++)
-   {
-    
-      if((*it).first.match(calibrationInput))
-      {
-        if(found >=0 ) 
-          {
-           edm::LogWarning("BTagCalibration") << "WARNING: OVERLAP in categories, using latest one" ;
-          }
-        
-        found=i;
+template <class CategoryT, class CalibDataT>
+int CalibrationInterface<CategoryT, CalibDataT>::getIndex(const typename CategoryT::Input& calibrationInput) const {
+  int i = 0;
+  int found = -1;
+  for (typename std::vector<std::pair<CategoryT, CalibDataT> >::const_iterator it = m_categoriesWithData.begin();
+       it != m_categoriesWithData.end();
+       it++) {
+    if ((*it).first.match(calibrationInput)) {
+      if (found >= 0) {
+        edm::LogWarning("BTagCalibration") << "WARNING: OVERLAP in categories, using latest one";
       }
-   i++;
+
+      found = i;
+    }
+    i++;
   }
   return found;
 }
-template <class CategoryT,class CalibDataT>
-const CalibDataT * CalibrationInterface<CategoryT,CalibDataT>::getCalibData(int i) const
-{
- size_t ii=i;
- if(i>=0 && ii < m_categoriesWithData.size() )
-  return &m_categoriesWithData[i].second;
- else
-  return 0;
+template <class CategoryT, class CalibDataT>
+const CalibDataT* CalibrationInterface<CategoryT, CalibDataT>::getCalibData(int i) const {
+  size_t ii = i;
+  if (i >= 0 && ii < m_categoriesWithData.size())
+    return &m_categoriesWithData[i].second;
+  else
+    return 0;
 }
 
-
-template <class CategoryT,class CalibDataT> 
-CalibDataT * CalibrationInterface<CategoryT,CalibDataT>::getCalibData(int i) 
-{
- size_t ii=i;
- if(i>=0 && ii < m_categoriesWithData.size() )
-  return &m_categoriesWithData[i].second;
- else
-  return 0;
+template <class CategoryT, class CalibDataT>
+CalibDataT* CalibrationInterface<CategoryT, CalibDataT>::getCalibData(int i) {
+  size_t ii = i;
+  if (i >= 0 && ii < m_categoriesWithData.size())
+    return &m_categoriesWithData[i].second;
+  else
+    return 0;
 }
 
-template <class CategoryT,class CalibDataT>
-int CalibrationInterface<CategoryT,CalibDataT>::addCategoryDefinition(const CategoryT & categoryDefinition) 
-{
- CalibDataT emptyData;
- return addEntry(categoryDefinition,emptyData);
+template <class CategoryT, class CalibDataT>
+int CalibrationInterface<CategoryT, CalibDataT>::addCategoryDefinition(const CategoryT& categoryDefinition) {
+  CalibDataT emptyData;
+  return addEntry(categoryDefinition, emptyData);
 }
 
-template <class CategoryT,class CalibDataT>
-int CalibrationInterface<CategoryT,CalibDataT>::addEntry(const CategoryT & categoryDefinition,const CalibDataT & data)
-{
- std::pair<CategoryT,CalibDataT> newEntry(categoryDefinition,data);
- m_categoriesWithData.push_back(newEntry);
- return  m_categoriesWithData.size();
+template <class CategoryT, class CalibDataT>
+int CalibrationInterface<CategoryT, CalibDataT>::addEntry(const CategoryT& categoryDefinition, const CalibDataT& data) {
+  std::pair<CategoryT, CalibDataT> newEntry(categoryDefinition, data);
+  m_categoriesWithData.push_back(newEntry);
+  return m_categoriesWithData.size();
 }
 
-
-template <class CategoryT,class CalibDataT>
-void CalibrationInterface<CategoryT,CalibDataT>::setCalibData(int index,const CalibDataT & data)
-{
- m_categoriesWithData[index].second=data;
+template <class CategoryT, class CalibDataT>
+void CalibrationInterface<CategoryT, CalibDataT>::setCalibData(int index, const CalibDataT& data) {
+  m_categoriesWithData[index].second = data;
 }
 #endif

--- a/RecoBTag/XMLCalibration/interface/CalibrationXML.h
+++ b/RecoBTag/XMLCalibration/interface/CalibrationXML.h
@@ -1,5 +1,5 @@
-#ifndef CALIBRATIONXML_H 
-#define CALIBRATIONXML_H 
+#ifndef CALIBRATIONXML_H
+#define CALIBRATIONXML_H
 
 #include <xercesc/util/XMLString.hpp>
 #include <xercesc/dom/DOM.hpp>
@@ -10,85 +10,81 @@
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include "FWCore/Concurrency/interface/Xerces.h"
 
-class CalibrationXML  
-{
+class CalibrationXML {
 public:
-	typedef XERCES_CPP_NAMESPACE::DOMDocument DOMDocument;
-	typedef XERCES_CPP_NAMESPACE::DOMElement DOMElement;
-	typedef XERCES_CPP_NAMESPACE::DOMNode DOMNode;
-	typedef XERCES_CPP_NAMESPACE::HandlerBase HandlerBase;
-	typedef XERCES_CPP_NAMESPACE::XercesDOMParser XercesDOMParser;
-	typedef XERCES_CPP_NAMESPACE::XMLPlatformUtils XMLPlatformUtils;
-	typedef XERCES_CPP_NAMESPACE::XMLString XMLString;
+  typedef XERCES_CPP_NAMESPACE::DOMDocument DOMDocument;
+  typedef XERCES_CPP_NAMESPACE::DOMElement DOMElement;
+  typedef XERCES_CPP_NAMESPACE::DOMNode DOMNode;
+  typedef XERCES_CPP_NAMESPACE::HandlerBase HandlerBase;
+  typedef XERCES_CPP_NAMESPACE::XercesDOMParser XercesDOMParser;
+  typedef XERCES_CPP_NAMESPACE::XMLPlatformUtils XMLPlatformUtils;
+  typedef XERCES_CPP_NAMESPACE::XMLString XMLString;
 
-	CalibrationXML();
-	~CalibrationXML();
-	
-	/**
+  CalibrationXML();
+  ~CalibrationXML();
+
+  /**
 	* Open an XML file
-	*/	
-	void openFile(const std::string & xmlFileName);
+	*/
+  void openFile(const std::string &xmlFileName);
 
-	/**
+  /**
 	* Save DOM to file
-	*/	
-	void saveFile(const std::string & xmlFileName);
+	*/
+  void saveFile(const std::string &xmlFileName);
 
-
-        void closeFile() 
-        {
-          delete errHandler;
-          delete parser; cms::concurrency::xercesTerminate();
-          errHandler=nullptr;
-          parser=nullptr;
-        } 	
-	/**
+  void closeFile() {
+    delete errHandler;
+    delete parser;
+    cms::concurrency::xercesTerminate();
+    errHandler = nullptr;
+    parser = nullptr;
+  }
+  /**
 	* Return the root DOM Element of the opened XML calibration file
 	*/
-	DOMElement * calibrationDOM() { return m_calibrationDOM;}
+  DOMElement *calibrationDOM() { return m_calibrationDOM; }
 
-
-//Static function to make everything easier, less transcode and type conversion
-	/**
+  //Static function to make everything easier, less transcode and type conversion
+  /**
 	* Helper static function to write an attribute in a DOM Element
 	*/
-           template <class T> static void writeAttribute(DOMElement *dom, const std::string & name, const T & value)
-        {
-            std::ostringstream buffer;
-            buffer << value;
-            XMLCh * nameStr = XMLString::transcode(name.c_str());
-            XMLCh * valueStr = XMLString::transcode(buffer.str().c_str());
-            dom->setAttribute(nameStr, valueStr );
-            XMLString::release(&nameStr);
-            XMLString::release(&valueStr);
-        }
+  template <class T>
+  static void writeAttribute(DOMElement *dom, const std::string &name, const T &value) {
+    std::ostringstream buffer;
+    buffer << value;
+    XMLCh *nameStr = XMLString::transcode(name.c_str());
+    XMLCh *valueStr = XMLString::transcode(buffer.str().c_str());
+    dom->setAttribute(nameStr, valueStr);
+    XMLString::release(&nameStr);
+    XMLString::release(&valueStr);
+  }
 
-        /**
+  /**
         * Helper static function to read an attribute in a DOM Element
         */
-        template <class T> static T readAttribute(DOMElement *dom, const std::string & name)
-        {
-            XMLCh* nameStr  = XMLString::transcode(name.c_str());
-            char * valueStr = XMLString::transcode(dom->getAttribute(nameStr));
-            std::istringstream buffer(valueStr);
-            T value;
-            buffer >> value;
-            XMLString::release(&nameStr);
-            XMLString::release(&valueStr);
-            return value;
-        }
-	
-	/**
+  template <class T>
+  static T readAttribute(DOMElement *dom, const std::string &name) {
+    XMLCh *nameStr = XMLString::transcode(name.c_str());
+    char *valueStr = XMLString::transcode(dom->getAttribute(nameStr));
+    std::istringstream buffer(valueStr);
+    T value;
+    buffer >> value;
+    XMLString::release(&nameStr);
+    XMLString::release(&valueStr);
+    return value;
+  }
+
+  /**
 	* Helper static function to add a child in a DOM Element with indentation
 	*/
-        static DOMElement * addChild(DOMNode *dom,const std::string & name);
-		
+  static DOMElement *addChild(DOMNode *dom, const std::string &name);
+
 private:
-	std::string m_xmlFileName;
-	DOMElement * m_calibrationDOM;
-	DOMDocument* doc;
-	HandlerBase* errHandler;
-	XercesDOMParser *parser;
+  std::string m_xmlFileName;
+  DOMElement *m_calibrationDOM;
+  DOMDocument *doc;
+  HandlerBase *errHandler;
+  XercesDOMParser *parser;
 };
 #endif
-

--- a/RecoBTag/XMLCalibration/src/CalibratedHistogramXML.cc
+++ b/RecoBTag/XMLCalibration/src/CalibratedHistogramXML.cc
@@ -3,46 +3,39 @@
 #include <iostream>
 
 using namespace std;
-void  CalibratedHistogramXML::read (XERCES_CPP_NAMESPACE::DOMElement * dom)
-  {
-    binValues.clear();
-    binULimits.clear();
-    int size=  CalibrationXML::readAttribute<int>(dom,"size");
-    
-    DOMNode * n1 = dom->getFirstChild();
-    int bin;
-    for(bin=0; bin < size; bin ++)
-    {
-        while( ( n1->getNodeType() != DOMNode::ELEMENT_NODE ) && ( n1 != nullptr ) )   n1 = n1->getNextSibling();
-          if (n1)
-	  {
-	      DOMElement * binElement = (DOMElement *) n1;
-              binValues.push_back(CalibrationXML::readAttribute<double>(binElement,"value"));
-	
-              binULimits.push_back(CalibrationXML::readAttribute<double>(binElement,"uLimit"));      
-	       n1 = n1->getNextSibling();
-	  }             
+void CalibratedHistogramXML::read(XERCES_CPP_NAMESPACE::DOMElement *dom) {
+  binValues.clear();
+  binULimits.clear();
+  int size = CalibrationXML::readAttribute<int>(dom, "size");
+
+  DOMNode *n1 = dom->getFirstChild();
+  int bin;
+  for (bin = 0; bin < size; bin++) {
+    while ((n1->getNodeType() != DOMNode::ELEMENT_NODE) && (n1 != nullptr))
+      n1 = n1->getNextSibling();
+    if (n1) {
+      DOMElement *binElement = (DOMElement *)n1;
+      binValues.push_back(CalibrationXML::readAttribute<double>(binElement, "value"));
+
+      binULimits.push_back(CalibrationXML::readAttribute<double>(binElement, "uLimit"));
+      n1 = n1->getNextSibling();
     }
-    if(bin>0)
-      binValues.push_back(CalibrationXML::readAttribute<int>(dom,"overFlowValue"));
-
-    limits = Range(binULimits.front(), binULimits.back());
-    totalValid = false;
   }
-  
-void  CalibratedHistogramXML::write (XERCES_CPP_NAMESPACE::DOMElement * dom) const
-  {
+  if (bin > 0)
+    binValues.push_back(CalibrationXML::readAttribute<int>(dom, "overFlowValue"));
 
-    int size=binULimits.size();
-    CalibrationXML::writeAttribute(dom,"size",size);
-    DOMElement * binElement;
-    for(int bin=0; bin < size; bin ++)
-    {
-       binElement = CalibrationXML::addChild(dom,"Bin");
-       CalibrationXML::writeAttribute(binElement,"value",binValues[bin]);
-       CalibrationXML::writeAttribute(binElement,"uLimit",binULimits[bin]);
-    }
-    CalibrationXML::writeAttribute(dom,"overFlowValue",binValues[size]);
+  limits = Range(binULimits.front(), binULimits.back());
+  totalValid = false;
+}
 
+void CalibratedHistogramXML::write(XERCES_CPP_NAMESPACE::DOMElement *dom) const {
+  int size = binULimits.size();
+  CalibrationXML::writeAttribute(dom, "size", size);
+  DOMElement *binElement;
+  for (int bin = 0; bin < size; bin++) {
+    binElement = CalibrationXML::addChild(dom, "Bin");
+    CalibrationXML::writeAttribute(binElement, "value", binValues[bin]);
+    CalibrationXML::writeAttribute(binElement, "uLimit", binULimits[bin]);
   }
-
+  CalibrationXML::writeAttribute(dom, "overFlowValue", binValues[size]);
+}

--- a/RecoBTag/XMLCalibration/test/XMLCalibrationTest.cc
+++ b/RecoBTag/XMLCalibration/test/XMLCalibrationTest.cc
@@ -18,91 +18,71 @@
 #include "RecoBTag/XMLCalibration/interface/CalibrationCategory.h"
 
 #include <iostream>
- using namespace std;
+using namespace std;
 class TestCategory;
 
 ///This is an example of how to use the AlgorithmCalibration stuff
 // to read the calibrated objects from a .xml file
 
-
-
 class XMLCalibrationTest : public edm::EDAnalyzer {
-   public:
-      explicit XMLCalibrationTest( const edm::ParameterSet& );
-      ~XMLCalibrationTest();
+public:
+  explicit XMLCalibrationTest(const edm::ParameterSet&);
+  ~XMLCalibrationTest();
 
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-      virtual void analyze( const edm::Event&, const edm::EventSetup& );
-   private:
-      // ----------member data ---------------------------
-    AlgorithmCalibration<TestCategory,CalibratedHistogramXML> * m_calib;
+private:
+  // ----------member data ---------------------------
+  AlgorithmCalibration<TestCategory, CalibratedHistogramXML>* m_calib;
 };
 
-
-//This class define calibration  "category" in this example 
+//This class define calibration  "category" in this example
 //the category is simply a range of float: i.e. the category match if
 //the calibrationInput (which is a float in that case) is min<= input < max
 //In the example .xml files I put two categories one with range 0..2.5 the other with
-// rang 2.5...5  
-class TestCategory : public CalibrationCategory<float>
-{
+// rang 2.5...5
+class TestCategory : public CalibrationCategory<float> {
 public:
-     bool match(const float & input) const // const reference  for float is stupid but input object 
-                                            // are not always  floats
-     {
-      return (input < m_max) && (input >= m_min);
-     }
-     std::string name()  {return "TestCategory";}
+  bool match(const float& input) const  // const reference  for float is stupid but input object
+                                        // are not always  floats
+  {
+    return (input < m_max) && (input >= m_min);
+  }
+  std::string name() { return "TestCategory"; }
 
-     void readFromDOM(DOMElement * dom)
-    {
-      m_min = CalibrationXML::readAttribute<float>(dom,"min");
-      m_max = CalibrationXML::readAttribute<float>(dom,"max");
-    }
+  void readFromDOM(DOMElement* dom) {
+    m_min = CalibrationXML::readAttribute<float>(dom, "min");
+    m_max = CalibrationXML::readAttribute<float>(dom, "max");
+  }
 
-     void saveToDOM(DOMElement * dom)
-    {
-      CalibrationXML::writeAttribute(dom,"min",m_min);
-      CalibrationXML::writeAttribute(dom,"max",m_max);
-    }
+  void saveToDOM(DOMElement* dom) {
+    CalibrationXML::writeAttribute(dom, "min", m_min);
+    CalibrationXML::writeAttribute(dom, "max", m_max);
+  }
+
 protected:
-
-    float  m_min;
-    float  m_max;  
-
+  float m_min;
+  float m_max;
 };
 
-
-
-XMLCalibrationTest::XMLCalibrationTest( const edm::ParameterSet& iConfig )
-{
- m_calib =new AlgorithmCalibration<TestCategory,CalibratedHistogramXML>("test.xml");
+XMLCalibrationTest::XMLCalibrationTest(const edm::ParameterSet& iConfig) {
+  m_calib = new AlgorithmCalibration<TestCategory, CalibratedHistogramXML>("test.xml");
 }
 
+XMLCalibrationTest::~XMLCalibrationTest() { delete m_calib; }
 
-XMLCalibrationTest::~XMLCalibrationTest()
-{
- delete m_calib;
-}
+void XMLCalibrationTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  //ask the algorithm the calibrated object for an input value
+  // of 1.2
+  // this will search for the matching category and return the associated calibrated
+  // object.
 
+  const CalibratedHistogram* histo = m_calib->getCalibData((float)1.2);
 
-void
-XMLCalibrationTest::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
-   using namespace edm;
- //ask the algorithm the calibrated object for an input value
- // of 1.2
- // this will search for the matching category and return the associated calibrated
- // object.
-
-
- const CalibratedHistogram * histo = m_calib->getCalibData((float)1.2);
-
-
- std::cout << "Pointer of the histogram: " << histo << std::endl;
- std::cout << histo->value(2);
- std::cout << " " <<  histo->integral(2) << std::endl;
-
+  std::cout << "Pointer of the histogram: " << histo << std::endl;
+  std::cout << histo->value(2);
+  std::cout << " " << histo->integral(2) << std::endl;
 }
 
 DEFINE_FWK_MODULE(XMLCalibrationTest);

--- a/RecoHI/HiMuonAlgos/plugins/HIMuonTrackingRegionProducer.h
+++ b/RecoHI/HiMuonAlgos/plugins/HIMuonTrackingRegionProducer.h
@@ -1,4 +1,4 @@
-#ifndef RecoHI_HiTracking_HIMuonTrackingRegionProducer_H 
+#ifndef RecoHI_HiTracking_HIMuonTrackingRegionProducer_H
 #define RecoHI_HiTracking_HIMuonTrackingRegionProducer_H
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -16,28 +16,22 @@
 #include "FWCore/Framework/interface/Event.h"
 
 class HIMuonTrackingRegionProducer : public TrackingRegionProducer {
-  
- public:
-  
-  HIMuonTrackingRegionProducer(const edm::ParameterSet& cfg, edm::ConsumesCollector && iC) { 
-        
+public:
+  HIMuonTrackingRegionProducer(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC) {
     // get parameters from PSet
-    theMuonSource                         = cfg.getParameter<edm::InputTag>("MuonSrc");
-    theMuonSourceToken                    = iC.consumes<reco::TrackCollection>(theMuonSource);
-    
+    theMuonSource = cfg.getParameter<edm::InputTag>("MuonSrc");
+    theMuonSourceToken = iC.consumes<reco::TrackCollection>(theMuonSource);
+
     // initialize region builder
-    edm::ParameterSet regionBuilderPSet   = cfg.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
-    theRegionBuilder                      = new MuonTrackingRegionBuilder(regionBuilderPSet,iC);
+    edm::ParameterSet regionBuilderPSet = cfg.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
+    theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet, iC);
 
     // initialize muon service proxy
-    edm::ParameterSet servicePSet         = cfg.getParameter<edm::ParameterSet>("ServiceParameters");
-    theService                            = new MuonServiceProxy(servicePSet);
+    edm::ParameterSet servicePSet = cfg.getParameter<edm::ParameterSet>("ServiceParameters");
+    theService = new MuonServiceProxy(servicePSet);
+  }
 
-  }  
-  
-
-  ~HIMuonTrackingRegionProducer() override{}
-  
+  ~HIMuonTrackingRegionProducer() override {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -55,8 +49,8 @@ class HIMuonTrackingRegionProducer : public TrackingRegionProducer {
     descriptions.add("HiTrackingRegionEDProducer", desc);
   }
 
-  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& ev, const edm::EventSetup& es) const override {
-    
+  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event& ev,
+                                                        const edm::EventSetup& es) const override {
     // initialize output vector of tracking regions
     std::vector<std::unique_ptr<TrackingRegion> > result;
 
@@ -66,34 +60,30 @@ class HIMuonTrackingRegionProducer : public TrackingRegionProducer {
 
     // get stand-alone muon collection
     edm::Handle<reco::TrackCollection> muonH;
-    ev.getByToken(theMuonSourceToken ,muonH);
-    
+    ev.getByToken(theMuonSourceToken, muonH);
+
     // loop over all muons and add a tracking region for each
     // that passes the requirements specified to theRegionBuilder
     unsigned int nMuons = muonH->size();
     //std::cout << "there are " << nMuons << " muon(s)" << std::endl;
 
-    // TO DO: this can be extended further to a double-loop 
+    // TO DO: this can be extended further to a double-loop
     // over all combinations of muons, returning tracking regions
     // for pairs that pass some loose invariant mass cuts
-    for(unsigned int imu=0; imu<nMuons; imu++) {
+    for (unsigned int imu = 0; imu < nMuons; imu++) {
       reco::TrackRef muRef(muonH, imu);
       //std::cout << "muon #" << imu << ": pt=" << muRef->pt() << std::endl;
       result.push_back(theRegionBuilder->region(muRef));
     }
 
     return result;
-
   }
-  
-  
- private:
-  
+
+private:
   edm::InputTag theMuonSource;
   edm::EDGetTokenT<reco::TrackCollection> theMuonSourceToken;
   MuonTrackingRegionBuilder* theRegionBuilder;
   MuonServiceProxy* theService;
-  
 };
 
-#endif 
+#endif

--- a/RecoLocalCalo/Castor/src/CastorCellProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorCellProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    Castor
 // Class:      CastorCellProducer
-// 
+//
 
 /**\class CastorCellProducer CastorCellProducer.cc RecoLocalCalo/Castor/src/CastorCellProducer.cc
 
@@ -16,15 +16,14 @@
 //
 //
 
-
-// system include 
+// system include
 #include <memory>
 #include <vector>
 #include <iostream>
 #include <TMath.h>
 #include <TRandom3.h>
 
-// user include 
+// user include
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -42,27 +41,27 @@
 //
 
 class CastorCellProducer : public edm::EDProducer {
-   public:
-      explicit CastorCellProducer(const edm::ParameterSet&);
-      ~CastorCellProducer() override;
+public:
+  explicit CastorCellProducer(const edm::ParameterSet&);
+  ~CastorCellProducer() override;
 
-   private:
-      void beginJob() override ;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endJob() override ;
-      
-      // member data
-      typedef math::XYZPointD Point;
-      typedef ROOT::Math::RhoZPhiPoint CellPoint;
-      typedef std::vector<reco::CastorCell> CastorCellCollection;
-      edm::EDGetTokenT<CastorRecHitCollection> tok_input_;
+private:
+  void beginJob() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  // member data
+  typedef math::XYZPointD Point;
+  typedef ROOT::Math::RhoZPhiPoint CellPoint;
+  typedef std::vector<reco::CastorCell> CastorCellCollection;
+  edm::EDGetTokenT<CastorRecHitCollection> tok_input_;
 };
 
 //
 // constants, enums and typedefs
 //
 
-const double MYR2D = 180/M_PI;
+const double MYR2D = 180 / M_PI;
 
 //
 // static data member definitions
@@ -72,21 +71,18 @@ const double MYR2D = 180/M_PI;
 // constructor and destructor
 //
 
-CastorCellProducer::CastorCellProducer(const edm::ParameterSet& iConfig) 
-{
-  tok_input_ = consumes<CastorRecHitCollection>(edm::InputTag(iConfig.getUntrackedParameter<std::string>("inputprocess","castorreco")));
+CastorCellProducer::CastorCellProducer(const edm::ParameterSet& iConfig) {
+  tok_input_ = consumes<CastorRecHitCollection>(
+      edm::InputTag(iConfig.getUntrackedParameter<std::string>("inputprocess", "castorreco")));
   // register your products
   produces<CastorCellCollection>();
   // now do what ever other initialization is needed
 }
 
-
-CastorCellProducer::~CastorCellProducer()
-{
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+CastorCellProducer::~CastorCellProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
@@ -95,97 +91,90 @@ CastorCellProducer::~CastorCellProducer()
 // ------------ method called to produce the data  ------------
 
 void CastorCellProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   using namespace edm;
   using namespace reco;
   using namespace TMath;
-  
+
   // Produce CastorCells from CastorRecHits
 
   edm::Handle<CastorRecHitCollection> InputRecHits;
   iEvent.getByToken(tok_input_, InputRecHits);
-    
+
   auto OutputCells = std::make_unique<CastorCellCollection>();
-   
+
   // looping over all CastorRecHits
 
-  LogDebug("CastorCellProducer")
-    <<"1. entering CastorCellProducer ";
+  LogDebug("CastorCellProducer") << "1. entering CastorCellProducer ";
 
   for (size_t i = 0; i < InputRecHits->size(); ++i) {
-    const CastorRecHit & rh = (*InputRecHits)[i];
+    const CastorRecHit& rh = (*InputRecHits)[i];
     int sector = rh.id().sector();
     int module = rh.id().module();
     double energy = rh.energy();
     int zside = rh.id().zside();
-    
+
     // define CastorCell properties
-    double zCell=0.;
+    double zCell = 0.;
     double phiCell;
     double rhoCell;
-      
+
     // set z position of the cell
     if (module < 3) {
       // starting in EM section
-      if (module == 1) zCell = 14415;
-      if (module == 2) zCell = 14464; 
+      if (module == 1)
+        zCell = 14415;
+      if (module == 2)
+        zCell = 14464;
     } else {
       // starting in HAD section
-      zCell = 14534 + (module - 3)*92;
+      zCell = 14534 + (module - 3) * 92;
     }
-      
+
     // set phi position of the cell
     double castorphi[16];
     for (int j = 0; j < 16; j++) {
-      castorphi[j] = -2.94524 + j*0.3927;
+      castorphi[j] = -2.94524 + j * 0.3927;
     }
     if (sector > 8) {
       phiCell = castorphi[sector - 9];
     } else {
       phiCell = castorphi[sector + 7];
     }
-      
+
     // add condition to select in eta sides
-    if (zside <= 0) zCell = -1*zCell;
-      
+    if (zside <= 0)
+      zCell = -1 * zCell;
+
     // set rho position of the cell (inner radius 3.7cm, outer radius 14cm)
     rhoCell = 88.5;
-    
+
     // store cell position
-    CellPoint tempcellposition(rhoCell,zCell,phiCell);
+    CellPoint tempcellposition(rhoCell, zCell, phiCell);
     Point cellposition(tempcellposition);
-    
-    LogDebug("CastorCellProducer")
-      <<"cell number: "<<i+1<<std::endl
-      <<"rho: "<<cellposition.rho()<<" phi: "<<cellposition.phi()*MYR2D<<" eta: "<<cellposition.eta()<<std::endl
-      <<"x: "<<cellposition.x()<<" y: "<<cellposition.y()<<" z: "<<cellposition.z();
-    
+
+    LogDebug("CastorCellProducer") << "cell number: " << i + 1 << std::endl
+                                   << "rho: " << cellposition.rho() << " phi: " << cellposition.phi() * MYR2D
+                                   << " eta: " << cellposition.eta() << std::endl
+                                   << "x: " << cellposition.x() << " y: " << cellposition.y()
+                                   << " z: " << cellposition.z();
+
     if (energy > 0.) {
-      CastorCell newCell(energy,cellposition);
+      CastorCell newCell(energy, cellposition);
       OutputCells->push_back(newCell);
     }
-      
-  } // end loop over CastorRecHits 
-    
-  LogDebug("CastorCellProducer")
-    <<"total number of cells in the event: "<<InputRecHits->size();
+
+  }  // end loop over CastorRecHits
+
+  LogDebug("CastorCellProducer") << "total number of cells in the event: " << InputRecHits->size();
 
   iEvent.put(std::move(OutputCells));
-
-
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void CastorCellProducer::beginJob() {
-  LogDebug("CastorCellProducer")
-    <<"Starting CastorCellProducer";
-}
+void CastorCellProducer::beginJob() { LogDebug("CastorCellProducer") << "Starting CastorCellProducer"; }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void CastorCellProducer::endJob() {
-  LogDebug("CastorCellProducer")
-    <<"Ending CastorCellProducer";
-}
+void CastorCellProducer::endJob() { LogDebug("CastorCellProducer") << "Ending CastorCellProducer"; }
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(CastorCellProducer);

--- a/RecoLocalCalo/Castor/src/CastorClusterProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorClusterProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    Castor
 // Class:      CastorClusterProducer
-// 
+//
 /**\class CastorClusterProducer CastorClusterProducer.cc RecoLocalCalo/Castor/src/CastorClusterProducer.cc
 
  Description: CastorCluster Reconstruction Producer. Produces Clusters from Towers
@@ -15,14 +15,14 @@
 //
 //
 
-// system include 
+// system include
 #include <memory>
 #include <vector>
 #include <iostream>
 #include <TMath.h>
 #include <TRandom3.h>
 
-// user include 
+// user include
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -41,40 +41,37 @@
 #include "DataFormats/JetReco/interface/BasicJetCollection.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 
-
-
 //
 // class decleration
 //
 
 class CastorClusterProducer : public edm::EDProducer {
-   public:
-      explicit CastorClusterProducer(const edm::ParameterSet&);
-      ~CastorClusterProducer() override;
+public:
+  explicit CastorClusterProducer(const edm::ParameterSet&);
+  ~CastorClusterProducer() override;
 
-   private:
-      void beginJob() override ;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      double phiangle (double testphi);
-      void endJob() override ;
-      
-      // ----------member data ---------------------------
-      typedef math::XYZPointD Point;
-      typedef ROOT::Math::RhoEtaPhiPoint TowerPoint;
-      typedef ROOT::Math::RhoZPhiPoint CellPoint;
-      typedef std::vector<reco::CastorTower> CastorTowerCollection;
-      typedef std::vector<reco::CastorCluster> CastorClusterCollection;
-      std::string input_, basicjets_;
-      edm::EDGetTokenT<CastorTowerCollection> tok_input_;
-      edm::EDGetTokenT<reco::BasicJetCollection> tok_jets_;
-    edm::EDGetTokenT<CastorTowerCollection> tok_tower_;
-      bool clusteralgo_;
+private:
+  void beginJob() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  double phiangle(double testphi);
+  void endJob() override;
+
+  // ----------member data ---------------------------
+  typedef math::XYZPointD Point;
+  typedef ROOT::Math::RhoEtaPhiPoint TowerPoint;
+  typedef ROOT::Math::RhoZPhiPoint CellPoint;
+  typedef std::vector<reco::CastorTower> CastorTowerCollection;
+  typedef std::vector<reco::CastorCluster> CastorClusterCollection;
+  std::string input_, basicjets_;
+  edm::EDGetTokenT<CastorTowerCollection> tok_input_;
+  edm::EDGetTokenT<reco::BasicJetCollection> tok_jets_;
+  edm::EDGetTokenT<CastorTowerCollection> tok_tower_;
+  bool clusteralgo_;
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -84,27 +81,23 @@ class CastorClusterProducer : public edm::EDProducer {
 // constructor and destructor
 //
 
-CastorClusterProducer::CastorClusterProducer(const edm::ParameterSet& iConfig) :
-  input_(iConfig.getUntrackedParameter<std::string>("inputtowers","")),
-  basicjets_(iConfig.getUntrackedParameter<std::string>("basicjets","")),
-  clusteralgo_(iConfig.getUntrackedParameter<bool>("ClusterAlgo",false))
-{
+CastorClusterProducer::CastorClusterProducer(const edm::ParameterSet& iConfig)
+    : input_(iConfig.getUntrackedParameter<std::string>("inputtowers", "")),
+      basicjets_(iConfig.getUntrackedParameter<std::string>("basicjets", "")),
+      clusteralgo_(iConfig.getUntrackedParameter<bool>("ClusterAlgo", false)) {
   // register for data access
   tok_input_ = consumes<CastorTowerCollection>(edm::InputTag(input_));
   tok_jets_ = consumes<reco::BasicJetCollection>(edm::InputTag(basicjets_));
-    tok_tower_ = consumes<CastorTowerCollection>(edm::InputTag("CastorTowerReco"));
+  tok_tower_ = consumes<CastorTowerCollection>(edm::InputTag("CastorTowerReco"));
   // register your products
   produces<CastorClusterCollection>();
   // now do what ever other initialization is needed
 }
 
-
-CastorClusterProducer::~CastorClusterProducer()
-{
+CastorClusterProducer::~CastorClusterProducer() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
@@ -112,152 +105,154 @@ CastorClusterProducer::~CastorClusterProducer()
 
 // ------------ method called to produce the data  ------------
 void CastorClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  
   using namespace edm;
   using namespace reco;
   using namespace TMath;
-  
-  LogDebug("CastorClusterProducer")
-    <<"3. entering CastorClusterProducer";
-  
-  if ( !input_.empty()) {
-  
-  // Produce CastorClusters from CastorTowers
-  
-  edm::Handle<CastorTowerCollection> InputTowers;
-  iEvent.getByToken(tok_input_, InputTowers);
 
-  auto OutputClustersfromClusterAlgo = std::make_unique<CastorClusterCollection>();
-  
-  // get and check input size
-  int nTowers = InputTowers->size();
+  LogDebug("CastorClusterProducer") << "3. entering CastorClusterProducer";
 
-  if (nTowers==0) LogDebug("CastorClusterProducer")<<"Warning: You are trying to run the Cluster algorithm with 0 input towers.";
+  if (!input_.empty()) {
+    // Produce CastorClusters from CastorTowers
 
-  CastorTowerRefVector posInputTowers, negInputTowers;
+    edm::Handle<CastorTowerCollection> InputTowers;
+    iEvent.getByToken(tok_input_, InputTowers);
 
-  for (size_t i = 0; i < InputTowers->size(); ++i) {
-    reco::CastorTowerRef tower_p = reco::CastorTowerRef(InputTowers, i);
-    if (tower_p->eta() > 0.) posInputTowers.push_back(tower_p);
-    if (tower_p->eta() < 0.) negInputTowers.push_back(tower_p);
+    auto OutputClustersfromClusterAlgo = std::make_unique<CastorClusterCollection>();
+
+    // get and check input size
+    int nTowers = InputTowers->size();
+
+    if (nTowers == 0)
+      LogDebug("CastorClusterProducer") << "Warning: You are trying to run the Cluster algorithm with 0 input towers.";
+
+    CastorTowerRefVector posInputTowers, negInputTowers;
+
+    for (size_t i = 0; i < InputTowers->size(); ++i) {
+      reco::CastorTowerRef tower_p = reco::CastorTowerRef(InputTowers, i);
+      if (tower_p->eta() > 0.)
+        posInputTowers.push_back(tower_p);
+      if (tower_p->eta() < 0.)
+        negInputTowers.push_back(tower_p);
+    }
+
+    // build cluster from ClusterAlgo
+    if (clusteralgo_ == true) {
+      // code
+      iEvent.put(std::move(OutputClustersfromClusterAlgo));
+    }
   }
-    
-  // build cluster from ClusterAlgo
-  if (clusteralgo_ == true) {
-    // code
-    iEvent.put(std::move(OutputClustersfromClusterAlgo));
+
+  if (!basicjets_.empty()) {
+    Handle<BasicJetCollection> bjCollection;
+    iEvent.getByToken(tok_jets_, bjCollection);
+
+    Handle<CastorTowerCollection> ctCollection;
+    iEvent.getByToken(tok_tower_, ctCollection);
+
+    auto OutputClustersfromBasicJets = std::make_unique<CastorClusterCollection>();
+
+    if (bjCollection->empty())
+      LogDebug("CastorClusterProducer")
+          << "Warning: You are trying to run the Cluster algorithm with 0 input basicjets.";
+
+    for (unsigned i = 0; i < bjCollection->size(); i++) {
+      const BasicJet* bj = &(*bjCollection)[i];
+
+      double energy = bj->energy();
+      TowerPoint temp(88.5, bj->eta(), bj->phi());
+      Point position(temp);
+      double emEnergy = 0.;
+      double hadEnergy = 0.;
+      double width = 0.;
+      double depth = 0.;
+      double fhot = 0.;
+      double sigmaz = 0.;
+      CastorTowerRefVector usedTowers;
+      double zmean = 0.;
+      double z2mean = 0.;
+
+      std::vector<CandidatePtr> ccp = bj->getJetConstituents();
+      std::vector<CandidatePtr>::const_iterator itParticle;
+      for (itParticle = ccp.begin(); itParticle != ccp.end(); ++itParticle) {
+        const CastorTower* castorcand = dynamic_cast<const CastorTower*>(itParticle->get());
+        //cout << " castortowercandidate reference energy = " << castorcand->castorTower()->energy() << endl;
+        //cout << " castortowercandidate reference eta = " << castorcand->castorTower()->eta() << endl;
+        //cout << " castortowercandidate reference phi = " << castorcand->castorTower()->phi() << endl;
+        //cout << " castortowercandidate reference depth = " << castorcand->castorTower()->depth() << endl;
+
+        //CastorTowerCollection *ctc = new CastorTowerCollection();
+        //ctc->push_back(*castorcand);
+        //CastorTowerRef towerref = CastorTowerRef(ctc,0);
+
+        size_t thisone = 0;
+        for (size_t l = 0; l < ctCollection->size(); l++) {
+          const CastorTower ct = (*ctCollection)[l];
+          if (std::abs(ct.phi() - castorcand->phi()) < 0.0001) {
+            thisone = l;
+          }
+        }
+
+        CastorTowerRef towerref(ctCollection, thisone);
+        usedTowers.push_back(towerref);
+        emEnergy += castorcand->emEnergy();
+        hadEnergy += castorcand->hadEnergy();
+        depth += castorcand->depth() * castorcand->energy();
+        width += pow(phiangle(castorcand->phi() - bj->phi()), 2) * castorcand->energy();
+        fhot += castorcand->fhot() * castorcand->energy();
+
+        // loop over rechits
+        for (edm::RefVector<edm::SortedCollection<CastorRecHit> >::iterator it = castorcand->rechitsBegin();
+             it != castorcand->rechitsEnd();
+             it++) {
+          edm::Ref<edm::SortedCollection<CastorRecHit> > rechit_p = *it;
+          double Erechit = rechit_p->energy();
+          HcalCastorDetId id = rechit_p->id();
+          int module = id.module();
+          double zrechit = 0;
+          if (module < 3)
+            zrechit = -14390 - 24.75 - 49.5 * (module - 1);
+          if (module > 2)
+            zrechit = -14390 - 99 - 49.5 - 99 * (module - 3);
+          zmean += Erechit * zrechit;
+          z2mean += Erechit * zrechit * zrechit;
+        }  // end loop over rechits
+      }
+      //cout << "" << endl;
+
+      depth = depth / energy;
+      width = sqrt(width / energy);
+      fhot = fhot / energy;
+
+      zmean = zmean / energy;
+      z2mean = z2mean / energy;
+      double sigmaz2 = z2mean - zmean * zmean;
+      if (sigmaz2 > 0)
+        sigmaz = sqrt(sigmaz2);
+
+      CastorCluster cc(
+          energy, position, emEnergy, hadEnergy, emEnergy / energy, width, depth, fhot, sigmaz, usedTowers);
+      OutputClustersfromBasicJets->push_back(cc);
+    }
+
+    iEvent.put(std::move(OutputClustersfromBasicJets));
   }
-  
-  }
-  
-  if ( !basicjets_.empty()) {
-  
-  	Handle<BasicJetCollection> bjCollection;
-   	iEvent.getByToken(tok_jets_,bjCollection);
-	
-	Handle<CastorTowerCollection> ctCollection;
-	iEvent.getByToken(tok_tower_,ctCollection);
-	
-	auto OutputClustersfromBasicJets = std::make_unique<CastorClusterCollection>();
-	
-	if (bjCollection->empty()) LogDebug("CastorClusterProducer")<< "Warning: You are trying to run the Cluster algorithm with 0 input basicjets.";
-   
-   	for (unsigned i=0; i< bjCollection->size();i++) {
-   		const BasicJet* bj = &(*bjCollection)[i];
-		
-		double energy = bj->energy();
-		TowerPoint temp(88.5,bj->eta(),bj->phi());
-  		Point position(temp);
-		double emEnergy = 0.;
-		double hadEnergy = 0.;
-		double width = 0.;
-		double depth = 0.;
-		double fhot = 0.;
-		double sigmaz = 0.;
-		CastorTowerRefVector usedTowers;
-		double zmean = 0.;
-		double z2mean = 0.;
-	
-		std::vector<CandidatePtr> ccp = bj->getJetConstituents();
-		std::vector<CandidatePtr>::const_iterator itParticle;
-   		for (itParticle=ccp.begin();itParticle!=ccp.end();++itParticle){	    
-        		const CastorTower* castorcand = dynamic_cast<const CastorTower*>(itParticle->get());
-			//cout << " castortowercandidate reference energy = " << castorcand->castorTower()->energy() << endl;
-			//cout << " castortowercandidate reference eta = " << castorcand->castorTower()->eta() << endl;
-			//cout << " castortowercandidate reference phi = " << castorcand->castorTower()->phi() << endl;
-			//cout << " castortowercandidate reference depth = " << castorcand->castorTower()->depth() << endl;
-			
-			//CastorTowerCollection *ctc = new CastorTowerCollection();
-			//ctc->push_back(*castorcand);
-			//CastorTowerRef towerref = CastorTowerRef(ctc,0);
-			
-			size_t thisone = 0;
-			for (size_t l=0;l<ctCollection->size();l++) {
-				const CastorTower ct = (*ctCollection)[l];
-				if ( std::abs(ct.phi() - castorcand->phi()) < 0.0001 ) { thisone = l;}
-			}
-			
-			CastorTowerRef towerref(ctCollection,thisone); 
-			usedTowers.push_back(towerref);
-			emEnergy += castorcand->emEnergy();
-			hadEnergy += castorcand->hadEnergy();
-			depth += castorcand->depth()*castorcand->energy();
-			width += pow(phiangle(castorcand->phi() - bj->phi()),2)*castorcand->energy();
-      			fhot += castorcand->fhot()*castorcand->energy();
-			
-			// loop over rechits
-      			for (edm::RefVector<edm::SortedCollection<CastorRecHit> >::iterator it = castorcand->rechitsBegin(); it != castorcand->rechitsEnd(); it++) {
-	                         edm::Ref<edm::SortedCollection<CastorRecHit> > rechit_p = *it;	                        
-	                         double Erechit = rechit_p->energy();
-	                         HcalCastorDetId id = rechit_p->id();
-	                         int module = id.module();	                                
-                                 double zrechit = 0;	 
-                                 if (module < 3) zrechit = -14390 - 24.75 - 49.5*(module-1);	 
-                                 if (module > 2) zrechit = -14390 - 99 - 49.5 - 99*(module-3);	 
-                                 zmean += Erechit*zrechit;	 
-                                 z2mean += Erechit*zrechit*zrechit;
-      			} // end loop over rechits
-		}
-		//cout << "" << endl;
-		
-		depth = depth/energy;
-		width = sqrt(width/energy);
-		fhot = fhot/energy;
-		
-		zmean = zmean/energy;
-    		z2mean = z2mean/energy;
-    		double sigmaz2 = z2mean - zmean*zmean;
-    		if(sigmaz2 > 0) sigmaz = sqrt(sigmaz2);
-		
-		CastorCluster cc(energy,position,emEnergy,hadEnergy,emEnergy/energy,width,depth,fhot,sigmaz,usedTowers);
-		OutputClustersfromBasicJets->push_back(cc);
-   	}
-	
-	iEvent.put(std::move(OutputClustersfromBasicJets));
-  
-  }
- 
 }
 
 // help function to calculate phi within [-pi,+pi]
-double CastorClusterProducer::phiangle (double testphi) {
+double CastorClusterProducer::phiangle(double testphi) {
   double phi = testphi;
-  while (phi>M_PI) phi -= (2*M_PI);
-  while (phi<-M_PI) phi += (2*M_PI);
+  while (phi > M_PI)
+    phi -= (2 * M_PI);
+  while (phi < -M_PI)
+    phi += (2 * M_PI);
   return phi;
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void CastorClusterProducer::beginJob() {
-  LogDebug("CastorClusterProducer")
-    <<"Starting CastorClusterProducer";
-}
+void CastorClusterProducer::beginJob() { LogDebug("CastorClusterProducer") << "Starting CastorClusterProducer"; }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void CastorClusterProducer::endJob() {
-  LogDebug("CastorClusterProducer")
-    <<"Ending CastorClusterProducer";
-}
+void CastorClusterProducer::endJob() { LogDebug("CastorClusterProducer") << "Ending CastorClusterProducer"; }
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(CastorClusterProducer);

--- a/RecoLocalCalo/Castor/src/CastorClusterProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorClusterProducer.cc
@@ -120,7 +120,7 @@ void CastorClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   LogDebug("CastorClusterProducer")
     <<"3. entering CastorClusterProducer";
   
-  if ( input_ != "") {
+  if ( !input_.empty()) {
   
   // Produce CastorClusters from CastorTowers
   
@@ -150,7 +150,7 @@ void CastorClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   
   }
   
-  if ( basicjets_ != "") {
+  if ( !basicjets_.empty()) {
   
   	Handle<BasicJetCollection> bjCollection;
    	iEvent.getByToken(tok_jets_,bjCollection);

--- a/RecoLocalCalo/Castor/src/CastorInvalidDataFilter.cc
+++ b/RecoLocalCalo/Castor/src/CastorInvalidDataFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CastorInvalidDataFilter
 // Class:      CastorInvalidDataFilter
-// 
+//
 /**\class CastorInvalidDataFilter CastorInvalidDataFilter.cc RecoLocalCalo/CastorInvalidDataFilter/src/CastorInvalidDataFilter.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Thu Apr 21 11:36:52 CEST 2011
 //
 //
-
 
 // system include files
 #include <memory>
@@ -36,16 +35,16 @@
 //
 
 class CastorInvalidDataFilter : public edm::EDFilter {
-   public:
-      explicit CastorInvalidDataFilter(const edm::ParameterSet&);
-      ~CastorInvalidDataFilter() override;
+public:
+  explicit CastorInvalidDataFilter(const edm::ParameterSet&);
+  ~CastorInvalidDataFilter() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      bool filter(edm::Event&, const edm::EventSetup&) override;
-      
-   edm::EDGetTokenT<std::vector<edm::ErrorSummaryEntry> > tok_summary_;
+private:
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+
+  edm::EDGetTokenT<std::vector<edm::ErrorSummaryEntry> > tok_summary_;
 };
 
 //
@@ -59,57 +58,42 @@ class CastorInvalidDataFilter : public edm::EDFilter {
 //
 // constructors and destructor
 //
-CastorInvalidDataFilter::CastorInvalidDataFilter(const edm::ParameterSet& iConfig)
-{
-   //now do what ever initialization is needed
-   tok_summary_ = consumes<std::vector<edm::ErrorSummaryEntry> >(edm::InputTag("logErrorHarvester"));
-
+CastorInvalidDataFilter::CastorInvalidDataFilter(const edm::ParameterSet& iConfig) {
+  //now do what ever initialization is needed
+  tok_summary_ = consumes<std::vector<edm::ErrorSummaryEntry> >(edm::InputTag("logErrorHarvester"));
 }
 
-
-CastorInvalidDataFilter::~CastorInvalidDataFilter()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+CastorInvalidDataFilter::~CastorInvalidDataFilter() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool
-CastorInvalidDataFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   
-   edm::Handle<std::vector<ErrorSummaryEntry> > summary;
-   iEvent.getByToken(tok_summary_,summary);
+bool CastorInvalidDataFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   bool invalid = false;
-   //std::cout << " logError summary size = " << summary->size() << std::endl;
-   for (size_t i=0;i<summary->size();i++) {
-        ErrorSummaryEntry error = (*summary)[i];
-        //std::cout << " category = " << error.category << " module = " << error.module << " severity = "
-        //        << error.severity.getName() << " count = " << error.count << std::endl;
-	if (error.category == "Invalid Data" && error.module == "CastorRawToDigi:castorDigis") invalid = true;
+  edm::Handle<std::vector<ErrorSummaryEntry> > summary;
+  iEvent.getByToken(tok_summary_, summary);
 
-   }
+  bool invalid = false;
+  //std::cout << " logError summary size = " << summary->size() << std::endl;
+  for (size_t i = 0; i < summary->size(); i++) {
+    ErrorSummaryEntry error = (*summary)[i];
+    //std::cout << " category = " << error.category << " module = " << error.module << " severity = "
+    //        << error.severity.getName() << " count = " << error.count << std::endl;
+    if (error.category == "Invalid Data" && error.module == "CastorRawToDigi:castorDigis")
+      invalid = true;
+  }
 
-   return !invalid;
+  return !invalid;
 }
 
-
-
-
-
-
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-CastorInvalidDataFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void CastorInvalidDataFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/RecoLocalCalo/Castor/src/CastorTowerProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorTowerProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    Castor
 // Class:      CastorTowerProducer
-// 
+//
 
 /**\class CastorTowerProducer CastorTowerProducer.cc RecoLocalCalo/Castor/src/CastorTowerProducer.cc
 
@@ -16,15 +16,14 @@
 //
 //
 
-
-// system include 
+// system include
 #include <memory>
 #include <vector>
 #include <iostream>
 #include <TMath.h>
 #include <TRandom3.h>
 
-// user include 
+// user include
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -49,31 +48,32 @@
 //
 
 class CastorTowerProducer : public edm::stream::EDProducer<> {
-   public:
-      explicit CastorTowerProducer(const edm::ParameterSet&);
-      ~CastorTowerProducer() override;
+public:
+  explicit CastorTowerProducer(const edm::ParameterSet&);
+  ~CastorTowerProducer() override;
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void ComputeTowerVariable(const edm::RefVector<edm::SortedCollection<CastorRecHit> >& usedRecHits, double&  Ehot, double& depth);
-      
-      // member data
-      typedef math::XYZPointD Point;
-      typedef ROOT::Math::RhoEtaPhiPoint TowerPoint;
-      typedef ROOT::Math::RhoZPhiPoint CellPoint;
-      typedef edm::SortedCollection<CastorRecHit> CastorRecHitCollection; 
-      typedef std::vector<reco::CastorTower> CastorTowerCollection;
-      typedef edm::RefVector<CastorRecHitCollection> CastorRecHitRefVector;
-      edm::EDGetTokenT<CastorRecHitCollection> tok_input_;
-      double towercut_;
-      double mintime_;
-      double maxtime_;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void ComputeTowerVariable(const edm::RefVector<edm::SortedCollection<CastorRecHit> >& usedRecHits,
+                                    double& Ehot,
+                                    double& depth);
+
+  // member data
+  typedef math::XYZPointD Point;
+  typedef ROOT::Math::RhoEtaPhiPoint TowerPoint;
+  typedef ROOT::Math::RhoZPhiPoint CellPoint;
+  typedef edm::SortedCollection<CastorRecHit> CastorRecHitCollection;
+  typedef std::vector<reco::CastorTower> CastorTowerCollection;
+  typedef edm::RefVector<CastorRecHitCollection> CastorRecHitRefVector;
+  edm::EDGetTokenT<CastorRecHitCollection> tok_input_;
+  double towercut_;
+  double mintime_;
+  double maxtime_;
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -83,24 +83,20 @@ class CastorTowerProducer : public edm::stream::EDProducer<> {
 // constructor and destructor
 //
 
-CastorTowerProducer::CastorTowerProducer(const edm::ParameterSet& iConfig) :
-  towercut_(iConfig.getParameter<double>("towercut")),
-  mintime_(iConfig.getParameter<double>("mintime")),
-  maxtime_(iConfig.getParameter<double>("maxtime"))
-{
+CastorTowerProducer::CastorTowerProducer(const edm::ParameterSet& iConfig)
+    : towercut_(iConfig.getParameter<double>("towercut")),
+      mintime_(iConfig.getParameter<double>("mintime")),
+      maxtime_(iConfig.getParameter<double>("maxtime")) {
   tok_input_ = consumes<CastorRecHitCollection>(iConfig.getParameter<std::string>("inputprocess"));
   //register your products
   produces<CastorTowerCollection>();
   //now do what ever other initialization is needed
 }
 
-
-CastorTowerProducer::~CastorTowerProducer()
-{
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+CastorTowerProducer::~CastorTowerProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
@@ -108,31 +104,29 @@ CastorTowerProducer::~CastorTowerProducer()
 
 // ------------ method called to produce the data  ------------
 void CastorTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   using namespace edm;
   using namespace reco;
   using namespace TMath;
-  
+
   // Produce CastorTowers from CastorCells
-  
+
   edm::Handle<CastorRecHitCollection> InputRecHits;
-  iEvent.getByToken(tok_input_,InputRecHits);
+  iEvent.getByToken(tok_input_, InputRecHits);
 
   auto OutputTowers = std::make_unique<CastorTowerCollection>();
-   
+
   // get and check input size
   int nRecHits = InputRecHits->size();
 
-  LogDebug("CastorTowerProducer")
-    <<"2. entering CastorTowerProducer"<<std::endl;
+  LogDebug("CastorTowerProducer") << "2. entering CastorTowerProducer" << std::endl;
 
-  if (nRecHits==0)
-    LogDebug("CastorTowerProducer") <<"Warning: You are trying to run the Tower algorithm with 0 input rechits.";
-  
+  if (nRecHits == 0)
+    LogDebug("CastorTowerProducer") << "Warning: You are trying to run the Tower algorithm with 0 input rechits.";
+
   // declare castor array
   // (0,x): Energies - (1,x): emEnergies - (2,x): hadEnergies - (3,x): phi position
-  
-  double poscastortowerarray[4][16]; 
+
+  double poscastortowerarray[4][16];
   double negcastortowerarray[4][16];
 
   CastorRecHitRefVector poscastorusedrechits[16];
@@ -140,132 +134,153 @@ void CastorTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   // set phi values and everything else to zero
   for (int j = 0; j < 16; j++) {
-    poscastortowerarray[3][j] = -2.94524 + j*0.3927;
+    poscastortowerarray[3][j] = -2.94524 + j * 0.3927;
     poscastortowerarray[0][j] = 0.;
     poscastortowerarray[1][j] = 0.;
     poscastortowerarray[2][j] = 0.;
 
-    negcastortowerarray[3][j] = -2.94524 + j*0.3927;
+    negcastortowerarray[3][j] = -2.94524 + j * 0.3927;
     negcastortowerarray[0][j] = 0.;
     negcastortowerarray[1][j] = 0.;
     negcastortowerarray[2][j] = 0.;
   }
-  
+
   // retrieve the channel quality lists from database
   edm::ESHandle<CastorChannelQuality> p;
   iSetup.get<CastorChannelQualityRcd>().get(p);
   std::vector<DetId> channels = p->getAllChannels();
 
-  // loop over rechits to build castortowerarray[4][16] and castorusedrechits[16] 
+  // loop over rechits to build castortowerarray[4][16] and castorusedrechits[16]
   for (unsigned int i = 0; i < InputRecHits->size(); i++) {
-    
     edm::Ref<CastorRecHitCollection> rechit_p = edm::Ref<CastorRecHitCollection>(InputRecHits, i);
-    
+
     HcalCastorDetId id = rechit_p->id();
-    DetId genericID=(DetId)id;
-    
+    DetId genericID = (DetId)id;
+
     // first check if the rechit is in the BAD channel list
     bool bad = false;
-    for (std::vector<DetId>::iterator channel = channels.begin();channel !=  channels.end();channel++) {	
-    	if (channel->rawId() == genericID.rawId()) {
-		// if the rechit is found in the list, set it bad
-	  bad = true; break;
-    	}
+    for (std::vector<DetId>::iterator channel = channels.begin(); channel != channels.end(); channel++) {
+      if (channel->rawId() == genericID.rawId()) {
+        // if the rechit is found in the list, set it bad
+        bad = true;
+        break;
+      }
     }
     // if bad, continue the loop to the next rechit
-    if (bad) continue;
-    
+    if (bad)
+      continue;
+
     double Erechit = rechit_p->energy();
     int module = id.module();
     int sector = id.sector();
     double zrechit = 0;
-    if (module < 3) zrechit = -14390 - 24.75 - 49.5*(module-1);
-    if (module > 2) zrechit = -14390 - 99 - 49.5 - 99*(module-3); 
+    if (module < 3)
+      zrechit = -14390 - 24.75 - 49.5 * (module - 1);
+    if (module > 2)
+      zrechit = -14390 - 99 - 49.5 - 99 * (module - 3);
     double phirechit = -100;
-    if (sector < 9) phirechit = 0.19635 + (sector-1)*0.3927;
-    if (sector > 8) phirechit = -2.94524 + (sector - 9)*0.3927;
+    if (sector < 9)
+      phirechit = 0.19635 + (sector - 1) * 0.3927;
+    if (sector > 8)
+      phirechit = -2.94524 + (sector - 9) * 0.3927;
 
     // add time conditions for the rechit
     if (rechit_p->time() > mintime_ && rechit_p->time() < maxtime_) {
+      // loop over the 16 towers possibilities
+      for (int j = 0; j < 16; j++) {
+        // phi matching condition
+        if (TMath::Abs(phirechit - poscastortowerarray[3][j]) < 0.0001) {
+          // condition over rechit z value
+          if (zrechit > 0.) {
+            poscastortowerarray[0][j] += Erechit;
+            if (module < 3) {
+              poscastortowerarray[1][j] += Erechit;
+            } else {
+              poscastortowerarray[2][j] += Erechit;
+            }
+            poscastorusedrechits[j].push_back(rechit_p);
+          } else {
+            negcastortowerarray[0][j] += Erechit;
+            if (module < 3) {
+              negcastortowerarray[1][j] += Erechit;
+            } else {
+              negcastortowerarray[2][j] += Erechit;
+            }
+            negcastorusedrechits[j].push_back(rechit_p);
+          }  // end condition over rechit z value
+        }    // end phi matching condition
+      }      // end loop over the 16 towers possibilities
+    }        // end time conditions
 
-    	// loop over the 16 towers possibilities
-    	for ( int j=0;j<16;j++) {
-      
-      		// phi matching condition
-      		if (TMath::Abs(phirechit - poscastortowerarray[3][j]) < 0.0001) {
+  }  // end loop over rechits to build castortowerarray[4][16] and castorusedrechits[16]
 
-			// condition over rechit z value
-    			if (zrechit > 0.) {
-	  			poscastortowerarray[0][j]+=Erechit;
-	  			if (module < 3) {poscastortowerarray[1][j]+=Erechit;} else {poscastortowerarray[2][j]+=Erechit;}
-	  			poscastorusedrechits[j].push_back(rechit_p);
-			} else {
-	  			negcastortowerarray[0][j]+=Erechit;
-	  			if (module < 3) {negcastortowerarray[1][j]+=Erechit;} else {negcastortowerarray[2][j]+=Erechit;}
-	  			negcastorusedrechits[j].push_back(rechit_p);
-			} // end condition over rechit z value
-      		} // end phi matching condition
-    	} // end loop over the 16 towers possibilities
-    } // end time conditions
-    
-  } // end loop over rechits to build castortowerarray[4][16] and castorusedrechits[16]
-  
   // make towers of the arrays
 
   double fem, Ehot, depth;
   double rhoTower = 88.5;
 
   // loop over the 16 towers possibilities
-  for (int k=0;k<16;k++) {
-    
+  for (int k = 0; k < 16; k++) {
     fem = 0;
     Ehot = 0;
     depth = 0;
 
     // select the positive towers with E > sqrt(Nusedrechits)*Ecut
-    if (poscastortowerarray[0][k] > sqrt(poscastorusedrechits[k].size())*towercut_) {
-      
-      fem = poscastortowerarray[1][k]/poscastortowerarray[0][k];
+    if (poscastortowerarray[0][k] > sqrt(poscastorusedrechits[k].size()) * towercut_) {
+      fem = poscastortowerarray[1][k] / poscastortowerarray[0][k];
       CastorRecHitRefVector usedRecHits = poscastorusedrechits[k];
-      ComputeTowerVariable(usedRecHits,Ehot,depth);
+      ComputeTowerVariable(usedRecHits, Ehot, depth);
 
-      LogDebug("CastorTowerProducer")
-	<<"tower "<<k+1<<": fem = "<<fem<<" ,depth = "<<depth<<" ,Ehot = "<<Ehot<<std::endl;
+      LogDebug("CastorTowerProducer") << "tower " << k + 1 << ": fem = " << fem << " ,depth = " << depth
+                                      << " ,Ehot = " << Ehot << std::endl;
 
-      TowerPoint temptowerposition(rhoTower,5.9,poscastortowerarray[3][k]);
+      TowerPoint temptowerposition(rhoTower, 5.9, poscastortowerarray[3][k]);
       Point towerposition(temptowerposition);
 
-      CastorTower newtower(poscastortowerarray[0][k],towerposition,poscastortowerarray[1][k],poscastortowerarray[2][k],fem,depth,Ehot,
-			   poscastorusedrechits[k]);
+      CastorTower newtower(poscastortowerarray[0][k],
+                           towerposition,
+                           poscastortowerarray[1][k],
+                           poscastortowerarray[2][k],
+                           fem,
+                           depth,
+                           Ehot,
+                           poscastorusedrechits[k]);
       OutputTowers->push_back(newtower);
-    } // end select the positive towers with E > Ecut
-    
+    }  // end select the positive towers with E > Ecut
+
     // select the negative towers with E > sqrt(Nusedrechits)*Ecut
-    if (negcastortowerarray[0][k] > sqrt(negcastorusedrechits[k].size())*towercut_) {
-      
-      fem = negcastortowerarray[1][k]/negcastortowerarray[0][k];
+    if (negcastortowerarray[0][k] > sqrt(negcastorusedrechits[k].size()) * towercut_) {
+      fem = negcastortowerarray[1][k] / negcastortowerarray[0][k];
       CastorRecHitRefVector usedRecHits = negcastorusedrechits[k];
-      ComputeTowerVariable(usedRecHits,Ehot,depth);
+      ComputeTowerVariable(usedRecHits, Ehot, depth);
 
-      LogDebug("CastorTowerProducer")
-	 <<"tower "<<k+1 << " energy = " << negcastortowerarray[0][k] << "EM = " << negcastortowerarray[1][k] << "HAD = " << negcastortowerarray[2][k] << "phi = " << negcastortowerarray[3][k] << ": fem = "<<fem<<" ,depth = "<<depth<<" ,Ehot = "<<Ehot<<std::endl;
+      LogDebug("CastorTowerProducer") << "tower " << k + 1 << " energy = " << negcastortowerarray[0][k]
+                                      << "EM = " << negcastortowerarray[1][k] << "HAD = " << negcastortowerarray[2][k]
+                                      << "phi = " << negcastortowerarray[3][k] << ": fem = " << fem
+                                      << " ,depth = " << depth << " ,Ehot = " << Ehot << std::endl;
 
-      TowerPoint temptowerposition(rhoTower,-5.9,negcastortowerarray[3][k]);
+      TowerPoint temptowerposition(rhoTower, -5.9, negcastortowerarray[3][k]);
       Point towerposition(temptowerposition);
 
-      CastorTower newtower(negcastortowerarray[0][k],towerposition,negcastortowerarray[1][k],negcastortowerarray[2][k],fem,depth,Ehot,
-			   negcastorusedrechits[k]);
+      CastorTower newtower(negcastortowerarray[0][k],
+                           towerposition,
+                           negcastortowerarray[1][k],
+                           negcastortowerarray[2][k],
+                           fem,
+                           depth,
+                           Ehot,
+                           negcastorusedrechits[k]);
       OutputTowers->push_back(newtower);
-    } // end select the negative towers with E > Ecut
-    
-  } // end loop over the 16 towers possibilities
-  
+    }  // end select the negative towers with E > Ecut
+
+  }  // end loop over the 16 towers possibilities
+
   iEvent.put(std::move(OutputTowers));
-} 
+}
 
-
-void CastorTowerProducer::ComputeTowerVariable(const edm::RefVector<edm::SortedCollection<CastorRecHit> >& usedRecHits, double&  Ehot, double& depth) {
-
+void CastorTowerProducer::ComputeTowerVariable(const edm::RefVector<edm::SortedCollection<CastorRecHit> >& usedRecHits,
+                                               double& Ehot,
+                                               double& depth) {
   using namespace reco;
 
   double Etot = 0;
@@ -278,16 +293,19 @@ void CastorTowerProducer::ComputeTowerVariable(const edm::RefVector<edm::SortedC
     HcalCastorDetId id = rechit_p->id();
     int module = id.module();
     double zrechit = 0;
-    if (module < 3) zrechit = -14390 - 24.75 - 49.5*(module-1);
-    if (module > 2) zrechit = -14390 - 99 - 49.5 - 99*(module-3); 
+    if (module < 3)
+      zrechit = -14390 - 24.75 - 49.5 * (module - 1);
+    if (module > 2)
+      zrechit = -14390 - 99 - 49.5 - 99 * (module - 3);
 
-    if(Erechit > Ehot) Ehot = Erechit;
-    depth+=Erechit*zrechit;
-    Etot+=Erechit;
+    if (Erechit > Ehot)
+      Ehot = Erechit;
+    depth += Erechit * zrechit;
+    Etot += Erechit;
   }
 
-  depth/=Etot;
-  Ehot/=Etot;
+  depth /= Etot;
+  Ehot /= Etot;
 }
 
 //define this as a plug-in

--- a/RecoLocalCalo/Castor/src/RecHitCorrector.cc
+++ b/RecoLocalCalo/Castor/src/RecHitCorrector.cc
@@ -2,7 +2,7 @@
 //
 // Package:    RecHitCorrector
 // Class:      RecHitCorrector
-// 
+//
 /**\class RecHitCorrector RecHitCorrector.cc RecoLocalCalo/Castor/src/RecHitCorrector.cc
 
  Description: [one line class summary]
@@ -15,7 +15,6 @@
 //         Created:  Wed Feb 23 11:29:43 CET 2011
 //
 //
-
 
 // system include files
 #include <memory>
@@ -45,23 +44,22 @@
 //
 
 class RecHitCorrector : public edm::stream::EDProducer<> {
-   public:
-      explicit RecHitCorrector(const edm::ParameterSet&);
-      ~RecHitCorrector() override;
+public:
+  explicit RecHitCorrector(const edm::ParameterSet&);
+  ~RecHitCorrector() override;
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<CastorRecHitCollection> tok_input_;
-      double factor_;
-      bool doInterCalib_;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<CastorRecHitCollection> tok_input_;
+  double factor_;
+  bool doInterCalib_;
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -70,91 +68,81 @@ class RecHitCorrector : public edm::stream::EDProducer<> {
 //
 // constructors and destructor
 //
-RecHitCorrector::RecHitCorrector(const edm::ParameterSet& iConfig):
-factor_(iConfig.getParameter<double>("revertFactor")),
-doInterCalib_(iConfig.getParameter<bool>("doInterCalib"))
-{
+RecHitCorrector::RecHitCorrector(const edm::ParameterSet& iConfig)
+    : factor_(iConfig.getParameter<double>("revertFactor")), doInterCalib_(iConfig.getParameter<bool>("doInterCalib")) {
   tok_input_ = consumes<CastorRecHitCollection>(iConfig.getParameter<edm::InputTag>("rechitLabel"));
-   //register your products
-   produces<CastorRecHitCollection>();
-   //now do what ever other initialization is needed
+  //register your products
+  produces<CastorRecHitCollection>();
+  //now do what ever other initialization is needed
 }
 
-
-RecHitCorrector::~RecHitCorrector()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+RecHitCorrector::~RecHitCorrector() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-RecHitCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   
-   // get original rechits
-   edm::Handle<CastorRecHitCollection> rechits;
-   iEvent.getByToken(tok_input_,rechits);
-   
-   // get conditions
-   edm::ESHandle<CastorDbService> conditions;
-   iSetup.get<CastorDbRecord>().get(conditions);
-   
-   edm::ESHandle<CastorChannelQuality> p;
-   iSetup.get<CastorChannelQualityRcd>().get(p);
-   CastorChannelQuality* myqual = new CastorChannelQuality(*p.product());
-   
-   if (!rechits.isValid()) edm::LogWarning("CastorRecHitCorrector") << "No valid CastorRecHitCollection found, please check the InputLabel...";
-   
-   CastorCalibrations calibrations;
-   
-   auto rec = std::make_unique<CastorRecHitCollection>();
-   
-   for (unsigned int i=0;i<rechits->size();i++) {
-   	CastorRecHit rechit = (*rechits)[i];
-	double time = rechit.time();
-	double correctedenergy = factor_*rechit.energy();
-	
-	if (doInterCalib_) {
-		// do proper gain calibration reading the latest entries in the condDB
-		const CastorCalibrations& calibrations=conditions->getCastorCalibrations(rechit.id());
-		int capid = 0; // take some capid, gains are the same for all capid's
-		correctedenergy *= calibrations.gain(capid);
-	}
-	
-	// now check the channelquality of this rechit
-	bool ok = true;
-	DetId detcell=(DetId)rechit.id();
-	std::vector<DetId> channels = myqual->getAllChannels();
-	for (auto channel : channels) {	
-		if (channel.rawId() == detcell.rawId()) {
-			const CastorChannelStatus* mydigistatus=myqual->getValues(channel);
-			if (mydigistatus->getValue() == 2989) {
-				ok = false; // 2989 = BAD
-				break;
-			}
-		}
-	}
-	
-	if (ok) {
-	    rec->emplace_back(rechit.id(),correctedenergy,time);
-	}
-   }
-   
-   iEvent.put(std::move(rec));
-   
-   delete myqual;
- 
-}
+void RecHitCorrector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
+  // get original rechits
+  edm::Handle<CastorRecHitCollection> rechits;
+  iEvent.getByToken(tok_input_, rechits);
+
+  // get conditions
+  edm::ESHandle<CastorDbService> conditions;
+  iSetup.get<CastorDbRecord>().get(conditions);
+
+  edm::ESHandle<CastorChannelQuality> p;
+  iSetup.get<CastorChannelQualityRcd>().get(p);
+  CastorChannelQuality* myqual = new CastorChannelQuality(*p.product());
+
+  if (!rechits.isValid())
+    edm::LogWarning("CastorRecHitCorrector") << "No valid CastorRecHitCollection found, please check the InputLabel...";
+
+  CastorCalibrations calibrations;
+
+  auto rec = std::make_unique<CastorRecHitCollection>();
+
+  for (unsigned int i = 0; i < rechits->size(); i++) {
+    CastorRecHit rechit = (*rechits)[i];
+    double time = rechit.time();
+    double correctedenergy = factor_ * rechit.energy();
+
+    if (doInterCalib_) {
+      // do proper gain calibration reading the latest entries in the condDB
+      const CastorCalibrations& calibrations = conditions->getCastorCalibrations(rechit.id());
+      int capid = 0;  // take some capid, gains are the same for all capid's
+      correctedenergy *= calibrations.gain(capid);
+    }
+
+    // now check the channelquality of this rechit
+    bool ok = true;
+    DetId detcell = (DetId)rechit.id();
+    std::vector<DetId> channels = myqual->getAllChannels();
+    for (auto channel : channels) {
+      if (channel.rawId() == detcell.rawId()) {
+        const CastorChannelStatus* mydigistatus = myqual->getValues(channel);
+        if (mydigistatus->getValue() == 2989) {
+          ok = false;  // 2989 = BAD
+          break;
+        }
+      }
+    }
+
+    if (ok) {
+      rec->emplace_back(rechit.id(), correctedenergy, time);
+    }
+  }
+
+  iEvent.put(std::move(rec));
+
+  delete myqual;
+}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(RecHitCorrector);

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
@@ -3,8 +3,8 @@
  *  Comments about the program logic are denoted by //----
  * 
  *  Stoyan Stoynev, Northwestern University.
- */ 
-  
+ */
+
 #include "RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h"
 
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
@@ -19,58 +19,61 @@
 
 using namespace std;
 
-bool CSCEfficiency::filter(edm::Event & event, const edm::EventSetup& eventSetup){
+bool CSCEfficiency::filter(edm::Event &event, const edm::EventSetup &eventSetup) {
   passTheEvent = false;
-  DataFlow->Fill(0.);  
+  DataFlow->Fill(0.);
   MuonPatternRecoDumper debug;
- 
+
   //---- increment counter
   nEventsAnalyzed++;
   // printalot debug output
-  printalot = (nEventsAnalyzed < int(printout_NEvents)); // 
+  printalot = (nEventsAnalyzed < int(printout_NEvents));  //
   edm::RunNumber_t const iRun = event.id().run();
   edm::EventNumber_t const iEvent = event.id().event();
-  if(0==fmod(double (nEventsAnalyzed) ,double(1000) )){
-    if(printalot){
-      printf("\n==enter==CSCEfficiency===== run %u\tevent %llu\tn Analyzed %i\n",iRun,iEvent,nEventsAnalyzed);
+  if (0 == fmod(double(nEventsAnalyzed), double(1000))) {
+    if (printalot) {
+      printf("\n==enter==CSCEfficiency===== run %u\tevent %llu\tn Analyzed %i\n", iRun, iEvent, nEventsAnalyzed);
     }
   }
-  theService->update(eventSetup);  
+  theService->update(eventSetup);
   //---- These declarations create handles to the types of records that you want
   //---- to retrieve from event "e".
-  if (printalot) printf("\tget handles for digi collections\n");
-  
+  if (printalot)
+    printf("\tget handles for digi collections\n");
+
   //---- Pass the handle to the method "getByType", which is used to retrieve
   //---- one and only one instance of the type in question out of event "e". If
   //---- zero or more than one instance exists in the event an exception is thrown.
-  if (printalot) printf("\tpass handles\n");
+  if (printalot)
+    printf("\tpass handles\n");
   edm::Handle<CSCALCTDigiCollection> alcts;
   edm::Handle<CSCCLCTDigiCollection> clcts;
   edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedlcts;
   edm::Handle<CSCWireDigiCollection> wires;
   edm::Handle<CSCStripDigiCollection> strips;
-  edm::Handle<CSCRecHit2DCollection> rechits; 
+  edm::Handle<CSCRecHit2DCollection> rechits;
   edm::Handle<CSCSegmentCollection> segments;
   edm::Handle<edm::View<reco::Track> > trackCollectionH;
   edm::Handle<edm::PSimHitContainer> simhits;
 
-  if(useDigis){
-    event.getByToken( wd_token, wires );
-    event.getByToken( sd_token, strips );
-    event.getByToken( al_token, alcts );
-    event.getByToken( cl_token, clcts );
-    event.getByToken( co_token, correlatedlcts );
+  if (useDigis) {
+    event.getByToken(wd_token, wires);
+    event.getByToken(sd_token, strips);
+    event.getByToken(al_token, alcts);
+    event.getByToken(cl_token, clcts);
+    event.getByToken(co_token, correlatedlcts);
   }
-  if(!isData){
-    event.getByToken( sh_token, simhits );
+  if (!isData) {
+    event.getByToken(sh_token, simhits);
   }
-  event.getByToken( rh_token, rechits );
-  event.getByToken( se_token, segments );
-  event.getByToken( tk_token, trackCollectionH );
-  const edm::View<reco::Track>  trackCollection = *(trackCollectionH.product());
+  event.getByToken(rh_token, rechits);
+  event.getByToken(se_token, segments);
+  event.getByToken(tk_token, trackCollectionH);
+  const edm::View<reco::Track> trackCollection = *(trackCollectionH.product());
 
   //---- Get the CSC Geometry :
-  if (printalot) printf("\tget the CSC geometry.\n");
+  if (printalot)
+    printf("\tget the CSC geometry.\n");
   edm::ESHandle<CSCGeometry> cscGeom;
   eventSetup.get<MuonGeometryRecord>().get(cscGeom);
 
@@ -79,24 +82,23 @@ bool CSCEfficiency::filter(edm::Event & event, const edm::EventSetup& eventSetup
   eventSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
 
   bool triggerPassed = true;
-  if(useTrigger){
+  if (useTrigger) {
     // access the trigger information
     // trigger names can be find in HLTrigger/Configuration/python/HLT_2E30_cff.py (or?)
-   // get hold of TriggerResults
+    // get hold of TriggerResults
     edm::Handle<edm::TriggerResults> hltR;
-    event.getByToken( ht_token, hltR );
-    const edm::TriggerNames & triggerNames = event.triggerNames(*hltR);
+    event.getByToken(ht_token, hltR);
+    const edm::TriggerNames &triggerNames = event.triggerNames(*hltR);
     triggerPassed = applyTrigger(hltR, triggerNames);
   }
-  if(!triggerPassed){
+  if (!triggerPassed) {
     return triggerPassed;
   }
-  DataFlow->Fill(1.);	
-  GlobalPoint gpZero(0.,0.,0.);
-  if(theService->magneticField()->inTesla(gpZero).mag2()<0.1){ 
+  DataFlow->Fill(1.);
+  GlobalPoint gpZero(0., 0., 0.);
+  if (theService->magneticField()->inTesla(gpZero).mag2() < 0.1) {
     magField = false;
-  }
-  else{
+  } else {
     magField = true;
   }
 
@@ -105,175 +107,173 @@ bool CSCEfficiency::filter(edm::Event & event, const edm::EventSetup& eventSetup
   //
   edm::Handle<reco::MuonCollection> muons;
   edm::InputTag muonTag_("muons");
-  event.getByLabel(muonTag_,muons);
+  event.getByLabel(muonTag_, muons);
 
   edm::Handle<reco::BeamSpot> beamSpotHandle;
   event.getByLabel("offlineBeamSpot", beamSpotHandle);
   reco::BeamSpot vertexBeamSpot = *beamSpotHandle;
   //
-  std::vector <reco::MuonCollection::const_iterator> goodMuons_it;
+  std::vector<reco::MuonCollection::const_iterator> goodMuons_it;
   unsigned int nPositiveZ = 0;
   unsigned int nNegativeZ = 0;
   float muonOuterZPosition = -99999.;
-  if(isIPdata){
-    if (printalot)std::cout<<" muons.size() = "<<muons->size() <<std::endl;
-    for ( reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon ) {
-      DataFlow->Fill(31.);	
+  if (isIPdata) {
+    if (printalot)
+      std::cout << " muons.size() = " << muons->size() << std::endl;
+    for (reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
+      DataFlow->Fill(31.);
       if (printalot) {
-        std::cout<<"  iMuon = "<<muon-muons->begin()<<" charge = "<<muon->charge()<<" p = "<<muon->p()<<" pt = "<<muon->pt()<<
-          " eta = "<<muon->eta()<<" phi = "<<muon->phi()<<
-          " matches = "<<
-          muon->matches().size()<<" matched Seg = "<<muon->numberOfMatches(reco::Muon::SegmentAndTrackArbitration)<<" GLB/TR/STA = "<<
-          muon->isGlobalMuon()<<"/"<<muon->isTrackerMuon()<<"/"<<muon->isStandAloneMuon()<<std::endl;
+        std::cout << "  iMuon = " << muon - muons->begin() << " charge = " << muon->charge() << " p = " << muon->p()
+                  << " pt = " << muon->pt() << " eta = " << muon->eta() << " phi = " << muon->phi()
+                  << " matches = " << muon->matches().size()
+                  << " matched Seg = " << muon->numberOfMatches(reco::Muon::SegmentAndTrackArbitration)
+                  << " GLB/TR/STA = " << muon->isGlobalMuon() << "/" << muon->isTrackerMuon() << "/"
+                  << muon->isStandAloneMuon() << std::endl;
       }
-      if(!(muon->isTrackerMuon() && muon->isGlobalMuon())){
-	continue;
+      if (!(muon->isTrackerMuon() && muon->isGlobalMuon())) {
+        continue;
       }
       DataFlow->Fill(32.);
-      double relISO = ( muon->isolationR03().sumPt +
-                        muon->isolationR03().emEt +
-                        muon->isolationR03().hadEt)/muon->track()->pt();
+      double relISO =
+          (muon->isolationR03().sumPt + muon->isolationR03().emEt + muon->isolationR03().hadEt) / muon->track()->pt();
       if (printalot) {
-        std::cout<<" relISO = "<<relISO<<" emVetoEt = "<<muon->isolationR03().emVetoEt<<" caloComp = "<<
-          muon::caloCompatibility(*(muon))<<" dxy = "<<fabs(muon->track()->dxy(vertexBeamSpot.position()))<<std::endl;
+        std::cout << " relISO = " << relISO << " emVetoEt = " << muon->isolationR03().emVetoEt
+                  << " caloComp = " << muon::caloCompatibility(*(muon))
+                  << " dxy = " << fabs(muon->track()->dxy(vertexBeamSpot.position())) << std::endl;
       }
-      if(
-	 //relISO>0.1 || muon::caloCompatibility(*(muon))<.90 ||
-         fabs(muon->track()->dxy(vertexBeamSpot.position()))>0.2 || muon->pt()<6.){
+      if (
+          //relISO>0.1 || muon::caloCompatibility(*(muon))<.90 ||
+          fabs(muon->track()->dxy(vertexBeamSpot.position())) > 0.2 || muon->pt() < 6.) {
         continue;
       }
       DataFlow->Fill(33.);
-      if(muon->track()->hitPattern().numberOfValidPixelHits()<1 ||
-	 muon->track()->hitPattern().numberOfValidTrackerHits()<11 ||
-	 muon->combinedMuon()->hitPattern().numberOfValidMuonHits()<1 ||
-	 muon->combinedMuon()->normalizedChi2()>10. ||
-	 muon->numberOfMatches()<2){
-	continue;
+      if (muon->track()->hitPattern().numberOfValidPixelHits() < 1 ||
+          muon->track()->hitPattern().numberOfValidTrackerHits() < 11 ||
+          muon->combinedMuon()->hitPattern().numberOfValidMuonHits() < 1 ||
+          muon->combinedMuon()->normalizedChi2() > 10. || muon->numberOfMatches() < 2) {
+        continue;
       }
       DataFlow->Fill(34.);
       float zOuter = muon->combinedMuon()->outerPosition().z();
       float rhoOuter = muon->combinedMuon()->outerPosition().rho();
       bool passDepth = true;
-      // barrel region 
+      // barrel region
       //if ( fabs(zOuter) < 660. && rhoOuter > 400. && rhoOuter < 480.){
-      if ( fabs(zOuter) < 660. && rhoOuter > 400. && rhoOuter < 540.){ 
-	passDepth = false;
+      if (fabs(zOuter) < 660. && rhoOuter > 400. && rhoOuter < 540.) {
+        passDepth = false;
       }
       // endcap region
       //else if( fabs(zOuter) > 550. && fabs(zOuter) < 650. && rhoOuter < 300.){
-      else if( fabs(zOuter) > 550. && fabs(zOuter) < 650. && rhoOuter < 300.){
-	passDepth = false;
+      else if (fabs(zOuter) > 550. && fabs(zOuter) < 650. && rhoOuter < 300.) {
+        passDepth = false;
       }
       // overlap region
       //else if ( fabs(zOuter) > 680. && fabs(zOuter) < 730. && rhoOuter < 480.){
-      else if ( fabs(zOuter) > 680. && fabs(zOuter) < 880. && rhoOuter < 540.){
-	passDepth = false;
+      else if (fabs(zOuter) > 680. && fabs(zOuter) < 880. && rhoOuter < 540.) {
+        passDepth = false;
       }
-      if(!passDepth){
-	continue;
+      if (!passDepth) {
+        continue;
       }
       DataFlow->Fill(35.);
       goodMuons_it.push_back(muon);
-      if(muon->track()->momentum().z()>0.){
-	++nPositiveZ;
+      if (muon->track()->momentum().z() > 0.) {
+        ++nPositiveZ;
       }
-      if(muon->track()->momentum().z()<0.){
-	++nNegativeZ;
+      if (muon->track()->momentum().z() < 0.) {
+        ++nNegativeZ;
       }
     }
   }
 
   //
 
-
-  if (printalot) std::cout<<"Start track loop over "<<trackCollection.size()<<" tracks"<<std::endl;
-  for(edm::View<reco::Track>::size_type i=0; i<trackCollection.size(); ++i) {
+  if (printalot)
+    std::cout << "Start track loop over " << trackCollection.size() << " tracks" << std::endl;
+  for (edm::View<reco::Track>::size_type i = 0; i < trackCollection.size(); ++i) {
     DataFlow->Fill(2.);
     edm::RefToBase<reco::Track> track(trackCollectionH, i);
     //std::cout<<" iTR = "<<i<<" eta = "<<track->eta()<<" phi = "<<track->phi()<<std::cout<<" pt = "<<track->pt()<<std::endl;
-    if(isIPdata){
-      if (printalot){
-	std::cout<<" nNegativeZ = "<<nNegativeZ<<" nPositiveZ = "<<nPositiveZ<<std::endl;
+    if (isIPdata) {
+      if (printalot) {
+        std::cout << " nNegativeZ = " << nNegativeZ << " nPositiveZ = " << nPositiveZ << std::endl;
       }
-      if(nNegativeZ>1 || nPositiveZ>1){
+      if (nNegativeZ > 1 || nPositiveZ > 1) {
         break;
       }
       bool trackOK = false;
-      if (printalot){
-	std::cout<<" goodMuons_it.size() = "<<goodMuons_it.size()<<std::endl;
+      if (printalot) {
+        std::cout << " goodMuons_it.size() = " << goodMuons_it.size() << std::endl;
       }
-      for(size_t iM=0;iM<goodMuons_it.size();++iM){
-	//std::cout<<" iM = "<<iM<<" eta = "<<goodMuons_it[iM]->track()->eta()<<
-	//" phi = "<<goodMuons_it[iM]->track()->phi()<<
-	//" pt = "<<goodMuons_it[iM]->track()->pt()<<std::endl;
-        float deltaR = pow(track->phi()-goodMuons_it[iM]->track()->phi(),2) +
-          pow(track->eta()-goodMuons_it[iM]->track()->eta(),2);
+      for (size_t iM = 0; iM < goodMuons_it.size(); ++iM) {
+        //std::cout<<" iM = "<<iM<<" eta = "<<goodMuons_it[iM]->track()->eta()<<
+        //" phi = "<<goodMuons_it[iM]->track()->phi()<<
+        //" pt = "<<goodMuons_it[iM]->track()->pt()<<std::endl;
+        float deltaR = pow(track->phi() - goodMuons_it[iM]->track()->phi(), 2) +
+                       pow(track->eta() - goodMuons_it[iM]->track()->eta(), 2);
         deltaR = sqrt(deltaR);
-        if (printalot){
-          std::cout<<" TR mu match to a tr: deltaR = "<<deltaR<<" dPt = "<<
-	    track->pt()-goodMuons_it[iM]->track()->pt()<<std::endl;
+        if (printalot) {
+          std::cout << " TR mu match to a tr: deltaR = " << deltaR
+                    << " dPt = " << track->pt() - goodMuons_it[iM]->track()->pt() << std::endl;
         }
-        if(deltaR>0.01 || fabs(track->pt()-goodMuons_it[iM]->track()->pt())>0.1 ){
+        if (deltaR > 0.01 || fabs(track->pt() - goodMuons_it[iM]->track()->pt()) > 0.1) {
           continue;
-        }
-        else{
+        } else {
           trackOK = true;
-	  if (printalot){
-	    std::cout<<" trackOK "<<std::endl;
-	  }
-	  muonOuterZPosition = goodMuons_it[iM]->combinedMuon()->outerPosition().z();
+          if (printalot) {
+            std::cout << " trackOK " << std::endl;
+          }
+          muonOuterZPosition = goodMuons_it[iM]->combinedMuon()->outerPosition().z();
           break;
           //++nChosenTracks;
         }
       }
-      if(!trackOK){
-	if (printalot){
-	  std::cout<<" failed: trackOK "<<std::endl;
-	}
+      if (!trackOK) {
+        if (printalot) {
+          std::cout << " failed: trackOK " << std::endl;
+        }
         continue;
       }
-    }
-    else{
+    } else {
       //---- Do we need a better "clean track" definition?
-      if(trackCollection.size()>2){
-	break;
+      if (trackCollection.size() > 2) {
+        break;
       }
       DataFlow->Fill(3.);
-      if(!i && 2==trackCollection.size()){
-	edm::View<reco::Track>::size_type tType = 1;
-	edm::RefToBase<reco::Track> trackTwo(trackCollectionH, tType);
-	if(track->outerPosition().z()*trackTwo->outerPosition().z()>0){// in one and the same "endcap"
-	  break;
-	}
+      if (!i && 2 == trackCollection.size()) {
+        edm::View<reco::Track>::size_type tType = 1;
+        edm::RefToBase<reco::Track> trackTwo(trackCollectionH, tType);
+        if (track->outerPosition().z() * trackTwo->outerPosition().z() > 0) {  // in one and the same "endcap"
+          break;
+        }
       }
     }
     DataFlow->Fill(4.);
-    if (printalot){
-      std::cout<<"i track = "<<i<<" P = "<<track->p()<<" chi2/ndf = "<<track->normalizedChi2()<<" nSeg = "<<segments->size()<<std::endl;
-      std::cout<<"quality undef/loose/tight/high/confirmed/goodIt/size "<<
-	track->quality(reco::Track::undefQuality)<<"/"<<
-	track->quality(reco::Track::loose)<<"/"<<
-	track->quality(reco::Track::tight)<<"/"<<
-	track->quality(reco::Track::highPurity)<<"/"<<
-	track->quality(reco::Track::confirmed)<<"/"<<
-	track->quality(reco::Track::goodIterative)<<"/"<<
-	track->quality(reco::Track::qualitySize)<<
-	std::endl;
-      std::cout<<" pt = "<< track->pt()<<" +-"<<track->ptError()<<" q/pt = "<<track->qoverp()<<" +- "<<track->qoverpError()<<std::endl;
+    if (printalot) {
+      std::cout << "i track = " << i << " P = " << track->p() << " chi2/ndf = " << track->normalizedChi2()
+                << " nSeg = " << segments->size() << std::endl;
+      std::cout << "quality undef/loose/tight/high/confirmed/goodIt/size " << track->quality(reco::Track::undefQuality)
+                << "/" << track->quality(reco::Track::loose) << "/" << track->quality(reco::Track::tight) << "/"
+                << track->quality(reco::Track::highPurity) << "/" << track->quality(reco::Track::confirmed) << "/"
+                << track->quality(reco::Track::goodIterative) << "/" << track->quality(reco::Track::qualitySize)
+                << std::endl;
+      std::cout << " pt = " << track->pt() << " +-" << track->ptError() << " q/pt = " << track->qoverp() << " +- "
+                << track->qoverpError() << std::endl;
       //std::cout<<" const Pmin = "<<minTrackMomentum<<" pMax = "<<maxTrackMomentum<<" maxNormChi2 = "<<maxNormChi2<<std::endl;
-      std::cout<<" track inner position = "<<track->innerPosition()<<" outer position = "<<track->outerPosition()<<std::endl;
-      std::cout<<"track eta (outer) = "<<track->outerPosition().eta()<<" phi (outer) = "<<
-	track->outerPosition().phi()<<std::endl;
-      if(fabs(track->innerPosition().z())>500.){      
-	DetId innerDetId(track->innerDetId());
-	std::cout<<" dump inner state MUON detid  = "<<debug.dumpMuonId(innerDetId)<<std::endl;
+      std::cout << " track inner position = " << track->innerPosition()
+                << " outer position = " << track->outerPosition() << std::endl;
+      std::cout << "track eta (outer) = " << track->outerPosition().eta()
+                << " phi (outer) = " << track->outerPosition().phi() << std::endl;
+      if (fabs(track->innerPosition().z()) > 500.) {
+        DetId innerDetId(track->innerDetId());
+        std::cout << " dump inner state MUON detid  = " << debug.dumpMuonId(innerDetId) << std::endl;
       }
-      if(fabs(track->outerPosition().z())>500.){
+      if (fabs(track->outerPosition().z()) > 500.) {
         DetId outerDetId(track->outerDetId());
-	std::cout<<" dump outer state MUON detid  = "<<debug.dumpMuonId(outerDetId)<<std::endl;
+        std::cout << " dump outer state MUON detid  = " << debug.dumpMuonId(outerDetId) << std::endl;
       }
 
-      std::cout<<" nHits = "<<track->found()<<std::endl;
+      std::cout << " nHits = " << track->found() << std::endl;
       /*
       trackingRecHit_iterator rhbegin = track->recHitsBegin();
       trackingRecHit_iterator rhend = track->recHitsEnd();
@@ -287,78 +287,77 @@ bool CSCEfficiency::filter(edm::Event & event, const edm::EventSetup& eventSetup
       */
     }
     float dpT_ov_pT = 0.;
-    if(fabs(track->pt())>0.001){
-      dpT_ov_pT =  track->ptError()/ track->pt();
+    if (fabs(track->pt()) > 0.001) {
+      dpT_ov_pT = track->ptError() / track->pt();
     }
     //---- These define a "good" track
-    if(track->normalizedChi2()>maxNormChi2){// quality
+    if (track->normalizedChi2() > maxNormChi2) {  // quality
       break;
     }
     DataFlow->Fill(5.);
-    if(track->found()<minTrackHits){// enough data points
+    if (track->found() < minTrackHits) {  // enough data points
       break;
     }
     DataFlow->Fill(6.);
-    if(!segments->size()){// better have something in the CSC 
+    if (!segments->size()) {  // better have something in the CSC
       break;
     }
     DataFlow->Fill(7.);
-    if(magField && (track->p()<minP || track->p()>maxP)){// proper energy range 
+    if (magField && (track->p() < minP || track->p() > maxP)) {  // proper energy range
       break;
     }
     DataFlow->Fill(8.);
-    if(magField && (dpT_ov_pT >0.5) ){// not too crazy uncertainty
+    if (magField && (dpT_ov_pT > 0.5)) {  // not too crazy uncertainty
       break;
     }
     DataFlow->Fill(9.);
 
-    passTheEvent = true; 
-    if (printalot) std::cout<<"good Track"<<std::endl;
-    CLHEP::Hep3Vector r3T_inner(track->innerPosition().x(),track->innerPosition().y(),track->innerPosition().z());
-    CLHEP::Hep3Vector r3T(track->outerPosition().x(),track->outerPosition().y(),track->outerPosition().z());
-    chooseDirection(r3T_inner, r3T);// for non-IP
+    passTheEvent = true;
+    if (printalot)
+      std::cout << "good Track" << std::endl;
+    CLHEP::Hep3Vector r3T_inner(track->innerPosition().x(), track->innerPosition().y(), track->innerPosition().z());
+    CLHEP::Hep3Vector r3T(track->outerPosition().x(), track->outerPosition().y(), track->outerPosition().z());
+    chooseDirection(r3T_inner, r3T);  // for non-IP
 
-    CLHEP::Hep3Vector p3T(track->outerMomentum().x(),track->outerMomentum().y(),track->outerMomentum().z());
+    CLHEP::Hep3Vector p3T(track->outerMomentum().x(), track->outerMomentum().y(), track->outerMomentum().z());
     CLHEP::Hep3Vector p3_propagated, r3_propagated;
     AlgebraicSymMatrix66 cov_propagated, covT;
     covT *= 1e-20;
     cov_propagated *= 1e-20;
-    int charge = track->charge(); 
+    int charge = track->charge();
     FreeTrajectoryState ftsStart = getFromCLHEP(p3T, r3T, charge, covT, &*(theService->magneticField()));
-    if (printalot){
-      std::cout<<" p = "<<track->p()<<" norm chi2 = "<<track->normalizedChi2()<<std::endl;
-      std::cout<<" dump the very first FTS  = "<<debug.dumpFTS(ftsStart)<<std::endl;
+    if (printalot) {
+      std::cout << " p = " << track->p() << " norm chi2 = " << track->normalizedChi2() << std::endl;
+      std::cout << " dump the very first FTS  = " << debug.dumpFTS(ftsStart) << std::endl;
     }
     TrajectoryStateOnSurface tSOSDest;
     int endcap = 0;
     //---- which endcap to look at
-    if(track->outerPosition().z()>0){
+    if (track->outerPosition().z() > 0) {
       endcap = 1;
-    }
-    else{
+    } else {
       endcap = 2;
     }
     int chamber = 1;
     //---- a "refference" CSCDetId for each ring
-    std::vector< CSCDetId > refME;
-    for(int iS=1;iS<5;++iS){
-      for(int iR=1;iR<4;++iR){
-	if(1!=iS && iR>2){
-	  continue;
-	}
-	else if(4==iS && iR>1){
-	  continue;
-	} 
-	refME.push_back( CSCDetId(endcap, iS, iR, chamber));
+    std::vector<CSCDetId> refME;
+    for (int iS = 1; iS < 5; ++iS) {
+      for (int iR = 1; iR < 4; ++iR) {
+        if (1 != iS && iR > 2) {
+          continue;
+        } else if (4 == iS && iR > 1) {
+          continue;
+        }
+        refME.push_back(CSCDetId(endcap, iS, iR, chamber));
       }
     }
     //---- loop over the "refference" CSCDetIds
-    for(size_t iSt = 0; iSt<refME.size();++iSt){
-      if (printalot){
-	std::cout<<"loop iStatation = "<<iSt<<std::endl;
-	std::cout<<"refME[iSt]: st = "<<refME[iSt].station()<<" rg = "<<refME[iSt].ring()<<std::endl;
+    for (size_t iSt = 0; iSt < refME.size(); ++iSt) {
+      if (printalot) {
+        std::cout << "loop iStatation = " << iSt << std::endl;
+        std::cout << "refME[iSt]: st = " << refME[iSt].station() << " rg = " << refME[iSt].ring() << std::endl;
       }
-      std::map <std::string, bool> chamberTypes;
+      std::map<std::string, bool> chamberTypes;
       chamberTypes["ME11"] = false;
       chamberTypes["ME12"] = false;
       chamberTypes["ME13"] = false;
@@ -367,708 +366,722 @@ bool CSCEfficiency::filter(edm::Event & event, const edm::EventSetup& eventSetup
       chamberTypes["ME31"] = false;
       chamberTypes["ME32"] = false;
       chamberTypes["ME41"] = false;
-      const CSCChamber* cscChamber_base = cscGeom->chamber(refME[iSt].chamberId());
+      const CSCChamber *cscChamber_base = cscGeom->chamber(refME[iSt].chamberId());
       DetId detId = cscChamber_base->geographicalId();
-      if (printalot){
-	std::cout<<" base iStation : eta = "<<cscGeom->idToDet(detId)->surface().position().eta()<<" phi = "<<
-	  cscGeom->idToDet(detId)->surface().position().phi() << " y = " <<cscGeom->idToDet(detId)->surface().position().y()<<std::endl;
-	std::cout<<" dump base iStation detid  = "<<debug.dumpMuonId(detId)<<std::endl;
-	std::cout<<" dump FTS start  = "<<debug.dumpFTS(ftsStart)<<std::endl;
+      if (printalot) {
+        std::cout << " base iStation : eta = " << cscGeom->idToDet(detId)->surface().position().eta()
+                  << " phi = " << cscGeom->idToDet(detId)->surface().position().phi()
+                  << " y = " << cscGeom->idToDet(detId)->surface().position().y() << std::endl;
+        std::cout << " dump base iStation detid  = " << debug.dumpMuonId(detId) << std::endl;
+        std::cout << " dump FTS start  = " << debug.dumpFTS(ftsStart) << std::endl;
       }
       //---- propagate to this ME
       tSOSDest = propagate(ftsStart, cscGeom->idToDet(detId)->surface());
-      if(tSOSDest.isValid()){
-	ftsStart = *tSOSDest.freeState();
-	if (printalot) std::cout<<"  dump FTS end   = "<<debug.dumpFTS(ftsStart)<<std::endl;
-	getFromFTS(ftsStart, p3_propagated, r3_propagated, charge, cov_propagated);
-	float feta =  fabs(r3_propagated.eta());
-	float phi =  r3_propagated.phi();
-	//---- which rings are (possibly) penetrated
-	ringCandidates(refME[iSt].station(), feta, chamberTypes);
+      if (tSOSDest.isValid()) {
+        ftsStart = *tSOSDest.freeState();
+        if (printalot)
+          std::cout << "  dump FTS end   = " << debug.dumpFTS(ftsStart) << std::endl;
+        getFromFTS(ftsStart, p3_propagated, r3_propagated, charge, cov_propagated);
+        float feta = fabs(r3_propagated.eta());
+        float phi = r3_propagated.phi();
+        //---- which rings are (possibly) penetrated
+        ringCandidates(refME[iSt].station(), feta, chamberTypes);
 
-	map<std::string,bool>::iterator iter;   
-	int iterations = 0;
-	//---- loop over ring candidates 
-	for( iter = chamberTypes.begin(); iter != chamberTypes.end(); iter++ ) {
-	  ++iterations;
-	  //---- is this ME a machinig candidate station 
-	  if(iter->second && (iterations-1)==int(iSt)){
-	    if (printalot){
-	      std::cout<<" Chamber type "<< iter->first<<" is a candidate..."<<std::endl;
-	      std::cout<<" station() = "<< refME[iSt].station()<<" ring() = "<<refME[iSt].ring()<<" iSt = "<<iSt<<std::endl;
-	    }
-	    std::vector <int> coupleOfChambers;
-	    //---- which chamber (and its closes neighbor) is penetrated by the track - candidates
-	    chamberCandidates(refME[iSt].station(), refME[iSt].ring(), phi, coupleOfChambers);
-	    //---- loop over the two chamber candidates
-	    for(size_t iCh =0;iCh<coupleOfChambers.size();++iCh){
-	      DataFlow->Fill(11.);  
-	      if (printalot) std::cout<<" Check chamber N = "<<coupleOfChambers.at(iCh)<<std::endl;;
-	      if((!getAbsoluteEfficiency) && (true == emptyChambers
-					      [refME[iSt].endcap()-1]
-					      [refME[iSt].station()-1]
-					      [refME[iSt].ring()-1]
-					      [coupleOfChambers.at(iCh)-FirstCh])){
-		continue;
-	      }
-	      CSCDetId theCSCId(refME[iSt].endcap(), refME[iSt].station(), refME[iSt].ring(), coupleOfChambers.at(iCh));
-	      const CSCChamber* cscChamber = cscGeom->chamber(theCSCId.chamberId());
-	      const BoundPlane bpCh = cscGeom->idToDet(cscChamber->geographicalId())->surface();
-	      float zFTS = ftsStart.position().z();
-	      float dz = fabs(bpCh.position().z() - zFTS);
-	      float zDistInner = track->innerPosition().z() - bpCh.position().z();
-	      float zDistOuter = track->outerPosition().z() - bpCh.position().z();
-	      //---- only detectors between the inner and outer points of the track are considered for non IP-data
-	      if(printalot){
-		std::cout<<" zIn = "<<track->innerPosition().z()<<" zOut = "<<track->outerPosition().z()<<" zSurf = "<<bpCh.position().z()<<std::endl;
-	      }
-	      if(!isIPdata && (zDistInner*zDistOuter>0. || fabs(zDistInner)<15. || fabs(zDistOuter)<15.)){ // for non IP-data
-		if(printalot){
-		  std::cout<<" Not an intermediate (as defined) point... Skip."<<std::endl;
-		}
-		continue;
-	      }
-	      if(isIPdata && fabs(track->eta())<1.8){
-		if(fabs(muonOuterZPosition) - fabs(bpCh.position().z())<0 || 
-		   fabs(muonOuterZPosition-bpCh.position().z())<15.){
-		  continue;
-		}
-	      }
-              DataFlow->Fill(13.);
-	      //---- propagate to the chamber (from this ME) if it is a different surface (odd/even chambers)
-	      if(dz>0.1){// i.e. non-zero (float 0 check is bad) 
-		//if(fabs(zChanmber - zFTS ) > 0.1){
-		tSOSDest = propagate(ftsStart, cscGeom->idToDet(cscChamber->geographicalId())->surface());		     
-		if(tSOSDest.isValid()){
-		  ftsStart = *tSOSDest.freeState();
-		}
-		else{
-		  if(printalot) std::cout<<"TSOS not valid! Break."<<std::endl;
-		  break;
-		}
-	      }
-              else{
-                if(printalot) std::cout<<" info: dz<0.1"<<std::endl;
+        map<std::string, bool>::iterator iter;
+        int iterations = 0;
+        //---- loop over ring candidates
+        for (iter = chamberTypes.begin(); iter != chamberTypes.end(); iter++) {
+          ++iterations;
+          //---- is this ME a machinig candidate station
+          if (iter->second && (iterations - 1) == int(iSt)) {
+            if (printalot) {
+              std::cout << " Chamber type " << iter->first << " is a candidate..." << std::endl;
+              std::cout << " station() = " << refME[iSt].station() << " ring() = " << refME[iSt].ring()
+                        << " iSt = " << iSt << std::endl;
+            }
+            std::vector<int> coupleOfChambers;
+            //---- which chamber (and its closes neighbor) is penetrated by the track - candidates
+            chamberCandidates(refME[iSt].station(), refME[iSt].ring(), phi, coupleOfChambers);
+            //---- loop over the two chamber candidates
+            for (size_t iCh = 0; iCh < coupleOfChambers.size(); ++iCh) {
+              DataFlow->Fill(11.);
+              if (printalot)
+                std::cout << " Check chamber N = " << coupleOfChambers.at(iCh) << std::endl;
+              ;
+              if ((!getAbsoluteEfficiency) &&
+                  (true == emptyChambers[refME[iSt].endcap() - 1][refME[iSt].station() - 1][refME[iSt].ring() - 1]
+                                        [coupleOfChambers.at(iCh) - FirstCh])) {
+                continue;
               }
-	      DataFlow->Fill(15.);  
-	      FreeTrajectoryState ftsInit = ftsStart;
-	      bool inDeadZone = false;
-	      //---- loop over the 6 layers
-	      for(int iLayer = 0;iLayer<6;++iLayer){
-		bool extrapolationPassed = true;
-		if (printalot){
-		  std::cout<<" iLayer = "<<iLayer<<"   dump FTS init  = "<<debug.dumpFTS(ftsInit)<<std::endl;
-		  std::cout<<" dump detid  = "<<debug.dumpMuonId(cscChamber->geographicalId())<<std::endl;
-		  std::cout<<"Surface to propagate to:  pos = "<<cscChamber->layer(iLayer+1)->surface().position()<<" eta = "
-			   <<cscChamber->layer(iLayer+1)->surface().position().eta()<<" phi = "
-			   <<cscChamber->layer(iLayer+1)->surface().position().phi()<<std::endl;
-		}
-		//---- propagate to this layer
-		tSOSDest = propagate(ftsInit, cscChamber->layer(iLayer+1)->surface());
-		if(tSOSDest.isValid()){
-		  ftsInit = *tSOSDest.freeState();
-		  if (printalot) std::cout<<" Propagation between layers successful:  dump FTS end  = "<<debug.dumpFTS(ftsInit)<<std::endl;
-		  getFromFTS(ftsInit, p3_propagated, r3_propagated, charge, cov_propagated);
-		}
-		else{
-		  if (printalot) std::cout<<"Propagation between layers not successful - notValid TSOS"<<std::endl;
-		  extrapolationPassed = false;
-		  inDeadZone = true;
-		}
-		//}
-		//---- Extrapolation passed? For each layer?
-		if(extrapolationPassed){
-		  GlobalPoint theExtrapolationPoint(r3_propagated.x(),r3_propagated.y(),r3_propagated.z());
-		  LocalPoint theLocalPoint = cscChamber->layer(iLayer+1)->toLocal(theExtrapolationPoint);
-		  //std::cout<<" Candidate chamber: extrapolated LocalPoint = "<<theLocalPoint<<std::endl;
-		  inDeadZone = ( inDeadZone ||
-				 !inSensitiveLocalRegion(theLocalPoint.x(), theLocalPoint.y(), 
-							 refME[iSt].station(), refME[iSt].ring()));
-		  if (printalot){
-                    std::cout<<" Candidate chamber: extrapolated LocalPoint = "<<theLocalPoint<<"inDeadZone = "<<inDeadZone<<std::endl;
+              CSCDetId theCSCId(refME[iSt].endcap(), refME[iSt].station(), refME[iSt].ring(), coupleOfChambers.at(iCh));
+              const CSCChamber *cscChamber = cscGeom->chamber(theCSCId.chamberId());
+              const BoundPlane bpCh = cscGeom->idToDet(cscChamber->geographicalId())->surface();
+              float zFTS = ftsStart.position().z();
+              float dz = fabs(bpCh.position().z() - zFTS);
+              float zDistInner = track->innerPosition().z() - bpCh.position().z();
+              float zDistOuter = track->outerPosition().z() - bpCh.position().z();
+              //---- only detectors between the inner and outer points of the track are considered for non IP-data
+              if (printalot) {
+                std::cout << " zIn = " << track->innerPosition().z() << " zOut = " << track->outerPosition().z()
+                          << " zSurf = " << bpCh.position().z() << std::endl;
+              }
+              if (!isIPdata && (zDistInner * zDistOuter > 0. || fabs(zDistInner) < 15. ||
+                                fabs(zDistOuter) < 15.)) {  // for non IP-data
+                if (printalot) {
+                  std::cout << " Not an intermediate (as defined) point... Skip." << std::endl;
+                }
+                continue;
+              }
+              if (isIPdata && fabs(track->eta()) < 1.8) {
+                if (fabs(muonOuterZPosition) - fabs(bpCh.position().z()) < 0 ||
+                    fabs(muonOuterZPosition - bpCh.position().z()) < 15.) {
+                  continue;
+                }
+              }
+              DataFlow->Fill(13.);
+              //---- propagate to the chamber (from this ME) if it is a different surface (odd/even chambers)
+              if (dz > 0.1) {  // i.e. non-zero (float 0 check is bad)
+                //if(fabs(zChanmber - zFTS ) > 0.1){
+                tSOSDest = propagate(ftsStart, cscGeom->idToDet(cscChamber->geographicalId())->surface());
+                if (tSOSDest.isValid()) {
+                  ftsStart = *tSOSDest.freeState();
+                } else {
+                  if (printalot)
+                    std::cout << "TSOS not valid! Break." << std::endl;
+                  break;
+                }
+              } else {
+                if (printalot)
+                  std::cout << " info: dz<0.1" << std::endl;
+              }
+              DataFlow->Fill(15.);
+              FreeTrajectoryState ftsInit = ftsStart;
+              bool inDeadZone = false;
+              //---- loop over the 6 layers
+              for (int iLayer = 0; iLayer < 6; ++iLayer) {
+                bool extrapolationPassed = true;
+                if (printalot) {
+                  std::cout << " iLayer = " << iLayer << "   dump FTS init  = " << debug.dumpFTS(ftsInit) << std::endl;
+                  std::cout << " dump detid  = " << debug.dumpMuonId(cscChamber->geographicalId()) << std::endl;
+                  std::cout << "Surface to propagate to:  pos = " << cscChamber->layer(iLayer + 1)->surface().position()
+                            << " eta = " << cscChamber->layer(iLayer + 1)->surface().position().eta()
+                            << " phi = " << cscChamber->layer(iLayer + 1)->surface().position().phi() << std::endl;
+                }
+                //---- propagate to this layer
+                tSOSDest = propagate(ftsInit, cscChamber->layer(iLayer + 1)->surface());
+                if (tSOSDest.isValid()) {
+                  ftsInit = *tSOSDest.freeState();
+                  if (printalot)
+                    std::cout << " Propagation between layers successful:  dump FTS end  = " << debug.dumpFTS(ftsInit)
+                              << std::endl;
+                  getFromFTS(ftsInit, p3_propagated, r3_propagated, charge, cov_propagated);
+                } else {
+                  if (printalot)
+                    std::cout << "Propagation between layers not successful - notValid TSOS" << std::endl;
+                  extrapolationPassed = false;
+                  inDeadZone = true;
+                }
+                //}
+                //---- Extrapolation passed? For each layer?
+                if (extrapolationPassed) {
+                  GlobalPoint theExtrapolationPoint(r3_propagated.x(), r3_propagated.y(), r3_propagated.z());
+                  LocalPoint theLocalPoint = cscChamber->layer(iLayer + 1)->toLocal(theExtrapolationPoint);
+                  //std::cout<<" Candidate chamber: extrapolated LocalPoint = "<<theLocalPoint<<std::endl;
+                  inDeadZone = (inDeadZone ||
+                                !inSensitiveLocalRegion(
+                                    theLocalPoint.x(), theLocalPoint.y(), refME[iSt].station(), refME[iSt].ring()));
+                  if (printalot) {
+                    std::cout << " Candidate chamber: extrapolated LocalPoint = " << theLocalPoint
+                              << "inDeadZone = " << inDeadZone << std::endl;
                   }
-		  //---- break if in dead zone for any layer ("clean" tracks)
-		  if(inDeadZone){
-		    break;
-		  }
-		}
-		else{
-		  break;
-		}
-	      }
-	      DataFlow->Fill(17.);
-	      //---- Is a track in a sensitive area for each layer?  
-	      if(!inDeadZone){//---- for any layer
-		DataFlow->Fill(19.);  
-		if (printalot) std::cout<<"Do efficiencies..."<<std::endl;
-		//---- Do efficiencies
-		// angle cuts applied (if configured)
-		bool angle_flag = true; angle_flag = efficienciesPerChamber(theCSCId, cscChamber, ftsStart);  
-		if(useDigis && angle_flag){
-		  stripWire_Efficiencies(theCSCId, ftsStart);
-		}
-                if(angle_flag){
-		  recHitSegment_Efficiencies(theCSCId, cscChamber, ftsStart);
-		  if(!isData){
-		    recSimHitEfficiency(theCSCId, ftsStart);
-		  }
-		}
-	      }
-              else{
-                if(printalot) std::cout<<" Not in active area for all layers"<<std::endl;
-	      }
-	    }
-	    if(tSOSDest.isValid()){
-	      ftsStart = *tSOSDest.freeState();
-	    }
-	  }
-	}
-      }
-      else{
-        if (printalot) std::cout<<" TSOS not valid..."<<std::endl;
+                  //---- break if in dead zone for any layer ("clean" tracks)
+                  if (inDeadZone) {
+                    break;
+                  }
+                } else {
+                  break;
+                }
+              }
+              DataFlow->Fill(17.);
+              //---- Is a track in a sensitive area for each layer?
+              if (!inDeadZone) {  //---- for any layer
+                DataFlow->Fill(19.);
+                if (printalot)
+                  std::cout << "Do efficiencies..." << std::endl;
+                //---- Do efficiencies
+                // angle cuts applied (if configured)
+                bool angle_flag = true;
+                angle_flag = efficienciesPerChamber(theCSCId, cscChamber, ftsStart);
+                if (useDigis && angle_flag) {
+                  stripWire_Efficiencies(theCSCId, ftsStart);
+                }
+                if (angle_flag) {
+                  recHitSegment_Efficiencies(theCSCId, cscChamber, ftsStart);
+                  if (!isData) {
+                    recSimHitEfficiency(theCSCId, ftsStart);
+                  }
+                }
+              } else {
+                if (printalot)
+                  std::cout << " Not in active area for all layers" << std::endl;
+              }
+            }
+            if (tSOSDest.isValid()) {
+              ftsStart = *tSOSDest.freeState();
+            }
+          }
+        }
+      } else {
+        if (printalot)
+          std::cout << " TSOS not valid..." << std::endl;
       }
     }
   }
   //---- End
-  if (printalot) printf("==exit===CSCEfficiency===== run %u\tevent %llu\n\n",iRun,iEvent);
+  if (printalot)
+    printf("==exit===CSCEfficiency===== run %u\tevent %llu\n\n", iRun, iEvent);
   return passTheEvent;
 }
 
 //
-bool CSCEfficiency::inSensitiveLocalRegion(double xLocal, double yLocal, int station, int ring){
-  //---- Good region means sensitive area of a chamber. "Local" stands for the local system 
+bool CSCEfficiency::inSensitiveLocalRegion(double xLocal, double yLocal, int station, int ring) {
+  //---- Good region means sensitive area of a chamber. "Local" stands for the local system
   bool pass = false;
-  std::vector <double> chamberBounds(3);// the sensitive area
+  std::vector<double> chamberBounds(3);  // the sensitive area
   float y_center = 99999.;
   //---- hardcoded... not good
-  if(station>1 && station<5){
-    if(2==ring){
-      chamberBounds[0] = 66.46/2; // (+-)x1 shorter
-      chamberBounds[1] = 127.15/2; // (+-)x2 longer 
-      chamberBounds[2] = 323.06/2;
+  if (station > 1 && station < 5) {
+    if (2 == ring) {
+      chamberBounds[0] = 66.46 / 2;   // (+-)x1 shorter
+      chamberBounds[1] = 127.15 / 2;  // (+-)x2 longer
+      chamberBounds[2] = 323.06 / 2;
       y_center = -0.95;
-    }
-    else{
-      if(2==station){
-	chamberBounds[0] = 54.00/2; // (+-)x1 shorter
-	chamberBounds[1] = 125.71/2; // (+-)x2 longer 
-	chamberBounds[2] = 189.66/2;
-	y_center = -0.955;
-      }
-      else if(3==station){
-	chamberBounds[0] = 61.40/2; // (+-)x1 shorter
-	chamberBounds[1] = 125.71/2; // (+-)x2 longer 
-	chamberBounds[2] = 169.70/2;
-	y_center = -0.97;
-      }
-      else if(4==station){
-	chamberBounds[0] = 69.01/2; // (+-)x1 shorter
-	chamberBounds[1] = 125.65/2; // (+-)x2 longer 
-	chamberBounds[2] = 149.42/2;
-	y_center = -0.94;
+    } else {
+      if (2 == station) {
+        chamberBounds[0] = 54.00 / 2;   // (+-)x1 shorter
+        chamberBounds[1] = 125.71 / 2;  // (+-)x2 longer
+        chamberBounds[2] = 189.66 / 2;
+        y_center = -0.955;
+      } else if (3 == station) {
+        chamberBounds[0] = 61.40 / 2;   // (+-)x1 shorter
+        chamberBounds[1] = 125.71 / 2;  // (+-)x2 longer
+        chamberBounds[2] = 169.70 / 2;
+        y_center = -0.97;
+      } else if (4 == station) {
+        chamberBounds[0] = 69.01 / 2;   // (+-)x1 shorter
+        chamberBounds[1] = 125.65 / 2;  // (+-)x2 longer
+        chamberBounds[2] = 149.42 / 2;
+        y_center = -0.94;
       }
     }
-  }
-  else if(1==station){
-    if(3==ring){
-      chamberBounds[0] = 63.40/2; // (+-)x1 shorter
-      chamberBounds[1] = 92.10/2; // (+-)x2 longer 
-      chamberBounds[2] = 164.16/2;
+  } else if (1 == station) {
+    if (3 == ring) {
+      chamberBounds[0] = 63.40 / 2;  // (+-)x1 shorter
+      chamberBounds[1] = 92.10 / 2;  // (+-)x2 longer
+      chamberBounds[2] = 164.16 / 2;
       y_center = -1.075;
-    }
-    else if(2==ring){
-      chamberBounds[0] = 51.00/2; // (+-)x1 shorter
-      chamberBounds[1] = 83.74/2; // (+-)x2 longer 
-      chamberBounds[2] = 174.49/2;
+    } else if (2 == ring) {
+      chamberBounds[0] = 51.00 / 2;  // (+-)x1 shorter
+      chamberBounds[1] = 83.74 / 2;  // (+-)x2 longer
+      chamberBounds[2] = 174.49 / 2;
       y_center = -0.96;
-    }
-    else{// to be investigated
-      chamberBounds[0] = 30./2;//40./2; // (+-)x1 shorter
-      chamberBounds[1] = 60./2;//100./2; // (+-)x2 longer 
-      chamberBounds[2] = 160./2;//142./2;
+    } else {                        // to be investigated
+      chamberBounds[0] = 30. / 2;   //40./2; // (+-)x1 shorter
+      chamberBounds[1] = 60. / 2;   //100./2; // (+-)x2 longer
+      chamberBounds[2] = 160. / 2;  //142./2;
       y_center = 0.;
     }
   }
   double yUp = chamberBounds[2] + y_center;
-  double yDown = - chamberBounds[2] + y_center;
-  double xBound1Shifted = chamberBounds[0]-distanceFromDeadZone;//
-  double xBound2Shifted = chamberBounds[1]-distanceFromDeadZone;//
-  double lineSlope = (yUp - yDown)/(xBound2Shifted-xBound1Shifted);
-  double lineConst = yUp - lineSlope*xBound2Shifted;
-  double yBoundary =  lineSlope*abs(xLocal) + lineConst;
+  double yDown = -chamberBounds[2] + y_center;
+  double xBound1Shifted = chamberBounds[0] - distanceFromDeadZone;  //
+  double xBound2Shifted = chamberBounds[1] - distanceFromDeadZone;  //
+  double lineSlope = (yUp - yDown) / (xBound2Shifted - xBound1Shifted);
+  double lineConst = yUp - lineSlope * xBound2Shifted;
+  double yBoundary = lineSlope * abs(xLocal) + lineConst;
   pass = checkLocal(yLocal, yBoundary, station, ring);
   return pass;
 }
 
-bool CSCEfficiency::checkLocal(double yLocal, double yBoundary, int station, int ring){
-//---- check if it is in a good local region (sensitive area - geometrical and HV boundaries excluded) 
+bool CSCEfficiency::checkLocal(double yLocal, double yBoundary, int station, int ring) {
+  //---- check if it is in a good local region (sensitive area - geometrical and HV boundaries excluded)
   bool pass = false;
-  std::vector <float> deadZoneCenter(6);
-  const float deadZoneHalf = 0.32*7/2;// wire spacing * (wires missing + 1)/2
-  float cutZone = deadZoneHalf + distanceFromDeadZone;//cm
+  std::vector<float> deadZoneCenter(6);
+  const float deadZoneHalf = 0.32 * 7 / 2;              // wire spacing * (wires missing + 1)/2
+  float cutZone = deadZoneHalf + distanceFromDeadZone;  //cm
   //---- hardcoded... not good
-  if(station>1 && station<5){
-    if(2==ring){
-      deadZoneCenter[0]= -162.48 ;
+  if (station > 1 && station < 5) {
+    if (2 == ring) {
+      deadZoneCenter[0] = -162.48;
       deadZoneCenter[1] = -81.8744;
       deadZoneCenter[2] = -21.18165;
       deadZoneCenter[3] = 39.51105;
       deadZoneCenter[4] = 100.2939;
       deadZoneCenter[5] = 160.58;
-      
-      if(yLocal >yBoundary &&
-	 ((yLocal> deadZoneCenter[0] + cutZone && yLocal< deadZoneCenter[1] - cutZone) ||
-	  (yLocal> deadZoneCenter[1] + cutZone && yLocal< deadZoneCenter[2] - cutZone) ||
-	  (yLocal> deadZoneCenter[2] + cutZone && yLocal< deadZoneCenter[3] - cutZone) ||
-	  (yLocal> deadZoneCenter[3] + cutZone && yLocal< deadZoneCenter[4] - cutZone) ||
-	  (yLocal> deadZoneCenter[4] + cutZone && yLocal< deadZoneCenter[5] - cutZone))){
-	pass = true;
+
+      if (yLocal > yBoundary && ((yLocal > deadZoneCenter[0] + cutZone && yLocal < deadZoneCenter[1] - cutZone) ||
+                                 (yLocal > deadZoneCenter[1] + cutZone && yLocal < deadZoneCenter[2] - cutZone) ||
+                                 (yLocal > deadZoneCenter[2] + cutZone && yLocal < deadZoneCenter[3] - cutZone) ||
+                                 (yLocal > deadZoneCenter[3] + cutZone && yLocal < deadZoneCenter[4] - cutZone) ||
+                                 (yLocal > deadZoneCenter[4] + cutZone && yLocal < deadZoneCenter[5] - cutZone))) {
+        pass = true;
+      }
+    } else if (1 == ring) {
+      if (2 == station) {
+        deadZoneCenter[0] = -95.94;
+        deadZoneCenter[1] = -27.47;
+        deadZoneCenter[2] = 33.67;
+        deadZoneCenter[3] = 93.72;
+      } else if (3 == station) {
+        deadZoneCenter[0] = -85.97;
+        deadZoneCenter[1] = -36.21;
+        deadZoneCenter[2] = 23.68;
+        deadZoneCenter[3] = 84.04;
+      } else if (4 == station) {
+        deadZoneCenter[0] = -75.82;
+        deadZoneCenter[1] = -26.14;
+        deadZoneCenter[2] = 23.85;
+        deadZoneCenter[3] = 73.91;
+      }
+      if (yLocal > yBoundary && ((yLocal > deadZoneCenter[0] + cutZone && yLocal < deadZoneCenter[1] - cutZone) ||
+                                 (yLocal > deadZoneCenter[1] + cutZone && yLocal < deadZoneCenter[2] - cutZone) ||
+                                 (yLocal > deadZoneCenter[2] + cutZone && yLocal < deadZoneCenter[3] - cutZone))) {
+        pass = true;
       }
     }
-    else if(1==ring){
-      if(2==station){
-	deadZoneCenter[0]= -95.94 ;
-	deadZoneCenter[1] = -27.47;
-	deadZoneCenter[2] = 33.67;
-	deadZoneCenter[3] = 93.72;
-      }
-      else if(3==station){
-	deadZoneCenter[0]= -85.97 ;
-	deadZoneCenter[1] = -36.21;
-	deadZoneCenter[2] = 23.68;
-	deadZoneCenter[3] = 84.04;
-      }
-      else if(4==station){
-	deadZoneCenter[0]= -75.82;
-	deadZoneCenter[1] = -26.14;
-	deadZoneCenter[2] = 23.85;
-	deadZoneCenter[3] = 73.91;
-      }
-      if(yLocal >yBoundary &&
-	 ((yLocal> deadZoneCenter[0] + cutZone && yLocal< deadZoneCenter[1] - cutZone) ||
-	  (yLocal> deadZoneCenter[1] + cutZone && yLocal< deadZoneCenter[2] - cutZone) ||
-	  (yLocal> deadZoneCenter[2] + cutZone && yLocal< deadZoneCenter[3] - cutZone))){
-	pass = true;
-      }
-    }
-  }
-  else if(1==station){
-    if(3==ring){
-      deadZoneCenter[0]= -83.155 ;
+  } else if (1 == station) {
+    if (3 == ring) {
+      deadZoneCenter[0] = -83.155;
       deadZoneCenter[1] = -22.7401;
       deadZoneCenter[2] = 27.86665;
       deadZoneCenter[3] = 81.005;
-      if(yLocal > yBoundary &&
-	 ((yLocal> deadZoneCenter[0] + cutZone && yLocal< deadZoneCenter[1] - cutZone) ||
-	  (yLocal> deadZoneCenter[1] + cutZone && yLocal< deadZoneCenter[2] - cutZone) ||
-	  (yLocal> deadZoneCenter[2] + cutZone && yLocal< deadZoneCenter[3] - cutZone))){
-	pass = true;
+      if (yLocal > yBoundary && ((yLocal > deadZoneCenter[0] + cutZone && yLocal < deadZoneCenter[1] - cutZone) ||
+                                 (yLocal > deadZoneCenter[1] + cutZone && yLocal < deadZoneCenter[2] - cutZone) ||
+                                 (yLocal > deadZoneCenter[2] + cutZone && yLocal < deadZoneCenter[3] - cutZone))) {
+        pass = true;
       }
-    }
-    else if(2==ring){
-      deadZoneCenter[0]= -86.285 ;
+    } else if (2 == ring) {
+      deadZoneCenter[0] = -86.285;
       deadZoneCenter[1] = -32.88305;
       deadZoneCenter[2] = 32.867423;
       deadZoneCenter[3] = 88.205;
-      if(yLocal > (yBoundary) &&
-	 ((yLocal> deadZoneCenter[0] + cutZone && yLocal< deadZoneCenter[1] - cutZone) ||
-	  (yLocal> deadZoneCenter[1] + cutZone && yLocal< deadZoneCenter[2] - cutZone) ||
-	  (yLocal> deadZoneCenter[2] + cutZone && yLocal< deadZoneCenter[3] - cutZone))){
-	pass = true;
+      if (yLocal > (yBoundary) && ((yLocal > deadZoneCenter[0] + cutZone && yLocal < deadZoneCenter[1] - cutZone) ||
+                                   (yLocal > deadZoneCenter[1] + cutZone && yLocal < deadZoneCenter[2] - cutZone) ||
+                                   (yLocal > deadZoneCenter[2] + cutZone && yLocal < deadZoneCenter[3] - cutZone))) {
+        pass = true;
       }
-    }
-    else{
-      deadZoneCenter[0]= -81.0;
+    } else {
+      deadZoneCenter[0] = -81.0;
       deadZoneCenter[1] = 81.0;
-      if(yLocal > (yBoundary) &&
-	 ((yLocal> deadZoneCenter[0] + cutZone && yLocal< deadZoneCenter[1] - cutZone) )){
-	pass = true;
+      if (yLocal > (yBoundary) && ((yLocal > deadZoneCenter[0] + cutZone && yLocal < deadZoneCenter[1] - cutZone))) {
+        pass = true;
       }
     }
   }
   return pass;
 }
 
-void CSCEfficiency::fillDigiInfo(edm::Handle<CSCALCTDigiCollection> &alcts, 
-				 edm::Handle<CSCCLCTDigiCollection> &clcts, 
-				 edm::Handle<CSCCorrelatedLCTDigiCollection> &correlatedlcts,
-				 edm::Handle<CSCWireDigiCollection> &wires,
-				 edm::Handle<CSCStripDigiCollection> &strips,
-				 edm::Handle<edm::PSimHitContainer> &simhits,
-				 edm::Handle<CSCRecHit2DCollection> &rechits,
-				 edm::Handle<CSCSegmentCollection> &segments,
-				 edm::ESHandle<CSCGeometry> &cscGeom){
-  for(int iE=0;iE<2;iE++){
-    for(int iS=0;iS<4;iS++){
-      for(int iR=0;iR<4;iR++){
-	for(int iC=0;iC<NumCh;iC++){
-	  allSegments[iE][iS][iR][iC].clear(); 
-	  allCLCT[iE][iS][iR][iC] = allALCT[iE][iS][iR][iC] = allCorrLCT[iE][iS][iR][iC] = false;
-	  for(int iL=0;iL<6;iL++){
-	    allStrips[iE][iS][iR][iC][iL].clear(); 
-	    allWG[iE][iS][iR][iC][iL].clear();
-	    allRechits[iE][iS][iR][iC][iL].clear(); 
-	    allSimhits[iE][iS][iR][iC][iL].clear(); 
-	  }
-	}
+void CSCEfficiency::fillDigiInfo(edm::Handle<CSCALCTDigiCollection> &alcts,
+                                 edm::Handle<CSCCLCTDigiCollection> &clcts,
+                                 edm::Handle<CSCCorrelatedLCTDigiCollection> &correlatedlcts,
+                                 edm::Handle<CSCWireDigiCollection> &wires,
+                                 edm::Handle<CSCStripDigiCollection> &strips,
+                                 edm::Handle<edm::PSimHitContainer> &simhits,
+                                 edm::Handle<CSCRecHit2DCollection> &rechits,
+                                 edm::Handle<CSCSegmentCollection> &segments,
+                                 edm::ESHandle<CSCGeometry> &cscGeom) {
+  for (int iE = 0; iE < 2; iE++) {
+    for (int iS = 0; iS < 4; iS++) {
+      for (int iR = 0; iR < 4; iR++) {
+        for (int iC = 0; iC < NumCh; iC++) {
+          allSegments[iE][iS][iR][iC].clear();
+          allCLCT[iE][iS][iR][iC] = allALCT[iE][iS][iR][iC] = allCorrLCT[iE][iS][iR][iC] = false;
+          for (int iL = 0; iL < 6; iL++) {
+            allStrips[iE][iS][iR][iC][iL].clear();
+            allWG[iE][iS][iR][iC][iL].clear();
+            allRechits[iE][iS][iR][iC][iL].clear();
+            allSimhits[iE][iS][iR][iC][iL].clear();
+          }
+        }
       }
     }
   }
   //
-  if(useDigis){
+  if (useDigis) {
     fillLCT_info(alcts, clcts, correlatedlcts);
     fillWG_info(wires, cscGeom);
     fillStrips_info(strips);
   }
   fillRechitsSegments_info(rechits, segments, cscGeom);
-  if(!isData){
+  if (!isData) {
     fillSimhit_info(simhits);
   }
 }
 
-
-void CSCEfficiency::fillLCT_info(edm::Handle<CSCALCTDigiCollection> &alcts, 
-				 edm::Handle<CSCCLCTDigiCollection> &clcts, 
-				 edm::Handle<CSCCorrelatedLCTDigiCollection> &correlatedlcts ){
+void CSCEfficiency::fillLCT_info(edm::Handle<CSCALCTDigiCollection> &alcts,
+                                 edm::Handle<CSCCLCTDigiCollection> &clcts,
+                                 edm::Handle<CSCCorrelatedLCTDigiCollection> &correlatedlcts) {
   //---- ALCTDigis
   int nSize = 0;
-  for (CSCALCTDigiCollection::DigiRangeIterator j=alcts->begin(); j!=alcts->end(); j++) {
+  for (CSCALCTDigiCollection::DigiRangeIterator j = alcts->begin(); j != alcts->end(); j++) {
     ++nSize;
-    const CSCDetId& id = (*j).first;
-    const CSCALCTDigiCollection::Range& range =(*j).second;
-    for (CSCALCTDigiCollection::const_iterator digiIt =
-	   range.first; digiIt!=range.second;
-	 ++digiIt){
-      // Valid digi in the chamber (or in neighbouring chamber) 
-      if((*digiIt).isValid()){
-	allALCT[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh] = true;
+    const CSCDetId &id = (*j).first;
+    const CSCALCTDigiCollection::Range &range = (*j).second;
+    for (CSCALCTDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
+      // Valid digi in the chamber (or in neighbouring chamber)
+      if ((*digiIt).isValid()) {
+        allALCT[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - FirstCh] = true;
       }
-    }// for digis in layer
-  }// end of for (j=...
+    }  // for digis in layer
+  }    // end of for (j=...
   ALCTPerEvent->Fill(nSize);
   //---- CLCTDigis
   nSize = 0;
-  for (CSCCLCTDigiCollection::DigiRangeIterator j=clcts->begin(); j!=clcts->end(); j++) {
+  for (CSCCLCTDigiCollection::DigiRangeIterator j = clcts->begin(); j != clcts->end(); j++) {
     ++nSize;
-    const CSCDetId& id = (*j).first;
+    const CSCDetId &id = (*j).first;
     std::vector<CSCCLCTDigi>::const_iterator digiIt = (*j).second.first;
     std::vector<CSCCLCTDigi>::const_iterator last = (*j).second.second;
-    for( ; digiIt != last; ++digiIt) {
-      // Valid digi in the chamber (or in neighbouring chamber) 
-      if((*digiIt).isValid()){
-	allCLCT[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh] = true;
+    for (; digiIt != last; ++digiIt) {
+      // Valid digi in the chamber (or in neighbouring chamber)
+      if ((*digiIt).isValid()) {
+        allCLCT[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - FirstCh] = true;
       }
     }
   }
   CLCTPerEvent->Fill(nSize);
   //---- CorrLCTDigis
-  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j=correlatedlcts->begin(); j!=correlatedlcts->end(); j++) {
-    const CSCDetId& id = (*j).first;
+  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j = correlatedlcts->begin(); j != correlatedlcts->end(); j++) {
+    const CSCDetId &id = (*j).first;
     std::vector<CSCCorrelatedLCTDigi>::const_iterator digiIt = (*j).second.first;
     std::vector<CSCCorrelatedLCTDigi>::const_iterator last = (*j).second.second;
-    for( ; digiIt != last; ++digiIt) {
-      // Valid digi in the chamber (or in neighbouring chamber) 
-      if((*digiIt).isValid()){
-	allCorrLCT[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh] = true;
+    for (; digiIt != last; ++digiIt) {
+      // Valid digi in the chamber (or in neighbouring chamber)
+      if ((*digiIt).isValid()) {
+        allCorrLCT[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - FirstCh] = true;
       }
     }
   }
 }
 //
-void CSCEfficiency::fillWG_info(edm::Handle<CSCWireDigiCollection> &wires, edm::ESHandle<CSCGeometry> &cscGeom){
+void CSCEfficiency::fillWG_info(edm::Handle<CSCWireDigiCollection> &wires, edm::ESHandle<CSCGeometry> &cscGeom) {
   //---- WIRE GROUPS
-  for (CSCWireDigiCollection::DigiRangeIterator j=wires->begin(); j!=wires->end(); j++) {
+  for (CSCWireDigiCollection::DigiRangeIterator j = wires->begin(); j != wires->end(); j++) {
     CSCDetId id = (CSCDetId)(*j).first;
-    const CSCLayer *layer_p = cscGeom->layer (id);
-    const CSCLayerGeometry *layerGeom = layer_p->geometry ();
+    const CSCLayer *layer_p = cscGeom->layer(id);
+    const CSCLayerGeometry *layerGeom = layer_p->geometry();
     //
     std::vector<CSCWireDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCWireDigi>::const_iterator last = (*j).second.second;
     //
-    for( ; digiItr != last; ++digiItr) {
-      std::pair < int, float > WG_pos(digiItr->getWireGroup(), layerGeom->yOfWireGroup(digiItr->getWireGroup())); 
-      std::pair <std::pair < int, float >, int >  LayerSignal(WG_pos, digiItr->getTimeBin()); 
-      
+    for (; digiItr != last; ++digiItr) {
+      std::pair<int, float> WG_pos(digiItr->getWireGroup(), layerGeom->yOfWireGroup(digiItr->getWireGroup()));
+      std::pair<std::pair<int, float>, int> LayerSignal(WG_pos, digiItr->getTimeBin());
+
       //---- AllWG contains basic information about WG (WG number and Y-position, time bin)
-      allWG[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh]
-	[id.layer()-1].push_back(LayerSignal);
-      if(printalot){
-	//std::cout<<" WG check : "<<std::endl;
-	//printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",id.endcap(),id.station(),id.ring(),id.chamber(),id.layer());
-	//std::cout<<" WG size = "<<allWG[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh]
-	//[id.layer()-1].size()<<std::endl;
+      allWG[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - FirstCh][id.layer() - 1].push_back(
+          LayerSignal);
+      if (printalot) {
+        //std::cout<<" WG check : "<<std::endl;
+        //printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",id.endcap(),id.station(),id.ring(),id.chamber(),id.layer());
+        //std::cout<<" WG size = "<<allWG[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh]
+        //[id.layer()-1].size()<<std::endl;
       }
     }
   }
 }
-void CSCEfficiency::fillStrips_info(edm::Handle<CSCStripDigiCollection> &strips){
+void CSCEfficiency::fillStrips_info(edm::Handle<CSCStripDigiCollection> &strips) {
   //---- STRIPS
-  for (CSCStripDigiCollection::DigiRangeIterator j=strips->begin(); j!=strips->end(); j++) {
+  for (CSCStripDigiCollection::DigiRangeIterator j = strips->begin(); j != strips->end(); j++) {
     CSCDetId id = (CSCDetId)(*j).first;
     int largestADCValue = -1;
     std::vector<CSCStripDigi>::const_iterator digiItr = (*j).second.first;
     std::vector<CSCStripDigi>::const_iterator last = (*j).second.second;
-    for( ; digiItr != last; ++digiItr) {
-      int maxADC=largestADCValue;
+    for (; digiItr != last; ++digiItr) {
+      int maxADC = largestADCValue;
       int myStrip = digiItr->getStrip();
       std::vector<int> myADCVals = digiItr->getADCCounts();
-      float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-      float threshold = 13.3 ;
+      float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+      float threshold = 13.3;
       float diff = 0.;
-      float peakADC  = -1000.;
+      float peakADC = -1000.;
       for (unsigned int iCount = 0; iCount < myADCVals.size(); iCount++) {
-	diff = (float)myADCVals[iCount]-thisPedestal;
-	if (diff > threshold) { 
-	  if (myADCVals[iCount] > largestADCValue) {
-	    largestADCValue = myADCVals[iCount];
-	  }
-	}
-	if (diff > threshold && diff > peakADC) {
-	  peakADC  = diff;
-	}
+        diff = (float)myADCVals[iCount] - thisPedestal;
+        if (diff > threshold) {
+          if (myADCVals[iCount] > largestADCValue) {
+            largestADCValue = myADCVals[iCount];
+          }
+        }
+        if (diff > threshold && diff > peakADC) {
+          peakADC = diff;
+        }
       }
-      if(largestADCValue>maxADC){// FIX IT!!!
-	maxADC = largestADCValue;
-	std::pair <int, float> LayerSignal (myStrip, peakADC);
-	
-        //---- AllStrips contains basic information about strips 
-        //---- (strip number and peak signal for most significant strip in the layer) 
-	allStrips[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-1][id.layer()-1].clear();
-	allStrips[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-1][id.layer()-1].push_back(LayerSignal);
+      if (largestADCValue > maxADC) {  // FIX IT!!!
+        maxADC = largestADCValue;
+        std::pair<int, float> LayerSignal(myStrip, peakADC);
+
+        //---- AllStrips contains basic information about strips
+        //---- (strip number and peak signal for most significant strip in the layer)
+        allStrips[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - 1][id.layer() - 1].clear();
+        allStrips[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - 1][id.layer() - 1].push_back(
+            LayerSignal);
       }
     }
   }
 }
-void CSCEfficiency::fillSimhit_info(edm::Handle<edm::PSimHitContainer> &simhits){
+void CSCEfficiency::fillSimhit_info(edm::Handle<edm::PSimHitContainer> &simhits) {
   //---- SIMHITS
   edm::PSimHitContainer::const_iterator dSHsimIter;
-  for (dSHsimIter = simhits->begin(); dSHsimIter != simhits->end(); dSHsimIter++){
+  for (dSHsimIter = simhits->begin(); dSHsimIter != simhits->end(); dSHsimIter++) {
     // Get DetID for this simHit:
     CSCDetId sId = (CSCDetId)(*dSHsimIter).detUnitId();
-    std::pair <LocalPoint, int> simHitPos((*dSHsimIter).localPosition(), (*dSHsimIter).particleType());  
-    allSimhits[sId.endcap()-1][sId.station()-1][sId.ring()-1][sId.chamber()-FirstCh][sId.layer()-1].push_back(simHitPos);
+    std::pair<LocalPoint, int> simHitPos((*dSHsimIter).localPosition(), (*dSHsimIter).particleType());
+    allSimhits[sId.endcap() - 1][sId.station() - 1][sId.ring() - 1][sId.chamber() - FirstCh][sId.layer() - 1].push_back(
+        simHitPos);
   }
 }
 //
 void CSCEfficiency::fillRechitsSegments_info(edm::Handle<CSCRecHit2DCollection> &rechits,
-					     edm::Handle<CSCSegmentCollection> &segments,
-					     edm::ESHandle<CSCGeometry> &cscGeom
-					     ){
+                                             edm::Handle<CSCSegmentCollection> &segments,
+                                             edm::ESHandle<CSCGeometry> &cscGeom) {
   //---- RECHITS AND SEGMENTS
-  //---- Loop over rechits 
-  if (printalot){ 
+  //---- Loop over rechits
+  if (printalot) {
     //printf("\tGet the recHits collection.\t ");
-    printf("  The size of the rechit collection is %i\n",int(rechits->size()));
+    printf("  The size of the rechit collection is %i\n", int(rechits->size()));
     //printf("\t...start loop over rechits...\n");
   }
   recHitsPerEvent->Fill(rechits->size());
   //---- Build iterator for rechits and loop :
   CSCRecHit2DCollection::const_iterator recIt;
   for (recIt = rechits->begin(); recIt != rechits->end(); recIt++) {
-    //---- Find chamber with rechits in CSC 
+    //---- Find chamber with rechits in CSC
     CSCDetId id = (CSCDetId)(*recIt).cscDetId();
-    if (printalot){
-      const CSCLayer* csclayer = cscGeom->layer( id);
-      LocalPoint rhitlocal = (*recIt).localPosition();  
-      LocalError rerrlocal = (*recIt).localPositionError();  
-      GlobalPoint rhitglobal= csclayer->toGlobal(rhitlocal);
-      printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",id.endcap(),id.station(),id.ring(),id.chamber(),id.layer());
+    if (printalot) {
+      const CSCLayer *csclayer = cscGeom->layer(id);
+      LocalPoint rhitlocal = (*recIt).localPosition();
+      LocalError rerrlocal = (*recIt).localPositionError();
+      GlobalPoint rhitglobal = csclayer->toGlobal(rhitlocal);
+      printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",
+             id.endcap(),
+             id.station(),
+             id.ring(),
+             id.chamber(),
+             id.layer());
       printf("\t\tx,y,z: %f, %f, %f\texx,eey,exy: %f, %f, %f\tglobal x,y,z: %f, %f, %f \n",
-	     rhitlocal.x(), rhitlocal.y(), rhitlocal.z(), rerrlocal.xx(), rerrlocal.yy(), rerrlocal.xy(),
-	     rhitglobal.x(), rhitglobal.y(), rhitglobal.z());
+             rhitlocal.x(),
+             rhitlocal.y(),
+             rhitlocal.z(),
+             rerrlocal.xx(),
+             rerrlocal.yy(),
+             rerrlocal.xy(),
+             rhitglobal.x(),
+             rhitglobal.y(),
+             rhitglobal.z());
     }
-    std::pair <LocalPoint, bool> recHitPos((*recIt).localPosition(), false);  
-    allRechits[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh][id.layer()-1].push_back(recHitPos);
+    std::pair<LocalPoint, bool> recHitPos((*recIt).localPosition(), false);
+    allRechits[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - FirstCh][id.layer() - 1].push_back(
+        recHitPos);
   }
   //---- "Empty" chambers
-  for(int iE=0;iE<2;iE++){
-    for(int iS=0;iS<4;iS++){
-      for(int iR=0;iR<4;iR++){
-	for(int iC=0;iC<NumCh;iC++){
-	  int numLayers = 0;
-	  for(int iL=0;iL<6;iL++){
-	    if(!allRechits[iE][iS][iR][iC][iL].empty()){
-	      ++numLayers; 
-	    }
-	  }
-	  if(numLayers>1){
-	    emptyChambers[iE][iS][iR][iC] = false;
-	  }
-	  else{
-	    emptyChambers[iE][iS][iR][iC] = true;
-	  }
-	}
+  for (int iE = 0; iE < 2; iE++) {
+    for (int iS = 0; iS < 4; iS++) {
+      for (int iR = 0; iR < 4; iR++) {
+        for (int iC = 0; iC < NumCh; iC++) {
+          int numLayers = 0;
+          for (int iL = 0; iL < 6; iL++) {
+            if (!allRechits[iE][iS][iR][iC][iL].empty()) {
+              ++numLayers;
+            }
+          }
+          if (numLayers > 1) {
+            emptyChambers[iE][iS][iR][iC] = false;
+          } else {
+            emptyChambers[iE][iS][iR][iC] = true;
+          }
+        }
       }
     }
   }
 
   //
-  if (printalot){
+  if (printalot) {
     printf("  The size of the segment collection is %i\n", int(segments->size()));
     //printf("\t...start loop over segments...\n");
   }
   segmentsPerEvent->Fill(segments->size());
-  for(CSCSegmentCollection::const_iterator it = segments->begin(); it != segments->end(); it++) {
-    CSCDetId id  = (CSCDetId)(*it).cscDetId();
-    StHist[id.endcap()-1][id.station()-1].segmentChi2_ndf->Fill((*it).chi2()/(*it).degreesOfFreedom());
-    StHist[id.endcap()-1][id.station()-1].hitsInSegment->Fill((*it).nRecHits());
-    if (printalot){ 
-      printf("\tendcap/station/ring/chamber: %i %i %i %i\n",
-	     id.endcap(),id.station(),id.ring(),id.chamber());
-      std::cout<<"\tposition(loc) = "<<(*it).localPosition()<<" error(loc) = "<<(*it).localPositionError()<<std::endl;
-      std::cout<<"\t chi2/ndf = "<<(*it).chi2()/(*it).degreesOfFreedom()<<" nhits = "<<(*it).nRecHits() <<std::endl;
-
+  for (CSCSegmentCollection::const_iterator it = segments->begin(); it != segments->end(); it++) {
+    CSCDetId id = (CSCDetId)(*it).cscDetId();
+    StHist[id.endcap() - 1][id.station() - 1].segmentChi2_ndf->Fill((*it).chi2() / (*it).degreesOfFreedom());
+    StHist[id.endcap() - 1][id.station() - 1].hitsInSegment->Fill((*it).nRecHits());
+    if (printalot) {
+      printf("\tendcap/station/ring/chamber: %i %i %i %i\n", id.endcap(), id.station(), id.ring(), id.chamber());
+      std::cout << "\tposition(loc) = " << (*it).localPosition() << " error(loc) = " << (*it).localPositionError()
+                << std::endl;
+      std::cout << "\t chi2/ndf = " << (*it).chi2() / (*it).degreesOfFreedom() << " nhits = " << (*it).nRecHits()
+                << std::endl;
     }
-    allSegments[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh].push_back
-      (make_pair((*it).localPosition(), (*it).localDirection()));
-
+    allSegments[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - FirstCh].push_back(
+        make_pair((*it).localPosition(), (*it).localDirection()));
 
     //---- try to get the CSC recHits that contribute to this segment.
     //if (printalot) printf("\tGet the recHits for this segment.\t");
     std::vector<CSCRecHit2D> theseRecHits = (*it).specificRecHits();
     int nRH = (*it).nRecHits();
-    if (printalot){
+    if (printalot) {
       printf("\tGet the recHits for this segment.\t");
-      printf("    nRH = %i\n",nRH);
+      printf("    nRH = %i\n", nRH);
     }
     //---- Find which of the rechits in the chamber is in the segment
     int layerRH = 0;
-    for ( vector<CSCRecHit2D>::const_iterator iRH = theseRecHits.begin(); iRH != theseRecHits.end(); iRH++) {
+    for (vector<CSCRecHit2D>::const_iterator iRH = theseRecHits.begin(); iRH != theseRecHits.end(); iRH++) {
       ++layerRH;
       CSCDetId idRH = (CSCDetId)(*iRH).cscDetId();
-      if(printalot){ 
-	printf("\t%i RH\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",
-	       layerRH,idRH.endcap(),idRH.station(),idRH.ring(),idRH.chamber(),idRH.layer());
+      if (printalot) {
+        printf("\t%i RH\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",
+               layerRH,
+               idRH.endcap(),
+               idRH.station(),
+               idRH.ring(),
+               idRH.chamber(),
+               idRH.layer());
       }
-      for(size_t jRH = 0; 
-	  jRH<allRechits[idRH.endcap()-1][idRH.station()-1][idRH.ring()-1][idRH.chamber()-FirstCh][idRH.layer()-1].size();
-	  ++jRH){
-	float xDiff = iRH->localPosition().x() - 
-	  allRechits[idRH.endcap()-1][idRH.station()-1][idRH.ring()-1][idRH.chamber()-FirstCh][idRH.layer()-1][jRH].first.x();
-	float yDiff = iRH->localPosition().y() - 
-	  allRechits[idRH.endcap()-1][idRH.station()-1][idRH.ring()-1][idRH.chamber()-FirstCh][idRH.layer()-1][jRH].first.y();
-	if(fabs(xDiff)<0.0001 && fabs(yDiff)<0.0001){
-	  std::pair <LocalPoint, bool> 
-	    recHitPos(allRechits[idRH.endcap()-1][idRH.station()-1][idRH.ring()-1][idRH.chamber()-FirstCh][idRH.layer()-1][jRH].first, true);
-	  allRechits[idRH.endcap()-1][idRH.station()-1][idRH.ring()-1][idRH.chamber()-FirstCh][idRH.layer()-1][jRH] = recHitPos;
-	  if(printalot){ 
-	    std::cout<<" number of the rechit (from zero) in the segment = "<< jRH<<std::endl;
-	  }
-	}
+      for (size_t jRH = 0;
+           jRH <
+           allRechits[idRH.endcap() - 1][idRH.station() - 1][idRH.ring() - 1][idRH.chamber() - FirstCh][idRH.layer() - 1]
+               .size();
+           ++jRH) {
+        float xDiff = iRH->localPosition().x() - allRechits[idRH.endcap() - 1][idRH.station() - 1][idRH.ring() - 1]
+                                                           [idRH.chamber() - FirstCh][idRH.layer() - 1][jRH]
+                                                               .first.x();
+        float yDiff = iRH->localPosition().y() - allRechits[idRH.endcap() - 1][idRH.station() - 1][idRH.ring() - 1]
+                                                           [idRH.chamber() - FirstCh][idRH.layer() - 1][jRH]
+                                                               .first.y();
+        if (fabs(xDiff) < 0.0001 && fabs(yDiff) < 0.0001) {
+          std::pair<LocalPoint, bool> recHitPos(allRechits[idRH.endcap() - 1][idRH.station() - 1][idRH.ring() - 1]
+                                                          [idRH.chamber() - FirstCh][idRH.layer() - 1][jRH]
+                                                              .first,
+                                                true);
+          allRechits[idRH.endcap() - 1][idRH.station() - 1][idRH.ring() - 1][idRH.chamber() - FirstCh][idRH.layer() - 1]
+                    [jRH] = recHitPos;
+          if (printalot) {
+            std::cout << " number of the rechit (from zero) in the segment = " << jRH << std::endl;
+          }
+        }
       }
     }
   }
 }
 //
 
-void CSCEfficiency::ringCandidates(int station, float feta, std::map <std::string, bool> & chamberTypes){
+void CSCEfficiency::ringCandidates(int station, float feta, std::map<std::string, bool> &chamberTypes) {
   // yeah, hardcoded again...
-  switch (station){
-  case 1:
-    if(feta>0.85 && feta<1.18){//ME13
-      chamberTypes["ME13"] = true;
-    }      
-    if(feta>1.18 && feta<1.7){//ME12
-      chamberTypes["ME12"] = true;
-    }
-    if(feta>1.5 && feta<2.45){//ME11
-      chamberTypes["ME11"] = true;
-    }
-    break;
-  case 2:
-    if(feta>0.95 && feta<1.6){//ME22
-      chamberTypes["ME22"] = true;
-      
-    }  
-    if(feta>1.55 && feta<2.45){//ME21
-      chamberTypes["ME21"] = true;
-    }
-    break;
-  case 3:
-    if(feta>1.08 && feta<1.72){//ME32
-      chamberTypes["ME32"] = true;
-      
-    }  
-    if(feta>1.69 && feta<2.45){//ME31
-      chamberTypes["ME31"] = true;
-    }
-    break;
-  case 4:
-    if(feta>1.78 && feta<2.45){//ME41
-      chamberTypes["ME41"] = true;
-    }
-    break;
-  default:
-    break;
+  switch (station) {
+    case 1:
+      if (feta > 0.85 && feta < 1.18) {  //ME13
+        chamberTypes["ME13"] = true;
+      }
+      if (feta > 1.18 && feta < 1.7) {  //ME12
+        chamberTypes["ME12"] = true;
+      }
+      if (feta > 1.5 && feta < 2.45) {  //ME11
+        chamberTypes["ME11"] = true;
+      }
+      break;
+    case 2:
+      if (feta > 0.95 && feta < 1.6) {  //ME22
+        chamberTypes["ME22"] = true;
+      }
+      if (feta > 1.55 && feta < 2.45) {  //ME21
+        chamberTypes["ME21"] = true;
+      }
+      break;
+    case 3:
+      if (feta > 1.08 && feta < 1.72) {  //ME32
+        chamberTypes["ME32"] = true;
+      }
+      if (feta > 1.69 && feta < 2.45) {  //ME31
+        chamberTypes["ME31"] = true;
+      }
+      break;
+    case 4:
+      if (feta > 1.78 && feta < 2.45) {  //ME41
+        chamberTypes["ME41"] = true;
+      }
+      break;
+    default:
+      break;
   }
 }
 //
-void CSCEfficiency::chamberCandidates(int station, int ring, float phi, std::vector <int> &coupleOfChambers){
+void CSCEfficiency::chamberCandidates(int station, int ring, float phi, std::vector<int> &coupleOfChambers) {
   coupleOfChambers.clear();
   // -pi< phi<+pi
-  float phi_zero = 0.;// check! the phi at the "edge" of Ch 1
-  float phi_const = 2.*M_PI/36.;
+  float phi_zero = 0.;  // check! the phi at the "edge" of Ch 1
+  float phi_const = 2. * M_PI / 36.;
   int last_chamber = 36;
   int first_chamber = 1;
-  if(1 != station && 1==ring){ // 18 chambers in the ring
-    phi_const*=2;
+  if (1 != station && 1 == ring) {  // 18 chambers in the ring
+    phi_const *= 2;
     last_chamber /= 2;
   }
-  if(phi<0.){
-    if (printalot) std::cout<<" info: negative phi = "<<phi<<std::endl;
-    phi += 2*M_PI;
+  if (phi < 0.) {
+    if (printalot)
+      std::cout << " info: negative phi = " << phi << std::endl;
+    phi += 2 * M_PI;
   }
-  float chamber_float = (phi - phi_zero)/phi_const;
+  float chamber_float = (phi - phi_zero) / phi_const;
   int chamber_int = int(chamber_float);
-  if (chamber_float - float(chamber_int) -0.5 <0.){
-    if(0!=chamber_int ){
+  if (chamber_float - float(chamber_int) - 0.5 < 0.) {
+    if (0 != chamber_int) {
       coupleOfChambers.push_back(chamber_int);
-    }
-    else{
+    } else {
       coupleOfChambers.push_back(last_chamber);
     }
-    coupleOfChambers.push_back(chamber_int+1); 
-    
-  }
-  else{
-    coupleOfChambers.push_back(chamber_int+1);
-    if(last_chamber!=chamber_int+1){
-      coupleOfChambers.push_back(chamber_int+2);
-    } 
-    else{
+    coupleOfChambers.push_back(chamber_int + 1);
+
+  } else {
+    coupleOfChambers.push_back(chamber_int + 1);
+    if (last_chamber != chamber_int + 1) {
+      coupleOfChambers.push_back(chamber_int + 2);
+    } else {
       coupleOfChambers.push_back(first_chamber);
     }
   }
-  if (printalot) std::cout<<" phi = "<<phi<<" phi_zero = "<<phi_zero<<" phi_const = "<<phi_const<<
-    " candidate chambers: first ch = "<<coupleOfChambers[0]<<" second ch = "<<coupleOfChambers[1]<<std::endl;
+  if (printalot)
+    std::cout << " phi = " << phi << " phi_zero = " << phi_zero << " phi_const = " << phi_const
+              << " candidate chambers: first ch = " << coupleOfChambers[0] << " second ch = " << coupleOfChambers[1]
+              << std::endl;
 }
 
 //
-bool CSCEfficiency::efficienciesPerChamber(CSCDetId & id, const CSCChamber* cscChamber, FreeTrajectoryState &ftsChamber){
+bool CSCEfficiency::efficienciesPerChamber(CSCDetId &id,
+                                           const CSCChamber *cscChamber,
+                                           FreeTrajectoryState &ftsChamber) {
   int ec, st, rg, ch, secondRing;
   returnTypes(id, ec, st, rg, ch, secondRing);
 
   LocalVector localDir = cscChamber->toLocal(ftsChamber.momentum());
-  if(printalot){
-    std::cout<<" global dir = "<<ftsChamber.momentum()<<std::endl;
-    std::cout<<" local dir = "<<localDir<<std::endl;
-    std::cout<<" local theta = "<<localDir.theta()<<std::endl;
+  if (printalot) {
+    std::cout << " global dir = " << ftsChamber.momentum() << std::endl;
+    std::cout << " local dir = " << localDir << std::endl;
+    std::cout << " local theta = " << localDir.theta() << std::endl;
   }
-  float dxdz = localDir.x()/localDir.z();
-  float dydz = localDir.y()/localDir.z();
-  if(2==st || 3==st){
-    if(printalot){
-      std::cout<<"st 3 or 4 ... flip dy/dz"<<std::endl;
+  float dxdz = localDir.x() / localDir.z();
+  float dydz = localDir.y() / localDir.z();
+  if (2 == st || 3 == st) {
+    if (printalot) {
+      std::cout << "st 3 or 4 ... flip dy/dz" << std::endl;
     }
-    dydz = - dydz;
+    dydz = -dydz;
   }
-  if(printalot){
-    std::cout<<"dy/dz = "<<dydz<<std::endl;
+  if (printalot) {
+    std::cout << "dy/dz = " << dydz << std::endl;
   }
   // Apply angle cut
   bool out = true;
-  if(applyIPangleCuts){
-    if(dydz>local_DY_DZ_Max || dydz<local_DY_DZ_Min || fabs(dxdz)>local_DX_DZ_Max){ 
+  if (applyIPangleCuts) {
+    if (dydz > local_DY_DZ_Max || dydz < local_DY_DZ_Min || fabs(dxdz) > local_DX_DZ_Max) {
       out = false;
     }
   }
@@ -1077,91 +1090,87 @@ bool CSCEfficiency::efficienciesPerChamber(CSCDetId & id, const CSCChamber* cscC
   bool firstCondition = !allSegments[ec][st][rg][ch].empty() ? true : false;
   bool secondCondition = false;
   //---- ME1 is special as usual - ME1a and ME1b are actually one chamber
-  if(secondRing>-1){
+  if (secondRing > -1) {
     secondCondition = !allSegments[ec][st][secondRing][ch].empty() ? true : false;
   }
-  if(firstCondition || secondCondition){
-    if(out){
+  if (firstCondition || secondCondition) {
+    if (out) {
       ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(1);
-    }  
-  }
-  else{
-    if(out){
+    }
+  } else {
+    if (out) {
       ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(0);
-    } 
+    }
   }
 
-  if(useDigis){
+  if (useDigis) {
     // ALCTs
     firstCondition = allALCT[ec][st][rg][ch];
     secondCondition = false;
-    if(secondRing>-1){
+    if (secondRing > -1) {
       secondCondition = allALCT[ec][st][secondRing][ch];
     }
-    if(firstCondition || secondCondition){
-      if(out){
-	ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(3);
+    if (firstCondition || secondCondition) {
+      if (out) {
+        ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(3);
       }
-      // always apply partial angle cuts for this kind of histos 
-      if(fabs(dxdz)<local_DX_DZ_Max){
-	StHist[ec][st].EfficientALCT_momTheta->Fill(ftsChamber.momentum().theta());
-	ChHist[ec][st][rg][ch].EfficientALCT_dydz->Fill(dydz);
+      // always apply partial angle cuts for this kind of histos
+      if (fabs(dxdz) < local_DX_DZ_Max) {
+        StHist[ec][st].EfficientALCT_momTheta->Fill(ftsChamber.momentum().theta());
+        ChHist[ec][st][rg][ch].EfficientALCT_dydz->Fill(dydz);
+      }
+    } else {
+      if (out) {
+        ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(2);
+      }
+      if (fabs(dxdz) < local_DX_DZ_Max) {
+        StHist[ec][st].InefficientALCT_momTheta->Fill(ftsChamber.momentum().theta());
+        ChHist[ec][st][rg][ch].InefficientALCT_dydz->Fill(dydz);
+      }
+      if (printalot) {
+        std::cout << " missing ALCT (dy/dz = " << dydz << ")";
+        printf("\t\tendcap/station/ring/chamber: %i/%i/%i/%i\n", ec + 1, st + 1, rg + 1, ch + 1);
       }
     }
-    else{
-      if(out){
-	ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(2);
-      }
-      if(fabs(dxdz)<local_DX_DZ_Max){ 
-	StHist[ec][st].InefficientALCT_momTheta->Fill(ftsChamber.momentum().theta());
-	ChHist[ec][st][rg][ch].InefficientALCT_dydz->Fill(dydz);
-      }
-      if(printalot){
-	std::cout<<" missing ALCT (dy/dz = "<<dydz<<")";
-	printf("\t\tendcap/station/ring/chamber: %i/%i/%i/%i\n",ec+1,st+1,rg+1,ch+1);
-      }
-    }
-    
+
     // CLCTs
     firstCondition = allCLCT[ec][st][rg][ch];
     secondCondition = false;
-    if(secondRing>-1){
+    if (secondRing > -1) {
       secondCondition = allCLCT[ec][st][secondRing][ch];
     }
-    if(firstCondition || secondCondition){
-      if(out){
-	ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(5);
+    if (firstCondition || secondCondition) {
+      if (out) {
+        ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(5);
       }
-      if(dydz<local_DY_DZ_Max && dydz>local_DY_DZ_Min){
-	StHist[ec][st].EfficientCLCT_momPhi->Fill(ftsChamber.momentum().phi() );// - phi chamber...
-	ChHist[ec][st][rg][ch].EfficientCLCT_dxdz->Fill(dxdz);
+      if (dydz < local_DY_DZ_Max && dydz > local_DY_DZ_Min) {
+        StHist[ec][st].EfficientCLCT_momPhi->Fill(ftsChamber.momentum().phi());  // - phi chamber...
+        ChHist[ec][st][rg][ch].EfficientCLCT_dxdz->Fill(dxdz);
+      }
+    } else {
+      if (out) {
+        ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(4);
+      }
+      if (dydz < local_DY_DZ_Max && dydz > local_DY_DZ_Min) {
+        StHist[ec][st].InefficientCLCT_momPhi->Fill(ftsChamber.momentum().phi());  // - phi chamber...
+        ChHist[ec][st][rg][ch].InefficientCLCT_dxdz->Fill(dxdz);
+      }
+      if (printalot) {
+        std::cout << " missing CLCT  (dx/dz = " << dxdz << ")";
+        printf("\t\tendcap/station/ring/chamber: %i/%i/%i/%i\n", ec + 1, st + 1, rg + 1, ch + 1);
       }
     }
-    else{
-      if(out){
-	ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(4);
-      }
-      if(dydz<local_DY_DZ_Max && dydz>local_DY_DZ_Min){ 
-	StHist[ec][st].InefficientCLCT_momPhi->Fill(ftsChamber.momentum().phi());// - phi chamber...
-	ChHist[ec][st][rg][ch].InefficientCLCT_dxdz->Fill(dxdz);
-      }
-      if(printalot){
-	std::cout<<" missing CLCT  (dx/dz = "<<dxdz<<")";
-	printf("\t\tendcap/station/ring/chamber: %i/%i/%i/%i\n",ec+1,st+1,rg+1,ch+1);
-      }
-    }
-    if(out){
+    if (out) {
       // CorrLCTs
       firstCondition = allCorrLCT[ec][st][rg][ch];
       secondCondition = false;
-      if(secondRing>-1){
-	secondCondition = allCorrLCT[ec][st][secondRing][ch];
+      if (secondRing > -1) {
+        secondCondition = allCorrLCT[ec][st][secondRing][ch];
       }
-      if(firstCondition || secondCondition){
-	ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(7);
-      }
-      else{
-	ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(6);
+      if (firstCondition || secondCondition) {
+        ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(7);
+      } else {
+        ChHist[ec][st][rg][ch].digiAppearanceCount->Fill(6);
       }
     }
   }
@@ -1169,110 +1178,121 @@ bool CSCEfficiency::efficienciesPerChamber(CSCDetId & id, const CSCChamber* cscC
 }
 
 //
-bool CSCEfficiency::stripWire_Efficiencies(CSCDetId & id, FreeTrajectoryState &ftsChamber){
+bool CSCEfficiency::stripWire_Efficiencies(CSCDetId &id, FreeTrajectoryState &ftsChamber) {
   int ec, st, rg, ch, secondRing;
   returnTypes(id, ec, st, rg, ch, secondRing);
 
   bool firstCondition, secondCondition;
   int missingLayers_s = 0;
   int missingLayers_wg = 0;
-  for(int iLayer=0;iLayer<6;iLayer++){
- //----Strips
-    if(printalot){ 
+  for (int iLayer = 0; iLayer < 6; iLayer++) {
+    //----Strips
+    if (printalot) {
       printf("\t%i swEff: \tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",
-	     iLayer + 1,id.endcap(),id.station(),id.ring(),id.chamber(),iLayer+1);
-      std::cout<<" size S = "<<allStrips[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh][iLayer].size()<<
-	"size W = "<<allWG[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh][iLayer].size()<<std::endl;
-
+             iLayer + 1,
+             id.endcap(),
+             id.station(),
+             id.ring(),
+             id.chamber(),
+             iLayer + 1);
+      std::cout << " size S = "
+                << allStrips[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - FirstCh][iLayer].size()
+                << "size W = "
+                << allWG[id.endcap() - 1][id.station() - 1][id.ring() - 1][id.chamber() - FirstCh][iLayer].size()
+                << std::endl;
     }
     firstCondition = !allStrips[ec][st][rg][ch][iLayer].empty() ? true : false;
     //allSegments[ec][st][rg][ch].size() ? true : false;
     secondCondition = false;
-    if(secondRing>-1){
+    if (secondRing > -1) {
       secondCondition = !allStrips[ec][st][secondRing][ch][iLayer].empty() ? true : false;
     }
-    if(firstCondition || secondCondition){
-      ChHist[ec][st][rg][ch].EfficientStrips->Fill(iLayer+1);
-    }
-    else{
-      if(printalot){ 
-	std::cout<<"missing strips ";
-	printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",id.endcap(),id.station(),id.ring(),id.chamber(),iLayer+1);
+    if (firstCondition || secondCondition) {
+      ChHist[ec][st][rg][ch].EfficientStrips->Fill(iLayer + 1);
+    } else {
+      if (printalot) {
+        std::cout << "missing strips ";
+        printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",
+               id.endcap(),
+               id.station(),
+               id.ring(),
+               id.chamber(),
+               iLayer + 1);
       }
     }
     // Wires
     firstCondition = !allWG[ec][st][rg][ch][iLayer].empty() ? true : false;
     secondCondition = false;
-    if(secondRing>-1){
+    if (secondRing > -1) {
       secondCondition = !allWG[ec][st][secondRing][ch][iLayer].empty() ? true : false;
     }
-    if(firstCondition || secondCondition){
-      ChHist[ec][st][rg][ch].EfficientWireGroups->Fill(iLayer+1);
-    }
-    else{
-      if(printalot){ 
-	std::cout<<"missing wires ";
-	printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",id.endcap(),id.station(),id.ring(),id.chamber(),iLayer+1);
+    if (firstCondition || secondCondition) {
+      ChHist[ec][st][rg][ch].EfficientWireGroups->Fill(iLayer + 1);
+    } else {
+      if (printalot) {
+        std::cout << "missing wires ";
+        printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",
+               id.endcap(),
+               id.station(),
+               id.ring(),
+               id.chamber(),
+               iLayer + 1);
       }
     }
   }
   // Normalization
-  if(6!=missingLayers_s){
+  if (6 != missingLayers_s) {
     ChHist[ec][st][rg][ch].EfficientStrips->Fill(8);
   }
-  if(6!=missingLayers_wg){
+  if (6 != missingLayers_wg) {
     ChHist[ec][st][rg][ch].EfficientWireGroups->Fill(8);
   }
   ChHist[ec][st][rg][ch].EfficientStrips->Fill(9);
   ChHist[ec][st][rg][ch].EfficientWireGroups->Fill(9);
-//
+  //
   ChHist[ec][st][rg][ch].StripWiresCorrelations->Fill(1);
-  if(missingLayers_s!=missingLayers_wg){
+  if (missingLayers_s != missingLayers_wg) {
     ChHist[ec][st][rg][ch].StripWiresCorrelations->Fill(2);
-    if(6==missingLayers_wg){
+    if (6 == missingLayers_wg) {
       ChHist[ec][st][rg][ch].StripWiresCorrelations->Fill(3);
       ChHist[ec][st][rg][ch].NoWires_momTheta->Fill(ftsChamber.momentum().theta());
     }
-    if(6==missingLayers_s){
+    if (6 == missingLayers_s) {
       ChHist[ec][st][rg][ch].StripWiresCorrelations->Fill(4);
       ChHist[ec][st][rg][ch].NoStrips_momPhi->Fill(ftsChamber.momentum().theta());
     }
-  }
-  else if(6==missingLayers_s){
+  } else if (6 == missingLayers_s) {
     ChHist[ec][st][rg][ch].StripWiresCorrelations->Fill(5);
   }
 
-  return true;	
+  return true;
 }
 //
-bool CSCEfficiency::recSimHitEfficiency(CSCDetId & id, FreeTrajectoryState &ftsChamber){
+bool CSCEfficiency::recSimHitEfficiency(CSCDetId &id, FreeTrajectoryState &ftsChamber) {
   int ec, st, rg, ch, secondRing;
   returnTypes(id, ec, st, rg, ch, secondRing);
   bool firstCondition, secondCondition;
-  for(int iLayer=0; iLayer<6;iLayer++){
+  for (int iLayer = 0; iLayer < 6; iLayer++) {
     firstCondition = !allSimhits[ec][st][rg][ch][iLayer].empty() ? true : false;
     secondCondition = false;
     int thisRing = rg;
-    if(secondRing>-1){
+    if (secondRing > -1) {
       secondCondition = !allSimhits[ec][st][secondRing][ch][iLayer].empty() ? true : false;
-      if(secondCondition){
-	thisRing = secondRing;
+      if (secondCondition) {
+        thisRing = secondRing;
       }
     }
-    if(firstCondition || secondCondition){
-      for(size_t iSH=0;
-	  iSH<allSimhits[ec][st][thisRing][ch][iLayer].size();
-	  ++iSH){
-	if(13 ==
-	   fabs(allSimhits[ec][st][thisRing][ch][iLayer][iSH].second)){
-	  ChHist[ec][st][rg][ch].SimSimhits->Fill(iLayer+1);
-	  if(!allRechits[ec][st][thisRing][ch][iLayer].empty()){
-	    ChHist[ec][st][rg][ch].SimRechits->Fill(iLayer+1);
-	  }
-	  break;
-	}
+    if (firstCondition || secondCondition) {
+      for (size_t iSH = 0; iSH < allSimhits[ec][st][thisRing][ch][iLayer].size(); ++iSH) {
+        if (13 == fabs(allSimhits[ec][st][thisRing][ch][iLayer][iSH].second)) {
+          ChHist[ec][st][rg][ch].SimSimhits->Fill(iLayer + 1);
+          if (!allRechits[ec][st][thisRing][ch][iLayer].empty()) {
+            ChHist[ec][st][rg][ch].SimRechits->Fill(iLayer + 1);
+          }
+          break;
+        }
       }
-      //---- Next is not too usefull... 
+      //---- Next is not too usefull...
       /*
       for(unsigned int iSimHits=0;
 	  iSimHits<allSimhits[id.endcap()-1][id.station()-1][id.ring()-1][id.chamber()-FirstCh][iLayer].size();
@@ -1286,157 +1306,164 @@ bool CSCEfficiency::recSimHitEfficiency(CSCDetId & id, FreeTrajectoryState &ftsC
       }
       */
       //
-    }   
+    }
   }
   return true;
 }
 
 //
-bool CSCEfficiency::recHitSegment_Efficiencies(CSCDetId & id, const CSCChamber* cscChamber, FreeTrajectoryState &ftsChamber){
+bool CSCEfficiency::recHitSegment_Efficiencies(CSCDetId &id,
+                                               const CSCChamber *cscChamber,
+                                               FreeTrajectoryState &ftsChamber) {
   int ec, st, rg, ch, secondRing;
   returnTypes(id, ec, st, rg, ch, secondRing);
   bool firstCondition, secondCondition;
 
-  std::vector <bool> missingLayers_rh(6);
-  std::vector <int> usedInSegment(6);
+  std::vector<bool> missingLayers_rh(6);
+  std::vector<int> usedInSegment(6);
   // Rechits
-  if(printalot) std::cout<<"RecHits eff"<<std::endl;
-  for(int iLayer=0;iLayer<6;++iLayer){
+  if (printalot)
+    std::cout << "RecHits eff" << std::endl;
+  for (int iLayer = 0; iLayer < 6; ++iLayer) {
     firstCondition = !allRechits[ec][st][rg][ch][iLayer].empty() ? true : false;
     secondCondition = false;
     int thisRing = rg;
-    if(secondRing>-1){
+    if (secondRing > -1) {
       secondCondition = !allRechits[ec][st][secondRing][ch][iLayer].empty() ? true : false;
-      if(secondCondition){
-	thisRing = secondRing;
+      if (secondCondition) {
+        thisRing = secondRing;
       }
     }
-    if(firstCondition || secondCondition){
-      ChHist[ec][st][rg][ch].EfficientRechits_good->Fill(iLayer+1);
-      for(size_t iR=0;
-	  iR<allRechits[ec][st][thisRing][ch][iLayer].size();
-	  ++iR){
-	if(allRechits[ec][st][thisRing][ch][iLayer][iR].second){
-	  usedInSegment[iLayer] = 1;
-	  break;
-	}
-	else{
-	  usedInSegment[iLayer] = -1;
-	}
+    if (firstCondition || secondCondition) {
+      ChHist[ec][st][rg][ch].EfficientRechits_good->Fill(iLayer + 1);
+      for (size_t iR = 0; iR < allRechits[ec][st][thisRing][ch][iLayer].size(); ++iR) {
+        if (allRechits[ec][st][thisRing][ch][iLayer][iR].second) {
+          usedInSegment[iLayer] = 1;
+          break;
+        } else {
+          usedInSegment[iLayer] = -1;
+        }
       }
-    }
-    else{
+    } else {
       missingLayers_rh[iLayer] = true;
-      if(printalot){
-	std::cout<<"missing rechits ";
-	printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",id.endcap(),id.station(),id.ring(),id.chamber(),iLayer+1);
+      if (printalot) {
+        std::cout << "missing rechits ";
+        printf("\t\tendcap/station/ring/chamber/layer: %i/%i/%i/%i/%i\n",
+               id.endcap(),
+               id.station(),
+               id.ring(),
+               id.chamber(),
+               iLayer + 1);
       }
     }
   }
   GlobalVector globalDir;
   GlobalPoint globalPos;
- // Segments
+  // Segments
   firstCondition = !allSegments[ec][st][rg][ch].empty() ? true : false;
   secondCondition = false;
   int secondSize = 0;
   int thisRing = rg;
-  if(secondRing>-1){
+  if (secondRing > -1) {
     secondCondition = !allSegments[ec][st][secondRing][ch].empty() ? true : false;
     secondSize = allSegments[ec][st][secondRing][ch].size();
-    if(secondCondition){
+    if (secondCondition) {
       thisRing = secondRing;
     }
   }
-  if(firstCondition || secondCondition){
-    if (printalot) std::cout<<"segments - start ec = "<<ec<<" st = "<<st<<" rg = "<<rg<<" ch = "<<ch<<std::endl;
-    StHist[ec][st].EfficientSegments_XY->Fill(ftsChamber.position().x(),ftsChamber.position().y());
-    if(1==allSegments[ec][st][rg][ch].size() + secondSize){
+  if (firstCondition || secondCondition) {
+    if (printalot)
+      std::cout << "segments - start ec = " << ec << " st = " << st << " rg = " << rg << " ch = " << ch << std::endl;
+    StHist[ec][st].EfficientSegments_XY->Fill(ftsChamber.position().x(), ftsChamber.position().y());
+    if (1 == allSegments[ec][st][rg][ch].size() + secondSize) {
       globalDir = cscChamber->toGlobal(allSegments[ec][st][thisRing][ch][0].second);
       globalPos = cscChamber->toGlobal(allSegments[ec][st][thisRing][ch][0].first);
       StHist[ec][st].EfficientSegments_eta->Fill(fabs(ftsChamber.position().eta()));
-      double residual = sqrt(pow(ftsChamber.position().x() - globalPos.x(),2)+
-			     pow(ftsChamber.position().y() - globalPos.y(),2)+
-			     pow(ftsChamber.position().z() - globalPos.z(),2));
-      if (printalot) std::cout<<" fts.position() = "<<ftsChamber.position()<<" segPos = "<<globalPos<<" res = "<<residual<< std::endl;
+      double residual =
+          sqrt(pow(ftsChamber.position().x() - globalPos.x(), 2) + pow(ftsChamber.position().y() - globalPos.y(), 2) +
+               pow(ftsChamber.position().z() - globalPos.z(), 2));
+      if (printalot)
+        std::cout << " fts.position() = " << ftsChamber.position() << " segPos = " << globalPos << " res = " << residual
+                  << std::endl;
       StHist[ec][st].ResidualSegments->Fill(residual);
     }
-    for(int iLayer=0;iLayer<6;++iLayer){
-      if(printalot) std::cout<<" iLayer = "<<iLayer<<" usedInSegment = "<<usedInSegment[iLayer]<<std::endl;
-      if(0!=usedInSegment[iLayer]){
-	if(-1==usedInSegment[iLayer]){
-	  ChHist[ec][st][rg][ch].InefficientSingleHits->Fill(iLayer+1);
-	}
-	ChHist[ec][st][rg][ch].AllSingleHits->Fill(iLayer+1);
+    for (int iLayer = 0; iLayer < 6; ++iLayer) {
+      if (printalot)
+        std::cout << " iLayer = " << iLayer << " usedInSegment = " << usedInSegment[iLayer] << std::endl;
+      if (0 != usedInSegment[iLayer]) {
+        if (-1 == usedInSegment[iLayer]) {
+          ChHist[ec][st][rg][ch].InefficientSingleHits->Fill(iLayer + 1);
+        }
+        ChHist[ec][st][rg][ch].AllSingleHits->Fill(iLayer + 1);
       }
       firstCondition = !allRechits[ec][st][rg][ch][iLayer].empty() ? true : false;
       secondCondition = false;
-      if(secondRing>-1){
-	secondCondition = !allRechits[ec][st][secondRing][ch][iLayer].empty() ? true : false;
+      if (secondRing > -1) {
+        secondCondition = !allRechits[ec][st][secondRing][ch][iLayer].empty() ? true : false;
       }
       float stripAngle = 99999.;
       std::vector<float> posXY(2);
       bool oneSegment = false;
-      if(1==allSegments[ec][st][rg][ch].size() + secondSize){
-	oneSegment = true;
-	const BoundPlane bp = cscChamber->layer(iLayer+1)->surface();
-	linearExtrapolation(globalPos,globalDir, bp.position().z(), posXY);
-        GlobalPoint gp_extrapol( posXY.at(0), posXY.at(1),bp.position().z());
-        const LocalPoint lp_extrapol = cscChamber->layer(iLayer+1)->toLocal(gp_extrapol);
+      if (1 == allSegments[ec][st][rg][ch].size() + secondSize) {
+        oneSegment = true;
+        const BoundPlane bp = cscChamber->layer(iLayer + 1)->surface();
+        linearExtrapolation(globalPos, globalDir, bp.position().z(), posXY);
+        GlobalPoint gp_extrapol(posXY.at(0), posXY.at(1), bp.position().z());
+        const LocalPoint lp_extrapol = cscChamber->layer(iLayer + 1)->toLocal(gp_extrapol);
         posXY.at(0) = lp_extrapol.x();
         posXY.at(1) = lp_extrapol.y();
-        int nearestStrip = cscChamber->layer(iLayer+1)->geometry()->nearestStrip(lp_extrapol);
-        stripAngle = cscChamber->layer(iLayer+1)->geometry()->stripAngle(nearestStrip) - M_PI/2. ;
+        int nearestStrip = cscChamber->layer(iLayer + 1)->geometry()->nearestStrip(lp_extrapol);
+        stripAngle = cscChamber->layer(iLayer + 1)->geometry()->stripAngle(nearestStrip) - M_PI / 2.;
       }
-      if(firstCondition || secondCondition){
-	ChHist[ec][st][rg][ch].EfficientRechits_inSegment->Fill(iLayer+1);
-	if(oneSegment){
-	  ChHist[ec][st][rg][ch].Y_EfficientRecHits_inSegment[iLayer]->Fill(posXY.at(1));
-	  ChHist[ec][st][rg][ch].Phi_EfficientRecHits_inSegment[iLayer]->Fill(stripAngle);
-	}
-      }
-      else{
-	if(oneSegment){
-	  ChHist[ec][st][rg][ch].Y_InefficientRecHits_inSegment[iLayer]->Fill(posXY.at(1));
-	  ChHist[ec][st][rg][ch].Phi_InefficientRecHits_inSegment[iLayer]->Fill(stripAngle);
-	}
+      if (firstCondition || secondCondition) {
+        ChHist[ec][st][rg][ch].EfficientRechits_inSegment->Fill(iLayer + 1);
+        if (oneSegment) {
+          ChHist[ec][st][rg][ch].Y_EfficientRecHits_inSegment[iLayer]->Fill(posXY.at(1));
+          ChHist[ec][st][rg][ch].Phi_EfficientRecHits_inSegment[iLayer]->Fill(stripAngle);
+        }
+      } else {
+        if (oneSegment) {
+          ChHist[ec][st][rg][ch].Y_InefficientRecHits_inSegment[iLayer]->Fill(posXY.at(1));
+          ChHist[ec][st][rg][ch].Phi_InefficientRecHits_inSegment[iLayer]->Fill(stripAngle);
+        }
       }
     }
-  }
-  else{
-    StHist[ec][st].InefficientSegments_XY->Fill(ftsChamber.position().x(),ftsChamber.position().y());
-    if(printalot){
-      std::cout<<"missing segment "<<std::endl;
-      printf("\t\tendcap/station/ring/chamber: %i/%i/%i/%i\n",id.endcap(),id.station(),id.ring(),id.chamber());
-      std::cout<<" fts.position() = "<<ftsChamber.position()<<std::endl;
+  } else {
+    StHist[ec][st].InefficientSegments_XY->Fill(ftsChamber.position().x(), ftsChamber.position().y());
+    if (printalot) {
+      std::cout << "missing segment " << std::endl;
+      printf("\t\tendcap/station/ring/chamber: %i/%i/%i/%i\n", id.endcap(), id.station(), id.ring(), id.chamber());
+      std::cout << " fts.position() = " << ftsChamber.position() << std::endl;
     }
   }
   // Normalization
   ChHist[ec][st][rg][ch].EfficientRechits_good->Fill(8);
-  if(allSegments[ec][st][rg][ch].size()+secondSize<2){
+  if (allSegments[ec][st][rg][ch].size() + secondSize < 2) {
     StHist[ec][st].AllSegments_eta->Fill(fabs(ftsChamber.position().eta()));
   }
-  ChHist[ec][st][rg][id.chamber()-FirstCh].EfficientRechits_inSegment->Fill(9);
+  ChHist[ec][st][rg][id.chamber() - FirstCh].EfficientRechits_inSegment->Fill(9);
 
   return true;
 }
 //
-void CSCEfficiency::returnTypes(CSCDetId & id, int &ec, int &st, int &rg, int &ch, int &secondRing){
-  ec = id.endcap()-1;
-  st = id.station()-1;
-  rg = id.ring()-1;
+void CSCEfficiency::returnTypes(CSCDetId &id, int &ec, int &st, int &rg, int &ch, int &secondRing) {
+  ec = id.endcap() - 1;
+  st = id.station() - 1;
+  rg = id.ring() - 1;
   secondRing = -1;
-  if(1==id.station() && (4==id.ring() || 1==id.ring()) ){
+  if (1 == id.station() && (4 == id.ring() || 1 == id.ring())) {
     rg = 0;
     secondRing = 3;
   }
-  ch = id.chamber()-FirstCh;
+  ch = id.chamber() - FirstCh;
 }
 
 //
-void CSCEfficiency::getFromFTS( const FreeTrajectoryState& fts,
-				CLHEP::Hep3Vector& p3, CLHEP::Hep3Vector& r3,
-				int& charge, AlgebraicSymMatrix66& cov){
-  
+void CSCEfficiency::getFromFTS(const FreeTrajectoryState &fts,
+                               CLHEP::Hep3Vector &p3,
+                               CLHEP::Hep3Vector &r3,
+                               int &charge,
+                               AlgebraicSymMatrix66 &cov) {
   GlobalVector p3GV = fts.momentum();
   GlobalPoint r3GP = fts.position();
 
@@ -1445,76 +1472,74 @@ void CSCEfficiency::getFromFTS( const FreeTrajectoryState& fts,
 
   charge = fts.charge();
   cov = fts.hasError() ? fts.cartesianError().matrix() : AlgebraicSymMatrix66();
-
 }
 
-FreeTrajectoryState CSCEfficiency::getFromCLHEP(const CLHEP::Hep3Vector& p3, const CLHEP::Hep3Vector& r3,
-                                                       int charge, const AlgebraicSymMatrix66& cov,
-                                                       const MagneticField* field){
-
+FreeTrajectoryState CSCEfficiency::getFromCLHEP(const CLHEP::Hep3Vector &p3,
+                                                const CLHEP::Hep3Vector &r3,
+                                                int charge,
+                                                const AlgebraicSymMatrix66 &cov,
+                                                const MagneticField *field) {
   GlobalVector p3GV(p3.x(), p3.y(), p3.z());
   GlobalPoint r3GP(r3.x(), r3.y(), r3.z());
   GlobalTrajectoryParameters tPars(r3GP, p3GV, charge, field);
 
   CartesianTrajectoryError tCov(cov);
 
-  return cov.kRows == 6 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars) ;
+  return cov.kRows == 6 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars);
 }
 
-void CSCEfficiency::linearExtrapolation(GlobalPoint initialPosition ,GlobalVector initialDirection, 
-					float zSurface, std::vector <float> &posZY){
-  double paramLine =  lineParameter(initialPosition.z(), zSurface, initialDirection.z());
-  double xPosition = extrapolate1D(initialPosition.x(), initialDirection.x(),paramLine);
-  double yPosition = extrapolate1D(initialPosition.y(), initialDirection.y(),paramLine);
+void CSCEfficiency::linearExtrapolation(GlobalPoint initialPosition,
+                                        GlobalVector initialDirection,
+                                        float zSurface,
+                                        std::vector<float> &posZY) {
+  double paramLine = lineParameter(initialPosition.z(), zSurface, initialDirection.z());
+  double xPosition = extrapolate1D(initialPosition.x(), initialDirection.x(), paramLine);
+  double yPosition = extrapolate1D(initialPosition.y(), initialDirection.y(), paramLine);
   posZY.clear();
   posZY.push_back(xPosition);
   posZY.push_back(yPosition);
 }
 //
-double CSCEfficiency::extrapolate1D(double initPosition, double initDirection, double parameterOfTheLine){
-  double extrapolatedPosition = initPosition + initDirection*parameterOfTheLine;
+double CSCEfficiency::extrapolate1D(double initPosition, double initDirection, double parameterOfTheLine) {
+  double extrapolatedPosition = initPosition + initDirection * parameterOfTheLine;
   return extrapolatedPosition;
 }
 //
-double CSCEfficiency::lineParameter(double initZPosition, double destZPosition, double initZDirection){
-  double paramLine = (destZPosition-initZPosition)/initZDirection;
+double CSCEfficiency::lineParameter(double initZPosition, double destZPosition, double initZDirection) {
+  double paramLine = (destZPosition - initZPosition) / initZDirection;
   return paramLine;
 }
 //
-void CSCEfficiency::chooseDirection(CLHEP::Hep3Vector & innerPosition, CLHEP::Hep3Vector & outerPosition){
-
+void CSCEfficiency::chooseDirection(CLHEP::Hep3Vector &innerPosition, CLHEP::Hep3Vector &outerPosition) {
   //---- Be careful with trigger conditions too
-  if(!isIPdata){
+  if (!isIPdata) {
     float dy = outerPosition.y() - innerPosition.y();
     float dz = outerPosition.z() - innerPosition.z();
-    if(isBeamdata){
-      if(dz>0){
-	alongZ = true;
+    if (isBeamdata) {
+      if (dz > 0) {
+        alongZ = true;
+      } else {
+        alongZ = false;
       }
-      else{
-	alongZ = false;
-      }
-    }
-    else{//cosmics
-      if(dy/dz>0){
-	alongZ = false;
-      }
-      else{
-	alongZ = true;
+    } else {  //cosmics
+      if (dy / dz > 0) {
+        alongZ = false;
+      } else {
+        alongZ = true;
       }
     }
   }
 }
 //
-const Propagator* CSCEfficiency::propagator(std::string propagatorName) const {
+const Propagator *CSCEfficiency::propagator(std::string propagatorName) const {
   return &*theService->propagator(propagatorName);
 }
-  
+
 //
-TrajectoryStateOnSurface CSCEfficiency::propagate(FreeTrajectoryState & ftsStart, const BoundPlane &bpDest){
+TrajectoryStateOnSurface CSCEfficiency::propagate(FreeTrajectoryState &ftsStart, const BoundPlane &bpDest) {
   TrajectoryStateOnSurface tSOSDest;
   std::string propagatorName;
-/*
+  /*
 // it would work if cosmic muons had properly assigned direction...
   bool dzPositive = bpDest.position().z() - ftsStart.position().z() > 0 ? true : false;
  //---- Be careful with trigger conditions too
@@ -1535,149 +1560,143 @@ TrajectoryStateOnSurface CSCEfficiency::propagate(FreeTrajectoryState & ftsStart
   }
 */
   propagatorName = "SteppingHelixPropagatorAny";
-  tSOSDest = propagator(propagatorName)->propagate(ftsStart, bpDest);	
+  tSOSDest = propagator(propagatorName)->propagate(ftsStart, bpDest);
   return tSOSDest;
 }
 //
-bool CSCEfficiency::applyTrigger(edm::Handle<edm::TriggerResults> &hltR,
-                                 const edm::TriggerNames & triggerNames){
+bool CSCEfficiency::applyTrigger(edm::Handle<edm::TriggerResults> &hltR, const edm::TriggerNames &triggerNames) {
   bool triggerPassed = true;
-  std::vector<std::string>  hlNames=triggerNames.triggerNames();
+  std::vector<std::string> hlNames = triggerNames.triggerNames();
   pointToTriggers.clear();
-  for(size_t imyT = 0;imyT<myTriggers.size();++imyT){
-    for (size_t iT=0; iT<hlNames.size(); ++iT) {
+  for (size_t imyT = 0; imyT < myTriggers.size(); ++imyT) {
+    for (size_t iT = 0; iT < hlNames.size(); ++iT) {
       //std::cout<<" iT = "<<iT<<" hlNames[iT] = "<<hlNames[iT]<<
       //" : wasrun = "<<hltR->wasrun(iT)<<" accept = "<<
-      //	 hltR->accept(iT)<<" !error = "<< 
-      //	!hltR->error(iT)<<std::endl; 
-      if(!imyT){       
-        if(hltR->wasrun(iT) &&
-           hltR->accept(iT) &&
-           !hltR->error(iT) ){
-           TriggersFired->Fill(iT); 
+      //	 hltR->accept(iT)<<" !error = "<<
+      //	!hltR->error(iT)<<std::endl;
+      if (!imyT) {
+        if (hltR->wasrun(iT) && hltR->accept(iT) && !hltR->error(iT)) {
+          TriggersFired->Fill(iT);
         }
       }
-      if(hlNames[iT]==myTriggers[imyT]){
-	pointToTriggers.push_back(iT);
-	if(imyT){
-	  break;
-	}
+      if (hlNames[iT] == myTriggers[imyT]) {
+        pointToTriggers.push_back(iT);
+        if (imyT) {
+          break;
+        }
       }
     }
   }
-  if(pointToTriggers.size()!=myTriggers.size()){
+  if (pointToTriggers.size() != myTriggers.size()) {
     pointToTriggers.clear();
-    if(printalot){
-      std::cout<<" Not all trigger names found - all trigger specifications will be ignored. Check your cfg file!"<<std::endl;
+    if (printalot) {
+      std::cout << " Not all trigger names found - all trigger specifications will be ignored. Check your cfg file!"
+                << std::endl;
     }
-  }
-  else{
-    if(!pointToTriggers.empty()){
-      if(printalot){
-        std::cout<<"The following triggers will be required in the event: "<<std::endl;
-        for(size_t imyT =0; imyT <pointToTriggers.size();++imyT){
-	  std::cout<<"  "<<hlNames[pointToTriggers[imyT]];
+  } else {
+    if (!pointToTriggers.empty()) {
+      if (printalot) {
+        std::cout << "The following triggers will be required in the event: " << std::endl;
+        for (size_t imyT = 0; imyT < pointToTriggers.size(); ++imyT) {
+          std::cout << "  " << hlNames[pointToTriggers[imyT]];
         }
-        std::cout<<std::endl;
-        std::cout<<" in condition (AND/OR) : "<<!andOr<<"/"<<andOr<<std::endl;
+        std::cout << std::endl;
+        std::cout << " in condition (AND/OR) : " << !andOr << "/" << andOr << std::endl;
       }
     }
   }
 
   if (hltR.isValid()) {
-    if(pointToTriggers.empty()){
-      if(printalot){
-        std::cout<<" No triggers specified in the configuration or all ignored - no trigger information will be considered"<<std::endl;
+    if (pointToTriggers.empty()) {
+      if (printalot) {
+        std::cout
+            << " No triggers specified in the configuration or all ignored - no trigger information will be considered"
+            << std::endl;
       }
     }
-    for(size_t imyT =0; imyT <pointToTriggers.size();++imyT){
-      if(hltR->wasrun(pointToTriggers[imyT]) && 
-	 hltR->accept(pointToTriggers[imyT]) && 
-	 !hltR->error(pointToTriggers[imyT]) ){
-	triggerPassed = true;
-	if(andOr){
-	  break;
-	}
+    for (size_t imyT = 0; imyT < pointToTriggers.size(); ++imyT) {
+      if (hltR->wasrun(pointToTriggers[imyT]) && hltR->accept(pointToTriggers[imyT]) &&
+          !hltR->error(pointToTriggers[imyT])) {
+        triggerPassed = true;
+        if (andOr) {
+          break;
+        }
+      } else {
+        triggerPassed = false;
+        if (!andOr) {
+          triggerPassed = false;
+          break;
+        }
       }
-      else{
-	triggerPassed = false;
-	if(!andOr){
-	  triggerPassed = false;
-	  break;
-	}
-      }
+    }
+  } else {
+    if (printalot) {
+      std::cout << " TriggerResults handle returns invalid state?! No trigger information will be considered"
+                << std::endl;
     }
   }
-  else{
-    if(printalot){
-      std::cout<<" TriggerResults handle returns invalid state?! No trigger information will be considered"<<std::endl;
-    }
-  }
-  if(printalot){
-    std::cout<<" Trigger passed: "<<triggerPassed<<std::endl;
+  if (printalot) {
+    std::cout << " Trigger passed: " << triggerPassed << std::endl;
   }
   return triggerPassed;
 }
 //
 
 // Constructor
-CSCEfficiency::CSCEfficiency(const edm::ParameterSet& pset){
-
+CSCEfficiency::CSCEfficiency(const edm::ParameterSet &pset) {
   // const float Xmin = -70;
   //const float Xmax = 70;
   //const int nXbins = int(4.*(Xmax - Xmin));
   const float Ymin = -165;
   const float Ymax = 165;
-  const int nYbins = int((Ymax - Ymin)/2);
+  const int nYbins = int((Ymax - Ymin) / 2);
   const float Layer_min = -0.5;
   const float Layer_max = 9.5;
   const int nLayer_bins = int(Layer_max - Layer_min);
   //
 
   //---- Get the input parameters
-  printout_NEvents  = pset.getUntrackedParameter<unsigned int>("printout_NEvents",0);
-  rootFileName     = pset.getUntrackedParameter<string>("rootFileName","cscHists.root");
+  printout_NEvents = pset.getUntrackedParameter<unsigned int>("printout_NEvents", 0);
+  rootFileName = pset.getUntrackedParameter<string>("rootFileName", "cscHists.root");
 
-  isData  = pset.getUntrackedParameter<bool>("runOnData",true);// 
-  isIPdata  = pset.getUntrackedParameter<bool>("IPdata",false);// 
-  isBeamdata  = pset.getUntrackedParameter<bool>("Beamdata",false);//
-  getAbsoluteEfficiency  = pset.getUntrackedParameter<bool>("getAbsoluteEfficiency",true);//
-  useDigis = pset.getUntrackedParameter<bool>("useDigis", true);// 
-  distanceFromDeadZone = pset.getUntrackedParameter<double>("distanceFromDeadZone", 10.);// 
-  minP = pset.getUntrackedParameter<double>("minP",20.);//
-  maxP = pset.getUntrackedParameter<double>("maxP",100.);//
-  maxNormChi2 = pset.getUntrackedParameter<double>("maxNormChi2", 3.);//
-  minTrackHits = pset.getUntrackedParameter<unsigned int>("minTrackHits",10);//
+  isData = pset.getUntrackedParameter<bool>("runOnData", true);                             //
+  isIPdata = pset.getUntrackedParameter<bool>("IPdata", false);                             //
+  isBeamdata = pset.getUntrackedParameter<bool>("Beamdata", false);                         //
+  getAbsoluteEfficiency = pset.getUntrackedParameter<bool>("getAbsoluteEfficiency", true);  //
+  useDigis = pset.getUntrackedParameter<bool>("useDigis", true);                            //
+  distanceFromDeadZone = pset.getUntrackedParameter<double>("distanceFromDeadZone", 10.);   //
+  minP = pset.getUntrackedParameter<double>("minP", 20.);                                   //
+  maxP = pset.getUntrackedParameter<double>("maxP", 100.);                                  //
+  maxNormChi2 = pset.getUntrackedParameter<double>("maxNormChi2", 3.);                      //
+  minTrackHits = pset.getUntrackedParameter<unsigned int>("minTrackHits", 10);              //
 
-  applyIPangleCuts = pset.getUntrackedParameter<bool>("applyIPangleCuts", false);// 
-    local_DY_DZ_Max = pset.getUntrackedParameter<double>("local_DY_DZ_Max",-0.1);//
-      local_DY_DZ_Min = pset.getUntrackedParameter<double>("local_DY_DZ_Min",-0.8);//
-        local_DX_DZ_Max = pset.getUntrackedParameter<double>("local_DX_DZ_Max",0.2);//
+  applyIPangleCuts = pset.getUntrackedParameter<bool>("applyIPangleCuts", false);  //
+  local_DY_DZ_Max = pset.getUntrackedParameter<double>("local_DY_DZ_Max", -0.1);   //
+  local_DY_DZ_Min = pset.getUntrackedParameter<double>("local_DY_DZ_Min", -0.8);   //
+  local_DX_DZ_Max = pset.getUntrackedParameter<double>("local_DX_DZ_Max", 0.2);    //
 
-  sd_token = consumes<CSCStripDigiCollection>( pset.getParameter<edm::InputTag>("stripDigiTag") );
-  wd_token = consumes<CSCWireDigiCollection>( pset.getParameter<edm::InputTag>("wireDigiTag") );
-  al_token = consumes<CSCALCTDigiCollection>( pset.getParameter<edm::InputTag>("alctDigiTag") );
-  cl_token = consumes<CSCCLCTDigiCollection>( pset.getParameter<edm::InputTag>("clctDigiTag") );
-  co_token = consumes<CSCCorrelatedLCTDigiCollection>( pset.getParameter<edm::InputTag>("corrlctDigiTag") );
-  rh_token = consumes<CSCRecHit2DCollection>( pset.getParameter<edm::InputTag>("rechitTag") );
-  se_token = consumes<CSCSegmentCollection>( pset.getParameter<edm::InputTag>("segmentTag") );
-  tk_token = consumes<edm::View<reco::Track> >( pset.getParameter<edm::InputTag>("tracksTag") );
-  sh_token = consumes<edm::PSimHitContainer>( pset.getParameter<edm::InputTag>("simHitTag") );
-
+  sd_token = consumes<CSCStripDigiCollection>(pset.getParameter<edm::InputTag>("stripDigiTag"));
+  wd_token = consumes<CSCWireDigiCollection>(pset.getParameter<edm::InputTag>("wireDigiTag"));
+  al_token = consumes<CSCALCTDigiCollection>(pset.getParameter<edm::InputTag>("alctDigiTag"));
+  cl_token = consumes<CSCCLCTDigiCollection>(pset.getParameter<edm::InputTag>("clctDigiTag"));
+  co_token = consumes<CSCCorrelatedLCTDigiCollection>(pset.getParameter<edm::InputTag>("corrlctDigiTag"));
+  rh_token = consumes<CSCRecHit2DCollection>(pset.getParameter<edm::InputTag>("rechitTag"));
+  se_token = consumes<CSCSegmentCollection>(pset.getParameter<edm::InputTag>("segmentTag"));
+  tk_token = consumes<edm::View<reco::Track> >(pset.getParameter<edm::InputTag>("tracksTag"));
+  sh_token = consumes<edm::PSimHitContainer>(pset.getParameter<edm::InputTag>("simHitTag"));
 
   edm::ParameterSet serviceParameters = pset.getParameter<edm::ParameterSet>("ServiceParameters");
   // maybe use the service for getting magnetic field, propagators, etc. ...
-  theService        = new MuonServiceProxy(serviceParameters);
+  theService = new MuonServiceProxy(serviceParameters);
 
   // Trigger
-  useTrigger =  pset.getUntrackedParameter<bool>("useTrigger", false);
+  useTrigger = pset.getUntrackedParameter<bool>("useTrigger", false);
 
-  ht_token = consumes<edm::TriggerResults>( pset.getParameter<edm::InputTag>("HLTriggerResults") );
+  ht_token = consumes<edm::TriggerResults>(pset.getParameter<edm::InputTag>("HLTriggerResults"));
 
-  myTriggers = pset.getParameter<std::vector <std::string> >("myTriggers");
-  andOr =  pset.getUntrackedParameter<bool>("andOr");
+  myTriggers = pset.getParameter<std::vector<std::string> >("myTriggers");
+  andOr = pset.getUntrackedParameter<bool>("andOr");
   pointToTriggers.clear();
-
 
   //---- set counter to zero
   nEventsAnalyzed = 0;
@@ -1686,70 +1705,64 @@ CSCEfficiency::CSCEfficiency(const edm::ParameterSet& pset){
   //
   std::string Path = "AllChambers/";
   std::string FullName;
-  //---- File with output histograms 
+  //---- File with output histograms
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
   theFile->cd();
   //---- Book histograms for the analysis
   char SpecName[60];
-  
-  sprintf(SpecName,"DataFlow"); 
-  DataFlow =  
-    new TH1F(SpecName,"Data flow;condition number;entries",40,-0.5,39.5);
+
+  sprintf(SpecName, "DataFlow");
+  DataFlow = new TH1F(SpecName, "Data flow;condition number;entries", 40, -0.5, 39.5);
   //
-  sprintf(SpecName,"TriggersFired"); 
-  TriggersFired =
-    new TH1F(SpecName,"Triggers fired;trigger number;entries",140,-0.5,139.5);
+  sprintf(SpecName, "TriggersFired");
+  TriggersFired = new TH1F(SpecName, "Triggers fired;trigger number;entries", 140, -0.5, 139.5);
   //
   int Chan = 50;
   float minChan = -0.5;
   float maxChan = 49.5;
   //
-  sprintf(SpecName,"ALCTPerEvent");    
-  ALCTPerEvent = new TH1F(SpecName,"ALCTs per event;N digis;entries",Chan,minChan,maxChan);
+  sprintf(SpecName, "ALCTPerEvent");
+  ALCTPerEvent = new TH1F(SpecName, "ALCTs per event;N digis;entries", Chan, minChan, maxChan);
   //
-  sprintf(SpecName,"CLCTPerEvent");    
-  CLCTPerEvent = new TH1F(SpecName,"CLCTs per event;N digis;entries",Chan,minChan,maxChan);
+  sprintf(SpecName, "CLCTPerEvent");
+  CLCTPerEvent = new TH1F(SpecName, "CLCTs per event;N digis;entries", Chan, minChan, maxChan);
   //
-    sprintf(SpecName,"recHitsPerEvent");    
-  recHitsPerEvent = new TH1F(SpecName,"RecHits per event;N digis;entries",150,-0.5,149.5);
+  sprintf(SpecName, "recHitsPerEvent");
+  recHitsPerEvent = new TH1F(SpecName, "RecHits per event;N digis;entries", 150, -0.5, 149.5);
   //
-  sprintf(SpecName,"segmentsPerEvent");    
-  segmentsPerEvent = new TH1F(SpecName,"segments per event;N digis;entries",Chan,minChan,maxChan);
+  sprintf(SpecName, "segmentsPerEvent");
+  segmentsPerEvent = new TH1F(SpecName, "segments per event;N digis;entries", Chan, minChan, maxChan);
   //
   //---- Book groups of histograms (for any chamber)
 
-  map<std::string,bool>::iterator iter;  
-  for(int ec = 0;ec<2;++ec){
-    for(int st = 0;st<4;++st){
+  map<std::string, bool>::iterator iter;
+  for (int ec = 0; ec < 2; ++ec) {
+    for (int st = 0; st < 4; ++st) {
       theFile->cd();
-      sprintf(SpecName,"Stations__E%d_S%d",ec+1, st+1);
+      sprintf(SpecName, "Stations__E%d_S%d", ec + 1, st + 1);
       theFile->mkdir(SpecName);
       theFile->cd(SpecName);
 
       //
-      sprintf(SpecName,"segmentChi2_ndf_St%d",st+1);
-      StHist[ec][st].segmentChi2_ndf = 
-	new TH1F(SpecName,"Chi2/ndf of a segment;chi2/ndf;entries",100,0.,20.);
+      sprintf(SpecName, "segmentChi2_ndf_St%d", st + 1);
+      StHist[ec][st].segmentChi2_ndf = new TH1F(SpecName, "Chi2/ndf of a segment;chi2/ndf;entries", 100, 0., 20.);
       //
-      sprintf(SpecName,"hitsInSegment_St%d",st+1);
-      StHist[ec][st].hitsInSegment = 
-	new TH1F(SpecName,"Number of hits in a segment;nHits;entries",7,-0.5,6.5);
+      sprintf(SpecName, "hitsInSegment_St%d", st + 1);
+      StHist[ec][st].hitsInSegment = new TH1F(SpecName, "Number of hits in a segment;nHits;entries", 7, -0.5, 6.5);
       //
       Chan = 170;
       minChan = 0.85;
       maxChan = 2.55;
       //
-      sprintf(SpecName,"AllSegments_eta_St%d",st+1);
-      StHist[ec][st].AllSegments_eta = 
-	new TH1F(SpecName,"All segments in eta;eta;entries",Chan,minChan,maxChan);
+      sprintf(SpecName, "AllSegments_eta_St%d", st + 1);
+      StHist[ec][st].AllSegments_eta = new TH1F(SpecName, "All segments in eta;eta;entries", Chan, minChan, maxChan);
       //
-      sprintf(SpecName,"EfficientSegments_eta_St%d",st+1);
-      StHist[ec][st].EfficientSegments_eta = 
-	new TH1F(SpecName,"Efficient segments in eta;eta;entries",Chan,minChan,maxChan);
+      sprintf(SpecName, "EfficientSegments_eta_St%d", st + 1);
+      StHist[ec][st].EfficientSegments_eta =
+          new TH1F(SpecName, "Efficient segments in eta;eta;entries", Chan, minChan, maxChan);
       //
-      sprintf(SpecName,"ResidualSegments_St%d",st+1);
-      StHist[ec][st].ResidualSegments = 
-	new TH1F(SpecName,"Residual (segments);residual,cm;entries",75,0.,15.);
+      sprintf(SpecName, "ResidualSegments_St%d", st + 1);
+      StHist[ec][st].ResidualSegments = new TH1F(SpecName, "Residual (segments);residual,cm;entries", 75, 0., 15.);
       //
       Chan = 200;
       minChan = -800.;
@@ -1757,164 +1770,177 @@ CSCEfficiency::CSCEfficiency(const edm::ParameterSet& pset){
       int Chan2 = 200;
       float minChan2 = -800.;
       float maxChan2 = 800.;
-      
-      sprintf(SpecName,"EfficientSegments_XY_St%d",st+1);
-      StHist[ec][st].EfficientSegments_XY = new TH2F(SpecName,"Efficient segments in XY;X;Y",
-						     Chan,minChan,maxChan,Chan2,minChan2,maxChan2);
-      sprintf(SpecName,"InefficientSegments_XY_St%d",st+1);
-      StHist[ec][st].InefficientSegments_XY = new TH2F(SpecName,"Inefficient segments in XY;X;Y",
-						       Chan,minChan,maxChan,Chan2,minChan2,maxChan2);
+
+      sprintf(SpecName, "EfficientSegments_XY_St%d", st + 1);
+      StHist[ec][st].EfficientSegments_XY =
+          new TH2F(SpecName, "Efficient segments in XY;X;Y", Chan, minChan, maxChan, Chan2, minChan2, maxChan2);
+      sprintf(SpecName, "InefficientSegments_XY_St%d", st + 1);
+      StHist[ec][st].InefficientSegments_XY =
+          new TH2F(SpecName, "Inefficient segments in XY;X;Y", Chan, minChan, maxChan, Chan2, minChan2, maxChan2);
       //
       Chan = 80;
       minChan = 0;
       maxChan = 3.2;
-      sprintf(SpecName,"EfficientALCT_momTheta_St%d",st+1);
-      StHist[ec][st].EfficientALCT_momTheta = new TH1F(SpecName,"Efficient ALCT in theta (momentum);theta, rad;entries",
-						       Chan,minChan,maxChan);
+      sprintf(SpecName, "EfficientALCT_momTheta_St%d", st + 1);
+      StHist[ec][st].EfficientALCT_momTheta =
+          new TH1F(SpecName, "Efficient ALCT in theta (momentum);theta, rad;entries", Chan, minChan, maxChan);
       //
-      sprintf(SpecName,"InefficientALCT_momTheta_St%d",st+1);
-      StHist[ec][st].InefficientALCT_momTheta = new TH1F(SpecName,"Inefficient ALCT in theta (momentum);theta, rad;entries",
-							 Chan,minChan,maxChan);
+      sprintf(SpecName, "InefficientALCT_momTheta_St%d", st + 1);
+      StHist[ec][st].InefficientALCT_momTheta =
+          new TH1F(SpecName, "Inefficient ALCT in theta (momentum);theta, rad;entries", Chan, minChan, maxChan);
       //
       Chan = 160;
       minChan = -3.2;
       maxChan = 3.2;
-      sprintf(SpecName,"EfficientCLCT_momPhi_St%d",st+1);
-      StHist[ec][st].EfficientCLCT_momPhi = new TH1F(SpecName,"Efficient CLCT in phi (momentum);phi, rad;entries",
-						     Chan,minChan,maxChan);
+      sprintf(SpecName, "EfficientCLCT_momPhi_St%d", st + 1);
+      StHist[ec][st].EfficientCLCT_momPhi =
+          new TH1F(SpecName, "Efficient CLCT in phi (momentum);phi, rad;entries", Chan, minChan, maxChan);
       //
-      sprintf(SpecName,"InefficientCLCT_momPhi_St%d",st+1);
-      StHist[ec][st].InefficientCLCT_momPhi = new TH1F(SpecName,"Inefficient CLCT in phi (momentum);phi, rad;entries",
-						       Chan,minChan,maxChan);
+      sprintf(SpecName, "InefficientCLCT_momPhi_St%d", st + 1);
+      StHist[ec][st].InefficientCLCT_momPhi =
+          new TH1F(SpecName, "Inefficient CLCT in phi (momentum);phi, rad;entries", Chan, minChan, maxChan);
       //
       theFile->cd();
-      for(int rg = 0;rg<3;++rg){
-	if(0!=st && rg>1){
-	  continue;
-	}
-	else if(1==rg && 3==st){
-	  continue;
-	}
-	for(int iChamber=FirstCh;iChamber<FirstCh+NumCh;iChamber++){
-	  if(0!=st && 0==rg && iChamber >18){
-	    continue;
-	  }
-	  theFile->cd();
-	  sprintf(SpecName,"Chambers__E%d_S%d_R%d_Chamber_%d",ec+1, st+1, rg+1,iChamber);
-	  theFile->mkdir(SpecName);
-	  theFile->cd(SpecName);
-	  //
+      for (int rg = 0; rg < 3; ++rg) {
+        if (0 != st && rg > 1) {
+          continue;
+        } else if (1 == rg && 3 == st) {
+          continue;
+        }
+        for (int iChamber = FirstCh; iChamber < FirstCh + NumCh; iChamber++) {
+          if (0 != st && 0 == rg && iChamber > 18) {
+            continue;
+          }
+          theFile->cd();
+          sprintf(SpecName, "Chambers__E%d_S%d_R%d_Chamber_%d", ec + 1, st + 1, rg + 1, iChamber);
+          theFile->mkdir(SpecName);
+          theFile->cd(SpecName);
+          //
 
-	  sprintf(SpecName,"EfficientRechits_inSegment_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientRechits_inSegment = 
-	    new TH1F(SpecName,"Existing RecHit given a segment;layers (1-6);entries",nLayer_bins,Layer_min,Layer_max);
-	  //
-	  sprintf(SpecName,"InefficientSingleHits_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].InefficientSingleHits = 
-	    new TH1F(SpecName,"Single RecHits not in the segment;layers (1-6);entries ",nLayer_bins,Layer_min,Layer_max);
-	  //
-	  sprintf(SpecName,"AllSingleHits_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].AllSingleHits = 
-	    new TH1F(SpecName,"Single RecHits given a segment; layers (1-6);entries",nLayer_bins,Layer_min,Layer_max);
-	  //
-	  sprintf(SpecName,"digiAppearanceCount_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].digiAppearanceCount = 
-	    new TH1F(SpecName,"Digi appearance (no-yes): segment(0,1), ALCT(2,3), CLCT(4,5), CorrLCT(6,7); digi type;entries",
-		     8,-0.5,7.5);
-	  //
-	  Chan = 100;
-	  minChan = -1.1;
-	  maxChan = 0.9;
-	  sprintf(SpecName,"EfficientALCT_dydz_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientALCT_dydz = 
-	    new TH1F(SpecName,"Efficient ALCT; local dy/dz (ME 3 and 4 flipped);entries",
-		     Chan, minChan, maxChan);
-	  //
-	  sprintf(SpecName,"InefficientALCT_dydz_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].InefficientALCT_dydz = 
-	    new TH1F(SpecName,"Inefficient ALCT; local dy/dz (ME 3 and 4 flipped);entries",
-		     Chan, minChan, maxChan);
-	  //
-	  Chan = 100;
-	  minChan = -1.;
-	  maxChan = 1.0;
-	  sprintf(SpecName,"EfficientCLCT_dxdz_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientCLCT_dxdz = 
-	    new TH1F(SpecName,"Efficient CLCT; local dxdz;entries",
-		     Chan, minChan, maxChan);
-	  //
-	  sprintf(SpecName,"InefficientCLCT_dxdz_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].InefficientCLCT_dxdz = 
-	    new TH1F(SpecName,"Inefficient CLCT; local dxdz;entries",
-		     Chan, minChan, maxChan);
-	  //
-	  sprintf(SpecName,"EfficientRechits_good_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientRechits_good = 
-	    new TH1F(SpecName,"Existing RecHit - sensitive area only;layers (1-6);entries",nLayer_bins,Layer_min,Layer_max);
-	  //
-	  sprintf(SpecName,"EfficientStrips_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientStrips = 
-	    new TH1F(SpecName,"Existing strip;layer (1-6); entries",nLayer_bins,Layer_min,Layer_max);
-	  //
-	  sprintf(SpecName,"EfficientWireGroups_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientWireGroups = 
-	    new TH1F(SpecName,"Existing WireGroups;layer (1-6); entries ",nLayer_bins,Layer_min,Layer_max);
-	  //
-	  sprintf(SpecName,"StripWiresCorrelations_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].StripWiresCorrelations = 
-	    new TH1F(SpecName,"StripWire correlations;; entries ",5,0.5,5.5);
-	  //
-	  Chan = 80;
-	  minChan = 0;
-	  maxChan = 3.2;
-	  sprintf(SpecName,"NoWires_momTheta_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].NoWires_momTheta = 
-	    new TH1F(SpecName,"No wires (all strips present) - in theta (momentum);theta, rad;entries",
-		     Chan,minChan,maxChan);
-	  //
-	  Chan = 160;
-	  minChan = -3.2;
-	  maxChan = 3.2;
-	  sprintf(SpecName,"NoStrips_momPhi_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].NoStrips_momPhi = 
-	    new TH1F(SpecName,"No strips (all wires present) - in phi (momentum);phi, rad;entries",
-		     Chan,minChan,maxChan);
-	  //
-	  for(int iLayer=0; iLayer<6;iLayer++){
-	    sprintf(SpecName,"Y_InefficientRecHits_inSegment_Ch%d_L%d",iChamber,iLayer);
-	    ChHist[ec][st][rg][iChamber-FirstCh].Y_InefficientRecHits_inSegment.push_back
-	      (new TH1F(SpecName,"Missing RecHit/layer in a segment (local system, whole chamber);Y, cm; entries",
-			nYbins,Ymin, Ymax));
-	    //
-	    sprintf(SpecName,"Y_EfficientRecHits_inSegment_Ch%d_L%d",iChamber,iLayer);
-	    ChHist[ec][st][rg][iChamber-FirstCh].Y_EfficientRecHits_inSegment.push_back
-	      (new TH1F(SpecName,"Efficient (extrapolated from the segment) RecHit/layer in a segment (local system, whole chamber);Y, cm; entries",
-			nYbins,Ymin, Ymax));
-	    //
+          sprintf(SpecName, "EfficientRechits_inSegment_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientRechits_inSegment = new TH1F(
+              SpecName, "Existing RecHit given a segment;layers (1-6);entries", nLayer_bins, Layer_min, Layer_max);
+          //
+          sprintf(SpecName, "InefficientSingleHits_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].InefficientSingleHits = new TH1F(
+              SpecName, "Single RecHits not in the segment;layers (1-6);entries ", nLayer_bins, Layer_min, Layer_max);
+          //
+          sprintf(SpecName, "AllSingleHits_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].AllSingleHits = new TH1F(
+              SpecName, "Single RecHits given a segment; layers (1-6);entries", nLayer_bins, Layer_min, Layer_max);
+          //
+          sprintf(SpecName, "digiAppearanceCount_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].digiAppearanceCount =
+              new TH1F(SpecName,
+                       "Digi appearance (no-yes): segment(0,1), ALCT(2,3), CLCT(4,5), CorrLCT(6,7); digi type;entries",
+                       8,
+                       -0.5,
+                       7.5);
+          //
+          Chan = 100;
+          minChan = -1.1;
+          maxChan = 0.9;
+          sprintf(SpecName, "EfficientALCT_dydz_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientALCT_dydz =
+              new TH1F(SpecName, "Efficient ALCT; local dy/dz (ME 3 and 4 flipped);entries", Chan, minChan, maxChan);
+          //
+          sprintf(SpecName, "InefficientALCT_dydz_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].InefficientALCT_dydz =
+              new TH1F(SpecName, "Inefficient ALCT; local dy/dz (ME 3 and 4 flipped);entries", Chan, minChan, maxChan);
+          //
+          Chan = 100;
+          minChan = -1.;
+          maxChan = 1.0;
+          sprintf(SpecName, "EfficientCLCT_dxdz_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientCLCT_dxdz =
+              new TH1F(SpecName, "Efficient CLCT; local dxdz;entries", Chan, minChan, maxChan);
+          //
+          sprintf(SpecName, "InefficientCLCT_dxdz_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].InefficientCLCT_dxdz =
+              new TH1F(SpecName, "Inefficient CLCT; local dxdz;entries", Chan, minChan, maxChan);
+          //
+          sprintf(SpecName, "EfficientRechits_good_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientRechits_good = new TH1F(
+              SpecName, "Existing RecHit - sensitive area only;layers (1-6);entries", nLayer_bins, Layer_min, Layer_max);
+          //
+          sprintf(SpecName, "EfficientStrips_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientStrips =
+              new TH1F(SpecName, "Existing strip;layer (1-6); entries", nLayer_bins, Layer_min, Layer_max);
+          //
+          sprintf(SpecName, "EfficientWireGroups_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientWireGroups =
+              new TH1F(SpecName, "Existing WireGroups;layer (1-6); entries ", nLayer_bins, Layer_min, Layer_max);
+          //
+          sprintf(SpecName, "StripWiresCorrelations_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].StripWiresCorrelations =
+              new TH1F(SpecName, "StripWire correlations;; entries ", 5, 0.5, 5.5);
+          //
+          Chan = 80;
+          minChan = 0;
+          maxChan = 3.2;
+          sprintf(SpecName, "NoWires_momTheta_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].NoWires_momTheta =
+              new TH1F(SpecName,
+                       "No wires (all strips present) - in theta (momentum);theta, rad;entries",
+                       Chan,
+                       minChan,
+                       maxChan);
+          //
+          Chan = 160;
+          minChan = -3.2;
+          maxChan = 3.2;
+          sprintf(SpecName, "NoStrips_momPhi_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].NoStrips_momPhi = new TH1F(
+              SpecName, "No strips (all wires present) - in phi (momentum);phi, rad;entries", Chan, minChan, maxChan);
+          //
+          for (int iLayer = 0; iLayer < 6; iLayer++) {
+            sprintf(SpecName, "Y_InefficientRecHits_inSegment_Ch%d_L%d", iChamber, iLayer);
+            ChHist[ec][st][rg][iChamber - FirstCh].Y_InefficientRecHits_inSegment.push_back(
+                new TH1F(SpecName,
+                         "Missing RecHit/layer in a segment (local system, whole chamber);Y, cm; entries",
+                         nYbins,
+                         Ymin,
+                         Ymax));
+            //
+            sprintf(SpecName, "Y_EfficientRecHits_inSegment_Ch%d_L%d", iChamber, iLayer);
+            ChHist[ec][st][rg][iChamber - FirstCh].Y_EfficientRecHits_inSegment.push_back(
+                new TH1F(SpecName,
+                         "Efficient (extrapolated from the segment) RecHit/layer in a segment (local system, whole "
+                         "chamber);Y, cm; entries",
+                         nYbins,
+                         Ymin,
+                         Ymax));
+            //
             Chan = 200;
             minChan = -0.2;
             maxChan = 0.2;
-            sprintf(SpecName,"Phi_InefficientRecHits_inSegment_Ch%d_L%d",iChamber,iLayer);
-            ChHist[ec][st][rg][iChamber-FirstCh].Phi_InefficientRecHits_inSegment.push_back
-              (new TH1F(SpecName,"Missing RecHit/layer in a segment (local system, whole chamber);Phi, rad; entries",
-                        Chan, minChan, maxChan));
+            sprintf(SpecName, "Phi_InefficientRecHits_inSegment_Ch%d_L%d", iChamber, iLayer);
+            ChHist[ec][st][rg][iChamber - FirstCh].Phi_InefficientRecHits_inSegment.push_back(
+                new TH1F(SpecName,
+                         "Missing RecHit/layer in a segment (local system, whole chamber);Phi, rad; entries",
+                         Chan,
+                         minChan,
+                         maxChan));
             //
-            sprintf(SpecName,"Phi_EfficientRecHits_inSegment_Ch%d_L%d",iChamber,iLayer);
-            ChHist[ec][st][rg][iChamber-FirstCh].Phi_EfficientRecHits_inSegment.push_back
-              (new TH1F(SpecName,"Efficient (extrapolated from the segment) in a segment (local system, whole chamber);Phi, rad; entries",
-                        Chan, minChan, maxChan));
-	    
-	  }
-	  //
-	  sprintf(SpecName,"Sim_Rechits_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].SimRechits = 
-	    new TH1F(SpecName,"Existing RecHit (Sim);layers (1-6);entries",nLayer_bins,Layer_min,Layer_max);
-	  //
-	  sprintf(SpecName,"Sim_Simhits_Ch%d",iChamber);
-	  ChHist[ec][st][rg][iChamber-FirstCh].SimSimhits = 
-	    new TH1F(SpecName,"Existing SimHit (Sim);layers (1-6);entries",nLayer_bins,Layer_min,Layer_max);
-	  //
-	  /*
+            sprintf(SpecName, "Phi_EfficientRecHits_inSegment_Ch%d_L%d", iChamber, iLayer);
+            ChHist[ec][st][rg][iChamber - FirstCh].Phi_EfficientRecHits_inSegment.push_back(
+                new TH1F(SpecName,
+                         "Efficient (extrapolated from the segment) in a segment (local system, whole chamber);Phi, "
+                         "rad; entries",
+                         Chan,
+                         minChan,
+                         maxChan));
+          }
+          //
+          sprintf(SpecName, "Sim_Rechits_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].SimRechits =
+              new TH1F(SpecName, "Existing RecHit (Sim);layers (1-6);entries", nLayer_bins, Layer_min, Layer_max);
+          //
+          sprintf(SpecName, "Sim_Simhits_Ch%d", iChamber);
+          ChHist[ec][st][rg][iChamber - FirstCh].SimSimhits =
+              new TH1F(SpecName, "Existing SimHit (Sim);layers (1-6);entries", nLayer_bins, Layer_min, Layer_max);
+          //
+          /*
 	  sprintf(SpecName,"Sim_Rechits_each_Ch%d",iChamber);
 	  ChHist[ec][st][rg][iChamber-FirstCh].SimRechits_each = 
 	    new TH1F(SpecName,"Existing RecHit (Sim), each;layers (1-6);entries",nLayer_bins,Layer_min,Layer_max);
@@ -1923,16 +1949,17 @@ CSCEfficiency::CSCEfficiency(const edm::ParameterSet& pset){
 	  ChHist[ec][st][rg][iChamber-FirstCh].SimSimhits_each = 
 	    new TH1F(SpecName,"Existing SimHit (Sim), each;layers (1-6);entries",nLayer_bins,Layer_min,Layer_max);
 	  */
-	  theFile->cd();
-	}
+          theFile->cd();
+        }
       }
     }
   }
 }
 
 // Destructor
-CSCEfficiency::~CSCEfficiency(){
-  if (theService) delete theService; 
+CSCEfficiency::~CSCEfficiency() {
+  if (theService)
+    delete theService;
   // Write the histos to a file
   theFile->cd();
   //
@@ -1941,7 +1968,7 @@ CSCEfficiency::~CSCEfficiency(){
   std::vector<float> eff(2);
 
   //---- loop over chambers
-  std::map <std::string, bool> chamberTypes;
+  std::map<std::string, bool> chamberTypes;
   chamberTypes["ME11"] = false;
   chamberTypes["ME12"] = false;
   chamberTypes["ME13"] = false;
@@ -1950,12 +1977,12 @@ CSCEfficiency::~CSCEfficiency(){
   chamberTypes["ME31"] = false;
   chamberTypes["ME32"] = false;
   chamberTypes["ME41"] = false;
-  
-  map<std::string,bool>::iterator iter;  
-  std::cout<<" Writing proper histogram structure (patience)..."<<std::endl;
-  for(int ec = 0;ec<2;++ec){
-    for(int st = 0;st<4;++st){
-      snprintf(SpecName, sizeof(SpecName), "Stations__E%d_S%d",ec+1, st+1);
+
+  map<std::string, bool>::iterator iter;
+  std::cout << " Writing proper histogram structure (patience)..." << std::endl;
+  for (int ec = 0; ec < 2; ++ec) {
+    for (int st = 0; st < 4; ++st) {
+      snprintf(SpecName, sizeof(SpecName), "Stations__E%d_S%d", ec + 1, st + 1);
       theFile->cd(SpecName);
       StHist[ec][st].segmentChi2_ndf->Write();
       StHist[ec][st].hitsInSegment->Write();
@@ -1968,50 +1995,49 @@ CSCEfficiency::~CSCEfficiency(){
       StHist[ec][st].InefficientALCT_momTheta->Write();
       StHist[ec][st].EfficientCLCT_momPhi->Write();
       StHist[ec][st].InefficientCLCT_momPhi->Write();
-      for(int rg = 0;rg<3;++rg){
-	if(0!=st && rg>1){
-	  continue;
-	}
-	else if(1==rg && 3==st){
-	  continue;
-	}
-	for(int iChamber=FirstCh;iChamber<FirstCh+NumCh;iChamber++){
-	  if(0!=st && 0==rg && iChamber >18){
-	    continue;
-	  }
-	  snprintf(SpecName, sizeof(SpecName), "Chambers__E%d_S%d_R%d_Chamber_%d",ec+1, st+1, rg+1,iChamber);
-	  theFile->cd(SpecName);
-	  
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientRechits_inSegment->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].AllSingleHits->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].digiAppearanceCount->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientALCT_dydz->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].InefficientALCT_dydz->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientCLCT_dxdz->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].InefficientCLCT_dxdz->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].InefficientSingleHits->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientRechits_good->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientStrips->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].StripWiresCorrelations->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].NoWires_momTheta->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].NoStrips_momPhi->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].EfficientWireGroups->Write();
-	  for(unsigned int iLayer = 0; iLayer< 6; iLayer++){
-	    ChHist[ec][st][rg][iChamber-FirstCh].Y_InefficientRecHits_inSegment[iLayer]->Write();
-	    ChHist[ec][st][rg][iChamber-FirstCh].Y_EfficientRecHits_inSegment[iLayer]->Write();
-            ChHist[ec][st][rg][iChamber-FirstCh].Phi_InefficientRecHits_inSegment[iLayer]->Write();
-            ChHist[ec][st][rg][iChamber-FirstCh].Phi_EfficientRecHits_inSegment[iLayer]->Write();
-	  }
-	  ChHist[ec][st][rg][iChamber-FirstCh].SimRechits->Write();
-	  ChHist[ec][st][rg][iChamber-FirstCh].SimSimhits->Write();
-	  /*
+      for (int rg = 0; rg < 3; ++rg) {
+        if (0 != st && rg > 1) {
+          continue;
+        } else if (1 == rg && 3 == st) {
+          continue;
+        }
+        for (int iChamber = FirstCh; iChamber < FirstCh + NumCh; iChamber++) {
+          if (0 != st && 0 == rg && iChamber > 18) {
+            continue;
+          }
+          snprintf(SpecName, sizeof(SpecName), "Chambers__E%d_S%d_R%d_Chamber_%d", ec + 1, st + 1, rg + 1, iChamber);
+          theFile->cd(SpecName);
+
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientRechits_inSegment->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].AllSingleHits->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].digiAppearanceCount->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientALCT_dydz->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].InefficientALCT_dydz->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientCLCT_dxdz->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].InefficientCLCT_dxdz->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].InefficientSingleHits->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientRechits_good->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientStrips->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].StripWiresCorrelations->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].NoWires_momTheta->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].NoStrips_momPhi->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].EfficientWireGroups->Write();
+          for (unsigned int iLayer = 0; iLayer < 6; iLayer++) {
+            ChHist[ec][st][rg][iChamber - FirstCh].Y_InefficientRecHits_inSegment[iLayer]->Write();
+            ChHist[ec][st][rg][iChamber - FirstCh].Y_EfficientRecHits_inSegment[iLayer]->Write();
+            ChHist[ec][st][rg][iChamber - FirstCh].Phi_InefficientRecHits_inSegment[iLayer]->Write();
+            ChHist[ec][st][rg][iChamber - FirstCh].Phi_EfficientRecHits_inSegment[iLayer]->Write();
+          }
+          ChHist[ec][st][rg][iChamber - FirstCh].SimRechits->Write();
+          ChHist[ec][st][rg][iChamber - FirstCh].SimSimhits->Write();
+          /*
 	  ChHist[ec][st][rg][iChamber-FirstCh].SimRechits_each->Write();
 	  ChHist[ec][st][rg][iChamber-FirstCh].SimSimhits_each->Write();
 	  */
-	  //
-	  theFile->cd(SpecName);
-	  theFile->cd();
-	}
+          //
+          theFile->cd(SpecName);
+          theFile->cd();
+        }
       }
     }
   }
@@ -2019,7 +2045,7 @@ CSCEfficiency::~CSCEfficiency(){
   snprintf(SpecName, sizeof(SpecName), "AllChambers");
   theFile->mkdir(SpecName);
   theFile->cd(SpecName);
-  DataFlow->Write(); 
+  DataFlow->Write();
   TriggersFired->Write();
   ALCTPerEvent->Write();
   CLCTPerEvent->Write();
@@ -2032,15 +2058,9 @@ CSCEfficiency::~CSCEfficiency(){
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void
-CSCEfficiency::beginJob()
-{
-}
+void CSCEfficiency::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-CSCEfficiency::endJob() {
-}
+void CSCEfficiency::endJob() {}
 
 DEFINE_FWK_MODULE(CSCEfficiency);
-

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
@@ -94,18 +94,18 @@
 #include <map>
 #include <string>
 
-#define SQR(x) ((x)*(x))
+#define SQR(x) ((x) * (x))
 
 #define LastCh 36
-#define FirstCh  1
-#define NumCh (LastCh-FirstCh+1)
+#define FirstCh 1
+#define NumCh (LastCh - FirstCh + 1)
 
 namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
   class TriggerNames;
-}
+}  // namespace edm
 
 class TFile;
 class CSCLayer;
@@ -114,17 +114,17 @@ class CSCDetId;
 class CSCEfficiency : public edm::EDFilter {
 public:
   /// Constructor
-  CSCEfficiency(const edm::ParameterSet& pset);
+  CSCEfficiency(const edm::ParameterSet &pset);
 
   /// Destructor
   ~CSCEfficiency() override;
 
- private:
-  void beginJob() override ;
+private:
+  void beginJob() override;
   //---- analysis + filter
-  bool filter(edm::Event & event, const edm::EventSetup& eventSetup) override;
+  bool filter(edm::Event &event, const edm::EventSetup &eventSetup) override;
 
-  void endJob() override ;
+  void endJob() override;
 
   //---- (input) parameters
   //---- Root file name
@@ -132,18 +132,18 @@ public:
 
   //---- digi/object tokens
 
-  edm::EDGetTokenT<CSCWireDigiCollection>          wd_token;
-  edm::EDGetTokenT<CSCStripDigiCollection>         sd_token;
-  edm::EDGetTokenT<CSCALCTDigiCollection>          al_token;
-  edm::EDGetTokenT<CSCCLCTDigiCollection>          cl_token;
+  edm::EDGetTokenT<CSCWireDigiCollection> wd_token;
+  edm::EDGetTokenT<CSCStripDigiCollection> sd_token;
+  edm::EDGetTokenT<CSCALCTDigiCollection> al_token;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> cl_token;
   edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> co_token;
-  edm::EDGetTokenT<CSCRecHit2DCollection>          rh_token;
-  edm::EDGetTokenT<CSCSegmentCollection>           se_token;
+  edm::EDGetTokenT<CSCRecHit2DCollection> rh_token;
+  edm::EDGetTokenT<CSCSegmentCollection> se_token;
 
-  edm::EDGetTokenT<edm::View<reco::Track> >        tk_token;
-  edm::EDGetTokenT<edm::PSimHitContainer>               sh_token;
+  edm::EDGetTokenT<edm::View<reco::Track> > tk_token;
+  edm::EDGetTokenT<edm::PSimHitContainer> sh_token;
 
-  edm::EDGetTokenT<edm::TriggerResults>            ht_token;
+  edm::EDGetTokenT<edm::TriggerResults> ht_token;
 
   //
   unsigned int printout_NEvents;
@@ -166,9 +166,8 @@ public:
   // trigger
   bool useTrigger;
   std::vector<std::string> myTriggers;
-  std::vector <int> pointToTriggers;
-  bool andOr; 
-
+  std::vector<int> pointToTriggers;
+  bool andOr;
 
   //---- The muon service
   MuonServiceProxy *theService;
@@ -187,135 +186,136 @@ public:
 
   //---- Variables
   //---- LCTs
-  bool allCLCT[2][4][4][NumCh];//endcap/station/ring/chamber
-  bool allALCT[2][4][4][NumCh];//endcap/station/ring/chamber
-  bool allCorrLCT[2][4][4][NumCh];//endcap/station/ring/chamber
+  bool allCLCT[2][4][4][NumCh];     //endcap/station/ring/chamber
+  bool allALCT[2][4][4][NumCh];     //endcap/station/ring/chamber
+  bool allCorrLCT[2][4][4][NumCh];  //endcap/station/ring/chamber
 
   //----  Strips: strip number and ADCPeak
-  std::vector <std::pair <int, float> > allStrips[2][4][4][NumCh][6];//endcap/station/ring/chamber/layer
+  std::vector<std::pair<int, float> > allStrips[2][4][4][NumCh][6];  //endcap/station/ring/chamber/layer
 
   //----Wires: WG number and Y-position, time bin
-  std::vector <std::pair <std::pair <int, float>, int> > allWG[2][4][4][NumCh][6];//endcap/station/ring/chamber/layer
+  std::vector<std::pair<std::pair<int, float>, int> > allWG[2][4][4][NumCh][6];  //endcap/station/ring/chamber/layer
 
   //SetOfSimHits  (*all_SimHits)[2][4][4][ NumCh];
   //---- Simhits
-  std::vector <std::pair <LocalPoint, int> > allSimhits[2][4][4][NumCh][6];//endcap/station/ring/chamber/layer
+  std::vector<std::pair<LocalPoint, int> > allSimhits[2][4][4][NumCh][6];  //endcap/station/ring/chamber/layer
 
   //rechits
   //SetOfRecHits  (*all_RecHits)[2][4][4][ NumCh];
-  std::vector <std::pair <LocalPoint, bool> > allRechits[2][4][4][NumCh][6];//endcap/station/ring/chamber/layer
+  std::vector<std::pair<LocalPoint, bool> > allRechits[2][4][4][NumCh][6];  //endcap/station/ring/chamber/layer
 
   // segments
-  std::vector <std::pair <LocalPoint, LocalVector> > allSegments[2][4][4][NumCh];//endcap/station/ring/chamber
+  std::vector<std::pair<LocalPoint, LocalVector> > allSegments[2][4][4][NumCh];  //endcap/station/ring/chamber
 
   // empty chambers
-  bool emptyChambers[2][4][4][NumCh];//endcap/station/ring/chamber
+  bool emptyChambers[2][4][4][NumCh];  //endcap/station/ring/chamber
 
   //---- Functions
-  void fillDigiInfo(edm::Handle<CSCALCTDigiCollection> &alcts, 
-		edm::Handle<CSCCLCTDigiCollection> &clcts, 
-		edm::Handle<CSCCorrelatedLCTDigiCollection> &correlatedlcts,
-		edm::Handle<CSCWireDigiCollection> &wires,
-		edm::Handle<CSCStripDigiCollection> &strips,
-		edm::Handle<edm::PSimHitContainer> &simhits,
-		edm::Handle<CSCRecHit2DCollection> &rechits,
-		edm::Handle<CSCSegmentCollection> &segments,
-		edm::ESHandle<CSCGeometry> &cscGeom);
-  void fillLCT_info(edm::Handle<CSCALCTDigiCollection> &alcts, 
-		    edm::Handle<CSCCLCTDigiCollection> &clcts, 
-		    edm::Handle<CSCCorrelatedLCTDigiCollection> &correlatedlcts );
+  void fillDigiInfo(edm::Handle<CSCALCTDigiCollection> &alcts,
+                    edm::Handle<CSCCLCTDigiCollection> &clcts,
+                    edm::Handle<CSCCorrelatedLCTDigiCollection> &correlatedlcts,
+                    edm::Handle<CSCWireDigiCollection> &wires,
+                    edm::Handle<CSCStripDigiCollection> &strips,
+                    edm::Handle<edm::PSimHitContainer> &simhits,
+                    edm::Handle<CSCRecHit2DCollection> &rechits,
+                    edm::Handle<CSCSegmentCollection> &segments,
+                    edm::ESHandle<CSCGeometry> &cscGeom);
+  void fillLCT_info(edm::Handle<CSCALCTDigiCollection> &alcts,
+                    edm::Handle<CSCCLCTDigiCollection> &clcts,
+                    edm::Handle<CSCCorrelatedLCTDigiCollection> &correlatedlcts);
   void fillWG_info(edm::Handle<CSCWireDigiCollection> &wires, edm::ESHandle<CSCGeometry> &cscGeom);
   void fillStrips_info(edm::Handle<CSCStripDigiCollection> &strips);
   void fillRechitsSegments_info(edm::Handle<CSCRecHit2DCollection> &rechits,
-				edm::Handle<CSCSegmentCollection> &segments,
-				edm::ESHandle<CSCGeometry> &cscGeom);
+                                edm::Handle<CSCSegmentCollection> &segments,
+                                edm::ESHandle<CSCGeometry> &cscGeom);
   void fillSimhit_info(edm::Handle<edm::PSimHitContainer> &simHits);
 
-  void ringCandidates(int station, float absEta, std::map <std::string, bool> & chamberTypes);
-  void chamberCandidates(int station, int ring, float phi, std::vector <int> &coupleOfChambers);
+  void ringCandidates(int station, float absEta, std::map<std::string, bool> &chamberTypes);
+  void chamberCandidates(int station, int ring, float phi, std::vector<int> &coupleOfChambers);
 
-  bool efficienciesPerChamber(CSCDetId & id, const CSCChamber* cscChamber, FreeTrajectoryState &ftsChamber);
-  bool stripWire_Efficiencies(CSCDetId & cscDetId, FreeTrajectoryState &ftsChamber);
-  bool recHitSegment_Efficiencies(CSCDetId & cscDetId, const CSCChamber* cscChamber, FreeTrajectoryState &ftsChamber);
-  bool recSimHitEfficiency(CSCDetId & id, FreeTrajectoryState &ftsChamber);
-  // 
-  void returnTypes(CSCDetId & id, int &ec, int &st, int &rg, int &ch, int &secondRing);
-  //  
-  void getFromFTS(const FreeTrajectoryState& fts,
-		  CLHEP::Hep3Vector& p3, CLHEP::Hep3Vector& r3,
-		  int& charge, AlgebraicSymMatrix66& cov);
-  
-  FreeTrajectoryState getFromCLHEP(const CLHEP::Hep3Vector& p3, const CLHEP::Hep3Vector& r3,
-				   int charge, const AlgebraicSymMatrix66& cov,
-				   const MagneticField* field);
+  bool efficienciesPerChamber(CSCDetId &id, const CSCChamber *cscChamber, FreeTrajectoryState &ftsChamber);
+  bool stripWire_Efficiencies(CSCDetId &cscDetId, FreeTrajectoryState &ftsChamber);
+  bool recHitSegment_Efficiencies(CSCDetId &cscDetId, const CSCChamber *cscChamber, FreeTrajectoryState &ftsChamber);
+  bool recSimHitEfficiency(CSCDetId &id, FreeTrajectoryState &ftsChamber);
+  //
+  void returnTypes(CSCDetId &id, int &ec, int &st, int &rg, int &ch, int &secondRing);
+  //
+  void getFromFTS(const FreeTrajectoryState &fts,
+                  CLHEP::Hep3Vector &p3,
+                  CLHEP::Hep3Vector &r3,
+                  int &charge,
+                  AlgebraicSymMatrix66 &cov);
 
-  void linearExtrapolation(GlobalPoint initialPosition ,GlobalVector initialDirection, 
-			   float zSurface, std::vector <float> &posZY);
+  FreeTrajectoryState getFromCLHEP(const CLHEP::Hep3Vector &p3,
+                                   const CLHEP::Hep3Vector &r3,
+                                   int charge,
+                                   const AlgebraicSymMatrix66 &cov,
+                                   const MagneticField *field);
+
+  void linearExtrapolation(GlobalPoint initialPosition,
+                           GlobalVector initialDirection,
+                           float zSurface,
+                           std::vector<float> &posZY);
   double extrapolate1D(double initPosition, double initDirection, double parameterOfTheLine);
   double lineParameter(double initZPosition, double destZPosition, double initZDirection);
   bool inSensitiveLocalRegion(double xLocal, double yLocal, int station, int ring);
   bool checkLocal(double yLocal, double yBoundary, int station, int ring);
-  void chooseDirection(CLHEP::Hep3Vector & innerPosition, CLHEP::Hep3Vector & outerPosition);
-  const Propagator* propagator(std::string propagatorName) const ;
-  TrajectoryStateOnSurface propagate(FreeTrajectoryState & ftsStart, const BoundPlane &bp);
-  bool applyTrigger(edm::Handle<edm::TriggerResults> &hltR, const edm::TriggerNames & triggerNames);
+  void chooseDirection(CLHEP::Hep3Vector &innerPosition, CLHEP::Hep3Vector &outerPosition);
+  const Propagator *propagator(std::string propagatorName) const;
+  TrajectoryStateOnSurface propagate(FreeTrajectoryState &ftsStart, const BoundPlane &bp);
+  bool applyTrigger(edm::Handle<edm::TriggerResults> &hltR, const edm::TriggerNames &triggerNames);
   //bool applyTrigger(void);
 
-
-  //---- Histograms 
-    TH1F * DataFlow;
-    TH1F * TriggersFired;
-    //
-    TH1F * ALCTPerEvent;
-    TH1F * CLCTPerEvent;
-    TH1F * recHitsPerEvent;
-    TH1F * segmentsPerEvent;
-//---- Histogram set (stations)...
-    struct StationHistos{
-      TH1F * segmentChi2_ndf;
-      TH1F * hitsInSegment;
-      TH1F * AllSegments_eta;
-      TH1F * EfficientSegments_eta;
-      TH1F * ResidualSegments;
-      TH2F * EfficientSegments_XY;
-      TH2F * InefficientSegments_XY;
-      TH1F * EfficientALCT_momTheta;
-      TH1F * InefficientALCT_momTheta;
-      TH1F * EfficientCLCT_momPhi;
-      TH1F * InefficientCLCT_momPhi;
-    }StHist[2][4];
-//---- Histogram set (chambers)...
-  struct ChamberHistos{
-    TH1F * EfficientRechits_inSegment;
-    TH1F * InefficientSingleHits;
-    TH1F * digiAppearanceCount;
-    TH1F * AllSingleHits;
-    TH1F * EfficientRechits_good;
-    TH1F * EfficientALCT_dydz;
-    TH1F * InefficientALCT_dydz;
-    TH1F * EfficientCLCT_dxdz;
-    TH1F * InefficientCLCT_dxdz;
-    TH1F * EfficientStrips;
-    TH1F * StripWiresCorrelations;
-    TH1F * NoWires_momTheta;
-    TH1F * NoStrips_momPhi;
-    TH1F * EfficientWireGroups;
+  //---- Histograms
+  TH1F *DataFlow;
+  TH1F *TriggersFired;
+  //
+  TH1F *ALCTPerEvent;
+  TH1F *CLCTPerEvent;
+  TH1F *recHitsPerEvent;
+  TH1F *segmentsPerEvent;
+  //---- Histogram set (stations)...
+  struct StationHistos {
+    TH1F *segmentChi2_ndf;
+    TH1F *hitsInSegment;
+    TH1F *AllSegments_eta;
+    TH1F *EfficientSegments_eta;
+    TH1F *ResidualSegments;
+    TH2F *EfficientSegments_XY;
+    TH2F *InefficientSegments_XY;
+    TH1F *EfficientALCT_momTheta;
+    TH1F *InefficientALCT_momTheta;
+    TH1F *EfficientCLCT_momPhi;
+    TH1F *InefficientCLCT_momPhi;
+  } StHist[2][4];
+  //---- Histogram set (chambers)...
+  struct ChamberHistos {
+    TH1F *EfficientRechits_inSegment;
+    TH1F *InefficientSingleHits;
+    TH1F *digiAppearanceCount;
+    TH1F *AllSingleHits;
+    TH1F *EfficientRechits_good;
+    TH1F *EfficientALCT_dydz;
+    TH1F *InefficientALCT_dydz;
+    TH1F *EfficientCLCT_dxdz;
+    TH1F *InefficientCLCT_dxdz;
+    TH1F *EfficientStrips;
+    TH1F *StripWiresCorrelations;
+    TH1F *NoWires_momTheta;
+    TH1F *NoStrips_momPhi;
+    TH1F *EfficientWireGroups;
     std::vector<TH1F *> Y_InefficientRecHits_inSegment;
     std::vector<TH1F *> Y_EfficientRecHits_inSegment;
     std::vector<TH1F *> Phi_InefficientRecHits_inSegment;
     std::vector<TH1F *> Phi_EfficientRecHits_inSegment;
     //
-    TH1F * SimRechits;
-    TH1F * SimSimhits;
+    TH1F *SimRechits;
+    TH1F *SimSimhits;
     /*
     TH1F * SimRechits_each;
     TH1F * SimSimhits_each;
     */
-  }ChHist[2][4][3][LastCh-FirstCh+1];
+  } ChHist[2][4][3][LastCh - FirstCh + 1];
 };
 
 #endif
-
-
-
-

--- a/RecoLocalMuon/CSCValidation/src/CSCValHists.cc
+++ b/RecoLocalMuon/CSCValidation/src/CSCValHists.cc
@@ -3,555 +3,609 @@
 
 using namespace std;
 
+CSCValHists::CSCValHists() { std::cout << "Initializing Histogram Manager..." << std::endl; }
 
-  CSCValHists::CSCValHists(){
+CSCValHists::~CSCValHists() {}
 
-    std::cout << "Initializing Histogram Manager..." << std::endl;
+void CSCValHists::writeHists(TFile* theFile) {
+  std::vector<std::string> theFolders;
+  std::vector<std::string>::iterator fit;
+  theFile->cd();
 
-  }  
-
-
-  CSCValHists::~CSCValHists(){
-
-  }
-
-
-  void CSCValHists::writeHists(TFile* theFile){
-
-    std::vector<std::string> theFolders;
-    std::vector<std::string>::iterator fit;
+  std::map<std::string, std::pair<TH1*, string> >::const_iterator mapit;
+  for (mapit = theMap.begin(); mapit != theMap.end(); mapit++) {
+    std::string folder = (*mapit).second.second;
+    fit = find(theFolders.begin(), theFolders.end(), folder);
+    if (fit == theFolders.end()) {
+      theFolders.push_back(folder);
+      theFile->mkdir(folder.c_str());
+    }
+    theFile->cd((*mapit).second.second.c_str());
+    (*mapit).second.first->Write();
     theFile->cd();
+  }
+}
 
-    std::map<std::string,std::pair<TH1*,string> >::const_iterator mapit;
-    for (mapit = theMap.begin(); mapit != theMap.end(); mapit++){
-      std::string folder = (*mapit).second.second;
-      fit = find(theFolders.begin(), theFolders.end(), folder);
-      if (fit == theFolders.end()){
-        theFolders.push_back(folder);
-        theFile->mkdir(folder.c_str());
-      }
-      theFile->cd((*mapit).second.second.c_str());
-      (*mapit).second.first->Write();
-      theFile->cd();
-    }
+void CSCValHists::writeTrees(TFile* theFile) {
+  theFile->cd("recHits");
+  rHTree->Write();
+  theFile->cd();
 
+  theFile->cd("Segments");
+  segTree->Write();
+  theFile->cd();
+}
+
+void CSCValHists::setupTrees() {
+  // Create the root tree to hold position info
+  rHTree = new TTree("rHPositions", "Local and Global reconstructed positions for recHits");
+  segTree = new TTree("segPositions", "Local and Global reconstructed positions for segments");
+
+  // Create a branch on the tree
+  rHTree->Branch("rHpos", &rHpos, "endcap/I:station/I:ring/I:chamber/I:layer/I:localx/F:localy/F:globalx/F:globaly/F");
+  segTree->Branch(
+      "segpos", &segpos, "endcap/I:station/I:ring/I:chamber/I:layer/I:localx/F:localy/F:globalx/F:globaly/F");
+}
+
+void CSCValHists::fillRechitTree(float x, float y, float gx, float gy, int en, int st, int ri, int ch, int la) {
+  // Fill the rechit position branch
+  rHpos.localx = x;
+  rHpos.localy = y;
+  rHpos.globalx = gx;
+  rHpos.globaly = gy;
+  rHpos.endcap = en;
+  rHpos.ring = ri;
+  rHpos.station = st;
+  rHpos.chamber = ch;
+  rHpos.layer = la;
+  rHTree->Fill();
+}
+
+void CSCValHists::fillSegmentTree(float x, float y, float gx, float gy, int en, int st, int ri, int ch) {
+  // Fill the segment position branch
+  segpos.localx = x;
+  segpos.localy = y;
+  segpos.globalx = gx;
+  segpos.globaly = gy;
+  segpos.endcap = en;
+  segpos.ring = ri;
+  segpos.station = st;
+  segpos.chamber = ch;
+  segpos.layer = 0;
+  segTree->Fill();
+}
+
+void CSCValHists::insertPlot(TH1* thePlot, std::string name, std::string folder) {
+  theMap[name] = std::pair<TH1*, string>(thePlot, folder);
+}
+
+void CSCValHists::fillCalibHist(
+    float x, std::string name, std::string title, int bins, float xmin, float xmax, int bin, std::string folder) {
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = std::pair<TH1*, string>(new TH1I(name.c_str(), title.c_str(), bins, xmin, xmax), folder);
   }
 
-  
-  void CSCValHists::writeTrees(TFile* theFile){
+  theMap[name].first->SetBinContent(bin, x);
+}
 
-    theFile->cd("recHits");
-    rHTree->Write();
-    theFile->cd();
-
-    theFile->cd("Segments");
-    segTree->Write();
-    theFile->cd();
-
-
+void CSCValHists::fill1DHist(
+    float x, std::string name, std::string title, int bins, float xmin, float xmax, std::string folder) {
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = std::pair<TH1*, string>(new TH1I(name.c_str(), title.c_str(), bins, xmin, xmax), folder);
   }
 
-  
-  void CSCValHists::setupTrees(){
+  theMap[name].first->Fill(x);
+}
 
-    // Create the root tree to hold position info
-    rHTree  = new TTree("rHPositions","Local and Global reconstructed positions for recHits");
-    segTree = new TTree("segPositions","Local and Global reconstructed positions for segments");
-
-    // Create a branch on the tree
-    rHTree->Branch("rHpos",&rHpos,"endcap/I:station/I:ring/I:chamber/I:layer/I:localx/F:localy/F:globalx/F:globaly/F");
-    segTree->Branch("segpos",&segpos,"endcap/I:station/I:ring/I:chamber/I:layer/I:localx/F:localy/F:globalx/F:globaly/F");
-
+void CSCValHists::fill2DHist(float x,
+                             float y,
+                             std::string name,
+                             std::string title,
+                             int binsx,
+                             float xmin,
+                             float xmax,
+                             int binsy,
+                             float ymin,
+                             float ymax,
+                             std::string folder) {
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] =
+        std::pair<TH1*, string>(new TH2F(name.c_str(), title.c_str(), binsx, xmin, xmax, binsy, ymin, ymax), folder);
   }
 
-  
-  void CSCValHists::fillRechitTree(float x, float y, float gx, float gy, int en, int st, int ri, int ch, int la){
+  theMap[name].first->Fill(x, y);
+}
 
-    // Fill the rechit position branch
-    rHpos.localx  = x;
-    rHpos.localy  = y;
-    rHpos.globalx = gx;
-    rHpos.globaly = gy;
-    rHpos.endcap  = en;
-    rHpos.ring    = ri;
-    rHpos.station = st;
-    rHpos.chamber = ch;
-    rHpos.layer   = la;
-    rHTree->Fill();
+void CSCValHists::fill1DHistByType(
+    float x, std::string name, std::string title, CSCDetId id, int bins, float xmin, float xmax, std::string folder) {
+  std::string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
 
-  }
-  
-  void CSCValHists::fillSegmentTree(float x, float y, float gx, float gy, int en, int st, int ri, int ch){
-
-    // Fill the segment position branch
-    segpos.localx  = x;
-    segpos.localy  = y;
-    segpos.globalx = gx;
-    segpos.globaly = gy;
-    segpos.endcap  = en;
-    segpos.ring    = ri;
-    segpos.station = st;
-    segpos.chamber = ch;
-    segpos.layer   = 0;
-    segTree->Fill();
-
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << endcap << id.station() << id.ring();
+  oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = std::pair<TH1*, string>(new TH1F(name.c_str(), title.c_str(), bins, xmin, xmax), folder);
   }
 
-  void CSCValHists::insertPlot(TH1* thePlot, std::string name, std::string folder){
+  theMap[name].first->Fill(x);
+}
 
-    theMap[name] = std::pair<TH1*,string>(thePlot, folder);
+void CSCValHists::fill2DHistByType(float x,
+                                   float y,
+                                   std::string name,
+                                   std::string title,
+                                   CSCDetId id,
+                                   int binsx,
+                                   float xmin,
+                                   float xmax,
+                                   int binsy,
+                                   float ymin,
+                                   float ymax,
+                                   std::string folder) {
+  std::string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
 
-  }
-  
-
-  void CSCValHists::fillCalibHist(float x, std::string name, std::string title, int bins, float xmin, float xmax,
-                                  int bin, std::string folder){
-
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH1I(name.c_str(),title.c_str(),bins,xmin,xmax), folder);
-    }
-
-    theMap[name].first->SetBinContent(bin,x);
-
-  }
-
-
-  void CSCValHists::fill1DHist(float x, std::string name, std::string title,
-                               int bins, float xmin, float xmax, std::string folder){
-
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH1I(name.c_str(),title.c_str(),bins,xmin,xmax), folder);
-    }
-
-
-    theMap[name].first->Fill(x);
-
-  }
-
-
-  void CSCValHists::fill2DHist(float x, float y, std::string name, std::string title,
-                               int binsx, float xmin, float xmax,
-                               int binsy, float ymin, float ymax, std::string folder){
-
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH2F(name.c_str(),title.c_str(),binsx,xmin,xmax,binsy,ymin,ymax),folder);
-    }
-
-    theMap[name].first->Fill(x,y);
-
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << endcap << id.station() << id.ring();
+  oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] =
+        std::pair<TH1*, string>(new TH2F(name.c_str(), title.c_str(), binsx, xmin, xmax, binsy, ymin, ymax), folder);
   }
 
+  theMap[name].first->Fill(x, y);
+}
 
-  void CSCValHists::fill1DHistByType(float x, std::string name, std::string title, CSCDetId id,
-                                     int bins, float xmin, float xmax, std::string folder){
+void CSCValHists::fill1DHistByCrate(
+    float x, string name, string title, CSCDetId id, int bins, float xmin, float xmax, string folder) {
+  int crate = crate_lookup(id);
 
-    std::string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
-
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << endcap << id.station() << id.ring();
-    oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << ")";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH1F(name.c_str(),title.c_str(),bins,xmin,xmax), folder);
-    }
-
-    theMap[name].first->Fill(x);
-
+  map<string, pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << "_crate_" << crate;
+  oss2 << title << "  (crate " << crate << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = pair<TH1*, string>(new TH1F(name.c_str(), title.c_str(), bins, xmin, xmax), folder);
   }
 
-  void CSCValHists::fill2DHistByType(float x, float y, std::string name, std::string title, CSCDetId id,
-                                   int binsx, float xmin, float xmax,
-                                   int binsy, float ymin, float ymax, std::string folder){
+  theMap[name].first->Fill(x);
+}
 
-    std::string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
+void CSCValHists::fill2DHistByCrate(float x,
+                                    float y,
+                                    string name,
+                                    string title,
+                                    CSCDetId id,
+                                    int binsx,
+                                    float xmin,
+                                    float xmax,
+                                    int binsy,
+                                    float ymin,
+                                    float ymax,
+                                    string folder) {
+  int crate = crate_lookup(id);
 
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << endcap << id.station() << id.ring();
-    oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << ")";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH2F(name.c_str(),title.c_str(),binsx,xmin,xmax,binsy,ymin,ymax), folder);
-    }
-
-    theMap[name].first->Fill(x,y);
-
+  map<string, pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << "_crate_" << crate;
+  oss2 << title << "  (crate " << crate << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] =
+        pair<TH1*, string>(new TH2F(name.c_str(), title.c_str(), binsx, xmin, xmax, binsy, ymin, ymax), folder);
   }
 
+  theMap[name].first->Fill(x, y);
+}
 
-  void CSCValHists::fill1DHistByCrate(float x, string name, string title, CSCDetId id,
-                                     int bins, float xmin, float xmax, string folder){
+void CSCValHists::fill1DHistByStation(
+    float x, string name, string title, CSCDetId id, int bins, float xmin, float xmax, string folder) {
+  string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
 
-    int crate = crate_lookup(id); 
-  
-    map<string,pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << "_crate_" << crate;
-    oss2 << title << "  (crate " << crate << ")";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = pair<TH1*,string>(new TH1F(name.c_str(),title.c_str(),bins,xmin,xmax), folder);
-    }
-  
-    theMap[name].first->Fill(x);
-  
+  map<string, pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << endcap << id.station();
+  oss2 << title << "  (Station " << endcap << id.station() << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = pair<TH1*, string>(new TH1F(name.c_str(), title.c_str(), bins, xmin, xmax), folder);
   }
 
-  void CSCValHists::fill2DHistByCrate(float x, float y, string name, string title, CSCDetId id,
-				      int binsx, float xmin, float xmax,
-				      int binsy, float ymin, float ymax, string folder){
-    
-    int crate = crate_lookup(id); 
-     
-    map<string,pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << "_crate_" << crate;
-    oss2 << title << "  (crate " << crate << ")";   
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = pair<TH1*,string>(new TH2F(name.c_str(),title.c_str(),binsx,xmin,xmax,binsy,ymin,ymax), folder);
-    }
-    
-    theMap[name].first->Fill(x,y);
-    
+  theMap[name].first->Fill(x);
+}
+
+void CSCValHists::fill2DHistByStation(float x,
+                                      float y,
+                                      string name,
+                                      string title,
+                                      CSCDetId id,
+                                      int binsx,
+                                      float xmin,
+                                      float xmax,
+                                      int binsy,
+                                      float ymin,
+                                      float ymax,
+                                      std::string folder) {
+  std::string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
+
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << endcap << id.station();
+  oss2 << title << "  (Station " << endcap << id.station() << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] =
+        std::pair<TH1*, string>(new TH2F(name.c_str(), title.c_str(), binsx, xmin, xmax, binsy, ymin, ymax), folder);
   }
 
+  theMap[name].first->Fill(x, y);
+}
 
+void CSCValHists::fill1DHistByChamber(
+    float x, std::string name, std::string title, CSCDetId id, int bins, float xmin, float xmax, std::string folder) {
+  std::string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
 
-  void CSCValHists::fill1DHistByStation(float x, string name, string title, CSCDetId id,
-                                        int bins, float xmin, float xmax, string folder){
-
-    string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
-
-    map<string,pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << endcap << id.station();
-    oss2 << title << "  (Station " << endcap << id.station() << ")";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = pair<TH1*,string>(new TH1F(name.c_str(),title.c_str(),bins,xmin,xmax), folder);
-    }
-
-    theMap[name].first->Fill(x);
-
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber();
+  oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = std::pair<TH1*, string>(new TH1F(name.c_str(), title.c_str(), bins, xmin, xmax), folder);
   }
 
+  theMap[name].first->Fill(x);
+}
 
-  void CSCValHists::fill2DHistByStation(float x, float y, string name, string title, CSCDetId id,
-                                        int binsx, float xmin, float xmax,
-                                        int binsy, float ymin, float ymax, std::string folder){
+void CSCValHists::fill2DHistByChamber(float x,
+                                      float y,
+                                      std::string name,
+                                      std::string title,
+                                      CSCDetId id,
+                                      int binsx,
+                                      float xmin,
+                                      float xmax,
+                                      int binsy,
+                                      float ymin,
+                                      float ymax,
+                                      std::string folder) {
+  std::string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
 
-    std::string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
-
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << endcap << id.station();
-    oss2 << title << "  (Station " << endcap << id.station() << ")";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH2F(name.c_str(),title.c_str(),binsx,xmin,xmax,binsy,ymin,ymax), folder);
-    }
-
-    theMap[name].first->Fill(x,y);
-
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber();
+  oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] =
+        std::pair<TH1*, string>(new TH2F(name.c_str(), title.c_str(), binsx, xmin, xmax, binsy, ymin, ymax), folder);
   }
 
+  theMap[name].first->Fill(x, y);
+}
 
-  void CSCValHists::fill1DHistByChamber(float x, std::string name, std::string title, CSCDetId id,
-                                       int bins, float xmin, float xmax, std::string folder){
+void CSCValHists::fill2DHistByEvent(int run, int event, float z, string name, string title, CSCDetId id, string folder) {
+  string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
 
-    std::string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
-
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber();
-    oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << ")";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH1F(name.c_str(),title.c_str(),bins,xmin,xmax),folder);
-    }
-
-    theMap[name].first->Fill(x);
-
+  map<string, pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << "_" << run << "_" << event;
+  oss2 << title << "  ( Run: " << run << " Event: " << event << " )";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = pair<TH1*, string>(new TH2F(name.c_str(), title.c_str(), 36, 0.5, 36.5, 18, 0.5, 18.5), folder);
   }
 
+  int x = id.chamber();
+  int y = id.ring();
+  if (y == 4)
+    y = 1;  //collapsing ME1/1a into ME1/1
+  if (id.station() > 1)
+    y = y + 3 + (id.station() - 2) * 2;
 
-  void CSCValHists::fill2DHistByChamber(float x, float y, std::string name, std::string title, CSCDetId id,
-                                        int binsx, float xmin, float xmax,
-                                        int binsy, float ymin, float ymax, std::string folder){
+  if (id.endcap() == 1)
+    y = y + 9;
+  else
+    y = -1 * y + 10;
 
-    std::string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
+  dynamic_cast<TH2F*>(theMap[name].first)->Fill(x, y, z);
+}
 
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber();
-    oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << ")";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH2F(name.c_str(),title.c_str(),binsx,xmin,xmax,binsy,ymin,ymax),folder);
-    }
-
-    theMap[name].first->Fill(x,y);
-
+void CSCValHists::fill2DHist(float z, string name, string title, CSCDetId id, string folder) {
+  map<string, pair<TH1*, string> >::iterator it;
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = pair<TH1*, string>(new TH2F(name.c_str(), title.c_str(), 36, 0.5, 36.5, 18, 0.5, 18.5), folder);
   }
 
-  void CSCValHists::fill2DHistByEvent(int run, int event, float z, string name, string title, CSCDetId id, string folder){
+  int x = id.chamber();
+  int y = id.ring();
+  if (y == 4)
+    y = 1;  //collapsing ME1/1a into ME1/1
+  if (id.station() > 1)
+    y = y + 3 + (id.station() - 2) * 2;
 
-    string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
-    
-    map<string,pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << "_" << run  << "_" << event ;
-    oss2 << title << "  ( Run: " << run  << " Event: " << event  << " )";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = pair<TH1*,string>(new TH2F(name.c_str(),title.c_str(),36,0.5,36.5,18,0.5,18.5),folder);
-    }
+  if (id.endcap() == 1)
+    y = y + 9;
+  else
+    y = -1 * y + 10;
 
-    int x = id.chamber();
-    int y = id.ring();
-    if (y==4) y =1; //collapsing ME1/1a into ME1/1
-    if (id.station() >1)
-      y = y + 3 + (id.station()-2)*2;
-    
-    if (id.endcap()==1)
-      y = y+9;
-    else
-      y = -1*y+10;
-    
-    dynamic_cast<TH2F*>(theMap[name].first)->Fill(x,y,z);
-    
+  dynamic_cast<TH2F*>(theMap[name].first)->Fill(x, y, z);
+}
+
+void CSCValHists::fill1DHistByLayer(
+    float x, string name, string title, CSCDetId id, int bins, float xmin, float xmax, string folder) {
+  std::string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
+
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber() << "_L" << id.layer();
+  oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << "/L" << id.layer()
+       << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = std::pair<TH1*, string>(new TH1F(name.c_str(), title.c_str(), bins, xmin, xmax), folder);
   }
 
-  void CSCValHists::fill2DHist(float z, string name, string title, CSCDetId id, string folder){
+  theMap[name].first->Fill(x);
+}
 
-    map<string,pair<TH1*,string> >::iterator it;
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = pair<TH1*,string>(new TH2F(name.c_str(),title.c_str(),36,0.5,36.5,18,0.5,18.5),folder);
-    }
+void CSCValHists::fill2DHistByLayer(float x,
+                                    float y,
+                                    std::string name,
+                                    std::string title,
+                                    CSCDetId id,
+                                    int binsx,
+                                    float xmin,
+                                    float xmax,
+                                    int binsy,
+                                    float ymin,
+                                    float ymax,
+                                    std::string folder) {
+  std::string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
 
-    int x = id.chamber();
-    int y = id.ring();
-    if (y==4) y =1; //collapsing ME1/1a into ME1/1
-    if (id.station() >1)
-      y = y + 3 + (id.station()-2)*2;
-
-    if (id.endcap()==1)
-      y = y+9;
-    else
-      y = -1*y+10;
-
-    dynamic_cast<TH2F*>(theMap[name].first)->Fill(x,y,z);
-
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber() << "_L" << id.layer();
+  ;
+  oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << "/L" << id.layer()
+       << ")";
+  name = oss1.str();
+  title = oss2.str();
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] =
+        std::pair<TH1*, string>(new TH2F(name.c_str(), title.c_str(), binsx, xmin, xmax, binsy, ymin, ymax), folder);
   }
 
-  void CSCValHists::fill1DHistByLayer(float x, string name, string title, CSCDetId id,
-                                      int bins, float xmin, float xmax, string folder){
+  theMap[name].first->Fill(x, y);
+}
 
-    std::string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
-
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber() << "_L" << id.layer();
-    oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << "/L" << id.layer() << ")";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH1F(name.c_str(),title.c_str(),bins,xmin,xmax),folder);
-    }
-
-    theMap[name].first->Fill(x);
-
+void CSCValHists::fillProfile(float x,
+                              float y,
+                              std::string name,
+                              std::string title,
+                              int binsx,
+                              float xmin,
+                              float xmax,
+                              float ymin,
+                              float ymax,
+                              std::string folder) {
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] =
+        std::pair<TProfile*, string>(new TProfile(name.c_str(), title.c_str(), binsx, xmin, xmax, ymin, ymax), folder);
   }
 
+  theMap[name].first->Fill(x, y);
+}
 
-  void CSCValHists::fill2DHistByLayer(float x, float y, std::string name, std::string title, CSCDetId id,
-                                      int binsx, float xmin, float xmax,
-                                      int binsy, float ymin, float ymax, std::string folder){
+void CSCValHists::fillProfileByType(float x,
+                                    float y,
+                                    std::string name,
+                                    std::string title,
+                                    CSCDetId id,
+                                    int binsx,
+                                    float xmin,
+                                    float xmax,
+                                    float ymin,
+                                    float ymax,
+                                    std::string folder) {
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  std::string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
 
-    std::string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << endcap << id.station() << id.ring();
+  oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << ")";
+  name = oss1.str();
+  title = oss2.str();
 
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber() << "_L" << id.layer();;
-    oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << "/L" << id.layer() << ")";
-    name = oss1.str();
-    title = oss2.str();
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TH1*,string>(new TH2F(name.c_str(),title.c_str(),binsx,xmin,xmax,binsy,ymin,ymax),folder);
-    }
-
-    theMap[name].first->Fill(x,y);
-
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] =
+        std::pair<TProfile*, string>(new TProfile(name.c_str(), title.c_str(), binsx, xmin, xmax, ymin, ymax), folder);
   }
 
+  theMap[name].first->Fill(x, y);
+}
 
-  void CSCValHists::fillProfile(float x, float y, std::string name, std::string title,
-                                int binsx, float xmin, float xmax,
-                                float ymin, float ymax, std::string folder){
+void CSCValHists::fillProfileByChamber(float x,
+                                       float y,
+                                       std::string name,
+                                       std::string title,
+                                       CSCDetId id,
+                                       int binsx,
+                                       float xmin,
+                                       float xmax,
+                                       float ymin,
+                                       float ymax,
+                                       std::string folder) {
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
+  std::string endcap;
+  if (id.endcap() == 1)
+    endcap = "+";
+  if (id.endcap() == 2)
+    endcap = "-";
 
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TProfile*,string>(new TProfile(name.c_str(),title.c_str(),binsx,xmin,xmax,ymin,ymax), folder);
-    }
+  ostringstream oss1;
+  ostringstream oss2;
+  oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber();
+  oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << ")";
+  name = oss1.str();
+  title = oss2.str();
 
-    theMap[name].first->Fill(x,y);
-
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] =
+        std::pair<TProfile*, string>(new TProfile(name.c_str(), title.c_str(), binsx, xmin, xmax, ymin, ymax), folder);
   }
 
+  theMap[name].first->Fill(x, y);
+}
 
-  void CSCValHists::fillProfileByType(float x, float y, std::string name, std::string title, CSCDetId id,
-                                      int binsx, float xmin, float xmax,
-                                      float ymin, float ymax, std::string folder){
+void CSCValHists::fill2DProfile(float x,
+                                float y,
+                                float z,
+                                std::string name,
+                                std::string title,
+                                int binsx,
+                                float xmin,
+                                float xmax,
+                                int binsy,
+                                float ymin,
+                                float ymax,
+                                float zmin,
+                                float zmax,
+                                std::string folder) {
+  std::map<std::string, std::pair<TH1*, string> >::iterator it;
 
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    std::string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
-
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << endcap << id.station() << id.ring();
-    oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << ")";
-    name = oss1.str();
-    title = oss2.str();
-
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TProfile*,string>(new TProfile(name.c_str(),title.c_str(),binsx,xmin,xmax,ymin,ymax), folder);
-    }
-
-    theMap[name].first->Fill(x,y);
-
+  it = theMap.find(name);
+  if (it == theMap.end()) {
+    theMap[name] = std::pair<TProfile2D*, string>(
+        new TProfile2D(name.c_str(), title.c_str(), binsx, xmin, xmax, binsy, ymin, ymax, zmin, zmax), folder);
   }
 
+  TProfile2D* tempp = (TProfile2D*)theMap[name].first;
+  tempp->Fill(x, y, z);
+}
 
-  void CSCValHists::fillProfileByChamber(float x, float y, std::string name, std::string title, CSCDetId id,
-                                         int binsx, float xmin, float xmax,
-                                         float ymin, float ymax, std::string folder){
-
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-    std::string endcap;
-    if (id.endcap() == 1) endcap = "+";
-    if (id.endcap() == 2) endcap = "-";
-
-    ostringstream oss1;
-    ostringstream oss2;
-    oss1 << name << "_" << endcap << id.station() << "_" << id.ring() << "_" << id.chamber();
-    oss2 << title << "  (ME " << endcap << id.station() << "/" << id.ring() << "/" << id.chamber() << ")";
-    name = oss1.str();
-    title = oss2.str();
-
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TProfile*,string>(new TProfile(name.c_str(),title.c_str(),binsx,xmin,xmax,ymin,ymax), folder);
-    }
-
-    theMap[name].first->Fill(x,y);
-
-  }
-
-
-  void CSCValHists::fill2DProfile(float x, float y, float z, std::string name, std::string title,
-                                  int binsx, float xmin, float xmax,
-                                  int binsy, float ymin, float ymax,
-                                  float zmin, float zmax, std::string folder){
-
-    std::map<std::string,std::pair<TH1*,string> >::iterator it;
-
-    it = theMap.find(name);
-    if (it == theMap.end()){
-      theMap[name] = std::pair<TProfile2D*,string>(new TProfile2D(name.c_str(),title.c_str(),binsx,xmin,xmax,binsy,ymin,ymax,zmin,zmax), folder);
-    }
-
-    TProfile2D *tempp = (TProfile2D*)theMap[name].first;
-    tempp->Fill(x,y,z);
-
-  }
-
-int CSCValHists::crate_lookup(CSCDetId id){
-
+int CSCValHists::crate_lookup(CSCDetId id) {
   int crate = 0;
 
-  if (id.station() == 1){
-    if (id.chamber() == 36 || id.chamber() == 1  || id.chamber() == 2  ) crate = 1;
-    if (id.chamber() == 3  || id.chamber() == 4  || id.chamber() == 5  ) crate = 2;
-    if (id.chamber() == 6  || id.chamber() == 7  || id.chamber() == 8  ) crate = 3;
-    if (id.chamber() == 9  || id.chamber() == 10 || id.chamber() == 11 ) crate = 4;
-    if (id.chamber() == 12 || id.chamber() == 13 || id.chamber() == 14 ) crate = 5;
-    if (id.chamber() == 15 || id.chamber() == 16 || id.chamber() == 17 ) crate = 6;
-    if (id.chamber() == 18 || id.chamber() == 19 || id.chamber() == 20 ) crate = 7;
-    if (id.chamber() == 21 || id.chamber() == 22 || id.chamber() == 23 ) crate = 8;
-    if (id.chamber() == 24 || id.chamber() == 25 || id.chamber() == 26 ) crate = 9;
-    if (id.chamber() == 27 || id.chamber() == 28 || id.chamber() == 29 ) crate = 10;
-    if (id.chamber() == 30 || id.chamber() == 31 || id.chamber() == 32 ) crate = 11;
-    if (id.chamber() == 33 || id.chamber() == 34 || id.chamber() == 35 ) crate = 12;
-  }
-  else{
-    crate = 12 + id.triggerSector() + (id.station()-2)*6;
+  if (id.station() == 1) {
+    if (id.chamber() == 36 || id.chamber() == 1 || id.chamber() == 2)
+      crate = 1;
+    if (id.chamber() == 3 || id.chamber() == 4 || id.chamber() == 5)
+      crate = 2;
+    if (id.chamber() == 6 || id.chamber() == 7 || id.chamber() == 8)
+      crate = 3;
+    if (id.chamber() == 9 || id.chamber() == 10 || id.chamber() == 11)
+      crate = 4;
+    if (id.chamber() == 12 || id.chamber() == 13 || id.chamber() == 14)
+      crate = 5;
+    if (id.chamber() == 15 || id.chamber() == 16 || id.chamber() == 17)
+      crate = 6;
+    if (id.chamber() == 18 || id.chamber() == 19 || id.chamber() == 20)
+      crate = 7;
+    if (id.chamber() == 21 || id.chamber() == 22 || id.chamber() == 23)
+      crate = 8;
+    if (id.chamber() == 24 || id.chamber() == 25 || id.chamber() == 26)
+      crate = 9;
+    if (id.chamber() == 27 || id.chamber() == 28 || id.chamber() == 29)
+      crate = 10;
+    if (id.chamber() == 30 || id.chamber() == 31 || id.chamber() == 32)
+      crate = 11;
+    if (id.chamber() == 33 || id.chamber() == 34 || id.chamber() == 35)
+      crate = 12;
+  } else {
+    crate = 12 + id.triggerSector() + (id.station() - 2) * 6;
   }
 
-  if (id.endcap() == 2) 
-    crate = crate+30;
+  if (id.endcap() == 2)
+    crate = crate + 30;
 
   return crate;
-
 }

--- a/RecoLocalMuon/CSCValidation/src/CSCValHists.h
+++ b/RecoLocalMuon/CSCValidation/src/CSCValHists.h
@@ -1,7 +1,6 @@
 #ifndef RecoLocalMuon_CSCValHists_H
 #define RecoLocalMuon_CSCValHists_H
 
-
 /** \class CSCValHists
  *
  *  Manages Histograms for CSCValidation
@@ -9,7 +8,6 @@
  *  Andy Kubik - Northwestern University
  *
  */
-
 
 // system include files
 #include <memory>
@@ -31,19 +29,15 @@
 #include "TTree.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 
-
-
-class CSCValHists{
-
-  public:
-
+class CSCValHists {
+public:
   // constructor
   CSCValHists();
 
   // destructor
   ~CSCValHists();
 
-    // write histograms the theFile
+  // write histograms the theFile
   void writeHists(TFile* theFile);
 
   // write trees to theFile
@@ -52,127 +46,207 @@ class CSCValHists{
   // setup trees
   void setupTrees();
 
-  // fill the global rechit position tree (this needs work!)  
-  void fillRechitTree(float x, float y, float gx, float gy,
-                      int en, int st, int ri, int ch, int la);
+  // fill the global rechit position tree (this needs work!)
+  void fillRechitTree(float x, float y, float gx, float gy, int en, int st, int ri, int ch, int la);
 
   // fill the global segment position tree
-  void fillSegmentTree(float x, float y, float gx, float gy,
-                       int en, int st, int ri, int ch);
+  void fillSegmentTree(float x, float y, float gx, float gy, int en, int st, int ri, int ch);
 
   // insert any TH1 into the big map
   void insertPlot(TH1* thePlot, std::string name, std::string folder);
 
   // calib hists are special because they are constants stored in a histogram, 1 per bin
-  void fillCalibHist(float x, std::string name, std::string title, int bins, float xmin, float xmax,
-                     int bin, std::string folder);
+  void fillCalibHist(
+      float x, std::string name, std::string title, int bins, float xmin, float xmax, int bin, std::string folder);
 
-  // fill 1D histogram 
-  void fill1DHist(float x, std::string name, std::string title,
-                  int bins, float xmin, float xmax, std::string folder);
+  // fill 1D histogram
+  void fill1DHist(float x, std::string name, std::string title, int bins, float xmin, float xmax, std::string folder);
 
   // fill 2D histogram
-  void fill2DHist(float x, float y, std::string name, std::string title,
-                  int binsx, float xmin, float xmax,
-                  int binsy, float ymin, float ymax, std::string folder);
+  void fill2DHist(float x,
+                  float y,
+                  std::string name,
+                  std::string title,
+                  int binsx,
+                  float xmin,
+                  float xmax,
+                  int binsy,
+                  float ymin,
+                  float ymax,
+                  std::string folder);
 
   // fill 1D histogram
   // a histogram is created for every chamber type
-  void fill1DHistByType(float x, std::string name, std::string title, CSCDetId id,
-                        int bins, float xmin, float xmax, std::string folder);
+  void fill1DHistByType(
+      float x, std::string name, std::string title, CSCDetId id, int bins, float xmin, float xmax, std::string folder);
 
   // fill 2D histogram
   // a histogram is created for every chamber type
-  void fill2DHistByType(float x, float y, std::string name, std::string title, CSCDetId id,
-                        int binsx, float xmin, float xmax,
-                        int binsy, float ymin, float ymax, std::string folder);
+  void fill2DHistByType(float x,
+                        float y,
+                        std::string name,
+                        std::string title,
+                        CSCDetId id,
+                        int binsx,
+                        float xmin,
+                        float xmax,
+                        int binsy,
+                        float ymin,
+                        float ymax,
+                        std::string folder);
 
   // fill 1D histogram
   // a histogram is created for every peripheral crate
-  void fill1DHistByCrate(float x, std::string name, std::string title, CSCDetId id,
-                        int bins, float xmin, float xmax, std::string folder);
+  void fill1DHistByCrate(
+      float x, std::string name, std::string title, CSCDetId id, int bins, float xmin, float xmax, std::string folder);
 
   // fill 2D histogram
   // a histogram is created for every peripheral crate
-  void fill2DHistByCrate(float x, float y, std::string name, std::string title, CSCDetId id,
-                        int binsx, float xmin, float xmax,
-                        int binsy, float ymin, float ymax, std::string folder);
+  void fill2DHistByCrate(float x,
+                         float y,
+                         std::string name,
+                         std::string title,
+                         CSCDetId id,
+                         int binsx,
+                         float xmin,
+                         float xmax,
+                         int binsy,
+                         float ymin,
+                         float ymax,
+                         std::string folder);
 
   // fill 2D histogram
   // a histogram is created for every station
-  void fill1DHistByStation(float x, std::string name, std::string title, CSCDetId id,
-                           int bins, float xmin, float xmax, std::string folder);
-
+  void fill1DHistByStation(
+      float x, std::string name, std::string title, CSCDetId id, int bins, float xmin, float xmax, std::string folder);
 
   // fill 2D histogram
   // a histogram is created for every station
-  void fill2DHistByStation(float x, float y, std::string name, std::string title, CSCDetId id,
-                           int binsx, float xmin, float xmax,
-                           int binsy, float ymin, float ymax, std::string folder);
+  void fill2DHistByStation(float x,
+                           float y,
+                           std::string name,
+                           std::string title,
+                           CSCDetId id,
+                           int binsx,
+                           float xmin,
+                           float xmax,
+                           int binsy,
+                           float ymin,
+                           float ymax,
+                           std::string folder);
 
   // fill 1D histogram
   // a histogram is created for every chamber
-  void fill1DHistByChamber(float x, std::string name, std::string title, CSCDetId id,
-                           int bins, float xmin, float xmax, std::string folder);
+  void fill1DHistByChamber(
+      float x, std::string name, std::string title, CSCDetId id, int bins, float xmin, float xmax, std::string folder);
 
   // fill 2D histogram
   // a histogram is created for every chamber
-  void fill2DHistByChamber(float x, float y, std::string name, std::string title, CSCDetId id,
-                           int binsx, float xmin, float xmax,
-                           int binsy, float ymin, float ymax, std::string folder);
+  void fill2DHistByChamber(float x,
+                           float y,
+                           std::string name,
+                           std::string title,
+                           CSCDetId id,
+                           int binsx,
+                           float xmin,
+                           float xmax,
+                           int binsy,
+                           float ymin,
+                           float ymax,
+                           std::string folder);
 
   // fill 2D histogram of entire detector
   // once per event
-  void fill2DHistByEvent(int run, int event, float x, std::string name, std::string title, CSCDetId id, std::string folder);
-  
+  void fill2DHistByEvent(
+      int run, int event, float x, std::string name, std::string title, CSCDetId id, std::string folder);
+
   // fill 2D histogram of entire detector
   // with a value z for the specified chamber
   void fill2DHist(float z, std::string name, std::string title, CSCDetId id, std::string folder);
 
   // fill 1D histogram
   // a histogram is created for every layer in every chamber
-  void fill1DHistByLayer(float x, std::string name, std::string title, CSCDetId id,
-                         int bins, float xmin, float xmax, std::string folder);
+  void fill1DHistByLayer(
+      float x, std::string name, std::string title, CSCDetId id, int bins, float xmin, float xmax, std::string folder);
 
   // fill 2D histogram
   // a histogram is created for every layer in every chamber
-  void fill2DHistByLayer(float x, float y, std::string name, std::string title, CSCDetId id,
-                         int binsx, float xmin, float xmax,
-                         int binsy, float ymin, float ymax, std::string folder);
-
+  void fill2DHistByLayer(float x,
+                         float y,
+                         std::string name,
+                         std::string title,
+                         CSCDetId id,
+                         int binsx,
+                         float xmin,
+                         float xmax,
+                         int binsy,
+                         float ymin,
+                         float ymax,
+                         std::string folder);
 
   // make a profile histogram
-  void fillProfile(float x, float y, std::string name, std::string title, 
-                   int binsx, float xmin, float xmax,
-                   float ymin, float ymax, std::string folder);
+  void fillProfile(float x,
+                   float y,
+                   std::string name,
+                   std::string title,
+                   int binsx,
+                   float xmin,
+                   float xmax,
+                   float ymin,
+                   float ymax,
+                   std::string folder);
 
   // make a profile histogram
   // one will be made for every chamber type
-  void fillProfileByType(float x, float y, std::string name, std::string title, CSCDetId id,
-                         int binsx, float xmin, float xmax,
-                         float ymin, float ymax, std::string folder);
+  void fillProfileByType(float x,
+                         float y,
+                         std::string name,
+                         std::string title,
+                         CSCDetId id,
+                         int binsx,
+                         float xmin,
+                         float xmax,
+                         float ymin,
+                         float ymax,
+                         std::string folder);
 
   // make a profile histogram
   // one will be made for every chamber
-  void fillProfileByChamber(float x, float y, std::string name, std::string title, CSCDetId id,
-                            int binsx, float xmin, float xmax,
-                            float ymin, float ymax, std::string folder);
+  void fillProfileByChamber(float x,
+                            float y,
+                            std::string name,
+                            std::string title,
+                            CSCDetId id,
+                            int binsx,
+                            float xmin,
+                            float xmax,
+                            float ymin,
+                            float ymax,
+                            std::string folder);
 
   // make a 2D profile histogram (usefull for summary plots)
-  void fill2DProfile(float x, float y, float z, std::string name, std::string title, 
-                     int binsx, float xmin, float xmax,
-                     int binsy, float ymin, float ymax,
-                     float zmin, float zmax, std::string folder);
+  void fill2DProfile(float x,
+                     float y,
+                     float z,
+                     std::string name,
+                     std::string title,
+                     int binsx,
+                     float xmin,
+                     float xmax,
+                     int binsy,
+                     float ymin,
+                     float ymax,
+                     float zmin,
+                     float zmax,
+                     std::string folder);
 
   // look-up which crate this chamber belongs to
   int crate_lookup(CSCDetId id);
 
-  protected:
-
-  private:
-
+protected:
+private:
   // map to hold histograms
-  std::map<std::string,std::pair<TH1*,std::string> > theMap;
+  std::map<std::string, std::pair<TH1*, std::string> > theMap;
 
   // A struct for creating a Tree/Branch of position info
   struct posRecord {
@@ -188,9 +262,8 @@ class CSCValHists{
   } rHpos, segpos;
 
   // The root tree
-  TTree *rHTree;
-  TTree *segTree;
-
+  TTree* rHTree;
+  TTree* segTree;
 };
 
-#endif   
+#endif

--- a/RecoLocalMuon/CSCValidation/src/CSCValidation.cc
+++ b/RecoLocalMuon/CSCValidation/src/CSCValidation.cc
@@ -10,76 +10,74 @@
 using namespace std;
 using namespace edm;
 
-
 ///////////////////
 //  CONSTRUCTOR  //
 ///////////////////
-CSCValidation::CSCValidation(const ParameterSet& pset){ 
-
+CSCValidation::CSCValidation(const ParameterSet& pset) {
   // Get the various input parameters
-  rootFileName         = pset.getUntrackedParameter<std::string>("rootFileName","valHists.root");
-  isSimulation         = pset.getUntrackedParameter<bool>("isSimulation",false);
-  writeTreeToFile      = pset.getUntrackedParameter<bool>("writeTreeToFile",true);
-  detailedAnalysis     = pset.getUntrackedParameter<bool>("detailedAnalysis",false);
-  useDigis             = pset.getUntrackedParameter<bool>("useDigis",true);
+  rootFileName = pset.getUntrackedParameter<std::string>("rootFileName", "valHists.root");
+  isSimulation = pset.getUntrackedParameter<bool>("isSimulation", false);
+  writeTreeToFile = pset.getUntrackedParameter<bool>("writeTreeToFile", true);
+  detailedAnalysis = pset.getUntrackedParameter<bool>("detailedAnalysis", false);
+  useDigis = pset.getUntrackedParameter<bool>("useDigis", true);
 
   // event quality filter
-  useQualityFilter     = pset.getUntrackedParameter<bool>("useQualityFilter",false);
-  pMin                 = pset.getUntrackedParameter<double>("pMin",4.);
-  chisqMax             = pset.getUntrackedParameter<double>("chisqMax",20.);
-  nCSCHitsMin          = pset.getUntrackedParameter<int>("nCSCHitsMin",10);
-  nCSCHitsMax          = pset.getUntrackedParameter<int>("nCSCHitsMax",25);
-  lengthMin            = pset.getUntrackedParameter<double>("lengthMin",140.);
-  lengthMax            = pset.getUntrackedParameter<double>("lengthMax",600.);
-  deltaPhiMax          = pset.getUntrackedParameter<double>("deltaPhiMax",0.2);
-  polarMax             = pset.getUntrackedParameter<double>("polarMax",0.7);
-  polarMin             = pset.getUntrackedParameter<double>("polarMin",0.3);
+  useQualityFilter = pset.getUntrackedParameter<bool>("useQualityFilter", false);
+  pMin = pset.getUntrackedParameter<double>("pMin", 4.);
+  chisqMax = pset.getUntrackedParameter<double>("chisqMax", 20.);
+  nCSCHitsMin = pset.getUntrackedParameter<int>("nCSCHitsMin", 10);
+  nCSCHitsMax = pset.getUntrackedParameter<int>("nCSCHitsMax", 25);
+  lengthMin = pset.getUntrackedParameter<double>("lengthMin", 140.);
+  lengthMax = pset.getUntrackedParameter<double>("lengthMax", 600.);
+  deltaPhiMax = pset.getUntrackedParameter<double>("deltaPhiMax", 0.2);
+  polarMax = pset.getUntrackedParameter<double>("polarMax", 0.7);
+  polarMin = pset.getUntrackedParameter<double>("polarMin", 0.3);
 
   // trigger filter
-  useTriggerFilter     = pset.getUntrackedParameter<bool>("useTriggerFilter",false);
+  useTriggerFilter = pset.getUntrackedParameter<bool>("useTriggerFilter", false);
 
   // input tags for collections
-  rd_token = consumes<FEDRawDataCollection>( pset.getParameter<edm::InputTag>("rawDataTag") );
-  sd_token = consumes<CSCStripDigiCollection>( pset.getParameter<edm::InputTag>("stripDigiTag") );
-  wd_token = consumes<CSCWireDigiCollection>( pset.getParameter<edm::InputTag>("wireDigiTag") );
-  cd_token = consumes<CSCComparatorDigiCollection>( pset.getParameter<edm::InputTag>("compDigiTag") );
-  al_token = consumes<CSCALCTDigiCollection>( pset.getParameter<edm::InputTag>("alctDigiTag") );
-  cl_token = consumes<CSCCLCTDigiCollection>( pset.getParameter<edm::InputTag>("clctDigiTag") );
-  co_token = consumes<CSCCorrelatedLCTDigiCollection>( pset.getParameter<edm::InputTag>("corrlctDigiTag") );
-  rh_token = consumes<CSCRecHit2DCollection>( pset.getParameter<edm::InputTag>("cscRecHitTag") );
-  se_token = consumes<CSCSegmentCollection>( pset.getParameter<edm::InputTag>("cscSegTag") );
-  sa_token = consumes<reco::TrackCollection>( pset.getParameter<edm::InputTag>("saMuonTag") );
-  l1_token = consumes<L1MuGMTReadoutCollection>( pset.getParameter<edm::InputTag>("l1aTag") );
-  tr_token = consumes<TriggerResults>( pset.getParameter<edm::InputTag>("hltTag") );
-  sh_token = consumes<PSimHitContainer>( pset.getParameter<edm::InputTag>("simHitTag") );
+  rd_token = consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("rawDataTag"));
+  sd_token = consumes<CSCStripDigiCollection>(pset.getParameter<edm::InputTag>("stripDigiTag"));
+  wd_token = consumes<CSCWireDigiCollection>(pset.getParameter<edm::InputTag>("wireDigiTag"));
+  cd_token = consumes<CSCComparatorDigiCollection>(pset.getParameter<edm::InputTag>("compDigiTag"));
+  al_token = consumes<CSCALCTDigiCollection>(pset.getParameter<edm::InputTag>("alctDigiTag"));
+  cl_token = consumes<CSCCLCTDigiCollection>(pset.getParameter<edm::InputTag>("clctDigiTag"));
+  co_token = consumes<CSCCorrelatedLCTDigiCollection>(pset.getParameter<edm::InputTag>("corrlctDigiTag"));
+  rh_token = consumes<CSCRecHit2DCollection>(pset.getParameter<edm::InputTag>("cscRecHitTag"));
+  se_token = consumes<CSCSegmentCollection>(pset.getParameter<edm::InputTag>("cscSegTag"));
+  sa_token = consumes<reco::TrackCollection>(pset.getParameter<edm::InputTag>("saMuonTag"));
+  l1_token = consumes<L1MuGMTReadoutCollection>(pset.getParameter<edm::InputTag>("l1aTag"));
+  tr_token = consumes<TriggerResults>(pset.getParameter<edm::InputTag>("hltTag"));
+  sh_token = consumes<PSimHitContainer>(pset.getParameter<edm::InputTag>("simHitTag"));
 
   // flags to switch on/off individual modules
-  makeOccupancyPlots   = pset.getUntrackedParameter<bool>("makeOccupancyPlots",true);
-  makeTriggerPlots     = pset.getUntrackedParameter<bool>("makeTriggerPlots",false);
-  makeStripPlots       = pset.getUntrackedParameter<bool>("makeStripPlots",true);
-  makeWirePlots        = pset.getUntrackedParameter<bool>("makeWirePlots",true);
-  makeRecHitPlots      = pset.getUntrackedParameter<bool>("makeRecHitPlots",true);
-  makeSimHitPlots      = pset.getUntrackedParameter<bool>("makeSimHitPlots",true);
-  makeSegmentPlots     = pset.getUntrackedParameter<bool>("makeSegmentPlots",true);
-  makeResolutionPlots  = pset.getUntrackedParameter<bool>("makeResolutionPlots",true);
-  makePedNoisePlots    = pset.getUntrackedParameter<bool>("makePedNoisePlots",true);
-  makeEfficiencyPlots  = pset.getUntrackedParameter<bool>("makeEfficiencyPlots",true);
-  makeGasGainPlots     = pset.getUntrackedParameter<bool>("makeGasGainPlots",true);
-  makeAFEBTimingPlots  = pset.getUntrackedParameter<bool>("makeAFEBTimingPlots",true);
-  makeCompTimingPlots  = pset.getUntrackedParameter<bool>("makeCompTimingPlots",true);
-  makeADCTimingPlots   = pset.getUntrackedParameter<bool>("makeADCTimingPlots",true);
-  makeRHNoisePlots     = pset.getUntrackedParameter<bool>("makeRHNoisePlots",false);
-  makeCalibPlots       = pset.getUntrackedParameter<bool>("makeCalibPlots",false);
-  makeStandalonePlots  = pset.getUntrackedParameter<bool>("makeStandalonePlots",false);
-  makeTimeMonitorPlots = pset.getUntrackedParameter<bool>("makeTimeMonitorPlots",false);
-  makeHLTPlots         = pset.getUntrackedParameter<bool>("makeHLTPlots",false);
+  makeOccupancyPlots = pset.getUntrackedParameter<bool>("makeOccupancyPlots", true);
+  makeTriggerPlots = pset.getUntrackedParameter<bool>("makeTriggerPlots", false);
+  makeStripPlots = pset.getUntrackedParameter<bool>("makeStripPlots", true);
+  makeWirePlots = pset.getUntrackedParameter<bool>("makeWirePlots", true);
+  makeRecHitPlots = pset.getUntrackedParameter<bool>("makeRecHitPlots", true);
+  makeSimHitPlots = pset.getUntrackedParameter<bool>("makeSimHitPlots", true);
+  makeSegmentPlots = pset.getUntrackedParameter<bool>("makeSegmentPlots", true);
+  makeResolutionPlots = pset.getUntrackedParameter<bool>("makeResolutionPlots", true);
+  makePedNoisePlots = pset.getUntrackedParameter<bool>("makePedNoisePlots", true);
+  makeEfficiencyPlots = pset.getUntrackedParameter<bool>("makeEfficiencyPlots", true);
+  makeGasGainPlots = pset.getUntrackedParameter<bool>("makeGasGainPlots", true);
+  makeAFEBTimingPlots = pset.getUntrackedParameter<bool>("makeAFEBTimingPlots", true);
+  makeCompTimingPlots = pset.getUntrackedParameter<bool>("makeCompTimingPlots", true);
+  makeADCTimingPlots = pset.getUntrackedParameter<bool>("makeADCTimingPlots", true);
+  makeRHNoisePlots = pset.getUntrackedParameter<bool>("makeRHNoisePlots", false);
+  makeCalibPlots = pset.getUntrackedParameter<bool>("makeCalibPlots", false);
+  makeStandalonePlots = pset.getUntrackedParameter<bool>("makeStandalonePlots", false);
+  makeTimeMonitorPlots = pset.getUntrackedParameter<bool>("makeTimeMonitorPlots", false);
+  makeHLTPlots = pset.getUntrackedParameter<bool>("makeHLTPlots", false);
 
   // set counters to zero
   nEventsAnalyzed = 0;
   rhTreeCount = 0;
   segTreeCount = 0;
-  firstEvent = true; 
- 
+  firstEvent = true;
+
   // Create the root file for the histograms
   theFile = new TFile(rootFileName.c_str(), "RECREATE");
   theFile->cd();
@@ -88,95 +86,92 @@ CSCValidation::CSCValidation(const ParameterSet& pset){
   histos = new CSCValHists();
 
   // book Occupancy Histos
-  hOWires    = new TH2I("hOWires","Wire Digi Occupancy",36,0.5,36.5,20,0.5,20.5);
-  hOStrips   = new TH2I("hOStrips","Strip Digi Occupancy",36,0.5,36.5,20,0.5,20.5);
-  hORecHits  = new TH2I("hORecHits","RecHit Occupancy",36,0.5,36.5,20,0.5,20.5);
-  hOSegments = new TH2I("hOSegments","Segments Occupancy",36,0.5,36.5,20,0.5,20.5);
+  hOWires = new TH2I("hOWires", "Wire Digi Occupancy", 36, 0.5, 36.5, 20, 0.5, 20.5);
+  hOStrips = new TH2I("hOStrips", "Strip Digi Occupancy", 36, 0.5, 36.5, 20, 0.5, 20.5);
+  hORecHits = new TH2I("hORecHits", "RecHit Occupancy", 36, 0.5, 36.5, 20, 0.5, 20.5);
+  hOSegments = new TH2I("hOSegments", "Segments Occupancy", 36, 0.5, 36.5, 20, 0.5, 20.5);
 
   // book Eff histos
-  hSSTE = new TH1F("hSSTE","hSSTE",40,0,40);
-  hRHSTE = new TH1F("hRHSTE","hRHSTE",40,0,40);
-  hSEff = new TH1F("hSEff","Segment Efficiency",20,0.5,20.5);
-  hRHEff = new TH1F("hRHEff","recHit Efficiency",20,0.5,20.5);
+  hSSTE = new TH1F("hSSTE", "hSSTE", 40, 0, 40);
+  hRHSTE = new TH1F("hRHSTE", "hRHSTE", 40, 0, 40);
+  hSEff = new TH1F("hSEff", "Segment Efficiency", 20, 0.5, 20.5);
+  hRHEff = new TH1F("hRHEff", "recHit Efficiency", 20, 0.5, 20.5);
 
-  const int nChambers = 36; 
+  const int nChambers = 36;
   const int nTypes = 18;
   float nCH_min = 0.5;
   float nCh_max = float(nChambers) + 0.5;
   float nT_min = 0.5;
   float nT_max = float(nTypes) + 0.5;
 
-  hSSTE2 = new TH2F("hSSTE2","hSSTE2",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
-  hRHSTE2 = new TH2F("hRHSTE2","hRHSTE2",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
-  hStripSTE2 = new TH2F("hStripSTE2","hStripSTE2",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
-  hWireSTE2 = new TH2F("hWireSTE2","hWireSTE2",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
-  
+  hSSTE2 = new TH2F("hSSTE2", "hSSTE2", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
+  hRHSTE2 = new TH2F("hRHSTE2", "hRHSTE2", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
+  hStripSTE2 = new TH2F("hStripSTE2", "hStripSTE2", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
+  hWireSTE2 = new TH2F("hWireSTE2", "hWireSTE2", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
 
-  hEffDenominator = new TH2F("hEffDenominator","hEffDenominator",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
-  hSEff2 = new TH2F("hSEff2","Segment Efficiency 2D",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
-  hRHEff2 = new TH2F("hRHEff2","recHit Efficiency 2D",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
+  hEffDenominator = new TH2F("hEffDenominator", "hEffDenominator", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
+  hSEff2 = new TH2F("hSEff2", "Segment Efficiency 2D", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
+  hRHEff2 = new TH2F("hRHEff2", "recHit Efficiency 2D", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
 
-  hStripEff2 = new TH2F("hStripEff2","strip Efficiency 2D",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
-  hWireEff2 = new TH2F("hWireEff2","wire Efficiency 2D",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
+  hStripEff2 = new TH2F("hStripEff2", "strip Efficiency 2D", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
+  hWireEff2 = new TH2F("hWireEff2", "wire Efficiency 2D", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
 
-  hSensitiveAreaEvt = new TH2F("hSensitiveAreaEvt","events in sensitive area",nChambers,nCH_min,nCh_max, nTypes, nT_min, nT_max);
- 
+  hSensitiveAreaEvt =
+      new TH2F("hSensitiveAreaEvt", "events in sensitive area", nChambers, nCH_min, nCh_max, nTypes, nT_min, nT_max);
+
   // setup trees to hold global position data for rechits and segments
-  if (writeTreeToFile) histos->setupTrees();
-
-
+  if (writeTreeToFile)
+    histos->setupTrees();
 }
 
 //////////////////
 //  DESTRUCTOR  //
 //////////////////
-CSCValidation::~CSCValidation(){
-
+CSCValidation::~CSCValidation() {
   // produce final efficiency histograms
-  histoEfficiency(hRHSTE,hRHEff);
-  histoEfficiency(hSSTE,hSEff);
-  hSEff2->Divide(hSSTE2,hEffDenominator,1.,1.,"B");
-  hRHEff2->Divide(hRHSTE2,hEffDenominator,1.,1.,"B");
-  hStripEff2->Divide(hStripSTE2,hEffDenominator,1.,1.,"B");
-  hWireEff2->Divide(hWireSTE2,hEffDenominator,1.,1.,"B");
+  histoEfficiency(hRHSTE, hRHEff);
+  histoEfficiency(hSSTE, hSEff);
+  hSEff2->Divide(hSSTE2, hEffDenominator, 1., 1., "B");
+  hRHEff2->Divide(hRHSTE2, hEffDenominator, 1., 1., "B");
+  hStripEff2->Divide(hStripSTE2, hEffDenominator, 1., 1., "B");
+  hWireEff2->Divide(hWireSTE2, hEffDenominator, 1., 1., "B");
 
-  histos->insertPlot(hRHSTE,"hRHSTE","Efficiency");
-  histos->insertPlot(hSSTE,"hSSTE","Efficiency");
-  histos->insertPlot(hSSTE2,"hSSTE2","Efficiency");
-  histos->insertPlot(hEffDenominator,"hEffDenominator","Efficiency");
-  histos->insertPlot(hRHSTE2,"hRHSTE2","Efficiency");
-  histos->insertPlot(hStripSTE2,"hStripSTE2","Efficiency");
-  histos->insertPlot(hWireSTE2,"hWireSTE2","Efficiency");
+  histos->insertPlot(hRHSTE, "hRHSTE", "Efficiency");
+  histos->insertPlot(hSSTE, "hSSTE", "Efficiency");
+  histos->insertPlot(hSSTE2, "hSSTE2", "Efficiency");
+  histos->insertPlot(hEffDenominator, "hEffDenominator", "Efficiency");
+  histos->insertPlot(hRHSTE2, "hRHSTE2", "Efficiency");
+  histos->insertPlot(hStripSTE2, "hStripSTE2", "Efficiency");
+  histos->insertPlot(hWireSTE2, "hWireSTE2", "Efficiency");
 
   //moving this to post job macros
-  histos->insertPlot(hSEff,"hSEff","Efficiency");
-  histos->insertPlot(hRHEff,"hRHEff","Efficiency");
+  histos->insertPlot(hSEff, "hSEff", "Efficiency");
+  histos->insertPlot(hRHEff, "hRHEff", "Efficiency");
 
-  histos->insertPlot(hSEff2,"hSEff2","Efficiency");
-  histos->insertPlot(hRHEff2,"hRHEff2","Efficiency");
-  histos->insertPlot(hStripEff2,"hStripff2","Efficiency");
-  histos->insertPlot(hWireEff2,"hWireff2","Efficiency");
-  
-  histos->insertPlot(hSensitiveAreaEvt,"","Efficiency");
+  histos->insertPlot(hSEff2, "hSEff2", "Efficiency");
+  histos->insertPlot(hRHEff2, "hRHEff2", "Efficiency");
+  histos->insertPlot(hStripEff2, "hStripff2", "Efficiency");
+  histos->insertPlot(hWireEff2, "hWireff2", "Efficiency");
+
+  histos->insertPlot(hSensitiveAreaEvt, "", "Efficiency");
 
   // throw in occupancy plots so they're saved
-  histos->insertPlot(hOWires,"hOWires","Digis");
-  histos->insertPlot(hOStrips,"hOStrips","Digis");
-  histos->insertPlot(hORecHits,"hORecHits","recHits");
-  histos->insertPlot(hOSegments,"hOSegments","Segments");
+  histos->insertPlot(hOWires, "hOWires", "Digis");
+  histos->insertPlot(hOStrips, "hOStrips", "Digis");
+  histos->insertPlot(hORecHits, "hORecHits", "recHits");
+  histos->insertPlot(hOSegments, "hOSegments", "Segments");
 
-  
   // write histos to the specified file
   histos->writeHists(theFile);
-  if (writeTreeToFile) histos->writeTrees(theFile);
+  if (writeTreeToFile)
+    histos->writeTrees(theFile);
   theFile->Close();
-
 }
 
 ////////////////
 //  Analysis  //
 ////////////////
-void CSCValidation::analyze(const Event & event, const EventSetup& eventSetup){
+void CSCValidation::analyze(const Event& event, const EventSetup& eventSetup) {
   // increment counter
   nEventsAnalyzed++;
 
@@ -190,14 +185,14 @@ void CSCValidation::analyze(const Event & event, const EventSetup& eventSetup){
   edm::Handle<CSCALCTDigiCollection> alcts;
   edm::Handle<CSCCLCTDigiCollection> clcts;
   edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedlcts;
-  if (useDigis){
-    event.getByToken( sd_token, strips );
-    event.getByToken( wd_token, wires );
-    event.getByToken( cd_token, compars );
-    event.getByToken( al_token, alcts );
-    event.getByToken( cl_token, clcts );
-    event.getByToken( co_token, correlatedlcts );
- }
+  if (useDigis) {
+    event.getByToken(sd_token, strips);
+    event.getByToken(wd_token, wires);
+    event.getByToken(cd_token, compars);
+    event.getByToken(al_token, alcts);
+    event.getByToken(cl_token, clcts);
+    event.getByToken(co_token, correlatedlcts);
+  }
 
   // Get the CSC Geometry :
   edm::ESHandle<CSCGeometry> cscGeom;
@@ -205,38 +200,37 @@ void CSCValidation::analyze(const Event & event, const EventSetup& eventSetup){
 
   // Get the RecHits collection :
   edm::Handle<CSCRecHit2DCollection> recHits;
-  event.getByToken( rh_token, recHits );
+  event.getByToken(rh_token, recHits);
 
   //CSCRecHit2DCollection::const_iterator recIt;
   //for (recIt = recHits->begin(); recIt != recHits->end(); recIt++) {
   //  recIt->print();
   // }
 
-
   // Get the SimHits (if applicable)
   edm::Handle<PSimHitContainer> simHits;
-  if ( isSimulation ) event.getByToken( sh_token, simHits );
+  if (isSimulation)
+    event.getByToken(sh_token, simHits);
 
   // get CSC segment collection
   edm::Handle<CSCSegmentCollection> cscSegments;
-  event.getByToken( se_token, cscSegments );
+  event.getByToken(se_token, cscSegments);
 
   // get the trigger collection
   edm::Handle<L1MuGMTReadoutCollection> pCollection;
-  if (makeTriggerPlots || useTriggerFilter || (useDigis && makeTimeMonitorPlots)){
-    event.getByToken( l1_token, pCollection );
+  if (makeTriggerPlots || useTriggerFilter || (useDigis && makeTimeMonitorPlots)) {
+    event.getByToken(l1_token, pCollection);
   }
   edm::Handle<TriggerResults> hlt;
   if (makeHLTPlots) {
-      event.getByToken( tr_token, hlt );
+    event.getByToken(tr_token, hlt);
   }
 
   // get the standalone muon collection
   edm::Handle<reco::TrackCollection> saMuons;
   if (makeStandalonePlots || useQualityFilter) {
-     event.getByToken( sa_token, saMuons );
+    event.getByToken(sa_token, saMuons);
   }
-
 
   /////////////////////
   // Run the modules //
@@ -244,84 +238,93 @@ void CSCValidation::analyze(const Event & event, const EventSetup& eventSetup){
 
   // Only do this for the first event
   // this is probably outdated and needs to be looked at
-  if (nEventsAnalyzed == 1 && makeCalibPlots) doCalibrations(eventSetup);
-
+  if (nEventsAnalyzed == 1 && makeCalibPlots)
+    doCalibrations(eventSetup);
 
   // Look at the l1a trigger info (returns true if csc L1A present)
   bool CSCL1A = false;
-  if (makeTriggerPlots || useTriggerFilter) CSCL1A = doTrigger(pCollection);
-  if (!useTriggerFilter) CSCL1A = true;  // always true if not filtering on trigger
-
+  if (makeTriggerPlots || useTriggerFilter)
+    CSCL1A = doTrigger(pCollection);
+  if (!useTriggerFilter)
+    CSCL1A = true;  // always true if not filtering on trigger
 
   cleanEvent = false;
-  if (makeStandalonePlots || useQualityFilter) cleanEvent = filterEvents(recHits,cscSegments,saMuons);
-  if (!useQualityFilter) cleanEvent = true; // always true if not filtering on event quality
+  if (makeStandalonePlots || useQualityFilter)
+    cleanEvent = filterEvents(recHits, cscSegments, saMuons);
+  if (!useQualityFilter)
+    cleanEvent = true;  // always true if not filtering on event quality
 
-  
   // look at various chamber occupancies
   // keep this outside of filter for diagnostics???
-  if (makeOccupancyPlots && CSCL1A) doOccupancies(strips,wires,recHits,cscSegments);
+  if (makeOccupancyPlots && CSCL1A)
+    doOccupancies(strips, wires, recHits, cscSegments);
 
+  if (makeHLTPlots)
+    doHLT(hlt);
 
-  if (makeHLTPlots) doHLT(hlt);
-
-
-  if (cleanEvent && CSCL1A){
-
+  if (cleanEvent && CSCL1A) {
     // general look at strip digis
-    if (makeStripPlots && useDigis) doStripDigis(strips);
+    if (makeStripPlots && useDigis)
+      doStripDigis(strips);
 
     // general look at wire digis
-    if (makeWirePlots && useDigis) doWireDigis(wires);
-
+    if (makeWirePlots && useDigis)
+      doWireDigis(wires);
 
     // general look at rechits
-    if (makeRecHitPlots) doRecHits(recHits,cscGeom);
+    if (makeRecHitPlots)
+      doRecHits(recHits, cscGeom);
 
     // look at simHits
-    if (isSimulation && makeSimHitPlots) doSimHits(recHits,simHits);
+    if (isSimulation && makeSimHitPlots)
+      doSimHits(recHits, simHits);
 
     // general look at Segments
-    if (makeSegmentPlots) doSegments(cscSegments,cscGeom);
+    if (makeSegmentPlots)
+      doSegments(cscSegments, cscGeom);
 
     // look at hit resolution
-    if (makeResolutionPlots) doResolution(cscSegments,cscGeom);
-
+    if (makeResolutionPlots)
+      doResolution(cscSegments, cscGeom);
 
     // look at Pedestal Noise
-    if (makePedNoisePlots && useDigis) doPedestalNoise(strips);
-  
+    if (makePedNoisePlots && useDigis)
+      doPedestalNoise(strips);
+
     // look at recHit and segment efficiencies
-    if (makeEfficiencyPlots) doEfficiencies(wires,strips, recHits, cscSegments,cscGeom);
+    if (makeEfficiencyPlots)
+      doEfficiencies(wires, strips, recHits, cscSegments, cscGeom);
 
     // gas gain
-    if (makeGasGainPlots && useDigis) doGasGain(*wires,*strips,*recHits);
-
+    if (makeGasGainPlots && useDigis)
+      doGasGain(*wires, *strips, *recHits);
 
     // AFEB timing
-    if (makeAFEBTimingPlots && useDigis) doAFEBTiming(*wires);
+    if (makeAFEBTimingPlots && useDigis)
+      doAFEBTiming(*wires);
 
     // Comparators timing
-    if (makeCompTimingPlots && useDigis) doCompTiming(*compars);
+    if (makeCompTimingPlots && useDigis)
+      doCompTiming(*compars);
 
     // strip ADC timing
-    if (makeADCTimingPlots) doADCTiming(*recHits);
-
-
+    if (makeADCTimingPlots)
+      doADCTiming(*recHits);
 
     // recHit Noise
-    if (makeRHNoisePlots && useDigis) doNoiseHits(recHits,cscSegments,cscGeom,strips);
+    if (makeRHNoisePlots && useDigis)
+      doNoiseHits(recHits, cscSegments, cscGeom, strips);
 
     // look at standalone muons (not implemented yet)
-    if (makeStandalonePlots) doStandalone(saMuons);
+    if (makeStandalonePlots)
+      doStandalone(saMuons);
 
     // make plots for monitoring the trigger and offline timing
-    if (makeTimeMonitorPlots) doTimeMonitoring(recHits,cscSegments, alcts, clcts, correlatedlcts, pCollection,cscGeom, eventSetup, event);
+    if (makeTimeMonitorPlots)
+      doTimeMonitoring(recHits, cscSegments, alcts, clcts, correlatedlcts, pCollection, cscGeom, eventSetup, event);
 
     firstEvent = false;
-
   }
-
 }
 
 // ==============================================
@@ -330,13 +333,15 @@ void CSCValidation::analyze(const Event & event, const EventSetup& eventSetup){
 //
 // ==============================================
 
-bool CSCValidation::filterEvents(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments,
-                                 edm::Handle<reco::TrackCollection> saMuons){
-
+bool CSCValidation::filterEvents(edm::Handle<CSCRecHit2DCollection> recHits,
+                                 edm::Handle<CSCSegmentCollection> cscSegments,
+                                 edm::Handle<reco::TrackCollection> saMuons) {
   //int  nGoodSAMuons = 0;
 
-  if (recHits->size() < 4 || recHits->size() > 100) return false;
-  if (cscSegments->size() < 1 || cscSegments->size() > 15) return false;
+  if (recHits->size() < 4 || recHits->size() > 100)
+    return false;
+  if (cscSegments->size() < 1 || cscSegments->size() > 15)
+    return false;
   return true;
   //if (saMuons->size() != 1) return false;
   /*
@@ -409,9 +414,10 @@ bool CSCValidation::filterEvents(edm::Handle<CSCRecHit2DCollection> recHits, edm
 //
 // ==============================================
 
-void CSCValidation::doOccupancies(edm::Handle<CSCStripDigiCollection> strips, edm::Handle<CSCWireDigiCollection> wires,
-                                  edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments){
-
+void CSCValidation::doOccupancies(edm::Handle<CSCStripDigiCollection> strips,
+                                  edm::Handle<CSCWireDigiCollection> wires,
+                                  edm::Handle<CSCRecHit2DCollection> recHits,
+                                  edm::Handle<CSCSegmentCollection> cscSegments) {
   bool wireo[2][4][4][36];
   bool stripo[2][4][4][36];
   bool rechito[2][4][4][36];
@@ -422,10 +428,10 @@ void CSCValidation::doOccupancies(edm::Handle<CSCStripDigiCollection> strips, ed
   bool hasRecHits = false;
   bool hasSegments = false;
 
-  for (int e = 0; e < 2; e++){
-    for (int s = 0; s < 4; s++){
-      for (int r = 0; r < 4; r++){
-        for (int c = 0; c < 36; c++){
+  for (int e = 0; e < 2; e++) {
+    for (int s = 0; s < 4; s++) {
+      for (int r = 0; r < 4; r++) {
+        for (int c = 0; c < 36; c++) {
           wireo[e][s][r][c] = false;
           stripo[e][s][r][c] = false;
           rechito[e][s][r][c] = false;
@@ -435,50 +441,54 @@ void CSCValidation::doOccupancies(edm::Handle<CSCStripDigiCollection> strips, ed
     }
   }
 
-  if (useDigis){
+  if (useDigis) {
     //wires
-    for (CSCWireDigiCollection::DigiRangeIterator wi=wires->begin(); wi!=wires->end(); wi++) {
+    for (CSCWireDigiCollection::DigiRangeIterator wi = wires->begin(); wi != wires->end(); wi++) {
       CSCDetId id = (CSCDetId)(*wi).first;
-      int kEndcap  = id.endcap();
-      int kRing    = id.ring();
+      int kEndcap = id.endcap();
+      int kRing = id.ring();
       int kStation = id.station();
       int kChamber = id.chamber();
       std::vector<CSCWireDigi>::const_iterator wireIt = (*wi).second.first;
       std::vector<CSCWireDigi>::const_iterator lastWire = (*wi).second.second;
-      for( ; wireIt != lastWire; ++wireIt){
-        if (!wireo[kEndcap-1][kStation-1][kRing-1][kChamber-1]){
-          wireo[kEndcap-1][kStation-1][kRing-1][kChamber-1] = true;
-          hOWires->Fill(kChamber,typeIndex(id));
-          histos->fill1DHist(chamberSerial(id),"hOWireSerial","Wire Occupancy by Chamber Serial",601,-0.5,600.5,"Digis");
+      for (; wireIt != lastWire; ++wireIt) {
+        if (!wireo[kEndcap - 1][kStation - 1][kRing - 1][kChamber - 1]) {
+          wireo[kEndcap - 1][kStation - 1][kRing - 1][kChamber - 1] = true;
+          hOWires->Fill(kChamber, typeIndex(id));
+          histos->fill1DHist(
+              chamberSerial(id), "hOWireSerial", "Wire Occupancy by Chamber Serial", 601, -0.5, 600.5, "Digis");
           hasWires = true;
         }
       }
     }
-  
+
     //strips
-    for (CSCStripDigiCollection::DigiRangeIterator si=strips->begin(); si!=strips->end(); si++) {
+    for (CSCStripDigiCollection::DigiRangeIterator si = strips->begin(); si != strips->end(); si++) {
       CSCDetId id = (CSCDetId)(*si).first;
-      int kEndcap  = id.endcap();
-      int kRing    = id.ring();
+      int kEndcap = id.endcap();
+      int kRing = id.ring();
       int kStation = id.station();
       int kChamber = id.chamber();
       std::vector<CSCStripDigi>::const_iterator stripIt = (*si).second.first;
       std::vector<CSCStripDigi>::const_iterator lastStrip = (*si).second.second;
-      for( ; stripIt != lastStrip; ++stripIt) {
+      for (; stripIt != lastStrip; ++stripIt) {
         std::vector<int> myADCVals = stripIt->getADCCounts();
         bool thisStripFired = false;
-        float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-        float threshold = 13.3 ;
+        float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+        float threshold = 13.3;
         float diff = 0.;
         for (unsigned int iCount = 0; iCount < myADCVals.size(); iCount++) {
-          diff = (float)myADCVals[iCount]-thisPedestal;
-          if (diff > threshold) { thisStripFired = true; }
+          diff = (float)myADCVals[iCount] - thisPedestal;
+          if (diff > threshold) {
+            thisStripFired = true;
+          }
         }
         if (thisStripFired) {
-          if (!stripo[kEndcap-1][kStation-1][kRing-1][kChamber-1]){
-            stripo[kEndcap-1][kStation-1][kRing-1][kChamber-1] = true;
-            hOStrips->Fill(kChamber,typeIndex(id));
-            histos->fill1DHist(chamberSerial(id),"hOStripSerial","Strip Occupancy by Chamber Serial",601,-0.5,600.5,"Digis");
+          if (!stripo[kEndcap - 1][kStation - 1][kRing - 1][kChamber - 1]) {
+            stripo[kEndcap - 1][kStation - 1][kRing - 1][kChamber - 1] = true;
+            hOStrips->Fill(kChamber, typeIndex(id));
+            histos->fill1DHist(
+                chamberSerial(id), "hOStripSerial", "Strip Occupancy by Chamber Serial", 601, -0.5, 600.5, "Digis");
             hasStrips = true;
           }
         }
@@ -490,42 +500,49 @@ void CSCValidation::doOccupancies(edm::Handle<CSCStripDigiCollection> strips, ed
   CSCRecHit2DCollection::const_iterator recIt;
   for (recIt = recHits->begin(); recIt != recHits->end(); recIt++) {
     CSCDetId idrec = (CSCDetId)(*recIt).cscDetId();
-    int kEndcap  = idrec.endcap();
-    int kRing    = idrec.ring();
+    int kEndcap = idrec.endcap();
+    int kRing = idrec.ring();
     int kStation = idrec.station();
     int kChamber = idrec.chamber();
-    if (!rechito[kEndcap-1][kStation-1][kRing-1][kChamber-1]){
-      rechito[kEndcap-1][kStation-1][kRing-1][kChamber-1] = true;
-      histos->fill1DHist(chamberSerial(idrec),"hORecHitsSerial","RecHit Occupancy by Chamber Serial",601,-0.5,600.5,"recHits");
-      hORecHits->Fill(kChamber,typeIndex(idrec));
+    if (!rechito[kEndcap - 1][kStation - 1][kRing - 1][kChamber - 1]) {
+      rechito[kEndcap - 1][kStation - 1][kRing - 1][kChamber - 1] = true;
+      histos->fill1DHist(
+          chamberSerial(idrec), "hORecHitsSerial", "RecHit Occupancy by Chamber Serial", 601, -0.5, 600.5, "recHits");
+      hORecHits->Fill(kChamber, typeIndex(idrec));
       hasRecHits = true;
     }
   }
 
   //segments
-  for(CSCSegmentCollection::const_iterator segIt=cscSegments->begin(); segIt != cscSegments->end(); segIt++) {
-    CSCDetId id  = (CSCDetId)(*segIt).cscDetId();
-    int kEndcap  = id.endcap();
-    int kRing    = id.ring();
+  for (CSCSegmentCollection::const_iterator segIt = cscSegments->begin(); segIt != cscSegments->end(); segIt++) {
+    CSCDetId id = (CSCDetId)(*segIt).cscDetId();
+    int kEndcap = id.endcap();
+    int kRing = id.ring();
     int kStation = id.station();
     int kChamber = id.chamber();
-    if (!segmento[kEndcap-1][kStation-1][kRing-1][kChamber-1]){
-      segmento[kEndcap-1][kStation-1][kRing-1][kChamber-1] = true;
-      histos->fill1DHist(chamberSerial(id),"hOSegmentsSerial","Segment Occupancy by Chamber Serial",601,-0.5,600.5,"Segments");
-      hOSegments->Fill(kChamber,typeIndex(id));
+    if (!segmento[kEndcap - 1][kStation - 1][kRing - 1][kChamber - 1]) {
+      segmento[kEndcap - 1][kStation - 1][kRing - 1][kChamber - 1] = true;
+      histos->fill1DHist(
+          chamberSerial(id), "hOSegmentsSerial", "Segment Occupancy by Chamber Serial", 601, -0.5, 600.5, "Segments");
+      hOSegments->Fill(kChamber, typeIndex(id));
       hasSegments = true;
     }
   }
 
   // overall CSC occupancy (events with CSC data compared to total)
-  histos->fill1DHist(1,"hCSCOccupancy","overall CSC occupancy",15,-0.5,14.5,"GeneralHists");
-  if (hasWires) histos->fill1DHist(3,"hCSCOccupancy","overall CSC occupancy",15,-0.5,14.5,"GeneralHists");
-  if (hasStrips) histos->fill1DHist(5,"hCSCOccupancy","overall CSC occupancy",15,-0.5,14.5,"GeneralHists");
-  if (hasWires && hasStrips) histos->fill1DHist(7,"hCSCOccupancy","overall CSC occupancy",15,-0.5,14.5,"GeneralHists");
-  if (hasRecHits) histos->fill1DHist(9,"hCSCOccupancy","overall CSC occupancy",15,-0.5,14.5,"GeneralHists");
-  if (hasSegments) histos->fill1DHist(11,"hCSCOccupancy","overall CSC occupancy",15,-0.5,14.5,"GeneralHists");
-  if (!cleanEvent) histos->fill1DHist(13,"hCSCOccupancy","overall CSC occupancy",15,-0.5,14.5,"GeneralHists");
-
+  histos->fill1DHist(1, "hCSCOccupancy", "overall CSC occupancy", 15, -0.5, 14.5, "GeneralHists");
+  if (hasWires)
+    histos->fill1DHist(3, "hCSCOccupancy", "overall CSC occupancy", 15, -0.5, 14.5, "GeneralHists");
+  if (hasStrips)
+    histos->fill1DHist(5, "hCSCOccupancy", "overall CSC occupancy", 15, -0.5, 14.5, "GeneralHists");
+  if (hasWires && hasStrips)
+    histos->fill1DHist(7, "hCSCOccupancy", "overall CSC occupancy", 15, -0.5, 14.5, "GeneralHists");
+  if (hasRecHits)
+    histos->fill1DHist(9, "hCSCOccupancy", "overall CSC occupancy", 15, -0.5, 14.5, "GeneralHists");
+  if (hasSegments)
+    histos->fill1DHist(11, "hCSCOccupancy", "overall CSC occupancy", 15, -0.5, 14.5, "GeneralHists");
+  if (!cleanEvent)
+    histos->fill1DHist(13, "hCSCOccupancy", "overall CSC occupancy", 15, -0.5, 14.5, "GeneralHists");
 }
 
 // ==============================================
@@ -534,117 +551,137 @@ void CSCValidation::doOccupancies(edm::Handle<CSCStripDigiCollection> strips, ed
 //
 // ==============================================
 
-bool CSCValidation::doTrigger(edm::Handle<L1MuGMTReadoutCollection> pCollection){
-
+bool CSCValidation::doTrigger(edm::Handle<L1MuGMTReadoutCollection> pCollection) {
   std::vector<L1MuGMTReadoutRecord> L1Mrec = pCollection->getRecords();
   std::vector<L1MuGMTReadoutRecord>::const_iterator igmtrr;
 
-  bool csc_l1a  = false;
-  bool dt_l1a   = false;
+  bool csc_l1a = false;
+  bool dt_l1a = false;
   bool rpcf_l1a = false;
   bool rpcb_l1a = false;
   bool beamHaloTrigger = false;
 
   int myBXNumber = -1000;
 
-  for(igmtrr=L1Mrec.begin(); igmtrr!=L1Mrec.end(); igmtrr++) {
+  for (igmtrr = L1Mrec.begin(); igmtrr != L1Mrec.end(); igmtrr++) {
     std::vector<L1MuRegionalCand>::const_iterator iter1;
     std::vector<L1MuRegionalCand> rmc;
 
     // CSC
     int icsc = 0;
     rmc = igmtrr->getCSCCands();
-    for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-      if ( !(*iter1).empty() ) {
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
         icsc++;
-        int kQuality = (*iter1).quality();   // kQuality = 1 means beam halo
-        if (kQuality == 1) beamHaloTrigger = true;
+        int kQuality = (*iter1).quality();  // kQuality = 1 means beam halo
+        if (kQuality == 1)
+          beamHaloTrigger = true;
       }
     }
-    if (igmtrr->getBxInEvent() == 0 && icsc>0) csc_l1a = true;
-    if (igmtrr->getBxInEvent() == 0 ) { myBXNumber = igmtrr->getBxNr(); }
+    if (igmtrr->getBxInEvent() == 0 && icsc > 0)
+      csc_l1a = true;
+    if (igmtrr->getBxInEvent() == 0) {
+      myBXNumber = igmtrr->getBxNr();
+    }
 
     // DT
     int idt = 0;
     rmc = igmtrr->getDTBXCands();
-    for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-      if ( !(*iter1).empty() ) {
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
         idt++;
       }
     }
-    if(igmtrr->getBxInEvent()==0 && idt>0) dt_l1a = true;
+    if (igmtrr->getBxInEvent() == 0 && idt > 0)
+      dt_l1a = true;
 
     // RPC Barrel
     int irpcb = 0;
     rmc = igmtrr->getBrlRPCCands();
-    for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-      if ( !(*iter1).empty() ) {
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
         irpcb++;
       }
     }
-    if(igmtrr->getBxInEvent()==0 && irpcb>0) rpcb_l1a = true;
+    if (igmtrr->getBxInEvent() == 0 && irpcb > 0)
+      rpcb_l1a = true;
 
     // RPC Forward
     int irpcf = 0;
     rmc = igmtrr->getFwdRPCCands();
-    for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-      if ( !(*iter1).empty() ) {
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
         irpcf++;
       }
     }
-    if(igmtrr->getBxInEvent()==0 && irpcf>0) rpcf_l1a = true;
-
+    if (igmtrr->getBxInEvent() == 0 && irpcf > 0)
+      rpcf_l1a = true;
   }
 
   // Fill some histograms with L1A info
-  if (csc_l1a)          histos->fill1DHist(myBXNumber,"vtBXNumber","BX Number",4001,-0.5,4000.5,"Trigger");
-  if (csc_l1a)          histos->fill1DHist(1,"vtBits","trigger bits",11,-0.5,10.5,"Trigger");
-  if (dt_l1a)           histos->fill1DHist(2,"vtBits","trigger bits",11,-0.5,10.5,"Trigger");
-  if (rpcb_l1a)         histos->fill1DHist(3,"vtBits","trigger bits",11,-0.5,10.5,"Trigger");
-  if (rpcf_l1a)         histos->fill1DHist(4,"vtBits","trigger bits",11,-0.5,10.5,"Trigger");
-  if (beamHaloTrigger)  histos->fill1DHist(8,"vtBits","trigger bits",11,-0.5,10.5,"Trigger");
+  if (csc_l1a)
+    histos->fill1DHist(myBXNumber, "vtBXNumber", "BX Number", 4001, -0.5, 4000.5, "Trigger");
+  if (csc_l1a)
+    histos->fill1DHist(1, "vtBits", "trigger bits", 11, -0.5, 10.5, "Trigger");
+  if (dt_l1a)
+    histos->fill1DHist(2, "vtBits", "trigger bits", 11, -0.5, 10.5, "Trigger");
+  if (rpcb_l1a)
+    histos->fill1DHist(3, "vtBits", "trigger bits", 11, -0.5, 10.5, "Trigger");
+  if (rpcf_l1a)
+    histos->fill1DHist(4, "vtBits", "trigger bits", 11, -0.5, 10.5, "Trigger");
+  if (beamHaloTrigger)
+    histos->fill1DHist(8, "vtBits", "trigger bits", 11, -0.5, 10.5, "Trigger");
 
   if (csc_l1a) {
-    histos->fill1DHist(1,"vtCSCY","trigger bits",11,-0.5,10.5,"Trigger");
-    if (dt_l1a)   histos->fill1DHist(2,"vtCSCY","trigger bits",11,-0.5,10.5,"Trigger");
-    if (rpcb_l1a) histos->fill1DHist(3,"vtCSCY","trigger bits",11,-0.5,10.5,"Trigger");
-    if (rpcf_l1a) histos->fill1DHist(4,"vtCSCY","trigger bits",11,-0.5,10.5,"Trigger");
-    if (  dt_l1a || rpcb_l1a || rpcf_l1a)  histos->fill1DHist(5,"vtCSCY","trigger bits",11,-0.5,10.5,"Trigger");
-    if (!(dt_l1a || rpcb_l1a || rpcf_l1a)) histos->fill1DHist(6,"vtCSCY","trigger bits",11,-0.5,10.5,"Trigger");
+    histos->fill1DHist(1, "vtCSCY", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (dt_l1a)
+      histos->fill1DHist(2, "vtCSCY", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (rpcb_l1a)
+      histos->fill1DHist(3, "vtCSCY", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (rpcf_l1a)
+      histos->fill1DHist(4, "vtCSCY", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (dt_l1a || rpcb_l1a || rpcf_l1a)
+      histos->fill1DHist(5, "vtCSCY", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (!(dt_l1a || rpcb_l1a || rpcf_l1a))
+      histos->fill1DHist(6, "vtCSCY", "trigger bits", 11, -0.5, 10.5, "Trigger");
   } else {
-    histos->fill1DHist(1,"vtCSCN","trigger bits",11,-0.5,10.5,"Trigger");
-    if (dt_l1a)   histos->fill1DHist(2,"vtCSCN","trigger bits",11,-0.5,10.5,"Trigger");
-    if (rpcb_l1a) histos->fill1DHist(3,"vtCSCN","trigger bits",11,-0.5,10.5,"Trigger");
-    if (rpcf_l1a) histos->fill1DHist(4,"vtCSCN","trigger bits",11,-0.5,10.5,"Trigger");
-    if (  dt_l1a || rpcb_l1a || rpcf_l1a)  histos->fill1DHist(5,"vtCSCN","trigger bits",11,-0.5,10.5,"Trigger");
-    if (!(dt_l1a || rpcb_l1a || rpcf_l1a)) histos->fill1DHist(6,"vtCSCN","trigger bits",11,-0.5,10.5,"Trigger");
+    histos->fill1DHist(1, "vtCSCN", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (dt_l1a)
+      histos->fill1DHist(2, "vtCSCN", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (rpcb_l1a)
+      histos->fill1DHist(3, "vtCSCN", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (rpcf_l1a)
+      histos->fill1DHist(4, "vtCSCN", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (dt_l1a || rpcb_l1a || rpcf_l1a)
+      histos->fill1DHist(5, "vtCSCN", "trigger bits", 11, -0.5, 10.5, "Trigger");
+    if (!(dt_l1a || rpcb_l1a || rpcf_l1a))
+      histos->fill1DHist(6, "vtCSCN", "trigger bits", 11, -0.5, 10.5, "Trigger");
   }
 
   // if valid CSC L1A then return true for possible use elsewhere
 
-  if (csc_l1a) return true;
-  
-  return false;
+  if (csc_l1a)
+    return true;
 
+  return false;
 }
 
 // ==============================================
-//    
+//
 // look at HLT Trigger
-//  
+//
 // ==============================================
 
-bool CSCValidation::doHLT(Handle<TriggerResults> hlt){
-
+bool CSCValidation::doHLT(Handle<TriggerResults> hlt) {
   // HLT stuff
   int hltSize = hlt->size();
-  for (int i = 0; i < hltSize; ++i){
-    if (hlt->accept(i)) histos->fill1DHist(i,"hltBits","HLT Trigger Bits",hltSize+1,-0.5,(float)hltSize+0.5,"Trigger");
+  for (int i = 0; i < hltSize; ++i) {
+    if (hlt->accept(i))
+      histos->fill1DHist(i, "hltBits", "HLT Trigger Bits", hltSize + 1, -0.5, (float)hltSize + 0.5, "Trigger");
   }
 
   return true;
 }
-
 
 // ==============================================
 //
@@ -652,62 +689,82 @@ bool CSCValidation::doHLT(Handle<TriggerResults> hlt){
 //
 // ==============================================
 
-void CSCValidation::doCalibrations(const edm::EventSetup& eventSetup){
-
+void CSCValidation::doCalibrations(const edm::EventSetup& eventSetup) {
   // Only do this for the first event
-  if (nEventsAnalyzed == 1){
-
+  if (nEventsAnalyzed == 1) {
     LogDebug("Calibrations") << "Loading Calibrations...";
 
     // get the gains
     edm::ESHandle<CSCDBGains> hGains;
-    eventSetup.get<CSCDBGainsRcd>().get( hGains );
+    eventSetup.get<CSCDBGainsRcd>().get(hGains);
     const CSCDBGains* pGains = hGains.product();
     // get the crosstalks
     edm::ESHandle<CSCDBCrosstalk> hCrosstalk;
-    eventSetup.get<CSCDBCrosstalkRcd>().get( hCrosstalk );
+    eventSetup.get<CSCDBCrosstalkRcd>().get(hCrosstalk);
     const CSCDBCrosstalk* pCrosstalk = hCrosstalk.product();
     // get the noise matrix
     edm::ESHandle<CSCDBNoiseMatrix> hNoiseMatrix;
-    eventSetup.get<CSCDBNoiseMatrixRcd>().get( hNoiseMatrix );
+    eventSetup.get<CSCDBNoiseMatrixRcd>().get(hNoiseMatrix);
     const CSCDBNoiseMatrix* pNoiseMatrix = hNoiseMatrix.product();
     // get pedestals
     edm::ESHandle<CSCDBPedestals> hPedestals;
-    eventSetup.get<CSCDBPedestalsRcd>().get( hPedestals );
+    eventSetup.get<CSCDBPedestalsRcd>().get(hPedestals);
     const CSCDBPedestals* pPedestals = hPedestals.product();
 
     LogDebug("Calibrations") << "Calibrations Loaded!";
 
-    for (int i = 0; i < 400; i++){
-      int bin = i+1;
-      histos->fillCalibHist(pGains->gains[i].gain_slope,"hCalibGainsS","Gains Slope",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pCrosstalk->crosstalk[i].xtalk_slope_left,"hCalibXtalkSL","Xtalk Slope Left",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pCrosstalk->crosstalk[i].xtalk_slope_right,"hCalibXtalkSR","Xtalk Slope Right",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pCrosstalk->crosstalk[i].xtalk_intercept_left,"hCalibXtalkIL","Xtalk Intercept Left",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pCrosstalk->crosstalk[i].xtalk_intercept_right,"hCalibXtalkIR","Xtalk Intercept Right",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pPedestals->pedestals[i].ped,"hCalibPedsP","Peds",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pPedestals->pedestals[i].rms,"hCalibPedsR","Peds RMS",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem33,"hCalibNoise33","Noise Matrix 33",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem34,"hCalibNoise34","Noise Matrix 34",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem35,"hCalibNoise35","Noise Matrix 35",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem44,"hCalibNoise44","Noise Matrix 44",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem45,"hCalibNoise45","Noise Matrix 45",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem46,"hCalibNoise46","Noise Matrix 46",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem55,"hCalibNoise55","Noise Matrix 55",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem56,"hCalibNoise56","Noise Matrix 56",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem57,"hCalibNoise57","Noise Matrix 57",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem66,"hCalibNoise66","Noise Matrix 66",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem67,"hCalibNoise67","Noise Matrix 67",400,0,400,bin,"Calib");
-      histos->fillCalibHist(pNoiseMatrix->matrix[i].elem77,"hCalibNoise77","Noise Matrix 77",400,0,400,bin,"Calib");
-
- 
+    for (int i = 0; i < 400; i++) {
+      int bin = i + 1;
+      histos->fillCalibHist(pGains->gains[i].gain_slope, "hCalibGainsS", "Gains Slope", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pCrosstalk->crosstalk[i].xtalk_slope_left, "hCalibXtalkSL", "Xtalk Slope Left", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pCrosstalk->crosstalk[i].xtalk_slope_right, "hCalibXtalkSR", "Xtalk Slope Right", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(pCrosstalk->crosstalk[i].xtalk_intercept_left,
+                            "hCalibXtalkIL",
+                            "Xtalk Intercept Left",
+                            400,
+                            0,
+                            400,
+                            bin,
+                            "Calib");
+      histos->fillCalibHist(pCrosstalk->crosstalk[i].xtalk_intercept_right,
+                            "hCalibXtalkIR",
+                            "Xtalk Intercept Right",
+                            400,
+                            0,
+                            400,
+                            bin,
+                            "Calib");
+      histos->fillCalibHist(pPedestals->pedestals[i].ped, "hCalibPedsP", "Peds", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(pPedestals->pedestals[i].rms, "hCalibPedsR", "Peds RMS", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem33, "hCalibNoise33", "Noise Matrix 33", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem34, "hCalibNoise34", "Noise Matrix 34", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem35, "hCalibNoise35", "Noise Matrix 35", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem44, "hCalibNoise44", "Noise Matrix 44", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem45, "hCalibNoise45", "Noise Matrix 45", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem46, "hCalibNoise46", "Noise Matrix 46", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem55, "hCalibNoise55", "Noise Matrix 55", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem56, "hCalibNoise56", "Noise Matrix 56", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem57, "hCalibNoise57", "Noise Matrix 57", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem66, "hCalibNoise66", "Noise Matrix 66", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem67, "hCalibNoise67", "Noise Matrix 67", 400, 0, 400, bin, "Calib");
+      histos->fillCalibHist(
+          pNoiseMatrix->matrix[i].elem77, "hCalibNoise77", "Noise Matrix 77", 400, 0, 400, bin, "Calib");
     }
-
   }
-
-
 }
-
 
 // ==============================================
 //
@@ -715,32 +772,33 @@ void CSCValidation::doCalibrations(const edm::EventSetup& eventSetup){
 //
 // ==============================================
 
-void CSCValidation::doWireDigis(edm::Handle<CSCWireDigiCollection> wires){
-
+void CSCValidation::doWireDigis(edm::Handle<CSCWireDigiCollection> wires) {
   int nWireGroupsTotal = 0;
-  for (CSCWireDigiCollection::DigiRangeIterator dWDiter=wires->begin(); dWDiter!=wires->end(); dWDiter++) {
+  for (CSCWireDigiCollection::DigiRangeIterator dWDiter = wires->begin(); dWDiter != wires->end(); dWDiter++) {
     CSCDetId id = (CSCDetId)(*dWDiter).first;
     std::vector<CSCWireDigi>::const_iterator wireIter = (*dWDiter).second.first;
     std::vector<CSCWireDigi>::const_iterator lWire = (*dWDiter).second.second;
-    for( ; wireIter != lWire; ++wireIter) {
+    for (; wireIter != lWire; ++wireIter) {
       int myWire = wireIter->getWireGroup();
       int myTBin = wireIter->getTimeBin();
       nWireGroupsTotal++;
-      histos->fill1DHistByType(myWire,"hWireWire","Wiregroup Numbers Fired",id,113,-0.5,112.5,"Digis");
-      histos->fill1DHistByType(myTBin,"hWireTBin","Wire TimeBin Fired",id,17,-0.5,16.5,"Digis");
-      histos->fillProfile(chamberSerial(id),myTBin,"hWireTBinProfile","Wire TimeBin Fired",601,-0.5,600.5,-0.5,16.5,"Digis");
-      if (detailedAnalysis){
-        histos->fill1DHistByLayer(myWire,"hWireWire","Wiregroup Numbers Fired",id,113,-0.5,112.5,"WireNumberByLayer");
-        histos->fill1DHistByLayer(myTBin,"hWireTBin","Wire TimeBin Fired",id,17,-0.5,16.5,"WireTimeByLayer");
+      histos->fill1DHistByType(myWire, "hWireWire", "Wiregroup Numbers Fired", id, 113, -0.5, 112.5, "Digis");
+      histos->fill1DHistByType(myTBin, "hWireTBin", "Wire TimeBin Fired", id, 17, -0.5, 16.5, "Digis");
+      histos->fillProfile(
+          chamberSerial(id), myTBin, "hWireTBinProfile", "Wire TimeBin Fired", 601, -0.5, 600.5, -0.5, 16.5, "Digis");
+      if (detailedAnalysis) {
+        histos->fill1DHistByLayer(
+            myWire, "hWireWire", "Wiregroup Numbers Fired", id, 113, -0.5, 112.5, "WireNumberByLayer");
+        histos->fill1DHistByLayer(myTBin, "hWireTBin", "Wire TimeBin Fired", id, 17, -0.5, 16.5, "WireTimeByLayer");
       }
     }
-  } // end wire loop
+  }  // end wire loop
 
   // this way you can zero suppress but still store info on # events with no digis
-  if (nWireGroupsTotal == 0) nWireGroupsTotal = -1;
+  if (nWireGroupsTotal == 0)
+    nWireGroupsTotal = -1;
 
-  histos->fill1DHist(nWireGroupsTotal,"hWirenGroupsTotal","Wires Fired Per Event",151,-0.5,150.5,"Digis");
-  
+  histos->fill1DHist(nWireGroupsTotal, "hWirenGroupsTotal", "Wires Fired Per Event", 151, -0.5, 150.5, "Digis");
 }
 
 // ==============================================
@@ -749,39 +807,40 @@ void CSCValidation::doWireDigis(edm::Handle<CSCWireDigiCollection> wires){
 //
 // ==============================================
 
-void CSCValidation::doStripDigis(edm::Handle<CSCStripDigiCollection> strips){
-
+void CSCValidation::doStripDigis(edm::Handle<CSCStripDigiCollection> strips) {
   int nStripsFired = 0;
-  for (CSCStripDigiCollection::DigiRangeIterator dSDiter=strips->begin(); dSDiter!=strips->end(); dSDiter++) {
+  for (CSCStripDigiCollection::DigiRangeIterator dSDiter = strips->begin(); dSDiter != strips->end(); dSDiter++) {
     CSCDetId id = (CSCDetId)(*dSDiter).first;
     std::vector<CSCStripDigi>::const_iterator stripIter = (*dSDiter).second.first;
     std::vector<CSCStripDigi>::const_iterator lStrip = (*dSDiter).second.second;
-    for( ; stripIter != lStrip; ++stripIter) {
+    for (; stripIter != lStrip; ++stripIter) {
       int myStrip = stripIter->getStrip();
       std::vector<int> myADCVals = stripIter->getADCCounts();
       bool thisStripFired = false;
-      float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-      float threshold = 13.3 ;
+      float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+      float threshold = 13.3;
       float diff = 0.;
       for (unsigned int iCount = 0; iCount < myADCVals.size(); iCount++) {
-	diff = (float)myADCVals[iCount]-thisPedestal;
-	if (diff > threshold) { thisStripFired = true; }
-      } 
+        diff = (float)myADCVals[iCount] - thisPedestal;
+        if (diff > threshold) {
+          thisStripFired = true;
+        }
+      }
       if (thisStripFired) {
         nStripsFired++;
         // fill strip histos
-        histos->fill1DHistByType(myStrip,"hStripStrip","Strip Number",id,81,-0.5,80.5,"Digis");
-        if (detailedAnalysis){
-          histos->fill1DHistByLayer(myStrip,"hStripStrip","Strip Number",id,81,-0.5,80.5,"StripNumberByLayer");
+        histos->fill1DHistByType(myStrip, "hStripStrip", "Strip Number", id, 81, -0.5, 80.5, "Digis");
+        if (detailedAnalysis) {
+          histos->fill1DHistByLayer(myStrip, "hStripStrip", "Strip Number", id, 81, -0.5, 80.5, "StripNumberByLayer");
         }
       }
     }
-  } // end strip loop
+  }  // end strip loop
 
-  if (nStripsFired == 0) nStripsFired = -1;
+  if (nStripsFired == 0)
+    nStripsFired = -1;
 
-  histos->fill1DHist(nStripsFired,"hStripNFired","Fired Strips per Event",251,-0.5,250.5,"Digis");
-
+  histos->fill1DHist(nStripsFired, "hStripNFired", "Fired Strips per Event", 251, -0.5, 250.5, "Digis");
 }
 
 //=======================================================
@@ -790,39 +849,49 @@ void CSCValidation::doStripDigis(edm::Handle<CSCStripDigiCollection> strips){
 //
 //=======================================================
 
-void CSCValidation::doPedestalNoise(edm::Handle<CSCStripDigiCollection> strips){
-
-  for (CSCStripDigiCollection::DigiRangeIterator dPNiter=strips->begin(); dPNiter!=strips->end(); dPNiter++) {
+void CSCValidation::doPedestalNoise(edm::Handle<CSCStripDigiCollection> strips) {
+  for (CSCStripDigiCollection::DigiRangeIterator dPNiter = strips->begin(); dPNiter != strips->end(); dPNiter++) {
     CSCDetId id = (CSCDetId)(*dPNiter).first;
     std::vector<CSCStripDigi>::const_iterator pedIt = (*dPNiter).second.first;
     std::vector<CSCStripDigi>::const_iterator lStrip = (*dPNiter).second.second;
-    for( ; pedIt != lStrip; ++pedIt) {
+    for (; pedIt != lStrip; ++pedIt) {
       int myStrip = pedIt->getStrip();
       std::vector<int> myADCVals = pedIt->getADCCounts();
       float TotalADC = getSignal(*strips, id, myStrip);
       bool thisStripFired = false;
-      float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-      float thisSignal = (1./6)*(myADCVals[2]+myADCVals[3]+myADCVals[4]+myADCVals[5]+myADCVals[6]+myADCVals[7]);
+      float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+      float thisSignal =
+          (1. / 6) * (myADCVals[2] + myADCVals[3] + myADCVals[4] + myADCVals[5] + myADCVals[6] + myADCVals[7]);
       float threshold = 13.3;
-      if(id.station() == 1 && id.ring() == 4)
-	{
-	  if(myStrip <= 16) myStrip += 64; // no trapping for any bizarreness
-	}
-      if (TotalADC > threshold) { thisStripFired = true;}
-      if (!thisStripFired){
-	float ADC = thisSignal - thisPedestal;
-        histos->fill1DHist(ADC,"hStripPed","Pedestal Noise Distribution",50,-25.,25.,"PedestalNoise");
-        histos->fill1DHistByType(ADC,"hStripPedME","Pedestal Noise Distribution",id,50,-25.,25.,"PedestalNoise");
-        histos->fillProfile(chamberSerial(id),ADC,"hStripPedMEProfile","Wire TimeBin Fired",601,-0.5,600.5,-25,25,"PedestalNoise");
-        if (detailedAnalysis){
-          histos->fill1DHistByLayer(ADC,"hStripPedME","Pedestal Noise Distribution",id,50,-25.,25.,"PedestalNoiseByLayer");
+      if (id.station() == 1 && id.ring() == 4) {
+        if (myStrip <= 16)
+          myStrip += 64;  // no trapping for any bizarreness
+      }
+      if (TotalADC > threshold) {
+        thisStripFired = true;
+      }
+      if (!thisStripFired) {
+        float ADC = thisSignal - thisPedestal;
+        histos->fill1DHist(ADC, "hStripPed", "Pedestal Noise Distribution", 50, -25., 25., "PedestalNoise");
+        histos->fill1DHistByType(ADC, "hStripPedME", "Pedestal Noise Distribution", id, 50, -25., 25., "PedestalNoise");
+        histos->fillProfile(chamberSerial(id),
+                            ADC,
+                            "hStripPedMEProfile",
+                            "Wire TimeBin Fired",
+                            601,
+                            -0.5,
+                            600.5,
+                            -25,
+                            25,
+                            "PedestalNoise");
+        if (detailedAnalysis) {
+          histos->fill1DHistByLayer(
+              ADC, "hStripPedME", "Pedestal Noise Distribution", id, 50, -25., 25., "PedestalNoiseByLayer");
         }
       }
     }
   }
-
 }
-
 
 // ==============================================
 //
@@ -830,13 +899,12 @@ void CSCValidation::doPedestalNoise(edm::Handle<CSCStripDigiCollection> strips){
 //
 // ==============================================
 
-void CSCValidation::doRecHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::ESHandle<CSCGeometry> cscGeom){
-
+void CSCValidation::doRecHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::ESHandle<CSCGeometry> cscGeom) {
   // Get the RecHits collection :
   int nRecHits = recHits->size();
- 
+
   // ---------------------
-  // Loop over rechits 
+  // Loop over rechits
   // ---------------------
   int iHit = 0;
 
@@ -845,19 +913,19 @@ void CSCValidation::doRecHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::E
   for (dRHIter = recHits->begin(); dRHIter != recHits->end(); dRHIter++) {
     iHit++;
 
-    // Find chamber with rechits in CSC 
+    // Find chamber with rechits in CSC
     CSCDetId idrec = (CSCDetId)(*dRHIter).cscDetId();
-    int kEndcap  = idrec.endcap();
-    int kRing    = idrec.ring();
+    int kEndcap = idrec.endcap();
+    int kRing = idrec.ring();
     int kStation = idrec.station();
     int kChamber = idrec.chamber();
-    int kLayer   = idrec.layer();
+    int kLayer = idrec.layer();
 
     // Store rechit as a Local Point:
-    LocalPoint rhitlocal = (*dRHIter).localPosition();  
+    LocalPoint rhitlocal = (*dRHIter).localPosition();
     float xreco = rhitlocal.x();
     float yreco = rhitlocal.y();
-    LocalError rerrlocal = (*dRHIter).localPositionError();  
+    LocalError rerrlocal = (*dRHIter).localPositionError();
     //these errors are squared!
     float xxerr = rerrlocal.xx();
     float yyerr = rerrlocal.yy();
@@ -868,68 +936,94 @@ void CSCValidation::doRecHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::E
 
     // Find the charge associated with this hit
     float rHSumQ = 0;
-    float sumsides=0.;
-    int adcsize=dRHIter->nStrips()*dRHIter->nTimeBins();
-    for ( unsigned int i=0; i< dRHIter->nStrips(); i++) {
-      for ( unsigned int j=0; j< dRHIter->nTimeBins()-1; j++) {
-	rHSumQ+=dRHIter->adcs(i,j); 
-	if (i!=1) sumsides+=dRHIter->adcs(i,j);
+    float sumsides = 0.;
+    int adcsize = dRHIter->nStrips() * dRHIter->nTimeBins();
+    for (unsigned int i = 0; i < dRHIter->nStrips(); i++) {
+      for (unsigned int j = 0; j < dRHIter->nTimeBins() - 1; j++) {
+        rHSumQ += dRHIter->adcs(i, j);
+        if (i != 1)
+          sumsides += dRHIter->adcs(i, j);
       }
     }
 
-    float rHratioQ = sumsides/rHSumQ;
-    if (adcsize != 12) rHratioQ = -99;
+    float rHratioQ = sumsides / rHSumQ;
+    if (adcsize != 12)
+      rHratioQ = -99;
 
     // Get the signal timing of this hit
     float rHtime = 0;
-    rHtime = (*dRHIter).tpeak()/50.;
+    rHtime = (*dRHIter).tpeak() / 50.;
 
     // Get pointer to the layer:
-    const CSCLayer* csclayer = cscGeom->layer( idrec );
+    const CSCLayer* csclayer = cscGeom->layer(idrec);
 
     // Transform hit position from local chamber geometry to global CMS geom
-    GlobalPoint rhitglobal= csclayer->toGlobal(rhitlocal);
-    float grecx   =  rhitglobal.x();
-    float grecy   =  rhitglobal.y();
+    GlobalPoint rhitglobal = csclayer->toGlobal(rhitlocal);
+    float grecx = rhitglobal.x();
+    float grecy = rhitglobal.y();
 
     // Fill the rechit position branch
-    if (writeTreeToFile && rhTreeCount < 1500000){
+    if (writeTreeToFile && rhTreeCount < 1500000) {
       histos->fillRechitTree(xreco, yreco, grecx, grecy, kEndcap, kStation, kRing, kChamber, kLayer);
       rhTreeCount++;
-    }    
+    }
 
     // Fill some histograms
     // only fill if 3 strips were used in the hit
-    histos->fill2DHistByStation(grecx,grecy,"hRHGlobal","recHit Global Position",idrec,100,-800.,800.,100,-800.,800.,"recHits");
-    if (kStation == 1 && (kRing == 1 || kRing == 4)) histos->fill1DHistByType(rHSumQ,"hRHSumQ","Sum 3x3 recHit Charge",idrec,125,0,4000,"recHits");
-    else histos->fill1DHistByType(rHSumQ,"hRHSumQ","Sum 3x3 recHit Charge",idrec,125,0,2000,"recHits");
-    histos->fill1DHistByType(rHratioQ,"hRHRatioQ","Charge Ratio (Ql+Qr)/Qt",idrec,120,-0.1,1.1,"recHits");
-    histos->fill1DHistByType(rHtime,"hRHTiming","recHit Timing",idrec,200,-10,10,"recHits");
-    histos->fill1DHistByType(sqrt(xxerr),"hRHxerr","RecHit Error on Local X",idrec,100,-0.1,2,"recHits");
-    histos->fill1DHistByType(sqrt(yyerr),"hRHyerr","RecHit Error on Local Y",idrec,100,-0.1,2,"recHits");
-    histos->fill1DHistByType(xyerr,"hRHxyerr","Corr. RecHit XY Error",idrec,100,-1,2,"recHits");
-    if (adcsize == 12) histos->fill1DHistByType(stpos,"hRHstpos","Reconstructed Position on Strip",idrec,120,-0.6,0.6,"recHits");
-    histos->fill1DHistByType(sterr,"hRHsterr","Estimated Error on Strip Measurement",idrec,120,-0.05,0.25,"recHits");
-    histos->fillProfile(chamberSerial(idrec),rHSumQ,"hRHSumQProfile","Sum 3x3 recHit Charge",601,-0.5,600.5,0,4000,"recHits");
-    histos->fillProfile(chamberSerial(idrec),rHtime,"hRHTimingProfile","recHit Timing",601,-0.5,600.5,-11,11,"recHits");
-    if (detailedAnalysis){
-      if (kStation == 1 && (kRing == 1 || kRing == 4)) histos->fill1DHistByLayer(rHSumQ,"hRHSumQ","Sum 3x3 recHit Charge",idrec,125,0,4000,"RHQByLayer");
-      else histos->fill1DHistByLayer(rHSumQ,"hRHSumQ","Sum 3x3 recHit Charge",idrec,125,0,2000,"RHQByLayer");
-      histos->fill1DHistByLayer(rHratioQ,"hRHRatioQ","Charge Ratio (Ql+Qr)/Qt",idrec,120,-0.1,1.1,"RHQByLayer");
-      histos->fill1DHistByLayer(rHtime,"hRHTiming","recHit Timing",idrec,200,-10,10,"RHTimingByLayer");
-      histos->fill2DHistByLayer(xreco,yreco,"hRHLocalXY","recHit Local Position",idrec,50,-100.,100.,75,-150.,150.,"RHLocalXYByLayer");
-      histos->fill1DHistByLayer(sqrt(xxerr),"hRHxerr","RecHit Error on Local X",idrec,100,-0.1,2,"RHErrorsByLayer");
-      histos->fill1DHistByLayer(sqrt(yyerr),"hRHyerr","RecHit Error on Local Y",idrec,100,-0.1,2,"RHErrorsByLayer");
-      histos->fill1DHistByType(stpos,"hRHstpos","Reconstructed Position on Strip",idrec,120,-0.6,0.6,"RHStripPosByLayer");
-      histos->fill1DHistByType(sterr,"hRHsterr","Estimated Error on Strip Measurement",idrec,120,-0.05,0.25,"RHStripPosByLayer");
+    histos->fill2DHistByStation(
+        grecx, grecy, "hRHGlobal", "recHit Global Position", idrec, 100, -800., 800., 100, -800., 800., "recHits");
+    if (kStation == 1 && (kRing == 1 || kRing == 4))
+      histos->fill1DHistByType(rHSumQ, "hRHSumQ", "Sum 3x3 recHit Charge", idrec, 125, 0, 4000, "recHits");
+    else
+      histos->fill1DHistByType(rHSumQ, "hRHSumQ", "Sum 3x3 recHit Charge", idrec, 125, 0, 2000, "recHits");
+    histos->fill1DHistByType(rHratioQ, "hRHRatioQ", "Charge Ratio (Ql+Qr)/Qt", idrec, 120, -0.1, 1.1, "recHits");
+    histos->fill1DHistByType(rHtime, "hRHTiming", "recHit Timing", idrec, 200, -10, 10, "recHits");
+    histos->fill1DHistByType(sqrt(xxerr), "hRHxerr", "RecHit Error on Local X", idrec, 100, -0.1, 2, "recHits");
+    histos->fill1DHistByType(sqrt(yyerr), "hRHyerr", "RecHit Error on Local Y", idrec, 100, -0.1, 2, "recHits");
+    histos->fill1DHistByType(xyerr, "hRHxyerr", "Corr. RecHit XY Error", idrec, 100, -1, 2, "recHits");
+    if (adcsize == 12)
+      histos->fill1DHistByType(stpos, "hRHstpos", "Reconstructed Position on Strip", idrec, 120, -0.6, 0.6, "recHits");
+    histos->fill1DHistByType(
+        sterr, "hRHsterr", "Estimated Error on Strip Measurement", idrec, 120, -0.05, 0.25, "recHits");
+    histos->fillProfile(
+        chamberSerial(idrec), rHSumQ, "hRHSumQProfile", "Sum 3x3 recHit Charge", 601, -0.5, 600.5, 0, 4000, "recHits");
+    histos->fillProfile(
+        chamberSerial(idrec), rHtime, "hRHTimingProfile", "recHit Timing", 601, -0.5, 600.5, -11, 11, "recHits");
+    if (detailedAnalysis) {
+      if (kStation == 1 && (kRing == 1 || kRing == 4))
+        histos->fill1DHistByLayer(rHSumQ, "hRHSumQ", "Sum 3x3 recHit Charge", idrec, 125, 0, 4000, "RHQByLayer");
+      else
+        histos->fill1DHistByLayer(rHSumQ, "hRHSumQ", "Sum 3x3 recHit Charge", idrec, 125, 0, 2000, "RHQByLayer");
+      histos->fill1DHistByLayer(rHratioQ, "hRHRatioQ", "Charge Ratio (Ql+Qr)/Qt", idrec, 120, -0.1, 1.1, "RHQByLayer");
+      histos->fill1DHistByLayer(rHtime, "hRHTiming", "recHit Timing", idrec, 200, -10, 10, "RHTimingByLayer");
+      histos->fill2DHistByLayer(xreco,
+                                yreco,
+                                "hRHLocalXY",
+                                "recHit Local Position",
+                                idrec,
+                                50,
+                                -100.,
+                                100.,
+                                75,
+                                -150.,
+                                150.,
+                                "RHLocalXYByLayer");
+      histos->fill1DHistByLayer(
+          sqrt(xxerr), "hRHxerr", "RecHit Error on Local X", idrec, 100, -0.1, 2, "RHErrorsByLayer");
+      histos->fill1DHistByLayer(
+          sqrt(yyerr), "hRHyerr", "RecHit Error on Local Y", idrec, 100, -0.1, 2, "RHErrorsByLayer");
+      histos->fill1DHistByType(
+          stpos, "hRHstpos", "Reconstructed Position on Strip", idrec, 120, -0.6, 0.6, "RHStripPosByLayer");
+      histos->fill1DHistByType(
+          sterr, "hRHsterr", "Estimated Error on Strip Measurement", idrec, 120, -0.05, 0.25, "RHStripPosByLayer");
     }
 
-  } //end rechit loop
+  }  //end rechit loop
 
-  if (nRecHits == 0) nRecHits = -1;
+  if (nRecHits == 0)
+    nRecHits = -1;
 
-  histos->fill1DHist(nRecHits,"hRHnrechits","recHits per Event (all chambers)",151,-0.5,150.5,"recHits");
-
+  histos->fill1DHist(nRecHits, "hRHnrechits", "recHits per Event (all chambers)", 151, -0.5, 150.5, "recHits");
 }
 
 // ==============================================
@@ -938,11 +1032,9 @@ void CSCValidation::doRecHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::E
 //
 // ==============================================
 
-void CSCValidation::doSimHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<PSimHitContainer> simHits){
-
+void CSCValidation::doSimHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<PSimHitContainer> simHits) {
   CSCRecHit2DCollection::const_iterator dSHrecIter;
   for (dSHrecIter = recHits->begin(); dSHrecIter != recHits->end(); dSHrecIter++) {
-
     CSCDetId idrec = (CSCDetId)(*dSHrecIter).cscDetId();
     LocalPoint rhitlocal = (*dSHrecIter).localPosition();
     float xreco = rhitlocal.x();
@@ -951,39 +1043,39 @@ void CSCValidation::doSimHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::H
     float yError = sqrt((*dSHrecIter).localPositionError().yy());
     float simHitXres = -99;
     float simHitYres = -99;
-    float xPull      = -99;
-    float yPull      = -99;
-    float mindiffX   = 99;
-    float mindiffY   = 10;
+    float xPull = -99;
+    float yPull = -99;
+    float mindiffX = 99;
+    float mindiffY = 10;
     // If MC, find closest muon simHit to check resolution:
     PSimHitContainer::const_iterator dSHsimIter;
-    for (dSHsimIter = simHits->begin(); dSHsimIter != simHits->end(); dSHsimIter++){
+    for (dSHsimIter = simHits->begin(); dSHsimIter != simHits->end(); dSHsimIter++) {
       // Get DetID for this simHit:
       CSCDetId sId = (CSCDetId)(*dSHsimIter).detUnitId();
       // Check if the simHit detID matches that of current recHit
       // and make sure it is a muon hit:
-      if (sId == idrec && abs((*dSHsimIter).particleType()) == 13){
+      if (sId == idrec && abs((*dSHsimIter).particleType()) == 13) {
         // Get the position of this simHit in local coordinate system:
         LocalPoint sHitlocal = (*dSHsimIter).localPosition();
         // Now we need to make reasonably sure that this simHit is
         // responsible for this recHit:
-        if ((sHitlocal.x() - xreco) < mindiffX && (sHitlocal.y() - yreco) < mindiffY){
+        if ((sHitlocal.x() - xreco) < mindiffX && (sHitlocal.y() - yreco) < mindiffY) {
           simHitXres = (sHitlocal.x() - xreco);
           simHitYres = (sHitlocal.y() - yreco);
           mindiffX = (sHitlocal.x() - xreco);
-          xPull = simHitXres/xError;
-          yPull = simHitYres/yError;
+          xPull = simHitXres / xError;
+          yPull = simHitYres / yError;
         }
       }
     }
 
-    histos->fill1DHistByType(simHitXres,"hSimXResid","SimHitX - Reconstructed X",idrec,100,-1.0,1.0,"Resolution");
-    histos->fill1DHistByType(simHitYres,"hSimYResid","SimHitY - Reconstructed Y",idrec,100,-5.0,5.0,"Resolution");
-    histos->fill1DHistByType(xPull,"hSimXPull","Local X Pulls",idrec,100,-5.0,5.0,"Resolution");
-    histos->fill1DHistByType(yPull,"hSimYPull","Local Y Pulls",idrec,100,-5.0,5.0,"Resolution");
-
+    histos->fill1DHistByType(
+        simHitXres, "hSimXResid", "SimHitX - Reconstructed X", idrec, 100, -1.0, 1.0, "Resolution");
+    histos->fill1DHistByType(
+        simHitYres, "hSimYResid", "SimHitY - Reconstructed Y", idrec, 100, -5.0, 5.0, "Resolution");
+    histos->fill1DHistByType(xPull, "hSimXPull", "Local X Pulls", idrec, 100, -5.0, 5.0, "Resolution");
+    histos->fill1DHistByType(yPull, "hSimYPull", "Local Y Pulls", idrec, 100, -5.0, 5.0, "Resolution");
   }
-
 }
 
 // ==============================================
@@ -992,8 +1084,7 @@ void CSCValidation::doSimHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::H
 //
 // ===============================================
 
-void CSCValidation::doSegments(edm::Handle<CSCSegmentCollection> cscSegments, edm::ESHandle<CSCGeometry> cscGeom){
-
+void CSCValidation::doSegments(edm::Handle<CSCSegmentCollection> cscSegments, edm::ESHandle<CSCGeometry> cscGeom) {
   // get CSC segment collection
   int nSegments = cscSegments->size();
 
@@ -1001,31 +1092,31 @@ void CSCValidation::doSegments(edm::Handle<CSCSegmentCollection> cscSegments, ed
   // loop over segments
   // -----------------------
   int iSegment = 0;
-  for(CSCSegmentCollection::const_iterator dSiter=cscSegments->begin(); dSiter != cscSegments->end(); dSiter++) {
+  for (CSCSegmentCollection::const_iterator dSiter = cscSegments->begin(); dSiter != cscSegments->end(); dSiter++) {
     iSegment++;
     //
-    CSCDetId id  = (CSCDetId)(*dSiter).cscDetId();
-    int kEndcap  = id.endcap();
-    int kRing    = id.ring();
+    CSCDetId id = (CSCDetId)(*dSiter).cscDetId();
+    int kEndcap = id.endcap();
+    int kRing = id.ring();
     int kStation = id.station();
     int kChamber = id.chamber();
 
     //
-    float chisq    = (*dSiter).chi2();
-    int nhits      = (*dSiter).nRecHits();
-    int nDOF       = 2*nhits-4;
-    double chisqProb = ChiSquaredProbability( (double)chisq, nDOF );
+    float chisq = (*dSiter).chi2();
+    int nhits = (*dSiter).nRecHits();
+    int nDOF = 2 * nhits - 4;
+    double chisqProb = ChiSquaredProbability((double)chisq, nDOF);
     LocalPoint localPos = (*dSiter).localPosition();
-    float segX     = localPos.x();
-    float segY     = localPos.y();
+    float segX = localPos.x();
+    float segY = localPos.y();
     LocalVector segDir = (*dSiter).localDirection();
-    double theta   = segDir.theta();
+    double theta = segDir.theta();
 
     // global transformation
     float globX = 0.;
     float globY = 0.;
     float globTheta = 0.;
-    float globPhi   = 0.;
+    float globPhi = 0.;
     const CSCChamber* cscchamber = cscGeom->chamber(id);
     if (cscchamber) {
       GlobalPoint globalPosition = cscchamber->toGlobal(localPos);
@@ -1033,38 +1124,52 @@ void CSCValidation::doSegments(edm::Handle<CSCSegmentCollection> cscSegments, ed
       globY = globalPosition.y();
       GlobalVector globalDirection = cscchamber->toGlobal(segDir);
       globTheta = globalDirection.theta();
-      globPhi   = globalDirection.phi();
+      globPhi = globalDirection.phi();
     }
 
-
     // Fill segment position branch
-    if (writeTreeToFile && segTreeCount < 1500000){
+    if (writeTreeToFile && segTreeCount < 1500000) {
       histos->fillSegmentTree(segX, segY, globX, globY, kEndcap, kStation, kRing, kChamber);
       segTreeCount++;
     }
 
     // Fill histos
-    histos->fill2DHistByStation(globX,globY,"hSGlobal","Segment Global Positions;global x (cm)",id,100,-800.,800.,100,-800.,800.,"Segments");
-    histos->fill1DHistByType(nhits,"hSnHits","N hits on Segments",id,8,-0.5,7.5,"Segments");
-    histos->fill1DHistByType(theta,"hSTheta","local theta segments",id,128,-3.2,3.2,"Segments");
-    histos->fill1DHistByType((chisq/nDOF),"hSChiSq","segments chi-squared/ndof",id,110,-0.05,10.5,"Segments");
-    histos->fill1DHistByType(chisqProb,"hSChiSqProb","segments chi-squared probability",id,110,-0.05,1.05,"Segments");
-    histos->fill1DHist(globTheta,"hSGlobalTheta","segment global theta",128,0,3.2,"Segments");
-    histos->fill1DHist(globPhi,"hSGlobalPhi","segment global phi",128,-3.2,3.2,"Segments");
-    histos->fillProfile(chamberSerial(id),nhits,"hSnHitsProfile","N hits on Segments",601,-0.5,600.5,-0.5,7.5,"Segments");
-    if (detailedAnalysis){
-      histos->fill1DHistByChamber(nhits,"hSnHits","N hits on Segments",id,8,-0.5,7.5,"HitsOnSegmentByChamber");
-      histos->fill1DHistByChamber(theta,"hSTheta","local theta segments",id,128,-3.2,3.2,"DetailedSegments");
-      histos->fill1DHistByChamber((chisq/nDOF),"hSChiSq","segments chi-squared/ndof",id,110,-0.05,10.5,"SegChi2ByChamber");
-      histos->fill1DHistByChamber(chisqProb,"hSChiSqProb","segments chi-squared probability",id,110,-0.05,1.05,"SegChi2ByChamber");
+    histos->fill2DHistByStation(globX,
+                                globY,
+                                "hSGlobal",
+                                "Segment Global Positions;global x (cm)",
+                                id,
+                                100,
+                                -800.,
+                                800.,
+                                100,
+                                -800.,
+                                800.,
+                                "Segments");
+    histos->fill1DHistByType(nhits, "hSnHits", "N hits on Segments", id, 8, -0.5, 7.5, "Segments");
+    histos->fill1DHistByType(theta, "hSTheta", "local theta segments", id, 128, -3.2, 3.2, "Segments");
+    histos->fill1DHistByType((chisq / nDOF), "hSChiSq", "segments chi-squared/ndof", id, 110, -0.05, 10.5, "Segments");
+    histos->fill1DHistByType(
+        chisqProb, "hSChiSqProb", "segments chi-squared probability", id, 110, -0.05, 1.05, "Segments");
+    histos->fill1DHist(globTheta, "hSGlobalTheta", "segment global theta", 128, 0, 3.2, "Segments");
+    histos->fill1DHist(globPhi, "hSGlobalPhi", "segment global phi", 128, -3.2, 3.2, "Segments");
+    histos->fillProfile(
+        chamberSerial(id), nhits, "hSnHitsProfile", "N hits on Segments", 601, -0.5, 600.5, -0.5, 7.5, "Segments");
+    if (detailedAnalysis) {
+      histos->fill1DHistByChamber(nhits, "hSnHits", "N hits on Segments", id, 8, -0.5, 7.5, "HitsOnSegmentByChamber");
+      histos->fill1DHistByChamber(theta, "hSTheta", "local theta segments", id, 128, -3.2, 3.2, "DetailedSegments");
+      histos->fill1DHistByChamber(
+          (chisq / nDOF), "hSChiSq", "segments chi-squared/ndof", id, 110, -0.05, 10.5, "SegChi2ByChamber");
+      histos->fill1DHistByChamber(
+          chisqProb, "hSChiSqProb", "segments chi-squared probability", id, 110, -0.05, 1.05, "SegChi2ByChamber");
     }
 
-  } // end segment loop
+  }  // end segment loop
 
-  if (nSegments == 0) nSegments = -1;
+  if (nSegments == 0)
+    nSegments = -1;
 
-  histos->fill1DHist(nSegments,"hSnSegments","Segments per Event",31,-0.5,30.5,"Segments");
-
+  histos->fill1DHist(nSegments, "hSnSegments", "Segments per Event", 31, -0.5, 30.5, "Segments");
 }
 
 // ==============================================
@@ -1073,66 +1178,79 @@ void CSCValidation::doSegments(edm::Handle<CSCSegmentCollection> cscSegments, ed
 //
 // ===============================================
 
-void CSCValidation::doResolution(edm::Handle<CSCSegmentCollection> cscSegments, edm::ESHandle<CSCGeometry> cscGeom){
-
-
-  for(CSCSegmentCollection::const_iterator dSiter=cscSegments->begin(); dSiter != cscSegments->end(); dSiter++) {
-
-    CSCDetId id  = (CSCDetId)(*dSiter).cscDetId();
+void CSCValidation::doResolution(edm::Handle<CSCSegmentCollection> cscSegments, edm::ESHandle<CSCGeometry> cscGeom) {
+  for (CSCSegmentCollection::const_iterator dSiter = cscSegments->begin(); dSiter != cscSegments->end(); dSiter++) {
+    CSCDetId id = (CSCDetId)(*dSiter).cscDetId();
 
     //
     // try to get the CSC recHits that contribute to this segment.
     std::vector<CSCRecHit2D> theseRecHits = (*dSiter).specificRecHits();
     int nRH = (*dSiter).nRecHits();
     int jRH = 0;
-    CLHEP::HepMatrix sp(6,1);
-    CLHEP::HepMatrix se(6,1);
-    for ( std::vector<CSCRecHit2D>::const_iterator iRH = theseRecHits.begin(); iRH != theseRecHits.end(); iRH++) {
+    CLHEP::HepMatrix sp(6, 1);
+    CLHEP::HepMatrix se(6, 1);
+    for (std::vector<CSCRecHit2D>::const_iterator iRH = theseRecHits.begin(); iRH != theseRecHits.end(); iRH++) {
       jRH++;
       CSCDetId idRH = (CSCDetId)(*iRH).cscDetId();
-      int kRing    = idRH.ring();
+      int kRing = idRH.ring();
       int kStation = idRH.station();
-      int kLayer   = idRH.layer();
+      int kLayer = idRH.layer();
 
       // Find the strip containing this hit
-      int centerid     =  iRH->nStrips()/2;
-      int centerStrip =  iRH->channels(centerid);
+      int centerid = iRH->nStrips() / 2;
+      int centerStrip = iRH->channels(centerid);
 
       // If this segment has 6 hits, find the position of each hit on the strip in units of stripwidth and store values
-      if (nRH == 6){
+      if (nRH == 6) {
         float stpos = (*iRH).positionWithinStrip();
-        se(kLayer,1) = (*iRH).errorWithinStrip();
+        se(kLayer, 1) = (*iRH).errorWithinStrip();
         // Take into account half-strip staggering of layers (ME1/1 has no staggering)
-        if (kStation == 1 && (kRing == 1 || kRing == 4)) sp(kLayer,1) = stpos + centerStrip;
-        else{
-          if (kLayer == 1 || kLayer == 3 || kLayer == 5) sp(kLayer,1) = stpos + centerStrip;
-          if (kLayer == 2 || kLayer == 4 || kLayer == 6) sp(kLayer,1) = stpos - 0.5 + centerStrip;
+        if (kStation == 1 && (kRing == 1 || kRing == 4))
+          sp(kLayer, 1) = stpos + centerStrip;
+        else {
+          if (kLayer == 1 || kLayer == 3 || kLayer == 5)
+            sp(kLayer, 1) = stpos + centerStrip;
+          if (kLayer == 2 || kLayer == 4 || kLayer == 6)
+            sp(kLayer, 1) = stpos - 0.5 + centerStrip;
         }
       }
-
     }
 
     float residual = -99;
     float pull = -99;
     // Fit all points except layer 3, then compare expected value for layer 3 to reconstructed value
-    if (nRH == 6){
-      float expected = fitX(sp,se);
-      residual = expected - sp(3,1);
-      pull = residual/se(3,1);
+    if (nRH == 6) {
+      float expected = fitX(sp, se);
+      residual = expected - sp(3, 1);
+      pull = residual / se(3, 1);
     }
 
     // Fill histos
-    histos->fill1DHistByType(residual,"hSResid","Fitted Position on Strip - Reconstructed for Layer 3",id,100,-0.5,0.5,"Resolution");
-    histos->fill1DHistByType(pull,"hSStripPosPull","Strip Measurement Pulls",id,100,-5.0,5.0,"Resolution");
-    histos->fillProfile(chamberSerial(id),residual,"hSResidProfile","Fitted Position on Strip - Reconstructed for Layer 3",601,-0.5,600.5,-0.5,0.5,"Resolution");
-    if (detailedAnalysis){
-      histos->fill1DHistByChamber(residual,"hSResid","Fitted Position on Strip - Reconstructed for Layer 3",id,100,-0.5,0.5,"DetailedResolution");
-      histos->fill1DHistByChamber(pull,"hSStripPosPull","Strip Measurement Pulls",id,100,-5.0,5.0,"Resolution");
+    histos->fill1DHistByType(
+        residual, "hSResid", "Fitted Position on Strip - Reconstructed for Layer 3", id, 100, -0.5, 0.5, "Resolution");
+    histos->fill1DHistByType(pull, "hSStripPosPull", "Strip Measurement Pulls", id, 100, -5.0, 5.0, "Resolution");
+    histos->fillProfile(chamberSerial(id),
+                        residual,
+                        "hSResidProfile",
+                        "Fitted Position on Strip - Reconstructed for Layer 3",
+                        601,
+                        -0.5,
+                        600.5,
+                        -0.5,
+                        0.5,
+                        "Resolution");
+    if (detailedAnalysis) {
+      histos->fill1DHistByChamber(residual,
+                                  "hSResid",
+                                  "Fitted Position on Strip - Reconstructed for Layer 3",
+                                  id,
+                                  100,
+                                  -0.5,
+                                  0.5,
+                                  "DetailedResolution");
+      histos->fill1DHistByChamber(pull, "hSStripPosPull", "Strip Measurement Pulls", id, 100, -5.0, 5.0, "Resolution");
     }
-
-
   }
-
 }
 
 // ==============================================
@@ -1141,15 +1259,14 @@ void CSCValidation::doResolution(edm::Handle<CSCSegmentCollection> cscSegments, 
 //
 // ==============================================
 
-void CSCValidation::doStandalone(Handle<reco::TrackCollection> saMuons){
-
+void CSCValidation::doStandalone(Handle<reco::TrackCollection> saMuons) {
   int nSAMuons = saMuons->size();
-  histos->fill1DHist(nSAMuons,"trNSAMuons","N Standalone Muons per Event",6,-0.5,5.5,"STAMuons");
+  histos->fill1DHist(nSAMuons, "trNSAMuons", "N Standalone Muons per Event", 6, -0.5, 5.5, "STAMuons");
 
-  for(reco::TrackCollection::const_iterator muon = saMuons->begin(); muon != saMuons->end(); ++ muon ) {
-    float preco  = muon->p();
+  for (reco::TrackCollection::const_iterator muon = saMuons->begin(); muon != saMuons->end(); ++muon) {
+    float preco = muon->p();
     float ptreco = muon->pt();
-    int   n = muon->recHitsSize();
+    int n = muon->recHitsSize();
     float chi2 = muon->chi2();
     float normchi2 = muon->normalizedChi2();
 
@@ -1164,87 +1281,114 @@ void CSCValidation::doStandalone(Handle<reco::TrackCollection> saMuons){
     int np = 0;
     int nm = 0;
     std::vector<CSCDetId> staChambers;
-    for (trackingRecHit_iterator hit = muon->recHitsBegin(); hit != muon->recHitsEnd(); ++hit ) {
-      const DetId detId( (*hit)->geographicalId() );
+    for (trackingRecHit_iterator hit = muon->recHitsBegin(); hit != muon->recHitsEnd(); ++hit) {
+      const DetId detId((*hit)->geographicalId());
       if (detId.det() == DetId::Muon) {
         if (detId.subdetId() == MuonSubdetId::RPC) {
           RPCDetId rpcId(detId.rawId());
           nRPCHits++;
-          if (rpcId.region() == 1){ nRPCHitsp++; np++;}
-          if (rpcId.region() == -1){ nRPCHitsm++; nm++;}
+          if (rpcId.region() == 1) {
+            nRPCHitsp++;
+            np++;
+          }
+          if (rpcId.region() == -1) {
+            nRPCHitsm++;
+            nm++;
+          }
         }
         if (detId.subdetId() == MuonSubdetId::DT) {
           nDTHits++;
-        }
-        else if (detId.subdetId() == MuonSubdetId::CSC) {
+        } else if (detId.subdetId() == MuonSubdetId::CSC) {
           CSCDetId cscId(detId.rawId());
           staChambers.push_back(detId.rawId());
           nCSCHits++;
-          if (cscId.endcap() == 1){ nCSCHitsp++; np++;}
-          if (cscId.endcap() == 2){ nCSCHitsm++; nm++;}
+          if (cscId.endcap() == 1) {
+            nCSCHitsp++;
+            np++;
+          }
+          if (cscId.endcap() == 2) {
+            nCSCHitsm++;
+            nm++;
+          }
         }
       }
     }
 
-    GlobalPoint  innerPnt(muon->innerPosition().x(),muon->innerPosition().y(),muon->innerPosition().z());
-    GlobalPoint  outerPnt(muon->outerPosition().x(),muon->outerPosition().y(),muon->outerPosition().z());
-    GlobalVector innerKin(muon->innerMomentum().x(),muon->innerMomentum().y(),muon->innerMomentum().z());
-    GlobalVector outerKin(muon->outerMomentum().x(),muon->outerMomentum().y(),muon->outerMomentum().z());
+    GlobalPoint innerPnt(muon->innerPosition().x(), muon->innerPosition().y(), muon->innerPosition().z());
+    GlobalPoint outerPnt(muon->outerPosition().x(), muon->outerPosition().y(), muon->outerPosition().z());
+    GlobalVector innerKin(muon->innerMomentum().x(), muon->innerMomentum().y(), muon->innerMomentum().z());
+    GlobalVector outerKin(muon->outerMomentum().x(), muon->outerMomentum().y(), muon->outerMomentum().z());
     GlobalVector deltaPnt = innerPnt - outerPnt;
     double crudeLength = deltaPnt.mag();
     double deltaPhi = innerPnt.phi() - outerPnt.phi();
     double innerGlobalPolarAngle = innerKin.theta();
     double outerGlobalPolarAngle = outerKin.theta();
 
-
     // fill histograms
-    histos->fill1DHist(n,"trN","N hits on a STA Muon Track",51,-0.5,50.5,"STAMuons");
-    if (np != 0) histos->fill1DHist(np,"trNp","N hits on a STA Muon Track (plus endcap)",51,-0.5,50.5,"STAMuons");
-    if (nm != 0) histos->fill1DHist(nm,"trNm","N hits on a STA Muon Track (minus endcap)",51,-0.5,50.5,"STAMuons");
-    histos->fill1DHist(nDTHits,"trNDT","N DT hits on a STA Muon Track",51,-0.5,50.5,"STAMuons");
-    histos->fill1DHist(nCSCHits,"trNCSC","N CSC hits on a STA Muon Track",51,-0.5,50.5,"STAMuons");
-    if (nCSCHitsp != 0) histos->fill1DHist(nCSCHitsp,"trNCSCp","N CSC hits on a STA Muon Track (+ endcap)",51,-0.5,50.5,"STAMuons");
-    if (nCSCHitsm != 0) histos->fill1DHist(nCSCHitsm,"trNCSCm","N CSC hits on a STA Muon Track (- endcap)",51,-0.5,50.5,"STAMuons");
-    histos->fill1DHist(nRPCHits,"trNRPC","N RPC hits on a STA Muon Track",51,-0.5,50.5,"STAMuons");
-    if (nRPCHitsp != 0) histos->fill1DHist(nRPCHitsp,"trNRPCp","N RPC hits on a STA Muon Track (+ endcap)",51,-0.5,50.5,"STAMuons");
-    if (nRPCHitsm != 0) histos->fill1DHist(nRPCHitsm,"trNRPCm","N RPC hits on a STA Muon Track (- endcap)",51,-0.5,50.5,"STAMuons");
-    histos->fill1DHist(preco,"trP","STA Muon Momentum",100,0,300,"STAMuons");
-    histos->fill1DHist(ptreco,"trPT","STA Muon pT",100,0,40,"STAMuons");
-    histos->fill1DHist(chi2,"trChi2","STA Muon Chi2",100,0,200,"STAMuons");
-    histos->fill1DHist(normchi2,"trNormChi2","STA Muon Normalized Chi2",100,0,10,"STAMuons");
-    histos->fill1DHist(crudeLength,"trLength","Straight Line Length of STA Muon",120,0.,2400.,"STAMuons");
-    histos->fill1DHist(deltaPhi,"trDeltaPhi","Delta-Phi Between Inner and Outer STA Muon Pos.",100,-0.5,0.5,"STAMuons");
-    histos->fill1DHist(innerGlobalPolarAngle,"trInnerPolar","Polar Angle of Inner P Vector (STA muons)",128,0,3.2,"STAMuons");
-    histos->fill1DHist(outerGlobalPolarAngle,"trOuterPolar","Polar Angle of Outer P Vector (STA muons)",128,0,3.2,"STAMuons");
-    histos->fill1DHist(innerPnt.phi(),"trInnerPhi","Phi of Inner Position (STA muons)",256,-3.2,3.2,"STAMuons");
-    histos->fill1DHist(outerPnt.phi(),"trOuterPhi","Phi of Outer Position (STA muons)",256,-3.2,3.2,"STAMuons");
-
+    histos->fill1DHist(n, "trN", "N hits on a STA Muon Track", 51, -0.5, 50.5, "STAMuons");
+    if (np != 0)
+      histos->fill1DHist(np, "trNp", "N hits on a STA Muon Track (plus endcap)", 51, -0.5, 50.5, "STAMuons");
+    if (nm != 0)
+      histos->fill1DHist(nm, "trNm", "N hits on a STA Muon Track (minus endcap)", 51, -0.5, 50.5, "STAMuons");
+    histos->fill1DHist(nDTHits, "trNDT", "N DT hits on a STA Muon Track", 51, -0.5, 50.5, "STAMuons");
+    histos->fill1DHist(nCSCHits, "trNCSC", "N CSC hits on a STA Muon Track", 51, -0.5, 50.5, "STAMuons");
+    if (nCSCHitsp != 0)
+      histos->fill1DHist(nCSCHitsp, "trNCSCp", "N CSC hits on a STA Muon Track (+ endcap)", 51, -0.5, 50.5, "STAMuons");
+    if (nCSCHitsm != 0)
+      histos->fill1DHist(nCSCHitsm, "trNCSCm", "N CSC hits on a STA Muon Track (- endcap)", 51, -0.5, 50.5, "STAMuons");
+    histos->fill1DHist(nRPCHits, "trNRPC", "N RPC hits on a STA Muon Track", 51, -0.5, 50.5, "STAMuons");
+    if (nRPCHitsp != 0)
+      histos->fill1DHist(nRPCHitsp, "trNRPCp", "N RPC hits on a STA Muon Track (+ endcap)", 51, -0.5, 50.5, "STAMuons");
+    if (nRPCHitsm != 0)
+      histos->fill1DHist(nRPCHitsm, "trNRPCm", "N RPC hits on a STA Muon Track (- endcap)", 51, -0.5, 50.5, "STAMuons");
+    histos->fill1DHist(preco, "trP", "STA Muon Momentum", 100, 0, 300, "STAMuons");
+    histos->fill1DHist(ptreco, "trPT", "STA Muon pT", 100, 0, 40, "STAMuons");
+    histos->fill1DHist(chi2, "trChi2", "STA Muon Chi2", 100, 0, 200, "STAMuons");
+    histos->fill1DHist(normchi2, "trNormChi2", "STA Muon Normalized Chi2", 100, 0, 10, "STAMuons");
+    histos->fill1DHist(crudeLength, "trLength", "Straight Line Length of STA Muon", 120, 0., 2400., "STAMuons");
+    histos->fill1DHist(
+        deltaPhi, "trDeltaPhi", "Delta-Phi Between Inner and Outer STA Muon Pos.", 100, -0.5, 0.5, "STAMuons");
+    histos->fill1DHist(
+        innerGlobalPolarAngle, "trInnerPolar", "Polar Angle of Inner P Vector (STA muons)", 128, 0, 3.2, "STAMuons");
+    histos->fill1DHist(
+        outerGlobalPolarAngle, "trOuterPolar", "Polar Angle of Outer P Vector (STA muons)", 128, 0, 3.2, "STAMuons");
+    histos->fill1DHist(innerPnt.phi(), "trInnerPhi", "Phi of Inner Position (STA muons)", 256, -3.2, 3.2, "STAMuons");
+    histos->fill1DHist(outerPnt.phi(), "trOuterPhi", "Phi of Outer Position (STA muons)", 256, -3.2, 3.2, "STAMuons");
   }
-
 }
-
 
 //--------------------------------------------------------------
 // Compute a serial number for the chamber.
 // This is useful when filling histograms and working with arrays.
 //--------------------------------------------------------------
-int CSCValidation::chamberSerial( CSCDetId id ) {
+int CSCValidation::chamberSerial(CSCDetId id) {
   int st = id.station();
   int ri = id.ring();
   int ch = id.chamber();
   int ec = id.endcap();
   int kSerial = ch;
-  if (st == 1 && ri == 1) kSerial = ch;
-  if (st == 1 && ri == 2) kSerial = ch + 36;
-  if (st == 1 && ri == 3) kSerial = ch + 72;
-  if (st == 1 && ri == 4) kSerial = ch;
-  if (st == 2 && ri == 1) kSerial = ch + 108;
-  if (st == 2 && ri == 2) kSerial = ch + 126;
-  if (st == 3 && ri == 1) kSerial = ch + 162;
-  if (st == 3 && ri == 2) kSerial = ch + 180;
-  if (st == 4 && ri == 1) kSerial = ch + 216;
-  if (st == 4 && ri == 2) kSerial = ch + 234;  // one day...
-  if (ec == 2) kSerial = kSerial + 300;
+  if (st == 1 && ri == 1)
+    kSerial = ch;
+  if (st == 1 && ri == 2)
+    kSerial = ch + 36;
+  if (st == 1 && ri == 3)
+    kSerial = ch + 72;
+  if (st == 1 && ri == 4)
+    kSerial = ch;
+  if (st == 2 && ri == 1)
+    kSerial = ch + 108;
+  if (st == 2 && ri == 2)
+    kSerial = ch + 126;
+  if (st == 3 && ri == 1)
+    kSerial = ch + 162;
+  if (st == 3 && ri == 2)
+    kSerial = ch + 180;
+  if (st == 4 && ri == 1)
+    kSerial = ch + 216;
+  if (st == 4 && ri == 2)
+    kSerial = ch + 234;  // one day...
+  if (ec == 2)
+    kSerial = kSerial + 300;
   return kSerial;
 }
 
@@ -1252,19 +1396,27 @@ int CSCValidation::chamberSerial( CSCDetId id ) {
 // Compute a serial number for the ring.
 // This is useful when filling histograms and working with arrays.
 //--------------------------------------------------------------
-int CSCValidation::ringSerial( CSCDetId id ) {
+int CSCValidation::ringSerial(CSCDetId id) {
   int st = id.station();
   int ri = id.ring();
   int ec = id.endcap();
-  int kSerial = 0 ;
-  if (st == 1 && ri == 1) kSerial = ri;
-  if (st == 1 && ri == 2) kSerial = ri ;
-  if (st == 1 && ri == 3) kSerial = ri ;
-  if (st == 1 && ri == 4) kSerial = 1;
-  if (st == 2 ) kSerial = ri + 3;
-  if (st == 3 ) kSerial = ri + 5;
-  if (st == 4 ) kSerial = ri + 7;
-  if (ec == 2) kSerial = kSerial * (-1);
+  int kSerial = 0;
+  if (st == 1 && ri == 1)
+    kSerial = ri;
+  if (st == 1 && ri == 2)
+    kSerial = ri;
+  if (st == 1 && ri == 3)
+    kSerial = ri;
+  if (st == 1 && ri == 4)
+    kSerial = 1;
+  if (st == 2)
+    kSerial = ri + 3;
+  if (st == 3)
+    kSerial = ri + 5;
+  if (st == 4)
+    kSerial = ri + 7;
+  if (ec == 2)
+    kSerial = kSerial * (-1);
   return kSerial;
 }
 
@@ -1273,29 +1425,28 @@ int CSCValidation::ringSerial( CSCDetId id ) {
 // and removes hit in layer 3.  It then returns the expected position value in layer 3
 // based on the fit.
 //-------------------------------------------------------------------------------------
-float CSCValidation::fitX(const CLHEP::HepMatrix& points, const CLHEP::HepMatrix& errors){
-
-  float S   = 0;
-  float Sx  = 0;
-  float Sy  = 0;
+float CSCValidation::fitX(const CLHEP::HepMatrix& points, const CLHEP::HepMatrix& errors) {
+  float S = 0;
+  float Sx = 0;
+  float Sy = 0;
   float Sxx = 0;
   float Sxy = 0;
   float sigma2 = 0;
 
-  for (int i=1;i<7;i++){
-    if (i != 3){
-      sigma2 = errors(i,1)*errors(i,1);
-      S = S + (1/sigma2);
-      Sy = Sy + (points(i,1)/sigma2);
-      Sx = Sx + ((i)/sigma2);
-      Sxx = Sxx + (i*i)/sigma2;
-      Sxy = Sxy + (((i)*points(i,1))/sigma2);
+  for (int i = 1; i < 7; i++) {
+    if (i != 3) {
+      sigma2 = errors(i, 1) * errors(i, 1);
+      S = S + (1 / sigma2);
+      Sy = Sy + (points(i, 1) / sigma2);
+      Sx = Sx + ((i) / sigma2);
+      Sxx = Sxx + (i * i) / sigma2;
+      Sxy = Sxy + (((i)*points(i, 1)) / sigma2);
     }
   }
 
-  float delta = S*Sxx - Sx*Sx;
-  float intercept = (Sxx*Sy - Sx*Sxy)/delta;
-  float slope = (S*Sxy - Sx*Sy)/delta;
+  float delta = S * Sxx - Sx * Sx;
+  float intercept = (Sxx * Sy - Sx * Sxy) / delta;
+  float slope = (S * Sxy - Sx * Sy) / delta;
 
   //float chi = 0;
   //float chi2 = 0;
@@ -1306,74 +1457,75 @@ float CSCValidation::fitX(const CLHEP::HepMatrix& points, const CLHEP::HepMatrix
   //  chi2 = chi2 + chi*chi;
   //}
 
-  return (intercept + slope*3);
-
+  return (intercept + slope * 3);
 }
-
 
 //----------------------------------------------------------------------------
 // Calculate basic efficiencies for recHits and Segments
 // Author: S. Stoynev
 //----------------------------------------------------------------------------
 
-void CSCValidation::doEfficiencies(edm::Handle<CSCWireDigiCollection> wires, edm::Handle<CSCStripDigiCollection> strips,
-                                   edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments,
-                                   edm::ESHandle<CSCGeometry> cscGeom){
-
+void CSCValidation::doEfficiencies(edm::Handle<CSCWireDigiCollection> wires,
+                                   edm::Handle<CSCStripDigiCollection> strips,
+                                   edm::Handle<CSCRecHit2DCollection> recHits,
+                                   edm::Handle<CSCSegmentCollection> cscSegments,
+                                   edm::ESHandle<CSCGeometry> cscGeom) {
   bool allWires[2][4][4][36][6];
   bool allStrips[2][4][4][36][6];
   bool AllRecHits[2][4][4][36][6];
   bool AllSegments[2][4][4][36];
-  
+
   //bool MultiSegments[2][4][4][36];
-  for(int iE = 0;iE<2;iE++){
-    for(int iS = 0;iS<4;iS++){
-      for(int iR = 0; iR<4;iR++){
-        for(int iC =0;iC<36;iC++){
+  for (int iE = 0; iE < 2; iE++) {
+    for (int iS = 0; iS < 4; iS++) {
+      for (int iR = 0; iR < 4; iR++) {
+        for (int iC = 0; iC < 36; iC++) {
           AllSegments[iE][iS][iR][iC] = false;
           //MultiSegments[iE][iS][iR][iC] = false;
-          for(int iL=0;iL<6;iL++){
-	    allWires[iE][iS][iR][iC][iL] = false;
-	    allStrips[iE][iS][iR][iC][iL] = false;
+          for (int iL = 0; iL < 6; iL++) {
+            allWires[iE][iS][iR][iC][iL] = false;
+            allStrips[iE][iS][iR][iC][iL] = false;
             AllRecHits[iE][iS][iR][iC][iL] = false;
           }
         }
       }
     }
   }
-  
-  if (useDigis){
+
+  if (useDigis) {
     // Wires
-    for (CSCWireDigiCollection::DigiRangeIterator dWDiter=wires->begin(); dWDiter!=wires->end(); dWDiter++) {
+    for (CSCWireDigiCollection::DigiRangeIterator dWDiter = wires->begin(); dWDiter != wires->end(); dWDiter++) {
       CSCDetId idrec = (CSCDetId)(*dWDiter).first;
       std::vector<CSCWireDigi>::const_iterator wireIter = (*dWDiter).second.first;
       std::vector<CSCWireDigi>::const_iterator lWire = (*dWDiter).second.second;
-      for( ; wireIter != lWire; ++wireIter) {
-        allWires[idrec.endcap() -1][idrec.station() -1][idrec.ring() -1][idrec.chamber() -1][idrec.layer() -1] = true;
+      for (; wireIter != lWire; ++wireIter) {
+        allWires[idrec.endcap() - 1][idrec.station() - 1][idrec.ring() - 1][idrec.chamber() - 1][idrec.layer() - 1] =
+            true;
         break;
       }
     }
 
     //---- STRIPS
-    for (CSCStripDigiCollection::DigiRangeIterator dSDiter=strips->begin(); dSDiter!=strips->end(); dSDiter++) {
+    for (CSCStripDigiCollection::DigiRangeIterator dSDiter = strips->begin(); dSDiter != strips->end(); dSDiter++) {
       CSCDetId idrec = (CSCDetId)(*dSDiter).first;
       std::vector<CSCStripDigi>::const_iterator stripIter = (*dSDiter).second.first;
       std::vector<CSCStripDigi>::const_iterator lStrip = (*dSDiter).second.second;
-      for( ; stripIter != lStrip; ++stripIter) {
+      for (; stripIter != lStrip; ++stripIter) {
         std::vector<int> myADCVals = stripIter->getADCCounts();
         bool thisStripFired = false;
-        float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-        float threshold = 13.3 ;
+        float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+        float threshold = 13.3;
         float diff = 0.;
         for (unsigned int iCount = 0; iCount < myADCVals.size(); iCount++) {
-          diff = (float)myADCVals[iCount]-thisPedestal;
+          diff = (float)myADCVals[iCount] - thisPedestal;
           if (diff > threshold) {
             thisStripFired = true;
-   	    break;
+            break;
           }
         }
-        if(thisStripFired){
-  	  allStrips[idrec.endcap() -1][idrec.station() -1][idrec.ring() -1][idrec.chamber() -1][idrec.layer() -1] = true;
+        if (thisStripFired) {
+          allStrips[idrec.endcap() - 1][idrec.station() - 1][idrec.ring() - 1][idrec.chamber() - 1][idrec.layer() - 1] =
+              true;
           break;
         }
       }
@@ -1383,38 +1535,38 @@ void CSCValidation::doEfficiencies(edm::Handle<CSCWireDigiCollection> wires, edm
   // Rechits
   for (CSCRecHit2DCollection::const_iterator recEffIt = recHits->begin(); recEffIt != recHits->end(); recEffIt++) {
     //CSCDetId idrec = (CSCDetId)(*recIt).cscDetId();
-    CSCDetId  idrec = (CSCDetId)(*recEffIt).cscDetId();
-    AllRecHits[idrec.endcap() -1][idrec.station() -1][idrec.ring() -1][idrec.chamber() -1][idrec.layer() -1] = true;
-
+    CSCDetId idrec = (CSCDetId)(*recEffIt).cscDetId();
+    AllRecHits[idrec.endcap() - 1][idrec.station() - 1][idrec.ring() - 1][idrec.chamber() - 1][idrec.layer() - 1] =
+        true;
   }
 
-  std::vector <unsigned int> seg_ME2(2,0) ;
-  std::vector <unsigned int> seg_ME3(2,0) ;
-  std::vector < std::pair <CSCDetId, CSCSegment> > theSegments(4);
+  std::vector<unsigned int> seg_ME2(2, 0);
+  std::vector<unsigned int> seg_ME3(2, 0);
+  std::vector<std::pair<CSCDetId, CSCSegment> > theSegments(4);
   // Segments
-  for(CSCSegmentCollection::const_iterator segEffIt=cscSegments->begin(); segEffIt != cscSegments->end(); segEffIt++) {
-    CSCDetId idseg  = (CSCDetId)(*segEffIt).cscDetId();
+  for (CSCSegmentCollection::const_iterator segEffIt = cscSegments->begin(); segEffIt != cscSegments->end();
+       segEffIt++) {
+    CSCDetId idseg = (CSCDetId)(*segEffIt).cscDetId();
     //if(AllSegments[idrec.endcap() -1][idrec.station() -1][idrec.ring() -1][idrec.chamber()]){
     //MultiSegments[idrec.endcap() -1][idrec.station() -1][idrec.ring() -1][idrec.chamber()] = true;
     //}
-    AllSegments[idseg.endcap() -1][idseg.station() -1][idseg.ring() -1][idseg.chamber() -1] = true;
+    AllSegments[idseg.endcap() - 1][idseg.station() - 1][idseg.ring() - 1][idseg.chamber() - 1] = true;
     // "Intrinsic" efficiency measurement relies on "good" segment extrapolation - we need the pre-selection below
     // station 2 "good" segment will be used for testing efficiencies in ME1 and ME3
     // station 3 "good" segment will be used for testing efficiencies in ME2 and ME4
-    if(2==idseg.station() || 3==idseg.station()){
-      unsigned int seg_tmp ; 
-      if(2==idseg.station()){
-	++seg_ME2[idseg.endcap() -1];
-	seg_tmp = seg_ME2[idseg.endcap() -1];
-      }
-      else{
-	++seg_ME3[idseg.endcap() -1];
-	seg_tmp = seg_ME3[idseg.endcap() -1];
+    if (2 == idseg.station() || 3 == idseg.station()) {
+      unsigned int seg_tmp;
+      if (2 == idseg.station()) {
+        ++seg_ME2[idseg.endcap() - 1];
+        seg_tmp = seg_ME2[idseg.endcap() - 1];
+      } else {
+        ++seg_ME3[idseg.endcap() - 1];
+        seg_tmp = seg_ME3[idseg.endcap() - 1];
       }
       // is the segment good
-      if(1== seg_tmp&& 6==(*segEffIt).nRecHits() && (*segEffIt).chi2()/(*segEffIt).degreesOfFreedom()<3.){
-	std::pair <CSCDetId, CSCSegment> specSeg = make_pair( (CSCDetId)(*segEffIt).cscDetId(),*segEffIt);
-	theSegments[2*(idseg.endcap()-1)+(idseg.station() -2)] = specSeg;
+      if (1 == seg_tmp && 6 == (*segEffIt).nRecHits() && (*segEffIt).chi2() / (*segEffIt).degreesOfFreedom() < 3.) {
+        std::pair<CSCDetId, CSCSegment> specSeg = make_pair((CSCDetId)(*segEffIt).cscDetId(), *segEffIt);
+        theSegments[2 * (idseg.endcap() - 1) + (idseg.station() - 2)] = specSeg;
       }
     }
     /*
@@ -1433,56 +1585,63 @@ void CSCValidation::doEfficiencies(edm::Handle<CSCWireDigiCollection> wires, edm
        }
     }
     */
-    
   }
   // Simple efficiency calculations
-  for(int iE = 0;iE<2;iE++){
-    for(int iS = 0;iS<4;iS++){
-      for(int iR = 0; iR<4;iR++){
-        for(int iC =0;iC<36;iC++){
+  for (int iE = 0; iE < 2; iE++) {
+    for (int iS = 0; iS < 4; iS++) {
+      for (int iR = 0; iR < 4; iR++) {
+        for (int iC = 0; iC < 36; iC++) {
           int NumberOfLayers = 0;
-          for(int iL=0;iL<6;iL++){
-            if(AllRecHits[iE][iS][iR][iC][iL]){
+          for (int iL = 0; iL < 6; iL++) {
+            if (AllRecHits[iE][iS][iR][iC][iL]) {
               NumberOfLayers++;
             }
           }
           int bin = 0;
-          if (iS==0) bin = iR+1+(iE*10);
-          else bin = (iS+1)*2 + (iR+1) + (iE*10);
-          if(NumberOfLayers>1){
+          if (iS == 0)
+            bin = iR + 1 + (iE * 10);
+          else
+            bin = (iS + 1) * 2 + (iR + 1) + (iE * 10);
+          if (NumberOfLayers > 1) {
             //if(!(MultiSegments[iE][iS][iR][iC])){
-            if(AllSegments[iE][iS][iR][iC]){
+            if (AllSegments[iE][iS][iR][iC]) {
               //---- Efficient segment evenents
               hSSTE->AddBinContent(bin);
             }
             //---- All segment events (normalization)
-            hSSTE->AddBinContent(20+bin);
+            hSSTE->AddBinContent(20 + bin);
             //}
           }
-          if(AllSegments[iE][iS][iR][iC]){
-            if(NumberOfLayers==6){
+          if (AllSegments[iE][iS][iR][iC]) {
+            if (NumberOfLayers == 6) {
               //---- Efficient rechit events
-              hRHSTE->AddBinContent(bin);;
+              hRHSTE->AddBinContent(bin);
+              ;
             }
             //---- All rechit events (normalization)
-            hRHSTE->AddBinContent(20+bin);;
+            hRHSTE->AddBinContent(20 + bin);
+            ;
           }
         }
       }
     }
   }
 
-// pick a segment only if there are no others in the station
-  std::vector < std::pair <CSCDetId, CSCSegment> * > theSeg;
-  if(1==seg_ME2[0]) theSeg.push_back(&theSegments[0]);
-  if(1==seg_ME3[0]) theSeg.push_back(&theSegments[1]);
-  if(1==seg_ME2[1]) theSeg.push_back(&theSegments[2]);
-  if(1==seg_ME3[1]) theSeg.push_back(&theSegments[3]);
+  // pick a segment only if there are no others in the station
+  std::vector<std::pair<CSCDetId, CSCSegment>*> theSeg;
+  if (1 == seg_ME2[0])
+    theSeg.push_back(&theSegments[0]);
+  if (1 == seg_ME3[0])
+    theSeg.push_back(&theSegments[1]);
+  if (1 == seg_ME2[1])
+    theSeg.push_back(&theSegments[2]);
+  if (1 == seg_ME3[1])
+    theSeg.push_back(&theSegments[3]);
 
   // Needed for plots
-  // at the end the chamber types will be numbered as 1 to 18 
-  // (ME-4/1, -ME3/2, -ME3/1, ..., +ME3/1, +ME3/2, ME+4/1 ) 
-  std::map <std::string, float> chamberTypes;
+  // at the end the chamber types will be numbered as 1 to 18
+  // (ME-4/1, -ME3/2, -ME3/1, ..., +ME3/1, +ME3/2, ME+4/1 )
+  std::map<std::string, float> chamberTypes;
   chamberTypes["ME1/a"] = 0.5;
   chamberTypes["ME1/b"] = 1.5;
   chamberTypes["ME1/2"] = 2.5;
@@ -1493,259 +1652,251 @@ void CSCValidation::doEfficiencies(edm::Handle<CSCWireDigiCollection> wires, edm
   chamberTypes["ME3/2"] = 7.5;
   chamberTypes["ME4/1"] = 8.5;
 
-  if(!theSeg.empty()){
-    std::map <int , GlobalPoint> extrapolatedPoint;
-    std::map <int , GlobalPoint>::iterator it;
+  if (!theSeg.empty()) {
+    std::map<int, GlobalPoint> extrapolatedPoint;
+    std::map<int, GlobalPoint>::iterator it;
     const CSCGeometry::ChamberContainer& ChamberContainer = cscGeom->chambers();
     // Pick which chamber with which segment to test
-    for(size_t nCh=0;nCh<ChamberContainer.size();nCh++){
-      const CSCChamber *cscchamber = ChamberContainer[nCh];
-      std::pair <CSCDetId, CSCSegment> * thisSegment = nullptr;
-      for(size_t iSeg =0;iSeg<theSeg.size();++iSeg ){
-        if(cscchamber->id().endcap() == theSeg[iSeg]->first.endcap()){ 
-          if(1==cscchamber->id().station() || 3==cscchamber->id().station() ){
-	    if(2==theSeg[iSeg]->first.station()){
-	      thisSegment = theSeg[iSeg];
-	    }
-	  }
-	  else if (2==cscchamber->id().station() || 4==cscchamber->id().station()){
-	    if(3==theSeg[iSeg]->first.station()){
-	      thisSegment = theSeg[iSeg];
-	    }
-	  }
-	}
+    for (size_t nCh = 0; nCh < ChamberContainer.size(); nCh++) {
+      const CSCChamber* cscchamber = ChamberContainer[nCh];
+      std::pair<CSCDetId, CSCSegment>* thisSegment = nullptr;
+      for (size_t iSeg = 0; iSeg < theSeg.size(); ++iSeg) {
+        if (cscchamber->id().endcap() == theSeg[iSeg]->first.endcap()) {
+          if (1 == cscchamber->id().station() || 3 == cscchamber->id().station()) {
+            if (2 == theSeg[iSeg]->first.station()) {
+              thisSegment = theSeg[iSeg];
+            }
+          } else if (2 == cscchamber->id().station() || 4 == cscchamber->id().station()) {
+            if (3 == theSeg[iSeg]->first.station()) {
+              thisSegment = theSeg[iSeg];
+            }
+          }
+        }
       }
       // this chamber is to be tested with thisSegment
-      if(thisSegment){
-	CSCSegment * seg = &(thisSegment->second);
-	const CSCChamber *segChamber = cscGeom->chamber(thisSegment->first);
-	LocalPoint localCenter(0.,0.,0);
-	GlobalPoint cscchamberCenter =  cscchamber->toGlobal(localCenter);
-	// try to save some time (extrapolate a segment to a certain position only once)
-	it = extrapolatedPoint.find(int(cscchamberCenter.z()));
-	if(it==extrapolatedPoint.end()){
-	  GlobalPoint segPos = segChamber->toGlobal(seg->localPosition());
-	  GlobalVector segDir = segChamber->toGlobal(seg->localDirection());
-	  double paramaterLine = lineParametrization(segPos.z(),cscchamberCenter.z() , segDir.z());
-	  double xExtrapolated = extrapolate1D(segPos.x(),segDir.x(), paramaterLine);
-	  double yExtrapolated = extrapolate1D(segPos.y(),segDir.y(), paramaterLine);
-	  GlobalPoint globP (xExtrapolated, yExtrapolated, cscchamberCenter.z());
-	  extrapolatedPoint[int(cscchamberCenter.z())] = globP;
-	}
-	// Where does the extrapolated point lie in the (tested) chamber local frame? Here: 
-	LocalPoint extrapolatedPointLocal = cscchamber->toLocal(extrapolatedPoint[int(cscchamberCenter.z())]);
-	const CSCLayer *layer_p = cscchamber->layer(1);//layer 1
-	const CSCLayerGeometry *layerGeom = layer_p->geometry ();
-	const std::array<const float, 4> & layerBounds = layerGeom->parameters ();
-	float shiftFromEdge = 15.;//cm
-	float shiftFromDeadZone = 10.;
-	// is the extrapolated point within a sensitive region
-	bool pass = withinSensitiveRegion(extrapolatedPointLocal, layerBounds, 
-					  cscchamber->id().station(), cscchamber->id().ring(), 
-					  shiftFromEdge, shiftFromDeadZone);
-	if(pass){// the extrapolation point of the segment lies within sensitive region of that chamber
-	  // how many rechit layers are there in the chamber?
-	  // 0 - maybe the muon died or is deflected at large angle? do not use that case
-	  // 1 - could be noise...
-	  // 2 or more - this is promissing; this is our definition of a reliable signal; use it below
-	  // is other definition better? 
-	  int nRHLayers = 0;
-	  for(int iL =0;iL<6;++iL){
-	    if(AllRecHits[cscchamber->id().endcap()-1]
-	       [cscchamber->id().station()-1]
-	       [cscchamber->id().ring()-1][cscchamber->id().chamber()-1][iL]){
-	      ++nRHLayers;
-	    }
-	  }
-	  //std::cout<<" nRHLayers = "<<nRHLayers<<std::endl;
-	  float verticalScale = chamberTypes[cscchamber->specs()->chamberTypeName()];
-	  if(cscchamberCenter.z()<0){
-	    verticalScale = - verticalScale;
-	  } 
-	  verticalScale +=9.5;
-	  hSensitiveAreaEvt->Fill(float(cscchamber->id().chamber()),verticalScale);
-	  if(nRHLayers>1){// this chamber contains a reliable signal
-	    //chamberTypes[cscchamber->specs()->chamberTypeName()];
-	    // "intrinsic" efficiencies
-	    //std::cout<<" verticalScale = "<<verticalScale<<" chType = "<<cscchamber->specs()->chamberTypeName()<<std::endl;
-	    // this is the denominator forr all efficiencies
-	    hEffDenominator->Fill(float(cscchamber->id().chamber()),verticalScale);
-	    // Segment efficiency
-	    if(AllSegments[cscchamber->id().endcap()-1]
-	       [cscchamber->id().station()-1]
-	       [cscchamber->id().ring()-1][cscchamber->id().chamber()-1]){
-	      hSSTE2->Fill(float(cscchamber->id().chamber()),float(verticalScale));
-	    }
-	  
-	    for(int iL =0;iL<6;++iL){
-	      float weight = 1./6.;
-	      // one shold account for the weight in the efficiency...
-	      // Rechit efficiency
-	      if(AllRecHits[cscchamber->id().endcap()-1]
-		 [cscchamber->id().station()-1]
-		 [cscchamber->id().ring()-1][cscchamber->id().chamber()-1][iL]){
-		hRHSTE2->Fill(float(cscchamber->id().chamber()),float(verticalScale),weight);
-	      }
-              if (useDigis){
-	        // Wire efficiency
-	        if(allWires[cscchamber->id().endcap()-1]
-	  	  [cscchamber->id().station()-1]
-		  [cscchamber->id().ring()-1][cscchamber->id().chamber()-1][iL]){
-		  // one shold account for the weight in the efficiency...
-	 	  hWireSTE2->Fill(float(cscchamber->id().chamber()),float(verticalScale),weight);
-	        }
-	        // Strip efficiency
-	        if(allStrips[cscchamber->id().endcap()-1]
-		  [cscchamber->id().station()-1]
-		  [cscchamber->id().ring()-1][cscchamber->id().chamber()-1][iL]){
-		  // one shold account for the weight in the efficiency...
-		  hStripSTE2->Fill(float(cscchamber->id().chamber()),float(verticalScale),weight);
-	        }
+      if (thisSegment) {
+        CSCSegment* seg = &(thisSegment->second);
+        const CSCChamber* segChamber = cscGeom->chamber(thisSegment->first);
+        LocalPoint localCenter(0., 0., 0);
+        GlobalPoint cscchamberCenter = cscchamber->toGlobal(localCenter);
+        // try to save some time (extrapolate a segment to a certain position only once)
+        it = extrapolatedPoint.find(int(cscchamberCenter.z()));
+        if (it == extrapolatedPoint.end()) {
+          GlobalPoint segPos = segChamber->toGlobal(seg->localPosition());
+          GlobalVector segDir = segChamber->toGlobal(seg->localDirection());
+          double paramaterLine = lineParametrization(segPos.z(), cscchamberCenter.z(), segDir.z());
+          double xExtrapolated = extrapolate1D(segPos.x(), segDir.x(), paramaterLine);
+          double yExtrapolated = extrapolate1D(segPos.y(), segDir.y(), paramaterLine);
+          GlobalPoint globP(xExtrapolated, yExtrapolated, cscchamberCenter.z());
+          extrapolatedPoint[int(cscchamberCenter.z())] = globP;
+        }
+        // Where does the extrapolated point lie in the (tested) chamber local frame? Here:
+        LocalPoint extrapolatedPointLocal = cscchamber->toLocal(extrapolatedPoint[int(cscchamberCenter.z())]);
+        const CSCLayer* layer_p = cscchamber->layer(1);  //layer 1
+        const CSCLayerGeometry* layerGeom = layer_p->geometry();
+        const std::array<const float, 4>& layerBounds = layerGeom->parameters();
+        float shiftFromEdge = 15.;  //cm
+        float shiftFromDeadZone = 10.;
+        // is the extrapolated point within a sensitive region
+        bool pass = withinSensitiveRegion(extrapolatedPointLocal,
+                                          layerBounds,
+                                          cscchamber->id().station(),
+                                          cscchamber->id().ring(),
+                                          shiftFromEdge,
+                                          shiftFromDeadZone);
+        if (pass) {  // the extrapolation point of the segment lies within sensitive region of that chamber
+          // how many rechit layers are there in the chamber?
+          // 0 - maybe the muon died or is deflected at large angle? do not use that case
+          // 1 - could be noise...
+          // 2 or more - this is promissing; this is our definition of a reliable signal; use it below
+          // is other definition better?
+          int nRHLayers = 0;
+          for (int iL = 0; iL < 6; ++iL) {
+            if (AllRecHits[cscchamber->id().endcap() - 1][cscchamber->id().station() - 1][cscchamber->id().ring() - 1]
+                          [cscchamber->id().chamber() - 1][iL]) {
+              ++nRHLayers;
+            }
+          }
+          //std::cout<<" nRHLayers = "<<nRHLayers<<std::endl;
+          float verticalScale = chamberTypes[cscchamber->specs()->chamberTypeName()];
+          if (cscchamberCenter.z() < 0) {
+            verticalScale = -verticalScale;
+          }
+          verticalScale += 9.5;
+          hSensitiveAreaEvt->Fill(float(cscchamber->id().chamber()), verticalScale);
+          if (nRHLayers > 1) {  // this chamber contains a reliable signal
+            //chamberTypes[cscchamber->specs()->chamberTypeName()];
+            // "intrinsic" efficiencies
+            //std::cout<<" verticalScale = "<<verticalScale<<" chType = "<<cscchamber->specs()->chamberTypeName()<<std::endl;
+            // this is the denominator forr all efficiencies
+            hEffDenominator->Fill(float(cscchamber->id().chamber()), verticalScale);
+            // Segment efficiency
+            if (AllSegments[cscchamber->id().endcap() - 1][cscchamber->id().station() - 1][cscchamber->id().ring() - 1]
+                           [cscchamber->id().chamber() - 1]) {
+              hSSTE2->Fill(float(cscchamber->id().chamber()), float(verticalScale));
+            }
+
+            for (int iL = 0; iL < 6; ++iL) {
+              float weight = 1. / 6.;
+              // one shold account for the weight in the efficiency...
+              // Rechit efficiency
+              if (AllRecHits[cscchamber->id().endcap() - 1][cscchamber->id().station() - 1][cscchamber->id().ring() - 1]
+                            [cscchamber->id().chamber() - 1][iL]) {
+                hRHSTE2->Fill(float(cscchamber->id().chamber()), float(verticalScale), weight);
               }
-	    }
-	  }
-	}
+              if (useDigis) {
+                // Wire efficiency
+                if (allWires[cscchamber->id().endcap() - 1][cscchamber->id().station() - 1][cscchamber->id().ring() - 1]
+                            [cscchamber->id().chamber() - 1][iL]) {
+                  // one shold account for the weight in the efficiency...
+                  hWireSTE2->Fill(float(cscchamber->id().chamber()), float(verticalScale), weight);
+                }
+                // Strip efficiency
+                if (allStrips[cscchamber->id().endcap() - 1][cscchamber->id().station() - 1]
+                             [cscchamber->id().ring() - 1][cscchamber->id().chamber() - 1][iL]) {
+                  // one shold account for the weight in the efficiency...
+                  hStripSTE2->Fill(float(cscchamber->id().chamber()), float(verticalScale), weight);
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
   //
-  
-  
 }
 
-void CSCValidation::getEfficiency(float bin, float Norm, std::vector<float> &eff){
+void CSCValidation::getEfficiency(float bin, float Norm, std::vector<float>& eff) {
   //---- Efficiency with binomial error
   float Efficiency = 0.;
   float EffError = 0.;
-  if(fabs(Norm)>0.000000001){
-    Efficiency = bin/Norm;
-    if(bin<Norm){
-      EffError = sqrt( (1.-Efficiency)*Efficiency/Norm );
+  if (fabs(Norm) > 0.000000001) {
+    Efficiency = bin / Norm;
+    if (bin < Norm) {
+      EffError = sqrt((1. - Efficiency) * Efficiency / Norm);
     }
   }
   eff[0] = Efficiency;
   eff[1] = EffError;
 }
 
-void CSCValidation::histoEfficiency(TH1F *readHisto, TH1F *writeHisto){
+void CSCValidation::histoEfficiency(TH1F* readHisto, TH1F* writeHisto) {
   std::vector<float> eff(2);
-  int Nbins =  readHisto->GetSize()-2;//without underflows and overflows
+  int Nbins = readHisto->GetSize() - 2;  //without underflows and overflows
   std::vector<float> bins(Nbins);
   std::vector<float> Efficiency(Nbins);
   std::vector<float> EffError(Nbins);
   float Num = 1;
   float Den = 1;
-  for (int i=0;i<20;i++){
-    Num = readHisto->GetBinContent(i+1);
-    Den = readHisto->GetBinContent(i+21);
+  for (int i = 0; i < 20; i++) {
+    Num = readHisto->GetBinContent(i + 1);
+    Den = readHisto->GetBinContent(i + 21);
     getEfficiency(Num, Den, eff);
     Efficiency[i] = eff[0];
     EffError[i] = eff[1];
-    writeHisto->SetBinContent(i+1, Efficiency[i]);
-    writeHisto->SetBinError(i+1, EffError[i]);
+    writeHisto->SetBinContent(i + 1, Efficiency[i]);
+    writeHisto->SetBinError(i + 1, EffError[i]);
   }
 }
 
-bool CSCValidation::withinSensitiveRegion(LocalPoint localPos, const std::array<const float, 4> & layerBounds, int station, int ring, float shiftFromEdge, float shiftFromDeadZone){
-//---- check if it is in a good local region (sensitive area - geometrical and HV boundaries excluded) 
+bool CSCValidation::withinSensitiveRegion(LocalPoint localPos,
+                                          const std::array<const float, 4>& layerBounds,
+                                          int station,
+                                          int ring,
+                                          float shiftFromEdge,
+                                          float shiftFromDeadZone) {
+  //---- check if it is in a good local region (sensitive area - geometrical and HV boundaries excluded)
   bool pass = false;
 
   float y_center = 0.;
   double yUp = layerBounds[3] + y_center;
-  double yDown = - layerBounds[3] + y_center;
-  double xBound1Shifted = layerBounds[0] - shiftFromEdge;//
-  double xBound2Shifted = layerBounds[1] - shiftFromEdge;//
-  double lineSlope = (yUp - yDown)/(xBound2Shifted-xBound1Shifted);
-  double lineConst = yUp - lineSlope*xBound2Shifted;
-  double yBorder =  lineSlope*abs(localPos.x()) + lineConst;
-      
+  double yDown = -layerBounds[3] + y_center;
+  double xBound1Shifted = layerBounds[0] - shiftFromEdge;  //
+  double xBound2Shifted = layerBounds[1] - shiftFromEdge;  //
+  double lineSlope = (yUp - yDown) / (xBound2Shifted - xBound1Shifted);
+  double lineConst = yUp - lineSlope * xBound2Shifted;
+  double yBorder = lineSlope * abs(localPos.x()) + lineConst;
+
   //bool withinChamberOnly = false;// false = "good region"; true - boundaries only
-  std::vector <float> deadZoneCenter(6);
-  float cutZone = shiftFromDeadZone;//cm
+  std::vector<float> deadZoneCenter(6);
+  float cutZone = shiftFromDeadZone;  //cm
   //---- hardcoded... not good
-  if(station>1 && station<5){
-    if(2==ring){
-      deadZoneCenter[0]= -162.48 ;
+  if (station > 1 && station < 5) {
+    if (2 == ring) {
+      deadZoneCenter[0] = -162.48;
       deadZoneCenter[1] = -81.8744;
       deadZoneCenter[2] = -21.18165;
       deadZoneCenter[3] = 39.51105;
       deadZoneCenter[4] = 100.2939;
       deadZoneCenter[5] = 160.58;
-      
-      if(localPos.y() >yBorder &&
-	 ((localPos.y()> deadZoneCenter[0] + cutZone && localPos.y()< deadZoneCenter[1] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[1] + cutZone && localPos.y()< deadZoneCenter[2] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[2] + cutZone && localPos.y()< deadZoneCenter[3] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[3] + cutZone && localPos.y()< deadZoneCenter[4] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[4] + cutZone && localPos.y()< deadZoneCenter[5] - cutZone))){
-	pass = true;
+
+      if (localPos.y() > yBorder &&
+          ((localPos.y() > deadZoneCenter[0] + cutZone && localPos.y() < deadZoneCenter[1] - cutZone) ||
+           (localPos.y() > deadZoneCenter[1] + cutZone && localPos.y() < deadZoneCenter[2] - cutZone) ||
+           (localPos.y() > deadZoneCenter[2] + cutZone && localPos.y() < deadZoneCenter[3] - cutZone) ||
+           (localPos.y() > deadZoneCenter[3] + cutZone && localPos.y() < deadZoneCenter[4] - cutZone) ||
+           (localPos.y() > deadZoneCenter[4] + cutZone && localPos.y() < deadZoneCenter[5] - cutZone))) {
+        pass = true;
+      }
+    } else if (1 == ring) {
+      if (2 == station) {
+        deadZoneCenter[0] = -95.80;
+        deadZoneCenter[1] = -27.47;
+        deadZoneCenter[2] = 33.67;
+        deadZoneCenter[3] = 90.85;
+      } else if (3 == station) {
+        deadZoneCenter[0] = -89.305;
+        deadZoneCenter[1] = -39.705;
+        deadZoneCenter[2] = 20.195;
+        deadZoneCenter[3] = 77.395;
+      } else if (4 == station) {
+        deadZoneCenter[0] = -75.645;
+        deadZoneCenter[1] = -26.055;
+        deadZoneCenter[2] = 23.855;
+        deadZoneCenter[3] = 70.575;
+      }
+      if (localPos.y() > yBorder &&
+          ((localPos.y() > deadZoneCenter[0] + cutZone && localPos.y() < deadZoneCenter[1] - cutZone) ||
+           (localPos.y() > deadZoneCenter[1] + cutZone && localPos.y() < deadZoneCenter[2] - cutZone) ||
+           (localPos.y() > deadZoneCenter[2] + cutZone && localPos.y() < deadZoneCenter[3] - cutZone))) {
+        pass = true;
       }
     }
-    else if(1==ring){
-      if(2==station){
-	deadZoneCenter[0]= -95.80 ;
-	deadZoneCenter[1] = -27.47;
-	deadZoneCenter[2] = 33.67;
-	deadZoneCenter[3] = 90.85;
-        }
-      else if(3==station){
-	deadZoneCenter[0]= -89.305 ;
-	deadZoneCenter[1] = -39.705;
-	deadZoneCenter[2] = 20.195;
-	deadZoneCenter[3] = 77.395;
-      }
-      else if(4==station){
-	deadZoneCenter[0]= -75.645;
-	deadZoneCenter[1] = -26.055;
-	deadZoneCenter[2] = 23.855;
-	deadZoneCenter[3] = 70.575;
-      }
-      if(localPos.y() >yBorder &&
-	 ((localPos.y()> deadZoneCenter[0] + cutZone && localPos.y()< deadZoneCenter[1] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[1] + cutZone && localPos.y()< deadZoneCenter[2] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[2] + cutZone && localPos.y()< deadZoneCenter[3] - cutZone))){
-	pass = true;
-      }
-    }
-  }
-  else if(1==station){
-    if(3==ring){
-      deadZoneCenter[0]= -83.155 ;
+  } else if (1 == station) {
+    if (3 == ring) {
+      deadZoneCenter[0] = -83.155;
       deadZoneCenter[1] = -22.7401;
       deadZoneCenter[2] = 27.86665;
       deadZoneCenter[3] = 81.005;
-      if(localPos.y() > yBorder &&
-	 ((localPos.y()> deadZoneCenter[0] + cutZone && localPos.y()< deadZoneCenter[1] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[1] + cutZone && localPos.y()< deadZoneCenter[2] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[2] + cutZone && localPos.y()< deadZoneCenter[3] - cutZone))){
-	pass = true;
+      if (localPos.y() > yBorder &&
+          ((localPos.y() > deadZoneCenter[0] + cutZone && localPos.y() < deadZoneCenter[1] - cutZone) ||
+           (localPos.y() > deadZoneCenter[1] + cutZone && localPos.y() < deadZoneCenter[2] - cutZone) ||
+           (localPos.y() > deadZoneCenter[2] + cutZone && localPos.y() < deadZoneCenter[3] - cutZone))) {
+        pass = true;
       }
-    }
-    else if(2==ring){
-      deadZoneCenter[0]= -86.285 ;
+    } else if (2 == ring) {
+      deadZoneCenter[0] = -86.285;
       deadZoneCenter[1] = -32.88305;
       deadZoneCenter[2] = 32.867423;
       deadZoneCenter[3] = 88.205;
-      if(localPos.y() > (yBorder) &&
-	 ((localPos.y()> deadZoneCenter[0] + cutZone && localPos.y()< deadZoneCenter[1] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[1] + cutZone && localPos.y()< deadZoneCenter[2] - cutZone) ||
-	  (localPos.y()> deadZoneCenter[2] + cutZone && localPos.y()< deadZoneCenter[3] - cutZone))){
-	pass = true;
+      if (localPos.y() > (yBorder) &&
+          ((localPos.y() > deadZoneCenter[0] + cutZone && localPos.y() < deadZoneCenter[1] - cutZone) ||
+           (localPos.y() > deadZoneCenter[1] + cutZone && localPos.y() < deadZoneCenter[2] - cutZone) ||
+           (localPos.y() > deadZoneCenter[2] + cutZone && localPos.y() < deadZoneCenter[3] - cutZone))) {
+        pass = true;
       }
-    }
-    else{
-      deadZoneCenter[0]= -81.0;
+    } else {
+      deadZoneCenter[0] = -81.0;
       deadZoneCenter[1] = 81.0;
-      if(localPos.y() > (yBorder) &&
-	 (localPos.y()> deadZoneCenter[0] + cutZone && localPos.y()< deadZoneCenter[1] - cutZone )){
-	pass = true;
+      if (localPos.y() > (yBorder) &&
+          (localPos.y() > deadZoneCenter[0] + cutZone && localPos.y() < deadZoneCenter[1] - cutZone)) {
+        pass = true;
       }
     }
   }
   return pass;
 }
-
-
 
 //---------------------------------------------------------------------------------------
 // Given a set of digis, the CSCDetId, and the central strip of your choosing, returns
@@ -1754,8 +1905,7 @@ bool CSCValidation::withinSensitiveRegion(LocalPoint localPos, const std::array<
 // Author: P. Jindal
 //---------------------------------------------------------------------------------------
 
-float CSCValidation::getSignal(const CSCStripDigiCollection& stripdigis, CSCDetId idCS, int centerStrip){
-
+float CSCValidation::getSignal(const CSCStripDigiCollection& stripdigis, CSCDetId idCS, int centerStrip) {
   float SigADC[5];
   float TotalADC = 0;
   SigADC[0] = 0;
@@ -1764,52 +1914,50 @@ float CSCValidation::getSignal(const CSCStripDigiCollection& stripdigis, CSCDetI
   SigADC[3] = 0;
   SigADC[4] = 0;
 
- 
-  // Loop over strip digis 
+  // Loop over strip digis
   CSCStripDigiCollection::DigiRangeIterator sIt;
-  
-  for (sIt = stripdigis.begin(); sIt != stripdigis.end(); sIt++){
-    CSCDetId id = (CSCDetId)(*sIt).first;
-    if (id == idCS){
 
+  for (sIt = stripdigis.begin(); sIt != stripdigis.end(); sIt++) {
+    CSCDetId id = (CSCDetId)(*sIt).first;
+    if (id == idCS) {
       // First, find the Signal-Pedestal for center strip
       std::vector<CSCStripDigi>::const_iterator digiItr = (*sIt).second.first;
       std::vector<CSCStripDigi>::const_iterator last = (*sIt).second.second;
-      for ( ; digiItr != last; ++digiItr ) {
+      for (; digiItr != last; ++digiItr) {
         int thisStrip = digiItr->getStrip();
-        if (thisStrip == (centerStrip)){
-	  std::vector<int> myADCVals = digiItr->getADCCounts();
-          float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-	  float thisSignal = (myADCVals[2]+myADCVals[3]+myADCVals[4]+myADCVals[5]+myADCVals[6]+myADCVals[7]);
-	  SigADC[0] = thisSignal - 6*thisPedestal;
-	}
-     // Now,find the Signal-Pedestal for neighbouring 4 strips
-        if (thisStrip == (centerStrip+1)){
-	  std::vector<int> myADCVals = digiItr->getADCCounts();
-          float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-	  float thisSignal = (myADCVals[2]+myADCVals[3]+myADCVals[4]+myADCVals[5]+myADCVals[6]+myADCVals[7]);
-	  SigADC[1] = thisSignal - 6*thisPedestal;
-	}
-        if (thisStrip == (centerStrip+2)){
-	  std::vector<int> myADCVals = digiItr->getADCCounts();
-          float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-	  float thisSignal = (myADCVals[2]+myADCVals[3]+myADCVals[4]+myADCVals[5]+myADCVals[6]+myADCVals[7]);
-	  SigADC[2] = thisSignal - 6*thisPedestal;
-	}
-        if (thisStrip == (centerStrip-1)){
-	  std::vector<int> myADCVals = digiItr->getADCCounts();
-          float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-	  float thisSignal = (myADCVals[2]+myADCVals[3]+myADCVals[4]+myADCVals[5]+myADCVals[6]+myADCVals[7]);
-	  SigADC[3] = thisSignal - 6*thisPedestal;
-	}
-        if (thisStrip == (centerStrip-2)){
-	  std::vector<int> myADCVals = digiItr->getADCCounts();
-          float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-	  float thisSignal = (myADCVals[2]+myADCVals[3]+myADCVals[4]+myADCVals[5]+myADCVals[6]+myADCVals[7]);
-	  SigADC[4] = thisSignal - 6*thisPedestal;
-	}
+        if (thisStrip == (centerStrip)) {
+          std::vector<int> myADCVals = digiItr->getADCCounts();
+          float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+          float thisSignal = (myADCVals[2] + myADCVals[3] + myADCVals[4] + myADCVals[5] + myADCVals[6] + myADCVals[7]);
+          SigADC[0] = thisSignal - 6 * thisPedestal;
+        }
+        // Now,find the Signal-Pedestal for neighbouring 4 strips
+        if (thisStrip == (centerStrip + 1)) {
+          std::vector<int> myADCVals = digiItr->getADCCounts();
+          float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+          float thisSignal = (myADCVals[2] + myADCVals[3] + myADCVals[4] + myADCVals[5] + myADCVals[6] + myADCVals[7]);
+          SigADC[1] = thisSignal - 6 * thisPedestal;
+        }
+        if (thisStrip == (centerStrip + 2)) {
+          std::vector<int> myADCVals = digiItr->getADCCounts();
+          float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+          float thisSignal = (myADCVals[2] + myADCVals[3] + myADCVals[4] + myADCVals[5] + myADCVals[6] + myADCVals[7]);
+          SigADC[2] = thisSignal - 6 * thisPedestal;
+        }
+        if (thisStrip == (centerStrip - 1)) {
+          std::vector<int> myADCVals = digiItr->getADCCounts();
+          float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+          float thisSignal = (myADCVals[2] + myADCVals[3] + myADCVals[4] + myADCVals[5] + myADCVals[6] + myADCVals[7]);
+          SigADC[3] = thisSignal - 6 * thisPedestal;
+        }
+        if (thisStrip == (centerStrip - 2)) {
+          std::vector<int> myADCVals = digiItr->getADCCounts();
+          float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+          float thisSignal = (myADCVals[2] + myADCVals[3] + myADCVals[4] + myADCVals[5] + myADCVals[6] + myADCVals[7]);
+          SigADC[4] = thisSignal - 6 * thisPedestal;
+        }
       }
-      TotalADC = 0.2*(SigADC[0]+SigADC[1]+SigADC[2]+SigADC[3]+SigADC[4]);
+      TotalADC = 0.2 * (SigADC[0] + SigADC[1] + SigADC[2] + SigADC[3] + SigADC[4]);
     }
   }
   return TotalADC;
@@ -1820,30 +1968,29 @@ float CSCValidation::getSignal(const CSCStripDigiCollection& stripdigis, CSCDetI
 // Author: P. Jindal
 //---------------------------------------------------------------------------------------
 
-void CSCValidation::doNoiseHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments,
-                                edm::ESHandle<CSCGeometry> cscGeom,  edm::Handle<CSCStripDigiCollection> strips){
-
+void CSCValidation::doNoiseHits(edm::Handle<CSCRecHit2DCollection> recHits,
+                                edm::Handle<CSCSegmentCollection> cscSegments,
+                                edm::ESHandle<CSCGeometry> cscGeom,
+                                edm::Handle<CSCStripDigiCollection> strips) {
   CSCRecHit2DCollection::const_iterator recIt;
   for (recIt = recHits->begin(); recIt != recHits->end(); recIt++) {
-
     CSCDetId idrec = (CSCDetId)(*recIt).cscDetId();
 
     //Store the Rechits into a Map
-    AllRechits.insert(std::pair<CSCDetId , CSCRecHit2D>(idrec,*recIt));
+    AllRechits.insert(std::pair<CSCDetId, CSCRecHit2D>(idrec, *recIt));
 
     // Find the strip containing this hit
-    int centerid     =  recIt->nStrips()/2;
-    int centerStrip =  recIt->channels(centerid);
+    int centerid = recIt->nStrips() / 2;
+    int centerStrip = recIt->channels(centerid);
 
-    float  rHsignal = getthisSignal(*strips, idrec, centerStrip);
-    histos->fill1DHist(rHsignal,"hrHSignal", "Signal in the 4th time bin for centre strip",1100,-99,1000,"recHits");
-
+    float rHsignal = getthisSignal(*strips, idrec, centerStrip);
+    histos->fill1DHist(
+        rHsignal, "hrHSignal", "Signal in the 4th time bin for centre strip", 1100, -99, 1000, "recHits");
   }
 
-  for(CSCSegmentCollection::const_iterator it=cscSegments->begin(); it != cscSegments->end(); it++) {
-
+  for (CSCSegmentCollection::const_iterator it = cscSegments->begin(); it != cscSegments->end(); it++) {
     std::vector<CSCRecHit2D> theseRecHits = (*it).specificRecHits();
-    for ( std::vector<CSCRecHit2D>::const_iterator iRH = theseRecHits.begin(); iRH != theseRecHits.end(); iRH++) {
+    for (std::vector<CSCRecHit2D>::const_iterator iRH = theseRecHits.begin(); iRH != theseRecHits.end(); iRH++) {
       CSCDetId idRH = (CSCDetId)(*iRH).cscDetId();
       LocalPoint lpRH = (*iRH).localPosition();
       float xrec = lpRH.x();
@@ -1851,279 +1998,380 @@ void CSCValidation::doNoiseHits(edm::Handle<CSCRecHit2DCollection> recHits, edm:
       float zrec = lpRH.z();
       bool RHalreadyinMap = false;
       //Store the rechits associated with segments into a Map
-      multimap<CSCDetId , CSCRecHit2D>::iterator segRHit;
+      multimap<CSCDetId, CSCRecHit2D>::iterator segRHit;
       segRHit = SegRechits.find(idRH);
-      if (segRHit != SegRechits.end()){
-	for( ; segRHit != SegRechits.upper_bound(idRH); ++segRHit){
-	  //for( segRHit = SegRechits.begin(); segRHit != SegRechits.end() ;++segRHit){
-	  LocalPoint lposRH = (segRHit->second).localPosition();
-	  float xpos = lposRH.x();
-	  float ypos = lposRH.y();
-	  float zpos = lposRH.z();
-	  if ( xrec == xpos && yrec == ypos && zrec == zpos){
-	  RHalreadyinMap = true;
-	  //std::cout << " Already exists " <<std ::endl;
-	  break;}
-	}
+      if (segRHit != SegRechits.end()) {
+        for (; segRHit != SegRechits.upper_bound(idRH); ++segRHit) {
+          //for( segRHit = SegRechits.begin(); segRHit != SegRechits.end() ;++segRHit){
+          LocalPoint lposRH = (segRHit->second).localPosition();
+          float xpos = lposRH.x();
+          float ypos = lposRH.y();
+          float zpos = lposRH.z();
+          if (xrec == xpos && yrec == ypos && zrec == zpos) {
+            RHalreadyinMap = true;
+            //std::cout << " Already exists " <<std ::endl;
+            break;
+          }
+        }
       }
-      if(!RHalreadyinMap){ SegRechits.insert(std::pair<CSCDetId , CSCRecHit2D>(idRH,*iRH));}
+      if (!RHalreadyinMap) {
+        SegRechits.insert(std::pair<CSCDetId, CSCRecHit2D>(idRH, *iRH));
+      }
     }
   }
 
-  findNonAssociatedRecHits(cscGeom,strips);
-
+  findNonAssociatedRecHits(cscGeom, strips);
 }
 
 //---------------------------------------------------------------------------------------
-// Given  the list of all rechits and the rechits on a segment finds the rechits 
+// Given  the list of all rechits and the rechits on a segment finds the rechits
 // not associated to a segment and stores in a list
 //
 //---------------------------------------------------------------------------------------
 
-void CSCValidation::findNonAssociatedRecHits(edm::ESHandle<CSCGeometry> cscGeom,  edm::Handle<CSCStripDigiCollection> strips){
- 
-  for(std::multimap<CSCDetId , CSCRecHit2D>::iterator allRHiter =  AllRechits.begin();allRHiter != AllRechits.end(); ++allRHiter){
-	CSCDetId idRH = allRHiter->first;
+void CSCValidation::findNonAssociatedRecHits(edm::ESHandle<CSCGeometry> cscGeom,
+                                             edm::Handle<CSCStripDigiCollection> strips) {
+  for (std::multimap<CSCDetId, CSCRecHit2D>::iterator allRHiter = AllRechits.begin(); allRHiter != AllRechits.end();
+       ++allRHiter) {
+    CSCDetId idRH = allRHiter->first;
     LocalPoint lpRH = (allRHiter->second).localPosition();
     float xrec = lpRH.x();
     float yrec = lpRH.y();
     float zrec = lpRH.z();
-    
+
     bool foundmatch = false;
-    multimap<CSCDetId , CSCRecHit2D>::iterator segRHit;
+    multimap<CSCDetId, CSCRecHit2D>::iterator segRHit;
     segRHit = SegRechits.find(idRH);
-    if (segRHit != SegRechits.end()){
-		for( ; segRHit != SegRechits.upper_bound(idRH); ++segRHit){
-			
-			LocalPoint lposRH = (segRHit->second).localPosition();
-			float xpos = lposRH.x();
-			float ypos = lposRH.y();
-			float zpos = lposRH.z();
+    if (segRHit != SegRechits.end()) {
+      for (; segRHit != SegRechits.upper_bound(idRH); ++segRHit) {
+        LocalPoint lposRH = (segRHit->second).localPosition();
+        float xpos = lposRH.x();
+        float ypos = lposRH.y();
+        float zpos = lposRH.z();
 
-			if ( xrec == xpos && yrec == ypos && zrec == zpos){
-				foundmatch = true;}
-	  
-			float d      = 0.;
-			float dclose =1000.;
+        if (xrec == xpos && yrec == ypos && zrec == zpos) {
+          foundmatch = true;
+        }
 
-			if ( !foundmatch) {
-				
-				d = sqrt(pow(xrec-xpos,2)+pow(yrec-ypos,2)+pow(zrec-zpos,2));
-				if (d < dclose) {
-					dclose = d;
-					if( distRHmap.find((allRHiter->second)) ==  distRHmap.end() ) { // entry for rechit does not yet exist, create one
-						distRHmap.insert(make_pair(allRHiter->second,dclose) );
-					}
-					else {
-						// we already have an entry for the detid.
-						distRHmap.erase(allRHiter->second);
-						distRHmap.insert(make_pair(allRHiter->second,dclose)); // fill rechits for the segment with the given detid
-					}
-				}
-			} 	    
-		}
+        float d = 0.;
+        float dclose = 1000.;
+
+        if (!foundmatch) {
+          d = sqrt(pow(xrec - xpos, 2) + pow(yrec - ypos, 2) + pow(zrec - zpos, 2));
+          if (d < dclose) {
+            dclose = d;
+            if (distRHmap.find((allRHiter->second)) ==
+                distRHmap.end()) {  // entry for rechit does not yet exist, create one
+              distRHmap.insert(make_pair(allRHiter->second, dclose));
+            } else {
+              // we already have an entry for the detid.
+              distRHmap.erase(allRHiter->second);
+              distRHmap.insert(
+                  make_pair(allRHiter->second, dclose));  // fill rechits for the segment with the given detid
+            }
+          }
+        }
+      }
     }
-    if(!foundmatch){NonAssociatedRechits.insert(std::pair<CSCDetId , CSCRecHit2D>(idRH,allRHiter->second));}
+    if (!foundmatch) {
+      NonAssociatedRechits.insert(std::pair<CSCDetId, CSCRecHit2D>(idRH, allRHiter->second));
+    }
   }
 
-  for(std::map<CSCRecHit2D,float,ltrh>::iterator iter =  distRHmap.begin();iter != distRHmap.end(); ++iter){
-    histos->fill1DHist(iter->second,"hdistRH","Distance of Non Associated RecHit from closest Segment RecHit",500,0.,100.,"NonAssociatedRechits");
+  for (std::map<CSCRecHit2D, float, ltrh>::iterator iter = distRHmap.begin(); iter != distRHmap.end(); ++iter) {
+    histos->fill1DHist(iter->second,
+                       "hdistRH",
+                       "Distance of Non Associated RecHit from closest Segment RecHit",
+                       500,
+                       0.,
+                       100.,
+                       "NonAssociatedRechits");
   }
 
-  for(std::multimap<CSCDetId , CSCRecHit2D>::iterator iter =  NonAssociatedRechits.begin();iter != NonAssociatedRechits.end(); ++iter){
+  for (std::multimap<CSCDetId, CSCRecHit2D>::iterator iter = NonAssociatedRechits.begin();
+       iter != NonAssociatedRechits.end();
+       ++iter) {
     CSCDetId idrec = iter->first;
-    int kEndcap  = idrec.endcap();
-    int cEndcap  = idrec.endcap();
-    if (kEndcap == 2)cEndcap = -1;
-    int kRing    = idrec.ring();
+    int kEndcap = idrec.endcap();
+    int cEndcap = idrec.endcap();
+    if (kEndcap == 2)
+      cEndcap = -1;
+    int kRing = idrec.ring();
     int kStation = idrec.station();
     int kChamber = idrec.chamber();
-    int kLayer   = idrec.layer();
+    int kLayer = idrec.layer();
 
     // Store rechit as a Local Point:
-    LocalPoint rhitlocal = (iter->second).localPosition();  
+    LocalPoint rhitlocal = (iter->second).localPosition();
     float xreco = rhitlocal.x();
     float yreco = rhitlocal.y();
 
     // Find the strip containing this hit
-    int centerid    =  (iter->second).nStrips()/2;
-    int centerStrip =  (iter->second).channels(centerid);
+    int centerid = (iter->second).nStrips() / 2;
+    int centerStrip = (iter->second).channels(centerid);
 
     // Find the charge associated with this hit
     float rHSumQ = 0;
-    float sumsides=0.;
-    int adcsize=(iter->second).nStrips()*(iter->second).nTimeBins();
-    for ( unsigned int i=0; i< (iter->second).nStrips(); i++) {
-      for ( unsigned int j=0; j< (iter->second).nTimeBins()-1; j++) {
-	rHSumQ+=(iter->second).adcs(i,j);
-	if (i!=1) sumsides+=(iter->second).adcs(i,j);
+    float sumsides = 0.;
+    int adcsize = (iter->second).nStrips() * (iter->second).nTimeBins();
+    for (unsigned int i = 0; i < (iter->second).nStrips(); i++) {
+      for (unsigned int j = 0; j < (iter->second).nTimeBins() - 1; j++) {
+        rHSumQ += (iter->second).adcs(i, j);
+        if (i != 1)
+          sumsides += (iter->second).adcs(i, j);
       }
     }
 
-    float rHratioQ = sumsides/rHSumQ;
-    if (adcsize != 12) rHratioQ = -99;
+    float rHratioQ = sumsides / rHSumQ;
+    if (adcsize != 12)
+      rHratioQ = -99;
 
     // Get the signal timing of this hit
-    float rHtime = (iter->second).tpeak()/50;
+    float rHtime = (iter->second).tpeak() / 50;
 
     // Get the width of this hit
     int rHwidth = getWidth(*strips, idrec, centerStrip);
 
-
     // Get pointer to the layer:
-    const CSCLayer* csclayer = cscGeom->layer( idrec );
+    const CSCLayer* csclayer = cscGeom->layer(idrec);
 
     // Transform hit position from local chamber geometry to global CMS geom
-    GlobalPoint rhitglobal= csclayer->toGlobal(rhitlocal);
-    float grecx   =  rhitglobal.x();
-    float grecy   =  rhitglobal.y();
+    GlobalPoint rhitglobal = csclayer->toGlobal(rhitlocal);
+    float grecx = rhitglobal.x();
+    float grecy = rhitglobal.y();
 
-
-
-   // Simple occupancy variables
-    int kCodeBroad  = cEndcap * ( 4*(kStation-1) + kRing) ;
-    int kCodeNarrow = cEndcap * ( 100*(kRing-1) + kChamber) ;
+    // Simple occupancy variables
+    int kCodeBroad = cEndcap * (4 * (kStation - 1) + kRing);
+    int kCodeNarrow = cEndcap * (100 * (kRing - 1) + kChamber);
 
     //Fill the non-associated rechits parameters in histogram
-    histos->fill1DHist(kCodeBroad,"hNARHCodeBroad","broad scope code for recHits",33,-16.5,16.5,"NonAssociatedRechits");
-    if (kStation == 1) histos->fill1DHist(kCodeNarrow,"hNARHCodeNarrow1","narrow scope recHit code station 1",801,-400.5,400.5,"NonAssociatedRechits");
-    if (kStation == 2) histos->fill1DHist(kCodeNarrow,"hNARHCodeNarrow2","narrow scope recHit code station 2",801,-400.5,400.5,"NonAssociatedRechits");
-    if (kStation == 3) histos->fill1DHist(kCodeNarrow,"hNARHCodeNarrow3","narrow scope recHit code station 3",801,-400.5,400.5,"NonAssociatedRechits");
-    if (kStation == 4) histos->fill1DHist(kCodeNarrow,"hNARHCodeNarrow4","narrow scope recHit code station 4",801,-400.5,400.5,"NonAssociatedRechits");
-    histos->fill1DHistByType(kLayer,"hNARHLayer","RecHits per Layer",idrec,8,-0.5,7.5,"NonAssociatedRechits");
-    histos->fill1DHistByType(xreco,"hNARHX","Local X of recHit",idrec,160,-80.,80.,"NonAssociatedRechits");
-    histos->fill1DHistByType(yreco,"hNARHY","Local Y of recHit",idrec,60,-180.,180.,"NonAssociatedRechits");
-    if (kStation == 1 && (kRing == 1 || kRing == 4)) histos->fill1DHistByType(rHSumQ,"hNARHSumQ","Sum 3x3 recHit Charge",idrec,250,0,4000,"NonAssociatedRechits");
-    else histos->fill1DHistByType(rHSumQ,"hNARHSumQ","Sum 3x3 recHit Charge",idrec,250,0,2000,"NonAssociatedRechits");
-    histos->fill1DHistByType(rHratioQ,"hNARHRatioQ","Ratio (Ql+Qr)/Qt)",idrec,120,-0.1,1.1,"NonAssociatedRechits");
-    histos->fill1DHistByType(rHtime,"hNARHTiming","recHit Timing",idrec,200,-10,10,"NonAssociatedRechits");
-    histos->fill2DHistByStation(grecx,grecy,"hNARHGlobal","recHit Global Position",idrec,400,-800.,800.,400,-800.,800.,"NonAssociatedRechits");
-    histos->fill1DHistByType(rHwidth,"hNARHwidth","width for Non associated recHit",idrec,21,-0.5,20.5,"NonAssociatedRechits");
-    
+    histos->fill1DHist(
+        kCodeBroad, "hNARHCodeBroad", "broad scope code for recHits", 33, -16.5, 16.5, "NonAssociatedRechits");
+    if (kStation == 1)
+      histos->fill1DHist(kCodeNarrow,
+                         "hNARHCodeNarrow1",
+                         "narrow scope recHit code station 1",
+                         801,
+                         -400.5,
+                         400.5,
+                         "NonAssociatedRechits");
+    if (kStation == 2)
+      histos->fill1DHist(kCodeNarrow,
+                         "hNARHCodeNarrow2",
+                         "narrow scope recHit code station 2",
+                         801,
+                         -400.5,
+                         400.5,
+                         "NonAssociatedRechits");
+    if (kStation == 3)
+      histos->fill1DHist(kCodeNarrow,
+                         "hNARHCodeNarrow3",
+                         "narrow scope recHit code station 3",
+                         801,
+                         -400.5,
+                         400.5,
+                         "NonAssociatedRechits");
+    if (kStation == 4)
+      histos->fill1DHist(kCodeNarrow,
+                         "hNARHCodeNarrow4",
+                         "narrow scope recHit code station 4",
+                         801,
+                         -400.5,
+                         400.5,
+                         "NonAssociatedRechits");
+    histos->fill1DHistByType(kLayer, "hNARHLayer", "RecHits per Layer", idrec, 8, -0.5, 7.5, "NonAssociatedRechits");
+    histos->fill1DHistByType(xreco, "hNARHX", "Local X of recHit", idrec, 160, -80., 80., "NonAssociatedRechits");
+    histos->fill1DHistByType(yreco, "hNARHY", "Local Y of recHit", idrec, 60, -180., 180., "NonAssociatedRechits");
+    if (kStation == 1 && (kRing == 1 || kRing == 4))
+      histos->fill1DHistByType(
+          rHSumQ, "hNARHSumQ", "Sum 3x3 recHit Charge", idrec, 250, 0, 4000, "NonAssociatedRechits");
+    else
+      histos->fill1DHistByType(
+          rHSumQ, "hNARHSumQ", "Sum 3x3 recHit Charge", idrec, 250, 0, 2000, "NonAssociatedRechits");
+    histos->fill1DHistByType(
+        rHratioQ, "hNARHRatioQ", "Ratio (Ql+Qr)/Qt)", idrec, 120, -0.1, 1.1, "NonAssociatedRechits");
+    histos->fill1DHistByType(rHtime, "hNARHTiming", "recHit Timing", idrec, 200, -10, 10, "NonAssociatedRechits");
+    histos->fill2DHistByStation(grecx,
+                                grecy,
+                                "hNARHGlobal",
+                                "recHit Global Position",
+                                idrec,
+                                400,
+                                -800.,
+                                800.,
+                                400,
+                                -800.,
+                                800.,
+                                "NonAssociatedRechits");
+    histos->fill1DHistByType(
+        rHwidth, "hNARHwidth", "width for Non associated recHit", idrec, 21, -0.5, 20.5, "NonAssociatedRechits");
   }
 
-   for(std::multimap<CSCDetId , CSCRecHit2D>::iterator iter =  SegRechits.begin();iter != SegRechits.end(); ++iter){
-	   CSCDetId idrec = iter->first;
-	   int kEndcap  = idrec.endcap();
-	   int cEndcap  = idrec.endcap();
-	   if (kEndcap == 2)cEndcap = -1;
-	   int kRing    = idrec.ring();
-	   int kStation = idrec.station();
-	   int kChamber = idrec.chamber();
-	   int kLayer   = idrec.layer();
+  for (std::multimap<CSCDetId, CSCRecHit2D>::iterator iter = SegRechits.begin(); iter != SegRechits.end(); ++iter) {
+    CSCDetId idrec = iter->first;
+    int kEndcap = idrec.endcap();
+    int cEndcap = idrec.endcap();
+    if (kEndcap == 2)
+      cEndcap = -1;
+    int kRing = idrec.ring();
+    int kStation = idrec.station();
+    int kChamber = idrec.chamber();
+    int kLayer = idrec.layer();
 
-	   // Store rechit as a Local Point:
-	   LocalPoint rhitlocal = (iter->second).localPosition();  
-	   float xreco = rhitlocal.x();
-	   float yreco = rhitlocal.y();
+    // Store rechit as a Local Point:
+    LocalPoint rhitlocal = (iter->second).localPosition();
+    float xreco = rhitlocal.x();
+    float yreco = rhitlocal.y();
 
-	   // Find the strip containing this hit
-	   int centerid    =  (iter->second).nStrips()/2;
-	   int centerStrip =  (iter->second).channels(centerid);
+    // Find the strip containing this hit
+    int centerid = (iter->second).nStrips() / 2;
+    int centerStrip = (iter->second).channels(centerid);
 
-	   // Find the charge associated with this hit
+    // Find the charge associated with this hit
 
-	   float rHSumQ = 0;
-	   float sumsides=0.;
-	   int adcsize=(iter->second).nStrips()*(iter->second).nTimeBins();
-	   for ( unsigned int i=0; i< (iter->second).nStrips(); i++) {
-	     for ( unsigned int j=0; j< (iter->second).nTimeBins()-1; j++) {
-	       rHSumQ+=(iter->second).adcs(i,j);
-    	       if (i!=1) sumsides+=(iter->second).adcs(i,j);
-	     }
-	   }
-	   
-	   float rHratioQ = sumsides/rHSumQ;
-	   if (adcsize != 12) rHratioQ = -99;
-	   
-	   // Get the signal timing of this hit
-	   float rHtime = (iter->second).tpeak()/50;
+    float rHSumQ = 0;
+    float sumsides = 0.;
+    int adcsize = (iter->second).nStrips() * (iter->second).nTimeBins();
+    for (unsigned int i = 0; i < (iter->second).nStrips(); i++) {
+      for (unsigned int j = 0; j < (iter->second).nTimeBins() - 1; j++) {
+        rHSumQ += (iter->second).adcs(i, j);
+        if (i != 1)
+          sumsides += (iter->second).adcs(i, j);
+      }
+    }
 
-	   // Get the width of this hit
-	   int rHwidth = getWidth(*strips, idrec, centerStrip);
+    float rHratioQ = sumsides / rHSumQ;
+    if (adcsize != 12)
+      rHratioQ = -99;
 
+    // Get the signal timing of this hit
+    float rHtime = (iter->second).tpeak() / 50;
 
-	   // Get pointer to the layer:
-	   const CSCLayer* csclayer = cscGeom->layer( idrec );
-	   
-	   // Transform hit position from local chamber geometry to global CMS geom
-	   GlobalPoint rhitglobal= csclayer->toGlobal(rhitlocal);
-	   float grecx   =  rhitglobal.x();
-	   float grecy   =  rhitglobal.y();
+    // Get the width of this hit
+    int rHwidth = getWidth(*strips, idrec, centerStrip);
 
-	   // Simple occupancy variables
-	   int kCodeBroad  = cEndcap * ( 4*(kStation-1) + kRing) ;
-	   int kCodeNarrow = cEndcap * ( 100*(kRing-1) + kChamber) ;
+    // Get pointer to the layer:
+    const CSCLayer* csclayer = cscGeom->layer(idrec);
 
-	   //Fill the non-associated rechits global position in histogram
-           histos->fill1DHist(kCodeBroad,"hSegRHCodeBroad","broad scope code for recHits",33,-16.5,16.5,"AssociatedRechits");
-           if (kStation == 1) histos->fill1DHist(kCodeNarrow,"hSegRHCodeNarrow1","narrow scope recHit code station 1",801,-400.5,400.5,"AssociatedRechits");
-           if (kStation == 2) histos->fill1DHist(kCodeNarrow,"hSegRHCodeNarrow2","narrow scope recHit code station 2",801,-400.5,400.5,"AssociatedRechits");
-           if (kStation == 3) histos->fill1DHist(kCodeNarrow,"hSegRHCodeNarrow3","narrow scope recHit code station 3",801,-400.5,400.5,"AssociatedRechits");
-           if (kStation == 4) histos->fill1DHist(kCodeNarrow,"hSegRHCodeNarrow4","narrow scope recHit code station 4",801,-400.5,400.5,"AssociatedRechits");
-           histos->fill1DHistByType(kLayer,"hSegRHLayer","RecHits per Layer",idrec,8,-0.5,7.5,"AssociatedRechits");
-           histos->fill1DHistByType(xreco,"hSegRHX","Local X of recHit",idrec,160,-80.,80.,"AssociatedRechits");
-           histos->fill1DHistByType(yreco,"hSegRHY","Local Y of recHit",idrec,60,-180.,180.,"AssociatedRechits");
-           if (kStation == 1 && (kRing == 1 || kRing == 4)) histos->fill1DHistByType(rHSumQ,"hSegRHSumQ","Sum 3x3 recHit Charge",idrec,250,0,4000,"AssociatedRechits");
-           else histos->fill1DHistByType(rHSumQ,"hSegRHSumQ","Sum 3x3 recHit Charge",idrec,250,0,2000,"AssociatedRechits");
-           histos->fill1DHistByType(rHratioQ,"hSegRHRatioQ","Ratio (Ql+Qr)/Qt)",idrec,120,-0.1,1.1,"AssociatedRechits");
-           histos->fill1DHistByType(rHtime,"hSegRHTiming","recHit Timing",idrec,200,-10,10,"AssociatedRechits");
-           histos->fill2DHistByStation(grecx,grecy,"hSegRHGlobal","recHit Global Position",idrec,400,-800.,800.,400,-800.,800.,"AssociatedRechits");
-           histos->fill1DHistByType(rHwidth,"hSegRHwidth","width for Non associated recHit",idrec,21,-0.5,20.5,"AssociatedRechits");
-	   
-   }
+    // Transform hit position from local chamber geometry to global CMS geom
+    GlobalPoint rhitglobal = csclayer->toGlobal(rhitlocal);
+    float grecx = rhitglobal.x();
+    float grecy = rhitglobal.y();
 
-   distRHmap.clear();
-   AllRechits.clear();
-   SegRechits.clear();
-   NonAssociatedRechits.clear();
+    // Simple occupancy variables
+    int kCodeBroad = cEndcap * (4 * (kStation - 1) + kRing);
+    int kCodeNarrow = cEndcap * (100 * (kRing - 1) + kChamber);
+
+    //Fill the non-associated rechits global position in histogram
+    histos->fill1DHist(
+        kCodeBroad, "hSegRHCodeBroad", "broad scope code for recHits", 33, -16.5, 16.5, "AssociatedRechits");
+    if (kStation == 1)
+      histos->fill1DHist(kCodeNarrow,
+                         "hSegRHCodeNarrow1",
+                         "narrow scope recHit code station 1",
+                         801,
+                         -400.5,
+                         400.5,
+                         "AssociatedRechits");
+    if (kStation == 2)
+      histos->fill1DHist(kCodeNarrow,
+                         "hSegRHCodeNarrow2",
+                         "narrow scope recHit code station 2",
+                         801,
+                         -400.5,
+                         400.5,
+                         "AssociatedRechits");
+    if (kStation == 3)
+      histos->fill1DHist(kCodeNarrow,
+                         "hSegRHCodeNarrow3",
+                         "narrow scope recHit code station 3",
+                         801,
+                         -400.5,
+                         400.5,
+                         "AssociatedRechits");
+    if (kStation == 4)
+      histos->fill1DHist(kCodeNarrow,
+                         "hSegRHCodeNarrow4",
+                         "narrow scope recHit code station 4",
+                         801,
+                         -400.5,
+                         400.5,
+                         "AssociatedRechits");
+    histos->fill1DHistByType(kLayer, "hSegRHLayer", "RecHits per Layer", idrec, 8, -0.5, 7.5, "AssociatedRechits");
+    histos->fill1DHistByType(xreco, "hSegRHX", "Local X of recHit", idrec, 160, -80., 80., "AssociatedRechits");
+    histos->fill1DHistByType(yreco, "hSegRHY", "Local Y of recHit", idrec, 60, -180., 180., "AssociatedRechits");
+    if (kStation == 1 && (kRing == 1 || kRing == 4))
+      histos->fill1DHistByType(rHSumQ, "hSegRHSumQ", "Sum 3x3 recHit Charge", idrec, 250, 0, 4000, "AssociatedRechits");
+    else
+      histos->fill1DHistByType(rHSumQ, "hSegRHSumQ", "Sum 3x3 recHit Charge", idrec, 250, 0, 2000, "AssociatedRechits");
+    histos->fill1DHistByType(rHratioQ, "hSegRHRatioQ", "Ratio (Ql+Qr)/Qt)", idrec, 120, -0.1, 1.1, "AssociatedRechits");
+    histos->fill1DHistByType(rHtime, "hSegRHTiming", "recHit Timing", idrec, 200, -10, 10, "AssociatedRechits");
+    histos->fill2DHistByStation(grecx,
+                                grecy,
+                                "hSegRHGlobal",
+                                "recHit Global Position",
+                                idrec,
+                                400,
+                                -800.,
+                                800.,
+                                400,
+                                -800.,
+                                800.,
+                                "AssociatedRechits");
+    histos->fill1DHistByType(
+        rHwidth, "hSegRHwidth", "width for Non associated recHit", idrec, 21, -0.5, 20.5, "AssociatedRechits");
+  }
+
+  distRHmap.clear();
+  AllRechits.clear();
+  SegRechits.clear();
+  NonAssociatedRechits.clear();
 }
 
-
-
-float CSCValidation::getthisSignal(const CSCStripDigiCollection& stripdigis, CSCDetId idRH, int centerStrip){
-	// Loop over strip digis responsible for this recHit
-	CSCStripDigiCollection::DigiRangeIterator sIt;
-	float thisADC = 0.;
-	//bool foundRHid = false;
-	// std::cout<<"iD   S/R/C/L = "<<idRH<<"    "<<idRH.station()<<"/"<<idRH.ring()<<"/"<<idRH.chamber()<<"/"<<idRH.layer()<<std::endl;
-	for (sIt = stripdigis.begin(); sIt != stripdigis.end(); sIt++){
-		CSCDetId id = (CSCDetId)(*sIt).first;
-		//std::cout<<"STRIPS: id    S/R/C/L = "<<id<<"     "<<id.station()<<"/"<<id.ring()<<"/"<<id.chamber()<<"/"<<id.layer()<<std::endl;
-		if (id == idRH){
-			//foundRHid = true;
-			vector<CSCStripDigi>::const_iterator digiItr = (*sIt).second.first;
-			vector<CSCStripDigi>::const_iterator last = (*sIt).second.second;
-			//if(digiItr == last ) {std::cout << " Attention1 :: Size of digi collection is zero " << std::endl;}
-			int St = idRH.station();
-			int Rg    = idRH.ring();
-			if (St == 1 && Rg == 4){
-				while(centerStrip> 16) centerStrip -= 16;
-			}
-			for ( ; digiItr != last; ++digiItr ) {
-				int thisStrip = digiItr->getStrip();
-				//std::cout<<" thisStrip = "<<thisStrip<<" centerStrip = "<<centerStrip<<std::endl;
-				std::vector<int> myADCVals = digiItr->getADCCounts();
-				float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-				float Signal = (float) myADCVals[3];
-				if (thisStrip == (centerStrip)){
-					thisADC = Signal-thisPedestal;
-					//if(thisADC >= 0. && thisADC <2.) {std::cout << " Attention2 :: The Signal is equal to the pedestal " << std::endl;
-					//}
-					//if(thisADC < 0.) {std::cout << " Attention3 :: The Signal is less than the pedestal " << std::endl;
-					//}
-				}
-				if (thisStrip == (centerStrip+1)){
-					std::vector<int> myADCVals = digiItr->getADCCounts();
-				}
-				if (thisStrip == (centerStrip-1)){
-					std::vector<int> myADCVals = digiItr->getADCCounts();
-				}
-			}
-		}
-	}
-	//if(!foundRHid){std::cout << " Attention4 :: Did not find a matching RH id in the Strip Digi collection " << std::endl;}
-	return thisADC;
+float CSCValidation::getthisSignal(const CSCStripDigiCollection& stripdigis, CSCDetId idRH, int centerStrip) {
+  // Loop over strip digis responsible for this recHit
+  CSCStripDigiCollection::DigiRangeIterator sIt;
+  float thisADC = 0.;
+  //bool foundRHid = false;
+  // std::cout<<"iD   S/R/C/L = "<<idRH<<"    "<<idRH.station()<<"/"<<idRH.ring()<<"/"<<idRH.chamber()<<"/"<<idRH.layer()<<std::endl;
+  for (sIt = stripdigis.begin(); sIt != stripdigis.end(); sIt++) {
+    CSCDetId id = (CSCDetId)(*sIt).first;
+    //std::cout<<"STRIPS: id    S/R/C/L = "<<id<<"     "<<id.station()<<"/"<<id.ring()<<"/"<<id.chamber()<<"/"<<id.layer()<<std::endl;
+    if (id == idRH) {
+      //foundRHid = true;
+      vector<CSCStripDigi>::const_iterator digiItr = (*sIt).second.first;
+      vector<CSCStripDigi>::const_iterator last = (*sIt).second.second;
+      //if(digiItr == last ) {std::cout << " Attention1 :: Size of digi collection is zero " << std::endl;}
+      int St = idRH.station();
+      int Rg = idRH.ring();
+      if (St == 1 && Rg == 4) {
+        while (centerStrip > 16)
+          centerStrip -= 16;
+      }
+      for (; digiItr != last; ++digiItr) {
+        int thisStrip = digiItr->getStrip();
+        //std::cout<<" thisStrip = "<<thisStrip<<" centerStrip = "<<centerStrip<<std::endl;
+        std::vector<int> myADCVals = digiItr->getADCCounts();
+        float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+        float Signal = (float)myADCVals[3];
+        if (thisStrip == (centerStrip)) {
+          thisADC = Signal - thisPedestal;
+          //if(thisADC >= 0. && thisADC <2.) {std::cout << " Attention2 :: The Signal is equal to the pedestal " << std::endl;
+          //}
+          //if(thisADC < 0.) {std::cout << " Attention3 :: The Signal is less than the pedestal " << std::endl;
+          //}
+        }
+        if (thisStrip == (centerStrip + 1)) {
+          std::vector<int> myADCVals = digiItr->getADCCounts();
+        }
+        if (thisStrip == (centerStrip - 1)) {
+          std::vector<int> myADCVals = digiItr->getADCCounts();
+        }
+      }
+    }
+  }
+  //if(!foundRHid){std::cout << " Attention4 :: Did not find a matching RH id in the Strip Digi collection " << std::endl;}
+  return thisADC;
 }
 
 //---------------------------------------------------------------------------------------
@@ -2132,8 +2380,7 @@ float CSCValidation::getthisSignal(const CSCStripDigiCollection& stripdigis, CSC
 // the width in terms of strips
 //---------------------------------------------------------------------------------------
 
-int CSCValidation::getWidth(const CSCStripDigiCollection& stripdigis, CSCDetId idRH, int centerStrip){
-
+int CSCValidation::getWidth(const CSCStripDigiCollection& stripdigis, CSCDetId idRH, int centerStrip) {
   int width = 1;
   int widthpos = 0;
   int widthneg = 0;
@@ -2141,285 +2388,331 @@ int CSCValidation::getWidth(const CSCStripDigiCollection& stripdigis, CSCDetId i
   // Loop over strip digis responsible for this recHit and sum charge
   CSCStripDigiCollection::DigiRangeIterator sIt;
 
-  for (sIt = stripdigis.begin(); sIt != stripdigis.end(); sIt++){
-	  CSCDetId id = (CSCDetId)(*sIt).first;
-	  if (id == idRH){
-		  std::vector<CSCStripDigi>::const_iterator digiItr = (*sIt).second.first;
-		  std::vector<CSCStripDigi>::const_iterator first = (*sIt).second.first;
-		  std::vector<CSCStripDigi>::const_iterator last = (*sIt).second.second;
-		  std::vector<CSCStripDigi>::const_iterator it = (*sIt).second.first;
-		  std::vector<CSCStripDigi>::const_iterator itr = (*sIt).second.first;
-		  //std::cout << " IDRH " << id <<std::endl;
-		  int St = idRH.station();
-		  int Rg    = idRH.ring();
-		  if (St == 1 && Rg == 4){
-			  while(centerStrip> 16) centerStrip -= 16;
-		  }
-		  for ( ; digiItr != last; ++digiItr ) {
-			  int thisStrip = digiItr->getStrip();
-			  if (thisStrip == (centerStrip)){
-				  it = digiItr;
-				  for( ; it != last; ++it ) {
-					  int strip = it->getStrip();
-					  std::vector<int> myADCVals = it->getADCCounts();
-					  float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-					  if(((float)myADCVals[3]-thisPedestal) < 6 || widthpos == 10 || it==last){break;}
-					   if(strip != centerStrip){ widthpos += 1;
-					   }
-				  }
-				  itr = digiItr;
-				  for( ; itr != first; --itr) {
-					  int strip = itr->getStrip();
-					  std::vector<int> myADCVals = itr->getADCCounts();
-					  float thisPedestal = 0.5*(float)(myADCVals[0]+myADCVals[1]);
-					  if(((float)myADCVals[3]-thisPedestal) < 6 || widthneg == 10 || itr==first){break;}	 
-					  if(strip != centerStrip) {widthneg += 1 ; 
-					  }
-				  }
-			  }
-		  }
-	  }
+  for (sIt = stripdigis.begin(); sIt != stripdigis.end(); sIt++) {
+    CSCDetId id = (CSCDetId)(*sIt).first;
+    if (id == idRH) {
+      std::vector<CSCStripDigi>::const_iterator digiItr = (*sIt).second.first;
+      std::vector<CSCStripDigi>::const_iterator first = (*sIt).second.first;
+      std::vector<CSCStripDigi>::const_iterator last = (*sIt).second.second;
+      std::vector<CSCStripDigi>::const_iterator it = (*sIt).second.first;
+      std::vector<CSCStripDigi>::const_iterator itr = (*sIt).second.first;
+      //std::cout << " IDRH " << id <<std::endl;
+      int St = idRH.station();
+      int Rg = idRH.ring();
+      if (St == 1 && Rg == 4) {
+        while (centerStrip > 16)
+          centerStrip -= 16;
+      }
+      for (; digiItr != last; ++digiItr) {
+        int thisStrip = digiItr->getStrip();
+        if (thisStrip == (centerStrip)) {
+          it = digiItr;
+          for (; it != last; ++it) {
+            int strip = it->getStrip();
+            std::vector<int> myADCVals = it->getADCCounts();
+            float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+            if (((float)myADCVals[3] - thisPedestal) < 6 || widthpos == 10 || it == last) {
+              break;
+            }
+            if (strip != centerStrip) {
+              widthpos += 1;
+            }
+          }
+          itr = digiItr;
+          for (; itr != first; --itr) {
+            int strip = itr->getStrip();
+            std::vector<int> myADCVals = itr->getADCCounts();
+            float thisPedestal = 0.5 * (float)(myADCVals[0] + myADCVals[1]);
+            if (((float)myADCVals[3] - thisPedestal) < 6 || widthneg == 10 || itr == first) {
+              break;
+            }
+            if (strip != centerStrip) {
+              widthneg += 1;
+            }
+          }
+        }
+      }
+    }
   }
   //std::cout << "Widthneg - " <<  widthneg << "Widthpos + " <<  widthpos << std::endl;
-  width =  width + widthneg +  widthpos ;
+  width = width + widthneg + widthpos;
   //std::cout << "Width " <<  width << std::endl;
   return width;
 }
-
 
 //---------------------------------------------------------------------------
 // Module for looking at gas gains
 // Author N. Terentiev
 //---------------------------------------------------------------------------
 
-void CSCValidation::doGasGain(const CSCWireDigiCollection& wirecltn, 
-                              const CSCStripDigiCollection&   strpcltn,
+void CSCValidation::doGasGain(const CSCWireDigiCollection& wirecltn,
+                              const CSCStripDigiCollection& strpcltn,
                               const CSCRecHit2DCollection& rechitcltn) {
-     int channel=0,mult,wire,layer,idlayer,idchamber,ring;
-     int wire_strip_rechit_present;
-     std::string name,title,endcapstr;
-     ostringstream ss;
-     CSCIndexer indexer;
-     std::map<int,int>::iterator intIt;
+  int channel = 0, mult, wire, layer, idlayer, idchamber, ring;
+  int wire_strip_rechit_present;
+  std::string name, title, endcapstr;
+  ostringstream ss;
+  CSCIndexer indexer;
+  std::map<int, int>::iterator intIt;
 
-     m_single_wire_layer.clear();
+  m_single_wire_layer.clear();
 
-  if(firstEvent) {
+  if (firstEvent) {
+    // HV segments, their # and location in terms of wire groups
 
-  // HV segments, their # and location in terms of wire groups
+    m_wire_hvsegm.clear();
+    std::map<int, std::vector<int> >::iterator intvecIt;
+    //                    ME1a ME1b ME1/2 ME1/3 ME2/1 ME2/2 ME3/1 ME3/2 ME4/1 ME4/2
+    int csctype[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    int hvsegm_layer[10] = {1, 1, 3, 3, 3, 5, 3, 5, 3, 5};
+    int id;
+    nmbhvsegm.clear();
+    for (int i = 0; i < 10; i++)
+      nmbhvsegm.push_back(hvsegm_layer[i]);
+    // For ME1/1a
+    std::vector<int> zer_1_1a(49, 0);
+    id = csctype[0];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_1_1a;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 48; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
 
-  m_wire_hvsegm.clear();
-  std::map<int,std::vector<int> >::iterator intvecIt;
-  //                    ME1a ME1b ME1/2 ME1/3 ME2/1 ME2/2 ME3/1 ME3/2 ME4/1 ME4/2 
-  int csctype[10]=     {1,   2,   3,    4,    5,    6,    7,    8,    9,    10};
-  int hvsegm_layer[10]={1,   1,   3,    3,    3,    5,    3,    5,    3,    5};
-  int id;
-  nmbhvsegm.clear();
-  for(int i=0;i<10;i++) nmbhvsegm.push_back(hvsegm_layer[i]);
-  // For ME1/1a
-  std::vector<int> zer_1_1a(49,0);
-  id=csctype[0];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_1_1a;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=48;wire++)  intvecIt->second[wire]=1;  // Segment 1
+    // For ME1/1b
+    std::vector<int> zer_1_1b(49, 0);
+    id = csctype[1];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_1_1b;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 48; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
 
-  // For ME1/1b
-  std::vector<int> zer_1_1b(49,0);
-  id=csctype[1];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_1_1b;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=48;wire++)  intvecIt->second[wire]=1;  // Segment 1
- 
-  // For ME1/2
-  std::vector<int> zer_1_2(65,0);
-  id=csctype[2];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_1_2;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=24;wire++)  intvecIt->second[wire]=1;  // Segment 1
-  for(int wire=25;wire<=48;wire++) intvecIt->second[wire]=2;  // Segment 2
-  for(int wire=49;wire<=64;wire++) intvecIt->second[wire]=3;  // Segment 3
- 
-  // For ME1/3
-  std::vector<int> zer_1_3(33,0);
-  id=csctype[3];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_1_3;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=12;wire++)  intvecIt->second[wire]=1;  // Segment 1
-  for(int wire=13;wire<=22;wire++) intvecIt->second[wire]=2;  // Segment 2
-  for(int wire=23;wire<=32;wire++) intvecIt->second[wire]=3;  // Segment 3
- 
-  // For ME2/1
-  std::vector<int> zer_2_1(113,0);
-  id=csctype[4];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_2_1;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=44;wire++)   intvecIt->second[wire]=1;  // Segment 1
-  for(int wire=45;wire<=80;wire++)  intvecIt->second[wire]=2;  // Segment 2
-  for(int wire=81;wire<=112;wire++) intvecIt->second[wire]=3;  // Segment 3
- 
-  // For ME2/2
-  std::vector<int> zer_2_2(65,0);
-  id=csctype[5];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_2_2;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=16;wire++)  intvecIt->second[wire]=1;  // Segment 1
-  for(int wire=17;wire<=28;wire++) intvecIt->second[wire]=2;  // Segment 2
-  for(int wire=29;wire<=40;wire++) intvecIt->second[wire]=3;  // Segment 3
-  for(int wire=41;wire<=52;wire++) intvecIt->second[wire]=4;  // Segment 4
-  for(int wire=53;wire<=64;wire++) intvecIt->second[wire]=5;  // Segment 5
+    // For ME1/2
+    std::vector<int> zer_1_2(65, 0);
+    id = csctype[2];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_1_2;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 24; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
+    for (int wire = 25; wire <= 48; wire++)
+      intvecIt->second[wire] = 2;  // Segment 2
+    for (int wire = 49; wire <= 64; wire++)
+      intvecIt->second[wire] = 3;  // Segment 3
 
-  // For ME3/1
-  std::vector<int> zer_3_1(97,0);
-  id=csctype[6];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_3_1;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=32;wire++)  intvecIt->second[wire]=1;  // Segment 1
-  for(int wire=33;wire<=64;wire++) intvecIt->second[wire]=2;  // Segment 2
-  for(int wire=65;wire<=96;wire++) intvecIt->second[wire]=3;  // Segment 3
- 
-  // For ME3/2
-  std::vector<int> zer_3_2(65,0);
-  id=csctype[7];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_3_2;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=16;wire++)  intvecIt->second[wire]=1;  // Segment 1
-  for(int wire=17;wire<=28;wire++) intvecIt->second[wire]=2;  // Segment 2
-  for(int wire=29;wire<=40;wire++) intvecIt->second[wire]=3;  // Segment 3
-  for(int wire=41;wire<=52;wire++) intvecIt->second[wire]=4;  // Segment 4
-  for(int wire=53;wire<=64;wire++) intvecIt->second[wire]=5;  // Segment 5
+    // For ME1/3
+    std::vector<int> zer_1_3(33, 0);
+    id = csctype[3];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_1_3;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 12; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
+    for (int wire = 13; wire <= 22; wire++)
+      intvecIt->second[wire] = 2;  // Segment 2
+    for (int wire = 23; wire <= 32; wire++)
+      intvecIt->second[wire] = 3;  // Segment 3
 
-  // For ME4/1
-  std::vector<int> zer_4_1(97,0);
-  id=csctype[8];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_4_1;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=32;wire++)  intvecIt->second[wire]=1;  // Segment 1
-  for(int wire=33;wire<=64;wire++) intvecIt->second[wire]=2;  // Segment 2
-  for(int wire=65;wire<=96;wire++) intvecIt->second[wire]=3;  // Segment 3
+    // For ME2/1
+    std::vector<int> zer_2_1(113, 0);
+    id = csctype[4];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_2_1;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 44; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
+    for (int wire = 45; wire <= 80; wire++)
+      intvecIt->second[wire] = 2;  // Segment 2
+    for (int wire = 81; wire <= 112; wire++)
+      intvecIt->second[wire] = 3;  // Segment 3
 
-  // For ME4/2
-  std::vector<int> zer_4_2(65,0);
-  id=csctype[9];
-  if(m_wire_hvsegm.find(id) == m_wire_hvsegm.end()) m_wire_hvsegm[id]=zer_4_2;
-  intvecIt=m_wire_hvsegm.find(id);
-  for(int wire=1;wire<=16;wire++)  intvecIt->second[wire]=1;  // Segment 1
-  for(int wire=17;wire<=28;wire++) intvecIt->second[wire]=2;  // Segment 2
-  for(int wire=29;wire<=40;wire++) intvecIt->second[wire]=3;  // Segment 3
-  for(int wire=41;wire<=52;wire++) intvecIt->second[wire]=4;  // Segment 4
-  for(int wire=53;wire<=64;wire++) intvecIt->second[wire]=5;  // Segment 5
+    // For ME2/2
+    std::vector<int> zer_2_2(65, 0);
+    id = csctype[5];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_2_2;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 16; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
+    for (int wire = 17; wire <= 28; wire++)
+      intvecIt->second[wire] = 2;  // Segment 2
+    for (int wire = 29; wire <= 40; wire++)
+      intvecIt->second[wire] = 3;  // Segment 3
+    for (int wire = 41; wire <= 52; wire++)
+      intvecIt->second[wire] = 4;  // Segment 4
+    for (int wire = 53; wire <= 64; wire++)
+      intvecIt->second[wire] = 5;  // Segment 5
 
-  } // end of if(nEventsAnalyzed==1)
+    // For ME3/1
+    std::vector<int> zer_3_1(97, 0);
+    id = csctype[6];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_3_1;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 32; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
+    for (int wire = 33; wire <= 64; wire++)
+      intvecIt->second[wire] = 2;  // Segment 2
+    for (int wire = 65; wire <= 96; wire++)
+      intvecIt->second[wire] = 3;  // Segment 3
 
+    // For ME3/2
+    std::vector<int> zer_3_2(65, 0);
+    id = csctype[7];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_3_2;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 16; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
+    for (int wire = 17; wire <= 28; wire++)
+      intvecIt->second[wire] = 2;  // Segment 2
+    for (int wire = 29; wire <= 40; wire++)
+      intvecIt->second[wire] = 3;  // Segment 3
+    for (int wire = 41; wire <= 52; wire++)
+      intvecIt->second[wire] = 4;  // Segment 4
+    for (int wire = 53; wire <= 64; wire++)
+      intvecIt->second[wire] = 5;  // Segment 5
 
-     // do wires, strips and rechits present?
-     wire_strip_rechit_present=0;
-     if(wirecltn.begin() != wirecltn.end())  
-       wire_strip_rechit_present= wire_strip_rechit_present+1;
-     if(strpcltn.begin() != strpcltn.end())    
-       wire_strip_rechit_present= wire_strip_rechit_present+2;
-     if(rechitcltn.begin() != rechitcltn.end())
-       wire_strip_rechit_present= wire_strip_rechit_present+4;
+    // For ME4/1
+    std::vector<int> zer_4_1(97, 0);
+    id = csctype[8];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_4_1;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 32; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
+    for (int wire = 33; wire <= 64; wire++)
+      intvecIt->second[wire] = 2;  // Segment 2
+    for (int wire = 65; wire <= 96; wire++)
+      intvecIt->second[wire] = 3;  // Segment 3
 
-     if(wire_strip_rechit_present==7) {
+    // For ME4/2
+    std::vector<int> zer_4_2(65, 0);
+    id = csctype[9];
+    if (m_wire_hvsegm.find(id) == m_wire_hvsegm.end())
+      m_wire_hvsegm[id] = zer_4_2;
+    intvecIt = m_wire_hvsegm.find(id);
+    for (int wire = 1; wire <= 16; wire++)
+      intvecIt->second[wire] = 1;  // Segment 1
+    for (int wire = 17; wire <= 28; wire++)
+      intvecIt->second[wire] = 2;  // Segment 2
+    for (int wire = 29; wire <= 40; wire++)
+      intvecIt->second[wire] = 3;  // Segment 3
+    for (int wire = 41; wire <= 52; wire++)
+      intvecIt->second[wire] = 4;  // Segment 4
+    for (int wire = 53; wire <= 64; wire++)
+      intvecIt->second[wire] = 5;  // Segment 5
 
-//       std::cout<<"Event "<<nEventsAnalyzed<<std::endl;
-//       std::cout<<std::endl;
+  }  // end of if(nEventsAnalyzed==1)
 
-       // cycle on wire collection for all CSC to select single wire hit layers
-       CSCWireDigiCollection::DigiRangeIterator wiredetUnitIt;
- 
-       for(wiredetUnitIt=wirecltn.begin();wiredetUnitIt!=wirecltn.end();
-          ++wiredetUnitIt) {
-          const CSCDetId id = (*wiredetUnitIt).first;
-          idlayer=indexer.dbIndex(id, channel);
-          idchamber=idlayer/10;
-          layer=id.layer();
-          // looping in the layer of given CSC
-          mult=0; wire=0; 
-          const CSCWireDigiCollection::Range& range = (*wiredetUnitIt).second;
-          for(CSCWireDigiCollection::const_iterator digiIt =
-             range.first; digiIt!=range.second; ++digiIt){
-             wire=(*digiIt).getWireGroup();
-             mult++;
-          }     // end of digis loop in layer
+  // do wires, strips and rechits present?
+  wire_strip_rechit_present = 0;
+  if (wirecltn.begin() != wirecltn.end())
+    wire_strip_rechit_present = wire_strip_rechit_present + 1;
+  if (strpcltn.begin() != strpcltn.end())
+    wire_strip_rechit_present = wire_strip_rechit_present + 2;
+  if (rechitcltn.begin() != rechitcltn.end())
+    wire_strip_rechit_present = wire_strip_rechit_present + 4;
 
-          // select layers with single wire hit
-          if(mult==1) {
-            if(m_single_wire_layer.find(idlayer) == m_single_wire_layer.end())
-              m_single_wire_layer[idlayer]=wire;
-          } // end of if(mult==1)
-       }   // end of cycle on detUnit
+  if (wire_strip_rechit_present == 7) {
+    //       std::cout<<"Event "<<nEventsAnalyzed<<std::endl;
+    //       std::cout<<std::endl;
 
-       // Looping thru rechit collection
-       CSCRecHit2DCollection::const_iterator recIt;
-       CSCRecHit2D::ADCContainer m_adc;
+    // cycle on wire collection for all CSC to select single wire hit layers
+    CSCWireDigiCollection::DigiRangeIterator wiredetUnitIt;
 
-       for(recIt = rechitcltn.begin(); recIt != rechitcltn.end(); ++recIt) {
-          CSCDetId id = (CSCDetId)(*recIt).cscDetId();
-          idlayer=indexer.dbIndex(id, channel);
-          idchamber=idlayer/10;
-          layer=id.layer();
-          // select layer with single wire rechit
-          if(m_single_wire_layer.find(idlayer) != m_single_wire_layer.end()) {
+    for (wiredetUnitIt = wirecltn.begin(); wiredetUnitIt != wirecltn.end(); ++wiredetUnitIt) {
+      const CSCDetId id = (*wiredetUnitIt).first;
+      idlayer = indexer.dbIndex(id, channel);
+      idchamber = idlayer / 10;
+      layer = id.layer();
+      // looping in the layer of given CSC
+      mult = 0;
+      wire = 0;
+      const CSCWireDigiCollection::Range& range = (*wiredetUnitIt).second;
+      for (CSCWireDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
+        wire = (*digiIt).getWireGroup();
+        mult++;
+      }  // end of digis loop in layer
 
-            if(recIt->nStrips()==3)  {        
-              // get 3X3 ADC Sum
-              unsigned int binmx=0;
-              float adcmax=0.0;
- 
-              for(unsigned int i=0;i<recIt->nStrips();i++) 
-		for(unsigned int j=0;j<recIt->nTimeBins();j++)
-		  if(recIt->adcs(i,j)>adcmax) {
-		    adcmax=recIt->adcs(i,j); 
-		    binmx=j;
-		  }
+      // select layers with single wire hit
+      if (mult == 1) {
+        if (m_single_wire_layer.find(idlayer) == m_single_wire_layer.end())
+          m_single_wire_layer[idlayer] = wire;
+      }  // end of if(mult==1)
+    }    // end of cycle on detUnit
 
-	      float adc_3_3_sum=0.0;
-	      //well, this really only works for 3 strips in readout - not sure the right fix for general case
-              for(unsigned int i=0;i<recIt->nStrips();i++) 
-		for(unsigned int j=binmx-1;j<=binmx+1;j++) 
-		  adc_3_3_sum+=recIt->adcs(i,j);
-		
+    // Looping thru rechit collection
+    CSCRecHit2DCollection::const_iterator recIt;
+    CSCRecHit2D::ADCContainer m_adc;
 
-               if(adc_3_3_sum > 0.0 &&  adc_3_3_sum < 2000.0) {
+    for (recIt = rechitcltn.begin(); recIt != rechitcltn.end(); ++recIt) {
+      CSCDetId id = (CSCDetId)(*recIt).cscDetId();
+      idlayer = indexer.dbIndex(id, channel);
+      idchamber = idlayer / 10;
+      layer = id.layer();
+      // select layer with single wire rechit
+      if (m_single_wire_layer.find(idlayer) != m_single_wire_layer.end()) {
+        if (recIt->nStrips() == 3) {
+          // get 3X3 ADC Sum
+          unsigned int binmx = 0;
+          float adcmax = 0.0;
 
-                 // temporary fix for ME1/1a to avoid triple entries
-                 int flag=0;
-                 if(id.station()==1 && id.ring()==4 &&  recIt->channels(1)>16)  flag=1;
-                 // end of temporary fix
-                 if(flag==0) {
+          for (unsigned int i = 0; i < recIt->nStrips(); i++)
+            for (unsigned int j = 0; j < recIt->nTimeBins(); j++)
+              if (recIt->adcs(i, j) > adcmax) {
+                adcmax = recIt->adcs(i, j);
+                binmx = j;
+              }
 
-                 wire= m_single_wire_layer[idlayer];
-                 int chambertype=id.iChamberType(id.station(),id.ring());
-                 int hvsgmtnmb=m_wire_hvsegm[chambertype][wire];
-                 int nmbofhvsegm=nmbhvsegm[chambertype-1];
-                 int location= (layer-1)*nmbofhvsegm+hvsgmtnmb;
-                
-                 ss<<"gas_gain_rechit_adc_3_3_sum_location_ME_"<<idchamber;
-                 name=ss.str(); ss.str("");
-                 if(id.endcap()==1) endcapstr = "+";
-                 ring=id.ring();
-                 if(id.station()==1 && id.ring()==4) ring=1;
-                 if(id.endcap()==2) endcapstr = "-"; 
-                 ss<<"Gas Gain Rechit ADC3X3 Sum ME"<<endcapstr<<
-                   id.station()<<"/"<<ring<<"/"<<id.chamber();
-                 title=ss.str(); ss.str("");
-                 float x=location;
-                 float y=adc_3_3_sum;
-                 histos->fill2DHist(x,y,name,title,30,1.0,31.0,50,0.0,2000.0,"GasGain");
+          float adc_3_3_sum = 0.0;
+          //well, this really only works for 3 strips in readout - not sure the right fix for general case
+          for (unsigned int i = 0; i < recIt->nStrips(); i++)
+            for (unsigned int j = binmx - 1; j <= binmx + 1; j++)
+              adc_3_3_sum += recIt->adcs(i, j);
 
-                 /*
+          if (adc_3_3_sum > 0.0 && adc_3_3_sum < 2000.0) {
+            // temporary fix for ME1/1a to avoid triple entries
+            int flag = 0;
+            if (id.station() == 1 && id.ring() == 4 && recIt->channels(1) > 16)
+              flag = 1;
+            // end of temporary fix
+            if (flag == 0) {
+              wire = m_single_wire_layer[idlayer];
+              int chambertype = id.iChamberType(id.station(), id.ring());
+              int hvsgmtnmb = m_wire_hvsegm[chambertype][wire];
+              int nmbofhvsegm = nmbhvsegm[chambertype - 1];
+              int location = (layer - 1) * nmbofhvsegm + hvsgmtnmb;
+
+              ss << "gas_gain_rechit_adc_3_3_sum_location_ME_" << idchamber;
+              name = ss.str();
+              ss.str("");
+              if (id.endcap() == 1)
+                endcapstr = "+";
+              ring = id.ring();
+              if (id.station() == 1 && id.ring() == 4)
+                ring = 1;
+              if (id.endcap() == 2)
+                endcapstr = "-";
+              ss << "Gas Gain Rechit ADC3X3 Sum ME" << endcapstr << id.station() << "/" << ring << "/" << id.chamber();
+              title = ss.str();
+              ss.str("");
+              float x = location;
+              float y = adc_3_3_sum;
+              histos->fill2DHist(x, y, name, title, 30, 1.0, 31.0, 50, 0.0, 2000.0, "GasGain");
+
+              /*
                    std::cout<<idchamber<<"   "<<id.station()<<" "<<id.ring()<<" "
                    <<id.chamber()<<"    "<<layer<<" "<< wire<<" "<<m_strip[1]<<" "<<
                    chambertype<<" "<< hvsgmtnmb<<" "<< nmbofhvsegm<<" "<< 
                    location<<"   "<<adc_3_3_sum<<std::endl;
                  */
-               } // end of if flag==0
-               } // end if(adcsum>0.0 && adcsum<2000.0)
-            } // end of if if(m_strip.size()==3
-          } // end of if single wire
-        } // end of looping thru rechit collection
-     }   // end of if wire and strip and rechit present 
+            }  // end of if flag==0
+          }    // end if(adcsum>0.0 && adcsum<2000.0)
+        }      // end of if if(m_strip.size()==3
+      }        // end of if single wire
+    }          // end of looping thru rechit collection
+  }            // end of if wire and strip and rechit present
 }
 
 //---------------------------------------------------------------------------
@@ -2428,63 +2721,65 @@ void CSCValidation::doGasGain(const CSCWireDigiCollection& wirecltn,
 //---------------------------------------------------------------------------
 
 void CSCValidation::doAFEBTiming(const CSCWireDigiCollection& wirecltn) {
-     ostringstream ss;
-     std::string name,title,endcapstr;
-     float x,y;
-     int wire,wiretbin,nmbwiretbin,layer,afeb,idlayer,idchamber;
-     int channel=0; // for  CSCIndexer::dbIndex(id, channel); irrelevant here
-     CSCIndexer indexer;
+  ostringstream ss;
+  std::string name, title, endcapstr;
+  float x, y;
+  int wire, wiretbin, nmbwiretbin, layer, afeb, idlayer, idchamber;
+  int channel = 0;  // for  CSCIndexer::dbIndex(id, channel); irrelevant here
+  CSCIndexer indexer;
 
-     if(wirecltn.begin() != wirecltn.end())  {
+  if (wirecltn.begin() != wirecltn.end()) {
+    //std::cout<<std::endl;
+    //std::cout<<"Event "<<nEventsAnalyzed<<std::endl;
+    //std::cout<<std::endl;
 
-       //std::cout<<std::endl;
-       //std::cout<<"Event "<<nEventsAnalyzed<<std::endl;
-       //std::cout<<std::endl;
+    // cycle on wire collection for all CSC
+    CSCWireDigiCollection::DigiRangeIterator wiredetUnitIt;
+    for (wiredetUnitIt = wirecltn.begin(); wiredetUnitIt != wirecltn.end(); ++wiredetUnitIt) {
+      const CSCDetId id = (*wiredetUnitIt).first;
+      idlayer = indexer.dbIndex(id, channel);
+      idchamber = idlayer / 10;
+      layer = id.layer();
 
-       // cycle on wire collection for all CSC
-       CSCWireDigiCollection::DigiRangeIterator wiredetUnitIt;
-       for(wiredetUnitIt=wirecltn.begin();wiredetUnitIt!=wirecltn.end();
-          ++wiredetUnitIt) {
-          const CSCDetId id = (*wiredetUnitIt).first;
-          idlayer=indexer.dbIndex(id, channel);
-          idchamber=idlayer/10;
-          layer=id.layer();
+      if (id.endcap() == 1)
+        endcapstr = "+";
+      if (id.endcap() == 2)
+        endcapstr = "-";
 
-          if (id.endcap() == 1) endcapstr = "+";
-          if (id.endcap() == 2) endcapstr = "-";
+      // looping in the layer of given CSC
 
-          // looping in the layer of given CSC
- 
-          const CSCWireDigiCollection::Range& range = (*wiredetUnitIt).second;
-          for(CSCWireDigiCollection::const_iterator digiIt =
-             range.first; digiIt!=range.second; ++digiIt){
-             wire=(*digiIt).getWireGroup();
-             wiretbin=(*digiIt).getTimeBin();
-             nmbwiretbin=(*digiIt).getTimeBinsOn().size();
-             afeb=3*((wire-1)/8)+(layer+1)/2;
-             
-             // Anode wire group time bin vs afeb for each CSC
-             x=afeb;
-             y=wiretbin;
-             ss<<"afeb_time_bin_vs_afeb_occupancy_ME_"<<idchamber;
-             name=ss.str(); ss.str("");
-             ss<<"Time Bin vs AFEB Occupancy ME"<<endcapstr<<id.station()<<"/"<<id.ring()<<"/"<< id.chamber();
-             title=ss.str(); ss.str("");
-             histos->fill2DHist(x,y,name,title,42,1.,43.,16,0.,16.,"AFEBTiming");
+      const CSCWireDigiCollection::Range& range = (*wiredetUnitIt).second;
+      for (CSCWireDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
+        wire = (*digiIt).getWireGroup();
+        wiretbin = (*digiIt).getTimeBin();
+        nmbwiretbin = (*digiIt).getTimeBinsOn().size();
+        afeb = 3 * ((wire - 1) / 8) + (layer + 1) / 2;
 
-             // Number of anode wire group time bin vs afeb for each CSC
-             x=afeb;
-             y=nmbwiretbin;
-             ss<<"nmb_afeb_time_bins_vs_afeb_ME_"<<idchamber;
-             name=ss.str(); ss.str("");
-             ss<<"Number of Time Bins vs AFEB ME"<<endcapstr<<id.station()<<"/"<<id.ring()<<"/"<< id.chamber();
-             title=ss.str(); 
-             ss.str("");
-             histos->fill2DHist(x,y,name,title,42,1.,43.,16,0.,16.,"AFEBTiming");
-             
-          }     // end of digis loop in layer
-       } // end of wire collection loop
-     } // end of      if(wirecltn.begin() != wirecltn.end())
+        // Anode wire group time bin vs afeb for each CSC
+        x = afeb;
+        y = wiretbin;
+        ss << "afeb_time_bin_vs_afeb_occupancy_ME_" << idchamber;
+        name = ss.str();
+        ss.str("");
+        ss << "Time Bin vs AFEB Occupancy ME" << endcapstr << id.station() << "/" << id.ring() << "/" << id.chamber();
+        title = ss.str();
+        ss.str("");
+        histos->fill2DHist(x, y, name, title, 42, 1., 43., 16, 0., 16., "AFEBTiming");
+
+        // Number of anode wire group time bin vs afeb for each CSC
+        x = afeb;
+        y = nmbwiretbin;
+        ss << "nmb_afeb_time_bins_vs_afeb_ME_" << idchamber;
+        name = ss.str();
+        ss.str("");
+        ss << "Number of Time Bins vs AFEB ME" << endcapstr << id.station() << "/" << id.ring() << "/" << id.chamber();
+        title = ss.str();
+        ss.str("");
+        histos->fill2DHist(x, y, name, title, 42, 1., 43., 16, 0., 16., "AFEBTiming");
+
+      }  // end of digis loop in layer
+    }    // end of wire collection loop
+  }      // end of      if(wirecltn.begin() != wirecltn.end())
 }
 
 //---------------------------------------------------------------------------
@@ -2493,59 +2788,59 @@ void CSCValidation::doAFEBTiming(const CSCWireDigiCollection& wirecltn) {
 //---------------------------------------------------------------------------
 
 void CSCValidation::doCompTiming(const CSCComparatorDigiCollection& compars) {
+  ostringstream ss;
+  std::string name, title, endcap;
+  float x, y;
+  int strip, tbin, cfeb, idlayer, idchamber;
+  int channel = 0;  // for  CSCIndexer::dbIndex(id, channel); irrelevant here
+  CSCIndexer indexer;
 
-     ostringstream ss;      std::string name,title,endcap;
-     float x,y;
-     int strip,tbin,cfeb,idlayer,idchamber;
-     int channel=0; // for  CSCIndexer::dbIndex(id, channel); irrelevant here
-     CSCIndexer indexer;
-                                                                                
-     if(compars.begin() != compars.end())  {
-                                                                                
-       //std::cout<<std::endl;
-       //std::cout<<"Event "<<nEventsAnalyzed<<std::endl;
-       //std::cout<<std::endl;
-                                                                                
-       // cycle on comparators collection for all CSC
-       CSCComparatorDigiCollection::DigiRangeIterator compdetUnitIt;
-       for(compdetUnitIt=compars.begin();compdetUnitIt!=compars.end();
-          ++compdetUnitIt) {
-          const CSCDetId id = (*compdetUnitIt).first;
-          idlayer=indexer.dbIndex(id, channel); // channel irrelevant here
-          idchamber=idlayer/10;
-                                                                                
-          if (id.endcap() == 1) endcap = "+";
-          if (id.endcap() == 2) endcap = "-";
-          // looping in the layer of given CSC
-          const CSCComparatorDigiCollection::Range& range = 
-          (*compdetUnitIt).second;
-          for(CSCComparatorDigiCollection::const_iterator digiIt =
-             range.first; digiIt!=range.second; ++digiIt){
-             strip=(*digiIt).getStrip();
-          /*
+  if (compars.begin() != compars.end()) {
+    //std::cout<<std::endl;
+    //std::cout<<"Event "<<nEventsAnalyzed<<std::endl;
+    //std::cout<<std::endl;
+
+    // cycle on comparators collection for all CSC
+    CSCComparatorDigiCollection::DigiRangeIterator compdetUnitIt;
+    for (compdetUnitIt = compars.begin(); compdetUnitIt != compars.end(); ++compdetUnitIt) {
+      const CSCDetId id = (*compdetUnitIt).first;
+      idlayer = indexer.dbIndex(id, channel);  // channel irrelevant here
+      idchamber = idlayer / 10;
+
+      if (id.endcap() == 1)
+        endcap = "+";
+      if (id.endcap() == 2)
+        endcap = "-";
+      // looping in the layer of given CSC
+      const CSCComparatorDigiCollection::Range& range = (*compdetUnitIt).second;
+      for (CSCComparatorDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
+        strip = (*digiIt).getStrip();
+        /*
           if(id.station()==1 && (id.ring()==1 || id.ring()==4))
              std::cout<<idchamber<<" "<<id.station()<<" "<<id.ring()<<" "
                       <<strip <<std::endl;  
           */
-             indexer.dbIndex(id, strip); // strips 1-16 of ME1/1a 
-                                         // become strips 65-80 of ME1/1 
-             tbin=(*digiIt).getTimeBin();
-             cfeb=(strip-1)/16+1;
-                                                                                
-             // time bin vs cfeb for each CSC
+        indexer.dbIndex(id, strip);  // strips 1-16 of ME1/1a
+                                     // become strips 65-80 of ME1/1
+        tbin = (*digiIt).getTimeBin();
+        cfeb = (strip - 1) / 16 + 1;
 
-             x=cfeb;
-             y=tbin;
-             ss<<"comp_time_bin_vs_cfeb_occupancy_ME_"<<idchamber;
-             name=ss.str(); ss.str("");
-             ss<<"Comparator Time Bin vs CFEB Occupancy ME"<<endcap<<
-                 id.station()<<"/"<< id.ring()<<"/"<< id.chamber();             
-             title=ss.str(); ss.str("");
-             histos->fill2DHist(x,y,name,title,5,1.,6.,16,0.,16.,"CompTiming");
+        // time bin vs cfeb for each CSC
 
-         }     // end of digis loop in layer
-       } // end of collection loop
-     } // end of      if(compars.begin() !=compars.end())
+        x = cfeb;
+        y = tbin;
+        ss << "comp_time_bin_vs_cfeb_occupancy_ME_" << idchamber;
+        name = ss.str();
+        ss.str("");
+        ss << "Comparator Time Bin vs CFEB Occupancy ME" << endcap << id.station() << "/" << id.ring() << "/"
+           << id.chamber();
+        title = ss.str();
+        ss.str("");
+        histos->fill2DHist(x, y, name, title, 5, 1., 6., 16, 0., 16., "CompTiming");
+
+      }  // end of digis loop in layer
+    }    // end of collection loop
+  }      // end of      if(compars.begin() !=compars.end())
 }
 
 //---------------------------------------------------------------------------
@@ -2554,84 +2849,88 @@ void CSCValidation::doCompTiming(const CSCComparatorDigiCollection& compars) {
 //---------------------------------------------------------------------------
 
 void CSCValidation::doADCTiming(const CSCRecHit2DCollection& rechitcltn) {
-  float  adc_3_3_sum,adc_3_3_wtbin,x,y;
-     int cfeb,idchamber,ring;
+  float adc_3_3_sum, adc_3_3_wtbin, x, y;
+  int cfeb, idchamber, ring;
 
-     std::string name,title,endcapstr;
-     ostringstream ss;
-     std::vector<float> zer(6,0.0);
+  std::string name, title, endcapstr;
+  ostringstream ss;
+  std::vector<float> zer(6, 0.0);
 
-     CSCIndexer indexer;
-     std::map<int,int>::iterator intIt;
+  CSCIndexer indexer;
+  std::map<int, int>::iterator intIt;
 
-     if(rechitcltn.begin() != rechitcltn.end()) {
+  if (rechitcltn.begin() != rechitcltn.end()) {
+    //   std::cout<<"Event "<<nEventsAnalyzed <<std::endl;
 
-  //   std::cout<<"Event "<<nEventsAnalyzed <<std::endl;
+    // Looping thru rechit collection
+    CSCRecHit2DCollection::const_iterator recIt;
+    CSCRecHit2D::ADCContainer m_adc;
+    for (recIt = rechitcltn.begin(); recIt != rechitcltn.end(); ++recIt) {
+      CSCDetId id = (CSCDetId)(*recIt).cscDetId();
+      // getting strips comprising rechit
+      if (recIt->nStrips() == 3) {
+        // get 3X3 ADC Sum
+        // get 3X3 ADC Sum
+        unsigned int binmx = 0;
+        float adcmax = 0.0;
 
-       // Looping thru rechit collection
-       CSCRecHit2DCollection::const_iterator recIt;
-       CSCRecHit2D::ADCContainer m_adc;
-       for(recIt = rechitcltn.begin(); recIt != rechitcltn.end(); ++recIt) {
-          CSCDetId id = (CSCDetId)(*recIt).cscDetId();
-          // getting strips comprising rechit
-          if(recIt->nStrips()==3) {
-            // get 3X3 ADC Sum
-              // get 3X3 ADC Sum
-              unsigned int binmx=0;
-              float adcmax=0.0;
- 
-              for(unsigned int i=0;i<recIt->nStrips();i++) 
-                for(unsigned int j=0;j<recIt->nTimeBins();j++)
-                  if(recIt->adcs(i,j)>adcmax) {
-                    adcmax=recIt->adcs(i,j); 
-                    binmx=j;
-                  }
+        for (unsigned int i = 0; i < recIt->nStrips(); i++)
+          for (unsigned int j = 0; j < recIt->nTimeBins(); j++)
+            if (recIt->adcs(i, j) > adcmax) {
+              adcmax = recIt->adcs(i, j);
+              binmx = j;
+            }
 
-               adc_3_3_sum=0.0;
-               //well, this really only works for 3 strips in readout - not sure the right fix for general case
-               for(unsigned int i=0;i<recIt->nStrips();i++) 
-                  for(unsigned int j=binmx-1;j<=binmx+1;j++) 
-                       adc_3_3_sum+=recIt->adcs(i,j);
-      
-      
-                  // ADC weighted time bin
-               if(adc_3_3_sum > 100.0) {
-                           
-      
-                 int centerStrip=recIt->channels(1); //take central from 3 strips;
-                 // temporary fix
-                 int flag=0;
-                 if(id.station()==1 && id.ring()==4 &&  centerStrip>16) flag=1;
-                 // end of temporary fix
-                 if(flag==0) {
-                      adc_3_3_wtbin=(*recIt).tpeak()/50;   //getTiming(strpcltn, id, centerStrip);
-                      idchamber=indexer.dbIndex(id, centerStrip)/10; //strips 1-16 ME1/1a
-                                                  // become strips 65-80 ME1/1 !!!
-                      /*
+        adc_3_3_sum = 0.0;
+        //well, this really only works for 3 strips in readout - not sure the right fix for general case
+        for (unsigned int i = 0; i < recIt->nStrips(); i++)
+          for (unsigned int j = binmx - 1; j <= binmx + 1; j++)
+            adc_3_3_sum += recIt->adcs(i, j);
+
+        // ADC weighted time bin
+        if (adc_3_3_sum > 100.0) {
+          int centerStrip = recIt->channels(1);  //take central from 3 strips;
+          // temporary fix
+          int flag = 0;
+          if (id.station() == 1 && id.ring() == 4 && centerStrip > 16)
+            flag = 1;
+          // end of temporary fix
+          if (flag == 0) {
+            adc_3_3_wtbin = (*recIt).tpeak() / 50;              //getTiming(strpcltn, id, centerStrip);
+            idchamber = indexer.dbIndex(id, centerStrip) / 10;  //strips 1-16 ME1/1a
+                                                                // become strips 65-80 ME1/1 !!!
+                                                                /*
                       if(id.station()==1 && (id.ring()==1 || id.ring()==4))
                       std::cout<<idchamber<<" "<<id.station()<<" "<<id.ring()<<" "<<m_strip[1]<<" "<<
                           "      "<<centerStrip<<
                              " "<<adc_3_3_wtbin<<"     "<<adc_3_3_sum<<std::endl;    
-                      */      
-                     ss<<"adc_3_3_weight_time_bin_vs_cfeb_occupancy_ME_"<<idchamber;
-                     name=ss.str(); ss.str("");
-      
-                     std::string endcapstr;
-                     if(id.endcap() == 1) endcapstr = "+";
-                     if(id.endcap() == 2) endcapstr = "-";
-                     ring=id.ring(); if(id.ring()==4) ring=1;
-                     ss<<"ADC 3X3 Weighted Time Bin vs CFEB Occupancy ME"
-                       <<endcapstr<<id.station()<<"/"<<ring<<"/"<<id.chamber();
-                     title=ss.str(); ss.str("");
-      
-                     cfeb=(centerStrip-1)/16+1;
-                     x=cfeb; y=adc_3_3_wtbin;
-                     histos->fill2DHist(x,y,name,title,5,1.,6.,80,-8.,8.,"ADCTiming");                                     
-                     } // end of if flag==0
-                 } // end of if (adc_3_3_sum > 100.0)
-            } // end of if if(m_strip.size()==3
-        } // end of the  pass thru CSCRecHit2DCollection
-    }  // end of if (rechitcltn.begin() != rechitcltn.end())
+                      */
+            ss << "adc_3_3_weight_time_bin_vs_cfeb_occupancy_ME_" << idchamber;
+            name = ss.str();
+            ss.str("");
+
+            std::string endcapstr;
+            if (id.endcap() == 1)
+              endcapstr = "+";
+            if (id.endcap() == 2)
+              endcapstr = "-";
+            ring = id.ring();
+            if (id.ring() == 4)
+              ring = 1;
+            ss << "ADC 3X3 Weighted Time Bin vs CFEB Occupancy ME" << endcapstr << id.station() << "/" << ring << "/"
+               << id.chamber();
+            title = ss.str();
+            ss.str("");
+
+            cfeb = (centerStrip - 1) / 16 + 1;
+            x = cfeb;
+            y = adc_3_3_wtbin;
+            histos->fill2DHist(x, y, name, title, 5, 1., 6., 80, -8., 8., "ADCTiming");
+          }  // end of if flag==0
+        }    // end of if (adc_3_3_sum > 100.0)
+      }      // end of if if(m_strip.size()==3
+    }        // end of the  pass thru CSCRecHit2DCollection
+  }          // end of if (rechitcltn.begin() != rechitcltn.end())
 }
 
 //---------------------------------------------------------------------------------------
@@ -2639,126 +2938,194 @@ void CSCValidation::doADCTiming(const CSCRecHit2DCollection& rechitcltn) {
 // Author: A. Deisher
 //---------------------------------------------------------------------------------------
 
-void CSCValidation::doTimeMonitoring(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments,
-				     edm::Handle<CSCALCTDigiCollection> alcts, edm::Handle<CSCCLCTDigiCollection> clcts,
-				     edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedlcts,
-				     edm::Handle<L1MuGMTReadoutCollection> pCollection, edm::ESHandle<CSCGeometry> cscGeom, 
-				     const edm::EventSetup& eventSetup, const edm::Event &event){
+void CSCValidation::doTimeMonitoring(edm::Handle<CSCRecHit2DCollection> recHits,
+                                     edm::Handle<CSCSegmentCollection> cscSegments,
+                                     edm::Handle<CSCALCTDigiCollection> alcts,
+                                     edm::Handle<CSCCLCTDigiCollection> clcts,
+                                     edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedlcts,
+                                     edm::Handle<L1MuGMTReadoutCollection> pCollection,
+                                     edm::ESHandle<CSCGeometry> cscGeom,
+                                     const edm::EventSetup& eventSetup,
+                                     const edm::Event& event) {
+  map<CSCDetId, float> segment_median_map;          //structure for storing the median time for segments in a chamber
+  map<CSCDetId, GlobalPoint> segment_position_map;  //structure for storing the global position for segments in a chamber
 
-  map<CSCDetId, float > segment_median_map; //structure for storing the median time for segments in a chamber 
-  map<CSCDetId, GlobalPoint > segment_position_map; //structure for storing the global position for segments in a chamber 
-  
   // -----------------------
   // loop over segments
   // -----------------------
-  int iSegment = 0; 
-  for(CSCSegmentCollection::const_iterator dSiter=cscSegments->begin(); dSiter != cscSegments->end(); dSiter++) {
+  int iSegment = 0;
+  for (CSCSegmentCollection::const_iterator dSiter = cscSegments->begin(); dSiter != cscSegments->end(); dSiter++) {
     iSegment++;
-    
-    CSCDetId id  = (CSCDetId)(*dSiter).cscDetId();
+
+    CSCDetId id = (CSCDetId)(*dSiter).cscDetId();
     LocalPoint localPos = (*dSiter).localPosition();
     GlobalPoint globalPosition = GlobalPoint(0.0, 0.0, 0.0);
     const CSCChamber* cscchamber = cscGeom->chamber(id);
     if (cscchamber) {
       globalPosition = cscchamber->toGlobal(localPos);
     }
-    
+
     // try to get the CSC recHits that contribute to this segment.
     std::vector<CSCRecHit2D> theseRecHits = (*dSiter).specificRecHits();
     int nRH = (*dSiter).nRecHits();
-    if (nRH < 4 ) continue;
-    
+    if (nRH < 4)
+      continue;
+
     //Store the recHit times of a segment in a vector for later sorting
     vector<float> non_zero;
-    
-    for ( vector<CSCRecHit2D>::const_iterator iRH = theseRecHits.begin(); iRH != theseRecHits.end(); iRH++) {
-      non_zero.push_back( iRH->tpeak());
-      
-    }// end rechit loop
-    
+
+    for (vector<CSCRecHit2D>::const_iterator iRH = theseRecHits.begin(); iRH != theseRecHits.end(); iRH++) {
+      non_zero.push_back(iRH->tpeak());
+
+    }  // end rechit loop
+
     //Sort the vector of hit times for this segment and average the center two
-    sort(non_zero.begin(),non_zero.end());
-    int middle_index = non_zero.size()/2;
-    float average_two = (non_zero.at(middle_index-1) + non_zero.at(middle_index))/2.;
-    if(non_zero.size()%2)
+    sort(non_zero.begin(), non_zero.end());
+    int middle_index = non_zero.size() / 2;
+    float average_two = (non_zero.at(middle_index - 1) + non_zero.at(middle_index)) / 2.;
+    if (non_zero.size() % 2)
       average_two = non_zero.at(middle_index);
 
     //If we've vetoed events with multiple segments per chamber, this should never overwrite informations
-    segment_median_map[id]=average_two;
-    segment_position_map[id]=globalPosition;
-    
-    double distToIP = sqrt(globalPosition.x()*globalPosition.x()+globalPosition.y()*globalPosition.y()+globalPosition.z()*globalPosition.z());
-     
-    histos->fillProfile(chamberSerial(id),average_two,"timeChamber","Segment mean time",601,-0.5,600.5,-400.,400.,"TimeMonitoring");
-    histos->fillProfileByType(id.chamber(),average_two,"timeChamberByType","Segment mean time by chamber",id,36,0.5,36.5,-400,400.,"TimeMonitoring");
-    histos->fill2DHist(distToIP,average_two,"seg_time_vs_distToIP","Segment time vs. Distance to IP",80,600.,1400.,800,-400,400.,"TimeMonitoring");
-    histos->fill2DHist(globalPosition.z(),average_two,"seg_time_vs_globZ","Segment time vs. z position",240,-1200,1200,800,-400.,400.,"TimeMonitoring");
-    histos->fill2DHist(fabs(globalPosition.z()),average_two,"seg_time_vs_absglobZ","Segment time vs. abs(z position)",120,0.,1200.,800,-400.,400.,"TimeMonitoring");
-    
-  }//end segment loop
-  
-   //Now that the information for each segment we're interest in is stored, it is time to go through the pairs and make plots
-  map<CSCDetId, float >::const_iterator it_outer; //for the outer loop 
-  map<CSCDetId, float >::const_iterator it_inner; //for the nested inner loop
-  for (it_outer = segment_median_map.begin(); it_outer != segment_median_map.end(); it_outer++){
-    
-    CSCDetId id_outer =  it_outer->first;
+    segment_median_map[id] = average_two;
+    segment_position_map[id] = globalPosition;
+
+    double distToIP = sqrt(globalPosition.x() * globalPosition.x() + globalPosition.y() * globalPosition.y() +
+                           globalPosition.z() * globalPosition.z());
+
+    histos->fillProfile(chamberSerial(id),
+                        average_two,
+                        "timeChamber",
+                        "Segment mean time",
+                        601,
+                        -0.5,
+                        600.5,
+                        -400.,
+                        400.,
+                        "TimeMonitoring");
+    histos->fillProfileByType(id.chamber(),
+                              average_two,
+                              "timeChamberByType",
+                              "Segment mean time by chamber",
+                              id,
+                              36,
+                              0.5,
+                              36.5,
+                              -400,
+                              400.,
+                              "TimeMonitoring");
+    histos->fill2DHist(distToIP,
+                       average_two,
+                       "seg_time_vs_distToIP",
+                       "Segment time vs. Distance to IP",
+                       80,
+                       600.,
+                       1400.,
+                       800,
+                       -400,
+                       400.,
+                       "TimeMonitoring");
+    histos->fill2DHist(globalPosition.z(),
+                       average_two,
+                       "seg_time_vs_globZ",
+                       "Segment time vs. z position",
+                       240,
+                       -1200,
+                       1200,
+                       800,
+                       -400.,
+                       400.,
+                       "TimeMonitoring");
+    histos->fill2DHist(fabs(globalPosition.z()),
+                       average_two,
+                       "seg_time_vs_absglobZ",
+                       "Segment time vs. abs(z position)",
+                       120,
+                       0.,
+                       1200.,
+                       800,
+                       -400.,
+                       400.,
+                       "TimeMonitoring");
+
+  }  //end segment loop
+
+  //Now that the information for each segment we're interest in is stored, it is time to go through the pairs and make plots
+  map<CSCDetId, float>::const_iterator it_outer;  //for the outer loop
+  map<CSCDetId, float>::const_iterator it_inner;  //for the nested inner loop
+  for (it_outer = segment_median_map.begin(); it_outer != segment_median_map.end(); it_outer++) {
+    CSCDetId id_outer = it_outer->first;
     float t_outer = it_outer->second;
-    
+
     //begin the inner loop
-    for (it_inner = segment_median_map.begin(); it_inner != segment_median_map.end(); it_inner++){
-      
-      CSCDetId id_inner =  it_inner->first;
+    for (it_inner = segment_median_map.begin(); it_inner != segment_median_map.end(); it_inner++) {
+      CSCDetId id_inner = it_inner->first;
       float t_inner = it_inner->second;
-      
-      // we're looking at ordered pairs, so combinations will be double counted 
+
+      // we're looking at ordered pairs, so combinations will be double counted
       // (chamber a, chamber b) will be counted as well as (chamber b, chamber a)
       // We will avoid (chamber a, chamber a) with the following line
-      if (chamberSerial(id_outer) == chamberSerial(id_inner)) continue;
-      
+      if (chamberSerial(id_outer) == chamberSerial(id_inner))
+        continue;
+
       // Calculate expected TOF (in ns units)
       // GlobalPoint gp_outer = segment_position_map.find(id_outer)->second;
       // GlobalPoint gp_inner = segment_position_map.find(id_inner)->second;
       // GlobalVector flight = gp_outer - gp_inner; //in cm
       // float TOF = flight.mag()/30.0;             //to ns
-      
+
       //Plot t(ME+) - t(ME-) for chamber pairs in the same stations and rings but opposite endcaps
-      if (id_outer.endcap() ==1 && id_inner.endcap() == 2 && id_outer.station() == id_inner.station() && id_outer.ring() == id_inner.ring() ){
-	histos->fill1DHist(t_outer-t_inner,"diff_opposite_endcaps","#Delta t [ME+]-[ME-] for chambers in same station and ring",800,-400.,400.,"TimeMonitoring");
-	histos->fill1DHistByType(t_outer-t_inner,"diff_opposite_endcaps_byType","#Delta t [ME+]-[ME-] for chambers in same station and ring",id_outer,800,-400.,400.,"TimeMonitoring");
+      if (id_outer.endcap() == 1 && id_inner.endcap() == 2 && id_outer.station() == id_inner.station() &&
+          id_outer.ring() == id_inner.ring()) {
+        histos->fill1DHist(t_outer - t_inner,
+                           "diff_opposite_endcaps",
+                           "#Delta t [ME+]-[ME-] for chambers in same station and ring",
+                           800,
+                           -400.,
+                           400.,
+                           "TimeMonitoring");
+        histos->fill1DHistByType(t_outer - t_inner,
+                                 "diff_opposite_endcaps_byType",
+                                 "#Delta t [ME+]-[ME-] for chambers in same station and ring",
+                                 id_outer,
+                                 800,
+                                 -400.,
+                                 400.,
+                                 "TimeMonitoring");
       }
 
-    }//end inner loop of segment pairs
-  }//end outer loop of segment pairs
+    }  //end inner loop of segment pairs
+  }    //end outer loop of segment pairs
 
   //if the digis, return here
-  if( !useDigis ) return;
+  if (!useDigis)
+    return;
 
-  //looking for the global trigger number 
+  //looking for the global trigger number
   vector<L1MuGMTReadoutRecord> L1Mrec = pCollection->getRecords();
   vector<L1MuGMTReadoutRecord>::const_iterator igmtrr;
   int L1GMT_BXN = -100;
   bool has_CSCTrigger = false;
   bool has_beamHaloTrigger = false;
-  for(igmtrr=L1Mrec.begin(); igmtrr!=L1Mrec.end(); igmtrr++) {
+  for (igmtrr = L1Mrec.begin(); igmtrr != L1Mrec.end(); igmtrr++) {
     std::vector<L1MuRegionalCand>::const_iterator iter1;
     std::vector<L1MuRegionalCand> rmc;
     // CSC
     int icsc = 0;
     rmc = igmtrr->getCSCCands();
-    for(iter1=rmc.begin(); iter1!=rmc.end(); iter1++) {
-      if ( !(*iter1).empty() ) {
+    for (iter1 = rmc.begin(); iter1 != rmc.end(); iter1++) {
+      if (!(*iter1).empty()) {
         icsc++;
-        int kQuality = (*iter1).quality();   // kQuality = 1 means beam halo
-        if (kQuality == 1) has_beamHaloTrigger = true;
+        int kQuality = (*iter1).quality();  // kQuality = 1 means beam halo
+        if (kQuality == 1)
+          has_beamHaloTrigger = true;
       }
     }
-    if (igmtrr->getBxInEvent() == 0 && icsc>0){
+    if (igmtrr->getBxInEvent() == 0 && icsc > 0) {
       //printf("L1 CSCCands exist.  L1MuGMTReadoutRecord BXN = %d \n", igmtrr->getBxNr());
       L1GMT_BXN = igmtrr->getBxNr();
       has_CSCTrigger = true;
-    }
-    else if (igmtrr->getBxInEvent() == 0 ) { 
+    } else if (igmtrr->getBxInEvent() == 0) {
       //printf("L1 CSCCands do not exist.  L1MuGMTReadoutRecord BXN = %d \n", igmtrr->getBxNr());
       L1GMT_BXN = igmtrr->getBxNr();
     }
@@ -2767,260 +3134,483 @@ void CSCValidation::doTimeMonitoring(edm::Handle<CSCRecHit2DCollection> recHits,
   // *************************************************
   // *** ALCT Digis **********************************
   // *************************************************
-  
-  int n_alcts = 0;
-  map<CSCDetId, int > ALCT_KeyWG_map; //structure for storing the key wire group for the first ALCT for each chamber
-  for (CSCALCTDigiCollection::DigiRangeIterator j=alcts->begin(); j!=alcts->end(); j++) {
-    const CSCALCTDigiCollection::Range& range =(*j).second;
-    const CSCDetId& idALCT = (*j).first;
-    for (CSCALCTDigiCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt){
-      // Valid digi in the chamber (or in neighbouring chamber)  
-      if((*digiIt).isValid()){
-	n_alcts++;
-	histos->fill1DHist( (*digiIt).getBX(), "ALCT_getBX","ALCT.getBX()",11,-0.5,10.5,"TimeMonitoring");
-	histos->fill1DHist( (*digiIt).getFullBX(), "ALCT_getFullBX","ALCT.getFullBX()",3601,-0.5,3600.5,"TimeMonitoring");
-	//if we don't already have digi information stored for this chamber, then we fill it
-	if (ALCT_KeyWG_map.find(idALCT.chamberId()) == ALCT_KeyWG_map.end()){
-	  ALCT_KeyWG_map[idALCT.chamberId()] = (*digiIt).getKeyWG();
-	  //printf("I did fill ALCT info for Chamber %d %d %d %d \n",idALCT.chamberId().endcap(), idALCT.chamberId().station(), idALCT.chamberId().ring(), idALCT.chamberId().chamber());
-	}
 
+  int n_alcts = 0;
+  map<CSCDetId, int> ALCT_KeyWG_map;  //structure for storing the key wire group for the first ALCT for each chamber
+  for (CSCALCTDigiCollection::DigiRangeIterator j = alcts->begin(); j != alcts->end(); j++) {
+    const CSCALCTDigiCollection::Range& range = (*j).second;
+    const CSCDetId& idALCT = (*j).first;
+    for (CSCALCTDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
+      // Valid digi in the chamber (or in neighbouring chamber)
+      if ((*digiIt).isValid()) {
+        n_alcts++;
+        histos->fill1DHist((*digiIt).getBX(), "ALCT_getBX", "ALCT.getBX()", 11, -0.5, 10.5, "TimeMonitoring");
+        histos->fill1DHist(
+            (*digiIt).getFullBX(), "ALCT_getFullBX", "ALCT.getFullBX()", 3601, -0.5, 3600.5, "TimeMonitoring");
+        //if we don't already have digi information stored for this chamber, then we fill it
+        if (ALCT_KeyWG_map.find(idALCT.chamberId()) == ALCT_KeyWG_map.end()) {
+          ALCT_KeyWG_map[idALCT.chamberId()] = (*digiIt).getKeyWG();
+          //printf("I did fill ALCT info for Chamber %d %d %d %d \n",idALCT.chamberId().endcap(), idALCT.chamberId().station(), idALCT.chamberId().ring(), idALCT.chamberId().chamber());
+        }
       }
     }
   }
-   
+
   // *************************************************
   // *** CLCT Digis **********************************
   // *************************************************
   int n_clcts = 0;
-  map<CSCDetId, int > CLCT_getFullBx_map; //structure for storing the pretrigger bxn for the first CLCT for each chamber
-  for (CSCCLCTDigiCollection::DigiRangeIterator j=clcts->begin(); j!=clcts->end(); j++) {
-    const CSCCLCTDigiCollection::Range& range =(*j).second;
+  map<CSCDetId, int> CLCT_getFullBx_map;  //structure for storing the pretrigger bxn for the first CLCT for each chamber
+  for (CSCCLCTDigiCollection::DigiRangeIterator j = clcts->begin(); j != clcts->end(); j++) {
+    const CSCCLCTDigiCollection::Range& range = (*j).second;
     const CSCDetId& idCLCT = (*j).first;
-    for (CSCCLCTDigiCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt){
-      // Valid digi in the chamber (or in neighbouring chamber) 
-      if((*digiIt).isValid()){
-	n_clcts++;
-	histos->fill1DHist( (*digiIt).getBX(), "CLCT_getBX","CLCT.getBX()",11,-0.5,10.5,"TimeMonitoring");
-	histos->fill1DHist( (*digiIt).getFullBX(), "CLCT_getFullBX","CLCT.getFullBX()",3601,-0.5,3600.5,"TimeMonitoring");
- 	//if we don't already have digi information stored for this chamber, then we fill it
-	if (CLCT_getFullBx_map.find(idCLCT.chamberId()) == CLCT_getFullBx_map.end()){
-	  CLCT_getFullBx_map[idCLCT.chamberId()] = (*digiIt).getFullBX();
-	  //printf("I did fill CLCT info for Chamber %d %d %d %d \n",idCLCT.chamberId().endcap(), idCLCT.chamberId().station(), idCLCT.chamberId().ring(), idCLCT.chamberId().chamber());
-	}
+    for (CSCCLCTDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
+      // Valid digi in the chamber (or in neighbouring chamber)
+      if ((*digiIt).isValid()) {
+        n_clcts++;
+        histos->fill1DHist((*digiIt).getBX(), "CLCT_getBX", "CLCT.getBX()", 11, -0.5, 10.5, "TimeMonitoring");
+        histos->fill1DHist(
+            (*digiIt).getFullBX(), "CLCT_getFullBX", "CLCT.getFullBX()", 3601, -0.5, 3600.5, "TimeMonitoring");
+        //if we don't already have digi information stored for this chamber, then we fill it
+        if (CLCT_getFullBx_map.find(idCLCT.chamberId()) == CLCT_getFullBx_map.end()) {
+          CLCT_getFullBx_map[idCLCT.chamberId()] = (*digiIt).getFullBX();
+          //printf("I did fill CLCT info for Chamber %d %d %d %d \n",idCLCT.chamberId().endcap(), idCLCT.chamberId().station(), idCLCT.chamberId().ring(), idCLCT.chamberId().chamber());
+        }
       }
     }
   }
-  
+
   // *************************************************
   // *** CorrelatedLCT Digis *************************
   // *************************************************
   int n_correlatedlcts = 0;
-  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j=correlatedlcts->begin(); j!=correlatedlcts->end(); j++) {
-    const CSCCorrelatedLCTDigiCollection::Range& range =(*j).second;
-    for (CSCCorrelatedLCTDigiCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt){
-      if((*digiIt).isValid()){
-	n_correlatedlcts++;
-	histos->fill1DHist( (*digiIt).getBX(), "CorrelatedLCTS_getBX","CorrelatedLCT.getBX()",11,-0.5,10.5,"TimeMonitoring");
+  for (CSCCorrelatedLCTDigiCollection::DigiRangeIterator j = correlatedlcts->begin(); j != correlatedlcts->end(); j++) {
+    const CSCCorrelatedLCTDigiCollection::Range& range = (*j).second;
+    for (CSCCorrelatedLCTDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
+      if ((*digiIt).isValid()) {
+        n_correlatedlcts++;
+        histos->fill1DHist(
+            (*digiIt).getBX(), "CorrelatedLCTS_getBX", "CorrelatedLCT.getBX()", 11, -0.5, 10.5, "TimeMonitoring");
       }
     }
   }
 
-
   int nRecHits = recHits->size();
   int nSegments = cscSegments->size();
-  if (has_CSCTrigger){
-    histos->fill1DHist(L1GMT_BXN,"BX_L1CSCCand","BX of L1 CSC Cand",4001,-0.5,4000.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,n_alcts,"n_ALCTs_v_BX_L1CSCCand","Number of ALCTs vs. BX of L1 CSC Cand",4001,-0.5,4000.5,51,-0.5,50.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,n_clcts,"n_CLCTs_v_BX_L1CSCCand","Number of CLCTs vs. BX of L1 CSC Cand",4001,-0.5,4000.5,51,-0.5,50.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,n_correlatedlcts,"n_CorrelatedLCTs_v_BX_L1CSCCand","Number of CorrelatedLCTs vs. BX of L1 CSC Cand",4001,-0.5,4000.5,51,-0.5,50.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,nRecHits,"n_RecHits_v_BX_L1CSCCand","Number of RecHits vs. BX of L1 CSC Cand",4001,-0.5,4000.5,101,-0.5,100.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,nSegments,"n_Segments_v_BX_L1CSCCand","Number of Segments vs. BX of L1 CSC Cand",4001,-0.5,4000.5,51,-0.5,50.5,"TimeMonitoring");
+  if (has_CSCTrigger) {
+    histos->fill1DHist(L1GMT_BXN, "BX_L1CSCCand", "BX of L1 CSC Cand", 4001, -0.5, 4000.5, "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       n_alcts,
+                       "n_ALCTs_v_BX_L1CSCCand",
+                       "Number of ALCTs vs. BX of L1 CSC Cand",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       51,
+                       -0.5,
+                       50.5,
+                       "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       n_clcts,
+                       "n_CLCTs_v_BX_L1CSCCand",
+                       "Number of CLCTs vs. BX of L1 CSC Cand",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       51,
+                       -0.5,
+                       50.5,
+                       "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       n_correlatedlcts,
+                       "n_CorrelatedLCTs_v_BX_L1CSCCand",
+                       "Number of CorrelatedLCTs vs. BX of L1 CSC Cand",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       51,
+                       -0.5,
+                       50.5,
+                       "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       nRecHits,
+                       "n_RecHits_v_BX_L1CSCCand",
+                       "Number of RecHits vs. BX of L1 CSC Cand",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       101,
+                       -0.5,
+                       100.5,
+                       "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       nSegments,
+                       "n_Segments_v_BX_L1CSCCand",
+                       "Number of Segments vs. BX of L1 CSC Cand",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       51,
+                       -0.5,
+                       50.5,
+                       "TimeMonitoring");
   }
-  if (has_CSCTrigger && has_beamHaloTrigger){
-    histos->fill1DHist(L1GMT_BXN,"BX_L1CSCCand_w_beamHalo","BX of L1 CSC (w beamHalo bit)",4001,-0.5,4000.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,n_alcts,"n_ALCTs_v_BX_L1CSCCand_w_beamHalo","Number of ALCTs vs. BX of L1 CSC Cand (w beamHalo bit)",4001,-0.5,4000.5,51,-0.5,50.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,n_clcts,"n_CLCTs_v_BX_L1CSCCand_w_beamHalo","Number of CLCTs vs. BX of L1 CSC Cand (w beamHalo bit)",4001,-0.5,4000.5,51,-0.5,50.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,n_correlatedlcts,"n_CorrelatedLCTs_v_BX_L1CSCCand_w_beamHalo","Number of CorrelatedLCTs vs. BX of L1 CSC Cand (w beamHalo bit)",4001,-0.5,4000.5,51,-0.5,50.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,nRecHits,"n_RecHits_v_BX_L1CSCCand_w_beamHalo","Number of RecHits vs. BX of L1 CSC Cand (w beamHalo bit)",4001,-0.5,4000.5,101,-0.5,100.5,"TimeMonitoring");
-    histos->fill2DHist(L1GMT_BXN,nSegments,"n_Segments_v_BX_L1CSCCand_w_beamHalo","Number of Segments vs. BX of L1 CSC Cand (w beamHalo bit)",4001,-0.5,4000.5,51,-0.5,50.5,"TimeMonitoring");
+  if (has_CSCTrigger && has_beamHaloTrigger) {
+    histos->fill1DHist(
+        L1GMT_BXN, "BX_L1CSCCand_w_beamHalo", "BX of L1 CSC (w beamHalo bit)", 4001, -0.5, 4000.5, "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       n_alcts,
+                       "n_ALCTs_v_BX_L1CSCCand_w_beamHalo",
+                       "Number of ALCTs vs. BX of L1 CSC Cand (w beamHalo bit)",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       51,
+                       -0.5,
+                       50.5,
+                       "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       n_clcts,
+                       "n_CLCTs_v_BX_L1CSCCand_w_beamHalo",
+                       "Number of CLCTs vs. BX of L1 CSC Cand (w beamHalo bit)",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       51,
+                       -0.5,
+                       50.5,
+                       "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       n_correlatedlcts,
+                       "n_CorrelatedLCTs_v_BX_L1CSCCand_w_beamHalo",
+                       "Number of CorrelatedLCTs vs. BX of L1 CSC Cand (w beamHalo bit)",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       51,
+                       -0.5,
+                       50.5,
+                       "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       nRecHits,
+                       "n_RecHits_v_BX_L1CSCCand_w_beamHalo",
+                       "Number of RecHits vs. BX of L1 CSC Cand (w beamHalo bit)",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       101,
+                       -0.5,
+                       100.5,
+                       "TimeMonitoring");
+    histos->fill2DHist(L1GMT_BXN,
+                       nSegments,
+                       "n_Segments_v_BX_L1CSCCand_w_beamHalo",
+                       "Number of Segments vs. BX of L1 CSC Cand (w beamHalo bit)",
+                       4001,
+                       -0.5,
+                       4000.5,
+                       51,
+                       -0.5,
+                       50.5,
+                       "TimeMonitoring");
   }
-  
+
   // *******************************************************************
-  // Get information from the TMB header.  
+  // Get information from the TMB header.
   // Can this eventually come out of the digis?
   // Taking code from EventFilter/CSCRawToDigis/CSCDCCUnpacker.cc
   // *******************************************************************
-  
+
   edm::ESHandle<CSCCrateMap> hcrate;
-  eventSetup.get<CSCCrateMapRcd>().get(hcrate); 
+  eventSetup.get<CSCCrateMapRcd>().get(hcrate);
   const CSCCrateMap* pcrate = hcrate.product();
-  
+
   /// Get a handle to the FED data collection
   edm::Handle<FEDRawDataCollection> rawdata;
-  event.getByToken( rd_token, rawdata);
+  event.getByToken(rd_token, rawdata);
   bool goodEvent = false;
-  // If set selective unpacking mode 
+  // If set selective unpacking mode
   // hardcoded examiner mask below to check for DCC and DDU level errors will be used first
   // then examinerMask for CSC level errors will be used during unpacking of each CSC block
   unsigned long dccBinCheckMask = 0x06080016;
-  unsigned int examinerMask = 0x1FEBF3F6; 
+  unsigned int examinerMask = 0x1FEBF3F6;
   unsigned int errorMask = 0x0;
 
-  for (int id=FEDNumbering::MINCSCFEDID; id<=FEDNumbering::MAXCSCFEDID; ++id) {
+  for (int id = FEDNumbering::MINCSCFEDID; id <= FEDNumbering::MAXCSCFEDID; ++id) {
     // loop over DCCs
     /// uncomment this for regional unpacking
     /// if (id!=SOME_ID) continue;
-    
+
     /// Take a reference to this FED's data
     const FEDRawData& fedData = rawdata->FEDData(id);
-    unsigned long length =  fedData.size();
-    
-    if (length>=32){ ///if fed has data then unpack it
+    unsigned long length = fedData.size();
+
+    if (length >= 32) {  ///if fed has data then unpack it
       CSCDCCExaminer* examiner = nullptr;
       std::stringstream examiner_out, examiner_err;
       goodEvent = true;
       ///examine event for integrity
       //CSCDCCExaminer examiner;
       examiner = new CSCDCCExaminer();
-      if( examinerMask&0x40000 ) examiner->crcCFEB(true);
-      if( examinerMask&0x8000  ) examiner->crcTMB (true);
-      if( examinerMask&0x0400  ) examiner->crcALCT(true);
+      if (examinerMask & 0x40000)
+        examiner->crcCFEB(true);
+      if (examinerMask & 0x8000)
+        examiner->crcTMB(true);
+      if (examinerMask & 0x0400)
+        examiner->crcALCT(true);
       examiner->setMask(examinerMask);
-      const short unsigned int *data = (short unsigned int *)fedData.data();
-     
-      if( examiner->check(data,long(fedData.size()/2)) < 0 )	{
-  	goodEvent=false;
-      } 
-      else {	  
-  	goodEvent=!(examiner->errors()&dccBinCheckMask);
-      }  
-      
+      const short unsigned int* data = (short unsigned int*)fedData.data();
+
+      if (examiner->check(data, long(fedData.size() / 2)) < 0) {
+        goodEvent = false;
+      } else {
+        goodEvent = !(examiner->errors() & dccBinCheckMask);
+      }
+
       if (goodEvent) {
-  	///get a pointer to data and pass it to constructor for unpacking
-  	CSCDCCExaminer * ptrExaminer = examiner;
-  	CSCDCCEventData dccData((short unsigned int *) fedData.data(),ptrExaminer);
-     	
-  	///get a reference to dduData
-  	const std::vector<CSCDDUEventData> & dduData = dccData.dduData();
-     	
-  	/// set default detid to that for E=+z, S=1, R=1, C=1, L=1
-  	CSCDetId layer(1, 1, 1, 1, 1);
-  	
-  	for (unsigned int iDDU=0; iDDU<dduData.size(); ++iDDU) {  // loop over DDUs
-  	  /// skip the DDU if its data has serious errors
-  	  /// define a mask for serious errors 
-  	  if (dduData[iDDU].trailer().errorstat()&errorMask) {
-  	    LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "DDU# " << iDDU << " has serious error - no digis unpacked! " <<
-  	      std::hex << dduData[iDDU].trailer().errorstat();
-  	    continue; // to next iteration of DDU loop
-  	  }
-  	  
-  	  ///get a reference to chamber data
-  	  const std::vector<CSCEventData> & cscData = dduData[iDDU].cscData();
-  	  for (unsigned int iCSC=0; iCSC<cscData.size(); ++iCSC) { // loop over CSCs
-  	    
-  	    int vmecrate = cscData[iCSC].dmbHeader()->crateID();
-  	    int dmb = cscData[iCSC].dmbHeader()->dmbID();
-  	    
-  	    ///adjust crate numbers for MTCC data
-  	    // SKIPPING MTCC redefinition of vmecrate
-  	    
-  	    int icfeb = 0;  /// default value for all digis not related to cfebs
-  	    int ilayer = 0; /// layer=0 flags entire chamber
-  	    
-  	    if ((vmecrate>=1)&&(vmecrate<=60) && (dmb>=1)&&(dmb<=10)&&(dmb!=6)) {
-  	      layer = pcrate->detId(vmecrate, dmb,icfeb,ilayer );
-  	    } 
-  	    else{
-	      LogTrace ("CSCTimingAlignment|CSCDCCUnpacker|CSCRawToDigi") << " detID input out of range!!! ";
-              LogTrace ("CSCTimingAlignment|CSCDCCUnpacker|CSCRawToDigi")
-                << " skipping chamber vme= " << vmecrate << " dmb= " << dmb;
-	      continue; // to next iteration of iCSC loop
-	    }
-	    
-  	    /// check alct data integrity 
-  	    int nalct = cscData[iCSC].dmbHeader()->nalct();
-  	    bool goodALCT=false;
-  	    //if (nalct&&(cscData[iCSC].dataPresent>>6&0x1)==1) {
-  	    if (nalct&&cscData[iCSC].alctHeader()) {  
-  	      if (cscData[iCSC].alctHeader()->check()){
-  		goodALCT=true;
-  	      }
-  	    }
-  	    
-  	    ///check tmb data integrity
-  	    int nclct = cscData[iCSC].dmbHeader()->nclct();
-  	    bool goodTMB=false;
-  	    if (nclct&&cscData[iCSC].tmbData()) {
-  	      if (cscData[iCSC].tmbHeader()->check()){
-  		if (cscData[iCSC].clctData()->check()) goodTMB=true; 
-  	      }
-  	    }  
-      	      
-  	    if (goodTMB && goodALCT) { 
+        ///get a pointer to data and pass it to constructor for unpacking
+        CSCDCCExaminer* ptrExaminer = examiner;
+        CSCDCCEventData dccData((short unsigned int*)fedData.data(), ptrExaminer);
 
-	      if (ALCT_KeyWG_map.find(layer) == ALCT_KeyWG_map.end()) {
-		printf("no ALCT info for Chamber %d %d %d %d \n",layer.endcap(), layer.station(), layer.ring(), layer.chamber());
-		continue;
-	      }
-	      if (CLCT_getFullBx_map.find(layer) == CLCT_getFullBx_map.end()) {
-		printf("no CLCT info for Chamber %d %d %d %d \n",layer.endcap(), layer.station(), layer.ring(), layer.chamber());
-		continue;
-	      }
-	      int ALCT0Key = ALCT_KeyWG_map.find(layer)->second;
-	      int CLCTPretrigger = CLCT_getFullBx_map.find(layer)->second;
+        ///get a reference to dduData
+        const std::vector<CSCDDUEventData>& dduData = dccData.dduData();
 
+        /// set default detid to that for E=+z, S=1, R=1, C=1, L=1
+        CSCDetId layer(1, 1, 1, 1, 1);
 
+        for (unsigned int iDDU = 0; iDDU < dduData.size(); ++iDDU) {  // loop over DDUs
+          /// skip the DDU if its data has serious errors
+          /// define a mask for serious errors
+          if (dduData[iDDU].trailer().errorstat() & errorMask) {
+            LogTrace("CSCDCCUnpacker|CSCRawToDigi") << "DDU# " << iDDU << " has serious error - no digis unpacked! "
+                                                    << std::hex << dduData[iDDU].trailer().errorstat();
+            continue;  // to next iteration of DDU loop
+          }
 
-  	      const CSCTMBHeader *tmbHead = cscData[iCSC].tmbHeader();
+          ///get a reference to chamber data
+          const std::vector<CSCEventData>& cscData = dduData[iDDU].cscData();
+          for (unsigned int iCSC = 0; iCSC < cscData.size(); ++iCSC) {  // loop over CSCs
 
-	      histos->fill1DHistByStation(tmbHead->BXNCount(),     "TMB_BXNCount"     ,"TMB_BXNCount"     , layer.chamberId(),3601,-0.5,3600.5,"TimeMonitoring");
-	      histos->fill1DHistByStation(tmbHead->ALCTMatchTime(),"TMB_ALCTMatchTime","TMB_ALCTMatchTime", layer.chamberId(),7,-0.5,6.5,"TimeMonitoring");
+            int vmecrate = cscData[iCSC].dmbHeader()->crateID();
+            int dmb = cscData[iCSC].dmbHeader()->dmbID();
 
-	      histos->fill1DHist(tmbHead->BXNCount(),     "TMB_BXNCount"     ,"TMB_BXNCount"     , 3601,-0.5,3600.5,"TimeMonitoring");
-	      histos->fill1DHist(tmbHead->ALCTMatchTime(),"TMB_ALCTMatchTime","TMB_ALCTMatchTime", 7,-0.5,6.5,"TimeMonitoring");
+            ///adjust crate numbers for MTCC data
+            // SKIPPING MTCC redefinition of vmecrate
 
-	      histos->fill1DHistByType(tmbHead->ALCTMatchTime(),"TMB_ALCTMatchTime","TMB_ALCTMatchTime",layer.chamberId(), 7,-0.5,6.5,"TimeMonitoring");
+            int icfeb = 0;   /// default value for all digis not related to cfebs
+            int ilayer = 0;  /// layer=0 flags entire chamber
 
-	      histos->fillProfile( chamberSerial(layer.chamberId()),tmbHead->ALCTMatchTime(),"prof_TMB_ALCTMatchTime","prof_TMB_ALCTMatchTime", 601,-0.5,600.5,-0.5,7.5,"TimeMonitoring");
-	      histos->fillProfile(ALCT0Key,tmbHead->ALCTMatchTime(),"prof_TMB_ALCTMatchTime_v_ALCT0KeyWG","prof_TMB_ALCTMatchTime_v_ALCT0KeyWG",128,-0.5,127.5,0,7,"TimeMonitoring");
-	      histos->fillProfileByType(ALCT0Key,tmbHead->ALCTMatchTime(),"prf_TMB_ALCTMatchTime_v_ALCT0KeyWG","prf_TMB_ALCTMatchTime_v_ALCT0KeyWG",layer.chamberId(),128,-0.5,127.5,0,7,"TimeMonitoring");
+            if ((vmecrate >= 1) && (vmecrate <= 60) && (dmb >= 1) && (dmb <= 10) && (dmb != 6)) {
+              layer = pcrate->detId(vmecrate, dmb, icfeb, ilayer);
+            } else {
+              LogTrace("CSCTimingAlignment|CSCDCCUnpacker|CSCRawToDigi") << " detID input out of range!!! ";
+              LogTrace("CSCTimingAlignment|CSCDCCUnpacker|CSCRawToDigi")
+                  << " skipping chamber vme= " << vmecrate << " dmb= " << dmb;
+              continue;  // to next iteration of iCSC loop
+            }
 
-	      //Attempt to make a few sum plots
+            /// check alct data integrity
+            int nalct = cscData[iCSC].dmbHeader()->nalct();
+            bool goodALCT = false;
+            //if (nalct&&(cscData[iCSC].dataPresent>>6&0x1)==1) {
+            if (nalct && cscData[iCSC].alctHeader()) {
+              if (cscData[iCSC].alctHeader()->check()) {
+                goodALCT = true;
+              }
+            }
 
-	      int TMB_ALCT_rel_L1A = tmbHead->BXNCount()-(CLCTPretrigger+2+tmbHead->ALCTMatchTime());
-	      if (TMB_ALCT_rel_L1A > 3563)
-		TMB_ALCT_rel_L1A = TMB_ALCT_rel_L1A - 3564;
-	      if (TMB_ALCT_rel_L1A < 0)
-		TMB_ALCT_rel_L1A = TMB_ALCT_rel_L1A + 3564;
+            ///check tmb data integrity
+            int nclct = cscData[iCSC].dmbHeader()->nclct();
+            bool goodTMB = false;
+            if (nclct && cscData[iCSC].tmbData()) {
+              if (cscData[iCSC].tmbHeader()->check()) {
+                if (cscData[iCSC].clctData()->check())
+                  goodTMB = true;
+              }
+            }
 
-	      //Plot TMB_ALCT_rel_L1A
-	      histos->fill1DHist(TMB_ALCT_rel_L1A,"h1D_TMB_ALCT_rel_L1A","h1D_TMB_ALCT_rel_L1A",11,144.5,155.5,"TimeMonitoring");
-	      histos->fill2DHist( chamberSerial(layer.chamberId()),TMB_ALCT_rel_L1A,"h2D_TMB_ALCT_rel_L1A","h2D_TMB_ALCT_rel_L1A", 601,-0.5,600.5,11,144.5,155.5,"TimeMonitoring");
-	      histos->fill2DHist( ringSerial(layer.chamberId()),TMB_ALCT_rel_L1A,"h2D_TMB_ALCT_rel_L1A_by_ring","h2D_TMB_ALCT_rel_L1A_by_ring",19,-9.5,9.5,11,144.5,155.5,"TimeMonitoring");
-	      histos->fillProfile( chamberSerial(layer.chamberId()),TMB_ALCT_rel_L1A,"prof_TMB_ALCT_rel_L1A","prof_TMB_ALCT_rel_L1A", 601,-0.5,600.5,145,155,"TimeMonitoring");
-	      histos->fillProfile( ringSerial(layer.chamberId()),TMB_ALCT_rel_L1A,"prof_TMB_ALCT_rel_L1A_by_ring","prof_TMB_ALCT_rel_L1A_by_ring",19,-9.5,9.5,145,155,"TimeMonitoring");
+            if (goodTMB && goodALCT) {
+              if (ALCT_KeyWG_map.find(layer) == ALCT_KeyWG_map.end()) {
+                printf("no ALCT info for Chamber %d %d %d %d \n",
+                       layer.endcap(),
+                       layer.station(),
+                       layer.ring(),
+                       layer.chamber());
+                continue;
+              }
+              if (CLCT_getFullBx_map.find(layer) == CLCT_getFullBx_map.end()) {
+                printf("no CLCT info for Chamber %d %d %d %d \n",
+                       layer.endcap(),
+                       layer.station(),
+                       layer.ring(),
+                       layer.chamber());
+                continue;
+              }
+              int ALCT0Key = ALCT_KeyWG_map.find(layer)->second;
+              int CLCTPretrigger = CLCT_getFullBx_map.find(layer)->second;
 
-	      histos->fill2DHist (ALCT0Key,TMB_ALCT_rel_L1A,"h2D_TMB_ALCT_rel_L1A_v_ALCT0KeyWG","h2D_TMB_ALCT_rel_L1A_v_ALCT0KeyWG",  128,-0.5,127.5,11,144.5,155.5,"TimeMonitoring");
-	      histos->fillProfile(ALCT0Key,TMB_ALCT_rel_L1A,"prof_TMB_ALCT_rel_L1A_v_ALCT0KeyWG","prof_TMB_ALCT_rel_L1A_v_ALCT0KeyWG",128,-0.5,127.5,145,155,"TimeMonitoring");
-	      histos->fillProfileByType(ALCT0Key,TMB_ALCT_rel_L1A,"prf_TMB_ALCT_rel_L1A_v_ALCT0KeyWG","prf_TMB_ALCT_rel_L1A_v_ALCT0KeyWG",layer.chamberId(),128,-0.5,127.5,145,155,"TimeMonitoring");
-	    }
+              const CSCTMBHeader* tmbHead = cscData[iCSC].tmbHeader();
 
-  	  } // end CSCData loop
-  	} // end ddu data loop
-      } // end if goodEvent
-      if (examiner!=nullptr) delete examiner;
-    }// end if non-zero fed data
-  } // end DCC loop for NON-REFERENCE
+              histos->fill1DHistByStation(tmbHead->BXNCount(),
+                                          "TMB_BXNCount",
+                                          "TMB_BXNCount",
+                                          layer.chamberId(),
+                                          3601,
+                                          -0.5,
+                                          3600.5,
+                                          "TimeMonitoring");
+              histos->fill1DHistByStation(tmbHead->ALCTMatchTime(),
+                                          "TMB_ALCTMatchTime",
+                                          "TMB_ALCTMatchTime",
+                                          layer.chamberId(),
+                                          7,
+                                          -0.5,
+                                          6.5,
+                                          "TimeMonitoring");
 
+              histos->fill1DHist(
+                  tmbHead->BXNCount(), "TMB_BXNCount", "TMB_BXNCount", 3601, -0.5, 3600.5, "TimeMonitoring");
+              histos->fill1DHist(
+                  tmbHead->ALCTMatchTime(), "TMB_ALCTMatchTime", "TMB_ALCTMatchTime", 7, -0.5, 6.5, "TimeMonitoring");
+
+              histos->fill1DHistByType(tmbHead->ALCTMatchTime(),
+                                       "TMB_ALCTMatchTime",
+                                       "TMB_ALCTMatchTime",
+                                       layer.chamberId(),
+                                       7,
+                                       -0.5,
+                                       6.5,
+                                       "TimeMonitoring");
+
+              histos->fillProfile(chamberSerial(layer.chamberId()),
+                                  tmbHead->ALCTMatchTime(),
+                                  "prof_TMB_ALCTMatchTime",
+                                  "prof_TMB_ALCTMatchTime",
+                                  601,
+                                  -0.5,
+                                  600.5,
+                                  -0.5,
+                                  7.5,
+                                  "TimeMonitoring");
+              histos->fillProfile(ALCT0Key,
+                                  tmbHead->ALCTMatchTime(),
+                                  "prof_TMB_ALCTMatchTime_v_ALCT0KeyWG",
+                                  "prof_TMB_ALCTMatchTime_v_ALCT0KeyWG",
+                                  128,
+                                  -0.5,
+                                  127.5,
+                                  0,
+                                  7,
+                                  "TimeMonitoring");
+              histos->fillProfileByType(ALCT0Key,
+                                        tmbHead->ALCTMatchTime(),
+                                        "prf_TMB_ALCTMatchTime_v_ALCT0KeyWG",
+                                        "prf_TMB_ALCTMatchTime_v_ALCT0KeyWG",
+                                        layer.chamberId(),
+                                        128,
+                                        -0.5,
+                                        127.5,
+                                        0,
+                                        7,
+                                        "TimeMonitoring");
+
+              //Attempt to make a few sum plots
+
+              int TMB_ALCT_rel_L1A = tmbHead->BXNCount() - (CLCTPretrigger + 2 + tmbHead->ALCTMatchTime());
+              if (TMB_ALCT_rel_L1A > 3563)
+                TMB_ALCT_rel_L1A = TMB_ALCT_rel_L1A - 3564;
+              if (TMB_ALCT_rel_L1A < 0)
+                TMB_ALCT_rel_L1A = TMB_ALCT_rel_L1A + 3564;
+
+              //Plot TMB_ALCT_rel_L1A
+              histos->fill1DHist(
+                  TMB_ALCT_rel_L1A, "h1D_TMB_ALCT_rel_L1A", "h1D_TMB_ALCT_rel_L1A", 11, 144.5, 155.5, "TimeMonitoring");
+              histos->fill2DHist(chamberSerial(layer.chamberId()),
+                                 TMB_ALCT_rel_L1A,
+                                 "h2D_TMB_ALCT_rel_L1A",
+                                 "h2D_TMB_ALCT_rel_L1A",
+                                 601,
+                                 -0.5,
+                                 600.5,
+                                 11,
+                                 144.5,
+                                 155.5,
+                                 "TimeMonitoring");
+              histos->fill2DHist(ringSerial(layer.chamberId()),
+                                 TMB_ALCT_rel_L1A,
+                                 "h2D_TMB_ALCT_rel_L1A_by_ring",
+                                 "h2D_TMB_ALCT_rel_L1A_by_ring",
+                                 19,
+                                 -9.5,
+                                 9.5,
+                                 11,
+                                 144.5,
+                                 155.5,
+                                 "TimeMonitoring");
+              histos->fillProfile(chamberSerial(layer.chamberId()),
+                                  TMB_ALCT_rel_L1A,
+                                  "prof_TMB_ALCT_rel_L1A",
+                                  "prof_TMB_ALCT_rel_L1A",
+                                  601,
+                                  -0.5,
+                                  600.5,
+                                  145,
+                                  155,
+                                  "TimeMonitoring");
+              histos->fillProfile(ringSerial(layer.chamberId()),
+                                  TMB_ALCT_rel_L1A,
+                                  "prof_TMB_ALCT_rel_L1A_by_ring",
+                                  "prof_TMB_ALCT_rel_L1A_by_ring",
+                                  19,
+                                  -9.5,
+                                  9.5,
+                                  145,
+                                  155,
+                                  "TimeMonitoring");
+
+              histos->fill2DHist(ALCT0Key,
+                                 TMB_ALCT_rel_L1A,
+                                 "h2D_TMB_ALCT_rel_L1A_v_ALCT0KeyWG",
+                                 "h2D_TMB_ALCT_rel_L1A_v_ALCT0KeyWG",
+                                 128,
+                                 -0.5,
+                                 127.5,
+                                 11,
+                                 144.5,
+                                 155.5,
+                                 "TimeMonitoring");
+              histos->fillProfile(ALCT0Key,
+                                  TMB_ALCT_rel_L1A,
+                                  "prof_TMB_ALCT_rel_L1A_v_ALCT0KeyWG",
+                                  "prof_TMB_ALCT_rel_L1A_v_ALCT0KeyWG",
+                                  128,
+                                  -0.5,
+                                  127.5,
+                                  145,
+                                  155,
+                                  "TimeMonitoring");
+              histos->fillProfileByType(ALCT0Key,
+                                        TMB_ALCT_rel_L1A,
+                                        "prf_TMB_ALCT_rel_L1A_v_ALCT0KeyWG",
+                                        "prf_TMB_ALCT_rel_L1A_v_ALCT0KeyWG",
+                                        layer.chamberId(),
+                                        128,
+                                        -0.5,
+                                        127.5,
+                                        145,
+                                        155,
+                                        "TimeMonitoring");
+            }
+
+          }  // end CSCData loop
+        }    // end ddu data loop
+      }      // end if goodEvent
+      if (examiner != nullptr)
+        delete examiner;
+    }  // end if non-zero fed data
+  }    // end DCC loop for NON-REFERENCE
 }
 
-
-void CSCValidation::endJob() {
-
-     std::cout<<"Events in "<<nEventsAnalyzed<<std::endl;
-}
+void CSCValidation::endJob() { std::cout << "Events in " << nEventsAnalyzed << std::endl; }
 
 DEFINE_FWK_MODULE(CSCValidation);
-

--- a/RecoLocalMuon/CSCValidation/src/CSCValidation.h
+++ b/RecoLocalMuon/CSCValidation/src/CSCValidation.h
@@ -64,7 +64,6 @@
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
-
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
@@ -119,86 +118,95 @@
 class CSCValidation : public edm::EDAnalyzer {
 public:
   /// Constructor
-  CSCValidation(const edm::ParameterSet& pset);
+  CSCValidation(const edm::ParameterSet &pset);
 
   /// Destructor
   ~CSCValidation() override;
 
   /// Perform the analysis
-  void analyze(const edm::Event & event, const edm::EventSetup& eventSetup) override;
+  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
   void endJob() override;
 
   // for noise module
-  struct ltrh
-  {
-    bool operator()(const CSCRecHit2D& rh1, const CSCRecHit2D& rh2) const
-    {
-      return ((rh1.localPosition()).x()-(rh2.localPosition()).x()) < 0;
+  struct ltrh {
+    bool operator()(const CSCRecHit2D &rh1, const CSCRecHit2D &rh2) const {
+      return ((rh1.localPosition()).x() - (rh2.localPosition()).x()) < 0;
     }
   };
 
-
 protected:
-
-private: 
-
+private:
   // these are the "modules"
   // if you would like to add code to CSCValidation, please do so by adding an
   // extra module in the form of an additional private member function
-  void  doOccupancies(edm::Handle<CSCStripDigiCollection> strips, edm::Handle<CSCWireDigiCollection> wires,
-                      edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments);
-  void  doStripDigis(edm::Handle<CSCStripDigiCollection> strips);
-  void  doWireDigis(edm::Handle<CSCWireDigiCollection> wires);
-  void  doRecHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::ESHandle<CSCGeometry> cscGeom);
-  void  doSimHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<edm::PSimHitContainer> simHits);
-  void  doPedestalNoise(edm::Handle<CSCStripDigiCollection> strips);
-  void  doSegments(edm::Handle<CSCSegmentCollection> cscSegments, edm::ESHandle<CSCGeometry> cscGeom);
-  void  doResolution(edm::Handle<CSCSegmentCollection> cscSegments, edm::ESHandle<CSCGeometry> cscGeom);
-  void  doEfficiencies(edm::Handle<CSCWireDigiCollection> wires, edm::Handle<CSCStripDigiCollection> strips,
-                       edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments,
-                       edm::ESHandle<CSCGeometry> cscGeom);
-  void  doGasGain(const CSCWireDigiCollection &, const CSCStripDigiCollection &, const CSCRecHit2DCollection &);
-  void  doCalibrations(const edm::EventSetup& eventSetup);
-  void  doAFEBTiming(const CSCWireDigiCollection &);
-  void  doCompTiming(const CSCComparatorDigiCollection &);
-  void  doADCTiming(const CSCRecHit2DCollection  &);
-  void  doNoiseHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments,
-                    edm::ESHandle<CSCGeometry> cscGeom,  edm::Handle<CSCStripDigiCollection> strips);
-  bool  doTrigger(edm::Handle<L1MuGMTReadoutCollection> pCollection);
-  void  doStandalone(edm::Handle<reco::TrackCollection> saMuons);
-  void  doTimeMonitoring(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments,
-                         edm::Handle<CSCALCTDigiCollection> alcts, edm::Handle<CSCCLCTDigiCollection> clcts,
-                         edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedlcts,
-                         edm::Handle<L1MuGMTReadoutCollection> pCollection, edm::ESHandle<CSCGeometry> cscGeom,
-                         const edm::EventSetup& eventSetup, const edm::Event &event);
-  bool  doHLT(edm::Handle<edm::TriggerResults> hltResults);
-
+  void doOccupancies(edm::Handle<CSCStripDigiCollection> strips,
+                     edm::Handle<CSCWireDigiCollection> wires,
+                     edm::Handle<CSCRecHit2DCollection> recHits,
+                     edm::Handle<CSCSegmentCollection> cscSegments);
+  void doStripDigis(edm::Handle<CSCStripDigiCollection> strips);
+  void doWireDigis(edm::Handle<CSCWireDigiCollection> wires);
+  void doRecHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::ESHandle<CSCGeometry> cscGeom);
+  void doSimHits(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<edm::PSimHitContainer> simHits);
+  void doPedestalNoise(edm::Handle<CSCStripDigiCollection> strips);
+  void doSegments(edm::Handle<CSCSegmentCollection> cscSegments, edm::ESHandle<CSCGeometry> cscGeom);
+  void doResolution(edm::Handle<CSCSegmentCollection> cscSegments, edm::ESHandle<CSCGeometry> cscGeom);
+  void doEfficiencies(edm::Handle<CSCWireDigiCollection> wires,
+                      edm::Handle<CSCStripDigiCollection> strips,
+                      edm::Handle<CSCRecHit2DCollection> recHits,
+                      edm::Handle<CSCSegmentCollection> cscSegments,
+                      edm::ESHandle<CSCGeometry> cscGeom);
+  void doGasGain(const CSCWireDigiCollection &, const CSCStripDigiCollection &, const CSCRecHit2DCollection &);
+  void doCalibrations(const edm::EventSetup &eventSetup);
+  void doAFEBTiming(const CSCWireDigiCollection &);
+  void doCompTiming(const CSCComparatorDigiCollection &);
+  void doADCTiming(const CSCRecHit2DCollection &);
+  void doNoiseHits(edm::Handle<CSCRecHit2DCollection> recHits,
+                   edm::Handle<CSCSegmentCollection> cscSegments,
+                   edm::ESHandle<CSCGeometry> cscGeom,
+                   edm::Handle<CSCStripDigiCollection> strips);
+  bool doTrigger(edm::Handle<L1MuGMTReadoutCollection> pCollection);
+  void doStandalone(edm::Handle<reco::TrackCollection> saMuons);
+  void doTimeMonitoring(edm::Handle<CSCRecHit2DCollection> recHits,
+                        edm::Handle<CSCSegmentCollection> cscSegments,
+                        edm::Handle<CSCALCTDigiCollection> alcts,
+                        edm::Handle<CSCCLCTDigiCollection> clcts,
+                        edm::Handle<CSCCorrelatedLCTDigiCollection> correlatedlcts,
+                        edm::Handle<L1MuGMTReadoutCollection> pCollection,
+                        edm::ESHandle<CSCGeometry> cscGeom,
+                        const edm::EventSetup &eventSetup,
+                        const edm::Event &event);
+  bool doHLT(edm::Handle<edm::TriggerResults> hltResults);
 
   // some useful functions
-  bool   filterEvents(edm::Handle<CSCRecHit2DCollection> recHits, edm::Handle<CSCSegmentCollection> cscSegments,
-                      edm::Handle<reco::TrackCollection> saMuons);
-  float  fitX(const CLHEP::HepMatrix& sp, const CLHEP::HepMatrix& ep);
-  float  getSignal(const CSCStripDigiCollection& stripdigis, CSCDetId idRH, int centerStrip);
-  float  getthisSignal(const CSCStripDigiCollection& stripdigis, CSCDetId idRH, int centerStrip);
-  int    getWidth(const CSCStripDigiCollection& stripdigis, CSCDetId idRH, int centerStrip);
-  void   findNonAssociatedRecHits(edm::ESHandle<CSCGeometry> cscGeom,  edm::Handle<CSCStripDigiCollection> strips);
-  int    chamberSerial( CSCDetId id );
-  int    ringSerial( CSCDetId id );
+  bool filterEvents(edm::Handle<CSCRecHit2DCollection> recHits,
+                    edm::Handle<CSCSegmentCollection> cscSegments,
+                    edm::Handle<reco::TrackCollection> saMuons);
+  float fitX(const CLHEP::HepMatrix &sp, const CLHEP::HepMatrix &ep);
+  float getSignal(const CSCStripDigiCollection &stripdigis, CSCDetId idRH, int centerStrip);
+  float getthisSignal(const CSCStripDigiCollection &stripdigis, CSCDetId idRH, int centerStrip);
+  int getWidth(const CSCStripDigiCollection &stripdigis, CSCDetId idRH, int centerStrip);
+  void findNonAssociatedRecHits(edm::ESHandle<CSCGeometry> cscGeom, edm::Handle<CSCStripDigiCollection> strips);
+  int chamberSerial(CSCDetId id);
+  int ringSerial(CSCDetId id);
 
   // these functions handle Stoyan's efficiency code
-  void  fillEfficiencyHistos(int bin, int flag);
-  void  getEfficiency(float bin, float Norm, std::vector<float> &eff);
-  void  histoEfficiency(TH1F *readHisto, TH1F *writeHisto);
-  double lineParametrization(double z1Position, double z2Position, double z1Direction){
-    double parameterLine = (z2Position-z1Position)/z1Direction;
+  void fillEfficiencyHistos(int bin, int flag);
+  void getEfficiency(float bin, float Norm, std::vector<float> &eff);
+  void histoEfficiency(TH1F *readHisto, TH1F *writeHisto);
+  double lineParametrization(double z1Position, double z2Position, double z1Direction) {
+    double parameterLine = (z2Position - z1Position) / z1Direction;
     return parameterLine;
   }
-  double extrapolate1D(double initPosition, double initDirection, double parameterOfTheLine){
-    double extrapolatedPosition = initPosition + initDirection*parameterOfTheLine;
-    return extrapolatedPosition; 
+  double extrapolate1D(double initPosition, double initDirection, double parameterOfTheLine) {
+    double extrapolatedPosition = initPosition + initDirection * parameterOfTheLine;
+    return extrapolatedPosition;
   }
-    bool withinSensitiveRegion(LocalPoint localPos, const std::array<const float, 4> & layerBounds, int station, int ring, float shiftFromEdge, float shiftFromDeadZone);
-
+  bool withinSensitiveRegion(LocalPoint localPos,
+                             const std::array<const float, 4> &layerBounds,
+                             int station,
+                             int ring,
+                             float shiftFromEdge,
+                             float shiftFromDeadZone);
 
   // counters
   int nEventsAnalyzed;
@@ -232,24 +240,24 @@ private:
   // quality filter parameters
   double pMin;
   double chisqMax;
-  int    nCSCHitsMin, nCSCHitsMax;
+  int nCSCHitsMin, nCSCHitsMax;
   double lengthMin, lengthMax;
   double deltaPhiMax;
   double polarMin, polarMax;
 
-  edm::EDGetTokenT<FEDRawDataCollection>           rd_token;
-  edm::EDGetTokenT<CSCWireDigiCollection>          wd_token;
-  edm::EDGetTokenT<CSCStripDigiCollection>         sd_token;
-  edm::EDGetTokenT<CSCComparatorDigiCollection>    cd_token;
-  edm::EDGetTokenT<CSCALCTDigiCollection>          al_token;
-  edm::EDGetTokenT<CSCCLCTDigiCollection>          cl_token;
+  edm::EDGetTokenT<FEDRawDataCollection> rd_token;
+  edm::EDGetTokenT<CSCWireDigiCollection> wd_token;
+  edm::EDGetTokenT<CSCStripDigiCollection> sd_token;
+  edm::EDGetTokenT<CSCComparatorDigiCollection> cd_token;
+  edm::EDGetTokenT<CSCALCTDigiCollection> al_token;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> cl_token;
   edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> co_token;
-  edm::EDGetTokenT<CSCRecHit2DCollection>          rh_token;
-  edm::EDGetTokenT<CSCSegmentCollection>           se_token;
-  edm::EDGetTokenT<L1MuGMTReadoutCollection>       l1_token;
-  edm::EDGetTokenT<edm::TriggerResults>            tr_token;
-  edm::EDGetTokenT<reco::TrackCollection>          sa_token;
-  edm::EDGetTokenT<edm::PSimHitContainer>          sh_token;
+  edm::EDGetTokenT<CSCRecHit2DCollection> rh_token;
+  edm::EDGetTokenT<CSCSegmentCollection> se_token;
+  edm::EDGetTokenT<L1MuGMTReadoutCollection> l1_token;
+  edm::EDGetTokenT<edm::TriggerResults> tr_token;
+  edm::EDGetTokenT<reco::TrackCollection> sa_token;
+  edm::EDGetTokenT<edm::PSimHitContainer> sh_token;
 
   // module on/off switches
   bool makeOccupancyPlots;
@@ -297,31 +305,30 @@ private:
   TH2I *hOSegments;
 
   /// Maps and vectors for module doGasGain()
-  std::vector<int>     nmbhvsegm;
-  std::map<int, std::vector<int> >   m_wire_hvsegm;
-  std::map<int, int>   m_single_wire_layer;
+  std::vector<int> nmbhvsegm;
+  std::map<int, std::vector<int> > m_wire_hvsegm;
+  std::map<int, int> m_single_wire_layer;
 
-  //maps to store the DetId and associated RecHits  
-  std::multimap<CSCDetId , CSCRecHit2D> AllRechits;
-  std::multimap<CSCDetId , CSCRecHit2D> SegRechits;
-  std::multimap<CSCDetId , CSCRecHit2D> NonAssociatedRechits;
-  std::map<CSCRecHit2D,float,ltrh> distRHmap;
+  //maps to store the DetId and associated RecHits
+  std::multimap<CSCDetId, CSCRecHit2D> AllRechits;
+  std::multimap<CSCDetId, CSCRecHit2D> SegRechits;
+  std::multimap<CSCDetId, CSCRecHit2D> NonAssociatedRechits;
+  std::map<CSCRecHit2D, float, ltrh> distRHmap;
 
-  int typeIndex(CSCDetId id){
+  int typeIndex(CSCDetId id) {
     // linearlized index bases on endcap, station, and ring
     int index = 0;
-    if (id.station() == 1){
+    if (id.station() == 1) {
       index = id.ring() + 1;
-      if (id.ring() == 4) index = 1;
-    }
-    else index = id.station()*2 + id.ring();
-    if (id.endcap() == 1) index = index + 10;
-    if (id.endcap() == 2) index = 11 - index;
+      if (id.ring() == 4)
+        index = 1;
+    } else
+      index = id.station() * 2 + id.ring();
+    if (id.endcap() == 1)
+      index = index + 10;
+    if (id.endcap() == 2)
+      index = 11 - index;
     return index;
   }
-  
-
-
-
 };
 #endif

--- a/RecoLocalTracker/Records/interface/TkPixelCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkPixelCPERecord.h
@@ -5,7 +5,7 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"      
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiPixelLorentzAngleRcd.h"
 //#include "CondFormats/DataRecord/interface/SiPixelCPEGenericErrorParmRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelGenErrorDBObjectRcd.h"
@@ -14,8 +14,14 @@
 
 #include "boost/mpl/vector.hpp"
 
-class  TkPixelCPERecord: public edm::eventsetup::DependentRecordImplementation<TkPixelCPERecord,
-  boost::mpl::vector<TrackerDigiGeometryRecord,IdealMagneticFieldRecord,SiPixelLorentzAngleRcd,SiPixelGenErrorDBObjectRcd,SiPixelTemplateDBObjectESProducerRcd,SiPixel2DTemplateDBObjectESProducerRcd> > {};
+class TkPixelCPERecord
+    : public edm::eventsetup::DependentRecordImplementation<TkPixelCPERecord,
+                                                            boost::mpl::vector<TrackerDigiGeometryRecord,
+                                                                               IdealMagneticFieldRecord,
+                                                                               SiPixelLorentzAngleRcd,
+                                                                               SiPixelGenErrorDBObjectRcd,
+                                                                               SiPixelTemplateDBObjectESProducerRcd,
+                                                                               SiPixel2DTemplateDBObjectESProducerRcd> > {
+};
 
-#endif 
-
+#endif

--- a/RecoLocalTracker/Records/interface/TkStripCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TkStripCPERecord.h
@@ -5,23 +5,21 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"                
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
 #include "boost/mpl/vector.hpp"
 
+class TkStripCPERecord
+    : public edm::eventsetup::DependentRecordImplementation<TkStripCPERecord,
+                                                            boost::mpl::vector<TrackerDigiGeometryRecord,
+                                                                               IdealMagneticFieldRecord,
+                                                                               SiStripLorentzAngleDepRcd,
+                                                                               SiStripBackPlaneCorrectionDepRcd,
+                                                                               SiStripConfObjectRcd,
+                                                                               SiStripLatencyRcd,
+                                                                               SiStripNoisesRcd,
+                                                                               SiStripApvGainRcd,
+                                                                               SiStripBadChannelRcd> > {};
 
-class  TkStripCPERecord: public edm::eventsetup::DependentRecordImplementation<TkStripCPERecord,
-  boost::mpl::vector<  TrackerDigiGeometryRecord,
-                       IdealMagneticFieldRecord,
-                       SiStripLorentzAngleDepRcd,
-                       SiStripBackPlaneCorrectionDepRcd,
-                       SiStripConfObjectRcd,
-                       SiStripLatencyRcd,
-                       SiStripNoisesRcd,
-                       SiStripApvGainRcd,
-                       SiStripBadChannelRcd
-                       > > {};
-
-#endif 
-
+#endif

--- a/RecoLocalTracker/Records/interface/TrackerCPERecord.h
+++ b/RecoLocalTracker/Records/interface/TrackerCPERecord.h
@@ -5,12 +5,12 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"                
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "boost/mpl/vector.hpp"
 
-class  TrackerCPERecord: public edm::eventsetup::DependentRecordImplementation<TrackerCPERecord,
-  boost::mpl::vector<TrackerDigiGeometryRecord,IdealMagneticFieldRecord> > {};
+class TrackerCPERecord : public edm::eventsetup::DependentRecordImplementation<
+                             TrackerCPERecord,
+                             boost::mpl::vector<TrackerDigiGeometryRecord, IdealMagneticFieldRecord> > {};
 
-#endif 
-
+#endif

--- a/RecoMET/METPUSubtraction/interface/MvaMEtUtilities.h
+++ b/RecoMET/METPUSubtraction/interface/MvaMEtUtilities.h
@@ -10,15 +10,12 @@
 #include <vector>
 #include <utility>
 
-class MvaMEtUtilities 
-{
- public:
+class MvaMEtUtilities {
+public:
+  enum { kPFCands = 0, kLeptons, kJets };
+  enum { kPF = 0, kChHS, kHS, kPU, kHSMinusNeutralPU };
 
-  enum {kPFCands=0,kLeptons,kJets};
-  enum {kPF=0, kChHS, kHS, kPU, kHSMinusNeutralPU};
-
- private:
-
+private:
   CommonMETData leptonsSum_;
   CommonMETData leptonsChSum_;
   CommonMETData pfCandSum_;
@@ -32,8 +29,7 @@ class MvaMEtUtilities
   double dzCut_;
   double ptThreshold_;
 
- public:
-  
+public:
   MvaMEtUtilities(const edm::ParameterSet& cfg);
   virtual ~MvaMEtUtilities();
 
@@ -48,42 +44,44 @@ class MvaMEtUtilities
   double getLeptonsSumMEY() const;
 
   double getLeptonsChSumMEX() const;
-  double getLeptonsChSumMEY() const; 
+  double getLeptonsChSumMEY() const;
 
   //recoil and sum computing functions ========
-  void computeAllSums(const std::vector<reco::PUSubMETCandInfo>& jets, 
-		      const std::vector<reco::PUSubMETCandInfo>& leptons,
-		      const std::vector<reco::PUSubMETCandInfo>& pfCandidates);
-  
+  void computeAllSums(const std::vector<reco::PUSubMETCandInfo>& jets,
+                      const std::vector<reco::PUSubMETCandInfo>& leptons,
+                      const std::vector<reco::PUSubMETCandInfo>& pfCandidates);
+
   CommonMETData computeRecoil(int metType);
 
-
- protected:
-
+protected:
   reco::Candidate::LorentzVector jetP4(const std::vector<reco::PUSubMETCandInfo>&, unsigned);
 
   // cuts on jet Id. MVA output in bins of jet Pt and eta
-  double mvaCut_[3][4][4]; 
+  double mvaCut_[3][4][4];
 
- private:
-
+private:
   //utilities functions for jets ===============
   bool passesMVA(const reco::Candidate::LorentzVector&, double);
 
-  std::vector<reco::PUSubMETCandInfo> cleanJets(const std::vector<reco::PUSubMETCandInfo>&, 
-						const std::vector<reco::PUSubMETCandInfo>&, double, double);
-  
-  //utilities functions for pf candidate ====== 
-  std::vector<reco::PUSubMETCandInfo> cleanPFCands(const std::vector<reco::PUSubMETCandInfo>&, 
-						   const std::vector<reco::PUSubMETCandInfo>&, double, bool);
+  std::vector<reco::PUSubMETCandInfo> cleanJets(const std::vector<reco::PUSubMETCandInfo>&,
+                                                const std::vector<reco::PUSubMETCandInfo>&,
+                                                double,
+                                                double);
 
-  CommonMETData computeCandSum( int compKey, double dZmax, int dZflag,
-				bool iCharged,  bool mvaPassFlag,
-				const std::vector<reco::PUSubMETCandInfo>& objects );
+  //utilities functions for pf candidate ======
+  std::vector<reco::PUSubMETCandInfo> cleanPFCands(const std::vector<reco::PUSubMETCandInfo>&,
+                                                   const std::vector<reco::PUSubMETCandInfo>&,
+                                                   double,
+                                                   bool);
 
+  CommonMETData computeCandSum(int compKey,
+                               double dZmax,
+                               int dZflag,
+                               bool iCharged,
+                               bool mvaPassFlag,
+                               const std::vector<reco::PUSubMETCandInfo>& objects);
 
   void finalize(CommonMETData& metData);
-
 };
 
 #endif

--- a/RecoMET/METPUSubtraction/interface/NoPileUpMEtAuxFunctions.h
+++ b/RecoMET/METPUSubtraction/interface/NoPileUpMEtAuxFunctions.h
@@ -14,41 +14,44 @@
 
 #include "CommonTools/RecoUtils/interface/PFCand_AssoMapAlgos.h"
 
- // 0 = neutral particle,
- // 1 = charged particle not associated to any vertex
- // 2 = charged particle associated to pile-up vertex
- // 3 = charged particle associated to vertex of hard-scatter event
+// 0 = neutral particle,
+// 1 = charged particle not associated to any vertex
+// 2 = charged particle associated to pile-up vertex
+// 3 = charged particle associated to vertex of hard-scatter event
 namespace noPuUtils {
-  enum {kNeutral=0, kChNoAssoc, kChPUAssoc, kChHSAssoc};
+  enum { kNeutral = 0, kChNoAssoc, kChPUAssoc, kChHSAssoc };
 
   typedef std::vector<std::pair<reco::PFCandidateRef, int> > CandQualityPairVector;
   typedef std::vector<std::pair<reco::VertexRef, int> > VertexQualityPairVector;
 
-  typedef edm::AssociationMap<edm::OneToManyWithQuality<reco::PFCandidateCollection, reco::VertexCollection, int> > 
-    reversedPFCandToVertexAssMap; 
-  
+  typedef edm::AssociationMap<edm::OneToManyWithQuality<reco::PFCandidateCollection, reco::VertexCollection, int> >
+      reversedPFCandToVertexAssMap;
 
+  // check if the pf candidate is associated with a vertex,
+  // return the type of association
+  int isVertexAssociated(const reco::PFCandidatePtr&,
+                         const PFCandToVertexAssMap&,
+                         const reco::VertexCollection&,
+                         double);
 
+  // reverse the vertex-pfcandidate association map
+  noPuUtils::reversedPFCandToVertexAssMap reversePFCandToVertexAssociation(const PFCandToVertexAssMap&);
 
-// check if the pf candidate is associated with a vertex, 
-// return the type of association
-int isVertexAssociated(const reco::PFCandidatePtr&, const PFCandToVertexAssMap&, const reco::VertexCollection&, double);
+  // check if the pf candidate is associated with a vertex,
+  // based over references keys
+  // return the type of association
+  int isVertexAssociated_fast(const reco::PFCandidateRef&,
+                              const noPuUtils::reversedPFCandToVertexAssMap&,
+                              const reco::VertexCollection&,
+                              double,
+                              int&,
+                              int);
 
-// reverse the vertex-pfcandidate association map
-noPuUtils::reversedPFCandToVertexAssMap reversePFCandToVertexAssociation(const PFCandToVertexAssMap&);
+  //promote a low quality association to a better level
+  // if dz justifies it
+  void promoteAssocToHSAssoc(
+      int quality, double z, const reco::VertexCollection& vertices, double dZ, int& vtxAssociationType, bool checkdR2);
 
-// check if the pf candidate is associated with a vertex,
-// based over references keys 
-// return the type of association
-int isVertexAssociated_fast(const reco::PFCandidateRef&, const noPuUtils::reversedPFCandToVertexAssMap&, const reco::VertexCollection&, double, int&, int);
-
-//promote a low quality association to a better level
-// if dz justifies it 
-void promoteAssocToHSAssoc(int quality, double z,
-			   const reco::VertexCollection& vertices,
-			   double dZ, int& vtxAssociationType, bool checkdR2);
-
-
-}
+}  // namespace noPuUtils
 
 #endif

--- a/RecoMET/METPUSubtraction/interface/NoPileUpMEtUtilities.h
+++ b/RecoMET/METPUSubtraction/interface/NoPileUpMEtUtilities.h
@@ -10,54 +10,52 @@
 
 #include <vector>
 
-class NoPileUpMEtUtilities
-{
-
- public:
-
-  enum {kOutsideJet=0,kWithin, kAll};
-  enum {kChHSMET=0, kChPUMET, kNeutralUncMET, kHadronicHSMET, kHadronicPUMET};
+class NoPileUpMEtUtilities {
+public:
+  enum { kOutsideJet = 0, kWithin, kAll };
+  enum { kChHSMET = 0, kChPUMET, kNeutralUncMET, kHadronicHSMET, kHadronicPUMET };
 
   NoPileUpMEtUtilities();
   ~NoPileUpMEtUtilities();
 
- 
   // general auxiliary functions
   void finalizeMEtData(CommonMETData&);
-  
+
   //-------------------------------------------------------------------------------
   // auxiliary functions for jets
-  reco::PUSubMETCandInfoCollection cleanJets(const reco::PUSubMETCandInfoCollection&, 
-					     const std::vector<reco::Candidate::LorentzVector>&, 
-					     double, bool);
-  
+  reco::PUSubMETCandInfoCollection cleanJets(const reco::PUSubMETCandInfoCollection&,
+                                             const std::vector<reco::Candidate::LorentzVector>&,
+                                             double,
+                                             bool);
+
   // auxiliary functions for PFCandidates
   reco::PUSubMETCandInfoCollection cleanPFCandidates(const reco::PUSubMETCandInfoCollection&,
-						     const std::vector<reco::Candidate::LorentzVector>&,
-						     double, bool);
+                                                     const std::vector<reco::Candidate::LorentzVector>&,
+                                                     double,
+                                                     bool);
 
- 
   // common internal functions for jets and pfCandidates
-  void computeAllSums( const reco::PUSubMETCandInfoCollection& jets,
-		       const reco::PUSubMETCandInfoCollection& pfCandidates);
+  void computeAllSums(const reco::PUSubMETCandInfoCollection& jets,
+                      const reco::PUSubMETCandInfoCollection& pfCandidates);
 
   CommonMETData computeRecoil(int metType, double& sumAbsPx, double& sumAbsPy);
   //-------------------------------------------------------------------------------
 
- private:
- 
+private:
   // common internal functions for jets and pfCandidates, to compute the different object sums
   CommonMETData computeCandidateSum(const reco::PUSubMETCandInfoCollection& cands,
-				    bool neutralFracOnly, double& sumAbsPx, double& sumAbsPy);
-  
-  reco::PUSubMETCandInfoCollection selectCandidates(const reco::PUSubMETCandInfoCollection& cands, 
-						    double minPt, double maxPt, int type, 
-						    bool isCharged, int isWithinJet);
+                                    bool neutralFracOnly,
+                                    double& sumAbsPx,
+                                    double& sumAbsPy);
 
+  reco::PUSubMETCandInfoCollection selectCandidates(const reco::PUSubMETCandInfoCollection& cands,
+                                                    double minPt,
+                                                    double maxPt,
+                                                    int type,
+                                                    bool isCharged,
+                                                    int isWithinJet);
 
- private:
-
-
+private:
   double minPtDef_;
   double maxPtDef_;
 
@@ -78,7 +76,6 @@ class NoPileUpMEtUtilities
   double nUncPfcSumAbsPy_;
   double nHSJetSumAbsPy_;
   double nPUJetSumAbsPy_;
-
 };
 
 #endif

--- a/RecoMET/METPUSubtraction/interface/PFMETAlgorithmMVA.h
+++ b/RecoMET/METPUSubtraction/interface/PFMETAlgorithmMVA.h
@@ -28,11 +28,8 @@
 #include <vector>
 #include <ostream>
 
-class PFMETAlgorithmMVA 
-{
-  
- public:
-
+class PFMETAlgorithmMVA {
+public:
   PFMETAlgorithmMVA(const edm::ParameterSet& cfg);
   ~PFMETAlgorithmMVA();
 
@@ -41,23 +38,23 @@ class PFMETAlgorithmMVA
   void setHasPhotons(bool hasPhotons) { hasPhotons_ = hasPhotons; }
 
   void setInput(const std::vector<reco::PUSubMETCandInfo>&,
-		const std::vector<reco::PUSubMETCandInfo>&,
-		const std::vector<reco::PUSubMETCandInfo>&,
-		const std::vector<reco::Vertex::Point>&);
+                const std::vector<reco::PUSubMETCandInfo>&,
+                const std::vector<reco::PUSubMETCandInfo>&,
+                const std::vector<reco::Vertex::Point>&);
 
   void evaluateMVA();
 
-  reco::Candidate::LorentzVector getMEt()    const { return mvaMEt_;    }
-  const reco::METCovMatrix&    getMEtCov() const { return mvaMEtCov_; }
+  reco::Candidate::LorentzVector getMEt() const { return mvaMEt_; }
+  const reco::METCovMatrix& getMEtCov() const { return mvaMEtCov_; }
 
-  double getU()     const { return mvaOutputU_;    }
-  double getDPhi()  const { return mvaOutputDPhi_;  }
+  double getU() const { return mvaOutputU_; }
+  double getDPhi() const { return mvaOutputDPhi_; }
   double getCovU1() const { return mvaOutputCovU1_; }
   double getCovU2() const { return mvaOutputCovU2_; }
-  
+
   void print(std::ostream&) const;
 
- private:
+private:
   const std::string updateVariableNames(std::string input);
   const GBRForest* loadMVAfromFile(const edm::FileInPath& inputFileName, const std::string& mvaName);
   const GBRForest* loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName);
@@ -68,27 +65,26 @@ class PFMETAlgorithmMVA
   const float evaluateCovU2();
 
   MvaMEtUtilities utils_;
-    
+
   std::string mvaNameU_;
   std::string mvaNameDPhi_;
   std::string mvaNameCovU1_;
   std::string mvaNameCovU2_;
 
-  int    mvaType_;
-  bool   hasPhotons_;
+  int mvaType_;
+  bool hasPhotons_;
 
   double dZcut_;
   std::unique_ptr<float[]> createFloatVector(std::vector<std::string> variableNames);
-  const float GetResponse(const GBRForest *Reader, std::vector<std::string> &variableNames);
+  const float GetResponse(const GBRForest* Reader, std::vector<std::string>& variableNames);
   void computeMET();
   std::map<std::string, float> var_;
-
 
   float* mvaInputU_;
   float* mvaInputDPhi_;
   float* mvaInputCovU1_;
   float* mvaInputCovU2_;
-  
+
   float mvaOutputU_;
   float mvaOutputDPhi_;
   float mvaOutputCovU1_;
@@ -98,7 +94,6 @@ class PFMETAlgorithmMVA
   std::vector<std::string> varForDPhi_;
   std::vector<std::string> varForCovU1_;
   std::vector<std::string> varForCovU2_;
-
 
   double sumLeptonPx_;
   double sumLeptonPy_;

--- a/RecoMET/METPUSubtraction/interface/PFMEtSignInterfaceBase.h
+++ b/RecoMET/METPUSubtraction/interface/PFMEtSignInterfaceBase.h
@@ -33,157 +33,151 @@
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-
 #include <TFile.h>
 #include <TH2.h>
 
-
-class PFMEtSignInterfaceBase
-{
- public:
-
+class PFMEtSignInterfaceBase {
+public:
   PFMEtSignInterfaceBase(const edm::ParameterSet&);
   ~PFMEtSignInterfaceBase();
 
   template <typename T>
-  metsig::SigInputObj compResolution(const T* particle) const
-  {
-    double pt   = particle->pt();
-    double eta  = particle->eta();
-    double phi  = particle->phi();
-    
-    if ( dynamic_cast<const reco::GsfElectron*>(particle) != nullptr ||
-	 dynamic_cast<const pat::Electron*>(particle) != nullptr ) {
+  metsig::SigInputObj compResolution(const T* particle) const {
+    double pt = particle->pt();
+    double eta = particle->eta();
+    double phi = particle->phi();
+
+    if (dynamic_cast<const reco::GsfElectron*>(particle) != nullptr ||
+        dynamic_cast<const pat::Electron*>(particle) != nullptr) {
       std::string particleType = "electron";
       // WARNING: SignAlgoResolutions::PFtype2 needs to be kept in sync with reco::PFCandidate::e !!
-      double dpt  = pfMEtResolution_->eval(metsig::PFtype2, metsig::ET,  pt, phi, eta);
+      double dpt = pfMEtResolution_->eval(metsig::PFtype2, metsig::ET, pt, phi, eta);
       double dphi = pfMEtResolution_->eval(metsig::PFtype2, metsig::PHI, pt, phi, eta);
-      //std::cout << "electron: pt = " << pt << ", eta = " << eta << ", phi = " << phi 
+      //std::cout << "electron: pt = " << pt << ", eta = " << eta << ", phi = " << phi
       //          << " --> dpt = " << dpt << ", dphi = " << dphi << std::endl;
       return metsig::SigInputObj(particleType, pt, phi, dpt, dphi);
-    } else if ( dynamic_cast<const reco::Photon*>(particle) != nullptr ||
-		dynamic_cast<const pat::Photon*>(particle) != nullptr ) {
+    } else if (dynamic_cast<const reco::Photon*>(particle) != nullptr ||
+               dynamic_cast<const pat::Photon*>(particle) != nullptr) {
       // CV: assume resolutions for photons to be identical to electron resolutions
       std::string particleType = "electron";
       // WARNING: SignAlgoResolutions::PFtype2 needs to be kept in sync with reco::PFCandidate::e !!
-      double dpt  = pfMEtResolution_->eval(metsig::PFtype2, metsig::ET,  pt, phi, eta);
+      double dpt = pfMEtResolution_->eval(metsig::PFtype2, metsig::ET, pt, phi, eta);
       double dphi = pfMEtResolution_->eval(metsig::PFtype2, metsig::PHI, pt, phi, eta);
-      //std::cout << "photon: pt = " << pt << ", eta = " << eta << ", phi = " << phi 
+      //std::cout << "photon: pt = " << pt << ", eta = " << eta << ", phi = " << phi
       //          << " --> dpt = " << dpt << ", dphi = " << dphi << std::endl;
       return metsig::SigInputObj(particleType, pt, phi, dpt, dphi);
-    } else if ( dynamic_cast<const reco::Muon*>(particle) != nullptr ||
-		dynamic_cast<const pat::Muon*>(particle) != nullptr ) {
+    } else if (dynamic_cast<const reco::Muon*>(particle) != nullptr ||
+               dynamic_cast<const pat::Muon*>(particle) != nullptr) {
       std::string particleType = "muon";
       double dpt, dphi;
       const reco::Track* muonTrack = nullptr;
-    if ( dynamic_cast<const pat::Muon*>(particle) != nullptr ) {
-      const pat::Muon* muon = dynamic_cast<const pat::Muon*>(particle);
-      if ( muon->track().isNonnull() && muon->track().isAvailable() ) muonTrack = muon->track().get();
-    } else if ( dynamic_cast<const reco::Muon*>(particle) != nullptr ) {
-      const reco::Muon* muon = dynamic_cast<const reco::Muon*>(particle);
-      if ( muon->track().isNonnull() && muon->track().isAvailable() ) muonTrack = muon->track().get();
-    } else assert(0);
-    if ( muonTrack ) {
-      dpt  = muonTrack->ptError();
-      dphi = pt*muonTrack->phiError(); // CV: pt*dphi is indeed correct
-    } else {
-      // WARNING: SignAlgoResolutions::PFtype3 needs to be kept in sync with reco::PFCandidate::mu !!
-      dpt  = pfMEtResolution_->eval(metsig::PFtype3, metsig::ET,  pt, phi, eta);
-      dphi = pfMEtResolution_->eval(metsig::PFtype3, metsig::PHI, pt, phi, eta);
-    }
-    //std::cout << "muon: pt = " << pt << ", eta = " << eta << ", phi = " << phi 
-    //	  << " --> dpt = " << dpt << ", dphi = " << dphi << std::endl;
-    return metsig::SigInputObj(particleType, pt, phi, dpt, dphi);
-    } else if ( dynamic_cast<const reco::PFTau*>(particle) != nullptr ||
-		dynamic_cast<const pat::Tau*>(particle) != nullptr ) {
+      if (dynamic_cast<const pat::Muon*>(particle) != nullptr) {
+        const pat::Muon* muon = dynamic_cast<const pat::Muon*>(particle);
+        if (muon->track().isNonnull() && muon->track().isAvailable())
+          muonTrack = muon->track().get();
+      } else if (dynamic_cast<const reco::Muon*>(particle) != nullptr) {
+        const reco::Muon* muon = dynamic_cast<const reco::Muon*>(particle);
+        if (muon->track().isNonnull() && muon->track().isAvailable())
+          muonTrack = muon->track().get();
+      } else
+        assert(0);
+      if (muonTrack) {
+        dpt = muonTrack->ptError();
+        dphi = pt * muonTrack->phiError();  // CV: pt*dphi is indeed correct
+      } else {
+        // WARNING: SignAlgoResolutions::PFtype3 needs to be kept in sync with reco::PFCandidate::mu !!
+        dpt = pfMEtResolution_->eval(metsig::PFtype3, metsig::ET, pt, phi, eta);
+        dphi = pfMEtResolution_->eval(metsig::PFtype3, metsig::PHI, pt, phi, eta);
+      }
+      //std::cout << "muon: pt = " << pt << ", eta = " << eta << ", phi = " << phi
+      //	  << " --> dpt = " << dpt << ", dphi = " << dphi << std::endl;
+      return metsig::SigInputObj(particleType, pt, phi, dpt, dphi);
+    } else if (dynamic_cast<const reco::PFTau*>(particle) != nullptr ||
+               dynamic_cast<const pat::Tau*>(particle) != nullptr) {
       // CV: use PFJet resolutions for PFTaus for now...
       //    (until PFTau specific resolutions are available)
-      if ( dynamic_cast<const pat::Tau*>(particle) != nullptr ) {
-	const pat::Tau* pfTau = dynamic_cast<const pat::Tau*>(particle);
-	return pfMEtResolution_->evalPFJet(pfTau->pfJetRef().get());
-      } else if ( dynamic_cast<const reco::PFTau*>(particle) != nullptr  ) {
-	const reco::PFTau* pfTau = dynamic_cast<const reco::PFTau*>(particle);
-	return pfMEtResolution_->evalPFJet(pfTau->jetRef().get());
-      } else assert(0);
-    } else if ( dynamic_cast<const reco::PFJet*>(particle) != nullptr ||
-		dynamic_cast<const pat::Jet*>(particle) != nullptr ) {
+      if (dynamic_cast<const pat::Tau*>(particle) != nullptr) {
+        const pat::Tau* pfTau = dynamic_cast<const pat::Tau*>(particle);
+        return pfMEtResolution_->evalPFJet(pfTau->pfJetRef().get());
+      } else if (dynamic_cast<const reco::PFTau*>(particle) != nullptr) {
+        const reco::PFTau* pfTau = dynamic_cast<const reco::PFTau*>(particle);
+        return pfMEtResolution_->evalPFJet(pfTau->jetRef().get());
+      } else
+        assert(0);
+    } else if (dynamic_cast<const reco::PFJet*>(particle) != nullptr ||
+               dynamic_cast<const pat::Jet*>(particle) != nullptr) {
       metsig::SigInputObj pfJetResolution;
-      if ( dynamic_cast<const reco::PFJet*>(particle) != nullptr ) {
-	const reco::PFJet* pfJet = dynamic_cast<const reco::PFJet*>(particle);
-	pfJetResolution = pfMEtResolution_->evalPFJet(pfJet);
-      } else if ( dynamic_cast<const pat::Jet*>(particle) != nullptr ) {
-	const pat::Jet* jet = dynamic_cast<const pat::Jet*>(particle);
-	if ( jet->isPFJet() ) {
-	  reco::PFJet pfJet(jet->p4(), jet->vertex(), jet->pfSpecific(), jet->getJetConstituents());
-	  pfJetResolution = pfMEtResolution_->evalPFJet(&pfJet);
-	} else throw cms::Exception("addPFMEtSignObjects")
-	    << "PAT jet not of PF-type !!\n";
-      } else assert(0);
+      if (dynamic_cast<const reco::PFJet*>(particle) != nullptr) {
+        const reco::PFJet* pfJet = dynamic_cast<const reco::PFJet*>(particle);
+        pfJetResolution = pfMEtResolution_->evalPFJet(pfJet);
+      } else if (dynamic_cast<const pat::Jet*>(particle) != nullptr) {
+        const pat::Jet* jet = dynamic_cast<const pat::Jet*>(particle);
+        if (jet->isPFJet()) {
+          reco::PFJet pfJet(jet->p4(), jet->vertex(), jet->pfSpecific(), jet->getJetConstituents());
+          pfJetResolution = pfMEtResolution_->evalPFJet(&pfJet);
+        } else
+          throw cms::Exception("addPFMEtSignObjects") << "PAT jet not of PF-type !!\n";
+      } else
+        assert(0);
       //std::cout << "pfJet: pt = " << pt << ", eta = " << eta << ", phi = " << phi << std::endl;
       // CV: apply additional jet energy resolution corrections
       //     not included in (PF)MEt significance algorithm yet
       //    (cf. CMS AN-11/400 vs. CMS AN-11/330)
-      if ( lut_ && pt > 10. ) {
-	double x = std::abs(eta);
-	double y = pt;
-	if ( x > lut_->GetXaxis()->GetXmin() && x < lut_->GetXaxis()->GetXmax() &&
-	     y > lut_->GetYaxis()->GetXmin() && y < lut_->GetYaxis()->GetXmax() ) {
-	  int binIndex = lut_->FindBin(x, y);
-	  double addJERcorrFactor = lut_->GetBinContent(binIndex);
-	  //std::cout << " addJERcorrFactor = " << addJERcorrFactor << std::endl;
-	  pfJetResolution.set(pfJetResolution.get_type(),
-			      pfJetResolution.get_energy(),
-			      pfJetResolution.get_phi(),
-			      addJERcorrFactor*pfJetResolution.get_sigma_e(),
-			      pfJetResolution.get_sigma_tan());
-	}
+      if (lut_ && pt > 10.) {
+        double x = std::abs(eta);
+        double y = pt;
+        if (x > lut_->GetXaxis()->GetXmin() && x < lut_->GetXaxis()->GetXmax() && y > lut_->GetYaxis()->GetXmin() &&
+            y < lut_->GetYaxis()->GetXmax()) {
+          int binIndex = lut_->FindBin(x, y);
+          double addJERcorrFactor = lut_->GetBinContent(binIndex);
+          //std::cout << " addJERcorrFactor = " << addJERcorrFactor << std::endl;
+          pfJetResolution.set(pfJetResolution.get_type(),
+                              pfJetResolution.get_energy(),
+                              pfJetResolution.get_phi(),
+                              addJERcorrFactor * pfJetResolution.get_sigma_e(),
+                              pfJetResolution.get_sigma_tan());
+        }
       }
       return pfJetResolution;
-    } else if ( dynamic_cast<const reco::PFCandidate*>(particle) != nullptr ) {
+    } else if (dynamic_cast<const reco::PFCandidate*>(particle) != nullptr) {
       const reco::PFCandidate* pfCandidate = dynamic_cast<const reco::PFCandidate*>(particle);
       //std::cout << "pfCandidate: pt = " << pt << ", eta = " << eta << ", phi = " << phi << std::endl;
       return pfMEtResolution_->evalPF(pfCandidate);
-    } else throw cms::Exception("addPFMEtSignObjects")
-	<< "Invalid type of particle:"
-	<< " valid types = { reco::GsfElectron/pat::Electron, reco::Photon/pat::Photon, reco::Muon/pat::Muon, reco::PFTau/pat::Tau," 
-	<< " reco::PFJet/pat::Jet, reco::PFCandidate } !!\n";
+    } else
+      throw cms::Exception("addPFMEtSignObjects")
+          << "Invalid type of particle:"
+          << " valid types = { reco::GsfElectron/pat::Electron, reco::Photon/pat::Photon, reco::Muon/pat::Muon, "
+             "reco::PFTau/pat::Tau,"
+          << " reco::PFJet/pat::Jet, reco::PFCandidate } !!\n";
   }
 
   template <typename T>
-  std::vector<metsig::SigInputObj> compResolution(const std::list<T*>& particles) const
-  {
-    LogDebug("compResolution")
-      << " particles: entries = " << particles.size() << std::endl;
-    
+  std::vector<metsig::SigInputObj> compResolution(const std::list<T*>& particles) const {
+    LogDebug("compResolution") << " particles: entries = " << particles.size() << std::endl;
+
     std::vector<metsig::SigInputObj> pfMEtSignObjects;
     addPFMEtSignObjects(pfMEtSignObjects, particles);
-    
+
     return pfMEtSignObjects;
   }
 
   reco::METCovMatrix operator()(const std::vector<metsig::SigInputObj>&) const;
 
   template <typename T>
-    reco::METCovMatrix operator()(const std::list<T*>& particles) const
-  {
+  reco::METCovMatrix operator()(const std::list<T*>& particles) const {
     std::vector<metsig::SigInputObj> pfMEtSignObjects = compResolution(particles);
     return this->operator()(pfMEtSignObjects);
   }
 
- protected:
-
-  template<typename T>
-  void addPFMEtSignObjects(std::vector<metsig::SigInputObj>& metSignObjects, 
-			   const std::list<T*>& particles) const
-  {
-    for ( typename std::list<T*>::const_iterator particle = particles.begin();
-	  particle != particles.end(); ++particle ) {
+protected:
+  template <typename T>
+  void addPFMEtSignObjects(std::vector<metsig::SigInputObj>& metSignObjects, const std::list<T*>& particles) const {
+    for (typename std::list<T*>::const_iterator particle = particles.begin(); particle != particles.end(); ++particle) {
       metSignObjects.push_back(this->compResolution(*particle));
     }
   }
 
- private:
-
+private:
   metsig::SignAlgoResolutions* pfMEtResolution_;
 
   // CV: look-up table for additional jet energy resolution corrections

--- a/RecoMET/METPUSubtraction/plugins/JVFJetIdProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/JVFJetIdProducer.cc
@@ -16,137 +16,147 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-
 enum { kNeutralJetPU, kNeutralJetNoPU };
 
-JVFJetIdProducer::JVFJetIdProducer(const edm::ParameterSet& cfg)
-{
+JVFJetIdProducer::JVFJetIdProducer(const edm::ParameterSet& cfg) {
   srcJets_ = consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcJets"));
 
   srcPFCandidates_ = consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates"));
-  srcPFCandToVertexAssociations_ = consumes<PFCandToVertexAssMap>(cfg.getParameter<edm::InputTag>("srcPFCandToVertexAssociations") );
-  srcHardScatterVertex_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcHardScatterVertex") );
+  srcPFCandToVertexAssociations_ =
+      consumes<PFCandToVertexAssMap>(cfg.getParameter<edm::InputTag>("srcPFCandToVertexAssociations"));
+  srcHardScatterVertex_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcHardScatterVertex"));
   minTrackPt_ = cfg.getParameter<double>("minTrackPt");
   dZcut_ = cfg.getParameter<double>("dZcut");
 
   JVFcut_ = cfg.getParameter<double>("JVFcut");
 
   std::string neutralJetOption_string = cfg.getParameter<std::string>("neutralJetOption");
-  if      ( neutralJetOption_string == "PU"   ) neutralJetOption_ = kNeutralJetPU;
-  else if ( neutralJetOption_string == "noPU" ) neutralJetOption_ = kNeutralJetNoPU;
-  else throw cms::Exception("JVFJetIdProducer")
-    << "Invalid Configuration Parameter 'neutralJetOption' = " << neutralJetOption_string << " !!\n";
+  if (neutralJetOption_string == "PU")
+    neutralJetOption_ = kNeutralJetPU;
+  else if (neutralJetOption_string == "noPU")
+    neutralJetOption_ = kNeutralJetNoPU;
+  else
+    throw cms::Exception("JVFJetIdProducer")
+        << "Invalid Configuration Parameter 'neutralJetOption' = " << neutralJetOption_string << " !!\n";
 
-  verbosity_ = ( cfg.exists("verbosity") ) ?
-    cfg.getParameter<int>("verbosity") : 0;
+  verbosity_ = (cfg.exists("verbosity")) ? cfg.getParameter<int>("verbosity") : 0;
 
-  produces<edm::ValueMap<double> >("Discriminant");
-  produces<edm::ValueMap<int> >("Id");
+  produces<edm::ValueMap<double>>("Discriminant");
+  produces<edm::ValueMap<int>>("Id");
 }
 
-JVFJetIdProducer::~JVFJetIdProducer()
-{
-// nothing to be done yet...
+JVFJetIdProducer::~JVFJetIdProducer() {
+  // nothing to be done yet...
 }
 
-namespace
-{
-  double computeJVF(const reco::PFJet& jet, 
-		    const PFCandToVertexAssMap& pfCandToVertexAssociations,
-		    const reco::VertexCollection& vertices, double dZ, double minTrackPt,
-		    int verbosity) {
+namespace {
+  double computeJVF(const reco::PFJet& jet,
+                    const PFCandToVertexAssMap& pfCandToVertexAssociations,
+                    const reco::VertexCollection& vertices,
+                    double dZ,
+                    double minTrackPt,
+                    int verbosity) {
+    LogDebug("computeJVF") << "<computeJVF>:" << std::endl
+                           << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi()
+                           << std::endl;
 
-    LogDebug ("computeJVF")
-      << "<computeJVF>:" << std::endl
-      << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << std::endl;
-    
-    double trackSum_isVtxAssociated    = 0.;
+    double trackSum_isVtxAssociated = 0.;
     double trackSum_isNotVtxAssociated = 0.;
-    
-    std::vector<reco::PFCandidatePtr> pfConsts = jet.getPFConstituents();
-    for ( std::vector<reco::PFCandidatePtr>::const_iterator jetConstituent = pfConsts.begin(); jetConstituent != pfConsts.end(); ++jetConstituent ) {
-      
-      if ( (*jetConstituent)->charge() == 0 ) continue;
-	
-	double trackPt = 0.;
-	if( (*jetConstituent)->gsfTrackRef().isNonnull() && (*jetConstituent)->gsfTrackRef().isAvailable() ) trackPt = (*jetConstituent)->gsfTrackRef()->pt();
-	else if ( (*jetConstituent)->trackRef().isNonnull() && (*jetConstituent)->trackRef().isAvailable() ) trackPt =(*jetConstituent)->trackRef()->pt();
-	else trackPt = (*jetConstituent)->pt();
 
-	if ( trackPt > minTrackPt ) {
-	  int jetConstituent_vtxAssociationType = noPuUtils::isVertexAssociated( (*jetConstituent), pfCandToVertexAssociations, vertices, dZ);
-	    //isVertexAssociated_fast(pfCandidateRef, pfCandToVertexAssociations_reversed, *hardScatterVertex, dZcut_, numWarnings_, maxWarnings_);
-	  bool jetConstituent_isVtxAssociated = (jetConstituent_vtxAssociationType == noPuUtils::kChHSAssoc ); 
-	  double jetConstituentPt = (*jetConstituent)->pt();
-	  if ( jetConstituent_isVtxAssociated ) {
-	    LogDebug ("computeJVF")
-	      << "associated track: Pt = " << (*jetConstituent)->pt() << ", eta = " << (*jetConstituent)->eta() << ", phi = " << (*jetConstituent)->phi() << std::endl
-	      << " (vtxAssociationType = " << jetConstituent_vtxAssociationType << ")" << std::endl;
-	    
-	    trackSum_isVtxAssociated += jetConstituentPt;
-	  } else {
-	    LogDebug ("computeJVF")
-	      << "unassociated track: Pt = " << (*jetConstituent)->pt() << ", eta = " << (*jetConstituent)->eta() << ", phi = " << (*jetConstituent)->phi() << std::endl
-	      << " (vtxAssociationType = " << jetConstituent_vtxAssociationType << ")" << std::endl;
-	   
-	    trackSum_isNotVtxAssociated += jetConstituentPt;
-	  }
-	}
+    std::vector<reco::PFCandidatePtr> pfConsts = jet.getPFConstituents();
+    for (std::vector<reco::PFCandidatePtr>::const_iterator jetConstituent = pfConsts.begin();
+         jetConstituent != pfConsts.end();
+         ++jetConstituent) {
+      if ((*jetConstituent)->charge() == 0)
+        continue;
+
+      double trackPt = 0.;
+      if ((*jetConstituent)->gsfTrackRef().isNonnull() && (*jetConstituent)->gsfTrackRef().isAvailable())
+        trackPt = (*jetConstituent)->gsfTrackRef()->pt();
+      else if ((*jetConstituent)->trackRef().isNonnull() && (*jetConstituent)->trackRef().isAvailable())
+        trackPt = (*jetConstituent)->trackRef()->pt();
+      else
+        trackPt = (*jetConstituent)->pt();
+
+      if (trackPt > minTrackPt) {
+        int jetConstituent_vtxAssociationType =
+            noPuUtils::isVertexAssociated((*jetConstituent), pfCandToVertexAssociations, vertices, dZ);
+        //isVertexAssociated_fast(pfCandidateRef, pfCandToVertexAssociations_reversed, *hardScatterVertex, dZcut_, numWarnings_, maxWarnings_);
+        bool jetConstituent_isVtxAssociated = (jetConstituent_vtxAssociationType == noPuUtils::kChHSAssoc);
+        double jetConstituentPt = (*jetConstituent)->pt();
+        if (jetConstituent_isVtxAssociated) {
+          LogDebug("computeJVF") << "associated track: Pt = " << (*jetConstituent)->pt()
+                                 << ", eta = " << (*jetConstituent)->eta() << ", phi = " << (*jetConstituent)->phi()
+                                 << std::endl
+                                 << " (vtxAssociationType = " << jetConstituent_vtxAssociationType << ")" << std::endl;
+
+          trackSum_isVtxAssociated += jetConstituentPt;
+        } else {
+          LogDebug("computeJVF") << "unassociated track: Pt = " << (*jetConstituent)->pt()
+                                 << ", eta = " << (*jetConstituent)->eta() << ", phi = " << (*jetConstituent)->phi()
+                                 << std::endl
+                                 << " (vtxAssociationType = " << jetConstituent_vtxAssociationType << ")" << std::endl;
+
+          trackSum_isNotVtxAssociated += jetConstituentPt;
+        }
+      }
     }
 
     double trackSum = trackSum_isVtxAssociated + trackSum_isNotVtxAssociated;
 
     double jvf = -1.;
-    if ( std::abs(jet.eta()) < 2.5 && trackSum > 5. ) {
-      jvf = trackSum_isVtxAssociated/trackSum;
+    if (std::abs(jet.eta()) < 2.5 && trackSum > 5.) {
+      jvf = trackSum_isVtxAssociated / trackSum;
     }
 
-    LogDebug ("computeJVF")
-      << "trackSum: associated = " << trackSum_isVtxAssociated << ", unassociated = " << trackSum_isNotVtxAssociated << std::endl
-      << " --> JVF = " << jvf << std::endl;
+    LogDebug("computeJVF") << "trackSum: associated = " << trackSum_isVtxAssociated
+                           << ", unassociated = " << trackSum_isNotVtxAssociated << std::endl
+                           << " --> JVF = " << jvf << std::endl;
 
     return jvf;
   }
-}
+}  // namespace
 
-void JVFJetIdProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-// get jets 
+void JVFJetIdProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  // get jets
   edm::Handle<reco::PFJetCollection> jets;
   evt.getByToken(srcJets_, jets);
-  
+
   // get PFCandidates
   edm::Handle<reco::PFCandidateCollection> pfCandidates;
   evt.getByToken(srcPFCandidates_, pfCandidates);
- 
+
   // get PFCandidate-to-vertex associations and "the" hard-scatter vertex
   edm::Handle<PFCandToVertexAssMap> pfCandToVertexAssociations;
   evt.getByToken(srcPFCandToVertexAssociations_, pfCandToVertexAssociations);
- 
+
   edm::Handle<reco::VertexCollection> hardScatterVertex;
   evt.getByToken(srcHardScatterVertex_, hardScatterVertex);
- 
+
   std::vector<double> jetIdDiscriminants;
   std::vector<int> jetIdFlags;
- 
+
   size_t numJets = jets->size();
-  for ( size_t iJet = 0; iJet < numJets; ++iJet ) {
+  for (size_t iJet = 0; iJet < numJets; ++iJet) {
     reco::PFJetRef jet(jets, iJet);
- 
-    double jetJVF = computeJVF(*jet, *pfCandToVertexAssociations, *hardScatterVertex, dZcut_, minTrackPt_, verbosity_ && jet->pt() > 20.);
+
+    double jetJVF = computeJVF(
+        *jet, *pfCandToVertexAssociations, *hardScatterVertex, dZcut_, minTrackPt_, verbosity_ && jet->pt() > 20.);
     jetIdDiscriminants.push_back(jetJVF);
- 
+
     int jetIdFlag = 0;
-    if ( jetJVF > JVFcut_ ) jetIdFlag = 255;
-    else if ( jetJVF < -0.5 && neutralJetOption_ == kNeutralJetNoPU ) jetIdFlag = 255;
+    if (jetJVF > JVFcut_)
+      jetIdFlag = 255;
+    else if (jetJVF < -0.5 && neutralJetOption_ == kNeutralJetNoPU)
+      jetIdFlag = 255;
     jetIdFlags.push_back(jetIdFlag);
   }
- 
+
   auto jetIdDiscriminants_ptr = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler jetIdDiscriminantFiller(*jetIdDiscriminants_ptr);
   jetIdDiscriminantFiller.insert(jets, jetIdDiscriminants.begin(), jetIdDiscriminants.end());
   jetIdDiscriminantFiller.fill();
- 
+
   auto jetIdFlags_ptr = std::make_unique<edm::ValueMap<int>>();
   edm::ValueMap<int>::Filler jetIdFlagFiller(*jetIdFlags_ptr);
   jetIdFlagFiller.insert(jets, jetIdFlags.begin(), jetIdFlags.end());

--- a/RecoMET/METPUSubtraction/plugins/JVFJetIdProducer.h
+++ b/RecoMET/METPUSubtraction/plugins/JVFJetIdProducer.h
@@ -18,22 +18,19 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h"
-#include "DataFormats/JetReco/interface/PileupJetIdentifier.h" 
+#include "DataFormats/JetReco/interface/PileupJetIdentifier.h"
 
 #include "RecoMET/METPUSubtraction/interface/NoPileUpMEtAuxFunctions.h"
 
-class JVFJetIdProducer : public edm::stream::EDProducer<>
-{
- public:
-  
+class JVFJetIdProducer : public edm::stream::EDProducer<> {
+public:
   JVFJetIdProducer(const edm::ParameterSet&);
   ~JVFJetIdProducer() override;
-  
- private:
-  
+
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
-  edm::EDGetTokenT<reco::PFJetCollection > srcJets_;
+
+  edm::EDGetTokenT<reco::PFJetCollection> srcJets_;
 
   edm::EDGetTokenT<reco::PFCandidateCollection> srcPFCandidates_;
   edm::EDGetTokenT<PFCandToVertexAssMap> srcPFCandToVertexAssociations_;
@@ -44,7 +41,7 @@ class JVFJetIdProducer : public edm::stream::EDProducer<>
   double JVFcut_;
 
   int neutralJetOption_;
-  
+
   int verbosity_;
 };
 

--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
@@ -3,35 +3,38 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 #include <algorithm>
 #include <cmath>
 
-const int flag_isWithinFakeJet      = 1;
-const int flag_isWithinSelectedJet  = 2;
+const int flag_isWithinFakeJet = 1;
+const int flag_isWithinSelectedJet = 2;
 const int flag_isWithinJetForMEtCov = 4;
 
-const double dR2Min = 0.001*0.001;
+const double dR2Min = 0.001 * 0.001;
 
 NoPileUpPFMEtDataProducer::NoPileUpPFMEtDataProducer(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-    looseJetIdAlgo_(nullptr),
-    pfMEtSignInterface_(nullptr)
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
+      looseJetIdAlgo_(nullptr),
+      pfMEtSignInterface_(nullptr) {
   srcJets_ = consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcJets"));
   srcJetIds_ = consumes<edm::ValueMap<int> >(cfg.getParameter<edm::InputTag>("srcJetIds"));
   minJetPt_ = cfg.getParameter<double>("minJetPt");
   std::string jetIdSelection_string = cfg.getParameter<std::string>("jetIdSelection");
-  if      ( jetIdSelection_string == "loose"  ) jetIdSelection_ = PileupJetIdentifier::kLoose;
-  else if ( jetIdSelection_string == "medium" ) jetIdSelection_ = PileupJetIdentifier::kMedium;
-  else if ( jetIdSelection_string == "tight"  ) jetIdSelection_ = PileupJetIdentifier::kTight;
-  else throw cms::Exception("NoPileUpPFMEtDataProducer")
-	 << "Invalid Configuration Parameter 'jetIdSelection' = " << jetIdSelection_string << " !!\n";
+  if (jetIdSelection_string == "loose")
+    jetIdSelection_ = PileupJetIdentifier::kLoose;
+  else if (jetIdSelection_string == "medium")
+    jetIdSelection_ = PileupJetIdentifier::kMedium;
+  else if (jetIdSelection_string == "tight")
+    jetIdSelection_ = PileupJetIdentifier::kTight;
+  else
+    throw cms::Exception("NoPileUpPFMEtDataProducer")
+        << "Invalid Configuration Parameter 'jetIdSelection' = " << jetIdSelection_string << " !!\n";
   jetEnOffsetCorrLabel_ = cfg.getParameter<std::string>("jetEnOffsetCorrLabel");
 
   srcPFCandidates_ = consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates"));
   srcPFCandidatesView_ = consumes<edm::View<reco::PFCandidate> >(cfg.getParameter<edm::InputTag>("srcPFCandidates"));
-  srcPFCandToVertexAssociations_ = consumes<PFCandToVertexAssMap>(cfg.getParameter<edm::InputTag>("srcPFCandToVertexAssociations"));
+  srcPFCandToVertexAssociations_ =
+      consumes<PFCandToVertexAssMap>(cfg.getParameter<edm::InputTag>("srcPFCandToVertexAssociations"));
   srcJetsForMEtCov_ = mayConsume<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcJetsForMEtCov"));
   minJetPtForMEtCov_ = cfg.getParameter<double>("minJetPtForMEtCov");
   srcHardScatterVertex_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcHardScatterVertex"));
@@ -44,230 +47,240 @@ NoPileUpPFMEtDataProducer::NoPileUpPFMEtDataProducer(const edm::ParameterSet& cf
 
   pfMEtSignInterface_ = new PFMEtSignInterfaceBase(cfg.getParameter<edm::ParameterSet>("resolution"));
 
-  maxWarnings_ = ( cfg.exists("maxWarnings") ) ?
-    cfg.getParameter<int>("maxWarnings") : 1;
+  maxWarnings_ = (cfg.exists("maxWarnings")) ? cfg.getParameter<int>("maxWarnings") : 1;
   numWarnings_ = 0;
 
-  verbosity_ = ( cfg.exists("verbosity") ) ?
-    cfg.getParameter<int>("verbosity") : 0;
+  verbosity_ = (cfg.exists("verbosity")) ? cfg.getParameter<int>("verbosity") : 0;
 
   produces<reco::PUSubMETCandInfoCollection>("jetInfos");
   produces<reco::PUSubMETCandInfoCollection>("pfCandInfos");
 }
 
-NoPileUpPFMEtDataProducer::~NoPileUpPFMEtDataProducer()
-{
+NoPileUpPFMEtDataProducer::~NoPileUpPFMEtDataProducer() {
   delete looseJetIdAlgo_;
   delete pfMEtSignInterface_;
 }
 
-namespace
-{
-  void setPFCandidateFlag(const reco::PFJet& pfJet, 
-			  const edm::View<reco::PFCandidate>& pfCandidateCollection, 
-			  std::vector<int>& flags, int value,
-			  int& numWarnings, int maxWarnings,
-			  std::vector<const reco::PFJet*>* pfCandidateToJetAssociations = nullptr) {
- 
+namespace {
+  void setPFCandidateFlag(const reco::PFJet& pfJet,
+                          const edm::View<reco::PFCandidate>& pfCandidateCollection,
+                          std::vector<int>& flags,
+                          int value,
+                          int& numWarnings,
+                          int maxWarnings,
+                          std::vector<const reco::PFJet*>* pfCandidateToJetAssociations = nullptr) {
     edm::ProductID viewProductID;
-    if(!pfCandidateCollection.empty()) {
+    if (!pfCandidateCollection.empty()) {
       viewProductID = pfCandidateCollection.ptrAt(0).id();
     }
 
     std::vector<reco::PFCandidatePtr> pfConsts = pfJet.getPFConstituents();
-    for ( std::vector<reco::PFCandidatePtr>::const_iterator pfJetConstituent = pfConsts.begin(); pfJetConstituent != pfConsts.end(); ++pfJetConstituent ) {
+    for (std::vector<reco::PFCandidatePtr>::const_iterator pfJetConstituent = pfConsts.begin();
+         pfJetConstituent != pfConsts.end();
+         ++pfJetConstituent) {
       std::vector<int> idxs;
       if (!pfCandidateCollection.empty() && pfJetConstituent->id() == viewProductID) {
-	idxs.push_back(pfJetConstituent->key());
+        idxs.push_back(pfJetConstituent->key());
       } else {
-	bool isMatched_fast = false;
-	if ( pfJetConstituent->key() < pfCandidateCollection.size() ) {
-	  edm::Ptr<reco::PFCandidate> pfCandidatePtr = pfCandidateCollection.ptrAt( pfJetConstituent->key() );
-	  double dR2 = deltaR2( (*pfJetConstituent)->p4(), pfCandidatePtr->p4());
-	  if ( dR2 < dR2Min ) {
-	    idxs.push_back(pfCandidatePtr.key());
-	    isMatched_fast = true;
-	  }
-	}
-	
-	if ( !isMatched_fast ) {
-	  size_t numPFCandidates = pfCandidateCollection.size();
-	  for ( size_t iPFCandidate = 0; iPFCandidate < numPFCandidates; ++iPFCandidate ) {
-	    edm::Ptr<reco::PFCandidate> pfCandidatePtr = pfCandidateCollection.ptrAt(iPFCandidate);
-	    double dR2 = deltaR2( (*pfJetConstituent)->p4(), pfCandidatePtr->p4());
-	    if ( dR2 < dR2Min ) {
-	      idxs.push_back(pfCandidatePtr.key());
-	    }
-	  }
-	  if ( numWarnings < maxWarnings ) {
-	    edm::LogWarning ("setPFCandidateFlag") 
-	      << " The productIDs of PFJetConstituent and PFCandidateCollection passed as function arguments don't match.\n" 
-	      << "NOTE: The return value will be unaffected, but the code will run MUCH slower !!";
-	    ++numWarnings;
-	  }
-	}
+        bool isMatched_fast = false;
+        if (pfJetConstituent->key() < pfCandidateCollection.size()) {
+          edm::Ptr<reco::PFCandidate> pfCandidatePtr = pfCandidateCollection.ptrAt(pfJetConstituent->key());
+          double dR2 = deltaR2((*pfJetConstituent)->p4(), pfCandidatePtr->p4());
+          if (dR2 < dR2Min) {
+            idxs.push_back(pfCandidatePtr.key());
+            isMatched_fast = true;
+          }
+        }
+
+        if (!isMatched_fast) {
+          size_t numPFCandidates = pfCandidateCollection.size();
+          for (size_t iPFCandidate = 0; iPFCandidate < numPFCandidates; ++iPFCandidate) {
+            edm::Ptr<reco::PFCandidate> pfCandidatePtr = pfCandidateCollection.ptrAt(iPFCandidate);
+            double dR2 = deltaR2((*pfJetConstituent)->p4(), pfCandidatePtr->p4());
+            if (dR2 < dR2Min) {
+              idxs.push_back(pfCandidatePtr.key());
+            }
+          }
+          if (numWarnings < maxWarnings) {
+            edm::LogWarning("setPFCandidateFlag")
+                << " The productIDs of PFJetConstituent and PFCandidateCollection passed as function arguments don't "
+                   "match.\n"
+                << "NOTE: The return value will be unaffected, but the code will run MUCH slower !!";
+            ++numWarnings;
+          }
+        }
       }
-      if ( !idxs.empty() ) {
-	for ( std::vector<int>::const_iterator idx = idxs.begin();
-	      idx != idxs.end(); ++idx ) {
-	  if ( (*idx) >= (int)flags.size() ) flags.resize(2*flags.size());
-	  flags[*idx] |= value;
-	  if ( pfCandidateToJetAssociations!=nullptr ) (*pfCandidateToJetAssociations)[*idx] = &pfJet;
-	}
+      if (!idxs.empty()) {
+        for (std::vector<int>::const_iterator idx = idxs.begin(); idx != idxs.end(); ++idx) {
+          if ((*idx) >= (int)flags.size())
+            flags.resize(2 * flags.size());
+          flags[*idx] |= value;
+          if (pfCandidateToJetAssociations != nullptr)
+            (*pfCandidateToJetAssociations)[*idx] = &pfJet;
+        }
       } else {
-	edm::LogError ("setPFCandidateFlag") 
-	  << " Failed to associated PFJetConstituent with index = " << pfJetConstituent->key() << " to any PFCandidate !!";
+        edm::LogError("setPFCandidateFlag")
+            << " Failed to associated PFJetConstituent with index = " << pfJetConstituent->key()
+            << " to any PFCandidate !!";
       }
     }
   }
-}
+}  // namespace
 
-void NoPileUpPFMEtDataProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  LogDebug ("produce")
-    << "<NoPileUpPFMEtDataProducer::produce>:\n"
-    << " moduleLabel = " << moduleLabel_ << std::endl;
-  
-  // get jets 
+void NoPileUpPFMEtDataProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  LogDebug("produce") << "<NoPileUpPFMEtDataProducer::produce>:\n"
+                      << " moduleLabel = " << moduleLabel_ << std::endl;
+
+  // get jets
   edm::Handle<reco::PFJetCollection> jets;
   evt.getByToken(srcJets_, jets);
 
   typedef edm::ValueMap<int> jetIdMap;
   edm::Handle<jetIdMap> jetIds;
   evt.getByToken(srcJetIds_, jetIds);
-  
+
   // get jets for computing contributions to PFMEt significance matrix
   edm::Handle<reco::PFJetCollection> jetsForMEtCov;
-  if ( ! srcJetsForMEtCov_.isUninitialized() ) evt.getByToken(srcJetsForMEtCov_, jetsForMEtCov);
- 
+  if (!srcJetsForMEtCov_.isUninitialized())
+    evt.getByToken(srcJetsForMEtCov_, jetsForMEtCov);
+
   // get PFCandidates
   edm::Handle<edm::View<reco::PFCandidate> > pfCandidates;
   evt.getByToken(srcPFCandidatesView_, pfCandidates);
- 
+
   std::vector<int> pfCandidateFlags(pfCandidates->size());
   std::vector<const reco::PFJet*> pfCandidateToJetAssociations(pfCandidates->size());
 
   edm::Handle<reco::PFCandidateCollection> pfCandidateHandle;
   evt.getByToken(srcPFCandidates_, pfCandidateHandle);
- 
+
   // get PFCandidate-to-vertex associations and "the" hard-scatter vertex
   edm::Handle<PFCandToVertexAssMap> pfCandToVertexAssociations;
   evt.getByToken(srcPFCandToVertexAssociations_, pfCandToVertexAssociations);
 
-  noPuUtils::reversedPFCandToVertexAssMap pfCandToVertexAssociations_reversed = noPuUtils::reversePFCandToVertexAssociation(*pfCandToVertexAssociations);
- 
+  noPuUtils::reversedPFCandToVertexAssMap pfCandToVertexAssociations_reversed =
+      noPuUtils::reversePFCandToVertexAssociation(*pfCandToVertexAssociations);
+
   edm::Handle<reco::VertexCollection> hardScatterVertex;
   evt.getByToken(srcHardScatterVertex_, hardScatterVertex);
-  
+
   auto jetInfos = std::make_unique<reco::PUSubMETCandInfoCollection>();
   auto pfCandInfos = std::make_unique<reco::PUSubMETCandInfoCollection>();
- 
+
   const JetCorrector* jetEnOffsetCorrector = nullptr;
-  if ( !jetEnOffsetCorrLabel_.empty() ) {
+  if (!jetEnOffsetCorrLabel_.empty()) {
     jetEnOffsetCorrector = JetCorrector::getJetCorrector(jetEnOffsetCorrLabel_, es);
-    if ( !jetEnOffsetCorrector )  
+    if (!jetEnOffsetCorrector)
       throw cms::Exception("NoPileUpPFMEtDataProducer::produce")
-	<< "Failed to access Jet corrections for = " << jetEnOffsetCorrLabel_ << " !!\n";
+          << "Failed to access Jet corrections for = " << jetEnOffsetCorrLabel_ << " !!\n";
   }
- 
+
   size_t numJets = jets->size();
-  for ( size_t iJet = 0; iJet < numJets; ++iJet ) {
+  for (size_t iJet = 0; iJet < numJets; ++iJet) {
     reco::PFJetRef jet(jets, iJet);
-    if ( !(jet->pt() > minJetPt_)  ) continue;
-   
+    if (!(jet->pt() > minJetPt_))
+      continue;
+
     bool passesLooseJetId = (*looseJetIdAlgo_)(*jet);
-    if ( !passesLooseJetId ) {
+    if (!passesLooseJetId) {
       setPFCandidateFlag(*jet, *pfCandidates, pfCandidateFlags, flag_isWithinFakeJet, numWarnings_, maxWarnings_);
     }
     setPFCandidateFlag(*jet, *pfCandidates, pfCandidateFlags, flag_isWithinSelectedJet, numWarnings_, maxWarnings_);
-    
+
     reco::PUSubMETCandInfo jetInfo;
-    jetInfo.setP4( jet->p4() );
+    jetInfo.setP4(jet->p4());
     int jetId = (*jetIds)[jet];
     bool jetIdSelection_passed = PileupJetIdentifier::passJetId(jetId, jetIdSelection_);
-    jetInfo.setType( ( jetIdSelection_passed ) ?
-		     reco::PUSubMETCandInfo::kHS : reco::PUSubMETCandInfo::kPU );
-    jetInfo.setPassesLooseJetId( passesLooseJetId );
-    double jetEnergy_uncorrected = 
-      jet->chargedHadronEnergy() 
-      + jet->neutralHadronEnergy()
-      + jet->photonEnergy()
-      + jet->electronEnergy()
-      + jet->muonEnergy()
-      + jet->HFHadronEnergy()
-      + jet->HFEMEnergy();
-    double jetPx_uncorrected = cos(jet->phi())*sin(jet->theta())*jetEnergy_uncorrected;
-    double jetPy_uncorrected = sin(jet->phi())*sin(jet->theta())*jetEnergy_uncorrected;
-    double jetPz_uncorrected = cos(jet->theta())*jetEnergy_uncorrected;
-    reco::Candidate::LorentzVector rawJetP4(jetPx_uncorrected, jetPy_uncorrected, jetPz_uncorrected, jetEnergy_uncorrected);
+    jetInfo.setType((jetIdSelection_passed) ? reco::PUSubMETCandInfo::kHS : reco::PUSubMETCandInfo::kPU);
+    jetInfo.setPassesLooseJetId(passesLooseJetId);
+    double jetEnergy_uncorrected = jet->chargedHadronEnergy() + jet->neutralHadronEnergy() + jet->photonEnergy() +
+                                   jet->electronEnergy() + jet->muonEnergy() + jet->HFHadronEnergy() +
+                                   jet->HFEMEnergy();
+    double jetPx_uncorrected = cos(jet->phi()) * sin(jet->theta()) * jetEnergy_uncorrected;
+    double jetPy_uncorrected = sin(jet->phi()) * sin(jet->theta()) * jetEnergy_uncorrected;
+    double jetPz_uncorrected = cos(jet->theta()) * jetEnergy_uncorrected;
+    reco::Candidate::LorentzVector rawJetP4(
+        jetPx_uncorrected, jetPy_uncorrected, jetPz_uncorrected, jetEnergy_uncorrected);
     reco::PFJet rawJet(*jet);
     rawJet.setP4(rawJetP4);
-    double jetNeutralEnFrac = ( jetEnergy_uncorrected > 0. ) ?
-      (jet->neutralEmEnergy() + jet->neutralHadronEnergy())/jetEnergy_uncorrected : -1.;
-    jetInfo.setChargedEnFrac( (1-jetNeutralEnFrac) );
-    jetInfo.setOffsetEnCorr( ( jetEnOffsetCorrector ) ?
-			     rawJet.energy()*(1. - jetEnOffsetCorrector->correction(rawJet, evt, es)) : 0.);
-    jetInfo.setMEtSignObj( pfMEtSignInterface_->compResolution(&(*jet)) );
- 
-    jetInfos->push_back(jetInfo);    
+    double jetNeutralEnFrac = (jetEnergy_uncorrected > 0.)
+                                  ? (jet->neutralEmEnergy() + jet->neutralHadronEnergy()) / jetEnergy_uncorrected
+                                  : -1.;
+    jetInfo.setChargedEnFrac((1 - jetNeutralEnFrac));
+    jetInfo.setOffsetEnCorr(
+        (jetEnOffsetCorrector) ? rawJet.energy() * (1. - jetEnOffsetCorrector->correction(rawJet, evt, es)) : 0.);
+    jetInfo.setMEtSignObj(pfMEtSignInterface_->compResolution(&(*jet)));
+
+    jetInfos->push_back(jetInfo);
   }
-  LogDebug ("produce")  << "#jetInfos = " << jetInfos->size() << std::endl;
- 
-  for ( reco::PFJetCollection::const_iterator jet = jets->begin();
-	jet != jets->end(); ++jet ) {
-    if ( jet->pt() > minJetPtForMEtCov_ ) {
-      setPFCandidateFlag(*jet, *pfCandidates, pfCandidateFlags, flag_isWithinJetForMEtCov, numWarnings_, maxWarnings_, &pfCandidateToJetAssociations);
+  LogDebug("produce") << "#jetInfos = " << jetInfos->size() << std::endl;
+
+  for (reco::PFJetCollection::const_iterator jet = jets->begin(); jet != jets->end(); ++jet) {
+    if (jet->pt() > minJetPtForMEtCov_) {
+      setPFCandidateFlag(*jet,
+                         *pfCandidates,
+                         pfCandidateFlags,
+                         flag_isWithinJetForMEtCov,
+                         numWarnings_,
+                         maxWarnings_,
+                         &pfCandidateToJetAssociations);
     }
   }
- 
+
   size_t numPFCandidates = pfCandidates->size();
-  for ( size_t iPFCandidate = 0; iPFCandidate < numPFCandidates; ++iPFCandidate ) {
+  for (size_t iPFCandidate = 0; iPFCandidate < numPFCandidates; ++iPFCandidate) {
     reco::PFCandidatePtr pfCandidatePtr = pfCandidates->ptrAt(iPFCandidate);
 
     int idx = pfCandidatePtr.key();
     reco::PUSubMETCandInfo pfCandInfo;
-    pfCandInfo.setP4( pfCandidatePtr->p4() );
-    pfCandInfo.setCharge( pfCandidatePtr->charge() );
-    pfCandInfo.setType( -1 );
+    pfCandInfo.setP4(pfCandidatePtr->p4());
+    pfCandInfo.setCharge(pfCandidatePtr->charge());
+    pfCandInfo.setType(-1);
     // CV: need to call isVertexAssociated_fast instead of isVertexAssociated function
     //    (makes run-time of MVAPFMEtDataProducer::produce decrease from ~1s per event to ~0.35s per event)
     //int vtxAssociationType = isVertexAssociated(*pfCandidatePtr, *pfCandToVertexAssociations, *hardScatterVertex, dZcut_);
-    reco::PFCandidateRef pfCandidateRef( pfCandidateHandle, iPFCandidate);
-    int vtxAssociationType = noPuUtils::isVertexAssociated_fast(pfCandidateRef, pfCandToVertexAssociations_reversed, *hardScatterVertex, dZcut_, numWarnings_, maxWarnings_);
+    reco::PFCandidateRef pfCandidateRef(pfCandidateHandle, iPFCandidate);
+    int vtxAssociationType = noPuUtils::isVertexAssociated_fast(
+        pfCandidateRef, pfCandToVertexAssociations_reversed, *hardScatterVertex, dZcut_, numWarnings_, maxWarnings_);
     bool isHardScatterVertex_associated = (vtxAssociationType == noPuUtils::kChHSAssoc);
-    if      ( pfCandidatePtr->charge() == 0 )   pfCandInfo.setType( reco::PUSubMETCandInfo::kNeutral );
-    else if ( isHardScatterVertex_associated       ) pfCandInfo.setType( reco::PUSubMETCandInfo::kChHS );
-    else                                             pfCandInfo.setType( reco::PUSubMETCandInfo::kChPU );
-    pfCandInfo.setIsWithinJet( (pfCandidateFlags[idx] & flag_isWithinSelectedJet) );
-    if ( pfCandInfo.isWithinJet() ) pfCandInfo.setPassesLooseJetId( (pfCandidateFlags[idx] & flag_isWithinFakeJet) );
-    else pfCandInfo.setPassesLooseJetId( true );
-    
+    if (pfCandidatePtr->charge() == 0)
+      pfCandInfo.setType(reco::PUSubMETCandInfo::kNeutral);
+    else if (isHardScatterVertex_associated)
+      pfCandInfo.setType(reco::PUSubMETCandInfo::kChHS);
+    else
+      pfCandInfo.setType(reco::PUSubMETCandInfo::kChPU);
+    pfCandInfo.setIsWithinJet((pfCandidateFlags[idx] & flag_isWithinSelectedJet));
+    if (pfCandInfo.isWithinJet())
+      pfCandInfo.setPassesLooseJetId((pfCandidateFlags[idx] & flag_isWithinFakeJet));
+    else
+      pfCandInfo.setPassesLooseJetId(true);
+
     // CV: for PFCandidates that are within PFJets (of Pt between 'minJetPtForMEtCov' and 'minJetPt'),
     //     take contribution to PFMEt significance matrix from associated PFJet.
     //    (energy uncertainty scaled by ratio of PFCandidate/PFJet energy)
     const reco::PFJet* jet_matched = pfCandidateToJetAssociations[idx];
-    if ( jet_matched ) {
+    if (jet_matched) {
       metsig::SigInputObj pfCandResolution = pfMEtSignInterface_->compResolution(pfCandidatePtr.get());
       metsig::SigInputObj jetResolution = pfMEtSignInterface_->compResolution(jet_matched);
-    
+
       metsig::SigInputObj metSign;
       metSign.set(pfCandResolution.get_type(),
-		 pfCandResolution.get_energy(),
-		 pfCandResolution.get_phi(),
-		 jetResolution.get_sigma_e()*(pfCandidatePtr->energy()/jet_matched->energy()),
-		 jetResolution.get_sigma_tan());
-      pfCandInfo.setMEtSignObj( metSign );
+                  pfCandResolution.get_energy(),
+                  pfCandResolution.get_phi(),
+                  jetResolution.get_sigma_e() * (pfCandidatePtr->energy() / jet_matched->energy()),
+                  jetResolution.get_sigma_tan());
+      pfCandInfo.setMEtSignObj(metSign);
     } else {
-      pfCandInfo.setMEtSignObj( pfMEtSignInterface_->compResolution(pfCandidatePtr.get()) );
+      pfCandInfo.setMEtSignObj(pfMEtSignInterface_->compResolution(pfCandidatePtr.get()));
     }
-    
+
     pfCandInfos->push_back(pfCandInfo);
   }
-  
-  LogDebug ("produce") << "#pfCandInfos = " << pfCandInfos->size() << std::endl;
-    
-  evt.put(std::move(jetInfos),"jetInfos");
-  evt.put(std::move(pfCandInfos),"pfCandInfos");
+
+  LogDebug("produce") << "#pfCandInfos = " << pfCandInfos->size() << std::endl;
+
+  evt.put(std::move(jetInfos), "jetInfos");
+  evt.put(std::move(pfCandInfos), "pfCandInfos");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
@@ -163,7 +163,7 @@ void NoPileUpPFMEtDataProducer::produce(edm::Event& evt, const edm::EventSetup& 
   auto pfCandInfos = std::make_unique<reco::PUSubMETCandInfoCollection>();
  
   const JetCorrector* jetEnOffsetCorrector = nullptr;
-  if ( jetEnOffsetCorrLabel_ != "" ) {
+  if ( !jetEnOffsetCorrLabel_.empty() ) {
     jetEnOffsetCorrector = JetCorrector::getJetCorrector(jetEnOffsetCorrLabel_, es);
     if ( !jetEnOffsetCorrector )  
       throw cms::Exception("NoPileUpPFMEtDataProducer::produce")

--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.h
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.h
@@ -16,7 +16,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h"
-#include "DataFormats/JetReco/interface/PileupJetIdentifier.h" 
+#include "DataFormats/JetReco/interface/PileupJetIdentifier.h"
 
 #include "RecoMET/METPUSubtraction/interface/PFMEtSignInterfaceBase.h"
 #include "RecoMET/METPUSubtraction/interface/NoPileUpMEtAuxFunctions.h"
@@ -32,23 +32,20 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/METReco/interface/PUSubMETData.h"       
-#include "DataFormats/METReco/interface/PUSubMETDataFwd.h"    
-#include "DataFormats/METReco/interface/SigInputObj.h"    //PH: preserve 5_3_x dependence
+#include "DataFormats/METReco/interface/PUSubMETData.h"
+#include "DataFormats/METReco/interface/PUSubMETDataFwd.h"
+#include "DataFormats/METReco/interface/SigInputObj.h"  //PH: preserve 5_3_x dependence
 
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
 
-class NoPileUpPFMEtDataProducer : public edm::stream::EDProducer<>
-{
- public:
-  
+class NoPileUpPFMEtDataProducer : public edm::stream::EDProducer<> {
+public:
   NoPileUpPFMEtDataProducer(const edm::ParameterSet&);
   ~NoPileUpPFMEtDataProducer() override;
-  
- private:
-  
+
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
+
   std::string moduleLabel_;
 
   edm::EDGetTokenT<reco::PFJetCollection> srcJets_;
@@ -56,7 +53,7 @@ class NoPileUpPFMEtDataProducer : public edm::stream::EDProducer<>
   double minJetPt_;
   PileupJetIdentifier::Id jetIdSelection_;
   std::string jetEnOffsetCorrLabel_;
-  
+
   edm::EDGetTokenT<reco::PFCandidateCollection> srcPFCandidates_;
   edm::EDGetTokenT<edm::View<reco::PFCandidate> > srcPFCandidatesView_;
   edm::EDGetTokenT<PFCandToVertexAssMap> srcPFCandToVertexAssociations_;
@@ -64,9 +61,9 @@ class NoPileUpPFMEtDataProducer : public edm::stream::EDProducer<>
   double minJetPtForMEtCov_;
   edm::EDGetTokenT<reco::VertexCollection> srcHardScatterVertex_;
   double dZcut_;
-  
+
   PFJetIDSelectionFunctor* looseJetIdAlgo_;
-  
+
   PFMEtSignInterfaceBase* pfMEtSignInterface_;
 
   int maxWarnings_;

--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtProducer.cc
@@ -218,7 +218,7 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   
   // get MET covariance matrix
   reco::METCovMatrix pfMEtCov;
-  if ( srcMEtCov_.label() != "" ) {
+  if ( !srcMEtCov_.label().empty() ) {
     //MM manual bypass to pfMET as this case has neer been presented
     // edm::Handle<PFMEtSignCovMatrix> pfMEtCovHandle;    
     // evt.getByToken(srcMEtCov_, pfMEtCovHandle);

--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtProducer.cc
@@ -14,19 +14,21 @@ const double defaultPFMEtResolutionY = 10.;
 const double epsilon = 1.e-9;
 
 NoPileUpPFMEtProducer::NoPileUpPFMEtProducer(const edm::ParameterSet& cfg)
-  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-{
+    : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
   srcMEt_ = consumes<reco::PFMETCollection>(cfg.getParameter<edm::InputTag>("srcMEt"));
-   srcMEtCov_ = edm::InputTag(); //MM, disabled for the moment until we really need it
+  srcMEtCov_ = edm::InputTag();  //MM, disabled for the moment until we really need it
   //( cfg.exists("srcMEtCov") ) ?
   //  consumes<edm::Handle<> >(cfg.getParameter<edm::InputTag>("srcMEtCov")) : edm::InputTag();
   srcJetInfo_ = consumes<reco::PUSubMETCandInfoCollection>(cfg.getParameter<edm::InputTag>("srcPUSubMETDataJet"));
-  srcJetInfoLeptonMatch_ = consumes<reco::PUSubMETCandInfoCollection>(cfg.getParameter<edm::InputTag>("srcPUSubMETDataJetLeptonMatch"));
-  srcPFCandInfo_ = consumes<reco::PUSubMETCandInfoCollection>(cfg.getParameter<edm::InputTag>("srcPUSubMETDataPFCands"));
-  srcPFCandInfoLeptonMatch_ = consumes<reco::PUSubMETCandInfoCollection>(cfg.getParameter<edm::InputTag>("srcPUSubMETDataPFCandsLeptonMatch"));
+  srcJetInfoLeptonMatch_ =
+      consumes<reco::PUSubMETCandInfoCollection>(cfg.getParameter<edm::InputTag>("srcPUSubMETDataJetLeptonMatch"));
+  srcPFCandInfo_ =
+      consumes<reco::PUSubMETCandInfoCollection>(cfg.getParameter<edm::InputTag>("srcPUSubMETDataPFCands"));
+  srcPFCandInfoLeptonMatch_ =
+      consumes<reco::PUSubMETCandInfoCollection>(cfg.getParameter<edm::InputTag>("srcPUSubMETDataPFCandsLeptonMatch"));
   vInputTag srcLeptonsTags = cfg.getParameter<vInputTag>("srcLeptons");
-  for(vInputTag::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
-    srcLeptons_.push_back( consumes<edm::View<reco::Candidate> >( *it ) );
+  for (vInputTag::const_iterator it = srcLeptonsTags.begin(); it != srcLeptonsTags.end(); it++) {
+    srcLeptons_.push_back(consumes<edm::View<reco::Candidate> >(*it));
   }
 
   srcType0Correction_ = consumes<CorrMETData>(cfg.getParameter<edm::InputTag>("srcType0Correction"));
@@ -44,12 +46,10 @@ NoPileUpPFMEtProducer::NoPileUpPFMEtProducer(const edm::ParameterSet& cfg)
   sfMEtCovMin_ = cfg.getParameter<double>("sfMEtCovMin");
   sfMEtCovMax_ = cfg.getParameter<double>("sfMEtCovMax");
 
-  saveInputs_ = ( cfg.exists("saveInputs") ) ?
-    cfg.getParameter<bool>("saveInputs") : false;
+  saveInputs_ = (cfg.exists("saveInputs")) ? cfg.getParameter<bool>("saveInputs") : false;
 
-  verbosity_ = ( cfg.exists("verbosity") ) ?
-    cfg.getParameter<int>("verbosity") : 0;
-  
+  verbosity_ = (cfg.exists("verbosity")) ? cfg.getParameter<int>("verbosity") : 0;
+
   produces<reco::PFMETCollection>();
 
   sfLeptonsName_ = "sumLeptons";
@@ -62,7 +62,7 @@ NoPileUpPFMEtProducer::NoPileUpPFMEtProducer(const edm::ParameterSet& cfg)
   sfType0CorrectionName_ = "type0Correction";
   sfLeptonIsoConesName_ = "sumLeptonIsoCones";
 
-  if ( saveInputs_ ) {
+  if (saveInputs_) {
     produces<CommonMETData>(sfLeptonsName_);
     produces<CommonMETData>(sfNoPUjetsName_);
     produces<CommonMETData>(sfNoPUjetOffsetEnCorrName_);
@@ -76,44 +76,38 @@ NoPileUpPFMEtProducer::NoPileUpPFMEtProducer(const edm::ParameterSet& cfg)
   produces<double>("sfNoPU");
 }
 
-NoPileUpPFMEtProducer::~NoPileUpPFMEtProducer() 
-{ 
-  delete pfMEtSignInterface_;
-}
+NoPileUpPFMEtProducer::~NoPileUpPFMEtProducer() { delete pfMEtSignInterface_; }
 
-void initializeCommonMETData(CommonMETData& metData)
-{
-  metData.met   = 0.;
-  metData.mex   = 0.;
-  metData.mey   = 0.;
-  metData.mez   = 0.;
+void initializeCommonMETData(CommonMETData& metData) {
+  metData.met = 0.;
+  metData.mex = 0.;
+  metData.mey = 0.;
+  metData.mez = 0.;
   metData.sumet = 0.;
-  metData.phi   = 0.;
+  metData.phi = 0.;
 }
 
-void addToCommonMETData(CommonMETData& metData, const reco::Candidate::LorentzVector& p4)
-{
-  metData.mex   += p4.px();
-  metData.mey   += p4.py();
-  metData.mez   += p4.pz();
+void addToCommonMETData(CommonMETData& metData, const reco::Candidate::LorentzVector& p4) {
+  metData.mex += p4.px();
+  metData.mey += p4.py();
+  metData.mez += p4.pz();
   metData.sumet += p4.pt();
 }
 
-void finalizeCommonMETData(CommonMETData& metData)
-{
-  metData.met = sqrt(metData.mex*metData.mex + metData.mey*metData.mey);
+void finalizeCommonMETData(CommonMETData& metData) {
+  metData.met = sqrt(metData.mex * metData.mex + metData.mey * metData.mey);
   metData.phi = atan2(metData.mey, metData.mex);
 }
 
-int findBestMatchingLepton(const std::vector<reco::Candidate::LorentzVector>& leptons, const reco::Candidate::LorentzVector& p4_ref)
-{
+int findBestMatchingLepton(const std::vector<reco::Candidate::LorentzVector>& leptons,
+                           const reco::Candidate::LorentzVector& p4_ref) {
   int leptonIdx_dR2min = -1;
   double dR2min = 1.e+3;
   int leptonIdx = 0;
-  for ( std::vector<reco::Candidate::LorentzVector>::const_iterator lepton = leptons.begin();
-	lepton != leptons.end(); ++lepton ) {
+  for (std::vector<reco::Candidate::LorentzVector>::const_iterator lepton = leptons.begin(); lepton != leptons.end();
+       ++lepton) {
     double dR2 = deltaR2(*lepton, p4_ref);
-    if ( leptonIdx_dR2min == -1 || dR2 < dR2min ) {
+    if (leptonIdx_dR2min == -1 || dR2 < dR2min) {
       leptonIdx_dR2min = leptonIdx;
       dR2min = dR2;
     }
@@ -123,134 +117,135 @@ int findBestMatchingLepton(const std::vector<reco::Candidate::LorentzVector>& le
   return leptonIdx_dR2min;
 }
 
-void scaleAndAddPFMEtSignObjects(std::vector<metsig::SigInputObj>& metSignObjects_scaled, const std::vector<metsig::SigInputObj>& metSignObjects, 
-				 double sf, double sfMin, double sfMax)
-{
+void scaleAndAddPFMEtSignObjects(std::vector<metsig::SigInputObj>& metSignObjects_scaled,
+                                 const std::vector<metsig::SigInputObj>& metSignObjects,
+                                 double sf,
+                                 double sfMin,
+                                 double sfMax) {
   double sf_value = sf;
-  if ( sf_value > sfMax ) sf_value = sfMax;
-  if ( sf_value < sfMin ) sf_value = sfMin;
-  for ( std::vector<metsig::SigInputObj>::const_iterator metSignObject = metSignObjects.begin();
-	metSignObject != metSignObjects.end(); ++metSignObject ) {
+  if (sf_value > sfMax)
+    sf_value = sfMax;
+  if (sf_value < sfMin)
+    sf_value = sfMin;
+  for (std::vector<metsig::SigInputObj>::const_iterator metSignObject = metSignObjects.begin();
+       metSignObject != metSignObjects.end();
+       ++metSignObject) {
     metsig::SigInputObj metSignObject_scaled;
-    metSignObject_scaled.set(
-      metSignObject->get_type(), 
-      sf_value*metSignObject->get_energy(), 
-      metSignObject->get_phi(),
-      sf_value*metSignObject->get_sigma_e(), 
-      metSignObject->get_sigma_tan());
+    metSignObject_scaled.set(metSignObject->get_type(),
+                             sf_value * metSignObject->get_energy(),
+                             metSignObject->get_phi(),
+                             sf_value * metSignObject->get_sigma_e(),
+                             metSignObject->get_sigma_tan());
     metSignObjects_scaled.push_back(metSignObject_scaled);
   }
 }
 
-reco::METCovMatrix computePFMEtSignificance(const std::vector<metsig::SigInputObj>& metSignObjects)
-{
+reco::METCovMatrix computePFMEtSignificance(const std::vector<metsig::SigInputObj>& metSignObjects) {
   reco::METCovMatrix pfMEtCov;
-  if ( metSignObjects.size() >= 2 ) {
+  if (metSignObjects.size() >= 2) {
     metsig::significanceAlgo pfMEtSignAlgorithm;
     pfMEtSignAlgorithm.addObjects(metSignObjects);
     pfMEtCov = pfMEtSignAlgorithm.getSignifMatrix();
-  } 
-  
+  }
+
   double det = 0;
   pfMEtCov.Det(det);
-  if ( std::abs(det) < epsilon ) {
-    edm::LogWarning("computePFMEtSignificance") 
-      << "Inversion of PFMEt covariance matrix failed, det = " << det
-      << " --> replacing covariance matrix by resolution defaults !!";    
-    pfMEtCov(0,0) = defaultPFMEtResolutionX*defaultPFMEtResolutionX;
-    pfMEtCov(0,1) = 0.;
-    pfMEtCov(1,0) = 0.;
-    pfMEtCov(1,1) = defaultPFMEtResolutionY*defaultPFMEtResolutionY;
+  if (std::abs(det) < epsilon) {
+    edm::LogWarning("computePFMEtSignificance") << "Inversion of PFMEt covariance matrix failed, det = " << det
+                                                << " --> replacing covariance matrix by resolution defaults !!";
+    pfMEtCov(0, 0) = defaultPFMEtResolutionX * defaultPFMEtResolutionX;
+    pfMEtCov(0, 1) = 0.;
+    pfMEtCov(1, 0) = 0.;
+    pfMEtCov(1, 1) = defaultPFMEtResolutionY * defaultPFMEtResolutionY;
   }
 
   return pfMEtCov;
 }
 
-void printP4(const std::string& label_part1, int idx, const std::string& label_part2, const reco::Candidate& candidate)
-{
-  std::cout << label_part1 << " #" << idx << label_part2 << ": Pt = " << candidate.pt() << ", eta = " << candidate.eta() << ", phi = " << candidate.phi() 
-	    << " (charge = " << candidate.charge() << ")" << std::endl;
+void printP4(const std::string& label_part1, int idx, const std::string& label_part2, const reco::Candidate& candidate) {
+  std::cout << label_part1 << " #" << idx << label_part2 << ": Pt = " << candidate.pt() << ", eta = " << candidate.eta()
+            << ", phi = " << candidate.phi() << " (charge = " << candidate.charge() << ")" << std::endl;
 }
 
-void printCommonMETData(const std::string& label, const CommonMETData& metData)
-{
-  std::cout << label << ": Px = " << metData.mex << ", Py = " << metData.mey << ", sumEt = " << metData.sumet << std::endl;
+void printCommonMETData(const std::string& label, const CommonMETData& metData) {
+  std::cout << label << ": Px = " << metData.mex << ", Py = " << metData.mey << ", sumEt = " << metData.sumet
+            << std::endl;
 }
 
-void printMVAMEtJetInfo(const std::string& label, int idx, const reco::PUSubMETCandInfo& jet)
-{
+void printMVAMEtJetInfo(const std::string& label, int idx, const reco::PUSubMETCandInfo& jet) {
   std::cout << label << " #" << idx << " (";
-  if      ( jet.type() == reco::PUSubMETCandInfo::kHS ) std::cout << "no-PU";
-  else if ( jet.type() == reco::PUSubMETCandInfo::kPU   ) std::cout << "PU";
+  if (jet.type() == reco::PUSubMETCandInfo::kHS)
+    std::cout << "no-PU";
+  else if (jet.type() == reco::PUSubMETCandInfo::kPU)
+    std::cout << "PU";
   std::cout << "): Pt = " << jet.p4().pt() << ", eta = " << jet.p4().eta() << ", phi = " << jet.p4().phi();
   std::cout << " id. flags: anti-noise = " << jet.passesLooseJetId() << std::endl;
   std::cout << std::endl;
 }
 
-void printMVAMEtPFCandInfo(const std::string& label, int idx, const reco::PUSubMETCandInfo& pfCand)
-{
+void printMVAMEtPFCandInfo(const std::string& label, int idx, const reco::PUSubMETCandInfo& pfCand) {
   std::cout << label << " #" << idx << " (";
-  if      ( pfCand.type() == reco::PUSubMETCandInfo::kChHS ) std::cout << "no-PU charged";
-  else if ( pfCand.type() == reco::PUSubMETCandInfo::kChPU   ) std::cout << "PU charged";
-  else if ( pfCand.type() == reco::PUSubMETCandInfo::kNeutral         ) std::cout << "neutral";
+  if (pfCand.type() == reco::PUSubMETCandInfo::kChHS)
+    std::cout << "no-PU charged";
+  else if (pfCand.type() == reco::PUSubMETCandInfo::kChPU)
+    std::cout << "PU charged";
+  else if (pfCand.type() == reco::PUSubMETCandInfo::kNeutral)
+    std::cout << "neutral";
   std::cout << "): Pt = " << pfCand.p4().pt() << ", eta = " << pfCand.p4().eta() << ", phi = " << pfCand.p4().phi();
   std::string isWithinJet_string;
-  if ( pfCand.isWithinJet() ) isWithinJet_string = "true";
-  else isWithinJet_string = "false";
+  if (pfCand.isWithinJet())
+    isWithinJet_string = "true";
+  else
+    isWithinJet_string = "false";
   std::cout << " (isWithinJet = " << isWithinJet_string << ")";
-  if ( pfCand.isWithinJet() ) std::cout << " Jet id. flags: anti-noise = " << pfCand.passesLooseJetId() << std::endl;
+  if (pfCand.isWithinJet())
+    std::cout << " Jet id. flags: anti-noise = " << pfCand.passesLooseJetId() << std::endl;
   std::cout << std::endl;
 }
 
-void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  LogDebug("produce") 
-    << " moduleLabel = " << moduleLabel_ << std::endl;
-  
+void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  LogDebug("produce") << " moduleLabel = " << moduleLabel_ << std::endl;
 
   // get original MET
   edm::Handle<reco::PFMETCollection> pfMETs;
   evt.getByToken(srcMEt_, pfMETs);
-  if ( !(pfMETs->size() == 1) )
-    throw cms::Exception("NoPileUpPFMEtProducer::produce") 
-      << "Failed to find unique MET object !!\n";
+  if (!(pfMETs->size() == 1))
+    throw cms::Exception("NoPileUpPFMEtProducer::produce") << "Failed to find unique MET object !!\n";
   const reco::PFMET& pfMEt_original = pfMETs->front();
-  
+
   // get MET covariance matrix
   reco::METCovMatrix pfMEtCov;
-  if ( !srcMEtCov_.label().empty() ) {
+  if (!srcMEtCov_.label().empty()) {
     //MM manual bypass to pfMET as this case has neer been presented
-    // edm::Handle<PFMEtSignCovMatrix> pfMEtCovHandle;    
+    // edm::Handle<PFMEtSignCovMatrix> pfMEtCovHandle;
     // evt.getByToken(srcMEtCov_, pfMEtCovHandle);
     // pfMEtCov = (*pfMEtCovHandle);
     pfMEtCov = pfMEt_original.getSignificanceMatrix();
   } else {
     pfMEtCov = pfMEt_original.getSignificanceMatrix();
   }
-  
+
   // get lepton momenta
   std::vector<reco::Candidate::LorentzVector> leptons;
   std::vector<metsig::SigInputObj> metSignObjectsLeptons;
   reco::Candidate::LorentzVector sumLeptonP4s;
-  for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = srcLeptons_.begin();
-	srcLeptons_i != srcLeptons_.end(); ++srcLeptons_i ) {
-    
+  for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = srcLeptons_.begin();
+       srcLeptons_i != srcLeptons_.end();
+       ++srcLeptons_i) {
     edm::Handle<reco::CandidateView> leptons_i;
     evt.getByToken(*srcLeptons_i, leptons_i);
     int leptonIdx = 0;
-    for ( reco::CandidateView::const_iterator lepton = leptons_i->begin();
-	  lepton != leptons_i->end(); ++lepton ) {
+    for (reco::CandidateView::const_iterator lepton = leptons_i->begin(); lepton != leptons_i->end(); ++lepton) {
       leptons.push_back(lepton->p4());
       metSignObjectsLeptons.push_back(pfMEtSignInterface_->compResolution(&(*lepton)));
       sumLeptonP4s += lepton->p4();
       ++leptonIdx;
     }
   }
-  LogDebug("produce")
-    << " sum(leptons): Pt = " << sumLeptonP4s.pt() << ", eta = " << sumLeptonP4s.eta() << ", phi = " << sumLeptonP4s.phi() << ","
-    << " mass = " << sumLeptonP4s.mass() << std::endl;
-  
-  
+  LogDebug("produce") << " sum(leptons): Pt = " << sumLeptonP4s.pt() << ", eta = " << sumLeptonP4s.eta()
+                      << ", phi = " << sumLeptonP4s.phi() << ","
+                      << " mass = " << sumLeptonP4s.mass() << std::endl;
+
   // get jet and PFCandidate information
   edm::Handle<reco::PUSubMETCandInfoCollection> jets;
   evt.getByToken(srcJetInfo_, jets);
@@ -262,50 +257,56 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   evt.getByToken(srcPFCandInfoLeptonMatch_, pfCandidatesLeptonMatch);
 
   reco::PUSubMETCandInfoCollection jets_leptons = utils_.cleanJets(*jetsLeptonMatch, leptons, 0.5, true);
-  reco::PUSubMETCandInfoCollection pfCandidates_leptons = utils_.cleanPFCandidates(*pfCandidatesLeptonMatch, leptons, 0.3, true);
+  reco::PUSubMETCandInfoCollection pfCandidates_leptons =
+      utils_.cleanPFCandidates(*pfCandidatesLeptonMatch, leptons, 0.3, true);
   std::vector<CommonMETData> sumJetsPlusPFCandidates_leptons(leptons.size());
-  for ( std::vector<CommonMETData>::iterator sumJetsPlusPFCandidates = sumJetsPlusPFCandidates_leptons.begin();
-	sumJetsPlusPFCandidates != sumJetsPlusPFCandidates_leptons.end(); ++sumJetsPlusPFCandidates ) {
+  for (std::vector<CommonMETData>::iterator sumJetsPlusPFCandidates = sumJetsPlusPFCandidates_leptons.begin();
+       sumJetsPlusPFCandidates != sumJetsPlusPFCandidates_leptons.end();
+       ++sumJetsPlusPFCandidates) {
     initializeCommonMETData(*sumJetsPlusPFCandidates);
   }
-  for ( reco::PUSubMETCandInfoCollection::const_iterator jet = jets_leptons.begin();
-	jet != jets_leptons.end(); ++jet ) {
-    int leptonIdx_dRmin = findBestMatchingLepton(leptons, jet->p4() );
+  for (reco::PUSubMETCandInfoCollection::const_iterator jet = jets_leptons.begin(); jet != jets_leptons.end(); ++jet) {
+    int leptonIdx_dRmin = findBestMatchingLepton(leptons, jet->p4());
     assert(leptonIdx_dRmin >= 0 && leptonIdx_dRmin < (int)sumJetsPlusPFCandidates_leptons.size());
-    
-    LogDebug("produce")
-      << "jet-to-lepton match:" 
-      << " jetPt = " << jet->p4().pt() << ", jetEta = " << jet->p4().eta() << ", jetPhi = " << jet->p4().phi() 
-      << " leptonPt = " << leptons[leptonIdx_dRmin].pt() << ", leptonEta = " << leptons[leptonIdx_dRmin].eta() << ", leptonPhi = " << leptons[leptonIdx_dRmin].phi() << std::endl;
-    
-    sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].mex   += jet->p4().px();
-    sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].mey   += jet->p4().py();
+
+    LogDebug("produce") << "jet-to-lepton match:"
+                        << " jetPt = " << jet->p4().pt() << ", jetEta = " << jet->p4().eta()
+                        << ", jetPhi = " << jet->p4().phi() << " leptonPt = " << leptons[leptonIdx_dRmin].pt()
+                        << ", leptonEta = " << leptons[leptonIdx_dRmin].eta()
+                        << ", leptonPhi = " << leptons[leptonIdx_dRmin].phi() << std::endl;
+
+    sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].mex += jet->p4().px();
+    sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].mey += jet->p4().py();
     sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].sumet += jet->p4().pt();
   }
-  for ( reco::PUSubMETCandInfoCollection::const_iterator pfCandidate = pfCandidates_leptons.begin();
-	pfCandidate != pfCandidates_leptons.end(); ++pfCandidate ) {
-    bool isWithinJet_lepton = false; 
-    if ( pfCandidate->isWithinJet() ) {
-      for ( reco::PUSubMETCandInfoCollection::const_iterator jet = jets_leptons.begin();
-	    jet != jets_leptons.end(); ++jet ) {
-	double dR2 = deltaR2(pfCandidate->p4(), jet->p4() );
-	if ( dR2 < 0.5*0.5 ) isWithinJet_lepton = true; 
+  for (reco::PUSubMETCandInfoCollection::const_iterator pfCandidate = pfCandidates_leptons.begin();
+       pfCandidate != pfCandidates_leptons.end();
+       ++pfCandidate) {
+    bool isWithinJet_lepton = false;
+    if (pfCandidate->isWithinJet()) {
+      for (reco::PUSubMETCandInfoCollection::const_iterator jet = jets_leptons.begin(); jet != jets_leptons.end();
+           ++jet) {
+        double dR2 = deltaR2(pfCandidate->p4(), jet->p4());
+        if (dR2 < 0.5 * 0.5)
+          isWithinJet_lepton = true;
       }
     }
-    if ( !isWithinJet_lepton ) {
-      int leptonIdx_dRmin = findBestMatchingLepton(leptons, pfCandidate->p4() );
+    if (!isWithinJet_lepton) {
+      int leptonIdx_dRmin = findBestMatchingLepton(leptons, pfCandidate->p4());
       assert(leptonIdx_dRmin >= 0 && leptonIdx_dRmin < (int)sumJetsPlusPFCandidates_leptons.size());
-      LogDebug("produce") 
-	<< "pfCandidate-to-lepton match:" 
-	<< " pfCandidatePt = " << pfCandidate->p4().pt() << ", pfCandidateEta = " << pfCandidate->p4().eta() << ", pfCandidatePhi = " << pfCandidate->p4().phi() 
-	<< " leptonPt = " << leptons[leptonIdx_dRmin].pt() << ", leptonEta = " << leptons[leptonIdx_dRmin].eta() << ", leptonPhi = " << leptons[leptonIdx_dRmin].phi() << std::endl;
-      
-      sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].mex   += pfCandidate->p4().px();
-      sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].mey   += pfCandidate->p4().py();
+      LogDebug("produce") << "pfCandidate-to-lepton match:"
+                          << " pfCandidatePt = " << pfCandidate->p4().pt()
+                          << ", pfCandidateEta = " << pfCandidate->p4().eta()
+                          << ", pfCandidatePhi = " << pfCandidate->p4().phi()
+                          << " leptonPt = " << leptons[leptonIdx_dRmin].pt()
+                          << ", leptonEta = " << leptons[leptonIdx_dRmin].eta()
+                          << ", leptonPhi = " << leptons[leptonIdx_dRmin].phi() << std::endl;
+
+      sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].mex += pfCandidate->p4().px();
+      sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].mey += pfCandidate->p4().py();
       sumJetsPlusPFCandidates_leptons[leptonIdx_dRmin].sumet += pfCandidate->p4().pt();
     } else {
-      LogDebug("produce") 
-	<< " pfCandidate is within jet --> skipping." << std::endl;
+      LogDebug("produce") << " pfCandidate is within jet --> skipping." << std::endl;
     }
   }
   auto sumLeptons = std::make_unique<CommonMETData>();
@@ -313,19 +314,20 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   auto sumLeptonIsoCones = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumLeptonIsoCones);
   int leptonIdx = 0;
-  for ( std::vector<CommonMETData>::iterator sumJetsPlusPFCandidates = sumJetsPlusPFCandidates_leptons.begin();
-	sumJetsPlusPFCandidates != sumJetsPlusPFCandidates_leptons.end(); ++sumJetsPlusPFCandidates ) {
-    if ( sumJetsPlusPFCandidates->sumet > leptons[leptonIdx].pt() ) {
-      double leptonEnFrac = leptons[leptonIdx].pt()/sumJetsPlusPFCandidates->sumet;
+  for (std::vector<CommonMETData>::iterator sumJetsPlusPFCandidates = sumJetsPlusPFCandidates_leptons.begin();
+       sumJetsPlusPFCandidates != sumJetsPlusPFCandidates_leptons.end();
+       ++sumJetsPlusPFCandidates) {
+    if (sumJetsPlusPFCandidates->sumet > leptons[leptonIdx].pt()) {
+      double leptonEnFrac = leptons[leptonIdx].pt() / sumJetsPlusPFCandidates->sumet;
       assert(leptonEnFrac >= 0.0 && leptonEnFrac <= 1.0);
-      sumLeptons->mex += (leptonEnFrac*sumJetsPlusPFCandidates->mex);
-      sumLeptons->mey += (leptonEnFrac*sumJetsPlusPFCandidates->mey);
-      sumLeptons->sumet += (leptonEnFrac*sumJetsPlusPFCandidates->sumet);
+      sumLeptons->mex += (leptonEnFrac * sumJetsPlusPFCandidates->mex);
+      sumLeptons->mey += (leptonEnFrac * sumJetsPlusPFCandidates->mey);
+      sumLeptons->sumet += (leptonEnFrac * sumJetsPlusPFCandidates->sumet);
       double leptonIsoConeEnFrac = 1.0 - leptonEnFrac;
       assert(leptonIsoConeEnFrac >= 0.0 && leptonIsoConeEnFrac <= 1.0);
-      sumLeptonIsoCones->mex += (leptonIsoConeEnFrac*sumJetsPlusPFCandidates->mex);
-      sumLeptonIsoCones->mey += (leptonIsoConeEnFrac*sumJetsPlusPFCandidates->mey);
-      sumLeptonIsoCones->sumet += (leptonIsoConeEnFrac*sumJetsPlusPFCandidates->sumet);      
+      sumLeptonIsoCones->mex += (leptonIsoConeEnFrac * sumJetsPlusPFCandidates->mex);
+      sumLeptonIsoCones->mey += (leptonIsoConeEnFrac * sumJetsPlusPFCandidates->mey);
+      sumLeptonIsoCones->sumet += (leptonIsoConeEnFrac * sumJetsPlusPFCandidates->sumet);
     } else {
       sumLeptons->mex += sumJetsPlusPFCandidates->mex;
       sumLeptons->mey += sumJetsPlusPFCandidates->mey;
@@ -333,7 +335,7 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
     }
     ++leptonIdx;
   }
-  
+
   reco::PUSubMETCandInfoCollection jets_cleaned = utils_.cleanJets(*jets, leptons, 0.5, false);
   reco::PUSubMETCandInfoCollection pfCandidates_cleaned = utils_.cleanPFCandidates(*pfCandidates, leptons, 0.3, false);
 
@@ -347,33 +349,32 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   initializeCommonMETData(*sumPUjets);
   std::vector<metsig::SigInputObj> metSignObjectsPUjets;
   int jetIdx = 0;
-  for ( reco::PUSubMETCandInfoCollection::const_iterator jet = jets_cleaned.begin();
-	jet != jets_cleaned.end(); ++jet ) {
-    if ( jet->passesLooseJetId() ) {
-      if ( jet->type() == reco::PUSubMETCandInfo::kHS ) {	
-	addToCommonMETData(*sumNoPUjets, jet->p4() );
-	metSignObjectsNoPUjets.push_back(jet->metSignObj() );
-	float jetp = jet->p4().P();
-	float jetcorr = jet->offsetEnCorr();
-	sumNoPUjetOffsetEnCorr->mex   += jetcorr*jet->p4().px()/jetp;
-	sumNoPUjetOffsetEnCorr->mey   += jetcorr*jet->p4().py()/jetp;
-	sumNoPUjetOffsetEnCorr->mez   += jetcorr*jet->p4().pz()/jetp;
-	sumNoPUjetOffsetEnCorr->sumet += jetcorr*jet->p4().pt()/jetp;
-	metsig::SigInputObj pfMEtSignObjectOffsetEnCorr(
-          jet->metSignObj().get_type(),
-	  jet->offsetEnCorr(),
-	  jet->metSignObj().get_phi(),
-	  (jet->offsetEnCorr()/jet->p4().E())*jet->metSignObj().get_sigma_e(),
-	  jet->metSignObj().get_sigma_tan());
-	metSignObjectsNoPUjetOffsetEnCorr.push_back(pfMEtSignObjectOffsetEnCorr);
+  for (reco::PUSubMETCandInfoCollection::const_iterator jet = jets_cleaned.begin(); jet != jets_cleaned.end(); ++jet) {
+    if (jet->passesLooseJetId()) {
+      if (jet->type() == reco::PUSubMETCandInfo::kHS) {
+        addToCommonMETData(*sumNoPUjets, jet->p4());
+        metSignObjectsNoPUjets.push_back(jet->metSignObj());
+        float jetp = jet->p4().P();
+        float jetcorr = jet->offsetEnCorr();
+        sumNoPUjetOffsetEnCorr->mex += jetcorr * jet->p4().px() / jetp;
+        sumNoPUjetOffsetEnCorr->mey += jetcorr * jet->p4().py() / jetp;
+        sumNoPUjetOffsetEnCorr->mez += jetcorr * jet->p4().pz() / jetp;
+        sumNoPUjetOffsetEnCorr->sumet += jetcorr * jet->p4().pt() / jetp;
+        metsig::SigInputObj pfMEtSignObjectOffsetEnCorr(
+            jet->metSignObj().get_type(),
+            jet->offsetEnCorr(),
+            jet->metSignObj().get_phi(),
+            (jet->offsetEnCorr() / jet->p4().E()) * jet->metSignObj().get_sigma_e(),
+            jet->metSignObj().get_sigma_tan());
+        metSignObjectsNoPUjetOffsetEnCorr.push_back(pfMEtSignObjectOffsetEnCorr);
       } else {
-	addToCommonMETData(*sumPUjets, jet->p4() );
-	metSignObjectsPUjets.push_back(jet->metSignObj() );
+        addToCommonMETData(*sumPUjets, jet->p4());
+        metSignObjectsPUjets.push_back(jet->metSignObj());
       }
     }
     ++jetIdx;
   }
-    
+
   auto sumNoPUunclChargedCands = std::make_unique<CommonMETData>();
   initializeCommonMETData(*sumNoPUunclChargedCands);
   std::vector<metsig::SigInputObj> metSignObjectsNoPUunclChargedCands;
@@ -384,20 +385,21 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   initializeCommonMETData(*sumUnclNeutralCands);
   std::vector<metsig::SigInputObj> metSignObjectsUnclNeutralCands;
   int pfCandIdx = 0;
-  for ( reco::PUSubMETCandInfoCollection::const_iterator pfCandidate = pfCandidates_cleaned.begin();
-	pfCandidate != pfCandidates_cleaned.end(); ++pfCandidate ) {
-    if ( pfCandidate->passesLooseJetId() ) {
-      if ( !pfCandidate->isWithinJet() ) {
-	if ( pfCandidate->type() == reco::PUSubMETCandInfo::kChHS ) {
-	  addToCommonMETData(*sumNoPUunclChargedCands, pfCandidate->p4() );
-	  metSignObjectsNoPUunclChargedCands.push_back(pfCandidate->metSignObj() );
-	} else if ( pfCandidate->type() == reco::PUSubMETCandInfo::kChPU ) {
-	  addToCommonMETData(*sumPUunclChargedCands, pfCandidate->p4() );
-	  metSignObjectsPUunclChargedCands.push_back(pfCandidate->metSignObj() );
-	} else if ( pfCandidate->type() == reco::PUSubMETCandInfo::kNeutral ) {
-	  addToCommonMETData(*sumUnclNeutralCands, pfCandidate->p4() );
-	  metSignObjectsUnclNeutralCands.push_back(pfCandidate->metSignObj() );
-	}
+  for (reco::PUSubMETCandInfoCollection::const_iterator pfCandidate = pfCandidates_cleaned.begin();
+       pfCandidate != pfCandidates_cleaned.end();
+       ++pfCandidate) {
+    if (pfCandidate->passesLooseJetId()) {
+      if (!pfCandidate->isWithinJet()) {
+        if (pfCandidate->type() == reco::PUSubMETCandInfo::kChHS) {
+          addToCommonMETData(*sumNoPUunclChargedCands, pfCandidate->p4());
+          metSignObjectsNoPUunclChargedCands.push_back(pfCandidate->metSignObj());
+        } else if (pfCandidate->type() == reco::PUSubMETCandInfo::kChPU) {
+          addToCommonMETData(*sumPUunclChargedCands, pfCandidate->p4());
+          metSignObjectsPUunclChargedCands.push_back(pfCandidate->metSignObj());
+        } else if (pfCandidate->type() == reco::PUSubMETCandInfo::kNeutral) {
+          addToCommonMETData(*sumUnclNeutralCands, pfCandidate->p4());
+          metSignObjectsUnclNeutralCands.push_back(pfCandidate->metSignObj());
+        }
       }
     }
     ++pfCandIdx;
@@ -420,23 +422,33 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
   finalizeCommonMETData(*type0Correction_output);
   finalizeCommonMETData(*sumLeptonIsoCones);
 
-  double noPileUpScaleFactor = ( sumPUunclChargedCands->sumet > 0. ) ?
-    (sumPUunclChargedCands->sumet/(sumNoPUunclChargedCands->sumet + sumPUunclChargedCands->sumet)) : 1.;
+  double noPileUpScaleFactor =
+      (sumPUunclChargedCands->sumet > 0.)
+          ? (sumPUunclChargedCands->sumet / (sumNoPUunclChargedCands->sumet + sumPUunclChargedCands->sumet))
+          : 1.;
   LogDebug("produce") << "noPileUpScaleFactor = " << noPileUpScaleFactor << std::endl;
 
-  double noPileUpMEtPx = -(sumLeptons->mex + sumNoPUjets->mex + sumNoPUunclChargedCands->mex 
-    + noPileUpScaleFactor*(sfNoPUjetOffsetEnCorr_*sumNoPUjetOffsetEnCorr->mex 
-			 + sfUnclNeutralCands_*sumUnclNeutralCands->mex + sfPUunclChargedCands_*sumPUunclChargedCands->mex + sfPUjets_*sumPUjets->mex))
-    + noPileUpScaleFactor*sfType0Correction_*type0Correction_output->mex;
-  if ( sfLeptonIsoCones_ >= 0. ) noPileUpMEtPx -= (noPileUpScaleFactor*sfLeptonIsoCones_*sumLeptonIsoCones->mex);
-  else noPileUpMEtPx -= (std::abs(sfLeptonIsoCones_)*sumLeptonIsoCones->mex);
-  double noPileUpMEtPy = -(sumLeptons->mey + sumNoPUjets->mey + sumNoPUunclChargedCands->mey
-    + noPileUpScaleFactor*(sfNoPUjetOffsetEnCorr_*sumNoPUjetOffsetEnCorr->mey
-			 + sfUnclNeutralCands_*sumUnclNeutralCands->mey + sfPUunclChargedCands_*sumPUunclChargedCands->mey + sfPUjets_*sumPUjets->mey))
-    + noPileUpScaleFactor*sfType0Correction_*type0Correction_output->mey;
-  if ( sfLeptonIsoCones_ >= 0. ) noPileUpMEtPy -= (noPileUpScaleFactor*sfLeptonIsoCones_*sumLeptonIsoCones->mey);
-  else noPileUpMEtPy -= (std::abs(sfLeptonIsoCones_)*sumLeptonIsoCones->mey);
-  double noPileUpMEtPt = sqrt(noPileUpMEtPx*noPileUpMEtPx + noPileUpMEtPy*noPileUpMEtPy);		  
+  double noPileUpMEtPx =
+      -(sumLeptons->mex + sumNoPUjets->mex + sumNoPUunclChargedCands->mex +
+        noPileUpScaleFactor *
+            (sfNoPUjetOffsetEnCorr_ * sumNoPUjetOffsetEnCorr->mex + sfUnclNeutralCands_ * sumUnclNeutralCands->mex +
+             sfPUunclChargedCands_ * sumPUunclChargedCands->mex + sfPUjets_ * sumPUjets->mex)) +
+      noPileUpScaleFactor * sfType0Correction_ * type0Correction_output->mex;
+  if (sfLeptonIsoCones_ >= 0.)
+    noPileUpMEtPx -= (noPileUpScaleFactor * sfLeptonIsoCones_ * sumLeptonIsoCones->mex);
+  else
+    noPileUpMEtPx -= (std::abs(sfLeptonIsoCones_) * sumLeptonIsoCones->mex);
+  double noPileUpMEtPy =
+      -(sumLeptons->mey + sumNoPUjets->mey + sumNoPUunclChargedCands->mey +
+        noPileUpScaleFactor *
+            (sfNoPUjetOffsetEnCorr_ * sumNoPUjetOffsetEnCorr->mey + sfUnclNeutralCands_ * sumUnclNeutralCands->mey +
+             sfPUunclChargedCands_ * sumPUunclChargedCands->mey + sfPUjets_ * sumPUjets->mey)) +
+      noPileUpScaleFactor * sfType0Correction_ * type0Correction_output->mey;
+  if (sfLeptonIsoCones_ >= 0.)
+    noPileUpMEtPy -= (noPileUpScaleFactor * sfLeptonIsoCones_ * sumLeptonIsoCones->mey);
+  else
+    noPileUpMEtPy -= (std::abs(sfLeptonIsoCones_) * sumLeptonIsoCones->mey);
+  double noPileUpMEtPt = sqrt(noPileUpMEtPx * noPileUpMEtPx + noPileUpMEtPy * noPileUpMEtPy);
   reco::Candidate::LorentzVector noPileUpMEtP4(noPileUpMEtPx, noPileUpMEtPy, 0., noPileUpMEtPt);
 
   reco::PFMET noPileUpMEt(pfMEt_original);
@@ -445,36 +457,47 @@ void NoPileUpPFMEtProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 
   std::vector<metsig::SigInputObj> metSignObjects_scaled;
   scaleAndAddPFMEtSignObjects(metSignObjects_scaled, metSignObjectsLeptons, 1.0, sfMEtCovMin_, sfMEtCovMax_);
-  scaleAndAddPFMEtSignObjects(metSignObjects_scaled, metSignObjectsNoPUjetOffsetEnCorr, sfNoPUjetOffsetEnCorr_, sfMEtCovMin_, sfMEtCovMax_);
+  scaleAndAddPFMEtSignObjects(
+      metSignObjects_scaled, metSignObjectsNoPUjetOffsetEnCorr, sfNoPUjetOffsetEnCorr_, sfMEtCovMin_, sfMEtCovMax_);
   scaleAndAddPFMEtSignObjects(metSignObjects_scaled, metSignObjectsNoPUjets, sfNoPUjets_, sfMEtCovMin_, sfMEtCovMax_);
-  scaleAndAddPFMEtSignObjects(metSignObjects_scaled, metSignObjectsPUjets, noPileUpScaleFactor*sfPUjets_, sfMEtCovMin_, sfMEtCovMax_);
-  scaleAndAddPFMEtSignObjects(metSignObjects_scaled, metSignObjectsNoPUunclChargedCands, sfNoPUunclChargedCands_, sfMEtCovMin_, sfMEtCovMax_);
-  scaleAndAddPFMEtSignObjects(metSignObjects_scaled, metSignObjectsPUunclChargedCands, noPileUpScaleFactor*sfPUunclChargedCands_, sfMEtCovMin_, sfMEtCovMax_);
-  scaleAndAddPFMEtSignObjects(metSignObjects_scaled, metSignObjectsUnclNeutralCands, noPileUpScaleFactor*sfUnclNeutralCands_, sfMEtCovMin_, sfMEtCovMax_);
+  scaleAndAddPFMEtSignObjects(
+      metSignObjects_scaled, metSignObjectsPUjets, noPileUpScaleFactor * sfPUjets_, sfMEtCovMin_, sfMEtCovMax_);
+  scaleAndAddPFMEtSignObjects(
+      metSignObjects_scaled, metSignObjectsNoPUunclChargedCands, sfNoPUunclChargedCands_, sfMEtCovMin_, sfMEtCovMax_);
+  scaleAndAddPFMEtSignObjects(metSignObjects_scaled,
+                              metSignObjectsPUunclChargedCands,
+                              noPileUpScaleFactor * sfPUunclChargedCands_,
+                              sfMEtCovMin_,
+                              sfMEtCovMax_);
+  scaleAndAddPFMEtSignObjects(metSignObjects_scaled,
+                              metSignObjectsUnclNeutralCands,
+                              noPileUpScaleFactor * sfUnclNeutralCands_,
+                              sfMEtCovMin_,
+                              sfMEtCovMax_);
   reco::METCovMatrix pfMEtCov_recomputed = computePFMEtSignificance(metSignObjects_scaled);
   noPileUpMEt.setSignificanceMatrix(pfMEtCov_recomputed);
 
-  LogDebug( "produce")
-    << "<NoPileUpPFMEtProducer::produce>:" << std::endl
-    << " moduleLabel = " << moduleLabel_ << std::endl
-    << " PFMET: Pt = " << pfMEt_original.pt() <<", phi = "<<pfMEt_original.phi()<<" "
-    << "(Px = "<<pfMEt_original.px()<<", Py = "<<pfMEt_original.py()<< ")"<<std::endl
-    << " Cov:" << std::endl
-    << " "<<pfMEtCov(0,0)<<"  "<<pfMEtCov(0,1)<<"\n "
-    <<pfMEtCov(1,0)<<"  "<<pfMEtCov(1,1)<<std::endl
-    << " no-PU MET: Pt = "<<noPileUpMEt.pt()<<", phi = "<<noPileUpMEt.phi()<< " "
-    << "(Px = " << noPileUpMEt.px() << ", Py = " << noPileUpMEt.py()<<")"<<std::endl
-    << " Cov:" << std::endl
-    <<" "<<(noPileUpMEt.getSignificanceMatrix())(0,0)<<"  "<<(noPileUpMEt.getSignificanceMatrix())(0,1)<<std::endl
-    <<(noPileUpMEt.getSignificanceMatrix())(1,0)<<"  "<<(noPileUpMEt.getSignificanceMatrix())(1,1)<<std::endl;
-  
-  
+  LogDebug("produce") << "<NoPileUpPFMEtProducer::produce>:" << std::endl
+                      << " moduleLabel = " << moduleLabel_ << std::endl
+                      << " PFMET: Pt = " << pfMEt_original.pt() << ", phi = " << pfMEt_original.phi() << " "
+                      << "(Px = " << pfMEt_original.px() << ", Py = " << pfMEt_original.py() << ")" << std::endl
+                      << " Cov:" << std::endl
+                      << " " << pfMEtCov(0, 0) << "  " << pfMEtCov(0, 1) << "\n " << pfMEtCov(1, 0) << "  "
+                      << pfMEtCov(1, 1) << std::endl
+                      << " no-PU MET: Pt = " << noPileUpMEt.pt() << ", phi = " << noPileUpMEt.phi() << " "
+                      << "(Px = " << noPileUpMEt.px() << ", Py = " << noPileUpMEt.py() << ")" << std::endl
+                      << " Cov:" << std::endl
+                      << " " << (noPileUpMEt.getSignificanceMatrix())(0, 0) << "  "
+                      << (noPileUpMEt.getSignificanceMatrix())(0, 1) << std::endl
+                      << (noPileUpMEt.getSignificanceMatrix())(1, 0) << "  "
+                      << (noPileUpMEt.getSignificanceMatrix())(1, 1) << std::endl;
+
   // add no-PU MET object to the event
   auto noPileUpMEtCollection = std::make_unique<reco::PFMETCollection>();
   noPileUpMEtCollection->push_back(noPileUpMEt);
-  
+
   evt.put(std::move(noPileUpMEtCollection));
-  if ( saveInputs_ ) {
+  if (saveInputs_) {
     evt.put(std::move(sumLeptons), sfLeptonsName_);
     evt.put(std::move(sumNoPUjetOffsetEnCorr), sfNoPUjetOffsetEnCorrName_);
     evt.put(std::move(sumNoPUjets), sfNoPUjetsName_);

--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtProducer.h
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtProducer.h
@@ -25,20 +25,16 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 
-
 #include <vector>
 
-class NoPileUpPFMEtProducer : public edm::stream::EDProducer<>
-{
- public:
-  
+class NoPileUpPFMEtProducer : public edm::stream::EDProducer<> {
+public:
   NoPileUpPFMEtProducer(const edm::ParameterSet&);
   ~NoPileUpPFMEtProducer() override;
-  
- private:
-  
+
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
+
   std::string moduleLabel_;
 
   edm::EDGetTokenT<reco::PFMETCollection> srcMEt_;
@@ -47,8 +43,8 @@ class NoPileUpPFMEtProducer : public edm::stream::EDProducer<>
   edm::EDGetTokenT<reco::PUSubMETCandInfoCollection> srcJetInfoLeptonMatch_;
   edm::EDGetTokenT<reco::PUSubMETCandInfoCollection> srcPFCandInfo_;
   edm::EDGetTokenT<reco::PUSubMETCandInfoCollection> srcPFCandInfoLeptonMatch_;
-  typedef std::vector<edm::InputTag>  vInputTag;
-  std::vector<edm::EDGetTokenT<reco::CandidateView > > srcLeptons_;
+  typedef std::vector<edm::InputTag> vInputTag;
+  std::vector<edm::EDGetTokenT<reco::CandidateView> > srcLeptons_;
 
   edm::EDGetTokenT<CorrMETData> srcType0Correction_;
 
@@ -60,7 +56,7 @@ class NoPileUpPFMEtProducer : public edm::stream::EDProducer<>
   double sfUnclNeutralCands_;
   double sfType0Correction_;
   double sfLeptonIsoCones_;
-  
+
   std::string sfLeptonsName_;
   std::string sfNoPUjetsName_;
   std::string sfNoPUjetOffsetEnCorrName_;
@@ -80,7 +76,6 @@ class NoPileUpPFMEtProducer : public edm::stream::EDProducer<>
   int verbosity_;
 
   NoPileUpMEtUtilities utils_;
-
 };
 
 #endif

--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
@@ -2,56 +2,53 @@
 
 using namespace reco;
 
-const double dR2Min = 0.01*0.01;
-const double dR2Max = 0.5*0.5;
+const double dR2Min = 0.01 * 0.01;
+const double dR2Max = 0.5 * 0.5;
 const double dPtMatch = 0.1;
 
-PFMETProducerMVA::PFMETProducerMVA(const edm::ParameterSet& cfg) 
-  : mvaMEtAlgo_(cfg),
-    mvaMEtAlgo_isInitialized_(false)
-{
-  srcCorrJets_     = consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcCorrJets"));
-  srcUncorrJets_   = consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcUncorrJets"));
-  srcJetIds_       = consumes<edm::ValueMap<float> >(cfg.getParameter<edm::InputTag>("srcMVAPileupJetId"));
+PFMETProducerMVA::PFMETProducerMVA(const edm::ParameterSet& cfg) : mvaMEtAlgo_(cfg), mvaMEtAlgo_isInitialized_(false) {
+  srcCorrJets_ = consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcCorrJets"));
+  srcUncorrJets_ = consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcUncorrJets"));
+  srcJetIds_ = consumes<edm::ValueMap<float> >(cfg.getParameter<edm::InputTag>("srcMVAPileupJetId"));
   srcPFCandidatesView_ = consumes<reco::CandidateView>(cfg.getParameter<edm::InputTag>("srcPFCandidates"));
-  srcVertices_     = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcVertices"));
+  srcVertices_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("srcVertices"));
   vInputTag srcLeptonsTags = cfg.getParameter<vInputTag>("srcLeptons");
-  for(vInputTag::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
-    srcLeptons_.push_back( consumes<reco::CandidateView >( *it ) );
+  for (vInputTag::const_iterator it = srcLeptonsTags.begin(); it != srcLeptonsTags.end(); it++) {
+    srcLeptons_.push_back(consumes<reco::CandidateView>(*it));
   }
-  mJetCorrector_  = consumes<reco::JetCorrector>(cfg.getParameter<edm::InputTag>("corrector"));
-  minNumLeptons_   = cfg.getParameter<int>("minNumLeptons");
+  mJetCorrector_ = consumes<reco::JetCorrector>(cfg.getParameter<edm::InputTag>("corrector"));
+  minNumLeptons_ = cfg.getParameter<int>("minNumLeptons");
 
   globalThreshold_ = cfg.getParameter<double>("globalThreshold");
 
-  minCorrJetPt_    = cfg.getParameter<double>     ("minCorrJetPt");
-  useType1_        = cfg.getParameter<bool>       ("useType1");
-   
-  verbosity_ = ( cfg.exists("verbosity") ) ?
-    cfg.getParameter<int>("verbosity") : 0;
+  minCorrJetPt_ = cfg.getParameter<double>("minCorrJetPt");
+  useType1_ = cfg.getParameter<bool>("useType1");
+
+  verbosity_ = (cfg.exists("verbosity")) ? cfg.getParameter<int>("verbosity") : 0;
 
   produces<reco::PFMETCollection>();
 }
 
-PFMETProducerMVA::~PFMETProducerMVA(){}
+PFMETProducerMVA::~PFMETProducerMVA() {}
 
-void PFMETProducerMVA::produce(edm::Event& evt, const edm::EventSetup& es) 
-{ 
+void PFMETProducerMVA::produce(edm::Event& evt, const edm::EventSetup& es) {
   // CV: check if the event is to be skipped
-  if ( minNumLeptons_ > 0 ) {
+  if (minNumLeptons_ > 0) {
     int numLeptons = 0;
-    for ( std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator srcLeptons_i = srcLeptons_.begin();
-	  srcLeptons_i != srcLeptons_.end(); ++srcLeptons_i ) {
+    for (std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator srcLeptons_i = srcLeptons_.begin();
+         srcLeptons_i != srcLeptons_.end();
+         ++srcLeptons_i) {
       edm::Handle<reco::CandidateView> leptons;
       evt.getByToken(*srcLeptons_i, leptons);
       numLeptons += leptons->size();
     }
-    if ( !(numLeptons >= minNumLeptons_) ) {
-      LogDebug( "produce" )
-	<< "<PFMETProducerMVA::produce>:" << std::endl
-	<< "Run: " << evt.id().run() << ", LS: " << evt.luminosityBlock()  << ", Event: " << evt.id().event() << std::endl
-	<< " numLeptons = " << numLeptons << ", minNumLeptons = " << minNumLeptons_ << " --> skipping !!" << std::endl;
-      
+    if (!(numLeptons >= minNumLeptons_)) {
+      LogDebug("produce") << "<PFMETProducerMVA::produce>:" << std::endl
+                          << "Run: " << evt.id().run() << ", LS: " << evt.luminosityBlock()
+                          << ", Event: " << evt.id().event() << std::endl
+                          << " numLeptons = " << numLeptons << ", minNumLeptons = " << minNumLeptons_
+                          << " --> skipping !!" << std::endl;
+
       reco::PFMET pfMEt;
       auto pfMEtCollection = std::make_unique<reco::PFMETCollection>();
       pfMEtCollection->push_back(pfMEt);
@@ -72,313 +69,363 @@ void PFMETProducerMVA::produce(edm::Event& evt, const edm::EventSetup& es)
   evt.getByToken(srcUncorrJets_, uncorrJets);
 
   edm::Handle<reco::JetCorrector> corrector;
-  if( useType1_ )
-  {
-    evt.getByToken(mJetCorrector_, corrector); 
+  if (useType1_) {
+    evt.getByToken(mJetCorrector_, corrector);
   }
-  
+
   edm::Handle<reco::CandidateView> pfCandidates_view;
   evt.getByToken(srcPFCandidatesView_, pfCandidates_view);
 
   // get vertices
   edm::Handle<reco::VertexCollection> vertices;
-  evt.getByToken(srcVertices_, vertices); 
+  evt.getByToken(srcVertices_, vertices);
   // take vertex with highest sum(trackPt) as the vertex of the "hard scatter" interaction
   // (= first entry in vertex collection)
-  const reco::Vertex* hardScatterVertex = ( !vertices->empty() ) ?
-    &(vertices->front()) : nullptr;
-  
+  const reco::Vertex* hardScatterVertex = (!vertices->empty()) ? &(vertices->front()) : nullptr;
+
   // get leptons
   // (excluded from sum over PFCandidates when computing hadronic recoil)
-  int  lId         = 0;
+  int lId = 0;
   bool lHasPhotons = false;
-  std::vector<reco::PUSubMETCandInfo> leptonInfo = computeLeptonInfo(srcLeptons_,*pfCandidates_view,hardScatterVertex, lId, lHasPhotons,
-								     evt);
+  std::vector<reco::PUSubMETCandInfo> leptonInfo =
+      computeLeptonInfo(srcLeptons_, *pfCandidates_view, hardScatterVertex, lId, lHasPhotons, evt);
 
   // initialize MVA MET algorithm
   // (this will load the BDTs, stored as GBRForrest objects;
-  //  either in input ROOT files or in SQL-lite files/the Conditions Database) 
-  if ( !mvaMEtAlgo_isInitialized_ ) {
+  //  either in input ROOT files or in SQL-lite files/the Conditions Database)
+  if (!mvaMEtAlgo_isInitialized_) {
     mvaMEtAlgo_.initialize(es);
     mvaMEtAlgo_isInitialized_ = true;
   }
 
   // reconstruct "standard" particle-flow missing Et
-  CommonMETData pfMEt_data = metAlgo_.run( (*pfCandidates_view), globalThreshold_);
-  SpecificPFMETData specificPfMET = pfMEtSpecificAlgo_.run( (*pfCandidates_view) );
-  const reco::Candidate::LorentzVector p4( pfMEt_data.mex, pfMEt_data.mey, 0.0, pfMEt_data.met);
-  const reco::Candidate::Point vtx(0.0, 0.0, 0.0 );
-  reco::PFMET pfMEt(specificPfMET,pfMEt_data.sumet, p4, vtx);
+  CommonMETData pfMEt_data = metAlgo_.run((*pfCandidates_view), globalThreshold_);
+  SpecificPFMETData specificPfMET = pfMEtSpecificAlgo_.run((*pfCandidates_view));
+  const reco::Candidate::LorentzVector p4(pfMEt_data.mex, pfMEt_data.mey, 0.0, pfMEt_data.met);
+  const reco::Candidate::Point vtx(0.0, 0.0, 0.0);
+  reco::PFMET pfMEt(specificPfMET, pfMEt_data.sumet, p4, vtx);
   reco::Candidate::LorentzVector pfMEtP4_original = pfMEt.p4();
-   
+
   // compute objects specific to MVA based MET reconstruction
   std::vector<reco::PUSubMETCandInfo> pfCandidateInfo = computePFCandidateInfo(*pfCandidates_view, hardScatterVertex);
-  std::vector<reco::PUSubMETCandInfo>    jetInfo         = computeJetInfo(*uncorrJets, corrJets, *jetIds, *vertices, hardScatterVertex, *corrector,evt,es,leptonInfo,pfCandidateInfo);
-  std::vector<reco::Vertex::Point>         vertexInfo      = computeVertexInfo(*vertices);
+  std::vector<reco::PUSubMETCandInfo> jetInfo = computeJetInfo(
+      *uncorrJets, corrJets, *jetIds, *vertices, hardScatterVertex, *corrector, evt, es, leptonInfo, pfCandidateInfo);
+  std::vector<reco::Vertex::Point> vertexInfo = computeVertexInfo(*vertices);
   // compute MVA based MET and estimate of its uncertainty
   mvaMEtAlgo_.setInput(leptonInfo, jetInfo, pfCandidateInfo, vertexInfo);
   mvaMEtAlgo_.setHasPhotons(lHasPhotons);
   mvaMEtAlgo_.evaluateMVA();
   pfMEt.setP4(mvaMEtAlgo_.getMEt());
   pfMEt.setSignificanceMatrix(mvaMEtAlgo_.getMEtCov());
-  
-  LogDebug("produce")
-    << "Run: " << evt.id().run() << ", LS: " << evt.luminosityBlock()  << ", Event: " << evt.id().event() << std::endl
-    << " PFMET: Pt = " << pfMEtP4_original.pt() << ", phi = " << pfMEtP4_original.phi() << " "
-    << "(Px = " << pfMEtP4_original.px() << ", Py = " << pfMEtP4_original.py() << ")" << std::endl
-    << " MVA MET: Pt = " << pfMEt.pt() << " phi = " << pfMEt.phi() << " (Px = " << pfMEt.px() << ", Py = " << pfMEt.py() << ")" << std::endl
-    << " Cov:" << std::endl
-    <<(mvaMEtAlgo_.getMEtCov())(0,0)<<"  "<<(mvaMEtAlgo_.getMEtCov())(0,1)<<std::endl
-    <<(mvaMEtAlgo_.getMEtCov())(1,0)<<"  "<<(mvaMEtAlgo_.getMEtCov())(1,1)<<std::endl  << std::endl;
- 
+
+  LogDebug("produce") << "Run: " << evt.id().run() << ", LS: " << evt.luminosityBlock()
+                      << ", Event: " << evt.id().event() << std::endl
+                      << " PFMET: Pt = " << pfMEtP4_original.pt() << ", phi = " << pfMEtP4_original.phi() << " "
+                      << "(Px = " << pfMEtP4_original.px() << ", Py = " << pfMEtP4_original.py() << ")" << std::endl
+                      << " MVA MET: Pt = " << pfMEt.pt() << " phi = " << pfMEt.phi() << " (Px = " << pfMEt.px()
+                      << ", Py = " << pfMEt.py() << ")" << std::endl
+                      << " Cov:" << std::endl
+                      << (mvaMEtAlgo_.getMEtCov())(0, 0) << "  " << (mvaMEtAlgo_.getMEtCov())(0, 1) << std::endl
+                      << (mvaMEtAlgo_.getMEtCov())(1, 0) << "  " << (mvaMEtAlgo_.getMEtCov())(1, 1) << std::endl
+                      << std::endl;
+
   // add PFMET object to the event
   auto pfMEtCollection = std::make_unique<reco::PFMETCollection>();
   pfMEtCollection->push_back(pfMEt);
   evt.put(std::move(pfMEtCollection));
 }
 
-std::vector<reco::PUSubMETCandInfo>
-PFMETProducerMVA::computeLeptonInfo(const std::vector<edm::EDGetTokenT<reco::CandidateView > >& srcLeptons_,
-				    const reco::CandidateView& pfCandidates_view,
-				    const reco::Vertex* hardScatterVertex,
-				    int& lId, bool& lHasPhotons, edm::Event& evt ) {
-
+std::vector<reco::PUSubMETCandInfo> PFMETProducerMVA::computeLeptonInfo(
+    const std::vector<edm::EDGetTokenT<reco::CandidateView> >& srcLeptons_,
+    const reco::CandidateView& pfCandidates_view,
+    const reco::Vertex* hardScatterVertex,
+    int& lId,
+    bool& lHasPhotons,
+    edm::Event& evt) {
   std::vector<reco::PUSubMETCandInfo> leptonInfo;
 
-  for ( std::vector<edm::EDGetTokenT<reco::CandidateView > >::const_iterator srcLeptons_i = srcLeptons_.begin();
-	srcLeptons_i != srcLeptons_.end(); ++srcLeptons_i ) {
+  for (std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator srcLeptons_i = srcLeptons_.begin();
+       srcLeptons_i != srcLeptons_.end();
+       ++srcLeptons_i) {
     edm::Handle<reco::CandidateView> leptons;
     evt.getByToken(*srcLeptons_i, leptons);
-    for ( reco::CandidateView::const_iterator lepton1 = leptons->begin();
-	  lepton1 != leptons->end(); ++lepton1 ) {
+    for (reco::CandidateView::const_iterator lepton1 = leptons->begin(); lepton1 != leptons->end(); ++lepton1) {
       bool pMatch = false;
-      for ( std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator srcLeptons_j = srcLeptons_.begin();
-	    srcLeptons_j != srcLeptons_.end(); ++srcLeptons_j ) {
-	edm::Handle<reco::CandidateView> leptons2;
-	evt.getByToken(*srcLeptons_j, leptons2);
-	for ( reco::CandidateView::const_iterator lepton2 = leptons2->begin();
-	      lepton2 != leptons2->end(); ++lepton2 ) {
-	  if(&(*lepton1) == &(*lepton2)) { continue; }
-	  if(deltaR2(lepton1->p4(),lepton2->p4()) < dR2Max) { pMatch = true; }
-	  if(pMatch &&     !istau(&(*lepton1)) &&  istau(&(*lepton2))) { pMatch = false; }
-	  if(pMatch &&    ( (istau(&(*lepton1)) && istau(&(*lepton2))) || (!istau(&(*lepton1)) && !istau(&(*lepton2)))) 
-	     &&     lepton1->pt() > lepton2->pt()) { pMatch = false; }
-	  if(pMatch && lepton1->pt() == lepton2->pt()) {
-	    pMatch = false;
-	    for(unsigned int i0 = 0; i0 < leptonInfo.size(); i0++) {
-	      if(std::abs(lepton1->pt() - leptonInfo[i0].p4().pt()) < dPtMatch) { pMatch = true; break; }
-	    }
-	  }
-	  if(pMatch) break;
-	}
-	if(pMatch) break;
+      for (std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator srcLeptons_j = srcLeptons_.begin();
+           srcLeptons_j != srcLeptons_.end();
+           ++srcLeptons_j) {
+        edm::Handle<reco::CandidateView> leptons2;
+        evt.getByToken(*srcLeptons_j, leptons2);
+        for (reco::CandidateView::const_iterator lepton2 = leptons2->begin(); lepton2 != leptons2->end(); ++lepton2) {
+          if (&(*lepton1) == &(*lepton2)) {
+            continue;
+          }
+          if (deltaR2(lepton1->p4(), lepton2->p4()) < dR2Max) {
+            pMatch = true;
+          }
+          if (pMatch && !istau(&(*lepton1)) && istau(&(*lepton2))) {
+            pMatch = false;
+          }
+          if (pMatch && ((istau(&(*lepton1)) && istau(&(*lepton2))) || (!istau(&(*lepton1)) && !istau(&(*lepton2)))) &&
+              lepton1->pt() > lepton2->pt()) {
+            pMatch = false;
+          }
+          if (pMatch && lepton1->pt() == lepton2->pt()) {
+            pMatch = false;
+            for (unsigned int i0 = 0; i0 < leptonInfo.size(); i0++) {
+              if (std::abs(lepton1->pt() - leptonInfo[i0].p4().pt()) < dPtMatch) {
+                pMatch = true;
+                break;
+              }
+            }
+          }
+          if (pMatch)
+            break;
+        }
+        if (pMatch)
+          break;
       }
-      if(pMatch) continue;
+      if (pMatch)
+        continue;
       reco::PUSubMETCandInfo pLeptonInfo;
-      pLeptonInfo.setP4( lepton1->p4() );
-      pLeptonInfo.setChargedEnFrac( chargedEnFrac(&(*lepton1),pfCandidates_view,hardScatterVertex) );
-      leptonInfo.push_back(pLeptonInfo); 
-      if(lepton1->isPhoton()) { lHasPhotons = true; }
+      pLeptonInfo.setP4(lepton1->p4());
+      pLeptonInfo.setChargedEnFrac(chargedEnFrac(&(*lepton1), pfCandidates_view, hardScatterVertex));
+      leptonInfo.push_back(pLeptonInfo);
+      if (lepton1->isPhoton()) {
+        lHasPhotons = true;
+      }
     }
     lId++;
   }
- 
+
   return leptonInfo;
 }
 
-
-std::vector<reco::PUSubMETCandInfo> 
-PFMETProducerMVA::computeJetInfo(const reco::PFJetCollection& uncorrJets, 
-				 const edm::Handle<reco::PFJetCollection>& corrJets, 
-				 const edm::ValueMap<float>& jetIds,
-				 const reco::VertexCollection& vertices,
-				 const reco::Vertex* hardScatterVertex,
-				 const reco::JetCorrector &iCorrector,edm::Event &iEvent,const edm::EventSetup &iSetup,
-				 std::vector<reco::PUSubMETCandInfo> &iLeptons,std::vector<reco::PUSubMETCandInfo> &iCands)
-{
+std::vector<reco::PUSubMETCandInfo> PFMETProducerMVA::computeJetInfo(const reco::PFJetCollection& uncorrJets,
+                                                                     const edm::Handle<reco::PFJetCollection>& corrJets,
+                                                                     const edm::ValueMap<float>& jetIds,
+                                                                     const reco::VertexCollection& vertices,
+                                                                     const reco::Vertex* hardScatterVertex,
+                                                                     const reco::JetCorrector& iCorrector,
+                                                                     edm::Event& iEvent,
+                                                                     const edm::EventSetup& iSetup,
+                                                                     std::vector<reco::PUSubMETCandInfo>& iLeptons,
+                                                                     std::vector<reco::PUSubMETCandInfo>& iCands) {
   std::vector<reco::PUSubMETCandInfo> retVal;
-  for ( reco::PFJetCollection::const_iterator uncorrJet = uncorrJets.begin();
-	uncorrJet != uncorrJets.end(); ++uncorrJet ) {
+  for (reco::PFJetCollection::const_iterator uncorrJet = uncorrJets.begin(); uncorrJet != uncorrJets.end();
+       ++uncorrJet) {
     // for ( reco::PFJetCollection::const_iterator corrJet = corrJets.begin();
     // 	  corrJet != corrJets.end(); ++corrJet ) {
     auto corrJet = corrJets->begin();
-    for( size_t cjIdx=0;cjIdx<corrJets->size();++cjIdx, ++corrJet) {
-      reco::PFJetRef corrJetRef( corrJets, cjIdx );
+    for (size_t cjIdx = 0; cjIdx < corrJets->size(); ++cjIdx, ++corrJet) {
+      reco::PFJetRef corrJetRef(corrJets, cjIdx);
 
       // match corrected and uncorrected jets
-      if ( uncorrJet->jetArea() != corrJet->jetArea() ) continue;
-      if ( deltaR2(corrJet->p4(),uncorrJet->p4()) > dR2Min ) continue;
+      if (uncorrJet->jetArea() != corrJet->jetArea())
+        continue;
+      if (deltaR2(corrJet->p4(), uncorrJet->p4()) > dR2Min)
+        continue;
 
       // check that jet passes loose PFJet id.
-      if(!passPFLooseId(&(*uncorrJet))) continue;
+      if (!passPFLooseId(&(*uncorrJet)))
+        continue;
 
       // compute jet energy correction factor
       // (= ratio of corrected/uncorrected jet Pt)
       //double jetEnCorrFactor = corrJet->pt()/uncorrJet->pt();
       reco::PUSubMETCandInfo jetInfo;
-      
-      // PH: apply jet energy corrections for all Jets ignoring recommendations
-      jetInfo.setP4( corrJet->p4() );
-      double lType1Corr = 0;
-      if(useType1_) { //Compute the type 1 correction ===> This code is crap 
-	double pCorr = iCorrector.correction(*uncorrJet);
-	lType1Corr = std::abs(corrJet->pt()-pCorr*uncorrJet->pt());
-	TLorentzVector pVec; pVec.SetPtEtaPhiM(lType1Corr,0,corrJet->phi(),0); 
-	reco::Candidate::LorentzVector pType1Corr; pType1Corr.SetCoordinates(pVec.Px(),pVec.Py(),pVec.Pz(),pVec.E());
-	//Filter to leptons
-	bool pOnLepton = false;
-	for(unsigned int i0 = 0; i0 < iLeptons.size(); i0++) {
-	  if(deltaR2(iLeptons[i0].p4(),corrJet->p4()) < dR2Max) {pOnLepton = true; break;}
-	}	
- 	//Add it to PF Collection
-	if(corrJet->pt() > 10 && !pOnLepton) {
-	  reco::PUSubMETCandInfo pfCandidateInfo;
-	  pfCandidateInfo.setP4( pType1Corr );
-	  pfCandidateInfo.setDZ( -999 );
-	  iCands.push_back(pfCandidateInfo);
-	}
-	//Scale
-	lType1Corr = (pCorr*uncorrJet->pt()-uncorrJet->pt());
-	lType1Corr /=corrJet->pt();
-      }
-      
-      // check that jet Pt used to compute MVA based jet id. is above threshold
-      if ( !(jetInfo.p4().pt() > minCorrJetPt_) ) continue;
 
-    
-      jetInfo.setMvaVal( jetIds[ corrJetRef ] );
-      float chEnF = (uncorrJet->chargedEmEnergy() + uncorrJet->chargedHadronEnergy() + uncorrJet->chargedMuEnergy() )/uncorrJet->energy();
-      if(useType1_) chEnF += lType1Corr*(1-jetInfo.chargedEnFrac() );
-      jetInfo.setChargedEnFrac( chEnF ); 
+      // PH: apply jet energy corrections for all Jets ignoring recommendations
+      jetInfo.setP4(corrJet->p4());
+      double lType1Corr = 0;
+      if (useType1_) {  //Compute the type 1 correction ===> This code is crap
+        double pCorr = iCorrector.correction(*uncorrJet);
+        lType1Corr = std::abs(corrJet->pt() - pCorr * uncorrJet->pt());
+        TLorentzVector pVec;
+        pVec.SetPtEtaPhiM(lType1Corr, 0, corrJet->phi(), 0);
+        reco::Candidate::LorentzVector pType1Corr;
+        pType1Corr.SetCoordinates(pVec.Px(), pVec.Py(), pVec.Pz(), pVec.E());
+        //Filter to leptons
+        bool pOnLepton = false;
+        for (unsigned int i0 = 0; i0 < iLeptons.size(); i0++) {
+          if (deltaR2(iLeptons[i0].p4(), corrJet->p4()) < dR2Max) {
+            pOnLepton = true;
+            break;
+          }
+        }
+        //Add it to PF Collection
+        if (corrJet->pt() > 10 && !pOnLepton) {
+          reco::PUSubMETCandInfo pfCandidateInfo;
+          pfCandidateInfo.setP4(pType1Corr);
+          pfCandidateInfo.setDZ(-999);
+          iCands.push_back(pfCandidateInfo);
+        }
+        //Scale
+        lType1Corr = (pCorr * uncorrJet->pt() - uncorrJet->pt());
+        lType1Corr /= corrJet->pt();
+      }
+
+      // check that jet Pt used to compute MVA based jet id. is above threshold
+      if (!(jetInfo.p4().pt() > minCorrJetPt_))
+        continue;
+
+      jetInfo.setMvaVal(jetIds[corrJetRef]);
+      float chEnF = (uncorrJet->chargedEmEnergy() + uncorrJet->chargedHadronEnergy() + uncorrJet->chargedMuEnergy()) /
+                    uncorrJet->energy();
+      if (useType1_)
+        chEnF += lType1Corr * (1 - jetInfo.chargedEnFrac());
+      jetInfo.setChargedEnFrac(chEnF);
       retVal.push_back(jetInfo);
       break;
     }
   }
 
   //order jets per pt
-  std::sort( retVal.begin(), retVal.end() );
+  std::sort(retVal.begin(), retVal.end());
 
   return retVal;
 }
 
 std::vector<reco::PUSubMETCandInfo> PFMETProducerMVA::computePFCandidateInfo(const reco::CandidateView& pfCandidates,
-										  const reco::Vertex* hardScatterVertex)
-{
+                                                                             const reco::Vertex* hardScatterVertex) {
   std::vector<reco::PUSubMETCandInfo> retVal;
-  for ( reco::CandidateView::const_iterator pfCandidate = pfCandidates.begin();
-	pfCandidate != pfCandidates.end(); ++pfCandidate ) {
-    double dZ = -999.; // PH: If no vertex is reconstructed in the event
-                       //     or PFCandidate has no track, set dZ to -999
-    if ( hardScatterVertex ) {
-      const reco::PFCandidate* pfc = dynamic_cast<const reco::PFCandidate* >( &(*pfCandidate) );
-      if( pfc != nullptr ) { //PF candidate for RECO and PAT levels
-	if      ( pfc->trackRef().isNonnull()    ) dZ = std::abs(pfc->trackRef()->dz(hardScatterVertex->position()));
-	else if ( pfc->gsfTrackRef().isNonnull() ) dZ = std::abs(pfc->gsfTrackRef()->dz(hardScatterVertex->position()));
-      }
-      else { //if not, then packedCandidate for miniAOD level
-	const pat::PackedCandidate* pfc = dynamic_cast<const pat::PackedCandidate* >( &(*pfCandidate) );
-	dZ = std::abs( pfc->dz( hardScatterVertex->position() ) );
-	//exact dz=zero corresponds to the -999 case for pfcandidate
-	if(dZ==0) {dZ=-999;}
+  for (reco::CandidateView::const_iterator pfCandidate = pfCandidates.begin(); pfCandidate != pfCandidates.end();
+       ++pfCandidate) {
+    double dZ = -999.;  // PH: If no vertex is reconstructed in the event
+                        //     or PFCandidate has no track, set dZ to -999
+    if (hardScatterVertex) {
+      const reco::PFCandidate* pfc = dynamic_cast<const reco::PFCandidate*>(&(*pfCandidate));
+      if (pfc != nullptr) {  //PF candidate for RECO and PAT levels
+        if (pfc->trackRef().isNonnull())
+          dZ = std::abs(pfc->trackRef()->dz(hardScatterVertex->position()));
+        else if (pfc->gsfTrackRef().isNonnull())
+          dZ = std::abs(pfc->gsfTrackRef()->dz(hardScatterVertex->position()));
+      } else {  //if not, then packedCandidate for miniAOD level
+        const pat::PackedCandidate* pfc = dynamic_cast<const pat::PackedCandidate*>(&(*pfCandidate));
+        dZ = std::abs(pfc->dz(hardScatterVertex->position()));
+        //exact dz=zero corresponds to the -999 case for pfcandidate
+        if (dZ == 0) {
+          dZ = -999;
+        }
       }
     }
     reco::PUSubMETCandInfo pfCandidateInfo;
-    pfCandidateInfo.setP4( pfCandidate->p4() );
-    pfCandidateInfo.setDZ( dZ );
+    pfCandidateInfo.setP4(pfCandidate->p4());
+    pfCandidateInfo.setDZ(dZ);
     retVal.push_back(pfCandidateInfo);
   }
   return retVal;
 }
 
-std::vector<reco::Vertex::Point> PFMETProducerMVA::computeVertexInfo(const reco::VertexCollection& vertices)
-{
+std::vector<reco::Vertex::Point> PFMETProducerMVA::computeVertexInfo(const reco::VertexCollection& vertices) {
   std::vector<reco::Vertex::Point> retVal;
-  for ( reco::VertexCollection::const_iterator vertex = vertices.begin();
-	vertex != vertices.end(); ++vertex ) {
-    if(std::abs(vertex->z())           > 24.) continue;
-    if(vertex->ndof()              <  4.) continue;
-    if(vertex->position().Rho()    >  2.) continue;
+  for (reco::VertexCollection::const_iterator vertex = vertices.begin(); vertex != vertices.end(); ++vertex) {
+    if (std::abs(vertex->z()) > 24.)
+      continue;
+    if (vertex->ndof() < 4.)
+      continue;
+    if (vertex->position().Rho() > 2.)
+      continue;
     retVal.push_back(vertex->position());
   }
   return retVal;
 }
-double PFMETProducerMVA::chargedEnFrac(const reco::Candidate *iCand,
-				     const reco::CandidateView& pfCandidates,const reco::Vertex* hardScatterVertex) { 
-  if(iCand->isMuon())     {
+double PFMETProducerMVA::chargedEnFrac(const reco::Candidate* iCand,
+                                       const reco::CandidateView& pfCandidates,
+                                       const reco::Vertex* hardScatterVertex) {
+  if (iCand->isMuon()) {
     return 1;
   }
-  if(iCand->isElectron())   {
+  if (iCand->isElectron()) {
     return 1.;
   }
-  if(iCand->isPhoton()  )   {return chargedFracInCone(iCand, pfCandidates,hardScatterVertex);}
-  double lPtTot = 0; double lPtCharged = 0;
-  const reco::PFTau *lPFTau = nullptr; 
+  if (iCand->isPhoton()) {
+    return chargedFracInCone(iCand, pfCandidates, hardScatterVertex);
+  }
+  double lPtTot = 0;
+  double lPtCharged = 0;
+  const reco::PFTau* lPFTau = nullptr;
   lPFTau = dynamic_cast<const reco::PFTau*>(iCand);
-  if(lPFTau != nullptr) { 
-    for (UInt_t i0 = 0; i0 < lPFTau->signalCands().size(); i0++) { 
-      lPtTot += (lPFTau->signalCands())[i0]->pt(); 
-      if((lPFTau->signalCands())[i0]->charge() == 0) continue;
-      lPtCharged += (lPFTau->signalCands())[i0]->pt(); 
+  if (lPFTau != nullptr) {
+    for (UInt_t i0 = 0; i0 < lPFTau->signalCands().size(); i0++) {
+      lPtTot += (lPFTau->signalCands())[i0]->pt();
+      if ((lPFTau->signalCands())[i0]->charge() == 0)
+        continue;
+      lPtCharged += (lPFTau->signalCands())[i0]->pt();
     }
-  } 
-  else { 
-    const pat::Tau *lPatPFTau = nullptr; 
+  } else {
+    const pat::Tau* lPatPFTau = nullptr;
     lPatPFTau = dynamic_cast<const pat::Tau*>(iCand);
-    if(lPatPFTau != nullptr) { 
-      for (UInt_t i0 = 0; i0 < lPatPFTau->signalCands().size(); i0++) { 
-	lPtTot += (lPatPFTau->signalCands())[i0]->pt(); 
-	if((lPatPFTau->signalCands())[i0]->charge() == 0) continue;
-	lPtCharged += (lPatPFTau->signalCands())[i0]->pt(); 
+    if (lPatPFTau != nullptr) {
+      for (UInt_t i0 = 0; i0 < lPatPFTau->signalCands().size(); i0++) {
+        lPtTot += (lPatPFTau->signalCands())[i0]->pt();
+        if ((lPatPFTau->signalCands())[i0]->charge() == 0)
+          continue;
+        lPtCharged += (lPatPFTau->signalCands())[i0]->pt();
       }
     }
   }
-  if(lPtTot == 0) lPtTot = 1.;
-  return lPtCharged/lPtTot;
+  if (lPtTot == 0)
+    lPtTot = 1.;
+  return lPtCharged / lPtTot;
 }
 //Return tau id by process of elimination
-bool PFMETProducerMVA::istau(const reco::Candidate *iCand) { 
-  if(iCand->isMuon())     return false;
-  if(iCand->isElectron()) return false;
-  if(iCand->isPhoton())   return false;
+bool PFMETProducerMVA::istau(const reco::Candidate* iCand) {
+  if (iCand->isMuon())
+    return false;
+  if (iCand->isElectron())
+    return false;
+  if (iCand->isPhoton())
+    return false;
   return true;
 }
-bool PFMETProducerMVA::passPFLooseId(const PFJet *iJet) { 
-  if(iJet->energy()== 0)                                  return false;
-  if(iJet->neutralHadronEnergy()/iJet->energy() > 0.99)   return false;
-  if(iJet->neutralEmEnergy()/iJet->energy()     > 0.99)   return false;
-  if(iJet->nConstituents() <  2)                          return false;
-  if(iJet->chargedHadronEnergy()/iJet->energy() <= 0 && std::abs(iJet->eta()) < 2.4 ) return false;
-  if(iJet->chargedEmEnergy()/iJet->energy() >  0.99  && std::abs(iJet->eta()) < 2.4 ) return false;
-  if(iJet->chargedMultiplicity()            < 1      && std::abs(iJet->eta()) < 2.4 ) return false;
+bool PFMETProducerMVA::passPFLooseId(const PFJet* iJet) {
+  if (iJet->energy() == 0)
+    return false;
+  if (iJet->neutralHadronEnergy() / iJet->energy() > 0.99)
+    return false;
+  if (iJet->neutralEmEnergy() / iJet->energy() > 0.99)
+    return false;
+  if (iJet->nConstituents() < 2)
+    return false;
+  if (iJet->chargedHadronEnergy() / iJet->energy() <= 0 && std::abs(iJet->eta()) < 2.4)
+    return false;
+  if (iJet->chargedEmEnergy() / iJet->energy() > 0.99 && std::abs(iJet->eta()) < 2.4)
+    return false;
+  if (iJet->chargedMultiplicity() < 1 && std::abs(iJet->eta()) < 2.4)
+    return false;
   return true;
 }
 
-double PFMETProducerMVA::chargedFracInCone(const reco::Candidate *iCand,
-					   const reco::CandidateView& pfCandidates,
-					   const reco::Vertex* hardScatterVertex,double iDRMax)
-{
-  double iDR2Max = iDRMax*iDRMax;
-  reco::Candidate::LorentzVector lVis(0,0,0,0);
-  for ( reco::CandidateView::const_iterator pfCandidate = pfCandidates.begin();
-	pfCandidate != pfCandidates.end(); ++pfCandidate ) {
-    if(deltaR2(iCand->p4(),pfCandidate->p4()) > iDR2Max)  continue;
-    double dZ = -999.; // PH: If no vertex is reconstructed in the event
-                       //     or PFCandidate has no track, set dZ to -999
-    if ( hardScatterVertex ) {
-      const reco::PFCandidate* pfc = dynamic_cast<const reco::PFCandidate* >( (&(*pfCandidate)) );
-      if( pfc != nullptr ) { //PF candidate for RECO and PAT levels
-	if      ( pfc->trackRef().isNonnull()    ) dZ = std::abs(pfc->trackRef()->dz(hardScatterVertex->position()));
-	else if ( pfc->gsfTrackRef().isNonnull() ) dZ = std::abs(pfc->gsfTrackRef()->dz(hardScatterVertex->position()));
-      }
-      else { //if not, then packedCandidate for miniAOD level
-	const pat::PackedCandidate* pfc = dynamic_cast<const pat::PackedCandidate* >( &(*pfCandidate) );
-	dZ = std::abs( pfc->dz( hardScatterVertex->position() ) );
+double PFMETProducerMVA::chargedFracInCone(const reco::Candidate* iCand,
+                                           const reco::CandidateView& pfCandidates,
+                                           const reco::Vertex* hardScatterVertex,
+                                           double iDRMax) {
+  double iDR2Max = iDRMax * iDRMax;
+  reco::Candidate::LorentzVector lVis(0, 0, 0, 0);
+  for (reco::CandidateView::const_iterator pfCandidate = pfCandidates.begin(); pfCandidate != pfCandidates.end();
+       ++pfCandidate) {
+    if (deltaR2(iCand->p4(), pfCandidate->p4()) > iDR2Max)
+      continue;
+    double dZ = -999.;  // PH: If no vertex is reconstructed in the event
+                        //     or PFCandidate has no track, set dZ to -999
+    if (hardScatterVertex) {
+      const reco::PFCandidate* pfc = dynamic_cast<const reco::PFCandidate*>((&(*pfCandidate)));
+      if (pfc != nullptr) {  //PF candidate for RECO and PAT levels
+        if (pfc->trackRef().isNonnull())
+          dZ = std::abs(pfc->trackRef()->dz(hardScatterVertex->position()));
+        else if (pfc->gsfTrackRef().isNonnull())
+          dZ = std::abs(pfc->gsfTrackRef()->dz(hardScatterVertex->position()));
+      } else {  //if not, then packedCandidate for miniAOD level
+        const pat::PackedCandidate* pfc = dynamic_cast<const pat::PackedCandidate*>(&(*pfCandidate));
+        dZ = std::abs(pfc->dz(hardScatterVertex->position()));
       }
     }
-    if(std::abs(dZ) > 0.1) continue; 
+    if (std::abs(dZ) > 0.1)
+      continue;
     lVis += pfCandidate->p4();
   }
-  return lVis.pt()/iCand->pt();
+  return lVis.pt() / iCand->pt();
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.h
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.h
@@ -16,7 +16,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
@@ -40,41 +39,49 @@
 #include "RecoJets/JetProducers/interface/PileupJetIdAlgo.h"
 #include <TLorentzVector.h>
 
-namespace reco
-{
-  class PFMETProducerMVA : public edm::stream::EDProducer<>
-  {
-   public:
-
-    PFMETProducerMVA(const edm::ParameterSet&); 
+namespace reco {
+  class PFMETProducerMVA : public edm::stream::EDProducer<> {
+  public:
+    PFMETProducerMVA(const edm::ParameterSet&);
     ~PFMETProducerMVA() override;
 
-   private:
-  
+  private:
     void produce(edm::Event&, const edm::EventSetup&) override;
 
     // auxiliary functions
-    std::vector<reco::PUSubMETCandInfo> computeLeptonInfo(const std::vector<edm::EDGetTokenT<reco::CandidateView > >& srcLeptons_,
-							  const reco::CandidateView& pfCandidates,
-							  const reco::Vertex* hardScatterVertex, 
-							  int& lId, bool& lHasPhotons, edm::Event & iEvent);
+    std::vector<reco::PUSubMETCandInfo> computeLeptonInfo(
+        const std::vector<edm::EDGetTokenT<reco::CandidateView> >& srcLeptons_,
+        const reco::CandidateView& pfCandidates,
+        const reco::Vertex* hardScatterVertex,
+        int& lId,
+        bool& lHasPhotons,
+        edm::Event& iEvent);
 
-    std::vector<reco::PUSubMETCandInfo> computeJetInfo(const reco::PFJetCollection&, const edm::Handle<reco::PFJetCollection>&,
-							  const edm::ValueMap<float>&, const reco::VertexCollection&, 
-							  const reco::Vertex*, const reco::JetCorrector &iCorr,
-							  edm::Event & iEvent,const edm::EventSetup &iSetup,
-							  std::vector<reco::PUSubMETCandInfo> &iLeptons,
-							  std::vector<reco::PUSubMETCandInfo> &iCands);
-    
+    std::vector<reco::PUSubMETCandInfo> computeJetInfo(const reco::PFJetCollection&,
+                                                       const edm::Handle<reco::PFJetCollection>&,
+                                                       const edm::ValueMap<float>&,
+                                                       const reco::VertexCollection&,
+                                                       const reco::Vertex*,
+                                                       const reco::JetCorrector& iCorr,
+                                                       edm::Event& iEvent,
+                                                       const edm::EventSetup& iSetup,
+                                                       std::vector<reco::PUSubMETCandInfo>& iLeptons,
+                                                       std::vector<reco::PUSubMETCandInfo>& iCands);
+
     std::vector<reco::PUSubMETCandInfo> computePFCandidateInfo(const reco::CandidateView&, const reco::Vertex*);
     std::vector<reco::Vertex::Point> computeVertexInfo(const reco::VertexCollection&);
-    double chargedEnFrac(const reco::Candidate *iCand,const reco::CandidateView& pfCandidates,const reco::Vertex* hardScatterVertex);
-    
-    bool   passPFLooseId(const reco::PFJet *iJet);
-    bool   istau        (const reco::Candidate *iCand);
-    double chargedFracInCone(const reco::Candidate *iCand,const reco::CandidateView& pfCandidates,const reco::Vertex* hardScatterVertex,double iDRMax=0.2);
+    double chargedEnFrac(const reco::Candidate* iCand,
+                         const reco::CandidateView& pfCandidates,
+                         const reco::Vertex* hardScatterVertex);
 
-   // configuration parameter
+    bool passPFLooseId(const reco::PFJet* iJet);
+    bool istau(const reco::Candidate* iCand);
+    double chargedFracInCone(const reco::Candidate* iCand,
+                             const reco::CandidateView& pfCandidates,
+                             const reco::Vertex* hardScatterVertex,
+                             double iDRMax = 0.2);
+
+    // configuration parameter
     edm::EDGetTokenT<reco::PFJetCollection> srcCorrJets_;
     edm::EDGetTokenT<reco::PFJetCollection> srcUncorrJets_;
     edm::EDGetTokenT<edm::ValueMap<float> > srcJetIds_;
@@ -83,11 +90,11 @@ namespace reco
     edm::EDGetTokenT<reco::VertexCollection> srcVertices_;
     edm::EDGetTokenT<reco::JetCorrector> mJetCorrector_;
     typedef std::vector<edm::InputTag> vInputTag;
-    std::vector<edm::EDGetTokenT<reco::CandidateView > > srcLeptons_;
-    int minNumLeptons_; // CV: option to skip MVA MET computation in case there are less than specified number of leptons in the event
+    std::vector<edm::EDGetTokenT<reco::CandidateView> > srcLeptons_;
+    int minNumLeptons_;  // CV: option to skip MVA MET computation in case there are less than specified number of leptons in the event
 
     bool useType1_;
-    
+
     double globalThreshold_;
 
     double minCorrJetPt_;
@@ -100,6 +107,6 @@ namespace reco
 
     int verbosity_;
   };
-}
+}  // namespace reco
 
 #endif

--- a/RecoMET/METPUSubtraction/src/MvaMEtUtilities.cc
+++ b/RecoMET/METPUSubtraction/src/MvaMEtUtilities.cc
@@ -5,8 +5,7 @@
 #include <algorithm>
 #include <cmath>
 
-MvaMEtUtilities::MvaMEtUtilities(const edm::ParameterSet& cfg) 
-{
+MvaMEtUtilities::MvaMEtUtilities(const edm::ParameterSet& cfg) {
   // jet id
   /* ===> this code parses an xml it uses parameter set 
   edm::ParameterSet jetConfig = iConfig.getParameter<edm::ParameterSet>("JetIdParams");
@@ -25,260 +24,281 @@ MvaMEtUtilities::MvaMEtUtilities(const edm::ParameterSet& cfg)
     }
   */
   //Tight Id => not used
-  mvaCut_[0][0][0] =  0.5; mvaCut_[0][0][1] = 0.6; mvaCut_[0][0][2] = 0.6; mvaCut_[0][0][3] = 0.9;
-  mvaCut_[0][1][0] = -0.2; mvaCut_[0][1][1] = 0.2; mvaCut_[0][1][2] = 0.2; mvaCut_[0][1][3] = 0.6;
-  mvaCut_[0][2][0] =  0.3; mvaCut_[0][2][1] = 0.4; mvaCut_[0][2][2] = 0.7; mvaCut_[0][2][3] = 0.8;
-  mvaCut_[0][3][0] =  0.5; mvaCut_[0][3][1] = 0.4; mvaCut_[0][3][2] = 0.8; mvaCut_[0][3][3] = 0.9;
+  mvaCut_[0][0][0] = 0.5;
+  mvaCut_[0][0][1] = 0.6;
+  mvaCut_[0][0][2] = 0.6;
+  mvaCut_[0][0][3] = 0.9;
+  mvaCut_[0][1][0] = -0.2;
+  mvaCut_[0][1][1] = 0.2;
+  mvaCut_[0][1][2] = 0.2;
+  mvaCut_[0][1][3] = 0.6;
+  mvaCut_[0][2][0] = 0.3;
+  mvaCut_[0][2][1] = 0.4;
+  mvaCut_[0][2][2] = 0.7;
+  mvaCut_[0][2][3] = 0.8;
+  mvaCut_[0][3][0] = 0.5;
+  mvaCut_[0][3][1] = 0.4;
+  mvaCut_[0][3][2] = 0.8;
+  mvaCut_[0][3][3] = 0.9;
   //Medium id => not used
-  mvaCut_[1][0][0] =  0.2; mvaCut_[1][0][1] = 0.4; mvaCut_[1][0][2] = 0.2; mvaCut_[1][0][3] = 0.6;
-  mvaCut_[1][1][0] = -0.3; mvaCut_[1][1][1] = 0. ; mvaCut_[1][1][2] = 0. ; mvaCut_[1][1][3] = 0.5;
-  mvaCut_[1][2][0] =  0.2; mvaCut_[1][2][1] = 0.2; mvaCut_[1][2][2] = 0.5; mvaCut_[1][2][3] = 0.7;
-  mvaCut_[1][3][0] =  0.3; mvaCut_[1][3][1] = 0.2; mvaCut_[1][3][2] = 0.7; mvaCut_[1][3][3] = 0.8;
+  mvaCut_[1][0][0] = 0.2;
+  mvaCut_[1][0][1] = 0.4;
+  mvaCut_[1][0][2] = 0.2;
+  mvaCut_[1][0][3] = 0.6;
+  mvaCut_[1][1][0] = -0.3;
+  mvaCut_[1][1][1] = 0.;
+  mvaCut_[1][1][2] = 0.;
+  mvaCut_[1][1][3] = 0.5;
+  mvaCut_[1][2][0] = 0.2;
+  mvaCut_[1][2][1] = 0.2;
+  mvaCut_[1][2][2] = 0.5;
+  mvaCut_[1][2][3] = 0.7;
+  mvaCut_[1][3][0] = 0.3;
+  mvaCut_[1][3][1] = 0.2;
+  mvaCut_[1][3][2] = 0.7;
+  mvaCut_[1][3][3] = 0.8;
   //Met Id => used
-  mvaCut_[2][0][0] = -0.2; mvaCut_[2][0][1] = -0.3; mvaCut_[2][0][2] = -0.5; mvaCut_[2][0][3] = -0.5;
-  mvaCut_[2][1][0] = -0.2; mvaCut_[2][1][1] = -0.2; mvaCut_[2][1][2] = -0.5; mvaCut_[2][1][3] = -0.3;
-  mvaCut_[2][2][0] = -0.2; mvaCut_[2][2][1] = -0.2; mvaCut_[2][2][2] = -0.2; mvaCut_[2][2][3] =  0.1;
-  mvaCut_[2][3][0] = -0.2; mvaCut_[2][3][1] = -0.2; mvaCut_[2][3][2] =  0. ; mvaCut_[2][3][3] =  0.2;
+  mvaCut_[2][0][0] = -0.2;
+  mvaCut_[2][0][1] = -0.3;
+  mvaCut_[2][0][2] = -0.5;
+  mvaCut_[2][0][3] = -0.5;
+  mvaCut_[2][1][0] = -0.2;
+  mvaCut_[2][1][1] = -0.2;
+  mvaCut_[2][1][2] = -0.5;
+  mvaCut_[2][1][3] = -0.3;
+  mvaCut_[2][2][0] = -0.2;
+  mvaCut_[2][2][1] = -0.2;
+  mvaCut_[2][2][2] = -0.2;
+  mvaCut_[2][2][3] = 0.1;
+  mvaCut_[2][3][0] = -0.2;
+  mvaCut_[2][3][1] = -0.2;
+  mvaCut_[2][3][2] = 0.;
+  mvaCut_[2][3][3] = 0.2;
 
   dzCut_ = cfg.getParameter<double>("dZcut");
-  ptThreshold_ = ( cfg.exists("ptThreshold") ) ?
-    cfg.getParameter<int>("ptThreshold") : -1000;
+  ptThreshold_ = (cfg.exists("ptThreshold")) ? cfg.getParameter<int>("ptThreshold") : -1000;
 }
 
-MvaMEtUtilities::~MvaMEtUtilities() 
-{
-// nothing to be done yet...
+MvaMEtUtilities::~MvaMEtUtilities() {
+  // nothing to be done yet...
 }
 
-bool MvaMEtUtilities::passesMVA(const reco::Candidate::LorentzVector& jetP4, double mvaJetId) 
-{ 
-  int ptBin = 0; 
-  if ( jetP4.pt() >= 10. && jetP4.pt() < 20. ) ptBin = 1;
-  if ( jetP4.pt() >= 20. && jetP4.pt() < 30. ) ptBin = 2;
-  if ( jetP4.pt() >= 30.                     ) ptBin = 3;
-  
+bool MvaMEtUtilities::passesMVA(const reco::Candidate::LorentzVector& jetP4, double mvaJetId) {
+  int ptBin = 0;
+  if (jetP4.pt() >= 10. && jetP4.pt() < 20.)
+    ptBin = 1;
+  if (jetP4.pt() >= 20. && jetP4.pt() < 30.)
+    ptBin = 2;
+  if (jetP4.pt() >= 30.)
+    ptBin = 3;
+
   int etaBin = 0;
-  if ( std::abs(jetP4.eta()) >= 2.5  && std::abs(jetP4.eta()) < 2.75) etaBin = 1; 
-  if ( std::abs(jetP4.eta()) >= 2.75 && std::abs(jetP4.eta()) < 3.0 ) etaBin = 2; 
-  if ( std::abs(jetP4.eta()) >= 3.0  && std::abs(jetP4.eta()) < 5.0 ) etaBin = 3; 
+  if (std::abs(jetP4.eta()) >= 2.5 && std::abs(jetP4.eta()) < 2.75)
+    etaBin = 1;
+  if (std::abs(jetP4.eta()) >= 2.75 && std::abs(jetP4.eta()) < 3.0)
+    etaBin = 2;
+  if (std::abs(jetP4.eta()) >= 3.0 && std::abs(jetP4.eta()) < 5.0)
+    etaBin = 3;
 
-  return ( mvaJetId > mvaCut_[2][ptBin][etaBin] );
+  return (mvaJetId > mvaCut_[2][ptBin][etaBin]);
 }
 
-reco::Candidate::LorentzVector MvaMEtUtilities::leadJetP4(const std::vector<reco::PUSubMETCandInfo>& jets) 
-{
+reco::Candidate::LorentzVector MvaMEtUtilities::leadJetP4(const std::vector<reco::PUSubMETCandInfo>& jets) {
   return jetP4(jets, 0);
 }
 
-reco::Candidate::LorentzVector MvaMEtUtilities::subleadJetP4(const std::vector<reco::PUSubMETCandInfo>& jets) 
-{
+reco::Candidate::LorentzVector MvaMEtUtilities::subleadJetP4(const std::vector<reco::PUSubMETCandInfo>& jets) {
   return jetP4(jets, 1);
 }
 
-reco::Candidate::LorentzVector MvaMEtUtilities::jetP4(const std::vector<reco::PUSubMETCandInfo>& jets, unsigned idx) 
-{
-  reco::Candidate::LorentzVector retVal(0.,0.,0.,0.);
-  if ( idx < jets.size() ) {
+reco::Candidate::LorentzVector MvaMEtUtilities::jetP4(const std::vector<reco::PUSubMETCandInfo>& jets, unsigned idx) {
+  reco::Candidate::LorentzVector retVal(0., 0., 0., 0.);
+  if (idx < jets.size()) {
     std::vector<reco::PUSubMETCandInfo> jets_sorted = jets;
     std::sort(jets_sorted.rbegin(), jets_sorted.rend());
     retVal = jets_sorted[idx].p4();
   }
   return retVal;
 }
-unsigned MvaMEtUtilities::numJetsAboveThreshold(const std::vector<reco::PUSubMETCandInfo>& jets, double ptThreshold) 
-{
+unsigned MvaMEtUtilities::numJetsAboveThreshold(const std::vector<reco::PUSubMETCandInfo>& jets, double ptThreshold) {
   unsigned retVal = 0;
-  for ( std::vector<reco::PUSubMETCandInfo>::const_iterator jet = jets.begin();
-	jet != jets.end(); ++jet ) {
-    if ( jet->p4().pt() > ptThreshold ) ++retVal;
+  for (std::vector<reco::PUSubMETCandInfo>::const_iterator jet = jets.begin(); jet != jets.end(); ++jet) {
+    if (jet->p4().pt() > ptThreshold)
+      ++retVal;
   }
   return retVal;
 }
-std::vector<reco::PUSubMETCandInfo> MvaMEtUtilities::cleanJets(const std::vector<reco::PUSubMETCandInfo>&    jets, 
-								 const std::vector<reco::PUSubMETCandInfo>& leptons,
-								 double ptThreshold, double dRmatch)
-{
-
-  double dR2match = dRmatch*dRmatch;
+std::vector<reco::PUSubMETCandInfo> MvaMEtUtilities::cleanJets(const std::vector<reco::PUSubMETCandInfo>& jets,
+                                                               const std::vector<reco::PUSubMETCandInfo>& leptons,
+                                                               double ptThreshold,
+                                                               double dRmatch) {
+  double dR2match = dRmatch * dRmatch;
   std::vector<reco::PUSubMETCandInfo> retVal;
-  for ( std::vector<reco::PUSubMETCandInfo>::const_iterator jet = jets.begin();
-	jet != jets.end(); ++jet ) {
+  for (std::vector<reco::PUSubMETCandInfo>::const_iterator jet = jets.begin(); jet != jets.end(); ++jet) {
     bool isOverlap = false;
-    for ( std::vector<reco::PUSubMETCandInfo>::const_iterator lepton = leptons.begin();
-	  lepton != leptons.end(); ++lepton ) {
-      if ( deltaR2(jet->p4(), lepton->p4()) < dR2match ) isOverlap = true;	
+    for (std::vector<reco::PUSubMETCandInfo>::const_iterator lepton = leptons.begin(); lepton != leptons.end();
+         ++lepton) {
+      if (deltaR2(jet->p4(), lepton->p4()) < dR2match)
+        isOverlap = true;
     }
-    if ( jet->p4().pt() > ptThreshold && !isOverlap ) retVal.push_back(*jet);
+    if (jet->p4().pt() > ptThreshold && !isOverlap)
+      retVal.push_back(*jet);
   }
   return retVal;
 }
 
-std::vector<reco::PUSubMETCandInfo> MvaMEtUtilities::cleanPFCands(const std::vector<reco::PUSubMETCandInfo>& pfCandidates, 
-								     const std::vector<reco::PUSubMETCandInfo>& leptons,
-								     double dRmatch, bool invert)
-{
-
-  double dR2match = dRmatch*dRmatch;
+std::vector<reco::PUSubMETCandInfo> MvaMEtUtilities::cleanPFCands(
+    const std::vector<reco::PUSubMETCandInfo>& pfCandidates,
+    const std::vector<reco::PUSubMETCandInfo>& leptons,
+    double dRmatch,
+    bool invert) {
+  double dR2match = dRmatch * dRmatch;
   std::vector<reco::PUSubMETCandInfo> retVal;
-  for ( std::vector<reco::PUSubMETCandInfo>::const_iterator pfCandidate = pfCandidates.begin();
-	pfCandidate != pfCandidates.end(); ++pfCandidate ) {
+  for (std::vector<reco::PUSubMETCandInfo>::const_iterator pfCandidate = pfCandidates.begin();
+       pfCandidate != pfCandidates.end();
+       ++pfCandidate) {
     bool isOverlap = false;
-    for ( std::vector<reco::PUSubMETCandInfo>::const_iterator lepton = leptons.begin();
-	  lepton != leptons.end(); ++lepton ) {
-      if ( deltaR2(pfCandidate->p4(), lepton->p4()) < dR2match ) isOverlap = true;
+    for (std::vector<reco::PUSubMETCandInfo>::const_iterator lepton = leptons.begin(); lepton != leptons.end();
+         ++lepton) {
+      if (deltaR2(pfCandidate->p4(), lepton->p4()) < dR2match)
+        isOverlap = true;
     }
-    if ( (!isOverlap && !invert) || (isOverlap && invert) ) retVal.push_back(*pfCandidate);
+    if ((!isOverlap && !invert) || (isOverlap && invert))
+      retVal.push_back(*pfCandidate);
   }
   return retVal;
 }
-void MvaMEtUtilities::finalize(CommonMETData& metData)
-{
-  metData.met = sqrt(metData.mex*metData.mex + metData.mey*metData.mey);
+void MvaMEtUtilities::finalize(CommonMETData& metData) {
+  metData.met = sqrt(metData.mex * metData.mex + metData.mey * metData.mey);
   metData.mez = 0.;
   metData.phi = atan2(metData.mey, metData.mex);
 }
 
-CommonMETData 
-MvaMEtUtilities::computeCandSum( int compKey, double dZmax, int dZflag,
-				 bool iCharged,  bool mvaPassFlag,
-				 const std::vector<reco::PUSubMETCandInfo>& objects ) {
-
+CommonMETData MvaMEtUtilities::computeCandSum(int compKey,
+                                              double dZmax,
+                                              int dZflag,
+                                              bool iCharged,
+                                              bool mvaPassFlag,
+                                              const std::vector<reco::PUSubMETCandInfo>& objects) {
   CommonMETData retVal;
-  retVal.mex   = 0.;
-  retVal.mey   = 0.;
+  retVal.mex = 0.;
+  retVal.mey = 0.;
   retVal.sumet = 0.;
 
-  for ( std::vector<reco::PUSubMETCandInfo>::const_iterator object = objects.begin();
-	object != objects.end(); ++object ) {
-
+  for (std::vector<reco::PUSubMETCandInfo>::const_iterator object = objects.begin(); object != objects.end();
+       ++object) {
     double pFrac = 1;
 
     //pf candidates
     // dZcut
-    //   maximum distance within which tracks are 
+    //   maximum distance within which tracks are
     //considered to be associated to hard scatter vertex
-    // dZflag 
+    // dZflag
     //   0 : select charged PFCandidates originating from hard scatter vertex
     //   1 : select charged PFCandidates originating from pile-up vertices
     //   2 : select all PFCandidates
-    if( compKey==MvaMEtUtilities::kPFCands ) {
-      if ( object->dZ() < 0.    && dZflag != 2 ) continue;
-      if ( object->dZ() > dZmax && dZflag == 0 ) continue;
-      if ( object->dZ() < dZmax && dZflag == 1 ) continue;
+    if (compKey == MvaMEtUtilities::kPFCands) {
+      if (object->dZ() < 0. && dZflag != 2)
+        continue;
+      if (object->dZ() > dZmax && dZflag == 0)
+        continue;
+      if (object->dZ() < dZmax && dZflag == 1)
+        continue;
     }
 
     //leptons
-    if( compKey==MvaMEtUtilities::kLeptons) {
-      if(iCharged) pFrac = object->chargedEnFrac();
+    if (compKey == MvaMEtUtilities::kLeptons) {
+      if (iCharged)
+        pFrac = object->chargedEnFrac();
     }
 
     //jets
-    if( compKey==MvaMEtUtilities::kJets) {
-      bool passesMVAjetId = passesMVA(object->p4(), object->mva() );
-      
-      if (  passesMVAjetId && !mvaPassFlag ) continue;
-      if ( !passesMVAjetId &&  mvaPassFlag ) continue;
-   
-      pFrac = 1-object->chargedEnFrac();//neutral energy fraction
+    if (compKey == MvaMEtUtilities::kJets) {
+      bool passesMVAjetId = passesMVA(object->p4(), object->mva());
+
+      if (passesMVAjetId && !mvaPassFlag)
+        continue;
+      if (!passesMVAjetId && mvaPassFlag)
+        continue;
+
+      pFrac = 1 - object->chargedEnFrac();  //neutral energy fraction
     }
 
-    retVal.mex   += object->p4().px()*pFrac;
-    retVal.mey   += object->p4().py()*pFrac;
-    retVal.sumet += object->p4().pt()*pFrac;
+    retVal.mex += object->p4().px() * pFrac;
+    retVal.mey += object->p4().py() * pFrac;
+    retVal.sumet += object->p4().pt() * pFrac;
   }
 
   finalize(retVal);
   return retVal;
 }
 
-
-CommonMETData
-MvaMEtUtilities::computeRecoil(int metType) {
-
+CommonMETData MvaMEtUtilities::computeRecoil(int metType) {
   CommonMETData retVal;
 
-  if(metType == MvaMEtUtilities::kPF ) {
-    //MET = pfMET = - all candidates 
+  if (metType == MvaMEtUtilities::kPF) {
+    //MET = pfMET = - all candidates
     // MET (1) in JME-13-003
-    retVal.mex  = leptonsSum_.mex - pfCandSum_.mex;
-    retVal.mey  = leptonsSum_.mey - pfCandSum_.mey;
+    retVal.mex = leptonsSum_.mex - pfCandSum_.mex;
+    retVal.mey = leptonsSum_.mey - pfCandSum_.mey;
     retVal.sumet = pfCandSum_.sumet - leptonsSum_.sumet;
   }
-  if(metType == MvaMEtUtilities::kChHS ) {
+  if (metType == MvaMEtUtilities::kChHS) {
     //MET = - charged HS
     // MET (2) in JME-13-003
-    retVal.mex  = leptonsChSum_.mex - pfCandChHSSum_.mex;
-    retVal.mey  = leptonsChSum_.mey - pfCandChHSSum_.mey;
+    retVal.mex = leptonsChSum_.mex - pfCandChHSSum_.mex;
+    retVal.mey = leptonsChSum_.mey - pfCandChHSSum_.mey;
     retVal.sumet = pfCandChHSSum_.sumet - leptonsChSum_.sumet;
   }
-  if(metType == MvaMEtUtilities::kHS ) { 
+  if (metType == MvaMEtUtilities::kHS) {
     //MET = - charged HS - neutral HS in jets
     // MET (3) in JME-13-003
-    retVal.mex  = leptonsChSum_.mex - (pfCandChHSSum_.mex + neutralJetHSSum_.mex);
-    retVal.mey  = leptonsChSum_.mey - (pfCandChHSSum_.mey + neutralJetHSSum_.mey);
+    retVal.mex = leptonsChSum_.mex - (pfCandChHSSum_.mex + neutralJetHSSum_.mex);
+    retVal.mey = leptonsChSum_.mey - (pfCandChHSSum_.mey + neutralJetHSSum_.mey);
     retVal.sumet = pfCandChHSSum_.sumet + neutralJetHSSum_.sumet - leptonsChSum_.sumet;
   }
-  if(metType == MvaMEtUtilities::kPU ) {
-    //MET = - charged PU - neutral PU in jets  
+  if (metType == MvaMEtUtilities::kPU) {
+    //MET = - charged PU - neutral PU in jets
     //MET = -recoil in that particular case, - sign not useful for the MVA and then discarded
     //motivated as PU IS its own recoil
     // MET (4) in JME-13-003
-    retVal.mex   = -(pfCandChPUSum_.mex + neutralJetPUSum_.mex);
-    retVal.mey   = -(pfCandChPUSum_.mey + neutralJetPUSum_.mey);
+    retVal.mex = -(pfCandChPUSum_.mex + neutralJetPUSum_.mex);
+    retVal.mey = -(pfCandChPUSum_.mey + neutralJetPUSum_.mey);
     retVal.sumet = pfCandChPUSum_.sumet + neutralJetPUSum_.sumet;
   }
-  if(metType == MvaMEtUtilities::kHSMinusNeutralPU ) {
+  if (metType == MvaMEtUtilities::kHSMinusNeutralPU) {
     //MET = all candidates - charged PU - neutral PU in jets
     // = all charged HS + all neutrals - neutral PU in jets
     // MET (5) in JME-13-003
-    retVal.mex  = leptonsSum_.mex - (pfCandSum_.mex - pfCandChPUSum_.mex - neutralJetPUSum_.mex);
-    retVal.mey  = leptonsSum_.mey - (pfCandSum_.mey - pfCandChPUSum_.mey - neutralJetPUSum_.mey);
-    retVal.sumet = (pfCandSum_.sumet - pfCandChPUSum_.sumet - neutralJetPUSum_.sumet) -leptonsSum_.sumet;
+    retVal.mex = leptonsSum_.mex - (pfCandSum_.mex - pfCandChPUSum_.mex - neutralJetPUSum_.mex);
+    retVal.mey = leptonsSum_.mey - (pfCandSum_.mey - pfCandChPUSum_.mey - neutralJetPUSum_.mey);
+    retVal.sumet = (pfCandSum_.sumet - pfCandChPUSum_.sumet - neutralJetPUSum_.sumet) - leptonsSum_.sumet;
   }
 
   finalize(retVal);
   return retVal;
 }
 
-void
-MvaMEtUtilities::computeAllSums(const std::vector<reco::PUSubMETCandInfo>& jets, 
-			       const std::vector<reco::PUSubMETCandInfo>& leptons,
-			       const std::vector<reco::PUSubMETCandInfo>& pfCandidates ) {
-
+void MvaMEtUtilities::computeAllSums(const std::vector<reco::PUSubMETCandInfo>& jets,
+                                     const std::vector<reco::PUSubMETCandInfo>& leptons,
+                                     const std::vector<reco::PUSubMETCandInfo>& pfCandidates) {
   cleanedJets_ = cleanJets(jets, leptons, ptThreshold_, 0.5);
 
-  leptonsSum_ = computeCandSum( kLeptons, 0., 0, false , false, leptons );
-  leptonsChSum_ = computeCandSum( kLeptons, 0., 0, true , false, leptons);
-  pfCandSum_ = computeCandSum( kPFCands, dzCut_, 2, false , false, pfCandidates);
-  pfCandChHSSum_ = computeCandSum( kPFCands, dzCut_, 0, false , false, pfCandidates);
-  pfCandChPUSum_ = computeCandSum( kPFCands, dzCut_, 1, false , false, pfCandidates);
-  neutralJetHSSum_ = computeCandSum( kJets, 0., 0, false , true, jets );
-  neutralJetPUSum_ = computeCandSum( kJets, 0., 0, false , false, jets );
-
+  leptonsSum_ = computeCandSum(kLeptons, 0., 0, false, false, leptons);
+  leptonsChSum_ = computeCandSum(kLeptons, 0., 0, true, false, leptons);
+  pfCandSum_ = computeCandSum(kPFCands, dzCut_, 2, false, false, pfCandidates);
+  pfCandChHSSum_ = computeCandSum(kPFCands, dzCut_, 0, false, false, pfCandidates);
+  pfCandChPUSum_ = computeCandSum(kPFCands, dzCut_, 1, false, false, pfCandidates);
+  neutralJetHSSum_ = computeCandSum(kJets, 0., 0, false, true, jets);
+  neutralJetPUSum_ = computeCandSum(kJets, 0., 0, false, false, jets);
 }
 
-double
-MvaMEtUtilities::getLeptonsSumMEX() const {
-  return leptonsSum_.mex;
-}
+double MvaMEtUtilities::getLeptonsSumMEX() const { return leptonsSum_.mex; }
 
-double
-MvaMEtUtilities::getLeptonsSumMEY() const {
-  return leptonsSum_.mey;
-}
+double MvaMEtUtilities::getLeptonsSumMEY() const { return leptonsSum_.mey; }
 
-double
-MvaMEtUtilities::getLeptonsChSumMEX() const {
-  return leptonsChSum_.mex;
-}
+double MvaMEtUtilities::getLeptonsChSumMEX() const { return leptonsChSum_.mex; }
 
-double
-MvaMEtUtilities::getLeptonsChSumMEY() const {
-  return leptonsChSum_.mey;
-} 
+double MvaMEtUtilities::getLeptonsChSumMEY() const { return leptonsChSum_.mey; }
 
-
-const std::vector<reco::PUSubMETCandInfo>& 
-MvaMEtUtilities::getCleanedJets() const {
-  return cleanedJets_;
-}
+const std::vector<reco::PUSubMETCandInfo>& MvaMEtUtilities::getCleanedJets() const { return cleanedJets_; }

--- a/RecoMET/METPUSubtraction/src/NoPileUpMEtAuxFunctions.cc
+++ b/RecoMET/METPUSubtraction/src/NoPileUpMEtAuxFunctions.cc
@@ -5,110 +5,116 @@
 
 #include <cmath>
 
-namespace noPuUtils{
-  const double dR2Min=0.01*0.01;
+namespace noPuUtils {
+  const double dR2Min = 0.01 * 0.01;
 
   int isVertexAssociated(const reco::PFCandidatePtr& pfCandidate,
-			 const PFCandToVertexAssMap& pfCandToVertexAssociations,
-			 const reco::VertexCollection& vertices, double dZ)
-  {
+                         const PFCandToVertexAssMap& pfCandToVertexAssociations,
+                         const reco::VertexCollection& vertices,
+                         double dZ) {
     int vtxAssociationType = noPuUtils::kNeutral;
 
-    if ( pfCandidate->charge() != 0 ) {
+    if (pfCandidate->charge() != 0) {
       vtxAssociationType = noPuUtils::kChNoAssoc;
-      for ( PFCandToVertexAssMap::const_iterator pfCandToVertexAssociation = pfCandToVertexAssociations.begin();
-	    pfCandToVertexAssociation != pfCandToVertexAssociations.end(); ++pfCandToVertexAssociation ) {
-     
-	const noPuUtils::CandQualityPairVector& pfCandidates_vertex = pfCandToVertexAssociation->val;
+      for (PFCandToVertexAssMap::const_iterator pfCandToVertexAssociation = pfCandToVertexAssociations.begin();
+           pfCandToVertexAssociation != pfCandToVertexAssociations.end();
+           ++pfCandToVertexAssociation) {
+        const noPuUtils::CandQualityPairVector& pfCandidates_vertex = pfCandToVertexAssociation->val;
 
-     
-	for ( noPuUtils::CandQualityPairVector::const_iterator pfCandidate_vertex = pfCandidates_vertex.begin();
-	      pfCandidate_vertex != pfCandidates_vertex.end(); ++pfCandidate_vertex ) {
-	 
-	  const reco::PFCandidatePtr pfcVtx= edm::refToPtr(pfCandidate_vertex->first); //<reco::PFCandidatePtr>
-	  //std::cout<<pfCandidate<<"   "<<test<<std::endl;
+        for (noPuUtils::CandQualityPairVector::const_iterator pfCandidate_vertex = pfCandidates_vertex.begin();
+             pfCandidate_vertex != pfCandidates_vertex.end();
+             ++pfCandidate_vertex) {
+          const reco::PFCandidatePtr pfcVtx = edm::refToPtr(pfCandidate_vertex->first);  //<reco::PFCandidatePtr>
+          //std::cout<<pfCandidate<<"   "<<test<<std::endl;
 
-	  if(pfCandidate != pfcVtx ) continue;//std::cout<<" pouet "<<pfCandidate<<"  "<<test<<std::endl;
+          if (pfCandidate != pfcVtx)
+            continue;  //std::cout<<" pouet "<<pfCandidate<<"  "<<test<<std::endl;
 
-	  //if(deltaR2(pfCandidate->p4(), pfCandidate_vertex->first->p4()) > dR2Min ) continue;
-	  double z = pfCandToVertexAssociation->key->position().z();
-	  int quality = pfCandidate_vertex->second;
-	  promoteAssocToHSAssoc( quality, z, vertices, dZ, vtxAssociationType, false);
-	}
+          //if(deltaR2(pfCandidate->p4(), pfCandidate_vertex->first->p4()) > dR2Min ) continue;
+          double z = pfCandToVertexAssociation->key->position().z();
+          int quality = pfCandidate_vertex->second;
+          promoteAssocToHSAssoc(quality, z, vertices, dZ, vtxAssociationType, false);
+        }
       }
     }
 
     return vtxAssociationType;
   }
 
-  noPuUtils::reversedPFCandToVertexAssMap 
-  reversePFCandToVertexAssociation(const PFCandToVertexAssMap& pfCandToVertexAssociations) {
-  
+  noPuUtils::reversedPFCandToVertexAssMap reversePFCandToVertexAssociation(
+      const PFCandToVertexAssMap& pfCandToVertexAssociations) {
     noPuUtils::reversedPFCandToVertexAssMap revPfCandToVtxAssoc;
 
-    for ( PFCandToVertexAssMap::const_iterator pfCandToVertexAssociation = pfCandToVertexAssociations.begin();
-	  pfCandToVertexAssociation != pfCandToVertexAssociations.end(); ++pfCandToVertexAssociation ) {
+    for (PFCandToVertexAssMap::const_iterator pfCandToVertexAssociation = pfCandToVertexAssociations.begin();
+         pfCandToVertexAssociation != pfCandToVertexAssociations.end();
+         ++pfCandToVertexAssociation) {
       const reco::VertexRef& vertex = pfCandToVertexAssociation->key;
-  
+
       const noPuUtils::CandQualityPairVector& pfCandidates_vertex = pfCandToVertexAssociation->val;
-      for ( noPuUtils::CandQualityPairVector::const_iterator pfCandidate_vertex = pfCandidates_vertex.begin();
-	    pfCandidate_vertex != pfCandidates_vertex.end(); ++pfCandidate_vertex ) {
-	revPfCandToVtxAssoc.insert(pfCandidate_vertex->first, std::make_pair(vertex,  pfCandidate_vertex->second));
+      for (noPuUtils::CandQualityPairVector::const_iterator pfCandidate_vertex = pfCandidates_vertex.begin();
+           pfCandidate_vertex != pfCandidates_vertex.end();
+           ++pfCandidate_vertex) {
+        revPfCandToVtxAssoc.insert(pfCandidate_vertex->first, std::make_pair(vertex, pfCandidate_vertex->second));
       }
     }
 
     return revPfCandToVtxAssoc;
   }
 
-  int 
-  isVertexAssociated_fast(const reco::PFCandidateRef& pfCandidate, 
-			  const noPuUtils::reversedPFCandToVertexAssMap& pfCandToVertexAssociations,
-			  const reco::VertexCollection& vertices, double dZ,
-			  int& numWarnings, int maxWarnings) {
-    int vtxAssociationType = noPuUtils::kNeutral; 
+  int isVertexAssociated_fast(const reco::PFCandidateRef& pfCandidate,
+                              const noPuUtils::reversedPFCandToVertexAssMap& pfCandToVertexAssociations,
+                              const reco::VertexCollection& vertices,
+                              double dZ,
+                              int& numWarnings,
+                              int maxWarnings) {
+    int vtxAssociationType = noPuUtils::kNeutral;
 
-    if ( pfCandidate->charge() != 0 ) {
+    if (pfCandidate->charge() != 0) {
       vtxAssociationType = noPuUtils::kChNoAssoc;
-    
+
       const noPuUtils::VertexQualityPairVector* pfCandAssocVtxs = nullptr;
-      noPuUtils::reversedPFCandToVertexAssMap::const_iterator itPfcToVtxAss = pfCandToVertexAssociations.find(pfCandidate);
-      if ( itPfcToVtxAss != pfCandToVertexAssociations.end() ) {
-	pfCandAssocVtxs = &itPfcToVtxAss->val;
+      noPuUtils::reversedPFCandToVertexAssMap::const_iterator itPfcToVtxAss =
+          pfCandToVertexAssociations.find(pfCandidate);
+      if (itPfcToVtxAss != pfCandToVertexAssociations.end()) {
+        pfCandAssocVtxs = &itPfcToVtxAss->val;
       } else {
-	for ( noPuUtils::reversedPFCandToVertexAssMap::const_iterator pfcToVtxAssoc = pfCandToVertexAssociations.begin();
-	      pfcToVtxAssoc != pfCandToVertexAssociations.end(); ++pfcToVtxAssoc ) {
-	  if ( deltaR2(pfCandidate->p4(), pfcToVtxAssoc->key->p4()) < dR2Min ) {
-	    pfCandAssocVtxs = &pfcToVtxAssoc->val;
-	    break;
-	  }
-	}
+        for (noPuUtils::reversedPFCandToVertexAssMap::const_iterator pfcToVtxAssoc = pfCandToVertexAssociations.begin();
+             pfcToVtxAssoc != pfCandToVertexAssociations.end();
+             ++pfcToVtxAssoc) {
+          if (deltaR2(pfCandidate->p4(), pfcToVtxAssoc->key->p4()) < dR2Min) {
+            pfCandAssocVtxs = &pfcToVtxAssoc->val;
+            break;
+          }
+        }
       }
-      if ( pfCandAssocVtxs!=nullptr ) {
-	for ( noPuUtils::VertexQualityPairVector::const_iterator pfcAssVtx = pfCandAssocVtxs->begin();
-	      pfcAssVtx != pfCandAssocVtxs->end(); ++pfcAssVtx ) {
-	  double z = pfcAssVtx->first->position().z();
-	  int quality = pfcAssVtx->second;
-	  promoteAssocToHSAssoc( quality, z, vertices, dZ, vtxAssociationType, false);
-	}
+      if (pfCandAssocVtxs != nullptr) {
+        for (noPuUtils::VertexQualityPairVector::const_iterator pfcAssVtx = pfCandAssocVtxs->begin();
+             pfcAssVtx != pfCandAssocVtxs->end();
+             ++pfcAssVtx) {
+          double z = pfcAssVtx->first->position().z();
+          int quality = pfcAssVtx->second;
+          promoteAssocToHSAssoc(quality, z, vertices, dZ, vtxAssociationType, false);
+        }
       }
     }
-  
+
     return vtxAssociationType;
   }
 
-  void promoteAssocToHSAssoc(int quality, double z, const reco::VertexCollection& vertices,
-			     double dZ, int& vtxAssociationType, bool checkdR2) {
-  
-    if ( quality >= noPuUtils::kChHSAssoc ) {
-      for ( reco::VertexCollection::const_iterator vertex = vertices.begin();
-	    vertex != vertices.end(); ++vertex ) {
-      
-	if ( std::abs( z - vertex->position().z()) < dZ ) {
-	  if ( vtxAssociationType < noPuUtils::kChHSAssoc ) vtxAssociationType = noPuUtils::kChHSAssoc;
-	}
+  void promoteAssocToHSAssoc(int quality,
+                             double z,
+                             const reco::VertexCollection& vertices,
+                             double dZ,
+                             int& vtxAssociationType,
+                             bool checkdR2) {
+    if (quality >= noPuUtils::kChHSAssoc) {
+      for (reco::VertexCollection::const_iterator vertex = vertices.begin(); vertex != vertices.end(); ++vertex) {
+        if (std::abs(z - vertex->position().z()) < dZ) {
+          if (vtxAssociationType < noPuUtils::kChHSAssoc)
+            vtxAssociationType = noPuUtils::kChHSAssoc;
+        }
       }
     }
-
   }
 
-}
+}  // namespace noPuUtils

--- a/RecoMET/METPUSubtraction/src/NoPileUpMEtUtilities.cc
+++ b/RecoMET/METPUSubtraction/src/NoPileUpMEtUtilities.cc
@@ -5,22 +5,19 @@
 #include <algorithm>
 #include <cmath>
 
-
 NoPileUpMEtUtilities::NoPileUpMEtUtilities() {
-  minPtDef_=-1;
-  maxPtDef_=1000000;
+  minPtDef_ = -1;
+  maxPtDef_ = 1000000;
 }
 
-NoPileUpMEtUtilities:: ~NoPileUpMEtUtilities() {
-}
+NoPileUpMEtUtilities::~NoPileUpMEtUtilities() {}
 
 // namespace NoPileUpMEtUtilities
 // {
 //-------------------------------------------------------------------------------
 // general auxiliary functions
-void 
-NoPileUpMEtUtilities::finalizeMEtData(CommonMETData& metData) {
-  metData.met = sqrt(metData.mex*metData.mex + metData.mey*metData.mey);
+void NoPileUpMEtUtilities::finalizeMEtData(CommonMETData& metData) {
+  metData.met = sqrt(metData.mex * metData.mex + metData.mey * metData.mey);
   metData.mez = 0.;
   metData.phi = atan2(metData.mey, metData.mex);
 }
@@ -28,47 +25,46 @@ NoPileUpMEtUtilities::finalizeMEtData(CommonMETData& metData) {
 
 //-------------------------------------------------------------------------------
 // auxiliary functions for jets
-reco::PUSubMETCandInfoCollection 
-NoPileUpMEtUtilities::cleanJets(const reco::PUSubMETCandInfoCollection& jets,
-				const std::vector<reco::Candidate::LorentzVector>& leptons,
-				double dRoverlap, bool invert) {
+reco::PUSubMETCandInfoCollection NoPileUpMEtUtilities::cleanJets(
+    const reco::PUSubMETCandInfoCollection& jets,
+    const std::vector<reco::Candidate::LorentzVector>& leptons,
+    double dRoverlap,
+    bool invert) {
   reco::PUSubMETCandInfoCollection retVal;
-  for ( reco::PUSubMETCandInfoCollection::const_iterator jet = jets.begin();
-	jet != jets.end(); ++jet ) {
+  for (reco::PUSubMETCandInfoCollection::const_iterator jet = jets.begin(); jet != jets.end(); ++jet) {
     bool isOverlap = false;
-    for ( std::vector<reco::Candidate::LorentzVector>::const_iterator lepton = leptons.begin();
-	  lepton != leptons.end(); ++lepton ) {
-      if ( deltaR2(jet->p4(), *lepton) < dRoverlap*dRoverlap ) {
-	isOverlap = true;
-	break;
+    for (std::vector<reco::Candidate::LorentzVector>::const_iterator lepton = leptons.begin(); lepton != leptons.end();
+         ++lepton) {
+      if (deltaR2(jet->p4(), *lepton) < dRoverlap * dRoverlap) {
+        isOverlap = true;
+        break;
       }
     }
-    if ( (!isOverlap && !invert) || (isOverlap && invert) ) retVal.push_back(*jet);
+    if ((!isOverlap && !invert) || (isOverlap && invert))
+      retVal.push_back(*jet);
   }
   return retVal;
 }
 
-
-CommonMETData 
-NoPileUpMEtUtilities::computeCandidateSum(const reco::PUSubMETCandInfoCollection& cands,
-					  bool neutralFracOnly, double& sumAbsPx, double& sumAbsPy) {
-  
+CommonMETData NoPileUpMEtUtilities::computeCandidateSum(const reco::PUSubMETCandInfoCollection& cands,
+                                                        bool neutralFracOnly,
+                                                        double& sumAbsPx,
+                                                        double& sumAbsPy) {
   CommonMETData retVal;
-  retVal.mex   = 0.;
-  retVal.mey   = 0.;
+  retVal.mex = 0.;
+  retVal.mey = 0.;
   retVal.sumet = 0.;
   double retVal_sumAbsPx = 0.;
   double retVal_sumAbsPy = 0.;
-  double pFrac=1;
-  for ( reco::PUSubMETCandInfoCollection::const_iterator cand = cands.begin();
-	cand != cands.end(); ++cand ) {
- 
-    pFrac=1;
-    if(neutralFracOnly) pFrac = (1-cand->chargedEnFrac() );
-      
-    retVal.mex   += cand->p4().px()*pFrac;
-    retVal.mey   += cand->p4().py()*pFrac;
-    retVal.sumet += cand->p4().pt()*pFrac;
+  double pFrac = 1;
+  for (reco::PUSubMETCandInfoCollection::const_iterator cand = cands.begin(); cand != cands.end(); ++cand) {
+    pFrac = 1;
+    if (neutralFracOnly)
+      pFrac = (1 - cand->chargedEnFrac());
+
+    retVal.mex += cand->p4().px() * pFrac;
+    retVal.mey += cand->p4().py() * pFrac;
+    retVal.sumet += cand->p4().pt() * pFrac;
     retVal_sumAbsPx += std::abs(cand->p4().px());
     retVal_sumAbsPy += std::abs(cand->p4().py());
   }
@@ -77,51 +73,57 @@ NoPileUpMEtUtilities::computeCandidateSum(const reco::PUSubMETCandInfoCollection
   sumAbsPy = retVal_sumAbsPy;
   return retVal;
 }
-  
+
 //-------------------------------------------------------------------------------
 
 //-------------------------------------------------------------------------------
 // auxiliary functions for PFCandidates
-reco::PUSubMETCandInfoCollection 
-NoPileUpMEtUtilities::cleanPFCandidates(const reco::PUSubMETCandInfoCollection& pfCandidates,
-					const std::vector<reco::Candidate::LorentzVector>& leptons,
-					double dRoverlap, bool invert) {
-// invert: false = PFCandidates are required not to overlap with leptons
-//         true  = PFCandidates are required to overlap with leptons
-  
+reco::PUSubMETCandInfoCollection NoPileUpMEtUtilities::cleanPFCandidates(
+    const reco::PUSubMETCandInfoCollection& pfCandidates,
+    const std::vector<reco::Candidate::LorentzVector>& leptons,
+    double dRoverlap,
+    bool invert) {
+  // invert: false = PFCandidates are required not to overlap with leptons
+  //         true  = PFCandidates are required to overlap with leptons
+
   reco::PUSubMETCandInfoCollection retVal;
-  for ( reco::PUSubMETCandInfoCollection::const_iterator pfCandidate = pfCandidates.begin();
-	pfCandidate != pfCandidates.end(); ++pfCandidate ) {
+  for (reco::PUSubMETCandInfoCollection::const_iterator pfCandidate = pfCandidates.begin();
+       pfCandidate != pfCandidates.end();
+       ++pfCandidate) {
     bool isOverlap = false;
-    for ( std::vector<reco::Candidate::LorentzVector>::const_iterator lepton = leptons.begin();
-	  lepton != leptons.end(); ++lepton ) {
-      if ( deltaR2(pfCandidate->p4(), *lepton) < dRoverlap*dRoverlap ) {
-	isOverlap = true;
-	break;
+    for (std::vector<reco::Candidate::LorentzVector>::const_iterator lepton = leptons.begin(); lepton != leptons.end();
+         ++lepton) {
+      if (deltaR2(pfCandidate->p4(), *lepton) < dRoverlap * dRoverlap) {
+        isOverlap = true;
+        break;
       }
     }
-    if ( (!isOverlap && !invert) || (isOverlap && invert) ) retVal.push_back(*pfCandidate);
+    if ((!isOverlap && !invert) || (isOverlap && invert))
+      retVal.push_back(*pfCandidate);
   }
   return retVal;
 }
 
-
-reco::PUSubMETCandInfoCollection 
-NoPileUpMEtUtilities::selectCandidates(const reco::PUSubMETCandInfoCollection& cands, 
-				       double minPt, double maxPt, int type, 
-				       bool isCharged, int isWithinJet) {
+reco::PUSubMETCandInfoCollection NoPileUpMEtUtilities::selectCandidates(const reco::PUSubMETCandInfoCollection& cands,
+                                                                        double minPt,
+                                                                        double maxPt,
+                                                                        int type,
+                                                                        bool isCharged,
+                                                                        int isWithinJet) {
   reco::PUSubMETCandInfoCollection retVal;
-  for ( reco::PUSubMETCandInfoCollection::const_iterator cand = cands.begin();
-	cand != cands.end(); ++cand ) {
-      
-    if( isCharged && cand->charge()==0) continue;
-    double jetPt = cand->p4().pt();      
-    if(  jetPt < minPt || jetPt > maxPt ) continue;
-    if(type != reco::PUSubMETCandInfo::kUndefined && cand->type() != type) continue; 
-      
+  for (reco::PUSubMETCandInfoCollection::const_iterator cand = cands.begin(); cand != cands.end(); ++cand) {
+    if (isCharged && cand->charge() == 0)
+      continue;
+    double jetPt = cand->p4().pt();
+    if (jetPt < minPt || jetPt > maxPt)
+      continue;
+    if (type != reco::PUSubMETCandInfo::kUndefined && cand->type() != type)
+      continue;
+
     //for pf candidates
-    if( isWithinJet!=NoPileUpMEtUtilities::kAll && ( cand->isWithinJet()!=isWithinJet ) ) continue;
-      
+    if (isWithinJet != NoPileUpMEtUtilities::kAll && (cand->isWithinJet() != isWithinJet))
+      continue;
+
     retVal.push_back(*cand);
   }
   return retVal;
@@ -135,30 +137,24 @@ NoPileUpMEtUtilities::selectCandidates(const reco::PUSubMETCandInfoCollection& c
 //       need to be cleaned wrt. leptons
 //
 
-void 
-NoPileUpMEtUtilities::computeAllSums( const reco::PUSubMETCandInfoCollection& jets,
-				      const reco::PUSubMETCandInfoCollection& pfCandidates) {
-  
-  reco::PUSubMETCandInfoCollection pfcsCh = selectCandidates( pfCandidates, minPtDef_, maxPtDef_,
-							      reco::PUSubMETCandInfo::kUndefined, false,
-							      NoPileUpMEtUtilities::kAll);
+void NoPileUpMEtUtilities::computeAllSums(const reco::PUSubMETCandInfoCollection& jets,
+                                          const reco::PUSubMETCandInfoCollection& pfCandidates) {
+  reco::PUSubMETCandInfoCollection pfcsCh = selectCandidates(
+      pfCandidates, minPtDef_, maxPtDef_, reco::PUSubMETCandInfo::kUndefined, false, NoPileUpMEtUtilities::kAll);
 
-  reco::PUSubMETCandInfoCollection pfcsChHS = selectCandidates( pfCandidates, minPtDef_, maxPtDef_, 
-								reco::PUSubMETCandInfo::kChHS, true,
-								NoPileUpMEtUtilities::kAll);
+  reco::PUSubMETCandInfoCollection pfcsChHS = selectCandidates(
+      pfCandidates, minPtDef_, maxPtDef_, reco::PUSubMETCandInfo::kChHS, true, NoPileUpMEtUtilities::kAll);
 
-  reco::PUSubMETCandInfoCollection pfcsChPU = selectCandidates( pfCandidates, minPtDef_, maxPtDef_,
-								reco::PUSubMETCandInfo::kChPU, true, 
-								NoPileUpMEtUtilities::kAll);
-  
-  reco::PUSubMETCandInfoCollection pfcsNUnclustered = selectCandidates( pfCandidates, minPtDef_, maxPtDef_, 
-									reco::PUSubMETCandInfo::kNeutral, false,
-									NoPileUpMEtUtilities::kOutsideJet);
-  
-  reco::PUSubMETCandInfoCollection jetsHS = selectCandidates(jets, 10.0, maxPtDef_, reco::PUSubMETCandInfo::kHS, false,
-							     NoPileUpMEtUtilities::kAll);
-  reco::PUSubMETCandInfoCollection jetsPU = selectCandidates(jets, 10.0, maxPtDef_, reco::PUSubMETCandInfo::kPU, false,
-							     NoPileUpMEtUtilities::kAll);
+  reco::PUSubMETCandInfoCollection pfcsChPU = selectCandidates(
+      pfCandidates, minPtDef_, maxPtDef_, reco::PUSubMETCandInfo::kChPU, true, NoPileUpMEtUtilities::kAll);
+
+  reco::PUSubMETCandInfoCollection pfcsNUnclustered = selectCandidates(
+      pfCandidates, minPtDef_, maxPtDef_, reco::PUSubMETCandInfo::kNeutral, false, NoPileUpMEtUtilities::kOutsideJet);
+
+  reco::PUSubMETCandInfoCollection jetsHS =
+      selectCandidates(jets, 10.0, maxPtDef_, reco::PUSubMETCandInfo::kHS, false, NoPileUpMEtUtilities::kAll);
+  reco::PUSubMETCandInfoCollection jetsPU =
+      selectCandidates(jets, 10.0, maxPtDef_, reco::PUSubMETCandInfo::kPU, false, NoPileUpMEtUtilities::kAll);
 
   //not used so far
   //_chPfcSum = computeCandidateSum(pfcsCh, false, &_chPfcSumAbsPx, &_chPfcSumAbsPy);
@@ -168,11 +164,9 @@ NoPileUpMEtUtilities::computeAllSums( const reco::PUSubMETCandInfoCollection& je
 
   nHSJetSum_ = computeCandidateSum(jetsHS, true, nHSJetSumAbsPx_, nHSJetSumAbsPy_);
   nPUJetSum_ = computeCandidateSum(jetsPU, true, nPUJetSumAbsPx_, nPUJetSumAbsPy_);
-  
 }
-  
-CommonMETData 
-NoPileUpMEtUtilities::computeRecoil(int metType, double& sumAbsPx, double& sumAbsPy) {
+
+CommonMETData NoPileUpMEtUtilities::computeRecoil(int metType, double& sumAbsPx, double& sumAbsPy) {
   CommonMETData retVal;
   double retSumAbsPx = 0.;
   double retSumAbsPy = 0.;
@@ -183,47 +177,47 @@ NoPileUpMEtUtilities::computeRecoil(int metType, double& sumAbsPx, double& sumAb
   //   retVal.mex   = -chPfcSum.mex;
   //   retVal.mey   = -chPfcSum.mey;
   //   retVal.sumet = chPfcSum.sumet;
-  //   retSumAbsPx = ; 
-  //   retSumAbsPy = ; 
+  //   retSumAbsPx = ;
+  //   retSumAbsPy = ;
   // }
-  if(metType==NoPileUpMEtUtilities::kChHSMET) {
-    retVal.mex   = chHSPfcSum_.mex;
-    retVal.mey   = chHSPfcSum_.mey;
+  if (metType == NoPileUpMEtUtilities::kChHSMET) {
+    retVal.mex = chHSPfcSum_.mex;
+    retVal.mey = chHSPfcSum_.mey;
     retVal.sumet = chHSPfcSum_.sumet;
-    retSumAbsPx = chHSPfcSumAbsPx_; 
-    retSumAbsPy = chHSPfcSumAbsPy_; 
+    retSumAbsPx = chHSPfcSumAbsPx_;
+    retSumAbsPy = chHSPfcSumAbsPy_;
   }
-  if(metType==NoPileUpMEtUtilities::kChPUMET) {
-    retVal.mex   = chPUPfcSum_.mex;
-    retVal.mey   = chPUPfcSum_.mey;
+  if (metType == NoPileUpMEtUtilities::kChPUMET) {
+    retVal.mex = chPUPfcSum_.mex;
+    retVal.mey = chPUPfcSum_.mey;
     retVal.sumet = chPUPfcSum_.sumet;
-    retSumAbsPx = chPUPfcSumAbsPx_; 
-    retSumAbsPy = chPUPfcSumAbsPy_; 
+    retSumAbsPx = chPUPfcSumAbsPx_;
+    retSumAbsPy = chPUPfcSumAbsPy_;
   }
-  if(metType==NoPileUpMEtUtilities::kNeutralUncMET) {
-    retVal.mex   = nUncPfcSum_.mex;
-    retVal.mey   = nUncPfcSum_.mey;
+  if (metType == NoPileUpMEtUtilities::kNeutralUncMET) {
+    retVal.mex = nUncPfcSum_.mex;
+    retVal.mey = nUncPfcSum_.mey;
     retVal.sumet = nUncPfcSum_.sumet;
-    retSumAbsPx = nUncPfcSumAbsPx_; 
-    retSumAbsPy = nUncPfcSumAbsPy_; 
+    retSumAbsPx = nUncPfcSumAbsPx_;
+    retSumAbsPy = nUncPfcSumAbsPy_;
   }
-  if(metType==NoPileUpMEtUtilities::kHadronicHSMET) {
-    retVal.mex   = chHSPfcSum_.mex + nHSJetSum_.mex;
-    retVal.mey   = chHSPfcSum_.mey + nHSJetSum_.mey;
+  if (metType == NoPileUpMEtUtilities::kHadronicHSMET) {
+    retVal.mex = chHSPfcSum_.mex + nHSJetSum_.mex;
+    retVal.mey = chHSPfcSum_.mey + nHSJetSum_.mey;
     retVal.sumet = chHSPfcSum_.sumet + nHSJetSum_.sumet;
-    retSumAbsPx = chHSPfcSumAbsPx_ + nHSJetSumAbsPx_; 
-    retSumAbsPy = chHSPfcSumAbsPy_ + nHSJetSumAbsPy_; 
+    retSumAbsPx = chHSPfcSumAbsPx_ + nHSJetSumAbsPx_;
+    retSumAbsPy = chHSPfcSumAbsPy_ + nHSJetSumAbsPy_;
   }
-  if(metType==NoPileUpMEtUtilities::kHadronicPUMET) {
-    retVal.mex   = chPUPfcSum_.mex + nHSJetSum_.mex;
-    retVal.mey   = chPUPfcSum_.mey + nHSJetSum_.mey;
+  if (metType == NoPileUpMEtUtilities::kHadronicPUMET) {
+    retVal.mex = chPUPfcSum_.mex + nHSJetSum_.mex;
+    retVal.mey = chPUPfcSum_.mey + nHSJetSum_.mey;
     retVal.sumet = chPUPfcSum_.sumet + nHSJetSum_.sumet;
-    retSumAbsPx = chPUPfcSumAbsPx_ + nHSJetSumAbsPx_; 
-    retSumAbsPy = chPUPfcSumAbsPy_ + nHSJetSumAbsPy_; 
+    retSumAbsPx = chPUPfcSumAbsPx_ + nHSJetSumAbsPx_;
+    retSumAbsPy = chPUPfcSumAbsPy_ + nHSJetSumAbsPy_;
   }
 
- sumAbsPx = retSumAbsPx;
- sumAbsPy = retSumAbsPy;
- 
- return retVal;
+  sumAbsPx = retSumAbsPx;
+  sumAbsPy = retSumAbsPy;
+
+  return retVal;
 }

--- a/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
+++ b/RecoMET/METPUSubtraction/src/PFMETAlgorithmMVA.cc
@@ -15,98 +15,123 @@
 
 enum MVAType { kBaseline = 0 };
 
-const double Pi=std::cos(-1);
+const double Pi = std::cos(-1);
 
-const std::string PFMETAlgorithmMVA::updateVariableNames(std::string input)
-{
-  if(input=="sumet")     return "particleFlow_SumET";
-  if(input=="npv")       return "nPV";
-  if(input=="pfu")       return "particleFlow_U";
-  if(input=="pfuphi")    return "particleFlow_UPhi";
-  if(input=="tksumet")   return "track_SumET";
-  if(input=="tku")       return "track_U";
-  if(input=="tkuphi")    return "track_UPhi";
-  if(input=="nopusumet") return "noPileUp_SumET";
-  if(input=="nopuu")     return "noPileUp_U";
-  if(input=="nopuuphi")  return "noPileUp_UPhi";
-  if(input=="pusumet")   return "pileUp_SumET";
-  if(input=="pumet")     return "pileUp_MET";
-  if(input=="pumetphi")  return "pileUp_METPhi";
-  if(input=="pucsumet")  return "pileUpCorrected_SumET";
-  if(input=="pucu")      return "pileUpCorrected_U";
-  if(input=="pucuphi")   return "pileUpCorrected_UPhi";
-  if(input=="jetpt1")    return "jet1_pT";
-  if(input=="jeteta1")   return "jet1_eta";
-  if(input=="jetphi1")   return "jet1_Phi";
-  if(input=="jetpt2")    return "jet2_pT";
-  if(input=="jeteta2")   return "jet2_eta";
-  if(input=="jetphi2")   return "jet2_Phi";
-  if(input=="nalljet")   return "nJets";
-  if(input=="njet")      return "numJetsPtGt30";
-  if(input=="uphi_mva")  return "PhiCor_UPhi";
-  if(input=="uphix_mva") return "PhiCor_UPhi";
-  if(input=="ux_mva")    return "RecoilCor_U";
+const std::string PFMETAlgorithmMVA::updateVariableNames(std::string input) {
+  if (input == "sumet")
+    return "particleFlow_SumET";
+  if (input == "npv")
+    return "nPV";
+  if (input == "pfu")
+    return "particleFlow_U";
+  if (input == "pfuphi")
+    return "particleFlow_UPhi";
+  if (input == "tksumet")
+    return "track_SumET";
+  if (input == "tku")
+    return "track_U";
+  if (input == "tkuphi")
+    return "track_UPhi";
+  if (input == "nopusumet")
+    return "noPileUp_SumET";
+  if (input == "nopuu")
+    return "noPileUp_U";
+  if (input == "nopuuphi")
+    return "noPileUp_UPhi";
+  if (input == "pusumet")
+    return "pileUp_SumET";
+  if (input == "pumet")
+    return "pileUp_MET";
+  if (input == "pumetphi")
+    return "pileUp_METPhi";
+  if (input == "pucsumet")
+    return "pileUpCorrected_SumET";
+  if (input == "pucu")
+    return "pileUpCorrected_U";
+  if (input == "pucuphi")
+    return "pileUpCorrected_UPhi";
+  if (input == "jetpt1")
+    return "jet1_pT";
+  if (input == "jeteta1")
+    return "jet1_eta";
+  if (input == "jetphi1")
+    return "jet1_Phi";
+  if (input == "jetpt2")
+    return "jet2_pT";
+  if (input == "jeteta2")
+    return "jet2_eta";
+  if (input == "jetphi2")
+    return "jet2_Phi";
+  if (input == "nalljet")
+    return "nJets";
+  if (input == "njet")
+    return "numJetsPtGt30";
+  if (input == "uphi_mva")
+    return "PhiCor_UPhi";
+  if (input == "uphix_mva")
+    return "PhiCor_UPhi";
+  if (input == "ux_mva")
+    return "RecoilCor_U";
   return input;
 }
 
-const GBRForest* PFMETAlgorithmMVA::loadMVAfromFile(const edm::FileInPath& inputFileName, const std::string& mvaName)
-{
-  if ( inputFileName.location()==edm::FileInPath::Unknown ) throw cms::Exception("PFMETAlgorithmMVA::loadMVA") 
-    << " Failed to find File = " << inputFileName << " !!\n";
-  std::unique_ptr<TFile> inputFile(new TFile(inputFileName.fullPath().data()) );
+const GBRForest* PFMETAlgorithmMVA::loadMVAfromFile(const edm::FileInPath& inputFileName, const std::string& mvaName) {
+  if (inputFileName.location() == edm::FileInPath::Unknown)
+    throw cms::Exception("PFMETAlgorithmMVA::loadMVA") << " Failed to find File = " << inputFileName << " !!\n";
+  std::unique_ptr<TFile> inputFile(new TFile(inputFileName.fullPath().data()));
 
-  std::vector<std::string> *lVec = (std::vector<std::string>*)inputFile->Get("varlist");
+  std::vector<std::string>* lVec = (std::vector<std::string>*)inputFile->Get("varlist");
 
-  if(lVec==nullptr) {
+  if (lVec == nullptr) {
     throw cms::Exception("PFMETAlgorithmMVA::loadMVA")
-      << " Failed to load mva file : " << inputFileName.fullPath().data() << " is not a proper file !!\n";
+        << " Failed to load mva file : " << inputFileName.fullPath().data() << " is not a proper file !!\n";
   }
 
   std::vector<std::string> variableNames;
-  for(unsigned int i=0; i< lVec->size();++i)
-  {
-      variableNames.push_back(updateVariableNames(lVec->at(i)));
+  for (unsigned int i = 0; i < lVec->size(); ++i) {
+    variableNames.push_back(updateVariableNames(lVec->at(i)));
   }
 
-  if(mvaName.find(mvaNameU_)      != std::string::npos) varForU_    = variableNames;
-  else if(mvaName.find(mvaNameDPhi_)   != std::string::npos) varForDPhi_ = variableNames;
-  else if(mvaName.find(mvaNameCovU1_)  != std::string::npos) varForCovU1_ = variableNames;
-  else if(mvaName.find(mvaNameCovU2_)  != std::string::npos) varForCovU2_ = variableNames;
-  else throw cms::Exception("PFMETAlgorithmMVA::loadMVA") << "MVA MET weight file tree names do not match specified inputs" << std::endl;
-
+  if (mvaName.find(mvaNameU_) != std::string::npos)
+    varForU_ = variableNames;
+  else if (mvaName.find(mvaNameDPhi_) != std::string::npos)
+    varForDPhi_ = variableNames;
+  else if (mvaName.find(mvaNameCovU1_) != std::string::npos)
+    varForCovU1_ = variableNames;
+  else if (mvaName.find(mvaNameCovU2_) != std::string::npos)
+    varForCovU2_ = variableNames;
+  else
+    throw cms::Exception("PFMETAlgorithmMVA::loadMVA")
+        << "MVA MET weight file tree names do not match specified inputs" << std::endl;
 
   const GBRForest* mva = (GBRForest*)inputFile->Get(mvaName.data());
-  if ( !mva )
+  if (!mva)
     throw cms::Exception("PFMETAlgorithmMVA::loadMVA")
-      << " Failed to load MVA = " << mvaName.data() << " from file = " << inputFileName.fullPath().data() << " !!\n";
+        << " Failed to load MVA = " << mvaName.data() << " from file = " << inputFileName.fullPath().data() << " !!\n";
 
   return mva;
 }
 
-const GBRForest* PFMETAlgorithmMVA::loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName)
-{
+const GBRForest* PFMETAlgorithmMVA::loadMVAfromDB(const edm::EventSetup& es, const std::string& mvaName) {
   edm::ESHandle<GBRForest> mva;
   es.get<GBRWrapperRcd>().get(mvaName, mva);
   return mva.product();
 }
 
-PFMETAlgorithmMVA::PFMETAlgorithmMVA(const edm::ParameterSet& cfg) 
-  : utils_(cfg),
-    mvaReaderU_(nullptr),
-    mvaReaderDPhi_(nullptr),
-    mvaReaderCovU1_(nullptr),
-    mvaReaderCovU2_(nullptr),
-    cfg_(cfg)
-{
+PFMETAlgorithmMVA::PFMETAlgorithmMVA(const edm::ParameterSet& cfg)
+    : utils_(cfg),
+      mvaReaderU_(nullptr),
+      mvaReaderDPhi_(nullptr),
+      mvaReaderCovU1_(nullptr),
+      mvaReaderCovU2_(nullptr),
+      cfg_(cfg) {
   mvaType_ = kBaseline;
 
   loadMVAfromDB_ = cfg.getParameter<bool>("loadMVAfromDB");
-  
 }
 
-PFMETAlgorithmMVA::~PFMETAlgorithmMVA()
-{
-  if ( !loadMVAfromDB_ ) {
+PFMETAlgorithmMVA::~PFMETAlgorithmMVA() {
+  if (!loadMVAfromDB_) {
     delete mvaReaderU_;
     delete mvaReaderDPhi_;
     delete mvaReaderCovU1_;
@@ -115,26 +140,25 @@ PFMETAlgorithmMVA::~PFMETAlgorithmMVA()
 }
 
 //-------------------------------------------------------------------------------
-void PFMETAlgorithmMVA::initialize(const edm::EventSetup& es)
-{
+void PFMETAlgorithmMVA::initialize(const edm::EventSetup& es) {
   edm::ParameterSet cfgInputRecords = cfg_.getParameter<edm::ParameterSet>("inputRecords");
-  mvaNameU_       = cfgInputRecords.getParameter<std::string>("U");
-  mvaNameDPhi_    = cfgInputRecords.getParameter<std::string>("DPhi");
-  mvaNameCovU1_   = cfgInputRecords.getParameter<std::string>("CovU1");
-  mvaNameCovU2_   = cfgInputRecords.getParameter<std::string>("CovU2");
+  mvaNameU_ = cfgInputRecords.getParameter<std::string>("U");
+  mvaNameDPhi_ = cfgInputRecords.getParameter<std::string>("DPhi");
+  mvaNameCovU1_ = cfgInputRecords.getParameter<std::string>("CovU1");
+  mvaNameCovU2_ = cfgInputRecords.getParameter<std::string>("CovU2");
 
-  if ( loadMVAfromDB_ ) {
-    mvaReaderU_     = loadMVAfromDB(es, mvaNameU_);
-    mvaReaderDPhi_  = loadMVAfromDB(es, mvaNameDPhi_);
+  if (loadMVAfromDB_) {
+    mvaReaderU_ = loadMVAfromDB(es, mvaNameU_);
+    mvaReaderDPhi_ = loadMVAfromDB(es, mvaNameDPhi_);
     mvaReaderCovU1_ = loadMVAfromDB(es, mvaNameCovU1_);
     mvaReaderCovU2_ = loadMVAfromDB(es, mvaNameCovU2_);
   } else {
     edm::ParameterSet cfgInputFileNames = cfg_.getParameter<edm::ParameterSet>("inputFileNames");
-    
+
     edm::FileInPath inputFileNameU = cfgInputFileNames.getParameter<edm::FileInPath>("U");
-    mvaReaderU_     = loadMVAfromFile(inputFileNameU, mvaNameU_);
+    mvaReaderU_ = loadMVAfromFile(inputFileNameU, mvaNameU_);
     edm::FileInPath inputFileNameDPhi = cfgInputFileNames.getParameter<edm::FileInPath>("DPhi");
-    mvaReaderDPhi_  = loadMVAfromFile(inputFileNameDPhi, mvaNameDPhi_);
+    mvaReaderDPhi_ = loadMVAfromFile(inputFileNameDPhi, mvaNameDPhi_);
     edm::FileInPath inputFileNameCovU1 = cfgInputFileNames.getParameter<edm::FileInPath>("CovU1");
     mvaReaderCovU1_ = loadMVAfromFile(inputFileNameCovU1, mvaNameCovU1_);
     edm::FileInPath inputFileNameCovU2 = cfgInputFileNames.getParameter<edm::FileInPath>("CovU2");
@@ -144,141 +168,131 @@ void PFMETAlgorithmMVA::initialize(const edm::EventSetup& es)
 
 //-------------------------------------------------------------------------------
 void PFMETAlgorithmMVA::setInput(const std::vector<reco::PUSubMETCandInfo>& leptons,
-				 const std::vector<reco::PUSubMETCandInfo>& jets,
-				 const std::vector<reco::PUSubMETCandInfo>& pfCandidates,
-				 const std::vector<reco::Vertex::Point>& vertices)
-{
+                                 const std::vector<reco::PUSubMETCandInfo>& jets,
+                                 const std::vector<reco::PUSubMETCandInfo>& pfCandidates,
+                                 const std::vector<reco::Vertex::Point>& vertices) {
+  utils_.computeAllSums(jets, leptons, pfCandidates);
 
-  
-  utils_.computeAllSums( jets, leptons, pfCandidates);
-  
-  sumLeptonPx_        = utils_.getLeptonsSumMEX();
-  sumLeptonPy_        = utils_.getLeptonsSumMEY();
+  sumLeptonPx_ = utils_.getLeptonsSumMEX();
+  sumLeptonPy_ = utils_.getLeptonsSumMEY();
 
   chargedSumLeptonPx_ = utils_.getLeptonsChSumMEX();
   chargedSumLeptonPy_ = utils_.getLeptonsChSumMEY();
 
   const std::vector<reco::PUSubMETCandInfo> jets_cleaned = utils_.getCleanedJets();
 
-  CommonMETData pfRecoil_data  = utils_.computeRecoil( MvaMEtUtilities::kPF );
-  CommonMETData chHSRecoil_data  = utils_.computeRecoil( MvaMEtUtilities::kChHS );
-  CommonMETData hsRecoil_data = utils_.computeRecoil( MvaMEtUtilities::kHS );
-  CommonMETData puRecoil_data = utils_.computeRecoil( MvaMEtUtilities::kPU );
-  CommonMETData hsMinusNeutralPUMEt_data = utils_.computeRecoil( MvaMEtUtilities::kHSMinusNeutralPU );
+  CommonMETData pfRecoil_data = utils_.computeRecoil(MvaMEtUtilities::kPF);
+  CommonMETData chHSRecoil_data = utils_.computeRecoil(MvaMEtUtilities::kChHS);
+  CommonMETData hsRecoil_data = utils_.computeRecoil(MvaMEtUtilities::kHS);
+  CommonMETData puRecoil_data = utils_.computeRecoil(MvaMEtUtilities::kPU);
+  CommonMETData hsMinusNeutralPUMEt_data = utils_.computeRecoil(MvaMEtUtilities::kHSMinusNeutralPU);
 
   reco::Candidate::LorentzVector jet1P4 = utils_.leadJetP4(jets_cleaned);
   reco::Candidate::LorentzVector jet2P4 = utils_.subleadJetP4(jets_cleaned);
 
+  var_["particleFlow_U"] = pfRecoil_data.met;
+  var_["particleFlow_SumET"] = pfRecoil_data.sumet;
+  var_["particleFlow_UPhi"] = pfRecoil_data.phi;
 
-  var_["particleFlow_U"]        = pfRecoil_data.met;
-  var_["particleFlow_SumET"]    = pfRecoil_data.sumet;
-  var_["particleFlow_UPhi"]     = pfRecoil_data.phi;
+  var_["track_SumET"] = chHSRecoil_data.sumet / var_["particleFlow_SumET"];
+  var_["track_U"] = chHSRecoil_data.met;
+  var_["track_UPhi"] = chHSRecoil_data.phi;
 
-  var_["track_SumET"]           = chHSRecoil_data.sumet/var_["particleFlow_SumET"];
-  var_["track_U"]               = chHSRecoil_data.met;
-  var_["track_UPhi"]            = chHSRecoil_data.phi;
+  var_["noPileUp_SumET"] = hsRecoil_data.sumet / var_["particleFlow_SumET"];
+  var_["noPileUp_U"] = hsRecoil_data.met;
+  var_["noPileUp_UPhi"] = hsRecoil_data.phi;
 
-  var_["noPileUp_SumET"]        = hsRecoil_data.sumet/var_["particleFlow_SumET"];
-  var_["noPileUp_U"]            = hsRecoil_data.met;
-  var_["noPileUp_UPhi"]         = hsRecoil_data.phi;
+  var_["pileUp_SumET"] = puRecoil_data.sumet / var_["particleFlow_SumET"];
+  var_["pileUp_MET"] = puRecoil_data.met;
+  var_["pileUp_METPhi"] = puRecoil_data.phi;
 
-  var_["pileUp_SumET"]          = puRecoil_data.sumet/var_["particleFlow_SumET"];
-  var_["pileUp_MET"]            = puRecoil_data.met;
-  var_["pileUp_METPhi"]         = puRecoil_data.phi;
+  var_["pileUpCorrected_SumET"] = hsMinusNeutralPUMEt_data.sumet / var_["particleFlow_SumET"];
+  var_["pileUpCorrected_U"] = hsMinusNeutralPUMEt_data.met;
+  var_["pileUpCorrected_UPhi"] = hsMinusNeutralPUMEt_data.phi;
 
-  var_["pileUpCorrected_SumET"] = hsMinusNeutralPUMEt_data.sumet/var_["particleFlow_SumET"];
-  var_["pileUpCorrected_U"]     = hsMinusNeutralPUMEt_data.met;
-  var_["pileUpCorrected_UPhi"]  = hsMinusNeutralPUMEt_data.phi;
+  var_["jet1_pT"] = jet1P4.pt();
+  var_["jet1_eta"] = jet1P4.eta();
+  var_["jet1_Phi"] = jet1P4.phi();
+  var_["jet2_pT"] = jet2P4.pt();
+  var_["jet2_eta"] = jet2P4.eta();
+  var_["jet2_Phi"] = jet2P4.phi();
 
-  var_["jet1_pT"]               = jet1P4.pt();
-  var_["jet1_eta"]              = jet1P4.eta();
-  var_["jet1_Phi"]              = jet1P4.phi();
-  var_["jet2_pT"]               = jet2P4.pt();
-  var_["jet2_eta"]              = jet2P4.eta();
-  var_["jet2_Phi"]              = jet2P4.phi();
-
-  var_["numJetsPtGt30"]         = utils_.numJetsAboveThreshold(jets_cleaned, 30.);
-  var_["nJets"]                 = jets_cleaned.size();
-  var_["nPV"]                   = vertices.size();
+  var_["numJetsPtGt30"] = utils_.numJetsAboveThreshold(jets_cleaned, 30.);
+  var_["nJets"] = jets_cleaned.size();
+  var_["nPV"] = vertices.size();
 }
 
 //-------------------------------------------------------------------------------
-std::unique_ptr<float[]> PFMETAlgorithmMVA::createFloatVector(std::vector<std::string> variableNames)
-{
+std::unique_ptr<float[]> PFMETAlgorithmMVA::createFloatVector(std::vector<std::string> variableNames) {
   std::unique_ptr<float[]> floatVector(new float[variableNames.size()]);
-    int i = 0;
-    for(auto variableName: variableNames)
-    {
-        floatVector[i++] = var_[variableName];
-    }
-    return floatVector;
+  int i = 0;
+  for (auto variableName : variableNames) {
+    floatVector[i++] = var_[variableName];
+  }
+  return floatVector;
 }
 
 //-------------------------------------------------------------------------------
-void PFMETAlgorithmMVA::evaluateMVA()
-{
+void PFMETAlgorithmMVA::evaluateMVA() {
   // CV: MVAs needs to be evaluated in order { DPhi, U1, CovU1, CovU2 }
   //     as MVA for U1 (CovU1, CovU2) uses output of DPhi (DPhi and U1) MVA
-  mvaOutputDPhi_  = GetResponse(mvaReaderDPhi_, varForDPhi_);
+  mvaOutputDPhi_ = GetResponse(mvaReaderDPhi_, varForDPhi_);
   var_["PhiCor_UPhi"] = var_["particleFlow_UPhi"] + mvaOutputDPhi_;
-  mvaOutputU_     = GetResponse(mvaReaderU_, varForU_);
+  mvaOutputU_ = GetResponse(mvaReaderU_, varForU_);
   var_["RecoilCor_U"] = var_["particleFlow_U"] * mvaOutputU_;
   var_["RecoilCor_UPhi"] = var_["PhiCor_UPhi"];
-  mvaOutputCovU1_ = std::pow(GetResponse(mvaReaderCovU1_, varForCovU1_)* mvaOutputU_ * var_["particleFlow_U"], 2);
-  mvaOutputCovU2_ = std::pow(GetResponse(mvaReaderCovU2_, varForCovU2_)* mvaOutputU_ * var_["particleFlow_U"], 2);
-
+  mvaOutputCovU1_ = std::pow(GetResponse(mvaReaderCovU1_, varForCovU1_) * mvaOutputU_ * var_["particleFlow_U"], 2);
+  mvaOutputCovU2_ = std::pow(GetResponse(mvaReaderCovU2_, varForCovU2_) * mvaOutputU_ * var_["particleFlow_U"], 2);
 
   // compute MET(Photon check)
-  if(hasPhotons_) { 
+  if (hasPhotons_) {
     //Fix events with unphysical properties
-    double sumLeptonPt = std::max(sqrt(sumLeptonPx_*sumLeptonPx_+sumLeptonPy_*sumLeptonPy_),1.);
-    if(var_["track_U"]/sumLeptonPt < 0.1 || var_["noPileUp_U"]/sumLeptonPt <  0.1 ) {
-      mvaOutputU_      = 1.;
-      mvaOutputDPhi_   = 0.;
+    double sumLeptonPt = std::max(sqrt(sumLeptonPx_ * sumLeptonPx_ + sumLeptonPy_ * sumLeptonPy_), 1.);
+    if (var_["track_U"] / sumLeptonPt < 0.1 || var_["noPileUp_U"] / sumLeptonPt < 0.1) {
+      mvaOutputU_ = 1.;
+      mvaOutputDPhi_ = 0.;
     }
   }
   computeMET();
 }
 //-------------------------------------------------------------------------------
 
-void PFMETAlgorithmMVA::computeMET()
-{
-    double U      = var_["RecoilCor_U"];
-    double Phi    = var_["PhiCor_UPhi"];
-    if ( U < 0. ) Phi += Pi; //RF: No sign flip for U necessary in that case?
-    double cosPhi = std::cos(Phi);
-    double sinPhi = std::sin(Phi);
-    double metPx  = U*cosPhi - sumLeptonPx_;
-    double metPy  = U*sinPhi - sumLeptonPy_;
-    double metPt  = sqrt(metPx*metPx + metPy*metPy);
-    mvaMEt_.SetCoordinates(metPx, metPy, 0., metPt);
-    // compute MET uncertainties in dirrections parallel and perpendicular to hadronic recoil
-    // (neglecting uncertainties on lepton momenta)
-    mvaMEtCov_(0, 0) =  mvaOutputCovU1_*cosPhi*cosPhi + mvaOutputCovU2_*sinPhi*sinPhi;
-    mvaMEtCov_(0, 1) = -mvaOutputCovU1_*sinPhi*cosPhi + mvaOutputCovU2_*sinPhi*cosPhi;
-    mvaMEtCov_(1, 0) =  mvaMEtCov_(0, 1);
-    mvaMEtCov_(1, 1) =  mvaOutputCovU1_*sinPhi*sinPhi + mvaOutputCovU2_*cosPhi*cosPhi;
+void PFMETAlgorithmMVA::computeMET() {
+  double U = var_["RecoilCor_U"];
+  double Phi = var_["PhiCor_UPhi"];
+  if (U < 0.)
+    Phi += Pi;  //RF: No sign flip for U necessary in that case?
+  double cosPhi = std::cos(Phi);
+  double sinPhi = std::sin(Phi);
+  double metPx = U * cosPhi - sumLeptonPx_;
+  double metPy = U * sinPhi - sumLeptonPy_;
+  double metPt = sqrt(metPx * metPx + metPy * metPy);
+  mvaMEt_.SetCoordinates(metPx, metPy, 0., metPt);
+  // compute MET uncertainties in dirrections parallel and perpendicular to hadronic recoil
+  // (neglecting uncertainties on lepton momenta)
+  mvaMEtCov_(0, 0) = mvaOutputCovU1_ * cosPhi * cosPhi + mvaOutputCovU2_ * sinPhi * sinPhi;
+  mvaMEtCov_(0, 1) = -mvaOutputCovU1_ * sinPhi * cosPhi + mvaOutputCovU2_ * sinPhi * cosPhi;
+  mvaMEtCov_(1, 0) = mvaMEtCov_(0, 1);
+  mvaMEtCov_(1, 1) = mvaOutputCovU1_ * sinPhi * sinPhi + mvaOutputCovU2_ * cosPhi * cosPhi;
 }
 
 //-------------------------------------------------------------------------------
-const float PFMETAlgorithmMVA::GetResponse(const GBRForest * Reader, std::vector<std::string> &variableNames )
-{
-    std::unique_ptr<float[]> mvaInputVector = createFloatVector(variableNames);
-    double result = Reader->GetResponse( mvaInputVector.get() );
-    return result;
+const float PFMETAlgorithmMVA::GetResponse(const GBRForest* Reader, std::vector<std::string>& variableNames) {
+  std::unique_ptr<float[]> mvaInputVector = createFloatVector(variableNames);
+  double result = Reader->GetResponse(mvaInputVector.get());
+  return result;
 }
 
 //-------------------------------------------------------------------------------
-void PFMETAlgorithmMVA::print(std::ostream& stream) const
-{
+void PFMETAlgorithmMVA::print(std::ostream& stream) const {
   stream << "<PFMETAlgorithmMVA::print>:" << std::endl;
-    for(auto entry: var_)
-        stream << entry.first << " = " << entry.second << std::endl;
+  for (auto entry : var_)
+    stream << entry.first << " = " << entry.second << std::endl;
   stream << " covU1 = " << mvaOutputCovU1_ << ", covU2 = " << mvaOutputCovU2_ << std::endl;
-  stream << " sum(leptons): Pt = " << sqrt(sumLeptonPx_*sumLeptonPx_ + sumLeptonPy_*sumLeptonPy_) << ","
-  << " phi = " << atan2(sumLeptonPy_, sumLeptonPx_) << " "
-  << "(Px = " << sumLeptonPx_ << ", Py = " << sumLeptonPy_ << ")" ;
-  stream << " MVA output: U = " << mvaOutputU_ << ", dPhi = " << mvaOutputDPhi_ << "," << " covU1 = " << mvaOutputCovU1_ << ", covU2 = " << mvaOutputCovU2_ << std::endl;
+  stream << " sum(leptons): Pt = " << sqrt(sumLeptonPx_ * sumLeptonPx_ + sumLeptonPy_ * sumLeptonPy_) << ","
+         << " phi = " << atan2(sumLeptonPy_, sumLeptonPx_) << " "
+         << "(Px = " << sumLeptonPx_ << ", Py = " << sumLeptonPy_ << ")";
+  stream << " MVA output: U = " << mvaOutputU_ << ", dPhi = " << mvaOutputDPhi_ << ","
+         << " covU1 = " << mvaOutputCovU1_ << ", covU2 = " << mvaOutputCovU2_ << std::endl;
   stream << std::endl;
 }
-

--- a/RecoMET/METPUSubtraction/src/PFMEtSignInterfaceBase.cc
+++ b/RecoMET/METPUSubtraction/src/PFMEtSignInterfaceBase.cc
@@ -13,47 +13,40 @@ const double defaultPFMEtResolutionY = 10.;
 const double epsilon = 1.e-9;
 
 PFMEtSignInterfaceBase::PFMEtSignInterfaceBase(const edm::ParameterSet& cfg)
-  : pfMEtResolution_(nullptr),
-    inputFile_(nullptr),
-    lut_(nullptr)
-{
+    : pfMEtResolution_(nullptr), inputFile_(nullptr), lut_(nullptr) {
   pfMEtResolution_ = new metsig::SignAlgoResolutions(cfg);
 
-  if ( cfg.exists("addJERcorr") ) {
+  if (cfg.exists("addJERcorr")) {
     edm::ParameterSet cfgJERcorr = cfg.getParameter<edm::ParameterSet>("addJERcorr");
     edm::FileInPath inputFileName = cfgJERcorr.getParameter<edm::FileInPath>("inputFileName");
     std::string lutName = cfgJERcorr.getParameter<std::string>("lutName");
-    if ( inputFileName.location()!=edm::FileInPath::Local ) 
-      throw cms::Exception("PFMEtSignInterfaceBase") 
-        << " Failed to find File = " << inputFileName << " !!\n";
-    
+    if (inputFileName.location() != edm::FileInPath::Local)
+      throw cms::Exception("PFMEtSignInterfaceBase") << " Failed to find File = " << inputFileName << " !!\n";
+
     inputFile_ = new TFile(inputFileName.fullPath().data());
     lut_ = dynamic_cast<TH2*>(inputFile_->Get(lutName.data()));
-    if ( !lut_ ) 
-      throw cms::Exception("PFMEtSignInterfaceBase") 
-        << " Failed to load LUT = " << lutName.data() << " from file = " << inputFileName.fullPath().data() << " !!\n";
+    if (!lut_)
+      throw cms::Exception("PFMEtSignInterfaceBase") << " Failed to load LUT = " << lutName.data()
+                                                     << " from file = " << inputFileName.fullPath().data() << " !!\n";
   }
-  
-  verbosity_ = cfg.exists("verbosity") ?
-    cfg.getParameter<int>("verbosity") : 0;
+
+  verbosity_ = cfg.exists("verbosity") ? cfg.getParameter<int>("verbosity") : 0;
 }
 
-PFMEtSignInterfaceBase::~PFMEtSignInterfaceBase()
-{
+PFMEtSignInterfaceBase::~PFMEtSignInterfaceBase() {
   delete pfMEtResolution_;
   delete inputFile_;
   delete lut_;
 }
 
-reco::METCovMatrix PFMEtSignInterfaceBase::operator()(const std::vector<metsig::SigInputObj>& pfMEtSignObjects) const
-{
+reco::METCovMatrix PFMEtSignInterfaceBase::operator()(const std::vector<metsig::SigInputObj>& pfMEtSignObjects) const {
   // if ( this->verbosity_ ) {
   //   std::cout << "<PFMEtSignInterfaceBase::operator()>:" << std::endl;
   //   std::cout << " pfMEtSignObjects: entries = " << pfMEtSignObjects.size() << std::endl;
   //   double dpt2Sum = 0.;
   //   for ( std::vector<metsig::SigInputObj>::const_iterator pfMEtSignObject = pfMEtSignObjects.begin();
   // 	  pfMEtSignObject != pfMEtSignObjects.end(); ++pfMEtSignObject ) {
-  //     std::cout << pfMEtSignObject->get_type() << ": pt = " << pfMEtSignObject->get_energy() << "," 
+  //     std::cout << pfMEtSignObject->get_type() << ": pt = " << pfMEtSignObject->get_energy() << ","
   // 		<< " phi = " << pfMEtSignObject->get_phi() << " --> dpt = " << pfMEtSignObject->get_sigma_e() << std::endl;
   //     dpt2Sum += pfMEtSignObject->get_sigma_e();
   //   }
@@ -61,16 +54,16 @@ reco::METCovMatrix PFMEtSignInterfaceBase::operator()(const std::vector<metsig::
   // }
 
   reco::METCovMatrix pfMEtCov;
-  if ( pfMEtSignObjects.size() >= 2 ) {
+  if (pfMEtSignObjects.size() >= 2) {
     metsig::significanceAlgo pfMEtSignAlgorithm;
     pfMEtSignAlgorithm.addObjects(pfMEtSignObjects);
     pfMEtCov = pfMEtSignAlgorithm.getSignifMatrix();
- 
-    double det=0;
+
+    double det = 0;
     pfMEtCov.Det(det);
 
     // if ( this->verbosity_ && std::abs(det) > epsilon ) {
-    //   //keep TMatrixD as it is much easier to find 
+    //   //keep TMatrixD as it is much easier to find
     //   //eigenvectors and values than with SMatrix;
     //   //not used anyway, except for debugging
     //   TMatrixD tmpMatrix(2,2);
@@ -81,30 +74,30 @@ reco::METCovMatrix PFMEtSignInterfaceBase::operator()(const std::vector<metsig::
 
     //   TVectorD eigenValues(2);
     //   TMatrixD eigenVectors = tmpMatrix.EigenVectors(eigenValues);
-    //   // CV: eigenvectors are stored in columns 
+    //   // CV: eigenvectors are stored in columns
     //   //     and are sorted such that the one corresponding to the highest eigenvalue is in the **first** column
     //   for ( unsigned iEigenVector = 0; iEigenVector < 2; ++iEigenVector ) {
-    // 	std::cout << "eigenVector #" << iEigenVector << " (eigenValue = " << eigenValues(iEigenVector) << "):" 
+    // 	std::cout << "eigenVector #" << iEigenVector << " (eigenValue = " << eigenValues(iEigenVector) << "):"
     // 		  << " x = " << eigenVectors(0, iEigenVector) << ", y = " << eigenVectors(1, iEigenVector) << std::endl;
     //   }
     // }
-    
-    //--- substitute (PF)MEt resolution matrix by default values 
+
+    //--- substitute (PF)MEt resolution matrix by default values
     //    in case resolution matrix cannot be inverted
-    if (std::abs(det) < epsilon ) {
-      edm::LogWarning("PFMEtSignInterfaceBase::operator()") 
-	<< "Inversion of PFMEt covariance matrix failed, det = " << det
-	<< " --> replacing covariance matrix by resolution defaults !!";
-      pfMEtCov(0,0) = defaultPFMEtResolutionX*defaultPFMEtResolutionX;
-      pfMEtCov(0,1) = 0.;
-      pfMEtCov(1,0) = 0.;
-      pfMEtCov(1,1) = defaultPFMEtResolutionY*defaultPFMEtResolutionY;
+    if (std::abs(det) < epsilon) {
+      edm::LogWarning("PFMEtSignInterfaceBase::operator()")
+          << "Inversion of PFMEt covariance matrix failed, det = " << det
+          << " --> replacing covariance matrix by resolution defaults !!";
+      pfMEtCov(0, 0) = defaultPFMEtResolutionX * defaultPFMEtResolutionX;
+      pfMEtCov(0, 1) = 0.;
+      pfMEtCov(1, 0) = 0.;
+      pfMEtCov(1, 1) = defaultPFMEtResolutionY * defaultPFMEtResolutionY;
     }
   } else {
-    pfMEtCov(0,0) = 0.;
-    pfMEtCov(0,1) = 0.;
-    pfMEtCov(1,0) = 0.;
-    pfMEtCov(1,1) = 0.;
+    pfMEtCov(0, 0) = 0.;
+    pfMEtCov(0, 1) = 0.;
+    pfMEtCov(1, 0) = 0.;
+    pfMEtCov(1, 1) = 0.;
   }
 
   return pfMEtCov;

--- a/RecoMuon/DetLayers/interface/MuDetRing.h
+++ b/RecoMuon/DetLayers/interface/MuDetRing.h
@@ -14,43 +14,35 @@
 class GeomDet;
 
 class MuDetRing : public ForwardDetRingOneZ {
- public:
-
+public:
   /// Construct from iterators on GeomDet*
-  MuDetRing(std::vector<const GeomDet*>::const_iterator first,
-	    std::vector<const GeomDet*>::const_iterator last);
+  MuDetRing(std::vector<const GeomDet*>::const_iterator first, std::vector<const GeomDet*>::const_iterator last);
 
   /// Construct from a vector of GeomDet*
   MuDetRing(const std::vector<const GeomDet*>& dets);
 
   ~MuDetRing() override;
 
-
   // GeometricSearchDet interface
 
   const std::vector<const GeometricSearchDet*>& components() const override;
 
-  std::pair<bool, TrajectoryStateOnSurface>
-  compatible( const TrajectoryStateOnSurface& ts, const Propagator& prop, 
-	      const MeasurementEstimator& est) const override;
+  std::pair<bool, TrajectoryStateOnSurface> compatible(const TrajectoryStateOnSurface& ts,
+                                                       const Propagator& prop,
+                                                       const MeasurementEstimator& est) const override;
 
-  std::vector<DetWithState> 
-  compatibleDets( const TrajectoryStateOnSurface& startingState,
-		  const Propagator& prop, 
-		  const MeasurementEstimator& est) const override;
+  std::vector<DetWithState> compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                           const Propagator& prop,
+                                           const MeasurementEstimator& est) const override;
 
-  std::vector<DetGroup> 
-  groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-			 const Propagator& prop,
-			 const MeasurementEstimator& est) const override;
+  std::vector<DetGroup> groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                              const Propagator& prop,
+                                              const MeasurementEstimator& est) const override;
 
-
- private:
-  typedef PeriodicBinFinderInPhi<float>   BinFinderType;
+private:
+  typedef PeriodicBinFinderInPhi<float> BinFinderType;
   BinFinderType theBinFinder;
 
   void init();
-
 };
 #endif
-

--- a/RecoMuon/DetLayers/interface/MuDetRod.h
+++ b/RecoMuon/DetLayers/interface/MuDetRod.h
@@ -15,11 +15,9 @@
 class GeomDet;
 
 class MuDetRod : public DetRodOneR {
- public:
-
+public:
   /// Construct from iterators on GeomDet*
-  MuDetRod(std::vector<const GeomDet*>::const_iterator first,
-	   std::vector<const GeomDet*>::const_iterator last);
+  MuDetRod(std::vector<const GeomDet*>::const_iterator first, std::vector<const GeomDet*>::const_iterator last);
 
   /// Construct from a std::vector of GeomDet*
   MuDetRod(const std::vector<const GeomDet*>& dets);
@@ -27,33 +25,28 @@ class MuDetRod : public DetRodOneR {
   /// Destructor
   ~MuDetRod() override;
 
-
   // GeometricSearchDet interface
 
   const std::vector<const GeometricSearchDet*>& components() const override;
 
-  std::pair<bool, TrajectoryStateOnSurface>
-  compatible( const TrajectoryStateOnSurface& ts, const Propagator& prop, 
-	      const MeasurementEstimator& est) const override;
+  std::pair<bool, TrajectoryStateOnSurface> compatible(const TrajectoryStateOnSurface& ts,
+                                                       const Propagator& prop,
+                                                       const MeasurementEstimator& est) const override;
 
-  std::vector<DetWithState> 
-  compatibleDets( const TrajectoryStateOnSurface& startingState,
-		  const Propagator& prop, 
-		  const MeasurementEstimator& est) const override;
+  std::vector<DetWithState> compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                           const Propagator& prop,
+                                           const MeasurementEstimator& est) const override;
 
-  std::vector<DetGroup> 
-  groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-			 const Propagator& prop,
-			 const MeasurementEstimator& est) const override;
+  std::vector<DetGroup> groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                              const Propagator& prop,
+                                              const MeasurementEstimator& est) const override;
 
-
- private:
+private:
   //typedef PeriodicBinFinderInZ<float>   BinFinderType;
   typedef GenericBinFinderInZ<float, GeomDet> BinFinderType;
   BinFinderType theBinFinder;
 
   void init();
-
 };
 
 #endif

--- a/RecoMuon/DetLayers/interface/MuRingForwardDoubleLayer.h
+++ b/RecoMuon/DetLayers/interface/MuRingForwardDoubleLayer.h
@@ -17,64 +17,57 @@ class ForwardDetRingBuilder;
 class GeomDet;
 
 class MuRingForwardDoubleLayer : public RingedForwardLayer {
-
- public:  
-
+public:
   /// Constructor, takes ownership of pointers
-  MuRingForwardDoubleLayer(const std::vector<const ForwardDetRing*>& frontRings,  
+  MuRingForwardDoubleLayer(const std::vector<const ForwardDetRing*>& frontRings,
                            const std::vector<const ForwardDetRing*>& backRings);
 
   ~MuRingForwardDoubleLayer() override {}
 
-
   // GeometricSearchDet interface
 
-  const std::vector<const GeomDet*>& basicComponents() const override {return theBasicComponents;}
-  
-  const std::vector<const GeometricSearchDet*>& components() const override {return theComponents;}
+  const std::vector<const GeomDet*>& basicComponents() const override { return theBasicComponents; }
 
-  bool isInsideOut(const TrajectoryStateOnSurface&tsos) const;
+  const std::vector<const GeometricSearchDet*>& components() const override { return theComponents; }
+
+  bool isInsideOut(const TrajectoryStateOnSurface& tsos) const;
 
   // tries closest layer first
-  std::pair<bool, TrajectoryStateOnSurface>
-  compatible( const TrajectoryStateOnSurface&, const Propagator&,
-              const MeasurementEstimator&) const override;
+  std::pair<bool, TrajectoryStateOnSurface> compatible(const TrajectoryStateOnSurface&,
+                                                       const Propagator&,
+                                                       const MeasurementEstimator&) const override;
 
-  std::vector<DetWithState> 
-  compatibleDets( const TrajectoryStateOnSurface& startingState,
-		  const Propagator& prop, 
-		  const MeasurementEstimator& est) const override;
-  
-  std::vector<DetGroup> 
-  groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-			 const Propagator& prop,
-			 const MeasurementEstimator& est) const override;
+  std::vector<DetWithState> compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                           const Propagator& prop,
+                                           const MeasurementEstimator& est) const override;
 
+  std::vector<DetGroup> groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                              const Propagator& prop,
+                                              const MeasurementEstimator& est) const override;
 
   // DetLayer interface
-  SubDetector subDetector() const override {return theBackLayer.subDetector();}
-
+  SubDetector subDetector() const override { return theBackLayer.subDetector(); }
 
   // Extension of the interface
 
   /// Return the vector of rings.
-  virtual const std::vector<const ForwardDetRing*>& rings() const {return theRings;}
+  virtual const std::vector<const ForwardDetRing*>& rings() const { return theRings; }
 
-  bool isCrack(const GlobalPoint & gp) const;
+  bool isCrack(const GlobalPoint& gp) const;
 
-  const MuRingForwardLayer * frontLayer() const {return &theFrontLayer;}
-  const MuRingForwardLayer * backLayer() const {return &theBackLayer;}
+  const MuRingForwardLayer* frontLayer() const { return &theFrontLayer; }
+  const MuRingForwardLayer* backLayer() const { return &theBackLayer; }
 
   void selfTest() const;
- protected:
-    BoundDisk * computeSurface() override;
- private:  
+
+protected:
+  BoundDisk* computeSurface() override;
+
+private:
   MuRingForwardLayer theFrontLayer;
   MuRingForwardLayer theBackLayer;
   std::vector<const ForwardDetRing*> theRings;
-  std::vector <const GeometricSearchDet*> theComponents; // duplication of the above
-  std::vector<const GeomDet*> theBasicComponents; // All chambers
-
+  std::vector<const GeometricSearchDet*> theComponents;  // duplication of the above
+  std::vector<const GeomDet*> theBasicComponents;        // All chambers
 };
 #endif
-

--- a/RecoMuon/DetLayers/interface/MuRingForwardLayer.h
+++ b/RecoMuon/DetLayers/interface/MuRingForwardLayer.h
@@ -16,50 +16,39 @@ class ForwardDetRingBuilder;
 class GeomDet;
 
 class MuRingForwardLayer : public RingedForwardLayer {
-
- public:  
-
+public:
   /// Constructor, takes ownership of pointers
   MuRingForwardLayer(const std::vector<const ForwardDetRing*>& rings);
 
   ~MuRingForwardLayer() override;
 
-
   // GeometricSearchDet interface
 
-  const std::vector<const GeomDet*>& basicComponents() const override {return theBasicComps;}
-  
+  const std::vector<const GeomDet*>& basicComponents() const override { return theBasicComps; }
+
   const std::vector<const GeometricSearchDet*>& components() const override;
 
-  std::vector<DetWithState> 
-  compatibleDets( const TrajectoryStateOnSurface& startingState,
-		  const Propagator& prop, 
-		  const MeasurementEstimator& est) const override;
-  
-  std::vector<DetGroup> 
-  groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-			 const Propagator& prop,
-			 const MeasurementEstimator& est) const override;
+  std::vector<DetWithState> compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                           const Propagator& prop,
+                                           const MeasurementEstimator& est) const override;
 
-
+  std::vector<DetGroup> groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                              const Propagator& prop,
+                                              const MeasurementEstimator& est) const override;
 
   // DetLayer interface
   SubDetector subDetector() const override;
 
-
   // Extension of the interface
 
   /// Return the vector of rings.
-  virtual const std::vector<const ForwardDetRing*>& rings() const {return theRings;}
+  virtual const std::vector<const ForwardDetRing*>& rings() const { return theRings; }
 
-
- private:  
+private:
   std::vector<const ForwardDetRing*> theRings;
-  std::vector <const GeometricSearchDet*> theComponents; // duplication of the above
-  std::vector<const GeomDet*> theBasicComps; // All chambers
-  BaseBinFinder<double> * theBinFinder;
+  std::vector<const GeometricSearchDet*> theComponents;  // duplication of the above
+  std::vector<const GeomDet*> theBasicComps;             // All chambers
+  BaseBinFinder<double>* theBinFinder;
   bool isOverlapping;
-
 };
 #endif
-

--- a/RecoMuon/DetLayers/interface/MuRodBarrelLayer.h
+++ b/RecoMuon/DetLayers/interface/MuRodBarrelLayer.h
@@ -16,7 +16,6 @@ class GeomDet;
 
 class MuRodBarrelLayer : public RodBarrelLayer {
 public:
-
   /// Constructor, takes ownership of pointers
   MuRodBarrelLayer(std::vector<const DetRod*>& rods);
 
@@ -24,20 +23,17 @@ public:
 
   // GeometricSearchDet interface
 
-  const std::vector<const GeomDet*>& basicComponents() const override {return theBasicComps;}
+  const std::vector<const GeomDet*>& basicComponents() const override { return theBasicComps; }
 
-  const std::vector<const GeometricSearchDet*>& components() const override;  
+  const std::vector<const GeometricSearchDet*>& components() const override;
 
-  std::vector<DetWithState> 
-  compatibleDets( const TrajectoryStateOnSurface& startingState,
-		  const Propagator& prop, 
-		  const MeasurementEstimator& est) const override;
-  
-  std::vector<DetGroup> 
-  groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-			 const Propagator& prop,
-			 const MeasurementEstimator& est) const override;
+  std::vector<DetWithState> compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                           const Propagator& prop,
+                                           const MeasurementEstimator& est) const override;
 
+  std::vector<DetGroup> groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                              const Propagator& prop,
+                                              const MeasurementEstimator& est) const override;
 
   // DetLayer interface
   SubDetector subDetector() const override;
@@ -45,18 +41,15 @@ public:
   // Extension of the interface
 
   /// Return the vector of rods.
-  virtual const std::vector<const DetRod*>& rods() const {return theRods;}
-
+  virtual const std::vector<const DetRod*>& rods() const { return theRods; }
 
 private:
-
-  float xError(const TrajectoryStateOnSurface& tsos,
-	       const MeasurementEstimator& est) const;
+  float xError(const TrajectoryStateOnSurface& tsos, const MeasurementEstimator& est) const;
 
   std::vector<const DetRod*> theRods;
-  std::vector <const GeometricSearchDet*> theComponents; // duplication of the above
-  std::vector<const GeomDet*> theBasicComps; // All chambers
-  BaseBinFinder<double> * theBinFinder;
+  std::vector<const GeometricSearchDet*> theComponents;  // duplication of the above
+  std::vector<const GeomDet*> theBasicComps;             // All chambers
+  BaseBinFinder<double>* theBinFinder;
   bool isOverlapping;
 };
 

--- a/RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h
+++ b/RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h
@@ -18,13 +18,12 @@
 
 class DetLayer;
 
-class MuonDetLayerGeometry : public DetLayerGeometry{
- public:
-
+class MuonDetLayerGeometry : public DetLayerGeometry {
+public:
   /// Constructor
   MuonDetLayerGeometry();
 
-  friend class MuonDetLayerGeometryESProducer;  
+  friend class MuonDetLayerGeometryESProducer;
 
   /// Destructor
   ~MuonDetLayerGeometry() override;
@@ -41,7 +40,7 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
   /// return the backward (-Z) CSC DetLayers, inside-out
   const std::vector<const DetLayer*>& backwardCSCLayers() const;
 
-/////////////////////////////// GEMs
+  /////////////////////////////// GEMs
 
   /// return the GEM DetLayers (endcap), -Z to +Z
   const std::vector<const DetLayer*>& allGEMLayers() const;
@@ -52,10 +51,9 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
   /// return the backward (-Z) GEM DetLayers, inside-out
   const std::vector<const DetLayer*>& backwardGEMLayers() const;
 
-//////////////////////////////
+  //////////////////////////////
 
-
-/////////////////////////////// ME0s
+  /////////////////////////////// ME0s
 
   /// return the ME0 DetLayers (endcap), -Z to +Z
   const std::vector<const DetLayer*>& allME0Layers() const;
@@ -66,7 +64,7 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
   /// return the backward (-Z) ME0 DetLayers, inside-out
   const std::vector<const DetLayer*>& backwardME0Layers() const;
 
-//////////////////////////////
+  //////////////////////////////
 
   /// return all RPC DetLayers, order: backward, barrel, forward
   const std::vector<const DetLayer*>& allRPCLayers() const;
@@ -91,14 +89,14 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
 
   /// return all endcap DetLayers (CSC+RPC+GEM+ME0), -Z to +Z
   const std::vector<const DetLayer*>& allEndcapLayers() const;
- 
+
   /// return all forward (+Z) layers (CSC+RPC+GEM+ME0), inside-out
   const std::vector<const DetLayer*>& allForwardLayers() const;
 
   /// return all backward (-Z) layers (CSC+RPC+GEM+ME0), inside-out
   const std::vector<const DetLayer*>& allBackwardLayers() const;
-    
-/////////////////////////////// GEMs
+
+  /////////////////////////////// GEMs
 
   /// return all endcap DetLayers (CSC+GEM), -Z to +Z
   const std::vector<const DetLayer*>& allEndcapCscGemLayers() const;
@@ -109,10 +107,9 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
   /// return all endcap DetLayers (CSC+GEM), -Z to +Z
   const std::vector<const DetLayer*>& allCscGemBackwardLayers() const;
 
-//////////////////////////////
+  //////////////////////////////
 
-
-/////////////////////////////// ME0s
+  /////////////////////////////// ME0s
 
   /// return all endcap DetLayers (CSC+ME0), -Z to +Z
   const std::vector<const DetLayer*>& allEndcapCscME0Layers() const;
@@ -123,13 +120,13 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
   /// return all endcap DetLayers (CSC+ME0), -Z to +Z
   const std::vector<const DetLayer*>& allCscME0BackwardLayers() const;
 
-//////////////////////////////
-  
+  //////////////////////////////
+
   /// return the DetLayer which correspond to a certain DetId
   const DetLayer* idToLayer(const DetId& detId) const override;
 
- private:
-  /// Add CSC layers 
+private:
+  /// Add CSC layers
   /// csclayers.first=forward (+Z), csclayers.second=backward (-Z)
   /// both vectors are ASSUMED to be sorted inside-out
   void addCSCLayers(const std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> >& csclayers);
@@ -140,48 +137,47 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
   /// Add RPC layers
   /// endcapRPCLayers.first=forward (+Z), endcapRPCLayers.second=backward (-Z)
   /// All three vectors are ASSUMED to be sorted inside-out
-  void addRPCLayers(const std::vector<DetLayer*>& barrelRPCLayers, const std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> >& endcapRPCLayers);
+  void addRPCLayers(const std::vector<DetLayer*>& barrelRPCLayers,
+                    const std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> >& endcapRPCLayers);
 
-/////////////////////////////// GEMs
+  /////////////////////////////// GEMs
 
-  /// Add GEM layers 
+  /// Add GEM layers
   /// gemlayers.first=forward (+Z), gemlayers.second=backward (-Z)
   /// both vectors are ASSUMED to be sorted inside-out
   void addGEMLayers(const std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> >& gemlayers);
-//////////////////////////////
+  //////////////////////////////
 
+  /////////////////////////////// ME0s
 
-/////////////////////////////// ME0s
-
-  /// Add ME0 layers 
+  /// Add ME0 layers
   /// gemlayers.first=forward (+Z), gemlayers.second=backward (-Z)
   /// both vectors are ASSUMED to be sorted inside-out
   void addME0Layers(const std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> >& gemlayers);
 
-//////////////////////////////
+  //////////////////////////////
 
-  
   DetId makeDetLayerId(const DetLayer* detLayer) const;
-  
+
   void sortLayers();
 
   std::vector<const DetLayer*> cscLayers_fw;
   std::vector<const DetLayer*> cscLayers_bk;
   std::vector<const DetLayer*> cscLayers_all;
 
-/////////////////////////////// GEMs
+  /////////////////////////////// GEMs
 
   std::vector<const DetLayer*> gemLayers_fw;
   std::vector<const DetLayer*> gemLayers_bk;
   std::vector<const DetLayer*> gemLayers_all;
 
-/////////////////////////////// ME0s
+  /////////////////////////////// ME0s
 
   std::vector<const DetLayer*> me0Layers_fw;
   std::vector<const DetLayer*> me0Layers_bk;
   std::vector<const DetLayer*> me0Layers_all;
 
-//////////////////////////////
+  //////////////////////////////
   //////////////////////////////
   std::vector<const DetLayer*> rpcLayers_all;
   std::vector<const DetLayer*> rpcLayers_endcap;
@@ -195,25 +191,22 @@ class MuonDetLayerGeometry : public DetLayerGeometry{
   std::vector<const DetLayer*> allBarrel;
   std::vector<const DetLayer*> allDetLayers;
 
-/////////////////////////////// GEMs
+  /////////////////////////////// GEMs
 
   std::vector<const DetLayer*> allEndcapCscGem;
   std::vector<const DetLayer*> allCscGemForward;
   std::vector<const DetLayer*> allCscGemBackward;
 
-//////////////////////////////
-         
+  //////////////////////////////
 
-/////////////////////////////// ME0s
+  /////////////////////////////// ME0s
 
   std::vector<const DetLayer*> allEndcapCscME0;
   std::vector<const DetLayer*> allCscME0Forward;
   std::vector<const DetLayer*> allCscME0Backward;
 
-//////////////////////////////
-    
+  //////////////////////////////
 
-  std::map<DetId,const DetLayer*> detLayersMap;
+  std::map<DetId, const DetLayer*> detLayersMap;
 };
 #endif
-

--- a/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
+++ b/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
@@ -31,27 +31,21 @@
 
 using namespace edm;
 
-MuonDetLayerGeometryESProducer::MuonDetLayerGeometryESProducer(const edm::ParameterSet & p){
-  setWhatProduced(this);
-}
+MuonDetLayerGeometryESProducer::MuonDetLayerGeometryESProducer(const edm::ParameterSet& p) { setWhatProduced(this); }
 
+MuonDetLayerGeometryESProducer::~MuonDetLayerGeometryESProducer() {}
 
-MuonDetLayerGeometryESProducer::~MuonDetLayerGeometryESProducer(){}
-
-
-std::unique_ptr<MuonDetLayerGeometry>
-MuonDetLayerGeometryESProducer::produce(const MuonRecoGeometryRecord & record) {
-
+std::unique_ptr<MuonDetLayerGeometry> MuonDetLayerGeometryESProducer::produce(const MuonRecoGeometryRecord& record) {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonDetLayerGeometryESProducer";
   auto muonDetLayerGeometry = std::make_unique<MuonDetLayerGeometry>();
-  
-  // Build DT layers  
+
+  // Build DT layers
   edm::ESHandle<DTGeometry> dt;
   record.getRecord<MuonGeometryRecord>().get(dt);
   if (dt.isValid()) {
     muonDetLayerGeometry->addDTLayers(MuonDTDetLayerGeometryBuilder::buildLayers(*dt));
   } else {
-    LogInfo(metname) << "No DT geometry is available."; 
+    LogInfo(metname) << "No DT geometry is available.";
   }
 
   // Build CSC layers
@@ -67,11 +61,11 @@ MuonDetLayerGeometryESProducer::produce(const MuonRecoGeometryRecord & record) {
   edm::ESHandle<GEMGeometry> gem;
   record.getRecord<MuonGeometryRecord>().get(gem);
   if (gem.isValid()) {
-      muonDetLayerGeometry->addGEMLayers(MuonGEMDetLayerGeometryBuilder::buildEndcapLayers(*gem));
+    muonDetLayerGeometry->addGEMLayers(MuonGEMDetLayerGeometryBuilder::buildEndcapLayers(*gem));
   } else {
     LogInfo(metname) << "No GEM geometry is available.";
   }
-    
+
   // Build ME0 layers
   edm::ESHandle<ME0Geometry> me0;
   record.getRecord<MuonGeometryRecord>().get(me0);
@@ -81,16 +75,15 @@ MuonDetLayerGeometryESProducer::produce(const MuonRecoGeometryRecord & record) {
     LogDebug(metname) << "No ME0 geometry is available.";
   }
 
-
   // Build RPC layers
   edm::ESHandle<RPCGeometry> rpc;
   record.getRecord<MuonGeometryRecord>().get(rpc);
   if (rpc.isValid()) {
-    muonDetLayerGeometry->addRPCLayers(MuonRPCDetLayerGeometryBuilder::buildBarrelLayers(*rpc),MuonRPCDetLayerGeometryBuilder::buildEndcapLayers(*rpc));
+    muonDetLayerGeometry->addRPCLayers(MuonRPCDetLayerGeometryBuilder::buildBarrelLayers(*rpc),
+                                       MuonRPCDetLayerGeometryBuilder::buildEndcapLayers(*rpc));
   } else {
     LogInfo(metname) << "No RPC geometry is available.";
-  }  
-  
+  }
 
   // Sort layers properly
   muonDetLayerGeometry->sortLayers();

--- a/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.h
+++ b/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.h
@@ -14,20 +14,18 @@
 #include <RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h>
 #include <memory>
 
-
-class  MuonDetLayerGeometryESProducer: public edm::ESProducer{
- public:
+class MuonDetLayerGeometryESProducer : public edm::ESProducer {
+public:
   /// Constructor
-  MuonDetLayerGeometryESProducer(const edm::ParameterSet & p);
+  MuonDetLayerGeometryESProducer(const edm::ParameterSet& p);
 
   /// Destructor
-  ~MuonDetLayerGeometryESProducer() override; 
+  ~MuonDetLayerGeometryESProducer() override;
 
   /// Produce MuonDeLayerGeometry.
-  std::unique_ptr<MuonDetLayerGeometry> produce(const MuonRecoGeometryRecord & record);
+  std::unique_ptr<MuonDetLayerGeometry> produce(const MuonRecoGeometryRecord& record);
 
- private:
+private:
 };
-
 
 #endif

--- a/RecoMuon/DetLayers/src/MuDetRing.cc
+++ b/RecoMuon/DetLayers/src/MuDetRing.cc
@@ -14,165 +14,136 @@
 
 using namespace std;
 
-MuDetRing::MuDetRing(vector<const GeomDet*>::const_iterator first,
-		     vector<const GeomDet*>::const_iterator last) : 
-  ForwardDetRingOneZ(first,last) 
-{
+MuDetRing::MuDetRing(vector<const GeomDet*>::const_iterator first, vector<const GeomDet*>::const_iterator last)
+    : ForwardDetRingOneZ(first, last) {
   init();
 }
 
+MuDetRing::MuDetRing(const vector<const GeomDet*>& vdets) : ForwardDetRingOneZ(vdets) { init(); }
 
-MuDetRing::MuDetRing(const vector<const GeomDet*>& vdets) : 
-  ForwardDetRingOneZ(vdets) 
-{
-  init();
+void MuDetRing::init() {
+  theBinFinder = BinFinderType(basicComponents().front()->position().phi(), basicComponents().size());
 }
 
+MuDetRing::~MuDetRing() {}
 
-void MuDetRing::init()
-{
-  theBinFinder = BinFinderType(basicComponents().front()->position().phi(),
-			       basicComponents().size());  
-}
-
-MuDetRing::~MuDetRing(){}
-
-
-const vector<const GeometricSearchDet*>&
-MuDetRing::components() const {
+const vector<const GeometricSearchDet*>& MuDetRing::components() const {
   // FIXME dummy impl.
   cout << "temporary dummy implementation of MuDetRing::components()!!" << endl;
   static const vector<const GeometricSearchDet*> result;
   return result;
 }
 
-
-pair<bool, TrajectoryStateOnSurface>
-MuDetRing::compatible(const TrajectoryStateOnSurface& ts, const Propagator& prop, 
-		      const MeasurementEstimator& est) const {
-  
+pair<bool, TrajectoryStateOnSurface> MuDetRing::compatible(const TrajectoryStateOnSurface& ts,
+                                                           const Propagator& prop,
+                                                           const MeasurementEstimator& est) const {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuDetRing";
-  TrajectoryStateOnSurface ms = prop.propagate(ts,specificSurface());
-  
-  LogTrace(metname) << "MuDetRing::compatible, Surface at Z: " 
-                    << specificSurface().position().z()
-                    << " R1: " << specificSurface().innerRadius()
-                    << " R2: " << specificSurface().outerRadius()
-                    << " TS   at Z,R: " << ts.globalPosition().z() << ","
-                    << ts.globalPosition().perp();
+  TrajectoryStateOnSurface ms = prop.propagate(ts, specificSurface());
+
+  LogTrace(metname) << "MuDetRing::compatible, Surface at Z: " << specificSurface().position().z()
+                    << " R1: " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
+                    << " TS   at Z,R: " << ts.globalPosition().z() << "," << ts.globalPosition().perp();
   if (ms.isValid()) {
-    LogTrace(metname) << " DEST at Z,R: " << ms.globalPosition().z() << ","
-		      << ms.globalPosition().perp()
-		      << " local Z: "   << ms.localPosition().z()  << endl;
-  }
+    LogTrace(metname) << " DEST at Z,R: " << ms.globalPosition().z() << "," << ms.globalPosition().perp()
+                      << " local Z: " << ms.localPosition().z() << endl;
+  } else
+    LogTrace(metname) << " DEST: not valid" << endl;
+
+  if (ms.isValid())
+    return make_pair(est.estimate(ms, specificSurface()) != 0, ms);
   else
-    LogTrace(metname) << " DEST: not valid" <<endl;
-  
-  
-  if (ms.isValid()) return make_pair(est.estimate(ms, specificSurface()) != 0, ms);
-  else return make_pair(false, ms);
+    return make_pair(false, ms);
 }
 
-
-vector<GeometricSearchDet::DetWithState> 
-MuDetRing::compatibleDets( const TrajectoryStateOnSurface& startingState,
-			   const Propagator& prop, 
-			   const MeasurementEstimator& est) const {
-
+vector<GeometricSearchDet::DetWithState> MuDetRing::compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                                   const Propagator& prop,
+                                                                   const MeasurementEstimator& est) const {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuDetRing";
 
-  LogTrace(metname) << "MuDetRing::compatibleDets, Surface at Z: " 
-                    << surface().position().z()
-                    << " R1: " << specificSurface().innerRadius()
-                    << " R2: " << specificSurface().outerRadius()
+  LogTrace(metname) << "MuDetRing::compatibleDets, Surface at Z: " << surface().position().z()
+                    << " R1: " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
                     << " TS at Z,R: " << startingState.globalPosition().z() << ","
                     << startingState.globalPosition().perp() << "     DetRing pos." << position();
 
   vector<DetWithState> result;
 
   // Propagate and check that the result is within bounds
-  pair<bool, TrajectoryStateOnSurface> compat =
-    compatible(startingState, prop, est);
+  pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
   if (!compat.first) {
     LogTrace(metname) << "    MuDetRing::compatibleDets: not compatible"
                       << "    (should not have been selected!)";
     return result;
   }
-  
+
   // Find the most probable destination component
   TrajectoryStateOnSurface& tsos = compat.second;
-  GlobalPoint startPos = tsos.globalPosition();  
+  GlobalPoint startPos = tsos.globalPosition();
   int closest = theBinFinder.binIndex(startPos.phi());
   const vector<const GeomDet*> dets = basicComponents();
-  LogTrace(metname) << "     MuDetRing::compatibleDets, closest det: " << closest 
-                    << " Phi: " << dets[closest]->surface().position().phi()
-                    << " impactPhi " << startPos.phi();
+  LogTrace(metname) << "     MuDetRing::compatibleDets, closest det: " << closest
+                    << " Phi: " << dets[closest]->surface().position().phi() << " impactPhi " << startPos.phi();
 
   // Add this detector, if it is compatible
   // NOTE: add performs a null propagation
   add(closest, result, tsos, prop, est);
 
-  int nclosest = result.size(); int nnextdet=0; // MDEBUG counters
+  int nclosest = result.size();
+  int nnextdet = 0;  // MDEBUG counters
 
   // Try the neighbors on each side until no more compatible.
-  float dphi=0;
-  if (!result.empty()) { // If closest is not compatible the next cannot be either
+  float dphi = 0;
+  if (!result.empty()) {  // If closest is not compatible the next cannot be either
     float nSigmas = 3.;
     if (result.back().second.hasError()) {
-      dphi = nSigmas*      
-        atan(sqrt(result.back().second.localError().positionError().xx())/
-             result.back().second.globalPosition().perp());
-    }  
+      dphi = nSigmas * atan(sqrt(result.back().second.localError().positionError().xx()) /
+                            result.back().second.globalPosition().perp());
+    }
   } else {
     LogTrace(metname) << "     MuDetRing::compatibleDets, closest not compatible!";
     //FIXME:  if closest is not compatible the next cannot be either
   }
-  
-  for (int idet=closest+1; idet < closest+int(dets.size())/4+1; idet++){
+
+  for (int idet = closest + 1; idet < closest + int(dets.size()) / 4 + 1; idet++) {
     // FIXME: should use dphi to decide if det must be queried.
     // Right now query until not compatible.
     int idetp = theBinFinder.binIndex(idet);
     {
-      LogTrace(metname) << "     next det:" << idetp
-                        << " at Z: " << dets[idetp]->position().z()
-                        << " phi: " << dets[idetp]->position().phi()
-                        << " FTS phi " << startPos.phi()
-                        << " max dphi " << dphi;
-      nnextdet++;      
-      if ( !add(idetp, result, tsos, prop, est)) break;
-    }
-  }
-  
-  for (int idet=closest-1; idet > closest-int(dets.size())/4-1; idet--){
-    // FIXME: should use dphi to decide if det must be queried.
-    // Right now query until not compatible.
-    int idetp = theBinFinder.binIndex(idet);
-    {
-      LogTrace(metname) << "     previous det:" << idetp << " " << idet << " " << closest-dets.size()/4-1
-                        << " at Z: " << dets[idetp]->position().z()
-                        << " phi: " << dets[idetp]->position().phi()
-                        << " FTS phi " << startPos.phi()
-                        << " max dphi" << dphi;
+      LogTrace(metname) << "     next det:" << idetp << " at Z: " << dets[idetp]->position().z()
+                        << " phi: " << dets[idetp]->position().phi() << " FTS phi " << startPos.phi() << " max dphi "
+                        << dphi;
       nnextdet++;
-      if ( !add(idetp, result, tsos, prop, est)) break;
+      if (!add(idetp, result, tsos, prop, est))
+        break;
     }
   }
-  
-  LogTrace(metname) << "     MuDetRing::compatibleDets, size: " << result.size()
-                    << " on closest: " << nclosest << " # checked dets: " << nnextdet+1;
+
+  for (int idet = closest - 1; idet > closest - int(dets.size()) / 4 - 1; idet--) {
+    // FIXME: should use dphi to decide if det must be queried.
+    // Right now query until not compatible.
+    int idetp = theBinFinder.binIndex(idet);
+    {
+      LogTrace(metname) << "     previous det:" << idetp << " " << idet << " " << closest - dets.size() / 4 - 1
+                        << " at Z: " << dets[idetp]->position().z() << " phi: " << dets[idetp]->position().phi()
+                        << " FTS phi " << startPos.phi() << " max dphi" << dphi;
+      nnextdet++;
+      if (!add(idetp, result, tsos, prop, est))
+        break;
+    }
+  }
+
+  LogTrace(metname) << "     MuDetRing::compatibleDets, size: " << result.size() << " on closest: " << nclosest
+                    << " # checked dets: " << nnextdet + 1;
 
   if (result.empty()) {
     LogTrace(metname) << "   ***Ring not compatible,should have been discarded before!!!";
   }
-  
+
   return result;
 }
 
-
-vector<DetGroup> 
-MuDetRing::groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-				  const Propagator& prop,
-				  const MeasurementEstimator& est) const {
+vector<DetGroup> MuDetRing::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                  const Propagator& prop,
+                                                  const MeasurementEstimator& est) const {
   // FIXME should be implemented to allow returning  overlapping chambers
   // as separate groups!
   cout << "dummy implementation of MuDetRod::groupedCompatibleDets()" << endl;

--- a/RecoMuon/DetLayers/src/MuDetRod.cc
+++ b/RecoMuon/DetLayers/src/MuDetRod.cc
@@ -13,137 +13,118 @@
 
 using namespace std;
 
-
-MuDetRod::MuDetRod(vector<const GeomDet*>::const_iterator first,
-                   vector<const GeomDet*>::const_iterator last)
-  : DetRodOneR(first,last) {
+MuDetRod::MuDetRod(vector<const GeomDet*>::const_iterator first, vector<const GeomDet*>::const_iterator last)
+    : DetRodOneR(first, last) {
   init();
 }
 
-MuDetRod::MuDetRod(const vector<const GeomDet*>& vdets)
-  : DetRodOneR(vdets) {
-  init();
-}
+MuDetRod::MuDetRod(const vector<const GeomDet*>& vdets) : DetRodOneR(vdets) { init(); }
 
+void MuDetRod::init() { theBinFinder = BinFinderType(basicComponents().begin(), basicComponents().end()); }
 
-void MuDetRod::init() {
-  theBinFinder = BinFinderType(basicComponents().begin(), basicComponents().end());
-}
+MuDetRod::~MuDetRod() {}
 
-
-MuDetRod::~MuDetRod(){}
-
-const vector<const GeometricSearchDet*>&
-MuDetRod::components() const {
-
+const vector<const GeometricSearchDet*>& MuDetRod::components() const {
   // FIXME dummy impl.
   cout << "temporary dummy implementation of MuDetRod::components()!!" << endl;
   static const vector<const GeometricSearchDet*> result;
   return result;
 }
 
-pair<bool, TrajectoryStateOnSurface>
-MuDetRod::compatible(const TrajectoryStateOnSurface& ts, const Propagator& prop, 
-                     const MeasurementEstimator& est) const {
-  
-  TrajectoryStateOnSurface ms = prop.propagate(ts,specificSurface());
-  if (ms.isValid()) return make_pair(est.estimate(ms, specificSurface()) != 0, ms);
-  else return make_pair(false, ms);
+pair<bool, TrajectoryStateOnSurface> MuDetRod::compatible(const TrajectoryStateOnSurface& ts,
+                                                          const Propagator& prop,
+                                                          const MeasurementEstimator& est) const {
+  TrajectoryStateOnSurface ms = prop.propagate(ts, specificSurface());
+  if (ms.isValid())
+    return make_pair(est.estimate(ms, specificSurface()) != 0, ms);
+  else
+    return make_pair(false, ms);
 }
 
-
-vector<GeometricSearchDet::DetWithState> 
-MuDetRod::compatibleDets( const TrajectoryStateOnSurface& startingState,
-                          const Propagator& prop, 
-                          const MeasurementEstimator& est) const {
+vector<GeometricSearchDet::DetWithState> MuDetRod::compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                                  const Propagator& prop,
+                                                                  const MeasurementEstimator& est) const {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuDetRod";
-  
-  LogTrace(metname) << "MuDetRod::compatibleDets, Surface at R,phi: " 
-                    << surface().position().perp()  << ","
-                    << surface().position().phi() << "     DetRod pos.";
-    // FIXME	    << " TS at R,phi: " << startingState.position().perp() << ","
-    // 		    << startingState.position().phi()
 
-    
+  LogTrace(metname) << "MuDetRod::compatibleDets, Surface at R,phi: " << surface().position().perp() << ","
+                    << surface().position().phi() << "     DetRod pos.";
+  // FIXME	    << " TS at R,phi: " << startingState.position().perp() << ","
+  // 		    << startingState.position().phi()
+
   vector<DetWithState> result;
-  
+
   // Propagate and check that the result is within bounds
-  pair<bool, TrajectoryStateOnSurface> compat =
-    compatible(startingState, prop, est);
-  
+  pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
+
   if (!compat.first) {
     LogTrace(metname) << "    MuDetRod::compatibleDets: not compatible"
                       << "    (should not have been selected!)";
     return result;
   }
-  
+
   // Find the most probable destination component
   TrajectoryStateOnSurface& tsos = compat.second;
   GlobalPoint startPos = tsos.globalPosition();
   int closest = theBinFinder.binIndex(startPos.z());
   const vector<const GeomDet*> dets = basicComponents();
-  LogTrace(metname) << "     MuDetRod::compatibleDets, closest det: " << closest 
-                    << " pos: " << dets[closest]->surface().position()
-                    << " impact " << startPos;
-  
+  LogTrace(metname) << "     MuDetRod::compatibleDets, closest det: " << closest
+                    << " pos: " << dets[closest]->surface().position() << " impact " << startPos;
+
   // Add this detector, if it is compatible
   // NOTE: add performs a null propagation
   add(closest, result, tsos, prop, est);
-  
-  int nclosest = result.size(); int nnextdet=0; // just DEBUG counters
-  
+
+  int nclosest = result.size();
+  int nnextdet = 0;  // just DEBUG counters
+
   // Try the neighbors on each side until no more compatible.
   // If closest is not compatible the next cannot be either
   if (!result.empty()) {
     const BoundPlane& closestPlane(dets[closest]->surface());
-    MeasurementEstimator::Local2DVector maxDistance = 
-      est.maximalLocalDisplacement( result.front().second, closestPlane);
-    
+    MeasurementEstimator::Local2DVector maxDistance = est.maximalLocalDisplacement(result.front().second, closestPlane);
+
     // detHalfLen is assumed to be the same for all detectors.
-    float detHalfLen = closestPlane.bounds().length()/2.;
-    
-    for (unsigned int idet=closest+1; idet < dets.size(); idet++) {
+    float detHalfLen = closestPlane.bounds().length() / 2.;
+
+    for (unsigned int idet = closest + 1; idet < dets.size(); idet++) {
       LocalPoint nextPos(dets[idet]->toLocal(startPos));
-      if (fabs(nextPos.y()) < detHalfLen + maxDistance.y()) { 
-        LogTrace(metname) << "     negativeZ: det:" << idet
-                          << " pos " << nextPos.y()
-                          << " maxDistance " << maxDistance.y();
+      if (fabs(nextPos.y()) < detHalfLen + maxDistance.y()) {
+        LogTrace(metname) << "     negativeZ: det:" << idet << " pos " << nextPos.y() << " maxDistance "
+                          << maxDistance.y();
         nnextdet++;
-        if ( !add(idet, result, tsos, prop, est)) break;
+        if (!add(idet, result, tsos, prop, est))
+          break;
       } else {
         break;
       }
     }
-    
-    for (int idet=closest-1; idet >= 0; idet--) {
-      LocalPoint nextPos( dets[idet]->toLocal(startPos));
+
+    for (int idet = closest - 1; idet >= 0; idet--) {
+      LocalPoint nextPos(dets[idet]->toLocal(startPos));
       if (fabs(nextPos.y()) < detHalfLen + maxDistance.y()) {
-        LogTrace(metname) << "     positiveZ: det:" << idet
-                          << " pos " << nextPos.y()
-                          << " maxDistance " << maxDistance.y();
+        LogTrace(metname) << "     positiveZ: det:" << idet << " pos " << nextPos.y() << " maxDistance "
+                          << maxDistance.y();
         nnextdet++;
-        if ( !add(idet, result, tsos, prop, est)) break;
+        if (!add(idet, result, tsos, prop, est))
+          break;
       } else {
         break;
       }
     }
   }
-  
-  LogTrace(metname) << "     MuDetRod::compatibleDets, size: " << result.size()
-                    << " on closest: " << nclosest
-                    << " # checked dets: " << nnextdet+1;
+
+  LogTrace(metname) << "     MuDetRod::compatibleDets, size: " << result.size() << " on closest: " << nclosest
+                    << " # checked dets: " << nnextdet + 1;
   if (result.empty()) {
     LogTrace(metname) << "   ***Rod not compatible---should have been discarded before!!!";
   }
   return result;
 }
 
-
-vector<DetGroup> 
-MuDetRod::groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-                                 const Propagator& prop,
-                                 const MeasurementEstimator& est) const {
-  // FIXME should return only 1 group 
+vector<DetGroup> MuDetRod::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                 const Propagator& prop,
+                                                 const MeasurementEstimator& est) const {
+  // FIXME should return only 1 group
   cout << "dummy implementation of MuDetRod::groupedCompatibleDets()" << endl;
   vector<DetGroup> result;
   return result;

--- a/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
+++ b/RecoMuon/DetLayers/src/MuRingForwardDoubleLayer.cc
@@ -19,99 +19,82 @@
 using namespace std;
 
 MuRingForwardDoubleLayer::MuRingForwardDoubleLayer(const vector<const ForwardDetRing*>& frontRings,
-                                       const vector<const ForwardDetRing*>& backRings) :
-  RingedForwardLayer(true),
-  theFrontLayer(frontRings),
-  theBackLayer(backRings),
-  theRings(frontRings), // add back later
-  theComponents(),
-  theBasicComponents()
-{
-
+                                                   const vector<const ForwardDetRing*>& backRings)
+    : RingedForwardLayer(true),
+      theFrontLayer(frontRings),
+      theBackLayer(backRings),
+      theRings(frontRings),  // add back later
+      theComponents(),
+      theBasicComponents() {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardDoubleLayer";
 
   theRings.insert(theRings.end(), backRings.begin(), backRings.end());
-  theComponents = std::vector <const GeometricSearchDet*>(theRings.begin(), theRings.end());
+  theComponents = std::vector<const GeometricSearchDet*>(theRings.begin(), theRings.end());
 
   // Cache chamber pointers (the basic components_)
   // and find extension in R and Z
-  for (vector<const ForwardDetRing*>::const_iterator it=theRings.begin();
-       it!=theRings.end(); it++) {
+  for (vector<const ForwardDetRing*>::const_iterator it = theRings.begin(); it != theRings.end(); it++) {
     vector<const GeomDet*> tmp2 = (*it)->basicComponents();
-    theBasicComponents.insert(theBasicComponents.end(),tmp2.begin(),tmp2.end());
-  }  
-  
+    theBasicComponents.insert(theBasicComponents.end(), tmp2.begin(), tmp2.end());
+  }
+
   setSurface(computeSurface());
-   
-  LogTrace(metname) << "Constructing MuRingForwardDoubleLayer: "
-                    << basicComponents().size() << " Dets " 
+
+  LogTrace(metname) << "Constructing MuRingForwardDoubleLayer: " << basicComponents().size() << " Dets "
                     << theRings.size() << " Rings "
-                    << " Z: " << specificSurface().position().z()
-                    << " R1: " << specificSurface().innerRadius()
+                    << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
                     << " R2: " << specificSurface().outerRadius();
 
   selfTest();
 }
 
+BoundDisk* MuRingForwardDoubleLayer::computeSurface() {
+  const BoundDisk& frontDisk = theFrontLayer.specificSurface();
+  const BoundDisk& backDisk = theBackLayer.specificSurface();
 
-BoundDisk * MuRingForwardDoubleLayer::computeSurface() 
-{
-  const BoundDisk & frontDisk = theFrontLayer.specificSurface();
-  const BoundDisk & backDisk  = theBackLayer.specificSurface();
-
-  float rmin = min( frontDisk.innerRadius(), backDisk.innerRadius() );
-  float rmax = max( frontDisk.outerRadius(), backDisk.outerRadius() );
+  float rmin = min(frontDisk.innerRadius(), backDisk.innerRadius());
+  float rmax = max(frontDisk.outerRadius(), backDisk.outerRadius());
   float zmin = frontDisk.position().z();
-  float halfThickness = frontDisk.bounds().thickness()/2.;
-  zmin = (zmin > 0) ? zmin-halfThickness : zmin+halfThickness;
+  float halfThickness = frontDisk.bounds().thickness() / 2.;
+  zmin = (zmin > 0) ? zmin - halfThickness : zmin + halfThickness;
   float zmax = backDisk.position().z();
-  halfThickness = backDisk.bounds().thickness()/2.;
-  zmax = (zmax > 0) ? zmax+halfThickness : zmax-halfThickness;
-  float zPos = (zmax+zmin)/2.;
-  PositionType pos(0.,0.,zPos);
+  halfThickness = backDisk.bounds().thickness() / 2.;
+  zmax = (zmax > 0) ? zmax + halfThickness : zmax - halfThickness;
+  float zPos = (zmax + zmin) / 2.;
+  PositionType pos(0., 0., zPos);
   RotationType rot;
 
-  return new BoundDisk( pos, rot,
-                        new SimpleDiskBounds( rmin, rmax,
-                                              zmin-zPos, zmax-zPos));
+  return new BoundDisk(pos, rot, new SimpleDiskBounds(rmin, rmax, zmin - zPos, zmax - zPos));
 }
 
-
-bool MuRingForwardDoubleLayer::isInsideOut(const TrajectoryStateOnSurface& tsos) const 
-{
+bool MuRingForwardDoubleLayer::isInsideOut(const TrajectoryStateOnSurface& tsos) const {
   return tsos.globalPosition().basicVector().dot(tsos.globalMomentum().basicVector()) > 0;
 }
 
-  
-
-std::pair<bool, TrajectoryStateOnSurface>
-MuRingForwardDoubleLayer::compatible(const TrajectoryStateOnSurface& startingState, const Propagator& prop,
-                                     const MeasurementEstimator& est) const
-{
+std::pair<bool, TrajectoryStateOnSurface> MuRingForwardDoubleLayer::compatible(
+    const TrajectoryStateOnSurface& startingState, const Propagator& prop, const MeasurementEstimator& est) const {
   // mostly copied from ForwardDetLayer, except propagates to closest surface,
   // not to center
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardDoubleLayer";
 
   bool insideOut = isInsideOut(startingState);
-  const MuRingForwardLayer & closerLayer = (insideOut) ? theFrontLayer : theBackLayer;
-  LogTrace("Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardDoubleLayer") 
-    << "MuRingForwardDoubleLayer::compatible is assuming inside-out direction: "<< insideOut;
+  const MuRingForwardLayer& closerLayer = (insideOut) ? theFrontLayer : theBackLayer;
+  LogTrace("Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardDoubleLayer")
+      << "MuRingForwardDoubleLayer::compatible is assuming inside-out direction: " << insideOut;
 
-
-  //std::pair<bool, TrajectoryStateOnSurface> result 
+  //std::pair<bool, TrajectoryStateOnSurface> result
   //  = closerLayer.compatible(startingState, prop, est);
   //if(!result.first)
   // {
   //  result = furtherLayer.compatible(startingState, prop, est);
   //}
 
-
-  TrajectoryStateOnSurface myState = prop.propagate( startingState, closerLayer.specificSurface());
-  if ( !myState.isValid()) return make_pair( false, myState);
+  TrajectoryStateOnSurface myState = prop.propagate(startingState, closerLayer.specificSurface());
+  if (!myState.isValid())
+    return make_pair(false, myState);
 
   // take into account the thickness of the layer
-  float deltaR = surface().bounds().thickness()/2. *
-    fabs( tan( myState.localDirection().theta()));
+  float deltaR = surface().bounds().thickness() / 2. * fabs(tan(myState.localDirection().theta()));
 
   // take into account the error on the predicted state
   const float nSigma = 3.;
@@ -121,116 +104,96 @@ MuRingForwardDoubleLayer::compatible(const TrajectoryStateOnSurface& startingSta
     deltaR += nSigma * sqrt(err.xx() + err.yy());
   }
 
-  float zPos = (zmax()+zmin())/2.;
-  SimpleDiskBounds tmp( rmin()-deltaR, rmax()+deltaR,
-                        zmin()-zPos, zmax()-zPos);
+  float zPos = (zmax() + zmin()) / 2.;
+  SimpleDiskBounds tmp(rmin() - deltaR, rmax() + deltaR, zmin() - zPos, zmax() - zPos);
 
-  return make_pair( tmp.inside(myState.localPosition()), myState);
+  return make_pair(tmp.inside(myState.localPosition()), myState);
 }
 
-
-vector<GeometricSearchDet::DetWithState> 
-MuRingForwardDoubleLayer::compatibleDets(const TrajectoryStateOnSurface& startingState,
-				   const Propagator& prop, 
-				   const MeasurementEstimator& est) const {
+vector<GeometricSearchDet::DetWithState> MuRingForwardDoubleLayer::compatibleDets(
+    const TrajectoryStateOnSurface& startingState, const Propagator& prop, const MeasurementEstimator& est) const {
   vector<DetWithState> result;
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardDoubleLayer";
-  pair<bool, TrajectoryStateOnSurface> compat =
-    compatible(startingState, prop, est);
+  pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
 
   if (!compat.first) {
-
     LogTrace(metname) << "     MuRingForwardDoubleLayer::compatibleDets: not compatible"
                       << " (should not have been selected!)";
     return result;
   }
 
-
   TrajectoryStateOnSurface& tsos = compat.second;
 
-   // standard implementation of compatibleDets() for class which have 
+  // standard implementation of compatibleDets() for class which have
   // groupedCompatibleDets implemented.
-  // This code should be moved in a common place intead of being 
+  // This code should be moved in a common place intead of being
   // copied many times.
-  vector<DetGroup> vectorGroups = groupedCompatibleDets(tsos,prop,est);
-  for(vector<DetGroup>::const_iterator itDG=vectorGroups.begin();
-      itDG!=vectorGroups.end();itDG++){
-    for(vector<DetGroupElement>::const_iterator itDGE=itDG->begin();
-        itDGE!=itDG->end();itDGE++){
-      result.push_back(DetWithState(itDGE->det(),itDGE->trajectoryState()));
+  vector<DetGroup> vectorGroups = groupedCompatibleDets(tsos, prop, est);
+  for (vector<DetGroup>::const_iterator itDG = vectorGroups.begin(); itDG != vectorGroups.end(); itDG++) {
+    for (vector<DetGroupElement>::const_iterator itDGE = itDG->begin(); itDGE != itDG->end(); itDGE++) {
+      result.push_back(DetWithState(itDGE->det(), itDGE->trajectoryState()));
     }
   }
-  return result;  
-} 
+  return result;
+}
 
-
-vector<DetGroup>
-MuRingForwardDoubleLayer::groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-                                           const Propagator& prop,
-                                           const MeasurementEstimator& est) const {
-
+vector<DetGroup> MuRingForwardDoubleLayer::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                                 const Propagator& prop,
+                                                                 const MeasurementEstimator& est) const {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardDoubleLayer";
   vector<GeometricSearchDet::DetWithState> detWithStates1, detWithStates2;
-  
+
   LogTrace(metname) << "groupedCompatibleDets are currently given always in inside-out order";
   // this should be fixed either in RecoMuon/MeasurementDet/MuonDetLayerMeasurements or
   // RecoMuon/DetLayers/MuRingForwardDoubleLayer
   // and removed the reverse operation in StandAloneMuonFilter::findBestMeasurements
 
   detWithStates1 = theFrontLayer.compatibleDets(startingState, prop, est);
-  detWithStates2 = theBackLayer.compatibleDets(startingState, prop, est);    
-  
+  detWithStates2 = theBackLayer.compatibleDets(startingState, prop, est);
+
   vector<DetGroup> result;
-  if(!detWithStates1.empty()) result.push_back( DetGroup(detWithStates1) );
-  if(!detWithStates2.empty()) result.push_back( DetGroup(detWithStates2) );
+  if (!detWithStates1.empty())
+    result.push_back(DetGroup(detWithStates1));
+  if (!detWithStates2.empty())
+    result.push_back(DetGroup(detWithStates2));
   LogTrace(metname) << "DoubleLayer Compatible dets: " << result.size();
   return result;
 }
 
-
-bool MuRingForwardDoubleLayer::isCrack(const GlobalPoint & gp) const
-{
+bool MuRingForwardDoubleLayer::isCrack(const GlobalPoint& gp) const {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardDoubleLayer";
   // approximate
   bool result = false;
   double r = gp.perp();
-  const std::vector<const ForwardDetRing*>& backRings = theBackLayer.rings(); 
-  if(backRings.size() > 1)
-  {
-    const MuDetRing * innerRing = dynamic_cast<const MuDetRing *>(backRings[0]);
-    const MuDetRing * outerRing = dynamic_cast<const MuDetRing *>(backRings[1]);
+  const std::vector<const ForwardDetRing*>& backRings = theBackLayer.rings();
+  if (backRings.size() > 1) {
+    const MuDetRing* innerRing = dynamic_cast<const MuDetRing*>(backRings[0]);
+    const MuDetRing* outerRing = dynamic_cast<const MuDetRing*>(backRings[1]);
     assert(innerRing && outerRing);
     float crackInner = innerRing->specificSurface().outerRadius();
     float crackOuter = outerRing->specificSurface().innerRadius();
-    LogTrace(metname)  << "In a crack:" << crackInner << " " << r << " " << crackOuter;
-    if(r > crackInner && r < crackOuter) return true;
+    LogTrace(metname) << "In a crack:" << crackInner << " " << r << " " << crackOuter;
+    if (r > crackInner && r < crackOuter)
+      return true;
   }
   // non-overlapping rings
   //double phi = gp.phi().degrees();
   return result;
 }
 
-
-void MuRingForwardDoubleLayer::selfTest() const
-{
+void MuRingForwardDoubleLayer::selfTest() const {
   const std::vector<const GeomDet*>& frontDets = theFrontLayer.basicComponents();
   const std::vector<const GeomDet*>& backDets = theBackLayer.basicComponents();
 
-  std::vector<const GeomDet*>::const_iterator frontItr = frontDets.begin(),
-                                              lastFront = frontDets.end(),
-                                              backItr = backDets.begin(),
-                                              lastBack = backDets.end();
+  std::vector<const GeomDet*>::const_iterator frontItr = frontDets.begin(), lastFront = frontDets.end(),
+                                              backItr = backDets.begin(), lastBack = backDets.end();
 
   // test that each front z is less than each back z
-  for( ; frontItr != lastFront; ++frontItr)
-  {
-    float frontz = fabs( (**frontItr).surface().position().z() );
-    for( ; backItr != lastBack; ++backItr)
-    {
-      float backz = fabs( (**backItr).surface().position().z() );
+  for (; frontItr != lastFront; ++frontItr) {
+    float frontz = fabs((**frontItr).surface().position().z());
+    for (; backItr != lastBack; ++backItr) {
+      float backz = fabs((**backItr).surface().position().z());
       assert(frontz < backz);
     }
   }
 }
-
-

--- a/RecoMuon/DetLayers/src/MuRingForwardLayer.cc
+++ b/RecoMuon/DetLayers/src/MuRingForwardLayer.cc
@@ -21,123 +21,103 @@
 
 using namespace std;
 
-MuRingForwardLayer::MuRingForwardLayer(const vector<const ForwardDetRing*>& rings) :
-  RingedForwardLayer(false),
-  theRings(rings),
-  theComponents(theRings.begin(),theRings.end()),
-  theBinFinder(nullptr),
-  isOverlapping(false) 
-{
-
+MuRingForwardLayer::MuRingForwardLayer(const vector<const ForwardDetRing*>& rings)
+    : RingedForwardLayer(false),
+      theRings(rings),
+      theComponents(theRings.begin(), theRings.end()),
+      theBinFinder(nullptr),
+      isOverlapping(false) {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardLayer";
 
   // Initial values for R and Z bounds
-  float theRmin = rings.front()->basicComponents().front()->position().perp(); 
+  float theRmin = rings.front()->basicComponents().front()->position().perp();
   float theRmax = theRmin;
   float theZmin = rings.front()->position().z();
   float theZmax = theZmin;
 
   // Cache chamber pointers (the basic components_)
   // and find extension in R and Z
-  for (vector<const ForwardDetRing*>::const_iterator it=rings.begin();
-       it!=rings.end(); it++) {
+  for (vector<const ForwardDetRing*>::const_iterator it = rings.begin(); it != rings.end(); it++) {
     vector<const GeomDet*> tmp2 = (*it)->basicComponents();
-    theBasicComps.insert(theBasicComps.end(),tmp2.begin(),tmp2.end());
-    
-    theRmin = min( theRmin, (*it)->specificSurface().innerRadius());
-    theRmax = max( theRmax, (*it)->specificSurface().outerRadius());
-    float halfThick = (*it)->surface().bounds().thickness()/2.;
+    theBasicComps.insert(theBasicComps.end(), tmp2.begin(), tmp2.end());
+
+    theRmin = min(theRmin, (*it)->specificSurface().innerRadius());
+    theRmax = max(theRmax, (*it)->specificSurface().outerRadius());
+    float halfThick = (*it)->surface().bounds().thickness() / 2.;
     float zCenter = (*it)->surface().position().z();
-    theZmin = min( theZmin, zCenter-halfThick);
-    theZmax = max( theZmax, zCenter+halfThick); 
-  }  
-  
+    theZmin = min(theZmin, zCenter - halfThick);
+    theZmax = max(theZmax, zCenter + halfThick);
+  }
+
   RBorderFinder bf(theRings);
   isOverlapping = bf.isROverlapping();
   theBinFinder = new GeneralBinFinderInR<double>(bf);
 
   // Build surface
-  
-  float zPos = (theZmax+theZmin)/2.;
-  PositionType pos(0.,0.,zPos);
+
+  float zPos = (theZmax + theZmin) / 2.;
+  PositionType pos(0., 0., zPos);
   RotationType rot;
 
-  setSurface(new BoundDisk( pos, rot, 
-			    new SimpleDiskBounds( theRmin, theRmax, 
-					          theZmin-zPos, theZmax-zPos)));
+  setSurface(new BoundDisk(pos, rot, new SimpleDiskBounds(theRmin, theRmax, theZmin - zPos, theZmax - zPos)));
 
-
-   
-  LogTrace(metname) << "Constructing MuRingForwardLayer: "
-                    << basicComponents().size() << " Dets " 
-                    << theRings.size() << " Rings "
-                    << " Z: " << specificSurface().position().z()
-                    << " R1: " << specificSurface().innerRadius()
-                    << " R2: " << specificSurface().outerRadius()
-                    << " Per.: " << bf.isRPeriodic()
+  LogTrace(metname) << "Constructing MuRingForwardLayer: " << basicComponents().size() << " Dets " << theRings.size()
+                    << " Rings "
+                    << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
+                    << " R2: " << specificSurface().outerRadius() << " Per.: " << bf.isRPeriodic()
                     << " Overl.: " << bf.isROverlapping();
 }
 
-
-MuRingForwardLayer::~MuRingForwardLayer(){
+MuRingForwardLayer::~MuRingForwardLayer() {
   delete theBinFinder;
-  for (vector <const ForwardDetRing*>::iterator i = theRings.begin();
-       i<theRings.end(); i++) {delete *i;}
+  for (vector<const ForwardDetRing*>::iterator i = theRings.begin(); i < theRings.end(); i++) {
+    delete *i;
+  }
 }
 
-
-vector<GeometricSearchDet::DetWithState> 
-MuRingForwardLayer::compatibleDets(const TrajectoryStateOnSurface& startingState,
-				   const Propagator& prop, 
-				   const MeasurementEstimator& est) const {
-  
+vector<GeometricSearchDet::DetWithState> MuRingForwardLayer::compatibleDets(
+    const TrajectoryStateOnSurface& startingState, const Propagator& prop, const MeasurementEstimator& est) const {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRingForwardLayer";
-  vector<DetWithState> result; 
-  
-  
-  LogTrace(metname) << "MuRingForwardLayer::compatibleDets," 
-                    << " R1 " << specificSurface().innerRadius()
-                    << " R2: " << specificSurface().outerRadius()
+  vector<DetWithState> result;
+
+  LogTrace(metname) << "MuRingForwardLayer::compatibleDets,"
+                    << " R1 " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
                     << " FTS at R: " << startingState.globalPosition().perp();
-  
-  pair<bool, TrajectoryStateOnSurface> compat =
-    compatible(startingState, prop, est);
-  
+
+  pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
+
   if (!compat.first) {
-    
     LogTrace(metname) << "     MuRingForwardLayer::compatibleDets: not compatible"
                       << " (should not have been selected!)";
     return result;
   }
-  
-  
+
   TrajectoryStateOnSurface& tsos = compat.second;
-  
+
   int closest = theBinFinder->binIndex(tsos.globalPosition().perp());
   const ForwardDetRing* closestRing = theRings[closest];
-  
+
   // Check the closest ring
-  
-  LogTrace(metname) << "     MuRingForwardLayer::fastCompatibleDets, closestRing: "
-		    << closest
-		    << " R1 " << closestRing->specificSurface().innerRadius()
-		    << " R2: " << closestRing->specificSurface().outerRadius()
-		    << " FTS R: " << tsos.globalPosition().perp();
+
+  LogTrace(metname) << "     MuRingForwardLayer::fastCompatibleDets, closestRing: " << closest << " R1 "
+                    << closestRing->specificSurface().innerRadius()
+                    << " R2: " << closestRing->specificSurface().outerRadius()
+                    << " FTS R: " << tsos.globalPosition().perp();
   if (tsos.hasError()) {
-    LogTrace(metname)  << " sR: " << sqrt(tsos.localError().positionError().yy())
-		       << " sX: " << sqrt(tsos.localError().positionError().xx());
+    LogTrace(metname) << " sR: " << sqrt(tsos.localError().positionError().yy())
+                      << " sX: " << sqrt(tsos.localError().positionError().xx());
   }
   LogTrace(metname) << endl;
-   
-   
+
   result = closestRing->compatibleDets(tsos, prop, est);
-   
-  int nclosest = result.size(); int nnextdet=0; // MDEBUG counters
-   
+
+  int nclosest = result.size();
+  int nnextdet = 0;  // MDEBUG counters
+
   //FIXME: if closest is not compatible next cannot be either?
-   
+
   // Use state on layer surface. Note that local coordinates and errors
-  // are the same on the layer and on all rings surfaces, since 
+  // are the same on the layer and on all rings surfaces, since
   // all BoundDisks are centered in 0,0 and have the same rotation.
   // CAVEAT: if the rings are not at the same Z, the local position and error
   // will be "Z-projected" to the rings. This is a fairly good approximation.
@@ -145,80 +125,63 @@ MuRingForwardLayer::compatibleDets(const TrajectoryStateOnSurface& startingState
   // compatibleDets.
   GlobalPoint startPos = tsos.globalPosition();
   LocalPoint nextPos(surface().toLocal(startPos));
-   
-  for (unsigned int idet=closest+1; idet < theRings.size(); idet++) {
+
+  for (unsigned int idet = closest + 1; idet < theRings.size(); idet++) {
     bool inside = false;
     if (tsos.hasError()) {
-      inside=theRings[idet]->specificSurface().bounds().inside(nextPos,tsos.localError().positionError());
+      inside = theRings[idet]->specificSurface().bounds().inside(nextPos, tsos.localError().positionError());
     } else {
-      inside=theRings[idet]->specificSurface().bounds().inside(nextPos);
+      inside = theRings[idet]->specificSurface().bounds().inside(nextPos);
     }
-    if (inside){
-      LogTrace(metname) << "     MuRingForwardLayer::fastCompatibleDets:NextRing" << idet
-			<< " R1 " << theRings[idet]->specificSurface().innerRadius()
-			<< " R2: " << theRings[idet]->specificSurface().outerRadius()
-			<< " FTS R " << nextPos.perp();
-      nnextdet++;      
-      vector<DetWithState> nextRodDets =
-	theRings[idet]->compatibleDets(tsos, prop, est);
-      if (!nextRodDets.empty()) {
-	result.insert( result.end(), 
-		       nextRodDets.begin(), nextRodDets.end());
-      } else {
-	break;
-      }
-    }
-  }
-   
-  for (int idet=closest-1; idet >= 0; idet--) {
-    bool inside = false;
-    if (tsos.hasError()) {
-      inside=theRings[idet]->specificSurface().bounds().inside(nextPos,tsos.localError().positionError());
-    } else {
-      inside=theRings[idet]->specificSurface().bounds().inside(nextPos);
-    }
-    if (inside){
-      LogTrace(metname) << "     MuRingForwardLayer::fastCompatibleDets:PreviousRing:" << idet
-			<< " R1 " << theRings[idet]->specificSurface().innerRadius()
-			<< " R2: " << theRings[idet]->specificSurface().outerRadius()
-			<< " FTS R " << nextPos.perp();
+    if (inside) {
+      LogTrace(metname) << "     MuRingForwardLayer::fastCompatibleDets:NextRing" << idet << " R1 "
+                        << theRings[idet]->specificSurface().innerRadius()
+                        << " R2: " << theRings[idet]->specificSurface().outerRadius() << " FTS R " << nextPos.perp();
       nnextdet++;
-      vector<DetWithState> nextRodDets =
-	theRings[idet]->compatibleDets(tsos, prop, est);
+      vector<DetWithState> nextRodDets = theRings[idet]->compatibleDets(tsos, prop, est);
       if (!nextRodDets.empty()) {
-	result.insert( result.end(), 
-		       nextRodDets.begin(), nextRodDets.end());
+        result.insert(result.end(), nextRodDets.begin(), nextRodDets.end());
       } else {
-	break;
+        break;
       }
     }
   }
-   
-  LogTrace(metname) << "     MuRingForwardLayer::fastCompatibleDets: found: "
-		    << result.size()
-		    << " on closest: " << nclosest
-		    << " # checked rings: " << 1 + nnextdet;
-   
+
+  for (int idet = closest - 1; idet >= 0; idet--) {
+    bool inside = false;
+    if (tsos.hasError()) {
+      inside = theRings[idet]->specificSurface().bounds().inside(nextPos, tsos.localError().positionError());
+    } else {
+      inside = theRings[idet]->specificSurface().bounds().inside(nextPos);
+    }
+    if (inside) {
+      LogTrace(metname) << "     MuRingForwardLayer::fastCompatibleDets:PreviousRing:" << idet << " R1 "
+                        << theRings[idet]->specificSurface().innerRadius()
+                        << " R2: " << theRings[idet]->specificSurface().outerRadius() << " FTS R " << nextPos.perp();
+      nnextdet++;
+      vector<DetWithState> nextRodDets = theRings[idet]->compatibleDets(tsos, prop, est);
+      if (!nextRodDets.empty()) {
+        result.insert(result.end(), nextRodDets.begin(), nextRodDets.end());
+      } else {
+        break;
+      }
+    }
+  }
+
+  LogTrace(metname) << "     MuRingForwardLayer::fastCompatibleDets: found: " << result.size()
+                    << " on closest: " << nclosest << " # checked rings: " << 1 + nnextdet;
+
   return result;
 }
 
-
-vector<DetGroup> 
-MuRingForwardLayer::groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-                                           const Propagator& prop,
-                                           const MeasurementEstimator& est) const {
-  // FIXME should return only 1 group 
+vector<DetGroup> MuRingForwardLayer::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                           const Propagator& prop,
+                                                           const MeasurementEstimator& est) const {
+  // FIXME should return only 1 group
   cout << "dummy implementation of MuRingForwardLayer::groupedCompatibleDets()" << endl;
   return vector<DetGroup>();
 }
 
+GeomDetEnumerators::SubDetector MuRingForwardLayer::subDetector() const { return theBasicComps.front()->subDetector(); }
 
-
-GeomDetEnumerators::SubDetector MuRingForwardLayer::subDetector() const {
-  return theBasicComps.front()->subDetector();
-}
-
-const vector<const GeometricSearchDet*> &
-MuRingForwardLayer::components() const {
-  return theComponents;
-}
+const vector<const GeometricSearchDet*>& MuRingForwardLayer::components() const { return theComponents; }

--- a/RecoMuon/DetLayers/src/MuRodBarrelLayer.cc
+++ b/RecoMuon/DetLayers/src/MuRodBarrelLayer.cc
@@ -3,7 +3,6 @@
  *  \author N. Amapane - CERN
  */
 
-
 #include "RecoMuon/DetLayers/interface/MuRodBarrelLayer.h"
 #include "RecoMuon/DetLayers/interface/MuDetRod.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
@@ -23,85 +22,69 @@
 
 using namespace std;
 
-MuRodBarrelLayer::MuRodBarrelLayer(vector<const DetRod*>& rods) :
-  RodBarrelLayer(false),
-  theRods(rods),
-  theBinFinder(nullptr),
-  isOverlapping(false)
-{
+MuRodBarrelLayer::MuRodBarrelLayer(vector<const DetRod*>& rods)
+    : RodBarrelLayer(false), theRods(rods), theBinFinder(nullptr), isOverlapping(false) {
   // Sort rods in phi
-  precomputed_value_sort(theRods.begin(),theRods.end(), geomsort::ExtractPhi<DetRod,float>());
+  precomputed_value_sort(theRods.begin(), theRods.end(), geomsort::ExtractPhi<DetRod, float>());
 
   theComponents.reserve(theRods.size());
-  std::copy(theRods.begin(),theRods.end(),back_inserter(theComponents));
+  std::copy(theRods.begin(), theRods.end(), back_inserter(theComponents));
 
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRodBarrelLayer";
 
   // Cache chamber pointers (the basic components_)
-  for (vector<const DetRod*>::const_iterator it=rods.begin();
-       it!=rods.end(); it++) {
+  for (vector<const DetRod*>::const_iterator it = rods.begin(); it != rods.end(); it++) {
     vector<const GeomDet*> tmp2 = (*it)->basicComponents();
-    theBasicComps.insert(theBasicComps.end(),tmp2.begin(),tmp2.end());
+    theBasicComps.insert(theBasicComps.end(), tmp2.begin(), tmp2.end());
   }
 
   // Initialize the binfinder
   PhiBorderFinder bf(theRods);
   isOverlapping = bf.isPhiOverlapping();
 
-  if ( bf.isPhiPeriodic() ) { 
-    theBinFinder = new PeriodicBinFinderInPhi<double>
-    (theRods.front()->position().phi(),theRods.size());
+  if (bf.isPhiPeriodic()) {
+    theBinFinder = new PeriodicBinFinderInPhi<double>(theRods.front()->position().phi(), theRods.size());
   } else {
     theBinFinder = new GeneralBinFinderInPhi<double>(bf);
   }
 
   // Compute the layer's surface and bounds (from the components())
-  BarrelDetLayer::initialize(); 
-  
-  LogTrace(metname) << "Constructing MuRodBarrelLayer: "
-		    << basicComponents().size() << " Dets " 
-		    << theRods.size() << " Rods "
-		    << " R: " << specificSurface().radius()
-		    << " Per.: " << bf.isPhiPeriodic()
-		    << " Overl.: " << isOverlapping;
-}
+  BarrelDetLayer::initialize();
 
+  LogTrace(metname) << "Constructing MuRodBarrelLayer: " << basicComponents().size() << " Dets " << theRods.size()
+                    << " Rods "
+                    << " R: " << specificSurface().radius() << " Per.: " << bf.isPhiPeriodic()
+                    << " Overl.: " << isOverlapping;
+}
 
 MuRodBarrelLayer::~MuRodBarrelLayer() {
   delete theBinFinder;
-  for (vector <const DetRod*>::iterator i = theRods.begin();
-       i<theRods.end(); i++) {delete *i;}
+  for (vector<const DetRod*>::iterator i = theRods.begin(); i < theRods.end(); i++) {
+    delete *i;
+  }
 }
 
-
-vector<GeometricSearchDet::DetWithState> 
-MuRodBarrelLayer::compatibleDets(const TrajectoryStateOnSurface& startingState,
-				 const Propagator& prop, 
-				 const MeasurementEstimator& est) const {
-
+vector<GeometricSearchDet::DetWithState> MuRodBarrelLayer::compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                                          const Propagator& prop,
+                                                                          const MeasurementEstimator& est) const {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuRodBarrelLayer";
-  vector<DetWithState> result; 
+  vector<DetWithState> result;
 
- 
-  LogTrace(metname) << "MuRodBarrelLayer::compatibleDets, Cyl R: " 
-                    << specificSurface().radius()
+  LogTrace(metname) << "MuRodBarrelLayer::compatibleDets, Cyl R: " << specificSurface().radius()
                     << " TSOS at R= " << startingState.globalPosition().perp()
-		    << " phi= " << startingState.globalPosition().phi();
+                    << " phi= " << startingState.globalPosition().phi();
 
-  pair<bool, TrajectoryStateOnSurface> compat =
-    compatible(startingState, prop, est);
+  pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
   if (!compat.first) {
     LogTrace(metname) << "     MuRodBarrelLayer::compatibleDets: not compatible"
                       << " (should not have been selected!)";
     return vector<DetWithState>();
-  } 
+  }
 
   TrajectoryStateOnSurface& tsos = compat.second;
 
-  LogTrace(metname) << "     MuRodBarrelLayer::compatibleDets, reached layer at: "
-		    << tsos.globalPosition()
-		    << " R = " << tsos.globalPosition().perp()
-		    << " phi = " << tsos.globalPosition().phi();
+  LogTrace(metname) << "     MuRodBarrelLayer::compatibleDets, reached layer at: " << tsos.globalPosition()
+                    << " R = " << tsos.globalPosition().perp() << " phi = " << tsos.globalPosition().phi();
 
   int closest = theBinFinder->binIndex(tsos.globalPosition().phi());
   const DetRod* closestRod = theRods[closest];
@@ -110,103 +93,87 @@ MuRodBarrelLayer::compatibleDets(const TrajectoryStateOnSurface& startingState,
   LogTrace(metname) << "     MuRodBarrelLayer::compatibleDets, closestRod: " << closest
                     << " phi : " << closestRod->surface().position().phi()
                     << " FTS phi: " << tsos.globalPosition().phi();
-  
+
   result = closestRod->compatibleDets(tsos, prop, est);
 
-  int nclosest = result.size(); // Debug counter
+  int nclosest = result.size();  // Debug counter
 
-  bool checknext = false ;
+  bool checknext = false;
   double dist;
 
-  if (!result.empty()) { 
-    // Check if the track go outside closest rod, then look for closest. 
+  if (!result.empty()) {
+    // Check if the track go outside closest rod, then look for closest.
     TrajectoryStateOnSurface& predictedState = result.front().second;
     float xErr = xError(predictedState, est);
-    float halfWid = closestRod->surface().bounds().width()/2.;
+    float halfWid = closestRod->surface().bounds().width() / 2.;
     dist = predictedState.localPosition().x();
 
     // If the layer is overlapping, additionally reduce halfWid by 10%
     // to account for overlap.
     // FIXME: should we account for the real amount of overlap?
-    if (isOverlapping) halfWid *= 0.9;
+    if (isOverlapping)
+      halfWid *= 0.9;
 
     if (fabs(dist) + xErr > halfWid) {
       checknext = true;
     }
-  } else { // Rod is not compatible
+  } else {  // Rod is not compatible
     //FIXME: Usually next cannot be either. Implement proper logic.
     // (in general at least one rod should be when this method is called by
     // compatibleDets() which calls compatible())
     checknext = true;
-    
+
     // Look for the next-to closest in phi.
     // Note Geom::Phi, subtraction is pi-border-safe
-    if ( tsos.globalPosition().phi()-closestRod->surface().position().phi()>0.)
-    {
+    if (tsos.globalPosition().phi() - closestRod->surface().position().phi() > 0.) {
       dist = -1.;
     } else {
       dist = +1.;
     }
 
-    
     LogTrace(metname) << "     MuRodBarrelLayer::fastCompatibleDets, none on closest rod!";
   }
 
   if (checknext) {
     int next;
-    if (dist<0.) next = closest+1;
-    else next = closest-1;
+    if (dist < 0.)
+      next = closest + 1;
+    else
+      next = closest - 1;
 
-    next = theBinFinder->binIndex(next); // Bin Periodicity
+    next = theBinFinder->binIndex(next);  // Bin Periodicity
     const DetRod* nextRod = theRods[next];
 
-  
     LogTrace(metname) << "     MuRodBarrelLayer::fastCompatibleDets, next-to closest"
-                      << " rod: " << next << " dist " << dist
-                      << " phi : " << nextRod->surface().position().phi()
-                      << " FTS phi: " << tsos.globalPosition().phi();   
-    
-    vector<DetWithState> nextRodDets =
-      nextRod->compatibleDets(tsos, prop, est);
-    result.insert(result.end(), 
-		  nextRodDets.begin(), nextRodDets.end());
+                      << " rod: " << next << " dist " << dist << " phi : " << nextRod->surface().position().phi()
+                      << " FTS phi: " << tsos.globalPosition().phi();
+
+    vector<DetWithState> nextRodDets = nextRod->compatibleDets(tsos, prop, est);
+    result.insert(result.end(), nextRodDets.begin(), nextRodDets.end());
   }
-  
-  
-   LogTrace(metname) << "     MuRodBarrelLayer::fastCompatibleDets: found: "
-                     << result.size()
-                     << " on closest: " << nclosest
-                     << " # checked rods: " << 1 + int(checknext);
-  
+
+  LogTrace(metname) << "     MuRodBarrelLayer::fastCompatibleDets: found: " << result.size()
+                    << " on closest: " << nclosest << " # checked rods: " << 1 + int(checknext);
+
   return result;
 }
 
-
-vector<DetGroup> 
-MuRodBarrelLayer::groupedCompatibleDets( const TrajectoryStateOnSurface& startingState,
-					 const Propagator& prop,
-					 const MeasurementEstimator& est) const {
-  // FIXME should return only 1 group 
+vector<DetGroup> MuRodBarrelLayer::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                         const Propagator& prop,
+                                                         const MeasurementEstimator& est) const {
+  // FIXME should return only 1 group
   cout << "dummy implementation of MuRodBarrelLayer::groupedCompatibleDets()" << endl;
   return vector<DetGroup>();
 }
 
+GeomDetEnumerators::SubDetector MuRodBarrelLayer::subDetector() const { return theBasicComps.front()->subDetector(); }
 
+const vector<const GeometricSearchDet*>& MuRodBarrelLayer::components() const { return theComponents; }
 
-GeomDetEnumerators::SubDetector MuRodBarrelLayer::subDetector() const {
-  return theBasicComps.front()->subDetector();
-}
-
-const vector<const GeometricSearchDet*>&
-MuRodBarrelLayer::components() const {
-  return theComponents;
-}
-
-float MuRodBarrelLayer::xError(const TrajectoryStateOnSurface& tsos,
-			       const MeasurementEstimator& est) const {
+float MuRodBarrelLayer::xError(const TrajectoryStateOnSurface& tsos, const MeasurementEstimator& est) const {
   const float nSigmas = 3.f;
   if (tsos.hasError()) {
     return nSigmas * sqrt(tsos.localError().positionError().xx());
-  }
-  else return nSigmas * 0.5;
+  } else
+    return nSigmas * 0.5;
 }

--- a/RecoMuon/DetLayers/src/MuonCSCDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonCSCDetLayerGeometryBuilder.cc
@@ -14,140 +14,120 @@
 
 using namespace std;
 
-pair<vector<DetLayer*>, vector<DetLayer*> > 
-MuonCSCDetLayerGeometryBuilder::buildLayers(const CSCGeometry& geo) {
+pair<vector<DetLayer*>, vector<DetLayer*> > MuonCSCDetLayerGeometryBuilder::buildLayers(const CSCGeometry& geo) {
+  vector<DetLayer*> result[2];  // one for each endcap
 
-  vector<DetLayer*> result[2]; // one for each endcap
-  
-  for(int i=0; i<2; i++) {        
-    
-    int endcap = i+1;
-    
+  for (int i = 0; i < 2; i++) {
+    int endcap = i + 1;
+
     // ME/1/1a (= station 1, ring 4) and ME/1/1b (= station 1, ring 1)
     {
       vector<int> rings;
       rings.push_back(4);
       rings.push_back(1);
-      
-      MuRingForwardDoubleLayer* layer = buildLayer(endcap, 1, rings, geo);          
-      if (layer) result[i].push_back(layer);  
+
+      MuRingForwardDoubleLayer* layer = buildLayer(endcap, 1, rings, geo);
+      if (layer)
+        result[i].push_back(layer);
     }
-    
+
     // ME/1/2 and 1/3 (= station 1, ring 2 and 3)
     {
       vector<int> rings;
       rings.push_back(2);
       rings.push_back(3);
-      
-      MuRingForwardDoubleLayer* layer = buildLayer(endcap, 1, rings, geo);          
-      if (layer) result[i].push_back(layer);  
-    }    
-    
+
+      MuRingForwardDoubleLayer* layer = buildLayer(endcap, 1, rings, geo);
+      if (layer)
+        result[i].push_back(layer);
+    }
+
     // Stations 2,3,4
-    for(int station = 2; station <= CSCDetId::maxStationId(); station++) {
-      vector<int> rings;      
-      for(int ring = CSCDetId::minRingId(); ring <= CSCDetId::maxRingId(); ring++) {
+    for (int station = 2; station <= CSCDetId::maxStationId(); station++) {
+      vector<int> rings;
+      for (int ring = CSCDetId::minRingId(); ring <= CSCDetId::maxRingId(); ring++) {
         rings.push_back(ring);
       }
-      MuRingForwardDoubleLayer* layer = buildLayer(endcap, station, rings, geo);          
-      if (layer) result[i].push_back(layer);
+      MuRingForwardDoubleLayer* layer = buildLayer(endcap, station, rings, geo);
+      if (layer)
+        result[i].push_back(layer);
     }
   }
-  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]); 
+  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]);
   return res_pair;
 }
 
 MuRingForwardDoubleLayer* MuonCSCDetLayerGeometryBuilder::buildLayer(int endcap,
-                                                               int station,
-                                                               vector<int>& rings,
-                                                               const CSCGeometry& geo) {
+                                                                     int station,
+                                                                     vector<int>& rings,
+                                                                     const CSCGeometry& geo) {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonCSCDetLayerGeometryBuilder";
-  MuRingForwardDoubleLayer* result=nullptr;
-  
+  MuRingForwardDoubleLayer* result = nullptr;
+
   vector<const ForwardDetRing*> frontRings, backRings;
-  
-  for (vector<int>::iterator ring = rings.begin(); ring!=rings.end(); ring++) {    
+
+  for (vector<int>::iterator ring = rings.begin(); ring != rings.end(); ring++) {
     vector<const GeomDet*> frontGeomDets, backGeomDets;
-    for(int chamber = CSCDetId::minChamberId(); chamber <= CSCDetId::maxChamberId(); chamber++) {
+    for (int chamber = CSCDetId::minChamberId(); chamber <= CSCDetId::maxChamberId(); chamber++) {
       CSCDetId detId(endcap, station, (*ring), chamber, 0);
       const GeomDet* geomDet = geo.idToDet(detId);
       // we sometimes loop over more chambers than there are in ring
       bool isInFront = isFront(station, *ring, chamber);
-      if(geomDet != nullptr)
-      {
-        if(isInFront)
-        {
+      if (geomDet != nullptr) {
+        if (isInFront) {
           frontGeomDets.push_back(geomDet);
-        }
-        else
-        {
+        } else {
           backGeomDets.push_back(geomDet);
         }
-        LogTrace(metname) << "get CSC chamber "
-                          <<  CSCDetId(endcap, station, (*ring), chamber, 0)
-                          << " at R=" << geomDet->position().perp()
-                          << ", phi=" << geomDet->position().phi()
-                          << ", z= " << geomDet->position().z() 
-                          << " isFront? " << isInFront;
+        LogTrace(metname) << "get CSC chamber " << CSCDetId(endcap, station, (*ring), chamber, 0)
+                          << " at R=" << geomDet->position().perp() << ", phi=" << geomDet->position().phi()
+                          << ", z= " << geomDet->position().z() << " isFront? " << isInFront;
       }
     }
 
-    if(!backGeomDets.empty())
-    {
+    if (!backGeomDets.empty()) {
       backRings.push_back(makeDetRing(backGeomDets));
     }
 
-    if(!frontGeomDets.empty())
-    {
+    if (!frontGeomDets.empty()) {
       frontRings.push_back(makeDetRing(frontGeomDets));
       assert(!backGeomDets.empty());
       float frontz = frontRings[0]->position().z();
-      float backz  = backRings[0]->position().z();
+      float backz = backRings[0]->position().z();
       assert(fabs(frontz) < fabs(backz));
     }
   }
-  
+
   // How should they be sorted?
   //    precomputed_value_sort(muDetRods.begin(), muDetRods.end(), geomsort::ExtractZ<GeometricSearchDet,float>());
-  result = new MuRingForwardDoubleLayer(frontRings, backRings);  
-  LogTrace(metname) << "New MuRingForwardLayer with " << frontRings.size() 
-                    << " and " << backRings.size()
-                    << " rings, at Z " << result->position().z()
-                    << " R1: " << result->specificSurface().innerRadius()
-                    << " R2: " << result->specificSurface().outerRadius(); 
+  result = new MuRingForwardDoubleLayer(frontRings, backRings);
+  LogTrace(metname) << "New MuRingForwardLayer with " << frontRings.size() << " and " << backRings.size()
+                    << " rings, at Z " << result->position().z() << " R1: " << result->specificSurface().innerRadius()
+                    << " R2: " << result->specificSurface().outerRadius();
   return result;
 }
 
-
-bool MuonCSCDetLayerGeometryBuilder::isFront(int station, int ring, int chamber)
-{
+bool MuonCSCDetLayerGeometryBuilder::isFront(int station, int ring, int chamber) {
   bool result = false;
-  
+
   bool isOverlapping = !(station == 1 && ring == 3);
   // not overlapping means back
-  if(isOverlapping)
-  {
-    bool isEven = (chamber%2==0);
+  if (isOverlapping) {
+    bool isEven = (chamber % 2 == 0);
     // odd chambers are bolted to the iron, which faces
     // forward in 1&2, backward in 3&4, so...
-    result = (station<3) ? isEven : !isEven;
+    result = (station < 3) ? isEven : !isEven;
   }
   return result;
 }
 
+MuDetRing* MuonCSCDetLayerGeometryBuilder::makeDetRing(vector<const GeomDet*>& geomDets) {
+  const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonCSCDetLayerGeometryBuilder";
 
-
-MuDetRing * MuonCSCDetLayerGeometryBuilder::makeDetRing(vector<const GeomDet*> & geomDets)
-{
-    const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonCSCDetLayerGeometryBuilder";
-
-
-    precomputed_value_sort(geomDets.begin(), geomDets.end(), geomsort::DetPhi());
-    MuDetRing * result = new MuDetRing(geomDets);
-    LogTrace(metname) << "New MuDetRing with " << geomDets.size()
-                        << " chambers at z="<< result->position().z()
-                        << " R1: " << result->specificSurface().innerRadius()
-                        << " R2: " << result->specificSurface().outerRadius();
-    return result;
+  precomputed_value_sort(geomDets.begin(), geomDets.end(), geomsort::DetPhi());
+  MuDetRing* result = new MuDetRing(geomDets);
+  LogTrace(metname) << "New MuDetRing with " << geomDets.size() << " chambers at z=" << result->position().z()
+                    << " R1: " << result->specificSurface().innerRadius()
+                    << " R2: " << result->specificSurface().outerRadius();
+  return result;
 }
-

--- a/RecoMuon/DetLayers/src/MuonCSCDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonCSCDetLayerGeometryBuilder.h
@@ -16,22 +16,18 @@ class MuRingForwardDoubleLayer;
 class MuDetRing;
 
 class MuonCSCDetLayerGeometryBuilder {
- public:
-
+public:
   /// return.first=forward (+Z), return.second=backward (-Z)
   /// both vectors are sorted inside-out
   static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildLayers(const CSCGeometry& geo);
- private:
+
+private:
   // Disable constructor - only static access is allowed.
-  MuonCSCDetLayerGeometryBuilder(){}
+  MuonCSCDetLayerGeometryBuilder() {}
 
-  static MuRingForwardDoubleLayer* buildLayer(int endcap,
-					int station,
-					std::vector<int>& rings,
-					const CSCGeometry& geo);
+  static MuRingForwardDoubleLayer* buildLayer(int endcap, int station, std::vector<int>& rings, const CSCGeometry& geo);
 
-  static MuDetRing * makeDetRing(std::vector<const GeomDet*> & geomDets);
+  static MuDetRing* makeDetRing(std::vector<const GeomDet*>& geomDets);
   static bool isFront(int station, int ring, int chamber);
 };
 #endif
-

--- a/RecoMuon/DetLayers/src/MuonDTDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonDTDetLayerGeometryBuilder.cc
@@ -14,36 +14,29 @@
 
 using namespace std;
 
-MuonDTDetLayerGeometryBuilder::MuonDTDetLayerGeometryBuilder() {
-}
+MuonDTDetLayerGeometryBuilder::MuonDTDetLayerGeometryBuilder() {}
 
-MuonDTDetLayerGeometryBuilder::~MuonDTDetLayerGeometryBuilder() {
-}
+MuonDTDetLayerGeometryBuilder::~MuonDTDetLayerGeometryBuilder() {}
 
-vector<DetLayer*> 
-MuonDTDetLayerGeometryBuilder::buildLayers(const DTGeometry& geo) {
-        
+vector<DetLayer*> MuonDTDetLayerGeometryBuilder::buildLayers(const DTGeometry& geo) {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonDTDetLayerGeometryBuilder";
 
   vector<DetLayer*> detlayers;
   vector<MuRodBarrelLayer*> result;
-            
-  for(int station = DTChamberId::minStationId; station <= DTChamberId::maxStationId; station++) {
-    
+
+  for (int station = DTChamberId::minStationId; station <= DTChamberId::maxStationId; station++) {
     vector<const DetRod*> muDetRods;
-    for(int sector = DTChamberId::minSectorId; sector <= DTChamberId::maxSectorId; sector++) {
-      
+    for (int sector = DTChamberId::minSectorId; sector <= DTChamberId::maxSectorId; sector++) {
       vector<const GeomDet*> geomDets;
-      for(int wheel = DTChamberId::minWheelId; wheel <= DTChamberId::maxWheelId; wheel++) {		  
+      for (int wheel = DTChamberId::minWheelId; wheel <= DTChamberId::maxWheelId; wheel++) {
         const GeomDet* geomDet = geo.idToDet(DTChamberId(wheel, station, sector));
         if (geomDet) {
           geomDets.push_back(geomDet);
-          LogTrace(metname) << "get DT chamber " <<  DTChamberId(wheel, station, sector)
-                            << " at R=" << geomDet->position().perp()
-                            << ", phi=" << geomDet->position().phi() ;
+          LogTrace(metname) << "get DT chamber " << DTChamberId(wheel, station, sector)
+                            << " at R=" << geomDet->position().perp() << ", phi=" << geomDet->position().phi();
         }
       }
-      
+
       if (!geomDets.empty()) {
         precomputed_value_sort(geomDets.begin(), geomDets.end(), geomsort::DetZ());
         muDetRods.push_back(new MuDetRod(geomDets));
@@ -52,14 +45,14 @@ MuonDTDetLayerGeometryBuilder::buildLayers(const DTGeometry& geo) {
                           << ", phi=" << muDetRods.back()->position().phi();
       }
     }
-    precomputed_value_sort(muDetRods.begin(), muDetRods.end(), geomsort::ExtractPhi<GeometricSearchDet,float>());
-    result.push_back(new MuRodBarrelLayer(muDetRods));  
-    LogDebug(metname) << "    New MuRodBarrelLayer with " << muDetRods.size()
-                      << " rods, at R " << result.back()->specificSurface().radius();
+    precomputed_value_sort(muDetRods.begin(), muDetRods.end(), geomsort::ExtractPhi<GeometricSearchDet, float>());
+    result.push_back(new MuRodBarrelLayer(muDetRods));
+    LogDebug(metname) << "    New MuRodBarrelLayer with " << muDetRods.size() << " rods, at R "
+                      << result.back()->specificSurface().radius();
   }
-  
-  for(vector<MuRodBarrelLayer*>::const_iterator it = result.begin(); it != result.end(); it++)
+
+  for (vector<MuRodBarrelLayer*>::const_iterator it = result.begin(); it != result.end(); it++)
     detlayers.push_back((DetLayer*)(*it));
-  
+
   return detlayers;
 }

--- a/RecoMuon/DetLayers/src/MuonDTDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonDTDetLayerGeometryBuilder.h
@@ -14,17 +14,16 @@
 class DetLayer;
 
 class MuonDTDetLayerGeometryBuilder {
-    public:
-        /// Constructor
-        MuonDTDetLayerGeometryBuilder();
+public:
+  /// Constructor
+  MuonDTDetLayerGeometryBuilder();
 
-        /// Destructor
-        virtual ~MuonDTDetLayerGeometryBuilder();
-  
-        /// Operations
-        static std::vector<DetLayer*> buildLayers(const DTGeometry& geo);
-    private:
-    
+  /// Destructor
+  virtual ~MuonDTDetLayerGeometryBuilder();
+
+  /// Operations
+  static std::vector<DetLayer*> buildLayers(const DTGeometry& geo);
+
+private:
 };
 #endif
-

--- a/RecoMuon/DetLayers/src/MuonDetLayerGeometry.cc
+++ b/RecoMuon/DetLayers/src/MuonDetLayerGeometry.cc
@@ -27,348 +27,231 @@ using namespace geomsort;
 
 MuonDetLayerGeometry::MuonDetLayerGeometry() {}
 
-MuonDetLayerGeometry::~MuonDetLayerGeometry(){
-  for(vector<const DetLayer*>::const_iterator it = allDetLayers.begin(); it != allDetLayers.end(); ++it)
-  {
+MuonDetLayerGeometry::~MuonDetLayerGeometry() {
+  for (vector<const DetLayer*>::const_iterator it = allDetLayers.begin(); it != allDetLayers.end(); ++it) {
     delete *it;
   }
 }
 
 void MuonDetLayerGeometry::addCSCLayers(const pair<vector<DetLayer*>, vector<DetLayer*> >& csclayers) {
-    
-  for(auto const it : csclayers.first) {
+  for (auto const it : csclayers.first) {
     cscLayers_fw.push_back(it);
     allForward.push_back(it);
-    
-    detLayersMap[ makeDetLayerId(it) ] = it;
+
+    detLayersMap[makeDetLayerId(it)] = it;
   }
 
-  for(auto const it: csclayers.second) {
+  for (auto const it : csclayers.second) {
     cscLayers_bk.push_back(it);
     allBackward.push_back(it);
-    
-    detLayersMap[ makeDetLayerId(it) ] = it;
-  }    
-}    
+
+    detLayersMap[makeDetLayerId(it)] = it;
+  }
+}
 
 void MuonDetLayerGeometry::addGEMLayers(const pair<vector<DetLayer*>, vector<DetLayer*> >& gemlayers) {
-  LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding GEMlayers "<<std::endl;
-  for(auto const it : gemlayers.first) {
+  LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding GEMlayers " << std::endl;
+  for (auto const it : gemlayers.first) {
     gemLayers_fw.push_back(it);
     allForward.push_back(it);
-    detLayersMap[ makeDetLayerId(it) ] = it;
-    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding GEMforward "<<std::endl;
+    detLayersMap[makeDetLayerId(it)] = it;
+    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding GEMforward " << std::endl;
   }
-  for(auto const it: gemlayers.second) {
+  for (auto const it : gemlayers.second) {
     gemLayers_bk.push_back(it);
     allBackward.push_back(it);
-    detLayersMap[ makeDetLayerId(it) ] = it;
-    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding GEMbackward "<<std::endl;
-    }
-}   
-
+    detLayersMap[makeDetLayerId(it)] = it;
+    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding GEMbackward " << std::endl;
+  }
+}
 
 void MuonDetLayerGeometry::addME0Layers(const pair<vector<DetLayer*>, vector<DetLayer*> >& me0layers) {
+  LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding ME0layers " << std::endl;
 
-  LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding ME0layers "<<std::endl;
-
-  for(auto const it : me0layers.first) {
+  for (auto const it : me0layers.first) {
     me0Layers_fw.push_back(it);
     allForward.push_back(it);
 
-    detLayersMap[ makeDetLayerId(it) ] = it;
-    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding ME0forward "<<std::endl;
+    detLayersMap[makeDetLayerId(it)] = it;
+    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding ME0forward " << std::endl;
   }
-  for(auto const it : me0layers.second) {
+  for (auto const it : me0layers.second) {
     me0Layers_bk.push_back(it);
     allBackward.push_back(it);
 
-    detLayersMap[ makeDetLayerId(it) ] = it;
-    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding ME0backward "<<std::endl;
+    detLayersMap[makeDetLayerId(it)] = it;
+    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << "Adding ME0backward " << std::endl;
   }
 }
 
-void MuonDetLayerGeometry::addRPCLayers(const vector<DetLayer*>& barrelLayers, const pair<vector<DetLayer*>, vector<DetLayer*> >& endcapLayers) {
-  
-  for(auto const it: barrelLayers) {
+void MuonDetLayerGeometry::addRPCLayers(const vector<DetLayer*>& barrelLayers,
+                                        const pair<vector<DetLayer*>, vector<DetLayer*> >& endcapLayers) {
+  for (auto const it : barrelLayers) {
     rpcLayers_barrel.push_back(it);
     allBarrel.push_back(it);
 
-    detLayersMap[ makeDetLayerId(it) ] = it;
+    detLayersMap[makeDetLayerId(it)] = it;
   }
-  for(auto const it: endcapLayers.first) {
+  for (auto const it : endcapLayers.first) {
     rpcLayers_fw.push_back(it);
     allForward.push_back(it);
 
-    detLayersMap[ makeDetLayerId(it) ] = it;
+    detLayersMap[makeDetLayerId(it)] = it;
   }
 
-  for(auto const it: endcapLayers.second) {
+  for (auto const it : endcapLayers.second) {
     rpcLayers_bk.push_back(it);
     allBackward.push_back(it);
 
-    detLayersMap[ makeDetLayerId(it) ] = it;
+    detLayersMap[makeDetLayerId(it)] = it;
   }
-  
-}    
+}
 
 void MuonDetLayerGeometry::addDTLayers(const vector<DetLayer*>& dtlayers) {
+  for (auto const it : dtlayers) {
+    dtLayers.push_back(it);
+    allBarrel.push_back(it);
 
-    for(auto const it : dtlayers) {
-        dtLayers.push_back(it);
-        allBarrel.push_back(it);
-
-	detLayersMap[ makeDetLayerId(it) ] = it;
-    }
-}    
-
-DetId MuonDetLayerGeometry::makeDetLayerId(const DetLayer* detLayer) const{
-
-  if(detLayer->subDetector() ==  GeomDetEnumerators::CSC){
-    CSCDetId id( detLayer->basicComponents().front()->geographicalId().rawId() ) ;
-
-    if(id.station() == 1 )
-      {
-	if(id.ring() == 1 || id.ring() == 4)
-	  return CSCDetId(id.endcap(),1,1,0,0);
-	else if(id.ring() == 2 || id.ring() == 3)
-	  return CSCDetId(id.endcap(),1,2,0,0);
-	else
-	  throw cms::Exception("InvalidCSCRing")<<" Invalid CSC Ring: "<<id.ring()<<endl;
-      }
-    else
-      return CSCDetId(id.endcap(),id.station(),0,0,0);
-    
+    detLayersMap[makeDetLayerId(it)] = it;
   }
-  else if(detLayer->subDetector() == GeomDetEnumerators::DT){
-    DTChamberId id( detLayer->basicComponents().front()->geographicalId().rawId() ) ;
-    return  DTChamberId(0,id.station(),0);
-  }
-  else if(detLayer->subDetector()== GeomDetEnumerators::RPCBarrel ||
-	  detLayer->subDetector()== GeomDetEnumerators::RPCEndcap){
-    RPCDetId id( detLayer->basicComponents().front()->geographicalId().rawId());
-    return RPCDetId(id.region(),0,id.station(),0,id.layer(),0,0);
-  }
-  else if( detLayer->subDetector()== GeomDetEnumerators::GEM){
-    GEMDetId id( detLayer->basicComponents().front()->geographicalId().rawId());
-    return GEMDetId(id.region(),1,id.station(),id.layer(),0,0);
-  }
-  else if( detLayer->subDetector()== GeomDetEnumerators::ME0){
-    ME0DetId id( detLayer->basicComponents().front()->geographicalId().rawId());
-    return ME0DetId(id.region(),id.layer(),0,0);
-  }
-  else throw cms::Exception("InvalidModuleIdentification"); // << detLayer->module();
 }
 
+DetId MuonDetLayerGeometry::makeDetLayerId(const DetLayer* detLayer) const {
+  if (detLayer->subDetector() == GeomDetEnumerators::CSC) {
+    CSCDetId id(detLayer->basicComponents().front()->geographicalId().rawId());
 
-const vector<const DetLayer*>& 
-MuonDetLayerGeometry::allDTLayers() const {    
-    return dtLayers; 
+    if (id.station() == 1) {
+      if (id.ring() == 1 || id.ring() == 4)
+        return CSCDetId(id.endcap(), 1, 1, 0, 0);
+      else if (id.ring() == 2 || id.ring() == 3)
+        return CSCDetId(id.endcap(), 1, 2, 0, 0);
+      else
+        throw cms::Exception("InvalidCSCRing") << " Invalid CSC Ring: " << id.ring() << endl;
+    } else
+      return CSCDetId(id.endcap(), id.station(), 0, 0, 0);
+
+  } else if (detLayer->subDetector() == GeomDetEnumerators::DT) {
+    DTChamberId id(detLayer->basicComponents().front()->geographicalId().rawId());
+    return DTChamberId(0, id.station(), 0);
+  } else if (detLayer->subDetector() == GeomDetEnumerators::RPCBarrel ||
+             detLayer->subDetector() == GeomDetEnumerators::RPCEndcap) {
+    RPCDetId id(detLayer->basicComponents().front()->geographicalId().rawId());
+    return RPCDetId(id.region(), 0, id.station(), 0, id.layer(), 0, 0);
+  } else if (detLayer->subDetector() == GeomDetEnumerators::GEM) {
+    GEMDetId id(detLayer->basicComponents().front()->geographicalId().rawId());
+    return GEMDetId(id.region(), 1, id.station(), id.layer(), 0, 0);
+  } else if (detLayer->subDetector() == GeomDetEnumerators::ME0) {
+    ME0DetId id(detLayer->basicComponents().front()->geographicalId().rawId());
+    return ME0DetId(id.region(), id.layer(), 0, 0);
+  } else
+    throw cms::Exception("InvalidModuleIdentification");  // << detLayer->module();
 }
 
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allCSCLayers() const {
-    return cscLayers_all;
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::allDTLayers() const { return dtLayers; }
 
+const vector<const DetLayer*>& MuonDetLayerGeometry::allCSCLayers() const { return cscLayers_all; }
 
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::forwardCSCLayers() const {
-    return cscLayers_fw;
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::forwardCSCLayers() const { return cscLayers_fw; }
 
-
-const vector<const DetLayer*>& 
-MuonDetLayerGeometry::backwardCSCLayers() const {
-    return cscLayers_bk;
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::backwardCSCLayers() const { return cscLayers_bk; }
 
 ////////////////////////////GEMs
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allGEMLayers() const {
-    return gemLayers_all;
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::allGEMLayers() const { return gemLayers_all; }
 
+const vector<const DetLayer*>& MuonDetLayerGeometry::forwardGEMLayers() const { return gemLayers_fw; }
 
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::forwardGEMLayers() const {
-    return gemLayers_fw;
-}
-
-
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::backwardGEMLayers() const {
-    return gemLayers_bk;
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::backwardGEMLayers() const { return gemLayers_bk; }
 
 //////////////////////////////////////////
 
-
 //////////////////// ME0s
 
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allME0Layers() const {
-    return me0Layers_all;
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::allME0Layers() const { return me0Layers_all; }
 
+const vector<const DetLayer*>& MuonDetLayerGeometry::forwardME0Layers() const { return me0Layers_fw; }
 
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::forwardME0Layers() const {
-    return me0Layers_fw;
-}
-
-
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::backwardME0Layers() const {
-    return me0Layers_bk;
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::backwardME0Layers() const { return me0Layers_bk; }
 
 ////////////////////
 
-const vector<const DetLayer*>& 
-MuonDetLayerGeometry::allRPCLayers() const {
-    return rpcLayers_all;    
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::allRPCLayers() const { return rpcLayers_all; }
 
+const vector<const DetLayer*>& MuonDetLayerGeometry::barrelRPCLayers() const { return rpcLayers_barrel; }
 
-const vector<const DetLayer*>& 
-MuonDetLayerGeometry::barrelRPCLayers() const {
-    return rpcLayers_barrel; 
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::endcapRPCLayers() const { return rpcLayers_endcap; }
 
+const vector<const DetLayer*>& MuonDetLayerGeometry::forwardRPCLayers() const { return rpcLayers_fw; }
 
-const vector<const DetLayer*>& 
-MuonDetLayerGeometry::endcapRPCLayers() const {
-    return rpcLayers_endcap;    
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::backwardRPCLayers() const { return rpcLayers_bk; }
 
+const vector<const DetLayer*>& MuonDetLayerGeometry::allLayers() const { return allDetLayers; }
 
-const vector<const DetLayer*>& 
-MuonDetLayerGeometry::forwardRPCLayers() const {
-     return rpcLayers_fw; 
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::allBarrelLayers() const { return allBarrel; }
 
+const vector<const DetLayer*>& MuonDetLayerGeometry::allEndcapLayers() const { return allEndcap; }
 
-const vector<const DetLayer*>& 
-MuonDetLayerGeometry::backwardRPCLayers() const {
-    return rpcLayers_bk; 
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::allForwardLayers() const { return allForward; }
 
-
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allLayers() const {
-    return allDetLayers;    
-}    
-
-
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allBarrelLayers() const {
-    return allBarrel;    
-}    
-
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allEndcapLayers() const {
-    return allEndcap;    
-}    
-
-
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allForwardLayers() const {
-    return allForward;    
-}    
-
-
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allBackwardLayers() const {
-    return allBackward;    
-}    
+const vector<const DetLayer*>& MuonDetLayerGeometry::allBackwardLayers() const { return allBackward; }
 
 //////////////////////////////GEMs
 //
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allEndcapCscGemLayers() const {
-    return allEndcapCscGem;
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::allEndcapCscGemLayers() const { return allEndcapCscGem; }
 
+const vector<const DetLayer*>& MuonDetLayerGeometry::allCscGemForwardLayers() const { return allCscGemForward; }
 
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allCscGemForwardLayers() const {
-    return allCscGemForward;
-}
-
-
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allCscGemBackwardLayers() const {
-    return allCscGemBackward;
-}
+const vector<const DetLayer*>& MuonDetLayerGeometry::allCscGemBackwardLayers() const { return allCscGemBackward; }
 
 //////////////////// ME0s
 
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allEndcapCscME0Layers() const {
-    return allEndcapCscME0;    
-}    
+const vector<const DetLayer*>& MuonDetLayerGeometry::allEndcapCscME0Layers() const { return allEndcapCscME0; }
 
+const vector<const DetLayer*>& MuonDetLayerGeometry::allCscME0ForwardLayers() const { return allCscME0Forward; }
 
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allCscME0ForwardLayers() const {
-    return allCscME0Forward;    
-}    
-
-
-const vector<const DetLayer*>&
-MuonDetLayerGeometry::allCscME0BackwardLayers() const {
-    return allCscME0Backward;    
-}    
-
+const vector<const DetLayer*>& MuonDetLayerGeometry::allCscME0BackwardLayers() const { return allCscME0Backward; }
 
 ////////////////////////////////////////////////////
 
-const DetLayer* MuonDetLayerGeometry::idToLayer(const DetId &detId) const{
-
+const DetLayer* MuonDetLayerGeometry::idToLayer(const DetId& detId) const {
   DetId id;
-  
-  if(detId.subdetId() == MuonSubdetId::CSC){
-    CSCDetId cscId( detId.rawId() );
 
-    if(cscId.station() == 1)
-      {
-	if(cscId.ring() == 1 || cscId.ring() == 4)
-	  id = CSCDetId(cscId.endcap(),1,1,0,0);
-	else if(cscId.ring() == 2 || cscId.ring() == 3)
-	  id = CSCDetId(cscId.endcap(),1,2,0,0);
-	else
-	  throw cms::Exception("InvalidCSCRing")<<" Invalid CSC Ring: "<<cscId.ring()<<endl;
-      }
-    else id = CSCDetId(cscId.endcap(),cscId.station(),0,0,0);
-  }
-  
-  else if (detId.subdetId() == MuonSubdetId::DT){
-    DTChamberId dtId( detId.rawId() );
-    id = DTChamberId(0,dtId.station(),0);
-  }
-  else if (detId.subdetId() == MuonSubdetId::RPC){
-    RPCDetId rpcId(detId.rawId() );
-    id = RPCDetId(rpcId.region(),0,rpcId.station(),0,rpcId.layer(),0,0);
-  }
-  else if (detId.subdetId() == MuonSubdetId::GEM){
-    GEMDetId gemId(detId.rawId() );
-    id = GEMDetId(gemId.region(),1,gemId.station(),gemId.layer(),0,0);
-  }
-  else if (detId.subdetId() == MuonSubdetId::ME0){
-    ME0DetId me0Id(detId.rawId() );
-    id = ME0DetId(me0Id.region(),me0Id.layer(),0,0);
-    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry") << " Found an ME0DetId:  " << me0Id.rawId()
-						   <<",id: "<< id.rawId()<<std::endl;
+  if (detId.subdetId() == MuonSubdetId::CSC) {
+    CSCDetId cscId(detId.rawId());
 
+    if (cscId.station() == 1) {
+      if (cscId.ring() == 1 || cscId.ring() == 4)
+        id = CSCDetId(cscId.endcap(), 1, 1, 0, 0);
+      else if (cscId.ring() == 2 || cscId.ring() == 3)
+        id = CSCDetId(cscId.endcap(), 1, 2, 0, 0);
+      else
+        throw cms::Exception("InvalidCSCRing") << " Invalid CSC Ring: " << cscId.ring() << endl;
+    } else
+      id = CSCDetId(cscId.endcap(), cscId.station(), 0, 0, 0);
   }
-  else throw cms::Exception("InvalidSubdetId")<< detId.subdetId();
 
-  std::map<DetId,const DetLayer*>::const_iterator layer = detLayersMap.find(id);
-  if (layer == detLayersMap.end()) return nullptr;
-  return layer->second; 
+  else if (detId.subdetId() == MuonSubdetId::DT) {
+    DTChamberId dtId(detId.rawId());
+    id = DTChamberId(0, dtId.station(), 0);
+  } else if (detId.subdetId() == MuonSubdetId::RPC) {
+    RPCDetId rpcId(detId.rawId());
+    id = RPCDetId(rpcId.region(), 0, rpcId.station(), 0, rpcId.layer(), 0, 0);
+  } else if (detId.subdetId() == MuonSubdetId::GEM) {
+    GEMDetId gemId(detId.rawId());
+    id = GEMDetId(gemId.region(), 1, gemId.station(), gemId.layer(), 0, 0);
+  } else if (detId.subdetId() == MuonSubdetId::ME0) {
+    ME0DetId me0Id(detId.rawId());
+    id = ME0DetId(me0Id.region(), me0Id.layer(), 0, 0);
+    LogDebug("Muon|RecoMuon|MuonDetLayerGeometry")
+        << " Found an ME0DetId:  " << me0Id.rawId() << ",id: " << id.rawId() << std::endl;
+
+  } else
+    throw cms::Exception("InvalidSubdetId") << detId.subdetId();
+
+  std::map<DetId, const DetLayer*>::const_iterator layer = detLayersMap.find(id);
+  if (layer == detLayersMap.end())
+    return nullptr;
+  return layer->second;
 }
-
 
 // Quick way to sort barrel det layers by increasing R,
 // do not abuse!
@@ -376,14 +259,15 @@ const DetLayer* MuonDetLayerGeometry::idToLayer(const DetId &detId) const{
 struct ExtractBarrelDetLayerR {
   typedef Surface::Scalar result_type;
   result_type operator()(const DetLayer* p) const {
-    const BarrelDetLayer * bdl = dynamic_cast<const BarrelDetLayer*>(p);
-    if (bdl) return bdl->specificSurface().radius();
-    else return -1.;
+    const BarrelDetLayer* bdl = dynamic_cast<const BarrelDetLayer*>(p);
+    if (bdl)
+      return bdl->specificSurface().radius();
+    else
+      return -1.;
   }
 };
 
 void MuonDetLayerGeometry::sortLayers() {
-
   // The following are filled inside-out, no need to re-sort
   // precomputed_value_sort(dtLayers.begin(), dtLayers.end(),ExtractR<DetLayer,float>());
   // precomputed_value_sort(cscLayers_fw.begin(), cscLayers_fw.end(),ExtractAbsZ<DetLayer,float>());
@@ -394,95 +278,93 @@ void MuonDetLayerGeometry::sortLayers() {
 
   // Sort these inside-out
   precomputed_value_sort(allBarrel.begin(), allBarrel.end(), ExtractBarrelDetLayerR());
-  precomputed_value_sort(allBackward.begin(), allBackward.end(), ExtractAbsZ<DetLayer,float>());
-  precomputed_value_sort(allForward.begin(), allForward.end(), ExtractAbsZ<DetLayer,float>());  
+  precomputed_value_sort(allBackward.begin(), allBackward.end(), ExtractAbsZ<DetLayer, float>());
+  precomputed_value_sort(allForward.begin(), allForward.end(), ExtractAbsZ<DetLayer, float>());
 
   // Build more complicated vectors with correct sorting
 
   //cscLayers_all: from -Z to +Z
-  cscLayers_all.reserve(cscLayers_bk.size()+cscLayers_fw.size());
-  std::copy(cscLayers_bk.begin(),cscLayers_bk.end(),back_inserter(cscLayers_all));
-  std::reverse(cscLayers_all.begin(),cscLayers_all.end());
-  std::copy(cscLayers_fw.begin(),cscLayers_fw.end(),back_inserter(cscLayers_all));
+  cscLayers_all.reserve(cscLayers_bk.size() + cscLayers_fw.size());
+  std::copy(cscLayers_bk.begin(), cscLayers_bk.end(), back_inserter(cscLayers_all));
+  std::reverse(cscLayers_all.begin(), cscLayers_all.end());
+  std::copy(cscLayers_fw.begin(), cscLayers_fw.end(), back_inserter(cscLayers_all));
 
   //gemLayers_all: from -Z to +Z
-  gemLayers_all.reserve(gemLayers_bk.size()+gemLayers_fw.size());
-  std::copy(gemLayers_bk.begin(),gemLayers_bk.end(),back_inserter(gemLayers_all));
-  std::reverse(gemLayers_all.begin(),gemLayers_all.end());
-  std::copy(gemLayers_fw.begin(),gemLayers_fw.end(),back_inserter(gemLayers_all));
+  gemLayers_all.reserve(gemLayers_bk.size() + gemLayers_fw.size());
+  std::copy(gemLayers_bk.begin(), gemLayers_bk.end(), back_inserter(gemLayers_all));
+  std::reverse(gemLayers_all.begin(), gemLayers_all.end());
+  std::copy(gemLayers_fw.begin(), gemLayers_fw.end(), back_inserter(gemLayers_all));
 
   //me0Layers_all: from -Z to +Z
-  me0Layers_all.reserve(me0Layers_bk.size()+me0Layers_fw.size());
-  std::copy(me0Layers_bk.begin(),me0Layers_bk.end(),back_inserter(me0Layers_all));
-  std::reverse(me0Layers_all.begin(),me0Layers_all.end());
-  std::copy(me0Layers_fw.begin(),me0Layers_fw.end(),back_inserter(me0Layers_all));
+  me0Layers_all.reserve(me0Layers_bk.size() + me0Layers_fw.size());
+  std::copy(me0Layers_bk.begin(), me0Layers_bk.end(), back_inserter(me0Layers_all));
+  std::reverse(me0Layers_all.begin(), me0Layers_all.end());
+  std::copy(me0Layers_fw.begin(), me0Layers_fw.end(), back_inserter(me0Layers_all));
 
   //rpcLayers_endcap: from -Z to +Z
-  rpcLayers_endcap.reserve(rpcLayers_bk.size()+rpcLayers_fw.size());
-  std::copy(rpcLayers_bk.begin(),rpcLayers_bk.end(),back_inserter(rpcLayers_endcap));
-  std::reverse(rpcLayers_endcap.begin(),rpcLayers_endcap.end());
-  std::copy(rpcLayers_fw.begin(),rpcLayers_fw.end(),back_inserter(rpcLayers_endcap));
+  rpcLayers_endcap.reserve(rpcLayers_bk.size() + rpcLayers_fw.size());
+  std::copy(rpcLayers_bk.begin(), rpcLayers_bk.end(), back_inserter(rpcLayers_endcap));
+  std::reverse(rpcLayers_endcap.begin(), rpcLayers_endcap.end());
+  std::copy(rpcLayers_fw.begin(), rpcLayers_fw.end(), back_inserter(rpcLayers_endcap));
 
   //rpcLayers_all: order is bw, barrel, fw
-  rpcLayers_all.reserve(rpcLayers_bk.size()+rpcLayers_barrel.size()+rpcLayers_fw.size());
-  std::copy(rpcLayers_bk.begin(),rpcLayers_bk.end(),back_inserter(rpcLayers_all));
-  std::reverse(rpcLayers_all.begin(),rpcLayers_all.end());
-  std::copy(rpcLayers_barrel.begin(),rpcLayers_barrel.end(),back_inserter(rpcLayers_all));
-  std::copy(rpcLayers_fw.begin(),rpcLayers_fw.end(),back_inserter(rpcLayers_all));
+  rpcLayers_all.reserve(rpcLayers_bk.size() + rpcLayers_barrel.size() + rpcLayers_fw.size());
+  std::copy(rpcLayers_bk.begin(), rpcLayers_bk.end(), back_inserter(rpcLayers_all));
+  std::reverse(rpcLayers_all.begin(), rpcLayers_all.end());
+  std::copy(rpcLayers_barrel.begin(), rpcLayers_barrel.end(), back_inserter(rpcLayers_all));
+  std::copy(rpcLayers_fw.begin(), rpcLayers_fw.end(), back_inserter(rpcLayers_all));
 
   // allEndcap: order is  all bw, all fw
-  allEndcap.reserve(allBackward.size()+allForward.size());
-  std::copy(allBackward.begin(),allBackward.end(),back_inserter(allEndcap));
-  std::reverse(allEndcap.begin(),allEndcap.end());
-  std::copy(allForward.begin(),allForward.end(),back_inserter(allEndcap));
+  allEndcap.reserve(allBackward.size() + allForward.size());
+  std::copy(allBackward.begin(), allBackward.end(), back_inserter(allEndcap));
+  std::reverse(allEndcap.begin(), allEndcap.end());
+  std::copy(allForward.begin(), allForward.end(), back_inserter(allEndcap));
 
   // allEndcapCSCGEM: order is  all bw, all fw
-  allEndcapCscGem.reserve(cscLayers_bk.size()+cscLayers_fw.size()+gemLayers_bk.size()+gemLayers_fw.size());
-  std::copy(cscLayers_bk.begin(),cscLayers_bk.end(),back_inserter(allEndcapCscGem));
-  std::copy(gemLayers_bk.begin(),gemLayers_bk.end(),back_inserter(allEndcapCscGem));
-  std::reverse(allEndcapCscGem.begin(),allEndcapCscGem.end());
-  std::copy(cscLayers_fw.begin(),cscLayers_fw.end(),back_inserter(allEndcapCscGem));
-  std::copy(gemLayers_fw.begin(),gemLayers_fw.end(),back_inserter(allEndcapCscGem));
+  allEndcapCscGem.reserve(cscLayers_bk.size() + cscLayers_fw.size() + gemLayers_bk.size() + gemLayers_fw.size());
+  std::copy(cscLayers_bk.begin(), cscLayers_bk.end(), back_inserter(allEndcapCscGem));
+  std::copy(gemLayers_bk.begin(), gemLayers_bk.end(), back_inserter(allEndcapCscGem));
+  std::reverse(allEndcapCscGem.begin(), allEndcapCscGem.end());
+  std::copy(cscLayers_fw.begin(), cscLayers_fw.end(), back_inserter(allEndcapCscGem));
+  std::copy(gemLayers_fw.begin(), gemLayers_fw.end(), back_inserter(allEndcapCscGem));
 
   // allCscGemForward
-  allCscGemForward.reserve(cscLayers_fw.size()+gemLayers_fw.size());
-  std::copy(cscLayers_fw.begin(),cscLayers_fw.end(),back_inserter(allCscGemForward));
-  std::copy(gemLayers_fw.begin(),gemLayers_fw.end(),back_inserter(allCscGemForward));
+  allCscGemForward.reserve(cscLayers_fw.size() + gemLayers_fw.size());
+  std::copy(cscLayers_fw.begin(), cscLayers_fw.end(), back_inserter(allCscGemForward));
+  std::copy(gemLayers_fw.begin(), gemLayers_fw.end(), back_inserter(allCscGemForward));
 
   // allCscGemBackward
-  allCscGemBackward.reserve(cscLayers_bk.size()+gemLayers_bk.size());
-  std::copy(cscLayers_bk.begin(),cscLayers_bk.end(),back_inserter(allCscGemBackward));
-  std::copy(gemLayers_bk.begin(),gemLayers_bk.end(),back_inserter(allCscGemBackward));
+  allCscGemBackward.reserve(cscLayers_bk.size() + gemLayers_bk.size());
+  std::copy(cscLayers_bk.begin(), cscLayers_bk.end(), back_inserter(allCscGemBackward));
+  std::copy(gemLayers_bk.begin(), gemLayers_bk.end(), back_inserter(allCscGemBackward));
 
   // allCscME0Forward
-  allCscME0Forward.reserve(cscLayers_fw.size()+me0Layers_fw.size());
-  std::copy(cscLayers_fw.begin(),cscLayers_fw.end(),back_inserter(allCscME0Forward));
-  std::copy(me0Layers_fw.begin(),me0Layers_fw.end(),back_inserter(allCscME0Forward));
+  allCscME0Forward.reserve(cscLayers_fw.size() + me0Layers_fw.size());
+  std::copy(cscLayers_fw.begin(), cscLayers_fw.end(), back_inserter(allCscME0Forward));
+  std::copy(me0Layers_fw.begin(), me0Layers_fw.end(), back_inserter(allCscME0Forward));
 
   // allCscME0Backward
-  allCscME0Backward.reserve(cscLayers_bk.size()+me0Layers_bk.size());
-  std::copy(cscLayers_bk.begin(),cscLayers_bk.end(),back_inserter(allCscME0Backward));
-  std::copy(me0Layers_bk.begin(),me0Layers_bk.end(),back_inserter(allCscME0Backward));
+  allCscME0Backward.reserve(cscLayers_bk.size() + me0Layers_bk.size());
+  std::copy(cscLayers_bk.begin(), cscLayers_bk.end(), back_inserter(allCscME0Backward));
+  std::copy(me0Layers_bk.begin(), me0Layers_bk.end(), back_inserter(allCscME0Backward));
 
   // allEndcapCSCME0: order is  all bw, all fw
-  allEndcapCscME0.reserve(cscLayers_bk.size()+cscLayers_fw.size()+me0Layers_bk.size()+me0Layers_fw.size());
-  std::copy(cscLayers_bk.begin(),cscLayers_bk.end(),back_inserter(allEndcapCscME0));
-  std::copy(me0Layers_bk.begin(),me0Layers_bk.end(),back_inserter(allEndcapCscME0));
-  std::reverse(allEndcapCscME0.begin(),allEndcapCscME0.end());
-  std::copy(cscLayers_fw.begin(),cscLayers_fw.end(),back_inserter(allEndcapCscME0));
-  std::copy(me0Layers_fw.begin(),me0Layers_fw.end(),back_inserter(allEndcapCscME0));
+  allEndcapCscME0.reserve(cscLayers_bk.size() + cscLayers_fw.size() + me0Layers_bk.size() + me0Layers_fw.size());
+  std::copy(cscLayers_bk.begin(), cscLayers_bk.end(), back_inserter(allEndcapCscME0));
+  std::copy(me0Layers_bk.begin(), me0Layers_bk.end(), back_inserter(allEndcapCscME0));
+  std::reverse(allEndcapCscME0.begin(), allEndcapCscME0.end());
+  std::copy(cscLayers_fw.begin(), cscLayers_fw.end(), back_inserter(allEndcapCscME0));
+  std::copy(me0Layers_fw.begin(), me0Layers_fw.end(), back_inserter(allEndcapCscME0));
 
   // allDetLayers: order is  all bw, all barrel, all fw
-  allDetLayers.reserve(allBackward.size()+allBarrel.size()+allForward.size());
-  std::copy(allBackward.begin(),allBackward.end(),back_inserter(allDetLayers));
-  std::reverse(allDetLayers.begin(),allDetLayers.end());
-  std::copy(allBarrel.begin(),allBarrel.end(),back_inserter(allDetLayers));
-  std::copy(allForward.begin(),allForward.end(),back_inserter(allDetLayers));
+  allDetLayers.reserve(allBackward.size() + allBarrel.size() + allForward.size());
+  std::copy(allBackward.begin(), allBackward.end(), back_inserter(allDetLayers));
+  std::reverse(allDetLayers.begin(), allDetLayers.end());
+  std::copy(allBarrel.begin(), allBarrel.end(), back_inserter(allDetLayers));
+  std::copy(allForward.begin(), allForward.end(), back_inserter(allDetLayers));
 
   // number layers
-  int sq=0;
-  for (auto l : allDetLayers) 
+  int sq = 0;
+  for (auto l : allDetLayers)
     (*const_cast<DetLayer*>(l)).setSeqNum(sq++);
-
-
 }

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
@@ -17,136 +17,117 @@
 
 using namespace std;
 
-MuonGEMDetLayerGeometryBuilder::~MuonGEMDetLayerGeometryBuilder() {
-}
+MuonGEMDetLayerGeometryBuilder::~MuonGEMDetLayerGeometryBuilder() {}
 
 // Builds the forward (first) and backward (second) layers
 // Builds etaPartitions (for rechits)
-pair<vector<DetLayer*>, vector<DetLayer*> > 
-MuonGEMDetLayerGeometryBuilder::buildEndcapLayers(const GEMGeometry& geo) {
-  
+pair<vector<DetLayer*>, vector<DetLayer*> > MuonGEMDetLayerGeometryBuilder::buildEndcapLayers(const GEMGeometry& geo) {
   vector<DetLayer*> result[2];
-	
-  for (int endcap = -1; endcap<=1; endcap+=2) {
-    int iendcap = (endcap==1) ? 0 : 1; // +1: forward, -1: backward
-      
-    for(int station = GEMDetId::minStationId; station <= GEMDetId::maxStationId; ++station) {      
-      for(int layer = GEMDetId::minLayerId+1; layer <= GEMDetId::maxLayerId; ++layer) { 
 
-	vector<int> rolls, rings, chambers; 
-	for(int ring = GEMDetId::minRingId; ring <= GEMDetId::maxRingId; ++ring) rings.push_back(ring);
-	for(int chamber = GEMDetId::minChamberId+1; chamber <= GEMDetId::maxChamberId; chamber++ )
-	  chambers.push_back(chamber);
-	for(int roll = GEMDetId::minRollId+1; roll <= GEMDetId::maxRollId; ++roll)
-	  rolls.push_back(roll);
-	
-	MuRingForwardDoubleLayer* ringLayer = buildLayer(endcap, rings, station, layer, chambers, rolls, geo);          
+  for (int endcap = -1; endcap <= 1; endcap += 2) {
+    int iendcap = (endcap == 1) ? 0 : 1;  // +1: forward, -1: backward
 
-	if (ringLayer) result[iendcap].push_back(ringLayer);
+    for (int station = GEMDetId::minStationId; station <= GEMDetId::maxStationId; ++station) {
+      for (int layer = GEMDetId::minLayerId + 1; layer <= GEMDetId::maxLayerId; ++layer) {
+        vector<int> rolls, rings, chambers;
+        for (int ring = GEMDetId::minRingId; ring <= GEMDetId::maxRingId; ++ring)
+          rings.push_back(ring);
+        for (int chamber = GEMDetId::minChamberId + 1; chamber <= GEMDetId::maxChamberId; chamber++)
+          chambers.push_back(chamber);
+        for (int roll = GEMDetId::minRollId + 1; roll <= GEMDetId::maxRollId; ++roll)
+          rolls.push_back(roll);
+
+        MuRingForwardDoubleLayer* ringLayer = buildLayer(endcap, rings, station, layer, chambers, rolls, geo);
+
+        if (ringLayer)
+          result[iendcap].push_back(ringLayer);
       }
     }
   }
-  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]); 
+  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]);
 
   return res_pair;
 }
 
-MuRingForwardDoubleLayer* 
-MuonGEMDetLayerGeometryBuilder::buildLayer(int endcap,vector<int>& rings, int station,
-					   int layer,
-					   vector<int>& chambers,
-					   vector<int>& rolls,
-					   const GEMGeometry& geo) {
-
+MuRingForwardDoubleLayer* MuonGEMDetLayerGeometryBuilder::buildLayer(int endcap,
+                                                                     vector<int>& rings,
+                                                                     int station,
+                                                                     int layer,
+                                                                     vector<int>& chambers,
+                                                                     vector<int>& rolls,
+                                                                     const GEMGeometry& geo) {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonGEMDetLayerGeometryBuilder";
-  MuRingForwardDoubleLayer * result = nullptr;
+  MuRingForwardDoubleLayer* result = nullptr;
   vector<const ForwardDetRing*> frontRings, backRings;
 
-
-  for (std::vector<int>::iterator ring=rings.begin(); ring!=rings.end()-2;ring++){ 
-
-    for (vector<int>::iterator roll = rolls.begin(); roll!=rolls.end(); roll++) {    
-
+  for (std::vector<int>::iterator ring = rings.begin(); ring != rings.end() - 2; ring++) {
+    for (vector<int>::iterator roll = rolls.begin(); roll != rolls.end(); roll++) {
       vector<const GeomDet*> frontDets, backDets;
-      
-      for(std::vector<int>::iterator chamber=chambers.begin(); chamber<chambers.end(); chamber++) {
-          GEMDetId gemId(endcap,(*ring), station,layer,(*chamber), (*roll));
 
- 	  const GeomDet* geomDet = geo.idToDet(gemId);
-	  
-	  if (geomDet !=nullptr) {
-	    bool isInFront = isFront(gemId);
-	    if(isInFront)
-            {
-              frontDets.push_back(geomDet);
-            }
-            else 
-            {
-              backDets.push_back(geomDet);
-            }
-	    LogTrace(metname) << "get GEM Endcap roll "
-			      << gemId
-                              << (isInFront ? "front" : "back ")
-			      << " at R=" << geomDet->position().perp()
-			      << ", phi=" << geomDet->position().phi()
-                              << ", Z=" << geomDet->position().z();
-	  }
+      for (std::vector<int>::iterator chamber = chambers.begin(); chamber < chambers.end(); chamber++) {
+        GEMDetId gemId(endcap, (*ring), station, layer, (*chamber), (*roll));
+
+        const GeomDet* geomDet = geo.idToDet(gemId);
+
+        if (geomDet != nullptr) {
+          bool isInFront = isFront(gemId);
+          if (isInFront) {
+            frontDets.push_back(geomDet);
+          } else {
+            backDets.push_back(geomDet);
+          }
+          LogTrace(metname) << "get GEM Endcap roll " << gemId << (isInFront ? "front" : "back ")
+                            << " at R=" << geomDet->position().perp() << ", phi=" << geomDet->position().phi()
+                            << ", Z=" << geomDet->position().z();
+        }
       }
 
       if (!frontDets.empty()) {
-	precomputed_value_sort(frontDets.begin(), frontDets.end(), geomsort::DetPhi());
-	frontRings.push_back(new MuDetRing(frontDets));
-	LogTrace(metname) << "New front ring with " << frontDets.size()
-			  << " chambers at z="<< frontRings.back()->position().z();
+        precomputed_value_sort(frontDets.begin(), frontDets.end(), geomsort::DetPhi());
+        frontRings.push_back(new MuDetRing(frontDets));
+        LogTrace(metname) << "New front ring with " << frontDets.size()
+                          << " chambers at z=" << frontRings.back()->position().z();
       }
       if (!backDets.empty()) {
         precomputed_value_sort(backDets.begin(), backDets.end(), geomsort::DetPhi());
         backRings.push_back(new MuDetRing(backDets));
         LogTrace(metname) << "New back ring with " << backDets.size()
-                          << " chambers at z="<< backRings.back()->position().z();
+                          << " chambers at z=" << backRings.back()->position().z();
       }
-
     }
-
   }
 
   // How should they be sorted?
-  //    precomputed_value_sort(muDetRods.begin(), muDetRods.end(), geomsort::ExtractZ<GeometricSearchDet,float>());                                   
-  if(!backRings.empty() && !frontRings.empty()) result = new MuRingForwardDoubleLayer(frontRings, backRings);
-    else result = nullptr;
-  if(result != nullptr){
-    LogTrace(metname) << "New MuRingForwardLayer with " << frontRings.size()
-		      << " and " << backRings.size()
-		      << " rings, at Z " << result->position().z()
-		      << " R1: " << result->specificSurface().innerRadius()
-		      << " R2: " << result->specificSurface().outerRadius();
+  //    precomputed_value_sort(muDetRods.begin(), muDetRods.end(), geomsort::ExtractZ<GeometricSearchDet,float>());
+  if (!backRings.empty() && !frontRings.empty())
+    result = new MuRingForwardDoubleLayer(frontRings, backRings);
+  else
+    result = nullptr;
+  if (result != nullptr) {
+    LogTrace(metname) << "New MuRingForwardLayer with " << frontRings.size() << " and " << backRings.size()
+                      << " rings, at Z " << result->position().z() << " R1: " << result->specificSurface().innerRadius()
+                      << " R2: " << result->specificSurface().outerRadius();
   }
   return result;
-
 }
 
-
-bool MuonGEMDetLayerGeometryBuilder::isFront(const GEMDetId & gemId)
-{
-
+bool MuonGEMDetLayerGeometryBuilder::isFront(const GEMDetId& gemId) {
   bool result = false;
   int chamber = gemId.chamber();
 
-    if(chamber%2 == 0) result = !result;
+  if (chamber % 2 == 0)
+    result = !result;
 
-    return result;
+  return result;
 }
 
-MuDetRing * MuonGEMDetLayerGeometryBuilder::makeDetRing(vector<const GeomDet*> & geomDets)
-{
-    const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonGEMDetLayerGeometryBuilder";
+MuDetRing* MuonGEMDetLayerGeometryBuilder::makeDetRing(vector<const GeomDet*>& geomDets) {
+  const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonGEMDetLayerGeometryBuilder";
 
-
-    precomputed_value_sort(geomDets.begin(), geomDets.end(), geomsort::DetPhi());
-    MuDetRing * result = new MuDetRing(geomDets);
-    LogTrace(metname) << "New MuDetRing with " << geomDets.size()
-                        << " chambers at z="<< result->position().z()
-                        << " R1: " << result->specificSurface().innerRadius()
-                        << " R2: " << result->specificSurface().outerRadius();
-    return result;
+  precomputed_value_sort(geomDets.begin(), geomDets.end(), geomsort::DetPhi());
+  MuDetRing* result = new MuDetRing(geomDets);
+  LogTrace(metname) << "New MuDetRing with " << geomDets.size() << " chambers at z=" << result->position().z()
+                    << " R1: " << result->specificSurface().innerRadius()
+                    << " R2: " << result->specificSurface().outerRadius();
+  return result;
 }

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
@@ -12,28 +12,31 @@ class DetLayer;
 class MuRingForwardDoubleLayer;
 class MuDetRing;
 
-
 #include <Geometry/GEMGeometry/interface/GEMGeometry.h>
 #include "RecoMuon/DetLayers/interface/MuDetRod.h"
 #include <vector>
 
 class MuonGEMDetLayerGeometryBuilder {
- public:
+public:
   /// Constructor (disabled, only static access is allowed)
-  MuonGEMDetLayerGeometryBuilder(){}
+  MuonGEMDetLayerGeometryBuilder() {}
 
   /// Destructor
   virtual ~MuonGEMDetLayerGeometryBuilder();
-  
+
   /// Builds the forward (+Z, return.first) and backward (-Z, return.second) layers.
   /// Both vectors are sorted inside-out
   static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildEndcapLayers(const GEMGeometry& geo);
-    
- private:
-  static MuRingForwardDoubleLayer* buildLayer(int endcap,std::vector<int>& rings, int station,int layer,std::vector<int>& chambers,std::vector<int>& rolls,const GEMGeometry& geo);          
-  static bool isFront(const GEMDetId & gemId);
-  static MuDetRing * makeDetRing(std::vector<const GeomDet*> & geomDets);
-  
+
+private:
+  static MuRingForwardDoubleLayer* buildLayer(int endcap,
+                                              std::vector<int>& rings,
+                                              int station,
+                                              int layer,
+                                              std::vector<int>& chambers,
+                                              std::vector<int>& rolls,
+                                              const GEMGeometry& geo);
+  static bool isFront(const GEMDetId& gemId);
+  static MuDetRing* makeDetRing(std::vector<const GeomDet*>& geomDets);
 };
 #endif
-

--- a/RecoMuon/DetLayers/src/MuonME0DetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonME0DetLayerGeometryBuilder.cc
@@ -18,70 +18,57 @@
 
 using namespace std;
 
-MuonME0DetLayerGeometryBuilder::~MuonME0DetLayerGeometryBuilder() {
-}
+MuonME0DetLayerGeometryBuilder::~MuonME0DetLayerGeometryBuilder() {}
 
 // Builds the forward (first) and backward (second) layers - NOTE: Currently just one layer, all 'front'
 // Builds chambers (for segments) only, me0RecHits not used in track finding
-pair<vector<DetLayer*>, vector<DetLayer*> > 
-MuonME0DetLayerGeometryBuilder::buildEndcapLayers(const ME0Geometry& geo) {
-  
+pair<vector<DetLayer*>, vector<DetLayer*> > MuonME0DetLayerGeometryBuilder::buildEndcapLayers(const ME0Geometry& geo) {
   vector<DetLayer*> result[2];
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonME0DetLayerGeometryBuilder";
   LogTrace(metname) << "Starting endcaplayers ";
-  for (int endcap = -1; endcap<=1; endcap+=2) {
-    int iendcap = (endcap==1) ? 0 : 1; // +1: forward, -1: backward
-    int layer = 0;// only need to make layer 0 for segments
-    vector<int> rolls, chambers;      
+  for (int endcap = -1; endcap <= 1; endcap += 2) {
+    int iendcap = (endcap == 1) ? 0 : 1;  // +1: forward, -1: backward
+    int layer = 0;                        // only need to make layer 0 for segments
+    vector<int> rolls, chambers;
     rolls.push_back(0);
-    for(int chamber = ME0DetId::minChamberId+1; chamber <= ME0DetId::maxChamberId; chamber++ )
+    for (int chamber = ME0DetId::minChamberId + 1; chamber <= ME0DetId::maxChamberId; chamber++)
       chambers.push_back(chamber);
-    
-    LogTrace(metname) << "Encap =  " << endcap
-		      << "Chambers =  " << chambers.size()
-		      << "Rolls =  " << rolls.size();
-    MuRingForwardLayer* ringLayer = buildLayer(endcap, layer, chambers, rolls, geo);          
 
-    if (ringLayer) result[iendcap].push_back(ringLayer);
+    LogTrace(metname) << "Encap =  " << endcap << "Chambers =  " << chambers.size() << "Rolls =  " << rolls.size();
+    MuRingForwardLayer* ringLayer = buildLayer(endcap, layer, chambers, rolls, geo);
+
+    if (ringLayer)
+      result[iendcap].push_back(ringLayer);
   }
-  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]); 
+  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]);
 
   return res_pair;
-
 }
 
-MuRingForwardLayer* 
-MuonME0DetLayerGeometryBuilder::buildLayer(int endcap,
-					   int layer,
-					   vector<int>& chambers,
-					   vector<int>& rolls,
-					   const ME0Geometry& geo) {
-
+MuRingForwardLayer* MuonME0DetLayerGeometryBuilder::buildLayer(
+    int endcap, int layer, vector<int>& chambers, vector<int>& rolls, const ME0Geometry& geo) {
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonME0DetLayerGeometryBuilder";
-  MuRingForwardLayer * result = nullptr;
+  MuRingForwardLayer* result = nullptr;
   vector<const ForwardDetRing*> frontRings, backRings;
 
   LogTrace(metname) << "Starting to Build Layer ";
-  
-  for (vector<int>::iterator roll = rolls.begin(); roll!=rolls.end(); roll++) {    
+
+  for (vector<int>::iterator roll = rolls.begin(); roll != rolls.end(); roll++) {
     LogTrace(metname) << "On a roll ";
-    
+
     vector<const GeomDet*> frontDets, backDets;
-      
-    for(std::vector<int>::iterator chamber=chambers.begin(); chamber<chambers.end(); chamber++) {
-      ME0DetId me0Id(endcap,layer,(*chamber), (*roll));
+
+    for (std::vector<int>::iterator chamber = chambers.begin(); chamber < chambers.end(); chamber++) {
+      ME0DetId me0Id(endcap, layer, (*chamber), (*roll));
       const GeomDet* geomDet = geo.idToDet(me0Id);
-	  
-      if (geomDet !=nullptr) {
-	bool isInFront = isFront(me0Id);
-	if(isInFront)
-	  {
-	    frontDets.push_back(geomDet);
-	  }
-	else 
-	  {
-	    backDets.push_back(geomDet);
-	  }
+
+      if (geomDet != nullptr) {
+        bool isInFront = isFront(me0Id);
+        if (isInFront) {
+          frontDets.push_back(geomDet);
+        } else {
+          backDets.push_back(geomDet);
+        }
       }
     }
 
@@ -89,51 +76,43 @@ MuonME0DetLayerGeometryBuilder::buildLayer(int endcap,
       precomputed_value_sort(frontDets.begin(), frontDets.end(), geomsort::DetPhi());
       frontRings.push_back(new MuDetRing(frontDets));
       LogTrace(metname) << "New front ring with " << frontDets.size()
-			<< " chambers at z="<< frontRings.back()->position().z();
+                        << " chambers at z=" << frontRings.back()->position().z();
     }
     if (!backDets.empty()) {
       precomputed_value_sort(backDets.begin(), backDets.end(), geomsort::DetPhi());
       backRings.push_back(new MuDetRing(backDets));
       LogTrace(metname) << "New back ring with " << backDets.size()
-			<< " chambers at z="<< backRings.back()->position().z();
+                        << " chambers at z=" << backRings.back()->position().z();
     }
-
   }
-  
+
   LogTrace(metname) << "About to make a MuRingForwardLayer";
-  if(!frontRings.empty()) result = new MuRingForwardLayer(frontRings);
-  else result = nullptr;
-  if(result != nullptr){
-    LogTrace(metname) << "New MuRingForwardLayer with " << frontRings.size()
-	 << " and " << backRings.size()
-	 << " rings, at Z " << result->position().z()
-	 << " R1: " << result->specificSurface().innerRadius()
-	 << " R2: " << result->specificSurface().outerRadius();
+  if (!frontRings.empty())
+    result = new MuRingForwardLayer(frontRings);
+  else
+    result = nullptr;
+  if (result != nullptr) {
+    LogTrace(metname) << "New MuRingForwardLayer with " << frontRings.size() << " and " << backRings.size()
+                      << " rings, at Z " << result->position().z() << " R1: " << result->specificSurface().innerRadius()
+                      << " R2: " << result->specificSurface().outerRadius();
   }
   return result;
-
 }
 
-
-bool MuonME0DetLayerGeometryBuilder::isFront(const ME0DetId & me0Id)
-{
-
+bool MuonME0DetLayerGeometryBuilder::isFront(const ME0DetId& me0Id) {
   //ME0s do not currently have an arrangement of which are front and which are back, going to always return true
 
   bool result = true;
   return result;
 }
 
-MuDetRing * MuonME0DetLayerGeometryBuilder::makeDetRing(vector<const GeomDet*> & geomDets)
-{
-    const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonME0DetLayerGeometryBuilder";
+MuDetRing* MuonME0DetLayerGeometryBuilder::makeDetRing(vector<const GeomDet*>& geomDets) {
+  const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonME0DetLayerGeometryBuilder";
 
-
-    precomputed_value_sort(geomDets.begin(), geomDets.end(), geomsort::DetPhi());
-    MuDetRing * result = new MuDetRing(geomDets);
-    LogTrace(metname) << "New MuDetRing with " << geomDets.size()
-                        << " chambers at z="<< result->position().z()
-                        << " R1: " << result->specificSurface().innerRadius()
-                        << " R2: " << result->specificSurface().outerRadius();
-    return result;
+  precomputed_value_sort(geomDets.begin(), geomDets.end(), geomsort::DetPhi());
+  MuDetRing* result = new MuDetRing(geomDets);
+  LogTrace(metname) << "New MuDetRing with " << geomDets.size() << " chambers at z=" << result->position().z()
+                    << " R1: " << result->specificSurface().innerRadius()
+                    << " R2: " << result->specificSurface().outerRadius();
+  return result;
 }

--- a/RecoMuon/DetLayers/src/MuonME0DetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonME0DetLayerGeometryBuilder.h
@@ -14,30 +14,28 @@ class MuRingForwardLayer;
 //class MuRodBarrelLayer;
 class MuDetRing;
 
-
 #include <Geometry/GEMGeometry/interface/ME0Geometry.h>
 #include "RecoMuon/DetLayers/interface/MuDetRod.h"
 #include <vector>
 
 class MuonME0DetLayerGeometryBuilder {
- public:
+public:
   /// Constructor (disabled, only static access is allowed)
-  MuonME0DetLayerGeometryBuilder(){}
+  MuonME0DetLayerGeometryBuilder() {}
 
   /// Destructor
   virtual ~MuonME0DetLayerGeometryBuilder();
-  
+
   /// Builds the forward (+Z, return.first) and backward (-Z, return.second) layers.
   /// Both vectors are sorted inside-out
   static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildEndcapLayers(const ME0Geometry& geo);
-    
- private:
-  //static MuRingForwardDoubleLayer* buildLayer(int endcap,int layer,std::vector<int>& chambers,std::vector<int>& rolls,const ME0Geometry& geo);          
-  //static MuRingForwardLayer* buildLayer(int endcap,int layer,std::vector<int>& chambers,std::vector<int>& rolls,const ME0Geometry& geo);          
-  static MuRingForwardLayer* buildLayer(int endcap, int layer, std::vector<int>& chambers,std::vector<int>& rolls,const ME0Geometry& geo);          
-  static bool isFront(const ME0DetId & me0Id);
-  static MuDetRing * makeDetRing(std::vector<const GeomDet*> & geomDets);
-  
+
+private:
+  //static MuRingForwardDoubleLayer* buildLayer(int endcap,int layer,std::vector<int>& chambers,std::vector<int>& rolls,const ME0Geometry& geo);
+  //static MuRingForwardLayer* buildLayer(int endcap,int layer,std::vector<int>& chambers,std::vector<int>& rolls,const ME0Geometry& geo);
+  static MuRingForwardLayer* buildLayer(
+      int endcap, int layer, std::vector<int>& chambers, std::vector<int>& rolls, const ME0Geometry& geo);
+  static bool isFront(const ME0DetId& me0Id);
+  static MuDetRing* makeDetRing(std::vector<const GeomDet*>& geomDets);
 };
 #endif
-

--- a/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
@@ -21,225 +21,189 @@ namespace rpcdetlayergeomsort {
   template <class T, class Scalar = typename T::Scalar>
   struct ExtractInnerRadius {
     typedef Scalar result_type;
-    Scalar operator()(const T* p) const {return fabs(p->specificSurface().innerRadius());}
-    Scalar operator()(const T& p) const {return fabs(p.specificSurface().innerRadius());}
+    Scalar operator()(const T* p) const { return fabs(p->specificSurface().innerRadius()); }
+    Scalar operator()(const T& p) const { return fabs(p.specificSurface().innerRadius()); }
   };
-}
+}  // namespace rpcdetlayergeomsort
 
-
-MuonRPCDetLayerGeometryBuilder::~MuonRPCDetLayerGeometryBuilder() {
-}
-
+MuonRPCDetLayerGeometryBuilder::~MuonRPCDetLayerGeometryBuilder() {}
 
 // Builds the forward (first) and backward (second) layers
-pair<vector<DetLayer*>, vector<DetLayer*> > 
-MuonRPCDetLayerGeometryBuilder::buildEndcapLayers(const RPCGeometry& geo) {
-  
+pair<vector<DetLayer*>, vector<DetLayer*> > MuonRPCDetLayerGeometryBuilder::buildEndcapLayers(const RPCGeometry& geo) {
   vector<DetLayer*> result[2];
 
-  for (int endcap = -1; endcap<=1; endcap+=2) {
-    int iendcap = (endcap==1) ? 0 : 1; // +1: forward, -1: backward
-    
+  for (int endcap = -1; endcap <= 1; endcap += 2) {
+    int iendcap = (endcap == 1) ? 0 : 1;  // +1: forward, -1: backward
+
     // ME 1
-    int firstStation=1;
-        
+    int firstStation = 1;
+
     // ME 1/1
-    for (int layer = RPCDetId::minLayerId; layer <= RPCDetId::maxLayerId; ++layer) { 
-      vector<int> rolls;      
+    for (int layer = RPCDetId::minLayerId; layer <= RPCDetId::maxLayerId; ++layer) {
+      vector<int> rolls;
       std::vector<int> rings;
-      int FirstStationRing = 1; 
+      int FirstStationRing = 1;
       rings.push_back(FirstStationRing);
-      for(int roll = RPCDetId::minRollId+1; 
-	  roll <= RPCDetId::maxRollId; ++roll) {
-	rolls.push_back(roll);
+      for (int roll = RPCDetId::minRollId + 1; roll <= RPCDetId::maxRollId; ++roll) {
+        rolls.push_back(roll);
       }
-      
 
-      
-      MuRingForwardDoubleLayer* ringLayer = buildLayer(endcap, rings,
-						 firstStation , layer, 
-						 rolls, geo);          
-      if (ringLayer) result[iendcap].push_back(ringLayer);
-      
+      MuRingForwardDoubleLayer* ringLayer = buildLayer(endcap, rings, firstStation, layer, rolls, geo);
+      if (ringLayer)
+        result[iendcap].push_back(ringLayer);
     }
-        
-    // ME 1/2 and ME1/3       
-    for(int layer = RPCDetId::minLayerId; layer <= RPCDetId::maxLayerId; ++layer) { 
-      vector<int> rolls;      
+
+    // ME 1/2 and ME1/3
+    for (int layer = RPCDetId::minLayerId; layer <= RPCDetId::maxLayerId; ++layer) {
+      vector<int> rolls;
       std::vector<int> rings;
-      for(int ring = 2; ring <= 3; ++ring) {
-	rings.push_back(ring);
+      for (int ring = 2; ring <= 3; ++ring) {
+        rings.push_back(ring);
       }
-      for(int roll = RPCDetId::minRollId+1; roll <= RPCDetId::maxRollId; 
-	  ++roll) {
-	rolls.push_back(roll);
+      for (int roll = RPCDetId::minRollId + 1; roll <= RPCDetId::maxRollId; ++roll) {
+        rolls.push_back(roll);
       }
-                
-      MuRingForwardDoubleLayer* ringLayer = buildLayer(endcap, rings, firstStation , layer, rolls, geo);          
-      if (ringLayer) result[iendcap].push_back(ringLayer);
-    }
-  
 
-    // ME 2 and ME 3 
-    for(int station = 2; station <= RPCDetId::maxStationId; ++station) {
-      for(int layer = RPCDetId::minLayerId; layer <= RPCDetId::maxLayerId; ++layer) { 
-	vector<int> rolls;      
-	std::vector<int> rings;
-	for(int ring = RPCDetId::minRingForwardId; ring <= RPCDetId::maxRingForwardId; ++ring) {
-	  rings.push_back(ring);
-	}
-	for(int roll = RPCDetId::minRollId+1; roll <= RPCDetId::maxRollId; ++roll) {
-	  rolls.push_back(roll);
-	}
-                
-	MuRingForwardDoubleLayer* ringLayer = buildLayer(endcap, rings, station, layer, rolls, geo);          
-	if (ringLayer) result[iendcap].push_back(ringLayer);
+      MuRingForwardDoubleLayer* ringLayer = buildLayer(endcap, rings, firstStation, layer, rolls, geo);
+      if (ringLayer)
+        result[iendcap].push_back(ringLayer);
+    }
+
+    // ME 2 and ME 3
+    for (int station = 2; station <= RPCDetId::maxStationId; ++station) {
+      for (int layer = RPCDetId::minLayerId; layer <= RPCDetId::maxLayerId; ++layer) {
+        vector<int> rolls;
+        std::vector<int> rings;
+        for (int ring = RPCDetId::minRingForwardId; ring <= RPCDetId::maxRingForwardId; ++ring) {
+          rings.push_back(ring);
+        }
+        for (int roll = RPCDetId::minRollId + 1; roll <= RPCDetId::maxRollId; ++roll) {
+          rolls.push_back(roll);
+        }
+
+        MuRingForwardDoubleLayer* ringLayer = buildLayer(endcap, rings, station, layer, rolls, geo);
+        if (ringLayer)
+          result[iendcap].push_back(ringLayer);
       }
     }
-    
   }
-  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]); 
+  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]);
   return res_pair;
-
 }
 
-
-
-MuRingForwardDoubleLayer* 
-MuonRPCDetLayerGeometryBuilder::buildLayer(int endcap,const std::vector<int>& rings, int station,
-					   int layer,
-					   vector<int>& rolls,
-					   const RPCGeometry& geo) {
-
+MuRingForwardDoubleLayer* MuonRPCDetLayerGeometryBuilder::buildLayer(
+    int endcap, const std::vector<int>& rings, int station, int layer, vector<int>& rolls, const RPCGeometry& geo) {
   const std::string metname = "Muon|RPC|RecoMuon|RecoMuonDetLayers|MuonRPCDetLayerGeometryBuilder";
 
   vector<const ForwardDetRing*> frontRings, backRings;
 
-
-  for (std::vector<int>::const_iterator ring=rings.begin(); ring<rings.end();++ring){ 
-    for (vector<int>::iterator roll = rolls.begin(); roll!=rolls.end(); ++roll) {    
+  for (std::vector<int>::const_iterator ring = rings.begin(); ring < rings.end(); ++ring) {
+    for (vector<int>::iterator roll = rolls.begin(); roll != rolls.end(); ++roll) {
       vector<const GeomDet*> frontDets, backDets;
-      for(int sector = RPCDetId::minSectorForwardId; sector <= RPCDetId::maxSectorForwardId; ++sector) {
-	for(int subsector = RPCDetId::minSubSectorForwardId; subsector <= RPCDetId::maxSectorForwardId; ++subsector) {
-          RPCDetId rpcId(endcap,*ring, station,sector,layer,subsector, (*roll));
+      for (int sector = RPCDetId::minSectorForwardId; sector <= RPCDetId::maxSectorForwardId; ++sector) {
+        for (int subsector = RPCDetId::minSubSectorForwardId; subsector <= RPCDetId::maxSectorForwardId; ++subsector) {
+          RPCDetId rpcId(endcap, *ring, station, sector, layer, subsector, (*roll));
           bool isInFront = isFront(rpcId);
-	  const GeomDet* geomDet = geo.idToDet(rpcId);
-	  if (geomDet) {
-	    
-	    if(isInFront)
-            {
+          const GeomDet* geomDet = geo.idToDet(rpcId);
+          if (geomDet) {
+            if (isInFront) {
               frontDets.push_back(geomDet);
-            }
-            else 
-            {
+            } else {
               backDets.push_back(geomDet);
             }
-	    LogTrace(metname) << "get RPC Endcap roll "
-			      << rpcId
-                              << (isInFront ? "front" : "back ")
-			      << " at R=" << geomDet->position().perp()
-			      << ", phi=" << geomDet->position().phi()
+            LogTrace(metname) << "get RPC Endcap roll " << rpcId << (isInFront ? "front" : "back ")
+                              << " at R=" << geomDet->position().perp() << ", phi=" << geomDet->position().phi()
                               << ", Z=" << geomDet->position().z();
-	    
-	  }
-	}
+          }
+        }
       }
       if (!frontDets.empty()) {
-	precomputed_value_sort(frontDets.begin(), frontDets.end(), geomsort::DetPhi());
-	frontRings.push_back(new MuDetRing(frontDets));
-	LogTrace(metname) << "New front ring with " << frontDets.size()
-			  << " chambers at z="<< frontRings.back()->position().z();
+        precomputed_value_sort(frontDets.begin(), frontDets.end(), geomsort::DetPhi());
+        frontRings.push_back(new MuDetRing(frontDets));
+        LogTrace(metname) << "New front ring with " << frontDets.size()
+                          << " chambers at z=" << frontRings.back()->position().z();
       }
       if (!backDets.empty()) {
         precomputed_value_sort(backDets.begin(), backDets.end(), geomsort::DetPhi());
         backRings.push_back(new MuDetRing(backDets));
         LogTrace(metname) << "New back ring with " << backDets.size()
-                          << " chambers at z="<< backRings.back()->position().z();
+                          << " chambers at z=" << backRings.back()->position().z();
       }
     }
   }
 
-   MuRingForwardDoubleLayer * result = nullptr;
+  MuRingForwardDoubleLayer* result = nullptr;
 
-  if(!backRings.empty() || !frontRings.empty())
-  {
+  if (!backRings.empty() || !frontRings.empty()) {
     typedef rpcdetlayergeomsort::ExtractInnerRadius<ForwardDetRing, float> SortRingByInnerR;
     precomputed_value_sort(frontRings.begin(), frontRings.end(), SortRingByInnerR());
     precomputed_value_sort(backRings.begin(), backRings.end(), SortRingByInnerR());
-  
-    result = new MuRingForwardDoubleLayer(frontRings, backRings);  
-    LogTrace(metname) << "New layer with " << frontRings.size() 
-                    << " front rings and " << backRings.size()
-                    << " back rings, at Z " << result->position().z();
+
+    result = new MuRingForwardDoubleLayer(frontRings, backRings);
+    LogTrace(metname) << "New layer with " << frontRings.size() << " front rings and " << backRings.size()
+                      << " back rings, at Z " << result->position().z();
   }
-  
+
   return result;
 }
 
-
-vector<DetLayer*> 
-MuonRPCDetLayerGeometryBuilder::buildBarrelLayers(const RPCGeometry& geo) {
+vector<DetLayer*> MuonRPCDetLayerGeometryBuilder::buildBarrelLayers(const RPCGeometry& geo) {
   const std::string metname = "Muon|RPC|RecoMuon|RecoMuonDetLayers|MuonRPCDetLayerGeometryBuilder";
 
   vector<DetLayer*> detlayers;
   vector<MuRodBarrelLayer*> result;
-  int region =0;
+  int region = 0;
 
-  for(int station = RPCDetId::minStationId; station <= RPCDetId::maxStationId; station++) {
-
+  for (int station = RPCDetId::minStationId; station <= RPCDetId::maxStationId; station++) {
     vector<const GeomDet*> geomDets;
 
-    for(int layer=RPCDetId::minLayerId; layer<= RPCDetId::maxLayerId;++layer){
-      for(int sector = RPCDetId::minSectorId; sector <= RPCDetId::maxSectorId; sector++) {
-	for(int subsector = RPCDetId::minSubSectorId; subsector <= RPCDetId::maxSubSectorId; subsector++) {
-	  for(int wheel = RPCDetId::minRingBarrelId; wheel <= RPCDetId::maxRingBarrelId; wheel++) {
-	    for(int roll=RPCDetId::minRollId+1; roll <= RPCDetId::maxRollId; roll++){         
-	      const GeomDet* geomDet = geo.idToDet(RPCDetId(region,wheel,station,sector,layer,subsector,roll));
-	      if (geomDet) {
-		geomDets.push_back(geomDet);
-		LogTrace(metname) << "get RPC Barrel roll " <<  RPCDetId(region,wheel,station,sector,layer,subsector,roll)
-				  << " at R=" << geomDet->position().perp()
-				  << ", phi=" << geomDet->position().phi() ;
-	      }
-	    }
-	  }
-	}
+    for (int layer = RPCDetId::minLayerId; layer <= RPCDetId::maxLayerId; ++layer) {
+      for (int sector = RPCDetId::minSectorId; sector <= RPCDetId::maxSectorId; sector++) {
+        for (int subsector = RPCDetId::minSubSectorId; subsector <= RPCDetId::maxSubSectorId; subsector++) {
+          for (int wheel = RPCDetId::minRingBarrelId; wheel <= RPCDetId::maxRingBarrelId; wheel++) {
+            for (int roll = RPCDetId::minRollId + 1; roll <= RPCDetId::maxRollId; roll++) {
+              const GeomDet* geomDet = geo.idToDet(RPCDetId(region, wheel, station, sector, layer, subsector, roll));
+              if (geomDet) {
+                geomDets.push_back(geomDet);
+                LogTrace(metname) << "get RPC Barrel roll "
+                                  << RPCDetId(region, wheel, station, sector, layer, subsector, roll)
+                                  << " at R=" << geomDet->position().perp() << ", phi=" << geomDet->position().phi();
+              }
+            }
+          }
+        }
       }
     }
     makeBarrelLayers(geomDets, result);
   }
-  
 
-  for(vector<MuRodBarrelLayer*>::const_iterator it = result.begin(); it != result.end(); it++)
+  for (vector<MuRodBarrelLayer*>::const_iterator it = result.begin(); it != result.end(); it++)
     detlayers.push_back((DetLayer*)(*it));
 
   return detlayers;
 }
 
-
-void MuonRPCDetLayerGeometryBuilder::makeBarrelLayers(vector<const GeomDet *> & geomDets,
-                                                      vector<MuRodBarrelLayer*> & result)
-{
+void MuonRPCDetLayerGeometryBuilder::makeBarrelLayers(vector<const GeomDet*>& geomDets,
+                                                      vector<MuRodBarrelLayer*>& result) {
   const std::string metname = "Muon|RPC|RecoMuon|RecoMuonDetLayers|MuonRPCDetLayerGeometryBuilder";
 
   //Sort in R
-  precomputed_value_sort(geomDets.begin(), geomDets.end(),geomsort::DetR());
+  precomputed_value_sort(geomDets.begin(), geomDets.end(), geomsort::DetR());
 
   // Clusterize in phi - phi0
-  float resolution(25); // cm
+  float resolution(25);  // cm
   float r0 = float(geomDets.front()->position().perp());
-  float rMin = - float(resolution);
+  float rMin = -float(resolution);
   float rMax = float(geomDets.back()->position().perp()) - r0 + resolution;
 
-  ClusterizingHistogram hisR( int((rMax-rMin)/resolution) + 1,
-                                rMin, rMax);
+  ClusterizingHistogram hisR(int((rMax - rMin) / resolution) + 1, rMin, rMax);
 
   vector<const GeomDet*>::iterator first = geomDets.begin();
   vector<const GeomDet*>::iterator last = geomDets.end();
 
-  for (vector<const GeomDet*>::iterator i=first; i!=last; i++){
-    hisR.fill(float((*i)->position().perp())-r0);
-    LogTrace(metname) << "R " << float((*i)->position().perp())-r0;
+  for (vector<const GeomDet*>::iterator i = first; i != last; i++) {
+    hisR.fill(float((*i)->position().perp()) - r0);
+    LogTrace(metname) << "R " << float((*i)->position().perp()) - r0;
   }
   vector<float> rClust = hisR.clusterize(resolution);
 
@@ -248,22 +212,22 @@ void MuonRPCDetLayerGeometryBuilder::makeBarrelLayers(vector<const GeomDet *> & 
   vector<const GeomDet*>::iterator layerStart = first;
   vector<const GeomDet*>::iterator separ = first;
 
-  for (unsigned int i=0; i<rClust.size(); i++) {
+  for (unsigned int i = 0; i < rClust.size(); i++) {
     float rSepar;
-    if (i<rClust.size()-1) {
-      rSepar = (rClust[i] + rClust[i+1])/2.f;
+    if (i < rClust.size() - 1) {
+      rSepar = (rClust[i] + rClust[i + 1]) / 2.f;
     } else {
       rSepar = rMax;
     }
 
     // LogTrace(metname) << "       cluster " << i
     // << " phisepar " << phiSepar <<endl;
-    while (separ < last && float((*separ)->position().perp())-r0 < rSepar ) {
+    while (separ < last && float((*separ)->position().perp()) - r0 < rSepar) {
       // LogTrace(metname) << "         roll at dphi:  " << float((*separ)->position().phi())-phi0;
       separ++;
     }
 
-    if (int(separ-layerStart) > 0) {
+    if (int(separ - layerStart) > 0) {
       // we have a layer in R.  Now separate it into rods
       vector<const DetRod*> rods;
       vector<const GeomDet*> layerDets(layerStart, separ);
@@ -271,39 +235,34 @@ void MuonRPCDetLayerGeometryBuilder::makeBarrelLayers(vector<const GeomDet *> & 
 
       if (!rods.empty()) {
         result.push_back(new MuRodBarrelLayer(rods));
-        LogTrace(metname) << "    New MuRodBarrelLayer with " << rods.size()
-                          << " rods, at R " << result.back()->specificSurface().radius();
+        LogTrace(metname) << "    New MuRodBarrelLayer with " << rods.size() << " rods, at R "
+                          << result.back()->specificSurface().radius();
       }
     }
     layerStart = separ;
   }
 }
 
-
-void
-MuonRPCDetLayerGeometryBuilder::makeBarrelRods(vector<const GeomDet *> & geomDets,
-                                               vector<const DetRod*> & result)
-{
+void MuonRPCDetLayerGeometryBuilder::makeBarrelRods(vector<const GeomDet*>& geomDets, vector<const DetRod*>& result) {
   const std::string metname = "Muon|RPC|RecoMuon|RecoMuonDetLayers|MuonRPCDetLayerGeometryBuilder";
 
   //Sort in phi
-  precomputed_value_sort(geomDets.begin(), geomDets.end(),geomsort::DetPhi());
+  precomputed_value_sort(geomDets.begin(), geomDets.end(), geomsort::DetPhi());
 
   // Clusterize in phi - phi0
-  float resolution(0.01); // rad
+  float resolution(0.01);  // rad
   float phi0 = float(geomDets.front()->position().phi());
-  float phiMin = - float(resolution);
+  float phiMin = -float(resolution);
   float phiMax = float(geomDets.back()->position().phi()) - phi0 + resolution;
 
-  ClusterizingHistogram hisPhi( int((phiMax-phiMin)/resolution) + 1,
-                                phiMin, phiMax);
+  ClusterizingHistogram hisPhi(int((phiMax - phiMin) / resolution) + 1, phiMin, phiMax);
 
   vector<const GeomDet*>::iterator first = geomDets.begin();
   vector<const GeomDet*>::iterator last = geomDets.end();
 
-  for (vector<const GeomDet*>::iterator i=first; i!=last; i++){
-    hisPhi.fill(float((*i)->position().phi())-phi0);
-    LogTrace(metname) << "C " << float((*i)->position().phi())-phi0;
+  for (vector<const GeomDet*>::iterator i = first; i != last; i++) {
+    hisPhi.fill(float((*i)->position().phi()) - phi0);
+    LogTrace(metname) << "C " << float((*i)->position().phi()) - phi0;
   }
   vector<float> phiClust = hisPhi.clusterize(resolution);
 
@@ -312,35 +271,32 @@ MuonRPCDetLayerGeometryBuilder::makeBarrelRods(vector<const GeomDet *> & geomDet
   vector<const GeomDet*>::iterator rodStart = first;
   vector<const GeomDet*>::iterator separ = first;
 
-  for (unsigned int i=0; i<phiClust.size(); i++) {
+  for (unsigned int i = 0; i < phiClust.size(); i++) {
     float phiSepar;
-    if (i<phiClust.size()-1) {
-      phiSepar = (phiClust[i] + phiClust[i+1])/2.f;
+    if (i < phiClust.size() - 1) {
+      phiSepar = (phiClust[i] + phiClust[i + 1]) / 2.f;
     } else {
       phiSepar = phiMax;
     }
 
     // LogTrace(metname) << "       cluster " << i
     // << " phisepar " << phiSepar <<endl;
-    while (separ < last && float((*separ)->position().phi())-phi0 < phiSepar ) {
+    while (separ < last && float((*separ)->position().phi()) - phi0 < phiSepar) {
       // LogTrace(metname) << "         roll at dphi:  " << float((*separ)->position().phi())-phi0;
       separ++;
     }
 
-    if (int(separ-rodStart) > 0) {
+    if (int(separ - rodStart) > 0) {
       result.push_back(new MuDetRod(rodStart, separ));
-      LogTrace(metname) << "  New MuDetRod with " << int(separ-rodStart)
+      LogTrace(metname) << "  New MuDetRod with " << int(separ - rodStart)
                         << " rolls at R=" << (*rodStart)->position().perp()
                         << ", phi=" << float((*rodStart)->position().phi());
-
     }
     rodStart = separ;
   }
 }
 
-
-bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId & rpcId)
-{
+bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId& rpcId) {
   // ME1/2 is always in back
   //  if(rpcId.station() == 1 && rpcId.ring() == 2)  return false;
 
@@ -348,8 +304,7 @@ bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId & rpcId)
   int ring = rpcId.ring();
   int station = rpcId.station();
   // 20 degree rings are a little weird! not anymore from 17x
-  if(ring == 1 && station > 1)
-  {
+  if (ring == 1 && station > 1) {
     // RE2/1 RE3/1  Upscope Geometry
     /* goes (sector) (subsector)            1/3
     1 1 back   // front 
@@ -361,15 +316,12 @@ bool MuonRPCDetLayerGeometryBuilder::isFront(const RPCDetId & rpcId)
                         
     */
     result = (rpcId.subsector() != 2);
-    if(rpcId.sector()%2 == 0) result = !result;
+    if (rpcId.sector() % 2 == 0)
+      result = !result;
     return result;
-  }
-  else
-  {
+  } else {
     // 10 degree rings have odd subsectors in front
-    result = (rpcId.subsector()%2 == 0);
+    result = (rpcId.subsector() % 2 == 0);
   }
   return result;
 }
-
-

--- a/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.h
@@ -12,34 +12,34 @@ class DetLayer;
 class MuRingForwardDoubleLayer;
 class MuRodBarrelLayer;
 
-
 #include <Geometry/RPCGeometry/interface/RPCGeometry.h>
 #include "RecoMuon/DetLayers/interface/MuDetRod.h"
 #include <vector>
 
 class MuonRPCDetLayerGeometryBuilder {
- public:
+public:
   /// Constructor (disabled, only static access is allowed)
-  MuonRPCDetLayerGeometryBuilder(){}
+  MuonRPCDetLayerGeometryBuilder() {}
 
   /// Destructor
   virtual ~MuonRPCDetLayerGeometryBuilder();
-  
+
   /// Builds the forward (+Z, return.first) and backward (-Z, return.second) layers.
   /// Both vectors are sorted inside-out
   static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildEndcapLayers(const RPCGeometry& geo);
-        
+
   /// Builds the barrel layers. Result vector is sorted inside-out
   static std::vector<DetLayer*> buildBarrelLayers(const RPCGeometry& geo);
-    
- private:
-  static void makeBarrelLayers(std::vector<const GeomDet *> & geomDets,
-                               std::vector<MuRodBarrelLayer*> & result);
-  static void makeBarrelRods(std::vector<const GeomDet *> & geomDets,
-                             std::vector<const DetRod*> & result);
-  static bool isFront(const RPCDetId & rpcId);
-  static MuRingForwardDoubleLayer* buildLayer(int endcap,const std::vector<int>& rings, int station,int layer, std::vector<int>& rolls,const RPCGeometry& geo);          
-    
+
+private:
+  static void makeBarrelLayers(std::vector<const GeomDet*>& geomDets, std::vector<MuRodBarrelLayer*>& result);
+  static void makeBarrelRods(std::vector<const GeomDet*>& geomDets, std::vector<const DetRod*>& result);
+  static bool isFront(const RPCDetId& rpcId);
+  static MuRingForwardDoubleLayer* buildLayer(int endcap,
+                                              const std::vector<int>& rings,
+                                              int station,
+                                              int layer,
+                                              std::vector<int>& rolls,
+                                              const RPCGeometry& geo);
 };
 #endif
-

--- a/RecoMuon/DetLayers/test/MuonRecoGeometryAnalyzer.cc
+++ b/RecoMuon/DetLayers/test/MuonRecoGeometryAnalyzer.cc
@@ -18,7 +18,6 @@
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 
-
 #include "RecoMuon/DetLayers/interface/MuRodBarrelLayer.h"
 #include "RecoMuon/DetLayers/interface/MuDetRod.h"
 #include "RecoMuon/DetLayers/interface/MuRingForwardDoubleLayer.h"
@@ -35,35 +34,27 @@ using namespace std;
 using namespace edm;
 
 class MuonRecoGeometryAnalyzer : public EDAnalyzer {
- public:
+public:
+  MuonRecoGeometryAnalyzer(const ParameterSet& pset);
 
-  MuonRecoGeometryAnalyzer( const ParameterSet& pset);
-
-  virtual void analyze( const Event& ev, const EventSetup& es);
+  virtual void analyze(const Event& ev, const EventSetup& es);
 
   void testDTLayers(const MuonDetLayerGeometry*, const MagneticField* field);
   void testCSCLayers(const MuonDetLayerGeometry*, const MagneticField* field);
 
   string dumpLayer(const DetLayer* layer) const;
 
- private:
-  MeasurementEstimator *theEstimator;
+private:
+  MeasurementEstimator* theEstimator;
 };
 
-
-  
-MuonRecoGeometryAnalyzer::MuonRecoGeometryAnalyzer(const ParameterSet& iConfig) 
-{
-  float theMaxChi2=25.;
-  float theNSigma=3.;
-  theEstimator = new Chi2MeasurementEstimator(theMaxChi2,theNSigma);
-  
+MuonRecoGeometryAnalyzer::MuonRecoGeometryAnalyzer(const ParameterSet& iConfig) {
+  float theMaxChi2 = 25.;
+  float theNSigma = 3.;
+  theEstimator = new Chi2MeasurementEstimator(theMaxChi2, theNSigma);
 }
 
-
-void MuonRecoGeometryAnalyzer::analyze( const Event& ev,
-				       const EventSetup& es ) {
-
+void MuonRecoGeometryAnalyzer::analyze(const Event& ev, const EventSetup& es) {
   ESHandle<MuonDetLayerGeometry> geo;
   es.get<MuonRecoGeometryRecord>().get(geo);
 
@@ -72,128 +63,107 @@ void MuonRecoGeometryAnalyzer::analyze( const Event& ev,
   // Some printouts
 
   cout << "*** allDTLayers(): " << geo->allDTLayers().size() << endl;
-  for (auto dl = geo->allDTLayers().begin();
-       dl != geo->allDTLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->allDTLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->allDTLayers().begin(); dl != geo->allDTLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->allDTLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allCSCLayers(): " << geo->allCSCLayers().size() << endl;
-  for (auto dl = geo->allCSCLayers().begin();
-       dl != geo->allCSCLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->allCSCLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->allCSCLayers().begin(); dl != geo->allCSCLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->allCSCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** forwardCSCLayers(): " << geo->forwardCSCLayers().size() << endl;
-  for (auto dl = geo->forwardCSCLayers().begin();
-       dl != geo->forwardCSCLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->forwardCSCLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->forwardCSCLayers().begin(); dl != geo->forwardCSCLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->forwardCSCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** backwardCSCLayers(): " << geo->backwardCSCLayers().size() << endl;
-  for (auto dl = geo->backwardCSCLayers().begin();
-       dl != geo->backwardCSCLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->backwardCSCLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->backwardCSCLayers().begin(); dl != geo->backwardCSCLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->backwardCSCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allRPCLayers(): " << geo->allRPCLayers().size() << endl;
-  for (auto dl = geo->allRPCLayers().begin();
-       dl != geo->allRPCLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->allRPCLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->allRPCLayers().begin(); dl != geo->allRPCLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->allRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** endcapRPCLayers(): " << geo->endcapRPCLayers().size() << endl;
-  for (auto dl = geo->endcapRPCLayers().begin();
-       dl != geo->endcapRPCLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->endcapRPCLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->endcapRPCLayers().begin(); dl != geo->endcapRPCLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->endcapRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** barrelRPCLayers(): " << geo->barrelRPCLayers().size() << endl;
-  for (auto dl = geo->barrelRPCLayers().begin();
-       dl != geo->barrelRPCLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->barrelRPCLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->barrelRPCLayers().begin(); dl != geo->barrelRPCLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->barrelRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** forwardRPCLayers(): " << geo->forwardRPCLayers().size() << endl;
-  for (auto dl = geo->forwardRPCLayers().begin();
-       dl != geo->forwardRPCLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->forwardRPCLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->forwardRPCLayers().begin(); dl != geo->forwardRPCLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->forwardRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** backwardRPCLayers(): " << geo->backwardRPCLayers().size() << endl;
-  for (auto dl = geo->backwardRPCLayers().begin();
-       dl != geo->backwardRPCLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->backwardRPCLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->backwardRPCLayers().begin(); dl != geo->backwardRPCLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->backwardRPCLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allBarrelLayers(): " << geo->allBarrelLayers().size() << endl;
-  for (auto dl = geo->allBarrelLayers().begin();
-       dl != geo->allBarrelLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->allBarrelLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->allBarrelLayers().begin(); dl != geo->allBarrelLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->allBarrelLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allEndcapLayers(): " << geo->allEndcapLayers().size() << endl;
-  for (auto dl = geo->allEndcapLayers().begin();
-       dl != geo->allEndcapLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->allEndcapLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->allEndcapLayers().begin(); dl != geo->allEndcapLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->allEndcapLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allForwardLayers(): " << geo->allForwardLayers().size() << endl;
-  for (auto dl = geo->allForwardLayers().begin();
-       dl != geo->allForwardLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->allForwardLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->allForwardLayers().begin(); dl != geo->allForwardLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->allForwardLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
   cout << "*** allBackwardLayers(): " << geo->allBackwardLayers().size() << endl;
-  for (auto dl = geo->allBackwardLayers().begin();
-       dl != geo->allBackwardLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->allBackwardLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->allBackwardLayers().begin(); dl != geo->allBackwardLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->allBackwardLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
-
 
   cout << "*** allLayers(): " << geo->allLayers().size() << endl;
-  for (auto dl = geo->allLayers().begin();
-       dl != geo->allLayers().end(); ++dl) {
-    cout << "  " << (int) (dl-geo->allLayers().begin()) << " " << dumpLayer(*dl);
+  for (auto dl = geo->allLayers().begin(); dl != geo->allLayers().end(); ++dl) {
+    cout << "  " << (int)(dl - geo->allLayers().begin()) << " " << dumpLayer(*dl);
   }
   cout << endl << endl;
 
-
-
-
-
-  testDTLayers(geo.product(),magfield.product());
-  testCSCLayers(geo.product(),magfield.product());
+  testDTLayers(geo.product(), magfield.product());
+  testCSCLayers(geo.product(), magfield.product());
 }
 
-
-void MuonRecoGeometryAnalyzer::testDTLayers(const MuonDetLayerGeometry* geo,const MagneticField* field) {
-
+void MuonRecoGeometryAnalyzer::testDTLayers(const MuonDetLayerGeometry* geo, const MagneticField* field) {
   const vector<const DetLayer*>& layers = geo->allDTLayers();
 
-  for (auto ilay = layers.begin(); ilay!=layers.end(); ++ilay) {
-    const MuRodBarrelLayer* layer = (const MuRodBarrelLayer*) (*ilay);
-  
-    const BoundCylinder& cyl = layer->specificSurface();  
+  for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
+    const MuRodBarrelLayer* layer = (const MuRodBarrelLayer*)(*ilay);
 
-    double halfZ = cyl.bounds().length()/2.;
+    const BoundCylinder& cyl = layer->specificSurface();
+
+    double halfZ = cyl.bounds().length() / 2.;
 
     // Generate a random point on the cylinder
-    double aPhi = CLHEP::RandFlat::shoot(-Geom::pi(),Geom::pi());
+    double aPhi = CLHEP::RandFlat::shoot(-Geom::pi(), Geom::pi());
     double aZ = CLHEP::RandFlat::shoot(-halfZ, halfZ);
-    GlobalPoint gp(GlobalPoint::Cylindrical(cyl.radius(), aPhi, aZ));  
+    GlobalPoint gp(GlobalPoint::Cylindrical(cyl.radius(), aPhi, aZ));
 
     // Momentum: 10 GeV, straight from the origin
     GlobalVector gv(GlobalVector::Spherical(gp.theta(), aPhi, 10.));
@@ -201,54 +171,47 @@ void MuonRecoGeometryAnalyzer::testDTLayers(const MuonDetLayerGeometry* geo,cons
     //FIXME: only negative charge
     int charge = -1;
 
-    GlobalTrajectoryParameters gtp(gp,gv,charge,field);
+    GlobalTrajectoryParameters gtp(gp, gv, charge, field);
     TrajectoryStateOnSurface tsos(gtp, cyl);
-    cout << "testDTLayers: at " << tsos.globalPosition()
-	 << " R=" << tsos.globalPosition().perp()
-	 << " phi=" << tsos.globalPosition().phi()
-	 << " Z=" << tsos.globalPosition().z()
-	 << " p = " << tsos.globalMomentum()
-	 << endl;
+    cout << "testDTLayers: at " << tsos.globalPosition() << " R=" << tsos.globalPosition().perp()
+         << " phi=" << tsos.globalPosition().phi() << " Z=" << tsos.globalPosition().z()
+         << " p = " << tsos.globalMomentum() << endl;
 
+    SteppingHelixPropagator prop(field, anyDirection);
 
-    SteppingHelixPropagator prop(field,anyDirection);
+    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
+    cout << "is compatible: " << comp.first << " at: R=" << comp.second.globalPosition().perp()
+         << " phi=" << comp.second.globalPosition().phi() << " Z=" << comp.second.globalPosition().z() << endl;
 
-    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos,prop,*theEstimator);
-    cout << "is compatible: " << comp.first
-	 << " at: R=" << comp.second.globalPosition().perp()
-	 << " phi=" << comp.second.globalPosition().phi()
-	 << " Z=" <<  comp.second.globalPosition().z()
-	 << endl;
-
-    vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos,prop,*theEstimator);
+    vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (compDets.size()) {
       cout << "compatibleDets: " << compDets.size() << endl
 
-	   << "  final state pos: " << compDets.front().second.globalPosition() << endl 
-	   << "  det         pos: " << compDets.front().first->position()
-	   << " id: " << DTWireId(compDets.front().first->geographicalId().rawId()) << endl 
-	   << "  distance " << (tsos.globalPosition()-compDets.front().first->position()).mag()
+           << "  final state pos: " << compDets.front().second.globalPosition() << endl
+           << "  det         pos: " << compDets.front().first->position()
+           << " id: " << DTWireId(compDets.front().first->geographicalId().rawId()) << endl
+           << "  distance " << (tsos.globalPosition() - compDets.front().first->position()).mag()
 
-	   << endl
-	   << endl;
+           << endl
+           << endl;
     } else {
       cout << " ERROR : no compatible det found" << endl;
-    }    
+    }
   }
 }
 
-void MuonRecoGeometryAnalyzer::testCSCLayers(const MuonDetLayerGeometry* geo,const MagneticField* field) {
+void MuonRecoGeometryAnalyzer::testCSCLayers(const MuonDetLayerGeometry* geo, const MagneticField* field) {
   const vector<const DetLayer*>& layers = geo->allCSCLayers();
 
-  for (auto ilay = layers.begin(); ilay!=layers.end(); ++ilay) {
-    const MuRingForwardDoubleLayer* layer = (const MuRingForwardDoubleLayer*) (*ilay);
-  
+  for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
+    const MuRingForwardDoubleLayer* layer = (const MuRingForwardDoubleLayer*)(*ilay);
+
     const BoundDisk& disk = layer->specificSurface();
 
     // Generate a random point on the disk
-    double aPhi = CLHEP::RandFlat::shoot(-Geom::pi(),Geom::pi());
+    double aPhi = CLHEP::RandFlat::shoot(-Geom::pi(), Geom::pi());
     double aR = CLHEP::RandFlat::shoot(disk.innerRadius(), disk.outerRadius());
-    GlobalPoint gp(GlobalPoint::Cylindrical(aR, aPhi, disk.position().z()));  
+    GlobalPoint gp(GlobalPoint::Cylindrical(aR, aPhi, disk.position().z()));
 
     // Momentum: 10 GeV, straight from the origin
     GlobalVector gv(GlobalVector::Spherical(gp.theta(), aPhi, 10.));
@@ -256,66 +219,52 @@ void MuonRecoGeometryAnalyzer::testCSCLayers(const MuonDetLayerGeometry* geo,con
     //FIXME: only negative charge
     int charge = -1;
 
-    GlobalTrajectoryParameters gtp(gp,gv,charge,field);
+    GlobalTrajectoryParameters gtp(gp, gv, charge, field);
     TrajectoryStateOnSurface tsos(gtp, disk);
-    cout << "testCSCLayers: at " << tsos.globalPosition()
-	 << " R=" << tsos.globalPosition().perp()
-	 << " phi=" << tsos.globalPosition().phi()
-	 << " Z=" << tsos.globalPosition().z()
-	 << " p = " << tsos.globalMomentum()
-	 << endl;
+    cout << "testCSCLayers: at " << tsos.globalPosition() << " R=" << tsos.globalPosition().perp()
+         << " phi=" << tsos.globalPosition().phi() << " Z=" << tsos.globalPosition().z()
+         << " p = " << tsos.globalMomentum() << endl;
 
+    SteppingHelixPropagator prop(field, anyDirection);
 
-    SteppingHelixPropagator prop(field,anyDirection);
+    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
+    cout << "is compatible: " << comp.first << " at: R=" << comp.second.globalPosition().perp()
+         << " phi=" << comp.second.globalPosition().phi() << " Z=" << comp.second.globalPosition().z() << endl;
 
-    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos,prop,*theEstimator);
-    cout << "is compatible: " << comp.first
-	 << " at: R=" << comp.second.globalPosition().perp()
-	 << " phi=" << comp.second.globalPosition().phi()
-	 << " Z=" <<  comp.second.globalPosition().z()
-	 << endl;
-  
-    vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos,prop,*theEstimator);
+    vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (compDets.size()) {
       cout << "compatibleDets: " << compDets.size() << endl
 
-	   << "  final state pos: " << compDets.front().second.globalPosition() << endl 
-	   << "  det         pos: " << compDets.front().first->position()
-	   << " id: " << CSCDetId(compDets.front().first->geographicalId().rawId()) << endl 
-	   << "  distance " << (tsos.globalPosition()-compDets.front().first->position()).mag()
+           << "  final state pos: " << compDets.front().second.globalPosition() << endl
+           << "  det         pos: " << compDets.front().first->position()
+           << " id: " << CSCDetId(compDets.front().first->geographicalId().rawId()) << endl
+           << "  distance " << (tsos.globalPosition() - compDets.front().first->position()).mag()
 
-	   << endl
-	   << endl;
+           << endl
+           << endl;
     } else {
-      if(layer->isCrack(gp))
-      {
-         cout << " CSC crack found ";
-      }
-      else
-      {
+      if (layer->isCrack(gp)) {
+        cout << " CSC crack found ";
+      } else {
         cout << " ERROR : no compatible det found in CSC"
-          << " at: R=" << gp.perp()
-          << " phi= " << gp.phi().degrees()
-          << " Z= " << gp.z();
+             << " at: R=" << gp.perp() << " phi= " << gp.phi().degrees() << " Z= " << gp.z();
       }
-
     }
   }
 }
 
 string MuonRecoGeometryAnalyzer::dumpLayer(const DetLayer* layer) const {
   stringstream output;
-  
-  const BoundSurface* sur=0;
-  const BoundCylinder* bc=0;
-  const BoundDisk* bd=0;
+
+  const BoundSurface* sur = 0;
+  const BoundCylinder* bc = 0;
+  const BoundDisk* bd = 0;
 
   sur = &(layer->surface());
-  if ( (bc = dynamic_cast<const BoundCylinder*>(sur)) ) {
+  if ((bc = dynamic_cast<const BoundCylinder*>(sur))) {
     output << "  Cylinder of radius: " << bc->radius() << endl;
-  }
-  else if ( (bd = dynamic_cast<const BoundDisk*>(sur)) ) {
-    output << "  Disk at: " <<  bd->position().z() << endl;
+  } else if ((bd = dynamic_cast<const BoundDisk*>(sur))) {
+    output << "  Disk at: " << bd->position().z() << endl;
   }
   return output.str();
 }

--- a/RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h
+++ b/RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h
@@ -28,93 +28,82 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-
-
 #include <vector>
 
 class DetLayer;
 class GeomDet;
 class TrajectoryMeasurement;
 
-
 //FIXME: these typedefs MUST GO inside the scope of MuonDetLayerMeasurements
-typedef std::vector<TrajectoryMeasurement>          MeasurementContainer;
-typedef std::pair<const GeomDet*,TrajectoryStateOnSurface> DetWithState;
-
+typedef std::vector<TrajectoryMeasurement> MeasurementContainer;
+typedef std::pair<const GeomDet*, TrajectoryStateOnSurface> DetWithState;
 
 class MuonDetLayerMeasurements {
- public:
+public:
   typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;
 
   MuonDetLayerMeasurements(edm::InputTag dtlabel,
-			   edm::InputTag csclabel,
-			   edm::InputTag rpclabel,
- 			   edm::InputTag gemlabel,
-			   edm::InputTag me0label,
-			   edm::ConsumesCollector& iC,
-			   bool enableDT = true,
-			   bool enableCSC = true,
-			   bool enableRPC = true,
-			   bool enableGEM = true,
-			   bool enableME0 = true);
-  
+                           edm::InputTag csclabel,
+                           edm::InputTag rpclabel,
+                           edm::InputTag gemlabel,
+                           edm::InputTag me0label,
+                           edm::ConsumesCollector& iC,
+                           bool enableDT = true,
+                           bool enableCSC = true,
+                           bool enableRPC = true,
+                           bool enableGEM = true,
+                           bool enableME0 = true);
+
   virtual ~MuonDetLayerMeasurements();
-  
+
   // for a given det and state.  Not clear when the fastMeasurements below
   //  should be used, since it isn't passed a GeomDet
-  MeasurementContainer
-    measurements( const DetLayer* layer,
-                  const GeomDet * det,
-                  const TrajectoryStateOnSurface& stateOnDet,
-                  const MeasurementEstimator& est,
-                  const edm::Event& iEvent);
+  MeasurementContainer measurements(const DetLayer* layer,
+                                    const GeomDet* det,
+                                    const TrajectoryStateOnSurface& stateOnDet,
+                                    const MeasurementEstimator& est,
+                                    const edm::Event& iEvent);
 
   /// returns TMeasurements in a DetLayer compatible with the TSOS.
-  MeasurementContainer
-    measurements( const DetLayer* layer,
-		  const TrajectoryStateOnSurface& startingState,
-		  const Propagator& prop,
-		  const MeasurementEstimator& est,
-		  const edm::Event& iEvent);
+  MeasurementContainer measurements(const DetLayer* layer,
+                                    const TrajectoryStateOnSurface& startingState,
+                                    const Propagator& prop,
+                                    const MeasurementEstimator& est,
+                                    const edm::Event& iEvent);
 
   /// faster version in case the TrajectoryState on the surface of the GeomDet is already available
-  MeasurementContainer
-    fastMeasurements( const DetLayer* layer,
-		      const TrajectoryStateOnSurface& theStateOnDet,
-		      const TrajectoryStateOnSurface& startingState,
-		      const Propagator& prop,
-		      const MeasurementEstimator& est,
-		      const edm::Event& iEvent);
+  MeasurementContainer fastMeasurements(const DetLayer* layer,
+                                        const TrajectoryStateOnSurface& theStateOnDet,
+                                        const TrajectoryStateOnSurface& startingState,
+                                        const Propagator& prop,
+                                        const MeasurementEstimator& est,
+                                        const edm::Event& iEvent);
 
   /// returns TMeasurements in a DetLayer compatible with the TSOS.
-  MeasurementContainer
-    measurements( const DetLayer* layer,
-		  const TrajectoryStateOnSurface& startingState,
-		  const Propagator& prop,
-		  const MeasurementEstimator& est);
+  MeasurementContainer measurements(const DetLayer* layer,
+                                    const TrajectoryStateOnSurface& startingState,
+                                    const Propagator& prop,
+                                    const MeasurementEstimator& est);
 
   /// faster version in case the TrajectoryState on the surface of the GeomDet is already available
-  MeasurementContainer
-    fastMeasurements( const DetLayer* layer,
-		      const TrajectoryStateOnSurface& theStateOnDet,
-		      const TrajectoryStateOnSurface& startingState,
-		      const Propagator& prop,
-		      const MeasurementEstimator& est);
+  MeasurementContainer fastMeasurements(const DetLayer* layer,
+                                        const TrajectoryStateOnSurface& theStateOnDet,
+                                        const TrajectoryStateOnSurface& startingState,
+                                        const Propagator& prop,
+                                        const MeasurementEstimator& est);
 
-  std::vector<TrajectoryMeasurementGroup>
-    groupedMeasurements( const DetLayer* layer,
-                  const TrajectoryStateOnSurface& startingState,
-                  const Propagator& prop,
-                  const MeasurementEstimator& est,
-                  const edm::Event& iEvent);
+  std::vector<TrajectoryMeasurementGroup> groupedMeasurements(const DetLayer* layer,
+                                                              const TrajectoryStateOnSurface& startingState,
+                                                              const Propagator& prop,
+                                                              const MeasurementEstimator& est,
+                                                              const edm::Event& iEvent);
 
-  std::vector<TrajectoryMeasurementGroup>
-    groupedMeasurements( const DetLayer* layer,
-                  const TrajectoryStateOnSurface& startingState,
-                  const Propagator& prop,
-                  const MeasurementEstimator& est);
- 
-  void setEvent(const edm::Event &);  
+  std::vector<TrajectoryMeasurementGroup> groupedMeasurements(const DetLayer* layer,
+                                                              const TrajectoryStateOnSurface& startingState,
+                                                              const Propagator& prop,
+                                                              const MeasurementEstimator& est);
+
+  void setEvent(const edm::Event&);
 
   /// returns the rechits which are on the layer
   MuonRecHitContainer recHits(const DetLayer* layer, const edm::Event& iEvent);
@@ -122,15 +111,12 @@ class MuonDetLayerMeasurements {
   /// returns the rechits which are on the layer
   MuonRecHitContainer recHits(const DetLayer* layer);
 
-
- private:
-
+private:
   /// obtain TrackingRecHits from a DetLayer
   MuonRecHitContainer recHits(const GeomDet*, const edm::Event& iEvent);
 
   /// check that the event is set, and throw otherwise
   void checkEvent() const;
-
 
   edm::EDGetTokenT<DTRecSegment4DCollection> dtToken_;
   edm::EDGetTokenT<CSCSegmentCollection> cscToken_;
@@ -138,19 +124,18 @@ class MuonDetLayerMeasurements {
   edm::EDGetTokenT<GEMRecHitCollection> gemToken_;
   edm::EDGetTokenT<ME0SegmentCollection> me0Token_;
 
-
   bool enableDTMeasurement;
   bool enableCSCMeasurement;
   bool enableRPCMeasurement;
   bool enableGEMMeasurement;
   bool enableME0Measurement;
-  
+
   // caches that should get filled once per event
   edm::Handle<DTRecSegment4DCollection> theDTRecHits;
-  edm::Handle<CSCSegmentCollection>     theCSCRecHits;
-  edm::Handle<RPCRecHitCollection>      theRPCRecHits;
-  edm::Handle<GEMRecHitCollection>      theGEMRecHits;
-  edm::Handle<ME0SegmentCollection>      theME0RecHits;
+  edm::Handle<CSCSegmentCollection> theCSCRecHits;
+  edm::Handle<RPCRecHitCollection> theRPCRecHits;
+  edm::Handle<GEMRecHitCollection> theGEMRecHits;
+  edm::Handle<ME0SegmentCollection> theME0RecHits;
 
   void checkDTRecHits();
   void checkCSCRecHits();
@@ -165,8 +150,6 @@ class MuonDetLayerMeasurements {
   edm::Event::CacheIdentifier_t theGEMEventCacheID;
   edm::Event::CacheIdentifier_t theME0EventCacheID;
 
-  const edm::Event* theEvent;   
-
+  const edm::Event* theEvent;
 };
 #endif
-

--- a/RecoMuon/MeasurementDet/src/MuonDetLayerMeasurements.cc
+++ b/RecoMuon/MeasurementDet/src/MuonDetLayerMeasurements.cc
@@ -12,44 +12,42 @@
 
 #include "RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h"
 
-#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h" 
+#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-
-
 typedef MuonTransientTrackingRecHit::MuonRecHitPointer MuonRecHitPointer;
 typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;
 
-
-
-MuonDetLayerMeasurements::MuonDetLayerMeasurements(edm::InputTag dtlabel, 
-						   edm::InputTag csclabel, 
-						   edm::InputTag rpclabel,
- 						   edm::InputTag gemlabel,
-						   edm::InputTag me0label,
-						   edm::ConsumesCollector& iC,
-						   bool enableDT, bool enableCSC, bool enableRPC, bool enableGEM, bool enableME0): 
-  enableDTMeasurement(enableDT),
-  enableCSCMeasurement(enableCSC),
-  enableRPCMeasurement(enableRPC),
-  enableGEMMeasurement(enableGEM),
-  enableME0Measurement(enableME0),
-  theDTRecHits(),
-  theCSCRecHits(),
-  theRPCRecHits(),
-  theGEMRecHits(),
-  theDTEventCacheID(0),
-  theCSCEventCacheID(0),
-  theRPCEventCacheID(0),
-  theGEMEventCacheID(0),
-  theME0EventCacheID(0),
-  theEvent(nullptr)
-{
-
+MuonDetLayerMeasurements::MuonDetLayerMeasurements(edm::InputTag dtlabel,
+                                                   edm::InputTag csclabel,
+                                                   edm::InputTag rpclabel,
+                                                   edm::InputTag gemlabel,
+                                                   edm::InputTag me0label,
+                                                   edm::ConsumesCollector& iC,
+                                                   bool enableDT,
+                                                   bool enableCSC,
+                                                   bool enableRPC,
+                                                   bool enableGEM,
+                                                   bool enableME0)
+    : enableDTMeasurement(enableDT),
+      enableCSCMeasurement(enableCSC),
+      enableRPCMeasurement(enableRPC),
+      enableGEMMeasurement(enableGEM),
+      enableME0Measurement(enableME0),
+      theDTRecHits(),
+      theCSCRecHits(),
+      theRPCRecHits(),
+      theGEMRecHits(),
+      theDTEventCacheID(0),
+      theCSCEventCacheID(0),
+      theRPCEventCacheID(0),
+      theGEMEventCacheID(0),
+      theME0EventCacheID(0),
+      theEvent(nullptr) {
   dtToken_ = iC.consumes<DTRecSegment4DCollection>(dtlabel);
   cscToken_ = iC.consumes<CSCSegmentCollection>(csclabel);
   rpcToken_ = iC.consumes<RPCRecHitCollection>(rpclabel);
@@ -58,370 +56,330 @@ MuonDetLayerMeasurements::MuonDetLayerMeasurements(edm::InputTag dtlabel,
 
   static std::atomic<int> procInstance{0};
   std::ostringstream sDT;
-  sDT<<"MuonDetLayerMeasurements::checkDTRecHits::" << procInstance;
+  sDT << "MuonDetLayerMeasurements::checkDTRecHits::" << procInstance;
   //  theDTCheckName = sDT.str();
   std::ostringstream sRPC;
-  sRPC<<"MuonDetLayerMeasurements::checkRPCRecHits::" << procInstance;
+  sRPC << "MuonDetLayerMeasurements::checkRPCRecHits::" << procInstance;
   //theRPCCheckName = sRPC.str();
   std::ostringstream sCSC;
-  sCSC<<"MuonDetLayerMeasurements::checkCSCRecHits::" << procInstance;
+  sCSC << "MuonDetLayerMeasurements::checkCSCRecHits::" << procInstance;
   //theCSCCheckName = sCSC.str();
   std::ostringstream sGEM;
-  sGEM<<"MuonDetLayerMeasurements::checkGEMRecHits::" << procInstance;
+  sGEM << "MuonDetLayerMeasurements::checkGEMRecHits::" << procInstance;
   //theGEMCheckName = sGEM.str();
   std::ostringstream sME0;
-  sME0<<"MuonDetLayerMeasurements::checkME0RecHits::" << procInstance;
+  sME0 << "MuonDetLayerMeasurements::checkME0RecHits::" << procInstance;
   //theME0CheckName = sME0.str();
   procInstance++;
 }
 
-MuonDetLayerMeasurements::~MuonDetLayerMeasurements(){}
+MuonDetLayerMeasurements::~MuonDetLayerMeasurements() {}
 
-MuonRecHitContainer MuonDetLayerMeasurements::recHits(const GeomDet* geomDet, 
-			                              const edm::Event& iEvent)
-{
+MuonRecHitContainer MuonDetLayerMeasurements::recHits(const GeomDet* geomDet, const edm::Event& iEvent) {
   DetId geoId = geomDet->geographicalId();
   theEvent = &iEvent;
   MuonRecHitContainer result;
 
-  if (geoId.subdetId()  == MuonSubdetId::DT) {
-    if(enableDTMeasurement) 
-    {
+  if (geoId.subdetId() == MuonSubdetId::DT) {
+    if (enableDTMeasurement) {
       checkDTRecHits();
-    
+
       // Create the ChamberId
       DTChamberId chamberId(geoId.rawId());
-      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(DT): "<<chamberId<<std::endl;
-    
+      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(DT): " << chamberId << std::endl;
+
       // Get the DT-Segment which relies on this chamber
       DTRecSegment4DCollection::range range = theDTRecHits->get(chamberId);
-    
+
       // Create the MuonTransientTrackingRechit
-      for (DTRecSegment4DCollection::const_iterator rechit = range.first; 
-           rechit!=range.second;++rechit)
-        result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet,&*rechit));
+      for (DTRecSegment4DCollection::const_iterator rechit = range.first; rechit != range.second; ++rechit)
+        result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet, &*rechit));
     }
   }
-  
-  else if (geoId.subdetId()  == MuonSubdetId::CSC) {
-    if(enableCSCMeasurement)
-    {
+
+  else if (geoId.subdetId() == MuonSubdetId::CSC) {
+    if (enableCSCMeasurement) {
       checkCSCRecHits();
 
       // Create the chamber Id
       CSCDetId chamberId(geoId.rawId());
-      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(CSC): "<<chamberId<<std::endl;
+      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(CSC): " << chamberId << std::endl;
 
       // Get the CSC-Segment which relies on this chamber
       CSCSegmentCollection::range range = theCSCRecHits->get(chamberId);
-    
+
       // Create the MuonTransientTrackingRecHit
-      for (CSCSegmentCollection::const_iterator rechit = range.first; 
-           rechit!=range.second; ++rechit)
-        result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet,&*rechit)); 
+      for (CSCSegmentCollection::const_iterator rechit = range.first; rechit != range.second; ++rechit)
+        result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet, &*rechit));
     }
   }
-  
-  else if (geoId.subdetId()  == MuonSubdetId::RPC) {
-    if(enableRPCMeasurement)
-    {
-      checkRPCRecHits(); 
+
+  else if (geoId.subdetId() == MuonSubdetId::RPC) {
+    if (enableRPCMeasurement) {
+      checkRPCRecHits();
 
       // Create the chamber Id
       RPCDetId chamberId(geoId.rawId());
-      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(RPC): "<<chamberId<<std::endl;
-    
+      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(RPC): " << chamberId << std::endl;
+
       // Get the RPC-Segment which relies on this chamber
       RPCRecHitCollection::range range = theRPCRecHits->get(chamberId);
-    
+
       // Create the MuonTransientTrackingRecHit
-      for (RPCRecHitCollection::const_iterator rechit = range.first; 
-           rechit!=range.second; ++rechit)
-        result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet,&*rechit));
+      for (RPCRecHitCollection::const_iterator rechit = range.first; rechit != range.second; ++rechit)
+        result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet, &*rechit));
+    }
+  } else if (geoId.subdetId() == MuonSubdetId::GEM) {
+    if (enableGEMMeasurement) {
+      checkGEMRecHits();
+
+      // Create the chamber Id
+      GEMDetId chamberId(geoId.rawId());
+
+      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(GEM): " << chamberId << std::endl;
+
+      // Get the GEM-Segment which relies on this chamber
+      GEMRecHitCollection::range range = theGEMRecHits->get(chamberId);
+
+      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements")
+          << "Number of GEM rechits available =  " << theGEMRecHits->size() << ", from chamber: " << chamberId
+          << std::endl;
+
+      // Create the MuonTransientTrackingRecHit
+      for (GEMRecHitCollection::const_iterator rechit = range.first; rechit != range.second; ++rechit)
+        result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet, &*rechit));
+      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Number of GEM rechits = " << result.size() << std::endl;
     }
   }
-  else if (geoId.subdetId()  == MuonSubdetId::GEM) {
-    if(enableGEMMeasurement)
-      {
-	checkGEMRecHits(); 
 
-	// Create the chamber Id
-	GEMDetId chamberId(geoId.rawId());
+  else if (geoId.subdetId() == MuonSubdetId::ME0) {
+    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(ME0): identified" << std::endl;
+    if (enableME0Measurement) {
+      checkME0RecHits();
 
-	LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(GEM): "<<chamberId<<std::endl;
+      // Create the chamber Id
+      ME0DetId chamberId(geoId.rawId());
 
-	// Get the GEM-Segment which relies on this chamber
-	GEMRecHitCollection::range range = theGEMRecHits->get(chamberId);
+      // Get the ME0-Segment which relies on this chamber
+      // Getting rechits right now, not segments - maybe it should be segments?
+      ME0SegmentCollection::range range = theME0RecHits->get(chamberId);
 
-	LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Number of GEM rechits available =  " << theGEMRecHits->size()
-							   <<", from chamber: "<< chamberId<<std::endl;
+      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements")
+          << "Number of ME0 rechits available =  " << theME0RecHits->size() << ", from chamber: " << chamberId
+          << std::endl;
 
-	// Create the MuonTransientTrackingRecHit
-	for (GEMRecHitCollection::const_iterator rechit = range.first; 
-	     rechit!=range.second; ++rechit)
-	  result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet,&*rechit));
-	LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Number of GEM rechits = " << result.size()<<std::endl;
+      // Create the MuonTransientTrackingRecHit
+      for (ME0SegmentCollection::const_iterator rechit = range.first; rechit != range.second; ++rechit) {
+        LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "On ME0 iteration " << std::endl;
+        result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet, &*rechit));
       }
-  }
-
-  else if (geoId.subdetId()  == MuonSubdetId::ME0) {
-    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(ME0): identified"<<std::endl;
-    if(enableME0Measurement)
-      {
-	checkME0RecHits(); 
-
-	// Create the chamber Id
-	ME0DetId chamberId(geoId.rawId());
-    
-	// Get the ME0-Segment which relies on this chamber
-	// Getting rechits right now, not segments - maybe it should be segments?
-	ME0SegmentCollection::range range = theME0RecHits->get(chamberId);
-
-	LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Number of ME0 rechits available =  " << theME0RecHits->size()
-							   <<", from chamber: "<< chamberId<<std::endl;
-
-	// Create the MuonTransientTrackingRecHit
-	for (ME0SegmentCollection::const_iterator rechit = range.first; 
-	     rechit!=range.second; ++rechit){
-	  LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "On ME0 iteration " <<std::endl;
-	  result.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet,&*rechit));
-	}
-	LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Number of ME0 rechits = " << result.size()<<std::endl;
-      }
-  }
-  else {
+      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Number of ME0 rechits = " << result.size() << std::endl;
+    }
+  } else {
     // wrong type
-    throw cms::Exception("MuonDetLayerMeasurements") << "The DetLayer with det " << geoId.det() << " subdet " << geoId.subdetId() << " is not a valid Muon DetLayer. ";
-    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements")<< "The DetLayer with det " << geoId.det() << " subdet " << geoId.subdetId() << " is not a valid Muon DetLayer. ";
+    throw cms::Exception("MuonDetLayerMeasurements") << "The DetLayer with det " << geoId.det() << " subdet "
+                                                     << geoId.subdetId() << " is not a valid Muon DetLayer. ";
+    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "The DetLayer with det " << geoId.det() << " subdet "
+                                                       << geoId.subdetId() << " is not a valid Muon DetLayer. ";
   }
-  if (enableME0Measurement){
-    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(ME0): enabled"<<std::endl;
+  if (enableME0Measurement) {
+    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(ME0): enabled" << std::endl;
   }
 
-  if (enableGEMMeasurement){
-    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(GEM): enabled"<<std::endl;
+  if (enableGEMMeasurement) {
+    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "(GEM): enabled" << std::endl;
   }
   return result;
 }
 
-
-void MuonDetLayerMeasurements::checkDTRecHits()
-{
+void MuonDetLayerMeasurements::checkDTRecHits() {
   checkEvent();
   auto const cacheID = theEvent->cacheIdentifier();
-  if (cacheID == theDTEventCacheID) return;
+  if (cacheID == theDTEventCacheID)
+    return;
 
-  {
-    theEvent->getByToken(dtToken_, theDTRecHits);
-  }
-  if(!theDTRecHits.isValid())
-  {
+  { theEvent->getByToken(dtToken_, theDTRecHits); }
+  if (!theDTRecHits.isValid()) {
     throw cms::Exception("MuonDetLayerMeasurements") << "Cannot get DT RecHits";
   }
 }
 
-
-void MuonDetLayerMeasurements::checkCSCRecHits()
-{
+void MuonDetLayerMeasurements::checkCSCRecHits() {
   checkEvent();
   auto cacheID = theEvent->cacheIdentifier();
-  if (cacheID == theCSCEventCacheID) return;
+  if (cacheID == theCSCEventCacheID)
+    return;
 
   {
     theEvent->getByToken(cscToken_, theCSCRecHits);
     theCSCEventCacheID = cacheID;
   }
-  if(!theCSCRecHits.isValid())
-  {
+  if (!theCSCRecHits.isValid()) {
     throw cms::Exception("MuonDetLayerMeasurements") << "Cannot get CSC RecHits";
   }
 }
 
-
-void MuonDetLayerMeasurements::checkRPCRecHits()
-{
+void MuonDetLayerMeasurements::checkRPCRecHits() {
   checkEvent();
   auto cacheID = theEvent->cacheIdentifier();
-  if (cacheID == theRPCEventCacheID) return;
+  if (cacheID == theRPCEventCacheID)
+    return;
 
   {
     theEvent->getByToken(rpcToken_, theRPCRecHits);
     theRPCEventCacheID = cacheID;
   }
-  if(!theRPCRecHits.isValid())
-  {
+  if (!theRPCRecHits.isValid()) {
     throw cms::Exception("MuonDetLayerMeasurements") << "Cannot get RPC RecHits";
   }
 }
 
-void MuonDetLayerMeasurements::checkGEMRecHits()
-{
+void MuonDetLayerMeasurements::checkGEMRecHits() {
   checkEvent();
   auto cacheID = theEvent->cacheIdentifier();
-  if (cacheID == theGEMEventCacheID) return;
+  if (cacheID == theGEMEventCacheID)
+    return;
 
   {
     theEvent->getByToken(gemToken_, theGEMRecHits);
     theGEMEventCacheID = cacheID;
   }
-  if(!theGEMRecHits.isValid())
-  {
+  if (!theGEMRecHits.isValid()) {
     throw cms::Exception("MuonDetLayerMeasurements") << "Cannot get GEM RecHits";
   }
 }
 
-void MuonDetLayerMeasurements::checkME0RecHits()
-{
+void MuonDetLayerMeasurements::checkME0RecHits() {
   LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Checking ME0 RecHits";
   checkEvent();
   auto cacheID = theEvent->cacheIdentifier();
-  if (cacheID == theME0EventCacheID) return;
+  if (cacheID == theME0EventCacheID)
+    return;
 
   {
     theEvent->getByToken(me0Token_, theME0RecHits);
     theME0EventCacheID = cacheID;
   }
-  if(!theME0RecHits.isValid())
-  {
+  if (!theME0RecHits.isValid()) {
     throw cms::Exception("MuonDetLayerMeasurements") << "Cannot get ME0 RecHits";
     LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Cannot get ME0 RecHits";
   }
 }
 
-///measurements method if already got the Event 
-MeasurementContainer
-MuonDetLayerMeasurements::measurements( const DetLayer* layer,
-					const TrajectoryStateOnSurface& startingState,
-					const Propagator& prop,
-					const MeasurementEstimator& est) {
+///measurements method if already got the Event
+MeasurementContainer MuonDetLayerMeasurements::measurements(const DetLayer* layer,
+                                                            const TrajectoryStateOnSurface& startingState,
+                                                            const Propagator& prop,
+                                                            const MeasurementEstimator& est) {
   checkEvent();
   return measurements(layer, startingState, prop, est, *theEvent);
 }
 
-
-MeasurementContainer
-MuonDetLayerMeasurements::measurements(const DetLayer* layer,
-				       const TrajectoryStateOnSurface& startingState,
-				       const Propagator& prop,
-				       const MeasurementEstimator& est,
-				       const edm::Event& iEvent) {
-  
+MeasurementContainer MuonDetLayerMeasurements::measurements(const DetLayer* layer,
+                                                            const TrajectoryStateOnSurface& startingState,
+                                                            const Propagator& prop,
+                                                            const MeasurementEstimator& est,
+                                                            const edm::Event& iEvent) {
   MeasurementContainer result;
-  
 
   std::vector<DetWithState> dss = layer->compatibleDets(startingState, prop, est);
-  LogDebug("RecoMuon")<<"compatibleDets: "<<dss.size()<<std::endl;
-  
-  for(std::vector<DetWithState>::const_iterator detWithStateItr = dss.begin();
-      detWithStateItr != dss.end(); ++detWithStateItr){
+  LogDebug("RecoMuon") << "compatibleDets: " << dss.size() << std::endl;
 
-    MeasurementContainer detMeasurements 
-      = measurements(layer, detWithStateItr->first, 
-                     detWithStateItr->second, est, iEvent);
+  for (std::vector<DetWithState>::const_iterator detWithStateItr = dss.begin(); detWithStateItr != dss.end();
+       ++detWithStateItr) {
+    MeasurementContainer detMeasurements =
+        measurements(layer, detWithStateItr->first, detWithStateItr->second, est, iEvent);
     result.insert(result.end(), detMeasurements.begin(), detMeasurements.end());
   }
-  
-  if (!result.empty()) sort( result.begin(), result.end(), TrajMeasLessEstim());
-  
+
+  if (!result.empty())
+    sort(result.begin(), result.end(), TrajMeasLessEstim());
+
   return result;
 }
 
-
-MeasurementContainer
-MuonDetLayerMeasurements::measurements( const DetLayer* layer,
-					const GeomDet* det,
-					const TrajectoryStateOnSurface& stateOnDet,
-					const MeasurementEstimator& est,
-					const edm::Event& iEvent) {
+MeasurementContainer MuonDetLayerMeasurements::measurements(const DetLayer* layer,
+                                                            const GeomDet* det,
+                                                            const TrajectoryStateOnSurface& stateOnDet,
+                                                            const MeasurementEstimator& est,
+                                                            const edm::Event& iEvent) {
   MeasurementContainer result;
 
   DetId geoId = det->geographicalId();
   //no chamber here that is actually an me0....
-  if (geoId.subdetId()  == MuonSubdetId::ME0) {
-    if(enableME0Measurement) {
+  if (geoId.subdetId() == MuonSubdetId::ME0) {
+    if (enableME0Measurement) {
       ME0DetId chamberId(geoId.rawId());
-      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "ME0 Chamber ID in measurements: "<<chamberId<<std::endl;
+      LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements")
+          << "ME0 Chamber ID in measurements: " << chamberId << std::endl;
     }
   }
-  
-  
+
   // Get the Segments which relies on the GeomDet given by compatibleDets
   MuonRecHitContainer muonRecHits = recHits(det, iEvent);
-  
-  // Create the Trajectory Measurement
-  for(MuonRecHitContainer::const_iterator rechit = muonRecHits.begin();
-      rechit != muonRecHits.end(); ++rechit) {
 
-    MeasurementEstimator::HitReturnType estimate = est.estimate(stateOnDet,**rechit);
-    LogDebug("RecoMuon")<<"Dimension: "<<(*rechit)->dimension()
-			<<" Chi2: "<<estimate.second<<std::endl;
+  // Create the Trajectory Measurement
+  for (MuonRecHitContainer::const_iterator rechit = muonRecHits.begin(); rechit != muonRecHits.end(); ++rechit) {
+    MeasurementEstimator::HitReturnType estimate = est.estimate(stateOnDet, **rechit);
+    LogDebug("RecoMuon") << "Dimension: " << (*rechit)->dimension() << " Chi2: " << estimate.second << std::endl;
     if (estimate.first) {
-      result.push_back(TrajectoryMeasurement(stateOnDet, *rechit,
-					     estimate.second,layer));
+      result.push_back(TrajectoryMeasurement(stateOnDet, *rechit, estimate.second, layer));
     }
   }
 
-  if (!result.empty()) sort( result.begin(), result.end(), TrajMeasLessEstim());
-   
+  if (!result.empty())
+    sort(result.begin(), result.end(), TrajMeasLessEstim());
+
   return result;
 }
 
-
-
-MeasurementContainer
-MuonDetLayerMeasurements::fastMeasurements( const DetLayer* layer,
-					    const TrajectoryStateOnSurface& theStateOnDet,
-					    const TrajectoryStateOnSurface& startingState,
-					    const Propagator& prop,
-					    const MeasurementEstimator& est,
-					    const edm::Event& iEvent) {
+MeasurementContainer MuonDetLayerMeasurements::fastMeasurements(const DetLayer* layer,
+                                                                const TrajectoryStateOnSurface& theStateOnDet,
+                                                                const TrajectoryStateOnSurface& startingState,
+                                                                const Propagator& prop,
+                                                                const MeasurementEstimator& est,
+                                                                const edm::Event& iEvent) {
   MeasurementContainer result;
   MuonRecHitContainer rhs = recHits(layer, iEvent);
-  for (MuonRecHitContainer::const_iterator irh = rhs.begin(); irh!=rhs.end(); irh++) {
+  for (MuonRecHitContainer::const_iterator irh = rhs.begin(); irh != rhs.end(); irh++) {
     MeasurementEstimator::HitReturnType estimate = est.estimate(theStateOnDet, (**irh));
-    if (estimate.first)
-    {
-      result.push_back(TrajectoryMeasurement(theStateOnDet,(*irh),
-                                             estimate.second,layer));
+    if (estimate.first) {
+      result.push_back(TrajectoryMeasurement(theStateOnDet, (*irh), estimate.second, layer));
     }
   }
 
   if (!result.empty()) {
-    sort( result.begin(), result.end(), TrajMeasLessEstim());
+    sort(result.begin(), result.end(), TrajMeasLessEstim());
   }
 
   return result;
 }
 
 ///fastMeasurements method if already got the Event
-MeasurementContainer
-MuonDetLayerMeasurements::fastMeasurements(const DetLayer* layer,
-					   const TrajectoryStateOnSurface& theStateOnDet,
-					   const TrajectoryStateOnSurface& startingState,
-					   const Propagator& prop,
-					   const MeasurementEstimator& est) {
+MeasurementContainer MuonDetLayerMeasurements::fastMeasurements(const DetLayer* layer,
+                                                                const TrajectoryStateOnSurface& theStateOnDet,
+                                                                const TrajectoryStateOnSurface& startingState,
+                                                                const Propagator& prop,
+                                                                const MeasurementEstimator& est) {
   checkEvent();
-  return fastMeasurements(layer, theStateOnDet, startingState, prop, est, *theEvent); 
+  return fastMeasurements(layer, theStateOnDet, startingState, prop, est, *theEvent);
 }
 
-
-std::vector<TrajectoryMeasurementGroup>
-MuonDetLayerMeasurements::groupedMeasurements(const DetLayer* layer,
-					      const TrajectoryStateOnSurface& startingState,
-					      const Propagator& prop,
-					      const MeasurementEstimator& est) {
+std::vector<TrajectoryMeasurementGroup> MuonDetLayerMeasurements::groupedMeasurements(
+    const DetLayer* layer,
+    const TrajectoryStateOnSurface& startingState,
+    const Propagator& prop,
+    const MeasurementEstimator& est) {
   checkEvent();
-  return groupedMeasurements(layer, startingState, prop,  est, *theEvent);
+  return groupedMeasurements(layer, startingState, prop, est, *theEvent);
 }
 
-
-std::vector<TrajectoryMeasurementGroup>
-MuonDetLayerMeasurements::groupedMeasurements(const DetLayer* layer,
-					      const TrajectoryStateOnSurface& startingState,
-					      const Propagator& prop,
-					      const MeasurementEstimator& est,
-					      const edm::Event& iEvent) {
-  
+std::vector<TrajectoryMeasurementGroup> MuonDetLayerMeasurements::groupedMeasurements(
+    const DetLayer* layer,
+    const TrajectoryStateOnSurface& startingState,
+    const Propagator& prop,
+    const MeasurementEstimator& est,
+    const edm::Event& iEvent) {
   std::vector<TrajectoryMeasurementGroup> result;
   // if we want to use the concept of InvalidRecHits,
   // we can reuse LayerMeasurements from TrackingTools/MeasurementDet
@@ -431,20 +389,17 @@ MuonDetLayerMeasurements::groupedMeasurements(const DetLayer* layer,
   // RecoMuon/DetLayers/MuRingForwardDoubleLayer
   // and removed the reverse operation in StandAloneMuonFilter::findBestMeasurements
 
-  for (std::vector<DetGroup>::const_iterator grp=groups.begin(); grp!=groups.end(); ++grp) {
-    
+  for (std::vector<DetGroup>::const_iterator grp = groups.begin(); grp != groups.end(); ++grp) {
     std::vector<TrajectoryMeasurement> groupMeasurements;
-    for (DetGroup::const_iterator detAndStateItr=grp->begin();
-         detAndStateItr !=grp->end(); ++detAndStateItr) {
-
-      std::vector<TrajectoryMeasurement> detMeasurements 
-        = measurements(layer, detAndStateItr->det(), detAndStateItr->trajectoryState(), est, iEvent);
+    for (DetGroup::const_iterator detAndStateItr = grp->begin(); detAndStateItr != grp->end(); ++detAndStateItr) {
+      std::vector<TrajectoryMeasurement> detMeasurements =
+          measurements(layer, detAndStateItr->det(), detAndStateItr->trajectoryState(), est, iEvent);
       groupMeasurements.insert(groupMeasurements.end(), detMeasurements.begin(), detMeasurements.end());
     }
-    
-    if (!groupMeasurements.empty()) 
-      std::sort( groupMeasurements.begin(), groupMeasurements.end(), TrajMeasLessEstim());  
-    
+
+    if (!groupMeasurements.empty())
+      std::sort(groupMeasurements.begin(), groupMeasurements.end(), TrajMeasLessEstim());
+
     result.push_back(TrajectoryMeasurementGroup(groupMeasurements, *grp));
   }
 
@@ -452,33 +407,26 @@ MuonDetLayerMeasurements::groupedMeasurements(const DetLayer* layer,
 }
 
 ///set event
-void MuonDetLayerMeasurements::setEvent(const edm::Event& event) {
-  theEvent = &event;
-}
-
+void MuonDetLayerMeasurements::setEvent(const edm::Event& event) { theEvent = &event; }
 
 void MuonDetLayerMeasurements::checkEvent() const {
-  if(!theEvent)
+  if (!theEvent)
     throw cms::Exception("MuonDetLayerMeasurements") << "The event has not been set";
 }
 
-MuonRecHitContainer MuonDetLayerMeasurements::recHits(const DetLayer* layer, 
-						      const edm::Event& iEvent) {
+MuonRecHitContainer MuonDetLayerMeasurements::recHits(const DetLayer* layer, const edm::Event& iEvent) {
   MuonRecHitContainer rhs;
-  
-  std::vector <const GeomDet*> gds = layer->basicComponents();
 
-  for (std::vector<const GeomDet*>::const_iterator igd = gds.begin(); 
-       igd != gds.end(); igd++) {
+  std::vector<const GeomDet*> gds = layer->basicComponents();
+
+  for (std::vector<const GeomDet*>::const_iterator igd = gds.begin(); igd != gds.end(); igd++) {
     MuonRecHitContainer detHits = recHits(*igd, iEvent);
     rhs.insert(rhs.end(), detHits.begin(), detHits.end());
   }
   return rhs;
 }
 
-MuonRecHitContainer MuonDetLayerMeasurements::recHits(const DetLayer* layer) 
-{
+MuonRecHitContainer MuonDetLayerMeasurements::recHits(const DetLayer* layer) {
   checkEvent();
   return recHits(layer, *theEvent);
 }
-

--- a/RecoMuon/Navigation/interface/DirectMuonNavigation.h
+++ b/RecoMuon/Navigation/interface/DirectMuonNavigation.h
@@ -17,50 +17,41 @@
 #include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class DirectMuonNavigation{
+class DirectMuonNavigation {
+public:
+  /* Constructor */
+  DirectMuonNavigation(const edm::ESHandle<MuonDetLayerGeometry>&);
 
-  public:
+  DirectMuonNavigation(const edm::ESHandle<MuonDetLayerGeometry>&, const edm::ParameterSet&);
 
-    /* Constructor */ 
-    DirectMuonNavigation(const edm::ESHandle<MuonDetLayerGeometry>&);
+  DirectMuonNavigation* clone() const { return new DirectMuonNavigation(*this); }
 
-    DirectMuonNavigation(const edm::ESHandle<MuonDetLayerGeometry>&, const edm::ParameterSet&);
+  /* Destructor */
+  ~DirectMuonNavigation() {}
 
-    DirectMuonNavigation* clone() const {
-      return new DirectMuonNavigation(*this);
-    }
+  std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
+                                                PropagationDirection timeDirection) const;
 
-    /* Destructor */ 
-    ~DirectMuonNavigation() {}
+  std::vector<const DetLayer*> compatibleEndcapLayers(const FreeTrajectoryState& fts,
+                                                      PropagationDirection timeDirection) const;
 
-    std::vector<const DetLayer*> 
-      compatibleLayers( const FreeTrajectoryState& fts, 
-                        PropagationDirection timeDirection) const;
+private:
+  void inOutBarrel(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  void outInBarrel(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
+  void inOutForward(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  void outInForward(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
-    std::vector<const DetLayer*>
-      compatibleEndcapLayers( const FreeTrajectoryState& fts,
-                              PropagationDirection timeDirection) const;
+  void inOutBackward(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  void outInBackward(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
-  private:
+  bool checkCompatible(const FreeTrajectoryState& fts, const BarrelDetLayer*) const;
+  bool checkCompatible(const FreeTrajectoryState& fts, const ForwardDetLayer*) const;
+  bool outward(const FreeTrajectoryState& fts) const;
 
-    void inOutBarrel(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
-    void outInBarrel(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
-
-    void inOutForward(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
-    void outInForward(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const; 
-
-    void inOutBackward(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
-    void outInBackward(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
-
-    bool checkCompatible(const FreeTrajectoryState& fts,const BarrelDetLayer*) const;
-    bool checkCompatible(const FreeTrajectoryState& fts,const ForwardDetLayer*) const;
-    bool outward(const FreeTrajectoryState& fts) const;
-
-    edm::ESHandle<MuonDetLayerGeometry> theMuonDetLayerGeometry;
-    float epsilon_;
-    bool theEndcapFlag;
-    bool theBarrelFlag;
-
+  edm::ESHandle<MuonDetLayerGeometry> theMuonDetLayerGeometry;
+  float epsilon_;
+  bool theEndcapFlag;
+  bool theBarrelFlag;
 };
 #endif

--- a/RecoMuon/Navigation/interface/MuonBarrelNavigableLayer.h
+++ b/RecoMuon/Navigation/interface/MuonBarrelNavigableLayer.h
@@ -16,7 +16,6 @@
  *  
  */
 
-
 /* Collaborating Class Declarations */
 #include "RecoMuon/Navigation/interface/MuonDetLayerMap.h"
 #include "RecoMuon/Navigation/interface/MuonEtaRange.h"
@@ -33,152 +32,140 @@ class BarrelDetLayer;
 /* Class MuonBarrelNavigableLayer Interface */
 
 class MuonBarrelNavigableLayer : public MuonNavigableLayer {
+public:
+  /// Constructor
+  MuonBarrelNavigableLayer(BarrelDetLayer* bdl,
+                           const MapB& outerBarrel,
+                           const MapB& innerBarrel,
+                           const MapE& outerBackward,
+                           const MapE& outerForward,
+                           const MapE& innerBackward,
+                           const MapE& innerForward)
+      : theDetLayer(bdl),
+        theOuterBarrelLayers(outerBarrel),
+        theInnerBarrelLayers(innerBarrel),
+        theOuterBackwardLayers(outerBackward),
+        theInnerBackwardLayers(innerBackward),
+        theOuterForwardLayers(outerForward),
+        theInnerForwardLayers(innerForward) {}
 
-  public:
+  MuonBarrelNavigableLayer(BarrelDetLayer* bdl,
+                           const MapB& outerBarrel,
+                           const MapB& innerBarrel,
+                           const MapE& outerBackward,
+                           const MapE& outerForward,
+                           const MapE& innerBackward,
+                           const MapE& innerForward,
+                           const MapB& allOuterBarrel,
+                           const MapB& allInnerBarrel,
+                           const MapE& allOuterBackward,
+                           const MapE& allOuterForward,
+                           const MapE& allInnerBackward,
+                           const MapE& allInnerForward)
+      : theDetLayer(bdl),
+        theOuterBarrelLayers(outerBarrel),
+        theInnerBarrelLayers(innerBarrel),
+        theOuterBackwardLayers(outerBackward),
+        theInnerBackwardLayers(innerBackward),
+        theOuterForwardLayers(outerForward),
+        theInnerForwardLayers(innerForward),
+        theAllOuterBarrelLayers(allOuterBarrel),
+        theAllInnerBarrelLayers(allInnerBarrel),
+        theAllOuterBackwardLayers(allOuterBackward),
+        theAllInnerBackwardLayers(allInnerBackward),
+        theAllOuterForwardLayers(allOuterForward),
+        theAllInnerForwardLayers(allInnerForward) {}
 
-    /// Constructor 
-    MuonBarrelNavigableLayer(BarrelDetLayer* bdl, 
-                             const MapB& outerBarrel, 
-                             const MapB& innerBarrel, 
-                             const MapE& outerBackward,
-                             const MapE& outerForward,
-                             const MapE& innerBackward,
-                             const MapE& innerForward) :
-      theDetLayer(bdl), 
-      theOuterBarrelLayers(outerBarrel),
-      theInnerBarrelLayers(innerBarrel), 
-      theOuterBackwardLayers(outerBackward),
-      theInnerBackwardLayers(innerBackward),
-      theOuterForwardLayers(outerForward),
-      theInnerForwardLayers(innerForward) {}
+  /// Constructor with outer layers only
+  MuonBarrelNavigableLayer(BarrelDetLayer* bdl,
+                           const MapB& outerBarrel,
+                           const MapE& outerBackward,
+                           const MapE& outerForward)
+      : theDetLayer(bdl),
+        theOuterBarrelLayers(outerBarrel),
+        theOuterBackwardLayers(outerBackward),
+        theOuterForwardLayers(outerForward) {}
 
-    MuonBarrelNavigableLayer(BarrelDetLayer* bdl,
-                             const MapB& outerBarrel,
-                             const MapB& innerBarrel,
-                             const MapE& outerBackward,
-                             const MapE& outerForward,
-                             const MapE& innerBackward,
-                             const MapE& innerForward,
-                             const MapB& allOuterBarrel,
-                             const MapB& allInnerBarrel,
-                             const MapE& allOuterBackward,
-                             const MapE& allOuterForward,
-                             const MapE& allInnerBackward,
-                             const MapE& allInnerForward) :
-      theDetLayer(bdl),
-      theOuterBarrelLayers(outerBarrel),
-      theInnerBarrelLayers(innerBarrel),
-      theOuterBackwardLayers(outerBackward),
-      theInnerBackwardLayers(innerBackward),
-      theOuterForwardLayers(outerForward),
-      theInnerForwardLayers(innerForward), 
-      theAllOuterBarrelLayers(allOuterBarrel),
-      theAllInnerBarrelLayers(allInnerBarrel),
-      theAllOuterBackwardLayers(allOuterBackward),
-      theAllInnerBackwardLayers(allInnerBackward),
-      theAllOuterForwardLayers(allOuterForward),
-      theAllInnerForwardLayers(allInnerForward) {}
+  MuonBarrelNavigableLayer(const BarrelDetLayer* bdl,
+                           const MapB& outerBarrel,
+                           const MapE& outerBackward,
+                           const MapE& outerForward,
+                           const MapB& allOuterBarrel,
+                           const MapE& allOuterBackward,
+                           const MapE& allOuterForward)
+      : theDetLayer(bdl),
+        theOuterBarrelLayers(outerBarrel),
+        theOuterBackwardLayers(outerBackward),
+        theOuterForwardLayers(outerForward),
+        theAllOuterBarrelLayers(allOuterBarrel),
+        theAllOuterBackwardLayers(allOuterBackward),
+        theAllOuterForwardLayers(allOuterForward) {}
 
-    /// Constructor with outer layers only
-    MuonBarrelNavigableLayer(BarrelDetLayer* bdl, 
-                             const MapB& outerBarrel,
-                             const MapE& outerBackward,
-                             const MapE& outerForward) :
-      theDetLayer(bdl), 
-      theOuterBarrelLayers(outerBarrel),
-      theOuterBackwardLayers(outerBackward),
-      theOuterForwardLayers(outerForward) { }
+  /// NavigableLayer interface
+  std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const override;
 
-    MuonBarrelNavigableLayer(const BarrelDetLayer* bdl,
-                             const MapB& outerBarrel,
-                             const MapE& outerBackward,
-                             const MapE& outerForward,
-                             const MapB& allOuterBarrel,
-                             const MapE& allOuterBackward,
-                             const MapE& allOuterForward) :
-      theDetLayer(bdl),
-      theOuterBarrelLayers(outerBarrel),
-      theOuterBackwardLayers(outerBackward),
-      theOuterForwardLayers(outerForward),
-      theAllOuterBarrelLayers(allOuterBarrel),
-      theAllOuterBackwardLayers(allOuterBackward),
-      theAllOuterForwardLayers(allOuterForward) {}
+  /// NavigableLayer interface
+  std::vector<const DetLayer*> nextLayers(const FreeTrajectoryState& fts, PropagationDirection dir) const override;
 
-    /// NavigableLayer interface
-    std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const override;
+  std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const override;
 
-    /// NavigableLayer interface
-    std::vector<const DetLayer*> nextLayers(const FreeTrajectoryState& fts, 
-                                               PropagationDirection dir) const override;
+  /// NavigableLayer interface
+  std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
+                                                PropagationDirection dir) const override;
 
-    std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const override;
+  /// return DetLayer
+  const DetLayer* detLayer() const override;
 
-    /// NavigableLayer interface
-    std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
-                                               PropagationDirection dir) const override;
+  /// set DetLayer
+  void setDetLayer(const DetLayer*) override;
 
-    /// return DetLayer
-    const DetLayer* detLayer() const override;
+  MapB getOuterBarrelLayers() const { return theOuterBarrelLayers; }
+  MapB getInnerBarrelLayers() const { return theInnerBarrelLayers; }
+  MapE getOuterBackwardLayers() const { return theOuterBackwardLayers; }
+  MapE getInnerBackwardLayers() const { return theInnerBackwardLayers; }
+  MapE getOuterForwardLayers() const { return theOuterForwardLayers; }
+  MapE getInnerForwardLayers() const { return theInnerForwardLayers; }
 
-    /// set DetLayer
-    void setDetLayer(const DetLayer*) override;
+  MapB getAllOuterBarrelLayers() const { return theAllOuterBarrelLayers; }
+  MapB getAllInnerBarrelLayers() const { return theAllInnerBarrelLayers; }
+  MapE getAllOuterBackwardLayers() const { return theAllOuterBackwardLayers; }
+  MapE getAllInnerBackwardLayers() const { return theAllInnerBackwardLayers; }
+  MapE getAllOuterForwardLayers() const { return theAllOuterForwardLayers; }
+  MapE getAllInnerForwardLayers() const { return theAllInnerForwardLayers; }
 
-    MapB getOuterBarrelLayers() const { return theOuterBarrelLayers; }
-    MapB getInnerBarrelLayers() const { return theInnerBarrelLayers; }
-    MapE getOuterBackwardLayers() const { return theOuterBackwardLayers; }
-    MapE getInnerBackwardLayers() const { return theInnerBackwardLayers; }
-    MapE getOuterForwardLayers() const { return theOuterForwardLayers; }
-    MapE getInnerForwardLayers() const { return theInnerForwardLayers; }
+  /// set inward links
+  void setInwardLinks(const MapB&);
+  void setInwardCompatibleLinks(const MapB&);
 
-    MapB getAllOuterBarrelLayers() const { return theAllOuterBarrelLayers; }
-    MapB getAllInnerBarrelLayers() const { return theAllInnerBarrelLayers; }
-    MapE getAllOuterBackwardLayers() const { return theAllOuterBackwardLayers; }
-    MapE getAllInnerBackwardLayers() const { return theAllInnerBackwardLayers; }
-    MapE getAllOuterForwardLayers() const { return theAllOuterForwardLayers; }
-    MapE getAllInnerForwardLayers() const { return theAllInnerForwardLayers; }
+private:
+  void pushResult(std::vector<const DetLayer*>& result, const MapB& map) const;
 
-    /// set inward links
-    void setInwardLinks(const MapB&);
-    void setInwardCompatibleLinks(const MapB&);
+  void pushResult(std::vector<const DetLayer*>& result, const MapE& map) const;
 
-  private:
+  void pushResult(std::vector<const DetLayer*>& result, const MapB& map, const FreeTrajectoryState& fts) const;
 
-    void pushResult(std::vector<const DetLayer*>& result,
-                    const MapB& map) const;
+  void pushResult(std::vector<const DetLayer*>& result, const MapE& map, const FreeTrajectoryState& fts) const;
+  void pushCompatibleResult(std::vector<const DetLayer*>& result,
+                            const MapB& map,
+                            const FreeTrajectoryState& fts) const;
 
-    void pushResult(std::vector<const DetLayer*>& result,
-                    const MapE& map) const;
+  void pushCompatibleResult(std::vector<const DetLayer*>& result,
+                            const MapE& map,
+                            const FreeTrajectoryState& fts) const;
 
-    void pushResult(std::vector<const DetLayer*>& result,
-                    const MapB& map, const
-                    FreeTrajectoryState& fts) const;
-
-    void pushResult(std::vector<const DetLayer*>& result,
-                    const MapE& map, const
-                    FreeTrajectoryState& fts) const;
-    void pushCompatibleResult(std::vector<const DetLayer*>& result,
-                    const MapB& map, const
-                    FreeTrajectoryState& fts) const;
-
-    void pushCompatibleResult(std::vector<const DetLayer*>& result,
-                    const MapE& map, const
-                    FreeTrajectoryState& fts) const;
-
-  private:
-
-    const BarrelDetLayer* theDetLayer;
-    MapB theOuterBarrelLayers;
-    MapB theInnerBarrelLayers;
-    MapE theOuterBackwardLayers;
-    MapE theInnerBackwardLayers;
-    MapE theOuterForwardLayers;
-    MapE theInnerForwardLayers;
-    MapB theAllOuterBarrelLayers;
-    MapB theAllInnerBarrelLayers;
-    MapE theAllOuterBackwardLayers;
-    MapE theAllInnerBackwardLayers;
-    MapE theAllOuterForwardLayers;
-    MapE theAllInnerForwardLayers;
-
+private:
+  const BarrelDetLayer* theDetLayer;
+  MapB theOuterBarrelLayers;
+  MapB theInnerBarrelLayers;
+  MapE theOuterBackwardLayers;
+  MapE theInnerBackwardLayers;
+  MapE theOuterForwardLayers;
+  MapE theInnerForwardLayers;
+  MapB theAllOuterBarrelLayers;
+  MapB theAllInnerBarrelLayers;
+  MapE theAllOuterBackwardLayers;
+  MapE theAllInnerBackwardLayers;
+  MapE theAllOuterForwardLayers;
+  MapE theAllInnerForwardLayers;
 };
 #endif

--- a/RecoMuon/Navigation/interface/MuonDetLayerMap.h
+++ b/RecoMuon/Navigation/interface/MuonDetLayerMap.h
@@ -19,17 +19,18 @@
  */
 
 struct MuonDetLayerComp {
-    bool operator()(const BarrelDetLayer* l1, const BarrelDetLayer* l2) const {
-      if ( l1->specificSurface().radius() < l2->specificSurface().radius() ) return true;
-      return false;
-    }
+  bool operator()(const BarrelDetLayer* l1, const BarrelDetLayer* l2) const {
+    if (l1->specificSurface().radius() < l2->specificSurface().radius())
+      return true;
+    return false;
+  }
 
-    bool operator()(const ForwardDetLayer* l1, const ForwardDetLayer* l2) const {
-      if ( fabs(l1->surface().position().z()) < fabs(l2->surface().position().z()) ) return true;
-      return false;
-    }
+  bool operator()(const ForwardDetLayer* l1, const ForwardDetLayer* l2) const {
+    if (fabs(l1->surface().position().z()) < fabs(l2->surface().position().z()))
+      return true;
+    return false;
+  }
 };
-
 
 // FIXME: these names are too generic...
 typedef std::map<const BarrelDetLayer*, MuonEtaRange, MuonDetLayerComp> MapB;
@@ -38,4 +39,3 @@ typedef MapB::const_iterator MapBI;
 typedef MapE::const_iterator MapEI;
 
 #endif
- 

--- a/RecoMuon/Navigation/interface/MuonEtaRange.h
+++ b/RecoMuon/Navigation/interface/MuonEtaRange.h
@@ -13,32 +13,29 @@
  */
 
 class MuonEtaRange {
+public:
+  MuonEtaRange();
+  MuonEtaRange(float max, float min);
+  MuonEtaRange(const MuonEtaRange&);
+  ~MuonEtaRange() {}
+  MuonEtaRange& operator=(const MuonEtaRange&);
+  inline float min() const { return theMin; }
+  inline float max() const { return theMax; }
+  bool isInside(float eta, float error = 0.) const;
+  bool isInside(const MuonEtaRange& range) const;
+  bool isCompatible(const MuonEtaRange& range) const;
+  MuonEtaRange add(const MuonEtaRange&) const;
+  MuonEtaRange minRange(const MuonEtaRange&) const;
+  MuonEtaRange subtract(const MuonEtaRange&) const;
 
-  public:
-
-    MuonEtaRange();
-    MuonEtaRange(float max, float min);
-    MuonEtaRange(const MuonEtaRange&);
-    ~MuonEtaRange() {}
-    MuonEtaRange& operator=(const MuonEtaRange&);
-    inline float min() const { return theMin; }
-    inline float max() const { return theMax; }
-    bool isInside(float eta, float error=0.) const;
-    bool isInside(const MuonEtaRange& range) const;
-    bool isCompatible(const MuonEtaRange& range) const;
-    MuonEtaRange add(const MuonEtaRange&) const;
-    MuonEtaRange minRange(const MuonEtaRange&) const;
-    MuonEtaRange subtract(const MuonEtaRange&) const;
-  private:
-
-    float theMin;
-    float theMax;
+private:
+  float theMin;
+  float theMax;
 };
 #include <iostream>
-inline std::ostream& operator<<(std::ostream& os, const MuonEtaRange& range)
-{
-  os << "(" << range.min() << " : " << range.max() << ")" ;
+inline std::ostream& operator<<(std::ostream& os, const MuonEtaRange& range) {
+  os << "(" << range.min() << " : " << range.max() << ")";
   return os;
 }
 
-#endif 
+#endif

--- a/RecoMuon/Navigation/interface/MuonForwardNavigableLayer.h
+++ b/RecoMuon/Navigation/interface/MuonForwardNavigableLayer.h
@@ -31,103 +31,83 @@ class ForwardDetLayer;
 /* Class MuonForwardNavigableLayer Interface */
 
 class MuonForwardNavigableLayer : public MuonNavigableLayer {
+public:
+  MuonForwardNavigableLayer(const ForwardDetLayer* fdl,
+                            const MapB& innerBarrel,
+                            const MapE& outerEndcap,
+                            const MapE& innerEndcap,
+                            const MapB& allInnerBarrel,
+                            const MapE& allOuterEndcap,
+                            const MapE& allInnerEndcap)
+      : theDetLayer(fdl),
+        theInnerBarrelLayers(innerBarrel),
+        theOuterEndcapLayers(outerEndcap),
+        theInnerEndcapLayers(innerEndcap),
+        theAllInnerBarrelLayers(allInnerBarrel),
+        theAllOuterEndcapLayers(allOuterEndcap),
+        theAllInnerEndcapLayers(allInnerEndcap) {}
 
-  public:
+  /// Constructor with outer layers only
+  MuonForwardNavigableLayer(const ForwardDetLayer* fdl, const MapE& outerEndcap)
+      : theDetLayer(fdl), theOuterEndcapLayers(outerEndcap) {}
+  /// Constructor with all outer layers only
+  MuonForwardNavigableLayer(const ForwardDetLayer* fdl, const MapE& outerEndcap, const MapE& allOuterEndcap)
+      : theDetLayer(fdl), theOuterEndcapLayers(outerEndcap), theAllOuterEndcapLayers(allOuterEndcap) {}
 
-    MuonForwardNavigableLayer(const ForwardDetLayer* fdl,
-                              const MapB& innerBarrel, 
-                              const MapE& outerEndcap,
-                              const MapE& innerEndcap,
-                              const MapB& allInnerBarrel,
-                              const MapE& allOuterEndcap,
-                              const MapE& allInnerEndcap) :
-      theDetLayer(fdl),
-      theInnerBarrelLayers(innerBarrel),
-      theOuterEndcapLayers(outerEndcap),
-      theInnerEndcapLayers(innerEndcap),
-      theAllInnerBarrelLayers(allInnerBarrel), 
-      theAllOuterEndcapLayers(allOuterEndcap),
-      theAllInnerEndcapLayers(allInnerEndcap)  {}
+  /// NavigableLayer interface
+  std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const override;
 
-    /// Constructor with outer layers only
-    MuonForwardNavigableLayer(const ForwardDetLayer* fdl,
-                              const MapE& outerEndcap) :
-      theDetLayer(fdl),
-      theOuterEndcapLayers(outerEndcap) {}
-    /// Constructor with all outer layers only
-    MuonForwardNavigableLayer(const ForwardDetLayer* fdl,
-                              const MapE& outerEndcap, 
-                              const MapE& allOuterEndcap) :
-      theDetLayer(fdl),
-      theOuterEndcapLayers(outerEndcap),
-      theAllOuterEndcapLayers(allOuterEndcap) {}
+  /// NavigableLayer interface
+  std::vector<const DetLayer*> nextLayers(const FreeTrajectoryState& fts, PropagationDirection dir) const override;
 
+  std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const override;
 
-    /// NavigableLayer interface
-    std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const override;
+  /// NavigableLayer interface
+  std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
+                                                PropagationDirection dir) const override;
+  /// return DetLayer
+  const DetLayer* detLayer() const override;
 
-    /// NavigableLayer interface
-    std::vector<const DetLayer*> nextLayers(const FreeTrajectoryState& fts, 
-                                               PropagationDirection dir) const override;
+  /// set DetLayer
+  void setDetLayer(const DetLayer*) override;
 
-    std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const override;
+  /// Operations
+  MapE getOuterEndcapLayers() const { return theOuterEndcapLayers; }
+  MapE getInnerEndcapLayers() const { return theInnerEndcapLayers; }
+  MapB getInnerBarrelLayers() const { return theInnerBarrelLayers; }
 
-    /// NavigableLayer interface
-    std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
-                                               PropagationDirection dir) const override;
-    /// return DetLayer
-    const DetLayer* detLayer() const override;
+  MapE getAllOuterEndcapLayers() const { return theAllOuterEndcapLayers; }
+  MapE getAllInnerEndcapLayers() const { return theAllInnerEndcapLayers; }
+  MapB getAllInnerBarrelLayers() const { return theAllInnerBarrelLayers; }
 
-    /// set DetLayer
-    void setDetLayer(const DetLayer*) override;
+  /// set inward links
+  void setInwardLinks(const MapB&, const MapE&);
+  void setInwardCompatibleLinks(const MapB&, const MapE&);
 
-    /// Operations
-    MapE getOuterEndcapLayers() const { return theOuterEndcapLayers; }
-    MapE getInnerEndcapLayers() const { return theInnerEndcapLayers; }
-    MapB getInnerBarrelLayers() const { return theInnerBarrelLayers; }
+private:
+  void pushResult(std::vector<const DetLayer*>& result, const MapB& map) const;
 
-    MapE getAllOuterEndcapLayers() const { return theAllOuterEndcapLayers; }
-    MapE getAllInnerEndcapLayers() const { return theAllInnerEndcapLayers; }
-    MapB getAllInnerBarrelLayers() const { return theAllInnerBarrelLayers; }
+  void pushResult(std::vector<const DetLayer*>& result, const MapE& map) const;
 
-    /// set inward links
-    void setInwardLinks(const MapB&, const MapE&);
-    void setInwardCompatibleLinks(const MapB&, const MapE&);
+  void pushResult(std::vector<const DetLayer*>& result, const MapB& map, const FreeTrajectoryState& fts) const;
 
-  private:
+  void pushResult(std::vector<const DetLayer*>& result, const MapE& map, const FreeTrajectoryState& fts) const;
 
-    void pushResult(std::vector<const DetLayer*>& result, 
-                    const MapB& map) const;
+  void pushCompatibleResult(std::vector<const DetLayer*>& result,
+                            const MapB& map,
+                            const FreeTrajectoryState& fts) const;
 
-    void pushResult(std::vector<const DetLayer*>& result,
-                     const MapE& map) const;
+  void pushCompatibleResult(std::vector<const DetLayer*>& result,
+                            const MapE& map,
+                            const FreeTrajectoryState& fts) const;
 
-    void pushResult(std::vector<const DetLayer*>& result, 
-                    const MapB& map, 
-                    const FreeTrajectoryState& fts) const;
-
-    void pushResult(std::vector<const DetLayer*>& result, 
-                    const MapE& map, const
-                    FreeTrajectoryState& fts) const;
-
-    void pushCompatibleResult(std::vector<const DetLayer*>& result,
-                    const MapB& map, const
-                    FreeTrajectoryState& fts) const;
-
-    void pushCompatibleResult(std::vector<const DetLayer*>& result,
-                    const MapE& map, const
-                    FreeTrajectoryState& fts) const;
-
-
-  private:
-
-    const ForwardDetLayer* theDetLayer;
-    MapB theInnerBarrelLayers;
-    MapE theOuterEndcapLayers;
-    MapE theInnerEndcapLayers;
-    MapB theAllInnerBarrelLayers;
-    MapE theAllOuterEndcapLayers;
-    MapE theAllInnerEndcapLayers;
-
+private:
+  const ForwardDetLayer* theDetLayer;
+  MapB theInnerBarrelLayers;
+  MapE theOuterEndcapLayers;
+  MapE theInnerEndcapLayers;
+  MapB theAllInnerBarrelLayers;
+  MapE theAllOuterEndcapLayers;
+  MapE theAllInnerEndcapLayers;
 };
 #endif

--- a/RecoMuon/Navigation/interface/MuonNavigableLayer.h
+++ b/RecoMuon/Navigation/interface/MuonNavigableLayer.h
@@ -22,33 +22,28 @@ class BarrelDetLayer;
 
 #include "TrackingTools/DetLayers/interface/NavigableLayer.h"
 
-
 class MuonNavigableLayer : public NavigableLayer {
+public:
+  /// NavigableLayer interface
+  std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const override = 0;
 
-  public:
+  /// NavigableLayer interface
+  std::vector<const DetLayer*> nextLayers(const FreeTrajectoryState& fts, PropagationDirection dir) const override = 0;
 
-    /// NavigableLayer interface
-    std::vector<const DetLayer*> nextLayers(NavigationDirection dir) const override =0;
+  std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const override = 0;
 
-    /// NavigableLayer interface
-    std::vector<const DetLayer*> nextLayers(const FreeTrajectoryState& fts, 
-                                               PropagationDirection dir) const override =0;
+  /// NavigableLayer interface
+  std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
+                                                PropagationDirection dir) const override = 0;
 
-    std::vector<const DetLayer*> compatibleLayers(NavigationDirection dir) const override =0;
+  /// return DetLayer
+  const DetLayer* detLayer() const override = 0;
 
-    /// NavigableLayer interface
-    std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
-                                               PropagationDirection dir) const override =0;
+  /// set DetLayer
+  void setDetLayer(const DetLayer*) override = 0;
 
-    /// return DetLayer
-    const DetLayer* detLayer() const override =0;
+  MuonEtaRange trackingRange(const FreeTrajectoryState& fts) const;
 
-    /// set DetLayer
-    void setDetLayer(const DetLayer*) override =0;
-
-    MuonEtaRange trackingRange(const FreeTrajectoryState& fts) const;
-
-    bool isInsideOut(const FreeTrajectoryState& fts) const;
-
+  bool isInsideOut(const FreeTrajectoryState& fts) const;
 };
 #endif

--- a/RecoMuon/Navigation/interface/MuonNavigationPrinter.h
+++ b/RecoMuon/Navigation/interface/MuonNavigationPrinter.h
@@ -31,21 +31,23 @@ class MuonNavigationSchool;
 #include <string>
 
 class MuonNavigationPrinter {
-  public:
+public:
+  MuonNavigationPrinter(const MuonDetLayerGeometry *,
+                        MuonNavigationSchool const &,
+                        bool enableRPC = true,
+                        bool enableCSC = true,
+                        bool enableGEM = false,
+                        bool enableME0 = false);
+  MuonNavigationPrinter(const MuonDetLayerGeometry *, MuonNavigationSchool const &, const GeometricSearchTracker *);
 
-  MuonNavigationPrinter(const MuonDetLayerGeometry *, MuonNavigationSchool const &, bool enableRPC = true, bool enableCSC = true, bool enableGEM = false, bool enableME0 = false );
-  MuonNavigationPrinter(const MuonDetLayerGeometry *,MuonNavigationSchool const &, const GeometricSearchTracker *);
+private:
+  void printLayer(const DetLayer *) const;
+  void printLayers(const std::vector<const DetLayer *> &) const;
+  /// return detector part (barrel, forward, backward)
+  //    std::string layerPart(const DetLayer*) const;
+  /// return detector module (pixel, silicon, msgc, dt, csc, rpc)
+  //    std::string layerModule(const DetLayer*) const;
 
-  private:
-    void printLayer(const DetLayer*) const;
-    void printLayers(const std::vector<const DetLayer*>&) const;
-    /// return detector part (barrel, forward, backward)
-//    std::string layerPart(const DetLayer*) const;
-    /// return detector module (pixel, silicon, msgc, dt, csc, rpc)
-//    std::string layerModule(const DetLayer*) const;
-
-
-  MuonNavigationSchool const * school=nullptr;
-
+  MuonNavigationSchool const *school = nullptr;
 };
 #endif

--- a/RecoMuon/Navigation/interface/MuonNavigationSchool.h
+++ b/RecoMuon/Navigation/interface/MuonNavigationSchool.h
@@ -23,7 +23,6 @@
  * ME0s implementation.
  */
 
-
 #include "RecoMuon/Navigation/interface/MuonDetLayerMap.h"
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 #include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
@@ -37,51 +36,50 @@ class BarrelDetLayer;
 class ForwardDetLayer;
 
 class MuonNavigationSchool : public NavigationSchool {
+public:
+  ///Constructor
+  MuonNavigationSchool(const MuonDetLayerGeometry*,
+                       bool enableRPC = true,
+                       bool enableCSC = true,
+                       bool enableGEM = false,
+                       bool enableME0 = false);
+  /// Destructor
+  ~MuonNavigationSchool() override;
+  /// return navigable layers, from base class
+  StateType navigableLayers() override;
 
-  public:
-    ///Constructor
-    MuonNavigationSchool(const MuonDetLayerGeometry *, bool enableRPC = true, bool enableCSC = true, bool enableGEM = false, bool enableME0 = false);
-    /// Destructor
-    ~MuonNavigationSchool() override;
-    /// return navigable layers, from base class
-    StateType navigableLayers() override;
-  private:
-    /// add barrel layer
-    void addBarrelLayer(const BarrelDetLayer*);
-    /// add endcap layer (backward and forward)
-    void addEndcapLayer(const ForwardDetLayer*);
-    /// link barrel layers
-    void linkBarrelLayers();
-    /// link endcap layers
-    void linkEndcapLayers(const MapE&,std::vector<MuonForwardNavigableLayer*>&);
-    /// establish inward links
-    void createInverseLinks();
-    float calculateEta(const float&, const float& ) const;
+private:
+  /// add barrel layer
+  void addBarrelLayer(const BarrelDetLayer*);
+  /// add endcap layer (backward and forward)
+  void addEndcapLayer(const ForwardDetLayer*);
+  /// link barrel layers
+  void linkBarrelLayers();
+  /// link endcap layers
+  void linkEndcapLayers(const MapE&, std::vector<MuonForwardNavigableLayer*>&);
+  /// establish inward links
+  void createInverseLinks();
+  float calculateEta(const float&, const float&) const;
 
-  private: 
-  
-    struct delete_layer
-    {
-      template <typename T>
-      void operator()(T*& p)
-      {
-        if( p)
-        {
-          delete p;
-          p = nullptr;
-        }
+private:
+  struct delete_layer {
+    template <typename T>
+    void operator()(T*& p) {
+      if (p) {
+        delete p;
+        p = nullptr;
       }
-    };
+    }
+  };
 
-    MapB theBarrelLayers;    /// barrel
-    MapE theForwardLayers;   /// +z endcap
-    MapE theBackwardLayers;  /// -z endcap 
+  MapB theBarrelLayers;    /// barrel
+  MapE theForwardLayers;   /// +z endcap
+  MapE theBackwardLayers;  /// -z endcap
 
-    std::vector<MuonBarrelNavigableLayer*> theBarrelNLC;
-    std::vector<MuonForwardNavigableLayer*> theForwardNLC;
-    std::vector<MuonForwardNavigableLayer*> theBackwardNLC;
+  std::vector<MuonBarrelNavigableLayer*> theBarrelNLC;
+  std::vector<MuonForwardNavigableLayer*> theForwardNLC;
+  std::vector<MuonForwardNavigableLayer*> theBackwardNLC;
 
-    const MuonDetLayerGeometry * theMuonDetLayerGeometry; 
-  
+  const MuonDetLayerGeometry* theMuonDetLayerGeometry;
 };
 #endif

--- a/RecoMuon/Navigation/src/DirectMuonNavigation.cc
+++ b/RecoMuon/Navigation/src/DirectMuonNavigation.cc
@@ -16,19 +16,19 @@
 
 using namespace std;
 
-DirectMuonNavigation::DirectMuonNavigation(const edm::ESHandle<MuonDetLayerGeometry>& muonLayout) : theMuonDetLayerGeometry(muonLayout), epsilon_(100.), theEndcapFlag(true), theBarrelFlag(true) {
-}
+DirectMuonNavigation::DirectMuonNavigation(const edm::ESHandle<MuonDetLayerGeometry>& muonLayout)
+    : theMuonDetLayerGeometry(muonLayout), epsilon_(100.), theEndcapFlag(true), theBarrelFlag(true) {}
 
-DirectMuonNavigation::DirectMuonNavigation(const edm::ESHandle<MuonDetLayerGeometry>& muonLayout, const edm::ParameterSet& par) : theMuonDetLayerGeometry(muonLayout), epsilon_(100.), theEndcapFlag(par.getParameter<bool>("Endcap")), theBarrelFlag(par.getParameter<bool>("Barrel")) {
+DirectMuonNavigation::DirectMuonNavigation(const edm::ESHandle<MuonDetLayerGeometry>& muonLayout,
+                                           const edm::ParameterSet& par)
+    : theMuonDetLayerGeometry(muonLayout),
+      epsilon_(100.),
+      theEndcapFlag(par.getParameter<bool>("Endcap")),
+      theBarrelFlag(par.getParameter<bool>("Barrel")) {}
 
-}
-
-
-/* return compatible layers for given trajectory state  */ 
-vector<const DetLayer*> 
-DirectMuonNavigation::compatibleLayers( const FreeTrajectoryState& fts,
-                                        PropagationDirection dir ) const {
-
+/* return compatible layers for given trajectory state  */
+vector<const DetLayer*> DirectMuonNavigation::compatibleLayers(const FreeTrajectoryState& fts,
+                                                               PropagationDirection dir) const {
   float z0 = fts.position().z();
   float zm = fts.momentum().z();
 
@@ -38,37 +38,50 @@ DirectMuonNavigation::compatibleLayers( const FreeTrajectoryState& fts,
 
   // check direction and position of FTS to get a correct order of DetLayers
 
-  if (inOut) { 
-     if ((zm * z0) >= 0) {
-        if (theBarrelFlag) inOutBarrel(fts,output);
-        if (theEndcapFlag) {
-           if ( z0 >= 0 ) inOutForward(fts,output);
-           else inOutBackward(fts,output);
-        } 
-      } else {
-        if (theEndcapFlag) {
-        if ( z0 >= 0 ) outInForward(fts,output);
-           else outInBackward(fts,output);
-        }
-        if (theBarrelFlag) inOutBarrel(fts,output);
-      } 
-   } else {
-     if ((zm * z0) >= 0) {
-        if (theBarrelFlag) outInBarrel(fts,output);
-        if (theEndcapFlag) {
-          if ( z0 >= 0 ) inOutForward(fts,output);
-          else inOutBackward(fts,output);
-        }
-      } else {
-        if (theEndcapFlag) {
-          if ( z0 >= 0 ) outInForward(fts,output);
-          else outInBackward(fts,output);
-        }
-        if (theBarrelFlag) outInBarrel(fts,output);
-      } 
-   }
+  if (inOut) {
+    if ((zm * z0) >= 0) {
+      if (theBarrelFlag)
+        inOutBarrel(fts, output);
+      if (theEndcapFlag) {
+        if (z0 >= 0)
+          inOutForward(fts, output);
+        else
+          inOutBackward(fts, output);
+      }
+    } else {
+      if (theEndcapFlag) {
+        if (z0 >= 0)
+          outInForward(fts, output);
+        else
+          outInBackward(fts, output);
+      }
+      if (theBarrelFlag)
+        inOutBarrel(fts, output);
+    }
+  } else {
+    if ((zm * z0) >= 0) {
+      if (theBarrelFlag)
+        outInBarrel(fts, output);
+      if (theEndcapFlag) {
+        if (z0 >= 0)
+          inOutForward(fts, output);
+        else
+          inOutBackward(fts, output);
+      }
+    } else {
+      if (theEndcapFlag) {
+        if (z0 >= 0)
+          outInForward(fts, output);
+        else
+          outInBackward(fts, output);
+      }
+      if (theBarrelFlag)
+        outInBarrel(fts, output);
+    }
+  }
 
-  if ( dir == oppositeToMomentum ) std::reverse(output.begin(),output.end());
+  if (dir == oppositeToMomentum)
+    std::reverse(output.begin(), output.end());
 
   return output;
 }
@@ -77,78 +90,72 @@ DirectMuonNavigation::compatibleLayers( const FreeTrajectoryState& fts,
 return compatible endcap layers on BOTH ends;
 used for beam-halo muons
 */
-vector<const DetLayer*> 
-DirectMuonNavigation::compatibleEndcapLayers( const FreeTrajectoryState& fts,
-                                              PropagationDirection dir ) const {
-
+vector<const DetLayer*> DirectMuonNavigation::compatibleEndcapLayers(const FreeTrajectoryState& fts,
+                                                                     PropagationDirection dir) const {
   float zm = fts.momentum().z();
 
   vector<const DetLayer*> output;
 
   // collect all endcap layers on 2 sides
-  outInBackward(fts,output);
-  inOutForward(fts,output);
+  outInBackward(fts, output);
+  inOutForward(fts, output);
 
   // check direction FTS to get a correct order of DetLayers
-  if ( ( zm > 0 && dir == oppositeToMomentum ) || 
-       ( zm < 0 && dir == alongMomentum )  )
-           std::reverse(output.begin(),output.end());
+  if ((zm > 0 && dir == oppositeToMomentum) || (zm < 0 && dir == alongMomentum))
+    std::reverse(output.begin(), output.end());
 
   return output;
 }
 
 void DirectMuonNavigation::inOutBarrel(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
   bool cont = false;
   const vector<const DetLayer*>& barrel = theMuonDetLayerGeometry->allBarrelLayers();
 
-  for (vector<const DetLayer*>::const_iterator iter_B = barrel.begin(); iter_B != barrel.end(); iter_B++){
-
-      if( cont ) output.push_back((*iter_B));
-      else if ( checkCompatible(fts,dynamic_cast<const BarrelDetLayer*>(*iter_B))) {
+  for (vector<const DetLayer*>::const_iterator iter_B = barrel.begin(); iter_B != barrel.end(); iter_B++) {
+    if (cont)
+      output.push_back((*iter_B));
+    else if (checkCompatible(fts, dynamic_cast<const BarrelDetLayer*>(*iter_B))) {
       output.push_back((*iter_B));
       cont = true;
-      }
+    }
   }
 }
 
-
 void DirectMuonNavigation::outInBarrel(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
-// default barrel layers are in out, reverse order 
+  // default barrel layers are in out, reverse order
   const vector<const DetLayer*>& barrel = theMuonDetLayerGeometry->allBarrelLayers();
 
   bool cont = false;
-  vector<const DetLayer*>::const_iterator rbegin = barrel.end(); 
+  vector<const DetLayer*>::const_iterator rbegin = barrel.end();
   rbegin--;
   vector<const DetLayer*>::const_iterator rend = barrel.begin();
   rend--;
 
-  for (vector<const DetLayer*>::const_iterator iter_B = rbegin; iter_B != rend; iter_B--){
-      if( cont ) output.push_back((*iter_B));
-      else if ( checkCompatible(fts,dynamic_cast<const BarrelDetLayer*>(*iter_B))) {
+  for (vector<const DetLayer*>::const_iterator iter_B = rbegin; iter_B != rend; iter_B--) {
+    if (cont)
+      output.push_back((*iter_B));
+    else if (checkCompatible(fts, dynamic_cast<const BarrelDetLayer*>(*iter_B))) {
       output.push_back((*iter_B));
       cont = true;
-      }
+    }
   }
 }
 
 void DirectMuonNavigation::inOutForward(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
   const vector<const DetLayer*>& forward = theMuonDetLayerGeometry->allForwardLayers();
   bool cont = false;
-  for (vector<const DetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); 
-	 iter_E++){
-      if( cont ) output.push_back((*iter_E));
-      else if ( checkCompatible(fts,dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
-	output.push_back((*iter_E));
-	cont = true;
-      }
+  for (vector<const DetLayer*>::const_iterator iter_E = forward.begin(); iter_E != forward.end(); iter_E++) {
+    if (cont)
+      output.push_back((*iter_E));
+    else if (checkCompatible(fts, dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
+      output.push_back((*iter_E));
+      cont = true;
     }
+  }
 }
 
 void DirectMuonNavigation::outInForward(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-// default forward layers are in out, reverse order
+  // default forward layers are in out, reverse order
 
   bool cont = false;
   const vector<const DetLayer*>& forward = theMuonDetLayerGeometry->allForwardLayers();
@@ -156,32 +163,31 @@ void DirectMuonNavigation::outInForward(const FreeTrajectoryState& fts, vector<c
   rbegin--;
   vector<const DetLayer*>::const_iterator rend = forward.begin();
   rend--;
-  for (vector<const DetLayer*>::const_iterator iter_E = rbegin; iter_E != rend;
-         iter_E--){
-      if( cont ) output.push_back((*iter_E));
-      else if ( checkCompatible(fts,dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
-        output.push_back((*iter_E));
-        cont = true;
-      }
+  for (vector<const DetLayer*>::const_iterator iter_E = rbegin; iter_E != rend; iter_E--) {
+    if (cont)
+      output.push_back((*iter_E));
+    else if (checkCompatible(fts, dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
+      output.push_back((*iter_E));
+      cont = true;
     }
+  }
 }
 
 void DirectMuonNavigation::inOutBackward(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
   bool cont = false;
   const vector<const DetLayer*>& backward = theMuonDetLayerGeometry->allBackwardLayers();
 
-  for (vector<const DetLayer*>::const_iterator iter_E = backward.begin(); iter_E != backward.end(); 
-       iter_E++){
-      if( cont ) output.push_back((*iter_E));
-      else if ( checkCompatible(fts,dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
-	output.push_back((*iter_E));
-	cont = true;
-      }
-   }
+  for (vector<const DetLayer*>::const_iterator iter_E = backward.begin(); iter_E != backward.end(); iter_E++) {
+    if (cont)
+      output.push_back((*iter_E));
+    else if (checkCompatible(fts, dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
+      output.push_back((*iter_E));
+      cont = true;
+    }
+  }
 }
 
 void DirectMuonNavigation::outInBackward(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
   bool cont = false;
   const vector<const DetLayer*>& backward = theMuonDetLayerGeometry->allBackwardLayers();
 
@@ -189,44 +195,41 @@ void DirectMuonNavigation::outInBackward(const FreeTrajectoryState& fts, vector<
   rbegin--;
   vector<const DetLayer*>::const_iterator rend = backward.begin();
   rend--;
-  for (vector<const DetLayer*>::const_iterator iter_E = rbegin; iter_E != rend;
-       iter_E--){
-      if( cont ) output.push_back((*iter_E));
-      else if ( checkCompatible(fts,dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
-        output.push_back((*iter_E));
-        cont = true;
-      }
-   }
-
+  for (vector<const DetLayer*>::const_iterator iter_E = rbegin; iter_E != rend; iter_E--) {
+    if (cont)
+      output.push_back((*iter_E));
+    else if (checkCompatible(fts, dynamic_cast<const ForwardDetLayer*>(*iter_E))) {
+      output.push_back((*iter_E));
+      cont = true;
+    }
+  }
 }
 
-
-bool DirectMuonNavigation::checkCompatible(const FreeTrajectoryState& fts,const BarrelDetLayer* dl) const {
-
+bool DirectMuonNavigation::checkCompatible(const FreeTrajectoryState& fts, const BarrelDetLayer* dl) const {
   float z0 = fts.position().z();
   float r0 = fts.position().perp();
   float zm = fts.momentum().z();
   float rm = fts.momentum().perp();
-  float slope = zm/rm; 
-  if (!outward(fts) ) slope = -slope;
+  float slope = zm / rm;
+  if (!outward(fts))
+    slope = -slope;
   const BoundCylinder& bc = dl->specificSurface();
   float radius = bc.radius();
-  float length = bc.bounds().length()/2.;
+  float length = bc.bounds().length() / 2.;
 
-  float z1 = slope*(radius - r0) + z0;
-  return ( fabs(z1) <= fabs(length)+epsilon_ );
-
+  float z1 = slope * (radius - r0) + z0;
+  return (fabs(z1) <= fabs(length) + epsilon_);
 }
 
-bool DirectMuonNavigation::checkCompatible(const FreeTrajectoryState& fts,const ForwardDetLayer* dl) const {
-
+bool DirectMuonNavigation::checkCompatible(const FreeTrajectoryState& fts, const ForwardDetLayer* dl) const {
   float z0 = fts.position().z();
   float r0 = fts.position().perp();
   float zm = fts.momentum().z();
   float rm = fts.momentum().perp();
-  float slope = rm/zm; 
+  float slope = rm / zm;
 
-  if (!outward(fts) ) slope = -slope;
+  if (!outward(fts))
+    slope = -slope;
 
   const BoundDisk& bd = dl->specificSurface();
 
@@ -234,14 +237,12 @@ bool DirectMuonNavigation::checkCompatible(const FreeTrajectoryState& fts,const 
   float inRadius = bd.innerRadius();
   float z = bd.position().z();
 
-  float r1 = slope*(z - z0) + r0;
-  return (r1 >= inRadius-epsilon_ && r1 <= outRadius+epsilon_);
-
+  float r1 = slope * (z - z0) + r0;
+  return (r1 >= inRadius - epsilon_ && r1 <= outRadius + epsilon_);
 }
 
 bool DirectMuonNavigation::outward(const FreeTrajectoryState& fts) const {
- 
-//  return (fts.position().basicVector().dot(fts.momentum().basicVector())>0);
+  //  return (fts.position().basicVector().dot(fts.momentum().basicVector())>0);
 
   float x0 = fts.position().x();
   float y0 = fts.position().y();
@@ -249,7 +250,5 @@ bool DirectMuonNavigation::outward(const FreeTrajectoryState& fts) const {
   float xm = fts.momentum().x();
   float ym = fts.momentum().y();
 
-  return ((x0 * xm + y0 * ym ) > 0);
-
-
+  return ((x0 * xm + y0 * ym) > 0);
 }

--- a/RecoMuon/Navigation/src/MuonBarrelNavigableLayer.cc
+++ b/RecoMuon/Navigation/src/MuonBarrelNavigableLayer.cc
@@ -26,43 +26,35 @@
 #include <algorithm>
 
 using namespace std;
-std::vector<const DetLayer*> 
-MuonBarrelNavigableLayer::nextLayers(NavigationDirection dir) const {
-  
+std::vector<const DetLayer*> MuonBarrelNavigableLayer::nextLayers(NavigationDirection dir) const {
   std::vector<const DetLayer*> result;
-  
-  if ( dir == insideOut ) {
+
+  if (dir == insideOut) {
     pushResult(result, theOuterBarrelLayers);
     pushResult(result, theOuterBackwardLayers);
     pushResult(result, theOuterForwardLayers);
-  }
-  else {
+  } else {
     pushResult(result, theInnerBarrelLayers);
-    reverse(result.begin(),result.end());
+    reverse(result.begin(), result.end());
     pushResult(result, theInnerBackwardLayers);
     pushResult(result, theInnerForwardLayers);
   }
-  
+
   result.reserve(result.size());
   return result;
-
 }
 
-
-std::vector<const DetLayer*> 
-MuonBarrelNavigableLayer::nextLayers(const FreeTrajectoryState& fts,
-                                     PropagationDirection dir) const {
-
+std::vector<const DetLayer*> MuonBarrelNavigableLayer::nextLayers(const FreeTrajectoryState& fts,
+                                                                  PropagationDirection dir) const {
   std::vector<const DetLayer*> result;
 
-  if ( (isInsideOut(fts) && dir == alongMomentum) || ( !isInsideOut(fts) && dir == oppositeToMomentum)) {
+  if ((isInsideOut(fts) && dir == alongMomentum) || (!isInsideOut(fts) && dir == oppositeToMomentum)) {
     pushResult(result, theOuterBarrelLayers, fts);
     pushResult(result, theOuterBackwardLayers, fts);
     pushResult(result, theOuterForwardLayers, fts);
-  }
-  else {
+  } else {
     pushResult(result, theInnerBarrelLayers, fts);
-    reverse(result.begin(),result.end());
+    reverse(result.begin(), result.end());
     pushResult(result, theInnerBackwardLayers, fts);
     pushResult(result, theInnerForwardLayers, fts);
   }
@@ -70,19 +62,16 @@ MuonBarrelNavigableLayer::nextLayers(const FreeTrajectoryState& fts,
   return result;
 }
 
-std::vector<const DetLayer*>
-MuonBarrelNavigableLayer::compatibleLayers(NavigationDirection dir) const {
-
+std::vector<const DetLayer*> MuonBarrelNavigableLayer::compatibleLayers(NavigationDirection dir) const {
   std::vector<const DetLayer*> result;
 
-  if ( dir == insideOut ) {
+  if (dir == insideOut) {
     pushResult(result, theAllOuterBarrelLayers);
     pushResult(result, theAllOuterBackwardLayers);
     pushResult(result, theAllOuterForwardLayers);
-  }
-  else {
+  } else {
     pushResult(result, theAllInnerBarrelLayers);
-    reverse(result.begin(),result.end());
+    reverse(result.begin(), result.end());
     pushResult(result, theAllInnerBackwardLayers);
     pushResult(result, theAllInnerForwardLayers);
   }
@@ -91,91 +80,73 @@ MuonBarrelNavigableLayer::compatibleLayers(NavigationDirection dir) const {
   return result;
 }
 
-std::vector<const DetLayer*>
-MuonBarrelNavigableLayer::compatibleLayers(const FreeTrajectoryState& fts,
-                                     PropagationDirection dir) const {
+std::vector<const DetLayer*> MuonBarrelNavigableLayer::compatibleLayers(const FreeTrajectoryState& fts,
+                                                                        PropagationDirection dir) const {
   std::vector<const DetLayer*> result;
 
-  if ( (isInsideOut(fts) && dir == alongMomentum) || ( !isInsideOut(fts) && dir == oppositeToMomentum)) {
+  if ((isInsideOut(fts) && dir == alongMomentum) || (!isInsideOut(fts) && dir == oppositeToMomentum)) {
     pushCompatibleResult(result, theAllOuterBarrelLayers, fts);
     pushCompatibleResult(result, theAllOuterBackwardLayers, fts);
     pushCompatibleResult(result, theAllOuterForwardLayers, fts);
-  }
-  else {
+  } else {
     pushCompatibleResult(result, theAllInnerBarrelLayers, fts);
-    reverse(result.begin(),result.end());
+    reverse(result.begin(), result.end());
     pushCompatibleResult(result, theAllInnerBackwardLayers, fts);
     pushCompatibleResult(result, theAllInnerForwardLayers, fts);
   }
   result.reserve(result.size());
   return result;
-
 }
 
-
-void MuonBarrelNavigableLayer::pushResult(std::vector<const DetLayer*>& result,
-                                          const MapB& map) const {
-
-  for ( MapBI i = map.begin(); i != map.end(); i++ ) result.push_back((*i).first); 
-
+void MuonBarrelNavigableLayer::pushResult(std::vector<const DetLayer*>& result, const MapB& map) const {
+  for (MapBI i = map.begin(); i != map.end(); i++)
+    result.push_back((*i).first);
 }
 
-void MuonBarrelNavigableLayer::pushResult(std::vector<const DetLayer*>& result,
-                                          const MapE& map) const {
-
-  for ( MapEI i = map.begin(); i != map.end(); i++ ) result.push_back((*i).first);  
-}
-
-
-void MuonBarrelNavigableLayer::pushResult(std::vector<const DetLayer*>& result,
-                                          const MapB& map, 
-                                          const FreeTrajectoryState& fts) const {
-  for ( MapBI i = map.begin(); i != map.end(); i++ ) 
-    if ((*i).second.isInside(fts.position().eta())) result.push_back((*i).first); 
-}
-
-void MuonBarrelNavigableLayer::pushResult(std::vector<const DetLayer*>& result,
-                                          const MapE& map, 
-                                          const FreeTrajectoryState& fts) const {
-
+void MuonBarrelNavigableLayer::pushResult(std::vector<const DetLayer*>& result, const MapE& map) const {
   for (MapEI i = map.begin(); i != map.end(); i++)
-    if ((*i).second.isInside(fts.position().eta())) result.push_back((*i).first); 
-
+    result.push_back((*i).first);
 }
 
-void MuonBarrelNavigableLayer::pushCompatibleResult(std::vector<const DetLayer*>& result,
+void MuonBarrelNavigableLayer::pushResult(std::vector<const DetLayer*>& result,
                                           const MapB& map,
                                           const FreeTrajectoryState& fts) const {
-  MuonEtaRange range= trackingRange(fts);
-  for ( MapBI i = map.begin(); i != map.end(); i++ )
-    if ((*i).second.isCompatible(range)) result.push_back((*i).first);
+  for (MapBI i = map.begin(); i != map.end(); i++)
+    if ((*i).second.isInside(fts.position().eta()))
+      result.push_back((*i).first);
+}
+
+void MuonBarrelNavigableLayer::pushResult(std::vector<const DetLayer*>& result,
+                                          const MapE& map,
+                                          const FreeTrajectoryState& fts) const {
+  for (MapEI i = map.begin(); i != map.end(); i++)
+    if ((*i).second.isInside(fts.position().eta()))
+      result.push_back((*i).first);
 }
 
 void MuonBarrelNavigableLayer::pushCompatibleResult(std::vector<const DetLayer*>& result,
-                                          const MapE& map,
-                                          const FreeTrajectoryState& fts) const {
-  MuonEtaRange range= trackingRange(fts);
+                                                    const MapB& map,
+                                                    const FreeTrajectoryState& fts) const {
+  MuonEtaRange range = trackingRange(fts);
+  for (MapBI i = map.begin(); i != map.end(); i++)
+    if ((*i).second.isCompatible(range))
+      result.push_back((*i).first);
+}
+
+void MuonBarrelNavigableLayer::pushCompatibleResult(std::vector<const DetLayer*>& result,
+                                                    const MapE& map,
+                                                    const FreeTrajectoryState& fts) const {
+  MuonEtaRange range = trackingRange(fts);
   for (MapEI i = map.begin(); i != map.end(); i++)
-    if ((*i).second.isCompatible(range)) result.push_back((*i).first);
-
+    if ((*i).second.isCompatible(range))
+      result.push_back((*i).first);
 }
 
-const DetLayer* MuonBarrelNavigableLayer::detLayer() const {
-  return theDetLayer;
-}
-
+const DetLayer* MuonBarrelNavigableLayer::detLayer() const { return theDetLayer; }
 
 void MuonBarrelNavigableLayer::setDetLayer(const DetLayer* dl) {
   edm::LogError("MuonBarrelNavigableLayer") << "MuonBarrelNavigableLayer::setDetLayer called!! " << endl;
 }
 
-
-void MuonBarrelNavigableLayer::setInwardLinks(const MapB& innerBL) {
-  theInnerBarrelLayers = innerBL;
-}
-void MuonBarrelNavigableLayer::setInwardCompatibleLinks(const MapB& innerCBL) {
-
-  theAllInnerBarrelLayers = innerCBL;
-
-}
-
+void MuonBarrelNavigableLayer::setInwardLinks(const MapB& innerBL) { theInnerBarrelLayers = innerBL; }
+void MuonBarrelNavigableLayer::setInwardCompatibleLinks(const MapB& innerCBL) { theAllInnerBarrelLayers = innerCBL; }

--- a/RecoMuon/Navigation/src/MuonEtaRange.cc
+++ b/RecoMuon/Navigation/src/MuonEtaRange.cc
@@ -11,29 +11,25 @@
 
 #include "RecoMuon/Navigation/interface/MuonEtaRange.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include<iostream>
+#include <iostream>
 
+MuonEtaRange::MuonEtaRange() : theMin(0), theMax(0) {}
 
-MuonEtaRange::MuonEtaRange() : 
-   theMin(0), theMax(0) {}
-   
 MuonEtaRange::MuonEtaRange(float max, float min) {
- if ( max < min ) {
-   edm::LogWarning ("MuonEtaRange") << "Warning MuonEtaRange:: max < min!! correcting" <<std::endl;
-   float tmp(min);
-   min = max;
-   max = tmp;
- }
- theMax = max;
- theMin = min;
+  if (max < min) {
+    edm::LogWarning("MuonEtaRange") << "Warning MuonEtaRange:: max < min!! correcting" << std::endl;
+    float tmp(min);
+    min = max;
+    max = tmp;
+  }
+  theMax = max;
+  theMin = min;
 }
 
-MuonEtaRange::MuonEtaRange(const MuonEtaRange& range) :
-    theMin(range.theMin), theMax(range.theMax) {}
+MuonEtaRange::MuonEtaRange(const MuonEtaRange& range) : theMin(range.theMin), theMax(range.theMax) {}
 /// Assignment operator
 MuonEtaRange& MuonEtaRange::operator=(const MuonEtaRange& range) {
-
-  if ( this != &range ) {
+  if (this != &range) {
     theMin = range.theMin;
     theMax = range.theMax;
   }
@@ -41,41 +37,40 @@ MuonEtaRange& MuonEtaRange::operator=(const MuonEtaRange& range) {
 }
 
 bool MuonEtaRange::isInside(float eta, float error) const {
-
-  if ( (eta+error) > max() || (eta-error) < min() ) return false;
+  if ((eta + error) > max() || (eta - error) < min())
+    return false;
   return true;
 }
 /// true if this is completely inside range
 bool MuonEtaRange::isInside(const MuonEtaRange& range) const {
-  if ( min() > range.min() && max() < range.max() ) return true;
+  if (min() > range.min() && max() < range.max())
+    return true;
   return false;
 }
 /// true if this overlaps with range
 bool MuonEtaRange::isCompatible(const MuonEtaRange& range) const {
-  if ( range.min() > max() || range.max() < min() ) return false; 
+  if (range.min() > max() || range.max() < min())
+    return false;
   return true;
 }
 /// create maximum of ranges
 MuonEtaRange MuonEtaRange::add(const MuonEtaRange& range) const {
-  float max = ( theMax > range.theMax ) ? theMax : range.theMax;
-  float min = ( theMin < range.theMin ) ? theMin : range.theMin;
-  return MuonEtaRange(max,min);
+  float max = (theMax > range.theMax) ? theMax : range.theMax;
+  float min = (theMin < range.theMin) ? theMin : range.theMin;
+  return MuonEtaRange(max, min);
 }
 /// create new range of size this minus range
 MuonEtaRange MuonEtaRange::subtract(const MuonEtaRange& range) const {
-
-  if ( range.isInside(*this) ) {
-    edm::LogInfo ("MuonEtaRange") << "MuonEtaRange: range is inside!" << std::endl;
+  if (range.isInside(*this)) {
+    edm::LogInfo("MuonEtaRange") << "MuonEtaRange: range is inside!" << std::endl;
     return *this;
   }
-  if ( !range.isCompatible(*this) ) {
-    edm::LogInfo ("MuonEtaRange") << "MuonEtaRange: no overlap between ranges" << std::endl;
+  if (!range.isCompatible(*this)) {
+    edm::LogInfo("MuonEtaRange") << "MuonEtaRange: no overlap between ranges" << std::endl;
     return *this;
   }
 
   float max = isInside(range.theMin) ? range.theMin : theMax;
   float min = isInside(range.theMax) ? range.theMax : theMin;
-  return MuonEtaRange(max,min);
+  return MuonEtaRange(max, min);
 }
-
-

--- a/RecoMuon/Navigation/src/MuonForwardNavigableLayer.cc
+++ b/RecoMuon/Navigation/src/MuonForwardNavigableLayer.cc
@@ -22,174 +22,133 @@
 using namespace std;
 using namespace edm;
 
-vector<const DetLayer*> 
-MuonForwardNavigableLayer::nextLayers(NavigationDirection dir) const {
-
+vector<const DetLayer*> MuonForwardNavigableLayer::nextLayers(NavigationDirection dir) const {
   vector<const DetLayer*> result;
   vector<const DetLayer*> barrel;
 
-  if ( dir == insideOut ) {
+  if (dir == insideOut) {
     pushResult(result, theOuterEndcapLayers);
-  }
-  else {
+  } else {
     pushResult(result, theInnerEndcapLayers);
-    reverse(result.begin(),result.end());
+    reverse(result.begin(), result.end());
     pushResult(barrel, theInnerBarrelLayers);
-    reverse(barrel.begin(),barrel.end());
-    result.insert(result.end(),barrel.begin(),barrel.end());
+    reverse(barrel.begin(), barrel.end());
+    result.insert(result.end(), barrel.begin(), barrel.end());
   }
 
   result.reserve(result.size());
   return result;
-
 }
 
-
-vector<const DetLayer*> 
-MuonForwardNavigableLayer::nextLayers(const FreeTrajectoryState& fts,
-                                      PropagationDirection dir) const {
-
+vector<const DetLayer*> MuonForwardNavigableLayer::nextLayers(const FreeTrajectoryState& fts,
+                                                              PropagationDirection dir) const {
   vector<const DetLayer*> result;
   vector<const DetLayer*> barrel;
 
-  if ( (isInsideOut(fts) && dir == alongMomentum) || ( !isInsideOut(fts) && dir == oppositeToMomentum)) {
+  if ((isInsideOut(fts) && dir == alongMomentum) || (!isInsideOut(fts) && dir == oppositeToMomentum)) {
     pushResult(result, theOuterEndcapLayers, fts);
-  }
-  else {
+  } else {
     pushResult(result, theInnerEndcapLayers, fts);
-    reverse(result.begin(),result.end());
+    reverse(result.begin(), result.end());
     pushResult(barrel, theInnerBarrelLayers, fts);
-    reverse(barrel.begin(),barrel.end());
-    result.insert(result.end(),barrel.begin(),barrel.end());
+    reverse(barrel.begin(), barrel.end());
+    result.insert(result.end(), barrel.begin(), barrel.end());
   }
 
   result.reserve(result.size());
   return result;
-
 }
 
-vector<const DetLayer*>
-MuonForwardNavigableLayer::compatibleLayers(NavigationDirection dir) const {
-
+vector<const DetLayer*> MuonForwardNavigableLayer::compatibleLayers(NavigationDirection dir) const {
   vector<const DetLayer*> result;
   vector<const DetLayer*> barrel;
 
-  if ( dir == insideOut ) {
+  if (dir == insideOut) {
     pushResult(result, theAllOuterEndcapLayers);
-  }
-  else {
+  } else {
     pushResult(result, theAllInnerEndcapLayers);
-    reverse(result.begin(),result.end());
+    reverse(result.begin(), result.end());
     pushResult(barrel, theAllInnerBarrelLayers);
-    reverse(barrel.begin(),barrel.end());
-    result.insert(result.end(),barrel.begin(),barrel.end());
+    reverse(barrel.begin(), barrel.end());
+    result.insert(result.end(), barrel.begin(), barrel.end());
   }
 
   result.reserve(result.size());
   return result;
-
 }
-vector<const DetLayer*>
-MuonForwardNavigableLayer::compatibleLayers(const FreeTrajectoryState& fts,
-                                      PropagationDirection dir) const {
+vector<const DetLayer*> MuonForwardNavigableLayer::compatibleLayers(const FreeTrajectoryState& fts,
+                                                                    PropagationDirection dir) const {
   vector<const DetLayer*> result;
   vector<const DetLayer*> barrel;
-  
-  if ( (isInsideOut(fts) && dir == alongMomentum) || ( !isInsideOut(fts) && dir == oppositeToMomentum)) {
+
+  if ((isInsideOut(fts) && dir == alongMomentum) || (!isInsideOut(fts) && dir == oppositeToMomentum)) {
     pushCompatibleResult(result, theAllOuterEndcapLayers, fts);
-  }
-  else {
+  } else {
     pushCompatibleResult(result, theAllInnerEndcapLayers, fts);
-    reverse(result.begin(),result.end());
+    reverse(result.begin(), result.end());
     pushCompatibleResult(barrel, theAllInnerBarrelLayers, fts);
-    reverse(barrel.begin(),barrel.end());
-    result.insert(result.end(),barrel.begin(),barrel.end());
+    reverse(barrel.begin(), barrel.end());
+    result.insert(result.end(), barrel.begin(), barrel.end());
   }
   result.reserve(result.size());
   return result;
-
 }
 
-void MuonForwardNavigableLayer::pushResult(vector<const DetLayer*>& result,
-                                           const MapB& map) const {
-
-  for (MapBI i = map.begin(); i != map.end(); i++) result.push_back((*i).first);
-
+void MuonForwardNavigableLayer::pushResult(vector<const DetLayer*>& result, const MapB& map) const {
+  for (MapBI i = map.begin(); i != map.end(); i++)
+    result.push_back((*i).first);
 }
 
-
-void MuonForwardNavigableLayer::pushResult(vector<const DetLayer*>& result,
-                                           const MapE& map) const {
-
-  for (MapEI i = map.begin(); i != map.end(); i++) result.push_back((*i).first);
-
+void MuonForwardNavigableLayer::pushResult(vector<const DetLayer*>& result, const MapE& map) const {
+  for (MapEI i = map.begin(); i != map.end(); i++)
+    result.push_back((*i).first);
 }
-
 
 void MuonForwardNavigableLayer::pushResult(vector<const DetLayer*>& result,
                                            const MapE& map,
                                            const FreeTrajectoryState& fts) const {
-
-  for (MapEI i = map.begin(); i != map.end(); i++) 
-    if ((*i).second.isInside(fts.position().eta())) result.push_back((*i).first);
-
+  for (MapEI i = map.begin(); i != map.end(); i++)
+    if ((*i).second.isInside(fts.position().eta()))
+      result.push_back((*i).first);
 }
-
 
 void MuonForwardNavigableLayer::pushResult(vector<const DetLayer*>& result,
-                                           const MapB& map, 
+                                           const MapB& map,
                                            const FreeTrajectoryState& fts) const {
-
   for (MapBI i = map.begin(); i != map.end(); i++)
-    if ((*i).second.isInside(fts.position().eta())) result.push_back((*i).first);
-
-}
-
-
-void MuonForwardNavigableLayer::pushCompatibleResult(vector<const DetLayer*>& result,
-                                          const MapB& map,
-                                          const FreeTrajectoryState& fts) const {
-  MuonEtaRange range=trackingRange(fts);
-  for ( MapBI i = map.begin(); i != map.end(); i++ )
-    if ((*i).second.isCompatible(range)) result.push_back((*i).first);
+    if ((*i).second.isInside(fts.position().eta()))
+      result.push_back((*i).first);
 }
 
 void MuonForwardNavigableLayer::pushCompatibleResult(vector<const DetLayer*>& result,
-                                          const MapE& map,
-                                          const FreeTrajectoryState& fts) const {
-  MuonEtaRange range=trackingRange(fts);
+                                                     const MapB& map,
+                                                     const FreeTrajectoryState& fts) const {
+  MuonEtaRange range = trackingRange(fts);
+  for (MapBI i = map.begin(); i != map.end(); i++)
+    if ((*i).second.isCompatible(range))
+      result.push_back((*i).first);
+}
+
+void MuonForwardNavigableLayer::pushCompatibleResult(vector<const DetLayer*>& result,
+                                                     const MapE& map,
+                                                     const FreeTrajectoryState& fts) const {
+  MuonEtaRange range = trackingRange(fts);
   for (MapEI i = map.begin(); i != map.end(); i++)
-    if ((*i).second.isCompatible(range)) result.push_back((*i).first);
-
+    if ((*i).second.isCompatible(range))
+      result.push_back((*i).first);
 }
 
-
-const DetLayer* MuonForwardNavigableLayer::detLayer() const {
-
-  return theDetLayer;
-
-}
-
+const DetLayer* MuonForwardNavigableLayer::detLayer() const { return theDetLayer; }
 
 void MuonForwardNavigableLayer::setDetLayer(const DetLayer* dl) {
-
-  edm::LogError ("MuonForwardNavigablaLayer") << "MuonForwardNavigableLayer::setDetLayer called!! " << endl;
-
+  edm::LogError("MuonForwardNavigablaLayer") << "MuonForwardNavigableLayer::setDetLayer called!! " << endl;
 }
 
-
-void MuonForwardNavigableLayer::setInwardLinks(const MapB& innerBL,
-                                               const MapE& innerEL) {
-
+void MuonForwardNavigableLayer::setInwardLinks(const MapB& innerBL, const MapE& innerEL) {
   theInnerBarrelLayers = innerBL;
   theInnerEndcapLayers = innerEL;
-
 }
-void MuonForwardNavigableLayer::setInwardCompatibleLinks(const MapB& innerCBL,
-                                               const MapE& innerCEL) {
-
+void MuonForwardNavigableLayer::setInwardCompatibleLinks(const MapB& innerCBL, const MapE& innerCEL) {
   theAllInnerBarrelLayers = innerCBL;
   theAllInnerEndcapLayers = innerCEL;
-
 }
-

--- a/RecoMuon/Navigation/src/MuonNavigableLayer.cc
+++ b/RecoMuon/Navigation/src/MuonNavigableLayer.cc
@@ -25,26 +25,26 @@
 /* C++ Headers */
 #include <algorithm>
 
-
 using namespace std;
 
-extern float calculateEta(float r, float z)  {
-  if ( z > 0 ) return -log((tan(atan(r/z)/2.)));
-  return log(-(tan(atan(r/z)/2.)));
-
+extern float calculateEta(float r, float z) {
+  if (z > 0)
+    return -log((tan(atan(r / z) / 2.)));
+  return log(-(tan(atan(r / z) / 2.)));
 }
 
-MuonEtaRange MuonNavigableLayer::trackingRange(const FreeTrajectoryState& fts) const
-{  
+MuonEtaRange MuonNavigableLayer::trackingRange(const FreeTrajectoryState& fts) const {
   float z = fts.position().z();
   float r = fts.position().perp();
   float eta;
-  if ( z>0 ) eta = -log((tan(atan(r/z)/2.)));
-  else eta = log(-(tan(atan(r/z)/2.)));
+  if (z > 0)
+    eta = -log((tan(atan(r / z) / 2.)));
+  else
+    eta = log(-(tan(atan(r / z) / 2.)));
 
-  double theta = atan(r/z);
+  double theta = atan(r / z);
 
-  double spread = 5.0*sqrt(fts.curvilinearError().matrix()(2,2))/fabs(sin(theta));  //5*sigma(eta)
+  double spread = 5.0 * sqrt(fts.curvilinearError().matrix()(2, 2)) / fabs(sin(theta));  //5*sigma(eta)
 
   //C.L.: this spread could be too large to use.
   // convert it to a smaller one by assuming a virtual radius
@@ -53,25 +53,26 @@ MuonEtaRange MuonNavigableLayer::trackingRange(const FreeTrajectoryState& fts) c
 
   double eta_max = 0;
 
-  if ( z > 0 ) eta_max = calculateEta(r, z+spread); 
-  else eta_max = calculateEta(r, z-spread); 
+  if (z > 0)
+    eta_max = calculateEta(r, z + spread);
+  else
+    eta_max = calculateEta(r, z - spread);
 
-  spread = std::min(0.07, fabs(eta_max-eta));
+  spread = std::min(0.07, fabs(eta_max - eta));
 
-  MuonEtaRange range(eta+spread,eta-spread);
+  MuonEtaRange range(eta + spread, eta - spread);
 
-  spread = 0.07; 
+  spread = 0.07;
   // special treatment for special geometry in overlap region
-  
-  if ( eta > 1.0 && eta < 1.1 )  range = MuonEtaRange(eta+3.0*spread,eta-spread);
-  if ( eta < -1.0 && eta > -1.1 ) range = MuonEtaRange(eta+spread,eta-3.0*spread);
+
+  if (eta > 1.0 && eta < 1.1)
+    range = MuonEtaRange(eta + 3.0 * spread, eta - spread);
+  if (eta < -1.0 && eta > -1.1)
+    range = MuonEtaRange(eta + spread, eta - 3.0 * spread);
 
   return range;
 }
 
 bool MuonNavigableLayer::isInsideOut(const FreeTrajectoryState& fts) const {
-  
-  return (fts.position().basicVector().dot(fts.momentum().basicVector())>0);
-  
+  return (fts.position().basicVector().dot(fts.momentum().basicVector()) > 0);
 }
-

--- a/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
+++ b/RecoMuon/Navigation/src/MuonNavigationPrinter.cc
@@ -20,7 +20,7 @@
 
 #include "RecoMuon/Navigation/interface/MuonNavigationPrinter.h"
 
-#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h" 
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "DataFormats/GeometrySurface/interface/BoundCylinder.h"
 #include "DataFormats/GeometrySurface/interface/BoundDisk.h"
@@ -41,180 +41,189 @@ using namespace std;
 #define PRINT(x) edm::LogInfo(x)
 #endif
 
-MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLayout,  MuonNavigationSchool const & sh,   bool enableCSC, bool enableRPC, bool enableGEM, bool enableME0) :
-  school(&sh) {
-
-  PRINT("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl;
-  PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
-  PRINT("MuonNavigationPrinter")<< "BARREL:" << std::endl;
+MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry* muonLayout,
+                                             MuonNavigationSchool const& sh,
+                                             bool enableCSC,
+                                             bool enableRPC,
+                                             bool enableGEM,
+                                             bool enableME0)
+    : school(&sh) {
+  PRINT("MuonNavigationPrinter") << "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl;
+  PRINT("MuonNavigationPrinter") << "================================" << std::endl;
+  PRINT("MuonNavigationPrinter") << "BARREL:" << std::endl;
   vector<const DetLayer*> barrel;
-  if ( enableRPC ) barrel = muonLayout->allBarrelLayers();
-  else barrel = muonLayout->allDTLayers();
+  if (enableRPC)
+    barrel = muonLayout->allBarrelLayers();
+  else
+    barrel = muonLayout->allDTLayers();
 
-  PRINT("MuonNavigationPrinter")<<"There are "<<barrel.size()<<" Barrel DetLayers";
-  for (auto i: barrel ) printLayer(i);
-  PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
-  PRINT("MuonNavigationPrinter")  << "BACKWARD:" << std::endl;
+  PRINT("MuonNavigationPrinter") << "There are " << barrel.size() << " Barrel DetLayers";
+  for (auto i : barrel)
+    printLayer(i);
+  PRINT("MuonNavigationPrinter") << "================================" << std::endl;
+  PRINT("MuonNavigationPrinter") << "BACKWARD:" << std::endl;
 
   vector<const DetLayer*> backward;
 
-  if ( enableCSC & enableGEM & enableRPC & enableME0) backward = muonLayout->allBackwardLayers();
-  else if ( enableCSC & enableGEM & !enableRPC & !enableME0) backward = muonLayout->allCscGemBackwardLayers(); // CSC + GEM
-  else if ( !enableCSC & enableGEM & !enableRPC & !enableME0 ) backward = muonLayout->backwardGEMLayers(); //GEM only
-  else if ( enableCSC & !enableGEM & !enableRPC & !enableME0 ) backward = muonLayout->backwardCSCLayers(); //CSC only
-  else if ( enableCSC & !enableGEM & !enableRPC & enableME0) backward = muonLayout->allCscME0BackwardLayers(); //CSC + ME0
-  else if ( !enableCSC & !enableGEM & !enableRPC & enableME0) backward = muonLayout->backwardME0Layers(); //ME0 only
-  else backward = muonLayout->allBackwardLayers();
+  if (enableCSC & enableGEM & enableRPC & enableME0)
+    backward = muonLayout->allBackwardLayers();
+  else if (enableCSC & enableGEM & !enableRPC & !enableME0)
+    backward = muonLayout->allCscGemBackwardLayers();  // CSC + GEM
+  else if (!enableCSC & enableGEM & !enableRPC & !enableME0)
+    backward = muonLayout->backwardGEMLayers();  //GEM only
+  else if (enableCSC & !enableGEM & !enableRPC & !enableME0)
+    backward = muonLayout->backwardCSCLayers();  //CSC only
+  else if (enableCSC & !enableGEM & !enableRPC & enableME0)
+    backward = muonLayout->allCscME0BackwardLayers();  //CSC + ME0
+  else if (!enableCSC & !enableGEM & !enableRPC & enableME0)
+    backward = muonLayout->backwardME0Layers();  //ME0 only
+  else
+    backward = muonLayout->allBackwardLayers();
 
-  PRINT("MuonNavigationPrinter")<<"There are "<<backward.size()<<" Backward DetLayers";
-  for (auto i : backward ) printLayer(i);
+  PRINT("MuonNavigationPrinter") << "There are " << backward.size() << " Backward DetLayers";
+  for (auto i : backward)
+    printLayer(i);
   PRINT("MuonNavigationPrinter") << "==============================" << std::endl;
   PRINT("MuonNavigationPrinter") << "FORWARD:" << std::endl;
   vector<const DetLayer*> forward;
 
-  if ( enableCSC & enableGEM & enableRPC & enableME0 ) forward = muonLayout->allForwardLayers();
-  else if ( enableCSC & enableGEM & !enableRPC & !enableME0) forward = muonLayout->allCscGemForwardLayers(); // CSC + GEM
-  else if ( !enableCSC & enableGEM & !enableRPC & !enableME0 ) forward = muonLayout->forwardGEMLayers(); //GEM only
-  else if ( enableCSC & !enableGEM & !enableRPC & !enableME0 ) forward = muonLayout->forwardCSCLayers(); //CSC only
-  else if ( enableCSC & !enableGEM & !enableRPC & enableME0) forward = muonLayout->allCscME0ForwardLayers(); //CSC + ME0
-  else if ( !enableCSC & !enableGEM & !enableRPC & enableME0) forward = muonLayout->forwardME0Layers(); //ME0 only
-  else forward = muonLayout->allForwardLayers();
+  if (enableCSC & enableGEM & enableRPC & enableME0)
+    forward = muonLayout->allForwardLayers();
+  else if (enableCSC & enableGEM & !enableRPC & !enableME0)
+    forward = muonLayout->allCscGemForwardLayers();  // CSC + GEM
+  else if (!enableCSC & enableGEM & !enableRPC & !enableME0)
+    forward = muonLayout->forwardGEMLayers();  //GEM only
+  else if (enableCSC & !enableGEM & !enableRPC & !enableME0)
+    forward = muonLayout->forwardCSCLayers();  //CSC only
+  else if (enableCSC & !enableGEM & !enableRPC & enableME0)
+    forward = muonLayout->allCscME0ForwardLayers();  //CSC + ME0
+  else if (!enableCSC & !enableGEM & !enableRPC & enableME0)
+    forward = muonLayout->forwardME0Layers();  //ME0 only
+  else
+    forward = muonLayout->allForwardLayers();
 
-  PRINT("MuonNavigationPrinter")<<"There are "<<forward.size()<<" Forward DetLayers" << std::endl;
-  for (auto i : forward ) printLayer(i);
-
+  PRINT("MuonNavigationPrinter") << "There are " << forward.size() << " Forward DetLayers" << std::endl;
+  for (auto i : forward)
+    printLayer(i);
 }
 
-MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry * muonLayout,  MuonNavigationSchool const & sh, const GeometricSearchTracker * tracker)  :
-  school(&sh){
-
-  PRINT("MuonNavigationPrinter")<< "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl ;
-//  vector<BarrelDetLayer*>::const_iterator tkiter;
-//  vector<ForwardDetLayer*>::const_iterator tkfiter;
-  PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
-  PRINT("MuonNavigationPrinter")<< "BARREL:" << std::endl;
+MuonNavigationPrinter::MuonNavigationPrinter(const MuonDetLayerGeometry* muonLayout,
+                                             MuonNavigationSchool const& sh,
+                                             const GeometricSearchTracker* tracker)
+    : school(&sh) {
+  PRINT("MuonNavigationPrinter") << "MuonNavigationPrinter::MuonNavigationPrinter" << std::endl;
+  //  vector<BarrelDetLayer*>::const_iterator tkiter;
+  //  vector<ForwardDetLayer*>::const_iterator tkfiter;
+  PRINT("MuonNavigationPrinter") << "================================" << std::endl;
+  PRINT("MuonNavigationPrinter") << "BARREL:" << std::endl;
   const vector<const BarrelDetLayer*>& tkbarrel = tracker->barrelLayers();
-  PRINT("MuonNavigationPrinter")<<"There are "<<tkbarrel.size()<<" Tk Barrel DetLayers" << std::endl;
-//  for ( tkiter = tkbarrel.begin(); tkiter != tkbarrel.end(); tkiter++ ) printLayer(*tkiter);
+  PRINT("MuonNavigationPrinter") << "There are " << tkbarrel.size() << " Tk Barrel DetLayers" << std::endl;
+  //  for ( tkiter = tkbarrel.begin(); tkiter != tkbarrel.end(); tkiter++ ) printLayer(*tkiter);
   vector<const DetLayer*> barrel = muonLayout->allBarrelLayers();
-  PRINT("MuonNavigationPrinter")<<"There are "<<barrel.size()<<" Mu Barrel DetLayers";
-  for ( auto i : barrel ) printLayer(i);
-  PRINT("MuonNavigationPrinter")<<"================================" << std::endl;
-  PRINT("MuonNavigationPrinter")  << "BACKWARD:" << std::endl;
+  PRINT("MuonNavigationPrinter") << "There are " << barrel.size() << " Mu Barrel DetLayers";
+  for (auto i : barrel)
+    printLayer(i);
+  PRINT("MuonNavigationPrinter") << "================================" << std::endl;
+  PRINT("MuonNavigationPrinter") << "BACKWARD:" << std::endl;
   const vector<const ForwardDetLayer*>& tkbackward = tracker->negForwardLayers();
-  PRINT("MuonNavigationPrinter")<<"There are "<<tkbackward.size()<<" Tk Backward DetLayers" << std::endl;
-///  for ( tkfiter = tkbackward.begin(); tkfiter != tkbackward.end(); tkfiter++ ) printLayer(*tkfiter);
+  PRINT("MuonNavigationPrinter") << "There are " << tkbackward.size() << " Tk Backward DetLayers" << std::endl;
+  ///  for ( tkfiter = tkbackward.begin(); tkfiter != tkbackward.end(); tkfiter++ ) printLayer(*tkfiter);
   vector<const DetLayer*> backward = muonLayout->allBackwardLayers();
-  PRINT("MuonNavigationPrinter")<<"There are "<<backward.size()<<" Mu Backward DetLayers << std::endl";
-  for (auto i : backward ) printLayer(i);
+  PRINT("MuonNavigationPrinter") << "There are " << backward.size() << " Mu Backward DetLayers << std::endl";
+  for (auto i : backward)
+    printLayer(i);
   PRINT("MuonNavigationPrinter") << "==============================" << std::endl;
   PRINT("MuonNavigationPrinter") << "FORWARD:" << std::endl;
-  const vector<const ForwardDetLayer*>& tkforward =  tracker->posForwardLayers();
-  PRINT("MuonNavigationPrinter")<<"There are "<<tkforward.size()<<" Tk Forward DetLayers" << std::endl;
-//  for ( tkfiter = tkforward.begin(); tkfiter != tkforward.end(); tkfiter++ ) printLayer(*tkfiter);
+  const vector<const ForwardDetLayer*>& tkforward = tracker->posForwardLayers();
+  PRINT("MuonNavigationPrinter") << "There are " << tkforward.size() << " Tk Forward DetLayers" << std::endl;
+  //  for ( tkfiter = tkforward.begin(); tkfiter != tkforward.end(); tkfiter++ ) printLayer(*tkfiter);
 
   vector<const DetLayer*> forward = muonLayout->allForwardLayers();
-  PRINT("MuonNavigationPrinter")<<"There are "<<forward.size()<<" Mu Forward DetLayers";
-  for ( auto i : forward ) printLayer(i);
-
+  PRINT("MuonNavigationPrinter") << "There are " << forward.size() << " Mu Forward DetLayers";
+  for (auto i : forward)
+    printLayer(i);
 }
 
 /// print layer
 void MuonNavigationPrinter::printLayer(const DetLayer* layer) const {
-  vector<const DetLayer*> nextLayers = school->nextLayers(*layer,insideOut);
-  vector<const DetLayer*> compatibleLayers = school->compatibleLayers(*layer,insideOut);
+  vector<const DetLayer*> nextLayers = school->nextLayers(*layer, insideOut);
+  vector<const DetLayer*> compatibleLayers = school->compatibleLayers(*layer, insideOut);
   if (const BarrelDetLayer* bdl = dynamic_cast<const BarrelDetLayer*>(layer)) {
-    PRINT("MuonNavigationPrinter") 
-         << layer->location() << " " << layer->subDetector() << " layer at R: "
-         << setiosflags(ios::showpoint | ios::fixed)
-         << setw(8) << setprecision(2)
-         << bdl->specificSurface().radius() << "  length: "
-         << setw(6) << setprecision(2)
-         << layer->surface().bounds().length() << std::endl;
-          
-  }
-  else if (const ForwardDetLayer* fdl = dynamic_cast<const ForwardDetLayer*>(layer)) {
+    PRINT("MuonNavigationPrinter") << layer->location() << " " << layer->subDetector()
+                                   << " layer at R: " << setiosflags(ios::showpoint | ios::fixed) << setw(8)
+                                   << setprecision(2) << bdl->specificSurface().radius() << "  length: " << setw(6)
+                                   << setprecision(2) << layer->surface().bounds().length() << std::endl;
+
+  } else if (const ForwardDetLayer* fdl = dynamic_cast<const ForwardDetLayer*>(layer)) {
     PRINT("MuonNavigationPrinter") << endl
-         << layer->location() << " " << layer->subDetector() << "layer at z: "
-         << setiosflags(ios::showpoint | ios::fixed)
-         << setw(8) << setprecision(2)
-         << layer->surface().position().z() << "  inner r: "
-         << setw(6) << setprecision(2)
-         << fdl->specificSurface().innerRadius() << "  outer r: "
-         << setw(6) << setprecision(2)
-         << fdl->specificSurface().outerRadius() << std::endl;
+                                   << layer->location() << " " << layer->subDetector()
+                                   << "layer at z: " << setiosflags(ios::showpoint | ios::fixed) << setw(8)
+                                   << setprecision(2) << layer->surface().position().z() << "  inner r: " << setw(6)
+                                   << setprecision(2) << fdl->specificSurface().innerRadius()
+                                   << "  outer r: " << setw(6) << setprecision(2)
+                                   << fdl->specificSurface().outerRadius() << std::endl;
   }
-  PRINT("MuonNavigationPrinter") << " has " << nextLayers.size() << " next layers in the direction inside-out: " << std::endl;
+  PRINT("MuonNavigationPrinter") << " has " << nextLayers.size()
+                                 << " next layers in the direction inside-out: " << std::endl;
   printLayers(nextLayers);
 
   nextLayers.clear();
-  nextLayers = school->nextLayers(*layer,outsideIn);
+  nextLayers = school->nextLayers(*layer, outsideIn);
 
-   PRINT("MuonNavigationPrinter") << " has " << nextLayers.size() << " next layers in the direction outside-in: " << std::endl;
+  PRINT("MuonNavigationPrinter") << " has " << nextLayers.size()
+                                 << " next layers in the direction outside-in: " << std::endl;
   printLayers(nextLayers);
 
-  PRINT("MuonNavigationPrinter") << " has " << compatibleLayers.size() << " compatible layers in the direction inside-out:: " << std::endl;
+  PRINT("MuonNavigationPrinter") << " has " << compatibleLayers.size()
+                                 << " compatible layers in the direction inside-out:: " << std::endl;
   printLayers(compatibleLayers);
   compatibleLayers.clear();
-  compatibleLayers = school->compatibleLayers(*layer,outsideIn);
-  
-  PRINT("MuonNavigationPrinter") << " has " << compatibleLayers.size() << " compatible layers in the direction outside-in: " << std::endl;
-  printLayers(compatibleLayers);
+  compatibleLayers = school->compatibleLayers(*layer, outsideIn);
 
+  PRINT("MuonNavigationPrinter") << " has " << compatibleLayers.size()
+                                 << " compatible layers in the direction outside-in: " << std::endl;
+  printLayers(compatibleLayers);
 }
 
 /// print next layers
 void MuonNavigationPrinter::printLayers(const vector<const DetLayer*>& nextLayers) const {
-
-  for ( vector<const DetLayer*>::const_iterator inext = nextLayers.begin();
-      inext != nextLayers.end(); inext++ ) {
-
-     PRINT("MuonNavigationPrinter") << " --> " << std::endl; 
-     if ( (*inext)->location() == GeomDetEnumerators::barrel ) {
+  for (vector<const DetLayer*>::const_iterator inext = nextLayers.begin(); inext != nextLayers.end(); inext++) {
+    PRINT("MuonNavigationPrinter") << " --> " << std::endl;
+    if ((*inext)->location() == GeomDetEnumerators::barrel) {
       const BarrelDetLayer* l = dynamic_cast<const BarrelDetLayer*>(&(**inext));
-      PRINT("MuonNavigationPrinter") << (*inext)->location() << " "
-           << (*inext)->subDetector()
-           << " layer at R: "
-           << setiosflags(ios::showpoint | ios::fixed)
-           << setw(8) << setprecision(2)
-           << l->specificSurface().radius() << "   " << std::endl;
-    }
-    else {
+      PRINT("MuonNavigationPrinter") << (*inext)->location() << " " << (*inext)->subDetector()
+                                     << " layer at R: " << setiosflags(ios::showpoint | ios::fixed) << setw(8)
+                                     << setprecision(2) << l->specificSurface().radius() << "   " << std::endl;
+    } else {
       const ForwardDetLayer* l = dynamic_cast<const ForwardDetLayer*>(&(**inext));
-       PRINT("MuonNavigationPrinter") << (*inext)->location() << " "
-           << (*inext)->subDetector()
-           << " layer at z: "
-           << setiosflags(ios::showpoint | ios::fixed)
-           << setw(8) << setprecision(2)
-           << l->surface().position().z() << "   " << std::endl;
+      PRINT("MuonNavigationPrinter") << (*inext)->location() << " " << (*inext)->subDetector()
+                                     << " layer at z: " << setiosflags(ios::showpoint | ios::fixed) << setw(8)
+                                     << setprecision(2) << l->surface().position().z() << "   " << std::endl;
     }
-    PRINT("MuonNavigationPrinter") << setiosflags(ios::showpoint | ios::fixed)
-         << setprecision(1)
-         << setw(6) << (*inext)->surface().bounds().length() << ", "
-         << setw(6) << (*inext)->surface().bounds().width() << ", "
-         << setw(4) <<(*inext)->surface().bounds().thickness() << " : " 
-         << (*inext)->surface().position() << std::endl;
+    PRINT("MuonNavigationPrinter") << setiosflags(ios::showpoint | ios::fixed) << setprecision(1) << setw(6)
+                                   << (*inext)->surface().bounds().length() << ", " << setw(6)
+                                   << (*inext)->surface().bounds().width() << ", " << setw(4)
+                                   << (*inext)->surface().bounds().thickness() << " : "
+                                   << (*inext)->surface().position() << std::endl;
   }
-
 }
-
 
 /// These should not be useful anymore as SubDetector and Location enums now have << operators
 
-// /// determine whether the layer is forward or backward 
+// /// determine whether the layer is forward or backward
 // string MuonNavigationPrinter::layerPart(const DetLayer* layer) const {
 
 //   string result = "unknown";
-  
+
 //   if ( layer->part() == barrel ) return "barrel";
 //   if ( layer->part() == forward && layer->surface().position().z() < 0 ) {
-//     result = "backward"; 
+//     result = "backward";
 //   }
 //   if ( layer->part() == forward && layer->surface().position().z() >= 0 ) {
 //     result = "forward";
 //   }
-  
-//   return result;    
+
+//   return result;
 
 // }
 
@@ -235,4 +244,3 @@ void MuonNavigationPrinter::printLayers(const vector<const DetLayer*>& nextLayer
 //   return result;
 
 // }
-

--- a/RecoMuon/Navigation/test/MuonNavigationTest.cc
+++ b/RecoMuon/Navigation/test/MuonNavigationTest.cc
@@ -4,7 +4,6 @@
  *  \author Chang Liu
  */
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 
@@ -26,49 +25,42 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 class MuonNavigationTest : public edm::EDAnalyzer {
-   public:
-      explicit MuonNavigationTest( const edm::ParameterSet& );
-      ~MuonNavigationTest();
+public:
+  explicit MuonNavigationTest(const edm::ParameterSet&);
+  ~MuonNavigationTest();
 
-      virtual void analyze( const edm::Event&, const edm::EventSetup& );
-   private:
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+private:
 };
 
 // constructor
 
-MuonNavigationTest::MuonNavigationTest( const edm::ParameterSet& iConfig )
-{
-      std::cout<<"Muon Navigation Printer Begin:"<<std::endl;
+MuonNavigationTest::MuonNavigationTest(const edm::ParameterSet& iConfig) {
+  std::cout << "Muon Navigation Printer Begin:" << std::endl;
 }
 
+MuonNavigationTest::~MuonNavigationTest() { std::cout << "Muon Navigation Printer End. " << std::endl; }
 
-MuonNavigationTest::~MuonNavigationTest()
-{
-       std::cout<<"Muon Navigation Printer End. "<<std::endl;
-}
+void MuonNavigationTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
+  //choose ONE and ONLY one to be true
+  bool testMuon = true;
+  //   bool testMuonTk = true;
+  //
+  // get Geometry
+  //
+  edm::ESHandle<MuonDetLayerGeometry> muon;
+  iSetup.get<MuonRecoGeometryRecord>().get(muon);
+  const MuonDetLayerGeometry* mm(&(*muon));
 
-void
-MuonNavigationTest::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
-   using namespace edm;
-
-   //choose ONE and ONLY one to be true
-   bool testMuon = true;
-//   bool testMuonTk = true;
-   //
-   // get Geometry
-   //
-   edm::ESHandle<MuonDetLayerGeometry> muon;
-   iSetup.get<MuonRecoGeometryRecord>().get(muon);     
-   const MuonDetLayerGeometry * mm(&(*muon));
-
-   if ( testMuon ) {
-      MuonNavigationSchool school(mm);
-      MuonNavigationPrinter* printer = new MuonNavigationPrinter(mm, school );
-      delete printer;
-   }
-/*
+  if (testMuon) {
+    MuonNavigationSchool school(mm);
+    MuonNavigationPrinter* printer = new MuonNavigationPrinter(mm, school);
+    delete printer;
+  }
+  /*
    if ( testMuonTk ) {
      edm::ESHandle<GeometricSearchTracker> tracker;
      iSetup.get<TrackerRecoGeometryRecord>().get(tracker);
@@ -88,4 +80,3 @@ MuonNavigationTest::analyze( const edm::Event& iEvent, const edm::EventSetup& iS
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(MuonNavigationTest);
-

--- a/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h
+++ b/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h
@@ -11,24 +11,22 @@
  *   \modified by C. Calabria    INFN & Universita  Bari
  */
 
-
 #include "TrackingTools/TransientTrackingRecHit/interface/GenericTransientTrackingRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/RecSegment.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
-class MuonTransientTrackingRecHit final : public GenericTransientTrackingRecHit{
+class MuonTransientTrackingRecHit final : public GenericTransientTrackingRecHit {
 public:
-   using MuonRecHitPointer = std::shared_ptr<MuonTransientTrackingRecHit>;
-   using ConstMuonRecHitPointer = std::shared_ptr<MuonTransientTrackingRecHit const>;
+  using MuonRecHitPointer = std::shared_ptr<MuonTransientTrackingRecHit>;
+  using ConstMuonRecHitPointer = std::shared_ptr<MuonTransientTrackingRecHit const>;
 
-//  typedef ReferenceCountingPointer<MuonTransientTrackingRecHit>      MuonRecHitPointer;
-//  typedef ConstReferenceCountingPointer<MuonTransientTrackingRecHit> ConstMuonRecHitPointer;
-  typedef std::vector<MuonRecHitPointer>                             MuonRecHitContainer;
-  typedef std::vector<ConstMuonRecHitPointer>                        ConstMuonRecHitContainer;
-  
-  ~MuonTransientTrackingRecHit() override{}
+  //  typedef ReferenceCountingPointer<MuonTransientTrackingRecHit>      MuonRecHitPointer;
+  //  typedef ConstReferenceCountingPointer<MuonTransientTrackingRecHit> ConstMuonRecHitPointer;
+  typedef std::vector<MuonRecHitPointer> MuonRecHitContainer;
+  typedef std::vector<ConstMuonRecHitPointer> ConstMuonRecHitContainer;
+
+  ~MuonTransientTrackingRecHit() override {}
 
   /// Direction in 3D for segments, otherwise (0,0,0)
   virtual LocalVector localDirection() const;
@@ -41,8 +39,8 @@ public:
 
   /// Error on the global direction
   virtual GlobalError globalDirectionError() const;
- 
-  AlgebraicSymMatrix parametersError() const  override;
+
+  AlgebraicSymMatrix parametersError() const override;
 
   /// Chi square of the fit for segments, else 0
   virtual double chi2() const;
@@ -50,17 +48,17 @@ public:
   /// Degrees of freedom for segments, else 0
   virtual int degreesOfFreedom() const;
 
-  /// if this rec hit is a DT rec hit 
+  /// if this rec hit is a DT rec hit
   bool isDT() const;
 
-  /// if this rec hit is a CSC rec hit 
+  /// if this rec hit is a CSC rec hit
   bool isCSC() const;
 
-  /// if this rec hit is a GEM rec hit 
-  bool isGEM() const; 
+  /// if this rec hit is a GEM rec hit
+  bool isGEM() const;
 
-  /// if this rec hit is a ME0 rec hit 
-  bool isME0() const; 
+  /// if this rec hit is a ME0 rec hit
+  bool isME0() const;
 
   /// if this rec hit is a RPC rec hit
   bool isRPC() const;
@@ -70,31 +68,26 @@ public:
 
   /// FIXME virtual ConstMuonRecHitContainer specificTransientHits() const;
 
-  static RecHitPointer build( const GeomDet * geom, const TrackingRecHit* rh) {
-    return RecHitPointer( new MuonTransientTrackingRecHit(geom, rh));
+  static RecHitPointer build(const GeomDet* geom, const TrackingRecHit* rh) {
+    return RecHitPointer(new MuonTransientTrackingRecHit(geom, rh));
   }
 
-  static MuonRecHitPointer specificBuild(const GeomDet * geom, const TrackingRecHit* rh) {
-    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Getting specificBuild"<<std::endl;
+  static MuonRecHitPointer specificBuild(const GeomDet* geom, const TrackingRecHit* rh) {
+    LogDebug("Muon|RecoMuon|MuonDetLayerMeasurements") << "Getting specificBuild" << std::endl;
     return MuonRecHitPointer(new MuonTransientTrackingRecHit(geom, rh));
   }
 
   void invalidateHit();
 
- private:
-
-  friend class kkkwwwxxxyyyzzz; //just to avoid the compiler warning...
+private:
+  friend class kkkwwwxxxyyyzzz;  //just to avoid the compiler warning...
 
   /// Construct from a TrackingRecHit and its GeomDet
-  MuonTransientTrackingRecHit(const GeomDet * geom, const TrackingRecHit * rh);
+  MuonTransientTrackingRecHit(const GeomDet* geom, const TrackingRecHit* rh);
 
   /// Copy ctor
-  MuonTransientTrackingRecHit(const MuonTransientTrackingRecHit & other );
+  MuonTransientTrackingRecHit(const MuonTransientTrackingRecHit& other);
 
-  MuonTransientTrackingRecHit* clone() const  override {
-    return new MuonTransientTrackingRecHit(*this);
-  }
-
+  MuonTransientTrackingRecHit* clone() const override { return new MuonTransientTrackingRecHit(*this); }
 };
 #endif
-

--- a/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBreaker.h
+++ b/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBreaker.h
@@ -10,17 +10,12 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 class MuonTransientTrackingRecHitBreaker {
-
 public:
-
-  /// takes a muon rechit and returns its sub-rechits given a certain granularity 
-  static TransientTrackingRecHit::ConstRecHitContainer 
-  breakInSubRecHits(TransientTrackingRecHit::ConstRecHitPointer, int granularity);
+  /// takes a muon rechit and returns its sub-rechits given a certain granularity
+  static TransientTrackingRecHit::ConstRecHitContainer breakInSubRecHits(TransientTrackingRecHit::ConstRecHitPointer,
+                                                                         int granularity);
 
 protected:
-
 private:
-
 };
 #endif
-

--- a/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h
+++ b/RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h
@@ -9,29 +9,25 @@
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-class MuonTransientTrackingRecHitBuilder: public TransientTrackingRecHitBuilder {
-  
- public:
-  
+class MuonTransientTrackingRecHitBuilder : public TransientTrackingRecHitBuilder {
+public:
   typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
-  typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;   
+  typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
 
   MuonTransientTrackingRecHitBuilder(edm::ESHandle<GlobalTrackingGeometry> trackingGeometry = nullptr);
 
-  ~MuonTransientTrackingRecHitBuilder() override {} ;
+  ~MuonTransientTrackingRecHitBuilder() override{};
 
   using TransientTrackingRecHitBuilder::build;
   /// Call the MuonTransientTrackingRecHit::specificBuild
-  RecHitPointer build(const TrackingRecHit *p, 
-		      edm::ESHandle<GlobalTrackingGeometry> trackingGeometry) const ;
-  
-  RecHitPointer build(const TrackingRecHit * p) const override;
-  
-  ConstRecHitContainer build(const trackingRecHit_iterator& start, const trackingRecHit_iterator& stop) const;
-  
- private:
-  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
+  RecHitPointer build(const TrackingRecHit* p, edm::ESHandle<GlobalTrackingGeometry> trackingGeometry) const;
 
+  RecHitPointer build(const TrackingRecHit* p) const override;
+
+  ConstRecHitContainer build(const trackingRecHit_iterator& start, const trackingRecHit_iterator& stop) const;
+
+private:
+  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
 };
 
 #endif

--- a/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.cc
@@ -11,27 +11,22 @@
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
-#include<memory>
+#include <memory>
 
 using namespace edm;
 using namespace std;
-    
-MuonTransientTrackingRecHitBuilderESProducer::MuonTransientTrackingRecHitBuilderESProducer(const ParameterSet & parameterSet) {
 
-  setWhatProduced(this,parameterSet.getParameter<string>("ComponentName"));
+MuonTransientTrackingRecHitBuilderESProducer::MuonTransientTrackingRecHitBuilderESProducer(
+    const ParameterSet& parameterSet) {
+  setWhatProduced(this, parameterSet.getParameter<string>("ComponentName"));
 }
-    
+
 MuonTransientTrackingRecHitBuilderESProducer::~MuonTransientTrackingRecHitBuilderESProducer() {}
 
-    
-std::unique_ptr<TransientTrackingRecHitBuilder> 
-MuonTransientTrackingRecHitBuilderESProducer::produce(const TransientRecHitRecord& iRecord){ 
-  
-
+std::unique_ptr<TransientTrackingRecHitBuilder> MuonTransientTrackingRecHitBuilderESProducer::produce(
+    const TransientRecHitRecord& iRecord) {
   ESHandle<GlobalTrackingGeometry> trackingGeometry;
   iRecord.getRecord<GlobalTrackingGeometryRecord>().get(trackingGeometry);
-  
+
   return std::make_unique<MuonTransientTrackingRecHitBuilder>(trackingGeometry);
 }
-    
-    

--- a/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.h
+++ b/RecoMuon/TransientTrackingRecHit/plugins/MuonTransientTrackingRecHitBuilderESProducer.h
@@ -15,11 +15,13 @@
 
 #include <memory>
 
-namespace edm {class ParameterSet;}
+namespace edm {
+  class ParameterSet;
+}
 
 class TransientRecHitRecord;
 
-class MuonTransientTrackingRecHitBuilderESProducer: public edm::ESProducer {
+class MuonTransientTrackingRecHitBuilderESProducer : public edm::ESProducer {
 public:
   /// Constructor
   MuonTransientTrackingRecHitBuilderESProducer(const edm::ParameterSet&);
@@ -31,7 +33,6 @@ public:
   std::unique_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord&);
 
 protected:
-
 private:
 };
 #endif

--- a/RecoMuon/TransientTrackingRecHit/src/MuonTransientTrackingRecHit.cc
+++ b/RecoMuon/TransientTrackingRecHit/src/MuonTransientTrackingRecHit.cc
@@ -15,233 +15,201 @@
 #include <map>
 
 typedef MuonTransientTrackingRecHit::MuonRecHitPointer MuonRecHitPointer;
-typedef MuonTransientTrackingRecHit::RecHitContainer   MuonRecHitContainer;
+typedef MuonTransientTrackingRecHit::RecHitContainer MuonRecHitContainer;
 
+MuonTransientTrackingRecHit::MuonTransientTrackingRecHit(const GeomDet* geom, const TrackingRecHit* rh)
+    : GenericTransientTrackingRecHit(*geom, *rh) {}
 
-MuonTransientTrackingRecHit::MuonTransientTrackingRecHit(const GeomDet* geom, const TrackingRecHit* rh) :
-  GenericTransientTrackingRecHit(*geom,*rh){}
-
-MuonTransientTrackingRecHit::MuonTransientTrackingRecHit(const MuonTransientTrackingRecHit& other ) :
-  GenericTransientTrackingRecHit(*other.det(), *(other.hit())) {}
-
+MuonTransientTrackingRecHit::MuonTransientTrackingRecHit(const MuonTransientTrackingRecHit& other)
+    : GenericTransientTrackingRecHit(*other.det(), *(other.hit())) {}
 
 LocalVector MuonTransientTrackingRecHit::localDirection() const {
-
-  if (dynamic_cast<const RecSegment*>(hit()) )
-     return dynamic_cast<const RecSegment*>(hit())->localDirection(); 
-  else return LocalVector(0.,0.,0.);
-
+  if (dynamic_cast<const RecSegment*>(hit()))
+    return dynamic_cast<const RecSegment*>(hit())->localDirection();
+  else
+    return LocalVector(0., 0., 0.);
 }
 
 LocalError MuonTransientTrackingRecHit::localDirectionError() const {
-
   if (dynamic_cast<const RecSegment*>(hit()))
-     return dynamic_cast<const RecSegment*>(hit())->localDirectionError();
-  else return LocalError(0.,0.,0.);
-
+    return dynamic_cast<const RecSegment*>(hit())->localDirectionError();
+  else
+    return LocalError(0., 0., 0.);
 }
 
-GlobalVector MuonTransientTrackingRecHit::globalDirection() const
-{
-  return  (det()->surface().toGlobal(localDirection()));
+GlobalVector MuonTransientTrackingRecHit::globalDirection() const {
+  return (det()->surface().toGlobal(localDirection()));
 }
 
-GlobalError MuonTransientTrackingRecHit::globalDirectionError() const
-{
-  return ErrorFrameTransformer().transform( localDirectionError(), (det()->surface()));
+GlobalError MuonTransientTrackingRecHit::globalDirectionError() const {
+  return ErrorFrameTransformer().transform(localDirectionError(), (det()->surface()));
 }
-
 
 AlgebraicSymMatrix MuonTransientTrackingRecHit::parametersError() const {
- 
   AlgebraicSymMatrix err = GenericTransientTrackingRecHit::parametersError();
   AlgebraicVector par = GenericTransientTrackingRecHit::parameters();
 
   const AlignmentPositionError* APE = det()->alignmentPositionError();
   if (APE != nullptr) {
-    AlgebraicVector positions(2,0);
-    AlgebraicVector directions(2,0);
+    AlgebraicVector positions(2, 0);
+    AlgebraicVector directions(2, 0);
 
-    if(err.num_row() == 1) {
-     positions[0] = 0.;
-     positions[1] = 0.;
-     directions[0] = 0.;
-     directions[1] = 0.;
-     LocalErrorExtended lape = ErrorFrameTransformer().transform46(APE->globalError(),positions,directions);
-     err[0][0] += lape.cxx();
+    if (err.num_row() == 1) {
+      positions[0] = 0.;
+      positions[1] = 0.;
+      directions[0] = 0.;
+      directions[1] = 0.;
+      LocalErrorExtended lape = ErrorFrameTransformer().transform46(APE->globalError(), positions, directions);
+      err[0][0] += lape.cxx();
     } else if (err.num_row() == 2) {
-     positions[0] = localPosition().x();
-     positions[1] = 0.;
-     directions[0] = 0.;
-     directions[1] = 0.;
-     LocalErrorExtended lape = ErrorFrameTransformer().transform46(APE->globalError(),positions,directions);
+      positions[0] = localPosition().x();
+      positions[1] = 0.;
+      directions[0] = 0.;
+      directions[1] = 0.;
+      LocalErrorExtended lape = ErrorFrameTransformer().transform46(APE->globalError(), positions, directions);
 
-     AlgebraicSymMatrix lapeMatrix(2,0);
-     lapeMatrix[1][1] = lape.cxx();
-     lapeMatrix[0][0] = lape.cphixphix();
-     lapeMatrix[0][1] = lape.cphixx();
+      AlgebraicSymMatrix lapeMatrix(2, 0);
+      lapeMatrix[1][1] = lape.cxx();
+      lapeMatrix[0][0] = lape.cphixphix();
+      lapeMatrix[0][1] = lape.cphixx();
 
-     if(err.num_row() != lapeMatrix.num_row())
-       throw cms::Exception("MuonTransientTrackingRecHit::parametersError")
-        <<"Discrepancy between alignment error matrix and error matrix: APE "
-        << lapeMatrix.num_row()
-        << ", error matrix " << err.num_row()
-        << std::endl;
+      if (err.num_row() != lapeMatrix.num_row())
+        throw cms::Exception("MuonTransientTrackingRecHit::parametersError")
+            << "Discrepancy between alignment error matrix and error matrix: APE " << lapeMatrix.num_row()
+            << ", error matrix " << err.num_row() << std::endl;
 
-     err += lapeMatrix;
-    } else if (err.num_row() == 4) { 
-     positions[0] = par[2];
-     positions[1] = par[3];
-     directions[0] = par[0];
-     directions[1] = par[1];
+      err += lapeMatrix;
+    } else if (err.num_row() == 4) {
+      positions[0] = par[2];
+      positions[1] = par[3];
+      directions[0] = par[0];
+      directions[1] = par[1];
 
-     LocalErrorExtended lape = ErrorFrameTransformer().transform46(APE->globalError(),positions,directions);
+      LocalErrorExtended lape = ErrorFrameTransformer().transform46(APE->globalError(), positions, directions);
 
-     AlgebraicSymMatrix lapeMatrix(4,0);
-     lapeMatrix[2][2] = lape.cxx();
-     lapeMatrix[2][3] = lape.cyx();
-     lapeMatrix[3][3] = lape.cyy();
-     lapeMatrix[0][0] = lape.cphixphix();
-     lapeMatrix[0][1] = lape.cphiyphix();
-     lapeMatrix[1][1] = lape.cphiyphiy();
+      AlgebraicSymMatrix lapeMatrix(4, 0);
+      lapeMatrix[2][2] = lape.cxx();
+      lapeMatrix[2][3] = lape.cyx();
+      lapeMatrix[3][3] = lape.cyy();
+      lapeMatrix[0][0] = lape.cphixphix();
+      lapeMatrix[0][1] = lape.cphiyphix();
+      lapeMatrix[1][1] = lape.cphiyphiy();
 
-     lapeMatrix[0][2] = lape.cphixx();
-     lapeMatrix[0][3] = lape.cphixy();
-     lapeMatrix[1][3] = lape.cphiyy();
-     lapeMatrix[1][2] = lape.cphiyx();
+      lapeMatrix[0][2] = lape.cphixx();
+      lapeMatrix[0][3] = lape.cphixy();
+      lapeMatrix[1][3] = lape.cphiyy();
+      lapeMatrix[1][2] = lape.cphiyx();
 
-     if(err.num_row() != lapeMatrix.num_row())
-       throw cms::Exception("MuonTransientTrackingRecHit::parametersError")
-        <<"Discrepancy between alignment error matrix and error matrix: APE "
-        << lapeMatrix.num_row()
-        << ", error matrix " << err.num_row()
-        << std::endl;
+      if (err.num_row() != lapeMatrix.num_row())
+        throw cms::Exception("MuonTransientTrackingRecHit::parametersError")
+            << "Discrepancy between alignment error matrix and error matrix: APE " << lapeMatrix.num_row()
+            << ", error matrix " << err.num_row() << std::endl;
 
-     err += lapeMatrix;
+      err += lapeMatrix;
     }
   }
   return err;
 }
 
-double MuonTransientTrackingRecHit::chi2() const 
-{
+double MuonTransientTrackingRecHit::chi2() const {
   if (dynamic_cast<const RecSegment*>(hit()))
     return dynamic_cast<const RecSegment*>(hit())->chi2();
-  else return 0.;
+  else
+    return 0.;
 }
 
-int MuonTransientTrackingRecHit::degreesOfFreedom() const 
-{
+int MuonTransientTrackingRecHit::degreesOfFreedom() const {
   if (dynamic_cast<const RecSegment*>(hit()))
     return dynamic_cast<const RecSegment*>(hit())->degreesOfFreedom();
-  else return 0;
+  else
+    return 0;
 }
 
-bool MuonTransientTrackingRecHit::isDT() const{
-  return  (geographicalId().subdetId() == MuonSubdetId::DT);
-}
+bool MuonTransientTrackingRecHit::isDT() const { return (geographicalId().subdetId() == MuonSubdetId::DT); }
 
-bool MuonTransientTrackingRecHit::isCSC() const{
-  return  (geographicalId().subdetId() == MuonSubdetId::CSC);
-}
+bool MuonTransientTrackingRecHit::isCSC() const { return (geographicalId().subdetId() == MuonSubdetId::CSC); }
 
-bool MuonTransientTrackingRecHit::isGEM() const{
-  return  (geographicalId().subdetId() == MuonSubdetId::GEM);
-}
+bool MuonTransientTrackingRecHit::isGEM() const { return (geographicalId().subdetId() == MuonSubdetId::GEM); }
 
-bool MuonTransientTrackingRecHit::isME0() const{
-  return  (geographicalId().subdetId() == MuonSubdetId::ME0);
-  
-}
+bool MuonTransientTrackingRecHit::isME0() const { return (geographicalId().subdetId() == MuonSubdetId::ME0); }
 
-bool MuonTransientTrackingRecHit::isRPC() const{
-  return  (geographicalId().subdetId() == MuonSubdetId::RPC);
-}
+bool MuonTransientTrackingRecHit::isRPC() const { return (geographicalId().subdetId() == MuonSubdetId::RPC); }
 
 // FIXME, now it is "on-demand". I have to change it.
 // FIXME check on mono hit!
-TransientTrackingRecHit::ConstRecHitContainer MuonTransientTrackingRecHit::transientHits() const{
-
+TransientTrackingRecHit::ConstRecHitContainer MuonTransientTrackingRecHit::transientHits() const {
   ConstRecHitContainer theSubTransientRecHits;
-  
+
   // the sub rec hit of this TransientRecHit
   std::vector<const TrackingRecHit*> ownRecHits = recHits();
 
-  if(ownRecHits.empty()){
+  if (ownRecHits.empty()) {
     theSubTransientRecHits.push_back(TransientTrackingRecHit::RecHitPointer(clone()));
     return theSubTransientRecHits;
   }
-  
-  // the components of the geom det on which reside this rechit
-  std::vector<const GeomDet *> geomDets = det()->components();
 
-  if(isDT() && dimension() == 2 && ownRecHits.front()->dimension() == 1 
-     && (geomDets.size() == 3 || geomDets.size() == 2) ){ // it is a phi segment!!
-    
-    std::vector<const GeomDet *> subGeomDets;
+  // the components of the geom det on which reside this rechit
+  std::vector<const GeomDet*> geomDets = det()->components();
+
+  if (isDT() && dimension() == 2 && ownRecHits.front()->dimension() == 1 &&
+      (geomDets.size() == 3 || geomDets.size() == 2)) {  // it is a phi segment!!
+
+    std::vector<const GeomDet*> subGeomDets;
 
     int sl = 1;
-    for(std::vector<const GeomDet *>::const_iterator geoDet = geomDets.begin();
-	geoDet != geomDets.end(); ++geoDet){
-      if(sl != 3){ // FIXME!! this maybe is not always true
-	std::vector<const GeomDet *> tmp = (*geoDet)->components();
-	std::copy(tmp.begin(),tmp.end(),back_inserter(subGeomDets));
+    for (std::vector<const GeomDet*>::const_iterator geoDet = geomDets.begin(); geoDet != geomDets.end(); ++geoDet) {
+      if (sl != 3) {  // FIXME!! this maybe is not always true
+        std::vector<const GeomDet*> tmp = (*geoDet)->components();
+        std::copy(tmp.begin(), tmp.end(), back_inserter(subGeomDets));
       }
       ++sl;
     }
     geomDets.clear();
     geomDets = subGeomDets;
   }
-  
+
   // Fill the GeomDet map
-  std::map<DetId,const GeomDet*> gemDetMap;
-  
-  for (std::vector<const GeomDet*>::const_iterator subDet = geomDets.begin(); 
-       subDet != geomDets.end(); ++subDet)
-    gemDetMap[ (*subDet)->geographicalId() ] = *subDet;
-  
-  std::map<DetId,const GeomDet*>::iterator gemDetMap_iter;
-  
+  std::map<DetId, const GeomDet*> gemDetMap;
+
+  for (std::vector<const GeomDet*>::const_iterator subDet = geomDets.begin(); subDet != geomDets.end(); ++subDet)
+    gemDetMap[(*subDet)->geographicalId()] = *subDet;
+
+  std::map<DetId, const GeomDet*>::iterator gemDetMap_iter;
+
   // Loop in order to check the ids
-  for (std::vector<const TrackingRecHit*>::const_iterator rechit = ownRecHits.begin(); 
-       rechit != ownRecHits.end(); ++rechit){
-    
-    gemDetMap_iter = gemDetMap.find( (*rechit)->geographicalId() );
-    
-    if(gemDetMap_iter != gemDetMap.end() )
-      theSubTransientRecHits.push_back(TransientTrackingRecHit::RecHitPointer(new MuonTransientTrackingRecHit(gemDetMap_iter->second, 
-									 *rechit)) );
-    else if( (*rechit)->geographicalId() == det()->geographicalId() ) // Phi in DT is on Chamber
-      theSubTransientRecHits.push_back(TransientTrackingRecHit::RecHitPointer(new MuonTransientTrackingRecHit(det(), 
-								       *rechit)) );
+  for (std::vector<const TrackingRecHit*>::const_iterator rechit = ownRecHits.begin(); rechit != ownRecHits.end();
+       ++rechit) {
+    gemDetMap_iter = gemDetMap.find((*rechit)->geographicalId());
+
+    if (gemDetMap_iter != gemDetMap.end())
+      theSubTransientRecHits.push_back(
+          TransientTrackingRecHit::RecHitPointer(new MuonTransientTrackingRecHit(gemDetMap_iter->second, *rechit)));
+    else if ((*rechit)->geographicalId() == det()->geographicalId())  // Phi in DT is on Chamber
+      theSubTransientRecHits.push_back(
+          TransientTrackingRecHit::RecHitPointer(new MuonTransientTrackingRecHit(det(), *rechit)));
   }
   return theSubTransientRecHits;
-
 }
 
+void MuonTransientTrackingRecHit::invalidateHit() {
+  setType(bad);
+  trackingRecHit_->setType(bad);
 
-void MuonTransientTrackingRecHit::invalidateHit(){ 
-  setType(bad); trackingRecHit_->setType(bad); 
-
-
-  if (isDT()){
-    if(dimension() > 1){ // MB4s have 2D, but formatted in 4D segments 
-      std::vector<TrackingRecHit*> seg2D = recHits(); // 4D --> 2D
+  if (isDT()) {
+    if (dimension() > 1) {                             // MB4s have 2D, but formatted in 4D segments
+      std::vector<TrackingRecHit*> seg2D = recHits();  // 4D --> 2D
       // load 1D hits (2D --> 1D)
-      for(std::vector<TrackingRecHit*>::iterator it = seg2D.begin(); it != seg2D.end(); ++it){
-	std::vector<TrackingRecHit*> hits1D =  (*it)->recHits();
-	(*it)->setType(bad);
-	for(std::vector<TrackingRecHit*>::iterator it2 = hits1D.begin(); it2 != hits1D.end(); ++it2)
-	  (*it2)->setType(bad);
+      for (std::vector<TrackingRecHit*>::iterator it = seg2D.begin(); it != seg2D.end(); ++it) {
+        std::vector<TrackingRecHit*> hits1D = (*it)->recHits();
+        (*it)->setType(bad);
+        for (std::vector<TrackingRecHit*>::iterator it2 = hits1D.begin(); it2 != hits1D.end(); ++it2)
+          (*it2)->setType(bad);
       }
     }
-  }
-  else if(isCSC())
-    if(dimension() == 4){
-      std::vector<TrackingRecHit*>  hits = recHits(); // load 2D hits (4D --> 1D)
-      for(std::vector<TrackingRecHit*>::iterator it = hits.begin(); it != hits.end(); ++it)
-	(*it)->setType(bad);
+  } else if (isCSC())
+    if (dimension() == 4) {
+      std::vector<TrackingRecHit*> hits = recHits();  // load 2D hits (4D --> 1D)
+      for (std::vector<TrackingRecHit*>::iterator it = hits.begin(); it != hits.end(); ++it)
+        (*it)->setType(bad);
     }
-  
-  
 }

--- a/RecoMuon/TransientTrackingRecHit/src/MuonTransientTrackingRecHitBreaker.cc
+++ b/RecoMuon/TransientTrackingRecHit/src/MuonTransientTrackingRecHitBreaker.cc
@@ -2,70 +2,63 @@
 
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 
-TransientTrackingRecHit::ConstRecHitContainer 
-MuonTransientTrackingRecHitBreaker::breakInSubRecHits(TransientTrackingRecHit::ConstRecHitPointer muonRecHit, int granularity){
-
+TransientTrackingRecHit::ConstRecHitContainer MuonTransientTrackingRecHitBreaker::breakInSubRecHits(
+    TransientTrackingRecHit::ConstRecHitPointer muonRecHit, int granularity) {
   const std::string metname = "Muon|RecoMuon|MuonTransientTrackingRecHitBreaker";
 
   TransientTrackingRecHit::ConstRecHitContainer recHitsForFit;
-  
+
   int subDet = muonRecHit->geographicalId().subdetId();
 
-  switch(granularity){
-  case 0:
-    {
+  switch (granularity) {
+    case 0: {
       // Asking for 4D segments for the CSC/DT and a point for the RPC
-      recHitsForFit.push_back( muonRecHit );
+      recHitsForFit.push_back(muonRecHit);
       break;
     }
-  case 1:
-    {
-      if (subDet == MuonSubdetId::DT ||
-	  subDet == MuonSubdetId::CSC) 
-	// measurement->recHit() returns a 4D segment, then
-	// DT case: asking for 2D segments.
-	// CSC case: asking for 2D points.
-	recHitsForFit = muonRecHit->transientHits();
-      
-      else if(subDet == MuonSubdetId::RPC)
-	recHitsForFit.push_back( muonRecHit);   
-      
+    case 1: {
+      if (subDet == MuonSubdetId::DT || subDet == MuonSubdetId::CSC)
+        // measurement->recHit() returns a 4D segment, then
+        // DT case: asking for 2D segments.
+        // CSC case: asking for 2D points.
+        recHitsForFit = muonRecHit->transientHits();
+
+      else if (subDet == MuonSubdetId::RPC)
+        recHitsForFit.push_back(muonRecHit);
+
       break;
     }
-    
-  case 2:
-    {
-      if (subDet == MuonSubdetId::DT ) {
 
-	// Asking for 2D segments. measurement->recHit() returns a 4D segment
-	TransientTrackingRecHit::ConstRecHitContainer segments2D = muonRecHit->transientHits();
-	
-	// loop over segment
-	for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator segment = segments2D.begin(); 
-	     segment != segments2D.end();++segment ){
+    case 2: {
+      if (subDet == MuonSubdetId::DT) {
+        // Asking for 2D segments. measurement->recHit() returns a 4D segment
+        TransientTrackingRecHit::ConstRecHitContainer segments2D = muonRecHit->transientHits();
 
-	  // asking for 1D Rec Hit
-	  TransientTrackingRecHit::ConstRecHitContainer rechit1D = (**segment).transientHits();
-	  
-	  // load them into the recHitsForFit container
-	  copy(rechit1D.begin(),rechit1D.end(),back_inserter(recHitsForFit));
-	}
+        // loop over segment
+        for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator segment = segments2D.begin();
+             segment != segments2D.end();
+             ++segment) {
+          // asking for 1D Rec Hit
+          TransientTrackingRecHit::ConstRecHitContainer rechit1D = (**segment).transientHits();
+
+          // load them into the recHitsForFit container
+          copy(rechit1D.begin(), rechit1D.end(), back_inserter(recHitsForFit));
+        }
       }
 
-      else if(subDet == MuonSubdetId::RPC)
-	recHitsForFit.push_back(muonRecHit);
-      
-      else if(subDet == MuonSubdetId::CSC)	
-	// Asking for 2D points. measurement->recHit() returns a 4D segment
-	recHitsForFit = (*muonRecHit).transientHits();
-      
+      else if (subDet == MuonSubdetId::RPC)
+        recHitsForFit.push_back(muonRecHit);
+
+      else if (subDet == MuonSubdetId::CSC)
+        // Asking for 2D points. measurement->recHit() returns a 4D segment
+        recHitsForFit = (*muonRecHit).transientHits();
+
       break;
     }
-    
-  default:
-    {
-      throw cms::Exception(metname) <<"Wrong granularity chosen!"
-				    <<"it will be set to 0";
+
+    default: {
+      throw cms::Exception(metname) << "Wrong granularity chosen!"
+                                    << "it will be set to 0";
       break;
     }
   }

--- a/RecoMuon/TransientTrackingRecHit/src/MuonTransientTrackingRecHitBuilder.cc
+++ b/RecoMuon/TransientTrackingRecHit/src/MuonTransientTrackingRecHitBuilder.cc
@@ -13,38 +13,33 @@
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
 
-MuonTransientTrackingRecHitBuilder::MuonTransientTrackingRecHitBuilder(edm::ESHandle<GlobalTrackingGeometry> trackingGeometry):
-  theTrackingGeometry(trackingGeometry)
-{}
+MuonTransientTrackingRecHitBuilder::MuonTransientTrackingRecHitBuilder(
+    edm::ESHandle<GlobalTrackingGeometry> trackingGeometry)
+    : theTrackingGeometry(trackingGeometry) {}
 
-
-MuonTransientTrackingRecHitBuilder::RecHitPointer
-MuonTransientTrackingRecHitBuilder::build (const TrackingRecHit* p, 
-					   edm::ESHandle<GlobalTrackingGeometry> trackingGeometry) const {
-  
-  if ( p->geographicalId().det() == DetId::Muon ) {
-    return MuonTransientTrackingRecHit::specificBuild(trackingGeometry->idToDet(p->geographicalId()),p);
+MuonTransientTrackingRecHitBuilder::RecHitPointer MuonTransientTrackingRecHitBuilder::build(
+    const TrackingRecHit* p, edm::ESHandle<GlobalTrackingGeometry> trackingGeometry) const {
+  if (p->geographicalId().det() == DetId::Muon) {
+    return MuonTransientTrackingRecHit::specificBuild(trackingGeometry->idToDet(p->geographicalId()), p);
   }
-  
-  return RecHitPointer();
 
+  return RecHitPointer();
 }
 
-MuonTransientTrackingRecHitBuilder::RecHitPointer
-MuonTransientTrackingRecHitBuilder::build(const TrackingRecHit * p) const {
-  if(theTrackingGeometry.isValid()) return build(p,theTrackingGeometry);
+MuonTransientTrackingRecHitBuilder::RecHitPointer MuonTransientTrackingRecHitBuilder::build(
+    const TrackingRecHit* p) const {
+  if (theTrackingGeometry.isValid())
+    return build(p, theTrackingGeometry);
   else
     throw cms::Exception("Muon|RecoMuon|MuonTransientTrackingRecHitBuilder")
-      <<"ERROR! You are trying to build a MuonTransientTrackingRecHit with a non valid GlobalTrackingGeometry";
+        << "ERROR! You are trying to build a MuonTransientTrackingRecHit with a non valid GlobalTrackingGeometry";
 }
 
-MuonTransientTrackingRecHitBuilder::ConstRecHitContainer 
-MuonTransientTrackingRecHitBuilder::build(const trackingRecHit_iterator& start, const trackingRecHit_iterator& stop) const {
- 
+MuonTransientTrackingRecHitBuilder::ConstRecHitContainer MuonTransientTrackingRecHitBuilder::build(
+    const trackingRecHit_iterator& start, const trackingRecHit_iterator& stop) const {
   ConstRecHitContainer result;
-  for(trackingRecHit_iterator hit = start; hit != stop; ++hit )
+  for (trackingRecHit_iterator hit = start; hit != stop; ++hit)
     result.push_back(build(&**hit));
-  
+
   return result;
 }
-  

--- a/RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimple2007H4TBAnalyzer.h
+++ b/RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimple2007H4TBAnalyzer.h
@@ -11,8 +11,6 @@
 //
 //
 
-
-
 // system include files
 #include <memory>
 
@@ -35,82 +33,78 @@
 #include "TH1.h"
 #include "TGraph.h"
 #include "TH2.h"
-#include<fstream>
-#include<map>
+#include <fstream>
+#include <map>
 //#include<stl_pair>
 
-
-
 class EcalSimple2007H4TBAnalyzer : public edm::EDAnalyzer {
-   public:
-      explicit EcalSimple2007H4TBAnalyzer( const edm::ParameterSet& );
-      ~EcalSimple2007H4TBAnalyzer() override;
+public:
+  explicit EcalSimple2007H4TBAnalyzer(const edm::ParameterSet&);
+  ~EcalSimple2007H4TBAnalyzer() override;
 
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endJob() override;
 
-      void analyze( edm::Event const &, edm::EventSetup const & ) override;
-      void beginRun(edm::Run const &, edm::EventSetup const&) override;
-      void endJob() override;
- private:
-      std::string rootfile_;
-      std::string digiCollection_;
-      std::string digiProducer_;
-      std::string hitCollection_;
-      std::string hitProducer_;
-      std::string hodoRecInfoCollection_;
-      std::string hodoRecInfoProducer_;
-      std::string tdcRecInfoCollection_;
-      std::string tdcRecInfoProducer_;
-      std::string eventHeaderCollection_;
-      std::string eventHeaderProducer_;
+private:
+  std::string rootfile_;
+  std::string digiCollection_;
+  std::string digiProducer_;
+  std::string hitCollection_;
+  std::string hitProducer_;
+  std::string hodoRecInfoCollection_;
+  std::string hodoRecInfoProducer_;
+  std::string tdcRecInfoCollection_;
+  std::string tdcRecInfoProducer_;
+  std::string eventHeaderCollection_;
+  std::string eventHeaderProducer_;
 
-      // Amplitude vs TDC offset
-      TH2F* h_ampltdc;
+  // Amplitude vs TDC offset
+  TH2F* h_ampltdc;
 
-      TH2F* h_Shape_;
-      
-      // Reconstructed energies
-      TH1F* h_tableIsMoving;
-      TH1F* h_e1x1;
-      TH1F* h_e3x3; 
-      TH1F* h_e5x5; 
+  TH2F* h_Shape_;
 
-      TH1F* h_e1x1_center;
-      TH1F* h_e3x3_center; 
-      TH1F* h_e5x5_center; 
-      
-      TH1F* h_e1e9;
-      TH1F* h_e1e25;
-      TH1F* h_e9e25;
+  // Reconstructed energies
+  TH1F* h_tableIsMoving;
+  TH1F* h_e1x1;
+  TH1F* h_e3x3;
+  TH1F* h_e5x5;
 
-      TH1F* h_S6; 
-      TH1F* h_bprofx; 
-      TH1F* h_bprofy; 
-      
-      TH1F* h_qualx; 
-      TH1F* h_qualy; 
-      
-      TH1F* h_slopex; 
-      TH1F* h_slopey; 
-      
-      TH2F* h_mapx[25]; 
-      TH2F* h_mapy[25]; 
+  TH1F* h_e1x1_center;
+  TH1F* h_e3x3_center;
+  TH1F* h_e5x5_center;
 
-      TH2F* h_e1e9_mapx;
-      TH2F* h_e1e9_mapy;
+  TH1F* h_e1e9;
+  TH1F* h_e1e25;
+  TH1F* h_e9e25;
 
-      TH2F* h_e1e25_mapx;
-      TH2F* h_e1e25_mapy;
+  TH1F* h_S6;
+  TH1F* h_bprofx;
+  TH1F* h_bprofy;
 
-      TH2F* h_e9e25_mapx;
-      TH2F* h_e9e25_mapy;
+  TH1F* h_qualx;
+  TH1F* h_qualy;
 
-      EEDetId xtalInBeam_;
-      EBDetId xtalInBeamTmp;
-      EEDetId Xtals5x5[25];
+  TH1F* h_slopex;
+  TH1F* h_slopey;
 
-      const CaloGeometry* theTBGeometry_;
+  TH2F* h_mapx[25];
+  TH2F* h_mapy[25];
+
+  TH2F* h_e1e9_mapx;
+  TH2F* h_e1e9_mapy;
+
+  TH2F* h_e1e25_mapx;
+  TH2F* h_e1e25_mapy;
+
+  TH2F* h_e9e25_mapx;
+  TH2F* h_e9e25_mapy;
+
+  EEDetId xtalInBeam_;
+  EBDetId xtalInBeamTmp;
+  EEDetId Xtals5x5[25];
+
+  const CaloGeometry* theTBGeometry_;
 };
-
-
 
 #endif

--- a/RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimpleTBAnalyzer.h
+++ b/RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimpleTBAnalyzer.h
@@ -11,8 +11,6 @@
 //
 //
 
-
-
 // system include files
 #include <memory>
 
@@ -33,79 +31,73 @@
 #include "TH1.h"
 #include "TGraph.h"
 #include "TH2.h"
-#include<fstream>
-#include<map>
+#include <fstream>
+#include <map>
 //#include<stl_pair>
 
-
-
 class EcalSimpleTBAnalyzer : public edm::EDAnalyzer {
-   public:
-      explicit EcalSimpleTBAnalyzer( const edm::ParameterSet& );
-      ~EcalSimpleTBAnalyzer() override;
+public:
+  explicit EcalSimpleTBAnalyzer(const edm::ParameterSet&);
+  ~EcalSimpleTBAnalyzer() override;
 
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void beginJob() override;
+  void endJob() override;
 
-      void analyze( const edm::Event&, const edm::EventSetup& ) override;
-      void beginJob() override;
-      void endJob() override;
- private:
+private:
+  std::string rootfile_;
+  std::string digiCollection_;
+  std::string digiProducer_;
+  std::string hitCollection_;
+  std::string hitProducer_;
+  std::string hodoRecInfoCollection_;
+  std::string hodoRecInfoProducer_;
+  std::string tdcRecInfoCollection_;
+  std::string tdcRecInfoProducer_;
+  std::string eventHeaderCollection_;
+  std::string eventHeaderProducer_;
 
-      
-      std::string rootfile_;
-      std::string digiCollection_;
-      std::string digiProducer_;
-      std::string hitCollection_;
-      std::string hitProducer_;
-      std::string hodoRecInfoCollection_;
-      std::string hodoRecInfoProducer_;
-      std::string tdcRecInfoCollection_;
-      std::string tdcRecInfoProducer_;
-      std::string eventHeaderCollection_;
-      std::string eventHeaderProducer_;
+  // Amplitude vs TDC offset
+  TH2F* h_ampltdc;
 
-      // Amplitude vs TDC offset
-      TH2F* h_ampltdc;
+  TH2F* h_Shape_;
 
-      TH2F* h_Shape_;
-      
-      // Reconstructed energies
-      TH1F* h_tableIsMoving;
-      TH1F* h_e1x1;
-      TH1F* h_e3x3; 
-      TH1F* h_e5x5; 
+  // Reconstructed energies
+  TH1F* h_tableIsMoving;
+  TH1F* h_e1x1;
+  TH1F* h_e3x3;
+  TH1F* h_e5x5;
 
-      TH1F* h_e1x1_center;
-      TH1F* h_e3x3_center; 
-      TH1F* h_e5x5_center; 
-      
-      TH1F* h_e1e9;
-      TH1F* h_e1e25;
-      TH1F* h_e9e25;
+  TH1F* h_e1x1_center;
+  TH1F* h_e3x3_center;
+  TH1F* h_e5x5_center;
 
-      TH1F* h_bprofx; 
-      TH1F* h_bprofy; 
-      
-      TH1F* h_qualx; 
-      TH1F* h_qualy; 
-      
-      TH1F* h_slopex; 
-      TH1F* h_slopey; 
-      
-      TH2F* h_mapx[25]; 
-      TH2F* h_mapy[25]; 
+  TH1F* h_e1e9;
+  TH1F* h_e1e25;
+  TH1F* h_e9e25;
 
-      TH2F* h_e1e9_mapx;
-      TH2F* h_e1e9_mapy;
+  TH1F* h_bprofx;
+  TH1F* h_bprofy;
 
-      TH2F* h_e1e25_mapx;
-      TH2F* h_e1e25_mapy;
+  TH1F* h_qualx;
+  TH1F* h_qualy;
 
-      TH2F* h_e9e25_mapx;
-      TH2F* h_e9e25_mapy;
+  TH1F* h_slopex;
+  TH1F* h_slopey;
 
-      EBDetId xtalInBeam_;
+  TH2F* h_mapx[25];
+  TH2F* h_mapy[25];
+
+  TH2F* h_e1e9_mapx;
+  TH2F* h_e1e9_mapy;
+
+  TH2F* h_e1e25_mapx;
+  TH2F* h_e1e25_mapy;
+
+  TH2F* h_e9e25_mapx;
+  TH2F* h_e9e25_mapy;
+
+  EBDetId xtalInBeam_;
 };
-
-
 
 #endif

--- a/RecoTBCalo/EcalSimpleTBAnalysis/src/EcalSimple2007H4TBAnalyzer.cc
+++ b/RecoTBCalo/EcalSimpleTBAnalysis/src/EcalSimple2007H4TBAnalyzer.cc
@@ -45,30 +45,27 @@
 // constructors and destructor
 //
 
-
 //========================================================================
-EcalSimple2007H4TBAnalyzer::EcalSimple2007H4TBAnalyzer( const edm::ParameterSet& iConfig ) : xtalInBeam_(0)
+EcalSimple2007H4TBAnalyzer::EcalSimple2007H4TBAnalyzer(const edm::ParameterSet& iConfig)
+    : xtalInBeam_(0)
 //========================================================================
 {
-   //now do what ever initialization is needed
-   rootfile_          = iConfig.getUntrackedParameter<std::string>("rootfile","ecalSimpleTBanalysis.root");
-   digiCollection_     = iConfig.getParameter<std::string>("digiCollection");
-   digiProducer_       = iConfig.getParameter<std::string>("digiProducer");
-   hitCollection_     = iConfig.getParameter<std::string>("hitCollection");
-   hitProducer_       = iConfig.getParameter<std::string>("hitProducer");
-   hodoRecInfoCollection_     = iConfig.getParameter<std::string>("hodoRecInfoCollection");
-   hodoRecInfoProducer_       = iConfig.getParameter<std::string>("hodoRecInfoProducer");
-   tdcRecInfoCollection_     = iConfig.getParameter<std::string>("tdcRecInfoCollection");
-   tdcRecInfoProducer_       = iConfig.getParameter<std::string>("tdcRecInfoProducer");
-   eventHeaderCollection_     = iConfig.getParameter<std::string>("eventHeaderCollection");
-   eventHeaderProducer_       = iConfig.getParameter<std::string>("eventHeaderProducer");
+  //now do what ever initialization is needed
+  rootfile_ = iConfig.getUntrackedParameter<std::string>("rootfile", "ecalSimpleTBanalysis.root");
+  digiCollection_ = iConfig.getParameter<std::string>("digiCollection");
+  digiProducer_ = iConfig.getParameter<std::string>("digiProducer");
+  hitCollection_ = iConfig.getParameter<std::string>("hitCollection");
+  hitProducer_ = iConfig.getParameter<std::string>("hitProducer");
+  hodoRecInfoCollection_ = iConfig.getParameter<std::string>("hodoRecInfoCollection");
+  hodoRecInfoProducer_ = iConfig.getParameter<std::string>("hodoRecInfoProducer");
+  tdcRecInfoCollection_ = iConfig.getParameter<std::string>("tdcRecInfoCollection");
+  tdcRecInfoProducer_ = iConfig.getParameter<std::string>("tdcRecInfoProducer");
+  eventHeaderCollection_ = iConfig.getParameter<std::string>("eventHeaderCollection");
+  eventHeaderProducer_ = iConfig.getParameter<std::string>("eventHeaderProducer");
 
-
-   std::cout << "EcalSimple2007H4TBAnalyzer: fetching hitCollection: " << hitCollection_.c_str()
-	<< " produced by " << hitProducer_.c_str() << std::endl;
-
+  std::cout << "EcalSimple2007H4TBAnalyzer: fetching hitCollection: " << hitCollection_.c_str() << " produced by "
+            << hitProducer_.c_str() << std::endl;
 }
-
 
 //========================================================================
 EcalSimple2007H4TBAnalyzer::~EcalSimple2007H4TBAnalyzer()
@@ -77,146 +74,139 @@ EcalSimple2007H4TBAnalyzer::~EcalSimple2007H4TBAnalyzer()
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
   // Amplitude vs TDC offset
-//   if (h_ampltdc)
-//   delete h_ampltdc;
-  
-//   // Reconstructed energies
-//   delete h_e1x1;
-//   delete h_e3x3; 
-//   delete h_e5x5; 
-  
-//   delete h_bprofx; 
-//   delete h_bprofy; 
-  
-//   delete h_qualx; 
-//   delete h_qualy; 
-  
-//   delete h_slopex; 
-//   delete h_slopey; 
-  
-//   delete h_mapx; 
-//   delete h_mapy; 
+  //   if (h_ampltdc)
+  //   delete h_ampltdc;
 
+  //   // Reconstructed energies
+  //   delete h_e1x1;
+  //   delete h_e3x3;
+  //   delete h_e5x5;
+
+  //   delete h_bprofx;
+  //   delete h_bprofy;
+
+  //   delete h_qualx;
+  //   delete h_qualy;
+
+  //   delete h_slopex;
+  //   delete h_slopey;
+
+  //   delete h_mapx;
+  //   delete h_mapy;
 }
 
 //========================================================================
-void
-EcalSimple2007H4TBAnalyzer::beginRun(edm::Run const &, edm::EventSetup const& iSetup) {
-//========================================================================
+void EcalSimple2007H4TBAnalyzer::beginRun(edm::Run const&, edm::EventSetup const& iSetup) {
+  //========================================================================
 
   edm::ESHandle<CaloGeometry> pG;
-  iSetup.get<CaloGeometryRecord>().get(pG);   
+  iSetup.get<CaloGeometryRecord>().get(pG);
 
-  
-  theTBGeometry_ =  pG.product();
-//  const std::vector<DetId>& validIds=theTBGeometry_->getValidDetIds(DetId::Ecal,EcalEndcap);
-//   std::cout << "Found " << validIds.size() << " channels in the geometry" << std::endl;
-//   for (unsigned int i=0;i<validIds.size();++i)
-//     std::cout << EEDetId(validIds[i]) << std::endl;
+  theTBGeometry_ = pG.product();
+  //  const std::vector<DetId>& validIds=theTBGeometry_->getValidDetIds(DetId::Ecal,EcalEndcap);
+  //   std::cout << "Found " << validIds.size() << " channels in the geometry" << std::endl;
+  //   for (unsigned int i=0;i<validIds.size();++i)
+  //     std::cout << EEDetId(validIds[i]) << std::endl;
 
-// Amplitude vs TDC offset
-  h_ampltdc = new TH2F("h_ampltdc","Max Amplitude vs TDC offset", 100,0.,1.,1000, 0., 4000.);
+  // Amplitude vs TDC offset
+  h_ampltdc = new TH2F("h_ampltdc", "Max Amplitude vs TDC offset", 100, 0., 1., 1000, 0., 4000.);
 
   // Reconstructed energies
-  h_tableIsMoving = new TH1F("h_tableIsMoving","TableIsMoving", 100000, 0., 100000.);
+  h_tableIsMoving = new TH1F("h_tableIsMoving", "TableIsMoving", 100000, 0., 100000.);
 
-  h_e1x1 = new TH1F("h_e1x1","E1x1 energy", 1000, 0., 4000.);
-  h_e3x3 = new TH1F("h_e3x3","E3x3 energy", 1000, 0., 4000.);
-  h_e5x5 = new TH1F("h_e5x5","E5x5 energy", 1000, 0., 4000.);
+  h_e1x1 = new TH1F("h_e1x1", "E1x1 energy", 1000, 0., 4000.);
+  h_e3x3 = new TH1F("h_e3x3", "E3x3 energy", 1000, 0., 4000.);
+  h_e5x5 = new TH1F("h_e5x5", "E5x5 energy", 1000, 0., 4000.);
 
-  h_e1x1_center = new TH1F("h_e1x1_center","E1x1 energy", 1000, 0., 4000.);
-  h_e3x3_center = new TH1F("h_e3x3_center","E3x3 energy", 1000, 0., 4000.);
-  h_e5x5_center = new TH1F("h_e5x5_center","E5x5 energy", 1000, 0., 4000.);
+  h_e1x1_center = new TH1F("h_e1x1_center", "E1x1 energy", 1000, 0., 4000.);
+  h_e3x3_center = new TH1F("h_e3x3_center", "E3x3 energy", 1000, 0., 4000.);
+  h_e5x5_center = new TH1F("h_e5x5_center", "E5x5 energy", 1000, 0., 4000.);
 
-  h_e1e9 = new TH1F("h_e1e9","E1/E9 ratio", 600, 0., 1.2);
-  h_e1e25 = new TH1F("h_e1e25","E1/E25 ratio", 600, 0., 1.2);
-  h_e9e25 = new TH1F("h_e9e25","E9/E25 ratio", 600, 0., 1.2);
+  h_e1e9 = new TH1F("h_e1e9", "E1/E9 ratio", 600, 0., 1.2);
+  h_e1e25 = new TH1F("h_e1e25", "E1/E25 ratio", 600, 0., 1.2);
+  h_e9e25 = new TH1F("h_e9e25", "E9/E25 ratio", 600, 0., 1.2);
 
-  h_S6 = new TH1F("h_S6","Amplitude S6", 1000, 0., 4000.);
+  h_S6 = new TH1F("h_S6", "Amplitude S6", 1000, 0., 4000.);
 
-  h_bprofx = new TH1F("h_bprofx","Beam Profile X",100,-20.,20.);
-  h_bprofy = new TH1F("h_bprofy","Beam Profile Y",100,-20.,20.);
+  h_bprofx = new TH1F("h_bprofx", "Beam Profile X", 100, -20., 20.);
+  h_bprofy = new TH1F("h_bprofy", "Beam Profile Y", 100, -20., 20.);
 
-  h_qualx = new TH1F("h_qualx","Beam Quality X",5000,0.,5.);
-  h_qualy = new TH1F("h_qualy","Beam Quality X",5000,0.,5.);
+  h_qualx = new TH1F("h_qualx", "Beam Quality X", 5000, 0., 5.);
+  h_qualy = new TH1F("h_qualy", "Beam Quality X", 5000, 0., 5.);
 
-  h_slopex = new TH1F("h_slopex","Beam Slope X",500, -5e-4 , 5e-4 );
-  h_slopey = new TH1F("h_slopey","Beam Slope Y",500, -5e-4 , 5e-4 );
+  h_slopex = new TH1F("h_slopex", "Beam Slope X", 500, -5e-4, 5e-4);
+  h_slopey = new TH1F("h_slopey", "Beam Slope Y", 500, -5e-4, 5e-4);
 
   char hname[50];
   char htitle[50];
-  for (unsigned int icry=0;icry<25;icry++)
-    {       
-      sprintf(hname,"h_mapx_%d",icry);
-      sprintf(htitle,"Max Amplitude vs X %d",icry);
-      h_mapx[icry] = new TH2F(hname,htitle,80,-20,20,1000,0.,4000.);
-      sprintf(hname,"h_mapy_%d",icry);
-      sprintf(htitle,"Max Amplitude vs Y %d",icry);
-      h_mapy[icry] = new TH2F(hname,htitle,80,-20,20,1000,0.,4000.);
-    }
-  
-  h_e1e9_mapx = new TH2F("h_e1e9_mapx","E1/E9 vs X",80,-20,20,600,0.,1.2);
-  h_e1e9_mapy = new TH2F("h_e1e9_mapy","E1/E9 vs Y",80,-20,20,600,0.,1.2);
+  for (unsigned int icry = 0; icry < 25; icry++) {
+    sprintf(hname, "h_mapx_%d", icry);
+    sprintf(htitle, "Max Amplitude vs X %d", icry);
+    h_mapx[icry] = new TH2F(hname, htitle, 80, -20, 20, 1000, 0., 4000.);
+    sprintf(hname, "h_mapy_%d", icry);
+    sprintf(htitle, "Max Amplitude vs Y %d", icry);
+    h_mapy[icry] = new TH2F(hname, htitle, 80, -20, 20, 1000, 0., 4000.);
+  }
 
-  h_e1e25_mapx = new TH2F("h_e1e25_mapx","E1/E25 vs X",80,-20,20,600,0.,1.2);
-  h_e1e25_mapy = new TH2F("h_e1e25_mapy","E1/E25 vs Y",80,-20,20,600,0.,1.2);
+  h_e1e9_mapx = new TH2F("h_e1e9_mapx", "E1/E9 vs X", 80, -20, 20, 600, 0., 1.2);
+  h_e1e9_mapy = new TH2F("h_e1e9_mapy", "E1/E9 vs Y", 80, -20, 20, 600, 0., 1.2);
 
-  h_e9e25_mapx = new TH2F("h_e9e25_mapx","E9/E25 vs X",80,-20,20,600,0.,1.2);
-  h_e9e25_mapy = new TH2F("h_e9e25_mapy","E9/E25 vs Y",80,-20,20,600,0.,1.2);
+  h_e1e25_mapx = new TH2F("h_e1e25_mapx", "E1/E25 vs X", 80, -20, 20, 600, 0., 1.2);
+  h_e1e25_mapy = new TH2F("h_e1e25_mapy", "E1/E25 vs Y", 80, -20, 20, 600, 0., 1.2);
 
-  h_Shape_ = new TH2F("h_Shape_","Xtal in Beam Shape",250,0,10,350,0,3500);
+  h_e9e25_mapx = new TH2F("h_e9e25_mapx", "E9/E25 vs X", 80, -20, 20, 600, 0., 1.2);
+  h_e9e25_mapy = new TH2F("h_e9e25_mapy", "E9/E25 vs Y", 80, -20, 20, 600, 0., 1.2);
 
+  h_Shape_ = new TH2F("h_Shape_", "Xtal in Beam Shape", 250, 0, 10, 350, 0, 3500);
 }
 
 //========================================================================
-void
-EcalSimple2007H4TBAnalyzer::endJob() {
-//========================================================================
+void EcalSimple2007H4TBAnalyzer::endJob() {
+  //========================================================================
 
-  TFile f(rootfile_.c_str(),"RECREATE");
+  TFile f(rootfile_.c_str(), "RECREATE");
 
   // Amplitude vs TDC offset
-  h_ampltdc->Write(); 
+  h_ampltdc->Write();
 
   // Reconstructed energies
-  h_e1x1->Write(); 
-  h_e3x3->Write(); 
-  h_e5x5->Write(); 
+  h_e1x1->Write();
+  h_e3x3->Write();
+  h_e5x5->Write();
 
-  h_e1x1_center->Write(); 
-  h_e3x3_center->Write(); 
-  h_e5x5_center->Write(); 
+  h_e1x1_center->Write();
+  h_e3x3_center->Write();
+  h_e5x5_center->Write();
 
-  h_e1e9->Write(); 
-  h_e1e25->Write(); 
-  h_e9e25->Write(); 
+  h_e1e9->Write();
+  h_e1e25->Write();
+  h_e9e25->Write();
 
-  h_S6->Write(); 
-  h_bprofx->Write(); 
-  h_bprofy->Write(); 
+  h_S6->Write();
+  h_bprofx->Write();
+  h_bprofy->Write();
 
-  h_qualx->Write(); 
-  h_qualy->Write(); 
+  h_qualx->Write();
+  h_qualy->Write();
 
-  h_slopex->Write(); 
-  h_slopey->Write(); 
-  
+  h_slopex->Write();
+  h_slopey->Write();
+
   h_Shape_->Write();
 
-  for (unsigned int icry=0;icry<25;icry++)
-    {       
-      h_mapx[icry]->Write(); 
-      h_mapy[icry]->Write(); 
-    }
+  for (unsigned int icry = 0; icry < 25; icry++) {
+    h_mapx[icry]->Write();
+    h_mapy[icry]->Write();
+  }
 
-  h_e1e9_mapx->Write(); 
-  h_e1e9_mapy->Write(); 
+  h_e1e9_mapx->Write();
+  h_e1e9_mapy->Write();
 
-  h_e1e25_mapx->Write(); 
-  h_e1e25_mapy->Write(); 
+  h_e1e25_mapx->Write();
+  h_e1e25_mapy->Write();
 
-  h_e9e25_mapx->Write(); 
-  h_e9e25_mapy->Write(); 
+  h_e9e25_mapx->Write();
+  h_e9e25_mapy->Write();
 
   h_tableIsMoving->Write();
 
@@ -228,283 +218,248 @@ EcalSimple2007H4TBAnalyzer::endJob() {
 //
 
 //========================================================================
-void
-EcalSimple2007H4TBAnalyzer::analyze( edm::Event const & iEvent, edm::EventSetup const & iSetup ) {
-//========================================================================
+void EcalSimple2007H4TBAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+  //========================================================================
 
-   using namespace edm;
-   using namespace cms;
+  using namespace edm;
+  using namespace cms;
 
+  Handle<EEDigiCollection> pdigis;
+  const EEDigiCollection* digis = nullptr;
+  //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(digiProducer_, digiCollection_, pdigis);
+  if (pdigis.isValid()) {
+    digis = pdigis.product();  // get a ptr to the product
+    //iEvent.getByLabel( hitProducer_, phits);
+  } else {
+    edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << digiCollection_;
+  }
 
+  // fetch the digis and compute signal amplitude
+  Handle<EEUncalibratedRecHitCollection> phits;
+  const EEUncalibratedRecHitCollection* hits = nullptr;
+  //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(hitProducer_, hitCollection_, phits);
+  if (phits.isValid()) {
+    hits = phits.product();  // get a ptr to the product
+    //iEvent.getByLabel( hitProducer_, phits);
+  } else {
+    edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << hitCollection_;
+  }
 
-   Handle<EEDigiCollection> pdigis;
-   const EEDigiCollection* digis=nullptr;
-   //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( digiProducer_, digiCollection_,pdigis);
-   if ( pdigis.isValid() ) {
-     digis = pdigis.product(); // get a ptr to the product
-     //iEvent.getByLabel( hitProducer_, phits);
-   } else {
-           edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << digiCollection_;
-   }
+  Handle<EcalTBHodoscopeRecInfo> pHodo;
+  const EcalTBHodoscopeRecInfo* recHodo = nullptr;
+  //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(hodoRecInfoProducer_, hodoRecInfoCollection_, pHodo);
+  if (pHodo.isValid()) {
+    recHodo = pHodo.product();  // get a ptr to the product
+  } else {
+    edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << hodoRecInfoCollection_;
+  }
 
-   // fetch the digis and compute signal amplitude
-   Handle<EEUncalibratedRecHitCollection> phits;
-   const EEUncalibratedRecHitCollection* hits=nullptr;
-   //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( hitProducer_, hitCollection_,phits);
-   if (phits.isValid()) {
-     hits = phits.product(); // get a ptr to the product
-     //iEvent.getByLabel( hitProducer_, phits);
-   } else {
-           edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << hitCollection_;
-   }
+  Handle<EcalTBTDCRecInfo> pTDC;
+  const EcalTBTDCRecInfo* recTDC = nullptr;
+  //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(tdcRecInfoProducer_, tdcRecInfoCollection_, pTDC);
+  if (pTDC.isValid()) {
+    recTDC = pTDC.product();  // get a ptr to the product
+  } else {
+    edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << tdcRecInfoCollection_;
+  }
 
-   Handle<EcalTBHodoscopeRecInfo> pHodo;
-   const EcalTBHodoscopeRecInfo* recHodo=nullptr;
-   //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( hodoRecInfoProducer_, hodoRecInfoCollection_, pHodo);
-   if ( pHodo.isValid() ) {
-     recHodo = pHodo.product(); // get a ptr to the product
-   } else {
-           edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << hodoRecInfoCollection_;
-   }
+  Handle<EcalTBEventHeader> pEventHeader;
+  const EcalTBEventHeader* evtHeader = nullptr;
+  //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(eventHeaderProducer_, pEventHeader);
+  if (pEventHeader.isValid()) {
+    evtHeader = pEventHeader.product();  // get a ptr to the product
+  } else {
+    edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << eventHeaderProducer_;
+  }
 
-   Handle<EcalTBTDCRecInfo> pTDC;
-   const EcalTBTDCRecInfo* recTDC=nullptr;
-   //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( tdcRecInfoProducer_, tdcRecInfoCollection_, pTDC);
-   if ( pTDC.isValid() ) {
-     recTDC = pTDC.product(); // get a ptr to the product
-   } else {
-           edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << tdcRecInfoCollection_;
-   }
+  if (!hits) {
+    //       std::cout << "1" << std::endl;
+    return;
+  }
 
-   Handle<EcalTBEventHeader> pEventHeader;
-   const EcalTBEventHeader* evtHeader=nullptr;
-   //std::cout << "EcalSimple2007H4TBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( eventHeaderProducer_ , pEventHeader );
-   if ( pEventHeader.isValid() ) {
-     evtHeader = pEventHeader.product(); // get a ptr to the product
-   } else {
-           edm::LogError("EcalSimple2007H4TBAnalyzerError") << "Error! can't get the product " << eventHeaderProducer_;
-   }
-   
-   
-   if (!hits)
-     {
-       //       std::cout << "1" << std::endl;
-       return;
-     }
+  if (!recTDC) {
+    //       std::cout << "2" << std::endl;
+    return;
+  }
 
-   if (!recTDC)
-     {
-       //       std::cout << "2" << std::endl;
-       return;
-     }
+  if (!recHodo) {
+    //       std::cout << "3" << std::endl;
+    return;
+  }
 
-   if (!recHodo)
-     {
-       //       std::cout << "3" << std::endl;
-       return;
-     }
+  if (!evtHeader) {
+    //       std::cout << "4" << std::endl;
+    return;
+  }
 
-   if (!evtHeader)
-     {
-       //       std::cout << "4" << std::endl;
-       return;
-     }
+  if (hits->empty()) {
+    //       std::cout << "5" << std::endl;
+    return;
+  }
 
-   if (hits->empty())
-     {
-       //       std::cout << "5" << std::endl;
-       return;
-     }
+  //Accessing various event information
+  if (evtHeader->tableIsMoving())
+    h_tableIsMoving->Fill(evtHeader->eventNumber());
 
-   //Accessing various event information
-   if (evtHeader->tableIsMoving())
-     h_tableIsMoving->Fill(evtHeader->eventNumber());
+  //    std::cout << "event " << evtHeader->eventNumber()
+  // 	     << "\trun number " << evtHeader->runNumber()
+  // 	     << "\tburst number " << evtHeader->burstNumber()
+  // 	     << "\tbeginLV1A " << evtHeader->begBurstLV1A()
+  // 	     << "\tendLV1A " << evtHeader->endBurstLV1A()
+  // 	     << "\ttime " << evtHeader->date()
+  // 	     << "\thas errors " << int(evtHeader->syncError())
+  // 	     << std::endl;
 
-//    std::cout << "event " << evtHeader->eventNumber() 
-// 	     << "\trun number " << evtHeader->runNumber()   
-// 	     << "\tburst number " << evtHeader->burstNumber()   
-// 	     << "\tbeginLV1A " << evtHeader->begBurstLV1A()
-// 	     << "\tendLV1A " << evtHeader->endBurstLV1A()
-// 	     << "\ttime " << evtHeader->date()
-// 	     << "\thas errors " << int(evtHeader->syncError())
-// 	     << std::endl;
+  //    std::cout << "scaler";
+  //    for (int iscaler=0;iscaler < 36;iscaler++)
+  //      std::cout << "\t#" << iscaler << " " <<  evtHeader->scaler(iscaler);
+  //    std::cout<<std::endl;
 
-//    std::cout << "scaler";
-//    for (int iscaler=0;iscaler < 36;iscaler++)
-//      std::cout << "\t#" << iscaler << " " <<  evtHeader->scaler(iscaler);
-//    std::cout<<std::endl;
+  //S6 beam scintillator
+  h_S6->Fill(evtHeader->S6ADC());
 
-   //S6 beam scintillator
-   h_S6->Fill(evtHeader->S6ADC());
+  if (xtalInBeamTmp.null()) {
+    xtalInBeamTmp = EBDetId(1, evtHeader->crystalInBeam(), EBDetId::SMCRYSTALMODE);
+    xtalInBeam_ = EEDetId(35 - ((xtalInBeamTmp.ic() - 1) % 20), int(int(xtalInBeamTmp.ic()) / int(20)) + 51, -1);
+    std::cout << "Xtal In Beam is " << xtalInBeam_.ic() << xtalInBeam_ << std::endl;
+    for (unsigned int icry = 0; icry < 25; icry++) {
+      unsigned int row = icry / 5;
+      unsigned int column = icry % 5;
+      int ix = xtalInBeam_.ix() + row - 2;
+      int iy = xtalInBeam_.iy() + column - 2;
+      EEDetId tempId(ix, iy, xtalInBeam_.zside());
+      //Selecting matrix of xtals used in 2007H4TB
+      if (tempId.ix() < 16 || tempId.ix() > 35 || tempId.iy() < 51 || tempId.iy() > 75)
+        Xtals5x5[icry] = EEDetId(0);
+      else {
+        Xtals5x5[icry] = tempId;
+        auto cell = theTBGeometry_->getGeometry(Xtals5x5[icry]);
+        if (!cell)
+          continue;
+        std::cout << "** Xtal in the matrix **** row " << row << ", column " << column << ", xtal " << Xtals5x5[icry]
+                  << " Position " << cell->getPosition(0.) << std::endl;
+      }
+    }
+  } else if (xtalInBeamTmp !=
+             EBDetId(1, evtHeader->crystalInBeam(), EBDetId::SMCRYSTALMODE))  //run analysis only on first xtal in beam
+    return;
 
-   if (xtalInBeamTmp.null())
-     {
-       xtalInBeamTmp = EBDetId(1,evtHeader->crystalInBeam(),EBDetId::SMCRYSTALMODE);
-       xtalInBeam_ = EEDetId( 35 - ((xtalInBeamTmp.ic()-1)%20) ,int(int(xtalInBeamTmp.ic())/int(20))+51, -1);
-       std::cout<< "Xtal In Beam is " << xtalInBeam_.ic() << xtalInBeam_ << std::endl;
-       for (unsigned int icry=0;icry<25;icry++)
-	 {
-	   unsigned int row = icry / 5;
-	   unsigned int column= icry %5;
-	   int ix=xtalInBeam_.ix()+row-2;
-	   int iy=xtalInBeam_.iy()+column-2;
-	   EEDetId tempId(ix, iy, xtalInBeam_.zside());
-	   //Selecting matrix of xtals used in 2007H4TB
-	   if (tempId.ix()<16 || tempId.ix()>35 || tempId.iy()<51 || tempId.iy()>75)
-	     Xtals5x5[icry]=EEDetId(0);
-	   else
-	     {
-	       Xtals5x5[icry]=tempId;
-	       auto cell=theTBGeometry_->getGeometry(Xtals5x5[icry]);
-	       if (!cell) 
-		 continue;
-	       std::cout << "** Xtal in the matrix **** row " << row  << ", column " << column << ", xtal " << Xtals5x5[icry] << " Position " << cell->getPosition(0.) << std::endl;
-	     }
-	 }
-     }
-   else 
-     if (xtalInBeamTmp != EBDetId(1,evtHeader->crystalInBeam(),EBDetId::SMCRYSTALMODE)) //run analysis only on first xtal in beam
-       return;
+  //Avoid moving table events
+  if (evtHeader->tableIsMoving()) {
+    std::cout << "Table is moving" << std::endl;
+    return;
+  }
 
-   //Avoid moving table events
-   if (evtHeader->tableIsMoving())
-     {
-       std::cout << "Table is moving" << std::endl;
-       return;
-     }
+  // Searching for max amplitude xtal alternative to use xtalInBeam_
+  EEDetId maxHitId(0);
+  float maxHit = -999999.;
+  for (EEUncalibratedRecHitCollection::const_iterator ithit = hits->begin(); ithit != hits->end(); ++ithit) {
+    if (ithit->amplitude() >= maxHit) {
+      maxHit = ithit->amplitude();
+      maxHitId = ithit->id();
+    }
+  }
+  if (maxHitId == EEDetId(0)) {
+    std::cout << "No maxHit found" << std::endl;
+    return;
+  }
 
+  //Filling the digis shape for the xtalInBeam
+  double samples_save[10];
+  for (int i = 0; i < 10; ++i)
+    samples_save[i] = 0.0;
 
-   
-   // Searching for max amplitude xtal alternative to use xtalInBeam_
-   EEDetId maxHitId(0); 
-   float maxHit= -999999.;
-   for(EEUncalibratedRecHitCollection::const_iterator ithit = hits->begin(); ithit != hits->end(); ++ithit) 
-     {
-       if (ithit->amplitude()>=maxHit)
-	 {
-	   maxHit=ithit->amplitude();
-	   maxHitId=ithit->id();
-	 }
-       
-     }   
-   if (maxHitId==EEDetId(0))
-     {
-       std::cout << "No maxHit found" << std::endl;
-       return;
-     }
+  double eMax = 0.;
+  for (EEDigiCollection::const_iterator digiItr = digis->begin(); digiItr != digis->end(); ++digiItr) {
+    if (EEDetId((*digiItr).id()) != xtalInBeam_)
+      continue;
 
-    
-   //Filling the digis shape for the xtalInBeam
-   double samples_save[10]; for(int i=0; i < 10; ++i) samples_save[i]=0.0;
-   
-   double eMax = 0.;
-   for ( EEDigiCollection::const_iterator digiItr= digis->begin();digiItr != digis->end(); 
-	 ++digiItr ) 
-     {		
-       if ( EEDetId((*digiItr).id()) != xtalInBeam_ )
-	 continue;
-       
-       EEDataFrame myDigi = (*digiItr);
-       for (int sample = 0; sample < myDigi.size(); ++sample)
-	 {
-	   double analogSample = myDigi.sample(sample).adc();
-	   samples_save[sample] = analogSample;
-	   //  std::cout << analogSample << " ";
-	   if ( eMax < analogSample )
-	     {
-	       eMax = analogSample;
-	     }
-	 }
-       // std::cout << std::endl;
-     }
+    EEDataFrame myDigi = (*digiItr);
+    for (int sample = 0; sample < myDigi.size(); ++sample) {
+      double analogSample = myDigi.sample(sample).adc();
+      samples_save[sample] = analogSample;
+      //  std::cout << analogSample << " ";
+      if (eMax < analogSample) {
+        eMax = analogSample;
+      }
+    }
+    // std::cout << std::endl;
+  }
 
-   for(int i =0; i < 10; ++i) 
-     h_Shape_->Fill(double(i)+recTDC->offset(),samples_save[i]);
+  for (int i = 0; i < 10; ++i)
+    h_Shape_->Fill(double(i) + recTDC->offset(), samples_save[i]);
 
+  // Taking amplitudes in 5x5
+  double amplitude[25];
+  double amplitude3x3 = 0;
+  double amplitude5x5 = 0;
+  for (unsigned int icry = 0; icry < 25; icry++) {
+    if (!Xtals5x5[icry].null()) {
+      amplitude[icry] = (hits->find(Xtals5x5[icry]))->amplitude();
+      amplitude5x5 += amplitude[icry];
+      // Is in 3x3?
+      if (icry == 6 || icry == 7 || icry == 8 || icry == 11 || icry == 12 || icry == 13 || icry == 16 || icry == 17 ||
+          icry == 18) {
+        amplitude3x3 += amplitude[icry];
+      }
+    }
+  }
 
+  //Filling amplitudes
+  h_e1x1->Fill(amplitude[12]);
+  h_e3x3->Fill(amplitude3x3);
+  h_e5x5->Fill(amplitude5x5);
 
-   // Taking amplitudes in 5x5
-   double amplitude[25];
-   double amplitude3x3=0;  
-   double amplitude5x5=0;  
-   for (unsigned int icry=0;icry<25;icry++)
-     {
-       if (!Xtals5x5[icry].null())
-	 {
-	   amplitude[icry]=(hits->find(Xtals5x5[icry]))->amplitude();
-	   amplitude5x5 += amplitude[icry];
-	   // Is in 3x3?
-	   if ( icry == 6  || icry == 7  || icry == 8 ||
-		icry == 11 || icry == 12 || icry ==13 ||
-		icry == 16 || icry == 17 || icry ==18   )
-	     {
-	       amplitude3x3+=amplitude[icry];
-	     }
-	 }
-     }
+  h_e1e9->Fill(amplitude[12] / amplitude3x3);
+  h_e1e25->Fill(amplitude[12] / amplitude5x5);
+  h_e9e25->Fill(amplitude3x3 / amplitude5x5);
 
-   //Filling amplitudes
-   h_e1x1->Fill(amplitude[12]);
-   h_e3x3->Fill(amplitude3x3);
-   h_e5x5->Fill(amplitude5x5);
+  //Checking stability of amplitude vs TDC
+  if (recTDC)
+    h_ampltdc->Fill(recTDC->offset(), amplitude[12]);
 
-   h_e1e9->Fill(amplitude[12]/amplitude3x3);
-   h_e1e25->Fill(amplitude[12]/amplitude5x5);
-   h_e9e25->Fill(amplitude3x3/amplitude5x5);
+  //Various amplitudes as a function of hodoscope coordinates
+  if (recHodo) {
+    float x = recHodo->posX();
+    float y = recHodo->posY();
+    float xslope = recHodo->slopeX();
+    float yslope = recHodo->slopeY();
+    float xqual = recHodo->qualX();
+    float yqual = recHodo->qualY();
 
-   //Checking stability of amplitude vs TDC
-   if (recTDC)
-     h_ampltdc->Fill(recTDC->offset(),amplitude[12]);
+    //Filling beam profiles
+    h_bprofx->Fill(x);
+    h_bprofy->Fill(y);
+    h_qualx->Fill(xqual);
+    h_qualy->Fill(yqual);
+    h_slopex->Fill(xslope);
+    h_slopey->Fill(yslope);
 
-   //Various amplitudes as a function of hodoscope coordinates
-   if (recHodo)
-     {
-       float x=recHodo->posX();
-       float y=recHodo->posY();
-       float xslope=recHodo->slopeX();
-       float yslope=recHodo->slopeY();
-       float xqual=recHodo->qualX();
-       float yqual=recHodo->qualY();
-       
-       //Filling beam profiles
-       h_bprofx->Fill(x);
-       h_bprofy->Fill(y);
-       h_qualx->Fill(xqual);
-       h_qualy->Fill(yqual);
-       h_slopex->Fill(xslope);
-       h_slopey->Fill(yslope);
+    //Fill central events
 
-       //Fill central events
+    if (fabs(x + 2.5) < 2.5 && fabs(y + 0.5) < 2.5) {
+      h_e1x1_center->Fill(amplitude[12]);
+      h_e3x3_center->Fill(amplitude3x3);
+      h_e5x5_center->Fill(amplitude5x5);
+    }
 
-       
-       if ( fabs(x + 2.5) < 2.5 && fabs(y + 0.5) < 2.5)
-	 {
-	   h_e1x1_center->Fill(amplitude[12]);
-	   h_e3x3_center->Fill(amplitude3x3);
-	   h_e5x5_center->Fill(amplitude5x5);
-	 }
+    for (unsigned int icry = 0; icry < 25; icry++) {
+      h_mapx[icry]->Fill(x, amplitude[icry]);
+      h_mapy[icry]->Fill(y, amplitude[icry]);
+    }
 
-       for (unsigned int icry=0;icry<25;icry++)
-	 {       
-	   h_mapx[icry]->Fill(x,amplitude[icry]);
-	   h_mapy[icry]->Fill(y,amplitude[icry]);
-	 }
+    h_e1e9_mapx->Fill(x, amplitude[12] / amplitude3x3);
+    h_e1e9_mapy->Fill(y, amplitude[12] / amplitude3x3);
 
-       h_e1e9_mapx->Fill(x,amplitude[12]/amplitude3x3);
-       h_e1e9_mapy->Fill(y,amplitude[12]/amplitude3x3);
+    h_e1e25_mapx->Fill(x, amplitude[12] / amplitude5x5);
+    h_e1e25_mapy->Fill(y, amplitude[12] / amplitude5x5);
 
-       h_e1e25_mapx->Fill(x,amplitude[12]/amplitude5x5);
-       h_e1e25_mapy->Fill(y,amplitude[12]/amplitude5x5);
-
-       h_e9e25_mapx->Fill(x,amplitude3x3/amplitude5x5);
-       h_e9e25_mapy->Fill(y,amplitude3x3/amplitude5x5);
-     }
-
+    h_e9e25_mapx->Fill(x, amplitude3x3 / amplitude5x5);
+    h_e9e25_mapy->Fill(y, amplitude3x3 / amplitude5x5);
+  }
 }
-
-

--- a/RecoTBCalo/EcalSimpleTBAnalysis/src/EcalSimpleTBAnalyzer.cc
+++ b/RecoTBCalo/EcalSimpleTBAnalysis/src/EcalSimpleTBAnalyzer.cc
@@ -17,7 +17,6 @@
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBTDCRecInfo.h"
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBEventHeader.h"
 
-
 //#include<fstream>
 
 #include "TFile.h"
@@ -40,30 +39,27 @@
 // constructors and destructor
 //
 
-
 //========================================================================
-EcalSimpleTBAnalyzer::EcalSimpleTBAnalyzer( const edm::ParameterSet& iConfig ) : xtalInBeam_(0)
+EcalSimpleTBAnalyzer::EcalSimpleTBAnalyzer(const edm::ParameterSet& iConfig)
+    : xtalInBeam_(0)
 //========================================================================
 {
-   //now do what ever initialization is needed
-   rootfile_          = iConfig.getUntrackedParameter<std::string>("rootfile","ecalSimpleTBanalysis.root");
-   digiCollection_     = iConfig.getParameter<std::string>("digiCollection");
-   digiProducer_       = iConfig.getParameter<std::string>("digiProducer");
-   hitCollection_     = iConfig.getParameter<std::string>("hitCollection");
-   hitProducer_       = iConfig.getParameter<std::string>("hitProducer");
-   hodoRecInfoCollection_     = iConfig.getParameter<std::string>("hodoRecInfoCollection");
-   hodoRecInfoProducer_       = iConfig.getParameter<std::string>("hodoRecInfoProducer");
-   tdcRecInfoCollection_     = iConfig.getParameter<std::string>("tdcRecInfoCollection");
-   tdcRecInfoProducer_       = iConfig.getParameter<std::string>("tdcRecInfoProducer");
-   eventHeaderCollection_     = iConfig.getParameter<std::string>("eventHeaderCollection");
-   eventHeaderProducer_       = iConfig.getParameter<std::string>("eventHeaderProducer");
+  //now do what ever initialization is needed
+  rootfile_ = iConfig.getUntrackedParameter<std::string>("rootfile", "ecalSimpleTBanalysis.root");
+  digiCollection_ = iConfig.getParameter<std::string>("digiCollection");
+  digiProducer_ = iConfig.getParameter<std::string>("digiProducer");
+  hitCollection_ = iConfig.getParameter<std::string>("hitCollection");
+  hitProducer_ = iConfig.getParameter<std::string>("hitProducer");
+  hodoRecInfoCollection_ = iConfig.getParameter<std::string>("hodoRecInfoCollection");
+  hodoRecInfoProducer_ = iConfig.getParameter<std::string>("hodoRecInfoProducer");
+  tdcRecInfoCollection_ = iConfig.getParameter<std::string>("tdcRecInfoCollection");
+  tdcRecInfoProducer_ = iConfig.getParameter<std::string>("tdcRecInfoProducer");
+  eventHeaderCollection_ = iConfig.getParameter<std::string>("eventHeaderCollection");
+  eventHeaderProducer_ = iConfig.getParameter<std::string>("eventHeaderProducer");
 
-
-   std::cout << "EcalSimpleTBAnalyzer: fetching hitCollection: " << hitCollection_.c_str()
-	<< " produced by " << hitProducer_.c_str() << std::endl;
-
+  std::cout << "EcalSimpleTBAnalyzer: fetching hitCollection: " << hitCollection_.c_str() << " produced by "
+            << hitProducer_.c_str() << std::endl;
 }
-
 
 //========================================================================
 EcalSimpleTBAnalyzer::~EcalSimpleTBAnalyzer()
@@ -72,133 +68,127 @@ EcalSimpleTBAnalyzer::~EcalSimpleTBAnalyzer()
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
   // Amplitude vs TDC offset
-//   if (h_ampltdc)
-//   delete h_ampltdc;
-  
-//   // Reconstructed energies
-//   delete h_e1x1;
-//   delete h_e3x3; 
-//   delete h_e5x5; 
-  
-//   delete h_bprofx; 
-//   delete h_bprofy; 
-  
-//   delete h_qualx; 
-//   delete h_qualy; 
-  
-//   delete h_slopex; 
-//   delete h_slopey; 
-  
-//   delete h_mapx; 
-//   delete h_mapy; 
+  //   if (h_ampltdc)
+  //   delete h_ampltdc;
 
+  //   // Reconstructed energies
+  //   delete h_e1x1;
+  //   delete h_e3x3;
+  //   delete h_e5x5;
+
+  //   delete h_bprofx;
+  //   delete h_bprofy;
+
+  //   delete h_qualx;
+  //   delete h_qualy;
+
+  //   delete h_slopex;
+  //   delete h_slopey;
+
+  //   delete h_mapx;
+  //   delete h_mapy;
 }
 
 //========================================================================
-void
-EcalSimpleTBAnalyzer::beginJob() {
-//========================================================================
+void EcalSimpleTBAnalyzer::beginJob() {
+  //========================================================================
 
   // Amplitude vs TDC offset
-  h_ampltdc = new TH2F("h_ampltdc","Max Amplitude vs TDC offset", 100,0.,1.,1000, 0., 4000.);
+  h_ampltdc = new TH2F("h_ampltdc", "Max Amplitude vs TDC offset", 100, 0., 1., 1000, 0., 4000.);
 
   // Reconstructed energies
-  h_tableIsMoving = new TH1F("h_tableIsMoving","TableIsMoving", 100000, 0., 100000.);
+  h_tableIsMoving = new TH1F("h_tableIsMoving", "TableIsMoving", 100000, 0., 100000.);
 
-  h_e1x1 = new TH1F("h_e1x1","E1x1 energy", 1000, 0., 4000.);
-  h_e3x3 = new TH1F("h_e3x3","E3x3 energy", 1000, 0., 4000.);
-  h_e5x5 = new TH1F("h_e5x5","E5x5 energy", 1000, 0., 4000.);
+  h_e1x1 = new TH1F("h_e1x1", "E1x1 energy", 1000, 0., 4000.);
+  h_e3x3 = new TH1F("h_e3x3", "E3x3 energy", 1000, 0., 4000.);
+  h_e5x5 = new TH1F("h_e5x5", "E5x5 energy", 1000, 0., 4000.);
 
-  h_e1x1_center = new TH1F("h_e1x1_center","E1x1 energy", 1000, 0., 4000.);
-  h_e3x3_center = new TH1F("h_e3x3_center","E3x3 energy", 1000, 0., 4000.);
-  h_e5x5_center = new TH1F("h_e5x5_center","E5x5 energy", 1000, 0., 4000.);
+  h_e1x1_center = new TH1F("h_e1x1_center", "E1x1 energy", 1000, 0., 4000.);
+  h_e3x3_center = new TH1F("h_e3x3_center", "E3x3 energy", 1000, 0., 4000.);
+  h_e5x5_center = new TH1F("h_e5x5_center", "E5x5 energy", 1000, 0., 4000.);
 
-  h_e1e9 = new TH1F("h_e1e9","E1/E9 ratio", 600, 0., 1.2);
-  h_e1e25 = new TH1F("h_e1e25","E1/E25 ratio", 600, 0., 1.2);
-  h_e9e25 = new TH1F("h_e9e25","E9/E25 ratio", 600, 0., 1.2);
+  h_e1e9 = new TH1F("h_e1e9", "E1/E9 ratio", 600, 0., 1.2);
+  h_e1e25 = new TH1F("h_e1e25", "E1/E25 ratio", 600, 0., 1.2);
+  h_e9e25 = new TH1F("h_e9e25", "E9/E25 ratio", 600, 0., 1.2);
 
-  h_bprofx = new TH1F("h_bprofx","Beam Profile X",100,-20.,20.);
-  h_bprofy = new TH1F("h_bprofy","Beam Profile Y",100,-20.,20.);
+  h_bprofx = new TH1F("h_bprofx", "Beam Profile X", 100, -20., 20.);
+  h_bprofy = new TH1F("h_bprofy", "Beam Profile Y", 100, -20., 20.);
 
-  h_qualx = new TH1F("h_qualx","Beam Quality X",5000,0.,5.);
-  h_qualy = new TH1F("h_qualy","Beam Quality X",5000,0.,5.);
+  h_qualx = new TH1F("h_qualx", "Beam Quality X", 5000, 0., 5.);
+  h_qualy = new TH1F("h_qualy", "Beam Quality X", 5000, 0., 5.);
 
-  h_slopex = new TH1F("h_slopex","Beam Slope X",500, -5e-4 , 5e-4 );
-  h_slopey = new TH1F("h_slopey","Beam Slope Y",500, -5e-4 , 5e-4 );
+  h_slopex = new TH1F("h_slopex", "Beam Slope X", 500, -5e-4, 5e-4);
+  h_slopey = new TH1F("h_slopey", "Beam Slope Y", 500, -5e-4, 5e-4);
 
   char hname[50];
   char htitle[50];
-  for (unsigned int icry=0;icry<25;icry++)
-    {       
-      sprintf(hname,"h_mapx_%d",icry);
-      sprintf(htitle,"Max Amplitude vs X %d",icry);
-      h_mapx[icry] = new TH2F(hname,htitle,80,-20,20,1000,0.,4000.);
-      sprintf(hname,"h_mapy_%d",icry);
-      sprintf(htitle,"Max Amplitude vs Y %d",icry);
-      h_mapy[icry] = new TH2F(hname,htitle,80,-20,20,1000,0.,4000.);
-    }
-  
-  h_e1e9_mapx = new TH2F("h_e1e9_mapx","E1/E9 vs X",80,-20,20,600,0.,1.2);
-  h_e1e9_mapy = new TH2F("h_e1e9_mapy","E1/E9 vs Y",80,-20,20,600,0.,1.2);
+  for (unsigned int icry = 0; icry < 25; icry++) {
+    sprintf(hname, "h_mapx_%d", icry);
+    sprintf(htitle, "Max Amplitude vs X %d", icry);
+    h_mapx[icry] = new TH2F(hname, htitle, 80, -20, 20, 1000, 0., 4000.);
+    sprintf(hname, "h_mapy_%d", icry);
+    sprintf(htitle, "Max Amplitude vs Y %d", icry);
+    h_mapy[icry] = new TH2F(hname, htitle, 80, -20, 20, 1000, 0., 4000.);
+  }
 
-  h_e1e25_mapx = new TH2F("h_e1e25_mapx","E1/E25 vs X",80,-20,20,600,0.,1.2);
-  h_e1e25_mapy = new TH2F("h_e1e25_mapy","E1/E25 vs Y",80,-20,20,600,0.,1.2);
+  h_e1e9_mapx = new TH2F("h_e1e9_mapx", "E1/E9 vs X", 80, -20, 20, 600, 0., 1.2);
+  h_e1e9_mapy = new TH2F("h_e1e9_mapy", "E1/E9 vs Y", 80, -20, 20, 600, 0., 1.2);
 
-  h_e9e25_mapx = new TH2F("h_e9e25_mapx","E9/E25 vs X",80,-20,20,600,0.,1.2);
-  h_e9e25_mapy = new TH2F("h_e9e25_mapy","E9/E25 vs Y",80,-20,20,600,0.,1.2);
+  h_e1e25_mapx = new TH2F("h_e1e25_mapx", "E1/E25 vs X", 80, -20, 20, 600, 0., 1.2);
+  h_e1e25_mapy = new TH2F("h_e1e25_mapy", "E1/E25 vs Y", 80, -20, 20, 600, 0., 1.2);
 
-  h_Shape_ = new TH2F("h_Shape_","Xtal in Beam Shape",250,0,10,350,0,3500);
+  h_e9e25_mapx = new TH2F("h_e9e25_mapx", "E9/E25 vs X", 80, -20, 20, 600, 0., 1.2);
+  h_e9e25_mapy = new TH2F("h_e9e25_mapy", "E9/E25 vs Y", 80, -20, 20, 600, 0., 1.2);
 
+  h_Shape_ = new TH2F("h_Shape_", "Xtal in Beam Shape", 250, 0, 10, 350, 0, 3500);
 }
 
 //========================================================================
-void
-EcalSimpleTBAnalyzer::endJob() {
-//========================================================================
+void EcalSimpleTBAnalyzer::endJob() {
+  //========================================================================
 
-  TFile f(rootfile_.c_str(),"RECREATE");
+  TFile f(rootfile_.c_str(), "RECREATE");
 
   // Amplitude vs TDC offset
-  h_ampltdc->Write(); 
+  h_ampltdc->Write();
 
   // Reconstructed energies
-  h_e1x1->Write(); 
-  h_e3x3->Write(); 
-  h_e5x5->Write(); 
+  h_e1x1->Write();
+  h_e3x3->Write();
+  h_e5x5->Write();
 
-  h_e1x1_center->Write(); 
-  h_e3x3_center->Write(); 
-  h_e5x5_center->Write(); 
+  h_e1x1_center->Write();
+  h_e3x3_center->Write();
+  h_e5x5_center->Write();
 
-  h_e1e9->Write(); 
-  h_e1e25->Write(); 
-  h_e9e25->Write(); 
+  h_e1e9->Write();
+  h_e1e25->Write();
+  h_e9e25->Write();
 
-  h_bprofx->Write(); 
-  h_bprofy->Write(); 
+  h_bprofx->Write();
+  h_bprofy->Write();
 
-  h_qualx->Write(); 
-  h_qualy->Write(); 
+  h_qualx->Write();
+  h_qualy->Write();
 
-  h_slopex->Write(); 
-  h_slopey->Write(); 
-  
+  h_slopex->Write();
+  h_slopey->Write();
+
   h_Shape_->Write();
 
-  for (unsigned int icry=0;icry<25;icry++)
-    {       
-      h_mapx[icry]->Write(); 
-      h_mapy[icry]->Write(); 
-    }
+  for (unsigned int icry = 0; icry < 25; icry++) {
+    h_mapx[icry]->Write();
+    h_mapy[icry]->Write();
+  }
 
-  h_e1e9_mapx->Write(); 
-  h_e1e9_mapy->Write(); 
+  h_e1e9_mapx->Write();
+  h_e1e9_mapy->Write();
 
-  h_e1e25_mapx->Write(); 
-  h_e1e25_mapy->Write(); 
+  h_e1e25_mapx->Write();
+  h_e1e25_mapy->Write();
 
-  h_e9e25_mapx->Write(); 
-  h_e9e25_mapy->Write(); 
+  h_e9e25_mapx->Write();
+  h_e9e25_mapy->Write();
 
   h_tableIsMoving->Write();
 
@@ -210,245 +200,222 @@ EcalSimpleTBAnalyzer::endJob() {
 //
 
 //========================================================================
-void
-EcalSimpleTBAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
-//========================================================================
+void EcalSimpleTBAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  //========================================================================
 
-   using namespace edm;
-   using namespace cms;
+  using namespace edm;
+  using namespace cms;
 
+  Handle<EBDigiCollection> pdigis;
+  const EBDigiCollection* digis = nullptr;
+  //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(digiProducer_, digiCollection_, pdigis);
+  if (pdigis.isValid()) {
+    digis = pdigis.product();  // get a ptr to the product
+    //iEvent.getByLabel( hitProducer_, phits);
+  } else {
+    edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << digiCollection_;
+  }
 
+  // fetch the digis and compute signal amplitude
+  Handle<EBUncalibratedRecHitCollection> phits;
+  const EBUncalibratedRecHitCollection* hits = nullptr;
+  //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(hitProducer_, hitCollection_, phits);
+  if (phits.isValid()) {
+    hits = phits.product();  // get a ptr to the product
+    //iEvent.getByLabel( hitProducer_, phits);
+  } else {
+    edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << hitCollection_;
+  }
 
-   Handle<EBDigiCollection> pdigis;
-   const EBDigiCollection* digis=nullptr;
-   //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( digiProducer_, digiCollection_,pdigis);
-   if ( pdigis.isValid() ) {
-     digis = pdigis.product(); // get a ptr to the product
-     //iEvent.getByLabel( hitProducer_, phits);
-   } else {
-           edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << digiCollection_;
-   }
+  Handle<EcalTBHodoscopeRecInfo> pHodo;
+  const EcalTBHodoscopeRecInfo* recHodo = nullptr;
+  //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(hodoRecInfoProducer_, hodoRecInfoCollection_, pHodo);
+  if (pHodo.isValid()) {
+    recHodo = pHodo.product();  // get a ptr to the product
+  } else {
+    edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << hodoRecInfoCollection_;
+  }
 
-   // fetch the digis and compute signal amplitude
-   Handle<EBUncalibratedRecHitCollection> phits;
-   const EBUncalibratedRecHitCollection* hits=nullptr;
-   //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( hitProducer_, hitCollection_,phits);
-   if (phits.isValid()) {
-     hits = phits.product(); // get a ptr to the product
-     //iEvent.getByLabel( hitProducer_, phits);
-   } else {
-           edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << hitCollection_;
-   }
+  Handle<EcalTBTDCRecInfo> pTDC;
+  const EcalTBTDCRecInfo* recTDC = nullptr;
+  //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(tdcRecInfoProducer_, tdcRecInfoCollection_, pTDC);
+  if (pTDC.isValid()) {
+    recTDC = pTDC.product();  // get a ptr to the product
+  } else {
+    edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << tdcRecInfoCollection_;
+  }
 
-   Handle<EcalTBHodoscopeRecInfo> pHodo;
-   const EcalTBHodoscopeRecInfo* recHodo=nullptr;
-   //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( hodoRecInfoProducer_, hodoRecInfoCollection_, pHodo);
-   if ( pHodo.isValid() ) {
-     recHodo = pHodo.product(); // get a ptr to the product
-   } else {
-           edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << hodoRecInfoCollection_;
-   }
+  Handle<EcalTBEventHeader> pEventHeader;
+  const EcalTBEventHeader* evtHeader = nullptr;
+  //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
+  iEvent.getByLabel(eventHeaderProducer_, pEventHeader);
+  if (pEventHeader.isValid()) {
+    evtHeader = pEventHeader.product();  // get a ptr to the product
+  } else {
+    edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << eventHeaderProducer_;
+  }
 
-   Handle<EcalTBTDCRecInfo> pTDC;
-   const EcalTBTDCRecInfo* recTDC=nullptr;
-   //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( tdcRecInfoProducer_, tdcRecInfoCollection_, pTDC);
-   if ( pTDC.isValid() ) {
-     recTDC = pTDC.product(); // get a ptr to the product
-   } else {
-           edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << tdcRecInfoCollection_;
-   }
+  if (!hits)
+    return;
 
-   Handle<EcalTBEventHeader> pEventHeader;
-   const EcalTBEventHeader* evtHeader=nullptr;
-   //std::cout << "EcalSimpleTBAnalyzer::analyze getting product with label: " << digiProducer_.c_str()<< " prodname: " << digiCollection_.c_str() << endl;
-   iEvent.getByLabel( eventHeaderProducer_ , pEventHeader );
-   if ( pEventHeader.isValid() ) {
-     evtHeader = pEventHeader.product(); // get a ptr to the product
-   } else {
-           edm::LogError("EcalSimpleTBAnalyzerError") << "Error! can't get the product " << eventHeaderProducer_;
-   }
-   
-   if (!hits)
-     return;
+  if (!recTDC)
+    return;
 
-   if (!recTDC)
-     return;
+  if (!recHodo)
+    return;
 
-   if (!recHodo)
-     return;
+  if (!evtHeader)
+    return;
 
-   if (!evtHeader)
-     return;
+  if (hits->empty())
+    return;
 
-   if (hits->empty())
-     return;
+  if (evtHeader->tableIsMoving())
+    h_tableIsMoving->Fill(evtHeader->eventNumber());
 
-   if (evtHeader->tableIsMoving())
-     h_tableIsMoving->Fill(evtHeader->eventNumber());
+  // Crystal hit by beam
+  if (xtalInBeam_.null()) {
+    xtalInBeam_ = EBDetId(1, evtHeader->crystalInBeam(), EBDetId::SMCRYSTALMODE);
+    std::cout << "Xtal In Beam is " << xtalInBeam_.ic() << std::endl;
+  } else if (xtalInBeam_ != EBDetId(1, evtHeader->crystalInBeam(), EBDetId::SMCRYSTALMODE))
+    return;
 
-   // Crystal hit by beam
-   if (xtalInBeam_.null())
-     {
-       xtalInBeam_ = EBDetId(1,evtHeader->crystalInBeam(),EBDetId::SMCRYSTALMODE);
-       std::cout<< "Xtal In Beam is " << xtalInBeam_.ic() << std::endl;
-     }
-   else if (xtalInBeam_ != EBDetId(1,evtHeader->crystalInBeam(),EBDetId::SMCRYSTALMODE))
-     return;
+  if (evtHeader->tableIsMoving())
+    return;
 
-   if (evtHeader->tableIsMoving())
-     return;
-   
-   
-//    EBDetId maxHitId(0); 
-//    float maxHit= -999999.;
-   
-//    for(EBUncalibratedRecHitCollection::const_iterator ithit = hits->begin(); ithit != hits->end(); ++ithit) 
-//      {
-//        if (ithit->amplitude()>=maxHit)
-// 	 {
-// 	   maxHit=ithit->amplitude();
-// 	   maxHitId=ithit->id();
-// 	 }
-       
-//      }   
+  //    EBDetId maxHitId(0);
+  //    float maxHit= -999999.;
 
-//    if (maxHitId==EBDetId(0))
-//      return;
+  //    for(EBUncalibratedRecHitCollection::const_iterator ithit = hits->begin(); ithit != hits->end(); ++ithit)
+  //      {
+  //        if (ithit->amplitude()>=maxHit)
+  // 	 {
+  // 	   maxHit=ithit->amplitude();
+  // 	   maxHitId=ithit->id();
+  // 	 }
 
-//   EBDetId maxHitId(1,704,EBDetId::SMCRYSTALMODE); 
+  //      }
 
-   //Find EBDetId in a 5x5 Matrix (to be substituted by the Selector code)
-   // Something like 
-   // EBFixedWindowSelector<EcalUncalibratedRecHit> Simple5x5Matrix(hits,maxHitId,5,5);
-   // std::vector<EcalUncalibratedRecHit> Energies5x5 = Simple5x5Matrix.getHits();
+  //    if (maxHitId==EBDetId(0))
+  //      return;
 
+  //   EBDetId maxHitId(1,704,EBDetId::SMCRYSTALMODE);
 
-   EBDetId Xtals5x5[25];
-   for (unsigned int icry=0;icry<25;icry++)
-     {
-       unsigned int row = icry / 5;
-       unsigned int column= icry %5;
-       int ieta=xtalInBeam_.ieta()+column-2;
-       int iphi=xtalInBeam_.iphi()+row-2;
-       EBDetId tempId(ieta, iphi,EBDetId::ETAPHIMODE);
-       if (tempId.ism()==1) 
-               Xtals5x5[icry]=tempId;
-       else
-               Xtals5x5[icry]=EBDetId(0);
-       ///       std::cout << "** Xtal in the matrix **** row " << row  << ", column " << column << ", xtal " << Xtals5x5[icry].ic() << std::endl;
-     } 
+  //Find EBDetId in a 5x5 Matrix (to be substituted by the Selector code)
+  // Something like
+  // EBFixedWindowSelector<EcalUncalibratedRecHit> Simple5x5Matrix(hits,maxHitId,5,5);
+  // std::vector<EcalUncalibratedRecHit> Energies5x5 = Simple5x5Matrix.getHits();
 
+  EBDetId Xtals5x5[25];
+  for (unsigned int icry = 0; icry < 25; icry++) {
+    unsigned int row = icry / 5;
+    unsigned int column = icry % 5;
+    int ieta = xtalInBeam_.ieta() + column - 2;
+    int iphi = xtalInBeam_.iphi() + row - 2;
+    EBDetId tempId(ieta, iphi, EBDetId::ETAPHIMODE);
+    if (tempId.ism() == 1)
+      Xtals5x5[icry] = tempId;
+    else
+      Xtals5x5[icry] = EBDetId(0);
+    ///       std::cout << "** Xtal in the matrix **** row " << row  << ", column " << column << ", xtal " << Xtals5x5[icry].ic() << std::endl;
+  }
 
-   
-   double samples_save[10]; for(int i=0; i < 10; ++i) samples_save[i]=0.0;
-   
-   // find the rechit corresponding digi and the max sample
-   EBDigiCollection::const_iterator myDg = digis->find(xtalInBeam_);
-   double eMax = 0.;
-   if (myDg != digis->end())
-     {
-       EBDataFrame myDigi = (*myDg);
-       for (int sample = 0; sample < myDigi.size(); ++sample)
-	 {
-	   double analogSample = myDigi.sample(sample).adc();
-	   samples_save[sample] = analogSample;
-	   //  std::cout << analogSample << " ";
-	   if ( eMax < analogSample )
-	     {
-	       eMax = analogSample;
-	     }
-	 }
-       // std::cout << std::endl;
-     }
+  double samples_save[10];
+  for (int i = 0; i < 10; ++i)
+    samples_save[i] = 0.0;
 
-   for(int i =0; i < 10; ++i) {
-     h_Shape_->Fill(double(i)+recTDC->offset(),samples_save[i]);
-   }
+  // find the rechit corresponding digi and the max sample
+  EBDigiCollection::const_iterator myDg = digis->find(xtalInBeam_);
+  double eMax = 0.;
+  if (myDg != digis->end()) {
+    EBDataFrame myDigi = (*myDg);
+    for (int sample = 0; sample < myDigi.size(); ++sample) {
+      double analogSample = myDigi.sample(sample).adc();
+      samples_save[sample] = analogSample;
+      //  std::cout << analogSample << " ";
+      if (eMax < analogSample) {
+        eMax = analogSample;
+      }
+    }
+    // std::cout << std::endl;
+  }
 
-   double amplitude[25];
-   
-   double amplitude3x3=0;  
-   double amplitude5x5=0;  
-   
-   for (unsigned int icry=0;icry<25;icry++)
-     {
-       if (!Xtals5x5[icry].null())
-	 {
-	   amplitude[icry]=(hits->find(Xtals5x5[icry]))->amplitude();
-	   amplitude5x5 += amplitude[icry];
-	   // Is in 3x3?
-	   if ( icry == 6  || icry == 7  || icry == 8 ||
-		icry == 11 || icry == 12 || icry ==13 ||
-		icry == 16 || icry == 17 || icry ==18   )
-	     {
-	       amplitude3x3+=amplitude[icry];
-	     }
-	 }
-     }
+  for (int i = 0; i < 10; ++i) {
+    h_Shape_->Fill(double(i) + recTDC->offset(), samples_save[i]);
+  }
 
+  double amplitude[25];
 
-   h_e1x1->Fill(amplitude[12]);
-   h_e3x3->Fill(amplitude3x3);
-   h_e5x5->Fill(amplitude5x5);
+  double amplitude3x3 = 0;
+  double amplitude5x5 = 0;
 
-   h_e1e9->Fill(amplitude[12]/amplitude3x3);
-   h_e1e25->Fill(amplitude[12]/amplitude5x5);
-   h_e9e25->Fill(amplitude3x3/amplitude5x5);
+  for (unsigned int icry = 0; icry < 25; icry++) {
+    if (!Xtals5x5[icry].null()) {
+      amplitude[icry] = (hits->find(Xtals5x5[icry]))->amplitude();
+      amplitude5x5 += amplitude[icry];
+      // Is in 3x3?
+      if (icry == 6 || icry == 7 || icry == 8 || icry == 11 || icry == 12 || icry == 13 || icry == 16 || icry == 17 ||
+          icry == 18) {
+        amplitude3x3 += amplitude[icry];
+      }
+    }
+  }
 
-   if (recTDC)
-     h_ampltdc->Fill(recTDC->offset(),amplitude[12]);
+  h_e1x1->Fill(amplitude[12]);
+  h_e3x3->Fill(amplitude3x3);
+  h_e5x5->Fill(amplitude5x5);
 
-   if (recHodo)
-     {
-       float x=recHodo->posX();
-       float y=recHodo->posY();
-       float xslope=recHodo->slopeX();
-       float yslope=recHodo->slopeY();
-       float xqual=recHodo->qualX();
-       float yqual=recHodo->qualY();
-       
-       //Filling beam profiles
-       h_bprofx->Fill(x);
-       h_bprofy->Fill(y);
-       h_qualx->Fill(xqual);
-       h_qualy->Fill(yqual);
-       h_slopex->Fill(xslope);
-       h_slopey->Fill(yslope);
+  h_e1e9->Fill(amplitude[12] / amplitude3x3);
+  h_e1e25->Fill(amplitude[12] / amplitude5x5);
+  h_e9e25->Fill(amplitude3x3 / amplitude5x5);
 
-       //Fill central events
+  if (recTDC)
+    h_ampltdc->Fill(recTDC->offset(), amplitude[12]);
 
-       
-       if ( fabs(x + 2.5) < 2.5 && fabs(y + 0.5) < 2.5)
-	 {
-	   h_e1x1_center->Fill(amplitude[12]);
-	   h_e3x3_center->Fill(amplitude3x3);
-	   h_e5x5_center->Fill(amplitude5x5);
-	   
-	   h_e1e9->Fill(amplitude[12]/amplitude3x3);
-	   h_e1e25->Fill(amplitude[12]/amplitude5x5);
-	   h_e9e25->Fill(amplitude3x3/amplitude5x5);
-	 }
+  if (recHodo) {
+    float x = recHodo->posX();
+    float y = recHodo->posY();
+    float xslope = recHodo->slopeX();
+    float yslope = recHodo->slopeY();
+    float xqual = recHodo->qualX();
+    float yqual = recHodo->qualY();
 
-       for (unsigned int icry=0;icry<25;icry++)
-	 {       
-	   h_mapx[icry]->Fill(x,amplitude[icry]);
-	   h_mapy[icry]->Fill(y,amplitude[icry]);
-	 }
+    //Filling beam profiles
+    h_bprofx->Fill(x);
+    h_bprofy->Fill(y);
+    h_qualx->Fill(xqual);
+    h_qualy->Fill(yqual);
+    h_slopex->Fill(xslope);
+    h_slopey->Fill(yslope);
 
-       h_e1e9_mapx->Fill(x,amplitude[12]/amplitude3x3);
-       h_e1e9_mapy->Fill(y,amplitude[12]/amplitude3x3);
+    //Fill central events
 
-       h_e1e25_mapx->Fill(x,amplitude[12]/amplitude5x5);
-       h_e1e25_mapy->Fill(y,amplitude[12]/amplitude5x5);
+    if (fabs(x + 2.5) < 2.5 && fabs(y + 0.5) < 2.5) {
+      h_e1x1_center->Fill(amplitude[12]);
+      h_e3x3_center->Fill(amplitude3x3);
+      h_e5x5_center->Fill(amplitude5x5);
 
-       h_e9e25_mapx->Fill(x,amplitude3x3/amplitude5x5);
-       h_e9e25_mapy->Fill(y,amplitude3x3/amplitude5x5);
-     }
+      h_e1e9->Fill(amplitude[12] / amplitude3x3);
+      h_e1e25->Fill(amplitude[12] / amplitude5x5);
+      h_e9e25->Fill(amplitude3x3 / amplitude5x5);
+    }
 
+    for (unsigned int icry = 0; icry < 25; icry++) {
+      h_mapx[icry]->Fill(x, amplitude[icry]);
+      h_mapy[icry]->Fill(y, amplitude[icry]);
+    }
+
+    h_e1e9_mapx->Fill(x, amplitude[12] / amplitude3x3);
+    h_e1e9_mapy->Fill(y, amplitude[12] / amplitude3x3);
+
+    h_e1e25_mapx->Fill(x, amplitude[12] / amplitude5x5);
+    h_e1e25_mapy->Fill(y, amplitude[12] / amplitude5x5);
+
+    h_e9e25_mapx->Fill(x, amplitude3x3 / amplitude5x5);
+    h_e9e25_mapy->Fill(y, amplitude3x3 / amplitude5x5);
+  }
 }
-
-

--- a/RecoTBCalo/EcalSimpleTBAnalysis/src/SealModule.cc
+++ b/RecoTBCalo/EcalSimpleTBAnalysis/src/SealModule.cc
@@ -3,7 +3,5 @@
 #include "RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimpleTBAnalyzer.h"
 #include "RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimple2007H4TBAnalyzer.h"
 
-
-
-DEFINE_FWK_MODULE( EcalSimpleTBAnalyzer );
-DEFINE_FWK_MODULE( EcalSimple2007H4TBAnalyzer );
+DEFINE_FWK_MODULE(EcalSimpleTBAnalyzer);
+DEFINE_FWK_MODULE(EcalSimple2007H4TBAnalyzer);

--- a/RecoTBCalo/EcalTBAnalysisCoreTools/interface/TBPositionCalc.h
+++ b/RecoTBCalo/EcalTBAnalysisCoreTools/interface/TBPositionCalc.h
@@ -20,37 +20,37 @@
 #include "Geometry/EcalTestBeam/interface/EcalTBCrystalMap.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h" 
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
 
+class TBPositionCalc {
+public:
+  TBPositionCalc(const std::map<std::string, double>& providedParameters,
+                 const std::string& mapFile,
+                 const CaloSubdetectorGeometry* passedGeometry);
 
-class TBPositionCalc
-{
- public:
-  
-  TBPositionCalc(const std::map<std::string,double>& providedParameters, const std::string& mapFile, const CaloSubdetectorGeometry *passedGeometry);  
-
-  TBPositionCalc() { };
+  TBPositionCalc(){};
 
   ~TBPositionCalc();
 
-  CLHEP::Hep3Vector CalculateTBPos(const std::vector<EBDetId>& passedDetIds, int myCrystal, EcalRecHitCollection const *passedRecHitsMap);
-  
-  CLHEP::Hep3Vector CalculateCMSPos(const std::vector<EBDetId>& passedDetIds, int myCrystal, EcalRecHitCollection const *passedRecHitsMap);
-  
-  void computeRotation(int myCrystal, CLHEP::HepRotation & CMStoTB );
-    
+  CLHEP::Hep3Vector CalculateTBPos(const std::vector<EBDetId>& passedDetIds,
+                                   int myCrystal,
+                                   EcalRecHitCollection const* passedRecHitsMap);
 
- private:
-  bool        param_LogWeighted_;
-  Double32_t  param_X0_;
-  Double32_t  param_T0_;
-  Double32_t  param_W0_;
+  CLHEP::Hep3Vector CalculateCMSPos(const std::vector<EBDetId>& passedDetIds,
+                                    int myCrystal,
+                                    EcalRecHitCollection const* passedRecHitsMap);
 
-  EcalTBCrystalMap * theTestMap;
+  void computeRotation(int myCrystal, CLHEP::HepRotation& CMStoTB);
 
-  const CaloSubdetectorGeometry *theGeometry_;
+private:
+  bool param_LogWeighted_;
+  Double32_t param_X0_;
+  Double32_t param_T0_;
+  Double32_t param_W0_;
+
+  EcalTBCrystalMap* theTestMap;
+
+  const CaloSubdetectorGeometry* theGeometry_;
 };
-  
+
 #endif
-
-

--- a/RecoTBCalo/EcalTBAnalysisCoreTools/src/TBPositionCalc.cc
+++ b/RecoTBCalo/EcalTBAnalysisCoreTools/src/TBPositionCalc.cc
@@ -2,45 +2,46 @@
 
 using namespace std;
 
-TBPositionCalc::TBPositionCalc(const std::map<std::string,double>& providedParameters, std::string const & fullMapName, const CaloSubdetectorGeometry *passedGeometry ) 
-{
+TBPositionCalc::TBPositionCalc(const std::map<std::string, double> &providedParameters,
+                               std::string const &fullMapName,
+                               const CaloSubdetectorGeometry *passedGeometry) {
   // barrel geometry initialization
-  if(passedGeometry == nullptr)
+  if (passedGeometry == nullptr)
     throw(std::runtime_error("\n\n TBPositionCalc: wrong initialization.\n\n"));
   theGeometry_ = passedGeometry;
-  
+
   // parameters initialization
   param_LogWeighted_ = providedParameters.find("LogWeighted")->second;
   param_X0_ = providedParameters.find("X0")->second;
-  param_T0_ = providedParameters.find("T0")->second; 
+  param_T0_ = providedParameters.find("T0")->second;
   param_W0_ = providedParameters.find("W0")->second;
 
   theTestMap = new EcalTBCrystalMap(fullMapName);
 }
 
-TBPositionCalc::~TBPositionCalc()
-{
-  if (theTestMap) delete theTestMap;
+TBPositionCalc::~TBPositionCalc() {
+  if (theTestMap)
+    delete theTestMap;
 }
 
-CLHEP::Hep3Vector TBPositionCalc::CalculateTBPos(const std::vector<EBDetId>& upassedDetIds, int myCrystal, EcalRecHitCollection const *passedRecHitsMap) {
-  
+CLHEP::Hep3Vector TBPositionCalc::CalculateTBPos(const std::vector<EBDetId> &upassedDetIds,
+                                                 int myCrystal,
+                                                 EcalRecHitCollection const *passedRecHitsMap) {
   std::vector<EBDetId> passedDetIds = upassedDetIds;
-  // throw an error if the cluster was not initialized properly  
-  if(passedRecHitsMap == nullptr)
+  // throw an error if the cluster was not initialized properly
+  if (passedRecHitsMap == nullptr)
     throw(std::runtime_error("\n\n TBPositionCalc::CalculateTBPos called uninitialized.\n\n"));
-  
+
   // check DetIds are nonzero
   std::vector<EBDetId> validDetIds;
   std::vector<EBDetId>::const_iterator iter;
   for (iter = passedDetIds.begin(); iter != passedDetIds.end(); iter++) {
-    if (((*iter) != DetId(0)) 
-	&& (passedRecHitsMap->find(*iter) != passedRecHitsMap->end()))
+    if (((*iter) != DetId(0)) && (passedRecHitsMap->find(*iter) != passedRecHitsMap->end()))
       validDetIds.push_back(*iter);
   }
   passedDetIds.clear();
   passedDetIds = validDetIds;
-  
+
   // computing the position in the cms frame
   CLHEP::Hep3Vector cmsPos = CalculateCMSPos(passedDetIds, myCrystal, passedRecHitsMap);
 
@@ -49,21 +50,21 @@ CLHEP::Hep3Vector TBPositionCalc::CalculateTBPos(const std::vector<EBDetId>& upa
   computeRotation(myCrystal, (*CMStoTB));
 
   // moving to testbeam frame
-  CLHEP::Hep3Vector tbPos = (*CMStoTB)*cmsPos;
+  CLHEP::Hep3Vector tbPos = (*CMStoTB) * cmsPos;
   delete CMStoTB;
 
   return tbPos;
-} 
+}
 
-
-CLHEP::Hep3Vector TBPositionCalc::CalculateCMSPos(const std::vector<EBDetId>& passedDetIds, int myCrystal, EcalRecHitCollection const *passedRecHitsMap) {
-  
+CLHEP::Hep3Vector TBPositionCalc::CalculateCMSPos(const std::vector<EBDetId> &passedDetIds,
+                                                  int myCrystal,
+                                                  EcalRecHitCollection const *passedRecHitsMap) {
   // Calculate the total energy
   double thisEne = 0;
   double eTot = 0;
   EBDetId myId;
   std::vector<EBDetId>::const_iterator myIt;
-  for (myIt = passedDetIds.begin(); myIt !=  passedDetIds.end(); myIt++) {
+  for (myIt = passedDetIds.begin(); myIt != passedDetIds.end(); myIt++) {
     myId = (*myIt);
     EcalRecHitCollection::const_iterator itt = passedRecHitsMap->find(myId);
     thisEne = itt->energy();
@@ -72,83 +73,89 @@ CLHEP::Hep3Vector TBPositionCalc::CalculateCMSPos(const std::vector<EBDetId>& pa
 
   // Calculate shower depth
   float depth = 0.;
-  if(eTot<=0.) {
+  if (eTot <= 0.) {
     edm::LogError("NegativeClusterEnergy") << "cluster with negative energy: " << eTot << ", setting depth to 0.";
   } else {
     depth = param_X0_ * (param_T0_ + log(eTot));
   }
 
-  // Get position of the central crystal from shower depth 
+  // Get position of the central crystal from shower depth
   EBDetId maxId_ = EBDetId(1, myCrystal, EBDetId::SMCRYSTALMODE);
-  auto center_cell = theGeometry_ -> getGeometry(maxId_);
-  GlobalPoint center_pos =  center_cell->getPosition(depth);
+  auto center_cell = theGeometry_->getGeometry(maxId_);
+  GlobalPoint center_pos = center_cell->getPosition(depth);
 
   // Loop over the hits collection
-  double weight        = 0;
-  double total_weight  = 0;
+  double weight = 0;
+  double total_weight = 0;
   double cluster_theta = 0;
-  double cluster_phi   = 0;
+  double cluster_phi = 0;
   std::vector<EBDetId>::const_iterator myIt2;
   for (myIt2 = passedDetIds.begin(); myIt2 != passedDetIds.end(); myIt2++) {
-
     // getting weights
     myId = (*myIt2);
     EcalRecHitCollection::const_iterator itj = passedRecHitsMap->find(myId);
     double ener = itj->energy();
 
     if (param_LogWeighted_) {
-      if(eTot<=0.) { weight = 0.; } 
-      else { weight = std::max(0., param_W0_ + log( fabs(ener)/eTot) ); }
+      if (eTot <= 0.) {
+        weight = 0.;
+      } else {
+        weight = std::max(0., param_W0_ + log(fabs(ener) / eTot));
+      }
     } else {
-      weight = ener/eTot;
+      weight = ener / eTot;
     }
     total_weight += weight;
 
     // weighted position of this detId
     auto jth_cell = theGeometry_->getGeometry(myId);
-    GlobalPoint jth_pos = jth_cell->getPosition(depth);    
-    cluster_theta += weight*jth_pos.theta();
-    cluster_phi   += weight*jth_pos.phi();
+    GlobalPoint jth_pos = jth_cell->getPosition(depth);
+    cluster_theta += weight * jth_pos.theta();
+    cluster_phi += weight * jth_pos.phi();
   }
-  
+
   // normalizing
   cluster_theta /= total_weight;
   cluster_phi /= total_weight;
-  if (cluster_phi > M_PI) { cluster_phi -= 2.*M_PI; }
-  if (cluster_phi < -M_PI){ cluster_phi += 2.*M_PI; }
+  if (cluster_phi > M_PI) {
+    cluster_phi -= 2. * M_PI;
+  }
+  if (cluster_phi < -M_PI) {
+    cluster_phi += 2. * M_PI;
+  }
 
   // position in the cms frame
-  double radius = sqrt(center_pos.x()*center_pos.x() + center_pos.y()*center_pos.y() + center_pos.z()*center_pos.z());
-  double xpos = radius*cos(cluster_phi)*sin(cluster_theta);
-  double ypos = radius*sin(cluster_phi)*sin(cluster_theta); 
-  double zpos = radius*cos(cluster_theta);
+  double radius =
+      sqrt(center_pos.x() * center_pos.x() + center_pos.y() * center_pos.y() + center_pos.z() * center_pos.z());
+  double xpos = radius * cos(cluster_phi) * sin(cluster_theta);
+  double ypos = radius * sin(cluster_phi) * sin(cluster_theta);
+  double zpos = radius * cos(cluster_theta);
 
   return CLHEP::Hep3Vector(xpos, ypos, zpos);
 }
 
-// rotation matrix to move from the CMS reference frame to the test beam one  
-void TBPositionCalc::computeRotation(int MyCrystal, CLHEP::HepRotation &CMStoTB){
-  
+// rotation matrix to move from the CMS reference frame to the test beam one
+void TBPositionCalc::computeRotation(int MyCrystal, CLHEP::HepRotation &CMStoTB) {
   // taking eta/phi of the crystal
 
-  double myEta   = 999.;
-  double myPhi   = 999.;
+  double myEta = 999.;
+  double myPhi = 999.;
   double myTheta = 999.;
   theTestMap->findCrystalAngles(MyCrystal, myEta, myPhi);
-  myTheta = 2.0*atan(exp(-myEta));
+  myTheta = 2.0 * atan(exp(-myEta));
 
   // matrix
-  CLHEP::HepRotation * fromCMStoTB = new CLHEP::HepRotation();
-  double angle1 = 90.*deg - myPhi;
-  CLHEP::HepRotationZ * r1 = new CLHEP::HepRotationZ(angle1);
+  CLHEP::HepRotation *fromCMStoTB = new CLHEP::HepRotation();
+  double angle1 = 90. * deg - myPhi;
+  CLHEP::HepRotationZ *r1 = new CLHEP::HepRotationZ(angle1);
   double angle2 = myTheta;
-  CLHEP::HepRotationX * r2 = new CLHEP::HepRotationX(angle2);
-  double angle3 = 90.*deg;
-  CLHEP::HepRotationZ * r3 = new CLHEP::HepRotationZ(angle3);
+  CLHEP::HepRotationX *r2 = new CLHEP::HepRotationX(angle2);
+  double angle3 = 90. * deg;
+  CLHEP::HepRotationZ *r3 = new CLHEP::HepRotationZ(angle3);
   (*fromCMStoTB) *= (*r3);
   (*fromCMStoTB) *= (*r2);
   (*fromCMStoTB) *= (*r1);
-  
+
   CMStoTB = (*fromCMStoTB);
 
   delete fromCMStoTB;
@@ -156,5 +163,3 @@ void TBPositionCalc::computeRotation(int MyCrystal, CLHEP::HepRotation &CMStoTB)
   delete r2;
   delete r3;
 }
-
-

--- a/RecoTBCalo/EcalTBAnalysisCoreTools/test/stubs/EcalShowerContainmentAnalyzer.cc
+++ b/RecoTBCalo/EcalTBAnalysisCoreTools/test/stubs/EcalShowerContainmentAnalyzer.cc
@@ -33,63 +33,54 @@
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
-
 #include <TFile.h>
 #include <TTree.h>
-
 
 #include <iostream>
 #include <vector>
 #include <map>
 
-
-class EcalShowerContainmentAnalyzer: public edm::EDAnalyzer{
-  
+class EcalShowerContainmentAnalyzer : public edm::EDAnalyzer {
 public:
   EcalShowerContainmentAnalyzer(const edm::ParameterSet& ps);
   ~EcalShowerContainmentAnalyzer();
-  
+
 protected:
-  
-  void analyze( edm::Event const & iEvent, const  edm::EventSetup& iSetup);
-  void endJob() ;
+  void analyze(edm::Event const& iEvent, const edm::EventSetup& iSetup);
+  void endJob();
 
   void readIntercalibrationConstants();
 
-  std::vector<EBDetId> Xtals3x3(const edm::Event& iEvent, 
-				EBDetId centerXtal);
-  std::vector<EBDetId> Xtals5x5(const edm::Event& iEvent, 
-				EBDetId centerXtal);
+  std::vector<EBDetId> Xtals3x3(const edm::Event& iEvent, EBDetId centerXtal);
+  std::vector<EBDetId> Xtals5x5(const edm::Event& iEvent, EBDetId centerXtal);
 
   double energy3x3(const edm::Event& iEvent, EBDetId centerXtal);
   double energy5x5(const edm::Event& iEvent, EBDetId centerXtal);
-  std::pair<double,double> contCorrection (const edm::Event& iEvent, 
-					   const  edm::EventSetup& iSetup,
-					   const EBDetId& centerXtal);
+  std::pair<double, double> contCorrection(const edm::Event& iEvent,
+                                           const edm::EventSetup& iSetup,
+                                           const EBDetId& centerXtal);
 
   /// fill a map of (detid,amplitude)
-  void fillxtalmap( edm::Event const & iEvent);
-  
-  double getAdcToGevConstant( const edm::EventSetup& eSetup);
+  void fillxtalmap(edm::Event const& iEvent);
 
-  
-  TFile *file_;
-  TTree *tree_;
+  double getAdcToGevConstant(const edm::EventSetup& eSetup);
+
+  TFile* file_;
+  TTree* tree_;
 
   // map of < xtal, (coefficient, goodness)>
-  typedef std::map<EBDetId, std::pair<double,double> > CalibMap;
+  typedef std::map<EBDetId, std::pair<double, double> > CalibMap;
   CalibMap calibmap_;
-  
+
   // map of <xtal, amplitude>
-  std::map<EBDetId,double> xtalmap_;
-  
+  std::map<EBDetId, double> xtalmap_;
+
   edm::InputTag inputTag_;
   std::string intercalibrationCoeffFile_;
 
   struct Ntuple {
-
-    int    run;
-    int    event;
+    int run;
+    int event;
     double energy1x1;
     double energy3x3;
     double energy5x5;
@@ -99,352 +90,282 @@ protected:
     double posy;
     double hodo_posx;
     double hodo_posy;
-    
-    void zero(){
-      run=event=0;
-      energy1x1=energy3x3=energy5x5=corrected3x3=corrected5x5=posx=posy=
-	hodo_posx=hodo_posy=0;
+
+    void zero() {
+      run = event = 0;
+      energy1x1 = energy3x3 = energy5x5 = corrected3x3 = corrected5x5 = posx = posy = hodo_posx = hodo_posy = 0;
     }
 
   } ntuple_;
 };
 
 DEFINE_FWK_MODULE(EcalShowerContainmentAnalyzer);
- 
-EcalShowerContainmentAnalyzer::EcalShowerContainmentAnalyzer(const edm::ParameterSet& ps){
 
-  std::string outfilename= 
-    ps.getUntrackedParameter<std::string>("OutputFile","testContCorrect.root");
-  
-  inputTag_=
-    ps.getUntrackedParameter<edm::InputTag>("EcalUnCalibratedRecHitsLabel");
-  
-  intercalibrationCoeffFile_=
-    ps.getUntrackedParameter<std::string>("IntercalibFile");
-  
-  file_ = new TFile(outfilename.c_str(),"recreate");
-  tree_ = new TTree("test","test");
-  
-  tree_->Branch("tb",&ntuple_,  "run/I:"
-                                "event/I:"
-		                "energy1x1/D:"
-		                "energy3x3/D:"
-		                "energy5x5/D:"
-		                "corrected3x3/D:"
-		                "corrected5x5/D:"
-		                "posx/D:"
-		                "posy/D:"
-		                "hodo_posx/D:"
-		                "hodo_posy/D");
+EcalShowerContainmentAnalyzer::EcalShowerContainmentAnalyzer(const edm::ParameterSet& ps) {
+  std::string outfilename = ps.getUntrackedParameter<std::string>("OutputFile", "testContCorrect.root");
+
+  inputTag_ = ps.getUntrackedParameter<edm::InputTag>("EcalUnCalibratedRecHitsLabel");
+
+  intercalibrationCoeffFile_ = ps.getUntrackedParameter<std::string>("IntercalibFile");
+
+  file_ = new TFile(outfilename.c_str(), "recreate");
+  tree_ = new TTree("test", "test");
+
+  tree_->Branch("tb",
+                &ntuple_,
+                "run/I:"
+                "event/I:"
+                "energy1x1/D:"
+                "energy3x3/D:"
+                "energy5x5/D:"
+                "corrected3x3/D:"
+                "corrected5x5/D:"
+                "posx/D:"
+                "posy/D:"
+                "hodo_posx/D:"
+                "hodo_posy/D");
 
   readIntercalibrationConstants();
-
 }
 
-EcalShowerContainmentAnalyzer::~EcalShowerContainmentAnalyzer(){
- 
-}
-
+EcalShowerContainmentAnalyzer::~EcalShowerContainmentAnalyzer() {}
 
 void EcalShowerContainmentAnalyzer::endJob() {
-
   file_->cd();
   tree_->Write();
-
 }
 
-
-void EcalShowerContainmentAnalyzer::analyze( edm::Event const & iEvent, 
-					     const  edm::EventSetup& iSetup){
-
+void EcalShowerContainmentAnalyzer::analyze(edm::Event const& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   using namespace std;
 
   fillxtalmap(iEvent);
 
   Handle<EcalTBEventHeader> pHeader;
-  iEvent.getByLabel("ecalTBunpack",pHeader);
-  
-  ntuple_.run        = pHeader->runNumber();
-  ntuple_.event      = pHeader->eventNumber();
-  
+  iEvent.getByLabel("ecalTBunpack", pHeader);
+
+  ntuple_.run = pHeader->runNumber();
+  ntuple_.event = pHeader->eventNumber();
 
   Handle<EcalTBHodoscopeRecInfo> pHodoscope;
-  iEvent.getByLabel("ecal2006TBHodoscopeReconstructor",
-		    "EcalTBHodoscopeRecInfo",
-		    pHodoscope);
-  
-  ntuple_.hodo_posx  = pHodoscope->posX();
-  ntuple_.hodo_posy  = pHodoscope->posY();
-  
-  
-  
+  iEvent.getByLabel("ecal2006TBHodoscopeReconstructor", "EcalTBHodoscopeRecInfo", pHodoscope);
+
+  ntuple_.hodo_posx = pHodoscope->posX();
+  ntuple_.hodo_posy = pHodoscope->posY();
+
   Handle<EcalUncalibratedRecHitCollection> pIn;
-  iEvent.getByLabel(inputTag_,pIn);
-  
-  
+  iEvent.getByLabel(inputTag_, pIn);
+
   // pick the hottest xtal
-  
-  
-  EcalUncalibratedRecHitCollection::const_iterator iter ;
-  double  maxampl=0;
+
+  EcalUncalibratedRecHitCollection::const_iterator iter;
+  double maxampl = 0;
   EBDetId maxid;
-  
-  for (iter = pIn->begin(); iter != pIn->end(); ++iter){
-    //cout << "raw detid " << iter->id().rawId() << endl; 
-    
+
+  for (iter = pIn->begin(); iter != pIn->end(); ++iter) {
+    //cout << "raw detid " << iter->id().rawId() << endl;
+
     EBDetId detid = iter->id();
-    
-    if (iter->amplitude() > maxampl){
-      maxampl = iter->amplitude() * calibmap_[detid].first; 
-      maxid   = iter ->id();      
+
+    if (iter->amplitude() > maxampl) {
+      maxampl = iter->amplitude() * calibmap_[detid].first;
+      maxid = iter->id();
     }
-  } // for
+  }  // for
 
-  double adctogev =  getAdcToGevConstant(iSetup);
+  double adctogev = getAdcToGevConstant(iSetup);
 
-  ntuple_.energy1x1=maxampl*calibmap_[maxid].first*adctogev;
-  ntuple_.energy3x3=energy3x3(iEvent,maxid) * adctogev;
-  ntuple_.energy5x5=energy5x5(iEvent,maxid) * adctogev;
-  
-  std::pair<double,double> correction = contCorrection(iEvent,iSetup,maxid);
-  ntuple_.corrected3x3=ntuple_.energy3x3/correction.first;
-  ntuple_.corrected5x5=ntuple_.energy5x5/correction.second;
+  ntuple_.energy1x1 = maxampl * calibmap_[maxid].first * adctogev;
+  ntuple_.energy3x3 = energy3x3(iEvent, maxid) * adctogev;
+  ntuple_.energy5x5 = energy5x5(iEvent, maxid) * adctogev;
 
-  
+  std::pair<double, double> correction = contCorrection(iEvent, iSetup, maxid);
+  ntuple_.corrected3x3 = ntuple_.energy3x3 / correction.first;
+  ntuple_.corrected5x5 = ntuple_.energy5x5 / correction.second;
+
   tree_->Fill();
 
   ntuple_.zero();
-
 }
 
-
-
 /// return vector of detids of the xtals around centerXtal (3x3)
-std::vector<EBDetId> 
-EcalShowerContainmentAnalyzer::Xtals3x3(const edm::Event& iEvent, 
-					EBDetId centerXtal){
-
+std::vector<EBDetId> EcalShowerContainmentAnalyzer::Xtals3x3(const edm::Event& iEvent, EBDetId centerXtal) {
   using namespace edm;
   using namespace std;
 
   Handle<EcalUncalibratedRecHitCollection> pIn;
-  iEvent.getByLabel(inputTag_,pIn);
-  
-  // find the ids of the 3x3 matrix    
-  vector<EBDetId> Xtals3x3; 
+  iEvent.getByLabel(inputTag_, pIn);
 
-  
-  for (unsigned int icry=0;icry<9;icry++) {
-      unsigned int row = icry / 3;
-      unsigned int column= icry %3;
-      
-      try {
+  // find the ids of the 3x3 matrix
+  vector<EBDetId> Xtals3x3;
 
-          Xtals3x3.push_back(EBDetId(centerXtal.ieta()+column-1,
-				     centerXtal.iphi()+row-1,
-				     EBDetId::ETAPHIMODE));
-      } catch ( cms::Exception &e ) {
-	Xtals3x3.clear();
-	return Xtals3x3;
-      }//catch
-  } // for
+  for (unsigned int icry = 0; icry < 9; icry++) {
+    unsigned int row = icry / 3;
+    unsigned int column = icry % 3;
+
+    try {
+      Xtals3x3.push_back(EBDetId(centerXtal.ieta() + column - 1, centerXtal.iphi() + row - 1, EBDetId::ETAPHIMODE));
+    } catch (cms::Exception& e) {
+      Xtals3x3.clear();
+      return Xtals3x3;
+    }  //catch
+  }    // for
   return Xtals3x3;
 }
 
 /// return vector of detids of the xtals around centerXtal (5x5)
-std::vector<EBDetId> 
-EcalShowerContainmentAnalyzer::Xtals5x5(const edm::Event& iEvent, 
-					EBDetId centerXtal){
+std::vector<EBDetId> EcalShowerContainmentAnalyzer::Xtals5x5(const edm::Event& iEvent, EBDetId centerXtal) {
   using namespace edm;
   using namespace std;
 
   Handle<EcalUncalibratedRecHitCollection> pIn;
-  iEvent.getByLabel(inputTag_,pIn);
-  
-  // find the ids of the 3x3 matrix    
-  vector<EBDetId> Xtals5x5; 
+  iEvent.getByLabel(inputTag_, pIn);
 
-  
-  for (unsigned int icry=0;icry<25;icry++) {
-      unsigned int row = icry / 5;
-      unsigned int column= icry %5;
-      
-      try {
+  // find the ids of the 3x3 matrix
+  vector<EBDetId> Xtals5x5;
 
-          Xtals5x5.push_back(EBDetId(centerXtal.ieta()+column-2,
-				     centerXtal.iphi()+row-2,
-				     EBDetId::ETAPHIMODE));
-      } catch ( cms::Exception &e ) {
-	Xtals5x5.clear();
-	return Xtals5x5;
-      }//catch
-  } // for
+  for (unsigned int icry = 0; icry < 25; icry++) {
+    unsigned int row = icry / 5;
+    unsigned int column = icry % 5;
+
+    try {
+      Xtals5x5.push_back(EBDetId(centerXtal.ieta() + column - 2, centerXtal.iphi() + row - 2, EBDetId::ETAPHIMODE));
+    } catch (cms::Exception& e) {
+      Xtals5x5.clear();
+      return Xtals5x5;
+    }  //catch
+  }    // for
 
   return Xtals5x5;
 }
 
-
-
-void EcalShowerContainmentAnalyzer::readIntercalibrationConstants(){
-  
+void EcalShowerContainmentAnalyzer::readIntercalibrationConstants() {
   using namespace std;
 
   ifstream calibrationfile(intercalibrationCoeffFile_.c_str());
 
   // skip header lines
-  int kHeaderLines=6;
-  for (int i=0; i<kHeaderLines;i++){
+  int kHeaderLines = 6;
+  for (int i = 0; i < kHeaderLines; i++) {
     char line[64];
-    calibrationfile.getline(line,64);
+    calibrationfile.getline(line, 64);
   }
 
-    
   int xtal;
   double coeff, sigma;
-  int nev,good;
+  int nev, good;
 
-  while(calibrationfile>> xtal >> coeff >> sigma >> nev >> good){
-    EBDetId detid(1,xtal,EBDetId::SMCRYSTALMODE);
-    calibmap_[detid] =pair<double,double>(coeff,good);
-   
+  while (calibrationfile >> xtal >> coeff >> sigma >> nev >> good) {
+    EBDetId detid(1, xtal, EBDetId::SMCRYSTALMODE);
+    calibmap_[detid] = pair<double, double>(coeff, good);
   }
- 
 }
 
-
-void EcalShowerContainmentAnalyzer::fillxtalmap(const edm::Event& iEvent){                     
-
+void EcalShowerContainmentAnalyzer::fillxtalmap(const edm::Event& iEvent) {
   using namespace edm;
 
   Handle<EcalUncalibratedRecHitCollection> pIn;
-  iEvent.getByLabel(inputTag_,pIn);
-  
-  EcalUncalibratedRecHitCollection::const_iterator iter ;
-  
-  for (iter = pIn->begin(); iter != pIn->end(); ++iter){   
+  iEvent.getByLabel(inputTag_, pIn);
+
+  EcalUncalibratedRecHitCollection::const_iterator iter;
+
+  for (iter = pIn->begin(); iter != pIn->end(); ++iter) {
     EBDetId detid = iter->id();
     double amplitude = iter->amplitude();
-    xtalmap_[detid]=amplitude;
-  } // for
-
-
+    xtalmap_[detid] = amplitude;
+  }  // for
 }
-
-
-
-
 
 /** return a pair with correction coeff for 3x3 in first place 
     and correction 5x5 in second   */
-std::pair<double,double> 
-EcalShowerContainmentAnalyzer::contCorrection(const edm::Event& iEvent, 
-					      const edm::EventSetup& iESetup,
-					      const EBDetId& centerXtal){
-
+std::pair<double, double> EcalShowerContainmentAnalyzer::contCorrection(const edm::Event& iEvent,
+                                                                        const edm::EventSetup& iESetup,
+                                                                        const EBDetId& centerXtal) {
   using namespace std;
   using namespace edm;
 
- 
   ESHandle<EcalShowerContainmentCorrections> pGapCorr;
   iESetup.get<EcalShowerContainmentCorrectionsRcd>().get(pGapCorr);
 
- 
-  Handle< EBRecHitCollection > pEBRecHits ;
-  const EBRecHitCollection*  EBRecHits = 0 ;
-  
+  Handle<EBRecHitCollection> pEBRecHits;
+  const EBRecHitCollection* EBRecHits = 0;
+
   const std::string RecHitProducer_("ecal2006TBRecHit");
   const std::string EBRecHitCollection_("EcalRecHitsEB");
 
-  iEvent.getByLabel (RecHitProducer_, EBRecHitCollection_, pEBRecHits) ;
-  EBRecHits = pEBRecHits.product(); 
-  
-  map<string,double> posparam;
-  posparam["LogWeighted"]=1.0;
-  posparam["X0"]=0.89;
-  posparam["T0"]=6.2;
-  posparam["W0"]=4.0;
-  
+  iEvent.getByLabel(RecHitProducer_, EBRecHitCollection_, pEBRecHits);
+  EBRecHits = pEBRecHits.product();
+
+  map<string, double> posparam;
+  posparam["LogWeighted"] = 1.0;
+  posparam["X0"] = 0.89;
+  posparam["T0"] = 6.2;
+  posparam["W0"] = 4.0;
+
   edm::ESHandle<CaloGeometry> geoHandle;
   iESetup.get<CaloGeometryRecord>().get(geoHandle);
   const CaloGeometry& geometry = *geoHandle;
-  const CaloSubdetectorGeometry *geometry_p= 
-    geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-  
-  edm::FileInPath mapfile("Geometry/EcalTestBeam/data/BarrelSM1CrystalCenterElectron120GeV.dat");
-  TBPositionCalc pos(posparam, mapfile.fullPath(),geometry_p);
+  const CaloSubdetectorGeometry* geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
 
-  vector<EBDetId> myDets = Xtals3x3(iEvent,centerXtal);
-  
+  edm::FileInPath mapfile("Geometry/EcalTestBeam/data/BarrelSM1CrystalCenterElectron120GeV.dat");
+  TBPositionCalc pos(posparam, mapfile.fullPath(), geometry_p);
+
+  vector<EBDetId> myDets = Xtals3x3(iEvent, centerXtal);
+
   CLHEP::Hep3Vector clusterPos;
   try {
-    clusterPos = pos.CalculateTBPos(myDets, 
-				    centerXtal.ic(), 
-				    EBRecHits);	      
+    clusterPos = pos.CalculateTBPos(myDets, centerXtal.ic(), EBRecHits);
   } catch (cms::Exception& e) {
-    return make_pair(-99.,-99.);
+    return make_pair(-99., -99.);
   }
 
-  ntuple_.posx= clusterPos.x()*10.;
-  ntuple_.posy= clusterPos.y()*10.;
+  ntuple_.posx = clusterPos.x() * 10.;
+  ntuple_.posy = clusterPos.y() * 10.;
 
-  math::XYZPoint mathpoint(clusterPos.x(),clusterPos.y(),clusterPos.z());
+  math::XYZPoint mathpoint(clusterPos.x(), clusterPos.y(), clusterPos.z());
 
-  double correction3x3 = pGapCorr->correction3x3(centerXtal,mathpoint);
-  double correction5x5 = pGapCorr->correction5x5(centerXtal,mathpoint);
+  double correction3x3 = pGapCorr->correction3x3(centerXtal, mathpoint);
+  double correction5x5 = pGapCorr->correction5x5(centerXtal, mathpoint);
 
-  return std::make_pair(correction3x3,correction5x5);
+  return std::make_pair(correction3x3, correction5x5);
 }
 
-
 // retrieve adctogev constant for xtalid from the database
-double  EcalShowerContainmentAnalyzer::getAdcToGevConstant( const edm::EventSetup& eSetup){
-
+double EcalShowerContainmentAnalyzer::getAdcToGevConstant(const edm::EventSetup& eSetup) {
   edm::ESHandle<EcalADCToGeVConstant> pIcal;
   eSetup.get<EcalADCToGeVConstantRcd>().get(pIcal);
   const EcalADCToGeVConstant* ical = pIcal.product();
   return ical->getEBValue();
-
 }
 
-
-double  
-EcalShowerContainmentAnalyzer::energy3x3(const edm::Event& iEvent, 
-					 EBDetId centerXtal){
+double EcalShowerContainmentAnalyzer::energy3x3(const edm::Event& iEvent, EBDetId centerXtal) {
   using namespace edm;
   using namespace std;
-  
 
-  vector<EBDetId> xtals3x3=Xtals3x3(iEvent, centerXtal); 
-    
+  vector<EBDetId> xtals3x3 = Xtals3x3(iEvent, centerXtal);
+
   // get the energy
-  double energy3x3=0;
+  double energy3x3 = 0;
   vector<EBDetId>::iterator detIt;
-  for (detIt=xtals3x3.begin(); detIt!=xtals3x3.end();++detIt){
-    energy3x3+= xtalmap_[*detIt] * calibmap_[*detIt].first; 
-   
+  for (detIt = xtals3x3.begin(); detIt != xtals3x3.end(); ++detIt) {
+    energy3x3 += xtalmap_[*detIt] * calibmap_[*detIt].first;
   }
-  
+
   return energy3x3;
-
 }
 
-double EcalShowerContainmentAnalyzer::energy5x5(const edm::Event& iEvent, 
-						EBDetId centerXtal){
+double EcalShowerContainmentAnalyzer::energy5x5(const edm::Event& iEvent, EBDetId centerXtal) {
   using namespace edm;
   using namespace std;
-  
-  vector<EBDetId> xtals5x5=Xtals5x5(iEvent,centerXtal); 
-  
+
+  vector<EBDetId> xtals5x5 = Xtals5x5(iEvent, centerXtal);
+
   // get the energy
-  double energy5x5=0;
+  double energy5x5 = 0;
   vector<EBDetId>::iterator detIt;
-  for (detIt=xtals5x5.begin(); detIt!=xtals5x5.end();++detIt){
-    energy5x5+= xtalmap_[*detIt] * calibmap_[*detIt].first; 
-   
+  for (detIt = xtals5x5.begin(); detIt != xtals5x5.end(); ++detIt) {
+    energy5x5 += xtalmap_[*detIt] * calibmap_[*detIt].first;
   }
-  
+
   return energy5x5;
-
 }
-

--- a/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.cc
+++ b/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.cc
@@ -11,40 +11,35 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-
 #include <memory>
 #include <string>
 
 using namespace edm;
 
-TrackerRecoGeometryESProducer::TrackerRecoGeometryESProducer(const edm::ParameterSet & p) 
-{
-    setWhatProduced(this);
-    // 08-Oct-2007 - Patrick Janot
-    // Allow several reco geometries to be created, corresponding to the labelled  
-    // TrackerDigiGeometry's - that must created beforehand. Useful to handle an 
-    // aligned and a misaligned geometry in the same job. 
-    // The default parameter ("") makes this change transparent to the user
-    // See FastSimulation/Configuration/data/ for examples of cfi's.
-    geoLabel = p.getUntrackedParameter<std::string>("trackerGeometryLabel","");
+TrackerRecoGeometryESProducer::TrackerRecoGeometryESProducer(const edm::ParameterSet &p) {
+  setWhatProduced(this);
+  // 08-Oct-2007 - Patrick Janot
+  // Allow several reco geometries to be created, corresponding to the labelled
+  // TrackerDigiGeometry's - that must created beforehand. Useful to handle an
+  // aligned and a misaligned geometry in the same job.
+  // The default parameter ("") makes this change transparent to the user
+  // See FastSimulation/Configuration/data/ for examples of cfi's.
+  geoLabel = p.getUntrackedParameter<std::string>("trackerGeometryLabel", "");
 }
 
 TrackerRecoGeometryESProducer::~TrackerRecoGeometryESProducer() {}
 
-std::unique_ptr<GeometricSearchTracker> 
-TrackerRecoGeometryESProducer::produce(const TrackerRecoGeometryRecord & iRecord){ 
-
-
+std::unique_ptr<GeometricSearchTracker> TrackerRecoGeometryESProducer::produce(
+    const TrackerRecoGeometryRecord &iRecord) {
   edm::ESHandle<TrackerGeometry> tG;
-  iRecord.getRecord<TrackerDigiGeometryRecord>().get( geoLabel, tG );
+  iRecord.getRecord<TrackerDigiGeometryRecord>().get(geoLabel, tG);
 
   edm::ESHandle<TrackerTopology> tTopoHand;
   iRecord.getRecord<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology *tTopo=tTopoHand.product();
+  const TrackerTopology *tTopo = tTopoHand.product();
 
   GeometricSearchTrackerBuilder builder;
-  return std::unique_ptr<GeometricSearchTracker>(builder.build( tG->trackerDet(), &(*tG), tTopo ));
+  return std::unique_ptr<GeometricSearchTracker>(builder.build(tG->trackerDet(), &(*tG), tTopo));
 }
-
 
 DEFINE_FWK_EVENTSETUP_MODULE(TrackerRecoGeometryESProducer);

--- a/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.h
+++ b/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.h
@@ -8,18 +8,14 @@
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 #include <memory>
 
-class  TrackerRecoGeometryESProducer: public edm::ESProducer{
- public:
-  TrackerRecoGeometryESProducer(const edm::ParameterSet & p);
-  ~TrackerRecoGeometryESProducer() override; 
+class TrackerRecoGeometryESProducer : public edm::ESProducer {
+public:
+  TrackerRecoGeometryESProducer(const edm::ParameterSet &p);
+  ~TrackerRecoGeometryESProducer() override;
   std::unique_ptr<GeometricSearchTracker> produce(const TrackerRecoGeometryRecord &);
- private:
- std::string geoLabel;
+
+private:
+  std::string geoLabel;
 };
 
-
 #endif
-
-
-
-

--- a/RecoTracker/GeometryESProducer/test/TrackerRecoGeometryAnalyzer.cc
+++ b/RecoTracker/GeometryESProducer/test/TrackerRecoGeometryAnalyzer.cc
@@ -18,7 +18,7 @@ using namespace std;
 
 class TrackerRecoGeometryAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  TrackerRecoGeometryAnalyzer( const edm::ParameterSet& );
+  TrackerRecoGeometryAnalyzer(const edm::ParameterSet&);
   ~TrackerRecoGeometryAnalyzer();
 
   void beginJob() override {}
@@ -26,34 +26,28 @@ public:
   void endJob() override {}
 };
 
-TrackerRecoGeometryAnalyzer::TrackerRecoGeometryAnalyzer( const edm::ParameterSet& iConfig )
-{}
+TrackerRecoGeometryAnalyzer::TrackerRecoGeometryAnalyzer(const edm::ParameterSet& iConfig) {}
 
-TrackerRecoGeometryAnalyzer::~TrackerRecoGeometryAnalyzer()
-{}
+TrackerRecoGeometryAnalyzer::~TrackerRecoGeometryAnalyzer() {}
 
-void
-TrackerRecoGeometryAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
-   using namespace edm;
+void TrackerRecoGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
 
-   //
-   // get the GeometricSearchDet
-   //
-   edm::ESHandle<GeometricSearchTracker> track;
-   iSetup.get<TrackerRecoGeometryRecord>().get( track );     
-   
-   //---- testing access to barrelLayers ----
-   vector<const BarrelDetLayer*> theBarrelLayers = track->barrelLayers();
-   edm::LogInfo("TrackerRecoGeometryAnalyzer") << "number of BarrelLayers: " << theBarrelLayers.size() ;
+  //
+  // get the GeometricSearchDet
+  //
+  edm::ESHandle<GeometricSearchTracker> track;
+  iSetup.get<TrackerRecoGeometryRecord>().get(track);
 
-   for(unsigned int i=0; i<3; i++){
-     const BarrelDetLayer* theLayer = theBarrelLayers[i];   
-     edm::LogInfo("TrackerRecoGeometryAnalyzer") << "theLayer[" << i << "]->position().perp(): " 
-	  << theLayer->components().front()->surface().position().perp() ;     
-   }   
+  //---- testing access to barrelLayers ----
+  vector<const BarrelDetLayer*> theBarrelLayers = track->barrelLayers();
+  edm::LogInfo("TrackerRecoGeometryAnalyzer") << "number of BarrelLayers: " << theBarrelLayers.size();
+
+  for (unsigned int i = 0; i < 3; i++) {
+    const BarrelDetLayer* theLayer = theBarrelLayers[i];
+    edm::LogInfo("TrackerRecoGeometryAnalyzer")
+        << "theLayer[" << i << "]->position().perp(): " << theLayer->components().front()->surface().position().perp();
+  }
 }
 
 DEFINE_FWK_MODULE(TrackerRecoGeometryAnalyzer);
- 
- 

--- a/RecoVertex/ConfigurableVertexReco/interface/AbstractConfFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/AbstractConfFitter.h
@@ -9,37 +9,36 @@
  *  must be configurable via ::configure
  */
 
-class AbstractConfFitter : public VertexFitter<5>
-{
-  public:
-
-    typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
-    /** The configure method configures the vertex reconstructor.
+class AbstractConfFitter : public VertexFitter<5> {
+public:
+  typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
+  /** The configure method configures the vertex reconstructor.
      *  It also should also write all its applied defaults back into the map,
      */
-    AbstractConfFitter ( const VertexFitter<5> & f );
-    AbstractConfFitter ();
-    AbstractConfFitter ( const AbstractConfFitter & );
+  AbstractConfFitter(const VertexFitter<5>& f);
+  AbstractConfFitter();
+  AbstractConfFitter(const AbstractConfFitter&);
 
-    virtual void configure ( const edm::ParameterSet & ) = 0;
-    virtual edm::ParameterSet defaults() const = 0;
-    ~AbstractConfFitter() override;
-    AbstractConfFitter * clone() const override = 0;
+  virtual void configure(const edm::ParameterSet&) = 0;
+  virtual edm::ParameterSet defaults() const = 0;
+  ~AbstractConfFitter() override;
+  AbstractConfFitter* clone() const override = 0;
 
-    CachingVertex<5> vertex ( const std::vector < reco::TransientTrack > & t ) const override;
-    CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks) const override;
-    CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks,
-        const reco::BeamSpot & spot ) const override;
-    CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-        const GlobalPoint& linPoint) const override;
-    CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-        const GlobalPoint& priorPos, const GlobalError& priorError) const override;
-    CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& t) const override;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks) const override;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks, const reco::BeamSpot& spot) const override;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks, const GlobalPoint& linPoint) const override;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
+                          const GlobalPoint& priorPos,
+                          const GlobalError& priorError) const override;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
                           const reco::BeamSpot& beamSpot) const override;
-    CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks, 
-      const GlobalPoint& priorPos, const GlobalError& priorError) const override;
- public:
-    const VertexFitter<5> * theFitter;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks,
+                          const GlobalPoint& priorPos,
+                          const GlobalError& priorError) const override;
+
+public:
+  const VertexFitter<5>* theFitter;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/AbstractConfReconstructor.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/AbstractConfReconstructor.h
@@ -9,17 +9,15 @@
  *  must be configurable via ::configure
  */
 
-class AbstractConfReconstructor : public VertexReconstructor
-{
-  public:
-
-    /** The configure method configures the vertex reconstructor.
+class AbstractConfReconstructor : public VertexReconstructor {
+public:
+  /** The configure method configures the vertex reconstructor.
      *  It also should also write all its applied defaults back into the map,
      */
-    virtual void configure ( const edm::ParameterSet & ) = 0;
-    virtual edm::ParameterSet defaults() const = 0;
-    ~AbstractConfReconstructor() override {};
-    AbstractConfReconstructor * clone() const override = 0;
+  virtual void configure(const edm::ParameterSet&) = 0;
+  virtual edm::ParameterSet defaults() const = 0;
+  ~AbstractConfReconstructor() override{};
+  AbstractConfReconstructor* clone() const override = 0;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h
@@ -7,12 +7,12 @@
  *  template class that registers an AbstractConfReconstructor
  */
 
-template < class O > class ConfFitterBuilder {
+template <class O>
+class ConfFitterBuilder {
 public:
-  ConfFitterBuilder < O > ( const std::string & name, const std::string & description  )
-  {
-    VertexFitterManager::Instance().registerFitter ( name, []()->AbstractConfFitter*{return new O();}, description );
+  ConfFitterBuilder<O>(const std::string& name, const std::string& description) {
+    VertexFitterManager::Instance().registerFitter(name, []() -> AbstractConfFitter* { return new O(); }, description);
   }
 };
 
-#endif // _ConfFitterBuilder_H_
+#endif  // _ConfFitterBuilder_H_

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h
@@ -7,12 +7,13 @@
  *  template class that registers an AbstractConfReconstructor
  */
 
-template < class O > class ConfRecoBuilder {
+template <class O>
+class ConfRecoBuilder {
 public:
-  ConfRecoBuilder < O > ( const std::string & name, const std::string & description  )
-  {
-    VertexRecoManager::Instance().registerReconstructor ( name,[]()->AbstractConfReconstructor*{ return new O(); } , description );
+  ConfRecoBuilder<O>(const std::string& name, const std::string& description) {
+    VertexRecoManager::Instance().registerReconstructor(
+        name, []() -> AbstractConfReconstructor* { return new O(); }, description);
   }
 };
 
-#endif // _ConfRecoBuilder_H_
+#endif  // _ConfRecoBuilder_H_

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAdaptiveFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAdaptiveFitter.h
@@ -7,21 +7,20 @@
  *  Wrap any VertexFitter into the VertexReconstructor interface
  */
 
-class ConfigurableAdaptiveFitter : public AbstractConfFitter
-{
-  public:
-    /**
+class ConfigurableAdaptiveFitter : public AbstractConfFitter {
+public:
+  /**
      *  Values that are respected:
      *  sigmacut: The sqrt(chi2_cut) criterion. Default: 3.0
      *  ratio:   The annealing ratio. Default: 0.25
      *  Tini:    The initial temparature. Default: 256
      */
-    ConfigurableAdaptiveFitter ();
-    void configure ( const edm::ParameterSet & ) override;
-    ConfigurableAdaptiveFitter ( const ConfigurableAdaptiveFitter & o );
-    ~ConfigurableAdaptiveFitter() override;
-    ConfigurableAdaptiveFitter * clone () const override;
-    edm::ParameterSet defaults() const override;
+  ConfigurableAdaptiveFitter();
+  void configure(const edm::ParameterSet&) override;
+  ConfigurableAdaptiveFitter(const ConfigurableAdaptiveFitter& o);
+  ~ConfigurableAdaptiveFitter() override;
+  ConfigurableAdaptiveFitter* clone() const override;
+  edm::ParameterSet defaults() const override;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAdaptiveReconstructor.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAdaptiveReconstructor.h
@@ -7,26 +7,23 @@
  *  Wrap any VertexFitter into the VertexReconstructor interface
  */
 
-class ConfigurableAdaptiveReconstructor : public AbstractConfReconstructor
-{
-  public:
-    ConfigurableAdaptiveReconstructor ();
-    void configure ( const edm::ParameterSet & ) override;
-    ConfigurableAdaptiveReconstructor ( const ConfigurableAdaptiveReconstructor & o );
-    ~ConfigurableAdaptiveReconstructor() override;
-    ConfigurableAdaptiveReconstructor * clone () const override;
-    std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & t ) const override;
-    std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & t,
-        const reco::BeamSpot & ) const override;
-    std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & prims,
-        const std::vector < reco::TransientTrack > & secs,
-        const reco::BeamSpot & ) const override;
-    edm::ParameterSet defaults() const override;
-  private:
-    const VertexReconstructor * theRector;
+class ConfigurableAdaptiveReconstructor : public AbstractConfReconstructor {
+public:
+  ConfigurableAdaptiveReconstructor();
+  void configure(const edm::ParameterSet&) override;
+  ConfigurableAdaptiveReconstructor(const ConfigurableAdaptiveReconstructor& o);
+  ~ConfigurableAdaptiveReconstructor() override;
+  ConfigurableAdaptiveReconstructor* clone() const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& t) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& t,
+                                        const reco::BeamSpot&) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& prims,
+                                        const std::vector<reco::TransientTrack>& secs,
+                                        const reco::BeamSpot&) const override;
+  edm::ParameterSet defaults() const override;
+
+private:
+  const VertexReconstructor* theRector;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAnnealing.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableAnnealing.h
@@ -12,23 +12,23 @@ class ConfigurableAnnealing : public AnnealingSchedule {
    */
 
 public:
-  ConfigurableAnnealing( const edm::ParameterSet & );
+  ConfigurableAnnealing(const edm::ParameterSet&);
   ~ConfigurableAnnealing() override;
-  ConfigurableAnnealing( const ConfigurableAnnealing & );
+  ConfigurableAnnealing(const ConfigurableAnnealing&);
   void anneal() override;
   void resetAnnealing() override;
-  double phi ( double chi2 ) const override;
-  double weight ( double chi2 ) const override;
+  double phi(double chi2) const override;
+  double weight(double chi2) const override;
   double cutoff() const override;
   double currentTemp() const override;
   double initialTemp() const override;
   bool isAnnealed() const override;
   void debug() const override;
 
-  ConfigurableAnnealing * clone() const override;
+  ConfigurableAnnealing* clone() const override;
 
 private:
-  AnnealingSchedule * theImpl;
+  AnnealingSchedule* theImpl;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableKalmanFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableKalmanFitter.h
@@ -7,16 +7,14 @@
  *  Kalman filter, configurable version
  */
 
-class ConfigurableKalmanFitter : public AbstractConfFitter
-{
-  public:
-    ConfigurableKalmanFitter ();
-    void configure ( const edm::ParameterSet & ) override;
-    ConfigurableKalmanFitter ( const ConfigurableKalmanFitter & o );
-    ~ConfigurableKalmanFitter() override;
-    ConfigurableKalmanFitter * clone () const override;
-    edm::ParameterSet defaults() const override;
-
+class ConfigurableKalmanFitter : public AbstractConfFitter {
+public:
+  ConfigurableKalmanFitter();
+  void configure(const edm::ParameterSet&) override;
+  ConfigurableKalmanFitter(const ConfigurableKalmanFitter& o);
+  ~ConfigurableKalmanFitter() override;
+  ConfigurableKalmanFitter* clone() const override;
+  edm::ParameterSet defaults() const override;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableMultiVertexFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableMultiVertexFitter.h
@@ -9,10 +9,9 @@ class MultiVertexReconstructor;
  *  Wrap any VertexFitter into the VertexReconstructor interface
  */
 
-class ConfigurableMultiVertexFitter : public AbstractConfReconstructor
-{
-  public:
-    /**
+class ConfigurableMultiVertexFitter : public AbstractConfReconstructor {
+public:
+  /**
      *
      * Accepted values:
      *  sigmacut: The sqrt(chi2_cut) criterion. Default: 3.0
@@ -20,24 +19,22 @@ class ConfigurableMultiVertexFitter : public AbstractConfReconstructor
      *  Tini:    The initial temparature. Default: 256
      *
      */
-    ConfigurableMultiVertexFitter ();
-    ConfigurableMultiVertexFitter ( const ConfigurableMultiVertexFitter & o );
-    ~ConfigurableMultiVertexFitter() override;
-    ConfigurableMultiVertexFitter * clone () const override;
-    std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & t ) const override;
-    std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & t,
-        const reco::BeamSpot & s ) const override;
-    std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & prims,
-        const std::vector < reco::TransientTrack > & secs,
-        const reco::BeamSpot & s ) const override;
-    void configure ( const edm::ParameterSet & ) override;
-    edm::ParameterSet defaults() const override;
-  private:
-    const MultiVertexReconstructor * theRector;
-    int theCheater;
+  ConfigurableMultiVertexFitter();
+  ConfigurableMultiVertexFitter(const ConfigurableMultiVertexFitter& o);
+  ~ConfigurableMultiVertexFitter() override;
+  ConfigurableMultiVertexFitter* clone() const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& t) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& t,
+                                        const reco::BeamSpot& s) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& prims,
+                                        const std::vector<reco::TransientTrack>& secs,
+                                        const reco::BeamSpot& s) const override;
+  void configure(const edm::ParameterSet&) override;
+  edm::ParameterSet defaults() const override;
+
+private:
+  const MultiVertexReconstructor* theRector;
+  int theCheater;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableTrimmedKalmanFinder.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableTrimmedKalmanFinder.h
@@ -7,26 +7,23 @@
  *  Wrap any VertexFitter into the VertexReconstructor interface
  */
 
-class ConfigurableTrimmedKalmanFinder : public AbstractConfReconstructor
-{
-  public:
-    ConfigurableTrimmedKalmanFinder ();
-    void configure ( const edm::ParameterSet & ) override;
-    ConfigurableTrimmedKalmanFinder ( const ConfigurableTrimmedKalmanFinder & o );
-    ~ConfigurableTrimmedKalmanFinder() override;
-    ConfigurableTrimmedKalmanFinder * clone () const override;
-    std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & t ) const override;
-    std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & t,
-        const reco::BeamSpot & s ) const override;
-    std::vector < TransientVertex > vertices ( 
-        const std::vector < reco::TransientTrack > & prims,
-        const std::vector < reco::TransientTrack > & secs,
-        const reco::BeamSpot & s ) const override;
-    edm::ParameterSet defaults() const override;
-  private:
-    const VertexReconstructor * theRector;
+class ConfigurableTrimmedKalmanFinder : public AbstractConfReconstructor {
+public:
+  ConfigurableTrimmedKalmanFinder();
+  void configure(const edm::ParameterSet&) override;
+  ConfigurableTrimmedKalmanFinder(const ConfigurableTrimmedKalmanFinder& o);
+  ~ConfigurableTrimmedKalmanFinder() override;
+  ConfigurableTrimmedKalmanFinder* clone() const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& t) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& t,
+                                        const reco::BeamSpot& s) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>& prims,
+                                        const std::vector<reco::TransientTrack>& secs,
+                                        const reco::BeamSpot& s) const override;
+  edm::ParameterSet defaults() const override;
+
+private:
+  const VertexReconstructor* theRector;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexFitter.h
@@ -14,33 +14,31 @@
  *  Note that every fitter registers as a finder, also.
  */
 
-class ConfigurableVertexFitter : public VertexFitter<5>
-{
-  public:
+class ConfigurableVertexFitter : public VertexFitter<5> {
+public:
+  typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
 
-    typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
+  ConfigurableVertexFitter(const edm::ParameterSet&);
+  ConfigurableVertexFitter(const ConfigurableVertexFitter& o);
+  ~ConfigurableVertexFitter() override;
 
-    ConfigurableVertexFitter ( const edm::ParameterSet & );
-    ConfigurableVertexFitter ( const ConfigurableVertexFitter & o );
-    ~ConfigurableVertexFitter() override;
+  ConfigurableVertexFitter* clone() const override;
 
-    ConfigurableVertexFitter * clone () const override;
-
-    CachingVertex<5> vertex ( const std::vector < reco::TransientTrack > & t ) const override;
-    CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks) const override;
-    CachingVertex<5> vertex( const std::vector<RefCountedVertexTrack> & tracks,
-        const reco::BeamSpot & spot ) const override;
-    CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-        const GlobalPoint& linPoint) const override;
-    CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
-        const GlobalPoint& priorPos, const GlobalError& priorError) const override;
-    CachingVertex<5> vertex( const std::vector<reco::TransientTrack> & tracks, 
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& t) const override;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks) const override;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks, const reco::BeamSpot& spot) const override;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks, const GlobalPoint& linPoint) const override;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
+                          const GlobalPoint& priorPos,
+                          const GlobalError& priorError) const override;
+  CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
                           const reco::BeamSpot& beamSpot) const override;
-    CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack> & tracks, 
-      const GlobalPoint& priorPos, const GlobalError& priorError) const override;
+  CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks,
+                          const GlobalPoint& priorPos,
+                          const GlobalError& priorError) const override;
 
-  private:
-    AbstractConfFitter * theFitter;
+private:
+  AbstractConfFitter* theFitter;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexReconstructor.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexReconstructor.h
@@ -10,23 +10,23 @@
  *  Wrap any VertexFitter into the VertexReconstructor interface
  */
 
-class ConfigurableVertexReconstructor : public VertexReconstructor
-{
-  public:
-    ConfigurableVertexReconstructor ( const edm::ParameterSet & );
-    ConfigurableVertexReconstructor ( const ConfigurableVertexReconstructor & o );
-    ~ConfigurableVertexReconstructor() override;
+class ConfigurableVertexReconstructor : public VertexReconstructor {
+public:
+  ConfigurableVertexReconstructor(const edm::ParameterSet &);
+  ConfigurableVertexReconstructor(const ConfigurableVertexReconstructor &o);
+  ~ConfigurableVertexReconstructor() override;
 
-    std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > & ) const override;
-    std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > &,
-        const reco::BeamSpot & ) const override;
-    std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > &,
-        const std::vector < reco::TransientTrack > &, const reco::BeamSpot & ) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
+                                        const reco::BeamSpot &) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
+                                        const std::vector<reco::TransientTrack> &,
+                                        const reco::BeamSpot &) const override;
 
-    ConfigurableVertexReconstructor * clone () const override;
+  ConfigurableVertexReconstructor *clone() const override;
 
-  private:
-    AbstractConfReconstructor * theRector;
+private:
+  AbstractConfReconstructor *theRector;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/ReconstructorFromFitter.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/ReconstructorFromFitter.h
@@ -9,22 +9,20 @@
  *  Wrap any VertexFitter into the VertexReconstructor interface
  */
 
-class ReconstructorFromFitter : public AbstractConfReconstructor 
-{
-  public:
-  explicit ReconstructorFromFitter ( std::unique_ptr<AbstractConfFitter>&&  );
-    ReconstructorFromFitter ( const ReconstructorFromFitter & o );
-    ~ReconstructorFromFitter() override;
-    void configure(const edm::ParameterSet&) override;
-    edm::ParameterSet defaults() const override;
-    std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > & ) const override;
-    std::vector < TransientVertex > vertices ( const std::vector < reco::TransientTrack > &,
-        const reco::BeamSpot & ) const override;
+class ReconstructorFromFitter : public AbstractConfReconstructor {
+public:
+  explicit ReconstructorFromFitter(std::unique_ptr<AbstractConfFitter>&&);
+  ReconstructorFromFitter(const ReconstructorFromFitter& o);
+  ~ReconstructorFromFitter() override;
+  void configure(const edm::ParameterSet&) override;
+  edm::ParameterSet defaults() const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>&) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack>&, const reco::BeamSpot&) const override;
 
-    ReconstructorFromFitter * clone () const override;
+  ReconstructorFromFitter* clone() const override;
 
-  private:
-    const AbstractConfFitter * theFitter;
+private:
+  const AbstractConfFitter* theFitter;
 };
 
 #endif

--- a/RecoVertex/ConfigurableVertexReco/interface/VertexFitterManager.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/VertexFitterManager.h
@@ -13,24 +13,22 @@
  */
 
 class VertexFitterManager {
-
 public:
-  static VertexFitterManager & Instance();
-  void registerFitter ( const std::string & name, std::function<AbstractConfFitter* ()> o,
-                          const std::string & description );
-  std::string describe ( const std::string & ) const;
+  static VertexFitterManager& Instance();
+  void registerFitter(const std::string& name, std::function<AbstractConfFitter*()> o, const std::string& description);
+  std::string describe(const std::string&) const;
 
-  std::unique_ptr<AbstractConfFitter> get ( const std::string & ) const;
+  std::unique_ptr<AbstractConfFitter> get(const std::string&) const;
   std::vector<std::string> getNames() const;
 
   ~VertexFitterManager();
-  VertexFitterManager * clone() const;
+  VertexFitterManager* clone() const;
 
 private:
-  VertexFitterManager ( const VertexFitterManager & );
-  VertexFitterManager ();
-  std::map < std::string, std::function<AbstractConfFitter*()> > theAbstractConfFitters;
-  std::map < std::string, std::string > theDescription;
+  VertexFitterManager(const VertexFitterManager&);
+  VertexFitterManager();
+  std::map<std::string, std::function<AbstractConfFitter*()> > theAbstractConfFitters;
+  std::map<std::string, std::string> theDescription;
 };
 
-#endif // _VertexFitterManager_H_
+#endif  // _VertexFitterManager_H_

--- a/RecoVertex/ConfigurableVertexReco/interface/VertexRecoManager.h
+++ b/RecoVertex/ConfigurableVertexReco/interface/VertexRecoManager.h
@@ -12,24 +12,24 @@
  */
 
 class VertexRecoManager {
-
 public:
-  static VertexRecoManager & Instance();
-  void registerReconstructor ( const std::string & name, std::function<AbstractConfReconstructor *()> o,
-                  const std::string & description );
-  std::string describe ( const std::string & ) const;
+  static VertexRecoManager &Instance();
+  void registerReconstructor(const std::string &name,
+                             std::function<AbstractConfReconstructor *()> o,
+                             const std::string &description);
+  std::string describe(const std::string &) const;
 
-  std::unique_ptr<AbstractConfReconstructor>  get ( const std::string & ) const;
+  std::unique_ptr<AbstractConfReconstructor> get(const std::string &) const;
   std::vector<std::string> getNames() const;
 
   ~VertexRecoManager();
-  VertexRecoManager * clone() const;
+  VertexRecoManager *clone() const;
 
 private:
-  VertexRecoManager ( const VertexRecoManager & );
-  VertexRecoManager ();
-  std::map < std::string, std::function<AbstractConfReconstructor*()> > theAbstractConfReconstructors;
-  std::map < std::string, std::string > theDescription;
+  VertexRecoManager(const VertexRecoManager &);
+  VertexRecoManager();
+  std::map<std::string, std::function<AbstractConfReconstructor *()> > theAbstractConfReconstructors;
+  std::map<std::string, std::string> theDescription;
 };
 
-#endif // _VertexRecoManager_H_
+#endif  // _VertexRecoManager_H_

--- a/RecoVertex/ConfigurableVertexReco/src/AbstractConfFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/AbstractConfFitter.cc
@@ -1,62 +1,47 @@
 #include "RecoVertex/ConfigurableVertexReco/interface/AbstractConfFitter.h"
-    
-AbstractConfFitter::AbstractConfFitter ( const VertexFitter<5> & f ) :
-  theFitter ( f.clone() )
-{}
 
-AbstractConfFitter::AbstractConfFitter() : theFitter ( nullptr )
-{}
+AbstractConfFitter::AbstractConfFitter(const VertexFitter<5>& f) : theFitter(f.clone()) {}
 
-AbstractConfFitter::AbstractConfFitter ( const AbstractConfFitter & o ) :
-  theFitter ( o.theFitter->clone() )
-{}
+AbstractConfFitter::AbstractConfFitter() : theFitter(nullptr) {}
 
-AbstractConfFitter::~AbstractConfFitter()
-{
-  if ( theFitter ) delete theFitter;
+AbstractConfFitter::AbstractConfFitter(const AbstractConfFitter& o) : theFitter(o.theFitter->clone()) {}
+
+AbstractConfFitter::~AbstractConfFitter() {
+  if (theFitter)
+    delete theFitter;
 }
 
-CachingVertex<5> AbstractConfFitter::vertex ( 
-    const std::vector < reco::TransientTrack > & t ) const
-{
-  return theFitter->vertex ( t );
+CachingVertex<5> AbstractConfFitter::vertex(const std::vector<reco::TransientTrack>& t) const {
+  return theFitter->vertex(t);
 }
 
-CachingVertex<5> AbstractConfFitter::vertex(
-  const std::vector<RefCountedVertexTrack> & tracks) const
-{
-  return theFitter->vertex ( tracks );
+CachingVertex<5> AbstractConfFitter::vertex(const std::vector<RefCountedVertexTrack>& tracks) const {
+  return theFitter->vertex(tracks);
 }
 
-CachingVertex<5> AbstractConfFitter::vertex(
-  const std::vector<RefCountedVertexTrack> & tracks,
-  const reco::BeamSpot & spot ) const
-{
-  return theFitter->vertex ( tracks, spot );
+CachingVertex<5> AbstractConfFitter::vertex(const std::vector<RefCountedVertexTrack>& tracks,
+                                            const reco::BeamSpot& spot) const {
+  return theFitter->vertex(tracks, spot);
 }
 
-
-CachingVertex<5> AbstractConfFitter::vertex(
-  const std::vector<reco::TransientTrack> & tracks, const GlobalPoint& linPoint) const
-{
-  return theFitter->vertex ( tracks, linPoint );
+CachingVertex<5> AbstractConfFitter::vertex(const std::vector<reco::TransientTrack>& tracks,
+                                            const GlobalPoint& linPoint) const {
+  return theFitter->vertex(tracks, linPoint);
 }
 
-CachingVertex<5> AbstractConfFitter::vertex(
-  const std::vector<reco::TransientTrack> & tracks, const GlobalPoint& priorPos,
-  const GlobalError& priorError) const
-{
-  return theFitter->vertex ( tracks, priorPos, priorError );
+CachingVertex<5> AbstractConfFitter::vertex(const std::vector<reco::TransientTrack>& tracks,
+                                            const GlobalPoint& priorPos,
+                                            const GlobalError& priorError) const {
+  return theFitter->vertex(tracks, priorPos, priorError);
 }
 
-CachingVertex<5> AbstractConfFitter::vertex(
-  const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const
-{
-  return theFitter->vertex ( tracks, beamSpot );
+CachingVertex<5> AbstractConfFitter::vertex(const std::vector<reco::TransientTrack>& tracks,
+                                            const reco::BeamSpot& beamSpot) const {
+  return theFitter->vertex(tracks, beamSpot);
 }
 
-CachingVertex<5> AbstractConfFitter::vertex(const std::vector<RefCountedVertexTrack> & tracks, 
-  const GlobalPoint& priorPos, const GlobalError& priorError) const
-{
-  return theFitter->vertex ( tracks, priorPos, priorError );
+CachingVertex<5> AbstractConfFitter::vertex(const std::vector<RefCountedVertexTrack>& tracks,
+                                            const GlobalPoint& priorPos,
+                                            const GlobalError& priorError) const {
+  return theFitter->vertex(tracks, priorPos, priorError);
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveFitter.cc
@@ -16,80 +16,65 @@
 using namespace std;
 
 namespace {
-  edm::ParameterSet mydefaults()
-  {
+  edm::ParameterSet mydefaults() {
     edm::ParameterSet ret;
-    ret.addParameter<string>("annealing", "geom" );
-    ret.addParameter<bool>("smoothing", true );
-    ret.addParameter<double>("sigmacut",3.0);
-    ret.addParameter<double>("Tini",256.0);
-    ret.addParameter<double>("ratio",0.25);
+    ret.addParameter<string>("annealing", "geom");
+    ret.addParameter<bool>("smoothing", true);
+    ret.addParameter<double>("sigmacut", 3.0);
+    ret.addParameter<double>("Tini", 256.0);
+    ret.addParameter<double>("ratio", 0.25);
 
-    ret.addParameter<double>("maxshift",0.0001);
-    ret.addParameter<double>("maxlpshift",0.1);
-    ret.addParameter<int>("maxstep",30);
-    ret.addParameter<double>("weightthreshold",0.001);
+    ret.addParameter<double>("maxshift", 0.0001);
+    ret.addParameter<double>("maxlpshift", 0.1);
+    ret.addParameter<int>("maxstep", 30);
+    ret.addParameter<double>("weightthreshold", 0.001);
     return ret;
   }
-}
+}  // namespace
 
-ConfigurableAdaptiveFitter::ConfigurableAdaptiveFitter() :
-    AbstractConfFitter ( AdaptiveVertexFitter() )
-{}
+ConfigurableAdaptiveFitter::ConfigurableAdaptiveFitter() : AbstractConfFitter(AdaptiveVertexFitter()) {}
 
-void ConfigurableAdaptiveFitter::configure(
-    const edm::ParameterSet & n )
-{
-  edm::ParameterSet m=n;
-  m.augment ( mydefaults() );
-  ConfigurableAnnealing ann ( m );
+void ConfigurableAdaptiveFitter::configure(const edm::ParameterSet& n) {
+  edm::ParameterSet m = n;
+  m.augment(mydefaults());
+  ConfigurableAnnealing ann(m);
   DefaultLinearizationPointFinder linpt;
   // ZeroLinearizationPointFinder linpt;
   // KalmanVertexFitter kvf;
   // GenericLinearizationPointFinder linpt ( kvf );
   KalmanVertexUpdator<5> updator;
-  bool s=m.getParameter< bool >("smoothing");
-  VertexSmoother<5> * smoother=nullptr;
-  if ( s )
-  {
-    smoother = new KalmanVertexSmoother ();
+  bool s = m.getParameter<bool>("smoothing");
+  VertexSmoother<5>* smoother = nullptr;
+  if (s) {
+    smoother = new KalmanVertexSmoother();
   } else {
-    smoother = new DummyVertexSmoother<5> ();
+    smoother = new DummyVertexSmoother<5>();
   }
   KalmanVertexTrackCompatibilityEstimator<5> estimator;
 
-  if (theFitter) delete theFitter;
-  AdaptiveVertexFitter * fitter = new AdaptiveVertexFitter ( ann, linpt, updator, estimator, *smoother );
+  if (theFitter)
+    delete theFitter;
+  AdaptiveVertexFitter* fitter = new AdaptiveVertexFitter(ann, linpt, updator, estimator, *smoother);
   delete smoother;
-  fitter->setParameters ( m );
-  theFitter=fitter;
+  fitter->setParameters(m);
+  theFitter = fitter;
 }
 
-ConfigurableAdaptiveFitter::~ConfigurableAdaptiveFitter()
-{
+ConfigurableAdaptiveFitter::~ConfigurableAdaptiveFitter() {
   /*
   if (theFitter) delete theFitter;
   theFitter=0;
   */
 }
 
-ConfigurableAdaptiveFitter::ConfigurableAdaptiveFitter 
-    ( const ConfigurableAdaptiveFitter & o ) :
-  AbstractConfFitter ( o )
-{}
+ConfigurableAdaptiveFitter::ConfigurableAdaptiveFitter(const ConfigurableAdaptiveFitter& o) : AbstractConfFitter(o) {}
 
-ConfigurableAdaptiveFitter * ConfigurableAdaptiveFitter::clone() const
-{
-  return new ConfigurableAdaptiveFitter ( *this );
-}
+ConfigurableAdaptiveFitter* ConfigurableAdaptiveFitter::clone() const { return new ConfigurableAdaptiveFitter(*this); }
 
-edm::ParameterSet ConfigurableAdaptiveFitter::defaults() const
-{
-  return mydefaults();
-}
+edm::ParameterSet ConfigurableAdaptiveFitter::defaults() const { return mydefaults(); }
 
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h"
 
 namespace {
-  const ConfFitterBuilder < ConfigurableAdaptiveFitter > t ( "avf", "AdaptiveVertexFitter" );
+  const ConfFitterBuilder<ConfigurableAdaptiveFitter> t("avf", "AdaptiveVertexFitter");
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveReconstructor.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableAdaptiveReconstructor.cc
@@ -4,83 +4,63 @@
 using namespace std;
 
 namespace {
-  edm::ParameterSet mydefaults()
-  {
+  edm::ParameterSet mydefaults() {
     edm::ParameterSet ret;
-    ret.addParameter<double>("primcut",2.0);
-    ret.addParameter<double>("primT",256.0);
-    ret.addParameter<double>("primr",0.25);
-    ret.addParameter<double>("seccut",6.0);
-    ret.addParameter<double>("secT",256.0);
-    ret.addParameter<double>("secr",0.25);
-    ret.addParameter<double>("minweight",0.5);
-    ret.addParameter<double>("weightthreshold",0.001 );
-    ret.addParameter<bool>("smoothing",false );
+    ret.addParameter<double>("primcut", 2.0);
+    ret.addParameter<double>("primT", 256.0);
+    ret.addParameter<double>("primr", 0.25);
+    ret.addParameter<double>("seccut", 6.0);
+    ret.addParameter<double>("secT", 256.0);
+    ret.addParameter<double>("secr", 0.25);
+    ret.addParameter<double>("minweight", 0.5);
+    ret.addParameter<double>("weightthreshold", 0.001);
+    ret.addParameter<bool>("smoothing", false);
     return ret;
   }
+}  // namespace
+
+ConfigurableAdaptiveReconstructor::ConfigurableAdaptiveReconstructor() : theRector(new AdaptiveVertexReconstructor()) {}
+
+void ConfigurableAdaptiveReconstructor::configure(const edm::ParameterSet& n) {
+  edm::ParameterSet m = n;
+  m.augment(mydefaults());
+  if (theRector)
+    delete theRector;
+  theRector = new AdaptiveVertexReconstructor(m);
 }
 
-ConfigurableAdaptiveReconstructor::ConfigurableAdaptiveReconstructor() :
-    theRector( new AdaptiveVertexReconstructor() )
-{}
-
-void ConfigurableAdaptiveReconstructor::configure(
-    const edm::ParameterSet & n )
-{
-  edm::ParameterSet m=n;
-  m.augment ( mydefaults() );
-  if ( theRector ) delete theRector;
-  theRector = new AdaptiveVertexReconstructor( m );
+ConfigurableAdaptiveReconstructor::~ConfigurableAdaptiveReconstructor() {
+  if (theRector)
+    delete theRector;
 }
 
-ConfigurableAdaptiveReconstructor::~ConfigurableAdaptiveReconstructor()
-{
-  if ( theRector ) delete theRector;
+ConfigurableAdaptiveReconstructor::ConfigurableAdaptiveReconstructor(const ConfigurableAdaptiveReconstructor& o)
+    : theRector(o.theRector->clone()) {}
+
+ConfigurableAdaptiveReconstructor* ConfigurableAdaptiveReconstructor::clone() const {
+  return new ConfigurableAdaptiveReconstructor(*this);
 }
 
-ConfigurableAdaptiveReconstructor::ConfigurableAdaptiveReconstructor 
-    ( const ConfigurableAdaptiveReconstructor & o ) :
-  theRector ( o.theRector->clone() )
-{}
-
-
-ConfigurableAdaptiveReconstructor * ConfigurableAdaptiveReconstructor::clone() const
-{
-  return new ConfigurableAdaptiveReconstructor ( *this );
+vector<TransientVertex> ConfigurableAdaptiveReconstructor::vertices(const std::vector<reco::TransientTrack>& t) const {
+  return theRector->vertices(t);
 }
 
-vector < TransientVertex > ConfigurableAdaptiveReconstructor::vertices ( 
-    const std::vector < reco::TransientTrack > & t ) const
-{
-  return theRector->vertices ( t );
+vector<TransientVertex> ConfigurableAdaptiveReconstructor::vertices(const std::vector<reco::TransientTrack>& t,
+                                                                    const reco::BeamSpot& s) const {
+  return theRector->vertices(t, s);
 }
 
-vector < TransientVertex > ConfigurableAdaptiveReconstructor::vertices ( 
-    const std::vector < reco::TransientTrack > & t,
-    const reco::BeamSpot & s ) const
-{
-  return theRector->vertices ( t, s );
+vector<TransientVertex> ConfigurableAdaptiveReconstructor::vertices(const std::vector<reco::TransientTrack>& prims,
+                                                                    const std::vector<reco::TransientTrack>& secs,
+                                                                    const reco::BeamSpot& s) const {
+  return theRector->vertices(prims, secs, s);
 }
 
-vector < TransientVertex > ConfigurableAdaptiveReconstructor::vertices ( 
-    const std::vector < reco::TransientTrack > & prims,
-    const std::vector < reco::TransientTrack > & secs,
-    const reco::BeamSpot & s ) const
-{
-  return theRector->vertices ( prims, secs, s );
-}
-
-
-
-edm::ParameterSet ConfigurableAdaptiveReconstructor::defaults() const
-{
-  return mydefaults();
-}
+edm::ParameterSet ConfigurableAdaptiveReconstructor::defaults() const { return mydefaults(); }
 
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h"
 
 namespace {
-  const ConfRecoBuilder < ConfigurableAdaptiveReconstructor > t
-    ( "avr", "Adaptive Vertex Reconstructor [ = Iterative avf]" );
+  const ConfRecoBuilder<ConfigurableAdaptiveReconstructor> t("avr", "Adaptive Vertex Reconstructor [ = Iterative avf]");
   // ConfRecoBuilder < ConfigurableAdaptiveReconstructor > s ( "default", "Adaptive Vertex Reconstructor [ = Iterative avf]" );
-}
+}  // namespace

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableAnnealing.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableAnnealing.cc
@@ -6,89 +6,49 @@
 
 using namespace std;
 
-ConfigurableAnnealing::ConfigurableAnnealing ( const edm::ParameterSet & m ) :
-  theImpl( nullptr )
-{
+ConfigurableAnnealing::ConfigurableAnnealing(const edm::ParameterSet& m) : theImpl(nullptr) {
   string type = m.getParameter<string>("annealing");
   // edm::LogWarning("ConfigurableAnnealing") << "below one code ist still here.";
-  if ( type == "below" )
-  {
+  if (type == "below") {
     edm::LogError("ConfigurableAnnealing") << "below one annealing employed!";
-    vector < float > sched;
+    vector<float> sched;
     double final = m.getParameter<double>("Tfinal");
-    sched.push_back ( 256. );
-    sched.push_back ( 64. );
-    sched.push_back ( 16. );
-    sched.push_back ( 4. );
-    sched.push_back ( 1. );
-    sched.push_back ( final );
-    theImpl = new DeterministicAnnealing( sched, m.getParameter<double>("sigmacut"));
-  } else if ( type =="geom" ) {
+    sched.push_back(256.);
+    sched.push_back(64.);
+    sched.push_back(16.);
+    sched.push_back(4.);
+    sched.push_back(1.);
+    sched.push_back(final);
+    theImpl = new DeterministicAnnealing(sched, m.getParameter<double>("sigmacut"));
+  } else if (type == "geom") {
     theImpl = new GeometricAnnealing(
-                    m.getParameter<double>("sigmacut"),
-                    m.getParameter<double>("Tini"),
-                    m.getParameter<double>("ratio") );
+        m.getParameter<double>("sigmacut"), m.getParameter<double>("Tini"), m.getParameter<double>("ratio"));
   } else {
     edm::LogError("ConfigurableAnnealing") << "annealing type " << type << " is not known.";
     exit(-1);
   }
 }
 
-ConfigurableAnnealing::ConfigurableAnnealing ( const ConfigurableAnnealing & o ) :
-  theImpl ( o.theImpl->clone() )
-{}
+ConfigurableAnnealing::ConfigurableAnnealing(const ConfigurableAnnealing& o) : theImpl(o.theImpl->clone()) {}
 
-ConfigurableAnnealing * ConfigurableAnnealing::clone() const
-{
-  return new ConfigurableAnnealing ( *this );
-}
+ConfigurableAnnealing* ConfigurableAnnealing::clone() const { return new ConfigurableAnnealing(*this); }
 
-ConfigurableAnnealing::~ConfigurableAnnealing()
-{
-  delete theImpl;
-}
+ConfigurableAnnealing::~ConfigurableAnnealing() { delete theImpl; }
 
-void ConfigurableAnnealing::debug() const
-{
-  theImpl->debug();
-}
+void ConfigurableAnnealing::debug() const { theImpl->debug(); }
 
-void ConfigurableAnnealing::anneal()
-{
-  theImpl->anneal();
-}
+void ConfigurableAnnealing::anneal() { theImpl->anneal(); }
 
-double ConfigurableAnnealing::weight ( double chi2 ) const
-{
-  return theImpl->weight ( chi2 );
-}
+double ConfigurableAnnealing::weight(double chi2) const { return theImpl->weight(chi2); }
 
-void ConfigurableAnnealing::resetAnnealing()
-{
-  theImpl->resetAnnealing();
-}
+void ConfigurableAnnealing::resetAnnealing() { theImpl->resetAnnealing(); }
 
-inline double ConfigurableAnnealing::phi( double chi2 ) const
-{
-  return theImpl->phi ( chi2 );
-}
+inline double ConfigurableAnnealing::phi(double chi2) const { return theImpl->phi(chi2); }
 
-double ConfigurableAnnealing::cutoff() const
-{
-  return theImpl->cutoff();
-}
+double ConfigurableAnnealing::cutoff() const { return theImpl->cutoff(); }
 
-double ConfigurableAnnealing::currentTemp() const
-{
-  return theImpl->currentTemp();
-}
+double ConfigurableAnnealing::currentTemp() const { return theImpl->currentTemp(); }
 
-double ConfigurableAnnealing::initialTemp() const
-{
-  return theImpl->initialTemp();
-}
+double ConfigurableAnnealing::initialTemp() const { return theImpl->initialTemp(); }
 
-bool ConfigurableAnnealing::isAnnealed() const
-{
-  return theImpl->isAnnealed();
-}
+bool ConfigurableAnnealing::isAnnealed() const { return theImpl->isAnnealed(); }

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableKalmanFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableKalmanFitter.cc
@@ -2,52 +2,37 @@
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
 
 namespace {
-  edm::ParameterSet mydefaults()
-  {
+  edm::ParameterSet mydefaults() {
     edm::ParameterSet ret;
-    ret.addParameter<double>("maxDistance",0.01);
-    ret.addParameter<int>("maxNbrOfIterations",10);
+    ret.addParameter<double>("maxDistance", 0.01);
+    ret.addParameter<int>("maxNbrOfIterations", 10);
     return ret;
   }
+}  // namespace
+
+ConfigurableKalmanFitter::ConfigurableKalmanFitter() : AbstractConfFitter(KalmanVertexFitter()) {}
+
+void ConfigurableKalmanFitter::configure(const edm::ParameterSet& n) {
+  edm::ParameterSet m = n;
+  m.augment(mydefaults());
+  if (theFitter)
+    delete theFitter;
+  theFitter = new KalmanVertexFitter(m);
 }
 
-ConfigurableKalmanFitter::ConfigurableKalmanFitter() :
-    AbstractConfFitter ( KalmanVertexFitter()  )
-{}
-
-void ConfigurableKalmanFitter::configure(
-    const edm::ParameterSet & n )
-{
-  edm::ParameterSet m=n;
-  m.augment ( mydefaults() );
-  if (theFitter ) delete theFitter;
-  theFitter = new KalmanVertexFitter( m ) ;
-}
-
-ConfigurableKalmanFitter::~ConfigurableKalmanFitter()
-{
+ConfigurableKalmanFitter::~ConfigurableKalmanFitter() {
   // if (theFitter) delete theFitter;
 }
 
-ConfigurableKalmanFitter::ConfigurableKalmanFitter 
-    ( const ConfigurableKalmanFitter & o ) :
-  AbstractConfFitter ( o )
-{}
+ConfigurableKalmanFitter::ConfigurableKalmanFitter(const ConfigurableKalmanFitter& o) : AbstractConfFitter(o) {}
 
+ConfigurableKalmanFitter* ConfigurableKalmanFitter::clone() const { return new ConfigurableKalmanFitter(*this); }
 
-ConfigurableKalmanFitter * ConfigurableKalmanFitter::clone() const
-{
-  return new ConfigurableKalmanFitter ( *this );
-}
-
-edm::ParameterSet ConfigurableKalmanFitter::defaults() const
-{
-  return mydefaults();
-}
+edm::ParameterSet ConfigurableKalmanFitter::defaults() const { return mydefaults(); }
 
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfFitterBuilder.h"
 
 namespace {
-  const ConfFitterBuilder < ConfigurableKalmanFitter > t ( "kalman", "Standard Kalman Filter" );
-  const ConfFitterBuilder < ConfigurableKalmanFitter > s ( "default", "Standard Kalman Filter" );
-}
+  const ConfFitterBuilder<ConfigurableKalmanFitter> t("kalman", "Standard Kalman Filter");
+  const ConfFitterBuilder<ConfigurableKalmanFitter> s("default", "Standard Kalman Filter");
+}  // namespace

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableMultiVertexFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableMultiVertexFitter.cc
@@ -5,99 +5,77 @@
 #include "RecoVertex/MultiVertexFit/interface/MultiVertexBSeeder.h"
 
 namespace {
-  edm::ParameterSet mydefaults()
-  {
+  edm::ParameterSet mydefaults() {
     edm::ParameterSet ret;
-    ret.addParameter<double>("sigmacut",9.0);
-    ret.addParameter<double>("Tini",8.0);
-    ret.addParameter<double>("ratio",0.25);
-    ret.addParameter<int>("cheat",0);
+    ret.addParameter<double>("sigmacut", 9.0);
+    ret.addParameter<double>("Tini", 8.0);
+    ret.addParameter<double>("ratio", 0.25);
+    ret.addParameter<int>("cheat", 0);
     edm::ParameterSet nest;
-    nest.addParameter<std::string>("finder","mbs");
-    ret.addParameter<edm::ParameterSet>("ini",nest);
+    nest.addParameter<std::string>("finder", "mbs");
+    ret.addParameter<edm::ParameterSet>("ini", nest);
     return ret;
   }
 
-  const AnnealingSchedule * schedule ( const edm::ParameterSet & m )
-  {
+  const AnnealingSchedule* schedule(const edm::ParameterSet& m) {
     return new GeometricAnnealing(
-        m.getParameter<double>("sigmacut"), 
-        m.getParameter<double>("Tini"),
-        m.getParameter<double>("ratio") );
+        m.getParameter<double>("sigmacut"), m.getParameter<double>("Tini"), m.getParameter<double>("ratio"));
   }
-  
-  const VertexReconstructor * initialiser ( const edm::ParameterSet & p )
-  {
+
+  const VertexReconstructor* initialiser(const edm::ParameterSet& p) {
     // std::cout << "[ConfigurableMultiVertexFitter] ini: " << p << std::endl;
-    return new ConfigurableVertexReconstructor ( p );
-  } 
-}
+    return new ConfigurableVertexReconstructor(p);
+  }
+}  // namespace
 
-ConfigurableMultiVertexFitter::ConfigurableMultiVertexFitter() :
-  theRector ( new MultiVertexReconstructor( MultiVertexBSeeder() ) ),
-  theCheater(0)
-{}
+ConfigurableMultiVertexFitter::ConfigurableMultiVertexFitter()
+    : theRector(new MultiVertexReconstructor(MultiVertexBSeeder())), theCheater(0) {}
 
-void ConfigurableMultiVertexFitter::configure(
-    const edm::ParameterSet & n )
-{
-  edm::ParameterSet m=n;
-  m.augment ( mydefaults() );
+void ConfigurableMultiVertexFitter::configure(const edm::ParameterSet& n) {
+  edm::ParameterSet m = n;
+  m.augment(mydefaults());
   // print ( m );
-  const AnnealingSchedule * ann = schedule ( m );
-  const VertexReconstructor * ini = initialiser ( m.getParameter<edm::ParameterSet>("ini") );
-  if ( theRector ) delete theRector;
-  theRector = new MultiVertexReconstructor( *ini, *ann );
-  theCheater=m.getParameter<int>("cheat");
+  const AnnealingSchedule* ann = schedule(m);
+  const VertexReconstructor* ini = initialiser(m.getParameter<edm::ParameterSet>("ini"));
+  if (theRector)
+    delete theRector;
+  theRector = new MultiVertexReconstructor(*ini, *ann);
+  theCheater = m.getParameter<int>("cheat");
   delete ann;
   delete ini;
 }
 
-ConfigurableMultiVertexFitter::~ConfigurableMultiVertexFitter()
-{
-  if ( theRector ) delete theRector;
+ConfigurableMultiVertexFitter::~ConfigurableMultiVertexFitter() {
+  if (theRector)
+    delete theRector;
 }
 
-ConfigurableMultiVertexFitter::ConfigurableMultiVertexFitter 
-    ( const ConfigurableMultiVertexFitter & o ) :
-  theRector ( o.theRector->clone() ),
-  theCheater(o.theCheater)
-{}
+ConfigurableMultiVertexFitter::ConfigurableMultiVertexFitter(const ConfigurableMultiVertexFitter& o)
+    : theRector(o.theRector->clone()), theCheater(o.theCheater) {}
 
-
-ConfigurableMultiVertexFitter * ConfigurableMultiVertexFitter::clone() const
-{
-  return new ConfigurableMultiVertexFitter ( *this );
+ConfigurableMultiVertexFitter* ConfigurableMultiVertexFitter::clone() const {
+  return new ConfigurableMultiVertexFitter(*this);
 }
 
-std::vector < TransientVertex > ConfigurableMultiVertexFitter::vertices ( 
-    const std::vector < reco::TransientTrack > & t,
-    const reco::BeamSpot & s ) const
-{
-  return theRector->vertices ( t, s );
+std::vector<TransientVertex> ConfigurableMultiVertexFitter::vertices(const std::vector<reco::TransientTrack>& t,
+                                                                     const reco::BeamSpot& s) const {
+  return theRector->vertices(t, s);
 }
 
-std::vector < TransientVertex > ConfigurableMultiVertexFitter::vertices ( 
-    const std::vector < reco::TransientTrack > & prims,
-    const std::vector < reco::TransientTrack > & secs,
-    const reco::BeamSpot & s ) const
-{
-  return theRector->vertices ( prims, secs, s );
+std::vector<TransientVertex> ConfigurableMultiVertexFitter::vertices(const std::vector<reco::TransientTrack>& prims,
+                                                                     const std::vector<reco::TransientTrack>& secs,
+                                                                     const reco::BeamSpot& s) const {
+  return theRector->vertices(prims, secs, s);
 }
 
-std::vector < TransientVertex > ConfigurableMultiVertexFitter::vertices ( 
-    const std::vector < reco::TransientTrack > & t ) const
-{
-  return theRector->vertices ( t );
+std::vector<TransientVertex> ConfigurableMultiVertexFitter::vertices(const std::vector<reco::TransientTrack>& t) const {
+  return theRector->vertices(t);
 }
 
-edm::ParameterSet ConfigurableMultiVertexFitter::defaults() const
-{
-  return mydefaults();
-}
+edm::ParameterSet ConfigurableMultiVertexFitter::defaults() const { return mydefaults(); }
 
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h"
 
 namespace {
-  const ConfRecoBuilder < ConfigurableMultiVertexFitter > t ( "mvf", "Multi Vertex Fitter" );
+  const ConfRecoBuilder<ConfigurableMultiVertexFitter> t("mvf", "Multi Vertex Fitter");
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableTrimmedKalmanFinder.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableTrimmedKalmanFinder.cc
@@ -2,79 +2,63 @@
 #include "RecoVertex/TrimmedKalmanVertexFinder/interface/KalmanTrimmedVertexFinder.h"
 
 namespace {
-  edm::ParameterSet mydefaults ()
-  {
+  edm::ParameterSet mydefaults() {
     edm::ParameterSet ret;
-    ret.addParameter<double>("ptcut",0.);
-    ret.addParameter<double>("trkcutpv",0.05);
-    ret.addParameter<double>("trkcutsv",0.01);
-    ret.addParameter<double>("vtxcut",0.01);
+    ret.addParameter<double>("ptcut", 0.);
+    ret.addParameter<double>("trkcutpv", 0.05);
+    ret.addParameter<double>("trkcutsv", 0.01);
+    ret.addParameter<double>("vtxcut", 0.01);
     return ret;
   }
-}
+}  // namespace
 
-ConfigurableTrimmedKalmanFinder::ConfigurableTrimmedKalmanFinder() :
-    theRector( new KalmanTrimmedVertexFinder() )
-{}
+ConfigurableTrimmedKalmanFinder::ConfigurableTrimmedKalmanFinder() : theRector(new KalmanTrimmedVertexFinder()) {}
 
-void ConfigurableTrimmedKalmanFinder::configure(
-    const edm::ParameterSet & n )
-{
-  if ( theRector ) delete theRector;
-  edm::ParameterSet m=n;
-  m.augment ( mydefaults() );
-  KalmanTrimmedVertexFinder * tmp = new KalmanTrimmedVertexFinder();
-  tmp->setPtCut ( m.getParameter<double>("ptcut") );
-  tmp->setTrackCompatibilityCut ( m.getParameter<double>("trkcutpv") );
-  tmp->setTrackCompatibilityToSV ( m.getParameter<double>("trkcutsv") );
-  tmp->setVertexFitProbabilityCut ( m.getParameter<double>( "vtxcut" ) );
+void ConfigurableTrimmedKalmanFinder::configure(const edm::ParameterSet& n) {
+  if (theRector)
+    delete theRector;
+  edm::ParameterSet m = n;
+  m.augment(mydefaults());
+  KalmanTrimmedVertexFinder* tmp = new KalmanTrimmedVertexFinder();
+  tmp->setPtCut(m.getParameter<double>("ptcut"));
+  tmp->setTrackCompatibilityCut(m.getParameter<double>("trkcutpv"));
+  tmp->setTrackCompatibilityToSV(m.getParameter<double>("trkcutsv"));
+  tmp->setVertexFitProbabilityCut(m.getParameter<double>("vtxcut"));
   theRector = tmp;
 }
 
-ConfigurableTrimmedKalmanFinder::~ConfigurableTrimmedKalmanFinder()
-{
-  if ( theRector ) delete theRector;
+ConfigurableTrimmedKalmanFinder::~ConfigurableTrimmedKalmanFinder() {
+  if (theRector)
+    delete theRector;
 }
 
-ConfigurableTrimmedKalmanFinder::ConfigurableTrimmedKalmanFinder 
-    ( const ConfigurableTrimmedKalmanFinder & o ) :
-  theRector ( o.theRector->clone() )
-{}
+ConfigurableTrimmedKalmanFinder::ConfigurableTrimmedKalmanFinder(const ConfigurableTrimmedKalmanFinder& o)
+    : theRector(o.theRector->clone()) {}
 
-
-ConfigurableTrimmedKalmanFinder * ConfigurableTrimmedKalmanFinder::clone() const
-{
-  return new ConfigurableTrimmedKalmanFinder ( *this );
+ConfigurableTrimmedKalmanFinder* ConfigurableTrimmedKalmanFinder::clone() const {
+  return new ConfigurableTrimmedKalmanFinder(*this);
 }
 
-std::vector < TransientVertex > ConfigurableTrimmedKalmanFinder::vertices ( 
-    const std::vector < reco::TransientTrack > & t,
-    const reco::BeamSpot & s ) const
-{
-  return theRector->vertices ( t, s );
+std::vector<TransientVertex> ConfigurableTrimmedKalmanFinder::vertices(const std::vector<reco::TransientTrack>& t,
+                                                                       const reco::BeamSpot& s) const {
+  return theRector->vertices(t, s);
 }
 
-std::vector < TransientVertex > ConfigurableTrimmedKalmanFinder::vertices ( 
-    const std::vector < reco::TransientTrack > & prims,
-    const std::vector < reco::TransientTrack > & secs,
-    const reco::BeamSpot & s ) const
-{
-  return theRector->vertices ( prims, secs, s );
+std::vector<TransientVertex> ConfigurableTrimmedKalmanFinder::vertices(const std::vector<reco::TransientTrack>& prims,
+                                                                       const std::vector<reco::TransientTrack>& secs,
+                                                                       const reco::BeamSpot& s) const {
+  return theRector->vertices(prims, secs, s);
 }
 
-std::vector < TransientVertex > ConfigurableTrimmedKalmanFinder::vertices ( 
-    const std::vector < reco::TransientTrack > & t ) const
-{
-  return theRector->vertices ( t );
+std::vector<TransientVertex> ConfigurableTrimmedKalmanFinder::vertices(
+    const std::vector<reco::TransientTrack>& t) const {
+  return theRector->vertices(t);
 }
 
-edm::ParameterSet ConfigurableTrimmedKalmanFinder::defaults() const
-{
-  return mydefaults();
-}
+edm::ParameterSet ConfigurableTrimmedKalmanFinder::defaults() const { return mydefaults(); }
 
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfRecoBuilder.h"
 
 namespace {
-  const ConfRecoBuilder < ConfigurableTrimmedKalmanFinder > t ( "tkf", "Trimmed Kalman Vertex Finder" );
+  const ConfRecoBuilder<ConfigurableTrimmedKalmanFinder> t("tkf", "Trimmed Kalman Vertex Finder");
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexFitter.cc
@@ -4,93 +4,65 @@
 using namespace std;
 
 namespace {
-  void errorNoFitter( const string & finder )
-  {
-    cout << "[ConfigurableVertexFitter] got no fitter for \""
-         << finder << "\"" << endl;
-    std::vector<std::string> valid =
-      VertexFitterManager::Instance().getNames();
+  void errorNoFitter(const string& finder) {
+    cout << "[ConfigurableVertexFitter] got no fitter for \"" << finder << "\"" << endl;
+    std::vector<std::string> valid = VertexFitterManager::Instance().getNames();
     cout << "  Valid fitters are:";
-    for (const auto& i: valid)
-    {
+    for (const auto& i : valid) {
       cout << "  " << i;
     }
     cout << endl;
-    throw std::string ( finder + " not available!" );
+    throw std::string(finder + " not available!");
   }
-}
+}  // namespace
 
-ConfigurableVertexFitter::ConfigurableVertexFitter ( 
-    const edm::ParameterSet & p ) : theFitter ( nullptr )
-{
-  string fitter=p.getParameter<string>("fitter");
-  theFitter = VertexFitterManager::Instance().get ( fitter ).release();
-  if (!theFitter)
-  {
-    errorNoFitter ( fitter );
+ConfigurableVertexFitter::ConfigurableVertexFitter(const edm::ParameterSet& p) : theFitter(nullptr) {
+  string fitter = p.getParameter<string>("fitter");
+  theFitter = VertexFitterManager::Instance().get(fitter).release();
+  if (!theFitter) {
+    errorNoFitter(fitter);
   }
-  theFitter->configure ( p );
+  theFitter->configure(p);
 }
 
-ConfigurableVertexFitter::~ConfigurableVertexFitter()
-{
-  delete theFitter;
+ConfigurableVertexFitter::~ConfigurableVertexFitter() { delete theFitter; }
+
+ConfigurableVertexFitter::ConfigurableVertexFitter(const ConfigurableVertexFitter& o)
+    : theFitter(o.theFitter->clone()) {}
+
+ConfigurableVertexFitter* ConfigurableVertexFitter::clone() const { return new ConfigurableVertexFitter(*this); }
+
+CachingVertex<5> ConfigurableVertexFitter::vertex(const std::vector<reco::TransientTrack>& t) const {
+  return theFitter->vertex(t);
 }
 
-ConfigurableVertexFitter::ConfigurableVertexFitter 
-    ( const ConfigurableVertexFitter & o ) :
-  theFitter ( o.theFitter->clone() )
-{}
-
-
-ConfigurableVertexFitter * ConfigurableVertexFitter::clone() const
-{
-  return new ConfigurableVertexFitter ( *this );
+CachingVertex<5> ConfigurableVertexFitter::vertex(const vector<RefCountedVertexTrack>& tracks) const {
+  return theFitter->vertex(tracks);
 }
 
-
-CachingVertex<5> ConfigurableVertexFitter::vertex ( 
-    const std::vector < reco::TransientTrack > & t ) const
-{
-  return theFitter->vertex ( t );
+CachingVertex<5> ConfigurableVertexFitter::vertex(const vector<RefCountedVertexTrack>& tracks,
+                                                  const reco::BeamSpot& spot) const {
+  return theFitter->vertex(tracks, spot);
 }
 
-CachingVertex<5> ConfigurableVertexFitter::vertex(
-  const vector<RefCountedVertexTrack> & tracks) const
-{
-  return theFitter->vertex ( tracks );
+CachingVertex<5> ConfigurableVertexFitter::vertex(const vector<reco::TransientTrack>& tracks,
+                                                  const GlobalPoint& linPoint) const {
+  return theFitter->vertex(tracks, linPoint);
 }
 
-CachingVertex<5> ConfigurableVertexFitter::vertex(
-  const vector<RefCountedVertexTrack> & tracks,
-  const reco::BeamSpot & spot ) const
-{
-  return theFitter->vertex ( tracks, spot );
+CachingVertex<5> ConfigurableVertexFitter::vertex(const vector<reco::TransientTrack>& tracks,
+                                                  const GlobalPoint& priorPos,
+                                                  const GlobalError& priorError) const {
+  return theFitter->vertex(tracks, priorPos, priorError);
 }
 
-
-CachingVertex<5> ConfigurableVertexFitter::vertex(
-  const vector<reco::TransientTrack> & tracks, const GlobalPoint& linPoint) const
-{
-  return theFitter->vertex ( tracks, linPoint );
+CachingVertex<5> ConfigurableVertexFitter::vertex(const vector<reco::TransientTrack>& tracks,
+                                                  const reco::BeamSpot& beamSpot) const {
+  return theFitter->vertex(tracks, beamSpot);
 }
 
-CachingVertex<5> ConfigurableVertexFitter::vertex(
-  const vector<reco::TransientTrack> & tracks, const GlobalPoint& priorPos,
-  const GlobalError& priorError) const
-{
-  return theFitter->vertex ( tracks, priorPos, priorError );
+CachingVertex<5> ConfigurableVertexFitter::vertex(const vector<RefCountedVertexTrack>& tracks,
+                                                  const GlobalPoint& priorPos,
+                                                  const GlobalError& priorError) const {
+  return theFitter->vertex(tracks, priorPos, priorError);
 }
-
-CachingVertex<5> ConfigurableVertexFitter::vertex(
-  const vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const
-{
-  return theFitter->vertex ( tracks, beamSpot );
-}
-
-CachingVertex<5> ConfigurableVertexFitter::vertex(const vector<RefCountedVertexTrack> & tracks, 
-  const GlobalPoint& priorPos, const GlobalError& priorError) const
-{
-  return theFitter->vertex ( tracks, priorPos, priorError );
-}
-

--- a/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexReconstructor.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ConfigurableVertexReconstructor.cc
@@ -5,69 +5,49 @@
 using namespace std;
 
 namespace {
-  void errorNoReconstructor( const string & finder )
-  {
-    edm::LogError ( "ConfigurableVertexReconstructor") << "got no reconstructor for \""
-         << finder << "\"";
-    vector <string> valid = 
-      VertexRecoManager::Instance().getNames();
+  void errorNoReconstructor(const string& finder) {
+    edm::LogError("ConfigurableVertexReconstructor") << "got no reconstructor for \"" << finder << "\"";
+    vector<string> valid = VertexRecoManager::Instance().getNames();
     cout << "  Valid reconstructors are:";
-    for (const auto& i : valid)
-    {
-      cout <<" "<<i;
+    for (const auto& i : valid) {
+      cout << " " << i;
     }
     cout << endl;
-    throw std::string ( finder + " not available!" );
+    throw std::string(finder + " not available!");
   }
-}
+}  // namespace
 
-ConfigurableVertexReconstructor::ConfigurableVertexReconstructor ( 
-    const edm::ParameterSet & p ) : theRector ( nullptr )
-{
-  string finder=p.getParameter<string>("finder");
-  theRector = VertexRecoManager::Instance().get ( finder ).release();
-  if (!theRector)
-  {
-    errorNoReconstructor ( finder );
+ConfigurableVertexReconstructor::ConfigurableVertexReconstructor(const edm::ParameterSet& p) : theRector(nullptr) {
+  string finder = p.getParameter<string>("finder");
+  theRector = VertexRecoManager::Instance().get(finder).release();
+  if (!theRector) {
+    errorNoReconstructor(finder);
   }
-  theRector->configure ( p );
+  theRector->configure(p);
   // theRector = theRector->clone();
   // theRector = new ReconstructorFromFitter ( KalmanVertexFitter() );
 }
 
-ConfigurableVertexReconstructor::~ConfigurableVertexReconstructor()
-{
-  delete theRector;
+ConfigurableVertexReconstructor::~ConfigurableVertexReconstructor() { delete theRector; }
+
+ConfigurableVertexReconstructor::ConfigurableVertexReconstructor(const ConfigurableVertexReconstructor& o)
+    : theRector(o.theRector->clone()) {}
+
+ConfigurableVertexReconstructor* ConfigurableVertexReconstructor::clone() const {
+  return new ConfigurableVertexReconstructor(*this);
 }
 
-ConfigurableVertexReconstructor::ConfigurableVertexReconstructor 
-    ( const ConfigurableVertexReconstructor & o ) :
-  theRector ( o.theRector->clone() )
-{}
-
-
-ConfigurableVertexReconstructor * ConfigurableVertexReconstructor::clone() const
-{
-  return new ConfigurableVertexReconstructor ( *this );
+vector<TransientVertex> ConfigurableVertexReconstructor::vertices(const std::vector<reco::TransientTrack>& prims,
+                                                                  const std::vector<reco::TransientTrack>& secs,
+                                                                  const reco::BeamSpot& s) const {
+  return theRector->vertices(prims, secs, s);
 }
 
-vector < TransientVertex > ConfigurableVertexReconstructor::vertices ( 
-    const std::vector < reco::TransientTrack > & prims,
-    const std::vector < reco::TransientTrack > & secs,
-    const reco::BeamSpot & s ) const
-{
-  return theRector->vertices ( prims, secs, s );
+vector<TransientVertex> ConfigurableVertexReconstructor::vertices(const std::vector<reco::TransientTrack>& t,
+                                                                  const reco::BeamSpot& s) const {
+  return theRector->vertices(t, s);
 }
 
-vector < TransientVertex > ConfigurableVertexReconstructor::vertices ( 
-    const std::vector < reco::TransientTrack > & t,
-    const reco::BeamSpot & s ) const
-{
-  return theRector->vertices ( t, s );
-}
-
-vector < TransientVertex > ConfigurableVertexReconstructor::vertices ( 
-    const std::vector < reco::TransientTrack > & t ) const
-{
-  return theRector->vertices ( t );
+vector<TransientVertex> ConfigurableVertexReconstructor::vertices(const std::vector<reco::TransientTrack>& t) const {
+  return theRector->vertices(t);
 }

--- a/RecoVertex/ConfigurableVertexReco/src/ReconstructorFromFitter.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/ReconstructorFromFitter.cc
@@ -3,62 +3,47 @@
 
 using namespace std;
 
-ReconstructorFromFitter::ReconstructorFromFitter ( std::unique_ptr<AbstractConfFitter>&& f ) :
-  theFitter ( f.release() )
-{}
+ReconstructorFromFitter::ReconstructorFromFitter(std::unique_ptr<AbstractConfFitter>&& f) : theFitter(f.release()) {}
 
-vector < TransientVertex > ReconstructorFromFitter::vertices
-  ( const vector < reco::TransientTrack > & t )  const
-{
-  vector < TransientVertex > ret;
-  // cout << "[ReconstructorFromFitter] debug: fitting without bs!" << endl; 
+vector<TransientVertex> ReconstructorFromFitter::vertices(const vector<reco::TransientTrack>& t) const {
+  vector<TransientVertex> ret;
+  // cout << "[ReconstructorFromFitter] debug: fitting without bs!" << endl;
   try {
-    CachingVertex<5> tmp = theFitter->vertex ( t );
-    if ( tmp.isValid() ) ret.push_back ( tmp );
-  } catch ( VertexException & e ) {
+    CachingVertex<5> tmp = theFitter->vertex(t);
+    if (tmp.isValid())
+      ret.push_back(tmp);
+  } catch (VertexException& e) {
     edm::LogWarning("ReconstructorFromFitter") << "exception caught: " << e.what();
   }
   return ret;
 }
 
-vector < TransientVertex > ReconstructorFromFitter::vertices
-  ( const vector < reco::TransientTrack > & t, const reco::BeamSpot & s )  const
-{
-  vector < TransientVertex > ret;
+vector<TransientVertex> ReconstructorFromFitter::vertices(const vector<reco::TransientTrack>& t,
+                                                          const reco::BeamSpot& s) const {
+  vector<TransientVertex> ret;
   try {
     /*
     cout << "[ReconstructorFromFitter] debug: fitting with s: " << s.BeamWidth() 
          << " sz=" << s.sigmaZ() << endl;
          */
-    CachingVertex<5> tmp = theFitter->vertex ( t, s );
-    if ( tmp.isValid() ) ret.push_back ( tmp );
-  } catch ( VertexException & e ) {
+    CachingVertex<5> tmp = theFitter->vertex(t, s);
+    if (tmp.isValid())
+      ret.push_back(tmp);
+  } catch (VertexException& e) {
     edm::LogWarning("ReconstructorFromFitter") << "exception caught: " << e.what();
   }
   return ret;
 }
 
-ReconstructorFromFitter::~ReconstructorFromFitter()
-{
-  delete theFitter;
-}
+ReconstructorFromFitter::~ReconstructorFromFitter() { delete theFitter; }
 
-ReconstructorFromFitter::ReconstructorFromFitter ( const ReconstructorFromFitter & o ) :
-  theFitter ( o.theFitter->clone() )
-{}
+ReconstructorFromFitter::ReconstructorFromFitter(const ReconstructorFromFitter& o) : theFitter(o.theFitter->clone()) {}
 
-edm::ParameterSet ReconstructorFromFitter::defaults() const
-{
-  return theFitter->defaults();
-}
+edm::ParameterSet ReconstructorFromFitter::defaults() const { return theFitter->defaults(); }
 
-void ReconstructorFromFitter::configure ( const edm::ParameterSet & s )
-{
+void ReconstructorFromFitter::configure(const edm::ParameterSet& s) {
   //this looks better than changing the data member to be non-const ptr and allow changes in all calls
-  const_cast < AbstractConfFitter *> (theFitter)->configure (s );
+  const_cast<AbstractConfFitter*>(theFitter)->configure(s);
 }
 
-ReconstructorFromFitter * ReconstructorFromFitter::clone () const
-{
-  return new ReconstructorFromFitter ( *this );
-}
+ReconstructorFromFitter* ReconstructorFromFitter::clone() const { return new ReconstructorFromFitter(*this); }

--- a/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexFitterManager.cc
@@ -5,40 +5,33 @@
 
 using namespace std;
 
-void VertexFitterManager::registerFitter (
-      const string & name, std::function<AbstractConfFitter*()> o, const string & d )
-{
-  theAbstractConfFitters[name]=o;
-  theDescription[name]=d;
+void VertexFitterManager::registerFitter(const string& name, std::function<AbstractConfFitter*()> o, const string& d) {
+  theAbstractConfFitters[name] = o;
+  theDescription[name] = d;
 
   // every fitter registers as a reconstructor, also
-  VertexRecoManager::Instance().registerReconstructor ( name, [o]()->AbstractConfReconstructor* {
-      //ReconstructorFromFitter clones the object passed
-      std::unique_ptr<AbstractConfFitter> t{o()};
-      return new ReconstructorFromFitter ( std::move(t) );},
-    d);
+  VertexRecoManager::Instance().registerReconstructor(name,
+                                                      [o]() -> AbstractConfReconstructor* {
+                                                        //ReconstructorFromFitter clones the object passed
+                                                        std::unique_ptr<AbstractConfFitter> t{o()};
+                                                        return new ReconstructorFromFitter(std::move(t));
+                                                      },
+                                                      d);
 }
 
-VertexFitterManager::~VertexFitterManager()
-{
-}
+VertexFitterManager::~VertexFitterManager() {}
 
-std::string VertexFitterManager::describe ( const std::string & d ) const
-{
+std::string VertexFitterManager::describe(const std::string& d) const {
   auto found = theDescription.find(d);
-  if(found == theDescription.end()) {
+  if (found == theDescription.end()) {
     return std::string{};
   }
   return found->first;
 }
 
-VertexFitterManager * VertexFitterManager::clone() const
-{
-  return new VertexFitterManager ( * this );
-}
+VertexFitterManager* VertexFitterManager::clone() const { return new VertexFitterManager(*this); }
 
-VertexFitterManager::VertexFitterManager ( const VertexFitterManager & o ) 
-{
+VertexFitterManager::VertexFitterManager(const VertexFitterManager& o) {
   std::cout << "[VertexFitterManager] copy constructor! Error!" << std::endl;
   exit(0);
   /*
@@ -52,34 +45,30 @@ VertexFitterManager::VertexFitterManager ( const VertexFitterManager & o )
   */
 }
 
-VertexFitterManager & VertexFitterManager::Instance()
-{
+VertexFitterManager& VertexFitterManager::Instance() {
   //The singleton's internal structure only changes while
   // this library is being loaded. All other methods are const.
-  
+
   CMS_THREAD_SAFE static VertexFitterManager singleton;
   return singleton;
 }
 
-std::unique_ptr<AbstractConfFitter> VertexFitterManager::get ( const string & s ) const
-{
+std::unique_ptr<AbstractConfFitter> VertexFitterManager::get(const string& s) const {
   auto found = theAbstractConfFitters.find(s);
-  if(found == theAbstractConfFitters.end()) {
+  if (found == theAbstractConfFitters.end()) {
     return std::unique_ptr<AbstractConfFitter>{};
   }
   return std::unique_ptr<AbstractConfFitter>{found->second()};
 }
 
-std::vector<std::string> VertexFitterManager::getNames() const 
-{
+std::vector<std::string> VertexFitterManager::getNames() const {
   std::vector<std::string> ret;
   ret.reserve(theAbstractConfFitters.size());
 
-  for(const auto& i : theAbstractConfFitters) {
+  for (const auto& i : theAbstractConfFitters) {
     ret.push_back(i.first);
   }
   return ret;
 }
 
-VertexFitterManager::VertexFitterManager()
-{}
+VertexFitterManager::VertexFitterManager() {}

--- a/RecoVertex/ConfigurableVertexReco/src/VertexRecoManager.cc
+++ b/RecoVertex/ConfigurableVertexReco/src/VertexRecoManager.cc
@@ -3,33 +3,26 @@
 
 using namespace std;
 
-void VertexRecoManager::registerReconstructor (
-					       const string & name, std::function<AbstractConfReconstructor*()> o, const string & d )
-{
-  theAbstractConfReconstructors[name]=o;
-  theDescription[name]=d;
+void VertexRecoManager::registerReconstructor(const string& name,
+                                              std::function<AbstractConfReconstructor*()> o,
+                                              const string& d) {
+  theAbstractConfReconstructors[name] = o;
+  theDescription[name] = d;
 }
 
-VertexRecoManager::~VertexRecoManager()
-{
-}
+VertexRecoManager::~VertexRecoManager() {}
 
-std::string VertexRecoManager::describe ( const std::string & d ) const
-{
+std::string VertexRecoManager::describe(const std::string& d) const {
   auto found = theDescription.find(d);
-  if(found == theDescription.end()) {
+  if (found == theDescription.end()) {
     return std::string();
   }
   return found->second;
 }
 
-VertexRecoManager * VertexRecoManager::clone() const
-{
-  return new VertexRecoManager ( * this );
-}
+VertexRecoManager* VertexRecoManager::clone() const { return new VertexRecoManager(*this); }
 
-VertexRecoManager::VertexRecoManager ( const VertexRecoManager & o ) 
-{
+VertexRecoManager::VertexRecoManager(const VertexRecoManager& o) {
   std::cout << "[VertexRecoManager] copy constructor! Error!" << std::endl;
   exit(0);
   /*
@@ -43,32 +36,28 @@ VertexRecoManager::VertexRecoManager ( const VertexRecoManager & o )
   */
 }
 
-VertexRecoManager & VertexRecoManager::Instance()
-{
+VertexRecoManager& VertexRecoManager::Instance() {
   //The singleton's internal structure only changes while
   // this library is being loaded. All other methods are const.
   CMS_THREAD_SAFE static VertexRecoManager singleton;
   return singleton;
 }
 
-std::unique_ptr<AbstractConfReconstructor> VertexRecoManager::get ( const string & s ) const
-{
+std::unique_ptr<AbstractConfReconstructor> VertexRecoManager::get(const string& s) const {
   auto found = theAbstractConfReconstructors.find(s);
-  if( found == theAbstractConfReconstructors.end()) {
+  if (found == theAbstractConfReconstructors.end()) {
     return std::unique_ptr<AbstractConfReconstructor>{};
   }
   return std::unique_ptr<AbstractConfReconstructor>{found->second()};
 }
 
-std::vector<std::string> VertexRecoManager::getNames() const 
-{
+std::vector<std::string> VertexRecoManager::getNames() const {
   std::vector<std::string> ret;
   ret.reserve(theAbstractConfReconstructors.size());
-  for(const auto& i : theAbstractConfReconstructors ) {
+  for (const auto& i : theAbstractConfReconstructors) {
     ret.push_back(i.first);
   }
   return ret;
 }
 
-VertexRecoManager::VertexRecoManager()
-{}
+VertexRecoManager::VertexRecoManager() {}

--- a/RecoVertex/ConfigurableVertexReco/test/CVRTest.h
+++ b/RecoVertex/ConfigurableVertexReco/test/CVRTest.h
@@ -9,21 +9,20 @@ class CVRTest : public edm::EDAnalyzer {
   /**
    *  Class that glues the combined btagging algorithm to the framework
    */
-   public:
-      explicit CVRTest( const edm::ParameterSet & );
-      ~CVRTest();
+public:
+  explicit CVRTest(const edm::ParameterSet &);
+  ~CVRTest();
 
-      virtual void analyze( const edm::Event &, const edm::EventSetup &);
+  virtual void analyze(const edm::Event &, const edm::EventSetup &);
 
-   private:
-      void discussPrimary( const edm::Event & ) const;
+private:
+  void discussPrimary(const edm::Event &) const;
 
-   private:
-      ConfigurableVertexReconstructor * vrec_;
-      std::string trackcoll_;
-      std::string vertexcoll_;
-      std::string beamspot_;
-
+private:
+  ConfigurableVertexReconstructor *vrec_;
+  std::string trackcoll_;
+  std::string vertexcoll_;
+  std::string beamspot_;
 };
 
 #endif

--- a/RecoVertex/GaussianSumVertexFit/interface/AdaptiveGsfVertexFitter.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/AdaptiveGsfVertexFitter.h
@@ -12,20 +12,17 @@
  * constraint of the vertex position.
  */
 
-
 class AdaptiveGsfVertexFitter : public VertexFitter<5> {
-
 public:
-
   typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
 
   /** Default constructor, using the given linearization point finder.
    *  \param linP	The LinearizationPointFinder to use
    *  \param useSmoothing  Specifies whether the tracks sould be refit.
-   */ 
- 
+   */
+
   AdaptiveGsfVertexFitter(const edm::ParameterSet& pSet,
-	const LinearizationPointFinder & linP = DefaultLinearizationPointFinder());
+                          const LinearizationPointFinder& linP = DefaultLinearizationPointFinder());
 
   ~AdaptiveGsfVertexFitter() override;
 
@@ -33,37 +30,28 @@ public:
    * Copy constructor
    */
 
-  AdaptiveGsfVertexFitter(const AdaptiveGsfVertexFitter & original);
+  AdaptiveGsfVertexFitter(const AdaptiveGsfVertexFitter& original);
 
-  AdaptiveGsfVertexFitter * clone() const override {
-    return new AdaptiveGsfVertexFitter(* this);
-  }
+  AdaptiveGsfVertexFitter* clone() const override { return new AdaptiveGsfVertexFitter(*this); }
 
 public:
-
   /** Fit vertex out of a set of RecTracks
    */
-  inline CachingVertex<5> 
-    vertex(const std::vector<reco::TransientTrack>  & tracks) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks) const override {
     return theFitter->vertex(tracks);
   }
 
   /** Fit vertex out of a set of VertexTracks
    */
-  inline CachingVertex<5> 
-  vertex(const std::vector<RefCountedVertexTrack> & tracks) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks) const override {
     return theFitter->vertex(tracks);
   }
 
   /** Fit vertex out of a set of RecTracks. 
    *  Uses the specified linearization point.
    */
-  inline CachingVertex<5> 
-    vertex(const std::vector<reco::TransientTrack>  & tracks, 
-	   const GlobalPoint& linPoint) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
+                                 const GlobalPoint& linPoint) const override {
     return theFitter->vertex(tracks, linPoint);
   }
 
@@ -71,48 +59,39 @@ public:
    *  The specified BeamSpot will be used as priot, but NOT for the linearization.
    * The specified LinearizationPointFinder will be used to find the linearization point.
    */
-  inline CachingVertex<5> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
+                                 const reco::BeamSpot& beamSpot) const override {
     return theFitter->vertex(tracks, beamSpot);
   }
-
 
   /** Fit vertex out of a set of RecTracks. 
    *  Uses the specified point as both the linearization point AND as prior
    *  estimate of the vertex position. The error is used for the 
    *  weight of the prior estimate.
    */
-  inline CachingVertex<5> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, 
-	 const GlobalPoint& priorPos,
-  	 const GlobalError& priorError) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
+                                 const GlobalPoint& priorPos,
+                                 const GlobalError& priorError) const override {
     return theFitter->vertex(tracks, priorPos, priorError);
   }
 
-  inline CachingVertex<5> 
-  vertex(const std::vector<RefCountedVertexTrack> & tracks,
-      const reco::BeamSpot & spot ) const override
-  {
-    return theFitter->vertex(tracks, spot );
+  inline CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks,
+                                 const reco::BeamSpot& spot) const override {
+    return theFitter->vertex(tracks, spot);
   }
 
   /** Fit vertex out of a set of VertexTracks.
    *  Uses the specified point and error as the prior estimate of the vertex.
    *  This position is not used to relinearize the tracks.
    */
-  inline CachingVertex<5> 
-  vertex(const std::vector<RefCountedVertexTrack> & tracks, 
-	 const GlobalPoint& priorPos,
-	 const GlobalError& priorError) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks,
+                                 const GlobalPoint& priorPos,
+                                 const GlobalError& priorError) const override {
     return theFitter->vertex(tracks, priorPos, priorError);
   }
 
 private:
-  
-  AdaptiveVertexFitter  * theFitter;
+  AdaptiveVertexFitter* theFitter;
 };
 
 #endif

--- a/RecoVertex/GaussianSumVertexFit/interface/BasicMultiVertexState.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/BasicMultiVertexState.h
@@ -10,21 +10,16 @@
  */
 
 class BasicMultiVertexState final : public BasicVertexState {
-
 public:
-
   /** Constructors
    */
-  BasicMultiVertexState() : valid(false){}
+  BasicMultiVertexState() : valid(false) {}
 
   BasicMultiVertexState(const std::vector<VertexState>& vsComp);
 
   /** Access methods
    */
-  pointer clone() const override
-  {
-    return build<BasicMultiVertexState>(*this);
-  }
+  pointer clone() const override { return build<BasicMultiVertexState>(*this); }
 
   /**
    * Mean position of the mixture (position of the collapsed state)
@@ -85,19 +80,19 @@ public:
   /**
    * Vector of individual components in the mixture.
    */
-  std::vector<VertexState> components() const override {
-    return theComponents;
-  }
+  std::vector<VertexState> components() const override { return theComponents; }
 
   /**
    * The validity of the vertex
    */
-  bool isValid() const override {return valid;}
+  bool isValid() const override { return valid; }
 
-  bool is4D() const override { checkCombinedState(); return theCombinedState.is4D(); }
+  bool is4D() const override {
+    checkCombinedState();
+    return theCombinedState.is4D();
+  }
 
 private:
-
   void checkCombinedState() const;
 
   bool valid;
@@ -106,7 +101,6 @@ private:
   mutable bool theCombinedStateUp2Date;
 
   MultiVertexStateCombiner theCombiner;
-
 };
 
 #endif

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexFitter.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexFitter.h
@@ -17,20 +17,17 @@
  * constraint of the vertex position.
  */
 
-
 class GsfVertexFitter : public VertexFitter<5> {
-
 public:
-
   typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
 
   /** Default constructor, using the given linearization point finder.
    *  \param linP	The LinearizationPointFinder to use
    *  \param useSmoothing  Specifies whether the tracks sould be refit.
-   */ 
- 
+   */
+
   GsfVertexFitter(const edm::ParameterSet& pSet,
-	const LinearizationPointFinder & linP = DefaultLinearizationPointFinder());
+                  const LinearizationPointFinder& linP = DefaultLinearizationPointFinder());
 
   ~GsfVertexFitter() override;
 
@@ -38,37 +35,28 @@ public:
    * Copy constructor
    */
 
-  GsfVertexFitter(const GsfVertexFitter & original);
+  GsfVertexFitter(const GsfVertexFitter& original);
 
-  GsfVertexFitter * clone() const override {
-    return new GsfVertexFitter(* this);
-  }
+  GsfVertexFitter* clone() const override { return new GsfVertexFitter(*this); }
 
 public:
-
   /** Fit vertex out of a set of RecTracks
    */
-  inline CachingVertex<5> 
-    vertex(const std::vector<reco::TransientTrack>  & tracks) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks) const override {
     return theSequentialFitter->vertex(tracks);
   }
 
   /** Fit vertex out of a set of VertexTracks
    */
-  inline CachingVertex<5> 
-  vertex(const std::vector<RefCountedVertexTrack> & tracks) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks) const override {
     return theSequentialFitter->vertex(tracks);
   }
 
   /** Fit vertex out of a set of RecTracks. 
    *  Uses the specified linearization point.
    */
-  inline CachingVertex<5> 
-    vertex(const std::vector<reco::TransientTrack>  & tracks, 
-	   const GlobalPoint& linPoint) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
+                                 const GlobalPoint& linPoint) const override {
     return theSequentialFitter->vertex(tracks, linPoint);
   }
 
@@ -77,11 +65,9 @@ public:
    *  estimate of the vertex position. The error is used for the 
    *  weight of the prior estimate.
    */
-  inline CachingVertex<5> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, 
-	 const GlobalPoint& priorPos,
-  	 const GlobalError& priorError) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
+                                 const GlobalPoint& priorPos,
+                                 const GlobalError& priorError) const override {
     return theSequentialFitter->vertex(tracks, priorPos, priorError);
   }
 
@@ -89,34 +75,28 @@ public:
    *  The specified BeamSpot will be used as priot, but NOT for the linearization.
    * The specified LinearizationPointFinder will be used to find the linearization point.
    */
-  inline CachingVertex<5> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<reco::TransientTrack>& tracks,
+                                 const reco::BeamSpot& beamSpot) const override {
     return theSequentialFitter->vertex(tracks, beamSpot);
   }
 
-  inline CachingVertex<5> 
-  vertex(const std::vector<RefCountedVertexTrack> & tracks,
-      const reco::BeamSpot & spot ) const override
-  {
-    return theSequentialFitter->vertex(tracks, spot );
+  inline CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks,
+                                 const reco::BeamSpot& spot) const override {
+    return theSequentialFitter->vertex(tracks, spot);
   }
 
   /** Fit vertex out of a set of VertexTracks.
    *  Uses the specified point and error as the prior estimate of the vertex.
    *  This position is not used to relinearize the tracks.
    */
-  inline CachingVertex<5> 
-  vertex(const std::vector<RefCountedVertexTrack> & tracks, 
-	 const GlobalPoint& priorPos,
-	 const GlobalError& priorError) const override
-  {
+  inline CachingVertex<5> vertex(const std::vector<RefCountedVertexTrack>& tracks,
+                                 const GlobalPoint& priorPos,
+                                 const GlobalError& priorError) const override {
     return theSequentialFitter->vertex(tracks, priorPos, priorError);
   }
 
 private:
-  
-  SequentialVertexFitter<5> * theSequentialFitter;
+  SequentialVertexFitter<5>* theSequentialFitter;
 };
 
 #endif

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexMerger.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexMerger.h
@@ -14,20 +14,17 @@ class VertexState;
 
 class GsfVertexMerger {
 public:
-
   GsfVertexMerger(const edm::ParameterSet& pSet);
   ~GsfVertexMerger() {}
 
-  CachingVertex<5> merge(const CachingVertex<5> & vertex) const;
+  CachingVertex<5> merge(const CachingVertex<5>& vertex) const;
 
-  VertexState merge(const VertexState & vertex) const;
+  VertexState merge(const VertexState& vertex) const;
 
-  GsfVertexMerger * clone() const {
-    return new GsfVertexMerger(* this);
-  }
+  GsfVertexMerger* clone() const { return new GsfVertexMerger(*this); }
 
 private:
-  DeepCopyPointerByClone< MultiGaussianStateMerger<3> > merger;
+  DeepCopyPointerByClone<MultiGaussianStateMerger<3> > merger;
   unsigned int maxComponents;
 };
 

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexSmoother.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexSmoother.h
@@ -1,7 +1,6 @@
 #ifndef _GsfVertexSmoother_H_
 #define _GsfVertexSmoother_H_
 
-
 #include "RecoVertex/VertexPrimitives/interface/VertexSmoother.h"
 #include "RecoVertex/GaussianSumVertexFit/interface/GsfVertexUpdator.h"
 #include "RecoVertex/GaussianSumVertexFit/interface/GsfVertexMerger.h"
@@ -13,7 +12,6 @@
 #include "DataFormats/GeometryCommonDetAlgo/interface/DeepCopyPointerByClone.h"
 #include "RecoVertex/KalmanVertexFit/interface/KVFHelper.h"
 
-
 /**
  *  The class which handles the track-refit and smoothed chi**2 calculations
  *  for the Gaussian Sum vertex fit. 
@@ -21,16 +19,14 @@
  */
 
 class GsfVertexSmoother : public VertexSmoother<5> {
-
 public:
-
   /**
    *  The constructor
    *  \param limit Specifies whether the number of components of the vertex
    *			 should be limited
    */
 
-  GsfVertexSmoother(bool limit, const GsfVertexMerger * merger);
+  GsfVertexSmoother(bool limit, const GsfVertexMerger* merger);
 
   ~GsfVertexSmoother() override {}
 
@@ -41,25 +37,20 @@ public:
    *	last update.
    *  \return the final vertex estimate, with all the supplementary information
    */
-  CachingVertex<5> smooth(const CachingVertex<5> & vertex) const override;
+  CachingVertex<5> smooth(const CachingVertex<5>& vertex) const override;
 
   /**
    *  Access methods
    */
 
-  const VertexUpdator<5> * vertexUpdator() const
-  {return &theUpdator;}
+  const VertexUpdator<5>* vertexUpdator() const { return &theUpdator; }
 
   /**
    * Clone method 
    */
-  VertexSmoother<5> * clone() const override 
-  {
-    return new GsfVertexSmoother(* this);
-  }
-  
-private:
+  VertexSmoother<5>* clone() const override { return new GsfVertexSmoother(*this); }
 
+private:
   typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
   typedef VertexTrack<5>::RefCountedLinearizedTrackState RefCountedLinearizedTrackState;
   typedef VertexTrack<5>::RefCountedRefittedTrackState RefCountedRefittedTrackState;
@@ -73,18 +64,18 @@ private:
   typedef std::pair<RefCountedRefittedTrackState, VtxTrkChi2Pair> TrackChi2Pair;
   typedef std::pair<TrackWeightPair, VtxTrkChi2Pair> RefittedTrackComponent;
 
-  VertexState meanVertex(const VertexState & vertexA,
-			 const VertexState & vertexB) const;
+  VertexState meanVertex(const VertexState& vertexA, const VertexState& vertexB) const;
 
-  TrackChi2Pair vertexAndTrackUpdate(const VertexState & oldVertex,
-	const RefCountedVertexTrack track, const GlobalPoint & referencePosition) const;
+  TrackChi2Pair vertexAndTrackUpdate(const VertexState& oldVertex,
+                                     const RefCountedVertexTrack track,
+                                     const GlobalPoint& referencePosition) const;
 
-  RefittedTrackComponent createNewComponent(const VertexState & oldVertex,
-	 const RefCountedLinearizedTrackState linTrack, float weight) const;
+  RefittedTrackComponent createNewComponent(const VertexState& oldVertex,
+                                            const RefCountedLinearizedTrackState linTrack,
+                                            float weight) const;
 
-  TrackChi2Pair assembleTrackComponents(
-	const std::vector<RefittedTrackComponent> & trackComponents,
-	const GlobalPoint & referencePosition) const;
+  TrackChi2Pair assembleTrackComponents(const std::vector<RefittedTrackComponent>& trackComponents,
+                                        const GlobalPoint& referencePosition) const;
 
   /**
    *  Methode which calculates the chi**2 between the prior and the fitted 
@@ -93,15 +84,14 @@ private:
    *  \param priorVertex The prior vertex state
    *  \param fittedVertex The fitted vertex state
    */
-  double priorVertexChi2(const VertexState priorVertex, 
-	const VertexState fittedVertex) const;
+  double priorVertexChi2(const VertexState priorVertex, const VertexState fittedVertex) const;
 
   bool limitComponents;
   DeepCopyPointerByClone<GsfVertexMerger> theMerger;
   GsfVertexUpdator theUpdator;
   KalmanVertexUpdator<5> kalmanVertexUpdator;
   KalmanSmoothedVertexChi2Estimator<5> smoothedChi2Estimator;
-  KalmanVertexTrackUpdator<5> theVertexTrackUpdator;       
+  KalmanVertexTrackUpdator<5> theVertexTrackUpdator;
   GsfVertexWeightCalculator theWeightCalculator;
   VertexTrackFactory<5> theVTFactory;
   KVFHelper<5> helper;

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexTrackCompatibilityEstimator.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexTrackCompatibilityEstimator.h
@@ -1,7 +1,6 @@
 #ifndef GsfVertexTrackCompatibilityEstimator_H
 #define GsfVertexTrackCompatibilityEstimator_H
 
-
 #include "RecoVertex/VertexPrimitives/interface/VertexTrackCompatibilityEstimator.h"
 #include "RecoVertex/VertexPrimitives/interface/VertexTrack.h"
 #include "RecoVertex/VertexPrimitives/interface/CachingVertex.h"
@@ -12,7 +11,7 @@
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexTrackUpdator.h"
 #include "RecoVertex/KalmanVertexFit/interface/KVFHelper.h"
 
-  /**
+/**
    * Calculates the compatiblity of a track with respect to a vertex 
    * using the Kalman filter algorithms. 
    * The compatibility is computed from the squared standardized residuals 
@@ -22,16 +21,13 @@
    * Can be used to identify outlying tracks.
    */
 
-class GsfVertexTrackCompatibilityEstimator:public VertexTrackCompatibilityEstimator<5>
-{
-
+class GsfVertexTrackCompatibilityEstimator : public VertexTrackCompatibilityEstimator<5> {
 public:
-
   typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
 
-  GsfVertexTrackCompatibilityEstimator(){}
+  GsfVertexTrackCompatibilityEstimator() {}
 
-  ~GsfVertexTrackCompatibilityEstimator() override{}
+  ~GsfVertexTrackCompatibilityEstimator() override {}
 
   /**
    * Track-to-vertex compatibility. 
@@ -41,33 +37,29 @@ public:
    * \return The chi**2.
    */
 
-  BDpair estimate(const CachingVertex<5> & vrt, const RefCountedVertexTrack track,
-			  unsigned int hint=UINT_MAX) const override;
+  BDpair estimate(const CachingVertex<5>& vrt,
+                  const RefCountedVertexTrack track,
+                  unsigned int hint = UINT_MAX) const override;
 
-  BDpair estimate(const CachingVertex<5> & v, 
-			  const RefCountedLinearizedTrackState track,
-			  unsigned int hint=UINT_MAX) const override;
+  BDpair estimate(const CachingVertex<5>& v,
+                  const RefCountedLinearizedTrackState track,
+                  unsigned int hint = UINT_MAX) const override;
 
-  BDpair estimate(const reco::Vertex & vertex, 
-			 const reco::TransientTrack & track) const override;
+  BDpair estimate(const reco::Vertex& vertex, const reco::TransientTrack& track) const override;
 
-  GsfVertexTrackCompatibilityEstimator * clone() const override
-  {
-    return new GsfVertexTrackCompatibilityEstimator(* this);
+  GsfVertexTrackCompatibilityEstimator* clone() const override {
+    return new GsfVertexTrackCompatibilityEstimator(*this);
   }
 
-
 private:
-
-  BDpair estimateFittedTrack(const CachingVertex<5> & v, const RefCountedVertexTrack track) const;
-  BDpair estimateNFittedTrack(const CachingVertex<5> & v, const RefCountedVertexTrack track) const;  
+  BDpair estimateFittedTrack(const CachingVertex<5>& v, const RefCountedVertexTrack track) const;
+  BDpair estimateNFittedTrack(const CachingVertex<5>& v, const RefCountedVertexTrack track) const;
 
   GsfVertexUpdator updator;
-//   KalmanVertexTrackUpdator trackUpdator;
+  //   KalmanVertexTrackUpdator trackUpdator;
   MultiPerigeeLTSFactory lTrackFactory;
   VertexTrackFactory<5> vTrackFactory;
-//   KVFHelper helper;
-
+  //   KVFHelper helper;
 };
 
 #endif

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexUpdator.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexUpdator.h
@@ -11,53 +11,45 @@
  *  (c.f. Th.Speer & R. Fruewirth, Comp.Phys.Comm 174, 935 (2006) )
  */
 
-class GsfVertexUpdator: public VertexUpdator<5> {
-
+class GsfVertexUpdator : public VertexUpdator<5> {
 public:
-
   typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
   typedef VertexTrack<5>::RefCountedLinearizedTrackState RefCountedLinearizedTrackState;
 
-  GsfVertexUpdator(bool limit = false, const GsfVertexMerger * merger = nullptr);
-/**
+  GsfVertexUpdator(bool limit = false, const GsfVertexMerger* merger = nullptr);
+  /**
  *  Method to add a track to an existing CachingVertex
  *  An invalid vertex is returned in case of problems during the update.
  */
 
-   CachingVertex<5> add(const CachingVertex<5> & oldVertex,
-        const RefCountedVertexTrack track) const override;
+  CachingVertex<5> add(const CachingVertex<5>& oldVertex, const RefCountedVertexTrack track) const override;
 
-/**
+  /**
  *  Method removing already used VertexTrack from existing CachingVertex
  *  This method is not yet implemented.
  */
 
-   CachingVertex<5> remove(const CachingVertex<5> & oldVertex,
-        const RefCountedVertexTrack track) const override;
+  CachingVertex<5> remove(const CachingVertex<5>& oldVertex, const RefCountedVertexTrack track) const override;
 
-/**
+  /**
  * Clone method
  */
 
-   VertexUpdator<5> * clone() const override
-   {
-    return new GsfVertexUpdator(* this);
-   }
-
+  VertexUpdator<5>* clone() const override { return new GsfVertexUpdator(*this); }
 
 private:
-
   typedef std::vector<VertexState> VSC;
   typedef std::vector<RefCountedLinearizedTrackState> LTC;
   typedef std::pair<double, double> WeightChi2Pair;
   typedef std::pair<VertexState, WeightChi2Pair> VertexComponent;
   typedef std::pair<VertexState, double> VertexChi2Pair;
 
-  VertexComponent createNewComponent(const VertexState & oldVertex,
-	 const RefCountedLinearizedTrackState linTrack, float weight, int sign) const;
+  VertexComponent createNewComponent(const VertexState& oldVertex,
+                                     const RefCountedLinearizedTrackState linTrack,
+                                     float weight,
+                                     int sign) const;
 
-  VertexChi2Pair assembleVertexComponents(
-  	 const std::vector<VertexComponent> & newVertexComponents) const;
+  VertexChi2Pair assembleVertexComponents(const std::vector<VertexComponent>& newVertexComponents) const;
 
   bool limitComponents;
   DeepCopyPointerByClone<GsfVertexMerger> theMerger;

--- a/RecoVertex/GaussianSumVertexFit/interface/GsfVertexWeightCalculator.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/GsfVertexWeightCalculator.h
@@ -12,26 +12,22 @@
  */
 
 class GsfVertexWeightCalculator {
-
 public:
-
   typedef ReferenceCountingPointer<LinearizedTrackState<5> > RefCountedLinearizedTrackState;
 
-/**
+  /**
  *  Method to calculate the weight
  *  A negative weight is returned in case of error.
  *
  */
 
-   double calculate(const VertexState & oldVertex,
-        const RefCountedLinearizedTrackState track, double cov) const;
+  double calculate(const VertexState& oldVertex, const RefCountedLinearizedTrackState track, double cov) const;
 
 private:
   typedef LinearizedTrackState<5>::AlgebraicVectorN AlgebraicVectorN;
   typedef LinearizedTrackState<5>::AlgebraicMatrixN3 AlgebraicMatrixN3;
-  typedef LinearizedTrackState<5>::AlgebraicMatrixNM   AlgebraicMatrixNM;
+  typedef LinearizedTrackState<5>::AlgebraicMatrixNM AlgebraicMatrixNM;
   typedef LinearizedTrackState<5>::AlgebraicSymMatrixNN AlgebraicSymMatrixNN;
-
 };
 
 #endif

--- a/RecoVertex/GaussianSumVertexFit/interface/MultiPerigeeLTSFactory.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/MultiPerigeeLTSFactory.h
@@ -13,23 +13,20 @@
  *  not one state, but a Gaussian Mixture of state (see BasicMultiTrajectoryState).
  *  Should always be used in order to create a new RefCountedLinearizedTrackState, 
  *  so that the reference-counting mechanism works well. 
- */ 
+ */
 
-class MultiPerigeeLTSFactory : public AbstractLTSFactory<5>  {
-
+class MultiPerigeeLTSFactory : public AbstractLTSFactory<5> {
 public:
-
   typedef ReferenceCountingPointer<LinearizedTrackState<5> > RefCountedLinearizedTrackState;
 
-  RefCountedLinearizedTrackState
-    linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track) const override;
+  RefCountedLinearizedTrackState linearizedTrackState(const GlobalPoint& linP,
+                                                      const reco::TransientTrack& track) const override;
 
-  RefCountedLinearizedTrackState
-    linearizedTrackState(const GlobalPoint & linP, const reco::TransientTrack & track,
-    	const TrajectoryStateOnSurface& tsos) const override;
+  RefCountedLinearizedTrackState linearizedTrackState(const GlobalPoint& linP,
+                                                      const reco::TransientTrack& track,
+                                                      const TrajectoryStateOnSurface& tsos) const override;
 
-  const MultiPerigeeLTSFactory * clone() const override;
-
+  const MultiPerigeeLTSFactory* clone() const override;
 };
 
 #endif

--- a/RecoVertex/GaussianSumVertexFit/interface/MultiRefittedTS.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/MultiRefittedTS.h
@@ -15,9 +15,7 @@
 class Surface;
 
 class MultiRefittedTS : public RefittedTrackState<5> {
-
 public:
-
   typedef ReferenceCountingPointer<RefittedTrackState<5> > RefCountedRefittedTrackState;
   typedef ReferenceCountingPointer<LinearizedTrackState<5> > RefCountedLinearizedTrackState;
 
@@ -25,18 +23,16 @@ public:
    *   Constructor with a reference surface, to be used to assemble the 
    *   TSOS components on one identical surface.
    */
-  MultiRefittedTS(const std::vector<RefCountedRefittedTrackState> & prtsComp,
-	const Surface & referenceSurface);
+  MultiRefittedTS(const std::vector<RefCountedRefittedTrackState>& prtsComp, const Surface& referenceSurface);
 
   /**
    *   Constructor with a reference position. The surface which is going to be usedto assemble the 
    *   TSOS components will be the surface perpendicular to the PCA of the state with the highest weight
    *   to the reference point.
    */
-  MultiRefittedTS(const std::vector<RefCountedRefittedTrackState> & prtsComp,
-	const GlobalPoint & referencePosition);
+  MultiRefittedTS(const std::vector<RefCountedRefittedTrackState>& prtsComp, const GlobalPoint& referencePosition);
 
-  ~MultiRefittedTS() override{}
+  ~MultiRefittedTS() override {}
 
   /**
    * Returns a FreeTrajectoryState. It will be the FTS of the single, collapsed
@@ -48,15 +44,14 @@ public:
   /**
    * Returns a multi-state TSOS at a given surface
    */
-  TrajectoryStateOnSurface trajectoryStateOnSurface(
-  		const Surface & surface) const override;
+  TrajectoryStateOnSurface trajectoryStateOnSurface(const Surface& surface) const override;
 
   /**
    * Returns a multi-state TSOS at a given surface, with a given propagator
    */
 
-  TrajectoryStateOnSurface trajectoryStateOnSurface(
-		const Surface & surface, const Propagator & propagator) const override;
+  TrajectoryStateOnSurface trajectoryStateOnSurface(const Surface& surface,
+                                                    const Propagator& propagator) const override;
 
   /**
    *   Returns a new reco::Track, which can then be made persistent. The parameters are taken
@@ -70,14 +65,14 @@ public:
    * multi-state, throws an exception.
    */
 
-  AlgebraicVectorN  parameters() const override;
+  AlgebraicVectorN parameters() const override;
 
   /**
    * The covariance matrix. Not possible yet for a
    * multi-state, throws an exception.
    */
 
-  AlgebraicSymMatrixNN  covariance() const override;
+  AlgebraicSymMatrixNN covariance() const override;
 
   /**
    * Position at which the momentum is defined. Not possible yet for a
@@ -96,10 +91,7 @@ public:
 
   double weight() const override;
 
-  std::vector<ReferenceCountingPointer<RefittedTrackState<5> > > components() const override
-  {
-    return theComponents;
-  }
+  std::vector<ReferenceCountingPointer<RefittedTrackState<5> > > components() const override { return theComponents; }
 
   /**
    * This method is meant to returns a new refitted state of the same type, 
@@ -109,16 +101,12 @@ public:
    * The current state is unchanged.
    */
 
-  ReferenceCountingPointer<RefittedTrackState<5> > stateWithNewWeight
-  	(const double newWeight) const override;
-
+  ReferenceCountingPointer<RefittedTrackState<5> > stateWithNewWeight(const double newWeight) const override;
 
 private:
-
   void computeFreeTrajectoryState() const;
 
-
-  typedef std::vector<RefCountedRefittedTrackState > RTSvector;
+  typedef std::vector<RefCountedRefittedTrackState> RTSvector;
 
   mutable RTSvector theComponents;
   mutable bool totalWeightAvailable, ftsAvailable;
@@ -127,6 +115,5 @@ private:
   const GlobalPoint refPosition;
   ConstReferenceCountingPointer<Surface> refSurface;
   const bool surf;
-
 };
 #endif

--- a/RecoVertex/GaussianSumVertexFit/interface/MultiVertexStateCombiner.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/MultiVertexStateCombiner.h
@@ -5,20 +5,17 @@
 
 #include <vector>
 
-  /**
+/**
    * Class to collapse (combine) a Gaussian mixture of VertexStates
    * into one.
    * (c.f. R. Fruewirth et.al., Comp.Phys.Comm 100 (1997) 1
    */
 
 class MultiVertexStateCombiner {
-
 public:
-
   typedef std::vector<VertexState> VSC;
 
-  VertexState combine(const VSC & theMixture) const ;
-
+  VertexState combine(const VSC& theMixture) const;
 };
 
 #endif

--- a/RecoVertex/GaussianSumVertexFit/interface/PerigeeMultiLTS.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/PerigeeMultiLTS.h
@@ -12,10 +12,7 @@
  */
 
 class PerigeeMultiLTS : public LinearizedTrackState<5> {
-
-
 public:
-
   typedef ReferenceCountingPointer<LinearizedTrackState<5> > RefCountedLinearizedTrackState;
 
   /** Friend class properly dealing with creation
@@ -28,14 +25,12 @@ public:
    * A new object of the same type is returned, without change to the existing one.
    */
 
-   RefCountedLinearizedTrackState stateWithNewLinearizationPoint
-  	(const GlobalPoint & newLP) const override;
-
+  RefCountedLinearizedTrackState stateWithNewLinearizationPoint(const GlobalPoint& newLP) const override;
 
   /**
    * The point at which the track state has been linearized
    */
-  const GlobalPoint & linearizationPoint() const override { return theLinPoint; }
+  const GlobalPoint& linearizationPoint() const override { return theLinPoint; }
 
   reco::TransientTrack track() const override { return theTrack; }
 
@@ -48,28 +43,28 @@ public:
   /** Method returning the constant term of the Taylor expansion
    *  of the measurement equation for the collapsed track state
    */
-  const AlgebraicVectorN & constantTerm() const override;
+  const AlgebraicVectorN& constantTerm() const override;
 
   /** Method returning the Position Jacobian from the Taylor expansion
    *  (Matrix A) for the collapsed track state
    */
-  const AlgebraicMatrixN3 & positionJacobian() const override;
+  const AlgebraicMatrixN3& positionJacobian() const override;
 
   /** Method returning the Momentum Jacobian from the Taylor expansion
    *  (Matrix B) for the collapsed track state
    */
-  const AlgebraicMatrixNM & momentumJacobian() const override;
+  const AlgebraicMatrixNM& momentumJacobian() const override;
 
   /** Method returning the parameters of the Taylor expansion for
    *  the collapsed track state
    */
-  const AlgebraicVectorN & parametersFromExpansion() const override;
+  const AlgebraicVectorN& parametersFromExpansion() const override;
 
   /** Method returning the track state at the point of closest approach
    *  to the linearization point, in the transverse plane (a.k.a.
    *  transverse impact point),  for the collapsed track state
    */
-  const TrajectoryStateClosestToPoint & predictedState() const;
+  const TrajectoryStateClosestToPoint& predictedState() const;
 
   /** Method returning the parameters of the track state at the
    *  transverse impact point, for the collapsed track state
@@ -85,7 +80,7 @@ public:
    *  transverse impact point, for the collapsed track state
    * The error variable is 0 in case of success.
    */
-  AlgebraicSymMatrixNN predictedStateWeight(int & error) const override;
+  AlgebraicSymMatrixNN predictedStateWeight(int& error) const override;
 
   /** Method returning the covariance matrix of the track state at the
    *  transverse impact point, for the collapsed track state
@@ -97,48 +92,43 @@ public:
    */
   AlgebraicSymMatrixMM predictedStateMomentumError() const override;
 
-  TrackCharge charge() const override {return theCharge;}
+  TrackCharge charge() const override { return theCharge; }
 
   bool hasError() const override;
 
-  bool operator ==(LinearizedTrackState<5>& other)const override;
+  bool operator==(LinearizedTrackState<5>& other) const override;
 
   /** Creates the correct refitted state according to the results of the
    *  track refit.
    */
-  RefCountedRefittedTrackState createRefittedTrackState(
-  	const GlobalPoint & vertexPosition,
-	const AlgebraicVectorM & vectorParameters,
-	const AlgebraicSymMatrixOO & covarianceMatrix) const override;
+  RefCountedRefittedTrackState createRefittedTrackState(const GlobalPoint& vertexPosition,
+                                                        const AlgebraicVectorM& vectorParameters,
+                                                        const AlgebraicSymMatrixOO& covarianceMatrix) const override;
 
-  AlgebraicVector5 refittedParamFromEquation(
-	const RefCountedRefittedTrackState & theRefittedState) const override;
+  AlgebraicVector5 refittedParamFromEquation(const RefCountedRefittedTrackState& theRefittedState) const override;
 
-  void inline checkParameters(AlgebraicVector5 & parameters) const override;
+  void inline checkParameters(AlgebraicVector5& parameters) const override;
   /**
    * The weight of this state. It will be the sum of the weights of the
    * individual components in the mixture.
    */
 
-  double weightInMixture() const override {return theTSOS.weight();}
+  double weightInMixture() const override { return theTSOS.weight(); }
 
   /**
    * Vector of individual components in the mixture.
    */
 
-  std::vector<ReferenceCountingPointer<LinearizedTrackState<5> > > components()
-  				const override {return ltComp;}
+  std::vector<ReferenceCountingPointer<LinearizedTrackState<5> > > components() const override { return ltComp; }
 
 private:
-
   /** Constructor with the linearization point and the track.
    *  Private, can only be used by LinearizedTrackFactory.
    * \param linP	The linearization point
    * \param track	The RecTrack
    * \param tsos	The original (multi-state) TrajectoryStateOnSurface
    */
-   PerigeeMultiLTS(const GlobalPoint & linP, const reco::TransientTrack & track,
-  	const TrajectoryStateOnSurface& tsos);
+  PerigeeMultiLTS(const GlobalPoint& linP, const reco::TransientTrack& track, const TrajectoryStateOnSurface& tsos);
 
   /** Linearize the collapsed track state.
    */
@@ -146,7 +136,6 @@ private:
 
   GlobalPoint theLinPoint;
   reco::TransientTrack theTrack;
-
 
   const TrajectoryStateOnSurface theTSOS;
   std::vector<RefCountedLinearizedTrackState> ltComp;

--- a/RecoVertex/GaussianSumVertexFit/interface/VertexGaussianStateConversions.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/VertexGaussianStateConversions.h
@@ -4,8 +4,8 @@
 #include "TrackingTools/GsfTools/interface/MultiGaussianState.h"
 
 namespace GaussianStateConversions {
-  MultiGaussianState<3> multiGaussianStateFromVertex (const VertexState aState);
-  VertexState vertexFromMultiGaussianState (const MultiGaussianState<3>& multiState);
-}
+  MultiGaussianState<3> multiGaussianStateFromVertex(const VertexState aState);
+  VertexState vertexFromMultiGaussianState(const MultiGaussianState<3>& multiState);
+}  // namespace GaussianStateConversions
 
 #endif

--- a/RecoVertex/GaussianSumVertexFit/src/AdaptiveGsfVertexFitter.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/AdaptiveGsfVertexFitter.cc
@@ -5,12 +5,7 @@
 #include "RecoVertex/GaussianSumVertexFit/interface/GsfVertexTrackCompatibilityEstimator.h"
 #include "RecoVertex/VertexTools/interface/GeometricAnnealing.h"
 
-
-
-AdaptiveGsfVertexFitter::AdaptiveGsfVertexFitter(const edm::ParameterSet& pSet,
-	const LinearizationPointFinder & linP )
-{
-
+AdaptiveGsfVertexFitter::AdaptiveGsfVertexFitter(const edm::ParameterSet& pSet, const LinearizationPointFinder& linP) {
   bool limitComponents_ = pSet.getParameter<bool>("limitComponents");
 
   DeepCopyPointerByClone<GsfVertexMerger> theMerger;
@@ -19,13 +14,12 @@ AdaptiveGsfVertexFitter::AdaptiveGsfVertexFitter(const edm::ParameterSet& pSet,
     theMerger = new GsfVertexMerger(pSet.getParameter<edm::ParameterSet>("GsfMergerParameters"));
   }
 
-  theFitter = new AdaptiveVertexFitter(
-      GeometricAnnealing(),
-      linP,
-      GsfVertexUpdator(limitComponents_, &*theMerger),
-      GsfVertexTrackCompatibilityEstimator(),
-      GsfVertexSmoother(limitComponents_, &*theMerger),
-      MultiPerigeeLTSFactory() );
+  theFitter = new AdaptiveVertexFitter(GeometricAnnealing(),
+                                       linP,
+                                       GsfVertexUpdator(limitComponents_, &*theMerger),
+                                       GsfVertexTrackCompatibilityEstimator(),
+                                       GsfVertexSmoother(limitComponents_, &*theMerger),
+                                       MultiPerigeeLTSFactory());
   theFitter->gsfIntermediarySmoothing(true);
 
   /**
@@ -39,19 +33,14 @@ AdaptiveGsfVertexFitter::AdaptiveGsfVertexFitter(const edm::ParameterSet& pSet,
    *   for a track to be considered "significant".
    *   If fewer than two tracks are significant, an exception is thrown.
    */
-  theFitter->setParameters ( pSet.getParameter<double>("maxshift"),
-                    pSet.getParameter<double>("maxlpshift"),
-                    pSet.getParameter<int>("maxstep"),
-                    pSet.getParameter<double>("weightthreshold") );
-
+  theFitter->setParameters(pSet.getParameter<double>("maxshift"),
+                           pSet.getParameter<double>("maxlpshift"),
+                           pSet.getParameter<int>("maxstep"),
+                           pSet.getParameter<double>("weightthreshold"));
 }
 
-AdaptiveGsfVertexFitter::AdaptiveGsfVertexFitter(const AdaptiveGsfVertexFitter & original)
-{
+AdaptiveGsfVertexFitter::AdaptiveGsfVertexFitter(const AdaptiveGsfVertexFitter& original) {
   theFitter = original.theFitter->clone();
 }
 
-AdaptiveGsfVertexFitter::~AdaptiveGsfVertexFitter()
-{
-  delete theFitter;
-}
+AdaptiveGsfVertexFitter::~AdaptiveGsfVertexFitter() { delete theFitter; }

--- a/RecoVertex/GaussianSumVertexFit/src/BasicMultiVertexState.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/BasicMultiVertexState.cc
@@ -3,66 +3,53 @@
 
 using namespace std;
 
-BasicMultiVertexState::
-BasicMultiVertexState(const vector<VertexState>& vsComp) :
-  valid(true), theComponents(vsComp), theCombinedStateUp2Date( false) {}
+BasicMultiVertexState::BasicMultiVertexState(const vector<VertexState>& vsComp)
+    : valid(true), theComponents(vsComp), theCombinedStateUp2Date(false) {}
 
-
-GlobalPoint BasicMultiVertexState::position() const
-{
+GlobalPoint BasicMultiVertexState::position() const {
   checkCombinedState();
   return theCombinedState.position();
 }
 
-double BasicMultiVertexState::time() const
-{
+double BasicMultiVertexState::time() const {
   checkCombinedState();
   return theCombinedState.time();
 }
 
-
-GlobalError BasicMultiVertexState::error() const
-{
+GlobalError BasicMultiVertexState::error() const {
   checkCombinedState();
   return theCombinedState.error();
 }
 
-double BasicMultiVertexState::timeError() const
-{
+double BasicMultiVertexState::timeError() const {
   checkCombinedState();
   return theCombinedState.timeError();
 }
 
-GlobalError BasicMultiVertexState::error4D() const
-{
+GlobalError BasicMultiVertexState::error4D() const {
   checkCombinedState();
   return theCombinedState.error4D();
 }
 
-GlobalWeight BasicMultiVertexState::weight() const
-{
+GlobalWeight BasicMultiVertexState::weight() const {
   checkCombinedState();
   return theCombinedState.weight();
 }
 
-GlobalWeight BasicMultiVertexState::weight4D() const
-{
+GlobalWeight BasicMultiVertexState::weight4D() const {
   checkCombinedState();
   return theCombinedState.weight4D();
 }
 
-AlgebraicVector3 BasicMultiVertexState::weightTimesPosition() const
-{
+AlgebraicVector3 BasicMultiVertexState::weightTimesPosition() const {
   checkCombinedState();
   return theCombinedState.weightTimesPosition();
 }
 
-AlgebraicVector4 BasicMultiVertexState::weightTimesPosition4D() const
-{
+AlgebraicVector4 BasicMultiVertexState::weightTimesPosition4D() const {
   checkCombinedState();
   return theCombinedState.weightTimesPosition4D();
 }
-
 
 // RefCountedVertexSeed BasicMultiVertexState::seedWithoutTracks() const
 // {
@@ -71,7 +58,8 @@ AlgebraicVector4 BasicMultiVertexState::weightTimesPosition4D() const
 // }
 
 double BasicMultiVertexState::weightInMixture() const {
-  if (!valid) throw VertexException("BasicSingleVertexState::invalid");
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::invalid");
   if (theComponents.empty()) {
     cout << "Asking for weight of empty MultiVertexState, returning zero!" << endl;
     throw VertexException("Asking for weight of empty MultiVertexState, returning zero!");
@@ -79,19 +67,18 @@ double BasicMultiVertexState::weightInMixture() const {
   }
 
   double weight = 0.;
-  for (vector<VertexState>::const_iterator it = theComponents.begin(); 
-  	it != theComponents.end(); it++) {
+  for (vector<VertexState>::const_iterator it = theComponents.begin(); it != theComponents.end(); it++) {
     weight += it->weightInMixture();
   }
   return weight;
 }
 
-void BasicMultiVertexState::checkCombinedState() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::invalid");
-  if (theCombinedStateUp2Date) return;
+void BasicMultiVertexState::checkCombinedState() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::invalid");
+  if (theCombinedStateUp2Date)
+    return;
 
   theCombinedState = theCombiner.combine(theComponents);
   theCombinedStateUp2Date = true;
 }
-

--- a/RecoVertex/GaussianSumVertexFit/src/GsfVertexFitter.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/GsfVertexFitter.cc
@@ -3,17 +3,13 @@
 #include "RecoVertex/GaussianSumVertexFit/interface/GsfVertexSmoother.h"
 #include "RecoVertex/GaussianSumVertexFit/interface/MultiPerigeeLTSFactory.h"
 
-
-
-GsfVertexFitter::GsfVertexFitter(const edm::ParameterSet& pSet,
-	const LinearizationPointFinder & linP )
-{
-  float theMaxShift = pSet.getParameter<double>("maxDistance"); //0.01
-  int theMaxStep = pSet.getParameter<int>("maxNbrOfIterations"); //10
+GsfVertexFitter::GsfVertexFitter(const edm::ParameterSet& pSet, const LinearizationPointFinder& linP) {
+  float theMaxShift = pSet.getParameter<double>("maxDistance");   //0.01
+  int theMaxStep = pSet.getParameter<int>("maxNbrOfIterations");  //10
   bool limitComponents_ = pSet.getParameter<bool>("limitComponents");
   bool useSmoothing = pSet.getParameter<bool>("smoothTracks");
 
-  VertexSmoother<5> * theSmoother;
+  VertexSmoother<5>* theSmoother;
   DeepCopyPointerByClone<GsfVertexMerger> theMerger;
 
   if (limitComponents_) {
@@ -21,24 +17,21 @@ GsfVertexFitter::GsfVertexFitter(const edm::ParameterSet& pSet,
     theMerger = new GsfVertexMerger(mergerPSet);
   }
 
-  if (useSmoothing) theSmoother = new GsfVertexSmoother(limitComponents_, &*theMerger);
-    else theSmoother = new DummyVertexSmoother<5>();
+  if (useSmoothing)
+    theSmoother = new GsfVertexSmoother(limitComponents_, &*theMerger);
+  else
+    theSmoother = new DummyVertexSmoother<5>();
 
-  theSequentialFitter = new SequentialVertexFitter<5>(linP, 
-	GsfVertexUpdator(limitComponents_, &*theMerger),
-	*theSmoother, MultiPerigeeLTSFactory());
+  theSequentialFitter = new SequentialVertexFitter<5>(
+      linP, GsfVertexUpdator(limitComponents_, &*theMerger), *theSmoother, MultiPerigeeLTSFactory());
   theSequentialFitter->setMaximumDistance(theMaxShift);
   theSequentialFitter->setMaximumNumberOfIterations(theMaxStep);
 
   delete theSmoother;
- }
+}
 
-GsfVertexFitter::GsfVertexFitter(const GsfVertexFitter & original)
-{
+GsfVertexFitter::GsfVertexFitter(const GsfVertexFitter& original) {
   theSequentialFitter = original.theSequentialFitter->clone();
 }
 
-GsfVertexFitter::~GsfVertexFitter()
-{
-  delete theSequentialFitter;
-}
+GsfVertexFitter::~GsfVertexFitter() { delete theSequentialFitter; }

--- a/RecoVertex/GaussianSumVertexFit/src/GsfVertexMerger.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/GsfVertexMerger.cc
@@ -10,65 +10,63 @@
 
 #include "RecoVertex/GaussianSumVertexFit/interface/VertexGaussianStateConversions.h"
 
-GsfVertexMerger::GsfVertexMerger(const edm::ParameterSet& pSet)
-{
-
+GsfVertexMerger::GsfVertexMerger(const edm::ParameterSet& pSet) {
   maxComponents = pSet.getParameter<int>("maxNbrComponents");
   std::string mergerName = pSet.getParameter<std::string>("merger");
   std::string distanceName = pSet.getParameter<std::string>("distance");
 
-  if ( mergerName=="CloseComponentsMerger" ) {
+  if (mergerName == "CloseComponentsMerger") {
     DistanceBetweenComponents<3>* distance;
 
-    if ( distanceName=="KullbackLeiblerDistance" )
+    if (distanceName == "KullbackLeiblerDistance")
       distance = new KullbackLeiblerDistance<3>();
-//     else if ( distanceName=="MahalanobisDistance" )
-//       distance = new MahalanobisDistance();
-    else 
-      throw VertexException("GsfVertexMerger: Distance type "+distanceName+" unknown. Check distance parameter in GsfMergerParameters PSet");
-    
+    //     else if ( distanceName=="MahalanobisDistance" )
+    //       distance = new MahalanobisDistance();
+    else
+      throw VertexException("GsfVertexMerger: Distance type " + distanceName +
+                            " unknown. Check distance parameter in GsfMergerParameters PSet");
+
     merger = new CloseComponentsMerger<3>(maxComponents, distance);
     delete distance;
-  } 
-//   else if ( mergerName=="LargestWeightsStateMerger" )
-//     merger = new LargestWeightsStateMerger(maxComponents);
-  else 
-    throw VertexException("GsfVertexMerger: Merger type "+mergerName+" unknown. Check merger parameter in GsfMergerParameters PSet");
+  }
+  //   else if ( mergerName=="LargestWeightsStateMerger" )
+  //     merger = new LargestWeightsStateMerger(maxComponents);
+  else
+    throw VertexException("GsfVertexMerger: Merger type " + mergerName +
+                          " unknown. Check merger parameter in GsfMergerParameters PSet");
 
-//   else if ( mergerName=="KeepingNonZeroWeightsMerger" )
-//     merger = new KeepingNonZeroWeightsMerger();
+  //   else if ( mergerName=="KeepingNonZeroWeightsMerger" )
+  //     merger = new KeepingNonZeroWeightsMerger();
 
-//   std::string mergerName = "test";
-//   edm::ESHandle<MultiGaussianStateMerger> mergerProducer;
-//   iRecord.get(mergerName,mergerProducer);
-//   merger = (MultiGaussianStateMerger *) mergerProducer.product();
-
+  //   std::string mergerName = "test";
+  //   edm::ESHandle<MultiGaussianStateMerger> mergerProducer;
+  //   iRecord.get(mergerName,mergerProducer);
+  //   merger = (MultiGaussianStateMerger *) mergerProducer.product();
 }
 
-CachingVertex<5> GsfVertexMerger::merge(const CachingVertex<5> & oldVertex) const
-{
-  if (oldVertex.vertexState().components().size() <= maxComponents) 
-  	return oldVertex;
+CachingVertex<5> GsfVertexMerger::merge(const CachingVertex<5>& oldVertex) const {
+  if (oldVertex.vertexState().components().size() <= maxComponents)
+    return oldVertex;
 
   VertexState newVertexState = merge(oldVertex.vertexState());
 
-  if  (oldVertex.hasPrior()) {
-    return CachingVertex<5>(oldVertex.priorPosition(), oldVertex.priorError(),
-    		newVertexState.weightTimesPosition(), newVertexState.weight(),
-		oldVertex.tracks(), oldVertex.totalChiSquared());
+  if (oldVertex.hasPrior()) {
+    return CachingVertex<5>(oldVertex.priorPosition(),
+                            oldVertex.priorError(),
+                            newVertexState.weightTimesPosition(),
+                            newVertexState.weight(),
+                            oldVertex.tracks(),
+                            oldVertex.totalChiSquared());
   } else {
-    return CachingVertex<5>(newVertexState, oldVertex.tracks(), 
-    		oldVertex.totalChiSquared());
+    return CachingVertex<5>(newVertexState, oldVertex.tracks(), oldVertex.totalChiSquared());
   }
 }
 
-
-VertexState GsfVertexMerger::merge(const VertexState & oldVertex) const
-{
+VertexState GsfVertexMerger::merge(const VertexState& oldVertex) const {
   using namespace GaussianStateConversions;
 
-  if (oldVertex.components().size() <= maxComponents) 
-  	return oldVertex;
+  if (oldVertex.components().size() <= maxComponents)
+    return oldVertex;
 
   MultiGaussianState<3> multiGaussianState(multiGaussianStateFromVertex(oldVertex));
   MultiGaussianState<3> finalState(merger->merge(multiGaussianState));

--- a/RecoVertex/GaussianSumVertexFit/src/GsfVertexSmoother.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/GsfVertexSmoother.cc
@@ -3,32 +3,28 @@
 #include "RecoVertex/GaussianSumVertexFit/interface/MultiRefittedTS.h"
 #include "RecoVertex/VertexPrimitives/interface/VertexException.h"
 
-GsfVertexSmoother::GsfVertexSmoother(bool limit, const GsfVertexMerger * merger) :
-  limitComponents (limit)
-{
-  if (limitComponents) theMerger = merger->clone();
+GsfVertexSmoother::GsfVertexSmoother(bool limit, const GsfVertexMerger* merger) : limitComponents(limit) {
+  if (limitComponents)
+    theMerger = merger->clone();
 }
 
-CachingVertex<5>
-GsfVertexSmoother::smooth(const CachingVertex<5> & vertex) const
-{
-
+CachingVertex<5> GsfVertexSmoother::smooth(const CachingVertex<5>& vertex) const {
   std::vector<RefCountedVertexTrack> tracks = vertex.tracks();
   int numberOfTracks = tracks.size();
-  if (numberOfTracks<1) return vertex;
+  if (numberOfTracks < 1)
+    return vertex;
 
   // Initial vertex for ascending fit
   GlobalPoint priorVertexPosition = tracks[0]->linearizedTrack()->linearizationPoint();
   AlgebraicSymMatrix33 we = ROOT::Math::SMatrixIdentity();
-  GlobalError priorVertexError(we*10000);
+  GlobalError priorVertexError(we * 10000);
 
   std::vector<RefCountedVertexTrack> initialTracks;
-  CachingVertex<5> fitVertex(priorVertexPosition,priorVertexError,initialTracks,0);
+  CachingVertex<5> fitVertex(priorVertexPosition, priorVertexError, initialTracks, 0);
   //In case prior vertex was used.
   if (vertex.hasPrior()) {
     const VertexState& priorVertexState = vertex.priorVertexState();
-    fitVertex = CachingVertex<5>(priorVertexState, priorVertexState,
-    		initialTracks,0);
+    fitVertex = CachingVertex<5>(priorVertexState, priorVertexState, initialTracks, 0);
   }
 
   // vertices from ascending fit
@@ -37,17 +33,17 @@ GsfVertexSmoother::smooth(const CachingVertex<5> & vertex) const
   ascendingFittedVertices.push_back(fitVertex);
 
   // ascending fit
-  for (std::vector<RefCountedVertexTrack>::const_iterator i = tracks.begin();
-	  i != (tracks.end()-1); ++i) {
-    fitVertex = theUpdator.add(fitVertex,*i);
-    if (limitComponents) fitVertex = theMerger->merge(fitVertex);
+  for (std::vector<RefCountedVertexTrack>::const_iterator i = tracks.begin(); i != (tracks.end() - 1); ++i) {
+    fitVertex = theUpdator.add(fitVertex, *i);
+    if (limitComponents)
+      fitVertex = theMerger->merge(fitVertex);
     ascendingFittedVertices.push_back(fitVertex);
   }
 
   // Initial vertex for descending fit
   priorVertexPosition = tracks[0]->linearizedTrack()->linearizationPoint();
-  priorVertexError = GlobalError(we*10000);
-  fitVertex = CachingVertex<5>(priorVertexPosition,priorVertexError,initialTracks,0);
+  priorVertexError = GlobalError(we * 10000);
+  fitVertex = CachingVertex<5>(priorVertexPosition, priorVertexError, initialTracks, 0);
 
   // vertices from descending fit
   std::vector<CachingVertex<5> > descendingFittedVertices;
@@ -55,10 +51,10 @@ GsfVertexSmoother::smooth(const CachingVertex<5> & vertex) const
   descendingFittedVertices.push_back(fitVertex);
 
   // descending fit
-  for (std::vector<RefCountedVertexTrack>::const_iterator i = (tracks.end()-1);
-	  i != (tracks.begin()); --i) {
-    fitVertex = theUpdator.add(fitVertex,*i);
-    if (limitComponents) fitVertex = theMerger->merge(fitVertex);
+  for (std::vector<RefCountedVertexTrack>::const_iterator i = (tracks.end() - 1); i != (tracks.begin()); --i) {
+    fitVertex = theUpdator.add(fitVertex, *i);
+    if (limitComponents)
+      fitVertex = theMerger->merge(fitVertex);
     descendingFittedVertices.insert(descendingFittedVertices.begin(), fitVertex);
   }
 
@@ -66,61 +62,54 @@ GsfVertexSmoother::smooth(const CachingVertex<5> & vertex) const
   double smoothedChi2 = 0.;  // Smoothed chi2
 
   // Track refit
-  for(std::vector<RefCountedVertexTrack>::const_iterator i = tracks.begin();
-  	i != tracks.end();i++)
-  {
-    int indexNumber = i-tracks.begin();
+  for (std::vector<RefCountedVertexTrack>::const_iterator i = tracks.begin(); i != tracks.end(); i++) {
+    int indexNumber = i - tracks.begin();
     //First, combine the vertices:
-    VertexState meanedVertex = 
-         meanVertex(ascendingFittedVertices[indexNumber].vertexState(), 
-    		    descendingFittedVertices[indexNumber].vertexState());
-    if (limitComponents) meanedVertex = theMerger->merge(meanedVertex);
+    VertexState meanedVertex = meanVertex(ascendingFittedVertices[indexNumber].vertexState(),
+                                          descendingFittedVertices[indexNumber].vertexState());
+    if (limitComponents)
+      meanedVertex = theMerger->merge(meanedVertex);
     // Add the vertex and smooth the track:
     TrackChi2Pair thePair = vertexAndTrackUpdate(meanedVertex, *i, vertex.position());
     smoothedChi2 += thePair.second.second;
-    newTracks.push_back( theVTFactory.vertexTrack((**i).linearizedTrack(),
-  	vertex.vertexState(), thePair.first, thePair.second.second,
-	AlgebraicSymMatrixOO(), (**i).weight()) );
+    newTracks.push_back(theVTFactory.vertexTrack((**i).linearizedTrack(),
+                                                 vertex.vertexState(),
+                                                 thePair.first,
+                                                 thePair.second.second,
+                                                 AlgebraicSymMatrixOO(),
+                                                 (**i).weight()));
   }
 
-  if  (vertex.hasPrior()) {
+  if (vertex.hasPrior()) {
     smoothedChi2 += priorVertexChi2(vertex.priorVertexState(), vertex.vertexState());
-    return CachingVertex<5>(vertex.priorVertexState(), vertex.vertexState(),
-    		newTracks, smoothedChi2);
+    return CachingVertex<5>(vertex.priorVertexState(), vertex.vertexState(), newTracks, smoothedChi2);
   } else {
     return CachingVertex<5>(vertex.vertexState(), newTracks, smoothedChi2);
   }
 }
 
-GsfVertexSmoother::TrackChi2Pair 
-GsfVertexSmoother::vertexAndTrackUpdate(const VertexState & oldVertex,
-	const RefCountedVertexTrack track, const GlobalPoint & referencePosition) const
-{
-
+GsfVertexSmoother::TrackChi2Pair GsfVertexSmoother::vertexAndTrackUpdate(const VertexState& oldVertex,
+                                                                         const RefCountedVertexTrack track,
+                                                                         const GlobalPoint& referencePosition) const {
   VSC prevVtxComponents = oldVertex.components();
 
   if (prevVtxComponents.empty()) {
-  throw VertexException
-    ("GsfVertexSmoother::(Previous) Vertex to update has no components");
+    throw VertexException("GsfVertexSmoother::(Previous) Vertex to update has no components");
   }
 
   LTC ltComponents = track->linearizedTrack()->components();
   if (ltComponents.empty()) {
-  throw VertexException
-    ("GsfVertexSmoother::Track to add to vertex has no components");
+    throw VertexException("GsfVertexSmoother::Track to add to vertex has no components");
   }
   float trackWeight = track->weight();
 
   std::vector<RefittedTrackComponent> newTrackComponents;
-  newTrackComponents.reserve(prevVtxComponents.size()*ltComponents.size());
+  newTrackComponents.reserve(prevVtxComponents.size() * ltComponents.size());
 
-  for (VSC::iterator vertexCompIter = prevVtxComponents.begin();
-  	vertexCompIter != prevVtxComponents.end(); vertexCompIter++ ) {
-
-    for (LTC::iterator trackCompIter = ltComponents.begin();
-  	trackCompIter != ltComponents.end(); trackCompIter++ ) {
-      newTrackComponents.push_back
-        (createNewComponent(*vertexCompIter, *trackCompIter, trackWeight));
+  for (VSC::iterator vertexCompIter = prevVtxComponents.begin(); vertexCompIter != prevVtxComponents.end();
+       vertexCompIter++) {
+    for (LTC::iterator trackCompIter = ltComponents.begin(); trackCompIter != ltComponents.end(); trackCompIter++) {
+      newTrackComponents.push_back(createNewComponent(*vertexCompIter, *trackCompIter, trackWeight));
     }
   }
 
@@ -133,118 +122,94 @@ GsfVertexSmoother::vertexAndTrackUpdate(const VertexState & oldVertex,
  */
 
 GsfVertexSmoother::TrackChi2Pair GsfVertexSmoother::assembleTrackComponents(
-	const std::vector<GsfVertexSmoother::RefittedTrackComponent> & trackComponents,
-	const GlobalPoint & referencePosition)
-	const
-{
-
+    const std::vector<GsfVertexSmoother::RefittedTrackComponent>& trackComponents,
+    const GlobalPoint& referencePosition) const {
   //renormalize weights
 
   double totalWeight = 0.;
   double totalVtxChi2 = 0., totalTrkChi2 = 0.;
 
   for (std::vector<RefittedTrackComponent>::const_iterator iter = trackComponents.begin();
-    iter != trackComponents.end(); ++iter ) {
+       iter != trackComponents.end();
+       ++iter) {
     totalWeight += iter->first.second;
-    totalVtxChi2 += iter->second.first  * iter->first.second ;
-    totalTrkChi2 += iter->second.second * iter->first.second ;
+    totalVtxChi2 += iter->second.first * iter->first.second;
+    totalTrkChi2 += iter->second.second * iter->first.second;
   }
 
-  totalVtxChi2 /= totalWeight ;
-  totalTrkChi2 /= totalWeight ;
+  totalVtxChi2 /= totalWeight;
+  totalTrkChi2 /= totalWeight;
 
   std::vector<RefCountedRefittedTrackState> reWeightedRTSC;
   reWeightedRTSC.reserve(trackComponents.size());
-  
 
   for (std::vector<RefittedTrackComponent>::const_iterator iter = trackComponents.begin();
-    iter != trackComponents.end(); ++iter ) {
-    if (iter->second.first!=0) {
-      reWeightedRTSC.push_back(iter->first.first->stateWithNewWeight(iter->second.first/totalWeight));
+       iter != trackComponents.end();
+       ++iter) {
+    if (iter->second.first != 0) {
+      reWeightedRTSC.push_back(iter->first.first->stateWithNewWeight(iter->second.first / totalWeight));
     }
   }
 
-  RefCountedRefittedTrackState finalRTS = 
-    RefCountedRefittedTrackState(new MultiRefittedTS(reWeightedRTSC, referencePosition));
+  RefCountedRefittedTrackState finalRTS =
+      RefCountedRefittedTrackState(new MultiRefittedTS(reWeightedRTSC, referencePosition));
   return TrackChi2Pair(finalRTS, VtxTrkChi2Pair(totalVtxChi2, totalTrkChi2));
 }
 
-
-  /**
+/**
    * This method does the smoothing of one track component with one vertex component.
    * And the track-component-chi2 increment and weight of new component in mixture.
    */
 
-GsfVertexSmoother::RefittedTrackComponent 
-GsfVertexSmoother::createNewComponent(const VertexState & oldVertex,
-	 const RefCountedLinearizedTrackState linTrack, float trackWeight) const
-{
-
-  int sign =+1;
+GsfVertexSmoother::RefittedTrackComponent GsfVertexSmoother::createNewComponent(
+    const VertexState& oldVertex, const RefCountedLinearizedTrackState linTrack, float trackWeight) const {
+  int sign = +1;
 
   // Weight of the component in the mixture (non-normalized)
   double weightInMixture = theWeightCalculator.calculate(oldVertex, linTrack, 1000000000.);
 
   // position estimate of the component
-  VertexState newVertex = kalmanVertexUpdator.positionUpdate(oldVertex,
-	linTrack, trackWeight, sign);
+  VertexState newVertex = kalmanVertexUpdator.positionUpdate(oldVertex, linTrack, trackWeight, sign);
 
-  KalmanVertexTrackUpdator<5>::trackMatrixPair thePair = 
-  	theVertexTrackUpdator.trackRefit(newVertex, linTrack, trackWeight);
+  KalmanVertexTrackUpdator<5>::trackMatrixPair thePair =
+      theVertexTrackUpdator.trackRefit(newVertex, linTrack, trackWeight);
 
   //Chi**2 contribution of the track component
   double vtxChi2 = helper.vertexChi2(oldVertex, newVertex);
   std::pair<bool, double> trkCi2 = helper.trackParameterChi2(linTrack, thePair.first);
 
-  return RefittedTrackComponent(TrackWeightPair(thePair.first, weightInMixture), 
-  			VtxTrkChi2Pair(vtxChi2, trkCi2.second));
+  return RefittedTrackComponent(TrackWeightPair(thePair.first, weightInMixture),
+                                VtxTrkChi2Pair(vtxChi2, trkCi2.second));
 }
 
-
-VertexState
-GsfVertexSmoother::meanVertex(const VertexState & vertexA,
-			      const VertexState & vertexB) const
-{
+VertexState GsfVertexSmoother::meanVertex(const VertexState& vertexA, const VertexState& vertexB) const {
   std::vector<VertexState> vsCompA = vertexA.components();
   std::vector<VertexState> vsCompB = vertexB.components();
   std::vector<VertexState> finalVS;
-  finalVS.reserve(vsCompA.size()*vsCompB.size());
-  for (std::vector<VertexState>::iterator iA = vsCompA.begin(); iA!= vsCompA.end(); ++iA)
-  {
-    for (std::vector<VertexState>::iterator iB = vsCompB.begin(); iB!= vsCompB.end(); ++iB)
-    {
-      AlgebraicSymMatrix33 newWeight = iA->weight().matrix() +
-				     iB->weight().matrix();
-      AlgebraicVector3 newWtP = iA->weightTimesPosition() +
-      			       iB->weightTimesPosition();
-      double newWeightInMixture = iA->weightInMixture() *
-				  iB->weightInMixture();
-      finalVS.push_back( VertexState(newWtP, newWeight, newWeightInMixture) );
+  finalVS.reserve(vsCompA.size() * vsCompB.size());
+  for (std::vector<VertexState>::iterator iA = vsCompA.begin(); iA != vsCompA.end(); ++iA) {
+    for (std::vector<VertexState>::iterator iB = vsCompB.begin(); iB != vsCompB.end(); ++iB) {
+      AlgebraicSymMatrix33 newWeight = iA->weight().matrix() + iB->weight().matrix();
+      AlgebraicVector3 newWtP = iA->weightTimesPosition() + iB->weightTimesPosition();
+      double newWeightInMixture = iA->weightInMixture() * iB->weightInMixture();
+      finalVS.push_back(VertexState(newWtP, newWeight, newWeightInMixture));
     }
   }
-  #ifndef CMS_NO_COMPLEX_RETURNS
-    return VertexState(new BasicMultiVertexState(finalVS));
-  #else
-    VertexState theFinalVM(new BasicMultiVertexState(finalVS));
-    return theFinalVM;
-  #endif
+#ifndef CMS_NO_COMPLEX_RETURNS
+  return VertexState(new BasicMultiVertexState(finalVS));
+#else
+  VertexState theFinalVM(new BasicMultiVertexState(finalVS));
+  return theFinalVM;
+#endif
 }
 
-
-double GsfVertexSmoother::priorVertexChi2(
-	const VertexState priorVertex, const VertexState fittedVertex) const
-{
-  std::vector<VertexState> priorVertexComp  = priorVertex.components();
+double GsfVertexSmoother::priorVertexChi2(const VertexState priorVertex, const VertexState fittedVertex) const {
+  std::vector<VertexState> priorVertexComp = priorVertex.components();
   std::vector<VertexState> fittedVertexComp = fittedVertex.components();
   double vetexChi2 = 0.;
-  for (std::vector<VertexState>::iterator pvI = priorVertexComp.begin(); 
-  	pvI!= priorVertexComp.end(); ++pvI)
-  {
-    for (std::vector<VertexState>::iterator fvI = fittedVertexComp.begin(); 
-    	fvI!= fittedVertexComp.end(); ++fvI)
-    {
-      vetexChi2 += (pvI->weightInMixture())*(fvI->weightInMixture())*
-      			helper.vertexChi2(*pvI, *fvI);
+  for (std::vector<VertexState>::iterator pvI = priorVertexComp.begin(); pvI != priorVertexComp.end(); ++pvI) {
+    for (std::vector<VertexState>::iterator fvI = fittedVertexComp.begin(); fvI != fittedVertexComp.end(); ++fvI) {
+      vetexChi2 += (pvI->weightInMixture()) * (fvI->weightInMixture()) * helper.vertexChi2(*pvI, *fvI);
     }
   }
   return vetexChi2;

--- a/RecoVertex/GaussianSumVertexFit/src/GsfVertexTrackCompatibilityEstimator.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/GsfVertexTrackCompatibilityEstimator.cc
@@ -9,100 +9,81 @@ using namespace reco;
 //   typedef typename CachingVertex<N>::RefCountedVertexTrack RefCountedVertexTrack;
 //   bool operator()(const CachingVertex<5> & v, const RefCountedVertexTrack t)
 //   {
-// //initial tracks  
+// //initial tracks
 //     vector<RefCountedVertexTrack> tracks = v.tracks();
-//     vector<RefCountedVertexTrack>::iterator pos 
+//     vector<RefCountedVertexTrack>::iterator pos
 //       = find_if(tracks.begin(), tracks.end(), VertexTrackEqual(t));
 //     return (pos != tracks.end());
 //   }
-// }; 
- 
- 
-std::pair<bool, double> 
-GsfVertexTrackCompatibilityEstimator::estimate(const CachingVertex<5> & vertex,
-					       const RefCountedVertexTrack tr, unsigned int hint) const
-{
-//checking if the track passed really belongs to the vertex
+// };
+
+std::pair<bool, double> GsfVertexTrackCompatibilityEstimator::estimate(const CachingVertex<5>& vertex,
+                                                                       const RefCountedVertexTrack tr,
+                                                                       unsigned int hint) const {
+  //checking if the track passed really belongs to the vertex
   std::vector<RefCountedVertexTrack> tracks = vertex.tracks();
-  std::vector<RefCountedVertexTrack>::iterator pos 
-    = find_if(tracks.begin(), tracks.end(), VertexTrackEqual<5>(tr));
- if (pos != tracks.end()) {
-   return estimateFittedTrack(vertex,*pos);
- } else {
-   return estimateNFittedTrack(vertex,tr);
- }
-} 
+  std::vector<RefCountedVertexTrack>::iterator pos = find_if(tracks.begin(), tracks.end(), VertexTrackEqual<5>(tr));
+  if (pos != tracks.end()) {
+    return estimateFittedTrack(vertex, *pos);
+  } else {
+    return estimateNFittedTrack(vertex, tr);
+  }
+}
 
-
-std::pair<bool, double>
-GsfVertexTrackCompatibilityEstimator::estimate(const CachingVertex<5> & vertex, 
-					       const RefCountedLinearizedTrackState track,
-					       unsigned int hint) const
-{
-  RefCountedVertexTrack vertexTrack = vTrackFactory.vertexTrack(track,
- 						 vertex.vertexState());
+std::pair<bool, double> GsfVertexTrackCompatibilityEstimator::estimate(const CachingVertex<5>& vertex,
+                                                                       const RefCountedLinearizedTrackState track,
+                                                                       unsigned int hint) const {
+  RefCountedVertexTrack vertexTrack = vTrackFactory.vertexTrack(track, vertex.vertexState());
   return estimate(vertex, vertexTrack);
 }
 
+std::pair<bool, double> GsfVertexTrackCompatibilityEstimator::estimate(const reco::Vertex& vertex,
+                                                                       const reco::TransientTrack& track) const {
+  //   GlobalPoint linP(vertex.position().x(), vertex.position().z(),vertex.position().z());
+  GlobalPoint linP(Basic3DVector<float>(vertex.position()));
 
-std::pair<bool, double>
-GsfVertexTrackCompatibilityEstimator::estimate(const reco::Vertex & vertex, 
-			 const reco::TransientTrack & track) const
-{ 	
-//   GlobalPoint linP(vertex.position().x(), vertex.position().z(),vertex.position().z());
-    GlobalPoint linP(Basic3DVector<float> (vertex.position()));
-
-  RefCountedLinearizedTrackState linTrack = 
-  			lTrackFactory.linearizedTrackState(linP, track);
+  RefCountedLinearizedTrackState linTrack = lTrackFactory.linearizedTrackState(linP, track);
   GlobalError err(vertex.covariance());
   VertexState vState(linP, err);
   RefCountedVertexTrack vertexTrack = vTrackFactory.vertexTrack(linTrack, vState);
 
   std::vector<RefCountedVertexTrack> initialTracks(1, vertexTrack);
-  CachingVertex<5> cachingVertex(linP, err, initialTracks,
-  			    vertex.chi2());
+  CachingVertex<5> cachingVertex(linP, err, initialTracks, vertex.chi2());
   // FIXME: this should work also for tracks without a persistent ref.
-//   const TrackTransientTrack* ttt = dynamic_cast<const TrackTransientTrack*>(track.basicTransientTrack());
-//   if ((ttt!=0) && 
-  if (find(vertex.tracks_begin(), vertex.tracks_end(), track.trackBaseRef()) != vertex.tracks_end())
-  {
+  //   const TrackTransientTrack* ttt = dynamic_cast<const TrackTransientTrack*>(track.basicTransientTrack());
+  //   if ((ttt!=0) &&
+  if (find(vertex.tracks_begin(), vertex.tracks_end(), track.trackBaseRef()) != vertex.tracks_end()) {
     return estimateFittedTrack(cachingVertex, vertexTrack);
   } else {
     return estimateNFittedTrack(cachingVertex, vertexTrack);
   }
 }
 
-
-
 // methods to calculate track<-->vertex compatibility
 // with the track belonging to the vertex
 
-std::pair<bool, double> 
-GsfVertexTrackCompatibilityEstimator::estimateFittedTrack
-		(const CachingVertex<5> & v, const RefCountedVertexTrack track) const
-{
+std::pair<bool, double> GsfVertexTrackCompatibilityEstimator::estimateFittedTrack(
+    const CachingVertex<5>& v, const RefCountedVertexTrack track) const {
   //remove track from the vertex using the vertex updator
   // Using the update instead of the remove methode, we can specify a weight which
   // is different than then one which the vertex track has been defined with.
-  if (track->refittedStateAvailable()) return BDpair(true, track->smoothedChi2());
-  throw VertexException
-    ("GsfVertexTrackCompatibilityEstimator::vertex has to be smoothed.");
+  if (track->refittedStateAvailable())
+    return BDpair(true, track->smoothedChi2());
+  throw VertexException("GsfVertexTrackCompatibilityEstimator::vertex has to be smoothed.");
 
-//   CachingVertex rVert = updator.remove(v, track);
-//   RefCountedVertexTrack newSmoothedTrack = trackUpdator.update(v, track);
-//   return estimateDifference(v,rVert,newSmoothedTrack);
+  //   CachingVertex rVert = updator.remove(v, track);
+  //   RefCountedVertexTrack newSmoothedTrack = trackUpdator.update(v, track);
+  //   return estimateDifference(v,rVert,newSmoothedTrack);
 }
 
 // method calculating track<-->vertex compatibility
 //with the track not belonging to vertex
-std::pair<bool, double>
-GsfVertexTrackCompatibilityEstimator::estimateNFittedTrack
- 	(const CachingVertex<5> & v, const RefCountedVertexTrack track) const
-{
+std::pair<bool, double> GsfVertexTrackCompatibilityEstimator::estimateNFittedTrack(
+    const CachingVertex<5>& v, const RefCountedVertexTrack track) const {
   // Using the update instead of the add methode, we can specify a weight which
   // is different than then one which the vertex track has been defined with.
   CachingVertex<5> rVert = updator.add(v, track);
-  if (!rVert.isValid()) return BDpair(false,-1.);
-  return BDpair(true, rVert.totalChiSquared()-v.totalChiSquared());
-}   
-
+  if (!rVert.isValid())
+    return BDpair(false, -1.);
+  return BDpair(true, rVert.totalChiSquared() - v.totalChiSquared());
+}

--- a/RecoVertex/GaussianSumVertexFit/src/GsfVertexUpdator.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/GsfVertexUpdator.cc
@@ -3,173 +3,159 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <cfloat>
 
-GsfVertexUpdator::GsfVertexUpdator(bool limit, const GsfVertexMerger * merger) :
-  limitComponents (limit)
-{
-  if (limitComponents) theMerger = merger->clone();
+GsfVertexUpdator::GsfVertexUpdator(bool limit, const GsfVertexMerger* merger) : limitComponents(limit) {
+  if (limitComponents)
+    theMerger = merger->clone();
 }
 
-
-CachingVertex<5> GsfVertexUpdator::add(const CachingVertex<5> & oldVertex,
-				    const RefCountedVertexTrack track) const
-{
-
+CachingVertex<5> GsfVertexUpdator::add(const CachingVertex<5>& oldVertex, const RefCountedVertexTrack track) const {
   VSC prevVtxComponents = oldVertex.vertexState().components();
 
-//   cout << "GsfVertexUpdator::Add new Track with "
-//       << track->linearizedTrack()->components().size() << " components to vertex of "
-//       << prevVtxComponents.size() << " components.\n";
+  //   cout << "GsfVertexUpdator::Add new Track with "
+  //       << track->linearizedTrack()->components().size() << " components to vertex of "
+  //       << prevVtxComponents.size() << " components.\n";
 
   if (prevVtxComponents.empty()) {
-  throw VertexException
-    ("GsfVertexUpdator::(Previous) Vertex to update has no components");
+    throw VertexException("GsfVertexUpdator::(Previous) Vertex to update has no components");
   }
 
   LTC ltComponents = track->linearizedTrack()->components();
   if (ltComponents.empty()) {
-  throw VertexException
-    ("GsfVertexUpdator::Track to add to vertex has no components");
+    throw VertexException("GsfVertexUpdator::Track to add to vertex has no components");
   }
 
-  if ((ltComponents.size()==1) && (prevVtxComponents.size()==1)) 
+  if ((ltComponents.size() == 1) && (prevVtxComponents.size() == 1))
     return kalmanVertexUpdator.add(oldVertex, track);
 
   float trackWeight = track->weight();
 
   std::vector<VertexComponent> newVertexComponents;
-  newVertexComponents.reserve(prevVtxComponents.size()*ltComponents.size());
+  newVertexComponents.reserve(prevVtxComponents.size() * ltComponents.size());
 
-//     for (LTC::iterator trackCompIter = ltComponents.begin();
-//   	trackCompIter != ltComponents.end(); trackCompIter++ ) {
-//   cout <<(**trackCompIter).state().globalPosition()<<endl;
-//     }
+  //     for (LTC::iterator trackCompIter = ltComponents.begin();
+  //   	trackCompIter != ltComponents.end(); trackCompIter++ ) {
+  //   cout <<(**trackCompIter).state().globalPosition()<<endl;
+  //     }
 
-  for (VSC::iterator vertexCompIter = prevVtxComponents.begin();
-  	vertexCompIter != prevVtxComponents.end(); vertexCompIter++ ) {
-    for (LTC::iterator trackCompIter = ltComponents.begin();
-  	trackCompIter != ltComponents.end(); trackCompIter++ ) {
-      newVertexComponents.push_back(
-        createNewComponent(*vertexCompIter, *trackCompIter, trackWeight, +1));
-	 // return invalid vertex in case one of the updated vertex-components is invalid
-      if (!newVertexComponents.back().first.isValid()) return CachingVertex<5>();
+  for (VSC::iterator vertexCompIter = prevVtxComponents.begin(); vertexCompIter != prevVtxComponents.end();
+       vertexCompIter++) {
+    for (LTC::iterator trackCompIter = ltComponents.begin(); trackCompIter != ltComponents.end(); trackCompIter++) {
+      newVertexComponents.push_back(createNewComponent(*vertexCompIter, *trackCompIter, trackWeight, +1));
+      // return invalid vertex in case one of the updated vertex-components is invalid
+      if (!newVertexComponents.back().first.isValid())
+        return CachingVertex<5>();
     }
   }
-//   cout << "updator components: "<<newVertexComponents.size()<<endl;
+  //   cout << "updator components: "<<newVertexComponents.size()<<endl;
 
   // Update tracks vector
 
   std::vector<RefCountedVertexTrack> newVertexTracks = oldVertex.tracks();
   newVertexTracks.push_back(track);
-//   cout << "a \n ";
+  //   cout << "a \n ";
 
   // Assemble VertexStates and compute Chi**2
 
   VertexChi2Pair vertexChi2Pair = assembleVertexComponents(newVertexComponents);
-//   cout << "b \n ";
+  //   cout << "b \n ";
   VertexState newVertexState = vertexChi2Pair.first;
-//   cout << "c \n ";
+  //   cout << "c \n ";
   double chi2 = oldVertex.totalChiSquared() + vertexChi2Pair.second;
 
   // Merge:
-  if (limitComponents) newVertexState = theMerger->merge(newVertexState);
+  if (limitComponents)
+    newVertexState = theMerger->merge(newVertexState);
 
-  if  (oldVertex.hasPrior()) {
-    return CachingVertex<5>(oldVertex.priorPosition(), oldVertex.priorError(),
-    		newVertexState.weightTimesPosition(),
-		newVertexState.weight(), newVertexTracks, chi2);
+  if (oldVertex.hasPrior()) {
+    return CachingVertex<5>(oldVertex.priorPosition(),
+                            oldVertex.priorError(),
+                            newVertexState.weightTimesPosition(),
+                            newVertexState.weight(),
+                            newVertexTracks,
+                            chi2);
   } else {
     return CachingVertex<5>(newVertexState, newVertexTracks, chi2);
   }
-
-
 }
 
-
-
-
-CachingVertex<5> GsfVertexUpdator::remove(const CachingVertex<5> & oldVertex, 
-	const RefCountedVertexTrack track) const
-{
+CachingVertex<5> GsfVertexUpdator::remove(const CachingVertex<5>& oldVertex, const RefCountedVertexTrack track) const {
   throw VertexException("GsfVertexUpdator::Remove Methode not yet done");
-//  return CachingVertex<5>();
+  //  return CachingVertex<5>();
 }
 
-
-  /**
+/**
    * Where one component of the previous vertex gets updated with one component of
    *  the track.
    */
 
-GsfVertexUpdator::VertexComponent 
-GsfVertexUpdator::createNewComponent(const VertexState & oldVertex,
-	 const RefCountedLinearizedTrackState linTrack, float weight, int sign) const
-{
+GsfVertexUpdator::VertexComponent GsfVertexUpdator::createNewComponent(const VertexState& oldVertex,
+                                                                       const RefCountedLinearizedTrackState linTrack,
+                                                                       float weight,
+                                                                       int sign) const {
+  if (abs(sign) != 1)
+    throw VertexException("GsfVertexUpdator::sign not equal to 1.");
 
-  if(abs(sign) != 1)
-    throw VertexException ("GsfVertexUpdator::sign not equal to 1.");
-
-  if(sign == -1)
+  if (sign == -1)
     throw VertexException("GsfVertexUpdator::sign of -1 not yet implemented.");
-
 
   // Weight of the component in the mixture (non-normalized)
   double weightInMixture = theWeightCalculator.calculate(oldVertex, linTrack, 1.E9);
-  if (weightInMixture < 0.) return VertexComponent(VertexState(), WeightChi2Pair(0.,0.));
+  if (weightInMixture < 0.)
+    return VertexComponent(VertexState(), WeightChi2Pair(0., 0.));
 
   // position estimate of the component
-  VertexState newVertex = kalmanVertexUpdator.positionUpdate(oldVertex, 
-  				linTrack, weight, sign);
-  if (!newVertex.isValid()) return VertexComponent(newVertex, WeightChi2Pair(0.,0.));
+  VertexState newVertex = kalmanVertexUpdator.positionUpdate(oldVertex, linTrack, weight, sign);
+  if (!newVertex.isValid())
+    return VertexComponent(newVertex, WeightChi2Pair(0., 0.));
 
   //Chi**2 contribution of the component
-  std::pair <bool, double> chi2P = kalmanVertexUpdator.chi2Increment(oldVertex, newVertex, 
-  				linTrack, weight);
-  if (!chi2P.first) return VertexComponent(VertexState(), WeightChi2Pair(0.,0.));
-//         cout << "Update: "<<oldVertex.position()<<" "<<newVertex.position()<<" "<<chi2
-// 	     <<" "<<linTrack->weightInMixture()<<" "<<weightInMixture<<endl;
+  std::pair<bool, double> chi2P = kalmanVertexUpdator.chi2Increment(oldVertex, newVertex, linTrack, weight);
+  if (!chi2P.first)
+    return VertexComponent(VertexState(), WeightChi2Pair(0., 0.));
+  //         cout << "Update: "<<oldVertex.position()<<" "<<newVertex.position()<<" "<<chi2
+  // 	     <<" "<<linTrack->weightInMixture()<<" "<<weightInMixture<<endl;
 
   return VertexComponent(newVertex, WeightChi2Pair(weightInMixture, chi2P.second));
 }
 
 GsfVertexUpdator::VertexChi2Pair GsfVertexUpdator::assembleVertexComponents(
-	const std::vector<GsfVertexUpdator::VertexComponent> & newVertexComponents) const
-{
+    const std::vector<GsfVertexUpdator::VertexComponent>& newVertexComponents) const {
   VSC vertexComponents;
   vertexComponents.reserve(newVertexComponents.size());
-  
+
   //renormalize weights
-// cout << "assemble "<<newVertexComponents.size()<<endl;
+  // cout << "assemble "<<newVertexComponents.size()<<endl;
   double totalWeight = 0.;
   double totalChi2 = 0.;
 
   for (std::vector<VertexComponent>::const_iterator iter = newVertexComponents.begin();
-    iter != newVertexComponents.end(); iter ++) {
+       iter != newVertexComponents.end();
+       iter++) {
     totalWeight += iter->second.first;
   }
-// cout << "totalWeight "<<totalWeight<<endl;
-  if (totalWeight<DBL_MIN) {
+  // cout << "totalWeight "<<totalWeight<<endl;
+  if (totalWeight < DBL_MIN) {
     edm::LogWarning("GsfVertexUpdator") << "Updated Vertex has total weight of 0. "
-    <<"The track is probably very far away.";
-    return VertexChi2Pair( VertexState(), 0.);
+                                        << "The track is probably very far away.";
+    return VertexChi2Pair(VertexState(), 0.);
   }
 
   for (std::vector<VertexComponent>::const_iterator iter = newVertexComponents.begin();
-    iter != newVertexComponents.end(); iter ++) {
-    double weight = iter->second.first/totalWeight;
-    if (iter->second.first>DBL_MIN) {
-      vertexComponents.push_back(VertexState(iter->first.weightTimesPosition(),
-       iter->first.weight(), weight));
+       iter != newVertexComponents.end();
+       iter++) {
+    double weight = iter->second.first / totalWeight;
+    if (iter->second.first > DBL_MIN) {
+      vertexComponents.push_back(VertexState(iter->first.weightTimesPosition(), iter->first.weight(), weight));
       totalChi2 += iter->second.second * weight;
     }
   }
-// cout << "totalChi2 "<<totalChi2<<endl;
-// cout << "vertexComponents "<<vertexComponents.size()<<endl;
+  // cout << "totalChi2 "<<totalChi2<<endl;
+  // cout << "vertexComponents "<<vertexComponents.size()<<endl;
 
-  if (vertexComponents.empty()){
+  if (vertexComponents.empty()) {
     edm::LogWarning("GsfVertexUpdator") << "No Vertex State left after reweighting.";
-    return VertexChi2Pair( VertexState(), 0.);
+    return VertexChi2Pair(VertexState(), 0.);
   }
 
-  return VertexChi2Pair( VertexState( new BasicMultiVertexState( vertexComponents)),
-  			totalChi2);
+  return VertexChi2Pair(VertexState(new BasicMultiVertexState(vertexComponents)), totalChi2);
 }

--- a/RecoVertex/GaussianSumVertexFit/src/GsfVertexWeightCalculator.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/GsfVertexWeightCalculator.cc
@@ -4,19 +4,19 @@
 
 #include <cfloat>
 
-double GsfVertexWeightCalculator::calculate(const  VertexState & oldVertex,
-	 const RefCountedLinearizedTrackState track, double cov) const
-{
+double GsfVertexWeightCalculator::calculate(const VertexState& oldVertex,
+                                            const RefCountedLinearizedTrackState track,
+                                            double cov) const {
   double previousWeight = oldVertex.weightInMixture() * track->weightInMixture();
   // Jacobians
-  const AlgebraicMatrixN3 & a = track->positionJacobian();
-  const AlgebraicMatrixNM & b = track->momentumJacobian();
+  const AlgebraicMatrixN3& a = track->positionJacobian();
+  const AlgebraicMatrixNM& b = track->momentumJacobian();
 
   //track information
   AlgebraicVectorN trackParameters = track->predictedStateParameters();
   AlgebraicSymMatrixNN trackParametersError = track->predictedStateError();
   //vertex information
-  AlgebraicSymMatrix33 oldVertexError  = oldVertex.error().matrix();
+  AlgebraicSymMatrix33 oldVertexError = oldVertex.error().matrix();
   //Vertex position
   GlobalPoint oldVertexPosition = oldVertex.position();
   AlgebraicVector3 oldVertexCoord;
@@ -28,35 +28,32 @@ double GsfVertexWeightCalculator::calculate(const  VertexState & oldVertex,
   AlgebraicVector3 priorMomentum = track->predictedStateMomentumParameters();
 
   AlgebraicSymMatrix33 priorMomentumCov;
-  priorMomentumCov(0,0) = 1.0E-9;
-  priorMomentumCov(1,1) = 1.0E-6;
-  priorMomentumCov(2,2) = 1.0E-6;
+  priorMomentumCov(0, 0) = 1.0E-9;
+  priorMomentumCov(1, 1) = 1.0E-6;
+  priorMomentumCov(2, 2) = 1.0E-6;
   priorMomentumCov *= cov;
 
-  AlgebraicVectorN diff = trackParameters - track->constantTerm() -
-    a*oldVertexCoord -b*priorMomentum;
+  AlgebraicVectorN diff = trackParameters - track->constantTerm() - a * oldVertexCoord - b * priorMomentum;
   track->checkParameters(diff);
-  AlgebraicSymMatrixNN sigmaM = trackParametersError +
-	ROOT::Math::Similarity(a,oldVertexError) +
-	ROOT::Math::Similarity(b,priorMomentumCov);
+  AlgebraicSymMatrixNN sigmaM =
+      trackParametersError + ROOT::Math::Similarity(a, oldVertexError) + ROOT::Math::Similarity(b, priorMomentumCov);
 
   double sigmaDet;
   sigmaM.Det(sigmaDet);
-  int  ifail = ! sigmaM.Invert(); 
-  if(ifail != 0) {
+  int ifail = !sigmaM.Invert();
+  if (ifail != 0) {
     edm::LogWarning("GsfVertexWeightCalculator") << "S matrix inversion failed";
     return -1.;
   }
-  
-	
-  double chi = ROOT::Math::Similarity(diff,sigmaM);;  //SigmaM is now inverted !!!
-  double weight = pow(2. * M_PI, -0.5 * 5) * sqrt(1./sigmaDet) * exp(-0.5 * chi);
 
-  if (edm::isNotFinite(weight) || sigmaDet<=0.) {
+  double chi = ROOT::Math::Similarity(diff, sigmaM);
+  ;  //SigmaM is now inverted !!!
+  double weight = pow(2. * M_PI, -0.5 * 5) * sqrt(1. / sigmaDet) * exp(-0.5 * chi);
+
+  if (edm::isNotFinite(weight) || sigmaDet <= 0.) {
     edm::LogWarning("GsfVertexWeightCalculator") << "Weight is NaN";
     return -1.;
   }
 
-  return weight*previousWeight;
-
+  return weight * previousWeight;
 }

--- a/RecoVertex/GaussianSumVertexFit/src/MultiPerigeeLTSFactory.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/MultiPerigeeLTSFactory.cc
@@ -3,30 +3,19 @@
 // MultiPerigeeLTSFactory::MultiPerigeeLTSFactory()
 // {
 // }
-// 
+//
 // MultiPerigeeLTSFactory::~MultiPerigeeLTSFactory()
 // {
 // }
 
-MultiPerigeeLTSFactory::RefCountedLinearizedTrackState 
-MultiPerigeeLTSFactory::linearizedTrackState(const GlobalPoint & linP, 
-	const reco::TransientTrack & track, const TrajectoryStateOnSurface& tsos) const
-{
-  return RefCountedLinearizedTrackState(
-    new PerigeeMultiLTS(linP, track, tsos ) );
-}
- 
-MultiPerigeeLTSFactory::RefCountedLinearizedTrackState 
-MultiPerigeeLTSFactory::linearizedTrackState(const GlobalPoint & linP, 
-	const reco::TransientTrack & track) const
-{
-  return RefCountedLinearizedTrackState(
-    new PerigeeMultiLTS(linP, track, track.stateOnSurface(linP) ) );
+MultiPerigeeLTSFactory::RefCountedLinearizedTrackState MultiPerigeeLTSFactory::linearizedTrackState(
+    const GlobalPoint& linP, const reco::TransientTrack& track, const TrajectoryStateOnSurface& tsos) const {
+  return RefCountedLinearizedTrackState(new PerigeeMultiLTS(linP, track, tsos));
 }
 
-
-const MultiPerigeeLTSFactory * MultiPerigeeLTSFactory::clone() const
-{
-  return new MultiPerigeeLTSFactory ( *this );
+MultiPerigeeLTSFactory::RefCountedLinearizedTrackState MultiPerigeeLTSFactory::linearizedTrackState(
+    const GlobalPoint& linP, const reco::TransientTrack& track) const {
+  return RefCountedLinearizedTrackState(new PerigeeMultiLTS(linP, track, track.stateOnSurface(linP)));
 }
 
+const MultiPerigeeLTSFactory* MultiPerigeeLTSFactory::clone() const { return new MultiPerigeeLTSFactory(*this); }

--- a/RecoVertex/GaussianSumVertexFit/src/MultiRefittedTS.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/MultiRefittedTS.cc
@@ -8,40 +8,34 @@
 #include <cfloat>
 using namespace std;
 
+MultiRefittedTS::MultiRefittedTS(const std::vector<RefCountedRefittedTrackState>& prtsComp,
+                                 const Surface& referenceSurface)
+    : theComponents(prtsComp), ftsAvailable(false), refSurface(&referenceSurface), surf(true) {}
 
-MultiRefittedTS::MultiRefittedTS(const std::vector<RefCountedRefittedTrackState> & prtsComp,
-	const Surface & referenceSurface) :
-	theComponents(prtsComp), ftsAvailable(false), refSurface(&referenceSurface),
-	surf(true) {}
+MultiRefittedTS::MultiRefittedTS(const std::vector<RefCountedRefittedTrackState>& prtsComp,
+                                 const GlobalPoint& referencePosition)
+    : theComponents(prtsComp), ftsAvailable(false), refPosition(referencePosition), surf(false) {}
 
-
-MultiRefittedTS::MultiRefittedTS(const std::vector<RefCountedRefittedTrackState> & prtsComp,
-	const GlobalPoint & referencePosition) :
-	theComponents(prtsComp), ftsAvailable(false), refPosition(referencePosition),
-	surf(false) {}
-
-  /**
+/**
    * Transformation into a FreeTrajectoryState
    */
 
-FreeTrajectoryState MultiRefittedTS::freeTrajectoryState() const
-{
-  if (!ftsAvailable) computeFreeTrajectoryState();
+FreeTrajectoryState MultiRefittedTS::freeTrajectoryState() const {
+  if (!ftsAvailable)
+    computeFreeTrajectoryState();
   return fts;
 }
 
-void MultiRefittedTS::computeFreeTrajectoryState() const
-{
+void MultiRefittedTS::computeFreeTrajectoryState() const {
   if (surf) {
-    fts =  *(trajectoryStateOnSurface(*refSurface).freeTrajectoryState());
+    fts = *(trajectoryStateOnSurface(*refSurface).freeTrajectoryState());
   } else {
     double maxWeight = -1.;
     RTSvector::const_iterator maxIt;
-    for (RTSvector::const_iterator it = theComponents.begin(); 
-	  it != theComponents.end(); it++) {
-      if ( (**it).weight() > maxWeight ) {
-	maxWeight = (**it).weight();
-	maxIt = it;
+    for (RTSvector::const_iterator it = theComponents.begin(); it != theComponents.end(); it++) {
+      if ((**it).weight() > maxWeight) {
+        maxWeight = (**it).weight();
+        maxIt = it;
       }
     }
 
@@ -53,81 +47,66 @@ void MultiRefittedTS::computeFreeTrajectoryState() const
   ftsAvailable = true;
 }
 
-  /**
+/**
    * Vector containing the refitted track parameters. <br>
    * These are (signed transverse curvature, theta, phi,
    *  (signed) transverse , longitudinal impact parameter)
    */
 
-MultiRefittedTS::AlgebraicVectorN MultiRefittedTS::parameters() const
-{
-  throw VertexException
-    ("MultiRefittedTS::freeTrajectoryState(): Don't know how to do that yet...");
+MultiRefittedTS::AlgebraicVectorN MultiRefittedTS::parameters() const {
+  throw VertexException("MultiRefittedTS::freeTrajectoryState(): Don't know how to do that yet...");
 }
 
-  /**
+/**
    * The covariance matrix
    */
 
-MultiRefittedTS::AlgebraicSymMatrixNN  MultiRefittedTS::covariance() const
-{
-  throw VertexException
-    ("MultiRefittedTS::freeTrajectoryState(): Don't know how to do that yet...");
+MultiRefittedTS::AlgebraicSymMatrixNN MultiRefittedTS::covariance() const {
+  throw VertexException("MultiRefittedTS::freeTrajectoryState(): Don't know how to do that yet...");
 }
 
-  /**
+/**
    * Position at which the momentum is defined.
    */
 
-GlobalPoint MultiRefittedTS::position() const
-{
-  throw VertexException
-    ("MultiRefittedTS::freeTrajectoryState(): Don't know how to do that yet...");
+GlobalPoint MultiRefittedTS::position() const {
+  throw VertexException("MultiRefittedTS::freeTrajectoryState(): Don't know how to do that yet...");
 }
 
-  /**
+/**
    * Vector containing the parameters describing the momentum as the vertex.
    * These are (signed transverse curvature, theta, phi)
    */
 
-MultiRefittedTS::AlgebraicVectorM MultiRefittedTS::momentumVector() const
-{
-  throw VertexException
-    ("MultiRefittedTS::freeTrajectoryState(): Don't know how to do that yet...");
+MultiRefittedTS::AlgebraicVectorM MultiRefittedTS::momentumVector() const {
+  throw VertexException("MultiRefittedTS::freeTrajectoryState(): Don't know how to do that yet...");
 }
 
-double MultiRefittedTS::weight() const
-{
-  if (!totalWeightAvailable)
-  {
+double MultiRefittedTS::weight() const {
+  if (!totalWeightAvailable) {
     totalWeight = 0.;
     if (theComponents.empty()) {
       cout << "Asking for weight of empty MultiRefittedTS, returning zero!" << endl;
     }
-    for (RTSvector::const_iterator it = theComponents.begin(); 
-  	  it != theComponents.end(); it++) {
+    for (RTSvector::const_iterator it = theComponents.begin(); it != theComponents.end(); it++) {
       totalWeight += (**it).weight();
     }
   }
   return totalWeight;
 }
 
-
-ReferenceCountingPointer<RefittedTrackState<5> > 
-MultiRefittedTS::stateWithNewWeight(const double newWeight) const
-{
+ReferenceCountingPointer<RefittedTrackState<5> > MultiRefittedTS::stateWithNewWeight(const double newWeight) const {
   if (weight() < DBL_MIN) {
-  throw VertexException
-    ("MultiRefittedTS::stateWithNewWeight(): Can not reweight multi-state with total weight < DBL_MIN");
+    throw VertexException(
+        "MultiRefittedTS::stateWithNewWeight(): Can not reweight multi-state with total weight < DBL_MIN");
   }
-  double factor = newWeight/weight();
+  double factor = newWeight / weight();
 
   RTSvector reWeightedRTSC;
   reWeightedRTSC.reserve(theComponents.size());
 
-  for (RTSvector::const_iterator it = theComponents.begin(); 
-	it != theComponents.end(); it++) {
-    reWeightedRTSC.push_back((**it).stateWithNewWeight((**it).weight()*factor));
+  for (RTSvector::const_iterator it = theComponents.begin(); it != theComponents.end(); it++) {
+    reWeightedRTSC.push_back((**it).stateWithNewWeight((**it).weight() * factor));
   }
   if (surf) {
     return RefCountedRefittedTrackState(new MultiRefittedTS(reWeightedRTSC, *refSurface));
@@ -136,35 +115,29 @@ MultiRefittedTS::stateWithNewWeight(const double newWeight) const
   }
 }
 
-  /**
+/**
    * Transformation into a TSOS at a given surface
    */
-TrajectoryStateOnSurface MultiRefittedTS::trajectoryStateOnSurface(
-  		const Surface & surface) const
-{
+TrajectoryStateOnSurface MultiRefittedTS::trajectoryStateOnSurface(const Surface& surface) const {
   vector<TrajectoryStateOnSurface> tsosComponents;
   tsosComponents.reserve(theComponents.size());
-  for (RTSvector::const_iterator it = theComponents.begin(); 
-	it != theComponents.end(); it++) {
+  for (RTSvector::const_iterator it = theComponents.begin(); it != theComponents.end(); it++) {
     tsosComponents.push_back((**it).trajectoryStateOnSurface(surface));
   }
   return TrajectoryStateOnSurface((BasicTrajectoryState*)new BasicMultiTrajectoryState(tsosComponents));
 }
 
-TrajectoryStateOnSurface MultiRefittedTS::trajectoryStateOnSurface(
-  		const Surface & surface, const Propagator & propagator) const
-{ //fixme... is the propagation done correctly? Is there a gsf propagator?
+TrajectoryStateOnSurface MultiRefittedTS::trajectoryStateOnSurface(const Surface& surface, const Propagator& propagator)
+    const {  //fixme... is the propagation done correctly? Is there a gsf propagator?
   vector<TrajectoryStateOnSurface> tsosComponents;
   tsosComponents.reserve(theComponents.size());
-  for (RTSvector::const_iterator it = theComponents.begin(); 
-	it != theComponents.end(); it++) {
+  for (RTSvector::const_iterator it = theComponents.begin(); it != theComponents.end(); it++) {
     tsosComponents.push_back((**it).trajectoryStateOnSurface(surface, propagator));
   }
   return TrajectoryStateOnSurface((BasicTrajectoryState*)new BasicMultiTrajectoryState(tsosComponents));
 }
 
-reco::TransientTrack MultiRefittedTS::transientTrack() const
-{
+reco::TransientTrack MultiRefittedTS::transientTrack() const {
   TransientTrackFromFTSFactory factory;
   return factory.build(freeTrajectoryState());
 }

--- a/RecoVertex/GaussianSumVertexFit/src/MultiVertexStateCombiner.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/MultiVertexStateCombiner.cc
@@ -1,31 +1,24 @@
 #include "RecoVertex/GaussianSumVertexFit/interface/MultiVertexStateCombiner.h"
 #include "RecoVertex/VertexPrimitives/interface/VertexException.h"
 
-
-VertexState
-MultiVertexStateCombiner::combine(const VSC & theMixture) const
-{
-
+VertexState MultiVertexStateCombiner::combine(const VSC& theMixture) const {
   if (theMixture.empty()) {
-    throw VertexException
-    ("MultiVertexStateCombiner:: VertexState container to collapse is empty");
+    throw VertexException("MultiVertexStateCombiner:: VertexState container to collapse is empty");
   }
 
-  if (theMixture.size()==1) {
-//     #ifndef CMS_NO_COMPLEX_RETURNS
-      return VertexState(theMixture.front().position(), theMixture.front().error(), 1.0);
-//     #else
-//       VertexState theFinalVM(theMixture.front().position(), theMixture.front().error(), 1.0);
-//       return theFinalVM;
-//     #endif
+  if (theMixture.size() == 1) {
+    //     #ifndef CMS_NO_COMPLEX_RETURNS
+    return VertexState(theMixture.front().position(), theMixture.front().error(), 1.0);
+    //     #else
+    //       VertexState theFinalVM(theMixture.front().position(), theMixture.front().error(), 1.0);
+    //       return theFinalVM;
+    //     #endif
   }
-
 
   AlgebraicVector3 meanPosition;
   double weightSum = 0.;
   AlgebraicSymMatrix33 measCovar1, measCovar2;
-  for (VSC::const_iterator mixtureIter1 = theMixture.begin();
-  	mixtureIter1 != theMixture.end(); mixtureIter1++ ) {
+  for (VSC::const_iterator mixtureIter1 = theMixture.begin(); mixtureIter1 != theMixture.end(); mixtureIter1++) {
     double vtxWeight = mixtureIter1->weightInMixture();
 
     GlobalPoint vertexPosition = mixtureIter1->position();
@@ -34,33 +27,33 @@ MultiVertexStateCombiner::combine(const VSC & theMixture) const
     vertexCoord1[1] = vertexPosition.y();
     vertexCoord1[2] = vertexPosition.z();
 
-//    AlgebraicVector position = mixtureIter1->position().vector(); //???
+    //    AlgebraicVector position = mixtureIter1->position().vector(); //???
     weightSum += vtxWeight;
     meanPosition += vtxWeight * vertexCoord1;
 
     measCovar1 += vtxWeight * mixtureIter1->error().matrix();
-    for (VSC::const_iterator mixtureIter2 = mixtureIter1+1;
-  	mixtureIter2 != theMixture.end(); mixtureIter2++ ) {
+    for (VSC::const_iterator mixtureIter2 = mixtureIter1 + 1; mixtureIter2 != theMixture.end(); mixtureIter2++) {
       GlobalPoint vertexPosition2 = mixtureIter2->position();
       AlgebraicVector3 vertexCoord2;
       vertexCoord2[0] = vertexPosition2.x();
       vertexCoord2[1] = vertexPosition2.y();
       vertexCoord2[2] = vertexPosition2.z();
       AlgebraicVector3 posDiff = vertexCoord1 - vertexCoord2;
-      AlgebraicMatrix13 tmp; tmp.Place_in_row(posDiff,0,0);
-      AlgebraicSymMatrix11 s = AlgebraicMatrixID(); 
-      measCovar2 +=vtxWeight * mixtureIter2->weightInMixture() * ROOT::Math::SimilarityT(tmp,s);
+      AlgebraicMatrix13 tmp;
+      tmp.Place_in_row(posDiff, 0, 0);
+      AlgebraicSymMatrix11 s = AlgebraicMatrixID();
+      measCovar2 += vtxWeight * mixtureIter2->weightInMixture() * ROOT::Math::SimilarityT(tmp, s);
     }
   }
   meanPosition /= weightSum;
-  AlgebraicSymMatrix33 measCovar = measCovar1/weightSum + measCovar2/weightSum/weightSum;
+  AlgebraicSymMatrix33 measCovar = measCovar1 / weightSum + measCovar2 / weightSum / weightSum;
 
   GlobalPoint newPos(meanPosition[0], meanPosition[1], meanPosition[2]);
 
-// #ifndef CMS_NO_COMPLEX_RETURNS
+  // #ifndef CMS_NO_COMPLEX_RETURNS
   return VertexState(newPos, GlobalError(measCovar), weightSum);
-// #else
-//   VertexState theFinalVS(newPos, GlobalError(measCovar), weightSum);
-//   return theFinalVS;
-// #endif
+  // #else
+  //   VertexState theFinalVS(newPos, GlobalError(measCovar), weightSum);
+  //   return theFinalVS;
+  // #endif
 }

--- a/RecoVertex/GaussianSumVertexFit/src/PerigeeMultiLTS.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/PerigeeMultiLTS.cc
@@ -4,70 +4,62 @@
 #include "RecoVertex/VertexPrimitives/interface/VertexException.h"
 #include "RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h"
 
-
-
 using namespace std;
 
-PerigeeMultiLTS::PerigeeMultiLTS(const GlobalPoint & linP,
-	const reco::TransientTrack & track, const TrajectoryStateOnSurface& tsos)
-     : theLinPoint(linP), theTrack(track), theTSOS(tsos),
-       theCharge(theTrack.charge()), collapsedStateAvailable(false)
-{
+PerigeeMultiLTS::PerigeeMultiLTS(const GlobalPoint& linP,
+                                 const reco::TransientTrack& track,
+                                 const TrajectoryStateOnSurface& tsos)
+    : theLinPoint(linP), theTrack(track), theTSOS(tsos), theCharge(theTrack.charge()), collapsedStateAvailable(false) {
   //Extract the TSOS components:
 
   vector<TrajectoryStateOnSurface> tsosComp = theTSOS.components();
   //cout << "PerigeeMultiLTS components: "<<tsosComp.size()<<endl;
   ltComp.reserve(tsosComp.size());
-  for (vector<TrajectoryStateOnSurface>::iterator it = tsosComp.begin();
-  	it != tsosComp.end(); it++) {
-  // cout <<(*it).globalPosition()<<endl;
-    ltComp.push_back(theLTSfactory.linearizedTrackState(theLinPoint, theTrack, *it ));
+  for (vector<TrajectoryStateOnSurface>::iterator it = tsosComp.begin(); it != tsosComp.end(); it++) {
+    // cout <<(*it).globalPosition()<<endl;
+    ltComp.push_back(theLTSfactory.linearizedTrackState(theLinPoint, theTrack, *it));
   }
-
 }
 
-
-void PerigeeMultiLTS::prepareCollapsedState() const
-{
+void PerigeeMultiLTS::prepareCollapsedState() const {
   if (!collapsedStateAvailable) {
     collapsedStateLT = theLTSfactory.linearizedTrackState(theLinPoint, theTrack, theTSOS);
   }
   collapsedStateAvailable = true;
 }
 
-
 /** Method returning the constant term of the Taylor expansion
  *  of the measurement equation
  */
-const AlgebraicVector5 & PerigeeMultiLTS::constantTerm() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
+const AlgebraicVector5& PerigeeMultiLTS::constantTerm() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
   return collapsedStateLT->constantTerm();
 }
 
 /**
  * Method returning the Position Jacobian (Matrix A)
  */
-const AlgebraicMatrix53 & PerigeeMultiLTS::positionJacobian() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
+const AlgebraicMatrix53& PerigeeMultiLTS::positionJacobian() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
   return collapsedStateLT->positionJacobian();
 }
 
 /**
  * Method returning the Momentum Jacobian (Matrix B)
  */
-const AlgebraicMatrix53 & PerigeeMultiLTS::momentumJacobian() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
+const AlgebraicMatrix53& PerigeeMultiLTS::momentumJacobian() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
   return collapsedStateLT->momentumJacobian();
 }
 
 /** Method returning the parameters of the Taylor expansion
  */
-const AlgebraicVector5 & PerigeeMultiLTS::parametersFromExpansion() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
+const AlgebraicVector5& PerigeeMultiLTS::parametersFromExpansion() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
   return collapsedStateLT->parametersFromExpansion();
 }
 
@@ -75,101 +67,89 @@ const AlgebraicVector5 & PerigeeMultiLTS::parametersFromExpansion() const
  * Method returning the TrajectoryStateClosestToPoint at the point
  * of closest approch to the z-axis (a.k.a. transverse impact point)
  */
-const TrajectoryStateClosestToPoint & PerigeeMultiLTS::predictedState() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
-  const PerigeeLinearizedTrackState* otherP =
-  	dynamic_cast<const PerigeeLinearizedTrackState*>(collapsedStateLT.get());
+const TrajectoryStateClosestToPoint& PerigeeMultiLTS::predictedState() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
+  const PerigeeLinearizedTrackState* otherP = dynamic_cast<const PerigeeLinearizedTrackState*>(collapsedStateLT.get());
   return otherP->predictedState();
 }
 
-
-bool PerigeeMultiLTS::hasError() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
+bool PerigeeMultiLTS::hasError() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
   return collapsedStateLT->hasError();
 }
 
-AlgebraicVector5 PerigeeMultiLTS::predictedStateParameters() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
+AlgebraicVector5 PerigeeMultiLTS::predictedStateParameters() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
   return collapsedStateLT->predictedStateParameters();
 }
 
-AlgebraicVector3 PerigeeMultiLTS::predictedStateMomentumParameters() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
+AlgebraicVector3 PerigeeMultiLTS::predictedStateMomentumParameters() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
   return collapsedStateLT->predictedStateMomentumParameters();
 }
 
-AlgebraicSymMatrix55 PerigeeMultiLTS::predictedStateWeight(int & error) const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
-  return collapsedStateLT->predictedStateWeight(error) ;
+AlgebraicSymMatrix55 PerigeeMultiLTS::predictedStateWeight(int& error) const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
+  return collapsedStateLT->predictedStateWeight(error);
 }
 
-AlgebraicSymMatrix55 PerigeeMultiLTS::predictedStateError() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
-  return collapsedStateLT-> predictedStateError();
+AlgebraicSymMatrix55 PerigeeMultiLTS::predictedStateError() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
+  return collapsedStateLT->predictedStateError();
 }
 
-AlgebraicSymMatrix33 PerigeeMultiLTS::predictedStateMomentumError() const
-{
-  if (!collapsedStateAvailable) prepareCollapsedState();
-  return collapsedStateLT->predictedStateMomentumError() ;
+AlgebraicSymMatrix33 PerigeeMultiLTS::predictedStateMomentumError() const {
+  if (!collapsedStateAvailable)
+    prepareCollapsedState();
+  return collapsedStateLT->predictedStateMomentumError();
 }
 
-bool PerigeeMultiLTS::operator ==(LinearizedTrackState<5>& other)const
-{
-  const PerigeeMultiLTS* otherP =
-  	dynamic_cast<const PerigeeMultiLTS*>(&other);
+bool PerigeeMultiLTS::operator==(LinearizedTrackState<5>& other) const {
+  const PerigeeMultiLTS* otherP = dynamic_cast<const PerigeeMultiLTS*>(&other);
   if (otherP == nullptr) {
-   throw VertexException("PerigeeMultiLTS: don't know how to compare myself to non-perigee track state");
+    throw VertexException("PerigeeMultiLTS: don't know how to compare myself to non-perigee track state");
   }
   return (otherP->track() == theTrack);
 }
 
-
-PerigeeMultiLTS::RefCountedLinearizedTrackState
-PerigeeMultiLTS::stateWithNewLinearizationPoint
-			(const GlobalPoint & newLP) const
-{
-  return RefCountedLinearizedTrackState(
-  		new PerigeeMultiLTS(newLP, track(), theTSOS));
+PerigeeMultiLTS::RefCountedLinearizedTrackState PerigeeMultiLTS::stateWithNewLinearizationPoint(
+    const GlobalPoint& newLP) const {
+  return RefCountedLinearizedTrackState(new PerigeeMultiLTS(newLP, track(), theTSOS));
 }
 
-PerigeeMultiLTS::RefCountedRefittedTrackState
-PerigeeMultiLTS::createRefittedTrackState(
-  	const GlobalPoint & vertexPosition,
-	const AlgebraicVectorM & vectorParameters,
-	const AlgebraicSymMatrixOO & covarianceMatrix) const
-{
-  TrajectoryStateClosestToPoint refittedTSCP =
-        PerigeeConversions::trajectoryStateClosestToPoint(
-	  vectorParameters, vertexPosition, charge(), covarianceMatrix, theTrack.field());
+PerigeeMultiLTS::RefCountedRefittedTrackState PerigeeMultiLTS::createRefittedTrackState(
+    const GlobalPoint& vertexPosition,
+    const AlgebraicVectorM& vectorParameters,
+    const AlgebraicSymMatrixOO& covarianceMatrix) const {
+  TrajectoryStateClosestToPoint refittedTSCP = PerigeeConversions::trajectoryStateClosestToPoint(
+      vectorParameters, vertexPosition, charge(), covarianceMatrix, theTrack.field());
   return RefCountedRefittedTrackState(new PerigeeRefittedTrackState(refittedTSCP, vectorParameters));
 }
 
-AlgebraicVector5 PerigeeMultiLTS::refittedParamFromEquation(
-	const RefCountedRefittedTrackState & theRefittedState) const
-{
+AlgebraicVector5 PerigeeMultiLTS::refittedParamFromEquation(const RefCountedRefittedTrackState& theRefittedState) const {
   AlgebraicVector3 vertexPosition;
   vertexPosition(0) = theRefittedState->position().x();
   vertexPosition(1) = theRefittedState->position().y();
   vertexPosition(2) = theRefittedState->position().z();
-  AlgebraicVectorN param = constantTerm() + 
-		       positionJacobian() * vertexPosition +
-		       momentumJacobian() * theRefittedState->momentumVector();
-  if (param(2) >  M_PI) param(2)-= 2*M_PI;
-  if (param(2) < -M_PI) param(2)+= 2*M_PI;
+  AlgebraicVectorN param =
+      constantTerm() + positionJacobian() * vertexPosition + momentumJacobian() * theRefittedState->momentumVector();
+  if (param(2) > M_PI)
+    param(2) -= 2 * M_PI;
+  if (param(2) < -M_PI)
+    param(2) += 2 * M_PI;
 
   return param;
 }
 
-
-void PerigeeMultiLTS::checkParameters(AlgebraicVector5 & parameters) const
-{
-  if (parameters(2) >  M_PI) parameters(2)-= 2*M_PI;
-  if (parameters(2) < -M_PI) parameters(2)+= 2*M_PI;
+void PerigeeMultiLTS::checkParameters(AlgebraicVector5& parameters) const {
+  if (parameters(2) > M_PI)
+    parameters(2) -= 2 * M_PI;
+  if (parameters(2) < -M_PI)
+    parameters(2) += 2 * M_PI;
 }

--- a/RecoVertex/GaussianSumVertexFit/src/VertexGaussianStateConversions.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/VertexGaussianStateConversions.cc
@@ -6,44 +6,41 @@
 
 namespace GaussianStateConversions {
 
-  MultiGaussianState<3> multiGaussianStateFromVertex (const VertexState aState)
-  {
-    typedef std::shared_ptr< SingleGaussianState<3> > SingleStatePtr;
+  MultiGaussianState<3> multiGaussianStateFromVertex(const VertexState aState) {
+    typedef std::shared_ptr<SingleGaussianState<3> > SingleStatePtr;
     const std::vector<VertexState> components = aState.components();
     MultiGaussianState<3>::SingleStateContainer singleStates;
     singleStates.reserve(components.size());
-    for ( std::vector<VertexState>::const_iterator ic=components.begin();
-	  ic!=components.end(); ic ++ ) {
-      if ( ic->isValid() ) {
-	GlobalPoint pos(ic->position());
-	AlgebraicVector3 parameters;
-	parameters(0) = pos.x(); parameters(1) = pos.y(); parameters(2) = pos.z();
-	SingleStatePtr sgs(new SingleGaussianState<3>(parameters,
-							 ic->error().matrix(),
-							 ic->weightInMixture()));
-	singleStates.push_back(sgs);
+    for (std::vector<VertexState>::const_iterator ic = components.begin(); ic != components.end(); ic++) {
+      if (ic->isValid()) {
+        GlobalPoint pos(ic->position());
+        AlgebraicVector3 parameters;
+        parameters(0) = pos.x();
+        parameters(1) = pos.y();
+        parameters(2) = pos.z();
+        SingleStatePtr sgs(new SingleGaussianState<3>(parameters, ic->error().matrix(), ic->weightInMixture()));
+        singleStates.push_back(sgs);
       }
     }
     return MultiGaussianState<3>(singleStates);
   }
 
-  VertexState vertexFromMultiGaussianState (const MultiGaussianState<3>& multiState)
-  {
-    if ( multiState.components().empty() )  return VertexState();
+  VertexState vertexFromMultiGaussianState(const MultiGaussianState<3>& multiState) {
+    if (multiState.components().empty())
+      return VertexState();
 
-    const MultiGaussianState<3>::SingleStateContainer& singleStates = 
-      multiState.components();
+    const MultiGaussianState<3>::SingleStateContainer& singleStates = multiState.components();
     std::vector<VertexState> components;
     components.reserve(singleStates.size());
-    for ( MultiGaussianState<3>::SingleStateContainer::const_iterator ic=singleStates.begin();
-	  ic!=singleStates.end(); ic++ ) {
+    for (MultiGaussianState<3>::SingleStateContainer::const_iterator ic = singleStates.begin();
+         ic != singleStates.end();
+         ic++) {
       const AlgebraicVector3& par = (**ic).mean();
-      GlobalPoint position(par(0),par(1),par(2));
+      GlobalPoint position(par(0), par(1), par(2));
       const AlgebraicSymMatrix33& cov = (**ic).covariance();
-      GlobalError error(cov(0,0),cov(1,0),cov(2,0),cov(1,1),cov(2,1),cov(2,2));
-      components.push_back(VertexState(position,error,(**ic).weight()));
+      GlobalError error(cov(0, 0), cov(1, 0), cov(2, 0), cov(1, 1), cov(2, 1), cov(2, 2));
+      components.push_back(VertexState(position, error, (**ic).weight()));
     }
     return VertexState(new BasicMultiVertexState(components));
   }
-}
-
+}  // namespace GaussianStateConversions

--- a/RecoVertex/GaussianSumVertexFit/test/GsfTest.cc
+++ b/RecoVertex/GaussianSumVertexFit/test/GsfTest.cc
@@ -24,128 +24,110 @@ using namespace reco;
 using namespace edm;
 using namespace std;
 
-GsfTest::GsfTest(const edm::ParameterSet& iConfig)
-  : theConfig(iConfig)
-{
+GsfTest::GsfTest(const edm::ParameterSet& iConfig) : theConfig(iConfig) {
   token_tracks = consumes<TrackCollection>(iConfig.getParameter<string>("TrackLabel"));
   outputFile_ = iConfig.getUntrackedParameter<std::string>("outputFile");
   gsfPSet = iConfig.getParameter<edm::ParameterSet>("GsfParameters");
-  rootFile_ = TFile::Open(outputFile_.c_str(),"RECREATE"); 
-  edm::LogInfo("RecoVertex/GsfTest") 
-    << "Initializing KVF TEST analyser  - Output file: " << outputFile_ <<"\n";
-//   token_TrackTruth = consumes<TrackingParticleCollection>(edm::InputTag("trackingtruth", "TrackTruth"));
+  rootFile_ = TFile::Open(outputFile_.c_str(), "RECREATE");
+  edm::LogInfo("RecoVertex/GsfTest") << "Initializing KVF TEST analyser  - Output file: " << outputFile_ << "\n";
+  //   token_TrackTruth = consumes<TrackingParticleCollection>(edm::InputTag("trackingtruth", "TrackTruth"));
   token_VertexTruth = consumes<TrackingVertexCollection>(edm::InputTag("trackingtruth", "VertexTruth"));
 }
 
+GsfTest::~GsfTest() { delete rootFile_; }
 
-GsfTest::~GsfTest() {
-  delete rootFile_;
-}
+void GsfTest::beginJob() {}
 
-void GsfTest::beginJob(){
-}
-
-
-void GsfTest::endJob() {
-}
+void GsfTest::endJob() {}
 
 //
 // member functions
 //
 
-void
-GsfTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  if( not tree ) {
+void GsfTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  if (not tree) {
     edm::ESHandle<MagneticField> magField;
     iSetup.get<IdealMagneticFieldRecord>().get(magField);
-    tree.reset( new SimpleVertexTree("VertexFitter",magField.product()) );
+    tree.reset(new SimpleVertexTree("VertexFitter", magField.product()));
   }
 
-
   try {
-    edm::LogInfo("RecoVertex/GsfTest") 
-      << "Reconstructing event number: " << iEvent.id() << "\n";
-    
+    edm::LogInfo("RecoVertex/GsfTest") << "Reconstructing event number: " << iEvent.id() << "\n";
+
     // get RECO tracks from the event
     // `tks` can be used as a ptr to a reco::TrackCollection
     edm::Handle<edm::View<reco::Track> > tks;
     iEvent.getByToken(token_tracks, tks);
 
-    edm::LogInfo("RecoVertex/GsfTest") 
-      << "Found: " << (*tks).size() << " reconstructed tracks" << "\n";
+    edm::LogInfo("RecoVertex/GsfTest") << "Found: " << (*tks).size() << " reconstructed tracks"
+                                       << "\n";
     cout << "got " << (*tks).size() << " tracks " << endl;
 
     // Transform Track to TransientTrack
 
     //get the builder:
     edm::ESHandle<TransientTrackBuilder> theB;
-    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
+    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
     //do the conversion:
     vector<TransientTrack> t_tks = (*theB).build(tks);
 
-    edm::LogInfo("RecoVertex/GsfTest") 
-      << "Found: " << t_tks.size() << " reconstructed tracks" << "\n";
-    
+    edm::LogInfo("RecoVertex/GsfTest") << "Found: " << t_tks.size() << " reconstructed tracks"
+                                       << "\n";
+
     // Call the KalmanVertexFitter if more than 1 track
     if (t_tks.size() > 1) {
       //      KalmanVertexFitter kvf(kvfPSet);
       // For the analysis: compare to your SimVertex
-//       TrackingVertex sv = getSimVertex(iEvent);
-//       std::cout << "SimV Position: " << Vertex::Point(sv.position()) << "\n";
+      //       TrackingVertex sv = getSimVertex(iEvent);
+      //       std::cout << "SimV Position: " << Vertex::Point(sv.position()) << "\n";
 
       KalmanVertexFitter kvf;
       TransientVertex tv2 = kvf.vertex(t_tks);
-      std::cout << "KVF Position:  " << Vertex::Point(tv2.position()) <<tv2.normalisedChiSquared ()<<" "<<tv2.degreesOfFreedom() << "\n";
+      std::cout << "KVF Position:  " << Vertex::Point(tv2.position()) << tv2.normalisedChiSquared() << " "
+                << tv2.degreesOfFreedom() << "\n";
 
       GsfVertexFitter gsf(gsfPSet);
       TransientVertex tv = gsf.vertex(t_tks);
       std::cout << "Position: " << Vertex::Point(tv.position()) << "\n";
 
+      //   edm::Handle<TrackingParticleCollection>  TPCollectionH ;
+      //   iEvent.getByToken(token_TrackTruth, TPCollectionH);
+      //   const TrackingParticleCollection tPC = *(TPCollectionH.product());
+      //       reco::RecoToSimCollection recSimColl=associatorForParamAtPca->associateRecoToSim(tks,
+      // 									      TPCollectionH,
+      // 									      &iEvent);
 
-
-//   edm::Handle<TrackingParticleCollection>  TPCollectionH ;
-//   iEvent.getByToken(token_TrackTruth, TPCollectionH);
-//   const TrackingParticleCollection tPC = *(TPCollectionH.product());
-//       reco::RecoToSimCollection recSimColl=associatorForParamAtPca->associateRecoToSim(tks,
-// 									      TPCollectionH,
-// 									      &iEvent);
-
-//       tree->fill(tv, &sv, 0, 0.0);
+      //       tree->fill(tv, &sv, 0, 0.0);
     }
-    
+
   }
 
-  catch (std::exception & err) {
-//   edm::LogInfo("RecoVertex/GsfTest") 
-     cout << "Exception during event number: " << iEvent.id() 
-      << "\n" << err.what() << "\n";
+  catch (std::exception& err) {
+    //   edm::LogInfo("RecoVertex/GsfTest")
+    cout << "Exception during event number: " << iEvent.id() << "\n" << err.what() << "\n";
   }
-
 }
-
 
 //Returns the first vertex in the list.
 
-TrackingVertex GsfTest::getSimVertex(const edm::Event& iEvent) const
-{
-   // get the simulated vertices
-  edm::Handle<TrackingVertexCollection>  TVCollectionH ;
-  iEvent.getByToken(token_VertexTruth,TVCollectionH);
+TrackingVertex GsfTest::getSimVertex(const edm::Event& iEvent) const {
+  // get the simulated vertices
+  edm::Handle<TrackingVertexCollection> TVCollectionH;
+  iEvent.getByToken(token_VertexTruth, TVCollectionH);
   const TrackingVertexCollection tPC = *(TVCollectionH.product());
 
-//    Handle<edm::SimVertexContainer> simVtcs;
-//    iEvent.getByLabel("g4SimHits", simVtcs);
-//    std::cout << "SimVertex " << simVtcs->size() << std::endl;
-//    for(edm::SimVertexContainer::const_iterator v=simVtcs->begin();
-//        v!=simVtcs->end(); ++v){
-//      std::cout << "simvtx "
-// 	       << v->position().x() << " "
-// 	       << v->position().y() << " "
-// 	       << v->position().z() << " "
-// 	       << v->parentIndex() << " "
-// 	       << v->noParent() << " "
-//               << std::endl;
-//    }
-   return *(tPC.begin());
+  //    Handle<edm::SimVertexContainer> simVtcs;
+  //    iEvent.getByLabel("g4SimHits", simVtcs);
+  //    std::cout << "SimVertex " << simVtcs->size() << std::endl;
+  //    for(edm::SimVertexContainer::const_iterator v=simVtcs->begin();
+  //        v!=simVtcs->end(); ++v){
+  //      std::cout << "simvtx "
+  // 	       << v->position().x() << " "
+  // 	       << v->position().y() << " "
+  // 	       << v->position().z() << " "
+  // 	       << v->parentIndex() << " "
+  // 	       << v->noParent() << " "
+  //               << std::endl;
+  //    }
+  return *(tPC.begin());
 }

--- a/RecoVertex/GaussianSumVertexFit/test/GsfTest.h
+++ b/RecoVertex/GaussianSumVertexFit/test/GsfTest.h
@@ -2,7 +2,7 @@
 //
 // Package:    GsfTest
 // Class:      GsfTest
-// 
+//
 /**\class GsfTest GsfTest.cc RecoVertex/GsfTest/src/GsfTest.cc
 
  Description: steers tracker primary vertex reconstruction and storage
@@ -10,7 +10,6 @@
  Implementation:
      <Notes on implementation>
 */
-
 
 // system include files
 #include <memory>
@@ -28,7 +27,7 @@
 #include "RecoVertex/KalmanVertexFit/interface/SimpleVertexTree.h"
 #include <TFile.h>
 
-  /**
+/**
    * This is a very simple test analyzer mean to test the KalmanVertexFitter
    */
 
@@ -36,24 +35,23 @@ class GsfTest : public edm::EDAnalyzer {
 public:
   explicit GsfTest(const edm::ParameterSet&);
   ~GsfTest();
-  
+
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
   virtual void beginJob();
   virtual void endJob();
 
 private:
-
   TrackingVertex getSimVertex(const edm::Event& iEvent) const;
 
   edm::ParameterSet theConfig;
   edm::ParameterSet gsfPSet;
 
   std::unique_ptr<SimpleVertexTree> tree;
-  TFile*  rootFile_;
+  TFile* rootFile_;
 
-  std::string outputFile_; // output file
-  edm::EDGetTokenT<reco::TrackCollection> token_tracks; 
-//   edm::EDGetTokenT<TrackingParticleCollection> token_TrackTruth;
+  std::string outputFile_;  // output file
+  edm::EDGetTokenT<reco::TrackCollection> token_tracks;
+  //   edm::EDGetTokenT<TrackingParticleCollection> token_TrackTruth;
   edm::EDGetTokenT<TrackingVertexCollection> token_VertexTruth;
 };

--- a/RecoVertex/GaussianSumVertexFit/test/SealModule.cc
+++ b/RecoVertex/GaussianSumVertexFit/test/SealModule.cc
@@ -2,6 +2,4 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "RecoVertex/GaussianSumVertexFit/test/GsfTest.h"
 
-
-
 DEFINE_FWK_MODULE(GsfTest);

--- a/RecoVertex/GaussianSumVertexFit/test/TrackMix.cc
+++ b/RecoVertex/GaussianSumVertexFit/test/TrackMix.cc
@@ -22,33 +22,21 @@ using namespace reco;
 using namespace edm;
 using namespace std;
 
-TrackMix::TrackMix(const edm::ParameterSet& iConfig)
-  : theConfig(iConfig)
-{
+TrackMix::TrackMix(const edm::ParameterSet& iConfig) : theConfig(iConfig) {
   token_gsf = consumes<edm::View<reco::Track> >(iConfig.getParameter<string>("gsfTrackLabel"));
   token_ckf = consumes<edm::View<reco::Track> >(iConfig.getParameter<string>("ckfTrackLabel"));
 }
 
+TrackMix::~TrackMix() {}
 
-TrackMix::~TrackMix() {
-}
-
-void TrackMix::beginJob(){
-}
-
+void TrackMix::beginJob() {}
 
 void TrackMix::endJob() {}
 
-void
-TrackMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
-
-
+void TrackMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   try {
-    edm::LogInfo("RecoVertex/TrackMix") 
-      << "Reconstructing event number: " << iEvent.id() << "\n";
-    
+    edm::LogInfo("RecoVertex/TrackMix") << "Reconstructing event number: " << iEvent.id() << "\n";
+
     // get RECO tracks from the event
     // `tks` can be used as a ptr to a reco::TrackCollection
     edm::Handle<edm::View<reco::Track> > tks;
@@ -57,20 +45,21 @@ TrackMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     iEvent.getByToken(token_ckf, tks2);
 
     cout << "got " << (*tks).size() << " gsf tracks " << endl;
-    cout << "got " << (*tks2).size()<< " ckf tracks " << endl;
+    cout << "got " << (*tks2).size() << " ckf tracks " << endl;
 
     // Transform Track to TransientTrack
 
     //get the builder:
     edm::ESHandle<TransientTrackBuilder> theB;
-    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
+    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
     //do the conversion:
     vector<TransientTrack> t_tks = (*theB).build(tks);
     vector<TransientTrack> t_tks2 = (*theB).build(tks2);
     t_tks.insert(t_tks.end(), t_tks2.begin(), t_tks2.end());
 
-    cout  << "Total: " << t_tks.size() << " reconstructed tracks" << "\n";
-    
+    cout << "Total: " << t_tks.size() << " reconstructed tracks"
+         << "\n";
+
     // Call the KalmanVertexFitter if more than 1 track
     if (t_tks.size() > 1) {
       KalmanVertexFitter kvf(true);
@@ -81,24 +70,20 @@ TrackMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       reco::Vertex v1 = tv;
       reco::Vertex::trackRef_iterator v1TrackIter;
       reco::Vertex::trackRef_iterator v1TrackBegin = v1.tracks_begin();
-      reco::Vertex::trackRef_iterator v1TrackEnd   = v1.tracks_end();
-      cout << v1.position()<<v1.tracksSize()<<endl;
-            for (v1TrackIter = v1TrackBegin; v1TrackIter != v1TrackEnd; v1TrackIter++) {
-	    cout << "pt" << (**v1TrackIter).pt() <<endl;
-	    cout << " weight " << v1.trackWeight(*v1TrackIter)<<endl;
-	    cout << " ref " << v1.refittedTrack(*v1TrackIter).pt()<<endl;
+      reco::Vertex::trackRef_iterator v1TrackEnd = v1.tracks_end();
+      cout << v1.position() << v1.tracksSize() << endl;
+      for (v1TrackIter = v1TrackBegin; v1TrackIter != v1TrackEnd; v1TrackIter++) {
+        cout << "pt" << (**v1TrackIter).pt() << endl;
+        cout << " weight " << v1.trackWeight(*v1TrackIter) << endl;
+        cout << " ref " << v1.refittedTrack(*v1TrackIter).pt() << endl;
       }
-
-
     }
-    
+
   }
 
-  catch (std::exception & err) {
-    cout  << "Exception during event number: " << iEvent.id() 
-      << "\n" << err.what() << "\n";
+  catch (std::exception& err) {
+    cout << "Exception during event number: " << iEvent.id() << "\n" << err.what() << "\n";
   }
-
 }
 
 DEFINE_FWK_MODULE(TrackMix);

--- a/RecoVertex/GaussianSumVertexFit/test/TrackMix.h
+++ b/RecoVertex/GaussianSumVertexFit/test/TrackMix.h
@@ -18,7 +18,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include <TFile.h>
 
-  /**
+/**
    * This is a very simple test analyzer mean to test the KalmanVertexFitter
    */
 
@@ -26,14 +26,13 @@ class TrackMix : public edm::EDAnalyzer {
 public:
   explicit TrackMix(const edm::ParameterSet&);
   ~TrackMix();
-  
+
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
   virtual void beginJob();
   virtual void endJob();
 
 private:
-
   edm::ParameterSet theConfig;
   edm::EDGetTokenT<edm::View<reco::Track> > token_gsf, token_ckf;
 };

--- a/RecoVertex/VertexPrimitives/interface/BasicSingleVertexState.h
+++ b/RecoVertex/VertexPrimitives/interface/BasicSingleVertexState.h
@@ -5,53 +5,54 @@
 
 //#include "CommonReco/CommonVertex/interface/RefCountedVertexSeed.h"
 
-
 /** Single state measurement of a vertex.
  * Some data is calculated on demand to improve performance.
  */
 
 class BasicSingleVertexState final : public BasicVertexState {
-
 public:
-
   /** Constructors
    */
   BasicSingleVertexState();
-  BasicSingleVertexState(const GlobalPoint & pos, const GlobalError & posErr,
-                         const double & weightInMix = 1.0);
-  BasicSingleVertexState(const GlobalPoint & pos, const GlobalWeight & posWeight,
-                         const double & weightInMix = 1.0);
-  BasicSingleVertexState(const AlgebraicVector3 & weightTimesPosition,
-                         const GlobalWeight & posWeight,
-                         const double & weightInMix = 1.0);
+  BasicSingleVertexState(const GlobalPoint& pos, const GlobalError& posErr, const double& weightInMix = 1.0);
+  BasicSingleVertexState(const GlobalPoint& pos, const GlobalWeight& posWeight, const double& weightInMix = 1.0);
+  BasicSingleVertexState(const AlgebraicVector3& weightTimesPosition,
+                         const GlobalWeight& posWeight,
+                         const double& weightInMix = 1.0);
 
   // constructors with time (ignores off-diagonals in fit)
-  BasicSingleVertexState(const GlobalPoint & pos, const GlobalError & posErr,
-                         const double time, const double timeError,
-                         const double & weightInMix = 1.0);
-  BasicSingleVertexState(const GlobalPoint & pos, const GlobalWeight & posWeight,
-                         const double time, const double timeWeight,
-                         const double & weightInMix = 1.0);
-  BasicSingleVertexState(const AlgebraicVector3 & weightTimesPosition, 
-                         const GlobalWeight & posWeight,
-                         const double weightTimesTime, const double timeWeight,
-                         const double & weightInMix = 1.0);
+  BasicSingleVertexState(const GlobalPoint& pos,
+                         const GlobalError& posErr,
+                         const double time,
+                         const double timeError,
+                         const double& weightInMix = 1.0);
+  BasicSingleVertexState(const GlobalPoint& pos,
+                         const GlobalWeight& posWeight,
+                         const double time,
+                         const double timeWeight,
+                         const double& weightInMix = 1.0);
+  BasicSingleVertexState(const AlgebraicVector3& weightTimesPosition,
+                         const GlobalWeight& posWeight,
+                         const double weightTimesTime,
+                         const double timeWeight,
+                         const double& weightInMix = 1.0);
 
   // constructors with time, full cov
-  BasicSingleVertexState(const GlobalPoint & pos, const double time, 
-                         const GlobalError & posTimeErr, const double & weightInMix = 1.0);
-  BasicSingleVertexState(const GlobalPoint & pos, const double time, 
-                         const GlobalWeight & posTimeWeight, const double & weightInMix = 1.0);
-  BasicSingleVertexState(const AlgebraicVector4 & weightTimesPosition,
-                         const GlobalWeight & posTimeWeight,
-                         const double & weightInMix = 1.0);
+  BasicSingleVertexState(const GlobalPoint& pos,
+                         const double time,
+                         const GlobalError& posTimeErr,
+                         const double& weightInMix = 1.0);
+  BasicSingleVertexState(const GlobalPoint& pos,
+                         const double time,
+                         const GlobalWeight& posTimeWeight,
+                         const double& weightInMix = 1.0);
+  BasicSingleVertexState(const AlgebraicVector4& weightTimesPosition,
+                         const GlobalWeight& posTimeWeight,
+                         const double& weightInMix = 1.0);
 
   /** Access methods
    */
-  pointer clone() const override
-  {
-    return build<BasicSingleVertexState>(*this);
-  }
+  pointer clone() const override { return build<BasicSingleVertexState>(*this); }
 
   GlobalPoint position() const override;
   GlobalError error() const override;
@@ -67,11 +68,10 @@ public:
   /**
    * The validity of the vertex
    */
-  bool isValid() const override {return valid;}
+  bool isValid() const override { return valid; }
   bool is4D() const override { return vertexIs4D; }
 
 private:
-
   void computePosition() const;
   void computeError() const;
   void computeWeight() const;
@@ -86,14 +86,14 @@ private:
   mutable AlgebraicVector4 theWeightTimesPos;
   double theWeightInMix;
 
-  mutable bool thePosAvailable;  
+  mutable bool thePosAvailable;
   mutable bool theTimeAvailable;
   mutable bool theErrAvailable;
   mutable bool theWeightAvailable;
   mutable bool theWeightTimesPosAvailable;
 
   bool valid;
-  bool vertexIs4D;  
+  bool vertexIs4D;
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/BasicVertexState.h
+++ b/RecoVertex/VertexPrimitives/interface/BasicVertexState.h
@@ -15,19 +15,17 @@ class VertexState;
  */
 
 class BasicVertexState {
+public:
+  using Proxy = ProxyBase11<BasicVertexState>;
+  using pointer = Proxy::pointer;
 
 public:
-
-  using Proxy=ProxyBase11<BasicVertexState>;
-  using pointer=Proxy::pointer;
-
-public:
-
   virtual ~BasicVertexState() {}
 
-  template<typename T, typename... Args>
-    static std::shared_ptr<BasicVertexState> build(Args && ...args){ return std::make_shared<T>(std::forward<Args>(args)...);}
-
+  template <typename T, typename... Args>
+  static std::shared_ptr<BasicVertexState> build(Args&&... args) {
+    return std::make_shared<T>(std::forward<Args>(args)...);
+  }
 
   virtual pointer clone() const = 0;
 
@@ -46,7 +44,6 @@ public:
   virtual std::vector<VertexState> components() const;
   virtual bool isValid() const = 0;
   virtual bool is4D() const = 0;
-
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/CachingVertex.h
+++ b/RecoVertex/VertexPrimitives/interface/CachingVertex.h
@@ -14,105 +14,128 @@
 #include <vector>
 #include <map>
 
-
-
 /** Class for vertices fitted with Kalman and linear fit algorithms. 
  *  Provides access to temporary data to speed up the vertex update. 
  */
 
-
 template <unsigned int N>
 class CachingVertex {
-
 public:
-
   typedef ReferenceCountingPointer<VertexTrack<N> > RefCountedVertexTrack;
-  typedef ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N> > AlgebraicSymMatrixNN;
-  typedef ROOT::Math::SMatrix<double,N-2,N-2,ROOT::Math::MatRepStd<double,N-2,N-2> > AlgebraicMatrixMM;
-  typedef std::map<RefCountedVertexTrack, AlgebraicMatrixMM > TrackMap;
-  typedef std::map<RefCountedVertexTrack, TrackMap > TrackToTrackMap;
+  typedef ROOT::Math::SMatrix<double, N, N, ROOT::Math::MatRepSym<double, N> > AlgebraicSymMatrixNN;
+  typedef ROOT::Math::SMatrix<double, N - 2, N - 2, ROOT::Math::MatRepStd<double, N - 2, N - 2> > AlgebraicMatrixMM;
+  typedef std::map<RefCountedVertexTrack, AlgebraicMatrixMM> TrackMap;
+  typedef std::map<RefCountedVertexTrack, TrackMap> TrackToTrackMap;
 
   /** Constructors
    */
   // no time
-  CachingVertex(const GlobalPoint & pos, const GlobalError & posErr, 
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
+  CachingVertex(const GlobalPoint &pos,
+                const GlobalError &posErr,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const GlobalPoint & pos, const GlobalWeight & posWeight, 
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
+  CachingVertex(const GlobalPoint &pos,
+                const GlobalWeight &posWeight,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const AlgebraicVector3 & weightTimesPosition, 
-		const GlobalWeight & posWeight, 
-		const std::vector<RefCountedVertexTrack> & tks, 
-		float totalChiSq);  
+  CachingVertex(const AlgebraicVector3 &weightTimesPosition,
+                const GlobalWeight &posWeight,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const GlobalPoint & priorPos, const GlobalError & priorErr,
-  		const AlgebraicVector3 & weightTimesPosition, 
-		const GlobalWeight & posWeight, 
-		const std::vector<RefCountedVertexTrack> & tks, 
-		float totalChiSq);
-  
+  CachingVertex(const GlobalPoint &priorPos,
+                const GlobalError &priorErr,
+                const AlgebraicVector3 &weightTimesPosition,
+                const GlobalWeight &posWeight,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
+
   // with time (tracks must have time as well)
-  CachingVertex(const GlobalPoint & pos, const double time,
-                const GlobalError & posTimeErr, 
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
+  CachingVertex(const GlobalPoint &pos,
+                const double time,
+                const GlobalError &posTimeErr,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const GlobalPoint & pos, const double time, 
-                const GlobalWeight & posTimeWeight, 
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
+  CachingVertex(const GlobalPoint &pos,
+                const double time,
+                const GlobalWeight &posTimeWeight,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const AlgebraicVector4 & weightTimesPosition, 
-		const GlobalWeight & posTimeWeight, 
-		const std::vector<RefCountedVertexTrack> & tks, 
-		float totalChiSq);
-  
-  CachingVertex(const GlobalPoint & priorPos, const GlobalError & priorErr,
-  		const AlgebraicVector4 & weightTimesPosition, 
-		const GlobalWeight & posWeight, 
-		const std::vector<RefCountedVertexTrack> & tks, 
-		float totalChiSq);
+  CachingVertex(const AlgebraicVector4 &weightTimesPosition,
+                const GlobalWeight &posTimeWeight,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
+
+  CachingVertex(const GlobalPoint &priorPos,
+                const GlobalError &priorErr,
+                const AlgebraicVector4 &weightTimesPosition,
+                const GlobalWeight &posWeight,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
   // either time or no time (depends on if the tracks/vertex states have times)
-  CachingVertex(const GlobalPoint & priorPos, const GlobalError & priorErr,
-  		const GlobalPoint & pos, const GlobalError & posErr, 
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
+  CachingVertex(const GlobalPoint &priorPos,
+                const GlobalError &priorErr,
+                const GlobalPoint &pos,
+                const GlobalError &posErr,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const GlobalPoint & priorPos, const double priorTime, const GlobalError & priorErr, 
-  		const GlobalPoint & pos, const double time, const GlobalError & posErr, 
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
+  CachingVertex(const GlobalPoint &priorPos,
+                const double priorTime,
+                const GlobalError &priorErr,
+                const GlobalPoint &pos,
+                const double time,
+                const GlobalError &posErr,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const GlobalPoint & priorPos, const GlobalError & priorErr,
-  		const GlobalPoint & pos, const GlobalWeight & posWeight, 
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
+  CachingVertex(const GlobalPoint &priorPos,
+                const GlobalError &priorErr,
+                const GlobalPoint &pos,
+                const GlobalWeight &posWeight,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const GlobalPoint & priorPos, const double priorTime, const GlobalError & priorErr,
-  		const GlobalPoint & pos, const double time, const GlobalWeight & posWeight, 
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
-  
-  CachingVertex(const VertexState & aVertexState, 
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
+  CachingVertex(const GlobalPoint &priorPos,
+                const double priorTime,
+                const GlobalError &priorErr,
+                const GlobalPoint &pos,
+                const double time,
+                const GlobalWeight &posWeight,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const VertexState & priorVertexState, 
-  		const VertexState & aVertexState,
-		const std::vector<RefCountedVertexTrack> & tks, float totalChiSq);
+  CachingVertex(const VertexState &aVertexState, const std::vector<RefCountedVertexTrack> &tks, float totalChiSq);
 
-  CachingVertex(const VertexState & aVertexState,
-		const std::vector<RefCountedVertexTrack> & tks, 
-		float totalChiSq, const TrackToTrackMap & covMap);
+  CachingVertex(const VertexState &priorVertexState,
+                const VertexState &aVertexState,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq);
 
-  CachingVertex(const VertexState & priorVertexState, 
-  		const VertexState & aVertexState,
-		const std::vector<RefCountedVertexTrack> & tks, 
-		float totalChiSq, const TrackToTrackMap & covMap);
+  CachingVertex(const VertexState &aVertexState,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq,
+                const TrackToTrackMap &covMap);
+
+  CachingVertex(const VertexState &priorVertexState,
+                const VertexState &aVertexState,
+                const std::vector<RefCountedVertexTrack> &tks,
+                float totalChiSq,
+                const TrackToTrackMap &covMap);
 
   /** Constructor for invalid CachingVertex
    */
   CachingVertex();
 
   /** Access methods
-   */      
-  VertexState const & vertexState() const {return theVertexState;}
-  VertexState const & priorVertexState() const {return thePriorVertexState;}
+   */
+  VertexState const &vertexState() const { return theVertexState; }
+  VertexState const &priorVertexState() const { return thePriorVertexState; }
   GlobalPoint position() const;
   double time() const;
   GlobalError error() const;
@@ -123,12 +146,12 @@ public:
   AlgebraicVector4 weightTimesPosition4D() const;
   std::vector<RefCountedVertexTrack> tracks() const { return theTracks; }
   const std::vector<RefCountedVertexTrack> &tracksRef() const { return theTracks; }
-  GlobalPoint priorPosition() const {return priorVertexState().position();}
+  GlobalPoint priorPosition() const { return priorVertexState().position(); }
   double priorTime() const { return priorVertexState().time(); }
-  GlobalError priorError() const {return priorVertexState().error();}
-  GlobalError priorError4D() const {return priorVertexState().error4D();}
-  bool hasPrior() const {return withPrior;}
-  bool isValid() const {return theValid;}
+  GlobalError priorError() const { return priorVertexState().error(); }
+  GlobalError priorError4D() const { return priorVertexState().error4D(); }
+  bool hasPrior() const { return withPrior; }
+  bool isValid() const { return theValid; }
   bool is4D() const { return vertexIs4D; }
 
   /** Chi2, degrees of freedom. The latter may not be integer. 
@@ -138,14 +161,12 @@ public:
 
   /** Track to track covariance
    */
-  AlgebraicMatrixMM tkToTkCovariance(const RefCountedVertexTrack t1, 
-				   const RefCountedVertexTrack t2) const;
+  AlgebraicMatrixMM tkToTkCovariance(const RefCountedVertexTrack t1, const RefCountedVertexTrack t2) const;
   bool tkToTkCovarianceIsAvailable() const { return theCovMapAvailable; }
 
   operator TransientVertex() const;
 
 private:
-
   void computeNDF() const;
 
   mutable VertexState theVertexState;
@@ -161,6 +182,5 @@ private:
   bool theValid;
   bool vertexIs4D;
 };
-
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/ConvertError.h
+++ b/RecoVertex/VertexPrimitives/interface/ConvertError.h
@@ -4,21 +4,21 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-namespace RecoVertex{
-  inline reco::Vertex::Error convertError(const GlobalError& ge) 
-    {
-      reco::Vertex::Error error;
-      error(0,0) = ge.cxx();
-      error(0,1) = ge.cyx();
-      error(0,2) = ge.czx();
-      error(1,1) = ge.cyy();
-      error(1,2) = ge.czy();
-      error(2,2) = ge.czz();
-      return error;
-    }
+namespace RecoVertex {
+  inline reco::Vertex::Error convertError(const GlobalError& ge) {
+    reco::Vertex::Error error;
+    error(0, 0) = ge.cxx();
+    error(0, 1) = ge.cyx();
+    error(0, 2) = ge.czx();
+    error(1, 1) = ge.cyy();
+    error(1, 2) = ge.czy();
+    error(2, 2) = ge.czz();
+    return error;
+  }
 
-  inline GlobalError convertError(const reco::Vertex::Error& error)
-    { return GlobalError(error(0,0), error(0,1), error(1,1), error(0,2), error(1,2), error(2,2)); }
-}
+  inline GlobalError convertError(const reco::Vertex::Error& error) {
+    return GlobalError(error(0, 0), error(0, 1), error(1, 1), error(0, 2), error(1, 2), error(2, 2));
+  }
+}  // namespace RecoVertex
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/ConvertToFromReco.h
+++ b/RecoVertex/VertexPrimitives/interface/ConvertToFromReco.h
@@ -3,18 +3,16 @@
 
 #include "RecoVertex/VertexPrimitives/interface/ConvertError.h"
 
-namespace RecoVertex{
-  inline reco::Vertex::Point convertPos(const GlobalPoint& p) 
-    {
-      reco::Vertex::Point pos;
-      pos.SetX(p.x());
-      pos.SetY(p.y());
-      pos.SetZ(p.z());
-      return pos;
-    }
+namespace RecoVertex {
+  inline reco::Vertex::Point convertPos(const GlobalPoint& p) {
+    reco::Vertex::Point pos;
+    pos.SetX(p.x());
+    pos.SetY(p.y());
+    pos.SetZ(p.z());
+    return pos;
+  }
 
-  inline GlobalPoint convertPos(const reco::Vertex::Point& p)
-    { return GlobalPoint(p.x(), p.y(), p.z()); }
-}
+  inline GlobalPoint convertPos(const reco::Vertex::Point& p) { return GlobalPoint(p.x(), p.y(), p.z()); }
+}  // namespace RecoVertex
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/LinearizedTrackState.h
+++ b/RecoVertex/VertexPrimitives/interface/LinearizedTrackState.h
@@ -34,51 +34,49 @@
 
 template <unsigned int N>
 class LinearizedTrackState : public ReferenceCounted {
-
 public:
-
-  typedef ROOT::Math::SVector<double,N> AlgebraicVectorN;
-  typedef ROOT::Math::SVector<double,N-2> AlgebraicVectorM;
-  typedef ROOT::Math::SMatrix<double,N,3,ROOT::Math::MatRepStd<double,N,3> > AlgebraicMatrixN3;
-  typedef ROOT::Math::SMatrix<double,N,N-2,ROOT::Math::MatRepStd<double,N,N-2> > AlgebraicMatrixNM;
-  typedef ROOT::Math::SMatrix<double,N-2,3,ROOT::Math::MatRepStd<double,N-2,3> > AlgebraicMatrixM3;
-  typedef ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N> > AlgebraicSymMatrixNN;
-  typedef ROOT::Math::SMatrix<double,N-2,N-2,ROOT::Math::MatRepSym<double,N-2> > AlgebraicSymMatrixMM;
-  typedef ROOT::Math::SMatrix<double,N+1,N+1,ROOT::Math::MatRepSym<double,N+1> > AlgebraicSymMatrixOO;
+  typedef ROOT::Math::SVector<double, N> AlgebraicVectorN;
+  typedef ROOT::Math::SVector<double, N - 2> AlgebraicVectorM;
+  typedef ROOT::Math::SMatrix<double, N, 3, ROOT::Math::MatRepStd<double, N, 3> > AlgebraicMatrixN3;
+  typedef ROOT::Math::SMatrix<double, N, N - 2, ROOT::Math::MatRepStd<double, N, N - 2> > AlgebraicMatrixNM;
+  typedef ROOT::Math::SMatrix<double, N - 2, 3, ROOT::Math::MatRepStd<double, N - 2, 3> > AlgebraicMatrixM3;
+  typedef ROOT::Math::SMatrix<double, N, N, ROOT::Math::MatRepSym<double, N> > AlgebraicSymMatrixNN;
+  typedef ROOT::Math::SMatrix<double, N - 2, N - 2, ROOT::Math::MatRepSym<double, N - 2> > AlgebraicSymMatrixMM;
+  typedef ROOT::Math::SMatrix<double, N + 1, N + 1, ROOT::Math::MatRepSym<double, N + 1> > AlgebraicSymMatrixOO;
 
   typedef ReferenceCountingPointer<RefittedTrackState<N> > RefCountedRefittedTrackState;
 
-  ~LinearizedTrackState() override{}
+  ~LinearizedTrackState() override {}
 
   /**
    * Returns a new linearized state with respect to a new linearization point.
    * A new object of the same type is returned, without change to the existing one.
    */
-  virtual  ReferenceCountingPointer<LinearizedTrackState<N> > stateWithNewLinearizationPoint
-    (const GlobalPoint & newLP) const = 0;
+  virtual ReferenceCountingPointer<LinearizedTrackState<N> > stateWithNewLinearizationPoint(
+      const GlobalPoint& newLP) const = 0;
 
   /** Access methods
    */
-  virtual const GlobalPoint & linearizationPoint() const = 0;
+  virtual const GlobalPoint& linearizationPoint() const = 0;
 
   /** Method returning the constant term of the Taylor expansion
    *  of the measurement equation
    */
-  virtual const AlgebraicVectorN & constantTerm() const = 0;
+  virtual const AlgebraicVectorN& constantTerm() const = 0;
 
   /** Method returning the Position Jacobian from the Taylor expansion
    *  (Matrix A)
    */
-  virtual const AlgebraicMatrixN3 & positionJacobian() const = 0;
+  virtual const AlgebraicMatrixN3& positionJacobian() const = 0;
 
   /** Method returning the Momentum Jacobian from the Taylor expansion
    *  (Matrix B)
    */
-  virtual const AlgebraicMatrixNM & momentumJacobian() const = 0;
+  virtual const AlgebraicMatrixNM& momentumJacobian() const = 0;
 
   /** Method returning the parameters of the Taylor expansion
    */
-  virtual const AlgebraicVectorN & parametersFromExpansion() const = 0;
+  virtual const AlgebraicVectorN& parametersFromExpansion() const = 0;
 
   /** Method returning the parameters of the track state at the
    *  linearization point.
@@ -94,7 +92,7 @@ public:
    *  linearization point.
    * The error variable is 0 in case of success.
    */
-  virtual AlgebraicSymMatrixNN predictedStateWeight(int & error) const = 0;
+  virtual AlgebraicSymMatrixNN predictedStateWeight(int& error) const = 0;
 
   /** Method returning the momentum covariance matrix of the track state at the
    *  transverse impact point.
@@ -112,31 +110,27 @@ public:
 
   /** Method returning the impact point measurement
    */
-//   virtual ImpactPointMeasurement impactPointMeasurement() const = 0;
+  //   virtual ImpactPointMeasurement impactPointMeasurement() const = 0;
 
-  virtual bool operator ==(LinearizedTrackState<N> & other) const = 0;
+  virtual bool operator==(LinearizedTrackState<N>& other) const = 0;
 
   /** Creates the correct refitted state according to the results of the
    *  track refit.
    */
-  virtual RefCountedRefittedTrackState createRefittedTrackState(
-  	const GlobalPoint & vertexPosition,
-	const AlgebraicVectorM & vectorParameters,
-	const AlgebraicSymMatrixOO & covarianceMatrix) const = 0;
+  virtual RefCountedRefittedTrackState createRefittedTrackState(const GlobalPoint& vertexPosition,
+                                                                const AlgebraicVectorM& vectorParameters,
+                                                                const AlgebraicSymMatrixOO& covarianceMatrix) const = 0;
 
   /** Method returning the parameters of the Taylor expansion evaluated with the
    *  refitted state.
    */
-  virtual AlgebraicVectorN refittedParamFromEquation(
-	const RefCountedRefittedTrackState & theRefittedState) const = 0;
+  virtual AlgebraicVectorN refittedParamFromEquation(const RefCountedRefittedTrackState& theRefittedState) const = 0;
 
-  virtual inline void checkParameters(AlgebraicVectorN & parameters) const
-	{}
+  virtual inline void checkParameters(AlgebraicVectorN& parameters) const {}
 
   virtual double weightInMixture() const = 0;
 
-  virtual std::vector< ReferenceCountingPointer<LinearizedTrackState<N> > > components()
-  								const = 0;
+  virtual std::vector<ReferenceCountingPointer<LinearizedTrackState<N> > > components() const = 0;
 
   virtual reco::TransientTrack track() const = 0;
 

--- a/RecoVertex/VertexPrimitives/interface/RefittedTrackState.h
+++ b/RecoVertex/VertexPrimitives/interface/RefittedTrackState.h
@@ -19,17 +19,15 @@ class Propagator;
 
 template <unsigned int N>
 class RefittedTrackState : public ReferenceCounted {
-
 public:
+  //   typedef ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N> > AlgebraicMatrixN3;
+  typedef ROOT::Math::SVector<double, N> AlgebraicVectorN;
+  typedef ROOT::Math::SVector<double, N - 2> AlgebraicVectorM;
+  //   typedef ROOT::Math::SMatrix<double,N,3,ROOT::Math::MatRepStd<double,N,3> > AlgebraicMatrixN3;
+  //   typedef ROOT::Math::SMatrix<double,N-2,3,ROOT::Math::MatRepStd<double,N-2,3> > AlgebraicMatrixM3;
+  typedef ROOT::Math::SMatrix<double, N, N, ROOT::Math::MatRepSym<double, N> > AlgebraicSymMatrixNN;
 
-//   typedef ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N> > AlgebraicMatrixN3;
-  typedef ROOT::Math::SVector<double,N> AlgebraicVectorN;
-  typedef ROOT::Math::SVector<double,N-2> AlgebraicVectorM;
-//   typedef ROOT::Math::SMatrix<double,N,3,ROOT::Math::MatRepStd<double,N,3> > AlgebraicMatrixN3;
-//   typedef ROOT::Math::SMatrix<double,N-2,3,ROOT::Math::MatRepStd<double,N-2,3> > AlgebraicMatrixM3;
-  typedef ROOT::Math::SMatrix<double,N,N,ROOT::Math::MatRepSym<double,N> > AlgebraicSymMatrixNN;
-
-  ~RefittedTrackState() override{}
+  ~RefittedTrackState() override {}
 
   /**
    * Transformation into a FreeTrajectoryState
@@ -39,15 +37,14 @@ public:
   /**
    * Transformation into a TSOS at a given surface
    */
-  virtual TrajectoryStateOnSurface trajectoryStateOnSurface(
-  		const Surface & surface) const = 0;
+  virtual TrajectoryStateOnSurface trajectoryStateOnSurface(const Surface& surface) const = 0;
 
   /**
    * Transformation into a TSOS at a given surface, with a given propagator
    */
 
-  virtual TrajectoryStateOnSurface trajectoryStateOnSurface(
-		const Surface & surface, const Propagator & propagator) const = 0;
+  virtual TrajectoryStateOnSurface trajectoryStateOnSurface(const Surface& surface,
+                                                            const Propagator& propagator) const = 0;
 
   /**
    * Vector containing the refitted track parameters.
@@ -81,12 +78,10 @@ public:
    * The current state is unchanged.
    */
 
-  virtual ReferenceCountingPointer<RefittedTrackState> stateWithNewWeight
-  	(const double newWeight) const = 0;
+  virtual ReferenceCountingPointer<RefittedTrackState> stateWithNewWeight(const double newWeight) const = 0;
 
-  virtual std::vector< ReferenceCountingPointer<RefittedTrackState> > components() const = 0;
+  virtual std::vector<ReferenceCountingPointer<RefittedTrackState> > components() const = 0;
 
   virtual reco::TransientTrack transientTrack() const = 0;
-
 };
 #endif

--- a/RecoVertex/VertexPrimitives/interface/TTtoTTmap.h
+++ b/RecoVertex/VertexPrimitives/interface/TTtoTTmap.h
@@ -11,5 +11,4 @@
 typedef std::map<reco::TransientTrack, AlgebraicMatrix33> TTmap;
 typedef std::map<reco::TransientTrack, TTmap> TTtoTTmap;
 
-
 #endif

--- a/RecoVertex/VertexPrimitives/interface/TrackToTrackCovCalculator.h
+++ b/RecoVertex/VertexPrimitives/interface/TrackToTrackCovCalculator.h
@@ -13,16 +13,13 @@
 
 template <unsigned int N>
 class TrackToTrackCovCalculator {
-
 public:
-
   TrackToTrackCovCalculator() {}
   virtual ~TrackToTrackCovCalculator() {}
 
-  virtual typename CachingVertex<N>::TrackToTrackMap operator() (const CachingVertex<N> &) const = 0;
-  
-  virtual TrackToTrackCovCalculator * clone() const = 0;
+  virtual typename CachingVertex<N>::TrackToTrackMap operator()(const CachingVertex<N> &) const = 0;
 
+  virtual TrackToTrackCovCalculator *clone() const = 0;
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/TransientVertex.h
+++ b/RecoVertex/VertexPrimitives/interface/TransientVertex.h
@@ -15,10 +15,9 @@
 /** \class TransientVertex
  */
 
-class TransientVertex {//: public reco::Vertex {
+class TransientVertex {  //: public reco::Vertex {
 
 public:
-
   typedef std::map<reco::TransientTrack, float> TransientTrackToFloatMap;
 
   /** Empty constructor, produces invalid vertex
@@ -31,21 +30,32 @@ public:
    *  The number of degrees of freedom is equal to
    *  2*nb of tracks - 3.
    */
-  TransientVertex(const GlobalPoint & pos, const GlobalError & posError,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2);
-  TransientVertex(const GlobalPoint & pos, const double time, 
-                  const GlobalError & posError,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2);
+  TransientVertex(const GlobalPoint& pos,
+                  const GlobalError& posError,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2);
+  TransientVertex(const GlobalPoint& pos,
+                  const double time,
+                  const GlobalError& posError,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2);
 
   /** Constructor defining the RecVertex by its 3D position
    *  and position uncertainty, its associated tracks, its chi-squared
    *  and its number of degrees of freedom.
    *  The ndf can be a float.
    */
-  TransientVertex(const GlobalPoint & pos, const GlobalError & posError,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2, float ndf);
-  TransientVertex(const GlobalPoint & pos, const double time, const GlobalError & posError,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2, float ndf);
+  TransientVertex(const GlobalPoint& pos,
+                  const GlobalError& posError,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2,
+                  float ndf);
+  TransientVertex(const GlobalPoint& pos,
+                  const double time,
+                  const GlobalError& posError,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2,
+                  float ndf);
 
   /** Constructor defining the RecVertex by the prior,
    *  the vertex 3D position and uncertainty, the associated tracks
@@ -53,35 +63,59 @@ public:
    *  3 coordinates, the number of degrees of freedom is equal to
    *  2*nb of tracks.
    */
-  TransientVertex(const GlobalPoint & priorPos, const GlobalError & priorErr,
-                  const GlobalPoint & pos, const GlobalError & posError,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2);
-  TransientVertex(const GlobalPoint & priorPos, const double priorTime, const GlobalError & priorErr,
-                  const GlobalPoint & pos, const double time, const GlobalError & posError,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2);
+  TransientVertex(const GlobalPoint& priorPos,
+                  const GlobalError& priorErr,
+                  const GlobalPoint& pos,
+                  const GlobalError& posError,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2);
+  TransientVertex(const GlobalPoint& priorPos,
+                  const double priorTime,
+                  const GlobalError& priorErr,
+                  const GlobalPoint& pos,
+                  const double time,
+                  const GlobalError& posError,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2);
 
   /** Constructor defining the RecVertex by the prior,
    *  the vertex 3D position and uncertainty, the associated tracks,
    *  the chi-squared and the number of degrees of freedom.
    *  The ndf can be a float.
    */
-  TransientVertex(const GlobalPoint & priorPos, const GlobalError & priorErr,
-                  const GlobalPoint & pos, const GlobalError & posError,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2, float ndf);
-  TransientVertex(const GlobalPoint & priorPos, const double priorTime, const GlobalError & priorErr,
-                  const GlobalPoint & pos, const double time, const GlobalError & posError,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2, float ndf);
+  TransientVertex(const GlobalPoint& priorPos,
+                  const GlobalError& priorErr,
+                  const GlobalPoint& pos,
+                  const GlobalError& posError,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2,
+                  float ndf);
+  TransientVertex(const GlobalPoint& priorPos,
+                  const double priorTime,
+                  const GlobalError& priorErr,
+                  const GlobalPoint& pos,
+                  const double time,
+                  const GlobalError& posError,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2,
+                  float ndf);
 
   /** Constructor defining the RecVertex by the prior,
    *  the vertex 3D position and uncertainty, time and uncertainty, the associated tracks,
    *  the chi-squared and the number of degrees of freedom.
    *  The ndf can be a float.
    */
-  TransientVertex(const GlobalPoint & priorPos, const GlobalError & priorErr,
-                  const double priorTime, const double priorTimeErr,
-                  const GlobalPoint & pos, const GlobalError & posError,
-                  const double time, const double timeErr,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2, float ndf);
+  TransientVertex(const GlobalPoint& priorPos,
+                  const GlobalError& priorErr,
+                  const double priorTime,
+                  const double priorTimeErr,
+                  const GlobalPoint& pos,
+                  const GlobalError& posError,
+                  const double time,
+                  const double timeErr,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2,
+                  float ndf);
 
   /** Constructor defining the RecVertex by its 3D position 
    *  and position uncertainty, its associated tracks 
@@ -89,16 +123,14 @@ public:
    *  The number of degrees of freedom is equal to 
    *  2*nb of tracks - 3.
    */
-  TransientVertex(const VertexState & state, 
-                  const std::vector<reco::TransientTrack> & tracks, float chi2);
+  TransientVertex(const VertexState& state, const std::vector<reco::TransientTrack>& tracks, float chi2);
 
   /** Constructor defining the RecVertex by its 3D position
    *  and position uncertainty, its associated tracks, its chi-squared
    *  and its number of degrees of freedom.
    *  The ndf can be a float.
    */
-  TransientVertex(const VertexState & state, 
-                  const std::vector<reco::TransientTrack> & tracks, float chi2, float ndf);
+  TransientVertex(const VertexState& state, const std::vector<reco::TransientTrack>& tracks, float chi2, float ndf);
 
   /** Constructor defining the RecVertex by the prior,
    *  the vertex 3D position and uncertainty, the associated tracks
@@ -106,68 +138,66 @@ public:
    *  3 coordinates, the number of degrees of freedom is equal to
    *  2*nb of tracks.
    */
-  TransientVertex(const VertexState & prior,
-                  const VertexState & state,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2);
+  TransientVertex(const VertexState& prior,
+                  const VertexState& state,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2);
 
   /** Constructor defining the RecVertex by the prior,
    *  the vertex 3D position and uncertainty, the associated tracks,
    *  the chi-squared and the number of degrees of freedom.
    *  The ndf can be a float.
    */
-  TransientVertex(const VertexState & prior,
-                  const VertexState & state,
-                  const std::vector<reco::TransientTrack> & tracks, float chi2, float ndf);
+  TransientVertex(const VertexState& prior,
+                  const VertexState& state,
+                  const std::vector<reco::TransientTrack>& tracks,
+                  float chi2,
+                  float ndf);
 
-
-//   /** Constructor defining the RecVertex by its 3D position
-//    *  and position uncertainty, its associated tracks, its chi-squared
-//    *  and its number of degrees of freedom, and the track weights. 
-//    *  The ndf can be a float.
-//    */
-//   TransientVertex(const VertexState & state, 
-// 		    const std::vector<reco::TransientTrack> & tracks, float chi2, float ndf, 
-// 		    const reco::TransientTrackToFloatMap & weightMap);
-
+  //   /** Constructor defining the RecVertex by its 3D position
+  //    *  and position uncertainty, its associated tracks, its chi-squared
+  //    *  and its number of degrees of freedom, and the track weights.
+  //    *  The ndf can be a float.
+  //    */
+  //   TransientVertex(const VertexState & state,
+  // 		    const std::vector<reco::TransientTrack> & tracks, float chi2, float ndf,
+  // 		    const reco::TransientTrackToFloatMap & weightMap);
 
   /** Access methods
    */
-  VertexState const & vertexState() const { return theVertexState; }
+  VertexState const& vertexState() const { return theVertexState; }
   GlobalPoint position() const { return theVertexState.position(); }
-  GlobalError positionError() const { return theVertexState.is4D() ? theVertexState.error4D() : theVertexState.error(); }
+  GlobalError positionError() const {
+    return theVertexState.is4D() ? theVertexState.error4D() : theVertexState.error();
+  }
   GlobalPoint priorPosition() const { return thePriorVertexState.position(); }
-  GlobalError priorError() const { return thePriorVertexState.is4D() ? thePriorVertexState.error4D() : thePriorVertexState.error(); }
-  double time() const { return theVertexState.time(); } 
+  GlobalError priorError() const {
+    return thePriorVertexState.is4D() ? thePriorVertexState.error4D() : thePriorVertexState.error();
+  }
+  double time() const { return theVertexState.time(); }
   double timeError() const { return theVertexState.timeError(); }
   double priorTime() const { return thePriorVertexState.time(); }
   double priorTimeError() const { return thePriorVertexState.timeError(); }
   bool hasPrior() const { return withPrior; }
 
-//   /** Implements method of abstract Vertex.
-//    *  Returns track pointer container by value
-//    */
-//   Vertex::TrackPtrContainer tracks() const;
+  //   /** Implements method of abstract Vertex.
+  //    *  Returns track pointer container by value
+  //    */
+  //   Vertex::TrackPtrContainer tracks() const;
 
   float totalChiSquared() const { return theChi2; }
-  float normalisedChiSquared() const {
-    return totalChiSquared() / degreesOfFreedom();
-  }
+  float normalisedChiSquared() const { return totalChiSquared() / degreesOfFreedom(); }
   float degreesOfFreedom() const { return theNDF; }
 
   /** Returns true if vertex is valid.
    *  An invalid RecVertex is created e.g. when vertex fitting fails.
    */
-  bool isValid() const {
-    return vertexValid;
-  }
+  bool isValid() const { return vertexValid; }
 
   /** Access to the original tracks used to make the vertex.
    *  Returns track container by value.
    */
-  std::vector<reco::TransientTrack> const & originalTracks() const {
-    return theOriginalTracks;
-  }
-
+  std::vector<reco::TransientTrack> const& originalTracks() const { return theOriginalTracks; }
 
   /**
    * Returns true if at for at least one of the original tracks,
@@ -175,37 +205,32 @@ public:
    */
   bool hasRefittedTracks() const { return withRefittedTracks; }
 
-
   /** Access to the refitted tracks used to make the vertex.
    *  Returns track container by value.
    */
-  std::vector<reco::TransientTrack> const &  refittedTracks() const {
-    return theRefittedTracks;
-  }
+  std::vector<reco::TransientTrack> const& refittedTracks() const { return theRefittedTracks; }
 
   /**
    * Returns the original track which corresponds to a particular refitted Track
    * Throws an exception if now refitted tracks are stored ot the track is not found in the list
    */
 
-  reco::TransientTrack originalTrack(const reco::TransientTrack & refTrack) const;
+  reco::TransientTrack originalTrack(const reco::TransientTrack& refTrack) const;
 
   /**
    * Returns the refitted track which corresponds to a particular original Track
    * Throws an exception if now refitted tracks are stored ot the track is not found in the list
    */
-  reco::TransientTrack refittedTrack(const reco::TransientTrack & track) const;
-
+  reco::TransientTrack refittedTrack(const reco::TransientTrack& track) const;
 
   /** Method to set the refitted tracks used to make the vertex.
    */
-  void refittedTracks(const std::vector<reco::TransientTrack> & refittedTracks);
+  void refittedTracks(const std::vector<reco::TransientTrack>& refittedTracks);
 
   /**
    * Returns true if the track-weights are available.
    */
   bool hasTrackWeight() const { return theWeightMapIsAvailable; }
-
 
   /**
    *   Returns the weight with which a track has been used in the fit.
@@ -214,11 +239,11 @@ public:
    *   If this information has not been provided at construction, a weight of
    *   1.0 is assumed for all tracks used and present in the originalTracks() std::vector.
    */
-  float trackWeight(const reco::TransientTrack & track) const;
+  float trackWeight(const reco::TransientTrack& track) const;
 
   TransientTrackToFloatMap weightMap() const { return theWeightMap; }
 
-  void weightMap(const TransientTrackToFloatMap & theMap);
+  void weightMap(const TransientTrackToFloatMap& theMap);
 
   /**
    * Returns true if the Track-to-track covariance matrices have been calculated.
@@ -230,24 +255,20 @@ public:
    *   In case these do not exist, or one of the tracks does not belong to the
    *   vertex, an exception is thrown.
    */
-  AlgebraicMatrix33 tkToTkCovariance(const reco::TransientTrack& t1, 
-  				const reco::TransientTrack& t2) const;
-  void tkToTkCovariance(const TTtoTTmap &covMap);
+  AlgebraicMatrix33 tkToTkCovariance(const reco::TransientTrack& t1, const reco::TransientTrack& t2) const;
+  void tkToTkCovariance(const TTtoTTmap& covMap);
 
   operator reco::Vertex() const;
   operator reco::VertexCompositePtrCandidate() const;
 
 private:
-
-
   mutable VertexState thePriorVertexState;
   mutable VertexState theVertexState;
 
-//   void addTracks(const std::vector<reco::TransientTrack> & tracks);
+  //   void addTracks(const std::vector<reco::TransientTrack> & tracks);
 
   std::vector<reco::TransientTrack> theOriginalTracks;
   std::vector<reco::TransientTrack> theRefittedTracks;
-
 
   float theChi2;
   float theNDF;
@@ -256,7 +277,6 @@ private:
   bool withRefittedTracks;
   TTtoTTmap theCovMap;
   TransientTrackToFloatMap theWeightMap;
-
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/VertexException.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexException.h
@@ -12,9 +12,10 @@
 class VertexException : public std::exception {
 public:
   VertexException() throw() {}
-  VertexException( const std::string& message) throw() : theMessage(message) {}
+  VertexException(const std::string& message) throw() : theMessage(message) {}
   ~VertexException() throw() override {}
-  const char* what() const throw() override { return theMessage.c_str();}
+  const char* what() const throw() override { return theMessage.c_str(); }
+
 private:
   std::string theMessage;
 };

--- a/RecoVertex/VertexPrimitives/interface/VertexFitter.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexFitter.h
@@ -18,69 +18,62 @@
 
 template <unsigned int N>
 class VertexFitter {
-
 public:
-
   VertexFitter() {}
 
   virtual ~VertexFitter() {}
 
   /** Fit vertex out of a set of TransientTracks
    */
-  virtual CachingVertex<N> 
-  vertex(const std::vector<reco::TransientTrack> & tracks) const = 0;
+  virtual CachingVertex<N> vertex(const std::vector<reco::TransientTrack>& tracks) const = 0;
 
   /** Fit vertex out of a set of VertexTracks. For the first iteration, the already 
    * linearized track will be used.
    */
-  virtual CachingVertex<N> 
-  vertex(const std::vector<typename CachingVertex<N>::RefCountedVertexTrack > & tracks) const = 0;
-  
+  virtual CachingVertex<N> vertex(const std::vector<typename CachingVertex<N>::RefCountedVertexTrack>& tracks) const = 0;
+
   /** Same as above, only now also the
    * BeamSpot constraint is provided.
    */
-  virtual CachingVertex<N> 
-  vertex(const std::vector<typename CachingVertex<N>::RefCountedVertexTrack > & tracks, const reco::BeamSpot & spot ) const = 0;
-
+  virtual CachingVertex<N> vertex(const std::vector<typename CachingVertex<N>::RefCountedVertexTrack>& tracks,
+                                  const reco::BeamSpot& spot) const = 0;
 
   /** Fit vertex out of a set of TransientTracks. 
    *  The specified point will be used as linearization point, but will NOT be used as prior.
    */
-  virtual CachingVertex<N> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, const GlobalPoint& linPoint) const = 0;
+  virtual CachingVertex<N> vertex(const std::vector<reco::TransientTrack>& tracks,
+                                  const GlobalPoint& linPoint) const = 0;
 
   /** Fit vertex out of a set of TransientTracks. 
    *  Uses the specified point as both the linearization point AND as prior
    *  estimate of the vertex position. The error is used for the 
    *  weight of the prior estimate.
    */
-  virtual CachingVertex<N> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, const GlobalPoint& priorPos,
-  	 const GlobalError& priorError) const = 0;
+  virtual CachingVertex<N> vertex(const std::vector<reco::TransientTrack>& tracks,
+                                  const GlobalPoint& priorPos,
+                                  const GlobalError& priorError) const = 0;
 
   /** Fit vertex out of a set of TransientTracks. 
    *  The specified BeamSpot will be used as priot, but NOT for the linearization.
    * The specified LinearizationPointFinder will be used to find the linearization point.
    */
-  virtual CachingVertex<N> 
-  vertex(const std::vector<reco::TransientTrack> & tracks, const reco::BeamSpot& beamSpot) const = 0;
+  virtual CachingVertex<N> vertex(const std::vector<reco::TransientTrack>& tracks,
+                                  const reco::BeamSpot& beamSpot) const = 0;
 
   /** Fit vertex out of a set of VertexTracks.
    *  Uses the specified point and error as the prior estimate of the vertex.
    *  This position is NOT used to relinearize the tracks.
    */
-  virtual CachingVertex<N> 
-  vertex(const std::vector<typename CachingVertex<N>::RefCountedVertexTrack > & tracks, 
-	 const GlobalPoint& priorPos,
-	 const GlobalError& priorError) const = 0;
+  virtual CachingVertex<N> vertex(const std::vector<typename CachingVertex<N>::RefCountedVertexTrack>& tracks,
+                                  const GlobalPoint& priorPos,
+                                  const GlobalError& priorError) const = 0;
 
   /** Fit vertex out of a VertexSeed
    */
-//   virtual CachingVertex<N> 
-//   vertex(const RefCountedVertexSeed vtxSeed) const = 0;
+  //   virtual CachingVertex<N>
+  //   vertex(const RefCountedVertexSeed vtxSeed) const = 0;
 
-  virtual VertexFitter * clone() const = 0;
-
+  virtual VertexFitter* clone() const = 0;
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/VertexReconstructor.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexReconstructor.h
@@ -11,25 +11,20 @@
  */
 
 class VertexReconstructor {
-
 public:
-
   VertexReconstructor() {}
   virtual ~VertexReconstructor() {}
 
   /** Reconstruct vertices
    */
-  virtual std::vector<TransientVertex> 
-    vertices(const std::vector<reco::TransientTrack> &) const = 0; 
+  virtual std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &) const = 0;
 
   /** Reconstruct vertices, exploiting the beamspot constraint
    *  for the primary vertex
    */
-  virtual std::vector<TransientVertex> 
-    vertices( const std::vector<reco::TransientTrack> & t, const 
-              reco::BeamSpot & ) const
-  {
-    return vertices ( t );
+  virtual std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &t,
+                                                const reco::BeamSpot &) const {
+    return vertices(t);
   }
 
   /** Reconstruct vertices, but exploit the fact that you know
@@ -41,16 +36,13 @@ public:
    *  tracks are subjected to pattern recognition.
    *  \paramname spot A beamspot constraint is mandatory in this method.
    */
-  virtual std::vector<TransientVertex>
-    vertices( const std::vector<reco::TransientTrack> & primaries,
-        const std::vector<reco::TransientTrack> & tracks,
-        const reco::BeamSpot & spot ) const 
-  {
-    return vertices ( tracks, spot );
+  virtual std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &primaries,
+                                                const std::vector<reco::TransientTrack> &tracks,
+                                                const reco::BeamSpot &spot) const {
+    return vertices(tracks, spot);
   }
 
-  virtual VertexReconstructor * clone() const = 0;
-
+  virtual VertexReconstructor *clone() const = 0;
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/VertexSmoothedChiSquaredEstimator.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexSmoothedChiSquaredEstimator.h
@@ -12,9 +12,7 @@
 
 template <unsigned int N>
 class VertexSmoothedChiSquaredEstimator {
-
 public:
-
   typedef typename CachingVertex<N>::RefCountedVertexTrack RefCountedVertexTrack;
   typedef typename std::pair<bool, double> BDpair;
 
@@ -22,10 +20,8 @@ public:
   virtual ~VertexSmoothedChiSquaredEstimator() {}
 
   virtual BDpair estimate(const CachingVertex<N> &) const = 0;
-  
-  virtual VertexSmoothedChiSquaredEstimator<N> * clone() const = 0; 
-  
 
+  virtual VertexSmoothedChiSquaredEstimator<N> *clone() const = 0;
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/VertexSmoother.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexSmoother.h
@@ -1,9 +1,7 @@
 #ifndef _VertexSmoother_H_
 #define _VertexSmoother_H_
 
-
 #include "RecoVertex/VertexPrimitives/interface/CachingVertex.h"
-
 
 /**
  * Pure abstract base class for vertex smoothers 
@@ -13,22 +11,19 @@
 
 template <unsigned int N>
 class VertexSmoother {
-
 public:
-
   VertexSmoother() {}
   virtual ~VertexSmoother() {}
-  
+
   /**
    *  Smoothing method
    */
-  virtual CachingVertex<N> smooth(const CachingVertex<N> & vertex) const = 0;
+  virtual CachingVertex<N> smooth(const CachingVertex<N>& vertex) const = 0;
 
   /**
    * Clone method 
    */
-  virtual VertexSmoother * clone() const = 0; 
-
+  virtual VertexSmoother* clone() const = 0;
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/VertexState.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexState.h
@@ -10,129 +10,89 @@
  * on demand to improve performance.
  */
 
-class VertexState final : private  BasicVertexState::Proxy {
-  
-  using Base =  BasicVertexState::Proxy;
-  using BSVS =  BasicSingleVertexState;
- public:
-  VertexState(){}
-  VertexState(VertexState const&) = default; 
-  VertexState(VertexState &&) = default;
-  VertexState & operator=(const VertexState&) = default;
-  VertexState & operator=(VertexState&&) = default;
-  
+class VertexState final : private BasicVertexState::Proxy {
+  using Base = BasicVertexState::Proxy;
+  using BSVS = BasicSingleVertexState;
+
+public:
+  VertexState() {}
+  VertexState(VertexState const&) = default;
+  VertexState(VertexState&&) = default;
+  VertexState& operator=(const VertexState&) = default;
+  VertexState& operator=(VertexState&&) = default;
+
   // template<typename... Args>
   //  VertexState(Args && ...args) :
   //  Base ( new BSVS ( std::forward<Args>(args)...)){}
-  
-  explicit VertexState(BasicVertexState* p) : 
-    Base(p) {}    
-  
-  explicit VertexState(const reco::BeamSpot& beamSpot) :
-    Base ( new BSVS ( GlobalPoint(Basic3DVector<float> (beamSpot.position())), 
-		    GlobalError(beamSpot.rotatedCovariance3D()), 1.0)) {}
-  
-  
-  VertexState(const GlobalPoint & pos, 
-	      const GlobalError & posErr, 
-	      const double & weightInMix= 1.0) :
-    Base ( new BSVS (pos, posErr, weightInMix)) {}
-  
-  VertexState(const GlobalPoint & pos, 
-	      const GlobalWeight & posWeight, 
-	      const double & weightInMix= 1.0) :
-    Base ( new BSVS (pos, posWeight, weightInMix)) {}
-  
-  VertexState(const AlgebraicVector3 & weightTimesPosition,
-	      const GlobalWeight & posWeight, 
-	      const double & weightInMix= 1.0) :
-    Base ( new BSVS (weightTimesPosition, posWeight, weightInMix)) {}
-      
+
+  explicit VertexState(BasicVertexState* p) : Base(p) {}
+
+  explicit VertexState(const reco::BeamSpot& beamSpot)
+      : Base(new BSVS(
+            GlobalPoint(Basic3DVector<float>(beamSpot.position())), GlobalError(beamSpot.rotatedCovariance3D()), 1.0)) {
+  }
+
+  VertexState(const GlobalPoint& pos, const GlobalError& posErr, const double& weightInMix = 1.0)
+      : Base(new BSVS(pos, posErr, weightInMix)) {}
+
+  VertexState(const GlobalPoint& pos, const GlobalWeight& posWeight, const double& weightInMix = 1.0)
+      : Base(new BSVS(pos, posWeight, weightInMix)) {}
+
+  VertexState(const AlgebraicVector3& weightTimesPosition,
+              const GlobalWeight& posWeight,
+              const double& weightInMix = 1.0)
+      : Base(new BSVS(weightTimesPosition, posWeight, weightInMix)) {}
+
   // with time
-  VertexState(const GlobalPoint & pos, const double time,
-	      const GlobalError & posTimeErr,
-	      const double & weightInMix = 1.0) :
-    Base ( new BSVS (pos, time, posTimeErr, weightInMix)) {}
+  VertexState(const GlobalPoint& pos, const double time, const GlobalError& posTimeErr, const double& weightInMix = 1.0)
+      : Base(new BSVS(pos, time, posTimeErr, weightInMix)) {}
 
-  VertexState(const GlobalPoint & pos, const double time,
-	      const GlobalWeight & posTimeWeight,
-	      const double & weightInMix = 1.0) :
-    Base ( new BSVS (pos, time, posTimeWeight, weightInMix)) {}
-  
-  VertexState(const AlgebraicVector4 & weightTimesPosition,
-	      const GlobalWeight & posTimeWeight,
-	      const double & weightInMix = 1.0) :
-    Base ( new BSVS (weightTimesPosition, posTimeWeight, weightInMix)) {}
-  
-  
+  VertexState(const GlobalPoint& pos,
+              const double time,
+              const GlobalWeight& posTimeWeight,
+              const double& weightInMix = 1.0)
+      : Base(new BSVS(pos, time, posTimeWeight, weightInMix)) {}
+
+  VertexState(const AlgebraicVector4& weightTimesPosition,
+              const GlobalWeight& posTimeWeight,
+              const double& weightInMix = 1.0)
+      : Base(new BSVS(weightTimesPosition, posTimeWeight, weightInMix)) {}
+
   //3D covariance matrices (backwards compatible)
-  GlobalPoint position() const
-  {
-    return data().position();
-  }
+  GlobalPoint position() const { return data().position(); }
 
-  GlobalError error() const
-  {
-    return data().error();
-  }
+  GlobalError error() const { return data().error(); }
 
   // with time, full cov
-  GlobalError error4D() const
-  {
-    return data().error4D();
-  }
+  GlobalError error4D() const { return data().error4D(); }
 
-  GlobalWeight weight() const
-  {
-    return data().weight();
-  }
+  GlobalWeight weight() const { return data().weight(); }
 
-  GlobalWeight weight4D() const
-  {
-    return data().weight4D();
-  }
+  GlobalWeight weight4D() const { return data().weight4D(); }
 
-  double time() const {
-    return data().time();
-  }
+  double time() const { return data().time(); }
 
-  double timeError() const {
-    return data().timeError();
-  }
-  
-  AlgebraicVector3 weightTimesPosition() const
-  {
-    return data().weightTimesPosition();
-  }
+  double timeError() const { return data().timeError(); }
 
-  AlgebraicVector4 weightTimesPosition4D() const 
-  {
-    return data().weightTimesPosition4D();
-  }
+  AlgebraicVector3 weightTimesPosition() const { return data().weightTimesPosition(); }
 
-  double weightInMixture() const
-  {
-    return data().weightInMixture();
-  }
+  AlgebraicVector4 weightTimesPosition4D() const { return data().weightTimesPosition4D(); }
+
+  double weightInMixture() const { return data().weightInMixture(); }
 
   /** conversion to VertexSeed
    */
-//   RefCountedVertexSeed seedWithoutTracks() const
-//   {
-//     return data().seedWithoutTracks();
-//   }
+  //   RefCountedVertexSeed seedWithoutTracks() const
+  //   {
+  //     return data().seedWithoutTracks();
+  //   }
 
-  std::vector<VertexState> components() const
-  {
-    return data().components();
-  }
+  std::vector<VertexState> components() const { return data().components(); }
 
   /// Make the ReferenceCountingProxy method to check validity public
-  bool isValid() const {return Base::isValid() && data().isValid();}
+  bool isValid() const { return Base::isValid() && data().isValid(); }
 
   bool is4D() const { return data().is4D(); }
-
 };
 
 #endif
-

--- a/RecoVertex/VertexPrimitives/interface/VertexTrack.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexTrack.h
@@ -6,7 +6,6 @@
 #include "RecoVertex/VertexPrimitives/interface/RefittedTrackState.h"
 #include "RecoVertex/VertexPrimitives/interface/VertexException.h"
 
-
 #define SMATRIX_USE_CONSTEXPR
 #include "Math/SMatrix.h"
 
@@ -17,42 +16,41 @@
 
 template <unsigned int N>
 class VertexTrack final : public ReferenceCounted {
-
 public:
-
-  typedef ROOT::Math::SVector<double,N> AlgebraicVectorN;
-  typedef ROOT::Math::SMatrix<double,N-2,N-2,ROOT::Math::MatRepStd<double,N-2,N-2> > AlgebraicMatrixMM;
-  typedef ROOT::Math::SMatrix<double,3,N-2,ROOT::Math::MatRepStd<double,3,N-2> > AlgebraicMatrix3M;
-  typedef ROOT::Math::SMatrix<double,N+1,N+1,ROOT::Math::MatRepSym<double,N+1> > AlgebraicSymMatrixOO;
+  typedef ROOT::Math::SVector<double, N> AlgebraicVectorN;
+  typedef ROOT::Math::SMatrix<double, N - 2, N - 2, ROOT::Math::MatRepStd<double, N - 2, N - 2> > AlgebraicMatrixMM;
+  typedef ROOT::Math::SMatrix<double, 3, N - 2, ROOT::Math::MatRepStd<double, 3, N - 2> > AlgebraicMatrix3M;
+  typedef ROOT::Math::SMatrix<double, N + 1, N + 1, ROOT::Math::MatRepSym<double, N + 1> > AlgebraicSymMatrixOO;
 
   //typedef ReferenceCountingPointer<VertexTrack<N> > RefCountedVertexTrack;
   typedef ReferenceCountingPointer<LinearizedTrackState<N> > RefCountedLinearizedTrackState;
   typedef ReferenceCountingPointer<RefittedTrackState<N> > RefCountedRefittedTrackState;
 
   /** Constructor with the linearized track data, vertex seed and weight
-   */     
-  VertexTrack(RefCountedLinearizedTrackState lt, 
-	      VertexState v, 
-	      float weight);
+   */
+  VertexTrack(RefCountedLinearizedTrackState lt, VertexState v, float weight);
 
   /** Constructor with the linearized track data, vertex seed and weight
    *  and state at vertex, constrained by vertex
-   */     
-  VertexTrack(RefCountedLinearizedTrackState lt, 
-	      VertexState v, 
-	      float weight, const RefCountedRefittedTrackState & refittedState,
-	      float smoothedChi2);
+   */
+  VertexTrack(RefCountedLinearizedTrackState lt,
+              VertexState v,
+              float weight,
+              const RefCountedRefittedTrackState& refittedState,
+              float smoothedChi2);
 
   /** Constructor with the linearized track data, vertex seed and weight
    *  and state and covariance at vertex, constrained by vertex
-   */     
-  VertexTrack(RefCountedLinearizedTrackState lt, 
-	      VertexState v, 
-	      float weight, const RefCountedRefittedTrackState & refittedState,
-	      float smoothedChi2, const AlgebraicSymMatrixOO & fullCov);
+   */
+  VertexTrack(RefCountedLinearizedTrackState lt,
+              VertexState v,
+              float weight,
+              const RefCountedRefittedTrackState& refittedState,
+              float smoothedChi2,
+              const AlgebraicSymMatrixOO& fullCov);
 
   /** Access methods
-   */ 
+   */
   RefCountedLinearizedTrackState linearizedTrack() const { return theLinTrack; }
   VertexState vertexState() const { return theVertexState; }
   float weight() const { return theWeight; }
@@ -68,25 +66,24 @@ public:
 
   float smoothedChi2() const { return smoothedChi2_; }
 
-
   /** Track state with vertex constraint
    */
-  RefCountedRefittedTrackState refittedState() const { 
-    if (!refittedStateAvailable()) { 
-      throw VertexException("VertexTrack::refitted state not available"); 
+  RefCountedRefittedTrackState refittedState() const {
+    if (!refittedStateAvailable()) {
+      throw VertexException("VertexTrack::refitted state not available");
     }
     return theRefittedState;
   }
 
-//   /** Track to vertex covariance 
-//    */   
-//   AlgebraicMatrix3M tkToVtxCovariance() const;
+  //   /** Track to vertex covariance
+  //    */
+  //   AlgebraicMatrix3M tkToVtxCovariance() const;
 
   /** Track to vertex covariance 
-   */   
+   */
   AlgebraicSymMatrixOO fullCovariance() const {
     if (!tkToVertexCovarianceAvailable()) {
-      throw VertexException("VertexTrack::track to vertex covariance not available"); 
+      throw VertexException("VertexTrack::track to vertex covariance not available");
     }
     return fullCovariance_;
   }
@@ -94,38 +91,34 @@ public:
   /** Equality for finding a VertexTrack in a container
    *  Compares the RecTrack addresses
    */
-  bool operator==(const VertexTrack<N> & data) const
-  {
-    return ((*data.linearizedTrack()) == (*linearizedTrack()));
-  }
+  bool operator==(const VertexTrack<N>& data) const { return ((*data.linearizedTrack()) == (*linearizedTrack())); }
 
   /** Method helping Kalman vertex fit
    */
   AlgebraicVectorN refittedParamFromEquation() const;
- 
 
 private:
-
   RefCountedLinearizedTrackState theLinTrack;
   VertexState theVertexState;
   float theWeight;
   bool stAvailable;
   bool covAvailable;
   RefCountedRefittedTrackState theRefittedState;
-  AlgebraicSymMatrixOO  fullCovariance_;
-  ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<double,6> > b6;
-  ROOT::Math::SMatrix<double,7,7,ROOT::Math::MatRepSym<double,7> > b7;
+  AlgebraicSymMatrixOO fullCovariance_;
+  ROOT::Math::SMatrix<double, 6, 6, ROOT::Math::MatRepSym<double, 6> > b6;
+  ROOT::Math::SMatrix<double, 7, 7, ROOT::Math::MatRepSym<double, 7> > b7;
   float smoothedChi2_;
 };
 
 template <unsigned int N>
 class VertexTrackEqual {
-  public:
-    typedef ReferenceCountingPointer<VertexTrack<N> > RefCountedVertexTrack;
-    VertexTrackEqual( const RefCountedVertexTrack & t) : track_( t ) { }
-    bool operator()( const RefCountedVertexTrack & t ) const { return t->operator==(*track_);}
-  private:
-    const RefCountedVertexTrack & track_;
+public:
+  typedef ReferenceCountingPointer<VertexTrack<N> > RefCountedVertexTrack;
+  VertexTrackEqual(const RefCountedVertexTrack& t) : track_(t) {}
+  bool operator()(const RefCountedVertexTrack& t) const { return t->operator==(*track_); }
+
+private:
+  const RefCountedVertexTrack& track_;
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/VertexTrackCompatibilityEstimator.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexTrackCompatibilityEstimator.h
@@ -13,34 +13,31 @@
 
 template <unsigned int N>
 class VertexTrackCompatibilityEstimator {
- 
 public:
-
   typedef typename CachingVertex<N>::RefCountedVertexTrack RefCountedVertexTrack;
   typedef typename VertexTrack<N>::RefCountedLinearizedTrackState RefCountedLinearizedTrackState;
-  typedef typename std::pair <bool, double> BDpair;
+  typedef typename std::pair<bool, double> BDpair;
 
-  VertexTrackCompatibilityEstimator(){}
-  virtual ~VertexTrackCompatibilityEstimator(){}
-  
+  VertexTrackCompatibilityEstimator() {}
+  virtual ~VertexTrackCompatibilityEstimator() {}
+
   /**
    * Methods giving back the compatibility estimation
    */
-  virtual BDpair estimate(const CachingVertex<N> & v, 
-			  const RefCountedLinearizedTrackState track,
-			  unsigned int hint=UINT_MAX) const = 0;
+  virtual BDpair estimate(const CachingVertex<N>& v,
+                          const RefCountedLinearizedTrackState track,
+                          unsigned int hint = UINT_MAX) const = 0;
 
-  virtual BDpair estimate(const reco::Vertex & v, 
-			 const reco::TransientTrack & track) const = 0;
+  virtual BDpair estimate(const reco::Vertex& v, const reco::TransientTrack& track) const = 0;
 
   // obsolete ?
-  virtual BDpair estimate(const CachingVertex<N> & v, 
-			  const RefCountedVertexTrack track, unsigned int hint=UINT_MAX) const = 0;
+  virtual BDpair estimate(const CachingVertex<N>& v,
+                          const RefCountedVertexTrack track,
+                          unsigned int hint = UINT_MAX) const = 0;
   /**
    * Clone method 
    */
-  virtual VertexTrackCompatibilityEstimator<N> * clone() const = 0; 
-  
+  virtual VertexTrackCompatibilityEstimator<N>* clone() const = 0;
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/VertexTrackUpdator.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexTrackUpdator.h
@@ -10,19 +10,15 @@
 
 template <unsigned int N>
 class VertexTrackUpdator {
-
 public:
-
   /**
    * Computes the constrained track parameters
    */
-  virtual typename CachingVertex<N>::RefCountedVertexTrack 
-	update(const CachingVertex<N> & v, 
-	typename CachingVertex<N>::RefCountedVertexTrack t) const = 0;
+  virtual typename CachingVertex<N>::RefCountedVertexTrack update(
+      const CachingVertex<N>& v, typename CachingVertex<N>::RefCountedVertexTrack t) const = 0;
 
-  virtual VertexTrackUpdator * clone() const = 0;
-  virtual ~VertexTrackUpdator() {};
-
+  virtual VertexTrackUpdator* clone() const = 0;
+  virtual ~VertexTrackUpdator(){};
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/interface/VertexUpdator.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexUpdator.h
@@ -10,31 +10,27 @@
 
 template <unsigned int N>
 class VertexUpdator {
-
 public:
-  
   typedef typename CachingVertex<N>::RefCountedVertexTrack RefCountedVertexTrack;
 
   /**
    * Default Constructor
-   */  
-   VertexUpdator() {}
-    
-   virtual ~VertexUpdator() {}
-    
+   */
+  VertexUpdator() {}
+
+  virtual ~VertexUpdator() {}
+
   /**
    * Method updating the vertex, with the information contained 
    * in the track.
    */
-  virtual CachingVertex<N> add(const CachingVertex<N> & v,
-	const typename CachingVertex<N>::RefCountedVertexTrack  t) const = 0;
+  virtual CachingVertex<N> add(const CachingVertex<N>& v,
+                               const typename CachingVertex<N>::RefCountedVertexTrack t) const = 0;
 
-  virtual CachingVertex<N> remove(const CachingVertex<N> & v,
-	const typename CachingVertex<N>::RefCountedVertexTrack  t) const = 0;
+  virtual CachingVertex<N> remove(const CachingVertex<N>& v,
+                                  const typename CachingVertex<N>::RefCountedVertexTrack t) const = 0;
 
-  virtual VertexUpdator * clone() const = 0;  
-
+  virtual VertexUpdator* clone() const = 0;
 };
-
 
 #endif

--- a/RecoVertex/VertexPrimitives/src/BasicSingleVertexState.cc
+++ b/RecoVertex/VertexPrimitives/src/BasicSingleVertexState.cc
@@ -7,232 +7,268 @@ namespace {
 }
 
 BasicSingleVertexState::BasicSingleVertexState()
-  : thePos(GlobalPoint(0, 0, 0)), 
-    theTime(dNaN),
-    theErr(AlgebraicSymMatrix44()),  
-    theWeight(AlgebraicSymMatrix44()), 
-    theWeightTimesPos(AlgebraicVector4()), theWeightInMix(0.) , 
-    thePosAvailable(false), theTimeAvailable(false), theErrAvailable(false),theWeightAvailable(false), theWeightTimesPosAvailable(false),
-    valid(false), vertexIs4D(false)
-{}
+    : thePos(GlobalPoint(0, 0, 0)),
+      theTime(dNaN),
+      theErr(AlgebraicSymMatrix44()),
+      theWeight(AlgebraicSymMatrix44()),
+      theWeightTimesPos(AlgebraicVector4()),
+      theWeightInMix(0.),
+      thePosAvailable(false),
+      theTimeAvailable(false),
+      theErrAvailable(false),
+      theWeightAvailable(false),
+      theWeightTimesPosAvailable(false),
+      valid(false),
+      vertexIs4D(false) {}
 
-BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint & pos,
-			     const GlobalError & posErr,
-			     const double & weightInMix)
-  : thePos(pos), 
-    theTime(dNaN),
-    theErr(posErr), 
-    theWeight(AlgebraicSymMatrix44()), 
-    theWeightTimesPos(AlgebraicVector4()),
-    theWeightInMix(weightInMix),
-    thePosAvailable(true), theTimeAvailable(false), theErrAvailable(true),theWeightAvailable(false), theWeightTimesPosAvailable(false),
-    valid(true), vertexIs4D(false)
-{}
+BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint& pos,
+                                               const GlobalError& posErr,
+                                               const double& weightInMix)
+    : thePos(pos),
+      theTime(dNaN),
+      theErr(posErr),
+      theWeight(AlgebraicSymMatrix44()),
+      theWeightTimesPos(AlgebraicVector4()),
+      theWeightInMix(weightInMix),
+      thePosAvailable(true),
+      theTimeAvailable(false),
+      theErrAvailable(true),
+      theWeightAvailable(false),
+      theWeightTimesPosAvailable(false),
+      valid(true),
+      vertexIs4D(false) {}
 
+BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint& pos,
+                                               const GlobalWeight& posWeight,
+                                               const double& weightInMix)
+    : thePos(pos),
+      theTime(dNaN),
+      theErr(AlgebraicSymMatrix44()),
+      theWeight(posWeight),
+      theWeightTimesPos(AlgebraicVector4()),
+      theWeightInMix(weightInMix),
+      thePosAvailable(true),
+      theTimeAvailable(false),
+      theErrAvailable(false),
+      theWeightAvailable(true),
+      theWeightTimesPosAvailable(false),
+      valid(true),
+      vertexIs4D(false) {}
 
-BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint & pos,
-			     const GlobalWeight & posWeight,
-			     const double & weightInMix)
-  : thePos(pos),
-    theTime(dNaN),
-    theErr(AlgebraicSymMatrix44()),
-    theWeight(posWeight),
-    theWeightTimesPos(AlgebraicVector4()), 
-    theWeightInMix(weightInMix),
-    thePosAvailable(true), theTimeAvailable(false), theErrAvailable(false),theWeightAvailable(true), theWeightTimesPosAvailable(false),
-    valid(true), vertexIs4D(false)
-{}
-
-
-BasicSingleVertexState::BasicSingleVertexState(const AlgebraicVector3 & weightTimesPosition,
-			     const GlobalWeight & posWeight,
-			     const double & weightInMix)
-  : thePos(GlobalPoint(0, 0, 0)),
-    theTime(dNaN),
-    theErr(AlgebraicSymMatrix44()), 
-    theWeight(posWeight), 
-    theWeightTimesPos(weightTimesPosition[0], weightTimesPosition[1], weightTimesPosition[2], 0), 
-    theWeightInMix(weightInMix),
-    thePosAvailable(false), theTimeAvailable(false), theErrAvailable(false),theWeightAvailable(true), theWeightTimesPosAvailable(true),
-    valid(true), vertexIs4D(false)
-{}
+BasicSingleVertexState::BasicSingleVertexState(const AlgebraicVector3& weightTimesPosition,
+                                               const GlobalWeight& posWeight,
+                                               const double& weightInMix)
+    : thePos(GlobalPoint(0, 0, 0)),
+      theTime(dNaN),
+      theErr(AlgebraicSymMatrix44()),
+      theWeight(posWeight),
+      theWeightTimesPos(weightTimesPosition[0], weightTimesPosition[1], weightTimesPosition[2], 0),
+      theWeightInMix(weightInMix),
+      thePosAvailable(false),
+      theTimeAvailable(false),
+      theErrAvailable(false),
+      theWeightAvailable(true),
+      theWeightTimesPosAvailable(true),
+      valid(true),
+      vertexIs4D(false) {}
 
 // no-offdiags for time
-BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint & pos,
-                                               const GlobalError & posErr,
+BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint& pos,
+                                               const GlobalError& posErr,
                                                const double time,
                                                const double timeErr,
-                                               const double & weightInMix)
-  : thePos(pos), 
-    theTime(time), 
-    theErr(posErr),
-    theWeight(AlgebraicSymMatrix44()),
-    theWeightTimesPos(AlgebraicVector4()),
-    theWeightInMix(weightInMix),
-    thePosAvailable(true), theTimeAvailable(true), theErrAvailable(true), theWeightAvailable(false), theWeightTimesPosAvailable(false),
-    valid(true), vertexIs4D(true) 
-{
+                                               const double& weightInMix)
+    : thePos(pos),
+      theTime(time),
+      theErr(posErr),
+      theWeight(AlgebraicSymMatrix44()),
+      theWeightTimesPos(AlgebraicVector4()),
+      theWeightInMix(weightInMix),
+      thePosAvailable(true),
+      theTimeAvailable(true),
+      theErrAvailable(true),
+      theWeightAvailable(false),
+      theWeightTimesPosAvailable(false),
+      valid(true),
+      vertexIs4D(true) {
   // You dumb bastard. It's not a schooner, its a sailboat.
-  GlobalError timeErrMat(0.,
-                         0.,0.,
-                         0.,0.,0.,
-                         0.,0.,0.,timeErr*timeErr);
+  GlobalError timeErrMat(0., 0., 0., 0., 0., 0., 0., 0., 0., timeErr * timeErr);
   theErr = theErr + timeErrMat;
 }
 
-
-BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint & pos,
-                                               const GlobalWeight & posWeight,
+BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint& pos,
+                                               const GlobalWeight& posWeight,
                                                const double time,
                                                const double timeWeight,
-                                               const double & weightInMix)
-  : thePos(pos), 
-    theTime(time), 
-    theErr(AlgebraicSymMatrix44()), 
-    theWeight(posWeight), 
-    theWeightTimesPos(AlgebraicVector4()), 
-    theWeightInMix(weightInMix),
-    thePosAvailable(true), theTimeAvailable(true), theErrAvailable(false), theWeightAvailable(true), theWeightTimesPosAvailable(false),
-    valid(true), vertexIs4D(true)
-{
-  GlobalWeight timeWeightMat(0.,
-                             0.,0.,
-                             0.,0.,0.,
-                             0.,0.,0.,timeWeight);
+                                               const double& weightInMix)
+    : thePos(pos),
+      theTime(time),
+      theErr(AlgebraicSymMatrix44()),
+      theWeight(posWeight),
+      theWeightTimesPos(AlgebraicVector4()),
+      theWeightInMix(weightInMix),
+      thePosAvailable(true),
+      theTimeAvailable(true),
+      theErrAvailable(false),
+      theWeightAvailable(true),
+      theWeightTimesPosAvailable(false),
+      valid(true),
+      vertexIs4D(true) {
+  GlobalWeight timeWeightMat(0., 0., 0., 0., 0., 0., 0., 0., 0., timeWeight);
   theWeight = theWeight + timeWeightMat;
 }
 
-
-BasicSingleVertexState::BasicSingleVertexState(const AlgebraicVector3 & weightTimesPosition,
-                                               const GlobalWeight & posWeight,
+BasicSingleVertexState::BasicSingleVertexState(const AlgebraicVector3& weightTimesPosition,
+                                               const GlobalWeight& posWeight,
                                                const double weightTimesTime,
                                                const double timeWeight,
-                                               const double & weightInMix)
-  : thePos(GlobalPoint(0, 0, 0)), 
-    theTime(dNaN), 
-    theErr(AlgebraicSymMatrix44()), 
-    theWeight(posWeight), 
-    theWeightTimesPos(weightTimesPosition[0],weightTimesPosition[1],weightTimesPosition[2],weightTimesTime), 
-    theWeightInMix(weightInMix),
-    thePosAvailable(false), theTimeAvailable(false), theErrAvailable(false), theWeightAvailable(true), theWeightTimesPosAvailable(true),
-    valid(true), vertexIs4D(true)
-{
-  GlobalWeight timeWeightMat(0.,
-                             0.,0.,
-                             0.,0.,0.,
-                             0.,0.,0.,timeWeight);
+                                               const double& weightInMix)
+    : thePos(GlobalPoint(0, 0, 0)),
+      theTime(dNaN),
+      theErr(AlgebraicSymMatrix44()),
+      theWeight(posWeight),
+      theWeightTimesPos(weightTimesPosition[0], weightTimesPosition[1], weightTimesPosition[2], weightTimesTime),
+      theWeightInMix(weightInMix),
+      thePosAvailable(false),
+      theTimeAvailable(false),
+      theErrAvailable(false),
+      theWeightAvailable(true),
+      theWeightTimesPosAvailable(true),
+      valid(true),
+      vertexIs4D(true) {
+  GlobalWeight timeWeightMat(0., 0., 0., 0., 0., 0., 0., 0., 0., timeWeight);
   theWeight = theWeight + timeWeightMat;
 }
 
 // off-diags for time
-BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint & pos,
+BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint& pos,
                                                const double time,
-                                               const GlobalError & posTimeErr, // fully filled 4x4 matrix
-                                               const double & weightInMix)
-  : thePos(pos), 
-    theTime(time), 
-    theErr(posTimeErr), 
-    theWeight(AlgebraicSymMatrix44()), 
-    theWeightTimesPos(AlgebraicVector4()), 
-    theWeightInMix(weightInMix),
-    thePosAvailable(true), theTimeAvailable(true), theErrAvailable(true), theWeightAvailable(false), theWeightTimesPosAvailable(false),
-    valid(true), vertexIs4D(true)
-{}
+                                               const GlobalError& posTimeErr,  // fully filled 4x4 matrix
+                                               const double& weightInMix)
+    : thePos(pos),
+      theTime(time),
+      theErr(posTimeErr),
+      theWeight(AlgebraicSymMatrix44()),
+      theWeightTimesPos(AlgebraicVector4()),
+      theWeightInMix(weightInMix),
+      thePosAvailable(true),
+      theTimeAvailable(true),
+      theErrAvailable(true),
+      theWeightAvailable(false),
+      theWeightTimesPosAvailable(false),
+      valid(true),
+      vertexIs4D(true) {}
 
-
-BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint & pos,
+BasicSingleVertexState::BasicSingleVertexState(const GlobalPoint& pos,
                                                const double time,
-                                               const GlobalWeight & posTimeWeight,
-                                               const double & weightInMix)
-  : thePos(pos), 
-    theTime(time), 
-    theErr(AlgebraicSymMatrix44()), 
-    theWeight(posTimeWeight), 
-    theWeightTimesPos(AlgebraicVector4()), 
-    theWeightInMix(weightInMix),
-    thePosAvailable(true), theTimeAvailable(true), theErrAvailable(false), theWeightAvailable(true), theWeightTimesPosAvailable(false),
-    valid(true), vertexIs4D(true)
-{}
+                                               const GlobalWeight& posTimeWeight,
+                                               const double& weightInMix)
+    : thePos(pos),
+      theTime(time),
+      theErr(AlgebraicSymMatrix44()),
+      theWeight(posTimeWeight),
+      theWeightTimesPos(AlgebraicVector4()),
+      theWeightInMix(weightInMix),
+      thePosAvailable(true),
+      theTimeAvailable(true),
+      theErrAvailable(false),
+      theWeightAvailable(true),
+      theWeightTimesPosAvailable(false),
+      valid(true),
+      vertexIs4D(true) {}
 
+BasicSingleVertexState::BasicSingleVertexState(const AlgebraicVector4& weightTimesPosition,
+                                               const GlobalWeight& posWeight,
+                                               const double& weightInMix)
+    : thePos(GlobalPoint(0, 0, 0)),
+      theTime(dNaN),
+      theErr(AlgebraicSymMatrix44()),
+      theWeight(posWeight),
+      theWeightTimesPos(weightTimesPosition),
+      theWeightInMix(weightInMix),
+      thePosAvailable(false),
+      theTimeAvailable(false),
+      theErrAvailable(false),
+      theWeightAvailable(true),
+      theWeightTimesPosAvailable(true),
+      valid(true),
+      vertexIs4D(true) {}
 
-BasicSingleVertexState::BasicSingleVertexState(const AlgebraicVector4 & weightTimesPosition,
-                                               const GlobalWeight & posWeight,
-                                               const double & weightInMix)
-  : thePos(GlobalPoint(0, 0, 0)), 
-    theTime(dNaN), 
-    theErr(AlgebraicSymMatrix44()), 
-    theWeight(posWeight), 
-    theWeightTimesPos(weightTimesPosition),
-    theWeightInMix(weightInMix),
-    thePosAvailable(false), theTimeAvailable(false), theErrAvailable(false), theWeightAvailable(true), theWeightTimesPosAvailable(true),
-    valid(true), vertexIs4D(true)
-{}
-
-GlobalPoint BasicSingleVertexState::position() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::position::invalid");
-  if (!thePosAvailable) computePosition();
+GlobalPoint BasicSingleVertexState::position() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::position::invalid");
+  if (!thePosAvailable)
+    computePosition();
   return thePos;
 }
 
-GlobalError BasicSingleVertexState::error() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::error::invalid");
-  if (!theErrAvailable) computeError();
+GlobalError BasicSingleVertexState::error() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::error::invalid");
+  if (!theErrAvailable)
+    computeError();
   return GlobalError(theErr.matrix());
 }
 
-GlobalError BasicSingleVertexState::error4D() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::error4D::invalid");
-  if (!theErrAvailable) computeError();
+GlobalError BasicSingleVertexState::error4D() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::error4D::invalid");
+  if (!theErrAvailable)
+    computeError();
   return theErr;
 }
 
 double BasicSingleVertexState::time() const {
-  if (!valid) throw VertexException("BasicSingleVertexState::time::invalid");
-  if (!theTimeAvailable) computePosition(); // time computed with position (4-vector)
-  return theTime;  
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::time::invalid");
+  if (!theTimeAvailable)
+    computePosition();  // time computed with position (4-vector)
+  return theTime;
 }
 
 double BasicSingleVertexState::timeError() const {
-  if (!valid) throw VertexException("BasicSingleVertexState::timeError::invalid");
-  if (!theTimeAvailable) computeError();
-  return std::sqrt(theErr.matrix4D()(3,3));
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::timeError::invalid");
+  if (!theTimeAvailable)
+    computeError();
+  return std::sqrt(theErr.matrix4D()(3, 3));
 }
 
-GlobalWeight BasicSingleVertexState::weight() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::weight::invalid");
-  if (!theWeightAvailable) computeWeight();
+GlobalWeight BasicSingleVertexState::weight() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::weight::invalid");
+  if (!theWeightAvailable)
+    computeWeight();
   return GlobalWeight(theWeight.matrix());
 }
 
-GlobalWeight BasicSingleVertexState::weight4D() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::weight4D::invalid");
-  if (!theWeightAvailable) computeWeight();
+GlobalWeight BasicSingleVertexState::weight4D() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::weight4D::invalid");
+  if (!theWeightAvailable)
+    computeWeight();
   return theWeight;
 }
 
-AlgebraicVector3 BasicSingleVertexState::weightTimesPosition() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::weightTimesPosition::invalid");
-  if (!theWeightTimesPosAvailable) computeWeightTimesPos();
-  return AlgebraicVector3(theWeightTimesPos[0],theWeightTimesPos[1],theWeightTimesPos[2]);
+AlgebraicVector3 BasicSingleVertexState::weightTimesPosition() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::weightTimesPosition::invalid");
+  if (!theWeightTimesPosAvailable)
+    computeWeightTimesPos();
+  return AlgebraicVector3(theWeightTimesPos[0], theWeightTimesPos[1], theWeightTimesPos[2]);
 }
 
-AlgebraicVector4 BasicSingleVertexState::weightTimesPosition4D() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::weightTimesPosition4D::invalid");
-  if (!theWeightTimesPosAvailable) computeWeightTimesPos();
-  return theWeightTimesPos;  
+AlgebraicVector4 BasicSingleVertexState::weightTimesPosition4D() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::weightTimesPosition4D::invalid");
+  if (!theWeightTimesPosAvailable)
+    computeWeightTimesPos();
+  return theWeightTimesPos;
 }
 
-
-double BasicSingleVertexState::weightInMixture() const 
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::weightInMixture::invalid");
+double BasicSingleVertexState::weightInMixture() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::weightInMixture::invalid");
   return theWeightInMix;
 }
 // RefCountedVertexSeed BasicSingleVertexState::seedWithoutTracks() const
@@ -241,60 +277,60 @@ double BasicSingleVertexState::weightInMixture() const
 //   return v;
 // }
 
-
-
-void BasicSingleVertexState::computePosition() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::computePosition::invalid");
-  AlgebraicVector4 pos = error4D().matrix4D()*weightTimesPosition4D();
+void BasicSingleVertexState::computePosition() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::computePosition::invalid");
+  AlgebraicVector4 pos = error4D().matrix4D() * weightTimesPosition4D();
   thePos = GlobalPoint(pos[0], pos[1], pos[2]);
   theTime = pos[3];
-  thePosAvailable  = true;
+  thePosAvailable = true;
   theTimeAvailable = true;
 }
 
-void BasicSingleVertexState::computeError() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::computeError::invalid");
+void BasicSingleVertexState::computeError() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::computeError::invalid");
   int ifail;
-  if( vertexIs4D ) {
+  if (vertexIs4D) {
     theErr = weight4D().matrix4D().Inverse(ifail);
-    if (ifail != 0) throw VertexException("BasicSingleVertexState::could not invert weight matrix");
+    if (ifail != 0)
+      throw VertexException("BasicSingleVertexState::could not invert weight matrix");
   } else {
     theErr = weight4D().matrix().Inverse(ifail);
-    if (ifail != 0) throw VertexException("BasicSingleVertexState::could not invert weight matrix");
+    if (ifail != 0)
+      throw VertexException("BasicSingleVertexState::could not invert weight matrix");
   }
   theErrAvailable = true;
 }
 
-
-void BasicSingleVertexState::computeWeight() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::computeWeight::invalid");
+void BasicSingleVertexState::computeWeight() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::computeWeight::invalid");
   int ifail;
-  if( vertexIs4D ) {
-    theWeight = error4D().matrix4D().Inverse(ifail);    
-    if (ifail != 0) throw VertexException("BasicSingleVertexState::could not invert error matrix");
+  if (vertexIs4D) {
+    theWeight = error4D().matrix4D().Inverse(ifail);
+    if (ifail != 0)
+      throw VertexException("BasicSingleVertexState::could not invert error matrix");
   } else {
     theWeight = error4D().matrix().Inverse(ifail);
-    if (ifail != 0) throw VertexException("BasicSingleVertexState::could not invert error matrix");
-  }  
+    if (ifail != 0)
+      throw VertexException("BasicSingleVertexState::could not invert error matrix");
+  }
   theWeightAvailable = true;
 }
 
-
-void BasicSingleVertexState::computeWeightTimesPos() const
-{
-  if (!valid) throw VertexException("BasicSingleVertexState::computeWeightTimesPos::invalid");
-  AlgebraicVector4 pos; pos(0) = position().x();
-  pos(1) = position().y(); pos(2) = position().z();
-  if ( vertexIs4D ) {
+void BasicSingleVertexState::computeWeightTimesPos() const {
+  if (!valid)
+    throw VertexException("BasicSingleVertexState::computeWeightTimesPos::invalid");
+  AlgebraicVector4 pos;
+  pos(0) = position().x();
+  pos(1) = position().y();
+  pos(2) = position().z();
+  if (vertexIs4D) {
     pos(3) = theTime;
   } else {
     pos(3) = 0.;
   }
-  theWeightTimesPos = weight4D().matrix4D()*pos;
+  theWeightTimesPos = weight4D().matrix4D() * pos;
   theWeightTimesPosAvailable = true;
 }
-
-

--- a/RecoVertex/VertexPrimitives/src/BasicVertexState.cc
+++ b/RecoVertex/VertexPrimitives/src/BasicVertexState.cc
@@ -1,10 +1,8 @@
 #include "RecoVertex/VertexPrimitives/interface/BasicVertexState.h"
 #include "RecoVertex/VertexPrimitives/interface/VertexState.h"
 
-std::vector<VertexState> 
-BasicVertexState::components() const {
+std::vector<VertexState> BasicVertexState::components() const {
   std::vector<VertexState> result;
-  result.emplace_back( const_cast<BasicVertexState*>(this));
+  result.emplace_back(const_cast<BasicVertexState*>(this));
   return result;
 }
-

--- a/RecoVertex/VertexPrimitives/src/CachingVertex.cc
+++ b/RecoVertex/VertexPrimitives/src/CachingVertex.cc
@@ -7,356 +7,408 @@
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & pos, 
-                                const GlobalError & posErr, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq) 
-  : theVertexState(pos, posErr),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), withPrior(false), 
-    theValid(true), vertexIs4D(false)
+CachingVertex<N>::CachingVertex(const GlobalPoint& pos,
+                                const GlobalError& posErr,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq)
+    : theVertexState(pos, posErr),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      withPrior(false),
+      theValid(true),
+      vertexIs4D(false)
 
 {}
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & pos, 
+CachingVertex<N>::CachingVertex(const GlobalPoint& pos,
                                 const double time,
-                                const GlobalError & posTimeErr, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq) 
-  : theVertexState(pos, time, posTimeErr),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), withPrior(false), 
-    theValid(true), vertexIs4D(true)
+                                const GlobalError& posTimeErr,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq)
+    : theVertexState(pos, time, posTimeErr),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      withPrior(false),
+      theValid(true),
+      vertexIs4D(true)
 
-{}
-
-
-//to be removed
-template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & pos, 
-                                const GlobalWeight & posWeight, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq) 
-  : theVertexState(pos, posWeight),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), withPrior(false), 
-    theValid(true), vertexIs4D(false)
 {}
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & pos, 
+CachingVertex<N>::CachingVertex(const GlobalPoint& pos,
+                                const GlobalWeight& posWeight,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq)
+    : theVertexState(pos, posWeight),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      withPrior(false),
+      theValid(true),
+      vertexIs4D(false) {}
+
+//to be removed
+template <unsigned int N>
+CachingVertex<N>::CachingVertex(const GlobalPoint& pos,
                                 const double time,
-                                const GlobalWeight & posTimeWeight, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq) 
-  : theVertexState(pos, time, posTimeWeight),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), withPrior(false), 
-    theValid(true), vertexIs4D(true)
-{}
-
+                                const GlobalWeight& posTimeWeight,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq)
+    : theVertexState(pos, time, posTimeWeight),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      withPrior(false),
+      theValid(true),
+      vertexIs4D(true) {}
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const AlgebraicVector3 & weightTimesPosition, 
-                                const GlobalWeight & posWeight, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
+CachingVertex<N>::CachingVertex(const AlgebraicVector3& weightTimesPosition,
+                                const GlobalWeight& posWeight,
+                                const std::vector<RefCountedVertexTrack>& tks,
                                 float totalChiSq)
-  : theVertexState(weightTimesPosition, posWeight),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), withPrior(false), 
-    theValid(true), vertexIs4D(false)
-{}
+    : theVertexState(weightTimesPosition, posWeight),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      withPrior(false),
+      theValid(true),
+      vertexIs4D(false) {}
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const AlgebraicVector4 & weightTimesPosition, 
-                                const GlobalWeight & posWeight, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
+CachingVertex<N>::CachingVertex(const AlgebraicVector4& weightTimesPosition,
+                                const GlobalWeight& posWeight,
+                                const std::vector<RefCountedVertexTrack>& tks,
                                 float totalChiSq)
-  : theVertexState(weightTimesPosition, posWeight),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), withPrior(false), 
-    theValid(true), vertexIs4D(false)
-{}
+    : theVertexState(weightTimesPosition, posWeight),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      withPrior(false),
+      theValid(true),
+      vertexIs4D(false) {}
 
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const VertexState & aVertexState, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
+CachingVertex<N>::CachingVertex(const VertexState& aVertexState,
+                                const std::vector<RefCountedVertexTrack>& tks,
                                 float totalChiSq)
-  : theVertexState(aVertexState),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), withPrior(false), 
-    theValid(true),
-    vertexIs4D( aVertexState.is4D() )
-{}
-
+    : theVertexState(aVertexState),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      withPrior(false),
+      theValid(true),
+      vertexIs4D(aVertexState.is4D()) {}
 
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const VertexState & aVertexState,
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq, 
-                                const TrackToTrackMap & covMap)
-  : theVertexState(aVertexState),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false),
-    theTracks(tks), theCovMap(covMap), theCovMapAvailable(true), 
-    withPrior(false), theValid(true),
-    vertexIs4D( aVertexState.is4D() )
-{
-  if (theCovMap.empty()) theCovMapAvailable = false;
+CachingVertex<N>::CachingVertex(const VertexState& aVertexState,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq,
+                                const TrackToTrackMap& covMap)
+    : theVertexState(aVertexState),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMap(covMap),
+      theCovMapAvailable(true),
+      withPrior(false),
+      theValid(true),
+      vertexIs4D(aVertexState.is4D()) {
+  if (theCovMap.empty())
+    theCovMapAvailable = false;
 }
 
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const VertexState & priorVertexState, 
-                                const VertexState & aVertexState, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
+CachingVertex<N>::CachingVertex(const VertexState& priorVertexState,
+                                const VertexState& aVertexState,
+                                const std::vector<RefCountedVertexTrack>& tks,
                                 float totalChiSq)
-  : theVertexState(aVertexState), theChiSquared(totalChiSq),
-    theNDF(0), theNDFAvailable(false), theTracks(tks),
-    theCovMapAvailable(false), thePriorVertexState(priorVertexState),
-    withPrior(true), theValid(true), 
-    vertexIs4D( priorVertexState.is4D() && aVertexState.is4D() )
-{}
+    : theVertexState(aVertexState),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      thePriorVertexState(priorVertexState),
+      withPrior(true),
+      theValid(true),
+      vertexIs4D(priorVertexState.is4D() && aVertexState.is4D()) {}
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & priorPos, 
-                                const GlobalError & priorErr,
-                                const GlobalPoint & pos, 
-                                const GlobalError & posErr, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq) 
-  : theVertexState(pos, posErr),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), 
-    thePriorVertexState(priorPos, priorErr), withPrior(true), theValid(true), vertexIs4D(false)
-{}
+CachingVertex<N>::CachingVertex(const GlobalPoint& priorPos,
+                                const GlobalError& priorErr,
+                                const GlobalPoint& pos,
+                                const GlobalError& posErr,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq)
+    : theVertexState(pos, posErr),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      thePriorVertexState(priorPos, priorErr),
+      withPrior(true),
+      theValid(true),
+      vertexIs4D(false) {}
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & priorPos,
+CachingVertex<N>::CachingVertex(const GlobalPoint& priorPos,
                                 const double priorTime,
-                                const GlobalError & priorErr,
-                                const GlobalPoint & pos, 
+                                const GlobalError& priorErr,
+                                const GlobalPoint& pos,
                                 const double time,
-                                const GlobalError & posErr, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq) 
-  : theVertexState(pos, time,posErr),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), 
-    thePriorVertexState(priorPos, priorTime, priorErr), withPrior(true), 
-    theValid(true), vertexIs4D(true)
-{}
-
-
-//to be removed
-template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & priorPos,
-                                const GlobalError & priorErr, 
-                                const GlobalPoint & pos, 
-                                const GlobalWeight & posWeight, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq) 
-  : theVertexState(pos, posWeight),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), 
-    thePriorVertexState(priorPos, priorErr), withPrior(true), theValid(true), vertexIs4D(false)
-{}
+                                const GlobalError& posErr,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq)
+    : theVertexState(pos, time, posErr),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      thePriorVertexState(priorPos, priorTime, priorErr),
+      withPrior(true),
+      theValid(true),
+      vertexIs4D(true) {}
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & priorPos,
+CachingVertex<N>::CachingVertex(const GlobalPoint& priorPos,
+                                const GlobalError& priorErr,
+                                const GlobalPoint& pos,
+                                const GlobalWeight& posWeight,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq)
+    : theVertexState(pos, posWeight),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      thePriorVertexState(priorPos, priorErr),
+      withPrior(true),
+      theValid(true),
+      vertexIs4D(false) {}
+
+//to be removed
+template <unsigned int N>
+CachingVertex<N>::CachingVertex(const GlobalPoint& priorPos,
                                 const double priorTime,
-                                const GlobalError & priorErr, 
-                                const GlobalPoint & pos, 
+                                const GlobalError& priorErr,
+                                const GlobalPoint& pos,
                                 const double time,
-                                const GlobalWeight & posWeight, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq) 
-  : theVertexState(pos, priorTime, posWeight),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), 
-    thePriorVertexState(priorPos, priorTime, priorErr), withPrior(true), 
-    theValid(true), vertexIs4D(true)
-{}
-
+                                const GlobalWeight& posWeight,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq)
+    : theVertexState(pos, priorTime, posWeight),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      thePriorVertexState(priorPos, priorTime, priorErr),
+      withPrior(true),
+      theValid(true),
+      vertexIs4D(true) {}
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & priorPos, 
-                                const GlobalError & priorErr,
-                                const AlgebraicVector3 & weightTimesPosition, 
-                                const GlobalWeight & posWeight, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
+CachingVertex<N>::CachingVertex(const GlobalPoint& priorPos,
+                                const GlobalError& priorErr,
+                                const AlgebraicVector3& weightTimesPosition,
+                                const GlobalWeight& posWeight,
+                                const std::vector<RefCountedVertexTrack>& tks,
                                 float totalChiSq)
-  : theVertexState(weightTimesPosition, posWeight),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), 
-    thePriorVertexState(priorPos, priorErr), withPrior(true), theValid(true)
-{}
+    : theVertexState(weightTimesPosition, posWeight),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      thePriorVertexState(priorPos, priorErr),
+      withPrior(true),
+      theValid(true) {}
 
 //to be removed
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const GlobalPoint & priorPos, 
-                                const GlobalError & priorErr,
-                                const AlgebraicVector4 & weightTimesPosition, 
-                                const GlobalWeight & posWeight, 
-                                const std::vector<RefCountedVertexTrack> & tks, 
+CachingVertex<N>::CachingVertex(const GlobalPoint& priorPos,
+                                const GlobalError& priorErr,
+                                const AlgebraicVector4& weightTimesPosition,
+                                const GlobalWeight& posWeight,
+                                const std::vector<RefCountedVertexTrack>& tks,
                                 float totalChiSq)
-  : theVertexState(weightTimesPosition, posWeight),
-    theChiSquared(totalChiSq), theNDF(0), theNDFAvailable(false), 
-    theTracks(tks), theCovMapAvailable(false), 
-    thePriorVertexState(priorPos, priorErr), withPrior(true), theValid(true)
-{}
-
+    : theVertexState(weightTimesPosition, posWeight),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMapAvailable(false),
+      thePriorVertexState(priorPos, priorErr),
+      withPrior(true),
+      theValid(true) {}
 
 template <unsigned int N>
-CachingVertex<N>::CachingVertex(const VertexState & priorVertexState, 
-                                const VertexState & aVertexState,
-                                const std::vector<RefCountedVertexTrack> & tks, 
-                                float totalChiSq, 
-                                const TrackToTrackMap & covMap)
-  : theVertexState(aVertexState), theChiSquared(totalChiSq),
-    theNDF(0), theNDFAvailable(false), theTracks(tks),
-    theCovMap(covMap), theCovMapAvailable(true), 
-    thePriorVertexState(priorVertexState), withPrior(true), theValid(true),
-    vertexIs4D( priorVertexState.is4D() && aVertexState.is4D() )
-{
-  if (theCovMap.empty()) theCovMapAvailable = false;
+CachingVertex<N>::CachingVertex(const VertexState& priorVertexState,
+                                const VertexState& aVertexState,
+                                const std::vector<RefCountedVertexTrack>& tks,
+                                float totalChiSq,
+                                const TrackToTrackMap& covMap)
+    : theVertexState(aVertexState),
+      theChiSquared(totalChiSq),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(tks),
+      theCovMap(covMap),
+      theCovMapAvailable(true),
+      thePriorVertexState(priorVertexState),
+      withPrior(true),
+      theValid(true),
+      vertexIs4D(priorVertexState.is4D() && aVertexState.is4D()) {
+  if (theCovMap.empty())
+    theCovMapAvailable = false;
 }
 
 template <unsigned int N>
-CachingVertex<N>::CachingVertex() 
-  : theChiSquared(-1), theNDF(0), theNDFAvailable(false), theTracks(),
-    theCovMapAvailable(false), withPrior(false), 
-    theValid(false), vertexIs4D(false)
-{}
+CachingVertex<N>::CachingVertex()
+    : theChiSquared(-1),
+      theNDF(0),
+      theNDFAvailable(false),
+      theTracks(),
+      theCovMapAvailable(false),
+      withPrior(false),
+      theValid(false),
+      vertexIs4D(false) {}
 
 template <unsigned int N>
-GlobalPoint CachingVertex<N>::position() const 
-{
+GlobalPoint CachingVertex<N>::position() const {
   return theVertexState.position();
 }
 
 template <unsigned int N>
-double CachingVertex<N>::time() const 
-{
+double CachingVertex<N>::time() const {
   return theVertexState.time();
 }
 
 template <unsigned int N>
-GlobalError CachingVertex<N>::error() const 
-{
+GlobalError CachingVertex<N>::error() const {
   return theVertexState.error();
 }
 
 template <unsigned int N>
-GlobalError CachingVertex<N>::error4D() const 
-{
+GlobalError CachingVertex<N>::error4D() const {
   return theVertexState.error4D();
 }
 
-
 template <unsigned int N>
-GlobalWeight CachingVertex<N>::weight() const 
-{
+GlobalWeight CachingVertex<N>::weight() const {
   return theVertexState.weight();
 }
 
 template <unsigned int N>
-GlobalWeight CachingVertex<N>::weight4D() const 
-{
+GlobalWeight CachingVertex<N>::weight4D() const {
   return theVertexState.weight4D();
 }
 
-
 template <unsigned int N>
-AlgebraicVector3 CachingVertex<N>::weightTimesPosition() const 
-{
+AlgebraicVector3 CachingVertex<N>::weightTimesPosition() const {
   return theVertexState.weightTimesPosition();
 }
 
 template <unsigned int N>
-AlgebraicVector4 CachingVertex<N>::weightTimesPosition4D() const 
-{
+AlgebraicVector4 CachingVertex<N>::weightTimesPosition4D() const {
   return theVertexState.weightTimesPosition4D();
 }
 
 template <unsigned int N>
-float CachingVertex<N>::degreesOfFreedom() const 
-{
-  if (!theNDFAvailable) computeNDF();
+float CachingVertex<N>::degreesOfFreedom() const {
+  if (!theNDFAvailable)
+    computeNDF();
   return theNDF;
 }
 
-
 template <unsigned int N>
-void CachingVertex<N>::computeNDF() const 
-{
+void CachingVertex<N>::computeNDF() const {
   theNDF = 0;
-  for (typename std::vector<RefCountedVertexTrack>::const_iterator itk = theTracks.begin(); 
-       itk != theTracks.end(); ++itk) {
-    theNDF += (**itk).weight(); // adds up weights
+  for (typename std::vector<RefCountedVertexTrack>::const_iterator itk = theTracks.begin(); itk != theTracks.end();
+       ++itk) {
+    theNDF += (**itk).weight();  // adds up weights
   }
-  theNDF *= 2.; // times 2df for each track
-  const double adjust = ( vertexIs4D ? 4 : 3 ); // ndf adjust is 3 or 4
-  if (!withPrior) theNDF -= adjust;  
+  theNDF *= 2.;                                // times 2df for each track
+  const double adjust = (vertexIs4D ? 4 : 3);  // ndf adjust is 3 or 4
+  if (!withPrior)
+    theNDF -= adjust;
   theNDFAvailable = true;
 }
 
-
 template <unsigned int N>
-typename CachingVertex<N>::AlgebraicMatrixMM
-CachingVertex<N>::tkToTkCovariance(const RefCountedVertexTrack t1, 
-                                   const RefCountedVertexTrack t2) const
-{
+typename CachingVertex<N>::AlgebraicMatrixMM CachingVertex<N>::tkToTkCovariance(const RefCountedVertexTrack t1,
+                                                                                const RefCountedVertexTrack t2) const {
   if (!tkToTkCovarianceIsAvailable()) {
-   throw VertexException("CachingVertex::TkTkCovariance requested before been calculated");
-  } 
-  else {
+    throw VertexException("CachingVertex::TkTkCovariance requested before been calculated");
+  } else {
     RefCountedVertexTrack tr1;
     RefCountedVertexTrack tr2;
     bool transp = false;
-    if(t1 < t2) {
-      tr1 = t1;    
+    if (t1 < t2) {
+      tr1 = t1;
       tr2 = t2;
-    }
-    else {
-      tr1 = t2;    
+    } else {
+      tr1 = t2;
       tr2 = t1;
       transp = true;
     }
     typename TrackToTrackMap::const_iterator it = theCovMap.find(tr1);
-    if (it !=  theCovMap.end()) {
-      const TrackMap & tm = it->second;
+    if (it != theCovMap.end()) {
+      const TrackMap& tm = it->second;
       typename TrackMap::const_iterator nit = tm.find(tr2);
       if (nit != tm.end()) {
-	if (transp) return( ROOT::Math::Transpose(nit->second) );
-	else return( nit->second);
+        if (transp)
+          return (ROOT::Math::Transpose(nit->second));
+        else
+          return (nit->second);
+      } else {
+        throw VertexException("CachingVertex::requested TkTkCovariance does not exist");
       }
-      else {
-	throw VertexException("CachingVertex::requested TkTkCovariance does not exist");
-      }       
-    }
-    else {
+    } else {
       throw VertexException("CachingVertex::requested TkTkCovariance does not exist");
-    }     
+    }
   }
 }
 
 template <unsigned int N>
-CachingVertex<N>::operator TransientVertex() const
-{
+CachingVertex<N>::operator TransientVertex() const {
   //If the vertex is invalid, return an invalid TV !
-  if (!isValid()) return TransientVertex();
+  if (!isValid())
+    return TransientVertex();
 
   typedef std::map<reco::TransientTrack, float> TransientTrackToFloatMap;
 
-// Construct Track vector
+  // Construct Track vector
   std::vector<reco::TransientTrack> ttVect;
   ttVect.reserve(theTracks.size());
   std::vector<reco::TransientTrack> refTTVect;
@@ -364,8 +416,7 @@ CachingVertex<N>::operator TransientVertex() const
   TTtoTTmap ttCovMap;
   // float theMinWeight = 0.5;
 
-  for (typename std::vector<RefCountedVertexTrack>::const_iterator i = theTracks.begin();
-       i != theTracks.end(); ++i) {
+  for (typename std::vector<RefCountedVertexTrack>::const_iterator i = theTracks.begin(); i != theTracks.end(); ++i) {
     // discard tracks with too low weight
     // if ((**i).weight() < theMinWeight) continue;
 
@@ -376,29 +427,28 @@ CachingVertex<N>::operator TransientVertex() const
 
     //Fill in the tk-to-tk covariance map
     if (theCovMapAvailable) {
-      for (typename std::vector<RefCountedVertexTrack>::const_iterator j = (i+1);
-	   j != theTracks.end(); ++j) {
-	reco::TransientTrack t2((**j).linearizedTrack()->track());
-	ttCovMap[t1][t2] = tkToTkCovariance(*i, *j);
+      for (typename std::vector<RefCountedVertexTrack>::const_iterator j = (i + 1); j != theTracks.end(); ++j) {
+        reco::TransientTrack t2((**j).linearizedTrack()->track());
+        ttCovMap[t1][t2] = tkToTkCovariance(*i, *j);
       }
     }
     if ((**i).refittedStateAvailable()) {
-      refTTVect.push_back( (**i).refittedState()->transientTrack()) ;
+      refTTVect.push_back((**i).refittedState()->transientTrack());
     }
   }
   TransientVertex tv;
   if (withPrior) {
-    tv =  TransientVertex(priorVertexState(), vertexState(), ttVect, totalChiSquared(), degreesOfFreedom());
+    tv = TransientVertex(priorVertexState(), vertexState(), ttVect, totalChiSquared(), degreesOfFreedom());
   } else {
     tv = TransientVertex(vertexState(), ttVect, totalChiSquared(), degreesOfFreedom());
   }
   tv.weightMap(theWeightMap);
-  if (theCovMapAvailable) tv.tkToTkCovariance(ttCovMap);
-  if (!refTTVect.empty()) tv.refittedTracks(refTTVect);
+  if (theCovMapAvailable)
+    tv.tkToTkCovariance(ttCovMap);
+  if (!refTTVect.empty())
+    tv.refittedTracks(refTTVect);
   return tv;
 }
-
-
 
 template class CachingVertex<5>;
 template class CachingVertex<6>;

--- a/RecoVertex/VertexPrimitives/src/TransientVertex.cc
+++ b/RecoVertex/VertexPrimitives/src/TransientVertex.cc
@@ -8,189 +8,256 @@
 using namespace std;
 using namespace reco;
 
-TransientVertex::TransientVertex() : theVertexState(), theOriginalTracks(),
-  theChi2(0), theNDF(0), vertexValid(false), withPrior(false),
-  theWeightMapIsAvailable(false), theCovMapAvailable(false), 
-  withRefittedTracks(false)
-{}
+TransientVertex::TransientVertex()
+    : theVertexState(),
+      theOriginalTracks(),
+      theChi2(0),
+      theNDF(0),
+      vertexValid(false),
+      withPrior(false),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {}
 
-
-TransientVertex::TransientVertex(const GlobalPoint & pos, const GlobalError & posError,
-		     const std::vector<TransientTrack> & tracks, float chi2) :
-    theVertexState(pos, posError), theOriginalTracks(tracks),
-    theChi2(chi2), theNDF(0), vertexValid(true), withPrior(false),
-  theWeightMapIsAvailable(false), theCovMapAvailable(false), 
-  withRefittedTracks(false)
-{
-  theNDF = 2.*theOriginalTracks.size() - 3.;
+TransientVertex::TransientVertex(const GlobalPoint& pos,
+                                 const GlobalError& posError,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2)
+    : theVertexState(pos, posError),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(0),
+      vertexValid(true),
+      withPrior(false),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {
+  theNDF = 2. * theOriginalTracks.size() - 3.;
 }
 
-TransientVertex::TransientVertex(const GlobalPoint & pos, const double time,
-                                 const GlobalError & posTimeError,
-                                 const std::vector<TransientTrack> & tracks, float chi2) :
-  theVertexState(pos, time, posTimeError), theOriginalTracks(tracks),
-  theChi2(chi2), theNDF(0), vertexValid(true), withPrior(false),
-  theWeightMapIsAvailable(false), theCovMapAvailable(false), 
-  withRefittedTracks(false)
-{
-  theNDF = 2.*theOriginalTracks.size() - 3.;
+TransientVertex::TransientVertex(const GlobalPoint& pos,
+                                 const double time,
+                                 const GlobalError& posTimeError,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2)
+    : theVertexState(pos, time, posTimeError),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(0),
+      vertexValid(true),
+      withPrior(false),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {
+  theNDF = 2. * theOriginalTracks.size() - 3.;
 }
 
+TransientVertex::TransientVertex(const GlobalPoint& pos,
+                                 const GlobalError& posError,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2,
+                                 float ndf)
+    : theVertexState(pos, posError),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(ndf),
+      vertexValid(true),
+      withPrior(false),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {}
 
-TransientVertex::TransientVertex(const GlobalPoint & pos, const GlobalError & posError,
-                                 const std::vector<TransientTrack> & tracks, float chi2, float ndf) :
-    theVertexState(pos, posError), theOriginalTracks(tracks),
-    theChi2(chi2), theNDF(ndf), vertexValid(true), withPrior(false),
-    theWeightMapIsAvailable(false), theCovMapAvailable(false), 
-    withRefittedTracks(false)
-{
+TransientVertex::TransientVertex(const GlobalPoint& pos,
+                                 const double time,
+                                 const GlobalError& posTimeError,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2,
+                                 float ndf)
+    : theVertexState(pos, time, posTimeError),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(ndf),
+      vertexValid(true),
+      withPrior(false),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {}
+
+TransientVertex::TransientVertex(const GlobalPoint& priorPos,
+                                 const GlobalError& priorErr,
+                                 const GlobalPoint& pos,
+                                 const GlobalError& posError,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2)
+    : thePriorVertexState(priorPos, priorErr),
+      theVertexState(pos, posError),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(0),
+      vertexValid(true),
+      withPrior(true),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {
+  theNDF = 2. * theOriginalTracks.size();
 }
 
-TransientVertex::TransientVertex(const GlobalPoint & pos, const double time,
-                                 const GlobalError & posTimeError,
-                                 const std::vector<TransientTrack> & tracks, float chi2, float ndf) :
-  theVertexState(pos, time, posTimeError), theOriginalTracks(tracks),
-  theChi2(chi2), theNDF(ndf), vertexValid(true), withPrior(false),
-  theWeightMapIsAvailable(false), theCovMapAvailable(false), 
-  withRefittedTracks(false)
-{
+TransientVertex::TransientVertex(const GlobalPoint& priorPos,
+                                 const double priorTime,
+                                 const GlobalError& priorErr,
+                                 const GlobalPoint& pos,
+                                 const double time,
+                                 const GlobalError& posError,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2)
+    : thePriorVertexState(priorPos, priorTime, priorErr),
+      theVertexState(pos, time, posError),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(0),
+      vertexValid(true),
+      withPrior(true),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {
+  theNDF = 2. * theOriginalTracks.size();
 }
 
+TransientVertex::TransientVertex(const GlobalPoint& priorPos,
+                                 const GlobalError& priorErr,
+                                 const GlobalPoint& pos,
+                                 const GlobalError& posError,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2,
+                                 float ndf)
+    : thePriorVertexState(priorPos, priorErr),
+      theVertexState(pos, posError),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(ndf),
+      vertexValid(true),
+      withPrior(true),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {}
 
-TransientVertex::TransientVertex(const GlobalPoint & priorPos, const GlobalError & priorErr,
-                                 const GlobalPoint & pos, const GlobalError & posError,
-                                 const std::vector<TransientTrack> & tracks, float chi2) :
-    thePriorVertexState(priorPos, priorErr), theVertexState(pos, posError),
-    theOriginalTracks(tracks), theChi2(chi2), theNDF(0), vertexValid(true),
-    withPrior(true), theWeightMapIsAvailable(false), theCovMapAvailable(false),
-    withRefittedTracks(false)
-{
-  theNDF = 2.*theOriginalTracks.size();
+TransientVertex::TransientVertex(const GlobalPoint& priorPos,
+                                 const double priorTime,
+                                 const GlobalError& priorErr,
+                                 const GlobalPoint& pos,
+                                 const double time,
+                                 const GlobalError& posError,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2,
+                                 float ndf)
+    : thePriorVertexState(priorPos, priorTime, priorErr),
+      theVertexState(pos, time, posError),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(ndf),
+      vertexValid(true),
+      withPrior(true),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {}
+
+TransientVertex::TransientVertex(const VertexState& state, const std::vector<TransientTrack>& tracks, float chi2)
+    : theVertexState(state),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(0),
+      vertexValid(true),
+      withPrior(false),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {
+  theNDF = 2. * theOriginalTracks.size() - 3.;
 }
 
-TransientVertex::TransientVertex(const GlobalPoint & priorPos, const double priorTime, const GlobalError & priorErr,
-                                 const GlobalPoint & pos, const double time, const GlobalError & posError,
-                                 const std::vector<TransientTrack> & tracks, float chi2) :
-  thePriorVertexState(priorPos, priorTime, priorErr), theVertexState(pos, time, posError),
-  theOriginalTracks(tracks), theChi2(chi2), theNDF(0), vertexValid(true),
-  withPrior(true), theWeightMapIsAvailable(false), theCovMapAvailable(false),
-  withRefittedTracks(false)
-{
-  theNDF = 2.*theOriginalTracks.size();
+TransientVertex::TransientVertex(const VertexState& state,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2,
+                                 float ndf)
+    : theVertexState(state),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(ndf),
+      vertexValid(true),
+      withPrior(false),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {}
+
+TransientVertex::TransientVertex(const VertexState& prior,
+                                 const VertexState& state,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2)
+    : thePriorVertexState(prior),
+      theVertexState(state),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(0),
+      vertexValid(true),
+      withPrior(true),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {
+  theNDF = 2. * theOriginalTracks.size();
 }
 
+TransientVertex::TransientVertex(const VertexState& prior,
+                                 const VertexState& state,
+                                 const std::vector<TransientTrack>& tracks,
+                                 float chi2,
+                                 float ndf)
+    : thePriorVertexState(prior),
+      theVertexState(state),
+      theOriginalTracks(tracks),
+      theChi2(chi2),
+      theNDF(ndf),
+      vertexValid(true),
+      withPrior(true),
+      theWeightMapIsAvailable(false),
+      theCovMapAvailable(false),
+      withRefittedTracks(false) {}
 
-TransientVertex::TransientVertex(const GlobalPoint & priorPos, const GlobalError & priorErr,
-                                 const GlobalPoint & pos, const GlobalError & posError,
-                                 const std::vector<TransientTrack> & tracks, float chi2, float ndf) :
-    thePriorVertexState(priorPos, priorErr), theVertexState(pos, posError),
-    theOriginalTracks(tracks), theChi2(chi2), theNDF(ndf), vertexValid(true),
-    withPrior(true), theWeightMapIsAvailable(false), theCovMapAvailable(false),
-    withRefittedTracks(false)
-{
-}
-
-TransientVertex::TransientVertex(const GlobalPoint & priorPos, const double priorTime, const GlobalError & priorErr,
-                                 const GlobalPoint & pos, const double time, const GlobalError & posError,
-                                 const std::vector<TransientTrack> & tracks, float chi2, float ndf) :
-  thePriorVertexState(priorPos, priorTime, priorErr), theVertexState(pos, time, posError),
-  theOriginalTracks(tracks), theChi2(chi2), theNDF(ndf), vertexValid(true),
-  withPrior(true), theWeightMapIsAvailable(false), theCovMapAvailable(false),
-  withRefittedTracks(false)
-{
-}
-
-
-TransientVertex::TransientVertex(const VertexState & state, 
-                                 const std::vector<TransientTrack> & tracks, float chi2) : 
-  theVertexState(state), theOriginalTracks(tracks),
-  theChi2(chi2), theNDF(0), vertexValid(true), withPrior(false),
-  theWeightMapIsAvailable(false), theCovMapAvailable(false), 
-  withRefittedTracks(false)
-{
-  theNDF = 2.*theOriginalTracks.size() - 3.;
-}
-
-
-TransientVertex::TransientVertex(const VertexState & state, 
-                                 const std::vector<TransientTrack> & tracks, float chi2, float ndf) : 
-    theVertexState(state), theOriginalTracks(tracks),
-    theChi2(chi2), theNDF(ndf), vertexValid(true), withPrior(false),
-    theWeightMapIsAvailable(false), theCovMapAvailable(false), 
-    withRefittedTracks(false) 
-{
-}
-
-
-TransientVertex::TransientVertex(const VertexState & prior, 
-				     const VertexState & state, 
-				     const std::vector<TransientTrack> & tracks, 
-				     float chi2) :
-    thePriorVertexState(prior), theVertexState(state),
-    theOriginalTracks(tracks), theChi2(chi2), theNDF(0), vertexValid(true),
-    withPrior(true), theWeightMapIsAvailable(false), theCovMapAvailable(false),
-    withRefittedTracks(false)
-{
-  theNDF = 2.*theOriginalTracks.size();
-}
-
-
-TransientVertex::TransientVertex(const VertexState & prior, 
-		     const VertexState & state, 
-		     const std::vector<TransientTrack> & tracks, 
-		     float chi2, float ndf) :
-    thePriorVertexState(prior), theVertexState(state),
-    theOriginalTracks(tracks), theChi2(chi2), theNDF(ndf), vertexValid(true),
-    withPrior(true), theWeightMapIsAvailable(false),
-    theCovMapAvailable(false), withRefittedTracks(false)
-{
-}
-
-void TransientVertex::weightMap(const TransientTrackToFloatMap & theMap)
-{
+void TransientVertex::weightMap(const TransientTrackToFloatMap& theMap) {
   theWeightMap = theMap;
   theWeightMapIsAvailable = true;
 }
 
-void TransientVertex::refittedTracks(
-	const std::vector<reco::TransientTrack> & refittedTracks)
-{
+void TransientVertex::refittedTracks(const std::vector<reco::TransientTrack>& refittedTracks) {
   if (refittedTracks.empty())
     throw VertexException("TransientVertex::refittedTracks: No refitted tracks stored in input container");
   theRefittedTracks = refittedTracks;
   withRefittedTracks = true;
 }
 
-
-void TransientVertex::tkToTkCovariance(const TTtoTTmap &covMap)
-{
+void TransientVertex::tkToTkCovariance(const TTtoTTmap& covMap) {
   theCovMap = covMap;
   theCovMapAvailable = true;
 }
 
-float TransientVertex::trackWeight(const TransientTrack & track) const {
+float TransientVertex::trackWeight(const TransientTrack& track) const {
   if (!theWeightMapIsAvailable) {
-    std::vector<TransientTrack>::const_iterator foundTrack = find(theOriginalTracks.begin(), 
-    		theOriginalTracks.end(), track);
+    std::vector<TransientTrack>::const_iterator foundTrack =
+        find(theOriginalTracks.begin(), theOriginalTracks.end(), track);
     return ((foundTrack != theOriginalTracks.end()) ? 1. : 0.);
   }
   TransientTrackToFloatMap::const_iterator it = theWeightMap.find(track);
-  if (it !=  theWeightMap.end()) {
-    return(it->second);
+  if (it != theWeightMap.end()) {
+    return (it->second);
   }
   return 0.;
-
 }
 
-AlgebraicMatrix33
-TransientVertex::tkToTkCovariance(const TransientTrack& t1, const TransientTrack& t2) const
-{
+AlgebraicMatrix33 TransientVertex::tkToTkCovariance(const TransientTrack& t1, const TransientTrack& t2) const {
   if (!theCovMapAvailable) {
-   throw VertexException("TransientVertex::Track-to-track covariance matrices not available");
+    throw VertexException("TransientVertex::Track-to-track covariance matrices not available");
   }
   const TransientTrack* tr1;
   const TransientTrack* tr2;
-  if (t1<t2) {
+  if (t1 < t2) {
     tr1 = &t1;
     tr2 = &t2;
   } else {
@@ -198,104 +265,95 @@ TransientVertex::tkToTkCovariance(const TransientTrack& t1, const TransientTrack
     tr2 = &t1;
   }
   TTtoTTmap::const_iterator it = theCovMap.find(*tr1);
-  if (it !=  theCovMap.end()) {
-    const TTmap & tm = it->second;
+  if (it != theCovMap.end()) {
+    const TTmap& tm = it->second;
     TTmap::const_iterator nit = tm.find(*tr2);
     if (nit != tm.end()) {
-      return( nit->second);
-    }
-    else {
+      return (nit->second);
+    } else {
       throw VertexException("TransientVertex::requested Track-to-track covariance matrix does not exist");
     }
-  }
-  else {
+  } else {
     throw VertexException("TransientVertex::requested Track-to-track covariance matrix does not exist");
   }
 }
 
-
-TransientTrack TransientVertex::originalTrack(const TransientTrack & refTrack) const
-{
+TransientTrack TransientVertex::originalTrack(const TransientTrack& refTrack) const {
   if (theRefittedTracks.empty())
-	throw VertexException("No refitted tracks stored in vertex");
-  std::vector<TransientTrack>::const_iterator it =
-	find(theRefittedTracks.begin(), theRefittedTracks.end(), refTrack);
-  if (it==theRefittedTracks.end())
-	throw VertexException("Refitted track not found in list");
+    throw VertexException("No refitted tracks stored in vertex");
+  std::vector<TransientTrack>::const_iterator it = find(theRefittedTracks.begin(), theRefittedTracks.end(), refTrack);
+  if (it == theRefittedTracks.end())
+    throw VertexException("Refitted track not found in list");
   size_t pos = it - theRefittedTracks.begin();
   return theOriginalTracks[pos];
 }
 
-TransientTrack TransientVertex::refittedTrack(const TransientTrack & track) const
-{
+TransientTrack TransientVertex::refittedTrack(const TransientTrack& track) const {
   if (theRefittedTracks.empty())
-	throw VertexException("No refitted tracks stored in vertex");
-  std::vector<TransientTrack>::const_iterator it =
-	find(theOriginalTracks.begin(), theOriginalTracks.end(), track);
-  if (it==theOriginalTracks.end())
-	throw VertexException("Track not found in list");
+    throw VertexException("No refitted tracks stored in vertex");
+  std::vector<TransientTrack>::const_iterator it = find(theOriginalTracks.begin(), theOriginalTracks.end(), track);
+  if (it == theOriginalTracks.end())
+    throw VertexException("Track not found in list");
   size_t pos = it - theOriginalTracks.begin();
   return theRefittedTracks[pos];
 }
 
-TransientVertex::operator reco::Vertex() const
-{
-   //If the vertex is invalid, return an invalid TV !
-  if (!isValid()) return Vertex();
-  
+TransientVertex::operator reco::Vertex() const {
+  //If the vertex is invalid, return an invalid TV !
+  if (!isValid())
+    return Vertex();
+
   Vertex vertex(Vertex::Point(theVertexState.position()),
-                // 	RecoVertex::convertError(theVertexState.error()), 
+                // 	RecoVertex::convertError(theVertexState.error()),
                 theVertexState.error4D().matrix4D(),
                 theVertexState.time(),
-                totalChiSquared(), degreesOfFreedom(), theOriginalTracks.size() );
-  for (std::vector<TransientTrack>::const_iterator i = theOriginalTracks.begin();
-       i != theOriginalTracks.end(); ++i) {
-//     const TrackTransientTrack* ttt = dynamic_cast<const TrackTransientTrack*>((*i).basicTransientTrack());
-//     if ((ttt!=0) && (ttt->persistentTrackRef().isNonnull()))
-//     {
-//       TrackRef tr = ttt->persistentTrackRef();
-//       TrackBaseRef tbr(tr);
-      if (withRefittedTracks) {
-        
-	vertex.add((*i).trackBaseRef(), refittedTrack(*i).track(), trackWeight ( *i ) );
-      } else { 
-	vertex.add((*i).trackBaseRef(), trackWeight ( *i ) );
-      }
+                totalChiSquared(),
+                degreesOfFreedom(),
+                theOriginalTracks.size());
+  for (std::vector<TransientTrack>::const_iterator i = theOriginalTracks.begin(); i != theOriginalTracks.end(); ++i) {
+    //     const TrackTransientTrack* ttt = dynamic_cast<const TrackTransientTrack*>((*i).basicTransientTrack());
+    //     if ((ttt!=0) && (ttt->persistentTrackRef().isNonnull()))
+    //     {
+    //       TrackRef tr = ttt->persistentTrackRef();
+    //       TrackBaseRef tbr(tr);
+    if (withRefittedTracks) {
+      vertex.add((*i).trackBaseRef(), refittedTrack(*i).track(), trackWeight(*i));
+    } else {
+      vertex.add((*i).trackBaseRef(), trackWeight(*i));
+    }
     //}
   }
   return vertex;
 }
 
-TransientVertex::operator reco::VertexCompositePtrCandidate() const
-{
+TransientVertex::operator reco::VertexCompositePtrCandidate() const {
   using namespace reco;
-  if (!isValid())  return VertexCompositePtrCandidate();
-  
+  if (!isValid())
+    return VertexCompositePtrCandidate();
+
   VertexCompositePtrCandidate vtxCompPtrCand;
-  
+
   vtxCompPtrCand.setTime(vertexState().time());
   vtxCompPtrCand.setCovariance(vertexState().error4D().matrix4D());
   vtxCompPtrCand.setChi2AndNdof(totalChiSquared(), degreesOfFreedom());
-  vtxCompPtrCand.setVertex(Candidate::Point(position().x(),position().y(),position().z()));
-  
+  vtxCompPtrCand.setVertex(Candidate::Point(position().x(), position().y(), position().z()));
+
   Candidate::LorentzVector p4;
-  for(std::vector<reco::TransientTrack>::const_iterator tt = theOriginalTracks.begin(); tt != theOriginalTracks.end(); ++tt)
-    {
-      if (trackWeight(*tt) < 0.5)
-	continue;
-      
-      const CandidatePtrTransientTrack* cptt = dynamic_cast<const CandidatePtrTransientTrack*>(tt->basicTransientTrack());
-      if ( cptt==nullptr )
-	edm::LogError("DynamicCastingFailed") << "Casting of TransientTrack to CandidatePtrTransientTrack failed!";
-      else
-	{
-	  p4 += cptt->candidate()->p4();
-	  vtxCompPtrCand.addDaughter(cptt->candidate());
-	}
+  for (std::vector<reco::TransientTrack>::const_iterator tt = theOriginalTracks.begin(); tt != theOriginalTracks.end();
+       ++tt) {
+    if (trackWeight(*tt) < 0.5)
+      continue;
+
+    const CandidatePtrTransientTrack* cptt = dynamic_cast<const CandidatePtrTransientTrack*>(tt->basicTransientTrack());
+    if (cptt == nullptr)
+      edm::LogError("DynamicCastingFailed") << "Casting of TransientTrack to CandidatePtrTransientTrack failed!";
+    else {
+      p4 += cptt->candidate()->p4();
+      vtxCompPtrCand.addDaughter(cptt->candidate());
     }
-  
+  }
+
   //TODO: if has refitted tracks we should scale the candidate p4 to the refitted one
   vtxCompPtrCand.setP4(p4);
   return vtxCompPtrCand;
 }
-

--- a/RecoVertex/VertexPrimitives/src/VertexState.cc
+++ b/RecoVertex/VertexPrimitives/src/VertexState.cc
@@ -1,2 +1,1 @@
 #include "RecoVertex/VertexPrimitives/interface/VertexState.h"
-

--- a/RecoVertex/VertexPrimitives/src/VertexTrack.cc
+++ b/RecoVertex/VertexPrimitives/src/VertexTrack.cc
@@ -1,50 +1,58 @@
 #include "RecoVertex/VertexPrimitives/interface/VertexTrack.h"
 
+template <unsigned int N>
+VertexTrack<N>::VertexTrack(RefCountedLinearizedTrackState lt, VertexState v, float weight)
+    : theLinTrack(std::move(lt)),
+      theVertexState(std::move(v)),
+      theWeight(weight),
+      stAvailable(false),
+      covAvailable(false),
+      smoothedChi2_(-1.) {}
 
 template <unsigned int N>
-VertexTrack<N>::VertexTrack(RefCountedLinearizedTrackState lt, 
-			 VertexState v, 
-			 float weight) 
-  : theLinTrack(std::move(lt)), theVertexState(std::move(v)), theWeight(weight),
-    stAvailable(false), covAvailable(false), smoothedChi2_(-1.) {}
-
-
-template <unsigned int N>
-VertexTrack<N>::VertexTrack(RefCountedLinearizedTrackState lt, 
-			    VertexState v, float weight,
-			    const RefCountedRefittedTrackState & refittedState,
-			    float smoothedChi2)
-  : theLinTrack(std::move(lt)), theVertexState(std::move(v)), theWeight(weight),
-    stAvailable(true), covAvailable(false), theRefittedState(refittedState),
-    smoothedChi2_(smoothedChi2) {}
-
+VertexTrack<N>::VertexTrack(RefCountedLinearizedTrackState lt,
+                            VertexState v,
+                            float weight,
+                            const RefCountedRefittedTrackState& refittedState,
+                            float smoothedChi2)
+    : theLinTrack(std::move(lt)),
+      theVertexState(std::move(v)),
+      theWeight(weight),
+      stAvailable(true),
+      covAvailable(false),
+      theRefittedState(refittedState),
+      smoothedChi2_(smoothedChi2) {}
 
 template <unsigned int N>
-VertexTrack<N>::VertexTrack(RefCountedLinearizedTrackState lt, 
-			    VertexState v, float weight, 
-			    const RefCountedRefittedTrackState & refittedState,
-			    float smoothedChi2, const AlgebraicSymMatrixOO & fullCov) 
-  : theLinTrack(std::move(lt)), theVertexState(std::move(v)), theWeight(weight),
-    stAvailable(true), covAvailable(true), 
-    theRefittedState(refittedState), fullCovariance_(fullCov),
-    smoothedChi2_(smoothedChi2) {}
-
+VertexTrack<N>::VertexTrack(RefCountedLinearizedTrackState lt,
+                            VertexState v,
+                            float weight,
+                            const RefCountedRefittedTrackState& refittedState,
+                            float smoothedChi2,
+                            const AlgebraicSymMatrixOO& fullCov)
+    : theLinTrack(std::move(lt)),
+      theVertexState(std::move(v)),
+      theWeight(weight),
+      stAvailable(true),
+      covAvailable(true),
+      theRefittedState(refittedState),
+      fullCovariance_(fullCov),
+      smoothedChi2_(smoothedChi2) {}
 
 template <unsigned int N>
-typename VertexTrack<N>::AlgebraicVectorN VertexTrack<N>::refittedParamFromEquation() const 
-{
+typename VertexTrack<N>::AlgebraicVectorN VertexTrack<N>::refittedParamFromEquation() const {
   return linearizedTrack()->refittedParamFromEquation(theRefittedState);
 }
 
 template class VertexTrack<5>;
 template class VertexTrack<6>;
 
-//   /** Track to vertex covariance 
-//    */   
+//   /** Track to vertex covariance
+//    */
 // template <unsigned int N>
 // typename VertexTrack<N>::AlgebraicMatrix3M VertexTrack<N>::tkToVtxCovariance() const {
 //     if (!tkToVertexCovarianceAvailable()) {
-//       throw VertexException("VertexTrack::track to vertex covariance not available"); 
+//       throw VertexException("VertexTrack::track to vertex covariance not available");
 //     }
 // //     if (N==5) {
 // //       ROOT::Math::SMatrix<double,6,6,ROOT::Math::MatRepSym<double,6> > b6 = fullCovariance_;

--- a/TrackingTools/Producers/interface/AnalyticalPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/AnalyticalPropagatorESProducer.h
@@ -7,18 +7,14 @@
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 #include <memory>
 
-class  AnalyticalPropagatorESProducer: public edm::ESProducer{
- public:
-  AnalyticalPropagatorESProducer(const edm::ParameterSet & p);
-  ~AnalyticalPropagatorESProducer() override; 
+class AnalyticalPropagatorESProducer : public edm::ESProducer {
+public:
+  AnalyticalPropagatorESProducer(const edm::ParameterSet &p);
+  ~AnalyticalPropagatorESProducer() override;
   std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
- private:
+
+private:
   edm::ParameterSet pset_;
 };
 
-
 #endif
-
-
-
-

--- a/TrackingTools/Producers/interface/BeamHaloPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/BeamHaloPropagatorESProducer.h
@@ -13,26 +13,25 @@
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 
 #include <memory>
-  
 
-namespace edm {class ParameterSet;}
+namespace edm {
+  class ParameterSet;
+}
 
 class TrackingComponentsRecord;
 
-class  BeamHaloPropagatorESProducer: public edm::ESProducer{
-
- public:
-  
+class BeamHaloPropagatorESProducer : public edm::ESProducer {
+public:
   /// Constructor
   BeamHaloPropagatorESProducer(const edm::ParameterSet &);
-  
+
   /// Destructor
-  ~BeamHaloPropagatorESProducer() override; 
-  
+  ~BeamHaloPropagatorESProducer() override;
+
   // Operations
   std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
-  
- private:
+
+private:
   PropagationDirection thePropagationDirection;
   std::string myname;
   std::string theEndCapTrackerPropagatorName;
@@ -40,4 +39,3 @@ class  BeamHaloPropagatorESProducer: public edm::ESProducer{
 };
 
 #endif
-

--- a/TrackingTools/Producers/interface/SmartPropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/SmartPropagatorESProducer.h
@@ -13,26 +13,25 @@
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 
 #include <memory>
-  
 
-namespace edm {class ParameterSet;}
+namespace edm {
+  class ParameterSet;
+}
 
 class TrackingComponentsRecord;
 
-class  SmartPropagatorESProducer: public edm::ESProducer{
-
- public:
-  
+class SmartPropagatorESProducer : public edm::ESProducer {
+public:
   /// Constructor
   SmartPropagatorESProducer(const edm::ParameterSet &);
-  
+
   /// Destructor
-  ~SmartPropagatorESProducer() override; 
-  
+  ~SmartPropagatorESProducer() override;
+
   // Operations
   std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
-  
- private:
+
+private:
   PropagationDirection thePropagationDirection;
   std::string theTrackerPropagatorName;
   std::string theMuonPropagatorName;
@@ -40,4 +39,3 @@ class  SmartPropagatorESProducer: public edm::ESProducer{
 };
 
 #endif
-

--- a/TrackingTools/Producers/interface/StraightLinePropagatorESProducer.h
+++ b/TrackingTools/Producers/interface/StraightLinePropagatorESProducer.h
@@ -7,18 +7,14 @@
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 #include <memory>
 
-class  StraightLinePropagatorESProducer: public edm::ESProducer{
- public:
-  StraightLinePropagatorESProducer(const edm::ParameterSet & p);
-  ~StraightLinePropagatorESProducer() override; 
+class StraightLinePropagatorESProducer : public edm::ESProducer {
+public:
+  StraightLinePropagatorESProducer(const edm::ParameterSet &p);
+  ~StraightLinePropagatorESProducer() override;
   std::unique_ptr<Propagator> produce(const TrackingComponentsRecord &);
- private:
+
+private:
   edm::ParameterSet pset_;
 };
 
-
 #endif
-
-
-
-

--- a/TrackingTools/Producers/interface/TrajectoryCleanerESProducer.h
+++ b/TrackingTools/Producers/interface/TrajectoryCleanerESProducer.h
@@ -2,7 +2,7 @@
 //
 // Package:    TrajectoryCleanerESProducer
 // Class:      TrajectoryCleanerESProducer
-// 
+//
 /**\class TrajectoryCleanerESProducer TrajectoryCleanerESProducer.h TrackingTools/Producers/src/TrajectoryCleanerESProducer.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //         Created:  Thu Oct 11 05:20:59 CEST 2007
 //
 //
-
 
 // system include files
 #include <memory>
@@ -30,14 +29,15 @@
 #include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleaner.h"
 
 class TrajectoryCleanerESProducer : public edm::ESProducer {
-   public:
-      TrajectoryCleanerESProducer(const edm::ParameterSet&);
-      ~TrajectoryCleanerESProducer() override;
+public:
+  TrajectoryCleanerESProducer(const edm::ParameterSet&);
+  ~TrajectoryCleanerESProducer() override;
 
   typedef std::unique_ptr<TrajectoryCleaner> ReturnType;
 
-      ReturnType produce(const  TrackingComponentsRecord&);
-   private:
+  ReturnType produce(const TrackingComponentsRecord&);
+
+private:
   std::string theComponentName;
   std::string theComponentType;
   edm::ParameterSet theConfig;

--- a/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/AnalyticalPropagatorESProducer.cc
@@ -13,39 +13,38 @@
 
 using namespace edm;
 
-AnalyticalPropagatorESProducer::AnalyticalPropagatorESProducer(const edm::ParameterSet & p) 
-{
+AnalyticalPropagatorESProducer::AnalyticalPropagatorESProducer(const edm::ParameterSet& p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
   pset_ = p;
-  setWhatProduced(this,myname);
+  setWhatProduced(this, myname);
 }
 
 AnalyticalPropagatorESProducer::~AnalyticalPropagatorESProducer() {}
 
-std::unique_ptr<Propagator> 
-AnalyticalPropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
-//   if (_propagator){
-//     delete _propagator;
-//     _propagator = 0;
-//   }
+std::unique_ptr<Propagator> AnalyticalPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord) {
+  //   if (_propagator){
+  //     delete _propagator;
+  //     _propagator = 0;
+  //   }
   ESHandle<MagneticField> magfield;
   std::string mfName = "";
   if (pset_.exists("SimpleMagneticField"))
     mfName = pset_.getParameter<std::string>("SimpleMagneticField");
-  iRecord.getRecord<IdealMagneticFieldRecord>().get(mfName,magfield);
+  iRecord.getRecord<IdealMagneticFieldRecord>().get(mfName, magfield);
   //  edm::ESInputTag mfESInputTag(mfName);
   //  iRecord.getRecord<IdealMagneticFieldRecord>().get(mfESInputTag,magfield);
 
   std::string pdir = pset_.getParameter<std::string>("PropagationDirection");
-  double dphiCut   = pset_.getParameter<double>("MaxDPhi");   
+  double dphiCut = pset_.getParameter<double>("MaxDPhi");
 
   PropagationDirection dir = alongMomentum;
-  
-  if (pdir == "oppositeToMomentum") dir = oppositeToMomentum;
-  if (pdir == "alongMomentum") dir = alongMomentum;
-  if (pdir == "anyDirection") dir = anyDirection;
-  
-  return std::make_unique<AnalyticalPropagator>(&(*magfield), dir,dphiCut);
+
+  if (pdir == "oppositeToMomentum")
+    dir = oppositeToMomentum;
+  if (pdir == "alongMomentum")
+    dir = alongMomentum;
+  if (pdir == "anyDirection")
+    dir = anyDirection;
+
+  return std::make_unique<AnalyticalPropagator>(&(*magfield), dir, dphiCut);
 }
-
-

--- a/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
@@ -19,48 +19,46 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-    
+
 using namespace edm;
 using namespace std;
-    
-BeamHaloPropagatorESProducer::BeamHaloPropagatorESProducer(const ParameterSet& parameterSet) 
-{
+
+BeamHaloPropagatorESProducer::BeamHaloPropagatorESProducer(const ParameterSet& parameterSet) {
   myname = parameterSet.getParameter<string>("ComponentName");
 
   string propDir = parameterSet.getParameter<string>("PropagationDirection");
-  
-  if (propDir == "oppositeToMomentum") thePropagationDirection = oppositeToMomentum;
-  else if (propDir == "alongMomentum") thePropagationDirection = alongMomentum;
-  else if (propDir == "anyDirection") thePropagationDirection = anyDirection;
+
+  if (propDir == "oppositeToMomentum")
+    thePropagationDirection = oppositeToMomentum;
+  else if (propDir == "alongMomentum")
+    thePropagationDirection = alongMomentum;
+  else if (propDir == "anyDirection")
+    thePropagationDirection = anyDirection;
   else
-    throw cms::Exception("BeamHaloPropagatorESProducer") 
-      << "Wrong fit direction ("<< propDir <<")chosen in BeamHaloPropagatorESProducer";
+    throw cms::Exception("BeamHaloPropagatorESProducer")
+        << "Wrong fit direction (" << propDir << ")chosen in BeamHaloPropagatorESProducer";
 
   theEndCapTrackerPropagatorName = parameterSet.getParameter<string>("EndCapTrackerPropagator");
   theCrossingTrackerPropagatorName = parameterSet.getParameter<string>("CrossingTrackerPropagator");
 
-  setWhatProduced(this,myname);
+  setWhatProduced(this, myname);
 }
 
 BeamHaloPropagatorESProducer::~BeamHaloPropagatorESProducer() {}
 
-std::unique_ptr<Propagator> 
-BeamHaloPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
-
+std::unique_ptr<Propagator> BeamHaloPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord) {
   ESHandle<MagneticField> magField;
   iRecord.getRecord<IdealMagneticFieldRecord>().get(magField);
-  
+
   ESHandle<Propagator> endcapPropagator;
-  iRecord.get(theEndCapTrackerPropagatorName,endcapPropagator);
+  iRecord.get(theEndCapTrackerPropagatorName, endcapPropagator);
 
   ESHandle<Propagator> crossPropagator;
-  iRecord.get(theCrossingTrackerPropagatorName,crossPropagator);
-  
-  LogDebug("BeamHaloPropagator")<<"Creating a BeamHaloPropagator: "<<myname
-				<<"\n with EndCap Propagator: "<<theEndCapTrackerPropagatorName
-				<<"\n with Crossing Propagator: "<<theCrossingTrackerPropagatorName;
+  iRecord.get(theCrossingTrackerPropagatorName, crossPropagator);
 
-  return            std::make_unique<BeamHaloPropagator>(*endcapPropagator,*crossPropagator,
-							&*magField,
-							thePropagationDirection);
+  LogDebug("BeamHaloPropagator") << "Creating a BeamHaloPropagator: " << myname
+                                 << "\n with EndCap Propagator: " << theEndCapTrackerPropagatorName
+                                 << "\n with Crossing Propagator: " << theCrossingTrackerPropagatorName;
+
+  return std::make_unique<BeamHaloPropagator>(*endcapPropagator, *crossPropagator, &*magField, thePropagationDirection);
 }

--- a/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
@@ -18,49 +18,43 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-    
 using namespace edm;
 using namespace std;
-    
-SmartPropagatorESProducer::SmartPropagatorESProducer(const ParameterSet& parameterSet) 
-{
+
+SmartPropagatorESProducer::SmartPropagatorESProducer(const ParameterSet& parameterSet) {
   string myname = parameterSet.getParameter<string>("ComponentName");
 
   string propDir = parameterSet.getParameter<string>("PropagationDirection");
-  
-  if (propDir == "oppositeToMomentum") thePropagationDirection = oppositeToMomentum;
-  else if (propDir == "alongMomentum") thePropagationDirection = alongMomentum;
-  else if (propDir == "anyDirection") thePropagationDirection = anyDirection;
-  else
-    throw cms::Exception("SmartPropagatorESProducer") 
-      << "Wrong fit direction chosen in SmartPropagatorESProducer";
 
+  if (propDir == "oppositeToMomentum")
+    thePropagationDirection = oppositeToMomentum;
+  else if (propDir == "alongMomentum")
+    thePropagationDirection = alongMomentum;
+  else if (propDir == "anyDirection")
+    thePropagationDirection = anyDirection;
+  else
+    throw cms::Exception("SmartPropagatorESProducer") << "Wrong fit direction chosen in SmartPropagatorESProducer";
 
   theEpsilon = parameterSet.getParameter<double>("Epsilon");
-  
+
   theTrackerPropagatorName = parameterSet.getParameter<string>("TrackerPropagator");
   theMuonPropagatorName = parameterSet.getParameter<string>("MuonPropagator");
 
-  setWhatProduced(this,myname);
+  setWhatProduced(this, myname);
 }
 
 SmartPropagatorESProducer::~SmartPropagatorESProducer() {}
 
-std::unique_ptr<Propagator> 
-SmartPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord){ 
-
+std::unique_ptr<Propagator> SmartPropagatorESProducer::produce(const TrackingComponentsRecord& iRecord) {
   ESHandle<MagneticField> magField;
   iRecord.getRecord<IdealMagneticFieldRecord>().get(magField);
-  
+
   ESHandle<Propagator> trackerPropagator;
-  iRecord.get(theTrackerPropagatorName,trackerPropagator);
+  iRecord.get(theTrackerPropagatorName, trackerPropagator);
 
   ESHandle<Propagator> muonPropagator;
-  iRecord.get(theMuonPropagatorName,muonPropagator);
-  
-  
-  return           std::make_unique<SmartPropagator>(*trackerPropagator, *muonPropagator,
-						     &*magField,
-						     thePropagationDirection, 
-						     theEpsilon);
+  iRecord.get(theMuonPropagatorName, muonPropagator);
+
+  return std::make_unique<SmartPropagator>(
+      *trackerPropagator, *muonPropagator, &*magField, thePropagationDirection, theEpsilon);
 }

--- a/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/StraightLinePropagatorESProducer.cc
@@ -12,30 +12,28 @@
 
 using namespace edm;
 
-StraightLinePropagatorESProducer::StraightLinePropagatorESProducer(const edm::ParameterSet & p) 
-{
+StraightLinePropagatorESProducer::StraightLinePropagatorESProducer(const edm::ParameterSet& p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
   pset_ = p;
-  setWhatProduced(this,myname);
+  setWhatProduced(this, myname);
 }
 
 StraightLinePropagatorESProducer::~StraightLinePropagatorESProducer() {}
 
-std::unique_ptr<Propagator> 
-StraightLinePropagatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
-//   if (_propagator){
-//     delete _propagator;
-//     _propagator = 0;
-//   }
+std::unique_ptr<Propagator> StraightLinePropagatorESProducer::produce(const TrackingComponentsRecord& iRecord) {
+  //   if (_propagator){
+  //     delete _propagator;
+  //     _propagator = 0;
+  //   }
   ESHandle<MagneticField> magfield;
-  iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield );
- std::string pdir = pset_.getParameter<std::string>("PropagationDirection");
+  iRecord.getRecord<IdealMagneticFieldRecord>().get(magfield);
+  std::string pdir = pset_.getParameter<std::string>("PropagationDirection");
 
   PropagationDirection dir = alongMomentum;
 
-  if (pdir == "oppositeToMomentum") dir = oppositeToMomentum;
-  else if (pdir == "anyDirection") dir = anyDirection;
-  return  std::make_unique<StraightLinePropagator>(&(*magfield),dir);
+  if (pdir == "oppositeToMomentum")
+    dir = oppositeToMomentum;
+  else if (pdir == "anyDirection")
+    dir = anyDirection;
+  return std::make_unique<StraightLinePropagator>(&(*magfield), dir);
 }
-
-

--- a/TrackingTools/Producers/src/TrajectoryCleanerESProducer.cc
+++ b/TrackingTools/Producers/src/TrajectoryCleanerESProducer.cc
@@ -1,8 +1,7 @@
 #include "TrackingTools/Producers/interface/TrajectoryCleanerESProducer.h"
 #include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleanerFactory.h"
 
-TrajectoryCleanerESProducer::TrajectoryCleanerESProducer(const edm::ParameterSet& iConfig)
-{
+TrajectoryCleanerESProducer::TrajectoryCleanerESProducer(const edm::ParameterSet& iConfig) {
   theComponentName = iConfig.getParameter<std::string>("ComponentName");
   theComponentType = iConfig.getParameter<std::string>("ComponentType");
 
@@ -10,14 +9,11 @@ TrajectoryCleanerESProducer::TrajectoryCleanerESProducer(const edm::ParameterSet
   setWhatProduced(this, theComponentName);
 }
 
-
-TrajectoryCleanerESProducer::~TrajectoryCleanerESProducer(){}
+TrajectoryCleanerESProducer::~TrajectoryCleanerESProducer() {}
 
 // ------------ method called to produce the data  ------------
-TrajectoryCleanerESProducer::ReturnType
-TrajectoryCleanerESProducer::produce(const  TrackingComponentsRecord & iRecord)
-{
-   using namespace edm::es;
-   
-   return ReturnType(TrajectoryCleanerFactory::get()->create(theComponentType, theConfig));
+TrajectoryCleanerESProducer::ReturnType TrajectoryCleanerESProducer::produce(const TrackingComponentsRecord& iRecord) {
+  using namespace edm::es;
+
+  return ReturnType(TrajectoryCleanerFactory::get()->create(theComponentType, theConfig));
 }

--- a/TrackingTools/Producers/src/module.cc
+++ b/TrackingTools/Producers/src/module.cc
@@ -9,7 +9,6 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-
 #include "FWCore/Utilities/interface/typelookup.h"
 
 DEFINE_FWK_EVENTSETUP_MODULE(StraightLinePropagatorESProducer);


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/258//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


