### PR TITLE
Running code-format for generators

### DIFF
--- a/GeneratorInterface/EvtGenInterface/interface/DataCardFileWriter.h
+++ b/GeneratorInterface/EvtGenInterface/interface/DataCardFileWriter.h
@@ -3,7 +3,6 @@
 
 // I. M. Nugent
 
-
 // system include files
 #include <memory>
 
@@ -18,17 +17,16 @@
 
 namespace gen {
 
-class DataCardFileWriter : public  edm::EDAnalyzer {
- public:
-  DataCardFileWriter(const edm::ParameterSet&);
-  ~DataCardFileWriter() override{};
+  class DataCardFileWriter : public edm::EDAnalyzer {
+  public:
+    DataCardFileWriter(const edm::ParameterSet&);
+    ~DataCardFileWriter() override{};
 
-  void beginJob() override{};
-  void analyze(const edm::Event&, const edm::EventSetup&) override{};
-  void endJob() override{};
+    void beginJob() override{};
+    void analyze(const edm::Event&, const edm::EventSetup&) override{};
+    void endJob() override{};
+  };
 
-};
-
-};
+};  // namespace gen
 
 #endif

--- a/GeneratorInterface/EvtGenInterface/interface/EvtGenFactory.h
+++ b/GeneratorInterface/EvtGenInterface/interface/EvtGenFactory.h
@@ -1,10 +1,10 @@
 #ifndef GeneratorInterface_EvtGenInterface_EvtGenFactory_H
 #define GeneratorInterface_EvtGenInterface_EvtGenFactory_H
- 
+
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "GeneratorInterface/EvtGenInterface/interface/EvtGenInterfaceBase.h"
 
-typedef edmplugin::PluginFactory<gen::EvtGenInterfaceBase* (const edm::ParameterSet&) >  EvtGenFactory;
+typedef edmplugin::PluginFactory<gen::EvtGenInterfaceBase*(const edm::ParameterSet&)> EvtGenFactory;
 
 #endif

--- a/GeneratorInterface/EvtGenInterface/interface/EvtGenInterfaceBase.h
+++ b/GeneratorInterface/EvtGenInterface/interface/EvtGenInterfaceBase.h
@@ -11,23 +11,22 @@ namespace CLHEP {
 }
 
 namespace gen {
-   class EvtGenInterfaceBase {
-   public:
-     EvtGenInterfaceBase(){ };
-     virtual ~EvtGenInterfaceBase(){ };
+  class EvtGenInterfaceBase {
+  public:
+    EvtGenInterfaceBase(){};
+    virtual ~EvtGenInterfaceBase(){};
 
-     virtual void SetPhotosDecayRandomEngine(CLHEP::HepRandomEngine* decayRandomEngine){};
-     virtual void init(){};
-     virtual const std::vector<int>& operatesOnParticles(){return m_PDGs;}
-     virtual const std::vector<std::string>& specialSettings() { return fSpecialSettings; }
-     virtual HepMC::GenEvent* decay( HepMC::GenEvent* evt){return evt;}
-     virtual void setRandomEngine(CLHEP::HepRandomEngine* v)=0;
+    virtual void SetPhotosDecayRandomEngine(CLHEP::HepRandomEngine* decayRandomEngine){};
+    virtual void init(){};
+    virtual const std::vector<int>& operatesOnParticles() { return m_PDGs; }
+    virtual const std::vector<std::string>& specialSettings() { return fSpecialSettings; }
+    virtual HepMC::GenEvent* decay(HepMC::GenEvent* evt) { return evt; }
+    virtual void setRandomEngine(CLHEP::HepRandomEngine* v) = 0;
 
-   protected: 
-     std::vector<int> m_PDGs;
-     std::vector<std::string> fSpecialSettings;
-
-   };
-}
+  protected:
+    std::vector<int> m_PDGs;
+    std::vector<std::string> fSpecialSettings;
+  };
+}  // namespace gen
 
 #endif

--- a/GeneratorInterface/EvtGenInterface/interface/myEvtRandomEngine.h
+++ b/GeneratorInterface/EvtGenInterface/interface/myEvtRandomEngine.h
@@ -24,11 +24,8 @@ namespace CLHEP {
   class HepRandomEngine;
 }
 
-class myEvtRandomEngine : public EvtRandomEngine  
-{
-
+class myEvtRandomEngine : public EvtRandomEngine {
 public:
-  
   myEvtRandomEngine(CLHEP::HepRandomEngine* xx);
 
   ~myEvtRandomEngine() override;
@@ -40,7 +37,6 @@ public:
   CLHEP::HepRandomEngine* engine() const { return the_engine; }
 
 private:
-
   void throwNullPtr() const;
 
   CLHEP::HepRandomEngine* the_engine;

--- a/GeneratorInterface/EvtGenInterface/plugins/DataCardFileWriter.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/DataCardFileWriter.cc
@@ -9,18 +9,18 @@
 
 using namespace gen;
 
-DataCardFileWriter::DataCardFileWriter(const edm::ParameterSet& pset){
-  std::string FileName =  pset.getParameter<std::string>("FileName") ;
-  std::string Base= getenv ("CMSSW_BASE");
-  Base+="/src/";
-  std::cout << "Writting file:" << Base+FileName << std::endl;
-  std::ofstream outputFile(Base+FileName);
-  std::vector<std::string> FileContent= pset.getParameter<std::vector<std::string> >("FileContent") ;
-  for(unsigned int i=0; i<FileContent.size();i++){
+DataCardFileWriter::DataCardFileWriter(const edm::ParameterSet& pset) {
+  std::string FileName = pset.getParameter<std::string>("FileName");
+  std::string Base = getenv("CMSSW_BASE");
+  Base += "/src/";
+  std::cout << "Writting file:" << Base + FileName << std::endl;
+  std::ofstream outputFile(Base + FileName);
+  std::vector<std::string> FileContent = pset.getParameter<std::vector<std::string> >("FileContent");
+  for (unsigned int i = 0; i < FileContent.size(); i++) {
     outputFile << FileContent.at(i) << std::endl;
   }
   outputFile.close();
-  std::cout << "File:" << Base+FileName << " Complete." << std::endl;
+  std::cout << "File:" << Base + FileName << " Complete." << std::endl;
 }
 
 DEFINE_FWK_MODULE(DataCardFileWriter);

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.cc
@@ -6,7 +6,7 @@
 // The modifications for EvtGen 1.3.0 are implemented by Ian M. Nugent
 // I would like to thank the EvtGen developers, in particular John Black, and Mikhail Kirsanov for their assistance.
 //
-// January 2015: Setting of coherent or incoherent B mixing included by Eduard Burelo 
+// January 2015: Setting of coherent or incoherent B mixing included by Eduard Burelo
 // January 2015: Adding new feature to allow users to provide new evtgen models
 
 #include "GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtModelUserReg.h"
@@ -44,7 +44,7 @@
 
 #include "TString.h"
 #include <string>
-#include <cstdlib> 
+#include <cstdlib>
 #include <cstdio>
 
 #include "boost/filesystem.hpp"
@@ -55,242 +55,241 @@ using namespace edm;
 
 CLHEP::HepRandomEngine* EvtGenInterface::fRandomEngine;
 
-EvtGenInterface::EvtGenInterface( const ParameterSet& pset ){
-  fPSet=new ParameterSet(pset);
+EvtGenInterface::EvtGenInterface(const ParameterSet& pset) {
+  fPSet = new ParameterSet(pset);
   the_engine = new myEvtRandomEngine(nullptr);
 }
 
-void EvtGenInterface::SetDefault_m_PDGs(){
+void EvtGenInterface::SetDefault_m_PDGs() {
   // fill up default list of particles to be declared stable in the "master generator"
   // these are assumed to be PDG ID's
   //
   // Note: Pythia6's kc=43, 44, and 84 commented out because they're obsolete (per S.Mrenna)
   //
-  m_PDGs.push_back( 300553 ) ;
-  m_PDGs.push_back( 511 ) ;
-  m_PDGs.push_back( 521 ) ;
-  m_PDGs.push_back( 523 ) ;
-  m_PDGs.push_back( 513 ) ;
-  m_PDGs.push_back( 533 ) ;
-  m_PDGs.push_back( 531 ) ; //B_s0
-  
-  m_PDGs.push_back( 15 ) ;
-  
-  m_PDGs.push_back( 413 ) ;
-  m_PDGs.push_back( 423 ) ;
-  m_PDGs.push_back( 433 ) ;
-  m_PDGs.push_back( 411 ) ;
-  m_PDGs.push_back( 421 ) ;
-  m_PDGs.push_back( 431 ) ;   
-  m_PDGs.push_back( 10411 );
-  m_PDGs.push_back( 10421 );
-  m_PDGs.push_back( 10413 );
-  m_PDGs.push_back( 10423 );   
-  m_PDGs.push_back( 20413 );
-  m_PDGs.push_back( 20423 );
-  
-  m_PDGs.push_back( 415 );
-  m_PDGs.push_back( 425 );
-  m_PDGs.push_back( 10431 );
-  m_PDGs.push_back( 20433 );
-  m_PDGs.push_back( 10433 );
-  m_PDGs.push_back( 435 );
-  
-  m_PDGs.push_back( 310 );
-  m_PDGs.push_back( 311 );
-  m_PDGs.push_back( 313 );
-  m_PDGs.push_back( 323 );
-  m_PDGs.push_back( 10321 );
-  m_PDGs.push_back( 10311 );
-  m_PDGs.push_back( 10313 );
-  m_PDGs.push_back( 10323 );
-  m_PDGs.push_back( 20323 );
-  m_PDGs.push_back( 20313 );
-  m_PDGs.push_back( 325 );
-  m_PDGs.push_back( 315 );
-  
-  m_PDGs.push_back( 100313 );
-  m_PDGs.push_back( 100323 );
-  m_PDGs.push_back( 30313 );
-  m_PDGs.push_back( 30323 );
-  m_PDGs.push_back( 30343 );
-  m_PDGs.push_back( 30353 );
-  m_PDGs.push_back( 30363 );
-  
-  m_PDGs.push_back( 111 );
-  m_PDGs.push_back( 221 );
-  m_PDGs.push_back( 113 );
-  m_PDGs.push_back( 213 );
-  m_PDGs.push_back( 223 );
-  m_PDGs.push_back( 331 );
-  m_PDGs.push_back( 333 );
-  m_PDGs.push_back( 20213 );
-  m_PDGs.push_back( 20113 );
-  m_PDGs.push_back( 215 );
-  m_PDGs.push_back( 115 );
-  m_PDGs.push_back( 10213 );
-  m_PDGs.push_back( 10113 );
-  m_PDGs.push_back( 9000111 ); // PDG ID = 9000111, Pythia6 ID = 10111
-  m_PDGs.push_back( 9000211 ); // PDG ID = 9000211, Pythia6 ID = 10211
-  m_PDGs.push_back( 9010221 ); // PDG ID = 9010211, Pythia6 ID = ???
-  m_PDGs.push_back( 10221 );
-  m_PDGs.push_back( 20223 );
-  m_PDGs.push_back( 20333 );
-  m_PDGs.push_back( 225 );
-  m_PDGs.push_back( 9020221 ); // PDG ID = 9020211, Pythia6 ID = ???
-  m_PDGs.push_back( 335 );
-  m_PDGs.push_back( 10223 );
-  m_PDGs.push_back( 10333 );
-  m_PDGs.push_back( 100213 );
-  m_PDGs.push_back( 100113 );
-  
-  m_PDGs.push_back( 441 );
-  m_PDGs.push_back( 100441 );
-  m_PDGs.push_back( 443 );
-  m_PDGs.push_back( 100443 );
-  m_PDGs.push_back( 9000443 );
-  m_PDGs.push_back( 9010443 );
-  m_PDGs.push_back( 9020443 );
-  m_PDGs.push_back( 10441 );
-  m_PDGs.push_back( 20443 );
-  m_PDGs.push_back( 445 );
-  
-  m_PDGs.push_back( 30443 );
-  m_PDGs.push_back( 551 );
-  m_PDGs.push_back( 553 );
-  m_PDGs.push_back( 100553 );
-  m_PDGs.push_back( 200553 );
-  m_PDGs.push_back( 10551 );
-  m_PDGs.push_back( 20553 );
-  m_PDGs.push_back( 555 );
-  m_PDGs.push_back( 10553 );
+  m_PDGs.push_back(300553);
+  m_PDGs.push_back(511);
+  m_PDGs.push_back(521);
+  m_PDGs.push_back(523);
+  m_PDGs.push_back(513);
+  m_PDGs.push_back(533);
+  m_PDGs.push_back(531);  //B_s0
 
-  m_PDGs.push_back( 110551 );
-  m_PDGs.push_back( 120553 );
-  m_PDGs.push_back( 100555 );
-  m_PDGs.push_back( 210551 );
-  m_PDGs.push_back( 220553 );
-  m_PDGs.push_back( 200555 );
-  m_PDGs.push_back( 30553 );
-  m_PDGs.push_back( 20555 );
-  
-  m_PDGs.push_back( 557 );
-  m_PDGs.push_back( 130553 ); 
-  m_PDGs.push_back( 120555 );
-  m_PDGs.push_back( 100557 );
-  m_PDGs.push_back( 110553 );
-  m_PDGs.push_back( 210553 );
-  m_PDGs.push_back( 10555 );
-  m_PDGs.push_back( 110555 );
-  
-  m_PDGs.push_back( 4122 );
-  m_PDGs.push_back( 4132 );
+  m_PDGs.push_back(15);
+
+  m_PDGs.push_back(413);
+  m_PDGs.push_back(423);
+  m_PDGs.push_back(433);
+  m_PDGs.push_back(411);
+  m_PDGs.push_back(421);
+  m_PDGs.push_back(431);
+  m_PDGs.push_back(10411);
+  m_PDGs.push_back(10421);
+  m_PDGs.push_back(10413);
+  m_PDGs.push_back(10423);
+  m_PDGs.push_back(20413);
+  m_PDGs.push_back(20423);
+
+  m_PDGs.push_back(415);
+  m_PDGs.push_back(425);
+  m_PDGs.push_back(10431);
+  m_PDGs.push_back(20433);
+  m_PDGs.push_back(10433);
+  m_PDGs.push_back(435);
+
+  m_PDGs.push_back(310);
+  m_PDGs.push_back(311);
+  m_PDGs.push_back(313);
+  m_PDGs.push_back(323);
+  m_PDGs.push_back(10321);
+  m_PDGs.push_back(10311);
+  m_PDGs.push_back(10313);
+  m_PDGs.push_back(10323);
+  m_PDGs.push_back(20323);
+  m_PDGs.push_back(20313);
+  m_PDGs.push_back(325);
+  m_PDGs.push_back(315);
+
+  m_PDGs.push_back(100313);
+  m_PDGs.push_back(100323);
+  m_PDGs.push_back(30313);
+  m_PDGs.push_back(30323);
+  m_PDGs.push_back(30343);
+  m_PDGs.push_back(30353);
+  m_PDGs.push_back(30363);
+
+  m_PDGs.push_back(111);
+  m_PDGs.push_back(221);
+  m_PDGs.push_back(113);
+  m_PDGs.push_back(213);
+  m_PDGs.push_back(223);
+  m_PDGs.push_back(331);
+  m_PDGs.push_back(333);
+  m_PDGs.push_back(20213);
+  m_PDGs.push_back(20113);
+  m_PDGs.push_back(215);
+  m_PDGs.push_back(115);
+  m_PDGs.push_back(10213);
+  m_PDGs.push_back(10113);
+  m_PDGs.push_back(9000111);  // PDG ID = 9000111, Pythia6 ID = 10111
+  m_PDGs.push_back(9000211);  // PDG ID = 9000211, Pythia6 ID = 10211
+  m_PDGs.push_back(9010221);  // PDG ID = 9010211, Pythia6 ID = ???
+  m_PDGs.push_back(10221);
+  m_PDGs.push_back(20223);
+  m_PDGs.push_back(20333);
+  m_PDGs.push_back(225);
+  m_PDGs.push_back(9020221);  // PDG ID = 9020211, Pythia6 ID = ???
+  m_PDGs.push_back(335);
+  m_PDGs.push_back(10223);
+  m_PDGs.push_back(10333);
+  m_PDGs.push_back(100213);
+  m_PDGs.push_back(100113);
+
+  m_PDGs.push_back(441);
+  m_PDGs.push_back(100441);
+  m_PDGs.push_back(443);
+  m_PDGs.push_back(100443);
+  m_PDGs.push_back(9000443);
+  m_PDGs.push_back(9010443);
+  m_PDGs.push_back(9020443);
+  m_PDGs.push_back(10441);
+  m_PDGs.push_back(20443);
+  m_PDGs.push_back(445);
+
+  m_PDGs.push_back(30443);
+  m_PDGs.push_back(551);
+  m_PDGs.push_back(553);
+  m_PDGs.push_back(100553);
+  m_PDGs.push_back(200553);
+  m_PDGs.push_back(10551);
+  m_PDGs.push_back(20553);
+  m_PDGs.push_back(555);
+  m_PDGs.push_back(10553);
+
+  m_PDGs.push_back(110551);
+  m_PDGs.push_back(120553);
+  m_PDGs.push_back(100555);
+  m_PDGs.push_back(210551);
+  m_PDGs.push_back(220553);
+  m_PDGs.push_back(200555);
+  m_PDGs.push_back(30553);
+  m_PDGs.push_back(20555);
+
+  m_PDGs.push_back(557);
+  m_PDGs.push_back(130553);
+  m_PDGs.push_back(120555);
+  m_PDGs.push_back(100557);
+  m_PDGs.push_back(110553);
+  m_PDGs.push_back(210553);
+  m_PDGs.push_back(10555);
+  m_PDGs.push_back(110555);
+
+  m_PDGs.push_back(4122);
+  m_PDGs.push_back(4132);
   // m_PDGs.push_back( 84 ); // obsolete
-  m_PDGs.push_back( 4112 );
-  m_PDGs.push_back( 4212 );
-  m_PDGs.push_back( 4232 );
-  m_PDGs.push_back( 4222 );
-  m_PDGs.push_back( 4322 );
-  m_PDGs.push_back( 4312 );
-  
-  m_PDGs.push_back( 13122 );
-  m_PDGs.push_back( 13124 );
-  m_PDGs.push_back( 23122 );
-  m_PDGs.push_back( 33122 );
-  m_PDGs.push_back( 43122 );
-  m_PDGs.push_back( 53122 );
-  m_PDGs.push_back( 13126 );
-  m_PDGs.push_back( 13212 );
+  m_PDGs.push_back(4112);
+  m_PDGs.push_back(4212);
+  m_PDGs.push_back(4232);
+  m_PDGs.push_back(4222);
+  m_PDGs.push_back(4322);
+  m_PDGs.push_back(4312);
+
+  m_PDGs.push_back(13122);
+  m_PDGs.push_back(13124);
+  m_PDGs.push_back(23122);
+  m_PDGs.push_back(33122);
+  m_PDGs.push_back(43122);
+  m_PDGs.push_back(53122);
+  m_PDGs.push_back(13126);
+  m_PDGs.push_back(13212);
   //m_PDGs.push_back( 13241 ); unknown particle -typo?
-  
-  m_PDGs.push_back( 3126 );
-  m_PDGs.push_back( 3124 );
-  m_PDGs.push_back( 3122 );
-  m_PDGs.push_back( 3222 );
-  m_PDGs.push_back( 2214 );
-  m_PDGs.push_back( 2224 );
-  m_PDGs.push_back( 3324 );
-  m_PDGs.push_back( 2114 );
-  m_PDGs.push_back( 1114 );
-  m_PDGs.push_back( 3112 );
-  m_PDGs.push_back( 3212 );
-  m_PDGs.push_back( 3114 );
-  m_PDGs.push_back( 3224 );
-  m_PDGs.push_back( 3214 );
-  m_PDGs.push_back( 3216 );
-  m_PDGs.push_back( 3322 );
-  m_PDGs.push_back( 3312 );
-  m_PDGs.push_back( 3314 );
-  m_PDGs.push_back( 3334 );
-  
-  m_PDGs.push_back( 4114 );
-  m_PDGs.push_back( 4214 );
-  m_PDGs.push_back( 4224 );
-  m_PDGs.push_back( 4314 );
-  m_PDGs.push_back( 4324 );
-  m_PDGs.push_back( 4332 );
-  m_PDGs.push_back( 4334 );
+
+  m_PDGs.push_back(3126);
+  m_PDGs.push_back(3124);
+  m_PDGs.push_back(3122);
+  m_PDGs.push_back(3222);
+  m_PDGs.push_back(2214);
+  m_PDGs.push_back(2224);
+  m_PDGs.push_back(3324);
+  m_PDGs.push_back(2114);
+  m_PDGs.push_back(1114);
+  m_PDGs.push_back(3112);
+  m_PDGs.push_back(3212);
+  m_PDGs.push_back(3114);
+  m_PDGs.push_back(3224);
+  m_PDGs.push_back(3214);
+  m_PDGs.push_back(3216);
+  m_PDGs.push_back(3322);
+  m_PDGs.push_back(3312);
+  m_PDGs.push_back(3314);
+  m_PDGs.push_back(3334);
+
+  m_PDGs.push_back(4114);
+  m_PDGs.push_back(4214);
+  m_PDGs.push_back(4224);
+  m_PDGs.push_back(4314);
+  m_PDGs.push_back(4324);
+  m_PDGs.push_back(4332);
+  m_PDGs.push_back(4334);
   //m_PDGs.push_back( 43 ); // obsolete (?)
   //m_PDGs.push_back( 44 ); // obsolete (?)
-  m_PDGs.push_back( 10443 );
-  
-  m_PDGs.push_back( 5122 );
-  m_PDGs.push_back( 5132 );
-  m_PDGs.push_back( 5232 );
-  m_PDGs.push_back( 5332 );
-  m_PDGs.push_back( 5222 );
-  m_PDGs.push_back( 5112 );
-  m_PDGs.push_back( 5212 );
-  m_PDGs.push_back( 541 );
-  m_PDGs.push_back( 14122 );
-  m_PDGs.push_back( 14124 );
-  m_PDGs.push_back( 5312 );
-  m_PDGs.push_back( 5322 );
-  m_PDGs.push_back( 10521 );
-  m_PDGs.push_back( 20523 );
-  m_PDGs.push_back( 10523 );
-  
-  m_PDGs.push_back( 525 );
-  m_PDGs.push_back( 10511 );
-  m_PDGs.push_back( 20513 );
-  m_PDGs.push_back( 10513 );
-  m_PDGs.push_back( 515 );
-  m_PDGs.push_back( 10531 );
-  m_PDGs.push_back( 20533 );
-  m_PDGs.push_back( 10533 );
-  m_PDGs.push_back( 535 );
-  m_PDGs.push_back( 543 );
-  m_PDGs.push_back( 545 );
-  m_PDGs.push_back( 5114 );
-  m_PDGs.push_back( 5224 );
-  m_PDGs.push_back( 5214 );
-  m_PDGs.push_back( 5314 );
-  m_PDGs.push_back( 5324 );
-  m_PDGs.push_back( 5334 );
-  m_PDGs.push_back( 10541 );
-  m_PDGs.push_back( 10543 );
-  m_PDGs.push_back( 20543 );
-  
-  m_PDGs.push_back( 4424 );
-  m_PDGs.push_back( 4422 );
-  m_PDGs.push_back( 4414 );
-  m_PDGs.push_back( 4412 );
-  m_PDGs.push_back( 4432 );
-  m_PDGs.push_back( 4434 );
-  
-  m_PDGs.push_back( 130 );
+  m_PDGs.push_back(10443);
 
+  m_PDGs.push_back(5122);
+  m_PDGs.push_back(5132);
+  m_PDGs.push_back(5232);
+  m_PDGs.push_back(5332);
+  m_PDGs.push_back(5222);
+  m_PDGs.push_back(5112);
+  m_PDGs.push_back(5212);
+  m_PDGs.push_back(541);
+  m_PDGs.push_back(14122);
+  m_PDGs.push_back(14124);
+  m_PDGs.push_back(5312);
+  m_PDGs.push_back(5322);
+  m_PDGs.push_back(10521);
+  m_PDGs.push_back(20523);
+  m_PDGs.push_back(10523);
 
-  for(unsigned int i=0; i<m_PDGs.size();i++){
-    int pdt=HepPID::translatePythiatoPDT (m_PDGs.at(i));
-    if(pdt!=m_PDGs.at(i))m_PDGs.at(i)=pdt;
+  m_PDGs.push_back(525);
+  m_PDGs.push_back(10511);
+  m_PDGs.push_back(20513);
+  m_PDGs.push_back(10513);
+  m_PDGs.push_back(515);
+  m_PDGs.push_back(10531);
+  m_PDGs.push_back(20533);
+  m_PDGs.push_back(10533);
+  m_PDGs.push_back(535);
+  m_PDGs.push_back(543);
+  m_PDGs.push_back(545);
+  m_PDGs.push_back(5114);
+  m_PDGs.push_back(5224);
+  m_PDGs.push_back(5214);
+  m_PDGs.push_back(5314);
+  m_PDGs.push_back(5324);
+  m_PDGs.push_back(5334);
+  m_PDGs.push_back(10541);
+  m_PDGs.push_back(10543);
+  m_PDGs.push_back(20543);
+
+  m_PDGs.push_back(4424);
+  m_PDGs.push_back(4422);
+  m_PDGs.push_back(4414);
+  m_PDGs.push_back(4412);
+  m_PDGs.push_back(4432);
+  m_PDGs.push_back(4434);
+
+  m_PDGs.push_back(130);
+
+  for (unsigned int i = 0; i < m_PDGs.size(); i++) {
+    int pdt = HepPID::translatePythiatoPDT(m_PDGs.at(i));
+    if (pdt != m_PDGs.at(i))
+      m_PDGs.at(i) = pdt;
   }
 }
 
-EvtGenInterface::~EvtGenInterface(){
-}
+EvtGenInterface::~EvtGenInterface() {}
 
-void EvtGenInterface::init(){
+void EvtGenInterface::init() {
   // flags for pythia8
   fSpecialSettings.push_back("Pythia8:ParticleDecays:mixB = off");
   //
@@ -298,69 +297,74 @@ void EvtGenInterface::init(){
   edm::FileInPath decay_table(fPSet->getParameter<std::string>("decay_table"));
   edm::FileInPath pdt(fPSet->getParameter<edm::FileInPath>("particle_property_file"));
 
-  bool usePythia = fPSet->getUntrackedParameter<bool>("use_internal_pythia",true);
-  bool useTauola = fPSet->getUntrackedParameter<bool>("use_internal_tauola",true);
-  bool usePhotos = fPSet->getUntrackedParameter<bool>("use_internal_photos",true);
+  bool usePythia = fPSet->getUntrackedParameter<bool>("use_internal_pythia", true);
+  bool useTauola = fPSet->getUntrackedParameter<bool>("use_internal_tauola", true);
+  bool usePhotos = fPSet->getUntrackedParameter<bool>("use_internal_photos", true);
 
-  //Setup evtGen following instructions on http://evtgen.warwick.ac.uk/docs/external/ 
-  bool convertPythiaCodes=fPSet->getUntrackedParameter<bool>("convertPythiaCodes",true); // Specify if we want to use Pythia 6 physics codes for decays
-  std::string pythiaDir = getenv ("PYTHIA8DATA"); // Specify the pythia xml data directory to use the default PYTHIA8DATA location
-  if(pythiaDir.empty()){
-    edm::LogError("EvtGenInterface::~EvtGenInterface") << "EvtGenInterface::init() PYTHIA8DATA not defined. Terminating program "; 
+  //Setup evtGen following instructions on http://evtgen.warwick.ac.uk/docs/external/
+  bool convertPythiaCodes = fPSet->getUntrackedParameter<bool>(
+      "convertPythiaCodes", true);  // Specify if we want to use Pythia 6 physics codes for decays
+  std::string pythiaDir =
+      getenv("PYTHIA8DATA");  // Specify the pythia xml data directory to use the default PYTHIA8DATA location
+  if (pythiaDir.empty()) {
+    edm::LogError("EvtGenInterface::~EvtGenInterface")
+        << "EvtGenInterface::init() PYTHIA8DATA not defined. Terminating program ";
     exit(0);
   }
-  std::string photonType("gamma");                // Specify the photon type for Photos
-  bool useEvtGenRandom(true);                     // Specify if we want to use the EvtGen random number engine for these generators
-  
+  std::string photonType("gamma");  // Specify the photon type for Photos
+  bool useEvtGenRandom(true);       // Specify if we want to use the EvtGen random number engine for these generators
+
   // Set up the default external generator list: Photos, Pythia and/or Tauola
   EvtExternalGenList genList(convertPythiaCodes, pythiaDir, photonType, useEvtGenRandom);
-  EvtAbsRadCorr* radCorrEngine=nullptr; 
-  if(usePhotos) radCorrEngine = genList.getPhotosModel(); // Get interface to radiative correction engine
-  std::list<EvtDecayBase*> extraModels = genList.getListOfModels(); // get interface to Pythia and Tauola
+  EvtAbsRadCorr* radCorrEngine = nullptr;
+  if (usePhotos)
+    radCorrEngine = genList.getPhotosModel();                        // Get interface to radiative correction engine
+  std::list<EvtDecayBase*> extraModels = genList.getListOfModels();  // get interface to Pythia and Tauola
   std::list<EvtDecayBase*> myExtraModels;
-  for(unsigned int i=0; i<extraModels.size();i++){
+  for (unsigned int i = 0; i < extraModels.size(); i++) {
     std::list<EvtDecayBase*>::iterator it = extraModels.begin();
-    std::advance(it,i);
-    TString name=(*it)->getName();
-    if(name.Contains("PYTHIA") && usePythia) myExtraModels.push_back(*it);
-    if(name.Contains("TAUOLA") && useTauola) myExtraModels.push_back(*it);
+    std::advance(it, i);
+    TString name = (*it)->getName();
+    if (name.Contains("PYTHIA") && usePythia)
+      myExtraModels.push_back(*it);
+    if (name.Contains("TAUOLA") && useTauola)
+      myExtraModels.push_back(*it);
   }
 
   //Set up user evtgen models
-  
-  EvtModelUserReg userList; 
-  std::list<EvtDecayBase*> userModels = userList.getUserModels(); // get interface to user models
-  for(unsigned int i=0; i<userModels.size();i++){
+
+  EvtModelUserReg userList;
+  std::list<EvtDecayBase*> userModels = userList.getUserModels();  // get interface to user models
+  for (unsigned int i = 0; i < userModels.size(); i++) {
     std::list<EvtDecayBase*>::iterator it = userModels.begin();
-    std::advance(it,i);
-    TString name=(*it)->getName();
-    edm::LogInfo("EvtGenInterface::~EvtGenInterface") << "Adding user model: "<<name;
+    std::advance(it, i);
+    TString name = (*it)->getName();
+    edm::LogInfo("EvtGenInterface::~EvtGenInterface") << "Adding user model: " << name;
     myExtraModels.push_back(*it);
   }
-  
 
-  
   // Set up the incoherent (1) or coherent (0) B mixing option
-  BmixingOption = fPSet->getUntrackedParameter<int>("B_Mixing",1);
-  if(BmixingOption!=0 && BmixingOption!=1){
-   throw cms::Exception("Configuration") << "EvtGenProducer requires B_Mixing to be 0 (coherent) or 1 (incoherent) \n"
-     "Please fix this in your configuration.";
+  BmixingOption = fPSet->getUntrackedParameter<int>("B_Mixing", 1);
+  if (BmixingOption != 0 && BmixingOption != 1) {
+    throw cms::Exception("Configuration") << "EvtGenProducer requires B_Mixing to be 0 (coherent) or 1 (incoherent) \n"
+                                             "Please fix this in your configuration.";
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Create the EvtGen generator object, passing the external generators
-  m_EvtGen = new EvtGen(decay_table.fullPath().c_str(),pdt.fullPath().c_str(),the_engine,radCorrEngine,&myExtraModels,BmixingOption);
-  
+  m_EvtGen = new EvtGen(
+      decay_table.fullPath().c_str(), pdt.fullPath().c_str(), the_engine, radCorrEngine, &myExtraModels, BmixingOption);
+
   // Add additional user information
-  if (fPSet->exists("user_decay_file")){
+  if (fPSet->exists("user_decay_file")) {
     std::vector<std::string> user_decays = fPSet->getParameter<std::vector<std::string> >("user_decay_file");
-    for(unsigned int i=0;i<user_decays.size();i++){
-      edm::FileInPath user_decay(user_decays.at(i)); 
+    for (unsigned int i = 0; i < user_decays.size(); i++) {
+      edm::FileInPath user_decay(user_decays.at(i));
       m_EvtGen->readUDecay(user_decay.fullPath().c_str());
     }
   }
 
-  if (fPSet->exists("user_decay_embedded")){
+  if (fPSet->exists("user_decay_embedded")) {
     std::vector<std::string> user_decay_lines = fPSet->getParameter<std::vector<std::string> >("user_decay_embedded");
     auto tmp_dir = boost::filesystem::temp_directory_path();
     tmp_dir += "/%%%%-%%%%-%%%%-%%%%";
@@ -368,162 +372,188 @@ void EvtGenInterface::init(){
     std::string user_decay_tmp = std::string(tmp_path.c_str());
     FILE* tmpf = std::fopen(user_decay_tmp.c_str(), "w");
     if (!tmpf) {
-        edm::LogError("EvtGenInterface::~EvtGenInterface") << "EvtGenInterface::init() fails when trying to open a temporary file for embedded user.dec. Terminating program ";
-        exit(0);
+      edm::LogError("EvtGenInterface::~EvtGenInterface")
+          << "EvtGenInterface::init() fails when trying to open a temporary file for embedded user.dec. Terminating "
+             "program ";
+      exit(0);
     }
-    for (unsigned int i=0; i<user_decay_lines.size(); i++) {
-        user_decay_lines.at(i) += "\n";
-        std::fputs(user_decay_lines.at(i).c_str(), tmpf);
+    for (unsigned int i = 0; i < user_decay_lines.size(); i++) {
+      user_decay_lines.at(i) += "\n";
+      std::fputs(user_decay_lines.at(i).c_str(), tmpf);
     }
     std::fclose(tmpf);
     m_EvtGen->readUDecay(user_decay_tmp.c_str());
   }
 
   // setup pdgid which the generator/hadronizer should not decay
-  if (fPSet->exists("operates_on_particles")){
-    std::vector<int> tmpPIDs = fPSet->getParameter< std::vector<int> >("operates_on_particles");
+  if (fPSet->exists("operates_on_particles")) {
+    std::vector<int> tmpPIDs = fPSet->getParameter<std::vector<int> >("operates_on_particles");
     m_PDGs.clear();
-    bool goodinput=false;
-    if(!tmpPIDs.empty()){ if(tmpPIDs.size()==1 && tmpPIDs[0]==0) goodinput=false;
-                          else goodinput=true;
-                        }
-    else{goodinput=false;}
-    if(goodinput) m_PDGs = tmpPIDs;
-    else SetDefault_m_PDGs();
-  }
-  else SetDefault_m_PDGs();
+    bool goodinput = false;
+    if (!tmpPIDs.empty()) {
+      if (tmpPIDs.size() == 1 && tmpPIDs[0] == 0)
+        goodinput = false;
+      else
+        goodinput = true;
+    } else {
+      goodinput = false;
+    }
+    if (goodinput)
+      m_PDGs = tmpPIDs;
+    else
+      SetDefault_m_PDGs();
+  } else
+    SetDefault_m_PDGs();
 
-  for(unsigned int i=0;i<m_PDGs.size();i++){
-    edm::LogInfo("EvtGenInterface::~EvtGenInterface") << "EvtGenInterface::init() Particles to Operate on: " << m_PDGs[i];
+  for (unsigned int i = 0; i < m_PDGs.size(); i++) {
+    edm::LogInfo("EvtGenInterface::~EvtGenInterface")
+        << "EvtGenInterface::init() Particles to Operate on: " << m_PDGs[i];
   }
 
-  // Obtain information to set polarization of particles 
-  polarize_ids = fPSet->getUntrackedParameter<std::vector<int> >("particles_to_polarize",std::vector<int>());
-  polarize_pol = fPSet->getUntrackedParameter<std::vector<double> >("particle_polarizations",std::vector<double>());
+  // Obtain information to set polarization of particles
+  polarize_ids = fPSet->getUntrackedParameter<std::vector<int> >("particles_to_polarize", std::vector<int>());
+  polarize_pol = fPSet->getUntrackedParameter<std::vector<double> >("particle_polarizations", std::vector<double>());
   if (polarize_ids.size() != polarize_pol.size()) {
-    throw cms::Exception("Configuration") << "EvtGenProducer requires that the particles_to_polarize and particle_polarization\n"
-      "vectors be the same size.  Please fix this in your configuration.";
+    throw cms::Exception("Configuration")
+        << "EvtGenProducer requires that the particles_to_polarize and particle_polarization\n"
+           "vectors be the same size.  Please fix this in your configuration.";
   }
   for (unsigned int ndx = 0; ndx < polarize_ids.size(); ndx++) {
     if (polarize_pol[ndx] < -1. || polarize_pol[ndx] > 1.) {
-      throw cms::Exception("Configuration") << "EvtGenProducer error: particle polarizations must be in the range -1 < P < 1";
+      throw cms::Exception("Configuration")
+          << "EvtGenProducer error: particle polarizations must be in the range -1 < P < 1";
     }
     polarizations.insert(std::pair<int, float>(polarize_ids[ndx], polarize_pol[ndx]));
   }
 
   // Forced decays are particles that are aliased and forced to be decayed by EvtGen
-  if (fPSet->exists("list_forced_decays")){
-    std::vector<std::string> forced_names = fPSet->getParameter< std::vector<std::string> >("list_forced_decays");
-    for(unsigned int i=0;i<forced_names.size();i++){
+  if (fPSet->exists("list_forced_decays")) {
+    std::vector<std::string> forced_names = fPSet->getParameter<std::vector<std::string> >("list_forced_decays");
+    for (unsigned int i = 0; i < forced_names.size(); i++) {
       EvtId found = EvtPDL::getId(forced_names[i]);
-      if(found.getId() == -1) throw cms::Exception("Configuration") << "name in part list for ignored decays not found: " << forced_names[i];
-      if(found.getId() == found.getAlias()) throw cms::Exception("Configuration") << "name of ignored decays is not an alias: " << forced_names[i];
+      if (found.getId() == -1)
+        throw cms::Exception("Configuration") << "name in part list for ignored decays not found: " << forced_names[i];
+      if (found.getId() == found.getAlias())
+        throw cms::Exception("Configuration") << "name of ignored decays is not an alias: " << forced_names[i];
       forced_id.push_back(found);
-      forced_pdgids.push_back(EvtPDL::getStdHep(found));   // force_pdgids is the list of stdhep codes
+      forced_pdgids.push_back(EvtPDL::getStdHep(found));  // force_pdgids is the list of stdhep codes
     }
   }
-  edm::LogInfo("EvtGenInterface::~EvtGenInterface") << "Number of Forced Paricles is: " << forced_pdgids.size() << std::endl;
-  for(unsigned int j=0;j<forced_id.size();j++){
-    edm::LogInfo("EvtGenInterface::~EvtGenInterface") << "Forced Paricles are: " << forced_pdgids.at(j) << " " << forced_id.at(j) << std::endl;
+  edm::LogInfo("EvtGenInterface::~EvtGenInterface")
+      << "Number of Forced Paricles is: " << forced_pdgids.size() << std::endl;
+  for (unsigned int j = 0; j < forced_id.size(); j++) {
+    edm::LogInfo("EvtGenInterface::~EvtGenInterface")
+        << "Forced Paricles are: " << forced_pdgids.at(j) << " " << forced_id.at(j) << std::endl;
   }
   // Ignore decays are particles that are not to be decayed by EvtGen
-  if (fPSet->exists("list_ignored_pdgids")){
-    ignore_pdgids = fPSet->getUntrackedParameter< std::vector<int> >("list_ignored_pdgids");
+  if (fPSet->exists("list_ignored_pdgids")) {
+    ignore_pdgids = fPSet->getUntrackedParameter<std::vector<int> >("list_ignored_pdgids");
   }
 
   return;
 }
 
-HepMC::GenEvent* EvtGenInterface::decay( HepMC::GenEvent* evt ){
-  if(the_engine->engine() == nullptr){
+HepMC::GenEvent* EvtGenInterface::decay(HepMC::GenEvent* evt) {
+  if (the_engine->engine() == nullptr) {
     throw edm::Exception(edm::errors::LogicError)
-      << "The EvtGen code attempted to use a random number engine while\n"
-      << "the engine pointer was null in EvtGenInterface::decay. This might\n"
-      << "mean that the code was modified to generate a random number outside\n"
-      << "the event and beginLuminosityBlock methods, which is not allowed.\n";
+        << "The EvtGen code attempted to use a random number engine while\n"
+        << "the engine pointer was null in EvtGenInterface::decay. This might\n"
+        << "mean that the code was modified to generate a random number outside\n"
+        << "the event and beginLuminosityBlock methods, which is not allowed.\n";
   }
   CLHEP::RandFlat m_flat(*the_engine->engine(), 0., 1.);
 
   // decay all request unforced particles and store the forced decays to later decay one per event
-  unsigned int nisforced=0;
+  unsigned int nisforced = 0;
   std::vector<std::vector<HepMC::GenParticle*> > forcedparticles;
-  for(unsigned int i=0;i<forced_pdgids.size();i++) forcedparticles.push_back(std::vector<HepMC::GenParticle*>());
+  for (unsigned int i = 0; i < forced_pdgids.size(); i++)
+    forcedparticles.push_back(std::vector<HepMC::GenParticle*>());
 
   // notice this is a dynamic loop
-  for (HepMC::GenEvent::particle_const_iterator p= evt->particles_begin(); p != evt->particles_end(); ++p){
-    if((*p)->status()==1){                                // all particles to be decays are set to status 1 by generator.hadronizer
+  for (HepMC::GenEvent::particle_const_iterator p = evt->particles_begin(); p != evt->particles_end(); ++p) {
+    if ((*p)->status() == 1) {  // all particles to be decays are set to status 1 by generator.hadronizer
       int idHep = (*p)->pdg_id();
-      bool isignore=false;
-      for(unsigned int i=0;i<ignore_pdgids.size();i++){
-	if(idHep==ignore_pdgids[i])isignore=true;
+      bool isignore = false;
+      for (unsigned int i = 0; i < ignore_pdgids.size(); i++) {
+        if (idHep == ignore_pdgids[i])
+          isignore = true;
       }
-      if (!isignore){
-        bool isforced=false;
-	for(unsigned int i=0;i<forced_pdgids.size();i++){
-          if(idHep==forced_pdgids[i]){
-            forcedparticles.at(i).push_back(*p);      // storing and counting forced decays.
+      if (!isignore) {
+        bool isforced = false;
+        for (unsigned int i = 0; i < forced_pdgids.size(); i++) {
+          if (idHep == forced_pdgids[i]) {
+            forcedparticles.at(i).push_back(*p);  // storing and counting forced decays.
             nisforced++;
-            isforced=true;
+            isforced = true;
             break;
           }
         }
-        bool isDefaultEvtGen=false;
-	for(unsigned int i=0;i<m_PDGs.size();i++){
-	  if(abs(idHep)==abs(m_PDGs[i])){
-	    isDefaultEvtGen=true;
-	    break;
-	  }
-	}
+        bool isDefaultEvtGen = false;
+        for (unsigned int i = 0; i < m_PDGs.size(); i++) {
+          if (abs(idHep) == abs(m_PDGs[i])) {
+            isDefaultEvtGen = true;
+            break;
+          }
+        }
         EvtId idEvt = EvtPDL::evtIdFromStdHep(idHep);
-	int ipart = idEvt.getId();
-	EvtDecayTable *evtDecayTable=EvtDecayTable::getInstance();
-	if(!isforced && isDefaultEvtGen && ipart!=-1 && evtDecayTable->getNMode(ipart)!=0){
-	  addToHepMC(*p,idEvt,evt,true);                // generate decay and remove daugther if they are forced
-	}
+        int ipart = idEvt.getId();
+        EvtDecayTable* evtDecayTable = EvtDecayTable::getInstance();
+        if (!isforced && isDefaultEvtGen && ipart != -1 && evtDecayTable->getNMode(ipart) != 0) {
+          addToHepMC(*p, idEvt, evt, true);  // generate decay and remove daugther if they are forced
+        }
       }
     }
   }
 
   // decay all forced particles (only 1/event is forced)... with no mixing allowed
-  unsigned int which = (unsigned int)(nisforced*flat());
-  if(which==nisforced && nisforced>0) which=nisforced-1;
+  unsigned int which = (unsigned int)(nisforced * flat());
+  if (which == nisforced && nisforced > 0)
+    which = nisforced - 1;
 
-  unsigned int idx=0;
-  for (unsigned int i=0; i<forcedparticles.size(); i++){
-    for (unsigned int j=0; j<forcedparticles.at(i).size(); j++){
-      EvtId idEvt = EvtPDL::evtIdFromStdHep(forcedparticles.at(i).at(j)->pdg_id()); // "standard" decay Id
-      if ( idx==which ) {
-        idEvt = forced_id[i];              // force decay Id
-        edm::LogInfo("EvtGenInterface::decay ") << EvtPDL::getStdHep(idEvt) << " will force to decay " << idx+1
-             << " out of " << nisforced  << std::endl;        
+  unsigned int idx = 0;
+  for (unsigned int i = 0; i < forcedparticles.size(); i++) {
+    for (unsigned int j = 0; j < forcedparticles.at(i).size(); j++) {
+      EvtId idEvt = EvtPDL::evtIdFromStdHep(forcedparticles.at(i).at(j)->pdg_id());  // "standard" decay Id
+      if (idx == which) {
+        idEvt = forced_id[i];  // force decay Id
+        edm::LogInfo("EvtGenInterface::decay ")
+            << EvtPDL::getStdHep(idEvt) << " will force to decay " << idx + 1 << " out of " << nisforced << std::endl;
       }
       bool decayed = false;
-      while(!decayed){decayed=addToHepMC(forcedparticles.at(i).at(j),idEvt,evt,false);} 
+      while (!decayed) {
+        decayed = addToHepMC(forcedparticles.at(i).at(j), idEvt, evt, false);
+      }
       idx++;
     }
   }
 
   // add code to ensure all particles have an end vertex and if they are undecayed with no end vertes set to status 1
-  for (HepMC::GenEvent::particle_const_iterator p= evt->particles_begin(); p != evt->particles_end(); ++p){
-    if((*p)->end_vertex() && (*p)->status() == 1)edm::LogWarning("EvtGenInterface::decay error: incorrect status!"); //(*p)->set_status(2);
-    if((*p)->end_vertex() && (*p)->end_vertex()->particles_out_size()==0) edm::LogWarning("EvtGenInterface::decay error: empty end vertex!");
-  } 
+  for (HepMC::GenEvent::particle_const_iterator p = evt->particles_begin(); p != evt->particles_end(); ++p) {
+    if ((*p)->end_vertex() && (*p)->status() == 1)
+      edm::LogWarning("EvtGenInterface::decay error: incorrect status!");  //(*p)->set_status(2);
+    if ((*p)->end_vertex() && (*p)->end_vertex()->particles_out_size() == 0)
+      edm::LogWarning("EvtGenInterface::decay error: empty end vertex!");
+  }
   return evt;
 }
 
 // Add particle to MC
-bool EvtGenInterface::addToHepMC(HepMC::GenParticle* partHep,const EvtId &idEvt, HepMC::GenEvent* theEvent, bool del_daug) {
-  // Set up the parent particle from the HepMC GenEvent tree. 
+bool EvtGenInterface::addToHepMC(HepMC::GenParticle* partHep,
+                                 const EvtId& idEvt,
+                                 HepMC::GenEvent* theEvent,
+                                 bool del_daug) {
+  // Set up the parent particle from the HepMC GenEvent tree.
   //EvtVector4R pInit(EvtPDL::getMass(idEvt),partHep->momentum().px(),partHep->momentum().py(),partHep->momentum().pz());
-  EvtVector4R pInit(partHep->momentum().e(),partHep->momentum().px(),partHep->momentum().py(),partHep->momentum().pz()); 
+  EvtVector4R pInit(
+      partHep->momentum().e(), partHep->momentum().px(), partHep->momentum().py(), partHep->momentum().pz());
   EvtParticle* parent = EvtParticleFactory::particleFactory(idEvt, pInit);
   HepMC::FourVector posHep = (partHep->production_vertex())->position();
-  EvtVector4R vInit(posHep.t(),posHep.x(),posHep.y(),posHep.z());
+  EvtVector4R vInit(posHep.t(), posHep.x(), posHep.y(), posHep.z());
   // Reset polarization if requested....
-  if(EvtPDL::getSpinType(idEvt) == EvtSpinType::DIRAC && polarizations.count(partHep->pdg_id())>0){
+  if (EvtPDL::getSpinType(idEvt) == EvtSpinType::DIRAC && polarizations.count(partHep->pdg_id()) > 0) {
     const HepMC::FourVector& momHep = partHep->momentum();
     EvtVector4R momEvt;
-    momEvt.set(momHep.t(),momHep.x(),momHep.y(),momHep.z());
+    momEvt.set(momHep.t(), momHep.x(), momHep.y(), momHep.z());
     // Particle is spin 1/2, so we can polarize it. Check polarizations map for particle, grab its polarization if it exists
     // and make the spin density matrix
     float pol = polarizations.find(partHep->pdg_id())->second;
@@ -533,50 +563,52 @@ bool EvtGenInterface::addToHepMC(HepMC::GenParticle* partHep,const EvtId &idEvt,
     GlobalVector polVec = pol * zCrossP.unit();
     EvtSpinDensity theSpinDensity;
     theSpinDensity.setDim(2);
-    theSpinDensity.set(0, 0, EvtComplex(1./2. + polVec.z()/2., 0.));
-    theSpinDensity.set(0, 1, EvtComplex(polVec.x()/2., -polVec.y()/2.));
-    theSpinDensity.set(1, 0, EvtComplex(polVec.x()/2., polVec.y()/2.));
-    theSpinDensity.set(1, 1, EvtComplex(1./2. - polVec.z()/2., 0.));
+    theSpinDensity.set(0, 0, EvtComplex(1. / 2. + polVec.z() / 2., 0.));
+    theSpinDensity.set(0, 1, EvtComplex(polVec.x() / 2., -polVec.y() / 2.));
+    theSpinDensity.set(1, 0, EvtComplex(polVec.x() / 2., polVec.y() / 2.));
+    theSpinDensity.set(1, 1, EvtComplex(1. / 2. - polVec.z() / 2., 0.));
     parent->setSpinDensityForwardHelicityBasis(theSpinDensity);
   }
-  if(parent){
+  if (parent) {
     // Generate the event
-     m_EvtGen->generateDecay(parent);
-     if (del_daug) go_through_daughters(parent);  // will delete all daugthers which are listed as forced, to allow decay them later 
+    m_EvtGen->generateDecay(parent);
+    if (del_daug)
+      go_through_daughters(parent);  // will delete all daugthers which are listed as forced, to allow decay them later
 
     // create HepMCTree
     EvtHepMCEvent evtHepMCEvent;
-    evtHepMCEvent.constructEvent(parent,vInit);
+    evtHepMCEvent.constructEvent(parent, vInit);
     HepMC::GenEvent* evtGenHepMCTree = evtHepMCEvent.getEvent();
     parent->deleteTree();
 
     // update the event using a recursive function
-    if(!evtGenHepMCTree->particles_empty()) update_particles(partHep,theEvent,(*evtGenHepMCTree->particles_begin()));
+    if (!evtGenHepMCTree->particles_empty())
+      update_particles(partHep, theEvent, (*evtGenHepMCTree->particles_begin()));
 
   } else {
     // this should never hapend, in such case, speak out.
     return false;
   }
   return true;
-}        
+}
 
 //Recursivley add EvtGen decay to to Event Decy tree
-void EvtGenInterface::update_particles(HepMC::GenParticle* partHep,HepMC::GenEvent* theEvent,HepMC::GenParticle* p){
-  if(p->end_vertex()){
-    if(!partHep->end_vertex()){
+void EvtGenInterface::update_particles(HepMC::GenParticle* partHep, HepMC::GenEvent* theEvent, HepMC::GenParticle* p) {
+  if (p->end_vertex()) {
+    if (!partHep->end_vertex()) {
       HepMC::GenVertex* vtx = new HepMC::GenVertex(p->end_vertex()->position());
       theEvent->add_vertex(vtx);
       vtx->add_particle_in(partHep);
     }
-    if ( p->end_vertex()->particles_out_size()!=0 ){
-      
-      for ( HepMC::GenVertex::particles_out_const_iterator d=p->end_vertex()->particles_out_const_begin(); 
-            d!=p->end_vertex()->particles_out_const_end();d++ ){
-
-	  HepMC::GenParticle *daughter = new HepMC::GenParticle((*d)->momentum(),(*d)->pdg_id(),(*d)->status());
-          daughter->suggest_barcode(theEvent->particles_size()+1);
-          partHep->end_vertex()->add_particle_out(daughter);
-	  if((*d)->end_vertex()) update_particles(daughter,theEvent,(*d)); // if daugthers add them as well
+    if (p->end_vertex()->particles_out_size() != 0) {
+      for (HepMC::GenVertex::particles_out_const_iterator d = p->end_vertex()->particles_out_const_begin();
+           d != p->end_vertex()->particles_out_const_end();
+           d++) {
+        HepMC::GenParticle* daughter = new HepMC::GenParticle((*d)->momentum(), (*d)->pdg_id(), (*d)->status());
+        daughter->suggest_barcode(theEvent->particles_size() + 1);
+        partHep->end_vertex()->add_particle_out(daughter);
+        if ((*d)->end_vertex())
+          update_particles(daughter, theEvent, (*d));  // if daugthers add them as well
       }
       partHep->set_status(p->status());
     }
@@ -585,38 +617,39 @@ void EvtGenInterface::update_particles(HepMC::GenParticle* partHep,HepMC::GenEve
 
 void EvtGenInterface::setRandomEngine(CLHEP::HepRandomEngine* v) {
   the_engine->setRandomEngine(v);
-  fRandomEngine=v;
+  fRandomEngine = v;
 }
 
-double EvtGenInterface::flat(){
-  if ( !fRandomEngine ) {
+double EvtGenInterface::flat() {
+  if (!fRandomEngine) {
     throw cms::Exception("LogicError")
-      << "EvtGenInterface::flat: Attempt to generate random number when engine pointer is null\n"
-      << "This might mean that the code was modified to generate a random number outside the\n"
-      << "event and beginLuminosityBlock methods, which is not allowed.\n";
+        << "EvtGenInterface::flat: Attempt to generate random number when engine pointer is null\n"
+        << "This might mean that the code was modified to generate a random number outside the\n"
+        << "event and beginLuminosityBlock methods, which is not allowed.\n";
   }
   return fRandomEngine->flat();
 }
 
-
-bool EvtGenInterface::findLastinChain(HepMC::GenParticle* &p){
-  if(p->end_vertex()){
-    if(p->end_vertex()->particles_out_size()!=0){
-      for(HepMC::GenVertex::particles_out_const_iterator d=p->end_vertex()->particles_out_const_begin(); d!=p->end_vertex()->particles_out_const_end();d++){
-	if(abs((*d)->pdg_id())==abs(p->pdg_id())){
-	  p=*d;
-	  findLastinChain(p);
-	  return false;
-	}
+bool EvtGenInterface::findLastinChain(HepMC::GenParticle*& p) {
+  if (p->end_vertex()) {
+    if (p->end_vertex()->particles_out_size() != 0) {
+      for (HepMC::GenVertex::particles_out_const_iterator d = p->end_vertex()->particles_out_const_begin();
+           d != p->end_vertex()->particles_out_const_end();
+           d++) {
+        if (abs((*d)->pdg_id()) == abs(p->pdg_id())) {
+          p = *d;
+          findLastinChain(p);
+          return false;
+        }
       }
     }
   }
   return true;
 }
 
-bool EvtGenInterface::hasnoDaughter(HepMC::GenParticle* p){
-  if(p->end_vertex()){
-    if(p->end_vertex()->particles_out_size()!=0){
+bool EvtGenInterface::hasnoDaughter(HepMC::GenParticle* p) {
+  if (p->end_vertex()) {
+    if (p->end_vertex()->particles_out_size() != 0) {
       return false;
     }
   }
@@ -624,23 +657,24 @@ bool EvtGenInterface::hasnoDaughter(HepMC::GenParticle* p){
 }
 
 void EvtGenInterface::go_through_daughters(EvtParticle* part) {
-  int NDaug=part->getNDaug();
+  int NDaug = part->getNDaug();
   if (NDaug) {
-      EvtParticle* Daughter;
-      for (int i=0;i<NDaug;i++)	{
-	  Daughter=part->getDaug(i);
-          int idHep = Daughter->getPDGId();
-	  int found=0;
-          for (unsigned int j=0;j<forced_pdgids.size();j++) {
-              if (idHep == forced_pdgids[j]) {
-                 found = 1;
-                 Daughter->deleteDaughters();
-                 break;
-              }
-          }
-	  if (!found) go_through_daughters(Daughter);
-	}
+    EvtParticle* Daughter;
+    for (int i = 0; i < NDaug; i++) {
+      Daughter = part->getDaug(i);
+      int idHep = Daughter->getPDGId();
+      int found = 0;
+      for (unsigned int j = 0; j < forced_pdgids.size(); j++) {
+        if (idHep == forced_pdgids[j]) {
+          found = 1;
+          Daughter->deleteDaughters();
+          break;
+        }
+      }
+      if (!found)
+        go_through_daughters(Daughter);
     }
+  }
 }
 
 DEFINE_EDM_PLUGIN(EvtGenFactory, gen::EvtGenInterface, "EvtGen130");

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.h
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGen/EvtGenInterface.h
@@ -7,7 +7,6 @@
 // I would like to thank the EvtGen developers, in particular John Black, and Mikhail Kirsanov for their assistance.
 //
 
-
 #ifndef gen_EvtGenInterface_h
 #define gen_EvtGenInterface_h
 
@@ -29,48 +28,48 @@ class myEvtRandomEngine;
 namespace HepMC {
   class GenParticle;
   class GenEvent;
-}				
+}  // namespace HepMC
 
-class EvtId; 
+class EvtId;
 class EvtGen;
 
 namespace gen {
-   class EvtGenInterface : public EvtGenInterfaceBase {
-     public:
+  class EvtGenInterface : public EvtGenInterfaceBase {
+  public:
     // ctor & dtor
-    EvtGenInterface( const edm::ParameterSet& );
+    EvtGenInterface(const edm::ParameterSet&);
     ~EvtGenInterface() override;
-    
+
     void init() override;
-    const std::vector<int>& operatesOnParticles() override { return m_PDGs; }      
-    HepMC::GenEvent* decay( HepMC::GenEvent* ) override;
+    const std::vector<int>& operatesOnParticles() override { return m_PDGs; }
+    HepMC::GenEvent* decay(HepMC::GenEvent*) override;
     void setRandomEngine(CLHEP::HepRandomEngine* v) override;
     static double flat();
-    
+
   private:
-    bool addToHepMC(HepMC::GenParticle* partHep,const EvtId &idEvt, HepMC::GenEvent* theEvent, bool del_daug); 
-    void update_particles(HepMC::GenParticle* partHep,HepMC::GenEvent* theEvent,HepMC::GenParticle* p);
+    bool addToHepMC(HepMC::GenParticle* partHep, const EvtId& idEvt, HepMC::GenEvent* theEvent, bool del_daug);
+    void update_particles(HepMC::GenParticle* partHep, HepMC::GenEvent* theEvent, HepMC::GenParticle* p);
     void SetDefault_m_PDGs();
-    bool findLastinChain(HepMC::GenParticle* &p);    
+    bool findLastinChain(HepMC::GenParticle*& p);
     bool hasnoDaughter(HepMC::GenParticle* p);
     void go_through_daughters(EvtParticle* part);
 
-    EvtGen *m_EvtGen;                // EvtGen main  object
+    EvtGen* m_EvtGen;  // EvtGen main  object
 
-    std::vector<EvtId> forced_id;     // EvtGen Id's of particles  which are to be forced by EvtGen
-    std::vector<int> forced_pdgids;    // PDG Id's of particles which are to be forced by EvtGen
-    
+    std::vector<EvtId> forced_id;    // EvtGen Id's of particles  which are to be forced by EvtGen
+    std::vector<int> forced_pdgids;  // PDG Id's of particles which are to be forced by EvtGen
+
     std::vector<int> ignore_pdgids;  // HepId's of particles  which are to be ignroed by EvtGen
-    
+
     // Adding parameters for polarization of spin-1/2 particles
     std::vector<int> polarize_ids;
     std::vector<double> polarize_pol;
     std::map<int, float> polarizations;
-    int BmixingOption = 1;        
+    int BmixingOption = 1;
     edm::ParameterSet* fPSet;
 
     static CLHEP::HepRandomEngine* fRandomEngine;
     myEvtRandomEngine* the_engine;
   };
-}
+}  // namespace gen
 #endif

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtLb2plnuLCSR.cpp
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtLb2plnuLCSR.cpp
@@ -12,9 +12,9 @@
 // Module: EvtLb2plnuLCSR.cc
 //
 // Description: Routine to implement Lb->p l nu semileptonic decays using form factor
-//              predictions form Light Cone Sum Rules.  The form factors are from 
+//              predictions form Light Cone Sum Rules.  The form factors are from
 //              A. Khodjamirian, C. Klein, T. Mannel and Y.-M. Wang, arXiv.1108.2971 (2011)
-//              
+//
 //
 // Modification history:
 //
@@ -39,146 +39,119 @@ using namespace std;
 #ifdef D0
 #undef D0
 #endif
-EvtLb2plnuLCSR::EvtLb2plnuLCSR():
-  ffmodel(nullptr)
-  ,calcamp(nullptr)
-{}
-
+EvtLb2plnuLCSR::EvtLb2plnuLCSR() : ffmodel(nullptr), calcamp(nullptr) {}
 
 EvtLb2plnuLCSR::~EvtLb2plnuLCSR() {
   delete ffmodel;
-  ffmodel=nullptr;
+  ffmodel = nullptr;
   delete calcamp;
-  calcamp=nullptr;
+  calcamp = nullptr;
 }
 
-std::string EvtLb2plnuLCSR::getName(){
-  
-  return "Lb2plnuLCSR";     
-  
-}
+std::string EvtLb2plnuLCSR::getName() { return "Lb2plnuLCSR"; }
 
+EvtDecayBase* EvtLb2plnuLCSR::clone() { return new EvtLb2plnuLCSR; }
 
-
-EvtDecayBase* EvtLb2plnuLCSR::clone(){
-  
-  return new EvtLb2plnuLCSR;
-  
-}
-
-void EvtLb2plnuLCSR::decay( EvtParticle *p ){
-  
+void EvtLb2plnuLCSR::decay(EvtParticle* p) {
   //This is a kludge to avoid warnings because the K_2* mass becomes to large.
-  static EvtIdSet regenerateMasses("K_2*+","K_2*-","K_2*0","anti-K_2*0",
-				   "K_1+","K_1-","K_10","anti-K_10",
-				   "D'_1+","D'_1-","D'_10","anti-D'_10");
-  
-  if (regenerateMasses.contains(getDaug(0))){
+  static EvtIdSet regenerateMasses("K_2*+",
+                                   "K_2*-",
+                                   "K_2*0",
+                                   "anti-K_2*0",
+                                   "K_1+",
+                                   "K_1-",
+                                   "K_10",
+                                   "anti-K_10",
+                                   "D'_1+",
+                                   "D'_1-",
+                                   "D'_10",
+                                   "anti-D'_10");
+
+  if (regenerateMasses.contains(getDaug(0))) {
     p->resetFirstOrNot();
   }
-  
-  p->initializePhaseSpace(getNDaug(),getDaugs());
-  
-  EvtComplex r00(getArg(0), 0.0 );
-  EvtComplex r01(getArg(1), 0.0 );
-  EvtComplex r10(getArg(2), 0.0 );
-  EvtComplex r11(getArg(3), 0.0 );
 
-  calcamp->CalcAmp(p,_amp2,ffmodel, r00, r01, r10, r11);
-  
+  p->initializePhaseSpace(getNDaug(), getDaugs());
+
+  EvtComplex r00(getArg(0), 0.0);
+  EvtComplex r01(getArg(1), 0.0);
+  EvtComplex r10(getArg(2), 0.0);
+  EvtComplex r11(getArg(3), 0.0);
+
+  calcamp->CalcAmp(p, _amp2, ffmodel, r00, r01, r10, r11);
 }
 
 void EvtLb2plnuLCSR::initProbMax() {
+  static EvtId LAMB = EvtPDL::getId("Lambda_b0");
+  static EvtId LAMBB = EvtPDL::getId("anti-Lambda_b0");
+  static EvtId PRO = EvtPDL::getId("p+");
+  static EvtId PROB = EvtPDL::getId("anti-p-");
 
+  EvtId parnum, barnum;
 
-  static EvtId LAMB=EvtPDL::getId("Lambda_b0");
-  static EvtId LAMBB=EvtPDL::getId("anti-Lambda_b0");
-  static EvtId PRO=EvtPDL::getId("p+");
-  static EvtId PROB=EvtPDL::getId("anti-p-");
-  
-  EvtId parnum,barnum;
-  
   parnum = getParentId();
   barnum = getDaug(0);
 
-  if( (parnum==LAMB && barnum==PRO) || (parnum==LAMBB && barnum==PROB) ) 
-  {
-      setProbMax(22000.0);
-  }
-  else
-  {
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Decay does not have Lb->p setting ProbMax = 0 "
-			   <<endl;
+  if ((parnum == LAMB && barnum == PRO) || (parnum == LAMBB && barnum == PROB)) {
+    setProbMax(22000.0);
+  } else {
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Decay does not have Lb->p setting ProbMax = 0 " << endl;
     setProbMax(0.0);
   }
-  
 }
 
-void EvtLb2plnuLCSR::init(){
-  
-  if (getNArg()!=4) {
-
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "EvtLb2plnuLCSR generator expected "
-			   << " 4 arguments but found:"<<getNArg()<<endl;
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Will terminate execution!"<<endl;
+void EvtLb2plnuLCSR::init() {
+  if (getNArg() != 4) {
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "EvtLb2plnuLCSR generator expected "
+                                         << " 4 arguments but found:" << getNArg() << endl;
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Will terminate execution!" << endl;
     ::abort();
-
   }
 
-  if ( getNDaug()!=3 ) {
-     EvtGenReport(EVTGEN_ERROR,"EvtGen") 
-       << "Wrong number of daughters in EvtLb2plnu.cc " 
-       << " 3 daughters expected but found: "<<getNDaug()<<endl;
-     EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Will terminate execution!"<<endl;
-     ::abort();
+  if (getNDaug() != 3) {
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Wrong number of daughters in EvtLb2plnu.cc "
+                                         << " 3 daughters expected but found: " << getNDaug() << endl;
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Will terminate execution!" << endl;
+    ::abort();
   }
 
-
-  //We expect the parent to be a dirac particle 
+  //We expect the parent to be a dirac particle
   //and the daughters to be X lepton neutrino
 
-  EvtSpinType::spintype parenttype=EvtPDL::getSpinType(getParentId());
-  EvtSpinType::spintype baryontype=EvtPDL::getSpinType(getDaug(0));
-  EvtSpinType::spintype leptontype=EvtPDL::getSpinType(getDaug(1));
-  EvtSpinType::spintype neutrinotype=EvtPDL::getSpinType(getDaug(2));
+  EvtSpinType::spintype parenttype = EvtPDL::getSpinType(getParentId());
+  EvtSpinType::spintype baryontype = EvtPDL::getSpinType(getDaug(0));
+  EvtSpinType::spintype leptontype = EvtPDL::getSpinType(getDaug(1));
+  EvtSpinType::spintype neutrinotype = EvtPDL::getSpinType(getDaug(2));
 
-  if ( parenttype != EvtSpinType::DIRAC ) {
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "EvtLb2plnuLCSR generator expected "
-                           << " a DIRAC parent, found:"<<
-                           EvtPDL::name(getParentId())<<endl;
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Will terminate execution!"<<endl;
+  if (parenttype != EvtSpinType::DIRAC) {
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "EvtLb2plnuLCSR generator expected "
+                                         << " a DIRAC parent, found:" << EvtPDL::name(getParentId()) << endl;
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Will terminate execution!" << endl;
     ::abort();
   }
-  if ( leptontype != EvtSpinType::DIRAC ) {
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "EvtLb2plnuLCSR generator expected "
-                           << " a DIRAC 2nd daughter, found:"<<
-                           EvtPDL::name(getDaug(1))<<endl;
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Will terminate execution!"<<endl;
+  if (leptontype != EvtSpinType::DIRAC) {
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "EvtLb2plnuLCSR generator expected "
+                                         << " a DIRAC 2nd daughter, found:" << EvtPDL::name(getDaug(1)) << endl;
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Will terminate execution!" << endl;
     ::abort();
   }
-  if ( neutrinotype != EvtSpinType::NEUTRINO ) {
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "EvtLb2plnuLCSR generator expected "
-                           << " a NEUTRINO 3rd daughter, found:"<<
-                           EvtPDL::name(getDaug(2))<<endl;
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Will terminate execution!"<<endl;
+  if (neutrinotype != EvtSpinType::NEUTRINO) {
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "EvtLb2plnuLCSR generator expected "
+                                         << " a NEUTRINO 3rd daughter, found:" << EvtPDL::name(getDaug(2)) << endl;
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Will terminate execution!" << endl;
     ::abort();
   }
 
   //set ffmodel
   ffmodel = new EvtLb2plnuLCSRFF;
 
-  if ( baryontype==EvtSpinType::DIRAC) 
-  { 
-    calcamp = new EvtSLBaryonAmp; 
+  if (baryontype == EvtSpinType::DIRAC) {
+    calcamp = new EvtSLBaryonAmp;
+  } else {
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Wrong baryon spin type in EvtLb2plnuLCSR.cc "
+                                         << "Expected spin type " << EvtSpinType::DIRAC << ", found spin type "
+                                         << baryontype << endl;
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Will terminate execution!" << endl;
+    ::abort();
   }
-  else {
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") 
-      << "Wrong baryon spin type in EvtLb2plnuLCSR.cc " 
-      << "Expected spin type " << EvtSpinType::DIRAC 
-      << ", found spin type " << baryontype <<endl;
-    EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Will terminate execution!" <<endl;
-     ::abort();
-  }
-  
 }
-

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtLb2plnuLCSR.hh
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtLb2plnuLCSR.hh
@@ -12,7 +12,7 @@
 //
 // Description:Implementation of the Lb2plnuLCSR model
 // Class to handle semileptonic Lb -> p l nu decays using the using form factor predictions from Light Cone Sum Rules.
-// 
+//
 //
 // Modification history:
 //
@@ -29,15 +29,13 @@
 
 class EvtParticle;
 
-class EvtLb2plnuLCSR:public  EvtDecayAmp  {
-
+class EvtLb2plnuLCSR : public EvtDecayAmp {
 public:
-
   EvtLb2plnuLCSR();
   ~EvtLb2plnuLCSR() override;
 
   std::string getName() override;
-  EvtDecayBase* clone() override;
+  EvtDecayBase *clone() override;
 
   void decay(EvtParticle *p) override;
   void initProbMax() override;
@@ -49,4 +47,3 @@ private:
 };
 
 #endif
-

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtLb2plnuLCSRFF.cpp
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtLb2plnuLCSRFF.cpp
@@ -16,7 +16,7 @@
 // Modification history:
 //
 //   William Sutcliffe     27/07/2013        Module created
-//                                      
+//
 //
 //--------------------------------------------------------------------------
 #include "EvtGenBase/EvtPatches.hh"
@@ -31,104 +31,88 @@
 #include <cstdlib>
 using std::endl;
 
-void EvtLb2plnuLCSRFF::getdiracff(EvtId parent, EvtId daught,
-				double q2, double /* mass */ , 
-				double *f1, double *f2, double *f3, 
-				double *g1, double *g2, double *g3 ) {
+void EvtLb2plnuLCSRFF::getdiracff(EvtId parent,
+                                  EvtId daught,
+                                  double q2,
+                                  double /* mass */,
+                                  double* f1,
+                                  double* f2,
+                                  double* f3,
+                                  double* g1,
+                                  double* g2,
+                                  double* g3) {
+  // Define Event IDs for Lb and p
+  static EvtId LAMB = EvtPDL::getId("Lambda_b0");
+  static EvtId LAMBB = EvtPDL::getId("anti-Lambda_b0");
+  static EvtId PRO = EvtPDL::getId("p+");
+  static EvtId PROB = EvtPDL::getId("anti-p-");
 
+  if ((parent == LAMB && daught == PRO) || (parent == LAMBB && daught == PROB)) {
+    // Calculate Lb->p form factors based on LCSR predictions
+    // Predictions taken from A. Khodjamirian, C. Klein, T. Mannel and Y.-M. Wang, arXiv.1108.2971 (2011)
 
-  // Define Event IDs for Lb and p 
-  static EvtId LAMB=EvtPDL::getId("Lambda_b0");
-  static EvtId LAMBB=EvtPDL::getId("anti-Lambda_b0");
-  static EvtId PRO=EvtPDL::getId("p+");
-  static EvtId PROB=EvtPDL::getId("anti-p-");
+    double MLamB = EvtPDL::getMass(parent);
+    double MPro = EvtPDL::getMass(daught);
 
-  if( (parent==LAMB && daught==PRO) 
-       || (parent==LAMBB && daught==PROB) ) 
-  {
-      // Calculate Lb->p form factors based on LCSR predictions
-      // Predictions taken from A. Khodjamirian, C. Klein, T. Mannel and Y.-M. Wang, arXiv.1108.2971 (2011)
+    double tplus = (MLamB + MPro) * (MLamB + MPro);
+    double tminus = (MLamB - MPro) * (MLamB - MPro);
+    double t0 = tplus - sqrt(tplus - tminus) * sqrt(tplus + 6);
+    double z = (sqrt(tplus - q2) - sqrt(tplus - t0)) / (sqrt(tplus - q2) + sqrt(tplus - t0));
+    double z0 = (sqrt(tplus) - sqrt(tplus - t0)) / (sqrt(tplus) + sqrt(tplus - t0));
 
-      double MLamB = EvtPDL::getMass(parent);
-      double MPro = EvtPDL::getMass(daught);
+    // FF parameters
+    double f10 = 0.14;
+    double bf1 = -1.49;
+    double f20 = -0.054;
+    double bf2 = -14.0;
+    double g10 = 0.14;
+    double bg1 = -4.05;
+    double g20 = -0.028;
+    double bg2 = -20.2;
 
-      double tplus = (MLamB + MPro) * (MLamB + MPro);      
-      double tminus = (MLamB - MPro) * (MLamB - MPro);      
-      double t0 = tplus - sqrt(tplus - tminus) * sqrt(tplus + 6);
-      double z = (sqrt(tplus - q2) - sqrt(tplus - t0))/(sqrt(tplus - q2) + sqrt(tplus - t0));
-      double z0 = (sqrt(tplus) - sqrt(tplus - t0))/(sqrt(tplus) + sqrt(tplus - t0));
-      
-      // FF parameters
-      double f10 = 0.14;
-      double bf1 = -1.49;
-      double f20 = -0.054;
-      double bf2 = -14.0;
-      double g10 = 0.14;
-      double bg1 = -4.05;
-      double g20 = -0.028;
-      double bg2 = -20.2;
+    //FF paramterisation
+    double F1 = (f10 / (1.0 - q2 / (5.325 * 5.325))) * (1.0 + bf1 * (z - z0));
+    double F2 = (f20 / (1.0 - q2 / (5.325 * 5.325))) * (1.0 + bf2 * (z - z0));
+    double G1 = (g10 / (1.0 - q2 / (5.723 * 5.723))) * (1.0 + bg1 * (z - z0));
+    double G2 = (g20 / (1.0 - q2 / (5.723 * 5.723))) * (1.0 + bg2 * (z - z0));
 
-      //FF paramterisation
-      double F1 = (f10 / ( 1.0 - q2/ (5.325 * 5.325)))*(1.0 + bf1 * (z - z0 ) ); 
-      double F2 = (f20 / ( 1.0 - q2/ (5.325 * 5.325)))*(1.0 + bf2 * (z - z0 ) );
-      double G1 = (g10 / ( 1.0 - q2/ (5.723 * 5.723)))*(1.0 + bg1 * (z - z0 ) ); 
-      double G2 = (g20 / ( 1.0 - q2/ (5.723 * 5.723)))*(1.0 + bg2 * (z - z0 ) );
+    *f1 = F1 - (MLamB + MPro) * F2 / MLamB;
+    *f2 = F2;
+    *f3 = MPro * (F2) / MLamB;
+    *g1 = G1 - (MLamB - MPro) * G2 / MLamB;
+    *g2 = -G2;
+    *g3 = -MPro * G2 / MLamB;
 
-      *f1  = F1 - (MLamB + MPro)*F2/MLamB;
-      *f2  = F2;
-      *f3  = MPro*(F2)/MLamB;
-      *g1  =  G1 - (MLamB - MPro)*G2/MLamB;
-      *g2  = -G2;
-      *g3  = -MPro*G2/MLamB;
-
+  } else {
+    EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Only Lb -> p transitions allowed in EvtLb2plnuLCSRFF.\n";
+    ::abort();
   }
-  else 
-  {
-  EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Only Lb -> p transitions allowed in EvtLb2plnuLCSRFF.\n";  
-  ::abort();
-  }
 
-  return ;
+  return;
 }
 
-
-void EvtLb2plnuLCSRFF::getraritaff( EvtId , EvtId ,
-				  double , double , 
-				  double* , double* , double* , double*, 
-				  double* , double* , double* , double*  ) {
-
-  EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Not implemented :getraritaff in EvtLb2plnuLCSRFF.\n";  
+void EvtLb2plnuLCSRFF::getraritaff(
+    EvtId, EvtId, double, double, double*, double*, double*, double*, double*, double*, double*, double*) {
+  EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Not implemented :getraritaff in EvtLb2plnuLCSRFF.\n";
   ::abort();
-
 }
 
 void EvtLb2plnuLCSRFF::getscalarff(EvtId, EvtId, double, double, double*, double*) {
-
-  EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Not implemented :getscalarff in EvtLb2plnuLCSRFF.\n";  
+  EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Not implemented :getscalarff in EvtLb2plnuLCSRFF.\n";
   ::abort();
-
 }
 
-void EvtLb2plnuLCSRFF::getvectorff(EvtId, EvtId, double, double, double*, double*,
-				 double*, double*) {
-
-  EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Not implemented :getvectorff in EvtLb2plnuLCSRFF.\n";  
+void EvtLb2plnuLCSRFF::getvectorff(EvtId, EvtId, double, double, double*, double*, double*, double*) {
+  EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Not implemented :getvectorff in EvtLb2plnuLCSRFF.\n";
   ::abort();
-
 }
 
-void EvtLb2plnuLCSRFF::gettensorff(EvtId, EvtId, double, double, double*, double*,
-				 double*, double*) {
-
-  EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Not implemented :gettensorff in EvtLb2plnuLCSRFF.\n";  
+void EvtLb2plnuLCSRFF::gettensorff(EvtId, EvtId, double, double, double*, double*, double*, double*) {
+  EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Not implemented :gettensorff in EvtLb2plnuLCSRFF.\n";
   ::abort();
-
 }
 
-void EvtLb2plnuLCSRFF::getbaryonff(EvtId, EvtId, double, double, double*, 
-				 double*, double*, double*){
-  
-  EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Not implemented :getbaryonff in EvtLb2plnuLCSRFF.\n";  
+void EvtLb2plnuLCSRFF::getbaryonff(EvtId, EvtId, double, double, double*, double*, double*, double*) {
+  EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Not implemented :getbaryonff in EvtLb2plnuLCSRFF.\n";
   ::abort();
-
 }

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtLb2plnuLCSRFF.hh
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtLb2plnuLCSRFF.hh
@@ -15,7 +15,7 @@
 // Modification history:
 //
 //    William Sutcliffe     July 27, 2013     Module created
-//    
+//
 //------------------------------------------------------------------------
 
 #ifndef EVTLB2PMUNULCSRFF_HH
@@ -26,33 +26,38 @@
 class EvtId;
 
 class EvtLb2plnuLCSRFF : public EvtSemiLeptonicFF {
-
 public:
+  void getscalarff(EvtId parent, EvtId daught, double t, double mass, double *fpf, double *f0f) override;
+  void getvectorff(
+      EvtId parent, EvtId daught, double t, double mass, double *a1f, double *a2f, double *vf, double *a0f) override;
+  void gettensorff(
+      EvtId parent, EvtId daught, double t, double mass, double *hf, double *kf, double *bpf, double *bmf) override;
 
-  void getscalarff(EvtId parent, EvtId daught,
-		   double t, double mass, double *fpf,
-		   double *f0f ) override;
-  void getvectorff(EvtId parent, EvtId daught,
-		   double t, double mass, double *a1f,
-		   double *a2f, double *vf, double *a0f ) override;
-  void gettensorff(EvtId parent, EvtId daught,
-		   double t, double mass, double *hf,
-		   double *kf, double *bpf, double *bmf ) override;
+  void getbaryonff(EvtId, EvtId, double, double, double *, double *, double *, double *) override;
 
-  void getbaryonff(EvtId, EvtId, double, double, double*, 
-		   double*, double*, double*) override;
+  void getdiracff(EvtId parent,
+                  EvtId daught,
+                  double q2,
+                  double mass,
+                  double *f1,
+                  double *f2,
+                  double *f3,
+                  double *g1,
+                  double *g2,
+                  double *g3) override;
 
-  void getdiracff( EvtId parent, EvtId daught,
-		   double q2, double mass, 
-		   double *f1, double *f2, double *f3,
-		   double *g1, double *g2, double *g3 ) override;
-
-  void getraritaff( EvtId parent, EvtId daught,
-		    double q2, double mass, 
-		    double *f1, double *f2, double *f3, double *f4,
-		    double *g1, double *g2, double *g3, double *g4 ) override;
+  void getraritaff(EvtId parent,
+                   EvtId daught,
+                   double q2,
+                   double mass,
+                   double *f1,
+                   double *f2,
+                   double *f3,
+                   double *f4,
+                   double *g1,
+                   double *g2,
+                   double *g3,
+                   double *g4) override;
 };
 
 #endif
-
-

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtModelUserReg.cpp
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtModelUserReg.cpp
@@ -2,8 +2,7 @@
 #include "GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtLb2plnuLCSR.hh"
 #include <list>
 
-std::list<EvtDecayBase*> EvtModelUserReg::getUserModels(){
-
+std::list<EvtDecayBase*> EvtModelUserReg::getUserModels() {
   // Create user models
   EvtLb2plnuLCSR* EvtLb2plnuLCSRModel = new EvtLb2plnuLCSR();
 
@@ -12,6 +11,4 @@ std::list<EvtDecayBase*> EvtModelUserReg::getUserModels(){
 
   // Return the list of models
   return extraModels;
-	
 }
-

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtModelUserReg.h
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtModelUserReg.h
@@ -8,8 +8,7 @@
 */
 //typedef std::list<EvtDecayBase*> EvtModelList;
 
-class EvtModelUserReg
-{
+class EvtModelUserReg {
 public:
   std::list<EvtDecayBase*> getUserModels();
 };

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtSLBaryonAmp.cpp
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtSLBaryonAmp.cpp
@@ -40,145 +40,122 @@
 
 using std::endl;
 
+EvtSLBaryonAmp::~EvtSLBaryonAmp() {}
 
-EvtSLBaryonAmp::~EvtSLBaryonAmp(){
-}
+void EvtSLBaryonAmp::CalcAmp(EvtParticle *parent, EvtAmp &amp, EvtSemiLeptonicFF *FormFactors) {
+  static EvtId EM = EvtPDL::getId("e-");
+  static EvtId MUM = EvtPDL::getId("mu-");
+  static EvtId TAUM = EvtPDL::getId("tau-");
+  static EvtId EP = EvtPDL::getId("e+");
+  static EvtId MUP = EvtPDL::getId("mu+");
+  static EvtId TAUP = EvtPDL::getId("tau+");
 
-
-void EvtSLBaryonAmp::CalcAmp( EvtParticle *parent,
-					EvtAmp& amp,
-					EvtSemiLeptonicFF *FormFactors ) {
-
-  static EvtId EM=EvtPDL::getId("e-");
-  static EvtId MUM=EvtPDL::getId("mu-");
-  static EvtId TAUM=EvtPDL::getId("tau-");
-  static EvtId EP=EvtPDL::getId("e+");
-  static EvtId MUP=EvtPDL::getId("mu+");
-  static EvtId TAUP=EvtPDL::getId("tau+");
-
- 
   //Add the lepton and neutrino 4 momenta to find q2
 
-  EvtVector4R q = parent->getDaug(1)->getP4() 
-                    + parent->getDaug(2)->getP4(); 
+  EvtVector4R q = parent->getDaug(1)->getP4() + parent->getDaug(2)->getP4();
   double q2 = (q.mass2());
 
-  double f1v,f1a,f2v,f2a;
+  double f1v, f1a, f2v, f2a;
   double m_meson = parent->getDaug(0)->mass();
 
-  FormFactors->getbaryonff(parent->getId(),
-			   parent->getDaug(0)->getId(),
-                           q2,
-                           m_meson,
-                           &f1v, 
-                           &f1a, 
-                           &f2v, 
-                           &f2a);
+  FormFactors->getbaryonff(parent->getId(), parent->getDaug(0)->getId(), q2, m_meson, &f1v, &f1a, &f2v, &f2a);
 
   EvtVector4R p4b;
-  p4b.set(parent->mass(),0.0,0.0,0.0);
-  
+  p4b.set(parent->mass(), 0.0, 0.0, 0.0);
+
   EvtVector4C temp_00_term1;
   EvtVector4C temp_00_term2;
-  
+
   EvtVector4C temp_01_term1;
   EvtVector4C temp_01_term2;
-  
+
   EvtVector4C temp_10_term1;
   EvtVector4C temp_10_term2;
-  
+
   EvtVector4C temp_11_term1;
   EvtVector4C temp_11_term2;
-  
-  EvtDiracSpinor p0=parent->sp(0);
-  EvtDiracSpinor p1=parent->sp(1);
-  
-  EvtDiracSpinor d0=parent->getDaug(0)->spParent(0);
-  EvtDiracSpinor d1=parent->getDaug(0)->spParent(1);
-  
-  temp_00_term1.set(0,f1v*(d0*(EvtGammaMatrix::g0()*p0)));
-  temp_00_term2.set(0,f1a*(d0*((EvtGammaMatrix::g0()*EvtGammaMatrix::g5())*p0)));
-  temp_01_term1.set(0,f1v*(d0*(EvtGammaMatrix::g0()*p1)));
-  temp_01_term2.set(0,f1a*(d0*((EvtGammaMatrix::g0()*EvtGammaMatrix::g5())*p1)));
-  temp_10_term1.set(0,f1v*(d1*(EvtGammaMatrix::g0()*p0)));
-  temp_10_term2.set(0,f1a*(d1*((EvtGammaMatrix::g0()*EvtGammaMatrix::g5())*p0)));
-  temp_11_term1.set(0,f1v*(d1*(EvtGammaMatrix::g0()*p1)));
-  temp_11_term2.set(0,f1a*(d1*((EvtGammaMatrix::g0()*EvtGammaMatrix::g5())*p1)));
-  
-  temp_00_term1.set(1,f1v*(d0*(EvtGammaMatrix::g1()*p0)));
-  temp_00_term2.set(1,f1a*(d0*((EvtGammaMatrix::g1()*EvtGammaMatrix::g5())*p0)));
-  temp_01_term1.set(1,f1v*(d0*(EvtGammaMatrix::g1()*p1)));
-  temp_01_term2.set(1,f1a*(d0*((EvtGammaMatrix::g1()*EvtGammaMatrix::g5())*p1)));
-  temp_10_term1.set(1,f1v*(d1*(EvtGammaMatrix::g1()*p0)));
-  temp_10_term2.set(1,f1a*(d1*((EvtGammaMatrix::g1()*EvtGammaMatrix::g5())*p0)));
-  temp_11_term1.set(1,f1v*(d1*(EvtGammaMatrix::g1()*p1)));
-  temp_11_term2.set(1,f1a*(d1*((EvtGammaMatrix::g1()*EvtGammaMatrix::g5())*p1)));
-  
-  temp_00_term1.set(2,f1v*(d0*(EvtGammaMatrix::g2()*p0)));
-  temp_00_term2.set(2,f1a*(d0*((EvtGammaMatrix::g2()*EvtGammaMatrix::g5())*p0)));
-  temp_01_term1.set(2,f1v*(d0*(EvtGammaMatrix::g2()*p1)));
-  temp_01_term2.set(2,f1a*(d0*((EvtGammaMatrix::g2()*EvtGammaMatrix::g5())*p1)));
-  temp_10_term1.set(2,f1v*(d1*(EvtGammaMatrix::g2()*p0)));
-  temp_10_term2.set(2,f1a*(d1*((EvtGammaMatrix::g2()*EvtGammaMatrix::g5())*p0)));
-  temp_11_term1.set(2,f1v*(d1*(EvtGammaMatrix::g2()*p1)));
-  temp_11_term2.set(2,f1a*(d1*((EvtGammaMatrix::g2()*EvtGammaMatrix::g5())*p1)));
-  
-  temp_00_term1.set(3,f1v*(d0*(EvtGammaMatrix::g3()*p0)));
-  temp_00_term2.set(3,f1a*(d0*((EvtGammaMatrix::g3()*EvtGammaMatrix::g5())*p0)));
-  temp_01_term1.set(3,f1v*(d0*(EvtGammaMatrix::g3()*p1)));
-  temp_01_term2.set(3,f1a*(d0*((EvtGammaMatrix::g3()*EvtGammaMatrix::g5())*p1)));
-  temp_10_term1.set(3,f1v*(d1*(EvtGammaMatrix::g3()*p0)));
-  temp_10_term2.set(3,f1a*(d1*((EvtGammaMatrix::g3()*EvtGammaMatrix::g5())*p0)));
-  temp_11_term1.set(3,f1v*(d1*(EvtGammaMatrix::g3()*p1)));
-  temp_11_term2.set(3,f1a*(d1*((EvtGammaMatrix::g3()*EvtGammaMatrix::g5())*p1)));
-  
 
+  EvtDiracSpinor p0 = parent->sp(0);
+  EvtDiracSpinor p1 = parent->sp(1);
 
-  EvtVector4C l1,l2;
+  EvtDiracSpinor d0 = parent->getDaug(0)->spParent(0);
+  EvtDiracSpinor d1 = parent->getDaug(0)->spParent(1);
+
+  temp_00_term1.set(0, f1v * (d0 * (EvtGammaMatrix::g0() * p0)));
+  temp_00_term2.set(0, f1a * (d0 * ((EvtGammaMatrix::g0() * EvtGammaMatrix::g5()) * p0)));
+  temp_01_term1.set(0, f1v * (d0 * (EvtGammaMatrix::g0() * p1)));
+  temp_01_term2.set(0, f1a * (d0 * ((EvtGammaMatrix::g0() * EvtGammaMatrix::g5()) * p1)));
+  temp_10_term1.set(0, f1v * (d1 * (EvtGammaMatrix::g0() * p0)));
+  temp_10_term2.set(0, f1a * (d1 * ((EvtGammaMatrix::g0() * EvtGammaMatrix::g5()) * p0)));
+  temp_11_term1.set(0, f1v * (d1 * (EvtGammaMatrix::g0() * p1)));
+  temp_11_term2.set(0, f1a * (d1 * ((EvtGammaMatrix::g0() * EvtGammaMatrix::g5()) * p1)));
+
+  temp_00_term1.set(1, f1v * (d0 * (EvtGammaMatrix::g1() * p0)));
+  temp_00_term2.set(1, f1a * (d0 * ((EvtGammaMatrix::g1() * EvtGammaMatrix::g5()) * p0)));
+  temp_01_term1.set(1, f1v * (d0 * (EvtGammaMatrix::g1() * p1)));
+  temp_01_term2.set(1, f1a * (d0 * ((EvtGammaMatrix::g1() * EvtGammaMatrix::g5()) * p1)));
+  temp_10_term1.set(1, f1v * (d1 * (EvtGammaMatrix::g1() * p0)));
+  temp_10_term2.set(1, f1a * (d1 * ((EvtGammaMatrix::g1() * EvtGammaMatrix::g5()) * p0)));
+  temp_11_term1.set(1, f1v * (d1 * (EvtGammaMatrix::g1() * p1)));
+  temp_11_term2.set(1, f1a * (d1 * ((EvtGammaMatrix::g1() * EvtGammaMatrix::g5()) * p1)));
+
+  temp_00_term1.set(2, f1v * (d0 * (EvtGammaMatrix::g2() * p0)));
+  temp_00_term2.set(2, f1a * (d0 * ((EvtGammaMatrix::g2() * EvtGammaMatrix::g5()) * p0)));
+  temp_01_term1.set(2, f1v * (d0 * (EvtGammaMatrix::g2() * p1)));
+  temp_01_term2.set(2, f1a * (d0 * ((EvtGammaMatrix::g2() * EvtGammaMatrix::g5()) * p1)));
+  temp_10_term1.set(2, f1v * (d1 * (EvtGammaMatrix::g2() * p0)));
+  temp_10_term2.set(2, f1a * (d1 * ((EvtGammaMatrix::g2() * EvtGammaMatrix::g5()) * p0)));
+  temp_11_term1.set(2, f1v * (d1 * (EvtGammaMatrix::g2() * p1)));
+  temp_11_term2.set(2, f1a * (d1 * ((EvtGammaMatrix::g2() * EvtGammaMatrix::g5()) * p1)));
+
+  temp_00_term1.set(3, f1v * (d0 * (EvtGammaMatrix::g3() * p0)));
+  temp_00_term2.set(3, f1a * (d0 * ((EvtGammaMatrix::g3() * EvtGammaMatrix::g5()) * p0)));
+  temp_01_term1.set(3, f1v * (d0 * (EvtGammaMatrix::g3() * p1)));
+  temp_01_term2.set(3, f1a * (d0 * ((EvtGammaMatrix::g3() * EvtGammaMatrix::g5()) * p1)));
+  temp_10_term1.set(3, f1v * (d1 * (EvtGammaMatrix::g3() * p0)));
+  temp_10_term2.set(3, f1a * (d1 * ((EvtGammaMatrix::g3() * EvtGammaMatrix::g5()) * p0)));
+  temp_11_term1.set(3, f1v * (d1 * (EvtGammaMatrix::g3() * p1)));
+  temp_11_term2.set(3, f1a * (d1 * ((EvtGammaMatrix::g3() * EvtGammaMatrix::g5()) * p1)));
+
+  EvtVector4C l1, l2;
 
   EvtId l_num = parent->getDaug(1)->getId();
-  if (l_num==EM||l_num==MUM||l_num==TAUM){
-
-    l1=EvtLeptonVACurrent(parent->getDaug(1)->spParent(0),
-                          parent->getDaug(2)->spParentNeutrino());
-    l2=EvtLeptonVACurrent(parent->getDaug(1)->spParent(1),
-                          parent->getDaug(2)->spParentNeutrino());
-  }
-  else{
-    if (l_num==EP||l_num==MUP||l_num==TAUP){
-    l1=EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(),
-			    parent->getDaug(1)->spParent(0));
-    l2=EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(),
-			    parent->getDaug(1)->spParent(1));
-    }
-    else{
-      EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Wrong lepton number"<<endl;
+  if (l_num == EM || l_num == MUM || l_num == TAUM) {
+    l1 = EvtLeptonVACurrent(parent->getDaug(1)->spParent(0), parent->getDaug(2)->spParentNeutrino());
+    l2 = EvtLeptonVACurrent(parent->getDaug(1)->spParent(1), parent->getDaug(2)->spParentNeutrino());
+  } else {
+    if (l_num == EP || l_num == MUP || l_num == TAUP) {
+      l1 = EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(), parent->getDaug(1)->spParent(0));
+      l2 = EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(), parent->getDaug(1)->spParent(1));
+    } else {
+      EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Wrong lepton number" << endl;
     }
   }
 
-  amp.vertex(0,0,0,l1.cont(temp_00_term1+temp_00_term2));
-  amp.vertex(0,0,1,l2.cont(temp_00_term1+temp_00_term2));
+  amp.vertex(0, 0, 0, l1.cont(temp_00_term1 + temp_00_term2));
+  amp.vertex(0, 0, 1, l2.cont(temp_00_term1 + temp_00_term2));
 
-  amp.vertex(0,1,0,l1.cont(temp_01_term1+temp_01_term2));
-  amp.vertex(0,1,1,l2.cont(temp_01_term1+temp_01_term2));
+  amp.vertex(0, 1, 0, l1.cont(temp_01_term1 + temp_01_term2));
+  amp.vertex(0, 1, 1, l2.cont(temp_01_term1 + temp_01_term2));
 
-  amp.vertex(1,0,0,l1.cont(temp_10_term1+temp_10_term2));
-  amp.vertex(1,0,1,l2.cont(temp_10_term1+temp_10_term2));
+  amp.vertex(1, 0, 0, l1.cont(temp_10_term1 + temp_10_term2));
+  amp.vertex(1, 0, 1, l2.cont(temp_10_term1 + temp_10_term2));
 
-  amp.vertex(1,1,0,l1.cont(temp_11_term1+temp_11_term2));
-  amp.vertex(1,1,1,l2.cont(temp_11_term1+temp_11_term2));
+  amp.vertex(1, 1, 0, l1.cont(temp_11_term1 + temp_11_term2));
+  amp.vertex(1, 1, 1, l2.cont(temp_11_term1 + temp_11_term2));
 
   return;
 }
 
-
-
-double EvtSLBaryonAmp::CalcMaxProb( EvtId parent, EvtId baryon, 
-					      EvtId lepton, EvtId nudaug,
-					      EvtSemiLeptonicFF *FormFactors,
-					      EvtComplex r00, EvtComplex r01, 
-					      EvtComplex r10, EvtComplex r11) {
-
+double EvtSLBaryonAmp::CalcMaxProb(EvtId parent,
+                                   EvtId baryon,
+                                   EvtId lepton,
+                                   EvtId nudaug,
+                                   EvtSemiLeptonicFF *FormFactors,
+                                   EvtComplex r00,
+                                   EvtComplex r01,
+                                   EvtComplex r10,
+                                   EvtComplex r11) {
   //This routine takes the arguements parent, baryon, and lepton
   //number, and a form factor model, and returns a maximum
   //probability for this semileptonic form factor model.  A
@@ -187,7 +164,7 @@ double EvtSLBaryonAmp::CalcMaxProb( EvtId parent, EvtId baryon,
 
   //Start by declaring a particle at rest.
 
-  //It only makes sense to have a scalar parent.  For now. 
+  //It only makes sense to have a scalar parent.  For now.
   //This should be generalized later.
 
   //  EvtScalarParticle *scalar_part;
@@ -195,25 +172,25 @@ double EvtSLBaryonAmp::CalcMaxProb( EvtId parent, EvtId baryon,
 
   EvtDiracParticle *dirac_part;
   EvtParticle *root_part;
-  dirac_part=new EvtDiracParticle;
+  dirac_part = new EvtDiracParticle;
 
   //cludge to avoid generating random numbers!
   //  scalar_part->noLifeTime();
   dirac_part->noLifeTime();
 
   EvtVector4R p_init;
-  
-  p_init.set(EvtPDL::getMass(parent),0.0,0.0,0.0);
+
+  p_init.set(EvtPDL::getMass(parent), 0.0, 0.0, 0.0);
   //  scalar_part->init(parent,p_init);
   //  root_part=(EvtParticle *)scalar_part;
   //  root_part->set_type(EvtSpinType::SCALAR);
 
-  dirac_part->init(parent,p_init);
-  root_part=(EvtParticle *)dirac_part;
-  root_part->setDiagonalSpinDensity();      
+  dirac_part->init(parent, p_init);
+  root_part = (EvtParticle *)dirac_part;
+  root_part->setDiagonalSpinDensity();
 
   EvtParticle *daughter, *lep, *trino;
-  
+
   EvtAmp amp;
 
   EvtId listdaug[3];
@@ -221,121 +198,118 @@ double EvtSLBaryonAmp::CalcMaxProb( EvtId parent, EvtId baryon,
   listdaug[1] = lepton;
   listdaug[2] = nudaug;
 
-  amp.init(parent,3,listdaug);
+  amp.init(parent, 3, listdaug);
 
-  root_part->makeDaughters(3,listdaug);
-  daughter=root_part->getDaug(0);
-  lep=root_part->getDaug(1);
-  trino=root_part->getDaug(2);
+  root_part->makeDaughters(3, listdaug);
+  daughter = root_part->getDaug(0);
+  lep = root_part->getDaug(1);
+  trino = root_part->getDaug(2);
 
   //cludge to avoid generating random numbers!
   daughter->noLifeTime();
   lep->noLifeTime();
   trino->noLifeTime();
 
-
-  //Initial particle is unpolarized, well it is a scalar so it is 
+  //Initial particle is unpolarized, well it is a scalar so it is
   //trivial
   EvtSpinDensity rho;
   rho.setDiag(root_part->getSpinStates());
-  
+
   double mass[3];
-  
+
   double m = root_part->mass();
-  
+
   EvtVector4R p4baryon, p4lepton, p4nu, p4w;
   double q2max;
 
   double q2, elepton, plepton;
-  int i,j;
-  double erho,prho,costl;
+  int i, j;
+  double erho, prho, costl;
 
   double maxfoundprob = 0.0;
   double prob = -10.0;
   int massiter;
 
-  for (massiter=0;massiter<3;massiter++){
-
+  for (massiter = 0; massiter < 3; massiter++) {
     mass[0] = EvtPDL::getMass(baryon);
     mass[1] = EvtPDL::getMass(lepton);
     mass[2] = EvtPDL::getMass(nudaug);
-    if ( massiter==1 ) {
+    if (massiter == 1) {
       mass[0] = EvtPDL::getMinMass(baryon);
     }
-    if ( massiter==2 ) {
+    if (massiter == 2) {
       mass[0] = EvtPDL::getMaxMass(baryon);
     }
 
-    q2max = (m-mass[0])*(m-mass[0]);
-    
+    q2max = (m - mass[0]) * (m - mass[0]);
+
     //loop over q2
 
-    for (i=0;i<25;i++) {
-      q2 = ((i+0.5)*q2max)/25.0;
-      
-      erho = ( m*m + mass[0]*mass[0] - q2 )/(2.0*m);
-      
-      prho = sqrt(erho*erho-mass[0]*mass[0]);
-      
-      p4baryon.set(erho,0.0,0.0,-1.0*prho);
-      p4w.set(m-erho,0.0,0.0,prho);
-      
+    for (i = 0; i < 25; i++) {
+      q2 = ((i + 0.5) * q2max) / 25.0;
+
+      erho = (m * m + mass[0] * mass[0] - q2) / (2.0 * m);
+
+      prho = sqrt(erho * erho - mass[0] * mass[0]);
+
+      p4baryon.set(erho, 0.0, 0.0, -1.0 * prho);
+      p4w.set(m - erho, 0.0, 0.0, prho);
+
       //This is in the W rest frame
-      elepton = (q2+mass[1]*mass[1])/(2.0*sqrt(q2));
-      plepton = sqrt(elepton*elepton-mass[1]*mass[1]);
-      
+      elepton = (q2 + mass[1] * mass[1]) / (2.0 * sqrt(q2));
+      plepton = sqrt(elepton * elepton - mass[1] * mass[1]);
+
       double probctl[3];
 
-      for (j=0;j<3;j++) {
-	
-        costl = 0.99*(j - 1.0);
-	
-	//These are in the W rest frame. Need to boost out into
-	//the B frame.
-        p4lepton.set(elepton,0.0,
-		  plepton*sqrt(1.0-costl*costl),plepton*costl);
-        p4nu.set(plepton,0.0,
-		 -1.0*plepton*sqrt(1.0-costl*costl),-1.0*plepton*costl);
+      for (j = 0; j < 3; j++) {
+        costl = 0.99 * (j - 1.0);
 
-	EvtVector4R boost((m-erho),0.0,0.0,1.0*prho);
-        p4lepton=boostTo(p4lepton,boost);
-        p4nu=boostTo(p4nu,boost);
+        //These are in the W rest frame. Need to boost out into
+        //the B frame.
+        p4lepton.set(elepton, 0.0, plepton * sqrt(1.0 - costl * costl), plepton * costl);
+        p4nu.set(plepton, 0.0, -1.0 * plepton * sqrt(1.0 - costl * costl), -1.0 * plepton * costl);
 
-	//Now initialize the daughters...
+        EvtVector4R boost((m - erho), 0.0, 0.0, 1.0 * prho);
+        p4lepton = boostTo(p4lepton, boost);
+        p4nu = boostTo(p4nu, boost);
 
-        daughter->init(baryon,p4baryon);
-        lep->init(lepton,p4lepton);
-        trino->init(nudaug,p4nu);
+        //Now initialize the daughters...
 
-        CalcAmp(root_part,amp,FormFactors,r00,r01,r10,r11);
+        daughter->init(baryon, p4baryon);
+        lep->init(lepton, p4lepton);
+        trino->init(nudaug, p4nu);
 
-	//Now find the probability at this q2 and cos theta lepton point
+        CalcAmp(root_part, amp, FormFactors, r00, r01, r10, r11);
+
+        //Now find the probability at this q2 and cos theta lepton point
         //and compare to maxfoundprob.
 
-	//Do a little magic to get the probability!!
-	prob = rho.normalizedProb(amp.getSpinDensity());
+        //Do a little magic to get the probability!!
+        prob = rho.normalizedProb(amp.getSpinDensity());
 
-	probctl[j]=prob;
+        probctl[j] = prob;
       }
 
       //probclt contains prob at ctl=-1,0,1.
       //prob=a+b*ctl+c*ctl^2
 
-      double a=probctl[1];
-      double b=0.5*(probctl[2]-probctl[0]);
-      double c=0.5*(probctl[2]+probctl[0])-probctl[1];
+      double a = probctl[1];
+      double b = 0.5 * (probctl[2] - probctl[0]);
+      double c = 0.5 * (probctl[2] + probctl[0]) - probctl[1];
 
-      prob=probctl[0];
-      if (probctl[1]>prob) prob=probctl[1];
-      if (probctl[2]>prob) prob=probctl[2];
+      prob = probctl[0];
+      if (probctl[1] > prob)
+        prob = probctl[1];
+      if (probctl[2] > prob)
+        prob = probctl[2];
 
-      if (fabs(c)>1e-20){
-	double ctlx=-0.5*b/c;
-	if (fabs(ctlx)<1.0){
-	  double probtmp=a+b*ctlx+c*ctlx*ctlx;
-	  if (probtmp>prob) prob=probtmp;
-	} 
-
+      if (fabs(c) > 1e-20) {
+        double ctlx = -0.5 * b / c;
+        if (fabs(ctlx) < 1.0) {
+          double probtmp = a + b * ctlx + c * ctlx * ctlx;
+          if (probtmp > prob)
+            prob = probtmp;
+        }
       }
 
       //report(DEBUG,"EvtGen") << "prob,probctl:"<<prob<<" "
@@ -343,141 +317,126 @@ double EvtSLBaryonAmp::CalcMaxProb( EvtId parent, EvtId baryon,
       //			    << probctl[1]<<" "
       //			    << probctl[2]<<std::endl;
 
-      if ( prob > maxfoundprob ) {
-	maxfoundprob = prob; 
+      if (prob > maxfoundprob) {
+        maxfoundprob = prob;
       }
-
     }
-    if ( EvtPDL::getWidth(baryon) <= 0.0 ) {
+    if (EvtPDL::getWidth(baryon) <= 0.0) {
       //if the particle is narrow dont bother with changing the mass.
       massiter = 4;
     }
-
   }
-  root_part->deleteTree();  
+  root_part->deleteTree();
 
-  maxfoundprob *=1.1;
+  maxfoundprob *= 1.1;
   return maxfoundprob;
-  
 }
 void EvtSLBaryonAmp::CalcAmp(EvtParticle *parent,
-				       EvtAmp& amp,
-				       EvtSemiLeptonicFF *FormFactors,
-				       EvtComplex r00, EvtComplex r01, 
-				       EvtComplex r10, EvtComplex r11) {
+                             EvtAmp &amp,
+                             EvtSemiLeptonicFF *FormFactors,
+                             EvtComplex r00,
+                             EvtComplex r01,
+                             EvtComplex r10,
+                             EvtComplex r11) {
   //  Leptons
-  static EvtId EM=EvtPDL::getId("e-");
-  static EvtId MUM=EvtPDL::getId("mu-");
-  static EvtId TAUM=EvtPDL::getId("tau-");
+  static EvtId EM = EvtPDL::getId("e-");
+  static EvtId MUM = EvtPDL::getId("mu-");
+  static EvtId TAUM = EvtPDL::getId("tau-");
   //  Anti-Leptons
-  static EvtId EP=EvtPDL::getId("e+");
-  static EvtId MUP=EvtPDL::getId("mu+");
-  static EvtId TAUP=EvtPDL::getId("tau+");
+  static EvtId EP = EvtPDL::getId("e+");
+  static EvtId MUP = EvtPDL::getId("mu+");
+  static EvtId TAUP = EvtPDL::getId("tau+");
 
   //  Baryons
-  static EvtId LAMCP=EvtPDL::getId("Lambda_c+");
-  static EvtId LAMC1P=EvtPDL::getId("Lambda_c(2593)+");
-  static EvtId LAMC2P=EvtPDL::getId("Lambda_c(2625)+");
-  static EvtId LAMB=EvtPDL::getId("Lambda_b0");
-  static EvtId PRO=EvtPDL::getId("p+");
-  static EvtId N1440=EvtPDL::getId("N(1440)+");
-  static EvtId N1520=EvtPDL::getId("N(1520)+");
-  static EvtId N1535=EvtPDL::getId("N(1535)+");
-  static EvtId N1720=EvtPDL::getId("N(1720)+");
-  static EvtId N1650=EvtPDL::getId("N(1650)+");
-  static EvtId N1700=EvtPDL::getId("N(1700)+");
-  static EvtId N1710=EvtPDL::getId("N(1710)+");
-  static EvtId N1875=EvtPDL::getId("N(1875)+");
-  static EvtId N1900=EvtPDL::getId("N(1900)+");
+  static EvtId LAMCP = EvtPDL::getId("Lambda_c+");
+  static EvtId LAMC1P = EvtPDL::getId("Lambda_c(2593)+");
+  static EvtId LAMC2P = EvtPDL::getId("Lambda_c(2625)+");
+  static EvtId LAMB = EvtPDL::getId("Lambda_b0");
+  static EvtId PRO = EvtPDL::getId("p+");
+  static EvtId N1440 = EvtPDL::getId("N(1440)+");
+  static EvtId N1520 = EvtPDL::getId("N(1520)+");
+  static EvtId N1535 = EvtPDL::getId("N(1535)+");
+  static EvtId N1720 = EvtPDL::getId("N(1720)+");
+  static EvtId N1650 = EvtPDL::getId("N(1650)+");
+  static EvtId N1700 = EvtPDL::getId("N(1700)+");
+  static EvtId N1710 = EvtPDL::getId("N(1710)+");
+  static EvtId N1875 = EvtPDL::getId("N(1875)+");
+  static EvtId N1900 = EvtPDL::getId("N(1900)+");
 
   // Anti-Baryons
-  static EvtId LAMCM=EvtPDL::getId("anti-Lambda_c-");
-  static EvtId LAMC1M=EvtPDL::getId("anti-Lambda_c(2593)-");
-  static EvtId LAMC2M=EvtPDL::getId("anti-Lambda_c(2625)-");
-  static EvtId LAMBB=EvtPDL::getId("anti-Lambda_b0");
-  static EvtId PROB=EvtPDL::getId("anti-p-");
-  static EvtId N1440B=EvtPDL::getId("anti-N(1440)-");
-  static EvtId N1520B=EvtPDL::getId("anti-N(1520)-");
-  static EvtId N1535B=EvtPDL::getId("anti-N(1535)-");
-  static EvtId N1720B=EvtPDL::getId("anti-N(1720)-");
-  static EvtId N1650B=EvtPDL::getId("anti-N(1650)-");
-  static EvtId N1700B=EvtPDL::getId("anti-N(1700)-");
-  static EvtId N1710B=EvtPDL::getId("anti-N(1710)-");
-  static EvtId N1875B=EvtPDL::getId("anti-N(1875)-");
-  static EvtId N1900B=EvtPDL::getId("anti-N(1900)-");
+  static EvtId LAMCM = EvtPDL::getId("anti-Lambda_c-");
+  static EvtId LAMC1M = EvtPDL::getId("anti-Lambda_c(2593)-");
+  static EvtId LAMC2M = EvtPDL::getId("anti-Lambda_c(2625)-");
+  static EvtId LAMBB = EvtPDL::getId("anti-Lambda_b0");
+  static EvtId PROB = EvtPDL::getId("anti-p-");
+  static EvtId N1440B = EvtPDL::getId("anti-N(1440)-");
+  static EvtId N1520B = EvtPDL::getId("anti-N(1520)-");
+  static EvtId N1535B = EvtPDL::getId("anti-N(1535)-");
+  static EvtId N1720B = EvtPDL::getId("anti-N(1720)-");
+  static EvtId N1650B = EvtPDL::getId("anti-N(1650)-");
+  static EvtId N1700B = EvtPDL::getId("anti-N(1700)-");
+  static EvtId N1710B = EvtPDL::getId("anti-N(1710)-");
+  static EvtId N1875B = EvtPDL::getId("anti-N(1875)-");
+  static EvtId N1900B = EvtPDL::getId("anti-N(1900)-");
 
   // Set the spin density matrix of the parent baryon
   EvtSpinDensity rho;
   rho.setDim(2);
-  rho.set(0,0,r00);
-  rho.set(0,1,r01);
+  rho.set(0, 0, r00);
+  rho.set(0, 1, r01);
 
-  rho.set(1,0,r10);
-  rho.set(1,1,r11);
+  rho.set(1, 0, r10);
+  rho.set(1, 1, r11);
 
   EvtVector4R vector4P = parent->getP4Lab();
   double pmag = vector4P.d3mag();
-  double cosTheta = vector4P.get(3)/pmag;
-  
+  double cosTheta = vector4P.get(3) / pmag;
+
   double theta = acos(cosTheta);
   double phi = atan2(vector4P.get(2), vector4P.get(1));
-  
-  parent->setSpinDensityForwardHelicityBasis(rho,phi,theta, 0.0);
+
+  parent->setSpinDensityForwardHelicityBasis(rho, phi, theta, 0.0);
   //parent->setSpinDensityForward(rho);
 
   // Set the four momentum of the parent baryon in it's rest frame
   EvtVector4R p4b;
-  p4b.set(parent->mass(), 0.0,0.0,0.0);
+  p4b.set(parent->mass(), 0.0, 0.0, 0.0);
 
   // Get the four momentum of the daughter baryon in the parent's rest frame
   EvtVector4R p4daught = parent->getDaug(0)->getP4();
-  
-  // Add the lepton and neutrino 4 momenta to find q (q^2)
-  EvtVector4R q = parent->getDaug(1)->getP4() 
-    + parent->getDaug(2)->getP4();
-  
-  double q2 = q.mass2();
 
+  // Add the lepton and neutrino 4 momenta to find q (q^2)
+  EvtVector4R q = parent->getDaug(1)->getP4() + parent->getDaug(2)->getP4();
+
+  double q2 = q.mass2();
 
   EvtId l_num = parent->getDaug(1)->getId();
   EvtId bar_num = parent->getDaug(0)->getId();
   EvtId par_num = parent->getId();
-  
-  double baryonmass = parent->getDaug(0)->mass();
-  
-  // Handle spin-1/2 daughter baryon Dirac spinor cases
-  if( EvtPDL::getSpinType(parent->getDaug(0)->getId())==EvtSpinType::DIRAC ) {
 
+  double baryonmass = parent->getDaug(0)->mass();
+
+  // Handle spin-1/2 daughter baryon Dirac spinor cases
+  if (EvtPDL::getSpinType(parent->getDaug(0)->getId()) == EvtSpinType::DIRAC) {
     // Set the form factors
-    double f1,f2,f3,g1,g2,g3;
-    FormFactors->getdiracff( par_num,
-			     bar_num,
-			     q2,
-			     baryonmass,
-			     &f1, &f2, &f3,
-			     &g1, &g2, &g3);
-    
+    double f1, f2, f3, g1, g2, g3;
+    FormFactors->getdiracff(par_num, bar_num, q2, baryonmass, &f1, &f2, &f3, &g1, &g2, &g3);
+
     const double form_fact[6] = {f1, f2, f3, g1, g2, g3};
-    
+
     EvtVector4C b11, b12, b21, b22, l1, l2;
 
     //  Lepton Current
-    if(l_num==EM || l_num==MUM || l_num==TAUM){
+    if (l_num == EM || l_num == MUM || l_num == TAUM) {
+      l1 = EvtLeptonVACurrent(parent->getDaug(1)->spParent(0), parent->getDaug(2)->spParentNeutrino());
+      l2 = EvtLeptonVACurrent(parent->getDaug(1)->spParent(1), parent->getDaug(2)->spParentNeutrino());
 
-      l1=EvtLeptonVACurrent(parent->getDaug(1)->spParent(0),
-			    parent->getDaug(2)->spParentNeutrino());
-      l2=EvtLeptonVACurrent(parent->getDaug(1)->spParent(1),
-			    parent->getDaug(2)->spParentNeutrino());
-      
-    } else if (l_num==EP || l_num==MUP || l_num==TAUP) {
+    } else if (l_num == EP || l_num == MUP || l_num == TAUP) {
+      l1 = EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(), parent->getDaug(1)->spParent(0));
+      l2 = EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(), parent->getDaug(1)->spParent(1));
 
-      l1=EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(),
-			    parent->getDaug(1)->spParent(0));
-      l2=EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(),
-			    parent->getDaug(1)->spParent(1));
-      
     } else {
-      EvtGenReport(EVTGEN_ERROR,"EvtGen")<< "Wrong lepton number \n";
+      EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Wrong lepton number \n";
       ::abort();
     }
 
@@ -492,236 +451,166 @@ void EvtSLBaryonAmp::CalcAmp(EvtParticle *parent,
     int pflag = 0;
 
     // Handle 1/2+ -> 1/2+ first
-    if ( (par_num==LAMB && bar_num==LAMCP) 
-	 || (par_num==LAMBB && bar_num==LAMCM)
-         || (par_num==LAMB && bar_num==PRO )
-	 || (par_num==LAMBB && bar_num==PROB)
-         || (par_num==LAMB && bar_num==N1440 )
-	 || (par_num==LAMBB && bar_num==N1440B)
-         || (par_num==LAMB && bar_num==N1710 )
-	 || (par_num==LAMBB && bar_num==N1710B)
-	 
-	 ) {
+    if ((par_num == LAMB && bar_num == LAMCP) || (par_num == LAMBB && bar_num == LAMCM) ||
+        (par_num == LAMB && bar_num == PRO) || (par_num == LAMBB && bar_num == PROB) ||
+        (par_num == LAMB && bar_num == N1440) || (par_num == LAMBB && bar_num == N1440B) ||
+        (par_num == LAMB && bar_num == N1710) || (par_num == LAMBB && bar_num == N1710B)
 
+    ) {
       // Set particle/anti-particle flag
-      if (bar_num==LAMCP || bar_num==PRO || bar_num==N1440 || bar_num==N1710)
-	pflag = 0;
-      else if (bar_num==LAMCM || bar_num==PROB || bar_num==N1440B || bar_num==N1710B)
-	pflag = 2;
+      if (bar_num == LAMCP || bar_num == PRO || bar_num == N1440 || bar_num == N1710)
+        pflag = 0;
+      else if (bar_num == LAMCM || bar_num == PROB || bar_num == N1440B || bar_num == N1710B)
+        pflag = 2;
 
-      b11=EvtBaryonVACurrent(parent->getDaug(0)->spParent(0),
-			     parent->sp(0),
-			     p4b, p4daught, form_fact, pflag);
-      b21=EvtBaryonVACurrent(parent->getDaug(0)->spParent(0),
-			     parent->sp(1),
-			     p4b, p4daught, form_fact, pflag);
-      b12=EvtBaryonVACurrent(parent->getDaug(0)->spParent(1),
-			     parent->sp(0),
-			     p4b, p4daught, form_fact, pflag);
-      b22=EvtBaryonVACurrent(parent->getDaug(0)->spParent(1),
-			     parent->sp(1),
-			     p4b, p4daught, form_fact, pflag);
+      b11 = EvtBaryonVACurrent(parent->getDaug(0)->spParent(0), parent->sp(0), p4b, p4daught, form_fact, pflag);
+      b21 = EvtBaryonVACurrent(parent->getDaug(0)->spParent(0), parent->sp(1), p4b, p4daught, form_fact, pflag);
+      b12 = EvtBaryonVACurrent(parent->getDaug(0)->spParent(1), parent->sp(0), p4b, p4daught, form_fact, pflag);
+      b22 = EvtBaryonVACurrent(parent->getDaug(0)->spParent(1), parent->sp(1), p4b, p4daught, form_fact, pflag);
     }
 
     // Handle 1/2+ -> 1/2- second
-    else if( 
-	    (par_num==LAMB && bar_num==LAMC1P) 
-	     || (par_num==LAMBB && bar_num==LAMC1M)
-	     || (par_num==LAMB && bar_num==N1535) 
-	     || (par_num==LAMBB && bar_num==N1535B)
-	     || (par_num==LAMB && bar_num==N1650) 
-	     || (par_num==LAMBB && bar_num==N1650B)
-	   ) {
-      
+    else if ((par_num == LAMB && bar_num == LAMC1P) || (par_num == LAMBB && bar_num == LAMC1M) ||
+             (par_num == LAMB && bar_num == N1535) || (par_num == LAMBB && bar_num == N1535B) ||
+             (par_num == LAMB && bar_num == N1650) || (par_num == LAMBB && bar_num == N1650B)) {
       // Set particle/anti-particle flag
-      if (bar_num==LAMC1P || bar_num == N1535 || bar_num == N1650)
-	pflag = 1;
-      else if (bar_num==LAMC1M || bar_num == N1535B || bar_num == N1650B)
-	pflag = 3;
+      if (bar_num == LAMC1P || bar_num == N1535 || bar_num == N1650)
+        pflag = 1;
+      else if (bar_num == LAMC1M || bar_num == N1535B || bar_num == N1650B)
+        pflag = 3;
 
-      b11=EvtBaryonVACurrent((parent->getDaug(0)->spParent(0)),
-			     (EvtGammaMatrix::g5()*parent->sp(0)),
-			     p4b, p4daught, form_fact, pflag);
-      b21=EvtBaryonVACurrent((parent->getDaug(0)->spParent(0)),
-			     (EvtGammaMatrix::g5()*parent->sp(1)),
-			     p4b, p4daught, form_fact, pflag);
-      b12=EvtBaryonVACurrent((parent->getDaug(0)->spParent(1)),
-			     (EvtGammaMatrix::g5()*parent->sp(0)),
-			     p4b, p4daught, form_fact, pflag);
-      b22=EvtBaryonVACurrent((parent->getDaug(0)->spParent(1)),
-			     (EvtGammaMatrix::g5()*parent->sp(1)),
-			     p4b, p4daught, form_fact, pflag);
-      
+      b11 = EvtBaryonVACurrent(
+          (parent->getDaug(0)->spParent(0)), (EvtGammaMatrix::g5() * parent->sp(0)), p4b, p4daught, form_fact, pflag);
+      b21 = EvtBaryonVACurrent(
+          (parent->getDaug(0)->spParent(0)), (EvtGammaMatrix::g5() * parent->sp(1)), p4b, p4daught, form_fact, pflag);
+      b12 = EvtBaryonVACurrent(
+          (parent->getDaug(0)->spParent(1)), (EvtGammaMatrix::g5() * parent->sp(0)), p4b, p4daught, form_fact, pflag);
+      b22 = EvtBaryonVACurrent(
+          (parent->getDaug(0)->spParent(1)), (EvtGammaMatrix::g5() * parent->sp(1)), p4b, p4daught, form_fact, pflag);
+
     }
 
     else {
-      EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Dirac semilep. baryon current " 
-			     << "not implemented for this decay sequence." 
-			     << std::endl;
+      EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Dirac semilep. baryon current "
+                                           << "not implemented for this decay sequence." << std::endl;
       ::abort();
     }
-     
-    amp.vertex(0,0,0,l1*b11);
-    amp.vertex(0,0,1,l2*b11);
-    
-    amp.vertex(1,0,0,l1*b21);
-    amp.vertex(1,0,1,l2*b21);
-    
-    amp.vertex(0,1,0,l1*b12);
-    amp.vertex(0,1,1,l2*b12);
-    
-    amp.vertex(1,1,0,l1*b22);
-    amp.vertex(1,1,1,l2*b22);
+
+    amp.vertex(0, 0, 0, l1 * b11);
+    amp.vertex(0, 0, 1, l2 * b11);
+
+    amp.vertex(1, 0, 0, l1 * b21);
+    amp.vertex(1, 0, 1, l2 * b21);
+
+    amp.vertex(0, 1, 0, l1 * b12);
+    amp.vertex(0, 1, 1, l2 * b12);
+
+    amp.vertex(1, 1, 0, l1 * b22);
+    amp.vertex(1, 1, 1, l2 * b22);
 
   }
-  
-  // Need special handling for the spin-3/2 daughter baryon 
+
+  // Need special handling for the spin-3/2 daughter baryon
   // Rarita-Schwinger spinor cases
-  else if( EvtPDL::getSpinType(parent->getDaug(0)->getId())==EvtSpinType::RARITASCHWINGER ) {
-    
+  else if (EvtPDL::getSpinType(parent->getDaug(0)->getId()) == EvtSpinType::RARITASCHWINGER) {
     // Set the form factors
-    double f1,f2,f3,f4,g1,g2,g3,g4;
-    FormFactors->getraritaff( par_num,
-			      bar_num,
-			      q2,
-			      baryonmass,
-			      &f1, &f2, &f3, &f4,
-			      &g1, &g2, &g3, &g4);
-    
+    double f1, f2, f3, f4, g1, g2, g3, g4;
+    FormFactors->getraritaff(par_num, bar_num, q2, baryonmass, &f1, &f2, &f3, &f4, &g1, &g2, &g3, &g4);
+
     const double form_fact[8] = {f1, f2, f3, f4, g1, g2, g3, g4};
-    
+
     EvtId l_num = parent->getDaug(1)->getId();
-    
+
     EvtVector4C b11, b12, b21, b22, b13, b23, b14, b24, l1, l2;
 
     //  Lepton Current
-    if (l_num==EM || l_num==MUM || l_num==TAUM) {
+    if (l_num == EM || l_num == MUM || l_num == TAUM) {
       //  Lepton Current
-      l1=EvtLeptonVACurrent(parent->getDaug(1)->spParent(0),
-			    parent->getDaug(2)->spParentNeutrino());
-      l2=EvtLeptonVACurrent(parent->getDaug(1)->spParent(1),
-			    parent->getDaug(2)->spParentNeutrino());
-    }
-    else if (l_num==EP || l_num==MUP || l_num==TAUP) {
-      l1=EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(),
-			    parent->getDaug(1)->spParent(0));
-      l2=EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(),
-			    parent->getDaug(1)->spParent(1));
-      
+      l1 = EvtLeptonVACurrent(parent->getDaug(1)->spParent(0), parent->getDaug(2)->spParentNeutrino());
+      l2 = EvtLeptonVACurrent(parent->getDaug(1)->spParent(1), parent->getDaug(2)->spParentNeutrino());
+    } else if (l_num == EP || l_num == MUP || l_num == TAUP) {
+      l1 = EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(), parent->getDaug(1)->spParent(0));
+      l2 = EvtLeptonVACurrent(parent->getDaug(2)->spParentNeutrino(), parent->getDaug(1)->spParent(1));
+
     } else {
-      EvtGenReport(EVTGEN_ERROR,"EvtGen")<< "Wrong lepton number \n";
+      EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Wrong lepton number \n";
     }
-      
+
     //  Baryon Current
     // Declare particle, anti-particle flag, same/opp. parity
     // pflag = 0 => particle
     // pflag = 1 => anti-particle
     int pflag = 0;
-    
+
     // Handle cases of 1/2+ -> 3/2- or 3/2+
-    if ( (par_num==LAMB && bar_num==LAMC2P) 
-	    ||(par_num==LAMB && bar_num==N1720 )
-	    ||(par_num==LAMB && bar_num==N1520 )
-	    ||(par_num==LAMB && bar_num==N1700 )
-	    ||(par_num==LAMB && bar_num==N1875 )
-	    ||(par_num==LAMB && bar_num==N1900 )
-       ) {
+    if ((par_num == LAMB && bar_num == LAMC2P) || (par_num == LAMB && bar_num == N1720) ||
+        (par_num == LAMB && bar_num == N1520) || (par_num == LAMB && bar_num == N1700) ||
+        (par_num == LAMB && bar_num == N1875) || (par_num == LAMB && bar_num == N1900)) {
       // Set flag for particle case
       pflag = 0;
-    }
-    else if (
-	    (par_num==LAMBB && bar_num==LAMC2M)
-	    ||(par_num==LAMBB && bar_num==N1520B )
-	    ||(par_num==LAMBB && bar_num==N1700B )
-	    ||(par_num==LAMBB && bar_num==N1875B )
-	    )
-    {
-    // Set flag for anti-particle opposite parity case
+    } else if ((par_num == LAMBB && bar_num == LAMC2M) || (par_num == LAMBB && bar_num == N1520B) ||
+               (par_num == LAMBB && bar_num == N1700B) || (par_num == LAMBB && bar_num == N1875B)) {
+      // Set flag for anti-particle opposite parity case
       pflag = 1;
     }
     // Handle anti-particle case for 1/2+ -> 3/2+
-    else if (
-	   ( par_num==LAMBB && bar_num==N1720B)
-	    || (par_num==LAMBB && bar_num==N1900B)
-	    ) {
+    else if ((par_num == LAMBB && bar_num == N1720B) || (par_num == LAMBB && bar_num == N1900B)) {
       pflag = 2;
-    }
-    else {
-      EvtGenReport(EVTGEN_ERROR,"EvtGen") << "Rarita-Schwinger semilep. baryon current " 
-			     << "not implemented for this decay sequence." 
-			     << std::endl;
+    } else {
+      EvtGenReport(EVTGEN_ERROR, "EvtGen") << "Rarita-Schwinger semilep. baryon current "
+                                           << "not implemented for this decay sequence." << std::endl;
       ::abort();
     }
-     
+
     // Baryon current
-    b11=EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(0),
-				 parent->sp(0),
-				 p4b, p4daught, form_fact, pflag);
-    b21=EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(0),
-				 parent->sp(1),
-				 p4b, p4daught, form_fact, pflag);
-    
-    b12=EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(1),
-				 parent->sp(0),
-				 p4b, p4daught, form_fact, pflag);
-    b22=EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(1),
-				 parent->sp(1),
-				 p4b, p4daught, form_fact, pflag);
-    
-    b13=EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(2),
-				 parent->sp(0),
-				 p4b, p4daught, form_fact, pflag);
-    b23=EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(2),
-				 parent->sp(1),
-				 p4b, p4daught, form_fact, pflag);
-    
-    b14=EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(3),
-				 parent->sp(0),
-				 p4b, p4daught, form_fact, pflag);
-    b24=EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(3),
-				 parent->sp(1),
-				 p4b, p4daught, form_fact, pflag);
-    
-    amp.vertex(0,0,0,l1*b11);
-    amp.vertex(0,0,1,l2*b11);
-    
-    amp.vertex(1,0,0,l1*b21);
-    amp.vertex(1,0,1,l2*b21);
-    
-    amp.vertex(0,1,0,l1*b12);
-    amp.vertex(0,1,1,l2*b12);
-    
-    amp.vertex(1,1,0,l1*b22);
-    amp.vertex(1,1,1,l2*b22);
-    
-    amp.vertex(0,2,0,l1*b13);
-    amp.vertex(0,2,1,l2*b13);
-    
-    amp.vertex(1,2,0,l1*b23);
-    amp.vertex(1,2,1,l2*b23);
+    b11 = EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(0), parent->sp(0), p4b, p4daught, form_fact, pflag);
+    b21 = EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(0), parent->sp(1), p4b, p4daught, form_fact, pflag);
 
-    amp.vertex(0,3,0,l1*b14);
-    amp.vertex(0,3,1,l2*b14);
-    
-    amp.vertex(1,3,0,l1*b24);
-    amp.vertex(1,3,1,l2*b24);
+    b12 = EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(1), parent->sp(0), p4b, p4daught, form_fact, pflag);
+    b22 = EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(1), parent->sp(1), p4b, p4daught, form_fact, pflag);
 
+    b13 = EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(2), parent->sp(0), p4b, p4daught, form_fact, pflag);
+    b23 = EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(2), parent->sp(1), p4b, p4daught, form_fact, pflag);
+
+    b14 = EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(3), parent->sp(0), p4b, p4daught, form_fact, pflag);
+    b24 = EvtBaryonVARaritaCurrent(parent->getDaug(0)->spRSParent(3), parent->sp(1), p4b, p4daught, form_fact, pflag);
+
+    amp.vertex(0, 0, 0, l1 * b11);
+    amp.vertex(0, 0, 1, l2 * b11);
+
+    amp.vertex(1, 0, 0, l1 * b21);
+    amp.vertex(1, 0, 1, l2 * b21);
+
+    amp.vertex(0, 1, 0, l1 * b12);
+    amp.vertex(0, 1, 1, l2 * b12);
+
+    amp.vertex(1, 1, 0, l1 * b22);
+    amp.vertex(1, 1, 1, l2 * b22);
+
+    amp.vertex(0, 2, 0, l1 * b13);
+    amp.vertex(0, 2, 1, l2 * b13);
+
+    amp.vertex(1, 2, 0, l1 * b23);
+    amp.vertex(1, 2, 1, l2 * b23);
+
+    amp.vertex(0, 3, 0, l1 * b14);
+    amp.vertex(0, 3, 1, l2 * b14);
+
+    amp.vertex(1, 3, 0, l1 * b24);
+    amp.vertex(1, 3, 1, l2 * b24);
   }
-
 }
-  
 
-EvtVector4C EvtSLBaryonAmp::EvtBaryonVACurrent( const EvtDiracSpinor& Bf,
-							  const EvtDiracSpinor& Bi, 
-							  EvtVector4R parent, 
-							  EvtVector4R daught, 
-							  const double *ff,
-							  int pflag) {
-
+EvtVector4C EvtSLBaryonAmp::EvtBaryonVACurrent(const EvtDiracSpinor &Bf,
+                                               const EvtDiracSpinor &Bi,
+                                               EvtVector4R parent,
+                                               EvtVector4R daught,
+                                               const double *ff,
+                                               int pflag) {
   // flag == 0 => particle
-  // flag == 1 => particle, opposite parity 
-  // flag == 2 => anti-particle, same parity 
-  // flag == 3 => anti-particle, opposite parity 
+  // flag == 1 => particle, opposite parity
+  // flag == 2 => anti-particle, same parity
+  // flag == 3 => anti-particle, opposite parity
 
   // particle
   EvtComplex cv = EvtComplex(1.0, 0.);
@@ -731,61 +620,56 @@ EvtVector4C EvtSLBaryonAmp::EvtBaryonVACurrent( const EvtDiracSpinor& Bf,
   EvtComplex cg5 = EvtComplex(1.0, 0.);
 
   // antiparticle- same parity parent & daughter
-  if( pflag == 2 ) {
+  if (pflag == 2) {
     cv = EvtComplex(-1.0, 0.);
     ca = EvtComplex(1.0, 0.);
 
-    cg0 =  EvtComplex(1.0, 0.0);
+    cg0 = EvtComplex(1.0, 0.0);
     // Changed cg5 from -i to -1 as appears to fix particle - anti-particle discrepency
-    cg5 =  EvtComplex(-1.0,0.0 );
+    cg5 = EvtComplex(-1.0, 0.0);
   }
   // antiparticle- opposite parity parent & daughter
-  else if( pflag == 3) {
+  else if (pflag == 3) {
     cv = EvtComplex(1.0, 0.);
     ca = EvtComplex(-1.0, 0.);
 
     // Changed cg0 from -i to -1 as appears to fix particle - anti-particle discrepency
-    cg0 =  EvtComplex(-1.0, 0.0);
-    cg5 =  EvtComplex(1.0, 0.0);
+    cg0 = EvtComplex(-1.0, 0.0);
+    cg5 = EvtComplex(1.0, 0.0);
   }
 
   EvtVector4C t[6];
 
-
-  
-
   // Term 1 = \bar{u}(p',s')*(F_1(q^2)*\gamma_{mu})*u(p,s)
-  t[0] = cv*EvtLeptonVCurrent( Bf, Bi);
+  t[0] = cv * EvtLeptonVCurrent(Bf, Bi);
 
   // Term 2 = \bar{u}(p',s')*(F_2(q^2)*(p_{mu}/m_{\Lambda_Q}))*u(p,s)
-  t[1] = cg0*EvtLeptonSCurrent( Bf, Bi ) * (parent/parent.mass());
+  t[1] = cg0 * EvtLeptonSCurrent(Bf, Bi) * (parent / parent.mass());
 
   // Term 3 = \bar{u}(p',s')*(F_3(q^2)*(p'_{mu}/m_{\Lambda_q}))*u(p,s)
-  t[2] = cg0*EvtLeptonSCurrent( Bf, Bi ) * (daught/daught.mass());
+  t[2] = cg0 * EvtLeptonSCurrent(Bf, Bi) * (daught / daught.mass());
 
   // Term 4 = \bar{u}(p',s')*(G_1(q^2)*\gamma_{mu}*\gamma_5)*u(p,s)
-  t[3] = ca*EvtLeptonACurrent( Bf, Bi);
+  t[3] = ca * EvtLeptonACurrent(Bf, Bi);
 
   // Term 5 =  \bar{u}(p',s')*(G_2(q^2)*(p_{mu}/m_{\Lambda_Q})*\gamma_5)*u(p,s)
-  t[4] = cg5*EvtLeptonPCurrent( Bf, Bi ) * (parent/parent.mass());
+  t[4] = cg5 * EvtLeptonPCurrent(Bf, Bi) * (parent / parent.mass());
 
   // Term 6 = \bar{u}(p',s')*(G_3(q^2)*(p'_{mu}/m_{\Lambda_q})*\gamma_5)*u(p,s)
-  t[5] = cg5*EvtLeptonPCurrent( Bf, Bi ) * (daught/daught.mass());
+  t[5] = cg5 * EvtLeptonPCurrent(Bf, Bi) * (daught / daught.mass());
 
   // Sum the individual terms
-  EvtVector4C current = (ff[0]*t[0] + ff[1]*t[1] + ff[2]*t[2]
-			 - ff[3]*t[3] - ff[4]*t[4] - ff[5]*t[5]);
-  
+  EvtVector4C current = (ff[0] * t[0] + ff[1] * t[1] + ff[2] * t[2] - ff[3] * t[3] - ff[4] * t[4] - ff[5] * t[5]);
+
   return current;
 }
 
-EvtVector4C EvtSLBaryonAmp::EvtBaryonVARaritaCurrent( const EvtRaritaSchwinger& Bf,
-								const EvtDiracSpinor& Bi, 
-								EvtVector4R parent, 
-								EvtVector4R daught, 
-								const double *ff,
-								int pflag) {
-
+EvtVector4C EvtSLBaryonAmp::EvtBaryonVARaritaCurrent(const EvtRaritaSchwinger &Bf,
+                                                     const EvtDiracSpinor &Bi,
+                                                     EvtVector4R parent,
+                                                     EvtVector4R daught,
+                                                     const double *ff,
+                                                     int pflag) {
   // flag == 0 => particle
   // flag == 1 => anti-particle
 
@@ -797,71 +681,71 @@ EvtVector4C EvtSLBaryonAmp::EvtBaryonVARaritaCurrent( const EvtRaritaSchwinger& 
   EvtComplex cg5 = EvtComplex(1.0, 0.);
 
   // antiparticle opposite parity
-  if( pflag == 1 ) {
+  if (pflag == 1) {
     cv = EvtComplex(-1.0, 0.);
     ca = EvtComplex(1.0, 0.);
- 
-    cg0 =  EvtComplex(1.0, 0.0);
-    cg5 =  EvtComplex(-1.0, 0.0);
- }
+
+    cg0 = EvtComplex(1.0, 0.0);
+    cg5 = EvtComplex(-1.0, 0.0);
+  }
   // antiparticle same parity
-  else if( pflag == 2) {
+  else if (pflag == 2) {
     cv = EvtComplex(1.0, 0.);
     ca = EvtComplex(-1.0, 0.);
 
-    cg0 =  EvtComplex(-1.0, 0.0);
-    cg5 =  EvtComplex(1.0, 0.0);
+    cg0 = EvtComplex(-1.0, 0.0);
+    cg5 = EvtComplex(1.0, 0.0);
   }
 
   EvtVector4C t[8];
   EvtTensor4C id;
-  id.setdiag(1.0,1.0,1.0,1.0);
+  id.setdiag(1.0, 1.0, 1.0, 1.0);
 
   EvtDiracSpinor tmp;
-  for(int i=0;i<4;i++){
-    tmp.set_spinor(i,Bf.getVector(i)*parent);
+  for (int i = 0; i < 4; i++) {
+    tmp.set_spinor(i, Bf.getVector(i) * parent);
   }
 
-  EvtVector4C v1,v2;
-  for(int i=0;i<4;i++){
-    v1.set(i,EvtLeptonSCurrent(Bf.getSpinor(i),Bi));
-    v2.set(i,EvtLeptonPCurrent(Bf.getSpinor(i),Bi));
+  EvtVector4C v1, v2;
+  for (int i = 0; i < 4; i++) {
+    v1.set(i, EvtLeptonSCurrent(Bf.getSpinor(i), Bi));
+    v2.set(i, EvtLeptonPCurrent(Bf.getSpinor(i), Bi));
   }
 
   // Term 1 = \bar{u}^{\alpha}(p',s')*(p_{\alpha}/m_{\Lambda_Q})*(F_1(q^2)*\gamma_{mu})*u(p,s)
-  t[0] = (cv/parent.mass()) * EvtLeptonVCurrent(tmp, Bi);
+  t[0] = (cv / parent.mass()) * EvtLeptonVCurrent(tmp, Bi);
 
-  // Term 2 
+  // Term 2
   // = \bar{u}^{\alpha}(p',s')*(p_{\alpha}/m_{\Lambda_Q})*(F_2(q^2)*(p_{mu}/m_{\Lambda_Q}))*u(p,s)
-  t[1] = ((cg0/parent.mass()) * EvtLeptonSCurrent(tmp, Bi)) * (parent/parent.mass());
+  t[1] = ((cg0 / parent.mass()) * EvtLeptonSCurrent(tmp, Bi)) * (parent / parent.mass());
 
-  // Term 3 
+  // Term 3
   // = \bar{u}^{\alpha}(p',s')*(p_{\alpha}/m_{\Lambda_Q})*(F_3(q^2)*(p'_{mu}/m_{\Lambda_q}))*u(p,s)
-  t[2] = ((cg0/parent.mass()) * EvtLeptonSCurrent(tmp, Bi)) * (daught/daught.mass());
+  t[2] = ((cg0 / parent.mass()) * EvtLeptonSCurrent(tmp, Bi)) * (daught / daught.mass());
 
   // Term 4 = \bar{u}^{\alpha}(p',s')*(F_4(q^2)*g_{\alpha,\mu})*u(p,s)
-  t[3] = cg0*(id.cont2(v1));
+  t[3] = cg0 * (id.cont2(v1));
 
-  // Term 5 
+  // Term 5
   // = \bar{u}^{\alpha}(p',s')*(p_{\alpha}/m_{\Lambda_Q})*(G_1(q^2)*\gamma_{mu}*\gamma_5)*u(p,s)
-  t[4] = (ca/parent.mass()) * EvtLeptonACurrent(tmp, Bi);
+  t[4] = (ca / parent.mass()) * EvtLeptonACurrent(tmp, Bi);
 
-  // Term 6 
+  // Term 6
   // = \bar{u}^{\alpha}(p',s')*(p_{\alpha}/m_{\Lambda_Q})
   //      *(G_2(q^2)*(p_{mu}/m_{\Lambda_Q})*\gamma_5)*u(p,s)
-  t[5] = ((cg5/parent.mass()) * EvtLeptonPCurrent(tmp, Bi)) * (parent/parent.mass());
+  t[5] = ((cg5 / parent.mass()) * EvtLeptonPCurrent(tmp, Bi)) * (parent / parent.mass());
 
-  // Term 7 
+  // Term 7
   // = \bar{u}^{\alpha}(p',s')*(p_{\alpha}/m_{\Lambda_Q})
   //      *(G_3(q^2)*(p'_{mu}/m_{\Lambda_q})*\gamma_5)*u(p,s)
-  t[6] = ((cg5/parent.mass()) * EvtLeptonPCurrent(tmp, Bi)) * (daught/daught.mass());
+  t[6] = ((cg5 / parent.mass()) * EvtLeptonPCurrent(tmp, Bi)) * (daught / daught.mass());
 
   // Term 8 = \bar{u}^{\alpha}(p',s')*(G_4(q^2)*g_{\alpha,\mu}*\gamma_5))*u(p,s)
-  t[7] = cg5*(id.cont2(v2));
+  t[7] = cg5 * (id.cont2(v2));
 
   // Sum the individual terms
-  EvtVector4C current = (ff[0]*t[0] + ff[1]*t[1] + ff[2]*t[2] + ff[3]*t[3]
-			 - ff[4]*t[4] - ff[5]*t[5] - ff[6]*t[6] - ff[7]*t[7]);
-  
+  EvtVector4C current = (ff[0] * t[0] + ff[1] * t[1] + ff[2] * t[2] + ff[3] * t[3] - ff[4] * t[4] - ff[5] * t[5] -
+                         ff[6] * t[6] - ff[7] * t[7]);
+
   return current;
 }

--- a/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtSLBaryonAmp.hh
+++ b/GeneratorInterface/EvtGenInterface/plugins/EvtGenUserModels/EvtSLBaryonAmp.hh
@@ -33,44 +33,46 @@ class EvtVector4R;
 class EvtDiracSpinor;
 class EvtRaritaSchwinger;
 
-class EvtSLBaryonAmp:public EvtSemiLeptonicAmp {
-
- public:
-
+class EvtSLBaryonAmp : public EvtSemiLeptonicAmp {
+public:
   ~EvtSLBaryonAmp() override;
 
   //Daughters are initialized and have been added to the parent.
   //No need to carry around the daughters seperately!
-  void CalcAmp( EvtParticle *parent,EvtAmp& amp,
-		EvtSemiLeptonicFF *FormFactors ) override;
+  void CalcAmp(EvtParticle *parent, EvtAmp &amp, EvtSemiLeptonicFF *FormFactors) override;
 
-  void CalcAmp( EvtParticle *parent, EvtAmp& amp,
-		EvtSemiLeptonicFF *FormFactors,
-		EvtComplex r00, EvtComplex r01,
-		EvtComplex r10, EvtComplex r11 );
-  
-  double CalcMaxProb( EvtId parent, EvtId meson, EvtId lepton,
-                      EvtId nudaug, EvtSemiLeptonicFF *FormFactors,
-                      EvtComplex r00, EvtComplex r01,
-                      EvtComplex r10, EvtComplex r11);
+  void CalcAmp(EvtParticle *parent,
+               EvtAmp &amp,
+               EvtSemiLeptonicFF *FormFactors,
+               EvtComplex r00,
+               EvtComplex r01,
+               EvtComplex r10,
+               EvtComplex r11);
 
+  double CalcMaxProb(EvtId parent,
+                     EvtId meson,
+                     EvtId lepton,
+                     EvtId nudaug,
+                     EvtSemiLeptonicFF *FormFactors,
+                     EvtComplex r00,
+                     EvtComplex r01,
+                     EvtComplex r10,
+                     EvtComplex r11);
 
- private:
+private:
+  EvtVector4C EvtBaryonVACurrent(const EvtDiracSpinor &Bf,
+                                 const EvtDiracSpinor &Bi,
+                                 EvtVector4R parent,
+                                 EvtVector4R daught,
+                                 const double *ff,
+                                 int pflag);
 
-  EvtVector4C EvtBaryonVACurrent( const EvtDiracSpinor& Bf,
-				  const EvtDiracSpinor& Bi, 
-				  EvtVector4R parent, 
-				  EvtVector4R daught, 
-				  const double *ff, int pflag);
-
-  EvtVector4C EvtBaryonVARaritaCurrent( const EvtRaritaSchwinger& Bf_vect,
-					const EvtDiracSpinor& Bi, 
-					EvtVector4R parent, 
-					EvtVector4R daught, 
-					const double *ff, int pflag);
-
+  EvtVector4C EvtBaryonVARaritaCurrent(const EvtRaritaSchwinger &Bf_vect,
+                                       const EvtDiracSpinor &Bi,
+                                       EvtVector4R parent,
+                                       EvtVector4R daught,
+                                       const double *ff,
+                                       int pflag);
 };
 
 #endif
-
-

--- a/GeneratorInterface/EvtGenInterface/plugins/myEvtRandomEngine.cc
+++ b/GeneratorInterface/EvtGenInterface/plugins/myEvtRandomEngine.cc
@@ -19,22 +19,20 @@
 #include "CLHEP/Random/RandomEngine.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
-myEvtRandomEngine::myEvtRandomEngine(CLHEP::HepRandomEngine *xx) {the_engine = xx;}
+myEvtRandomEngine::myEvtRandomEngine(CLHEP::HepRandomEngine *xx) { the_engine = xx; }
 
 myEvtRandomEngine::~myEvtRandomEngine() {}
 
-double myEvtRandomEngine::random()
-{
-  if(the_engine == nullptr) {
+double myEvtRandomEngine::random() {
+  if (the_engine == nullptr) {
     throwNullPtr();
   }
   return the_engine->flat();
 }
 
 void myEvtRandomEngine::throwNullPtr() const {
-  throw edm::Exception(edm::errors::LogicError)
-    << "The EvtGen code attempted to a generate random number while\n"
-    << "the engine pointer was null. This might mean that the code\n"
-    << "was modified to generate a random number outside the event and\n"
-    << "beginLuminosityBlock methods, which is not allowed.\n";
+  throw edm::Exception(edm::errors::LogicError) << "The EvtGen code attempted to a generate random number while\n"
+                                                << "the engine pointer was null. This might mean that the code\n"
+                                                << "was modified to generate a random number outside the event and\n"
+                                                << "beginLuminosityBlock methods, which is not allowed.\n";
 }

--- a/GeneratorInterface/EvtGenInterface/src/EvtGenFactory.cc
+++ b/GeneratorInterface/EvtGenInterface/src/EvtGenFactory.cc
@@ -1,3 +1,2 @@
 #include "GeneratorInterface/EvtGenInterface/interface/EvtGenFactory.h"
-EDM_REGISTER_PLUGINFACTORY(EvtGenFactory,"EvtGenFactory");
-
+EDM_REGISTER_PLUGINFACTORY(EvtGenFactory, "EvtGenFactory");


### PR DESCRIPTION

Applying code-format for CMSSW category generators.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/292//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


