### PR TITLE
[CORE] fixes needed to build cxxmodules

### DIFF
--- a/DataFormats/CLHEP/interface/AlgebraicObjects.h
+++ b/DataFormats/CLHEP/interface/AlgebraicObjects.h
@@ -4,7 +4,8 @@
 #ifdef HEP_SHORT_NAMES
 #undef HEP_SHORT_NAMES
 #endif
-
+#include <vector>
+#include <ostream>
 #include "CLHEP/Matrix/Vector.h"
 #include "CLHEP/Matrix/Matrix.h"
 #include "CLHEP/Matrix/SymMatrix.h"


### PR DESCRIPTION
- External CLHEP should be fixed to include `vector` and `ostream` in `CLHEP/Matrix/*.h` . This PR adds the missing headers to avoid build errors for CXXMODULES IBs.
