### PR TITLE
Running code-format for simulation

### DIFF
--- a/DataFormats/GeometryVector/interface/Basic2DVector.h
+++ b/DataFormats/GeometryVector/interface/Basic2DVector.h
@@ -2,7 +2,7 @@
 #define GeometryVector_Basic2DVector_h
 #include "DataFormats/Math/interface/SIMDVec.h"
 
-#if defined(USE_EXTVECT)       
+#if defined(USE_EXTVECT)
 #include "private/extBasic2DVector.h"
 #elif defined(USE_SSEVECT)
 #include "private/sseBasic2DVector.h"
@@ -10,5 +10,4 @@
 #include "private/oldBasic2DVector.h"
 #endif
 
-#endif // GeometryVector_Basic2DVector_h
-
+#endif  // GeometryVector_Basic2DVector_h

--- a/DataFormats/GeometryVector/interface/Basic3DVector.h
+++ b/DataFormats/GeometryVector/interface/Basic3DVector.h
@@ -3,7 +3,7 @@
 
 #include "DataFormats/Math/interface/SIMDVec.h"
 
-#if defined(USE_EXTVECT)       
+#if defined(USE_EXTVECT)
 #include "private/extBasic3DVector.h"
 #elif defined(USE_SSEVECT)
 #include "private/sseBasic3DVector.h"
@@ -11,5 +11,4 @@
 #include "private/oldBasic3DVector.h"
 #endif
 
-#endif // GeometryVector_Basic3DVector_h
-
+#endif  // GeometryVector_Basic3DVector_h

--- a/DataFormats/GeometryVector/interface/CoordinateSets.h
+++ b/DataFormats/GeometryVector/interface/CoordinateSets.h
@@ -5,100 +5,96 @@
 
 namespace Geom {
 
-/** Converts polar 2D coordinates to cartesian coordinates.
+  /** Converts polar 2D coordinates to cartesian coordinates.
  *  Note: Spherical coordinates (also sometimes called Polar 3D coordinates)
  *  are handled by class Spherical2Cartesian
  */
 
-    template <typename T>
-    class Polar2Cartesian {
-    public:
-        /// Construct from radius and polar angle
-	Polar2Cartesian( const T& r, const T& phi) :
-	    r_(r), phi_(phi) {}
+  template <typename T>
+  class Polar2Cartesian {
+  public:
+    /// Construct from radius and polar angle
+    Polar2Cartesian(const T& r, const T& phi) : r_(r), phi_(phi) {}
 
-	const T& r() const   {return r_;}
-	const T& phi() const {return phi_;}
+    const T& r() const { return r_; }
+    const T& phi() const { return phi_; }
 
-	T x() const {return r_ * cos(phi_);}
-	T y() const {return r_ * sin(phi_);}
+    T x() const { return r_ * cos(phi_); }
+    T y() const { return r_ * sin(phi_); }
 
-    private:
-	T r_;
-	T phi_;
-    };
+  private:
+    T r_;
+    T phi_;
+  };
 
-/** Converts cylindtical coordinates to cartesian coordinates.
+  /** Converts cylindtical coordinates to cartesian coordinates.
  */
 
-    template <typename T>
-    class Cylindrical2Cartesian {
-    public:
-        /** Construct from radius, azimuthal angle, and z component.
+  template <typename T>
+  class Cylindrical2Cartesian {
+  public:
+    /** Construct from radius, azimuthal angle, and z component.
 	 *  The radius in the cylindrical frame is the transverse component.
 	 */
-	Cylindrical2Cartesian( const T& r, const T& phi, const T& z) :
-	    r_(r), phi_(phi), z_(z) {}
+    Cylindrical2Cartesian(const T& r, const T& phi, const T& z) : r_(r), phi_(phi), z_(z) {}
 
-	const T& r() const   {return r_;}
-	const T& phi() const {return phi_;}
-	const T& z() const   {return z_;}
+    const T& r() const { return r_; }
+    const T& phi() const { return phi_; }
+    const T& z() const { return z_; }
 
-	T x() const {return r_ * cos(phi_);}
-	T y() const {return r_ * sin(phi_);}
+    T x() const { return r_ * cos(phi_); }
+    T y() const { return r_ * sin(phi_); }
 
-    private:
-	T r_;
-	T phi_;
-	T z_;
-    };
+  private:
+    T r_;
+    T phi_;
+    T z_;
+  };
 
-/** Converts spherical (or polar 3D) coordinates to cartesian coordinates.
+  /** Converts spherical (or polar 3D) coordinates to cartesian coordinates.
  */
 
-    template <typename T>
-    class Spherical2Cartesian {
-    public:
-        /** Construct from polar angle, azimuthal angle, and radius.
+  template <typename T>
+  class Spherical2Cartesian {
+  public:
+    /** Construct from polar angle, azimuthal angle, and radius.
 	 *  The radius in the spherical frame is the magnitude of the vector.
 	 */
-	Spherical2Cartesian( const T& theta, const T& phi, const T& mag) :
-	    theta_(theta), phi_(phi), r_(mag), 
-	    transv_( sin(theta)*mag) {}
+    Spherical2Cartesian(const T& theta, const T& phi, const T& mag)
+        : theta_(theta), phi_(phi), r_(mag), transv_(sin(theta) * mag) {}
 
-	const T& theta() const   {return theta_;}
-	const T& phi() const     {return phi_;}
-	const T& r() const       {return r_;}
+    const T& theta() const { return theta_; }
+    const T& phi() const { return phi_; }
+    const T& r() const { return r_; }
 
-	T x() const {return transv_ * cos(phi());}
-	T y() const {return transv_ * sin(phi());}
-	T z() const {return cos(theta()) * r();}
+    T x() const { return transv_ * cos(phi()); }
+    T y() const { return transv_ * sin(phi()); }
+    T z() const { return cos(theta()) * r(); }
 
-    private:
-	T theta_;
-	T phi_;
-	T r_;
-	T transv_;
-    };
+  private:
+    T theta_;
+    T phi_;
+    T r_;
+    T transv_;
+  };
 
-
-/** Cartesian coordinate set, for uniformity with other coordinate systems
+  /** Cartesian coordinate set, for uniformity with other coordinate systems
  */
 
-    template <typename T>
-    class Cartesian2Cartesian3D {
-    public:
-	Cartesian2Cartesian3D( const T& x, const T& y, const T& z) :
-	    x_(x), y_(y), z_(z) {}
+  template <typename T>
+  class Cartesian2Cartesian3D {
+  public:
+    Cartesian2Cartesian3D(const T& x, const T& y, const T& z) : x_(x), y_(y), z_(z) {}
 
-	const T& x() const   {return x_;}
-	const T& y() const   {return y_;}
-	const T& z() const   {return z_;}
-   private:
-	T x_;
-	T y_;
-	T z_;
-    };
-}
+    const T& x() const { return x_; }
+    const T& y() const { return y_; }
+    const T& z() const { return z_; }
+
+  private:
+    T x_;
+    T y_;
+    T z_;
+  };
+}  // namespace Geom
 
 #endif

--- a/DataFormats/GeometryVector/interface/EtaInterval.h
+++ b/DataFormats/GeometryVector/interface/EtaInterval.h
@@ -4,19 +4,17 @@
 
 class EtaInterval {
 public:
-  EtaInterval(float eta1, float eta2) : z1(::sinhf(eta1)), z2(::sinhf(eta2)){}
+  EtaInterval(float eta1, float eta2) : z1(::sinhf(eta1)), z2(::sinhf(eta2)) {}
 
-  template<typename T>
-  bool inside(Basic3DVector<T> const & v) const {
+  template <typename T>
+  bool inside(Basic3DVector<T> const& v) const {
     auto z = v.z();
     auto r = v.perp();
-    return (z>z1*r) & (z<z2*r);
+    return (z > z1 * r) & (z < z2 * r);
   }
 
 private:
   float z1, z2;
-
 };
 
 #endif
-

--- a/DataFormats/GeometryVector/interface/GlobalPoint.h
+++ b/DataFormats/GeometryVector/interface/GlobalPoint.h
@@ -4,10 +4,9 @@
 #include "DataFormats/GeometryVector/interface/GlobalTag.h"
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
 
-typedef Point3DBase< float, GlobalTag>    Global3DPoint;
+typedef Point3DBase<float, GlobalTag> Global3DPoint;
 
 // Global points are three-dimensional by default
-typedef Global3DPoint                     GlobalPoint;
+typedef Global3DPoint GlobalPoint;
 
-
-#endif // GeometryVector_GlobalPoint_h
+#endif  // GeometryVector_GlobalPoint_h

--- a/DataFormats/GeometryVector/interface/GlobalTag.h
+++ b/DataFormats/GeometryVector/interface/GlobalTag.h
@@ -1,6 +1,6 @@
 #ifndef GeometryVector_GlobalTag_h
 #define GeometryVector_GlobalTag_h
 
-class GlobalTag{};
+class GlobalTag {};
 
-#endif // GeometryVector_GlobalTag_h
+#endif  // GeometryVector_GlobalTag_h

--- a/DataFormats/GeometryVector/interface/GlobalVector.h
+++ b/DataFormats/GeometryVector/interface/GlobalVector.h
@@ -4,9 +4,9 @@
 #include "DataFormats/GeometryVector/interface/GlobalTag.h"
 #include "DataFormats/GeometryVector/interface/Vector3DBase.h"
 
-typedef Vector3DBase< float, GlobalTag>    Global3DVector;
+typedef Vector3DBase<float, GlobalTag> Global3DVector;
 
 // Global Vectors are three-dimensional by default
-typedef Global3DVector                     GlobalVector;
+typedef Global3DVector GlobalVector;
 
-#endif // GeometryVector_GlobalVector_h
+#endif  // GeometryVector_GlobalVector_h

--- a/DataFormats/GeometryVector/interface/LocalPoint.h
+++ b/DataFormats/GeometryVector/interface/LocalPoint.h
@@ -5,9 +5,9 @@
 #include "DataFormats/GeometryVector/interface/Point2DBase.h"
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
 
-typedef Point2DBase< float, LocalTag>    Local2DPoint;
-typedef Point3DBase< float, LocalTag>    Local3DPoint;
+typedef Point2DBase<float, LocalTag> Local2DPoint;
+typedef Point3DBase<float, LocalTag> Local3DPoint;
 
-typedef Local3DPoint                     LocalPoint;
+typedef Local3DPoint LocalPoint;
 
-#endif // GeometryVector_LocalPoint_h
+#endif  // GeometryVector_LocalPoint_h

--- a/DataFormats/GeometryVector/interface/LocalTag.h
+++ b/DataFormats/GeometryVector/interface/LocalTag.h
@@ -1,6 +1,6 @@
 #ifndef GeometryVector_LocalTag_h
 #define GeometryVector_LocalTag_h
 
-class LocalTag{};
+class LocalTag {};
 
-#endif // GeometryVector_LocalTag_h
+#endif  // GeometryVector_LocalTag_h

--- a/DataFormats/GeometryVector/interface/LocalVector.h
+++ b/DataFormats/GeometryVector/interface/LocalVector.h
@@ -6,9 +6,9 @@
 #include "DataFormats/GeometryVector/interface/Vector3DBase.h"
 
 //typedef Vector2DBase< float, LocalTag>    Local2DVector;
-typedef Vector3DBase< float, LocalTag>    Local3DVector;
+typedef Vector3DBase<float, LocalTag> Local3DVector;
 
 // Local Vectors are three-dimensional by default
-typedef Local3DVector                     LocalVector;
+typedef Local3DVector LocalVector;
 
-#endif // GeometryVector_LocalVector_h
+#endif  // GeometryVector_LocalVector_h

--- a/DataFormats/GeometryVector/interface/MeasurementTag.h
+++ b/DataFormats/GeometryVector/interface/MeasurementTag.h
@@ -1,6 +1,6 @@
 #ifndef GeometryVector_MeasurementTag_h
 #define GeometryVector_MeasurementTag_h
 
-class MeasurementTag{};
+class MeasurementTag {};
 
-#endif // GeometryVector_MeasurementTag_h
+#endif  // GeometryVector_MeasurementTag_h

--- a/DataFormats/GeometryVector/interface/PV2DBase.h
+++ b/DataFormats/GeometryVector/interface/PV2DBase.h
@@ -9,11 +9,10 @@
 template <class T, class PVType, class FrameType>
 class PV2DBase {
 public:
-
-  typedef T                                     ScalarType;
-  typedef Basic2DVector<T>                      BasicVectorType;
-  typedef typename BasicVectorType::Polar       Polar;
-  typedef typename BasicVectorType::MathVector  MathVector;
+  typedef T ScalarType;
+  typedef Basic2DVector<T> BasicVectorType;
+  typedef typename BasicVectorType::Polar Polar;
+  typedef typename BasicVectorType::MathVector MathVector;
 
   /** default constructor uses default constructor of T to initialize the 
    *  components. For built-in floating-point types this means initialization 
@@ -22,44 +21,42 @@ public:
   PV2DBase() : theVector() {}
 
   /// construct from cartesian coordinates
-  PV2DBase( const T& x, const T& y) : theVector(x,y) {}
+  PV2DBase(const T& x, const T& y) : theVector(x, y) {}
 
   /// construct from polar coordinates
-  PV2DBase( const Polar& set) : theVector( set) {}
+  PV2DBase(const Polar& set) : theVector(set) {}
 
   /** Explicit constructor from BasicVectorType, possibly of different precision
    */
   template <class U>
-  explicit PV2DBase( const Basic2DVector<U>& v) : theVector(v) {}
+  explicit PV2DBase(const Basic2DVector<U>& v) : theVector(v) {}
 
   /** Access to the basic vector, use only when the operations on Point and Vector
    *  are too restrictive (preferably never). 
    */
-  const BasicVectorType& basicVector() const { return theVector;}
+  const BasicVectorType& basicVector() const { return theVector; }
 #ifndef __REFLEX__
-  MathVector const & mathVector() const { return theVector.v;}
-  MathVector & mathVector() { return theVector.v;}
+  MathVector const& mathVector() const { return theVector.v; }
+  MathVector& mathVector() { return theVector.v; }
 #endif
 
-  
-  T x() const { return basicVector().x();}
-  T y() const { return basicVector().y();}
-  T mag2() const { return basicVector().mag2();}
-  T r() const    { return basicVector().r();}
-  T mag() const  { return basicVector().mag();}
-  T barePhi() const  { return basicVector().barePhi();}
-  Geom::Phi<T> phi() const { return basicVector().phi();}
+  T x() const { return basicVector().x(); }
+  T y() const { return basicVector().y(); }
+  T mag2() const { return basicVector().mag2(); }
+  T r() const { return basicVector().r(); }
+  T mag() const { return basicVector().mag(); }
+  T barePhi() const { return basicVector().barePhi(); }
+  Geom::Phi<T> phi() const { return basicVector().phi(); }
 
 protected:
   // required in the implementation of inherited types...
-  BasicVectorType& basicVector() { return theVector;}
+  BasicVectorType& basicVector() { return theVector; }
 
   BasicVectorType theVector;
-
 };
 
 template <class T, class PV, class F>
-inline std::ostream & operator<<(std::ostream& s, const PV2DBase<T,PV,F>& v) {
+inline std::ostream& operator<<(std::ostream& s, const PV2DBase<T, PV, F>& v) {
   return s << " (" << v.x() << ',' << v.y() << ") ";
-} 
-#endif // GeometryVector_PV2DBase_h
+}
+#endif  // GeometryVector_PV2DBase_h

--- a/DataFormats/GeometryVector/interface/PV3DBase.h
+++ b/DataFormats/GeometryVector/interface/PV3DBase.h
@@ -14,14 +14,12 @@
 template <class T, class PVType, class FrameType>
 class PV3DBase {
 public:
-
-  typedef T                                         ScalarType;
-  typedef Basic3DVector<T>                          BasicVectorType;
-  typedef typename BasicVectorType::Cylindrical     Cylindrical;
-  typedef typename BasicVectorType::Spherical       Spherical;
-  typedef typename BasicVectorType::Polar           Polar;
-  typedef typename BasicVectorType::MathVector  MathVector;
-
+  typedef T ScalarType;
+  typedef Basic3DVector<T> BasicVectorType;
+  typedef typename BasicVectorType::Cylindrical Cylindrical;
+  typedef typename BasicVectorType::Spherical Spherical;
+  typedef typename BasicVectorType::Polar Polar;
+  typedef typename BasicVectorType::MathVector MathVector;
 
   /** default constructor uses default constructor of T to initialize the 
    *  components. For built-in floating-point types this means initialization 
@@ -30,58 +28,57 @@ public:
   PV3DBase() : theVector() {}
 
   /// construct from cartesian coordinates
-  PV3DBase(const T & x, const T & y, const T & z) : theVector(x, y, z) {}
+  PV3DBase(const T& x, const T& y, const T& z) : theVector(x, y, z) {}
 
   /** Construct from cylindrical coordinates.
    */
-  PV3DBase( const Cylindrical& set) : theVector( set) {}
+  PV3DBase(const Cylindrical& set) : theVector(set) {}
 
   /// construct from polar coordinates
-  PV3DBase( const Polar& set) : theVector( set) {}
+  PV3DBase(const Polar& set) : theVector(set) {}
 
   /** Deprecated construct from polar coordinates, use 
    *  constructor from Polar( theta, phi, r) instead. 
    */
-  PV3DBase( const Geom::Theta<T>& th, 
-	    const Geom::Phi<T>& ph, const T& r) : theVector(th,ph,r) {}
+  PV3DBase(const Geom::Theta<T>& th, const Geom::Phi<T>& ph, const T& r) : theVector(th, ph, r) {}
 
   /** Explicit constructor from BasicVectorType, possibly of different precision
    */
   template <class U>
-  explicit PV3DBase( const Basic3DVector<U>& v) : theVector(v) {}
+  explicit PV3DBase(const Basic3DVector<U>& v) : theVector(v) {}
 
   /** Access to the basic vector, use only when the operations on Point and Vector
    *  are too restrictive (preferably never). 
    */
-  const BasicVectorType& basicVector() const { return theVector;}
+  const BasicVectorType& basicVector() const { return theVector; }
 #ifndef __REFLEX__
-  MathVector const & mathVector() const { return theVector.v;}
-  MathVector & mathVector() { return theVector.v;}
-#endif  
+  MathVector const& mathVector() const { return theVector.v; }
+  MathVector& mathVector() { return theVector.v; }
+#endif
 
-  T x() const { return basicVector().x();}
-  T y() const { return basicVector().y();}
-  T z() const { return basicVector().z();}
+  T x() const { return basicVector().x(); }
+  T y() const { return basicVector().y(); }
+  T z() const { return basicVector().z(); }
 
-  T mag2() const { return basicVector().mag2();}
-  T mag() const  { return basicVector().mag();}
-  T barePhi() const  { return basicVector().barePhi();}
-  Geom::Phi<T> phi() const  { return basicVector().phi();}
+  T mag2() const { return basicVector().mag2(); }
+  T mag() const { return basicVector().mag(); }
+  T barePhi() const { return basicVector().barePhi(); }
+  Geom::Phi<T> phi() const { return basicVector().phi(); }
 
-  T perp2() const { return basicVector().perp2();}
-  T perp() const  { return basicVector().perp();}
-  T transverse() const  { return basicVector().transverse();}
-  T bareTheta() const { return basicVector().bareTheta();}
-  Geom::Theta<T> theta() const { return basicVector().theta();}
-  T eta() const   { return basicVector().eta();}
+  T perp2() const { return basicVector().perp2(); }
+  T perp() const { return basicVector().perp(); }
+  T transverse() const { return basicVector().transverse(); }
+  T bareTheta() const { return basicVector().bareTheta(); }
+  Geom::Theta<T> theta() const { return basicVector().theta(); }
+  T eta() const { return basicVector().eta(); }
 
 protected:
   BasicVectorType theVector;
 };
 
 template <class T, class PV, class F>
-inline std::ostream & operator<<( std::ostream& s, const PV3DBase<T,PV,F>& v) {
+inline std::ostream& operator<<(std::ostream& s, const PV3DBase<T, PV, F>& v) {
   return s << v.basicVector();
-} 
+}
 
-#endif // GeometryVector_PV3DBase_h
+#endif  // GeometryVector_PV3DBase_h

--- a/DataFormats/GeometryVector/interface/Phi.h
+++ b/DataFormats/GeometryVector/interface/Phi.h
@@ -7,7 +7,7 @@
 
 namespace Geom {
 
-/** \class Phi
+  /** \class Phi
  *  A class for azimuthal angle represantation and algebra.
  *  The use of Phi<T> is tranparant due to the implicit conversion to T
  *  Constructs like cos(phi) work as with float or double.
@@ -22,35 +22,34 @@ namespace Geom {
   using angle_units::operators::convertRadToDeg;
 
   struct MinusPiToPi {};  // Dummy struct to indicate -pi to pi range
-  struct ZeroTo2pi{};  // Dummy struct to indicate 0 to 2pi range
+  struct ZeroTo2pi {};    // Dummy struct to indicate 0 to 2pi range
 
   template <typename T1, typename Range>
   class NormalizeWrapper {};
 
   template <typename T1>
   class NormalizeWrapper<T1, MinusPiToPi> {
-    public:
-    static void normalize(T1 &value) { // Reduce range to -pi to pi
-      if( value > twoPi() || value < -twoPi()) {
+  public:
+    static void normalize(T1& value) {  // Reduce range to -pi to pi
+      if (value > twoPi() || value < -twoPi()) {
         value = std::fmod(value, static_cast<T1>(twoPi()));
       }
-      if (value <= -pi()) value += twoPi();
-      if (value >  pi()) value -= twoPi();
+      if (value <= -pi())
+        value += twoPi();
+      if (value > pi())
+        value -= twoPi();
     }
   };
 
   template <typename T1>
-  class NormalizeWrapper<T1, ZeroTo2pi> { // Reduce range to 0 to 2pi
+  class NormalizeWrapper<T1, ZeroTo2pi> {  // Reduce range to 0 to 2pi
   public:
-    static void normalize(T1 &value) {
-      value = angle0to2pi::make0To2pi(value);
-    }
+    static void normalize(T1& value) { value = angle0to2pi::make0To2pi(value); }
   };
 
   template <typename T1, typename Range = MinusPiToPi>
   class Phi {
   public:
-
     /// Default constructor does not initialise - just as double.
     Phi() {}
 
@@ -60,59 +59,73 @@ namespace Geom {
     // conversions, in which case explicit casts must be used.
     // The constructor provides range checking and normalization,
     // e.g. the value of Phi(2*pi()+1) is 1
-    Phi( const T1& val) : theValue(val) { normalize(theValue);}
+    Phi(const T1& val) : theValue(val) { normalize(theValue); }
 
     /// conversion operator makes transparent use possible.
-    operator T1() const { return theValue;}
+    operator T1() const { return theValue; }
 
     /// Template argument conversion
-    template <typename T2, typename Range1> operator Phi<T2, Range1>() { return Phi<T2, Range1>(theValue);}
+    template <typename T2, typename Range1>
+    operator Phi<T2, Range1>() {
+      return Phi<T2, Range1>(theValue);
+    }
 
     /// Explicit access to value in case implicit conversion not OK
-    T1 value() const { return theValue;}
+    T1 value() const { return theValue; }
 
     // so that template classes expecting phi() works! (deltaPhi)
-    T1 phi() const { return theValue;}
+    T1 phi() const { return theValue; }
 
-    /// Standard arithmetics 
-    Phi& operator+=(const T1& a) {theValue+=a; normalize(theValue); return *this;}
-    Phi& operator+=(const Phi& a) {return operator+=(a.value());}
+    /// Standard arithmetics
+    Phi& operator+=(const T1& a) {
+      theValue += a;
+      normalize(theValue);
+      return *this;
+    }
+    Phi& operator+=(const Phi& a) { return operator+=(a.value()); }
 
-    Phi& operator-=(const T1& a) {theValue-=a; normalize(theValue); return *this;}
-    Phi& operator-=(const Phi& a) {return operator-=(a.value());}
+    Phi& operator-=(const T1& a) {
+      theValue -= a;
+      normalize(theValue);
+      return *this;
+    }
+    Phi& operator-=(const Phi& a) { return operator-=(a.value()); }
 
-    Phi& operator*=(const T1& a) {theValue*=a; normalize(theValue); return *this;}
+    Phi& operator*=(const T1& a) {
+      theValue *= a;
+      normalize(theValue);
+      return *this;
+    }
 
-    Phi& operator/=(const T1& a) {theValue/=a; normalize(theValue); return *this;}
+    Phi& operator/=(const T1& a) {
+      theValue /= a;
+      normalize(theValue);
+      return *this;
+    }
 
     T1 degrees() const { return convertRadToDeg(theValue); }
-    
+
     // nearZero() tells whether the angle is close enough to 0 to be considered 0.
     // The default tolerance is 1 degree.
-    inline bool nearZero(float tolerance = 1.0_deg) const {
-      return (std::abs(theValue) - tolerance <= 0.0);
-    }
+    inline bool nearZero(float tolerance = 1.0_deg) const { return (std::abs(theValue) - tolerance <= 0.0); }
 
     // nearEqual() tells whether two angles are close enough to be considered equal.
     // The default tolerance is 0.001 radian.
-    inline bool nearEqual(const Phi<T1, Range> &angle, float tolerance = 0.001) const {
+    inline bool nearEqual(const Phi<T1, Range>& angle, float tolerance = 0.001) const {
       return (std::abs(theValue - angle) - tolerance <= 0.0);
     }
 
   private:
-
     T1 theValue;
 
-    void normalize(T1 &value) {
-      NormalizeWrapper<T1, Range>::normalize(value);
-    }
+    void normalize(T1& value) { NormalizeWrapper<T1, Range>::normalize(value); }
   };
-
 
   /// - operator
   template <typename T1, typename Range>
-  inline Phi<T1, Range> operator-(const Phi<T1, Range>& a) {return Phi<T1, Range>(-a.value());}
-
+  inline Phi<T1, Range> operator-(const Phi<T1, Range>& a) {
+    return Phi<T1, Range>(-a.value());
+  }
 
   /// Addition
   template <typename T1, typename Range>
@@ -130,23 +143,21 @@ namespace Geom {
     return Phi<T1, Range>(b) += a;
   }
 
-
   /// Subtraction
   template <typename T1, typename Range>
-  inline Phi<T1, Range> operator-(const Phi<T1, Range>& a, const Phi<T1, Range>& b) { 
+  inline Phi<T1, Range> operator-(const Phi<T1, Range>& a, const Phi<T1, Range>& b) {
     return Phi<T1, Range>(a) -= b;
   }
   /// Subtraction with scalar, does not change the precision
   template <typename T1, typename Range, typename Scalar>
-  inline Phi<T1, Range> operator-(const Phi<T1, Range>& a, const Scalar& b) { 
+  inline Phi<T1, Range> operator-(const Phi<T1, Range>& a, const Scalar& b) {
     return Phi<T1, Range>(a) -= b;
   }
   /// Subtraction with scalar, does not change the precision
   template <typename T1, typename Range, typename Scalar>
-  inline Phi<T1, Range> operator-(const Scalar& a, const Phi<T1, Range>& b) { 
+  inline Phi<T1, Range> operator-(const Scalar& a, const Phi<T1, Range>& b) {
     return Phi<T1, Range>(a - b.value());
   }
-
 
   /// Multiplication with scalar, does not change the precision
   template <typename T1, typename Range, typename Scalar>
@@ -159,10 +170,9 @@ namespace Geom {
     return Phi<T1, Range>(b) *= a;
   }
 
-
   /// Division
   template <typename T1, typename Range>
-  inline T1 operator/(const Phi<T1, Range>& a, const Phi<T1, Range>& b) { 
+  inline T1 operator/(const Phi<T1, Range>& a, const Phi<T1, Range>& b) {
     return a.value() / b.value();
   }
   /// Division by scalar
@@ -172,9 +182,9 @@ namespace Geom {
   }
 
   // For convenience
-  template<typename T>
+  template <typename T>
   using Phi0To2pi = Phi<T, ZeroTo2pi>;
-}
+}  // namespace Geom
 
 /*
 // this a full mess with the above that is a mess in itself
@@ -205,14 +215,3 @@ namespace reco {
 */
 
 #endif
-
-
-
-
-
-
-
-
-
-
-

--- a/DataFormats/GeometryVector/interface/PhiInterval.h
+++ b/DataFormats/GeometryVector/interface/PhiInterval.h
@@ -6,37 +6,34 @@
 class PhiInterval {
 public:
   PhiInterval(float phi1, float phi2) {
-    phi2 = proxim(phi2,phi1);
-    constexpr float c1 = 2.*M_PI;
-    if (phi2<phi1) phi2+=c1;
-    auto dphi = 0.5f*(phi2-phi1);
-    auto phi = phi1+dphi;
+    phi2 = proxim(phi2, phi1);
+    constexpr float c1 = 2. * M_PI;
+    if (phi2 < phi1)
+      phi2 += c1;
+    auto dphi = 0.5f * (phi2 - phi1);
+    auto phi = phi1 + dphi;
     x = std::cos(phi);
     y = std::sin(phi);
     dcos = std::cos(dphi);
   }
 
   PhiInterval(float ix, float iy, float dphi) {
-    auto norm = 1.f/std::sqrt(ix*ix+iy*iy);
-    x = ix*norm;
-    y = iy*norm;
+    auto norm = 1.f / std::sqrt(ix * ix + iy * iy);
+    x = ix * norm;
+    y = iy * norm;
     dcos = std::cos(dphi);
   }
 
-  template<typename T>
-  bool inside(Basic3DVector<T> const & v) const {
-    return inside(v.x(),v.y());
+  template <typename T>
+  bool inside(Basic3DVector<T> const& v) const {
+    return inside(v.x(), v.y());
   }
 
-  bool inside(float ix, float iy) const {
-    return ix*x+iy*y > dcos*std::sqrt(ix*ix+iy*iy);
-  }
+  bool inside(float ix, float iy) const { return ix * x + iy * y > dcos * std::sqrt(ix * ix + iy * iy); }
 
 private:
-  float x,y;
+  float x, y;
   float dcos;
-
 };
 
 #endif
-

--- a/DataFormats/GeometryVector/interface/Pi.h
+++ b/DataFormats/GeometryVector/interface/Pi.h
@@ -28,15 +28,14 @@
 
 namespace Geom {
 
-  inline constexpr double pi()     {return     3.141592653589793238;}
-  inline constexpr double twoPi()  {return 2. *3.141592653589793238;}
-  inline constexpr double halfPi() {return 0.5*3.141592653589793238;}
+  inline constexpr double pi() { return 3.141592653589793238; }
+  inline constexpr double twoPi() { return 2. * 3.141592653589793238; }
+  inline constexpr double halfPi() { return 0.5 * 3.141592653589793238; }
 
-  inline constexpr float fpi()     {return     3.141592653589793238f;}
-  inline constexpr float ftwoPi()  {return 2.f *3.141592653589793238f;}
-  inline constexpr float fhalfPi() {return 0.5f*3.141592653589793238f;}
+  inline constexpr float fpi() { return 3.141592653589793238f; }
+  inline constexpr float ftwoPi() { return 2.f * 3.141592653589793238f; }
+  inline constexpr float fhalfPi() { return 0.5f * 3.141592653589793238f; }
 
-
-}
+}  // namespace Geom
 
 #endif

--- a/DataFormats/GeometryVector/interface/Point2DBase.h
+++ b/DataFormats/GeometryVector/interface/Point2DBase.h
@@ -1,19 +1,17 @@
 #ifndef GeometryVector_Point2DBase_h
 #define GeometryVector_Point2DBase_h
 
-
 #include "DataFormats/GeometryVector/interface/PointTag.h"
 #include "DataFormats/GeometryVector/interface/PV2DBase.h"
 #include "DataFormats/GeometryVector/interface/Vector2DBase.h"
 
 template <class T, class FrameTag>
-class Point2DBase : public PV2DBase< T, PointTag, FrameTag> {
+class Point2DBase : public PV2DBase<T, PointTag, FrameTag> {
 public:
-
-  typedef PV2DBase< T, PointTag, FrameTag>    BaseClass;
-  typedef Vector2DBase< T, FrameTag>          VectorType;
-  typedef Basic2DVector<T>                    BasicVectorType;
-  typedef typename BaseClass::Polar           Polar;
+  typedef PV2DBase<T, PointTag, FrameTag> BaseClass;
+  typedef Vector2DBase<T, FrameTag> VectorType;
+  typedef Basic2DVector<T> BasicVectorType;
+  typedef typename BaseClass::Polar Polar;
 
   /** default constructor uses default constructor of T to initialize the 
    *  components. For built-in floating-point types this means initialization 
@@ -23,69 +21,68 @@ public:
 
   /** Construct from another point in the same reference frame, possiblly
    *  with different precision
-   */ 
-  template <class U> 
-  Point2DBase( const Point2DBase<U,FrameTag>& p) : BaseClass( p.basicVector()) {}
+   */
+  template <class U>
+  Point2DBase(const Point2DBase<U, FrameTag>& p) : BaseClass(p.basicVector()) {}
 
   /// construct from cartesian coordinates
   Point2DBase(const T& x, const T& y) : BaseClass(x, y) {}
 
   /// construct from polar coordinates
-  explicit Point2DBase( const Polar& set) : BaseClass( set) {}
+  explicit Point2DBase(const Polar& set) : BaseClass(set) {}
 
   /** Explicit constructor from BasicVectorType, bypasses consistency checks
    *  for point/vector and for coordinate frame. To be used as carefully as
    *  e.g. const_cast.
    */
   template <class U>
-  explicit Point2DBase( const Basic2DVector<U>& v) : BaseClass(v) {}
+  explicit Point2DBase(const Basic2DVector<U>& v) : BaseClass(v) {}
 
   /** A Point can be shifted by a Vector of possibly different precision,
    *  defined in the same coordinate frame
    */
-  template <class U> 
-  Point2DBase& operator+=( const Vector2DBase< U, FrameTag>& v) {
+  template <class U>
+  Point2DBase& operator+=(const Vector2DBase<U, FrameTag>& v) {
     this->basicVector() += v.basicVector();
     return *this;
-  } 
+  }
 
-  template <class U> 
-  Point2DBase& operator-=( const Vector2DBase< U, FrameTag>& v) {
+  template <class U>
+  Point2DBase& operator-=(const Vector2DBase<U, FrameTag>& v) {
     this->basicVector() -= v.basicVector();
     return *this;
-  } 
-
+  }
 };
 
 /** The sum of a Point and a Vector is a Point. The arguments must be defined
  *  in the same reference frame. The resulting point has the higher precision
  *  of the precisions of the two arguments.
  */
-template< typename T, typename U, class Frame>
-inline Point2DBase< typename PreciseFloatType<T,U>::Type, Frame> 
-operator+( const Point2DBase<T,Frame>& p, const Vector2DBase<U,Frame>& v) {
-  typedef Point2DBase< typename PreciseFloatType<T,U>::Type, Frame> RT;
-  return RT( p.basicVector() + v.basicVector());
+template <typename T, typename U, class Frame>
+inline Point2DBase<typename PreciseFloatType<T, U>::Type, Frame> operator+(const Point2DBase<T, Frame>& p,
+                                                                           const Vector2DBase<U, Frame>& v) {
+  typedef Point2DBase<typename PreciseFloatType<T, U>::Type, Frame> RT;
+  return RT(p.basicVector() + v.basicVector());
 }
 
 /** Same as operator+(Point,Vector) (see above)
  */
-template< typename T, typename U, class Frame>
-inline Point2DBase< typename PreciseFloatType<T,U>::Type, Frame> 
-operator+( const Vector2DBase<T,Frame>& p, const Point2DBase<U,Frame>& v) {
-  typedef Point2DBase< typename PreciseFloatType<T,U>::Type, Frame> RT;
-  return RT( p.basicVector() + v.basicVector());
+template <typename T, typename U, class Frame>
+inline Point2DBase<typename PreciseFloatType<T, U>::Type, Frame> operator+(const Vector2DBase<T, Frame>& p,
+                                                                           const Point2DBase<U, Frame>& v) {
+  typedef Point2DBase<typename PreciseFloatType<T, U>::Type, Frame> RT;
+  return RT(p.basicVector() + v.basicVector());
 }
 
 /** The difference of two points is a vector. The arguments must be defined
  *  in the same reference frame. The resulting vector has the higher precision
  *  of the precisions of the two arguments.
  */
-template< typename T, typename U, class Frame>
-inline Vector2DBase< typename PreciseFloatType<T,U>::Type, Frame>
-operator-( const Point2DBase<T,Frame>& p1, const Point2DBase<U,Frame>& p2) {
-  typedef Vector2DBase< typename PreciseFloatType<T,U>::Type, Frame> RT;
-  return RT( p1.basicVector() - p2.basicVector());
+template <typename T, typename U, class Frame>
+inline Vector2DBase<typename PreciseFloatType<T, U>::Type, Frame> operator-(const Point2DBase<T, Frame>& p1,
+                                                                            const Point2DBase<U, Frame>& p2) {
+  typedef Vector2DBase<typename PreciseFloatType<T, U>::Type, Frame> RT;
+  return RT(p1.basicVector() - p2.basicVector());
 }
 
-#endif // GeometryVector_Point2DBase_h
+#endif  // GeometryVector_Point2DBase_h

--- a/DataFormats/GeometryVector/interface/Point3DBase.h
+++ b/DataFormats/GeometryVector/interface/Point3DBase.h
@@ -1,21 +1,19 @@
 #ifndef GeometryVector_Point3DBase_h
 #define GeometryVector_Point3DBase_h
 
-
 #include "DataFormats/GeometryVector/interface/PointTag.h"
 #include "DataFormats/GeometryVector/interface/PV3DBase.h"
 #include "DataFormats/GeometryVector/interface/Point2DBase.h"
 #include "DataFormats/GeometryVector/interface/Vector3DBase.h"
 
 template <class T, class FrameTag>
-class Point3DBase : public PV3DBase< T, PointTag, FrameTag> {
+class Point3DBase : public PV3DBase<T, PointTag, FrameTag> {
 public:
-
-  typedef PV3DBase< T, PointTag, FrameTag>    BaseClass;
-  typedef Vector3DBase< T, FrameTag>          VectorType;
-  typedef typename BaseClass::Cylindrical     Cylindrical;
-  typedef typename BaseClass::Spherical       Spherical;
-  typedef typename BaseClass::Polar           Polar;
+  typedef PV3DBase<T, PointTag, FrameTag> BaseClass;
+  typedef Vector3DBase<T, FrameTag> VectorType;
+  typedef typename BaseClass::Cylindrical Cylindrical;
+  typedef typename BaseClass::Spherical Spherical;
+  typedef typename BaseClass::Polar Polar;
   typedef typename BaseClass::BasicVectorType BasicVectorType;
 
   /** default constructor uses default constructor of T to initialize the 
@@ -26,101 +24,96 @@ public:
 
   /** Construct from another point in the same reference frame, possiblly
    *  with different precision
-   */ 
-  template <class U> 
-  Point3DBase( const Point3DBase<U,FrameTag>& p) : BaseClass( p.basicVector()) {}
+   */
+  template <class U>
+  Point3DBase(const Point3DBase<U, FrameTag>& p) : BaseClass(p.basicVector()) {}
 
   /// construct from cartesian coordinates
   Point3DBase(const T& x, const T& y, const T& z) : BaseClass(x, y, z) {}
 
   /** Construct from cylindrical coordinates.
    */
-  explicit Point3DBase( const Cylindrical& set) : BaseClass( set) {}
+  explicit Point3DBase(const Cylindrical& set) : BaseClass(set) {}
 
   /// construct from polar coordinates
-  explicit Point3DBase( const Polar& set) : BaseClass( set) {}
+  explicit Point3DBase(const Polar& set) : BaseClass(set) {}
 
   /** Deprecated construct from polar coordinates, use 
    *  constructor from Polar( theta, phi, r) instead. 
    */
-  Point3DBase(const Geom::Theta<T>& th, 
-	      const Geom::Phi<T>& ph, const T& r) : BaseClass(th,ph,r) {}
+  Point3DBase(const Geom::Theta<T>& th, const Geom::Phi<T>& ph, const T& r) : BaseClass(th, ph, r) {}
 
   /** Mimick 2D point. This constructor is convenient for points on a plane,
    *  since the z component for them is zero. 
    */
-  Point3DBase( const T& x, const T& y) : BaseClass( x, y, 0) {}
-  explicit Point3DBase( Point2DBase<T,FrameTag> p) : 
-    BaseClass( p.x(), p.y(), 0) {}
+  Point3DBase(const T& x, const T& y) : BaseClass(x, y, 0) {}
+  explicit Point3DBase(Point2DBase<T, FrameTag> p) : BaseClass(p.x(), p.y(), 0) {}
 
   /** Explicit constructor from BasicVectorType, bypasses consistency checks
    *  for point/vector and for coordinate frame. To be used as carefully as
    *  e.g. const_cast.
    */
   template <class U>
-  explicit Point3DBase( const Basic3DVector<U>& v) : BaseClass(v) {}
+  explicit Point3DBase(const Basic3DVector<U>& v) : BaseClass(v) {}
 
   // equality
-  bool operator==(const Point3DBase & rh) const {
-    return this->basicVector()==rh.basicVector();
-  }
+  bool operator==(const Point3DBase& rh) const { return this->basicVector() == rh.basicVector(); }
 
   /** A Point can be shifted by a Vector of possibly different precision,
    *  defined in the same coordinate frame
    */
-  template <class U> 
-  Point3DBase& operator+=( const Vector3DBase< U, FrameTag>& v) {
+  template <class U>
+  Point3DBase& operator+=(const Vector3DBase<U, FrameTag>& v) {
     this->theVector += v.basicVector();
     return *this;
-  } 
+  }
 
-  template <class U> 
-  Point3DBase& operator-=( const Vector3DBase< U, FrameTag>& v) {
+  template <class U>
+  Point3DBase& operator-=(const Vector3DBase<U, FrameTag>& v) {
     this->theVector -= v.basicVector();
     return *this;
-  } 
-
+  }
 };
 
 /** The sum of a Point and a Vector is a Point. The arguments must be defined
  *  in the same reference frame. The resulting point has the higher precision
  *  of the precisions of the two arguments.
  */
-template< typename T, typename U, class Frame>
-inline Point3DBase< typename PreciseFloatType<T,U>::Type, Frame> 
-operator+( const Point3DBase<T,Frame>& p, const Vector3DBase<U,Frame>& v) {
-  typedef Point3DBase< typename PreciseFloatType<T,U>::Type, Frame> RT;
-  return RT( p.basicVector() + v.basicVector());
+template <typename T, typename U, class Frame>
+inline Point3DBase<typename PreciseFloatType<T, U>::Type, Frame> operator+(const Point3DBase<T, Frame>& p,
+                                                                           const Vector3DBase<U, Frame>& v) {
+  typedef Point3DBase<typename PreciseFloatType<T, U>::Type, Frame> RT;
+  return RT(p.basicVector() + v.basicVector());
 }
 
 /** Same as operator+(Point,Vector) (see above)
  */
-template< typename T, typename U, class Frame>
-inline Point3DBase< typename PreciseFloatType<T,U>::Type, Frame> 
-operator+( const Vector3DBase<T,Frame>& p, const Point3DBase<U,Frame>& v) {
-  typedef Point3DBase< typename PreciseFloatType<T,U>::Type, Frame> RT;
-  return RT( p.basicVector() + v.basicVector());
+template <typename T, typename U, class Frame>
+inline Point3DBase<typename PreciseFloatType<T, U>::Type, Frame> operator+(const Vector3DBase<T, Frame>& p,
+                                                                           const Point3DBase<U, Frame>& v) {
+  typedef Point3DBase<typename PreciseFloatType<T, U>::Type, Frame> RT;
+  return RT(p.basicVector() + v.basicVector());
 }
 
 /** The difference of two points is a vector. The arguments must be defined
  *  in the same reference frame. The resulting vector has the higher precision
  *  of the precisions of the two arguments.
  */
-template< typename T, typename U, class Frame>
-inline Vector3DBase< typename PreciseFloatType<T,U>::Type, Frame>
-operator-( const Point3DBase<T,Frame>& p1, const Point3DBase<U,Frame>& p2) {
-  typedef Vector3DBase< typename PreciseFloatType<T,U>::Type, Frame> RT;
-  return RT( p1.basicVector() - p2.basicVector());
+template <typename T, typename U, class Frame>
+inline Vector3DBase<typename PreciseFloatType<T, U>::Type, Frame> operator-(const Point3DBase<T, Frame>& p1,
+                                                                            const Point3DBase<U, Frame>& p2) {
+  typedef Vector3DBase<typename PreciseFloatType<T, U>::Type, Frame> RT;
+  return RT(p1.basicVector() - p2.basicVector());
 }
 
 /** The difference of a Point and a Vector is a Point. The arguments must be defined
  *  in the same reference frame. The resulting point has the higher precision
  *  of the precisions of the two arguments.
  */
-template< typename T, typename U, class Frame>
-inline Point3DBase< typename PreciseFloatType<T,U>::Type, Frame> 
-operator-( const Point3DBase<T,Frame>& p, const Vector3DBase<U,Frame>& v) {
-  typedef Point3DBase< typename PreciseFloatType<T,U>::Type, Frame> RT;
-  return RT( p.basicVector() - v.basicVector());
+template <typename T, typename U, class Frame>
+inline Point3DBase<typename PreciseFloatType<T, U>::Type, Frame> operator-(const Point3DBase<T, Frame>& p,
+                                                                           const Vector3DBase<U, Frame>& v) {
+  typedef Point3DBase<typename PreciseFloatType<T, U>::Type, Frame> RT;
+  return RT(p.basicVector() - v.basicVector());
 }
-#endif // GeometryVector_Point3DBase_h
+#endif  // GeometryVector_Point3DBase_h

--- a/DataFormats/GeometryVector/interface/PointTag.h
+++ b/DataFormats/GeometryVector/interface/PointTag.h
@@ -1,6 +1,6 @@
 #ifndef GeometryVector_PointTag_h
 #define GeometryVector_PointTag_h
 
-class PointTag{};
+class PointTag {};
 
-#endif // GeometryVector_PointTag_h
+#endif  // GeometryVector_PointTag_h

--- a/DataFormats/GeometryVector/interface/PreciseFloatType.h
+++ b/DataFormats/GeometryVector/interface/PreciseFloatType.h
@@ -21,32 +21,28 @@
 
 template <typename T, typename U>
 struct PreciseFloatType {
-
   typedef double Type;
-
 };
 
 /// If the two types are identical that is also the precise type
 
 template <typename T>
-struct PreciseFloatType<T,T> {
-
+struct PreciseFloatType<T, T> {
   typedef T Type;
-
 };
 
 /// long double is more precise by default than other types
 
 template <typename T>
-struct PreciseFloatType< long double, T> {
+struct PreciseFloatType<long double, T> {
   typedef long double Type;
 };
 template <typename T>
-struct PreciseFloatType< T, long double> {
+struct PreciseFloatType<T, long double> {
   typedef long double Type;
 };
 template <>
-struct PreciseFloatType< long double, long double> {
+struct PreciseFloatType<long double, long double> {
   typedef long double Type;
 };
 

--- a/DataFormats/GeometryVector/interface/Theta.h
+++ b/DataFormats/GeometryVector/interface/Theta.h
@@ -3,7 +3,7 @@
 
 namespace Geom {
 
-/** A class for polar angle represantation.
+  /** A class for polar angle represantation.
  *  So far only useful to differentiate from double, for
  * example in function overloading.
  */
@@ -11,22 +11,21 @@ namespace Geom {
   template <class T>
   class Theta {
   public:
-
     /// Default constructor does not initialise - just as double.
     Theta() {}
 
     /// Constructor from T, does not provide automatic conversion.
-    explicit Theta( const T& val) : theValue(val) {}
+    explicit Theta(const T& val) : theValue(val) {}
 
     /// conversion operator makes transparent use possible.
-    operator T() const { return theValue;}
+    operator T() const { return theValue; }
 
     /// Explicit access to value in case implicit conversion not OK
-    T value() const { return theValue;}
+    T value() const { return theValue; }
 
   private:
     T theValue;
   };
 
-}
+}  // namespace Geom
 #endif

--- a/DataFormats/GeometryVector/interface/TrackingJacobians.h
+++ b/DataFormats/GeometryVector/interface/TrackingJacobians.h
@@ -1,11 +1,10 @@
 #ifndef GeomVector_jacobians_
 #define GeomVector_jacobians_
 
-
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 
-AlgebraicMatrix65 jacobianCurvilinearToCartesian(const GlobalVector  & momentum, int charge) ;
-AlgebraicMatrix56 jacobianCartesianToCurvilinear(const GlobalVector  & momentum, int charge) ;
+AlgebraicMatrix65 jacobianCurvilinearToCartesian(const GlobalVector& momentum, int charge);
+AlgebraicMatrix56 jacobianCartesianToCurvilinear(const GlobalVector& momentum, int charge);
 
 #endif

--- a/DataFormats/GeometryVector/interface/Vector2DBase.h
+++ b/DataFormats/GeometryVector/interface/Vector2DBase.h
@@ -1,17 +1,15 @@
 #ifndef GeometryVector_Vector2DBase_h
 #define GeometryVector_Vector2DBase_h
 
-
 #include "DataFormats/GeometryVector/interface/VectorTag.h"
 #include "DataFormats/GeometryVector/interface/PV2DBase.h"
 
-template <class T, class FrameTag> 
+template <class T, class FrameTag>
 class Vector2DBase : public PV2DBase<T, VectorTag, FrameTag> {
 public:
-
-  typedef PV2DBase<T, VectorTag, FrameTag>    BaseClass;
-  typedef Basic2DVector<T>                    BasicVectorType;
-  typedef typename BaseClass::Polar           Polar;
+  typedef PV2DBase<T, VectorTag, FrameTag> BaseClass;
+  typedef Basic2DVector<T> BasicVectorType;
+  typedef typename BaseClass::Polar Polar;
 
   /** default constructor uses default constructor of T to initialize the 
    *  components. For built-in floating-point types this means initialization 
@@ -21,60 +19,60 @@ public:
 
   /** Construct from another vector in the same reference frame, possiblly
    *  with different precision
-   */ 
-  template <class U> 
-  Vector2DBase( const Vector2DBase<U,FrameTag>& p) : BaseClass( p.basicVector()) {}
+   */
+  template <class U>
+  Vector2DBase(const Vector2DBase<U, FrameTag>& p) : BaseClass(p.basicVector()) {}
 
   /// construct from cartesian coordinates
   Vector2DBase(const T& x, const T& y) : BaseClass(x, y) {}
 
   /// construct from polar coordinates
-  explicit Vector2DBase( const Polar& set) : BaseClass( set) {}
+  explicit Vector2DBase(const Polar& set) : BaseClass(set) {}
 
   /** Explicit constructor from BasicVectorType, bypasses consistency checks
    *  for point/vector and for coordinate frame. To be used as carefully as
    *  e.g. const_cast.
    */
   template <class U>
-  explicit Vector2DBase( const Basic2DVector<U>& v) : BaseClass(v) {}
+  explicit Vector2DBase(const Basic2DVector<U>& v) : BaseClass(v) {}
 
   /** Unit vector parallel to this.
    *  If mag() is zero, a zero vector is returned.
    */
-  Vector2DBase unit() const { return Vector2DBase( this->basicVector().unit());}
+  Vector2DBase unit() const { return Vector2DBase(this->basicVector().unit()); }
 
   /** Increment by another Vector of possibly different precision,
    *  defined in the same reference frame 
    */
-  template <class U> 
-  Vector2DBase& operator+=( const Vector2DBase< U, FrameTag>& v) {
+  template <class U>
+  Vector2DBase& operator+=(const Vector2DBase<U, FrameTag>& v) {
     this->basicVector() += v.basicVector();
     return *this;
-  } 
+  }
 
   /** Decrement by another Vector of possibly different precision,
    *  defined in the same reference frame 
    */
-  template <class U> 
-  Vector2DBase& operator-=( const Vector2DBase< U, FrameTag>& v) {
+  template <class U>
+  Vector2DBase& operator-=(const Vector2DBase<U, FrameTag>& v) {
     this->basicVector() -= v.basicVector();
     return *this;
-  } 
-    
+  }
+
   /// Unary minus, returns a vector with components (-x(),-y())
-  Vector2DBase operator-() const { return Vector2DBase(-this->basicVector());}
+  Vector2DBase operator-() const { return Vector2DBase(-this->basicVector()); }
 
   /// Scaling by a scalar value (multiplication)
-  Vector2DBase& operator*= ( const T& t) { 
+  Vector2DBase& operator*=(const T& t) {
     this->basicVector() *= t;
     return *this;
-  } 
+  }
 
   /// Scaling by a scalar value (division)
-  Vector2DBase& operator/= ( const T& t) { 
+  Vector2DBase& operator/=(const T& t) {
     this->basicVector() /= t;
     return *this;
-  } 
+  }
 
   /** Scalar (or dot) product with a vector of possibly different precision,
    *  defined in the same reference frame.
@@ -82,33 +80,31 @@ public:
    *  of the returned scalar is the more precise of the scalar types 
    *  of the two vectors.
    */
-  template <class U> 
-  typename PreciseFloatType<T,U>::Type 
-  dot( const Vector2DBase< U, FrameTag>& v) const { 
-    return this->basicVector().dot( v.basicVector());
+  template <class U>
+  typename PreciseFloatType<T, U>::Type dot(const Vector2DBase<U, FrameTag>& v) const {
+    return this->basicVector().dot(v.basicVector());
   }
-
 };
 
 /// vector sum and subtraction of vectors of possibly different precision
 template <class T, class U, class FrameTag>
-inline Vector2DBase<typename PreciseFloatType<T,U>::Type, FrameTag>
-operator+( const Vector2DBase<T, FrameTag>& v1, const Vector2DBase<U, FrameTag>& v2) {
-  typedef Vector2DBase<typename PreciseFloatType<T,U>::Type, FrameTag> RT;
+inline Vector2DBase<typename PreciseFloatType<T, U>::Type, FrameTag> operator+(const Vector2DBase<T, FrameTag>& v1,
+                                                                               const Vector2DBase<U, FrameTag>& v2) {
+  typedef Vector2DBase<typename PreciseFloatType<T, U>::Type, FrameTag> RT;
   return RT(v1.basicVector() + v2.basicVector());
 }
 
 template <class T, class U, class FrameTag>
-inline Vector2DBase<typename PreciseFloatType<T,U>::Type, FrameTag>
-operator-( const Vector2DBase<T, FrameTag>& v1, const Vector2DBase<U, FrameTag>& v2) {
-  typedef Vector2DBase<typename PreciseFloatType<T,U>::Type, FrameTag> RT;
+inline Vector2DBase<typename PreciseFloatType<T, U>::Type, FrameTag> operator-(const Vector2DBase<T, FrameTag>& v1,
+                                                                               const Vector2DBase<U, FrameTag>& v2) {
+  typedef Vector2DBase<typename PreciseFloatType<T, U>::Type, FrameTag> RT;
   return RT(v1.basicVector() - v2.basicVector());
 }
 
 /// scalar product of vectors of possibly different precision
 template <class T, class U, class FrameTag>
-inline typename PreciseFloatType<T,U>::Type
-operator*( const Vector2DBase<T, FrameTag>& v1, const Vector2DBase<U, FrameTag>& v2) {
+inline typename PreciseFloatType<T, U>::Type operator*(const Vector2DBase<T, FrameTag>& v1,
+                                                       const Vector2DBase<U, FrameTag>& v2) {
   return v1.basicVector() * v2.basicVector();
 }
 
@@ -116,25 +112,22 @@ operator*( const Vector2DBase<T, FrameTag>& v1, const Vector2DBase<U, FrameTag>&
  *  The return type is the same as the type of the vector argument.
  */
 template <class T, class FrameTag, class Scalar>
-inline Vector2DBase<T, FrameTag> 
-operator*( const Vector2DBase<T, FrameTag>& v, const Scalar& s) {
-  return Vector2DBase<T, FrameTag>( v.basicVector() * s);
+inline Vector2DBase<T, FrameTag> operator*(const Vector2DBase<T, FrameTag>& v, const Scalar& s) {
+  return Vector2DBase<T, FrameTag>(v.basicVector() * s);
 }
 
 /// Same as operator*( Vector, Scalar)
 template <class T, class FrameTag, class Scalar>
-inline Vector2DBase<T, FrameTag> 
-operator*( const Scalar& s, const Vector2DBase<T, FrameTag>& v) {
-  return Vector2DBase<T, FrameTag>( v.basicVector() * s);
+inline Vector2DBase<T, FrameTag> operator*(const Scalar& s, const Vector2DBase<T, FrameTag>& v) {
+  return Vector2DBase<T, FrameTag>(v.basicVector() * s);
 }
 
 /** Division by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 template <class T, class FrameTag, class Scalar>
-inline Vector2DBase<T, FrameTag> 
-operator/( const Vector2DBase<T, FrameTag>& v, const Scalar& s) {
-  return Vector2DBase<T, FrameTag>( v.basicVector() / s);
+inline Vector2DBase<T, FrameTag> operator/(const Vector2DBase<T, FrameTag>& v, const Scalar& s) {
+  return Vector2DBase<T, FrameTag>(v.basicVector() / s);
 }
 
-#endif // GeometryVector_Vector2DBase_h
+#endif  // GeometryVector_Vector2DBase_h

--- a/DataFormats/GeometryVector/interface/Vector3DBase.h
+++ b/DataFormats/GeometryVector/interface/Vector3DBase.h
@@ -1,19 +1,17 @@
 #ifndef GeometryVector_Vector3DBase_h
 #define GeometryVector_Vector3DBase_h
 
-
 #include "DataFormats/GeometryVector/interface/VectorTag.h"
 #include "DataFormats/GeometryVector/interface/PV3DBase.h"
 
-template <class T, class FrameTag> 
+template <class T, class FrameTag>
 class Vector3DBase : public PV3DBase<T, VectorTag, FrameTag> {
 public:
-
-  typedef PV3DBase<T, VectorTag, FrameTag>    BaseClass;
-  typedef Vector3DBase< T, FrameTag>          VectorType;
-  typedef typename BaseClass::Cylindrical     Cylindrical;
-  typedef typename BaseClass::Spherical       Spherical;
-  typedef typename BaseClass::Polar           Polar;
+  typedef PV3DBase<T, VectorTag, FrameTag> BaseClass;
+  typedef Vector3DBase<T, FrameTag> VectorType;
+  typedef typename BaseClass::Cylindrical Cylindrical;
+  typedef typename BaseClass::Spherical Spherical;
+  typedef typename BaseClass::Polar Polar;
   typedef typename BaseClass::BasicVectorType BasicVectorType;
 
   /** default constructor uses default constructor of T to initialize the 
@@ -24,77 +22,72 @@ public:
 
   /** Construct from another point in the same reference frame, possiblly
    *  with different precision
-   */ 
-  template <class U> 
-  Vector3DBase( const Vector3DBase<U,FrameTag>& v) : BaseClass( v.basicVector()) {}
+   */
+  template <class U>
+  Vector3DBase(const Vector3DBase<U, FrameTag>& v) : BaseClass(v.basicVector()) {}
 
   /// construct from cartesian coordinates
   Vector3DBase(const T& x, const T& y, const T& z) : BaseClass(x, y, z) {}
 
   /** Construct from cylindrical coordinates.
    */
-  explicit Vector3DBase( const Cylindrical& set) : BaseClass( set) {}
+  explicit Vector3DBase(const Cylindrical& set) : BaseClass(set) {}
 
   /// construct from polar coordinates
-  explicit Vector3DBase( const Polar& set) : BaseClass( set) {}
+  explicit Vector3DBase(const Polar& set) : BaseClass(set) {}
 
   /** Deprecated construct from polar coordinates, use 
    *  constructor from Polar( theta, phi, r) instead. 
    */
-  Vector3DBase(const Geom::Theta<T>& th, 
-	       const Geom::Phi<T>& ph, const T& r) : BaseClass(th,ph,r) {}
+  Vector3DBase(const Geom::Theta<T>& th, const Geom::Phi<T>& ph, const T& r) : BaseClass(th, ph, r) {}
 
   /** Explicit constructor from BasicVectorType, bypasses consistency checks
    *  for point/vector and for coordinate frame. To be used as carefully as
    *  e.g. const_cast.
    */
   template <class U>
-  explicit Vector3DBase( const Basic3DVector<U>& v) : BaseClass(v) {}
+  explicit Vector3DBase(const Basic3DVector<U>& v) : BaseClass(v) {}
 
   /** Unit vector parallel to this.
    *  If mag() is zero, a zero vector is returned.
    */
-  Vector3DBase unit() const { return Vector3DBase( this->basicVector().unit());}
+  Vector3DBase unit() const { return Vector3DBase(this->basicVector().unit()); }
 
   // equality
-  bool operator==(const Vector3DBase & rh) const {
-    return this->basicVector()==rh.basicVector();
-  }
-
+  bool operator==(const Vector3DBase& rh) const { return this->basicVector() == rh.basicVector(); }
 
   /** Increment by another Vector of possibly different precision,
    *  defined in the same reference frame 
    */
-  template <class U> 
-  Vector3DBase& operator+= ( const Vector3DBase< U, FrameTag>& v) {
+  template <class U>
+  Vector3DBase& operator+=(const Vector3DBase<U, FrameTag>& v) {
     this->theVector += v.basicVector();
     return *this;
-  } 
-    
+  }
+
   /** Decrement by another Vector of possibly different precision,
    *  defined in the same reference frame 
    */
-  template <class U> 
-  Vector3DBase& operator-= ( const Vector3DBase< U, FrameTag>& v) {
+  template <class U>
+  Vector3DBase& operator-=(const Vector3DBase<U, FrameTag>& v) {
     this->theVector -= v.basicVector();
     return *this;
-  } 
-    
-  /// Unary minus, returns a vector with components (-x(),-y(),-z())
-  Vector3DBase operator-() const { return Vector3DBase(-this->basicVector());}
+  }
 
+  /// Unary minus, returns a vector with components (-x(),-y(),-z())
+  Vector3DBase operator-() const { return Vector3DBase(-this->basicVector()); }
 
   /// Scaling by a scalar value (multiplication)
-  Vector3DBase& operator*= ( const T& t) { 
+  Vector3DBase& operator*=(const T& t) {
     this->theVector *= t;
     return *this;
-  } 
+  }
 
   /// Scaling by a scalar value (division)
-  Vector3DBase& operator/= ( const T& t) { 
+  Vector3DBase& operator/=(const T& t) {
     this->theVector /= t;
     return *this;
-  } 
+  }
 
   /** Scalar (or dot) product with a vector of possibly different precision,
    *  defined in the same reference frame.
@@ -102,10 +95,9 @@ public:
    *  of the returned scalar is the more precise of the scalar types 
    *  of the two vectors.
    */
-  template <class U> 
-  typename PreciseFloatType<T,U>::Type 
-  dot( const Vector3DBase< U, FrameTag>& v) const { 
-    return this->theVector.dot( v.basicVector());
+  template <class U>
+  typename PreciseFloatType<T, U>::Type dot(const Vector3DBase<U, FrameTag>& v) const {
+    return this->theVector.dot(v.basicVector());
   }
 
   /** Vector (or cross) product with a vector of possibly different precision,
@@ -114,34 +106,32 @@ public:
    *  of the returned Vector is the higher precision of the scalar types 
    *  of the two vectors.
    */
-  template <class U> 
-  Vector3DBase< typename PreciseFloatType<T,U>::Type, FrameTag> 
-  cross( const  Vector3DBase< U, FrameTag>& v) const {
-    typedef Vector3DBase< typename PreciseFloatType<T,U>::Type, FrameTag> RT;
-    return RT( this->theVector.cross( v.basicVector()));
+  template <class U>
+  Vector3DBase<typename PreciseFloatType<T, U>::Type, FrameTag> cross(const Vector3DBase<U, FrameTag>& v) const {
+    typedef Vector3DBase<typename PreciseFloatType<T, U>::Type, FrameTag> RT;
+    return RT(this->theVector.cross(v.basicVector()));
   }
-
 };
 
 /// vector sum and subtraction of vectors of possibly different precision
 template <class T, class U, class FrameTag>
-inline Vector3DBase<typename PreciseFloatType<T,U>::Type, FrameTag>
-operator+( const Vector3DBase<T, FrameTag>& v1, const Vector3DBase<U, FrameTag>& v2) {
-  typedef Vector3DBase<typename PreciseFloatType<T,U>::Type, FrameTag> RT;
+inline Vector3DBase<typename PreciseFloatType<T, U>::Type, FrameTag> operator+(const Vector3DBase<T, FrameTag>& v1,
+                                                                               const Vector3DBase<U, FrameTag>& v2) {
+  typedef Vector3DBase<typename PreciseFloatType<T, U>::Type, FrameTag> RT;
   return RT(v1.basicVector() + v2.basicVector());
 }
 
 template <class T, class U, class FrameTag>
-inline Vector3DBase<typename PreciseFloatType<T,U>::Type, FrameTag>
-operator-( const Vector3DBase<T, FrameTag>& v1, const Vector3DBase<U, FrameTag>& v2) {
-  typedef Vector3DBase<typename PreciseFloatType<T,U>::Type, FrameTag> RT;
+inline Vector3DBase<typename PreciseFloatType<T, U>::Type, FrameTag> operator-(const Vector3DBase<T, FrameTag>& v1,
+                                                                               const Vector3DBase<U, FrameTag>& v2) {
+  typedef Vector3DBase<typename PreciseFloatType<T, U>::Type, FrameTag> RT;
   return RT(v1.basicVector() - v2.basicVector());
 }
 
 /// scalar product of vectors of possibly different precision
 template <class T, class U, class FrameTag>
-inline typename PreciseFloatType<T,U>::Type
-operator*( const Vector3DBase<T, FrameTag>& v1, const Vector3DBase<U, FrameTag>& v2) {
+inline typename PreciseFloatType<T, U>::Type operator*(const Vector3DBase<T, FrameTag>& v1,
+                                                       const Vector3DBase<U, FrameTag>& v2) {
   return v1.basicVector() * v2.basicVector();
 }
 
@@ -149,25 +139,22 @@ operator*( const Vector3DBase<T, FrameTag>& v1, const Vector3DBase<U, FrameTag>&
  *  The return type is the same as the type of the vector argument.
  */
 template <class T, class FrameTag, class Scalar>
-inline Vector3DBase<T, FrameTag> 
-operator*( const Vector3DBase<T, FrameTag>& v, const Scalar& s) {
-  return Vector3DBase<T, FrameTag>( v.basicVector() * s);
+inline Vector3DBase<T, FrameTag> operator*(const Vector3DBase<T, FrameTag>& v, const Scalar& s) {
+  return Vector3DBase<T, FrameTag>(v.basicVector() * s);
 }
 
 /// Same as operator*( Vector, Scalar)
 template <class T, class FrameTag, class Scalar>
-inline Vector3DBase<T, FrameTag> 
-operator*( const Scalar& s, const Vector3DBase<T, FrameTag>& v) {
-  return Vector3DBase<T, FrameTag>( v.basicVector() * s);
+inline Vector3DBase<T, FrameTag> operator*(const Scalar& s, const Vector3DBase<T, FrameTag>& v) {
+  return Vector3DBase<T, FrameTag>(v.basicVector() * s);
 }
 
 /** Division by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 template <class T, class FrameTag, class Scalar>
-inline Vector3DBase<T, FrameTag> 
-operator/( const Vector3DBase<T, FrameTag>& v, const Scalar& s) {
-  return Vector3DBase<T, FrameTag>( v.basicVector() / s);
+inline Vector3DBase<T, FrameTag> operator/(const Vector3DBase<T, FrameTag>& v, const Scalar& s) {
+  return Vector3DBase<T, FrameTag>(v.basicVector() / s);
 }
 
-#endif // GeometryVector_Vector3DBase_h
+#endif  // GeometryVector_Vector3DBase_h

--- a/DataFormats/GeometryVector/interface/VectorTag.h
+++ b/DataFormats/GeometryVector/interface/VectorTag.h
@@ -1,6 +1,6 @@
 #ifndef GeometryVector_VectorTag_h
 #define GeometryVector_VectorTag_h
 
-class VectorTag{};
+class VectorTag {};
 
-#endif // GeometryVector_VectorTag_h
+#endif  // GeometryVector_VectorTag_h

--- a/DataFormats/GeometryVector/interface/VectorUtil.h
+++ b/DataFormats/GeometryVector/interface/VectorUtil.h
@@ -1,37 +1,27 @@
 #ifndef GeometryVector_Geom_Util_h
 #define GeometryVector_Geom_Util_h
 
-
-
 #include "DataFormats/GeometryVector/interface/Pi.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include <cmath>
 
-
 namespace Geom {
-   using reco::deltaPhi;
-   using reco::deltaR2;
-   using reco::deltaR;
-
-  
+  using reco::deltaPhi;
+  using reco::deltaR;
+  using reco::deltaR2;
 
   /** Definition of ordering of azimuthal angles.
    *  phi1 is less than phi2 if the angle covered by a point going from
    *  phi1 to phi2 in the counterclockwise direction is smaller than pi.
    *  It makes sense only if ALL phis are in a single hemisphere...
    */
-  inline bool phiLess(float phi1, float phi2) {
-    return deltaPhi(phi1,phi2)<0;
-  }
-  inline bool phiLess(double phi1, double phi2) {
-    return deltaPhi(phi1,phi2)<0;
-  }
-  template <class Vector1, class Vector2> 
-  bool phiLess(const Vector1 & v1, const Vector2 & v2) {
-    return deltaPhi(v1.phi(),v2.phi())<0.; 
+  inline bool phiLess(float phi1, float phi2) { return deltaPhi(phi1, phi2) < 0; }
+  inline bool phiLess(double phi1, double phi2) { return deltaPhi(phi1, phi2) < 0; }
+  template <class Vector1, class Vector2>
+  bool phiLess(const Vector1& v1, const Vector2& v2) {
+    return deltaPhi(v1.phi(), v2.phi()) < 0.;
   }
 
-    
-}
+}  // namespace Geom
 
 #endif

--- a/DataFormats/GeometryVector/interface/private/Basic3DVectorLD.h
+++ b/DataFormats/GeometryVector/interface/private/Basic3DVectorLD.h
@@ -2,25 +2,23 @@
 #define GeometryVector_Basic3DVectorLD_h
 
 #ifdef __clang__
-#pragma clang diagnostic push 
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
 
 #include "extBasic3DVector.h"
 // long double specialization
-template <> 
+template <>
 class Basic3DVector<long double> {
 public:
+  typedef long double T;
+  typedef T ScalarType;
+  typedef Geom::Cylindrical2Cartesian<T> Cylindrical;
+  typedef Geom::Spherical2Cartesian<T> Spherical;
+  typedef Spherical Polar;  // synonym
 
+  typedef Basic3DVector<T> MathVector;
 
-  typedef long double                         T;
-  typedef T                                   ScalarType;
-  typedef Geom::Cylindrical2Cartesian<T>      Cylindrical;
-  typedef Geom::Spherical2Cartesian<T>        Spherical;
-  typedef Spherical                           Polar; // synonym
-
-  typedef  Basic3DVector<T> MathVector;
-    
   /** default constructor uses default constructor of T to initialize the 
    *  components. For built-in floating-point types this means initialization 
    * to zero??? (force init to 0)
@@ -28,17 +26,14 @@ public:
   Basic3DVector() : theX(0), theY(0), theZ(0), theW(0) {}
 
   /// Copy constructor from same type. Should not be needed but for gcc bug 12685
-  Basic3DVector( const Basic3DVector & p) : 
-    theX(p.x()), theY(p.y()), theZ(p.z()), theW(0) {}
+  Basic3DVector(const Basic3DVector& p) : theX(p.x()), theY(p.y()), theZ(p.z()), theW(0) {}
 
   /// Copy constructor and implicit conversion from Basic3DVector of different precision
   template <class U>
-  Basic3DVector( const Basic3DVector<U> & p) : 
-    theX(p.x()), theY(p.y()), theZ(p.z()), theW(0) {}
+  Basic3DVector(const Basic3DVector<U>& p) : theX(p.x()), theY(p.y()), theZ(p.z()), theW(0) {}
 
   /// constructor from 2D vector (X and Y from 2D vector, z set to zero)
-  Basic3DVector( const Basic2DVector<T> & p) : 
-    theX(p.x()), theY(p.y()), theZ(0), theW(0) {}
+  Basic3DVector(const Basic2DVector<T>& p) : theX(p.x()), theY(p.y()), theZ(0), theW(0) {}
 
   /** Explicit constructor from other (possibly unrelated) vector classes 
    *  The only constraint on the argument type is that it has methods
@@ -48,179 +43,164 @@ public:
    *   <BR> construction from a Hep3Vector
    *   <BR> construction from a coordinate system converter 
    */
-  template <class OtherPoint> 
-  explicit Basic3DVector( const OtherPoint& p) : 
-    theX(p.x()), theY(p.y()), theZ(p.z()), theW(0) {}
-
+  template <class OtherPoint>
+  explicit Basic3DVector(const OtherPoint& p) : theX(p.x()), theY(p.y()), theZ(p.z()), theW(0) {}
 
 #ifdef USE_SSEVECT
   // constructor from Vec4
-  template<typename U>
-  Basic3DVector(mathSSE::Vec4<U> const& iv) :
-    theX(iv.arr[0]), theY(iv.arr[1]), theZ(iv.arr[2]), theW(0) {}
-#endif  
+  template <typename U>
+  Basic3DVector(mathSSE::Vec4<U> const& iv) : theX(iv.arr[0]), theY(iv.arr[1]), theZ(iv.arr[2]), theW(0) {}
+#endif
 #ifdef USE_EXTVECT
   // constructor from Vec4
-  template<typename U>
-  Basic3DVector(Vec4<U> const& iv) :
-    theX(iv[0]), theY(iv[1]), theZ(iv[2]), theW(0) {}
+  template <typename U>
+  Basic3DVector(Vec4<U> const& iv) : theX(iv[0]), theY(iv[1]), theZ(iv[2]), theW(0) {}
 #endif
 
-
   /// construct from cartesian coordinates
-  Basic3DVector( const T& x, const T& y, const T& z) : 
-    theX(x), theY(y), theZ(z), theW(0) {}
+  Basic3DVector(const T& x, const T& y, const T& z) : theX(x), theY(y), theZ(z), theW(0) {}
 
   /** Deprecated construct from polar coordinates, use 
    *  <BR> Basic3DVector<T>( Basic3DVector<T>::Polar( theta, phi, r))
    *  instead. 
    */
   template <typename U>
-  Basic3DVector( const Geom::Theta<U>& theta, 
-		 const Geom::Phi<U>& phi, const T& r) {
-    Polar p( theta.value(), phi.value(), r);
-    theX = p.x(); theY = p.y(); theZ = p.z();
+  Basic3DVector(const Geom::Theta<U>& theta, const Geom::Phi<U>& phi, const T& r) {
+    Polar p(theta.value(), phi.value(), r);
+    theX = p.x();
+    theY = p.y();
+    theZ = p.z();
   }
 
   /// Cartesian x coordinate
-  T x() const { return theX;}
+  T x() const { return theX; }
 
   /// Cartesian y coordinate
-  T y() const { return theY;}
+  T y() const { return theY; }
 
   /// Cartesian z coordinate
-  T z() const { return theZ;}
+  T z() const { return theZ; }
 
-  Basic2DVector<T> xy() const { return  Basic2DVector<T>(theX,theY);}
-
+  Basic2DVector<T> xy() const { return Basic2DVector<T>(theX, theY); }
 
   // equality
-  bool operator==(const Basic3DVector& rh) const {
-    return x()==rh.x() && y()==rh.y() && z()==rh.z();
-  }
+  bool operator==(const Basic3DVector& rh) const { return x() == rh.x() && y() == rh.y() && z() == rh.z(); }
 
   /// The vector magnitude squared. Equivalent to vec.dot(vec)
-  T mag2() const { return  x()*x() + y()*y()+z()*z();}
+  T mag2() const { return x() * x() + y() * y() + z() * z(); }
 
   /// The vector magnitude. Equivalent to sqrt(vec.mag2())
-  T mag() const  { return std::sqrt( mag2());}
+  T mag() const { return std::sqrt(mag2()); }
 
-  /// Squared magnitude of transverse component 
-  T perp2() const { return x()*x() + y()*y();}
+  /// Squared magnitude of transverse component
+  T perp2() const { return x() * x() + y() * y(); }
 
-  /// Magnitude of transverse component 
-  T perp() const { return std::sqrt( perp2());}
+  /// Magnitude of transverse component
+  T perp() const { return std::sqrt(perp2()); }
 
   /// Another name for perp()
-  T transverse() const { return perp();}
+  T transverse() const { return perp(); }
 
   /** Azimuthal angle. The value is returned in radians, in the range (-pi,pi].
    *  Same precision as the system atan2(x,y) function.
    *  The return type is Geom::Phi<T>, see it's documentation.
-   */ 
-  T barePhi() const {return std::atan2(y(),x());}
-  Geom::Phi<T> phi() const {return Geom::Phi<T>(barePhi());}
+   */
+  T barePhi() const { return std::atan2(y(), x()); }
+  Geom::Phi<T> phi() const { return Geom::Phi<T>(barePhi()); }
 
   /** Polar angle. The value is returned in radians, in the range [0,pi]
    *  Same precision as the system atan2(x,y) function.
    *  The return type is Geom::Phi<T>, see it's documentation.
-   */ 
-  T bareTheta() const {return std::atan2(perp(),z());}
-  Geom::Theta<T> theta() const {return Geom::Theta<T>(std::atan2(perp(),z()));}
+   */
+  T bareTheta() const { return std::atan2(perp(), z()); }
+  Geom::Theta<T> theta() const { return Geom::Theta<T>(std::atan2(perp(), z())); }
 
   /** Pseudorapidity. 
    *  Does not check for zero transverse component; in this case the behavior 
    *  is as for divide-by zero, i.e. system-dependent.
    */
-  // T eta() const { return -log( tan( theta()/2.));} 
-  T eta() const { return detailsBasic3DVector::eta(x(),y(),z());} // correct 
-
+  // T eta() const { return -log( tan( theta()/2.));}
+  T eta() const { return detailsBasic3DVector::eta(x(), y(), z()); }  // correct
 
   /** Unit vector parallel to this.
    *  If mag() is zero, a zero vector is returned.
    */
   Basic3DVector unit() const {
     T my_mag = mag2();
-    if (my_mag==0) return *this;
-    my_mag = T(1)/std::sqrt(my_mag);
+    if (my_mag == 0)
+      return *this;
+    my_mag = T(1) / std::sqrt(my_mag);
     Basic3DVector ret(*this);
-    return  ret*=my_mag;
+    return ret *= my_mag;
   }
 
   /** Operator += with a Basic3DVector of possibly different precision.
    */
-  template <class U> 
-  Basic3DVector& operator+= ( const Basic3DVector<U>& p) {
+  template <class U>
+  Basic3DVector& operator+=(const Basic3DVector<U>& p) {
     theX += p.x();
     theY += p.y();
     theZ += p.z();
     return *this;
-  } 
+  }
 
   /** Operator -= with a Basic3DVector of possibly different precision.
    */
-  template <class U> 
-  Basic3DVector& operator-= ( const Basic3DVector<U>& p) {
+  template <class U>
+  Basic3DVector& operator-=(const Basic3DVector<U>& p) {
     theX -= p.x();
     theY -= p.y();
     theZ -= p.z();
     return *this;
-  } 
+  }
 
   /// Unary minus, returns a vector with components (-x(),-y(),-z())
-  Basic3DVector operator-() const { return Basic3DVector(-x(),-y(),-z());}
+  Basic3DVector operator-() const { return Basic3DVector(-x(), -y(), -z()); }
 
   /// Scaling by a scalar value (multiplication)
-  Basic3DVector& operator*= ( T t) {
+  Basic3DVector& operator*=(T t) {
     theX *= t;
     theY *= t;
     theZ *= t;
     return *this;
-  } 
+  }
 
   /// Scaling by a scalar value (division)
-  Basic3DVector& operator/= ( T t) {
-    t = T(1)/t;
+  Basic3DVector& operator/=(T t) {
+    t = T(1) / t;
     theX *= t;
-    theY *= t;   
+    theY *= t;
     theZ *= t;
     return *this;
-  } 
+  }
 
   /// Scalar product, or "dot" product, with a vector of same type.
-  T dot( const Basic3DVector& v) const { 
-    return x()*v.x() + y()*v.y() + z()*v.z();
-  }
+  T dot(const Basic3DVector& v) const { return x() * v.x() + y() * v.y() + z() * v.z(); }
 
   /** Scalar (or dot) product with a vector of different precision.
    *  The product is computed without loss of precision. The type
    *  of the returned scalar is the more precise of the scalar types 
    *  of the two vectors.
    */
-  template <class U> 
-  typename PreciseFloatType<T,U>::Type dot( const Basic3DVector<U>& v) const { 
-    return x()*v.x() + y()*v.y() + z()*v.z();
+  template <class U>
+  typename PreciseFloatType<T, U>::Type dot(const Basic3DVector<U>& v) const {
+    return x() * v.x() + y() * v.y() + z() * v.z();
   }
 
   /// Vector product, or "cross" product, with a vector of same type.
-  Basic3DVector cross( const Basic3DVector& v) const {
-    return Basic3DVector( y()*v.z() - v.y()*z(), 
-			  z()*v.x() - v.z()*x(), 
-			  x()*v.y() - v.x()*y());
+  Basic3DVector cross(const Basic3DVector& v) const {
+    return Basic3DVector(y() * v.z() - v.y() * z(), z() * v.x() - v.z() * x(), x() * v.y() - v.x() * y());
   }
-
 
   /** Vector (or cross) product with a vector of different precision.
    *  The product is computed without loss of precision. The type
    *  of the returned vector is the more precise of the types 
    *  of the two vectors.   
    */
-  template <class U> 
-  Basic3DVector<typename PreciseFloatType<T,U>::Type> 
-  cross( const Basic3DVector<U>& v) const {
-    return Basic3DVector<typename PreciseFloatType<T,U>::Type>( y()*v.z() - v.y()*z(), 
-								z()*v.x() - v.z()*x(), 
-								x()*v.y() - v.x()*y());
+  template <class U>
+  Basic3DVector<typename PreciseFloatType<T, U>::Type> cross(const Basic3DVector<U>& v) const {
+    return Basic3DVector<typename PreciseFloatType<T, U>::Type>(
+        y() * v.z() - v.y() * z(), z() * v.x() - v.z() * x(), x() * v.y() - v.x() * y());
   }
 
 private:
@@ -228,110 +208,101 @@ private:
   T theY;
   T theZ;
   T theW;
-}  
+}
 #ifndef __CINT__
-__attribute__ ((aligned (16)))
+__attribute__((aligned(16)))
 #endif
 ;
 
-
 /// vector sum and subtraction of vectors of possibly different precision
-inline Basic3DVector<long double>
-operator+( const Basic3DVector<long double>& a, const Basic3DVector<long double>& b) {
+inline Basic3DVector<long double> operator+(const Basic3DVector<long double>& a, const Basic3DVector<long double>& b) {
   typedef Basic3DVector<long double> RT;
-  return RT(a.x()+b.x(), a.y()+b.y(), a.z()+b.z());
+  return RT(a.x() + b.x(), a.y() + b.y(), a.z() + b.z());
 }
-inline Basic3DVector<long double>
-operator-( const Basic3DVector<long double>& a, const Basic3DVector<long double>& b) {
+inline Basic3DVector<long double> operator-(const Basic3DVector<long double>& a, const Basic3DVector<long double>& b) {
   typedef Basic3DVector<long double> RT;
-  return RT(a.x()-b.x(), a.y()-b.y(), a.z()-b.z());
-}
-
-
-
-template <class U>
-inline Basic3DVector<typename PreciseFloatType<long double,U>::Type>
-operator+( const Basic3DVector<long double>& a, const Basic3DVector<U>& b) {
-  typedef Basic3DVector<typename PreciseFloatType<long double,U>::Type> RT;
-  return RT(a.x()+b.x(), a.y()+b.y(), a.z()+b.z());
+  return RT(a.x() - b.x(), a.y() - b.y(), a.z() - b.z());
 }
 
 template <class U>
-inline Basic3DVector<typename PreciseFloatType<long double,U>::Type>
-operator+(const Basic3DVector<U>& a, const Basic3DVector<long double>& b) {
-  typedef Basic3DVector<typename PreciseFloatType<long double,U>::Type> RT;
-  return RT(a.x()+b.x(), a.y()+b.y(), a.z()+b.z());
-}
-
-
-template <class U>
-inline Basic3DVector<typename PreciseFloatType<long double,U>::Type>
-operator-( const Basic3DVector<long double>& a, const Basic3DVector<U>& b) {
-  typedef Basic3DVector<typename PreciseFloatType<long double,U>::Type> RT;
-  return RT(a.x()-b.x(), a.y()-b.y(), a.z()-b.z());
+inline Basic3DVector<typename PreciseFloatType<long double, U>::Type> operator+(const Basic3DVector<long double>& a,
+                                                                                const Basic3DVector<U>& b) {
+  typedef Basic3DVector<typename PreciseFloatType<long double, U>::Type> RT;
+  return RT(a.x() + b.x(), a.y() + b.y(), a.z() + b.z());
 }
 
 template <class U>
-inline Basic3DVector<typename PreciseFloatType<long double,U>::Type>
-operator-(const Basic3DVector<U>& a,  const Basic3DVector<long double>& b) {
-  typedef Basic3DVector<typename PreciseFloatType<long double,U>::Type> RT;
-  return RT(a.x()-b.x(), a.y()-b.y(), a.z()-b.z());
+inline Basic3DVector<typename PreciseFloatType<long double, U>::Type> operator+(const Basic3DVector<U>& a,
+                                                                                const Basic3DVector<long double>& b) {
+  typedef Basic3DVector<typename PreciseFloatType<long double, U>::Type> RT;
+  return RT(a.x() + b.x(), a.y() + b.y(), a.z() + b.z());
+}
+
+template <class U>
+inline Basic3DVector<typename PreciseFloatType<long double, U>::Type> operator-(const Basic3DVector<long double>& a,
+                                                                                const Basic3DVector<U>& b) {
+  typedef Basic3DVector<typename PreciseFloatType<long double, U>::Type> RT;
+  return RT(a.x() - b.x(), a.y() - b.y(), a.z() - b.z());
+}
+
+template <class U>
+inline Basic3DVector<typename PreciseFloatType<long double, U>::Type> operator-(const Basic3DVector<U>& a,
+                                                                                const Basic3DVector<long double>& b) {
+  typedef Basic3DVector<typename PreciseFloatType<long double, U>::Type> RT;
+  return RT(a.x() - b.x(), a.y() - b.y(), a.z() - b.z());
 }
 
 /// scalar product of vectors of same precision
 // template <>
-inline long double operator*( const Basic3DVector<long double>& v1, const Basic3DVector<long double>& v2) {
+inline long double operator*(const Basic3DVector<long double>& v1, const Basic3DVector<long double>& v2) {
   return v1.dot(v2);
 }
 
 /// scalar product of vectors of different precision
 template <class U>
-inline typename PreciseFloatType<long double,U>::Type operator*( const Basic3DVector<long double>& v1, 
-						       const Basic3DVector<U>& v2) {
-  return v1.x()*v2.x() + v1.y()*v2.y() + v1.z()*v2.z();
+inline typename PreciseFloatType<long double, U>::Type operator*(const Basic3DVector<long double>& v1,
+                                                                 const Basic3DVector<U>& v2) {
+  return v1.x() * v2.x() + v1.y() * v2.y() + v1.z() * v2.z();
 }
 
 template <class U>
-inline typename PreciseFloatType<long double,U>::Type operator*(const Basic3DVector<U>& v1,
-								const Basic3DVector<long double>& v2 ) {
-  return v1.x()*v2.x() + v1.y()*v2.y() + v1.z()*v2.z();
+inline typename PreciseFloatType<long double, U>::Type operator*(const Basic3DVector<U>& v1,
+                                                                 const Basic3DVector<long double>& v2) {
+  return v1.x() * v2.x() + v1.y() * v2.y() + v1.z() * v2.z();
 }
-
 
 /** Multiplication by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 //template <>
-inline Basic3DVector<long double> operator*( const Basic3DVector<long double>& v, long double t) {
-  return Basic3DVector<long double>(v.x()*t, v.y()*t, v.z()*t);
+inline Basic3DVector<long double> operator*(const Basic3DVector<long double>& v, long double t) {
+  return Basic3DVector<long double>(v.x() * t, v.y() * t, v.z() * t);
 }
 
 /// Same as operator*( Vector, Scalar)
 // template <>
 inline Basic3DVector<long double> operator*(long double t, const Basic3DVector<long double>& v) {
-  return Basic3DVector<long double>(v.x()*t, v.y()*t, v.z()*t);
+  return Basic3DVector<long double>(v.x() * t, v.y() * t, v.z() * t);
 }
 
 template <typename S>
-inline Basic3DVector<long double> operator*(S t,  const Basic3DVector<long double>& v) {
-  return static_cast<long double>(t)*v;
+inline Basic3DVector<long double> operator*(S t, const Basic3DVector<long double>& v) {
+  return static_cast<long double>(t) * v;
 }
 
 template <typename S>
 inline Basic3DVector<long double> operator*(const Basic3DVector<long double>& v, S t) {
-  return static_cast<long double>(t)*v;
+  return static_cast<long double>(t) * v;
 }
-
 
 /** Division by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 template <typename S>
-inline Basic3DVector<long double> operator/( const Basic3DVector<long double>& v, S s) {
-  long double t = 1/s;
-  return v*t;
+inline Basic3DVector<long double> operator/(const Basic3DVector<long double>& v, S s) {
+  long double t = 1 / s;
+  return v * t;
 }
-
 
 typedef Basic3DVector<long double> Basic3DVectorLD;
 
@@ -339,7 +310,4 @@ typedef Basic3DVector<long double> Basic3DVectorLD;
 #pragma clang diagnostic pop
 #endif
 
-#endif // GeometryVector_Basic3DVectorLD_h
-
-
-
+#endif  // GeometryVector_Basic3DVectorLD_h

--- a/DataFormats/GeometryVector/interface/private/extBasic3DVector.h
+++ b/DataFormats/GeometryVector/interface/private/extBasic3DVector.h
@@ -11,47 +11,47 @@
 #include <cmath>
 
 namespace detailsBasic3DVector {
-  inline float __attribute__((always_inline)) __attribute__ ((pure))
-  eta(float x, float y, float z) { float t(z/std::sqrt(x*x+y*y)); return ::asinhf(t);} 
-  inline double __attribute__((always_inline)) __attribute__ ((pure))
-  eta(double x, double y, double z) { double t(z/std::sqrt(x*x+y*y)); return ::asinh(t);} 
-  inline long double __attribute__((always_inline)) __attribute__ ((pure))
-  eta(long double x, long double y, long double z) { long double t(z/std::sqrt(x*x+y*y)); return ::asinhl(t);} 
-}
+  inline float __attribute__((always_inline)) __attribute__((pure)) eta(float x, float y, float z) {
+    float t(z / std::sqrt(x * x + y * y));
+    return ::asinhf(t);
+  }
+  inline double __attribute__((always_inline)) __attribute__((pure)) eta(double x, double y, double z) {
+    double t(z / std::sqrt(x * x + y * y));
+    return ::asinh(t);
+  }
+  inline long double __attribute__((always_inline)) __attribute__((pure))
+  eta(long double x, long double y, long double z) {
+    long double t(z / std::sqrt(x * x + y * y));
+    return ::asinhl(t);
+  }
+}  // namespace detailsBasic3DVector
 
-
-template < typename T> 
+template <typename T>
 class Basic3DVector {
 public:
+  typedef T ScalarType;
+  typedef Vec4<T> VectorType;
+  typedef Vec4<T> MathVector;
+  typedef Geom::Cylindrical2Cartesian<T> Cylindrical;
+  typedef Geom::Spherical2Cartesian<T> Spherical;
+  typedef Spherical Polar;  // synonym
 
-  typedef T                                   ScalarType;
-  typedef Vec4<T>                             VectorType;
-  typedef Vec4<T>                             MathVector;
-  typedef Geom::Cylindrical2Cartesian<T>      Cylindrical;
-  typedef Geom::Spherical2Cartesian<T>        Spherical;
-  typedef Spherical                           Polar; // synonym
-    
   /** default constructor uses default constructor of T to initialize the 
    *  components. For built-in floating-point types this means initialization 
    * to zero??? (force init to 0)
    */
-  Basic3DVector() : v{0,0,0,0} {}
+  Basic3DVector() : v{0, 0, 0, 0} {}
 
   /// Copy constructor from same type. Should not be needed but for gcc bug 12685
-  Basic3DVector( const Basic3DVector & p) : 
-    v(p.v) {}
+  Basic3DVector(const Basic3DVector& p) : v(p.v) {}
 
   /// Copy constructor and implicit conversion from Basic3DVector of different precision
   template <class U>
-  Basic3DVector( const Basic3DVector<U> & p) : 
-    v{T(p.v[0]),T(p.v[1]),T(p.v[2]),T(p.v[3])} {}
-
+  Basic3DVector(const Basic3DVector<U>& p) : v{T(p.v[0]), T(p.v[1]), T(p.v[2]), T(p.v[3])} {}
 
   /// constructor from 2D vector (X and Y from 2D vector, z set to zero)
-  Basic3DVector( const Basic2DVector<T> & p) : 
-    v{p.x(),p.y(),0} {}
+  Basic3DVector(const Basic2DVector<T>& p) : v{p.x(), p.y(), 0} {}
 
- 
   /** Explicit constructor from other (possibly unrelated) vector classes 
    *  The only constraint on the argument type is that it has methods
    *  x(), y() and z(), and that these methods return a type convertible to T.
@@ -60,275 +60,252 @@ public:
    *   <BR> construction from a Hep3Vector
    *   <BR> construction from a coordinate system converter 
    */
-  template <class OtherPoint> 
-  explicit Basic3DVector( const OtherPoint& p) : 
-        v{T(p.x()),T(p.y()),T(p.z())} {}
-
+  template <class OtherPoint>
+  explicit Basic3DVector(const OtherPoint& p) : v{T(p.x()), T(p.y()), T(p.z())} {}
 
   // constructor from Vec4
-  Basic3DVector(MathVector const& iv) :
-  v(iv) {}
+  Basic3DVector(MathVector const& iv) : v(iv) {}
 
-  template<class U>
-  Basic3DVector(Vec4<U> const& iv) : 
-  v{T(iv[0]),T(iv[1]),T(iv[2]),T(iv[3])} {}
+  template <class U>
+  Basic3DVector(Vec4<U> const& iv) : v{T(iv[0]), T(iv[1]), T(iv[2]), T(iv[3])} {}
 
   /// construct from cartesian coordinates
-  Basic3DVector( const T& x, const T& y, const T& z, const T&w=0) : 
-    v{x,y,z,w}{}
+  Basic3DVector(const T& x, const T& y, const T& z, const T& w = 0) : v{x, y, z, w} {}
 
   /** Deprecated construct from polar coordinates, use 
    *  <BR> Basic3DVector<T>( Basic3DVector<T>::Polar( theta, phi, r))
    *  instead. 
    */
   template <typename U>
-  Basic3DVector( const Geom::Theta<U>& theta, 
-		 const Geom::Phi<U>& phi, const T& r) {
-    Polar p( theta.value(), phi.value(), r);
-    v[0] = p.x(); v[1] = p.y(); v[2] = p.z();
+  Basic3DVector(const Geom::Theta<U>& theta, const Geom::Phi<U>& phi, const T& r) {
+    Polar p(theta.value(), phi.value(), r);
+    v[0] = p.x();
+    v[1] = p.y();
+    v[2] = p.z();
   }
 
-  MathVector const & mathVector() const { return v;}
-  MathVector & mathVector() { return v;}
+  MathVector const& mathVector() const { return v; }
+  MathVector& mathVector() { return v; }
 
-  T operator[](int i) const { return v[i];}
-  T & operator[](int i) { return v[i];}
-
+  T operator[](int i) const { return v[i]; }
+  T& operator[](int i) { return v[i]; }
 
   /// Cartesian x coordinate
-  T x() const { return v[0];}
+  T x() const { return v[0]; }
 
   /// Cartesian y coordinate
-  T y() const { return v[1];}
+  T y() const { return v[1]; }
 
   /// Cartesian z coordinate
-  T z() const { return v[2];}
+  T z() const { return v[2]; }
 
-  T w() const { return v[3];}
+  T w() const { return v[3]; }
 
-  Basic2DVector<T> xy() const { return ::xy(v);}
+  Basic2DVector<T> xy() const { return ::xy(v); }
 
   // equality
   bool operator==(const Basic3DVector& rh) const {
-    auto res = v==rh.v;
-    return res[0]&res[1]&res[2]&res[3];
+    auto res = v == rh.v;
+    return res[0] & res[1] & res[2] & res[3];
   }
 
   /// The vector magnitude squared. Equivalent to vec.dot(vec)
-  T mag2() const { return  ::dot(v,v);}
+  T mag2() const { return ::dot(v, v); }
 
   /// The vector magnitude. Equivalent to sqrt(vec.mag2())
-  T mag() const  { return std::sqrt( mag2());}
+  T mag() const { return std::sqrt(mag2()); }
 
-  /// Squared magnitude of transverse component 
-  T perp2() const { return ::dot2(v,v);}
+  /// Squared magnitude of transverse component
+  T perp2() const { return ::dot2(v, v); }
 
-  /// Magnitude of transverse component 
-  T perp() const { return std::sqrt( perp2());}
+  /// Magnitude of transverse component
+  T perp() const { return std::sqrt(perp2()); }
 
   /// Another name for perp()
-  T transverse() const { return perp();}
+  T transverse() const { return perp(); }
 
   /** Azimuthal angle. The value is returned in radians, in the range (-pi,pi].
    *  Same precision as the system atan2(x,y) function.
    *  The return type is Geom::Phi<T>, see it's documentation.
-   */ 
-  T barePhi() const {return std::atan2(y(),x());}
-  Geom::Phi<T> phi() const {return Geom::Phi<T>(barePhi());}
+   */
+  T barePhi() const { return std::atan2(y(), x()); }
+  Geom::Phi<T> phi() const { return Geom::Phi<T>(barePhi()); }
 
   /** Polar angle. The value is returned in radians, in the range [0,pi]
    *  Same precision as the system atan2(x,y) function.
    *  The return type is Geom::Phi<T>, see it's documentation.
-   */ 
-  T bareTheta() const {return std::atan2(perp(),z());}
-  Geom::Theta<T> theta() const {return Geom::Theta<T>(std::atan2(perp(),z()));}
+   */
+  T bareTheta() const { return std::atan2(perp(), z()); }
+  Geom::Theta<T> theta() const { return Geom::Theta<T>(std::atan2(perp(), z())); }
 
   /** Pseudorapidity. 
    *  Does not check for zero transverse component; in this case the behavior 
    *  is as for divide-by zero, i.e. system-dependent.
    */
-  // T eta() const { return -log( tan( theta()/2.));} 
-  T eta() const { return detailsBasic3DVector::eta(x(),y(),z());} // correct 
+  // T eta() const { return -log( tan( theta()/2.));}
+  T eta() const { return detailsBasic3DVector::eta(x(), y(), z()); }  // correct
 
   /** Unit vector parallel to this.
    *  If mag() is zero, a zero vector is returned.
    */
   Basic3DVector unit() const {
     T my_mag = mag2();
-    return (0!=my_mag) ? (*this)*(T(1)/std::sqrt(my_mag)) : *this;
+    return (0 != my_mag) ? (*this) * (T(1) / std::sqrt(my_mag)) : *this;
   }
 
   /** Operator += with a Basic3DVector of possibly different precision.
    */
-  template <class U> 
-  Basic3DVector& operator+= ( const Basic3DVector<U>& p) {
+  template <class U>
+  Basic3DVector& operator+=(const Basic3DVector<U>& p) {
     v = v + p.v;
     return *this;
-  } 
+  }
 
   /** Operator -= with a Basic3DVector of possibly different precision.
    */
-  template <class U> 
-  Basic3DVector& operator-= ( const Basic3DVector<U>& p) {
+  template <class U>
+  Basic3DVector& operator-=(const Basic3DVector<U>& p) {
     v = v - p.v;
     return *this;
-  } 
+  }
 
   /// Unary minus, returns a vector with components (-x(),-y(),-z())
-  Basic3DVector operator-() const { return Basic3DVector(-v);}
+  Basic3DVector operator-() const { return Basic3DVector(-v); }
 
   /// Scaling by a scalar value (multiplication)
-  Basic3DVector& operator*= ( T t) {
-    v = t*v;
+  Basic3DVector& operator*=(T t) {
+    v = t * v;
     return *this;
-  } 
+  }
 
   /// Scaling by a scalar value (division)
-  Basic3DVector& operator/= ( T t) {
+  Basic3DVector& operator/=(T t) {
     //t = T(1)/t;
-    v = v/t;
+    v = v / t;
     return *this;
-  } 
+  }
 
   /// Scalar product, or "dot" product, with a vector of same type.
-  T dot( const Basic3DVector& rh) const { 
-    return ::dot(v,rh.v);
-  }
+  T dot(const Basic3DVector& rh) const { return ::dot(v, rh.v); }
 
   /** Scalar (or dot) product with a vector of different precision.
    *  The product is computed without loss of precision. The type
    *  of the returned scalar is the more precise of the scalar types 
    *  of the two vectors.
    */
-  template <class U> 
-  typename PreciseFloatType<T,U>::Type dot( const Basic3DVector<U>& lh) const { 
-    return Basic3DVector<typename PreciseFloatType<T,U>::Type>(*this)
-      .dot(Basic3DVector<typename PreciseFloatType<T,U>::Type>(lh));
+  template <class U>
+  typename PreciseFloatType<T, U>::Type dot(const Basic3DVector<U>& lh) const {
+    return Basic3DVector<typename PreciseFloatType<T, U>::Type>(*this).dot(
+        Basic3DVector<typename PreciseFloatType<T, U>::Type>(lh));
   }
 
   /// Vector product, or "cross" product, with a vector of same type.
-  Basic3DVector cross( const Basic3DVector& lh) const {
-    return ::cross3(v,lh.v);
-  }
-
+  Basic3DVector cross(const Basic3DVector& lh) const { return ::cross3(v, lh.v); }
 
   /** Vector (or cross) product with a vector of different precision.
    *  The product is computed without loss of precision. The type
    *  of the returned vector is the more precise of the types 
    *  of the two vectors.   
    */
-  template <class U> 
-  Basic3DVector<typename PreciseFloatType<T,U>::Type> 
-  cross( const Basic3DVector<U>& lh) const {
-    return Basic3DVector<typename PreciseFloatType<T,U>::Type>(*this)
-      .cross(Basic3DVector<typename PreciseFloatType<T,U>::Type>(lh));
+  template <class U>
+  Basic3DVector<typename PreciseFloatType<T, U>::Type> cross(const Basic3DVector<U>& lh) const {
+    return Basic3DVector<typename PreciseFloatType<T, U>::Type>(*this).cross(
+        Basic3DVector<typename PreciseFloatType<T, U>::Type>(lh));
   }
 
 public:
   Vec4<T> v;
-}  __attribute__ ((aligned (16)));
-
+} __attribute__((aligned(16)));
 
 namespace geometryDetails {
-  std::ostream & print3D(std::ostream& s, double x, double y, double z);
+  std::ostream& print3D(std::ostream& s, double x, double y, double z);
 }
 
 /// simple text output to standard streams
 template <class T>
-inline std::ostream & operator<<( std::ostream& s, const Basic3DVector<T>& v) {
-  return geometryDetails::print3D(s, v.x(),v.y(), v.z());
+inline std::ostream& operator<<(std::ostream& s, const Basic3DVector<T>& v) {
+  return geometryDetails::print3D(s, v.x(), v.y(), v.z());
 }
-
 
 /// vector sum and subtraction of vectors of possibly different precision
 template <class T>
-inline Basic3DVector<T>
-operator+( const Basic3DVector<T>& a, const Basic3DVector<T>& b) {
-  return a.v+b.v;
+inline Basic3DVector<T> operator+(const Basic3DVector<T>& a, const Basic3DVector<T>& b) {
+  return a.v + b.v;
 }
 template <class T>
-inline Basic3DVector<T>
-operator-( const Basic3DVector<T>& a, const Basic3DVector<T>& b) {
-  return a.v-b.v;
+inline Basic3DVector<T> operator-(const Basic3DVector<T>& a, const Basic3DVector<T>& b) {
+  return a.v - b.v;
 }
 
 template <class T, class U>
-inline Basic3DVector<typename PreciseFloatType<T,U>::Type>
-operator+( const Basic3DVector<T>& a, const Basic3DVector<U>& b) {
-  typedef Basic3DVector<typename PreciseFloatType<T,U>::Type> RT;
-  return RT(a).v+RT(b).v;
+inline Basic3DVector<typename PreciseFloatType<T, U>::Type> operator+(const Basic3DVector<T>& a,
+                                                                      const Basic3DVector<U>& b) {
+  typedef Basic3DVector<typename PreciseFloatType<T, U>::Type> RT;
+  return RT(a).v + RT(b).v;
 }
 
 template <class T, class U>
-inline Basic3DVector<typename PreciseFloatType<T,U>::Type>
-operator-( const Basic3DVector<T>& a, const Basic3DVector<U>& b) {
-  typedef Basic3DVector<typename PreciseFloatType<T,U>::Type> RT;
-  return RT(a).v-RT(b).v;
+inline Basic3DVector<typename PreciseFloatType<T, U>::Type> operator-(const Basic3DVector<T>& a,
+                                                                      const Basic3DVector<U>& b) {
+  typedef Basic3DVector<typename PreciseFloatType<T, U>::Type> RT;
+  return RT(a).v - RT(b).v;
 }
 
 /// scalar product of vectors of same precision
 template <class T>
-inline T operator*( const Basic3DVector<T>& v1, const Basic3DVector<T>& v2) {
+inline T operator*(const Basic3DVector<T>& v1, const Basic3DVector<T>& v2) {
   return v1.dot(v2);
 }
 
 /// scalar product of vectors of different precision
 template <class T, class U>
-inline typename PreciseFloatType<T,U>::Type operator*( const Basic3DVector<T>& v1, 
-						       const Basic3DVector<U>& v2) {
-  return  v1.dot(v2);
+inline typename PreciseFloatType<T, U>::Type operator*(const Basic3DVector<T>& v1, const Basic3DVector<U>& v2) {
+  return v1.dot(v2);
 }
 
 /** Multiplication by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 template <class T>
-inline Basic3DVector<T> operator*( const Basic3DVector<T>& v, T t) {
-  return v.v*t;
+inline Basic3DVector<T> operator*(const Basic3DVector<T>& v, T t) {
+  return v.v * t;
 }
 
 /// Same as operator*( Vector, Scalar)
 template <class T>
 inline Basic3DVector<T> operator*(T t, const Basic3DVector<T>& v) {
-  return v.v*t;
+  return v.v * t;
 }
 
-
-
 template <class T, typename S>
-inline Basic3DVector<T> operator*(S t,  const Basic3DVector<T>& v) {
-  return static_cast<T>(t)*v;
+inline Basic3DVector<T> operator*(S t, const Basic3DVector<T>& v) {
+  return static_cast<T>(t) * v;
 }
 
 template <class T, typename S>
 inline Basic3DVector<T> operator*(const Basic3DVector<T>& v, S t) {
-  return static_cast<T>(t)*v;
+  return static_cast<T>(t) * v;
 }
-
 
 /** Division by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 template <class T>
 inline Basic3DVector<T> operator/(const Basic3DVector<T>& v, T t) {
-  return v.v/t;
+  return v.v / t;
 }
 
 template <class T, typename S>
-inline Basic3DVector<T> operator/( const Basic3DVector<T>& v, S s) {
+inline Basic3DVector<T> operator/(const Basic3DVector<T>& v, S s) {
   //  T t = S(1)/s; return v*t;
   T t = s;
-  return v/t;
+  return v / t;
 }
-
 
 typedef Basic3DVector<float> Basic3DVectorF;
 typedef Basic3DVector<double> Basic3DVectorD;
 
-
 //  add long double specialization
 #include "Basic3DVectorLD.h"
 
-#endif // GeometryVector_Basic3DVector_h
-
-
+#endif  // GeometryVector_Basic3DVector_h

--- a/DataFormats/GeometryVector/interface/private/sseBasic2DVector.h
+++ b/DataFormats/GeometryVector/interface/private/sseBasic2DVector.h
@@ -6,19 +6,16 @@
 #include "DataFormats/GeometryVector/interface/CoordinateSets.h"
 #include "DataFormats/Math/interface/SSEVec.h"
 
-
 #include <cmath>
 #include <iosfwd>
 
-
-template < class T> 
+template <class T>
 class Basic2DVector {
 public:
-
-  typedef T    ScalarType;
+  typedef T ScalarType;
   typedef mathSSE::Vec2<T> VectorType;
   typedef mathSSE::Vec2<T> MathVector;
-  typedef Geom::Polar2Cartesian<T>        Polar;
+  typedef Geom::Polar2Cartesian<T> Polar;
 
   /** default constructor uses default constructor of T to initialize the 
    *  components. For built-in floating-point types this means initialization 
@@ -27,11 +24,10 @@ public:
   Basic2DVector() {}
 
   /// Copy constructor from same type. Should not be needed but for gcc bug 12685
-  Basic2DVector( const Basic2DVector & p) : v(p.v) {}
+  Basic2DVector(const Basic2DVector& p) : v(p.v) {}
 
-  template<typename U>
-  Basic2DVector( const Basic2DVector<U> & p) : v(p.v) {}
-
+  template <typename U>
+  Basic2DVector(const Basic2DVector<U>& p) : v(p.v) {}
 
   /** Explicit constructor from other (possibly unrelated) vector classes 
    *  The only constraint on the argument type is that it has methods
@@ -40,45 +36,45 @@ public:
    *   <BR> construction from a Basic2DVector with different precision
    *   <BR> construction from a coordinate system converter 
    */
-  template <class Other> 
-  explicit Basic2DVector( const Other& p) : v(p.x(),p.y()) {}
+  template <class Other>
+  explicit Basic2DVector(const Other& p) : v(p.x(), p.y()) {}
 
   /// construct from cartesian coordinates
-  Basic2DVector( const T& x, const T& y) : v(x,y) {}
+  Basic2DVector(const T& x, const T& y) : v(x, y) {}
 
   // constructor from Vec2 or vec4
-  template<typename U>
-  Basic2DVector(mathSSE::Vec2<U> const& iv) : v(iv){}
-  template<typename U>
-  Basic2DVector(mathSSE::Vec4<U> const& iv) : v(iv.xy()){}
+  template <typename U>
+  Basic2DVector(mathSSE::Vec2<U> const& iv) : v(iv) {}
+  template <typename U>
+  Basic2DVector(mathSSE::Vec4<U> const& iv) : v(iv.xy()) {}
 
-  MathVector const & mathVector() const { return v;}
-  MathVector & mathVector() { return v;}
+  MathVector const& mathVector() const { return v; }
+  MathVector& mathVector() { return v; }
 
-  T operator[](int i) const { return v[i];}
-  T & operator[](int i) { return v[i];}
+  T operator[](int i) const { return v[i]; }
+  T& operator[](int i) { return v[i]; }
 
   /// Cartesian x coordinate
-  T x() const { return v[0];}
+  T x() const { return v[0]; }
 
   /// Cartesian y coordinate
-  T y() const { return v[1];}
+  T y() const { return v[1]; }
 
   /// The vector magnitude squared. Equivalent to vec.dot(vec)
-  T mag2() const { return ::dot(v,v);}
+  T mag2() const { return ::dot(v, v); }
 
   /// The vector magnitude. Equivalent to sqrt(vec.mag2())
-  T mag() const  { return std::sqrt( mag2());}
+  T mag() const { return std::sqrt(mag2()); }
 
   /// Radius, same as mag()
-  T r() const    { return mag();}
+  T r() const { return mag(); }
 
   /** Azimuthal angle. The value is returned in radians, in the range (-pi,pi].
    *  Same precision as the system atan2(x,y) function.
    *  The return type is Geom::Phi<T>, see it's documentation.
-   */ 
-  T barePhi() const {return std::atan2(y(),x());}
-  Geom::Phi<T> phi() const {return Geom::Phi<T>(atan2(y(),x()));}
+   */
+  T barePhi() const { return std::atan2(y(), x()); }
+  Geom::Phi<T> phi() const { return Geom::Phi<T>(atan2(y(), x())); }
 
   /** Unit vector parallel to this.
    *  If mag() is zero, a zero vector is returned.
@@ -90,154 +86,140 @@ public:
 
   /** Operator += with a Basic2DVector of possibly different precision.
    */
-  template <class U> 
-  Basic2DVector& operator+= ( const Basic2DVector<U>& p) {
+  template <class U>
+  Basic2DVector& operator+=(const Basic2DVector<U>& p) {
     v = v + p.v;
     return *this;
-  } 
+  }
 
   /** Operator -= with a Basic2DVector of possibly different precision.
    */
-  template <class U> 
-  Basic2DVector& operator-= ( const Basic2DVector<U>& p) {
+  template <class U>
+  Basic2DVector& operator-=(const Basic2DVector<U>& p) {
     v = v - p.v;
     return *this;
-  } 
+  }
 
   /// Unary minus, returns a vector with components (-x(),-y(),-z())
-  Basic2DVector operator-() const { return Basic2DVector(-v);}
+  Basic2DVector operator-() const { return Basic2DVector(-v); }
 
   /// Scaling by a scalar value (multiplication)
-  Basic2DVector& operator*= ( T t) {
-    v = v*t;
+  Basic2DVector& operator*=(T t) {
+    v = v * t;
     return *this;
-  } 
+  }
 
   /// Scaling by a scalar value (division)
-  Basic2DVector& operator/= ( T t) {
-    t = T(1)/t;
-    v = v*t;
+  Basic2DVector& operator/=(T t) {
+    t = T(1) / t;
+    v = v * t;
     return *this;
-  } 
+  }
 
   /// Scalar product, or "dot" product, with a vector of same type.
-  T dot( const Basic2DVector& lh) const { return ::dot(v,lh.v);}
+  T dot(const Basic2DVector& lh) const { return ::dot(v, lh.v); }
 
   /** Scalar (or dot) product with a vector of different precision.
    *  The product is computed without loss of precision. The type
    *  of the returned scalar is the more precise of the scalar types 
    *  of the two vectors.
    */
-  template <class U> 
-  typename PreciseFloatType<T,U>::Type dot( const Basic2DVector<U>& lh) const { 
-    return Basic2DVector<typename PreciseFloatType<T,U>::Type>(*this)
-      .dot(Basic2DVector<typename PreciseFloatType<T,U>::Type>(lh));
+  template <class U>
+  typename PreciseFloatType<T, U>::Type dot(const Basic2DVector<U>& lh) const {
+    return Basic2DVector<typename PreciseFloatType<T, U>::Type>(*this).dot(
+        Basic2DVector<typename PreciseFloatType<T, U>::Type>(lh));
   }
 
   /// Vector product, or "cross" product, with a vector of same type.
-  T cross( const Basic2DVector& lh) const { return ::cross(v,lh.v);}
+  T cross(const Basic2DVector& lh) const { return ::cross(v, lh.v); }
 
   /** Vector (or cross) product with a vector of different precision.
    *  The product is computed without loss of precision. The type
    *  of the returned scalar is the more precise of the scalar types 
    *  of the two vectors.
    */
-  template <class U> 
-  typename PreciseFloatType<T,U>::Type cross( const Basic2DVector<U>& lh) const { 
-    return Basic2DVector<typename PreciseFloatType<T,U>::Type>(*this)
-      .cross(Basic2DVector<typename PreciseFloatType<T,U>::Type>(lh));
+  template <class U>
+  typename PreciseFloatType<T, U>::Type cross(const Basic2DVector<U>& lh) const {
+    return Basic2DVector<typename PreciseFloatType<T, U>::Type>(*this).cross(
+        Basic2DVector<typename PreciseFloatType<T, U>::Type>(lh));
   }
 
-
 public:
-
   mathSSE::Vec2<T> v;
-
 };
 
-
 namespace geometryDetails {
-  std::ostream & print2D(std::ostream& s, double x, double y);
+  std::ostream& print2D(std::ostream& s, double x, double y);
 
 }
 
 /// simple text output to standard streams
 template <class T>
-inline std::ostream & operator<<( std::ostream& s, const Basic2DVector<T>& v) {
-  return geometryDetails::print2D(s, v.x(),v.y());
+inline std::ostream& operator<<(std::ostream& s, const Basic2DVector<T>& v) {
+  return geometryDetails::print2D(s, v.x(), v.y());
 }
-
 
 /// vector sum and subtraction of vectors of possibly different precision
 template <class T>
-inline Basic2DVector<T>
-operator+( const Basic2DVector<T>& a, const Basic2DVector<T>& b) {
-  return a.v+b.v;
+inline Basic2DVector<T> operator+(const Basic2DVector<T>& a, const Basic2DVector<T>& b) {
+  return a.v + b.v;
 }
 template <class T>
-inline Basic2DVector<T>
-operator-( const Basic2DVector<T>& a, const Basic2DVector<T>& b) {
-  return a.v-b.v;
+inline Basic2DVector<T> operator-(const Basic2DVector<T>& a, const Basic2DVector<T>& b) {
+  return a.v - b.v;
 }
 
 template <class T, class U>
-inline Basic2DVector<typename PreciseFloatType<T,U>::Type>
-operator+( const Basic2DVector<T>& a, const Basic2DVector<U>& b) {
-  typedef Basic2DVector<typename PreciseFloatType<T,U>::Type> RT;
+inline Basic2DVector<typename PreciseFloatType<T, U>::Type> operator+(const Basic2DVector<T>& a,
+                                                                      const Basic2DVector<U>& b) {
+  typedef Basic2DVector<typename PreciseFloatType<T, U>::Type> RT;
   return RT(a) + RT(b);
 }
 
 template <class T, class U>
-inline Basic2DVector<typename PreciseFloatType<T,U>::Type>
-operator-( const Basic2DVector<T>& a, const Basic2DVector<U>& b) {
-  typedef Basic2DVector<typename PreciseFloatType<T,U>::Type> RT;
-  return RT(a)-RT(b);
+inline Basic2DVector<typename PreciseFloatType<T, U>::Type> operator-(const Basic2DVector<T>& a,
+                                                                      const Basic2DVector<U>& b) {
+  typedef Basic2DVector<typename PreciseFloatType<T, U>::Type> RT;
+  return RT(a) - RT(b);
 }
-
-
-
 
 // scalar product of vectors of same precision
 template <class T>
-inline T operator*( const Basic2DVector<T>& v1, const Basic2DVector<T>& v2) {
+inline T operator*(const Basic2DVector<T>& v1, const Basic2DVector<T>& v2) {
   return v1.dot(v2);
 }
 
 /// scalar product of vectors of different precision
 template <class T, class U>
-inline typename PreciseFloatType<T,U>::Type operator*( const Basic2DVector<T>& v1, 
-						       const Basic2DVector<U>& v2) {
+inline typename PreciseFloatType<T, U>::Type operator*(const Basic2DVector<T>& v1, const Basic2DVector<U>& v2) {
   return v1.dot(v2);
 }
-
 
 /** Multiplication by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 template <class T>
-inline Basic2DVector<T> operator*( const Basic2DVector<T>& v, T t) {
-  return v.v*t;
+inline Basic2DVector<T> operator*(const Basic2DVector<T>& v, T t) {
+  return v.v * t;
 }
 
 /// Same as operator*( Vector, Scalar)
 template <class T>
 inline Basic2DVector<T> operator*(T t, const Basic2DVector<T>& v) {
-  return v.v*t;
+  return v.v * t;
 }
 
-
-
 template <class T, class Scalar>
-inline Basic2DVector<T> operator*( const Basic2DVector<T>& v, const Scalar& s) {
+inline Basic2DVector<T> operator*(const Basic2DVector<T>& v, const Scalar& s) {
   T t = static_cast<T>(s);
-  return v*t;
+  return v * t;
 }
 
 /// Same as operator*( Vector, Scalar)
 template <class T, class Scalar>
-inline Basic2DVector<T> operator*( const Scalar& s, const Basic2DVector<T>& v) {
+inline Basic2DVector<T> operator*(const Scalar& s, const Basic2DVector<T>& v) {
   T t = static_cast<T>(s);
-  return v*t;
+  return v * t;
 }
 
 /** Division by scalar, does not change the precision of the vector.
@@ -245,18 +227,17 @@ inline Basic2DVector<T> operator*( const Scalar& s, const Basic2DVector<T>& v) {
  */
 template <class T>
 inline Basic2DVector<T> operator/(const Basic2DVector<T>& v, T t) {
-  return v.v/t;
+  return v.v / t;
 }
 
 template <class T, class Scalar>
-inline Basic2DVector<T> operator/( const Basic2DVector<T>& v, const Scalar& s) {
+inline Basic2DVector<T> operator/(const Basic2DVector<T>& v, const Scalar& s) {
   //   T t = static_cast<T>(Scalar(1)/s); return v*t;
-   T t = static_cast<T>(s);
-  return v/t;
+  T t = static_cast<T>(s);
+  return v / t;
 }
 
 typedef Basic2DVector<float> Basic2DVectorF;
 typedef Basic2DVector<double> Basic2DVectorD;
 
-
-#endif // GeometryVector_Basic2DVector_h
+#endif  // GeometryVector_Basic2DVector_h

--- a/DataFormats/GeometryVector/interface/private/sseBasic3DVector.h
+++ b/DataFormats/GeometryVector/interface/private/sseBasic3DVector.h
@@ -11,26 +11,31 @@
 #include <cmath>
 
 namespace detailsBasic3DVector {
-  inline float __attribute__((always_inline)) __attribute__ ((pure))
-  eta(float x, float y, float z) { float t(z/std::sqrt(x*x+y*y)); return ::asinhf(t);} 
-  inline double __attribute__((always_inline)) __attribute__ ((pure))
-  eta(double x, double y, double z) { double t(z/std::sqrt(x*x+y*y)); return ::asinh(t);} 
-  inline long double __attribute__((always_inline)) __attribute__ ((pure))
-  eta(long double x, long double y, long double z) { long double t(z/std::sqrt(x*x+y*y)); return ::asinhl(t);} 
-}
+  inline float __attribute__((always_inline)) __attribute__((pure)) eta(float x, float y, float z) {
+    float t(z / std::sqrt(x * x + y * y));
+    return ::asinhf(t);
+  }
+  inline double __attribute__((always_inline)) __attribute__((pure)) eta(double x, double y, double z) {
+    double t(z / std::sqrt(x * x + y * y));
+    return ::asinh(t);
+  }
+  inline long double __attribute__((always_inline)) __attribute__((pure))
+  eta(long double x, long double y, long double z) {
+    long double t(z / std::sqrt(x * x + y * y));
+    return ::asinhl(t);
+  }
+}  // namespace detailsBasic3DVector
 
-
-template < typename T> 
+template <typename T>
 class Basic3DVector {
 public:
+  typedef T ScalarType;
+  typedef mathSSE::Vec4<T> VectorType;
+  typedef mathSSE::Vec4<T> MathVector;
+  typedef Geom::Cylindrical2Cartesian<T> Cylindrical;
+  typedef Geom::Spherical2Cartesian<T> Spherical;
+  typedef Spherical Polar;  // synonym
 
-  typedef T                                   ScalarType;
-  typedef mathSSE::Vec4<T>                    VectorType;
-  typedef mathSSE::Vec4<T>                    MathVector;
-  typedef Geom::Cylindrical2Cartesian<T>      Cylindrical;
-  typedef Geom::Spherical2Cartesian<T>        Spherical;
-  typedef Spherical                           Polar; // synonym
-    
   /** default constructor uses default constructor of T to initialize the 
    *  components. For built-in floating-point types this means initialization 
    * to zero??? (force init to 0)
@@ -38,20 +43,15 @@ public:
   Basic3DVector() {}
 
   /// Copy constructor from same type. Should not be needed but for gcc bug 12685
-  Basic3DVector( const Basic3DVector & p) : 
-    v(p.v) {}
+  Basic3DVector(const Basic3DVector& p) : v(p.v) {}
 
   /// Copy constructor and implicit conversion from Basic3DVector of different precision
   template <class U>
-  Basic3DVector( const Basic3DVector<U> & p) : 
-    v(p.v) {}
-
+  Basic3DVector(const Basic3DVector<U>& p) : v(p.v) {}
 
   /// constructor from 2D vector (X and Y from 2D vector, z set to zero)
-  Basic3DVector( const Basic2DVector<T> & p) : 
-    v(p.x(),p.y(),0) {}
+  Basic3DVector(const Basic2DVector<T>& p) : v(p.x(), p.y(), 0) {}
 
- 
   /** Explicit constructor from other (possibly unrelated) vector classes 
    *  The only constraint on the argument type is that it has methods
    *  x(), y() and z(), and that these methods return a type convertible to T.
@@ -60,269 +60,247 @@ public:
    *   <BR> construction from a Hep3Vector
    *   <BR> construction from a coordinate system converter 
    */
-  template <class OtherPoint> 
-  explicit Basic3DVector( const OtherPoint& p) : 
-        v(p.x(),p.y(),p.z()) {}
-
+  template <class OtherPoint>
+  explicit Basic3DVector(const OtherPoint& p) : v(p.x(), p.y(), p.z()) {}
 
   // constructor from Vec4
-  template<class U>
-  Basic3DVector(mathSSE::Vec4<U> const& iv) : v(iv){}
+  template <class U>
+  Basic3DVector(mathSSE::Vec4<U> const& iv) : v(iv) {}
 
   /// construct from cartesian coordinates
-  Basic3DVector( const T& x, const T& y, const T& z, const T&w=0) : 
-    v(x,y,z,w){}
+  Basic3DVector(const T& x, const T& y, const T& z, const T& w = 0) : v(x, y, z, w) {}
 
   /** Deprecated construct from polar coordinates, use 
    *  <BR> Basic3DVector<T>( Basic3DVector<T>::Polar( theta, phi, r))
    *  instead. 
    */
   template <typename U>
-  Basic3DVector( const Geom::Theta<U>& theta, 
-		 const Geom::Phi<U>& phi, const T& r) {
-    Polar p( theta.value(), phi.value(), r);
-    v.o.theX = p.x(); v.o.theY = p.y(); v.o.theZ = p.z();
+  Basic3DVector(const Geom::Theta<U>& theta, const Geom::Phi<U>& phi, const T& r) {
+    Polar p(theta.value(), phi.value(), r);
+    v.o.theX = p.x();
+    v.o.theY = p.y();
+    v.o.theZ = p.z();
   }
 
-  MathVector const & mathVector() const { return v;}
-  MathVector & mathVector() { return v;}
+  MathVector const& mathVector() const { return v; }
+  MathVector& mathVector() { return v; }
 
-  T operator[](int i) const { return v[i];}
-  T & operator[](int i) { return v[i];}
+  T operator[](int i) const { return v[i]; }
+  T& operator[](int i) { return v[i]; }
 
   /// Cartesian x coordinate
-  T x() const { return v.o.theX;}
+  T x() const { return v.o.theX; }
 
   /// Cartesian y coordinate
-  T y() const { return v.o.theY;}
+  T y() const { return v.o.theY; }
 
   /// Cartesian z coordinate
-  T z() const { return v.o.theZ;}
+  T z() const { return v.o.theZ; }
 
-  T w() const { return v.o.theW;}
+  T w() const { return v.o.theW; }
 
-  Basic2DVector<T> xy() const { return v.xy();}
+  Basic2DVector<T> xy() const { return v.xy(); }
 
   // equality
-  bool operator==(const Basic3DVector& rh) const {
-    return v==rh.v;
-  }
+  bool operator==(const Basic3DVector& rh) const { return v == rh.v; }
 
   /// The vector magnitude squared. Equivalent to vec.dot(vec)
-  T mag2() const { return  ::dot(v,v);}
+  T mag2() const { return ::dot(v, v); }
 
   /// The vector magnitude. Equivalent to sqrt(vec.mag2())
-  T mag() const  { return std::sqrt( mag2());}
+  T mag() const { return std::sqrt(mag2()); }
 
-  /// Squared magnitude of transverse component 
-  T perp2() const { return ::dotxy(v,v);}
+  /// Squared magnitude of transverse component
+  T perp2() const { return ::dotxy(v, v); }
 
-  /// Magnitude of transverse component 
-  T perp() const { return std::sqrt( perp2());}
+  /// Magnitude of transverse component
+  T perp() const { return std::sqrt(perp2()); }
 
   /// Another name for perp()
-  T transverse() const { return perp();}
+  T transverse() const { return perp(); }
 
   /** Azimuthal angle. The value is returned in radians, in the range (-pi,pi].
    *  Same precision as the system atan2(x,y) function.
    *  The return type is Geom::Phi<T>, see it's documentation.
-   */ 
-  T barePhi() const {return std::atan2(y(),x());}
-  Geom::Phi<T> phi() const {return Geom::Phi<T>(barePhi());}
+   */
+  T barePhi() const { return std::atan2(y(), x()); }
+  Geom::Phi<T> phi() const { return Geom::Phi<T>(barePhi()); }
 
   /** Polar angle. The value is returned in radians, in the range [0,pi]
    *  Same precision as the system atan2(x,y) function.
    *  The return type is Geom::Phi<T>, see it's documentation.
-   */ 
-  T bareTheta() const {return std::atan2(perp(),z());}
-  Geom::Theta<T> theta() const {return Geom::Theta<T>(std::atan2(perp(),z()));}
+   */
+  T bareTheta() const { return std::atan2(perp(), z()); }
+  Geom::Theta<T> theta() const { return Geom::Theta<T>(std::atan2(perp(), z())); }
 
   /** Pseudorapidity. 
    *  Does not check for zero transverse component; in this case the behavior 
    *  is as for divide-by zero, i.e. system-dependent.
    */
-  // T eta() const { return -log( tan( theta()/2.));} 
-  T eta() const { return detailsBasic3DVector::eta(x(),y(),z());} // correct 
+  // T eta() const { return -log( tan( theta()/2.));}
+  T eta() const { return detailsBasic3DVector::eta(x(), y(), z()); }  // correct
 
   /** Unit vector parallel to this.
    *  If mag() is zero, a zero vector is returned.
    */
   Basic3DVector unit() const {
     T my_mag = mag2();
-    return (0!=my_mag) ? (*this)*(T(1)/std::sqrt(my_mag)) : *this;
+    return (0 != my_mag) ? (*this) * (T(1) / std::sqrt(my_mag)) : *this;
   }
 
   /** Operator += with a Basic3DVector of possibly different precision.
    */
-  template <class U> 
-  Basic3DVector& operator+= ( const Basic3DVector<U>& p) {
+  template <class U>
+  Basic3DVector& operator+=(const Basic3DVector<U>& p) {
     v = v + p.v;
     return *this;
-  } 
+  }
 
   /** Operator -= with a Basic3DVector of possibly different precision.
    */
-  template <class U> 
-  Basic3DVector& operator-= ( const Basic3DVector<U>& p) {
+  template <class U>
+  Basic3DVector& operator-=(const Basic3DVector<U>& p) {
     v = v - p.v;
     return *this;
-  } 
+  }
 
   /// Unary minus, returns a vector with components (-x(),-y(),-z())
-  Basic3DVector operator-() const { return Basic3DVector(-v);}
+  Basic3DVector operator-() const { return Basic3DVector(-v); }
 
   /// Scaling by a scalar value (multiplication)
-  Basic3DVector& operator*= ( T t) {
-    v = t*v;
+  Basic3DVector& operator*=(T t) {
+    v = t * v;
     return *this;
-  } 
+  }
 
   /// Scaling by a scalar value (division)
-  Basic3DVector& operator/= ( T t) {
+  Basic3DVector& operator/=(T t) {
     //t = T(1)/t;
-    v = v/t;
+    v = v / t;
     return *this;
-  } 
+  }
 
   /// Scalar product, or "dot" product, with a vector of same type.
-  T dot( const Basic3DVector& rh) const { 
-    return ::dot(v,rh.v);
-  }
+  T dot(const Basic3DVector& rh) const { return ::dot(v, rh.v); }
 
   /** Scalar (or dot) product with a vector of different precision.
    *  The product is computed without loss of precision. The type
    *  of the returned scalar is the more precise of the scalar types 
    *  of the two vectors.
    */
-  template <class U> 
-  typename PreciseFloatType<T,U>::Type dot( const Basic3DVector<U>& lh) const { 
-    return Basic3DVector<typename PreciseFloatType<T,U>::Type>(*this)
-      .dot(Basic3DVector<typename PreciseFloatType<T,U>::Type>(lh));
+  template <class U>
+  typename PreciseFloatType<T, U>::Type dot(const Basic3DVector<U>& lh) const {
+    return Basic3DVector<typename PreciseFloatType<T, U>::Type>(*this).dot(
+        Basic3DVector<typename PreciseFloatType<T, U>::Type>(lh));
   }
 
   /// Vector product, or "cross" product, with a vector of same type.
-  Basic3DVector cross( const Basic3DVector& lh) const {
-    return ::cross(v,lh.v);
-  }
-
+  Basic3DVector cross(const Basic3DVector& lh) const { return ::cross(v, lh.v); }
 
   /** Vector (or cross) product with a vector of different precision.
    *  The product is computed without loss of precision. The type
    *  of the returned vector is the more precise of the types 
    *  of the two vectors.   
    */
-  template <class U> 
-  Basic3DVector<typename PreciseFloatType<T,U>::Type> 
-  cross( const Basic3DVector<U>& lh) const {
-    return Basic3DVector<typename PreciseFloatType<T,U>::Type>(*this)
-      .cross(Basic3DVector<typename PreciseFloatType<T,U>::Type>(lh));
+  template <class U>
+  Basic3DVector<typename PreciseFloatType<T, U>::Type> cross(const Basic3DVector<U>& lh) const {
+    return Basic3DVector<typename PreciseFloatType<T, U>::Type>(*this).cross(
+        Basic3DVector<typename PreciseFloatType<T, U>::Type>(lh));
   }
 
 public:
   mathSSE::Vec4<T> v;
-}  __attribute__ ((aligned (16)));
-
+} __attribute__((aligned(16)));
 
 namespace geometryDetails {
-  std::ostream & print3D(std::ostream& s, double x, double y, double z);
+  std::ostream& print3D(std::ostream& s, double x, double y, double z);
 }
 
 /// simple text output to standard streams
 template <class T>
-inline std::ostream & operator<<( std::ostream& s, const Basic3DVector<T>& v) {
-  return geometryDetails::print3D(s, v.x(),v.y(), v.z());
+inline std::ostream& operator<<(std::ostream& s, const Basic3DVector<T>& v) {
+  return geometryDetails::print3D(s, v.x(), v.y(), v.z());
 }
-
 
 /// vector sum and subtraction of vectors of possibly different precision
 template <class T>
-inline Basic3DVector<T>
-operator+( const Basic3DVector<T>& a, const Basic3DVector<T>& b) {
-  return a.v+b.v;
+inline Basic3DVector<T> operator+(const Basic3DVector<T>& a, const Basic3DVector<T>& b) {
+  return a.v + b.v;
 }
 template <class T>
-inline Basic3DVector<T>
-operator-( const Basic3DVector<T>& a, const Basic3DVector<T>& b) {
-  return a.v-b.v;
+inline Basic3DVector<T> operator-(const Basic3DVector<T>& a, const Basic3DVector<T>& b) {
+  return a.v - b.v;
 }
 
 template <class T, class U>
-inline Basic3DVector<typename PreciseFloatType<T,U>::Type>
-operator+( const Basic3DVector<T>& a, const Basic3DVector<U>& b) {
-  typedef Basic3DVector<typename PreciseFloatType<T,U>::Type> RT;
-  return RT(a).v+RT(b).v;
+inline Basic3DVector<typename PreciseFloatType<T, U>::Type> operator+(const Basic3DVector<T>& a,
+                                                                      const Basic3DVector<U>& b) {
+  typedef Basic3DVector<typename PreciseFloatType<T, U>::Type> RT;
+  return RT(a).v + RT(b).v;
 }
 
 template <class T, class U>
-inline Basic3DVector<typename PreciseFloatType<T,U>::Type>
-operator-( const Basic3DVector<T>& a, const Basic3DVector<U>& b) {
-  typedef Basic3DVector<typename PreciseFloatType<T,U>::Type> RT;
-  return RT(a).v-RT(b).v;
+inline Basic3DVector<typename PreciseFloatType<T, U>::Type> operator-(const Basic3DVector<T>& a,
+                                                                      const Basic3DVector<U>& b) {
+  typedef Basic3DVector<typename PreciseFloatType<T, U>::Type> RT;
+  return RT(a).v - RT(b).v;
 }
 
 /// scalar product of vectors of same precision
 template <class T>
-inline T operator*( const Basic3DVector<T>& v1, const Basic3DVector<T>& v2) {
+inline T operator*(const Basic3DVector<T>& v1, const Basic3DVector<T>& v2) {
   return v1.dot(v2);
 }
 
 /// scalar product of vectors of different precision
 template <class T, class U>
-inline typename PreciseFloatType<T,U>::Type operator*( const Basic3DVector<T>& v1, 
-						       const Basic3DVector<U>& v2) {
-  return  v1.dot(v2);
+inline typename PreciseFloatType<T, U>::Type operator*(const Basic3DVector<T>& v1, const Basic3DVector<U>& v2) {
+  return v1.dot(v2);
 }
 
 /** Multiplication by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 template <class T>
-inline Basic3DVector<T> operator*( const Basic3DVector<T>& v, T t) {
-  return v.v*t;
+inline Basic3DVector<T> operator*(const Basic3DVector<T>& v, T t) {
+  return v.v * t;
 }
 
 /// Same as operator*( Vector, Scalar)
 template <class T>
 inline Basic3DVector<T> operator*(T t, const Basic3DVector<T>& v) {
-  return v.v*t;
+  return v.v * t;
 }
 
-
-
 template <class T, typename S>
-inline Basic3DVector<T> operator*(S t,  const Basic3DVector<T>& v) {
-  return static_cast<T>(t)*v;
+inline Basic3DVector<T> operator*(S t, const Basic3DVector<T>& v) {
+  return static_cast<T>(t) * v;
 }
 
 template <class T, typename S>
 inline Basic3DVector<T> operator*(const Basic3DVector<T>& v, S t) {
-  return static_cast<T>(t)*v;
+  return static_cast<T>(t) * v;
 }
-
 
 /** Division by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 template <class T>
 inline Basic3DVector<T> operator/(const Basic3DVector<T>& v, T t) {
-  return v.v/t;
+  return v.v / t;
 }
 
 template <class T, typename S>
-inline Basic3DVector<T> operator/( const Basic3DVector<T>& v, S s) {
+inline Basic3DVector<T> operator/(const Basic3DVector<T>& v, S s) {
   //  T t = S(1)/s; return v*t;
   T t = s;
-  return v/t;
+  return v / t;
 }
-
 
 typedef Basic3DVector<float> Basic3DVectorF;
 typedef Basic3DVector<double> Basic3DVectorD;
 
-
 //  add long double specialization
 #include "Basic3DVectorLD.h"
 
-#endif // GeometryVector_Basic3DVector_h
-
-
+#endif  // GeometryVector_Basic3DVector_h

--- a/DataFormats/GeometryVector/src/TrackingJacobians.cc
+++ b/DataFormats/GeometryVector/src/TrackingJacobians.cc
@@ -2,92 +2,111 @@
 
 // Code moved from TrackingTools/AnalyticalJacobians
 
-
-AlgebraicMatrix65 jacobianCurvilinearToCartesian(const GlobalVector & momentum, int q) {
+AlgebraicMatrix65 jacobianCurvilinearToCartesian(const GlobalVector& momentum, int q) {
   AlgebraicMatrix65 theJacobian;
-  GlobalVector xt=momentum;
-  GlobalVector yt(-xt.y(), xt.x(), 0.); 
+  GlobalVector xt = momentum;
+  GlobalVector yt(-xt.y(), xt.x(), 0.);
   GlobalVector zt = xt.cross(yt);
 
-  const GlobalVector& pvec=momentum;
+  const GlobalVector& pvec = momentum;
   double pt = pvec.perp();
-  // for neutrals: qbp is 1/p instead of q/p - 
+  // for neutrals: qbp is 1/p instead of q/p -
   //   equivalent to charge 1
-  if ( q==0 )  q = 1;
+  if (q == 0)
+    q = 1;
 
-  xt = xt.unit(); 
-  if(fabs(pt) > 0){
-    yt = yt.unit(); 
+  xt = xt.unit();
+  if (fabs(pt) > 0) {
+    yt = yt.unit();
     zt = zt.unit();
   }
-  
-  AlgebraicMatrix66 R;
-  R(0,0) = xt.x(); R(0,1) = yt.x(); R(0,2) = zt.x();
-  R(1,0) = xt.y(); R(1,1) = yt.y(); R(1,2) = zt.y();
-  R(2,0) = xt.z(); R(2,1) = yt.z(); R(2,2) = zt.z();
-  R(3,3) = 1.;
-  R(4,4) = 1.;
-  R(5,5) = 1.;
 
-  double p = pvec.mag(), p2 = p*p;
+  AlgebraicMatrix66 R;
+  R(0, 0) = xt.x();
+  R(0, 1) = yt.x();
+  R(0, 2) = zt.x();
+  R(1, 0) = xt.y();
+  R(1, 1) = yt.y();
+  R(1, 2) = zt.y();
+  R(2, 0) = xt.z();
+  R(2, 1) = yt.z();
+  R(2, 2) = zt.z();
+  R(3, 3) = 1.;
+  R(4, 4) = 1.;
+  R(5, 5) = 1.;
+
+  double p = pvec.mag(), p2 = p * p;
   double lambda = 0.5 * M_PI - pvec.theta();
   double phi = pvec.phi();
   double sinlambda = sin(lambda), coslambda = cos(lambda);
   double sinphi = sin(phi), cosphi = cos(phi);
 
-  theJacobian(1,3) = 1.;
-  theJacobian(2,4) = 1.;
-  theJacobian(3,0) = -q * p2 * coslambda * cosphi;
-  theJacobian(3,1) = -p * sinlambda * cosphi;
-  theJacobian(3,2) = -p * coslambda * sinphi;
-  theJacobian(4,0) = -q * p2 * coslambda * sinphi;
-  theJacobian(4,1) = -p * sinlambda * sinphi;
-  theJacobian(4,2) = p * coslambda * cosphi;
-  theJacobian(5,0) = -q * p2 * sinlambda;
-  theJacobian(5,1) = p * coslambda;
-  theJacobian(5,2) = 0.;
+  theJacobian(1, 3) = 1.;
+  theJacobian(2, 4) = 1.;
+  theJacobian(3, 0) = -q * p2 * coslambda * cosphi;
+  theJacobian(3, 1) = -p * sinlambda * cosphi;
+  theJacobian(3, 2) = -p * coslambda * sinphi;
+  theJacobian(4, 0) = -q * p2 * coslambda * sinphi;
+  theJacobian(4, 1) = -p * sinlambda * sinphi;
+  theJacobian(4, 2) = p * coslambda * cosphi;
+  theJacobian(5, 0) = -q * p2 * sinlambda;
+  theJacobian(5, 1) = p * coslambda;
+  theJacobian(5, 2) = 0.;
 
-  //ErrorPropagation: 
+  //ErrorPropagation:
   //    C(Cart) = R(6*6) * J(6*5) * C(Curvi) * J(5*6)_T * R(6*6)_T
-  theJacobian = R*theJacobian;
+  theJacobian = R * theJacobian;
   //dbg::dbg_trace(1,"Cu2Ca", globalParameters.vector(),theJacobian);
- return theJacobian;
+  return theJacobian;
 }
 
-AlgebraicMatrix56 jacobianCartesianToCurvilinear(const GlobalVector & momentum,int q) {
+AlgebraicMatrix56 jacobianCartesianToCurvilinear(const GlobalVector& momentum, int q) {
   AlgebraicMatrix56 theJacobian;
-  GlobalVector xt=momentum;
+  GlobalVector xt = momentum;
   GlobalVector yt(-xt.y(), xt.x(), 0.);
   GlobalVector zt = xt.cross(yt);
-  const GlobalVector& pvec=momentum;
+  const GlobalVector& pvec = momentum;
   double pt = pvec.perp(), p = pvec.mag();
   double px = pvec.x(), py = pvec.y(), pz = pvec.z();
-  double pt2 = pt*pt, p2 = p*p, p3 = p*p*p;
-  // for neutrals: qbp is 1/p instead of q/p - 
+  double pt2 = pt * pt, p2 = p * p, p3 = p * p * p;
+  // for neutrals: qbp is 1/p instead of q/p -
   //   equivalent to charge 1
-  if ( q==0 )  q = 1;
-  xt = xt.unit(); 
-  if(fabs(pt) > 0){
-    yt = yt.unit(); 
+  if (q == 0)
+    q = 1;
+  xt = xt.unit();
+  if (fabs(pt) > 0) {
+    yt = yt.unit();
     zt = zt.unit();
   }
-  
-  AlgebraicMatrix66 R;
-  R(0,0) = xt.x(); R(0,1) = xt.y(); R(0,2) = xt.z();
-  R(1,0) = yt.x(); R(1,1) = yt.y(); R(1,2) = yt.z();
-  R(2,0) = zt.x(); R(2,1) = zt.y(); R(2,2) = zt.z();
-  R(3,3) = 1.;
-  R(4,4) = 1.;
-  R(5,5) = 1.;
 
-  theJacobian(0,3) = -q*px/p3;        theJacobian(0,4) = -q*py/p3;        theJacobian(0,5) = -q*pz/p3;
-  if(fabs(pt) > 0){
+  AlgebraicMatrix66 R;
+  R(0, 0) = xt.x();
+  R(0, 1) = xt.y();
+  R(0, 2) = xt.z();
+  R(1, 0) = yt.x();
+  R(1, 1) = yt.y();
+  R(1, 2) = yt.z();
+  R(2, 0) = zt.x();
+  R(2, 1) = zt.y();
+  R(2, 2) = zt.z();
+  R(3, 3) = 1.;
+  R(4, 4) = 1.;
+  R(5, 5) = 1.;
+
+  theJacobian(0, 3) = -q * px / p3;
+  theJacobian(0, 4) = -q * py / p3;
+  theJacobian(0, 5) = -q * pz / p3;
+  if (fabs(pt) > 0) {
     //theJacobian(1,3) = (px*pz)/(pt*p2); theJacobian(1,4) = (py*pz)/(pt*p2); theJacobian(1,5) = -pt/p2; //wrong sign
-    theJacobian(1,3) = -(px*pz)/(pt*p2); theJacobian(1,4) = -(py*pz)/(pt*p2); theJacobian(1,5) = pt/p2;
-    theJacobian(2,3) = -py/pt2;         theJacobian(2,4) = px/pt2;          theJacobian(2,5) = 0.;
+    theJacobian(1, 3) = -(px * pz) / (pt * p2);
+    theJacobian(1, 4) = -(py * pz) / (pt * p2);
+    theJacobian(1, 5) = pt / p2;
+    theJacobian(2, 3) = -py / pt2;
+    theJacobian(2, 4) = px / pt2;
+    theJacobian(2, 5) = 0.;
   }
-  theJacobian(3,1) = 1.;
-  theJacobian(4,2) = 1.;
+  theJacobian(3, 1) = 1.;
+  theJacobian(4, 2) = 1.;
   theJacobian = theJacobian * R;
   //dbg::dbg_trace(1,"Ca2Cu", globalParameters.vector(),theJacobian);
   return theJacobian;

--- a/DataFormats/GeometryVector/src/classes.h
+++ b/DataFormats/GeometryVector/src/classes.h
@@ -2,7 +2,7 @@
 namespace {
   Geom::Phi<double, Geom::MinusPiToPi> dummy;
   Geom::Phi<float, Geom::MinusPiToPi> dummy1;
-}
+}  // namespace
 
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"
 //
@@ -18,4 +18,3 @@ namespace {
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
 #include "DataFormats/GeometryVector/interface/Vector2DBase.h"
 #include "DataFormats/GeometryVector/interface/Vector3DBase.h"
-

--- a/DataFormats/GeometryVector/test/BasicVector_t.cpp
+++ b/DataFormats/GeometryVector/test/BasicVector_t.cpp
@@ -1,105 +1,104 @@
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"
 
-#include<vector>
+#include <vector>
 
-#include<iostream>
+#include <iostream>
 
 // this is a test,
 // using namespace mathSSE;
 
-void addScaleddiff(Basic3DVectorF&res, float s,  Basic3DVectorF const & a, Basic3DVectorF const & b) {
-  res += s*(a-b);
-} 
-
-void addScaleddiff2(Basic3DVectorF&res, float s,  Basic3DVectorF const & a, Basic3DVectorF const & b) {
-  res = res + s*(a-b);
+void addScaleddiff(Basic3DVectorF& res, float s, Basic3DVectorF const& a, Basic3DVectorF const& b) {
+  res += s * (a - b);
 }
 
-void addScaleddiff(Basic3DVectorD&res, float s,  Basic3DVectorD const & a, Basic3DVectorD const & b) {
-  res += s*(a-b);
-} 
-
-void multiSum(Basic3DVectorF&res, float s,  Basic3DVectorF const & a, Basic3DVectorF const & b) {
-  res = s*(a-b) + s*(a+b);
-} 
-
-void multiSum(Basic3DVectorD&res, float s,  Basic3DVectorD const & a, Basic3DVectorD const & b) {
-  res = s*(a-b) + s*(a+b);
-} 
-
-void multiSum(Basic3DVectorLD&res, float s,  Basic3DVectorLD const & a, Basic3DVectorLD const & b) {
-  res = s*(a-b) + s*(a+b);
-} 
-
-
-
-template<typename T, typename U>
-typename PreciseFloatType<T,U>::Type dotV(  Basic3DVector<T> const & a,  Basic3DVector<U> const & b) {
-  return a*b;
+void addScaleddiff2(Basic3DVectorF& res, float s, Basic3DVectorF const& a, Basic3DVectorF const& b) {
+  res = res + s * (a - b);
 }
 
-template<typename T>
-T norm(Basic3DVector<T> const & a) {
-  return std::sqrt(a*a);
+void addScaleddiff(Basic3DVectorD& res, float s, Basic3DVectorD const& a, Basic3DVectorD const& b) {
+  res += s * (a - b);
 }
 
-template<typename T>
-T normV(Basic3DVector<T> const & a) {
+void multiSum(Basic3DVectorF& res, float s, Basic3DVectorF const& a, Basic3DVectorF const& b) {
+  res = s * (a - b) + s * (a + b);
+}
+
+void multiSum(Basic3DVectorD& res, float s, Basic3DVectorD const& a, Basic3DVectorD const& b) {
+  res = s * (a - b) + s * (a + b);
+}
+
+void multiSum(Basic3DVectorLD& res, float s, Basic3DVectorLD const& a, Basic3DVectorLD const& b) {
+  res = s * (a - b) + s * (a + b);
+}
+
+template <typename T, typename U>
+typename PreciseFloatType<T, U>::Type dotV(Basic3DVector<T> const& a, Basic3DVector<U> const& b) {
+  return a * b;
+}
+
+template <typename T>
+T norm(Basic3DVector<T> const& a) {
+  return std::sqrt(a * a);
+}
+
+template <typename T>
+T normV(Basic3DVector<T> const& a) {
   return a.mag();
 }
 
-template<typename T, typename U>
-typename PreciseFloatType<T,U>::Type dotV(  Basic2DVector<T> const & a,  Basic2DVector<U> const & b) {
-  return a*b;
+template <typename T, typename U>
+typename PreciseFloatType<T, U>::Type dotV(Basic2DVector<T> const& a, Basic2DVector<U> const& b) {
+  return a * b;
 }
 
-template<typename T>
-T norm(Basic2DVector<T> const & a) {
-  return std::sqrt(a*a);
+template <typename T>
+T norm(Basic2DVector<T> const& a) {
+  return std::sqrt(a * a);
 }
 
-template<typename T>
-T normV(Basic2DVector<T> const & a) {
+template <typename T>
+T normV(Basic2DVector<T> const& a) {
   return a.mag();
 }
 
+long aligned(void* p) { return long(p) & 0xf; }
 
-long aligned(void * p) {
-  return long(p)&0xf;
+volatile int* vi = 0;
 
-}
-
-volatile int * vi=0;
-
-template<typename T> 
+template <typename T>
 void verifyAlign() {
-  int sum=0;
-  int nota=0;
-  for (int i=0; i!=100; ++i) {
-    auto p= new int(3);
-    sum +=(*p);
+  int sum = 0;
+  int nota = 0;
+  for (int i = 0; i != 100; ++i) {
+    auto p = new int(3);
+    sum += (*p);
     auto t = new T;
-    if (aligned(t)!=0) ++nota;
-    else sum +=(*t)[0];
+    if (aligned(t) != 0)
+      ++nota;
+    else
+      sum += (*t)[0];
     delete p;
     delete t;
     t = new T;
-    sum +=(*t)[0];
-    if (aligned(t)!=0) ++nota;
-    else sum +=(*t)[0];  
+    sum += (*t)[0];
+    if (aligned(t) != 0)
+      ++nota;
+    else
+      sum += (*t)[0];
     delete t;
     vi = new int[3];
     auto vt = new T[3];
-    if (aligned(vt)!=0) ++nota;
-    else sum +=vt[1][1];
-    delete [] vi;
-    delete [] vt;
+    if (aligned(vt) != 0)
+      ++nota;
+    else
+      sum += vt[1][1];
+    delete[] vi;
+    delete[] vt;
   }
 
   std::cout << "sum " << sum << std::endl;
   std::cout << "not aligned " << nota << std::endl;
-
 }
 
 int main() {
@@ -113,16 +112,13 @@ int main() {
   std::cout << "extended vector notation enabled in cmssw" << std::endl;
 #endif
 
-
 #ifdef __clang__
-  struct MxAling {} __attribute__((__aligned__));
+  struct MxAling {
+  } __attribute__((__aligned__));
   std::cout << "biggest alignment " << alignof(MxAling) << std::endl;
 #else
   std::cout << "biggest alignment " << __BIGGEST_ALIGNMENT__ << std::endl;
 #endif
-
-
-
 
   std::cout << sizeof(Basic2DVectorF) << ' ' << alignof(Basic2DVectorF) << std::endl;
   std::cout << sizeof(Basic2DVectorD) << ' ' << alignof(Basic2DVectorD) << std::endl;
@@ -130,126 +126,121 @@ int main() {
   std::cout << sizeof(Basic3DVectorD) << ' ' << alignof(Basic3DVectorD) << std::endl;
   std::cout << sizeof(Basic3DVectorLD) << ' ' << alignof(Basic3DVectorLD) << std::endl;
 
-
   verifyAlign<Basic3DVectorF>();
   // verifyAlign<Basic3DVectorD>();  // crashes for AVX
 
+  Basic3DVectorF x(2.0f, 4.0f, 5.0f);
+  Basic3DVectorF y(-3.0f, 2.0f, -5.0f);
+  Basic3DVectorD xd(2.0, 4.0, 5.0);
+  Basic3DVectorD yd = y;
 
-  Basic3DVectorF  x(2.0f,4.0f,5.0f);
-  Basic3DVectorF  y(-3.0f,2.0f,-5.0f);
-  Basic3DVectorD  xd(2.0,4.0,5.0);
-  Basic3DVectorD  yd = y;
+  Basic3DVectorLD xld(2.0, 4.0, 5.0);
+  Basic3DVectorLD yld = y;
 
-  Basic3DVectorLD  xld(2.0,4.0,5.0);
-  Basic3DVectorLD  yld = y;
-
-
-  Basic2DVectorF  x2(2.0f,4.0f);
-  Basic2DVectorF  y2 = y.xy();
-  Basic2DVectorD  xd2(2.0,4.0);
-  Basic2DVectorD  yd2 = yd.xy();
+  Basic2DVectorF x2(2.0f, 4.0f);
+  Basic2DVectorF y2 = y.xy();
+  Basic2DVectorD xd2(2.0, 4.0);
+  Basic2DVectorD yd2 = yd.xy();
 
   {
-    std::cout << dotV(x,y) << std::endl; 
-    std::cout << normV(x) << std::endl; 
-    std::cout << norm(x) << std::endl; 
+    std::cout << dotV(x, y) << std::endl;
+    std::cout << normV(x) << std::endl;
+    std::cout << norm(x) << std::endl;
     // std::cout << std::min(x.mathVector(),y.mathVector()) << std::endl;
     // std::cout << std::max(x.mathVector(),y.mathVector()) << std::endl;
 
-    std::cout << dotV(x,yd) << std::endl; 
-    std::cout << dotV(xd,y) << std::endl; 
-    std::cout << dotV(xd,yd) << std::endl; 
-    std::cout << normV(xd) << std::endl; 
-    std::cout << norm(xd) << std::endl; 
-    std::cout << dotV(xld,yld) << std::endl; 
-    std::cout << normV(xld) << std::endl; 
-    std::cout << norm(xld) << std::endl; 
-    
-    
-    Basic3DVectorF  z = x.cross(y);
+    std::cout << dotV(x, yd) << std::endl;
+    std::cout << dotV(xd, y) << std::endl;
+    std::cout << dotV(xd, yd) << std::endl;
+    std::cout << normV(xd) << std::endl;
+    std::cout << norm(xd) << std::endl;
+    std::cout << dotV(xld, yld) << std::endl;
+    std::cout << normV(xld) << std::endl;
+    std::cout << norm(xld) << std::endl;
+
+    Basic3DVectorF z = x.cross(y);
     std::cout << z << std::endl;
     std::cout << -z << std::endl;
-    Basic3DVectorD  zd = x.cross(yd);
+    Basic3DVectorD zd = x.cross(yd);
     std::cout << zd << std::endl;
     std::cout << -zd << std::endl;
-    std::cout << xd.cross(y)<< std::endl;
-    std::cout << xd.cross(yd)<< std::endl;
+    std::cout << xd.cross(y) << std::endl;
+    std::cout << xd.cross(yd) << std::endl;
 
-    Basic3DVectorLD  zld = x.cross(yld);
+    Basic3DVectorLD zld = x.cross(yld);
     std::cout << zld << std::endl;
     std::cout << -zld << std::endl;
-    std::cout << xld.cross(y)<< std::endl;
-    std::cout << xld.cross(yld)<< std::endl;
+    std::cout << xld.cross(y) << std::endl;
+    std::cout << xld.cross(yld) << std::endl;
 
     std::cout << z.eta() << " " << (-z).eta() << std::endl;
-    std::cout << zd.eta()  << " " << (-zd).eta() << std::endl;
-    std::cout << zld.eta()  << " " << (-zld).eta() << std::endl;
-    
-    auto s = x+xd - 3.1*z;
-    std::cout << s << std::endl;
-    auto s2 = x+xld - 3.1*zd;
-    std::cout << s2 << std::endl;
+    std::cout << zd.eta() << " " << (-zd).eta() << std::endl;
+    std::cout << zld.eta() << " " << (-zld).eta() << std::endl;
 
+    auto s = x + xd - 3.1 * z;
+    std::cout << s << std::endl;
+    auto s2 = x + xld - 3.1 * zd;
+    std::cout << s2 << std::endl;
   }
 
- {
-    std::cout << dotV(x2,y2) << std::endl; 
-    std::cout << normV(x2) << std::endl; 
-    std::cout << norm(x2) << std::endl; 
+  {
+    std::cout << dotV(x2, y2) << std::endl;
+    std::cout << normV(x2) << std::endl;
+    std::cout << norm(x2) << std::endl;
     // std::cout << std::min(x2.mathVector(),y2.mathVector()) << std::endl;
     // std::cout << std::max(x2.mathVector(),y2.mathVector()) << std::endl;
 
-    std::cout << dotV(x2,yd2) << std::endl; 
-    std::cout << dotV(xd2,y2) << std::endl; 
-    std::cout << dotV(xd2,yd2) << std::endl; 
-    std::cout << normV(xd2) << std::endl; 
-    std::cout << norm(xd2) << std::endl; 
-    
-    
-    Basic2DVectorF  z2(x2); z2-=y2;
+    std::cout << dotV(x2, yd2) << std::endl;
+    std::cout << dotV(xd2, y2) << std::endl;
+    std::cout << dotV(xd2, yd2) << std::endl;
+    std::cout << normV(xd2) << std::endl;
+    std::cout << norm(xd2) << std::endl;
+
+    Basic2DVectorF z2(x2);
+    z2 -= y2;
     std::cout << z2 << std::endl;
     std::cout << -z2 << std::endl;
-    Basic2DVectorD zd2 = x2-yd2;
+    Basic2DVectorD zd2 = x2 - yd2;
     std::cout << zd2 << std::endl;
     std::cout << -zd2 << std::endl;
     std::cout << x2.cross(y2) << std::endl;
     std::cout << x2.cross(yd2) << std::endl;
-    std::cout << xd2.cross(y2)<< std::endl;
-    std::cout << xd2.cross(yd2)<< std::endl;
-    
-    auto s2 = x2+xd2 - 3.1*z2;
+    std::cout << xd2.cross(y2) << std::endl;
+    std::cout << xd2.cross(yd2) << std::endl;
+
+    auto s2 = x2 + xd2 - 3.1 * z2;
     std::cout << s2 << std::endl;
   }
 
-
-
   {
     std::cout << "f" << std::endl;
-    Basic3DVectorF  vx(2.0f,4.0f,5.0f);
-    Basic3DVectorF  vy(-3.0f,2.0f,-5.0f);
-    vx+=vy;
+    Basic3DVectorF vx(2.0f, 4.0f, 5.0f);
+    Basic3DVectorF vy(-3.0f, 2.0f, -5.0f);
+    vx += vy;
     std::cout << vx << std::endl;
-    
-    Basic3DVectorF vz(1.f,1.f,1.f);
-    addScaleddiff(vz,0.1f,vx,vy);
+
+    Basic3DVectorF vz(1.f, 1.f, 1.f);
+    addScaleddiff(vz, 0.1f, vx, vy);
     std::cout << vz << std::endl;
   }
 
- {
+  {
     std::cout << "d" << std::endl;
-    Basic3DVectorD  vx(2.0,4.0,5.0);
-    Basic3DVectorD  vy(-3.0,2.0,-5.0);
-    vx+=vy;
+    Basic3DVectorD vx(2.0, 4.0, 5.0);
+    Basic3DVectorD vy(-3.0, 2.0, -5.0);
+    vx += vy;
     std::cout << vx << std::endl;
-    
-    Basic3DVectorD vz(1.,1.,1);
-    addScaleddiff(vz,0.1,vx,vy);
-    std::cout << vz << std::endl;
- }
 
- std::cout << "std::vector" << std::endl;
- std::vector<Basic3DVectorF> vec1; vec1.reserve(50);
- std::vector<float> vecf(21);
- std::vector<Basic3DVectorF> vec2(51);
- std::vector<Basic3DVectorF> vec3; vec3.reserve(23456);
+    Basic3DVectorD vz(1., 1., 1);
+    addScaleddiff(vz, 0.1, vx, vy);
+    std::cout << vz << std::endl;
+  }
+
+  std::cout << "std::vector" << std::endl;
+  std::vector<Basic3DVectorF> vec1;
+  vec1.reserve(50);
+  std::vector<float> vecf(21);
+  std::vector<Basic3DVectorF> vec2(51);
+  std::vector<Basic3DVectorF> vec3;
+  vec3.reserve(23456);
 }

--- a/DataFormats/GeometryVector/test/Intervals_t.cpp
+++ b/DataFormats/GeometryVector/test/Intervals_t.cpp
@@ -7,88 +7,82 @@
 
 #include <cassert>
 
-
-
 int main() {
+  assert(!checkPhiInRange(-0.9f, 1.f, -1.f));
+  assert(!checkPhiInRange(0.9f, 1.f, -1.f));
+  assert(checkPhiInRange(-1.1f, 1.f, -1.f));
+  assert(checkPhiInRange(1.1f, 1.f, -1.f));
 
-  assert(!checkPhiInRange(-0.9f,1.f,-1.f));
-  assert(!checkPhiInRange(0.9f,1.f,-1.f));
-  assert(checkPhiInRange(-1.1f,1.f,-1.f));
-  assert(checkPhiInRange(1.1f,1.f,-1.f));
+  assert(checkPhiInRange(-0.9f, -1.f, 1.f));
+  assert(checkPhiInRange(0.9f, -1.f, 1.f));
+  assert(!checkPhiInRange(-1.1f, -1.f, 1.f));
+  assert(!checkPhiInRange(1.1f, -1.f, 1.f));
 
-  assert(checkPhiInRange(-0.9f,-1.f,1.f));
-  assert(checkPhiInRange(0.9f,-1.f,1.f));
-  assert(!checkPhiInRange(-1.1f,-1.f,1.f));
-  assert(!checkPhiInRange(1.1f,-1.f,1.f));
+  assert(checkPhiInRange(-2.9f, -3.f, 3.f));
+  assert(checkPhiInRange(2.9f, -3.f, 3.f));
+  assert(!checkPhiInRange(-3.1f, -3.f, 3.f));
+  assert(!checkPhiInRange(3.1f, -3.f, 3.f));
 
+  assert(!checkPhiInRange(-2.9f, 3.f, -3.f));
+  assert(!checkPhiInRange(2.9f, 3.f, -3.f));
+  assert(checkPhiInRange(-3.1f, 3.f, -3.f));
+  assert(checkPhiInRange(3.1f, 3.f, -3.f));
 
-  assert(checkPhiInRange(-2.9f,-3.f,3.f));
-  assert(checkPhiInRange(2.9f,-3.f,3.f));
-  assert(!checkPhiInRange(-3.1f,-3.f,3.f));
-  assert(!checkPhiInRange(3.1f,-3.f,3.f));
+  for (float x = -10; x < 10; x += 1.)
+    for (float y = -10; y < 10; y += 1.)
+      for (float z = -10; z < 10; z += 1.) {
+        if (x == 0 && y == 0)
+          continue;
+        GlobalPoint p(x, y, z);
 
-  
-  assert(!checkPhiInRange(-2.9f,3.f,-3.f));
-  assert(!checkPhiInRange(2.9f,3.f,-3.f));
-  assert(checkPhiInRange(-3.1f,3.f,-3.f));
-  assert(checkPhiInRange(3.1f,3.f,-3.f));
-  
+        // eta
+        for (float eta = -4; eta < 3.5; eta += 0.2)
+          for (float deta = 0.1; deta < 2.; deta += 0.2) {
+            EtaInterval ei(eta, eta + deta);
+            auto in = ei.inside(p.basicVector());
+            auto e = etaFromXYZ(x, y, z);
+            auto in2 = (e > eta) & (e < eta + deta);
+            assert(in == in2);
+          }
 
-  for (float x=-10;x<10;x+=1.)
-  for (float y=-10;y<10;y+=1.) 
-  for (float z=-10;z<10;z+=1.) {
-    if (x==0 && y==0) continue;
-    GlobalPoint p(x,y,z);
+        //phi
+        for (float phi = -6.001; phi < 6.5; phi += 0.2)
+          for (float dphi = -3.1; dphi < 3.15; dphi += 0.2) {
+            PhiInterval pi(phi, phi + dphi);
+            auto in = pi.inside(p.basicVector());
+            auto ph = p.barePhi();
+            auto in2 = checkPhiInRange(ph, phi, phi + dphi);
+            assert(in == in2);
+          }
+        {
+          PhiInterval pi(3.f, -3.f);
+          auto in = pi.inside(p.basicVector());
+          auto ph = p.barePhi();
+          auto it = ph > 3.f || ph < -3.f;
+          assert(in == it);
+          auto in2 = checkPhiInRange(ph, 3.f, -3.f);
+          assert(in2 == it);
+        }
+        {
+          PhiInterval pi(3.f, 4.f);
+          auto in = pi.inside(p.basicVector());
+          auto ph = p.barePhi();
+          auto it = ph > 3.f || ph < 4 - 2 * M_PI;
+          ;
+          assert(in == it);
+          auto in2 = checkPhiInRange(ph, 3.f, 4.f);
+          assert(in2 == it);
+        }
 
-    // eta
-    for (float eta=-4;eta<3.5; eta+=0.2)
-    for (float deta=0.1;deta<2.; deta+=0.2) {
-       EtaInterval ei(eta,eta+deta);
-       auto in = ei.inside(p.basicVector());       
-       auto e = etaFromXYZ(x,y,z);
-       auto in2 = (e>eta) & (e<eta+deta);
-       assert(in==in2);
-    }
-
-    //phi
-    for (float phi=-6.001;phi<6.5; phi+=0.2)
-    for (float dphi=-3.1;dphi<3.15; dphi+=0.2) {
-      PhiInterval pi(phi,phi+dphi);
-      auto in = pi.inside(p.basicVector());
-      auto ph = p.barePhi();
-      auto in2 = checkPhiInRange(ph,phi,phi+dphi);
-      assert(in==in2);      
-    }
-    {
-      PhiInterval pi(3.f,-3.f);
-      auto in = pi.inside(p.basicVector());
-      auto ph = p.barePhi();
-      auto it = ph>3.f || ph<-3.f;
-      assert(in==it);
-      auto in2 = checkPhiInRange(ph,3.f,-3.f);
-      assert(in2==it);
-    }
-    {
-      PhiInterval pi(3.f,4.f);
-      auto in = pi.inside(p.basicVector());
-      auto ph = p.barePhi();
-      auto it = ph>3.f || ph< 4-2*M_PI; ;
-      assert(in==it);
-      auto in2 = checkPhiInRange(ph,3.f,4.f);
-      assert(in2==it);
-    }
-
-    {
-      PhiInterval pi(-1.f,1.f);
-      auto in = pi.inside(p.basicVector());
-      auto ph = p.barePhi();
-      auto it = std::abs(ph)<1;
-      assert(in==it);
-      auto in2 = checkPhiInRange(ph,-1.f,1.f);
-      assert(in2==it);
-    }
-
-
-  } 
+        {
+          PhiInterval pi(-1.f, 1.f);
+          auto in = pi.inside(p.basicVector());
+          auto ph = p.barePhi();
+          auto it = std::abs(ph) < 1;
+          assert(in == it);
+          auto in2 = checkPhiInRange(ph, -1.f, 1.f);
+          assert(in2 == it);
+        }
+      }
   return 0;
 }

--- a/DataFormats/GeometryVector/test/PhiTest.cc
+++ b/DataFormats/GeometryVector/test/PhiTest.cc
@@ -6,56 +6,53 @@
 #include <ctime>
 #include <chrono>
 
-
 using namespace angle0to2pi;
 using namespace Geom;
 using namespace std;
 using namespace reco;
 using namespace std::chrono;
 
-
 template <class valType>
 inline constexpr valType useReduceRange(valType angle) {
   constexpr valType twoPi = 2._pi;
   angle = reduceRange(angle);
-  if (angle < 0.) angle += twoPi;
+  if (angle < 0.)
+    angle += twoPi;
   return angle;
 }
 
 template <class valType>
-inline constexpr valType simpleMake0to2pi(valType angle)
-{
-    constexpr valType twoPi = 2._pi;
-    
-    angle = fmod(angle, twoPi);
-    if (angle < 0.) angle += twoPi;
-      return angle;
+inline constexpr valType simpleMake0to2pi(valType angle) {
+  constexpr valType twoPi = 2._pi;
+
+  angle = fmod(angle, twoPi);
+  if (angle < 0.)
+    angle += twoPi;
+  return angle;
 }
 
 template <class valType>
-static int testSmall()
-{ // Test with long double
+static int testSmall() {  // Test with long double
   Phi<valType, ZeroTo2pi> ang1(15.3_pi);
   cout << "Phi that started as 15.3 pi is " << ang1 << endl;
   cout << "In degrees " << ang1.degrees() << endl;
   constexpr valType testval = 15.2999_pi;
   Phi<valType, ZeroTo2pi> ang2 = ang1 - testval;
   ang1 -= testval;
-  if  (ang1 != ang2) {
+  if (ang1 != ang2) {
     cout << "angle1 = " << ang1 << " and angle2 = " << ang2;
     cout << " should be equal but they are not. Test failure." << endl;
     return (1);
   }
-  if  (ang1.nearZero()) {
+  if (ang1.nearZero()) {
     cout << "angle = " << ang1 << " close enough to zero to be considered zero." << endl;
-  } else  {
+  } else {
     cout << "angle = " << ang1 << " should be considered nearly 0 but it is not.";
     cout << " Test failure." << endl;
     return (1);
   }
   return (0);
 }
-
 
 template <class valType>
 static int iterationTest(valType increm) {
@@ -66,7 +63,7 @@ static int iterationTest(valType increm) {
     ang1 += increm;
   }
   steady_clock::time_point endTime = steady_clock::now();
-  cout << "Phi after "<< iters << " iterations is " << ang1 << endl;
+  cout << "Phi after " << iters << " iterations is " << ang1 << endl;
   duration<double> time_span = duration_cast<duration<double>>(endTime - startTime);
   cout << "Time diff is  " << time_span.count() << endl;
   valType plainAng = 0.;
@@ -76,7 +73,7 @@ static int iterationTest(valType increm) {
   }
   endTime = steady_clock::now();
   cout << "plainAng  is  now " << plainAng << endl;
-  cout << "Base-type variable after "<< iters << " iterations is " << plainAng << endl;
+  cout << "Base-type variable after " << iters << " iterations is " << plainAng << endl;
   duration<double> time_span2 = duration_cast<duration<double>>(endTime - startTime);
   cout << "Time diff is  " << time_span2.count() << endl;
   cout << "Ratio of class/base-type CPU time is " << (time_span.count() / time_span2.count()) << endl;
@@ -88,7 +85,6 @@ static int iterationTest(valType increm) {
   return (0);
 }
 
-
 template <class valType>
 static int iter3Test(valType increm) {
   // const int iters = 1234567899;
@@ -99,7 +95,7 @@ static int iter3Test(valType increm) {
     ang1 = make0To2pi(increm + ang1);
   }
   steady_clock::time_point endTime = steady_clock::now();
-  cout << "Fast version after "<< iters << " iterations is " << ang1 << endl;
+  cout << "Fast version after " << iters << " iterations is " << ang1 << endl;
   duration<double> time_span = duration_cast<duration<double>>(endTime - startTime);
   cout << "Time diff is  " << time_span.count() << endl;
   valType plainAng = 0.;
@@ -108,7 +104,7 @@ static int iter3Test(valType increm) {
     plainAng = simpleMake0to2pi(increm + plainAng);
   }
   endTime = steady_clock::now();
-  cout << "Simple version after "<< iters << " iterations is " << plainAng << endl;
+  cout << "Simple version after " << iters << " iterations is " << plainAng << endl;
   duration<double> time_span2 = duration_cast<duration<double>>(endTime - startTime);
   cout << "Time diff is  " << time_span2.count() << endl;
   plainAng = 0.;
@@ -117,12 +113,11 @@ static int iter3Test(valType increm) {
     plainAng = useReduceRange(increm + plainAng);
   }
   endTime = steady_clock::now();
-  cout << "ReduceRange after "<< iters << " iterations is " << plainAng << endl;
+  cout << "ReduceRange after " << iters << " iterations is " << plainAng << endl;
   time_span2 = duration_cast<duration<double>>(endTime - startTime);
   cout << "Time diff is  " << time_span2.count() << endl;
   return (0);
 }
-
 
 int main() {
   cout << "long pi   = " << std::setprecision(32) << M_PIl << endl;
@@ -134,7 +129,7 @@ int main() {
   cout << "Sizes of Phi<double> and double = " << setprecision(16) << sizeof(testval) << ", " << sizeof(double) << endl;
   {
     Phi<double, ZeroTo2pi> angle = 3.3_pi;
-    if (! angle.nearEqual(1.3_pi)) {
+    if (!angle.nearEqual(1.3_pi)) {
       cout << "Angle should be from 0-2pi but it is out of range = " << angle << endl;
       return (1);
     }
@@ -143,19 +138,19 @@ int main() {
   cout << "getval should be 39.3pi = " << getval << endl;
   {
     Phi<long double, ZeroTo2pi> angle = -3.3_pi;
-    if (! angle.nearEqual(0.7_pi)) {
+    if (!angle.nearEqual(0.7_pi)) {
       cout << "Angle should be from 0-2pi but it is out of range = " << angle << endl;
       return (1);
     }
   }
-   // Test operations
-   Phi<double, ZeroTo2pi> phi1, phi2;
-   phi1 = 0.25_pi;
-   phi2 = 1._pi / 6.;
-   cout << "pi/4 + pi/6 = " << phi1 + phi2 << endl;
-   cout << "pi/4 - pi/6 = " << phi1 - phi2 << endl;
-   cout << "pi/4 * pi/6 = " << phi1 * phi2 << endl;
-   cout << "pi/4 / pi/6 = " << phi1 / phi2 << endl;
+  // Test operations
+  Phi<double, ZeroTo2pi> phi1, phi2;
+  phi1 = 0.25_pi;
+  phi2 = 1._pi / 6.;
+  cout << "pi/4 + pi/6 = " << phi1 + phi2 << endl;
+  cout << "pi/4 - pi/6 = " << phi1 - phi2 << endl;
+  cout << "pi/4 * pi/6 = " << phi1 * phi2 << endl;
+  cout << "pi/4 / pi/6 = " << phi1 / phi2 << endl;
 
   Phi<double, ZeroTo2pi> phi3{3.2_pi};
   cout << "Phi0To2pi started at 3.2pi but reduced to = " << phi3 << endl;
@@ -193,7 +188,7 @@ int main() {
   cout << "Test repeated small decrement\n";
   if (iterationTest<double>(-1._deg) == 1)
     return (1);
-  
+
   // long double smallincr = 1.39_deg;
   long double smallincr = 1._deg;
   long double bigincr = 7.77_pi;
@@ -225,6 +220,5 @@ int main() {
   if (iter3Test<long double>(bigincr) == 1)
     return (1);
 
-   return (0);
+  return (0);
 }
-

--- a/DataFormats/GeometryVector/test/phiLess_t.cpp
+++ b/DataFormats/GeometryVector/test/phiLess_t.cpp
@@ -2,20 +2,15 @@
 
 #include <cassert>
 
-
 int main() {
+  assert(Geom::phiLess(0.f, 2.f));
+  assert(Geom::phiLess(6.f, 0.f));
+  assert(Geom::phiLess(3.2f, 0.f));
+  assert(Geom::phiLess(3.0f, 3.2f));
 
-  assert(Geom::phiLess(0.f,2.f));
-  assert(Geom::phiLess(6.f,0.f));
-  assert(Geom::phiLess(3.2f,0.f));
-  assert(Geom::phiLess(3.0f,3.2f));
-
-  assert(Geom::phiLess(-0.3f,0.f));
-  assert(Geom::phiLess(-0.3f,0.1f));
-  assert(Geom::phiLess(-3.0f,0.f));
-  assert(Geom::phiLess(3.0f,-3.0f));
-  assert(Geom::phiLess(0.f,-3.4f));
-
-
-
+  assert(Geom::phiLess(-0.3f, 0.f));
+  assert(Geom::phiLess(-0.3f, 0.1f));
+  assert(Geom::phiLess(-3.0f, 0.f));
+  assert(Geom::phiLess(3.0f, -3.0f));
+  assert(Geom::phiLess(0.f, -3.4f));
 }


### PR DESCRIPTION

Applying code-format for CMSSW category simulation.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/303//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


