### PR TITLE
HCALDQM: Updates for Run 3 HB

### DIFF
--- a/DQM/HcalCommon/src/DetectorQuantity.cc
+++ b/DQM/HcalCommon/src/DetectorQuantity.cc
@@ -26,7 +26,8 @@ namespace hcaldqm {
 
     uint32_t getBin_ieta(HcalDetId const &did) { return (uint32_t)(getValue_ieta(did) + 1); }
 
-    uint32_t getBin_depth(HcalDetId const &did) { return (uint32_t)(did.depth()); }
+    uint32_t getBin_depth(HcalDetId const &did) { return (uint32_t)(
+      did.subdet() == HcalOuter ? 7 : did.depth()); }
 
     uint32_t getBin_Subdet(HcalDetId const &did) { return (uint32_t)(did.subdet()); }
 

--- a/DQM/HcalCommon/src/DetectorQuantity.cc
+++ b/DQM/HcalCommon/src/DetectorQuantity.cc
@@ -26,8 +26,9 @@ namespace hcaldqm {
 
     uint32_t getBin_ieta(HcalDetId const &did) { return (uint32_t)(getValue_ieta(did) + 1); }
 
-    uint32_t getBin_depth(HcalDetId const &did) { return (uint32_t)(
-      did.subdet() == HcalOuter ? 7 : did.depth()); }
+    uint32_t getBin_depth(HcalDetId const &did) { //return (uint32_t)(did.depth());}
+      return (uint32_t)(did.subdet() == HcalOuter ? 7 : did.depth());
+    }
 
     uint32_t getBin_Subdet(HcalDetId const &did) { return (uint32_t)(did.subdet()); }
 

--- a/DQM/HcalTasks/interface/DigiTask.h
+++ b/DQM/HcalTasks/interface/DigiTask.h
@@ -39,16 +39,14 @@ protected:
   void _process(edm::Event const &, edm::EventSetup const &) override;
   void _resetMonitors(hcaldqm::UpdateFreq) override;
 
-  edm::InputTag _tagHBHE;
-  edm::InputTag _tagHE;
+  edm::InputTag _tagQIE11;
   edm::InputTag _tagHO;
-  edm::InputTag _tagHF;
-  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-  edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
+  edm::InputTag _tagQIE10;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
   edm::EDGetTokenT<HODigiCollection> _tokHO;
-  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
 
-  double _cutSumQ_HBHE, _cutSumQ_HE, _cutSumQ_HO, _cutSumQ_HF;
+  double _cutSumQ_HBHE, _cutSumQ_HO, _cutSumQ_HF;
   double _thresh_unihf;
 
   //	flag vector
@@ -70,7 +68,6 @@ protected:
   hcaldqm::filter::HashFilter _filter_FEDHF;
   hcaldqm::filter::HashFilter _filter_QIE1011;
   hcaldqm::filter::HashFilter _filter_QIE8;
-  hcaldqm::filter::HashFilter _filter_HEP17;
 
   /* hcaldqm::Containers */
   //	ADC, fC - Charge - just filling - no summary!

--- a/DQM/HcalTasks/interface/LEDTask.h
+++ b/DQM/HcalTasks/interface/LEDTask.h
@@ -40,16 +40,14 @@ protected:
   virtual void _dump();
 
   //	tags and tokens
-  edm::InputTag _tagHBHE;
-  edm::InputTag _tagHE;
-  edm::InputTag _tagHO;
-  edm::InputTag _tagHF;
-  edm::InputTag _tagTrigger;
-  edm::InputTag _taguMN;
-  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-  edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
+  edm::InputTag	_tagQIE11;
+  edm::InputTag	_tagHO;
+  edm::InputTag	_tagQIE10;
+  edm::InputTag	_tagTrigger;
+  edm::InputTag	_taguMN;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
   edm::EDGetTokenT<HODigiCollection> _tokHO;
-  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::EDGetTokenT<HcalTBTriggerData> _tokTrigger;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
@@ -61,7 +59,6 @@ protected:
   //	Cuts
   int _nevents;
   double _lowHBHE;
-  double _lowHE;
   double _lowHO;
   double _lowHF;
 

--- a/DQM/HcalTasks/interface/LaserTask.h
+++ b/DQM/HcalTasks/interface/LaserTask.h
@@ -46,15 +46,13 @@ protected:
   void processLaserMon(edm::Handle<QIE10DigiCollection> &col, std::vector<int> &iLaserMonADC);
 
   //	tags and tokens
-  edm::InputTag _tagHBHE;
-  edm::InputTag _tagHE;
+  edm::InputTag _tagQIE11;
   edm::InputTag _tagHO;
-  edm::InputTag _tagHF;
+  edm::InputTag _tagQIE10;
   edm::InputTag _taguMN;
-  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-  edm::EDGetTokenT<QIE11DigiCollection> _tokHE;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
   edm::EDGetTokenT<HODigiCollection> _tokHO;
-  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
 
   enum LaserFlag { fBadTiming = 0, fMissingLaserMon = 1, nLaserFlag = 2 };

--- a/DQM/HcalTasks/interface/PedestalTask.h
+++ b/DQM/HcalTasks/interface/PedestalTask.h
@@ -36,17 +36,15 @@ protected:
   virtual void _dump();
 
   //	tags and tokens
-  edm::InputTag _tagHBHE;
-  edm::InputTag _tagHE;
+  edm::InputTag _tagQIE11;
   edm::InputTag _tagHO;
-  edm::InputTag _tagHF;
+  edm::InputTag _tagQIE10;
   edm::InputTag _tagTrigger;
   edm::InputTag _taguMN;
   edm::EDGetTokenT<HcalUMNioDigi> _tokuMN;
-  edm::EDGetTokenT<HBHEDigiCollection> _tokHBHE;
-  edm::EDGetTokenT<QIE11DigiCollection> _tokHEP17;
+  edm::EDGetTokenT<QIE11DigiCollection> _tokQIE11;
   edm::EDGetTokenT<HODigiCollection> _tokHO;
-  edm::EDGetTokenT<QIE10DigiCollection> _tokHF;
+  edm::EDGetTokenT<QIE10DigiCollection> _tokQIE10;
   edm::EDGetTokenT<HcalTBTriggerData> _tokTrigger;
 
   std::vector<hcaldqm::flag::Flag> _vflags;

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -779,15 +779,15 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
 }
 
 /* virtual */ void DigiTask::_process(edm::Event const& e, edm::EventSetup const&) {
-  edm::Handle<QIE11DigiCollection>     c_qie11;
+  edm::Handle<QIE11DigiCollection>     c_QIE11;
   edm::Handle<HODigiCollection>       c_ho;
-  edm::Handle<QIE10DigiCollection>       c_qie10;
+  edm::Handle<QIE10DigiCollection>       c_QIE10;
 
-  if (!e.getByToken(_tokQIE11, c_qie11))
+  if (!e.getByToken(_tokQIE11, c_QIE11))
     _logger.dqmthrow("Collection QIE11DigiCollection isn't available" + _tagQIE11.label() + " " + _tagQIE11.instance());
   if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokQIE10, c_qie10))
+  if (!e.getByToken(_tokQIE10, c_QIE10))
     _logger.dqmthrow("Collection QIE10DigiCollection isn't available" + _tagQIE10.label() + " " + _tagQIE10.instance());
 
   //	extract some info per event
@@ -807,7 +807,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   int numChsCutHE = 0;
 
   // HB+HE QIE11 collection
-  for (QIE11DigiCollection::const_iterator it=c_qie11->begin(); it!=c_qie11->end();
+  for (QIE11DigiCollection::const_iterator it=c_QIE11->begin(); it!=c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
 
     //	Explicit check on the DetIds present in the Collection
@@ -1146,7 +1146,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   rawidValid = 0;
 
   //	HF collection
-  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_QIE10->begin(); it != c_QIE10->end(); ++it) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
 
     //	Explicit check on the DetIds present in the Collection

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -94,7 +94,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
   // Filters for QIE8 vs QIE10/11
   std::vector<uint32_t> vhashQIE8;
   vhashQIE8.push_back(hcaldqm::hashfunctions::hash_did[hcaldqm::hashfunctions::fSubdet](HcalDetId(HcalOuter, 1,1,4)));  
-  _filter_QIE8.initialize(filter::fFilter, hcaldqm::hashfunctions::fSubdet,
+  _filter_QIE8.initialize(filter::fPreserver, hcaldqm::hashfunctions::fSubdet,
     vhashQIE8);
 
   std::vector<uint32_t> vhashQIE1011; 
@@ -1234,6 +1234,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps) : DQTask(ps) {
     //if (!_filter_QIE1011.filter(did)) {
     _cSumQ_SubdetPM_QIE1011.fill(did, sumQ);
     //}
+    
     _cOccupancy_depth.fill(did);
     if (_ptype == fOnline) {
       _xNChs.get(eid)++;

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -407,22 +407,22 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
 
 /* virtual */ void LEDTask::_process(edm::Event const& e, edm::EventSetup const& es) {
   edm::Handle<HODigiCollection>   c_ho;
-  edm::Handle<QIE10DigiCollection>    c_qie10;
-  edm::Handle<QIE11DigiCollection>    c_qie11;
+  edm::Handle<QIE10DigiCollection>    c_QIE10;
+  edm::Handle<QIE11DigiCollection>    c_QIE11;
 
   if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available "
       + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokQIE10, c_qie10))
+  if (!e.getByToken(_tokQIE10, c_QIE10))
     _logger.dqmthrow("Collection QIE10DigiCollection isn't available "
       + _tagQIE10.label() + " " + _tagQIE10.instance());
-  if (!e.getByToken(_tokQIE11, c_qie11))
+  if (!e.getByToken(_tokQIE11, c_QIE11))
     _logger.dqmthrow("Collection QIE11DigiCollection isn't available "
       + _tagQIE11.label() + " " + _tagQIE11.instance());
 
   //	int currentEvent = e.eventAuxiliary().id().event();
 
-  for (QIE11DigiCollection::const_iterator it = c_qie11->begin(); it != c_qie11->end(); ++it) {
+  for (QIE11DigiCollection::const_iterator it = c_QIE11->begin(); it != c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
     if ((did.subdet() != HcalBarrel) && (did.subdet() != HcalEndcap)) {
@@ -438,6 +438,16 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
               } else if (_ptype == fLocal) {
                 _LED_ADCvsEvn_Subdet.fill(
                     HcalDetId(HcalEndcap, 16, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
+              }
+            }
+          } else if (std::find(_ledCalibrationChannels[HcalBarrel].begin(), _ledCalibrationChannels[HcalBarrel].end(), did) !=
+              _ledCalibrationChannels[HcalBarrel].end()) {
+            for (int i = 0; i < digi.samples(); i++) {
+              if (_ptype == fOnline) {
+                _LED_ADCvsBX_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), e.bunchCrossing(), digi[i].adc());
+              } else if (_ptype == fLocal) {
+                _LED_ADCvsEvn_Subdet.fill(
+                    HcalDetId(HcalBarrel, 1, 1, 1), e.eventAuxiliary().id().event(), digi[i].adc());
               }
             }
           }
@@ -504,7 +514,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
       }
     }
   }
-  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+  for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
     HcalDetId did = digi.id();
     HcalElectronicsId eid = digi.elecId();
@@ -539,7 +549,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
     }
   }
 
-  for (QIE10DigiCollection::const_iterator it = c_qie10->begin(); it != c_qie10->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_QIE10->begin(); it != c_QIE10->end(); ++it) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
     HcalDetId did = digi.detid();
     if (did.subdet() != HcalForward) {

--- a/DQM/HcalTasks/plugins/LEDTask.cc
+++ b/DQM/HcalTasks/plugins/LEDTask.cc
@@ -4,25 +4,28 @@
 using namespace hcaldqm;
 using namespace hcaldqm::constants;
 using namespace hcaldqm::filter;
+
 LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _nevents = ps.getUntrackedParameter<int>("nevents", 2000);
   //	tags
-  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
-  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
-  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
-  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
-  _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger", edm::InputTag("tbunpacker"));
-  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
-  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-  _tokHE = consumes<QIE11DigiCollection>(_tagHE);
+  _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE",
+    edm::InputTag("hcalDigis"));
+  _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO",
+    edm::InputTag("hcalDigis"));
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF",
+    edm::InputTag("hcalDigis"));
+  _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger",
+    edm::InputTag("tbunpacker"));
+  _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN",
+    edm::InputTag("hcalDigis"));
+  _tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
   _tokHO = consumes<HODigiCollection>(_tagHO);
-  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
   _tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
   _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 
   //	constants
   _lowHBHE = ps.getUntrackedParameter<double>("lowHBHE", 20);
-  _lowHE = ps.getUntrackedParameter<double>("lowHE", 20);
   _lowHO = ps.getUntrackedParameter<double>("lowHO", 20);
   _lowHF = ps.getUntrackedParameter<double>("lowHF", 20);
 
@@ -225,14 +228,14 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
   }
 
   // Plots for LED in global
+  if (_ptype == fOnline || _ptype == fLocal) {
+    _cADCvsTS_SubdetPM.initialize(_name, "ADCvsTS",
+      hcaldqm::hashfunctions::fSubdetPM,
+      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
+      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
+      new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),0);   
+  }
   if (_ptype == fOnline) {
-    _cADCvsTS_SubdetPM.initialize(_name,
-                                  "ADCvsTS",
-                                  hcaldqm::hashfunctions::fSubdetPM,
-                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fTiming_TS),
-                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fQIE10ADC_256),
-                                  new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN, true),
-                                  0);
     _cLowSignal_CrateSlot.initialize(_name,
                                      "LowSignal",
                                      new hcaldqm::quantity::ElectronicsQuantity(hcaldqm::quantity::fCrateuTCA),
@@ -307,8 +310,10 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
     _cMissing_FEDVME.book(ib, _emap, _filter_uTCA, _subsystem);
     _cMissing_FEDuTCA.book(ib, _emap, _filter_VME, _subsystem);
   }
+  if (_ptype == fOnline || _ptype == fLocal) {
+    _cADCvsTS_SubdetPM.book(ib, _emap, _subsystem);   
+  }
   if (_ptype == fOnline) {
-    _cADCvsTS_SubdetPM.book(ib, _emap, _subsystem);
     _cLowSignal_CrateSlot.book(ib, _subsystem);
     _cSumQ_SubdetPM.book(ib, _emap, _subsystem);
     _cTDCTime_SubdetPM.book(ib, _emap, _subsystem);
@@ -401,62 +406,26 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
 }
 
 /* virtual */ void LEDTask::_process(edm::Event const& e, edm::EventSetup const& es) {
-  edm::Handle<HBHEDigiCollection> chbhe;
-  edm::Handle<HODigiCollection> cho;
-  edm::Handle<QIE10DigiCollection> chf;
-  edm::Handle<QIE11DigiCollection> che;
+  edm::Handle<HODigiCollection>   c_ho;
+  edm::Handle<QIE10DigiCollection>    c_qie10;
+  edm::Handle<QIE11DigiCollection>    c_qie11;
 
-  if (!e.getByToken(_tokHBHE, chbhe))
-    _logger.dqmthrow("Collection HBHEDigiCollection isn't available " + _tagHBHE.label() + " " + _tagHBHE.instance());
-  if (!e.getByToken(_tokHO, cho))
-    _logger.dqmthrow("Collection HODigiCollection isn't available " + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokHF, chf))
-    _logger.dqmthrow("Collection QIE10DigiCollection isn't available " + _tagHF.label() + " " + _tagHF.instance());
-  if (!e.getByToken(_tokHE, che))
-    _logger.dqmthrow("Collection QIE11DigiCollection isn't available " + _tagHE.label() + " " + _tagHE.instance());
+  if (!e.getByToken(_tokHO, c_ho))
+    _logger.dqmthrow("Collection HODigiCollection isn't available "
+      + _tagHO.label() + " " + _tagHO.instance());
+  if (!e.getByToken(_tokQIE10, c_qie10))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available "
+      + _tagQIE10.label() + " " + _tagQIE10.instance());
+  if (!e.getByToken(_tokQIE11, c_qie11))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available "
+      + _tagQIE11.label() + " " + _tagQIE11.instance());
 
   //	int currentEvent = e.eventAuxiliary().id().event();
 
-  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
-    const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
-    HcalDetId did = digi.id();
-    HcalElectronicsId eid = digi.elecId();
-
-    // Get total charge and apply charge cut
-    CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<HBHEDataFrame>(_dbService, did, digi);
-    //double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(digi, 2.5, 0, digi.size()-1);
-    double sumQ = hcaldqm::utilities::sumQDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
-    if (sumQ >= _lowHBHE) {
-      //double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0,digi.size()-1);
-      double aveTS = hcaldqm::utilities::aveTSDB<HBHEDataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
-
-      _xSignalSum.get(did) += sumQ;
-      _xSignalSum2.get(did) += sumQ * sumQ;
-      _xTimingSum.get(did) += aveTS;
-      _xTimingSum2.get(did) += aveTS * aveTS;
-      _xEntries.get(did)++;
-
-      if (_ptype == fLocal) {  // hidefed2crate
-        for (int i = 0; i < digi.size(); i++) {
-          //_cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC()-2.5);
-          _cShapeCut_FEDSlot.fill(
-              eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HBHEDataFrame>(_dbService, digi_fC, did, digi, i));
-        }
-      }
-
-      if (_ptype == fOnline) {
-        for (int iTS = 0; iTS < digi.size(); ++iTS) {
-          _cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());
-        }
-        _cSumQ_SubdetPM.fill(did, sumQ);
-      }
-    }
-  }
-
-  for (QIE11DigiCollection::const_iterator it = che->begin(); it != che->end(); ++it) {
+  for (QIE11DigiCollection::const_iterator it = c_qie11->begin(); it != c_qie11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
-    if (did.subdet() != HcalEndcap) {
+    if ((did.subdet() != HcalBarrel) && (did.subdet() != HcalEndcap)) {
       // LED monitoring from calibration channels
       if (did.subdet() == HcalOther) {
         HcalOtherDetId hodid(digi.detid());
@@ -474,7 +443,6 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
           }
         }
       }
-
       continue;
     }
     uint32_t rawid = _ehashmap.lookup(did);
@@ -490,7 +458,7 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
     CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
     //double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
     double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
-    if (sumQ >= _lowHE) {
+    if (sumQ >= _lowHBHE) {
       //double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
       double aveTS = hcaldqm::utilities::aveTSDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.size() - 1);
 
@@ -507,9 +475,13 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
               eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE11DataFrame>(_dbService, digi_fC, did, digi, i));
         }
       }
+      if (_ptype == fOnline || _ptype == fLocal) {
+        for (int iTS = 0; iTS < digi.samples(); ++iTS) {
+          _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc()); 
+        }       
+      }
       if (_ptype == fOnline) {
         for (int iTS = 0; iTS < digi.samples(); ++iTS) {
-          _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());
           if (digi[iTS].tdc() < 50) {
             double time = iTS * 25. + (digi[iTS].tdc() / 2.);
             _cTDCTime_SubdetPM.fill(did, time);
@@ -556,16 +528,18 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
               eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<HODataFrame>(_dbService, digi_fC, did, digi, i));
         }
       }
-      if (_ptype == fOnline) {
+      if (_ptype == fOnline || _ptype == fLocal) {
         for (int iTS = 0; iTS < digi.size(); ++iTS) {
           _cADCvsTS_SubdetPM.fill(did, iTS, digi.sample(iTS).adc());
         }
+      }
+      if (_ptype == fOnline) {
         _cSumQ_SubdetPM.fill(did, sumQ);
       }
     }
   }
 
-  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_qie10->begin(); it != c_qie10->end(); ++it) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
     HcalDetId did = digi.detid();
     if (did.subdet() != HcalForward) {
@@ -612,9 +586,13 @@ LEDTask::LEDTask(edm::ParameterSet const& ps) : DQTask(ps) {
               eid, i, hcaldqm::utilities::adc2fCDBMinusPedestal<QIE10DataFrame>(_dbService, digi_fC, did, digi, i));
         }
       }
-      if (_ptype == fOnline) {
+      if (_ptype == fOnline || _ptype == fLocal) {
         for (int iTS = 0; iTS < digi.samples(); ++iTS) {
           _cADCvsTS_SubdetPM.fill(did, iTS, digi[iTS].adc());
+       	}
+      }
+      if (_ptype == fOnline) {
+        for (int iTS = 0; iTS < digi.samples(); ++iTS) {
           if (digi[iTS].le_tdc() < 50) {
             double time = iTS * 25. + (digi[iTS].le_tdc() / 2.);
             _cTDCTime_SubdetPM.fill(did, time);

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -7,16 +7,14 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _nevents = ps.getUntrackedParameter<int>("nevents", 2000);
 
   //	tags
-  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
-  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
+  _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
   _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
-  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
   _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
   _tagLaserMon = ps.getUntrackedParameter<edm::InputTag>("tagLaserMon", edm::InputTag("LASERMON"));
-  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-  _tokHE = consumes<QIE11DigiCollection>(_tagHE);
+  _tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
   _tokHO = consumes<HODigiCollection>(_tagHO);
-  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
   _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
   _tokLaserMon = consumes<QIE10DigiCollection>(_tagLaserMon);
 
@@ -26,7 +24,6 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
 
   //	constants
   _lowHBHE = ps.getUntrackedParameter<double>("lowHBHE", 50);
-  _lowHE = ps.getUntrackedParameter<double>("lowHE", 150);
   _lowHO = ps.getUntrackedParameter<double>("lowHO", 100);
   _lowHF = ps.getUntrackedParameter<double>("lowHF", 50);
   _laserType = (uint32_t)ps.getUntrackedParameter<uint32_t>("laserType");
@@ -564,19 +561,16 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
 }
 
 /* virtual */ void LaserTask::_process(edm::Event const& e, edm::EventSetup const& es) {
-  edm::Handle<HBHEDigiCollection> chbhe;
-  edm::Handle<QIE11DigiCollection> cHE;
-  edm::Handle<HODigiCollection> cho;
-  edm::Handle<QIE10DigiCollection> chf;
+  edm::Handle<QIE11DigiCollection> c_QIE11;
+  edm::Handle<HODigiCollection> c_ho;
+  edm::Handle<QIE10DigiCollection> c_QIE10;
 
-  if (!e.getByToken(_tokHBHE, chbhe))
-    _logger.dqmthrow("Collection HBHEDigiCollection isn't available " + _tagHBHE.label() + " " + _tagHBHE.instance());
-  if (!e.getByToken(_tokHE, cHE))
-    _logger.dqmthrow("Collection QIE11DigiCollection isn't available " + _tagHE.label() + " " + _tagHE.instance());
-  if (!e.getByToken(_tokHO, cho))
+  if (!e.getByToken(_tokQIE11, c_QIE11))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available " + _tagQIE11.label() + " " + _tagQIE11.instance());
+  if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available " + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokHF, chf))
-    _logger.dqmthrow("Collection QIE10DigiCollection isn't available " + _tagHF.label() + " " + _tagHF.instance());
+  if (!e.getByToken(_tokQIE10, c_QIE10))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available " + _tagQIE10.label() + " " + _tagQIE10.instance());
 
   //	int currentEvent = e.eventAuxiliary().id().event();
   int bx = e.bunchCrossing();
@@ -631,51 +625,10 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
     }
   }
 
-  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
-    const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
-    double sumQ = hcaldqm::utilities::sumQ<HBHEDataFrame>(digi, 2.5, 0, digi.size() - 1);
-    if (sumQ < _lowHBHE)
-      continue;
-    HcalDetId did = digi.id();
-    HcalElectronicsId eid = digi.elecId();
-
-    double aveTS = hcaldqm::utilities::aveTS<HBHEDataFrame>(digi, 2.5, 0, digi.size() - 1);
-    _xSignalSum.get(did) += sumQ;
-    _xSignalSum2.get(did) += sumQ * sumQ;
-    _xTimingSum.get(did) += aveTS;
-    _xTimingSum2.get(did) += aveTS * aveTS;
-    _xEntries.get(did)++;
-
-    for (int i = 0; i < digi.size(); i++) {
-      if (_ptype == fLocal) {  // hidefed2crate
-        _cShapeCut_FEDSlot.fill(eid, i, digi.sample(i).nominal_fC() - 2.5);
-      }
-      _cADC_SubdetPM.fill(did, digi.sample(i).adc());
-    }
-
-    //	select based on local global
-    double digiTimingSOI = (aveTS - digi.presamples()) * 25.;
-    double deltaTiming = digiTimingSOI - laserMonTiming;
-    _cTiming_DigivsLaserMon_SubdetPM.fill(did, laserMonTiming, digiTimingSOI);
-    _xTimingRefLMSum.get(did) += deltaTiming;
-    _xTimingRefLMSum2.get(did) += deltaTiming * deltaTiming;
-    if (_ptype == fLocal) {
-      int currentEvent = e.eventAuxiliary().id().event();
-      _cTimingvsEvent_SubdetPM.fill(did, currentEvent, aveTS);
-      _cSignalvsEvent_SubdetPM.fill(did, currentEvent, sumQ);
-      _cTimingDiffLS_SubdetPM.fill(did, currentEvent, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-    } else {
-      _cTimingvsLS_SubdetPM.fill(did, _currentLS, aveTS);
-      _cSignalvsLS_SubdetPM.fill(did, _currentLS, sumQ);
-      _cTimingvsBX_SubdetPM.fill(did, bx, aveTS);
-      _cSignalvsBX_SubdetPM.fill(did, bx, sumQ);
-      _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
-    }
-  }
   for (QIE11DigiCollection::const_iterator it = cHE->begin(); it != cHE->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
-    if (did.subdet() != HcalEndcap) {
+    if ((did.subdet() != HcalBarrel) && (did.subdet() != HcalEndcap)) {
       continue;
     }
     uint32_t rawid = _ehashmap.lookup(did);
@@ -684,7 +637,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
     CaloSamples digi_fC = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(_dbService, did, digi);
     //double sumQ = hcaldqm::utilities::sumQ_v10<QIE11DataFrame>(digi, 2.5, 0, digi.samples()-1);
     double sumQ = hcaldqm::utilities::sumQDB<QIE11DataFrame>(_dbService, digi_fC, did, digi, 0, digi.samples() - 1);
-    if (sumQ < _lowHE)
+    if (sumQ < _lowHBHE)
       continue;
 
     //double aveTS = hcaldqm::utilities::aveTS_v10<QIE11DataFrame>(digi, 2.5, 0,digi.samples()-1);
@@ -722,7 +675,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
       _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
     }
   }
-  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+  for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
     double sumQ = hcaldqm::utilities::sumQ<HODataFrame>(digi, 8.5, 0, digi.size() - 1);
     if (sumQ < _lowHO)
@@ -763,7 +716,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
       _cTimingDiffLS_SubdetPM.fill(did, _currentLS, hcaldqm::utilities::getRBX(did.iphi()), deltaTiming);
     }
   }
-  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_QIE10->begin(); it != c_QIE10->end(); ++it) {
     const QIE10DataFrame digi = (const QIE10DataFrame)(*it);
     HcalDetId did = digi.detid();
     if (did.subdet() != HcalForward) {

--- a/DQM/HcalTasks/plugins/LaserTask.cc
+++ b/DQM/HcalTasks/plugins/LaserTask.cc
@@ -625,7 +625,7 @@ LaserTask::LaserTask(edm::ParameterSet const& ps) : DQTask(ps) {
     }
   }
 
-  for (QIE11DigiCollection::const_iterator it = cHE->begin(); it != cHE->end(); ++it) {
+  for (QIE11DigiCollection::const_iterator it = c_QIE11->begin(); it != c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
     if ((did.subdet() != HcalBarrel) && (did.subdet() != HcalEndcap)) {

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -6,15 +6,15 @@ using namespace hcaldqm::constants;
 PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
   //	tags
   _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
-  _tagHE = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
+  _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
   _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
-  _tagHF = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
+  _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
   _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger", edm::InputTag("tbunpacker"));
   _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
   _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
-  _tokHEP17 = consumes<QIE11DigiCollection>(_tagHE);
+  _tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
   _tokHO = consumes<HODigiCollection>(_tagHO);
-  _tokHF = consumes<QIE10DigiCollection>(_tagHF);
+  _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
   _tokTrigger = consumes<HcalTBTriggerData>(_tagTrigger);
   _tokuMN = consumes<HcalUMNioDigi>(_taguMN);
 
@@ -947,40 +947,19 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
 }
 
 /* virtual */ void PedestalTask::_process(edm::Event const& e, edm::EventSetup const& es) {
-  edm::Handle<HBHEDigiCollection> chbhe;
-  edm::Handle<HODigiCollection> cho;
-  edm::Handle<QIE10DigiCollection> chf;
-  edm::Handle<QIE11DigiCollection> chep17;
+  edm::Handle<HODigiCollection> c_ho;
+  edm::Handle<QIE10DigiCollection> c_qie10;
+  edm::Handle<QIE11DigiCollection> c_qie11;
 
-  if (!e.getByToken(_tokHBHE, chbhe))
-    _logger.dqmthrow("Collection HBHEDigiCollection isn't available" + _tagHBHE.label() + " " + _tagHBHE.instance());
-  if (!e.getByToken(_tokHO, cho))
+  if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());
-  if (!e.getByToken(_tokHF, chf))
-    _logger.dqmthrow("Collection QIE10DigiCollection isn't available" + _tagHF.label() + " " + _tagHF.instance());
-  if (!e.getByToken(_tokHEP17, chep17))
-    _logger.dqmthrow("Collection QIE11DigiCollection isn't available" + _tagHE.label() + " " + _tagHE.instance());
+  if (!e.getByToken(_tokQIE10, c_QIE10))
+    _logger.dqmthrow("Collection QIE10DigiCollection isn't available" + _tagQIE10.label() + " " + _tagQIE10.instance());
+  if (!e.getByToken(_tokQIE11, c_QIE11))
+    _logger.dqmthrow("Collection QIE11DigiCollection isn't available" + _tagQIE11.label() + " " + _tagQIE11.instance());
 
   int nHB(0), nHE(0), nHO(0), nHF(0);
-  for (HBHEDigiCollection::const_iterator it = chbhe->begin(); it != chbhe->end(); ++it) {
-    const HBHEDataFrame digi = (const HBHEDataFrame)(*it);
-    HcalDetId did = digi.id();
-    int digiSizeToUse = floor(digi.size() / constants::CAPS_NUM) * constants::CAPS_NUM - 1;
-    did.subdet() == HcalBarrel ? nHB++ : nHE++;
-
-    for (int i = 0; i < digiSizeToUse; i++) {
-      _cADC_SubdetPM.fill(did, it->sample(i).adc());
-
-      _xPedSum1LS.get(did) += it->sample(i).adc();
-      _xPedSum21LS.get(did) += it->sample(i).adc() * it->sample(i).adc();
-      _xPedEntries1LS.get(did)++;
-
-      _xPedSumTotal.get(did) += it->sample(i).adc();
-      _xPedSum2Total.get(did) += it->sample(i).adc() * it->sample(i).adc();
-      _xPedEntriesTotal.get(did)++;
-    }
-  }
-  for (QIE11DigiCollection::const_iterator it = chep17->begin(); it != chep17->end(); ++it) {
+  for (QIE11DigiCollection::const_iterator it = c_QIE11->begin(); it != c_QIE11->end(); ++it) {
     const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*it);
     HcalDetId const& did = digi.detid();
     // Require barrel or endcap. As of 2017, some calibration channels are ending up in this collection.
@@ -1006,7 +985,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
   _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalBarrel, 1, 1, 1), _currentLS, nHB);
   _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalEndcap, 1, 1, 1), _currentLS, nHE);
 
-  for (HODigiCollection::const_iterator it = cho->begin(); it != cho->end(); ++it) {
+  for (HODigiCollection::const_iterator it = c_ho->begin(); it != c_ho->end(); ++it) {
     const HODataFrame digi = (const HODataFrame)(*it);
     HcalDetId did = digi.id();
     int digiSizeToUse = floor(digi.size() / constants::CAPS_NUM) * constants::CAPS_NUM - 1;
@@ -1025,7 +1004,7 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
   }
   _cOccupancyEAvsLS_Subdet.fill(HcalDetId(HcalOuter, 1, 1, 1), _currentLS, nHO);
 
-  for (QIE10DigiCollection::const_iterator it = chf->begin(); it != chf->end(); ++it) {
+  for (QIE10DigiCollection::const_iterator it = c_QIE10->begin(); it != c_QIE10->end(); ++it) {
     const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
     HcalDetId did = digi.detid();
     if (did.subdet() != HcalForward) {

--- a/DQM/HcalTasks/plugins/PedestalTask.cc
+++ b/DQM/HcalTasks/plugins/PedestalTask.cc
@@ -5,13 +5,11 @@ using namespace hcaldqm;
 using namespace hcaldqm::constants;
 PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
   //	tags
-  _tagHBHE = ps.getUntrackedParameter<edm::InputTag>("tagHBHE", edm::InputTag("hcalDigis"));
   _tagQIE11 = ps.getUntrackedParameter<edm::InputTag>("tagHE", edm::InputTag("hcalDigis"));
   _tagHO = ps.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"));
   _tagQIE10 = ps.getUntrackedParameter<edm::InputTag>("tagHF", edm::InputTag("hcalDigis"));
   _tagTrigger = ps.getUntrackedParameter<edm::InputTag>("tagTrigger", edm::InputTag("tbunpacker"));
   _taguMN = ps.getUntrackedParameter<edm::InputTag>("taguMN", edm::InputTag("hcalDigis"));
-  _tokHBHE = consumes<HBHEDigiCollection>(_tagHBHE);
   _tokQIE11 = consumes<QIE11DigiCollection>(_tagQIE11);
   _tokHO = consumes<HODigiCollection>(_tagHO);
   _tokQIE10 = consumes<QIE10DigiCollection>(_tagQIE10);
@@ -948,8 +946,8 @@ PedestalTask::PedestalTask(edm::ParameterSet const& ps) : DQTask(ps) {
 
 /* virtual */ void PedestalTask::_process(edm::Event const& e, edm::EventSetup const& es) {
   edm::Handle<HODigiCollection> c_ho;
-  edm::Handle<QIE10DigiCollection> c_qie10;
-  edm::Handle<QIE11DigiCollection> c_qie11;
+  edm::Handle<QIE10DigiCollection> c_QIE10;
+  edm::Handle<QIE11DigiCollection> c_QIE11;
 
   if (!e.getByToken(_tokHO, c_ho))
     _logger.dqmthrow("Collection HODigiCollection isn't available" + _tagHO.label() + " " + _tagHO.instance());

--- a/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcal_dqm_sourceclient-live_cfg.py
@@ -28,7 +28,7 @@ useMap       = False
 from DQM.Integration.config.online_customizations_cfi import *
 if useOfflineGT:
 	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
-	process.GlobalTag.globaltag = '100X_dataRun2_HLT_v1'
+	process.GlobalTag.globaltag = '106X_dataRun2_PromptLike_Candidate_2019_05_04_08_47_47'
 	#process.GlobalTag.globaltag = '100X_dataRun2_HLT_Candidate_2018_01_31_16_04_35'
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')


### PR DESCRIPTION
#### PR description:

This PR implements Run 3 HB in HCAL DQM. The old HBHEDigiCollection is removed, and the new HB digis are taken from QIE11DigiCollection. Since HB now overlaps with HO in (ieta, iphi, depth) space, HO digis are plotted in depth 7 for now. A future PR will improve on that hack, moving HO (and perhaps all subsystems) to their own ieta-iphi plots, rather than attempting to plot all subsystems together. 

#### PR validation:

Successfully ran over recent local and global runs with partial HB installation. Note that running in online DQM will require appropriate conditions, which are being developed in parallel.
