### PR TITLE
Take SeedGeneratorFromRegionHits constructor arguments as unique_ptrs

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h
@@ -45,7 +45,7 @@ class SeedFilter {
   void seeds(edm::Event&, const edm::EventSetup&, const reco::SuperClusterRef &, TrajectorySeedCollection *);
 
  private:
-  SeedGeneratorFromRegionHits *combinatorialSeedGenerator;
+  std::unique_ptr<SeedGeneratorFromRegionHits> combinatorialSeedGenerator;
 
   // remove them FIXME
   double dr_, deta_, dphi_, pt_;

--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRegionalPixelSeedGeneratorProducers.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTRegionalPixelSeedGeneratorProducers.cc
@@ -66,9 +66,9 @@ EgammaHLTRegionalPixelSeedGeneratorProducers::EgammaHLTRegionalPixelSeedGenerato
   creatorPSet.addParameter<std::string>("propagator","PropagatorWithMaterial");
 
   edm::ConsumesCollector iC = consumesCollector();
-  combinatorialSeedGenerator = std::make_unique<SeedGeneratorFromRegionHits>( OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC),
+  combinatorialSeedGenerator = std::make_unique<SeedGeneratorFromRegionHits>( std::unique_ptr<OrderedHitsGenerator>{OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC)},
                                                                               nullptr,
-                                                                              SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
+                                                                              std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)}
                                                                               );
   // setup orderedhits setup (in order to tell seed generator to use pairs/triplets, which layers)
 }

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromOrderedHits.cc
@@ -20,9 +20,9 @@ TSGFromOrderedHits::TSGFromOrderedHits(const edm::ParameterSet &pset,edm::Consum
   edm::ParameterSet seedCreatorPSet = pset.getParameter<edm::ParameterSet>("SeedCreatorPSet");
   std::string seedCreatorType = seedCreatorPSet.getParameter<std::string>("ComponentName");
 
-  theGenerator = std::make_unique<SeedGeneratorFromRegionHits>(OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC),
+  theGenerator = std::make_unique<SeedGeneratorFromRegionHits>(std::unique_ptr<OrderedHitsGenerator>{OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC)},
                                                                nullptr,
-                                                               SeedCreatorFactory::get()->create(seedCreatorType, seedCreatorPSet)
+                                                               std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create(seedCreatorType, seedCreatorPSet)}
                                                                );
 
 }

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGSmart.cc
@@ -21,9 +21,9 @@ TSGSmart::TSGSmart(const edm::ParameterSet &pset,edm::ConsumesCollector& iC)
     PairPSet.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
   std::string pairhitsfactoryName = pairhitsfactoryPSet.getParameter<std::string>("ComponentName");
 
-  thePairGenerator = std::make_unique<SeedGeneratorFromRegionHits>( OrderedHitsGeneratorFactory::get()->create( pairhitsfactoryName, pairhitsfactoryPSet, iC),
+  thePairGenerator = std::make_unique<SeedGeneratorFromRegionHits>( std::unique_ptr<OrderedHitsGenerator>{OrderedHitsGeneratorFactory::get()->create( pairhitsfactoryName, pairhitsfactoryPSet, iC)},
                                                                     nullptr,
-                                                                    SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
+                                                                    std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)}
                                                                     );
 
   edm::ParameterSet TripletPSet = pset.getParameter<edm::ParameterSet>("PixelTripletGeneratorSet"); 
@@ -31,9 +31,9 @@ TSGSmart::TSGSmart(const edm::ParameterSet &pset,edm::ConsumesCollector& iC)
     TripletPSet.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
   std::string triplethitsfactoryName = triplethitsfactoryPSet.getParameter<std::string>("ComponentName");
 
-  theTripletGenerator = std::make_unique<SeedGeneratorFromRegionHits>( OrderedHitsGeneratorFactory::get()->create( triplethitsfactoryName, triplethitsfactoryPSet, iC),
+  theTripletGenerator = std::make_unique<SeedGeneratorFromRegionHits>( std::unique_ptr<OrderedHitsGenerator>{OrderedHitsGeneratorFactory::get()->create( triplethitsfactoryName, triplethitsfactoryPSet, iC)},
                                                                        nullptr,
-                                                                       SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
+                                                                       std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)}
                                                                        );
 
   edm::ParameterSet MixedPSet = pset.getParameter<edm::ParameterSet>("MixedGeneratorSet");
@@ -41,9 +41,9 @@ TSGSmart::TSGSmart(const edm::ParameterSet &pset,edm::ConsumesCollector& iC)
     MixedPSet.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
   std::string mixedhitsfactoryName = mixedhitsfactoryPSet.getParameter<std::string>("ComponentName");
 
-  theMixedGenerator = std::make_unique<SeedGeneratorFromRegionHits>( OrderedHitsGeneratorFactory::get()->create( mixedhitsfactoryName, mixedhitsfactoryPSet, iC),
+  theMixedGenerator = std::make_unique<SeedGeneratorFromRegionHits>( std::unique_ptr<OrderedHitsGenerator>{OrderedHitsGeneratorFactory::get()->create( mixedhitsfactoryName, mixedhitsfactoryPSet, iC)},
                                                                      nullptr,
-                                                                     SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)
+                                                                     std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", creatorPSet)}
                                                                      );
 }
 

--- a/RecoTracker/TkSeedGenerator/interface/SeedGeneratorFromRegionHits.h
+++ b/RecoTracker/TkSeedGenerator/interface/SeedGeneratorFromRegionHits.h
@@ -17,18 +17,11 @@ namespace edm { class Event; class EventSetup; }
 class SeedGeneratorFromRegionHits {
 public:
 
-  template <typename GEN>
-  SeedGeneratorFromRegionHits(GEN aGenerator): SeedGeneratorFromRegionHits(std::move(aGenerator), nullptr, nullptr) {}
-
-  template <typename GEN, typename COMP>
-  SeedGeneratorFromRegionHits(GEN aGenerator, COMP aComparitor): SeedGeneratorFromRegionHits(std::move(aGenerator), std::move(aComparitor), nullptr) {}
-
-  template <typename GEN, typename COMP, typename CREA>
-  SeedGeneratorFromRegionHits(GEN aGenerator, COMP aComparitor, CREA aSeedCreator):
-    theHitsGenerator{std::move(aGenerator)}, theComparitor{std::move(aComparitor)}, theSeedCreator{std::move(aSeedCreator)}
-  {}
-
-
+  SeedGeneratorFromRegionHits(
+      std::unique_ptr<OrderedHitsGenerator> aGenerator,
+      std::unique_ptr<SeedComparitor> aComparitor = nullptr,
+      std::unique_ptr<SeedCreator> aSeedCreator = nullptr
+    );
 
   // make job
   void run(TrajectorySeedCollection & seedCollection, const TrackingRegion & region, 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
@@ -54,9 +54,9 @@ SeedGeneratorFromRegionHitsEDProducer::SeedGeneratorFromRegionHitsEDProducer(
 
   std::string creatorName = creatorPSet.getParameter<std::string>("ComponentName");
 
-  theGenerator = std::make_unique<SeedGeneratorFromRegionHits>(OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC),
+  theGenerator = std::make_unique<SeedGeneratorFromRegionHits>(std::unique_ptr<OrderedHitsGenerator>{OrderedHitsGeneratorFactory::get()->create( hitsfactoryName, hitsfactoryPSet, iC)},
                                                                std::move(aComparitor),
-                                                               SeedCreatorFactory::get()->create( creatorName, creatorPSet));
+                                                               std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create( creatorName, creatorPSet)});
 
   produces<TrajectorySeedCollection>();
 }

--- a/RecoTracker/TkSeedGenerator/src/SeedGeneratorFromRegionHits.cc
+++ b/RecoTracker/TkSeedGenerator/src/SeedGeneratorFromRegionHits.cc
@@ -4,6 +4,11 @@
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
 #include "RecoTracker/TkSeedGenerator/interface/SeedCreator.h"
 
+SeedGeneratorFromRegionHits::SeedGeneratorFromRegionHits(
+  std::unique_ptr<OrderedHitsGenerator> ohg, std::unique_ptr<SeedComparitor> asc, std::unique_ptr<SeedCreator> asp)
+  : theHitsGenerator{std::move(ohg)}, theComparitor{std::move(asc)}, theSeedCreator{std::move(asp)}
+{ }
+
 void SeedGeneratorFromRegionHits::run(TrajectorySeedCollection & seedCollection, 
     const TrackingRegion & region, const edm::Event& ev, const edm::EventSetup& es)
 {


### PR DESCRIPTION
#### PR description:

This PR is a preparatory step to change PluginFactory to return `std::unique_ptr`.

(should be the last PR before making the change on the framework side, unless I've missed something)

#### PR validation:

Code compiles.