### PR TITLE
Running code-format for fastsim

### DIFF
--- a/FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastRecHit.h
+++ b/FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastRecHit.h
@@ -7,58 +7,53 @@
 #include <vector>
 
 class CTPPSFastRecHit {
-    public: 
-        //destructor
-        // ~CTPPSFastRecHit() {}
-        CTPPSFastRecHit() : theDetUnitId(0) {}
-        // constructor
-        // requires the DetId, the hit position, the ToF and the CellId 
-        // For the Tracker, ToF and CellId = 0
-        // For the timing x = x_CellId, y = y_CellId, z = z_detector
+public:
+  //destructor
+  // ~CTPPSFastRecHit() {}
+  CTPPSFastRecHit() : theDetUnitId(0) {}
+  // constructor
+  // requires the DetId, the hit position, the ToF and the CellId
+  // For the Tracker, ToF and CellId = 0
+  // For the timing x = x_CellId, y = y_CellId, z = z_detector
 
-        CTPPSFastRecHit(const Local3DPoint& entry, unsigned int detId, float tof, unsigned int cellId):
-            theEntryPoint( entry), 
-            theDetUnitId( detId),
-            theTof(tof),       
-            theCellId( cellId) {}
-        /// Entry point in the local Det frame 
-        Local3DPoint entryPoint() const {return theEntryPoint;}
+  CTPPSFastRecHit(const Local3DPoint& entry, unsigned int detId, float tof, unsigned int cellId)
+      : theEntryPoint(entry), theDetUnitId(detId), theTof(tof), theCellId(cellId) {}
+  /// Entry point in the local Det frame
+  Local3DPoint entryPoint() const { return theEntryPoint; }
 
-        /* Time of flight in nanoseconds from the primary interaction
+  /* Time of flight in nanoseconds from the primary interaction
          *  to the entry point. Always positive in a PSimHit,
          *  but may become negative in a SimHit due to bunch assignment.
          */
-        float timeOfFlight() const {return tof();}
+  float timeOfFlight() const { return tof(); }
 
-        /// deprecated name for timeOfFlight()
-        float tof() const {return theTof;}
+  /// deprecated name for timeOfFlight()
+  float tof() const { return theTof; }
 
-        /* The DetUnit identifier, to be interpreted in the context of the
+  /* The DetUnit identifier, to be interpreted in the context of the
          *  detector system that produced the hit.
          *  For CTPPS its content has: Detector(CTPPS), SubDet (Tracker or Timing)
          *  ArmF(z>0)/ArmB(z<0),  Pot and Plane (= 0)
          */
-        unsigned int detUnitId() const {return theDetUnitId;}
-        //the ToF cell number
-        unsigned int cellId() const {return theCellId;}
+  unsigned int detUnitId() const { return theDetUnitId; }
+  //the ToF cell number
+  unsigned int cellId() const { return theCellId; }
 
-        void setTof(float tof) {theTof=tof;}
+  void setTof(float tof) { theTof = tof; }
 
-        void setLocal3DPoint(const Local3DPoint& entry){theEntryPoint = entry;}
+  void setLocal3DPoint(const Local3DPoint& entry) { theEntryPoint = entry; }
 
-        void setDetUnitId(unsigned int detId){theDetUnitId = detId;}
+  void setDetUnitId(unsigned int detId) { theDetUnitId = detId; }
 
-	void setCellId(unsigned int cellId){theCellId = cellId;}
+  void setCellId(unsigned int cellId) { theCellId = cellId; }
 
+protected:
+  // properties
+  Local3DPoint theEntryPoint;  // position at entry
+  // association
+  unsigned int theDetUnitId;
+  float theTof;  // Time Of Flight
+  unsigned int theCellId;
+};
 
-    protected: 
-        // properties
-        Local3DPoint theEntryPoint; // position at entry
-        // association
-        unsigned int theDetUnitId;
-        float theTof; // Time Of Flight 
-        unsigned int theCellId;
-}; 
-
-
-#endif //CTPPSFastRecHit_H
+#endif  //CTPPSFastRecHit_H

--- a/FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastRecHitContainer.h
+++ b/FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastRecHitContainer.h
@@ -7,11 +7,10 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include <vector>
-#include "DataFormats/Common/interface/RefToBase.h" 
+#include "DataFormats/Common/interface/RefToBase.h"
 
 namespace edm {
-    typedef std::vector<CTPPSFastRecHit> CTPPSFastRecHitContainer;
-} // edm
+  typedef std::vector<CTPPSFastRecHit> CTPPSFastRecHitContainer;
+}  // namespace edm
 
-#endif 
-
+#endif

--- a/FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastTrack.h
+++ b/FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastTrack.h
@@ -1,99 +1,116 @@
 #ifndef FastSimDataFormats_CTPPSFastSim_CTPPSFastTrack_H
 #define FastSimDataFormats_CTPPSFastSim_CTPPSFastTrack_H
 
-
 #include "DataFormats/Math/interface/Vector.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Math/interface/Point3D.h"
 
 #include <vector>
 class CTPPSFastTrack {
-    public: 
-        typedef math::XYZVector Vector;
-        typedef math::XYZPoint Point;
-        // ~CTPPSFastTrack() {}
-        CTPPSFastTrack() : thet(0.),thexi(0.),thecellid(0),thetof(0.),thex1(0.),they1(0.),thex2(0.),they2(0.),momentum_(0, 0, 0),vertex_(0, 0, 0) {}
-        // constructor
-        CTPPSFastTrack(float t,float xi,unsigned int cellid ,float tof,float x1,float y1,float x2,float y2,const Vector &momentum,const Point &vertex): 
-            thet(t),
-            thexi(xi),
-            thecellid(cellid),
-            thetof(tof),
-            thex1(x1),
-            they1(y1),
-            thex2(x2),
-            they2(y2),
-            momentum_(momentum),
-            vertex_(vertex) {}	
+public:
+  typedef math::XYZVector Vector;
+  typedef math::XYZPoint Point;
+  // ~CTPPSFastTrack() {}
+  CTPPSFastTrack()
+      : thet(0.),
+        thexi(0.),
+        thecellid(0),
+        thetof(0.),
+        thex1(0.),
+        they1(0.),
+        thex2(0.),
+        they2(0.),
+        momentum_(0, 0, 0),
+        vertex_(0, 0, 0) {}
+  // constructor
+  CTPPSFastTrack(float t,
+                 float xi,
+                 unsigned int cellid,
+                 float tof,
+                 float x1,
+                 float y1,
+                 float x2,
+                 float y2,
+                 const Vector &momentum,
+                 const Point &vertex)
+      : thet(t),
+        thexi(xi),
+        thecellid(cellid),
+        thetof(tof),
+        thex1(x1),
+        they1(y1),
+        thex2(x2),
+        they2(y2),
+        momentum_(momentum),
+        vertex_(vertex) {}
 
-        ////////////////////////////
-        //
-        /// track momentum vector
-        const Vector &momentum() const;
-        /// Reference point on the track
-        const Point &referencePoint() const;
-        // reference point on the track. This method is DEPRECATED, please use referencePoint() instead
-        const Point &vertex() const ;
-        /* Time of flight in nanoseconds from the primary interaction
+  ////////////////////////////
+  //
+  /// track momentum vector
+  const Vector &momentum() const;
+  /// Reference point on the track
+  const Point &referencePoint() const;
+  // reference point on the track. This method is DEPRECATED, please use referencePoint() instead
+  const Point &vertex() const;
+  /* Time of flight in nanoseconds from the primary interaction
          *  to the entry point. Always positive in a PSimHit,
          *  but may become negative in a SimHit due to bunch assignment.
          */
-        float timeOfFlight() const {return tof();}
+  float timeOfFlight() const { return tof(); }
 
-        float t() const {return thet;}
+  float t() const { return thet; }
 
-        float xi() const {return thexi;}
+  float xi() const { return thexi; }
 
-        float tof() const {return thetof;}
-        
-        float x1() const {return thex1;}
+  float tof() const { return thetof; }
 
-        float y1() const {return they1;}
+  float x1() const { return thex1; }
 
-        float x2() const {return thex2;}
+  float y1() const { return they1; }
 
-        float y2() const {return they2;}
-        float px() const {return momentum_.x();}
-        float py() const {return momentum_.Y();}
-        float pz() const {return momentum_.Z();}
-        float x0() const {return vertex_.x();}
-        float y0() const {return vertex_.Y();}
-        float z0() const {return vertex_.Z();}
+  float x2() const { return thex2; }
 
-        unsigned int cellid() const {return thecellid;}
+  float y2() const { return they2; }
+  float px() const { return momentum_.x(); }
+  float py() const { return momentum_.Y(); }
+  float pz() const { return momentum_.Z(); }
+  float x0() const { return vertex_.x(); }
+  float y0() const { return vertex_.Y(); }
+  float z0() const { return vertex_.Z(); }
 
-        void setp(const Vector& momentum ) { momentum_ = momentum; }
+  unsigned int cellid() const { return thecellid; }
 
-        void setvertex(const Point &vertex) {vertex_ = vertex;}
+  void setp(const Vector &momentum) { momentum_ = momentum; }
 
-        void settof(float tof) {thetof=tof;}
+  void setvertex(const Point &vertex) { vertex_ = vertex; }
 
-        void sett(float t){thet = t;}
+  void settof(float tof) { thetof = tof; }
 
-        void setxi(float xi){thexi = xi;}
+  void sett(float t) { thet = t; }
 
-        void setx1(float x1){thex1 = x1;}
+  void setxi(float xi) { thexi = xi; }
 
-        void sety1(float y1){they1 = y1;}
+  void setx1(float x1) { thex1 = x1; }
 
-        void setx2(float x2){thex2 = x2;}
+  void sety1(float y1) { they1 = y1; }
 
-        void sety2(float y2){they2 = y2;}
+  void setx2(float x2) { thex2 = x2; }
 
-        void setcellid(unsigned int cellid ){thecellid=cellid;}
+  void sety2(float y2) { they2 = y2; }
 
-    private: 
-        float    thet;
-        float    thexi;
-        unsigned int   thecellid;
-        float    thetof;
-        float    thex1;
-        float    they1;
-        float    thex2;
-        float    they2;
-        Vector momentum_;
-        Point vertex_;
+  void setcellid(unsigned int cellid) { thecellid = cellid; }
 
-}; 
+private:
+  float thet;
+  float thexi;
+  unsigned int thecellid;
+  float thetof;
+  float thex1;
+  float they1;
+  float thex2;
+  float they2;
+  Vector momentum_;
+  Point vertex_;
+};
 
-#endif //CTPPSFastTrack_H
+#endif  //CTPPSFastTrack_H

--- a/FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastTrackContainer.h
+++ b/FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastTrackContainer.h
@@ -5,11 +5,10 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include <vector>
-#include "DataFormats/Common/interface/RefToBase.h" 
+#include "DataFormats/Common/interface/RefToBase.h"
 
 namespace edm {
-    typedef std::vector<CTPPSFastTrack> CTPPSFastTrackContainer;
-} // edm
+  typedef std::vector<CTPPSFastTrack> CTPPSFastTrackContainer;
+}  // namespace edm
 
-#endif 
-
+#endif

--- a/FastSimDataFormats/CTPPSFastSim/src/CTPPSFastRecHit.cc
+++ b/FastSimDataFormats/CTPPSFastSim/src/CTPPSFastRecHit.cc
@@ -1,6 +1,6 @@
 #include "FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastRecHit.h"
 #include <ostream>
 
-std::ostream & operator<<(std::ostream & o, const CTPPSFastRecHit & hit) 
-{ return o << hit.detUnitId() << " " << hit.entryPoint() << " " << hit.tof() << "  "  << hit.cellId(); }
-
+std::ostream& operator<<(std::ostream& o, const CTPPSFastRecHit& hit) {
+  return o << hit.detUnitId() << " " << hit.entryPoint() << " " << hit.tof() << "  " << hit.cellId();
+}

--- a/FastSimDataFormats/CTPPSFastSim/src/CTPPSFastTrack.cc
+++ b/FastSimDataFormats/CTPPSFastSim/src/CTPPSFastTrack.cc
@@ -1,6 +1,6 @@
 #include "FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastTrack.h"
 #include <ostream>
 //float t,float xi,unsigned int cellid ,float tof,const Vector &momentum,const Point &vertex)
-std::ostream & operator<<(std::ostream & o, const CTPPSFastTrack & hit) 
-{ return o << hit.t() << " " << hit.xi() << " " << hit.cellid() << "  "  << hit.tof()  ;}
-
+std::ostream& operator<<(std::ostream& o, const CTPPSFastTrack& hit) {
+  return o << hit.t() << " " << hit.xi() << " " << hit.cellid() << "  " << hit.tof();
+}

--- a/FastSimDataFormats/CTPPSFastSim/src/classes.h
+++ b/FastSimDataFormats/CTPPSFastSim/src/classes.h
@@ -5,6 +5,4 @@
 #include "FastSimDataFormats/CTPPSFastSim/interface/CTPPSFastRecHitContainer.h"
 /***/
 
-
 #include <vector>
-


### PR DESCRIPTION
Applying code-format for CMSSW category fastsim.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/275//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


