### PR TITLE
[RECO] Remove ROOT::Math dict which are unused

### DIFF
--- a/DataFormats/Math/src/classes_def.xml
+++ b/DataFormats/Math/src/classes_def.xml
@@ -5,9 +5,6 @@
   <class pattern="ROOT::Math::RowOffsets<*>" />
   <class pattern="ROOT::Math::SVector<*>" />
   <class pattern="std::vector<ROOT::Math::SMatrix<*>>" />
-  <class pattern="std::vector<ROOT::Math::MatRepStd<*>>" />
-  <class pattern="std::vector<ROOT::Math::RowOffsets<*>>" />
-  <class pattern="std::vector<ROOT::Math::SVector<*>>" />
   <class pattern="edm::Wrapper<*>" />
   <class pattern="edm::RefVector<*>" />
   <class pattern="edm::ValueMap<*>" />


### PR DESCRIPTION
#### PR description:

PR https://github.com/cms-sw/cmssw/pull/26883 replaced the usage of `ROOT::Math::*` with explicit dictionaries for 
```
  <class pattern="std::vector<ROOT::Math::SMatrix<*>>" />
  <class pattern="std::vector<ROOT::Math::MatRepStd<*>>" />
  <class pattern="std::vector<ROOT::Math::RowOffsets<*>>" />
  <class pattern="std::vector<ROOT::Math::SVector<*>>" />
```
rootcling complains that 3 of these are not used. 
```
>> Building LCG reflex dict from header file src/DataFormats/Math/src/classes.h
  Warning: Unused class rule: std::vector<ROOT::Math::SVector<*>>
   Warning: Unused class rule: std::vector<ROOT::Math::RowOffsets<*>>
   Warning: Unused class rule: std::vector<ROOT::Math::MatRepStd<*>>
```
This PR proposes to drop these to avoid the warnings. 
#### PR validation:

Local compilation does not show these warnings any more.