### PR TITLE
Fix the storage of the header record from the SiPixel template in case it is less than 80 chars long

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
@@ -59,10 +59,9 @@ std::unique_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::pr
 			  title_char[iter] ='\n';
 			} else  {
 			  for (unsigned int it=0; it!=3-(iter%4); it++) {
-			    iter++;
 			    title_char[iter] =' ';
+			    iter++;
 			  }
-			  iter++;
 			  title_char[iter] ='\n';
 			}
 			

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
@@ -49,16 +49,24 @@ std::unique_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::pr
 			char title_char[80], c;
 			SiPixelGenErrorDBObject::char2float temp;
 			float tempstore;
-			int iter,j;
+			unsigned int iter;
 			
 			// GenErrors contain a header char - we must be clever about storing this
-			for (iter = 0; (c=in_file.get()) != '\n'; ++iter) {
-				if(iter < 79) {title_char[iter] = c;}
+			for (iter = 0; (c=in_file.get()) != '\n' && iter<79; ++iter) {
+			  title_char[iter] = c;
 			}
-			if(iter > 78) {iter=78;}
-			title_char[iter+1] ='\n';
+			if(iter == 79) {
+			  title_char[iter] ='\n';
+			} else  {
+			  for (unsigned int it=0; it!=3-(iter%4); it++) {
+			    iter++;
+			    title_char[iter] =' ';
+			  }
+			  iter++;
+			  title_char[iter] ='\n';
+			}
 			
-			for(j=0; j<80; j+=4) {
+			for(unsigned int j=0; j<=iter; j+=4) {
 				temp.c[0] = title_char[j];
 				temp.c[1] = title_char[j+1];
 				temp.c[2] = title_char[j+2];

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGenErrorDBObjectESSource.cc
@@ -58,7 +58,8 @@ std::unique_ptr<SiPixelGenErrorDBObject> SiPixelFakeGenErrorDBObjectESSource::pr
 			if(iter == 79) {
 			  title_char[iter] ='\n';
 			} else  {
-			  for (unsigned int it=0; it!=3-(iter%4); it++) {
+			  unsigned int ilast = 3-(iter%4);
+			  for (unsigned int it=0; it!=ilast; it++) {
 			    title_char[iter] =' ';
 			    iter++;
 			  }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
@@ -58,7 +58,8 @@ std::unique_ptr<SiPixelTemplateDBObject> SiPixelFakeTemplateDBObjectESSource::pr
 			if(iter == 79) {
 			  title_char[iter] ='\n';
 			} else  {
-			  for (unsigned int it=0; it!=3-(iter%4); it++) {
+			  unsigned int ilast =  3-(iter%4);
+			  for (unsigned int it=0; it!=ilast; it++) {
 			    title_char[iter] =' ';
 			    iter++;
 			  }

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
@@ -49,16 +49,24 @@ std::unique_ptr<SiPixelTemplateDBObject> SiPixelFakeTemplateDBObjectESSource::pr
 			char title_char[80], c;
 			SiPixelTemplateDBObject::char2float temp;
 			float tempstore;
-			int iter,j;
+			unsigned int iter;
 			
 			// Templates contain a header char - we must be clever about storing this
-			for (iter = 0; (c=in_file.get()) != '\n'; ++iter) {
-				if(iter < 79) {title_char[iter] = c;}
+			for (iter = 0; (c=in_file.get()) != '\n' && iter<79; ++iter) {
+			  title_char[iter] = c;
 			}
-			if(iter > 78) {iter=78;}
-			title_char[iter+1] ='\n';
+			if(iter == 79) {
+			  title_char[iter] ='\n';
+			} else  {
+			  for (unsigned int it=0; it!=3-(iter%4); it++) {
+			    iter++;
+			    title_char[iter] =' ';
+			  }
+			  iter++;
+			  title_char[iter] ='\n';
+			}
 			
-			for(j=0; j<80; j+=4) {
+			for(unsigned int j=0; j<=iter; j+=4) {
 				temp.c[0] = title_char[j];
 				temp.c[1] = title_char[j+1];
 				temp.c[2] = title_char[j+2];

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeTemplateDBObjectESSource.cc
@@ -59,10 +59,9 @@ std::unique_ptr<SiPixelTemplateDBObject> SiPixelFakeTemplateDBObjectESSource::pr
 			  title_char[iter] ='\n';
 			} else  {
 			  for (unsigned int it=0; it!=3-(iter%4); it++) {
-			    iter++;
 			    title_char[iter] =' ';
+			    iter++;
 			  }
-			  iter++;
 			  title_char[iter] ='\n';
 			}
 			


### PR DESCRIPTION
#### PR description:

As catched by the static analyzer automatically run during the standar PR tests, there would be garbage values assigned in case the header record of the template calibration file contains a carriage return before its 80th character.

This PR contains a proposal to fix that hypothetical case, which had quite likely never happened (otherwise I'd expect we would have encountered it already in current tests and productions).

Please @pmaksim1 @OzAmram verify that this does not conflict with the original purpose of this code.

#### PR validation:

It compiles, and short matrix tests run to completion.
No differences are expected in output, although this was not actually checked explicitly.

