### PR TITLE
Fix ESInputTag syntax in test for GEM after #26780

### DIFF
--- a/DetectorDescription/DDCMS/test/python/testDDGEMAngularAlgorithm.py
+++ b/DetectorDescription/DDCMS/test/python/testDDGEMAngularAlgorithm.py
@@ -18,7 +18,7 @@ process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             )
 
 process.testDump = cms.EDAnalyzer("DDTestDumpFile",
-                                  DDDetector = cms.ESInputTag('TestDDGEMAngular')
+                                  DDDetector = cms.ESInputTag('','TestDDGEMAngular')
                                   )
 
 process.p = cms.Path(process.testDump)


### PR DESCRIPTION
#### PR description:

Trivial fix of a failure of a new geometry test configuration added by #26852 after the integration of #26780 that enforces label separation in the ESInputTag declaration.

#### PR validation:

The unit test failing in the CMSSW_11_0_X_2019-05-23-2300 IB has been verified to run smoothly.
 