### PR TITLE
Running code-format for fastsim-reconstruction

### DIFF
--- a/CommonTools/BaseParticlePropagator/interface/BaseParticlePropagator.h
+++ b/CommonTools/BaseParticlePropagator/interface/BaseParticlePropagator.h
@@ -80,19 +80,15 @@
 #include "CommonTools/BaseParticlePropagator/interface/RawParticle.h"
 
 class BaseParticlePropagator {
-  
 public:
-
   /// Default c'tor
   BaseParticlePropagator();
 
   /** Constructors taking as arguments a RawParticle, as well as the radius,
       half-height and magnetic field defining the cylinder for which 
       propagation is to be performed, and optionally, the proper decay time */
-  BaseParticlePropagator(const RawParticle& myPart, 
-			 double r, double z, double B);
-  BaseParticlePropagator(const RawParticle& myPart, 
-			 double r, double z, double B, double t);
+  BaseParticlePropagator(const RawParticle& myPart, double r, double z, double B);
+  BaseParticlePropagator(const RawParticle& myPart, double r, double z, double B, double t);
 
   /// Initialize internal switches and quantities
   void init();
@@ -114,19 +110,19 @@ public:
       HCAL entrance, the HCAL 2nd and 3rd layer (not coded yet), the VFCAL 
       entrance, or any BoundSurface(disk or cylinder)*/
 
-  bool propagateToClosestApproach(double x0=0.,double y0=0,bool first=true);
-  bool propagateToEcal(bool first=true);
-  bool propagateToPreshowerLayer1(bool first=true);
-  bool propagateToPreshowerLayer2(bool first=true);
-  bool propagateToEcalEntrance(bool first=true);
-  bool propagateToHcalEntrance(bool first=true);
-  bool propagateToVFcalEntrance(bool first=true);
-  bool propagateToHcalExit(bool first=true);
-  bool propagateToHOLayer(bool first=true);
-  bool propagateToNominalVertex(const XYZTLorentzVector& hit2=XYZTLorentzVector(0.,0.,0.,0.));
-  bool propagateToBeamCylinder(const XYZTLorentzVector& v, double radius=0.); 
+  bool propagateToClosestApproach(double x0 = 0., double y0 = 0, bool first = true);
+  bool propagateToEcal(bool first = true);
+  bool propagateToPreshowerLayer1(bool first = true);
+  bool propagateToPreshowerLayer2(bool first = true);
+  bool propagateToEcalEntrance(bool first = true);
+  bool propagateToHcalEntrance(bool first = true);
+  bool propagateToVFcalEntrance(bool first = true);
+  bool propagateToHcalExit(bool first = true);
+  bool propagateToHOLayer(bool first = true);
+  bool propagateToNominalVertex(const XYZTLorentzVector& hit2 = XYZTLorentzVector(0., 0., 0., 0.));
+  bool propagateToBeamCylinder(const XYZTLorentzVector& v, double radius = 0.);
   /// Set the propagation characteristics (rCyl, zCyl and first loop only)
-  void setPropagationConditions(double r, double z, bool firstLoop=true);
+  void setPropagationConditions(double r, double z, bool firstLoop = true);
 
 private:
   RawParticle particle_;
@@ -160,138 +156,135 @@ private:
   bool decayed;
   /// The proper time of the particle
   double properTime;
-  /// The propagation direction 
+  /// The propagation direction
   int propDir;
 
 public:
-
   /// The particle being propagated
-  inline RawParticle const& particle() const { return particle_;}
-  inline RawParticle& particle() { return particle_;}
-  void setParticle(RawParticle const& iParticle) { particle_=iParticle;}
+  inline RawParticle const& particle() const { return particle_; }
+  inline RawParticle& particle() { return particle_; }
+  void setParticle(RawParticle const& iParticle) { particle_ = iParticle; }
 
   /// Set the proper decay time
   inline void setProperDecayTime(double t) { properDecayTime = t; }
 
   /// Just an internal trick
-  inline void increaseRCyl(double delta) {rCyl = rCyl + delta; rCyl2 = rCyl*rCyl; }
+  inline void increaseRCyl(double delta) {
+    rCyl = rCyl + delta;
+    rCyl2 = rCyl * rCyl;
+  }
 
   /// Transverse impact parameter
-  double xyImpactParameter(double x0=0., double y0=0.) const;
+  double xyImpactParameter(double x0 = 0., double y0 = 0.) const;
 
   /// Longitudinal impact parameter
-  inline double zImpactParameter(double x0=0, double y0=0.) const {
+  inline double zImpactParameter(double x0 = 0, double y0 = 0.) const {
     // Longitudinal impact parameter
-    return particle_.Z() - particle_.Pz() * std::sqrt( ((particle_.X()-x0)*(particle_.X()-x0) + (particle_.Y()-y0)*(particle_.Y()-y0) ) / particle_.Perp2());
+    return particle_.Z() - particle_.Pz() * std::sqrt(((particle_.X() - x0) * (particle_.X() - x0) +
+                                                       (particle_.Y() - y0) * (particle_.Y() - y0)) /
+                                                      particle_.Perp2());
   }
 
   /// The helix Radius
-  inline double helixRadius() const { 
+  inline double helixRadius() const {
     // The helix Radius
     //
-    // The helix' Radius sign accounts for the orientation of the magnetic field 
-    // (+ = along z axis) and the sign of the electric charge of the particle. 
-    // It signs the rotation of the (charged) particle around the z axis: 
+    // The helix' Radius sign accounts for the orientation of the magnetic field
+    // (+ = along z axis) and the sign of the electric charge of the particle.
+    // It signs the rotation of the (charged) particle around the z axis:
     // Positive means anti-clockwise, negative means clockwise rotation.
     //
     // The radius is returned in cm to match the units in RawParticle.
-    return particle_.charge() == 0 ? 0.0 : - particle_.Pt() / ( c_light() * 1e-5 * bField * particle_.charge() );
+    return particle_.charge() == 0 ? 0.0 : -particle_.Pt() / (c_light() * 1e-5 * bField * particle_.charge());
   }
 
-  inline double helixRadius(double pT) const { 
+  inline double helixRadius(double pT) const {
     // a faster version of helixRadius, once Perp() has been computed
-    return particle_.charge() == 0 ? 0.0 : - pT / ( c_light() * 1e-5 * bField * particle_.charge() );
+    return particle_.charge() == 0 ? 0.0 : -pT / (c_light() * 1e-5 * bField * particle_.charge());
   }
 
   /// The azimuth of the momentum at the vertex
-  inline double helixStartPhi() const { 
+  inline double helixStartPhi() const {
     // The azimuth of the momentum at the vertex
-    return particle_.Px() == 0.0 && particle_.Py() == 0.0 ? 0.0 : std::atan2(particle_.Py(),particle_.Px());
-  }
-  
-  /// The x coordinate of the helix axis
-  inline double helixCentreX() const { 
-    // The x coordinate of the helix axis
-    return particle_.X() - helixRadius() * std::sin ( helixStartPhi() );
+    return particle_.Px() == 0.0 && particle_.Py() == 0.0 ? 0.0 : std::atan2(particle_.Py(), particle_.Px());
   }
 
-  inline double helixCentreX(double radius, double phi) const { 
+  /// The x coordinate of the helix axis
+  inline double helixCentreX() const {
+    // The x coordinate of the helix axis
+    return particle_.X() - helixRadius() * std::sin(helixStartPhi());
+  }
+
+  inline double helixCentreX(double radius, double phi) const {
     // Fast version of helixCentreX()
-    return particle_.X() - radius * std::sin (phi);
+    return particle_.X() - radius * std::sin(phi);
   }
 
   /// The y coordinate of the helix axis
-  inline double helixCentreY() const { 
+  inline double helixCentreY() const {
     // The y coordinate of the helix axis
-    return particle_.Y() + helixRadius() * std::cos ( helixStartPhi() );
-}
+    return particle_.Y() + helixRadius() * std::cos(helixStartPhi());
+  }
 
-  inline double helixCentreY(double radius, double phi) const { 
+  inline double helixCentreY(double radius, double phi) const {
     // Fast version of helixCentreX()
-    return particle_.Y() + radius * std::cos (phi);
+    return particle_.Y() + radius * std::cos(phi);
   }
 
   /// The distance between the cylinder and the helix axes
-  inline double helixCentreDistToAxis() const { 
+  inline double helixCentreDistToAxis() const {
     // The distance between the cylinder and the helix axes
     double xC = helixCentreX();
     double yC = helixCentreY();
-    return std::sqrt( xC*xC + yC*yC );
+    return std::sqrt(xC * xC + yC * yC);
   }
 
-  inline double helixCentreDistToAxis(double xC, double yC) const { 
+  inline double helixCentreDistToAxis(double xC, double yC) const {
     // Faster version of helixCentreDistToAxis
-    return std::sqrt( xC*xC + yC*yC );
+    return std::sqrt(xC * xC + yC * yC);
   }
 
   /// The azimuth if the vector joining the cylinder and the helix axes
-  inline double helixCentrePhi() const { 
+  inline double helixCentrePhi() const {
     // The azimuth if the vector joining the cylinder and the helix axes
     double xC = helixCentreX();
     double yC = helixCentreY();
-    return xC == 0.0 && yC == 0.0 ? 0.0 : std::atan2(yC,xC);
-  }
-  
-  inline double helixCentrePhi(double xC, double yC) const { 
-    // Faster version of helixCentrePhi() 
-    return xC == 0.0 && yC == 0.0 ? 0.0 : std::atan2(yC,xC);
+    return xC == 0.0 && yC == 0.0 ? 0.0 : std::atan2(yC, xC);
   }
 
-  /// Is the vertex inside the cylinder ? (stricly inside : true) 
+  inline double helixCentrePhi(double xC, double yC) const {
+    // Faster version of helixCentrePhi()
+    return xC == 0.0 && yC == 0.0 ? 0.0 : std::atan2(yC, xC);
+  }
+
+  /// Is the vertex inside the cylinder ? (stricly inside : true)
   inline bool inside() const {
-    return (particle_.R2()<rCyl2-0.00001*rCyl && fabs(particle_.Z())<zCyl-0.00001);}
+    return (particle_.R2() < rCyl2 - 0.00001 * rCyl && fabs(particle_.Z()) < zCyl - 0.00001);
+  }
 
   inline bool inside(double rPos2) const {
-    return (rPos2<rCyl2-0.00001*rCyl && fabs(particle_.Z())<zCyl-0.00001);}
-
-
-  /// Is the vertex already on the cylinder surface ? 
-  inline bool onSurface() const {
-    return ( onBarrel() || onEndcap() ); 
+    return (rPos2 < rCyl2 - 0.00001 * rCyl && fabs(particle_.Z()) < zCyl - 0.00001);
   }
 
-  inline bool onSurface(double rPos2) const {
-    return ( onBarrel(rPos2) || onEndcap(rPos2) ); 
-  }
+  /// Is the vertex already on the cylinder surface ?
+  inline bool onSurface() const { return (onBarrel() || onEndcap()); }
 
-  /// Is the vertex already on the cylinder barrel ? 
+  inline bool onSurface(double rPos2) const { return (onBarrel(rPos2) || onEndcap(rPos2)); }
+
+  /// Is the vertex already on the cylinder barrel ?
   inline bool onBarrel() const {
     double rPos2 = particle_.R2();
-    return ( fabs(rPos2-rCyl2) < 0.00001*rCyl && fabs(particle_.Z()) <= zCyl );
+    return (fabs(rPos2 - rCyl2) < 0.00001 * rCyl && fabs(particle_.Z()) <= zCyl);
   }
 
   inline bool onBarrel(double rPos2) const {
-    return ( fabs(rPos2-rCyl2) < 0.00001*rCyl && fabs(particle_.Z()) <= zCyl );
+    return (fabs(rPos2 - rCyl2) < 0.00001 * rCyl && fabs(particle_.Z()) <= zCyl);
   }
 
-  /// Is the vertex already on the cylinder endcap ? 
-  inline bool onEndcap() const {
-    return ( fabs(fabs(particle_.Z())-zCyl) < 0.00001 && particle_.R2() <= rCyl2 ); 
-  }
-  
-  inline bool onEndcap(double rPos2) const {
-    return ( fabs(fabs(particle_.Z())-zCyl) < 0.00001 && rPos2 <= rCyl2 ); 
-  }
+  /// Is the vertex already on the cylinder endcap ?
+  inline bool onEndcap() const { return (fabs(fabs(particle_.Z()) - zCyl) < 0.00001 && particle_.R2() <= rCyl2); }
+
+  inline bool onEndcap(double rPos2) const { return (fabs(fabs(particle_.Z()) - zCyl) < 0.00001 && rPos2 <= rCyl2); }
 
   /// Is the vertex on some material ?
   inline bool onFiducial() const { return fiducial; }
@@ -300,18 +293,17 @@ public:
   inline bool hasDecayed() const { return decayed; }
 
   /// Has propagation been performed and was barrel or endcap reached ?
-  inline int  getSuccess() const { return success;  }
+  inline int getSuccess() const { return success; }
 
   /// Set the magnetic field
-  inline void setMagneticField(double b) {  bField=b; }
+  inline void setMagneticField(double b) { bField = b; }
 
-  /// Get the magnetic field 
-  inline double getMagneticField() const {  return bField; }
+  /// Get the magnetic field
+  inline double getMagneticField() const { return bField; }
 
   /// Set the debug leve;
-  inline void setDebug() { debug = true; } 
+  inline void setDebug() { debug = true; }
   inline void resetDebug() { debug = false; }
-    
 };
 
 #endif

--- a/CommonTools/BaseParticlePropagator/interface/RawParticle.h
+++ b/CommonTools/BaseParticlePropagator/interface/RawParticle.h
@@ -1,7 +1,6 @@
 #ifndef CommonTools_BaseParticlePropagator_RawParticle_h
 #define CommonTools_BaseParticlePropagator_RawParticle_h
 
-
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 
@@ -15,8 +14,7 @@
 #include <string>
 #include <iosfwd>
 
-#include<memory>
-
+#include <memory>
 
 /**
  * A prototype for a particle class.
@@ -33,16 +31,15 @@ namespace rawparticle {
   ///Create a particle with momentum 'p' at space-time point xStart
   /// The particle will be a muon if iParticle==true, else it will
   /// be an anti-muon.
-  RawParticle makeMuon(bool isParticle, const XYZTLorentzVector& p, 
-                       const XYZTLorentzVector& xStart);
-}
+  RawParticle makeMuon(bool isParticle, const XYZTLorentzVector& p, const XYZTLorentzVector& xStart);
+}  // namespace rawparticle
 
 class RawParticle {
 public:
-
   friend RawParticle rawparticle::makeMuon(bool, const XYZTLorentzVector&, const XYZTLorentzVector&);
   friend RawParticle unchecked_makeParticle(int id, const math::XYZTLorentzVector& p, double mass, double charge);
-  friend RawParticle unchecked_makeParticle(int id, const math::XYZTLorentzVector& p, const math::XYZTLorentzVector& xStart, double mass, double charge);
+  friend RawParticle unchecked_makeParticle(
+      int id, const math::XYZTLorentzVector& p, const math::XYZTLorentzVector& xStart, double mass, double charge);
 
   typedef ROOT::Math::AxisAngle Rotation;
   typedef ROOT::Math::Rotation3D Rotation3D;
@@ -61,25 +58,22 @@ public:
   /** Construct from 2 fourvectors.
    *  The first fourvector is taken for the particle, the second for its vertex.
    */
-  RawParticle(const XYZTLorentzVector& p, 
-	      const XYZTLorentzVector& xStart,
-              double charge = 0.);
+  RawParticle(const XYZTLorentzVector& p, const XYZTLorentzVector& xStart, double charge = 0.);
 
   /** Construct from fourmomentum components.
    *  Vertex is set to 0.
    */
-  RawParticle(double px, double py, double pz, double e, double charge =0.);
+  RawParticle(double px, double py, double pz, double e, double charge = 0.);
 
   /** Copy constructor    */
-  RawParticle(const RawParticle &p) = default;
-  RawParticle(RawParticle &&p) = default;
+  RawParticle(const RawParticle& p) = default;
+  RawParticle(RawParticle&& p) = default;
 
   /** Copy assignment operator */
-  RawParticle&  operator = (const RawParticle & rhs ) = default;
-  RawParticle&  operator = (RawParticle&& rhs ) = default;
+  RawParticle& operator=(const RawParticle& rhs) = default;
+  RawParticle& operator=(RawParticle&& rhs) = default;
 
 public:
-
   /** Set the status of this particle.
    *  The coding follows PYTHIAs convention:
    *  1 = stable
@@ -87,7 +81,7 @@ public:
   void setStatus(int istat);
 
   /// set the RECONSTRUCTED mass
-  void setMass(float m);   
+  void setMass(float m);
 
   /// set the MEASURED charge
   void setCharge(float q);
@@ -96,12 +90,12 @@ public:
   void setT(const double t);
 
   ///  set the vertex
-  void setVertex(const XYZTLorentzVector& vtx); 
-  void setVertex(double xv, double yv, double zv, double tv); 
+  void setVertex(const XYZTLorentzVector& vtx);
+  void setVertex(double xv, double yv, double zv, double tv);
 
   ///  set the momentum
-  void setMomentum(const XYZTLorentzVector& vtx); 
-  void setMomentum(double xv, double yv, double zv, double tv); 
+  void setMomentum(const XYZTLorentzVector& vtx);
+  void setMomentum(double xv, double yv, double zv, double tv);
 
   void SetPx(double);
   void SetPy(double);
@@ -116,7 +110,7 @@ public:
    */
   void boost(double bx, double by, double bz);
   void boost(const Boost& b);
-  
+
   //  inline void boost(const Hep3Vector<double> &bv );
 
   /** Rotate the particle around an axis in space.
@@ -134,7 +128,7 @@ public:
   /** Rotate around x axis.
    *  Rotate \a rphi radian around the x axis. The Vertex is rotated as well.
    */
-  void rotateX(double rphi); 
+  void rotateX(double rphi);
   void rotate(const RotationX& r);
 
   /** Rotate around z axis.
@@ -161,143 +155,130 @@ public:
       particle (if one exists). Also the measured charge is multiplied by -1.
    */
   void chargeConjugate();
-  
-  int    pid() const;         //!< get the HEP particle ID number
-  
-  int    status() const;      //!< get the particle status
-  
-  double charge() const;      //!< get the MEASURED charge 
-  
-  double mass() const;        //!< get the MEASURED mass
-  
+
+  int pid() const;  //!< get the HEP particle ID number
+
+  int status() const;  //!< get the particle status
+
+  double charge() const;  //!< get the MEASURED charge
+
+  double mass() const;  //!< get the MEASURED mass
+
   /** Get the pseudo rapidity of the particle.
    * \f$ \eta = -\log ( \tan ( \vartheta/2)) \f$
    */
-  double eta() const; 
+  double eta() const;
 
-  /// Cos**2(theta) is faster to determine than eta 
+  /// Cos**2(theta) is faster to determine than eta
   double cos2Theta() const;
   double cos2ThetaV() const;
-  
-  double et() const;   //!< get the transverse energy 
-  
-  double x() const;  //!< x of vertex 
-  double X() const;  //!< x of vertex 
-  
-  double y() const;  //!< y of vertex 
-  double Y() const;  //!< y of vertex 
-  
-  double z() const;  //!< z of vertex 
-  double Z() const;  //!< z of vertex 
-  
+
+  double et() const;  //!< get the transverse energy
+
+  double x() const;  //!< x of vertex
+  double X() const;  //!< x of vertex
+
+  double y() const;  //!< y of vertex
+  double Y() const;  //!< y of vertex
+
+  double z() const;  //!< z of vertex
+  double Z() const;  //!< z of vertex
+
   double t() const;  //!< vertex time
   double T() const;  //!< vertex time
-  
+
   double r() const;  //!< vertex radius
   double R() const;  //!< vertex radius
-  
+
   double r2() const;  //!< vertex radius**2
   double R2() const;  //!< vertex radius**2
-  
-  const XYZTLorentzVector& vertex() const;   //!< the vertex fourvector
 
-  double px() const; //!< x of the momentum
-  double Px() const; //!< x of the momentum
+  const XYZTLorentzVector& vertex() const;  //!< the vertex fourvector
 
-  double py() const; //!< y of the momentum
-  double Py() const; //!< y of the momentum
+  double px() const;  //!< x of the momentum
+  double Px() const;  //!< x of the momentum
 
-  double pz() const; //!< z of the momentum
-  double Pz() const; //!< z of the momentum
+  double py() const;  //!< y of the momentum
+  double Py() const;  //!< y of the momentum
 
-  double e() const; //!< energy of the momentum
-  double E() const; //!< energy of the momentum
+  double pz() const;  //!< z of the momentum
+  double Pz() const;  //!< z of the momentum
 
-  double Pt() const; //!< transverse momentum
-  double pt() const; //!< transverse momentum
+  double e() const;  //!< energy of the momentum
+  double E() const;  //!< energy of the momentum
 
-  double Perp2() const; //!< perpendicular momentum squared
+  double Pt() const;  //!< transverse momentum
+  double pt() const;  //!< transverse momentum
 
-  double mag() const; //!< the magnitude of the momentum
+  double Perp2() const;  //!< perpendicular momentum squared
 
-  double theta() const; //!< theta of momentum vector
-  double phi() const; //!< phi of momentum vector
+  double mag() const;  //!< the magnitude of the momentum
 
-  double M2() const; //!< mass squared
+  double theta() const;  //!< theta of momentum vector
+  double phi() const;    //!< phi of momentum vector
 
-  const XYZTLorentzVector& momentum() const;   //!< the momentum fourvector
-  XYZTLorentzVector& momentum();   //!< the momentum fourvector
-  
-  XYZVector Vect() const; //!< the momentum threevector
+  double M2() const;  //!< mass squared
+
+  const XYZTLorentzVector& momentum() const;  //!< the momentum fourvector
+  XYZTLorentzVector& momentum();              //!< the momentum fourvector
+
+  XYZVector Vect() const;  //!< the momentum threevector
 
   /** Print the name of the particle.
    *  The name is deduced from the particle ID using a particle data table.
    *  It is printed with a length of 10 characters. If the id number cannot
    *  be found in the table "unknown" is printed as name.
    */
-  void printName() const; 
-  
+  void printName() const;
+
   /** Print the formated particle information.
    *  The format is:
    *  NAME______PX______PY______PZ______E_______Mtheo___Mrec____Qrec____X_______Y_______Z_______T_______
    */
   void print() const;
-  
+
   /** Is the particle marked as used.
    *  The three methods isUsed(), use() and reUse() implement a simple
    *  locking mechanism. 
    */
-  int isUsed() const {return myUsed;}
-  
+  int isUsed() const { return myUsed; }
+
   /** Lock the particle, see isUsed()
    */
-  void use() { myUsed = 1;}    
-  
+  void use() { myUsed = 1; }
+
   /** Unlock the particle, see isUsed()
    */
-  void reUse() { myUsed = 0;}  
-  
- private:
+  void reUse() { myUsed = 0; }
 
+private:
   /** Construct from a fourvector and a PID.
    *  The fourvector and PID are taken for the particle, the vertex is set to 0.
    */
-  RawParticle(const int id, 
-	      const XYZTLorentzVector& p,
-              double mass,
-              double charge);
-
+  RawParticle(const int id, const XYZTLorentzVector& p, double mass, double charge);
 
   /** Construct from 2 fourvectosr and a PID.
    *  The fourvector and PID are taken for the particle, the vertex is set to 0.
    */
-  RawParticle(const int id, 
-	      const XYZTLorentzVector& p,
-              const XYZTLorentzVector& xStart,
-              double mass,
-              double charge);
+  RawParticle(const int id, const XYZTLorentzVector& p, const XYZTLorentzVector& xStart, double mass, double charge);
 
-  
- private:
-
-  XYZTLorentzVector myMomentum;       //!< the four vector of the momentum
-  XYZTLorentzVector myVertex;         //!< the four vector of the vertex
-  double myCharge= 0.;                //!< the MEASURED charge
-  double myMass = 0.;                 //!< the RECONSTRUCTED mass
-  int myId = 0;                       //!< the particle id number HEP-PID 
-  int myStatus=99;                    //!< the status code according to PYTHIA
-  int myUsed = 0;                     //!< status of the locking
-
+private:
+  XYZTLorentzVector myMomentum;  //!< the four vector of the momentum
+  XYZTLorentzVector myVertex;    //!< the four vector of the vertex
+  double myCharge = 0.;          //!< the MEASURED charge
+  double myMass = 0.;            //!< the RECONSTRUCTED mass
+  int myId = 0;                  //!< the particle id number HEP-PID
+  int myStatus = 99;             //!< the status code according to PYTHIA
+  int myUsed = 0;                //!< status of the locking
 };
 
-
-std::ostream& operator <<(std::ostream& o , const RawParticle& p); 
+std::ostream& operator<<(std::ostream& o, const RawParticle& p);
 
 inline int RawParticle::pid() const { return myId; }
 inline int RawParticle::status() const { return myStatus; }
-inline double RawParticle::eta() const { return -std::log(std::tan(this->theta()/2.)); }
-inline double RawParticle::cos2Theta() const { return Pz()*Pz()/myMomentum.Vect().Mag2(); }
-inline double RawParticle::cos2ThetaV() const { return Z()*Z()/myVertex.Vect().Mag2(); }
+inline double RawParticle::eta() const { return -std::log(std::tan(this->theta() / 2.)); }
+inline double RawParticle::cos2Theta() const { return Pz() * Pz() / myMomentum.Vect().Mag2(); }
+inline double RawParticle::cos2ThetaV() const { return Z() * Z() / myVertex.Vect().Mag2(); }
 inline double RawParticle::x() const { return myVertex.Px(); }
 inline double RawParticle::y() const { return myVertex.Py(); }
 inline double RawParticle::z() const { return myVertex.Pz(); }
@@ -312,73 +293,78 @@ inline double RawParticle::r() const { return std::sqrt(r2()); }
 inline double RawParticle::r2() const { return myVertex.Perp2(); }
 inline double RawParticle::charge() const { return myCharge; }
 inline double RawParticle::mass() const { return myMass; }
-inline double RawParticle::px() const { return myMomentum.px() ; }
-inline double RawParticle::Px() const { return myMomentum.Px() ; }
+inline double RawParticle::px() const { return myMomentum.px(); }
+inline double RawParticle::Px() const { return myMomentum.Px(); }
 
-inline double RawParticle::py() const { return myMomentum.py() ; }
-inline double RawParticle::Py() const { return myMomentum.Py() ; }
+inline double RawParticle::py() const { return myMomentum.py(); }
+inline double RawParticle::Py() const { return myMomentum.Py(); }
 
-inline double RawParticle::pz() const { return myMomentum.pz() ; }
-inline double RawParticle::Pz() const { return myMomentum.Pz() ; }
+inline double RawParticle::pz() const { return myMomentum.pz(); }
+inline double RawParticle::Pz() const { return myMomentum.Pz(); }
 
-inline double RawParticle::e() const { return myMomentum.e() ; }
-inline double RawParticle::E() const { return myMomentum.E() ; }
+inline double RawParticle::e() const { return myMomentum.e(); }
+inline double RawParticle::E() const { return myMomentum.E(); }
 
-inline double RawParticle::Pt() const { return myMomentum.Pt() ; }
-inline double RawParticle::pt() const { return myMomentum.pt() ; }
+inline double RawParticle::Pt() const { return myMomentum.Pt(); }
+inline double RawParticle::pt() const { return myMomentum.pt(); }
 
-inline double RawParticle::Perp2() const { return  myMomentum.Perp2(); }
+inline double RawParticle::Perp2() const { return myMomentum.Perp2(); }
 
-inline double RawParticle::mag() const { return  myMomentum.mag(); }
+inline double RawParticle::mag() const { return myMomentum.mag(); }
 
 inline double RawParticle::theta() const { return myMomentum.theta(); }
 inline double RawParticle::phi() const { return myMomentum.phi(); }
 
 inline double RawParticle::M2() const { return myMomentum.M2(); }
 
-inline const XYZTLorentzVector&  RawParticle::vertex() const { return myVertex ; }
-inline const XYZTLorentzVector&  RawParticle::momentum() const { return myMomentum; }
-inline XYZTLorentzVector&  RawParticle::momentum() { return myMomentum; }
+inline const XYZTLorentzVector& RawParticle::vertex() const { return myVertex; }
+inline const XYZTLorentzVector& RawParticle::momentum() const { return myMomentum; }
+inline XYZTLorentzVector& RawParticle::momentum() { return myMomentum; }
 inline XYZVector RawParticle::Vect() const { return myMomentum.Vect(); }
 
 inline void RawParticle::setVertex(const XYZTLorentzVector& vtx) { myVertex = vtx; }
-inline void RawParticle::setVertex(double a, double b, double c, double d) { myVertex.SetXYZT(a,b,c,d); }
+inline void RawParticle::setVertex(double a, double b, double c, double d) { myVertex.SetXYZT(a, b, c, d); }
 
 inline void RawParticle::setMomentum(const XYZTLorentzVector& p4) { myMomentum = p4; }
-inline void RawParticle::setMomentum(double a, double b, double c, double d) { myMomentum.SetXYZT(a,b,c,d); }
+inline void RawParticle::setMomentum(double a, double b, double c, double d) { myMomentum.SetXYZT(a, b, c, d); }
 
-inline void RawParticle::SetPx(double px) {myMomentum.SetPx(px);}
-inline void RawParticle::SetPy(double py) {myMomentum.SetPy(py);}
-inline void RawParticle::SetPz(double pz) {myMomentum.SetPz(pz);}
-inline void RawParticle::SetE(double e) {myMomentum.SetE(e);}
+inline void RawParticle::SetPx(double px) { myMomentum.SetPx(px); }
+inline void RawParticle::SetPy(double py) { myMomentum.SetPy(py); }
+inline void RawParticle::SetPz(double pz) { myMomentum.SetPz(pz); }
+inline void RawParticle::SetE(double e) { myMomentum.SetE(e); }
 
-
-inline void RawParticle::rotate(const RawParticle::Rotation3D& r) { 
-  XYZVector v ( r(myMomentum.Vect()) ); setMomentum(v.X(),v.Y(),v.Z(),E());
+inline void RawParticle::rotate(const RawParticle::Rotation3D& r) {
+  XYZVector v(r(myMomentum.Vect()));
+  setMomentum(v.X(), v.Y(), v.Z(), E());
 }
 
-inline void RawParticle::rotate(const RawParticle::Rotation& r) { 
-  XYZVector v ( r(myMomentum.Vect()) ); setMomentum(v.X(),v.Y(),v.Z(),E());
+inline void RawParticle::rotate(const RawParticle::Rotation& r) {
+  XYZVector v(r(myMomentum.Vect()));
+  setMomentum(v.X(), v.Y(), v.Z(), E());
 }
 
-inline void RawParticle::rotate(const RawParticle::RotationX& r) { 
-  XYZVector v ( r(myMomentum.Vect()) ); setMomentum(v.X(),v.Y(),v.Z(),E());
+inline void RawParticle::rotate(const RawParticle::RotationX& r) {
+  XYZVector v(r(myMomentum.Vect()));
+  setMomentum(v.X(), v.Y(), v.Z(), E());
 }
 
-inline void RawParticle::rotate(const RawParticle::RotationY& r) { 
-  XYZVector v ( r(myMomentum.Vect()) ); setMomentum(v.X(),v.Y(),v.Z(),E());
+inline void RawParticle::rotate(const RawParticle::RotationY& r) {
+  XYZVector v(r(myMomentum.Vect()));
+  setMomentum(v.X(), v.Y(), v.Z(), E());
 }
 
-inline void RawParticle::rotate(const RawParticle::RotationZ& r) { 
-  XYZVector v ( r(myMomentum.Vect()) ); setMomentum(v.X(),v.Y(),v.Z(),E());
+inline void RawParticle::rotate(const RawParticle::RotationZ& r) {
+  XYZVector v(r(myMomentum.Vect()));
+  setMomentum(v.X(), v.Y(), v.Z(), E());
 }
 
-inline void RawParticle::boost(const RawParticle::Boost& b) { 
-  XYZTLorentzVector p ( b(momentum()) ); setMomentum(p.Px(),p.Py(),p.Pz(),p.E());
+inline void RawParticle::boost(const RawParticle::Boost& b) {
+  XYZTLorentzVector p(b(momentum()));
+  setMomentum(p.Px(), p.Py(), p.Pz(), p.E());
 }
 
-inline void RawParticle::translate(const XYZVector& tr) { 
-  myVertex.SetXYZT(X()+tr.X(),Y()+tr.Y(),Z()+tr.Z(),T());
+inline void RawParticle::translate(const XYZVector& tr) {
+  myVertex.SetXYZT(X() + tr.X(), Y() + tr.Y(), Z() + tr.Z(), T());
 }
 
 #endif

--- a/CommonTools/BaseParticlePropagator/interface/makeMuon.h
+++ b/CommonTools/BaseParticlePropagator/interface/makeMuon.h
@@ -4,7 +4,7 @@
 //
 // Package:     CommonTools/BaseParticlePropagator
 // Class  :     makeMuon
-// 
+//
 /**\class makeMuon makeMuon.h "CommonTools/BaseParticlePropagator/interface/makeMuon.h"
 
  Description: Creates a RawParticle of type muon
@@ -30,8 +30,7 @@ namespace rawparticle {
   ///Create a particle with momentum 'p' at space-time point xStart
   /// The particle will be a muon if iParticle==true, else it will
   /// be an anti-muon.
-  RawParticle makeMuon(bool isParticle, const math::XYZTLorentzVector& p, 
-                       const math::XYZTLorentzVector& xStart);
-}
+  RawParticle makeMuon(bool isParticle, const math::XYZTLorentzVector& p, const math::XYZTLorentzVector& xStart);
+}  // namespace rawparticle
 
 #endif

--- a/CommonTools/BaseParticlePropagator/src/BaseParticlePropagator.cc
+++ b/CommonTools/BaseParticlePropagator/src/BaseParticlePropagator.cc
@@ -2,27 +2,19 @@
 #include "CommonTools/BaseParticlePropagator/interface/BaseParticlePropagator.h"
 #include <array>
 
-BaseParticlePropagator::BaseParticlePropagator() :
-  rCyl(0.), rCyl2(0.), zCyl(0.), bField(0), properDecayTime(1E99)
-{;}
+BaseParticlePropagator::BaseParticlePropagator() : rCyl(0.), rCyl2(0.), zCyl(0.), bField(0), properDecayTime(1E99) { ; }
 
-BaseParticlePropagator::BaseParticlePropagator( 
-         const RawParticle& myPart,double R, double Z, double B, double t ) :
-  particle_(myPart), rCyl(R), rCyl2(R*R), zCyl(Z), bField(B), properDecayTime(t) 
-{
+BaseParticlePropagator::BaseParticlePropagator(const RawParticle& myPart, double R, double Z, double B, double t)
+    : particle_(myPart), rCyl(R), rCyl2(R * R), zCyl(Z), bField(B), properDecayTime(t) {
   init();
 }
 
-BaseParticlePropagator::BaseParticlePropagator( 
-         const RawParticle& myPart,double R, double Z, double B) :
-  particle_(myPart), rCyl(R), rCyl2(R*R), zCyl(Z), bField(B), properDecayTime(1E99) 
-{
+BaseParticlePropagator::BaseParticlePropagator(const RawParticle& myPart, double R, double Z, double B)
+    : particle_(myPart), rCyl(R), rCyl2(R * R), zCyl(Z), bField(B), properDecayTime(1E99) {
   init();
 }
 
-void 
-BaseParticlePropagator::init() {
-  
+void BaseParticlePropagator::init() {
   // The status of the propagation
   success = 0;
   // Propagate only for the first half-loop
@@ -37,32 +29,27 @@ BaseParticlePropagator::init() {
   propDir = 1;
   //
   debug = false;
-
 }
 
-bool 
-BaseParticlePropagator::propagate() { 
-
-
+bool BaseParticlePropagator::propagate() {
   //
   // Check that the particle is not already on the cylinder surface
   //
   double rPos2 = particle_.R2();
 
-  if ( onBarrel(rPos2) ) { 
+  if (onBarrel(rPos2)) {
     success = 1;
     return true;
   }
   //
-  if ( onEndcap(rPos2) ) { 
+  if (onEndcap(rPos2)) {
     success = 2;
     return true;
   }
   //
-  // Treat neutral particles (or no magnetic field) first 
+  // Treat neutral particles (or no magnetic field) first
   //
-  if ( fabs(particle_.charge()) < 1E-12 || bField < 1E-12 ) {
-
+  if (fabs(particle_.charge()) < 1E-12 || bField < 1E-12) {
     //
     // First check that the particle crosses the cylinder
     //
@@ -70,37 +57,39 @@ BaseParticlePropagator::propagate() {
     //    double pT2 = pT*pT;
     //    double b2 = rCyl * pT;
     double b2 = rCyl2 * pT2;
-    double ac = fabs ( particle_.X()*particle_.Py() - particle_.Y()*particle_.Px() );
-    double ac2 = ac*ac;
+    double ac = fabs(particle_.X() * particle_.Py() - particle_.Y() * particle_.Px());
+    double ac2 = ac * ac;
     //
     // The particle never crosses (or never crossed) the cylinder
     //
     //    if ( ac > b2 ) return false;
-    if ( ac2 > b2 ) return false;
+    if (ac2 > b2)
+      return false;
 
     //    double delta  = std::sqrt(b2*b2 - ac*ac);
-    double delta  = std::sqrt(b2 - ac2);
-    double tplus  = -( particle_.X()*particle_.Px()+particle_.Y()*particle_.Py() ) + delta;
-    double tminus = -( particle_.X()*particle_.Px()+particle_.Y()*particle_.Py() ) - delta;
+    double delta = std::sqrt(b2 - ac2);
+    double tplus = -(particle_.X() * particle_.Px() + particle_.Y() * particle_.Py()) + delta;
+    double tminus = -(particle_.X() * particle_.Px() + particle_.Y() * particle_.Py()) - delta;
     //
     // Find the first (time-wise) intersection point with the cylinder
     //
 
-    double solution = tminus < 0 ? tplus/pT2 : tminus/pT2;
-    if ( solution < 0. ) return false;
+    double solution = tminus < 0 ? tplus / pT2 : tminus / pT2;
+    if (solution < 0.)
+      return false;
     //
     // Check that the particle does (did) not exit from the endcaps first.
     //
     double zProp = particle_.Z() + particle_.Pz() * solution;
-    if ( fabs(zProp) > zCyl ) {
-      tplus  = ( zCyl - particle_.Z() ) / particle_.Pz();
-      tminus = (-zCyl - particle_.Z() ) / particle_.Pz();
+    if (fabs(zProp) > zCyl) {
+      tplus = (zCyl - particle_.Z()) / particle_.Pz();
+      tminus = (-zCyl - particle_.Z()) / particle_.Pz();
       solution = tminus < 0 ? tplus : tminus;
-      if ( solution < 0. ) return false;
+      if (solution < 0.)
+        return false;
       zProp = particle_.Z() + particle_.Pz() * solution;
       success = 2;
-    }
-    else {
+    } else {
       success = 1;
     }
 
@@ -110,8 +99,8 @@ BaseParticlePropagator::propagate() {
     double delTime = propDir * particle_.mass() * solution;
     double factor = 1.;
     properTime += delTime;
-    if ( properTime > properDecayTime ) {
-      factor = 1.-(properTime-properDecayTime)/delTime;
+    if (properTime > properDecayTime) {
+      factor = 1. - (properTime - properDecayTime) / delTime;
       properTime = properDecayTime;
       decayed = true;
     }
@@ -121,14 +110,14 @@ BaseParticlePropagator::propagate() {
     //
     double xProp = particle_.X() + particle_.Px() * solution * factor;
     double yProp = particle_.Y() + particle_.Py() * solution * factor;
-           zProp = particle_.Z() + particle_.Pz() * solution * factor;
-    double tProp = particle_.T() + particle_.E()  * solution * factor;
+    zProp = particle_.Z() + particle_.Pz() * solution * factor;
+    double tProp = particle_.T() + particle_.E() * solution * factor;
 
     //
     // Last check : Although propagated to the endcaps, R could still be
     // larger than rCyl because the cylinder was too short...
     //
-    if ( success == 2 && xProp*xProp+yProp*yProp > rCyl2 ) { 
+    if (success == 2 && xProp * xProp + yProp * yProp > rCyl2) {
       success = -1;
       return true;
     }
@@ -136,8 +125,8 @@ BaseParticlePropagator::propagate() {
     //
     // ... and update the particle with its propagated coordinates
     //
-    particle_.setVertex( XYZTLorentzVector(xProp,yProp,zProp,tProp) );
-    
+    particle_.setVertex(XYZTLorentzVector(xProp, yProp, zProp, tProp));
+
     return true;
   }
   //
@@ -150,18 +139,19 @@ BaseParticlePropagator::propagate() {
     double pT = particle_.Pt();
     double radius = helixRadius(pT);
     double phi0 = helixStartPhi();
-    double xC = helixCentreX(radius,phi0);
-    double yC = helixCentreY(radius,phi0);
-    double dist = helixCentreDistToAxis(xC,yC);
+    double xC = helixCentreX(radius, phi0);
+    double yC = helixCentreY(radius, phi0);
+    double dist = helixCentreDistToAxis(xC, yC);
     //
     // The helix either is outside or includes the cylinder -> no intersection
     //
-    if ( fabs ( fabs(radius) - dist ) > rCyl ) return false;
+    if (fabs(fabs(radius) - dist) > rCyl)
+      return false;
     //
     // The particle is already away from the endcaps, and will never come back
     // Could be back-propagated, so warn the user that it is so.
-    // 
-    if ( particle_.Z() * particle_.Pz() > zCyl * fabs(particle_.Pz()) ) { 
+    //
+    if (particle_.Z() * particle_.Pz() > zCyl * fabs(particle_.Pz())) {
       success = -2;
       return true;
     }
@@ -171,103 +161,86 @@ BaseParticlePropagator::propagate() {
     //
     // Does the helix cross the cylinder barrel ? If not, do the first half-loop
     //
-    double rProp = std::min(fabs(radius)+dist-0.000001, rCyl);
+    double rProp = std::min(fabs(radius) + dist - 0.000001, rCyl);
 
     // Check for rounding errors in the ArcSin.
-    double sinPhiProp = 
-      (rProp*rProp-radius*radius-dist*dist)/( 2.*dist*radius);
-    
+    double sinPhiProp = (rProp * rProp - radius * radius - dist * dist) / (2. * dist * radius);
+
     //
     double deltaPhi = 1E99;
 
-    // Taylor development up to third order for large momenta 
-    if ( 1.-fabs(sinPhiProp) < 1E-9 ) { 
-
+    // Taylor development up to third order for large momenta
+    if (1. - fabs(sinPhiProp) < 1E-9) {
       double cphi0 = std::cos(phi0);
       double sphi0 = std::sin(phi0);
-      double r0 = (particle_.X()*cphi0 + particle_.Y()*sphi0)/radius;
-      double q0 = (particle_.X()*sphi0 - particle_.Y()*cphi0)/radius;
-      double rcyl2 = (rCyl2 - particle_.X()*particle_.X() - particle_.Y()*particle_.Y())/(radius*radius);
-      double delta = r0*r0 + rcyl2*(1.-q0);
+      double r0 = (particle_.X() * cphi0 + particle_.Y() * sphi0) / radius;
+      double q0 = (particle_.X() * sphi0 - particle_.Y() * cphi0) / radius;
+      double rcyl2 = (rCyl2 - particle_.X() * particle_.X() - particle_.Y() * particle_.Y()) / (radius * radius);
+      double delta = r0 * r0 + rcyl2 * (1. - q0);
 
       // This is a solution of a second order equation, assuming phi = phi0 + epsilon
-      // and epsilon is small. 
-      deltaPhi = radius > 0 ? 
-	( -r0 + std::sqrt(delta ) ) / (1.-q0) :   
-	( -r0 - std::sqrt(delta ) ) / (1.-q0); 
-      
+      // and epsilon is small.
+      deltaPhi = radius > 0 ? (-r0 + std::sqrt(delta)) / (1. - q0) : (-r0 - std::sqrt(delta)) / (1. - q0);
     }
 
     // Use complete calculation otherwise, or if the delta phi is large anyway.
-    if ( fabs(deltaPhi) > 1E-3 ) { 
-
-    //    phiProp =  fabs(sinPhiProp) < 0.99999999  ? 
-    //      std::asin(sinPhiProp) : M_PI/2. * sinPhiProp;
-      phiProp =  std::asin(sinPhiProp);
+    if (fabs(deltaPhi) > 1E-3) {
+      //    phiProp =  fabs(sinPhiProp) < 0.99999999  ?
+      //      std::asin(sinPhiProp) : M_PI/2. * sinPhiProp;
+      phiProp = std::asin(sinPhiProp);
 
       //
       // Compute phi after propagation (two solutions, but the asin definition
       // (between -pi/2 and +pi/2) takes care of the wrong one.
       //
-      phiProp = helixCentrePhi(xC,yC) + 
-	( inside(rPos2) || onSurface(rPos2) ? phiProp : M_PI-phiProp ); 
-      
+      phiProp = helixCentrePhi(xC, yC) + (inside(rPos2) || onSurface(rPos2) ? phiProp : M_PI - phiProp);
+
       //
       // Solve the obvious two-pi ambiguities: more than one turn!
       //
-      if ( fabs(phiProp - phi0) > 2.*M_PI )
-	phiProp += ( phiProp > phi0 ? -2.*M_PI : +2.*M_PI );
-      
+      if (fabs(phiProp - phi0) > 2. * M_PI)
+        phiProp += (phiProp > phi0 ? -2. * M_PI : +2. * M_PI);
+
       //
       // Check that the phi difference has the right sign, according to Q*B
       // (Another two pi ambuiguity, slightly more subtle)
       //
-      if ( (phiProp-phi0)*radius < 0.0 )
-	radius > 0.0 ? phiProp += 2 * M_PI : phiProp -= 2 * M_PI;
-      
-    } else { 
+      if ((phiProp - phi0) * radius < 0.0)
+        radius > 0.0 ? phiProp += 2 * M_PI : phiProp -= 2 * M_PI;
 
+    } else {
       // Use Taylor
       phiProp = phi0 + deltaPhi;
-
     }
 
     //
     // Check that the particle does not exit from the endcaps first.
     //
-    zProp = particle_.Z() + ( phiProp - phi0 ) * pZ * radius / pT ;
-    if ( fabs(zProp) > zCyl ) {
-
-      zProp = zCyl * fabs(pZ)/pZ;
+    zProp = particle_.Z() + (phiProp - phi0) * pZ * radius / pT;
+    if (fabs(zProp) > zCyl) {
+      zProp = zCyl * fabs(pZ) / pZ;
       phiProp = phi0 + (zProp - particle_.Z()) / radius * pT / pZ;
       success = 2;
 
     } else {
-
       //
       // If the particle does not cross the barrel, either process the
       // first-half loop only or propagate all the way down to the endcaps
       //
-      if ( rProp < rCyl ) {
+      if (rProp < rCyl) {
+        if (firstLoop || fabs(pZ) / pT < 1E-10) {
+          success = 0;
 
-	if ( firstLoop || fabs(pZ)/pT < 1E-10 ) {
-
-	  success = 0;
-
-	} else {
-
-	  zProp = zCyl * fabs(pZ)/pZ;
-	  phiProp = phi0 + (zProp - particle_.Z()) / radius * pT / pZ;
-	  success = 2;
-
-	}
-      //
-      // The particle crossed the barrel 
-      // 
+        } else {
+          zProp = zCyl * fabs(pZ) / pZ;
+          phiProp = phi0 + (zProp - particle_.Z()) / radius * pT / pZ;
+          success = 2;
+        }
+        //
+        // The particle crossed the barrel
+        //
       } else {
-
-	success = 1;
-
+        success = 1;
       }
     }
     //
@@ -276,24 +249,24 @@ BaseParticlePropagator::propagate() {
     //
     // Check the decay time
     //
-    double delTime = propDir * (phiProp-phi0)*radius*particle_.mass() / pT;
+    double delTime = propDir * (phiProp - phi0) * radius * particle_.mass() / pT;
     double factor = 1.;
     properTime += delTime;
-    if ( properTime > properDecayTime ) {
-      factor = 1.-(properTime-properDecayTime)/delTime;
+    if (properTime > properDecayTime) {
+      factor = 1. - (properTime - properDecayTime) / delTime;
       properTime = properDecayTime;
       decayed = true;
     }
 
-    zProp = particle_.Z() + (zProp-particle_.Z())*factor;
+    zProp = particle_.Z() + (zProp - particle_.Z()) * factor;
 
-    phiProp = phi0 + (phiProp-phi0)*factor;
+    phiProp = phi0 + (phiProp - phi0) * factor;
 
     double sProp = std::sin(phiProp);
     double cProp = std::cos(phiProp);
     double xProp = xC + radius * sProp;
     double yProp = yC - radius * cProp;
-    double tProp = particle_.T() + (phiProp-phi0)*radius*particle_.E()/pT;
+    double tProp = particle_.T() + (phiProp - phi0) * radius * particle_.E() / pT;
     double pxProp = pT * cProp;
     double pyProp = pT * sProp;
 
@@ -301,63 +274,56 @@ BaseParticlePropagator::propagate() {
     // Last check : Although propagated to the endcaps, R could still be
     // larger than rCyl because the cylinder was too short...
     //
-    if ( success == 2 && xProp*xProp+yProp*yProp > rCyl2 ) { 
+    if (success == 2 && xProp * xProp + yProp * yProp > rCyl2) {
       success = -1;
       return true;
     }
     //
     // ... and update the particle vertex and momentum
     //
-    particle_.setVertex( XYZTLorentzVector(xProp,yProp,zProp,tProp) );
-    particle_.setMomentum(pxProp,pyProp,pZ,particle_.E());
+    particle_.setVertex(XYZTLorentzVector(xProp, yProp, zProp, tProp));
+    particle_.setMomentum(pxProp, pyProp, pZ, particle_.E());
     //    particle_.SetPx(pxProp);
     //    particle_.SetPy(pyProp);
     return true;
- 
   }
 }
 
-bool
-BaseParticlePropagator::backPropagate() {
-
+bool BaseParticlePropagator::backPropagate() {
   // Backpropagate
-  particle_.setMomentum(-particle_.Px(),-particle_.Py(),-particle_.Pz(),particle_.E());
+  particle_.setMomentum(-particle_.Px(), -particle_.Py(), -particle_.Pz(), particle_.E());
   particle_.setCharge(-particle_.charge());
   propDir = -1;
   bool done = propagate();
-  particle_.setMomentum(-particle_.Px(),-particle_.Py(),-particle_.Pz(),particle_.E());
+  particle_.setMomentum(-particle_.Px(), -particle_.Py(), -particle_.Pz(), particle_.E());
   particle_.setCharge(-particle_.charge());
   propDir = +1;
 
   return done;
 }
 
-BaseParticlePropagator
-BaseParticlePropagator::propagated() const {
+BaseParticlePropagator BaseParticlePropagator::propagated() const {
   // Copy the input particle in a new instance
   BaseParticlePropagator myPropPart(*this);
   // Allow for many loops
-  myPropPart.firstLoop=false;
-  // Propagate the particle ! 
+  myPropPart.firstLoop = false;
+  // Propagate the particle !
   myPropPart.propagate();
   // Back propagate if the forward propagation was not a success
-  if (myPropPart.success < 0 )
+  if (myPropPart.success < 0)
     myPropPart.backPropagate();
   // Return the new instance
   return myPropPart;
 }
 
-void 
-BaseParticlePropagator::setPropagationConditions(double R, double Z, bool f) { 
+void BaseParticlePropagator::setPropagationConditions(double R, double Z, bool f) {
   rCyl = R;
-  rCyl2 = R*R;
+  rCyl2 = R * R;
   zCyl = Z;
   firstLoop = f;
 }
 
-bool
-BaseParticlePropagator::propagateToClosestApproach(double x0, double y0, bool first) {
-
+bool BaseParticlePropagator::propagateToClosestApproach(double x0, double y0, bool first) {
   // Pre-computed quantities
   double pT = particle_.Pt();
   double radius = helixRadius(pT);
@@ -365,161 +331,159 @@ BaseParticlePropagator::propagateToClosestApproach(double x0, double y0, bool fi
 
   // The Helix centre coordinates are computed wrt to the z axis
   // Actually the z axis might be centred on 0,0: it's the beam spot position (x0,y0)!
-  double xC = helixCentreX(radius,phi0);
-  double yC = helixCentreY(radius,phi0);
-  double distz = helixCentreDistToAxis(xC-x0,yC-y0);
-  double dist0 = helixCentreDistToAxis(xC,yC);
+  double xC = helixCentreX(radius, phi0);
+  double yC = helixCentreY(radius, phi0);
+  double distz = helixCentreDistToAxis(xC - x0, yC - y0);
+  double dist0 = helixCentreDistToAxis(xC, yC);
 
   //
   // Propagation to point of clostest approach to z axis
   //
-  double rz,r0,z;
-  if ( particle_.charge() != 0.0 && bField != 0.0 ) {
-    rz = fabs ( fabs(radius) - distz ) + std::sqrt(x0*x0+y0*y0) + 0.0000001;
-    r0 = fabs ( fabs(radius) - dist0 ) + 0.0000001;
+  double rz, r0, z;
+  if (particle_.charge() != 0.0 && bField != 0.0) {
+    rz = fabs(fabs(radius) - distz) + std::sqrt(x0 * x0 + y0 * y0) + 0.0000001;
+    r0 = fabs(fabs(radius) - dist0) + 0.0000001;
   } else {
-    rz = fabs( particle_.Px() * (particle_.Y()-y0) - particle_.Py() * (particle_.X()-x0) ) / particle_.Pt(); 
-    r0 = fabs( particle_.Px() *  particle_.Y()     - particle_.Py() *  particle_.X() ) / particle_.Pt(); 
+    rz = fabs(particle_.Px() * (particle_.Y() - y0) - particle_.Py() * (particle_.X() - x0)) / particle_.Pt();
+    r0 = fabs(particle_.Px() * particle_.Y() - particle_.Py() * particle_.X()) / particle_.Pt();
   }
 
   z = 999999.;
 
-  // Propagate to the first interesection point 
+  // Propagate to the first interesection point
   // with cylinder of radius sqrt(x0**2+y0**2)
-  setPropagationConditions(rz , z, first);
+  setPropagationConditions(rz, z, first);
   bool done = backPropagate();
 
   // Unsuccessful propagation - should not happen!
-  if ( !done ) return done; 
+  if (!done)
+    return done;
 
   // The z axis is (0,0) - no need to go further
-  if ( fabs(rz-r0) < 1E-10 ) return done;
-  double dist1 = (particle_.X()-x0)*(particle_.X()-x0) + (particle_.Y()-y0)*(particle_.Y()-y0);
+  if (fabs(rz - r0) < 1E-10)
+    return done;
+  double dist1 = (particle_.X() - x0) * (particle_.X() - x0) + (particle_.Y() - y0) * (particle_.Y() - y0);
 
   // We are already at closest approach - no need to go further
-  if ( dist1 < 1E-10 ) return done;
+  if (dist1 < 1E-10)
+    return done;
 
   // Keep for later if it happens to be the right solution
   XYZTLorentzVector vertex1 = particle_.vertex();
   XYZTLorentzVector momentum1 = particle_.momentum();
-  
-  // Propagate to the distance of closest approach to (0,0)
-  setPropagationConditions(r0 , z, first);
-  done = backPropagate();
-  if ( !done ) return done; 
 
-  // Propagate to the first interesection point 
-  // with cylinder of radius sqrt(x0**2+y0**2)
-  setPropagationConditions(rz , z, first);
+  // Propagate to the distance of closest approach to (0,0)
+  setPropagationConditions(r0, z, first);
   done = backPropagate();
-  if ( !done ) return done; 
-  double dist2 = (particle_.X()-x0)*(particle_.X()-x0) + (particle_.Y()-y0)*(particle_.Y()-y0);
+  if (!done)
+    return done;
+
+  // Propagate to the first interesection point
+  // with cylinder of radius sqrt(x0**2+y0**2)
+  setPropagationConditions(rz, z, first);
+  done = backPropagate();
+  if (!done)
+    return done;
+  double dist2 = (particle_.X() - x0) * (particle_.X() - x0) + (particle_.Y() - y0) * (particle_.Y() - y0);
 
   // Keep the good solution.
-  if ( dist2 > dist1 ) { 
+  if (dist2 > dist1) {
     particle_.setVertex(vertex1);
-    particle_.setMomentum(momentum1.X(),momentum1.Y(),momentum1.Z(),momentum1.E());
+    particle_.setMomentum(momentum1.X(), momentum1.Y(), momentum1.Z(), momentum1.E());
     dist2 = dist1;
   }
 
   // Done
   return done;
-
 }
 
-bool
-BaseParticlePropagator::propagateToEcal(bool first) {
+bool BaseParticlePropagator::propagateToEcal(bool first) {
   //
   // Propagation to Ecal (including preshower) after the
   // last Tracker layer
   // TODO: include proper geometry
   // Geometry taken from CMS ECAL TDR
   //
-  // First propagate to global barrel / endcap cylinder 
+  // First propagate to global barrel / endcap cylinder
   //  setPropagationConditions(1290. , 3045 , first);
   //  New position of the preshower as of CMSSW_1_7_X
-  setPropagationConditions(129.0 , 303.353 , first);
+  setPropagationConditions(129.0, 303.353, first);
   return propagate();
-
 }
 
-bool
-BaseParticlePropagator::propagateToPreshowerLayer1(bool first) {
+bool BaseParticlePropagator::propagateToPreshowerLayer1(bool first) {
   //
   // Propagation to Preshower Layer 1
   // TODO: include proper geometry
   // Geometry taken from CMS ECAL TDR
   //
-  // First propagate to global barrel / endcap cylinder 
+  // First propagate to global barrel / endcap cylinder
   //  setPropagationConditions(1290., 3045 , first);
   //  New position of the preshower as of CMSSW_1_7_X
-  setPropagationConditions(129.0, 303.353 , first);
+  setPropagationConditions(129.0, 303.353, first);
   bool done = propagate();
 
-  // Check that were are on the Layer 1 
-  if ( done && (particle_.R2() > 125.0*125.0 || particle_.R2() < 45.0*45.0) ) 
+  // Check that were are on the Layer 1
+  if (done && (particle_.R2() > 125.0 * 125.0 || particle_.R2() < 45.0 * 45.0))
     success = 0;
-  
+
   return done;
 }
 
-bool
-BaseParticlePropagator::propagateToPreshowerLayer2(bool first) {
+bool BaseParticlePropagator::propagateToPreshowerLayer2(bool first) {
   //
   // Propagation to Preshower Layer 2
   // TODO: include proper geometry
   // Geometry taken from CMS ECAL TDR
   //
-  // First propagate to global barrel / endcap cylinder 
+  // First propagate to global barrel / endcap cylinder
   //  setPropagationConditions(1290. , 3090 , first);
   //  New position of the preshower as of CMSSW_1_7_X
-  setPropagationConditions(129.0 , 307.838 , first);
+  setPropagationConditions(129.0, 307.838, first);
   bool done = propagate();
 
-  // Check that we are on Layer 2 
-  if ( done && (particle_.R2() > 125.0*125.0 || particle_.R2() < 45.0*45.0 ) )
+  // Check that we are on Layer 2
+  if (done && (particle_.R2() > 125.0 * 125.0 || particle_.R2() < 45.0 * 45.0))
     success = 0;
 
   return done;
-
 }
 
-bool
-BaseParticlePropagator::propagateToEcalEntrance(bool first) {
+bool BaseParticlePropagator::propagateToEcalEntrance(bool first) {
   //
   // Propagation to ECAL entrance
   // TODO: include proper geometry
   // Geometry taken from CMS ECAL TDR
   //
-  // First propagate to global barrel / endcap cylinder 
-  setPropagationConditions(129.0 , 320.9,first);
+  // First propagate to global barrel / endcap cylinder
+  setPropagationConditions(129.0, 320.9, first);
   bool done = propagate();
 
-  // Go to endcap cylinder in the "barrel cut corner" 
+  // Go to endcap cylinder in the "barrel cut corner"
   // eta = 1.479 -> cos^2(theta) = 0.81230
   //  if ( done && eta > 1.479 && success == 1 ) {
-  if ( done && particle_.cos2ThetaV() > 0.81230 && success == 1 ) {
-    setPropagationConditions(152.6 , 320.9, first);
+  if (done && particle_.cos2ThetaV() > 0.81230 && success == 1) {
+    setPropagationConditions(152.6, 320.9, first);
     done = propagate();
   }
 
   // We are not in the ECAL acceptance
   // eta = 3.0 -> cos^2(theta) = 0.99013
-  if ( particle_.cos2ThetaV() > 0.99014 ) success = 0;
+  if (particle_.cos2ThetaV() > 0.99014)
+    success = 0;
 
   return done;
 }
 
-bool
-BaseParticlePropagator::propagateToHcalEntrance(bool first) {
+bool BaseParticlePropagator::propagateToHcalEntrance(bool first) {
   //
   // Propagation to HCAL entrance
   // TODO: include proper geometry
   // Geometry taken from CMSSW_3_1_X xml (Sunanda)
   //
 
-  // First propagate to global barrel / endcap cylinder 
-  setPropagationConditions(177.5 , 335.0, first);
+  // First propagate to global barrel / endcap cylinder
+  setPropagationConditions(177.5, 335.0, first);
   propDir = 0;
   bool done = propagate();
   propDir = 1;
@@ -532,39 +496,39 @@ BaseParticlePropagator::propagateToHcalEntrance(bool first) {
     propDir = 1;
   }
 
-
   // out of the HB/HE acceptance
   // eta = 3.0 -> cos^2(theta) = 0.99014
-  if ( done && particle_.cos2ThetaV() > 0.99014 ) success = 0;
+  if (done && particle_.cos2ThetaV() > 0.99014)
+    success = 0;
 
   return done;
 }
 
-bool
-BaseParticlePropagator::propagateToVFcalEntrance(bool first) {
+bool BaseParticlePropagator::propagateToVFcalEntrance(bool first) {
   //
   // Propagation to VFCAL entrance
   // TODO: include proper geometry
   // Geometry taken from DAQ TDR Chapter 13
 
-  setPropagationConditions(400.0 , 1110.0, first);
+  setPropagationConditions(400.0, 1110.0, first);
   propDir = 0;
   bool done = propagate();
   propDir = 1;
 
-  if (!done) success = 0;
+  if (!done)
+    success = 0;
 
   // We are not in the VFCAL acceptance
   // eta = 3.0  -> cos^2(theta) = 0.99014
   // eta = 5.2  -> cos^2(theta) = 0.9998755
   double c2teta = particle_.cos2ThetaV();
-  if ( done && ( c2teta < 0.99014 || c2teta > 0.9998755 ) ) success = 0;
+  if (done && (c2teta < 0.99014 || c2teta > 0.9998755))
+    success = 0;
 
   return done;
 }
 
-bool
-BaseParticlePropagator::propagateToHcalExit(bool first) {
+bool BaseParticlePropagator::propagateToHcalExit(bool first) {
   //
   // Propagation to HCAL exit
   // TODO: include proper geometry
@@ -572,7 +536,7 @@ BaseParticlePropagator::propagateToHcalExit(bool first) {
   //
 
   // Approximate it to a single cylinder as it is not that crucial.
-  setPropagationConditions(263.9 , 554.1, first);
+  setPropagationConditions(263.9, 554.1, first);
   //  this->rawPart().particle_.setCharge(0.0); ?? Shower Propagation ??
   propDir = 0;
   bool done = propagate();
@@ -581,8 +545,7 @@ BaseParticlePropagator::propagateToHcalExit(bool first) {
   return done;
 }
 
-bool
-BaseParticlePropagator::propagateToHOLayer(bool first) {
+bool BaseParticlePropagator::propagateToHOLayer(bool first) {
   //
   // Propagation to Layer0 of HO (Ring-0)
   // TODO: include proper geometry
@@ -590,98 +553,91 @@ BaseParticlePropagator::propagateToHOLayer(bool first) {
   //
 
   // Approximate it to a single cylinder as it is not that crucial.
-  setPropagationConditions(387.6, 1000.0, first); //Dia is the middle of HO \sqrt{384.8**2+46.2**2}
+  setPropagationConditions(387.6, 1000.0, first);  //Dia is the middle of HO \sqrt{384.8**2+46.2**2}
   //  setPropagationConditions(410.2, 1000.0, first); //sqrt{406.6**2+54.2**2} //for outer layer
   //  this->rawPart().setCharge(0.0); ?? Shower Propagation ??
   propDir = 0;
   bool done = propagate();
   propDir = 1;
-  
-  if ( done && std::abs(particle_.Z()) > 700.25) success = 0;
-  
+
+  if (done && std::abs(particle_.Z()) > 700.25)
+    success = 0;
+
   return done;
 }
 
-
-bool
-BaseParticlePropagator::propagateToNominalVertex(const XYZTLorentzVector& v) 
-{
-
-
+bool BaseParticlePropagator::propagateToNominalVertex(const XYZTLorentzVector& v) {
   // Not implemented for neutrals (used for electrons only)
-  if ( particle_.charge() == 0. || bField == 0.) return false;
+  if (particle_.charge() == 0. || bField == 0.)
+    return false;
 
   // Define the proper pT direction to meet the point (vx,vy) in (x,y)
-  double dx = particle_.X()-v.X();
-  double dy = particle_.Y()-v.Y();
-  double phi = std::atan2(dy,dx) + std::asin ( std::sqrt(dx*dx+dy*dy)/(2.*helixRadius()) );
+  double dx = particle_.X() - v.X();
+  double dy = particle_.Y() - v.Y();
+  double phi = std::atan2(dy, dx) + std::asin(std::sqrt(dx * dx + dy * dy) / (2. * helixRadius()));
 
   // The absolute pT (kept to the original value)
   double pT = particle_.pt();
 
   // Set the new pT
-  particle_.SetPx(pT*std::cos(phi));
-  particle_.SetPy(pT*std::sin(phi));
+  particle_.SetPx(pT * std::cos(phi));
+  particle_.SetPy(pT * std::sin(phi));
 
-  return propagateToClosestApproach(v.X(),v.Y());
-  
+  return propagateToClosestApproach(v.X(), v.Y());
 }
 
-bool
-BaseParticlePropagator::propagateToBeamCylinder(const XYZTLorentzVector& v, double radius) 
-{
-
+bool BaseParticlePropagator::propagateToBeamCylinder(const XYZTLorentzVector& v, double radius) {
   // For neutral (or BField = 0, simply check that the track passes through the cylinder
-  if ( particle_.charge() == 0. || bField == 0.) 
-    return fabs( particle_.Px() * particle_.Y() - particle_.Py() * particle_.X() ) / particle_.Pt() < radius; 
+  if (particle_.charge() == 0. || bField == 0.)
+    return fabs(particle_.Px() * particle_.Y() - particle_.Py() * particle_.X()) / particle_.Pt() < radius;
 
   // Now go to the charged particles
 
   // A few needed intermediate variables (to make the code understandable)
   // The inner cylinder
   double r = radius;
-  double r2 = r*r;
-  double r4 = r2*r2;
+  double r2 = r * r;
+  double r4 = r2 * r2;
   // The two hits
-  double dx = particle_.X()-v.X();
-  double dy = particle_.Y()-v.Y();
-  double dz = particle_.Z()-v.Z();
-  double Sxy = particle_.X()*v.X() + particle_.Y()*v.Y();
-  double Dxy = particle_.Y()*v.X() - particle_.X()*v.Y();
-  double Dxy2 = Dxy*Dxy;
-  double Sxy2 = Sxy*Sxy;
-  double SDxy = dx*dx + dy*dy;
+  double dx = particle_.X() - v.X();
+  double dy = particle_.Y() - v.Y();
+  double dz = particle_.Z() - v.Z();
+  double Sxy = particle_.X() * v.X() + particle_.Y() * v.Y();
+  double Dxy = particle_.Y() * v.X() - particle_.X() * v.Y();
+  double Dxy2 = Dxy * Dxy;
+  double Sxy2 = Sxy * Sxy;
+  double SDxy = dx * dx + dy * dy;
   double SSDxy = std::sqrt(SDxy);
-  double ATxy = std::atan2(dy,dx);
+  double ATxy = std::atan2(dy, dx);
   // The coefficients of the second order equation for the trajectory radius
-  double a = r2 - Dxy2/SDxy;
+  double a = r2 - Dxy2 / SDxy;
   double b = r * (r2 - Sxy);
-  double c = r4 - 2.*Sxy*r2 + Sxy2 + Dxy2;
+  double c = r4 - 2. * Sxy * r2 + Sxy2 + Dxy2;
 
   // Here are the four possible solutions for
   // 1) The trajectory radius
-  std::array<double,4> helixRs = {{0.}};
-  helixRs[0] = (b - std::sqrt(b*b - a*c))/(2.*a); 
-  helixRs[1] = (b + std::sqrt(b*b - a*c))/(2.*a); 
-  helixRs[2] = -helixRs[0]; 
-  helixRs[3] = -helixRs[1]; 
+  std::array<double, 4> helixRs = {{0.}};
+  helixRs[0] = (b - std::sqrt(b * b - a * c)) / (2. * a);
+  helixRs[1] = (b + std::sqrt(b * b - a * c)) / (2. * a);
+  helixRs[2] = -helixRs[0];
+  helixRs[3] = -helixRs[1];
   // 2) The azimuthal direction at the second point
-  std::array<double,4> helixPhis = {{0.}};
-  helixPhis[0] = std::asin ( SSDxy/(2.*helixRs[0]) );
-  helixPhis[1] = std::asin ( SSDxy/(2.*helixRs[1]) );
+  std::array<double, 4> helixPhis = {{0.}};
+  helixPhis[0] = std::asin(SSDxy / (2. * helixRs[0]));
+  helixPhis[1] = std::asin(SSDxy / (2. * helixRs[1]));
   helixPhis[2] = -helixPhis[0];
   helixPhis[3] = -helixPhis[1];
   // Only two solutions are valid though
-  double solution1=0.;
-  double solution2=0.;
-  double phi1=0.;
-  double phi2=0.;
+  double solution1 = 0.;
+  double solution2 = 0.;
+  double phi1 = 0.;
+  double phi2 = 0.;
   // Loop over the four possibilities
-  for ( unsigned int i=0; i<4; ++i ) {
+  for (unsigned int i = 0; i < 4; ++i) {
     helixPhis[i] = ATxy + helixPhis[i];
     // The centre of the helix
-    double xC = helixCentreX(helixRs[i],helixPhis[i]);
-    double yC = helixCentreY(helixRs[i],helixPhis[i]);
+    double xC = helixCentreX(helixRs[i], helixPhis[i]);
+    double yC = helixCentreY(helixRs[i], helixPhis[i]);
     // The distance of that centre to the origin
     double dist = helixCentreDistToAxis(xC, yC);
     /*
@@ -691,25 +647,25 @@ BaseParticlePropagator::propagateToBeamCylinder(const XYZTLorentzVector& v, doub
 	      << ( fabs( fabs(fabs(helixRs[i]) - dist) -fabs(radius) ) < 1e-6)  << std::endl;
     */
     // Check that the propagation will lead to a trajectroy tangent to the inner cylinder
-    if ( fabs( fabs(fabs(helixRs[i]) - dist) -fabs(radius) ) < 1e-6 ) { 
+    if (fabs(fabs(fabs(helixRs[i]) - dist) - fabs(radius)) < 1e-6) {
       // Fill first solution
-      if ( solution1 == 0. ) { 
-	solution1 = helixRs[i];
-	phi1 = helixPhis[i];
-      // Fill second solution (ordered)
-      } else if ( solution2 == 0. ) {
-	if ( helixRs[i] < solution1 ) {
-	  solution2 = solution1;
-	  solution1 = helixRs[i];
-	  phi2 = phi1;
-	  phi1 = helixPhis[i];
-	} else {
-	  solution2 = helixRs[i];
-	  phi2 = helixPhis[i];
-	}
-      // Must not happen! 
-      } else { 
-	std::cout << "warning !!! More than two solutions for this track !!! " << std::endl;
+      if (solution1 == 0.) {
+        solution1 = helixRs[i];
+        phi1 = helixPhis[i];
+        // Fill second solution (ordered)
+      } else if (solution2 == 0.) {
+        if (helixRs[i] < solution1) {
+          solution2 = solution1;
+          solution1 = helixRs[i];
+          phi2 = phi1;
+          phi1 = helixPhis[i];
+        } else {
+          solution2 = helixRs[i];
+          phi2 = helixPhis[i];
+        }
+        // Must not happen!
+      } else {
+        std::cout << "warning !!! More than two solutions for this track !!! " << std::endl;
       }
     }
   }
@@ -719,21 +675,20 @@ BaseParticlePropagator::propagateToBeamCylinder(const XYZTLorentzVector& v, doub
   double helixPhi = 0.;
   double helixR = 0.;
   // This should not happen
-  if ( solution1*solution2 == 0. ) { 
-    std::cout << "warning !!! Less than two solution for this track! " 
-	      << solution1 << " " << solution2 << std::endl;
+  if (solution1 * solution2 == 0.) {
+    std::cout << "warning !!! Less than two solution for this track! " << solution1 << " " << solution2 << std::endl;
     return false;
-  // If the two solutions have opposite sign, it means that pT = infinity is a possibility.
-  } else if ( solution1*solution2 < 0. ) { 
+    // If the two solutions have opposite sign, it means that pT = infinity is a possibility.
+  } else if (solution1 * solution2 < 0.) {
     pT = 1000.;
-    double norm = pT/SSDxy;
+    double norm = pT / SSDxy;
     particle_.setCharge(+1.);
-    particle_.setMomentum(dx*norm,dy*norm,dz*norm,0.);
+    particle_.setMomentum(dx * norm, dy * norm, dz * norm, 0.);
     particle_.SetE(std::sqrt(particle_.momentum().Vect().Mag2()));
-  // Otherwise take the solution that gives the largest transverse momentum 
-  } else { 
-    if (solution1<0.) { 
-      helixR   = solution1;
+    // Otherwise take the solution that gives the largest transverse momentum
+  } else {
+    if (solution1 < 0.) {
+      helixR = solution1;
       helixPhi = phi1;
       particle_.setCharge(+1.);
     } else {
@@ -741,36 +696,32 @@ BaseParticlePropagator::propagateToBeamCylinder(const XYZTLorentzVector& v, doub
       helixPhi = phi2;
       particle_.setCharge(-1.);
     }
-    pT = fabs(helixR) * 1e-5 * c_light() *bField;
-    double norm = pT/SSDxy;
-    particle_.setMomentum(pT*std::cos(helixPhi),pT*std::sin(helixPhi),dz*norm,0.);
-    particle_.SetE(std::sqrt(particle_.momentum().Vect().Mag2()));      
+    pT = fabs(helixR) * 1e-5 * c_light() * bField;
+    double norm = pT / SSDxy;
+    particle_.setMomentum(pT * std::cos(helixPhi), pT * std::sin(helixPhi), dz * norm, 0.);
+    particle_.SetE(std::sqrt(particle_.momentum().Vect().Mag2()));
   }
-    
+
   // Propagate to closest approach to get the Z value (a bit of an overkill)
   return propagateToClosestApproach();
-  
 }
 
-double 
-BaseParticlePropagator::xyImpactParameter(double x0, double y0) const {
-
-  double ip=0.;
+double BaseParticlePropagator::xyImpactParameter(double x0, double y0) const {
+  double ip = 0.;
   double pT = particle_.Pt();
 
-  if ( particle_.charge() != 0.0 && bField != 0.0 ) {
+  if (particle_.charge() != 0.0 && bField != 0.0) {
     double radius = helixRadius(pT);
     double phi0 = helixStartPhi();
-    
+
     // The Helix centre coordinates are computed wrt to the z axis
-    double xC = helixCentreX(radius,phi0);
-    double yC = helixCentreY(radius,phi0);
-    double distz = helixCentreDistToAxis(xC-x0,yC-y0);
+    double xC = helixCentreX(radius, phi0);
+    double yC = helixCentreY(radius, phi0);
+    double distz = helixCentreDistToAxis(xC - x0, yC - y0);
     ip = distz - fabs(radius);
   } else {
-    ip = fabs( particle_.Px() * (particle_.Y()-y0) - particle_.Py() * (particle_.X()-x0) ) / pT; 
+    ip = fabs(particle_.Px() * (particle_.Y() - y0) - particle_.Py() * (particle_.X() - x0)) / pT;
   }
 
   return ip;
-
 }

--- a/CommonTools/BaseParticlePropagator/src/RawParticle.cc
+++ b/CommonTools/BaseParticlePropagator/src/RawParticle.cc
@@ -10,133 +10,81 @@
 
 #include <cmath>
 
-RawParticle::RawParticle(const XYZTLorentzVector& p) 
-  : myMomentum(p) {
-}
+RawParticle::RawParticle(const XYZTLorentzVector& p) : myMomentum(p) {}
 
-RawParticle::RawParticle(const int id, 
-			 const XYZTLorentzVector& p,
-                         double mass,
-                         double charge) : 
-  myMomentum(p),
-  myCharge{charge},
-  myMass{mass},
-  myId{id}
-{
-}
+RawParticle::RawParticle(const int id, const XYZTLorentzVector& p, double mass, double charge)
+    : myMomentum(p), myCharge{charge}, myMass{mass}, myId{id} {}
 
-RawParticle::RawParticle(const int id, 
-			 const XYZTLorentzVector& p,
-                         const XYZTLorentzVector& xStart,
-                         double mass,
-                         double charge) : 
-  myMomentum(p),
-  myVertex{xStart},
-  myCharge{charge},
-  myMass{mass},
-  myId{id}
-{
-}
+RawParticle::RawParticle(
+    const int id, const XYZTLorentzVector& p, const XYZTLorentzVector& xStart, double mass, double charge)
+    : myMomentum(p), myVertex{xStart}, myCharge{charge}, myMass{mass}, myId{id} {}
 
-RawParticle::RawParticle(const XYZTLorentzVector& p, 
-			 const XYZTLorentzVector& xStart,
-                         double charge)  : 
-  myMomentum(p),
-  myVertex{xStart},
-  myCharge{charge}
-{
-}
+RawParticle::RawParticle(const XYZTLorentzVector& p, const XYZTLorentzVector& xStart, double charge)
+    : myMomentum(p), myVertex{xStart}, myCharge{charge} {}
 
-RawParticle::RawParticle(double px, double py, double pz, double e, double charge) : 
-  myMomentum(px,py,pz,e),
-  myCharge{charge}
-{
-}
+RawParticle::RawParticle(double px, double py, double pz, double e, double charge)
+    : myMomentum(px, py, pz, e), myCharge{charge} {}
 
-void 
-RawParticle::setStatus(int istat) {
-  myStatus = istat;
-}
+void RawParticle::setStatus(int istat) { myStatus = istat; }
 
-void 
-RawParticle::setMass(float m) {
-  myMass = m;
-}
+void RawParticle::setMass(float m) { myMass = m; }
 
-void 
-RawParticle::setCharge(float q) {
-  myCharge = q;
-}
+void RawParticle::setCharge(float q) { myCharge = q; }
 
-void 
-RawParticle::chargeConjugate() {
+void RawParticle::chargeConjugate() {
   myId = -myId;
-  myCharge = -1*myCharge;
+  myCharge = -1 * myCharge;
 }
 
-void 
-RawParticle::setT(const double t) {
-  myVertex.SetE(t);
-}
+void RawParticle::setT(const double t) { myVertex.SetE(t); }
 
-void 
-RawParticle::rotate(double angle, const XYZVector& raxis) {
-  Rotation r(raxis,angle);
+void RawParticle::rotate(double angle, const XYZVector& raxis) {
+  Rotation r(raxis, angle);
   XYZVector v(r * myMomentum.Vect());
-  setMomentum(v.X(),v.Y(),v.Z(),E());
+  setMomentum(v.X(), v.Y(), v.Z(), E());
 }
 
-void 
-RawParticle::rotateX(double rphi) {
+void RawParticle::rotateX(double rphi) {
   RotationX r(rphi);
   XYZVector v(r * myMomentum.Vect());
-  setMomentum(v.X(),v.Y(),v.Z(),E());
+  setMomentum(v.X(), v.Y(), v.Z(), E());
 }
 
-void 
-RawParticle::rotateY(double rphi) {
+void RawParticle::rotateY(double rphi) {
   RotationY r(rphi);
   XYZVector v(r * myMomentum.Vect());
-  setMomentum(v.X(),v.Y(),v.Z(),E());
+  setMomentum(v.X(), v.Y(), v.Z(), E());
 }
 
-void 
-RawParticle::rotateZ(double rphi) {
+void RawParticle::rotateZ(double rphi) {
   RotationZ r(rphi);
   XYZVector v(r * myMomentum.Vect());
-  setMomentum(v.X(),v.Y(),v.Z(),E());
+  setMomentum(v.X(), v.Y(), v.Z(), E());
 }
 
-void 
-RawParticle::boost(double betax, double betay, double betaz) {
-  Boost b(betax,betay,betaz);
-  XYZTLorentzVector p ( b * momentum() );
-  setMomentum(p.X(),p.Y(),p.Z(),p.T());
+void RawParticle::boost(double betax, double betay, double betaz) {
+  Boost b(betax, betay, betaz);
+  XYZTLorentzVector p(b * momentum());
+  setMomentum(p.X(), p.Y(), p.Z(), p.T());
 }
 
-
-std::ostream& operator <<(std::ostream& o , const RawParticle& p) {
-
+std::ostream& operator<<(std::ostream& o, const RawParticle& p) {
   o.setf(std::ios::fixed, std::ios::floatfield);
   o.setf(std::ios::right, std::ios::adjustfield);
-
 
   o << std::setw(4) << std::setprecision(2) << p.pid() << " (";
   o << std::setw(2) << std::setprecision(2) << p.status() << "): ";
   o << std::setw(10) << std::setprecision(4) << p.momentum() << " ";
   o << std::setw(10) << std::setprecision(4) << p.vertex();
   return o;
+}
 
-} 
+double RawParticle::et() const {
+  double mypp, tmpEt = -1.;
 
-double 
-RawParticle::et() const { 
-  double mypp, tmpEt=-1.;
-  
   mypp = std::sqrt(momentum().mag2());
-  if ( mypp != 0 ) {
+  if (mypp != 0) {
     tmpEt = E() * pt() / mypp;
   }
   return tmpEt;
 }
-

--- a/CommonTools/BaseParticlePropagator/src/makeMuon.cc
+++ b/CommonTools/BaseParticlePropagator/src/makeMuon.cc
@@ -2,7 +2,7 @@
 //
 // Package:     CommonTools/BaseParticlePropagator
 // Class  :     makeMuon
-// 
+//
 // Implementation:
 //     [Notes on implementation]
 //
@@ -17,12 +17,11 @@
 
 #include "CommonTools/BaseParticlePropagator/interface/RawParticle.h"
 namespace rawparticle {
-  RawParticle makeMuon(bool isParticle, const math::XYZTLorentzVector& p, 
-                       const math::XYZTLorentzVector& xStart) {
-    constexpr double kMass = 0.10566; //taken from SimGeneral/HepPDTESSource/data/particle.tbl
-    if(isParticle) {
-      return RawParticle(13, p,xStart,kMass,-1.);
+  RawParticle makeMuon(bool isParticle, const math::XYZTLorentzVector& p, const math::XYZTLorentzVector& xStart) {
+    constexpr double kMass = 0.10566;  //taken from SimGeneral/HepPDTESSource/data/particle.tbl
+    if (isParticle) {
+      return RawParticle(13, p, xStart, kMass, -1.);
     }
-    return RawParticle(-13,p,xStart, kMass, +1.);
+    return RawParticle(-13, p, xStart, kMass, +1.);
   }
-}
+}  // namespace rawparticle

--- a/CommonTools/BaseParticlePropagator/test/makeMuon_catch2.cc
+++ b/CommonTools/BaseParticlePropagator/test/makeMuon_catch2.cc
@@ -4,12 +4,11 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-
 static constexpr const double kMuonMass = 0.10566;
 
 TEST_CASE("makeMuon tests", "[makeMuon]") {
   SECTION("muon at rest") {
-    auto m1 = rawparticle::makeMuon(true,math::XYZTLorentzVector{}, math::XYZTLorentzVector{});
+    auto m1 = rawparticle::makeMuon(true, math::XYZTLorentzVector{}, math::XYZTLorentzVector{});
 
     REQUIRE(m1.charge() == -1.);
     REQUIRE(m1.mass() == kMuonMass);
@@ -27,7 +26,7 @@ TEST_CASE("makeMuon tests", "[makeMuon]") {
   }
 
   SECTION("anti-muon at rest") {
-    auto m1 = rawparticle::makeMuon(false,math::XYZTLorentzVector{}, math::XYZTLorentzVector{});
+    auto m1 = rawparticle::makeMuon(false, math::XYZTLorentzVector{}, math::XYZTLorentzVector{});
 
     REQUIRE(m1.charge() == 1.);
     REQUIRE(m1.mass() == kMuonMass);
@@ -45,7 +44,7 @@ TEST_CASE("makeMuon tests", "[makeMuon]") {
   }
 
   SECTION("muon at rest, transposed") {
-    auto m1 = rawparticle::makeMuon(true,math::XYZTLorentzVector{}, math::XYZTLorentzVector{1.,2.,3.,4.});
+    auto m1 = rawparticle::makeMuon(true, math::XYZTLorentzVector{}, math::XYZTLorentzVector{1., 2., 3., 4.});
 
     REQUIRE(m1.charge() == -1.);
     REQUIRE(m1.mass() == kMuonMass);
@@ -63,7 +62,7 @@ TEST_CASE("makeMuon tests", "[makeMuon]") {
   }
 
   SECTION("muon in motion") {
-    auto m1 = rawparticle::makeMuon(true,math::XYZTLorentzVector{1.,2.,3., 8.}, math::XYZTLorentzVector{});
+    auto m1 = rawparticle::makeMuon(true, math::XYZTLorentzVector{1., 2., 3., 8.}, math::XYZTLorentzVector{});
 
     REQUIRE(m1.charge() == -1.);
     REQUIRE(m1.mass() == kMuonMass);
@@ -79,5 +78,4 @@ TEST_CASE("makeMuon tests", "[makeMuon]") {
     //REQUIRE(m1.e() == sqrt(kMuonMass*kMuonMass+m1.px()*m1.px()+m1.py()*m1.py()+m1.pz()*m1.pz()));
     REQUIRE(m1.e() == 8.);
   }
-
 }


### PR DESCRIPTION

Applying code-format for CMSSW category fastsim,reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/291//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


