### PR TITLE
Run3-hcx205 Fixes the segmentation violation in Phase2 workflow with darkening

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -505,7 +505,7 @@ std::unique_ptr<HcalRespCorrs> HcalHardcodeCalibrations::produceRespCorrs (const
   //set depth segmentation for HB/HE recalib - only happens once
   if((he_recalibration && !setHEdsegm) || (hb_recalibration && !setHBdsegm)){
     std::vector<std::vector<int>> m_segmentation;
-    int maxEta = topo->lastHERing();
+    int maxEta = std::max(topo->lastHERing(),topo->lastHBRing());
     m_segmentation.resize(maxEta);
     for (int i = 0; i < maxEta; i++) {
       topo->getDepthSegmentation(i+1,m_segmentation[i]);


### PR DESCRIPTION
#### PR description:

Fixes segmentation violation observed in the Phase2 workflows requiring scintillation darkening (backport PR #26964)

#### PR validation:

Tested with the workflow concerned 29034 + Hcal darkening

#### if this PR is a backport please specify the original PR:

Backport from PR#26964