### PR TITLE
Running code-format for db-hlt

### DIFF
--- a/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
+++ b/CondCore/HLTPlugins/plugins/AlCaRecoTriggerBits_PayloadInspector.cc
@@ -11,108 +11,111 @@
 #include "TLine.h"
 
 namespace {
-  
+
   /************************************************
     Display AlCaRecoTriggerBits mapping
   *************************************************/
-  class AlCaRecoTriggerBits_Display: public cond::payloadInspector::PlotImage<AlCaRecoTriggerBits> {
+  class AlCaRecoTriggerBits_Display : public cond::payloadInspector::PlotImage<AlCaRecoTriggerBits> {
   public:
-    AlCaRecoTriggerBits_Display() : cond::payloadInspector::PlotImage<AlCaRecoTriggerBits>( "Table of AlCaRecoTriggerBits" ){
-      setSingleIov( true );
+    AlCaRecoTriggerBits_Display()
+        : cond::payloadInspector::PlotImage<AlCaRecoTriggerBits>("Table of AlCaRecoTriggerBits") {
+      setSingleIov(true);
     }
 
-    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
       auto iov = iovs.front();
-      std::shared_ptr<AlCaRecoTriggerBits> payload = fetchPayload( std::get<1>(iov) );
+      std::shared_ptr<AlCaRecoTriggerBits> payload = fetchPayload(std::get<1>(iov));
 
-      std::string IOVsince  = std::to_string(std::get<0>(iov));
+      std::string IOVsince = std::to_string(std::get<0>(iov));
 
       // Get map of strings to concatenated list of names of HLT paths:
       typedef std::map<std::string, std::string> TriggerMap;
       const TriggerMap &triggerMap = payload->m_alcarecoToTrig;
 
       unsigned int mapsize = triggerMap.size();
-      float pitch = 1./(mapsize*1.1);
+      float pitch = 1. / (mapsize * 1.1);
 
       float y, x1, x2;
-      std::vector<float> y_x1,y_x2,y_line;
-      std::vector<std::string>   s_x1,s_x2,s_x3;
+      std::vector<float> y_x1, y_x2, y_line;
+      std::vector<std::string> s_x1, s_x2, s_x3;
 
       // starting table at y=1.0 (top of the canvas)
       // first column is at 0.02, second column at 0.32 NDC
-      y = 1.0; x1 = 0.02; x2 = x1+0.30;
-	
-      y -= pitch; 
+      y = 1.0;
+      x1 = 0.02;
+      x2 = x1 + 0.30;
+
+      y -= pitch;
       y_x1.push_back(y);
       s_x1.push_back("#scale[1.2]{Key}");
       y_x2.push_back(y);
-      s_x2.push_back("#scale[1.2]{in IOV: "+IOVsince+"}");
+      s_x2.push_back("#scale[1.2]{in IOV: " + IOVsince + "}");
 
-      y -= pitch/2.;
+      y -= pitch / 2.;
       y_line.push_back(y);
 
-      for(const auto &element : triggerMap){
+      for (const auto &element : triggerMap) {
+        y -= pitch;
+        y_x1.push_back(y);
+        s_x1.push_back(element.first);
 
-	y -= pitch; 
-	y_x1.push_back(y);
-	s_x1.push_back(element.first);
+        std::vector<std::string> output;
+        std::string toAppend = "";
+        const std::vector<std::string> paths = payload->decompose(element.second);
+        for (unsigned int iPath = 0; iPath < paths.size(); ++iPath) {
+          // if the line to be added has less than 60 chars append to current
+          if ((toAppend + paths[iPath]).length() < 60) {
+            toAppend += paths[iPath] + ";";
+          } else {
+            // else if the line exceeds 60 chars, dump in the vector and resume from scratch
+            output.push_back(toAppend);
+            toAppend.clear();
+            toAppend += paths[iPath] + ";";
+          }
+          // if it's the last, dump it
+          if (iPath == paths.size() - 1)
+            output.push_back(toAppend);
+        }
 
-	std::vector<std::string> output;
-	std::string toAppend=""; 
-	const std::vector<std::string> paths = payload->decompose(element.second);
-	for (unsigned int iPath = 0; iPath < paths.size(); ++iPath) {
-	  // if the line to be added has less than 60 chars append to current 
-	  if((toAppend+paths[iPath]).length()<60){
-	    toAppend+=paths[iPath]+";";
-	  } else {
-	    // else if the line exceeds 60 chars, dump in the vector and resume from scratch
-	    output.push_back(toAppend);
-	    toAppend.clear();
-	    toAppend+=paths[iPath]+";";
-	  }
-	  // if it's the last, dump it
-	  if(iPath==paths.size()-1) output.push_back(toAppend);
-	}
-      	
-	for (unsigned int br=0; br<output.size();br++){
-	  y_x2.push_back(y);
-	  s_x2.push_back("#color[2]{"+output[br]+"}");
-	  if(br!=output.size()-1) y-=pitch;
-	}
+        for (unsigned int br = 0; br < output.size(); br++) {
+          y_x2.push_back(y);
+          s_x2.push_back("#color[2]{" + output[br] + "}");
+          if (br != output.size() - 1)
+            y -= pitch;
+        }
 
-	y_line.push_back(y-(pitch/2.));
-       
+        y_line.push_back(y - (pitch / 2.));
       }
 
-      TCanvas canvas("AlCaRecoTriggerBits","AlCaRecoTriggerBits",2000,std::max(y_x1.size(),y_x2.size())*40); 
+      TCanvas canvas("AlCaRecoTriggerBits", "AlCaRecoTriggerBits", 2000, std::max(y_x1.size(), y_x2.size()) * 40);
       TLatex l;
       // Draw the columns titles
       l.SetTextAlign(12);
 
-      float newpitch = 1/(std::max(y_x1.size(),y_x2.size())*1.1);
-      float factor  = newpitch/pitch;
-      l.SetTextSize(newpitch-0.002);
+      float newpitch = 1 / (std::max(y_x1.size(), y_x2.size()) * 1.1);
+      float factor = newpitch / pitch;
+      l.SetTextSize(newpitch - 0.002);
       canvas.cd();
-      for(unsigned int i=0;i<y_x1.size();i++){
-	l.DrawLatexNDC(x1,1-(1-y_x1[i])*factor,s_x1[i].c_str());
+      for (unsigned int i = 0; i < y_x1.size(); i++) {
+        l.DrawLatexNDC(x1, 1 - (1 - y_x1[i]) * factor, s_x1[i].c_str());
       }
 
-      for(unsigned int i=0;i<y_x2.size();i++){
-	l.DrawLatexNDC(x2,1-(1-y_x2[i])*factor,s_x2[i].c_str());
-      }  
+      for (unsigned int i = 0; i < y_x2.size(); i++) {
+        l.DrawLatexNDC(x2, 1 - (1 - y_x2[i]) * factor, s_x2[i].c_str());
+      }
 
       canvas.cd();
       canvas.Update();
 
       TLine lines[y_line.size()];
-      unsigned int iL=0;
-      for (const auto & line : y_line){
-	lines[iL] = TLine(gPad->GetUxmin(),1-(1-line)*factor,gPad->GetUxmax(),1-(1-line)*factor);
-	lines[iL].SetLineWidth(1);
-	lines[iL].SetLineStyle(9);
-	lines[iL].SetLineColor(2);
-	lines[iL].Draw("same");
-	iL++;
+      unsigned int iL = 0;
+      for (const auto &line : y_line) {
+        lines[iL] = TLine(gPad->GetUxmin(), 1 - (1 - line) * factor, gPad->GetUxmax(), 1 - (1 - line) * factor);
+        lines[iL].SetLineWidth(1);
+        lines[iL].SetLineStyle(9);
+        lines[iL].SetLineColor(2);
+        lines[iL].Draw("same");
+        iL++;
       }
 
       std::string fileName(m_imageFileName);
@@ -124,256 +127,269 @@ namespace {
   /************************************************
     Compare AlCaRecoTriggerBits mapping
   *************************************************/
-  class AlCaRecoTriggerBits_Compare: public cond::payloadInspector::PlotImage<AlCaRecoTriggerBits> {
+  class AlCaRecoTriggerBits_Compare : public cond::payloadInspector::PlotImage<AlCaRecoTriggerBits> {
   public:
-    AlCaRecoTriggerBits_Compare() : cond::payloadInspector::PlotImage<AlCaRecoTriggerBits>( "Table of AlCaRecoTriggerBits comparison" ){
-      setSingleIov( false );
+    AlCaRecoTriggerBits_Compare()
+        : cond::payloadInspector::PlotImage<AlCaRecoTriggerBits>("Table of AlCaRecoTriggerBits comparison") {
+      setSingleIov(false);
     }
 
-    bool fill( const std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs ) override{
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
+      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
 
-      std::vector<std::tuple<cond::Time_t,cond::Hash> > sorted_iovs = iovs;
-      
       // make absolute sure the IOVs are sortd by since
       std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const &t1, auto const &t2) {
-	  return std::get<0>(t1) < std::get<0>(t2);
-	});
-      
-      auto firstiov  = sorted_iovs.front();
-      auto lastiov   = sorted_iovs.back();
-      
-      std::shared_ptr<AlCaRecoTriggerBits> last_payload  = fetchPayload( std::get<1>(lastiov) );
-      std::shared_ptr<AlCaRecoTriggerBits> first_payload = fetchPayload( std::get<1>(firstiov) );
-      
-      std::string lastIOVsince  = std::to_string(std::get<0>(lastiov));
+        return std::get<0>(t1) < std::get<0>(t2);
+      });
+
+      auto firstiov = sorted_iovs.front();
+      auto lastiov = sorted_iovs.back();
+
+      std::shared_ptr<AlCaRecoTriggerBits> last_payload = fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<AlCaRecoTriggerBits> first_payload = fetchPayload(std::get<1>(firstiov));
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
-      
+
       // Get map of strings to concatenated list of names of HLT paths:
       typedef std::map<std::string, std::string> TriggerMap;
       const TriggerMap &first_triggerMap = first_payload->m_alcarecoToTrig;
-      const TriggerMap &last_triggerMap  = last_payload->m_alcarecoToTrig;
+      const TriggerMap &last_triggerMap = last_payload->m_alcarecoToTrig;
 
       std::vector<std::string> first_keys, not_in_first_keys;
       std::vector<std::string> last_keys, not_in_last_keys;
 
       // fill the vector of first keys
-      for (const auto& element : first_triggerMap){
-	first_keys.push_back(element.first);
+      for (const auto &element : first_triggerMap) {
+        first_keys.push_back(element.first);
       }
 
       // fill the vector of last keys
-      for (const auto& element : last_triggerMap){
-	last_keys.push_back(element.first);
+      for (const auto &element : last_triggerMap) {
+        last_keys.push_back(element.first);
       }
 
       // find the elements not in common
-      std::set_difference(first_keys.begin(),first_keys.end(),last_keys.begin(),last_keys.end(), 
-			  std::inserter(not_in_last_keys, not_in_last_keys.begin()));
-      
-      std::set_difference(last_keys.begin(),last_keys.end(),first_keys.begin(),first_keys.end(), 
-			  std::inserter(not_in_first_keys, not_in_first_keys.begin()));
+      std::set_difference(first_keys.begin(),
+                          first_keys.end(),
+                          last_keys.begin(),
+                          last_keys.end(),
+                          std::inserter(not_in_last_keys, not_in_last_keys.begin()));
+
+      std::set_difference(last_keys.begin(),
+                          last_keys.end(),
+                          first_keys.begin(),
+                          first_keys.end(),
+                          std::inserter(not_in_first_keys, not_in_first_keys.begin()));
 
       float pitch = 0.013;
       float y, x1, x2, x3;
 
-      std::vector<float>         y_x1,y_x2,y_x3,y_line;
-      std::vector<std::string>   s_x1,s_x2,s_x3;
+      std::vector<float> y_x1, y_x2, y_x3, y_line;
+      std::vector<std::string> s_x1, s_x2, s_x3;
 
-      y  = 1.0; 
-      x1 = 0.02; 
-      x2 = x1+0.20; 
-      x3 = x2+0.30;
+      y = 1.0;
+      x1 = 0.02;
+      x2 = x1 + 0.20;
+      x3 = x2 + 0.30;
 
-      y -= pitch; 
+      y -= pitch;
       y_x1.push_back(y);
       s_x1.push_back("#scale[1.2]{Key}");
       y_x2.push_back(y);
-      s_x2.push_back("#scale[1.2]{in IOV: "+firstIOVsince+"}");
+      s_x2.push_back("#scale[1.2]{in IOV: " + firstIOVsince + "}");
       y_x3.push_back(y);
-      s_x3.push_back("#scale[1.2]{in IOV: "+lastIOVsince+"}");
-      y -= pitch/3;
+      s_x3.push_back("#scale[1.2]{in IOV: " + lastIOVsince + "}");
+      y -= pitch / 3;
 
       // print the ones missing in the last key
-      for(const auto& key : not_in_last_keys ) {
-	y -= pitch;  
-	y_x1.push_back(y);
-	s_x1.push_back(key);
+      for (const auto &key : not_in_last_keys) {
+        y -= pitch;
+        y_x1.push_back(y);
+        s_x1.push_back(key);
 
-	const std::vector<std::string> missing_in_last_paths = first_payload->decompose(first_triggerMap.at(key));
-	
-	std::vector<std::string> output;
-	std::string toAppend=""; 
-	for (unsigned int iPath = 0; iPath < missing_in_last_paths.size(); ++iPath) {
-	  // if the line to be added has less than 60 chars append to current 
-	  if((toAppend+missing_in_last_paths[iPath]).length()<60){
-	    toAppend+=missing_in_last_paths[iPath]+";";
-	  } else {
-	    // else if the line exceeds 60 chars, dump in the vector and resume from scratch
-	    output.push_back(toAppend);
-	    toAppend.clear();
-	    toAppend+=missing_in_last_paths[iPath]+";";
-	  }
-	  // if it's the last, dump it
-	  if(iPath==missing_in_last_paths.size()-1) output.push_back(toAppend);
-	}
-	
-	for (unsigned int br=0; br<output.size();br++){
-	  y_x2.push_back(y);
-	  s_x2.push_back("#color[2]{"+output[br]+"}");
-	  if(br!=output.size()-1) y -=pitch;
-	}
-	y_line.push_back(y-0.008);
+        const std::vector<std::string> missing_in_last_paths = first_payload->decompose(first_triggerMap.at(key));
 
+        std::vector<std::string> output;
+        std::string toAppend = "";
+        for (unsigned int iPath = 0; iPath < missing_in_last_paths.size(); ++iPath) {
+          // if the line to be added has less than 60 chars append to current
+          if ((toAppend + missing_in_last_paths[iPath]).length() < 60) {
+            toAppend += missing_in_last_paths[iPath] + ";";
+          } else {
+            // else if the line exceeds 60 chars, dump in the vector and resume from scratch
+            output.push_back(toAppend);
+            toAppend.clear();
+            toAppend += missing_in_last_paths[iPath] + ";";
+          }
+          // if it's the last, dump it
+          if (iPath == missing_in_last_paths.size() - 1)
+            output.push_back(toAppend);
+        }
+
+        for (unsigned int br = 0; br < output.size(); br++) {
+          y_x2.push_back(y);
+          s_x2.push_back("#color[2]{" + output[br] + "}");
+          if (br != output.size() - 1)
+            y -= pitch;
+        }
+        y_line.push_back(y - 0.008);
       }
-      
+
       // print the ones missing in the first key
-      for(const auto& key : not_in_first_keys ) {
-	y -= pitch;  
-	y_x1.push_back(y);
-	s_x1.push_back(key);
-	const std::vector<std::string> missing_in_first_paths = last_payload->decompose(last_triggerMap.at(key));
+      for (const auto &key : not_in_first_keys) {
+        y -= pitch;
+        y_x1.push_back(y);
+        s_x1.push_back(key);
+        const std::vector<std::string> missing_in_first_paths = last_payload->decompose(last_triggerMap.at(key));
 
-	std::vector<std::string> output;
-	std::string toAppend=""; 
-	for (unsigned int iPath = 0; iPath < missing_in_first_paths.size(); ++iPath) {
-	  // if the line to be added has less than 60 chars append to current 
-	  if((toAppend+missing_in_first_paths[iPath]).length()<60){
-	    toAppend+=missing_in_first_paths[iPath]+";";
-	  } else {
-	    // else if the line exceeds 60 chars, dump in the vector and resume from scratch
-	    output.push_back(toAppend);
-	    toAppend.clear();
-	    toAppend+=missing_in_first_paths[iPath]+";";
-	  }
-	  // if it's the last, dump it
-	  if(iPath==missing_in_first_paths.size()-1) output.push_back(toAppend);
-	}
+        std::vector<std::string> output;
+        std::string toAppend = "";
+        for (unsigned int iPath = 0; iPath < missing_in_first_paths.size(); ++iPath) {
+          // if the line to be added has less than 60 chars append to current
+          if ((toAppend + missing_in_first_paths[iPath]).length() < 60) {
+            toAppend += missing_in_first_paths[iPath] + ";";
+          } else {
+            // else if the line exceeds 60 chars, dump in the vector and resume from scratch
+            output.push_back(toAppend);
+            toAppend.clear();
+            toAppend += missing_in_first_paths[iPath] + ";";
+          }
+          // if it's the last, dump it
+          if (iPath == missing_in_first_paths.size() - 1)
+            output.push_back(toAppend);
+        }
 
-	for (unsigned int br=0; br<output.size();br++){
-	  y_x3.push_back(y);
-	  s_x3.push_back("#color[4]{"+output[br]+"}");
-	  if(br!=output.size()-1) y -= pitch;
-	}
-	y_line.push_back(y-0.008);
-	
+        for (unsigned int br = 0; br < output.size(); br++) {
+          y_x3.push_back(y);
+          s_x3.push_back("#color[4]{" + output[br] + "}");
+          if (br != output.size() - 1)
+            y -= pitch;
+        }
+        y_line.push_back(y - 0.008);
       }
 
-      for(const auto &element : first_triggerMap){
+      for (const auto &element : first_triggerMap) {
+        if (last_triggerMap.find(element.first) != last_triggerMap.end()) {
+          auto lastElement = last_triggerMap.find(element.first);
 
-      	if(last_triggerMap.find(element.first)!=last_triggerMap.end()){
+          std::string output;
+          const std::vector<std::string> first_paths = first_payload->decompose(element.second);
+          const std::vector<std::string> last_paths = last_payload->decompose(lastElement->second);
 
-      	  auto lastElement = last_triggerMap.find(element.first);
-	
-      	  std::string output;
-      	  const std::vector<std::string> first_paths = first_payload->decompose(element.second);
-      	  const std::vector<std::string> last_paths  = last_payload->decompose(lastElement->second);
+          std::vector<std::string> not_in_first;
+          std::vector<std::string> not_in_last;
 
-      	  std::vector<std::string> not_in_first;
-      	  std::vector<std::string> not_in_last;
+          std::set_difference(first_paths.begin(),
+                              first_paths.end(),
+                              last_paths.begin(),
+                              last_paths.end(),
+                              std::inserter(not_in_last, not_in_last.begin()));
 
-      	  std::set_difference(first_paths.begin(),first_paths.end(),last_paths.begin(),last_paths.end(), 
-      			      std::inserter(not_in_last, not_in_last.begin()));
+          std::set_difference(last_paths.begin(),
+                              last_paths.end(),
+                              first_paths.begin(),
+                              first_paths.end(),
+                              std::inserter(not_in_first, not_in_first.begin()));
 
-      	  std::set_difference(last_paths.begin(),last_paths.end(),first_paths.begin(),first_paths.end(), 
-      	  		      std::inserter(not_in_first, not_in_first.begin()));
+          if (!not_in_last.empty() || !not_in_first.empty()) {
+            y -= pitch;
+            y_x1.push_back(y);
+            s_x1.push_back(element.first);
 
-      	  if(!not_in_last.empty() || !not_in_first.empty()) {
+            std::vector<std::string> output;
+            std::string toAppend = "";
+            for (unsigned int iPath = 0; iPath < not_in_last.size(); ++iPath) {
+              // if the line to be added has less than 60 chars append to current
+              if ((toAppend + not_in_last[iPath]).length() < 60) {
+                toAppend += not_in_last[iPath] + ";";
+              } else {
+                // else if the line exceeds 60 chars, dump in the vector and resume from scratch
+                output.push_back(toAppend);
+                toAppend.clear();
+                toAppend += not_in_last[iPath] + ";";
+              }
+              // if it's the last and not empty, dump it
+              if (toAppend.length() > 0 && iPath == not_in_last.size() - 1)
+                output.push_back(toAppend);
+            }
 
-      	    y -= pitch;  
-	    y_x1.push_back(y);
-	    s_x1.push_back(element.first);
-    
-	    std::vector<std::string> output;
-	    std::string toAppend=""; 
-	    for (unsigned int iPath = 0; iPath < not_in_last.size(); ++iPath) {
-	      // if the line to be added has less than 60 chars append to current 
-	      if((toAppend+not_in_last[iPath]).length()<60){
-		toAppend+=not_in_last[iPath]+";";
-	      } else {
-		// else if the line exceeds 60 chars, dump in the vector and resume from scratch
-		output.push_back(toAppend);
-		toAppend.clear();
-		toAppend+=not_in_last[iPath]+";";
-	      }
-	      // if it's the last and not empty, dump it
-	      if(toAppend.length()>0 && iPath==not_in_last.size()-1) output.push_back(toAppend);
-	    }
+            unsigned int count = output.size();
 
-	    unsigned int count = output.size();
+            for (unsigned int br = 0; br < count; br++) {
+              y_x2.push_back(y - (br * pitch));
+              s_x2.push_back("#color[6]{" + output[br] + "}");
+            }
 
-      	    for (unsigned int br=0; br<count;br++){
-	      y_x2.push_back(y-(br*pitch));
-	      s_x2.push_back("#color[6]{"+output[br]+"}");
-      	    }  
-	    
-	    // clear vector and string
-	    toAppend.clear();
-	    output.clear();
-	    for (unsigned int jPath = 0; jPath < not_in_first.size(); ++jPath) {
-	      // if the line to be added has less than 60 chars append to current 
-	      if((toAppend+not_in_first[jPath]).length()<60){
-		toAppend+=not_in_first[jPath]+";";
-	      } else {
-		// else if the line exceeds 60 chars, dump in the vector and resume from scratch
-		output.push_back(toAppend);
-		toAppend.clear();
-		toAppend+=not_in_first[jPath]+";";
-	      }
-	      // if it's the last and not empty, dump it
-	      if(toAppend.length()>0 && jPath==not_in_first.size()-1) output.push_back(toAppend);
-	    }
-	    
-	    unsigned int count1 = output.size();
-		    
-      	    for (unsigned int br=0; br<count1;br++){  
-	      y_x3.push_back(y-(br*pitch));
-	      s_x3.push_back("#color[8]{"+output[br]+"}");
-      	    }
+            // clear vector and string
+            toAppend.clear();
+            output.clear();
+            for (unsigned int jPath = 0; jPath < not_in_first.size(); ++jPath) {
+              // if the line to be added has less than 60 chars append to current
+              if ((toAppend + not_in_first[jPath]).length() < 60) {
+                toAppend += not_in_first[jPath] + ";";
+              } else {
+                // else if the line exceeds 60 chars, dump in the vector and resume from scratch
+                output.push_back(toAppend);
+                toAppend.clear();
+                toAppend += not_in_first[jPath] + ";";
+              }
+              // if it's the last and not empty, dump it
+              if (toAppend.length() > 0 && jPath == not_in_first.size() - 1)
+                output.push_back(toAppend);
+            }
 
-	    // decrease the y position to the maximum of the two lists
-	    y-=(std::max(count,count1)-1)*pitch;
-	    //y-=count*pitch;
-	    y_line.push_back(y-0.008);
-	    
-      	  } // close if there is at least a difference 
-      	} // if there is a common key
-      }//loop on the keys
+            unsigned int count1 = output.size();
 
-      TCanvas canvas("AlCaRecoTriggerBits","AlCaRecoTriggerBits",2500.,std::max(y_x1.size(),y_x2.size())*40); 
+            for (unsigned int br = 0; br < count1; br++) {
+              y_x3.push_back(y - (br * pitch));
+              s_x3.push_back("#color[8]{" + output[br] + "}");
+            }
+
+            // decrease the y position to the maximum of the two lists
+            y -= (std::max(count, count1) - 1) * pitch;
+            //y-=count*pitch;
+            y_line.push_back(y - 0.008);
+
+          }  // close if there is at least a difference
+        }    // if there is a common key
+      }      //loop on the keys
+
+      TCanvas canvas("AlCaRecoTriggerBits", "AlCaRecoTriggerBits", 2500., std::max(y_x1.size(), y_x2.size()) * 40);
 
       TLatex l;
       // Draw the columns titles
       l.SetTextAlign(12);
 
       // rescale the width of the table row to fit into the canvas
-      float newpitch = 1/(std::max(y_x1.size(),y_x2.size())*1.65);
-      float factor  = newpitch/pitch;
-      l.SetTextSize(newpitch-0.002);
+      float newpitch = 1 / (std::max(y_x1.size(), y_x2.size()) * 1.65);
+      float factor = newpitch / pitch;
+      l.SetTextSize(newpitch - 0.002);
       canvas.cd();
-      for(unsigned int i=0;i<y_x1.size();i++){
-	l.DrawLatexNDC(x1,1-(1-y_x1[i])*factor,s_x1[i].c_str());
+      for (unsigned int i = 0; i < y_x1.size(); i++) {
+        l.DrawLatexNDC(x1, 1 - (1 - y_x1[i]) * factor, s_x1[i].c_str());
       }
 
-      for(unsigned int i=0;i<y_x2.size();i++){
-	l.DrawLatexNDC(x2,1-(1-y_x2[i])*factor,s_x2[i].c_str());
+      for (unsigned int i = 0; i < y_x2.size(); i++) {
+        l.DrawLatexNDC(x2, 1 - (1 - y_x2[i]) * factor, s_x2[i].c_str());
       }
 
-      for(unsigned int i=0;i<y_x3.size();i++){
-	l.DrawLatexNDC(x3,1-(1-y_x3[i])*factor,s_x3[i].c_str());
+      for (unsigned int i = 0; i < y_x3.size(); i++) {
+        l.DrawLatexNDC(x3, 1 - (1 - y_x3[i]) * factor, s_x3[i].c_str());
       }
 
       canvas.cd();
       canvas.Update();
 
       TLine lines[y_line.size()];
-      unsigned int iL=0;
-      for (const auto & line : y_line){
-	lines[iL] = TLine(gPad->GetUxmin(),1-(1-line)*factor,gPad->GetUxmax(),1-(1-line)*factor);
-	lines[iL].SetLineWidth(1);
-	lines[iL].SetLineStyle(9);
-	lines[iL].SetLineColor(2);
-	lines[iL].Draw("same");
-	iL++;
+      unsigned int iL = 0;
+      for (const auto &line : y_line) {
+        lines[iL] = TLine(gPad->GetUxmin(), 1 - (1 - line) * factor, gPad->GetUxmax(), 1 - (1 - line) * factor);
+        lines[iL].SetLineWidth(1);
+        lines[iL].SetLineStyle(9);
+        lines[iL].SetLineColor(2);
+        lines[iL].Draw("same");
+        iL++;
       }
 
       //canvas.SetCanvasSize(2000,(1-y)*1000);
@@ -383,10 +399,9 @@ namespace {
     }
   };
 
-}
+}  // namespace
 
-
-PAYLOAD_INSPECTOR_MODULE( AlCaRecoTriggerBits ){
-  PAYLOAD_INSPECTOR_CLASS( AlCaRecoTriggerBits_Display );
-  PAYLOAD_INSPECTOR_CLASS( AlCaRecoTriggerBits_Compare );
+PAYLOAD_INSPECTOR_MODULE(AlCaRecoTriggerBits) {
+  PAYLOAD_INSPECTOR_CLASS(AlCaRecoTriggerBits_Display);
+  PAYLOAD_INSPECTOR_CLASS(AlCaRecoTriggerBits_Compare);
 }

--- a/CondCore/HLTPlugins/src/plugin.cc
+++ b/CondCore/HLTPlugins/src/plugin.cc
@@ -6,5 +6,5 @@
 #include "CondFormats/HLTObjects/interface/HLTPrescaleTableCond.h"
 #include "CondFormats/DataRecord/interface/HLTPrescaleTableRcd.h"
 
-REGISTER_PLUGIN(AlCaRecoTriggerBitsRcd,AlCaRecoTriggerBits);
-REGISTER_PLUGIN(HLTPrescaleTableRcd,trigger::HLTPrescaleTableCond);
+REGISTER_PLUGIN(AlCaRecoTriggerBitsRcd, AlCaRecoTriggerBits);
+REGISTER_PLUGIN(HLTPrescaleTableRcd, trigger::HLTPrescaleTableCond);

--- a/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
+++ b/CondTools/HLT/src/AlCaRecoTriggerBitsRcdUpdate.cc
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////
 ///
 /// Module to write trigger bit mappings (AlCaRecoTriggerBits) to DB.
-/// Can be configured to read an old one and update this by 
+/// Can be configured to read an old one and update this by
 /// - removing old entries
 /// - adding new ones
 ///
@@ -28,107 +28,96 @@
 // Rcd for reading old one:
 #include "CondFormats/DataRecord/interface/AlCaRecoTriggerBitsRcd.h"
 
-
-class  AlCaRecoTriggerBitsRcdUpdate : public edm::EDAnalyzer {
+class AlCaRecoTriggerBitsRcdUpdate : public edm::EDAnalyzer {
 public:
-  explicit  AlCaRecoTriggerBitsRcdUpdate(const edm::ParameterSet& cfg);
+  explicit AlCaRecoTriggerBitsRcdUpdate(const edm::ParameterSet &cfg);
   ~AlCaRecoTriggerBitsRcdUpdate() override {}
-  
-  void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) override;
-  
+
+  void analyze(const edm::Event &evt, const edm::EventSetup &evtSetup) override;
+
 private:
   typedef std::map<std::string, std::string> TriggerMap;
-  AlCaRecoTriggerBits* createStartTriggerBits(bool startEmpty, const edm::EventSetup& evtSetup) const;
+  AlCaRecoTriggerBits *createStartTriggerBits(bool startEmpty, const edm::EventSetup &evtSetup) const;
   bool removeKeysFromMap(const std::vector<std::string> &keys, TriggerMap &triggerMap) const;
-  bool replaceKeysFromMap(const std::vector<edm::ParameterSet> &alcarecoReplace,
-			  TriggerMap &triggerMap) const;
-  bool addTriggerLists(const std::vector<edm::ParameterSet> &triggerListsAdd,
-		       AlCaRecoTriggerBits &bits) const;
-  /// Takes over memory uresponsibility for 'bitsToWrite'. 
+  bool replaceKeysFromMap(const std::vector<edm::ParameterSet> &alcarecoReplace, TriggerMap &triggerMap) const;
+  bool addTriggerLists(const std::vector<edm::ParameterSet> &triggerListsAdd, AlCaRecoTriggerBits &bits) const;
+  /// Takes over memory uresponsibility for 'bitsToWrite'.
   void writeBitsToDB(AlCaRecoTriggerBits *bitsToWrite) const;
 
   unsigned int nEventCalls_;
   const unsigned int firstRunIOV_;
   const int lastRunIOV_;
-  const bool startEmpty_; 
+  const bool startEmpty_;
   const std::vector<std::string> listNamesRemove_;
   const std::vector<edm::ParameterSet> triggerListsAdd_;
-  const std::vector<edm::ParameterSet> alcarecoReplace_; 
+  const std::vector<edm::ParameterSet> alcarecoReplace_;
 };
 
 ///////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////
 
-AlCaRecoTriggerBitsRcdUpdate::AlCaRecoTriggerBitsRcdUpdate(const edm::ParameterSet& cfg)
-  : nEventCalls_(0), 
-    firstRunIOV_(cfg.getParameter<unsigned int>("firstRunIOV")),
-    lastRunIOV_(cfg.getParameter<int>("lastRunIOV")),
-    startEmpty_(cfg.getParameter<bool>("startEmpty")),
-    listNamesRemove_(cfg.getParameter<std::vector<std::string> >("listNamesRemove")),
-    triggerListsAdd_(cfg.getParameter<std::vector<edm::ParameterSet> >("triggerListsAdd")),
-    alcarecoReplace_(cfg.getParameter<std::vector<edm::ParameterSet> >("alcarecoToReplace"))
-{
-}
-  
+AlCaRecoTriggerBitsRcdUpdate::AlCaRecoTriggerBitsRcdUpdate(const edm::ParameterSet &cfg)
+    : nEventCalls_(0),
+      firstRunIOV_(cfg.getParameter<unsigned int>("firstRunIOV")),
+      lastRunIOV_(cfg.getParameter<int>("lastRunIOV")),
+      startEmpty_(cfg.getParameter<bool>("startEmpty")),
+      listNamesRemove_(cfg.getParameter<std::vector<std::string> >("listNamesRemove")),
+      triggerListsAdd_(cfg.getParameter<std::vector<edm::ParameterSet> >("triggerListsAdd")),
+      alcarecoReplace_(cfg.getParameter<std::vector<edm::ParameterSet> >("alcarecoToReplace")) {}
+
 ///////////////////////////////////////////////////////////////////////
-void AlCaRecoTriggerBitsRcdUpdate::analyze(const edm::Event& evt, const edm::EventSetup& iSetup)
-{
-  if (nEventCalls_++ > 0) { // postfix increment!
-    edm::LogWarning("BadConfig")
-      << "@SUB=analyze" << "Writing to DB to be done only once, set\n"
-      << "'process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))'\n"
-      << " next time. But your writing is fine.)";
+void AlCaRecoTriggerBitsRcdUpdate::analyze(const edm::Event &evt, const edm::EventSetup &iSetup) {
+  if (nEventCalls_++ > 0) {  // postfix increment!
+    edm::LogWarning("BadConfig") << "@SUB=analyze"
+                                 << "Writing to DB to be done only once, set\n"
+                                 << "'process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))'\n"
+                                 << " next time. But your writing is fine.)";
     return;
   }
 
   // create what to write - starting from empty or existing list (auto_ptr?)
   AlCaRecoTriggerBits *bitsToWrite = this->createStartTriggerBits(startEmpty_, iSetup);
 
-  // remove some existing entries in map 
+  // remove some existing entries in map
   this->removeKeysFromMap(listNamesRemove_, bitsToWrite->m_alcarecoToTrig);
 
   // now add new entries
   this->addTriggerLists(triggerListsAdd_, *bitsToWrite);
 
-  // now replace keys 
-  this->replaceKeysFromMap(alcarecoReplace_,bitsToWrite->m_alcarecoToTrig);
+  // now replace keys
+  this->replaceKeysFromMap(alcarecoReplace_, bitsToWrite->m_alcarecoToTrig);
 
   // finally write to DB
   this->writeBitsToDB(bitsToWrite);
-
 }
 
 ///////////////////////////////////////////////////////////////////////
-AlCaRecoTriggerBits*  // auto_ptr?
-AlCaRecoTriggerBitsRcdUpdate::createStartTriggerBits(bool startEmpty,
-						     const edm::EventSetup& evtSetup) const
-{
+AlCaRecoTriggerBits *  // auto_ptr?
+AlCaRecoTriggerBitsRcdUpdate::createStartTriggerBits(bool startEmpty, const edm::EventSetup &evtSetup) const {
   if (startEmpty) {
     return new AlCaRecoTriggerBits;
   } else {
     edm::ESHandle<AlCaRecoTriggerBits> triggerBits;
     evtSetup.get<AlCaRecoTriggerBitsRcd>().get(triggerBits);
-    return new AlCaRecoTriggerBits(*triggerBits); // copy old one
+    return new AlCaRecoTriggerBits(*triggerBits);  // copy old one
   }
 }
 
 ///////////////////////////////////////////////////////////////////////
 bool AlCaRecoTriggerBitsRcdUpdate::removeKeysFromMap(const std::vector<std::string> &keys,
-						     TriggerMap &triggerMap) const
-{
-  for (std::vector<std::string>::const_iterator iKey = keys.begin(), endKey = keys.end(); 
-       iKey != endKey; ++iKey) {
+                                                     TriggerMap &triggerMap) const {
+  for (std::vector<std::string>::const_iterator iKey = keys.begin(), endKey = keys.end(); iKey != endKey; ++iKey) {
     if (triggerMap.find(*iKey) != triggerMap.end()) {
       // remove
-//      edm::LogError("Temp") << "@SUB=removeKeysFromMap" << "Cannot yet remove '" << *iKey
-// 			    << "' from map.";
-// FIXME: test next line@
+      //      edm::LogError("Temp") << "@SUB=removeKeysFromMap" << "Cannot yet remove '" << *iKey
+      // 			    << "' from map.";
+      // FIXME: test next line@
       triggerMap.erase(*iKey);
-    } else { // not in list ==> misconfiguartion!
+    } else {  // not in list ==> misconfiguartion!
       throw cms::Exception("BadConfig") << "[AlCaRecoTriggerBitsRcdUpdate::removeKeysFromMap] "
-					<< "Cannot remove key '" << *iKey << "' since not in "
-					<< "list - typo in configuration?\n";
+                                        << "Cannot remove key '" << *iKey << "' since not in "
+                                        << "list - typo in configuration?\n";
       return false;
     }
   }
@@ -137,27 +126,26 @@ bool AlCaRecoTriggerBitsRcdUpdate::removeKeysFromMap(const std::vector<std::stri
 
 ///////////////////////////////////////////////////////////////////////
 bool AlCaRecoTriggerBitsRcdUpdate::replaceKeysFromMap(const std::vector<edm::ParameterSet> &alcarecoReplace,
-						      TriggerMap &triggerMap) const
-{
-  
-  std::vector<std::pair<std::string,std::string> > keyPairs;
+                                                      TriggerMap &triggerMap) const {
+  std::vector<std::pair<std::string, std::string> > keyPairs;
   keyPairs.reserve(alcarecoReplace.size());
 
-  for(auto &iSet : alcarecoReplace ){
+  for (auto &iSet : alcarecoReplace) {
     const std::string oldKey(iSet.getParameter<std::string>("oldKey"));
     const std::string newKey(iSet.getParameter<std::string>("newKey"));
-    keyPairs.push_back(std::make_pair(oldKey,newKey));
+    keyPairs.push_back(std::make_pair(oldKey, newKey));
   }
 
-  for(auto& iKey : keyPairs){
-    if(triggerMap.find(iKey.first) != triggerMap.end() ){
+  for (auto &iKey : keyPairs) {
+    if (triggerMap.find(iKey.first) != triggerMap.end()) {
       std::string bitsToReplace = triggerMap[iKey.first];
       triggerMap.erase(iKey.first);
       triggerMap[iKey.second] = bitsToReplace;
-    } else { // not in list ==> misconfiguration!
-      edm::LogWarning("AlCaRecoTriggerBitsRcdUpdate") << "[AlCaRecoTriggerBitsRcdUpdate::replaceKeysFromMap] "
-						      << "Cannot replace key '" << iKey.first << "with " << iKey.second << " since not in "
-						      << "list - typo in configuration?\n";
+    } else {  // not in list ==> misconfiguration!
+      edm::LogWarning("AlCaRecoTriggerBitsRcdUpdate")
+          << "[AlCaRecoTriggerBitsRcdUpdate::replaceKeysFromMap] "
+          << "Cannot replace key '" << iKey.first << "with " << iKey.second << " since not in "
+          << "list - typo in configuration?\n";
       return false;
     }
   }
@@ -166,24 +154,22 @@ bool AlCaRecoTriggerBitsRcdUpdate::replaceKeysFromMap(const std::vector<edm::Par
 
 ///////////////////////////////////////////////////////////////////////
 bool AlCaRecoTriggerBitsRcdUpdate::addTriggerLists(const std::vector<edm::ParameterSet> &triggerListsAdd,
-						   AlCaRecoTriggerBits &bits) const
-{
+                                                   AlCaRecoTriggerBits &bits) const {
   TriggerMap &triggerMap = bits.m_alcarecoToTrig;
 
   // loop on PSets, each containing the key (filter name) and a vstring with triggers
-  for (std::vector<edm::ParameterSet>::const_iterator iSet = triggerListsAdd.begin();
-       iSet != triggerListsAdd.end(); ++iSet) {
-    
+  for (std::vector<edm::ParameterSet>::const_iterator iSet = triggerListsAdd.begin(); iSet != triggerListsAdd.end();
+       ++iSet) {
     const std::vector<std::string> paths(iSet->getParameter<std::vector<std::string> >("hltPaths"));
     // We must avoid a map<string,vector<string> > in DB for performance reason,
     // so we have to merge the paths into one string that will be decoded when needed:
     const std::string mergedPaths = bits.compose(paths);
-    
+
     const std::string filter(iSet->getParameter<std::string>("listName"));
     if (triggerMap.find(filter) != triggerMap.end()) {
-      throw cms::Exception("BadConfig") << "List name '" << filter << "' already in map, either " 
+      throw cms::Exception("BadConfig") << "List name '" << filter << "' already in map, either "
                                         << "remove from 'triggerListsAdd' or "
-					<< " add to 'listNamesRemove'.\n";
+                                        << " add to 'listNamesRemove'.\n";
     }
     triggerMap[filter] = mergedPaths;
   }
@@ -192,10 +178,9 @@ bool AlCaRecoTriggerBitsRcdUpdate::addTriggerLists(const std::vector<edm::Parame
 }
 
 ///////////////////////////////////////////////////////////////////////
-void AlCaRecoTriggerBitsRcdUpdate::writeBitsToDB(AlCaRecoTriggerBits *bitsToWrite) const
-{
+void AlCaRecoTriggerBitsRcdUpdate::writeBitsToDB(AlCaRecoTriggerBits *bitsToWrite) const {
   edm::LogInfo("") << "Uploading to the database...";
-  
+
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (!poolDbService.isAvailable()) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available.\n";
@@ -204,20 +189,19 @@ void AlCaRecoTriggerBitsRcdUpdate::writeBitsToDB(AlCaRecoTriggerBits *bitsToWrit
   // ownership of bitsToWrite transferred
   // FIXME: Have to check that timetype is run number! How?
   const std::string recordName("AlCaRecoTriggerBitsRcd");
-  if (poolDbService->isNewTagRequest(recordName)) { // tag not yet existing
+  if (poolDbService->isNewTagRequest(recordName)) {  // tag not yet existing
     // lastRunIOV_ = -1 means infinity:
     const cond::Time_t lastRun = (lastRunIOV_ < 0 ? poolDbService->endOfTime() : lastRunIOV_);
     poolDbService->createNewIOV(bitsToWrite, firstRunIOV_, lastRun, recordName);
-  } else { // tag exists, can only append
+  } else {  // tag exists, can only append
     if (lastRunIOV_ >= 0) {
       throw cms::Exception("BadConfig") << "Tag already exists, can only append until infinity,"
                                         << " but lastRunIOV = " << lastRunIOV_ << ".\n";
     }
     poolDbService->appendSinceTime(bitsToWrite, firstRunIOV_, recordName);
-  }  
-  
-  edm::LogInfo("") << "...done for runs " << firstRunIOV_ << " to " << lastRunIOV_ 
-                   << " (< 0 meaning infinity)!";
+  }
+
+  edm::LogInfo("") << "...done for runs " << firstRunIOV_ << " to " << lastRunIOV_ << " (< 0 meaning infinity)!";
 }
 
 //define this as a plug-in


### PR DESCRIPTION

Applying code-format for CMSSW category db,hlt.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/286//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


