### PR TITLE
Run3-hcx204 Fixes the segmentaion violation in Phase2 workflow with darkening

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -501,7 +501,7 @@ std::unique_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs(const 
   //set depth segmentation for HB/HE recalib - only happens once
   if ((he_recalibration && !setHEdsegm) || (hb_recalibration && !setHBdsegm)) {
     std::vector<std::vector<int>> m_segmentation;
-    int maxEta = topo->lastHERing();
+    int maxEta = std::max(topo->lastHERing(),topo->lastHBRing());
     m_segmentation.resize(maxEta);
     for (int i = 0; i < maxEta; i++) {
       topo->getDepthSegmentation(i + 1, m_segmentation[i]);


### PR DESCRIPTION
#### PR description:

Fix segmentation violation in phase 2 workflows with scintillator darkening 

#### PR validation:

Checked with the workflow where the segmentation violation is observed

#### if this PR is a backport please specify the original PR:

To be backported to 10_6_0