### PR TITLE
Running code-format for l1-simulation

### DIFF
--- a/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
@@ -21,7 +21,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h" /// NOTE: this is needed even if it seems not
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"  /// NOTE: this is needed even if it seems not
 #include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/Track/interface/SimTrack.h"
@@ -29,48 +29,61 @@
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 
-template< typename T >
-class TTClusterAssociationMap
-{
-  public:
-    /// Constructors
-    TTClusterAssociationMap();
+template <typename T>
+class TTClusterAssociationMap {
+public:
+  /// Constructors
+  TTClusterAssociationMap();
 
-    /// Destructor
-    ~TTClusterAssociationMap();
+  /// Destructor
+  ~TTClusterAssociationMap();
 
-    /// Data members:   getABC( ... )
-    /// Helper methods: findABC( ... )
+  /// Data members:   getABC( ... )
+  /// Helper methods: findABC( ... )
 
-    /// Maps
-    std::map< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > >, std::vector< edm::Ptr< TrackingParticle > > > getTTClusterToTrackingParticlesMap() const
-      { return clusterToTrackingParticleVectorMap; }
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > > > getTrackingParticleToTTClustersMap() const
-      { return trackingParticleToClusterVectorMap; }
+  /// Maps
+  std::map<edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> >, std::vector<edm::Ptr<TrackingParticle> > >
+  getTTClusterToTrackingParticlesMap() const {
+    return clusterToTrackingParticleVectorMap;
+  }
+  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > > >
+  getTrackingParticleToTTClustersMap() const {
+    return trackingParticleToClusterVectorMap;
+  }
 
-    void setTTClusterToTrackingParticlesMap( std::map< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > >, std::vector< edm::Ptr< TrackingParticle > > > aMap )
-      { clusterToTrackingParticleVectorMap = aMap; }
-    void setTrackingParticleToTTClustersMap( std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > > > aMap )
-      { trackingParticleToClusterVectorMap = aMap; }
+  void setTTClusterToTrackingParticlesMap(std::map<edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> >,
+                                                   std::vector<edm::Ptr<TrackingParticle> > > aMap) {
+    clusterToTrackingParticleVectorMap = aMap;
+  }
+  void setTrackingParticleToTTClustersMap(
+      std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > > >
+          aMap) {
+    trackingParticleToClusterVectorMap = aMap;
+  }
 
-    /// Operations
-    std::vector< edm::Ptr< TrackingParticle > >                                       findTrackingParticlePtrs( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const;
-    edm::Ptr< TrackingParticle >                                                      findTrackingParticlePtr( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const;
-    std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > > findTTClusterRefs( edm::Ptr< TrackingParticle > aTrackingParticle ) const;
+  /// Operations
+  std::vector<edm::Ptr<TrackingParticle> > findTrackingParticlePtrs(
+      edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const;
+  edm::Ptr<TrackingParticle> findTrackingParticlePtr(
+      edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const;
+  std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > > findTTClusterRefs(
+      edm::Ptr<TrackingParticle> aTrackingParticle) const;
 
-    /// MC Truth methods
-    bool isGenuine( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const;
-    bool isCombinatoric( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const;
-    bool isUnknown( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const;
+  /// MC Truth methods
+  bool isGenuine(edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const;
+  bool isCombinatoric(edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const;
+  bool isUnknown(edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const;
 
-  private:
-    /// Data members
-    std::map< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > >, std::vector< edm::Ptr< TrackingParticle > > > clusterToTrackingParticleVectorMap;
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > > > trackingParticleToClusterVectorMap;
+private:
+  /// Data members
+  std::map<edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> >, std::vector<edm::Ptr<TrackingParticle> > >
+      clusterToTrackingParticleVectorMap;
+  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > > >
+      trackingParticleToClusterVectorMap;
 
-    int nclus;
+  int nclus;
 
-}; /// Close class
+};  /// Close class
 
 /*! \brief   Implementation of methods
  *  \details Here, in the header file, the methods which do not depend
@@ -81,46 +94,42 @@ class TTClusterAssociationMap
 
 /// Default Constructor
 /// NOTE: to be used with setSomething(...) methods
-template< typename T >
-TTClusterAssociationMap< T >::TTClusterAssociationMap()
-{
+template <typename T>
+TTClusterAssociationMap<T>::TTClusterAssociationMap() {
   /// Set default data members
   clusterToTrackingParticleVectorMap.clear();
   trackingParticleToClusterVectorMap.clear();
-  nclus=0;
+  nclus = 0;
 }
 
 /// Destructor
-template< typename T >
-TTClusterAssociationMap< T >::~TTClusterAssociationMap(){}
+template <typename T>
+TTClusterAssociationMap<T>::~TTClusterAssociationMap() {}
 
 /// Operations
-template< typename T >
-std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > > TTClusterAssociationMap< T >::findTTClusterRefs( edm::Ptr< TrackingParticle > aTrackingParticle ) const
-{
-  if ( trackingParticleToClusterVectorMap.find( aTrackingParticle ) != trackingParticleToClusterVectorMap.end() )
-  {
-    return trackingParticleToClusterVectorMap.find( aTrackingParticle )->second;
+template <typename T>
+std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > >
+TTClusterAssociationMap<T>::findTTClusterRefs(edm::Ptr<TrackingParticle> aTrackingParticle) const {
+  if (trackingParticleToClusterVectorMap.find(aTrackingParticle) != trackingParticleToClusterVectorMap.end()) {
+    return trackingParticleToClusterVectorMap.find(aTrackingParticle)->second;
   }
 
-  std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > > tempVector;
+  std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > > tempVector;
   tempVector.clear();
   return tempVector;
 }
 
-template< typename T >
-std::vector< edm::Ptr< TrackingParticle > > TTClusterAssociationMap< T >::findTrackingParticlePtrs( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const
-{
-  if ( clusterToTrackingParticleVectorMap.find( aCluster ) != clusterToTrackingParticleVectorMap.end() )
-  {
-    return clusterToTrackingParticleVectorMap.find( aCluster )->second;
+template <typename T>
+std::vector<edm::Ptr<TrackingParticle> > TTClusterAssociationMap<T>::findTrackingParticlePtrs(
+    edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const {
+  if (clusterToTrackingParticleVectorMap.find(aCluster) != clusterToTrackingParticleVectorMap.end()) {
+    return clusterToTrackingParticleVectorMap.find(aCluster)->second;
   }
 
-  std::vector< edm::Ptr< TrackingParticle > > tempVector;
+  std::vector<edm::Ptr<TrackingParticle> > tempVector;
   tempVector.clear();
   return tempVector;
 }
-
 
 /// MC truth
 /// Table to define Genuine, Combinatoric and Unknown
@@ -144,160 +153,140 @@ std::vector< edm::Ptr< TrackingParticle > > TTClusterAssociationMap< T >::findTr
 /// >0       | U | G | G                                          | C
 ///
 
-template< typename T >
-bool TTClusterAssociationMap< T >::isGenuine( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const
-{
-
-
+template <typename T>
+bool TTClusterAssociationMap<T>::isGenuine(edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const {
   /// Get the TrackingParticles
-  std::vector< edm::Ptr< TrackingParticle > > theseTrackingParticles = this->findTrackingParticlePtrs( aCluster );
-
-
+  std::vector<edm::Ptr<TrackingParticle> > theseTrackingParticles = this->findTrackingParticlePtrs(aCluster);
 
   /// If the vector is empty, then the cluster is UNKNOWN
-  if ( theseTrackingParticles.empty() )
+  if (theseTrackingParticles.empty())
     return false;
 
   /// If we are here, it means there are some TrackingParticles
   unsigned int nullTPs = 0;
   unsigned int goodDifferentTPs = 0;
-  std::vector< const TrackingParticle* > tpAddressVector;
+  std::vector<const TrackingParticle*> tpAddressVector;
 
   std::vector<float> tp_mom;
 
-  float tp_tot=0;
+  float tp_tot = 0;
 
   /// Loop over the TrackingParticles
-  for ( const auto& tp : theseTrackingParticles )
-  {
+  for (const auto& tp : theseTrackingParticles) {
     /// Get the TrackingParticle
-    const edm::Ptr< TrackingParticle >& curTP = tp;
+    const edm::Ptr<TrackingParticle>& curTP = tp;
 
     /// Count the NULL TrackingParticles
-    if ( curTP.isNull() )
-    {
+    if (curTP.isNull()) {
       //      nullTPs++;
       tp_mom.push_back(0);
-    }
-    else
-    {
+    } else {
       tp_mom.push_back(curTP.get()->p4().pt());
-      tp_tot+=curTP.get()->p4().pt();
+      tp_tot += curTP.get()->p4().pt();
     }
   }
 
-  if (tp_tot==0) return false;
-  
-  for ( unsigned int itp = 0; itp < theseTrackingParticles.size(); itp++ )
-  {
+  if (tp_tot == 0)
+    return false;
+
+  for (unsigned int itp = 0; itp < theseTrackingParticles.size(); itp++) {
     /// Get the TrackingParticle
-    edm::Ptr< TrackingParticle > curTP = theseTrackingParticles.at(itp);
+    edm::Ptr<TrackingParticle> curTP = theseTrackingParticles.at(itp);
 
     /// Count the NULL TrackingParticles
-    if ( tp_mom.at(itp) <= 0.01*tp_tot)
-    {
+    if (tp_mom.at(itp) <= 0.01 * tp_tot) {
       nullTPs++;
-    }
-    else
-    {
+    } else {
       /// Store the pointers (addresses) of the TrackingParticle
       /// to be able to count how many different there are
-      tpAddressVector.push_back( curTP.get() );
+      tpAddressVector.push_back(curTP.get());
     }
   }
-  
 
   /// Count how many different TrackingParticle there are
-  std::sort( tpAddressVector.begin(), tpAddressVector.end() );
-  tpAddressVector.erase( std::unique( tpAddressVector.begin(), tpAddressVector.end() ), tpAddressVector.end() );
+  std::sort(tpAddressVector.begin(), tpAddressVector.end());
+  tpAddressVector.erase(std::unique(tpAddressVector.begin(), tpAddressVector.end()), tpAddressVector.end());
   goodDifferentTPs = tpAddressVector.size();
 
-  return ( goodDifferentTPs == 1 );
+  return (goodDifferentTPs == 1);
 }
 
-template< typename T >
-bool TTClusterAssociationMap< T >::isUnknown( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const
-{
+template <typename T>
+bool TTClusterAssociationMap<T>::isUnknown(edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const {
   /// Get the TrackingParticles
-  std::vector< edm::Ptr< TrackingParticle > > theseTrackingParticles = this->findTrackingParticlePtrs( aCluster );
+  std::vector<edm::Ptr<TrackingParticle> > theseTrackingParticles = this->findTrackingParticlePtrs(aCluster);
 
   /// If the vector is empty, then the cluster is UNKNOWN
-  if ( theseTrackingParticles.empty() )
+  if (theseTrackingParticles.empty())
     return true;
 
   /// If we are here, it means there are some TrackingParticles
   unsigned int goodDifferentTPs = 0;
-  std::vector< const TrackingParticle* > tpAddressVector;
+  std::vector<const TrackingParticle*> tpAddressVector;
 
   /// Loop over the TrackingParticles
-  for ( unsigned int itp = 0; itp < theseTrackingParticles.size(); itp++ )
-  {
+  for (unsigned int itp = 0; itp < theseTrackingParticles.size(); itp++) {
     /// Get the TrackingParticle
-    edm::Ptr< TrackingParticle > curTP = theseTrackingParticles.at(itp);
+    edm::Ptr<TrackingParticle> curTP = theseTrackingParticles.at(itp);
 
     /// Count the non-NULL TrackingParticles
-    if ( !curTP.isNull() )
-    {
+    if (!curTP.isNull()) {
       /// Store the pointers (addresses) of the TrackingParticle
       /// to be able to count how many different there are
-      tpAddressVector.push_back( curTP.get() );
+      tpAddressVector.push_back(curTP.get());
     }
   }
 
   /// Count how many different TrackingParticle there are
-  std::sort( tpAddressVector.begin(), tpAddressVector.end() );
-  tpAddressVector.erase( std::unique( tpAddressVector.begin(), tpAddressVector.end() ), tpAddressVector.end() );
+  std::sort(tpAddressVector.begin(), tpAddressVector.end());
+  tpAddressVector.erase(std::unique(tpAddressVector.begin(), tpAddressVector.end()), tpAddressVector.end());
   goodDifferentTPs = tpAddressVector.size();
 
   /// UNKNOWN means no good TP is found
-  return ( goodDifferentTPs == 0 );
+  return (goodDifferentTPs == 0);
 }
 
-template< typename T >
-bool TTClusterAssociationMap< T >::isCombinatoric( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const
-{
+template <typename T>
+bool TTClusterAssociationMap<T>::isCombinatoric(
+    edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const {
   /// Get the TrackingParticles
-  std::vector< edm::Ptr< TrackingParticle > > theseTrackingParticles = this->findTrackingParticlePtrs( aCluster );
+  std::vector<edm::Ptr<TrackingParticle> > theseTrackingParticles = this->findTrackingParticlePtrs(aCluster);
 
   /// If the vector is empty, then the cluster is UNKNOWN
-  if ( theseTrackingParticles.empty())
+  if (theseTrackingParticles.empty())
     return false;
 
+  bool genuineClu = this->isGenuine(aCluster);
+  bool unknownClu = this->isUnknown(aCluster);
 
-  bool genuineClu = this->isGenuine( aCluster );
-  bool unknownClu = this->isUnknown( aCluster );
-
-  if (genuineClu || unknownClu) return false;
+  if (genuineClu || unknownClu)
+    return false;
 
   return true;
 
   /// If we are here, it means there are some TrackingParticles
   unsigned int nullTPs = 0;
   unsigned int goodDifferentTPs = 0;
-  std::vector< const TrackingParticle* > tpAddressVector;
-  
-  /// Loop over the TrackingParticles 
-  for ( unsigned int itp = 0; itp < theseTrackingParticles.size(); itp++ )
-  {
-    /// Get the TrackingParticle 
-    edm::Ptr< TrackingParticle > curTP = theseTrackingParticles.at(itp);
+  std::vector<const TrackingParticle*> tpAddressVector;
+
+  /// Loop over the TrackingParticles
+  for (unsigned int itp = 0; itp < theseTrackingParticles.size(); itp++) {
+    /// Get the TrackingParticle
+    edm::Ptr<TrackingParticle> curTP = theseTrackingParticles.at(itp);
 
     /// Count the NULL TrackingParticles
-    if ( curTP.isNull() )
-    {
+    if (curTP.isNull()) {
       nullTPs++;
-    }
-    else
-    {
+    } else {
       /// Store the pointers (addresses) of the TrackingParticle
       /// to be able to count how many different there are
-      tpAddressVector.push_back( curTP.get() );
+      tpAddressVector.push_back(curTP.get());
     }
   }
 
   /// Count how many different TrackingParticle there are
-  std::sort( tpAddressVector.begin(), tpAddressVector.end() );
-  tpAddressVector.erase( std::unique( tpAddressVector.begin(), tpAddressVector.end() ), tpAddressVector.end() );
+  std::sort(tpAddressVector.begin(), tpAddressVector.end());
+  tpAddressVector.erase(std::unique(tpAddressVector.begin(), tpAddressVector.end()), tpAddressVector.end());
   goodDifferentTPs = tpAddressVector.size();
 
   /// COMBINATORIC means no NULLs and more than one good TP
@@ -306,18 +295,15 @@ bool TTClusterAssociationMap< T >::isCombinatoric( edm::Ref< edmNew::DetSetVecto
   return (goodDifferentTPs > 1);
 }
 
-template< typename T >
-edm::Ptr< TrackingParticle > TTClusterAssociationMap< T >::findTrackingParticlePtr( edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > aCluster ) const
-{
-  if ( this->isGenuine( aCluster ) )
-  {
-    return this->findTrackingParticlePtrs( aCluster ).at(0);
+template <typename T>
+edm::Ptr<TrackingParticle> TTClusterAssociationMap<T>::findTrackingParticlePtr(
+    edm::Ref<edmNew::DetSetVector<TTCluster<T> >, TTCluster<T> > aCluster) const {
+  if (this->isGenuine(aCluster)) {
+    return this->findTrackingParticlePtrs(aCluster).at(0);
   }
 
-  edm::Ptr< TrackingParticle >* temp = new edm::Ptr< TrackingParticle >();
+  edm::Ptr<TrackingParticle>* temp = new edm::Ptr<TrackingParticle>();
   return *temp;
 }
 
 #endif
-
-

--- a/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
@@ -171,7 +171,7 @@ bool TTClusterAssociationMap< T >::isGenuine( edm::Ref< edmNew::DetSetVector< TT
   for ( const auto& tp : theseTrackingParticles )
   {
     /// Get the TrackingParticle
-    edm::Ptr< TrackingParticle > curTP = tp;
+    const edm::Ptr< TrackingParticle >& curTP = tp;
 
     /// Count the NULL TrackingParticles
     if ( curTP.isNull() )

--- a/SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h
@@ -23,7 +23,7 @@
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 //#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h" /// NOTE: this is needed even if it seems not
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"  /// NOTE: this is needed even if it seems not
 #include "DataFormats/L1TrackTrigger/interface/TTStub.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/Track/interface/SimTrack.h"
@@ -32,48 +32,59 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h"
 
-template< typename T >
-class TTStubAssociationMap
-{
-  public:
-    /// Constructors
-    TTStubAssociationMap();
+template <typename T>
+class TTStubAssociationMap {
+public:
+  /// Constructors
+  TTStubAssociationMap();
 
-    /// Destructor
-    ~TTStubAssociationMap();
+  /// Destructor
+  ~TTStubAssociationMap();
 
-    /// Data members:   getABC( ... )
-    /// Helper methods: findABC( ... )
+  /// Data members:   getABC( ... )
+  /// Helper methods: findABC( ... )
 
-    /// Maps
-    std::map< edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > >, edm::Ptr< TrackingParticle > > getTTStubToTrackingParticleMap() const
-      { return stubToTrackingParticleMap; }
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > > > getTrackingParticleToTTStubsMap() const
-      { return trackingParticleToStubVectorMap; }
+  /// Maps
+  std::map<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> >, edm::Ptr<TrackingParticle> >
+  getTTStubToTrackingParticleMap() const {
+    return stubToTrackingParticleMap;
+  }
+  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > >
+  getTrackingParticleToTTStubsMap() const {
+    return trackingParticleToStubVectorMap;
+  }
 
-    void setTTStubToTrackingParticleMap( std::map< edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > >, edm::Ptr< TrackingParticle > > aMap )
-      { stubToTrackingParticleMap = aMap; }
-    void setTrackingParticleToTTStubsMap( std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > > > aMap )
-      { trackingParticleToStubVectorMap = aMap; }
-    void setTTClusterAssociationMap( edm::RefProd< TTClusterAssociationMap< T > > aCluAssoMap )
-      { theClusterAssociationMap = aCluAssoMap; }
+  void setTTStubToTrackingParticleMap(
+      std::map<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> >, edm::Ptr<TrackingParticle> > aMap) {
+    stubToTrackingParticleMap = aMap;
+  }
+  void setTrackingParticleToTTStubsMap(
+      std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > > aMap) {
+    trackingParticleToStubVectorMap = aMap;
+  }
+  void setTTClusterAssociationMap(edm::RefProd<TTClusterAssociationMap<T> > aCluAssoMap) {
+    theClusterAssociationMap = aCluAssoMap;
+  }
 
-    /// Operations
-    edm::Ptr< TrackingParticle >                                                findTrackingParticlePtr( edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > aStub ) const;
-    std::vector< edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > > findTTStubRefs( edm::Ptr< TrackingParticle > aTrackingParticle ) const;
+  /// Operations
+  edm::Ptr<TrackingParticle> findTrackingParticlePtr(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const;
+  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > findTTStubRefs(
+      edm::Ptr<TrackingParticle> aTrackingParticle) const;
 
-    /// MC Truth methods
-    bool isGenuine( edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > aStub ) const;
-    bool isCombinatoric( edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > aStub ) const;
-    bool isUnknown( edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > aStub ) const;
+  /// MC Truth methods
+  bool isGenuine(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const;
+  bool isCombinatoric(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const;
+  bool isUnknown(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const;
 
-  private:
-    /// Data members
-    std::map< edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > >, edm::Ptr< TrackingParticle > >                stubToTrackingParticleMap;
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > > > trackingParticleToStubVectorMap;
-    edm::RefProd< TTClusterAssociationMap< T > >                                                                          theClusterAssociationMap;
+private:
+  /// Data members
+  std::map<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> >, edm::Ptr<TrackingParticle> >
+      stubToTrackingParticleMap;
+  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > >
+      trackingParticleToStubVectorMap;
+  edm::RefProd<TTClusterAssociationMap<T> > theClusterAssociationMap;
 
-}; /// Close class
+};  /// Close class
 
 /*! \brief   Implementation of methods
  *  \details Here, in the header file, the methods which do not depend
@@ -84,91 +95,81 @@ class TTStubAssociationMap
 
 /// Default Constructor
 /// NOTE: to be used with setSomething(...) methods
-template< typename T >
-TTStubAssociationMap< T >::TTStubAssociationMap()
-{
+template <typename T>
+TTStubAssociationMap<T>::TTStubAssociationMap() {
   /// Set default data members
   stubToTrackingParticleMap.clear();
   trackingParticleToStubVectorMap.clear();
-  edm::RefProd< TTClusterAssociationMap< T > >* aRefProd = new edm::RefProd< TTClusterAssociationMap< T > >();
+  edm::RefProd<TTClusterAssociationMap<T> >* aRefProd = new edm::RefProd<TTClusterAssociationMap<T> >();
   theClusterAssociationMap = *aRefProd;
 }
 
 /// Destructor
-template< typename T >
-TTStubAssociationMap< T >::~TTStubAssociationMap(){}
+template <typename T>
+TTStubAssociationMap<T>::~TTStubAssociationMap() {}
 
 /// Operations
-template< typename T >
-edm::Ptr< TrackingParticle > TTStubAssociationMap< T >::findTrackingParticlePtr( edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > aStub ) const
-{
-  if ( stubToTrackingParticleMap.find( aStub ) != stubToTrackingParticleMap.end() )
-  {
-    return stubToTrackingParticleMap.find( aStub )->second;
+template <typename T>
+edm::Ptr<TrackingParticle> TTStubAssociationMap<T>::findTrackingParticlePtr(
+    edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const {
+  if (stubToTrackingParticleMap.find(aStub) != stubToTrackingParticleMap.end()) {
+    return stubToTrackingParticleMap.find(aStub)->second;
   }
 
   /// Default: return NULL
   //edm::Ptr< TrackingParticle >* temp = new edm::Ptr< TrackingParticle >();
-  return edm::Ptr< TrackingParticle >();
+  return edm::Ptr<TrackingParticle>();
 }
 
-template< typename T >
-std::vector< edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > > TTStubAssociationMap< T >::findTTStubRefs( edm::Ptr< TrackingParticle > aTrackingParticle ) const
-{
-  if ( trackingParticleToStubVectorMap.find( aTrackingParticle ) != trackingParticleToStubVectorMap.end() )
-  {
-    return trackingParticleToStubVectorMap.find( aTrackingParticle )->second;
+template <typename T>
+std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > TTStubAssociationMap<T>::findTTStubRefs(
+    edm::Ptr<TrackingParticle> aTrackingParticle) const {
+  if (trackingParticleToStubVectorMap.find(aTrackingParticle) != trackingParticleToStubVectorMap.end()) {
+    return trackingParticleToStubVectorMap.find(aTrackingParticle)->second;
   }
 
-  std::vector< edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > > tempVector;
+  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > tempVector;
   tempVector.clear();
   return tempVector;
 }
 
-
 /// MC truth
-template< typename T >
-bool TTStubAssociationMap< T >::isGenuine( edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > aStub ) const
-{
+template <typename T>
+bool TTStubAssociationMap<T>::isGenuine(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const {
   /// Check if there is a SimTrack
-  if ( (this->findTrackingParticlePtr( aStub )).isNull() )
+  if ((this->findTrackingParticlePtr(aStub)).isNull())
     return false;
 
   return true;
 }
 
-template< typename T >
-bool TTStubAssociationMap< T >::isCombinatoric( edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > aStub ) const
-{
+template <typename T>
+bool TTStubAssociationMap<T>::isCombinatoric(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const {
   /// Defined by exclusion
-  if ( this->isGenuine( aStub ) )
+  if (this->isGenuine(aStub))
     return false;
 
-  if ( this->isUnknown( aStub ) )
+  if (this->isUnknown(aStub))
     return false;
 
   return true;
 }
 
-template< typename T >
-bool TTStubAssociationMap< T >::isUnknown( edm::Ref< edmNew::DetSetVector< TTStub< T > >, TTStub< T > > aStub ) const
-{
+template <typename T>
+bool TTStubAssociationMap<T>::isUnknown(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const {
   /// UNKNOWN means that both clusters are unknown
   //std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > > theseClusters = aStub->getClusterRefs();
 
   /// Sanity check
-  if ( theClusterAssociationMap.isNull() )
-  {
+  if (theClusterAssociationMap.isNull()) {
     return true;
   }
 
-  if ( theClusterAssociationMap->isUnknown( aStub->getClusterRef(0) ) &&
-       theClusterAssociationMap->isUnknown( aStub->getClusterRef(1) ) )
+  if (theClusterAssociationMap->isUnknown(aStub->getClusterRef(0)) &&
+      theClusterAssociationMap->isUnknown(aStub->getClusterRef(1)))
     return true;
 
   return false;
 }
 
-
 #endif
-

--- a/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
@@ -21,7 +21,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h" /// NOTE: this is needed even if it seems not
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"  /// NOTE: this is needed even if it seems not
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/Track/interface/SimTrack.h"
@@ -30,49 +30,54 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h"
 
-template< typename T >
-class TTTrackAssociationMap
-{
-  public:
-    /// Constructors
-    TTTrackAssociationMap();
+template <typename T>
+class TTTrackAssociationMap {
+public:
+  /// Constructors
+  TTTrackAssociationMap();
 
-    /// Destructor
-    ~TTTrackAssociationMap();
+  /// Destructor
+  ~TTTrackAssociationMap();
 
-    /// Data members:   getABC( ... )
-    /// Helper methods: findABC( ... )
+  /// Data members:   getABC( ... )
+  /// Helper methods: findABC( ... )
 
-    /// Maps
-    std::map< edm::Ptr< TTTrack< T > >, edm::Ptr< TrackingParticle > >                getTTTrackToTrackingParticleMap() const
-      { return trackToTrackingParticleMap; }
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ptr< TTTrack< T > > > > getTrackingParticleToTTTracksMap() const
-      { return trackingParticleToTrackVectorMap; }
+  /// Maps
+  std::map<edm::Ptr<TTTrack<T> >, edm::Ptr<TrackingParticle> > getTTTrackToTrackingParticleMap() const {
+    return trackToTrackingParticleMap;
+  }
+  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<T> > > > getTrackingParticleToTTTracksMap() const {
+    return trackingParticleToTrackVectorMap;
+  }
 
-    void setTTTrackToTrackingParticleMap( std::map< edm::Ptr< TTTrack< T > >, edm::Ptr< TrackingParticle > > aMap )
-      { trackToTrackingParticleMap = aMap; }
-    void setTrackingParticleToTTTracksMap( std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ptr< TTTrack< T > > > > aMap )
-      { trackingParticleToTrackVectorMap = aMap; }
-    void setTTStubAssociationMap( edm::RefProd< TTStubAssociationMap< T > > aStubAssoMap )
-      { theStubAssociationMap = aStubAssoMap; }
+  void setTTTrackToTrackingParticleMap(std::map<edm::Ptr<TTTrack<T> >, edm::Ptr<TrackingParticle> > aMap) {
+    trackToTrackingParticleMap = aMap;
+  }
+  void setTrackingParticleToTTTracksMap(
+      std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<T> > > > aMap) {
+    trackingParticleToTrackVectorMap = aMap;
+  }
+  void setTTStubAssociationMap(edm::RefProd<TTStubAssociationMap<T> > aStubAssoMap) {
+    theStubAssociationMap = aStubAssoMap;
+  }
 
-    /// Operations
-    edm::Ptr< TrackingParticle >            findTrackingParticlePtr( edm::Ptr< TTTrack< T > > aTrack ) const;
-    std::vector< edm::Ptr< TTTrack< T > > > findTTTrackPtrs( edm::Ptr< TrackingParticle > aTrackingParticle ) const; 
+  /// Operations
+  edm::Ptr<TrackingParticle> findTrackingParticlePtr(edm::Ptr<TTTrack<T> > aTrack) const;
+  std::vector<edm::Ptr<TTTrack<T> > > findTTTrackPtrs(edm::Ptr<TrackingParticle> aTrackingParticle) const;
 
-    /// MC Truth methods
-    bool isGenuine( edm::Ptr< TTTrack< T > > aTrack ) const;
-    bool isLooselyGenuine( edm::Ptr< TTTrack< T > > aTrack ) const;
-    bool isCombinatoric( edm::Ptr< TTTrack< T > > aTrack ) const;
-    bool isUnknown( edm::Ptr< TTTrack< T > > aTrack ) const;
+  /// MC Truth methods
+  bool isGenuine(edm::Ptr<TTTrack<T> > aTrack) const;
+  bool isLooselyGenuine(edm::Ptr<TTTrack<T> > aTrack) const;
+  bool isCombinatoric(edm::Ptr<TTTrack<T> > aTrack) const;
+  bool isUnknown(edm::Ptr<TTTrack<T> > aTrack) const;
 
-  private:
-    /// Data members
-    std::map< edm::Ptr< TTTrack< T > >, edm::Ptr< TrackingParticle > >                trackToTrackingParticleMap;
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ptr< TTTrack< T > > > > trackingParticleToTrackVectorMap;
-    edm::RefProd< TTStubAssociationMap< T > >                                         theStubAssociationMap;
+private:
+  /// Data members
+  std::map<edm::Ptr<TTTrack<T> >, edm::Ptr<TrackingParticle> > trackToTrackingParticleMap;
+  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<T> > > > trackingParticleToTrackVectorMap;
+  edm::RefProd<TTStubAssociationMap<T> > theStubAssociationMap;
 
-}; /// Close class
+};  /// Close class
 
 /*! \brief   Implementation of methods
  *  \details Here, in the header file, the methods which do not depend
@@ -83,39 +88,40 @@ class TTTrackAssociationMap
 
 /// Default Constructor
 /// NOTE: to be used with setSomething(...) methods
-template< typename T >
-TTTrackAssociationMap< T >::TTTrackAssociationMap()
-{
+template <typename T>
+TTTrackAssociationMap<T>::TTTrackAssociationMap() {
   /// Set default data members
   trackToTrackingParticleMap.clear();
   trackingParticleToTrackVectorMap.clear();
 }
 
 /// Destructor
-template< typename T >
-TTTrackAssociationMap< T >::~TTTrackAssociationMap(){}
+template <typename T>
+TTTrackAssociationMap<T>::~TTTrackAssociationMap() {}
 
 /// Operations
-template< >
-edm::Ptr< TrackingParticle > TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::findTrackingParticlePtr( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const;
+template <>
+edm::Ptr<TrackingParticle> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
 
-template< >
-std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::findTTTrackPtrs( edm::Ptr< TrackingParticle > aTrackingParticle ) const;
-
-/// MC truth
-template< >
-bool TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::isLooselyGenuine( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const;
+template <>
+std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > > TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
+    edm::Ptr<TrackingParticle> aTrackingParticle) const;
 
 /// MC truth
-template< >
-bool TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::isGenuine( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const;
+template <>
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isLooselyGenuine(
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
 
+/// MC truth
+template <>
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
 
-template< >
-bool TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::isCombinatoric( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const;
+template <>
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isCombinatoric(
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
 
-template< >
-bool TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::isUnknown( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const;
+template <>
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isUnknown(edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
 
 #endif
-

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
@@ -10,11 +10,10 @@
 #include "SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h"
 
 /// Implement the producer
-template< >
-void TTClusterAssociator< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+template <>
+void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   /// Exit if real data
-  if ( iEvent.isRealData() )
+  if (iEvent.isRealData())
     return;
 
   /// Get the PixelDigiSimLink
@@ -22,125 +21,114 @@ void TTClusterAssociator< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent,
 
   /// Get the TrackingParticles
 
-  iEvent.getByToken(tpToken, TrackingParticleHandle );
+  iEvent.getByToken(tpToken, TrackingParticleHandle);
 
   //  const TrackerTopology* const tTopo = theTrackerTopology.product();
   const TrackerGeometry* const theTrackerGeom = theTrackerGeometry.product();
 
-
   /// Preliminary task: map SimTracks by TrackingParticle
   /// Prepare the map
-  std::map< std::pair< unsigned int, EncodedEventId >, edm::Ptr< TrackingParticle > > simTrackUniqueToTPMap;
+  std::map<std::pair<unsigned int, EncodedEventId>, edm::Ptr<TrackingParticle>> simTrackUniqueToTPMap;
   simTrackUniqueToTPMap.clear();
 
-  if ( !TrackingParticleHandle->empty() )
-  {
+  if (!TrackingParticleHandle->empty()) {
     /// Loop over TrackingParticles
     unsigned int tpCnt = 0;
-    std::vector< TrackingParticle >::const_iterator iterTPart;
-    for ( iterTPart = TrackingParticleHandle->begin();
-          iterTPart != TrackingParticleHandle->end();
-          ++iterTPart )
-    {
+    std::vector<TrackingParticle>::const_iterator iterTPart;
+    for (iterTPart = TrackingParticleHandle->begin(); iterTPart != TrackingParticleHandle->end(); ++iterTPart) {
       /// Make the pointer to the TrackingParticle
-      edm::Ptr< TrackingParticle > tempTPPtr( TrackingParticleHandle, tpCnt++ );
+      edm::Ptr<TrackingParticle> tempTPPtr(TrackingParticleHandle, tpCnt++);
 
       /// Get the EncodedEventId
-      EncodedEventId eventId = EncodedEventId( tempTPPtr->eventId() );
+      EncodedEventId eventId = EncodedEventId(tempTPPtr->eventId());
 
       /// Loop over SimTracks inside TrackingParticle
-      std::vector< SimTrack >::const_iterator iterSimTrack;
-      for ( iterSimTrack = tempTPPtr->g4Tracks().begin();
-            iterSimTrack != tempTPPtr->g4Tracks().end();
-            ++iterSimTrack )
-      {
+      std::vector<SimTrack>::const_iterator iterSimTrack;
+      for (iterSimTrack = tempTPPtr->g4Tracks().begin(); iterSimTrack != tempTPPtr->g4Tracks().end(); ++iterSimTrack) {
         /// Build the unique SimTrack Id (which is SimTrack ID + EncodedEventId)
-        std::pair< unsigned int, EncodedEventId > simTrackUniqueId( iterSimTrack->trackId(), eventId );
-        simTrackUniqueToTPMap.insert( std::make_pair( simTrackUniqueId, tempTPPtr ) );
+        std::pair<unsigned int, EncodedEventId> simTrackUniqueId(iterSimTrack->trackId(), eventId);
+        simTrackUniqueToTPMap.insert(std::make_pair(simTrackUniqueId, tempTPPtr));
       }
-    } /// End of loop over TrackingParticles
+    }  /// End of loop over TrackingParticles
   }
 
   /// Loop over InputTags to handle multiple collections
 
-  int ncont1=0;
+  int ncont1 = 0;
 
-  for ( auto iTag =  TTClustersTokens.begin(); iTag!=  TTClustersTokens.end(); iTag++ )
-  {
-    
+  for (auto iTag = TTClustersTokens.begin(); iTag != TTClustersTokens.end(); iTag++) {
     /// Prepare output
-    auto associationMapForOutput      = std::make_unique<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>();
+    auto associationMapForOutput = std::make_unique<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>();
 
     /// Get the Clusters already stored away
-    edm::Handle< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > > > TTClusterHandle;
+    edm::Handle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> TTClusterHandle;
 
-    iEvent.getByToken( *iTag, TTClusterHandle );
+    iEvent.getByToken(*iTag, TTClusterHandle);
 
     /// Prepare the necessary maps
-    std::map< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > >, std::vector< edm::Ptr< TrackingParticle > > > clusterToTrackingParticleVectorMap;
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > > trackingParticleToClusterVectorMap;
+    std::map<edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>,
+             std::vector<edm::Ptr<TrackingParticle>>>
+        clusterToTrackingParticleVectorMap;
+    std::map<edm::Ptr<TrackingParticle>,
+             std::vector<
+                 edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>>>
+        trackingParticleToClusterVectorMap;
     clusterToTrackingParticleVectorMap.clear();
     trackingParticleToClusterVectorMap.clear();
 
     /// Loop over the input Clusters
-    for (auto gd=theTrackerGeom->dets().begin(); gd != theTrackerGeom->dets().end(); gd++) 
-    {
+    for (auto gd = theTrackerGeom->dets().begin(); gd != theTrackerGeom->dets().end(); gd++) {
       DetId detid = (*gd)->geographicalId();
-      if(detid.subdetId()!=StripSubdetector::TOB && detid.subdetId()!=StripSubdetector::TID ) continue; // only run on OT
+      if (detid.subdetId() != StripSubdetector::TOB && detid.subdetId() != StripSubdetector::TID)
+        continue;  // only run on OT
 
-      if (TTClusterHandle->find( detid ) == TTClusterHandle->end() ) continue;
+      if (TTClusterHandle->find(detid) == TTClusterHandle->end())
+        continue;
 
       /// Get the DetSets of the Clusters
-      edmNew::DetSet< TTCluster< Ref_Phase2TrackerDigi_ > > clusters = (*TTClusterHandle)[ detid ];
+      edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> clusters = (*TTClusterHandle)[detid];
 
-      for ( auto contentIter = clusters.begin();contentIter != clusters.end();++contentIter ) 
-      {
+      for (auto contentIter = clusters.begin(); contentIter != clusters.end(); ++contentIter) {
         /// Make the reference to be put in the map
-        edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > tempCluRef = edmNew::makeRefTo( TTClusterHandle, contentIter );
+        edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>> tempCluRef =
+            edmNew::makeRefTo(TTClusterHandle, contentIter);
 
         /// Prepare the maps wrt TTCluster
-        if ( clusterToTrackingParticleVectorMap.find( tempCluRef ) == clusterToTrackingParticleVectorMap.end() )
-        {
-          std::vector< edm::Ptr< TrackingParticle > > tpVector;
+        if (clusterToTrackingParticleVectorMap.find(tempCluRef) == clusterToTrackingParticleVectorMap.end()) {
+          std::vector<edm::Ptr<TrackingParticle>> tpVector;
           tpVector.clear();
-          clusterToTrackingParticleVectorMap.insert( std::make_pair( tempCluRef, tpVector ) );
+          clusterToTrackingParticleVectorMap.insert(std::make_pair(tempCluRef, tpVector));
         }
 
         /// Get the PixelDigiSimLink
         /// Safety check added after new digitizer (Oct 2014)
-        if ( thePixelDigiSimLinkHandle->find(detid) == thePixelDigiSimLinkHandle->end() )
-        {
+        if (thePixelDigiSimLinkHandle->find(detid) == thePixelDigiSimLinkHandle->end()) {
           /// Sensor is not found in DigiSimLink.
           /// Set MC truth to NULL for all hits in this sensor. Period.
 
           /// Get the Digis and loop over them
-          std::vector< Ref_Phase2TrackerDigi_ > theseHits = tempCluRef->getHits();
-          for ( unsigned int i = 0; i < theseHits.size(); i++ )
-          {
+          std::vector<Ref_Phase2TrackerDigi_> theseHits = tempCluRef->getHits();
+          for (unsigned int i = 0; i < theseHits.size(); i++) {
             /// No SimLink is found by definition
             /// Then store NULL MC truth for all the digis
-            edm::Ptr< TrackingParticle > tempTPPtr; // = new edm::Ptr< TrackingParticle >();
-            clusterToTrackingParticleVectorMap.find( tempCluRef )->second.push_back( tempTPPtr );
+            edm::Ptr<TrackingParticle> tempTPPtr;  // = new edm::Ptr< TrackingParticle >();
+            clusterToTrackingParticleVectorMap.find(tempCluRef)->second.push_back(tempTPPtr);
           }
 
           /// Go to the next sensor
           continue;
         }
 
-        edm::DetSet<PixelDigiSimLink> thisDigiSimLink = (*(thePixelDigiSimLinkHandle) )[detid];
+        edm::DetSet<PixelDigiSimLink> thisDigiSimLink = (*(thePixelDigiSimLinkHandle))[detid];
         edm::DetSet<PixelDigiSimLink>::const_iterator iterSimLink;
 
         /// Get the Digis and loop over them
-        std::vector< Ref_Phase2TrackerDigi_ > theseHits = tempCluRef->getHits();
-        for ( unsigned int i = 0; i < theseHits.size(); i++ )
-        {
+        std::vector<Ref_Phase2TrackerDigi_> theseHits = tempCluRef->getHits();
+        for (unsigned int i = 0; i < theseHits.size(); i++) {
           /// Loop over PixelDigiSimLink
-          for ( iterSimLink = thisDigiSimLink.data.begin();
-                iterSimLink != thisDigiSimLink.data.end();
-                iterSimLink++ )
-          {
+          for (iterSimLink = thisDigiSimLink.data.begin(); iterSimLink != thisDigiSimLink.data.end(); iterSimLink++) {
             /// Find the link and, if there's not, skip
-            if ( static_cast<int>(iterSimLink->channel()) != static_cast<int>(theseHits.at(i)->channel()) )
+            if (static_cast<int>(iterSimLink->channel()) != static_cast<int>(theseHits.at(i)->channel()))
               continue;
 
             /// Get SimTrack Id and type
@@ -148,79 +136,78 @@ void TTClusterAssociator< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent,
             EncodedEventId curSimEvId = iterSimLink->eventId();
 
             /// Prepare the SimTrack Unique ID
-            std::pair< unsigned int, EncodedEventId > thisUniqueId = std::make_pair( curSimTrkId, curSimEvId );
+            std::pair<unsigned int, EncodedEventId> thisUniqueId = std::make_pair(curSimTrkId, curSimEvId);
 
             /// Get the corresponding TrackingParticle
-            if ( simTrackUniqueToTPMap.find( thisUniqueId ) != simTrackUniqueToTPMap.end() )
-            {
-              edm::Ptr< TrackingParticle > thisTrackingParticle = simTrackUniqueToTPMap.find( thisUniqueId )->second;
+            if (simTrackUniqueToTPMap.find(thisUniqueId) != simTrackUniqueToTPMap.end()) {
+              edm::Ptr<TrackingParticle> thisTrackingParticle = simTrackUniqueToTPMap.find(thisUniqueId)->second;
 
               /// Store the TrackingParticle
-              clusterToTrackingParticleVectorMap.find( tempCluRef )->second.push_back( thisTrackingParticle );
+              clusterToTrackingParticleVectorMap.find(tempCluRef)->second.push_back(thisTrackingParticle);
 
               /// Prepare the maps wrt TrackingParticle
-              if ( trackingParticleToClusterVectorMap.find( thisTrackingParticle ) == trackingParticleToClusterVectorMap.end() )
-              {
-                std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > clusterVector;
+              if (trackingParticleToClusterVectorMap.find(thisTrackingParticle) ==
+                  trackingParticleToClusterVectorMap.end()) {
+                std::vector<
+                    edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>>
+                    clusterVector;
                 clusterVector.clear();
-                trackingParticleToClusterVectorMap.insert( std::make_pair( thisTrackingParticle, clusterVector ) );
+                trackingParticleToClusterVectorMap.insert(std::make_pair(thisTrackingParticle, clusterVector));
               }
-              trackingParticleToClusterVectorMap.find( thisTrackingParticle )->second.push_back( tempCluRef ); /// Fill the auxiliary map
-            }
-            else 
-            {
+              trackingParticleToClusterVectorMap.find(thisTrackingParticle)
+                  ->second.push_back(tempCluRef);  /// Fill the auxiliary map
+            } else {
               /// In case no TrackingParticle is found, store a NULL pointer
 
-              edm::Ptr< TrackingParticle > tempTPPtr; // = new edm::Ptr< TrackingParticle >();
-              clusterToTrackingParticleVectorMap.find( tempCluRef )->second.push_back( tempTPPtr );
+              edm::Ptr<TrackingParticle> tempTPPtr;  // = new edm::Ptr< TrackingParticle >();
+              clusterToTrackingParticleVectorMap.find(tempCluRef)->second.push_back(tempTPPtr);
             }
-          } /// End of loop over PixelDigiSimLink
-        } /// End of loop over all the hits composing the Cluster
+          }  /// End of loop over PixelDigiSimLink
+        }    /// End of loop over all the hits composing the Cluster
 
         /// Check that the cluster has a non-NULL TP pointer
-        std::vector< edm::Ptr< TrackingParticle > > theseClusterTrackingParticlePtrs = clusterToTrackingParticleVectorMap.find( tempCluRef )->second;
+        std::vector<edm::Ptr<TrackingParticle>> theseClusterTrackingParticlePtrs =
+            clusterToTrackingParticleVectorMap.find(tempCluRef)->second;
         bool allOfThemAreNull = true;
-        for ( unsigned int tpi = 0; tpi < theseClusterTrackingParticlePtrs.size() && allOfThemAreNull; tpi++ )
-        {
-          if ( theseClusterTrackingParticlePtrs.at(tpi).isNull() == false )
+        for (unsigned int tpi = 0; tpi < theseClusterTrackingParticlePtrs.size() && allOfThemAreNull; tpi++) {
+          if (theseClusterTrackingParticlePtrs.at(tpi).isNull() == false)
             allOfThemAreNull = false;
         }
 
-        if ( allOfThemAreNull )
-        {
+        if (allOfThemAreNull) {
           /// In case no TrackingParticle is found at all, drop the map element
-          clusterToTrackingParticleVectorMap.erase( tempCluRef ); /// Use "erase by key"
+          clusterToTrackingParticleVectorMap.erase(tempCluRef);  /// Use "erase by key"
         }
-
       }
-    } /// End of loop over all the TTClusters of the event
+    }  /// End of loop over all the TTClusters of the event
 
     /// Clean the maps that need cleaning
     /// Prepare the output map wrt TrackingParticle
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > >::iterator iterMapToClean;
-    for ( iterMapToClean = trackingParticleToClusterVectorMap.begin();
-          iterMapToClean != trackingParticleToClusterVectorMap.end();
-          ++iterMapToClean )
-    {
+    std::map<edm::Ptr<TrackingParticle>,
+             std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>,
+                                  TTCluster<Ref_Phase2TrackerDigi_>>>>::iterator iterMapToClean;
+    for (iterMapToClean = trackingParticleToClusterVectorMap.begin();
+         iterMapToClean != trackingParticleToClusterVectorMap.end();
+         ++iterMapToClean) {
       /// Get the vector of references to TTCluster
-      std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > tempVector = iterMapToClean->second;
+      std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>>
+          tempVector = iterMapToClean->second;
 
       /// Sort and remove duplicates
-      std::sort( tempVector.begin(), tempVector.end() );
-      tempVector.erase( std::unique( tempVector.begin(), tempVector.end() ), tempVector.end() );
+      std::sort(tempVector.begin(), tempVector.end());
+      tempVector.erase(std::unique(tempVector.begin(), tempVector.end()), tempVector.end());
       iterMapToClean->second = tempVector;
     }
 
     /// Put the maps in the association object
-    associationMapForOutput->setTTClusterToTrackingParticlesMap( clusterToTrackingParticleVectorMap );
-    associationMapForOutput->setTrackingParticleToTTClustersMap( trackingParticleToClusterVectorMap );
+    associationMapForOutput->setTTClusterToTrackingParticlesMap(clusterToTrackingParticleVectorMap);
+    associationMapForOutput->setTrackingParticleToTTClustersMap(trackingParticleToClusterVectorMap);
 
     /// Put output in the event
     //   iEvent.put( associationMapForOutput, (*iTag).instance() );
-    iEvent.put( std::move(associationMapForOutput), TTClustersInputTags.at(ncont1).instance() );
+    iEvent.put(std::move(associationMapForOutput), TTClustersInputTags.at(ncont1).instance());
 
     ++ncont1;
 
-  } /// End of loop over input tags
+  }  /// End of loop over input tags
 }
-

--- a/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.cc
@@ -10,242 +10,230 @@
 #include "SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h"
 
 /// Implement the producer
-template< >
-void TTStubAssociator< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+template <>
+void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   /// Exit if real data
-  if ( iEvent.isRealData() )
+  if (iEvent.isRealData())
     return;
 
   /// Exit if the vectors are uncorrectly dimensioned
-  if ( TTClusterTruthInputTags.size() != TTStubsInputTags.size() )
-  {
+  if (TTClusterTruthInputTags.size() != TTStubsInputTags.size()) {
     edm::LogError("TTStubAsso ") << "E R R O R! the InputTag vectors have different size!";
     return;
   }
 
-  int ncont1=0;
+  int ncont1 = 0;
 
   const TrackerGeometry* const theTrackerGeom = theTrackerGeometry.product();
-  const TrackerTopology* const tTopo          = theTrackerTopology.product();
+  const TrackerTopology* const tTopo = theTrackerTopology.product();
 
   /// Loop over the InputTags to handle multiple collections
 
-  for ( auto iTag =  TTStubsTokens.begin(); iTag!=  TTStubsTokens.end(); iTag++ )
-  {
+  for (auto iTag = TTStubsTokens.begin(); iTag != TTStubsTokens.end(); iTag++) {
     /// Prepare output
-    auto associationMapForOutput      = std::make_unique<TTStubAssociationMap<Ref_Phase2TrackerDigi_>>();
+    auto associationMapForOutput = std::make_unique<TTStubAssociationMap<Ref_Phase2TrackerDigi_>>();
 
     /// Get the Stubs already stored away
-    edm::Handle< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > > > TTStubHandle;
-    iEvent.getByToken( *iTag, TTStubHandle );
+    edm::Handle<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> TTStubHandle;
+    iEvent.getByToken(*iTag, TTStubHandle);
 
     /// Get the Cluster MC truth
-    edm::Handle< TTClusterAssociationMap< Ref_Phase2TrackerDigi_ > > TTClusterAssociationMapHandle;
-    iEvent.getByToken( TTClusterTruthTokens.at(ncont1), TTClusterAssociationMapHandle );
+    edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> TTClusterAssociationMapHandle;
+    iEvent.getByToken(TTClusterTruthTokens.at(ncont1), TTClusterAssociationMapHandle);
 
     /// Prepare the necessary maps
-    std::map< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > >, edm::Ptr< TrackingParticle > >                stubToTrackingParticleMap;
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > > trackingParticleToStubVectorMap;
+    std::map<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>,
+             edm::Ptr<TrackingParticle>>
+        stubToTrackingParticleMap;
+    std::map<edm::Ptr<TrackingParticle>,
+             std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>>
+        trackingParticleToStubVectorMap;
     stubToTrackingParticleMap.clear();
     trackingParticleToStubVectorMap.clear();
 
     /// Loop over the input Stubs
 
-    if ( !TTStubHandle->empty() )
-    {
-    for (auto gd=theTrackerGeom->dets().begin(); gd != theTrackerGeom->dets().end(); gd++) 
-    {
-      DetId detid = (*gd)->geographicalId();
-      if(detid.subdetId()!=StripSubdetector::TOB && detid.subdetId()!=StripSubdetector::TID ) continue; // only run on OT
+    if (!TTStubHandle->empty()) {
+      for (auto gd = theTrackerGeom->dets().begin(); gd != theTrackerGeom->dets().end(); gd++) {
+        DetId detid = (*gd)->geographicalId();
+        if (detid.subdetId() != StripSubdetector::TOB && detid.subdetId() != StripSubdetector::TID)
+          continue;  // only run on OT
 
-      if(!tTopo->isLower(detid) ) continue; // loop on the stacks: choose the lower arbitrarily
+        if (!tTopo->isLower(detid))
+          continue;  // loop on the stacks: choose the lower arbitrarily
 
-      DetId stackDetid = tTopo->stack(detid); // Stub module detid
+        DetId stackDetid = tTopo->stack(detid);  // Stub module detid
 
-      if (TTStubHandle->find( stackDetid ) == TTStubHandle->end() ) continue;
-
-      /// Get the DetSets of the Clusters
-      edmNew::DetSet< TTStub< Ref_Phase2TrackerDigi_ > > stubs = (*TTStubHandle)[ stackDetid ];
-
-      for ( auto contentIter = stubs.begin();contentIter != stubs.end();++contentIter ) 
-      {
-        /// Make the reference to be put in the map
-        edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > tempStubRef = edmNew::makeRefTo( TTStubHandle, contentIter );
-
-        /// Get the two clusters
-	//        std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > theseClusters = tempStubRef->getClusterRefs();
-
-        /// Fill the inclusive map which is careless of the stub classification
-        for ( unsigned int ic = 0; ic < 2; ic++ )
-        {
-          std::vector< edm::Ptr< TrackingParticle > > tempTPs = TTClusterAssociationMapHandle->findTrackingParticlePtrs( tempStubRef->getClusterRef(ic) );
-
-          for ( unsigned int itp = 0; itp < tempTPs.size(); itp++ )
-          {
-            edm::Ptr< TrackingParticle > testTP = tempTPs.at(itp);
-
-            if ( testTP.isNull() )
-              continue;
-
-            /// Prepare the maps wrt TrackingParticle
-            if ( trackingParticleToStubVectorMap.find( testTP ) == trackingParticleToStubVectorMap.end() )
-            {
-              std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > stubVector;
-              stubVector.clear();
-              trackingParticleToStubVectorMap.insert( std::make_pair( testTP, stubVector ) );
-            }
-            trackingParticleToStubVectorMap.find( testTP )->second.push_back( tempStubRef ); /// Fill the auxiliary map
-          }
-        }
-
-        /// GENUINE for clusters means not combinatoric and
-        /// not unknown: same MC truth content MUST be found
-        /// in both clusters composing the stub
-        if ( TTClusterAssociationMapHandle->isUnknown( tempStubRef->getClusterRef(0) ) ||
-             TTClusterAssociationMapHandle->isUnknown( tempStubRef->getClusterRef(1) ) )
-        {
-          /// If at least one cluster is unknown, it means
-          /// either unknown, either combinatoric
-          /// Do nothing, and go to the next Stub
+        if (TTStubHandle->find(stackDetid) == TTStubHandle->end())
           continue;
-        }
-        else
-        {
-          /// Here both are clusters are genuine/combinatoric
-          /// If both clusters have some known SimTrack content
-          /// they must be compared to each other
-          if ( TTClusterAssociationMapHandle->isGenuine( tempStubRef->getClusterRef(0) ) &&
-               TTClusterAssociationMapHandle->isGenuine( tempStubRef->getClusterRef(1) ) )
-          {
-            /// If both clusters are genuine, they must be associated to the same TrackingParticle
-            /// in order to return a genuine stub. Period. Note we can perform safely
-            /// this comparison because, if both clusters are genuine, their TrackingParticle shall NEVER be NULL
-            if ( TTClusterAssociationMapHandle->findTrackingParticlePtr( tempStubRef->getClusterRef(0) ).get() ==
-                 TTClusterAssociationMapHandle->findTrackingParticlePtr( tempStubRef->getClusterRef(1) ).get() )
-            {
-              /// Two genuine clusters with same SimTrack content mean genuine
-              edm::Ptr< TrackingParticle > testTP = TTClusterAssociationMapHandle->findTrackingParticlePtr( tempStubRef->getClusterRef(0) );
 
-              /// Fill the map: by construction, this will always be the first time the
-              /// stub is inserted into the map: no need for "find"
-              stubToTrackingParticleMap.insert( std::make_pair( tempStubRef, testTP ) );
+        /// Get the DetSets of the Clusters
+        edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>> stubs = (*TTStubHandle)[stackDetid];
 
-              /// At this point, go to the next Stub
-              continue;
-            }
-            else
-            {
-              /// It means combinatoric
-              continue;
-            }
-          } /// End of two genuine clusters
-          else
-          {
-            /// Here, at least one cluster is combinatoric
-            TrackingParticle* prevTPAddress = nullptr;
-            unsigned int whichTP = 0;
+        for (auto contentIter = stubs.begin(); contentIter != stubs.end(); ++contentIter) {
+          /// Make the reference to be put in the map
+          edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>> tempStubRef =
+              edmNew::makeRefTo(TTStubHandle, contentIter);
 
-            std::vector< edm::Ptr< TrackingParticle > > trackingParticles0 = TTClusterAssociationMapHandle->findTrackingParticlePtrs( tempStubRef->getClusterRef(0) );
-            std::vector< edm::Ptr< TrackingParticle > > trackingParticles1 = TTClusterAssociationMapHandle->findTrackingParticlePtrs( tempStubRef->getClusterRef(1) );
+          /// Get the two clusters
+          //        std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > theseClusters = tempStubRef->getClusterRefs();
 
-            bool escape = false;
+          /// Fill the inclusive map which is careless of the stub classification
+          for (unsigned int ic = 0; ic < 2; ic++) {
+            std::vector<edm::Ptr<TrackingParticle>> tempTPs =
+                TTClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->getClusterRef(ic));
 
-            for ( unsigned int i = 0; i < trackingParticles0.size() && !escape; i++ )
-            {
-              /// Skip NULL pointers
-              if ( trackingParticles0.at(i).isNull() )
+            for (unsigned int itp = 0; itp < tempTPs.size(); itp++) {
+              edm::Ptr<TrackingParticle> testTP = tempTPs.at(itp);
+
+              if (testTP.isNull())
                 continue;
 
-              for ( unsigned int k = 0; k < trackingParticles1.size() && !escape; k++ )
-              {
+              /// Prepare the maps wrt TrackingParticle
+              if (trackingParticleToStubVectorMap.find(testTP) == trackingParticleToStubVectorMap.end()) {
+                std::vector<
+                    edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
+                    stubVector;
+                stubVector.clear();
+                trackingParticleToStubVectorMap.insert(std::make_pair(testTP, stubVector));
+              }
+              trackingParticleToStubVectorMap.find(testTP)->second.push_back(tempStubRef);  /// Fill the auxiliary map
+            }
+          }
+
+          /// GENUINE for clusters means not combinatoric and
+          /// not unknown: same MC truth content MUST be found
+          /// in both clusters composing the stub
+          if (TTClusterAssociationMapHandle->isUnknown(tempStubRef->getClusterRef(0)) ||
+              TTClusterAssociationMapHandle->isUnknown(tempStubRef->getClusterRef(1))) {
+            /// If at least one cluster is unknown, it means
+            /// either unknown, either combinatoric
+            /// Do nothing, and go to the next Stub
+            continue;
+          } else {
+            /// Here both are clusters are genuine/combinatoric
+            /// If both clusters have some known SimTrack content
+            /// they must be compared to each other
+            if (TTClusterAssociationMapHandle->isGenuine(tempStubRef->getClusterRef(0)) &&
+                TTClusterAssociationMapHandle->isGenuine(tempStubRef->getClusterRef(1))) {
+              /// If both clusters are genuine, they must be associated to the same TrackingParticle
+              /// in order to return a genuine stub. Period. Note we can perform safely
+              /// this comparison because, if both clusters are genuine, their TrackingParticle shall NEVER be NULL
+              if (TTClusterAssociationMapHandle->findTrackingParticlePtr(tempStubRef->getClusterRef(0)).get() ==
+                  TTClusterAssociationMapHandle->findTrackingParticlePtr(tempStubRef->getClusterRef(1)).get()) {
+                /// Two genuine clusters with same SimTrack content mean genuine
+                edm::Ptr<TrackingParticle> testTP =
+                    TTClusterAssociationMapHandle->findTrackingParticlePtr(tempStubRef->getClusterRef(0));
+
+                /// Fill the map: by construction, this will always be the first time the
+                /// stub is inserted into the map: no need for "find"
+                stubToTrackingParticleMap.insert(std::make_pair(tempStubRef, testTP));
+
+                /// At this point, go to the next Stub
+                continue;
+              } else {
+                /// It means combinatoric
+                continue;
+              }
+            }  /// End of two genuine clusters
+            else {
+              /// Here, at least one cluster is combinatoric
+              TrackingParticle* prevTPAddress = nullptr;
+              unsigned int whichTP = 0;
+
+              std::vector<edm::Ptr<TrackingParticle>> trackingParticles0 =
+                  TTClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->getClusterRef(0));
+              std::vector<edm::Ptr<TrackingParticle>> trackingParticles1 =
+                  TTClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->getClusterRef(1));
+
+              bool escape = false;
+
+              for (unsigned int i = 0; i < trackingParticles0.size() && !escape; i++) {
                 /// Skip NULL pointers
-                if ( trackingParticles1.at(k).isNull() )
+                if (trackingParticles0.at(i).isNull())
                   continue;
 
-                if ( trackingParticles0.at(i).get() == trackingParticles1.at(k).get() )
-                {
-                  /// Same SimTrack is present in both clusters
-                  if ( prevTPAddress == nullptr )
-                  {
-                    prevTPAddress = const_cast< TrackingParticle* >(trackingParticles1.at(k).get());
-                    whichTP = k;
-                  }
-
-                  /// If two different SimTracks are found in both clusters,
-                  /// then the stub is for sure combinatoric
-                  if ( prevTPAddress != const_cast< TrackingParticle* >(trackingParticles1.at(k).get()) )
-                  {
-                    escape = true;
+                for (unsigned int k = 0; k < trackingParticles1.size() && !escape; k++) {
+                  /// Skip NULL pointers
+                  if (trackingParticles1.at(k).isNull())
                     continue;
+
+                  if (trackingParticles0.at(i).get() == trackingParticles1.at(k).get()) {
+                    /// Same SimTrack is present in both clusters
+                    if (prevTPAddress == nullptr) {
+                      prevTPAddress = const_cast<TrackingParticle*>(trackingParticles1.at(k).get());
+                      whichTP = k;
+                    }
+
+                    /// If two different SimTracks are found in both clusters,
+                    /// then the stub is for sure combinatoric
+                    if (prevTPAddress != const_cast<TrackingParticle*>(trackingParticles1.at(k).get())) {
+                      escape = true;
+                      continue;
+                    }
                   }
                 }
-              }
-            } /// End of double loop over SimTracks of both clusters
+              }  /// End of double loop over SimTracks of both clusters
 
-            /// If two different SimTracks are found in both clusters,
-            /// go to the next stub
-            if ( escape )
-              continue;
+              /// If two different SimTracks are found in both clusters,
+              /// go to the next stub
+              if (escape)
+                continue;
 
-            if ( prevTPAddress == nullptr )
-            {
-              /// No SimTracks were found to be in both clusters
-              continue;
-            }
-            else
-            {
-              /// Only one SimTrack was found to be present in both clusters
-              /// even if one of the clusters (or both) are combinatoric:
-              /// this means there is only one track that participates in
-              /// both clusters, hence the stub is genuine
-              edm::Ptr< TrackingParticle > testTP = trackingParticles1.at(whichTP);
+              if (prevTPAddress == nullptr) {
+                /// No SimTracks were found to be in both clusters
+                continue;
+              } else {
+                /// Only one SimTrack was found to be present in both clusters
+                /// even if one of the clusters (or both) are combinatoric:
+                /// this means there is only one track that participates in
+                /// both clusters, hence the stub is genuine
+                edm::Ptr<TrackingParticle> testTP = trackingParticles1.at(whichTP);
 
-              /// Fill the map: by construction, this will always be the first time the
-              /// stub is inserted into the map: no need for "find"
-              stubToTrackingParticleMap.insert( std::make_pair( tempStubRef, testTP ) );
+                /// Fill the map: by construction, this will always be the first time the
+                /// stub is inserted into the map: no need for "find"
+                stubToTrackingParticleMap.insert(std::make_pair(tempStubRef, testTP));
 
-              /// At this point, go to the next Stub
-              continue;
-            } /// End of one single SimTrack in both clusters
-          } /// End of "at least one cluster is combinatoric"
-        } /// End of "both clusters are known, somehow..."
-      }
-    } /// End of loop over Stubs
-      
-  }
+                /// At this point, go to the next Stub
+                continue;
+              }  /// End of one single SimTrack in both clusters
+            }    /// End of "at least one cluster is combinatoric"
+          }      /// End of "both clusters are known, somehow..."
+        }
+      }  /// End of loop over Stubs
+    }
 
     /// Clean the only map that needs cleaning
     /// Prepare the output map wrt TrackingParticle
-    typename std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > >::iterator iterMapToClean;
-    for ( iterMapToClean = trackingParticleToStubVectorMap.begin();
-          iterMapToClean != trackingParticleToStubVectorMap.end();
-          ++iterMapToClean )
-    {
+    typename std::map<edm::Ptr<TrackingParticle>,
+                      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>,
+                                           TTStub<Ref_Phase2TrackerDigi_>>>>::iterator iterMapToClean;
+    for (iterMapToClean = trackingParticleToStubVectorMap.begin();
+         iterMapToClean != trackingParticleToStubVectorMap.end();
+         ++iterMapToClean) {
       /// Get the vector of references to TTStub
-      std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > tempVector = iterMapToClean->second;
+      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
+          tempVector = iterMapToClean->second;
 
       /// Sort and remove duplicates
-      std::sort( tempVector.begin(), tempVector.end() );
-      tempVector.erase( std::unique( tempVector.begin(), tempVector.end() ), tempVector.end() );
+      std::sort(tempVector.begin(), tempVector.end());
+      tempVector.erase(std::unique(tempVector.begin(), tempVector.end()), tempVector.end());
 
       /// Put the vector in the output map
       iterMapToClean->second = tempVector;
     }
 
     /// Also, create the pointer to the TTClusterAssociationMap
-    edm::RefProd< TTClusterAssociationMap< Ref_Phase2TrackerDigi_ > > theCluAssoMap( TTClusterAssociationMapHandle ); 
+    edm::RefProd<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> theCluAssoMap(TTClusterAssociationMapHandle);
 
     /// Put the maps in the association object
-    associationMapForOutput->setTTStubToTrackingParticleMap( stubToTrackingParticleMap );
-    associationMapForOutput->setTrackingParticleToTTStubsMap( trackingParticleToStubVectorMap );
-    associationMapForOutput->setTTClusterAssociationMap( theCluAssoMap );
+    associationMapForOutput->setTTStubToTrackingParticleMap(stubToTrackingParticleMap);
+    associationMapForOutput->setTrackingParticleToTTStubsMap(trackingParticleToStubVectorMap);
+    associationMapForOutput->setTTClusterAssociationMap(theCluAssoMap);
 
     /// Put output in the event
-    iEvent.put( std::move(associationMapForOutput), TTStubsInputTags.at(ncont1).instance() );
+    iEvent.put(std::move(associationMapForOutput), TTStubsInputTags.at(ncont1).instance());
 
     ++ncont1;
-  } /// End of loop over InputTags
+  }  /// End of loop over InputTags
 }
-
-

--- a/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
@@ -40,35 +40,34 @@
 #include <map>
 #include <vector>
 
-template< typename T >
-class TTStubAssociator : public edm::stream::EDProducer<>
-{
+template <typename T>
+class TTStubAssociator : public edm::stream::EDProducer<> {
   /// NOTE since pattern hit correlation must be performed within a stacked module, one must store
   /// Clusters in a proper way, providing easy access to them in a detector/member-wise way
-  public:
-    /// Constructors
-    explicit TTStubAssociator( const edm::ParameterSet& iConfig );
+public:
+  /// Constructors
+  explicit TTStubAssociator(const edm::ParameterSet& iConfig);
 
-    /// Destructor
-    ~TTStubAssociator() override;
+  /// Destructor
+  ~TTStubAssociator() override;
 
-  private:
-    /// Data members
-    std::vector< edm::InputTag > TTStubsInputTags;
-    std::vector< edm::InputTag > TTClusterTruthInputTags;
+private:
+  /// Data members
+  std::vector<edm::InputTag> TTStubsInputTags;
+  std::vector<edm::InputTag> TTClusterTruthInputTags;
 
-    std::vector<edm::EDGetTokenT< edmNew::DetSetVector< TTStub< T > > > > TTStubsTokens;
-    std::vector<edm::EDGetTokenT< TTClusterAssociationMap< T > > > TTClusterTruthTokens;
+  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTStub<T> > > > TTStubsTokens;
+  std::vector<edm::EDGetTokenT<TTClusterAssociationMap<T> > > TTClusterTruthTokens;
 
-    edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-    edm::ESHandle<TrackerTopology> theTrackerTopology;
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
+  edm::ESHandle<TrackerTopology> theTrackerTopology;
 
-    /// Mandatory methods
-    void beginRun( const edm::Run& run, const edm::EventSetup& iSetup ) override;
-    void endRun( const edm::Run& run, const edm::EventSetup& iSetup ) override;
-    void produce( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
+  /// Mandatory methods
+  void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
+  void endRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-}; /// Close class
+};  /// Close class
 
 /*! \brief   Implementation of methods
  *  \details Here, in the header file, the methods which do not depend
@@ -78,48 +77,42 @@ class TTStubAssociator : public edm::stream::EDProducer<>
  */
 
 /// Constructors
-template< typename T >
-TTStubAssociator< T >::TTStubAssociator( const edm::ParameterSet& iConfig )
-{
-  TTStubsInputTags = iConfig.getParameter< std::vector< edm::InputTag > >( "TTStubs" );
-  TTClusterTruthInputTags = iConfig.getParameter< std::vector< edm::InputTag > >( "TTClusterTruth" );
+template <typename T>
+TTStubAssociator<T>::TTStubAssociator(const edm::ParameterSet& iConfig) {
+  TTStubsInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTStubs");
+  TTClusterTruthInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTClusterTruth");
 
-
-  for ( auto iTag =  TTClusterTruthInputTags.begin(); iTag!=  TTClusterTruthInputTags.end(); iTag++ )
-  {
-    TTClusterTruthTokens.push_back(consumes< TTClusterAssociationMap< T > >(*iTag));
+  for (auto iTag = TTClusterTruthInputTags.begin(); iTag != TTClusterTruthInputTags.end(); iTag++) {
+    TTClusterTruthTokens.push_back(consumes<TTClusterAssociationMap<T> >(*iTag));
   }
 
-  for ( auto iTag =  TTStubsInputTags.begin(); iTag!=  TTStubsInputTags.end(); iTag++ )
-  {
-    TTStubsTokens.push_back(consumes< edmNew::DetSetVector< TTStub< T > > >(*iTag));
+  for (auto iTag = TTStubsInputTags.begin(); iTag != TTStubsInputTags.end(); iTag++) {
+    TTStubsTokens.push_back(consumes<edmNew::DetSetVector<TTStub<T> > >(*iTag));
 
-    produces< TTStubAssociationMap< T > >( (*iTag).instance() );
+    produces<TTStubAssociationMap<T> >((*iTag).instance());
   }
 }
 
 /// Destructor
-template< typename T >
-TTStubAssociator< T >::~TTStubAssociator(){}
+template <typename T>
+TTStubAssociator<T>::~TTStubAssociator() {}
 
 /// Begin run
-template< typename T >
-void TTStubAssociator< T >::beginRun( const edm::Run& run, const edm::EventSetup& iSetup )
-{
+template <typename T>
+void TTStubAssociator<T>::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
   /// Print some information when loaded
-  edm::LogInfo("TTStubAssociator< ") << templateNameFinder< T >() << " > loaded.";
+  edm::LogInfo("TTStubAssociator< ") << templateNameFinder<T>() << " > loaded.";
 
   iSetup.get<TrackerTopologyRcd>().get(theTrackerTopology);
   iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
 }
 
 /// End run
-template< typename T >
-void TTStubAssociator< T >::endRun( const edm::Run& run, const edm::EventSetup& iSetup ){}
+template <typename T>
+void TTStubAssociator<T>::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
 /// Implement the producer
-template< >
-void TTStubAssociator< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const edm::EventSetup& iSetup );
+template <>
+void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup);
 
 #endif
-

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
@@ -10,190 +10,176 @@
 #include "SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h"
 
 /// Implement the producer
-template< >
-void TTTrackAssociator< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+template <>
+void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   /// Exit if real data
-  if ( iEvent.isRealData() )
+  if (iEvent.isRealData())
     return;
 
   /// Get the Stub and Cluster MC truth
-  edm::Handle< TTClusterAssociationMap< Ref_Phase2TrackerDigi_ > > TTClusterAssociationMapHandle;
-  iEvent.getByToken( TTClusterTruthToken, TTClusterAssociationMapHandle );
-  edm::Handle< TTStubAssociationMap< Ref_Phase2TrackerDigi_ > > TTStubAssociationMapHandle;
-  iEvent.getByToken( TTStubTruthToken, TTStubAssociationMapHandle );
+  edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> TTClusterAssociationMapHandle;
+  iEvent.getByToken(TTClusterTruthToken, TTClusterAssociationMapHandle);
+  edm::Handle<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> TTStubAssociationMapHandle;
+  iEvent.getByToken(TTStubTruthToken, TTStubAssociationMapHandle);
 
-
-  int ncont1=0;
+  int ncont1 = 0;
 
   /// Loop over InputTags to handle multiple collections
-  for ( auto iTag =  TTTracksTokens.begin(); iTag!=  TTTracksTokens.end(); iTag++ )
-  {
+  for (auto iTag = TTTracksTokens.begin(); iTag != TTTracksTokens.end(); iTag++) {
     /// Prepare output
     auto associationMapForOutput = std::make_unique<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>();
 
     /// Get the Tracks already stored away
-    edm::Handle< std::vector< TTTrack< Ref_Phase2TrackerDigi_ > > > TTTrackHandle;
-    iEvent.getByToken( *iTag, TTTrackHandle );
+    edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> TTTrackHandle;
+    iEvent.getByToken(*iTag, TTTrackHandle);
 
     /// Prepare the necessary maps
-    std::map< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > >, edm::Ptr< TrackingParticle > >                trackToTrackingParticleMap;
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > > trackingParticleToTrackVectorMap;
+    std::map<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>, edm::Ptr<TrackingParticle>> trackToTrackingParticleMap;
+    std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>>
+        trackingParticleToTrackVectorMap;
     trackToTrackingParticleMap.clear();
     trackingParticleToTrackVectorMap.clear();
 
-
     // Start the loop on tracks
 
-    unsigned int j = 0; /// Counter needed to build the edm::Ptr to the TTTrack
-    typename std::vector< TTTrack< Ref_Phase2TrackerDigi_ > >::const_iterator inputIter;
-    for ( inputIter = TTTrackHandle->begin();
-          inputIter != TTTrackHandle->end();
-          ++inputIter )
-    {
+    unsigned int j = 0;  /// Counter needed to build the edm::Ptr to the TTTrack
+    typename std::vector<TTTrack<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
+    for (inputIter = TTTrackHandle->begin(); inputIter != TTTrackHandle->end(); ++inputIter) {
       /// Make the pointer to be put in the map
-      edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > tempTrackPtr( TTTrackHandle, j++ );
+      edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>> tempTrackPtr(TTTrackHandle, j++);
 
       /// Get the stubs of the TTTrack (theseStubs)
-      std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > theseStubs = tempTrackPtr->getStubRefs();
+      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
+          theseStubs = tempTrackPtr->getStubRefs();
 
       /// Auxiliary map to store TP addresses and TP edm::Ptr
-      std::map< const TrackingParticle*, edm::Ptr< TrackingParticle > > auxMap;
+      std::map<const TrackingParticle*, edm::Ptr<TrackingParticle>> auxMap;
       auxMap.clear();
       int mayCombinUnknown = 0;
 
       /// Fill the inclusive map which is careless of the stub classification
-      for ( unsigned int is = 0; is < theseStubs.size(); is++ )
-      {
-	//        std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > theseClusters = theseStubs.at(is)->getClusterRefs();
-        for ( unsigned int ic = 0; ic < 2; ic++ )
-        {
-          std::vector< edm::Ptr< TrackingParticle > > tempTPs = TTClusterAssociationMapHandle->findTrackingParticlePtrs( theseStubs.at(is)->getClusterRef(ic) );
-          for ( unsigned int itp = 0; itp < tempTPs.size(); itp++ ) // List of TPs linked to stub clusters
+      for (unsigned int is = 0; is < theseStubs.size(); is++) {
+        //        std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > theseClusters = theseStubs.at(is)->getClusterRefs();
+        for (unsigned int ic = 0; ic < 2; ic++) {
+          std::vector<edm::Ptr<TrackingParticle>> tempTPs =
+              TTClusterAssociationMapHandle->findTrackingParticlePtrs(theseStubs.at(is)->getClusterRef(ic));
+          for (unsigned int itp = 0; itp < tempTPs.size(); itp++)  // List of TPs linked to stub clusters
           {
-            edm::Ptr< TrackingParticle > testTP = tempTPs.at(itp);
+            edm::Ptr<TrackingParticle> testTP = tempTPs.at(itp);
 
-            if ( testTP.isNull() ) // No TP linked to this cluster
+            if (testTP.isNull())  // No TP linked to this cluster
               continue;
 
             /// Prepare the maps wrt TrackingParticle
-            if ( trackingParticleToTrackVectorMap.find( testTP ) == trackingParticleToTrackVectorMap.end() )
-            {
-              std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > trackVector;
+            if (trackingParticleToTrackVectorMap.find(testTP) == trackingParticleToTrackVectorMap.end()) {
+              std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>> trackVector;
               trackVector.clear();
-              trackingParticleToTrackVectorMap.insert( std::make_pair( testTP, trackVector ) );
+              trackingParticleToTrackVectorMap.insert(std::make_pair(testTP, trackVector));
             }
-            trackingParticleToTrackVectorMap.find( testTP )->second.push_back( tempTrackPtr ); /// Fill the auxiliary map
+            trackingParticleToTrackVectorMap.find(testTP)->second.push_back(tempTrackPtr);  /// Fill the auxiliary map
 
             /// Fill the other auxiliary map
-            if ( auxMap.find( testTP.get() ) == auxMap.end() )
-            {
-              auxMap.insert( std::make_pair( testTP.get(), testTP ) );
+            if (auxMap.find(testTP.get()) == auxMap.end()) {
+              auxMap.insert(std::make_pair(testTP.get(), testTP));
             }
-
           }
-        } /// End of loop over the clusters
+        }  /// End of loop over the clusters
 
         /// Check if the stub is unknown
-	if ( TTStubAssociationMapHandle->isUnknown( theseStubs.at(is) ) )
-	  ++mayCombinUnknown;
+        if (TTStubAssociationMapHandle->isUnknown(theseStubs.at(is)))
+          ++mayCombinUnknown;
 
-      } /// End of loop over the stubs
+      }  /// End of loop over the stubs
 
       /// If there more than 2 unknown stubs, go to the next track
       /// as this track may be COMBINATORIC or UNKNOWN
-      if ( mayCombinUnknown >= 2 )
-      	continue;
+      if (mayCombinUnknown >= 2)
+        continue;
 
       /// If we are here, all the stubs are either combinatoric or genuine
       /// and there is no more than one fake stub in the track
       /// Loop over all the TrackingParticle which have been found in the track at some point
       /// (stored in auxMap)
 
-      std::vector< const TrackingParticle* > tpInAllStubs;
+      std::vector<const TrackingParticle*> tpInAllStubs;
 
-      std::map< const TrackingParticle*, edm::Ptr< TrackingParticle > >::const_iterator iterAuxMap;
-      for ( iterAuxMap = auxMap.begin();
-            iterAuxMap != auxMap.end();
-            ++iterAuxMap )
-      {
+      std::map<const TrackingParticle*, edm::Ptr<TrackingParticle>>::const_iterator iterAuxMap;
+      for (iterAuxMap = auxMap.begin(); iterAuxMap != auxMap.end(); ++iterAuxMap) {
         /// Get all the stubs from this TrackingParticle
-        std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > tempStubs = TTStubAssociationMapHandle->findTTStubRefs( iterAuxMap->second );
+        std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
+            tempStubs = TTStubAssociationMapHandle->findTTStubRefs(iterAuxMap->second);
 
-	int nnotfound=0;
+        int nnotfound = 0;
         //bool allFound = true;
         /// Loop over the stubs
-	//        for ( unsigned int js = 0; js < theseStubs.size() && allFound; js++ )
-        for ( unsigned int js = 0; js < theseStubs.size(); js++ )
-        {
+        //        for ( unsigned int js = 0; js < theseStubs.size() && allFound; js++ )
+        for (unsigned int js = 0; js < theseStubs.size(); js++) {
           /// We want that all the stubs of the track are included in the container of
           /// all the stubs produced by this particular TrackingParticle which we
           /// already know is one of the TrackingParticles that released hits
           /// in this track we are evaluating right now
-          if ( std::find( tempStubs.begin(), tempStubs.end(), theseStubs.at(js) ) == tempStubs.end() )
-          {
-	    //  allFound = false;
-	    ++nnotfound;
+          if (std::find(tempStubs.begin(), tempStubs.end(), theseStubs.at(js)) == tempStubs.end()) {
+            //  allFound = false;
+            ++nnotfound;
           }
         }
 
         /// If the TrackingParticle does not appear in all stubs but one
         /// then go to the next track
-        if (nnotfound>1)
-	  //if (!allFound)
-	  continue;
+        if (nnotfound > 1)
+          //if (!allFound)
+          continue;
 
         /// If we are here, it means that the TrackingParticle
         /// generates hits in all stubs but one of the current track
         /// so put it into the vector
-        tpInAllStubs.push_back( iterAuxMap->first );
+        tpInAllStubs.push_back(iterAuxMap->first);
       }
 
       /// Count how many TrackingParticles we do have
-      std::sort( tpInAllStubs.begin(), tpInAllStubs.end() );
-      tpInAllStubs.erase( std::unique( tpInAllStubs.begin(), tpInAllStubs.end() ), tpInAllStubs.end() );
+      std::sort(tpInAllStubs.begin(), tpInAllStubs.end());
+      tpInAllStubs.erase(std::unique(tpInAllStubs.begin(), tpInAllStubs.end()), tpInAllStubs.end());
       unsigned int nTPs = tpInAllStubs.size();
 
       /// If only one TrackingParticle, GENUINE
       /// if different than one, COMBINATORIC
-      if ( nTPs != 1 ) continue;
+      if (nTPs != 1)
+        continue;
 
       /// Here, the track may only be GENUINE
       /// Fill the map
-      trackToTrackingParticleMap.insert( std::make_pair( tempTrackPtr, auxMap.find( tpInAllStubs.at(0) )->second ) ); 
+      trackToTrackingParticleMap.insert(std::make_pair(tempTrackPtr, auxMap.find(tpInAllStubs.at(0))->second));
 
-    } /// End of loop over Tracks
+    }  /// End of loop over Tracks
 
     /// Clean the only map that needs cleaning
     /// Prepare the output map wrt TrackingParticle
-    typename std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > >::iterator iterMapToClean;
-    for ( iterMapToClean = trackingParticleToTrackVectorMap.begin();
-          iterMapToClean != trackingParticleToTrackVectorMap.end();
-          ++iterMapToClean )
-    {
+    typename std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>>::iterator
+        iterMapToClean;
+    for (iterMapToClean = trackingParticleToTrackVectorMap.begin();
+         iterMapToClean != trackingParticleToTrackVectorMap.end();
+         ++iterMapToClean) {
       /// Get the vector of edm::Ptr< TTTrack >
-      std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > tempVector = iterMapToClean->second;
+      std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>> tempVector = iterMapToClean->second;
 
       /// Sort and remove duplicates
-      std::sort( tempVector.begin(), tempVector.end() );
-      tempVector.erase( std::unique( tempVector.begin(), tempVector.end() ), tempVector.end() );
+      std::sort(tempVector.begin(), tempVector.end());
+      tempVector.erase(std::unique(tempVector.begin(), tempVector.end()), tempVector.end());
 
       iterMapToClean->second = tempVector;
     }
 
     /// Also, create the pointer to the TTClusterAssociationMap
-    edm::RefProd< TTStubAssociationMap< Ref_Phase2TrackerDigi_ > > theStubAssoMap( TTStubAssociationMapHandle );
+    edm::RefProd<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> theStubAssoMap(TTStubAssociationMapHandle);
 
     /// Put the maps in the association object
-    associationMapForOutput->setTTTrackToTrackingParticleMap( trackToTrackingParticleMap ); 
-    associationMapForOutput->setTrackingParticleToTTTracksMap( trackingParticleToTrackVectorMap );
-    associationMapForOutput->setTTStubAssociationMap( theStubAssoMap );
+    associationMapForOutput->setTTTrackToTrackingParticleMap(trackToTrackingParticleMap);
+    associationMapForOutput->setTrackingParticleToTTTracksMap(trackingParticleToTrackVectorMap);
+    associationMapForOutput->setTTStubAssociationMap(theStubAssoMap);
 
     /// Put output in the event
-    iEvent.put( std::move(associationMapForOutput), TTTracksInputTags.at(ncont1).instance() );
+    iEvent.put(std::move(associationMapForOutput), TTTracksInputTags.at(ncont1).instance());
 
     ++ncont1;
-  } /// End of loop over InputTags
+  }  /// End of loop over InputTags
 }
-
-

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
@@ -36,37 +36,35 @@
 #include <map>
 #include <vector>
 
-template< typename T >
-class TTTrackAssociator : public edm::stream::EDProducer<>
-{
+template <typename T>
+class TTTrackAssociator : public edm::stream::EDProducer<> {
   /// NOTE since pattern hit correlation must be performed within a stacked module, one must store
   /// Clusters in a proper way, providing easy access to them in a detector/member-wise way
-  public:
-    /// Constructors
-    explicit TTTrackAssociator( const edm::ParameterSet& iConfig );
+public:
+  /// Constructors
+  explicit TTTrackAssociator(const edm::ParameterSet& iConfig);
 
-    /// Destructor
-    ~TTTrackAssociator() override;
+  /// Destructor
+  ~TTTrackAssociator() override;
 
-  private:
-    /// Data members
-    std::vector< edm::InputTag > TTTracksInputTags;
+private:
+  /// Data members
+  std::vector<edm::InputTag> TTTracksInputTags;
 
+  std::vector<edm::EDGetTokenT<std::vector<TTTrack<T> > > > TTTracksTokens;
 
-    std::vector<edm::EDGetTokenT< std::vector< TTTrack< T > > > > TTTracksTokens;
+  edm::EDGetTokenT<TTStubAssociationMap<T> > TTStubTruthToken;
+  edm::EDGetTokenT<TTClusterAssociationMap<T> > TTClusterTruthToken;
 
-    edm::EDGetTokenT< TTStubAssociationMap< T > > TTStubTruthToken;
-    edm::EDGetTokenT< TTClusterAssociationMap< T > > TTClusterTruthToken;
+  //    edm::InputTag TTClusterTruthInputTag;
+  //    edm::InputTag TTStubTruthInputTag;
 
-    //    edm::InputTag TTClusterTruthInputTag;
-    //    edm::InputTag TTStubTruthInputTag;
+  /// Mandatory methods
+  void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
+  void endRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-    /// Mandatory methods
-    void beginRun( const edm::Run& run, const edm::EventSetup& iSetup ) override;
-    void endRun( const edm::Run& run, const edm::EventSetup& iSetup ) override;
-    void produce( edm::Event& iEvent, const edm::EventSetup& iSetup ) override;
-
-}; /// Close class
+};  /// Close class
 
 /*! \brief   Implementation of methods
  *  \details Here, in the header file, the methods which do not depend
@@ -76,40 +74,36 @@ class TTTrackAssociator : public edm::stream::EDProducer<>
  */
 
 /// Constructors
-template< typename T >
-TTTrackAssociator< T >::TTTrackAssociator( const edm::ParameterSet& iConfig )
-{
-  TTTracksInputTags   = iConfig.getParameter< std::vector< edm::InputTag > >( "TTTracks" );
-  TTClusterTruthToken = consumes< TTClusterAssociationMap< T > >(iConfig.getParameter< edm::InputTag >( "TTClusterTruth" ));
-  TTStubTruthToken    = consumes< TTStubAssociationMap< T > >(iConfig.getParameter< edm::InputTag >( "TTStubTruth" ));
+template <typename T>
+TTTrackAssociator<T>::TTTrackAssociator(const edm::ParameterSet& iConfig) {
+  TTTracksInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTTracks");
+  TTClusterTruthToken = consumes<TTClusterAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTClusterTruth"));
+  TTStubTruthToken = consumes<TTStubAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTStubTruth"));
 
-  for ( auto iTag =  TTTracksInputTags.begin(); iTag!=  TTTracksInputTags.end(); iTag++ )
-  {
-    TTTracksTokens.push_back(consumes< std::vector< TTTrack< T > > >(*iTag));
+  for (auto iTag = TTTracksInputTags.begin(); iTag != TTTracksInputTags.end(); iTag++) {
+    TTTracksTokens.push_back(consumes<std::vector<TTTrack<T> > >(*iTag));
 
-    produces< TTTrackAssociationMap< T > >( (*iTag).instance() );
+    produces<TTTrackAssociationMap<T> >((*iTag).instance());
   }
 }
 
 /// Destructor
-template< typename T >
-TTTrackAssociator< T >::~TTTrackAssociator(){}
+template <typename T>
+TTTrackAssociator<T>::~TTTrackAssociator() {}
 
 /// Begin run
-template< typename T >
-void TTTrackAssociator< T >::beginRun( const edm::Run& run, const edm::EventSetup& iSetup )
-{
+template <typename T>
+void TTTrackAssociator<T>::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
   /// Print some information when loaded
-  edm::LogInfo("TTStubAssociator< ") << "TTTrackAssociator< " << templateNameFinder< T >() << " > loaded.";
+  edm::LogInfo("TTStubAssociator< ") << "TTTrackAssociator< " << templateNameFinder<T>() << " > loaded.";
 }
 
 /// End run
-template< typename T >
-void TTTrackAssociator< T >::endRun( const edm::Run& run, const edm::EventSetup& iSetup ){}
+template <typename T>
+void TTTrackAssociator<T>::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
 /// Implement the producer
-template< >
-void TTTrackAssociator< Ref_Phase2TrackerDigi_ >::produce( edm::Event& iEvent, const edm::EventSetup& iSetup );
+template <>
+void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup);
 
 #endif
-

--- a/SimTracker/TrackTriggerAssociation/plugins/module.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/module.cc
@@ -8,14 +8,13 @@
 /// The Associators
 
 #include "SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h"
-typedef TTClusterAssociator< Ref_Phase2TrackerDigi_> TTClusterAssociator_Phase2TrackerDigi_;
-DEFINE_FWK_MODULE( TTClusterAssociator_Phase2TrackerDigi_ );
+typedef TTClusterAssociator<Ref_Phase2TrackerDigi_> TTClusterAssociator_Phase2TrackerDigi_;
+DEFINE_FWK_MODULE(TTClusterAssociator_Phase2TrackerDigi_);
 
 #include "SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h"
-typedef TTStubAssociator< Ref_Phase2TrackerDigi_ > TTStubAssociator_Phase2TrackerDigi_;
-DEFINE_FWK_MODULE( TTStubAssociator_Phase2TrackerDigi_ );
+typedef TTStubAssociator<Ref_Phase2TrackerDigi_> TTStubAssociator_Phase2TrackerDigi_;
+DEFINE_FWK_MODULE(TTStubAssociator_Phase2TrackerDigi_);
 
 #include "SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h"
-typedef TTTrackAssociator< Ref_Phase2TrackerDigi_ > TTTrackAssociator_Phase2TrackerDigi_;
-DEFINE_FWK_MODULE( TTTrackAssociator_Phase2TrackerDigi_ );
-
+typedef TTTrackAssociator<Ref_Phase2TrackerDigi_> TTTrackAssociator_Phase2TrackerDigi_;
+DEFINE_FWK_MODULE(TTTrackAssociator_Phase2TrackerDigi_);

--- a/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
+++ b/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
@@ -7,104 +7,96 @@
 
 #include "SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h"
 
-
 /// Operations
-template< >
-edm::Ptr< TrackingParticle > TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::findTrackingParticlePtr( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const
-{
-  if ( trackToTrackingParticleMap.find( aTrack ) != trackToTrackingParticleMap.end() )
-  {
-    return trackToTrackingParticleMap.find( aTrack )->second;
+template <>
+edm::Ptr<TrackingParticle> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
+  if (trackToTrackingParticleMap.find(aTrack) != trackToTrackingParticleMap.end()) {
+    return trackToTrackingParticleMap.find(aTrack)->second;
   }
 
   /// Default: return NULL
-  edm::Ptr< TrackingParticle >* temp = new edm::Ptr< TrackingParticle >();
+  edm::Ptr<TrackingParticle>* temp = new edm::Ptr<TrackingParticle>();
   return *temp;
 }
 
-template< >
-std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::findTTTrackPtrs( edm::Ptr< TrackingParticle > aTrackingParticle ) const
-{
-  if ( trackingParticleToTrackVectorMap.find( aTrackingParticle ) != trackingParticleToTrackVectorMap.end() )
-  {
-    return trackingParticleToTrackVectorMap.find( aTrackingParticle )->second;
+template <>
+std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > > TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
+    edm::Ptr<TrackingParticle> aTrackingParticle) const {
+  if (trackingParticleToTrackVectorMap.find(aTrackingParticle) != trackingParticleToTrackVectorMap.end()) {
+    return trackingParticleToTrackVectorMap.find(aTrackingParticle)->second;
   }
 
   /// Default: return empty vector
-  std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > tempVec;
+  std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > > tempVec;
   tempVec.clear();
   return tempVec;
 }
 
 /// MC truth
-template< >
-bool TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::isLooselyGenuine( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const
-{
+template <>
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isLooselyGenuine(
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
   /// Check if there is a TrackingParticle
-  if ( (this->findTrackingParticlePtr( aTrack )).isNull() )
+  if ((this->findTrackingParticlePtr(aTrack)).isNull())
     return false;
 
   return true;
 }
 
 /// MC truth
-template< >
-bool TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::isGenuine( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const
-{
+template <>
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
   /// Check if there is a TrackingParticle
-  if ( (this->findTrackingParticlePtr( aTrack )).isNull() )
+  if ((this->findTrackingParticlePtr(aTrack)).isNull())
     return false;
 
   /// Get all the stubs from this TrackingParticle
-  std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > TP_Stubs = theStubAssociationMap->findTTStubRefs( this->findTrackingParticlePtr( aTrack ) );
-  std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > TRK_Stubs = aTrack->getStubRefs();
- 
-  for ( unsigned int js = 0; js < TRK_Stubs.size(); js++ )
-  {
+  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+      TP_Stubs = theStubAssociationMap->findTTStubRefs(this->findTrackingParticlePtr(aTrack));
+  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+      TRK_Stubs = aTrack->getStubRefs();
+
+  for (unsigned int js = 0; js < TRK_Stubs.size(); js++) {
     /// We want that all the stubs of the track are included in the container of
     /// all the stubs produced by this particular TrackingParticle which we
     /// already know is one of the TrackingParticles that released hits
     /// in this track we are evaluating right now
-    if ( std::find( TP_Stubs.begin(), TP_Stubs.end(), TRK_Stubs.at(js) ) == TP_Stubs.end() )
-      {
-	return false;
-      }
-  }
-
-  return true;
-}
-
-
-template< >
-bool TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::isCombinatoric( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const
-{
-  /// Defined by exclusion
-  if ( this->isLooselyGenuine( aTrack ) )
-    return false;
-
-  if ( this->isUnknown( aTrack ) )
-    return false;
-
-  return true;
-}
-
-template< >
-bool TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >::isUnknown( edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > aTrack ) const
-{
-  /// UNKNOWN means that more than 2 stubs are unknown
-  int unknownstubs=0;
-
-  std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > theseStubs = aTrack->getStubRefs();
-  for ( unsigned int i = 0; i < theseStubs.size(); i++ )
-  {
-    if ( theStubAssociationMap->isUnknown( theseStubs.at(i) ) == false )
-    {
-      ++unknownstubs;
-      if (unknownstubs>=2) return false;
+    if (std::find(TP_Stubs.begin(), TP_Stubs.end(), TRK_Stubs.at(js)) == TP_Stubs.end()) {
+      return false;
     }
   }
 
   return true;
 }
 
+template <>
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isCombinatoric(
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
+  /// Defined by exclusion
+  if (this->isLooselyGenuine(aTrack))
+    return false;
 
+  if (this->isUnknown(aTrack))
+    return false;
+
+  return true;
+}
+
+template <>
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isUnknown(edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
+  /// UNKNOWN means that more than 2 stubs are unknown
+  int unknownstubs = 0;
+
+  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
+      theseStubs = aTrack->getStubRefs();
+  for (unsigned int i = 0; i < theseStubs.size(); i++) {
+    if (theStubAssociationMap->isUnknown(theseStubs.at(i)) == false) {
+      ++unknownstubs;
+      if (unknownstubs >= 2)
+        return false;
+    }
+  }
+
+  return true;
+}

--- a/SimTracker/TrackTriggerAssociation/src/classes.h
+++ b/SimTracker/TrackTriggerAssociation/src/classes.h
@@ -13,30 +13,38 @@
 #include "SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h"
 #include "SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h"
 
-namespace
-{
-  namespace
-  {
+namespace {
+  namespace {
     // edm::Ptr< TrackingParticle >                  TP;
     // std::vector< edm::Ptr< TrackingParticle > > V_TP;
 
-    TTClusterAssociationMap< Ref_Phase2TrackerDigi_ >                   CAM_PD;
-    edm::Wrapper< TTClusterAssociationMap< Ref_Phase2TrackerDigi_ > > W_CAM_PD;
+    TTClusterAssociationMap<Ref_Phase2TrackerDigi_> CAM_PD;
+    edm::Wrapper<TTClusterAssociationMap<Ref_Phase2TrackerDigi_> > W_CAM_PD;
 
-    std::map< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > >, std::vector< edm::Ptr< TrackingParticle > > > M_CAM_C_TP_PD;
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > > M_CAM_TP_C_PD;
-    edm::RefProd< TTClusterAssociationMap< Ref_Phase2TrackerDigi_ > >                                                                                                  R_CAM_PD;
+    std::map<edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_> >, TTCluster<Ref_Phase2TrackerDigi_> >,
+             std::vector<edm::Ptr<TrackingParticle> > >
+        M_CAM_C_TP_PD;
+    std::map<edm::Ptr<TrackingParticle>,
+             std::vector<edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_> >,
+                                  TTCluster<Ref_Phase2TrackerDigi_> > > >
+        M_CAM_TP_C_PD;
+    edm::RefProd<TTClusterAssociationMap<Ref_Phase2TrackerDigi_> > R_CAM_PD;
 
-    TTStubAssociationMap< Ref_Phase2TrackerDigi_ >                   SAM_PD;
-    edm::Wrapper< TTStubAssociationMap< Ref_Phase2TrackerDigi_ > > W_SAM_PD;
+    TTStubAssociationMap<Ref_Phase2TrackerDigi_> SAM_PD;
+    edm::Wrapper<TTStubAssociationMap<Ref_Phase2TrackerDigi_> > W_SAM_PD;
 
-    std::map< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > >, edm::Ptr< TrackingParticle > >                M_SAM_S_TP_PD;
-    std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_Phase2TrackerDigi_ > >, TTStub< Ref_Phase2TrackerDigi_ > > > > M_SAM_TP_S_PD;
-    edm::RefProd< TTStubAssociationMap< Ref_Phase2TrackerDigi_ > >                                                                                               R_SAM_PD;
-    
-    TTTrackAssociationMap< Ref_Phase2TrackerDigi_ >                   TAM_PD;
-    edm::Wrapper< TTTrackAssociationMap< Ref_Phase2TrackerDigi_ > > W_TAM_PD;
-    edm::RefProd< TTTrackAssociationMap< Ref_Phase2TrackerDigi_ > > R_TAM_PD;
+    std::map<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> >,
+             edm::Ptr<TrackingParticle> >
+        M_SAM_S_TP_PD;
+    std::map<
+        edm::Ptr<TrackingParticle>,
+        std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > > >
+        M_SAM_TP_S_PD;
+    edm::RefProd<TTStubAssociationMap<Ref_Phase2TrackerDigi_> > R_SAM_PD;
+
+    TTTrackAssociationMap<Ref_Phase2TrackerDigi_> TAM_PD;
+    edm::Wrapper<TTTrackAssociationMap<Ref_Phase2TrackerDigi_> > W_TAM_PD;
+    edm::RefProd<TTTrackAssociationMap<Ref_Phase2TrackerDigi_> > R_TAM_PD;
 
     /*
     std::pair< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > >, edm::Ptr< TrackingParticle > >                P_TAM_S_TP_PD;
@@ -44,7 +52,6 @@ namespace
 
     std::map< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > >, edm::Ptr< TrackingParticle > >                M_TAM_S_TP_PD;
     std::map< edm::Ptr< TrackingParticle >, std::vector< edm::Ptr< TTTrack< Ref_Phase2TrackerDigi_ > > > > M_TAM_TP_S_PD;
-    */    
-  }
-}
-
+    */
+  }  // namespace
+}  // namespace


### PR DESCRIPTION

Applying code-format for CMSSW category l1,simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/297//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


