### PR TITLE
Address warnings raised from L1T DQM for UL reco

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2uGT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGT_cff.py
@@ -28,7 +28,7 @@ l1tStage2uGMTOutVsuGTIn = DQMEDAnalyzer(
 # sequences
 l1tStage2uGTOnlineDQMSeq = cms.Sequence(
     l1tStage2uGT +
-    l1tStage2uGTTiming +
+    # l1tStage2uGTTiming +
     l1tStage2uGTCaloLayer2Comp +
     l1tStage2uGMTOutVsuGTIn
 )

--- a/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
@@ -177,13 +177,13 @@ l1tEtSumJetOfflineDQMEmu = l1tEtSumJetOfflineDQM.clone(
 
 # sequences
 l1tEtSumJetOfflineDQMSeq = cms.Sequence(
-    goodPFJetsForL1T
+    cms.ignore(goodPFJetsForL1T)
     + l1tPFMetNoMuForDQM
     + l1tEtSumJetOfflineDQM
 )
 
 l1tEtSumJetOfflineDQMEmuSeq = cms.Sequence(
-    goodPFJetsForL1T
+    cms.ignore(goodPFJetsForL1T)
     + l1tPFMetNoMuForDQM
     + l1tEtSumJetOfflineDQMEmu
 )


### PR DESCRIPTION
#### PR description:
Adds small fixes to prevent warnings from L1 DQM for the UL reco.  Namely:
* Tell CMSSW not to check the `goodPFJetsForL1T` EDFilter, which appears in an EndJob.
* Remove `l1tStage2uGTTiming` from the sequence since it doesn't have Era-dependent configuration causing several warnings.

#### PR validation:
I have confirmed that the reported warnings are no longer appearing, and the output DQM files seem as I'd expect.