### PR TITLE
Change default beamspot from "RoundOpticsHighSigmaZ" to "RoundOpticsLowSigmaZ"

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -66,7 +66,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v5', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2 2023

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -281,7 +281,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2021_realistic',
         'HLTmenu': '@relval2017',
         'Era' : 'Run3',
-        'BeamSpot': 'Run3RoundOptics25ns13TeVHighSigmaZ',
+        'BeamSpot': 'Run3RoundOptics25ns13TeVLowSigmaZ',
         'ScenToRun' : ['GenSimFull','DigiFull','RecoFull','HARVESTFull','ALCAFull'],
     },
     '2021Design' : {


### PR DESCRIPTION
#### PR description:

PC has requested a change in the default beamspot in 2021 realistic workflows from "RoundOpticsHighSigmaZ" to "RoundOpticsLowSigmaZ". This PR implements the change in both conditions:

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_realistic_v5/106X_upgrade2021_realistic_v4

and validation workflows.

#### PR validation:

``runTheMatrix.py --what upgrade -l 11825.0 --ibeos`` generates workflows that use the updated beamspot and runs to completion.

#### if this PR is a backport please specify the original PR:

This PR will be backported to 10_6_X.
