### PR TITLE
Running code-format for db-dqm

### DIFF
--- a/CondFormats/DQMObjects/interface/DQMSummary.h
+++ b/CondFormats/DQMObjects/interface/DQMSummary.h
@@ -17,7 +17,7 @@
 */
 
 class DQMSummary {
- public:
+public:
   long long m_run;
   struct RunItem {
     long long m_lumisec;
@@ -26,33 +26,30 @@ class DQMSummary {
       std::string m_reportcontent;
       std::string m_type;
       double m_status;
-    
-    COND_SERIALIZABLE;
-};
+
+      COND_SERIALIZABLE;
+    };
     std::vector<LumiItem> m_lumisummary;
-  
-  COND_SERIALIZABLE;
-};
-  DQMSummary(){}
-  virtual ~DQMSummary(){}
+
+    COND_SERIALIZABLE;
+  };
+  DQMSummary() {}
+  virtual ~DQMSummary() {}
   std::vector<RunItem> m_summary;
   void printAllValues() const {
     std::cout << "run number = " << m_run << std::endl;
     std::vector<RunItem>::const_iterator runIt;
-    for(runIt = m_summary.begin(); runIt != m_summary.end(); ++runIt) {
+    for (runIt = m_summary.begin(); runIt != m_summary.end(); ++runIt) {
       std::cout << "--- lumisection = " << runIt->m_lumisec << std::endl;
       std::vector<RunItem::LumiItem>::const_iterator lumiIt;
-      for(lumiIt = runIt->m_lumisummary.begin(); lumiIt != runIt->m_lumisummary.end(); ++lumiIt) {
-	std::cout << "------ subsystem: " << lumiIt->m_subsystem 
-		  << ", report content: " << lumiIt->m_reportcontent
-		  << ", type: " << lumiIt->m_type
-		  << ", status = " << lumiIt->m_status
-		  << std::endl;
+      for (lumiIt = runIt->m_lumisummary.begin(); lumiIt != runIt->m_lumisummary.end(); ++lumiIt) {
+        std::cout << "------ subsystem: " << lumiIt->m_subsystem << ", report content: " << lumiIt->m_reportcontent
+                  << ", type: " << lumiIt->m_type << ", status = " << lumiIt->m_status << std::endl;
       }
     }
   }
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/DQMObjects/interface/HDQMSummary.h
+++ b/CondFormats/DQMObjects/interface/HDQMSummary.h
@@ -3,10 +3,10 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-#include<vector>
-#include<map>
-#include<iostream>
-#include<boost/cstdint.hpp>
+#include <vector>
+#include <map>
+#include <iostream>
+#include <boost/cstdint.hpp>
 #include "FWCore/Utilities/interface/Exception.h"
 
 /**
@@ -37,110 +37,94 @@ namespace hdqmsummary {
 */
 
 class HDQMSummary {
+public:
+  struct DetRegistry {
+    uint32_t detid;
+    uint32_t ibegin;
 
-	public:
-
-		struct DetRegistry{
-			uint32_t detid;
-			uint32_t ibegin;
-		
     COND_SERIALIZABLE;
-};
-                
-		class StrictWeakOrdering{
-			public:
-				bool operator() (const DetRegistry& p,const uint32_t& i) const {return p.detid < i;}
-		};
+  };
 
+  class StrictWeakOrdering {
+  public:
+    bool operator()(const DetRegistry& p, const uint32_t& i) const { return p.detid < i; }
+  };
 
-                // SOME DEFINITIONS
-                //
-	        typedef std::vector<float>::const_iterator               ContainerIterator;  
-		typedef std::pair<ContainerIterator, ContainerIterator>  Range; 		     
-		typedef std::vector<DetRegistry>                         Registry;
-		typedef Registry::const_iterator                         RegistryIterator;
-		typedef std::vector<float>		                 InputVector;
-                
-		
-		HDQMSummary(std::vector<std::string>& userDBContent);
-		HDQMSummary(const HDQMSummary& input);
-		HDQMSummary(){};
-		~HDQMSummary(){};
-		
-             
-		ContainerIterator getDataVectorBegin()     const {return v_sum_.begin();  }
-		ContainerIterator getDataVectorEnd()       const {return v_sum_.end();    } 
-		RegistryIterator  getRegistryVectorBegin() const {return indexes_.begin();}
-		RegistryIterator  getRegistryVectorEnd()   const {return indexes_.end();  }
+  // SOME DEFINITIONS
+  //
+  typedef std::vector<float>::const_iterator ContainerIterator;
+  typedef std::pair<ContainerIterator, ContainerIterator> Range;
+  typedef std::vector<DetRegistry> Registry;
+  typedef Registry::const_iterator RegistryIterator;
+  typedef std::vector<float> InputVector;
 
-                // RETURNS POSITION OF DETID IN v_sum_
-		//
-		const Range getRange(const uint32_t& detID) const;
-		
-		
-		// RETURNS LIST OF DETIDS 
-		//
-		std::vector<uint32_t> getDetIds() const;
-                
-		
-		// INSERT SUMMARY OBJECTS...
-		//
-		bool put(const uint32_t& detID, InputVector &input, std::vector<std::string>& userContent );
-		void setObj(const uint32_t& detID, std::string elementName, float value);
-		
-		
-		// RETRIEVE SUMMARY OBJECTS...
-		//
-		
-		// returns a vector of selected infos related to a given detId 
-		std::vector<float> getSummaryObj(uint32_t& detID, const std::vector<std::string>& list) const; 
-		 
-		// returns a vector filled with "info elementName" for each detId 
-		// The order is SORTED according to the one used in getDetIds() !
-		std::vector<float> getSummaryObj(std::string elementName) const;     
-		                                                      
-		// returns the entire SummaryObj related to one detId
-		std::vector<float> getSummaryObj(uint32_t& detID) const;
-			
-		// returns everything, all SummaryObjects for all detIds (unsorted !)
-		std::vector<float> getSummaryObj() const;		      
-		
-	
-		// INLINE METHODS ABOUT RUN, TIME VALUE...
-		//
-                inline void setUserDBContent(const std::vector<std::string>& userDBContent)  { userDBContent_ = userDBContent;}
-	        inline void setRunNr(int inputRunNr)                       { runNr_ = inputRunNr;      }
-                inline void setTimeValue(unsigned long long inputTimeValue){ timeValue_=inputTimeValue;}
-                
-		inline unsigned long long getTimeValue() const             { return timeValue_;        }
-                inline std::vector<std::string>  getUserDBContent() const  { return userDBContent_;    }
-                inline int getRunNr() const                                { return runNr_;            }
-               
-	       
-	        // PRINT METHOD...
-		//
-                void print();
-                
-		
-		// HDQMSummary MEMBERS...
-		//
-		std::vector<std::string>        userDBContent_;
-                std::vector<float> 	        v_sum_; 
-		std::vector<DetRegistry> 	indexes_;
-		
-	        int runNr_; 
-                unsigned long long timeValue_;
-		
-		
-        protected:	
-	
-	        // RETURNS POSITION OF ELEMENTNAME IN userDBContent_
-	        const short getPosition(std::string elementName) const;
-	
-	
-   
+  HDQMSummary(std::vector<std::string>& userDBContent);
+  HDQMSummary(const HDQMSummary& input);
+  HDQMSummary(){};
+  ~HDQMSummary(){};
+
+  ContainerIterator getDataVectorBegin() const { return v_sum_.begin(); }
+  ContainerIterator getDataVectorEnd() const { return v_sum_.end(); }
+  RegistryIterator getRegistryVectorBegin() const { return indexes_.begin(); }
+  RegistryIterator getRegistryVectorEnd() const { return indexes_.end(); }
+
+  // RETURNS POSITION OF DETID IN v_sum_
+  //
+  const Range getRange(const uint32_t& detID) const;
+
+  // RETURNS LIST OF DETIDS
+  //
+  std::vector<uint32_t> getDetIds() const;
+
+  // INSERT SUMMARY OBJECTS...
+  //
+  bool put(const uint32_t& detID, InputVector& input, std::vector<std::string>& userContent);
+  void setObj(const uint32_t& detID, std::string elementName, float value);
+
+  // RETRIEVE SUMMARY OBJECTS...
+  //
+
+  // returns a vector of selected infos related to a given detId
+  std::vector<float> getSummaryObj(uint32_t& detID, const std::vector<std::string>& list) const;
+
+  // returns a vector filled with "info elementName" for each detId
+  // The order is SORTED according to the one used in getDetIds() !
+  std::vector<float> getSummaryObj(std::string elementName) const;
+
+  // returns the entire SummaryObj related to one detId
+  std::vector<float> getSummaryObj(uint32_t& detID) const;
+
+  // returns everything, all SummaryObjects for all detIds (unsorted !)
+  std::vector<float> getSummaryObj() const;
+
+  // INLINE METHODS ABOUT RUN, TIME VALUE...
+  //
+  inline void setUserDBContent(const std::vector<std::string>& userDBContent) { userDBContent_ = userDBContent; }
+  inline void setRunNr(int inputRunNr) { runNr_ = inputRunNr; }
+  inline void setTimeValue(unsigned long long inputTimeValue) { timeValue_ = inputTimeValue; }
+
+  inline unsigned long long getTimeValue() const { return timeValue_; }
+  inline std::vector<std::string> getUserDBContent() const { return userDBContent_; }
+  inline int getRunNr() const { return runNr_; }
+
+  // PRINT METHOD...
+  //
+  void print();
+
+  // HDQMSummary MEMBERS...
+  //
+  std::vector<std::string> userDBContent_;
+  std::vector<float> v_sum_;
+  std::vector<DetRegistry> indexes_;
+
+  int runNr_;
+  unsigned long long timeValue_;
+
+protected:
+  // RETURNS POSITION OF ELEMENTNAME IN userDBContent_
+  const short getPosition(std::string elementName) const;
+
   COND_SERIALIZABLE;
 };
-		
 
 #endif

--- a/CondFormats/DQMObjects/src/HDQMSummary.cc
+++ b/CondFormats/DQMObjects/src/HDQMSummary.cc
@@ -2,185 +2,162 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <algorithm>
-		
-HDQMSummary::HDQMSummary(std::vector<std::string>& userDBContent)
-{
+
+HDQMSummary::HDQMSummary(std::vector<std::string>& userDBContent) {
   userDBContent_ = userDBContent;
   runNr_ = 0;
   timeValue_ = 0;
 }
 
-
-HDQMSummary::HDQMSummary(const HDQMSummary& input)
-{
+HDQMSummary::HDQMSummary(const HDQMSummary& input) {
   userDBContent_ = input.getUserDBContent();
   runNr_ = input.getTimeValue();
   timeValue_ = input.getRunNr();
   v_sum_.clear();
   indexes_.clear();
-  v_sum_.insert(v_sum_.end(),input.v_sum_.begin(),input.v_sum_.end());
-  indexes_.insert(indexes_.end(),input.indexes_.begin(),input.indexes_.end());
+  v_sum_.insert(v_sum_.end(), input.v_sum_.begin(), input.v_sum_.end());
+  indexes_.insert(indexes_.end(), input.indexes_.begin(), input.indexes_.end());
 }
 
+bool HDQMSummary::put(const uint32_t& DetId, InputVector& input, std::vector<std::string>& userContent) {
+  Registry::iterator p = std::lower_bound(indexes_.begin(), indexes_.end(), DetId, HDQMSummary::StrictWeakOrdering());
 
-bool HDQMSummary::put(const uint32_t& DetId, InputVector &input, std::vector<std::string>& userContent ) 
-{
-  Registry::iterator p 	= std::lower_bound(indexes_.begin(),indexes_.end(),DetId,HDQMSummary::StrictWeakOrdering());
-  
-  if(p==indexes_.end() || p->detid!=DetId){
+  if (p == indexes_.end() || p->detid != DetId) {
     //First request for the given DetID
     //Create entries for all the declared userDBContent
     //and fill for the provided userContent
- 
+
     DetRegistry detregistry;
-    detregistry.detid  = DetId;
+    detregistry.detid = DetId;
     detregistry.ibegin = v_sum_.size();
-    indexes_.insert(p,detregistry);
-    InputVector tmp(userDBContent_.size(),-9999);
+    indexes_.insert(p, detregistry);
+    InputVector tmp(userDBContent_.size(), -9999);
 
-    for(size_t i=0;i<userContent.size();++i)
-      tmp[getPosition(userContent[i])]=input[i];
-    
-    v_sum_.insert(v_sum_.end(),tmp.begin(),tmp.end());
+    for (size_t i = 0; i < userContent.size(); ++i)
+      tmp[getPosition(userContent[i])] = input[i];
+
+    v_sum_.insert(v_sum_.end(), tmp.begin(), tmp.end());
   } else {
-
-    if (p->detid==DetId){
-      //I should already find the entries 
+    if (p->detid == DetId) {
+      //I should already find the entries
       //fill for the provided userContent
 
-      for(size_t i=0;i<userContent.size();++i)
-	v_sum_[p->ibegin+getPosition(userContent[i])]=input[i];
+      for (size_t i = 0; i < userContent.size(); ++i)
+        v_sum_[p->ibegin + getPosition(userContent[i])] = input[i];
     }
   }
-	
+
   return true;
 }
 
-
-const HDQMSummary::Range HDQMSummary::getRange(const uint32_t& DetId) const 
-{
-
-  RegistryIterator p = std::lower_bound(indexes_.begin(),indexes_.end(),DetId,HDQMSummary::StrictWeakOrdering());
-  if (p==indexes_.end()|| p->detid!=DetId) {
-    return HDQMSummary::Range(v_sum_.end(),v_sum_.end()); std::cout << "not in range " << std::endl;}
-  else 
-    return HDQMSummary::Range(v_sum_.begin()+p->ibegin,v_sum_.begin()+p->ibegin+userDBContent_.size());
+const HDQMSummary::Range HDQMSummary::getRange(const uint32_t& DetId) const {
+  RegistryIterator p = std::lower_bound(indexes_.begin(), indexes_.end(), DetId, HDQMSummary::StrictWeakOrdering());
+  if (p == indexes_.end() || p->detid != DetId) {
+    return HDQMSummary::Range(v_sum_.end(), v_sum_.end());
+    std::cout << "not in range " << std::endl;
+  } else
+    return HDQMSummary::Range(v_sum_.begin() + p->ibegin, v_sum_.begin() + p->ibegin + userDBContent_.size());
 }
 
-
-std::vector<uint32_t> HDQMSummary::getDetIds() const 
-{
+std::vector<uint32_t> HDQMSummary::getDetIds() const {
   // returns vector of DetIds in map
   std::vector<uint32_t> DetIds_;
   HDQMSummary::RegistryIterator begin = indexes_.begin();
-  HDQMSummary::RegistryIterator end   = indexes_.end();
-  for (HDQMSummary::RegistryIterator p=begin; p != end; ++p) {
+  HDQMSummary::RegistryIterator end = indexes_.end();
+  for (HDQMSummary::RegistryIterator p = begin; p != end; ++p) {
     DetIds_.push_back(p->detid);
   }
   return DetIds_;
 }
 
-
-
-const short HDQMSummary::getPosition(std::string elementName) const
-{
+const short HDQMSummary::getPosition(std::string elementName) const {
   // returns position of elementName in UserDBContent_
-    
-  std::vector<std::string>::const_iterator it = find(userDBContent_.begin(),userDBContent_.end(),elementName);  
+
+  std::vector<std::string>::const_iterator it = find(userDBContent_.begin(), userDBContent_.end(), elementName);
   short pos = -1;
-  if (it != userDBContent_.end()) pos = it - userDBContent_.begin();
-  else edm::LogError("HDQMSummary") << "attempting to retrieve non existing historic DB object : "<< elementName <<std::endl;
-  return pos;  
-}   
-
-
-
-void  HDQMSummary::setObj(const uint32_t& detID, std::string elementName, float value) 
-{
-  // modifies value of info "elementName" for the given detID
-  // requires that an entry has be defined beforehand for detId in DB
-  RegistryIterator p = std::lower_bound(indexes_.begin(),indexes_.end(),detID,HDQMSummary::StrictWeakOrdering());
-  if (p==indexes_.end()|| p->detid!=detID) 
-    {
-      throw cms::Exception("")
-	<<"not allowed to modify "<< elementName << " in historic DB - SummaryObj needs to be available first !";
-    }
-
-  const HDQMSummary::Range range = getRange(detID);
-   
-  std::vector<float>::const_iterator it = range.first+getPosition(elementName);
-  std::vector<float>::difference_type pos = -1;
-  if (it != v_sum_.end()){ 
-    pos = it - v_sum_.begin();
-    v_sum_.at(pos) = value; }  
+  if (it != userDBContent_.end())
+    pos = it - userDBContent_.begin();
+  else
+    edm::LogError("HDQMSummary") << "attempting to retrieve non existing historic DB object : " << elementName
+                                 << std::endl;
+  return pos;
 }
 
+void HDQMSummary::setObj(const uint32_t& detID, std::string elementName, float value) {
+  // modifies value of info "elementName" for the given detID
+  // requires that an entry has be defined beforehand for detId in DB
+  RegistryIterator p = std::lower_bound(indexes_.begin(), indexes_.end(), detID, HDQMSummary::StrictWeakOrdering());
+  if (p == indexes_.end() || p->detid != detID) {
+    throw cms::Exception("") << "not allowed to modify " << elementName
+                             << " in historic DB - SummaryObj needs to be available first !";
+  }
 
-std::vector<float> HDQMSummary::getSummaryObj(uint32_t& detID, const std::vector<std::string>& _list) const
-{  
+  const HDQMSummary::Range range = getRange(detID);
+
+  std::vector<float>::const_iterator it = range.first + getPosition(elementName);
+  std::vector<float>::difference_type pos = -1;
+  if (it != v_sum_.end()) {
+    pos = it - v_sum_.begin();
+    v_sum_.at(pos) = value;
+  }
+}
+
+std::vector<float> HDQMSummary::getSummaryObj(uint32_t& detID, const std::vector<std::string>& _list) const {
   std::vector<std::string> list = _list;
   std::vector<float> SummaryObj;
   const HDQMSummary::Range range = getRange(detID);
-  if (range.first != range.second ) {
-   for (unsigned int i=0; i<list.size(); i++){ 
-     const short pos=getPosition(list.at(i));
-     
-     if (pos!=-1) 
-       SummaryObj.push_back(*((range.first)+pos));
-     else 
-       SummaryObj.push_back(-999.);
-   }
-  }
-  else 
-   for (unsigned int i=0; i<list.size(); i++) SummaryObj.push_back(-99.); // no summary obj has ever been inserted for this detid, most likely all related histos were not available in DQM
-  
+  if (range.first != range.second) {
+    for (unsigned int i = 0; i < list.size(); i++) {
+      const short pos = getPosition(list.at(i));
+
+      if (pos != -1)
+        SummaryObj.push_back(*((range.first) + pos));
+      else
+        SummaryObj.push_back(-999.);
+    }
+  } else
+    for (unsigned int i = 0; i < list.size(); i++)
+      SummaryObj.push_back(
+          -99.);  // no summary obj has ever been inserted for this detid, most likely all related histos were not available in DQM
+
   return SummaryObj;
 }
 
-std::vector<float> HDQMSummary::getSummaryObj(uint32_t& detID) const
-{  
+std::vector<float> HDQMSummary::getSummaryObj(uint32_t& detID) const {
   std::vector<float> SummaryObj;
   const HDQMSummary::Range range = getRange(detID);
-  if (range.first != range.second ) {
-   for (unsigned int i=0; i<userDBContent_.size(); i++) SummaryObj.push_back(*((range.first)+i));}
-  else {
-   for (unsigned int i=0; i<userDBContent_.size(); i++) SummaryObj.push_back(-99.);} 
+  if (range.first != range.second) {
+    for (unsigned int i = 0; i < userDBContent_.size(); i++)
+      SummaryObj.push_back(*((range.first) + i));
+  } else {
+    for (unsigned int i = 0; i < userDBContent_.size(); i++)
+      SummaryObj.push_back(-99.);
+  }
   return SummaryObj;
 }
 
+std::vector<float> HDQMSummary::getSummaryObj() const { return v_sum_; }
 
-
-std::vector<float> HDQMSummary::getSummaryObj() const
-{
-  return v_sum_;
-}
-
-
-std::vector<float> HDQMSummary::getSummaryObj(std::string elementName) const
-{
+std::vector<float> HDQMSummary::getSummaryObj(std::string elementName) const {
   std::vector<float> vSumElement;
   std::vector<uint32_t> DetIds_ = getDetIds();
   const short pos = getPosition(elementName);
-   
-  if (pos !=-1)
-    {
-      for (unsigned int i=0; i<DetIds_.size(); i++){
-	const HDQMSummary::Range range = getRange(DetIds_.at(i));
-	if (range.first != range.second ) {
-	vSumElement.push_back(*((range.first)+pos));}
-	else { vSumElement.push_back(-99.);}
+
+  if (pos != -1) {
+    for (unsigned int i = 0; i < DetIds_.size(); i++) {
+      const HDQMSummary::Range range = getRange(DetIds_.at(i));
+      if (range.first != range.second) {
+        vSumElement.push_back(*((range.first) + pos));
+      } else {
+        vSumElement.push_back(-99.);
+      }
     }
   }
-  
+
   return vSumElement;
 }
 
-
-void  HDQMSummary::print() 
-{
-  std::cout << "Nr. of detector elements in HDQMSummary object is " << indexes_.size() 
-	    << " RunNr= " << runNr_ 
-	    << " timeValue= " << timeValue_ 
-	    << std::endl;
+void HDQMSummary::print() {
+  std::cout << "Nr. of detector elements in HDQMSummary object is " << indexes_.size() << " RunNr= " << runNr_
+            << " timeValue= " << timeValue_ << std::endl;
 }
-

--- a/CondFormats/DQMObjects/src/classes.h
+++ b/CondFormats/DQMObjects/src/classes.h
@@ -1,13 +1,10 @@
 #include "CondFormats/DQMObjects/src/headers.h"
 
-
-
 namespace CondFormats_DQMObjects {
-  struct dictionary { 
-  
-  std::vector<std::string>::iterator tmp30;
-  std::vector<std::string>::const_iterator tmp31;
-  std::vector< HDQMSummary::DetRegistry >::iterator tmp32;
-  std::vector< HDQMSummary::DetRegistry >::const_iterator tmp33;
+  struct dictionary {
+    std::vector<std::string>::iterator tmp30;
+    std::vector<std::string>::const_iterator tmp31;
+    std::vector<HDQMSummary::DetRegistry>::iterator tmp32;
+    std::vector<HDQMSummary::DetRegistry>::const_iterator tmp33;
   };
-}
+}  // namespace CondFormats_DQMObjects

--- a/CondFormats/DQMObjects/test/testSerializationDQMObjects.cpp
+++ b/CondFormats/DQMObjects/test/testSerializationDQMObjects.cpp
@@ -2,16 +2,15 @@
 
 #include "CondFormats/DQMObjects/src/headers.h"
 
-int main()
-{
-    testSerialization<DQMSummary>();
-    testSerialization<DQMSummary::RunItem>();
-    testSerialization<DQMSummary::RunItem::LumiItem>();
-    testSerialization<HDQMSummary>();
-    testSerialization<HDQMSummary::DetRegistry>();
-    testSerialization<std::vector<DQMSummary::RunItem::LumiItem>>();
-    testSerialization<std::vector<DQMSummary::RunItem>>();
-    testSerialization<std::vector<HDQMSummary::DetRegistry>>();
+int main() {
+  testSerialization<DQMSummary>();
+  testSerialization<DQMSummary::RunItem>();
+  testSerialization<DQMSummary::RunItem::LumiItem>();
+  testSerialization<HDQMSummary>();
+  testSerialization<HDQMSummary::DetRegistry>();
+  testSerialization<std::vector<DQMSummary::RunItem::LumiItem>>();
+  testSerialization<std::vector<DQMSummary::RunItem>>();
+  testSerialization<std::vector<HDQMSummary::DetRegistry>>();
 
-    return 0;
+  return 0;
 }

--- a/CondTools/DQM/interface/DQMReferenceHistogramRootFileSourceHandler.h
+++ b/CondTools/DQM/interface/DQMReferenceHistogramRootFileSourceHandler.h
@@ -9,12 +9,13 @@
 
 namespace popcon {
   class DQMReferenceHistogramRootFileSourceHandler : public popcon::PopConSourceHandler<FileBlob> {
-   public:
-    DQMReferenceHistogramRootFileSourceHandler(const edm::ParameterSet & pset);
+  public:
+    DQMReferenceHistogramRootFileSourceHandler(const edm::ParameterSet& pset);
     ~DQMReferenceHistogramRootFileSourceHandler() override;
     void getNewObjects() override;
     std::string id() const override;
-   private:
+
+  private:
     std::string m_name;
     std::string m_file;
     bool m_zip;
@@ -22,6 +23,6 @@ namespace popcon {
     unsigned long long m_since;
     bool m_debugMode;
   };
-}
+}  // namespace popcon
 
 #endif

--- a/CondTools/DQM/interface/DQMSummaryReader.h
+++ b/CondTools/DQM/interface/DQMSummaryReader.h
@@ -6,14 +6,13 @@
 //#include "CondTools/DQM/interface/ReadBase.h"
 
 class DQMSummaryReader : virtual public TestBase /*ReadBase*/ {
- public:
-  DQMSummaryReader(const std::string& connectionString,
-		   const std::string& user,
-		   const std::string& pass);
-   ~DQMSummaryReader() override;
-   void run() override;
-  DQMSummary readData(const std::string & table, /*const std::string & column,*/ const long long r_number); 
- private:
+public:
+  DQMSummaryReader(const std::string& connectionString, const std::string& user, const std::string& pass);
+  ~DQMSummaryReader() override;
+  void run() override;
+  DQMSummary readData(const std::string& table, /*const std::string & column,*/ const long long r_number);
+
+private:
   std::string m_tableToRead;
   //std::string m_columnToRead;
   std::string m_connectionString;

--- a/CondTools/DQM/interface/DQMSummarySourceHandler.h
+++ b/CondTools/DQM/interface/DQMSummarySourceHandler.h
@@ -9,20 +9,21 @@
 
 namespace popcon {
   class DQMSummarySourceHandler : public popcon::PopConSourceHandler<DQMSummary> {
-   public:
-    DQMSummarySourceHandler(const edm::ParameterSet & pset);
+  public:
+    DQMSummarySourceHandler(const edm::ParameterSet& pset);
     ~DQMSummarySourceHandler() override;
     void getNewObjects() override;
     std::string id() const override;
-   private:
+
+  private:
     std::string m_name;
     //cond::Time_t m_since;
     unsigned long long m_since;
-    // for reading from omds 
+    // for reading from omds
     std::string m_connectionString;
     std::string m_user;
     std::string m_pass;
   };
-}
+}  // namespace popcon
 
 #endif

--- a/CondTools/DQM/interface/DQMXMLFileSourceHandler.h
+++ b/CondTools/DQM/interface/DQMXMLFileSourceHandler.h
@@ -9,12 +9,13 @@
 
 namespace popcon {
   class DQMXMLFileSourceHandler : public popcon::PopConSourceHandler<FileBlob> {
-   public:
-    DQMXMLFileSourceHandler(const edm::ParameterSet & pset);
+  public:
+    DQMXMLFileSourceHandler(const edm::ParameterSet& pset);
     ~DQMXMLFileSourceHandler() override;
     void getNewObjects() override;
     std::string id() const override;
-   private:
+
+  private:
     std::string m_name;
     std::string m_file;
     bool m_zip;
@@ -22,6 +23,6 @@ namespace popcon {
     unsigned long long m_since;
     bool m_debugMode;
   };
-}
+}  // namespace popcon
 
 #endif

--- a/CondTools/DQM/interface/ReadBase.h
+++ b/CondTools/DQM/interface/ReadBase.h
@@ -17,19 +17,21 @@
 namespace coral {
   //class IConnection;
   class ISessionProxy;
-}
+}  // namespace coral
 
 class ReadBase {
- public:
+public:
   ReadBase();
   virtual ~ReadBase();
   virtual void run() = 0;
-  void setVerbosityLevel( coral::MsgLevel level ) ;
- protected:
-  coral::ISessionProxy* connect( const std::string& connectionString,
-				 const std::string& user, 
-				 const std::string& password );
- private:
+  void setVerbosityLevel(coral::MsgLevel level);
+
+protected:
+  coral::ISessionProxy* connect(const std::string& connectionString,
+                                const std::string& user,
+                                const std::string& password);
+
+private:
   //coral::IConnection* m_connection;
   coral::ConnectionService m_connectionService;
 };

--- a/CondTools/DQM/interface/TestBase.h
+++ b/CondTools/DQM/interface/TestBase.h
@@ -16,18 +16,17 @@
 namespace coral {
   class IConnection;
   class ISession;
-}
+}  // namespace coral
 
 class TestBase {
 public:
   TestBase();
   virtual ~TestBase();
   virtual void run() = 0;
-  void setVerbosityLevel( coral::MsgLevel level ) ;
+  void setVerbosityLevel(coral::MsgLevel level);
+
 protected:
-  coral::ISession* connect( const std::string& connectionString,
-                            const std::string& user, 
-                            const std::string& password );
+  coral::ISession* connect(const std::string& connectionString, const std::string& user, const std::string& password);
 
 private:
   coral::IConnection* m_connection;

--- a/CondTools/DQM/plugins/DQMReferenceHistogramRootFileEventSetupAnalyzer.cc
+++ b/CondTools/DQM/plugins/DQMReferenceHistogramRootFileEventSetupAnalyzer.cc
@@ -19,74 +19,74 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 namespace edmtest {
-  class DQMReferenceHistogramRootFileEventSetupAnalyzer: public edm::EDAnalyzer {
-   public:
-    explicit DQMReferenceHistogramRootFileEventSetupAnalyzer(const edm::ParameterSet & pset);
+  class DQMReferenceHistogramRootFileEventSetupAnalyzer : public edm::EDAnalyzer {
+  public:
+    explicit DQMReferenceHistogramRootFileEventSetupAnalyzer(const edm::ParameterSet& pset);
     explicit DQMReferenceHistogramRootFileEventSetupAnalyzer(int i);
     ~DQMReferenceHistogramRootFileEventSetupAnalyzer() override;
     void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
-    void beginRun(edm::Run const&, edm::EventSetup const&) override ;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
+
   private:
-    bool init_ ;
+    bool init_;
   };
-  
-  DQMReferenceHistogramRootFileEventSetupAnalyzer::DQMReferenceHistogramRootFileEventSetupAnalyzer(const edm::ParameterSet &ps) {
-    init_ = false ;
+
+  DQMReferenceHistogramRootFileEventSetupAnalyzer::DQMReferenceHistogramRootFileEventSetupAnalyzer(
+      const edm::ParameterSet& ps) {
+    init_ = false;
     //std::cout << "DQMReferenceHistogramRootFileEventSetupAnalyzer(const edm::ParameterSet &ps)" << std::endl;
   }
-  
+
   DQMReferenceHistogramRootFileEventSetupAnalyzer::DQMReferenceHistogramRootFileEventSetupAnalyzer(int i) {
-    init_ = false ;
+    init_ = false;
     //std::cout << "DQMReferenceHistogramRootFileEventSetupAnalyzer(int i) " << i << std::endl;
   }
-  
-  DQMReferenceHistogramRootFileEventSetupAnalyzer::~DQMReferenceHistogramRootFileEventSetupAnalyzer()
-  {
-    init_ = false ;
+
+  DQMReferenceHistogramRootFileEventSetupAnalyzer::~DQMReferenceHistogramRootFileEventSetupAnalyzer() {
+    init_ = false;
     //std::cout << "~DQMReferenceHistogramRootFileEventSetupAnalyzer" << std::endl;
   }
-  
-  void DQMReferenceHistogramRootFileEventSetupAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup)
-  {
-    return ;
+
+  void DQMReferenceHistogramRootFileEventSetupAnalyzer::analyze(const edm::Event& iEvent,
+                                                                const edm::EventSetup& iSetup) {
+    return;
   }
 
-  void DQMReferenceHistogramRootFileEventSetupAnalyzer::beginRun(edm::Run const& run , edm::EventSetup const& iSetup)
-  {
-    //std::cout << "DQMReferenceHistogramRootFileEventSetupAnalyzer::beginRun()" << std::endl;    
-    if(!init_)
-      {
-	init_ = true ;
-	edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("DQMReferenceHistogramRootFileRcd"));
-	if(recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
-	  throw cms::Exception ("Record not found") << "Record \"DQMReferenceHistogramRootFileRcd" 
-						    << "\" does not exist!" << std::endl;
-	}
-	edm::ESHandle<FileBlob> rootgeo;
-	iSetup.get<DQMReferenceHistogramRootFileRcd>().get(rootgeo);
-	//std::cout<<"ROOT FILE IN MEMORY"<<std::endl;
-        std::unique_ptr<std::vector<unsigned char> > tb( (*rootgeo).getUncompressedBlob() );
-	// char filename[128];
-	// sprintf(filename, "mem:%p,%ul", &(*tb)[0], (unsigned long) tb->size());
-	// edm::Service<DQMStore>()->open(filename, false, "", "Reference");
-	
-	//here you can implement the stream for putting the TFile on disk...
-	std::string outfile("dqmreference.root") ;
-	std::ofstream output(outfile.c_str()) ;
-	output.write((const char *)&(*tb)[0], tb->size());
-	output.close() ;
-	
-	DQMStore *dqm = &*edm::Service<DQMStore>();
-	dqm->open(outfile, false, "", "Reference");
- 	remove(outfile.c_str());
-	
-	std::vector<MonitorElement *> mes = dqm->getAllContents("");
-	// for (std::vector<MonitorElement *>::iterator i = mes.begin(), e = mes.end(); i != e; ++i)
-	//  std::cout << "ME '" << (*i)->getFullname() << "'\n";
-	
-	//std::cout<<"SIZE FILE = "<<tb->size()<<std::endl;
+  void DQMReferenceHistogramRootFileEventSetupAnalyzer::beginRun(edm::Run const& run, edm::EventSetup const& iSetup) {
+    //std::cout << "DQMReferenceHistogramRootFileEventSetupAnalyzer::beginRun()" << std::endl;
+    if (!init_) {
+      init_ = true;
+      edm::eventsetup::EventSetupRecordKey recordKey(
+          edm::eventsetup::EventSetupRecordKey::TypeTag::findType("DQMReferenceHistogramRootFileRcd"));
+      if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+        throw cms::Exception("Record not found") << "Record \"DQMReferenceHistogramRootFileRcd"
+                                                 << "\" does not exist!" << std::endl;
       }
+      edm::ESHandle<FileBlob> rootgeo;
+      iSetup.get<DQMReferenceHistogramRootFileRcd>().get(rootgeo);
+      //std::cout<<"ROOT FILE IN MEMORY"<<std::endl;
+      std::unique_ptr<std::vector<unsigned char> > tb((*rootgeo).getUncompressedBlob());
+      // char filename[128];
+      // sprintf(filename, "mem:%p,%ul", &(*tb)[0], (unsigned long) tb->size());
+      // edm::Service<DQMStore>()->open(filename, false, "", "Reference");
+
+      //here you can implement the stream for putting the TFile on disk...
+      std::string outfile("dqmreference.root");
+      std::ofstream output(outfile.c_str());
+      output.write((const char*)&(*tb)[0], tb->size());
+      output.close();
+
+      DQMStore* dqm = &*edm::Service<DQMStore>();
+      dqm->open(outfile, false, "", "Reference");
+      remove(outfile.c_str());
+
+      std::vector<MonitorElement*> mes = dqm->getAllContents("");
+      // for (std::vector<MonitorElement *>::iterator i = mes.begin(), e = mes.end(); i != e; ++i)
+      //  std::cout << "ME '" << (*i)->getFullname() << "'\n";
+
+      //std::cout<<"SIZE FILE = "<<tb->size()<<std::endl;
+    }
   }
-  
+
   DEFINE_FWK_MODULE(DQMReferenceHistogramRootFileEventSetupAnalyzer);
-}
+}  // namespace edmtest

--- a/CondTools/DQM/plugins/DQMReferenceHistogramRootFilePopConAnalyzer.cc
+++ b/CondTools/DQM/plugins/DQMReferenceHistogramRootFilePopConAnalyzer.cc
@@ -2,6 +2,7 @@
 #include "CondTools/DQM/interface/DQMReferenceHistogramRootFileSourceHandler.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-typedef popcon::PopConAnalyzer<popcon::DQMReferenceHistogramRootFileSourceHandler> DQMReferenceHistogramRootFilePopConAnalyzer;
+typedef popcon::PopConAnalyzer<popcon::DQMReferenceHistogramRootFileSourceHandler>
+    DQMReferenceHistogramRootFilePopConAnalyzer;
 //define this as a plug-in
 DEFINE_FWK_MODULE(DQMReferenceHistogramRootFilePopConAnalyzer);

--- a/CondTools/DQM/plugins/DQMSummaryEventSetupAnalyzer.cc
+++ b/CondTools/DQM/plugins/DQMSummaryEventSetupAnalyzer.cc
@@ -10,44 +10,45 @@
 #include <iostream>
 
 namespace edmtest {
-  class DQMSummaryEventSetupAnalyzer: public edm::EDAnalyzer {
-   public:
-    explicit DQMSummaryEventSetupAnalyzer(const edm::ParameterSet & pset);
+  class DQMSummaryEventSetupAnalyzer : public edm::EDAnalyzer {
+  public:
+    explicit DQMSummaryEventSetupAnalyzer(const edm::ParameterSet& pset);
     explicit DQMSummaryEventSetupAnalyzer(int i);
     ~DQMSummaryEventSetupAnalyzer() override;
     void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
   };
-  
-  DQMSummaryEventSetupAnalyzer::DQMSummaryEventSetupAnalyzer(const edm::ParameterSet & pset) {
+
+  DQMSummaryEventSetupAnalyzer::DQMSummaryEventSetupAnalyzer(const edm::ParameterSet& pset) {
     std::cout << "DQMSummaryEventSetupAnalyzer" << std::endl;
   }
 
   DQMSummaryEventSetupAnalyzer::DQMSummaryEventSetupAnalyzer(int i) {
     std::cout << "DQMSummaryEventSetupAnalyzer" << i << std::endl;
   }
-  
+
   DQMSummaryEventSetupAnalyzer::~DQMSummaryEventSetupAnalyzer() {
     std::cout << "~DQMSummaryEventSetupAnalyzer" << std::endl;
   }
-  
+
   void DQMSummaryEventSetupAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup) {
     std::cout << "### DQMSummaryEventSetupAnalyzer::analyze" << std::endl;
-      std::cout << "--- RUN NUMBER: " << event.id().run() << std::endl;
-      std::cout << "--- EVENT NUMBER: " << event.id().event() << std::endl;
-      edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("DQMSummaryRcd"));
-      if(recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
-	throw cms::Exception ("Record not found") << "Record \"DQMSummaryRcd" 
-						  << "\" does not exist!" << std::endl;
-      }
-      edm::ESHandle<DQMSummary> sum;
-      std::cout << "got EShandle" << std::endl;
-      setup.get<DQMSummaryRcd>().get(sum);
-      std::cout <<"got the Event Setup" << std::endl;
-      const DQMSummary* summary = sum.product();
-      std::cout <<"got DQMSummary* "<< std::endl;
-      std::cout<< "print result" << std::endl;
-      summary->printAllValues();
+    std::cout << "--- RUN NUMBER: " << event.id().run() << std::endl;
+    std::cout << "--- EVENT NUMBER: " << event.id().event() << std::endl;
+    edm::eventsetup::EventSetupRecordKey recordKey(
+        edm::eventsetup::EventSetupRecordKey::TypeTag::findType("DQMSummaryRcd"));
+    if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+      throw cms::Exception("Record not found") << "Record \"DQMSummaryRcd"
+                                               << "\" does not exist!" << std::endl;
+    }
+    edm::ESHandle<DQMSummary> sum;
+    std::cout << "got EShandle" << std::endl;
+    setup.get<DQMSummaryRcd>().get(sum);
+    std::cout << "got the Event Setup" << std::endl;
+    const DQMSummary* summary = sum.product();
+    std::cout << "got DQMSummary* " << std::endl;
+    std::cout << "print result" << std::endl;
+    summary->printAllValues();
   }
-  
+
   DEFINE_FWK_MODULE(DQMSummaryEventSetupAnalyzer);
-}
+}  // namespace edmtest

--- a/CondTools/DQM/plugins/DQMXMLFileEventSetupAnalyzer.cc
+++ b/CondTools/DQM/plugins/DQMXMLFileEventSetupAnalyzer.cc
@@ -19,71 +19,68 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 namespace edmtest {
-  class DQMXMLFileEventSetupAnalyzer: public edm::EDAnalyzer {
-   public:
-    explicit DQMXMLFileEventSetupAnalyzer(const edm::ParameterSet & pset);
+  class DQMXMLFileEventSetupAnalyzer : public edm::EDAnalyzer {
+  public:
+    explicit DQMXMLFileEventSetupAnalyzer(const edm::ParameterSet& pset);
     explicit DQMXMLFileEventSetupAnalyzer(int i);
     ~DQMXMLFileEventSetupAnalyzer() override;
     void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
-    void beginRun(edm::Run const&, edm::EventSetup const&) override ;
+    void beginRun(edm::Run const&, edm::EventSetup const&) override;
+
   private:
-    bool init_ ;
-    std::string labelToGet_ ;
+    bool init_;
+    std::string labelToGet_;
   };
-  
-  DQMXMLFileEventSetupAnalyzer::DQMXMLFileEventSetupAnalyzer(const edm::ParameterSet &ps):labelToGet_(ps.getParameter<std::string>("labelToGet")) {
-    init_ = false ;
+
+  DQMXMLFileEventSetupAnalyzer::DQMXMLFileEventSetupAnalyzer(const edm::ParameterSet& ps)
+      : labelToGet_(ps.getParameter<std::string>("labelToGet")) {
+    init_ = false;
     //std::cout << "DQMXMLFileEventSetupAnalyzer(const edm::ParameterSet &ps)" << std::endl;
   }
-  
+
   DQMXMLFileEventSetupAnalyzer::DQMXMLFileEventSetupAnalyzer(int i) {
-    init_ = false ;
+    init_ = false;
     //std::cout << "DQMXMLFileEventSetupAnalyzer(int i) " << i << std::endl;
   }
-  
-  DQMXMLFileEventSetupAnalyzer::~DQMXMLFileEventSetupAnalyzer()
-  {
-    init_ = false ;
+
+  DQMXMLFileEventSetupAnalyzer::~DQMXMLFileEventSetupAnalyzer() {
+    init_ = false;
     //std::cout << "~DQMXMLFileEventSetupAnalyzer" << std::endl;
   }
-  
-  void DQMXMLFileEventSetupAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup)
-  {
-    return ;
+
+  void DQMXMLFileEventSetupAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) { return; }
+
+  void DQMXMLFileEventSetupAnalyzer::beginRun(edm::Run const& run, edm::EventSetup const& iSetup) {
+    //std::cout << "DQMXMLFileEventSetupAnalyzer::beginRun()" << std::endl;
+    if (!init_) {
+      init_ = true;
+      edm::eventsetup::EventSetupRecordKey recordKey(
+          edm::eventsetup::EventSetupRecordKey::TypeTag::findType("DQMXMLFileRcd"));
+      if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
+        throw cms::Exception("Record not found") << "Record \"DQMXMLFileRcd"
+                                                 << "\" does not exist!" << std::endl;
+      }
+      edm::ESHandle<FileBlob> rootgeo;
+      iSetup.get<DQMXMLFileRcd>().get(labelToGet_, rootgeo);
+      //std::cout<<"XML FILE IN MEMORY 1 with label " << labelToGet_ <<std::endl;
+      std::unique_ptr<std::vector<unsigned char> > tb1((*rootgeo).getUncompressedBlob());
+      //here you can implement the stream for putting the TFile on disk...
+      std::string outfile1("XML1_retrieved.xml");
+      std::ofstream output1(outfile1.c_str());
+      output1.write((const char*)&(*tb1)[0], tb1->size());
+      output1.close();
+
+      // 	iSetup.get<DQMXMLFileRcd>().get("XML2_mio",rootgeo);
+      // 	std::cout<<"ROOT FILE IN MEMORY 2"<<std::endl;
+      // 	std::unique_ptr<std::vector<unsigned char> > tb2( (*rootgeo).getUncompressedBlob() );
+      // 	//here you can implement the stream for putting the TFile on disk...
+      // 	std::string outfile2("XML2_retrieved.xml") ;
+      // 	std::ofstream output2(outfile2.c_str()) ;
+      // 	output2.write((const char *)&(*tb2)[0], tb2->size());
+      // 	output2.close() ;
+      //	std::unique_ptr<std::vector<unsigned char> > tb( (*rootgeo).getUncompressedBlob() );
+    }
   }
 
-  void DQMXMLFileEventSetupAnalyzer::beginRun(edm::Run const& run , edm::EventSetup const& iSetup)
-  {
-    //std::cout << "DQMXMLFileEventSetupAnalyzer::beginRun()" << std::endl;    
-    if(!init_)
-      {
-	init_ = true ;
-	edm::eventsetup::EventSetupRecordKey recordKey(edm::eventsetup::EventSetupRecordKey::TypeTag::findType("DQMXMLFileRcd"));
-	if(recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
-	  throw cms::Exception ("Record not found") << "Record \"DQMXMLFileRcd" 
-						    << "\" does not exist!" << std::endl;
-	}
-	edm::ESHandle<FileBlob> rootgeo;
-	iSetup.get<DQMXMLFileRcd>().get(labelToGet_,rootgeo);
-	//std::cout<<"XML FILE IN MEMORY 1 with label " << labelToGet_ <<std::endl;
-	std::unique_ptr<std::vector<unsigned char> > tb1( (*rootgeo).getUncompressedBlob() );
-	//here you can implement the stream for putting the TFile on disk...
-	std::string outfile1("XML1_retrieved.xml") ;
-	std::ofstream output1(outfile1.c_str()) ;
-	output1.write((const char *)&(*tb1)[0], tb1->size());
-	output1.close() ;
-	
-// 	iSetup.get<DQMXMLFileRcd>().get("XML2_mio",rootgeo);
-// 	std::cout<<"ROOT FILE IN MEMORY 2"<<std::endl;
-// 	std::unique_ptr<std::vector<unsigned char> > tb2( (*rootgeo).getUncompressedBlob() );
-// 	//here you can implement the stream for putting the TFile on disk...
-// 	std::string outfile2("XML2_retrieved.xml") ;
-// 	std::ofstream output2(outfile2.c_str()) ;
-// 	output2.write((const char *)&(*tb2)[0], tb2->size());
-// 	output2.close() ;
-	//	std::unique_ptr<std::vector<unsigned char> > tb( (*rootgeo).getUncompressedBlob() );
-      }
-  }
-  
   DEFINE_FWK_MODULE(DQMXMLFileEventSetupAnalyzer);
-}
+}  // namespace edmtest

--- a/CondTools/DQM/src/DQMReferenceHistogramRootFileSourceHandler.cc
+++ b/CondTools/DQM/src/DQMReferenceHistogramRootFileSourceHandler.cc
@@ -7,80 +7,70 @@
 #include <vector>
 
 namespace popcon {
-  DQMReferenceHistogramRootFileSourceHandler::DQMReferenceHistogramRootFileSourceHandler(const edm::ParameterSet & pset):
-    m_name(pset.getUntrackedParameter<std::string>("name","DQMReferenceHistogramRootFileSourceHandler")),
-    m_file(pset.getUntrackedParameter<std::string>("ROOTFile","./file.root")),
-    m_zip(pset.getUntrackedParameter<bool>("zip",false)),
-    m_since(pset.getUntrackedParameter<unsigned long long>("firstSince",1)),
-    m_debugMode(pset.getUntrackedParameter<bool>("debug",false)) {
-  }
-  
+  DQMReferenceHistogramRootFileSourceHandler::DQMReferenceHistogramRootFileSourceHandler(const edm::ParameterSet& pset)
+      : m_name(pset.getUntrackedParameter<std::string>("name", "DQMReferenceHistogramRootFileSourceHandler")),
+        m_file(pset.getUntrackedParameter<std::string>("ROOTFile", "./file.root")),
+        m_zip(pset.getUntrackedParameter<bool>("zip", false)),
+        m_since(pset.getUntrackedParameter<unsigned long long>("firstSince", 1)),
+        m_debugMode(pset.getUntrackedParameter<bool>("debug", false)) {}
+
   DQMReferenceHistogramRootFileSourceHandler::~DQMReferenceHistogramRootFileSourceHandler() {}
-  
+
   void DQMReferenceHistogramRootFileSourceHandler::getNewObjects() {
-    edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler") << "[DQMReferenceHistogramRootFileSourceHandler::getNewObjects] for PopCon application " << m_name;
-    if(m_debugMode){
-	std::stringstream ss;
-	ss << "\n------- " << m_name 
-	   << " - > getNewObjects\n";
-	if (this->tagInfo().size > 0){
-	  //check what is already inside of the database
-	  ss << "\ngot offlineInfo "<< this->tagInfo().name 
-	     << ",\n size " << this->tagInfo().size 
-	     << ",\n" << this->tagInfo().token 
-	     << ",\n last object valid since " << this->tagInfo().lastInterval.first 
-	     << ",\n token " << this->tagInfo().lastPayloadToken 
-	     << ",\n UserText " << this->userTextLog()
-	     << ";\n last entry info regarding the payload (if existing):" 
-	     << ",\n logId"<<this->logDBEntry().logId 
-	     << ",\n last record with the correct tag (if existing) has been written in the db " << this->logDBEntry().destinationDB
-	     << ",\n provenance " << this->logDBEntry().provenance
-	     << ",\n usertext " << this->logDBEntry().usertext
-	     << ",\n iovtag " << this->logDBEntry().iovtag
-	     << ",\n timetype " << this->logDBEntry().iovtimetype
-	     << ",\n payload index " << this->logDBEntry().payloadIdx
-	     << ",\n payload class " << this->logDBEntry().payloadClass 
-	     << ",\n payload token " << this->logDBEntry().payloadToken
-	     << ",\n execution time " << this->logDBEntry().exectime
-	     << ",\n execution message " << this->logDBEntry().execmessage
-	     << std::endl;
-	  Ref payload = this->lastPayload();
-	  ss << "size of last payload " << payload->size() << std::endl;
-	} else {
-	  ss << " First object for this tag " << std::endl;
-	}
-	edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler") << ss.str();
+    edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler")
+        << "[DQMReferenceHistogramRootFileSourceHandler::getNewObjects] for PopCon application " << m_name;
+    if (m_debugMode) {
+      std::stringstream ss;
+      ss << "\n------- " << m_name << " - > getNewObjects\n";
+      if (this->tagInfo().size > 0) {
+        //check what is already inside of the database
+        ss << "\ngot offlineInfo " << this->tagInfo().name << ",\n size " << this->tagInfo().size << ",\n"
+           << this->tagInfo().token << ",\n last object valid since " << this->tagInfo().lastInterval.first
+           << ",\n token " << this->tagInfo().lastPayloadToken << ",\n UserText " << this->userTextLog()
+           << ";\n last entry info regarding the payload (if existing):"
+           << ",\n logId" << this->logDBEntry().logId
+           << ",\n last record with the correct tag (if existing) has been written in the db "
+           << this->logDBEntry().destinationDB << ",\n provenance " << this->logDBEntry().provenance << ",\n usertext "
+           << this->logDBEntry().usertext << ",\n iovtag " << this->logDBEntry().iovtag << ",\n timetype "
+           << this->logDBEntry().iovtimetype << ",\n payload index " << this->logDBEntry().payloadIdx
+           << ",\n payload class " << this->logDBEntry().payloadClass << ",\n payload token "
+           << this->logDBEntry().payloadToken << ",\n execution time " << this->logDBEntry().exectime
+           << ",\n execution message " << this->logDBEntry().execmessage << std::endl;
+        Ref payload = this->lastPayload();
+        ss << "size of last payload " << payload->size() << std::endl;
+      } else {
+        ss << " First object for this tag " << std::endl;
+      }
+      edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler") << ss.str();
     }
     edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler") << "runnumber/first since = " << m_since << std::endl;
-    if(m_since<=this->tagInfo().lastInterval.first){
-      edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler") 
-	<< "[DQMReferenceHistogramRootFileSourceHandler::getNewObjects] \nthe current starting iov " << m_since
-	<< "\nis not compatible with the last iov ("  
-	<< this->tagInfo().lastInterval.first << ") open for the object " 
-	<< this->logDBEntry().payloadClass << " \nin the db " 
-	<< this->logDBEntry().destinationDB << " \n NO TRANSFER NEEDED"
-	<< std::endl;
+    if (m_since <= this->tagInfo().lastInterval.first) {
+      edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler")
+          << "[DQMReferenceHistogramRootFileSourceHandler::getNewObjects] \nthe current starting iov " << m_since
+          << "\nis not compatible with the last iov (" << this->tagInfo().lastInterval.first << ") open for the object "
+          << this->logDBEntry().payloadClass << " \nin the db " << this->logDBEntry().destinationDB
+          << " \n NO TRANSFER NEEDED" << std::endl;
       return;
-      }
-    edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler") 
-      << "[DQMReferenceHistogramRootFileSourceHandler::getNewObjects] " << m_name << " getting data to be transferred "  << std::endl;
-    FileBlob* rootFile = new FileBlob(m_file,m_zip);
+    }
+    edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler")
+        << "[DQMReferenceHistogramRootFileSourceHandler::getNewObjects] " << m_name
+        << " getting data to be transferred " << std::endl;
+    FileBlob* rootFile = new FileBlob(m_file, m_zip);
     /*if(!this->tagInfo().size)
       m_since=1;
     else
       if (m_debugMode)
       m_since=this->tagInfo().lastInterval.first+1; */
-    if(rootFile->size() != 0){
-      edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler") << "setting runnumber/first since = " << m_since << std::endl;
-      this->m_to_transfer.push_back(std::make_pair(rootFile,m_since));
+    if (rootFile->size() != 0) {
+      edm::LogInfo("DQMReferenceHistogramRootFileSourceHandler")
+          << "setting runnumber/first since = " << m_since << std::endl;
+      this->m_to_transfer.push_back(std::make_pair(rootFile, m_since));
     } else {
       edm::LogError("DQMSummarySourceHandler") << "Root file " << m_file << " does not exist" << std::endl;
       delete rootFile;
     }
-    edm::LogInfo("DQMSummarySourceHandler") << "------- " 
-					    << m_name << " - > getNewObjects" 
-					    << std::endl;
+    edm::LogInfo("DQMSummarySourceHandler") << "------- " << m_name << " - > getNewObjects" << std::endl;
   }
-  
-  std::string DQMReferenceHistogramRootFileSourceHandler::id() const {return m_name;}
-}
+
+  std::string DQMReferenceHistogramRootFileSourceHandler::id() const { return m_name; }
+}  // namespace popcon

--- a/CondTools/DQM/src/DQMSummaryReader.cc
+++ b/CondTools/DQM/src/DQMSummaryReader.cc
@@ -19,45 +19,45 @@
 #include <cmath>
 
 DQMSummaryReader::DQMSummaryReader(const std::string& connectionString,
-				   const std::string& user,
-				   const std::string& pass):
-  TestBase(), /*ReadBase(),*/
-  m_connectionString( connectionString ),
-  m_user( user ),
-  m_pass( pass ) {
-  m_tableToRead="";
+                                   const std::string& user,
+                                   const std::string& pass)
+    : TestBase(), /*ReadBase(),*/
+      m_connectionString(connectionString),
+      m_user(user),
+      m_pass(pass) {
+  m_tableToRead = "";
 }
 
 DQMSummaryReader::~DQMSummaryReader() {}
 
 void DQMSummaryReader::run() {}
 
-DQMSummary DQMSummaryReader::readData(const std::string & table, /*const std::string & column,*/ const long long r_number) {
-  m_tableToRead = table; // to be  CMS_DQM_SUMMARY.summarycontent
+DQMSummary DQMSummaryReader::readData(const std::string& table,
+                                      /*const std::string & column,*/ const long long r_number) {
+  m_tableToRead = table;  // to be  CMS_DQM_SUMMARY.summarycontent
   //m_columnToRead = column;  // to be run, lumisec
   DQMSummary dqmSummary;
   dqmSummary.m_run = r_number;
-  std::cout<< "Entering readData" << std::endl;
-  coral::ISession* session = this->connect(m_connectionString,
-                                           m_user, m_pass);
+  std::cout << "Entering readData" << std::endl;
+  coral::ISession* session = this->connect(m_connectionString, m_user, m_pass);
   //coral::ISessionProxy* session = this->connect(m_connectionString,
   //                                              m_user, m_pass);
-  try{
+  try {
     //session->typeConverter().setCppTypeForSqlType(coral::AttributeSpecification::typeNameForId(typeid(std::string)), "VARCHAR2(20)");
     //session->typeConverter().setCppTypeForSqlType(coral::AttributeSpecification::typeNameForId(typeid(std::string)), "VARCHAR2(40)");
     session->transaction().start();
-    std::cout<< "Starting session on the connection " << m_connectionString << std::endl;
+    std::cout << "Starting session on the connection " << m_connectionString << std::endl;
     coral::ISchema& schema = session->nominalSchema();
-    std::cout<< "--- accessing schema for user " << m_user << std::endl;
-    std::cout<< "------ trying to handle table " << m_tableToRead << std::endl;
+    std::cout << "--- accessing schema for user " << m_user << std::endl;
+    std::cout << "------ trying to handle table " << m_tableToRead << std::endl;
     //defining count query
     coral::IQuery* query = schema.tableHandle(m_tableToRead).newQuery();
     query->addToOutputList("count(*)", "count");
     //condition for the WHERE clause in the count query
     std::string condition = "run=:n_run";
     coral::AttributeList conditionData;
-    conditionData.extend<long long>( "n_run" );
-    //conditionData[0].setValue<long long>(r_number); 
+    conditionData.extend<long long>("n_run");
+    //conditionData[0].setValue<long long>(r_number);
     conditionData[0].data<long long>() = r_number;
     query->setCondition(condition, conditionData);
     //performing count query
@@ -65,7 +65,7 @@ DQMSummary DQMSummaryReader::readData(const std::string & table, /*const std::st
     DQMSummary::DQMSummary::RunItem runItem;
     DQMSummary::DQMSummary::RunItem::LumiItem lumiItem;
     double nRows = 0;
-    if( cursor.next() ) {
+    if (cursor.next()) {
       //cursor.currentRow().toOutputStream(std::cout) << std::endl;
       const coral::AttributeList& row = cursor.currentRow();
       nRows = row["count"].data<double>();
@@ -75,93 +75,88 @@ DQMSummary DQMSummaryReader::readData(const std::string & table, /*const std::st
       else
       nRows = count.data<float>();*/
       std::cout << "Rows for count query " << nRows << std::endl;
-      if( nRows != 0 ) {
-	std::cout << "Starting to build DQMSummary" << std::endl;
-	//defining first query
-	coral::IQuery* queryI = schema.tableHandle(m_tableToRead).newQuery();
-	queryI->setDistinct();
-	queryI->addToOutputList("lumisec");
-	//condition for the WHERE clause in the first query
-	std::string conditionI = "run=:n_run";
-	coral::AttributeList conditionDataI;
-	conditionDataI.extend<long long>( "n_run" );
-	//conditionDataI[0].setValue<long long>(r_number); 
-	conditionDataI[0].data<long long>() = r_number;
-	queryI->setCondition(conditionI, conditionDataI);
-	//performing query
-	coral::ICursor& cursorI = queryI->execute();
-	//a little printout, then filling DQMSummary
-	int nRowsI = 0;
-	while( cursorI.next() ) {
-	  //cursorI.currentRow().toOutputStream(std::cout) << std::endl;
-	  ++nRowsI;
-	  const coral::AttributeList& rowI = cursorI.currentRow();
-	  runItem.m_lumisec = rowI["lumisec"].data<long long>();
-	  //defining second query
-	  coral::IQuery* queryII = schema.tableHandle(m_tableToRead).newQuery();
-	  queryII->addToOutputList("subsystem");
-	  queryII->addToOutputList("reportcontent");
-	  //queryII->addToOutputList("type"); // when implemented in OMDS
-	  queryII->addToOutputList("status");
-	  std::string conditionII = "run= :n_run AND lumisec= :n_lumisec";
-	  coral::AttributeList conditionDataII;
-	  conditionDataII.extend<long long>( "n_run" );
-	  //conditionDataII[0].setValue<long long>(r_number); 
-	  conditionDataII[0].data<long long>() = r_number;
-	  conditionDataII.extend<long long>( "n_lumisec" );
-	  //conditionDataII[1].setValue<long long>(rowI["lumisec"].data<long long>()); 
-	  conditionDataII[1].data<long long>() = rowI["lumisec"].data<long long>();
-	  queryII->setCondition(conditionII, conditionDataII);
-	  //performing query
-	  coral::ICursor& cursorII = queryII->execute();
-	  //a little printout, then filling DQMSummary
-	  int nRowsII = 0;
-	  while( cursorII.next() ) {
-	    //cursorII.currentRow().toOutputStream(std::cout) << std::endl;
-	    ++nRowsII;
-	    const coral::AttributeList& rowII = cursorII.currentRow();
-	    lumiItem.m_subsystem = rowII["subsystem"].data<std::string>();
-	    lumiItem.m_reportcontent = rowII["reportcontent"].data<std::string>();
-	    //lumiItem.m_type = rowII["type"].data<std::string>(); // when implemented in OMDS
-	    lumiItem.m_type = "reportSummary";
-	    lumiItem.m_status = rowII["status"].data<double>();
-	    runItem.m_lumisummary.push_back(lumiItem);
-	    std::cout << "DQMSummary::DQMSummary::RunItem::LumiItem filled" << std::endl;
-	  }
-	  std::cout << "Returned rows for lumisection query " << nRowsII << std::endl;
-	  dqmSummary.m_summary.push_back(runItem);
-	  std::cout << "DQMSummary::DQMSummary::RunItem filled" << std::endl;
-	  delete queryII;
-	}
-	std::cout << "Returned rows for run number query " << nRowsI << std::endl;
-	delete queryI;
+      if (nRows != 0) {
+        std::cout << "Starting to build DQMSummary" << std::endl;
+        //defining first query
+        coral::IQuery* queryI = schema.tableHandle(m_tableToRead).newQuery();
+        queryI->setDistinct();
+        queryI->addToOutputList("lumisec");
+        //condition for the WHERE clause in the first query
+        std::string conditionI = "run=:n_run";
+        coral::AttributeList conditionDataI;
+        conditionDataI.extend<long long>("n_run");
+        //conditionDataI[0].setValue<long long>(r_number);
+        conditionDataI[0].data<long long>() = r_number;
+        queryI->setCondition(conditionI, conditionDataI);
+        //performing query
+        coral::ICursor& cursorI = queryI->execute();
+        //a little printout, then filling DQMSummary
+        int nRowsI = 0;
+        while (cursorI.next()) {
+          //cursorI.currentRow().toOutputStream(std::cout) << std::endl;
+          ++nRowsI;
+          const coral::AttributeList& rowI = cursorI.currentRow();
+          runItem.m_lumisec = rowI["lumisec"].data<long long>();
+          //defining second query
+          coral::IQuery* queryII = schema.tableHandle(m_tableToRead).newQuery();
+          queryII->addToOutputList("subsystem");
+          queryII->addToOutputList("reportcontent");
+          //queryII->addToOutputList("type"); // when implemented in OMDS
+          queryII->addToOutputList("status");
+          std::string conditionII = "run= :n_run AND lumisec= :n_lumisec";
+          coral::AttributeList conditionDataII;
+          conditionDataII.extend<long long>("n_run");
+          //conditionDataII[0].setValue<long long>(r_number);
+          conditionDataII[0].data<long long>() = r_number;
+          conditionDataII.extend<long long>("n_lumisec");
+          //conditionDataII[1].setValue<long long>(rowI["lumisec"].data<long long>());
+          conditionDataII[1].data<long long>() = rowI["lumisec"].data<long long>();
+          queryII->setCondition(conditionII, conditionDataII);
+          //performing query
+          coral::ICursor& cursorII = queryII->execute();
+          //a little printout, then filling DQMSummary
+          int nRowsII = 0;
+          while (cursorII.next()) {
+            //cursorII.currentRow().toOutputStream(std::cout) << std::endl;
+            ++nRowsII;
+            const coral::AttributeList& rowII = cursorII.currentRow();
+            lumiItem.m_subsystem = rowII["subsystem"].data<std::string>();
+            lumiItem.m_reportcontent = rowII["reportcontent"].data<std::string>();
+            //lumiItem.m_type = rowII["type"].data<std::string>(); // when implemented in OMDS
+            lumiItem.m_type = "reportSummary";
+            lumiItem.m_status = rowII["status"].data<double>();
+            runItem.m_lumisummary.push_back(lumiItem);
+            std::cout << "DQMSummary::DQMSummary::RunItem::LumiItem filled" << std::endl;
+          }
+          std::cout << "Returned rows for lumisection query " << nRowsII << std::endl;
+          dqmSummary.m_summary.push_back(runItem);
+          std::cout << "DQMSummary::DQMSummary::RunItem filled" << std::endl;
+          delete queryII;
+        }
+        std::cout << "Returned rows for run number query " << nRowsI << std::endl;
+        delete queryI;
+      } else {
+        runItem.m_lumisec = 0;
+        lumiItem.m_subsystem = " ";
+        lumiItem.m_reportcontent = " ";
+        lumiItem.m_type = " ";
+        lumiItem.m_status = -2;
+        std::cout << "[lumisec (long long) : " << runItem.m_lumisec
+                  << "], [subsystem (string) : " << lumiItem.m_subsystem
+                  << "], [reportcontent (string) : " << lumiItem.m_reportcontent
+                  << "], [type (string) : " << lumiItem.m_type << "], [status (double) : " << lumiItem.m_status << "]"
+                  << std::endl;
+        runItem.m_lumisummary.push_back(lumiItem);
+        dqmSummary.m_summary.push_back(runItem);
+        std::cout << "No information in DQMSummary for run " << r_number << std::endl;
       }
-      else {
-	runItem.m_lumisec = 0;
-	lumiItem.m_subsystem = " ";
-	lumiItem.m_reportcontent = " ";
-	lumiItem.m_type = " ";
-	lumiItem.m_status = -2;
-	std::cout << "[lumisec (long long) : " << runItem.m_lumisec
-		  << "], [subsystem (string) : " << lumiItem.m_subsystem
-		  << "], [reportcontent (string) : " << lumiItem.m_reportcontent
-		  << "], [type (string) : " << lumiItem.m_type
-		  << "], [status (double) : " << lumiItem.m_status
-		  << "]" << std::endl;
-	runItem.m_lumisummary.push_back(lumiItem);
-	dqmSummary.m_summary.push_back(runItem);
-	std::cout << "No information in DQMSummary for run " 
-		  << r_number <<std::endl;
-      }
-    }
-    else 
+    } else
       throw cms::Exception("UnconsistentData") << "What is wrong with you?" << std::endl;
     std::cout << "DQMSummary built" << std::endl;
     delete query;
     session->transaction().commit();
-  } 
-  catch (const std::exception& e) { 
-    std::cout << "Exception: "<<e.what()<<std::endl; 
+  } catch (const std::exception& e) {
+    std::cout << "Exception: " << e.what() << std::endl;
   }
   delete session;
   return dqmSummary;

--- a/CondTools/DQM/src/DQMSummarySourceHandler.cc
+++ b/CondTools/DQM/src/DQMSummarySourceHandler.cc
@@ -8,42 +8,37 @@
 #include <vector>
 
 namespace popcon {
-  DQMSummarySourceHandler::DQMSummarySourceHandler(const edm::ParameterSet & pset):
-    m_name(pset.getUntrackedParameter<std::string>("name","DQMSummarySourceHandler")),
-    m_since(pset.getUntrackedParameter<unsigned long long>("firstSince",1)), 
-    m_user(pset.getUntrackedParameter<std::string>("OnlineDBUser","CMS_DQM_SUMMARY")), 
-    m_pass(pset.getUntrackedParameter<std::string>("OnlineDBPass","****")) {
+  DQMSummarySourceHandler::DQMSummarySourceHandler(const edm::ParameterSet& pset)
+      : m_name(pset.getUntrackedParameter<std::string>("name", "DQMSummarySourceHandler")),
+        m_since(pset.getUntrackedParameter<unsigned long long>("firstSince", 1)),
+        m_user(pset.getUntrackedParameter<std::string>("OnlineDBUser", "CMS_DQM_SUMMARY")),
+        m_pass(pset.getUntrackedParameter<std::string>("OnlineDBPass", "****")) {
     m_connectionString = "oracle://cms_omds_lb/CMS_DQM_SUMMARY";
   }
-  
+
   DQMSummarySourceHandler::~DQMSummarySourceHandler() {}
-  
+
   void DQMSummarySourceHandler::getNewObjects() {
     //check what is already inside of the database
-    edm::LogInfo("DQMSummarySourceHandler") << "------- " << m_name << " -> getNewObjects\n" 
-					    << "got offlineInfo " << tagInfo().name 
-					    << ", size " << tagInfo().size 
-					    << ", last object valid since " 
-					    << tagInfo().lastInterval.first << " token "   
-					    << tagInfo().lastPayloadToken << std::endl;
-    edm::LogInfo("DQMSummarySourceHandler") << " ------ last entry info regarding the payload (if existing): " 
-					    << logDBEntry().usertext
-					    << "; last record with the correct tag (if existing) has been written in the db: " 
-					    << logDBEntry().destinationDB << std::endl; 
+    edm::LogInfo("DQMSummarySourceHandler")
+        << "------- " << m_name << " -> getNewObjects\n"
+        << "got offlineInfo " << tagInfo().name << ", size " << tagInfo().size << ", last object valid since "
+        << tagInfo().lastInterval.first << " token " << tagInfo().lastPayloadToken << std::endl;
+    edm::LogInfo("DQMSummarySourceHandler")
+        << " ------ last entry info regarding the payload (if existing): " << logDBEntry().usertext
+        << "; last record with the correct tag (if existing) has been written in the db: " << logDBEntry().destinationDB
+        << std::endl;
     if (tagInfo().size > 0) {
       Ref payload = lastPayload();
-      edm::LogInfo("DQMSummarySourceHandler") << "size of last payload  "
-					      << payload->m_summary.size() << std::endl;
+      edm::LogInfo("DQMSummarySourceHandler") << "size of last payload  " << payload->m_summary.size() << std::endl;
     }
     std::cout << "runnumber/first since = " << m_since << std::endl;
-    DQMSummary * dqmSummary = new DQMSummary;
+    DQMSummary* dqmSummary = new DQMSummary;
     DQMSummaryReader dqmSummaryReader(m_connectionString, m_user, m_pass);
     *dqmSummary = dqmSummaryReader.readData("SUMMARYCONTENT", m_since);
-    m_to_transfer.push_back(std::make_pair((DQMSummary*)dqmSummary,m_since));
-    edm::LogInfo("DQMSummarySourceHandler") << "------- " 
-					    << m_name << " - > getNewObjects" 
-					    << std::endl;
+    m_to_transfer.push_back(std::make_pair((DQMSummary*)dqmSummary, m_since));
+    edm::LogInfo("DQMSummarySourceHandler") << "------- " << m_name << " - > getNewObjects" << std::endl;
   }
-  
-  std::string DQMSummarySourceHandler::id() const {return m_name;}
-}
+
+  std::string DQMSummarySourceHandler::id() const { return m_name; }
+}  // namespace popcon

--- a/CondTools/DQM/src/DQMXMLFileSourceHandler.cc
+++ b/CondTools/DQM/src/DQMXMLFileSourceHandler.cc
@@ -7,80 +7,68 @@
 #include <vector>
 
 namespace popcon {
-  DQMXMLFileSourceHandler::DQMXMLFileSourceHandler(const edm::ParameterSet & pset):
-    m_name(pset.getUntrackedParameter<std::string>("name","DQMXMLFileSourceHandler")),
-    m_file(pset.getUntrackedParameter<std::string>("XMLFile","./file.xml")),
-    m_zip(pset.getUntrackedParameter<bool>("zip",false)),
-    m_since(pset.getUntrackedParameter<unsigned long long>("firstSince",1)),
-    m_debugMode(pset.getUntrackedParameter<bool>("debug",false)) {
-  }
-  
+  DQMXMLFileSourceHandler::DQMXMLFileSourceHandler(const edm::ParameterSet& pset)
+      : m_name(pset.getUntrackedParameter<std::string>("name", "DQMXMLFileSourceHandler")),
+        m_file(pset.getUntrackedParameter<std::string>("XMLFile", "./file.xml")),
+        m_zip(pset.getUntrackedParameter<bool>("zip", false)),
+        m_since(pset.getUntrackedParameter<unsigned long long>("firstSince", 1)),
+        m_debugMode(pset.getUntrackedParameter<bool>("debug", false)) {}
+
   DQMXMLFileSourceHandler::~DQMXMLFileSourceHandler() {}
-  
+
   void DQMXMLFileSourceHandler::getNewObjects() {
-    edm::LogInfo("DQMXMLFileSourceHandler") << "[DQMXMLFileSourceHandler::getNewObjects] for PopCon application " << m_name;
-    if(m_debugMode){
-	std::stringstream ss;
-	ss << "\n------- " << m_name 
-	   << " - > getNewObjects\n";
-	if (this->tagInfo().size > 0){
-	  //check what is already inside of the database
-	  ss << "\ngot offlineInfo "<< this->tagInfo().name 
-	     << ",\n size " << this->tagInfo().size 
-	     << ",\n" << this->tagInfo().token 
-	     << ",\n last object valid since " << this->tagInfo().lastInterval.first 
-	     << ",\n token " << this->tagInfo().lastPayloadToken 
-	     << ",\n UserText " << this->userTextLog()
-	     << ";\n last entry info regarding the payload (if existing):" 
-	     << ",\n logId"<<this->logDBEntry().logId 
-	     << ",\n last record with the correct tag (if existing) has been written in the db " << this->logDBEntry().destinationDB
-	     << ",\n provenance " << this->logDBEntry().provenance
-	     << ",\n usertext " << this->logDBEntry().usertext
-	     << ",\n iovtag " << this->logDBEntry().iovtag
-	     << ",\n timetype " << this->logDBEntry().iovtimetype
-	     << ",\n payload index " << this->logDBEntry().payloadIdx
-	     << ",\n payload class " << this->logDBEntry().payloadClass 
-	     << ",\n payload token " << this->logDBEntry().payloadToken
-	     << ",\n execution time " << this->logDBEntry().exectime
-	     << ",\n execution message " << this->logDBEntry().execmessage
-	     << std::endl;
-	  Ref payload = this->lastPayload();
-	  ss << "size of last payload " << payload->size() << std::endl;
-	} else {
-	  ss << " First object for this tag " << std::endl;
-	}
-	edm::LogInfo("DQMXMLFileSourceHandler") << ss.str();
+    edm::LogInfo("DQMXMLFileSourceHandler")
+        << "[DQMXMLFileSourceHandler::getNewObjects] for PopCon application " << m_name;
+    if (m_debugMode) {
+      std::stringstream ss;
+      ss << "\n------- " << m_name << " - > getNewObjects\n";
+      if (this->tagInfo().size > 0) {
+        //check what is already inside of the database
+        ss << "\ngot offlineInfo " << this->tagInfo().name << ",\n size " << this->tagInfo().size << ",\n"
+           << this->tagInfo().token << ",\n last object valid since " << this->tagInfo().lastInterval.first
+           << ",\n token " << this->tagInfo().lastPayloadToken << ",\n UserText " << this->userTextLog()
+           << ";\n last entry info regarding the payload (if existing):"
+           << ",\n logId" << this->logDBEntry().logId
+           << ",\n last record with the correct tag (if existing) has been written in the db "
+           << this->logDBEntry().destinationDB << ",\n provenance " << this->logDBEntry().provenance << ",\n usertext "
+           << this->logDBEntry().usertext << ",\n iovtag " << this->logDBEntry().iovtag << ",\n timetype "
+           << this->logDBEntry().iovtimetype << ",\n payload index " << this->logDBEntry().payloadIdx
+           << ",\n payload class " << this->logDBEntry().payloadClass << ",\n payload token "
+           << this->logDBEntry().payloadToken << ",\n execution time " << this->logDBEntry().exectime
+           << ",\n execution message " << this->logDBEntry().execmessage << std::endl;
+        Ref payload = this->lastPayload();
+        ss << "size of last payload " << payload->size() << std::endl;
+      } else {
+        ss << " First object for this tag " << std::endl;
+      }
+      edm::LogInfo("DQMXMLFileSourceHandler") << ss.str();
     }
     edm::LogInfo("DQMXMLFileSourceHandler") << "runnumber/first since = " << m_since << std::endl;
-    if(m_since<=this->tagInfo().lastInterval.first){
-      edm::LogInfo("DQMXMLFileSourceHandler") 
-	<< "[DQMXMLFileSourceHandler::getNewObjects] \nthe current starting iov " << m_since
-	<< "\nis not compatible with the last iov ("  
-	<< this->tagInfo().lastInterval.first << ") open for the object " 
-	<< this->logDBEntry().payloadClass << " \nin the db " 
-	<< this->logDBEntry().destinationDB << " \n NO TRANSFER NEEDED"
-	<< std::endl;
+    if (m_since <= this->tagInfo().lastInterval.first) {
+      edm::LogInfo("DQMXMLFileSourceHandler")
+          << "[DQMXMLFileSourceHandler::getNewObjects] \nthe current starting iov " << m_since
+          << "\nis not compatible with the last iov (" << this->tagInfo().lastInterval.first << ") open for the object "
+          << this->logDBEntry().payloadClass << " \nin the db " << this->logDBEntry().destinationDB
+          << " \n NO TRANSFER NEEDED" << std::endl;
       return;
-      }
-    edm::LogInfo("DQMXMLFileSourceHandler") 
-      << "[DQMXMLFileSourceHandler::getNewObjects] " << m_name << " getting data to be transferred "  << std::endl;
-    FileBlob* XMLFile = new FileBlob(m_file,m_zip);
+    }
+    edm::LogInfo("DQMXMLFileSourceHandler")
+        << "[DQMXMLFileSourceHandler::getNewObjects] " << m_name << " getting data to be transferred " << std::endl;
+    FileBlob* XMLFile = new FileBlob(m_file, m_zip);
     /*if(!this->tagInfo().size)
       m_since=1;
     else
       if (m_debugMode)
       m_since=this->tagInfo().lastInterval.first+1; */
-    if(XMLFile->size() != 0){
+    if (XMLFile->size() != 0) {
       edm::LogInfo("DQMXMLFileSourceHandler") << "setting runnumber/first since = " << m_since << std::endl;
-      this->m_to_transfer.push_back(std::make_pair(XMLFile,m_since));
+      this->m_to_transfer.push_back(std::make_pair(XMLFile, m_since));
     } else {
       edm::LogError("DQMSummarySourceHandler") << "XML file " << m_file << " does not exist" << std::endl;
       delete XMLFile;
     }
-    edm::LogInfo("DQMSummarySourceHandler") << "------- " 
-					    << m_name << " - > getNewObjects" 
-					    << std::endl;
+    edm::LogInfo("DQMSummarySourceHandler") << "------- " << m_name << " - > getNewObjects" << std::endl;
   }
-  
-  std::string DQMXMLFileSourceHandler::id() const {return m_name;}
-}
+
+  std::string DQMXMLFileSourceHandler::id() const { return m_name; }
+}  // namespace popcon

--- a/CondTools/DQM/src/ReadBase.cc
+++ b/CondTools/DQM/src/ReadBase.cc
@@ -6,14 +6,13 @@
 #include "RelationalAccess/ISessionProxy.h"
 #include "RelationalAccess/RelationalServiceException.h"
 //#include "CoralKernel/Context.h"
-#include<iostream>
+#include <iostream>
 #include <cstdlib>
 
-ReadBase::ReadBase():
-  m_connectionService() {
+ReadBase::ReadBase() : m_connectionService() {
   //coral::Context& context = coral::Context::instance();
   //context.loadComponent( "CORAL/RelationalPlugins/oracle" );
-  //coral::IHandle<coral::IRelationalDomain> domain = context.query<coral::IRelationalDomain>( "CORAL/RelationalPlugins/oracle" );    
+  //coral::IHandle<coral::IRelationalDomain> domain = context.query<coral::IRelationalDomain>( "CORAL/RelationalPlugins/oracle" );
   //if ( ! domain.isValid() )
   //  throw std::runtime_error( "Could not load the OracleAccess plugin" );
 }
@@ -22,13 +21,12 @@ ReadBase::~ReadBase() {
   //if ( m_connection ) delete m_connection;
 }
 
-coral::ISessionProxy*
-ReadBase::connect( const std::string& connectionString,
-                   const std::string& user,
-                   const std::string& pass ) {
+coral::ISessionProxy* ReadBase::connect(const std::string& connectionString,
+                                        const std::string& user,
+                                        const std::string& pass) {
   //coral::Context& ctx = coral::Context::instance();
   //coral::IHandle<coral::IRelationalDomain> iHandle=ctx.query<coral::IRelationalDomain>("CORAL/RelationalPlugins/oracle");
-  //if ( ! iHandle.isValid() ) 
+  //if ( ! iHandle.isValid() )
   //  throw std::runtime_error( "Could not load the OracleAccess plugin" );
   //
   //std::pair<std::string, std::string> connectionAndSchema = iHandle->decodeUserConnectionString( connectionString );
@@ -39,17 +37,14 @@ ReadBase::connect( const std::string& connectionString,
   //  m_connection->connect();
 
   //coral::ISession* session = m_connection->newSession( connectionAndSchema.second );
-  //if ( session ) 
+  //if ( session )
   //  session->startUserSession( user, pass );
-  std::string userEnv("CORAL_AUTH_USER="+user);
-  std::string passEnv("CORAL_AUTH_PASSWORD="+pass);
-  ::putenv( const_cast<char*>(userEnv.c_str()));  
-  ::putenv( const_cast<char*>(passEnv.c_str())); 
+  std::string userEnv("CORAL_AUTH_USER=" + user);
+  std::string passEnv("CORAL_AUTH_PASSWORD=" + pass);
+  ::putenv(const_cast<char*>(userEnv.c_str()));
+  ::putenv(const_cast<char*>(passEnv.c_str()));
   m_connectionService.configuration().setAuthenticationService("CORAL/Services/EnvironmentAuthenticationService");
-  return m_connectionService.connect( connectionString );
+  return m_connectionService.connect(connectionString);
 }
 
-void
-ReadBase::setVerbosityLevel( coral::MsgLevel level ) {
-  coral::MessageStream::setMsgVerbosity(level);
-}
+void ReadBase::setVerbosityLevel(coral::MsgLevel level) { coral::MessageStream::setMsgVerbosity(level); }

--- a/CondTools/DQM/src/TestBase.cc
+++ b/CondTools/DQM/src/TestBase.cc
@@ -4,46 +4,43 @@
 #include "RelationalAccess/ISession.h"
 #include "RelationalAccess/RelationalServiceException.h"
 #include "CoralKernel/Context.h"
-#include<iostream>
+#include <iostream>
 
-
-TestBase::TestBase():
-  m_connection( nullptr ) {
+TestBase::TestBase() : m_connection(nullptr) {
   coral::Context& context = coral::Context::instance();
-  context.loadComponent( "CORAL/RelationalPlugins/oracle" );
-  coral::IHandle<coral::IRelationalDomain> domain = context.query<coral::IRelationalDomain>( "CORAL/RelationalPlugins/oracle" );    
-  if ( ! domain.isValid() )
-    throw std::runtime_error( "Could not load the OracleAccess plugin" );
+  context.loadComponent("CORAL/RelationalPlugins/oracle");
+  coral::IHandle<coral::IRelationalDomain> domain =
+      context.query<coral::IRelationalDomain>("CORAL/RelationalPlugins/oracle");
+  if (!domain.isValid())
+    throw std::runtime_error("Could not load the OracleAccess plugin");
 }
 
 TestBase::~TestBase() {
-  if ( m_connection ) delete m_connection;
+  if (m_connection)
+    delete m_connection;
 }
 
-coral::ISession*
-TestBase::connect( const std::string& connectionString,
-                   const std::string& user,
-                   const std::string& pass ) {
+coral::ISession* TestBase::connect(const std::string& connectionString,
+                                   const std::string& user,
+                                   const std::string& pass) {
   coral::Context& ctx = coral::Context::instance();
-  coral::IHandle<coral::IRelationalDomain> iHandle=ctx.query<coral::IRelationalDomain>("CORAL/RelationalPlugins/oracle");
-  if ( ! iHandle.isValid() ) 
-    throw std::runtime_error( "Could not load the OracleAccess plugin" );
-  
-  std::pair<std::string, std::string> connectionAndSchema = iHandle->decodeUserConnectionString( connectionString );
-  if ( ! m_connection )
-    m_connection = iHandle->newConnection( connectionAndSchema.first );
+  coral::IHandle<coral::IRelationalDomain> iHandle =
+      ctx.query<coral::IRelationalDomain>("CORAL/RelationalPlugins/oracle");
+  if (!iHandle.isValid())
+    throw std::runtime_error("Could not load the OracleAccess plugin");
 
-  if ( ! m_connection->isConnected() )
+  std::pair<std::string, std::string> connectionAndSchema = iHandle->decodeUserConnectionString(connectionString);
+  if (!m_connection)
+    m_connection = iHandle->newConnection(connectionAndSchema.first);
+
+  if (!m_connection->isConnected())
     m_connection->connect();
 
-  coral::ISession* session = m_connection->newSession( connectionAndSchema.second );
-  if ( session ) 
-    session->startUserSession( user, pass );
-  
+  coral::ISession* session = m_connection->newSession(connectionAndSchema.second);
+  if (session)
+    session->startUserSession(user, pass);
+
   return session;
 }
 
-void
-TestBase::setVerbosityLevel( coral::MsgLevel level ) {
-  coral::MessageStream::setMsgVerbosity(level);
-}
+void TestBase::setVerbosityLevel(coral::MsgLevel level) { coral::MessageStream::setMsgVerbosity(level); }


### PR DESCRIPTION

Applying code-format for CMSSW category db,dqm.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/279//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


