### PR TITLE
Running code-format for reconstruction-simulation

### DIFF
--- a/DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h
+++ b/DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h
@@ -13,116 +13,76 @@
 #include <cstdint>
 #include "DataFormats/CTPPSDigi/interface/HPTDCErrorFlags.h"
 
-class CTPPSDiamondDigi{
+class CTPPSDiamondDigi {
+public:
+  CTPPSDiamondDigi(
+      unsigned int ledgt_, unsigned int tedgt_, unsigned int threvolt, bool mhit_, unsigned short hptdcerror_);
+  CTPPSDiamondDigi();
+  ~CTPPSDiamondDigi(){};
 
-  public:
-  
-    CTPPSDiamondDigi(unsigned int ledgt_, unsigned int tedgt_, unsigned int threvolt, bool mhit_, unsigned short hptdcerror_);
-    CTPPSDiamondDigi();
-    ~CTPPSDiamondDigi() {};
-  
-    /// Digis are equal if they are have same  ledt and tedt, threshold voltage, multihit flag, hptdcerror flags
-    bool operator==(const CTPPSDiamondDigi& digi) const;
+  /// Digis are equal if they are have same  ledt and tedt, threshold voltage, multihit flag, hptdcerror flags
+  bool operator==(const CTPPSDiamondDigi& digi) const;
 
-    /// Return digi values number
-  
-    unsigned int getLeadingEdge() const 
-    { 
-      return ledgt; 
-    }
-  
-    unsigned int getTrailingEdge() const 
-    { 
-      return tedgt; 
-    }
-  
-    unsigned int getThresholdVoltage() const 
-    { 
-      return threvolt; 
-    }
-  
-    bool getMultipleHit() const 
-    { 
-      return mhit; 
-    }
-  
-    HPTDCErrorFlags getHPTDCErrorFlags() const 
-    { 
-      return hptdcerror; 
-    }
+  /// Return digi values number
 
-    /// Set digi values
-    inline void setLeadingEdge(unsigned int ledgt_) 
-    { 
-      ledgt = ledgt_; 
-    }
-    inline void setTrailingEdge(unsigned int tedgt_) 
-    { 
-      tedgt = tedgt_; 
-    }
-    inline void setThresholdVoltage(unsigned int threvolt_) 
-    { 
-      threvolt = threvolt_; 
-    }
-    inline void setMultipleHit(bool mhit_) 
-    { 
-      mhit = mhit_; 
-    }
-    inline void setHPTDCErrorFlags(const HPTDCErrorFlags& hptdcerror_) 
-    { 
-      hptdcerror = hptdcerror_; 
-    }
+  unsigned int getLeadingEdge() const { return ledgt; }
 
+  unsigned int getTrailingEdge() const { return tedgt; }
 
-  private:
-    // variable represents leading edge time
-    unsigned int ledgt;
-    // variable	represents trailing edge time
-    unsigned int tedgt;
-    // variable represents threshold voltage
-    unsigned int threvolt;
-    // variable represents multi-hit 
-    bool mhit;
-    HPTDCErrorFlags hptdcerror;
+  unsigned int getThresholdVoltage() const { return threvolt; }
+
+  bool getMultipleHit() const { return mhit; }
+
+  HPTDCErrorFlags getHPTDCErrorFlags() const { return hptdcerror; }
+
+  /// Set digi values
+  inline void setLeadingEdge(unsigned int ledgt_) { ledgt = ledgt_; }
+  inline void setTrailingEdge(unsigned int tedgt_) { tedgt = tedgt_; }
+  inline void setThresholdVoltage(unsigned int threvolt_) { threvolt = threvolt_; }
+  inline void setMultipleHit(bool mhit_) { mhit = mhit_; }
+  inline void setHPTDCErrorFlags(const HPTDCErrorFlags& hptdcerror_) { hptdcerror = hptdcerror_; }
+
+private:
+  // variable represents leading edge time
+  unsigned int ledgt;
+  // variable	represents trailing edge time
+  unsigned int tedgt;
+  // variable represents threshold voltage
+  unsigned int threvolt;
+  // variable represents multi-hit
+  bool mhit;
+  HPTDCErrorFlags hptdcerror;
 };
 
 #include <iostream>
 
-
-inline bool operator< (const CTPPSDiamondDigi& one, const CTPPSDiamondDigi& other)
-{
-  if( one.getLeadingEdge() < other.getLeadingEdge() )                                     
-    return true; 
-  if( one.getLeadingEdge() > other.getLeadingEdge() )                                      
-    return false;
-  if( one.getTrailingEdge() < other.getTrailingEdge() )                                    
+inline bool operator<(const CTPPSDiamondDigi& one, const CTPPSDiamondDigi& other) {
+  if (one.getLeadingEdge() < other.getLeadingEdge())
     return true;
-  if( one.getTrailingEdge() > other.getTrailingEdge() )                                     
+  if (one.getLeadingEdge() > other.getLeadingEdge())
     return false;
-  if( one.getMultipleHit() < other.getMultipleHit() )                                 
+  if (one.getTrailingEdge() < other.getTrailingEdge())
     return true;
-  if( one.getMultipleHit() > other.getMultipleHit() )                                    
+  if (one.getTrailingEdge() > other.getTrailingEdge())
     return false;
-  if( one.getHPTDCErrorFlags().getErrorFlag() < other.getHPTDCErrorFlags().getErrorFlag() ) 
+  if (one.getMultipleHit() < other.getMultipleHit())
     return true;
-  if( one.getHPTDCErrorFlags().getErrorFlag() > other.getHPTDCErrorFlags().getErrorFlag() ) 
+  if (one.getMultipleHit() > other.getMultipleHit())
     return false;
-  if( one.getThresholdVoltage() < other.getThresholdVoltage() )                             
+  if (one.getHPTDCErrorFlags().getErrorFlag() < other.getHPTDCErrorFlags().getErrorFlag())
     return true;
-  if( one.getThresholdVoltage() > other.getThresholdVoltage() )  
+  if (one.getHPTDCErrorFlags().getErrorFlag() > other.getHPTDCErrorFlags().getErrorFlag())
+    return false;
+  if (one.getThresholdVoltage() < other.getThresholdVoltage())
+    return true;
+  if (one.getThresholdVoltage() > other.getThresholdVoltage())
     return false;
   return false;
-}  
+}
 
-
-inline std::ostream & operator<<(std::ostream & o, const CTPPSDiamondDigi& digi)
-{
-  return o << " " << digi.getLeadingEdge()
-	   << " " << digi.getTrailingEdge()
-           << " " << digi.getThresholdVoltage()
-           << " " << digi.getMultipleHit()
-           << " " << digi.getHPTDCErrorFlags().getErrorFlag();
+inline std::ostream& operator<<(std::ostream& o, const CTPPSDiamondDigi& digi) {
+  return o << " " << digi.getLeadingEdge() << " " << digi.getTrailingEdge() << " " << digi.getThresholdVoltage() << " "
+           << digi.getMultipleHit() << " " << digi.getHPTDCErrorFlags().getErrorFlag();
 }
 
 #endif
-

--- a/DataFormats/CTPPSDigi/interface/CTPPSPixelDataError.h
+++ b/DataFormats/CTPPSDigi/interface/CTPPSPixelDataError.h
@@ -3,10 +3,10 @@
 
 //---------------------------------------------------------------------------
 //!  \class CTPPSPixelDataError
-//!  \brief Pixel error -- collection of errors 
+//!  \brief Pixel error -- collection of errors
 //!
 //!  Class storing info about pixel errors
-//!  
+//!
 //---------------------------------------------------------------------------
 
 #include "FWCore/Utilities/interface/typedefs.h"
@@ -16,7 +16,6 @@
 
 class CTPPSPixelDataError {
 public:
-
   /// Default constructor
   CTPPSPixelDataError();
   /// Constructor for 32-bit error word
@@ -25,36 +24,33 @@ public:
   CTPPSPixelDataError(uint64_t errorWord64, const int errorType, int fedId);
   /// Destructor
   ~CTPPSPixelDataError();
-  
-				        
-/// the 32-bit word that contains the error information
-  inline uint32_t errorWord32() const {return errorWord32_;} 
-/// the 64-bit word that contains the error information
-  inline uint64_t errorWord64() const {return errorWord64_;} 
-  /// the number associated with the error type (26-31 for ROC number errors, 32-33 for calibration errors)
-  inline int errorType() const {return errorType_;} 	    
-  /// the fedId where the error occured    
-  inline int fedId() const {return fedId_;} 	        
-  /// the error message to be displayed with the error	
-  inline const std::string & errorMessage() const {
-    if(errorType_>=25 && errorType_ <= 37) return errorMessages_[errorType_-24];
-    return errorMessages_[0];
-  }   
 
+  /// the 32-bit word that contains the error information
+  inline uint32_t errorWord32() const { return errorWord32_; }
+  /// the 64-bit word that contains the error information
+  inline uint64_t errorWord64() const { return errorWord64_; }
+  /// the number associated with the error type (26-31 for ROC number errors, 32-33 for calibration errors)
+  inline int errorType() const { return errorType_; }
+  /// the fedId where the error occured
+  inline int fedId() const { return fedId_; }
+  /// the error message to be displayed with the error
+  inline const std::string& errorMessage() const {
+    if (errorType_ >= 25 && errorType_ <= 37)
+      return errorMessages_[errorType_ - 24];
+    return errorMessages_[0];
+  }
 
 private:
-
   static const std::array<std::string, 14> errorMessages_;
 
   uint64_t errorWord64_;
-  uint32_t errorWord32_; 
+  uint32_t errorWord32_;
   int errorType_;
   int fedId_;
-
 };
 
 /// Comparison operators
-inline bool operator<( const CTPPSPixelDataError& one, const CTPPSPixelDataError& other) {
+inline bool operator<(const CTPPSPixelDataError& one, const CTPPSPixelDataError& other) {
   return one.fedId() < other.fedId();
 }
 

--- a/DataFormats/CTPPSDigi/interface/CTPPSPixelDigi.h
+++ b/DataFormats/CTPPSDigi/interface/CTPPSPixelDigi.h
@@ -9,66 +9,58 @@
 
 class CTPPSPixelDigi {
 public:
+  CTPPSPixelDigi(int packed_value) : theData(packed_value) {}
 
+  CTPPSPixelDigi(int row, int col, int adc) { init(row, col, adc); }
 
-  CTPPSPixelDigi( int packed_value) : theData(packed_value) {}
-
-  CTPPSPixelDigi( int row, int col, int adc) {
-    init( row, col, adc);
+  CTPPSPixelDigi(int chan, int adc) {
+    std::pair<int, int> rc = channelToPixel(chan);
+    init(rc.first, rc.second, adc);
   }
 
-  CTPPSPixelDigi( int chan, int adc) {
-    std::pair<int,int> rc = channelToPixel(chan);
-    init( rc.first, rc.second, adc);
-  }
-
-  CTPPSPixelDigi() : theData(0)  {}
+  CTPPSPixelDigi() : theData(0) {}
 
   /// Access to digi information
-  int row() const     {return (theData >> row_shift) & row_mask;}
-  int column() const  {return (theData >> column_shift) & column_mask;} 
-  unsigned short adc() const  {return (theData >> adc_shift) & adc_mask;}
-  uint32_t packedData() const {return theData;}
+  int row() const { return (theData >> row_shift) & row_mask; }
+  int column() const { return (theData >> column_shift) & column_mask; }
+  unsigned short adc() const { return (theData >> adc_shift) & adc_mask; }
+  uint32_t packedData() const { return theData; }
 
-  static std::pair<int,int> channelToPixel( int ch) {
-    int row = ( ch >> column_width_ch) & row_mask_ch;
+  static std::pair<int, int> channelToPixel(int ch) {
+    int row = (ch >> column_width_ch) & row_mask_ch;
     int col = ch & column_mask_ch;
-    return std::pair<int,int>(row,col);
+    return std::pair<int, int>(row, col);
   }
 
-  static int pixelToChannel( int row, int col) {
-    return (row << column_width_ch) | col;
-  }
+  static int pixelToChannel(int row, int col) { return (row << column_width_ch) | col; }
 
-  int channel() const {return pixelToChannel( row(), column());}
+  int channel() const { return pixelToChannel(row(), column()); }
 
-/// const values for digi packing with bit structure: adc_bits+col_bits+row_bits
+  /// const values for digi packing with bit structure: adc_bits+col_bits+row_bits
   static const uint32_t row_shift, column_shift, adc_shift;
   static const uint32_t row_mask, column_mask, adc_mask, rowcol_mask;
   static const uint32_t row_width, column_width, adc_width;
   static const uint32_t max_row, max_column, max_adc;
 
-/// const values for channel definition with bit structure: row_bits+col_bits
-  static const uint32_t column_width_ch; 
+  /// const values for channel definition with bit structure: row_bits+col_bits
+  static const uint32_t column_width_ch;
   static const uint32_t column_mask_ch;
   static const uint32_t row_mask_ch;
 
- private:
-
-  void init( int row, int col, int adc) ;
+private:
+  void init(int row, int col, int adc);
   uint32_t theData;
-};  
+};
 
 /// Comparison operator
 
-inline bool operator<( const CTPPSPixelDigi& one, const CTPPSPixelDigi& other) {
-  return (one.packedData()&CTPPSPixelDigi::rowcol_mask) < (other.packedData()&CTPPSPixelDigi::rowcol_mask);
+inline bool operator<(const CTPPSPixelDigi& one, const CTPPSPixelDigi& other) {
+  return (one.packedData() & CTPPSPixelDigi::rowcol_mask) < (other.packedData() & CTPPSPixelDigi::rowcol_mask);
 }
 
-#include<iostream>
-inline std::ostream & operator<<(std::ostream & o, const CTPPSPixelDigi& digi) {
-  return o << " " << digi.row() << " " << digi.column()
-	   << " " << digi.adc();
+#include <iostream>
+inline std::ostream& operator<<(std::ostream& o, const CTPPSPixelDigi& digi) {
+  return o << " " << digi.row() << " " << digi.column() << " " << digi.adc();
 }
 
 #endif

--- a/DataFormats/CTPPSDigi/interface/CTPPSPixelDigiCollection.h
+++ b/DataFormats/CTPPSDigi/interface/CTPPSPixelDigiCollection.h
@@ -7,9 +7,7 @@
 #include <utility>
 
 class CTPPSPixelDigiCollection {
-
- public:
-
+public:
   typedef std::vector<CTPPSPixelDigi>::const_iterator ContainerIterator;
   typedef std::pair<ContainerIterator, ContainerIterator> Range;
   typedef std::pair<unsigned int, unsigned int> IndexRange;
@@ -17,15 +15,14 @@ class CTPPSPixelDigiCollection {
   typedef std::map<unsigned int, IndexRange>::const_iterator RegistryIterator;
 
   CTPPSPixelDigiCollection() {}
-  
+
   void put(Range input, unsigned int detID);
   const Range get(unsigned int detID) const;
   const std::vector<unsigned int> detIDs() const;
-  
- private:
+
+private:
   std::vector<CTPPSPixelDigi> container_;
   Registry map_;
-
 };
 
-#endif 
+#endif

--- a/DataFormats/CTPPSDigi/interface/HPTDCErrorFlags.h
+++ b/DataFormats/CTPPSDigi/interface/HPTDCErrorFlags.h
@@ -12,77 +12,104 @@
  * July 2016
  */
 
-class HPTDCErrorFlags
-{
-  public:
+class HPTDCErrorFlags {
+public:
+  HPTDCErrorFlags(unsigned short flags = 0) : error_flags(flags) {}
 
-    HPTDCErrorFlags( unsigned short flags=0 ) : error_flags( flags ) {}
-
-    bool getErrorId( unsigned short id ) const {
-      switch (id) {
-      case 0: return getInternalFatalChipError();
-      case 1: return getEventLost();
-      case 2: return getHitRejectedByEventSizeLimit();
-      case 3: return getHitErrorGroup3();
-      case 4: return getHitLostL1OverflowGroup3();
-      case 5: return getHitLostROFifoOverflowGroup3();
-      case 6: return getHitErrorGroup2();
-      case 7: return getHitLostL1OverflowGroup2();
-      case 8: return getHitLostROFifoOverflowGroup2();
-      case 9: return getHitErrorGroup1();
-      case 10: return getHitLostL1OverflowGroup1();
-      case 11: return getHitLostROFifoOverflowGroup1();
-      case 12: return getHitErrorGroup0();
-      case 13: return getHitLostL1OverflowGroup0();
-      case 14: return getHitLostROFifoOverflowGroup0();
-      default: return true;
-      }
+  bool getErrorId(unsigned short id) const {
+    switch (id) {
+      case 0:
+        return getInternalFatalChipError();
+      case 1:
+        return getEventLost();
+      case 2:
+        return getHitRejectedByEventSizeLimit();
+      case 3:
+        return getHitErrorGroup3();
+      case 4:
+        return getHitLostL1OverflowGroup3();
+      case 5:
+        return getHitLostROFifoOverflowGroup3();
+      case 6:
+        return getHitErrorGroup2();
+      case 7:
+        return getHitLostL1OverflowGroup2();
+      case 8:
+        return getHitLostROFifoOverflowGroup2();
+      case 9:
+        return getHitErrorGroup1();
+      case 10:
+        return getHitLostL1OverflowGroup1();
+      case 11:
+        return getHitLostROFifoOverflowGroup1();
+      case 12:
+        return getHitErrorGroup0();
+      case 13:
+        return getHitLostL1OverflowGroup0();
+      case 14:
+        return getHitLostROFifoOverflowGroup0();
+      default:
+        return true;
     }
+  }
 
-    bool getInternalFatalChipError() const      { return   error_flags       & 0x1; }
-    bool getEventLost() const                   { return ( error_flags>> 1 ) & 0x1; }
-    bool getHitRejectedByEventSizeLimit() const { return ( error_flags>> 2 ) & 0x1; }
-    bool getHitErrorGroup3() const              { return ( error_flags>> 3 ) & 0x1; }
-    bool getHitLostL1OverflowGroup3() const     { return ( error_flags>> 4 ) & 0x1; }
-    bool getHitLostROFifoOverflowGroup3() const { return ( error_flags>> 5 ) & 0x1; }
-    bool getHitErrorGroup2() const              { return ( error_flags>> 6 ) & 0x1; }
-    bool getHitLostL1OverflowGroup2() const     { return ( error_flags>> 7 ) & 0x1; }
-    bool getHitLostROFifoOverflowGroup2() const { return ( error_flags>> 8 ) & 0x1; }
-    bool getHitErrorGroup1() const              { return ( error_flags>> 9 ) & 0x1; }
-    bool getHitLostL1OverflowGroup1() const     { return ( error_flags>>10 ) & 0x1; }
-    bool getHitLostROFifoOverflowGroup1() const { return ( error_flags>>11 ) & 0x1; }
-    bool getHitErrorGroup0() const              { return ( error_flags>>12 ) & 0x1; }
-    bool getHitLostL1OverflowGroup0() const     { return ( error_flags>>13 ) & 0x1; }
-    bool getHitLostROFifoOverflowGroup0() const { return ( error_flags>>14 ) & 0x1; }
-   
-    inline unsigned short getErrorFlag() const {
-      return error_flags;
-    }
-   
-    static std::string getHPTDCErrorName( const unsigned short id ) {
-      switch ( id ) {
-        case 0: return "InternalFatalChipError";
-        case 1: return "EventLost";
-        case 2: return "HitRejectedByEventSizeLimit";
-        case 3: return "HitErrorGroup3";
-        case 4: return "HitLostL1OverflowGroup3";
-        case 5: return "HitLostROFifoOverflowGroup3";
-        case 6: return "HitErrorGroup2";
-        case 7: return "HitLostL1OverflowGroup2";
-        case 8: return "HitLostROFifoOverflowGroup2";
-        case 9: return "HitErrorGroup1";
-        case 10: return "HitLostL1OverflowGroup1";
-        case 11: return "HitLostROFifoOverflowGroup1";
-        case 12: return "HitErrorGroup0";
-        case 13: return "HitLostL1OverflowGroup0";
-        case 14: return "HitLostROFifoOverflowGroup0";
-        default: return "NONE";
-      }
-    }
+  bool getInternalFatalChipError() const { return error_flags & 0x1; }
+  bool getEventLost() const { return (error_flags >> 1) & 0x1; }
+  bool getHitRejectedByEventSizeLimit() const { return (error_flags >> 2) & 0x1; }
+  bool getHitErrorGroup3() const { return (error_flags >> 3) & 0x1; }
+  bool getHitLostL1OverflowGroup3() const { return (error_flags >> 4) & 0x1; }
+  bool getHitLostROFifoOverflowGroup3() const { return (error_flags >> 5) & 0x1; }
+  bool getHitErrorGroup2() const { return (error_flags >> 6) & 0x1; }
+  bool getHitLostL1OverflowGroup2() const { return (error_flags >> 7) & 0x1; }
+  bool getHitLostROFifoOverflowGroup2() const { return (error_flags >> 8) & 0x1; }
+  bool getHitErrorGroup1() const { return (error_flags >> 9) & 0x1; }
+  bool getHitLostL1OverflowGroup1() const { return (error_flags >> 10) & 0x1; }
+  bool getHitLostROFifoOverflowGroup1() const { return (error_flags >> 11) & 0x1; }
+  bool getHitErrorGroup0() const { return (error_flags >> 12) & 0x1; }
+  bool getHitLostL1OverflowGroup0() const { return (error_flags >> 13) & 0x1; }
+  bool getHitLostROFifoOverflowGroup0() const { return (error_flags >> 14) & 0x1; }
 
-  private:
-    unsigned short error_flags;
+  inline unsigned short getErrorFlag() const { return error_flags; }
+
+  static std::string getHPTDCErrorName(const unsigned short id) {
+    switch (id) {
+      case 0:
+        return "InternalFatalChipError";
+      case 1:
+        return "EventLost";
+      case 2:
+        return "HitRejectedByEventSizeLimit";
+      case 3:
+        return "HitErrorGroup3";
+      case 4:
+        return "HitLostL1OverflowGroup3";
+      case 5:
+        return "HitLostROFifoOverflowGroup3";
+      case 6:
+        return "HitErrorGroup2";
+      case 7:
+        return "HitLostL1OverflowGroup2";
+      case 8:
+        return "HitLostROFifoOverflowGroup2";
+      case 9:
+        return "HitErrorGroup1";
+      case 10:
+        return "HitLostL1OverflowGroup1";
+      case 11:
+        return "HitLostROFifoOverflowGroup1";
+      case 12:
+        return "HitErrorGroup0";
+      case 13:
+        return "HitLostL1OverflowGroup0";
+      case 14:
+        return "HitLostROFifoOverflowGroup0";
+      default:
+        return "NONE";
+    }
+  }
+
+private:
+  unsigned short error_flags;
 };
 
 #endif
-

--- a/DataFormats/CTPPSDigi/interface/TotemFEDInfo.h
+++ b/DataFormats/CTPPSDigi/interface/TotemFEDInfo.h
@@ -14,40 +14,37 @@
 /**
  * \brief OptoRx headers and footers.
  **/
-class TotemFEDInfo
-{
-  public:
-    TotemFEDInfo(int _id=0) : fedId(_id), header(0), orbitCounter(0), footer(0)
-    {
-    }
+class TotemFEDInfo {
+public:
+  TotemFEDInfo(int _id = 0) : fedId(_id), header(0), orbitCounter(0), footer(0) {}
 
-    void setFEDId(int _f) { fedId = _f; }
-    int getFEDId() const { return fedId; }
+  void setFEDId(int _f) { fedId = _f; }
+  int getFEDId() const { return fedId; }
 
-    void setHeader(uint64_t _h) { header = _h; }
-    uint8_t getBOE() const { return (header >> 60) & 0xF; }
-    uint32_t getLV1() const { return (header >> 32) & 0xFFFFFF; }
-    uint16_t getBX() const { return (header >> 20) & 0xFFF; }
-    uint16_t getOptoRxId() const { return (header >> 8) & 0xFFF; }
-    uint8_t getFOV() const { return (header >> 4) & 0xF; }
-    uint8_t getH0() const { return (header >> 0) & 0xF; }
+  void setHeader(uint64_t _h) { header = _h; }
+  uint8_t getBOE() const { return (header >> 60) & 0xF; }
+  uint32_t getLV1() const { return (header >> 32) & 0xFFFFFF; }
+  uint16_t getBX() const { return (header >> 20) & 0xFFF; }
+  uint16_t getOptoRxId() const { return (header >> 8) & 0xFFF; }
+  uint8_t getFOV() const { return (header >> 4) & 0xF; }
+  uint8_t getH0() const { return (header >> 0) & 0xF; }
 
-    void setOrbitCounter(uint32_t _oc) { orbitCounter = _oc; }
-    uint32_t getOrbitCounter() const { return orbitCounter; }
-  
-    void setFooter(uint64_t _f) { footer = _f; }
-    uint8_t getEOE() const { return (footer >> 60) & 0xF; }
-    uint16_t getFSize() const { return (footer >> 32) & 0x3FF; }
-    uint8_t getF0() const { return (footer >> 0) & 0xF; }
+  void setOrbitCounter(uint32_t _oc) { orbitCounter = _oc; }
+  uint32_t getOrbitCounter() const { return orbitCounter; }
 
-  private:
-    /// Id from FEDRawDataCollection.
-    int fedId;
+  void setFooter(uint64_t _f) { footer = _f; }
+  uint8_t getEOE() const { return (footer >> 60) & 0xF; }
+  uint16_t getFSize() const { return (footer >> 32) & 0x3FF; }
+  uint8_t getF0() const { return (footer >> 0) & 0xF; }
 
-    /// Data from OptoRx headers and footer.
-    uint64_t header;
-    uint32_t orbitCounter;
-    uint64_t footer;
+private:
+  /// Id from FEDRawDataCollection.
+  int fedId;
+
+  /// Data from OptoRx headers and footer.
+  uint64_t header;
+  uint32_t orbitCounter;
+  uint64_t footer;
 };
 
 #endif

--- a/DataFormats/CTPPSDigi/interface/TotemRPDigi.h
+++ b/DataFormats/CTPPSDigi/interface/TotemRPDigi.h
@@ -13,26 +13,18 @@
 /**
  * Digi structure for TOTEM RP silicon strip sensors.
 **/
-class TotemRPDigi
-{
-  public:
-    TotemRPDigi(unsigned short strip_no=0) : strip_no_(strip_no)
-    {
-    };
+class TotemRPDigi {
+public:
+  TotemRPDigi(unsigned short strip_no = 0) : strip_no_(strip_no){};
 
-    unsigned short getStripNumber() const
-    {
-      return strip_no_;
-    }
-  
-  private:
-    /// index of the activated strip
-    unsigned short strip_no_;
+  unsigned short getStripNumber() const { return strip_no_; }
+
+private:
+  /// index of the activated strip
+  unsigned short strip_no_;
 };
 
-
-inline bool operator< (const TotemRPDigi& one, const TotemRPDigi& other)
-{
+inline bool operator<(const TotemRPDigi& one, const TotemRPDigi& other) {
   return one.getStripNumber() < other.getStripNumber();
 }
 

--- a/DataFormats/CTPPSDigi/interface/TotemTimingDigi.h
+++ b/DataFormats/CTPPSDigi/interface/TotemTimingDigi.h
@@ -16,194 +16,129 @@
 
 #include <DataFormats/CTPPSDigi/interface/TotemTimingEventInfo.h>
 
-class TotemTimingDigi
-{
-  public:
-    TotemTimingDigi( const uint8_t hwId, const uint64_t fpgaTimestamp, const uint16_t timestampA, const uint16_t timestampB, const uint16_t cellInfo, const std::vector<uint8_t>& samples, const TotemTimingEventInfo& totemTimingEventInfo );
-    TotemTimingDigi( const TotemTimingDigi& digi );
-    TotemTimingDigi();
-    ~TotemTimingDigi() {};
+class TotemTimingDigi {
+public:
+  TotemTimingDigi(const uint8_t hwId,
+                  const uint64_t fpgaTimestamp,
+                  const uint16_t timestampA,
+                  const uint16_t timestampB,
+                  const uint16_t cellInfo,
+                  const std::vector<uint8_t>& samples,
+                  const TotemTimingEventInfo& totemTimingEventInfo);
+  TotemTimingDigi(const TotemTimingDigi& digi);
+  TotemTimingDigi();
+  ~TotemTimingDigi(){};
 
-    /// Digis are equal if they have all the same values, NOT checking the samples!
-    bool operator==( const TotemTimingDigi& digi ) const;
+  /// Digis are equal if they have all the same values, NOT checking the samples!
+  bool operator==(const TotemTimingDigi& digi) const;
 
-    /// Return digi values number
+  /// Return digi values number
 
-    /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
-    inline unsigned int getHardwareId() const
-    {
-      return hwId_;
-    }
+  /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
+  inline unsigned int getHardwareId() const { return hwId_; }
 
-    inline unsigned int getHardwareBoardId() const
-    {
-      return ( hwId_ & 0xE0 ) >> 5;
-    }
+  inline unsigned int getHardwareBoardId() const { return (hwId_ & 0xE0) >> 5; }
 
-    inline unsigned int getHardwareSampicId() const
-    {
-      return ( hwId_ & 0x10 ) >> 4;
-    }
+  inline unsigned int getHardwareSampicId() const { return (hwId_ & 0x10) >> 4; }
 
-    inline unsigned int getHardwareChannelId() const
-    {
-      return ( hwId_ & 0x0F );
-    }
+  inline unsigned int getHardwareChannelId() const { return (hwId_ & 0x0F); }
 
-    inline unsigned int getFPGATimestamp() const
-    {
-      return fpgaTimestamp_;
-    }
+  inline unsigned int getFPGATimestamp() const { return fpgaTimestamp_; }
 
-    inline unsigned int getTimestampA() const
-    {
-      return timestampA_;
-    }
+  inline unsigned int getTimestampA() const { return timestampA_; }
 
-    inline unsigned int getTimestampB() const
-    {
-      return timestampB_;
-    }
+  inline unsigned int getTimestampB() const { return timestampB_; }
 
-    inline unsigned int getCellInfo() const
-    {
-      return cellInfo_;
-    }
+  inline unsigned int getCellInfo() const { return cellInfo_; }
 
-    inline std::vector<uint8_t> getSamples() const
-    {
-      return samples_;
-    }
+  inline std::vector<uint8_t> getSamples() const { return samples_; }
 
-    inline std::vector<uint8_t>::const_iterator getSamplesBegin() const
-    {
-      return samples_.cbegin();
-    }
+  inline std::vector<uint8_t>::const_iterator getSamplesBegin() const { return samples_.cbegin(); }
 
-    inline std::vector<uint8_t>::const_iterator getSamplesEnd() const
-    {
-      return samples_.cend();
-    }
+  inline std::vector<uint8_t>::const_iterator getSamplesEnd() const { return samples_.cend(); }
 
-    inline unsigned int getNumberOfSamples() const
-    {
-      return samples_.size();
-    }
+  inline unsigned int getNumberOfSamples() const { return samples_.size(); }
 
-    inline int getSampleAt( const unsigned int i ) const
-    {
-      int sampleValue = -1;
-      if ( i < samples_.size() )
-        sampleValue = (int) samples_.at( i );
-      return sampleValue;
-    }
+  inline int getSampleAt(const unsigned int i) const {
+    int sampleValue = -1;
+    if (i < samples_.size())
+      sampleValue = (int)samples_.at(i);
+    return sampleValue;
+  }
 
-    inline TotemTimingEventInfo getEventInfo() const
-    {
-      return totemTimingEventInfo_;
-    }
+  inline TotemTimingEventInfo getEventInfo() const { return totemTimingEventInfo_; }
 
-    /// Set digi values
-    /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
-    inline void setHardwareId( const uint8_t hwId )
-    {
-      hwId_ = hwId;
-    }
+  /// Set digi values
+  /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
+  inline void setHardwareId(const uint8_t hwId) { hwId_ = hwId; }
 
-    inline void setHardwareBoardId( const unsigned int boardId )
-    {
-      hwId_ &= 0x1F; // set board bits to 0
-      hwId_ |= ( ( boardId & 0x07 ) << 5 ) & 0xE0;
-    }
+  inline void setHardwareBoardId(const unsigned int boardId) {
+    hwId_ &= 0x1F;  // set board bits to 0
+    hwId_ |= ((boardId & 0x07) << 5) & 0xE0;
+  }
 
-    inline void setHardwareSampicId( const unsigned int sampicId )
-    {
-      hwId_ &= 0xEF; // set Sampic bit to 0
-      hwId_ |= ( ( sampicId & 0x01 ) << 4 ) & 0x10;
-    }
+  inline void setHardwareSampicId(const unsigned int sampicId) {
+    hwId_ &= 0xEF;  // set Sampic bit to 0
+    hwId_ |= ((sampicId & 0x01) << 4) & 0x10;
+  }
 
-    inline void setHardwareChannelId( const unsigned int channelId )
-    {
-      hwId_ &= 0xF0; // Set Sampic bit to 0
-      hwId_ |= ( channelId & 0x0F ) & 0x0F;
-    }
+  inline void setHardwareChannelId(const unsigned int channelId) {
+    hwId_ &= 0xF0;  // Set Sampic bit to 0
+    hwId_ |= (channelId & 0x0F) & 0x0F;
+  }
 
-    inline void setFPGATimestamp( const uint64_t fpgaTimestamp )
-    {
-      fpgaTimestamp_ = fpgaTimestamp;
-    }
+  inline void setFPGATimestamp(const uint64_t fpgaTimestamp) { fpgaTimestamp_ = fpgaTimestamp; }
 
-    inline void setTimestampA( const uint16_t timestampA )
-    {
-      timestampA_ = timestampA;
-    }
+  inline void setTimestampA(const uint16_t timestampA) { timestampA_ = timestampA; }
 
-    inline void setTimestampB( const uint16_t timestampB )
-    {
-      timestampB_ = timestampB;
-    }
+  inline void setTimestampB(const uint16_t timestampB) { timestampB_ = timestampB; }
 
-    inline void setCellInfo( const uint16_t cellInfo )
-    {
-      cellInfo_ = cellInfo & 0x3F;
-    }
+  inline void setCellInfo(const uint16_t cellInfo) { cellInfo_ = cellInfo & 0x3F; }
 
-    inline void setSamples( const std::vector<uint8_t>& samples )
-    {
-      samples_ = samples;
-    }
+  inline void setSamples(const std::vector<uint8_t>& samples) { samples_ = samples; }
 
-    inline void addSample( const uint8_t sampleValue )
-    {
-      samples_.emplace_back( sampleValue );
-    }
+  inline void addSample(const uint8_t sampleValue) { samples_.emplace_back(sampleValue); }
 
-    inline void setSampleAt( const unsigned int i, const uint8_t sampleValue )
-    {
-      if ( i < samples_.size() )
-        samples_.at(i) = sampleValue;
-    }
+  inline void setSampleAt(const unsigned int i, const uint8_t sampleValue) {
+    if (i < samples_.size())
+      samples_.at(i) = sampleValue;
+  }
 
-    inline void setEventInfo( const TotemTimingEventInfo& totemTimingEventInfo )
-    {
-      totemTimingEventInfo_ = totemTimingEventInfo;
-    }
+  inline void setEventInfo(const TotemTimingEventInfo& totemTimingEventInfo) {
+    totemTimingEventInfo_ = totemTimingEventInfo;
+  }
 
-  private:
-    uint8_t hwId_;
-    uint64_t fpgaTimestamp_;
-    uint16_t timestampA_;
-    uint16_t timestampB_;
-    uint16_t cellInfo_;
+private:
+  uint8_t hwId_;
+  uint64_t fpgaTimestamp_;
+  uint16_t timestampA_;
+  uint16_t timestampB_;
+  uint16_t cellInfo_;
 
-    std::vector<uint8_t> samples_;
+  std::vector<uint8_t> samples_;
 
-    TotemTimingEventInfo totemTimingEventInfo_;
+  TotemTimingEventInfo totemTimingEventInfo_;
 };
 
 #include <iostream>
 
-inline bool operator<( const TotemTimingDigi& one, const TotemTimingDigi& other )
-{
-  if ( one.getEventInfo() < other.getEventInfo() )
+inline bool operator<(const TotemTimingDigi& one, const TotemTimingDigi& other) {
+  if (one.getEventInfo() < other.getEventInfo())
     return true;
-  if ( one.getHardwareId() < other.getHardwareId() )
+  if (one.getHardwareId() < other.getHardwareId())
     return true;
   return false;
 }
 
-inline std::ostream& operator<<( std::ostream& os, const TotemTimingDigi& digi )
-{
+inline std::ostream& operator<<(std::ostream& os, const TotemTimingDigi& digi) {
   return os << "TotemTimingDigi:"
-            << "\nHardwareId:\t" << std::hex << digi.getHardwareId()
-            << "\nDB: " << std::dec << digi.getHardwareBoardId() << "\tSampic: " << digi.getHardwareSampicId() << "\tChannel: " << digi.getHardwareChannelId()
-            << "\nFPGATimestamp:\t" << std::dec << digi.getFPGATimestamp()
-            << "\nTimestampA:\t" << std::dec << digi.getTimestampA()
-            << "\nTimestampB:\t" << std::dec << digi.getTimestampB()
-            << "\nCellInfo:\t" << std::hex << digi.getCellInfo()
-            << "\nNumberOfSamples:\t" << std::dec << digi.getNumberOfSamples()
-            << std::endl << digi.getEventInfo() << std::endl;
+            << "\nHardwareId:\t" << std::hex << digi.getHardwareId() << "\nDB: " << std::dec
+            << digi.getHardwareBoardId() << "\tSampic: " << digi.getHardwareSampicId()
+            << "\tChannel: " << digi.getHardwareChannelId() << "\nFPGATimestamp:\t" << std::dec
+            << digi.getFPGATimestamp() << "\nTimestampA:\t" << std::dec << digi.getTimestampA() << "\nTimestampB:\t"
+            << std::dec << digi.getTimestampB() << "\nCellInfo:\t" << std::hex << digi.getCellInfo()
+            << "\nNumberOfSamples:\t" << std::dec << digi.getNumberOfSamples() << std::endl
+            << digi.getEventInfo() << std::endl;
 }
 
 #endif
-

--- a/DataFormats/CTPPSDigi/interface/TotemTimingEventInfo.h
+++ b/DataFormats/CTPPSDigi/interface/TotemTimingEventInfo.h
@@ -14,198 +14,127 @@
 #include <cstdint>
 #include <bitset>
 
-class TotemTimingEventInfo
-{
-  public:
-    TotemTimingEventInfo( const uint8_t hwId, const uint64_t l1ATimestamp, const uint16_t bunchNumber, const uint32_t orbitNumber, const uint32_t eventNumber, const uint16_t channelMap, const uint16_t l1ALatency, const uint8_t numberOfSamples, const uint8_t offsetOfSamples, const uint8_t pllInfo );
-    TotemTimingEventInfo( const TotemTimingEventInfo& eventInfo );
-    TotemTimingEventInfo();
-    ~TotemTimingEventInfo() {};
+class TotemTimingEventInfo {
+public:
+  TotemTimingEventInfo(const uint8_t hwId,
+                       const uint64_t l1ATimestamp,
+                       const uint16_t bunchNumber,
+                       const uint32_t orbitNumber,
+                       const uint32_t eventNumber,
+                       const uint16_t channelMap,
+                       const uint16_t l1ALatency,
+                       const uint8_t numberOfSamples,
+                       const uint8_t offsetOfSamples,
+                       const uint8_t pllInfo);
+  TotemTimingEventInfo(const TotemTimingEventInfo& eventInfo);
+  TotemTimingEventInfo();
+  ~TotemTimingEventInfo(){};
 
-    /// Digis are equal if they have all the same values, NOT checking the samples!
-    bool operator==( const TotemTimingEventInfo& eventInfo ) const;
+  /// Digis are equal if they have all the same values, NOT checking the samples!
+  bool operator==(const TotemTimingEventInfo& eventInfo) const;
 
-    /// Return digi values number
+  /// Return digi values number
 
-    /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
-    inline unsigned int getHardwareId() const
-    {
-      return hwId_;
-    }
+  /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
+  inline unsigned int getHardwareId() const { return hwId_; }
 
-    inline unsigned int getHardwareBoardId() const
-    {
-      return ( hwId_ & 0xE0 ) >> 5;
-    }
+  inline unsigned int getHardwareBoardId() const { return (hwId_ & 0xE0) >> 5; }
 
-    inline unsigned int getHardwareSampicId() const
-    {
-      return ( hwId_ & 0x10 ) >> 4;
-    }
+  inline unsigned int getHardwareSampicId() const { return (hwId_ & 0x10) >> 4; }
 
-    inline unsigned int getHardwareChannelId() const
-    {
-      return ( hwId_ & 0x0F );
-    }
+  inline unsigned int getHardwareChannelId() const { return (hwId_ & 0x0F); }
 
-    inline unsigned int getL1ATimestamp() const
-    {
-      return l1ATimestamp_;
-    }
+  inline unsigned int getL1ATimestamp() const { return l1ATimestamp_; }
 
-    inline unsigned int getBunchNumber() const
-    {
-      return bunchNumber_;
-    }
+  inline unsigned int getBunchNumber() const { return bunchNumber_; }
 
-    inline unsigned int getOrbitNumber() const
-    {
-      return orbitNumber_;
-    }
+  inline unsigned int getOrbitNumber() const { return orbitNumber_; }
 
-    inline unsigned int getEventNumber() const
-    {
-      return eventNumber_;
-    }
+  inline unsigned int getEventNumber() const { return eventNumber_; }
 
-    inline uint16_t getChannelMap() const
-    {
-      return channelMap_;
-    }
+  inline uint16_t getChannelMap() const { return channelMap_; }
 
-    inline unsigned int getL1ALatency() const
-    {
-      return l1ALatency_;
-    }
+  inline unsigned int getL1ALatency() const { return l1ALatency_; }
 
-    inline unsigned int getNumberOfSamples() const
-    {
-      return numberOfSamples_;
-    }
+  inline unsigned int getNumberOfSamples() const { return numberOfSamples_; }
 
-    inline unsigned int getOffsetOfSamples() const
-    {
-      return offsetOfSamples_;
-    }
+  inline unsigned int getOffsetOfSamples() const { return offsetOfSamples_; }
 
-    inline uint8_t getPLLInfo() const
-    {
-      return pllInfo_;
-    }
+  inline uint8_t getPLLInfo() const { return pllInfo_; }
 
-    /// Set digi values
-    /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
-    inline void setHardwareId( const uint8_t hwId )
-    {
-      hwId_ = hwId;
-    }
+  /// Set digi values
+  /// Hardware Id formatted as: bits 0-3 Channel Id, bit 4 Sampic Id, bits 5-7 Digitizer Board Id
+  inline void setHardwareId(const uint8_t hwId) { hwId_ = hwId; }
 
-    inline void setHardwareBoardId( const unsigned int boardId )
-    {
-      hwId_ &= 0x1F;      // Set board bits to 0
-      hwId_ |= ( ( boardId & 0x07 ) << 5 ) & 0xE0;
-    }
+  inline void setHardwareBoardId(const unsigned int boardId) {
+    hwId_ &= 0x1F;  // Set board bits to 0
+    hwId_ |= ((boardId & 0x07) << 5) & 0xE0;
+  }
 
-    inline void setHardwareSampicId( const unsigned int sampicId )
-    {
-      hwId_ &= 0xEF; // set Sampic bit to 0
-      hwId_ |= ( ( sampicId & 0x01 ) << 4 ) & 0x10;
-    }
+  inline void setHardwareSampicId(const unsigned int sampicId) {
+    hwId_ &= 0xEF;  // set Sampic bit to 0
+    hwId_ |= ((sampicId & 0x01) << 4) & 0x10;
+  }
 
-    inline void setHardwareChannelId( const unsigned int channelId )
-    {
-      hwId_ &= 0xF0; // set Sampic bit to 0
-      hwId_ |= ( channelId & 0x0F ) & 0x0F;
-    }
+  inline void setHardwareChannelId(const unsigned int channelId) {
+    hwId_ &= 0xF0;  // set Sampic bit to 0
+    hwId_ |= (channelId & 0x0F) & 0x0F;
+  }
 
-    inline void setL1ATimestamp( const uint64_t l1ATimestamp )
-    {
-      l1ATimestamp_ = l1ATimestamp;
-    }
+  inline void setL1ATimestamp(const uint64_t l1ATimestamp) { l1ATimestamp_ = l1ATimestamp; }
 
-    inline void setBunchNumber( const uint16_t bunchNumber )
-    {
-      bunchNumber_ = bunchNumber;
-    }
+  inline void setBunchNumber(const uint16_t bunchNumber) { bunchNumber_ = bunchNumber; }
 
-    inline void setOrbitNumber( const uint32_t orbitNumber )
-    {
-      orbitNumber_ = orbitNumber;
-    }
+  inline void setOrbitNumber(const uint32_t orbitNumber) { orbitNumber_ = orbitNumber; }
 
-    inline void setEventNumber( const uint32_t eventNumber )
-    {
-      eventNumber_ = eventNumber;
-    }
+  inline void setEventNumber(const uint32_t eventNumber) { eventNumber_ = eventNumber; }
 
-    inline void setChannelMap( const uint16_t channelMap )
-    {
-      channelMap_ = channelMap;
-    }
+  inline void setChannelMap(const uint16_t channelMap) { channelMap_ = channelMap; }
 
-    inline void setL1ALatency( const uint16_t l1ALatency )
-    {
-      l1ALatency_ = l1ALatency;
-    }
+  inline void setL1ALatency(const uint16_t l1ALatency) { l1ALatency_ = l1ALatency; }
 
-    inline void setNumberOfSamples( const uint8_t numberOfSamples )
-    {
-      numberOfSamples_ = numberOfSamples;
-    }
+  inline void setNumberOfSamples(const uint8_t numberOfSamples) { numberOfSamples_ = numberOfSamples; }
 
-    inline void setOffsetOfSamples( const uint8_t offsetOfSamples )
-    {
-      offsetOfSamples_ = offsetOfSamples;
-    }
+  inline void setOffsetOfSamples(const uint8_t offsetOfSamples) { offsetOfSamples_ = offsetOfSamples; }
 
-    inline void setPLLInfo( const uint8_t pllInfo )
-    {
-      pllInfo_ = pllInfo;
-    }
+  inline void setPLLInfo(const uint8_t pllInfo) { pllInfo_ = pllInfo; }
 
-  private:
-    uint8_t hwId_;
-    uint64_t l1ATimestamp_;
-    uint16_t bunchNumber_;
-    uint32_t orbitNumber_;
-    uint32_t eventNumber_;
-    uint16_t channelMap_;
-    uint16_t l1ALatency_;
-    uint8_t numberOfSamples_;
-    uint8_t offsetOfSamples_;
-    uint8_t pllInfo_;
+private:
+  uint8_t hwId_;
+  uint64_t l1ATimestamp_;
+  uint16_t bunchNumber_;
+  uint32_t orbitNumber_;
+  uint32_t eventNumber_;
+  uint16_t channelMap_;
+  uint16_t l1ALatency_;
+  uint8_t numberOfSamples_;
+  uint8_t offsetOfSamples_;
+  uint8_t pllInfo_;
 };
 
 #include <iostream>
 
-inline bool operator<( const TotemTimingEventInfo& one, const TotemTimingEventInfo& other )
-{
-  if ( one.getEventNumber() < other.getEventNumber() )
+inline bool operator<(const TotemTimingEventInfo& one, const TotemTimingEventInfo& other) {
+  if (one.getEventNumber() < other.getEventNumber())
     return true;
-  if ( one.getL1ATimestamp() < other.getL1ATimestamp() )
+  if (one.getL1ATimestamp() < other.getL1ATimestamp())
     return true;
-  if ( one.getHardwareId() < other.getHardwareId() )
+  if (one.getHardwareId() < other.getHardwareId())
     return true;
   return false;
 }
 
-inline std::ostream& operator<<( std::ostream& o, const TotemTimingEventInfo& digi )
-{
-  std::bitset<16> bitsPLLInfo( digi.getPLLInfo() );
+inline std::ostream& operator<<(std::ostream& o, const TotemTimingEventInfo& digi) {
+  std::bitset<16> bitsPLLInfo(digi.getPLLInfo());
   return o << "TotemTimingEventInfo:"
-           << "\nHardwareId:\t" << std::hex << digi.getHardwareId()
-           << "\nDB: " << std::dec << digi.getHardwareBoardId() << "\tSampic: " << digi.getHardwareSampicId() << "\tChannel: " << digi.getHardwareChannelId()
-           << "\nL1A Timestamp:\t" << std::dec << digi.getL1ATimestamp()
-           << "\nL1A Latency:\t" << std::dec << digi.getL1ALatency()
-           << "\nBunch Number:\t" << std::dec << digi.getBunchNumber()
-           << "\nOrbit Number:\t" << std::dec << digi.getOrbitNumber()
-           << "\nEvent Number:\t" << std::dec << digi.getEventNumber()
-           << "\nChannels fired:\t" << std::hex << digi.getChannelMap()
-           << "\nNumber of Samples:\t" << std::dec << digi.getNumberOfSamples()
-           << "\nOffset of Samples:\t" << std::dec << digi.getOffsetOfSamples()
-           << "\nPLL Info:\t" << bitsPLLInfo.to_string()
-           << std::endl;
+           << "\nHardwareId:\t" << std::hex << digi.getHardwareId() << "\nDB: " << std::dec << digi.getHardwareBoardId()
+           << "\tSampic: " << digi.getHardwareSampicId() << "\tChannel: " << digi.getHardwareChannelId()
+           << "\nL1A Timestamp:\t" << std::dec << digi.getL1ATimestamp() << "\nL1A Latency:\t" << std::dec
+           << digi.getL1ALatency() << "\nBunch Number:\t" << std::dec << digi.getBunchNumber() << "\nOrbit Number:\t"
+           << std::dec << digi.getOrbitNumber() << "\nEvent Number:\t" << std::dec << digi.getEventNumber()
+           << "\nChannels fired:\t" << std::hex << digi.getChannelMap() << "\nNumber of Samples:\t" << std::dec
+           << digi.getNumberOfSamples() << "\nOffset of Samples:\t" << std::dec << digi.getOffsetOfSamples()
+           << "\nPLL Info:\t" << bitsPLLInfo.to_string() << std::endl;
 }
 
 #endif
-

--- a/DataFormats/CTPPSDigi/interface/TotemTriggerCounters.h
+++ b/DataFormats/CTPPSDigi/interface/TotemTriggerCounters.h
@@ -12,22 +12,24 @@
 /**
  * Trigger counters from LoneG.
 **/
-struct TotemTriggerCounters
-{
-    unsigned char type;
-    unsigned int event_num, bunch_num, src_id;
-    unsigned int orbit_num;
-    unsigned char revision_num;
-    unsigned int run_num, trigger_num, inhibited_triggers_num, input_status_bits;
+struct TotemTriggerCounters {
+  unsigned char type;
+  unsigned int event_num, bunch_num, src_id;
+  unsigned int orbit_num;
+  unsigned char revision_num;
+  unsigned int run_num, trigger_num, inhibited_triggers_num, input_status_bits;
 
-    TotemTriggerCounters() :
-      type(0),
-      event_num(0), bunch_num(0), src_id(0),
-      orbit_num(0),
-      revision_num(0),
-      run_num(0), trigger_num(0), inhibited_triggers_num(0), input_status_bits(0)
-    {
-    } 
+  TotemTriggerCounters()
+      : type(0),
+        event_num(0),
+        bunch_num(0),
+        src_id(0),
+        orbit_num(0),
+        revision_num(0),
+        run_num(0),
+        trigger_num(0),
+        inhibited_triggers_num(0),
+        input_status_bits(0) {}
 };
 
 #endif

--- a/DataFormats/CTPPSDigi/interface/TotemVFATStatus.h
+++ b/DataFormats/CTPPSDigi/interface/TotemVFATStatus.h
@@ -18,89 +18,81 @@
 /**
  * Class which contains information about conversion from RAW to DIGI for a single read-out chip (VFAT).
  */
-class TotemVFATStatus
-{
-  public:
-    TotemVFATStatus(uint8_t _cp = 0) : chipPosition(_cp), status(0), numberOfClustersSpecified(false), numberOfClusters(0), eventCounter(0)
-    {
-    }
+class TotemVFATStatus {
+public:
+  TotemVFATStatus(uint8_t _cp = 0)
+      : chipPosition(_cp), status(0), numberOfClustersSpecified(false), numberOfClusters(0), eventCounter(0) {}
 
-    /// Chip position
-    inline uint8_t getChipPosition() const { return chipPosition; }
-    inline void setChipPosition(uint8_t _cp) { chipPosition = _cp; }
+  /// Chip position
+  inline uint8_t getChipPosition() const { return chipPosition; }
+  inline void setChipPosition(uint8_t _cp) { chipPosition = _cp; }
 
-    /// VFAT is present in mapping but no data is present int raw event
-    inline bool isMissing() const { return status[0]; }
-    inline void setMissing(bool val = true) { status[0] = val; }
+  /// VFAT is present in mapping but no data is present int raw event
+  inline bool isMissing() const { return status[0]; }
+  inline void setMissing(bool val = true) { status[0] = val; }
 
-    /// 12-bit hw id from the header of the vfat frame is diffrent from the 16-bit one from hw mapping
-    inline bool isIDMismatch() const { return status[1]; }
-    inline void setIDMismatch(bool val = true) { status[1] = val; }
-    
-    /// Footprint error
-    inline bool isFootprintError() const { return status[2]; }
-    inline void setFootprintError(bool val = true) { status[2] = val; }
+  /// 12-bit hw id from the header of the vfat frame is diffrent from the 16-bit one from hw mapping
+  inline bool isIDMismatch() const { return status[1]; }
+  inline void setIDMismatch(bool val = true) { status[1] = val; }
 
-    /// CRC error
-    inline bool isCRCError() const { return status[3]; }
-    inline void setCRCError(bool val = true) { status[3] = val; }
+  /// Footprint error
+  inline bool isFootprintError() const { return status[2]; }
+  inline void setFootprintError(bool val = true) { status[2] = val; }
 
-    /// VFATFrame event number doesn't follow the number derived from DAQ
-    inline bool isECProgressError() const { return status[4]; }
-    inline void setECProgressError(bool val = true) { status[4] = val; }
+  /// CRC error
+  inline bool isCRCError() const { return status[3]; }
+  inline void setCRCError(bool val = true) { status[3] = val; }
 
-    /// BC number is incorrect
-    inline bool isBCProgressError() const { return status[5]; }
-    inline void setBCProgressError(bool val = true) { status[5] = val; }
+  /// VFATFrame event number doesn't follow the number derived from DAQ
+  inline bool isECProgressError() const { return status[4]; }
+  inline void setECProgressError(bool val = true) { status[4] = val; }
 
-    /// All channels from that VFAT are not taken into account
-    inline bool isFullyMaskedOut() const { return status[6]; }
-    inline void setFullyMaskedOut() { status[6]=true; }
+  /// BC number is incorrect
+  inline bool isBCProgressError() const { return status[5]; }
+  inline void setBCProgressError(bool val = true) { status[5] = val; }
 
-    /// Some channels from VFAT ale masked out, but not all
-    inline bool isPartiallyMaskedOut() const { return status[7]; }
-    inline void setPartiallyMaskedOut() { status[7]=true; }
+  /// All channels from that VFAT are not taken into account
+  inline bool isFullyMaskedOut() const { return status[6]; }
+  inline void setFullyMaskedOut() { status[6] = true; }
 
-    /// No channels are masked out
-    inline bool isNotMasked() const { return !(status[6] || status[7]); }
-    inline void setNotMasked() { status[6]=status[7]=false; }
+  /// Some channels from VFAT ale masked out, but not all
+  inline bool isPartiallyMaskedOut() const { return status[7]; }
+  inline void setPartiallyMaskedOut() { status[7] = true; }
 
-    bool isOK() const
-    {
-	  return !(status[0] || status[1] || status[2] || status[3] || status[4] || status[5]);
-	}
+  /// No channels are masked out
+  inline bool isNotMasked() const { return !(status[6] || status[7]); }
+  inline void setNotMasked() { status[6] = status[7] = false; }
 
-    /// number of clusters
-    inline bool isNumberOfClustersSpecified() const { return numberOfClustersSpecified; }
-    inline void setNumberOfClustersSpecified(bool v) { numberOfClustersSpecified = v; }
+  bool isOK() const { return !(status[0] || status[1] || status[2] || status[3] || status[4] || status[5]); }
 
-    inline uint8_t getNumberOfClusters() const { return numberOfClusters; }
-    inline void setNumberOfClusters(uint8_t v) { numberOfClusters = v; }
+  /// number of clusters
+  inline bool isNumberOfClustersSpecified() const { return numberOfClustersSpecified; }
+  inline void setNumberOfClustersSpecified(bool v) { numberOfClustersSpecified = v; }
 
-    bool operator < (const TotemVFATStatus &cmp) const
-    {
-      return (status.to_ulong() < cmp.status.to_ulong());
-	}
-  
-    friend std::ostream& operator << (std::ostream& s, const TotemVFATStatus &st);
-    
-    /// event Counter
-    inline uint8_t getEC() const {return eventCounter;}
-    inline void setEC(const uint8_t ec) { eventCounter = ec; }
+  inline uint8_t getNumberOfClusters() const { return numberOfClusters; }
+  inline void setNumberOfClusters(uint8_t v) { numberOfClusters = v; }
 
-  private:
-    /// describes placement of the VFAT within the detector
-    uint8_t chipPosition;
+  bool operator<(const TotemVFATStatus& cmp) const { return (status.to_ulong() < cmp.status.to_ulong()); }
 
-    /// the status bits
-    std::bitset<8> status;
+  friend std::ostream& operator<<(std::ostream& s, const TotemVFATStatus& st);
 
-    /// the number of hit clusters before DAQ trimming
-    bool numberOfClustersSpecified;
-    uint8_t numberOfClusters;
-    
-    /// event counter in the VFAT frame
-    uint8_t eventCounter;
+  /// event Counter
+  inline uint8_t getEC() const { return eventCounter; }
+  inline void setEC(const uint8_t ec) { eventCounter = ec; }
+
+private:
+  /// describes placement of the VFAT within the detector
+  uint8_t chipPosition;
+
+  /// the status bits
+  std::bitset<8> status;
+
+  /// the number of hit clusters before DAQ trimming
+  bool numberOfClustersSpecified;
+  uint8_t numberOfClusters;
+
+  /// event counter in the VFAT frame
+  uint8_t eventCounter;
 };
 
 #endif

--- a/DataFormats/CTPPSDigi/src/CTPPSDiamondDigi.cc
+++ b/DataFormats/CTPPSDigi/src/CTPPSDiamondDigi.cc
@@ -8,24 +8,17 @@
 
 using namespace std;
 
-CTPPSDiamondDigi::CTPPSDiamondDigi(unsigned int ledgt_, unsigned int tedgt_, unsigned int threvolt_, bool mhit_, unsigned short hptdcerror_) :
-  ledgt(ledgt_), tedgt(tedgt_), threvolt(threvolt_), mhit(mhit_), hptdcerror(HPTDCErrorFlags(hptdcerror_))
-{}
+CTPPSDiamondDigi::CTPPSDiamondDigi(
+    unsigned int ledgt_, unsigned int tedgt_, unsigned int threvolt_, bool mhit_, unsigned short hptdcerror_)
+    : ledgt(ledgt_), tedgt(tedgt_), threvolt(threvolt_), mhit(mhit_), hptdcerror(HPTDCErrorFlags(hptdcerror_)) {}
 
-CTPPSDiamondDigi::CTPPSDiamondDigi() :
-  ledgt(0), tedgt(0), threvolt(0), mhit(false), hptdcerror(HPTDCErrorFlags(0))
-{}
+CTPPSDiamondDigi::CTPPSDiamondDigi() : ledgt(0), tedgt(0), threvolt(0), mhit(false), hptdcerror(HPTDCErrorFlags(0)) {}
 
 // Comparison
-bool
-CTPPSDiamondDigi::operator==(const CTPPSDiamondDigi& digi) const
-{
-  if ( ledgt     != digi.getLeadingEdge()
-   || tedgt     != digi.getTrailingEdge()
-   || threvolt  != digi.getThresholdVoltage()
-   || mhit      != digi.getMultipleHit()
-   || hptdcerror.getErrorFlag() != digi.getHPTDCErrorFlags().getErrorFlag()) return false;
-  else  
-    return true; 
+bool CTPPSDiamondDigi::operator==(const CTPPSDiamondDigi& digi) const {
+  if (ledgt != digi.getLeadingEdge() || tedgt != digi.getTrailingEdge() || threvolt != digi.getThresholdVoltage() ||
+      mhit != digi.getMultipleHit() || hptdcerror.getErrorFlag() != digi.getHPTDCErrorFlags().getErrorFlag())
+    return false;
+  else
+    return true;
 }
-

--- a/DataFormats/CTPPSDigi/src/CTPPSPixelDataError.cc
+++ b/DataFormats/CTPPSDigi/src/CTPPSPixelDataError.cc
@@ -3,57 +3,40 @@
 
 const std::array<std::string, 14> CTPPSPixelDataError::errorMessages_ = {{
 
-    "Error: Unknown error type", 
-      /// error 25
-      "Error: ROC=25",
-      /// error  26
-      "Error: Gap word",
-      /// error  27
-      "Error: Dummy word",
-      /// error  28
-      "Error: FIFO nearly full",
-      /// error  29
-      "Error: Timeout",
-      /// error  30
-      "Error: Trailer",
-      /// error  31
-      "Error: Event number mismatch",
-      /// error  32
-      "Error: Invalid or missing header",
-      /// error  33
-      "Error: Invalid or missing trailer",
-      /// error  34
-      "Error: Size mismatch",
-      /// error  35
-      "Error: Invalid channel",
-      /// error  36
-      "Error: Invalid ROC number",
-      /// error  37
-      "Error: Invalid dcol/pixel address"
-      }}; 
+    "Error: Unknown error type",
+    /// error 25
+    "Error: ROC=25",
+    /// error  26
+    "Error: Gap word",
+    /// error  27
+    "Error: Dummy word",
+    /// error  28
+    "Error: FIFO nearly full",
+    /// error  29
+    "Error: Timeout",
+    /// error  30
+    "Error: Trailer",
+    /// error  31
+    "Error: Event number mismatch",
+    /// error  32
+    "Error: Invalid or missing header",
+    /// error  33
+    "Error: Invalid or missing trailer",
+    /// error  34
+    "Error: Size mismatch",
+    /// error  35
+    "Error: Invalid channel",
+    /// error  36
+    "Error: Invalid ROC number",
+    /// error  37
+    "Error: Invalid dcol/pixel address"}};
 
-CTPPSPixelDataError::CTPPSPixelDataError():
-  errorWord64_(0),
-  errorWord32_(0),
-  errorType_(0),
-  fedId_(0) 
-{}
+CTPPSPixelDataError::CTPPSPixelDataError() : errorWord64_(0), errorWord32_(0), errorType_(0), fedId_(0) {}
 
-CTPPSPixelDataError::CTPPSPixelDataError(uint32_t errorWord32, const int errorType, int fedId) : 
-  errorWord64_(0),
-  errorWord32_(errorWord32),
-  errorType_(errorType),
-  fedId_(fedId)
-{}
+CTPPSPixelDataError::CTPPSPixelDataError(uint32_t errorWord32, const int errorType, int fedId)
+    : errorWord64_(0), errorWord32_(errorWord32), errorType_(errorType), fedId_(fedId) {}
 
-CTPPSPixelDataError::CTPPSPixelDataError(uint64_t errorWord64, const int errorType, int fedId) : 
-  errorWord64_(errorWord64),
-  errorWord32_(0),
-  errorType_(errorType),
-  fedId_(fedId)
-{}
+CTPPSPixelDataError::CTPPSPixelDataError(uint64_t errorWord64, const int errorType, int fedId)
+    : errorWord64_(errorWord64), errorWord32_(0), errorType_(errorType), fedId_(fedId) {}
 
 CTPPSPixelDataError::~CTPPSPixelDataError() = default;
-
-
-

--- a/DataFormats/CTPPSDigi/src/CTPPSPixelDigi.cc
+++ b/DataFormats/CTPPSDigi/src/CTPPSPixelDigi.cc
@@ -1,31 +1,27 @@
 #include "DataFormats/CTPPSDigi/interface/CTPPSPixelDigi.h"
 
 /// row_w 11, column_w 11, adc_w 10 bits
-const uint32_t CTPPSPixelDigi::row_shift = 0; 
-const uint32_t CTPPSPixelDigi::column_shift = 11; 
+const uint32_t CTPPSPixelDigi::row_shift = 0;
+const uint32_t CTPPSPixelDigi::column_shift = 11;
 const uint32_t CTPPSPixelDigi::adc_shift = 22;
-const uint32_t CTPPSPixelDigi::row_width = 11; 
-const uint32_t CTPPSPixelDigi::column_width = 11; 
+const uint32_t CTPPSPixelDigi::row_width = 11;
+const uint32_t CTPPSPixelDigi::column_width = 11;
 const uint32_t CTPPSPixelDigi::adc_width = 10;
-const uint32_t CTPPSPixelDigi::row_mask = 0x7FF; 
+const uint32_t CTPPSPixelDigi::row_mask = 0x7FF;
 const uint32_t CTPPSPixelDigi::column_mask = 0x7FF;
-const uint32_t CTPPSPixelDigi::adc_mask = 0x3FF; 
+const uint32_t CTPPSPixelDigi::adc_mask = 0x3FF;
 const uint32_t CTPPSPixelDigi::rowcol_mask = 0x3FFFFF;
-const uint32_t CTPPSPixelDigi::max_row = 0x7FF; 
-const uint32_t CTPPSPixelDigi::max_column = 0x7FF; 
+const uint32_t CTPPSPixelDigi::max_row = 0x7FF;
+const uint32_t CTPPSPixelDigi::max_column = 0x7FF;
 const uint32_t CTPPSPixelDigi::max_adc = 0x3FF;
 
-const uint32_t CTPPSPixelDigi::column_width_ch = 11; 
+const uint32_t CTPPSPixelDigi::column_width_ch = 11;
 const uint32_t CTPPSPixelDigi::column_mask_ch = 0x7FF;
 const uint32_t CTPPSPixelDigi::row_mask_ch = 0x7FF;
 
 void CTPPSPixelDigi::init(int row, int col, int adc) {
+  /// Set adc to max_adc in case of overflow
+  adc = (uint32_t(adc) > max_adc) ? max_adc : std::max(adc, 0);
 
-/// Set adc to max_adc in case of overflow
-  adc = (uint32_t(adc) > max_adc) ? max_adc : std::max(adc,0);
-
-  theData = (row << row_shift) |
-    (col << column_shift) |
-    (adc << adc_shift);
-
+  theData = (row << row_shift) | (col << column_shift) | (adc << adc_shift);
 }

--- a/DataFormats/CTPPSDigi/src/CTPPSPixelDigiCollection.cc
+++ b/DataFormats/CTPPSDigi/src/CTPPSPixelDigiCollection.cc
@@ -3,12 +3,12 @@
 #include <algorithm>
 
 void CTPPSPixelDigiCollection::put(Range input, unsigned int detID) {
-/// put in Digis of detID
+  /// put in Digis of detID
 
-/// store size of vector before put
+  /// store size of vector before put
   IndexRange inputRange;
 
-/// fill input in temporary vector for sorting
+  /// fill input in temporary vector for sorting
   std::vector<CTPPSPixelDigi> temporary;
 
   auto sort_begin = input.first;
@@ -16,38 +16,37 @@ void CTPPSPixelDigiCollection::put(Range input, unsigned int detID) {
 
   temporary.insert(std::end(temporary), sort_begin, sort_end);
 
-  std::sort(temporary.begin(),temporary.end());
+  std::sort(temporary.begin(), temporary.end());
 
-  inputRange.first=container_.size();
+  inputRange.first = container_.size();
   container_.insert(std::end(container_), std::begin(temporary), std::end(temporary));
-  inputRange.second = container_.size()-1;
-  
-/// fill map
-  map_[detID] = inputRange;
+  inputRange.second = container_.size() - 1;
 
+  /// fill map
+  map_[detID] = inputRange;
 }
 
 const CTPPSPixelDigiCollection::Range CTPPSPixelDigiCollection::get(unsigned int detID) const {
-/// get Digis of detID
-  
+  /// get Digis of detID
+
   auto found = map_.find(detID);
   CTPPSPixelDigiCollection::IndexRange returnIndexRange{};
-  if(found != map_.end()) {
+  if (found != map_.end()) {
     returnIndexRange = found->second;
   }
 
   CTPPSPixelDigiCollection::Range returnRange;
-  returnRange.first  = container_.begin()+returnIndexRange.first;
-  returnRange.second = container_.begin()+returnIndexRange.second+1;
+  returnRange.first = container_.begin() + returnIndexRange.first;
+  returnRange.second = container_.begin() + returnIndexRange.second + 1;
 
   return returnRange;
 }
 
 const std::vector<unsigned int> CTPPSPixelDigiCollection::detIDs() const {
-/// returns vector of detIDs in map
+  /// returns vector of detIDs in map
 
   auto begin = map_.begin();
-  auto end   = map_.end();
+  auto end = map_.end();
 
   std::vector<unsigned int> output;
   output.reserve(12);
@@ -57,5 +56,4 @@ const std::vector<unsigned int> CTPPSPixelDigiCollection::detIDs() const {
   }
 
   return output;
-
 }

--- a/DataFormats/CTPPSDigi/src/TotemTimingDigi.cc
+++ b/DataFormats/CTPPSDigi/src/TotemTimingDigi.cc
@@ -7,34 +7,36 @@
 
 #include "DataFormats/CTPPSDigi/interface/TotemTimingDigi.h"
 
-TotemTimingDigi::TotemTimingDigi( const uint8_t hwId,
-                                  const uint64_t fpgaTimestamp, const uint16_t timestampA, const uint16_t timestampB,
-                                  const uint16_t cellInfo, const std::vector<uint8_t>& samples,
-                                  const TotemTimingEventInfo& totemTimingEventInfo ) :
-  hwId_( hwId ), fpgaTimestamp_( fpgaTimestamp ), timestampA_( timestampA ), timestampB_( timestampB ),
-  cellInfo_( cellInfo ), samples_( samples ), totemTimingEventInfo_( totemTimingEventInfo )
-{}
+TotemTimingDigi::TotemTimingDigi(const uint8_t hwId,
+                                 const uint64_t fpgaTimestamp,
+                                 const uint16_t timestampA,
+                                 const uint16_t timestampB,
+                                 const uint16_t cellInfo,
+                                 const std::vector<uint8_t>& samples,
+                                 const TotemTimingEventInfo& totemTimingEventInfo)
+    : hwId_(hwId),
+      fpgaTimestamp_(fpgaTimestamp),
+      timestampA_(timestampA),
+      timestampB_(timestampB),
+      cellInfo_(cellInfo),
+      samples_(samples),
+      totemTimingEventInfo_(totemTimingEventInfo) {}
 
-TotemTimingDigi::TotemTimingDigi( const TotemTimingDigi& digi ) :
-  hwId_( digi.hwId_ ), fpgaTimestamp_( digi.fpgaTimestamp_ ), timestampA_( digi.timestampA_ ), timestampB_( digi.timestampB_ ),
-  cellInfo_( digi.cellInfo_ ), samples_( digi.samples_ ), totemTimingEventInfo_( digi.totemTimingEventInfo_ )
-{}
+TotemTimingDigi::TotemTimingDigi(const TotemTimingDigi& digi)
+    : hwId_(digi.hwId_),
+      fpgaTimestamp_(digi.fpgaTimestamp_),
+      timestampA_(digi.timestampA_),
+      timestampB_(digi.timestampB_),
+      cellInfo_(digi.cellInfo_),
+      samples_(digi.samples_),
+      totemTimingEventInfo_(digi.totemTimingEventInfo_) {}
 
-TotemTimingDigi::TotemTimingDigi() :
-  hwId_( 0 ), fpgaTimestamp_( 0 ), timestampA_( 0 ), timestampB_( 0 ), cellInfo_( 0 )
-{}
+TotemTimingDigi::TotemTimingDigi() : hwId_(0), fpgaTimestamp_(0), timestampA_(0), timestampB_(0), cellInfo_(0) {}
 
 // Comparison
-bool
-TotemTimingDigi::operator==( const TotemTimingDigi& digi ) const
-{
-  if ( hwId_          != digi.hwId_
-    || fpgaTimestamp_ != digi.fpgaTimestamp_
-    || timestampA_    != digi.timestampA_
-    || timestampB_    != digi.timestampB_
-    || cellInfo_      != digi.cellInfo_
-    || samples_       != digi.samples_
-  ) return false;
+bool TotemTimingDigi::operator==(const TotemTimingDigi& digi) const {
+  if (hwId_ != digi.hwId_ || fpgaTimestamp_ != digi.fpgaTimestamp_ || timestampA_ != digi.timestampA_ ||
+      timestampB_ != digi.timestampB_ || cellInfo_ != digi.cellInfo_ || samples_ != digi.samples_)
+    return false;
   return true;
 }
-

--- a/DataFormats/CTPPSDigi/src/TotemTimingEventInfo.cc
+++ b/DataFormats/CTPPSDigi/src/TotemTimingEventInfo.cc
@@ -6,45 +6,58 @@
 
 #include <DataFormats/CTPPSDigi/interface/TotemTimingEventInfo.h>
 
-TotemTimingEventInfo::TotemTimingEventInfo( const uint8_t hwId, const uint64_t l1ATimestamp,
-                                            const uint16_t bunchNumber, const uint32_t orbitNumber, const uint32_t eventNumber,
-                                            const uint16_t channelMap, const uint16_t l1ALatency,
-                                            const uint8_t numberOfSamples, const uint8_t offsetOfSamples, const uint8_t pllInfo ) :
-  hwId_( hwId ), l1ATimestamp_( l1ATimestamp ),
-  bunchNumber_( bunchNumber ), orbitNumber_( orbitNumber ), eventNumber_( eventNumber ),
-  channelMap_( channelMap ), l1ALatency_( l1ALatency ),
-  numberOfSamples_( numberOfSamples ), offsetOfSamples_( offsetOfSamples ), pllInfo_( pllInfo )
-{}
+TotemTimingEventInfo::TotemTimingEventInfo(const uint8_t hwId,
+                                           const uint64_t l1ATimestamp,
+                                           const uint16_t bunchNumber,
+                                           const uint32_t orbitNumber,
+                                           const uint32_t eventNumber,
+                                           const uint16_t channelMap,
+                                           const uint16_t l1ALatency,
+                                           const uint8_t numberOfSamples,
+                                           const uint8_t offsetOfSamples,
+                                           const uint8_t pllInfo)
+    : hwId_(hwId),
+      l1ATimestamp_(l1ATimestamp),
+      bunchNumber_(bunchNumber),
+      orbitNumber_(orbitNumber),
+      eventNumber_(eventNumber),
+      channelMap_(channelMap),
+      l1ALatency_(l1ALatency),
+      numberOfSamples_(numberOfSamples),
+      offsetOfSamples_(offsetOfSamples),
+      pllInfo_(pllInfo) {}
 
-TotemTimingEventInfo::TotemTimingEventInfo( const TotemTimingEventInfo& eventInfo ) :
-  hwId_( eventInfo.hwId_ ), l1ATimestamp_( eventInfo.l1ATimestamp_ ),
-  bunchNumber_( eventInfo.bunchNumber_ ), orbitNumber_( eventInfo.orbitNumber_ ), eventNumber_( eventInfo.eventNumber_ ),
-  channelMap_( eventInfo.channelMap_ ), l1ALatency_( eventInfo.l1ALatency_ ),
-  numberOfSamples_( eventInfo.numberOfSamples_ ), offsetOfSamples_( eventInfo.offsetOfSamples_ ), pllInfo_ ( eventInfo.pllInfo_ )
-{}
+TotemTimingEventInfo::TotemTimingEventInfo(const TotemTimingEventInfo& eventInfo)
+    : hwId_(eventInfo.hwId_),
+      l1ATimestamp_(eventInfo.l1ATimestamp_),
+      bunchNumber_(eventInfo.bunchNumber_),
+      orbitNumber_(eventInfo.orbitNumber_),
+      eventNumber_(eventInfo.eventNumber_),
+      channelMap_(eventInfo.channelMap_),
+      l1ALatency_(eventInfo.l1ALatency_),
+      numberOfSamples_(eventInfo.numberOfSamples_),
+      offsetOfSamples_(eventInfo.offsetOfSamples_),
+      pllInfo_(eventInfo.pllInfo_) {}
 
-TotemTimingEventInfo::TotemTimingEventInfo() :
-  hwId_( 0 ), l1ATimestamp_( 0 ),
-  bunchNumber_( 0 ), orbitNumber_( 0 ), eventNumber_( 0 ),
-  channelMap_( 0 ), l1ALatency_( 0 ),
-  numberOfSamples_( 0 ), offsetOfSamples_( 0 ), pllInfo_( 0 )
-{}
+TotemTimingEventInfo::TotemTimingEventInfo()
+    : hwId_(0),
+      l1ATimestamp_(0),
+      bunchNumber_(0),
+      orbitNumber_(0),
+      eventNumber_(0),
+      channelMap_(0),
+      l1ALatency_(0),
+      numberOfSamples_(0),
+      offsetOfSamples_(0),
+      pllInfo_(0) {}
 
 // Comparison
-bool
-TotemTimingEventInfo::operator==(const TotemTimingEventInfo& eventInfo) const
-{
-  if ( hwId_            != eventInfo.hwId_
-    || l1ATimestamp_    != eventInfo.l1ATimestamp_
-    || bunchNumber_     != eventInfo.bunchNumber_
-    || orbitNumber_     != eventInfo.orbitNumber_
-    || eventNumber_     != eventInfo.eventNumber_
-    || channelMap_      != eventInfo.channelMap_
-    || l1ALatency_      != eventInfo.l1ALatency_
-    || numberOfSamples_ != eventInfo.numberOfSamples_
-    || offsetOfSamples_ != eventInfo.offsetOfSamples_
-    || pllInfo_         != eventInfo.pllInfo_
-  ) return false;
+bool TotemTimingEventInfo::operator==(const TotemTimingEventInfo& eventInfo) const {
+  if (hwId_ != eventInfo.hwId_ || l1ATimestamp_ != eventInfo.l1ATimestamp_ || bunchNumber_ != eventInfo.bunchNumber_ ||
+      orbitNumber_ != eventInfo.orbitNumber_ || eventNumber_ != eventInfo.eventNumber_ ||
+      channelMap_ != eventInfo.channelMap_ || l1ALatency_ != eventInfo.l1ALatency_ ||
+      numberOfSamples_ != eventInfo.numberOfSamples_ || offsetOfSamples_ != eventInfo.offsetOfSamples_ ||
+      pllInfo_ != eventInfo.pllInfo_)
+    return false;
   return true;
 }
-

--- a/DataFormats/CTPPSDigi/src/TotemVFATStatus.cc
+++ b/DataFormats/CTPPSDigi/src/TotemVFATStatus.cc
@@ -11,15 +11,7 @@
 
 #include <ostream>
 
-std::ostream& operator << (std::ostream& s, const TotemVFATStatus &st)
-{
-  return s
-      << "miss=" << st.status[0]
-      << ",ID=" << st.status[1]
-      << ",foot=" << st.status[2]
-      << ",CRC=" << st.status[3]
-      << ",EC=" << st.status[4]
-      << ",BC=" << st.status[5]
-      << ",fm=" << st.status[6]
-      << ",pm=" << st.status[7];
+std::ostream& operator<<(std::ostream& s, const TotemVFATStatus& st) {
+  return s << "miss=" << st.status[0] << ",ID=" << st.status[1] << ",foot=" << st.status[2] << ",CRC=" << st.status[3]
+           << ",EC=" << st.status[4] << ",BC=" << st.status[5] << ",fm=" << st.status[6] << ",pm=" << st.status[7];
 }

--- a/DataFormats/CTPPSDigi/src/classes.h
+++ b/DataFormats/CTPPSDigi/src/classes.h
@@ -22,4 +22,3 @@
 #include "DataFormats/CTPPSDigi/interface/CTPPSPixelDataError.h"
 
 #include <vector>
-


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction,simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/301//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


