### PR TITLE
[RECO_ANALYSIS] fixes needed to build cxxmodules

### DIFF
--- a/DataFormats/Candidate/interface/CandidateWithRef.h
+++ b/DataFormats/Candidate/interface/CandidateWithRef.h
@@ -8,7 +8,6 @@
  *
  *
  */
-#include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/Common/interface/RefToBase.h"


### PR DESCRIPTION
#### PR description:

Removed un-used include statement
```
DataFormats/Candidate/interface/CandidateWithRef.h:#include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
```