### PR TITLE
Adapt RivetInterface for Rivet 2.7.2

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/RivetAnalyzer.cc
@@ -47,15 +47,10 @@ RivetAnalyzer::RivetAnalyzer(const edm::ParameterSet& pset)
   _analysisHandler.addAnalyses(analysisNames);
 
   //go through the analyses and check those that need the cross section
-  const std::set<AnaHandle, CmpAnaHandle>& analyses = _analysisHandler.analyses();
-
-  std::set<AnaHandle, CmpAnaHandle>::const_iterator ibeg = analyses.begin();
-  std::set<AnaHandle, CmpAnaHandle>::const_iterator iend = analyses.end();
-  std::set<AnaHandle, CmpAnaHandle>::const_iterator iana;
   _xsection = pset.getParameter<double>("CrossSection");
-  for (iana = ibeg; iana != iend; ++iana) {
-    if ((*iana)->needsCrossSection())
-      (*iana)->setCrossSection(_xsection);
+  for (AnaHandle iana : _analysisHandler.analyses()) {
+    if (iana->needsCrossSection())
+      iana->setCrossSection(_xsection);
   }
   if (_produceDQM) {
     // book stuff needed for DQM

--- a/GeneratorInterface/RivetInterface/test/runRivetAnalyzerMiniAOD_cfg.py
+++ b/GeneratorInterface/RivetInterface/test/runRivetAnalyzerMiniAOD_cfg.py
@@ -2,6 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('GEN')
 
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(100)
+
 process.load("GeneratorInterface.RivetInterface.mergedGenParticles_cfi")
 process.load("GeneratorInterface.RivetInterface.genParticles2HepMC_cff")
 process.load("GeneratorInterface.RivetInterface.rivetAnalyzer_cfi")
@@ -13,7 +16,7 @@ process.maxEvents = cms.untracked.PSet(
 # Input source
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        '/store/relval/CMSSW_9_1_0_pre1/RelValTTbar_13/MINIAODSIM/PU25ns_90X_mcRun2_asymptotic_v5-v1/00000/BE649FEB-C610-E711-AFD5-0CC47A4D769E.root',
+        '/store/relval/CMSSW_10_6_0/RelValTTbar_13/MINIAODSIM/PUpmx25ns_106X_upgrade2018_realistic_v4-v1/10000/DB4F12C2-3B53-4247-A1C3-BEB74F177362.root',
     ),
 )
 
@@ -22,7 +25,7 @@ process.options = cms.untracked.PSet()
 process.genParticles2HepMC.genParticles = cms.InputTag("mergedGenParticles")
 process.rivetAnalyzer.HepMCCollection = cms.InputTag("genParticles2HepMC:unsmeared")
 
-process.rivetAnalyzer.AnalysisNames = cms.vstring('CMS_2013_I1224539_DIJET')
+process.rivetAnalyzer.AnalysisNames = cms.vstring('CMS_2013_I1224539_DIJET', 'MC_TTBAR', 'CMS_2018_I1662081')
 process.rivetAnalyzer.OutputFile = cms.string('mcfile.yoda')
 
 process.p = cms.Path(process.mergedGenParticles*process.genParticles2HepMC*process.rivetAnalyzer)


### PR DESCRIPTION
#### PR description:

Update RivetInterface for Rivet Core change https://bitbucket.org/heprivet/rivet/commits/6ae4b32acee01c19b4fc064fa168e1083a61621c

#### PR validation:

RivetInterface runs successfully with new Rivet release 2.7.2

**Needs https://github.com/cms-sw/cmsdist/pull/5005**